### PR TITLE
fix: let a feed operator open a continuation line, and keep an infinite closure sequence lazy in a for loop

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -51,7 +51,7 @@ S\* 系 24 本しか載せておらず、`integration/` 41 本・`6.c/` 7 本・
 | 根本原因クラスタ | 本数 | 該当ファイル（抜粋） | 症状 |
 |---|---|---|---|
 | **① スタックオーバーフローで abort**（★根本原因は 1 つではない — 下節参照） | 4 | `99problems-41-to-50.t`・`99problems-51-to-60.t`・`man-or-boy.t`・`deep-recursion-initing-native-array.t` | `fatal runtime error: stack overflow, aborting`（プロセス abort）。**症状は同じだが原因は 4 つ別々**で、うち「本当に深い再帰」は 1 本だけだった |
-| **② パース不能（`===SORRY!===`）** | 残 2 | **残: `advent2012-day04.t`・`advent2012-day19.t`** | 個別の構文が未対応。**8 本は解消済み（#4511 / #4514）** — 下の「② の内訳」参照 |
+| **② パース不能（`===SORRY!===`）** | **残 1** | **残: `advent2012-day19.t`**（ユーザ定義演算子の優先順位） | **9 本は解消済み（#4511 / #4514 / #4515）** — 下の「② の内訳」参照。②はほぼ枯渇 |
 | **③ ハング / タイムアウト** | 5 | `advent2012-day21.t`・`advent2013-day14.t`・`gather-with-loops.t`・`APPENDICES/A01-limits/{misc,overflow}.t` | 25s で打ち切り。gather×loop の遅延評価と limit 系 |
 | **④ エラーメッセージ品質** | 2 | `error-reporting.t`（mutsu 4/33・raku 33/33）・`weird-errors.t`（26/36） | 「Parse error contains line number」等、**例外の文面・行番号・バックトレース**を検査するテスト。PLAN §6「エラーメッセージ品質向上」と同一の的 |
 | **⑤ 個別機能ギャップ** | 残り | `advent2009-day24.t`（派生 grammar の拡張）・`advent2010-day14.t`（`nextsame` の継承/mixin）・`advent2010-day22.t`（`Rat` の `$!numerator`/`$!denominator` 属性）・`advent2011-day07.t`（`Metamodel::GrammarHOW` 継承）・`advent2011-day10.t`（`--doc` / `DOC INIT {}`）・`advent2009-day20.t`（signature の introspection/stringification）・`advent2009-day18.t`（パラメタ化 role の mixin）・`advent2013-day10.t`（`:round` 等の演算子 adverb）・`precompiled.t`（precomp） | 1 ファイル数本ずつ。★の近道はここ |
@@ -74,7 +74,7 @@ test 57 `OUTER::<$x>` 疑似パッケージ）。`advent2011-day04.t` は 1/2、
 無限再帰か有限の深い再帰かを先に分けること（`raku` 側は 8 呼び出しで終わるのに mutsu が
 1900 行トレースを吐く、で一発で分かる）。
 
-### ② の内訳（2026-07-14 実測・#4511 / #4514 後）
+### ② の内訳（2026-07-14 実測・#4511 / #4514 / #4515 後）
 
 **whitelist 到達（5 本）**: `advent2010-day11.t`・`advent2013-day04.t`・`advent2014-day16.t`（#4511:
 `qto`/`qqto` fused adverb、quote 語とデリミタ間の空白・改行、heredoc 本体の開始行、`q:to:c` の
@@ -82,13 +82,25 @@ test 57 `OUTER::<$x>` 疑似パッケージ）。`advent2011-day04.t` は 1/2、
 `when` 文修飾子、Match を RHS とする smartmatch、`(with …)`/`(given …)` の式化、`my@i` の
 空白なし宣言）。
 
-**パースは通ったが subtest が残る（3 本）** — ②ではなく機能ギャップに移行:
+**パースは通ったが subtest が残る（4 本）** — ②ではなく機能ギャップに移行:
 
 | ファイル | 残 | ブロッカー |
 |---|---|---|
