### PR TITLE
fix(vm): capture &-sigiled code variables as closure free variables (man-or-boy)

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -50,7 +50,7 @@ S\* 系 24 本しか載せておらず、`integration/` 41 本・`6.c/` 7 本・
 
 | 根本原因クラスタ | 本数 | 該当ファイル（抜粋） | 症状 |
 |---|---|---|---|
-| **① スタックオーバーフローで abort**（★同じ症状で原因は 4 つ別々 — 下節参照） | **残 1** | **残: `man-or-boy.t`**。`99problems-41-to-50.t`(#4510)・`99problems-51-to-60.t`(#4516) は無限再帰で修正済み、`deep-recursion-initing-native-array.t` は debug 計測の誤診（release では元から通る）＝whitelist 追加 | `fatal runtime error: stack overflow, aborting`（プロセス abort）。**4 本のうち 3 本は無限再帰、1 本は計測ミス。「本当に深い再帰でスタックが足りない」ものは 1 本も無かった** |
+| **① スタックオーバーフローで abort**（★同じ症状で原因は 4 つ別々 — 下節参照） | **完了** | `99problems-41-to-50.t`(#4510)・`99problems-51-to-60.t`(#4516)・`man-or-boy.t`（`&`-シジル free var スキャン + vouch — 下節）は無限再帰で修正済み、`deep-recursion-initing-native-array.t` は debug 計測の誤診（release では元から通る）＝whitelist 追加 | `fatal runtime error: stack overflow, aborting`（プロセス abort）。**4 本のうち 3 本は無限再帰、1 本は計測ミス。「本当に深い再帰でスタックが足りない」ものは 1 本も無かった** |
 | **② パース不能（`===SORRY!===`）** | **0（完了）** | 10 本すべて解消（#4511 / #4514 / #4515 / #4517 / #4518 / #4522） | **このクラスタは枯渇。** 7 本が whitelist 到達、3 本はパースを通過して機能ギャップへ移行 — 下の「② の内訳」参照 |
 | **③ ハング / タイムアウト** | 5 | `advent2012-day21.t`・`advent2013-day14.t`・`gather-with-loops.t`・`APPENDICES/A01-limits/{misc,overflow}.t` | 25s で打ち切り。gather×loop の遅延評価と limit 系 |
 | **④ エラーメッセージ品質** | 2 | `error-reporting.t`（mutsu 4/33・raku 33/33）・`weird-errors.t`（26/36） | 「Parse error contains line number」等、**例外の文面・行番号・バックトレース**を検査するテスト。PLAN §6「エラーメッセージ品質向上」と同一の的 |
@@ -67,7 +67,7 @@ test 57 `OUTER::<$x>` 疑似パッケージ）。`advent2011-day04.t` は 1/2、
 |---|---|---|
 | `99problems-41-to-50.t` | **無限再帰**。クロージャのフレーム env が *caller* の env の scoped child で、捕捉 env を「既にあれば入れない」でマージしていたため、caller の同名レキシカルが callee 自身の捕捉を shadow する（＝レキシカルスコープが動的スコープに化ける）。P46 のアクションは節ごとに `my @args` を持つクロージャを作るので、内側の節が外側の `@args`（自分自身を含む）を読み自己再帰した | **#4510 で修正**。P41・P46 通過。以降は P47 の パラメータ化 `multi rule expr($p)` 待ち（⑤へ） |
 | `99problems-51-to-60.t` | **無限再帰**（P57）。`CallMethodMut` が名前付きレシーバへのメソッド呼び出しのたびに `locals[slot] = env[name]` を無条件実行していたが、callee の env は「flat 化した caller + 自分の書き込み」で、**パラメータはスロットにしか無い**。よってレシーバが変わっていないとき caller の同名変数が callee のパラメータを上書きし、自己再帰 `add-to-tree($tree[1], …)` の `$tree` が呼び出し側のノードに巻き戻って葉に到達しなかった | **#4516 で修正**（rebind したときだけ書き戻す）。37 テスト完走。残 fail = test 8（平衡二分木の枝落ち）・test 21 |
-| `man-or-boy.t` | **無限再帰**。#4510 と同じ「呼び出し側フレームの同名レキシカルがクロージャ自身の捕捉を shadow する」バグの残り。ただし今回 shadow されるのは **`&x1..&x5`（A の `&`-シジル・パラメータ）**で、`authoritative_free_vars` に入っていないため上書き install されない。詳細は下記 | 未解決。`#4510` の権威判定を `&` コード変数まで届かせる必要がある |
+| `man-or-boy.t` | **無限再帰**。#4510 と同じ「呼び出し側フレームの同名レキシカルがクロージャ自身の捕捉を shadow する」バグの残り。ただし今回 shadow されるのは **`&x1..&x5`（A の `&`-シジル・パラメータ）**で、`authoritative_free_vars` に入っていないため上書き install されない。詳細は下記 | **修正済み・whitelist 追加**（10/10）。(a) `GetCodeVar`/`CallOnCodeVar` を free var スキャンに追加（定数はシジル無し `"x1"`・レキシカルは `&x1` なので `&` を付けて記録）、(b) rw-arg sink 除外（`own_call_arg_sources`）から `&` 名を免除（raku は `&` パラメータへの `is rw` を拒否するので rebind 経路が無い） |
 | `deep-recursion-initing-native-array.t` | **バグではなかった。** 約 20,000 段のネストが要るのは本当だが、**release では元から通る**（7 秒・3/3 安定）。この表の初回計測が **debug ビルド**だったせいで overflow に見えていただけ（debug は 1 フレームあたりのネイティブスタックが数倍。release の限界は 20k–40k 段で、必要な 20k はぎりぎり収まる） | **whitelist 追加**。スタック拡張も上限ガードも不要だった |
 
 教訓: **abort の形（`stack overflow`）は原因を意味しない。** 深さを数えて raku と突き合わせ、
@@ -116,10 +116,28 @@ A#6 は「A#1 の B が **A#5 の中から** 発火した」もの。B の本体
 これは #4510 で直した shadowing と同一のバグ。#4510 は「creator が捕捉後に変更しない
 plain lexical」だけを上書き install する（`CompiledCode::authoritative_free_vars`）が、
 `&x1..&x5` はそこに入っていないため don't-overwrite に落ち、呼び出し元の同名パラメータに
-負ける。`own_call_arg_sources`（`x4(&x1, …)` に渡すので除外）を `&` シジルだけ免除する実験は
-**効かなかった** ので、`&`-シジル・コード変数が free var / locals としてどのキー
-（`&x1` か `x1` か）で扱われているかを先に確認すること — `CallOnCodeVar { name_idx }` は
-シジル無しの名前を持つ疑いがある。
+負ける。
+
+**解決（2026-07-15）**: 原因は 2 段重ねで、両方を直す必要があった（片方だけの実験が
+「効かなかった」のはこのため）:
+
+1. **free var スキャン漏れ**: `&x1` の読みは `GetCodeVar`/`CallOnCodeVar` で行われ、定数は
+   シジル無しの `"x1"`。`op_name_const_idx`（GetGlobal 系）に含まれないため `free_var_syms` に
+   一切入らず、capture フィルタ（`&x1` は plain user lexical なのでシステム名ルールでも
+   残らない）が落として **捕捉すらされていなかった**＝純粋な動的スコープで解決されていた。
+   → スキャンに `&` を付けた `&x1` キーで記録する。
+2. **rw-arg sink 除外**: A は `x4($k, &x1, …)` と `&x1..&x5` を引数として転送するので
+   `own_call_arg_sources` が vouch を却下していた。だが **raku は `&`-シジル・パラメータへの
+   `is rw` を拒否する**（"Can only use 'is rw' on a scalar ('$' sigil) parameter"）ので、
+   `&` 引数が callee から rebind される経路はスペック上存在しない → `&` 名を免除。
+   （`is raw` での rebind は理論上残るが既知ギャップとして許容。直接の `&f = …` rebind は
+   name-write なので従来どおり捕捉される。）
+
+**残ギャップ（roast 上の既知 fail なし）**: ベアコール `x()` は `CallFunc { name_idx }` で
+callee 名としてしか現れず free var スキャン対象外のまま。`sub mk(&x) { sub { x() } }` の
+クロージャを同名 `&x` を持つ別フレームから呼ぶと今も動的スコープに落ちる（`&x.()` や
+引数転送 `f(&x)` は修正済み）。CallFunc 名の全登録は `&say` 等の bloat になるため、
+やるなら「creator の fold 時に `own` の `&name` と突き合わせる」設計が要る。
 
 ### ② の内訳（クラスタ完了・#4511 / #4514 / #4515 / #4517 / #4518 / #4522）
 
@@ -196,8 +214,9 @@ postfix** が、項に対して一切適用されない（`4.7k` が SORRY）。
 
 ## 今のおすすめ着手順
 
-1. **① の残り 1 本 = `man-or-boy.t`**（下記「man-or-boy の診断」に正確な根本原因あり）。
-   **スタック拡張の機構は不要だった**（上の内訳表を参照）。
+1. ~~**① の残り 1 本 = `man-or-boy.t`**~~ **完了**（2026-07-15・whitelist 追加。
+   「man-or-boy の診断」節の解決記録を参照）。①クラスタは全消化。
+   ②パース不能クラスタも #4522 で全消化（上の表参照）。
 3. **近道**: `6.c/S04-declarations/my-6c.t` は `OUTER::<$x>` の 1 subtest だけ
    （111/112）。`advent2011-day04.t` は 1/2。
 4. **④ エラーメッセージ品質**（`error-reporting.t` 4/33）は PLAN §6 の同名タスクと同じ的なので、

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1376,6 +1376,7 @@ roast/integration/failure-and-callsame.t
 roast/integration/lazy-bentley-generator.t
 roast/integration/lexical-array-in-inner-block.t
 roast/integration/lexicals-and-attributes.t
+roast/integration/man-or-boy.t
 roast/integration/method-calls-and-instantiation.t
 roast/integration/no-indirect-new.t
 roast/integration/packages.t

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2586,6 +2586,18 @@ impl CompiledCode {
         }
     }
 
+    /// The constant-pool index of a code-variable read (`&f` as a value, or a
+    /// call through a code variable, `&f.()`). The constant holds the SIGIL-LESS
+    /// name (`"f"`), but the lexical itself lives under `&f` in `locals`/`env`,
+    /// so the free-var scan must re-key it with the sigil before matching.
+    fn op_code_var_read_const_idx(op: &OpCode) -> Option<u32> {
+        match op {
+            OpCode::GetCodeVar(idx) => Some(*idx),
+            OpCode::CallOnCodeVar { name_idx, .. } => Some(*name_idx),
+            _ => None,
+        }
+    }
+
     /// The `closure_compiled_codes` index an op embeds, for the ops that create a
     /// closure value (and so snapshot the creating frame's env at that point).
     fn op_closure_code_idx(op: &OpCode) -> Option<u32> {
@@ -2645,6 +2657,28 @@ impl CompiledCode {
             {
                 free.insert(Symbol::intern(&name));
             }
+            // A code-variable read (`&x1` as a value, `&x1.()`): the op's constant
+            // is the sigil-less name, but the lexical lives under `&x1`. Without
+            // this, a closure that captures a `&`-sigiled parameter never records
+            // it as a free variable — `&x1` is a plain user lexical, so the
+            // capture filter drops it and every read silently resolves through the
+            // CALLING frame's env instead (lexical scoping degrading into dynamic
+            // scoping). The closure looks right while it fires from its creator's
+            // own frame — the chains agree — and breaks the first time a sibling
+            // frame with same-named parameters invokes it (roast
+            // integration/man-or-boy.t). Non-lexical forms (`&!attr`, `&?ROUTINE`,
+            // `&*dyn`, package-qualified and operator names) keep resolving
+            // against the live env by design.
+            if let Some(idx) = Self::op_code_var_read_const_idx(op)
+                && let Some(ValueView::Str(name)) =
+                    self.constants.get(idx as usize).map(Value::view)
+                && !name.contains(':')
+            {
+                let key = format!("&{}", name.as_str());
+                if crate::env::is_plain_user_lexical(&key) && !own.contains(key.as_str()) {
+                    free.insert(Symbol::intern(&key));
+                }
+            }
             // Own locals reaching a call as arguments: an `is rw` parameter can
             // write straight back into them without any name-write op here.
             if let Some(idx) = Self::op_arg_sources_idx(op)
@@ -2658,8 +2692,19 @@ impl CompiledCode {
                         ValueView::Pair(k, _) => Some(k.to_string()),
                         _ => None,
                     };
+                    // `&`-sigiled arguments are exempt from the rw-arg-sink rule:
+                    // Raku rejects `is rw` on a non-scalar parameter ("Can only
+                    // use 'is rw' on a scalar ('$' sigil) parameter"), so a code
+                    // variable handed to a call cannot be rebound through one.
+                    // Without the exemption, a routine that both captures its
+                    // `&`-params in a closure and forwards them to calls (the
+                    // man-or-boy `A`) could never vouch for them. A direct
+                    // `&f = ...` rebind is a name-write and is still caught; an
+                    // `is raw` param rebinding a passed `&`-arg remains a known
+                    // gap of this analysis.
                     if let Some(name) = name
                         && own.contains(name.as_str())
+                        && !name.starts_with('&')
                     {
                         own_call_arg_sources.insert(Symbol::intern(&name));
                     }

--- a/t/closure-free-var-scope.t
+++ b/t/closure-free-var-scope.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 14;
+plan 17;
 
 # A closure's free variables are bound in the scope where the closure was
 # *created*. When one closure calls another, the callee must read its own
@@ -120,6 +120,45 @@ plan 14;
         is ($bump(), $bump(), $a).join(','), '3,4,-10',
             'inner redeclaration does not write through the captured cell';
     }
+}
+
+# `&`-sigiled code parameters are lexicals too: a closure that forwards them
+# must read its OWN captured bindings, not same-named `&`-params in whichever
+# frame happens to invoke it. This is the man-or-boy shape: A#1's inner closure
+# fires from a deeper A frame whose &x-params are different subs
+# (roast integration/man-or-boy.t).
+{
+    sub trap(&cb, &x) { cb() }              # a frame with its own &x
+    sub mk(&x) { return sub { &x.() } }     # closure capturing the creator's &x
+    my $c = mk(sub { 'MINE' });
+    is trap($c, sub { 'CALLERS' }), 'MINE',
+        'closure reads its own captured &x, not the calling frame\'s';
+}
+
+{
+    # ... including when the &-param is only ever *forwarded as an argument*
+    # (the man-or-boy `A(--$k, $B, &x1, ...)` shape). Forwarding must not
+    # disqualify the capture: `is rw` is illegal on a `&`-parameter, so the
+    # callee cannot rebind it behind the analysis's back.
+    sub apply(&f, $v) { f($v) }
+    sub trap2(&cb, &x) { cb() }
+    sub mk2(&x) { return sub { apply(&x, 5) } }
+    my $c = mk2(sub ($n) { $n * 2 });
+    is trap2($c, sub ($n) { $n * 1000 }), 10,
+        'a forwarded &-param still resolves in the closure\'s own scope';
+}
+
+{
+    # The man-or-boy divergence in miniature: the k<=0 branch fires x1 from a
+    # frame whose own &x1 is a different sub.
+    sub A($k is copy, &x1) {
+        my $B;
+        $B = sub (*@) { A(--$k, &x1) };
+        if ($k <= 0) { return x1($k) }
+        return $B();
+    }
+    is A(2, sub (*@) { 'ORIG' }), 'ORIG',
+        'man-or-boy shape: &x1 resolves to the creating frame\'s sub';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
## Summary

Fixes the last remaining file of BLOCKERS cluster (1): `roast/integration/man-or-boy.t` now passes 10/10 and is whitelisted.

A closure that reads a `&`-sigiled lexical (`&x1` as a value, or `&x1.()`) never recorded it as a free variable: the read compiles to `GetCodeVar`/`CallOnCodeVar`, whose name constant is the sigil-less form (`"x1"`), and neither op was in the free-var scan. Since `&x1` is a plain user lexical, the capture filter dropped it too — the closure did not capture it at all, and every read resolved through the **calling** frame's env chain (lexical scoping degrading into dynamic scoping). It looks correct while the closure fires from its creator's own frame and breaks the first time a sibling frame with same-named parameters invokes it — exactly the man-or-boy shape, where the divergence turned Knuth's recursion into an infinite one that aborted with a Rust stack overflow.

Two coupled fixes (per #4520's diagnosis, either alone does not work):

1. **Scan `GetCodeVar`/`CallOnCodeVar` in `compute_free_vars`**, re-keying the sigil-less constant as `&name` to match the locals/env convention. Non-lexical forms (`&!attr`, `&?ROUTINE`, `&*dyn`, package-qualified/operator names) stay excluded.
2. **Exempt `&`-sigiled names from the rw-arg-sink veto** (`own_call_arg_sources`): Raku rejects `is rw` on a non-scalar parameter, so a code variable forwarded as an argument cannot be rebound through the call. Without this, man-or-boy's `A` — which both captures its `&`-params and forwards them to `x4`/`x5` — could never vouch for them and the #4510 authoritative overwrite never applied. A direct `&f = ...` rebind is a name-write and is still caught; `is raw` rebinding remains a documented gap.

Known residual (no failing roast test): a bare call `x()` reaches the callee name only through `CallFunc`, which is deliberately not scanned (it would register `&say` etc. on every closure); `&x.()` and `f(&x)` forms are covered. Recorded in TODO_roast/BLOCKERS.md along with the full resolution notes.

## Testing

- `roast/integration/man-or-boy.t`: 10/10 via `MUTSU_FUDGE=1 prove` — whitelisted
- `t/closure-free-var-scope.t` extended 14 → 17 (all 17 validated against `raku`)
- `make test` clean (1701 files / 16761 tests)
- 254-file whitelist subset (S04/S06/integration): clean apart from two debug-build artifacts (`catch.t` passes solo, `deep-recursion-initing-native-array.t` is the known #4519 debug case)
- `roast/S17-lowlevel/cas.t`, `cas-int.t` (the rw-arg-sink rule's motivating tests) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMcTn8pCmYdeJKDi6KNzcw