### PR TITLE
fix: close the metamodel, coercion, hyper and scoping gaps behind A04-experimental

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -145,7 +145,7 @@ callee 名としてしか現れず free var スキャン対象外のまま。`su
 `qto`/`qqto` fused adverb、quote 語とデリミタ間の空白・改行、heredoc 本体の開始行、`q:to:c` の
 選択的 adverb、lazy gather Seq の多引数 `for`）／`advent2009-day16.t`・`advent2009-day23.t`（#4514:
 `when` 文修飾子、Match を RHS とする smartmatch、`(with …)`/`(given …)` の式化、`my@i` の
-空白なし宣言）／`advent2012-day04.t`（#4515 の feed 継続行・無限 closure sequence の lazy `for`、#4517 のコンマより緩い演算子の優先順位、#4518 の分解シグネチャ＋grep バインダ）／`advent2012-day19.t`（#4522）。
+空白なし宣言）／`advent2012-day04.t`（#4515 の feed 継続行・無限 closure sequence の lazy `for`、#4517 のコンマより緩い演算子の優先順位、#4518 の分解シグネチャ＋grep バインダ）／`advent2012-day19.t`（#4522）／`6.c/APPENDICES/A04-experimental/01-misc.t`（#4523: `^find_method`/`^lookup` を具体値に対して引けるように、coercion 型の暗黙ソースを `Any` に、`Date`/`DateTime` の `.IO` を型オブジェクトで例外に）。
 
 最後の 1 本 `advent2012-day19.t` は #4522 で全 10 subtest 通過。**優先順位トレイト付きユーザ定義
 演算子**（`sub postfix:<k> is tighter(&infix:<*>)`）が項に一切適用されない問題（postfix ループが
@@ -153,13 +153,12 @@ callee 名としてしか現れず free var スキャン対象外のまま。`su
 しか無かった）・英字 postfix の連鎖（`4kVW`）・`is looser(&postfix:<k>)` が k の登録レベルではなく
 `PREC_PREFIX` を基準にしていたバグ・`Mu.ACCEPTS`・`Range.new` を実装。
 
-**パースは通ったが subtest が残る（3 本）** — ②ではなく機能ギャップに移行:
+**パースは通ったが subtest が残る（2 本）** — ②ではなく機能ギャップに移行:
 
 | ファイル | 残 | ブロッカー |
 |---|---|---|
 | `integration/advent2012-day15.t` | 2/11 | phaser の文形式が独自スコープを作る（`NEXT (state $best) max= $_;` の `$best` が `LAST` から見えない）／`INIT` がメインラインより後に走る |
