### PR TITLE
fix: close three integration cluster-5 introspection gaps (day18/day20/day22)

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -54,10 +54,30 @@ S\* 系 24 本しか載せておらず、`integration/` 41 本・`6.c/` 7 本・
 | **② パース不能（`===SORRY!===`）** | **0（完了）** | 10 本すべて解消（#4511 / #4514 / #4515 / #4517 / #4518 / #4522） | **このクラスタは枯渇。** 7 本が whitelist 到達、3 本はパースを通過して機能ギャップへ移行 — 下の「② の内訳」参照 |
 | **③ ハング / タイムアウト** | 5 | `advent2012-day21.t`・`advent2013-day14.t`・`gather-with-loops.t`・`APPENDICES/A01-limits/{misc,overflow}.t` | 25s で打ち切り。gather×loop の遅延評価と limit 系 |
 | **④ エラーメッセージ品質** | 2 | `error-reporting.t`（mutsu 4/33・raku 33/33）・`weird-errors.t`（26/36） | 「Parse error contains line number」等、**例外の文面・行番号・バックトレース**を検査するテスト。PLAN §6「エラーメッセージ品質向上」と同一の的 |
-| **⑤ 個別機能ギャップ** | 残り | `advent2009-day24.t`（派生 grammar の拡張）・`advent2010-day14.t`（`nextsame` の継承/mixin）・`advent2010-day22.t`（`Rat` の `$!numerator`/`$!denominator` 属性）・`advent2011-day07.t`（`Metamodel::GrammarHOW` 継承）・`advent2011-day10.t`（`--doc` / `DOC INIT {}`）・`advent2009-day20.t`（signature の introspection/stringification）・`advent2009-day18.t`（パラメタ化 role の mixin）・`advent2013-day10.t`（`:round` 等の演算子 adverb）・`precompiled.t`（precomp） | 1 ファイル数本ずつ。★の近道はここ |
+| **⑤ 個別機能ギャップ** | 残り | `advent2009-day24.t`（派生 grammar の拡張 — **test 2 の `.parse` がハングに変化**、要再調査）・`advent2010-day14.t`（**`nextsame` ではなく** メソッド内 `say` → user `$*OUT.print` の captured-outer 書き込みが消える dual-store バグ — 最小再現は下記）・`advent2011-day07.t`（`Metamodel::GrammarHOW` 継承）・`advent2011-day10.t`（`--doc` / `DOC INIT {}`）・`advent2011-day04.t`（`.wrap` 後の再帰呼び出しが wrapper を通らず cache が top-level のみ）・`advent2013-day10.t`（演算子 adverb: `1/3 :round` のユーザ infix 適用・prefix `!` 適用・`1+2-3 :adv` の最後の infix・`1**2**3 :adv` の最左 `**`・`m:nth[5]` の X::Comp::Group — fail 26,28,31-32,38）・`precompiled.t`（precomp） | 1 ファイル数本ずつ。**whitelist 到達 (2026-07-15)**: `advent2010-day22.t`（builtin 型の `^attributes`/`^methods(:local)` テーブル）・`advent2009-day20.t`（signature.raku のリテラル default 表示・sigil→Positional/Associative/Callable 型・stub map callback の遅延）・`advent2009-day18.t`（`my Cup of EggNog $mug` の `.WHAT.raku` が型引数を保持） |
 
 **近道（1 subtest 差のファイル）**: `6.c/S04-declarations/my-6c.t` は **111/112**（唯一の失敗＝
 test 57 `OUTER::<$x>` 疑似パッケージ）。`advent2011-day04.t` は 1/2、`advent2009-day24.t` は 3/4。
