### PR TITLE
fix: resolve all 5 hang/timeout roast blockers (BLOCKERS cluster ③)

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -52,7 +52,7 @@ S\* 系 24 本しか載せておらず、`integration/` 41 本・`6.c/` 7 本・
 |---|---|---|---|
 | **① スタックオーバーフローで abort**（★同じ症状で原因は 4 つ別々 — 下節参照） | **完了** | `99problems-41-to-50.t`(#4510)・`99problems-51-to-60.t`(#4516)・`man-or-boy.t`（`&`-シジル free var スキャン + vouch — 下節）は無限再帰で修正済み、`deep-recursion-initing-native-array.t` は debug 計測の誤診（release では元から通る）＝whitelist 追加 | `fatal runtime error: stack overflow, aborting`（プロセス abort）。**4 本のうち 3 本は無限再帰、1 本は計測ミス。「本当に深い再帰でスタックが足りない」ものは 1 本も無かった** |
 | **② パース不能（`===SORRY!===`）** | **0（完了）** | 10 本すべて解消（#4511 / #4514 / #4515 / #4517 / #4518 / #4522） | **このクラスタは枯渇。** 7 本が whitelist 到達、3 本はパースを通過して機能ギャップへ移行 — 下の「② の内訳」参照 |
-| **③ ハング / タイムアウト** | 5 | `advent2012-day21.t`・`advent2013-day14.t`・`gather-with-loops.t`・`APPENDICES/A01-limits/{misc,overflow}.t` | 25s で打ち切り。gather×loop の遅延評価と limit 系 |
+| **③ ハング / タイムアウト** | **完了** | 5 本すべて whitelist 到達（2026-07-15）: `gather-with-loops.t`（`next`/`redo` で終わったイテレーションの state 書き込み喪失＋sibling gather 間の state キー衝突＋ネストループの state 非リセット）・`advent2013-day14.t`（whenever ブロックの placeholder パラメータ非バインド＋thread 内再宣言の親レキシカル clobber）・`APPENDICES/A01-limits/misc.t`（`x` 演算子の O(n) push ループ→倍々 memcpy 化で 4GiB 文字列が数秒に＋異 role 間 multi method 合成＋where 節の動的変数副作用保持）・`overflow.t`（巨大指数 `**` の X::Numeric::Overflow/Underflow Failure 化＋worker thread からの `exit` のプロセス終了＋`say` の未 handled Failure 爆発）・`advent2012-day21.t`（純粋な速度ストレス — debug 102s/release は余裕。per-file timeout 120s を設定） | — |
 | **④ エラーメッセージ品質** | 2 | `error-reporting.t`（mutsu 4/33・raku 33/33）・`weird-errors.t`（26/36） | 「Parse error contains line number」等、**例外の文面・行番号・バックトレース**を検査するテスト。PLAN §6「エラーメッセージ品質向上」と同一の的 |
 | **⑤ 個別機能ギャップ** | 残り | `advent2009-day24.t`（派生 grammar の拡張）・`advent2010-day14.t`（`nextsame` の継承/mixin）・`advent2010-day22.t`（`Rat` の `$!numerator`/`$!denominator` 属性）・`advent2011-day07.t`（`Metamodel::GrammarHOW` 継承）・`advent2011-day10.t`（`--doc` / `DOC INIT {}`）・`advent2009-day20.t`（signature の introspection/stringification）・`advent2009-day18.t`（パラメタ化 role の mixin）・`advent2013-day10.t`（`:round` 等の演算子 adverb）・`precompiled.t`（precomp） | 1 ファイル数本ずつ。★の近道はここ |
 
@@ -226,6 +226,7 @@ postfix** が、項に対して一切適用されない（`4.7k` が SORRY）。
 1. ~~**① の残り 1 本 = `man-or-boy.t`**~~ **完了**（2026-07-15・whitelist 追加。
    「man-or-boy の診断」節の解決記録を参照）。①クラスタは全消化。
    ②パース不能クラスタも #4522 で全消化（上の表参照）。
+2. ~~**③ ハング / タイムアウト（5 本）**~~ **完了**（2026-07-15・5 本すべて whitelist 追加 — 表の ③ 行を参照）。
 3. **近道**: `6.c/S04-declarations/my-6c.t` は `OUTER::<$x>` の 1 subtest だけ
    （111/112）。`advent2011-day04.t` は 1/2。
 4. **④ エラーメッセージ品質**（`error-reporting.t` 4/33）は PLAN §6 の同名タスクと同じ的なので、

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -28,6 +28,8 @@ roast/6.d/S32-str/sprintf-s.t
 roast/6.d/S32-str/sprintf-u.t
 roast/6.d/S32-str/sprintf-x.t
 roast/6.d/S32-str/sprintf.t
+roast/APPENDICES/A01-limits/misc.t
+roast/APPENDICES/A01-limits/overflow.t
 roast/APPENDICES/A02-some-day-maybe/concreteness.t
 roast/APPENDICES/A02-some-day-maybe/io-cathandle.t
 roast/MISC/bug-coverage-6.d.t
@@ -1353,6 +1355,7 @@ roast/integration/advent2012-day13.t
 roast/integration/advent2012-day16.t
 roast/integration/advent2012-day19.t
 roast/integration/advent2012-day20.t
+roast/integration/advent2012-day21.t
 roast/integration/advent2012-day22.t
 roast/integration/advent2012-day24.t
 roast/integration/advent2013-day02.t
@@ -1361,6 +1364,7 @@ roast/integration/advent2013-day06.t
 roast/integration/advent2013-day07.t
 roast/integration/advent2013-day09.t
 roast/integration/advent2013-day12.t
+roast/integration/advent2013-day14.t
 roast/integration/advent2013-day15.t
 roast/integration/advent2013-day19.t
 roast/integration/advent2013-day20.t
@@ -1374,6 +1378,7 @@ roast/integration/deep-recursion-initing-native-array.t
 roast/integration/diamond.t
 roast/integration/eval-and-threads.t
 roast/integration/failure-and-callsame.t
+roast/integration/gather-with-loops.t
 roast/integration/lazy-bentley-generator.t
 roast/integration/lexical-array-in-inner-block.t
 roast/integration/lexicals-and-attributes.t

--- a/scripts/run-roast-test.sh
+++ b/scripts/run-roast-test.sh
@@ -68,6 +68,24 @@ per_file_timeout() {
       # infinite sequences with head() truncation. Release builds take ~15s.
       echo 60
       ;;
+    roast/integration/advent2012-day21.t)
+      # A Collatz benchmark shoot-out: 8 sub-programs each computing 402
+      # collatz lengths in a subprocess (Test::Util::run). Pure wall-clock
+      # stress (~100s debug); give release headroom under -j4 contention.
+      echo 120
+      ;;
+    roast/integration/advent2013-day14.t)
+      # Promise/Channel pipeline with fixed sleeps (sleep 1/3/7 exchanges
+      # capped by Promise.in(5), plus a 2s .then chain) — ~12s of wall-clock
+      # waiting regardless of build, needs headroom under CI load.
+      echo 60
+      ;;
+    roast/APPENDICES/A01-limits/misc.t)
+      # Declares a 4 GiB native string ("a" x 2**32-1): allocation +
+      # doubling-memcpy build takes ~9s locally and is memory-bandwidth
+      # bound, so give CI runners headroom.
+      echo 90
+      ;;
     *)
       echo "$DEFAULT_TIMEOUT"
       ;;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1915,11 +1915,13 @@ fn collect_ph_stmt_shallow(stmt: &Stmt, out: &mut Vec<String>) {
                 collect_ph_stmt_shallow(s, out);
             }
         }
