### PR TITLE
fix: merge inherited proto-token candidates in derived grammars

### DIFF
--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1329,6 +1329,7 @@ roast/integration/advent2009-day20.t
 roast/integration/advent2009-day21.t
 roast/integration/advent2009-day22.t
 roast/integration/advent2009-day23.t
+roast/integration/advent2009-day24.t
 roast/integration/advent2010-day04.t
 roast/integration/advent2010-day06.t
 roast/integration/advent2010-day07.t

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -142,6 +142,34 @@ impl Interpreter {
         }
     }
 
+    /// Like [`Self::collect_token_patterns_for_scope`], but deduplicating by
+    /// candidate identity (`None` for the exact token, `Some(sym)` for a proto
+    /// candidate) across successive calls via `seen`, so an MRO walk merges
+    /// proto candidates from every class while a same-identity redefinition in
+    /// a more-derived class overrides its ancestor's.
+    fn collect_token_patterns_for_scope_dedup(
+        &self,
+        scope: &str,
+        name: &str,
+        out: &mut Vec<(String, String, Option<String>)>,
+        seen: &mut std::collections::HashSet<Option<String>>,
+    ) {
+        // Dedupe against ancestors only: multi candidates within ONE scope
+        // legitimately share a sym key and must all be kept.
+        let seen_before = seen.clone();
+        let before = out.len();
+        self.collect_token_patterns_for_scope(scope, name, out);
+        let mut idx = before;
+        while idx < out.len() {
+            if seen_before.contains(&out[idx].2) {
+                out.remove(idx);
+            } else {
+                seen.insert(out[idx].2.clone());
+                idx += 1;
+            }
+        }
+    }
+
     /// Collect static token patterns for a given scope.
     /// Returns (pattern, package, sym_key) tuples. sym_key is Some for :sym<> variants.
     pub(super) fn collect_token_patterns_for_scope(
@@ -192,37 +220,51 @@ impl Interpreter {
                 &name[name.rfind("::").unwrap() + 2..],
                 &mut out,
             );
-            // Walk MRO for qualified names
-            if out.is_empty()
-                && let Some(pos) = name.rfind("::")
-            {
+            // Walk the MRO for qualified names, merging proto candidates from
+            // every ancestor (dedup by sym identity, derived-first).
+            if let Some(pos) = name.rfind("::") {
                 let qual_pkg = &name[..pos];
                 let token_name = &name[pos + 2..];
+                let mut seen: std::collections::HashSet<Option<String>> =
+                    out.iter().map(|e| e.2.clone()).collect();
+                let own = out.len();
                 for ancestor in self.mro_readonly(qual_pkg) {
                     if ancestor == qual_pkg {
                         continue;
                     }
-                    self.collect_token_patterns_for_scope(&ancestor, token_name, &mut out);
-                    if !out.is_empty() {
-                        // Rewrite the dispatch package to the original qualified
-                        // package so nested subrule lookups dispatch virtually
-                        // through the receiver's MRO (Liskov substitution).
-                        for entry in out.iter_mut() {
-                            entry.1 = qual_pkg.to_string();
-                        }
-                        break;
-                    }
+                    self.collect_token_patterns_for_scope_dedup(
+                        &ancestor, token_name, &mut out, &mut seen,
+                    );
+                }
+                // Rewrite ancestor entries' dispatch package to the original
+                // qualified package so nested subrule lookups dispatch
+                // virtually through the receiver's MRO (Liskov substitution).
+                for entry in out.iter_mut().skip(own) {
+                    entry.1 = qual_pkg.to_string();
                 }
             }
             return out;
         }
         if !pkg.is_empty() {
-            // Walk MRO of pkg
+            // Walk the MRO of pkg, merging proto candidates from every class:
+            // a derived grammar adding `rule statement:sym<repeat>` keeps the
+            // base grammar's candidates (advent2009-day24).
+            let mut seen: std::collections::HashSet<Option<String>> =
+                std::collections::HashSet::new();
+            let mut own = None;
             for scope in self.mro_readonly(pkg) {
-                self.collect_token_patterns_for_scope(&scope, name, &mut out);
-                if !out.is_empty() {
-                    return out;
+                if scope != pkg && own.is_none() {
+                    own = Some(out.len());
                 }
+                self.collect_token_patterns_for_scope_dedup(&scope, name, &mut out, &mut seen);
+            }
+            // Ancestor entries dispatch virtually through the receiver package.
+            let own = own.unwrap_or(out.len());
+            for entry in out.iter_mut().skip(own) {
+                entry.1 = pkg.to_string();
+            }
+            if !out.is_empty() {
+                return out;
             }
         }
         self.collect_token_patterns_for_scope("GLOBAL", name, &mut out);

--- a/src/runtime/regex/regex_token_resolve.rs
+++ b/src/runtime/regex/regex_token_resolve.rs
@@ -26,31 +26,36 @@ impl Interpreter {
                     out.extend(defs.clone());
                 }
             }
-            // Walk MRO for qualified names
-            if out.is_empty()
-                && let Some(pos) = name.rfind("::")
-            {
+            // Walk the MRO for qualified names, merging proto candidates from
+            // every ancestor (dedup by candidate identity, derived-first).
+            if let Some(pos) = name.rfind("::") {
                 let qual_pkg = &name[..pos];
                 let token_name = &name[pos + 2..];
+                let mut seen: std::collections::HashSet<String> = out
+                    .iter()
+                    .map(|d| Self::token_def_identity(&d.name.resolve(), token_name))
+                    .collect();
                 for ancestor in self.mro_readonly(qual_pkg) {
                     if ancestor == qual_pkg {
                         continue;
                     }
-                    self.collect_token_defs_for_scope(&ancestor, token_name, &mut out);
-                    if !out.is_empty() {
-                        break;
-                    }
+                    self.collect_token_defs_for_scope_dedup(
+                        &ancestor, token_name, &mut out, &mut seen,
+                    );
                 }
             }
             return out;
         }
         if !pkg.is_empty() {
-            // Walk MRO of pkg
+            // Walk the MRO of pkg, merging proto candidates from every class:
+            // a derived grammar adding `rule statement:sym<repeat>` keeps the
+            // base grammar's candidates (advent2009-day24).
+            let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
             for scope in self.mro_readonly(pkg) {
-                self.collect_token_defs_for_scope(&scope, name, &mut out);
-                if !out.is_empty() {
-                    return out;
-                }
+                self.collect_token_defs_for_scope_dedup(&scope, name, &mut out, &mut seen);
+            }
+            if !out.is_empty() {
+                return out;
             }
         }
         self.collect_token_defs_for_scope("GLOBAL", name, &mut out);

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -87,6 +87,64 @@ impl Interpreter {
     }
 
     /// Collect token defs for a given scope (exact + :sym<> variants).
+    /// Candidate identity of a token def: the def's own name when it is a
+    /// proto candidate of `token_name` (`statement:sym<expr>`), else the bare
+    /// `token_name`.
+    pub(crate) fn token_def_identity(def_name: &str, token_name: &str) -> String {
+        if def_name
+            .strip_prefix(token_name)
+            .is_some_and(|rest| rest.starts_with(":sym"))
+        {
+            def_name.to_string()
+        } else {
+            token_name.to_string()
+        }
+    }
+
+    /// Collect token defs for `name` in `scope`, deduplicating by candidate
+    /// identity (the bare `name` for an exact def, `name:sym<X>` for a proto
+    /// candidate) across successive calls via `seen`. Walking an MRO with this
+    /// merges proto candidates from every class — a derived grammar that adds
+    /// `rule statement:sym<repeat>` keeps the base grammar's candidates — while
+    /// a same-identity redefinition in a more-derived class still overrides its
+    /// ancestor's (first hit wins).
+    pub(crate) fn collect_token_defs_for_scope_dedup(
+        &self,
+        scope: &str,
+        name: &str,
+        defs: &mut Vec<std::sync::Arc<FunctionDef>>,
+        seen: &mut std::collections::HashSet<String>,
+    ) {
+        let exact_key = format!("{scope}::{name}");
+        if !seen.contains(name)
+            && let Some(exact) = self.registry().token_defs.get(&Symbol::intern(&exact_key))
+        {
+            defs.extend(exact.clone());
+            seen.insert(name.to_string());
+        }
+        let scope_prefix_len = scope.len() + 2;
+        let sym_prefix_angle = format!("{scope}::{name}:sym<");
+        let sym_prefix_french = format!("{scope}::{name}:sym\u{ab}");
+        let mut sym_keys: Vec<String> = self
+            .registry()
+            .token_defs
+            .keys()
+            .map(|key| key.resolve())
+            .filter(|key| key.starts_with(&sym_prefix_angle) || key.starts_with(&sym_prefix_french))
+            .collect();
+        sym_keys.sort();
+        for key in &sym_keys {
+            let identity = &key[scope_prefix_len..];
+            if seen.contains(identity) {
+                continue;
+            }
+            if let Some(sym_defs) = self.registry().token_defs.get(&Symbol::intern(key)) {
+                defs.extend(sym_defs.clone());
+                seen.insert(identity.to_string());
+            }
+        }
+    }
+
     pub(crate) fn collect_token_defs_for_scope(
         &self,
         scope: &str,
@@ -186,32 +244,32 @@ impl Interpreter {
                     defs.extend(sym_defs.clone());
                 }
             }
-            // If not found, try walking MRO of the package part
-            if defs.is_empty()
-                && let Some(pos) = name.rfind("::")
-            {
+            // Walk the MRO of the package part, merging proto candidates from
+            // every ancestor (dedup by candidate identity, derived-first).
+            if let Some(pos) = name.rfind("::") {
                 let pkg = &name[..pos];
                 let token_name = &name[pos + 2..];
+                let mut seen: std::collections::HashSet<String> = defs
+                    .iter()
+                    .map(|d| Self::token_def_identity(&d.name.resolve(), token_name))
+                    .collect();
                 for ancestor in self.mro_readonly(pkg) {
                     if ancestor == pkg {
                         continue; // already checked
                     }
-                    self.collect_token_defs_for_scope(&ancestor, token_name, &mut defs);
-                    if !defs.is_empty() {
-                        break;
-                    }
+                    self.collect_token_defs_for_scope_dedup(
+                        &ancestor, token_name, &mut defs, &mut seen,
+                    );
                 }
             }
             return if defs.is_empty() { None } else { Some(defs) };
         }
         let mut defs = Vec::new();
-        // Check current package and its MRO
+        // Check current package and its MRO, merging proto candidates.
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
         let scopes_to_check = self.mro_readonly(&self.current_package());
         for scope in &scopes_to_check {
-            self.collect_token_defs_for_scope(scope, name, &mut defs);
-            if !defs.is_empty() {
-                break;
-            }
+            self.collect_token_defs_for_scope_dedup(scope, name, &mut defs, &mut seen);
         }
         // Also check GLOBAL
         if defs.is_empty() {

--- a/t/grammar-derived-proto-candidates.t
+++ b/t/grammar-derived-proto-candidates.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+plan 6;
+
+# A derived grammar that adds a proto-token candidate must keep the base
+# grammar's candidates (advent2009-day24).
+
+grammar B {
+    rule TOP { <statement> }
+    proto token statement { <...> }
+    rule statement:sym<expr> { \d+ }
+}
+grammar D is B {
+    rule statement:sym<repeat> { 'repeat' \d+ }
+}
+
+ok D.parse('repeat 5'), 'derived candidate matches';
+ok D.parse('7'), 'inherited candidate still matches in the derived grammar';
+ok B.parse('7'), 'base grammar unchanged';
+nok B.parse('repeat 5'), 'base grammar is not extended by the derived one';
+
+# A derived same-sym candidate replaces (shadows) the base one — it does not
+# merge with it (matches Rakudo v2026.06 behavior).
+grammar D2 is B {
+    rule statement:sym<expr> { 'x' \d+ }
+}
+nok D2.parse('9'), 'overridden base candidate no longer matches';
+ok B.parse('7'), 'base grammar unaffected by the override';


### PR DESCRIPTION
## Summary

Whitelists `roast/integration/advent2009-day24.t` (4/4) from BLOCKERS cluster ⑤ (the ledger's "test 2 hangs" note was stale — with current main the file failed test 3 because inherited candidates were lost).

A derived grammar that added its own proto-token candidate lost every candidate inherited from its base: the token-def/pattern resolution walked the MRO but **stopped at the first scope with any hit**, so `grammar D is B { rule statement:sym<repeat> {...} }` made `<statement>` in `D` see only `sym<repeat>`.

The MRO walks in `resolve_token_defs`, `resolve_token_defs_in_pkg`, and `resolve_token_patterns_static_in_pkg` now **merge candidates from every class**, deduplicating by candidate identity (bare name for an exact def, `name:sym<X>` for a proto candidate) with the most-derived definition winning; multi candidates within one scope are all kept. Ancestor pattern entries keep dispatching virtually through the receiver package (Liskov), as the qualified-name branch already did.

## Tests
- Pin: `t/grammar-derived-proto-candidates.t` (inheritance + extension, base isolation, same-sym override shadows — matches Rakudo v2026.06)
- `advent2009-day24.t`: 4/4
- `roast/S05-grammar/` (11 files): PASS; full local `t/`: PASS
- `S05-metasyntax` non-whitelisted files stay at their pre-existing known counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)