### PR TITLE
fix(vm): only refresh the receiver's slot when a method actually rebinds it

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -995,6 +995,20 @@ impl Value {
     }
 }
 
+impl Value {
+    /// O(1) *binding* identity: the same immediate value, or the same heap
+    /// allocation. Unlike `PartialEq` it never walks container contents, so it is
+    /// usable on hot paths that only need to know whether a name was **rebound**
+    /// (as opposed to its container being mutated in place, which leaves the
+    /// binding — and these bits — unchanged).
+    ///
+    /// Available in every build, unlike the `jit`-gated `nanbox_bits`.
+    #[inline]
+    pub(crate) fn same_binding(&self, other: &Value) -> bool {
+        self.0.bits() == other.0.bits()
+    }
+}
+
 /// The `Value` representation (3b-1 step A). Private to `crate::value` — this
 /// is the compile-time seal: only the wall API (`view()` / `as_*` /
 /// constructors) crosses the module boundary. Tuple/unit variant construction

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2906,6 +2906,16 @@ impl Interpreter {
             } => {
                 self.sync_source_line(code, *ip);
                 let pre = self.array_hash_attr_env_snapshot(code, *target_name_idx);
+                // Bit-identity of the receiver's env binding before the call, so
+                // the writeback below can tell whether this method actually
+                // rebound it (see there). `nanbox_bits` is O(1) and never walks
+                // container contents, unlike `PartialEq`.
+                let receiver_bits_before = (!Self::const_str(code, *target_name_idx).is_empty())
+                    .then(|| {
+                        self.env()
+                            .get_sym(code.const_sym(*target_name_idx))
+                            .map(Value::nanbox_bits)
+                    });
                 match self.exec_call_method_mut_op(
                     code,
                     *name_idx,
@@ -2931,11 +2941,37 @@ impl Interpreter {
                 // local slot. Write the receiver through to its slot here so it
                 // stays coherent without the pull. (`apply_pending_rw_writeback`
                 // mirrors the reverse pull's HashEntryRef-skip invariant.)
-                {
-                    let target_name = Self::const_str(code, *target_name_idx);
-                    if !target_name.is_empty() {
+                //
+                // ONLY when the call actually REBOUND `env[receiver]`. This used
+                // to fire after every method call on a named receiver, and
+                // `apply_pending_rw_writeback` copies `env[name]` into the local
+                // slot by name — but a frame's env also carries every same-named
+                // binding it inherited from its caller (the callee env is the
+                // flattened caller plus its own writes; parameters live in slots,
+                // not in env). So on an unchanged receiver it copied the CALLER's
+                // variable over the callee's parameter. A self-recursive routine is
+                // exactly that shape:
+                //
+                //     sub f($tree, $d) { ... ; f($tree[1], $d + 1) }
+                //
+                // Every frame has a `tree`, so *any* method call on `$tree` in the
+                // callee (`.defined`, `.gist`, even inside a `say`) silently
+                // reverted `$tree` to the caller's node, the descent never reached
+                // a leaf, and the recursion ran until the Rust stack gave out
+                // (roast integration/99problems-51-to-60.t P57 — a stack overflow
+                // that was really an infinite recursion).
+                //
+                // A method that mutates the receiver in place through its `Gc`
+                // (rather than rebinding the name) leaves the bits equal, and that
+                // is correct: the slot already holds the very same `Gc`.
+                if let Some(before) = receiver_bits_before {
+                    let after = self
+                        .env()
+                        .get_sym(code.const_sym(*target_name_idx))
+                        .map(Value::nanbox_bits);
+                    if after != before {
                         self.pending_rw_writeback_sources
-                            .push(target_name.to_string());
+                            .push(Self::const_str(code, *target_name_idx).to_string());
                     }
                 }
                 self.apply_pending_rw_writeback(code);

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2906,15 +2906,15 @@ impl Interpreter {
             } => {
                 self.sync_source_line(code, *ip);
                 let pre = self.array_hash_attr_env_snapshot(code, *target_name_idx);
-                // Bit-identity of the receiver's env binding before the call, so
-                // the writeback below can tell whether this method actually
-                // rebound it (see there). `nanbox_bits` is O(1) and never walks
-                // container contents, unlike `PartialEq`.
-                let receiver_bits_before = (!Self::const_str(code, *target_name_idx).is_empty())
-                    .then(|| {
+                // The receiver's env binding before the call, so the writeback
+                // below can tell whether this method actually rebound it (see
+                // there). Compared with `same_binding` — O(1), and it never walks
+                // container contents the way `PartialEq` would.
+                let receiver_before: Option<Option<Value>> =
+                    (!Self::const_str(code, *target_name_idx).is_empty()).then(|| {
                         self.env()
                             .get_sym(code.const_sym(*target_name_idx))
-                            .map(Value::nanbox_bits)
+                            .cloned()
                     });
                 match self.exec_call_method_mut_op(
                     code,
@@ -2964,12 +2964,14 @@ impl Interpreter {
                 // A method that mutates the receiver in place through its `Gc`
                 // (rather than rebinding the name) leaves the bits equal, and that
                 // is correct: the slot already holds the very same `Gc`.
-                if let Some(before) = receiver_bits_before {
-                    let after = self
-                        .env()
-                        .get_sym(code.const_sym(*target_name_idx))
-                        .map(Value::nanbox_bits);
-                    if after != before {
+                if let Some(before) = receiver_before {
+                    let after = self.env().get_sym(code.const_sym(*target_name_idx));
+                    let rebound = match (&before, after) {
+                        (Some(b), Some(a)) => !b.same_binding(a),
+                        (None, None) => false,
+                        _ => true,
+                    };
+                    if rebound {
                         self.pending_rw_writeback_sources
                             .push(Self::const_str(code, *target_name_idx).to_string());
                     }

--- a/t/recursive-param-method-call.t
+++ b/t/recursive-param-method-call.t
@@ -1,0 +1,65 @@
+use Test;
+
+plan 6;
+
+# A method call on a named receiver refreshed the receiver's local slot from
+# `env[name]` unconditionally. But a frame's env also carries every same-named
+# binding it inherited from its caller (parameters live in local slots, not in
+# env), so on an *unchanged* receiver that copied the CALLER's variable over the
+# callee's parameter.
+#
+# A self-recursive routine is exactly that shape — every frame has a `$tree` —
+# so any method call on the parameter reverted it to the caller's value, the
+# descent never reached a leaf, and the recursion ran until the Rust stack gave
+# out. It presented as `fatal runtime error: stack overflow` (roast
+# integration/99problems-51-to-60.t P57) but was an infinite recursion.
+
+{
+    my @seen;
+    sub descend($tree, $d) {
+        @seen.push($tree.gist);          # a method call on the parameter
+        return if $d >= 2;
+        descend($tree[1], $d + 1);
+    }
+    descend([3, [2, Any, Any], Any], 0);
+    is @seen.elems, 3, 'recursive descent through a method-called parameter terminates';
+    is @seen[1], '[2 (Any) (Any)]', 'the parameter is the callee argument, not the caller value';
+    is @seen[2], '(Any)', '... at every level';
+}
+
+{
+    # Two reads of the parameter in one expression must agree: the first read
+    # used to be right and the second stale.
+    my $out;
+    sub twice($tree, $d) {
+        $out = $tree.WHAT.^name ~ '|' ~ $tree.WHAT.^name if $d == 1;
+        return if $d >= 1;
+        twice($tree[1], $d + 1);
+    }
+    twice([3, Any, Any], 0);
+    is $out, 'Any|Any', 'both reads of a recursed parameter see the same value';
+}
+
+{
+    # `not $tree.defined` is the real-world shape: a binary-tree insert that
+    # never bottoms out.
+    sub add($tree, $node) {
+        return [$node, Any, Any] unless $tree.defined;
+        return $node <= $tree[0]
+            ?? [$tree[0], add($tree[1], $node), $tree[2]]
+            !! [$tree[0], $tree[1], add($tree[2], $node)];
+    }
+    my $t = Any;
+    $t = add($t, $_) for 3, 2, 5;
+    is $t.gist, '[3 [2 (Any) (Any)] [5 (Any) (Any)]]', 'binary search tree insert bottoms out';
+}
+
+{
+    # The writeback this gate protects must still happen: a method that really
+    # DOES rebind the receiver in env has to refresh the local slot.
+    my @a = 1, 2;
+    @a.push(3);
+    is @a.join(','), '1,2,3', 'a mutating method still updates the receiver';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
## The bug

`CallMethodMut` refreshed the receiver's local slot from `env[name]` after **every** method call on a named receiver. But a frame's env also carries every same-named binding it inherited from its caller — the callee env is the flattened caller plus its own writes, and *parameters live in local slots, not in env*. So on an **unchanged** receiver the refresh copied the **caller's** variable over the callee's parameter.

A self-recursive routine is exactly that shape. Every frame has a `tree`:

```raku
sub add-to-tree($tree, $node) {
    return [$node, Any, Any] if not $tree.defined;
    ...
    return [$tree[0], add-to-tree($tree[1], $node), $tree[2]];
}
```

Any method call on `$tree` in the callee — `.defined`, `.gist`, even one inside a `say` — silently reverted `$tree` to the caller's node. The descent never reached a leaf and the recursion ran until the Rust stack gave out.

It presented as `fatal runtime error: stack overflow` (roast `integration/99problems-51-to-60.t` P57, filed under BLOCKERS cluster ① *"deep recursion"*) — but it was an **infinite** recursion.

## The tell

Two reads of the parameter in one expression disagreed — the first right, the second stale:

```raku
sub f($tree, $d) {
    say $tree.WHAT.^name ~ ' | ' ~ $tree.WHAT.^name;
    return if $d >= 1;
    f($tree[1], $d + 1);
}
f([3, Any, Any], 0);
# raku:  Array | Array  /  Any | Any
# mutsu: Array | Array  /  Any | Array     <-- second read reverted to the caller
```

## Fix

Gate the writeback on the call having actually **rebound** `env[receiver]`, compared by `nanbox_bits` (O(1) — `PartialEq` would deep-compare containers on a hot path).

- A method that mutates the receiver **in place** through its `Gc` leaves the bits equal, and that is correct: the slot already holds that same `Gc`.
- A method that **reassigns the name** (the ~15 `env_mut().insert(target, ..)` branches in `exec_call_method_mut_op`) changes them, and the slot is refreshed exactly as before.

## Result

- `99problems-51-to-60.t`: **aborting the process at test 18 → all 37 tests run** (2 unrelated failures remain, tests 8 and 21 — a balanced-tree bug and a separate gap).
- Full roast whitelist on release: **PASS** (1387 files, 219,836 tests).
- `prove -j4 t/`: **PASS** (1694 files).
- `benchmarks/method-call.raku`: **~6% faster** (146.5ms vs 155.7ms) — an unchanged receiver now skips both the push and the drain.

New `t/recursive-param-method-call.t` (6 subtests, verified against `raku`) pins the descent, the two-reads-agree property, the real binary-search-tree insert, and that a genuinely-mutating method still updates its receiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMcTn8pCmYdeJKDi6KNzcw