### PR TITLE
fix(parser): give the operators looser than the comma their real precedence in every comma splitter

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -86,7 +86,7 @@ test 57 `OUTER::<$x>` 疑似パッケージ）。`advent2011-day04.t` は 1/2、
 
 | ファイル | 残 | ブロッカー |
 |---|---|---|
-| `integration/advent2012-day04.t` | 6/8 | **配列コンポーザ `[...]` の中で list infix がコンマより強く結合する**。`[0, \|@p Z+ \|@p, 0]` は Raku では `(0, \|@p) Z+ (\|@p, 0)`（`Z`/`X` はコンマより緩い）だが、`array_literal` がコンマで先に手分割してしまう。`parse_comma_or_expr` は `lift_meta_ops_in_list` で補正しているのに、配列コンポーザは通していない。#4515 で 0/8（コンパイル不能）→ 2/8 |
+| `integration/advent2012-day04.t` | test 5 で中断 | **pointy の分解シグネチャが sigilless 名をパーサに登録しない**。`-> [ \a, \u, \v ] { u %% v }` の `u` が宣言済みの項として見えず listop 呼び出しに化ける（`Unknown function: u`）。#4515 で 0/8（コンパイル不能）→ 2 本、#4516 で **test 1・2・4 pass ＋ test 3 は TODO（raku も同値 0 を返す）** まで前進 |
 | `integration/advent2012-day15.t` | 2/11 | phaser の文形式が独自スコープを作る（`NEXT (state $best) max= $_;` の `$best` が `LAST` から見えない）／`INIT` がメインラインより後に走る |
 | `6.c/MISC/bug-coverage.t` | 5/17 | `.count-only`/`.bool-only`、thunk のクロージャスコープ 等 |
 | `6.c/APPENDICES/A04-experimental/01-misc.t` | 3/19 | `:D`/`:U` DefiniteHow coercion（`Target:D(Source:U)`）。#4514 で 0/19 → 16/19 |

--- a/src/parser/expr/precedence/list_infix.rs
+++ b/src/parser/expr/precedence/list_infix.rs
@@ -78,14 +78,19 @@ pub(crate) fn sequence_expr(input: &str) -> PResult<'_, Expr> {
                 return Err(non_list_associative_error(prev, op_str));
             }
             let (r2, _) = ws(r2)?;
-            let (r2, mut right) =
-                comparison_expr_mode(r2, ExprMode::NoSequence).map_err(|err| {
-                    enrich_expected_error(
-                        err,
-                        format!("expected expression after '{op_str}'").as_str(),
-                        r2.len(),
-                    )
-                })?;
+            // The endpoint is parsed *below* the list-infix layer. `NoSequence` routes
+            // through `list_infix_expr`, whose loop consumes a feed -- so `1, *+1 ... *
+            // ==> elems()` bound the feed into the endpoint (`* ==> elems()`), and the
+            // Whatever-curry below then turned that endpoint into a 1-ary WhateverCode.
+            // The feed is the loosest operator in Raku and belongs to this function's own
+            // list-infix loop below, outside the sequence.
+            let (r2, mut right) = comparison_expr_mode(r2, ExprMode::ListopArg).map_err(|err| {
+                enrich_expected_error(
+                    err,
+                    format!("expected expression after '{op_str}'").as_str(),
+                    r2.len(),
+                )
+            })?;
             if contains_whatever(&right) && !matches!(right, Expr::Whatever) {
                 right = wrap_whatevercode(&right);
             }

--- a/src/parser/primary/container/array.rs
+++ b/src/parser/primary/container/array.rs
@@ -89,17 +89,24 @@ fn finalize_array_sections(
     trailing_comma: bool,
 ) -> Expr {
     if !saw_semicolon {
-        return Expr::BracketArray(merge_sequence_seeds(current), trailing_comma);
+        return Expr::BracketArray(normalize_array_items(current), trailing_comma);
     }
     if !current.is_empty() {
         sections.push(current);
     }
     if sections.len() <= 1 {
         let flat = sections.into_iter().next().unwrap_or_default();
-        return Expr::BracketArray(merge_sequence_seeds(flat), false);
+        return Expr::BracketArray(normalize_array_items(flat), false);
     }
     let elems = sections.into_iter().map(build_array_section).collect();
     Expr::BracketArray(elems, false)
+}
+
+/// `array_literal` splits the composer's contents on commas itself, so the operators that
+/// are looser than the comma have to be given their real precedence afterwards — the same
+/// repair `parse_comma_or_expr` applies to a bare comma list.
+fn normalize_array_items(items: Vec<Expr>) -> Vec<Expr> {
+    crate::parser::stmt::assign::normalize_comma_list_items(items)
 }
 
 /// Render one array section: a single item stays bare; multiple items form a
