### PR TITLE
fix: give a user-defined operator's precedence trait its actual effect

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -51,7 +51,7 @@ S\* 系 24 本しか載せておらず、`integration/` 41 本・`6.c/` 7 本・
 | 根本原因クラスタ | 本数 | 該当ファイル（抜粋） | 症状 |
 |---|---|---|---|
 | **① スタックオーバーフローで abort**（★同じ症状で原因は 4 つ別々 — 下節参照） | **残 1** | **残: `man-or-boy.t`**。`99problems-41-to-50.t`(#4510)・`99problems-51-to-60.t`(#4516) は無限再帰で修正済み、`deep-recursion-initing-native-array.t` は debug 計測の誤診（release では元から通る）＝whitelist 追加 | `fatal runtime error: stack overflow, aborting`（プロセス abort）。**4 本のうち 3 本は無限再帰、1 本は計測ミス。「本当に深い再帰でスタックが足りない」ものは 1 本も無かった** |
-| **② パース不能（`===SORRY!===`）** | **残 1** | **残: `advent2012-day19.t`**（ユーザ定義演算子の優先順位） | **9 本は解消済み（#4511 / #4514 / #4515 / #4517 / #4518）** — 下の「② の内訳」参照。②はほぼ枯渇 |
+| **② パース不能（`===SORRY!===`）** | **0（完了）** | 10 本すべて解消（#4511 / #4514 / #4515 / #4517 / #4518 / #4522） | **このクラスタは枯渇。** 7 本が whitelist 到達、3 本はパースを通過して機能ギャップへ移行 — 下の「② の内訳」参照 |
 | **③ ハング / タイムアウト** | 5 | `advent2012-day21.t`・`advent2013-day14.t`・`gather-with-loops.t`・`APPENDICES/A01-limits/{misc,overflow}.t` | 25s で打ち切り。gather×loop の遅延評価と limit 系 |
 | **④ エラーメッセージ品質** | 2 | `error-reporting.t`（mutsu 4/33・raku 33/33）・`weird-errors.t`（26/36） | 「Parse error contains line number」等、**例外の文面・行番号・バックトレース**を検査するテスト。PLAN §6「エラーメッセージ品質向上」と同一の的 |
 | **⑤ 個別機能ギャップ** | 残り | `advent2009-day24.t`（派生 grammar の拡張）・`advent2010-day14.t`（`nextsame` の継承/mixin）・`advent2010-day22.t`（`Rat` の `$!numerator`/`$!denominator` 属性）・`advent2011-day07.t`（`Metamodel::GrammarHOW` 継承）・`advent2011-day10.t`（`--doc` / `DOC INIT {}`）・`advent2009-day20.t`（signature の introspection/stringification）・`advent2009-day18.t`（パラメタ化 role の mixin）・`advent2013-day10.t`（`:round` 等の演算子 adverb）・`precompiled.t`（precomp） | 1 ファイル数本ずつ。★の近道はここ |
@@ -121,13 +121,19 @@ plain lexical」だけを上書き install する（`CompiledCode::authoritative
 （`&x1` か `x1` か）で扱われているかを先に確認すること — `CallOnCodeVar { name_idx }` は
 シジル無しの名前を持つ疑いがある。
 
-### ② の内訳（2026-07-14 実測・#4511 / #4514 / #4515 後）
+### ② の内訳（クラスタ完了・#4511 / #4514 / #4515 / #4517 / #4518 / #4522）
 
-**whitelist 到達（6 本）**: `advent2010-day11.t`・`advent2013-day04.t`・`advent2014-day16.t`（#4511:
+**whitelist 到達（7 本）**: `advent2010-day11.t`・`advent2013-day04.t`・`advent2014-day16.t`（#4511:
 `qto`/`qqto` fused adverb、quote 語とデリミタ間の空白・改行、heredoc 本体の開始行、`q:to:c` の
 選択的 adverb、lazy gather Seq の多引数 `for`）／`advent2009-day16.t`・`advent2009-day23.t`（#4514:
 `when` 文修飾子、Match を RHS とする smartmatch、`(with …)`/`(given …)` の式化、`my@i` の
-空白なし宣言）／`advent2012-day04.t`（#4515 の feed 継続行・無限 closure sequence の lazy `for`、#4517 のコンマより緩い演算子の優先順位、#4518 の分解シグネチャ＋grep バインダ）。
+空白なし宣言）／`advent2012-day04.t`（#4515 の feed 継続行・無限 closure sequence の lazy `for`、#4517 のコンマより緩い演算子の優先順位、#4518 の分解シグネチャ＋grep バインダ）／`advent2012-day19.t`（#4522）。
+
+最後の 1 本 `advent2012-day19.t` は #4522 で全 10 subtest 通過。**優先順位トレイト付きユーザ定義
+演算子**（`sub postfix:<k> is tighter(&infix:<*>)`）が項に一切適用されない問題（postfix ループが
+「prefix 層で拾われる」として全部スキップしていたが、その拾い上げはユーザ定義 prefix の分岐内に
+しか無かった）・英字 postfix の連鎖（`4kVW`）・`is looser(&postfix:<k>)` が k の登録レベルではなく
+`PREC_PREFIX` を基準にしていたバグ・`Mu.ACCEPTS`・`Range.new` を実装。
 
 **パースは通ったが subtest が残る（3 本）** — ②ではなく機能ギャップに移行:
 
@@ -192,8 +198,6 @@ postfix** が、項に対して一切適用されない（`4.7k` が SORRY）。
 
 1. **① の残り 1 本 = `man-or-boy.t`**（下記「man-or-boy の診断」に正確な根本原因あり）。
    **スタック拡張の機構は不要だった**（上の内訳表を参照）。
-2. **② パース不能 10 本を 1 本ずつ**。構文ごとに独立で、安い ★ が混じっている見込み
-   （`q | … |` デリミタ・ユーザ定義 postfix `4.7k`・heredoc インデント等）。
 3. **近道**: `6.c/S04-declarations/my-6c.t` は `OUTER::<$x>` の 1 subtest だけ
    （111/112）。`advent2011-day04.t` は 1/2。
 4. **④ エラーメッセージ品質**（`error-reporting.t` 4/33）は PLAN §6 の同名タスクと同じ的なので、

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1350,6 +1350,7 @@ roast/integration/advent2012-day10.t
 roast/integration/advent2012-day12.t
 roast/integration/advent2012-day13.t
 roast/integration/advent2012-day16.t
+roast/integration/advent2012-day19.t
 roast/integration/advent2012-day20.t
 roast/integration/advent2012-day22.t
 roast/integration/advent2012-day24.t

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -28,6 +28,29 @@ use crate::symbol::Symbol;
 use crate::token_kind::TokenKind;
 use crate::value::{Value, ValueView};
 
+thread_local! {
+    /// The precedence level of the user-defined *prefix* operator whose operand is
+    /// currently being parsed, if any.
+    ///
+    /// A user-defined postfix normally binds to the term it follows, so the postfix loop
+    /// consumes it right there. The one exception is a postfix declared `is looser(...)`
+    /// than a prefix that is still waiting for its operand: `'foo1'3'bar1'` must be
+    /// `('foo1' 3)'bar1'`, so the postfix has to be left for the prefix branch to apply
+    /// after it has built its call. This records that pending prefix so the postfix loop
+    /// can tell the two situations apart — without it, the loop skipped *every*
+    /// precedence-annotated postfix, and a plain term (`4.7k`) then found no one to
+    /// consume it at all.
+    static PENDING_PREFIX_LEVEL: std::cell::Cell<Option<i32>> = const { std::cell::Cell::new(None) };
+}
+
+/// Run `f` while parsing the operand of a user-defined prefix operator at `level`.
+fn with_pending_prefix_level<T>(level: Option<i32>, f: impl FnOnce() -> T) -> T {
+    let saved = PENDING_PREFIX_LEVEL.with(|c| c.replace(level));
+    let out = f();
+    PENDING_PREFIX_LEVEL.with(|c| c.set(saved));
+    out
+}
+
 /// Parse the operand of a `lazy`/`eager`/`hyper` statement prefix: like
 /// `return`'s `parse_comma_or_expr`, these bind looser than the comma
 /// operator, so `lazy 3,4,5` must wrap the *entire* list `(3,4,5)` rather
@@ -158,21 +181,25 @@ pub(in crate::parser::expr) fn prefix_expr(input: &str) -> PResult<'_, Expr> {
             let (rest, _) = ws(rest)?;
             // Check if this prefix has a custom precedence level
             let prec_level = crate::parser::stmt::simple::lookup_prefix_precedence(&name);
-            let (mut rest, arg) = match prec_level {
-                Some(level) if level <= crate::parser::stmt::simple::PREC_ADDITIVE => {
-                    // Looser than additive: grab everything up to additive level
-                    crate::parser::expr::precedence::loose_prefix_operand(rest, level)?
-                }
-                Some(level) if level <= crate::parser::stmt::simple::PREC_MULTIPLICATIVE => {
-                    // Between additive and multiplicative
-                    crate::parser::expr::precedence::multiplicative_operand(rest)?
-                }
-                Some(level) if level <= crate::parser::stmt::simple::PREC_POWER => {
-                    // Between multiplicative and power
-                    crate::parser::expr::precedence::power_operand(rest)?
-                }
-                _ => prefix_expr(rest)?,
-            };
+            let own_level = prec_level.unwrap_or(crate::parser::stmt::simple::PREC_PREFIX);
+            // While the operand is being parsed, a postfix looser than this prefix must be
+            // left alone -- it belongs to the whole prefix call, applied by the loop below.
+            let (mut rest, arg) =
+                with_pending_prefix_level(Some(own_level), || match prec_level {
+                    Some(level) if level <= crate::parser::stmt::simple::PREC_ADDITIVE => {
+                        // Looser than additive: grab everything up to additive level
+                        crate::parser::expr::precedence::loose_prefix_operand(rest, level)
+                    }
+                    Some(level) if level <= crate::parser::stmt::simple::PREC_MULTIPLICATIVE => {
+                        // Between additive and multiplicative
+                        crate::parser::expr::precedence::multiplicative_operand(rest)
+                    }
+                    Some(level) if level <= crate::parser::stmt::simple::PREC_POWER => {
+                        // Between multiplicative and power
+                        crate::parser::expr::precedence::power_operand(rest)
+                    }
+                    _ => prefix_expr(rest),
+                })?;
             let mut result = Expr::Call {
                 name: Symbol::intern(&name),
                 args: vec![arg],
@@ -184,7 +211,7 @@ pub(in crate::parser::expr) fn prefix_expr(input: &str) -> PResult<'_, Expr> {
                 {
                     let post_prec =
                         crate::parser::stmt::simple::lookup_postfix_precedence(&post_name);
-                    if post_prec.is_some_and(|p| p < crate::parser::stmt::simple::PREC_PREFIX) {
+                    if post_prec.is_some_and(|p| p < own_level) {
                         let after = &rest[post_len..];
                         result = Expr::Call {
                             name: Symbol::intern(&post_name),
@@ -2714,17 +2741,29 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
         if let Some((name, len)) = crate::parser::stmt::simple::match_user_declared_postfix_op(rest)
         {
             let after = &rest[len..];
+            // A word character after the operator normally means we matched inside a longer
+            // identifier, not an operator. But two alphabetic postfixes can chain (`4.0kV`
+            // is `postfix:<V>(postfix:<k>(4.0))`), so a following *declared* postfix is a
+            // real boundary.
             let ident_continuation = after
                 .as_bytes()
                 .first()
                 .copied()
-                .is_some_and(|b| is_ident_char(Some(b)));
+                .is_some_and(|b| is_ident_char(Some(b)))
+                && crate::parser::stmt::simple::match_user_declared_postfix_op(after).is_none();
             if !ident_continuation {
-                // Skip postfix ops that have a precedence level lower than PREFIX
-                // (declared `is looser(&prefix:<...>)`). These will be handled
-                // at the prefix level after the prefix operand is parsed.
+                // A postfix declared looser than the user-defined prefix whose operand we
+                // are currently inside belongs to the whole prefix call, so leave it for the
+                // prefix branch. Outside such an operand there is nothing looser to wait
+                // for, and the postfix binds to the term it follows -- which is how a plain
+                // `4.7k` (postfix:<k> is tighter(&infix:<*>)) gets consumed at all.
                 let post_prec = crate::parser::stmt::simple::lookup_postfix_precedence(&name);
-                if post_prec.is_some_and(|p| p < crate::parser::stmt::simple::PREC_PREFIX) {
+                let pending = PENDING_PREFIX_LEVEL.with(|c| c.get());
+                let defer_to_prefix = match (post_prec, pending) {
+                    (Some(p), Some(prefix_level)) => p < prefix_level,
+                    _ => false,
+                };
+                if defer_to_prefix {
                     // Don't consume this postfix here; let it be consumed at prefix level
                 } else {
                     expr = Expr::Call {

--- a/src/parser/stmt/simple/registry.rs
+++ b/src/parser/stmt/simple/registry.rs
@@ -42,7 +42,10 @@ pub(crate) fn resolve_op_precedence(ref_op: &str) -> Option<i32> {
         return resolve_infix_symbol_precedence(symbol);
     }
     if op.starts_with("prefix:<") || op.starts_with("postfix:<") {
-        return Some(PREC_PREFIX);
+        // A user-defined prefix/postfix may itself carry a precedence trait, and a later
+        // `is looser(&postfix:<k>)` has to be relative to *that* level, not to the default
+        // one it would have had without the trait.
+        return Some(lookup_op_precedence(op).unwrap_or(PREC_PREFIX));
     }
 
     // Bare symbol: +, *, **, ~

--- a/src/parser/stmt/simple/user_ops.rs
+++ b/src/parser/stmt/simple/user_ops.rs
@@ -64,40 +64,64 @@ pub(crate) fn match_user_declared_prefix_op(input: &str) -> Option<(String, usiz
 pub(crate) fn match_user_declared_postfix_op(input: &str) -> Option<(String, usize)> {
     SCOPES.with(|s| {
         let scopes = s.borrow();
-        let mut best: Option<(String, usize)> = None;
-
-        for scope in scopes.iter().rev() {
-            for name in &scope.user_subs {
-                let Some(op) = name
-                    .strip_prefix("postfix:<")
+        let ops: Vec<(&String, &str)> = scopes
+            .iter()
+            .rev()
+            .flat_map(|scope| scope.user_subs.iter())
+            .filter_map(|name| {
+                name.strip_prefix("postfix:<")
                     .and_then(|s| s.strip_suffix('>'))
+                    .map(|op| (name, op))
+            })
+            .collect();
+
+        // A word-like operator needs an identifier boundary after it, or we matched inside
+        // a longer name rather than an operator.
+        let word_like = |op: &str| {
+            op.as_bytes()
+                .last()
+                .copied()
+                .is_some_and(|b| crate::parser::helpers::is_ident_char(Some(b)))
+        };
+        let starts_ident = |rest: &str| {
+            rest.as_bytes()
+                .first()
+                .copied()
+                .is_some_and(|b| crate::parser::helpers::is_ident_char(Some(b)))
+        };
+        // Alphabetic postfixes chain (`4kVW` is `W(V(k(4)))`), so what follows a word-like
+        // operator is a boundary as long as it can be peeled off by further declared
+        // postfixes. `4.7keys` still has no such peeling and stays one identifier.
+        let chain_ok = |mut rest: &str| {
+            while starts_ident(rest) {
+                let Some(next) = ops
+                    .iter()
+                    .map(|(_, op)| *op)
+                    .filter(|op| rest.starts_with(op))
+                    .max_by_key(|op| op.len())
                 else {
-                    continue;
+                    return false;
                 };
-                if !input.starts_with(op) {
-                    continue;
-                }
-                let consumed = op.len();
-                // For word-like operators, require identifier boundary.
-                if op
-                    .as_bytes()
-                    .last()
-                    .copied()
-                    .is_some_and(|b| crate::parser::helpers::is_ident_char(Some(b)))
-                    && input
-                        .as_bytes()
-                        .get(consumed)
-                        .copied()
-                        .is_some_and(|b| crate::parser::helpers::is_ident_char(Some(b)))
-                {
-                    continue;
-                }
-                if best
-                    .as_ref()
-                    .is_none_or(|(_, best_len)| consumed > *best_len)
-                {
-                    best = Some((name.clone(), consumed));
-                }
+                rest = &rest[next.len()..];
+            }
+            true
+        };
+
+        let mut best: Option<(String, usize)> = None;
+        for (name, op) in &ops {
+            if !input.starts_with(op) {
+                continue;
+            }
+            let consumed = op.len();
+            let rest = &input[consumed..];
+            if word_like(op) && !chain_ok(rest) {
+                continue;
+            }
+            if best
+                .as_ref()
+                .is_none_or(|(_, best_len)| consumed > *best_len)
+            {
+                best = Some(((*name).clone(), consumed));
             }
         }
         best

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -33,6 +33,25 @@ impl Interpreter {
             }
             return Err(RuntimeError::emit_signal(target));
         }
+        // `Mu.ACCEPTS`: every value can be smart-matched against, and `$x.ACCEPTS($y)` is
+        // just `$y ~~ $x`. The builtins carry their own ACCEPTS for the container types
+        // (Range, Set, Bag, Pair, ...) and a user class may define one, so this only backs
+        // the plain scalars, which otherwise threw X::Method::NotFound.
+        if method == "ACCEPTS"
+            && args.len() == 1
+            && matches!(
+                target.view(),
+                ValueView::Int(_)
+                    | ValueView::Num(_)
+                    | ValueView::Rat(..)
+                    | ValueView::Complex(..)
+                    | ValueView::Str(_)
+                    | ValueView::Bool(_)
+            )
+        {
+            let matched = self.smart_match(&args[0], &target);
+            return Ok(Value::truth(matched));
+        }
         // `.self` ignores any arguments (e.g. the fake-infix adverbs on
         // `$x .= self :42moews`); it always returns the invocant.
         if method == "self" && !args.is_empty() {

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -11,6 +11,40 @@ impl Interpreter {
         args: Vec<Value>,
     ) -> Option<Result<Value, RuntimeError>> {
         match method {
+            // `Range.new($min, $max)`, with the `:excludes-min` / `:excludes-max` adverbs.
+            // The same range `$min..$max` builds, just spelled as a constructor.
+            "new" if matches!(target.view(), ValueView::Package(name) if name == "Range") => {
+                let adverb = |key: &str| {
+                    args.iter().any(|a| match a.view() {
+                        ValueView::Pair(k, v) => k == key && v.truthy(),
+                        ValueView::ValuePair(k, v) => k.to_string_value() == key && v.truthy(),
+                        _ => false,
+                    })
+                };
+                let positional: Vec<Value> = args
+                    .iter()
+                    .filter(|a| !matches!(a.view(), ValueView::Pair(..) | ValueView::ValuePair(..)))
+                    .cloned()
+                    .collect();
+                if positional.len() != 2 {
+                    return Some(Err(RuntimeError::new(
+                        "Range.new requires a minimum and a maximum".to_string(),
+                    )));
+                }
+                let (excl_min, excl_max) = (adverb("excludes-min"), adverb("excludes-max"));
+                if !excl_min && !excl_max {
+                    return Some(Ok(Self::make_inclusive_range_value(
+                        positional[0].clone(),
+                        positional[1].clone(),
+                    )));
+                }
+                Some(Ok(Value::generic_range(
+                    positional[0].clone(),
+                    positional[1].clone(),
+                    excl_min,
+                    excl_max,
+                )))
+            }
             "new" if matches!(target.view(), ValueView::Package(name) if name == "IO::ArgFiles") => {
                 // IO::ArgFiles.new(@files): an $*ARGFILES-like handle that reads
                 // from an explicit file list rather than the global @*ARGS.

--- a/t/user-op-precedence.t
+++ b/t/user-op-precedence.t
@@ -1,0 +1,39 @@
+use Test;
+
+plan 10;
+
+# A user-defined postfix with a precedence trait binds to the term it follows. The postfix
+# loop used to skip *every* precedence-annotated postfix, on the theory that a prefix would
+# pick it up later -- but nothing picks it up after a plain term, so `4.7k` was a parse error.
+sub postfix:<k> ($a) is tighter(&infix:<*>) { $a * 1000 }
+
+is 4.7k, 4700, 'a postfix with a precedence trait applies to a plain term';
+is 2 * 3k, 6000, 'tighter(&infix:<*>) binds before the multiplication';
+
+# A postfix declared looser than another postfix still chains left to right, even when both
+# are alphabetic: `4kV` is postfix:<V>(postfix:<k>(4)).
+sub postfix:<V> ($a) is looser(&postfix:<k>) { "V" ~ $a }
+is 4kV, 'V4000', 'two alphabetic postfixes chain';
+
+# `is looser(&postfix:<k>)` is relative to k's *registered* level, not to the default
+# prefix level it would have had without its trait.
+sub postfix:<W> ($a) is looser(&postfix:<V>) { "W" ~ $a }
+is 4kVW, 'WV4000', 'a chain of three postfixes at descending levels';
+
+# A postfix declared looser than a *prefix* still waits for the prefix to build its call.
+sub prefix:<D> (Int $x) { 2 * $x }
+sub postfix:<P> (Int $x) is looser(&prefix:<D>) { 1 + $x }
+sub postfix:<Q> (Int $x) is tighter(&prefix:<D>) { 1 + $x }
+is (D 3P), 7, 'a postfix looser than a prefix applies to the whole prefix call';
+is (D 3Q), 8, 'a postfix tighter than a prefix applies to the prefix operand';
+
+# `Mu.ACCEPTS`: `$x.ACCEPTS($y)` is the smartmatch `$y ~~ $x`. Plain scalars used to throw
+# X::Method::NotFound.
+ok 4000.ACCEPTS(4000.0), 'a numeric ACCEPTS smart-matches its argument';
+nok 4000.ACCEPTS(5), 'a numeric ACCEPTS rejects a non-match';
+ok 'a'.ACCEPTS('a'), 'a string ACCEPTS smart-matches its argument';
+
+# `Range.new` builds the same range as `..`, adverbs included.
+is-deeply (Range.new(1, 5), Range.new(1, 5, :excludes-max), Range.new(3700/1, 5700/1)).map(*.gist).List,
+    ('1..5', '1..^5', '3700.0..5700.0'),
+    'Range.new builds a range, with excludes-min/max';


### PR DESCRIPTION
The last file in `TODO_roast/BLOCKERS.md` §"② パース不能（===SORRY!===）" — `roast/integration/advent2012-day19.t` — needed a user-defined postfix to actually honour its precedence trait. Five bugs.

- **A precedence-annotated postfix was never applied to a plain term.** The postfix loop skipped every postfix whose registered level was below `PREC_PREFIX`, on the theory that the prefix layer would pick it up — but that pickup loop lives *inside* the user-defined-prefix branch, so after a bare term like `4.7` nothing consumed it and `4.7k` was a parse error. The skip now applies only while we are genuinely parsing the operand of a user prefix the postfix is looser than, which is the case it was written for (`'foo1'3'bar1'` in `S06-traits/precedence.t`, still passing).

- **`is looser(&postfix:<k>)` resolved against `PREC_PREFIX`** rather than k's *registered* level, so a trait relative to a trait-carrying operator landed at the wrong place.

- **Two alphabetic postfixes could not chain.** The word-boundary rule rejected `k` in `4kV` because a letter followed. A following *declared* postfix is a boundary too; the check now peels the whole chain (`4kVW`), while `4.7keys` still stays one identifier.

- **`Mu.ACCEPTS` did not exist for plain scalars** — `4000.ACCEPTS(4000.0)` threw `X::Method::NotFound`. It is just the smartmatch `$y ~~ $x`.

- **`Range.new($min, $max)` was not implemented** (with `:excludes-min` / `:excludes-max`).

## Result

`advent2012-day19.t` passes in full and is whitelisted (1391 → 1392).

**With it, BLOCKERS.md cluster ② is closed.** All ten files that failed to parse are handled: seven reached the whitelist (`advent2010-day11`, `advent2013-day04`, `advent2014-day16`, `advent2009-day16`, `advent2009-day23`, `advent2012-day04`, `advent2012-day19`) and three now parse and run, having become feature gaps recorded in BLOCKERS.md (`advent2012-day15` 9/11, `bug-coverage` 12/17, `A04-experimental/01-misc` 16/19 — it did not compile at all before).

New test: `t/user-op-precedence.t`. `make test` is green; `S06-traits/precedence.t` and the operator/range/smartmatch-heavy whitelisted roast files were re-run individually with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tFv8btbbJZpJT6G2vCS2i