### PR TITLE
fix(vm): capture bare-call code-var reads and keep vouched captures authoritative at depth

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -133,11 +133,21 @@ plain lexical」だけを上書き install する（`CompiledCode::authoritative
    （`is raw` での rebind は理論上残るが既知ギャップとして許容。直接の `&f = …` rebind は
    name-write なので従来どおり捕捉される。）
 
-**残ギャップ（roast 上の既知 fail なし）**: ベアコール `x()` は `CallFunc { name_idx }` で
-callee 名としてしか現れず free var スキャン対象外のまま。`sub mk(&x) { sub { x() } }` の
-クロージャを同名 `&x` を持つ別フレームから呼ぶと今も動的スコープに落ちる（`&x.()` や
-引数転送 `f(&x)` は修正済み）。CallFunc 名の全登録は `&say` 等の bloat になるため、
-やるなら「creator の fold 時に `own` の `&name` と突き合わせる」設計が要る。
+**残ギャップも解消（同 PR の追いコミット）**:
+
+- **ベアコール `x()`**: `CallFunc`/`ExecCall` 系は callee 名としてしか読みを記録しないため
+  free var スキャン対象外だった。全 callee 名の登録は `&say` 等で `free_var_syms` が bloat
+  する（クロージャ呼び出しごとの `free_at_entry` lookup 代）ので、**定義点で見えている
+  enclosing `&`-シジル・レキシカルの集合**（`CompiledCode::outer_code_var_names`、
+  `compile_closure_body`/`compile_sub_body` が親の `local_map` から transitively に伝搬）に
+  一致する callee 名だけを `&name` free var として記録する。ゼロ bloat・レキシカルに正確。
+- **多段ネストの authority 消失**（scalar でも同じだった pre-existing バグ）: vouch は
+  「creator 直下の子」にしか焼かれず、`sub mk($x) { my $mid = sub { sub { $x } }; $mid.() }`
+  の内側クロージャは中間フレームが vouch できない（`$x` は中間の local でない）ため、
+  呼び出し側の同名レキシカルに再び shadow された。vouch は「サブツリー全体が書かない」
+  ことを既に保証している（nested の free-var write は creator まで fold される）ので、
+  **中間クロージャが同名を再宣言しない限り authority を子孫へ伝搬**して解決
+  （`propagate_authoritative_down`）。
 
 ### ② の内訳（クラスタ完了・#4511 / #4514 / #4515 / #4517 / #4518 / #4522）
 

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -43,6 +43,22 @@ impl Compiler {
             .collect()
     }
 
+    /// Thread the `&`-sigiled lexicals visible at this point (own `&` locals —
+    /// params like `&x1`, `my &f` — plus everything inherited from enclosing
+    /// scopes) down to a child sub/closure compiler. `compute_free_vars` uses
+    /// the set to recognise a bare call `x1(...)` as a read of the lexical
+    /// `&x1` that the child must capture (see
+    /// `CompiledCode::outer_code_var_names`).
+    pub(super) fn inherit_outer_code_var_names(&self, child: &mut Compiler) {
+        child.code.outer_code_var_names = self
+            .local_map
+            .keys()
+            .filter(|k| k.starts_with('&'))
+            .cloned()
+            .chain(self.code.outer_code_var_names.iter().cloned())
+            .collect();
+    }
+
     /// Compile a SubDecl body to a CompiledFunction and store it.
     #[allow(clippy::too_many_arguments)]
     pub(super) fn compile_sub_body(
@@ -99,6 +115,7 @@ impl Compiler {
             .unwrap_or(false);
         let mut sub_compiler = Compiler::new();
         self.inherit_fold_ctx(&mut sub_compiler);
+        self.inherit_outer_code_var_names(&mut sub_compiler);
         sub_compiler.is_routine = true;
         sub_compiler.lexically_in_routine = true;
         // A method body carries the synthetic `?CLASS` parameter injected by the
@@ -592,6 +609,7 @@ impl Compiler {
     ) -> CompiledCode {
         let mut sub_compiler = Compiler::new();
         self.inherit_fold_ctx(&mut sub_compiler);
+        self.inherit_outer_code_var_names(&mut sub_compiler);
         sub_compiler.is_routine = is_routine;
         // Make the names of all constants visible at this closure's definition
         // point known to the child compiler, so a `constant X` inside the body

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1819,6 +1819,18 @@ pub(crate) struct CompiledCode {
     /// this very declaration's initializer, so clearing it orphans the closure's
     /// capture and `$f` reads back as `Any`.
     pub(crate) self_capture_decl_locals: Vec<Symbol>,
+    /// `&`-sigiled lexicals (params like `&x1`, `my &f = ...`) visible in the
+    /// ENCLOSING scopes at this closure's definition point, threaded down by
+    /// `compile_closure_body` (transitively, so a grandchild still sees an
+    /// ancestor's `&`-param). A bare call `x1(...)` records the callee only as a
+    /// call opcode's name constant — there is no separate read op — yet at
+    /// runtime it resolves against the lexical `&x1` before the global function
+    /// registry. `compute_free_vars` uses this set to decide which callee names
+    /// are really code-variable reads that must be captured: registering EVERY
+    /// called name would bloat `free_var_syms` with `&say` etc. on every closure
+    /// (a per-call `free_at_entry` cost), so only names matching a declared
+    /// `&`-lexical count.
+    pub(crate) outer_code_var_names: std::collections::HashSet<String>,
     /// Free variables (names NOT in this code's own locals) that must become a
     /// shared `ContainerRef` cell in whichever *ancestor* frame declares them,
     /// because they are captured-and-mutated by an ESCAPING closure somewhere in
@@ -2006,6 +2018,7 @@ impl CompiledCode {
             needs_cell_locals: Vec::new(),
             authoritative_free_vars: Vec::new(),
             self_capture_decl_locals: Vec::new(),
+            outer_code_var_names: std::collections::HashSet::new(),
             needs_cell_free_vars: Vec::new(),
             has_calls: false,
             captures_env_by_name: false,
@@ -2598,6 +2611,21 @@ impl CompiledCode {
         }
     }
 
+    /// The constant-pool index of a bare call's CALLEE name (`f(...)` in
+    /// expression or statement position). At runtime the callee resolves against
+    /// the lexical `&f` before the global function registry, so when an
+    /// enclosing scope declares `&f` (see `outer_code_var_names`) the call is
+    /// really a code-variable read this closure must capture.
+    fn op_callee_name_const_idx(op: &OpCode) -> Option<u32> {
+        match op {
+            OpCode::CallFunc { name_idx, .. }
+            | OpCode::CallFuncSlip { name_idx, .. }
+            | OpCode::ExecCall { name_idx, .. }
+            | OpCode::ExecCallSlip { name_idx, .. } => Some(*name_idx),
+            _ => None,
+        }
+    }
+
     /// The `closure_compiled_codes` index an op embeds, for the ops that create a
     /// closure value (and so snapshot the creating frame's env at that point).
     fn op_closure_code_idx(op: &OpCode) -> Option<u32> {
@@ -2676,6 +2704,22 @@ impl CompiledCode {
             {
                 let key = format!("&{}", name.as_str());
                 if crate::env::is_plain_user_lexical(&key) && !own.contains(key.as_str()) {
+                    free.insert(Symbol::intern(&key));
+                }
+            }
+            // A bare call `x1(...)` records the read of `&x1` only as the call
+            // opcode's callee name. Registering every called name would bloat
+            // `free_var_syms` with `&say` etc. on every closure, so only callees
+            // matching a `&`-sigiled lexical declared in an enclosing scope
+            // (`outer_code_var_names`, threaded down at compile time) count as
+            // code-variable reads.
+            if !self.outer_code_var_names.is_empty()
+                && let Some(idx) = Self::op_callee_name_const_idx(op)
+                && let Some(ValueView::Str(name)) =
+                    self.constants.get(idx as usize).map(Value::view)
+            {
+                let key = format!("&{}", name.as_str());
+                if self.outer_code_var_names.contains(&key) && !own.contains(key.as_str()) {
                     free.insert(Symbol::intern(&key));
                 }
             }
@@ -3046,7 +3090,48 @@ impl CompiledCode {
             if authoritative.is_empty() && nested.authoritative_free_vars.is_empty() {
                 continue;
             }
-            Arc::make_mut(nested).authoritative_free_vars = authoritative;
+            let nested_mut = Arc::make_mut(nested);
+            nested_mut.authoritative_free_vars = authoritative;
+            // Transitive vouching: a vouched capture stays authoritative
+            // arbitrarily deep in this closure's subtree, as long as no
+            // intermediate closure redeclares the name. The vouch already
+            // guarantees the ENTIRE subtree never writes the name (nested
+            // free-var writes fold into `captured_mutated` here, at the
+            // declaring frame), so a grandchild's snapshot — taken from its own
+            // creator's frame, where this same vouched value was installed —
+            // cannot go stale either. Without this, a closure created inside
+            // another closure's frame lost its authority the moment it escaped:
+            // the middle frame cannot vouch (the name is not ITS local), so a
+            // same-named lexical in the eventual calling frame shadowed the
+            // capture again — the exact #4510 bug, one level deeper.
+            let names = nested_mut.authoritative_free_vars.clone();
+            for child in nested_mut.closure_compiled_codes.iter_mut() {
+                Self::propagate_authoritative_down(child, &names);
+            }
+        }
+    }
+
+    /// Append `names` to the authoritative set of `cc` (when it captures them)
+    /// and recurse into its closure subtree, stopping at any level that
+    /// redeclares a name — from there down the name is a different binding.
+    /// See the transitive-vouching comment in `compute_free_vars`.
+    fn propagate_authoritative_down(cc: &mut std::sync::Arc<CompiledCode>, names: &[Symbol]) {
+        let live: Vec<Symbol> = names
+            .iter()
+            .filter(|sym| sym.with_str(|s| !cc.locals.iter().any(|l| l == s)))
+            .copied()
+            .collect();
+        if live.is_empty() {
+            return;
+        }
+        let cc_mut = Arc::make_mut(cc);
+        for sym in &live {
+            if cc_mut.free_var_syms.contains(sym) && !cc_mut.authoritative_free_vars.contains(sym) {
+                cc_mut.authoritative_free_vars.push(*sym);
+            }
+        }
+        for child in cc_mut.closure_compiled_codes.iter_mut() {
+            Self::propagate_authoritative_down(child, &live);
         }
     }
 

--- a/t/closure-free-var-scope.t
+++ b/t/closure-free-var-scope.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 17;
+plan 22;
 
 # A closure's free variables are bound in the scope where the closure was
 # *created*. When one closure calls another, the callee must read its own
@@ -159,6 +159,51 @@ plan 17;
     }
     is A(2, sub (*@) { 'ORIG' }), 'ORIG',
         'man-or-boy shape: &x1 resolves to the creating frame\'s sub';
+}
+
+{
+    # A BARE call `x()` reaches the callee name only through the call opcode
+    # (there is no separate read op), and must still capture the creator's &x.
+    sub trap-b(&cb, &x) { cb() }
+    sub mk-b(&x) { return sub { x() } }
+    my $c = mk-b(sub { 'BARE-MINE' });
+    is trap-b($c, sub { 'BARE-CALLERS' }), 'BARE-MINE',
+        'a bare call x() captures the creating frame\'s &x';
+}
+
+{
+    # ... in statement position too (a different call opcode).
+    sub trap-s(&cb, &x) { cb() }
+    sub mk-s(&x) { return sub { x(); 'done' } }
+    my $c = mk-s(sub { 'ignored' });
+    is trap-s($c, sub { die 'read the wrong &x' }), 'done',
+        'a statement-position bare call resolves in the closure\'s own scope';
+}
+
+# A vouched capture must stay authoritative arbitrarily deep: a closure created
+# inside ANOTHER closure's frame captures the same never-mutated binding, and a
+# same-named lexical in whatever frame finally calls it must not shadow it.
+{
+    sub trap-d(&cb, $x) { cb() }
+    sub mk-d($x) { my $mid = sub { sub { $x } }; return $mid.() }
+    is trap-d(mk-d('DEEP-MINE'), 'DEEP-CALLERS'), 'DEEP-MINE',
+        'a two-level-deep scalar capture survives a shadowing caller frame';
+}
+
+{
+    sub trap-e(&cb, &x) { cb() }
+    sub mk-e(&x) { my $mid = sub { sub { x() } }; return $mid.() }
+    is trap-e(mk-e(sub { 'DEEP-AMP-MINE' }), sub { 'DEEP-AMP-CALLERS' }),
+        'DEEP-AMP-MINE',
+        'a two-level-deep &-capture (bare call) survives a shadowing caller frame';
+}
+
+{
+    # A closure's own `my &x` shadows an outer &-param for its bare calls.
+    sub trap-o(&cb, &x) { cb() }
+    sub mk-o(&x) { return sub { my &x = sub { 'LOCAL' }; x() } }
+    is trap-o(mk-o(sub { 'OUTER' }), sub { 'CALLER' }), 'LOCAL',
+        'an own my &x shadows the captured outer one for bare calls';
 }
 
 # vim: expandtab shiftwidth=4


### PR DESCRIPTION
## Summary

Two follow-ups to #4523, closing the residual gaps it documented in TODO_roast/BLOCKERS.md:

### 1. Bare-call code-variable reads (`x1(...)`)

A bare call records the read of a `&`-sigiled lexical only as the call opcode's callee name (`CallFunc`/`CallFuncSlip`/`ExecCall`/`ExecCallSlip`) — there is no separate read op — so the free-var scan never saw it and the closure resolved `x1` through the **calling** frame's env (dynamic scoping), exactly like the `GetCodeVar` case #4523 fixed:

```raku
sub trap(&cb, &x) { cb() }
sub mk(&x) { return sub { x() } }
say trap(mk(sub { 'MINE' }), sub { 'CALLERS' });  # was CALLERS, now MINE (= raku)
```

Registering *every* callee name would bloat `free_var_syms` with `&say` etc. on every closure (a per-call `free_at_entry` cost), so the compiler now threads the set of `&`-sigiled lexicals visible at the closure's definition point (`CompiledCode::outer_code_var_names`, from the parent compiler's `local_map`, transitively down through nested sub/closure compilers) and `compute_free_vars` records only callee names matching that set. Zero bloat for global/builtin calls, lexically precise.

### 2. Vouched captures lost authority one closure level down (all sigils)

`authoritative_free_vars` is baked only into the creator's **direct** children, so a closure created inside another closure's frame could not be vouched by the middle frame (the name is not *its* local), and a same-named lexical in the eventual calling frame shadowed the capture again — the #4510 bug, one level deeper. This was broken for scalars too:

```raku
sub trap(&cb, $x) { cb() }
sub mk($x) { my $mid = sub { sub { $x } }; return $mid.() }
say trap(mk('S-MINE'), 'S-CALLERS');  # was S-CALLERS, now S-MINE (= raku)
```

The vouch already guarantees the **entire subtree** never writes the name (nested free-var writes fold into `captured_mutated` at the declaring frame), so a grandchild's snapshot — taken from its own creator's frame, where the same vouched value was installed — cannot go stale either. `propagate_authoritative_down` now walks the closure subtree, stopping at any level that redeclares the name (from there down it is a different binding).

## Testing

- `t/closure-free-var-scope.t` 17 → 22 (bare call, statement-position bare call, two-level scalar and `&` captures, own `my &x` shadowing); all 22 validated against `raku`
- `make test` clean (1702 files / 16779 tests)
- `roast/integration/man-or-boy.t` still 10/10
- Perf-checked the state-var-heavy `roast/S04-declarations/state.t` in debug: 46–50s vs main's 45–46s — within run-to-run noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMcTn8pCmYdeJKDi6KNzcw