+
+### advent2010-day14.t の実バグ（2026-07-15 root-cause）
+
+fail 1・5 は `nextsame` ではない（`nextsame` の継承チェーンも mixin も単体では動く）。
+実体は **メソッド内から `say` したときだけ、user 定義 `$*OUT.print` の captured-outer /
+`our` 変数への書き込みが完全に消える** dual-store バグ:
+
+```raku
+our $out = "";
+my $*OUT = class { method print(*@args) { $out ~= @args.join } }
+class A { method m { say "y" } }
+A.new.m;                      # print は呼ばれる（$*ERR 経由で確認済み）
+# raku: $out eq "y\n" / mutsu: $out eq "" — env からも消えている
+```
+
+- sub 内からの `say` は正しく蓄積される（`write_to_named_handle` の Slice F reconcile が効く）。
+- メソッド内から **明示的に** `$*OUT.print("y")` と書けば正しい（CallMethod op 経由）。
+- 消えるのは `say`（`Say` op → `write_to_named_handle` → `call_method_with_values` の
+  内部 redispatch）がメソッドフレームの中で走った場合のみ。`our` 変数ですら消えるので、
+  メソッド return 時の env merge が内部 redispatch の書き込みを捨てていると思われる。
 
 ### ① の内訳（2026-07-14 に 4 本とも root-cause 済み）
 

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1321,7 +1321,9 @@ roast/integration/advent2009-day14.t
 roast/integration/advent2009-day15.t
 roast/integration/advent2009-day16.t
 roast/integration/advent2009-day17.t
+roast/integration/advent2009-day18.t
 roast/integration/advent2009-day19.t
+roast/integration/advent2009-day20.t
 roast/integration/advent2009-day21.t
 roast/integration/advent2009-day22.t
 roast/integration/advent2009-day23.t
@@ -1334,6 +1336,7 @@ roast/integration/advent2010-day11.t
 roast/integration/advent2010-day12.t
 roast/integration/advent2010-day19.t
 roast/integration/advent2010-day21.t
+roast/integration/advent2010-day22.t
 roast/integration/advent2010-day23.t
 roast/integration/advent2011-day03.t
 roast/integration/advent2011-day05.t

--- a/src/builtins/builtin_type_methods.rs
+++ b/src/builtins/builtin_type_methods.rs
@@ -708,6 +708,31 @@ pub(crate) fn introspected_type_method_names(type_name: &str) -> Vec<&'static st
     names
 }
 
