### PR TITLE
perf(vm): J4d slice 2 — kill the per-store intern chain on the SetLocal mirror

### DIFF
--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,29 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-15: J4d 第2弾 — SetLocal ミラーの per-store intern 連鎖除去（#4528）
+
+第1弾（#4527）後の profile で、hot Num ループの残コストは dispatch でなく **SetLocal の
+env-mirror 連鎖が毎ストア名前を intern し直す**ことだった（`Symbol::intern` の TLS だけで
+~29%）。既存機構の再利用のみで 3 点修正:
+
+- **plain lexical の SetLocal ミラー**: `exec_set_local_op_inner` の無条件 env ミラーを、
+  `plain_locals`（シジル/twigil/qualifier 無し = 圧倒的多数の scalar SetLocal）なら
+  pre-interned `locals_sym` で `set_env_plain_lexical`（`flush_local_to_env` と同じ
+  1-Symbol-insert writer）へ。フルミラーの alias 分岐（`Main::` probe + `format!`・twigil
+  ペア・`&infix` alias）はこの名前群では到達不能（#4507 の分析を statement-assignment
+  ミラーにも適用）。
+- **`CheckReadOnly` を pre-interned probe に**: 毎 whole-variable 代入で
+  `check_readonly_for_modify(name)` が名前を intern していたのを
+  `is_readonly_sym(code.const_sym(idx))` に。エラー構築は cold 側に温存。
+- **for-loop topic/param intern の hoist**: `exec_for_loop_int_range` が**毎 iteration**
+  `"_".to_string()` + `Env::insert`（内部 intern）していたのを、topic/param/caret-alias の
+  Symbol をループ前に 1 回 intern し本体は `insert_sym` のみに。
+
+実測（local release・3M-iter Num ループ・本スライス単独 vs pre-J4d main）: JIT on
+1.09s → **0.53s**、**JIT off（インタプリタ基準線）0.92s → 0.70s** — ミラー連鎖は JIT と
+無関係に全 SetLocal で走るため、第1弾と違いインタプリタ側も -24% 速くなる。#4527 と合成。
+
 ## 2026-07-15: 層4 JIT J4d 第1弾 — Tier B GetLocal インライン + hot-loop entry のロック除去（#4527）
 
 J4d（ADR-0004・Tier B 変数 op インライン）の最初のスライス。JIT on の fib / Num ループを

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4338,7 +4338,14 @@ impl Interpreter {
                         return Ok(());
                     }
                 }
-                self.check_readonly_for_modify(name)?;
+                // Probe through the pre-interned constant Symbol: this opcode
+                // runs on every whole-variable assignment (per iteration in
+                // tight loops), and `check_readonly_for_modify(name)` would
+                // re-intern the name on each execution just to miss the set.
+                // The error construction (readonly hit) is the cold path.
+                if self.is_readonly_sym(code.const_sym(*name_idx)) {
+                    self.check_readonly_for_modify(name)?;
+                }
                 // Also check env-based readonly status set by cross-scope
                 // `:=` binding (e.g. binding to a readonly sub parameter
                 // in a closure).  The readonly_vars set is scope-local

