### PR TITLE
fix: bind a destructuring signature's names — in the parser, in grep, and through a grep-containerized slot

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -51,7 +51,7 @@ S\* 系 24 本しか載せておらず、`integration/` 41 本・`6.c/` 7 本・
 | 根本原因クラスタ | 本数 | 該当ファイル（抜粋） | 症状 |
 |---|---|---|---|
 | **① スタックオーバーフローで abort**（★同じ症状で原因は 4 つ別々 — 下節参照） | **残 1** | **残: `man-or-boy.t`**。`99problems-41-to-50.t`(#4510)・`99problems-51-to-60.t`(#4516) は無限再帰で修正済み、`deep-recursion-initing-native-array.t` は debug 計測の誤診（release では元から通る）＝whitelist 追加 | `fatal runtime error: stack overflow, aborting`（プロセス abort）。**4 本のうち 3 本は無限再帰、1 本は計測ミス。「本当に深い再帰でスタックが足りない」ものは 1 本も無かった** |
-| **② パース不能（`===SORRY!===`）** | **残 1** | **残: `advent2012-day19.t`**（ユーザ定義演算子の優先順位） | **9 本は解消済み（#4511 / #4514 / #4515）** — 下の「② の内訳」参照。②はほぼ枯渇 |
+| **② パース不能（`===SORRY!===`）** | **残 1** | **残: `advent2012-day19.t`**（ユーザ定義演算子の優先順位） | **9 本は解消済み（#4511 / #4514 / #4515 / #4517 / #4518）** — 下の「② の内訳」参照。②はほぼ枯渇 |
 | **③ ハング / タイムアウト** | 5 | `advent2012-day21.t`・`advent2013-day14.t`・`gather-with-loops.t`・`APPENDICES/A01-limits/{misc,overflow}.t` | 25s で打ち切り。gather×loop の遅延評価と limit 系 |
 | **④ エラーメッセージ品質** | 2 | `error-reporting.t`（mutsu 4/33・raku 33/33）・`weird-errors.t`（26/36） | 「Parse error contains line number」等、**例外の文面・行番号・バックトレース**を検査するテスト。PLAN §6「エラーメッセージ品質向上」と同一の的 |
 | **⑤ 個別機能ギャップ** | 残り | `advent2009-day24.t`（派生 grammar の拡張）・`advent2010-day14.t`（`nextsame` の継承/mixin）・`advent2010-day22.t`（`Rat` の `$!numerator`/`$!denominator` 属性）・`advent2011-day07.t`（`Metamodel::GrammarHOW` 継承）・`advent2011-day10.t`（`--doc` / `DOC INIT {}`）・`advent2009-day20.t`（signature の introspection/stringification）・`advent2009-day18.t`（パラメタ化 role の mixin）・`advent2013-day10.t`（`:round` 等の演算子 adverb）・`precompiled.t`（precomp） | 1 ファイル数本ずつ。★の近道はここ |
@@ -94,17 +94,16 @@ f([3, Any, Any], 0);
 
 ### ② の内訳（2026-07-14 実測・#4511 / #4514 / #4515 後）
 
-**whitelist 到達（5 本）**: `advent2010-day11.t`・`advent2013-day04.t`・`advent2014-day16.t`（#4511:
+**whitelist 到達（6 本）**: `advent2010-day11.t`・`advent2013-day04.t`・`advent2014-day16.t`（#4511:
 `qto`/`qqto` fused adverb、quote 語とデリミタ間の空白・改行、heredoc 本体の開始行、`q:to:c` の
 選択的 adverb、lazy gather Seq の多引数 `for`）／`advent2009-day16.t`・`advent2009-day23.t`（#4514:
 `when` 文修飾子、Match を RHS とする smartmatch、`(with …)`/`(given …)` の式化、`my@i` の
-空白なし宣言）。
+空白なし宣言）／`advent2012-day04.t`（#4515 の feed 継続行・無限 closure sequence の lazy `for`、#4517 のコンマより緩い演算子の優先順位、#4518 の分解シグネチャ＋grep バインダ）。
 
-**パースは通ったが subtest が残る（4 本）** — ②ではなく機能ギャップに移行:
+**パースは通ったが subtest が残る（3 本）** — ②ではなく機能ギャップに移行:
 
 | ファイル | 残 | ブロッカー |
 |---|---|---|
-| `integration/advent2012-day04.t` | test 5 で中断 | **pointy の分解シグネチャが sigilless 名をパーサに登録しない**。`-> [ \a, \u, \v ] { u %% v }` の `u` が宣言済みの項として見えず listop 呼び出しに化ける（`Unknown function: u`）。#4515 で 0/8（コンパイル不能）→ 2 本、#4516 で **test 1・2・4 pass ＋ test 3 は TODO（raku も同値 0 を返す）** まで前進 |
 | `integration/advent2012-day15.t` | 2/11 | phaser の文形式が独自スコープを作る（`NEXT (state $best) max= $_;` の `$best` が `LAST` から見えない）／`INIT` がメインラインより後に走る |
 | `6.c/MISC/bug-coverage.t` | 5/17 | `.count-only`/`.bool-only`、thunk のクロージャスコープ 等 |
 | `6.c/APPENDICES/A04-experimental/01-misc.t` | 3/19 | `:D`/`:U` DefiniteHow coercion（`Target:D(Source:U)`）。#4514 で 0/19 → 16/19 |

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1344,6 +1344,7 @@ roast/integration/advent2011-day23.t
 roast/integration/advent2011-day24.t
 roast/integration/advent2012-day02.t
 roast/integration/advent2012-day03.t
+roast/integration/advent2012-day04.t
 roast/integration/advent2012-day06.t
 roast/integration/advent2012-day10.t
 roast/integration/advent2012-day12.t

--- a/src/parser/primary/misc/lambda.rs
+++ b/src/parser/primary/misc/lambda.rs
@@ -317,6 +317,29 @@ pub(crate) fn parse_block_body(input: &str) -> PResult<'_, Vec<crate::ast::Stmt>
     result
 }
 
