### PR TITLE
fix: count Say/Put/Print/Note as calls so method exit keeps env writes

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -54,30 +54,24 @@ S\* 系 24 本しか載せておらず、`integration/` 41 本・`6.c/` 7 本・
 | **② パース不能（`===SORRY!===`）** | **0（完了）** | 10 本すべて解消（#4511 / #4514 / #4515 / #4517 / #4518 / #4522） | **このクラスタは枯渇。** 7 本が whitelist 到達、3 本はパースを通過して機能ギャップへ移行 — 下の「② の内訳」参照 |
 | **③ ハング / タイムアウト** | **完了** | 5 本すべて whitelist 到達（2026-07-15）: `gather-with-loops.t`（`next`/`redo` で終わったイテレーションの state 書き込み喪失＋sibling gather 間の state キー衝突＋ネストループの state 非リセット）・`advent2013-day14.t`（whenever ブロックの placeholder パラメータ非バインド＋thread 内再宣言の親レキシカル clobber）・`APPENDICES/A01-limits/misc.t`（`x` 演算子の O(n) push ループ→倍々 memcpy 化で 4GiB 文字列が数秒に＋異 role 間 multi method 合成＋where 節の動的変数副作用保持）・`overflow.t`（巨大指数 `**` の X::Numeric::Overflow/Underflow Failure 化＋worker thread からの `exit` のプロセス終了＋`say` の未 handled Failure 爆発）・`advent2012-day21.t`（純粋な速度ストレス — debug 102s/release は余裕。per-file timeout 120s を設定） | — |
 | **④ エラーメッセージ品質** | 2 | `error-reporting.t`（mutsu 4/33・raku 33/33）・`weird-errors.t`（26/36） | 「Parse error contains line number」等、**例外の文面・行番号・バックトレース**を検査するテスト。PLAN §6「エラーメッセージ品質向上」と同一の的 |
-| **⑤ 個別機能ギャップ** | 残り | `advent2009-day24.t`（派生 grammar の拡張 — **test 2 の `.parse` がハングに変化**、要再調査）・`advent2010-day14.t`（**`nextsame` ではなく** メソッド内 `say` → user `$*OUT.print` の captured-outer 書き込みが消える dual-store バグ — 最小再現は下記）・`advent2011-day07.t`（`Metamodel::GrammarHOW` 継承）・`advent2011-day10.t`（`--doc` / `DOC INIT {}`）・`advent2011-day04.t`（`.wrap` 後の再帰呼び出しが wrapper を通らず cache が top-level のみ）・`advent2013-day10.t`（演算子 adverb: `1/3 :round` のユーザ infix 適用・prefix `!` 適用・`1+2-3 :adv` の最後の infix・`1**2**3 :adv` の最左 `**`・`m:nth[5]` の X::Comp::Group — fail 26,28,31-32,38）・`precompiled.t`（precomp） | 1 ファイル数本ずつ。**whitelist 到達 (2026-07-15)**: `advent2010-day22.t`（builtin 型の `^attributes`/`^methods(:local)` テーブル）・`advent2009-day20.t`（signature.raku のリテラル default 表示・sigil→Positional/Associative/Callable 型・stub map callback の遅延）・`advent2009-day18.t`（`my Cup of EggNog $mug` の `.WHAT.raku` が型引数を保持） |
+| **⑤ 個別機能ギャップ** | 残り | `advent2009-day24.t`（派生 grammar の拡張 — **test 2 の `.parse` がハングに変化**、要再調査）・`advent2011-day07.t`（`Metamodel::GrammarHOW` 継承）・`advent2011-day10.t`（`--doc` / `DOC INIT {}`）・`advent2011-day04.t`（`.wrap` 後の再帰呼び出しが wrapper を通らず cache が top-level のみ）・`advent2013-day10.t`（演算子 adverb: `1/3 :round` のユーザ infix 適用・prefix `!` 適用・`1+2-3 :adv` の最後の infix・`1**2**3 :adv` の最左 `**`・`m:nth[5]` の X::Comp::Group — fail 26,28,31-32,38）・`precompiled.t`（precomp） | 1 ファイル数本ずつ。**whitelist 到達 (2026-07-15)**: `advent2010-day22.t`（builtin 型の `^attributes`/`^methods(:local)` テーブル）・`advent2009-day20.t`（signature.raku のリテラル default 表示・sigil→Positional/Associative/Callable 型・stub map callback の遅延）・`advent2009-day18.t`（`my Cup of EggNog $mug` の `.WHAT.raku` が型引数を保持）・`advent2010-day14.t`（`Say`/`Put`/`Print`/`Note` opcode を `has_calls` に追加 — 下節参照） |
 
 **近道（1 subtest 差のファイル）**: `6.c/S04-declarations/my-6c.t` は **111/112**（唯一の失敗＝
 test 57 `OUTER::<$x>` 疑似パッケージ）。`advent2011-day04.t` は 1/2、`advent2009-day24.t` は 3/4。
 
