### PR TITLE
docs: translate ADRs (docs/adr/) to English

### DIFF
--- a/docs/adr/0001-gc-strategy-and-phasing.md
+++ b/docs/adr/0001-gc-strategy-and-phasing.md
@@ -1,203 +1,202 @@
-# ADR-0001: GC 導入の方式選定とフェーズ計画
+# ADR-0001: GC adoption — mechanism selection and phasing
 
-- **Status**: Accepted（2026-06-27 — レベル1採用。収集方式 §4.2・A' 範囲 §4.3 は未決として残す）
+- **Status**: Accepted (2026-06-27 — level 1 adopted. The collection-trigger mechanism §4.2 and the A' scope §4.3 remain open)
 - **Date**: 2026-06-27
 - **Deciders**: tokuhirom, Claude
-- **関連**: [ANALYSIS.md](../../ANALYSIS.md) §2.1 / §1.3 / §5、[PLAN.md](../../PLAN.md) §G(perf) / §I(Track C)
+- **Related**: [ANALYSIS.md](../../ANALYSIS.md) §2.1 / §1.3 / §5, [PLAN.md](../../PLAN.md) §G(perf) / §I(Track C)
 
-> このファイルは「mutsu に GC をいつ・どの方式で導入するか」を巡る設計判断を記録する。
-> 最終決定が確定していない論点は「未決」節に分け、合意済みの方向性と区別する。
-> ADR は今後この決定に触れる作業の起点とし、判断が変わったら新しい ADR で supersede する。
-
----
-
-## 1. Context（背景）
-
-### 1.1 現状
-
-- mutsu のメモリ管理は **`Arc` 参照カウントのみ**。tracing GC も cycle collector も存在しない。
-  → **循環参照はリークする**（`value/mod.rs`）。`Weak` は `CONSUMED_SEQS` / `WeakSub` /
-  `ptr_keyed.rs` 等の局所対策に留まり、系統的ではない。
-- 循環は Raku で普通に書ける：再帰クロージャの env 自己捕捉、相互参照オブジェクト（親子・グラフ・
-  双方向リスト）、`%h<k> := %h` 系の自己束縛（`element-element-bind-plan.md` の MAX_DESCENT は
-  「無限ループ防止」であって**メモリは回収していない**）、Promise/Supply の channel 相互参照。
-  → **実害あり**。
-
-### 1.2 プロジェクト方針との関係
-
-- gain 定義（CLAUDE.md）：gain = 正しいアーキテクチャ（Raku 互換 + 速度 + flaky なし）。
-- ユーザー方針：**まず raku に追いついて十分な速度を出す → その上で明確なメリットのある実装を作る**。
-- そのフェーズに到達したとき、**GC のないインタプリタは「欠陥品」とみなされ誰も使わない**。
-  → GC は「やるか否か」ではなく **table stakes（プロダクト品質の最低ライン）**。論点は *いつ・どの方式で*。
-
-### 1.3 決定を縛る技術的制約
-
-- **mutsu は既にマルチスレッド実行する**：`start{}` / `Promise` / `hyper` / `race`。
-  `Value` は `Arc` ベースで **Send + Sync 前提**。cross-thread 共有の実体は `clone_for_thread` →
-  `shared_vars: RwLock<HashMap>`（`runtime/mod.rs`、ANALYSIS §2.1）。
-- **mutsu は Rust の所有権の上に乗っている**：`Value` は Rust の enum で、Rust のスタック・ローカル変数・
-  一時値・`Vec<Value>` のあちこちに**生で**存在する。VM が全 Value の居場所を把握しているわけではない。
+> This file records the design judgment around "when, and with which mechanism, to introduce GC into mutsu".
+> Points where the final decision is not yet fixed are separated into the "Open questions" section, distinct from the agreed direction.
+> This ADR is the starting point for any future work that touches this decision; if the judgment changes, supersede it with a new ADR.
 
 ---
 
-## 2. 参考：リファレンス実装（MoarVM）の GC
+## 1. Context
 
-Rakudo → NQP → **MoarVM**。GC は MoarVM が持ち、構成は：
+### 1.1 Current state
 
-- **Generational（世代別）**：
-  - **Nursery（若い世代）= semi-space copying**。各スレッドが自分の nursery を持ち、**alloc = bump
-    pointer（ポインタを進めるだけ）**で激速。collection 時に tospace/fromspace でコピー。
-  - **Gen2（古い世代）**：nursery collection を生き残ったオブジェクトを昇格（tenure）。サイズ別
-    free-list pools ＋ large object、回収は full collection で mark-sweep 的。
-- **Moving（コピーする）**：nursery オブジェクトはアドレスが動く → forwarding ポインタで付け替え。
-- **Parallel / stop-the-world**：collection 時に全スレッドを safepoint で止め、回収を複数スレッドで分担。
-  世代間参照は **write barrier** で remembered set に記録。
-- **refcount は一切使わない。**
+- mutsu's memory management is **`Arc` reference counting only**. There is no tracing GC and no cycle collector.
+  → **Cyclic references leak** (`value/mod.rs`). `Weak` is limited to local countermeasures such as `CONSUMED_SEQS` / `WeakSub` /
+  `ptr_keyed.rs`, and is not systematic.
+- Cycles are trivially expressible in ordinary Raku: env self-capture in recursive closures, mutually-referencing objects (parent-child, graphs,
+  doubly-linked lists), self-bindings of the `%h<k> := %h` kind (the MAX_DESCENT in `element-element-bind-plan.md` is
+  "infinite-loop prevention" — it **does not reclaim memory**), and Promise/Supply channel mutual references.
+  → **Real harm exists.**
 
-**重要な含意**：tracing GC は mutate ごとの atomic inc/dec が無く alloc が bump pointer で激速。
-つまり「シングルスレッドの速さ」という観点では、**tracing GC の方が refcount/cycle collector より速い**。
+### 1.2 Relationship to project policy
 
-**なぜ MoarVM はそれができるか**：VM が世界を完全に所有しているから。全オブジェクトが `MVMObject`
-ヘッダを持ち、値は `MVMThreadContext` 管理下のフレーム経由でアクセスし、C 拡張ですら `MVMROOT` で
-root を明示登録する。→ GC が全 root と全ポインタの居場所を正確に把握でき、安全に動かせる。
+- Definition of gain (CLAUDE.md): gain = the correct architecture (Raku compatibility + speed + no flakiness).
+- User policy: **first catch up to raku and reach sufficient speed → then build an implementation with clear advantages on top of that**.
+- Once that phase is reached, **an interpreter without GC will be regarded as "defective" and nobody will use it**.
+  → GC is not a question of "whether" but **table stakes (the minimum bar for product quality)**. The open questions are *when and with which mechanism*.
 
-**mutsu との根本差**：mutsu は Rust スタックに生 Value が散らばっているため、precise moving GC が必要と
-する「全 root の把握」が不可能。実現するには Value を必ずハンドル経由でしか触らない設計への
-**全面再設計**が要る（後述レベル2）。
+### 1.3 Technical constraints binding the decision
+
+- **mutsu already executes multi-threaded**: `start{}` / `Promise` / `hyper` / `race`.
+  `Value` is `Arc`-based and assumes **Send + Sync**. The substance of cross-thread sharing is `clone_for_thread` →
+  `shared_vars: RwLock<HashMap>` (`runtime/mod.rs`, ANALYSIS §2.1).
+- **mutsu sits on top of Rust's ownership model**: `Value` is a Rust enum and lives **raw** all over Rust stacks, local variables,
+  temporaries, and `Vec<Value>`s. The VM does not know the location of every Value.
 
 ---
 
-## 3. Decision（合意した方向性）
+## 2. Reference: the GC of the reference implementation (MoarVM)
 
-> 以下は 2026-06-27 の議論で合意した方向性。**最終承認待ちの分岐は §4 に分離**。
+Rakudo → NQP → **MoarVM**. The GC belongs to MoarVM, and its structure is:
 
-1. **GC は最終的に必須**（プロダクト品質要件）。論点は導入時期と方式のみ。
+- **Generational**:
+  - **Nursery (young generation) = semi-space copying**. Each thread owns its own nursery, and **alloc = bump
+    pointer (just advancing a pointer)** — extremely fast. At collection time, objects are copied between tospace/fromspace.
+  - **Gen2 (old generation)**: objects that survive a nursery collection are promoted (tenured). Size-segregated
+    free-list pools plus large objects; reclamation happens mark-sweep-style in a full collection.
+- **Moving (copying)**: nursery objects change addresses → repointed via forwarding pointers.
+- **Parallel / stop-the-world**: at collection time all threads are stopped at a safepoint, and the collection work is divided across multiple threads.
+  Inter-generational references are recorded in a remembered set via a **write barrier**.
+- **No refcounting whatsoever.**
 
-2. **フェーズ順序を固定する**：
+**Key implication**: a tracing GC has no atomic inc/dec per mutation, and alloc is a blazing-fast bump pointer.
+In other words, from the standpoint of "single-thread speed", **a tracing GC is faster than refcount/cycle-collector approaches**.
 
-   | フェーズ | 内容 | 現 PLAN.md の該当 | シングルスレッド速度への影響 |
+**Why MoarVM can do this**: because the VM owns the world completely. Every object carries an `MVMObject`
+header, values are accessed via frames managed under `MVMThreadContext`, and even C extensions explicitly register
+roots with `MVMROOT`. → The GC knows the exact location of every root and every pointer, and can safely move objects.
+
+**The fundamental difference from mutsu**: mutsu has raw Values scattered across Rust stacks, so the "full knowledge of all roots"
+that a precise moving GC requires is impossible. Achieving it would require a **full redesign** in which Values are only ever
+touched through handles (level 2, described below).
+
+---
+
+## 3. Decision (agreed direction)
+
+> The following is the direction agreed in the 2026-06-27 discussion. **Forks still awaiting final approval are separated into §4.**
+
+1. **GC is ultimately mandatory** (a product-quality requirement). The only open questions are timing and mechanism.
+
+2. **Fix the phase ordering**:
+
+   | Phase | Content | Corresponding items in current PLAN.md | Impact on single-thread speed |
    |---|---|---|---|
-   | **A. 追いつく** | 互換性＋速度で raku に並ぶ | §F roast, §2 multi-dispatch, §H module, perf Lever 1/3 | — |
-   | **A'. 地ならし** | root を集約し GC 実装を楽にする | §1.4 レキシカルスコープ, §1.3 upvalue index 化 | — |
-   | **B. Value 表現リワーク＋GC** | 下記 §3 層3a | §2.1 Track B, GC（新規） | 中立（型フィルタで hot path 0） |
-   | **C. JIT** | 独自メリット | perf Lever 4 | 改善 |
+   | **A. Catch up** | Match raku on compatibility + speed | §F roast, §2 multi-dispatch, §H module, perf Lever 1/3 | — |
+   | **A'. Groundwork** | Consolidate roots to make the GC implementation easier | §1.4 lexical scope, §1.3 upvalue index conversion | — |
+   | **B. Value-representation rework + GC** | Layer 3a below (§3) | §2.1 Track B, GC (new) | Neutral (type filter keeps hot path at 0) |
+   | **C. JIT** | Distinct advantage of its own | perf Lever 4 | Improvement |
 
-   - **GC は JIT の前**：JIT が生成するネイティブコード上のオブジェクト参照を後から GC の root 走査／
-     セーフポイントに組み込むのは困難。先に GC を入れてから JIT なら最初から GC 前提の root を吐ける。
-   - **GC は Phase A 完了後に着手**：追いついていない段階で GC を入れても「遅くてリークしない
-     インタプリタ」にしかならない。GC は当面 PLAN.md の「将来」節に置く。
+   - **GC before JIT**: retrofitting object references inside JIT-generated native code into GC root scanning /
+     safepoints is hard. If GC lands first, the JIT can emit GC-aware roots from day one.
+   - **Start GC only after Phase A is done**: introducing GC before catching up merely yields a "slow but
+     leak-free interpreter". For now, GC stays in PLAN.md's "future" section.
 
-3. **moving GC（MoarVM 式 nursery copying）は却下**：Rust 所有 + Arc 直接保持と非互換。
-   root の完全把握が不可能で、アドレスが動くと `arc_contents_mut`（生ポインタ書き込み）が全壊する。
+3. **Moving GC (MoarVM-style nursery copying) is rejected**: incompatible with Rust ownership + directly held Arcs.
+   Full root knowledge is impossible, and moving addresses would completely break `arc_contents_mut` (raw-pointer writes).
 
-4. **第一候補は cycle collector on Arc（Bacon-Rajan trial-deletion / concurrent cycle collection）**：
-   - `Arc` の Send + Sync を維持 → 既存の cross-thread モデル（start/Promise/hyper/race・`shared_vars`）を
-     壊さない。Bacon-Rajan は元々 concurrent 環境向け設計。
-   - Value 表現の全置換が不要 → blast radius が tracing より桁違いに小さい。
-   - 「循環リークという実害そのもの」だけを狙い撃つ。gain 定義（互換性・正しさ）に直結。
+4. **The primary candidate is a cycle collector on Arc (Bacon-Rajan trial-deletion / concurrent cycle collection)**:
+   - Keeps `Arc`'s Send + Sync → does not break the existing cross-thread model (start/Promise/hyper/race, `shared_vars`).
+     Bacon-Rajan was originally designed for concurrent environments.
+   - No wholesale replacement of the Value representation → the blast radius is orders of magnitude smaller than tracing.
+   - Targets exactly "the real harm of cyclic leaks" and nothing more. Directly tied to the gain definition (compatibility, correctness).
 
-5. **型フィルタで hot path を守る**：`Gc<T>` 管理は**循環を作り得るコンテナ系 variant だけ**に導入する。
-   - 対象（コンテナ系）：`Array` / `Hash` / `Set` / `Bag` / `Mix` / `Pair` / `Instance` / `Sub`(closure) /
-     `ContainerRef`。
-   - 非対象（スカラ系・循環不可能）：`Int` / `Num` / `Rat` / `Complex` / `Str` / `Bool` / `Nil`。
-   - → fib 等の**数値演算ループ・文字列処理は candidate 登録ゼロ**。mutsu のベンチ律速（数値・
-     メソッド呼び出し）が GC の影響を受けない。「Bacon-Rajan は遅い」は naïve に全オブジェクトへ
-     均一適用した場合の話で、型で切れば回避できる。
+5. **Protect the hot path with a type filter**: introduce `Gc<T>` management **only for the container-kind variants that can form cycles**.
+   - In scope (container-kind): `Array` / `Hash` / `Set` / `Bag` / `Mix` / `Pair` / `Instance` / `Sub`(closure) /
+     `ContainerRef`.
+   - Out of scope (scalar-kind, cannot form cycles): `Int` / `Num` / `Rat` / `Complex` / `Str` / `Bool` / `Nil`.
+   - → **Numeric loops and string processing (fib etc.) register zero candidates**. mutsu's benchmark bottlenecks (numerics,
+     method calls) are unaffected by GC. "Bacon-Rajan is slow" applies to the naïve case of applying it uniformly to all
+     objects; filtering by type avoids it.
 
-6. **層分割（Value 表現リワークの内訳）**：
+6. **Layer split (breakdown of the Value-representation rework)**:
 
-   | 層 | 内容 | 関係 |
+   | Layer | Content | Relationship |
    |---|---|---|
-   | **3a** | Track B（要素セル化）＋ cycle collector ＝ コンテナ系の `Arc → Gc<T>` 一斉置換 | **不可分。1キャンペーンで実施** |
-   | **3b** | NaN-boxing（Value 48→8B） | **JIT の地ならし**（8B 固定・タグ単純・レジスタに乗る）。GC 後・JIT 前。順序 3a→3b→4 |
-   | **3c** | biased reference counting（所有スレッドからの操作は非 atomic） | GC 後の独立 perf 課題。**JIT が intループをネイティブ化すれば優先度低下**（hot path から refcount が消える） |
+   | **3a** | Track B (element cell-ification) + cycle collector = one-shot `Arc → Gc<T>` replacement of the container kinds | **Inseparable. Executed as one campaign** |
+   | **3b** | NaN-boxing (Value 48→8B) | **Groundwork for the JIT** (fixed 8B, simple tags, fits in a register). After GC, before JIT. Order 3a→3b→4 |
+   | **3c** | Biased reference counting (operations from the owning thread are non-atomic) | Independent perf work after GC. **Priority drops once the JIT natively compiles int loops** (refcounting disappears from the hot path) |
 
-   - **3a が不可分な理由**：Track B も GC も同じ `Arc<ArrayData>` / `Arc<HashData>` 群（ANALYSIS §2.1、
-     79 箇所）を触る。別々にやると 79 箇所を 2 回触り、相互に作り直しになる。さらに Track B の最大の
-     地雷「`arc_contents_mut` 借用保持中の VM 再入デッドロック」と、cycle collector の「いつ collect を
-     走らせるか（セーフポイント）」は**同じ再入境界の問題**で、一緒に設計すれば一本化できる。
-   - **3b を分離できる理由**：cycle collector 案では Arc/Gc ポインタが残るので、NaN-boxing は
-     「スカラ=payload / コンテナ=Gc ポインタタグ」になるだけ。tracing GC の mark ビット配置問題が
-     起きず、GC と同時必須ではなくなる。
+   - **Why 3a is inseparable**: Track B and GC both touch the same `Arc<ArrayData>` / `Arc<HashData>` family (ANALYSIS §2.1,
+     79 sites). Doing them separately means touching those 79 sites twice, each round reworking the other. Furthermore, Track B's biggest
+     landmine — "VM re-entry deadlock while holding an `arc_contents_mut` borrow" — and the cycle collector's "when to run
+     collection (safepoint)" question are **the same re-entry-boundary problem**; designed together, they can be unified.
+   - **Why 3b can be separated**: under the cycle-collector plan, Arc/Gc pointers remain, so NaN-boxing simply becomes
+     "scalar = payload / container = Gc pointer tag". The tracing-GC mark-bit placement problem does not
+     arise, so it is no longer mandatory to do simultaneously with GC.
 
-7. **検証手段**：`MUTSU_VM_STATS` に `gc_candidate_pushes` / `gc_collections` 等のカウンタを追加し、
-   **fib ベンチで candidate push = 0 を実測で保証**する（counters は最適化レベル非依存・debug build で回す
-   = CLAUDE.md 方針に合致）。「GC を入れたら hot path が遅くなった」を推測でなく数字で監視する。
+7. **Verification means**: add counters such as `gc_candidate_pushes` / `gc_collections` to `MUTSU_VM_STATS`, and
+   **guarantee by measurement that candidate pushes = 0 on the fib bench** (the counters are independent of optimization level and iterated with debug builds
+   — matching the CLAUDE.md policy). Monitor "GC made the hot path slower" with numbers, not guesses.
 
