### PR TITLE
perf(jit): J4d slice 1 — Tier B inline GetLocal + lock-free hot-range cache

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -179,10 +179,15 @@ HTTP::Parser / MIME::Base64 / HTTP::Server::Tiny（end-to-end HTTP 配信）/ Tu
 
 - [ ] **層4 JIT（Cranelift・= §5 Lever 4）— J1〜J5 完了・既定 on（2026-07-13）**
       （J1 #4471・J2 #4474・J3 #4476・J4 #4478/#4479/#4480・J5 既定 on 切替、
-      詳細 = news/2026-07.md）。残スライス:
-      **J4d（Tier B 変数 op インライン: GetLocal/SetLocal fast path・JIT→JIT per-call
-      bind インライン・args Vec alloc 除去 — 「int ループ 5-10x」ゲートの本体）**
-      = [ADR-0004](docs/adr/0004-jit-strategy.md)。ベンチ数字の正本は bench CI
+      詳細 = news/2026-07.md）。J4d 第1弾（#4527: Tier B GetLocal インライン +
+      hot-loop entry の per-iteration ロック除去 — Num ループ -43%）完了。残スライス:
+      **J4d 続き** = [ADR-0004](docs/adr/0004-jit-strategy.md):
+      ① SetLocal の env-mirror 連鎖（`Symbol::intern`/TLS ~35% — インタプリタ側、
+      `set_env_with_main_alias_sym`→`set_shared_var_sym` の再 intern と for-loop の
+      per-iteration topic insert が主犯・profile = news 2026-07-15 の項）
+      ② JIT→JIT per-call bind インライン（fib profile:
+      `call_compiled_function_positional_light` 19% + `Env::scoped_child`/drop ~14%）
+      ③ args Vec alloc 除去。ベンチ数字の正本は bench CI
       （`bench-data` ブランチ・`+jit` 系列は #4480 から・J5 以降 plain 系列は
       `MUTSU_JIT=off` 明示 pin のインタプリタ基準線）。
 - [ ] **3b-2 traffic pruning**（[docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) §3.3）:

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,36 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-15: 層4 JIT J4d 第1弾 — Tier B GetLocal インライン + hot-loop entry のロック除去（#4527）
+
+J4d（ADR-0004・Tier B 変数 op インライン）の最初のスライス。JIT on の fib / Num ループを
+perf で実測してから着手した（教訓 = ADR-0006「opcode 数 ≠ 時間」の計測プロトコル踏襲）:
+
+- **hot-loop entry の per-iteration ロック除去**: `try_enter_range` が compound ループの
+  **毎 iteration** に mutex lock + 線形走査 + `Arc` clone を払っていた（hot Num ループの 11.9%）。
+  settled な range（compiled fn ptr / bailout）を `JitCodeState` 上の write-once lock-free
+  `(key, entry)` cache（4 slot）に publish し、定常状態を atomic load 2 発に。溢れた range は
+  従来の mutex 経路のまま（正しさ不変・遅いだけ）。11.9% → 3.1%。
+- **Tier B インライン GetLocal**: JIT 済みボディの GetLocal は常に Tier A shim 経由で、
+  `exec_get_local_op` のガード連鎖 —— **毎読みの env `get_sym` cell-adoption probe
+  （ハッシュ引き）** 込み —— を再実行していた。動的 spoiler が無く slot word が refcount-free
+  scalar（small Int / Num / Bool / Package）なら load×2 + store×1 に直接展開。健全性は
+  ユーザコードの静的解析でなく **monotonic latch**（USER_INFIX_DECLS パターン）で担保:
+  `CONTAINER_CELLS`（NaN-box encode の `Kind::ContainerRef` 単一チョークポイントで bump —
+  0 ⟺ プロセス内にセルが存在せず adoption probe は恒真 no-op）/ `CALLER_VAR_BINDS`
+  （`$CALLER::x := ...`）/ per-interp `atomic_var_seen`・`sigilless_attrs_active`。
+  属性 slot と `!`/`.`/`@`/`%` 名は静的に除外。latch 値は `MUTSU_VM_STATS` の jit: 行に出る。
+- **実測（local release A/B・同一手法）**: 3M-iter Num ループ JIT on **1.09s → 0.62s（-43%）**。
+  この形は従来 **JIT on がインタプリタに負けていた**（1.09 vs 0.92 — per-iteration entry
+  オーバーヘッドが native 化の利得を食い潰していた）が、+33% 勝ちに反転。fib(25) 0.136 → ~0.07s。
+  正本の比は merge 後の bench CI（bench-data）。
+- pin = `t/jit-getlocal-fastpath.t`（fast set 4 種 + spoiler 全種: `is rw` セル・`:=` alias・
+  boxed Str・Nil 宣言チェック。threshold=2 / JIT off / raku で同一出力）。
+- **残（次スライス）**: ① Num ループの残コスト = SetLocal の env-mirror 連鎖
+  （`Symbol::intern`/TLS ~35% — インタプリタ側）② JIT→JIT per-call bind インライン
+  （fib profile: `call_compiled_function_positional_light` 19% + `Env::scoped_child`/drop ~14%）
+  ③ args Vec alloc 除去。
+
 ## 2026-07-14: `my $x = ...` が intern・SipHash・COW を払うのをやめた — time-parts が raku 比 1.17 → 0.62（#4506 / #4507 / #4508）
 
 time-parts は **JIT on でも raku より遅い唯一のベンチ**（比 1.17）として残っていた。profile を

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1909,6 +1909,18 @@ pub(crate) struct JitCodeState {
     /// `vm_jit::try_enter_range` on each `run_range` call once the JIT is on.
     /// A linear-scan Vec: chunks hold only a handful of distinct hot ranges.
     pub(crate) ranges: std::sync::Mutex<JitRangeTable>,
+    /// Lock-free read cache over `ranges` for *settled* sub-ranges (ADR-0004
+    /// J4d): once a range's entry word is final (a compiled function pointer
+    /// or `JIT_ENTRY_BAILOUT`), it is published here as a write-once
+    /// `(key, entry)` pair so the per-iteration `run_range` hook resolves it
+    /// with a couple of atomic loads instead of a mutex + linear scan (which
+    /// profiled at ~12% of a hot numeric loop). `key` packs
+    /// `(start << 32 | end) + 1` (never 0, so 0 = empty slot); the writer
+    /// stores `entry` before releasing `key`, and readers acquire `key` first,
+    /// so a visible key implies a visible entry. Slots are claimed under the
+    /// `ranges` mutex; ranges beyond the fixed capacity simply stay on the
+    /// mutex path (correct, just slower).
+    pub(crate) range_cache: [(std::sync::atomic::AtomicU64, std::sync::atomic::AtomicU64); 4],
 }
 
 /// The per-chunk range table: `(start, end)` keys to shared range states.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1392,7 +1392,9 @@ pub struct Interpreter {
     /// a program that stops using an atomic still resolves correctly. See also the
     /// process-global `atomic_var_seen_anywhere`, which the reset path needs
     /// because a worker thread's `cas` marks only the WORKER's copy of this field.