+| `integration/advent2012-day04.t` | 6/8 | **配列コンポーザ `[...]` の中で list infix がコンマより強く結合する**。`[0, \|@p Z+ \|@p, 0]` は Raku では `(0, \|@p) Z+ (\|@p, 0)`（`Z`/`X` はコンマより緩い）だが、`array_literal` がコンマで先に手分割してしまう。`parse_comma_or_expr` は `lift_meta_ops_in_list` で補正しているのに、配列コンポーザは通していない。#4515 で 0/8（コンパイル不能）→ 2/8 |
 | `integration/advent2012-day15.t` | 2/11 | phaser の文形式が独自スコープを作る（`NEXT (state $best) max= $_;` の `$best` が `LAST` から見えない）／`INIT` がメインラインより後に走る |
 | `6.c/MISC/bug-coverage.t` | 5/17 | `.count-only`/`.bool-only`、thunk のクロージャスコープ 等 |
 | `6.c/APPENDICES/A04-experimental/01-misc.t` | 3/19 | `:D`/`:U` DefiniteHow coercion（`Target:D(Source:U)`）。#4514 で 0/19 → 16/19 |
+
+**②で唯一パースできないまま残った 1 本**: `integration/advent2012-day19.t`。
+`sub postfix:<k> ($a) is tighter(&infix:<*>)` のように**優先順位トレイト付きのユーザ定義
+postfix** が、項に対して一切適用されない（`4.7k` が SORRY）。`postfix/loop_.rs` の postfix
+ループは登録済み優先順位が `PREC_PREFIX` 未満の postfix を「prefix 層で拾われる」として
+スキップするが、その拾い上げループは**ユーザ定義 prefix 演算子の分岐の中にしか無い**ので、
+`4.7` のような素の項では誰も消費しない。さらにこのファイルは `4kΩ`（別レベルの postfix の
+連鎖）と `4.7kΩ ± 5%`（それらより緩い中置）を要求するので、**ユーザ定義演算子を精度順位表に
+沿って適用する precedence climbing** が要る＝単発 fix ではない。付随して
+`registry.rs` の `resolve_op_precedence` が `is looser(&postfix:<k>)` を
+「登録済みレベル-5」ではなく「`PREC_PREFIX`-5」と解決するバグも直す必要がある。
 
 ## S* 系の個別ファイル残件
 

--- a/src/parser/expr/precedence/list_infix_loop.rs
+++ b/src/parser/expr/precedence/list_infix_loop.rs
@@ -383,13 +383,12 @@ pub(crate) fn parse_list_infix_loop<'a>(
             rest = r;
             continue;
         }
-        // User-defined infix words (typically via my &infix:<...> = ...),
-        // e.g. `42 same-in-Int "42"`.
-        // Do not span statement boundaries across newlines.
         let ws_before = &rest[..rest.len() - r.len()];