@@ -108,8 +115,20 @@ fn build_array_section(items: Vec<Expr>) -> Expr {
     if items.len() == 1 {
         items.into_iter().next().unwrap()
     } else {
-        Expr::ArrayLiteral(merge_sequence_seeds(items))
+        Expr::ArrayLiteral(normalize_array_items(items))
     }
+}
+
+/// Build a fatal `X::Syntax::Confused` parse error with reason
+/// "Two terms in a row".
+fn two_terms_confused() -> PError {
+    let reason = "Two terms in a row";
+    let message = format!("Confused: {}", reason);
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("message".to_string(), Value::str(message.clone()));
+    attrs.insert("reason".to_string(), Value::str(reason.to_string()));
+    let exception = Value::make_instance(Symbol::intern("X::Syntax::Confused"), attrs);
+    PError::fatal_with_exception(message, Box::new(exception))
 }
 
 /// Build a fatal `X::Comp::FailGoal` parse error for an unterminated array
@@ -139,42 +158,6 @@ pub(crate) fn fail_goal_error_at(dba: &str, goal: &str, pos: Option<&str>) -> PE
     }
     let exception = Value::make_instance(Symbol::intern("X::Comp::FailGoal"), attrs);
     PError::fatal_with_exception(message, Box::new(exception))
-}
-
-/// Build a fatal `X::Syntax::Confused` parse error with reason
-/// "Two terms in a row".
-fn two_terms_confused() -> PError {
-    let reason = "Two terms in a row";
-    let message = format!("Confused: {}", reason);
-    let mut attrs = std::collections::HashMap::new();
-    attrs.insert("message".to_string(), Value::str(message.clone()));
-    attrs.insert("reason".to_string(), Value::str(reason.to_string()));
-    let exception = Value::make_instance(Symbol::intern("X::Syntax::Confused"), attrs);
-    PError::fatal_with_exception(message, Box::new(exception))
-}
-
-fn merge_sequence_seeds(items: Vec<Expr>) -> Vec<Expr> {
-    if items.len() < 2 {
-        return items;
-    }
-    let last = items.last().unwrap();
-    if let Expr::Binary { left, op, right } = last
-        && matches!(
-            op,
-            crate::token_kind::TokenKind::DotDotDot | crate::token_kind::TokenKind::DotDotDotCaret
-        )
-    {
-        let mut seeds: Vec<Expr> = items[..items.len() - 1].to_vec();
-        seeds.push(*left.clone());
-        let merged = Expr::Binary {
-            left: Box::new(Expr::ArrayLiteral(seeds)),
-            op: op.clone(),
-            right: right.clone(),
-        };
-        vec![merged]
-    } else {
-        items
-    }
 }
 
 /// Parse a hash constructor literal: %(key => value, :name, ...)

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -75,7 +75,9 @@ mod try_assign;
 
 // ---- Re-exports preserving each public function's original visibility ----
 pub(in crate::parser) use assign_stmt::assign_stmt;
-pub(in crate::parser) use comma::{parse_comma_or_expr, parse_comma_or_expr_item};
+pub(in crate::parser) use comma::{
+    normalize_comma_list_items, parse_comma_or_expr, parse_comma_or_expr_item,
+};
 pub(in crate::parser) use try_assign::try_parse_assign_expr;
 
 pub(crate) use bracket::parse_bracket_meta_assign_op;

--- a/src/parser/stmt/assign/comma.rs
+++ b/src/parser/stmt/assign/comma.rs
@@ -36,13 +36,13 @@ fn parse_comma_or_expr_impl(input: &str, item_context: bool) -> PResult<'_, Expr
         loop {
             let (r2, _) = ws(r)?;
             if !r2.starts_with(',') {
-                let items = merge_sequence_seeds(lift_meta_ops_in_list(items));
+                let items = normalize_comma_list_items(items);
                 return Ok((r2, finalize_list(items)));
             }
             let (r2, _) = parse_char(r2, ',')?;
             let (r2, _) = ws(r2)?;
             if r2.starts_with(';') || r2.is_empty() || r2.starts_with('}') || r2.starts_with(')') {
-                let items = merge_sequence_seeds(lift_meta_ops_in_list(items));
+                let items = normalize_comma_list_items(items);
                 return Ok((r2, finalize_list(items)));
             }
             let (r2, next) = expression(r2)?;
@@ -63,6 +63,16 @@ fn finalize_list(items: Vec<Expr>) -> Expr {
     }
 }
 