-### advent2010-day14.t の実バグ（2026-07-15 root-cause）
+### advent2010-day14.t の実バグ（2026-07-15 root-cause → 修正済み・whitelist 到達）
 
-fail 1・5 は `nextsame` ではない（`nextsame` の継承チェーンも mixin も単体では動く）。
-実体は **メソッド内から `say` したときだけ、user 定義 `$*OUT.print` の captured-outer /
-`our` 変数への書き込みが完全に消える** dual-store バグ:
-
-```raku
-our $out = "";
-my $*OUT = class { method print(*@args) { $out ~= @args.join } }
-class A { method m { say "y" } }
-A.new.m;                      # print は呼ばれる（$*ERR 経由で確認済み）
-# raku: $out eq "y\n" / mutsu: $out eq "" — env からも消えている
-```
-
-- sub 内からの `say` は正しく蓄積される（`write_to_named_handle` の Slice F reconcile が効く）。
-- メソッド内から **明示的に** `$*OUT.print("y")` と書けば正しい（CallMethod op 経由）。
-- 消えるのは `say`（`Say` op → `write_to_named_handle` → `call_method_with_values` の
-  内部 redispatch）がメソッドフレームの中で走った場合のみ。`our` 変数ですら消えるので、
-  メソッド return 時の env merge が内部 redispatch の書き込みを捨てていると思われる。
+fail 1・5 は `nextsame` ではなかった（`nextsame` の継承チェーンも mixin も単体では動く）。
+実体: `method m { say "y" }` のように本体が I/O op だけのメソッドは、`Say`/`Put`/`Print`/
+`Note` opcode が `CompiledCode::emit` の `has_calls` 判定リスト（`src/opcode.rs`）に
+入っていなかったため `can_skip_merge = true` と誤分類され、メソッド exit が
+`frame.saved_env`（entry 時のスナップショット）を復元して live env を破棄していた。
+`say` は user 定義 `$*OUT` override の `print` を内部 dispatch できる＝任意のユーザコードが
+env に書き込める op なので、`has_calls` に含めるのが正しい（同リストのコメントの通り
+「漏れた variant は外向き mutation を静かに落とす」の実例）。sub 経路が無事だったのは
+`call_compiled_function_positional_light` に skip-merge 短絡が無く、常に overlay を
+drain して返すため。修正: 4 op を `has_calls` リストへ追加。pin:
+`t/method-say-out-override-writeback.t`。
 
 ### ① の内訳（2026-07-14 に 4 本とも root-cause 済み）
 

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1336,6 +1336,7 @@ roast/integration/advent2010-day08.t
 roast/integration/advent2010-day10.t
 roast/integration/advent2010-day11.t
 roast/integration/advent2010-day12.t
