### PR TITLE
perf(vm): J4d slice 5 — reuse the caller env frame on light calls via a CoW write latch

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -310,8 +310,14 @@ const MAX_OVERLAY_DEPTH: u16 = 16;
 /// unaffected: two envs sharing this map are both empty, and any write
 /// un-shares the writer before it can be observed.
 fn empty_overlay() -> Arc<SymMap> {
+    empty_overlay_ref().clone()
+}
+
+/// Borrowed access to the shared empty overlay singleton, for identity checks
+/// that must not pay the `Arc` refcount round-trip a `clone` would cost.
+fn empty_overlay_ref() -> &'static Arc<SymMap> {
     static EMPTY: std::sync::OnceLock<Arc<SymMap>> = std::sync::OnceLock::new();
-    EMPTY.get_or_init(|| Arc::new(SymMap::default())).clone()
+    EMPTY.get_or_init(|| Arc::new(SymMap::default()))
 }
 
 impl Env {
@@ -415,6 +421,36 @@ impl Env {
     #[inline(always)]
     pub(crate) fn is_scoped(&self) -> bool {
         self.parent.is_some()
+    }
+
+    /// True when this scoped env's overlay is *exactly* the process-shared
+    /// empty singleton (see [`empty_overlay`]) with no tombstones: the state a
+    /// fresh `scoped_child` starts in and leaves only on the first by-name
+    /// write (`cow_mut`'s `Arc::make_mut` un-shares it) or `remove`. This is
+    /// the dynamic "did the frame ever write env?" latch the light-call frame
+    /// reuse (ADR-0004 J4d) keys on: `true` on return proves the body wrote
+    /// nothing by name, with no static analysis involved.
+    #[inline(always)]
+    pub(crate) fn overlay_is_shared_empty(&self) -> bool {
+        self.parent.is_some()
+            && self.tombstones.is_none()
+            && Arc::ptr_eq(&self.inner, empty_overlay_ref())
+    }
+
+    /// Filter this env's overlay in place, keeping only entries `keep` accepts,
+    /// and drop any tombstones. When the overlay ends up empty it is reset to
+    /// the shared empty singleton so the [`overlay_is_shared_empty`] latch
+    /// re-arms for the next frame-reuse call. Used by the light-call frame
+    /// reuse unwind: with the caller's overlay known-empty at entry, every
+    /// surviving entry is a callee write, so this is exactly the scoped-overlay
+    /// return merge performed in place.
+    pub(crate) fn retain_overlay(&mut self, keep: impl FnMut(&Symbol, &mut Value) -> bool) {
+        self.tombstones = None;
+        let map = self.cow_mut();
+        map.retain(keep);
+        if map.is_empty() {
+            self.inner = empty_overlay();
+        }
     }
 
     /// Collapse a scoped env into a flat (`parent=None`) env. For a flat env

--- a/src/gc/safepoint.rs
+++ b/src/gc/safepoint.rs
@@ -370,10 +370,16 @@ pub(crate) fn gc_safepoint(kind: SafepointKind) {
     let t = triggers();
     // `every_safepoint` / the `MUTSU_GC_AT` kind list / the random draw fire
     // directly; otherwise consume a pending arming from the candidate counter.
+    // Test-and-test-and-set: the unconditional `swap` was a locked RMW on a
+    // process-shared cache line executed once per call safepoint (~4% of a
+    // recursion-heavy workload's hottest function); the plain load short-cuts
+    // the common not-pending case. A pending flag set between the load and a
+    // racing consumer's swap is simply consumed at the next safepoint — same
+    // deferral the arming already tolerates.
     let fire = t.every_safepoint
         || t.at_mask & kind.bit() != 0
         || (t.random_rate_bits != 0 && random_fires(t.random_rate_bits))
-        || PENDING.swap(false, Ordering::Relaxed);
+        || (PENDING.load(Ordering::Relaxed) && PENDING.swap(false, Ordering::Relaxed));
     if fire {
         collect_cycles_at(kind.name());
     }

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -58,8 +58,29 @@ impl Interpreter {
         // This replaces the previous name-keyed save/restore juggling
         // (saved_env_locals / saved_param_env) with a single O(callee-writes)
         // merge -- the function's own params/locals never pollute the caller env.
-        let parent = self.env().clone();
-        let caller_env = std::mem::replace(self.env_mut(), crate::env::Env::scoped_child(parent));
+        //
+        // Frame reuse (ADR-0004 J4d): when the caller's live env is itself a
+        // scoped child whose overlay is still the process-shared empty
+        // singleton, a fresh scoped child over it would be observationally
+        // identical (an empty overlay is invisible to lookups; both read
+        // through the same parent chain at the same depth), so keep the
+        // caller's env in place — the clone + scoped_child + drop round-trip
+        // was ~8 `lock inc/dec`s per call, ~15% of fib(28) with the JIT on.
+        // Soundness rests on a dynamic latch, not on any static "the body
+        // never writes env" claim (that shortcut was rejected in slice 3):
+        // the shared singleton doubles as a write detector — the body's first
+        // by-name write un-shares it via `cow_mut`'s CoW (or sets a
+        // tombstone), and the unwind arm below detects that and replays the
+        // scoped-overlay return merge in place.
+        let caller_env = if self.env().overlay_is_shared_empty() {
+            None
+        } else {
+            let parent = self.env().clone();
+            Some(std::mem::replace(
+                self.env_mut(),
+                crate::env::Env::scoped_child(parent),
+            ))
+        };
 
         let num_locals = cf.code.locals.len();
         self.locals = self.take_locals_from_pool(num_locals);
@@ -109,7 +130,19 @@ impl Interpreter {
                     && !Self::fast_type_check(&val, tc)
                 {
                     self.restore_readonly_vars(saved_readonly);
-                    self.set_env(caller_env);
+                    match caller_env {
+                        Some(caller_env) => self.set_env(caller_env),
+                        // Reused frame: drop every by-name write made since
+                        // entry (the overlay was the shared empty singleton, so
+                        // all surviving entries are this call's param binds) —
+                        // the same wholesale discard the swap path gets from
+                        // dropping the scoped overlay.
+                        None => {
+                            if !self.env().overlay_is_shared_empty() {
+                                self.env_mut().retain_overlay(|_, _| false);
+                            }
+                        }
+                    }
                     let used = std::mem::replace(&mut self.locals, saved_locals);
                     self.recycle_locals(used);
                     self.loop_local_vars = saved_loop_local_vars;
@@ -242,29 +275,51 @@ impl Interpreter {
         // back: a write to a captured outer variable (not a declared local of
         // this function) persists in the caller; the function's params/locals are
         // dropped with the overlay. This replaces the prior per-name save/restore.
-        {
-            // The callee-local test reads the compile-time `Symbol` set
-            // (`is_callee_local_sym`) instead of materializing a `HashSet<&str>`
-            // per call: the old set was built even when the overlay was empty
-            // (a body whose params/locals are all slot-resolved never writes
-            // env), and hashed every local name with SipHash to build it.
-            let scoped = std::mem::replace(self.env_mut(), caller_env);
-            for (k, v) in scoped.overlay_iter() {
-                // The callee's private topic / arg array / routine id, and the
-                // per-frame contextual vars (`?LINE`/`?FILE`/...), must not
-                // propagate to the caller (which retains its own). Skipping the
-                // `?`-prefixed ones also avoids spurious `env_dirty` churn from
-                // the per-statement `?LINE` write on every recursive call.
-                if *k == "_"
-                    || *k == "@_"
-                    || *k == "%_"
-                    || *k == "__mutsu_callable_id"
-                    || k.with_str(|s| s.starts_with('?'))
-                {
-                    continue;
+        match caller_env {
+            Some(caller_env) => {
+                // The callee-local test reads the compile-time `Symbol` set
+                // (`is_callee_local_sym`) instead of materializing a `HashSet<&str>`
+                // per call: the old set was built even when the overlay was empty
+                // (a body whose params/locals are all slot-resolved never writes
+                // env), and hashed every local name with SipHash to build it.
+                let scoped = std::mem::replace(self.env_mut(), caller_env);
+                for (k, v) in scoped.overlay_iter() {
+                    // The callee's private topic / arg array / routine id, and the
+                    // per-frame contextual vars (`?LINE`/`?FILE`/...), must not
+                    // propagate to the caller (which retains its own). Skipping the
+                    // `?`-prefixed ones also avoids spurious `env_dirty` churn from
+                    // the per-statement `?LINE` write on every recursive call.
+                    if *k == "_"
+                        || *k == "@_"
+                        || *k == "%_"
+                        || *k == "__mutsu_callable_id"
+                        || k.with_str(|s| s.starts_with('?'))
+                    {
+                        continue;
+                    }
+                    if !cf.is_callee_local_sym(*k) {
+                        self.env_mut().insert_sym(*k, v.clone());
+                    }
                 }
-                if !cf.is_callee_local_sym(*k) {
-                    self.env_mut().insert_sym(*k, v.clone());
+            }
+            None => {
+                // Reused frame: the caller's overlay was the shared empty
+                // singleton at entry, so if the latch is still armed the body
+                // never wrote env — nothing to merge or restore. Otherwise
+                // every overlay entry is a write made by this call; replay the
+                // swap path's return merge in place — keep captured-outer
+                // writes (they are already sitting in the caller's env, which
+                // is where the merge would put them) and drop callee-locals
+                // and the per-frame private names.
+                if !self.env().overlay_is_shared_empty() {
+                    self.env_mut().retain_overlay(|k, _| {
+                        !(*k == "_"
+                            || *k == "@_"
+                            || *k == "%_"
+                            || *k == "__mutsu_callable_id"
+                            || k.with_str(|s| s.starts_with('?'))
+                            || cf.is_callee_local_sym(*k))
+                    });
                 }
             }
         }


### PR DESCRIPTION
## Summary

ADR-0004 J4d continuation. The post-slice-4 fib(28) profile put **~26% of `call_compiled_function_positional_light`'s self time in Arc refcount `lock inc/dec`s** from the per-call env ceremony (clone caller env → `scoped_child` → swap → drop), plus ~10% in `Env::scoped_child`/`drop_in_place<Env>` — all to install an empty overlay that, for a steady-state light call, is observationally identical to the caller's own env (an empty overlay is invisible to lookups; both read through the same parent chain at the same depth).

**Reuse the caller's env in place when its overlay is still the process-shared empty singleton** (`overlay_is_shared_empty`). Soundness does not rest on any static "the body never writes env" claim — the overlay-skip lean call was rejected in slice 3 (#4529) for exactly that. Instead the shared singleton doubles as a **dynamic write latch**: the body's first by-name write un-shares it through `cow_mut`'s `Arc::make_mut` (every env mutation goes through that chokepoint; audited) or sets a tombstone, and the unwind detects the tripped latch and replays the scoped-overlay return merge **in place** (`retain_overlay`: keep captured-outer writes — they already sit in the caller's env, where the merge would have put them; drop callee-locals, `_`/`@_`/`%_`/`__mutsu_callable_id`/`?`-prefixed names, and callee tombstones — exactly the swap path's semantics). When the retain empties the overlay it resets to the singleton so the latch re-arms for the next call.

Also **test-and-test-and-set the GC call-safepoint `PENDING` probe**: the unconditional `swap` was a locked RMW on a shared cache line once per call (~4% of the hot function). A relaxed load short-cuts the not-pending case; a flag set concurrently is consumed at the next safepoint (the same deferral the arming already tolerates).

## Measurements (local, release, P-core pinned, interleaved A/B vs slice 4)

| bench | slice 4 | this PR |
|---|---|---|
| fib(28), JIT on | 0.16–0.17s | **0.13–0.14s (~-19%)** |
| 3M-iter Num loop | 0.72–0.78s | 0.69–0.74s (unchanged) |

`MUTSU_JIT=off`/`on` outputs are byte-identical on both benches. Cumulative J4d so far: fib(28) ~0.4s (pre-J4d) → 0.13s.

Follow-up candidates (measured, not yet done): the same reuse for `call_compiled_function_fast` / `call_compiled_function_light`, and re-profiling to re-judge whether a per-call-site inline cache still pays post-slice-4 (the two Fx probes are now ~10-15ns/call).

## Test plan

- `make test` after rebase onto main: 1710 files / 16835 tests PASS
- Targeted roast (scoping/phasers/closures): S04-declarations/my-6e.t, state.t, S04-phasers/enter-leave.t, S12-construction/roles-6e.t, S06-signature/outside-subroutine.t PASS
- Full roast: CI (gc-stress / jit-stress cover the latch under stress schedules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)