-| `6.c/MISC/bug-coverage.t` | 5/17 | `.count-only`/`.bool-only`、thunk のクロージャスコープ 等 |
-| `6.c/APPENDICES/A04-experimental/01-misc.t` | 3/19 | `:D`/`:U` DefiniteHow coercion（`Target:D(Source:U)`）。#4514 で 0/19 → 16/19 |
+| `6.c/MISC/bug-coverage.t` | 3/17 | **① `.count-only`/`.bool-only`（Iterator API 一式）が最大の壁**。② `is-deeply gather { … }` を続けて 2 回書くと 2 本目が空になる（gather の遅延評価と Test 関数の引数評価の相互作用）。③ 等差列 `0.1, 2 ... 3` の第 2 項は raku では「前項＋公差」で再計算され Rat 2.0 になるが mutsu は種 Int 2 をそのまま出す。#4523 で 12/17 → 14/17 |
 
 **②で唯一パースできないまま残った 1 本**: `integration/advent2012-day19.t`。
 `sub postfix:<k> ($a) is tighter(&infix:<*>)` のように**優先順位トレイト付きのユーザ定義

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1,3 +1,4 @@
+roast/6.c/APPENDICES/A04-experimental/01-misc.t
 roast/6.c/MISC/misc-6.c.t
 roast/6.c/S02-names/SETTING-6c.t
 roast/6.c/S02-types/subset-6c.t

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -294,7 +294,7 @@ impl Compiler {
     /// at its top level. Used to decide whether a for-loop body needs
     /// routine-registry scoping (hoist + snapshot/restore). Mirrors the set of
     /// statements that [`hoist_sub_decls`] acts on (`Stmt::SubDecl`).
-    pub(super) fn stmts_declare_routines(stmts: &[Stmt]) -> bool {
+    pub(crate) fn stmts_declare_routines(stmts: &[Stmt]) -> bool {
         stmts.iter().any(|s| matches!(s, Stmt::SubDecl { .. }))
     }
 

--- a/src/parser/stmt/control/with_stmt.rs
+++ b/src/parser/stmt/control/with_stmt.rs
@@ -100,7 +100,10 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
     // Topicalize `$_` for the body. For a non-literal, non-`given` topic reuse the
     // `$tmp` holding the (once-evaluated) condition value.
     let topic_assign = topicalize(&tmp_var);
-    let mut with_body = if use_given_alias || route_literal_through_given {
+    // A block with an explicit signature does not bind `$_`: `with 1 -> $a { $_ }` leaves
+    // the outer topic alone, exactly as `for 1 -> $b { $_ }` does. Only the parameterless
+    // form topicalizes.
+    let mut with_body = if use_given_alias || route_literal_through_given || param_name.is_some() {
         Vec::new()
     } else {
         vec![topic_assign]

--- a/src/parser/stmt/sub/return_type.rs
+++ b/src/parser/stmt/sub/return_type.rs
@@ -93,9 +93,16 @@ pub(crate) fn parse_return_type_annotation(input: &str) -> PResult<'_, String> {
         }
     }
 
-    let annotation = rest[..idx].trim().to_string();
+    let mut annotation = rest[..idx].trim().to_string();
     if annotation.is_empty() {
         return Err(PError::expected("return type annotation"));
+    }
+    // A coercion type's empty source is `Any`: `--> Str()` is `Str(Any)`, which is the
+    // name `.returns` reports.
+    if let Some(base) = annotation.strip_suffix("()")
+        && !base.is_empty()
+    {
+        annotation = format!("{base}(Any)");
     }
     // Detect multiple prefix constraints in return type (e.g. `--> Int Str`)
     if let Some(space_pos) = annotation.find(' ') {

--- a/src/parser/stmt/sub/traits.rs
+++ b/src/parser/stmt/sub/traits.rs
@@ -15,8 +15,11 @@ fn parse_trait_type_name(input: &str) -> PResult<'_, String> {
             ')' => {
                 depth -= 1;
                 if depth == 0 {
-                    let name = format!("{base}({})", &inner[..idx]);
-                    return Ok((&inner[idx + 1..], name));
+                    // An empty source is `Any`: `Str()` is `Str(Any)`, which is what
+                    // `.returns` reports.
+                    let source = inner[..idx].trim();
+                    let source = if source.is_empty() { "Any" } else { source };
+                    return Ok((&inner[idx + 1..], format!("{base}({source})")));
                 }
             }
             _ => {}

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -351,7 +351,18 @@ impl Interpreter {
             }
             "find_method" if args.len() >= 2 => {
                 let invocant = &args[0];
-                let method_name = args[1].to_string_value();
+                // The method name is the last *positional* argument: calling
+                // `$obj.^find_method('v')` on a concrete value prepends the Package and
+                // leaves the instance in between (so `args[1]` is not the name), while
+                // `.^find_method('foo', :no_fallback)` trails an adverb after it.
+                let Some(name_arg) = args
+                    .iter()
+                    .rev()
+                    .find(|a| !matches!(a.view(), ValueView::Pair(..) | ValueView::ValuePair(..)))
+                else {
+                    return Ok(Value::NIL);
+                };
+                let method_name = name_arg.to_string_value();
                 Ok(self
                     .classhow_find_method(invocant, &method_name)
                     .unwrap_or(Value::NIL))

--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -5,6 +5,10 @@ impl Interpreter {
     pub(super) fn classhow_lookup(&self, invocant: &Value, method_name: &str) -> Option<Value> {
         let (class_name, class_name_str) = match invocant.view() {
             ValueView::Package(name) => (name, name.resolve()),
+            // An instance of a user class carries its class name; `value_type_name` would
+            // flatten it to "Any" and lose the registry entry, so `$obj.^lookup('m')` found
+            // nothing while `Class.^lookup('m')` did.
+            ValueView::Instance { class_name, .. } => (class_name, class_name.resolve()),
             _ => {
                 // For concrete values, derive the type name
                 let type_name = crate::runtime::utils::value_type_name(invocant).to_string();

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -235,6 +235,9 @@ impl Interpreter {
                     if n == "IO::Path" || n.starts_with("IO::Path::") {
                         return Some(Ok(target.clone()));
                     }
+                    if let Some(err) = crate::runtime::utils::dateish_io_concreteness_error(&n) {
+                        return Some(Err(err));
+                    }
                 }
                 let s = target.to_string_value();
                 if s.contains('\0') {

--- a/src/runtime/utils/errors.rs
+++ b/src/runtime/utils/errors.rs
@@ -1,5 +1,18 @@
 use super::*;
 
+/// `Date`/`DateTime` get their `.IO` from `Dateish`, whose signature takes a `Dateish:D`
+/// invocant, so calling it on the type object is a concreteness error rather than a
+/// stringification of `(Date)` into a path. Returns the error when `name` is one of them.
+pub(crate) fn dateish_io_concreteness_error(name: &str) -> Option<RuntimeError> {
+    if !matches!(name, "Date" | "DateTime") {
+        return None;
+    }
+    Some(RuntimeError::parameter_invalid_concreteness(
+        "Dateish", name, "IO", "self", true, // should_be_concrete
+        true, // param_is_invocant
+    ))
+}
+
 pub(crate) fn merge_junction(kind: JunctionKind, left: Value, right: Value) -> Value {
     // Infix junction operators (|, &, ^) always create a new 2-element
     // junction without flattening. List-associative flattening is handled

--- a/src/vm/vm_call_method_compiled_coerce.rs
+++ b/src/vm/vm_call_method_compiled_coerce.rs
@@ -144,10 +144,9 @@ impl Interpreter {
             ValueView::Package(name) => {
                 let n = name.resolve();
                 if n == "IO::Path" || n.starts_with("IO::Path::") {
-                    Some(Ok(target.clone()))
-                } else {
-                    None
+                    return Some(Ok(target.clone()));
                 }
+                crate::runtime::utils::dateish_io_concreteness_error(&n).map(Err)
             }
             // Plain stringifiable scalars coerce their string value to an IO::Path.
             ValueView::Str(_)

--- a/src/vm/vm_hyper_ops.rs
+++ b/src/vm/vm_hyper_ops.rs
@@ -342,6 +342,19 @@ impl Interpreter {
             if left_fixed && right_fixed && left_len != right_len {
                 return Err(Self::hyperop_nondwim_error(left_len, right_len, op));
             }
+            // A scalar leaf on the non-dwimmy side is a single element that cannot grow to
+            // meet the other side, so `5 »*» (2..4)` is X::HyperOp::NonDWIM even though the
+            // right dwims -- a dwim side adapts to the fixed side, and 1 is not 3. An empty
+            // other side still yields an empty result (`True »+» ()` is `()`).
+            let scalar_fixed_mismatch = |fixed: bool, is_scalar: bool, other_len: usize| {
+                fixed && is_scalar && other_len != 0 && other_len != 1
+            };
+            if scalar_fixed_mismatch(left_fixed, !Self::is_listy(left), right_len) {
+                return Err(Self::hyperop_nondwim_error(left_len, right_len, op));
+            }
+            if scalar_fixed_mismatch(right_fixed, !Self::is_listy(right), left_len) {
+                return Err(Self::hyperop_nondwim_error(left_len, right_len, op));
+            }
             // An empty operand cannot be cycled or padded to fill a dwim side, so
             // any empty side yields an empty result (`True »+» ()` is `()`, not a
             // `0`-padded `(1,)`). The fixed-length mismatch above already covers

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -35,9 +35,20 @@ impl Interpreter {
             self.box_captured_lexicals(code, &analysis_cc);
             let mut env = self.env().clone();
             env.insert("__mutsu_lazylist_from_gather".to_string(), Value::TRUE);
-            // Compile the gather body to bytecode for Interpreter-native forcing
+            // Compile the gather body to bytecode for Interpreter-native forcing.
+            // A `sub` declared in the body is lexical to it, so compile through a
+            // `Stmt::Block` (whose `BlockScope` restores the routine registry) when there
+            // is one. Without it two sibling `gather { sub foo {...} }` blocks collided
+            // with X::Redeclaration, and the first block's `foo` stayed callable outside.
             let compiler = Compiler::new();
-            let (compiled_code, compiled_fns) = compiler.compile(body);
+            let scoped_body: Vec<Stmt>;
+            let compile_target: &[Stmt] = if Compiler::stmts_declare_routines(body) {
+                scoped_body = vec![Stmt::Block(body.clone())];
+                &scoped_body
+            } else {
+                body
+            };
+            let (compiled_code, compiled_fns) = compiler.compile(compile_target);
             let list = LazyList {
                 body: body.clone(),
                 env,

--- a/t/metamodel-and-coercion-gaps.t
+++ b/t/metamodel-and-coercion-gaps.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 12;
+
+# `.^lookup` / `.^find_method` on a concrete value used to find nothing: the invocant's
+# class name was flattened to "Any" before the registry was consulted, so only the type
+# object worked.
+class C { method v (Int $x --> Str()) { $x } }
+my $o = C.new;
+
+ok $o.^lookup('v').defined, '.^lookup on an instance finds the method';
+ok $o.^find_method('v').defined, '.^find_method on an instance finds the method';
+ok C.^find_method('v').defined, '.^find_method on the type object is unchanged';
+
+# A coercion type's empty source is `Any`, which is the name `.returns` reports.
+my sub arrow (Int $x --> Str()) { $x }
+is &arrow.returns.raku, 'Str(Any)', '--> Str() reports Str(Any)';
+my sub trait-form (Int $x) returns Str() { $x }
+is &trait-form.returns.raku, 'Str(Any)', 'returns Str() reports Str(Any)';
+is $o.^find_method('v').returns.raku, 'Str(Any)',
+    "a method's declared coercion return type survives ^find_method";
+
+# `.^find_method` still takes its adverbs: the name is the last *positional* argument.
+ok C.^find_method('v', :no_fallback).defined, '.^find_method accepts :no_fallback';
+
+# `Date`/`DateTime` take a `Dateish:D` invocant for `.IO`, so the type object throws
+# rather than stringifying "(Date)" into a path.
+is Date.new('2016-10-03').IO.Str, '2016-10-03', '.IO on a Date instance is its path';
+throws-like { Date.IO }, X::Parameter::InvalidConcreteness, '.IO on Date:U throws';
+throws-like { DateTime.IO }, X::Parameter::InvalidConcreteness, '.IO on DateTime:U throws';
+
+# A scalar on the non-dwimmy side of a hyper cannot grow to meet the other side.
+throws-like { my $ = 5 »*» (2..4) }, X::HyperOp::NonDWIM,
+    'a scalar on the non-dwimmy side of a hyper throws';
+is-deeply (5 «*» (2..4)).List, (10, 15, 20), 'the same scalar on the dwimmy side broadcasts';

--- a/t/with-topic-and-gather-scope.t
+++ b/t/with-topic-and-gather-scope.t
@@ -1,0 +1,29 @@
+use Test;
+
+plan 6;
+
+# A block with an explicit signature does not bind `$_`: `with 1 -> $a { $_ }` leaves the
+# outer topic alone, exactly as `for 1 -> $b { $_ }` already did.
+$_ = 42;
+with 1 -> $a {
+    is $a, 1, 'the pointy parameter gets the value';
+    is $_, 42, 'with -> $a leaves the outer topic alone';
+}
+
+# The parameterless form still topicalizes.
+with 7 {
+    is $_, 7, 'with without a signature topicalizes';
+}
+
+# This is what makes the rakudo#1695 case work: `.flip` inside the inner block reads the
+# *outer* topic, not the `with` value.
+$_ = 42;
+is-deeply ((with 1 -> $a { .flip }) andthen $_), '24',
+    'the inner block sees the enclosing topic';
+
+# A `sub` declared in a gather block is lexical to it: two sibling gathers may each
+# declare the same name, which used to be X::Redeclaration.
+my $first = gather { sub emit-it($s) { take $s }; emit-it 'cc'; emit-it 'dd' };
+my $second = gather { sub emit-it($n) { take $n * 2 }; emit-it 1; emit-it 2 };
+is-deeply $first.List, ('cc', 'dd'), 'the first gather runs its own sub';
+is-deeply $second.List, (2, 4), 'a sibling gather may redeclare the same sub';


### PR DESCRIPTION
The feature gaps left over from the parse-failure cluster. Six bugs, none specific to the files that surfaced them.

- **`.^lookup` / `.^find_method` found nothing on a concrete value.** `classhow_lookup` derived the invocant's class name through `value_type_name`, which flattens any instance to `"Any"` — so only the *type object* could be looked up. `find_method` also read the method name from `args[1]`, which is the instance (the Package is prepended when the meta-call is made on a concrete value); it is the last *positional* argument, since `.^find_method('foo', :no_fallback)` trails an adverb after it.

- **A coercion type's empty source is `Any`.** `--> Str()` and `returns Str()` are `Str(Any)`, which is the name `.returns` reports.

- **`Date.IO` / `DateTime.IO` on the type object.** They take a `Dateish:D` invocant, so this is `X::Parameter::InvalidConcreteness` — not a stringification of `"(Date)"` into a path.

- **A scalar on the non-dwimmy side of a hyper cannot grow to meet the other side.** `5 »*» (2..4)` is `X::HyperOp::NonDWIM`; mutsu silently produced `(10,)`. An empty other side still yields an empty result (`True »+» ()` is `()`).

- **A block with an explicit signature does not bind `$_`.** `with 1 -> $a { $_ }` leaves the outer topic alone, exactly as `for 1 -> $b { $_ }` already did.

- **A `sub` declared in a `gather` block is lexical to it.** The body was compiled as a bare statement list, so it got no `BlockScope`: two sibling `gather { sub foo {...} }` blocks collided with `X::Redeclaration`.

## Result

`roast/6.c/APPENDICES/A04-experimental/01-misc.t` passes in full and is whitelisted (1393 → 1394).

`6.c/MISC/bug-coverage.t` goes from 12/17 to **14/17**. BLOCKERS.md records the three left: the `.count-only`/`.bool-only` Iterator API (the big one), a gather/`is-deeply` laziness interaction, and an arithmetic-sequence seed that raku recomputes as `prev + step` (so `0.1, 2 ... 3` yields a Rat `2.0`, not the Int seed).

New tests: `t/metamodel-and-coercion-gaps.t`, `t/with-topic-and-gather-scope.t`. `make test` is green; the metamodel/IO/operator/block-heavy whitelisted roast files were re-run individually with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tFv8btbbJZpJT6G2vCS2i