--- a/src/vm/vm_for_loop_intrange.rs
+++ b/src/vm/vm_for_loop_intrange.rs
@@ -75,21 +75,44 @@ impl Interpreter {
         // local slot for much better performance in tight loops.
         let use_local_only = spec.param_local.is_some() && param_name.is_none();
 
+        // Pre-intern the per-iteration env keys once (J4d): `Env::insert` is
+        // `note_env_key` + `Symbol::intern` + `insert_sym`, and interning the
+        // same key (plus a `String` alloc for it) on every iteration profiled
+        // at ~3% of a hot numeric loop. The careted-placeholder alias pair is
+        // resolved here too, so the loop body is one or two `insert_sym`s.
+        let topic_sym = (!use_local_only && param_name.is_none()).then(|| {
+            crate::env::note_env_key("_");
+            crate::symbol::Symbol::intern("_")
+        });
+        let param_sym = param_name.as_ref().map(|name| {
+            crate::env::note_env_key(name);
+            crate::symbol::Symbol::intern(name)
+        });
+        let caret_alias_sym = param_name.as_ref().and_then(|name| {
+            let alias = if let Some(bare) = name.strip_prefix("&^") {
+                format!("&{}", bare)
+            } else if let Some(bare) = name.strip_prefix('^') {
+                bare.to_string()
+            } else {
+                return None;
+            };
+            crate::env::note_env_key(&alias);
+            Some(crate::symbol::Symbol::intern(&alias))
+        });
+
         // Use <= for inclusive ranges instead of end_val + 1 to avoid overflow
         // when end_val is i64::MAX
         'for_loop: while if inclusive { i <= end_val } else { i < end_val } {
             let item = Value::int(i);
             self.topic_source_var = None;
 
-            if !use_local_only && param_name.is_none() {
-                self.env_mut().insert("_".to_string(), item.clone());
+            if let Some(sym) = topic_sym {
+                self.env_mut().insert_sym(sym, item.clone());
             }
-            if let Some(ref name) = param_name {
-                self.env_mut().insert(name.clone(), item.clone());
-                if let Some(bare) = name.strip_prefix("&^") {
-                    self.env_mut().insert(format!("&{}", bare), item.clone());
-                } else if let Some(bare) = name.strip_prefix('^') {
-                    self.env_mut().insert(bare.to_string(), item.clone());
+            if let Some(sym) = param_sym {
+                self.env_mut().insert_sym(sym, item.clone());
+                if let Some(alias) = caret_alias_sym {
+                    self.env_mut().insert_sym(alias, item.clone());
                 }
             }
             if let Some(slot) = spec.param_local {

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1589,6 +1589,14 @@ impl Interpreter {
             // For `:=` bind and `constant @x`, bypass set_shared_var's
             // List->Array normalization so the container type is preserved.
             self.env_mut().insert(name.to_string(), val.clone());
+        } else if code.plain_locals.get(idx).copied().unwrap_or(false) {
+            // Plain lexical (no sigil/twigil/qualifier — the overwhelmingly
+            // common SetLocal): every alias branch of the full mirror is
+            // unreachable, so take the one-Symbol-insert writer and skip the
+            // per-store `Symbol::intern` + `Main::` probe (J4d; profiled at
+            // ~12% of a hot Num loop). Same writer flush_local_to_env uses.
+            let sym = code.locals_sym.get(idx).copied();
+            self.set_env_plain_lexical(name, sym, val.clone());
         } else {
             self.set_env_with_main_alias(name, val.clone());
         }


### PR DESCRIPTION
## Summary

Second J4d slice. The post-#4527 profile of a hot Num loop (`$x = 3.9e0 * $x * (1e0 - $x)` ×3M, JIT on) showed the remaining cost is not dispatch but the **SetLocal env-mirror chain re-interning names on every store** — `Symbol::intern`'s thread-local cache alone was ~29% of cycles. Three mechanical fixes, all reusing existing machinery (no new mechanisms):

1. **Plain-lexical SetLocal mirror**: `exec_set_local_op_inner`'s unconditional env mirror now routes plain lexicals (`CompiledCode::plain_locals` — no sigil/twigil/qualifier, i.e. the overwhelmingly common scalar `SetLocal`) through `set_env_plain_lexical` with the pre-interned `locals_sym` — the same one-Symbol-insert writer `flush_local_to_env` already uses. Every alias branch of the full `set_env_with_main_alias_sym` (`Main::` probe + `format!`, `$*x`/`*x` twigil pair, `&infix:<>` alias) is unreachable for such names (#4507's analysis, now applied to the statement-assignment mirror too).

2. **`CheckReadOnly` via pre-interned Symbol**: the opcode probed the readonly set through `check_readonly_for_modify(name)`, interning the name on every whole-variable assignment. It now probes `is_readonly_sym(code.const_sym(idx))`; the error construction stays on the cold readonly-hit path.

3. **for-loop topic/param intern hoist**: `exec_for_loop_int_range` built a fresh `"_".to_string()` (or cloned the param-name `String`) and re-interned it inside `Env::insert` on **every iteration**. The topic/param/caret-alias Symbols are interned once before the loop; the body does `insert_sym` only. (`Env::insert` ≡ `note_env_key` + `intern` + `insert_sym`, so hoisting the first two is exactly equivalent.)

## Measurements (local release A/B, same machine & method, 3M-iter Num loop)

| config | main (pre-J4d) | this slice alone | slice 1 (#4527) alone |
|---|---|---|---|
| JIT on | 1.09s | **0.53s** | 0.62s |
| JIT off (interpreter) | 0.92s | **0.70s** | 0.92s |

The two slices compose (this branch is rebased on #4527); authoritative combined numbers come from bench CI after merge. Unlike slice 1, this slice also speeds up the **interpreter baseline** (−24%), since the mirror chain runs on every SetLocal regardless of JIT.

## Tests

`make test` green (1703 files / 16776 tests) pre-rebase; post-rebase re-verified with the JIT pins (`t/jit-getlocal-fastpath.t`, `t/jit-hot-loop.t`, `t/jit-tier-b-arith.t`) plus `t/lock.t` / `t/wrap.t` under `MUTSU_JIT_THRESHOLD=2`, and JIT on/off output equality on the Num loop. CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCtDdpZV9bHh4xwTtUAZAk