-        if !ws_before.contains('\n')
-            && let Some((feed_op, len)) = parse_feed_op(r)
-        {
+        // A feed operator may start a continuation line -- `==>` and `<==` are symbol
+        // operators that can never begin a statement, so crossing a newline is
+        // unambiguous. (The user-defined infix *word* below keeps the newline guard: a
+        // bare identifier opening the next line would otherwise be eaten as an infix.)
+        if let Some((feed_op, len)) = parse_feed_op(r) {
             let r = &r[len..];
             let (r, _) = ws(r)?;
             let (r, right) = (if matches!(feed_op, FeedOp::ToLeft | FeedOp::AppendLeft) {
@@ -404,6 +403,9 @@ pub(crate) fn parse_list_infix_loop<'a>(
             rest = r;
             continue;
         }
+        // User-defined infix words (typically via my &infix:<...> = ...),
+        // e.g. `42 same-in-Int "42"`.
+        // Do not span statement boundaries across newlines.
         if !ws_before.contains('\n')
             && let Some((name, len)) = parse_custom_infix_word(r)
             && crate::parser::stmt::simple::lookup_custom_infix_precedence(&name)

--- a/src/vm/vm_for_loop_dispatch.rs
+++ b/src/vm/vm_for_loop_dispatch.rs
@@ -149,6 +149,11 @@ impl Interpreter {
         if let ValueView::LazyList(ll) = iterable.view()
             && (ll.coroutine.is_some()
                 || ll.sequence_spec.is_some()
+                // An endpoint-less closure sequence (`for 2, 3, *+2 ... * { }`) must be
+                // pulled on demand too. Without this it fell through to the eager path,
+                // which sees only the 32-element prefix `eval_sequence` generated up
+                // front and ends the loop there.
+                || ll.closure_seq.is_some()
                 || ll.lazy_pipe.is_some()
                 || ll.walk_pending.is_some()
                 // `for $cat.lines` / `for $cat.handles`: pull one element per

--- a/t/feed-and-lazy-closure-seq.t
+++ b/t/feed-and-lazy-closure-seq.t
@@ -1,0 +1,52 @@
+use Test;
+
+plan 7;
+
+# A feed operator may open a continuation line. `==>` and `<==` are symbol operators
+# that can never begin a statement, so crossing a newline is unambiguous.
+# (The feed is looser than `=`, so the whole chain needs its own parentheses here --
+# `my $x = (1..10) ==> ...` assigns the range and feeds afterwards, in raku too.)
+my $forward = ((1..10)
+    ==> grep * > 5
+    ==> elems());
+is $forward, 5, '==> continues across a newline';
+
+my @backward;
+@backward
+    <== grep * > 5
+    <== (1..10);
+is-deeply @backward, [6, 7, 8, 9, 10], '<== continues across a newline';
+
+is ((1..10) ==> grep * > 5 ==> elems()), 5, '==> on one line is unchanged';
+
+# An endpoint-less closure sequence must be pulled on demand, not truncated to the
+# 32-element prefix that `eval_sequence` generates up front.
+my $count = 0;
+for 2, 3, *+2 ... * {
+    $count++;
+    last if $_ > 7000;
+}
+is $count, 3501, 'for over an infinite closure sequence pulls past its eager prefix';
+
+my @fib;
+for 1, 1, *+* ... * {
+    @fib.push($_);
+    last if $_ > 100;
+}
+is @fib.tail, 144, 'a two-seed infinite closure sequence keeps generating';
+
+# The loop must stay lazy: an infinite sequence is never materialized.
+my $iterations = 0;
+for 1, *+1 ... * {
+    $iterations++;
+    last if $iterations == 5000;
+}
+is $iterations, 5000, 'an infinite closure sequence stays lazy for 5000 pulls';
+
+# A `return` out of such a loop still carries its value.
+sub first-above($limit) {
+    for 2, 3, *+2 ... * {
+        return $_ if $_ > $limit;
+    }
+}
+is first-above(1000), 1001, 'return out of an infinite closure-sequence loop works';


### PR DESCRIPTION
The last two general bugs in `TODO_roast/BLOCKERS.md` §"② パース不能（===SORRY!===）" that are not a precedence-table project. Both are general, not specific to the file that surfaced them.

## Fixes

- **`==>` and `<==` could not start a continuation line.** The feed branch of `parse_list_infix_loop` carried a `!ws_before.contains('\n')` guard copy-pasted from the user-defined infix *word* branch below it, where the guard is needed (a bare identifier opening the next line would otherwise be eaten as an infix). A feed is a symbol operator that can never begin a statement, so crossing a newline is unambiguous — and a pipeline written one stage per line, the usual way, was a parse error.

- **A `for` over an endpoint-less closure sequence stopped after ~34 iterations.** `eval_sequence` generates a 32-element eager prefix and hands back a LazyList carrying the generator so the rest can be produced on demand, but the for-loop's lazy dispatch only recognized `coroutine`, `sequence_spec`, `lazy_pipe`, `walk_pending` and `cat_pull` — not `closure_seq`. The loop fell through to the eager path, saw the prefix, and ended there **silently**. Even the documented `1, 1, *+* ... *` case truncated. `for 2, 3, *+2 ... * { last if $_ > 7000 }` now runs 3501 iterations, matching raku.

## Result

`roast/integration/advent2012-day04.t` compiles and its first two subtests pass (was 0 — the file did not parse at all).

It is not whitelisted yet: the array composer still gives list infix operators the wrong precedence. `[0, |@p Z+ |@p, 0]` must be `(0, |@p) Z+ (|@p, 0)` — `Z`/`X` are *looser* than the comma in Raku — but `array_literal` splits on commas before the list-infix loop sees them. `parse_comma_or_expr` already repairs this with `lift_meta_ops_in_list`; the array composer does not route through it. BLOCKERS.md records this, and records why `advent2012-day19.t` (the one file in ② still failing to parse) needs real precedence climbing for user-defined operators rather than a point fix.

New test: `t/feed-and-lazy-closure-seq.t`. `make test` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tFv8btbbJZpJT6G2vCS2i