### PR TITLE
perf(vm): J4d slice 6 — replace the readonly-set Arc snapshot with a mutation journal

### DIFF
--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -432,7 +432,7 @@ impl Interpreter {
             let routine_is_rw = !def.is_raw;
             let return_spec = self.routine_return_spec_by_name(&def.name.resolve());
             let saved_env = self.env.clone();
-            let saved_readonly = self.save_readonly_vars();
+            let saved_readonly = self.enter_readonly_frame();
             if let Some(line) = self.test_pending_callsite_line {
                 self.cur_source_line = line;
             }
@@ -469,7 +469,7 @@ impl Interpreter {
                     Err(e) => {
                         self.pop_caller_env();
                         self.env = saved_env;
-                        self.restore_readonly_vars(saved_readonly);
+                        self.exit_readonly_frame(saved_readonly);
                         self.samewith_context_stack.pop();
                         return Err(Self::enhance_binding_error(
                             e,
@@ -558,7 +558,7 @@ impl Interpreter {
                 .as_deref()
                 .map(|spec| self.resolved_type_capture_name(spec));
             self.env = restored_env;
-            self.restore_readonly_vars(saved_readonly);
+            self.exit_readonly_frame(saved_readonly);
             self.samewith_context_stack.pop();
             if pushed_dispatch {
                 self.multi_dispatch_stack.pop();

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -113,7 +113,7 @@ impl Interpreter {
             return Err(Self::reject_args_for_empty_sig(&args));
         }
         let saved_env = self.env.clone();
-        let saved_readonly = self.save_readonly_vars();
+        let saved_readonly = self.enter_readonly_frame();
         if let Some(line) = self.test_pending_callsite_line {
             self.cur_source_line = line;
         }
@@ -133,7 +133,7 @@ impl Interpreter {
                 self.set_current_package(saved_package);
                 self.pop_caller_env();
                 self.env = saved_env;
-                self.restore_readonly_vars(saved_readonly);
+                self.exit_readonly_frame(saved_readonly);
                 return Err(Self::enhance_binding_error(
                     e,
                     &def.name.resolve(),
@@ -247,7 +247,7 @@ impl Interpreter {
         self.apply_rw_bindings_to_env(&rw_bindings, &mut restored_env);
         self.merge_sigilless_alias_writes(&mut restored_env, &self.env);
         self.env = restored_env;
-        self.restore_readonly_vars(saved_readonly);
+        self.exit_readonly_frame(saved_readonly);
         let call_result = match result {
             Ok(()) => Ok(implicit_return),
             Err(e) => Err(e),
@@ -309,7 +309,7 @@ impl Interpreter {
                         return Err(Self::reject_args_for_empty_sig(&args));
                     }
                     let saved_env = self.env.clone();
-                    let saved_readonly = self.save_readonly_vars();
+                    let saved_readonly = self.enter_readonly_frame();
                     if let Some(line) = self.test_pending_callsite_line {
                         self.cur_source_line = line;
                     }
@@ -327,7 +327,7 @@ impl Interpreter {
                                 self.set_current_package(saved_package);
                                 self.pop_caller_env();
                                 self.env = saved_env;
-                                self.restore_readonly_vars(saved_readonly);
+                                self.exit_readonly_frame(saved_readonly);
                                 return Err(Self::enhance_binding_error(
                                     e,
                                     &def.name.resolve(),
@@ -394,7 +394,7 @@ impl Interpreter {
                         .as_deref()
                         .map(|spec| self.resolved_type_capture_name(spec));
                     self.env = restored_env;
-                    self.restore_readonly_vars(saved_readonly);
+                    self.exit_readonly_frame(saved_readonly);
                     let call_result = match result {
                         Ok(()) => Ok(implicit_return),
                         Err(e) => Err(e),

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -154,13 +154,13 @@ impl Interpreter {
             return Err(Self::reject_args_for_empty_sig(arg_values));
         }
         let saved_env = self.env.clone();
-        let saved_readonly = self.save_readonly_vars();
+        let saved_readonly = self.enter_readonly_frame();
         let rw_bindings =
             match self.bind_function_args_values(&def.param_defs, &def.params, arg_values) {
                 Ok(bindings) => bindings,
                 Err(e) => {
                     self.env = saved_env;
-                    self.restore_readonly_vars(saved_readonly);
+                    self.exit_readonly_frame(saved_readonly);
                     return Err(e);
                 }
             };
@@ -222,7 +222,7 @@ impl Interpreter {
         self.apply_rw_bindings_to_env(&rw_bindings, &mut restored_env);
         self.merge_sigilless_alias_writes(&mut restored_env, &self.env);
         self.env = restored_env;
-        self.restore_readonly_vars(saved_readonly);
+        self.exit_readonly_frame(saved_readonly);
         rendered
     }
 }

--- a/src/runtime/dispatch_proto.rs
+++ b/src/runtime/dispatch_proto.rs
@@ -101,12 +101,12 @@ impl Interpreter {
             return Err(Self::reject_args_for_empty_sig(args));
         }
         let saved_env = self.env.clone();
-        let saved_readonly = self.save_readonly_vars();
+        let saved_readonly = self.enter_readonly_frame();
         let rw_bindings = match self.bind_function_args_values(&def.param_defs, &def.params, args) {
             Ok(bindings) => bindings,
             Err(e) => {
                 self.env = saved_env;
-                self.restore_readonly_vars(saved_readonly);
+                self.exit_readonly_frame(saved_readonly);
                 // Convert binding type-check errors to X::TypeCheck::Argument for proto calls
                 let is_binding_param = e.exception.as_ref().is_some_and(|ex| {
                     if let ValueView::Instance { class_name, .. } = ex.as_ref().view() {
@@ -203,7 +203,7 @@ impl Interpreter {
         let mut restored_env = saved_env.clone();
         self.apply_rw_bindings_to_env(&rw_bindings, &mut restored_env);
         self.restore_env_preserving_existing(&restored_env, &def.params);
-        self.restore_readonly_vars(saved_readonly);
+        self.exit_readonly_frame(saved_readonly);
         match result {
             Err(e) if e.return_value.is_some() => Ok(e.return_value.unwrap()),
             other => other,

--- a/src/runtime/dispatch_proto_call.rs
+++ b/src/runtime/dispatch_proto_call.rs
@@ -86,13 +86,13 @@ impl Interpreter {
             return Err(Self::reject_args_for_empty_sig(&args));
         }
         let saved_env = self.env.clone();
-        let saved_readonly = self.save_readonly_vars();
+        let saved_readonly = self.enter_readonly_frame();
         let rw_bindings = match self.bind_function_args_values(&def.param_defs, &def.params, &args)
         {
             Ok(bindings) => bindings,
             Err(e) => {
                 self.env = saved_env;
-                self.restore_readonly_vars(saved_readonly);
+                self.exit_readonly_frame(saved_readonly);
                 return Err(e);
             }
         };
@@ -131,7 +131,7 @@ impl Interpreter {
         let mut restored_env = saved_env.clone();
         self.apply_rw_bindings_to_env(&rw_bindings, &mut restored_env);
         self.restore_env_preserving_existing(&restored_env, &def.params);
-        self.restore_readonly_vars(saved_readonly);
+        self.exit_readonly_frame(saved_readonly);
         match result {
             Err(e) if e.return_value.is_some() => Ok(e.return_value.unwrap()),
             Err(e) => Err(e),

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -853,10 +853,10 @@ impl Interpreter {
             && let Some(formatter) = attributes.as_map().get("formatter")
         {
             let saved_env = self.env().clone();
-            let saved_readonly = self.save_readonly_vars();
+            let saved_readonly = self.enter_readonly_frame();
             let rendered = self.eval_call_on_value(formatter.clone(), vec![target.clone()])?;
             *self.env_mut() = saved_env;
-            self.restore_readonly_vars(saved_readonly);
+            self.exit_readonly_frame(saved_readonly);
             return Ok(Value::str(rendered.to_string_value()));
         }
         // Immutable List/Range: push/pop/shift/unshift/append/prepend/splice must throw

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -811,14 +811,14 @@ impl Interpreter {
             attrs.insert("formatter".to_string(), formatter_value.clone());
             let dt_with_formatter = Value::write_back_sharing(&attributes, class_name, attrs, id);
             let saved_env = self.env().clone();
-            let saved_readonly = self.save_readonly_vars();
+            let saved_readonly = self.enter_readonly_frame();
             let rendered =
                 match self.eval_call_on_value(formatter_value, vec![dt_with_formatter.clone()]) {
                     Ok(v) => v.to_string_value(),
                     Err(e) => return Some(Err(e)),
                 };
             *self.env_mut() = saved_env;
-            self.restore_readonly_vars(saved_readonly);
+            self.exit_readonly_frame(saved_readonly);
             if let ValueView::Instance {
                 class_name,
                 attributes,

--- a/src/runtime/methods_object_attr_constraints.rs
+++ b/src/runtime/methods_object_attr_constraints.rs
@@ -332,12 +332,12 @@ impl Interpreter {
                 unreachable!()
             };
             let saved_env = self.env().clone();
-            let saved_readonly = self.save_readonly_vars();
+            let saved_readonly = self.enter_readonly_frame();
             let rendered = self
                 .eval_call_on_value(formatter_value, vec![date.clone()])?
                 .to_string_value();
             *self.env_mut() = saved_env;
-            self.restore_readonly_vars(saved_readonly);
+            self.exit_readonly_frame(saved_readonly);
             let mut updated = attributes.to_map();
             updated.insert("__formatter_rendered".to_string(), Value::str(rendered));
             Ok(Value::write_back_sharing(

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -607,12 +607,12 @@ impl Interpreter {
                         let dt_with_formatter =
                             Value::write_back_sharing(&attributes, class_name, attrs, id);
                         let saved_env = self.env().clone();
-                        let saved_readonly = self.save_readonly_vars();
+                        let saved_readonly = self.enter_readonly_frame();
                         let rendered = self
                             .eval_call_on_value(formatter_value, vec![dt_with_formatter.clone()])?
                             .to_string_value();
                         *self.env_mut() = saved_env;
-                        self.restore_readonly_vars(saved_readonly);
+                        self.exit_readonly_frame(saved_readonly);
                         if let ValueView::Instance {
                             class_name,
                             attributes,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -383,7 +383,17 @@ pub(crate) type ClassAttributeDef = (
 /// `unmark_readonly`) pays a `memcpy` of `u32`s only when it actually changes
 /// the set while a snapshot is alive. `Symbol` keys also replace the default
 /// hasher's SipHash-over-the-name with a `u32` hash.
-pub(crate) type ReadonlySet = Arc<rustc_hash::FxHashSet<Symbol>>;
+pub(crate) type ReadonlySet = rustc_hash::FxHashSet<Symbol>;
+
+/// One journaled readonly-set mutation (see `Interpreter::enter_readonly_frame`):
+/// the inverse to replay on scope exit, or a `Scope` sentinel marking a frame
+/// boundary (bounds the unmark/mark cancellation peephole).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum ReadonlyUndo {
+    Marked(Symbol),
+    Unmarked(Symbol),
+    Scope,
+}
 
 /// A set of variable names (`block_declared_vars` / `loop_local_vars`), keyed by
 /// the interned `Symbol` rather than an owned `String`.
@@ -1586,6 +1596,15 @@ pub struct Interpreter {
     /// Set of variable names that are readonly (default parameter binding).
     /// Copy-on-write and `Symbol`-keyed — see [`ReadonlySet`].
     readonly_vars: ReadonlySet,
+    /// Journal of readonly-set mutations made while at least one readonly
+    /// scope is open (newest last); `exit_readonly_frame` replays the
+    /// inverses back to its scope's mark. `Scope` sentinels bound each open
+    /// frame's entries (see `enter_readonly_frame`). Journaling is off at top
+    /// level (`readonly_frames == 0`), so the journal cannot grow across a
+    /// program's lifetime.
+    readonly_undo: Vec<ReadonlyUndo>,
+    /// Number of currently-open readonly scopes (see `enter_readonly_frame`).
+    readonly_frames: u32,
     /// Metadata for Seq values produced by `squish` with callbacks, used to
     /// provide callback-aware iterator behavior.
     pub(crate) squish_iterator_meta: HashMap<usize, SquishIteratorMeta>,

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -283,7 +283,7 @@ impl Interpreter {
                 return Err(Self::reject_args_for_empty_sig(&call_args));
             }
             let saved_env = self.env.clone();
-            let saved_readonly = self.save_readonly_vars();
+            let saved_readonly = self.enter_readonly_frame();
             if let Some(line) = self.test_pending_callsite_line {
                 self.cur_source_line = line;
             }
@@ -335,7 +335,7 @@ impl Interpreter {
             if data.empty_sig && !positional_call_args.is_empty() {
                 self.pop_caller_env();
                 self.env = saved_env;
-                self.restore_readonly_vars(saved_readonly);
+                self.exit_readonly_frame(saved_readonly);
                 return Err(Self::reject_args_for_empty_sig(&call_args));
             }
             let rw_bindings =
@@ -344,7 +344,7 @@ impl Interpreter {
                     Err(e) => {
                         self.pop_caller_env();
                         self.env = saved_env;
-                        self.restore_readonly_vars(saved_readonly);
+                        self.exit_readonly_frame(saved_readonly);
                         return Err(e);
                     }
                 };
@@ -582,7 +582,7 @@ impl Interpreter {
                 merged.insert("__mutsu_rw_map_topic__".to_string(), topic_val);
             }
             self.env = merged;
-            self.restore_readonly_vars(saved_readonly);
+            self.exit_readonly_frame(saved_readonly);
             if let Err(e) = &result
                 && e.is_fail()
             {

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2150,6 +2150,8 @@ impl Interpreter {
             last_value: None,
             pending_local_updates: Vec::new(),
             readonly_vars: crate::runtime::ReadonlySet::default(),
+            readonly_undo: Vec::new(),
+            readonly_frames: 0,
             squish_iterator_meta: HashMap::new(),
             custom_type_data: HashMap::new(),
             rebless_map: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -325,6 +325,8 @@ impl Interpreter {
             last_value: None,
             pending_local_updates: Vec::new(),
             readonly_vars: crate::runtime::ReadonlySet::default(),
+            readonly_undo: Vec::new(),
+            readonly_frames: 0,
             squish_iterator_meta: HashMap::new(),
             custom_type_data: self.custom_type_data.clone(),
             rebless_map: self.rebless_map.clone(),

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -115,20 +115,58 @@ pub(crate) fn value_is_defined(value: &Value) -> bool {
 }
 
 impl Interpreter {
-    /// Save the current readonly_vars set (call before function body execution).
-    ///
-    /// O(1): an `Arc` bump, not a deep copy. The set is copy-on-write (see
-    /// [`ReadonlySet`]), so the snapshot only materializes if the callee
-    /// actually changes the set — and a callee whose params are already marked
-    /// (the monomorphic/recursive steady state) changes nothing, so a call pays
-    /// no allocation at all.
-    pub(crate) fn save_readonly_vars(&self) -> ReadonlySet {
-        ReadonlySet::clone(&self.readonly_vars)
+    /// Open a readonly scope (call before function body execution) and return
+    /// its rollback mark. Replaces the old whole-set `Arc` snapshot
+    /// (`save_readonly_vars`): the two `lock inc/dec`s of the snapshot's
+    /// clone + drop were a measured ~15% of the hottest call path's self time
+    /// (ADR-0004 J4d), while the set almost never changes inside a frame. The
+    /// mutators below journal their *actual* changes into `readonly_undo`
+    /// while at least one scope is open, and [`exit_readonly_frame`] replays
+    /// the inverses — a frame whose params are already marked (the
+    /// monomorphic/recursive steady state) journals nothing and pays two
+    /// integer ops total.
+    #[inline]
+    pub(crate) fn enter_readonly_frame(&mut self) -> usize {
+        self.readonly_frames += 1;
+        // The scope sentinel bounds the cancellation peephole in
+        // `unmark_readonly_sym`: an unmark may only cancel a mark journaled by
+        // the *same* frame — cancelling across the sentinel would erase an
+        // outer frame's rollback entry (e.g. an `is copy` param transiently
+        // unmarking the caller's same-named readonly param would eat the
+        // caller's own mark, leaving it writable after the inner call).
+        self.readonly_undo.push(ReadonlyUndo::Scope);
+        self.readonly_undo.len()
     }
 
-    /// Restore the readonly_vars set (call after function body execution).
-    pub(crate) fn restore_readonly_vars(&mut self, saved: ReadonlySet) {
-        self.readonly_vars = saved;
+    /// Close a readonly scope: undo every journaled mutation made since the
+    /// matching [`enter_readonly_frame`], newest first, then pop the scope
+    /// sentinel. Scopes are strictly LIFO (each pairs entry/exit around one
+    /// call frame); an inner scope abandoned by an error unwind is cleaned up
+    /// by the enclosing exit, since rolling back to a lower mark replays the
+    /// abandoned entries (and drops their sentinels) too.
+    pub(crate) fn exit_readonly_frame(&mut self, mark: usize) {
+        self.readonly_frames -= 1;
+        while self.readonly_undo.len() > mark {
+            match self.readonly_undo.pop().unwrap() {
+                ReadonlyUndo::Marked(sym) => {
+                    self.readonly_vars.remove(&sym);
+                }
+                ReadonlyUndo::Unmarked(sym) => {
+                    self.readonly_vars.insert(sym);
+                }
+                // An abandoned inner scope's sentinel: its exit was skipped by
+                // an error unwind, so re-balance the open-scope counter here.
+                ReadonlyUndo::Scope => {
+                    self.readonly_frames = self.readonly_frames.saturating_sub(1);
+                }
+            }
+        }
+        // Pop this scope's own sentinel (at `mark - 1`).
+        debug_assert!(matches!(
+            self.readonly_undo.last(),
+            Some(ReadonlyUndo::Scope)
+        ));
+        self.readonly_undo.pop();
     }
 
     /// Check if a variable is readonly.
@@ -149,12 +187,11 @@ impl Interpreter {
 
     /// Mark an already-interned name as readonly. The membership test comes
     /// first so a no-op mark (the common case: a recursive/monomorphic call
-    /// re-marking a param the caller's frame already marked) does not trigger
-    /// the copy-on-write clone.
+    /// re-marking a param the caller's frame already marked) journals nothing.
     #[inline]
     pub(crate) fn mark_readonly_sym(&mut self, sym: Symbol) {
-        if !self.readonly_vars.contains(&sym) {
-            std::sync::Arc::make_mut(&mut self.readonly_vars).insert(sym);
+        if self.readonly_vars.insert(sym) && self.readonly_frames > 0 {
+            self.readonly_undo.push(ReadonlyUndo::Marked(sym));
         }
     }
 
@@ -172,11 +209,20 @@ impl Interpreter {
     }
 
     /// Remove an already-interned name from the readonly set. Like
-    /// `mark_readonly_sym`, a no-op unmark skips the copy-on-write clone.
+    /// `mark_readonly_sym`, a no-op unmark journals nothing. A remove that
+    /// exactly cancels the journal's newest entry (the per-iteration
+    /// mark/unmark churn of loop topics) pops it instead of appending, so a
+    /// long loop inside an open scope keeps the journal flat. The scope
+    /// sentinel bounds the cancellation to the current frame's own entries —
+    /// an outer frame's mark stays journaled so its exit re-marks the name.
     #[inline]
     pub(crate) fn unmark_readonly_sym(&mut self, sym: Symbol) {
-        if self.readonly_vars.contains(&sym) {
-            std::sync::Arc::make_mut(&mut self.readonly_vars).remove(&sym);
+        if self.readonly_vars.remove(&sym) && self.readonly_frames > 0 {
+            if self.readonly_undo.last() == Some(&ReadonlyUndo::Marked(sym)) {
+                self.readonly_undo.pop();
+            } else {
+                self.readonly_undo.push(ReadonlyUndo::Unmarked(sym));
+            }
         }
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -288,18 +288,13 @@ pub(crate) struct VmCallFrame {
     pub saved_locals: Vec<Value>,
     pub saved_upvalues: Vec<Option<Value>>,
     pub saved_stack_depth: usize,
-    /// None when using light call frame (simple methods that don't use `:=` binding).
-    pub saved_readonly: Option<crate::runtime::ReadonlySet>,
-    /// Read-only var names this frame *newly* added to `readonly_vars` (used by
-    /// the light-frame method path, which marks `$` scalar params read-only
-    /// without cloning the whole set). Removed on `pop_call_frame`. Empty for the
-    /// slow path, which restores the full set via `saved_readonly` instead.
-    pub readonly_added: Vec<String>,
-    /// Read-only var names this frame *removed* from `readonly_vars` because a
-    /// writable (`is copy`/`is rw`/`is raw`) param shadows a caller's same-named
-    /// read-only variable. Re-added on `pop_call_frame` to restore the caller's
-    /// state. Light-frame method path counterpart to `readonly_added`.
-    pub readonly_removed: Vec<String>,
+    /// Rollback mark of this frame's readonly scope (see
+    /// `enter_readonly_frame`): `pop_call_frame` replays the readonly-set
+    /// mutations journaled since the frame was pushed. Replaces both the old
+    /// whole-set `Arc` snapshot and the light-frame `readonly_added`/
+    /// `readonly_removed` delta lists — the journal records exactly the
+    /// mutations either mechanism would have to undo.
+    pub readonly_mark: usize,
     pub saved_local_bind_pairs: Vec<(usize, usize)>,
     /// The caller's loop-body-local declaration scopes. These VM fields track
     /// which `my` names a `for`/`while` body declared so they can be restored at

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -115,7 +115,7 @@ impl Interpreter {
             }
         }
 
-        let saved_readonly = self.save_readonly_vars();
+        let saved_readonly = self.enter_readonly_frame();
         // Bind params to slots. Also write the param into the overlay when a
         // name-based reader needs it (reflective access anywhere / GetGlobal /
         // closure capture via needs_env_sync), or when it is `Nil` (the GetLocal
@@ -129,7 +129,7 @@ impl Interpreter {
                 if let Some(ref tc) = cf.param_defs[param_idx].type_constraint
                     && !Self::fast_type_check(&val, tc)
                 {
-                    self.restore_readonly_vars(saved_readonly);
+                    self.exit_readonly_frame(saved_readonly);
                     match caller_env {
                         Some(caller_env) => self.set_env(caller_env),
                         // Reused frame: drop every by-name write made since
@@ -269,7 +269,7 @@ impl Interpreter {
         self.loop_local_vars = saved_loop_local_vars;
         self.loop_local_saved_env = saved_loop_local_saved_env;
         self.block_declared_vars = saved_block_declared_vars;
-        self.restore_readonly_vars(saved_readonly);
+        self.exit_readonly_frame(saved_readonly);
 
         // Restore the caller env and merge the overlay (the callee's own writes)
         // back: a write to a captured outer variable (not a declared local of

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -192,7 +192,7 @@ impl Interpreter {
 
         // Mark parameters as readonly (by default, params are immutable in Raku).
         // Save existing readonly state so we can restore it after the call.
-        let saved_readonly = self.save_readonly_vars();
+        let saved_readonly = self.enter_readonly_frame();
         for (i, pd) in cf.param_defs.iter().enumerate() {
             if !pd.name.is_empty()
                 && !pd.sigilless
@@ -372,7 +372,7 @@ impl Interpreter {
         self.block_declared_vars = saved_block_declared_vars;
 
         // Restore readonly vars
-        self.restore_readonly_vars(saved_readonly);
+        self.exit_readonly_frame(saved_readonly);
 
         // Restore the caller env, merging the overlay (the callee's own writes)
         // back: a write to a captured outer variable (not a declared local /

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -51,9 +51,7 @@ impl Interpreter {
         let frame = VmCallFrame {
             saved_env: self.env().clone(),
             saved_cur_line: self.cur_source_line,
-            saved_readonly: Some(self.save_readonly_vars()),
-            readonly_added: Vec::new(),
-            readonly_removed: Vec::new(),
+            readonly_mark: self.enter_readonly_frame(),
             saved_locals: std::mem::take(&mut self.locals),
             saved_upvalues: std::mem::take(&mut self.upvalues),
             saved_stack_depth: self.stack.len(),
@@ -65,8 +63,10 @@ impl Interpreter {
         self.call_frames.push(frame);
     }
 
-    /// Lightweight call frame for simple methods: skips saving readonly vars
-    /// since simple methods don't use `:=` binding.
+    /// Lightweight call frame for simple methods. Historically this skipped
+    /// the whole-set readonly snapshot and tracked param deltas by hand; the
+    /// journal (`enter_readonly_frame`) made that split obsolete — both frame
+    /// flavors now open a scope for two integer ops.
     pub(super) fn push_light_call_frame(&mut self) {
         // GC safepoint (§9.2a `call`) — see `push_call_frame`.
         crate::gc::gc_safepoint(crate::gc::SafepointKind::Call);
@@ -74,9 +74,7 @@ impl Interpreter {
         let frame = VmCallFrame {
             saved_env: self.env().clone(),
             saved_cur_line: self.cur_source_line,
-            saved_readonly: None,
-            readonly_added: Vec::new(),
-            readonly_removed: Vec::new(),
+            readonly_mark: self.enter_readonly_frame(),
             saved_locals: std::mem::take(&mut self.locals),
             saved_upvalues: std::mem::take(&mut self.upvalues),
             saved_stack_depth: self.stack.len(),
@@ -105,19 +103,7 @@ impl Interpreter {
         self.loop_local_vars = std::mem::take(&mut frame.saved_loop_local_vars);
         self.loop_local_saved_env = std::mem::take(&mut frame.saved_loop_local_saved_env);
         self.block_declared_vars = std::mem::take(&mut frame.saved_block_declared_vars);
-        if let Some(readonly) = std::mem::take(&mut frame.saved_readonly) {
-            // Slow path: restore the whole snapshot (covers any `:=` marking).
-            self.restore_readonly_vars(readonly);
-        } else {
-            // Light-frame method path: drop only the param names this frame added
-            // and restore any caller names this frame's writable params shadowed.
-            for name in &frame.readonly_added {
-                self.unmark_readonly(name);
-            }
-            for name in &frame.readonly_removed {
-                self.mark_readonly(name);
-            }
-        }
+        self.exit_readonly_frame(frame.readonly_mark);
         frame
     }
 

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -989,20 +989,17 @@ impl Interpreter {
                 // frames). Drop the mark and record it so `pop_call_frame`
                 // restores the caller's state.
                 if self.is_readonly(&pd.name) {
+                    // The frame's readonly journal records the removal, so
+                    // `pop_call_frame` restores the caller's mark.
                     self.unmark_readonly(&pd.name);
-                    if let Some(frame) = self.call_frames.last_mut() {
-                        frame.readonly_removed.push(pd.name.clone());
-                    }
                 }
                 continue;
             }
             if self.is_readonly(&pd.name) {
                 continue; // already read-only (e.g. caller-owned same name)
             }
+            // Journaled — dropped again at `pop_call_frame`.
             self.mark_readonly(&pd.name);
-            if let Some(frame) = self.call_frames.last_mut() {
-                frame.readonly_added.push(pd.name.clone());
-            }
         }
     }
 


### PR DESCRIPTION
## Summary

ADR-0004 J4d continuation. Every call frame snapshotted `readonly_vars` (an `Arc<FxHashSet<Symbol>>`) on entry and swapped it back on exit; the snapshot's `lock inc/dec` pair profiled at **~15% of `call_compiled_function_positional_light`'s self time** on fib(28), while the set almost never changes inside a frame. There was also a second, hand-rolled delta mechanism for light method frames (`readonly_added`/`readonly_removed` name lists on `VmCallFrame`) — a dual mechanism this PR unifies away.

**Replace both with a single mutation journal**: `mark_readonly_sym`/`unmark_readonly_sym` record their actual changes into `readonly_undo` while at least one readonly scope is open, and `exit_readonly_frame` replays the inverses back to the scope's mark. A frame whose params are already marked (the monomorphic/recursive steady state) journals nothing and pays two integer ops.

- **Scope sentinels** bound each frame's journal entries. The unmark/mark cancellation peephole (keeps a loop's per-iteration topic churn from growing the journal) may only cancel same-frame entries — cancelling across the sentinel would eat an outer frame's rollback entry. Caught during development by `t/copy-param-shadows-caller-readonly.t`: an `is copy` param transiently unmarking the caller's same-named readonly param must not leave it writable after the call.
- **Journaling is off at top level** (`readonly_frames == 0`), so top-level `:=` marks don't grow the journal across a program's lifetime; an exit reached past an abandoned inner scope (error unwind) re-balances the counter from the sentinels it pops.
- `ReadonlySet` drops its `Arc` wrapper; `VmCallFrame`'s `saved_readonly` snapshot and the delta lists are gone — both frame flavors now open the same journal scope, and `save_readonly_vars`/`restore_readonly_vars` are replaced at all ~18 call sites (each audited for LIFO pairing on every exit path).

## Measurements

fib(28) cycle-count A/B (perf stat, P-core pinned, interleaved vs main@c397b90b): **~526M → ~494M cycles (~-6%)**. `MUTSU_JIT=off/on` outputs byte-identical.

## Test plan

- `make test` (rebased on main): 1710 files / 16835 tests PASS — including `t/copy-param-shadows-caller-readonly.t`, which caught the cross-frame peephole bug during development
- Targeted roast: S03-binding/nested.t, scalars.t, S06-traits/is-copy.t, is-rw.t, S06-signature/defaults.t PASS
- Full roast: CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)