### PR TITLE
perf(vm): J4d slice 3 — make the light-call ceremony allocation-free

### DIFF
--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -5,6 +5,27 @@
 7月は 6月末からの流れを引き継ぎ、dispatch cluster（wrap/dispatching）と S17 並行実行基盤の残件を
 まとめて前進させた。detailed な残件・進行中の分析は [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md) を参照。
 
+## 2026-07-15: J4d 第3弾 — light-call 儀式の alloc-free 化（#4529）
+
+第2弾後も fib は per-call 儀式が ~50%。健全性を変えない 3 カット:
+
+- **`Env::scoped_child` を定常状態 alloc-free に**: 毎呼び出し `Arc` ×2（空 overlay map の新規
+  確保 + walk 先 parent の Env clone→再 Arc 包み）だったのを、空ティア walk で既存 parent `Arc`
+  をそのまま再利用 + 空 overlay はプロセス共有シングルトン（初回 insert 時に `cow_mut` の
+  `Arc::make_mut` が CoW で複製 = 挙動不変）に。`ptr_eq` 消費側も影響なし（シングルトン共有 =
+  双方空 = 「merge 不要」の判定はどのみち正しい）。
+- **param slot の seed skip**: `positional_light` が全 local を env から seed していたが、
+  param slot は直後の bind で無条件上書き（arity 不足は seed 前に early return 済み）＝純粋な
+  無駄。fib のような all-params ボディでは seed（毎呼び出しの overlay chain ハッシュ walk）が
+  丸ごと消える。
+- **args Vec の pool 再利用**: pos-light call site の `stack.drain(..).collect::<Vec>()`
+  （最hot経路で毎呼び出し malloc/free）を locals pool 借用+recycle に。
+
+累計実測（local release・pre-J4d main 比）: fib(28) JIT on ~0.4s → **0.23s**、3M-iter Num
+ループ 1.09s → **0.39s（-64%）**。fib profile: `positional_light` 19.3→12.8%・
+`scoped_child`/seed walk 消滅。残 = `exec_call_func_op` 本体（cache probe・junction scan・
+`peek_callsite_line`）＝後続スライス候補。
+
 ## 2026-07-15: J4d 第2弾 — SetLocal ミラーの per-store intern 連鎖除去（#4528）
 
 第1弾（#4527）後の profile で、hot Num ループの残コストは dispatch でなく **SetLocal の

