### PR TITLE
docs: update PLAN J4d status after slices 1-3

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -179,15 +179,18 @@ HTTP::Parser / MIME::Base64 / HTTP::Server::Tiny（end-to-end HTTP 配信）/ Tu
 
 - [ ] **層4 JIT（Cranelift・= §5 Lever 4）— J1〜J5 完了・既定 on（2026-07-13）**
       （J1 #4471・J2 #4474・J3 #4476・J4 #4478/#4479/#4480・J5 既定 on 切替、
-      詳細 = news/2026-07.md）。J4d 第1弾（#4527: Tier B GetLocal インライン +
-      hot-loop entry の per-iteration ロック除去 — Num ループ -43%）完了。残スライス:
-      **J4d 続き** = [ADR-0004](docs/adr/0004-jit-strategy.md):
-      ① SetLocal の env-mirror 連鎖（`Symbol::intern`/TLS ~35% — インタプリタ側、
-      `set_env_with_main_alias_sym`→`set_shared_var_sym` の再 intern と for-loop の
-      per-iteration topic insert が主犯・profile = news 2026-07-15 の項）
-      ② JIT→JIT per-call bind インライン（fib profile:
-      `call_compiled_function_positional_light` 19% + `Env::scoped_child`/drop ~14%）
-      ③ args Vec alloc 除去。ベンチ数字の正本は bench CI
+      詳細 = news/2026-07.md）。**J4d 第1〜3弾（#4527 GetLocal インライン+range cache /
+      #4528 SetLocal intern 連鎖 / #4529 light-call 儀式 alloc-free）完了** —
+      累計 local 実測: 3M-iter Num ループ 1.09→0.39s（-64%）・fib(28) ~0.4→0.23s。
+      残スライス = [ADR-0004](docs/adr/0004-jit-strategy.md):
+      ① **`exec_call_func_op` 本体**（fib after-profile 15% — pos-light cache probe の
+      name-hash・junction scan・`peek_callsite_line`。CallFunc opcode への per-call-site
+      inline cache が本命候補）
+      ② **JIT→JIT 直接呼び出し**（Tier B CallFunc インライン）
+      ③ 済んだら **J4 の「int ループ 5-10x」ゲートを bench CI で再判定**して ADR-0004 に
+      追記しクローズ（現状 Num ループ on/off 比 ~1.8x — 共通固定費が残るため。
+      SetLocal env-mirror の根治は §6 lexical-slot campaign 側）。
+      ベンチ数字の正本は bench CI
       （`bench-data` ブランチ・`+jit` 系列は #4480 から・J5 以降 plain 系列は
       `MUTSU_JIT=off` 明示 pin のインタプリタ基準線）。
 - [ ] **3b-2 traffic pruning**（[docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) §3.3）:


### PR DESCRIPTION
PLAN §2 の J4d 項を実態に更新: 第1〜3弾（#4527/#4528/#4529）完了を反映し、残スライスを ① exec_call_func_op inline cache ② JIT→JIT 直接呼び出し ③ 5-10x ゲート再判定 に書き換え。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCtDdpZV9bHh4xwTtUAZAk