+/// Introspectable instance attributes for built-in types, as
+/// `(name-without-sigil, type-name)` pairs in declaration order. These mirror
+/// the attributes Rakudo reports from `.^attributes` (e.g. `Rat.^attributes`
+/// yields `$!numerator` and `$!denominator`). Types without modelled
+/// attributes return an empty slice.
+pub(crate) fn builtin_type_attributes(type_name: &str) -> &'static [(&'static str, &'static str)] {
+    match type_name {
+        "Rat" | "FatRat" => &[("numerator", "Int"), ("denominator", "Int")],
+        "Complex" => &[("re", "Num"), ("im", "Num")],
+        "Int" => &[("value", "int")],
+        "Num" => &[("value", "num")],
+        "Str" => &[("value", "str")],
+        "Pair" => &[("key", "Mu"), ("value", "Mu")],
+        "Range" => &[
+            ("min", "Mu"),
+            ("max", "Mu"),
+            ("excludes-min", "Bool"),
+            ("excludes-max", "Bool"),
+            ("infinite", "Bool"),
+            ("is-int", "Bool"),
+        ],
+        _ => &[],
+    }
+}
+
 /// The built-in MRO (parent chain) for `type_name`, up to but not including
 /// `Any`/`Mu` (those are appended by the caller). Returns an empty slice for
 /// types with no modelled built-in hierarchy.

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -87,6 +87,16 @@ pub(super) fn dispatch(
         return Some(None);
     }
     Some(match target.view() {
+        // A parameterized role type object: raku is the bare name
+        // (`Cup[EggNog]`), gist wraps it in type-object parens.
+        ValueView::ParametricRole { .. } => {
+            let name = raku_value(target);
+            if method == "gist" {
+                Some(Ok(Value::str(format!("({})", name))))
+            } else {
+                Some(Ok(Value::str(name)))
+            }
+        }
         ValueView::Bool(b) => {
             if method == "gist" {
                 Some(Ok(Value::str(if b { "True" } else { "False" }.to_string())))

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -734,6 +734,14 @@ pub fn raku_value(v: &Value) -> String {
         }
         ValueView::Nil => "Nil".to_string(),
         ValueView::Package(name) => name.resolve().to_string(),
+        // A parameterized role type object renders as `Cup[EggNog]`.
+        ValueView::ParametricRole {
+            base_name,
+            type_args,
+        } => {
+            let args: Vec<String> = type_args.iter().map(raku_value).collect();
+            format!("{}[{}]", base_name.resolve(), args.join(","))
+        }
         ValueView::Range(a, b) => {
             format!(
                 "{}..{}",

--- a/src/runtime/builtins_collection_mapgrep.rs
+++ b/src/runtime/builtins_collection_mapgrep.rs
@@ -64,6 +64,14 @@ impl Interpreter {
             self.env.insert(var_name, Value::real_array(list_items));
             Ok(result)
         } else {
+            // Same deferral as dispatch_map_method: a callback containing
+            // `return` or a stub (`...`) must not run until the Seq is forced.
+            if let Some(ValueView::Sub(sub_data)) = func.as_ref().map(Value::view)
+                && (Self::body_contains_return(&sub_data.body)
+                    || Self::is_stub_routine_body(&sub_data.body))
+            {
+                return Ok(self.create_lazy_map_list(list_items, &sub_data));
+            }
             self.eval_map_over_items(func, list_items)
         }
     }

--- a/src/runtime/methods_classhow_attribute.rs
+++ b/src/runtime/methods_classhow_attribute.rs
@@ -11,6 +11,21 @@ impl Interpreter {
         if class_name == "Attribute" && !self.registry().classes.contains_key("Attribute") {
             return Self::make_bootstrapattr_list();
         }
+        // Built-in types have no registry entry; serve their modelled
+        // attributes (e.g. Rat's $!numerator/$!denominator). They are declared
+        // on the leaf type itself, so :local and the MRO walk agree.
+        if !self.registry().classes.contains_key(class_name) {
+            let builtin =
+                crate::builtins::builtin_type_methods::builtin_type_attributes(class_name);
+            if !builtin.is_empty() {
+                return builtin
+                    .iter()
+                    .map(|(name, type_name)| {
+                        Self::make_builtin_attribute_object(name, type_name, class_name)
+                    })
+                    .collect();
+            }
+        }
         if local_only {
             if let Some(class_def) = self.registry().classes.get(class_name) {
                 class_def
@@ -91,6 +106,30 @@ impl Interpreter {
                 Value::make_instance(Symbol::intern("Attribute"), meta)
             })
             .collect()
+    }
+
+    /// Build an Attribute introspection object for a modelled built-in type
+    /// attribute (private `$!name`, no accessor, read-only).
+    fn make_builtin_attribute_object(attr_name: &str, type_name: &str, owner: &str) -> Value {
+        let mut meta = HashMap::new();
+        meta.insert("name".to_string(), Value::str(format!("$!{}", attr_name)));
+        meta.insert(
+            "__mutsu_attr_name".to_string(),
+            Value::str(attr_name.to_string()),
+        );
+        meta.insert(
+            "__mutsu_attr_owner".to_string(),
+            Value::str(owner.to_string()),
+        );
+        meta.insert("is_public".to_string(), Value::FALSE);
+        meta.insert("is_rw".to_string(), Value::FALSE);
+        meta.insert("sigil".to_string(), Value::str("$".to_string()));
+        meta.insert(
+            "type".to_string(),
+            Value::package(Symbol::intern(type_name)),
+        );
+        meta.insert("has_accessor".to_string(), Value::FALSE);
+        Value::make_instance(Symbol::intern("Attribute"), meta)
     }
 
     fn make_attribute_object(&self, attr: &super::ClassAttributeDef, owner: &str) -> Value {

--- a/src/runtime/methods_classhow_builtin_methods.rs
+++ b/src/runtime/methods_classhow_builtin_methods.rs
@@ -53,6 +53,13 @@ impl Interpreter {
             for role_name in &mixin_role_names {
                 self.collect_role_methods(role_name, private, &mut result);
             }
+            // Built-in types have no registry entry; their declared own list
+            // (leaf methods up to the coercion tail) approximates :local.
+            if result.is_empty() && !self.registry().classes.contains_key(&class_name) {
+                let names =
+                    crate::builtins::builtin_type_methods::builtin_type_method_names(&class_name);
+                self.push_native_method_objects(&names, &mut result);
+            }
         } else {
             // Walk MRO (already includes the class itself)
             let mro = self.class_mro(&class_name);
@@ -84,7 +91,13 @@ impl Interpreter {
         // `builtins::builtin_type_methods` for the rationale.
         let methods =
             crate::builtins::builtin_type_methods::introspected_type_method_names(type_name);
-        for name in &methods {
+        self.push_native_method_objects(&methods, result);
+    }
+
+    /// Append a native Method object for each name not already present in
+    /// `result` (dedup by the Method object's `name` attribute).
+    fn push_native_method_objects(&self, names: &[&str], result: &mut Vec<Value>) {
+        for name in names {
             if !result.iter().any(|v| {
                 if let ValueView::Instance { attributes, .. } = v.view() {
                     attributes
@@ -92,7 +105,7 @@ impl Interpreter {
                         .get("name")
                         .map(|n| n.to_string_value())
                         .as_deref()
-                        == Some(name)
+                        == Some(*name)
                 } else {
                     false
                 }

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -469,8 +469,12 @@ impl Interpreter {
         // out-of-dynamic-scope set. To get that right without making every map
         // lazy (which perturbs list shape/context in many call sites), only
         // defer evaluation when the callback body actually contains a `return`.
+        // A stub body (`...`) must likewise stay unevaluated until the Seq is
+        // forced: `map -> $x, $y { ... }, @list` lives in Raku as long as the
+        // result is never iterated.
         if let Some(ValueView::Sub(sub_data)) = args.first().map(Value::view)
-            && Self::body_contains_return(&sub_data.body)
+            && (Self::body_contains_return(&sub_data.body)
+                || Self::is_stub_routine_body(&sub_data.body))
         {
             return Ok(self.create_lazy_map_list(items, &sub_data));
         }
@@ -489,7 +493,7 @@ impl Interpreter {
     /// the callback for each item. This ensures that `return` inside the
     /// callback correctly detects when the lexically enclosing routine has
     /// already exited (out-of-dynamic-scope).
-    fn create_lazy_map_list(
+    pub(super) fn create_lazy_map_list(
         &self,
         items: Vec<Value>,
         callback: &crate::gc::Gc<crate::value::SubData>,

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -431,7 +431,16 @@ impl Interpreter {
         if let Some((target, _source)) = parse_coercion_type(base) {
             return self.nominal_type_object_name_for_constraint(target);
         }
-        let base_name = Self::optional_type_object_name(base);
+        // A parameterized type constraint (`Cup[EggNog]`, `Array[Int]`) keeps
+        // its type arguments in the nominal type object name — Rakudo reports
+        // `Cup[EggNog]` from `.WHAT` on an uninitialized `my Cup[EggNog] $x`.
+        // Coercion parens were already unwrapped above, so `[` here is always
+        // a parameterization.
+        let base_name = if base.contains('[') && !base.contains('(') {
+            base.to_string()
+        } else {
+            Self::optional_type_object_name(base)
+        };
         if let Some(captured_name) = base_name.strip_prefix("::")
             && let Some(ValueView::Package(bound)) = self.env.get(captured_name).map(Value::view)
         {

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl Interpreter {
-    pub(in crate::runtime) fn type_arg_value_from_name(&self, name: &str) -> Value {
+    pub(crate) fn type_arg_value_from_name(&self, name: &str) -> Value {
         let trimmed = name.trim().trim_start_matches('(').trim_end_matches(')');
         if let Some((base, args)) = Self::parse_parametric_type_name(trimmed)
             && self.is_role(&base)

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -842,7 +842,11 @@ impl Value {
                 class_name,
                 attributes,
                 ..
-            } if class_name == "Method" || class_name == "Sub" || class_name == "Routine" => {
+            } if class_name == "Method"
+                || class_name == "Sub"
+                || class_name == "Routine"
+                || class_name == "Attribute" =>
+            {
                 attributes
                     .as_map()
                     .get("name")

--- a/src/value/signature.rs
+++ b/src/value/signature.rs
@@ -272,8 +272,18 @@ fn build_parameter_attrs(p: &SigParam) -> HashMap<String, Value> {
             type_captures.push(Value::str(t[2..].to_string()));
             Value::Package(Symbol::intern("Any"))
         }
+        // `Int @x` / `Int %h` constrain the *element* type; the parameter's
+        // own type is the parameterized container role.
+        Some(t) if p.sigil == '@' => Value::Package(Symbol::intern(&format!("Positional[{t}]"))),
+        Some(t) if p.sigil == '%' => Value::Package(Symbol::intern(&format!("Associative[{t}]"))),
         Some(t) => Value::Package(Symbol::intern(t)),
-        None => Value::Package(Symbol::intern("Any")),
+        // Untyped params: the sigil implies the container role.
+        None => Value::Package(Symbol::intern(match p.sigil {
+            '@' => "Positional",
+            '%' => "Associative",
+            '&' => "Callable",
+            _ => "Any",
+        })),
     };
     attrs.insert("type".to_string(), type_val);
     attrs.insert("type_captures".to_string(), Value::array(type_captures));
@@ -386,13 +396,36 @@ pub(crate) fn parameter_to_raku(attrs: &AttrMap) -> String {
     let mut parts = Vec::new();
 
     // Type constraint
-    let type_name = attrs
+    let mut type_name = attrs
         .get("type")
         .map(|v| match v.view() {
             ValueView::Package(sym) => sym.resolve(),
             _ => v.to_string_value(),
         })
         .unwrap_or_default();
+    // The sigil-implied container role is not spelled out (`@x`, not
+    // `Positional @x`), and `Positional[Int] @x` renders as `Int @x`.
+    let sigil = attrs
+        .get("sigil")
+        .map(Value::to_string_value)
+        .unwrap_or_default();
+    let implied = match sigil.as_str() {
+        "@" => Some("Positional"),
+        "%" => Some("Associative"),
+        "&" => Some("Callable"),
+        _ => None,
+    };
+    if let Some(implied) = implied {
+        if type_name == implied {
+            type_name = String::new();
+        } else if let Some(inner) = type_name
+            .strip_prefix(implied)
+            .and_then(|r| r.strip_prefix('['))
+            .and_then(|r| r.strip_suffix(']'))
+        {
+            type_name = inner.to_string();
+        }
+    }
     if !type_name.is_empty() && type_name != "Any" && type_name != "Mu" {
         parts.push(type_name);
     } else if type_name == "Mu" {
@@ -687,6 +720,15 @@ fn render_param(p: &SigParam) -> String {
     for t in &p.traits {
         result.push_str(" is ");
         result.push_str(t);
+    }
+
+    // Literal default values render as `= 5`; complex default expressions
+    // are not reconstructed (mutsu has no full deparser).
+    if let Some(ref de) = p.default_expr
+        && let Expr::Literal(lit) = de.as_ref()
+    {
+        result.push_str(" = ");
+        result.push_str(&crate::builtins::methods_0arg::raku_repr::raku_value(lit));
     }
 
     result

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1526,10 +1526,26 @@ impl Interpreter {
                             } else if constraint == "str" {
                                 Value::str(String::new())
                             } else {
-                                Value::package(Symbol::intern(
-                                    &loan_env!(self, var_type_constraint(&name))
-                                        .unwrap_or(constraint.clone()),
-                                ))
+                                // A parameterized role constraint (`my Cup of
+                                // EggNog $mug` / `my Cup[EggNog] $mug`) resolves
+                                // to the ParametricRole type object so .WHAT /
+                                // .raku keep the type arguments. The stored
+                                // constraint metadata normalizes to the base
+                                // name, so probe the raw constraint here.
+                                let parametric = constraint.contains('[').then(|| {
+                                    loan_env!(self, type_arg_value_from_name(&constraint))
+                                });
+                                match parametric {
+                                    Some(v)
+                                        if matches!(v.view(), ValueView::ParametricRole { .. }) =>
+                                    {
+                                        v
+                                    }
+                                    _ => Value::package(Symbol::intern(
+                                        &loan_env!(self, var_type_constraint(&name))
+                                            .unwrap_or(constraint.clone()),
+                                    )),
+                                }
                             };
                         self.set_env_with_main_alias(&name, init_val.clone());
                         self.update_local_if_exists(code, &name, &init_val);

--- a/t/builtin-type-introspection.t
+++ b/t/builtin-type-introspection.t
@@ -1,0 +1,23 @@
+use v6;
+use Test;
+
+plan 8;
+
+# Rat models its numerator/denominator attributes (advent2010-day22)
+my $rat-atts = join(', ', Rat.^attributes);
+ok $rat-atts ~~ /'$!numerator'/, 'Rat.^attributes includes $!numerator';
+ok $rat-atts ~~ /'$!denominator'/, 'Rat.^attributes includes $!denominator';
+is Rat.^attributes[0].name, '$!numerator', 'Attribute .name works';
+
+# Complex attributes
+is join(', ', Complex.^attributes), '$!re, $!im', 'Complex.^attributes';
+
+# ^methods(:local) is non-empty for builtin types
+my $rat-methods = join ', ', Rat.^methods(:local).map({.name});
+ok $rat-methods ~~ /<< 'Str' >>/, 'Rat.^methods(:local) includes Str';
+ok $rat-methods ~~ /<< 'round' >>/, 'Rat.^methods(:local) includes round';
+ok Rat.^methods(:local).grep({.name eq 'log'}).elems > 0, 'Rat.^methods(:local) includes log';
+
+# user classes still report only their own methods with :local
+class Foo { method bar { 42 } }
+is Foo.^methods(:local).map({.name}).join(','), 'bar', 'user class :local methods unchanged';

--- a/t/parametric-role-typed-var.t
+++ b/t/parametric-role-typed-var.t
@@ -1,0 +1,28 @@
+use v6;
+use Test;
+
+plan 5;
+
+role Cup[::Contents] { }
+role Glass[::Contents] { }
+role Tray[::ItemType] { }
+class EggNog { }
+class MulledWine { }
+
+# An uninitialized parameterized-role typed variable keeps its type args
+# (advent2009-day18)
+my Cup of EggNog $mug;
+is $mug.WHAT.raku, 'Cup[EggNog]', 'my Cup of EggNog $mug — .WHAT.raku';
+
+my Glass[MulledWine] $glass;
+is $glass.WHAT.raku, 'Glass[MulledWine]', 'bracket form declaration';
+
+my Tray of Glass of MulledWine $valuable;
+is $valuable.WHAT.raku, 'Tray[Glass[MulledWine]]', 'nested parameterization';
+
+# Direct parameterization value renders without parens
+is Cup[EggNog].raku, 'Cup[EggNog]', 'ParametricRole .raku';
+
+# Plain typed variables unchanged
+my Int $n;
+is $n.WHAT.raku, 'Int', 'plain typed variable .WHAT unchanged';

--- a/t/signature-introspection-gaps.t
+++ b/t/signature-introspection-gaps.t
@@ -1,0 +1,24 @@
+use v6;
+use Test;
+
+plan 8;
+
+sub foo (Int $i, @stuff, $blah = 5) { ... }   #OK not used
+
+# Literal defaults render in .signature.raku (advent2009-day20)
+is &foo.signature.raku, ':(Int $i, @stuff, $blah = 5)',
+    'signature.raku renders literal default';
+
+# @-sigil parameter type is Positional
+is &foo.signature.params[1].type.raku, 'Positional', 'untyped @param .type is Positional';
+is &foo.signature.params[2].type.raku, 'Any', 'untyped $param .type is Any';
+
+sub typed (Int @x, Str %h, &cb) { ... }   #OK not used
+is &typed.signature.params[0].type.^name, 'Positional[Int]', 'Int @x type is Positional[Int]';
+is &typed.signature.params[1].type.^name, 'Associative[Str]', 'Str %h type is Associative[Str]';
+is &typed.signature.params[2].type.raku, 'Callable', 'untyped &param .type is Callable';
+is &typed.signature.raku, ':(Int @x, Str %h, &cb)',
+    'sigil-implied types are not spelled out in signature.raku';
+
+# A map callback that is a stub must not run until the Seq is forced
+lives-ok { my $s = map -> $x, $y { ... }, 1..6; }, 'stub map callback stays unevaluated';


### PR DESCRIPTION
## Summary

Whitelists three `integration/` files from BLOCKERS.md cluster ⑤ (個別機能ギャップ), all raku-PASS (★達成可能):

- **`advent2010-day22.t`** — builtin types expose modelled attributes via `.^attributes` (`Rat` → `$!numerator`/`$!denominator`, plus Complex/Int/Num/Str/Pair/Range) and a non-empty `.^methods(:local)` backed by the declared own-method list (`builtin_type_method_names`). `Attribute` instances stringify as their name (`$!numerator`) so `join`/interpolation match Rakudo.
- **`advent2009-day20.t`** — `signature.raku` renders literal parameter defaults (`:(Int $i, @stuff, $blah = 5)`); untyped `@`/`%`/`&` params introspect as `Positional`/`Associative`/`Callable` and typed `@`/`%` as `Positional[T]`/`Associative[T]`, while `parameter_to_raku` keeps sigil-implied roles out of the rendered string; `map` callbacks whose body is a stub (`...`) defer evaluation until the Seq is forced (same mechanism as the existing `return`-in-body deferral), covering both method and function form.
- **`advent2009-day18.t`** — `my Cup of EggNog $mug` keeps its type arguments through `.WHAT`/`.raku`: `SetVarType` materializes the `ParametricRole` type object for bracketed constraints, `nominal_type_object_name_for_constraint` no longer truncates at `[`, and `ParametricRole` gets proper `raku`/`gist` reprs (`Cup[EggNog]` / `(Cup[EggNog])`).

## Also

- BLOCKERS.md ⑤ row updated; documents the **advent2010-day14.t root cause** (not `nextsame` — a dual-store env-merge bug that discards user `$*OUT.print` writes when `say` fires inside a method frame, minimal repro included).

## Tests

- New pins: `t/builtin-type-introspection.t`, `t/signature-introspection-gaps.t`, `t/parametric-role-typed-var.t`
- Full local `t/` suite: 1708 files PASS
- The three roast files pass under `MUTSU_FUDGE=1 prove`

🤖 Generated with [Claude Code](https://claude.com/claude-code)