+roast/integration/advent2010-day14.t
 roast/integration/advent2010-day19.t
 roast/integration/advent2010-day21.t
 roast/integration/advent2010-day22.t

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -3277,6 +3277,16 @@ impl CompiledCode {
                     | OpCode::CallOnCodeVar { .. }
                     | OpCode::HyperMethodCall { .. }
                     | OpCode::HyperMethodCallDynamic { .. }
+                    // The I/O ops internally dispatch a user `$*OUT`/`$*ERR`
+                    // override's `print` (plus `.Str`/`.gist` coercion of the
+                    // arguments), which can write captured-outer/`our`/dynamic
+                    // variables into this frame's env — omitting them made
+                    // `can_skip_merge` restore a stale env snapshot on method
+                    // exit and drop those writes (advent2010-day14).
+                    | OpCode::Say(_)
+                    | OpCode::Put(_)
+                    | OpCode::Print(_)
+                    | OpCode::Note(_)
             );
         }
         if !self.has_env_writes {

--- a/t/method-say-out-override-writeback.t
+++ b/t/method-say-out-override-writeback.t
@@ -1,0 +1,38 @@
+use v6;
+use Test;
+
+plan 4;
+
+# A user $*OUT override whose print writes a captured-outer / our variable
+# must keep that write when say/print/put/note fires inside a *method* body.
+# Regression pin for advent2010-day14.t: Say/Put/Print/Note opcodes were not
+# counted as calls, so can_skip_merge restored a stale env snapshot on method
+# exit and dropped the write.
+
+our $out = '';
+sub capture($code) {
+    temp our $out = '';
+    my $*OUT = class { method print(*@args) { $out ~= @args.join } }
+    $code();
+    return $out;
+}
+
+class Sayer {
+    method one   { say "from-method" }
+    method multi { say "a"; say "b" }
+    method puts  { print "p"; put "q" }
+}
+
+is capture({ Sayer.new.one }), "from-method\n", 'say inside method reaches $*OUT override';
+is capture({ Sayer.new.multi }), "a\nb\n", 'successive says accumulate';
+is capture({ Sayer.new.puts }), "pq\n", 'print/put inside method';
+
+# capture-said idiom from advent2010-day14 (lexical, not our)
+sub capture-said($code) {
+    my $output = '';
+    my $*OUT = class { method print(*@args) { $output ~= @args.join } }
+    $code();
+    return $output.lines;
+}
+class C { method sing { say "row"; say "boat" } }
+is-deeply capture-said({ C.new.sing }), ("row", "boat"), 'lexical accumulation across method says';


### PR DESCRIPTION
## Summary

Whitelists `roast/integration/advent2010-day14.t` (BLOCKERS cluster ⑤). The two failures were never about `nextsame` — both worked standalone. The real bug:

- A method whose body contains only I/O ops (`method m { say "y" }`) was classified `can_skip_merge = true` because `Say`/`Put`/`Print`/`Note` were missing from the `has_calls` opcode list in `CompiledCode::emit` (`src/opcode.rs`).
- On method exit, the `can_skip_merge` branch restores `frame.saved_env` (the entry-time snapshot), discarding everything the live env accumulated — including writes that the internal `$*OUT`-override `print` dispatch (`write_to_named_handle` → `call_method_with_values`) had correctly merged in.
- Net effect: the classic output-capture idiom (`my $*OUT = class { method print(*@a) { $out ~= @a.join } }`) silently lost every `say` made from inside a method — even writes to `our` variables vanished.

These opcodes can invoke arbitrary user code (a dynamic `$*OUT`/`$*ERR` override's `print`, plus `.Str`/`.gist` coercion of arguments), which is exactly the invariant `has_calls` exists to protect — the list's own comment warns "a missed variant silently drops outward mutations". The sub path was already sound because `call_compiled_function_positional_light` has no skip-merge short-circuit and always drains the overlay.

## Tests

- New pin: `t/method-say-out-override-writeback.t` (say/print/put from methods, our-var and lexical accumulation)
- `advent2010-day14.t`: 5/5
- Full local `t/` suite (1706 files): PASS
- Spot-checked `S12-methods/defer-next.t`, `S12-construction/roles-6e.t`, `S32-io/note.t`, `S06-advanced/wrap.t`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)