### PR TITLE
feat: --doc renders pod before declarators, =item bullets, native pod2text

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1344,6 +1344,7 @@ roast/integration/advent2010-day23.t
 roast/integration/advent2011-day03.t
 roast/integration/advent2011-day04.t
 roast/integration/advent2011-day05.t
+roast/integration/advent2011-day10.t
 roast/integration/advent2011-day15.t
 roast/integration/advent2011-day16.t
 roast/integration/advent2011-day20.t

--- a/src/doc_mode.rs
+++ b/src/doc_mode.rs
@@ -228,6 +228,17 @@ fn render_begin_pod_blocks(source: &str) -> String {
                     i += 1;
                     continue;
                 }
+                // `=item text` renders as a bullet (Pod::To::Text style).
+                if let Some(rest) = inner.strip_prefix("=item") {
+                    let text = rest
+                        .trim_start_matches(|c: char| c.is_ascii_digit())
+                        .trim_start();
+                    output.push_str("  * ");
+                    output.push_str(text);
+                    output.push('\n');
+                    i += 1;
+                    continue;
+                }
                 if inner.starts_with('=') {
                     i += 1;
                     continue;
@@ -383,8 +394,10 @@ pub fn run_doc_mode(source: &str) -> Result<DocModeResult, RuntimeError> {
     validate_pod_blocks(source)?;
     let (mut output, status, halted) = run_doc_init_blocks(source)?;
     if !halted {
-        output.push_str(&render_doc(source));
+        // Rakudo's Pod::To::Text renders the pod blocks in source order
+        // first, then the declarator (#| / #=) blocks.
         output.push_str(&render_begin_pod_blocks(source));
+        output.push_str(&render_doc(source));
     }
     Ok(DocModeResult { output, status })
 }

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -401,6 +401,9 @@ impl Interpreter {
             }
             "__mutsu_stub_die" => self.builtin_stub_die(&args),
             "__mutsu_stub_warn" => self.builtin_stub_warn(&args),
+            // From `use Pod::To::Text` (built-in module, like JSON::Fast's
+            // to-json/from-json).
+            "pod2text" => self.builtin_pod2text(&args),
             "__mutsu_incdec_nomatch" => self.builtin_incdec_nomatch(&args),
             "__mutsu_index_var_meta" => self.builtin_index_var_meta(&args),
             "exit" => self.builtin_exit(&args),

--- a/src/runtime/io_pod.rs
+++ b/src/runtime/io_pod.rs
@@ -41,6 +41,111 @@ impl Interpreter {
         Value::make_instance(Symbol::intern("Pod::Heading"), attrs)
     }
 
+    /// Render a Pod object tree to plain text, Pod::To::Text style. Backs the
+    /// native `pod2text` (from `use Pod::To::Text`, recognized as a built-in
+    /// module the same way JSON::Fast is).
+    pub(crate) fn pod_to_text(value: &Value) -> String {
+        fn contents_of(value: &Value) -> Vec<Value> {
+            if let ValueView::Instance { attributes, .. } = value.view() {
+                match attributes.as_map().get("contents").map(Value::view) {
+                    Some(ValueView::Array(items, _)) => return items.to_vec(),
+                    Some(_) => {
+                        return attributes
+                            .as_map()
+                            .get("contents")
+                            .cloned()
+                            .into_iter()
+                            .collect();
+                    }
+                    None => {}
+                }
+            }
+            Vec::new()
+        }
+        fn inline_text(values: &[Value]) -> String {
+            let mut out = String::new();
+            for v in values {
+                match v.view() {
+                    ValueView::Str(s) => out.push_str(&s),
+                    ValueView::Instance { .. } => {
+                        out.push_str(&inline_text(&contents_of(v)));
+                    }
+                    ValueView::Array(items, _) => out.push_str(&inline_text(&items.to_vec())),
+                    _ => out.push_str(&v.to_string_value()),
+                }
+            }
+            out
+        }
+        fn render(value: &Value, out: &mut String) {
+            match value.view() {
+                ValueView::Array(items, _) => {
+                    for item in items.iter() {
+                        render(item, out);
+                    }
+                }
+                ValueView::Seq(items) => {
+                    for item in items.iter() {
+                        render(item, out);
+                    }
+                }
+                ValueView::Instance { class_name, .. } => {
+                    let contents = contents_of(value);
+                    match class_name.resolve().as_str() {
+                        "Pod::Heading" => {
+                            out.push_str(&inline_text(&contents));
+                            out.push_str("\n\n");
+                        }
+                        "Pod::Block::Para" => {
+                            out.push_str(&inline_text(&contents));
+                            out.push_str("\n\n");
+                        }
+                        "Pod::Item" => {
+                            out.push_str("  * ");
+                            out.push_str(&inline_text(&contents));
+                            out.push_str("\n\n");
+                        }
+                        "Pod::Block::Code" => {
+                            for line in inline_text(&contents).lines() {
+                                out.push_str("    ");
+                                out.push_str(line);
+                                out.push('\n');
+                            }
+                            out.push('\n');
+                        }
+                        "Pod::Block::Comment" => {}
+                        // Pod::Block, Pod::Block::Named, Pod::Block::Declarator, ...
+                        _ => {
+                            for item in &contents {
+                                render(item, out);
+                            }
+                        }
+                    }
+                }
+                ValueView::Str(s) => {
+                    out.push_str(&s);
+                    out.push('\n');
+                }
+                ValueView::Nil => {}
+                _ => {
+                    out.push_str(&value.to_string_value());
+                    out.push('\n');
+                }
+            }
+        }
+        let mut out = String::new();
+        render(value, &mut out);
+        out
+    }
+
+    pub(crate) fn builtin_pod2text(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
+        let rendered = args
+            .iter()
+            .map(Self::pod_to_text)
+            .collect::<Vec<_>>()
+            .join("");
+        Ok(Value::str(rendered))
+    }
+
     /// Strip the `# ` / `#` abbreviated-block alias for `:numbered` from the
     /// start of a directive tail. Returns `(is_numbered, remainder)`.
     pub(crate) fn extract_numbered_alias(rest: &str) -> (bool, &str) {

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -135,6 +135,10 @@ impl Interpreter {
                     // (see runtime/json.rs, dispatched in vm_native_json.rs).
                     | "JSON::Fast"
                     | "JSON::Tiny"
+                    // Pod::To::Text: `pod2text` is implemented natively over the
+                    // Pod object tree (see runtime/io_pod.rs), so the `use` only
+                    // needs to be recognized (same pattern as JSON::Fast).
+                    | "Pod::To::Text"
             ) {
             // Track MONKEY-TYPING pragma
             if module == "MONKEY-TYPING" || module == "MONKEY" {

--- a/t/doc-mode-pod-render.t
+++ b/t/doc-mode-pod-render.t
@@ -1,0 +1,59 @@
+use v6;
+use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers");
+use Test::Util;
+
+plan 3;
+
+# --doc renders pod blocks in source order BEFORE declarator blocks, and
+# renders =item bullets (advent2011-day10).
+
+my $main = q:to"END";
+    =begin pod
+
+    =head1 A Heading!
+
+    A paragraph!
+
+    =item A list!
+
+    =end pod
+
+    #| it's a sheep! really!
+    class Sheep {
+        #| produces a funny sound
+        method bark { say "no" }
+    }
+    END
+
+my $expected = rx/'A Heading!'
+       .*? 'A list!'
+       .*? 'class Sheep' .*? "it's a sheep! really!"
+       .*? 'method bark' .*? 'produces a funny sound'/;
+
+is_run($main, %( out => $expected, err => ''), :compiler-args['--doc'], '--doc order and items');
+
+my $main2 = $main ~ q:to"--END--";
+
+    DOC INIT {
+        use Pod::To::Text;
+        pod2text($=pod);
+    }
+    --END--
+
+is_run($main2, %( out => $expected, err => ''), :compiler-args['--doc'], '--doc + DOC INIT');
+
+# pod2text renders the Pod object tree
+=begin pod
+
+=head2 P2T Heading
+
+P2T body text
+
+=item bullet one
+
+=end pod
+
+use Pod::To::Text;
+my $text = pod2text($=pod);
+ok $text ~~ /'P2T Heading' .*? 'P2T body text' .*? '* bullet one'/, 'pod2text over $=pod';


### PR DESCRIPTION
## Summary

Whitelists `roast/integration/advent2011-day10.t` (5/5) from BLOCKERS cluster ⑤.

- `--doc` renders `=begin pod` blocks in source order **before** the `#|`/`#=` declarator blocks (Rakudo's Pod::To::Text order — previously declarators came first, breaking the test's ordered regex), and renders `=item` as `  * ...` bullets (previously swallowed by the generic directive skip).
- `use Pod::To::Text` is recognized as a built-in module (same pattern as JSON::Fast), with a native `pod2text` that genuinely renders the Pod object tree (headings, paragraphs, items, code blocks, declarator blocks) to plain text — so `DOC INIT { use Pod::To::Text; pod2text($=pod) }` runs cleanly under `--doc`.

## Tests
- Pin: `t/doc-mode-pod-render.t` — `is_run` with `--doc` (order + items), the DOC INIT variant, and `pod2text` over a real `$=pod` tree
- `advent2011-day10.t`: 5/5; doc_mode unit tests: 14 passed; full local `t/`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)