-8. **レベル1（cycle collector on Arc）を採用する**（2026-06-27 決定）。方針は「cyclic reference が
-   解決すればよく、性能は JIT で稼ぐ」。**GC に性能を求めない＝GC を単純に保てる＝JIT も載せやすい**、
-   という連鎖で一貫する。
-   - **JIT 観点でもレベル1 が載せやすい**：レベル1 は **non-moving + refcount**。JIT＋GC 協調で地獄に
-     なる 3 点（① セーフポイントごとのスタックマップ生成 ② moving 時の forwarding ③ write barrier emit）が
-     ほぼ消える。non-moving ゆえポインタが動かず forwarding 不要、refcount が生存を保証するので root
-     スキャンに JIT スタックマップが原理的に不要。**JIT がやるのは「Arc inc/dec を emit する」だけ**。
-   - **レベル2 は JIT の上限性能は最高だが JIT 実装そのものが本格 VM 級**（MoarVM/V8/JVM 相当の
-     スタックマップ・forwarding・barrier）。「やりやすさ」では逆に最難関。
-   - **mutsu の律速と噛み合う**：数値・fib・メソッド呼び出しが律速で、Int/Num/Bool は型フィルタで
-     Gc 対象外。JIT が intループをネイティブ int 化すれば内側は **GC も refcount もゼロの完全ネイティブ
-     コード**になり、hot path はレベル2 とほぼ同性能。GC を重く作って性能を取りにいく必要が消える。
-   - **レベル2 は長期オプションとして保留**：レベル1 JIT が refcost の天井（オブジェクト多用コード）に
-     当たり、かつそれが**実測で**ボトルネックと判明した場合にのみ、新しい ADR で再評価する。
-
----
-
-## 4. Open questions（未決 — 4.2 / 4.3 のみ。4.1 は §3-8 で決定済み）
-
-### 4.1 レベル1 か レベル2 か → **レベル1で決定（§3-8）**
-
-2026-06-27、**レベル1（cycle collector on Arc）採用で決定**。根拠は §3-8（特に JIT 観点：
-non-moving + refcount が JIT のスタックマップ/forwarding/barrier を回避し、型フィルタで数値 hot path は
-JIT ネイティブ化で GC/refcost ゼロ）。レベル2（VM 全面再設計で MoarVM 式 precise moving tracing）は、
-レベル1 JIT が refcost の天井に**実測で**当たった場合にのみ新しい ADR で再評価する長期オプションとして保留。
-
-参考（却下したレベル2 の特性）：全 Value をハンドル/ヒープ管理し Rust スタックに生 Value を置かない
-全面再設計。性能の上限は最も高い（bump alloc・refcost ゼロ）が、事実上インタプリタの再設計で年単位、
-Rust で書く安全性の旨味を相当捨てる。
-
-### 4.2 cycle collection の起動方式
-
-- 同期（candidate buffer が閾値超過時にトリガ、その場で trial-deletion scan）
-- 非同期（background thread で concurrent collection、シングルスレッド実行は push のみ）
-
-→ 4.1 がレベル1で確定した後、3a 設計時に決める。
-
-### 4.3 A'（地ならし）の範囲
-
-§1.4 レキシカルスコープ導入・§1.3 upvalue index 化のどこまでを「GC の前提条件」とするか。
-root を「フレームの `Vec<Value>` ＋ upvalue 配列」に集約できれば cycle collector の root 列挙が単純化する。
-env HashMap が root 経路に残る限り走査が複雑化する点が判断材料。
+8. **Adopt level 1 (cycle collector on Arc)** (decided 2026-06-27). The policy is "it suffices to solve cyclic
+   references; performance is earned by the JIT". The chain is consistent: **demanding no performance from GC = keeping GC simple = making the JIT easier to land**.
+   - **Level 1 is also the easier one to put a JIT on**: level 1 is **non-moving + refcount**. The three points that turn JIT+GC
+     cooperation into hell (① stack-map generation at every safepoint ② forwarding under moving ③ write-barrier emission)
+     essentially disappear. Being non-moving, pointers never move so no forwarding is needed; refcounting guarantees liveness, so root
+     scanning needs no JIT stack maps in principle. **All the JIT does is "emit Arc inc/dec".**
+   - **Level 2 has the highest JIT performance ceiling, but the JIT implementation itself is full-VM grade** (MoarVM/V8/JVM-class
+     stack maps, forwarding, barriers). In terms of "ease of landing" it is, conversely, the hardest.
+   - **It matches mutsu's bottlenecks**: numerics, fib, and method calls are the bottlenecks, and Int/Num/Bool are excluded from
+     Gc by the type filter. Once the JIT compiles int loops to native ints, the inner loop becomes **fully native
+     code with zero GC and zero refcounting**, so the hot path performs almost the same as level 2. The need to build a heavyweight GC to chase performance disappears.
+   - **Level 2 is shelved as a long-term option**: only if the level-1 JIT hits the refcount-cost ceiling (object-heavy code)
+     and that is shown **by measurement** to be the bottleneck, re-evaluate it with a new ADR.
 
 ---
 
-## 5. Consequences（決定の帰結）
+## 4. Open questions (only 4.2 / 4.3 remain — 4.1 was decided in §3-8)
 
-- **Phase A 完了までは GC 本体に着手しない。** PLAN.md の GC は「将来」節に置く。
-- **Track B を単独で先行着手しない。** GC と統合（層3a）する前提に変更する。ANALYSIS §2.1 / §7-6 に
-  「Track B は GC と一体（Arc→Gc 一斉置換）」を追記する。
-- **perf Lever 2（NaN-boxing）は GC と同時必須ではない**（層3b・GC 後でも可）と PLAN.md §G に反映する。
-- **biased refcount を新規 perf 課題（層3c）として PLAN.md §G に追加する**（NaN-boxing・JIT と並ぶ箱）。
-- 層3a 着手時は、コンテナ系 variant の `Arc → Gc` 置換と Track B 要素セル化を **1 キャンペーン**で行う。
-- 層3a の実装詳細（cooperative STW / root 列挙 / async node の first-wave 切り方）は
-  [gc-level1-detailed-design.md](../gc-level1-detailed-design.md) で管理する。
+### 4.1 Level 1 or level 2 → **decided: level 1 (§3-8)**
 
-- **CLAUDE.md にエージェント向けルールを追記する**：ADR 慣習（`docs/adr/`）と本 ADR の GC/JIT
-  ロードマップ要約（フェーズ順序・moving 却下・cycle collector・型フィルタ・Track B 統合・level-1/2 未決）。
+On 2026-06-27, **level 1 (cycle collector on Arc) was adopted**. Rationale in §3-8 (especially the JIT angle:
+non-moving + refcount avoids JIT stack maps/forwarding/barriers, and with the type filter the numeric hot path reaches
+zero GC/refcount cost via JIT native compilation). Level 2 (full VM redesign for MoarVM-style precise moving tracing) is
+shelved as a long-term option, to be re-evaluated with a new ADR only if the level-1 JIT hits the refcount-cost ceiling **in actual measurement**.
 
-> 注：本 ADR は方向性の記録であり、上記の PLAN.md / ANALYSIS.md への反映（文書再整理）は
-> 別作業として実施する（このセッションでは「まず議論を詰める」を選択したため未反映）。CLAUDE.md への
-> ルール反映は本 PR で実施済み。
+For reference (characteristics of the rejected level 2): a full redesign managing every Value via handles/heap, with no raw
+Values on Rust stacks. Its performance ceiling is the highest (bump alloc, zero refcount cost), but it is effectively a reimplementation of the interpreter — on the order of years —
+and throws away much of the safety benefit of writing in Rust.
+
+### 4.2 How cycle collection is triggered
+
+- Synchronous (triggered when the candidate buffer exceeds a threshold, trial-deletion scan on the spot)
+- Asynchronous (concurrent collection on a background thread; single-threaded execution only does pushes)
+
+→ To be decided during 3a design, now that 4.1 has settled on level 1.
+
+### 4.3 Scope of A' (groundwork)
+
+How much of §1.4 lexical-scope introduction and §1.3 upvalue index conversion counts as a "GC prerequisite".
+If roots can be consolidated into "the frame's `Vec<Value>` + the upvalue array", root enumeration for the cycle collector becomes simple.
+The deciding factor is that as long as the env HashMap remains on the root path, scanning stays complicated.
 
 ---
 
-## 6. Alternatives considered（検討した代替案）
+## 5. Consequences
 
-| 案 | alloc/mutate 速度 | mutsu への実装現実性 | Rust 所有権との関係 | 判定 |
+- **Do not start on the GC proper until Phase A is complete.** GC stays in PLAN.md's "future" section.
+- **Do not start Track B standalone ahead of time.** Change the premise to integrating it with GC (layer 3a). Add to ANALYSIS §2.1 / §7-6
+  that "Track B is one with GC (one-shot Arc→Gc replacement)".
+- **perf Lever 2 (NaN-boxing) is not mandatory simultaneously with GC** (layer 3b, fine after GC) — reflect this in PLAN.md §G.
+- **Add biased refcounting as a new perf work item (layer 3c) to PLAN.md §G** (a box alongside NaN-boxing and JIT).
+- When starting layer 3a, perform the `Arc → Gc` replacement of the container-kind variants and Track B element cell-ification as **one campaign**.
+- The implementation details of layer 3a (cooperative STW / root enumeration / how to carve the first wave of async nodes) are
+  managed in [gc-level1-detailed-design.md](../gc-level1-detailed-design.md).
+
+- **Add agent-facing rules to CLAUDE.md**: the ADR convention (`docs/adr/`) and a summary of this ADR's GC/JIT
+  roadmap (phase ordering, moving rejected, cycle collector, type filter, Track B integration, level-1/2 open).
+
+> Note: this ADR is a record of direction; propagating the above into PLAN.md / ANALYSIS.md (document reorganization) is
+> carried out as separate work (this session chose "settle the discussion first", so it is not yet reflected). The rule
+> additions to CLAUDE.md were done in this PR.
+
+---
+
+## 6. Alternatives considered
+
+| Option | alloc/mutate speed | Implementation feasibility for mutsu | Relationship to Rust ownership | Verdict |
 |---|---|---|---|---|
-| **MoarVM 式 generational moving tracing** | 最速（bump alloc・refcost 0） | ✕ 全 Value ハンドル化＝VM 全面再設計 | 捨てる | レベル2 として長期保留 |
-| **conservative non-moving mark-sweep（Boehm 式）** | 中（bump 無し・Arc 併存問題） | △ Arc/GC 二重管理・誤検出・MT スタック走査が地雷、cycle collector より難しくなりがち | 半分捨てる | 却下寄り |
-| **既存 GC ライブラリ（gc-arena / rust-gc / broom）** | — | ✕ ほぼ single-thread（`Gc<T>: !Send`）、cross-thread 不可 | — | 却下（MT 非対応） |
-| **cycle collector on Arc（Bacon-Rajan）** | refcost 残るが型フィルタで hot path 0 | ○ 最小侵襲・既存 Arc 活用 | 維持 | **第一候補（レベル1）** |
+| **MoarVM-style generational moving tracing** | Fastest (bump alloc, refcount cost 0) | ✕ Handle-ifying every Value = full VM redesign | Abandoned | Shelved long-term as level 2 |
+| **Conservative non-moving mark-sweep (Boehm-style)** | Medium (no bump; Arc-coexistence problem) | △ Dual Arc/GC management, false positives, MT stack scanning are landmines; tends to end up harder than a cycle collector | Half abandoned | Leaning reject |
+| **Existing GC libraries (gc-arena / rust-gc / broom)** | — | ✕ Essentially single-thread (`Gc<T>: !Send`), no cross-thread | — | Rejected (no MT support) |
+| **Cycle collector on Arc (Bacon-Rajan)** | Refcount cost remains, but type filter keeps hot path at 0 | ○ Minimally invasive, reuses existing Arc | Preserved | **Primary candidate (level 1)** |
 
 ---
 
-*この ADR は 2026-06-27 の設計議論を記録したもの。判断が変わった場合は新しい ADR で supersede する。*
+*This ADR records the design discussion of 2026-06-27. If the judgment changes, supersede it with a new ADR.*

--- a/docs/adr/0002-phase-a-gate-reassessment.md
+++ b/docs/adr/0002-phase-a-gate-reassessment.md
@@ -1,40 +1,40 @@
-# ADR-0002: Phase A ゲート再評価 — GC 着手条件の充足確認
+# ADR-0002: Phase A gate reassessment — confirming the preconditions for starting GC
 
 - **Status**: Accepted
 - **Date**: 2026-07-03
 - **Deciders**: tokuhirom, Claude