+/// Whether any parameter -- including one nested in a destructuring sub-signature --
+/// is sigilless.
+fn has_sigilless_param(param_defs: &[crate::ast::ParamDef]) -> bool {
+    param_defs
+        .iter()
+        .any(|p| p.sigilless || p.sub_signature.as_deref().is_some_and(has_sigilless_param))
+}
+
+/// Register every sigilless parameter as a term symbol, descending into destructuring
+/// sub-signatures: `-> [ \a, \u, \v ] { u %% v }` binds `u` and `v` just as
+/// `-> \u, \v { ... }` does, so the body must see them as terms rather than parse `u`
+/// as the head of a listop call.
+fn register_sigilless_params(param_defs: &[crate::ast::ParamDef]) {
+    for pd in param_defs {
+        if pd.sigilless {
+            crate::parser::stmt::simple::register_user_term_symbol(&pd.name);
+        }
+        if let Some(sub) = pd.sub_signature.as_deref() {
+            register_sigilless_params(sub);
+        }
+    }
+}
+
 /// Like `parse_block_body`, but registers any sigilless parameters as term symbols
 /// before parsing the body.  This prevents bare names like `s` or `q` from being
 /// misinterpreted as substitution / quoting operators inside arrow-lambda bodies.
@@ -324,17 +347,12 @@ fn parse_block_body_with_sigilless<'a>(
     param_defs: &[crate::ast::ParamDef],
     input: &'a str,
 ) -> PResult<'a, Vec<crate::ast::Stmt>> {