-        Stmt::Whenever { supply, body, .. } => {
+        Stmt::Whenever { supply, .. } => {
+            // A whenever body is its own block scope: a placeholder inside it
+            // (`whenever $ch { %^content.kv }`) is the WHENEVER block's
+            // parameter (bound to the emitted value), not the enclosing
+            // block's — attributing it here would give e.g. the surrounding
+            // `start {}` block a phantom arity-1 signature.
             collect_ph_expr_shallow(supply, out);
-            for s in body {
-                collect_ph_stmt_shallow(s, out);
-            }
         }
         Stmt::Block(body)
         | Stmt::SyntheticBlock(body)

--- a/src/builtins/arith/pow_negate.rs
+++ b/src/builtins/arith/pow_negate.rs
@@ -82,9 +82,21 @@ pub(crate) fn arith_pow(left: Value, right: Value) -> Value {
         let mag = wr.exp();
         Value::complex(mag * wi.cos(), mag * wi.sin())
     } else {
+        // Raku refuses to attempt astronomically large integer powers: an
+        // exponent with magnitude >= 2**32 yields a soft Failure —
+        // X::Numeric::Overflow for a positive exponent, X::Numeric::Underflow
+        // for a negative one (A01-limits/overflow.t; bases 0/±1 still compute).
+        const POW_EXP_LIMIT: i64 = 4_294_967_296;
         match (l.view(), r.view()) {
             (ValueView::Int(a), ValueView::Int(b)) if b >= 0 => {
-                if let Some(result) = a.checked_pow(b as u32) {
+                if b >= POW_EXP_LIMIT {
+                    match a {
+                        0 => Value::int(0),
+                        1 => Value::int(1),
+                        -1 => Value::int(if b % 2 == 0 { 1 } else { -1 }),
+                        _ => RuntimeError::numeric_overflow_failure(),
+                    }
+                } else if let Some(result) = a.checked_pow(b as u32) {
                     Value::int(result)
                 } else {
                     // Overflow: use BigInt
@@ -94,14 +106,33 @@ pub(crate) fn arith_pow(left: Value, right: Value) -> Value {
                 }
             }
             (ValueView::Int(a), ValueView::Int(b)) => {
+                if b <= -POW_EXP_LIMIT {
+                    return match a {
+                        0 => Value::num(f64::INFINITY),
+                        1 => Value::int(1),
+                        -1 => Value::int(if b % 2 == 0 { 1 } else { -1 }),
+                        _ => RuntimeError::numeric_underflow_failure(),
+                    };
+                }
                 let pos = (-b) as u32;
                 if let Some(base) = a.checked_pow(pos) {
                     make_rat(1, base)
                 } else {
-                    Value::num(1.0 / (a as f64).powi(pos as i32))
+                    // The exact reciprocal is out of integer range; degrade to
+                    // float. A result rounding to 0.0 is a numeric underflow
+                    // (raku: 2**-1074 is 5e-324, 2**-1075 is a Failure).
+                    let result = (a as f64).powf(b as f64);
+                    if result == 0.0 && a != 0 {
+                        RuntimeError::numeric_underflow_failure()
+                    } else {
+                        Value::num(result)
+                    }
                 }
             }
             (ValueView::Rat(n, d), ValueView::Int(b)) if b >= 0 => {
+                if b >= POW_EXP_LIMIT && n != 0 && n.unsigned_abs() != d.unsigned_abs() {
+                    return RuntimeError::numeric_overflow_failure();
+                }
                 let p = b as u32;
                 if let (Some(np), Some(dp)) = (n.checked_pow(p), d.checked_pow(p)) {
                     make_rat(np, dp)
@@ -127,6 +158,9 @@ pub(crate) fn arith_pow(left: Value, right: Value) -> Value {
                 }
             }
             (ValueView::Rat(n, d), ValueView::Int(b)) => {
+                if b <= -POW_EXP_LIMIT && n != 0 && n.unsigned_abs() != d.unsigned_abs() {
+                    return RuntimeError::numeric_underflow_failure();
+                }
                 let p = (-b) as u32;
                 if let (Some(dp), Some(np)) = (d.checked_pow(p), n.checked_pow(p)) {
                     make_rat(dp, np)
@@ -148,6 +182,9 @@ pub(crate) fn arith_pow(left: Value, right: Value) -> Value {
                 }
             }
             (ValueView::FatRat(n, d), ValueView::Int(b)) if b >= 0 => {
+                if b >= POW_EXP_LIMIT && n != 0 && n.unsigned_abs() != d.unsigned_abs() {
+                    return RuntimeError::numeric_overflow_failure();
+                }
                 let p = b as u32;
                 if let (Some(np), Some(dp)) = (n.checked_pow(p), d.checked_pow(p)) {
                     make_fat_rat(np, dp)
@@ -163,6 +200,9 @@ pub(crate) fn arith_pow(left: Value, right: Value) -> Value {
                 }
             }
             (ValueView::FatRat(n, d), ValueView::Int(b)) => {
+                if b <= -POW_EXP_LIMIT && n != 0 && n.unsigned_abs() != d.unsigned_abs() {
+                    return RuntimeError::numeric_underflow_failure();
+                }
                 let p = (-b) as u32;
                 if let (Some(dp), Some(np)) = (d.checked_pow(p), n.checked_pow(p)) {
                     make_fat_rat(dp, np)
@@ -178,10 +218,16 @@ pub(crate) fn arith_pow(left: Value, right: Value) -> Value {
                 }
             }
             (ValueView::BigRat(n, d), ValueView::Int(b)) if b >= 0 => {
+                if b >= POW_EXP_LIMIT && !n.is_zero() && n.magnitude() != d.magnitude() {
+                    return RuntimeError::numeric_overflow_failure();
+                }
                 let p = b as u32;
                 make_big_rat_arith(n.pow(p), d.pow(p))
             }
             (ValueView::BigRat(n, d), ValueView::Int(b)) => {
+                if b <= -POW_EXP_LIMIT && !n.is_zero() && n.magnitude() != d.magnitude() {
+                    return RuntimeError::numeric_underflow_failure();
+                }
                 let p = (-b) as u32;
                 make_big_rat_arith(d.pow(p), n.pow(p))
             }
@@ -244,8 +290,14 @@ pub(crate) fn arith_pow(left: Value, right: Value) -> Value {
                     } else {
                         Value::bigint(NumBigInt::from(a).pow(exp_u))
                     }
+                } else if let Some(exp_i) = b.as_ref().to_i64() {
+                    // Negative or 2**32..2**63 exponent: same rules as Int**Int.
+                    arith_pow(Value::int(a), Value::int(exp_i))
+                } else if b.sign() == Sign::Minus {
+                    // |a| > 1 here (0/±1 handled above): soft under/overflow.
+                    RuntimeError::numeric_underflow_failure()
                 } else {
-                    Value::num((a as f64).powf(b.as_ref().to_f64().unwrap_or(f64::INFINITY)))
+                    RuntimeError::numeric_overflow_failure()
                 }
             }
             (ValueView::Num(a), ValueView::BigInt(b)) => {
@@ -266,6 +318,33 @@ pub(crate) fn arith_pow(left: Value, right: Value) -> Value {
                     RuntimeError::numeric_underflow_failure()
                 } else {
                     Value::num(result)
+                }
+            }
+            (
+                ValueView::Rat(..) | ValueView::FatRat(..) | ValueView::BigRat(..),
+                ValueView::BigInt(b),
+            ) => {
+                if let Some(exp_i) = b.as_ref().to_i64() {
+                    arith_pow(l.clone(), Value::int(exp_i))
+                } else {
+                    // Exponent beyond i64: soft failure by exponent sign, unless
+                    // the base is 0 or ±1 (which stay exact).
+                    let (num_zero, mag_one) = match l.view() {
+                        ValueView::Rat(n, d) | ValueView::FatRat(n, d) => {
+                            (n == 0, n.unsigned_abs() == d.unsigned_abs())
+                        }
+                        ValueView::BigRat(n, d) => (n.is_zero(), n.magnitude() == d.magnitude()),
+                        _ => (false, false),
+                    };
+                    if num_zero {
+                        Value::int(0)
+                    } else if mag_one {
+                        powf_or_zero(&l, &r)
+                    } else if b.sign() == Sign::Minus {
+                        RuntimeError::numeric_underflow_failure()
+                    } else {
+                        RuntimeError::numeric_overflow_failure()
+                    }
                 }
             }
             _ => powf_or_zero(&l, &r),

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3130,6 +3130,14 @@ impl Compiler {
             } => {
                 self.compile_expr(supply);
                 let body_idx = self.code.add_stmt(Stmt::Block(body.clone()));
+                // A whenever block without a pointy param may still declare
+                // its parameter as a placeholder (`whenever $ch { %^content.kv
+                // }`): the emitted value binds to it, arity-1 like `-> $v`.
+                let param = param.clone().or_else(|| {
+                    crate::ast::collect_placeholders_shallow(body)
+                        .into_iter()
+                        .next()
+                });
                 // Case B (cross-thread lexicals): surface the runtime-compiled
                 // body's free vars so a captured-and-mutated lexical read
                 // directly in the whenever body (`start { react { whenever $ch

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -286,6 +286,15 @@ impl Interpreter {
         self.state_vars.get(key)
     }
 
+    /// Drop a `state` variable's stored value so the next `StateVarInit`
+    /// re-runs its initializer. Used when a loop statement is re-entered:
+    /// each execution of the statement is a fresh clone of its body block
+    /// (Raku clones a block each time its enclosing block runs), so `state`
+    /// declarations inside the body re-initialize.
+    pub(crate) fn remove_state_var(&mut self, key: &str) {
+        self.state_vars.remove(key);
+    }
+
     pub(crate) fn set_state_var(&mut self, key: String, value: Value) {
         // Track C/Track B: once a `state` variable lives in a shared
         // `ContainerRef` cell (StateVarInit under an active thread context),

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -280,6 +280,38 @@ impl Interpreter {
         // and needs to wake up.
         if !self.nested_mode {
             set_global_exit_flag(code);
+            // `exit` terminates the PROCESS in raku, wherever it is called.
+            // The flag above only works if some thread polls it; when `exit`
+            // runs on a worker thread while the main thread is stuck inside a
+            // long non-polling computation (`start { sleep 2; exit }; EVAL
+            // 'say 1.0000001 ** 10**8'`, A01-limits/overflow.t), the process
+            // would hang forever. Flush this thread's buffered output, then
+            // exit for real.
+            if self.output_sink().is_thread_clone {
+                use std::io::Write;
+                let (out, err, shared_out, shared_err) = {
+                    let sink = self.output_sink();
+                    (
+                        sink.output.clone(),
+                        sink.stderr_output.clone(),
+                        sink.shared_thread_output.clone(),
+                        sink.shared_thread_stderr.clone(),
+                    )
+                };
+                let mut stdout = std::io::stdout();
+                if let Some(so) = shared_out {
+                    let _ = stdout.write_all(so.lock().unwrap().as_bytes());
+                }
+                let _ = stdout.write_all(out.as_bytes());
+                let _ = stdout.flush();
+                let mut stderr_h = std::io::stderr();
+                if let Some(se) = shared_err {
+                    let _ = stderr_h.write_all(se.lock().unwrap().as_bytes());
+                }
+                let _ = stderr_h.write_all(err.as_bytes());
+                let _ = stderr_h.flush();
+                std::process::exit(code as i32);
+            }
         }
         Ok(Value::NIL)
     }

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -136,6 +136,36 @@ impl Interpreter {
         Ok(())
     }
 
+    /// Whether two multi-method candidates whose positional type signatures
+    /// match are nonetheless distinguished by value-level constraints: a
+    /// differing literal parameter (`multi method f(1)` vs `f(3)`) or a
+    /// `where` clause on either side. Raku composes such candidates from
+    /// different roles into one candidate set instead of demanding the class
+    /// resolve a conflict (`where` equality is undecidable, so any `where` is
+    /// treated as distinguishing).
+    fn multi_constraints_distinguish(a: &MethodDef, b: &MethodDef) -> bool {
+        let positionals = |def: &MethodDef| -> Vec<(Option<Value>, bool)> {
+            def.param_defs
+                .iter()
+                .filter(|pd| !(pd.named || (pd.slurpy && pd.name.starts_with('%'))))
+                .map(|pd| (pd.literal_value.clone(), pd.where_constraint.is_some()))
+                .collect()
+        };
+        let pa = positionals(a);
+        let pb = positionals(b);
+        pa.iter()
+            .zip(pb.iter())
+            .any(|((lit_a, wh_a), (lit_b, wh_b))| {
+                *wh_a
+                    || *wh_b
+                    || match (lit_a, lit_b) {
+                        (Some(va), Some(vb)) => va != vb,
+                        (None, None) => false,
+                        _ => true,
+                    }
+            })
+    }
+
     pub(super) fn detect_unresolved_role_method_conflicts(
         &self,
         class_name: &str,
@@ -213,7 +243,9 @@ impl Interpreter {
                         roles_for_sig.push(r.clone());
                     }
                     for def_b in multi_defs.iter().skip(i + 1) {
-                        if Self::method_signatures_match(def_a, def_b) {
+                        if Self::method_signatures_match(def_a, def_b)
+                            && !Self::multi_constraints_distinguish(def_a, def_b)
+                        {
                             if def_b.role_origin.is_none() {
                                 class_resolves = true;
                             }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1356,6 +1356,15 @@ pub struct Interpreter {
     /// variable's name must keep resolving through its own live env capture.
     pub(crate) escaped_our_sub_names: std::collections::HashSet<String>,
     state_vars: HashMap<String, Value>,
+    /// Names re-declared (`my $x` / `if ... -> $x`) in THIS thread while the
+    /// cross-thread shared store is active. A re-declaration is a fresh
+    /// binding shadowing the captured outer lexical, so subsequent writes to
+    /// the name must stay thread-local: `set_shared_var_sym` skips the shared
+    /// write and `sync_shared_vars_to_env` skips the pull for these names.
+    /// Reset to empty in `clone_for_thread` (a child thread captures the
+    /// parent's *current* bindings). Only populated while
+    /// `shared_vars_active`; empty (zero-cost) for single-threaded programs.
+    pub(crate) thread_redeclared_vars: std::collections::HashSet<String>,
     /// Per-closure-instance captured-variable state, keyed by
     /// (closure instance id, captured variable Symbol). This is the hot
     /// closure-call persistence store (loaded/saved on every closure call for

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -50,8 +50,36 @@ impl Interpreter {
             }
         }
         let args_match = self.method_args_match(arg_values, &def.param_defs);
-        self.env = saved_env;
+        if def.param_defs.iter().any(|p| p.where_constraint.is_some()) {
+            // A `where` clause is user code: its writes to *dynamic* variables
+            // are observable side effects (`multi method f($ where { $*checked
+            // ~= "d1"; ... })`, A01-limits/misc.t) and must survive the
+            // restore, exactly as on the sub-dispatch path.
+            self.restore_env_preserving_dynamics(saved_env);
+        } else {
+            self.env = saved_env;
+        }
         args_match
+    }
+
+    /// Restore `self.env` to `saved` while keeping any *dynamic*-variable
+    /// (`$*name`) writes made since — the observable side effects of user code
+    /// (e.g. a `where` clause) run during a speculative dispatch match whose
+    /// bindings are otherwise rolled back.
+    pub(crate) fn restore_env_preserving_dynamics(&mut self, saved: crate::env::Env) {
+        let dyn_writes: Vec<(crate::symbol::Symbol, Value)> = self
+            .env
+            .iter()
+            .filter(|(k, v)| {
+                k.with_str(|name| name.starts_with('*') || name.starts_with("$*"))
+                    && saved.get_sym(**k) != Some(*v)
+            })
+            .map(|(k, v)| (*k, v.clone()))
+            .collect();
+        self.env = saved;
+        for (k, v) in dyn_writes {
+            self.env.insert_sym(k, v);
+        }
     }
 
     pub(crate) fn resolve_method_with_owner(

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2096,6 +2096,7 @@ impl Interpreter {
             escaping_our_lexical_names: std::collections::HashSet::new(),
             escaped_our_sub_names: std::collections::HashSet::new(),
             state_vars: HashMap::new(),
+            thread_redeclared_vars: std::collections::HashSet::new(),
             closure_captured_state: HashMap::new(),
             once_values: HashMap::new(),
             once_scope_stack: Vec::new(),

--- a/src/runtime/runtime_shared_vars.rs
+++ b/src/runtime/runtime_shared_vars.rs
@@ -318,7 +318,7 @@ impl Interpreter {
                 self.env.insert(key.to_string(), value.clone());
             }
         }
-        if self.shared_vars_active {
+        if self.shared_vars_active && !self.thread_redeclared_vars.contains(key) {
             // Ensure @-variables always store Array(true) (real Arrays) in the
             // cross-thread shared store, which backs the atomic-array CAS
             // mechanism and expects non-flattening Array semantics. This must
@@ -406,7 +406,13 @@ impl Interpreter {
         // so we must not hold shared_vars_dirty while acquiring shared_vars.
         let dirty_keys: Vec<String> = {
             let dirty = self.shared_vars_dirty.read().unwrap();
-            dirty.iter().cloned().collect()
+            dirty
+                .iter()
+                // A name re-declared in this thread is a fresh local binding;
+                // pulling the shared (outer) value in would clobber it.
+                .filter(|k| !self.thread_redeclared_vars.contains(*k))
+                .cloned()
+                .collect()
         };
         if dirty_keys.is_empty() {
             return;

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -40,7 +40,16 @@ impl Interpreter {
                 }
                 // Only insert if not already present — existing values may have
                 // been updated by earlier threads that are already running.
-                sv.entry(key.resolve()).or_insert_with(|| val.clone());
+                // EXCEPT names this thread re-declared: their shared entry (if
+                // any) belongs to the shadowed outer binding and was frozen at
+                // its pre-declaration value (writes were masked), so the child
+                // must see the parent's *current* binding instead.
+                let key = key.resolve();
+                if self.thread_redeclared_vars.contains(&key) {
+                    sv.insert(key, val.clone());
+                } else {
+                    sv.entry(key).or_insert_with(|| val.clone());
+                }
             }
             // Track C: migrate the parent's existing `state` variables into shared
             // cells (keyed by their normalized cross-compilation key) so a routine
@@ -59,6 +68,12 @@ impl Interpreter {
             }
         }
         self.shared_vars_active = true;
+        // The child captures the parent's CURRENT bindings — including any
+        // name the parent re-declared since an earlier spawn (its current
+        // value was force-seeded above). From this spawn on, writes to those
+        // names must flow both ways again, so drop the parent-side masks.
+        // (The child's own mask starts empty via the struct literal below.)
+        self.thread_redeclared_vars.clear();
         let mut referenced_handle_ids = std::collections::HashSet::new();
         for value in self.env.values() {
             if let Some(id) = Self::handle_id_from_value(value) {
@@ -241,6 +256,7 @@ impl Interpreter {
             escaping_our_lexical_names: self.escaping_our_lexical_names.clone(),
             escaped_our_sub_names: self.escaped_our_sub_names.clone(),
             state_vars: HashMap::new(),
+            thread_redeclared_vars: std::collections::HashSet::new(),
             // Mirror state_vars: a thread clone starts with no persisted
             // closure captured state (falls back to the captured-env initial
             // values), exactly as before this store existed.

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -444,7 +444,9 @@ impl Interpreter {
                             .map(|v| self.smart_match(arg, &v))
                             .unwrap_or(false),
                     };
-                    self.env = saved;
+                    // Keep the where clause's dynamic-variable side effects
+                    // across the bindings rollback (A01-limits/misc.t).
+                    self.restore_env_preserving_dynamics(saved);
                     if !ok {
                         return false;
                     }
@@ -579,7 +581,9 @@ impl Interpreter {
                             .map(|v| self.smart_match(&val, &v))
                             .unwrap_or(false),
                     };
-                    self.env = saved;
+                    // Keep the where clause's dynamic-variable side effects
+                    // across the bindings rollback (A01-limits/misc.t).
+                    self.restore_env_preserving_dynamics(saved);
                     if !ok {
                         return false;
                     }
@@ -587,7 +591,13 @@ impl Interpreter {
             }
             true
         })();
-        self.env = saved_env;
+        if param_defs.iter().any(|pd| pd.where_constraint.is_some()) {
+            // Keep where clauses' dynamic-variable side effects across the
+            // bindings rollback (A01-limits/misc.t).
+            self.restore_env_preserving_dynamics(saved_env);
+        } else {
+            self.env = saved_env;
+        }
         result
     }
 

--- a/src/value/error_construct.rs
+++ b/src/value/error_construct.rs
@@ -234,4 +234,17 @@ impl RuntimeError {
         failure_attrs.insert("exception".to_string(), ex);
         Value::make_instance(Symbol::intern("Failure"), failure_attrs)
     }
+
+    /// Create a Failure wrapping an X::Numeric::Overflow exception.
+    pub(crate) fn numeric_overflow_failure() -> Value {
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "message".to_string(),
+            Value::str("Numeric overflow".to_string()),
+        );
+        let ex = Value::make_instance(Symbol::intern("X::Numeric::Overflow"), attrs);
+        let mut failure_attrs = HashMap::new();
+        failure_attrs.insert("exception".to_string(), ex);
+        Value::make_instance(Symbol::intern("Failure"), failure_attrs)
+    }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1659,6 +1659,14 @@ pub(crate) struct GatherCoroutineState {
     /// instead of resuming double-applies the body's side effects on
     /// cell-promoted captured lexicals.
     pub(crate) started: bool,
+    /// Unique state-variable scope for this gather instance (from
+    /// `next_instance_id()` at `MakeGather` time). Each evaluation of a
+    /// `gather` expression is a fresh block clone, so its `state` variables
+    /// must not collide with a sibling gather's — the bodies are compiled
+    /// separately (ip restarts at 0), so the compile-time `@ip` key suffix
+    /// alone cannot distinguish them. Installed as `state_scope_id` while
+    /// the body runs. 0 = no scope (pre-existing coroutine states).
+    pub(crate) state_scope_id: u64,
     /// Saved for-loop iteration state when suspended inside a for loop.
     pub(crate) for_loop_resume: Option<ForLoopResumeState>,
 }

--- a/src/vm/vm_arith_int_ops.rs
+++ b/src/vm/vm_arith_int_ops.rs
@@ -386,15 +386,27 @@ impl Interpreter {
             .len()
             .checked_mul(n)
             .ok_or_else(|| RuntimeError::new("Cannot repeat string: length overflow"))?;
-        let mut repeated = String::new();
-        repeated.try_reserve(total).map_err(|_| {
+        // Build by doubling (`extend_from_within` = one memcpy per doubling)
+        // instead of `n` per-copy `push_str` calls: the roast A01-limits test
+        // declares `"a" x 2**32-1` (a 4 GiB string), which must complete in
+        // seconds, not minutes.
+        let mut buf: Vec<u8> = Vec::new();
+        buf.try_reserve_exact(total).map_err(|_| {
             RuntimeError::new(format!(
                 "Cannot repeat string to {total} bytes: memory allocation failed"
             ))
         })?;
-        for _ in 0..n {
-            repeated.push_str(&src);
+        if total > 0 {
+            buf.extend_from_slice(src.as_bytes());
+            while buf.len() < total {
+                let take = (total - buf.len()).min(buf.len());
+                buf.extend_from_within(..take);
+            }
         }
+        // SAFETY: `buf` is `src.as_bytes()` (valid UTF-8) repeated whole times;
+        // a concatenation of valid UTF-8 strings is valid UTF-8. Skipping the
+        // validation scan matters at this size (multi-GiB).
+        let repeated = unsafe { String::from_utf8_unchecked(buf) };
         let result = if repeated.is_ascii() {
             Value::str(repeated)
         } else {

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -272,6 +272,11 @@ impl Interpreter {
             Some(crate::value::ForLoopResumeState::CStyleLoop)
         ) {
             self.gather_for_loop_resume = None;
+        } else if !code.state_locals.is_empty() {
+            // Fresh entry to the loop statement: state variables declared in
+            // the condition or body re-initialize (fresh block clone per
+            // statement execution — see `reset_state_locals_in_range`).
+            self.reset_state_locals_in_range(code, cond_start, loop_end);
         }
 
         // Track loop-body declarations for per-iteration closure capture
@@ -297,13 +302,17 @@ impl Interpreter {
                 None
             };
             'body_redo: loop {
-                match self.run_range(code, body_start, loop_end, compiled_fns) {
+                let body_res = self.run_range(code, body_start, loop_end, compiled_fns);
+                // Sync state variables modified in this iteration so the next
+                // iteration's StateVarInit sees updated values. State mutations
+                // persist on every exit path (`next`/`redo`/`last`/exception),
+                // not just normal completion — a `next if ++$count > 1` must
+                // not roll back the increment.
+                if !code.state_locals.is_empty() {
+                    self.sync_state_locals_in_range(code, body_start, loop_end);
+                }
+                match body_res {
                     Ok(()) => {
-                        // Sync state variables modified in this iteration so
-                        // the next iteration's StateVarInit sees updated values.
-                        if !code.state_locals.is_empty() {
-                            self.sync_state_locals_in_range(code, body_start, loop_end);
-                        }
                         if let Some(saved_topic) = &topic_before_body {
                             if let Some(v) = saved_topic.clone() {
                                 self.env_mut().insert("_".to_string(), v);

--- a/src/vm/vm_data_io_ops.rs
+++ b/src/vm/vm_data_io_ops.rs
@@ -67,6 +67,33 @@ fn element_needs_method_dispatch(v: &Value) -> bool {
     }
 }
 
+/// `say`/`put`/`print`/`note` on an *unhandled* Failure throws its wrapped
+/// exception: raku explodes a Failure as soon as `.gist`/`.Str` is called on
+/// it (`say 1.0000001 ** 10**90000` dies with X::Numeric::Overflow,
+/// A01-limits/overflow.t). A handled Failure renders normally.
+fn check_unhandled_failure(v: &Value) -> Result<(), RuntimeError> {
+    if let ValueView::Instance {
+        class_name,
+        attributes,
+        ..
+    } = v.view()
+        && class_name == "Failure"
+    {
+        let handled = attributes
+            .as_map()
+            .get("handled")
+            .map(|h| h.truthy())
+            .unwrap_or(false);
+        if !handled && let Some(ex) = attributes.as_map().get("exception").cloned() {
+            let ex = crate::runtime::Interpreter::as_exception_value(ex);
+            let mut err = RuntimeError::new(ex.to_string_value());
+            err.exception = Some(Box::new(ex));
+            return Err(err);
+        }
+    }
+    Ok(())
+}
+
 /// Check if a value is a Rat/FatRat/BigRat with zero denominator and throw
 /// X::Numeric::DivideByZero if so (Raku defers the error until the value is used).
 fn check_rat_divide_by_zero(v: &Value) -> Result<(), RuntimeError> {
@@ -118,6 +145,7 @@ impl Interpreter {
         for v in &values {
             let v = loan_env!(self, auto_fetch_proxy(v))?;
             check_rat_divide_by_zero(&v)?;
+            check_unhandled_failure(&v)?;
             // Resolve bound-element sentinels inside arrays before gist
             let v = self.resolve_bound_array_elements(v);
             if needs_method_dispatch(&v) {

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -329,14 +329,15 @@ impl Interpreter {
                 {
                     body_result = Err(err);
                 }
+                // Sync state variables modified in this iteration so that
+                // StateVarInit in the next iteration sees the updated values.
+                // State mutations persist on every exit path (`next`/`redo`/
+                // `last`/exception), not just normal completion.
+                if !code.state_locals.is_empty() {
+                    self.sync_state_locals_in_range(code, body_start, loop_end);
+                }
                 match body_result {
                     Ok(()) => {
-                        // Sync state variables modified in this iteration so
-                        // that StateVarInit in the next iteration sees the
-                        // updated values.
-                        if !code.state_locals.is_empty() {
-                            self.sync_state_locals_in_range(code, body_start, loop_end);
-                        }
                         if writes_back_loop_var {
                             self.write_back_for_topic_item(
                                 code,

--- a/src/vm/vm_for_loop_dispatch.rs
+++ b/src/vm/vm_for_loop_dispatch.rs
@@ -93,6 +93,15 @@ impl Interpreter {
             }
         }
 
+        // Fresh (non-resume) entry to the loop statement: state variables
+        // declared inside the body re-initialize (fresh block clone per
+        // statement execution — see `reset_state_locals_in_range`). The
+        // resume paths above returned early, so this never fires on a
+        // gather-coroutine re-entry.
+        if !code.state_locals.is_empty() {
+            self.reset_state_locals_in_range(code, *ip + 1, spec.body_end as usize);
+        }
+
         let iterable = self.stack.pop().unwrap();
 
         // Handle lazy IO lines: iterate by pulling one line at a time

--- a/src/vm/vm_for_loop_intrange.rs
+++ b/src/vm/vm_for_loop_intrange.rs
@@ -119,11 +119,14 @@ impl Interpreter {
                 self.locals[slot as usize] = item.clone();
             }
             'body_redo: loop {
-                match self.run_range(code, body_start, loop_end, compiled_fns) {
+                let body_res = self.run_range(code, body_start, loop_end, compiled_fns);
+                // State mutations persist on every exit path (`next`/`redo`/
+                // `last`/exception), not just normal completion.
+                if !code.state_locals.is_empty() {
+                    self.sync_state_locals_in_range(code, body_start, loop_end);
+                }
+                match body_res {
                     Ok(()) => {
-                        if !code.state_locals.is_empty() {
-                            self.sync_state_locals_in_range(code, body_start, loop_end);
-                        }
                         self.write_back_to_source_var(
                             code,
                             &spec.source_var_names,

--- a/src/vm/vm_for_loop_lazy.rs
+++ b/src/vm/vm_for_loop_lazy.rs
@@ -94,11 +94,14 @@ impl Interpreter {
                 self.env_mut().insert(key, Value::FALSE);
             }
             'body_redo: loop {
-                match self.run_range(code, body_start, loop_end, compiled_fns) {
+                let body_res = self.run_range(code, body_start, loop_end, compiled_fns);
+                // State mutations persist on every exit path (`next`/`redo`/
+                // `last`/exception), not just normal completion.
+                if !code.state_locals.is_empty() {
+                    self.sync_state_locals_in_range(code, body_start, loop_end);
+                }
+                match body_res {
                     Ok(()) => {
-                        if !code.state_locals.is_empty() {
-                            self.sync_state_locals_in_range(code, body_start, loop_end);
-                        }
                         break 'body_redo;
                     }
                     Err(e) if e.is_succeed() => {
@@ -308,11 +311,14 @@ impl Interpreter {
             }
 
             'body_redo: loop {
-                match self.run_range(code, body_start, loop_end, compiled_fns) {
+                let body_res = self.run_range(code, body_start, loop_end, compiled_fns);
+                // State mutations persist on every exit path (`next`/`redo`/
+                // `last`/exception), not just normal completion.
+                if !code.state_locals.is_empty() {
+                    self.sync_state_locals_in_range(code, body_start, loop_end);
+                }
+                match body_res {
                     Ok(()) => {
-                        if !code.state_locals.is_empty() {
-                            self.sync_state_locals_in_range(code, body_start, loop_end);
-                        }
                         if let Some(ref mut coll) = collected {
                             let base = stack_base.unwrap();
                             if self.stack.len() > base {

--- a/src/vm/vm_helpers_lazy_pull.rs
+++ b/src/vm/vm_helpers_lazy_pull.rs
@@ -73,6 +73,20 @@ impl Interpreter {
         let saved_locals = std::mem::take(&mut self.locals);
         let saved_stack = std::mem::take(&mut self.stack);
 
+        // Each gather instance is its own state-variable scope (a fresh block
+        // clone per `gather` evaluation): install its id so `state`
+        // declarations in the body cannot collide with a sibling gather's
+        // separately-compiled (ip-identical) body.
+        let saved_state_scope = self.state_scope_id;
+        let gather_scope_id = list
+            .coroutine
+            .as_ref()
+            .map(|m| m.lock().unwrap().state_scope_id)
+            .unwrap_or(0);
+        if gather_scope_id != 0 {
+            self.state_scope_id = Some(gather_scope_id);
+        }
+
         // Determine starting IP and locals from coroutine state or fresh start
         let mut ip;
         let has_prior_state;
@@ -208,6 +222,7 @@ impl Interpreter {
                 finished: false,
                 started: true,
                 for_loop_resume,
+                state_scope_id: gather_scope_id,
             };
             if let Some(ref coro_mutex) = list.coroutine {
                 *coro_mutex.lock().unwrap() = coro_state;
@@ -242,6 +257,7 @@ impl Interpreter {
         self.record_eager_block_free_var_writeback(cc.as_ref(), &[]);
 
         // Restore Interpreter state
+        self.state_scope_id = saved_state_scope;
         self.locals = saved_locals;
         self.stack = saved_stack;
 

--- a/src/vm/vm_loop_cstyle_repeat.rs
+++ b/src/vm/vm_loop_cstyle_repeat.rs
@@ -28,6 +28,11 @@ impl Interpreter {
             Some(crate::value::ForLoopResumeState::CStyleLoop)
         ) {
             self.gather_for_loop_resume = None;
+        } else if !code.state_locals.is_empty() {
+            // Fresh entry to the loop statement: state variables declared in
+            // the condition, body or step re-initialize (fresh block clone per
+            // statement execution — see `reset_state_locals_in_range`).
+            self.reset_state_locals_in_range(code, cond_start, loop_end);
         }
 
         // Track loop-body declarations for per-iteration closure capture
@@ -47,11 +52,14 @@ impl Interpreter {
                 break;
             }
             'body_redo: loop {
-                match self.run_range(code, body_start, step_begin, compiled_fns) {
+                let body_res = self.run_range(code, body_start, step_begin, compiled_fns);
+                // State mutations persist on every exit path (`next`/`redo`/
+                // `last`/exception), not just normal completion.
+                if !code.state_locals.is_empty() {
+                    self.sync_state_locals_in_range(code, body_start, step_begin);
+                }
+                match body_res {
                     Ok(()) => {
-                        if !code.state_locals.is_empty() {
-                            self.sync_state_locals_in_range(code, body_start, step_begin);
-                        }
                         if let Some(ref mut coll) = collected {
                             let base = stack_base.unwrap();
                             if self.stack.len() > base {
@@ -145,6 +153,15 @@ impl Interpreter {
         let cond_start = cond_end as usize;
         let loop_end = body_end as usize;
 
+        // Fresh entry to the loop statement: state variables declared in the
+        // body or condition re-initialize (fresh block clone per statement
+        // execution — see `reset_state_locals_in_range`). Skipped while a
+        // gather-coroutine resume marker is pending (the re-entry continues
+        // the same statement execution).
+        if self.gather_for_loop_resume.is_none() && !code.state_locals.is_empty() {
+            self.reset_state_locals_in_range(code, body_start, loop_end);
+        }
+
         // Track loop-body declarations for per-iteration closure capture
         // (owned_captures). Balanced by pop on every exit path.
         self.push_loop_local_scope();
@@ -166,11 +183,14 @@ impl Interpreter {
             }
             first = false;
             'body_redo: loop {
-                match self.run_range(code, body_start, cond_start, compiled_fns) {
+                let body_res = self.run_range(code, body_start, cond_start, compiled_fns);
+                // State mutations persist on every exit path (`next`/`redo`/
+                // `last`/exception), not just normal completion.
+                if !code.state_locals.is_empty() {
+                    self.sync_state_locals_in_range(code, body_start, cond_start);
+                }
+                match body_res {
                     Ok(()) => {
-                        if !code.state_locals.is_empty() {
-                            self.sync_state_locals_in_range(code, body_start, cond_start);
-                        }
                         break 'body_redo;
                     }
                     Err(e) if e.is_redo() && Self::label_matches(&e.label, label) => {

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -66,6 +66,7 @@ impl Interpreter {
                     finished: false,
                     started: false,
                     for_loop_resume: None,
+                    state_scope_id: crate::value::next_instance_id(),
                 })),
                 lazy_pipe: None,
                 closure_seq: None,

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -444,6 +444,32 @@ impl Interpreter {
         }
     }
 
+    /// Whether the state variable `(slot, key)` has its `StateVarInit` opcode
+    /// within [start..end). Matches both slot and key constant to avoid false
+    /// matches when multiple state variables share the same local slot.
+    fn state_local_init_in_range(
+        code: &CompiledCode,
+        slot: usize,
+        key: &str,
+        start: usize,
+        end: usize,
+    ) -> bool {
+        code.ops[start..end].iter().any(|op| {
+            if let OpCode::StateVarInit(s, k) = op {
+                if *s as usize != slot {
+                    return false;
+                }
+                if let ValueView::Str(stored_key) = code.constants[*k as usize].view() {
+                    stored_key.as_ref() == key
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        })
+    }
+
     /// Sync only state variables whose `StateVarInit` opcode falls within
     /// the given instruction range [start..end). This avoids prematurely
     /// syncing state variables that haven't been initialized yet.
@@ -454,25 +480,7 @@ impl Interpreter {
         end: usize,
     ) {
         for (slot, key) in &code.state_locals {
-            // Check if this exact state variable (by key) has its StateVarInit in the range.
-            // We match both slot and key_idx to avoid false matches when multiple
-            // state variables share the same local slot.
-            let has_init_in_range = code.ops[start..end].iter().any(|op| {
-                if let OpCode::StateVarInit(s, k) = op {
-                    if *s as usize != *slot {
-                        return false;
-                    }
-                    // Verify the key constant matches
-                    if let ValueView::Str(stored_key) = code.constants[*k as usize].view() {
-                        stored_key.as_ref() == key.as_str()
-                    } else {
-                        false
-                    }
-                } else {
-                    false
-                }
-            });
-            if !has_init_in_range {
+            if !Self::state_local_init_in_range(code, *slot, key, start, end) {
                 continue;
             }
             let local_name = &code.locals[*slot];
@@ -482,6 +490,30 @@ impl Interpreter {
                 .cloned()
                 .unwrap_or_else(|| self.locals[*slot].clone());
             self.set_state_var(key.clone(), val);
+        }
+    }
+
+    /// Reset (drop from the state store) every state variable whose
+    /// `StateVarInit` falls within [start..end). Called on entry to a compound
+    /// loop opcode: each execution of the loop *statement* is a fresh clone of
+    /// its body block (Raku clones a block each time its enclosing block
+    /// runs), so `state` declarations inside the body — including nested loop
+    /// bodies — re-run their initializers. Iterations within one execution
+    /// share state (the loop re-invokes the same clone), which is why this
+    /// runs at statement entry, not per iteration. Callers must skip this when
+    /// resuming a suspended gather coroutine into the same loop opcode.
+    pub(crate) fn reset_state_locals_in_range(
+        &mut self,
+        code: &CompiledCode,
+        start: usize,
+        end: usize,
+    ) {
+        for (slot, key) in &code.state_locals {
+            if !Self::state_local_init_in_range(code, *slot, key, start, end) {
+                continue;
+            }
+            let scoped_key = self.scoped_state_key(key);
+            self.remove_state_var(&scoped_key);
         }
     }
 

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1710,6 +1710,28 @@ impl Interpreter {
         // execution.
         let name_sym = code.const_sym(name_idx);
         loan_env!(self, set_var_dynamic(name, dynamic));
+        // While the cross-thread shared store is active, a re-declaration is a
+        // fresh binding shadowing the captured outer lexical: mark the name so
+        // subsequent writes stay thread-local instead of leaking to the parent
+        // through the shared store (`start { my $x ... }` / a pointy-if
+        // binding must not clobber the caller's same-named lexical). Scalars
+        // only: `@`/`%` names back the name-keyed atomic element stores
+        // (concurrent push/unshift), which need the shared entry maintained on
+        // every write, and `state` sharing goes through the dedicated
+        // shared-state cells — both must keep propagating.
+        if self.shared_vars_active
+            && !name.starts_with('@')
+            && !name.starts_with('%')
+            && !name.starts_with('&')
+        {
+            let is_state = code
+                .state_locals
+                .iter()
+                .any(|(_, key)| key.contains(&format!("::{}@", name)));
+            if !is_state {
+                self.thread_redeclared_vars.insert(name.to_string());
+            }
+        }
         // A fresh declaration without an explicit type must not inherit stale
         // constraints from an earlier lexical with the same name.
         self.vm_set_var_type_constraint(name, None);


### PR DESCRIPTION
## Summary

Closes out BLOCKERS.md cluster ③ (hang/timeout): all 5 remaining files now pass and are whitelisted.

| File | Result | Root causes fixed |
|---|---|---|
| `integration/gather-with-loops.t` | 21/21 | state writes lost on `next`/`redo` iterations (all 7 loop executors); state-key collision between separately-compiled sibling gathers; nested-loop `state` not re-initializing per enclosing statement execution |
| `integration/advent2013-day14.t` | 10/10 | whenever-block placeholder param (`%^content`) never bound + shallow placeholder collector descending into whenever bodies (phantom arity-1 start block); thread-local re-declarations (`my`/pointy-if) leaking to the parent's same-named lexical via the shared store |
| `APPENDICES/A01-limits/misc.t` | 3/3 | `x` repeat now builds by doubling memcpy (4 GiB string in seconds); multi methods from different roles compose when distinguished by literal/where constraints; where-clause dynamic-var side effects survive the dispatch-match env rollback |
| `APPENDICES/A01-limits/overflow.t` | 18/18 | `**` exponent ≥ 2³² → soft `X::Numeric::Overflow`/`Underflow` Failure (thresholds verified against Rakudo v2026.06, incl. the 2**-1074 / 2**-1075 boundary); `exit` from a worker thread terminates the process; `say` of an unhandled Failure throws |
| `integration/advent2012-day21.t` | 9/9 | pure speed stress — 20s on release; per-file timeout entries added (120s day21, 60s day14, 90s misc.t) |

## Verification

- All 5 files pass with the release build through `scripts/run-roast-test.sh` (CI configuration).
- `make test` passes (including the previously-regressed `t/thread-start-join.t` / `t/shared-array-push.t`, now green with the scalar-only re-declaration mask).
- All 97 whitelisted S17 concurrency files pass; multi/role/subset and numeric roast sweeps pass.
- clippy (1.96.1) + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMcTn8pCmYdeJKDi6KNzcw