+/// Give the operators that are *looser than the comma* their real precedence.
+///
+/// Every parser that splits a comma list itself has to run this, or those operators end
+/// up binding tighter than the comma: the sequence `...` would take only its adjacent
+/// element as a seed (`0, 1, *+* ... *`), and a list infix meta-op only its adjacent
+/// element as an operand (`[0, |@p Z+ |@p, 0]`).
+pub(in crate::parser) fn normalize_comma_list_items(items: Vec<Expr>) -> Vec<Expr> {
+    merge_sequence_seeds(lift_meta_ops_in_list(items))
+}
+
 /// In a comma-separated list, if the last item is a sequence expression
 /// (Binary { ..., DotDotDot/DotDotDotCaret, ... }), merge all preceding
 /// items into the sequence LHS.
@@ -71,27 +81,56 @@ fn merge_sequence_seeds(items: Vec<Expr>) -> Vec<Expr> {
     if items.len() < 2 {
         return items;
     }
-    let last = items.last().unwrap();
-    if let Expr::Binary { left, op, right } = last
-        && matches!(op, TokenKind::DotDotDot | TokenKind::DotDotDotCaret)
-    {
-        // Merge preceding items + sequence LHS into a new ArrayLiteral
-        let mut seeds: Vec<Expr> = items[..items.len() - 1].to_vec();
-        seeds.push(*left.clone());
-        let merged = Expr::Binary {
-            left: Box::new(Expr::ArrayLiteral(seeds)),
-            op: op.clone(),
-            right: right.clone(),
-        };
-        vec![merged]
-    } else {
-        items
+    let seeds: Vec<Expr> = items[..items.len() - 1].to_vec();
+    match merge_seeds_into_sequence(items.last().unwrap(), &seeds) {
+        Some(merged) => vec![merged],
+        None => items,
+    }
+}
+
+/// Fold `seeds` into the LHS of the sequence at (or inside) `last`.
+///
+/// A feed is the loosest operator in Raku, so it sits *outside* the sequence:
+/// `$[1], -> @p {...} ... * ==> f()` is `(($[1], -> @p {...}) ... *) ==> f()`. The
+/// comma-list splitter sees the whole `-> @p {...} ... * ==> f()` as one element, so
+/// the sequence to merge into is one level down, under the feed's source.
+fn merge_seeds_into_sequence(last: &Expr, seeds: &[Expr]) -> Option<Expr> {
+    match last {
+        Expr::Binary { left, op, right }
+            if matches!(op, TokenKind::DotDotDot | TokenKind::DotDotDotCaret) =>
+        {
+            let mut merged_seeds: Vec<Expr> = seeds.to_vec();
+            merged_seeds.push(*left.clone());
+            Some(Expr::Binary {
+                left: Box::new(Expr::ArrayLiteral(merged_seeds)),
+                op: op.clone(),
+                right: right.clone(),
+            })
+        }
+        Expr::Feed {
+            source,
+            sink,
+            append,
+            left_is_source,
+        } if *left_is_source => {
+            let merged_source = merge_seeds_into_sequence(source, seeds)?;
+            Some(Expr::Feed {
+                source: Box::new(merged_source),
+                sink: sink.clone(),
+                append: *append,
+                left_is_source: *left_is_source,
+            })
+        }
+        _ => None,
     }
 }
 
 /// In a comma-separated list, if an item is a MetaOp (X+, Z-, etc.), merge
 /// all preceding items into its left operand. This gives meta-ops effective
 /// list-infix precedence: `1, 2 X+ 10` → `MetaOp(X, +, [1,2], 10)`.
+///
+/// The array composer needs this for `[0, |@p Z+ |@p, 0]`, which is
+/// `(0, |@p) Z+ (|@p, 0)` in Raku.
 fn lift_meta_ops_in_list(items: Vec<Expr>) -> Vec<Expr> {
     // Find the first MetaOp in the list
     let meta_idx = items.iter().position(|e| matches!(e, Expr::MetaOp { .. }));

--- a/src/parser/stmt/simple_expr_stmt/core.rs
+++ b/src/parser/stmt/simple_expr_stmt/core.rs
@@ -1394,6 +1394,10 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
         // A trailing comma before `}` always creates a list, even with
         // a single element (e.g. `{ 42, }` gives `(42,)`).
         if !is_stmt_modifier_keyword(r) {
+            // This split the comma list by hand, so the operators that are looser than the
+            // comma still need their real precedence: without this, `$[1], -> @p {...} ... *`
+            // seeds the sequence with the pointy block alone, dropping `$[1]`.
+            let mut exprs = crate::parser::stmt::assign::normalize_comma_list_items(exprs);
             let expr = if trailing_comma || exprs.len() > 1 {
                 Expr::ArrayLiteral(exprs)
             } else {

--- a/t/comma-list-precedence.t
+++ b/t/comma-list-precedence.t
@@ -1,0 +1,44 @@
+use Test;
+
+plan 10;
+
+# The comma is TIGHTER than the list infix operators (Z, X and their meta forms) and
+# tighter than the sequence operator. Every parser that splits a comma list by hand has
+# to honour that, or `Z+` takes only its adjacent element as an operand.
+
+# Array composer.
+is-deeply [1, 2 Z+ 3, 4], [4, 6], 'Z+ is looser than the comma inside [ ]';
+is-deeply [1, 2 X~ 3, 4], ['13', '14', '23', '24'], 'X~ is looser than the comma inside [ ]';
+
+my @p = 1;
+is-deeply $[0, |@p Z+ |@p, 0], $[1, 1], 'the Pascal step composes inside $[ ]';
+
+# Parenthesized list and assignment RHS already agreed; they must keep agreeing.
+is-deeply (1, 2 Z+ 3, 4), (4, 6), 'Z+ is looser than the comma inside ( )';
+my @assigned = 1, 2 Z+ 3, 4;
+is-deeply @assigned, [4, 6], 'Z+ is looser than the comma on an assignment RHS';
+
+# The sequence operator takes every preceding comma element as a seed.
+is-deeply [0, 1, *+* ... 8], [0, 1, 1, 2, 3, 5, 8], 'the sequence seeds on all preceding elements';
+
+# The feed is looser than the sequence, so it sits outside it -- and the seeds still
+# have to reach the sequence through the feed.
+my $fed = do {
+    1, 2, *+* ... *
+        ==> (*[0..6])()
+        ==> map *.Int
+        ==> elems()
+};
+is $fed, 7, 'a feed after a seeded sequence keeps its seeds';
+
+my @pascal = do {
+    $[1], -> @row { $[0, |@row Z+ |@row, 0] } ... *
+        ==> (*[0..4])()
+};
+is-deeply @pascal[4], $[1, 4, 6, 4, 1], 'the Pascal triangle builds through a feed';
+
+# A sequence endpoint must not swallow the feed into a WhateverCode.
+is ((1, *+1 ... *) ==> (*[0..3])() ==> elems()), 4, 'a Whatever endpoint does not absorb the feed';
+
+# Plain composers are unchanged.
+is-deeply [[1, 2], [3, 4]], [[1, 2], [3, 4]], 'a nested array composer is unchanged';


### PR DESCRIPTION
Raku's list infix operators (`Z`, `X` and their meta forms) and the sequence operator are **looser than the comma**, and the feed is looser still. mutsu has **five** parsers that split a comma list by hand, and only one of them — `parse_comma_or_expr` — repaired the precedence afterwards. The others bound those operators *tighter* than the comma:

```raku
[1, 2 Z+ 3, 4]                    # was [1, (5,)]   — raku: [4, 6]
[0, |@p Z+ |@p, 0]                # was [0, (2,)]   — raku: [1, 1]
$[1], -> @p {...} ... * ==> f()   # seeded the sequence with the pointy block alone, dropping $[1]
```

The repair (`merge_sequence_seeds` + `lift_meta_ops_in_list`) is now one shared `normalize_comma_list_items`, and the array composer and the comma expression statement both route through it. The array composer's duplicate `merge_sequence_seeds` goes away.

## Two more precedence bugs the same expression surfaced

- **A sequence endpoint swallowed the feed.** `sequence_expr` parsed its endpoint through `ExprMode::NoSequence`, which routes to `list_infix_expr` — and *that* loop consumes a feed. So `1, *+1 ... * ==> elems()` parsed the endpoint as `* ==> elems()`, and the Whatever-curry then turned it into a 1-ary WhateverCode ("Too few positionals passed"). The endpoint now parses below the list-infix layer; the feed belongs to `sequence_expr`'s own loop, outside the sequence.

- **`merge_sequence_seeds` could not see a sequence through a feed.** Since the feed is the loosest operator, `A, B ... * ==> f()` is `((A, B) ... *) ==> f()`, and the comma splitter hands the whole feed to it as one element.

## Result

`roast/integration/advent2012-day04.t` goes from **does not compile** to running: tests 1, 2 and 4 pass, and test 3 is a `#?rakudo todo` that now returns 0 — the same value rakudo itself returns.

It stops at test 5, where a pointy block's *destructuring* signature does not register its sigilless names, so `-> [ \a, \u, \v ] { u %% v }` parses `u` as a listop call (`Unknown function: u`). BLOCKERS.md records that as the next step.

New test: `t/comma-list-precedence.t`. `make test` is green, and the operator/array/sequence-heavy whitelisted roast files were re-run individually with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tFv8btbbJZpJT6G2vCS2i