-- **関連**: [ADR-0001](0001-gc-strategy-and-phasing.md)（本 ADR は ADR-0001 §3-2 の「GC は Phase A 完了後に着手」の
-  判定基準を補足・確定する。ADR-0001 自体を撤回・supersede するものではない）
+- **Related**: [ADR-0001](0001-gc-strategy-and-phasing.md) (this ADR supplements and finalizes the judgment criteria for
+  ADR-0001 §3-2's "start GC only after Phase A is complete". It does not retract or supersede ADR-0001 itself)
 
 ## 1. Context
 
-ADR-0001 は「GC は Phase A（互換性＋速度で raku に追いつく）完了後に着手」と決めたが、
-「完了」の判定を PLAN.md のメトリクス表（whitelist 数・perf 倍率）に委ねていた。
-2026-07-03 時点で GC 開発着手の是非を検討したところ、この表が **stale** であることが判明した。
+ADR-0001 decided "start GC after Phase A (catching up to raku on compatibility + speed) is complete",
+but delegated the judgment of "complete" to PLAN.md's metrics table (whitelist count, perf ratios).
+When evaluating on 2026-07-03 whether to start GC development, that table turned out to be **stale**.
 
-## 2. 判明した事実
+## 2. Findings
 
-- PLAN.md 記載の whitelist 数「1285 / 目標 1300+」は古い値。
-- 実測: whitelist **1345**（`roast-whitelist.txt`）／ roast 全 `.t` ファイル **1463**。
-  → **目標 1300+ は既に達成済み**。残り ~118 件は §F 記載の通り、rakudo 自身が未実装の構文・
-  MoarVM REPR 依存・fudge 対象など、個別対応の見込みが薄いロングテール。
-- perf 目標（method-call <1.5x 等）は未達だが、残る主要レバー（Lever 2 NaN-boxing・Lever 4 JIT）は
-  **ADR-0001 自身が GC の後（層3b・層4）に順序づけている**。GC 未着手を理由に perf 完了を待つのは
-  「GC の後にやる作業の完了を GC 着手条件にする」循環になり、自己矛盾する。
-  残る pre-GC perf 項目は Lever 3（threaded dispatch）のみで、これは GC と独立に並行可能。
+- The whitelist count recorded in PLAN.md, "1285 / target 1300+", is an old value.
+- Measured: whitelist **1345** (`roast-whitelist.txt`) / **1463** total roast `.t` files.
+  → **The 1300+ target is already met.** The remaining ~118 files are, as §F describes, a long tail with
+  little prospect of individual fixes: syntax rakudo itself has not implemented, MoarVM REPR dependencies, fudge targets, etc.
+- The perf targets (method-call <1.5x etc.) are not met, but the remaining major levers (Lever 2 NaN-boxing, Lever 4 JIT) are
+  **ordered after GC (layer 3b, layer 4) by ADR-0001 itself**. Waiting for perf completion before starting GC would be
+  the circular condition "make completion of post-GC work a precondition for starting GC" — self-contradictory.
+  The only remaining pre-GC perf item is Lever 3 (threaded dispatch), which can proceed in parallel, independent of GC.
 
 ## 3. Decision
 
-- **Phase A の完了条件を「substrate 完了 ∧ roast 目標達成」と確定する。** perf の全レバー完了は
-  Phase A 完了条件に含めない（Lever 2/4 は設計上 GC 後のため）。
-- 上記基準により **Phase A は完了とみなし、GC（Phase B）の開発に着手する。**
-- PLAN.md のフェーズ表・メトリクス表を本 ADR の数値に合わせて更新する。
-- 実装は `docs/gc-level1-detailed-design.md` §11 の手順に従い、**root visitor 導入**
-  （`Interpreter::visit_roots()` への root 集約。GC 本体・`Gc<T>` はまだ実装しない）から着手する。
+- **Fix the Phase A completion criterion as "substrate complete ∧ roast target met."** Completion of all perf levers is
+  not part of the Phase A completion criterion (Levers 2/4 come after GC by design).
+- By the above criterion, **Phase A is deemed complete, and development of GC (Phase B) begins.**
+- Update PLAN.md's phase table and metrics table to the numbers in this ADR.
+- Implementation follows the procedure in `docs/gc-level1-detailed-design.md` §11, starting with **root visitor introduction**
+  (consolidating roots into `Interpreter::visit_roots()`; the GC proper and `Gc<T>` are not yet implemented).
 
 ## 4. Consequences
 
-- PLAN.md の「A. 追いつく（いまここ）」を「B. Value 表現リワーク＋GC（いまここ）」に更新する。
-- roast/perf の残件（§F ロングテール・Lever 3 以降）は引き続き並行して進める。GC 着手と排他ではない。
-- 今後 PLAN.md のメトリクス表を更新する際は、都度 `wc -l roast-whitelist.txt` 等で実測し、
-  stale な数値を記載し続けない（本件のように判断を誤らせるため）。
+- Update PLAN.md's "A. Catch up (we are here)" to "B. Value-representation rework + GC (we are here)".
+- The remaining roast/perf items (§F long tail, Lever 3 onward) continue in parallel. They are not mutually exclusive with starting GC.
+- Whenever PLAN.md's metrics table is updated in the future, measure at that time (e.g. `wc -l roast-whitelist.txt`) rather than
+  keeping stale numbers on record (as in this case, they distort judgment).

--- a/docs/adr/0003-default-on-gc-trigger.md
+++ b/docs/adr/0003-default-on-gc-trigger.md
@@ -1,99 +1,112 @@
-# ADR-0003: デフォルト GC=on のトリガ方針（level-1a の production トリガ）
+# ADR-0003: Trigger policy for default-on GC (the level-1a production trigger)
 
-- **Status**: Accepted（2026-07-05 ユーザー承認）
+- **Status**: Accepted (user approval 2026-07-05)
 - **Date**: 2026-07-05
-- **Relates to**: [ADR-0001](0001-gc-strategy-and-phasing.md)（§4.2 起動方式 / §4.3 A' 範囲）,
+- **Relates to**: [ADR-0001](0001-gc-strategy-and-phasing.md) (§4.2 activation mechanism / §4.3 A' scope),
   [ADR-0002](0002-phase-a-gate-reassessment.md), `docs/gc-level1-detailed-design.md` §9
 
 ## 1. Context
 
-level-1a cycle collector（Bacon-Rajan on Arc）は機能的に完成した: 全 safepoint 種別の emit
-（#4195）、worker churn 下の cooperative cross-thread STW（#4205）、共有 captured-env の
-phantom-edge unsoundness 修正（#4213）、deterministic/random stress 面の完備（§9.2）、CI
-gc-stress の全ステップ blocking 化（#4219）。しかし GC は**依然 default off** であり、
-`MUTSU_GC=on` でも automatic トリガ未設定なら collect は program-end の 1 回のみ —
-長時間稼働のサーバプロセスはサイクルゴミを溜め続ける。ADR-0001 は §4.2（同期/非同期）と
-§4.3（A' をどこまで前提とするか）を未決のまま残していた。
+The level-1a cycle collector (Bacon-Rajan on Arc) is functionally complete: emission of all
+safepoint kinds (#4195), cooperative cross-thread STW under worker churn (#4205), the
+phantom-edge unsoundness fix for shared captured-envs (#4213), a complete deterministic/random
+stress surface (§9.2), and making every CI gc-stress step blocking (#4219). However, GC is
+**still default off**, and even with `MUTSU_GC=on`, without an automatic trigger configured,
+collection happens exactly once at program end — a long-running server process keeps
+accumulating cycle garbage. ADR-0001 left §4.2 (synchronous vs asynchronous) and
+§4.3 (how much of A' to assume as a prerequisite) undecided.
 
-2026-07-05 に確定した 2 つの事実が設計を規定する:
+Two facts established on 2026-07-05 constrain the design:
 
-1. **push 回数周期のトリガは production には漸近的に不適**。`MUTSU_GC_EVERY_CANDIDATE=N` は
-   N push ごとに full trial-deletion scan（コスト = O(live suspect graph)）を発火する。
-   candidate を churn しながら大きな生存構造を伸ばすワークロード
-   （S17-lowlevel/cas-loop.t: 4×1000 `cas` で linked list 構築）では、N=64 で
-   8500+ collects × 各 ~4300 ノードのトレース = **180 秒超**（N=1024 で 3.3 秒、GC-off ~5 秒）。
-   固定周期は同じ生存 suspect を何度も再走査する。トリガは「前回の scan がどれだけ回収できたか」
-   に適応しなければならない。
-2. **A'（root 集約）は level-1a の前提ではない**（§11 step 11 調査）: collector は refcount
-   駆動で root 列挙を一切消費しないため、frame/upvalue の root 集約は 1a のトリガにも
-   正しさにも寄与しない。ADR-0001 §4.3 は「A' は繰延」として狭く解決する。
+1. **A push-count-periodic trigger is asymptotically unsuitable for production**.
+   `MUTSU_GC_EVERY_CANDIDATE=N` fires a full trial-deletion scan (cost = O(live suspect graph))
+   every N pushes. On a workload that churns candidates while growing a large live structure
+   (S17-lowlevel/cas-loop.t: building a linked list via 4×1000 `cas`), N=64 yields
+   8500+ collects × ~4300 nodes traced each = **over 180 seconds** (N=1024: 3.3 seconds,
+   GC-off ~5 seconds). A fixed period re-scans the same surviving suspects over and over.
+   The trigger must adapt to "how much did the previous scan actually reclaim".
+2. **A' (root consolidation) is NOT a prerequisite for level-1a** (per the §11 step 11
+   investigation): the collector is refcount-driven and consumes no root enumeration at all,
+   so consolidating frame/upvalue roots contributes nothing to either the 1a trigger or its
+   correctness. ADR-0001 §4.3 is resolved narrowly as "A' is deferred".
 
-## 2. Decision（Proposed）
+## 2. Decision (Proposed)
 
-1. **同期 collect**（ADR-0001 §4.2 = 同期。設計書 §12「1a では background collector を捨てる」を
-   再確認）。トリガは既存の `PENDING` フラグを arm し、次に safepoint を踏んだ mutator 上で
-   inline に collect する（他 mutator が生きていれば既存の cooperative STW）。非同期
-   （concurrent collection）は 1a では却下: trial deletion は並行 refcount 変異に耐えられず
-   （epoch 機構が必要）、全種 safepoint 網の完備によりトリガ→collect の遅延は既に十分小さい。
+1. **Synchronous collect** (ADR-0001 §4.2 = synchronous; reconfirming the detailed design's
+   §12 "1a drops the background collector"). The trigger arms the existing `PENDING` flag,
+   and the collect runs inline on the next mutator that hits a safepoint (with the existing
+   cooperative STW if other mutators are alive). Asynchronous (concurrent) collection is
+   rejected for 1a: trial deletion cannot tolerate concurrent refcount mutation (it would
+   need an epoch mechanism), and with the full safepoint coverage in place, the
+   trigger-to-collect latency is already small enough.
 
-2. **トリガ = candidate バッファの「サイズ」閾値 + adaptive backoff**。
-   `buffer_candidate` はバッファ長が実効閾値に達したら `PENDING` を arm する。collect の
-   たびに `threshold = clamp(BASE, 2 × survivors, MAX)`（survivors = revive された生存
-   suspect 数）へ更新: 「ほぼ全部生きていた」scan は閾値を引き上げ（cas-loop 型の quadratic
-   から自動退避）、「ほぼ全部回収できた」scan は BASE へ戻す。チューナブルは
-   `MUTSU_GC_THRESHOLD`（BASE。既定値は計測で決定 — 出発点 16384）のみ。既存の stress 用
-   env 変数群は CI/デバッグ用としてそのまま残す（production トリガは独立した追加機構）。
+2. **Trigger = candidate-buffer "size" threshold + adaptive backoff**.
+   `buffer_candidate` arms `PENDING` when the buffer length reaches the effective threshold.
+   After each collect, update `threshold = clamp(BASE, 2 × survivors, MAX)`
+   (survivors = number of live suspects that were revived): a scan where "almost everything
+   was alive" raises the threshold (automatic escape from the cas-loop-style quadratic),
+   while a scan where "almost everything was reclaimed" resets it to BASE. The only tunable
+   is `MUTSU_GC_THRESHOLD` (BASE; default to be determined by measurement — starting point
+   16384). The existing stress env variables remain as-is for CI/debugging (the production
+   trigger is an independent, additional mechanism).
 
-3. **`MUTSU_GC` の既定値 off → on の切替**は、次を順に満たしてから行う:
-   a. gc-stress roast の blocking 化と green 維持（#4219 で完了・継続観察）。
-   b. 閾値トリガの実装 + gc_stress での担保（GC-off と出力 byte 一致・churn 下の
-      `pause_ns_max` 有界・cas-loop 型ワークロードが GC-off 比 ~1.2 倍以内）。
-   c. 計測オーバーヘッド予算: fib/int ループ ≈ 0（スカラ型フィルタ — ADR-0001 の
-      「fib で push == 0」ゲート）、method-call / bench-class は GC-off 比 < 5%。
-   d. opt-out `MUTSU_GC=off` の維持。
-   切替自体は本 ADR の Accepted 後、b/c の実測を添えた PR で行う。
+3. **Flipping the `MUTSU_GC` default from off to on** happens only after satisfying, in order:
+   a. gc-stress roast made blocking and kept green (done in #4219; continued observation).
+   b. Threshold-trigger implementation + assurance via gc_stress (byte-identical output vs
+      GC-off; bounded `pause_ns_max` under churn; cas-loop-style workloads within ~1.2x of
+      GC-off).
+   c. Measured overhead budget: fib/int loops ≈ 0 (the scalar type filter — ADR-0001's
+      "push == 0 on fib" gate); method-call / bench-class < 5% vs GC-off.
+   d. The opt-out `MUTSU_GC=off` is retained.
+   The flip itself happens after this ADR is Accepted, in a PR accompanied by the actual
+   measurements for b/c.
 
-4. **A' は繰延**（Context 2 による）: 将来の root 消費型 VERIFY 拡張、および
-   NaN-boxing / JIT 世代の最適化の enabler として、それぞれの時間軸で扱う。
+4. **A' is deferred** (per Context item 2): treated on its own timeline, as an enabler for
+   future root-consuming VERIFY extensions and for NaN-boxing / JIT-generation optimizations.
 
 ## 3. Consequences
 
-- サーバ型プログラム（join しない worker がサイクルを churn する — ADR-0001 の動機ケース）が、
-  バッファ増加に比例した自動サイクル回収を quadratic 病理なしで得る。
-- `MUTSU_VM_STATS` の gc カウンタ群が default-on 切替の受け入れ計測器になる。
-- stress ノブ（`EVERY_SAFEPOINT`/`EVERY_CANDIDATE`/`AT`/random）は CI・デバッグ用として不変。
+- Server-style programs (workers that never join and churn cycles — ADR-0001's motivating
+  case) get automatic cycle reclamation proportional to buffer growth, without the quadratic
+  pathology.
+- The `MUTSU_VM_STATS` gc counters become the acceptance instrumentation for the default-on
+  flip.
+- The stress knobs (`EVERY_SAFEPOINT`/`EVERY_CANDIDATE`/`AT`/random) are unchanged, for
+  CI/debugging use.
 
 ## 4. Alternatives considered
 
-| 案 | 判定 |
+| Option | Verdict |
 |---|---|
-| push 回数周期（`EVERY_CANDIDATE` の流用） | 却下 — O(live graph) scan の周期発火は quadratic（cas-loop.t 実測 180 秒超） |
-| background thread での concurrent collect | 却下（1a）— trial deletion が並行変異に非対応。設計書 §12 の再確認 |
-| 時間ベース（N 秒ごと） | 却下 — アイドルプロセスで無駄、バースト時に遅すぎる。サイズ閾値が負荷に自然追従 |
-| A' 完了を前提にする | 却下 — collector は root 列挙を消費しない（§11 step 11 調査） |
+| Push-count period (reusing `EVERY_CANDIDATE`) | Rejected — periodic firing of the O(live graph) scan is quadratic (cas-loop.t measured at over 180 seconds) |
+| Concurrent collect on a background thread | Rejected (for 1a) — trial deletion does not tolerate concurrent mutation. Reconfirms the detailed design's §12 |
+| Time-based (every N seconds) | Rejected — wasteful on idle processes, too slow under bursts. A size threshold naturally tracks load |
+| Requiring A' completion as a prerequisite | Rejected — the collector consumes no root enumeration (§11 step 11 investigation) |
 
 ---
 
-*2026-07-05 ユーザー承認により Accepted。実装は §2 の Decision に従い、§2-3 のゲートを満たして default-on を切り替える。*
+*Accepted by user approval on 2026-07-05. Implementation follows the Decision in §2; the
+default-on flip happens once the gates in §2-3 are met.*
 
-## 5. Update（2026-07-05・切替時の受け入れ実測とゲート改訂）
+## 5. Update (2026-07-05 — acceptance measurements at flip time and gate revision)
 
-§2-3c の実測（release・9 反復 best・load < 1.5）:
+Measurements for §2-3c (release build, best of 9 iterations, load < 1.5):
 
-| bench | GC-on overhead | 判定 |
+| bench | GC-on overhead | Verdict |
 |---|---|---|
-| fib25 / bench-fib / int-arith | +0.5% / +3.0% / +2.0% | ✓（型フィルタで scalar/関数 hot path はほぼ無料 — ADR-0001 の本来の狙いを達成） |
-| method-call | +0.7〜6.4%（測定ノイズ帯） | ✓/△ |
-| **bench-class** | **+7.5〜8.3%** | ✗（< 5% に対し） |
-| churn 系 | ≤ +10% | ✓（≤ 1.2x） |
+| fib25 / bench-fib / int-arith | +0.5% / +3.0% / +2.0% | ✓ (with the type filter, scalar/function hot paths are nearly free — achieving ADR-0001's original intent) |
+| method-call | +0.7–6.4% (measurement noise band) | ✓/△ |
+| **bench-class** | **+7.5–8.3%** | ✗ (against < 5%) |
+| churn suite | ≤ +10% | ✓ (≤ 1.2x) |
 
-bench-class の残差は「28k インスタンスに対して 16.5M 回の `Value` clone/drop」という既存の
-クローン交通量に per-drop の buffered-bit 分岐 1 個が乗る構造的コストで、GC 側の安価な改善
-（drop fast path で +61%→+8%・program-end collect skip・`gc_enabled` キャッシュ）は投入済み。
-交通量自体の削減は ADR-0001 が層 3b（NaN-boxing）に割り当てる領域である。
+The bench-class residual is a structural cost: one buffered-bit branch per drop layered on
+the pre-existing clone traffic of "16.5M `Value` clone/drop operations against 28k
+instances". The cheap GC-side improvements have already landed (drop fast path taking
++61%→+8%, skipping the program-end collect, caching `gc_enabled`). Reducing the traffic
+itself is the territory ADR-0001 assigns to layer 3b (NaN-boxing).
 
-**ユーザー判断（2026-07-05）: bench-class ~8% を許容してこのまま default-on に切り替える。**
-リークしない既定の価値が class 密度の高いコードの 8% に優先し、根本削減は 3b で回収する。
-`cfg!(test)`（crate 自身の unit-test ビルド）のみ既定 off — 並列 `cargo test` のテスト分離のため
-（GC-on unit test は CI gc-stress ジョブが担保）。
-
+**User decision (2026-07-05): accept the ~8% on bench-class and flip to default-on as-is.**
+The value of a leak-free default outweighs 8% on class-dense code, and the root-cause
+reduction will be recovered in 3b. The only exception is `cfg!(test)` (the crate's own
+unit-test builds), which stays default off — for test isolation under parallel `cargo test`
+(GC-on unit testing is covered by the CI gc-stress job).

--- a/docs/adr/0004-jit-strategy.md
+++ b/docs/adr/0004-jit-strategy.md
@@ -1,168 +1,187 @@
-# ADR-0004: JIT の方式選定とフェーズ計画（層4）
+# ADR-0004: JIT — mechanism selection and phasing (layer 4)
 
-- **Status**: Accepted（2026-07-06 ユーザー承認 — Lever 3 凍結を含む）
+- **Status**: Accepted (user approval 2026-07-06 — including the Lever 3 freeze)
 - **Date**: 2026-07-05
 - **Deciders**: tokuhirom, Claude
-- **関連**: [ADR-0001](0001-gc-strategy-and-phasing.md)（フェーズ順序 3a→3b→4、レベル1 GC が
-  JIT の前提コストを消す判断）, [gc-post-3a-roadmap.md](../gc-post-3a-roadmap.md)（層3b が本 ADR の
-  前提工事）, [PLAN.md](../../PLAN.md) §5 Lever 3/4, PERFORMANCE.md
+- **Relates to**: [ADR-0001](0001-gc-strategy-and-phasing.md) (phase order 3a→3b→4; the
+  decision that level-1 GC eliminates the JIT's prerequisite costs),
+  [gc-post-3a-roadmap.md](../gc-post-3a-roadmap.md) (layer 3b is the prerequisite work for
+  this ADR), [PLAN.md](../../PLAN.md) §5 Lever 3/4, PERFORMANCE.md
 
-> ADR-0001 は「JIT は GC の後」「レベル1 GC（non-moving + refcount）なら JIT は stack map /
-> forwarding / write barrier が不要で、`Arc`/`Gc` の inc/dec を emit するだけ」という
-> *順序と前提* を決めた。本 ADR は JIT **そのもの**の方式を決める。
+> ADR-0001 fixed the *order and prerequisites*: "JIT comes after GC" and "with level-1 GC
+> (non-moving + refcount), the JIT needs no stack maps / forwarding / write barriers — it
+> just emits `Arc`/`Gc` inc/dec". This ADR decides the approach for the JIT **itself**.
 
 ---
 
-## 1. Context（背景）
+## 1. Context
 
-- 実行系は単一の bytecode VM（`Interpreter`、~330 opcode、`exec_one` の match dispatch）。
-  コンパイル単位は `CompiledCode`（定数プール・indexed locals・`simple_locals`/upvalue 解析済み）。
-- perf 現況（対 raku）: fib(25) 1.0x・int-arith 0.7x と命令律速はほぼ互角だが、
-  **bench-fib（型制約付き）3.2x・method-call 2.7x・bench-class 2.3x** が残る。
-  目標（PLAN §5）: method-call < 1.5x・bench-class < 1.5x・bench-fib < 2x。
-- JIT の期待値（PERFORMANCE.md Phase 4c）: tight numeric loop で 5–10x。
-- GC はレベル1（cycle collector on Arc, default-on）。**non-moving**なのでポインタは動かず、
-  refcount が生存を保証する。safepoint 機構（backedge/call/return/await/...）と
-  cooperative STW は稼働済み — JIT コードはこの safepoint を **poll する側**として参加する。
-- 層3b（NaN-boxing, 8B `Value`）が先行する（ADR-0001 の順序）。JIT は 8B 固定幅の
-  値をレジスタで扱える前提で設計する。
+- The execution engine is a single bytecode VM (`Interpreter`, ~330 opcodes, `exec_one`
+  match dispatch). The compilation unit is `CompiledCode` (constant pool, indexed locals,
+  `simple_locals`/upvalue analysis done).
+- Current perf (vs raku): fib(25) 1.0x and int-arith 0.7x — instruction-bound workloads are
+  roughly at parity — but **bench-fib (with type constraints) 3.2x, method-call 2.7x,
+  bench-class 2.3x** remain. Targets (PLAN §5): method-call < 1.5x, bench-class < 1.5x,
+  bench-fib < 2x.
+- Expected JIT payoff (PERFORMANCE.md Phase 4c): 5–10x on tight numeric loops.
+- GC is level-1 (cycle collector on Arc, default-on). It is **non-moving**, so pointers
+  never move and refcounts guarantee liveness. The safepoint machinery
+  (backedge/call/return/await/...) and cooperative STW are already operational — JIT code
+  participates as a **poller** of these safepoints.
+- Layer 3b (NaN-boxing, 8B `Value`) comes first (ADR-0001's ordering). The JIT is designed
+  on the assumption that 8B fixed-width values can be handled in registers.
 
-## 2. Decision（提案する決定）
+## 2. Decision (proposed decisions)
 
-### 2.1 バックエンド = **Cranelift**（JIT モード）
+### 2.1 Backend = **Cranelift** (JIT mode)
 
-- 理由: pure-Rust で組み込みが軽い（rustc/LLVM ツールチェーン非依存）・コンパイル速度が
-  JIT 向き・wasmtime で実運用実績・non-moving GC と相性の良い「素の関数ポインタ」モデル。
-- 却下: LLVM(inkwell) は生成コード品質最強だがビルド・リンク・コンパイル時間とも
-  重量級で、mutsu の「高速起動」の武器（起動 0.04x）を損ねるリスク。自前 asm template JIT は
-  arch ごとの保守コスト。wasm 経由は間接層が無駄。
-- 依存は **feature flag + 実行時 flag**（`MUTSU_JIT=on|off`、既定は当面 off）で隔離し、
-  JIT なしビルド（非対応 arch）でも full 機能を維持する。
-  （**2026-07-13 更新**: J5 ゲート達成により既定 on へ切替済み — 末尾の追記参照。
-  `MUTSU_JIT=off` が明示オプトアウト。）
+- Rationale: pure Rust with lightweight embedding (no rustc/LLVM toolchain dependency);
+  compilation speed suited to JIT; production track record in wasmtime; a "plain function
+  pointer" model that fits well with a non-moving GC.
+- Rejected: LLVM (inkwell) has the strongest generated-code quality but is heavyweight in
+  build, link, and compile time, risking mutsu's "fast startup" weapon (startup 0.04x).
+  A hand-rolled asm template JIT means per-arch maintenance cost. Going through wasm is a
+  wasted indirection layer.
+- The dependency is isolated behind a **feature flag + runtime flag** (`MUTSU_JIT=on|off`,
+  default off for the time being), keeping full functionality in JIT-less builds
+  (unsupported arches).
+  (**Update 2026-07-13**: with the J5 gates met, the default has been flipped to on — see
+  the addendum at the end. `MUTSU_JIT=off` is the explicit opt-out.)
 
-### 2.2 コンパイル単位 = **`CompiledCode` 関数全体**（method JIT）。tracing はしない
+### 2.2 Compilation unit = **whole `CompiledCode` functions** (method JIT). No tracing
 
-- ホット判定: `CompiledCode` ごとの呼び出しカウンタ（+ backedge カウンタ）。閾値超過で
-  コンパイルし、以後のエントリはネイティブ関数ポインタ経由。
-- OSR（実行中ループの途中乗り換え）は **初期スコープ外**（フェーズ J4 で backedge カウンタ
-  からの hot-loop entry を再検討）。mutsu の主要ベンチは関数呼び出し反復なので、
-  entry 置換だけで大半を回収できる。
-- meta-tracing（PyPy 型）は却下: インフラ規模が別次元で、既存 VM 資産を捨てることになる。
+- Hotness detection: a per-`CompiledCode` call counter (+ backedge counter). Compile when
+  the threshold is exceeded; subsequent entries go through the native function pointer.
+- OSR (switching over mid-execution inside a running loop) is **out of initial scope**
+  (revisit hot-loop entry from the backedge counter in phase J4). mutsu's main benchmarks
+  are repeated function calls, so entry replacement alone recovers most of the gain.
+- Meta-tracing (PyPy-style) is rejected: the infrastructure scale is of a different order,
+  and it would mean throwing away the existing VM assets.
 
-### 2.3 実行モデル = **subroutine-threading + inline 化の漸進**（deopt なし）
+### 2.3 Execution model = **subroutine-threading + gradual inlining** (no deopt)
 
-JIT の最初の形は「opcode 列を、**VM ヘルパ関数呼び出しの列**としてネイティブ化」する
-（= dispatch ループの除去がまず取れる）。その上で高頻度 opcode から順に CLIF へ
-インライン展開していく:
+The JIT's first form is "nativize the opcode sequence as a **sequence of calls to VM helper
+functions**" (= removing the dispatch loop is the first win). From there, expand the
+highest-frequency opcodes into CLIF inline, in order:
 
-- Tier A（J1–J2）: 全対応 opcode を helper call で直訳。未対応 opcode を含む関数は
-  JIT 対象外（インタプリタのまま）— **guard/deopt/OSR-exit を一切作らない**。
-  「コンパイルできるか」は静的に `CompiledCode` を見て決まるので、実行中の脱最適化が
-  不要になる。これが ADR-0001 の「GC を単純に保つ＝JIT も単純に保つ」路線の JIT 版。
-- Tier B（J3–J4）: Int/Num の算術・比較・分岐・local get/set・定数・小さな呼び出し規約を
-  CLIF に直接展開（NaN-box タグ判定 + fast path、slow path は helper へ）。
-  型プロファイルではなく **タグ分岐**で済ませる（8B NaN-box 前提）。
-- 「JIT が emit する GC 協調コード」は 2 つだけ:
-  1. 値の複製/破棄サイトでの `Gc`/`Arc` inc/dec（Tier B のインライン部のみ。helper call 部は
-     helper 内で従来どおり）
-  2. backedge / call サイトでの **safepoint poll**（`STOP_REQUESTED` チェック → 協調 park）
+- Tier A (J1–J2): translate all supported opcodes directly as helper calls. Functions
+  containing unsupported opcodes are excluded from JIT (they stay interpreted) —
+  **no guards/deopt/OSR-exits are built at all**. Whether a function "can be compiled" is
+  determined statically by looking at the `CompiledCode`, so no runtime deoptimization is
+  needed. This is the JIT counterpart of ADR-0001's "keep GC simple = keep the JIT simple"
+  line.
+- Tier B (J3–J4): expand Int/Num arithmetic, comparison, branches, local get/set,
+  constants, and the small calling convention directly into CLIF (NaN-box tag check +
+  fast path; slow path goes to a helper). Use **tag branching** rather than type profiling
+  (relying on the 8B NaN-box).
+- The "GC-cooperation code the JIT emits" is only two things:
+  1. `Gc`/`Arc` inc/dec at value copy/destroy sites (only in Tier B inline sections; helper
+     call sections handle it inside the helper as before)
+  2. **Safepoint polls** at backedges / call sites (`STOP_REQUESTED` check → cooperative
+     park)
 
-### 2.4 GC / スレッドとの整合（レベル1 前提の明文化）
+### 2.4 GC / thread coherence (making the level-1 assumptions explicit)
 
-- **stack map 不要**: JIT フレームに「collector から見えない生ポインタ」を置いてよい。
-  refcount を正しく保っている限り、参照中の node が回収されることはない
-  （cycle collector は孤立サイクルだけを刈る）。
-- **forwarding 不要**: non-moving なのでコンパイル済みコードに埋めたポインタは不変。
-- **write barrier 不要**: 世代別ではない。ただし mutation chokepoint の
-  candidate push（buffered bit）は helper 経由の変異では従来どおり動く。Tier B で
-  コンテナ変異をインライン化する時は candidate push もセットで emit する（＝コンテナ変異の
-  インライン化は優先度最下位に置き、当面 helper に残す）。
-- **STW**: JIT コードは safepoint poll を挟むので、cooperative STW の quiescence 会計に
-  そのまま参加する。long-running なネイティブループが poll を欠くと STW が飢えるため、
-  **backedge poll は Tier A から必須**とする。
+- **No stack maps needed**: JIT frames may hold "raw pointers invisible to the collector".
+  As long as refcounts are maintained correctly, a node being referenced is never reclaimed
+  (the cycle collector only reaps isolated cycles).
+- **No forwarding needed**: non-moving, so pointers embedded in compiled code are immutable.
+- **No write barriers needed**: not generational. However, the candidate push at the
+  mutation chokepoint (buffered bit) still works as before for mutations that go through
+  helpers. When Tier B inlines container mutation, the candidate push must be emitted
+  together with it (= container-mutation inlining is placed at the lowest priority and stays
+  in helpers for now).
+- **STW**: JIT code interleaves safepoint polls, so it participates in the cooperative STW
+  quiescence accounting as-is. A long-running native loop that lacks polls would starve the
+  STW, so **backedge polls are mandatory from Tier A onward**.
 
-### 2.5 フェーズとゲート
+### 2.5 Phases and gates
 
-| フェーズ | 内容 | ゲート（受け入れ条件） |
+| Phase | Content | Gate (acceptance criteria) |
 |---|---|---|
-| **J0** | 前提: 層3b 完了（8B Value）。**Lever 3（threaded dispatch）は凍結**（Tier A が dispatch ループ除去で同じ利得をより大きく取るため、二重投資を避ける） | 3b のゲート（gc-post-3a-roadmap §3.3）達成 |
-| **J1** | Cranelift 組み込み骨組み: feature flag・関数カウンタ・コンパイルキュー・エントリ差し替え。fib 相当の最小 opcode 集合を Tier A で | `MUTSU_JIT=on` で fib/int-arith が JIT 実行され、**on/off で出力 byte 一致**。make test green（on） |
-| **J2** | Tier A opcode カバレッジ拡大（arith/compare/branch/local/const/call-compiled-fn/return）+ CI に **jit-stress ジョブ**（gc-stress と同型: `MUTSU_JIT=on` で make test + roast） | jit-stress green。bench-fib で dispatch 除去分の実測改善（目標 3.2x → ~2.5x） |
-| **J3** | 呼び出し規約の最適化: JIT→JIT 直接呼び出し・method dispatch の inline cache（class Symbol キー）・型制約チェックの JIT 内 fast path | method-call < 1.5x・bench-class < 1.5x・bench-fib < 2x（PLAN §5 目標の達成レバー） |
-| **J4** | Tier B: NaN-box タグ分岐つき算術インライン + hot-loop（backedge カウンタ、必要なら OSR entry） | int ループ 5–10x（PERFORMANCE.md 期待値）。fib ループ内で `gc_candidate_pushes == 0` かつ refcount 操作ゼロ（ADR-0001 §3-8 の完成形） |
-| **J5** | 既定 on 切替: gc-stress × jit-stress のマトリクス green + オーバーヘッド予算（非ホットコードのコンパイルコストが起動 0.04x を悪化させない）を実測して `MUTSU_JIT` 既定 on | 起動ベンチ不変・全 CI green・ADR 更新 |
+| **J0** | Prerequisite: layer 3b complete (8B Value). **Lever 3 (threaded dispatch) is frozen** (Tier A captures the same gain, larger, via dispatch-loop removal; avoid double investment) | 3b gates (gc-post-3a-roadmap §3.3) met |
+| **J1** | Cranelift integration skeleton: feature flag, function counters, compile queue, entry swapping. Minimal opcode set for fib-equivalent code in Tier A | With `MUTSU_JIT=on`, fib/int-arith run under JIT with **byte-identical output on/off**. make test green (on) |
+| **J2** | Expand Tier A opcode coverage (arith/compare/branch/local/const/call-compiled-fn/return) + a **jit-stress job** in CI (same shape as gc-stress: `MUTSU_JIT=on` for make test + roast) | jit-stress green. Measured improvement on bench-fib from dispatch removal (target 3.2x → ~2.5x) |
+| **J3** | Calling-convention optimization: JIT→JIT direct calls, inline caches for method dispatch (class Symbol keys), in-JIT fast path for type-constraint checks | method-call < 1.5x, bench-class < 1.5x, bench-fib < 2x (the lever for hitting the PLAN §5 targets) |
+| **J4** | Tier B: NaN-box tag-branching arithmetic inlining + hot loops (backedge counter, OSR entry if needed) | Int loops 5–10x (PERFORMANCE.md expectation). Inside the fib loop, `gc_candidate_pushes == 0` and zero refcount operations (the finished form of ADR-0001 §3-8) |
+| **J5** | Default-on flip: gc-stress × jit-stress matrix green + overhead budget (compile cost of non-hot code must not worsen startup 0.04x) measured, then `MUTSU_JIT` default on | Startup bench unchanged, all CI green, ADR updated |
 
-### 2.6 テスト戦略
+### 2.6 Test strategy
 
-- **差分実行が第一ゲート**: 同一プログラムを `MUTSU_JIT=off/on` で走らせ出力 byte 一致
-  （gc-stress で確立した手法の流用）。
-- CI: `jit-stress` ジョブ（J2〜）。将来 `MUTSU_GC=on × MUTSU_JIT=on` は default 同士なので
-  通常ジョブがマトリクスを兼ねる。
-- `MUTSU_VM_STATS` に `jit_compiles` / `jit_entries` / `jit_bailouts`（対象外関数の理由別
-  カウント）を追加し、「何がまだインタプリタに落ちているか」を数字で追う。
+- **Differential execution is the first gate**: run the same program with `MUTSU_JIT=off/on`
+  and require byte-identical output (reusing the methodology established for gc-stress).
+- CI: a `jit-stress` job (from J2 onward). Eventually, `MUTSU_GC=on × MUTSU_JIT=on` are
+  both defaults, so the regular jobs double as the matrix.
+- Add `jit_compiles` / `jit_entries` / `jit_bailouts` (per-reason counts of excluded
+  functions) to `MUTSU_VM_STATS`, tracking "what still falls back to the interpreter" with
+  numbers.
 
 ## 3. Consequences
 
-- deopt/OSR-exit/stack map を持たない分、**JIT 本体は小さく保てる**が、対応 opcode を
-  含まない関数は丸ごとインタプリタに残る。→ `jit_bailouts` カウンタで対象外の分布を可視化し、
-  カバレッジ拡大を計測駆動にする。
-- Lever 3（threaded dispatch）は凍結。JIT が頓挫した場合のみ復活させる。
-- 層3c（biased RC）の要否判断は J4 完了後の profile まで保留（gc-post-3a-roadmap §4）。
-- Cranelift 依存が増える（ビルド時間・バイナリサイズ）。feature flag で非 JIT ビルドを
-  維持し、リリースバイナリでの既定は J5 で判断する。
+- Without deopt/OSR-exit/stack maps, **the JIT core stays small**, but any function
+  containing an unsupported opcode remains fully interpreted. → The `jit_bailouts` counter
+  makes the distribution of excluded functions visible, driving coverage expansion by
+  measurement.
+- Lever 3 (threaded dispatch) is frozen. It is revived only if the JIT founders.
+- The go/no-go decision on layer 3c (biased RC) is deferred until profiling after J4
+  completes (gc-post-3a-roadmap §4).
+- A Cranelift dependency is added (build time, binary size). The feature flag keeps
+  non-JIT builds viable; the default for release binaries is decided at J5.
 
 ## 4. Alternatives considered
 
-| 案 | 利点 | 欠点 | 判定 |
+| Option | Pros | Cons | Verdict |
 |---|---|---|---|
-| **Cranelift method JIT（本 ADR）** | 軽量・Rust 統合・JIT 向きコンパイル速度 | ピーク性能は LLVM 未満 | **採用** |
-| LLVM (inkwell) | 最高のコード品質 | ビルド/リンク重量級・コンパイル遅い・起動性能の武器を損ねる | 却下 |
-| 自前 template/copy-patch JIT | 依存ゼロ・最速コンパイル | arch ごとの実装/保守、Tier B 相当の最適化を自作 | 却下（Cranelift の Tier A がほぼ同コストで可搬） |
-| meta-tracing（PyPy 型） | 理論上の適応最適化 | VM 資産の作り直し・年単位 | 却下 |
-| wasm 経由（wasmtime） | sandbox/可搬 | 間接層のオーバーヘッド・GC/host 連携が煩雑 | 却下 |
-| deopt/guard 型 speculative JIT | ピーク性能 | stack 再構築（OSR-exit）実装が本格 VM 級 | 却下（bailout=関数単位不採用で代替） |
+| **Cranelift method JIT (this ADR)** | Lightweight, Rust integration, JIT-suited compile speed | Peak performance below LLVM | **Adopted** |
+| LLVM (inkwell) | Best code quality | Heavyweight build/link, slow compiles, undermines the startup-performance weapon | Rejected |
+| Hand-rolled template/copy-patch JIT | Zero dependencies, fastest compiles | Per-arch implementation/maintenance; Tier B-grade optimizations built by hand | Rejected (Cranelift's Tier A is portable at roughly the same cost) |
+| Meta-tracing (PyPy-style) | Adaptive optimization in theory | Rebuilding the VM assets; measured in years | Rejected |
+| Via wasm (wasmtime) | Sandboxing/portability | Indirection-layer overhead; GC/host interop is cumbersome | Rejected |
+| Deopt/guard speculative JIT | Peak performance | Stack reconstruction (OSR-exit) implementation is full-scale-VM-grade | Rejected (replaced by bailout = whole-function exclusion) |
 
 ---
 
-*2026-07-06 ユーザー承認により Accepted（Lever 3 の凍結も同時承認）。実装は
-gc-post-3a-roadmap の層3b（NaN-boxing）完了後、§2.5 のフェーズ J1 から着手する。*
+*Accepted by user approval on 2026-07-06 (the Lever 3 freeze approved at the same time).
+Implementation starts at phase J1 of §2.5, after gc-post-3a-roadmap's layer 3b (NaN-boxing)
+is complete.*
 
-*2026-07-13 追記: **J5 完了 — `MUTSU_JIT` 既定 on**。ゲート実測（bench CI main
-`f19946ad`）: gc-stress × jit-stress マトリクス green（J2 以降常設）・
-bench-startup 0.0087s → +jit 0.0086s（起動予算不変 — cold code は閾値未満で
-コンパイルされないため）・全 `+jit` 系列がインタプリタ同等以上
-（fib 0.77x→0.59x・bench-fib 1.64x→1.26x・回帰系列なし）。bench CI の plain
-系列は以後 `MUTSU_JIT=off` を明示 pin してインタプリタ基準線の意味を維持する。
-J4 の「int ループ 5–10x」ゲートは文言上未達のまま J5 を先行した: J4c で
-インタプリタ自体が -34% 高速化して相対差の分母が縮んだためで、絶対性能は
-両系列とも改善している。残る J4d（変数 op インライン）は既定 on の上で続行。*
+*Addendum 2026-07-13: **J5 complete — `MUTSU_JIT` default on**. Gate measurements (bench CI
+main `f19946ad`): gc-stress × jit-stress matrix green (permanent since J2);
+bench-startup 0.0087s → +jit 0.0086s (startup budget unchanged — cold code stays below the
+threshold and is never compiled); all `+jit` series at or above interpreter parity
+(fib 0.77x→0.59x, bench-fib 1.64x→1.26x, no regressing series). The bench CI plain series
+henceforth pins `MUTSU_JIT=off` explicitly to preserve its meaning as the interpreter
+baseline. The J4 "int loops 5–10x" gate was, by its letter, still unmet when J5 went ahead:
+J4c sped up the interpreter itself by -34%, shrinking the denominator of the relative
+difference, while absolute performance improved in both series. The remaining J4d
+(variable-op inlining) continues on top of default on.*
 
-*2026-07-15 追記: **J4d 完了 — 本 ADR のフェーズ計画を完遂しクローズ**。
-スライス構成: #4527（Tier B GetLocal インライン + lock-free hot-range cache）・
-#4528（SetLocal ミラーの per-store intern 連鎖除去）・#4529（light-call 儀式の
-alloc-free 化）・#4534（dispatch テーブルの FxHash 化 + 引数スキャン融合）・
-#4537（light-call の caller-env フレーム再利用 — 空 overlay シングルトンを
-CoW write latch として使う動的検出方式）・#4540（readonly-set の Arc
-スナップショット → mutation journal 化）。bench CI 実測（ratio = 対 raku）:
-fib+jit 0.34（`d6d405cc`・pre-#4534）→ 0.28（`c397b90b`）・bench-fib+jit
-0.66 → 0.56。local 累計では fib(28) が pre-J4d ~0.4s → 0.13s。*
+*Addendum 2026-07-15: **J4d complete — this ADR's phase plan is fulfilled and closed**.
+Slice breakdown: #4527 (Tier B GetLocal inlining + lock-free hot-range cache), #4528
+(removal of the per-store intern chain in the SetLocal mirror), #4529 (alloc-free
+light-call ceremony), #4534 (FxHash-ing the dispatch table + fusing the argument scan), #4537
+(caller-env frame reuse for light-call — a dynamic-detection scheme using the empty overlay
+singleton as a CoW write latch), #4540 (readonly-set Arc snapshot → mutation journal). Bench CI measurements (ratio = vs raku): fib+jit 0.34 (`d6d405cc`, pre-#4534)
+→ 0.28 (`c397b90b`); bench-fib+jit 0.66 → 0.56. Cumulatively, local fib(28) went from
+pre-J4d ~0.4s → 0.13s.*
 
-*J4 の「int ループ 5–10x」ゲート再判定: int-arith の JIT on/off 比は 1.24x
-（`c397b90b`: 0.0375s vs 0.0466s）で文言上は未達のままだが、この期待値は
-**J4c/J4d 以前のインタプリタを分母にした数字**であり、J4c（インタプリタ -34%）と
-J4d（dispatch・call 儀式という on/off 共通コストの削減）が分母を縮め続けた結果、
-比率では原理的に届かない。絶対性能では int-arith+jit は raku の 0.18x
-（≈5.5 倍高速）・全 `+jit` 系列がインタプリタ系列と同等以上で、当初「5–10x」が
-意図した水準（tight numeric loop の native 級実行）は絶対値で実現済み。
-比率ゲートは obsolete と判定してクローズする。*
+*Re-judgment of the J4 "int loops 5–10x" gate: the JIT on/off ratio for int-arith is 1.24x
+(`c397b90b`: 0.0375s vs 0.0466s), still unmet by its letter — but that expectation used
+**the pre-J4c/J4d interpreter as its denominator**, and as J4c (interpreter -34%) and J4d
+(reduction of dispatch and call ceremony, costs shared by on and off) kept shrinking the
+denominator, the ratio became unreachable in principle. In absolute terms, int-arith+jit is
+0.18x of raku (≈5.5x faster), and every `+jit` series is at or above its interpreter
+counterpart — the level the original "5–10x" intended (native-grade execution of tight
+numeric loops) has been achieved in absolute terms. The ratio gate is judged obsolete and
+closed.*
 
-*設計メモ（J4d ①②の評価結果）: 「CallFunc opcode への per-call-site inline
-cache」は評価の上**不採用** — #4534 の FxHash 化後、名前キーの二重 probe は
-~10-15ns/call まで下がり、per-site 化の残り利得（~3%）は `CompiledFns` の
-Arc 化 + map-id 検証機構の複雑さに見合わない。「JIT→JIT 直接呼び出し」も
-専用 native 経路は作らず、interpreter/JIT が共有する light-call 経路の固定費
-（env swap の Arc churn / readonly snapshot / GC safepoint の locked RMW）を
-削る形で同じ利得を回収した（#4537/#4540 — profile 上 call 儀式が dispatch probe の
-3 倍超だったため）。残る on/off 共通固定費の根治（SetLocal env-mirror 等）は
-PLAN §6 lexical-slot campaign の領域。*
+*Design note (evaluation results for J4d items ① and ②): "per-call-site inline caches on the
+CallFunc opcode" was evaluated and **not adopted** — after #4534's FxHash conversion, the
+double probe on name keys dropped to ~10-15ns/call, and the remaining gain from
+per-site-ification (~3%) does not justify the complexity of Arc-ifying `CompiledFns` plus a
+map-id validation mechanism. "JIT→JIT direct calls" likewise did not get a dedicated native
+path; the same gain was recovered by cutting the fixed costs of the light-call path shared
+by interpreter and JIT (the env swap's Arc churn / the readonly snapshot / the GC
+safepoint's locked RMW) (#4537/#4540 — because in profiles the call ceremony was over 3x
+the dispatch probe). The root-cause fix for the remaining on/off-shared fixed costs
+(the SetLocal env-mirror, etc.) belongs to the PLAN §6 lexical-slot campaign.*

--- a/docs/adr/0005-nanbox-representation-encoding.md
+++ b/docs/adr/0005-nanbox-representation-encoding.md
@@ -1,178 +1,203 @@
-# ADR-0005: NaN-boxing 表現スイッチ（3b-1）のエンコーディング選択と newtype seal 統合
+# ADR-0005: NaN-boxing representation switch (3b-1) — encoding choice and newtype-seal integration
 
-- **Status**: **Accepted**（2026-07-12 tokuhirom 承認）
-- **Date**: 2026-07-07（Proposed）/ 2026-07-12（Accepted）
+- **Status**: **Accepted** (approved by tokuhirom 2026-07-12)
+- **Date**: 2026-07-07 (Proposed) / 2026-07-12 (Accepted)
 - **Deciders**: tokuhirom, Claude
-- **関連**: [ADR-0001](0001-gc-strategy-and-phasing.md)（層3b の位置づけ・順序 3a→3b→4）,
-  [ADR-0004](0004-jit-strategy.md)（JIT は 8B 固定幅 `Value` を前提）,
-  [gc-post-3a-roadmap.md](../gc-post-3a-roadmap.md) §3.2/§3.3（表現方針・スライス分割）,
-  [nanbox-3b0-api-wall.md](../nanbox-3b0-api-wall.md)（3b-0 API 壁・移行レシピ・§6 未決事項・§7 seal）,
+- **Related**: [ADR-0001](0001-gc-strategy-and-phasing.md) (positioning of layer 3b; order 3a→3b→4),
+  [ADR-0004](0004-jit-strategy.md) (the JIT assumes an 8B fixed-width `Value`),
+  [gc-post-3a-roadmap.md](../gc-post-3a-roadmap.md) §3.2/§3.3 (representation policy, slice breakdown),
+  [nanbox-3b0-api-wall.md](../nanbox-3b0-api-wall.md) (3b-0 API wall, migration recipe, §6 open questions, §7 seal),
   [PLAN.md](../../PLAN.md) §5 Lever 2
 
-> 3b-0（API 壁）は完了済み — `src/value/` 外の直接 `Value::<Variant>` 参照は **0**（ratchet
-> `check-value-wall.sh` が `make test` で保証）。本 ADR は 3b-1（`Value` 48B→8B の表現スイッチ）の
-> **唯一のブロッキング設計判断＝エンコーディング選択**を決め、あわせて wall doc §7.1 の
-> variant-privacy seal を 3b-1 に統合する方針を確定する。実装は本 ADR が Accepted になってから。
+> 3b-0 (the API wall) is complete — direct `Value::<Variant>` references outside `src/value/` are **0**
+> (guaranteed by the ratchet `check-value-wall.sh`, run as part of `make test`). This ADR decides the
+> **single blocking design decision of 3b-1 (the `Value` 48B→8B representation switch), namely the
+> encoding choice**, and also fixes the policy of folding the variant-privacy seal from wall doc §7.1
+> into 3b-1. Implementation starts only after this ADR is Accepted.
 
 ---
 
-## 1. Context（背景）
+## 1. Context
 
-- `Value` は現在 48B の `enum`（~50 variant、`value_size_guard` テストで `<= 48` を固定）。
-  bench-class の ~50% が `Value::clone`/`drop_in_place`/`Vec::clone`（PERFORMANCE.md）、
-  GC default-on の bench-class +8% 残差も同じ交通量に乗る。3b は `Value` を **8B 固定幅**の
-  NaN-box に変え、これらをまとめて回収する（roadmap §3.1）。JIT（ADR-0004）は 8B 固定幅・
-  タグ判定数命令・レジスタ搭載を前提にしており、3b はその地ならし。
-- 3b-0 で全呼び出し側は `view()`/`ValueView`/accessor/constructor 経由に統一済み。したがって
-  3b-1 は原則 **`src/value/` の内部（表現モジュール）だけ**を書き換える。壁が保たれていれば
-  外部呼び出し側の変更は不要（これが 3b-0 の狙い）。
-- 3b-0 完了時点で判明した重要事実（本 ADR の前提を 1 つ補正する）:
-  wall doc §7.1 が「small・mechanical・~zero churn」と見積もっていた **variant-privacy seal の
-  module-boundary 方式（private サブモジュール ＋ `pub use` 再エクスポート）は実際には seal に
-  ならない**。Rust の enum variant は enum 自体の可視性を継承し、型の再エクスポートで variant も
-  外部から到達可能になる（`pub use repr::Value;` の後 `Value::Int(3)` が外部モジュールで
-  コンパイル可能なことを実証済み）。同一クレート内なので `#[non_exhaustive]` も無効。
-  コンパイル時に真に seal できる唯一の手段は **newtype ラッパー** `struct Value(ValueRepr)`
-  （private field ＋ private `ValueRepr`）であり、これは `src/value/` 内部の直接 variant 参照
-  **1293 箇所**を `.0` 経由へ書き換える大規模リファクタになる。
+- `Value` is currently a 48B `enum` (~50 variants; the `value_size_guard` test pins it at `<= 48`).
+  ~50% of bench-class is `Value::clone`/`drop_in_place`/`Vec::clone` (PERFORMANCE.md), and the
+  +8% GC-default-on residual on bench-class rides on the same traffic. 3b changes `Value` into an
+  **8B fixed-width** NaN-box and recovers all of these at once (roadmap §3.1). The JIT (ADR-0004)
+  assumes an 8B fixed width, tag checks in a few instructions, and register residency — 3b is the
+  groundwork for it.
+- After 3b-0, all call sites go through `view()`/`ValueView`/accessors/constructors. Therefore 3b-1
+  in principle rewrites **only the inside of `src/value/` (the representation module)**. As long as
+  the wall holds, no changes to external call sites are needed (this was the point of 3b-0).
+- An important fact discovered at 3b-0 completion (correcting one premise of this ADR):
+  the **module-boundary approach to the variant-privacy seal (private submodule + `pub use`
+  re-export), which wall doc §7.1 estimated as "small, mechanical, ~zero churn", does not actually
+  seal anything**. Rust enum variants inherit the visibility of the enum itself, and re-exporting
+  the type makes the variants reachable from outside as well (verified: after `pub use repr::Value;`,
+  `Value::Int(3)` compiles in an external module). Since it is the same crate, `#[non_exhaustive]`
+  is also ineffective. The only mechanism that truly seals at compile time is a **newtype wrapper**
+  `struct Value(ValueRepr)` (private field + private `ValueRepr`), and that is a large refactor
+  rewriting the **1293 sites** of direct variant references inside `src/value/` to go through `.0`.
 
-### 3b-0 で確定した variant 3 分類（roadmap §3.2・wall doc §2 の具体化）
+### The 3-way variant classification fixed in 3b-0 (concretizing roadmap §3.2 / wall doc §2)
 
-現行 enum を payload 形状で分類する（8B box の格納先を決める）:
+Classify the current enum by payload shape (this decides where each variant is stored in the 8B box):
 
-- **inline scalar**（ヒープなし・box payload に直接デコード格納、view は by-value）:
-  `Int`（小整数）・`Bool`・`Nil`・`Whatever`・`HyperWhatever`・`Num`（f64 生値）・
-  `Package(Symbol)`。**注意**: `Range*`(2×i64)・`Rat`/`FatRat`(2×i64)・`Complex`(2×f64) は
-  payload が 48bit を超えるため inline 不可 → boxed。
-- **single-pointer（pointer tag）**（`Gc<T>`/`Arc<T>` の生ポインタを payload に）:
-  `Str`・`Array`・`Hash`・`Set`・`Bag`・`Mix`・`Sub`・`WeakSub`・`LazyList`・`ContainerRef`・
-  `Seq`/`HyperSeq`/`RaceSeq`/`Slip`・`Junction`・`Regex`・`BigInt`・`Promise`/`Channel`・
-  `LazyThunk`・`Instance`（下記の付随フィールド問題あり）。
-- **heap-boxed struct**（多フィールド → 1 ヒープ箱に退避）:
-  `GenericRange`・`Range*`・`Rat`/`FatRat`/`BigRat`/`Complex`・`Pair`・`ValuePair`・`Enum`・
-  `RegexWithAdverbs`・`Version`・`Capture`・`Uni`・`Proxy`・`ParametricRole`・`CustomType`・
-  `CustomTypeInstance`・`Scalar`・`Mixin`(2 ポインタ)・`LazyIoLines`・`HashEntryRef`・
-  `CompUnitDepSpec`・`Routine`(3 Symbol)。
+- **inline scalar** (no heap; decoded value stored directly in the box payload; view is by-value):
+  `Int` (small integers), `Bool`, `Nil`, `Whatever`, `HyperWhatever`, `Num` (raw f64),
+  `Package(Symbol)`. **Note**: `Range*` (2×i64), `Rat`/`FatRat` (2×i64), and `Complex` (2×f64) have
+  payloads exceeding 48 bits and cannot be inlined → boxed.
+- **single-pointer (pointer tag)** (raw `Gc<T>`/`Arc<T>` pointer in the payload):
+  `Str`, `Array`, `Hash`, `Set`, `Bag`, `Mix`, `Sub`, `WeakSub`, `LazyList`, `ContainerRef`,
+  `Seq`/`HyperSeq`/`RaceSeq`/`Slip`, `Junction`, `Regex`, `BigInt`, `Promise`/`Channel`,
+  `LazyThunk`, `Instance` (has the companion-field problem described below).
+- **heap-boxed struct** (multiple fields → evacuated into a single heap box):
+  `GenericRange`, `Range*`, `Rat`/`FatRat`/`BigRat`/`Complex`, `Pair`, `ValuePair`, `Enum`,
+  `RegexWithAdverbs`, `Version`, `Capture`, `Uni`, `Proxy`, `ParametricRole`, `CustomType`,
+  `CustomTypeInstance`, `Scalar`, `Mixin` (2 pointers), `LazyIoLines`, `HashEntryRef`,
+  `CompUnitDepSpec`, `Routine` (3 Symbols).
 
-**付随フィールド問題**（wall doc §6 の未決事項）: `Array(Gc, ArrayKind)`・`Set/Bag/Mix(Gc, bool)`・
-`Instance{Symbol, Gc, u64}` はポインタ以外の小フィールドを持つ。ポインタ＋付随ビットを 48bit box に
-同居させるか、付随ビットを pointee 側へ移すかの選択がある（§3.3）。
+**Companion-field problem** (an open question from wall doc §6): `Array(Gc, ArrayKind)`,
+`Set/Bag/Mix(Gc, bool)`, and `Instance{Symbol, Gc, u64}` carry small fields besides the pointer.
+There is a choice between co-locating pointer + companion bits in the 48-bit box, or moving the
+companion bits into the pointee (§3.3).
 
-## 2. Decision（提案する決定）
+## 2. Decision (proposed)
 
-### 2.1 エンコーディング = **pointer-favored（NuN-boxing 型）** を推奨採用
+### 2.1 Encoding = **pointer-favored (NuN-boxing style)**, recommended for adoption
 
-box は 64bit の 1 ワード。**ポインタは低位ビットにクリーンに格納**し、`f64` は
-**オフセット・エンコード**（load/store 時に定数バイアスを加減）で quiet-NaN 空間の外へ退避する。
-inline 小整数・タグは残りのビット空間に割り当てる（正確なビット配分は実装時に確定・§3.1）。
+The box is a single 64-bit word. **Pointers are stored cleanly in the low bits**, and `f64` is
+evacuated out of the quiet-NaN space via **offset encoding** (adding/subtracting a constant bias on
+load/store). Inline small integers and tags are assigned to the remaining bit space (the exact bit
+allocation is finalized at implementation time; §3.1).
 
-**pointer-favored を選ぶ理由**:
+**Reasons for choosing pointer-favored**:
 
-1. **mutsu のホットパスはポインタ支配的**。method dispatch・コンテナアクセス（`Str`/`Array`/
-   `Hash`/`Instance`/`Sub`）が最頻で、pointer-favored はこれらの deref を **マスク操作なし**
-   （生ポインタがそのまま）にできる。
-2. **移行コストが最小**。生ポインタが payload そのものなので `&self.0` を `&Arc<T>`/`&Gc<T>` へ
-   transmute でき、`ValueView` の pointer variant フィールドを **現行の `&'a Arc<T>`/`&'a Gc<T>`
-   のまま維持**できる（wall doc §2/§7.2）。→ `view.rs` の変更が最小、外部呼び出し側の変更ゼロ。
-3. **ヘッドラインベンチは Int 律速**。int-arith・fib は `Int`（両エンコーディングとも inline）を
-   使い、`Num`(f64) は二次的。f64 のオフセット加減は 1 ALU 命令で、非主要パスに乗る。
+1. **mutsu's hot paths are pointer-dominated.** Method dispatch and container access (`Str`/`Array`/
+   `Hash`/`Instance`/`Sub`) are the most frequent, and pointer-favored makes their derefs
+   **mask-free** (the raw pointer is used as-is).
+2. **Minimal migration cost.** Since the raw pointer *is* the payload, `&self.0` can be transmuted
+   to `&Arc<T>`/`&Gc<T>`, and the pointer-variant fields of `ValueView` can be **kept as the current
+   `&'a Arc<T>`/`&'a Gc<T>`** (wall doc §2/§7.2). → Minimal changes to `view.rs`, zero changes to
+   external call sites.
+3. **The headline benchmarks are Int-bound.** int-arith and fib use `Int` (inline under either
+   encoding); `Num` (f64) is secondary. The f64 offset add/subtract is 1 ALU instruction and lands
+   on a non-primary path.
 
-**却下する対案 = NaN-favored（native double）**: `f64` を生値で持ち、非 f64 を quiet-NaN payload に
-タグ格納する（JSC/LuaJIT 方式）。`Num` 演算がゼロコストになる利点はあるが、(a) ポインタ deref に
-マスク（AND）が要る、(b) `&self.0` がクリーンな `&Arc<T>` にならないため `ValueView` の pointer
-variant フィールドを **by-value guard 型 `ArcRef<'a,T>`/`GcRef<'a,T>`**（`ManuallyDrop` で refcount を
-触らず `Deref` する再構成型）に変える追加実装が要る。mutsu では Num より pointer/Int が支配的なので
-利得が逆。
+**Rejected alternative = NaN-favored (native double)**: hold `f64` as a raw value and tag-store
+non-f64 in the quiet-NaN payload (the JSC/LuaJIT approach). It has the advantage of zero-cost `Num`
+arithmetic, but (a) pointer derefs need a mask (AND), and (b) `&self.0` does not become a clean
+`&Arc<T>`, so the pointer-variant fields of `ValueView` would need extra implementation as
+**by-value guard types `ArcRef<'a,T>`/`GcRef<'a,T>`** (reconstructed types that `Deref` without
+touching the refcount via `ManuallyDrop`). In mutsu, pointer/Int dominate over Num, so the payoff
+is inverted.
 
-**両出口を開けたまま進める**: wall doc §2 の移行規則（call site を deref 互換の使い方に限定 —
-`s.clone()`/`s.is_empty()`/`&*s`/`Arc::ptr_eq` は可、`&Arc` 自体の保存やアドレス比較は不可）は
-3b-0 で既に守られている。したがって、後述のベンチ（§3.2）で pointer-favored が Num 重ワークロードで
-不利と実測された場合に限り、guard 型を導入して NaN-favored へ切り替える退路が残る
-（call site 変更は不要、`view.rs` の pointer フィールド型と box 内部のみ差し替え）。
+**Proceed with both exits kept open**: the migration rules of wall doc §2 (restrict call sites to
+deref-compatible usage — `s.clone()`/`s.is_empty()`/`&*s`/`Arc::ptr_eq` allowed; storing the `&Arc`
+itself or comparing addresses not allowed) are already upheld as of 3b-0. Therefore, only if the
+benchmarks below (§3.2) empirically show pointer-favored losing on Num-heavy workloads, an escape
+route remains to introduce the guard types and switch to NaN-favored (no call-site changes needed;
+only the pointer-field types in `view.rs` and the box internals are swapped).
 
-### 2.2 variant-privacy seal は **3b-1 に統合**（単独 PR にしない）
+### 2.2 The variant-privacy seal is **folded into 3b-1** (not a standalone PR)
 
-wall doc §7.1 の seal を独立ステップとして先行実施しない。理由:
+Do not carry out the seal from wall doc §7.1 as a preceding independent step. Reasons:
 
-1. seal の唯一の実効メカニズム（newtype ラッパー）が **3b-1 step 2 の構造的前半そのもの**。
-   3b-1 は `Value` を `struct Value(内部表現)` の newtype にするので、newtype 化＝副作用で
-   variant が compile-time に seal される。単独 seal を挟むと同じ 1293 サイトを二度触る。
-2. wall の後退は ratchet（`check-value-wall.sh`・`make test` 組込）が **決定的に検出**済み。
-   単独 seal の追加価値は「CI 失敗をコンパイル失敗へ前倒し」する belt-and-suspenders のみで、
-   1293 サイトの二重リファクタに見合わない。
-3. ratchet は seal 後も残置する（安価な回帰ネット）。
+1. The only effective mechanism for the seal (the newtype wrapper) is **exactly the structural first
+   half of 3b-1 step 2**. 3b-1 turns `Value` into the newtype `struct Value(internal repr)`, so the
+   newtype-ification seals the variants at compile time as a side effect. Inserting a standalone
+   seal would touch the same 1293 sites twice.
+2. Regression of the wall is already **deterministically detected** by the ratchet
+   (`check-value-wall.sh`, integrated into `make test`). The only added value of a standalone seal
+   is a belt-and-suspenders "move the CI failure forward to a compile failure", which does not
+   justify a double refactor of 1293 sites.
+3. The ratchet stays in place after the seal (a cheap regression net).
 
-→ 3b-1 の最初のコミットが **byte-identical な newtype 化**（内部表現はまだ現行 enum のまま
-`struct Value(ValueRepr)` に包むだけ）になり、これが seal を兼ねる（§3.3 step A）。
+→ The first commit of 3b-1 becomes a **byte-identical newtype-ification** (the internal
+representation stays the current enum; it is merely wrapped in `struct Value(ValueRepr)`), and this
+doubles as the seal (§3.3 step A).
 
-### 2.3 スライス構成（roadmap §3.3 step 2 を細分化）
+### 2.3 Slice structure (subdividing roadmap §3.3 step 2)
 
-3b-1 を「安全な機械変換（構造）」と「危険な表現差し替え（実体）」に分割する:
+Split 3b-1 into "safe mechanical transformation (structure)" and "dangerous representation swap
+(substance)":
 
-- **step A（newtype seal・byte-identical）**: `pub enum Value` → `pub struct Value(ValueRepr)`
-  （`ValueRepr` は `src/value/` private の enum、現行 variant をそのまま保持）。`src/value/` 内部の
-  1293 サイトを `.0` 経由へ機械変換。`ValueRepr` は依然 48B なので **挙動・サイズとも不変**。
-  variant は compile-time に seal される。ゲート: make test byte-identical、`value_size_guard` は 48 のまま。
-  **✅ 実装済み（2026-07-11）**。実装形: パターン/struct-like variant 式サイトは
-  `Value(ValueRepr::..)`（コンパイルエラー span 駆動の機械変換 ~1800 サイト）、tuple/unit variant の
-  **式**サイトは variant 名 constructor shim（`crate::value` 限定可視の `fn Int(..)`/`const Nil` 等 —
-  step B でこの shim 本体が NaN-box の tag-packing constructor になる）。seal 実証 =
-  `src/value/` 外の `Value::Int(3)` が E0624 (private) でコンパイル不能。`mem::discriminant` の
-  variant 比較 3 サイトは wall API `Value::same_variant()` へ置換（struct への discriminant は
-  `enum_intrinsics_non_enums` エラー — seal が非-enum 前提の残存 idiom も炙り出した）。
-- **step B（表現差し替え・実体）**: `ValueRepr`（48B enum）を pointer-favored NaN-box（8B）へ置換。
-  `view()`/constructor/accessor/`with_*_mut` の中身だけが変わる。`value_size_guard` を 48→8 に更新。
-  ゲート: make test ＋ full roast ＋ gc-stress green、GC カウンタ不変（型フィルタのスカラ/コンテナ
-  判定がタグ判定に変わるだけ）、§3.2 のマイクロベンチ達成。
-- step A と step B の分割により、**中間状態が常に byte-identical**（step A）→ 危険な変更（step B）は
-  確立済みの newtype 境界の背後だけに閉じる。bisect/レビューも容易。
+- **step A (newtype seal, byte-identical)**: `pub enum Value` → `pub struct Value(ValueRepr)`
+  (`ValueRepr` is a private enum in `src/value/`, keeping the current variants as-is). Mechanically
+  convert the 1293 sites inside `src/value/` to go through `.0`. `ValueRepr` is still 48B, so
+  **both behavior and size are unchanged**. Variants become sealed at compile time. Gate: make test
+  byte-identical; `value_size_guard` stays at 48.
+  **✅ Implemented (2026-07-11)**. Implementation shape: pattern / struct-like variant expression
+  sites became `Value(ValueRepr::..)` (~1800 sites mechanically converted, driven by compile-error
+  spans); tuple/unit variant **expression** sites use variant-name constructor shims (`fn Int(..)` /
+  `const Nil` etc., visible only within `crate::value` — in step B these shim bodies become the
+  NaN-box tag-packing constructors). Seal verification = `Value::Int(3)` outside `src/value/` fails
+  to compile with E0624 (private). The 3 sites doing `mem::discriminant` variant comparison were
+  replaced with the wall API `Value::same_variant()` (taking a discriminant of a struct is an
+  `enum_intrinsics_non_enums` error — the seal also flushed out remaining idioms that assumed a
+  non-enum was an enum).
+- **step B (representation swap, substance)**: replace `ValueRepr` (48B enum) with the
+  pointer-favored NaN-box (8B). Only the internals of `view()`/constructors/accessors/`with_*_mut`
+  change. Update `value_size_guard` from 48 → 8.
+  Gates: make test + full roast + gc-stress green; GC counters unchanged (the scalar/container
+  discrimination of the type filter merely becomes a tag check); the microbenchmarks of §3.2
+  achieved.
+- Splitting step A from step B means the **intermediate state is always byte-identical** (step A) →
+  the dangerous change (step B) stays confined behind the already-established newtype boundary.
+  Bisecting/review also becomes easy.
 
-## 3. 実装時に確定する下位判断（本 ADR では方針のみ）
+## 3. Subordinate decisions finalized at implementation time (this ADR sets policy only)
 
-### 3.1 小整数幅
+### 3.1 Small-integer width
 
-inline `Int` の幅（48bit inline / 32bit inline / 範囲外は `Gc<i64>` 箱 or `BigInt` 箱行き）は
-**int-arith / fib ベンチで flip 時に決定**（roadmap §3.2）。pointer-favored はタグ空間がやや狭い点に
-注意。既定案: 48bit 級 inline、範囲外は既存の `BigInt` 経路へ委譲（`Gc<i64>` 箱は計測で必要なら）。
+The width of inline `Int` (48-bit inline / 32-bit inline / out-of-range goes to a `Gc<i64>` box or
+the `BigInt` box) is **decided at flip time using the int-arith / fib benchmarks** (roadmap §3.2).
+Note that pointer-favored has a somewhat narrower tag space. Default proposal: ~48-bit inline;
+out-of-range delegates to the existing `BigInt` path (a `Gc<i64>` box only if measurements demand
+it).
 
-### 3.2 受け入れマイクロベンチ（step B ゲート）
+### 3.2 Acceptance microbenchmarks (step B gate)
 
-- **int-arith 2x**・**fib +30%**（PERFORMANCE.md Phase 4a 期待値）。
-- bench-class の `Value` clone/drop share **50% → 20% 以下**。
-- GC-on bench-class 残差 **+8% → +3% 以下**（roadmap §3.3 の 3b 全体ゲート）。
-- **pointer-favored 妥当性チェック**: `Num` 重ワークロード（複素数/浮動小数ループのマイクロベンチを
-  1 本追加）で回帰が **f64 オフセット 1 命令ぶんに収まる**ことを確認。ここで想定外の回帰が出た場合のみ
-  §2.1 の退路（guard 型で NaN-favored）を発動。
+- **int-arith 2x**, **fib +30%** (PERFORMANCE.md Phase 4a expectations).
+- bench-class `Value` clone/drop share **50% → 20% or below**.
+- GC-on bench-class residual **+8% → +3% or below** (the overall 3b gate from roadmap §3.3).
+- **pointer-favored validity check**: on a Num-heavy workload (add one microbenchmark with a
+  complex-number / floating-point loop), confirm that the regression **stays within the single f64
+  offset instruction**. Only if an unexpected regression shows up here, trigger the escape route of
+  §2.1 (guard types, NaN-favored).
 
-### 3.3 付随フィールドの配置
+### 3.3 Placement of companion fields
 
-`Array` の `ArrayKind`・`Set/Bag/Mix` の mutability bool は **box のスペアタグビットに載せる**を
-既定とし、ビットが逼迫した場合に pointee へ移す。`Instance` の `{class_name: Symbol, id: u64}` は
-ポインタ 1 本に収まらないため、`InstanceAttrs`（既に `Gc`）側へ寄せるか専用ヒープ箱にする
-（step B の設計で確定）。
+The default is to **put the `ArrayKind` of `Array` and the mutability bool of `Set/Bag/Mix` in the
+box's spare tag bits**, moving them into the pointee if bits get tight. `Instance`'s
+`{class_name: Symbol, id: u64}` does not fit in a single pointer, so it is either pushed into the
+`InstanceAttrs` side (already `Gc`) or given a dedicated heap box (finalized during step B design).
 
 ## 4. Consequences
 
-- step A 完了時点で variant は compile-time に seal され、wall doc §7.1 の目的を達成（ratchet は残置）。
-- pointer-favored 採用により `ValueView` の pointer variant フィールドが現行の `&Arc<T>`/`&Gc<T>` の
-  まま維持され、`view.rs` の変更と外部影響が最小化される。
-- `Num` 演算に f64 オフセット加減 1 命令が乗る（非主要パス・§3.2 で妥当性を実測）。
-- Send/Sync は不変（payload はポインタのまま・roadmap §3.4）。タグ操作は 1 モジュールに閉じ込め
-  Miri でユニット検証（roadmap §3.4）。
-- 3b-1 完了で JIT（ADR-0004 J1）の前提「8B 固定幅 `Value`」が満たされる。続いて 3b-2（交通量刈り）。
+- At step A completion the variants are sealed at compile time, achieving the goal of wall doc §7.1
+  (the ratchet stays in place).
+- Adopting pointer-favored keeps the pointer-variant fields of `ValueView` as the current
+  `&Arc<T>`/`&Gc<T>`, minimizing changes to `view.rs` and external impact.
+- `Num` arithmetic pays 1 f64 offset add/subtract instruction (non-primary path; validity measured
+  in §3.2).
+- Send/Sync is unchanged (the payload remains a pointer; roadmap §3.4). Tag manipulation is confined
+  to a single module and unit-verified with Miri (roadmap §3.4).
+- Completing 3b-1 satisfies the JIT's (ADR-0004 J1) prerequisite of an "8B fixed-width `Value`".
+  Next comes 3b-2 (traffic pruning).
 
 ## 5. Alternatives considered
 
-| 案 | 利点 | 欠点 | 判定 |
+| Option | Pros | Cons | Verdict |
 |---|---|---|---|
-| **pointer-favored NaN-box（本 ADR）** | ポインタ deref マスク不要・view 移行最小（`&Arc<T>` 維持）・外部影響ゼロ | f64 にオフセット 1 命令 | **推奨採用** |
-| NaN-favored（native double） | `Num` 演算ゼロコスト | ポインタ deref にマスク・view が guard 型（ArcRef/GcRef）へ追加実装・mutsu は Num 非支配 | 却下（退路として保持） |
-| 単独 variant-privacy seal を先行 | 表現変更と分離してレビュー | 実効メカニズム=newtype=3b-1 step A なので 1293 サイトを二度触る・ratchet で回帰は既に防止済 | 却下（3b-1 に統合） |
-| module-boundary seal（`pub use` 再エクスポート） | churn ゼロの想定だった | **seal にならない**（variant が再エクスポートで漏れる・実証済み） | 却下（実現不能） |
-| 一斉 flip（step A/B 非分割） | コミット数少 | 5b で 479 エラー/型・レビュー/bisect 不能（roadmap §3.3/§3.4） | 却下（段階必須） |
+| **pointer-favored NaN-box (this ADR)** | No mask on pointer deref; minimal view migration (`&Arc<T>` kept); zero external impact | 1 offset instruction on f64 | **Recommended, adopted** |
+| NaN-favored (native double) | Zero-cost `Num` arithmetic | Mask on pointer deref; view needs extra guard-type implementation (ArcRef/GcRef); Num is not dominant in mutsu | Rejected (kept as escape route) |
+| Standalone variant-privacy seal first | Reviewable separately from the representation change | The effective mechanism = newtype = 3b-1 step A, so the 1293 sites get touched twice; regression already prevented by the ratchet | Rejected (folded into 3b-1) |
+| module-boundary seal (`pub use` re-export) | Was expected to be zero churn | **Does not seal** (variants leak through the re-export; verified) | Rejected (infeasible) |
+| Single flip (no step A/B split) | Fewer commits | 479 errors/type in 5b; unreviewable/unbisectable (roadmap §3.3/§3.4) | Rejected (staging mandatory) |
 
 ---
 
-*本 ADR は 2026-07-12 に Accepted。3b-1 step A（newtype seal・byte-identical）は先行完了済み
-（2026-07-11・news/2026-07.md）。承認により **step B（pointer-favored 表現差し替え）が着手可能** —
-§3.2 のベンチゲート（make test＋roast＋gc-stress green・マイクロベンチ）で受け入れる。*
+*This ADR was Accepted on 2026-07-12. 3b-1 step A (newtype seal, byte-identical) was completed ahead
+of time (2026-07-11, news/2026-07.md). With the approval, **step B (the pointer-favored
+representation swap) may begin** — accepted against the benchmark gates of §3.2 (make test + roast +
+gc-stress green, plus the microbenchmarks).*

--- a/docs/adr/0006-baseline-interpreter-optimizations.md
+++ b/docs/adr/0006-baseline-interpreter-optimizations.md
@@ -1,239 +1,258 @@
-# ADR-0006: ベースライン（古典的）インタープリタ最適化の採否と優先順位
+# ADR-0006: Baseline (classical) interpreter optimizations — adoption decisions and priorities
 
-- **Status**: Accepted（2026-07-13 tokuhirom 承認）
+- **Status**: Accepted (approved by tokuhirom 2026-07-13)
 - **Date**: 2026-07-13
 - **Deciders**: tokuhirom, Claude
-- **関連**: [ADR-0004](0004-jit-strategy.md)（JIT・threaded dispatch 凍結の判断）,
-  [ADR-0005](0005-nanbox-representation-encoding.md)（8B Value）,
-  [docs/opcode-design-review.md](../opcode-design-review.md)（opcode 残件 §2/§5/§6）,
+- **Related**: [ADR-0004](0004-jit-strategy.md) (JIT; the decision to freeze threaded dispatch),
+  [ADR-0005](0005-nanbox-representation-encoding.md) (8B Value),
+  [docs/opcode-design-review.md](../opcode-design-review.md) (remaining opcode items §2/§5/§6),
   PLAN.md §5, PERFORMANCE.md
 
-> ADR-0004 で JIT（Cranelift, J5 で既定 on・2026-07-13）まで到達した一方、
-> CPython / Ruby (YARV) / PHP (opcache) が**JIT 以前から**備えている古典的な
-> バイトコード最適化はほぼ未実装であることが監査（2026-07-13）で判明した。
-> 本 ADR はその監査結果を記録し、各施策の採否・優先順位・Raku 固有の安全条件を決める。
+> While ADR-0004 got us all the way to a JIT (Cranelift, default-on since J5, 2026-07-13),
+> an audit (2026-07-13) found that the classical bytecode optimizations that CPython /
+> Ruby (YARV) / PHP (opcache) have had **since before their JITs** are almost entirely
+> unimplemented. This ADR records that audit and decides the adoption, priority, and
+> Raku-specific safety conditions for each measure.
 
 ---
 
-## 1. Context（背景）
+## 1. Context
 
-- 実行系: Parser → Compiler（`src/compiler/`）→ bytecode（~340 opcode）→ VM。
-  コンパイラは AST を**一対一で**opcode 列に落とし、emit 後の最適化パスは
-  `compute_upvalues` / `compute_needs_env_sync`（変数アクセス系）のみ。
-- 主要言語処理系の対応状況（比較のための整理）:
-  - **CPython**: AST レベル定数畳み込み・peephole（jump 最適化）・3.11 adaptive
-    specializing interpreter（quickening + inline cache）。
-  - **Ruby (YARV)**: peephole・specialized instructions（`opt_plus` 等）・
-    operand/instruction unification・call-site inline cache。
-  - **PHP (opcache)**: SSA ベースの最適化パス群 — 定数畳み込み・定数伝播・DCE・
-    jump 最適化・型推論による opcode 特殊化。
-- mutsu が**既に持つ**同等物: スーパーインストラクション（`WhileLoop`/`ForLoop` 等の
-  複合 op・`StringConcat(n)`・`JunctionAnyN` 等）、グローバルメソッドキャッシュ
-  （`method_resolve_cache` + monomorphic 1-entry `last_method_resolve`）、
-  indexed locals、COW env、Symbol インターン、NaN-box small-Int（±2^47 インライン）、
-  grammar token の静的 fold（#4460）。
-- つまり「変数アクセス・呼び出し・データ表現」の最適化は進んでいるが、
-  **「opcode 列そのものを短くする」系の最適化が丸ごと欠けている**。
+- Execution pipeline: Parser → Compiler (`src/compiler/`) → bytecode (~340 opcodes) → VM.
+  The compiler lowers the AST to the opcode stream **one-to-one**; the only post-emit
+  optimization passes are `compute_upvalues` / `compute_needs_env_sync` (variable-access
+  related).
+- Status in the major language implementations (organized for comparison):
+  - **CPython**: AST-level constant folding, peephole (jump optimization), the 3.11
+    adaptive specializing interpreter (quickening + inline caches).
+  - **Ruby (YARV)**: peephole, specialized instructions (`opt_plus` etc.),
+    operand/instruction unification, call-site inline caches.
+  - **PHP (opcache)**: a suite of SSA-based optimization passes — constant folding,
+    constant propagation, DCE, jump optimization, opcode specialization via type inference.
+- Equivalents mutsu **already has**: superinstructions (compound ops like `WhileLoop`/`ForLoop`,
+  `StringConcat(n)`, `JunctionAnyN`, etc.), a global method cache
+  (`method_resolve_cache` + the monomorphic 1-entry `last_method_resolve`),
+  indexed locals, COW env, Symbol interning, NaN-box small-Int (±2^47 inline),
+  static folding of grammar tokens (#4460).
+- In other words, the "variable access / calls / data representation" optimizations are well
+  advanced, but the entire class of optimizations that **shorten the opcode stream itself**
+  is missing.
 
-### 1.1 監査結果（2026-07-13、実装状況の正本）
+### 1.1 Audit results (2026-07-13; authoritative record of implementation status)
 
-| 施策 | CPython | YARV | opcache | mutsu の現状 | 判定 |
+| Measure | CPython | YARV | opcache | Current state in mutsu | Verdict |
 |---|---|---|---|---|---|
-| 定数畳み込み | ✅ | ✅ | ✅ | ❌ `compile_expr_binary` はリテラル同士でも常に演算 op を emit（`expr_binary.rs`） | **採用** (§2.1) |
-| `constant` 読みのインライン化 | ✅ (co_consts) | ✅ | ✅ | ❌ BEGIN 時評価はするが読みは `GetLocal`/`GetBareWord`/`GetGlobal`（`stmt.rs` constant 宣言） | **採用** (§2.2) |
-| 定数条件の分岐除去・DCE | ✅ | ✅ | ✅ | ❌ `if False {...}` も条件評価+`JumpIfFalse` を emit | **採用** (§2.2) |
-| peephole（冗長 op 除去/融合） | ✅ | ✅ | ✅ | ❌ emit 後の書き換えパスなし（変数系の `compute_*` のみ） | **採用** (§2.3) |
-| 定数プール重複排除 | ✅ | ✅ | ✅ | ❌ `add_constant` は無条件 `constants.push`（`opcode.rs:2927`） | **採用** (§2.4) |
-| per-call-site inline cache (PIC) | ✅ (3.11) | ✅ | 部分 | 部分: グローバルキャッシュ+monomorphic 1-entry のみ、opcode 埋め込みキャッシュなし | **保留** (§3.1) |
-| quickening / adaptive specialization | ✅ (3.11) | 部分 | ✅ | ❌ | **却下** (§3.2) |
-| threaded dispatch | ✅ (computed goto) | ✅ | ✅ | ❌ | **却下済み**（ADR-0004 §2.5 J0 で凍結 — 再論しない） |
-| 小整数キャッシュ | ✅ | ✅ (Fixnum) | — | **実質達成**: NaN-box small-Int はヒープ非確保（層3b） | 対応不要 |
-| 文字列インターン（値） | 部分 (fstring) | ✅ (frozen str) | ✅ | ❌ `Value::Str` は都度 `Arc<String>`（Symbol は別途インターン済み） | **保留** (§3.3) |
+| Constant folding | ✅ | ✅ | ✅ | ❌ `compile_expr_binary` always emits the arithmetic op even for literal-literal pairs (`expr_binary.rs`) | **Adopt** (§2.1) |
+| Inlining of `constant` reads | ✅ (co_consts) | ✅ | ✅ | ❌ evaluated at BEGIN time, but reads go through `GetLocal`/`GetBareWord`/`GetGlobal` (`stmt.rs` constant declaration) | **Adopt** (§2.2) |
+| Constant-condition branch elimination / DCE | ✅ | ✅ | ✅ | ❌ even `if False {...}` emits the condition evaluation + `JumpIfFalse` | **Adopt** (§2.2) |
+| Peephole (redundant-op removal/fusion) | ✅ | ✅ | ✅ | ❌ no post-emit rewrite pass (only the variable-related `compute_*`) | **Adopt** (§2.3) |
+| Constant-pool deduplication | ✅ | ✅ | ✅ | ❌ `add_constant` unconditionally does `constants.push` (`opcode.rs:2927`) | **Adopt** (§2.4) |
+| Per-call-site inline cache (PIC) | ✅ (3.11) | ✅ | partial | Partial: only the global cache + monomorphic 1-entry; no cache embedded in the opcode | **Deferred** (§3.1) |
+| Quickening / adaptive specialization | ✅ (3.11) | partial | ✅ | ❌ | **Rejected** (§3.2) |
+| Threaded dispatch | ✅ (computed goto) | ✅ | ✅ | ❌ | **Already rejected** (frozen in ADR-0004 §2.5 J0 — not relitigated) |
+| Small-integer cache | ✅ | ✅ (Fixnum) | — | **Effectively achieved**: NaN-box small-Int is heap-allocation-free (layer 3b) | No action needed |
+| String interning (values) | partial (fstring) | ✅ (frozen str) | ✅ | ❌ `Value::Str` is a fresh `Arc<String>` each time (Symbols are interned separately) | **Deferred** (§3.3) |
 
-### 1.2 実測根拠（新設ベンチ、ローカル release・3 回最小値・2026-07-13）
+### 1.2 Empirical basis (newly added benchmarks; local release, min of 3 runs, 2026-07-13)
 
-判定を「一般論」でなく mutsu の実測で裏づけるため、対象最適化に感応する
-自然なワークロードを `benchmarks/` に 4 本新設して測った:
+To back the verdicts with mutsu measurements rather than generalities, four natural workloads
+sensitive to the targeted optimizations were newly added under `benchmarks/` and measured:
 
-| ベンチ | interp | JIT on | raku | 比（interp） | 主な感応対象 |
+| Benchmark | interp | JIT on | raku | Ratio (interp) | Primary sensitivity |
 |---|---|---|---|---|---|
-| time-parts（タイムスタンプ分解） | 0.73s | 0.75s | 0.21s | **3.5x** | 定数畳み込み・peephole |
-| debug-guard（定数ガード付きホット関数） | 0.42s | 0.43s | 0.19s | **2.2x** | constant インライン化・定数条件 DCE |
-| poly-call（3 クラス混合の area 集計） | 0.10s | 0.10s | 0.21s | 0.48x | PIC（保留の基準線） |
-| word-count（単語頻度カウント） | 0.10s | 0.10s | 0.22s | 0.45x | 文字列インターン（保留の基準線） |
+| time-parts (timestamp decomposition) | 0.73s | 0.75s | 0.21s | **3.5x** | constant folding, peephole |
+| debug-guard (hot function with a constant guard) | 0.42s | 0.43s | 0.19s | **2.2x** | constant inlining, constant-condition DCE |
+| poly-call (area aggregation over 3 mixed classes) | 0.10s | 0.10s | 0.21s | 0.48x | PIC (baseline for the deferral) |
+| word-count (word frequency counting) | 0.10s | 0.10s | 0.22s | 0.45x | string interning (baseline for the deferral) |
 
-- **time-parts 3.5x / debug-guard 2.2x は現行スイート最悪の bench-fib 1.78x を超える**。
-  既存スイートが「関数呼び出し・OOP・コレクション」に寄っていて、
-  素朴な式・文の密度が高いコードの弱さを見落としていた。
-- **JIT on でも改善しない**（interp と同時間）— この 2 本の遅さは dispatch でなく
-  「実行する opcode がそもそも多い」ことに由来し、JIT と独立の直交レバーである証拠。
-- opcode ヒストグラム（`MUTSU_VM_STATS=1`）の内訳:
-  - time-parts: total 7.6M op/run のうち `LoadConst`=1.7M・`Mul`=1.0M（うち
-    リテラル定数式 `60*60*24` 等の再計算が iteration あたり Mul×6 = 600k）、
-    加えて `SetSourceLine`=600k・`Mark*`/`SetVarDynamic`=1.5M の administrative op。
-  - debug-guard: `if DEBUG` が毎回 `GetBareWord`+`JumpIfFalse`（各 200k）として実行
-    される。constant インライン化 + 定数条件 DCE でブロックごと消える形。
-- poly-call / word-count は**既に raku 比で優位**（0.48x / 0.45x）。PIC・文字列インターンを
-  「他言語にあるから」という理由で実装する緊急性はない、という判定の根拠。
+- **time-parts at 3.5x / debug-guard at 2.2x exceed bench-fib's 1.78x, the worst in the current
+  suite**. The existing suite skews toward "function calls / OOP / collections" and had missed
+  the weakness on code with a high density of plain expressions and statements.
+- **The JIT does not help either** (same time as interp) — the slowness of these two comes not
+  from dispatch but from "simply executing too many opcodes", which is evidence that this is an
+  orthogonal lever independent of the JIT.
+- Breakdown of the opcode histogram (`MUTSU_VM_STATS=1`):
+  - time-parts: out of 7.6M ops/run, `LoadConst`=1.7M and `Mul`=1.0M (of which recomputation
+    of literal constant expressions like `60*60*24` is Mul×6 per iteration = 600k), plus the
+    administrative ops `SetSourceLine`=600k and `Mark*`/`SetVarDynamic`=1.5M.
+  - debug-guard: `if DEBUG` executes as `GetBareWord`+`JumpIfFalse` every time (200k each).
+    With constant inlining + constant-condition DCE the whole block disappears.
+- poly-call / word-count are **already ahead of raku** (0.48x / 0.45x). This is the basis for
+  the verdict that there is no urgency to implement PIC or string interning merely "because
+  other languages have them".
 
-## 2. Decision — 採用する施策（優先順）
+## 2. Decision — adopted measures (in priority order)
 
-すべて**コンパイル時（emit 時/emit 後）の変換**で、実行時の適応機構を持たない。
-ADR-0004 の「deopt を作らない」方針と同型: 静的に安全と証明できる場合のみ変換し、
-証明できなければ何もしない（フォールバックは「無変換」なので flaky になり得ない）。
+All are **compile-time transformations (at emit time / post-emit)** with no runtime adaptive
+machinery. Same shape as ADR-0004's "no deopt" policy: transform only when statically provable
+safe; otherwise do nothing (the fallback is "no transformation", so it cannot become flaky).
 
-### 2.1 定数畳み込み（constant folding）
+### 2.1 Constant folding
 
-リテラル同士の純粋演算（算術・比較・文字列連結・論理）を emit 時に評価して
-`LoadConst` 1 個に置換する。実装は `compile_expr_binary` の入口で
-「両オペランドが畳み込み済み定数か」を見る bottom-up 方式（AST は変更しない）。
+Evaluate pure operations between literals (arithmetic, comparison, string concatenation,
+logical) at emit time and replace them with a single `LoadConst`. Implemented bottom-up at the
+entry of `compile_expr_binary` by checking "are both operands already-folded constants" (the
+AST is not modified).
 
-**Raku 固有の安全条件**（畳み込んでよいのは以下を全て満たす場合のみ）:
+**Raku-specific safety conditions** (folding is allowed only when all of the following hold):
 
-1. **演算子オーバーライド不在**: 同一コンパイル単位に当該演算子の
-   `multi sub infix:<op>` 宣言（`sub infix:<op>` 含む）が存在する場合、
-   そのファイル全体で fold を無効化する（宣言スコープの精密解析はしない —
-   保守的すぎて畳み込み機会を失っても、誤畳み込みよりよい）。
-   JIT Tier B が同じ問題を infix-override ガードで解いている
-   （pin: `t/jit-tier-b-infix-override.t`）— 同じ検出結果を共有する。
-2. **実行時と同一の演算実装**: 畳み込みは VM の native 演算（`builtins/arith.rs` 等）を
-   そのまま呼んで評価する。独自の「コンパイル時演算」を書かない
-   （Int の BigInt 昇格・Rat 化 `1/3`・型昇格規則が実行時と自動で一致する）。
-3. **例外を投げ得る式は畳み込まない**: 評価が `Err`（`0 div 0` 等）になったら
-   無変換で残す（実行時に投げる意味論を保存。コンパイル時エラーへの昇格はしない）。
-4. **畳み込み結果が value 型のみ**: Int/Num/Str/Bool/Rat。コンテナや Instance に
-   なる式は対象外（同一性が観測可能）。
+1. **No operator override present**: if the same compilation unit contains a
+   `multi sub infix:<op>` declaration for the operator (including `sub infix:<op>`),
+   disable folding for the entire file (no precise declaration-scope analysis —
+   being too conservative and losing folding opportunities is better than mis-folding).
+   JIT Tier B solves the same problem with an infix-override guard
+   (pin: `t/jit-tier-b-infix-override.t`) — share the same detection result.
+2. **Same operation implementation as at runtime**: folding evaluates by calling the VM's
+   native operations (`builtins/arith.rs` etc.) directly. Do not write a separate
+   "compile-time arithmetic" (Int's BigInt promotion, Rat-ification of `1/3`, and type
+   promotion rules automatically match runtime behavior).
+3. **Do not fold expressions that can throw**: if evaluation yields `Err` (`0 div 0` etc.),
+   leave the expression untransformed (preserving throw-at-runtime semantics; no promotion
+   to a compile-time error).
+4. **Fold results must be value types only**: Int/Num/Str/Bool/Rat. Expressions producing
+   containers or Instances are out of scope (identity is observable).
 
-### 2.2 `constant` 読みのインライン化 + 定数条件 DCE
+### 2.2 Inlining of `constant` reads + constant-condition DCE
 
-- `constant NAME = ...` は言語仕様上コンパイル時（BEGIN）に確定し再代入不可。
-  現在は BEGIN 評価した値をスロット/env に入れて実行時に読んでいる
-  （`src/compiler/mod.rs:180` 付近が「GetLocal に変える」ことを意図的に避けているのは
-  *宣言前使用の検出*のためで、インライン化自体の否定ではない）。
-  値が value 型（Int/Num/Str/Bool/Rat/Nil）の `constant` の読みを `LoadConst` に置換する。
-  コンテナ値の constant は同一性が観測可能なので対象外（従来どおり）。
-- インライン化で条件がリテラル定数になった `if`/`unless`/`while` は分岐ごと解決する:
-  `if False {...}` はブロックを emit しない（elsif/else 連鎖は残りを通常コンパイル）。
-  `constant DEBUG = False; if DEBUG { note ... }` というガード付きロギングは
-  実コードの頻出パターンで、debug-guard ベンチ（2.2x）がこれを測る。
-- **safety**: DCE で消すのは「値が確定した分岐の非到達側」のみ。副作用解析は不要
-  （条件式自体がリテラル定数のときだけ発動するため）。ブロック内の `BEGIN`/宣言の
-  扱いは Rakudo の意味論（コンパイルはされる）に合わせ、**宣言を含むブロックは
-  消さず従来コンパイルに落とす**保守則から始める。
+- `constant NAME = ...` is, per the language spec, fixed at compile time (BEGIN) and cannot
+  be reassigned. Currently the BEGIN-evaluated value is put into a slot/env and read at
+  runtime (the code around `src/compiler/mod.rs:180` deliberately avoids "turning it into
+  GetLocal" — but that is for *use-before-declaration detection*, not a rejection of inlining
+  itself). Replace reads of `constant`s whose value is a value type (Int/Num/Str/Bool/Rat/Nil)
+  with `LoadConst`. Container-valued constants have observable identity and are out of scope
+  (as before).
+- When inlining turns the condition of an `if`/`unless`/`while` into a literal constant,
+  resolve the branch entirely: `if False {...}` emits no block (for elsif/else chains, the
+  remainder is compiled normally). `constant DEBUG = False; if DEBUG { note ... }` — guarded
+  logging — is a frequent pattern in real code, and the debug-guard benchmark (2.2x)
+  measures it.
+- **Safety**: DCE removes only "the unreachable side of a branch whose value is determined".
+  No side-effect analysis is needed (it only fires when the condition expression itself is a
+  literal constant). Handling of `BEGIN`/declarations inside the block follows Rakudo
+  semantics (they still get compiled): start from the conservative rule that **blocks
+  containing declarations are not removed but fall back to normal compilation**.
 
-### 2.3 peephole — administrative opcode の削減・融合
+### 2.3 Peephole — reduction/fusion of administrative opcodes
 
-time-parts の per-iteration 64 op のうち約 27% が administrative
-（`SetSourceLine`・`MarkVarDeclContext`・`MarkExplicitInitializerContext`・
-`SetVarDynamic`・`CheckReadOnly`）。古典的な push/pop 除去より、
-この mutsu 固有の administrative 列の静的化・融合の方が実測上大きい:
+Of time-parts' 64 ops per iteration, about 27% are administrative
+(`SetSourceLine`, `MarkVarDeclContext`, `MarkExplicitInitializerContext`,
+`SetVarDynamic`, `CheckReadOnly`). Statically eliminating/fusing this mutsu-specific
+administrative sequence yields more, empirically, than classical push/pop removal:
 
-- `my $x = <expr>` の宣言 3-4 op 列の複合 op 化ないし静的フラグ化（`SetLocalDecl`, #4488）。
-- **`SetSourceLine` は「重複除去」ではなく opcode ごと廃止する（実装済み）**:
-  行番号は命令ごとの**静的データ**であり、それを運ぶために dispatch される命令は要らない。
-  `CompiledCode` に ip→行の静的テーブル（`op_lines`、`ops` と平行な `Vec<u32>`）を持たせ、
-  `Stmt::SetLine` は opcode を emit せず emit カーソル（`set_emit_line`）を進めるだけにする。
-  `cur_source_line` は**行を観測し得る命令だけ**が `sync_source_line(code, ip)` で引く
-  （呼び出し/ユーザコードへの再入・フレーム push・宣言登録・raise site の各 arm と、
-  ネイティブ実行される JIT の call shim）。算術・ローカル・分岐といった純粋な hot op は
-  一切払わない。
-  - **毎命令リフレッシュは駄目**（実測）: `exec_one` プロローグで全命令に対して
-    テーブル参照 + ストアを行う版は、削減した dispatch より高くつき fib で
-    **命令数 +7.8%**。「観測点のみ」に絞ると fib で **-3.4%**（インタプリタ経路）。
-  - 実行 opcode 数自体は fib で -21%（1.91M/8.90M が `SetSourceLine` だった）、
-    time-parts で -11% 減るが、**opcode 数の削減幅と時間の削減幅は一致しない**
-    （`SetSourceLine` は 1 命令ストアの最安 op で、mutsu の平均 op は桁違いに重い）。
-    JIT 経路（既定構成）では ±0%。bytecode のメモリは ~15% 減る。
-  - 行番号はむしろ**より正確**になる（従来はブロック/ループ本体の実行後に行が古いまま
-    残るため、メソッド呼び出し前に `SetSourceLine` を防御的に再 emit していた
-    `emit_source_line_if_known` が必要だった。これも削除）。pin: `t/source-line-table.t`。
-- jump-to-jump は複合ループ op のおかげで現状ほぼ発生しないため優先しない。
-- 対象の選定は**ヒストグラム駆動**（`MUTSU_VM_STATS=1` の opcode_histogram）で行い、
-  美学による書き換えはしない — [opcode-design-review.md](../opcode-design-review.md) §6
-  の既存方針をそのまま peephole にも適用する。
+- Turn the 3-4-op declaration sequence of `my $x = <expr>` into a compound op or a static
+  flag (`SetLocalDecl`, #4488).
+- **`SetSourceLine` is not "deduplicated" but abolished as an opcode entirely (implemented)**:
+  the line number is **static data** per instruction, and no dispatched instruction is needed
+  to carry it. Give `CompiledCode` a static ip→line table (`op_lines`, a `Vec<u32>` parallel
+  to `ops`); `Stmt::SetLine` emits no opcode and merely advances the emit cursor
+  (`set_emit_line`). `cur_source_line` is pulled via `sync_source_line(code, ip)` **only by
+  instructions that can observe the line** (the arms for calls / re-entry into user code /
+  frame pushes / declaration registration / raise sites, and the JIT's call shim that runs
+  natively). Pure hot ops — arithmetic, locals, branches — pay nothing at all.
+  - **Refreshing on every instruction is a loser** (measured): a version doing a table lookup
+    + store for every instruction in the `exec_one` prologue costs more than the dispatch it
+    saved — **+7.8% instructions** on fib. Restricting to "observation points only" gives
+    **-3.4%** on fib (interpreter path).
+  - The executed opcode count itself drops by -21% on fib (1.91M of 8.90M were
+    `SetSourceLine`) and -11% on time-parts, but **the reduction in opcode count does not
+    match the reduction in time** (`SetSourceLine` was the cheapest op — a single store —
+    while mutsu's average op is an order of magnitude heavier). On the JIT path (the default
+    configuration) it is ±0%. Bytecode memory shrinks by ~15%.
+  - Line numbers actually become **more accurate** (previously the line stayed stale after
+    executing a block/loop body, which required defensively re-emitting `SetSourceLine`
+    before method calls via `emit_source_line_if_known` — also deleted).
+    Pin: `t/source-line-table.t`.
+- Jump-to-jump barely occurs today thanks to the compound loop ops, so it is not prioritized.
+- Target selection is **histogram-driven** (`MUTSU_VM_STATS=1` opcode_histogram); no
+  rewriting for aesthetics — the existing policy of
+  [opcode-design-review.md](../opcode-design-review.md) §6 applies to peephole as-is.
 
-### 2.4 定数プール重複排除（dedup）
+### 2.4 Constant-pool deduplication (dedup)
 
-`add_constant` に FxHashMap の逆引き（値→index、hashable な value 型のみ）を足して
-同値定数を共有する。実行速度への直接効果は小さいが、コンパイラ各所が名前文字列を
-使用箇所ごとに push している現状は `CompiledCode` のメモリと cache locality を
-無駄にしており、mzef の大規模 populate（数万 dist のコンパイル）でも効く方向。
-実装が最小（1 関数）なので最初のスライスに向く。
+Add an FxHashMap reverse index (value→index, hashable value types only) to `add_constant` so
+equal constants are shared. The direct effect on execution speed is small, but the current
+state — every compiler site pushing name strings once per use site — wastes `CompiledCode`
+memory and cache locality, and this also helps mzef's large-scale populate (compiling tens of
+thousands of dists). Minimal to implement (1 function), so it suits the first slice.
 
-### 実装順序
+### Implementation order
 
-依存関係と費用対効果から: **(1) §2.4 dedup →(2) §2.1 畳み込み →
-(3) §2.2 constant インライン化+DCE →(4) §2.3 peephole**。
-(2) と (3) は同じ「emit 時定数性トラッキング」基盤を共有する。
-ゲート: 各スライスで time-parts / debug-guard の改善を bench CI で確認し、
-既存 12 ベンチに退行がないこと。
+By dependency and cost-effectiveness: **(1) §2.4 dedup → (2) §2.1 folding →
+(3) §2.2 constant inlining + DCE → (4) §2.3 peephole**.
+(2) and (3) share the same "emit-time constness tracking" foundation.
+Gate: for each slice, confirm the time-parts / debug-guard improvement in the bench CI, and
+that the existing 12 benchmarks show no regression.
 
-### 実装スライスの計測プロトコル（★2026-07-13 追記・#4489 の教訓）
+### Measurement protocol for implementation slices (★added 2026-07-13; lessons from #4489)
 
-**opcode 数の削減幅は、時間の削減幅と一致しない。** `MUTSU_VM_STATS` の
-opcode ヒストグラムは「どの op が多いか」しか答えず、「その op が時間を食っているか」は
-答えない。実際 §2.3-b（`SetSourceLine` 廃止）は実行 opcode を fib で 21% 減らしたが、
-時間の削減は 1 桁小さかった（1 ストアの最安 op だったため）。さらに、削減と引き換えに
-**全命令に小さなコストを足す実装は簡単に赤字になる**（毎命令の行 refresh 版 = 命令数 +7.8%）。
+**The reduction in opcode count does not match the reduction in time.** The
+`MUTSU_VM_STATS` opcode histogram only answers "which ops are frequent", not "whether that op
+is eating time". Indeed §2.3-b (abolishing `SetSourceLine`) cut executed opcodes by 21% on
+fib, but the time reduction was an order of magnitude smaller (it was the cheapest op — a
+single store). Moreover, **an implementation that trades the reduction for a small cost added
+to every instruction easily goes into the red** (the per-instruction line-refresh version =
++7.8% instructions).
 
-したがって administrative op の削減スライスは、着手前と実装後に**必ず命令数で検証**する:
+Therefore, every administrative-op-reduction slice must be **verified by instruction counts**
+before starting and after implementing:
 
-1. **ヒストグラムは候補出しにのみ使う**（`MUTSU_VM_STATS=1`・デバッグビルドで可・
-   最適化レベル非依存）。
-2. **判定は perf の retired instructions で行う**（wall-clock はこの規模では ±2〜6% 揺れて
-   判定不能）。ハイブリッド CPU（P/E コア）では計測が 8% 揺れるので、
-   **ユーザ空間のみ・コア固定**が必須:
+1. **Use the histogram only for candidate generation** (`MUTSU_VM_STATS=1`; a debug build is
+   fine; independent of optimization level).
+2. **Judge by perf's retired instructions** (wall-clock jitters by ±2–6% at this scale and
+   cannot decide). On hybrid CPUs (P/E cores) measurements swing by 8%, so
+   **user-space only + core pinning** is mandatory:
    ```
    sudo perf stat -r 5 -x, -e instructions:u,task-clock -- taskset -c 2 <bin> <bench>
    ```
-   （`instructions`（カーネル込み）で測るとページフォルト等が混ざって再現しない。
-   `:u` + `taskset` なら同一バイナリの再実行で 0.1% 以内に再現する。）
-3. **hot op に 1 命令でも足さない**設計を優先する（#4489 は「行を観測し得る op だけが
-   テーブルを引く」形にして初めて黒字化した）。
-4. 最終的なベンチ数字の正本は bench CI（`bench-data` ブランチ）— ローカル perf は
-   in-flight の設計判断用。
+   (Measuring with `instructions` (kernel included) mixes in page faults etc. and does not
+   reproduce. With `:u` + `taskset`, re-running the same binary reproduces within 0.1%.)
+3. **Prefer designs that add not even one instruction to hot ops** (#4489 only went into the
+   black once shaped as "only ops that can observe the line consult the table").
+4. The authoritative final benchmark numbers are the bench CI (`bench-data` branch) — local
+   perf is for in-flight design decisions.
 
-**次の的の見直し**: fib の profile 上位は `call_compiled_function_positional_light` /
-`malloc`・`free` / `Env::get_sym` であり、administrative opcode ではない。残る
-`SetVarDynamic`（time-parts 500k）・`CheckReadOnly` に着手する前に、上記プロトコルで
-「時間を食っているか」を確認すること。食っていなければ **割当チャーンと call path
-（＝レキシカル slot キャンペーン）が本命**。
+**Re-aiming the next target**: fib's profile top entries are
+`call_compiled_function_positional_light` / `malloc`+`free` / `Env::get_sym`, not
+administrative opcodes. Before starting on the remaining `SetVarDynamic` (time-parts 500k)
+and `CheckReadOnly`, confirm via the protocol above that they are "eating time". If they are
+not, **allocation churn and the call path (= the lexical-slot campaign) are the real target**.
 
-## 3. 保留・却下する施策（と、再開のトリガ）
+## 3. Deferred / rejected measures (and their re-activation triggers)
 
-### 3.1 per-call-site inline cache（PIC）— 保留
+### 3.1 Per-call-site inline cache (PIC) — deferred
 
-- 現状の monomorphic 1-entry（`last_method_resolve`）+ グローバルキャッシュで
-  poly-call が **0.48x と既に raku 比優位**。メガモーフィックサイトでの
-  1-entry ミス単価は FxHashMap ルックアップ 1 回で、現時点で律速でない。
-- 再開トリガ: profile で `method_resolve_cache` ルックアップが上位に入る、
-  または JIT J4d（呼び出しインライン化）で call-site 単位のキャッシュ構造が
-  どのみち必要になったとき。その場合 **opcode 側でなく JIT の CallMethod shim 側**
-  （ADR-0004 J3）に設ける — インタプリタと JIT で二重のキャッシュ機構を作らない。
+- With the current monomorphic 1-entry (`last_method_resolve`) + global cache, poly-call is
+  **already ahead of raku at 0.48x**. The per-miss cost of the 1-entry cache at megamorphic
+  sites is a single FxHashMap lookup, which is not the bottleneck at present.
+- Re-activation trigger: `method_resolve_cache` lookups showing up high in a profile, or JIT
+  J4d (call inlining) needing a per-call-site cache structure anyway. In that case, put it
+  **on the JIT's CallMethod shim side (ADR-0004 J3), not on the opcode side** — do not build
+  duplicate cache machinery in the interpreter and the JIT.
 
-### 3.2 quickening / adaptive specialization — 却下
+### 3.2 Quickening / adaptive specialization — rejected
 
-CPython 3.11 の主戦力だが、mutsu では **JIT Tier B（NaN-box タグ分岐の
-インライン算術）が同じ役割をより大きな天井で担う**。実行時に opcode 列を
-書き換える機構は resume/再入・並行実行との相互作用が複雑で、
-threaded dispatch と同じ「JIT との二重投資」判断（ADR-0004 §2.5）を適用する。
-JIT が頓挫した場合のみ threaded dispatch とセットで再検討。
+CPython 3.11's main weapon, but in mutsu **JIT Tier B (inline arithmetic on NaN-box tag
+branches) plays the same role with a higher ceiling**. Machinery that rewrites the opcode
+stream at runtime interacts in complex ways with resume/re-entry and concurrent execution;
+apply the same "double investment alongside the JIT" judgment as threaded dispatch
+(ADR-0004 §2.5). Reconsider only if the JIT fails, together with threaded dispatch.
 
-### 3.3 Value 文字列インターン — 保留
+### 3.3 Value string interning — deferred
 
-word-count（文字列キーのハッシュ集計）が **0.45x で既に優位**。
-ハッシュキーは既に `Symbol` ベースの経路が太く、`Value::Str` の Arc 共有で
-コピーは O(1)。再開トリガ: profile で文字列 alloc/hash が上位に入ったとき。
-その場合も全域インターンでなく、NaN-box の小文字列インライン化（SSO）を
-先に検討する（層3b の設計と整合）。
+word-count (hash aggregation over string keys) is **already ahead at 0.45x**. Hash keys
+already flow mostly through the `Symbol`-based path, and `Value::Str`'s Arc sharing makes
+copies O(1). Re-activation trigger: string alloc/hash showing up high in a profile. Even
+then, consider NaN-box small-string inlining (SSO) first rather than whole-program interning
+(consistent with the layer-3b design).
 
-## 4. Consequences（結果）
+## 4. Consequences
 
-- 新設ベンチ 4 本（time-parts / debug-guard / poly-call / word-count）を
-  `benchmarks/` に追加 — `bench-ci.sh` の glob に自動収載され、
-  採用施策の各スライスの効果と、保留施策の基準線が bench CI 履歴に残る。
-- 採用施策はすべて「静的に安全な場合のみ・フォールバックは無変換」なので、
-  roast への意味論リスクは低い。オーバーライドガード（§2.1-1）が唯一の
-  意味論境界で、pin テストを実装スライスに含めること。
-- 畳み込み・インライン化は **JIT の入力（opcode 列）を短くする**ため、
-  Tier B のカバレッジ・コンパイル時間にもプラスに働く（独立ではあるが順方向）。
+- Four new benchmarks (time-parts / debug-guard / poly-call / word-count) added under
+  `benchmarks/` — automatically picked up by the `bench-ci.sh` glob, so the effect of each
+  adopted-measure slice and the baselines for the deferred measures remain in the bench CI
+  history.
+- All adopted measures are "only when statically safe; fallback is no transformation", so
+  semantic risk to roast is low. The override guard (§2.1-1) is the only semantic boundary;
+  include its pin test in the implementation slice.
+- Folding and inlining **shorten the JIT's input (the opcode stream)**, which also benefits
+  Tier B coverage and compile time (independent, but same direction).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,27 +1,27 @@
 # Architecture Decision Records (ADR)
 
-このディレクトリは mutsu のアーキテクチャ上の意思決定を記録する。
+This directory records mutsu's architectural decisions.
 
-## 目的
+## Purpose
 
-設計の分岐点（大きな方式選定・順序決定・撤回しうる判断）について、
-**「なぜそう決めたか」と「何を却下したか」**を後から辿れるようにする。
-コードや PLAN.md からは読み取れない *判断の文脈* を残すのが ADR の役割。
+For design forks in the road (major mechanism selections, ordering decisions, judgments that could be reversed),
+make it possible to trace **"why we decided that way" and "what we rejected"** after the fact.
+The role of an ADR is to preserve the *context of the judgment* — something that cannot be read out of the code or PLAN.md.
 
-## 運用
+## Conventions
 
-- 1 決定 = 1 ファイル。`NNNN-kebab-title.md`（連番）。
-- **Status**: `Proposed`（議論中・承認待ち）/ `Accepted`（確定）/ `Superseded by ADR-XXXX`（更新済）。
-- 判断が変わったら**既存 ADR を書き換えず**、新しい ADR で supersede し、旧 ADR の Status を更新する。
-- 既存 docs に合わせ日本語で記述する。
+- 1 decision = 1 file. `NNNN-kebab-title.md` (sequential numbering).
+- **Status**: `Proposed` (under discussion / awaiting approval) / `Accepted` (final) / `Superseded by ADR-XXXX` (updated).
+- When a decision changes, **do not rewrite the existing ADR** — supersede it with a new ADR and update the old ADR's Status.
+- Written in English (repo-wide English-only documentation rule).
 
-## 一覧
+## Index
 
-| # | タイトル | Status |
+| # | Title | Status |
 |---|---|---|
-| [0001](0001-gc-strategy-and-phasing.md) | GC 導入の方式選定とフェーズ計画 | Accepted |
-| [0002](0002-phase-a-gate-reassessment.md) | Phase A ゲート再評価 — GC 着手条件の充足確認 | Accepted |
-| [0003](0003-default-on-gc-trigger.md) | デフォルト GC=on のトリガ方針（同期 + バッファサイズ閾値 + adaptive backoff） | Accepted |
-| [0004](0004-jit-strategy.md) | JIT の方式選定とフェーズ計画（Cranelift method JIT・deopt なし） | Accepted |
-| [0005](0005-nanbox-representation-encoding.md) | NaN-boxing 表現スイッチ（3b-1）のエンコーディング選択と newtype seal 統合 | Accepted |
-| [0006](0006-baseline-interpreter-optimizations.md) | ベースライン（古典的）インタープリタ最適化の採否と優先順位 | Accepted |
+| [0001](0001-gc-strategy-and-phasing.md) | GC adoption — mechanism selection and phasing | Accepted |
+| [0002](0002-phase-a-gate-reassessment.md) | Phase A gate reassessment — confirming the preconditions for starting GC | Accepted |
+| [0003](0003-default-on-gc-trigger.md) | Trigger policy for default-on GC (synchronous + buffer-size threshold + adaptive backoff) | Accepted |
+| [0004](0004-jit-strategy.md) | JIT — mechanism selection and phasing (Cranelift method JIT, no deopt) | Accepted |
+| [0005](0005-nanbox-representation-encoding.md) | NaN-boxing representation switch (3b-1) — encoding choice and newtype-seal integration | Accepted |
+| [0006](0006-baseline-interpreter-optimizations.md) | Baseline (classical) interpreter optimizations — adoption decisions and priorities | Accepted |


### PR DESCRIPTION
## Summary

Second category of the English-only documentation cleanup (news/ + CLAUDE.md rule clarification are in #4546). Translates all six ADRs and the README index to English.

- Heading counts and structure match the originals 1:1 (0001: 13, 0002: 5, 0003: 6, 0004: 11, 0005: 13, 0006: 16 headings).
- PR numbers, commit hashes, benchmark figures, dates, §-cross-references, tables, and code blocks preserved exactly.
- README index titles reconciled with each ADR's H1 (0003/0004 keep the original's intentionally-more-detailed index parentheticals).
- The README convention line "既存 docs に合わせ日本語で記述する" was deliberately inverted to "Written in English (repo-wide English-only documentation rule)" — a literal translation would contradict the rule this change implements.

## Verification

- `grep -rc '[ぁ-んァ-ヶ一-龠]' docs/adr/` → 0 for all seven files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)