--- a/src/env.rs
+++ b/src/env.rs
@@ -302,6 +302,18 @@ pub struct Env {
 /// deep recursion ever hits it, paying one O(env) flatten per this many frames.
 const MAX_OVERLAY_DEPTH: u16 = 16;
 
+/// Process-wide shared empty overlay map for fresh scoped children. A brand-new
+/// overlay is always empty, so every frame can share one allocation: the first
+/// `insert` goes through `cow_mut`'s `Arc::make_mut`, which sees the shared
+/// refcount and clones the (empty) map into a private one — plain
+/// copy-on-write, no behavioral difference. `Env::ptr_eq` consumers are
+/// unaffected: two envs sharing this map are both empty, and any write
+/// un-shares the writer before it can be observed.
+fn empty_overlay() -> Arc<SymMap> {
+    static EMPTY: std::sync::OnceLock<Arc<SymMap>> = std::sync::OnceLock::new();
+    EMPTY.get_or_init(|| Arc::new(SymMap::default())).clone()
+}
+
 impl Env {
     pub(crate) fn new() -> Self {
         Self {
@@ -345,14 +357,40 @@ impl Env {
         // writes) then runs at constant chain depth and never triggers the
         // MAX_OVERLAY_DEPTH flatten — which was measured at >40% of fib(25)
         // wall time (HashMap deep clone + drop per flatten).
-        while parent.inner.is_empty() && parent.tombstones.is_none() {
-            match &parent.parent {
-                Some(gp) => {
-                    let gp = Env::clone(gp);
-                    parent = gp;
-                }
-                None => break,
+        //
+        // J4d: the walked-to tier is reused as its existing `Arc` (instead of
+        // cloning the `Env` out and re-wrapping it in a fresh `Arc`), and the
+        // new empty overlay shares the process-wide [`empty_overlay`] map
+        // (copy-on-write on first insert via `cow_mut`'s `Arc::make_mut`).
+        // Steady-state recursion therefore allocates nothing here — the two
+        // `Arc::new`s per call were ~14% of fib with the JIT on.
+        if parent.inner.is_empty()
+            && parent.tombstones.is_none()
+            && let Some(gp) = parent.parent.take()
+        {
+            let mut arc = gp;
+            while arc.inner.is_empty()
+                && arc.tombstones.is_none()
+                && let Some(gp) = &arc.parent
+            {
+                let gp = Arc::clone(gp);
+                arc = gp;
             }
+            if arc.depth >= MAX_OVERLAY_DEPTH {
+                let flat = arc.flattened();
+                return Self {
+                    inner: empty_overlay(),
+                    depth: flat.depth + 1,
+                    parent: Some(Arc::new(flat)),
+                    tombstones: None,
+                };
+            }
+            return Self {
+                inner: empty_overlay(),
+                depth: arc.depth + 1,
+                parent: Some(arc),
+                tombstones: None,
+            };
         }
         let parent = if parent.depth >= MAX_OVERLAY_DEPTH {
             parent.flattened()
@@ -360,7 +398,7 @@ impl Env {
             parent
         };
         Self {
-            inner: Arc::new(SymMap::default()),
+            inner: empty_overlay(),
             depth: parent.depth + 1,
             parent: Some(Arc::new(parent)),
             tombstones: None,

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -177,7 +177,12 @@ impl Interpreter {
                             Self::call_shares_container_into_scalar_param(cf, stack_args);
                         if !has_junction && !share_into_scalar {
                             let start = self.stack.len() - arity_usize;
-                            let args: Vec<Value> = self.stack.drain(start..).collect();
+                            // Pooled args buffer (J4d): `drain(..).collect()`
+                            // was one malloc/free per call on the hottest call
+                            // path; the locals pool already recycles
+                            // `Vec<Value>`s, so borrow it for the args too.
+                            let mut args = self.take_locals_from_pool(0);
+                            args.extend(self.stack.drain(start..));
                             // Extract callsite line for deprecation tracking
                             let cl = crate::runtime::Interpreter::peek_callsite_line(&args);
                             if cl.is_some() {
@@ -188,8 +193,9 @@ impl Interpreter {
                                 &args,
                                 compiled_fns,
                                 name_str,
-                            )?;
-                            self.stack.push(result);
+                            );
+                            self.recycle_locals(args);
+                            self.stack.push(result?);
                             // Slice F: drain any captured-outer writes the body
                             // recorded through to this caller frame's local slots
                             // (the slow dispatch path drains too; the cached fast

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -68,9 +68,16 @@ impl Interpreter {
         // local that shadows a same-named caller variable, matching the prior
         // env().get() semantics. `locals_sym` is `locals` pre-interned at
         // finalize(), so the seed loop hashes a `u32` per local instead of
-        // re-interning the name string on every call.
+        // re-interning the name string on every call. Param slots are skipped
+        // (J4d): the bind loop below overwrites them unconditionally (the
+        // arity check already returned on a shortfall), so seeding them is a
+        // wasted overlay-chain walk per call — for an all-params body like
+        // `fib` the whole seed disappears.
         if cf.code.locals_sym.len() == num_locals {
             for (i, sym) in cf.code.locals_sym.iter().enumerate() {
+                if param_slots.contains(&i) {
+                    continue;
+                }
                 if let Some(val) = self.env().get_sym(*sym) {
                     self.locals[i] = val.clone();
                 }
@@ -78,6 +85,9 @@ impl Interpreter {
         } else {
             // Hand-built chunk with no pre-interned locals: resolve by name.
             for (i, local_name) in cf.code.locals.iter().enumerate() {
+                if param_slots.contains(&i) {
+                    continue;
+                }
                 if let Some(val) = self.env().get(local_name) {
                     self.locals[i] = val.clone();
                 }


### PR DESCRIPTION
## Summary

Third J4d slice. After #4527/#4528, the fib profile still spent ~50% in the **per-call ceremony** around the JIT'd body (`call_compiled_function_positional_light` 19.3% + `Env::scoped_child` 5.8% + `drop_in_place<Env>` ~8% + the env seed's `get_sym` chain walk ~6% + malloc/free). Three sound, semantics-preserving cuts:

1. **`Env::scoped_child` is now allocation-free in the steady state.** It allocated two `Arc`s per call: a fresh empty overlay `SymMap` and a re-wrap of the walked-to parent `Env`. The empty-tier walk now reuses the existing parent `Arc` directly, and every fresh overlay shares one process-wide empty map that copy-on-writes on first insert (`cow_mut` is already `Arc::make_mut`, which un-shares before any write). `ptr_eq` consumers are unaffected: two envs sharing the empty singleton are both empty — "nothing to merge" is the correct verdict either way.

2. **Param-slot seed skip**: `call_compiled_function_positional_light` seeded *every* local from the env by name — including param slots, which the bind loop overwrites unconditionally right after (the arity check has already early-returned on a shortfall). Param slots are now skipped; for an all-params body like `fib` the entire seed (an overlay-chain hash walk per call) disappears.

3. **Pooled args buffer**: the positional-light call site drained the stack into a fresh `Vec<Value>` per call (`drain(..).collect()` = one malloc/free on the hottest call path). It now borrows a vec from the existing locals pool and recycles it after the call.

## Measurements (local release, same machine/method — all three J4d slices combined vs pre-J4d main)

| bench | pre-J4d | after #4528 | this PR |
|---|---|---|---|
| fib(28), JIT on | ~0.4s | 0.30s | **0.23s** |
| 3M-iter Num loop, JIT on | 1.09s | 0.53s | **0.39s (−64% cumulative)** |

fib profile shift: `positional_light` 19.3% → 12.8%; `Env::scoped_child` and the seed `get_sym` walk disappear from the top. Remaining call-path cost is `exec_call_func_op` itself (cache probes / junction scan / `peek_callsite_line`) — a candidate for a later slice. Authoritative ratios from bench CI after merge.

## Tests

`make test` green (1706 files / 16810 tests), including the J4d pins from #4527/#4528 (`t/jit-getlocal-fastpath.t`, `t/jit-hot-loop.t`). Env-scoping roast spot checks (`S06-signature/positional.t`, `S04-declarations/my-6e.t`, `S02-names/name.t`) green. The Env change is exercised by every call in the suite; CI runs the full roast as the comprehensive net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCtDdpZV9bHh4xwTtUAZAk