-    atomic_var_seen: bool,
+    /// pub(crate) so `vm_jit_layout` can `offset_of!` it: the Tier B inline
+    /// GetLocal fast path reads this flag from native code.
+    pub(crate) atomic_var_seen: bool,
     /// Monotonic flag: set once any *env-scoped* variable type constraint has been
     /// written (via `set_var_type_constraint`'s `env.insert` branch or
     /// `bind_param_type_constraint`). The hot `var_type_constraint` read does a

--- a/src/runtime/runtime_caller_env.rs
+++ b/src/runtime/runtime_caller_env.rs
@@ -217,6 +217,9 @@ impl Interpreter {
         let idx = stack_len - depth;
         self.caller_env_stack[idx].insert(target_name.to_string(), source_val.clone());
         // Set up binding alias so reads of target_name resolve to source_name
+        // (latched process-wide: the Tier B inline GetLocal fast path relies
+        // on a zero counter to skip resolve_binding — see CALLER_VAR_BINDS).
+        crate::vm::vm_jit::note_caller_var_binding();
         self.var_bindings
             .insert(target_name.to_string(), source_name.to_string());
         // Also update current env

--- a/src/value/nanbox/encode.rs
+++ b/src/value/nanbox/encode.rs
@@ -191,7 +191,14 @@ impl NanBox {
             ValueRepr::CustomType(d) => pack_arc(Kind::CustomType, Arc::new(*d)),
             ValueRepr::CustomTypeInstance(d) => pack_arc(Kind::CustomTypeInstance, Arc::new(*d)),
             ValueRepr::Scalar(inner) => pack_arc(Kind::Scalar, Arc::new(*inner)),
-            ValueRepr::ContainerRef(cell) => pack_gc(Kind::ContainerRef, cell),
+            ValueRepr::ContainerRef(cell) => {
+                // Latch for the Tier B inline GetLocal fast path: this is the
+                // single point every ContainerRef word passes through, so a
+                // zero counter proves no cell exists anywhere (see
+                // `vm_jit::CONTAINER_CELLS`).
+                crate::vm::vm_jit::note_container_cell();
+                pack_gc(Kind::ContainerRef, cell)
+            }
             ValueRepr::LazyThunk(t) => pack_arc(Kind::LazyThunk, t),
             ValueRepr::LazyIoLines { handle, kv, words } => pack_arc(
                 Kind::LazyIoLines,

--- a/src/value/nanbox/mod.rs
+++ b/src/value/nanbox/mod.rs
@@ -490,6 +490,14 @@ pub(crate) mod jit_words {
     pub(crate) const KIND_MASK: u64 = (0xFFFF << TAG_SHIFT) | SUB_MASK;
     /// `Kind::Pair` probe pattern (for the `ContainerizePair` fast skip).
     pub(crate) const PAIR_PATTERN: u64 = word_for_kind(Kind::Pair, 0).get();
+    /// `Kind::Bool` probe pattern (payload = 0/1 in the inline bits, outside
+    /// `KIND_MASK`, so one probe covers True and False).
+    pub(crate) const BOOL_PATTERN: u64 = word_for_kind(Kind::Bool, 0).get();
+    /// `Kind::Package` probe pattern (payload = `Symbol` id in the inline
+    /// bits). Package words are payload-free for ownership purposes (the
+    /// symbol id is not refcounted), so the Tier B GetLocal fast path may
+    /// duplicate them as raw bits.
+    pub(crate) const PACKAGE_PATTERN: u64 = word_for_kind(Kind::Package, 0).get();
 
     /// True when duplicating/discarding this word needs no refcount or GC
     /// bookkeeping: small Int, Num, or a payload-free inline kind. The Tier B

--- a/src/vm/vm_jit.rs
+++ b/src/vm/vm_jit.rs
@@ -44,6 +44,37 @@ pub(crate) fn note_user_infix_decl() {
     USER_INFIX_DECLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 }
 
+/// Process-wide, monotonic count of `ContainerRef` cell words ever packed
+/// (bumped at the single NaN-box encode chokepoint for `Kind::ContainerRef`).
+/// Zero proves no shared `:=`/capture cell exists anywhere in the process, so
+/// the Tier B inline `GetLocal` fast path (vm_jit_tier_b.rs) can skip the
+/// env cell-adoption probe (`exec_get_local_op`'s per-read `env().get_sym`)
+/// outright; nonzero conservatively routes every inline read through the
+/// helper, which re-runs the full interpreter arm. Never decremented — a
+/// program that stops using cells only loses speed, never correctness.
+pub(crate) static CONTAINER_CELLS: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(0);
+
+/// Record one `ContainerRef` cell creation (see `CONTAINER_CELLS`).
+#[inline]
+pub(crate) fn note_container_cell() {
+    CONTAINER_CELLS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Process-wide, monotonic count of `$CALLER::x := ...` variable-binding
+/// aliases ever created (`Interpreter::var_bindings` inserts). Zero proves
+/// `resolve_binding` is a no-op everywhere, letting the Tier B inline
+/// `GetLocal` fast path skip it; same conservative monotonic contract as
+/// [`CONTAINER_CELLS`].
+pub(crate) static CALLER_VAR_BINDS: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(0);
+
+/// Record one caller-variable binding registration (see `CALLER_VAR_BINDS`).
+#[inline]
+pub(crate) fn note_caller_var_binding() {
+    CALLER_VAR_BINDS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+}
+
 /// Native entry signature: `(interp, code, compiled_fns) -> status`.
 #[cfg(feature = "jit")]
 pub(crate) type JitEntryFn = unsafe extern "C" fn(
@@ -167,40 +198,66 @@ pub(crate) fn try_enter_range(
     if !jit_enabled() || start >= end || end > code.ops.len() {
         return None;
     }
-    let st = {
-        let mut ranges = code.jit.ranges.lock().unwrap();
-        let key = (start as u32, end as u32);
-        match ranges.iter().find(|(k, _)| *k == key) {
-            Some((_, s)) => s.clone(),
-            None => {
-                let s = std::sync::Arc::new(crate::opcode::JitRangeState::default());
-                ranges.push((key, s.clone()));
-                s
-            }
+    // Settled-range fast path (ADR-0004 J4d): a range whose entry word is
+    // final is published in the lock-free `range_cache`, so the steady state
+    // of a hot loop pays a couple of atomic loads here instead of the mutex +
+    // linear scan below (which profiled at ~12% of a hot numeric loop).
+    let cache_key = (((start as u64) << 32) | end as u64).wrapping_add(1);
+    let mut entry = 0u64;
+    for (k, e) in &code.jit.range_cache {
+        // Acquire pairs with the publishing store: a visible key implies the
+        // entry word (stored before the key) is visible too.
+        if k.load(Ordering::Acquire) == cache_key {
+            entry = e.load(Ordering::Relaxed);
+            break;
         }
-    };
-    let entry = st.entry.load(Ordering::Acquire);
-    let f: JitEntryFn = if entry == 0 {
-        let calls = st.calls.fetch_add(1, Ordering::Relaxed) + 1;
-        if calls < jit_threshold() {
-            return None;
-        }
-        match super::vm_jit_compile::compile_range(code, start, end) {
-            Some(f) => {
-                st.entry.store(f as usize as u64, Ordering::Release);
-                crate::vm::vm_stats::record_jit_compile();
-                f
-            }
-            None => {
-                st.entry.store(JIT_ENTRY_BAILOUT, Ordering::Release);
-                return None;
-            }
-        }
-    } else if entry == JIT_ENTRY_BAILOUT {
+    }
+    if entry == JIT_ENTRY_BAILOUT {
         return None;
-    } else {
+    }
+    let f: JitEntryFn = if entry != 0 {
         // Same soundness argument as `try_enter`: 0 -> fn-pointer only.
         unsafe { std::mem::transmute::<usize, JitEntryFn>(entry as usize) }
+    } else {
+        let st = {
+            let mut ranges = code.jit.ranges.lock().unwrap();
+            let key = (start as u32, end as u32);
+            match ranges.iter().find(|(k, _)| *k == key) {
+                Some((_, s)) => s.clone(),
+                None => {
+                    let s = std::sync::Arc::new(crate::opcode::JitRangeState::default());
+                    ranges.push((key, s.clone()));
+                    s
+                }
+            }
+        };
+        let entry = st.entry.load(Ordering::Acquire);
+        if entry == 0 {
+            let calls = st.calls.fetch_add(1, Ordering::Relaxed) + 1;
+            if calls < jit_threshold() {
+                return None;
+            }
+            match super::vm_jit_compile::compile_range(code, start, end) {
+                Some(f) => {
+                    st.entry.store(f as usize as u64, Ordering::Release);
+                    crate::vm::vm_stats::record_jit_compile();
+                    publish_range_entry(code, cache_key, f as usize as u64);
+                    f
+                }
+                None => {
+                    st.entry.store(JIT_ENTRY_BAILOUT, Ordering::Release);
+                    publish_range_entry(code, cache_key, JIT_ENTRY_BAILOUT);
+                    return None;
+                }
+            }
+        } else if entry == JIT_ENTRY_BAILOUT {
+            publish_range_entry(code, cache_key, JIT_ENTRY_BAILOUT);
+            return None;
+        } else {
+            publish_range_entry(code, cache_key, entry);
+            // Same soundness argument as `try_enter`: 0 -> fn-pointer only.
+            unsafe { std::mem::transmute::<usize, JitEntryFn>(entry as usize) }
+        }
     };
     crate::vm::vm_stats::record_jit_entry();
     // The interpreter loop polls the GC safepoint once per opcode; a native
@@ -218,6 +275,29 @@ pub(crate) fn try_enter_range(
             Some(Err(e))
         }
         _ => Some(Ok(())),
+    }
+}
+
+/// Publish a settled range entry (compiled fn pointer or `JIT_ENTRY_BAILOUT`)
+/// into the chunk's lock-free `range_cache`. Slot claiming is serialized by
+/// taking the `ranges` mutex; the entry word is stored *before* the key is
+/// released so a reader that acquires the key always sees the entry. A full
+/// cache (more settled ranges than slots) or an already-published key is
+/// fine — the range just keeps resolving through the mutex path.
+#[cfg(feature = "jit")]
+fn publish_range_entry(code: &CompiledCode, cache_key: u64, entry: u64) {
+    use std::sync::atomic::Ordering;
+    let _guard = code.jit.ranges.lock().unwrap();
+    for (k, e) in &code.jit.range_cache {
+        let cur = k.load(Ordering::Relaxed);
+        if cur == cache_key {
+            return; // another thread already published it
+        }
+        if cur == 0 {
+            e.store(entry, Ordering::Relaxed);
+            k.store(cache_key, Ordering::Release);
+            return;
+        }
     }
 }
 

--- a/src/vm/vm_jit_compile.rs
+++ b/src/vm/vm_jit_compile.rs
@@ -87,6 +87,29 @@ pub(super) fn compile_range(code: &CompiledCode, start: usize, end: usize) -> Op
     build(code, start, end, &targets)
 }
 
+/// Static half of the Tier B `GetLocal` fast-path eligibility (ADR-0004
+/// J4d). Rejected shapes stay on the Tier A shim unconditionally:
+/// - attribute slots (`$!x` / `$.x` / bare sigilless attrs): the arm reads
+///   `self`'s shared cell, resolved through `local_attr_key`;
+/// - `!` / `.` twigil names: shared-var dirty probes and accessor aliases;
+/// - `@` / `%` containers: atomic-key and cross-thread shared-snapshot
+///   probes are keyed on the sigil.
+///
+/// Everything dynamic (cells, atomics, thunks, Nil) is handled by the
+/// emitted word/latch checks — see `TierB::emit_get_local`.
+fn get_local_tier_b_eligible(code: &CompiledCode, idx: usize) -> bool {
+    let Some(name) = code.locals.get(idx) else {
+        return false;
+    };
+    if code.local_attr_key(idx).is_some() {
+        return false;
+    }
+    !matches!(
+        name.as_bytes().first(),
+        Some(b'!') | Some(b'@') | Some(b'%') | Some(b'.')
+    )
+}
+
 /// Helper-call signatures used by the emitted code, imported once per
 /// function. All shims take the interpreter pointer first; fallible ones
 /// return an `i32` status (see `vm_jit::JIT_STATUS_*`).
@@ -180,6 +203,7 @@ fn build(
             s1: sigs.s1,
             v1: sigs.v1,
             v_code_u32: sigs.v_code_u32,
+            s_code_u32: sigs.s_code_u32,
         })
     } else {
         None
@@ -321,14 +345,27 @@ fn build(
                 tb.emit_compare(&mut b, NumCmp::Ne, helpers::num_ne as *const () as usize);
             }
             OpCode::GetLocal(idx) => {
-                let idxv = b.ins().iconst(types::I32, *idx as i64);
-                let status = call_helper(
-                    &mut b,
-                    sigs.s_code_u32,
-                    helpers::get_local as *const () as usize,
-                    &[interp, codep, idxv],
-                )?;
-                check_status(&mut b, status);
+                if let Some(tb) = &tier_b
+                    && get_local_tier_b_eligible(code, *idx as usize)
+                {
+                    // Tier B inline fast path (ADR-0004 J4d): plain scalar
+                    // slot read as two loads + a store, shim otherwise.
+                    tb.emit_get_local(
+                        &mut b,
+                        codep,
+                        *idx,
+                        helpers::get_local as *const () as usize,
+                    );
+                } else {
+                    let idxv = b.ins().iconst(types::I32, *idx as i64);
+                    let status = call_helper(
+                        &mut b,
+                        sigs.s_code_u32,
+                        helpers::get_local as *const () as usize,
+                        &[interp, codep, idxv],
+                    )?;
+                    check_status(&mut b, status);
+                }
             }
             OpCode::SetLocal(idx) => {
                 let idxv = b.ins().iconst(types::I32, *idx as i64);

--- a/src/vm/vm_jit_layout.rs
+++ b/src/vm/vm_jit_layout.rs
@@ -15,6 +15,13 @@ use super::*;
 pub(super) struct JitLayout {
     /// Byte offset of `Interpreter::stack` (a `Vec<Value>`).
     pub(super) stack: i32,
+    /// Byte offset of `Interpreter::locals` (a `Vec<Value>`) — the Tier B
+    /// GetLocal fast path reads slot words in place (ADR-0004 J4d).
+    pub(super) locals: i32,
+    /// Byte offsets of the per-Interpreter gate flags the GetLocal fast path
+    /// loads (both plain `bool` fields).
+    pub(super) atomic_var_seen: i32,
+    pub(super) sigilless_attrs_active: i32,
     /// Byte offsets of the data pointer / length / capacity words inside
     /// `Vec<Value>` (relative to the start of the `Vec`).
     pub(super) vec_ptr: i32,
@@ -60,6 +67,10 @@ pub(super) fn layout() -> Option<&'static JitLayout> {
             let (vec_ptr, vec_len, vec_cap) = probe_vec_layout()?;
             Some(JitLayout {
                 stack: std::mem::offset_of!(Interpreter, stack) as i32,
+                locals: std::mem::offset_of!(Interpreter, locals) as i32,
+                atomic_var_seen: std::mem::offset_of!(Interpreter, atomic_var_seen) as i32,
+                sigilless_attrs_active: std::mem::offset_of!(Interpreter, sigilless_attrs_active)
+                    as i32,
                 vec_ptr,
                 vec_len,
                 vec_cap,

--- a/src/vm/vm_jit_tier_b.rs
+++ b/src/vm/vm_jit_tier_b.rs
@@ -59,6 +59,8 @@ pub(super) struct TierB {
     pub(super) v1: SigRef,
     /// `(interp, code, u32) -> ()` — the `load_const` slow path.
     pub(super) v_code_u32: SigRef,
+    /// `(interp, code, u32) -> i32` — the `get_local` slow path.
+    pub(super) s_code_u32: SigRef,
 }
 
 impl TierB {
@@ -491,6 +493,131 @@ impl TierB {
         let idxv = b.ins().iconst(types::I32, idx as i64);
         b.ins()
             .call_indirect(self.v_code_u32, callee, &[self.interp, codep, idxv]);
+        b.ins().jump(done, &[]);
+
+        b.switch_to_block(done);
+    }
+
+    /// `GetLocal` of a statically-eligible plain local (ADR-0004 J4d): when
+    /// no dynamic spoiler exists — no `ContainerRef` cell anywhere in the
+    /// process, no `$CALLER::x := ...` alias, no atomic variable on this
+    /// interpreter, no sigilless attribute alias — and the slot word is a
+    /// refcount-free scalar (small Int / Num / Bool / Package), the
+    /// interpreter arm reduces to `stack.push(locals[idx].clone())`, which is
+    /// emitted here as two loads and a store. Every other combination calls
+    /// the Tier A shim, which re-runs the full `exec_get_local_op` guard
+    /// chain (cell adoption, lazy thunks, HashEntryRef, Nil declaration
+    /// checks, ...) on the untouched stack.
+    ///
+    /// The static half of the eligibility (name shape, attribute slots) is
+    /// checked by the caller; see `get_local_tier_b_eligible`.
+    pub(super) fn emit_get_local(
+        &self,
+        b: &mut FunctionBuilder,
+        codep: CVal,
+        idx: u32,
+        slow_fn: usize,
+    ) {
+        let slow_blk = b.create_block();
+        let done = b.create_block();
+
+        // -- process-global spoiler latches (see vm_jit::CONTAINER_CELLS /
+        // CALLER_VAR_BINDS): both zero ⟺ the resolve_binding and env
+        // cell-adoption probes are provably no-ops everywhere.
+        let cells_addr = std::ptr::addr_of!(super::vm_jit::CONTAINER_CELLS) as usize;
+        let cells_addr = b.ins().iconst(self.ptr_ty, cells_addr as i64);
+        let cells = b.ins().load(types::I32, Self::mf(), cells_addr, 0);
+        let binds_addr = std::ptr::addr_of!(super::vm_jit::CALLER_VAR_BINDS) as usize;
+        let binds_addr = b.ins().iconst(self.ptr_ty, binds_addr as i64);
+        let binds = b.ins().load(types::I32, Self::mf(), binds_addr, 0);
+        let global_spoil = b.ins().bor(cells, binds);
+        // -- per-interpreter spoiler flags (plain bool fields, 0 or 1).
+        let atomic = b
+            .ins()
+            .load(types::I8, Self::mf(), self.interp, self.lay.atomic_var_seen);
+        let sigil = b.ins().load(
+            types::I8,
+            Self::mf(),
+            self.interp,
+            self.lay.sigilless_attrs_active,
+        );
+        let interp_spoil = b.ins().bor(atomic, sigil);
+        let interp_spoil = b.ins().uextend(types::I32, interp_spoil);
+        let spoiled = b.ins().bor(global_spoil, interp_spoil);
+        let word_chk = b.create_block();
+        b.ins().brif(spoiled, slow_blk, &[], word_chk, &[]);
+
+        // -- slot word load (bounds-checked: a non-standard runner may have
+        // installed a shorter locals vec; the shim handles that shape).
+        b.switch_to_block(word_chk);
+        let lptr = b.ins().load(
+            self.ptr_ty,
+            Self::mf(),
+            self.interp,
+            self.lay.locals + self.lay.vec_ptr,
+        );
+        let llen = b.ins().load(
+            types::I64,
+            Self::mf(),
+            self.interp,
+            self.lay.locals + self.lay.vec_len,
+        );
+        let inbounds = b
+            .ins()
+            .icmp_imm(IntCC::UnsignedGreaterThan, llen, idx as i64);
+        let tag_chk = b.create_block();
+        b.ins().brif(inbounds, tag_chk, &[], slow_blk, &[]);
+
+        b.switch_to_block(tag_chk);
+        let word = b.ins().load(types::I64, Self::mf(), lptr, (idx as i32) * 8);
+        // Refcount-free scalar probe: small Int page, encoded-Num page range,
+        // Bool kind, or Package kind. Everything else (Nil included — the arm
+        // has a whole undeclared-check branch for it) goes to the shim.
+        let page = self.page(b, word);
+        let is_int = self.is_int_page(b, page);
+        let is_num = self.is_num_page(b, page);
+        let masked = b.ins().band_imm(word, w::KIND_MASK as i64);
+        let is_bool = b
+            .ins()
+            .icmp_imm(IntCC::Equal, masked, w::BOOL_PATTERN as i64);
+        let is_pkg = b
+            .ins()
+            .icmp_imm(IntCC::Equal, masked, w::PACKAGE_PATTERN as i64);
+        let num_or_int = b.ins().bor(is_int, is_num);
+        let inline_kind = b.ins().bor(is_bool, is_pkg);
+        let ok = b.ins().bor(num_or_int, inline_kind);
+        let push_chk = b.create_block();
+        b.ins().brif(ok, push_chk, &[], slow_blk, &[]);
+
+        // -- push (only a full stack falls back, mirroring emit_load_const).
+        b.switch_to_block(push_chk);
+        let sptr = self.stack_ptr(b);
+        let slen = self.stack_len(b);
+        let scap = self.stack_cap(b);
+        let full = b.ins().icmp(IntCC::Equal, slen, scap);
+        let push_blk = b.create_block();
+        b.ins().brif(full, slow_blk, &[], push_blk, &[]);
+        b.switch_to_block(push_blk);
+        let off = b.ins().ishl_imm(slen, 3);
+        let addr = b.ins().iadd(sptr, off);
+        b.ins().store(Self::mf(), word, addr, 0);
+        self.adjust_len(b, slen, 1);
+        b.ins().jump(done, &[]);
+
+        // -- slow path: the Tier A shim re-runs the full interpreter arm.
+        b.switch_to_block(slow_blk);
+        let callee = b.ins().iconst(self.ptr_ty, slow_fn as i64);
+        let idxv = b.ins().iconst(types::I32, idx as i64);
+        let call = b
+            .ins()
+            .call_indirect(self.s_code_u32, callee, &[self.interp, codep, idxv]);
+        let status = b.inst_results(call)[0];
+        let err = b.create_block();
+        let cont = b.create_block();
+        b.ins().brif(status, err, &[], cont, &[]);
+        b.switch_to_block(err);
+        b.ins().return_(&[status]);
+        b.switch_to_block(cont);
         b.ins().jump(done, &[]);
 
         b.switch_to_block(done);

--- a/src/vm/vm_stats.rs
+++ b/src/vm/vm_stats.rs
@@ -417,8 +417,12 @@ pub(crate) fn dump() {
     let jit_compiles = JIT_COMPILES.load(Ordering::Relaxed);
     let jit_entries = JIT_ENTRIES.load(Ordering::Relaxed);
     let jit_bailouts = JIT_BAILOUTS.load(Ordering::Relaxed);
+    // Tier B GetLocal fast-path spoiler latches (J4d): nonzero means every
+    // inline local read fell back to the shim for the rest of the run.
+    let cells = crate::vm::vm_jit::CONTAINER_CELLS.load(Ordering::Relaxed);
+    let caller_binds = crate::vm::vm_jit::CALLER_VAR_BINDS.load(Ordering::Relaxed);
     eprintln!(
-        "[mutsu vm-stats] jit: compiles={jit_compiles} entries={jit_entries} bailouts={jit_bailouts}"
+        "[mutsu vm-stats] jit: compiles={jit_compiles} entries={jit_entries} bailouts={jit_bailouts} container_cells={cells} caller_binds={caller_binds}"
     );
     if let Ok(map) = jit_bailout_by_opcode().lock()
         && !map.is_empty()

--- a/t/jit-getlocal-fastpath.t
+++ b/t/jit-getlocal-fastpath.t
@@ -1,0 +1,75 @@
+use v6;
+use Test;
+
+# Tier B GetLocal inline fast path (ADR-0004 J4d): hot JIT'd bodies read
+# plain scalar locals as raw NaN-box words. These pin the fast set (Int,
+# Num, Bool, Package) and every dynamic spoiler that must force the shim:
+# ContainerRef cells (`:=` / `is rw`), boxed (non-word) values like Str,
+# and Nil-slot declaration checks. Run under the default JIT; CI's
+# jit-stress job re-runs with MUTSU_JIT_THRESHOLD=2.
+
+plan 8;
+
+# 1. Plain Int local, hot recursive body (fast path shape).
+sub sum-to($n) {
+    if $n < 1 { return 0 }
+    return $n + sum-to($n - 1);
+}
+my $r = 0;
+for ^150 { $r = sum-to(60) }
+is $r, 1830, 'hot Int local reads stay correct';
+
+# 2. Num local in a hot loop body.
+my $x = 0.5e0;
+for ^300 { $x = 3.9e0 * $x * (1e0 - $x) }
+ok $x > 0e0 && $x < 1e0, 'hot Num local reads stay in range';
+
+# 3. Bool local read in a hot body.
+sub flip-count($n) {
+    my $b = True;
+    my $c = 0;
+    for ^$n { $c = $c + ($b ?? 1 !! 0); $b = !$b }
+    return $c;
+}
+is flip-count(200), 100, 'hot Bool local reads stay correct';
+
+# 4. Str local (boxed word — must take the shim, values intact).
+sub tag($n) {
+    my $prefix = "v";
+    return $prefix ~ $n;
+}
+my $s = "";
+for ^150 { $s = tag($_) }
+is $s, "v149", 'boxed Str locals still read correctly';
+
+# 5. `is rw` parameter (ContainerRef cell spoiler): the caller's slot and
+#    the callee's param share a cell, so post-call reads must see the write.
+sub bump($v is rw) { $v = $v + 1 }
+my $acc = 0;
+for ^200 { bump($acc) }
+is $acc, 200, 'is-rw cell writes visible through hot caller reads';
+
+# 6. `:=` bound alias read in a hot loop: both names track one cell.
+my $src = 0;
+my $alias := $src;
+for ^200 { $src = $src + 1; $r = $alias }
+is $r, 200, 'bound alias reads track the shared cell';
+
+# 7. Type-object (Package word) local read in a hot body.
+sub type-name($n) {
+    my $t = Int;
+    return $t.^name ~ $n;
+}
+my $tn = "";
+for ^150 { $tn = type-name($_) }
+is $tn, "Int149", 'Package-word locals read correctly';
+
+# 8. Nil-slot read (undeclared-check branch must still fire via the shim):
+#    a declared-but-Nil local reads as Any, not a crash.
+sub niler() {
+    my $u;
+    return $u.defined;
+}
+my $d = True;
+for ^150 { $d = niler() }
+nok $d, 'Nil slots keep the interpreter declaration semantics';


### PR DESCRIPTION
## Summary

First slice of **J4d** (ADR-0004 — Tier B variable-op inlining), driven by fresh `perf` profiles of `fib` and a 3M-iteration Num loop with JIT on:

### 1. Lock-free settled-range cache for hot-loop entry (J4b infra fix)

`try_enter_range` paid a `Mutex` lock + linear scan + `Arc` clone on **every iteration** of every compound loop — 11.9% of the hot Num loop. Settled ranges (compiled fn pointer or bailout) are now published into a write-once lock-free `(key, entry)` cache (4 slots) on `JitCodeState`; the steady state resolves the native body with two atomic loads. Overflow/cold ranges keep the mutex path (correct, just slower). After: 3.1%.

### 2. Tier B inline `GetLocal` fast path

`GetLocal` in a JIT'd body always called the Tier A shim, re-running the full `exec_get_local_op` guard chain — including a **per-read `env().get_sym` cell-adoption probe** (a hash lookup on every local read). Tier B now emits the read inline: when no dynamic spoiler exists and the slot word is a refcount-free scalar (small Int / Num / Bool / Package), the read is two loads + a store, with zero refcount/GC traffic. Every other combination calls the unchanged shim.

Soundness is carried by conservative monotonic latches (the `USER_INFIX_DECLS` pattern), never by static analysis of user code:

- **`CONTAINER_CELLS`** — bumped at the *single* NaN-box encode chokepoint for `Kind::ContainerRef`. Zero proves no `:=`/capture cell exists anywhere in the process, so the env cell-adoption probe is provably a no-op. Any live cell word must have passed through this encode before reaching any env, so a zero read is race-free on the reading thread.
- **`CALLER_VAR_BINDS`** — same pattern for `$CALLER::x := ...` aliases (`resolve_binding`'s only writer).
- Per-interpreter `atomic_var_seen` / `sigilless_attrs_active` flags, loaded from native code via `offset_of!`.
- Static exclusions: attribute slots (`local_attr_key`) and `!`/`.`/`@`/`%` names never inline.

`MUTSU_VM_STATS` now reports both latch values on the `jit:` line (both stay 0 on fib/int-arith/num-arith — the fast path is live there).

## Measurements (local release A/B, same machine & method)

| bench | before | after |
|---|---|---|
| 3M-iter Num loop (`$x = 3.9e0 * $x * (1e0 - $x)`), JIT on | 1.09s | **0.62s (−43%)** |
| same, JIT off (interpreter baseline) | ~0.92s | ~0.92s |
| fib(25) JIT on | 0.136s | ~0.07s |

Notably, JIT on previously **lost** to the interpreter on the Num-loop shape (1.09 vs 0.92) because the per-iteration `try_enter_range` overhead outweighed the native body; it now wins by 33%. Authoritative ratios come from bench CI (`bench-data`) after merge.

Profile shift (Num loop, JIT on): `try_enter_range` 11.9% → 3.1%; `exec_get_local_op` + `get_local` shim (~4%) disappear from the top. Remaining loop cost is the `SetLocal` env-mirror chain (`Symbol::intern`/TLS ~35%) — that is interpreter-side and queued as the next J4d slice, along with JIT→JIT per-call bind inlining and args-Vec-alloc removal (the fib profile: `call_compiled_function_positional_light` 19% + `Env::scoped_child`/drop ~14%).

## Tests

- New pin `t/jit-getlocal-fastpath.t`: the fast word set (Int/Num/Bool/Package) plus every spoiler (`is rw` cells, `:=` aliases, boxed Str, Nil declaration checks) — passes with `MUTSU_JIT_THRESHOLD=2`, with `MUTSU_JIT=off`, and on raku.
- `make test` green (1704 files / 16784 tests), `cargo test --test jit_diff` green, existing JIT pins (`t/jit-*.t`) green with `MUTSU_JIT_THRESHOLD=2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCtDdpZV9bHh4xwTtUAZAk