-    let has_sigilless = param_defs.iter().any(|p| p.sigilless);
-    if !has_sigilless {
+    if !has_sigilless_param(param_defs) {
         return parse_block_body(input);
     }
     let (r, _) = parse_char(input, '{')?;
     crate::parser::stmt::simple::push_scope();
-    for pd in param_defs {
-        if pd.sigilless {
-            crate::parser::stmt::simple::register_user_term_symbol(&pd.name);
-        }
-    }
+    register_sigilless_params(param_defs);
     let result = (|| -> PResult<'_, Vec<crate::ast::Stmt>> {
         let (r, stmts) = crate::parser::stmt::stmt_list_pub(r)?;
         let (r, _) = ws_inner(r);

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -230,6 +230,27 @@ impl Interpreter {
         {
             let data = data.clone();
             let mut result = Vec::new();
+            // A destructuring sub-signature (`grep -> [ \a, \u, \v ] { u %% v }`) has to go
+            // through the real binder. The fast path below inserts each parameter into the
+            // env *by name*, which cannot take an element apart, so the inner names stayed
+            // unbound. `map` already routes such signatures to `call_sub_value`.
+            let needs_full_binding = data
+                .param_defs
+                .iter()
+                .any(|pd| pd.sub_signature.is_some() || pd.outer_sub_signature.is_some());
+            if needs_full_binding {
+                for item in &list_items {
+                    let pred = self.call_sub_value(
+                        Value::sub_value(data.clone()),
+                        vec![item.clone()],
+                        false,
+                    )?;
+                    if pred.truthy() {
+                        result.push(item.clone());
+                    }
+                }
+                return Ok((Value::array(result), list_items));
+            }
             let arity = if !data.params.is_empty() {
                 let effective = data
                     .params

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -6,6 +6,14 @@ pub(in crate::runtime) fn positional_values_from_unpack_target(value: &Value) ->
     if let Some((_, inner)) = varref_from_value(value) {
         return positional_values_from_unpack_target(&inner);
     }
+    // `grep` promotes each matched source slot to a shared `ContainerRef` cell so a
+    // writeback loop can mutate through it. A later destructuring bind of that element
+    // (`@a.grep(...); @a.map(-> [$x, $y] {...})`) has to look through the cell, or it
+    // sees one opaque value and reports "Too few positional arguments".
+    if let ValueView::ContainerRef(cell) = value.view() {
+        let inner = cell.lock().unwrap().clone();
+        return positional_values_from_unpack_target(&inner);
+    }
     match value.view() {
         ValueView::Capture { positional, .. } => (*positional).clone(),
         // For sub-signature destructuring, a list is always taken apart

--- a/t/destructuring-sigilless-params.t
+++ b/t/destructuring-sigilless-params.t
@@ -1,0 +1,48 @@
+use Test;
+
+plan 10;
+
+# A destructuring signature binds its inner names exactly as a flat one does, so the
+# body must see them as declared terms -- not as the head of a listop call. `u %% v`
+# used to parse as `u(%% v)` and die with "Unknown function: u".
+my &divisible = -> [ \a, \u, \v ] { u %% v };
+ok divisible([1, 4, 2]), 'a destructured sigilless name is a term, not a listop';
+nok divisible([1, 3, 2]), 'the destructured names carry the right values';
+
+# Flat sigilless params already worked; they must keep working.
+my &flat = -> \u, \v { u %% v };
+ok flat(4, 2), 'flat sigilless params are unchanged';
+
+# Sigiled destructuring, for comparison.
+my &sigiled = -> [$a, $u, $v] { $u %% $v };
+ok sigiled([1, 4, 2]), 'a sigiled destructuring signature binds too';
+
+# `grep` used to bind its block's parameters by name straight into the env, which cannot
+# take an element apart -- so a destructuring signature left the inner names unbound.
+my @triples = ([1, 4, 2], [1, 3, 2], [5, 9, 3]);
+is-deeply @triples.grep(-> [ \a, \u, \v ] { u %% v }).List,
+    ([1, 4, 2], [5, 9, 3]),
+    'grep binds a destructuring signature';
+
+is-deeply @triples.grep(-> [$a, $u, $v] { $u %% $v }).List,
+    ([1, 4, 2], [5, 9, 3]),
+    'grep binds a sigiled destructuring signature';
+
+# `map` already went through the real binder; it must keep agreeing with grep.
+is-deeply @triples.map(-> [ \a, \u, \v ] { u div v }).List,
+    (2, 1, 3),
+    'map binds a destructuring signature';
+
+# A plain grep block is unaffected.
+is-deeply (1..6).grep(-> $n { $n %% 2 }).List, (2, 4, 6), 'a plain grep block is unchanged';
+
+# `grep` promotes each matched source slot to a shared ContainerRef cell so a writeback
+# loop can mutate through it. A later destructuring bind has to look through that cell.
+my @cells = ([1, 4, 2], [1, 3, 2]);
+@cells.grep({ .elems == 3 });
+is-deeply @cells.map(-> [ \a, \u, \v ] { u }).List, (4, 3),
+    'destructuring still binds after grep containerized the source slots';
+
+@cells.grep(-> [ \a, \u, \v ] { u %% v });
+is-deeply @cells.grep(-> [ \a, \u, \v ] { u %% v }).List, ([1, 4, 2],),
+    'a second destructuring grep over the same array still binds';


### PR DESCRIPTION
Three bugs that together kept `-> [ \a, \u, \v ] { u %% v }` from working — the last thing between `roast/integration/advent2012-day04.t` and the whitelist.

- **The parser only registered *top-level* sigilless parameters as term symbols.** A destructuring sub-signature's names were never registered, so the body parsed `u %% v` as the listop call `u(%% v)` — `Unknown function: u`. `register_sigilless_params` now descends into `sub_signature`.

- **`grep` bound its block's parameters by name straight into the env**, which cannot take an element apart, so a destructuring signature left the inner names unbound (`Attempt to divide by zero`). `map` already routed such signatures to `call_sub_value`; `grep` now does too.

- **Pre-existing, and the reason a *second* destructuring bind over the same array failed:** `grep` promotes each matched source slot to a shared `ContainerRef` cell (so a writeback loop can mutate through it), and `positional_values_from_unpack_target` did not look through that cell — it saw one opaque value and reported "Too few positional arguments in sub-signature binding". This reproduces on `main` with no other change:

  ```raku
  my @a = ([1,4,2],[1,3,2]);
  @a.grep({ .elems == 3 });
  @a.map(-> [$x, $y, $z] { $y });   # Too few positional arguments in sub-signature binding
  ```

## Result

`roast/integration/advent2012-day04.t` passes in full and is whitelisted (1390 → 1391). With it, **9 of the 10 files** in BLOCKERS.md's "② パース不能" cluster are done; only `advent2012-day19.t` remains, and it needs real precedence climbing for user-defined operators (recorded in BLOCKERS.md).

New test: `t/destructuring-sigilless-params.t`. `make test` is green, and the signature/block/list-heavy whitelisted roast files were re-run individually with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tFv8btbbJZpJT6G2vCS2i