### PR TITLE
docs: translate design documents to English (batch 1 of 2)

### DIFF
--- a/docs/captured-outer-cell-sharing.md
+++ b/docs/captured-outer-cell-sharing.md
@@ -1,122 +1,122 @@
-# Captured-outer lexical cell 共有 — 実装プラン（Sub-slice 1b+ / env_dirty 削除への substrate）
+# Captured-outer lexical cell sharing — implementation plan (Sub-slice 1b+ / substrate for env_dirty removal)
 
-> **★★ 2026-06-22 達成: boxing 恒久 ON 化＝goal「env↔locals コンテナ cell 共有」をデフォルト挙動として実現。**
-> `blanket_reconcile_disabled()` / `precise_reconcile_disabled()` を恒久 `true` にフリップ（cell-boxing を唯一の
-> コヒーレンス機構に）。根拠＝double-OFF survey（roast whitelist 1285・proper harness）＋フル `make test`（`t/` 10135）が
-> 両方 0 失敗。残＝`env_dirty`/`reconcile_locals_from_env_at_site`/`ensure_locals_synced`/`saved_env_dirty` の物理削除
-> （344 uses・dead code 化済み＝挙動不変の機械的クリーンアップ）。詳細＝§10.26 / PLAN §1-A。
+> **★★ Achieved 2026-06-22: boxing permanently ON = the goal "env↔locals container cell sharing" realized as the default behavior.**
+> Flipped `blanket_reconcile_disabled()` / `precise_reconcile_disabled()` to permanent `true` (making cell-boxing the sole
+> coherence mechanism). Rationale = the double-OFF survey (roast whitelist 1285, proper harness) plus the full `make test` (`t/` 10135)
+> both show 0 failures. Remaining = physical removal of `env_dirty`/`reconcile_locals_from_env_at_site`/`ensure_locals_synced`/`saved_env_dirty`
+> (344 uses, already dead code = a behavior-preserving mechanical cleanup). Details = §10.26 / PLAN §1-A.
 >
-> **Status:** SLICE 1〜1.19 DONE（〜2026-06-21・第41〜47セッション）。§6 第1スライス（named-sub 捕捉
-> scalar decl-site cell 化）＋§7.1〜7.1l（metaop-thunk `Mu`／carrier single-frame／EVAL carrier multi-frame／
-> captured-outer container `@`/`%` cell 化／`X`-cross metaop thunk／nested-method capture／cross-thread shared-var／
-> object 添字代入 invocant slot／substr-rw・subbuf-rw／zip short-circuit／map LAST phaser／undefine() lvalue）
-> ＋slice 1.17（proto state-%cache）／1.18（caller-frame by-name write）／**1.19（param default self-scoping＝code.t 8）**
-> を実装。各 pin が **blanket reconcile ON/OFF 両方で PASS**。**OFF roast survey（authoritative・§7.2a）= 初回 13 → 残 1**。
-> **destruction.t 3 = slice 1.20（#3400）で解決済**（cross-thread writeback の retain-on-miss・§7.2c）。
-> **lazy-lists.t 24-26 = 2026-06-22 で解決済**（`.kv`/`.pairs`/`.antipairs` を lazy index-pipe 化＝
-> `MapGrepSpec.index_transform`・lazy ソースを eager force しない）。**∴ OFF roast survey の決定的サーフェスは
-> IO-Socket-Async.t の reactive 並行 flaky のみ（決定的 pin 不可）に枯渇。**
-> 次＝env_dirty 削除の最終段（§7.4・`blanket_reconcile_if_dirty` 空洞化）。
-> 関連: [docs/env-locals-coherence.md](env-locals-coherence.md)（§7.3 = env_dirty 削除の壁）/
-> [docs/container-identity.md](container-identity.md)（cell インフラ）/ PLAN.md §1-A・§2-C・§2-E。
+> **Status:** SLICE 1–1.19 DONE (through 2026-06-21, sessions 41–47). §6 first slice (cell-ification of named-sub-captured
+> scalars at the decl site) plus §7.1–7.1l (metaop-thunk `Mu` / carrier single-frame / EVAL carrier multi-frame /
+> captured-outer container `@`/`%` cell-ification / `X`-cross metaop thunk / nested-method capture / cross-thread shared-var /
+> object subscript-assignment invocant slot / substr-rw & subbuf-rw / zip short-circuit / map LAST phaser / undefine() lvalue)
+> plus slice 1.17 (proto state-%cache) / 1.18 (caller-frame by-name write) / **1.19 (param default self-scoping = code.t 8)**
+> implemented. Every pin **PASSES with blanket reconcile both ON and OFF**. **OFF roast survey (authoritative, §7.2a) = initially 13 → 1 remaining**.
+> **destruction.t 3 = resolved by slice 1.20 (#3400)** (retain-on-miss for cross-thread writeback, §7.2c).
+> **lazy-lists.t 24-26 = resolved on 2026-06-22** (`.kv`/`.pairs`/`.antipairs` made lazy index-pipes =
+> `MapGrepSpec.index_transform`; lazy sources are not eagerly forced). **∴ The deterministic surface of the OFF roast survey
+> has been exhausted down to only IO-Socket-Async.t's reactive concurrency flakiness (no deterministic pin possible).**
+> Next = the final stage of env_dirty removal (§7.4, hollowing out `blanket_reconcile_if_dirty`).
+> Related: [docs/env-locals-coherence.md](env-locals-coherence.md) (§7.3 = the wall for env_dirty removal) /
+> [docs/container-identity.md](container-identity.md) (cell infrastructure) / PLAN.md §1-A, §2-C, §2-E.
 >
-> **★設計判断（第41セッション）— boxing は blanket reconcile と相互排他・toggle gated**:
-> cell boxing と blanket reconcile は **どちらか一方のみ active**（`box_decl_local_cell` は
-> `cell_boxing_active()` = `MUTSU_NO_BLANKET_RECONCILE` 時のみ発火）。理由＝reconcile ON のまま boxing
-> すると、reconcile が一部 carrier（`lives-ok {…}` 等）で **落とす** captured-outer write を cell が
-> 正しく伝播 → その伝播が **無関係な潜在バグを露出**（例: `&foo = &foo` の self-ref 型チェック欠落＝
-> roast `S06-signature/code.t` test 8 が main では write-loss で偶然 PASS していた）。∴ デフォルト
-> （shipping/CI）は reconcile が coherence を担い main と byte-identical、toggle 時のみ boxing を
-> exercise（pin が named-sub accumulation surface を担保）。env_dirty 削除時に boxing を恒久 ON 化＋
-> 露出バグを順次修正する。`let`/`temp` の cell-aware restore（`exec_let_save_op` deref +
-> `restore_let_value` write-through）も同 toggle gated。
+> **★Design decision (session 41) — boxing is mutually exclusive with blanket reconcile, toggle gated**:
+> cell boxing and blanket reconcile are **only ever one active at a time** (`box_decl_local_cell` fires only when
+> `cell_boxing_active()` = `MUTSU_NO_BLANKET_RECONCILE`). Reason = if you box while reconcile stays ON,
+> the cell correctly propagates captured-outer writes that reconcile **drops** in some carriers (`lives-ok {…}` etc.)
+> → that propagation **exposes unrelated latent bugs** (e.g. the missing self-ref type check for `&foo = &foo` =
+> roast `S06-signature/code.t` test 8 was accidentally PASSing on main due to write-loss). ∴ By default
+> (shipping/CI) reconcile carries coherence and stays byte-identical with main; boxing is exercised only under the toggle
+> (the pins guarantee the named-sub accumulation surface). When env_dirty is removed, boxing is flipped permanently ON and
+> the exposed bugs are fixed one by one. The cell-aware restore for `let`/`temp` (`exec_let_save_op` deref +
+> `restore_let_value` write-through) is gated by the same toggle.
 >
-> **実装メモ（第41セッション）**: 検出＝compile-time。`CompiledCode.named_sub_captures:
-> Vec<(free_var_writes, needs_cell_named_sub_free)>` に直接子 named sub の **write 集合**のみ畳む
-> （`compile_sub_body` が cf 構築後 push）。`compute_free_vars` が own local への named-sub write を
-> `needs_cell_named_sub` に、非 own を `needs_cell_named_sub_free`（祖先へ bubble）に計上。**closure 駆動の
-> `needs_cell_locals` とは完全分離**＝closure は creation op で精密 box されるので、それを decl-site で
-> 流用すると無関係な同名 local（同名 `my` は同一 slot 共有）を over-box し `let`-restore 等を壊す
-> （当初これで roast `let.t` 4/9/12 回帰＝修正済）。ボックス化＝**decl-site**だが捕捉 scalar は
-> `needs_env_sync`（non-simple）のため `exec_set_local_op` の **fast/slow 両 inner path をラップする
-> 外側**で box（fast path 内だけだと non-simple var に効かない＝当初の誤り）。検証トグル＝
-> `MUTSU_NO_BLANKET_RECONCILE`、6 つの env_dirty-gated reconcile を `blanket_reconcile_if_dirty(code)` に
-> 集約（将来の env_dirty 削除を 1 メソッドの空洞化で行えるように）。教訓: ①top-level/bare-block の
-> `my` は env(SetGlobal)行き＝slot box 不可だが、捕捉は **block-scoped か sub-body** の local で起きる
-> ので問題なし。②local 名は **sigil なし**（"acc" 等）で `free_var_writes`/`locals` 一貫。
-> ③同名 `my` は `alloc_local` で **同一 slot 共有**＝by-name box は scope を跨ぐので write 集合で精密化必須。
+> **Implementation notes (session 41)**: detection = compile-time. `CompiledCode.named_sub_captures:
+> Vec<(free_var_writes, needs_cell_named_sub_free)>` folds in only the **write sets** of direct child named subs
+> (`compile_sub_body` pushes after building the cf). `compute_free_vars` records named-sub writes to an own local into
+> `needs_cell_named_sub`, and non-own ones into `needs_cell_named_sub_free` (bubbled to ancestors). **Completely separate
+> from the closure-driven `needs_cell_locals`** = closures are precisely boxed at their creation op, so reusing that at the
+> decl site would over-box unrelated same-named locals (same-named `my` shares the same slot) and break `let`-restore etc.
+> (this initially regressed roast `let.t` 4/9/12 = fixed). Boxing happens at the **decl site**, but a captured scalar is
+> `needs_env_sync` (non-simple), so box in the **outer wrapper around both the fast and slow inner paths** of
+> `exec_set_local_op` (boxing only inside the fast path misses non-simple vars = the initial mistake). Verification toggle =
+> `MUTSU_NO_BLANKET_RECONCILE`; the six env_dirty-gated reconciles were consolidated into `blanket_reconcile_if_dirty(code)`
+> (so the future env_dirty removal can be done by hollowing out a single method). Lessons: (1) top-level/bare-block
+> `my` goes to env (SetGlobal) = cannot be slot-boxed, but captures happen on **block-scoped or sub-body** locals,
+> so this is not a problem. (2) Local names are **sigil-less** ("acc" etc.) consistently across `free_var_writes`/`locals`.
+> (3) Same-named `my` **shares the same slot** via `alloc_local` = by-name boxing crosses scopes, so refinement via the write set is mandatory.
 
 ---
 
-## 0. TL;DR — 配管は全て揃っている。欠落は「検出＋ボックス化」だけ
+## 0. TL;DR — all the plumbing is in place. The only gap is "detection + boxing"
 
-`env_dirty` を削除するには env と locals が乖離しないことが必要。第40セッションの調査で、**それを実現する
-ランタイム配管は 100% 既存**と確定した。唯一の欠落は:
+Removing `env_dirty` requires that env and locals never diverge. The session-40 investigation established that **the
+runtime plumbing to achieve this is 100% already present**. The only gap is:
 
-> **nested callee（closure **だけでなく** named sub）に捕捉＋変異される lexical を、
-> owner の local slot と env エントリの両方で同一 `ContainerRef` cell にボックス化する**こと。
+> **Boxing a lexical that is captured-and-mutated by a nested callee (not just a closure but **also** a named sub)
+> into the same `ContainerRef` cell in both the owner's local slot and the env entry.**
 
-`:=` bind が既にこの「同一 Arc を slot + env + saved frames に置く」パターンを完全実装している（§3）ので、
-それを **`:=` の無い暗黙キャプチャにも適用する**のが本作業。
+The `:=` bind already fully implements this "place the same Arc into slot + env + saved frames" pattern (§3), so
+the work here is to **apply it to implicit captures without `:=`**.
 
 ---
 
-## 1. なぜこれが env_dirty 削除の本丸か（§7.3 の壁の正体）
+## 1. Why this is the crux of env_dirty removal (the true nature of the §7.3 wall)
 
-env_dirty の唯一残る load-bearing な役割は「multi-frame captured-outer accumulation」を支えること:
+The only remaining load-bearing role of env_dirty is supporting "multi-frame captured-outer accumulation":
 
 ```raku
 my $acc = 0;
-sub bump-outer() { $acc = $acc + 10 }   # $acc は free var・SetGlobal で env を名前書き
+sub bump-outer() { $acc = $acc + 10 }   # $acc is a free var; writes env by name via SetGlobal
 sub via()        { bump-outer() }
-via(); via();                            # raku=20・env_dirty 削除すると 10（accumulation 失敗）
+via(); via();                            # raku=20; removing env_dirty gives 10 (accumulation fails)
 ```
 
-**壁の機構（agent 調査で確定）**: named sub `bump-outer` は fresh compiler で別個にコンパイルされ
-（`src/compiler/helpers_sub_body.rs:100`）、`$acc` を **free var として `GetGlobal`/`SetGlobal` で env 名前引き**する。
-top-level の escape 解析（`src/opcode.rs:1576-1690` `compute_free_vars`）は **closure（`closure_compiled_codes`）しか
-見ず named sub を見ない**ので `$acc` を `needs_cell` に flag しない → `$acc` は cell 化されず、env writeback +
-（かつては reverse pull、今は）env_dirty-gated blanket reconcile に依存する。
+**Mechanism of the wall (confirmed by agent investigation)**: the named sub `bump-outer` is compiled separately with a fresh
+compiler (`src/compiler/helpers_sub_body.rs:100`) and accesses `$acc` **as a free var by name in env via `GetGlobal`/`SetGlobal`**.
+The top-level escape analysis (`src/opcode.rs:1576-1690` `compute_free_vars`) **only looks at closures (`closure_compiled_codes`)
+and not named subs**, so it does not flag `$acc` as `needs_cell` → `$acc` is not cell-ified and depends on env writeback +
+(previously reverse pull, now) the env_dirty-gated blanket reconcile.
 
-`$acc` が **共有 cell** なら、`bump-outer` の `SetGlobal("$acc")` は cell を通して書き込み（§2-Q1）、top の
-slot も同じ cell を読む（§2-Q2）→ **reconcile 不要**で multi-frame accumulation が成立 → env_dirty のこの役割が消える。
+If `$acc` were a **shared cell**, `bump-outer`'s `SetGlobal("$acc")` would write through the cell (§2-Q1) and the top-level
+slot would read the same cell (§2-Q2) → multi-frame accumulation works **without reconcile** → this role of env_dirty disappears.
 
 ---
 
-## 2. Make-or-break 配管（全て確認済 ✓）
+## 2. Make-or-break plumbing (all verified ✓)
 
-| # | 経路 | 挙動 | 場所 |
+| # | Path | Behavior | Location |
 |---|------|------|------|
-| Q1 | **`SetGlobal`** | env が `ContainerRef` のとき **cell を通して書込**（Arc 置換しない）`arc.lock().clone_from(&val)` | `src/vm.rs:1999-2005` |
-| Q2 | **`GetGlobal`** | `into_deref()` で cell の内側を読む（Arc 非 detach） | `src/vm.rs:1387` / `value/mod.rs:3070` |
-| Q3 | **`$x++`/`$x+=n`（RMW）** | cell を通して RMW（atomic 対応・Track C） | `src/vm/vm_var_assign_ops.rs:1889-1902` |
-| — | **`SetLocal`** | 既存 `ContainerRef` slot を **通して書込** `arc.lock().clone_from(&val)`（非 rebind 時） | `src/vm/vm_var_assign_ops.rs:5837-5852` |
-| — | **`GetLocal`** | `into_deref()` で cell を読む | `value/mod.rs` `into_deref` |
-| Q4 | **`flush_local_to_env`** | `locals[idx]` が `ContainerRef` なら同一 Arc を env へ伝播（`set_env_with_main_alias`） | `src/vm/vm_env_helpers.rs:587-603` |
+| Q1 | **`SetGlobal`** | When env holds a `ContainerRef`, **writes through the cell** (does not replace the Arc): `arc.lock().clone_from(&val)` | `src/vm.rs:1999-2005` |
+| Q2 | **`GetGlobal`** | Reads the inside of the cell via `into_deref()` (does not detach the Arc) | `src/vm.rs:1387` / `value/mod.rs:3070` |
+| Q3 | **`$x++`/`$x+=n` (RMW)** | RMW through the cell (atomic-capable, Track C) | `src/vm/vm_var_assign_ops.rs:1889-1902` |
+| — | **`SetLocal`** | Writes **through** an existing `ContainerRef` slot: `arc.lock().clone_from(&val)` (when not rebinding) | `src/vm/vm_var_assign_ops.rs:5837-5852` |
+| — | **`GetLocal`** | Reads the cell via `into_deref()` | `value/mod.rs` `into_deref` |
+| Q4 | **`flush_local_to_env`** | If `locals[idx]` is a `ContainerRef`, propagates the same Arc to env (`set_env_with_main_alias`) | `src/vm/vm_env_helpers.rs:587-603` |
 
-**∴ 読み書き両側（Local/Global）が cell を透過し、slot→env 伝播も Arc を保つ。配管に欠落なし。**
+**∴ Both the read and write sides (Local/Global) pass through the cell, and slot→env propagation preserves the Arc. No gaps in the plumbing.**
 
 ---
 
-## 3. 従うべき precedent — `:=` bind の cell 共有（既存・動作中）
+## 3. The precedent to follow — `:=` bind's cell sharing (existing, working)
 
-`:=` bind は **まさに目標の「同一 cell を slot+env+saved frames に配置」を実装済**。これをテンプレにする。
+The `:=` bind **already implements exactly the target "place the same cell into slot+env+saved frames"**. Use it as the template.
 
-### scalar `:=`（`my $a := $b`）— `src/vm/vm_var_assign_ops.rs:6633-6689
+### scalar `:=` (`my $a := $b`) — `src/vm/vm_var_assign_ops.rs:6633-6689
 
 ```rust
 let container = if let Value::ContainerRef(ref arc) = val {
-    Value::ContainerRef(arc.clone())          // 既に cell なら再利用（第3の alias が同 cell に join）
+    Value::ContainerRef(arc.clone())          // if already a cell, reuse it (a third alias joins the same cell)
 } else {
-    val.clone().into_container_ref()           // 値を新 cell に包む
+    val.clone().into_container_ref()           // wrap the value in a new cell
 };
 self.locals[idx] = container.clone();          // target slot
 if let Some(source_idx) = code.locals.iter().rposition(|n| n == &resolved_source) {
-    self.locals[source_idx] = container.clone(); // source slot も同 cell
+    self.locals[source_idx] = container.clone(); // source slot gets the same cell too
     self.flush_local_to_env(code, source_idx);
 }
 self.env_mut().insert(resolved_source.clone(), container.clone()); // source env
-for frame in self.call_frames.iter_mut().rev() {                   // ★saved frames へ伝播
+for frame in self.call_frames.iter_mut().rev() {                   // ★propagate to saved frames
     if frame.saved_env.contains_key(&resolved_source) { frame.saved_env.insert(...); }
     for (i, local_name) in code.locals.iter().enumerate() {
         if local_name == &resolved_source && i < frame.saved_locals.len() {
@@ -128,307 +128,330 @@ self.set_env_with_main_alias(name, container.clone());  // target env
 self.flush_local_to_env(code, idx);
 ```
 
-### container `:=`（`my @a := @b`）— `src/vm/vm_var_assign_ops.rs:6534-6612`（同型・Array/Hash 用）
+### container `:=` (`my @a := @b`) — `src/vm/vm_var_assign_ops.rs:6534-6612` (same shape, for Array/Hash)
 
-**重要な教訓（saved-frame 伝播）**: cell を slot+env に置くだけでなく **`call_frames` の `saved_env`/`saved_locals`
-にも同 Arc を伝播**しないと、メソッド return（env 復元）で cell が stale 値に巻き戻る。新規ボックス化でも必須。
-
----
-
-## 4. 現状の coverage と gap
-
-### 既存の cell 化（done）
-- `:=` bind scalar / array / hash（§3）= env↔locals 同一 cell・**完了**。
-- **escaping closure に捕捉＋変異される scalar local**: `box_captured_lexicals`（`src/vm/vm_register_ops.rs:302-395`）が
-  `needs_cell_locals`（escape 解析・`closure_escapes[i]==true`）の **scalar** を cell 化。
-
-### gap（env_dirty 削除に必要な未カバー）
-`box_captured_lexicals` の skip ロジック（vm_register_ops.rs:334-376）と escape 解析の限界:
-- **(a) named sub に捕捉される scalar**（`$acc` ケース）= **未カバー**。`box_captured_lexicals` は closure
-  （`MakeLambda`/`MakeBlockClosure`）でしか呼ばれず、named sub 登録（`RegisterSub`）では呼ばれない。
-  escape 解析も named sub を `closure_compiled_codes` に含めない。← **multi-frame の壁・最初のスライス**
-- **(b) 捕捉される container `@`/`%`**（closure / named sub 双方）= **未カバー**。box は `@`/`%`/`&` sigil を skip。
-- **(c) type/where 制約付き scalar** = **意図的に skip**（cell write-through が制約再チェックを迂回するため・維持）。
-- **(d) blanket reconcile を外して surface する他のケース**（scoped overlay / carrier 等）。
+**Key lesson (saved-frame propagation)**: it is not enough to place the cell into slot+env — you must **also propagate the
+same Arc into the `saved_env`/`saved_locals` of `call_frames`**, or a method return (env restore) rolls the cell back to a
+stale value. This is mandatory for new boxing as well.
 
 ---
 
-## 5. 検証法 — 「blanket reconcile を外して壊れるもの」が残サーフェス
+## 4. Current coverage and gaps
 
-`drain_and_reconcile_after_cached_call`（`src/vm/vm_env_helpers.rs`）の `if env_dirty { reconcile_locals_from_env_at_site }`
-を一時的に外し（＋他の env_dirty consumer 6 サイト）、`make test` + roast を回す。**壊れる各テスト = まだ cell 共有
-されていない captured-outer ケース**。これを 0 にしてから env_dirty を削除する。
+### Existing cell-ification (done)
+- `:=` bind scalar / array / hash (§3) = env↔locals same cell, **complete**.
+- **Scalar locals captured-and-mutated by escaping closures**: `box_captured_lexicals` (`src/vm/vm_register_ops.rs:302-395`)
+  cell-ifies the **scalars** in `needs_cell_locals` (escape analysis, `closure_escapes[i]==true`).
 
-> 第40セッションで実証済: 外すと `t/multi-frame-accumulation-coherence.t` の 4 subtest が壊れる（= (a) のケース）。
-> consumer サイト一覧: `drain_and_reconcile_after_cached_call`（vm_env_helpers.rs:651）・`vm_call_func_ops.rs:605`・
-> `vm_call_method_ops.rs:1253`・`vm_call_method_mut_ops.rs:1549`・`vm_closure_dispatch.rs:745`・`vm_helpers.rs:662`。
-
----
-
-## 6. ★第1スライス（推奨）— named-sub 捕捉 scalar の cell 化（`$acc` ケース）
-
-env_dirty 削除に向けた最初の検証可能な一手。multi-frame の壁を直接攻める。
-
-### 6.1 検出（detection）— 2案
-
-**案A（compile-time・推奨）**: `compute_free_vars`（opcode.rs:1576-1690）を拡張し、**同スコープで宣言された
-named sub の `free_var_syms`/`free_var_writes` を、closure と同様に enclosing scope の capture 解析へ畳む**。
-これで `$acc` が `needs_cell_locals` に乗る。
-- 利点: 既存の `box_captured_lexicals` 機構に自然に乗る（escape 解析の一貫拡張）。
-- 要調査: top-level の `compute_free_vars` 実行時点で named sub の `CompiledCode`（free_var_writes 済）に
-  アクセスできるか。named sub は `sub` 宣言文のコンパイル時に compile される（`helpers_sub_body.rs`）ので、
-  enclosing body のコンパイル中に既に存在するはず。配線箇所を特定する。
-
-**案B（runtime・代替）**: `RegisterSub` op 実行時に、登録する sub の `free_var_writes` を走査し、登録フレームの
-local slot に一致する名前を §3 パターンで cell 化。
-- 利点: 配線が局所的。
-- 欠点: ordering（forward-declared/hoisted sub は `$acc=0` の前に登録され得る）。ただし slot は Nil で既存なので
-  Nil cell を box → 後続 `$acc=0`（SetLocal）が cell を通して書く（vm_var_assign_ops.rs:5837 で確認済）ので可。
-
-→ **まず案A を調査し、配線可能なら採用。困難なら案B。**
-
-### 6.2 ボックス化（boxing）
-検出した lexical を §3 の scalar `:=` パターンで cell 化（同一 Arc を slot + env + **saved frames** へ）。
-`box_captured_lexicals` を named-sub 捕捉でも呼ぶか、decl サイト（`$acc` の SetLocal で `needs_cell` 時）で box する。
-
-### 6.3 ガード（perf 崖回避・既存ルール踏襲）
-- **捕捉 AND 変異**のみ（`free_var_writes` に含まれる＝書かれる free var のみ）。読むだけは box しない。
-- **scalar のみ**（第1スライス）。container `@`/`%` は別スライス（§7）。
-- **type/where 制約付きは skip**（既存ルール・vm_register_ops.rs:349-352）。
-- escape-aware。`fib`/`method-call` は captured-mutated lexical を持たないので無影響（要 timed 確認・#2746 教訓）。
-
-### 6.4 検証
-1. 第1スライス後、`drain_and_reconcile_after_cached_call` の blanket reconcile を一時的に外して
-   `t/multi-frame-accumulation-coherence.t` が **通る**ことを確認（= (a) が cell 共有で解けた証拠）。
-2. blanket を戻して byte-identical（make test 988/9634 維持）。
-3. pin = `t/captured-outer-cell-sharing.t`（multi-frame scalar accumulation・nested named sub・再帰・
-   ON/OFF reconcile 同値）。
+### Gaps (uncovered cases needed for env_dirty removal)
+Limits of the skip logic in `box_captured_lexicals` (vm_register_ops.rs:334-376) and of the escape analysis:
+- **(a) Scalars captured by named subs** (the `$acc` case) = **uncovered**. `box_captured_lexicals` is only called for closures
+  (`MakeLambda`/`MakeBlockClosure`), not for named-sub registration (`RegisterSub`).
+  The escape analysis also does not include named subs in `closure_compiled_codes`. ← **the multi-frame wall, the first slice**
+- **(b) Captured containers `@`/`%`** (both closure / named sub) = **uncovered**. Boxing skips the `@`/`%`/`&` sigils.
+- **(c) Scalars with type/where constraints** = **intentionally skipped** (cell write-through would bypass constraint re-checks; kept).
+- **(d) Other cases surfaced by removing blanket reconcile** (scoped overlay / carriers etc.).
 
 ---
 
-## 7. 後続スライス（env_dirty 削除まで）
+## 5. Verification method — "what breaks when blanket reconcile is removed" is the remaining surface
 
-### 7.0 ★残サーフェス地図（slice 1 後・2026-06-21 計測）
+Temporarily remove the `if env_dirty { reconcile_locals_from_env_at_site }` in `drain_and_reconcile_after_cached_call`
+(`src/vm/vm_env_helpers.rs`) (plus the 6 other env_dirty consumer sites) and run `make test` + roast. **Each broken test =
+a captured-outer case not yet cell-shared**. Drive these to 0, then remove env_dirty.
 
-slice 1 マージ後に `MUTSU_NO_BLANKET_RECONCILE=1 prove -e target/debug/mutsu t/` で計測した、
-**まだ blanket reconcile に依存する（= cell 共有未到達の）23 file**。全て **default build では PASS**（reconcile
-が担う）。container `@`/`%` は Arc 共有で既に成立済（survey に container 単独 test なし）。slice 1 の named-sub
-scalar accumulation は boxing で解決済（pin 2 本が toggle 下 PASS）ので地図に出ない。
+> Demonstrated in session 40: removing it breaks 4 subtests of `t/multi-frame-accumulation-coherence.t` (= case (a)).
+> Consumer site list: `drain_and_reconcile_after_cached_call` (vm_env_helpers.rs:651), `vm_call_func_ops.rs:605`,
+> `vm_call_method_ops.rs:1253`, `vm_call_method_mut_ops.rs:1549`, `vm_closure_dispatch.rs:745`, `vm_helpers.rs:662`.
 
-| クラスタ | files | 性質・着手難度 |
+---
+
+## 6. ★First slice (recommended) — cell-ification of named-sub-captured scalars (the `$acc` case)
+
+The first verifiable step toward env_dirty removal. Attacks the multi-frame wall directly.
+
+### 6.1 Detection — 2 options
+
+**Option A (compile-time, recommended)**: extend `compute_free_vars` (opcode.rs:1576-1690) so that **the
+`free_var_syms`/`free_var_writes` of named subs declared in the same scope are folded into the enclosing scope's capture
+analysis, just like closures**. This puts `$acc` into `needs_cell_locals`.
+- Advantage: rides naturally on the existing `box_captured_lexicals` machinery (a consistent extension of the escape analysis).
+- To investigate: whether the named sub's `CompiledCode` (with free_var_writes already computed) is accessible at the point
+  the top-level `compute_free_vars` runs. Named subs are compiled when the `sub` declaration statement is compiled
+  (`helpers_sub_body.rs`), so it should already exist while the enclosing body is being compiled. Identify the wiring point.
+
+**Option B (runtime, alternative)**: when the `RegisterSub` op executes, scan the registered sub's `free_var_writes` and
+cell-ify names matching local slots of the registering frame using the §3 pattern.
+- Advantage: the wiring is local.
+- Drawback: ordering (a forward-declared/hoisted sub may be registered before `$acc=0`). However the slot already exists as Nil,
+  so box a Nil cell → the subsequent `$acc=0` (SetLocal) writes through the cell (verified at vm_var_assign_ops.rs:5837), so it works.
+
+→ **Investigate Option A first; adopt it if the wiring is feasible. Fall back to Option B if difficult.**
+
+### 6.2 Boxing
+Cell-ify the detected lexical using the §3 scalar `:=` pattern (same Arc into slot + env + **saved frames**).
+Either call `box_captured_lexicals` for named-sub captures too, or box at the decl site (on `$acc`'s SetLocal when `needs_cell`).
+
+### 6.3 Guards (avoiding the perf cliff, following existing rules)
+- **Captured AND mutated** only (only free vars included in `free_var_writes` = actually written). Do not box read-only captures.
+- **Scalars only** (first slice). Containers `@`/`%` are a separate slice (§7).
+- **Skip type/where-constrained** (existing rule, vm_register_ops.rs:349-352).
+- Escape-aware. `fib`/`method-call` have no captured-mutated lexicals so they are unaffected (needs timed confirmation, #2746 lesson).
+
+### 6.4 Verification
+1. After the first slice, temporarily remove the blanket reconcile in `drain_and_reconcile_after_cached_call` and confirm
+   `t/multi-frame-accumulation-coherence.t` **passes** (= evidence that (a) is solved by cell sharing).
+2. Restore the blanket and confirm byte-identical behavior (make test 988/9634 maintained).
+3. pin = `t/captured-outer-cell-sharing.t` (multi-frame scalar accumulation, nested named subs, recursion,
+   ON/OFF reconcile equivalence).
+
+---
+
+## 7. Follow-up slices (up to env_dirty removal)
+
+### 7.0 ★Remaining-surface map (after slice 1, measured 2026-06-21)
+
+Measured after the slice-1 merge with `MUTSU_NO_BLANKET_RECONCILE=1 prove -e target/debug/mutsu t/`:
+**23 files still depending on blanket reconcile (= not yet reached by cell sharing)**. All of them **PASS in the default build**
+(reconcile carries them). Containers `@`/`%` already work via Arc sharing (no container-only test in the survey). Slice 1's
+named-sub scalar accumulation is solved by boxing (the 2 pins PASS under the toggle) so it does not appear on the map.
+
+| Cluster | files | Nature / difficulty of attack |
 |---|---|---|
-| **並行(~13)** | `supply-{act,close-phaser,elems,multi-whenever-done,quit-handler,sync-infinite-emit,syntax-basic}`・`whenever-{last,quit}-phaser`・`promise-combinator`・`proc-async`(4)・`scheduler-cue-times`・`concurrency-basic` | cross-thread cell 共有の壁。`Arc<Mutex>` cell と `shared_vars`/`clone_for_thread` 整合（§8）。**最難・後回し**。 |
-| **carrier(~5)** | `metaop-thunk-captured-outer`(4)・`subst-closure-writeback`(3)・`eval-carrier-precise`(2)・`lazy-reify-captured-outer`(2)・`require-expression`(1) | 捕捉 outer write を carrier 経由で運ぶが multi-frame で cell 未共有。 |
-| **attr/method(~3)** | `attribute-trait-mod`(5・単一最大)・`methods-instance-regressions`(1)・`cross-metaops-regressions`(1) | method dispatch 経由の捕捉。 |
-| **misc** | `gather-lazy`(2)・`env-dirty-reconcile-coherence`(1=reconcile 自体の test) | |
+| **Concurrency (~13)** | `supply-{act,close-phaser,elems,multi-whenever-done,quit-handler,sync-infinite-emit,syntax-basic}`, `whenever-{last,quit}-phaser`, `promise-combinator`, `proc-async`(4), `scheduler-cue-times`, `concurrency-basic` | The cross-thread cell-sharing wall. Consistency of the `Arc<Mutex>` cell with `shared_vars`/`clone_for_thread` (§8). **Hardest, defer**. |
+| **Carrier (~5)** | `metaop-thunk-captured-outer`(4), `subst-closure-writeback`(3), `eval-carrier-precise`(2), `lazy-reify-captured-outer`(2), `require-expression`(1) | Captured outer writes are carried via a carrier but the cell is not shared multi-frame. |
+| **attr/method (~3)** | `attribute-trait-mod`(5, single largest), `methods-instance-regressions`(1), `cross-metaops-regressions`(1) | Captures via method dispatch. |
+| **misc** | `gather-lazy`(2), `env-dirty-reconcile-coherence`(1 = the test of reconcile itself) | |
 
-> 地図は `tmp/blanket-reconcile-surface.txt`（揮発）にも出力。再計測コマンドは上記。
+> The map is also output to `tmp/blanket-reconcile-surface.txt` (volatile). Re-measure command is above.
 
-### 7.1 ✅ スライス1.5（DONE・第42セッション）= `metaop-thunk` の typed-scalar（`Mu` universal 緩和）
+### 7.1 ✅ Slice 1.5 (DONE, session 42) = `metaop-thunk` typed scalars (`Mu` universal relaxation)
 
-`metaop-thunk-captured-outer`(4 fail) は `my Mu $s; 1 Zand ($s++,)` 系＝**thunk（closure）に捕捉される
-typed scalar**。untyped `my $s` は toggle 下 PASS（`box_captured_lexicals` が box）だが、`Mu` 制約付きは
-§6.3/§8 の「type/where 制約 skip」で box されず fail。**`Mu` は universal type（全値マッチ）なので write-through が
-制約再チェックを迂回しても無害**＝`box_captured_lexicals`（vm_register_ops.rs:343-353）の type-skip を
-`tc != "Mu"` のときのみ発火するよう緩和。subtest 4/6/8/9（`Zand`/`Zor`/`Z&&`/`Z||` with `my Mu $s`）が
-toggle 下でも PASS に。pin=`t/metaop-thunk-captured-outer-coherence.t`（12・ON/OFF 両 PASS）。make test 9656 /
-make roast 1285 回帰なし。**注意**: `Any` は Junction を弾くので universal でない＝緩和は `Mu` のみ。closure 駆動
-なので `box_captured_lexicals` 側の緩和のみで足り、`box_decl_local_cell`（named-sub path）は今回不要だった。
+`metaop-thunk-captured-outer` (4 fail) is the `my Mu $s; 1 Zand ($s++,)` family = **typed scalars captured by a thunk
+(closure)**. Untyped `my $s` PASSES under the toggle (`box_captured_lexicals` boxes it), but the `Mu`-constrained one is not
+boxed due to the §6.3/§8 "skip type/where constraints" rule and fails. **`Mu` is the universal type (matches all values), so
+write-through bypassing the constraint re-check is harmless** = relax the type-skip in `box_captured_lexicals`
+(vm_register_ops.rs:343-353) to only fire when `tc != "Mu"`. Subtests 4/6/8/9 (`Zand`/`Zor`/`Z&&`/`Z||` with `my Mu $s`)
+now PASS under the toggle as well. pin=`t/metaop-thunk-captured-outer-coherence.t` (12, PASSES both ON/OFF). make test 9656 /
+make roast 1285, no regressions. **Note**: `Any` rejects Junction so it is not universal = the relaxation is `Mu` only. This is
+closure-driven, so relaxing only the `box_captured_lexicals` side sufficed; `box_decl_local_cell` (the named-sub path) was not needed here.
 
-### 7.1b ✅ スライス1.6（DONE・第42セッション）= carrier cluster の single-frame 部（lazy map / gather / subst）
+### 7.1b ✅ Slice 1.6 (DONE, session 42) = the single-frame part of the carrier cluster (lazy map / gather / subst)
 
-carrier cluster のうち **single-frame**（書く callee が caller と同一フレーム or 直接呼ばれた callee）の3機構を
-precise writeback 化（`pending_rw_writeback_sources` に積み、既存の call-site/force-site drain が処理）＝blanket
-reconcile 非依存に。**この3つは cell 化ではなく precise-writeback で解けた**（map/grep が既に使う #3335/#3307 の機構を
-横展開）:
+Made the 3 **single-frame** mechanisms of the carrier cluster (where the writing callee is in the same frame as the caller
+or is a directly-invoked callee) precise-writeback (pushed to `pending_rw_writeback_sources`; the existing call-site/force-site
+drain handles them) = independent of blanket reconcile. **These three were solved by precise-writeback, not cell-ification**
+(a lateral rollout of the #3335/#3307 machinery that map/grep already use):
 
-- **lazy map（`@a.map({$c++}).eager`）**: `try_native_array_map` の `classify_body` が `$c++`/`$c--`（topic 以外の
-  **plain named** scalar inc/dec）を過剰に escape（`None`）扱いし slow path へ落とし、slow path は captured write を
-  記録しなかった。`Expr::Var(_) => Some(false)`（topic を変異しないので simple）に緩和＝native loop が処理し
-  `$c=$c+1` 同様に free-var write を記録（vm_native_map.rs:303）。indexed `@a[$i]++`/attr `$o.x++` は引き続き fall back。
-- **gather（`gather { ...; $c++; take $_ }`）**: forcing 時の `reconcile_caller_after_lazy_force` が gather body を
-  `blanket_reconcile_if_dirty`（OFF 無効）でしか reconcile していなかった。両 force inner（`force_lazy_list_vm_inner` /
-  `_n_inner`）の env-merge 直後に gather body の `free_var_writes` を `record_eager_block_free_var_writeback` で記録
-  （vm_helpers.rs）＝force-site の既存 `apply_pending_rw_writeback` が precise drain。
-- **subst（`.subst(/../, { $n++ })`）**: `eval_subst_replacement_cased` は捕捉 lexical write を env へ伝播するが
-  pending に積まず blanket 依存だった。伝播箇所で名前を `pending_rw_writeback_sources` に push（methods_string.rs）＝
-  `.subst` call-site が drain。
+- **lazy map (`@a.map({$c++}).eager`)**: `try_native_array_map`'s `classify_body` over-eagerly treated `$c++`/`$c--`
+  (inc/dec of a **plain named** scalar other than the topic) as escaping (`None`) and fell to the slow path, and the slow
+  path did not record captured writes. Relaxed to `Expr::Var(_) => Some(false)` (does not mutate the topic, so simple) =
+  the native loop handles it and records the free-var write like `$c=$c+1` (vm_native_map.rs:303). Indexed `@a[$i]++`/attr
+  `$o.x++` continue to fall back.
+- **gather (`gather { ...; $c++; take $_ }`)**: at forcing time `reconcile_caller_after_lazy_force` only reconciled the
+  gather body via `blanket_reconcile_if_dirty` (disabled when OFF). Right after the env-merge in both force inners
+  (`force_lazy_list_vm_inner` / `_n_inner`), record the gather body's `free_var_writes` via
+  `record_eager_block_free_var_writeback` (vm_helpers.rs) = the force-site's existing `apply_pending_rw_writeback` drains precisely.
+- **subst (`.subst(/../, { $n++ })`)**: `eval_subst_replacement_cased` propagates captured lexical writes to env but did not
+  push to pending, relying on blanket. Push the name to `pending_rw_writeback_sources` at the propagation point
+  (methods_string.rs) = the `.subst` call-site drains.
 
-pin（既存）=`t/{lazy-reify-captured-outer,gather-lazy,subst-closure-writeback}.t`（ON/OFF 両 PASS）。make test 9672 /
-make roast 1285 回帰なし。
+pins (existing) = `t/{lazy-reify-captured-outer,gather-lazy,subst-closure-writeback}.t` (PASS both ON/OFF). make test 9672 /
+make roast 1285, no regressions.
 
-### 7.1c ✅ スライス1.7（DONE・第42セッション）= EVAL carrier の multi-frame cell 共有
+### 7.1c ✅ Slice 1.7 (DONE, session 42) = multi-frame cell sharing for the EVAL carrier
 
-carrier cluster の **multi-frame** 部（`eval-carrier-precise` subtest 3/5・`require-expression` subtest 3）＝
-**descendant frame から ancestor lexical を書く EVAL carrier**（`sub set_x(){ EVAL '$x = 5' }; set_x()`）。
-EVAL 文字列内の write は **静的 `free_var_writes` 解析が見えず**、owner の decl-site で cell 化できない。precise
-single-frame writeback も**不可**＝値が callee の env restore で失われ、drain は restore 後の stale env を読む（実証済）。
-∴ **EVAL 実行時に cross-frame cell 化**: `box_carrier_free_var_writes`（vm_env_helpers.rs）が EVAL'd code の
-`free_var_writes` の captured-outer scalar を、live `env` + 全 `call_frames.saved_env` で同一 `ContainerRef` cell 化
-→ EVAL の by-name write が cell を通り、owner frame の env restore 後も cell が 5 を保持。**ガード**:
-①`cell_boxing_active()` gated（default は no-op・byte-identical）②`__mutsu_in_eval` 限定（supply/whenever/gather body も
-eval_block_value 経由だが Track C 並行 cell が別管理＝触れない）③sigilless alias（`__mutsu_sigilless_alias::x`）は
-skip（`\x`→`$a` の alias chain を cell が detach するため）④type/where 制約 skip（`Mu` 除く）。
-呼び出し＝`eval_block_value`（resolution.rs・compile 後・run 前）。pin（既存）=`t/{eval-carrier-precise-writeback,
-require-expression}.t`（ON/OFF 両 PASS）。make test 9679 / make roast 1285 回帰なし。OFF survey 20→18。
-**注意**: 当初 `__mutsu_in_eval` 無し（broad）版は supply/whenever 14 file を OFF-clean 化したが
-`concurrent-cell-writeback` subtest4 / `sigilless-params` subtest3 を**回帰**＝並行 cell 機構との衝突。EVAL 限定で解消。
+The **multi-frame** part of the carrier cluster (`eval-carrier-precise` subtests 3/5, `require-expression` subtest 3) =
+**an EVAL carrier writing an ancestor lexical from a descendant frame** (`sub set_x(){ EVAL '$x = 5' }; set_x()`).
+Writes inside the EVAL string are **invisible to static `free_var_writes` analysis**, so they cannot be cell-ified at the
+owner's decl site. Precise single-frame writeback is also **impossible** = the value is lost on the callee's env restore, and
+the drain reads the stale post-restore env (demonstrated). ∴ **Cross-frame cell-ification at EVAL execution time**:
+`box_carrier_free_var_writes` (vm_env_helpers.rs) cell-ifies the captured-outer scalars in the EVAL'd code's
+`free_var_writes` into the same `ContainerRef` cell across the live `env` + all `call_frames.saved_env`
+→ the EVAL's by-name write goes through the cell, and the cell retains 5 even after the owner frame's env restore. **Guards**:
+(1) gated by `cell_boxing_active()` (default is a no-op, byte-identical); (2) limited to `__mutsu_in_eval`
+(supply/whenever/gather bodies also go via eval_block_value, but Track C concurrency cells are managed separately = don't touch);
+(3) sigilless aliases (`__mutsu_sigilless_alias::x`) are skipped (a cell would detach the `\x`→`$a` alias chain);
+(4) skip type/where constraints (except `Mu`).
+Call site = `eval_block_value` (resolution.rs, after compile, before run). pins (existing) = `t/{eval-carrier-precise-writeback,
+require-expression}.t` (PASS both ON/OFF). make test 9679 / make roast 1285, no regressions. OFF survey 20→18.
+**Note**: the initial version without `__mutsu_in_eval` (broad) made 14 supply/whenever files OFF-clean but **regressed**
+`concurrent-cell-writeback` subtest 4 / `sigilless-params` subtest 3 = a collision with the concurrency cell machinery. Restricting to EVAL resolved it.
 
-### 7.1d ✅ スライス1.8（DONE・第43セッション）= captured-outer container `@`/`%` cell 化（`attribute-trait-mod` 5 fail）
+### 7.1d ✅ Slice 1.8 (DONE, session 43) = captured-outer container `@`/`%` cell-ification (`attribute-trait-mod` 5 fail)
 
-`attribute-trait-mod`（OFF 5 fail・単一最大）の真因＝**captured-outer container の COW detach + slot-restore clobber**。`my @noted-names` を
-ユーザ `trait_mod:<is>` が class composition 中に `push` するが、①class registration の `saved_env = self.env.clone()` が
-配列 Arc の refcount を上げ、push の `Arc::make_mut` が COW で detach（env=新 Arc B(3)、slot=旧 Arc A(0)）。②その後の
-`$obj ~~ Type` smartmatch が **env を local slot から復元**するため、stale な slot A(0) が env を 0 に巻き戻す（blanket
-reconcile ON なら smartmatch 前に slot を env から pull するので顕在化しない）。∴ `@noted-names` を **whole-container cell**
-にして slot==env を保てば、push が cell を通り、`saved_env.clone()` は cell（`Arc<Mutex>`）を共有し COW しない、smartmatch の
-slot-restore も同一 cell を保つ。
+The true cause of `attribute-trait-mod` (OFF 5 fail, single largest) = **COW detach of a captured-outer container + slot-restore clobber**. A user
+`trait_mod:<is>` `push`es `my @noted-names` during class composition, but (1) class registration's `saved_env = self.env.clone()`
+raises the array Arc's refcount, and the push's `Arc::make_mut` COW-detaches (env = new Arc B(3), slot = old Arc A(0)). (2) The
+subsequent `$obj ~~ Type` smartmatch **restores env from the local slot**, so the stale slot A(0) rolls env back to 0 (with blanket
+reconcile ON this never manifests because the slot is pulled from env before the smartmatch). ∴ Make `@noted-names` a **whole-container cell**
+so slot==env is preserved: the push goes through the cell, `saved_env.clone()` shares the cell (`Arc<Mutex>`) and does not COW,
+and the smartmatch's slot-restore keeps the same cell.
 
-- **検出（compile-time）**: container の in-place mutation（`push`/`append`/element-assign）は `SetGlobal` name-write では
-  **ない**ので `free_var_writes` に乗らない。新フィールド `CompiledCode.free_var_container_writes`（`op_container_mutate_const_idx`
-  が `CallMethodMut`＋mutating method 名／`IndexAssign*Named`／`ArrayPush` から `@`/`%` non-own 名を抽出）に分離計上し、
-  `compile_sub_body` が named sub の `free_var_writes ∪ free_var_container_writes` を `named_sub_captures` に push →
-  既存の fold が `needs_cell_named_sub` に乗せる。**`free_var_writes` 本体は不変＝default-build の precise-writeback drain に
-  無影響。**
-- **boxing**: `box_decl_local_cell` の `@`/`%` skip を解き `box_decl_local_container_cell`（Array/Hash を `ContainerRef` cell に
-  包み slot+env に配置・typed container は skip）へ dispatch。write-back（`try_native_array_mut`/`try_native_hash_mut_bound`/
-  `env_root_descended_mut`）と read（`GetArrayVar`/`GetHashVar` の `into_deref`）は `:=` bound container 用に既に cell 対応済。
-- **★broad boxing は不可（decont 漏れ）**: spike で「全 `@`/`%` decl を box」したところ aliased-container-mutation /
-  constant-hash-element-ro / hash-push-seq-of-pairs / quanthash-hyper-funcop など ~12 file が OFF 回帰（cell が slice/`.kv`/
-  raw-items 読みで漏れる）。∴ **precise 検出（named-sub captured-and-mutated container のみ）が必須**。precise 版は decont 漏れ 0。
-- pin=`t/captured-outer-container-cell-sharing.t`（9・trait_mod push/hash-elem・named-sub accumulation・ON/OFF 両 PASS）。
-  OFF survey 17 file（attribute-trait-mod の 5 fail 解消）。
+- **Detection (compile-time)**: in-place mutation of a container (`push`/`append`/element-assign) is **not** a `SetGlobal`
+  name-write, so it does not appear in `free_var_writes`. Accounted separately in a new field `CompiledCode.free_var_container_writes`
+  (`op_container_mutate_const_idx` extracts `@`/`%` non-own names from `CallMethodMut` + mutating method names /
+  `IndexAssign*Named` / `ArrayPush`), and `compile_sub_body` pushes the named sub's `free_var_writes ∪ free_var_container_writes`
+  into `named_sub_captures` → the existing fold puts it into `needs_cell_named_sub`. **`free_var_writes` itself is unchanged =
+  no impact on the default build's precise-writeback drain.**
+- **Boxing**: lift the `@`/`%` skip in `box_decl_local_cell` and dispatch to `box_decl_local_container_cell` (wraps Array/Hash
+  in a `ContainerRef` cell and places it in slot+env; typed containers are skipped). Write-back (`try_native_array_mut`/`try_native_hash_mut_bound`/
+  `env_root_descended_mut`) and read (`into_deref` in `GetArrayVar`/`GetHashVar`) are already cell-aware for `:=`-bound containers.
+- **★Broad boxing is not viable (decont leaks)**: a spike that boxed "all `@`/`%` decls" regressed ~12 files OFF
+  (aliased-container-mutation / constant-hash-element-ro / hash-push-seq-of-pairs / quanthash-hyper-funcop etc.; the cell leaks
+  through slice/`.kv`/raw-items reads). ∴ **Precise detection (only named-sub captured-and-mutated containers) is mandatory**. The precise version has 0 decont leaks.
+- pin=`t/captured-outer-container-cell-sharing.t` (9; trait_mod push/hash-elem, named-sub accumulation, PASSES both ON/OFF).
+  OFF survey 17 files (the 5 attribute-trait-mod fails resolved).
 
-### 7.1e ✅ スライス1.9（DONE・第43セッション）= `X`-cross metaop thunk の captured-outer scalar write（`cross-metaops` subtest 2）
+### 7.1e ✅ Slice 1.9 (DONE, session 43) = captured-outer scalar write in `X`-cross metaop thunks (`cross-metaops` subtest 2)
 
-`Nil Xorelse ($t = $_,)`（`X` cross meta over short-circuit op）は右辺を `__mutsu_cross_shortcircuit("orelse", Nil,
-AnonSub{$t=$_})` の **immediately-invoked thunk** にコンパイルする。call arg として渡される closure は escape 解析が
-non-escaping 扱い→`box_captured_lexicals` が box しない→thunk の captured-outer write（`$t`）が OFF で caller slot に
-届かない。**cell 化でなく precise-writeback で解決**（slice 1.6 の lazy-map/gather/subst と同型）: `builtin_cross_shortcircuit`
-が thunk 実行後（`thunk_ran` 時のみ）に thunk の `compiled_code.free_var_writes` を `record_eager_block_free_var_writeback`
-で `pending_rw_writeback_sources` に積む→`__mutsu_cross_shortcircuit` の call-site が既存 `apply_pending_rw_writeback` で
-drain。**非gated（ON/OFF 両対応・reconcile と idempotent）**。pin=`t/cross-metaop-thunk-captured-writeback-coherence.t`
-（6・Xorelse/Xandthen/Xor・ON/OFF 両 PASS）。make test 回帰なし。OFF survey 17→16。
-**注意（範囲外の別バグ）**: ①`(1,2,3) Xandthen (...)` の list 反復 count（raku=3・mutsu=2）は cross_shortcircuit ループの
-別バグ（ON でも fail・captured-write 無関係）。②`$x + 1`（`$x=11` 後）が 2 を返すパーサ quirk も別件。両方とも本スライス対象外。
+`Nil Xorelse ($t = $_,)` (`X` cross meta over a short-circuit op) compiles the RHS into an **immediately-invoked thunk**
+`__mutsu_cross_shortcircuit("orelse", Nil, AnonSub{$t=$_})`. A closure passed as a call arg is treated as non-escaping by
+the escape analysis → `box_captured_lexicals` does not box it → the thunk's captured-outer write (`$t`) does not reach the
+caller slot when OFF. **Solved by precise-writeback, not cell-ification** (same shape as slice 1.6's lazy-map/gather/subst):
+`builtin_cross_shortcircuit` pushes the thunk's `compiled_code.free_var_writes` onto `pending_rw_writeback_sources` via
+`record_eager_block_free_var_writeback` after thunk execution (only when `thunk_ran`) → the call-site of
+`__mutsu_cross_shortcircuit` drains with the existing `apply_pending_rw_writeback`.
+**Ungated (works both ON/OFF, idempotent with reconcile)**. pin=`t/cross-metaop-thunk-captured-writeback-coherence.t`
+(6; Xorelse/Xandthen/Xor; PASSES both ON/OFF). make test, no regressions. OFF survey 17→16.
+**Note (separate out-of-scope bugs)**: (1) the list-iteration count of `(1,2,3) Xandthen (...)` (raku=3, mutsu=2) is a separate
+bug in the cross_shortcircuit loop (fails even ON, unrelated to captured writes). (2) The parser quirk where `$x + 1` (after
+`$x=11`) returns 2 is also a separate issue. Both are out of scope for this slice.
 
-### 7.1f ✅ スライス1.10（DONE・第44セッション）= nested-method capture（`methods-instance` subtest 3）
+### 7.1f ✅ Slice 1.10 (DONE, session 44) = nested-method capture (`methods-instance` subtest 3)
 
-`method foo { my $a = 42; method bar { $tracker = $a } }` の **method body 内で宣言された method** `bar` を
-`.foo` 後に `.bar` で呼ぶケース。`bar` の captured-outer write（`$tracker`）が OFF で caller slot に届かず stale。
-**真因＝dispatch path**: nested-declared method は foo 実行時に RegisterSub で **captured env 付き `&bar` sub** として登録され、
-`$d.bar` は compiled method merge path（`call_compiled_method` / `merge_method_env`）でも closure dispatch
-（`call_compiled_closure_with_topic`）でもなく、slow path `call_method_with_values` → **`call_sub_value(merge_all=true)`**
-（tree-walk）を通る。`call_sub_value` は captured-outer scalar write を `merged`（caller env）へ正しくマージするが、
-**caller の local slot を refresh しない**＝blanket reconcile ON 時のみ slot が env から pull される。
-（class-level method の `$Foo++` は compiled path = #3322 の `merge_method_env` `changed_caller_locals` 記録で OFF も成立済。
-gap は nested-declared method の interpreter dispatch path だけ）。
+The case where the **method declared inside a method body** — `method foo { my $a = 42; method bar { $tracker = $a } }` —
+is called as `.bar` after `.foo`. `bar`'s captured-outer write (`$tracker`) does not reach the caller slot when OFF and goes stale.
+**True cause = the dispatch path**: the nested-declared method is registered when foo runs, via RegisterSub, as a
+**`&bar` sub with a captured env**, and `$d.bar` goes through neither the compiled method merge path
+(`call_compiled_method` / `merge_method_env`) nor closure dispatch (`call_compiled_closure_with_topic`), but the slow path
+`call_method_with_values` → **`call_sub_value(merge_all=true)`** (tree-walk). `call_sub_value` correctly merges captured-outer
+scalar writes into `merged` (the caller env), but **does not refresh the caller's local slot** = the slot is pulled from env
+only when blanket reconcile is ON.
+(For class-level methods, `$Foo++` uses the compiled path = already OFF-viable via #3322's `merge_method_env`
+`changed_caller_locals` recording. The gap is only the nested-declared method's interpreter dispatch path.)
 
-- **修正（precise-writeback・非gated）**: ①`call_sub_value`（resolution.rs）の merge ループで、body-entry snapshot
-  （`body_entry_env`）から **変化した captured-outer scalar**（Bool/Int/Num/Str/Rat・caller env に存在）を収集し
-  `pending_rw_writeback_sources` に push（merge_all / non-merge_all 両 branch・既存の precise scalar-changed 条件と同型）。
-  ②CallMethod op（vm_call_method_ops.rs）の call-site tail を `blanket_reconcile_if_dirty(code)` →
-  `drain_and_reconcile_after_cached_call(code)`（= `apply_pending_rw_writeback` + blanket）に変更。**この op は従来
-  pending を drain しておらず**（`merge_method_env` のコメント「CallMethod op が slot へ書き戻す」が示す意図に実装が
-  追いついていなかった＝latent gap も同時に解消）。ON では blanket が superset なので byte-identical、OFF では
-  precise drain のみが効く。
-- pin=`t/nested-method-captured-writeback-coherence.t`（9・given/topic・explicit invocant・RMW 累積・+=・string・
-  enclosing lexical read＋outer write・複数 outer・後続式コヒーレンス・intervening call・ON/OFF 両 PASS）。
-  make test 9727 / make roast 回帰なし。OFF survey 16→15（並行 ~13 残）。
+- **Fix (precise-writeback, ungated)**: (1) in the merge loop of `call_sub_value` (resolution.rs), collect the
+  **captured-outer scalars that changed** relative to the body-entry snapshot (`body_entry_env`) (Bool/Int/Num/Str/Rat,
+  present in the caller env) and push to `pending_rw_writeback_sources` (both merge_all / non-merge_all branches; same shape
+  as the existing precise scalar-changed condition).
+  (2) Change the call-site tail of the CallMethod op (vm_call_method_ops.rs) from `blanket_reconcile_if_dirty(code)` →
+  `drain_and_reconcile_after_cached_call(code)` (= `apply_pending_rw_writeback` + blanket). **This op previously did not
+  drain pending** (the `merge_method_env` comment "the CallMethod op writes back to the slot" expressed an intent the
+  implementation had not caught up with = a latent gap fixed at the same time). ON: blanket is a superset so byte-identical;
+  OFF: only the precise drain takes effect.
+- pin=`t/nested-method-captured-writeback-coherence.t` (9; given/topic, explicit invocant, RMW accumulation, +=, string,
+  enclosing lexical read + outer write, multiple outers, subsequent-expression coherence, intervening call; PASSES both ON/OFF).
+  make test 9727 / make roast, no regressions. OFF survey 16→15 (~13 concurrency remaining).
 
-### 7.1g ✅ スライス1.11（DONE・第44セッション）= cross-thread shared-var writeback（並行 cluster の決定的部）
+### 7.1g ✅ Slice 1.11 (DONE, session 44) = cross-thread shared-var writeback (the deterministic part of the concurrency cluster)
 
-並行 cluster ~13 のうち、`promise-combinator`・`scheduler-cue-times` は **flaky でなく決定的**な OFF 依存（OFF=1 が 4/4 再現・
-ON=0）。`my $seen = []; Promise.allof(start { cas $seen, -> @c { flat @c, 1 } }).result; is ~$seen, '1'` ＝worker
-`start` block の `cas`（atomic array CAS・`__mutsu_atomic_arr::$seen` shared store に書く）が `.result`（await）後に
-parent の `$seen` **local slot** に届かない。`sync_shared_vars_to_env`（runtime/mod.rs）は cross-thread の dirty key を
-env に書き戻すが（`__mutsu_atomic_arr::`/`__mutsu_atomic_hash::`/`__mutsu_atomic_name::` を解決）、**caller slot は
-refresh しない**＝blanket reconcile ON のみ pull。
+Of the ~13 concurrency cluster, `promise-combinator` and `scheduler-cue-times` are **deterministic**, not flaky, OFF
+dependencies (OFF=1 reproduces 4/4, ON=0). `my $seen = []; Promise.allof(start { cas $seen, -> @c { flat @c, 1 } }).result;
+is ~$seen, '1'` = the worker `start` block's `cas` (atomic array CAS; writes to the `__mutsu_atomic_arr::$seen` shared store)
+does not reach the parent's `$seen` **local slot** after `.result` (await). `sync_shared_vars_to_env` (runtime/mod.rs)
+writes cross-thread dirty keys back to env (resolving `__mutsu_atomic_arr::`/`__mutsu_atomic_hash::`/`__mutsu_atomic_name::`),
+but **does not refresh the caller slot** = pulled only with blanket reconcile ON.
 
-- **修正（precise-writeback・非gated）**: `sync_shared_vars_to_env` の `updates` 反映ループで各 synced key を
-  `pending_rw_writeback_sources` に push → `.result`/await の **CallMethod call-site が drain**（slice 1.10 で
-  `drain_and_reconcile_after_cached_call` 化済みなので追加配線不要）。ON は env_dirty→blanket superset=byte-identical、
-  OFF は precise drain のみ。env が cross-thread sync 後の source of truth なので slot=env は常に coherence 方向＝安全。
-- **★cross-thread cell（doc §8）の本格実装は不要だった**: 基本 cross-thread captured-write（`start { $x = v }; await`）は
-  既に shared_vars で ON/OFF 両成立（決定的 probe で確認）。決定的 OFF 依存は **atomic CAS の sync→slot writeback** のみで、
-  slice 1.10 の drain 基盤に sync 名を載せるだけで解けた。残る並行 cluster の OFF 依存は **flaky な reactive 系**
-  （supply/whenever の timing 依存・`^not ok` に出ない）で、決定的 substrate ではない。
-- pin=`t/cross-thread-shared-var-writeback-coherence.t`（6・cas array/scalar/hash・累積・後続式・intervening・ON/OFF 両 PASS）。
-  make test 9739 / make roast（要確認）。**決定的 OFF-only fail（`^not ok`）= 0 に到達**。
+- **Fix (precise-writeback, ungated)**: in the `updates` application loop of `sync_shared_vars_to_env`, push each synced key
+  to `pending_rw_writeback_sources` → the **CallMethod call-site of `.result`/await drains** (already converted to
+  `drain_and_reconcile_after_cached_call` in slice 1.10, so no extra wiring needed). ON: env_dirty→blanket superset =
+  byte-identical; OFF: only the precise drain. Env is the source of truth after a cross-thread sync, so slot=env is always
+  the coherence direction = safe.
+- **★A full implementation of cross-thread cells (doc §8) was not needed**: basic cross-thread captured writes
+  (`start { $x = v }; await`) already work both ON/OFF via shared_vars (confirmed with a deterministic probe). The
+  deterministic OFF dependency was **only the atomic CAS sync→slot writeback**, solved by simply putting the sync names onto
+  slice 1.10's drain substrate. The remaining OFF dependencies in the concurrency cluster are the **flaky reactive family**
+  (supply/whenever timing dependencies; do not show up in `^not ok`), not a deterministic substrate.
+- pin=`t/cross-thread-shared-var-writeback-coherence.t` (6; cas array/scalar/hash, accumulation, subsequent expression,
+  intervening; PASSES both ON/OFF). make test 9739 / make roast (to confirm). **Deterministic OFF-only fails (`^not ok`) = reached 0**.
 
-### 7.1h ✅ スライス1.12（DONE・第45セッション）= object 添字代入の invocant slot writeback（`parametric-role-of-type`）
-`parametric-role-of-type`（OFF で決定的 abort・ran 11/14・test 12）を解消。真因は当初の「typed array 属性の COW detach」
-診断ではなく **object 添字代入の invocant slot 未 refresh** だった。最小再現＝
+### 7.1h ✅ Slice 1.12 (DONE, session 45) = invocant slot writeback for object subscript assignment (`parametric-role-of-type`)
+Resolved `parametric-role-of-type` (deterministic abort when OFF; ran 11/14; test 12). The true cause was not the initial
+"COW detach of the typed array attribute" diagnosis but **the invocant slot not being refreshed on object subscript assignment**.
+Minimal reproduction =
 `role ER[::T] does Positional { has ER[T] @!c handles <AT-POS ASSIGN-POS BIND-POS> }; my $e = ER[Int].new; $e[0] = ER[Int].new; say $e[0].WHAT`
-が ON=`(ER)`／OFF=`(Any)`。`$e[0] = v` は `exec_index_assign_expr_named_op` → ASSIGN-POS dispatch →
-`assign_method_lvalue_with_values`（methods_mut.rs:1813 の handles delegation 経路）が delegate container を変異させ
-`env[$e]` に更新済 instance を `write_back_sharing` で書くが、**caller の local slot は refresh しない**。default build は
-blanket reconcile が `$e` を env から pull するので顕在化せず、OFF（cell boxing）では slot が stale instance のまま →
-AT-POS が空 `@!c` を読む。
-- **修正（precise・非gated）**: `exec_index_assign_expr_named_op` 末尾で、添字代入後 `env[var]` が `Instance`/`Mixin`
-  （＝object 添字代入で ASSIGN-POS/ASSIGN-KEY を dispatch したケース）なら `locals_set_by_name` で local slot へ write-through。
-  plain Array/Hash 要素代入は fast path で既に slot 更新済＆ここに Instance/Mixin として到達しないので発火しない。
-  ON は blanket reconcile の冪等 superset＝byte-identical。**副次効果**: plain `role P does Positional { has @!c handles
-  <AT-POS ASSIGN-POS> }` の `$p[0]=v`（ON/OFF 両方で `Nil` を返していた pre-existing バグ）も同時に修正。
-- pin=`t/positional-role-attr-writeback-coherence.t`（7・Positional/parametric/Associative 添字代入・BIND-POS・ON/OFF 両 PASS）。
-  make test 9755。**注**: delegated mutating *method call*（`$q.push(5)` が `@!c` へ委譲）は ON/OFF **両方**で失敗する別の
-  pre-existing バグ（method-call 後の invocant slot 未 refresh・トグル非依存）＝本スライス対象外・スコープ外として pin から除外。
+gives ON=`(ER)` / OFF=`(Any)`. `$e[0] = v` goes `exec_index_assign_expr_named_op` → ASSIGN-POS dispatch →
+`assign_method_lvalue_with_values` (the handles delegation path at methods_mut.rs:1813) mutates the delegate container and
+writes the updated instance to `env[$e]` via `write_back_sharing`, but **does not refresh the caller's local slot**. The default
+build never manifests this because blanket reconcile pulls `$e` from env; under OFF (cell boxing) the slot remains the stale
+instance → AT-POS reads an empty `@!c`.
+- **Fix (precise, ungated)**: at the tail of `exec_index_assign_expr_named_op`, if `env[var]` after the subscript assignment
+  is `Instance`/`Mixin` (= the case where the object subscript assignment dispatched ASSIGN-POS/ASSIGN-KEY), write through to
+  the local slot via `locals_set_by_name`. Plain Array/Hash element assignment already updates the slot on the fast path and
+  never arrives here as Instance/Mixin, so it does not fire. ON is an idempotent superset of blanket reconcile = byte-identical.
+  **Side effect**: also fixes the pre-existing bug where `$p[0]=v` on a plain `role P does Positional { has @!c handles
+  <AT-POS ASSIGN-POS> }` returned `Nil` (both ON/OFF).
+- pin=`t/positional-role-attr-writeback-coherence.t` (7; Positional/parametric/Associative subscript assignment, BIND-POS; PASSES both ON/OFF).
+  make test 9755. **Note**: a delegated mutating *method call* (`$q.push(5)` delegating to `@!c`) failing both ON/OFF is a
+  separate pre-existing bug (invocant slot not refreshed after a method call; toggle-independent) = out of scope for this
+  slice and excluded from the pin.
 
-### 7.1i ✅ スライス1.13（DONE・第45セッション）= substr-rw / subbuf-rw lvalue slot writeback（OFF 最大塊・12 fail）
-`substr-rw($s, ...) = v`／`subbuf-rw($buf, ...) = v` が OFF で `$s`/`$buf` を変更しない（`gorch ding` のまま・raku=
-`gloop ding`）。経路＝lvalue assign は `__mutsu_assign_named_sub_lvalue` Call → `assign_named_sub_lvalue_with_values`
-（builtins_lvalue.rs:258/281）が env scan で target var を特定し `assign_method_lvalue_with_values` に委譲→string/buf を
-変異して `env[$s]` に書くが **caller local slot 未 refresh**。`exec_call_func_op` の `lvalue_writeback_target` 機構は
-`__mutsu_assign_method_lvalue`/`__mutsu_index_assign_method_lvalue`（args[4]=target）専用で named-sub lvalue は対象外。
-- **修正（precise・非gated）**: substr-rw/subbuf-rw branch で解決済 target var 名を `pending_rw_writeback_sources` に push。
-  `exec_call_func_op` は **常に** `apply_pending_rw_writeback(code)`（vm_call_func_ops.rs:597）を呼ぶので、env の更新値が
-  precise に slot へ drain される（blanket pull 不要）。ON は冪等 superset＝byte-identical。
-- pin=`t/substr-rw-lvalue-writeback-coherence.t`（6・substr-rw/from-only/累積/bound proxy/subbuf-rw・ON/OFF 両 PASS）。
-  make test 9754。`S32-str/substr-rw.t` 46/46・`S03-operators/buf.t` も ON/OFF PASS（OFF survey の **2 file** 消化）。
+### 7.1i ✅ Slice 1.13 (DONE, session 45) = substr-rw / subbuf-rw lvalue slot writeback (largest OFF chunk, 12 fails)
+`substr-rw($s, ...) = v` / `subbuf-rw($buf, ...) = v` do not modify `$s`/`$buf` when OFF (stays `gorch ding`; raku=
+`gloop ding`). Path = the lvalue assign is a `__mutsu_assign_named_sub_lvalue` Call → `assign_named_sub_lvalue_with_values`
+(builtins_lvalue.rs:258/281) locates the target var by env scan and delegates to `assign_method_lvalue_with_values` →
+mutates the string/buf and writes to `env[$s]` but **the caller local slot is not refreshed**. The `lvalue_writeback_target`
+mechanism of `exec_call_func_op` is exclusive to `__mutsu_assign_method_lvalue`/`__mutsu_index_assign_method_lvalue`
+(args[4]=target) and does not cover named-sub lvalues.
+- **Fix (precise, ungated)**: in the substr-rw/subbuf-rw branch, push the resolved target var name to
+  `pending_rw_writeback_sources`. `exec_call_func_op` **always** calls `apply_pending_rw_writeback(code)`
+  (vm_call_func_ops.rs:597), so the updated env value is drained precisely to the slot (no blanket pull needed). ON is an
+  idempotent superset = byte-identical.
+- pin=`t/substr-rw-lvalue-writeback-coherence.t` (6; substr-rw/from-only/accumulation/bound proxy/subbuf-rw; PASSES both ON/OFF).
+  make test 9754. `S32-str/substr-rw.t` 46/46 and `S03-operators/buf.t` also PASS ON/OFF (**2 files** cleared from the OFF survey).
 
-### 7.1j ✅ スライス1.14（DONE・第45セッション）= zip short-circuit topicalizing thunk writeback（`zip.t` 68/71）
-`23 Zandthen ($side-effect = $_,)` の topicalize thunk write が OFF で lost（OFF=0・raku/ON=23）。`Zandthen`/`Zorelse`
-は `builtin_zip_shortcircuit_topic`（builtins_feed.rs:299）/`builtin_zip_shortcircuit` 経由で thunk を評価するが、
-`builtin_cross_shortcircuit`（slice 1.9・X-cross）と違い **captured-outer write を記録していなかった**＝即時起動 closure で
-escape 解析が box しない→blanket reconcile のみが運んでいた。修正＝両関数で thunk 実行後に
-`record_eager_block_free_var_writeback(&code, &params)` を呼び pending に push→`__mutsu_zip_shortcircuit*` call site の
-`apply_pending_rw_writeback` が drain（X-cross と同型）。ON は冪等 superset＝byte-identical。
-pin=`t/zip-shortcircuit-topic-writeback-coherence.t`（5・Zandthen/Zorelse topicalize＋increment・ON/OFF 両 PASS）。
-make test 9769。`S03-metaops/zip.t` ON/OFF PASS（OFF survey の **1 file** 消化）。
+### 7.1j ✅ Slice 1.14 (DONE, session 45) = zip short-circuit topicalizing thunk writeback (`zip.t` 68/71)
+The topicalize thunk write of `23 Zandthen ($side-effect = $_,)` is lost when OFF (OFF=0; raku/ON=23). `Zandthen`/`Zorelse`
+evaluate the thunk via `builtin_zip_shortcircuit_topic` (builtins_feed.rs:299) / `builtin_zip_shortcircuit`, but unlike
+`builtin_cross_shortcircuit` (slice 1.9, X-cross) **they did not record captured-outer writes** = an immediately-invoked
+closure the escape analysis does not box → only blanket reconcile was carrying it. Fix = both functions call
+`record_eager_block_free_var_writeback(&code, &params)` after thunk execution, pushing to pending → the
+`apply_pending_rw_writeback` at the `__mutsu_zip_shortcircuit*` call site drains (same shape as X-cross). ON is an idempotent
+superset = byte-identical.
+pin=`t/zip-shortcircuit-topic-writeback-coherence.t` (5; Zandthen/Zorelse topicalize + increment; PASSES both ON/OFF).
+make test 9769. `S03-metaops/zip.t` PASSES ON/OFF (**1 file** cleared from the OFF survey).
 
-### 7.1k ✅ スライス1.15（DONE・第45セッション）= `.map` block LAST phaser writeback（`map.t` 62）
-`(^20).map({ LAST $ranLAST=True; last if $_==10; $_ }).iterator` の LAST phaser write が OFF で lost（OFF=Nil・ON=True）。
-真因＝eager map loop（`resolution.rs:2123` 周辺）は LAST phaser body を map body と**別に** compile/run し
-（:2253-2258）、その直後の `record_eager_block_free_var_writeback(&code, ...)`（:2276）は **map body の `code` のみ**記録＝
-phaser の `$ranLAST=True` を拾わない。修正＝phaser 実行直後に `vm.record_eager_block_free_var_writeback(&phaser_code, &[])`
-追加→pending push→call site の `apply_pending_rw_writeback` drain。ON は冪等 superset＝byte-identical。
-pin=`t/map-last-phaser-writeback-coherence.t`（4・last/natural-end/eager・ON/OFF 両 PASS）。`S32-list/map.t` ON/OFF PASS。
+### 7.1k ✅ Slice 1.15 (DONE, session 45) = `.map` block LAST phaser writeback (`map.t` 62)
+The LAST phaser write of `(^20).map({ LAST $ranLAST=True; last if $_==10; $_ }).iterator` is lost when OFF (OFF=Nil; ON=True).
+True cause = the eager map loop (around `resolution.rs:2123`) compiles/runs the LAST phaser body **separately** from the map
+body (:2253-2258), and the immediately following `record_eager_block_free_var_writeback(&code, ...)` (:2276) records **only
+the map body's `code`** = it does not pick up the phaser's `$ranLAST=True`. Fix = add
+`vm.record_eager_block_free_var_writeback(&phaser_code, &[])` right after phaser execution → pending push → the call site's
+`apply_pending_rw_writeback` drains. ON is an idempotent superset = byte-identical.
+pin=`t/map-last-phaser-writeback-coherence.t` (4; last/natural-end/eager; PASSES both ON/OFF). `S32-list/map.t` PASSES ON/OFF.
 
-### 7.1l ✅ スライス1.16（DONE・第45セッション）= `undefine()` lvalue slot writeback（`undef.t` 85）
-`undefine($x) = v`（rw）が OFF で `$x` を変更しない（OFF=foo・ON/raku=bar）。slice 1.13 の substr-rw と**同一経路**＝
-`assign_named_sub_lvalue_with_values` の `undefine` branch（builtins_lvalue.rs:250）が `env[$x]` のみ書き slot 未 refresh。
-修正＝env 書込前に target var 名を `pending_rw_writeback_sources` に push→call site の `apply_pending_rw_writeback` drain。
-pin=`t/undefine-lvalue-writeback-coherence.t`（3）。`S32-scalar/undef.t` ON/OFF PASS。
+### 7.1l ✅ Slice 1.16 (DONE, session 45) = `undefine()` lvalue slot writeback (`undef.t` 85)
+`undefine($x) = v` (rw) does not modify `$x` when OFF (OFF=foo; ON/raku=bar). **Same path** as slice 1.13's substr-rw =
+the `undefine` branch of `assign_named_sub_lvalue_with_values` (builtins_lvalue.rs:250) writes only `env[$x]` without
+refreshing the slot. Fix = push the target var name to `pending_rw_writeback_sources` before the env write → the call site's
+`apply_pending_rw_writeback` drains.
+pin=`t/undefine-lvalue-writeback-coherence.t` (3). `S32-scalar/undef.t` PASSES ON/OFF.
 
-### 7.2 後続スライス（その先）
-- **delegated mutating method call の invocant writeback**（pre-existing・トグル非依存）: `$q.push(5)` が `handles` 経由で
-  `@!c` に委譲されるとき、attr は変異するが method-call 後に caller の `$q` slot/instance が refresh されず累積が壊れる
-  （ON/OFF 両方で失敗）。env_dirty 削除には不要（ON でも壊れている＝OFF survey の決定的依存ではない）が、一般的バグとして別途修正可。
-- **container `@`/`%` の named-sub 以外の cell 化**（必要なら）: closure 捕捉 container は現状 Arc 共有で動く。`box_captured_lexicals`
-  の `@`/`%` skip を緩和する場合は §8 の decont 監査が前提（broad boxing は ~12 file 回帰を実証済＝precise 限定必須）。
-- **並行 cluster の残り**（supply/whenever/react ~11）: §7.1g で決定的部（promise-combinator/scheduler-cue-times の
-  atomic-CAS sync）は解決。残りは **flaky な reactive 系**（supply/whenever の timing 依存・`^not ok` に出ず
-  abort/timeout で manifest）＝決定的 OFF-pin が書けないため toggle survey で追いきれない。env_dirty 削除の最終段
-  （`blanket_reconcile_if_dirty` 空洞化）で実挙動を確認するのが現実的。基本 cross-thread captured-write は shared_vars で
-  既に ON/OFF 両成立済（cross-thread cell の本格実装は不要と判明）。
+### 7.2 Follow-up slices (beyond that)
+- **Invocant writeback for delegated mutating method calls** (pre-existing, toggle-independent): when `$q.push(5)` is
+  delegated to `@!c` via `handles`, the attr mutates but the caller's `$q` slot/instance is not refreshed after the method
+  call and accumulation breaks (fails both ON/OFF). Not needed for env_dirty removal (broken even ON = not a deterministic
+  dependency of the OFF survey), but fixable separately as a general bug.
+- **Cell-ification of containers `@`/`%` beyond named subs** (if needed): closure-captured containers currently work via Arc
+  sharing. Relaxing the `@`/`%` skip in `box_captured_lexicals` requires the §8 decont audit as a prerequisite (broad boxing
+  demonstrably regressed ~12 files = precise-only is mandatory).
+- **Remainder of the concurrency cluster** (supply/whenever/react ~11): §7.1g resolved the deterministic part
+  (the atomic-CAS sync of promise-combinator/scheduler-cue-times). The remainder is the **flaky reactive family**
+  (supply/whenever timing dependencies; does not show in `^not ok`, manifests as abort/timeout) = no deterministic OFF pin can
+  be written, so the toggle survey cannot chase it. Realistically, verify actual behavior at the final stage of env_dirty
+  removal (hollowing out `blanket_reconcile_if_dirty`). Basic cross-thread captured writes already work both ON/OFF via
+  shared_vars (a full cross-thread cell implementation turned out to be unnecessary).
 
-### 7.2a ★OFF roast survey（第45セッション・2026-06-21・authoritative）= env_dirty 削除の真の残サーフェス
-これまでの「決定的 OFF 依存 = 0 到達」は **t/ のみの `^not ok` survey** に基づく過小評価だった。`MUTSU_NO_BLANKET_RECONCILE=1
-make roast`（release・全 whitelist 1285）を実走したところ、**13 ファイルが OFF で決定的に fail**（全て pre-existing＝
-main baseline でも同じ subtest が OFF fail・本スライスの変更とは無関係＝debug 比較で確認）。これが env_dirty 物理削除
-（§7.4）を解禁するために潰すべき残サーフェス（初回 13 → slice 1.13 で substr-rw.t/buf.t、slice 1.14 で zip.t、slice 1.15 で map.t、slice 1.16 で undef.t、slice 1.17 で proto.t/subsignature.t、slice 1.18 で caller.t/callframe.t 消化 → **残 4**）:
+### 7.2a ★OFF roast survey (session 45, 2026-06-21, authoritative) = the true remaining surface for env_dirty removal
+The earlier "deterministic OFF dependencies = reached 0" was an underestimate based on a **`^not ok` survey of t/ only**.
+Actually running `MUTSU_NO_BLANKET_RECONCILE=1 make roast` (release, full whitelist 1285) showed **13 files failing
+deterministically when OFF** (all pre-existing = the same subtests fail OFF on the main baseline too; unrelated to this
+slice's changes = confirmed by debug comparison). This is the remaining surface that must be cleared to unlock the physical
+removal of env_dirty (§7.4) (initially 13 → slice 1.13 cleared substr-rw.t/buf.t, slice 1.14 zip.t, slice 1.15 map.t,
+slice 1.16 undef.t, slice 1.17 proto.t/subsignature.t, slice 1.18 caller.t/callframe.t → **4 remaining**):
 
-| file | failed subtests | 推定カテゴリ | 状態 |
+| file | failed subtests | Estimated category | Status |
 |------|-----------------|--------------|------|
 | ~~S32-str/substr-rw.t~~ | 1, 8-9, 16, 24-25, 33-38 | substr-rw lvalue slot writeback | ✅ slice 1.13 |
 | ~~S03-operators/buf.t~~ | 38 | subbuf-rw lvalue slot writeback | ✅ slice 1.13 |
@@ -439,78 +462,90 @@ main baseline でも同じ subtest が OFF fail・本スライスの変更とは
 | ~~S06-multi/proto.t~~ | 21 | caching proto `state %` writeback | ✅ slice 1.17 |
 | ~~S06-multi/subsignature.t~~ | 54 | caching proto `state %` writeback | ✅ slice 1.17 |
 | ~~S06-signature/code.t~~ | 8 | `&`-param default self-scoping | ✅ slice 1.19 |
-| ~~S12-construction/destruction.t~~ | 3 | cross-thread worker-DESTROY captured-write（retain-on-miss sync） | ✅ slice 1.20 |
+| ~~S12-construction/destruction.t~~ | 3 | cross-thread worker-DESTROY captured-write (retain-on-miss sync) | ✅ slice 1.20 |
 | ~~S32-list/map.t~~ | 62 | `.map` block LAST phaser writeback | ✅ slice 1.15 |
 | ~~S32-scalar/undef.t~~ | 85 | undefine() lvalue slot writeback | ✅ slice 1.16 |
-| S32-io/IO-Socket-Async.t | 5, 7 | reactive 並行（flaky 疑い） | |
+| S32-io/IO-Socket-Async.t | 5, 7 | reactive concurrency (suspected flaky) | |
 
-**triage（第45〜46セッション・実測済）**:
-- ~~**map.t 62**~~ ✅ **slice 1.15 で消化**（§7.1k）。`.map({ LAST $x=True })` の LAST phaser body は map body と**別に**
-  コンパイル・実行される（`resolution.rs:2253`）ので、map body の `record_eager_block_free_var_writeback`（:2276）が
-  phaser の write を拾わなかった。phaser 実行直後に `record_eager_block_free_var_writeback(&phaser_code, &[])` 追加で解決。
-- **lazy-lists.t 24-26（`.kv`/`.pairs`/`.antipairs` is lazy）= writeback ではなく laziness バグの露出**（実測 ON=1/OFF=0/
-  raku=1）。`make-lazy-list = gather { take ...; $was-lazy = 0 }.lazy` を `.kv` が **eager に force**して `$was-lazy=0` を
-  走らせてしまう（mutsu の `.kv`/`.pairs`/`.antipairs` が非 lazy）。ON は write-loss で偶然 raku 一致、OFF は slice 1.6 の
-  gather writeback が正しく伝播して**潜在 laziness バグを露出**（doc §7.3 教訓 #3 の典型）。∴ 修正は `.kv`/`.pairs`/
-  `.antipairs` の **真の lazy 化**（L 系・別軸）＝precise-writeback では解けない。env_dirty 削除には laziness 修正が前提。
-- ~~**undef.t 85**~~ ✅ **slice 1.16 で消化**（§7.1l・substr-rw と同経路の `undefine()` lvalue）。
-- ~~**proto.t 21 ＋ subsignature.t 54**~~ ✅ **slice 1.17 で消化（1 修正で 2 file・PR #3389）**。caching proto
-  （`proto cached($a){ state %cache; %cache{$a} //= {*} }`）の cache が呼び出しを跨いで accumulate せず multi が毎回
-  再 dispatch（OFF=`aba`／raku=ON=`ab`）。真因＝**`{*}` redispatch が RHS で評価される hash element-assign の
-  dual-store divergence**: `{*}`（`call_proto_dispatch`）の `restore_env_preserving_existing`（dispatch.rs:2074）が
-  `self.env` を丸ごとスワップし、env の `%cache` Arc を proto body の local slot の Arc から**切り離す**（strong_count→1）。
-  `try_fast_hash_element_assign`（vm_var_assign_ops.rs:2606）は strong_count==1 だと local slot を更新しない（env のみ
-  in-place mutate）ので slot が stale な空 hash のまま残り、続く `sync_env_from_locals`（run_inner）が stale slot を env に
-  書き戻して `state` 永続化が空 hash を保存→cache 喪失。修正（非 gated・precise）＝fast hash assign 末尾で strong_count==1
-  でも local slot が**存在すれば**（＝定義上必ず diverged）代入後 env 値を slot へ mirror（env-only `%*ENV` 等は slot 無し＝
-  no-op、default は blanket reconcile で冗長＝byte-identical）。`state @`-array element-assign（`@cache[$i] //= {*}`）+
-  in-place push は元々 coherent で非該当。教訓: run_inner の state persist は `sync_state_locals`（env 優先・476）→
-  `sync_env_from_locals`（480）順なので、reorder（env flush 先）は逆効果（stale local が fresh env を clobber）＝源流の
-  divergence 修正が正解。pin=`t/proto-state-cache-writeback-coherence.t`（6・ON/OFF 両 PASS）。make test 9788。
-- ~~**caller.t 9 ＋ callframe.t 12**~~ ✅ **slice 1.18 で消化（1 修正で 2 file・第46セッション）**。caller-frame の
-  lexical を名前書きする `$CALLER::x = v`（rw dynamic-var）／`callframe(d).my.<$x> = v` が OFF=stale（ON=書込成功）。
-  真因＝`set_caller_var`（mod.rs:5327）は `caller_env_stack[idx]` と現在 env に書き、`pop_caller_env_with_writeback`
-  （mod.rs:5277）が return 時に restored caller env へ dynamic var を伝播するが、**caller の local slot は未更新**＝OFF で
-  stale slot を読む。修正＝`set_caller_var` で書いた bare name を**新リスト `pending_caller_var_writeback`** に push し、
-  call-site の `apply_pending_rw_writeback` が `env[name]`→slot に drain。★`pending_rw_writeback_sources`（drop-on-miss）
-  と分離した理由＝caller-frame の slot は数フレーム上にあり、writer が return 前に**より深い**呼び出しをすると（`f(){ callframe(1).my.<$x>=v; g() }`）pending が g() の call-site で1フレーム早く消費される→**retain-on-miss**（slot が
-  当該 code に無ければ破棄せず保持し、所有フレームまで運ぶ）。`is dynamic` でない caller lexical は従来通り die。
-  pin=`t/caller-frame-write-slot-coherence.t`（5・ON/OFF 両 PASS）。make test 9799。
-- ~~**code.t 8（`&`-param）**~~ ✅ **slice 1.19 で消化（第47セッション・PR 別途）**。`sub foo(&foo = &foo){...}` の default
-  scoping バグ＝**writeback でなく露出バグ**（ON は carrier `lives-ok { foo }` で captured write が reconcile に落とされ偶然
-  PASS、OFF が正しく伝播して露出）。真因＝パラメータの default 式を評価する際に **そのパラメータ自身が scope に入っていない**
-  ため、`&foo`（default RHS）が外側の登録済み sub `foo` に解決されていた（raku は param `&foo` 自身＝undefined に解決）。
-  修正＝`bind_function_args_values` の両 default-eval サイト（binding.rs ~770 named / ~1500 positional）を新ヘルパー
-  `eval_param_default` に集約し、default 式評価の**直前にパラメータ名自身を undefined 型オブジェクト（or Nil）で env に
-  pre-bind**（self-reference が outer ではなく未定義パラメータに解決＝Raku の「param はその default 内で scope に入る」規則）。
-  earlier param（`$b = $a`）は前 iter で bind 済なので影響なし、別名 outer（`$z = $y`）も影響なし。pin=
-  `t/param-default-self-scoping.t`（7・ON/OFF 両 PASS）。make test 9819。
-- ~~**destruction.t 3**~~ ✅ **slice 1.20 で消化（第48セッション・retain-on-miss cross-thread sync）**。`submethod DESTROY {
-  $a++ }` の worker-thread captured write が top-level slot に届かない。真因＝§7.2c の「cell-detachment」は**誤診断**（#3398
-  で訂正済・真因は cross-thread writeback の **drop-on-miss** リスト誤用）。実測トレースで確定: worker が `$a` を 1 に書き
-  `shared_vars_dirty` にマーク → `await` の `sync_shared_vars_to_env`（mod.rs:6420）が `["a","@order"]` を pending に push し
-  `env["a"]=1` → しかしその後 `await` 内の `run_pending_instance_destroys()`（builtins_system.rs:1796）が **DESTROY を
-  `locals=[]` で dispatch** し、その tail の `apply_pending_rw_writeback`（drop-on-miss）が pending を**消費して捨てる** →
-  top-level frame（`locals=["a","@order","b0"]`・"a" slot 所有）が drain する頃には `sources=[]`。**修正**＝`sync_shared_vars_to_env`
-  の push 先を **drop-on-miss の `pending_rw_writeback_sources` → retain-on-miss の `pending_caller_var_writeback`** に変更
-  （cross-thread synced var の owning slot は数フレーム上＝caller-var と同形の retain-on-miss が正しい）。slice 1.18 の
-  caller-frame writeback と同じリストを再利用＝中間 DESTROY frame は slot 無しで retain、top-level が drain して slot refresh。
-  pin=`t/destroy-cross-thread-writeback-coherence.t`（5・ON/OFF 両 PASS）。
-  - ＋別軸: lazy-lists.t 24-26（laziness バグ・L 系）／IO-Socket-Async.t 5,7（flaky）。
+**Triage (sessions 45–46, measured)**:
+- ~~**map.t 62**~~ ✅ **cleared by slice 1.15** (§7.1k). The LAST phaser body of `.map({ LAST $x=True })` is compiled and
+  executed **separately** from the map body (`resolution.rs:2253`), so the map body's `record_eager_block_free_var_writeback`
+  (:2276) did not pick up the phaser's write. Solved by adding `record_eager_block_free_var_writeback(&phaser_code, &[])`
+  right after phaser execution.
+- **lazy-lists.t 24-26 (`.kv`/`.pairs`/`.antipairs` is lazy) = an exposed laziness bug, not a writeback issue** (measured
+  ON=1/OFF=0/raku=1). `.kv` **eagerly forces** `make-lazy-list = gather { take ...; $was-lazy = 0 }.lazy`, running
+  `$was-lazy=0` (mutsu's `.kv`/`.pairs`/`.antipairs` are non-lazy). ON matched raku by accident via write-loss; OFF
+  propagates correctly via slice 1.6's gather writeback and **exposes the latent laziness bug** (a classic instance of doc
+  §7.3 lesson #3). ∴ The fix is **true lazification** of `.kv`/`.pairs`/`.antipairs` (L family, separate axis) =
+  precise-writeback cannot solve it. The laziness fix is a prerequisite for env_dirty removal.
+- ~~**undef.t 85**~~ ✅ **cleared by slice 1.16** (§7.1l, the `undefine()` lvalue on the same path as substr-rw).
+- ~~**proto.t 21 + subsignature.t 54**~~ ✅ **cleared by slice 1.17 (1 fix, 2 files, PR #3389)**. The caching proto's
+  (`proto cached($a){ state %cache; %cache{$a} //= {*} }`) cache did not accumulate across calls, and the multi was
+  re-dispatched every time (OFF=`aba` / raku=ON=`ab`). True cause = **dual-store divergence of a hash element-assign whose
+  RHS evaluates a `{*}` redispatch**: `{*}`'s (`call_proto_dispatch`) `restore_env_preserving_existing` (dispatch.rs:2074)
+  swaps `self.env` wholesale, **detaching** env's `%cache` Arc from the proto body's local-slot Arc (strong_count→1).
+  `try_fast_hash_element_assign` (vm_var_assign_ops.rs:2606) does not update the local slot when strong_count==1 (it only
+  mutates env in place), so the slot remains a stale empty hash, and the subsequent `sync_env_from_locals` (run_inner)
+  writes the stale slot back to env → the `state` persistence saves an empty hash → cache lost. Fix (ungated, precise) =
+  at the tail of the fast hash assign, even when strong_count==1, if the local slot **exists** (= by definition necessarily
+  diverged) mirror the post-assignment env value to the slot (env-only vars like `%*ENV` have no slot = no-op; default is
+  redundant with blanket reconcile = byte-identical). `state @`-array element-assign (`@cache[$i] //= {*}`) + in-place push
+  were already coherent and not affected. Lesson: run_inner's state persist runs in the order `sync_state_locals` (env
+  priority; 476) → `sync_env_from_locals` (480), so reordering (env flush first) backfires (the stale local clobbers the
+  fresh env) = fixing the divergence at the source is the right answer. pin=`t/proto-state-cache-writeback-coherence.t`
+  (6; PASSES both ON/OFF). make test 9788.
+- ~~**caller.t 9 + callframe.t 12**~~ ✅ **cleared by slice 1.18 (1 fix, 2 files, session 46)**. Writing a caller-frame
+  lexical by name — `$CALLER::x = v` (rw dynamic-var) / `callframe(d).my.<$x> = v` — is stale when OFF (write succeeds ON).
+  True cause = `set_caller_var` (mod.rs:5327) writes to `caller_env_stack[idx]` and the current env, and
+  `pop_caller_env_with_writeback` (mod.rs:5277) propagates dynamic vars to the restored caller env at return, but
+  **the caller's local slot is not updated** = OFF reads the stale slot. Fix = push the bare names written by
+  `set_caller_var` onto a **new list `pending_caller_var_writeback`**, drained by the call-site's
+  `apply_pending_rw_writeback` from `env[name]` → slot. ★Reason for separating it from `pending_rw_writeback_sources`
+  (drop-on-miss) = the caller-frame's slot is several frames up, and if the writer makes a **deeper** call before returning
+  (`f(){ callframe(1).my.<$x>=v; g() }`), the pending would be consumed one frame too early at g()'s call site →
+  **retain-on-miss** (if the slot is not in the current code, keep instead of discarding, carrying it up to the owning
+  frame). Caller lexicals that are not `is dynamic` still die as before.
+  pin=`t/caller-frame-write-slot-coherence.t` (5; PASSES both ON/OFF). make test 9799.
+- ~~**code.t 8 (`&`-param)**~~ ✅ **cleared by slice 1.19 (session 47, separate PR)**. The default-scoping bug of
+  `sub foo(&foo = &foo){...}` = **an exposed bug, not a writeback issue** (ON accidentally PASSes because the captured write
+  is dropped by reconcile in the `lives-ok { foo }` carrier; OFF propagates correctly and exposes it). True cause = when the
+  parameter's default expression is evaluated, **the parameter itself is not yet in scope**, so `&foo` (the default RHS)
+  resolved to the outer registered sub `foo` (raku resolves it to the param `&foo` itself = undefined).
+  Fix = consolidate both default-eval sites of `bind_function_args_values` (binding.rs ~770 named / ~1500 positional) into a
+  new helper `eval_param_default` that **pre-binds the parameter's own name in env to an undefined type object (or Nil)
+  immediately before** evaluating the default expression (self-reference resolves to the undefined parameter rather than the
+  outer = Raku's "a param is in scope inside its own default" rule). Earlier params (`$b = $a`) are already bound in a prior
+  iteration so unaffected; differently-named outers (`$z = $y`) are also unaffected. pin=
+  `t/param-default-self-scoping.t` (7; PASSES both ON/OFF). make test 9819.
+- ~~**destruction.t 3**~~ ✅ **cleared by slice 1.20 (session 48, retain-on-miss cross-thread sync)**. The worker-thread
+  captured write of `submethod DESTROY { $a++ }` does not reach the top-level slot. True cause = §7.2c's "cell-detachment"
+  was a **misdiagnosis** (corrected in #3398; the real cause is misuse of the **drop-on-miss** list for cross-thread
+  writeback). Confirmed by measured trace: the worker writes `$a` to 1 and marks `shared_vars_dirty` → `await`'s
+  `sync_shared_vars_to_env` (mod.rs:6420) pushes `["a","@order"]` to pending and sets `env["a"]=1` → but then
+  `run_pending_instance_destroys()` inside `await` (builtins_system.rs:1796) **dispatches DESTROY with `locals=[]`**, and its
+  tail `apply_pending_rw_writeback` (drop-on-miss) **consumes and discards** the pending → by the time the top-level frame
+  (`locals=["a","@order","b0"]`, owning the "a" slot) drains, `sources=[]`. **Fix** = change the push target of
+  `sync_shared_vars_to_env` from the **drop-on-miss `pending_rw_writeback_sources` → the retain-on-miss
+  `pending_caller_var_writeback`** (the owning slot of a cross-thread synced var is several frames up = the same shape as
+  caller-var, so retain-on-miss is correct). Reuses the same list as slice 1.18's caller-frame writeback = intermediate
+  DESTROY frames retain (no slot), and the top-level drains and refreshes the slot.
+  pin=`t/destroy-cross-thread-writeback-coherence.t` (5; PASSES both ON/OFF).
+  - Plus separate axes: lazy-lists.t 24-26 (laziness bug, L family) / IO-Socket-Async.t 5,7 (flaky).
 
-**残＝別軸 2（lazy-lists laziness・IO-Socket-Async flaky）のみ。純 writeback コヒーレンスのサーフェスは枯渇
-（slice 1.18 で純 writeback、1.19 で露出バグ、1.20 で cross-thread DESTROY writeback）。
-§7.4（env_dirty 削除）は lazy-lists の真 lazy 化（L 系・別軸）後に射程。**
+**Remaining = only the 2 separate-axis items (lazy-lists laziness, IO-Socket-Async flaky). The pure writeback-coherence
+surface is exhausted (slice 1.18 was pure writeback, 1.19 an exposed bug, 1.20 cross-thread DESTROY writeback).
+§7.4 (env_dirty removal) comes into range after true lazification of lazy-lists (L family, separate axis).**
 
-### 7.2c ✅ destruction.t 3 — cross-thread（worker DESTROY）captured-write（第47調査・第48解決＝slice 1.20）
+### 7.2c ✅ destruction.t 3 — cross-thread (worker DESTROY) captured-write (investigated session 47, resolved session 48 = slice 1.20)
 
-**★解決済（slice 1.20・第48セッション）。** 真因は cross-thread writeback の **drop-on-miss リスト誤用**（§7.2a の slice 1.20
-行を参照）。修正＝`sync_shared_vars_to_env` の push 先を `pending_rw_writeback_sources`（drop-on-miss）→
-`pending_caller_var_writeback`（retain-on-miss）に変更。なお第47前半の「cell-detachment」診断は#3398 で誤りと訂正済
-（計測で `$a` は cell-box されておらず、`box_decl_local_cell`/`box_captured_lexicals` の probe が一切発火しない）＝
-真因は cross-thread。以下は当時の調査記録（歴史参考）。
+**★Resolved (slice 1.20, session 48).** The true cause was **misuse of the drop-on-miss list** for cross-thread writeback
+(see the slice 1.20 row in §7.2a). Fix = change `sync_shared_vars_to_env`'s push target from `pending_rw_writeback_sources`
+(drop-on-miss) → `pending_caller_var_writeback` (retain-on-miss). Note that the "cell-detachment" diagnosis from the first
+half of session 47 was corrected as wrong in #3398 (measurement showed `$a` was never cell-boxed; the
+`box_decl_local_cell`/`box_captured_lexicals` probes never fired) = the true cause is cross-thread. What follows is the
+investigation record from that time (historical reference).
 
-**最小再現（決定的・`MUTSU_NO_BLANKET_RECONCILE=1` で確実 fail）**:
+**Minimal reproduction (deterministic; reliably fails with `MUTSU_NO_BLANKET_RECONCILE=1`)**:
 ```raku
 my $a = 0;
 my @order;
@@ -521,541 +556,593 @@ await start {
     loop {
         $*VM.request-garbage-collection;
         my $foo = Foo.new;
-        my $bar = Bar.new unless +@order;   # 条件付き生成
+        my $bar = Bar.new unless +@order;   # conditional creation
         last if $a && @order;
     }
 };
-say "a=$a";     # OFF: a=0（ON/raku: a=1）
+say "a=$a";     # OFF: a=0 (ON/raku: a=1)
 ```
 
-**最重要事実: `start` は別スレッド**。`builtin_start`→`spawn_callable_promise`（builtins_system.rs:106）が
-**`clone_for_thread()` + `spawn_user_thread`** でワーカーを起動＝**DESTROY はワーカースレッド（クローン interpreter）で発火**。
-env はワーカー→親に伝播するが（slice 1.11 の shared_vars 機構）、親の **local slot** は別途 refresh が要る。
+**Most important fact: `start` is a separate thread**. `builtin_start`→`spawn_callable_promise` (builtins_system.rs:106)
+launches the worker with **`clone_for_thread()` + `spawn_user_thread`** = **DESTROY fires on the worker thread (a cloned
+interpreter)**. Env propagates worker→parent (slice 1.11's shared_vars machinery), but the parent's **local slot** needs a
+separate refresh.
 
-**切り分け（OFF）**:
-- 単純 cross-thread write `await start { $x = 5 }` → ✅ `x=5`（slice 1.11 で既に成立）。
-- 単一 DESTROY-in-thread `await start { my $f=Foo.new; $f=Nil; $*VM.request-garbage-collection }` → ✅ `x=5`。
-- **fail するのは loop + 複数 captured var（`$a` scalar + `@order` array）+ 条件付き生成**（d10/min4/min10）。
-  ループ無し・単一 var は OK。
+**Isolation (OFF)**:
+- Simple cross-thread write `await start { $x = 5 }` → ✅ `x=5` (already works since slice 1.11).
+- Single DESTROY-in-thread `await start { my $f=Foo.new; $f=Nil; $*VM.request-garbage-collection }` → ✅ `x=5`.
+- **What fails is loop + multiple captured vars (`$a` scalar + `@order` array) + conditional creation** (d10/min4/min10).
+  No loop / single var is OK.
 
-**真因（計測で確定・親の await call-site で probe）**: `exec_call_func_op`→`dispatch_func_call_inner`→**L597
-`apply_pending_rw_writeback(code)`** の時点で:
-- `code.locals = ["a","@order","b0"]`（top-level frame）／`find_local_slot("a") = Some(0)`（**slot は存在**）／
-  `env.get("a") = Int(1)`（**env は正しく伝播済**）。
-- だが `pending_rw_writeback_sources` / `pending_caller_var_writeback` が **空**＝drain が走らず slot[0] が 0 のまま。
-- ∴ **欠落は「ワーカーが書いた captured scalar `a` を親の pending writeback に記録する」一点だけ**。単一 write 版は
-  slice 1.11 の `sync_shared_vars_to_env`（mod.rs:6412・dirty key を `pending_rw_writeback_sources` に push）が "a" を
-  運ぶので動く。loop+複数 var 版では **"a" が dirty として運ばれない**（ループ内の `last if $a` 読み出しが dirty を消費する／
-  複数 var の dirty 追跡が一部しか乗らない、のいずれか＝要特定）。
+**True cause (confirmed by measurement; probed at the parent's await call-site)**: at the point of
+`exec_call_func_op`→`dispatch_func_call_inner`→**L597 `apply_pending_rw_writeback(code)`**:
+- `code.locals = ["a","@order","b0"]` (top-level frame) / `find_local_slot("a") = Some(0)` (**the slot exists**) /
+  `env.get("a") = Int(1)` (**env is correctly propagated**).
+- But `pending_rw_writeback_sources` / `pending_caller_var_writeback` are **empty** = the drain never runs and slot[0] stays 0.
+- ∴ **The only missing piece is "recording the captured scalar `a` written by the worker into the parent's pending
+  writeback"**. The single-write version works because slice 1.11's `sync_shared_vars_to_env` (mod.rs:6412; pushes dirty keys
+  to `pending_rw_writeback_sources`) carries "a". In the loop+multiple-var version, **"a" is not carried as dirty** (either
+  the `last if $a` read inside the loop consumes the dirty flag, or the multi-var dirty tracking only carries a subset — to
+  be determined).
 
-**試した修正と不成立（第47・全 revert 済）**: ①DESTROY merge（class.rs:1421）で変更 captured scalar を
-`pending_rw_writeback_sources`/`pending_caller_var_writeback` に記録＋loop 境界 drain → ❌ 記録は**ワーカー interpreter の
-pending** に入り join で消失（drain は `locals=[]`/`["foo","bar"]` のワーカー frame でしか起きず "a" slot 不在で retain→消失）。
-②DESTROY merge で cell write-through → ❌ そもそも env が cell でなく plain Int（`saved=Some(Int(0))`）＝cell 不在で不成立。
+**Attempted fixes that did not work (session 47; all reverted)**: (1) recording changed captured scalars at the DESTROY merge
+(class.rs:1421) into `pending_rw_writeback_sources`/`pending_caller_var_writeback` + a loop-boundary drain → ❌ the recording
+goes into the **worker interpreter's pending** and vanishes at join (the drain only happens on the worker frames with
+`locals=[]`/`["foo","bar"]`, "a" slot absent so retain→lost). (2) cell write-through at the DESTROY merge → ❌ env is not a
+cell in the first place, just a plain Int (`saved=Some(Int(0))`) = no cell, so it fails.
 
-**∴ 次セッションの本丸＝cross-thread writeback recording の拡張（slice 1.11 family・localized で解ける見込み）**:
-`sync_shared_vars_to_env`（await が builtins_system.rs:1791 で呼ぶ）が、ワーカーで mutate された captured-outer scalar を
-**漏れなく** `pending_rw_writeback_sources` に push すれば、親の await call-site の既存 drain（L597・top-level slot に到達可）が
-slot を refresh する。**まず特定すべき: loop+複数 var の場合に shared_vars_dirty から "a" が落ちる経路**（ループ内 `$a` 読み出しの
-dirty クリア? worker の最終 sync で一部 var のみ?）。これは **cell substrate 不要**＝cross-thread shared-var の dirty/pending
-記録の取りこぼし修正。env も slot も await call-site で到達可能なことは計測済みなので、pending 記録さえ補えば通る。
-destruction.t 3 がその pin。（別軸: lazy-lists.t laziness / IO-Socket-Async flaky は無関係。）
-（補助案B＝await/loop 境界 top-level drain は、cell 伝播が入れば不要。）
+**∴ The core of the next session = extending cross-thread writeback recording (slice 1.11 family; expected to be solvable
+locally)**: if `sync_shared_vars_to_env` (called by await at builtins_system.rs:1791) pushes the captured-outer scalars
+mutated in the worker to `pending_rw_writeback_sources` **without omission**, the parent's existing await call-site drain
+(L597, which can reach the top-level slot) refreshes the slot. **First identify: the path through which "a" falls out of
+shared_vars_dirty in the loop+multiple-var case** (dirty cleared by the `$a` read inside the loop? only a subset of vars in
+the worker's final sync?). This requires **no cell substrate** = it is a fix for dropped dirty/pending recording of
+cross-thread shared vars. Both env and slot are measured to be reachable at the await call-site, so supplying the pending
+recording alone makes it pass. destruction.t 3 is the pin. (Separate axes: lazy-lists.t laziness / IO-Socket-Async flaky are
+unrelated.) (Auxiliary option B = an await/loop-boundary top-level drain becomes unnecessary once cell propagation lands.)
 
-### 7.2b ✅ proto `{*}` redispatch ＋ `state` var coherence（proto.t 21 / subsignature.t 54）= slice 1.17 で解決
-**実際の真因は当初推測（`restore_env_preserving_existing` が state を巻き戻す）とは別だった。** plain `state %h` を持つ
-通常 sub は OFF でも正常 persist（`counter(){state %seen; %seen<x>++}` → 1 2 3）＝state 機構自体は OK。`state $n`
-スカラも proto body で正常 persist。**問題は `%cache{$a} //= {*}` の hash element-assign 固有**: `{*}`
-（`call_proto_dispatch`）の `restore_env_preserving_existing`（dispatch.rs:2074）が `self.env` を丸ごとスワップし、env の
-`%cache` Arc を proto body の local slot の Arc から切り離す（strong_count→1）。`try_fast_hash_element_assign`
-（vm_var_assign_ops.rs:2606）が strong_count==1 で local slot を更新しない→slot stale→`sync_env_from_locals` が
-env を stale slot で clobber→state 永続化が空 hash 保存。修正＝fast hash assign 末尾で strong_count==1 でも local slot
-存在時に env 値を mirror。詳細＝§7.2a の proto.t 行。pin=`t/proto-state-cache-writeback-coherence.t`。
+### 7.2b ✅ proto `{*}` redispatch + `state` var coherence (proto.t 21 / subsignature.t 54) = resolved by slice 1.17
+**The actual root cause differed from the initial guess (`restore_env_preserving_existing` rolling back state).** A normal
+sub with a plain `state %h` persists correctly even OFF (`counter(){state %seen; %seen<x>++}` → 1 2 3) = the state machinery
+itself is OK. A `state $n` scalar also persists correctly in a proto body. **The problem is specific to the
+`%cache{$a} //= {*}` hash element-assign**: `{*}`'s (`call_proto_dispatch`) `restore_env_preserving_existing`
+(dispatch.rs:2074) swaps `self.env` wholesale, detaching env's `%cache` Arc from the proto body's local-slot Arc
+(strong_count→1). `try_fast_hash_element_assign` (vm_var_assign_ops.rs:2606) does not update the local slot when
+strong_count==1 → slot stale → `sync_env_from_locals` clobbers env with the stale slot → the state persistence saves an
+empty hash. Fix = at the tail of the fast hash assign, mirror the env value to the local slot when it exists, even at
+strong_count==1. Details = the proto.t row of §7.2a. pin=`t/proto-state-cache-writeback-coherence.t`.
 
-### 7.3 ★各スライスの必須手順（slice 1 の教訓）
+### 7.3 ★Mandatory procedure for each slice (lessons from slice 1)
 
-1. **boxing は `cell_boxing_active()` gated を維持**（default は reconcile・byte-identical）。新サーフェスを cell 化する
-   = その cluster の var を toggle 下で box する実装を追加。
-2. **必ず local で `make roast`（または該当 synopsis）を回す**。`make test` だけでは roast 回帰を見逃す
-   （slice 1 は let.t/code.t を make test では検出できなかった）。
-3. **cell 化が露出する潜在バグ**（reconcile が carrier で write を落として偶然 PASS していたケース）を覚悟する。
-   toggle 下で fail が残るなら、それは「次に直すべき本当のバグ」＝記録して order 付け。
-4. toggle OFF/ON 両方で pin が PASS することを確認。
+1. **Keep boxing gated by `cell_boxing_active()`** (default is reconcile, byte-identical). Cell-ifying a new surface
+   = adding an implementation that boxes that cluster's vars under the toggle.
+2. **Always run `make roast` locally (or the relevant synopsis)**. `make test` alone misses roast regressions
+   (slice 1 could not detect let.t/code.t via make test).
+3. **Expect latent bugs exposed by cell-ification** (cases that accidentally PASSed because reconcile dropped a write in a
+   carrier). If a fail remains under the toggle, that is "the next real bug to fix" = record it and order it.
+4. Confirm the pins PASS with the toggle both OFF and ON.
 
-### 7.4 最終（env_dirty 削除）
+### 7.4 Final (env_dirty removal)
 
-残サーフェス（toggle OFF survey）が 0 になったら → `blanket_reconcile_if_dirty` を空洞化 →
-`env_dirty` / `ensure_locals_synced` / `saved_env_dirty` 削除（PLAN.md §2-E）。`pairs`/`slip` carrier-drop も同時に安全化。
-このとき boxing の `cell_boxing_active()` gate を外して恒久 ON 化。
-
----
-
-## 8. Hazard チェックリスト
-
-- [ ] **saved-frame 伝播必須**（§3 教訓）。slot+env だけだとメソッド return で cell が巻き戻る。
-- [ ] **type/where 制約付き scalar は box 禁止**（制約再チェック迂回）。
-- [ ] **non-scalar Value 種（Package/Sub/Instance/Proxy）は box 禁止**（identity/メタ破壊・既存 skip 維持）。
-- [ ] **forward-declared sub の ordering**（案B の場合）。Nil cell box → SetLocal 透過で吸収できるか確認。
-- [ ] **perf**: 該当 var の毎アクセスに Mutex lock。escape-aware で captured-mutated に限定。timed roast / fib・method-call 確認。
-- [ ] **container decont 漏れ**（スライス2）: cell が slice/`.kv`/`.pairs`/native raw-items 読みで漏れない監査。
-- [ ] **cross-thread**（Track C）: `Arc<Mutex>` cell と `shared_vars`/`clone_for_thread` の整合。
+Once the remaining surface (toggle OFF survey) reaches 0 → hollow out `blanket_reconcile_if_dirty` →
+remove `env_dirty` / `ensure_locals_synced` / `saved_env_dirty` (PLAN.md §2-E). The `pairs`/`slip` carrier-drop is made safe
+at the same time. At this point, remove the `cell_boxing_active()` gate and make boxing permanently ON.
 
 ---
 
-## 9. 着手手順（次セッション用クイックスタート）
+## 8. Hazard checklist
 
-**★純 writeback コヒーレンスは slice 1.20（#3400）で完了。lazy-lists.t 24-26 の真 lazy 化も完了（2026-06-22）＝
-OFF roast survey の決定的サーフェスは IO-Socket-Async.t の flaky のみに枯渇。** これで env_dirty 削除（§7.4）の前提が
-すべて揃った。
-
-**lazy-lists.t 24-26 の解決（2026-06-22・完了）**:
-- 真因: `make-lazy-list = gather { take ...; $was-lazy = 0 }.lazy` を `.kv`/`.pairs`/`.antipairs` が **eager に force** して
-  `$was-lazy = 0` を走らせていた。ON は write-loss で偶然 raku 一致、OFF が正しく伝播して露出（writeback でなく laziness バグ）。
-- 修正: `MapGrepSpec` に `index_transform: Option<IndexTransform>`（Pairs/AntiPairs/Kv）を追加し、`.kv`/`.pairs`/`.antipairs`
-  を **lazy index-pipe**（`LazyList::new_index_pipe`）化。genuinely-lazy ソース（`.lazy` gather・無限 spec）に対しては eager
-  force でなく lazy pipe を返す。`source_idx` を positional key に使い、pull は既存の `pull_source_element`（gather coroutine を
-  incremental 消費）を再利用。`force_lazy_pipe` が `index_transform` Some 時に func/grep を bypass して index 変換を emit。
-  3 dispatch 経路（CallMethodMut fast-path・CallMethod 非mut・runtime slow-path methods.rs）すべてに早期 dispatch を追加。
-  index-pipe は preserve marker を持つので `my @res = one.kv` が lazy 保持。値は eager 版とバイト一致。pin=
-  `t/lazy-pairs-kv-antipairs.t`（18・ON/OFF 両 PASS）。
-
-**次 = §7.4（env_dirty 物理削除）**: `blanket_reconcile_if_dirty` 空洞化 → `env_dirty`/`ensure_locals_synced`/
-`saved_env_dirty` 削除 → `cell_boxing_active()` gate を外して boxing 恒久 ON 化。IO-Socket-Async の flaky はこの空洞化で実挙動確認。
+- [ ] **Saved-frame propagation is mandatory** (§3 lesson). Slot+env alone means the cell rolls back on method return.
+- [ ] **Do not box scalars with type/where constraints** (bypasses constraint re-checks).
+- [ ] **Do not box non-scalar Value kinds (Package/Sub/Instance/Proxy)** (breaks identity/meta; keep the existing skip).
+- [ ] **Ordering of forward-declared subs** (for Option B). Confirm that a Nil cell box → SetLocal transparency absorbs it.
+- [ ] **perf**: every access to affected vars takes a Mutex lock. Escape-aware, limited to captured-mutated. Check timed roast / fib and method-call.
+- [ ] **Container decont leaks** (slice 2): audit that the cell does not leak through slice/`.kv`/`.pairs`/native raw-items reads.
+- [ ] **Cross-thread** (Track C): consistency of the `Arc<Mutex>` cell with `shared_vars`/`clone_for_thread`.
 
 ---
 
-## 10. env_dirty 物理削除 substrate グラインド（2026-06-22 着手）
+## 9. Getting-started procedure (quick start for the next session)
 
-§7.4 は「blanket reconcile を空洞化すれば env_dirty を消せる」と書いていたが、**第49セッションの実証で
-それは不十分**と判明した。env_dirty は2つの役割を持つ:
+**★Pure writeback coherence completed with slice 1.20 (#3400). True lazification of lazy-lists.t 24-26 also complete
+(2026-06-22) = the deterministic surface of the OFF roast survey is exhausted down to only IO-Socket-Async.t's flakiness.**
+With this, all the prerequisites for env_dirty removal (§7.4) are in place.
 
-1. **blanket reconcile**（`blanket_reconcile_if_dirty`・env_dirty-gated の O(全 locals) 巻き戻し）のゲート。
-   `MUTSU_NO_BLANKET_RECONCILE`（boxing）下で既に無効＝**除去可能**。
-2. **精密 reconcile**（`reconcile_locals_from_env_at_site`・carrier fallback `lives-ok{}`・Proxy STORE 等の
-   サイトで全 locals を env から pull）の perf ゲート。**boxing 下でも load-bearing**。
+**Resolution of lazy-lists.t 24-26 (2026-06-22, complete)**:
+- True cause: `.kv`/`.pairs`/`.antipairs` **eagerly forced** `make-lazy-list = gather { take ...; $was-lazy = 0 }.lazy`,
+  running `$was-lazy = 0`. ON matched raku by accident via write-loss; OFF propagated correctly and exposed it (a laziness
+  bug, not writeback).
+- Fix: added `index_transform: Option<IndexTransform>` (Pairs/AntiPairs/Kv) to `MapGrepSpec` and made `.kv`/`.pairs`/`.antipairs`
+  **lazy index-pipes** (`LazyList::new_index_pipe`). For genuinely-lazy sources (`.lazy` gather, infinite spec) they return a
+  lazy pipe rather than eagerly forcing. Uses `source_idx` as the positional key; pull reuses the existing
+  `pull_source_element` (incrementally consumes the gather coroutine). `force_lazy_pipe` bypasses func/grep when
+  `index_transform` is Some and emits the index transformation. Early dispatch was added to all 3 dispatch paths
+  (CallMethodMut fast-path, CallMethod non-mut, runtime slow-path methods.rs).
+  The index-pipe carries the preserve marker, so `my @res = one.kv` stays lazy. Values are byte-identical with the eager
+  version. pin=`t/lazy-pairs-kv-antipairs.t` (18; PASSES both ON/OFF).
 
-**実証**: `MUTSU_NO_BLANKET_RECONCILE=1` のまま `reconcile_locals_from_env_at_site` を no-op 化すると
-`make test` が FAIL（"wrapper scalar mutation of captured var propagates" 他）。∴ env_dirty 完全削除は
-**精密 reconcile も不要にする＝精密 reconcile に依存する surface を一つずつ precise writeback / cell 共有へ畳む**
-multi-session グラインドが前提（§4-A の outer cell 共有・PLAN §2-E）。
+**Next = §7.4 (physical removal of env_dirty)**: hollow out `blanket_reconcile_if_dirty` → remove
+`env_dirty`/`ensure_locals_synced`/`saved_env_dirty` → remove the `cell_boxing_active()` gate and make boxing permanently ON.
+IO-Socket-Async's flakiness is verified against actual behavior during this hollowing-out.
 
-### 10.1 計測ハーネス `MUTSU_NO_PRECISE_RECONCILE`
+---
 
-`reconcile_locals_from_env_at_site` を no-op 化する独立トグル（`precise_reconcile_disabled()`・
-`vm/vm_env_helpers.rs`）。`MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1`（double-OFF）＝
-**boxing のみ＝env_dirty 削除後の到達状態**を測定する。double-OFF で残る fail が「precise writeback / cell 共有に
-未変換の by-name writer」。これが 0（flaky 除く）になったら精密 reconcile + env_dirty を物理削除できる。
-（旧 `MUTSU_NO_BLANKET_RECONCILE` が slice 1〜1.20 の OFF survey を駆動したのと同型のハーネス。）
+## 10. env_dirty physical-removal substrate grind (started 2026-06-22)
 
-### 10.2 double-OFF baseline（2026-06-22・16 → 15）
+§7.4 said "hollowing out blanket reconcile lets us delete env_dirty", but **session 49's experiments showed that is
+insufficient**. env_dirty has two roles:
 
-double-OFF で fail する t/（＝精密 reconcile 依存 surface）:
-`closure-nested-writeback`（method 捕捉 `$output`）/ `concurrent-cell-writeback-coherence` /
-`done-paren-stmt-modifier`（react done()）/ `eval-carrier-precise-writeback` /
+1. Gate for **blanket reconcile** (`blanket_reconcile_if_dirty`, the env_dirty-gated O(all locals) rollback).
+   Already disabled under `MUTSU_NO_BLANKET_RECONCILE` (boxing) = **removable**.
+2. Perf gate for **precise reconcile** (`reconcile_locals_from_env_at_site`, pulling all locals from env at sites such as
+   the carrier fallback `lives-ok{}` and Proxy STORE). **Load-bearing even under boxing**.
+
+**Demonstration**: with `MUTSU_NO_BLANKET_RECONCILE=1` still set, making `reconcile_locals_from_env_at_site` a no-op makes
+`make test` FAIL ("wrapper scalar mutation of captured var propagates" and others). ∴ Full env_dirty removal presupposes a
+multi-session grind that **also makes precise reconcile unnecessary = folding each surface that depends on precise reconcile
+into precise writeback / cell sharing** (§4-A's outer cell sharing, PLAN §2-E).
+
+### 10.1 Measurement harness `MUTSU_NO_PRECISE_RECONCILE`
+
+An independent toggle that makes `reconcile_locals_from_env_at_site` a no-op (`precise_reconcile_disabled()`,
+`vm/vm_env_helpers.rs`). `MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1` (double-OFF) =
+measures **boxing only = the state reached after env_dirty removal**. The fails remaining under double-OFF are "by-name
+writers not yet converted to precise writeback / cell sharing". Once these reach 0 (excluding flaky), precise reconcile +
+env_dirty can be physically removed.
+(A harness of the same shape as the old `MUTSU_NO_BLANKET_RECONCILE` that drove the OFF survey of slices 1–1.20.)
+
+### 10.2 double-OFF baseline (2026-06-22, 16 → 15)
+
+t/ files failing under double-OFF (= surfaces depending on precise reconcile):
+`closure-nested-writeback` (method-captured `$output`) / `concurrent-cell-writeback-coherence` /
+`done-paren-stmt-modifier` (react done()) / `eval-carrier-precise-writeback` /
 `junction-invocant-autothread-writeback-coherence` / `let-temp` + `let-temp-restore-writeback-coherence` /
 `note-gist-and-dynamic-handle` / `react-do-whenever-tap-coherence` / `react-whenever-last-next` /
 `resumable-control-signal-indirect-call` / `single-store-slice-c-prime` / `supply-on-demand-closing` /
-`supply-sync-infinite-emit` / `wrap-closure-capture`。カテゴリ＝carrier / 並行（supply/react）/ closure / その他。
+`supply-sync-infinite-emit` / `wrap-closure-capture`. Categories = carrier / concurrency (supply/react) / closure / other.
 
-### 10.3 slice S1（2026-06-22）— bound-Proxy substr-rw/subbuf-rw/undefine を precise 化（16→15）
+### 10.3 Slice S1 (2026-06-22) — make bound-Proxy substr-rw/subbuf-rw/undefine precise (16→15)
 
-`my $r := substr-rw($s, ...); $r = v` の Proxy STORE が `$s` を env に by-name 書きするが、STORE は
-slot owner の1フレーム下で走るため slice 1.13 の `pending_rw_writeback_sources`（drop-on-miss）では消える。
-**修正**: STORE の record サイト（`builtins_lvalue.rs` の substr-rw/subbuf-rw/undefine 分岐）で retain-on-miss の
-`pending_caller_var_writeback`（新ヘルパ `record_caller_var_writeback`）にも記録し、Proxy STORE assign サイト
-（`vm_var_assign_ops.rs` の local 3 サイト＋`vm_misc_ops.rs` の global by-name サイト）で
-`reconcile_locals_from_env_at_site` でなく `apply_pending_rw_writeback` で精密 drain。owner slot が数フレーム上でも
-retain-on-miss が運ぶ（slice 1.18 と同型）。blanket reconcile は任意 user `Proxy` STORE 用の fallback として local
-サイトに残置（double-OFF harness 下では no-op）＝default build はバイト不変。pin=既存
-`t/substr-rw-lvalue-writeback-coherence.t`（test 4・double-OFF で PASS 化）。make test 9890（default/double-OFF 両 PASS）。
+The Proxy STORE of `my $r := substr-rw($s, ...); $r = v` writes `$s` by name to env, but STORE runs one frame below the
+slot owner, so slice 1.13's `pending_rw_writeback_sources` (drop-on-miss) loses it.
+**Fix**: at STORE's recording sites (the substr-rw/subbuf-rw/undefine branches of `builtins_lvalue.rs`), also record into the
+retain-on-miss `pending_caller_var_writeback` (new helper `record_caller_var_writeback`), and at the Proxy STORE assign sites
+(3 local sites in `vm_var_assign_ops.rs` + the global by-name site in `vm_misc_ops.rs`) drain precisely via
+`apply_pending_rw_writeback` instead of `reconcile_locals_from_env_at_site`. Retain-on-miss carries it even when the owner
+slot is several frames up (same shape as slice 1.18). Blanket reconcile is left at the local sites as a fallback for
+arbitrary user `Proxy` STOREs (a no-op under the double-OFF harness) = the default build is byte-identical. pin = existing
+`t/substr-rw-lvalue-writeback-coherence.t` (test 4; now PASSES under double-OFF). make test 9890 (PASSES both default/double-OFF).
 
-### 10.4 slice S2（2026-06-22）— `let`/`temp` restore を precise 化（15→13）
+### 10.4 Slice S2 (2026-06-22) — make `let`/`temp` restore precise (15→13)
 
-`temp $x = 20` のブロック退出復元が `restore_let_value`（`accessors.rs`）の非cell path で `env.insert` のみ＝
-slot stale（double-OFF で `$x` が 20 のまま）。restore は復元名を正確に知っている。**修正**: 非cell path で復元名を
-`pending_rw_writeback_sources`（drop-on-miss・same-frame bare block 用）＋ `pending_caller_var_writeback`
-（retain-on-miss・nested callee の `temp` 用）に記録し、block-exit op 3 サイト（`vm_misc_ops.rs` success/err・
-`vm_control_ops.rs` err）で `reconcile_locals_from_env_at_site` の前に `apply_pending_rw_writeback` で精密 drain。
-blanket reconcile は fallback として残置（harness 下 no-op）＝default build 挙動不変。cell-boxed binding は従来どおり
-shared Arc 経由で slot が見えるので非該当。pin=`t/let-temp.t` + `t/let-temp-restore-writeback-coherence.t`
-（double-OFF で PASS 化）。make test 9904。
+The block-exit restore of `temp $x = 20` only does `env.insert` on the non-cell path of `restore_let_value` (`accessors.rs`)
+= slot stale (`$x` stays 20 under double-OFF). The restore knows the restored name exactly. **Fix**: on the non-cell path,
+record the restored name into `pending_rw_writeback_sources` (drop-on-miss, for same-frame bare blocks) plus
+`pending_caller_var_writeback` (retain-on-miss, for `temp` in nested callees), and at the 3 block-exit op sites
+(`vm_misc_ops.rs` success/err, `vm_control_ops.rs` err) drain precisely via `apply_pending_rw_writeback` before
+`reconcile_locals_from_env_at_site`. Blanket reconcile is left as a fallback (a no-op under the harness) = default-build
+behavior unchanged. Cell-boxed bindings are unaffected since the slot sees them via the shared Arc as before.
+pin=`t/let-temp.t` + `t/let-temp-restore-writeback-coherence.t` (now PASS under double-OFF). make test 9904.
 
-### 10.5 slice S3（2026-06-22）— closure/method nested-capture writeback を precise 化（13→10）
+### 10.5 Slice S3 (2026-06-22) — make closure/method nested-capture writeback precise (13→10)
 
-`cap({ note "" but role { method gist { $seen = 1 } } })`（note-gist）/ `capture-out` の `$output`
-（closure-nested-writeback）/ `&f.wrap(-> { $seen = True; callsame })`（wrap-closure-capture）= nested な
-gist/method/wrapper closure が捕捉した outer lexical を変異するが、その lexical は当該 closure の**直接 free var で
-ない**（nested 内で捕捉）ため §closure-dispatch の free_var 記録（811行）が拾えない。**修正**: ①closure-dispatch の
-env-scan writeback ループ（`vm_closure_dispatch.rs`）で、書き戻す caller-visible var の値が変化した場合
-`pending_caller_var_writeback`（retain-on-miss）に記録（`cell_boxing_active()` ガード＝default build の hot closure 経路
-には不可。blanket reconcile が担う）。②wrap dispatch（`vm_call_func_ops.rs:518`・`vm_call_exec_ops.rs:56`）で
-`apply_pending_rw_writeback` を追加（wrapper の記録を drain）。blanket reconcile は fallback として残置。
-pin=`t/note-gist-and-dynamic-handle.t` + `t/closure-nested-writeback.t` + `t/wrap-closure-capture.t`（double-OFF で
-PASS 化）。make test 9904。
+`cap({ note "" but role { method gist { $seen = 1 } } })` (note-gist) / `capture-out`'s `$output`
+(closure-nested-writeback) / `&f.wrap(-> { $seen = True; callsame })` (wrap-closure-capture) = a nested
+gist/method/wrapper closure mutates a captured outer lexical, but that lexical is **not a direct free var** of the closure
+in question (captured within the nesting), so the free_var recording of §closure-dispatch (line 811) cannot pick it up.
+**Fix**: (1) in the env-scan writeback loop of closure dispatch (`vm_closure_dispatch.rs`), when the value of a
+caller-visible var being written back has changed, record it into `pending_caller_var_writeback` (retain-on-miss)
+(guarded by `cell_boxing_active()` = not allowed on the default build's hot closure path; blanket reconcile carries it there).
+(2) at wrap dispatch (`vm_call_func_ops.rs:518`, `vm_call_exec_ops.rs:56`), add `apply_pending_rw_writeback` (drains the
+wrapper's recordings). Blanket reconcile is left as a fallback.
+pin=`t/note-gist-and-dynamic-handle.t` + `t/closure-nested-writeback.t` + `t/wrap-closure-capture.t` (now PASS under
+double-OFF). make test 9904.
 
-### 10.6 slice S4（2026-06-22）— regex embedded `{ }` / `:let` の cross-frame caller writeback を precise 化（10→8）
+### 10.6 Slice S4 (2026-06-22) — make cross-frame caller writeback of regex embedded `{ }` / `:let` precise (10→8)
 
-`sub do-match($txt) { $txt ~~ / (\d+) { $tracked = +$0 } / }`（single-store-slice-c-prime test 7）/
-EVAL 内 `my regex la { :let $a = 5; … }`（eval-carrier-precise-writeback test 12）= regex の埋め込み `{ }` /
-`:let` ブロックが、当該マッチが走るフレーム（`do-match` の本体・EVAL'd code）の slot では**ない** caller lexical
-（sub の呼び出し元／EVAL の呼び出し元の `$tracked`/`$a`）を `env` へ by-name 書きする。`writeback_match_locals`
-（マッチサイト `vm_comparison_ops.rs`）は**現フレームの slot しか書かない**ため、owning slot は1つ以上上のフレームに
-あり stale のまま残る（double-OFF で `$tracked=-1`/`$a=1`）。EVAL の cell-boxing（slice 1.7）は `$x=5` 型の
-`SetGlobal` 書き込みは cell 経由で拾うが、`:let` は `restore_env_entries` の直接 env insert で cell リンクを断つ
-ため拾えない。**修正**: マッチサイトで `writeback_match_locals` の後、埋め込み write 名（`pending_local_updates`）の
-うち match-special（`$/`/`$0`…）でも現フレーム slot でもないものを retain-on-miss の
-`pending_caller_var_writeback`（`record_caller_var_writeback`）に記録。owning フレームへ戻る call site の
-`apply_pending_caller_var_writeback` が drain する（slice 1.18/S1-S3 と同型）。**1 修正で 2 surface 消化**（sub
-carrier と EVAL carrier の双方）。`cell_boxing_active()` ガード＝default build は従来どおり blanket/精密 reconcile が
-担う＝バイト不変。pin=`t/single-store-slice-c-prime.t`（test 7）+ `t/eval-carrier-precise-writeback.t`（test 12）
-（double-OFF で PASS 化）。
+`sub do-match($txt) { $txt ~~ / (\d+) { $tracked = +$0 } / }` (single-store-slice-c-prime test 7) /
+`my regex la { :let $a = 5; … }` inside EVAL (eval-carrier-precise-writeback test 12) = a regex's embedded `{ }` /
+`:let` block writes by name to `env` a caller lexical (`$tracked`/`$a` of the sub's caller / the EVAL's caller) that is
+**not** a slot of the frame where the match runs (`do-match`'s body / the EVAL'd code). `writeback_match_locals`
+(at the match site, `vm_comparison_ops.rs`) **only writes the current frame's slots**, so the owning slot is one or more
+frames up and stays stale (`$tracked=-1`/`$a=1` under double-OFF). EVAL's cell-boxing (slice 1.7) picks up `$x=5`-style
+`SetGlobal` writes via the cell, but `:let` severs the cell link via `restore_env_entries`' direct env insert, so it cannot.
+**Fix**: at the match site, after `writeback_match_locals`, record the embedded write names (`pending_local_updates`)
+that are neither match specials (`$/`/`$0`…) nor current-frame slots into the retain-on-miss
+`pending_caller_var_writeback` (`record_caller_var_writeback`). The `apply_pending_caller_var_writeback` at the call site
+returning to the owning frame drains it (same shape as slices 1.18/S1-S3). **1 fix clears 2 surfaces** (both the sub carrier
+and the EVAL carrier). Guarded by `cell_boxing_active()` = the default build is carried by blanket/precise reconcile as
+before = byte-identical. pin=`t/single-store-slice-c-prime.t` (test 7) + `t/eval-carrier-precise-writeback.t` (test 12)
+(now PASS under double-OFF).
 
-### 10.7 slice S5（2026-06-22）— junction invocant autothread の per-eigenstate writeback を precise 化（8→7）
+### 10.7 Slice S5 (2026-06-22) — make per-eigenstate writeback of junction invocant autothreading precise (8→7)
 
-`my Mu $x = JB1.new | JB1.new | JB2.new; $x.a`（`method a { $cnt1++ }` / JB2 は `$cnt2++`）= invocant junction を
-ユーザーメソッドで autothread し、各 eigenstate が captured-outer / `our` 変数を変異する。各 eigenstate の dispatch は
-その by-name write を `pending_rw_writeback_sources` に記録するが、**次の eigenstate の dispatch がそのバッファを
-上書き**するため、post-loop drain に残るのは**最後の eigenstate のソースだけ**。EARLIER eigenstate のみが書いた変数
-（最後が `$cnt2` を書く間に `$cnt1` を書いた）は失われ owning slot が stale（double-OFF で `$cnt1=1`・期待 2）。同じ変数を
-全 eigenstate が書く場合は最後のソースで足りるので動いていた（露出は「異なる変数を異なる eigenstate が書く」場合のみ）。
-**修正**: junction loop の各 eigenstate 呼び出し後に `pending_rw_writeback_sources` ＋ `pending_caller_var_writeback` を
-drain して retain-on-miss の `pending_caller_var_writeback` に accumulate（`record_caller_var_writeback`・dedup）。
-loop 後の 1 回の `apply_pending_caller_var_writeback` が env（既に全 eigenstate の累積値を保持）から owning caller slot を
-精密に書く。CallMethod（非mut）/ CallMethodMut（mut）両 junction path に対称適用（`$cnt++` は mut path 経由）。
-`cell_boxing_active()` ガード＝default build は従来どおり blanket `reconcile_locals_from_env_at_site` の pull＝バイト不変。
-pin=`t/junction-invocant-autothread-writeback-coherence.t`（6・double-OFF で PASS 化）。回帰元
-`roast/S03-junctions/autothreading.t` 107/107 PASS。
+`my Mu $x = JB1.new | JB1.new | JB2.new; $x.a` (`method a { $cnt1++ }` / JB2 does `$cnt2++`) = autothreading an invocant
+junction over a user method, with each eigenstate mutating captured-outer / `our` variables. Each eigenstate's dispatch
+records its by-name write into `pending_rw_writeback_sources`, but **the next eigenstate's dispatch overwrites that buffer**,
+so all that remains for the post-loop drain is **only the last eigenstate's sources**. Variables written only by EARLIER
+eigenstates (`$cnt1` written while the last wrote `$cnt2`) are lost and the owning slot goes stale (double-OFF gives
+`$cnt1=1`, expected 2). When all eigenstates write the same variable, the last source suffices, so it worked (the exposure is
+only "different eigenstates write different variables").
+**Fix**: after each eigenstate call in the junction loop, drain `pending_rw_writeback_sources` + `pending_caller_var_writeback`
+and accumulate into the retain-on-miss `pending_caller_var_writeback` (`record_caller_var_writeback`, dedup). A single
+post-loop `apply_pending_caller_var_writeback` writes the owning caller slots precisely from env (which already holds the
+accumulated values of all eigenstates). Applied symmetrically to both junction paths, CallMethod (non-mut) / CallMethodMut
+(mut) (`$cnt++` goes via the mut path). Guarded by `cell_boxing_active()` = the default build keeps the blanket
+`reconcile_locals_from_env_at_site` pull as before = byte-identical.
+pin=`t/junction-invocant-autothread-writeback-coherence.t` (6; now PASSES under double-OFF). The regression source
+`roast/S03-junctions/autothreading.t` PASSES 107/107.
 
-### 10.8 slice S6（2026-06-22）— resumable CONTROL handler writeback を precise 化（7→6）
+### 10.8 Slice S6 (2026-06-22) — make resumable CONTROL handler writeback precise (7→6)
 
 `my $out=''; CONTROL { default { $out ~= "[{.message}]"; .resume } }; my $w = &warn; $w.("indirect")` =
-indirect call（`$w.(...)`／`&warn.(...)`＝CallOnValue）から raise された resumable な `warn` を、enclosing CONTROL の
-`resume_safe` ハンドラがインライン実行する（`try_resume_safe_control_inline`・builtins_control_flow.rs）。ハンドラ本体は
-installing frame の lexical `$out` を変異するが、ハンドラは locals を env から再構成 → 実行 → **変化した slot を env に
-flush + env_dirty** するだけで、frame の local SLOT は warn-call サイトの blanket/精密 `reconcile_locals_from_env_at_site`
-でしか更新されない＝double-OFF で no-op。**direct `warn`（ExecCall）は通り**、indirect（CallOnValue）だけ落ちた
-（計測: indirect 後 `env["out"]=[indirect]` は生存・slot[0] が stale・read が slot を見て空）。**修正**: ハンドラの flush
-ループで変化した名前を `pending_rw_writeback_sources`（drop-on-miss・same-frame）＋ `pending_caller_var_writeback`
-（retain-on-miss・deeper raise site が installing frame まで運ぶ）に記録。両 call site（ExecCall/CallOnValue）が既に走らせる
-**非ゲートの `apply_pending_rw_writeback`** が env → slot を drain する。`cell_boxing_active()` ガード＝default build は従来
-どおり blanket reconcile が担う＝バイト不変。pin=`t/resumable-control-signal-indirect-call.t`（5・double-OFF で PASS 化）。
+a resumable `warn` raised from an indirect call (`$w.(...)`/`&warn.(...)` = CallOnValue) is executed inline by the enclosing
+CONTROL's `resume_safe` handler (`try_resume_safe_control_inline`, builtins_control_flow.rs). The handler body mutates the
+installing frame's lexical `$out`, but the handler only reconstructs locals from env → runs → **flushes changed slots to env
++ env_dirty**; the frame's local SLOT is updated only by the warn-call site's blanket/precise
+`reconcile_locals_from_env_at_site` = a no-op under double-OFF. **Direct `warn` (ExecCall) passes**; only indirect
+(CallOnValue) dropped (measured: after the indirect call, `env["out"]=[indirect]` survives, slot[0] is stale, and the read
+sees the slot and comes up empty). **Fix**: in the handler's flush loop, record changed names into
+`pending_rw_writeback_sources` (drop-on-miss, same-frame) plus `pending_caller_var_writeback` (retain-on-miss; a deeper raise
+site carries it up to the installing frame). The **ungated `apply_pending_rw_writeback`** that both call sites
+(ExecCall/CallOnValue) already run drains env → slot. Guarded by `cell_boxing_active()` = the default build is carried by
+blanket reconcile as before = byte-identical. pin=`t/resumable-control-signal-indirect-call.t` (5; now PASSES under double-OFF).
 
-### 10.9 slice S7（2026-06-22）— react/whenever captured-outer writeback を precise 化（6→0）
+### 10.9 Slice S7 (2026-06-22) — make react/whenever captured-outer writeback precise (6→0)
 
-`react whenever Supply.from-list(…) { …; $i++ }` の `whenever` callback が captured-outer lexical `$i` を変異する。
-callback は `vm_call_map_block` 経由で by-name に env を書くが per-write 記録がなく、`exec_react_scope_op`
-（vm_register_ops.rs）の post-loop `reconcile_locals_from_env_at_site`（double-OFF で no-op）でしか slot に届かない。
-**修正**: react event loop の**前後で caller-frame slot-backing env 値をスナップショット**し、変化した slot だけを env
-から精密に書き戻す（per-write 記録が無い by-name writer の唯一の精密化手段＝loop が書いた名前を差分で同定）。**この
-1 修正で 5 surface 一掃**（`done-paren-stmt-modifier`/`concurrent-cell-writeback-coherence`/`react-whenever-last-next`/
-`supply-on-demand-closing`/`supply-sync-infinite-emit`）。加えて `exec_whenever_scope_op`（:1841）の
-`my $tap = do whenever $sup {…}` bind は **target_var 名が既知**なのでその slot のみ精密書き戻し
-（`react-do-whenever-tap-coherence`）。同期 `from-list` emit＝単一スレッドなので tractable。`cell_boxing_active()`
-ガード＝default build は blanket reconcile が担う＝バイト不変。pin=`t/done-paren-stmt-modifier.t`（4）+
-`t/react-do-whenever-tap-coherence.t`（2）他（全 6・double-OFF で PASS 化）。broad supply/react/concurrency/promise/start
-t/ も両モード PASS。
+The `whenever` callback of `react whenever Supply.from-list(…) { …; $i++ }` mutates the captured-outer lexical `$i`.
+The callback writes env by name via `vm_call_map_block` without per-write recording, and only the post-loop
+`reconcile_locals_from_env_at_site` of `exec_react_scope_op` (vm_register_ops.rs) (a no-op under double-OFF) delivers it to
+the slot. **Fix**: **snapshot the caller-frame slot-backing env values before and after the react event loop** and write back
+precisely only the changed slots from env (the only precise-ification method for by-name writers without per-write
+recording = identify the names the loop wrote by diffing). **This 1 fix sweeps 5 surfaces**
+(`done-paren-stmt-modifier`/`concurrent-cell-writeback-coherence`/`react-whenever-last-next`/
+`supply-on-demand-closing`/`supply-sync-infinite-emit`). Additionally, the `my $tap = do whenever $sup {…}` bind of
+`exec_whenever_scope_op` (:1841) has a **known target_var name**, so write back precisely only that slot
+(`react-do-whenever-tap-coherence`). Synchronous `from-list` emit = single-threaded so tractable. Guarded by
+`cell_boxing_active()` = the default build is carried by blanket reconcile = byte-identical. pin=`t/done-paren-stmt-modifier.t` (4) +
+`t/react-do-whenever-tap-coherence.t` (2) and others (all 6; now PASS under double-OFF). The broad
+supply/react/concurrency/promise/start t/ also PASSES in both modes.
 
-### 10.10 t/ surface 0 到達・**roast double-OFF sweep が 25 file の隠れサーフェスを露呈**（authoritative）
+### 10.10 t/ surface reaches 0; **the roast double-OFF sweep exposes 25 files of hidden surface** (authoritative)
 
-S1〜S7 で **t/ pin（16）＋ broad supply/react/concurrency/promise/start クラスタが両モード（default / double-OFF）で全
-PASS**＝t/ で観測できる精密 reconcile 依存サーフェスは枯渇。**だが全 roast whitelist（1285）の double-OFF sweep
-（`MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1` release）を初めて実走したところ 25 file が決定的 fail
-＝t/ pin は不完全だった**（第45 で「OFF roast survey こそ authoritative」と判明したのと同型の教訓）。env_dirty 物理削除は
-この roast サーフェスを全消化してから。診断は `tmp/roast-double-off.log` / `tmp/roast-double-off-fails.txt`。
+With S1–S7, **the t/ pins (16) plus the broad supply/react/concurrency/promise/start cluster all PASS in both modes
+(default / double-OFF)** = the precise-reconcile-dependent surface observable in t/ is exhausted. **But the first actual
+double-OFF sweep of the full roast whitelist (1285) (`MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1` release)
+showed 25 files failing deterministically = the t/ pins were incomplete** (the same lesson as session 45's discovery that
+"the OFF roast survey is what is authoritative"). Physical removal of env_dirty comes only after fully clearing this roast
+surface. Diagnostics in `tmp/roast-double-off.log` / `tmp/roast-double-off-fails.txt`.
 
-**roast double-OFF 25 file（S8 着手前・カテゴリ別）**:
-- **S03 演算子（andthen/orelse/notandthen）**＝user `method defined { $calls++ }` の captured-outer write。
-  → **✅ S10.11 で解決**（CallDefined snapshot writeback・1 修正 3 file）。
-- **S14 roles（anonymous/mixin-6e/parameterized-mixin/rw/submethods-6e・5）**＝role mixin/`rw` accessor の writeback
-  （anonymous/parameterized-mixin は abort=Bad plan）。
-- **S02 types（baghash/mixhash/set・3）**＝Set/Bag/Mix 演算の captured write。
-- **S02 names（our/symbolic-deref・2）**＝`our`/symbolic deref の by-name writeback。
-- **その他**: S02-types/lazy-lists・S04 gather（abort）・S04 terminator・S04 pointy-rw・S06 lvalue-subroutines・
-  S06 named-parameters・S12 coercion-methods・S12 primitives・S12 defer-next・S17 cas-loop・S17 throttle・S32 kv。
+**The 25 roast double-OFF files (before S8, by category)**:
+- **S03 operators (andthen/orelse/notandthen)** = captured-outer writes of a user `method defined { $calls++ }`.
+  → **✅ Resolved by S10.11** (CallDefined snapshot writeback; 1 fix, 3 files).
+- **S14 roles (anonymous/mixin-6e/parameterized-mixin/rw/submethods-6e, 5)** = writeback of role mixin/`rw` accessors
+  (anonymous/parameterized-mixin are abort=Bad plan).
+- **S02 types (baghash/mixhash/set, 3)** = captured writes of Set/Bag/Mix operations.
+- **S02 names (our/symbolic-deref, 2)** = by-name writeback of `our`/symbolic deref.
+- **Others**: S02-types/lazy-lists, S04 gather (abort), S04 terminator, S04 pointy-rw, S06 lvalue-subroutines,
+  S06 named-parameters, S12 coercion-methods, S12 primitives, S12 defer-next, S17 cas-loop, S17 throttle, S32 kv.
 
-**∴ env_dirty 物理削除（§7.4 / PLAN §2-E）は roast double-OFF 0 が前提**: ①roast 25→0 を slice で消化 →
-②`blanket_reconcile_if_dirty` / `reconcile_locals_from_env_at_site` を空洞化 → ③`env_dirty` / `ensure_locals_synced` /
-`saved_env_dirty` を削除 → ④`cell_boxing_active()` gate を撤去して boxing を恒久 ON（＝単一ストアの派生ビュー化）。
+**∴ Physical removal of env_dirty (§7.4 / PLAN §2-E) requires roast double-OFF 0**: (1) clear roast 25→0 in slices →
+(2) hollow out `blanket_reconcile_if_dirty` / `reconcile_locals_from_env_at_site` → (3) remove `env_dirty` /
+`ensure_locals_synced` / `saved_env_dirty` → (4) remove the `cell_boxing_active()` gate and make boxing permanently ON
+(= turning it into a derived view of a single store).
 
-### 10.11 slice S8（2026-06-22）— user `.defined`（andthen/orelse/notandthen）writeback を precise 化（roast 25→22）
+### 10.11 Slice S8 (2026-06-22) — make user `.defined` (andthen/orelse/notandthen) writeback precise (roast 25→22)
 
 `my $calls=0; my class Foo { method defined { $calls++; True } }; Foo andthen meow $_` = `andthen`/`orelse`/`notandthen`
-は LHS の definedness を `OpCode::CallDefined` で判定し、user `method defined` があれば dispatch する（vm.rs:2831）。その
-user method が captured-outer `$calls` を by-name env 書きするが、`CallDefined` の post-call `reconcile_locals_from_env_at_site`
-（double-OFF で no-op）でしか slot に届かず stale（double-OFF で `$calls=0`・期待 1）。`run_instance_method` 経由なので
-per-write 記録なし→**user-method 呼び出し前後で caller-frame slot-backing env 値をスナップショット**し変化した slot だけ
-精密書き戻し（react S7 と同手法）。`cell_boxing_active()` ガード＝default は blanket reconcile が担う＝バイト不変。
-**1 修正で 3 roast file（S03 andthen/orelse/notandthen）消化**。pin=roast/S03-operators/{andthen,orelse,notandthen}.t
-（double-OFF で PASS 化）。
+determine the LHS's definedness via `OpCode::CallDefined`, dispatching to a user `method defined` if present (vm.rs:2831).
+That user method writes the captured-outer `$calls` by name to env, but it only reaches the slot via `CallDefined`'s
+post-call `reconcile_locals_from_env_at_site` (a no-op under double-OFF) and goes stale (double-OFF gives `$calls=0`,
+expected 1). It goes via `run_instance_method`, so there is no per-write recording → **snapshot the caller-frame
+slot-backing env values before and after the user-method call** and write back precisely only the changed slots (same
+technique as react S7). Guarded by `cell_boxing_active()` = the default is carried by blanket reconcile = byte-identical.
+**1 fix clears 3 roast files (S03 andthen/orelse/notandthen)**. pin=roast/S03-operators/{andthen,orelse,notandthen}.t
+(now PASS under double-OFF).
 
-### 10.12 slice S9（2026-06-22）— symbolic-deref store の carrier writeback を precise 化（roast 22→21）
+### 10.12 Slice S9 (2026-06-22) — make carrier writeback of symbolic-deref stores precise (roast 22→21)
 
-`my $a_var=42; my $b_var="a_var"; lives-ok { $::($b_var) = 23 }; is $a_var, 23` = `$::($name) = v`（symbolic deref store・
-`exec_symbolic_deref_store_op`）と `::('$x') = v`（indirect type lookup store・`exec_indirect_type_lookup_store_op`）は
-ターゲット lexical を by-name で env 書きし `update_local_if_exists` で**現フレームの** slot だけ更新する。`lives-ok { }`
-carrier 内ではターゲット slot は carrier-caller のフレームにあり、carrier writeback（`writeback_carrier_writes`）経由で
-しか届かないが、両 store op は**carrier_writes にログしていなかった**ため OFF で reconcile されず stale（bare block では
-動くが lives-ok 内だけ失敗）。**修正**: 両 store op の env insert 後に `note_caller_env_write(&store_name)` を呼び
-carrier_writes へログ＋env_dirty（regex `:let`・`s///` writeback と同パターン）。スカラなので `:=` cell hazard なし。
-default build はバイト不変（scalar reconcile は blanket の subset）。pin=roast/S02-names/symbolic-deref.t（double-OFF で
-PASS 化）。**残 roast double-OFF 21**（our.t は EVAL+class+`$GLOBAL::`++ の別機構で未消化）。
+`my $a_var=42; my $b_var="a_var"; lives-ok { $::($b_var) = 23 }; is $a_var, 23` = `$::($name) = v` (symbolic deref store,
+`exec_symbolic_deref_store_op`) and `::('$x') = v` (indirect type lookup store, `exec_indirect_type_lookup_store_op`) write
+the target lexical by name to env and update only **the current frame's** slot via `update_local_if_exists`. Inside a
+`lives-ok { }` carrier the target slot is in the carrier-caller's frame, reachable only via the carrier writeback
+(`writeback_carrier_writes`), but neither store op **logged to carrier_writes**, so OFF was never reconciled and stale
+(works in a bare block but fails only inside lives-ok). **Fix**: after the env insert in both store ops, call
+`note_caller_env_write(&store_name)` to log into carrier_writes + env_dirty (the same pattern as regex `:let` and `s///`
+writeback). Scalar, so no `:=` cell hazard. The default build is byte-identical (scalar reconcile is a subset of blanket).
+pin=roast/S02-names/symbolic-deref.t (now PASSES under double-OFF). **21 roast double-OFF remaining** (our.t is a separate
+mechanism, EVAL+class+`$GLOBAL::`++, not yet cleared).
 
-### 10.13 slice S10（2026-06-22）— user Proxy STORE の captured-outer writeback を precise 化（roast 21→20）
+### 10.13 Slice S10 (2026-06-22) — make captured-outer writeback of user Proxy STORE precise (roast 21→20)
 
 `my $realvar="foo"; sub proxyvar($p) is rw { Proxy.new(STORE => method ($v) { $realvar = $v }, …) }; proxyvar("PRE")="BAR";
-is $realvar, 'BAR'` = lvalue sub が返す user `Proxy` の STORE method が captured-outer scalar `$realvar` を by-name 書き
-する（`assign_proxy_lvalue`・builtins_lvalue.rs）。ターゲット slot は assign-caller のフレームにあり、assign サイトの
-blanket reconcile（double-OFF で no-op）でしか届かず stale（double-OFF で `foo`・期待 `BAR`）。**修正**: `assign_proxy_lvalue`
-の STORE 呼び出し**前後で env の writeback-safe スカラのみをスナップショット**し、変化した名前を `record_caller_var_writeback`
-（retain-on-miss）に記録 → assign call site の `apply_pending_caller_var_writeback` が drain。スカラ限定
-（`is_writeback_safe_scalar` フィルタ）なので container/`:=` cell hazard なし。`cell_boxing_active()` ガード＝default は
-blanket reconcile が担う＝バイト不変。pin=roast/S06-routine-modifiers/lvalue-subroutines.t（double-OFF で PASS 化）。
-**残 roast double-OFF 20**。
+is $realvar, 'BAR'` = the STORE method of a user `Proxy` returned by an lvalue sub writes the captured-outer scalar
+`$realvar` by name (`assign_proxy_lvalue`, builtins_lvalue.rs). The target slot is in the assign-caller's frame and only
+reachable via the assign site's blanket reconcile (a no-op under double-OFF), so stale (double-OFF gives `foo`, expected
+`BAR`). **Fix**: **snapshot only the writeback-safe scalars of env before and after** `assign_proxy_lvalue`'s STORE call,
+record the changed names into `record_caller_var_writeback` (retain-on-miss) → the assign call site's
+`apply_pending_caller_var_writeback` drains. Scalar-limited (the `is_writeback_safe_scalar` filter), so no container/`:=`
+cell hazard. Guarded by `cell_boxing_active()` = the default is carried by blanket reconcile = byte-identical.
+pin=roast/S06-routine-modifiers/lvalue-subroutines.t (now PASSES under double-OFF).
+**20 roast double-OFF remaining**.
 
-### 10.14 slice S11（2026-06-22）— lives-ok container carrier の Set/Bag/Mix writeback を precise 化（roast 20→17）
+### 10.14 Slice S11 (2026-06-22) — make Set/Bag/Mix writeback of lives-ok container carriers precise (roast 20→17)
 
-`my $b=(…).BagHash; lives-ok { $b<a> = 42 }; is $b<a>, 42` = block Test fn（`lives-ok`/`dies-ok`＝`exec_call_pairs_op`
-carrier）が captured-outer の Set/Bag/Mix を env 経由で変異するが、`writeback_carrier_writes` は container slot を保護的に
-スキップ（barrier 任せ）するため double-OFF で stale。**修正**: carrier 実行**前後で env をスナップショット**し、変化した
-slot を write-through。**対象を COW aggregate（scalar + Set/Bag/Mix）に限定**＝`Value::Set/Bag/Mix(Arc<…Data>)` は
-in-place 変異で `make_mut` が COW し新 Arc へ detach する（pre snapshot は旧 Arc を保持）ので差分検出が確実。**Array/Hash
-除外**（env が COW-detach コピーで interior `:=` element cell を破壊する hazard）。**★Instance も除外**＝attributes が
-`Arc<RwLock>` の **shared cell** で in-place 変異するため snapshot が cell を共有し pre==post で差分検出**不可**（Instance
-rw-accessor は別スライス＝S14-roles/rw.t に残置）。`cell_boxing_active()` ガード＝default はバイト不変。
-回帰確認: element-bind-cell/S03-binding nested・arrays/set・mix 全 PASS（`:=` hazard なし）。pin=roast/S02-types/{baghash,
-mixhash,set}.t（double-OFF で PASS 化）。**残 roast double-OFF 17**（rw.t Instance rw-accessor 含む）。
+`my $b=(…).BagHash; lives-ok { $b<a> = 42 }; is $b<a>, 42` = a block Test fn (`lives-ok`/`dies-ok` = the
+`exec_call_pairs_op` carrier) mutates a captured-outer Set/Bag/Mix via env, but `writeback_carrier_writes` protectively
+skips container slots (leaving it to the barrier), so double-OFF is stale. **Fix**: **snapshot env before and after** carrier
+execution and write through the changed slots. **Limit the targets to COW aggregates (scalar + Set/Bag/Mix)** =
+`Value::Set/Bag/Mix(Arc<…Data>)` COWs on in-place mutation via `make_mut` and detaches to a new Arc (the pre snapshot keeps
+the old Arc), so diff detection is reliable. **Array/Hash excluded** (hazard: env being a COW-detached copy would destroy
+interior `:=` element cells). **★Instance also excluded** = attributes are a **shared cell** of `Arc<RwLock>` mutated in
+place, so the snapshot shares the cell and pre==post makes diff detection **impossible** (Instance rw-accessors are a
+separate slice = left in S14-roles/rw.t). Guarded by `cell_boxing_active()` = the default is byte-identical.
+Regression check: element-bind-cell/S03-binding nested, arrays/set, mix all PASS (no `:=` hazard). pin=roast/S02-types/{baghash,
+mixhash,set}.t (now PASS under double-OFF). **17 roast double-OFF remaining** (including rw.t Instance rw-accessor).
 
-### 10.15 slice S12（2026-06-22）— lives-ok carrier writeback の eligibility を slot-overwritable に拡張（roast 17→11）
+### 10.15 Slice S12 (2026-06-22) — extend lives-ok carrier writeback eligibility to slot-overwritable (roast 17→11)
 
-S11（§10.14）は carrier writeback を **COW aggregate（scalar + Set/Bag/Mix）に限定**したが、これは「新しい env 値の型」で
-判定していたため取りこぼしが多かった。S12 は eligibility を **「上書きされる slot の*現在値*の型」**（`slot_carrier_overwritable`）
-へ転換: 除外は `HashSlotRef`/`ContainerRef`（`:=` binding cell）と plain `Array`/`Hash`（env COW-detach コピーが interior
-`:=` element cell を破壊する hazard）の**2 種のみ**で、それ以外（scalar/Set/Bag/Mix/Mixin/Instance/…）はすべて write-through
-対象。これで `lives-ok { $a does Role[42] }`（Int(0) slot → Mixin・型変化）/ `lives-ok { $obj.r1++ }`（Instance rw-accessor・
-diverged Instance）/ Pair `.kv`/`.values` rw aliasing / `$GLOBAL::`++ も拾える。Instance の in-place attribute 変異は
-shared `Arc<RwLock>` cell で pre==post になり diff 不発火＝無害（genuine な値/型変化のみ write-through）。**全 roast double-OFF
-sweep で 17→11（新規回帰ゼロ・残 11 全て pre-existing）＝S11 比でさらに 6 file 消化**（S02-names/our・S04 pointy-rw・S04
-gather・S12 coercion-methods・S14 rw・S32 kv）。`cell_boxing_active()` ガード＝default はバイト不変。回帰確認: S03-binding
-nested/arrays・element-bind-cell 全 PASS。**残 roast double-OFF 11**: S14 `does`-mixin block-scoped 再代入 4（anonymous/
-mixin-6e/parameterized-mixin/submethods-6e＝block 内 `$a does R` 再代入が outer env に届かない・次スライス）／lazy-lists／
-terminator／named-parameters／primitives／defer-next／cas-loop／throttle。
+S11 (§10.14) limited carrier writeback to **COW aggregates (scalar + Set/Bag/Mix)**, but since it judged by "the type of the
+new env value" it missed many cases. S12 switches eligibility to **"the type of the *current value* of the slot being
+overwritten"** (`slot_carrier_overwritable`): the exclusions are **only 2 kinds** — `HashSlotRef`/`ContainerRef`
+(`:=` binding cells) and plain `Array`/`Hash` (hazard: an env COW-detached copy destroys interior `:=` element cells) —
+and everything else (scalar/Set/Bag/Mix/Mixin/Instance/…) is write-through eligible. This also picks up
+`lives-ok { $a does Role[42] }` (Int(0) slot → Mixin, a type change) / `lives-ok { $obj.r1++ }` (Instance rw-accessor,
+diverged Instance) / Pair `.kv`/`.values` rw aliasing / `$GLOBAL::`++. In-place attribute mutation of an Instance becomes
+pre==post via the shared `Arc<RwLock>` cell and the diff does not fire = harmless (only genuine value/type changes are
+written through). **The full roast double-OFF sweep goes 17→11 (zero new regressions; all 11 remaining are pre-existing)
+= 6 more files cleared vs S11** (S02-names/our, S04 pointy-rw, S04 gather, S12 coercion-methods, S14 rw, S32 kv).
+Guarded by `cell_boxing_active()` = the default is byte-identical. Regression check: S03-binding nested/arrays,
+element-bind-cell all PASS. **11 roast double-OFF remaining**: S14 `does`-mixin block-scoped reassignment 4 (anonymous/
+mixin-6e/parameterized-mixin/submethods-6e = `$a does R` reassignment inside a block does not reach the outer env; next
+slice) / lazy-lists / terminator / named-parameters / primitives / defer-next / cas-loop / throttle.
 
-### 10.16 slice S13（2026-06-22）— does/but mixin の captured-outer writeback を precise 化（roast 11→7）
+### 10.16 Slice S13 (2026-06-22) — make captured-outer writeback of does/but mixins precise (roast 11→7)
 
-S14 roles の `does`/`but` mixin 4 file（anonymous/mixin-6e/parameterized-mixin/submethods-6e）。3 つの異なる取りこぼし:
-1. **`Mixin` PartialEq の inner 委譲**: `lives-ok { $a does Role[42] }` で Int(0) slot が Mixin になるが、
-   `Value::Mixin(Int(0),_) == Int(0)`（PartialEq が inner に委譲・value/mod.rs:2881）のため carrier の差分（`pre != cur`）が
-   false → 上書き漏れ。**修正**: `carrier_writeback_changed_aggregates` の差分判定に `std::mem::discriminant` 比較を追加
-   （variant 変化 Int→Mixin を value 等価でも検出）。
-2. **`does`/`but` op 自体の reconcile 依存**: `$y does R`（`exec_does_op`/`exec_does_var_op`）/ `$obj but R`
-   （`exec_but_mixin_op`）が走らせる role の `submethod TWEAK`/`BUILD` が captured-outer counter
-   （`my $n=0; submethod TWEAK { $n++ }`）を変異するが、各 op の post-call `reconcile_locals_from_env_at_site` は
-   double-OFF で no-op。**修正**: 3 op に carrier snapshot 差分（`snapshot_carrier_overwritable_env` +
-   `carrier_writeback_changed_aggregates`）を `cell_boxing_active()` ガードで追加。
-3. **Hash slot の型変化**: `my $a = {:x}; lives-ok { $a does role {...} }` で **Hash** slot が Mixin 化。Hash は interior
-   `:=` element cell hazard で通常除外だが、**型変化（Hash→Mixin の whole replacement）は安全**。**修正**:
-   `carrier_writeback_changed_aggregates` で Array/Hash slot も `discriminant(slot) != discriminant(env)`（型変化）時のみ
-   上書き（同 variant の detached コピーは引き続き skip）。
-`cell_boxing_active()` ガード＝default はバイト不変。**全 roast double-OFF sweep で 11→7（新規回帰ゼロ）**。回帰確認:
-S03-binding nested/arrays PASS。**残 roast double-OFF 7**: lazy-lists／terminator／named-parameters／primitives／
-defer-next／cas-loop／throttle（各別機構）。
+The 4 S14-roles `does`/`but` mixin files (anonymous/mixin-6e/parameterized-mixin/submethods-6e). 3 distinct misses:
+1. **`Mixin` PartialEq delegating to the inner value**: `lives-ok { $a does Role[42] }` turns the Int(0) slot into a Mixin,
+   but since `Value::Mixin(Int(0),_) == Int(0)` (PartialEq delegates to the inner, value/mod.rs:2881), the carrier's diff
+   (`pre != cur`) is false → the overwrite is missed. **Fix**: add a `std::mem::discriminant` comparison to the diff check in
+   `carrier_writeback_changed_aggregates` (detects the variant change Int→Mixin even under value equality).
+2. **The `does`/`but` ops themselves depending on reconcile**: the role's `submethod TWEAK`/`BUILD` run by
+   `$y does R` (`exec_does_op`/`exec_does_var_op`) / `$obj but R` (`exec_but_mixin_op`) mutates a captured-outer counter
+   (`my $n=0; submethod TWEAK { $n++ }`), but each op's post-call `reconcile_locals_from_env_at_site` is a no-op under
+   double-OFF. **Fix**: add a carrier snapshot diff (`snapshot_carrier_overwritable_env` +
+   `carrier_writeback_changed_aggregates`) to the 3 ops, guarded by `cell_boxing_active()`.
+3. **Type change of a Hash slot**: `my $a = {:x}; lives-ok { $a does role {...} }` turns a **Hash** slot into a Mixin. Hash
+   is normally excluded due to the interior `:=` element cell hazard, but **a type change (whole replacement Hash→Mixin) is
+   safe**. **Fix**: in `carrier_writeback_changed_aggregates`, also overwrite Array/Hash slots but only when
+   `discriminant(slot) != discriminant(env)` (type change) (same-variant detached copies continue to be skipped).
+Guarded by `cell_boxing_active()` = the default is byte-identical. **The full roast double-OFF sweep goes 11→7 (zero new
+regressions)**. Regression check: S03-binding nested/arrays PASS. **7 roast double-OFF remaining**: lazy-lists / terminator /
+named-parameters / primitives / defer-next / cas-loop / throttle (each a separate mechanism).
 
-### 10.17 slice S14（2026-06-22）— param `where` clause の captured-outer writeback を precise 化（roast 7→6）
+### 10.17 Slice S14 (2026-06-22) — make captured-outer writeback of param `where` clauses precise (roast 7→6)
 
 `my $t=''; sub order_test(:$a where { $t ~= 'a' }, :$b where { $t ~= 'b' }) {…}; order_test(b=>2, a=>3); ok $t ~~ /a.*b/`
-= named param の `where { $t ~= 'a' }` clause が binding 中に captured-outer `$t` を変異する。**計測で slot-only と確定**:
-`order_test(...)` 後、closure 経由読みは `$t='ab'`（env に届いている）が direct 読みは空（caller slot stale）＝where-clause の
-write は outer env に達するが caller slot は call-site の blanket pull（double-OFF で no-op）でしか refresh されない。
-**修正**: where-constraint named-eval（`types/binding.rs` ~797）で **eval 前後に env の writeback-safe スカラをスナップ
-ショット**し、変化した名前（`_`/param 自身を除く）を retain-on-miss の `pending_caller_var_writeback`
-（`record_caller_var_writeback`）に記録 → compiled-function call site の `drain_and_reconcile_after_cached_call`
-→`apply_pending_caller_var_writeback` が drain。スカラ限定（`is_writeback_safe_scalar`）で `:=` hazard なし。
-`cell_boxing_active()` ガード＝default はバイト不変（where-constraint は稀パスで hot でない）。pin=roast/S06-signature/
-named-parameters.t（double-OFF で PASS 化）。**残 roast double-OFF 6**: cas-loop／defer-next／primitives／lazy-lists
-（laziness 別軸）／throttle（timing）／terminator（parser）。
+= a named param's `where { $t ~= 'a' }` clause mutates the captured-outer `$t` during binding. **Measurement confirmed
+slot-only**: after `order_test(...)`, a closure-mediated read gives `$t='ab'` (reaches env) but a direct read is empty
+(caller slot stale) = the where-clause's write reaches the outer env, but the caller slot is refreshed only by the
+call-site's blanket pull (a no-op under double-OFF).
+**Fix**: in the where-constraint named-eval (`types/binding.rs` ~797), **snapshot env's writeback-safe scalars before and
+after the eval** and record the changed names (excluding `_`/the param itself) into the retain-on-miss
+`pending_caller_var_writeback` (`record_caller_var_writeback`) → the compiled-function call site's
+`drain_and_reconcile_after_cached_call` → `apply_pending_caller_var_writeback` drains. Scalar-limited
+(`is_writeback_safe_scalar`), so no `:=` hazard. Guarded by `cell_boxing_active()` = the default is byte-identical
+(where-constraints are a rare, non-hot path). pin=roast/S06-signature/named-parameters.t (now PASSES under double-OFF).
+**6 roast double-OFF remaining**: cas-loop / defer-next / primitives / lazy-lists (laziness, separate axis) /
+throttle (timing) / terminator (parser).
 
-### 10.18 slice S15（2026-06-22）— CAS block の captured-outer writeback を precise 化（roast 6→5）
+### 10.18 Slice S15 (2026-06-22) — make captured-outer writeback of CAS blocks precise (roast 6→5)
 
-`my $was='WRONG'; cas($head, { $was = $_; $next }); ok $was === Node` = `cas $var, { … }` の block が captured-outer
-caller scalar `$was` を変異する。**slot-only と確定**（closure 経由読みは正・direct は stale・bare block 内のみ顕在化）:
-block の write は env に届くが caller slot は cas の呼び出しサイトの blanket pull（double-OFF で no-op）でしか refresh
-されない。**修正**: `builtin_cas_var`（`builtins_atomic.rs`）の block 実行（`call_sub_value`）前後で env writeback-safe
-スカラをスナップショットし、変化した名前（`_`/`$_`/cas 対象名を除く）を retain-on-miss の `pending_caller_var_writeback`
-に記録 → cas call site の `apply_pending_rw_writeback`（slow path L600）が drain。スカラ限定で `:=` hazard なし。
-`cell_boxing_active()` ガード＝default はバイト不変。pin=roast/S17-lowlevel/cas-loop.t（double-OFF で PASS 化）。
-**残 roast double-OFF 5**: defer-next（multi-dispatch）／primitives（meta compose）／lazy-lists（laziness 別軸・writeback
-でない）／throttle（timing・flaky 系）／terminator（auto-curly array composer・parser）。
+`my $was='WRONG'; cas($head, { $was = $_; $next }); ok $was === Node` = the block of `cas $var, { … }` mutates the
+captured-outer caller scalar `$was`. **Confirmed slot-only** (a closure-mediated read is correct, a direct read is stale;
+manifests only inside a bare block): the block's write reaches env, but the caller slot is refreshed only by the blanket pull
+at cas's call site (a no-op under double-OFF). **Fix**: snapshot env's writeback-safe scalars before and after the block
+execution (`call_sub_value`) in `builtin_cas_var` (`builtins_atomic.rs`), and record the changed names (excluding
+`_`/`$_`/the cas target name) into the retain-on-miss `pending_caller_var_writeback` → the cas call site's
+`apply_pending_rw_writeback` (slow path L600) drains. Scalar-limited, so no `:=` hazard. Guarded by `cell_boxing_active()`
+= the default is byte-identical. pin=roast/S17-lowlevel/cas-loop.t (now PASSES under double-OFF).
+**5 roast double-OFF remaining**: defer-next (multi-dispatch) / primitives (meta compose) / lazy-lists (laziness, separate
+axis, not writeback) / throttle (timing, flaky family) / terminator (auto-curly array composer, parser).
 
-### 10.20 slice S16（#3437・2026-06-22）— proto-multi 候補の captured-outer writeback を precise 化（roast 5→4）
+### 10.20 Slice S16 (#3437, 2026-06-22) — make captured-outer writeback of proto-multi candidates precise (roast 5→4)
 
-`proto method l(|){*}` ＋ `multi method l(%t,*@l){ $r ~= '%'; &?ROUTINE.dispatcher()(self,…) }` の候補 body が
-captured-outer caller scalar `$r` を変異する。**真因＝proto 候補は常に slow path 経由**: `proto method` の `{*}`
-（`call_proto_dispatch`・method_ctx あり）は `call_method_with_values` で候補を再ディスパッチし、候補は
-compiled path（`vm_call_method_compiled`＝env_dirty/saved_env_dirty/pending を記録）でなく
-`run_instance_method_resolved`（class.rs:934）を通る。この slow path は捕捉スカラ write を `merged_env`
-（L1421 の「saved_env に在るキーのみ伝播」ループ）で env へ伝播するが **`env_dirty` を立てず precise writeback も
-記録しない**。∴ caller の **local slot** は call-site の blanket pull でしか refresh されず、しかも slow path が
-`env_dirty` を立てないため blanket pull すら発火せず **default build でも caller slot が stale**（double-OFF 限定で
-ない潜在バグ）。計測＝MUTSU_DBG プローブで `merged_env["r"]=="X"`（env 伝播済）だが top-level slot 空を確認。
-**修正**: `try_proto_method_body`（dispatch.rs）で `run_proto_method` の **前後に env writeback-safe スカラを
-スナップショット**し、変化した名前（`_`/`$_` 除く）を retain-on-miss の `pending_caller_var_writeback`
-（`record_caller_var_writeback`）に記録 → proto call site（`vm_call_method_ops`/`vm_call_method_mut_ops` の
-`try_proto_method_body` 短絡 return 直前）の `apply_pending_rw_writeback` が drain。**★ungated**（`cell_boxing_active()`
-ガード無し）＝precise writeback は blanket reconcile の部分集合で正しい結果を変えず、かつ default build の潜在バグ
-（`say "$r"` 読みで stale）も直すため。`is $r` 読みは reconcile site を踏むので roast defer-next.t は default で偶然
-通っていたが、`say` 直読みは default でも壊れていた。pin=`t/proto-multi-captured-writeback-coherence.t`（5・ON/OFF
-両 PASS）。スカラ限定（`is_writeback_safe_scalar`）で `:=` hazard なし。make test 10015。
-**残 roast double-OFF 4**: primitives（meta compose・writeback 候補）／lazy-lists（laziness 別軸）／throttle
-（timing・flaky 系）／terminator（auto-curly array composer・parser）。
+The candidate body of `proto method l(|){*}` + `multi method l(%t,*@l){ $r ~= '%'; &?ROUTINE.dispatcher()(self,…) }` mutates
+the captured-outer caller scalar `$r`. **True cause = proto candidates always go via the slow path**: `proto method`'s `{*}`
+(`call_proto_dispatch`, with method_ctx) re-dispatches the candidate via `call_method_with_values`, and the candidate goes
+through `run_instance_method_resolved` (class.rs:934) rather than the compiled path (`vm_call_method_compiled` = which
+records env_dirty/saved_env_dirty/pending). This slow path propagates captured scalar writes to env via `merged_env`
+(the "propagate only keys present in saved_env" loop at L1421) but **sets no `env_dirty` and records no precise writeback**.
+∴ The caller's **local slot** is refreshed only by the call-site's blanket pull, and moreover, since the slow path does not
+set `env_dirty`, the blanket pull never even fires and **the caller slot is stale even in the default build** (a latent bug,
+not double-OFF-only). Measurement = a MUTSU_DBG probe confirmed `merged_env["r"]=="X"` (env propagated) but the top-level
+slot empty.
+**Fix**: in `try_proto_method_body` (dispatch.rs), **snapshot env's writeback-safe scalars before and after**
+`run_proto_method`, and record the changed names (excluding `_`/`$_`) into the retain-on-miss
+`pending_caller_var_writeback` (`record_caller_var_writeback`) → the `apply_pending_rw_writeback` at the proto call site
+(right before the `try_proto_method_body` short-circuit return in `vm_call_method_ops`/`vm_call_method_mut_ops`) drains.
+**★Ungated** (no `cell_boxing_active()` guard) = precise writeback is a subset of blanket reconcile and does not change
+correct results, and it also fixes the default build's latent bug (stale on a `say "$r"` read). An `is $r` read steps on a
+reconcile site, so roast defer-next.t happened to pass by accident in default, but a direct `say` read was broken even in
+default. pin=`t/proto-multi-captured-writeback-coherence.t` (5; PASSES both ON/OFF). Scalar-limited
+(`is_writeback_safe_scalar`), so no `:=` hazard. make test 10015.
+**4 roast double-OFF remaining**: primitives (meta compose, writeback candidate) / lazy-lists (laziness, separate axis) /
+throttle (timing, flaky family) / terminator (auto-curly array composer, parser).
 
-### 10.21 slice S17（#3438・2026-06-22）— custom HOW type-check メソッドの captured-outer writeback を precise 化（roast 4→3）
+### 10.21 Slice S17 (#3438, 2026-06-22) — make captured-outer writeback of custom HOW type-check methods precise (roast 4→3)
 
 `class UnionTypeHOW { method type_check(Mu $, Mu \c){ ++$union-type-checks; … } method find_method(Mu $,$n){ $find++; … } }`
-＋ `Metamodel::Primitives.create_type($how, …)` の custom 型に対する `Int ~~ $union` / `$union ~~ Int` smartmatch。
-HOW の `type_check`/`accepts_type`/`find_method` メソッドが captured-outer caller **counter** を `++` する。**S16 と同
-family**: HOW メソッドは type-check 時に slow path（`run_instance_method_resolved`）で dispatch され、捕捉スカラ write を
-env に伝播するが `env_dirty` を立てず precise writeback も記録しない → caller slot が blanket pull でしか refresh されない。
-**counter が read-modify-write（`++$c`）なので一層厄介**: slot が stale だと次の smartmatch 文が stale slot を env へ
-re-flush し increment が文跨ぎで消える（double-OFF で find=4→1・checks=2→0 に潰れる）。**修正**: 3 dispatch サイト
-（`metamodel.rs` の `accepts_type`/`find_method`、`smart_match.rs` の `type_check`）を新ヘルパー
-`call_how_method_recording_writeback`（env writeback-safe スカラを HOW 呼び出し前後でスナップショット→変化名を
-`pending_caller_var_writeback` に記録）経由に置換 → smartmatch op（`exec_smart_match_expr_op` 末尾）の
-`apply_pending_caller_var_writeback` が drain（各文末で slot refresh＝次文の re-flush が fresh 値を使う）。**★ungated**
-（S16 同様・custom-HOW dispatch 限定スコープ・precise writeback は blanket の部分集合・bare sink-context smartmatch
-`$obj~~T;$obj~~U;` の default 潜在バグも直す）。pin=`t/custom-how-type-check-writeback-coherence.t`（6・ON/OFF 両 PASS）。
-**残 roast double-OFF 3**: lazy-lists（laziness 別軸）／throttle（timing・flaky 系）／terminator（auto-curly composer・parser）。
+plus `Int ~~ $union` / `$union ~~ Int` smartmatches against a custom type from `Metamodel::Primitives.create_type($how, …)`.
+The HOW's `type_check`/`accepts_type`/`find_method` methods `++` a captured-outer caller **counter**. **Same family as
+S16**: HOW methods are dispatched at type-check time via the slow path (`run_instance_method_resolved`), propagating
+captured scalar writes to env but setting no `env_dirty` and recording no precise writeback → the caller slot is refreshed
+only by the blanket pull. **The counter being a read-modify-write (`++$c`) makes it even nastier**: if the slot is stale,
+the next smartmatch statement re-flushes the stale slot to env, and the increment is lost across statements (under
+double-OFF, find=4→1 and checks=2→0 collapse). **Fix**: replace the 3 dispatch sites (`accepts_type`/`find_method` in
+`metamodel.rs`, `type_check` in `smart_match.rs`) with a new helper `call_how_method_recording_writeback` (snapshots env's
+writeback-safe scalars before and after the HOW call → records the changed names into `pending_caller_var_writeback`) →
+the `apply_pending_caller_var_writeback` at the smartmatch op (tail of `exec_smart_match_expr_op`) drains (slot refresh at
+the end of each statement = the next statement's re-flush uses fresh values). **★Ungated** (like S16; scope limited to
+custom-HOW dispatch; precise writeback is a subset of blanket; also fixes the default build's latent bug in bare
+sink-context smartmatches `$obj~~T;$obj~~U;`). pin=`t/custom-how-type-check-writeback-coherence.t` (6; PASSES both ON/OFF).
+**3 roast double-OFF remaining**: lazy-lists (laziness, separate axis) / throttle (timing, flaky family) /
+terminator (auto-curly composer, parser).
 
-### 10.22 slice S18（#3439・2026-06-22）— EVAL carrier の scalar 再代入 writeback を container slot にも適用（roast 3→2）
+### 10.22 Slice S18 (#3439, 2026-06-22) — apply the EVAL carrier's scalar-reassignment writeback to container slots too (roast 3→2)
 
-`my $z = []; EVAL q'$z = do { 1 } + 2;'; is $z, 1` = EVAL carrier が captured-outer caller scalar `$z` を **container を
-保持していた slot に** scalar 再代入する。**真因＝`writeback_carrier_writes`（vm_env_helpers.rs）の reconcile 適格判定が
-「古い slot 値が scalar か」だった**: `my $z = []`（slot=Array）→ EVAL の `$z = 1`（env=Int）writeback 時、slot の現在値が
-Array なので scalar 分岐をスキップ → container 保護分岐（COW `:=` cell hazard 回避で上書き拒否）→ blanket reconcile
-（double-OFF で no-op）頼みになり slot が stale Array のまま。**この case は誤って「parser（auto-curly）」と分類されていたが
-実体は EVAL carrier scalar writeback**（normal は z=1・auto-curly parse は正常・double-OFF だけ z=[]）。**修正**: 適格判定を
-**新しい env 値が scalar か**に変更（`is_writeback_safe_scalar(&env_val)` ＋ slot が `:=` bind cell＝`ContainerRef`/`HashSlotRef`
-でないこと）。scalar 新値は container COW-copy hazard を持たないので、slot が以前 container を持っていても安全に上書き可。
-`my @e = …; EVAL q'@e = 7,8'`（container→container）は新値が container なので従来の保護分岐のまま＝非該当。`:=` bind cell
-（`t/element-bind-cell.t`・`S03-binding/nested.t`・`arrays.t`）両モード PASS で回帰なし。pin=`t/eval-carrier-scalar-writeback-coherence.t`
-（6・ON/OFF 両 PASS）。**この修正は一般的**（任意の `EVAL q'$x = scalar'` で container を持っていた slot を救う）。
-**残 roast double-OFF 2**: lazy-lists（laziness 別軸）／throttle（timing・flaky 系）。
+`my $z = []; EVAL q'$z = do { 1 } + 2;'; is $z, 1` = the EVAL carrier scalar-reassigns the captured-outer caller scalar
+`$z` **into a slot that previously held a container**. **True cause = the reconcile-eligibility check of
+`writeback_carrier_writes` (vm_env_helpers.rs) was "is the old slot value a scalar"**: `my $z = []` (slot=Array) → on
+writeback of EVAL's `$z = 1` (env=Int), the slot's current value is an Array so the scalar branch is skipped → the container
+protection branch (which refuses the overwrite to avoid the COW `:=` cell hazard) → falls back on blanket reconcile (a no-op
+under double-OFF) and the slot stays a stale Array. **This case was mistakenly classified as "parser (auto-curly)", but the
+substance is EVAL carrier scalar writeback** (normal gives z=1; the auto-curly parse is fine; only double-OFF gives z=[]).
+**Fix**: change the eligibility check to **whether the new env value is a scalar** (`is_writeback_safe_scalar(&env_val)`
+plus the slot not being a `:=` bind cell = `ContainerRef`/`HashSlotRef`). A scalar new value carries no container COW-copy
+hazard, so it can safely overwrite even a slot that previously held a container. `my @e = …; EVAL q'@e = 7,8'`
+(container→container) has a container new value so it keeps the old protection branch = unaffected. The `:=` bind cells
+(`t/element-bind-cell.t`, `S03-binding/nested.t`, `arrays.t`) PASS in both modes, no regressions.
+pin=`t/eval-carrier-scalar-writeback-coherence.t` (6; PASSES both ON/OFF). **This fix is general** (rescues any
+`EVAL q'$x = scalar'` where the slot held a container).
+**2 roast double-OFF remaining**: lazy-lists (laziness, separate axis) / throttle (timing, flaky family).
 
-### 10.23 S19 — lazy-lists の真 lazy 化（gather grep/map・PR 進行中・2026-06-22）
+### 10.23 S19 — true lazification of lazy-lists (gather grep/map; PR in progress, 2026-06-22)
 
-§10.19 で「真の laziness blocker」とした `S02-types/lazy-lists.t` 14/16（`grep is lazy` / `map is lazy`）を **真 lazy 化で解決**
-（double-OFF でも 27/27 PASS）。**真因＝blanket reconcile は load-bearing ではなかった**: gather は normal/double-OFF の
-**両方で eager force されていた**（§10.19 の「take counter=10」計測は正しいが結論が逆）。normal で `$was-lazy=1` だったのは
-gather tail `$was-lazy=0` の captured write が **write-loss していた**だけ（ON は write-loss で偶然 raku 一致＝doc §7.3 教訓#3）。
-∴ blanket reconcile が laziness を維持していたのではなく、reconcile が write を伝播した瞬間に露出した。修正は writeback でなく
-**`gather { … }.grep/.map` を eager force せず lazy pipe で pull する**こと。
+The `S02-types/lazy-lists.t` 14/16 (`grep is lazy` / `map is lazy`) that §10.19 identified as the "true laziness blocker"
+is **resolved by true lazification** (27/27 PASS even under double-OFF). **True cause = blanket reconcile was not
+load-bearing after all**: the gather was eagerly forced in **both** normal and double-OFF (the §10.19 "take counter=10"
+measurement was correct but the conclusion was inverted). Normal showed `$was-lazy=1` only because the captured write of the
+gather tail `$was-lazy=0` was **being write-lost** (ON matched raku by accident via write-loss = doc §7.3 lesson #3).
+∴ Blanket reconcile was not maintaining laziness — the bug was exposed the moment reconcile propagated the write. The fix is
+not writeback but **pulling `gather { … }.grep/.map` through a lazy pipe instead of eagerly forcing it**.
 
-真の eager-force 元は **4 サイト**（すべて「`.lazy` gather/infinite spec を map/grep で lazy pipe 化する」例外が
-`lazy_pipe.is_some() || is_infinite_spec()` のみで **gather coroutine を除外していた**）:
-1. `is_lazy_pipe_source`（methods_collection.rs:69）— gather を lazy pipe source と認めず → `ll.needs_vm_lazy_dispatch()`
-   （`is_from_gather() || is_infinite_spec()`）を OR 追加。
-2. `try_native_method`（vm_native_dispatch.rs:41）— gather+map/grep を native impl に流して materialize → `is_lazy_pipe_source`
-   ゲートに統一して defer。
-3. `vm_call_method_ops.rs:733` / 4. `vm_call_method_mut_ops.rs:474`（method dispatch 前の force ブロック）/ 加えて
-   `runtime/methods.rs:3157`（slow path force）— map/grep 例外に `|| ll.is_from_gather()` を追加し gather を force しない。
-インフラ（`pull_source_element` の `Value::LazyList → force_lazy_list_vm_n(ll, idx+1)`・vm_helpers.rs:1131）は既存＝coroutine を
-1 take ずつ resume できる。plain gather（非 `.lazy`）も Rakudo では grep+slice で lazy なので `is_from_gather()` で判定（lazy
-マーカーは sub return で失われる＝`is_genuinely_lazy()` は不可）。pin=`t/lazy-gather-grep-map-laziness.t`（8・両モード PASS）。
+The true eager-force sources were **4 sites** (all with a "make `.lazy` gather/infinite specs into lazy pipes for map/grep"
+exception that was only `lazy_pipe.is_some() || is_infinite_spec()`, thereby **excluding gather coroutines**):
+1. `is_lazy_pipe_source` (methods_collection.rs:69) — did not recognize gather as a lazy pipe source → OR in
+   `ll.needs_vm_lazy_dispatch()` (`is_from_gather() || is_infinite_spec()`).
+2. `try_native_method` (vm_native_dispatch.rs:41) — routed gather+map/grep to the native impl and materialized → unified on
+   the `is_lazy_pipe_source` gate to defer.
+3. `vm_call_method_ops.rs:733` / 4. `vm_call_method_mut_ops.rs:474` (the force block before method dispatch) / plus
+   `runtime/methods.rs:3157` (the slow-path force) — add `|| ll.is_from_gather()` to the map/grep exception so gather is not forced.
+The infrastructure (`pull_source_element`'s `Value::LazyList → force_lazy_list_vm_n(ll, idx+1)`, vm_helpers.rs:1131) already
+exists = coroutines can be resumed one take at a time. Plain gather (non-`.lazy`) is also lazy in Rakudo under grep+slice,
+so gate on `is_from_gather()` (the lazy marker is lost on sub return = `is_genuinely_lazy()` won't do).
+pin=`t/lazy-gather-grep-map-laziness.t` (8; PASSES in both modes).
 
-**★残 double-OFF サーフェス（authoritative survey・全1285 release・S19 後）= 2（writeback 候補ゼロ・新規回帰ゼロ）**:
-- **`S04-statements/lazy.t`** = **S20 で解決**（`Value::LazyThunk` 自己比較 deadlock・下記 §10.24）。
-- **`S17-supply/throttle.t`** 3,4 = timing flaky（§10.19 のまま・決定的 pin 不可なら削除ブロッカーから外す）。
-（survey で出た spurt.t / gb18030・gb2312・shiftjis-encode-decode.t は **harness artifact**＝raw `prove -e mutsu` が fudge
-ラッパー無しで誤検出・`run-roast-test.sh` 経由では全 PASS。spurt.t は stale temp-file flaky。double-OFF blocker でない。）
+**★Remaining double-OFF surface (authoritative survey, all 1285 release, after S19) = 2 (zero writeback candidates, zero new regressions)**:
+- **`S04-statements/lazy.t`** = **resolved by S20** (`Value::LazyThunk` self-comparison deadlock; see §10.24 below).
+- **`S17-supply/throttle.t`** 3,4 = timing flaky (as in §10.19; if no deterministic pin is possible, drop it from the removal blockers).
+(The spurt.t / gb18030, gb2312, shiftjis-encode-decode.t hits in the survey are **harness artifacts** = raw `prove -e mutsu`
+misdetects without the fudge wrapper; all PASS via `run-roast-test.sh`. spurt.t is the stale temp-file flakiness. Not
+double-OFF blockers.)
 
-**★full-consumption-through-pipe の gather tail writeback は double-OFF で残**（`my @a=gather{…;$t=1}.grep(*>1); ok $t`）:
-直接 gather force は伝播するが、lazy pipe 経由（grep）だと内側 `force_lazy_list_vm_n` の `reconcile_caller_after_lazy_force` が
-pipe 中の誤フレームに drop-on-miss で drain して落とす。**lazy-lists.t（slice・full-consume せず）では踏まれない**ので S19 では
-未修正（pin からも除外）。env_dirty 削除前の writeback slice 候補（retain-on-miss 化 or 外側 force での drain）。
+**★The full-consumption-through-pipe gather tail writeback remains under double-OFF** (`my @a=gather{…;$t=1}.grep(*>1); ok $t`):
+a direct gather force propagates, but via a lazy pipe (grep) the inner `force_lazy_list_vm_n`'s
+`reconcile_caller_after_lazy_force` drains drop-on-miss into the wrong frame mid-pipe and loses it.
+**lazy-lists.t (which slices, never fully consuming) does not step on it**, so it was left unfixed in S19 (also excluded
+from the pin). A writeback slice candidate before env_dirty removal (retain-on-miss conversion or draining at the outer force).
 
-### 10.24 S20 — LazyThunk 自己比較 deadlock（`use Test` END phaser・PR・2026-06-22）
+### 10.24 S20 — LazyThunk self-comparison deadlock (`use Test` END phaser; PR, 2026-06-22)
 
-§10.23 で「次の最有力 double-OFF blocker」とした `S04-statements/lazy.t` の double-OFF **hang** を解決。**busy-loop でなく
-futex deadlock**（`ps` STAT=S・%CPU=0・WCHAN=`futex_do_wait`・perf on-CPU サンプルゼロで確定）。
+Resolved the double-OFF **hang** of `S04-statements/lazy.t`, which §10.23 called "the next most likely double-OFF blocker".
+**A futex deadlock, not a busy loop** (confirmed by `ps` STAT=S, %CPU=0, WCHAN=`futex_do_wait`, zero perf on-CPU samples).
 
-**真因＝`Value::LazyThunk` の自己比較で非再入 mutex を二重ロック**。`PartialEq`（value/mod.rs:2885）が
-`(LazyThunk(a), LazyThunk(b))` で `a.cache.lock()` → `b.cache.lock()` と続けてロックするが、**a と b が同一 Arc のとき同じ mutex を
-二重ロック**して deadlock（std `Mutex` は非再入）。踏む経路は **`finish()` の END phaser overlay**（run.rs:1083 `if v != orig_v`）:
-`my $x := lazy { … }` で束縛した lexical が、END phaser の captured env（`v`）と original env（`orig_v`）の**両方に同一 Arc**で入り、
-`v != orig_v` の比較が自己比較になる。**double-OFF 限定の理由**＝normal は reconcile が END 前に thunk を force/置換して同一 Arc を
-崩すか別経路を取るが、double-OFF では同一 Arc のまま END まで残り自己比較に至る。
+**True cause = double-locking a non-reentrant mutex in a `Value::LazyThunk` self-comparison**. `PartialEq`
+(value/mod.rs:2885) for `(LazyThunk(a), LazyThunk(b))` locks `a.cache.lock()` → then `b.cache.lock()`, but **when a and b
+are the same Arc it double-locks the same mutex** and deadlocks (std `Mutex` is non-reentrant). The path that steps on it is
+**the END phaser overlay of `finish()`** (run.rs:1083 `if v != orig_v`): a lexical bound with `my $x := lazy { … }` enters
+**both** the END phaser's captured env (`v`) and the original env (`orig_v`) as the same Arc, making the `v != orig_v`
+comparison a self-comparison. **Why double-OFF only** = under normal, reconcile forces/replaces the thunk before END or
+takes another path, breaking the same-Arc identity; under double-OFF the same Arc survives to END and reaches the
+self-comparison.
 
-**修正**＝`ContainerRef`（value/mod.rs:2904）と同パターンで **比較冒頭に `Arc::ptr_eq(a, b)` を入れてロック前に短絡**（同一 thunk は
-自明に等しい）。1 行の汎用バグ修正（double-OFF 限定でない潜在 deadlock も塞ぐ）。**最小再現**＝`use Test; plan 1; my $var := lazy { 42 };
-ok 1;`（force/capture 不要・END phaser 到達がトリガ）。pin=`t/lazythunk-self-compare-deadlock.t`（4・両モード PASS）。lazy.t 10/10
-両モード PASS。make test 10069 PASS（回帰ゼロ）。
+**Fix** = following the same pattern as `ContainerRef` (value/mod.rs:2904), **add `Arc::ptr_eq(a, b)` at the head of the
+comparison to short-circuit before locking** (an identical thunk is trivially equal). A one-line general-purpose bug fix
+(also plugs the latent deadlock beyond double-OFF). **Minimal reproduction** = `use Test; plan 1; my $var := lazy { 42 };
+ok 1;` (no force/capture needed; reaching the END phaser is the trigger). pin=`t/lazythunk-self-compare-deadlock.t`
+(4; PASSES in both modes). lazy.t 10/10 PASSES in both modes. make test 10069 PASS (zero regressions).
 
-**★残 double-OFF サーフェス（S20 後）= 1（throttle）→ S21 で解決（§10.25）**。
+**★Remaining double-OFF surface (after S20) = 1 (throttle) → resolved by S21 (§10.25)**.
 
-### 10.25 S21 — Supply `.tap` callback の captured-outer writeback（PR・2026-06-22）
+### 10.25 S21 — Supply `.tap` callback captured-outer writeback (PR, 2026-06-22)
 
-§10.24 で「残 1」とした `S17-supply/throttle.t` を解決。**handoff の「timing flaky」ラベルは誤りで実体は決定的 writeback バグ**
-（3 run 連続で tests 3-4 fail・normal は決定的 PASS＝flaky でない）。`(1..10).Supply.throttle(1,.5).tap: { $max = $max min …;
-$min = $min max …; $before = now }` の tap callback が captured-outer scalar `$min`/`$max`/`$before` を書くが double-OFF で
-slot に伝播せず初期値（`$min=0`/`$max=10`）のまま→`ok $min > .5`/`ok $max < .9` が fail（**timing でなく初期値残留**）。`@seen`
-配列は Arc 共有で伝播していた点が「scalar だけ落ちる」writeback 問題の証左。
+Resolved `S17-supply/throttle.t`, the "1 remaining" from §10.24. **The handoff's "timing flaky" label was wrong; the
+substance is a deterministic writeback bug** (tests 3-4 fail 3 runs in a row; normal is a deterministic PASS = not flaky).
+The tap callback of `(1..10).Supply.throttle(1,.5).tap: { $max = $max min …; $min = $min max …; $before = now }` writes the
+captured-outer scalars `$min`/`$max`/`$before`, but under double-OFF they do not propagate to the slots and stay at their
+initial values (`$min=0`/`$max=10`) → `ok $min > .5`/`ok $max < .9` fail (**leftover initial values, not timing**). The
+`@seen` array did propagate via Arc sharing — evidence that this is a "only scalars drop" writeback problem.
 
-**真因＝同期 tap emission ループ（native_supply_mut_methods.rs:474-498）の `call_sub_value(tap_cb,…)` が captured write を
-記録しない**。tap callback はメインスレッドで即時実行される closure＝escape 解析が外側 lexical を box しないので slot 未 refresh。
-**修正**＝ループ後に `Value::Sub` の `compiled_code` から `record_eager_block_free_var_writeback(&code, &data.params)` を呼び
-free-var writes を `pending_rw_writeback_sources` に記録→`.tap` の `CallMethodMut` op が `apply_pending_rw_writeback` で drain
-（lazy-map / gather / cross-shortcircuit carrier と同機構・S19 の S7 react と同クラス）。throttle.t 両モード PASS。pin=
-`t/supply-tap-callback-writeback.t`（4・両モード PASS・timing 不要の高速 supply tap で writeback を pin）。make test 10105 PASS。
+**True cause = the synchronous tap emission loop's (native_supply_mut_methods.rs:474-498) `call_sub_value(tap_cb,…)` does
+not record captured writes**. The tap callback is a closure executed immediately on the main thread = the escape analysis
+does not box the outer lexicals, so the slots are never refreshed.
+**Fix** = after the loop, call `record_eager_block_free_var_writeback(&code, &data.params)` from the `Value::Sub`'s
+`compiled_code`, recording the free-var writes into `pending_rw_writeback_sources` → the `.tap` `CallMethodMut` op drains
+via `apply_pending_rw_writeback` (the same machinery as the lazy-map / gather / cross-shortcircuit carriers; the same class
+as S19's S7 react). throttle.t PASSES in both modes. pin=
+`t/supply-tap-callback-writeback.t` (4; PASSES in both modes; pins the writeback with a fast supply tap needing no timing). make test 10105 PASS.
 
-**★★ roast double-OFF 決定的サーフェス = 0 到達**（S4〜S21）。残る非決定的＝full-consumption-through-pipe gather tail
-writeback（§10.23・lazy pipe 経由 grep の内側 force が誤フレームに drop-on-miss・roast 非該当）と IO-Socket-Async.t flaky のみ。
-∴ **env_dirty 物理削除（§7.4 / PLAN §2-E）の前提（double-OFF roast 0）を達成**。次セッション＝`blanket_reconcile_if_dirty` /
-`reconcile_locals_from_env_at_site` 空洞化 → `env_dirty` / `ensure_locals_synced` / `saved_env_dirty` 物理削除 →
-`cell_boxing_active()` gate 撤去で boxing 恒久 ON 化に着手できる。**★教訓: handoff の「timing flaky」分類は要再検証（S18
-terminator＝EVAL writeback 誤分類と同型）。決定性は 3-5 run で確認せよ＝throttle は決定的 writeback だった。**
+**★★ roast double-OFF deterministic surface = 0 reached** (S4–S21). The remaining non-deterministic items = the
+full-consumption-through-pipe gather tail writeback (§10.23; the inner force of a grep via a lazy pipe drains drop-on-miss
+into the wrong frame; not hit by roast) and the IO-Socket-Async.t flakiness only.
+∴ **The prerequisite for physical env_dirty removal (§7.4 / PLAN §2-E) — double-OFF roast 0 — is achieved**. Next session =
+hollow out `blanket_reconcile_if_dirty` / `reconcile_locals_from_env_at_site` → physically remove `env_dirty` /
+`ensure_locals_synced` / `saved_env_dirty` → remove the `cell_boxing_active()` gate and make boxing permanently ON.
+**★Lesson: re-verify the handoff's "timing flaky" classifications (same shape as S18 terminator = the EVAL writeback
+misclassification). Confirm determinism with 3-5 runs = throttle was a deterministic writeback bug.**
 
-### 10.26 ★★ boxing 恒久 ON 化 — goal「env↔locals コンテナ cell 共有」をデフォルト挙動として実現（PR・2026-06-22）
+### 10.26 ★★ Boxing permanently ON — the goal "env↔locals container cell sharing" realized as the default behavior (PR, 2026-06-22)
 
-S4〜S21 で roast double-OFF 決定的サーフェス 0 を達成（§10.25）後、**`blanket_reconcile_disabled()` /
-`precise_reconcile_disabled()`（vm_env_helpers.rs）を恒久 `true` にフリップ**し、env→locals reconcile（blanket + precise）を
-retire。これで **cell-boxing が唯一のコヒーレンス機構**になり、env と locals は共有 `ContainerRef` cell（または precise
-write-back）で常に整合する＝goal の実現。
+After S4–S21 achieved roast double-OFF deterministic surface 0 (§10.25), **flipped `blanket_reconcile_disabled()` /
+`precise_reconcile_disabled()` (vm_env_helpers.rs) to permanent `true`**, retiring the env→locals reconcile
+(blanket + precise). With this, **cell-boxing becomes the sole coherence mechanism**, and env and locals are always
+consistent via shared `ContainerRef` cells (or precise write-back) = the goal is realized.
 
-**検証**: フリップは double-OFF 計測ハーネス（`MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1`）と**完全に同一の
-到達状態**で、その状態は既に ①authoritative roast survey（whitelist 1285・`run-roast-test.sh`）= 0 失敗 ②フル `make test`
-（`t/` 10135）= PASS で検証済み。フリップ後の default build で make test 10135 PASS・diverse roast spot-check（lazy-lists /
-lazy / gather / throttle / grep / map / caller / callframe）全 PASS。
+**Verification**: the flip reaches **exactly the same state** as the double-OFF measurement harness
+(`MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1`), and that state was already verified by (1) the authoritative
+roast survey (whitelist 1285, `run-roast-test.sh`) = 0 failures and (2) the full `make test` (`t/` 10135) = PASS. After the
+flip, the default build passes make test 10135 and a diverse roast spot-check (lazy-lists / lazy / gather / throttle /
+grep / map / caller / callframe) all PASS.
 
-**残＝機械的クリーンアップ**（挙動不変）: `env_dirty`（344 uses）/ `reconcile_locals_from_env_at_site`（33）/
-`ensure_locals_synced`（11）/ `saved_env_dirty`（21）/ `cell_boxing_active()`（24・常に true）は dead code 化済み。
-段階的に物理削除する（reconcile は既に no-op なので安全）。**perf**: 全 captured-mutated scalar が毎アクセス Mutex cell に
-なるので、cleanup と並行して fib / method-call の wall-clock を確認すること（§8 hazard チェックリスト）。
+**Remaining = mechanical cleanup** (behavior-preserving): `env_dirty` (344 uses) / `reconcile_locals_from_env_at_site` (33) /
+`ensure_locals_synced` (11) / `saved_env_dirty` (21) / `cell_boxing_active()` (24, always true) are now dead code.
+Physically remove them in stages (reconcile is already a no-op, so it is safe). **perf**: every captured-mutated scalar now
+becomes a Mutex cell on every access, so check the fib / method-call wall-clock in parallel with the cleanup (§8 hazard
+checklist).
 
-### 10.19 ハンドオフ — roast double-OFF 残 2（S18 後・2026-06-22）
+### 10.19 Handoff — roast double-OFF 2 remaining (after S18, 2026-06-22)
 
-S4〜S18（16 slice）で **roast double-OFF surface 25 → 2**。全 whitelist（1285）の double-OFF sweep
-（`MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1` release）で確定した残 2（**両方 writeback でない別軸**・新規回帰ゼロ）:
+S4–S18 (16 slices) took the **roast double-OFF surface 25 → 2**. The remaining 2 confirmed by the double-OFF sweep of the
+full whitelist (1285) (`MUTSU_NO_BLANKET_RECONCILE=1 MUTSU_NO_PRECISE_RECONCILE=1` release) (**both are separate axes, not
+writeback**; zero new regressions):
 
-| file | サブテスト | 種別 | 次の一手 |
+| file | Subtests | Kind | Next move |
 |---|---|---|---|
-| `S02-types/lazy-lists.t` | 14,16 | **真の laziness blocker** | `grep is lazy`/`map is lazy`。**精密切り分け済（下記）**＝blanket reconcile が laziness 維持に load-bearing。precise writeback では解けない。env_dirty 削除前に **grep/map が `.lazy` gather を eager force しない真 lazy 化**が必要。 |
-| `S17-supply/throttle.t` | 3,4 | **別軸（timing）** | `.5〜.8 秒差`のタイミングアサート。flaky 系。env_dirty と無関係の可能性大（決定的 pin 不可なら削除ブロッカーから外す）。 |
+| `S02-types/lazy-lists.t` | 14,16 | **true laziness blocker** | `grep is lazy`/`map is lazy`. **Precisely isolated (below)** = blanket reconcile is load-bearing for laziness maintenance. Cannot be solved by precise writeback. Before env_dirty removal, **true lazification so grep/map do not eagerly force a `.lazy` gather** is needed. |
+| `S17-supply/throttle.t` | 3,4 | **separate axis (timing)** | A timing assert on a `.5–.8 second gap`. Flaky family. Likely unrelated to env_dirty (if no deterministic pin is possible, drop it from the removal blockers). |
 
-**★lazy-lists の精密切り分け（重要・次セッション必読）**: `gather { take $_ for 0..^$n; $was-lazy = 0 }.lazy` を
-`grep(*.is-prime)[^3]` で消費し `ok $was-lazy`（lazy なら gather 未完で `$was-lazy=0` 行が走らず 1 のまま）。**blanket だけ
-OFF でも precise だけ OFF でも `$was-lazy=0`（両方 ON の default のみ 1）**。take counter を仕込んで計測すると、double-OFF /
-blanket-OFF では gather が **eager force される**（takes=10）が normal は lazy（take 計上前に grep が 3 個取って止まる）。
-∴ **precise writeback（snapshot 差分）では解けない＝blanket reconcile が「`.lazy` gather を eager force しない」laziness 維持に
-load-bearing**。env_dirty 物理削除はこの真 lazy 化が前提。再現＝`my $w=1; sub mk($n){gather{take $_ for 0..^$n; $w=0}.lazy};
-$w=1; my \one=mk(10); one.grep(*.is-prime)[^3]; say $w`（normal=1 / double-OFF=0）。
+**★Precise isolation of lazy-lists (important; required reading for the next session)**: consume
+`gather { take $_ for 0..^$n; $was-lazy = 0 }.lazy` via `grep(*.is-prime)[^3]` and `ok $was-lazy` (if lazy, the gather never
+completes, the `$was-lazy=0` line never runs, and it stays 1). **`$was-lazy=0` with blanket-only OFF and with precise-only
+OFF (only the both-ON default gives 1)**. Instrumenting a take counter shows the gather is **eagerly forced**
+(takes=10) under double-OFF / blanket-OFF, but normal is lazy (grep takes 3 and stops before the take count accrues).
+∴ **Precise writeback (snapshot diff) cannot solve it = blanket reconcile is load-bearing for the "do not eagerly force a
+`.lazy` gather" laziness maintenance**. Physical env_dirty removal presupposes this true lazification.
+Reproduction = `my $w=1; sub mk($n){gather{take $_ for 0..^$n; $w=0}.lazy};
+$w=1; my \one=mk(10); one.grep(*.is-prime)[^3]; say $w` (normal=1 / double-OFF=0).
 
-**∴ writeback 候補は枯渇**（S16 proto-multi・S17 custom-HOW・S18 EVAL container-slot scalar writeback で消化）。**残 2 は
-両方 writeback でない別軸**（laziness/timing）。**★terminator は parser 誤分類で実体は EVAL writeback だった（S18 で消化）＝
-ハンドオフの「別軸」分類は要再検証の教訓**。**次セッション着手順**: ①**lazy-lists の真 lazy 化**（grep/map on lazy gather・
-確定した最有力ブロッカー）→ ②throttle が flaky か最終確認 → ③§7.4 / PLAN §2-E（`env_dirty` 物理削除：
-`blanket_reconcile_if_dirty`/`reconcile_locals_from_env_at_site` 空洞化 → `env_dirty`/`ensure_locals_synced`/`saved_env_dirty`
-削除 → `cell_boxing_active()` gate 撤去）に着手できる。診断ファイル＝`tmp/roast-double-off-final-fails.txt`。
-**★S16/S17 の共通教訓**: slow path（`run_instance_method_resolved`）経由の dispatch（proto-multi 候補・custom HOW メソッド）は
-捕捉 write を env に伝播するが `env_dirty` を立てない＝blanket pull すら発火せず default build でも slot stale。修正は dispatch
-前後の env scalar スナップショット差分→`pending_caller_var_writeback` 記録 → 呼び出し op で drain。**ungated でよい**（custom
-dispatch 限定スコープ・blanket の部分集合・default 潜在バグも直す）。**slot-only 判定法**＝同変数を `{ $x }()`（closure＝env 読み）と
-direct（slot 読み）で比較し差があれば slot-only＝snapshot 差分で解ける。
+**∴ Writeback candidates are exhausted** (consumed by S16 proto-multi, S17 custom-HOW, S18 EVAL container-slot scalar
+writeback). **The remaining 2 are both separate axes, not writeback** (laziness/timing). **★terminator was a parser
+misclassification whose substance was EVAL writeback (consumed by S18) = the lesson that the handoff's "separate axis"
+classifications need re-verification**. **Next-session order of attack**: (1) **true lazification of lazy-lists** (grep/map
+on lazy gather; the confirmed top blocker) → (2) final check whether throttle is flaky → (3) §7.4 / PLAN §2-E (physical
+env_dirty removal: hollow out `blanket_reconcile_if_dirty`/`reconcile_locals_from_env_at_site` → remove
+`env_dirty`/`ensure_locals_synced`/`saved_env_dirty` → remove the `cell_boxing_active()` gate). Diagnostic file =
+`tmp/roast-double-off-final-fails.txt`.
+**★Common lesson of S16/S17**: dispatch via the slow path (`run_instance_method_resolved`) (proto-multi candidates, custom
+HOW methods) propagates captured writes to env but does not set `env_dirty` = not even the blanket pull fires, and the slot
+is stale even in the default build. The fix is an env scalar snapshot diff around the dispatch → record into
+`pending_caller_var_writeback` → drain at the calling op. **Ungated is fine** (scope limited to custom dispatch; a subset of
+blanket; also fixes default latent bugs). **The slot-only diagnosis method** = compare the same variable via `{ $x }()`
+(closure = env read) and directly (slot read); a difference means slot-only = solvable by snapshot diff.

--- a/docs/container-identity.md
+++ b/docs/container-identity.md
@@ -1,827 +1,826 @@
-# 第一級コンテナ (container identity) 実装台帳
+# First-class containers (container identity) implementation ledger
 
-PLAN.md「🟣 第2優先: 第一級コンテナへの移行」の実装ログ。
-`docs/vm-dual-store.md` / `docs/vm-decoupling.md` と同じく、**現状の正確な地図 →
-段階スライス → 各 PR の進捗**を残す台帳。コードに触る前に「どこを直すか」を
-確定させ、過去の ContainerRef プロトタイプが踏んだ "deref everywhere" 回帰を避ける。
+Implementation log for PLAN.md "🟣 Priority 2: Migration to first-class containers".
+Like `docs/vm-dual-store.md` / `docs/vm-decoupling.md`, this is a ledger that records **an accurate map of the current state →
+staged slices → per-PR progress**. Before touching any code, we pin down "what to fix where",
+and avoid the "deref everywhere" regression that the past ContainerRef prototype ran into.
 
-最終ゴール: **最速かつ最もメンテしやすい** Raku インタープリタ。コンテナ統一は
-正しさ修正であると同時に、散在する workaround を削除するメンテ性の勝ち筋。
+Final goal: the **fastest and most maintainable** Raku interpreter. Container unification is
+a correctness fix and, at the same time, the maintainability win of deleting scattered workarounds.
 
-> **★ 収束（2026-06-18）**: この campaign は二重ストア統合（[docs/vm-single-store.md](vm-single-store.md)）の
-> 最終 Slice F（`env_dirty` 削除＝`locals` 単一権威化）と**同一の壁に収束する**。Slice F は「env と locals が
-> コンテナで乖離しないこと」を要し、それは本 campaign の Phase 2/3 が構築する保証そのもの。ContainerRef cell は
-> 1 ストア内の COW 跨ぎ生存を解決済みだが、**dual-store の env↔locals 乖離は別レイヤ**として残る（pairs/slip
-> carrier-drop が cell 機構ありでも `element-bind-cell.t` を壊すのが証左）。両 campaign は Slice F で 1 本化する。
-> **この env↔locals 乖離の解消設計＝[docs/env-locals-coherence.md](env-locals-coherence.md)**（推奨＝outer コンテナを
-> env でも `ContainerRef` cell 化し両ストアが同 cell 共有＝Phase 3 instance attr と同型・escape-aware）。Slice E
-> （closure upvalue・#3245/#3247）で single-store の独立前提は完了済み。残るのはこの coherence のみ。
+> **★ Convergence (2026-06-18)**: This campaign **converges onto the same wall** as the dual-store unification
+> ([docs/vm-single-store.md](vm-single-store.md)) final Slice F (removal of `env_dirty` = making `locals` the single authority). Slice F requires
+> "env and locals must not diverge on containers", and that is exactly the guarantee that Phase 2/3 of this campaign builds. The ContainerRef cell
+> already solves survival across COW within 1 store, but **the dual-store env↔locals divergence remains as a separate layer** (the fact that the pairs/slip
+> carrier-drop breaks `element-bind-cell.t` even with the cell mechanism in place is the evidence). Both campaigns unify into one at Slice F.
+> **The design for resolving this env↔locals divergence = [docs/env-locals-coherence.md](env-locals-coherence.md)** (recommended = make outer containers
+> `ContainerRef` cells in env too, so both stores share the same cell = same shape as Phase 3 instance attrs, escape-aware). Slice E
+> (closure upvalues, #3245/#3247) completed the single-store independence prerequisite. Only this coherence work remains.
 
 ---
 
-## 1. 現状: コンテナ/itemization が **3 つに断片化**している
+## 1. Current state: containers/itemization are **fragmented into 3 representations**
 
-mutsu は「Raku のコンテナ identity」を持たず、代わりに重複する 3 表現が併存する。
-これが断片化＝負債の実体で、統一の対象。
+mutsu does not have "Raku's container identity"; instead, 3 overlapping representations coexist.
+This fragmentation is the substance of the debt, and the target of unification.
 
-| # | 表現 | 定義 | 役割 | 主な構築箇所 |
+| # | Representation | Definition | Role | Main construction sites |
 |---|------|------|------|------------|
-| 1 | `Value::Scalar(Box<Value>)` | `src/value/mod.rs:1075` | itemization ラッパ (`$(...)`) | `vm.rs:1814`(WrapScalar), `vm.rs:1803`(Seq itemize), `runtime/methods.rs:215/2327` |
-| 2 | `Value::ContainerRef(Arc<Mutex<Value>>)` | `src/value/mod.rs:1078` | `:=` の変数間共有セル | `into_container_ref()` (`value/mod.rs:2136`)。呼び出しは**わずか4箇所**: `vm.rs:1475`, `vm_register_ops.rs:271`, `vm_var_assign_ops.rs:4880` |
-| 3 | `ArrayKind::ItemList` / `ItemArray` | `src/value/mod.rs:844-846` | Array 値に焼いた itemization フラグ | `ArrayKind::itemize()` (`value/mod.rs:867`), `OpCode::Itemize` (`vm.rs:1792`) |
+| 1 | `Value::Scalar(Box<Value>)` | `src/value/mod.rs:1075` | itemization wrapper (`$(...)`) | `vm.rs:1814`(WrapScalar), `vm.rs:1803`(Seq itemize), `runtime/methods.rs:215/2327` |
+| 2 | `Value::ContainerRef(Arc<Mutex<Value>>)` | `src/value/mod.rs:1078` | inter-variable shared cell for `:=` | `into_container_ref()` (`value/mod.rs:2136`). Callers are **only 4 sites**: `vm.rs:1475`, `vm_register_ops.rs:271`, `vm_var_assign_ops.rs:4880` |
+| 3 | `ArrayKind::ItemList` / `ItemArray` | `src/value/mod.rs:844-846` | itemization flag baked into the Array value | `ArrayKind::itemize()` (`value/mod.rs:867`), `OpCode::Itemize` (`vm.rs:1792`) |
 
-decont（脱コンテナ）ヘルパも分散:
-- `Value::deref_container()` — `value/mod.rs:2112`（ContainerRef を読む）
-- `Value::decontainerize(&self) -> &Value` — `value/mod.rs:2367`（Scalar を剥がす）
-- `ArrayKind::decontainerize()` — `value/mod.rs:878`（item フラグを落とす）
+The decont (de-containerize) helpers are also scattered:
+- `Value::deref_container()` — `value/mod.rs:2112` (reads a ContainerRef)
+- `Value::decontainerize(&self) -> &Value` — `value/mod.rs:2367` (strips Scalar)
+- `ArrayKind::decontainerize()` — `value/mod.rs:878` (drops the item flag)
 
-→ **「コンテナを剥がす」操作が 3 つあり、呼ぶ側が文脈ごとにどれを使うか判断している。**
-これが "deref everywhere" の温床。
+→ **There are 3 "strip the container" operations, and each caller decides per context which one to use.**
+This is the breeding ground of "deref everywhere".
 
 ---
 
-## 2. 標準ケーススタディ: `:=` 束縛リストが平坦化されない (reduce.t 62)
+## 2. Canonical case study: a `:=`-bound list is not flattened (reduce.t 62)
 
 ```raku
-my $l := (1,2,3);   # raku: $l は List そのもの。.VAR は List
-my @a = $l;         # raku: 3 要素（List が平坦化）
-say @a.elems;       # raku: 3 / mutsu: 1   ← バグ
+my $l := (1,2,3);   # raku: $l is the List itself. .VAR is List
+my @a = $l;         # raku: 3 elements (the List flattens)
+say @a.elems;       # raku: 3 / mutsu: 1   ← bug
 ```
 
-### なぜこうなるか（トレース）
+### Why this happens (trace)
 
-1. `my $l := (1,2,3)` と `my $l = (1,2,3)` は **どちらも `Value::Array(items, List)`（非
-   itemized）を格納**する。`:=` はコンパイラで `MarkBindContext` により区別されるが
-   (`compiler/stmt.rs:768/795`)、スカラー格納パスは束縛/代入で同じ bare List を置く
-   （`normalize_scalar_assignment_value` は itemize しない、`vm_var_assign_ops.rs:766`）。
-   → **格納段階でコンテナ status が失われる**。`$l.VAR.^name` は両方 `Scalar`（raku は
-   束縛なら `List`）。
-2. `@a = $l` のコンパイル時、`compile_assignment_rhs_for_target`
-   (`compiler/stmt.rs:233`) が **`@`ターゲット + `Expr::Var` なら無条件で
-   `OpCode::Itemize` を emit**する (`stmt.rs:245`)。
-3. `OpCode::Itemize` (`vm.rs:1792`) が `Array(.., List)` → `Array(.., ItemList)` に変換。
-4. 配列代入の flatten は ArrayKind を尊重する（`ItemList`→1要素、`List`→平坦化）。
-   実際 `@a = (1,2,3)`（リテラル、Var を経由しない）は 3 要素、`@a = $(1,2,3)` は 1 要素で
-   **既に正しく動く**。問題は (2) の **Var 経由のスカラー読みが無条件 itemize される**こと。
+1. `my $l := (1,2,3)` and `my $l = (1,2,3)` **both store `Value::Array(items, List)` (non-
+   itemized)**. `:=` is distinguished in the compiler via `MarkBindContext`
+   (`compiler/stmt.rs:768/795`), but the scalar-store path places the same bare List for bind/assign
+   (`normalize_scalar_assignment_value` does not itemize, `vm_var_assign_ops.rs:766`).
+   → **Container status is lost at the storage stage**. `$l.VAR.^name` is `Scalar` in both cases (raku says
+   `List` for a binding).
+2. When compiling `@a = $l`, `compile_assignment_rhs_for_target`
+   (`compiler/stmt.rs:233`) **unconditionally emits `OpCode::Itemize` whenever the target is
+   `@` and the RHS is `Expr::Var`** (`stmt.rs:245`).
+3. `OpCode::Itemize` (`vm.rs:1792`) converts `Array(.., List)` → `Array(.., ItemList)`.
+4. Array-assignment flattening respects the ArrayKind (`ItemList` → 1 element, `List` → flatten).
+   In fact `@a = (1,2,3)` (a literal, not going through a Var) yields 3 elements and `@a = $(1,2,3)` yields 1 element —
+   **these already work correctly**. The problem is (2): **a Var-mediated scalar read is unconditionally itemized**.
 
-### なぜ局所修正できないか
+### Why it cannot be fixed locally
 
-`stmt.rs:245` の `Itemize` を「束縛変数なら skip」したくても、**ランタイム値は束縛/代入で
-完全に同一**（どちらも bare `Array(.., List)`）。コンパイラも別宣言の `$l` の束縛性を知らない。
-→ 区別するには **格納レベルでコンテナ status を持たせる**しかない＝ Phase 1。
-束縛変数集合を別管理する等の局所ハックは、まさに戦略が警告する散在 workaround。
-
----
-
-## 3. 設計: decont を単一チョークポイントに集約する
-
-Rakudo/MoarVM 流。コンテナは**格納サイト**（変数スロット・配列/ハッシュ要素・属性）に
-のみ存在し、**値読み出しは VM のオペランド取得という唯一の経路で必ず decont**する。
-算術・比較・ディスパッチ等の値 op は「decont 済み」をスタックから pop するので**無変更**。
-コンテナが見えるのは明示的に lvalue/コンテナを要求する数少ない経路だけ:
-
-- `:=` bind（コンテナ差し替え）
-- `is rw` / `is raw` パラメータ（caller コンテナをエイリアス）
-- `.VAR` / `=:=`（コンテナ identity の reflection）
-- take-rw（要素コンテナの identity 保持）
-- itemization 判定（list 文脈で 1 要素か平坦化か）
-
-この設計なら消費面が「数百の値 op」→「上記一握り」に**反転**する。
-
-### mutsu での着地
-
-1. **canonical `decont()` の制定**: 現状 3 つの decont ヘルパを 1 つに統合
-   （`Scalar`/`ContainerRef`/item-flag をすべて剥がす単一関数）。これを VM の値読み出し
-   不変条件にする。
-2. **値スタック不変条件**: 「スタックに積む値は常に decont 済み」。lvalue/コンテナが要る
-   経路だけ専用 opcode（`GetLocalContainer`/`IndexContainer` 等）で生のセルを取得。
+Even if we wanted to make the `Itemize` at `stmt.rs:245` "skip if the variable is bound", **the runtime values are
+completely identical for bind and assign** (both are bare `Array(.., List)`). The compiler also does not know the boundness of a `$l` declared elsewhere.
+→ The only way to distinguish them is to **carry container status at the storage level** = Phase 1.
+Local hacks like separately tracking the set of bound variables are exactly the scattered workarounds the strategy warns against.
 
 ---
 
-## 4. 段階スライス（big-bang 回帰を避ける順序）
+## 3. Design: consolidate decont into a single chokepoint
 
-> **正準の実装順序は PLAN.md §🟣「実装順序（アーキテクチャ第一）」を参照。** 北極星は最もクリーン × 最速で、
-> 進捗メトリクスは **「削除した重複/特例メカニズムの数」**（roast 通過数ではない）。下の Phase 区分は地図として
-> 残すが、着手は「キーストーン = escape 解析」→「スカラーのセル化」の統合解決で進める（個別 boxing パッチを
-> 足さない）。
+The Rakudo/MoarVM way. Containers exist **only at storage sites** (variable slots, array/hash elements, attributes),
+and **value reads always decont through the single path of VM operand fetch**.
+Value ops for arithmetic, comparison, dispatch, etc. pop "already deconted" values from the stack, so they are **unchanged**.
+Containers are visible only on the few paths that explicitly request an lvalue/container:
 
-### 現状の重複（クロージャ捕捉だけで 4 メカニズム併存・step 1 で subsume → 削除）
+- `:=` bind (container replacement)
+- `is rw` / `is raw` parameters (aliasing the caller's container)
+- `.VAR` / `=:=` (reflection on container identity)
+- take-rw (preserving element container identity)
+- itemization decision (1 element vs flatten in list context)
 
-クロージャが捕捉変数を見るための機構が場当たりに 4 つ併存し、隙間（単一脱出クロージャ等）を残している。
-これらは escape 解析（PLAN.md 実装順序 step 1）が単一の needs-cell 判定に統合し、step 2 のセル化で**削除**する:
+With this design, the consumer surface **inverts** from "hundreds of value ops" → "the handful above".
 
-**⚠️ 2026-06-08 実証で確定: 下表の「step 2 で削除」想定は誤り。`multi_captured_mutated_locals` のみ #2758 で
-subsume・削除済み。残り 3 機構は非冗長で削除不可（理由は各行）。** PLAN.md §🟣 STATUS と一致。
+### Landing this in mutsu
 
-| 機構 | 役割 | 削除可否（実証） |
+1. **Establish a canonical `decont()`**: unify the current 3 decont helpers into 1
+   (a single function that strips `Scalar`/`ContainerRef`/item-flag all at once). Make this the VM's
+   value-read invariant.
+2. **Value-stack invariant**: "values pushed onto the stack are always deconted". Only paths that need an lvalue/container
+   fetch the raw cell via dedicated opcodes (`GetLocalContainer`/`IndexContainer` etc.).
+
+---
+
+## 4. Staged slices (an order that avoids big-bang regressions)
+
+> **The canonical implementation order is PLAN.md §🟣 "Implementation order (architecture first)".** The north star is cleanest × fastest, and
+> the progress metric is **"number of duplicated/special-case mechanisms deleted"** (not the roast pass count). The Phase breakdown below remains as
+> a map, but work proceeds via the unified resolution "keystone = escape analysis" → "cell-ification of scalars" (do not add
+> individual boxing patches).
+
+### Current duplication (4 mechanisms coexist for closure capture alone; step 1 subsumes → delete)
+
+There are 4 ad-hoc mechanisms for a closure to see its captured variables, leaving gaps (e.g. single escaping closures).
+Escape analysis (PLAN.md implementation order step 1) unifies these into a single needs-cell decision, and step 2's cell-ification **deletes** them:
+
+**⚠️ Confirmed by the 2026-06-08 experiments: the "delete in step 2" assumption in the table below is wrong. Only `multi_captured_mutated_locals`
+was subsumed and deleted in #2758. The remaining 3 mechanisms are non-redundant and cannot be deleted (reasons on each row).** Consistent with PLAN.md §🟣 STATUS.
+
+| Mechanism | Role | Deletable? (empirical) |
 |------|------|----------------|
-| `owned_captures`（`compute_owned_captures`） | ループ per-iteration **値凍結** | ❌ read-only 捕捉はセル化されず代替不可 |
-| `closure_captured_state`（per-instance 値凍結 + writeback） | 返却クロージャの state 維持 | ❌ 事前コンパイル deserialize で load-bearing（セルはシリアライズ不可、`precompilation.t` 回帰）|
-| `box_captured_lexicals` | 捕捉時セル生成（escape/loop） | ❌ 捕捉時が正位置。宣言時移設は `let`/`temp` 復元を壊す（`let.t` 回帰）|
-| `multi_captured_mutated_locals`（#2751） | 兄弟クロージャ boxing（暫定 proxy） | ✅ #2758 escape 信号が subsume・削除済み |
+| `owned_captures` (`compute_owned_captures`) | Loop per-iteration **value freezing** | ❌ read-only captures are not cell-ified, no substitute |
+| `closure_captured_state` (per-instance value freeze + writeback) | State maintenance for returned closures | ❌ load-bearing for precompiled deserialize (cells cannot be serialized, `precompilation.t` regression)|
+| `box_captured_lexicals` | Cell creation at capture time (escape/loop) | ❌ capture time is the right place. Moving to declaration time breaks `let`/`temp` restore (`let.t` regression)|
+| `multi_captured_mutated_locals` (#2751) | Sibling-closure boxing (interim proxy) | ✅ subsumed by the #2758 escape signal, deleted |
 
-env snapshot（`clone_env`/`flattened`）は捕捉の土台として残る。**セルは「ランタイム共有変異」は包含するが、
-宣言時機構（let/temp）・シリアライズ・read-only 値凍結 は包含しない**ので、上 3 機構はセルを*補完*する別役割。
+The env snapshot (`clone_env`/`flattened`) remains as the foundation of capture. **Cells subsume "runtime shared mutation" but do NOT subsume
+declaration-time mechanisms (let/temp), serialization, or read-only value freezing**, so the top 3 mechanisms play distinct roles that *complement* cells.
 
-### step 2 の撤回ログ（2026-06-08）
+### Step 2 retraction log (2026-06-08)
 
-- **「box を宣言時へ移設して削除」= 試行→revert**: 捕捉ローカルは block/loop/sub で sigil 無し名（`a`）＝
-  `simple=false`→slow path、と解明し動かしたが、`let`/`temp` 復元（`S04-blocks-and-statements/let.t`）を決定的回帰。
-  宣言時セル化が `let`-save より前に走り save がセル Arc を保存し復元不可。**box は捕捉時が正位置。**
-- **「closure_captured_state を削除」= 試行→close（PR #2765）**: step 1 で代入/返却クロージャがセル化され冗長と
-  仮説。無効化→make test PASS・166 state-sensitive ファイル release 0-fail。だが `S10-packages/precompilation.t`
-  （GH2897）を回帰: `gen-counter` の返すクロージャは BEGIN/事前コンパイル時に生成・**ディスク serialize** され、
-  ContainerRef セルはプロセス跨ぎで保存されないため deserialize 後は本副テーブルが per-call 状態を担う＝**load-bearing**。
-- **教訓**: ①セル化の境界（runtime 共有変異のみ）。②これら release-only 回帰は `make test` を通過する — クロージャ
-  捕捉に触る変更は **release で main vs branch 比較** ＋ `precompilation.t` を必ず含める。③container の機構削除はここで
-  頭打ち。残る正しさは PLAN.md §🟣「機会的バックログ」で単発対応。
+- **"Move box to declaration time and delete it" = attempted → reverted**: We worked out that captured locals in block/loop/sub have sigil-less names (`a`) =
+  `simple=false` → slow path, and got it running, but it deterministically regressed `let`/`temp` restore (`S04-blocks-and-statements/let.t`).
+  Declaration-time cell-ification runs before the `let`-save, so the save stores the cell Arc and restore becomes impossible. **Boxing at capture time is the right place.**
+- **"Delete `closure_captured_state`" = attempted → closed (PR #2765)**: Hypothesis was that step 1 cell-ifies assigned/returned closures making it redundant.
+  Disabled it → make test PASS, 166 state-sensitive files release 0-fail. But it regressed `S10-packages/precompilation.t`
+  (GH2897): the closure returned by `gen-counter` is created at BEGIN/precompilation time and **serialized to disk**;
+  ContainerRef cells are not preserved across processes, so after deserialize this side table carries per-call state = **load-bearing**.
+- **Lessons**: (1) the boundary of cell-ification (runtime shared mutation only). (2) These release-only regressions pass `make test` — any change touching closure
+  capture must **compare main vs branch in release** and always include `precompilation.t`. (3) Mechanism deletion for containers hits its ceiling here.
+  The remaining correctness items are handled one-off in PLAN.md §🟣 "Opportunistic backlog".
 
-### Phase 0 — decont チョークポイント整備（挙動不変）
-- [ ] 3 つの decont ヘルパを単一 `decont()` に統合（`value/mod.rs`）。既存呼び出しを置換、
-      挙動は完全不変＝ roast 完全一致で検証。
-- [ ] 値読み出し経路を棚卸しし、「decont 済みを積む」不変条件を確立。lvalue 専用 opcode を追加
-      （まだコンテナは殆ど無いので挙動不変）。
-- 検証: `make test` + 全 roast 完全一致（差分ゼロが Phase 0 の合格条件）。
+### Phase 0 — decont chokepoint groundwork (behavior-preserving)
+- [ ] Unify the 3 decont helpers into a single `decont()` (`value/mod.rs`). Replace existing call sites;
+      behavior fully unchanged = verified by exact roast match.
+- [ ] Inventory the value-read paths and establish the "push deconted values" invariant. Add lvalue-only opcodes
+      (behavior-preserving since there are still almost no containers).
+- Verification: `make test` + full roast exact match (zero diff is the pass criterion for Phase 0).
 
-### Phase 1 — スカラーの第一級コンテナ化
-- [ ] `$` 変数が `Scalar` セルを保持。`=` はセルへ格納、`:=` は束縛差し替え（bare 値）、
-      itemization はセル wrap。`§2` の格納段階コンテナ status を実装。
-- [ ] `stmt.rs:245` の無条件 `Itemize` を、**コンテナ保持変数のときだけ itemize** に変更
-      （束縛変数の bare List は平坦化）。
-- 解ける: reduce.t 62, `=:=`/`.VAR`（スカラー）, 兄弟クロージャ共有（レバー C 完了）,
-  S02 variables-and-packages 変数捕捉, S03-binding/scalars。
+### Phase 1 — first-class containerization of scalars
+- [ ] `$` variables hold a `Scalar` cell. `=` stores into the cell, `:=` swaps the binding (bare value),
+      itemization is a cell wrap. Implement the storage-stage container status of `§2`.
+- [ ] Change the unconditional `Itemize` at `stmt.rs:245` to **itemize only when the variable holds a container**
+      (a bound variable's bare List flattens).
+- Solves: reduce.t 62, `=:=`/`.VAR` (scalar), sibling-closure sharing (lever C completed),
+  S02 variables-and-packages variable capture, S03-binding/scalars.
 
-### Phase 2 — 配列/ハッシュ要素のコンテナ化
-- [ ] 要素を COW な `Arc<Vec<Scalar>>` 等のセルに。最もホットな表現なので Phase 1 の後。
-- 解ける: take-rw（gather.t 38）, `@a[0] :=`, 深い `>>++`/`deepmap(++*)`（hyper.t 330-333）,
-  object-hash, S12-methods/accessors, S12-attributes/instance, S03-binding/nested。
+### Phase 2 — containerization of array/hash elements
+- [ ] Make elements cells like COW `Arc<Vec<Scalar>>`. This is the hottest representation, so it comes after Phase 1.
+- Solves: take-rw (gather.t 38), `@a[0] :=`, deep `>>++`/`deepmap(++*)` (hyper.t 330-333),
+  object-hash, S12-methods/accessors, S12-attributes/instance, S03-binding/nested.
 
-#### 調査記録 2026-06-11（プロトタイプ実証 → 段階順を確定。コードは revert）
+#### Investigation record 2026-06-11 (prototype experiment → staged order fixed. Code reverted)
 
-ユーザー方針 (2026-06-11): 「束縛要素のみセル化（escape-aware）」で進める — 全要素をセル化せず、
-`:=` で束縛された要素だけを `ContainerRef` セルに昇格し、読みは単一チョークポイントで decont。
-プロトタイプを当て、**機構の正しさと write-surface の広さを実証**した（その後 revert）:
+User direction (2026-06-11): proceed with "cell-ify only bound elements (escape-aware)" — do not cell-ify all elements;
+promote only elements bound with `:=` to `ContainerRef` cells, and decont reads at a single chokepoint.
+A prototype was applied, **demonstrating both the correctness of the mechanism and the breadth of the write surface** (then reverted):
 
-- **現状の要素束縛は ad-hoc な後方参照**: `$x := @a[0]` は `Value::ArraySlotRef { array: Arc<Vec<Value>>,
-  index }`（`value/mod.rs` `array_slot_ref`、`IndexAutovivify` opcode 経由・`:=` バインド時のみ emit）を
-  `$x` に置く。`HashSlotRef`/`DeferredHashAccess` も同型。**浅い束縛（`$x:=@a[0]`/2 段）は動く**が、深い
-  `$struct[1]<key><subkey>[1]` は**後方参照が stale 化**して落ちる（nested.t 3/4/7/8/19/21/26/28/31-37/40-43）:
-  後続の write が経路を再解決する際、中間コンテナが COW で別 Arc にクローンされると SlotRef の捕捉 Arc が
-  古いまま＝書きが束縛変数に届かない。
-- **セルが正準解な理由（実証）**: 要素を `ContainerRef(Arc<Mutex<Value>>)` に昇格すると、**COW クローンでも
-  Arc<Mutex> はクローン間で共有**されるため、leaf セルの identity が任意深度の経路を跨いで生存する。
-  `array_slot_ref` を「要素を ContainerRef に in-place 置換し同じ cell を返す」へ変えると束縛が cell 共有になる。
-- **read チョークポイント**: 単一 int 読みは `resolve_array_entry`（`vm_var_ops.rs:146`）の `Some(value)=>value.clone()`
-  に `ContainerRef => cell.lock().clone()` を足せば decont される（**通常配列は ContainerRef 要素を持たないので no-op**）。
-- **❌ ブロッカー = write-surface が広い（"deref/write-through everywhere"）**: `@a[i] = v` の要素書きが
-  **十数箇所**に散在（`vm_var_assign_ops.rs` の 158/180/2511/2622/2692/3070… + 深い/named/generic index-assign の各
-  arm、`array_slot_write`）。各サイトで「既存要素が ContainerRef なら cell へ write-through、でなければ置換」が要る。
-  1 箇所でも漏らすと、その経路の書きが leaf cell を**置換して束縛を切る**（プロトタイプで単一レベル `@a[0]=99` が
-  別経路を通り束縛が切れて実証）。同様に slice/iteration/`.raku`/native method の**要素 read も items を直接舐める**ので
-  ContainerRef がそれらに漏れる（"deref everywhere" 回帰の入口）。
+- **Current element binding is an ad-hoc back-reference**: `$x := @a[0]` places `Value::ArraySlotRef { array: Arc<Vec<Value>>,
+  index }` (`value/mod.rs` `array_slot_ref`, emitted only on `:=` bind via the `IndexAutovivify` opcode) into
+  `$x`. `HashSlotRef`/`DeferredHashAccess` are the same shape. **Shallow binds (`$x:=@a[0]`/2 levels) work**, but deep
+  `$struct[1]<key><subkey>[1]` fails because **the back-reference goes stale** (nested.t 3/4/7/8/19/21/26/28/31-37/40-43):
+  when a subsequent write re-resolves the path, if an intermediate container is cloned to a different Arc by COW, the SlotRef's captured Arc
+  stays old = writes no longer reach the bound variable.
+- **Why cells are the canonical solution (demonstrated)**: promoting an element to `ContainerRef(Arc<Mutex<Value>>)` means the
+  **Arc<Mutex> is shared across clones even under COW clone**, so the leaf cell's identity survives across paths of arbitrary depth.
+  Changing `array_slot_ref` to "replace the element in-place with a ContainerRef and return the same cell" makes the binding cell-shared.
+- **Read chokepoint**: a single int read decontifies by adding `ContainerRef => cell.lock().clone()` to the `Some(value)=>value.clone()`
+  in `resolve_array_entry` (`vm_var_ops.rs:146`) (**ordinary arrays have no ContainerRef elements, so this is a no-op**).
+- **❌ Blocker = the write surface is wide ("deref/write-through everywhere")**: element writes for `@a[i] = v` are scattered across
+  **a dozen-plus sites** (`vm_var_assign_ops.rs` 158/180/2511/2622/2692/3070… plus each deep/named/generic index-assign
+  arm, `array_slot_write`). Each site needs "if the existing element is a ContainerRef, write through the cell; otherwise replace".
+  Miss even 1 site and that path's write **replaces the leaf cell and severs the binding** (demonstrated in the prototype: single-level `@a[0]=99` went
+  through a different path and severed the binding). Likewise, slice/iteration/`.raku`/native-method **element reads scan the items directly**, so
+  ContainerRef leaks into them (the entrance of the "deref everywhere" regression).
 
-#### 確定した段階順（次セッションはここから）
+#### The staged order that was fixed (next session starts here)
 
-big-bang は不可。**Phase 3 Stage 0 と同じく「チョークポイントを先に確立（挙動不変）」してからセル切替**する:
+Big-bang is impossible. Like Phase 3 Stage 0, **"establish the chokepoints first (behavior-preserving)", then switch to cells**:
 
-- [~] **Stage 0+1 — 配列要素の束縛セル化（着手・RHS 束縛 landed）**: Stage 0（write チョークポイント）と
-  Stage 1（cell 切替）を 1 PR に統合実装:
-  - **write チョークポイント** `Value::assign_element_slot(slot, val)`（ContainerRef なら write-through、でなければ
-    置換）を新設し、配列要素 write の主要経路にルーティング（`assign_array_multidim` の leaf、`exec_index_assign_*`
-    の単一 int / 2-level / deep-nested arm）。
-  - **read decont** を `resolve_array_entry` / `resolve_hash_entry`（単一読みチョークポイント）に追加（通常配列は
-    ContainerRef 要素を持たないので no-op）。
-  - **cell 切替** `array_slot_ref` を「要素が *スカラー leaf* なら `ContainerRef` へ in-place 昇格、Array/Hash の
-    *中間* 要素は従来 `ArraySlotRef`（Arc 共有 traversal を保持）」に。`$x` は同じ cell の ContainerRef を持ち、
-    Phase 1 のスカラー cell 機構を再利用。**escape-aware**: 昇格は `:=` 束縛時のみ＝通常配列は bare 値のまま
-    （perf 崖回避。#2746 の轍を踏まない）。
-  - **値コンテキスト透過化**: 束縛要素 cell が native メソッドの raw items 読みで leak しても無害になるよう、
-    `to_int`/`to_float_value`/`to_f64`/`arith_*`（reduce 等が raw items を fold）を ContainerRef decont 対応に。
-  - **解けた**: 単一/2-level/深い array/hash 混在パスの **RHS 要素束縛**（`$x:=@a[i]`、`$x:=$s[1][1]`、
-    `$abbrev:=$struct[1]<key><subkey>[1]`）— 書きが COW を跨いで届く（cell 共有が SlotRef の stale を解消）。
-    nested.t 25→30。`make test` 緑（native-array-mut.t の flaky は Arc-ptr メタ既存・main と同率 ~35%）、
-    common 配列/ハッシュ操作で leak なし。`t/element-bind-cell.t` 13 ケース。
-  - **残（次スライス）**: LHS 束縛（`$struct[..]:=$var`、nested.t 7/8/26/28）・要素間束縛（`$a[i]:=$b[j]`、31-37）は
-    BOUND_*_REF sentinel / varref 機構なので別途。ハッシュ要素の cell 化（`%h<k>:=` 深いパス）も未（HashSlotRef のまま）。
-  - **調査記録 2026-06-11（hash 要素 cell 化を試行 → revert）**: `hash_autovivify` / `hash_slot_ref_lazy` に
-    array 同型の scalar-leaf 昇格（`promote_hash_entry_cell`）と単一 hash-key write の write-through（`exec_index_assign_expr_named`
-    の 3115 付近）を入れたが、**nested.t が 30→7 に激減＋ hash bind 自体も write-through せず**で revert。array 経由の
-    深い束縛（`$struct[1]<key><subkey>[1]`）はハッシュ中間層を多数の hash-read/write 経路で traverse しており、hash 昇格が
-    それらと干渉した。**教訓**: hash 要素 cell 化は (a) 全 hash element read を `resolve_hash_entry` 系チョークポイントに
-    集約し、(b) 全 hash insert（`vm_var_assign_ops` に ~15 箇所: 163/1843/2144/2180/2614/2762/2784/3096/3113/3934…）を
-    write-through ヘルパへルーティングしてから、で**ないと array-through-hash が壊れる**。array より write-surface が広い。
-    順序: まず hash write チョークポイント確立（挙動不変）→ それから昇格、と array と同じ Stage 0→1 を hash でも踏む。
-  - [x] **ハッシュ要素 Stage 0 — write チョークポイント確立（挙動不変・landed）**: 全 Raku-hash-value の
-    要素 write を新ヘルパ `Value::hash_insert_through(map, key, val)`（`value/mod.rs`、`assign_element_slot` の
-    hash 版＝既存 entry が `ContainerRef` なら write-through、でなければ insert/replace）へルーティング。配線済みサイト:
-    `vm_var_assign_ops.rs` の 1843（typed hash element）/ 2144（fast-path 単一 hash key）/ 3115（generic index-assign
-    の plain insert 分岐）/ 3699・3703（nested hash-in-hash）/ 3759（深い hash-in-hash）/ 3934（deep multidim final-level、
-    既存インライン write-through を helper へ抽出）/ 4017（interior-mutation hash write）＋ `value/mod.rs` の
-    `hash_assign_at` / `hash_slot_write`。**brand-new 空 map への insert**（2180/3350/3373/3953 等、`contains_key` 後の
-    autoviv 中間層 3873/3910）は既存 entry が無く ContainerRef になり得ないので routing 不要・据え置き。
-    現状はどの hash も ContainerRef entry を持たないので全呼びが plain insert/replace に縮退＝**挙動不変**（nested.t 30/43
-    維持、`make test` 緑、`hash_chokepoint_tests` 3 ケース）。
-  - [x] **ハッシュ要素 Stage 1 — 束縛 hash 要素の cell 昇格（landed）**: `array_slot_ref` 対称の新ヘルパ
-    `Value::hash_slot_ref(key)`（`value/mod.rs`）を新設し、`:=` 束縛経路（`exec_index_autovivify_lazy_op` の
-    `Value::Hash` arm、`vm_var_index_ops.rs`）を `hash_slot_ref_lazy` から差し替え。挙動: **既存 scalar leaf** →
-    `ContainerRef` cell へ in-place 昇格（COW を跨いで生存）、**既存 Array/Hash 中間層** → 従来 `HashSlotRef` 保持
-    （深い traversal を壊さない）、**欠落 key** → lazy のまま（write まで生成しない）。解けた: **深い hash leaf RHS 束縛**
-    `my $y := %g<outer><inner>; %g<outer><inner> = 55; say $y # 55`（旧 HashSlotRef は inner hash の COW で stale→10）。
-    - **過剰昇格バグ＋修正**: 中間 `%h<key>()...` の `<key>` が **Sub 値**（callable）の場合、bind context が CallOn の
-      invocant にまで伝播して `<key>` を cell 化→`()` が ContainerRef を decont できず "CALL-ME on Sub" で abort
-      （nested.t がテスト 9 後に全 abort）。修正: `compile_expr_call_on`（`expr_block.rs`）で `scalar_bind_autovivify` を
-      save/false/restore（call の invocant・args は値読みで bind target ではない＝escape analysis の call-arg リセットと同型）。
-    - **leak 修正**: hash `.values`（`collection.rs`）が ContainerRef を decont せず collect→`.sort`/比較が壊れる
-      （`%h.values.sort` が `10,2,3`）。`v.deref_container()` で decont（**array `.values` にも同型の既存 leak あり**＝別途）。
-    - 検証: nested.t 30/43 維持（Failed 7-8/11-12/26/28/31-37 は LHS/element-element の別機構で不変）、`make test` 緑
-      （native-array-mut.t 26 は Arc-ptr メタ既存 flaky・main 3/8≈branch）、int.t 0.16s（perf 崖なし＝escape-aware で
-      `:=` 束縛要素のみ昇格）、`t/element-bind-cell.t` 22 ケース（hash leaf 単一/深い + callable 非昇格 + iteration 非 leak）。
-    - **残（Stage 2 へ）**: 欠落 key の lazy 束縛は DeferredHashAccess のまま（write で生成・promote）。slice/`.kv`/`.pairs`/
-      `.raku` 等の他 raw-items 読みは cell leak の可能性（束縛要素限定で稀＝CI release roast で炙り出す）。
-  - [x] **深い LHS 束縛の cell 化（landed・Stage 2 着手）**: `$struct[..]<..>[..] := $scalar`（`IndexAssignDeepNested`
-    → `exec_index_assign_deep_nested_op`）に bind 処理を新設。従来この handler は bind_mode を一切扱わず `val`（bind payload）
-    を生のまま代入していた＝深い LHS 束縛が完全に未動作だった。新ヘルパ `unwrap_bind_index_value`（payload 展開）で
-    `(val, source)` を取り出し、**plain scalar source**（`\0idx\0` 無し）に限り: ①`val` で `ContainerRef` cell 作成、
-    ②final-level で element に同 cell を直接格納（fresh `:=` は write-through でなく置換）、③ループ後に同 cell を source 変数
-    スロット（`set_env_with_main_alias` + `update_local_if_exists`）へ書き戻し。両側が同 cell を共有＝RHS の対称形で、既存
-    read（`resolve_array_entry` decont）/ write（`assign_element_slot` write-through）/ scalar var cell（Phase 1）チョークポイント
-    を再利用。COW を跨いで生存（旧 `BOUND_ARRAY_REF_SENTINEL` の by-name back-ref は深さで stale だった）。
-    - 結果: **nested.t 13→7**（7-8/26/28/31/34 を修正）、`make test` 緑、int.t 0.21s、let.t PASS（let/temp×cell OK）、
-      `t/element-bind-cell.t` 31 ケース。単一レベル LHS 束縛（`@a[0]:=$v`、sentinel 経路 `IndexAssignExprNamed`）は未変更で温存。
-    - **残**: ①`<key>()` を挟む LHS 束縛（nested.t 11-12、`IndexAssignGeneric`/method-lvalue 経路）。②element-element 束縛
-      （`$a[i]:=$b[j]`、nested.t 32-33/35-37、`\0idx\0` encoded source）。
-  - [x] **単一レベル LHS 束縛の cell 化＋配列コピー decont（landed）**: `@a[i] := $scalar`（`IndexAssignExprNamed` の
-    単一-int array arm）を `BOUND_ARRAY_REF_SENTINEL` から cell へ移行。plain scalar source 限定で element に `ContainerRef`
-    cell を格納＋ source 変数へ書き戻し（`pending_source_cell`、deep handler と同型）。element source（`\0idx\0`）は当面 sentinel
-    温存。cell-bind は `mark_bound_index` 不要（cell 自体が alias）。**副次バグ修正**: `my @new = @array`（配列値コピー）が
-    `coerce_to_array`（`runtime/utils.rs`）で items Arc を共有＝**cell 要素が漏れて snapshot されない**（`$var` 書きが copy に
-    伝播）。これは LHS だけでなく **RHS 束縛の pre-existing leak**でもあった（Stage 1 #2902）。cell 要素がある場合のみ
-    `deref_container()` で decont（Raku の `=` 値意味論。通常配列は Arc 共有のまま＝perf 維持）。arrays.t 回帰修正＋RHS leak も解消。
-    nested.t 7 維持、`make test` 緑、int.t 0.16s、`t/element-bind-cell.t` 35 ケース（LHS/RHS の copy-snapshot 含む）。
-    **sentinel 削除はまだ**（element source bind ②と read 経路が残存利用）。
-  - **調査記録 2026-06-11（element-element / container-leaf 束縛 = 最難・プロトタイプ revert）**: nested.t 32-37 と
-    `my $x := $foo[1]<key>`（**container-valued な終端要素**への束縛）を解こうとした。**再挑戦用の実装プラン（プロトタイプ
-    コード片・残作業・循環安全性・leak チェックリスト・検証手順を埋め込み済み）= `docs/element-element-bind-plan.md`。**
-    プロトタイプ（その後 revert）の知見:
-    - **根本**: container 値の束縛終端要素（`$foo[1]<key>` が Hash）が HashSlotRef のままで COW stale。RHS scalar-leaf と異なり
-      **container leaf を cell 化**する必要。だが `array_slot_ref`/`hash_slot_ref` は深い traversal 用に Array/Hash leaf を
-      cell 化しない設計。→ **terminal-promotion** で解決: 束縛 RHS の最外（終端）index を compiler フラグ `bind_terminal`
-      ＋新 op `IndexAutovivifyLazyTerminal` で識別し、終端だけ container leaf も cell 昇格（中間は SlotRef 保持）。`=:=` には
-      非適用（過剰昇格回避）。terminal フラグは stmt.rs:767 ＋ SyntheticBlock/MarkBind 経路（helpers_block_inline）両方で要設定。
-    - **しかし container cell への深い write-through が全 assign handler に波及**: cell が **Hash/Array を保持**するため、
-      `%h<key><inner>=50`（cell 経由の深い write）は assign handler が ContainerRef 中間/root を decont して **cell の内側
-      container を in-place 変異**せねば届かない。素朴には match が `_=>{}` で **write が落ちる**。対処として
-      (a) 2-level nested handler に `assign_into_nested_container`（ContainerRef descent）, (b) deep handler の raw-pointer walk に
-      `descend_container_ref`（Mutex data ポインタへ降りる）を入れたら **単一レベル container 束縛は解決**（`my $x:=%h<key>` の
-      双方向 OK）。だが **RHS container-leaf は 1/3 方向のみ**（逆方向 `$x<subkey>[1]=8` は root `$x` 自身が cell＝nested/generic
-      handler が root を Hash として読めず write 落ち）、**element-element は未解決**。
-    - **結論＝最難たる所以**: container-leaf cell は **全 index-assign handler（named/nested/deep/generic）の root 読みと
-      中間 traversal すべてに ContainerRef-descent が要る**（"deref everywhere" surface）＋ **循環安全性**（nested.t 268+ の
-      自己参照束縛で descend ループが無限ループ化しうる）＋ **container cell の leak 硬化**（iteration/.raku/slice）。
-      単一 PR では安全に閉じない。terminal-promotion 機構と 2 つの descent ヘルパは有効だが、root-cell descent の全 handler
-      展開＋循環検出＋leak 検証を伴う専用作業が要る。プロトタイプは binding sweep 回帰無しだが target（32-37）未修正・
-      make test full 未確認のため revert。再挑戦時はこの順で: ①terminal-promotion ②全 handler root/中間 descent（循環検出付き）
-      ③container-cell leak 硬化 ④release roast。
-  - **✅ LANDED (PR #2922 + #2925, 2026-06-12)**: 上記プランを Phase 1-5 順で逐語適用し element-element /
-    container-leaf / cyclic 束縛を実装、`docs/element-element-bind-plan.md` 通りに完遂。**nested.t 43/43（ホワイト
-    リスト追加）**。#2922 が 32-37（terminal-promotion ＋ `assign_into_nested_container`/`descend_container_ref` ＋
-    nested/named handler の `env_root_descended_mut` root descent ＋ RHS の `compile_bind_index_value` terminal
-    promotion ＋ read-side decont ＋ `MAX_DESCENT` 循環ガード ＋ `.raku`/`.gist` leak 硬化）。**プラン外で発見した真因**:
-    deep-nested traversal の中間 array level の `needs_viv` が既存 `ContainerRef` 要素を vivify で上書き破壊（cyclic の
-    off-by-one の正体）→ `needs_viv` から `ContainerRef` 除外で解決。#2925 が 11-12（`$struct[1]<key>()<subkey>[1]`
-    = `is raw` sub mid-path 束縛）: stack-target IndexAssign の generic handler Array arm を `assign_element_slot` 経由に
-    して bound cell を write-through（直接置換が cell を破壊していた）。`t/element-bind-cell.t` 35→54。
-- [x] **`is rw` param 真の共有セル（scalars.t 24/27）= LANDED (#2928)**: `is rw` param への `:=` 再束縛が
-  live `ContainerRef` cell で caller 変数と共有される。take-rw も #2930 で landed（gather.t 38）。
-  実装プラン（履歴）= `docs/is-rw-shared-cell-plan.md`。scalars.t 33/33。
-- [~] **Q2 型メタ Arc-ptr flaky の構造的除去（2026-06-12、2 本立て）**:
-  - **① Hash = HashData 埋め込み（完全吸収）DONE (#2952)**: `Value::Hash(Arc<HashData>)` に
-    value_type/key_type/declared_type を埋め込み、`hash_type_metadata` 副テーブルと
-    `reconcile_hash_type_metadata_from_name` を削除。メタが COW と共に移動＝ptr 再利用の誤継承が Hash で消滅。
-    計画・残作業（original_keys の埋め込み = Stage 2、その後 Array/Set/Bag/Mix へ同 wrapper 展開）=
-    `docs/hashdata-migration-plan.md`。
-  - **② 未 wrapper テーブルの Weak-guard 化 (#2953)**: `runtime/ptr_keyed.rs` の `PtrKeyedMap`
-    （`HashMap<usize,(Weak<T>,V)>`）へ: `array/mix/set/bag_type_metadata`・`container_defaults`
-    （array/hash に分割）・utils グローバルの `shaped_array_ids`・`grep_view_bindings`。
-    - **機構**: エントリの `Weak` が ArcInner を pin → **エントリ生存中はアドレス再利用が物理的に不可能**＝
-      死んだ typed コンテナのメタを新コンテナが誤継承する間欠 flaky（S02-names-vars/perl.t・native-array-mut.t 等の
-      alloc 順依存死）が構造的に消滅。lookup は `strong_count>0` 検証、insert 時に閾値超過で dead エントリ sweep
-      （無限成長と pin メモリも解消）。`remove` は dead でも値を返す（pre-COW 回収 = migrate 用）。
-    - **衝突防御ハック撤去**: `clear_container_default`（+4 サイト）、`vm_call_method_mut_ops` の make_mut 後
-      防御 unregister ×2。
-    - **★ 重要副作用と対処**: `Weak` 保持により `Arc::make_mut` は strong==1 でも**必ず再配置**（weak>0 ルール）→
-      「unique 所有 in-place 変異はポインタ安定」という暗黙依存が壊れる（guard 付きコンテナのみ）。顕在化 3 経路を
-      heal: VM native push（`exec_array_push_op` に `capture_container_meta`/`restore_container_meta` = 型メタ+
-      `is default`）、interpreter push arm（`reattach_array_type_metadata`）、**`.WHICH` 安定性**（2-level nested
-      hash write の outer を strong==1 時は raw-ptr in-place 書き — cast は必ず `*mut HashData`、
-      hashdata-migration-plan の UB 教訓参照）。**新たな heal 漏れは「typed/shaped コンテナの変異後メタ消失」または
-      「.WHICH 変化」の形で出る** — tmp/typed-meta-smoke{,2}.raku / tmp/which-map.raku を main と比較が検出法。
-    - **hash original-keys 2 テーブル（`hash_object_keys`・`hash_original_keys_registry`）は意図的に対象外**:
-      object-hash 構築は反復 make_mut の in-place ポインタ安定性に依存しており（guard を被せると
-      S09-typed-arrays/hashes.t の .antipairs/.invert が回帰）、正解は ① Stage 2 の HashData 埋め込み。
-    - **残（未ガード）**: Seq 系 ptr-key（`predictive_seq_iters`・`squish_iterator_meta`・
-      `__mutsu_predictive_seq_iter::` env キー）と WHICH 文字列の `{:p}` 埋め込みは別サブシステムで同 hazard が残存（小）。
-    - 検証: cargo test 466（PtrKeyedMap 単体 5 含む、stale-inheritance 不可能性の決定的テスト）、make test 727/6588、
-      whitelist S09×17 + perl.t×3 + map.t + S02-types/hash.t + let.t + typed-hash canary 3467 テスト、int.t 0.163s。
-- [~] **Stage 2 — 深い `>>++`/`deepmap`/object-hash・既存 SlotRef 機構の撤去**（着手 2026-06-13、スライス進行中）:
-  - [x] **slice 1 = deepmap コンテナ渡し (#2964)**: leaf を transient `ContainerRef` cell 経由で callable に渡し、
-    呼び出し後に cell 値を source Array/Hash slot へ in-place 書き戻し（cell は残らない）。結果は decont して
-    identity block の cell leak を防止。hyper.t 330-333 修正（12→9 fail、残は nodal/callable 別機能)。
-    t/deepmap-container.t (16)。
-  - [x] **slice 2 = bind 経路の中間 SlotRef 撤去 (#2966)**: `exec_index_autovivify_lazy_op` の中間 Array/Hash
-    要素を SlotRef back-ref で包まず**要素値そのもの（inner Arc 共有）を返す** — #2902-#2925 後は leaf promotion が
-    共有 Arc 内で in-place に起きるため back-ref は不要だった。`array_slot_ref`/`hash_slot_ref` の中間 arm 2 箇所。
-  - [x] **slice 3 = BOUND_HASH_REF_SENTINEL 全廃**: 生成 3 経路（単一 hash-key bind named handler・
-    slice bind・`.BIND-KEY` ×2）を「`ContainerRef` cell を hash entry に格納 + source 変数へ同 cell
-    書き戻し」へ置換し、consumer（resolve_hash_entry/hash_has_sentinels/resolve_hash_for_iteration の
-    BOUND arm・sentinel write-through arm）と sentinel 定数を削除。設計ポイント:
-    (a) **element source（`%h<k> := @a[0]`）は val が既に LazyTerminal 昇格済みの cell** — そのまま entry に
-    格納（旧 sentinel は `\0idx\0` 名を env に書く壊れた経路で、hash-key write が element に届かなかったのを
-    正攻法修正）。(b) **cell 再利用 pre-read**: source が既に cell-bound（`@arr[0] := $x; %h<k> := $x`）なら
-    既存 cell を共有（新 cell で上書きすると別 alias が切れる — これも既存バグ修正）。borrow 前に pre-read
-    する `BindSourceCell` 型。(c) **代入スナップショット**: `%new = %hash` は `resolve_hash_for_iteration` で
-    cell を decont（assignment creates new containers、S03-binding/hashes.t 30）。(d) `@`/`%` source の
-    cell-bound 変数への `.push` は `exec_array_push_op` fallback で decont→dispatch→cell 書き戻し
-    （array 側 #2914 由来の既存 fail も修正）。t/hash-bind-cell.t (19)。
-  - [x] **slice 4 = BOUND_ARRAY_REF_SENTINEL 全廃**: 単一レベル array element bind の生成（named handler の
-    `\0idx\0` element-source 分岐）を hash 側と同じ共有 `ContainerRef` cell へ。slice 3 の `bind_cell` pre-read を
-    target 非依存に一般化（`hash_bind_cell`→`bind_cell`、array/hash 両 arm が消費）し、array element-source
-    （`@x[i] := @b[j]`）も hash と同じく LazyTerminal 昇格済み cell をそのまま格納。consumer 全廃:
-    `resolve_array_entry` の BOUND arm + `resolve_bound_source` ヘルパ・`resolve_bound_array_elements`（sentinel
-    走査→cell decont へ）・`is_bound_index` staleness check（sentinel 有無判定→非cell 要素なら stale 掃除へ）・
-    `exec_container_eq_indexed_op`（`get_binding_source_of_indexed` の名前一致判定→`raw_element_at_encoded` で
-    両 slot の cell `Arc::ptr_eq`）。sentinel 定数削除。**バグ修正**: hash-element-source への array 経由
-    write-through（`@y[0] := %src<a>; @y[0] = v` が `%src<a>` に届かず "Cannot modify an immutable value"）が解消
-    （raku 一致）。`mark_bound_index` は cell 格納 bind ではスキップ（`stored_bind_cell` フラグ）。t/array-bind-cell.t (14)。
-    **温存**: 別機構の `WrapVarRef`/`__mutsu_varref_*` capture（`\($a)`・`key=>$var` write-through、binding.rs:499/506）は
-    array element に格納されうるので `varref_target` 分岐は維持。
-  - [x] **slice 5 = whole-container source の深い write-through**: `@h[i] := @inner; @h[i][j] = v` が `@inner[j]` に
-    届かなかった根本原因 = array-as-outer の nested-assign 経路（vm_var_assign ~3780）で `arr[inner_i]` が `ContainerRef`
-    cell のとき `needs_viv`（`!matches!(Array|Hash)`）が true → cell を空配列で**上書き**。修正 = needs_viv を ContainerRef
-    も除外 + match に ContainerRef arm 追加 → `assign_into_nested_container`（既に cell 降下・array resize・hash insert
-    対応済み）へ委譲。**whole-container source は bind 時に `@inner` も同一 cell へ rebind 済み**（pending_source_cell）
-    なので、deep write が cell を辿れば source 側 alias にも届く（`@h[i][j]=v`→`@inner[j]`、push 併用・複数 sibling
-    bind の共有も raku 一致）。array-valued/hash-valued source・hash-key bound・sibling 共有を t/array-bind-cell.t (20)
-    で pin。
-  - **残スライスのマップ** — 詳細設計は **`docs/slotref-removal-plan.md`**（cells-everywhere
-    課題の役割分離・phantom-entry・hazard 監査・段階スライスを固めた専用 doc）:
-    - [x] **slice 1 = computed-target `:=` bind の cell 化 (#2974)**: `IndexAssignGeneric` の
-      `HashSlotRef`/`ArraySlotRef`-into-env を cell へ（現役かつ write-through バグも修正）。
-    - [x] **slice 2 = デッド `ArraySlotRef` variant 全削除**: slice 1 が最後の生成サイト（4291）を
-      消したため variant 生成ゼロ＝完全デッド → variant 定義・`array_slot_read/write`・全 consumer
-      arm を削除。挙動不変。**重要訂正**: 当初の「plain write-autoviv カーソル非 Value 化」案は
-      実在せず不採用 — `%h<a><b> = 5` は `IndexAssignDeepNested` 経由で元々 SlotRef-free、非 lazy
-      `IndexAutovivify` opcode もデッド（plan §3 冒頭の訂正参照）。
-    - [x] **slice 3 = phantom-entry: 欠落 key bind の materialize を cell 化**: 欠落 key の `:=` bind
-      （`HashSlotRef`/`DeferredHashAccess`）を **first write で** 共有 `ContainerRef` cell へ materialize。
-      bound var↔hash entry が双方向 alias（materialize 後 cross-write 非伝播の **case-C バグ**を修正、raku 一致）。
-      `materialize_bound_slot_to_cell` ヘルパ・dead `deferred_hash_write` 削除。`t/phantom-entry-bind.t`(12)。
-      **token 残置が正解**: deferred token を Value から消すには map 内 phantom 表現（intermediate も lazy ゆえ
-      tombstone 不可）or side-table（ptr-keyed global＝anti-goal）が要る → materialize cell 化が phantom 本体。
-    - [x] **slice 4 = bind-descent の `hash_autovivify` を cell/shared-Arc 化 (#2966 系)**: bind 降下の
-      autoviv を `hash_autovivify_cell`（existing cell→そのまま / container leaf→shared Arc / scalar leaf→cell 昇格 /
-      missing→empty Hash）へ。`HashSlotRef` back-ref を撲滅。
-    - [x] **slice 5 = 最終 SlotRef キル = `HashSlotRef`+`DeferredHashAccess` を単一 `HashEntryRef{hash,path}` に統合
-      (#3472・2026-06-23)**: 全 variant 削除は **anti-goal の side-table 無しには原理的に不可能**（欠落 key bind の
-      deferred-vivification token は Value variant を要求）と確定。「`SlotRef` 概念の払拭＋単一 honest token への統合」で
-      `git grep 'SlotRef\|DeferredHashAccess' src/`=0 を達成。`parent_slot` チェーン廃止で 3 段以上の全欠落 path bind が動く
-      ようになった。詳細＝`docs/slotref-removal-plan.md` §0/slice 5。pin=`t/hash-entry-ref-deep-bind.t`。
-      - **意図的に未対応（zero-value・据え置き）**: `is raw` reduce lvalue-read の eager `hash_autovivify`（path-len-1 の
-        `HashEntryRef` を返す）の cell 化。**variant は deferred-token 用途で irreducible ゆえ cell 化しても消えず**、かつ
-        対象は **現 rakudo 自身が `assign requires a concrete object` でエラーにする寛容パス**（mutsu のみ通す）＝挙動も変えない。
-        純粋 internal purity で value ゼロのため据え置き。
-    - [x] **grep-rw-view 撤去 (#3466・2026-06-23)**: 登録ゲート下で matched 要素を cell 昇格し view registry
-      （ptr-keyed グローバル）を全廃（`for_grep_view`/`GrepView`/`grep_source`/index-based writeback・-90 行）。
-      `.grep` の rw topic は通常の要素 cell write パスで source に書き戻る。pin=`t/grep-cell-read-deref.t`。
+- [~] **Stage 0+1 — bind cell-ification of array elements (started; RHS binds landed)**: Stage 0 (write chokepoint) and
+  Stage 1 (cell switch) implemented together in 1 PR:
+  - **Write chokepoint** `Value::assign_element_slot(slot, val)` (write-through if ContainerRef, otherwise
+    replace) newly added, routed into the main array-element write paths (the leaf of `assign_array_multidim`, the single-int / 2-level /
+    deep-nested arms of `exec_index_assign_*`).
+  - **Read decont** added to `resolve_array_entry` / `resolve_hash_entry` (the single-read chokepoints) (ordinary arrays
+    have no ContainerRef elements, so this is a no-op).
+  - **Cell switch**: `array_slot_ref` becomes "if the element is a *scalar leaf*, promote in-place to `ContainerRef`; for Array/Hash
+    *intermediate* elements keep the traditional `ArraySlotRef` (preserving Arc-shared traversal)". `$x` holds a ContainerRef to the same cell,
+    reusing Phase 1's scalar cell mechanism. **Escape-aware**: promotion happens only at `:=` bind = ordinary arrays stay bare values
+    (avoids the perf cliff; not repeating the #2746 mistake).
+  - **Value-context transparency**: so that a bound-element cell leaking through a native method's raw items read is harmless,
+    `to_int`/`to_float_value`/`to_f64`/`arith_*` (reduce etc. fold raw items) were made ContainerRef-decont aware.
+  - **Solved**: **RHS element binds** across single/2-level/deep array/hash mixed paths (`$x:=@a[i]`, `$x:=$s[1][1]`,
+    `$abbrev:=$struct[1]<key><subkey>[1]`) — writes reach across COW (cell sharing resolves SlotRef staleness).
+    nested.t 25→30. `make test` green (native-array-mut.t flakiness is a pre-existing Arc-ptr meta issue, same rate as main ~35%),
+    no leaks in common array/hash operations. `t/element-bind-cell.t` 13 cases.
+  - **Remaining (next slices)**: LHS binds (`$struct[..]:=$var`, nested.t 7/8/26/28) and element-to-element binds (`$a[i]:=$b[j]`, 31-37) are
+    the BOUND_*_REF sentinel / varref mechanisms, handled separately. Cell-ification of hash elements (`%h<k>:=` deep paths) also not done (still HashSlotRef).
+  - **Investigation record 2026-06-11 (attempted hash element cell-ification → revert)**: added the array-analogous
+    scalar-leaf promotion (`promote_hash_entry_cell`) to `hash_autovivify` / `hash_slot_ref_lazy` and write-through for single hash-key writes (around 3115 in
+    `exec_index_assign_expr_named`), but **nested.t collapsed from 30→7 AND hash bind itself failed to write through**, so reverted. Deep binds via arrays
+    (`$struct[1]<key><subkey>[1]`) traverse hash intermediate layers via many hash read/write paths, and the hash promotion
+    interfered with them. **Lesson**: hash element cell-ification must first (a) consolidate all hash element reads into the `resolve_hash_entry`-family
+    chokepoints and (b) route all hash inserts (~15 sites in `vm_var_assign_ops`: 163/1843/2144/2180/2614/2762/2784/3096/3113/3934…)
+    through a write-through helper — **otherwise array-through-hash breaks**. The write surface is wider than arrays.
+    Order: first establish the hash write chokepoint (behavior-preserving) → then promote; follow the same Stage 0→1 as arrays for hashes.
+  - [x] **Hash elements Stage 0 — write chokepoint established (behavior-preserving; landed)**: routed all Raku-hash-value
+    element writes through the new helper `Value::hash_insert_through(map, key, val)` (`value/mod.rs`, the hash counterpart of
+    `assign_element_slot` = write-through if the existing entry is a `ContainerRef`, otherwise insert/replace). Wired sites:
+    `vm_var_assign_ops.rs` 1843 (typed hash element) / 2144 (fast-path single hash key) / 3115 (the plain insert branch of the generic index-assign)
+    / 3699 & 3703 (nested hash-in-hash) / 3759 (deep hash-in-hash) / 3934 (deep multidim final level,
+    extracting the existing inline write-through into the helper) / 4017 (interior-mutation hash write), plus `value/mod.rs`'s
+    `hash_assign_at` / `hash_slot_write`. **Inserts into brand-new empty maps** (2180/3350/3373/3953 etc., plus the post-`contains_key`
+    autoviv intermediate layers 3873/3910) have no existing entry and thus can never be a ContainerRef, so they need no routing and are left as-is.
+    Currently no hash holds ContainerRef entries, so all calls degenerate to plain insert/replace = **behavior unchanged** (nested.t 30/43
+    maintained, `make test` green, `hash_chokepoint_tests` 3 cases).
+  - [x] **Hash elements Stage 1 — cell promotion of bound hash elements (landed)**: added the new helper
+    `Value::hash_slot_ref(key)` (`value/mod.rs`), symmetric to `array_slot_ref`, and switched the `:=` bind path (the
+    `Value::Hash` arm of `exec_index_autovivify_lazy_op`, `vm_var_index_ops.rs`) over from `hash_slot_ref_lazy`. Behavior: **existing scalar leaf** →
+    promote in-place to a `ContainerRef` cell (survives across COW); **existing Array/Hash intermediate layer** → keep the traditional `HashSlotRef`
+    (do not break deep traversal); **missing key** → stay lazy (create nothing until write). Solved: **deep hash-leaf RHS binds**
+    `my $y := %g<outer><inner>; %g<outer><inner> = 55; say $y # 55` (the old HashSlotRef went stale when the inner hash COW-ed → 10).
+    - **Over-promotion bug + fix**: when the intermediate `<key>` in `%h<key>()...` is a **Sub value** (callable), the bind context propagated
+      all the way to the CallOn invocant and cell-ified `<key>` → `()` could not decont the ContainerRef and aborted with "CALL-ME on Sub"
+      (nested.t aborted entirely after test 9). Fix: in `compile_expr_call_on` (`expr_block.rs`), save/false/restore `scalar_bind_autovivify`
+      (a call's invocant and args are value reads, not bind targets = same shape as the call-arg reset in escape analysis).
+    - **Leak fix**: hash `.values` (`collection.rs`) collected ContainerRefs without deconting → `.sort`/comparison broke
+      (`%h.values.sort` yielded `10,2,3`). Decont with `v.deref_container()` (**array `.values` has the same pre-existing leak** = handled separately).
+    - Verification: nested.t 30/43 maintained (Failed 7-8/11-12/26/28/31-37 are the separate LHS/element-element mechanisms, unchanged), `make test` green
+      (native-array-mut.t 26 is the pre-existing Arc-ptr meta flake, main 3/8 ≈ branch), int.t 0.16s (no perf cliff = escape-aware,
+      only `:=`-bound elements are promoted), `t/element-bind-cell.t` 22 cases (hash leaf single/deep + callable non-promotion + iteration non-leak).
+    - **Remaining (to Stage 2)**: missing-key lazy binds remain DeferredHashAccess (create & promote on write). Other raw-items reads such as slice/`.kv`/`.pairs`/
+      `.raku` may leak cells (rare since limited to bound elements = flush out via CI release roast).
+  - [x] **Cell-ification of deep LHS binds (landed; Stage 2 started)**: added bind handling to `$struct[..]<..>[..] := $scalar` (`IndexAssignDeepNested`
+    → `exec_index_assign_deep_nested_op`). Previously this handler did not handle bind_mode at all and assigned `val` (the bind payload)
+    raw = deep LHS binds were entirely non-functional. The new helper `unwrap_bind_index_value` (payload unwrap) extracts
+    `(val, source)`, and only for a **plain scalar source** (no `\0idx\0`): (1) create a `ContainerRef` cell from `val`,
+    (2) at the final level store that same cell directly into the element (a fresh `:=` is a replacement, not a write-through), (3) after the loop write the same cell back to the source variable
+    slot (`set_env_with_main_alias` + `update_local_if_exists`). Both sides share the same cell = the symmetric form of RHS, reusing the existing
+    read (`resolve_array_entry` decont) / write (`assign_element_slot` write-through) / scalar var cell (Phase 1) chokepoints.
+    Survives across COW (the old `BOUND_ARRAY_REF_SENTINEL` by-name back-ref went stale with depth).
+    - Result: **nested.t 13→7** (fixed 7-8/26/28/31/34), `make test` green, int.t 0.21s, let.t PASS (let/temp × cell OK),
+      `t/element-bind-cell.t` 31 cases. Single-level LHS binds (`@a[0]:=$v`, the sentinel path `IndexAssignExprNamed`) left unchanged for now.
+    - **Remaining**: (1) LHS binds through `<key>()` (nested.t 11-12, the `IndexAssignGeneric`/method-lvalue paths). (2) element-to-element binds
+      (`$a[i]:=$b[j]`, nested.t 32-33/35-37, `\0idx\0`-encoded source).
+  - [x] **Cell-ification of single-level LHS binds + array-copy decont (landed)**: migrated `@a[i] := $scalar` (the
+    single-int array arm of `IndexAssignExprNamed`) from `BOUND_ARRAY_REF_SENTINEL` to cells. Only for a plain scalar source, store a `ContainerRef`
+    cell into the element + write back to the source variable (`pending_source_cell`, same shape as the deep handler). Element sources (`\0idx\0`) keep the sentinel
+    for now. Cell binds do not need `mark_bound_index` (the cell itself is the alias). **Side bug fix**: `my @new = @array` (array value copy)
+    shared the items Arc in `coerce_to_array` (`runtime/utils.rs`) = **cell elements leaked and were not snapshotted** (writes to `$var` propagated into the copy).
+    This was also a **pre-existing leak for RHS binds**, not just LHS (Stage 1 #2902). Only when cell elements exist, decont with
+    `deref_container()` (Raku's `=` value semantics; ordinary arrays keep sharing the Arc = perf preserved). Fixed the arrays.t regression + the RHS leak too.
+    nested.t 7 maintained, `make test` green, int.t 0.16s, `t/element-bind-cell.t` 35 cases (including LHS/RHS copy-snapshot).
+    **Sentinel deletion not yet** (element-source bind (2) and read paths still use it).
+  - **Investigation record 2026-06-11 (element-element / container-leaf binds = hardest; prototype reverted)**: attempted to solve nested.t 32-37 and
+    `my $x := $foo[1]<key>` (binding to a **container-valued terminal element**). **The implementation plan for a retry (with embedded prototype
+    code fragments, remaining work, cycle safety, a leak checklist, and verification steps) = `docs/element-element-bind-plan.md`.**
+    Findings from the prototype (subsequently reverted):
+    - **Root cause**: a bound terminal element with a container value (`$foo[1]<key>` being a Hash) stays a HashSlotRef and goes COW-stale. Unlike RHS scalar leaves,
+      the **container leaf must be cell-ified**. But `array_slot_ref`/`hash_slot_ref` by design do not cell-ify Array/Hash leaves,
+      for the sake of deep traversal. → Solved by **terminal-promotion**: identify the outermost (terminal) index of a bind RHS with a compiler flag `bind_terminal`
+      + a new op `IndexAutovivifyLazyTerminal`, and promote container leaves to cells only at the terminal (intermediates keep SlotRef). Not applied to `=:=`
+      (avoids over-promotion). The terminal flag must be set both at stmt.rs:767 and on the SyntheticBlock/MarkBind path (helpers_block_inline).
+    - **However, deep write-through into container cells ripples into every assign handler**: since the cell **holds a Hash/Array**,
+      `%h<key><inner>=50` (a deep write through the cell) only lands if the assign handlers decont ContainerRef intermediates/roots and **mutate the
+      container inside the cell in-place**. Naively, the match falls into `_=>{}` and **the write is dropped**. As countermeasures,
+      adding (a) `assign_into_nested_container` (ContainerRef descent) to the 2-level nested handler and (b) `descend_container_ref` (descending to the Mutex data pointer)
+      to the deep handler's raw-pointer walk **solved single-level container binds** (`my $x:=%h<key>` bidirectional OK). But **RHS container-leaf works in only 1 of 3
+      directions** (the reverse direction `$x<subkey>[1]=8` fails because root `$x` itself is a cell = the nested/generic handlers cannot read the root as a Hash and the write drops),
+      and **element-element remains unsolved**.
+    - **Conclusion = why it is the hardest**: container-leaf cells require **ContainerRef-descent in the root reads and intermediate traversal of all
+      index-assign handlers (named/nested/deep/generic)** (a "deref everywhere" surface) + **cycle safety** (self-referential binds at nested.t 268+
+      can make the descent loop infinite) + **container-cell leak hardening** (iteration/.raku/slice).
+      It cannot close safely in a single PR. The terminal-promotion mechanism and the 2 descent helpers are valid, but the full-handler rollout of root-cell descent
+      + cycle detection + leak verification needs dedicated work. The prototype had no binding-sweep regressions but did not fix the targets (32-37) and
+      `make test` full was unverified, so it was reverted. On retry, proceed in this order: (1) terminal-promotion (2) all-handler root/intermediate descent (with cycle detection)
+      (3) container-cell leak hardening (4) release roast.
+  - **✅ LANDED (PR #2922 + #2925, 2026-06-12)**: applied the above plan verbatim in Phase 1-5 order and implemented element-element /
+    container-leaf / cyclic binds, completing it exactly as `docs/element-element-bind-plan.md` prescribes. **nested.t 43/43 (added to the
+    whitelist)**. #2922 covers 32-37 (terminal-promotion + `assign_into_nested_container`/`descend_container_ref` +
+    `env_root_descended_mut` root descent in the nested/named handlers + `compile_bind_index_value` terminal
+    promotion on RHS + read-side decont + `MAX_DESCENT` cycle guard + `.raku`/`.gist` leak hardening). **True root cause found outside the plan**:
+    the intermediate array level's `needs_viv` in the deep-nested traversal destroyed existing `ContainerRef` elements by overwriting them via vivify (the real identity of the
+    cyclic off-by-one) → solved by excluding `ContainerRef` from `needs_viv`. #2925 covers 11-12 (`$struct[1]<key>()<subkey>[1]`
+    = `is raw` sub mid-path binds): routed the generic handler's Array arm for stack-target IndexAssign through `assign_element_slot`
+    so bound cells are written through (direct replacement was destroying the cell). `t/element-bind-cell.t` 35→54.
+- [x] **True shared cell for `is rw` params (scalars.t 24/27) = LANDED (#2928)**: `:=` rebinding to an `is rw` param
+  is shared with the caller's variable via a live `ContainerRef` cell. take-rw also landed in #2930 (gather.t 38).
+  Implementation plan (historical) = `docs/is-rw-shared-cell-plan.md`. scalars.t 33/33.
+- [~] **Structural elimination of the Q2 type-meta Arc-ptr flake (2026-06-12, two-pronged)**:
+  - **(1) Hash = HashData embedding (full absorption) DONE (#2952)**: embedded
+    value_type/key_type/declared_type into `Value::Hash(Arc<HashData>)`, deleting the `hash_type_metadata` side table and
+    `reconcile_hash_type_metadata_from_name`. Metadata moves together with COW = mis-inheritance from ptr reuse is gone for Hash.
+    Plan and remaining work (embedding original_keys = Stage 2, then rolling the same wrapper out to Array/Set/Bag/Mix) =
+    `docs/hashdata-migration-plan.md`.
+  - **(2) Weak-guarding the not-yet-wrapped tables (#2953)**: moved to `PtrKeyedMap`
+    (`HashMap<usize,(Weak<T>,V)>`) in `runtime/ptr_keyed.rs`: `array/mix/set/bag_type_metadata`, `container_defaults`
+    (split into array/hash), the utils globals `shaped_array_ids` and `grep_view_bindings`.
+    - **Mechanism**: each entry's `Weak` pins the ArcInner → **address reuse is physically impossible while the entry lives** =
+      the intermittent flake where a new container mis-inherits a dead typed container's metadata (the alloc-order-dependent deaths of
+      S02-names-vars/perl.t, native-array-mut.t, etc.) is structurally eliminated. Lookups verify `strong_count>0`; inserts sweep dead entries when a threshold
+      is exceeded (also resolving unbounded growth and pinned memory). `remove` returns the value even if dead (pre-COW reclamation = for migrate).
+    - **Collision-defense hacks removed**: `clear_container_default` (+4 sites), and the 2 defensive post-make_mut
+      unregisters in `vm_call_method_mut_ops`.
+    - **★ Important side effect and countermeasure**: with a `Weak` held, `Arc::make_mut` **always relocates** even at strong==1 (the weak>0 rule) →
+      the implicit assumption "uniquely-owned in-place mutation is pointer-stable" breaks (only for guarded containers). Healed the 3 manifest paths:
+      VM native push (`capture_container_meta`/`restore_container_meta` in `exec_array_push_op` = type meta +
+      `is default`), the interpreter push arm (`reattach_array_type_metadata`), and **`.WHICH` stability** (2-level nested
+      hash writes write the outer in-place via raw ptr when strong==1 — the cast must be `*mut HashData`;
+      see the UB lesson in hashdata-migration-plan). **New healing gaps will manifest as "typed/shaped container loses metadata after mutation" or
+      ".WHICH changes"** — compare tmp/typed-meta-smoke{,2}.raku / tmp/which-map.raku against main to detect.
+    - **The 2 hash original-keys tables (`hash_object_keys`, `hash_original_keys_registry`) are deliberately out of scope**:
+      object-hash construction depends on the in-place pointer stability of repeated make_mut (putting the guard on regresses
+      .antipairs/.invert of S09-typed-arrays/hashes.t); the right fix is (1) the HashData embedding of Stage 2.
+    - **Remaining (unguarded)**: the Seq-family ptr keys (`predictive_seq_iters`, `squish_iterator_meta`,
+      the `__mutsu_predictive_seq_iter::` env key) and the `{:p}` embedding in WHICH strings are a separate subsystem where the same hazard remains (small).
+    - Verification: cargo test 466 (including 5 PtrKeyedMap unit tests, deterministic tests of stale-inheritance impossibility), make test 727/6588,
+      whitelist S09×17 + perl.t×3 + map.t + S02-types/hash.t + let.t + 3467 typed-hash canary tests, int.t 0.163s.
+- [~] **Stage 2 — deep `>>++`/`deepmap`/object-hash; removal of the legacy SlotRef mechanisms** (started 2026-06-13, slices in progress):
+  - [x] **slice 1 = deepmap container passing (#2964)**: pass leaves to the callable via transient `ContainerRef` cells, and
+    after the call write the cell value back in-place to the source Array/Hash slot (no cell remains). Results are deconted to prevent
+    cell leaks from identity blocks. Fixed hyper.t 330-333 (12→9 fail; the rest are separate nodal/callable features).
+    t/deepmap-container.t (16).
+  - [x] **slice 2 = removal of intermediate SlotRefs on the bind path (#2966)**: `exec_index_autovivify_lazy_op` returns
+    intermediate Array/Hash elements **as the element value itself (inner Arc shared)** instead of wrapping them in SlotRef back-refs — after #2902-#2925,
+    leaf promotion happens in-place inside the shared Arc, so the back-ref was unnecessary. The 2 intermediate arms of `array_slot_ref`/`hash_slot_ref`.
+  - [x] **slice 3 = total abolition of BOUND_HASH_REF_SENTINEL**: replaced the 3 creation paths (single hash-key bind named handler,
+    slice bind, `.BIND-KEY` ×2) with "store a `ContainerRef` cell into the hash entry + write the same cell back to the source variable",
+    and deleted the consumers (the BOUND arms of resolve_hash_entry/hash_has_sentinels/resolve_hash_for_iteration,
+    the sentinel write-through arm) and the sentinel constants. Design points:
+    (a) **For an element source (`%h<k> := @a[0]`), val is already a LazyTerminal-promoted cell** — store it into the entry as-is
+    (the old sentinel was a broken path writing a `\0idx\0` name into env, so hash-key writes never reached the element; fixed
+    properly). (b) **Cell-reuse pre-read**: if the source is already cell-bound (`@arr[0] := $x; %h<k> := $x`), share the
+    existing cell (overwriting with a new cell would sever the other alias — also a pre-existing bug fix). The `BindSourceCell` type
+    pre-reads before the borrow. (c) **Assignment snapshot**: `%new = %hash` deconts cells in `resolve_hash_for_iteration`
+    (assignment creates new containers, S03-binding/hashes.t 30). (d) `.push` onto a cell-bound variable with an `@`/`%` source
+    goes through the `exec_array_push_op` fallback: decont → dispatch → write back to the cell
+    (also fixing the pre-existing failure inherited from #2914 on the array side). t/hash-bind-cell.t (19).
+  - [x] **slice 4 = total abolition of BOUND_ARRAY_REF_SENTINEL**: moved the creation of single-level array element binds (the named handler's
+    `\0idx\0` element-source branch) to the same shared `ContainerRef` cell as the hash side. Generalized slice 3's `bind_cell` pre-read to be
+    target-independent (`hash_bind_cell`→`bind_cell`, consumed by both array/hash arms); array element sources
+    (`@x[i] := @b[j]`) also store the LazyTerminal-promoted cell as-is, like hash. All consumers abolished:
+    the BOUND arm of `resolve_array_entry` + the `resolve_bound_source` helper, `resolve_bound_array_elements` (sentinel
+    scan → cell decont), the `is_bound_index` staleness check (sentinel-presence test → stale cleanup if the element is a non-cell),
+    `exec_container_eq_indexed_op` (name-match test of `get_binding_source_of_indexed` → `Arc::ptr_eq` of both
+    slots' cells via `raw_element_at_encoded`). Sentinel constants deleted. **Bug fix**: array-mediated write-through
+    to a hash-element source (`@y[0] := %src<a>; @y[0] = v` did not reach `%src<a>`, dying with "Cannot modify an immutable value") is resolved
+    (matches raku). `mark_bound_index` is skipped for cell-storing binds (the `stored_bind_cell` flag). t/array-bind-cell.t (14).
+    **Kept**: the separate `WrapVarRef`/`__mutsu_varref_*` capture mechanism (`\($a)`, `key=>$var` write-through, binding.rs:499/506) can
+    be stored into array elements, so the `varref_target` branch is retained.
+  - [x] **slice 5 = deep write-through for whole-container sources**: the root cause of `@h[i] := @inner; @h[i][j] = v` not reaching
+    `@inner[j]` = on the array-as-outer nested-assign path (vm_var_assign ~3780), when `arr[inner_i]` is a `ContainerRef`
+    cell, `needs_viv` (`!matches!(Array|Hash)`) was true → the cell was **overwritten** with an empty array. Fix = exclude ContainerRef from needs_viv
+    too + add a ContainerRef arm to the match → delegate to `assign_into_nested_container` (already handles cell descent, array resize, hash
+    insert). **A whole-container source has `@inner` rebound to the same cell at bind time** (pending_source_cell),
+    so if the deep write follows the cell it also reaches the source-side alias (`@h[i][j]=v`→`@inner[j]`; combined with push and shared multi-sibling
+    binds, matches raku). Pinned array-valued/hash-valued sources, hash-key bound, and sibling sharing in t/array-bind-cell.t (20).
+  - **Map of remaining slices** — detailed design in **`docs/slotref-removal-plan.md`** (a dedicated doc that pins down the
+    role separation of the cells-everywhere problem, phantom entries, the hazard audit, and the staged slices):
+    - [x] **slice 1 = cell-ification of computed-target `:=` binds (#2974)**: the `IndexAssignGeneric`
+      `HashSlotRef`/`ArraySlotRef`-into-env becomes cells (this path was live and also had a write-through bug, now fixed).
+    - [x] **slice 2 = full deletion of the dead `ArraySlotRef` variant**: slice 1 removed the last creation site (4291),
+      so variant creation is zero = fully dead → deleted the variant definition, `array_slot_read/write`, and all consumer
+      arms. Behavior-preserving. **Important correction**: the original "de-Value-ify the plain write-autoviv cursor" idea
+      did not correspond to reality and was dropped — `%h<a><b> = 5` goes via `IndexAssignDeepNested` and was SlotRef-free from the start, and the non-lazy
+      `IndexAutovivify` opcode is also dead (see the correction at the top of plan §3).
+    - [x] **slice 3 = phantom-entry: cell-ify materialization of missing-key binds**: `:=` binds of missing keys
+      (`HashSlotRef`/`DeferredHashAccess`) materialize **on first write** into shared `ContainerRef` cells.
+      bound var ↔ hash entry become a bidirectional alias (fixed the **case-C bug** where cross-writes did not propagate after materialization; matches raku).
+      Added the `materialize_bound_slot_to_cell` helper; deleted the dead `deferred_hash_write`. `t/phantom-entry-bind.t` (12).
+      **Keeping the token is correct**: removing the deferred token from Value would require an in-map phantom representation (intermediates are also lazy, so
+      a tombstone is impossible) or a side table (ptr-keyed global = anti-goal) → cell-ified materialization is the substance of phantom.
+    - [x] **slice 4 = cell/shared-Arc-ify `hash_autovivify` in bind descent (#2966 family)**: bind-descent
+      autoviv becomes `hash_autovivify_cell` (existing cell → as-is / container leaf → shared Arc / scalar leaf → cell promotion /
+      missing → empty Hash). Eradicated the `HashSlotRef` back-ref.
+    - [x] **slice 5 = final SlotRef kill = merge `HashSlotRef`+`DeferredHashAccess` into a single `HashEntryRef{hash,path}`
+      (#3472, 2026-06-23)**: confirmed that deleting all variants is **fundamentally impossible without an anti-goal side table** (the
+      deferred-vivification token for missing-key binds demands a Value variant). Via "purging the `SlotRef` concept + merging into a single honest token",
+      achieved `git grep 'SlotRef\|DeferredHashAccess' src/`=0. Abolishing the `parent_slot` chain made all missing-path binds of 3+ levels work.
+      Details = `docs/slotref-removal-plan.md` §0/slice 5. Pin = `t/hash-entry-ref-deep-bind.t`.
+      - **Deliberately not addressed (zero-value; deferred)**: cell-ification of the eager `hash_autovivify` in `is raw` reduce lvalue-reads
+        (returns a path-len-1 `HashEntryRef`). **The variant is irreducible due to its deferred-token role, so cell-ifying would not remove it**, and
+        the target is a **lenient path that current rakudo itself rejects with `assign requires a concrete object`** (only mutsu accepts it) = no behavior change either.
+        Pure internal purity with zero value, so deferred.
+    - [x] **grep-rw-view removal (#3466, 2026-06-23)**: under the registration gate, promote matched elements to cells and abolish the view registry
+      (a ptr-keyed global) entirely (`for_grep_view`/`GrepView`/`grep_source`/index-based writeback; -90 lines).
+      `.grep`'s rw topic writes back to the source via the ordinary element-cell write path. Pin = `t/grep-cell-read-deref.t`.
 
-> **✅ Phase 2（配列/ハッシュ要素の第一級コンテナ化）= 完了（2026-06-23）**。Stage 0/1/2 + slotref-removal slice 1-5 +
-> grep-rw-view 撤去まで landed。`=`-share / `:=`-bind / 要素-要素 bind / 深い欠落 path bind / scalar-param 共有 /
-> typed-array 共有 / for-rw / HoH 深い共有が全て raku 一致（probe + `t/container-identity-phase2-complete.t` 18 / nested.t 43
-> / 各 share 系 suite で担保）。残る唯一の未対応は上記 zero-value の reduce-eager-cell purity のみ（variant が irreducible
-> ゆえ着手不要）。**次は Phase 3（instance 属性セル・下記）が first-class 化の残テーマ。**
+> **✅ Phase 2 (first-class containerization of array/hash elements) = COMPLETE (2026-06-23)**. Stage 0/1/2 + slotref-removal slices 1-5 +
+> grep-rw-view removal all landed. `=`-share / `:=`-bind / element-element bind / deep missing-path bind / scalar-param sharing /
+> typed-array sharing / for-rw / deep HoH sharing all match raku (backed by probes + `t/container-identity-phase2-complete.t` 18 / nested.t 43
+> / the various share suites). The only remaining non-addressed item is the zero-value reduce-eager-cell purity above (no need to start since the variant
+> is irreducible). **Next, Phase 3 (instance attribute cells, below) is the remaining theme of first-class-ification.**
 
-**必須検証（各 Stage）**: nested.t、`make test`、**release roast の main-vs-branch 比較**（PR #2898 で
-typed-array 修正が make test を通過しつつ release roast の `S06-currying/misc.t` を回帰させた轍＝要素変更は
-release でしか出ない leak がある）、int.t の wall-clock（perf 崖カナリア）。
+**Mandatory verification (each Stage)**: nested.t, `make test`, **release-roast main-vs-branch comparison** (the lesson of PR #2898, where a
+typed-array fix passed make test yet regressed `S06-currying/misc.t` in the release roast = element changes have leaks that only
+show in release), and int.t wall-clock (the perf-cliff canary).
 
-### Phase 3 — 第一級 instance セル（属性コンテナ + 属性束縛）
+### Phase 3 — first-class instance cells (attribute containers + attribute binding)
 
-> ユーザー方針 (2026-06-10): dynamic var / instance mutation の closure 跨ぎ問題は、修正オプション
-> (A) writeback 全チェーン走査 / (B) exit-writeback by-id / (C) 第一級 instance セル のうち **(C) で進める**。
-> 構造的解決＝最大改修。下記が (C) の設計。
+> User direction (2026-06-10): for the dynamic var / instance mutation across-closure problem, among the fix options
+> (A) writeback full-chain scan / (B) exit-writeback by-id / (C) first-class instance cells, proceed with **(C)**.
+> Structural solution = the largest rework. Below is the design of (C).
 
-#### 解く問題（根本原因。詳細は docs/vm-state-ownership.md「調査記録 2026-06-10」）
+#### Problem to solve (root cause; details in docs/vm-state-ownership.md "Investigation record 2026-06-10")
 
-instance を**値で保持**しているため、closure frame 内の変異メソッド（`$*ERR.print`、`$obj.set-x` 等）の
-writeback `overwrite_instance_bindings_by_identity`（`methods_mut.rs:415`）が `self.env.values_mut()`＝
-**scoped env の overlay tier のみ**を走査し、caller frame（parent tier＝immutable `Arc<Env>`）が保持する同一
-instance の binding に届かない。同一 id でも変異が frame 復帰で消える。`sub cap(&code){ my $*ERR=F.new; &code() }`
-で `code` 内の `note` が rebound `$*ERR` に書けない、が代表症状（pre-existing・`&code()` で再現）。map/for は
-**同一フレーム実行**で overlay==caller のため偶然成立しているだけ。
+Because instances are held **by value**, when a mutating method inside a closure frame (`$*ERR.print`, `$obj.set-x`, etc.) runs, the
+writeback `overwrite_instance_bindings_by_identity` (`methods_mut.rs:415`) scans `self.env.values_mut()` =
+**only the overlay tier of the scoped env**, and never reaches the binding of the same instance held by the caller frame (parent tier =
+immutable `Arc<Env>`). Even with the same id, the mutation vanishes when the frame returns. The representative symptom:
+in `sub cap(&code){ my $*ERR=F.new; &code() }`, a `note` inside `code` cannot write to the rebound `$*ERR` (pre-existing; reproduced via `&code()`).
+map/for only happen to work because they execute **in the same frame** so overlay == caller.
 
-#### 現状の表現
+#### Current representation
 
-`Value::Instance { class_name: Symbol, attributes: Arc<InstanceAttrs>, id: u64 }`（`value/mod.rs:1000`）。
-`InstanceAttrs` は `attributes: HashMap<String,Value>` を **Deref/DerefMut で包む**（`:455`）。
-- 共有: `Arc<InstanceAttrs>` を clone で共有（CoW）。
-- 変異: `Arc::make_mut`（CoW で別コピー化）→ `overwrite_instance_bindings_by_identity`（**id 一致の全 env binding を
-  scan して置換**）で伝播。**この scan が overlay-only ＝バグの本体**。
+`Value::Instance { class_name: Symbol, attributes: Arc<InstanceAttrs>, id: u64 }` (`value/mod.rs:1000`).
+`InstanceAttrs` **wraps** `attributes: HashMap<String,Value>` **via Deref/DerefMut** (`:455`).
+- Sharing: share `Arc<InstanceAttrs>` by clone (CoW).
+- Mutation: `Arc::make_mut` (CoW into a separate copy) → propagate via `overwrite_instance_bindings_by_identity` (**scan all env bindings
+  matching the id and replace them**). **This scan being overlay-only = the substance of the bug**.
 
-#### 目標の表現（C）
+#### Target representation (C)
 
-`attributes` を **共有可変セル**にする。`Value::Instance` を clone してもセルを共有 → 変異が全 holder
-（caller env / closure overlay / ネスト属性）で可視 → **`overwrite_*_bindings_by_identity` の by-id scan を全廃**。
-- スレッド越境（`clone_for_thread`）があるので `Rc<RefCell>` 不可 → **`Arc<RwLock<HashMap<String,Value>>>`**
-  （または `InstanceAttrs` 自体を内部可変セル化し `Value::Instance` は従来どおり `Arc<InstanceAttrs>` を持つ）。
+Make `attributes` a **shared mutable cell**. Cloning `Value::Instance` still shares the cell → mutations are visible to all holders
+(caller env / closure overlay / nested attributes) → **abolish the by-id scan of `overwrite_*_bindings_by_identity` entirely**.
+- Because of thread crossing (`clone_for_thread`), `Rc<RefCell>` is impossible → **`Arc<RwLock<HashMap<String,Value>>>`**
+  (or make `InstanceAttrs` itself an interior-mutable cell while `Value::Instance` keeps holding `Arc<InstanceAttrs>` as before).
 
-#### blast radius（実測）
+#### Blast radius (measured)
 
-`Value::Instance` 参照 **875**、`Instance { attributes, .. }` パターン **127**、`make_mut`(methods_mut) **16**。
-**Rust の借用モデル上、ロックした HashMap への `Deref` は不可**（guard の lifetime）。よって 127 の
-`attributes.get(k)` 系 read サイトは API 経由（lock+clone）へ移す必要がある。一括変更は不可能。
+`Value::Instance` references: **875**; `Instance { attributes, .. }` patterns: **127**; `make_mut`(methods_mut): **16**.
+**Under Rust's borrow model, `Deref` into a locked HashMap is impossible** (guard lifetime). Therefore the 127
+`attributes.get(k)`-style read sites must move to API access (lock+clone). A one-shot change is impossible.
 
-#### 段階導入（big-bang を避ける。各段 CI を安全網に）
+#### Staged introduction (avoid big-bang; CI as the safety net at each stage)
 
-- [x] **Stage 0 — カプセル化境界の確立（挙動不変）完了 (#2856)**: `InstanceAttrs` から `Deref`/`DerefMut` を撤去し、
-      代わりに `HashMap` と同シグネチャの inherent メソッド（`get`/`contains_key`/`insert`/`get_mut`/`entry`/`iter`/
-      `keys`/`values`）＋owned アクセサ `as_map()->&HashMap` / `to_map()->HashMap` を追加。これで属性ストレージへの
-      全アクセスがメソッド境界を通る（Deref 漏れを排除）。**内部表現は HashMap のまま**＝byte-identical。
-      Deref 撤去でコンパイラが ~197 サイトを列挙：deref-coercion（`fn(&HashMap)` へ `&Arc<InstanceAttrs>` 渡し）は
-      `.as_map()` へ、`(**attributes).clone()` は `.to_map()` へ機械置換。make test 6112 全緑・cargo test 458/0・
-      clippy 緑。これで Stage 1（内部を共有可変セルへ）の表現切替が局所化された。
-- [x] **Stage 1 — 表現切替（共有セル化）完了**: `InstanceAttrs.attributes` を `HashMap` → `Arc<RwLock<HashMap>>`
-      （`AttrCell`）に。`Value::Instance` は従来どおり `Arc<InstanceAttrs>` を保持。
-  - **read API**: `as_map()` は `RwLockReadGuard`（`Deref`→`&HashMap`）を返す。チェーン呼び（`.get`/`.iter`/`for`）は
-        無改変、`fn(&HashMap)` へ渡す ~87 サイトは `&` 付与のみ。`get()`（owned 化は `*x`/`.cloned()`/`and_then(fn(&Value))`
-        を全部壊す）は**削除**し、全 `.get()` を `.as_map().get()` へ降ろして借用セマンティクスを温存（504 サイト機械置換）。
-  - **mutation**: `insert`/`insert_if_absent`/`with_attr_mut` は `&self`（write-lock で in-place）。`make_mut(attributes)`
-        サイトは直接 `&self` 変異へ。
-  - **クロスフレーム可視化（バグ修正の本体）**: `id→Weak<cell>` レジストリ（`instance_cells`）を新設。
-        `make_instance_with_id` は既存の生きたセルを**再利用**（map を書き込んで alias 共有のインスタンスを返す）。
-        `overwrite_instance_bindings_by_identity` はスキャン前に `update_instance_cell(id, &updated)` で**生きたセルへ
-        直接書き込む** → スキャンが訪れない caller フレームの alias にも変異が届く。これで `note`/$*ERR・closure 経由
-        instance mutation が解消。レジストリは Stage 2 で scan ごと撤去するための足場。
-  - **`.clone`（Raku 独立コピー）保全**: `InstanceAttrs::clone` を手書きで**deep copy（新セル・queue_destroy=false・
-        非登録）**に。共有は `Arc<InstanceAttrs>`（Value clone）経由のみ。これで ~30 の `(*attributes).clone()`
-        writeback サイトは無改変で独立コピー意味論を維持。`temp`/`let` save も同型の独立スナップショットが必要だった
-        （`into_temp_snapshot` で instance を deep copy、restore は `make_instance_with_id` で**生きたセルへ書き戻し**
-        identity と alias 可視性を保つ）— これを怠ると `t/lvalue-method-rw.t` の temp 復元が壊れる（実際に踏んで修正）。
-  - 検証: cross-frame note/closure mutation・alias 共有・`.clone` 独立・`===`/`.WHICH`/`eqv` identity・DESTROY(1回)・
-        temp/let 復元 すべて raku 一致。clippy 緑。
-- [ ] **Stage 2 — cell を唯一の真実源に（keystone）＋ 伝播ハック全廃**: ユーザー判断 (2026-06-10) で当初**一括 PR** 想定 →
-      **配列/ハッシュ属性の in-place 変異（`@!a.push`/`%!h<k>=`）の cell 書き戻し配線が別プロジェクト規模**と判明したため、
-      ユーザー再判断 (2026-06-10) で **sigil でスライス**（スカラー先行）に変更。
-  - [x] **Stage 2a — スカラー属性 (`$!x`/`$.x`) を cell 直結（landed: branch `phase3-stage2-scalar-cell`）**:
-        `Var("!x")`/`Var(".x")` の read を `self` の共有 cell 直読に（`read_self_attr_cell`、atomic/CAS チェックの後段＝CAS は
-        従来 `shared_vars` 維持で livelock 回避）。write 経路 — `exec_set_local_op`/`exec_assign_expr_local_op`（ラッパーで
-        `mirror_attr_local_to_cell`）、名前ベース `exec_assign_expr_op`（`$.x = v`/`$!x = v`、`mirror_attr_value_to_cell_by_name`）、
-        post/pre inc・dec（`sync_attr_local_from_cell_by_name` → 実行 → mirror）— を全て cell 書き込みに。**スカラー writeback
-        撤去**（`writeback_attributes*` を array/hash 専用化、`AttrSlots::private/public` 削除）。代わりに method exit の
-        live env/locals 段階で `reconcile_scalar_attrs`：「env/local が entry スナップショットから変化 → その値、不変 → live cell
-        値（cross-frame/cell-direct 変異を採用）」で attr マップを確定し make_instance_with_id へ。これが **attributive param
-        (`method m($!s)`)・no-twigil sigilless attr (`has $x`)・`is rw` accessor 書き込み**（cell 非経由で env を書く 3 経路）を
-        cell に届ける。**cross-frame スカラー変異バグ修正**（`self.bump` が caller の `$!x` に可視、11 vs 旧 10）。配列/ハッシュ属性・
-        CAS・registry/scan/detached/`instance_cells` は Stage 2b まで維持（まだ削除不可）。
-        検証: make test 全緑、S12-attributes/instance・native、S12-methods/{attribute-params,lastcall,defer-call,defer-next}・
-        S17-lowlevel/cas（whitelist）PASS。継承同名 private（Parent/Child `$!p`）は main と同挙動の pre-existing バグで非回帰。
-  - [x] **Stage 2b — 配列/ハッシュ属性 (`@!a`/`%!h`) を cell 直結（landed: branch `phase3-stage2b-array-hash-cell`）**:
-        read を `GetArrayVar`/`GetHashVar` で `self` の cell 直読（`read_self_attr_cell` を全6 twigil 対応に一般化＝
-        `scalar_attr_twigil_base`→`attr_twigil_base`、`(bare, is_private)` 返却）。各変異 op の **後**に env→cell ミラー
-        （`mirror_array_hash_attr_to_cell`）を配線: `CallMethodMut`/`CallMethodDynamicMut`/`ArrayPush`/`IndexAssignExprNamed`/
-        `MultiDimIndexAssign`/名前ベース `AssignExpr`。**重要＝op 前に env スナップショット**（`array_hash_attr_env_snapshot`）を取り、
-        env が実際に変化したときだけミラー：非変異メソッド（`@!a.join`）も `CallMethodMut` で来るため、stale env コピーを
-        無条件ミラーすると cross-frame の cell 変異を clobber する（cf3 で実証・修正）。**スカラー reconcile を全 sigil 統一**
-        （`reconcile_scalar_attrs`→`reconcile_attrs`、ルール「cell が entry から変化→cell 優先、でなければ env 変化を採用」＝
-        cross-frame/per-op ミラーは cell が勝ち、attributive array param `method m(@!a)`・sigilless は env が勝つ）。
-        これで **array/hash writeback (`writeback_attributes*`) を完全撤去**（`AttrSlots` 構造体 + `compute_attr_slots` も削除、net -115 行）。
-        **cross-frame 配列/ハッシュ変異バグ修正**（nested method の `@!a.push`/`%!h<k>=` が caller に可視）。
-        検証: make test 全緑、S12-attributes/methods・S14-traits・S17/cas（whitelist）PASS、Stage 2b edge 21/21
-        （push/pop/shift/unshift/要素代入/`:delete`以外/whole-assign/cross-frame array+hash/attributive param/`.=`/chain/read-no-clobber）。
-        既知の非対応（pre-existing・非回帰）: `%!h<x>:delete`（DELETE-KEY が Index target 経由でミラー外）、`@b[0]=v` のスペース無し
-        パース、継承同名 private。**materialize の array/hash 挿入 / by-id scan (`overwrite_instance_bindings_by_identity`) /
-        registry (`instance_cells`) / detached は未撤去**＝Stage 2c（次）で cell 単一源を根拠に全廃。
-  - [~] **Stage 2c — 伝播ハック全廃（着手・slice 1 done）**: cell が全 attr の単一源になったので伝播スキャンを撤去。
-        - [x] **slice 1 — by-id env/locals scan 撤去（branch `phase3-stage2c-drop-byid-scan`）**: `overwrite_instance_bindings_by_identity`
-              の `for bound in self.env.values_mut()` 走査 + 再帰ヘルパ `overwrite_instance_recursive`（Instance/nested-attr/Mixin/
-              ContainerRef の各 arm）と、locals 走査 `overwrite_instance_in_locals`（+ 6 call sites）を**全削除**。伝播は単一の
-              `update_instance_cell(id, &updated)`（live shared cell への直書き）に集約。**根拠**: Stage 1/2a/2b 後、instance の
-              全 alias（同一フレーム・caller フレーム・`ContainerRef` boxed capture・role `Mixin`・他 instance のネスト属性）は
-              `Arc<InstanceAttrs>` 参照共有で**同一 cell を見る**（deep-copy は明示 `.clone` のみ）→ scan が rebuild していた
-              holder は元から同じ cell を共有しており scan は観測上 no-op。`_class_name` は vestigial（cell は id keying）だが
-              ~40 call site churn 回避のため signature 維持（後続 slice で撤去）。検証: make test 6247・S12/S14/S17 whitelist
-              106 ファイル 2111 テスト PASS（cross-thread cas・全 role/mixin・cross-frame note/closure・nested・escaping-closure
-              scalar-holding-instance すべて緑）、clippy 緑。net -108 行。
-        - **materialize/reconcile 撤去（ユーザー選択 2026-06-11、段階 PR）**: reconcile は `attributes`(entry snapshot) を最終値へ
-              書き換え、cell 非経由の2経路を merge する: (a) attributive param (`method m($!x)`)、(b) sigilless `has $x`（bare `Var("x")`
-              にコンパイルされ実行時 alias テーブルのみが属性と判別）。`is rw` accessor 等は既に cell に届く。reconcile を単純撤去すると
-              caller の cell writeback が snapshot で cell を巻き戻すため、最終的に `reconcile → attributes = base.cell.to_map()`（cell 単一源）
-              へ置換する。exit-mirror は 2b 実証の stale-clobber を起こすため write-time の cell routing が必須。→ (i) attributive param、
-              (ii) sigilless cell-direct（2a 相当）、(iii) reconcile/materialize 撤去、の3段に分割。
-          - [x] **(i) attributive param → cell（landed: branch `phase3-stage2c-registry-removal`）**: binding 直後に
-                `mirror_attributive_params_to_cell`（`mirror_attr_value_to_cell_by_name` 再利用、scalar/array/hash 全 twigil）で param を
-                self の cell へ。**併せて read-only fast path から attributive param を除外**（`attr_twigil_base(pd.name).is_some()` を
-                `has_complex_params` に追加）—— attributive param は属性を変異させるのに fast path は writeback を落とすため `$obj.m($!x)`
-                後に変異が消えるバグ（`method set-and-read($!x){ say $!x }` が in-body 7 でなく stale cell 99 を読み属性も 99 のまま）を修正。
-                検証: make test 6247、S12/S14/S17/S06 whitelist 140 ファイル 2890 テスト PASS、named `:$!x`/BUILD/array/hash param・
-                in-body read・cross-frame すべて raku 一致。reconcile は (ii)(iii) まで維持（attributive param 経路は今や mirror で冗長だが無害）。
-          - [x] **(ii) sigilless `has $x` を cell-direct 化（landed: branch `phase3-stage2c-sigilless-cell`）**: bare `Var("x")`
-                （sigilless attr）を実行時 `__mutsu_sigilless_alias::` テーブル参照で cell に回す。**read**: `read_self_attr_cell` を
-                `canonical_attr_twigil`（直接 twigil → そのまま / bare sigilless → alias chain 辿って `!x` twigil 解決）経由に拡張。
-                sigilless `$x` は method local 宣言でないため **GetGlobal** で読まれる（GetLocal でない）と判明 → vm.rs の GetGlobal handler
-                にも cell-direct read を追加（env read の前）。**write**: 6つの alias-chain 伝播ループ（inc/dec 4 + name-based assign 1 +
-                SetGlobal 1）の各 alias target に `write_self_attr_cell` を追加し attr-twigil alias (`!x`) を cell へミラー。inc/dec の
-                4ループは重複していたので共通ヘルパ `propagate_sigilless_alias_chain` に factor（cell mirror 込み）。**perf**: read 経路は
-                hot なので新フラグ `Interpreter::sigilless_attrs_active`（materialize で sigilless alias 設定時に立てる process-sticky bool）で
-                ゲート → 非 sigilless プログラム（大多数）は string check のみ。**修正バグ**: 同フレーム/nested-frame の sigilless read が
-                entry env コピー（stale）を読んでいた（`method outer { self.inner; $y }` が inner の変異後 10 でなく 99 を返すべき所で 10）。
-                検証: make test 6247、S12/S14/S17/S06/S32-num whitelist 171 ファイル 6432・S02/S03/S04 318 ファイル 32004 PASS、
-                int.t perf 0.085s（回帰なし）、nested-read/same-method write-read/inc-dec/closure/multi-attr すべて raku 一致。
-                reconcile は (iii) まで維持（sigilless 経路は今や cell 直結で reconcile case-2 は冗長だが無害）。
-          - [x] **(iii-a) reconcile を cell 単一源に簡素化（landed: branch `phase3-stage2c-reconcile-removal`）**: `reconcile_attrs` の
-                entry-snapshot-vs-env の値比較（case-1 cell-changed / case-2 env-changed の優先判定 + sigil-by-type twigil 推定）を撤去し、
-                `*attributes = base.cell.to_map()`（cell が単一源）に。全 plain write（2a/2b/2c-i/ii）は write-time で cell に着地済みなので
-                cell snapshot が最終値。**例外 = `:=` 束縛属性**（`$!x := $outer`）: 外部 ContainerRef を env/locals に持ち cell を経由しない
-                **第3の bypass**（has-attr-binding.t で発覚）。cell.to_map() 後に env/locals の各 attr key（bare sigilless + 6 twigil）を走査し
-                ContainerRef なら優先採用して `:=` alias を method exit 越しに保全。検証: make test 6260、S12/S14/S17/S03-binding/S06 144 ファイル
-                2994 PASS、has-attr-binding 6/6、全 bypass/sigilless/attrparam テスト raku 一致。（S32-temporal/DateTime.t の 2 失敗は
-                `Date.today`=UTC vs `DateTime.now.Date`=local の pre-existing timezone バグで、変更退避した baseline でも同一＝非関連・
-                ローカル JST のみの artifact、CI=UTC では両者一致でパス。）
-          - [x] **(iii-b) slow-path materialize の attr-value env コピー撤去（landed: branch `phase3-stage2c-materialize-removal`）**:
-                complex-param メソッド経路（`call_compiled_method`）の attr value env コピー挿入（`!attr`/`.attr`/`@!attr`/`@.attr`/
-                `%!attr`/`%.attr`、~30行）を撤去。reads は全 cell-direct（2a/2b/2c-ii）、exit reconcile は cell.to_map()（iii-a）なので冗長。
-                sigilless alias テーブル設定 + `is default` 登録は保持。検証: make test 6265、S12/S14/S04/S03-binding/S06 144 ファイル 3076 PASS、
-                closure が private/array/hash/sigilless attr を捕捉・読み書きするケース（reader/writer 返却・nested+closure・map/gather）すべて raku 一致。
-                ~~**fast-path（`call_compiled_method_fast`）の array/hash env コピーは保持**~~ → **(iii-c) で撤去済み（下記）**。
-          - [x] **(iii-c) 変異 op の pre-op cell sync + fast-path env コピー撤去（branch `phase3-attr-cell-presync`）**:
-                `array_hash_attr_env_snapshot`（全変異 op サイトの pre-snapshot）を「**self の live cell から env/locals を refresh**
-                してから cell 値を pre として返す」へ拡張（Arc ptr 比較で同一なら no-op、`:=` ContainerRef は legacy 維持）。
-                これで closure-captured env コピー（closure 生成時の stale snapshot）を変異してミラーする事故が消え、
-                **pre-existing バグ「closure 経由 `%!h{$k}=$v` は最後の write しか残らない（最初の write が `(Any)`）」を修正**。
-                各 closure 呼び出しが live cell 値から開始する。修正後、`call_compiled_method_fast` の array/hash attr env コピー
-                （iii-b で保持した分）を撤去 — 読みは cell-direct（2b）、変異は pre-op sync が env を埋めるので不要。
-                **おまけ: `DeleteIndexNamed`（`%!h{$k}:delete`）にも同じ pre-sync + mirror を配線**し、Stage 2b の
-                pre-existing gap「DELETE-KEY がミラー外で cell に届かない」も修正。回帰テスト `t/closure-attr-element-write.t`（16）。
-        - [x] **registry 撤去（done, branch `phase3-drop-instance-cell-registry`）**: `instance_cells`（`id -> Weak<cell>` グローバル
-              Mutex registry）+ `register_instance_cell`/`lookup_instance_cell`/`update_instance_cell`/`overwrite_instance_bindings_by_identity`
-              を**全廃**。~98 の writeback/rebuild サイト（`overwrite_*` 47 + rebuild `make_instance_with_id` 51）を、receiver の
-              `Arc<InstanceAttrs>` cell を直接 in-place 変異する 3 つの新ヘルパへ全変換:
-              `InstanceAttrs::commit_attrs(map)`（live cell へ in-place 書き、deadlock-safe な `write_cell_respecting_reads` 経由）/
-              `Value::instance_sharing_cell(attrs, class, id)`（Arc を共有して rebuild、class 変更時のみ cell 共有の新 InstanceAttrs）/
-              `Value::write_back_sharing(attrs, class, map, id)`（commit + share の複合）。**`make_instance_with_id` から id→cell reuse 分岐を削除**
-              （以後 fresh cell 専用＝genuinely-new / sentinel id 用のみ）。snapshot+id しか持たなかった `proxy_store`・buf write・MRO multi
-              invocant 等は receiver の Arc を呼び出しチェーンへ通して解決。`make_instance_detached` は registry 撤去後 `make_instance_with_id`
-              と等価になったが CAS の atomic-sync 意図マーカとして名前のみ残置（→ `make_instance_with_id` 委譲）。`_class_name` vestigial param 撤去。
-              副次効果: グローバル Mutex registry の Weak エントリ蓄積（メモリリーク）解消、id-0 sentinel Supply の cell 誤共有 latent バグ解消。
-              検証: cargo test 461、clippy 緑、whitelisted S12/S14/S17/S32-temporal/buf 40 ファイル + cross-frame/closure/temp-let/proxy/buf/iterator/grammar 全緑。
-        - [x] **CAS cell-CAS 化（branch `phase3-cas-cell`）**: instance 属性の cas/atomic ops を shared_vars 側道
-              （`!attr::{id}` 値キー / `__mutsu_atomic_attr::{id}::{attr}` / `__mutsu_instance::{id}` 親回収 + env scan-replace /
-              `make_instance_detached` / `sync_atomic_attribute_to_instance`）から **cell 直接の atomic primitive** へ全面移行。
-              `InstanceAttrs::compare_and_swap(key, matches, new)`（単一 write lock 下で比較+格納）/ `fetch_update(key, f)`
-              （単一 write lock 下で RMW、atomic add/inc/dec 用）を新設し、`builtin_cas_var`（3-arg/2-arg）・
-              `builtin_atomic_update_unit`・`builtin_atomic_{add,fetch_add,fetch,store}_var` に attr-cell 分岐
-              （`self_attr_cell_target`: `!x`/`.x` → self の cell + qualified key 解決）。Stage 1 の livelock は
-              cell-direct read（2a）完備で解消（cas.t 5 連続 PASS で確認）。
-              **発見した第2の lost-update race**: method exit の reconcile snapshot を caller が毎回
-              `cell.commit_attrs(new_attrs)` で whole-map 書き戻し → 並行 cell-RMW を TOCTOU clobber
-              （8スレッド `$!count⚛++` ×500 が 2448/4000。main では親に全く伝播せず **0** だった）。
-              **修正**: `reconcile_attrs` が「cell snapshot を超える調整（`:=` ContainerRef 回収）があったか」の
-              bool を返し、`(Value, HashMap, bool)` で呼び出し元へ伝播 — 未調整なら exit commit / `write_back_sharing`
-              を **skip**（snapshot==cell なので no-op、かつ race 源）。調整あり（`:=`）のみ commit。
-              副次効果: 毎 method exit の冗長 whole-map 書き込み消滅（perf）。回帰テスト `t/cas-cell-attr.t`（14、
-              4スレッド increment/2-arg cas/await 後親可視を含む、raku 一致）。
-  - 旧「一括」設計（下記）は Stage 2a/2b/2c に分割。以下は参照マップ。
+- [x] **Stage 0 — establish the encapsulation boundary (behavior-preserving), completed (#2856)**: removed `Deref`/`DerefMut` from `InstanceAttrs` and
+      instead added inherent methods with the same signatures as `HashMap` (`get`/`contains_key`/`insert`/`get_mut`/`entry`/`iter`/
+      `keys`/`values`) plus owned accessors `as_map()->&HashMap` / `to_map()->HashMap`. All access to attribute storage now
+      goes through a method boundary (eliminating Deref leaks). **The internal representation stays HashMap** = byte-identical.
+      Removing Deref made the compiler enumerate ~197 sites: deref-coercions (passing `&Arc<InstanceAttrs>` to `fn(&HashMap)`) mechanically replaced
+      with `.as_map()`, `(**attributes).clone()` with `.to_map()`. make test 6112 all green, cargo test 458/0,
+      clippy green. This localizes Stage 1's representation switch (internals to a shared mutable cell).
+- [x] **Stage 1 — representation switch (shared cell-ification), completed**: `InstanceAttrs.attributes` from `HashMap` → `Arc<RwLock<HashMap>>`
+      (`AttrCell`). `Value::Instance` keeps holding `Arc<InstanceAttrs>` as before.
+  - **read API**: `as_map()` returns an `RwLockReadGuard` (`Deref`→`&HashMap`). Chained calls (`.get`/`.iter`/`for`) are
+        unmodified; the ~87 sites passing to `fn(&HashMap)` only need an added `&`. `get()` (making it owned would break all of `*x`/`.cloned()`/`and_then(fn(&Value))`)
+        was **deleted**, and all `.get()` were lowered to `.as_map().get()` to preserve borrow semantics (504 sites mechanically replaced).
+  - **mutation**: `insert`/`insert_if_absent`/`with_attr_mut` are `&self` (in-place under the write lock). `make_mut(attributes)`
+        sites become direct `&self` mutation.
+  - **Cross-frame visibility (the substance of the bug fix)**: added a new `id→Weak<cell>` registry (`instance_cells`).
+        `make_instance_with_id` **reuses** an existing live cell (writes the map and returns an alias-sharing instance).
+        `overwrite_instance_bindings_by_identity` **writes directly into the live cell** via `update_instance_cell(id, &updated)` before
+        scanning → mutations reach aliases in caller frames the scan never visits. This resolves `note`/$*ERR and closure-mediated
+        instance mutation. The registry is scaffolding to be removed together with the scan in Stage 2.
+  - **Preserving `.clone` (Raku's independent copy)**: hand-wrote `InstanceAttrs::clone` as a **deep copy (new cell, queue_destroy=false,
+        unregistered)**. Sharing happens only via `Arc<InstanceAttrs>` (Value clone). With this, the ~30 `(*attributes).clone()`
+        writeback sites keep independent-copy semantics unmodified. `temp`/`let` saves needed the same kind of independent snapshot
+        (`into_temp_snapshot` deep-copies the instance; restore writes back **into the live cell** via `make_instance_with_id`,
+        preserving identity and alias visibility) — neglecting this breaks temp restore in `t/lvalue-method-rw.t` (actually hit and fixed).
+  - Verification: cross-frame note/closure mutation, alias sharing, `.clone` independence, `===`/`.WHICH`/`eqv` identity, DESTROY (once),
+        temp/let restore — all match raku. clippy green.
+- [ ] **Stage 2 — make the cell the single source of truth (keystone) + abolish all propagation hacks**: the user's decision (2026-06-10) initially assumed a **single PR** →
+      it turned out that **wiring cell writeback for in-place mutation of array/hash attributes (`@!a.push`/`%!h<k>=`) is a separate-project-sized job**, so
+      the user re-decided (2026-06-10) to **slice by sigil** (scalars first).
+  - [x] **Stage 2a — wire scalar attributes (`$!x`/`$.x`) directly to the cell (landed: branch `phase3-stage2-scalar-cell`)**:
+        reads of `Var("!x")`/`Var(".x")` become direct reads of `self`'s shared cell (`read_self_attr_cell`, placed after the atomic/CAS check = CAS keeps
+        the traditional `shared_vars` to avoid livelock). Write paths — `exec_set_local_op`/`exec_assign_expr_local_op` (wrapped with
+        `mirror_attr_local_to_cell`), name-based `exec_assign_expr_op` (`$.x = v`/`$!x = v`, `mirror_attr_value_to_cell_by_name`),
+        post/pre inc & dec (`sync_attr_local_from_cell_by_name` → execute → mirror) — all write to the cell. **Scalar writeback
+        removed** (`writeback_attributes*` specialized to array/hash only; `AttrSlots::private/public` deleted). Instead, at method exit, while env/locals are live,
+        `reconcile_scalar_attrs` finalizes the attr map: "env/local changed from the entry snapshot → take that value; unchanged → take the live cell
+        value (adopting cross-frame/cell-direct mutations)" and feeds it to make_instance_with_id. This delivers to the cell the 3 paths that write env without
+        going through the cell: **attributive params (`method m($!s)`), no-twigil sigilless attrs (`has $x`), and `is rw` accessor
+        writes**. **Cross-frame scalar mutation bug fixed** (`self.bump` is visible to the caller's `$!x`; 11 vs old 10). Array/hash attributes,
+        CAS, registry/scan/detached/`instance_cells` kept until Stage 2b (cannot be deleted yet).
+        Verification: make test all green; S12-attributes/instance & native, S12-methods/{attribute-params,lastcall,defer-call,defer-next},
+        S17-lowlevel/cas (whitelist) PASS. Inherited same-name privates (Parent/Child `$!p`) behave the same as main — a pre-existing bug, not a regression.
+  - [x] **Stage 2b — wire array/hash attributes (`@!a`/`%!h`) directly to the cell (landed: branch `phase3-stage2b-array-hash-cell`)**:
+        reads go via `GetArrayVar`/`GetHashVar` as direct reads of `self`'s cell (generalized `read_self_attr_cell` to all 6 twigils =
+        `scalar_attr_twigil_base`→`attr_twigil_base`, returning `(bare, is_private)`). Wired an env→cell mirror
+        (`mirror_array_hash_attr_to_cell`) **after** each mutating op: `CallMethodMut`/`CallMethodDynamicMut`/`ArrayPush`/`IndexAssignExprNamed`/
+        `MultiDimIndexAssign`/name-based `AssignExpr`. **Crucially, take an env snapshot before the op** (`array_hash_attr_env_snapshot`) and
+        mirror only when env actually changed: non-mutating methods (`@!a.join`) also come through `CallMethodMut`, so unconditionally mirroring
+        a stale env copy would clobber cross-frame cell mutations (demonstrated and fixed in cf3). **Unified the scalar reconcile across all sigils**
+        (`reconcile_scalar_attrs`→`reconcile_attrs`, rule: "cell changed since entry → cell wins; otherwise adopt env changes" =
+        cross-frame/per-op mirrors let the cell win; attributive array params `method m(@!a)` and sigilless let env win).
+        With this, **array/hash writeback (`writeback_attributes*`) is fully removed** (the `AttrSlots` struct + `compute_attr_slots` also deleted, net -115 lines).
+        **Cross-frame array/hash mutation bug fixed** (a nested method's `@!a.push`/`%!h<k>=` visible to the caller).
+        Verification: make test all green; S12-attributes/methods, S14-traits, S17/cas (whitelist) PASS; Stage 2b edges 21/21
+        (push/pop/shift/unshift/element assign/non-`:delete`/whole-assign/cross-frame array+hash/attributive param/`.=`/chain/read-no-clobber).
+        Known unsupported (pre-existing, not regressions): `%!h<x>:delete` (DELETE-KEY goes via an Index target outside the mirror), the space-less
+        parse of `@b[0]=v`, inherited same-name privates. **materialize's array/hash insertion / the by-id scan (`overwrite_instance_bindings_by_identity`) /
+        the registry (`instance_cells`) / detached are not yet removed** = Stage 2c (next) abolishes them all on the grounds that the cell is the single source.
+  - [~] **Stage 2c — abolish all propagation hacks (started; slice 1 done)**: the cell is now the single source for all attrs, so remove the propagation scans.
+        - [x] **slice 1 — remove the by-id env/locals scan (branch `phase3-stage2c-drop-byid-scan`)**: **deleted entirely** the
+              `for bound in self.env.values_mut()` walk of `overwrite_instance_bindings_by_identity` + the recursive helper `overwrite_instance_recursive`
+              (the Instance/nested-attr/Mixin/ContainerRef arms), and the locals walk `overwrite_instance_in_locals` (+ 6 call sites). Propagation is consolidated
+              into the single `update_instance_cell(id, &updated)` (direct write to the live shared cell). **Rationale**: after Stage 1/2a/2b, all aliases of an
+              instance (same frame, caller frames, `ContainerRef` boxed captures, role `Mixin`s, nested attributes of other instances) share the
+              `Arc<InstanceAttrs>` reference and **see the same cell** (deep copy only on explicit `.clone`) → the holders the scan used to rebuild already shared
+              the same cell, so the scan was observationally a no-op. `_class_name` is vestigial (the cell is keyed by id) but the signature is kept to
+              avoid ~40 call-site churn (removed in a later slice). Verification: make test 6247; S12/S14/S17 whitelist
+              106 files, 2111 tests PASS (cross-thread cas, all role/mixin, cross-frame note/closure, nested, escaping-closure
+              scalar-holding-instance all green); clippy green. Net -108 lines.
+        - **materialize/reconcile removal (user's choice 2026-06-11, staged PRs)**: reconcile rewrites `attributes` (the entry snapshot) to the final values,
+              merging the 2 paths that bypass the cell: (a) attributive params (`method m($!x)`), (b) sigilless `has $x` (compiled to bare `Var("x")`,
+              distinguishable as an attribute only via the runtime alias table). `is rw` accessors etc. already reach the cell. Simply removing reconcile would let the
+              caller's cell writeback roll the cell back to the snapshot, so ultimately replace `reconcile → attributes = base.cell.to_map()` (cell as single source).
+              An exit mirror would cause the stale-clobber demonstrated in 2b, so write-time cell routing is mandatory. → Split into 3 stages: (i) attributive params,
+              (ii) sigilless cell-direct (equivalent to 2a), (iii) reconcile/materialize removal.
+          - [x] **(i) attributive params → cell (landed: branch `phase3-stage2c-registry-removal`)**: right after binding,
+                `mirror_attributive_params_to_cell` (reusing `mirror_attr_value_to_cell_by_name`; scalar/array/hash, all twigils) mirrors the params into
+                self's cell. **Also excluded attributive params from the read-only fast path** (added `attr_twigil_base(pd.name).is_some()` to
+                `has_complex_params`) —— attributive params mutate attributes but the fast path drops writeback, fixing the bug where the mutation vanished after
+                `$obj.m($!x)` (`method set-and-read($!x){ say $!x }` read the stale cell 99 instead of the in-body 7, and the attribute stayed 99).
+                Verification: make test 6247; S12/S14/S17/S06 whitelist 140 files, 2890 tests PASS; named `:$!x`/BUILD/array/hash params,
+                in-body reads, cross-frame all match raku. reconcile kept until (ii)(iii) (the attributive-param path is now redundant with the mirror but harmless).
+          - [x] **(ii) sigilless `has $x` made cell-direct (landed: branch `phase3-stage2c-sigilless-cell`)**: bare `Var("x")`
+                (sigilless attrs) is routed to the cell via the runtime `__mutsu_sigilless_alias::` table. **read**: extended `read_self_attr_cell` to go through
+                `canonical_attr_twigil` (direct twigil → as-is / bare sigilless → follow the alias chain and resolve the `!x` twigil).
+                Discovered that sigilless `$x` is read via **GetGlobal** (not GetLocal) since it is not a method-local declaration → also added a cell-direct read to the
+                GetGlobal handler in vm.rs (before the env read). **write**: added `write_self_attr_cell` to each alias target of the 6 alias-chain
+                propagation loops (inc/dec 4 + name-based assign 1 + SetGlobal 1), mirroring the attr-twigil alias (`!x`) to the cell. The 4 inc/dec
+                loops were duplicated, so factored them into the common helper `propagate_sigilless_alias_chain` (cell mirror included). **perf**: the read path is
+                hot, so gated by a new flag `Interpreter::sigilless_attrs_active` (a process-sticky bool set when materialize installs a sigilless alias)
+                → non-sigilless programs (the vast majority) pay only a string check. **Bug fixed**: same-frame/nested-frame sigilless reads were reading the
+                entry env copy (stale) (`method outer { self.inner; $y }` returned 10 where it should return 99 after inner's mutation).
+                Verification: make test 6247; S12/S14/S17/S06/S32-num whitelist 171 files 6432, S02/S03/S04 318 files 32004 PASS;
+                int.t perf 0.085s (no regression); nested-read/same-method write-read/inc-dec/closure/multi-attr all match raku.
+                reconcile kept until (iii) (the sigilless path is now cell-direct so reconcile case-2 is redundant but harmless).
+          - [x] **(iii-a) simplify reconcile to cell-single-source (landed: branch `phase3-stage2c-reconcile-removal`)**: removed
+                `reconcile_attrs`'s entry-snapshot-vs-env value comparison (the case-1 cell-changed / case-2 env-changed priority decision + sigil-by-type twigil
+                inference) in favor of `*attributes = base.cell.to_map()` (the cell is the single source). All plain writes (2a/2b/2c-i/ii) land in the cell at
+                write time, so the cell snapshot is the final value. **Exception = `:=`-bound attributes** (`$!x := $outer`): they hold an external ContainerRef in
+                env/locals and bypass the cell — **a third bypass** (discovered via has-attr-binding.t). After cell.to_map(), walk each attr key in env/locals
+                (bare sigilless + 6 twigils) and if it is a ContainerRef, adopt it preferentially, preserving the `:=` alias across method exit. Verification: make test 6260;
+                S12/S14/S17/S03-binding/S06 144 files 2994 PASS; has-attr-binding 6/6; all bypass/sigilless/attrparam tests match raku. (The 2 failures in
+                S32-temporal/DateTime.t are the pre-existing timezone bug of `Date.today`=UTC vs `DateTime.now.Date`=local; identical on a baseline with the changes
+                stashed = unrelated, an artifact of local JST only; on CI=UTC both agree and it passes.)
+          - [x] **(iii-b) remove the slow-path materialize's attr-value env copies (landed: branch `phase3-stage2c-materialize-removal`)**:
+                removed the attr-value env copy insertion (~30 lines: `!attr`/`.attr`/`@!attr`/`@.attr`/
+                `%!attr`/`%.attr`) on the complex-param method path (`call_compiled_method`). Reads are all cell-direct (2a/2b/2c-ii), exit reconcile is cell.to_map()
+                (iii-a), so it was redundant. The sigilless alias table setup + `is default` registration are kept. Verification: make test 6265; S12/S14/S04/S03-binding/S06
+                144 files 3076 PASS; cases where closures capture and read/write private/array/hash/sigilless attrs (returning readers/writers, nested+closure, map/gather)
+                all match raku.
+                ~~**The fast-path (`call_compiled_method_fast`) array/hash env copies are kept**~~ → **removed in (iii-c) (below)**.
+          - [x] **(iii-c) pre-op cell sync for mutating ops + fast-path env copy removal (branch `phase3-attr-cell-presync`)**:
+                extended `array_hash_attr_env_snapshot` (the pre-snapshot at every mutating-op site) to "**refresh env/locals from self's live cell**
+                first, then return the cell value as the pre" (no-op if the Arc ptrs match; `:=` ContainerRef keeps the legacy behavior).
+                This eliminates the accident of mutating and mirroring a closure-captured env copy (a stale snapshot from closure creation time),
+                **fixing the pre-existing bug "via a closure, `%!h{$k}=$v` keeps only the last write (the first write reads `(Any)`)"**.
+                Each closure call now starts from the live cell value. After the fix, removed the array/hash attr env copies in
+                `call_compiled_method_fast` (the ones kept in iii-b) — reads are cell-direct (2b) and mutation pre-op sync fills env, so they are unneeded.
+                **Bonus: wired the same pre-sync + mirror into `DeleteIndexNamed` (`%!h{$k}:delete`)**, also fixing Stage 2b's
+                pre-existing gap "DELETE-KEY is outside the mirror and never reaches the cell". Regression test `t/closure-attr-element-write.t` (16).
+        - [x] **registry removal (done, branch `phase3-drop-instance-cell-registry`)**: **abolished entirely** `instance_cells` (the `id -> Weak<cell>` global
+              Mutex registry) + `register_instance_cell`/`lookup_instance_cell`/`update_instance_cell`/`overwrite_instance_bindings_by_identity`.
+              Converted all ~98 writeback/rebuild sites (`overwrite_*` 47 + rebuild `make_instance_with_id` 51) to 3 new helpers that mutate the receiver's
+              `Arc<InstanceAttrs>` cell directly in place:
+              `InstanceAttrs::commit_attrs(map)` (in-place write to the live cell, via the deadlock-safe `write_cell_respecting_reads`) /
+              `Value::instance_sharing_cell(attrs, class, id)` (rebuild sharing the Arc; a new InstanceAttrs sharing the cell only when the class changes) /
+              `Value::write_back_sharing(attrs, class, map, id)` (commit + share combined). **Deleted the id→cell reuse branch from `make_instance_with_id`**
+              (from now on fresh-cell only = only for genuinely-new / sentinel ids). Sites that held only snapshot+id (`proxy_store`, buf writes, MRO multi
+              invocant, etc.) were solved by threading the receiver's Arc through the call chain. `make_instance_detached` became equivalent to `make_instance_with_id`
+              after registry removal but the name is kept as an intent marker for CAS atomic-sync (→ delegates to `make_instance_with_id`). Removed the `_class_name` vestigial param.
+              Side effects: resolved the global Mutex registry's Weak entry accumulation (memory leak) and the latent bug of id-0 sentinel Supplies mis-sharing cells.
+              Verification: cargo test 461, clippy green, whitelisted S12/S14/S17/S32-temporal/buf 40 files + cross-frame/closure/temp-let/proxy/buf/iterator/grammar all green.
+        - [x] **CAS cell-CAS-ification (branch `phase3-cas-cell`)**: migrated instance-attribute cas/atomic ops entirely from the shared_vars side channel
+              (`!attr::{id}` value keys / `__mutsu_atomic_attr::{id}::{attr}` / `__mutsu_instance::{id}` parent reclamation + env scan-replace /
+              `make_instance_detached` / `sync_atomic_attribute_to_instance`) to **atomic primitives directly on the cell**.
+              Added `InstanceAttrs::compare_and_swap(key, matches, new)` (compare+store under a single write lock) / `fetch_update(key, f)`
+              (RMW under a single write lock, for atomic add/inc/dec), and gave `builtin_cas_var` (3-arg/2-arg),
+              `builtin_atomic_update_unit`, and `builtin_atomic_{add,fetch_add,fetch,store}_var` an attr-cell branch
+              (`self_attr_cell_target`: `!x`/`.x` → self's cell + qualified key resolution). Stage 1's livelock is resolved now that
+              cell-direct reads (2a) are complete (confirmed by 5 consecutive cas.t PASSes).
+              **Discovered a second lost-update race**: the caller wrote back the method-exit reconcile snapshot whole-map via
+              `cell.commit_attrs(new_attrs)` every time → TOCTOU-clobbering concurrent cell-RMWs
+              (8 threads × `$!count⚛++` ×500 gave 2448/4000. On main it did not propagate to the parent at all = **0**).
+              **Fix**: `reconcile_attrs` returns a bool "were there adjustments beyond the cell snapshot (`:=` ContainerRef reclamation)?",
+              propagated to callers as `(Value, HashMap, bool)` — if unadjusted, **skip** the exit commit / `write_back_sharing`
+              (snapshot==cell so it is a no-op, and it is the race source). Commit only when adjusted (`:=`).
+              Side effect: the redundant whole-map write at every method exit is gone (perf). Regression test `t/cas-cell-attr.t` (14,
+              including 4-thread increment / 2-arg cas / parent visibility after await; matches raku).
+  - The old "single-shot" design (below) was split into Stage 2a/2b/2c. The following is a reference map.
 
-  #### 現状メカニズム（CI 調査で確定したフルマップ）
-  method frame は instance attr を **env/locals コピー**で持ち、cell は writeback でしか同期されない:
-  - **materialize（method entry）**: `vm_method_dispatch.rs:~380-430` が attr ごとに env `!attr`/`.attr`/`@!attr`/`@.attr`/
-    `%!attr`/`%.attr` を **value コピー**で挿入。private は `qualified_key = "{owner_class}\0{attr}"` を優先
-    （継承の Parent/Child 同名 disambiguation）。`is default(...)` は `set_var_default("!attr")` で登録。
-    sigilless alias（trait handles）は `__mutsu_sigilless_alias::` で双方向。
-  - **read（body）**: `$!attr` は **plain `Var("!x")`** にコンパイル → `exec_get_local_op`（`vm_var_assign_ops.rs:4131`）が
-    `locals[idx]`（env `!attr` から dual-store sync 済み）を返す。cas dirty は env 優先（4147 コメント）。
-  - **write（body）**: `exec_set_local_op`（4281）/`exec_assign_expr_local_op`（5480）。type-object への `$!attr=` は die。
-    bind/rebind/constant/vardecl/decont-marker など多数の context と絡む。
-  - **writeback（method exit）**: `writeback_attributes_from_locals`/`writeback_attributes`
-    （`vm_method_dispatch.rs:586/607/1088/1105`）が locals/env の `!attr` を instance attrs へ集約 → 再構築。
-  - **cas 側道**: `$!attr` の cas は env `!attr` + `shared_vars`（`__mutsu_atomic`/`__mutsu_instance::`）が真実源、
-    cell は `make_instance_detached` で別途同期（Stage 1 で race 回避のため detached 化）。
+  #### Current mechanism (full map established by CI investigation)
+  A method frame holds instance attrs as **env/locals copies**, and the cell is synchronized only via writeback:
+  - **materialize (method entry)**: `vm_method_dispatch.rs:~380-430` inserts, per attr, env keys `!attr`/`.attr`/`@!attr`/`@.attr`/
+    `%!attr`/`%.attr` as **value copies**. Privates prefer `qualified_key = "{owner_class}\0{attr}"`
+    (Parent/Child same-name disambiguation under inheritance). `is default(...)` is registered via `set_var_default("!attr")`.
+    Sigilless aliases (trait handles) are bidirectional via `__mutsu_sigilless_alias::`.
+  - **read (body)**: `$!attr` compiles to a **plain `Var("!x")`** → `exec_get_local_op` (`vm_var_assign_ops.rs:4131`) returns
+    `locals[idx]` (dual-store-synced from env `!attr`). cas dirty prefers env (comment at 4147).
+  - **write (body)**: `exec_set_local_op` (4281) / `exec_assign_expr_local_op` (5480). `$!attr=` on a type object dies.
+    Intertwined with many contexts: bind/rebind/constant/vardecl/decont-marker, etc.
+  - **writeback (method exit)**: `writeback_attributes_from_locals`/`writeback_attributes`
+    (`vm_method_dispatch.rs:586/607/1088/1105`) aggregate `!attr` from locals/env into the instance attrs → rebuild.
+  - **cas side channel**: for `$!attr`, cas's source of truth is env `!attr` + `shared_vars` (`__mutsu_atomic`/`__mutsu_instance::`);
+    the cell is synchronized separately via `make_instance_detached` (detached in Stage 1 to avoid the race).
 
-  #### keystone（実装方針）
-  `$!attr`/`$.attr`/`@!`/`@.`/`%!`/`%.` の read/write を **self の cell 直結**にする:
-  - var handler に attr-twigil 判定（`attr_twigil_base(name) -> Option<&str>`: `!x`/`.x`/`@!x`/… → `x`）を入れ、
-    env `self`(Instance) の cell から read / cell へ write。継承 qualified key は cell 側に `owner\0attr` を保持するか、
-    owner_class を frame に持たせて解決（materialize と同じ優先順位を cell read で再現）。
-  - **materialize 撤去**（env コピー挿入をやめる）、**writeback 撤去**（`writeback_attributes*`）、
-    **cas を cell-CAS 化**（cell の write-lock を atomic primitive に。Stage 1 で livelock したのは read が env コピー経由
-    だったから＝cell 直結後は解消する。これが cell-direct read の検証ケース）。
-  - これらが入れば **`overwrite_instance_bindings_by_identity` + by-id scan（17ファイル~50サイト）/ `instance_cells`
-    レジストリ / `HELD_READ_CELLS`+deferred-write / `make_instance_detached` / `update_instance_cell` / CoW `make_mut`16**
-    を全廃。`temp`/`let` の cell 書き戻しも素直化。
+  #### Keystone (implementation policy)
+  Wire the read/write of `$!attr`/`$.attr`/`@!`/`@.`/`%!`/`%.` **directly to self's cell**:
+  - Add an attr-twigil check to the var handlers (`attr_twigil_base(name) -> Option<&str>`: `!x`/`.x`/`@!x`/… → `x`), and
+    read from / write to the cell of env `self` (Instance). For inherited qualified keys, either hold `owner\0attr` on the cell side, or
+    carry owner_class in the frame and resolve (reproduce materialize's priority order in the cell read).
+  - **Remove materialize** (stop inserting env copies), **remove writeback** (`writeback_attributes*`),
+    **cell-CAS-ify cas** (make the cell's write lock the atomic primitive. Stage 1's livelock happened because reads went through env copies
+    = it resolves once reads are cell-direct. This is the verification case for cell-direct reads).
+  - Once these are in, abolish entirely: **`overwrite_instance_bindings_by_identity` + the by-id scans (17 files, ~50 sites) / the `instance_cells`
+    registry / `HELD_READ_CELLS`+deferred-write / `make_instance_detached` / `update_instance_cell` / CoW `make_mut` ×16**.
+    `temp`/`let` cell write-back also becomes straightforward.
 
-  #### リスク / 検証
-  - hot path（var read/write）と dual-store（locals↔env sync）の中核を触る＝Stage 1 級の blast radius。CI 反復前提。
-  - 必須検証: 継承同名 attr（Parent/Child `$!priv`）、`@!`/`%!` の container type metadata、sigilless alias（trait handles）、
-    `is default`/`.VAR.default`、rw accessor、cas（cell-CAS で 4000）、cross-frame、temp/let、DESTROY。
-  - perf: cell read は env コピー読みより重い（self 取得 + read-lock + clone）。Stage 3 の escape 解析で非エスケープ
-    instance を bare 値に戻して救済。
-- [ ] **Stage 3 — 仕上げ / perf**: escape 解析で「捕捉も `.clone` もされない instance はセル省略」（hot path 救済。
-      Phase 1 のスカラーと同型）。型メタ副テーブルの Arc-ptr keying もセルに載せて廃止（Q2 flaky 吸収）。
-      **再評価（2026-06-12 perf 計測で確定）**: 両サブ項目とも**現時点では着手しない**。
-      - **escape 解析セル省略は数値が支持しない**: bench-class heavy の release プロファイルで cell の
-        RwLock は self-time top30 に**現れない**。支配的コストは **allocator ~48%**（`_int_malloc` 18% +
-        `memmove` 12% + realloc/free）＝ `Value::clone` + HashMap churn。startup 補正後の実効倍率は
-        bench-class **~4x** / method-call **~5.5x** raku（startup 込みでは 2.1x/2.2x、mutsu startup 0.01s vs
-        raku 0.09s）。セル省略より alloc 削減が先。
-      - **型メタの instance 側は既に安定キー**: `instance_type_metadata` は `HashMap<u64(instance id), _>`
-        で Arc-ptr ではない（flaky 無関係）。Q2 flaky の根は Array/Hash/Set/Bag/Mix の Arc-ptr keyed
-        副テーブル → **要素セル Phase 2（トラック B）の領域**であり本 Phase 3 では扱えない。
-      - **プロファイルで見つけた安い perf 候補**（Stage 3 の代替実体）:
-        (a) `reset_atomic_var_key_decl`（self 3.7%）— VarDecl 毎に `format!` + shared_vars **write lock**、
-        atomic 未使用でも。既存の `atomic_var_seen()` process-sticky bool でゲートするだけ。
-        (b) method exit の `reconcile_attrs` が毎呼び出し `cell.to_map()`（attr map 全 clone）— 返り値の
-        HashMap は今や proxy_fetch と（gated）commit でしか使われない。lazy 化／必要時のみ clone へ。
-        (c) 残りは `Value::clone`/env insert の alloc 削減＝より大きな独立プロジェクト。
+  #### Risks / verification
+  - This touches the core of the hot path (var read/write) and the dual store (locals↔env sync) = Stage-1-class blast radius. Assumes CI iteration.
+  - Mandatory verification: inherited same-name attrs (Parent/Child `$!priv`), container type metadata for `@!`/`%!`, sigilless aliases (trait handles),
+    `is default`/`.VAR.default`, rw accessors, cas (4000 under cell-CAS), cross-frame, temp/let, DESTROY.
+  - perf: a cell read is heavier than reading an env copy (fetch self + read-lock + clone). Stage 3's escape analysis rescues by
+    reverting non-escaping instances to bare values.
+- [ ] **Stage 3 — finishing / perf**: use escape analysis to "omit the cell for instances that are neither captured nor `.clone`d" (hot-path rescue;
+      same shape as Phase 1 scalars). Also move the type-meta side tables' Arc-ptr keying onto the cell and abolish it (absorbing the Q2 flake).
+      **Re-evaluation (settled by the 2026-06-12 perf measurements)**: **neither sub-item is worth starting at this point**.
+      - **Escape-analysis cell omission is not supported by the numbers**: in the release profile of bench-class heavy, the cell's
+        RwLock **does not appear** in the self-time top 30. The dominant cost is the **allocator ~48%** (`_int_malloc` 18% +
+        `memmove` 12% + realloc/free) = `Value::clone` + HashMap churn. The startup-corrected effective ratio is
+        bench-class **~4x** / method-call **~5.5x** raku (2.1x/2.2x including startup; mutsu startup 0.01s vs
+        raku 0.09s). Allocation reduction comes before cell omission.
+      - **The instance side of type meta already has stable keys**: `instance_type_metadata` is a `HashMap<u64(instance id), _>`,
+        not Arc-ptr (unrelated to the flake). The root of the Q2 flake is the Arc-ptr keyed side tables of Array/Hash/Set/Bag/Mix
+        → **the territory of element cells, Phase 2 (Track B)** and cannot be handled in this Phase 3.
+      - **Cheap perf candidates found in the profile** (the de-facto replacement of Stage 3):
+        (a) `reset_atomic_var_key_decl` (self 3.7%) — a `format!` + shared_vars **write lock** on every VarDecl,
+        even when atomics are unused. Just gate it with the existing `atomic_var_seen()` process-sticky bool.
+        (b) `reconcile_attrs` at method exit does `cell.to_map()` (full clone of the attr map) on every call — the returned
+        HashMap is by now used only by proxy_fetch and the (gated) commit. Make it lazy / clone only when needed.
+        (c) The rest is allocation reduction for `Value::clone`/env inserts = a larger independent project.
 
-#### 必須の正しさ監査（切替時に同梱）
+#### Mandatory correctness audit (bundle with the switch)
 
-- **`.clone`（Raku の独立コピー）は新セルを作る（deep copy）**: 共有セル化すると clone がセル共有になり
-      `$b = $a.clone; $b.x = 1` が `$a` を汚す。`clone` メソッド（および `but`/mixin の独立コピー意味論）は
-      **明示的にセルを複製**する必要がある。現状の「値 clone = 独立コピー」が無料で与えていた意味論を再現せよ。
-- **dynamic var は lexical capture しない**: `call_compiled_closure` の captured-env merge（`vm_closure_dispatch.rs`
-      ~230）が captured `$*ERR`（stale）を overlay に入れ live parent を shadow する。twigil `*` を capture から除外。
-      （セル化単独でも読み取り側でこれが要る。）
-- **制御フロー名除外**: lexical `&`-var dispatch を将来再開する際、`return`/`take`/`emit`/`callsame`/… は
-      `call_function` の match が直接処理するので dispatch から除外（`&r=&return` 無限再帰防止。`is_builtin_function`
-      に無い名が複数）。
-- **eqv / WHICH / 比較**: instance 同一性比較（`===`/`.WHICH`）は id ベースのまま（セル共有でも id 不変）。
-- **シリアライズ / precompilation**: セルは ContainerRef 同様プロセス越境で保存されない。`closure_captured_state`
-      相当の per-instance 状態経路を壊さないか確認（[[project_lever_b_slice63_prep]] の precompilation 回帰の轍）。
+- **`.clone` (Raku's independent copy) creates a new cell (deep copy)**: with shared cells, clone would share the cell and
+      `$b = $a.clone; $b.x = 1` would pollute `$a`. The `clone` method (and the independent-copy semantics of `but`/mixins) must
+      **explicitly duplicate the cell**. Reproduce the semantics that the current "value clone = independent copy" gave for free.
+- **Dynamic vars are not lexically captured**: the captured-env merge in `call_compiled_closure` (`vm_closure_dispatch.rs`
+      ~230) puts a captured (stale) `$*ERR` into the overlay, shadowing the live parent. Exclude twigil `*` from capture.
+      (This is needed on the read side even with cell-ification alone.)
+- **Control-flow name exclusion**: when re-enabling lexical `&`-var dispatch in the future, `return`/`take`/`emit`/`callsame`/… are
+      handled directly by the match in `call_function`, so exclude them from dispatch (preventing `&r=&return` infinite recursion; several names
+      are not in `is_builtin_function`).
+- **eqv / WHICH / comparison**: instance identity comparison (`===`/`.WHICH`) stays id-based (id is invariant under cell sharing).
+- **Serialization / precompilation**: cells, like ContainerRef, are not preserved across processes. Check that the per-instance state path
+      equivalent to `closure_captured_state` is not broken (the precompilation-regression lesson of [[project_lever_b_slice63_prep]]).
 
-#### これで解ける roast / 症状
+#### Roast tests / symptoms this solves
 
-- `$!x :=` / per-attribute container template（S03-binding/attributes, S14-traits/attributes 5-8）。
-- closure-provided block 内の `note`/dynamic-handle 書き込み（テストハーネス `sub cap(&code){ my $*ERR=...; code() }`）。
-- closure 内の任意の caller-held instance への変異メソッド。
-- トラック A lexical `&`-var dispatch の前提解消（[[project_lexical_amp_var_blocked]]）。
+- `$!x :=` / per-attribute container templates (S03-binding/attributes, S14-traits/attributes 5-8).
+- `note`/dynamic-handle writes inside closure-provided blocks (the test-harness pattern `sub cap(&code){ my $*ERR=...; code() }`).
+- Mutating methods on any caller-held instance inside a closure.
+- Removes the prerequisite blocking Track A lexical `&`-var dispatch ([[project_lexical_amp_var_blocked]]).
 
-#### 最初のスライス
+#### First slice
 
-**Stage 0（compat read API + 127 read サイト移行、挙動不変）**から。これが入れば Stage 1 の表現切替が
-レビュー可能な単位になる。Stage 0 自体は機能変化ゼロなので CI でほぼ確実に緑、安全に大きく入れられる。
-
----
-
-## 5. 統一で削除できる workaround（メンテ性の勝ち筋）
-
-コンテナ統一が進むと以下の散在ハックが**不要化**する（= 削除対象）:
-- dual-store env↔locals の双方向 sync（レバー B と連動）
-- Arc-pointer-keyed 型メタ副テーブル（PLAN Q2 項目。flaky の根。コンテナに型メタを載せれば消滅）
-- ad-hoc itemization フラグ（`ArrayKind::ItemList/ItemArray` と `Value::Scalar` の二重化）
-- grep-rw-view binding（`Arc`-pointer keyed、`=` 代入を跨いで残存するバグ持ち）
-- name-based writeback reconcile（map/grep の rw エイリアス）
-
-## 6. 速度の担保
-
-- **エスケープ解析**でコンテナを省略（捕捉も `.VAR` もエイリアスもされないローカルは bare 値）。
-- 配列は **COW** で読みはクローン無し。
-- decont は単一分岐で予測が効く。
-- 中期の NaN-boxing で payload 8 byte 化すればセルも安価。
+Start with **Stage 0 (compat read API + migrating the 127 read sites, behavior-preserving)**. Once that is in, Stage 1's representation switch
+becomes a reviewable unit. Stage 0 itself has zero functional change, so CI is almost certainly green and it can be landed large, safely.
 
 ---
 
-## 7. 値読み出し opcode の棚卸し（Phase 0.5 地ならし / Phase 1 の設計図）
+## 5. Workarounds deletable through unification (the maintainability win)
 
-「スタックに積む値は常に decont 済み」不変条件を Phase 1 で確立するための前段棚卸し。各値読み出し
-opcode が **今 push しうるコンテナ形** と **Phase 1 の目標** を対比する。`GetLocalRaw` が「生セルを
-push する lvalue 読み」の既存前例（アンカー）で、Phase 1 の新 lvalue opcode
-（`GetLocalContainer`/`IndexContainer`）はこれを一般化する。
+As container unification progresses, the following scattered hacks become **unnecessary** (= deletion targets):
+- the bidirectional dual-store env↔locals sync (coupled with lever B)
+- the Arc-pointer-keyed type-meta side tables (the PLAN Q2 item; root of the flake. Carrying type meta on the container removes them)
+- the ad-hoc itemization flags (the duplication of `ArrayKind::ItemList/ItemArray` and `Value::Scalar`)
+- grep-rw-view binding (`Arc`-pointer keyed; has the bug of surviving across `=` assignment)
+- name-based writeback reconcile (the rw aliases of map/grep)
 
-| opcode | ハンドラ | 今 push しうる形 | 今の deref | Phase 1 目標 |
+## 6. Guaranteeing speed
+
+- **Escape analysis** omits containers (locals that are never captured, `.VAR`ed, or aliased stay bare values).
+- Arrays are **COW**, so reads are clone-free.
+- decont is a single branch and predicts well.
+- With mid-term NaN-boxing shrinking the payload to 8 bytes, cells become cheap too.
+
+---
+
+## 7. Inventory of value-read opcodes (Phase 0.5 groundwork / Phase 1 blueprint)
+
+A preparatory inventory for establishing the "values pushed onto the stack are always deconted" invariant in Phase 1. For each value-read
+opcode, it contrasts **the container shapes it can currently push** with **the Phase 1 goal**. `GetLocalRaw` is the existing precedent (anchor)
+for "an lvalue read that pushes the raw cell"; Phase 1's new lvalue opcodes
+(`GetLocalContainer`/`IndexContainer`) generalize it.
+
+| opcode | handler | shapes it can push today | current deref | Phase 1 goal |
 |--------|---------|-----------------|-----------|-------------|
-| `GetLocalRaw` | `vm_var_assign_ops.rs:exec_get_local_raw_op` (~4101) | **生セル**（deref/descalarize 無し。DeferredHashAccess/HashSlotRef も解決しない） | なし（意図的・`=:=` 用） | **lvalue opcode の設計テンプレ** |
-| `GetLocal` | `vm_var_assign_ops.rs:exec_get_local_op` (~4108) | ContainerRef は `into_deref` 済み（本 PR で集約）。Scalar/ItemArray は素通し | ContainerRef→inner（単一段） | 常に decont 済み |
-| `GetGlobal` | `vm.rs:851-1078` (inline) | 同上 | ContainerRef→inner（単一段） | 常に decont 済み |
-| `GetArrayVar` | `vm.rs:1079-1138` (inline) | Hash→Pairs 変換のみ。Scalar/ContainerRef/ItemArray 素通し | なし | 常に decont 済み（**実挙動変化・次段**） |
-| `GetHashVar` | `vm.rs:1139-1201` (inline) | 素通し | なし | 常に decont 済み（次段） |
-| `Index` | `vm_var_index_ops.rs:exec_index_op_with_positional` (~265-269) | Scalar は unwrap、ContainerRef/ItemArray は素通し | 部分（Scalar のみ） | 常に decont 済み（**実挙動変化・次段**） |
+| `GetLocalRaw` | `vm_var_assign_ops.rs:exec_get_local_raw_op` (~4101) | **raw cell** (no deref/descalarize; does not resolve DeferredHashAccess/HashSlotRef either) | none (intentional; for `=:=`) | **design template for lvalue opcodes** |
+| `GetLocal` | `vm_var_assign_ops.rs:exec_get_local_op` (~4108) | ContainerRef is `into_deref`ed (consolidated in this PR). Scalar/ItemArray pass through | ContainerRef→inner (single level) | always deconted |
+| `GetGlobal` | `vm.rs:851-1078` (inline) | same as above | ContainerRef→inner (single level) | always deconted |
+| `GetArrayVar` | `vm.rs:1079-1138` (inline) | only Hash→Pairs conversion. Scalar/ContainerRef/ItemArray pass through | none | always deconted (**actual behavior change; next stage**) |
+| `GetHashVar` | `vm.rs:1139-1201` (inline) | passes through | none | always deconted (next stage) |
+| `Index` | `vm_var_index_ops.rs:exec_index_op_with_positional` (~265-269) | Scalar is unwrapped, ContainerRef/ItemArray pass through | partial (Scalar only) | always deconted (**actual behavior change; next stage**) |
 
-**ContainerRef 値読みの集約面は厳密に 2 サイト**（`GetLocal` / `GetGlobal`）。他の
-`arc.lock().unwrap().clone()` は別軸（LazyList cache）か read-modify-**write**（increment サイト
-`vm_misc_ops.rs:879/927/956/1004`, `vm_var_assign_ops.rs:1468/1514/1606/1652` — 同じ arc に書き戻すので
-into_deref で arc を consume したら壊れる）であり**値読みではない**。よって本 PR の集約対象外。
+**The consolidation surface for ContainerRef value reads is exactly 2 sites** (`GetLocal` / `GetGlobal`). The other
+`arc.lock().unwrap().clone()` occurrences are either a different axis (LazyList cache) or read-modify-**write** (the increment sites
+`vm_misc_ops.rs:879/927/956/1004`, `vm_var_assign_ops.rs:1468/1514/1606/1652` — they write back to the same arc, so consuming
+the arc with into_deref would break them) and are **not value reads**. Hence out of scope for this PR's consolidation.
 
-**次段（Phase 1 と同梱）で入る挙動変化**: `GetArrayVar`/`Index`/`GetHashVar` を「常に decont 済みを
-push」に変えると、配列要素が `Value::Scalar`/`ContainerRef`/`ItemArray` を持つケースで観測可能な挙動変化
-が起きる（`$(...)`/`.VAR`/itemization）。「いつ decont し、いつコンテナを保持するか」は Phase 1 の
-スカラー・コンテナ意味論が前提なので、新 lvalue opcode の本配線と合わせて Phase 1 と同一 PR で実施する。
+**Behavior changes that land in the next stage (bundled with Phase 1)**: changing `GetArrayVar`/`Index`/`GetHashVar` to "always push
+deconted" produces observable behavior changes in cases where array elements hold `Value::Scalar`/`ContainerRef`/`ItemArray`
+(`$(...)`/`.VAR`/itemization). "When to decont and when to keep the container" presupposes Phase 1's
+scalar-container semantics, so it will be done in the same PR as Phase 1, together with the real wiring of the new lvalue opcodes.
 
-## 進捗ログ
+## Progress log
 
-（PR ごとに追記）
+(appended per PR)
 
-- 2026-06-06: 台帳作成。現状の 3 表現と `:=` 平坦化バグの完全トレースを記録。コード未変更。
-- 2026-06-08: **Phase 0 着手（decont ヘルパ統合・挙動不変）**。3 軸（Scalar / ContainerRef /
-  ArrayKind itemization）は別の型・別の意味論なので**融合せず**、各軸に正規ヘルパを制定して散在する
-  アドホック展開を集約する方針に確定（融合は `is rw` writeback の Pair 判定・`@a=$l` 平坦化を壊すため）。
-  - PR1 (#2736): `Value::decontainerize` → `descalarize` 改名 + owned `into_descalarized` 追加 + decont
-    family doc。重複していた再帰 `strip_scalar` を削除、`methods.rs` の再帰 `while let Scalar` ループ 4 件を
-    集約。`OpCode::Decont`（単一段）と recursive helper の違いをコメントで明示。
-  - PR2 (#2737): 単一 Scalar-arm 関数の再帰アドホック展開を `descalarize`/`into_descalarized` へ集約
-    （ops の bag/mix multiply、utils の coerce_to_hash/numeric/set/quanthash、methods_narg の 1arg/2arg）。
-    単一段サイト・`.VAR` ガード付き dispatch・mixed-axis（eqv/truthy/isa）・exhaustive match の
-    value_type_name は意図的にインライン維持。
-  - PR3: ContainerRef 読み軸。既存 `deref_container` は常に clone するため in-place 読み（lock して
-    `&inner` を使う）サイトには不適（clone 追加）、hot read-opcode には致命的（全読みで clone）。
-    そこで**非 clone の正規リーダ `Value::with_deref<R>(&self, f) -> R`** を新設し `deref_container` を
-    その上に再定義、in-place 読み 6 箇所（utils value_type_name / introspect dispatch_what /
-    display to_string_value / types eqv・truthy・isa_check・what_type_name の ContainerRef arm）を集約。
-    hot read-opcode（GetLocal/GetGlobal の move-or-clone）と Group B（束縛/identity/write-through）は
-    Phase 0.5 / Phase 1 へ後送り（現状維持）。
-  - いずれも挙動不変を確認: `make test` PASS（5274）、binding/flatten/set/bag/mix/eqv の roast は
-    plan/ran/failed カウントがベースライン一致（pre-existing 非 whitelist 失敗は不変）。
-- 2026-06-08: **Phase 0.5 第1段（挙動不変な地ならし）**。ユーザー判断で段階的アプローチを採用 — 挙動変化を
-  伴う stack 不変条件（`GetArrayVar`/`Index` の auto-decont）と新 lvalue opcode の本配線は Phase 1 と同梱の
-  次段へ送り、本 PR は安全に切り出せる地ならしのみ:
-  - **`Value::into_deref(self)` 追加**（ContainerRef 軸の owned move-through 版。`descalarize`↔
-    `into_descalarized` と同型の `deref_container`↔`into_deref` ペアを完成）。PR3 が「hot read-opcode
-    GetLocal/GetGlobal の move-or-clone … 現状維持」として明示的に後送りした分を集約。
-  - `GetLocal`（`vm_var_assign_ops.rs` ~4206、`is_container_ref()` gate で早期 return 構造維持）と
-    `GetGlobal`（`vm.rs` ~1071）の手書き inline `arc.lock().unwrap().clone()` を `into_deref` へ集約。
-    非 ContainerRef は move 維持（hot path の挙動/perf 完全不変）。
-  - §7 に値読み出し opcode の棚卸し表を追加（Phase 1 の設計図。`GetLocalRaw` を lvalue 読みのアンカー前例に）。
-  - 挙動不変を確認: build/clippy/fmt PASS。binding/`.VAR`/`=:=`/sigilless の t/ + S03-binding roast 全 PASS。
-    全 roast は CI に委譲。
-- 2026-06-08: **Phase 1 第1スライス（非ループ兄弟クロージャの broad boxing）を試行 → revert（重要な教訓）**。
-  `box_captured_lexicals` のループ限定ゲートを撤去し非ループの捕捉＋変異 `$` スカラーも `ContainerRef` 化する
-  approach を試したが、**性能・正しさの両面で under-scoped** と判明し revert。理由を記録（次スライスの設計制約）:
-  - **(1) mutation-writeback ギャップ（部分的に対処可）**: `into_deref`（PR #2742）は**読み**だけを cell 対応に
-    したが、**変異の書き戻し**は cell 非対応だった。具体的に `overwrite_instance_recursive`
-    （`runtime/methods_mut.rs`、変異メソッドの結果を instance identity で全 env 束縛へ伝播するチョークポイント）が
-    `Value::ContainerRef` の中を見ず、boxed スカラーが instance を保持して変異メソッドを受けると変異が消えた
-    （`my $x; lives-ok { $x = Obj.new }; lives-ok { $x.mutate }; $x.read` という **roast 頻出のテストヘルパ
-    パターン**。submethods.t / S24-testing / test-util 等が回帰）。`ContainerRef` arm 追加で修正可能と確認したが、
-    これは「mutation 経路を全て cell 対応にする broad audit」の入口に過ぎない。
-  - **(2) 深刻な性能回帰（approach を否定する決定打）**: broad boxing は **closure 生成毎に**捕捉＋変異の全
-    自由変数を `Arc<Mutex>` 化し env へ insert する（= env COW のディープクローン誘発）。loop-only 制限は
-    正しさだけでなく **boxing コストの上限**でもあった。撤去した結果 `roast/S32-num/int.t` が **1 秒 → 150s+
-    に激遅化**（3 ファイルを main へ戻すと 1 秒に復帰、と差分で確定）。`make test` では露見せず CI の release
-    全 roast で timeout として顕在化。
-  - **教訓 / 次スライスの設計制約**: 兄弟クロージャ共有は **escape 解析（脱出する＝返却/外部格納される
-    クロージャの捕捉だけ box。`lives-ok {…}` のような即時呼び出し引数クロージャは box しない）** で
-    boxing 対象を絞り、かつ **mutation-writeback を cell 対応化**してから入れる必要がある。素朴な
-    「ループ限定を外すだけ」は不可。これは §6「速度の担保＝エスケープ解析でコンテナを省略」の実証でもある。
-  - revert で main は clean（`#2742` の `into_deref` 地ならしのみ残す）。`int.t` は 1 秒に復帰。
-- 2026-06-08: **Phase 1 第1スライス再設計（escape-aware）= 成功**。前回の教訓どおり box 対象を精密 signal で
-  絞り、非ループ兄弟クロージャのコンテナ共有を実装。
-  - **コンパイラ signal `multi_captured_mutated_locals`**（`opcode.rs` `compute_free_vars`）: own-local を
-    捕捉する distinct な子クロージャ数を数え、**≥2** かつ `captured_mutated` のものを集合化。
-  - **`box_captured_lexicals`**（`vm_register_ops.rs`）: box 条件を (A) ループローカル（既存・不変）OR
-    (B) `multi_captured_mutated_locals`（新・非ループ兄弟）に。型/`where` 制約ガードは (B) のみに適用
-    （ループパスは byte 単位で維持）。`>=2` 制限が `lives-ok {…}`（1 クロージャ）を除外し、前回の perf 爆発
-    （`Arc<Mutex>`+env COW を closure 生成毎）と correctness 回帰（テストヘルパパターン）を**構造的に回避**。
-  - **mutation-writeback を cell 対応化**: `overwrite_instance_recursive`（env 経路）と
-    `overwrite_instance_in_locals`（locals 経路）に `ContainerRef` arm を追加（boxed スカラーが instance を
-    保持して変異メソッドを受けても共有セルを通して伝播）。`try_eval_simple_protect_expr` の Var 直接読みに
-    `into_deref` を追加（fast-path の値漏れ防止）。
-  - 検証: ターゲット `make(); $s(42); $g()` → `42`。**`int.t` は ~1s/165 維持（性能回帰なし）**、重量級 roast
-    サンプル 11 ファイル 2314 テストが 3 秒で完走。`where-constraint-var.t`（block/whatever where がガードで保護）/
-    `submethods.t` / `S24-testing` / closure 一式 全 PASS。`make test` PASS（456 unit + 5315 prove）。
-    `gather.t` 38 は Phase 2 take-rw の既知未対応（非 whitelist・無関係）。
-  - **範囲外（次スライス）**: 単一の脱出クロージャ（`my &f; { my $a=3; &f=sub{$a++} }` → 3,0）は 1 クロージャで
-    multi に入らず未修正。`.VAR.^name` 反映 / `is rw` 3-way persistent も別スライス。
-- 2026-06-08: **step 1 = escape 解析（コンパイラ・キーストーン）= 成功**。PLAN.md §🟣「実装順序」step 1。
-  `multi_captured_mutated_locals`（「≥2 兄弟クロージャに捕捉」という proxy）を、本来の信号 **escape 解析**
-  （捕捉する子クロージャの値がフレームを脱出するか）に置換。proxy ではなく本機構にしたことで、単一脱出
-  クロージャを**構造的に**捕捉し、かつ即時呼び出し（`lives-ok {...}`/`map {...}`）は非 box のまま維持。
-  - **コンパイラ signal**: `Compiler::escaping_position`（bool）+ `with_escape(escaping, f)` save/restore ヘルパ。
-    escaping=true: 代入/`:=` RHS（`compile_assignment_rhs_for_target`）、`return`/`fail` operand、ブロック/
-    ルーチン tail（`helpers_sub_body.rs` の last-`Stmt::Expr` 3 箇所 + `mod.rs` top-level tail）、配列/ハッシュ/
-    capture リテラル要素。escaping=false（既定）: 呼び出し引数（`compile_call_arg`/`compile_method_arg` で
-    リセット＝#2746 ガード。`my @r = map {...}` のように call が脱出位置でも引数クロージャは非 box）。
-  - **データ**: `CompiledCode.closure_escapes: Vec<bool>`（`closure_compiled_codes` と添字一致）。
-    `add_closure_code(code, escapes)` が `escaping_position` を記録。`compute_free_vars` は子を enumerate して
-    `closure_escapes[i]` を見、捕捉×変異 own-local を**脱出する子に捕捉**されたら `needs_cell_locals`
-    （旧 `multi_captured_mutated_locals` をリネーム）へ。`captured_mutated_locals`（path A ループ boxing 用）は不変。
-  - **VM**: `box_captured_lexicals` の path B が `needs_cell_locals` を参照（型/`where` ガード・path A は byte-for-byte 不変）。
-  - 検証: `$f = sub{$a++}` 単一脱出（`my $f`/`&f()`）→ 3/4（旧 3/0）。兄弟 `make(); $s(42); $g()` → 42（subsume）。
-    factory `return sub{$n++}` → 0/1/0。即時呼び出し `for`/`map` → 非 box（3 / 12）。**perf カナリア
-    int.t 0.21s 維持（#2746 回帰なし）**。`make test` PASS（458 unit + 5315 prove）、clippy clean、
-    S03-binding/closure・S04-declarations/state・pointy(-rw) 等 whitelist PASS。
-  - **bareword `f()` 抜けたブロック捕捉バグも修正**: `my &f; { my $a=3; &f=sub{$a++} }; f(); f()` が
-    `3,0`（read-only `sub{$a}` は `3,Nil`）だった件。bareword `f()` は interpreter の `call_sub_value` 経由、
-    `&f()`/`$f()` は VM の cell 対応 dispatch（`call_compiled_closure`）経由 — dual-store 分岐で VM 経路は元々正しい。
-    原因: `call_sub_value` のキャプチャ env マージが `merge_all=true` で `ContainerRef`（共有セル）も
-    `entry_or_insert`（caller 優先）していたため、宣言ブロックが漏らした stale 値や前回呼びの writeback が
-    生きたセルを隠し、2回目の呼びで失われていた。修正: **マージで `ContainerRef` だけ `insert_sym`（上書き）して
-    生きたセルを必ず採用**（VM `call_compiled_closure` と同じ「セルが真実の源」原則。`box_captured_lexicals` が
-    捕捉×変異スカラーを box するので read-only/mutating とも $a はセル）。**dynamic 変数や非セルの値には触れない**ので
-    `note`/`$*ERR` rebind（`note-gist-and-dynamic-handle.t`）も非回帰。
-    - **試して revert（重要教訓）**: 当初「クロージャの実スカラー lexical free var も `insert_sym` で強制」する広い版を
-      試したが、`S17-scheduler/{at,in,every}.t`・`S32-io/IO-Socket-Async.t` を回帰させた（`:in`/`:at` 遅延スケジューリングの
-      内部クロージャ scalar を強制上書きしてコールバックが過剰発火、every.t "seen 38 runs"）。`make test`・isolated 再現では
-      露見せず、**release roast で main 5/5 PASS vs branch 5/5 FAIL の比較で確定**。`ContainerRef`-only の最小版に縮小して解決
-      （`trans.t`/`squish.t` の二重カウント回帰も同時に消滅）。教訓: call_sub_value マージは全 interpreter クロージャ呼びの
-      hot path で、scalar 値の強制は scheduler 等の内部クロージャに広く干渉する。**触るのは既に共有な `ContainerRef` だけに限る。**
-    `make test` PASS（458 unit + 5336 prove）、clippy clean、int.t 0.20s、4 回帰ファイル release 8/8 PASS。
-  - **次（step 2）**: needs-cell な `$` local を宣言時にセル化し、`owned_captures`/`closure_captured_state`/
-    `box_captured_lexicals` の boxing ヒューリスティック（4→1）を削除（PLAN.md 実装順序 step 2）。
+- 2026-06-06: Ledger created. Recorded the current 3 representations and the full trace of the `:=` flattening bug. No code changed.
+- 2026-06-08: **Phase 0 started (decont helper consolidation; behavior-preserving)**. The 3 axes (Scalar / ContainerRef /
+  ArrayKind itemization) are distinct types with distinct semantics, so the decision was **not to fuse them** but to establish a canonical helper
+  per axis and consolidate the scattered ad-hoc unwrapping (fusing would break the Pair check in `is rw` writeback and the `@a=$l` flattening).
+  - PR1 (#2736): renamed `Value::decontainerize` → `descalarize` + added owned `into_descalarized` + a decont
+    family doc. Deleted the duplicated recursive `strip_scalar`, consolidated the 4 recursive `while let Scalar` loops in
+    `methods.rs`. Documented in comments the difference between `OpCode::Decont` (single level) and the recursive helper.
+  - PR2 (#2737): consolidated the recursive ad-hoc unwrapping of single-Scalar-arm functions into `descalarize`/`into_descalarized`
+    (ops' bag/mix multiply, utils' coerce_to_hash/numeric/set/quanthash, methods_narg's 1arg/2arg).
+    Single-level sites, `.VAR`-guarded dispatch, mixed-axis (eqv/truthy/isa), and the exhaustive-match
+    value_type_name were deliberately kept inline.
+  - PR3: the ContainerRef read axis. The existing `deref_container` always clones, so it is unsuitable for in-place read sites (which lock and
+    use `&inner`) (adds a clone), and fatal for hot read opcodes (clone on every read).
+    So a **non-cloning canonical reader `Value::with_deref<R>(&self, f) -> R`** was added, `deref_container` was redefined
+    on top of it, and 6 in-place read sites were consolidated (utils value_type_name / introspect dispatch_what /
+    display to_string_value / the ContainerRef arms of types eqv, truthy, isa_check, what_type_name).
+    The hot read opcodes (the move-or-clone of GetLocal/GetGlobal) and Group B (bind/identity/write-through) are
+    postponed to Phase 0.5 / Phase 1 (status quo).
+  - Behavior invariance confirmed for all of these: `make test` PASS (5274), and the binding/flatten/set/bag/mix/eqv roast
+    plan/ran/failed counts match baseline (pre-existing non-whitelist failures unchanged).
+- 2026-06-08: **Phase 0.5 stage 1 (behavior-preserving groundwork)**. Per user decision, adopted the staged approach — the behavior-changing
+  stack invariant (auto-decont of `GetArrayVar`/`Index`) and the real wiring of the new lvalue opcodes are deferred to the next stage bundled with
+  Phase 1; this PR is only groundwork that can be carved out safely:
+  - **Added `Value::into_deref(self)`** (the owned move-through version on the ContainerRef axis; completes the `deref_container`↔`into_deref`
+    pair, same shape as `descalarize`↔`into_descalarized`). Consolidates the part PR3 explicitly postponed as "hot read-opcodes
+    GetLocal/GetGlobal move-or-clone … status quo".
+  - Consolidated the hand-written inline `arc.lock().unwrap().clone()` of `GetLocal` (`vm_var_assign_ops.rs` ~4206, keeping the early-return
+    structure with the `is_container_ref()` gate) and `GetGlobal` (`vm.rs` ~1071) into `into_deref`.
+    Non-ContainerRef keeps the move (hot-path behavior/perf fully unchanged).
+  - Added the value-read opcode inventory table to §7 (Phase 1 blueprint; `GetLocalRaw` as the anchor precedent for lvalue reads).
+  - Behavior invariance confirmed: build/clippy/fmt PASS. binding/`.VAR`/`=:=`/sigilless t/ + S03-binding roast all PASS.
+    Full roast delegated to CI.
+- 2026-06-08: **Phase 1 slice 1 (broad boxing of non-loop sibling closures) attempted → reverted (important lessons)**.
+  Tried the approach of removing the loop-only gate of `box_captured_lexicals` and `ContainerRef`-ifying captured+mutated `$` scalars outside loops
+  too, but it turned out to be **under-scoped on both performance and correctness** and was reverted. Reasons recorded (design constraints for the next slice):
+  - **(1) The mutation-writeback gap (partially addressable)**: `into_deref` (PR #2742) made only **reads** cell-aware, but
+    **mutation write-back** was not cell-aware. Concretely, `overwrite_instance_recursive`
+    (`runtime/methods_mut.rs`, the chokepoint that propagates a mutating method's result to all env bindings by instance identity) did not
+    look inside `Value::ContainerRef`, so when a boxed scalar held an instance and received a mutating method, the mutation vanished
+    (`my $x; lives-ok { $x = Obj.new }; lives-ok { $x.mutate }; $x.read` — a **test-helper pattern ubiquitous in roast**;
+    submethods.t / S24-testing / test-util etc. regressed). Confirmed fixable by adding a `ContainerRef` arm, but
+    that is merely the entrance to "a broad audit making all mutation paths cell-aware".
+  - **(2) Severe performance regression (the decisive strike against the approach)**: broad boxing turns **on every closure creation** all
+    captured+mutated free variables into `Arc<Mutex>` and inserts them into env (= inducing deep clones of the env COW). The loop-only restriction was
+    not just correctness but also **an upper bound on boxing cost**. After removing it, `roast/S32-num/int.t` slowed **from 1 second to 150s+**
+    (confirmed by diff: restoring the 3 files to main brought it back to 1 second). Not visible in `make test`; it surfaced as a timeout
+    in CI's release full roast.
+  - **Lessons / design constraints for the next slice**: sibling-closure sharing must narrow the boxing targets via **escape analysis (box only
+    the captures of closures that escape = are returned/stored externally. Do not box immediately-invoked argument closures like `lives-ok {…}`)**, and
+    must first **make mutation-writeback cell-aware**. The naive "just drop the loop-only restriction" is not viable. This is also empirical proof of
+    §6 "guaranteeing speed = omit containers via escape analysis".
+  - After the revert, main is clean (keeping only the `into_deref` groundwork of `#2742`). `int.t` is back to 1 second.
+- 2026-06-08: **Phase 1 slice 1 redesign (escape-aware) = success**. Per the previous lessons, narrowed the boxing targets with a precise signal and
+  implemented container sharing for non-loop sibling closures.
+  - **Compiler signal `multi_captured_mutated_locals`** (`opcode.rs` `compute_free_vars`): counts the distinct child closures capturing
+    an own-local, and collects those with **≥2** and `captured_mutated` into a set.
+  - **`box_captured_lexicals`** (`vm_register_ops.rs`): boxing condition becomes (A) loop locals (existing, unchanged) OR
+    (B) `multi_captured_mutated_locals` (new; non-loop siblings). The type/`where` constraint guard applies only to (B)
+    (the loop path is kept byte-for-byte). The `>=2` restriction excludes `lives-ok {…}` (1 closure), **structurally avoiding** the previous
+    perf explosion (`Arc<Mutex>`+env COW per closure creation) and the correctness regression (the test-helper pattern).
+  - **Made mutation-writeback cell-aware**: added `ContainerRef` arms to `overwrite_instance_recursive` (env path) and
+    `overwrite_instance_in_locals` (locals path) (a boxed scalar holding an instance that receives a mutating method now propagates
+    through the shared cell). Added `into_deref` to the direct Var read in `try_eval_simple_protect_expr` (preventing value leaks in the fast path).
+  - Verification: target `make(); $s(42); $g()` → `42`. **`int.t` stays ~1s/165 (no perf regression)**; an 11-file heavyweight roast
+    sample of 2314 tests completes in 3 seconds. `where-constraint-var.t` (block/whatever where protected by the guard) /
+    `submethods.t` / `S24-testing` / the closure suite all PASS. `make test` PASS (456 unit + 5315 prove).
+    `gather.t` 38 is the known Phase 2 take-rw gap (non-whitelist, unrelated).
+  - **Out of scope (next slice)**: a single escaping closure (`my &f; { my $a=3; &f=sub{$a++} }` → 3,0) has 1 closure, does not enter multi, and
+    is unfixed. `.VAR.^name` reflection / `is rw` 3-way persistence are also separate slices.
+- 2026-06-08: **step 1 = escape analysis (compiler, keystone) = success**. PLAN.md §🟣 "Implementation order" step 1.
+  Replaced `multi_captured_mutated_locals` (the proxy "captured by ≥2 sibling closures") with the true signal, **escape analysis**
+  (does the value of the capturing child closure escape the frame?). Being the real mechanism rather than a proxy, it **structurally** catches the single
+  escaping closure while keeping immediate invocations (`lives-ok {...}`/`map {...}`) unboxed.
+  - **Compiler signal**: `Compiler::escaping_position` (bool) + the `with_escape(escaping, f)` save/restore helper.
+    escaping=true: assignment/`:=` RHS (`compile_assignment_rhs_for_target`), `return`/`fail` operands, block/
+    routine tails (3 last-`Stmt::Expr` sites in `helpers_sub_body.rs` + the top-level tail in `mod.rs`), array/hash/
+    capture literal elements. escaping=false (default): call arguments (reset in `compile_call_arg`/`compile_method_arg`
+    = the #2746 guard; even when the call is in an escaping position like `my @r = map {...}`, argument closures stay unboxed).
+  - **Data**: `CompiledCode.closure_escapes: Vec<bool>` (index-aligned with `closure_compiled_codes`).
+    `add_closure_code(code, escapes)` records `escaping_position`. `compute_free_vars` enumerates children, checks
+    `closure_escapes[i]`, and if a captured×mutated own-local is **captured by an escaping child**, adds it to `needs_cell_locals`
+    (renamed from the old `multi_captured_mutated_locals`). `captured_mutated_locals` (for path A loop boxing) is unchanged.
+  - **VM**: path B of `box_captured_lexicals` references `needs_cell_locals` (the type/`where` guard and path A are byte-for-byte unchanged).
+  - Verification: single escape `$f = sub{$a++}` (`my $f`/`&f()`) → 3/4 (was 3/0). Siblings `make(); $s(42); $g()` → 42 (subsumed).
+    Factory `return sub{$n++}` → 0/1/0. Immediate invocations `for`/`map` → unboxed (3 / 12). **Perf canary
+    int.t stays 0.21s (no #2746 regression)**. `make test` PASS (458 unit + 5315 prove), clippy clean,
+    S03-binding/closure, S04-declarations/state, pointy(-rw) etc. whitelist PASS.
+  - **Also fixed the bareword `f()` escaped-block-capture bug**: `my &f; { my $a=3; &f=sub{$a++} }; f(); f()` yielded
+    `3,0` (read-only `sub{$a}` gave `3,Nil`). Bareword `f()` goes through the interpreter's `call_sub_value`, while
+    `&f()`/`$f()` go through the VM's cell-aware dispatch (`call_compiled_closure`) — under the dual-store split the VM path was already correct.
+    Cause: `call_sub_value`'s captured-env merge used `merge_all=true` and applied `entry_or_insert` (caller wins) even to
+    `ContainerRef` (shared cells), so a stale value leaked from the declaring block, or the previous call's writeback, hid the
+    live cell, and it was lost on the 2nd call. Fix: **in the merge, only `ContainerRef` uses `insert_sym` (overwrite) so the
+    live cell is always adopted** (the same "the cell is the source of truth" principle as the VM's `call_compiled_closure`; since `box_captured_lexicals`
+    boxes captured×mutated scalars, `$a` is a cell in both the read-only and mutating cases). **Dynamic variables and non-cell values are untouched**, so
+    `note`/`$*ERR` rebind (`note-gist-and-dynamic-handle.t`) does not regress.
+    - **Tried and reverted (important lesson)**: initially tried the broader version "force `insert_sym` for the closure's actual scalar lexical free vars too",
+      but it regressed `S17-scheduler/{at,in,every}.t` and `S32-io/IO-Socket-Async.t` (force-overwriting the internal closure scalars of `:in`/`:at`
+      delayed scheduling made callbacks over-fire; every.t "seen 38 runs"). Not visible in `make test` or isolated repros —
+      **settled by the release-roast comparison: main 5/5 PASS vs branch 5/5 FAIL**. Shrunk to the minimal `ContainerRef`-only version, which solved it
+      (the double-count regressions of `trans.t`/`squish.t` disappeared at the same time). Lesson: the call_sub_value merge is the hot path for all
+      interpreter closure calls, and forcing scalar values interferes broadly with internal closures like the scheduler's. **Touch only `ContainerRef`, which is already shared.**
+    `make test` PASS (458 unit + 5336 prove), clippy clean, int.t 0.20s, the 4 regression files release 8/8 PASS.
+  - **Next (step 2)**: cell-ify needs-cell `$` locals at declaration time and delete the boxing heuristics of
+    `owned_captures`/`closure_captured_state`/`box_captured_lexicals` (4→1) (PLAN.md implementation order step 2).

--- a/docs/element-element-bind-plan.md
+++ b/docs/element-element-bind-plan.md
@@ -2,7 +2,7 @@
 
 > Prep for the next session. Phase 2 Stage 2, the **hardest** remaining slice
 > (binding to a *container-valued* element). Read alongside
-> `docs/container-identity.md` "調査記録 2026-06-11 (element-element …)".
+> `docs/container-identity.md` "Investigation record 2026-06-11 (element-element …)".
 >
 > The 2026-06-11 prototype got **single-level container binds fully working** but
 > was reverted because the deep cases need ContainerRef-descent across *all*

--- a/docs/env-locals-coherence.md
+++ b/docs/env-locals-coherence.md
@@ -1,724 +1,863 @@
-# env↔locals コンテナ coherence — Slice F の真の本丸（設計）
+# env↔locals container coherence — the true core of Slice F (design)
 
-> **Status:** DESIGN (2026-06-18). コードなし。`docs/vm-single-store.md`（二重ストア統合）と
-> `docs/container-identity.md`（第一級コンテナ）が **Slice F で収束する** と確定した
-> 2026-06-18 の結論を受け、その収束点＝「`env` と `locals` が同一コンテナで乖離しないこと」
-> をどう保証するかを設計から問い直す。Slice E（closure upvalue・#3245/#3247）で single-store の
-> *独立* 前提は片付いたので、残るのはこの coherence のみ。
+> **Status:** DESIGN (2026-06-18). No code. Following the 2026-06-18 conclusion that
+> `docs/vm-single-store.md` (dual-store unification) and
+> `docs/container-identity.md` (first-class containers) **converge at Slice F**,
+> this document re-examines from the design level how to guarantee that convergence point —
+> "`env` and `locals` must not diverge on the same container".
+> Slice E (closure upvalues, #3245/#3247) settled the *independent* prerequisites of single-store,
+> so this coherence is the only thing left.
 
 ---
 
 ## 0. TL;DR
 
-Slice F（`env_dirty` / `sync_locals_from_env` / `ensure_locals_synced` / `saved_env_dirty` の削除＝
-`locals` を真の単一権威化）の**唯一残る前提**は:
+The **sole remaining prerequisite** of Slice F (deleting `env_dirty` / `sync_locals_from_env` /
+`ensure_locals_synced` / `saved_env_dirty` = making `locals` the true single authority) is:
 
-> **同一の論理コンテナ（`:=` cell を含む Array/Hash）について、`env` と `locals` が
-> *別の outer `Arc`* を持って構造的に乖離してはならない。**
+> **For the same logical container (an Array/Hash including `:=` cells), `env` and `locals`
+> must never hold *different outer `Arc`s* and diverge structurally.**
 
-第一級コンテナ campaign（`docs/container-identity.md` Phase 2）の `ContainerRef` cell は
-**1 ストア内**の COW 跨ぎ leaf 生存を解決済みだが、**dual-store の env↔locals 乖離は別レイヤ**として残る。
-これが `pairs`/`slip` carrier-drop を `t/element-bind-cell.t` で壊す根本（cell 機構があっても残る）。
-本ドキュメントはこの乖離の正確な地図・なぜ cell だけでは閉じないか・設計選択肢・段階スライス・hazard を残す。
+The `ContainerRef` cell of the first-class container campaign (`docs/container-identity.md` Phase 2)
+already solves leaf survival across COW **within one store**, but **the dual-store env↔locals divergence
+remains as a separate layer**. This is the root cause of the `pairs`/`slip` carrier-drop breaking
+`t/element-bind-cell.t` (it persists even with the cell mechanism).
+This document records an exact map of the divergence, why cells alone do not close it, the design options,
+staged slices, and hazards.
 
 ---
 
-## 1. 二つのストアと、コンテナが *通常は* coherent に保たれる仕組み
+## 1. The two stores, and the mechanism that *normally* keeps containers coherent
 
-| store | 形 | 役割 |
+| store | shape | role |
 |---|---|---|
-| `Interpreter::locals` | `Vec<Value>`、slot index | hot path、`GetLocal`/`SetLocal` |
-| `Interpreter::env` | `Env` = `Arc<HashMap<Symbol,Value>>`（COW・scoped overlay 連鎖） | 名前キーの全消費者 |
+| `Interpreter::locals` | `Vec<Value>`, slot index | hot path, `GetLocal`/`SetLocal` |
+| `Interpreter::env` | `Env` = `Arc<HashMap<Symbol,Value>>` (COW, scoped-overlay chain) | all consumers keyed by name |
 
-同期プリミティブ（`src/vm/vm_env_helpers.rs`）:
-- **forward**（locals→env）= `flush_local_to_env(code, idx)`: `set_env_with_main_alias(name, self.locals[idx].clone())`。
-  `Value::clone` は **Array/Hash では `Arc` bump ＝ outer Arc を共有**。`needs_env_sync[idx]` ＋
-  `simple_locals||bare_param` でゲート。
-- **reverse**（env→locals）= `sync_locals_from_env(code)`: 各 local 名で `self.locals[i] = env.get(name).clone()`
-  （同じく Arc bump ＝共有）。`HashSlotRef` / `!attr` は skip。`env_dirty` ゲートで `ensure_locals_synced` から呼ばれる。
+Sync primitives (`src/vm/vm_env_helpers.rs`):
+- **forward** (locals→env) = `flush_local_to_env(code, idx)`: `set_env_with_main_alias(name, self.locals[idx].clone())`.
+  For Array/Hash, `Value::clone` is an **`Arc` bump = shares the outer Arc**. Gated by `needs_env_sync[idx]` plus
+  `simple_locals||bare_param`.
+- **reverse** (env→locals) = `sync_locals_from_env(code)`: for each local name, `self.locals[i] = env.get(name).clone()`
+  (likewise an Arc bump = shared). `HashSlotRef` / `!attr` are skipped. Called from `ensure_locals_synced`,
+  gated by `env_dirty`.
 
-**∴ 通常、slot を持つコンテナは env と locals で *同一 outer `Arc`* を共有する**（clone はすべて Arc bump）。
-この共有が崩れる＝乖離が起きるのは次の §2。
-
----
-
-## 2. 乖離はいつ起きるか（outer `Arc` が env と locals で別物になる瞬間）
-
-`Arc::make_mut`（`Env::cow_mut` / コンテナ要素の in-place 変異）は **strong_count>1 のとき deep copy** して
-**新しい Arc** を作る。これが乖離の源:
-
-1. **片側 store だけが make_mut**: `env` 側のコンテナを `env_mut()` 経由で変異すると（carrier の by-name write、
-   scoped overlay への insert）、env の outer Arc が複製され locals と別物になる。逆に locals 側を直接変異しても同様。
-   次の reverse pull（`sync_locals_from_env`）が走れば locals が env の新 Arc を取り直して**再収束**する——
-   これが `env_dirty` の役目。**`env_dirty` を落とす＝この再収束を飛ばす**＝乖離が残る。
-2. **carrier が fresh env を builds**: EVAL/pairs/slip carrier は scoped overlay や flatten 上で実行され、
-   コンテナが COW-detach されうる。carrier-return の `writeback_carrier_writes` は **scalar のみ** reconcile し
-   **コンテナは決して上書きしない**（COW-detached env が内部 `:=` cell を壊す S03-binding/nested.t hazard ゆえ・#3227）。
-   つまりコンテナは barrier pull（env_dirty）に委ねられている。drop するとコンテナ乖離が残る。
-3. **scoped_child / flattened**: 深い再帰で chain が `MAX_OVERLAY_DEPTH` を超えると parent を flatten（`env.rs`）。
-   flatten 自体は Arc bump だが、その後の overlay write で make_mut が走ると同上。
-
-**leaf cell は乖離しない**: `ContainerRef(Arc<Mutex<Value>>)` は COW deep-copy でも **`Arc<Mutex>` がクローン間で共有**
-（Arc bump）されるため、leaf cell の identity は任意深度の経路を跨いで生存する（container-identity Phase 2 の核心）。
-**乖離するのは outer container の *構造*** — 「どの index にどの cell が居るか・長さ・非 cell 要素」。
+**∴ Normally, a container that has a slot shares the *same outer `Arc`* between env and locals** (every clone is an Arc bump).
+The moments this sharing breaks — i.e., divergence occurs — are §2 below.
 
 ---
 
-## 3. なぜ cell（Phase 2）だけでは閉じないか — 具体ケース
+## 2. When does divergence happen (the moment the outer `Arc` becomes different between env and locals)
 
-`t/element-bind-cell.t` の deep bind（テスト 39-44）:
+`Arc::make_mut` (`Env::cow_mut` / in-place mutation of container elements) **deep-copies when strong_count>1**
+and creates a **new Arc**. This is the source of divergence:
+
+1. **Only one store runs make_mut**: mutating a container on the `env` side via `env_mut()` (a carrier's
+   by-name write, an insert into a scoped overlay) duplicates env's outer Arc, making it different from locals'.
+   The same happens if the locals side is mutated directly. If the next reverse pull (`sync_locals_from_env`)
+   runs, locals re-fetches env's new Arc and **re-converges** —
+   that is the job of `env_dirty`. **Dropping `env_dirty` = skipping this re-convergence** = the divergence remains.
+2. **A carrier builds a fresh env**: an EVAL/pairs/slip carrier runs on a scoped overlay or flatten, and
+   containers can be COW-detached. The carrier-return `writeback_carrier_writes` reconciles **scalars only** and
+   **never overwrites containers** (because a COW-detached env would break internal `:=` cells — the
+   S03-binding/nested.t hazard, #3227).
+   In other words, containers are delegated to the barrier pull (env_dirty). Dropping it leaves container divergence.
+3. **scoped_child / flattened**: when deep recursion pushes the chain past `MAX_OVERLAY_DEPTH`, the parent is
+   flattened (`env.rs`). The flatten itself is an Arc bump, but if a subsequent overlay write triggers make_mut,
+   the same applies as above.
+
+**Leaf cells do not diverge**: `ContainerRef(Arc<Mutex<Value>>)` keeps the **`Arc<Mutex>` shared between clones**
+(Arc bump) even under COW deep-copy, so a leaf cell's identity survives across paths of arbitrary depth
+(the core of container-identity Phase 2).
+**What diverges is the *structure* of the outer container** — "which cell lives at which index, the length, the non-cell elements".
+
+---
+
+## 3. Why cells (Phase 2) alone do not close it — concrete case
+
+Deep bind in `t/element-bind-cell.t` (tests 39-44):
 
 ```raku
 my $struct = [ "ignored", { key => { subkey => [10, 42] } } ];
-my $abbrev := $struct[1]<key><subkey>[1];   # leaf 要素を cell 昇格、$abbrev は同 cell
-$struct[1]<key><subkey>[1] = 43;            # 要素 write → cell → $abbrev も 43（COW 跨ぎ OK）
-$abbrev = 44;                                # cell write → $struct の leaf も 44
+my $abbrev := $struct[1]<key><subkey>[1];   # promotes the leaf element to a cell; $abbrev is the same cell
+$struct[1]<key><subkey>[1] = 43;            # element write → cell → $abbrev is also 43 (OK across COW)
+$abbrev = 44;                                # cell write → $struct's leaf is also 44
 ```
 
-これは **単一ストア内**では cell 共有で成立する（#2922/#2925、nested.t 43/43）。
-しかし `pairs`/`slip` carrier が `env_dirty` を drop すると壊れる（memory 第13/14 セッション・テスト 9/28/41/44/46/47）:
+This works via cell sharing **within a single store** (#2922/#2925, nested.t 43/43).
+But when the `pairs`/`slip` carrier drops `env_dirty`, it breaks (memory sessions 13/14, tests 9/28/41/44/46/47):
 
-- carrier 内で `$abbrev = 44`（cell write）は **leaf cell に届く**（cell は共有・乖離しない）。
-- だが carrier 中に `env` 側の `$struct` outer Arc が COW-detach されると、carrier-return で **コンテナは
-  writeback されず**（§2-2）、かつ drop で **barrier pull も飛ぶ**ため、`locals` 側 `$struct` は
-  **古い outer Arc**（cell を別 index に持つ／別構造）を読み続ける。
-- 結果、`$struct[1]<key><subkey>[1]` を locals 経由で読むと **stale な経路**を辿り `Nil` / 旧値になる
-  （leaf cell は生きているのに、そこへ至る outer 構造が env と locals で食い違う）。
+- Inside the carrier, `$abbrev = 44` (a cell write) **reaches the leaf cell** (the cell is shared; it does not diverge).
+- But if the `env`-side `$struct` outer Arc gets COW-detached during the carrier, then at carrier-return the
+  **container is not written back** (§2-2), and with the drop the **barrier pull is also skipped**, so the
+  `locals`-side `$struct` keeps reading the **old outer Arc** (which has the cell at a different index / a different structure).
+- As a result, reading `$struct[1]<key><subkey>[1]` via locals traverses a **stale path** and yields `Nil` / the old value
+  (the leaf cell is alive, but the outer structure leading to it differs between env and locals).
 
-**∴ cell は leaf identity を保証するが、env↔locals 間の *outer 構造の同一性* は保証しない。**
-これが「別レイヤ」の意味であり、Slice F = この outer 同一性の保証。
-
----
-
-## 4. 設計選択肢
-
-### (A) コンテナを env でも cell（`ContainerRef`）として持つ＝**env↔locals が outer cell を共有**（推奨の軸）
-
-instance attr が Phase 3 で `Arc<RwLock<HashMap>>` cell 一本化したのと同型。slot を持つ Array/Hash を
-**`ContainerRef` cell に包み、env と locals が *同じ cell* を保持**する。すると:
-- forward/reverse とも cell の Arc bump ＝ outer 構造も常に共有（make_mut で片側が detach しても、両者が同 cell を
-  指すので detach 自体が起きない／起きても cell 内 1 箇所）。
-- `env_dirty`/`sync_locals_from_env` の **再収束が不要**になる（乖離が構造的に発生しない）→ Slice F が解禁。
-- carrier-drop も安全化（コンテナは cell 共有なので pull に依存しない）→ `pairs`/`slip` 一般化が同時に成立。
-
-**コスト/hazard**:
-- **perf 崖リスク**: 全コンテナを cell 化すると、値 op（算術 fold・iteration・native method の raw-items 読み）の
-  消費面が ContainerRef を毎回 decont する必要＝"deref everywhere"。**escape-aware が必須**（捕捉/エイリアス/`:=`/
-  `is rw`/`.VAR` されない裸ローカルは cell 化しない＝#2746 の轍を踏まない）。Phase 2 の単一 decont チョークポイント
-  （`docs/container-identity.md` §3）が前提。
-- **leak 硬化**: slice/`.kv`/`.pairs`/`.raku`/native method の raw-items 読みで cell が漏れない監査（Phase 2 既知課題）。
-- **書込チョークポイント**: 配列/ハッシュ要素 write は既に `assign_element_slot`/`hash_insert_through` に集約済み
-  （Phase 2 Stage 0）。outer cell 化はその上に乗る。
-
-### (B) coherence invariant ＝「slot コンテナの outer Arc を片側だけ make_mut しない」
-
-env と locals が常に同 Arc を指すよう、**どちらかを変異する直前に必ずもう一方を同 Arc に再リンク**する不変条件。
-forward/reverse を「Arc 同一性を壊さない write-through」に限定。**(A) の弱い版**だが、make_mut が
-strong_count>1 で必ず detach する以上「片側だけ変異」を完全に防ぐのは難しく、結局 cell 一本化（A）に収束する。
-記録用に残すが本命ではない。
-
-### (C) carrier がコンテナ write も精密ログ＝carrier-drop を安全化（局所対症）
-
-`pairs`/`slip` carrier がコンテナ変異も `carrier_writes` に記録し、carrier-return で cell-aware reconcile。
-memory 第14セッションで **deep `:=` cell coherence を壊すと実証済み**（write-logging 完全化しても outer 乖離は残る）。
-= 対症療法で根本（outer 同一性）を解かない。**不採用**（記録のみ）。
+**∴ Cells guarantee leaf identity, but they do not guarantee *outer structural identity* between env and locals.**
+That is what "a separate layer" means, and Slice F = guaranteeing this outer identity.
 
 ---
 
-## 5. 推奨＝(A) を Phase 2 完了の上に段階導入
+## 4. Design options
 
-> 北極星（PLAN.md §🟣）= 最もクリーン×最速。進捗メトリクスは **削除した重複/特例メカニズムの数**。
-> (A) は `env_dirty` 系 4 機構 ＋ carrier コンテナ reconcile 特例 ＋ pairs/slip carrier-drop 抑止を一掃する勝ち筋。
+### (A) Hold containers as cells (`ContainerRef`) in env too = **env↔locals share the outer cell** (the recommended axis)
 
-big-bang 不可。Phase 2（要素 cell）が leaf を解いたのと同じく、**outer コンテナ cell 化も
-「チョークポイント先行（挙動不変）→ escape-aware 昇格 → 機構削除」** の順:
+Same shape as Phase 3 unifying instance attrs onto a single `Arc<RwLock<HashMap>>` cell. Wrap slot-holding
+Array/Hash in a **`ContainerRef` cell, and have env and locals hold *the same cell***. Then:
+- Both forward and reverse become Arc bumps of the cell = the outer structure is always shared too (even if one
+  side detaches via make_mut, both point at the same cell, so the detach itself does not happen — or if it does,
+  it is confined to one place inside the cell).
+- The **re-convergence** of `env_dirty`/`sync_locals_from_env` becomes unnecessary (divergence structurally cannot occur)
+  → Slice F is unblocked.
+- Carrier-drop is also made safe (containers are cell-shared, so they no longer depend on the pull)
+  → the `pairs`/`slip` generalization lands at the same time.
 
-- **Stage 0 — outer 読み/書きチョークポイント棚卸し（挙動不変）**: slot コンテナの read（GetLocal/GetGlobal/
-  GetArrayVar/GetHashVar/Index）が単一 decont を通り、write が単一 write-through を通ることを確認・補完。
-  Phase 0/2 Stage 0 の延長。roast 完全一致が合格条件。
-  - **[~] 棚卸し結果（2026-06-18）**: **read 側は既に単一 decont チョークポイント化済み**＝想定より良好。
-    `GetLocal`/`GetGlobal`/`GetArrayVar`/`GetHashVar` は全て `into_deref()`（`value/mod.rs`）で top-level
-    `ContainerRef` を剥がしてから push（`vm_var_assign_ops.rs:5388`・`vm.rs:1347/1439/1521`）、要素 read は
-    `resolve_array_entry`/`resolve_hash_entry`（`vm_var_ops.rs`）で cell を decont。**outer cell の値消費面
-    （open-q#1）は slot-read 境界で既に閉じている**＝Stage 1 の主リスクが想定より小さい。write 側は要素 write が
-    `assign_element_slot`/`hash_insert_through`（`value/mod.rs`）に集約済み、whole-container write-through も
-    `SetLocal` は既存 `ContainerRef` を維持（`vm_var_assign_ops.rs:5543`）。
-  - **[x] write チョークポイント gap 1 件を補完 — `our %g := %h`（global hash bind）の readonly 誤発火**:
-    `our` の `:=` 束縛は var を readonly マーク（bind signal）するが、`SetGlobal` がそれを真の RO と誤認し
-    "Cannot assign to a readonly variable (%g)" で bind 自体が abort（`my %g := %h` は動作・global hash 特有・
-    array global は別機構で無害）。修正＝bound container vardecl の `SetGlobal` 直前に `MarkBindContext` 再 emit
-    （`compiler/stmt.rs`）＋ `SetGlobal` が bind context のとき readonly チェックをスキップ（`vm.rs`）。bind 後は
-    var が readonly マークを保持＝後続の `%g<k>=v` が named index-assign の `is_bound_hash_var` 経路で in-place
-    変異し双方向 alias 成立（local と同型）。`t/our-hash-bind.t`（9）。
-  - **[~] 差分 probe で炙り出した残 Stage 0 gap（2026-06-18・着手前に解くべき設計込み）**: `my`/`our` ×
-    `@`/`%` × element/whole/push/for-rw の bind coherence を raku と差分比較。上記 2 件（#3252 の `our` hash bind ＋
-    別途 sink-warn #3253）以外に **3 件の実バグ**が残存（いずれも単独修正は危険・設計を要す）:
-    1. ✅ **修正済（#3255 + 本セッション follow-up）— bound hash の whole 再代入 ＋ 対称な constant 要素書込**:
-       `my %a := %b; %a = (z=>9)` が "Cannot assign to a readonly variable (%a)" で die していた（raku は %b も (z) に置換）。
-       root-cause は **`readonly_vars` が 3 概念を混同**: ①`:=` bind signal ②`constant %M` の不変性 ③`is readonly` param。
-       **正攻法（採用）＝`:=` bound container に readonly とは別の専用マーカー `__mutsu_bound::%a` を立て**（新
-       `Stmt::MarkBoundContainer`・hash bind desugar が emit・`compiler/stmt.rs` が `SetGlobal` で env key 化）、
-       readonly path をそのマーカーで分岐:
-       - **whole-reassign（#3255）**: slot 経路の `CheckReadOnly` opcode（`vm.rs`）がマーカー持ち var を exempt。
-       - **closure 内 whole-reassign（本セッション）**: closure が `%b` を free var 捕捉すると whole-reassign は
-         by-name `SetGlobal` 経路（`vm.rs` の `check_readonly_for_modify`）を通る——ここにもマーカー exempt
-         （`is_bound_container`）を追加。`lives-ok { %b = (z=>9) }` 等が die しなくなった。
-       - **対称バグ（本セッション）**: 要素 path（`is_bound_hash_var`・`vm_var_assign_ops.rs`）が readonly % を**全て
-         bound（writable）扱い**＝`constant %M<a>=9` が誤って成功していた。`is_bound_hash_var` をマーカー必須に絞り、
-         マーカー無し readonly `%`-var（＝`constant %M`）の要素書込は X::Assignment::RO（"Cannot modify an immutable
-         Int (1)" — raku 一致）で die。`constant @A` は元から正しく die（別 array 経路）。
-       pin=`t/bound-hash-whole-reassign.t`（#3255・10）+ `t/constant-hash-element-ro.t`（本セッション・14）。
-    2. **param deref bind の push 非伝播 — 真因＝`$x = @arr` の非共有（より深い first-class container 課題）**:
-       `sub f($n){ my @a := @$n; @a.push(99) }; my @z=(1,2); f(@z); say @z.elems` が mutsu 2 / raku 3。
-       **本セッションで root-cause 切り分け確定**: bind や writeback の問題ではなく、**`my $n = @z`（scalar に array を
-       代入）が mutsu では Array を *コピー* している**こと（raku は同一 Array オブジェクトを参照共有＝`@z.push` が `$n`
-       経由で見える）。`my $n := @z`（bind）・`my @a := @z`（array bind）は mutsu でも正しく共有する＝壊れているのは
-       **`=`（代入）で scalar が array を持つとき**だけ。∴ `@$n` deref bind は「コピーされた $n の array」を bind するので
-       caller @z に届かない。**修正＝`$x = @arr` が array の *outer cell* を共有する（Raku の reference 型セマンティクス）**＝
-       `$x = @arr` 全般の COW セマンティクスに関わる**高 blast radius な first-class container 変更**（writeback site-A の
-       局所 deref とは別レイヤ）。Stage 1 の次の本丸ターゲット。**設計＝`docs/scalar-array-sharing.md`（design-first・
-       ユーザー選択 2026-06-18）。** 追加 probe で判明: `$n = @z` は既に同 Arc を共有（`$n[0]=8` は @z に伝播）するが
-       **`.push` 等の構造変異が `Arc::make_mut` で COW detach** する＝要素 write と同型の問題が whole-container に残存。
-       正準解＝source/target を共有 `ContainerRef` cell に昇格（escape-aware）。
-    3. ✅ **修正済（Stage 1 sub-slice 1b・本セッション）— bound array の for-rw 非書き戻し**:
-       `my @a := @b; for @a { $_++ }; say @b` が mutsu で @a/@b とも不変だった（raku は両方加算）。
-       **真因が判明**: `my @a := @b` は **@a/@b を同一 `ContainerRef` cell に cell 化**している（だから push/要素は
-       伝播）。だが for-rw の writeback（`write_back_for_topic_item`/`write_back_for_rw_param` の array 分岐）が
-       `get_env_with_main_alias(source)` の戻り値を **deref 無しで `Value::Array` に直 match**＝ContainerRef を取り
-       こぼし writeback ごと skip していた（blast-radius site A）。修正＝戻り値を `deref_container()` してから inner
-       Array を読み、rebuild した array を**共有 cell 経由で write-through**（`write_back_container_source` ヘルパ＝
-       ContainerRef なら `cell.lock().clone_from`、それ以外は従来の set_env+update_local）。topic（`$_`）/ named rw
-       param（`-> $x is rw`）/ multi-param rw（`-> $x, $y is rw`）/ bound chain（`@a:=@b:=@c`）/ named `@`-param `.push`
-       を網羅。非-bound array の writeback は不変。**これが Stage 1 が「outer cell の writeback チョークポイント」を
-       実証した最初の slice＝site A を ContainerRef-aware 化したもの。** pin=`t/bound-array-for-rw.t`（15）。
-       ✅ **hash 版 site A も修正済（本セッション follow-up）**: bound **hash** の for-values-rw（`for %h.values { $_++ }` /
-       `-> $v is rw` / `%h.kv -> $k, $v is rw`）も同じ deref 無し match で壊れていた。**3 サイト**を deref 化:
-       ①hash key 事前キャプチャ（loop setup・`hash_keys_for_writeback`＝`get_env_with_main_alias(source)` を `Value::Hash`
-       直 match→bound だと `None`→writeback 全 skip の真因）②`write_back_hash_value_item`（topic 経路）③`write_back_for_rw_param`
-       の hash 分岐（kv/values）。いずれも `deref_container()` + `write_back_container_source` 経由に。pin=
-       `t/bound-hash-for-values-rw.t`（11）。**∴ bound array/hash の for-rw site A は array/hash とも完了。残=bug②（deref bind）。**
-    - これらは Stage 1（outer cell 化）が構造的に解く候補だが、2/3 は per-bug の aliasing 修正でも対処可。1 は
-      上記のとおり `__mutsu_bound::` マーカーで element/whole/closure 全 path を分離し**完了**（`readonly_vars`
-      の物理的な分離リファクタは不要だった——マーカーが論理分離を与える）。残る deep wall は 2/3 のみ。
-    - **[2026-06-18 Stage 1 着手前の差分 probe・絞り込み]** bound container の各操作を raku と網羅比較した結果、
-      **user-visible に壊れているのは bug②（deref bind）と bug③（for-rw）の 2 つだけ**と確定:
-      - `my @a := @b` の **push / 要素代入 / reverse push は既に正しく伝播**（共有 Arc + in-place 変異）。
-      - `my %h := %g` の要素書込も正しく伝播。
-      - **closure が `@`/`%` を捕捉＋変異するケース（`my &f = { @a.push(9) }` / getter-setter factory）も既に正しい**
-        ——`box_captured_lexicals` は `@`/`%` を skip するが、Array/Hash は Arc 共有 + `env_dirty` reverse pull で
-        伝播するため bug にならない。**∴ Stage 1 sub-slice 1c（closure capture の outer 拡張）は user-visible bug を
-        持たない＝純粋なアーキ整理（inert になりがち）で優先度低。**
-      - bug③ の writeback 抑制を追跡: `for @a` は bound でも `TagContainerRef("@a")` を emit し `writes_back_topic`
-        も真＝writeback には到達する。だが bound @a では topic 変異（`$_++` / `$_=99`）が @a/@b どちらにも届かない
-        （raku は両方更新）。`write_back_for_topic_item` は `get_env_with_main_alias("@a")` を deref 無しで読み、
-        rebuild した array を `set_env_with_main_alias`（readonly チェック無し）で書くが**それでも @a が不変**＝
-        snapshot 反復と bound の readonly/共有 storage 相互作用による（session 19 の localized fix が効かなかった所以）。
-        **∴ bug③ は localized writeback patch では閉じない＝Stage 1 の outer cell（@a の要素が @b の storage を真に
-        rw-alias する）が前提。** これが「着手」の最初の実装ターゲット＝**sub-slice 1b**。
-- **Stage 1 — escape-aware に outer コンテナを cell 化**: 「捕捉/`:=`/`is rw`/`.VAR`/cross-frame 変異」される
-  slot コンテナのみ outer `ContainerRef` 昇格し env↔locals が同 cell を共有。裸ローカルは従来どおり Arc 共有
-  （perf 崖回避）。escape 解析（#2758）の判定を outer コンテナへ拡張。
+**Costs/hazards**:
+- **Perf-cliff risk**: if all containers are cell-ified, the consumption surface of value ops (arithmetic folds,
+  iteration, native methods' raw-items reads) has to decont a ContainerRef every time = "deref everywhere".
+  **Escape-awareness is mandatory** (bare locals that are not captured/aliased/`:=`-bound/
+  `is rw`/`.VAR`-taken are NOT cell-ified — do not repeat the #2746 mistake). The single decont chokepoint of
+  Phase 2 (`docs/container-identity.md` §3) is a prerequisite.
+- **Leak hardening**: audit that cells do not leak via slice/`.kv`/`.pairs`/`.raku`/native methods' raw-items reads
+  (a known Phase 2 issue).
+- **Write chokepoints**: array/hash element writes are already funneled through `assign_element_slot`/`hash_insert_through`
+  (Phase 2 Stage 0). Outer cell-ification builds on top of that.
 
-  **[2026-06-18 着手前 audit でサブスライス確定]** READ 側は `into_deref()`（GetLocal/GetGlobal/GetArrayVar/
-  GetHashVar）/ `resolve_array_entry`/`resolve_hash_entry`（要素）で**既に decont 済**＝open-q#1 の主リスクは
-  **write/mutation/writeback サイト**（`env_mut().get_mut(name)` / `env_root_descended_mut(name)` /
-  `get_env_with_main_alias(name)` で生の `Value::Array(..)`/`Value::Hash(..)` を直 match する箇所）に集中する。
-  audit が列挙した~14 サイト（カテゴリ別）:
-  - **A. for-rw topic writeback**: `vm_control_ops.rs` `write_back_for_topic_item`(2078) / hash 版(2257,2327,2341)
-    — `get_env_with_main_alias(source)` を deref 無しで match。bug③ の writeback 経路そのもの。
-  - **B. push / 要素直変異**: `vm_data_ops.rs` `@a.push` fast path(615) `env_mut().get_mut`、junction index
-    assign(`vm_var_assign_ops.rs` 3000/3006)。
-  - **C. bound-index メタ追跡**: `vm_var_assign_ops.rs:2966`、`vm_var_ops.rs` is/mark/remove_bound_index(598/607/619)。
+### (B) Coherence invariant = "never make_mut a slot container's outer Arc on only one side"
+
+An invariant that, so env and locals always point at the same Arc, **immediately before mutating either one you
+must relink the other to the same Arc**. Restrict forward/reverse to "write-throughs that never break Arc identity".
+A **weaker version of (A)**, but since make_mut always detaches at strong_count>1, completely preventing
+"mutation on only one side" is hard, and it ultimately converges on cell unification (A).
+Kept for the record, but not the main line.
+
+### (C) Carriers precisely log container writes too = make carrier-drop safe (local symptomatic fix)
+
+Have the `pairs`/`slip` carrier record container mutations in `carrier_writes` as well, and do a cell-aware
+reconcile at carrier-return. **Proven in memory session 14 to break deep `:=` cell coherence** (even with complete
+write-logging, the outer divergence remains).
+= A symptomatic treatment that does not solve the root (outer identity). **Rejected** (recorded only).
+
+---
+
+## 5. Recommendation = introduce (A) in stages, on top of a completed Phase 2
+
+> North star (PLAN.md §🟣) = cleanest × fastest. The progress metric is **the number of deleted
+> duplicate/special-case mechanisms**.
+> (A) is the winning line that sweeps away the 4 `env_dirty`-family mechanisms + the carrier container-reconcile
+> special case + the pairs/slip carrier-drop suppression.
+
+A big bang is not possible. Just as Phase 2 (element cells) solved leaves, **outer container cell-ification
+also proceeds in the order "chokepoints first (behavior-preserving) → escape-aware promotion → mechanism deletion"**:
+
+- **Stage 0 — inventory of outer read/write chokepoints (behavior-preserving)**: confirm and complete that
+  reads of slot containers (GetLocal/GetGlobal/GetArrayVar/GetHashVar/Index) go through a single decont and
+  writes go through a single write-through. An extension of Phase 0/2 Stage 0. Acceptance criterion: exact roast parity.
+  - **[~] Inventory result (2026-06-18)**: **the read side is already funneled through a single decont chokepoint**
+    = better than expected. `GetLocal`/`GetGlobal`/`GetArrayVar`/`GetHashVar` all strip a top-level
+    `ContainerRef` via `into_deref()` (`value/mod.rs`) before pushing (`vm_var_assign_ops.rs:5388`,
+    `vm.rs:1347/1439/1521`), and element reads decont cells in
+    `resolve_array_entry`/`resolve_hash_entry` (`vm_var_ops.rs`). **The value-consumption surface of outer cells
+    (open-q#1) is already closed at the slot-read boundary** = the main risk of Stage 1 is smaller than expected.
+    On the write side, element writes are already funneled into
+    `assign_element_slot`/`hash_insert_through` (`value/mod.rs`), and for whole-container write-through,
+    `SetLocal` already preserves an existing `ContainerRef` (`vm_var_assign_ops.rs:5543`).
+  - **[x] Filled 1 write-chokepoint gap — spurious readonly firing on `our %g := %h` (global hash bind)**:
+    an `our` `:=` binding marks the var readonly (a bind signal), but `SetGlobal` misread that as genuinely RO and
+    aborted the bind itself with "Cannot assign to a readonly variable (%g)" (`my %g := %h` worked; specific to
+    global hashes; array globals use a different mechanism and were unaffected). Fix = re-emit `MarkBindContext`
+    right before the `SetGlobal` of a bound-container vardecl (`compiler/stmt.rs`) + have `SetGlobal` skip the
+    readonly check while in bind context (`vm.rs`). After the bind the var keeps its readonly mark = subsequent
+    `%g<k>=v` mutates in place via the named index-assign `is_bound_hash_var` path, establishing the bidirectional
+    alias (same shape as locals). `t/our-hash-bind.t` (9).
+  - **[~] Remaining Stage 0 gaps flushed out by differential probing (2026-06-18; including design to be settled
+    before starting)**: differential comparison against raku of bind coherence across `my`/`our` ×
+    `@`/`%` × element/whole/push/for-rw. Besides the 2 items above (#3252 `our` hash bind + the separate
+    sink-warn #3253), **3 real bugs** remain (none is safe to fix in isolation; each needs design):
+    1. ✅ **Fixed (#3255 + this session's follow-up) — whole reassignment of a bound hash + the symmetric
+       constant element write**:
+       `my %a := %b; %a = (z=>9)` died with "Cannot assign to a readonly variable (%a)" (raku also replaces %b with (z)).
+       Root cause: **`readonly_vars` conflated 3 concepts**: ① the `:=` bind signal ② the immutability of `constant %M`
+       ③ `is readonly` params.
+       **Proper fix (adopted) = plant a dedicated marker `__mutsu_bound::%a`, separate from readonly, on `:=` bound
+       containers** (new `Stmt::MarkBoundContainer`; the hash-bind desugar emits it; `compiler/stmt.rs` turns it into
+       an env key at `SetGlobal`), and branch the readonly paths on that marker:
+       - **Whole-reassign (#3255)**: the slot-path `CheckReadOnly` opcode (`vm.rs`) exempts marker-bearing vars.
+       - **Whole-reassign inside a closure (this session)**: when a closure captures `%b` as a free var, the
+         whole-reassign goes through the by-name `SetGlobal` path (`check_readonly_for_modify` in `vm.rs`) — added
+         the marker exemption there too (`is_bound_container`). `lives-ok { %b = (z=>9) }` etc. no longer die.
+       - **Symmetric bug (this session)**: the element path (`is_bound_hash_var`, `vm_var_assign_ops.rs`) treated
+         **every** readonly `%` as bound (writable) = `constant %M<a>=9` wrongly succeeded. Narrowed
+         `is_bound_hash_var` to require the marker; element writes to a marker-less readonly `%`-var (= `constant %M`)
+         now die with X::Assignment::RO ("Cannot modify an immutable Int (1)" — matches raku). `constant @A` already
+         died correctly (a separate array path).
+       pin=`t/bound-hash-whole-reassign.t` (#3255, 10) + `t/constant-hash-element-ro.t` (this session, 14).
+    2. **push non-propagation of param deref bind — real cause = non-sharing of `$x = @arr` (a deeper first-class
+       container problem)**:
+       `sub f($n){ my @a := @$n; @a.push(99) }; my @z=(1,2); f(@z); say @z.elems` gives mutsu 2 / raku 3.
+       **Root cause isolated this session**: it is not a bind or writeback problem — **`my $n = @z` (assigning an
+       array to a scalar) *copies* the Array in mutsu** (raku shares a reference to the same Array object =
+       `@z.push` is visible through `$n`). `my $n := @z` (bind) and `my @a := @z` (array bind) share correctly in
+       mutsu too = what is broken is **only `=` (assignment) when a scalar holds an array**. ∴ the `@$n` deref bind
+       binds "the copied $n's array", so it never reaches the caller's @z.
+       **Fix = have `$x = @arr` share the array's *outer cell* (Raku's reference-type semantics)** = a
+       **high-blast-radius first-class-container change** touching the COW semantics of `$x = @arr` in general
+       (a different layer from the local deref of writeback site-A). The next major Stage 1 target.
+       **Design = `docs/scalar-array-sharing.md` (design-first; user's choice 2026-06-18).**
+       An additional probe revealed: `$n = @z` already shares the same Arc (`$n[0]=8` propagates to @z), but
+       **structural mutations like `.push` COW-detach via `Arc::make_mut`** = the same problem as element writes
+       remains for the whole container. Canonical solution = promote source/target to a shared `ContainerRef` cell
+       (escape-aware).
+    3. ✅ **Fixed (Stage 1 sub-slice 1b, this session) — bound array's for-rw not writing back**:
+       `my @a := @b; for @a { $_++ }; say @b` left both @a/@b unchanged in mutsu (raku increments both).
+       **True cause identified**: `my @a := @b` **cell-ifies @a/@b onto the same `ContainerRef` cell** (which is
+       why push/element writes propagate). But the for-rw writeback (the array branch of
+       `write_back_for_topic_item`/`write_back_for_rw_param`) directly matched the return value of
+       `get_env_with_main_alias(source)` against `Value::Array` **without a deref** = it missed the ContainerRef
+       and skipped the writeback entirely (blast-radius site A). Fix = `deref_container()` the return value before
+       reading the inner Array, and **write the rebuilt array through the shared cell** (the
+       `write_back_container_source` helper = `cell.lock().clone_from` for ContainerRef, the previous
+       set_env+update_local otherwise). Covers topic (`$_`) / named rw param (`-> $x is rw`) / multi-param rw
+       (`-> $x, $y is rw`) / bound chains (`@a:=@b:=@c`) / named `@`-param `.push`.
+       Writeback for non-bound arrays is unchanged. **This is the first slice where Stage 1 demonstrated the
+       "outer-cell writeback chokepoint" = making site A ContainerRef-aware.** pin=`t/bound-array-for-rw.t` (15).
+       ✅ **The hash version of site A is also fixed (this session's follow-up)**: bound **hash** for-values-rw
+       (`for %h.values { $_++ }` / `-> $v is rw` / `%h.kv -> $k, $v is rw`) was broken by the same deref-less
+       match. **3 sites** made deref-aware:
+       ① hash-key pre-capture (loop setup, `hash_keys_for_writeback` = matching `get_env_with_main_alias(source)`
+       directly against `Value::Hash` → `None` when bound → the true cause of the entire writeback being skipped)
+       ② `write_back_hash_value_item` (topic path) ③ the hash branch of `write_back_for_rw_param` (kv/values).
+       All now go via `deref_container()` + `write_back_container_source`. pin=
+       `t/bound-hash-for-values-rw.t` (11). **∴ site A for-rw is complete for both bound arrays and hashes.
+       Remaining = bug② (deref bind).**
+    - These are candidates that Stage 1 (outer cell-ification) solves structurally, but 2/3 could also be handled
+      by per-bug aliasing fixes. 1 is **done** as above, separating element/whole/closure paths with the
+      `__mutsu_bound::` marker (a physical refactor splitting `readonly_vars` was unnecessary — the marker provides
+      the logical separation). The remaining deep walls are only 2/3.
+    - **[2026-06-18 pre-Stage-1 differential probe, narrowing]** exhaustive comparison of bound-container operations
+      against raku confirmed that **only bug② (deref bind) and bug③ (for-rw) are user-visibly broken**:
+      - `my @a := @b`'s **push / element assignment / reverse push already propagate correctly** (shared Arc +
+        in-place mutation).
+      - `my %h := %g`'s element writes also propagate correctly.
+      - **Cases where a closure captures and mutates `@`/`%` (`my &f = { @a.push(9) }` / getter-setter factory)
+        are already correct** — `box_captured_lexicals` skips `@`/`%`, but Array/Hash propagate via Arc sharing +
+        the `env_dirty` reverse pull, so no bug arises. **∴ Stage 1 sub-slice 1c (extending closure capture to
+        outer containers) has no user-visible bug = pure architectural cleanup (tends to be inert), low priority.**
+      - Tracking bug③'s writeback suppression: even when bound, `for @a` emits `TagContainerRef("@a")` and
+        `writes_back_topic` is true = the writeback is reached. But with a bound @a, topic mutations
+        (`$_++` / `$_=99`) reach neither @a nor @b (raku updates both). `write_back_for_topic_item` reads
+        `get_env_with_main_alias("@a")` without a deref and writes the rebuilt array via
+        `set_env_with_main_alias` (no readonly check) — **and @a is still unchanged** = due to the interaction
+        of snapshot iteration with bound readonly/shared storage (why session 19's localized fix didn't work).
+        **∴ bug③ cannot be closed by a localized writeback patch = it presupposes Stage 1's outer cell
+        (@a's elements truly rw-aliasing @b's storage).** This is the first implementation target of "starting" =
+        **sub-slice 1b**.
+- **Stage 1 — cell-ify outer containers escape-awarely**: promote to an outer `ContainerRef` only those slot
+  containers that are "captured / `:=`-bound / `is rw` / `.VAR`-taken / mutated cross-frame", with env↔locals
+  sharing the same cell. Bare locals keep the traditional Arc sharing (avoiding the perf cliff). Extend the
+  escape analysis (#2758) verdicts to outer containers.
+
+  **[2026-06-18 pre-start audit fixed the sub-slices]** The READ side is **already deconted** via `into_deref()`
+  (GetLocal/GetGlobal/GetArrayVar/GetHashVar) / `resolve_array_entry`/`resolve_hash_entry` (elements) = the main
+  risk of open-q#1 is concentrated in **write/mutation/writeback sites** (places that directly match raw
+  `Value::Array(..)`/`Value::Hash(..)` from `env_mut().get_mut(name)` / `env_root_descended_mut(name)` /
+  `get_env_with_main_alias(name)`). The ~14 sites the audit enumerated (by category):
+  - **A. for-rw topic writeback**: `vm_control_ops.rs` `write_back_for_topic_item`(2078) / hash versions(2257,2327,2341)
+    — matches `get_env_with_main_alias(source)` without a deref. The very writeback path of bug③.
+  - **B. push / direct element mutation**: `vm_data_ops.rs` `@a.push` fast path(615) `env_mut().get_mut`, junction
+    index assign (`vm_var_assign_ops.rs` 3000/3006).
+  - **C. bound-index meta tracking**: `vm_var_assign_ops.rs:2966`, `vm_var_ops.rs` is/mark/remove_bound_index(598/607/619).
   - **D. simple array/hash op fast path**: `vm_var_assign_ops.rs` `exec_simple_array_op`(4200)/`exec_simple_hash_op`(4278)
-    が `env_root_descended_mut` で生 match。`is_simple_op_target`(4196) は `self.locals[slot]` を生 match。
-  - **E. 初期化/coercion 検査**: shaped-array push 検査(`vm_data_ops.rs:508`)、hash 型検査(2994/3130)、push-assign の
-    array 長さ取得(3353)。
-  - **F. delete/exists**: `vm_var_delete_ops.rs` delete_hash(135)/array_exists(295/311)。
-  - **G. `%*ENV` 読み**: `vm_misc_ops.rs:1673/1695`（内部・名前固定なので boxing 対象外＝触らなくてよい）。
-  - **H. thunk capture 最適化**: `vm_arith_ops.rs:118`（読み・decont 追加で no-op 化可）。
+    raw-match via `env_root_descended_mut`. `is_simple_op_target`(4196) raw-matches `self.locals[slot]`.
+  - **E. initialization/coercion checks**: shaped-array push check (`vm_data_ops.rs:508`), hash type checks (2994/3130),
+    push-assign array length fetch (3353).
+  - **F. delete/exists**: `vm_var_delete_ops.rs` delete_hash(135)/array_exists(295/311).
+  - **G. `%*ENV` reads**: `vm_misc_ops.rs:1673/1695` (internal, fixed name, so not a boxing target = can be left alone).
+  - **H. thunk capture optimization**: `vm_arith_ops.rs:118` (read; adding a decont makes it a no-op).
 
-  **Sub-slice 1a — write チョークポイント先行（挙動不変）= ✅ 実質完了（2026-06-19 の監査で確定）**: 当初は A–F の
-  各サイトに decont を一括追加する想定だったが、**read-only な clean 監査で「残る生 match の write サイトは junction
-  index-assign だけ」と判明**——他は既に ContainerRef-aware だった:
-  - **A（for-rw writeback）** = `write_back_container_source`/`deref_container` 化済み（#3259/#3260）。
-  - **D（nested index-assign）** = `env_root_descended_mut` が `descend_container_ref` で cell を降下済み。
-  - **B の push（`vm_data_ops.rs` `@a.push`）** = `is_simple_array` 早期ガードが bound cell を `ContainerRef` arm
-    （577 付近の cell-COW push）へ流すので fast path（634）には plain Array しか到達せず**ギャップなし**。
-  - **F（delete）** = `exec_delete_index_named_op` が cell を一時 unwrap→delete→write-back で cell-aware。
-  - **C（bound-index メタ）/ E（init/coercion 検査）** = 内部メタ hash or read-only 検査で `ContainerRef` 不発生＝安全。
-  - **残った唯一の実ギャップ = junction index-assign（B）**: `@a[0|1]=v` / `%h{'x'|'y'}=v` が bound cell を deref せず
-    生 match（hash arm は cell を空 hash で上書きして bind を切る実バグ）。**#3279 で `env_root_descended_mut` 経由に統一して
-    修正**（plain は byte-identical・bound は raku 一致）。pin=`t/junction-bound-cell.t`（10）。
-  - **∴ Sub-slice 1a は完了。** 当初想定の汎用 `env_container_mut(name) -> guard` ヘルパは不要だった（既存の
-    `env_root_descended_mut` + `write_back_container_source` + push の cell arm が消費面を網羅）。次は Sub-slice 1b。
+  **Sub-slice 1a — write chokepoints first (behavior-preserving) = ✅ effectively complete (confirmed by the
+  2026-06-19 audit)**: the initial plan was to add deconts to each of sites A–F in one sweep, but a **read-only
+  clean audit found "the only remaining raw-match write site is junction index-assign"** — the rest were already
+  ContainerRef-aware:
+  - **A (for-rw writeback)** = already converted to `write_back_container_source`/`deref_container` (#3259/#3260).
+  - **D (nested index-assign)** = `env_root_descended_mut` already descends cells via `descend_container_ref`.
+  - **B's push (`vm_data_ops.rs` `@a.push`)** = the `is_simple_array` early guard routes bound cells to the
+    `ContainerRef` arm (the cell-COW push near 577), so only plain Arrays reach the fast path (634) = **no gap**.
+  - **F (delete)** = `exec_delete_index_named_op` is cell-aware via temporary unwrap→delete→write-back.
+  - **C (bound-index meta) / E (init/coercion checks)** = internal meta hash or read-only checks where
+    `ContainerRef` cannot occur = safe.
+  - **The only remaining real gap = junction index-assign (B)**: `@a[0|1]=v` / `%h{'x'|'y'}=v` raw-matched without
+    dereffing a bound cell (the hash arm was a real bug overwriting the cell with an empty hash and severing the
+    bind). **Fixed in #3279 by unifying through `env_root_descended_mut`**
+    (plain is byte-identical; bound matches raku). pin=`t/junction-bound-cell.t` (10).
+  - **∴ Sub-slice 1a is complete.** The originally envisioned generic `env_container_mut(name) -> guard` helper
+    turned out to be unnecessary (the existing `env_root_descended_mut` + `write_back_container_source` + push's
+    cell arm cover the consumption surface). Next is Sub-slice 1b.
 
-  **Sub-slice 1b — `:=` bound array/hash を outer cell 化（bug②③ を構造的に解消）**: bind desugar が現在立てる
-  `__mutsu_bound_array_len::`/`MarkBoundContainer` の延長で、bound array/hash の slot+env を**同一 `ContainerRef`
-  cell**にし、`@a := @b` が outer 構造まで共有するようにする（escape 解析の `needs_cell` を `:=` bound container へ
-  拡張、または bind 確立サイトで直接 box）。これで for-rw writeback(A) は cell 経由で @b に届き、push 非伝播(②)も解消。
-  Sub-slice 1a の write チョークポイントが前提。
+  **Sub-slice 1b — cell-ify `:=` bound arrays/hashes at the outer level (structurally resolving bugs ②③)**:
+  extending the `__mutsu_bound_array_len::`/`MarkBoundContainer` markers that the bind desugar currently plants,
+  make the bound array/hash's slot+env hold **the same `ContainerRef` cell**, so that `@a := @b` shares the outer
+  structure too (extend the escape analysis `needs_cell` to `:=` bound containers, or box directly at the
+  bind-establishment site). With this, the for-rw writeback (A) reaches @b through the cell, and the push
+  non-propagation (②) is resolved as well. Sub-slice 1a's write chokepoints are the prerequisite.
 
-  **Sub-slice 1c — escape-aware closure capture を outer container へ拡張**: `box_captured_lexicals`
-  （`vm_register_ops.rs:333-377`）が現在 `@`/`%` sigil と `Value::Array`/`Hash` を明示 skip しているのを、
-  `needs_cell_locals` に乗った Array/Hash local について box するよう緩和。裸ローカルは従来どおり（perf）。
-- **Stage 2 — `env_dirty` 依存の除去**: 乖離が構造的に消えたコンテナについて reverse pull を不要化。まず計測
-  （`MUTSU_VM_STATS` reverse-sync の container stale が 0 になることを確認）。
-  - **[2026-06-19 着手・計測] `:=` bound container は既に coherent と判明（追加の cell 化不要）+ 計測ギャップを修正（PR #3296）。**
-    `my @a := @b` の whole-container bind は既に **env と locals 両方に同一 `ContainerRef` cell を設置済**
-    （`vm_var_assign_ops.rs` の `:=` 本体 ~6415-6493: source/target 双方の slot・env・saved-frame に同一 cell）。
-    つまり sub-slice 1b（outer cell 化）の主目的は**既存 bind コードで実質達成済**。だが reverse-sync survey の
-    `cheaply_unchanged`（`vm_method_dispatch.rs`）に `ContainerRef` アームが無く、同一 cell 同士を生 `_ => false`
-    で「changed」誤判定していた → bound container が effective stale と過大計上され、`merge_method_env` も同一 cell
-    返却で spurious に `env_dirty` を立てていた。**修正 = `(ContainerRef(a),ContainerRef(b)) => Arc::ptr_eq(a,b)`**。
-    bound-container probe が `effective=6→0 / spurious=6`、hot bench（fix 後）= bench-fib/hash/string/method-call は
-    `effective=0`、bench-class=`effective=1`（slot `desc`＝method 戻り値 local の境界 pull 1回）、bench-array=
-    `effective=1`（slot `@arr`＝top-level push の境界 pull 1回）。**∴ container reverse-sync は消滅し、残る genuine
-    reverse-sync は per-bench 1–2 の scalar/attr 境界 pull のみ（per-iteration でない）。**
-  - **次のターゲット（Stage 3 への残作業）= この境界 scalar/attr pull（R1: method 属性 writeback `desc`・by-name array
-    write `@arr`）を精密 write-through 化して `env_dirty` を立てない**。これらは hot loop 毎ではなく境界一度きりなので
-    perf 影響は元から微小＝`env_dirty` 削除の価値は **アーキ（dual-store 複雑性除去）であって perf ではない**（実測で確認）。
-    + Stage 1 sub-slice 1c（closure capture の `@`/`%` outer 拡張）は user-visible bug 無し（既に Arc+env_dirty で動く）
-    ＝低優先・`env_dirty` 削除と同時に整理。
-  - **[2026-06-19 第27セッション] ★reverse-sync 依存サーフェス全数調査（correctness 視点）= Slice F の真の規模が判明。**
-    Stage 2 の hot-bench 計測は **perf 視点**（per-iteration の pull が無いこと）の指標で、`:=` bound container coherence
-    後は「残り 1–2 の境界 pull」と読めた。だが**正確性視点**で reverse pull が本当に何を支えているかを、`sync_locals_from_env`
-    の本体（`self.locals[i]=val` 書き戻し）を実験的に no-op 化して `t/` 全 949 ファイルを走らせて棚卸しした結果、
-    **約 80 ファイル（カテゴリ横断）が壊れる**ことが判明。hot bench（bench-array/bench-class）は no-op 化しても**正答**
-    （forward write-through で既に coherent・effective=1 は `cheaply_unchanged` の distinct-Arc 過大計上）＝**ベンチは
-    依存サーフェスを代表しない**。実際の依存カテゴリ（壊れたファイル数）:
-    1. **carrier（EVAL/regex/`s///`/`let`/`temp`）** ≈8: `eval-carrier-precise-writeback` `regex-m-s`
+  **Sub-slice 1c — extend escape-aware closure capture to outer containers**: relax `box_captured_lexicals`
+  (`vm_register_ops.rs:333-377`), which currently explicitly skips `@`/`%` sigils and `Value::Array`/`Hash`, so
+  that it boxes Array/Hash locals that are on `needs_cell_locals`. Bare locals stay as before (perf).
+- **Stage 2 — removing the `env_dirty` dependence**: for containers whose divergence has structurally disappeared,
+  make the reverse pull unnecessary. Measure first
+  (confirm via `MUTSU_VM_STATS` that reverse-sync container staleness drops to 0).
+  - **[2026-06-19 started, measured] `:=` bound containers turned out to be already coherent (no extra
+    cell-ification needed) + fixed a measurement gap (PR #3296).**
+    The whole-container bind of `my @a := @b` **already installs the same `ContainerRef` cell in both env and locals**
+    (the `:=` body in `vm_var_assign_ops.rs` ~6415-6493: the same cell in the slot, env, and saved-frame of both
+    source and target). So sub-slice 1b's main goal was **effectively already achieved by the existing bind code**.
+    However, the reverse-sync survey's `cheaply_unchanged` (`vm_method_dispatch.rs`) had no `ContainerRef` arm and
+    misjudged identical cells as "changed" via the raw `_ => false` — so bound containers were overcounted as
+    effective stale, and `merge_method_env` was spuriously setting `env_dirty` when returning the identical cell.
+    **Fix = `(ContainerRef(a),ContainerRef(b)) => Arc::ptr_eq(a,b)`**.
+    The bound-container probe went `effective=6→0 / spurious=6`; hot benches (post-fix) =
+    bench-fib/hash/string/method-call at `effective=0`, bench-class=`effective=1` (slot `desc` = one boundary pull
+    of a method-return local), bench-array=`effective=1` (slot `@arr` = one boundary pull of a top-level push).
+    **∴ container reverse-sync has vanished; the remaining genuine reverse-syncs are just 1–2 per-bench
+    scalar/attr boundary pulls (not per-iteration).**
+  - **Next target (remaining work toward Stage 3) = convert these boundary scalar/attr pulls (R1: method attribute
+    writeback `desc`, by-name array write `@arr`) into precise write-throughs so `env_dirty` is never set.** These
+    happen once at a boundary, not per hot-loop iteration, so the perf impact was tiny to begin with = the value of
+    deleting `env_dirty` is **architectural (removing dual-store complexity), not perf** (confirmed by measurement).
+    + Stage 1 sub-slice 1c (extending closure capture to `@`/`%` outers) has no user-visible bug (already works via
+    Arc+env_dirty) = low priority, to be tidied together with the `env_dirty` deletion.
+  - **[2026-06-19 session 27] ★Full census of the reverse-sync dependence surface (correctness view) = the true
+    scale of Slice F revealed.** Stage 2's hot-bench measurement was a **perf-view** indicator (no per-iteration
+    pulls), and after the `:=` bound container coherence it read as "1–2 remaining boundary pulls". But taking the
+    **correctness view** — what does the reverse pull actually hold up — by experimentally no-op'ing the body of
+    `sync_locals_from_env` (the `self.locals[i]=val` write-back) and running all 949 `t/` files, the inventory
+    showed **about 80 files break (across categories)**. The hot benches (bench-array/bench-class) still **answer
+    correctly** with the no-op (already coherent via forward write-through; effective=1 was the `cheaply_unchanged`
+    distinct-Arc overcount) = **the benches do not represent the dependence surface**. The actual dependence
+    categories (number of broken files):
+    1. **carrier (EVAL/regex/`s///`/`let`/`temp`)** ≈8: `eval-carrier-precise-writeback` `regex-m-s`
        `regex-declarative-modifiers` `smartmatch-env-dirty` `single-store-slice-c-prime` `subst-closure-writeback`
-       `let-temp` `keep-undo`。= R2 carrier writeback（pairs/slip 一般化が deep-cell 壁で延期中の領域そのもの）。
-    2. **supply/react/whenever/gather/promise/proc-async（並行 carrier）** ≈22: `supply-*`(10) `whenever-*`(2)
-       `react-*`(1) `gather-*`(3) `promise-combinator` `proc-async`(4) `concurrency-*`(2) `io-watch` `scheduler-cue-times`。
-       = coroutine/scheduler 再入が caller lexical を env 経由で書き、再開後に reverse pull で観測している。
+       `let-temp` `keep-undo`. = R2 carrier writeback (the very area where the pairs/slip generalization is
+       deferred at the deep-cell wall).
+    2. **supply/react/whenever/gather/promise/proc-async (concurrent carriers)** ≈22: `supply-*`(10) `whenever-*`(2)
+       `react-*`(1) `gather-*`(3) `promise-combinator` `proc-async`(4) `concurrency-*`(2) `io-watch` `scheduler-cue-times`.
+       = coroutine/scheduler re-entry writes caller lexicals via env, observed after resumption via the reverse pull.
     3. **bound container / cell / rw-param** ≈15: `element-bind-cell`(11) `for-pairs-value-quanthash-writeback`(13)
        `rw-param-shared-cell`(5) `pair-value-*` `bound-container-pair-writethrough` `*-param-container-share`
-       `map-native-rw` `is-rw-traits` `role-is-rw` `lvalue-subroutines-rw-proxy` `slurpy-*`。
+       `map-native-rw` `is-rw-traits` `role-is-rw` `lvalue-subroutines-rw-proxy` `slurpy-*`.
     4. **scoped overlay / method / named-call dispatch** ≈14: `scoped-overlay-*`(5) `method-env-dirty`(4)
        `named-call-env-dirty`(6) `zeroarg-env-dirty`(6) `multitier-overlay-env` `say-env-roundtrip`
-       `bareword-assign-expr` `statement-modifier*` `done-paren-stmt-modifier`(4)。
+       `bareword-assign-expr` `statement-modifier*` `done-paren-stmt-modifier`(4).
     5. **attribute / native-backed instance** ≈7: `native-array-backed-instance`(**18/20**) `attribute-trait-mod`(5)
        `attribute-defaults-and-set-build` `class-var-namespace-separation` `methods-instance-regressions`(4)
-       `definite-return` `return-method`。
-    6. **closure** ≈3: `closure-container-capture` `closure-nested-writeback` `wrap-closure-capture`。
-    7. **その他** ≈10（dynamic-var/nil/catch/metaop/import/require/return-exception 等の単発）。
-    **∴ Slice F は「境界 scalar/attr pull の精密化」ではなく、上記 7 カテゴリの by-name writer を一つずつ
-    precise write-through / cell 共有へ畳む multi-session 作業**。特にカテゴリ 1/2（carrier・並行 carrier）は
-    docs/vm-single-store.md が繰り返し当たってきた **deep-cell 壁**（pairs/slip carrier-drop が `element-bind-cell.t` を
-    壊す）と同根で、env↔locals コンテナ coherence（本書 §4-A の outer cell 共有）が前提。**`env_dirty` の global 削除は
-    最後の一手で、それまでは reverse pull が backstop として残る。** ベンチの「1–2 pull」表現は perf 文脈限定で、
-    correctness の依存規模はこの調査が初出。
-    - **[2026-06-19 第27セッション・slice 1] lvalue-method writeback の call-site write-through（カテゴリ3 の一部を依存サーフェスから除去）。**
-      `MUTSU_NO_REVERSE_SYNC=1` を `vm_stats::reverse_sync_disabled()`（キャッシュ済・release ゼロコスト）で配線し、
-      `sync_locals_from_env` 本体を skip できる**恒久 campaign 診断**を追加（各 slice が「この test はもう reverse pull に
-      依存しない」を検証する手段）。最初の write-through 変換 = `__mutsu_assign_method_lvalue` /
-      `__mutsu_index_assign_method_lvalue`（`$p.value = X`・`.value--`・`@a.head=`/`.tail=`/`.first(...)=`・`%h.AT-KEY(k)=`・
-      accessor 経由 nested index）。これらの runtime builtin は `self.env.insert(var, ...)` で target var を by-name 変異し
-      local slot を reverse pull 任せにしていた。VM 呼び出し側（`exec_call_func`）で **target var 名（args[4]）を dispatch 前に
-      キャプチャ → dispatch 後に `env[var]` を local slot へ write-through**（`HashSlotRef` slot は reverse pull と同じく skip）。
-      結果（`MUTSU_NO_REVERSE_SYNC=1`）: `t/role-is-rw.t`・`t/pair-value-container.t` が **OFF で全 pass に転じ依存サーフェスから
-      除去**、`t/for-pairs-value-quanthash-writeback.t` は 13→12（`$p.value--` 解消・残 12 は for-loop topic 経路＝別 slice）。
-      ON は全 t/ green（write-through は reverse pull が引く値と同一＝additive・回帰なし）。pin=`t/lvalue-method-writeback-coherence.t`（12）。
-    - **[2026-06-19 第27セッション・slice 2] for-loop topic writeback（`.value = X for $b.pairs`）の source local write-through。**
-      `for $b.pairs { .value = X }`（mutable BagHash/MixHash/SetHash）の body は `__mutsu_assign_method_lvalue($_,"value",..)` を
-      emit し、builtin 内で `topic_source_var`（=`$b`）経由に `quanthash_set_weight(&EMPTY_code, ...)` を呼ぶ。**空の `CompiledCode`
-      を渡すのは builtin path に bytecode が無いため**（methods_mut.rs のコメント明記）→ env[$b] のみ更新し local slot は reverse pull
-      任せ。修正 = for-loop（`exec_for_loop_body`、real `code` 保有）のループ終了後に、source が mutable QuantHash のとき
-      `container_binding`(=`$b`) の env 最終値を local slot へ write-through（per-arm でなくループ末で一度・`HashSlotRef` skip）。
-      結果（`MUTSU_NO_REVERSE_SYNC=1`）: `t/for-pairs-value-quanthash-writeback.t` が 12→**0**（slice 1 と合わせ 13→0・**ファイル全体を
-      依存サーフェスから除去**）。ON 全 t/ green（additive）。
-      **残カテゴリ3 の本丸は deep `:=` cell（element-bind-cell 9/28/41-47）= §4-A outer cell 共有が前提。**
-    - **[2026-06-19 第28セッション・slice 3] `is rw` / `is raw` パラメータ writeback の call-site write-through。**
-      `sub f($a is rw){ $a = 42 }; f($x)` は `$x` が更新されない**実バグ**だった（reverse pull ON でも fail）。真因 = rw パラメータ
-      `$a` は body 内で slot-only local（`GetLocal`/`SetLocal`）に bind され、`$a = 42` が **env に届かない**（`flush_local_to_env`
-      は `needs_env_sync=false` の slot-only local を mirror しない）→ 返り値時の `apply_rw_bindings_to_env` が **stale な env[a]**
-      を読み caller の source var に書いていた。**(1) 正答化**: `call_compiled_function_named` の返り値経路で、`pop_call_frame` の前
-      （`self.locals` がまだ callee のもの）に rw パラメータの最終 slot 値を env へ flush → `apply_rw_bindings_to_env` が正しい値を書く。
-      **(2) Slice F（OFF 化）**: dispatch が書き戻した caller-source 名を新フィールド `pending_rw_writeback_sources` に記録し、
-      call-site op（caller の `code` 保有）が `apply_pending_rw_writeback(code)` で各 source の env 値を **caller local slot へ
-      write-through**（`HashSlotRef` skip）。sub function dispatch（`call_compiled_function_named`）と pointy-block / closure
-      dispatch（`call_compiled_closure_with_topic`）の両経路をカバーし、drain は `exec_call_func`/`CallOnValue`/`CallOnCodeVar`/
-      carrier（`ExecCall*`）の各 call-site に配線。dispatch 入口で field を clear し、drain されない sibling 経路からのリークを防止。
-      結果（`MUTSU_NO_REVERSE_SYNC=1`）: `t/is-rw-traits.t`（sub rw・pointy-block rw）が OFF で全 pass。pin=`t/rw-param-writeback-coherence.t`（16・
-      scalar/compound/nested-forward/is-raw/pointy-block/loop/2-rw/mixed・ON=OFF=raku 一致）。
-      **残カテゴリ3: lvalue sub/rw Proxy store（`sub () is rw`・`Proxy.new`）・method rw param（`vm_method_dispatch.rs` rw_writeback）・
-      pair-value 要素 write-through（hash 値・`$p.value<f>=`）・map captured-var。**
-    - **[2026-06-19 第29セッション・slice 4] `is rw` / `is raw` *method* パラメータ writeback の call-site write-through（slice 3 の機構を method dispatch へ流用）。**
-      `class C { method m($a is rw){ $a = 9 } }; C.m($x)` は ON では動くが OFF で fail（reverse pull 依存）だった。
-      `call_compiled_method`（`vm_method_dispatch.rs`）は返り値時に rw_writeback を `merge_method_env` の結果に書き込み env を caller-source 名で
-      更新するが、caller local slot は reverse pull 任せだった。slice 3 の `pending_rw_writeback_sources` 機構を再利用: `call_compiled_method`
-      が rw_writeback の source 名を field に記録（入口で clear・leak 防止）→ `CallMethod`/`CallMethodMut`/`CallMethodDynamic(Mut)` op
-      （caller `code` 保有）が `apply_pending_rw_writeback(code)` で write-through。**併せて pre-existing バグ修正**: `has_rw_params` が
-      `"rw"` のみ判定で `"raw"` を見ておらず、`is raw` のみの method が fast-path / merge-skip に乗り writeback が脱落していた（ON でも fail）→
-      `"rw" || "raw"` に拡張（sub dispatch と対称・raw も lvalue arg なら rw_bindings 経由で writeback される）。
-      結果（`MUTSU_NO_REVERSE_SYNC=1`）: scalar/compound/swap/instance/raw の method rw param が OFF で全 pass。pin=`t/method-rw-param-writeback-coherence.t`（13）。
-      **残カテゴリ3: lvalue sub/rw Proxy store（`sub () is rw`・`Proxy.new`）・pair-value 要素 hash 形（`$p.value<f>=`＝§4-A container-identity の deep wall・単純 write-through 不可）・map captured-var。**
-    - **[2026-06-19 第30セッション・slice 5（closure カテゴリ）] クロージャ捕捉変数 write-through。**
-      `@a.map({ $sum += $_ })` の捕捉スカラ `$sum` は ON=6 / OFF=0（reverse pull 依存）だった。`call_compiled_closure_with_topic`
-      （`vm_closure_dispatch.rs`）は body 終了時に変化した free var を `restored_env`（=`self.env`）へ書き戻すが、caller local slot は
-      reverse pull 任せだった。slice 3/4 の `pending_rw_writeback_sources` 機構を再利用: closure dispatch の caller-writeback scan 直後に、
-      入口時スナップショット（`free_at_entry`）と比較して**変化した free var のうち caller lexical（`restored_env.contains_key_sym`）のもの**を
-      field に記録（`$_`/`@_`/param は除外）→ `CallMethod`/`CallOnValue`/`CallOnCodeVar`/`ExecCall` の各 op（caller `code` 保有・slice 3/4 で配線済）が
-      `apply_pending_rw_writeback(code)` で write-through。slice 3 で closure dispatch 入口に追加済の field clear が leak を防ぐ。
-      結果（`MUTSU_NO_REVERSE_SYNC=1`）: 直接 `$blk()`・array `.map`・pointy block・per-iteration closure・captured `@`-push が OFF で全 pass。
-      pin=`t/closure-captured-var-writeback-coherence.t`（10）・`t/map-native-rw.t` test 15 も OFF 解消。
-      **このスライスは VM closure dispatch 経由のみ。range `.map` / `.grep` は interpreter dispatch（`call_sub_value`）経由で別 follow-up（captured hash 要素 `%h{$k}=` via block は ON でも fail＝pre-existing 別バグ）。**
-    - **[2026-06-19 第30セッション後半・range map/grep DEFERRED] range `.map` / `.grep` の captured-var は lazy-eval に阻まれる。**
-      `(1..5).map({ $s += $_ })` は `dispatch_map_method` で `is_lazy_pipe_source`→`make_lazy_pipe`＝**lazy pipe** を返し、ブロックは
-      `.map` の CallMethod op でなく **Seq 強制時（sink context）に走る**ため、CallMethod drain がブロックの captured-var 変化を捕捉できない。
-      `call_sub_value`（merge_all true/false 両分岐）に記録を足しても効果なし（ブロック実行が sink へ遅延・別スコープ）。**lazy pipe の
-      OFF coherence は sink-forcing site で drain する別設計が必要＝deferred。** 試行は revert。
-    - **[2026-06-19 第31セッション・slice 6] `is rw` サブの lvalue 返り write-through。**
-      `my $f = sub () is rw { $v }; $f() = 9` は `$v` を更新するが ON のみ（OFF で `$v` slot stale）。`$f() = 9` は
-      `__mutsu_assign_callable_lvalue` builtin にコンパイルされ、`assign_rw_target_expr`（`builtins_lvalue.rs`）が target var（`$v` / forward の
-      `$leaf()`→…→`$v` / `return-rw` target）を `self.env.insert(name, value)` で by-name 書き、caller slot は reverse pull 任せだった。
-      `assign_rw_target_expr` の `Expr::Var` と `return-rw` 分岐で書いた var 名を `pending_rw_writeback_sources` に記録 → `__mutsu_assign_callable_lvalue`
-      の ExecCall drain（slice 3 で配線済）が caller slot へ write-through。forward（nested rw sub）は recursion で最終 Var に到達し記録。
-      結果（`MUTSU_NO_REVERSE_SYNC=1`）: `t/lvalue-subroutines-rw-proxy.t`（5）が OFF で全 pass。pin=`t/rw-sub-lvalue-writeback-coherence.t`（8）。
-    - **[2026-06-19 第31セッション・slice 7（attribute-native-instance カテゴリ）] mutating method の receiver write-through。**
-      `class Stack is Array {}; my $s = Stack.new; $s.push(1)` の receiver `$s` は ON のみ coherent（OFF で `$s.elems` が stale）。
-      `exec_call_method_mut_op`（`vm_call_method_mut_ops.rs`）の native mutator 群（`$s.push`/`.pop`/`.unshift`/… on Array-/Hash-backed
-      instance ＋ ~15 個の `env_mut().insert(target_name, ..)` 分岐）は receiver を env に by-name 再代入し caller slot は reverse pull 任せだった。
-      `CallMethodMut` op（`vm.rs`・caller `code`＋`target_name_idx` 保有）で **dispatch 後に receiver 名を `pending_rw_writeback_sources` に push** →
-      既存 `apply_pending_rw_writeback(code)` drain（slice 3/4 で配線済）が caller slot へ write-through（HashSlotRef-skip 不変は reverse pull と同じ）。
-      receiver 名を毎 CallMethodMut で push＝reverse pull の per-slot 動作を 1 receiver に限定して再現（最大 blast-radius だが make test 9314＋roast 181 サンプル回帰なし）。
-      結果（`MUTSU_NO_REVERSE_SYNC=1`）: `t/native-array-backed-instance.t`（20）が OFF 2→20 全 pass。pin=`t/mut-method-receiver-writeback-coherence.t`（12・Array/Hash-backed instance・plain array regression guard）。
-    - **[slice: 0-arg fast-call captured-outer write-through (PR #3317)]**: `sub bump { $acc = $acc + 5 }` を
-      `bump()`（0-arg）で呼ぶと captured-outer `$acc` の書き戻しが OFF で stale（#3307 は closure dispatch のみ・0-arg
-      named sub は `call_compiled_function_fast` の別経路）。`call_compiled_function_fast` exit で `cf.code.free_var_writes`
-      （topic `_`/`@_`/`%_` 除外）を `pending_rw_writeback_sources` に push → fast-call site で `apply_pending_rw_writeback`
-      drain。**single-level（直接 caller）のみ**。**multi-frame（nested 0-arg / 0-arg 再帰）は retention（置けない source を
-      祖先へ伝播）が必要だが、retention は lazy-iteration topic を撹乱して `grep(*.is-prime, 1..Inf)` を無限ループ化＝
-      session 30 の range map/grep と同じ lazy-eval 壁＝deferred。** `t/single-store-slice-a.t` を OFF 依存サーフェスから除去。
-      pin=`t/fast-call-captured-write-coherence.t`（10）。
-- **★依存サーフェス再測定（第32セッション・重要訂正）**: 「`t/` + whitelisted roast が 100% reverse-sync 非依存」（第31の
-  マイルストーン）は**測定エラーで誤り**。Stage 3a（`sync_locals_from_env` デフォルト無効化）を試すと **65 個の `t/` が回帰**
-  （全て ON pass / OFF fail＝真に依存）。前回の差分スキャンは `MUTSU_NO_REVERSE_SYNC` トグルが実際に効いていなかった偽陰性。
-  内訳: 並行 21・**通常言語機能 21**（catch-in-blocks/definite-return/statement-modifiers/return-exception/slurpy/attr-trait/
-  import/require/role-body 等）・env-dirty/overlay pins 14・carrier 6・closure 5・deep-cell 2。**∴ Stage 3 全廃は「2-4 セッション
-  射程内」ではなく、65 ファイル分の by-name writer を write-through/cell 共有へ畳む大規模グラインドが残る**（survey #3299 の
-  「7 カテゴリ・約80 files」framing が正しい）。教訓: 「0 dependent」を信じる前に既知依存ケース（`t/zeroarg-env-dirty.t`）で
-  トグルが挙動を変えるか sanity-check。
-- **Stage 3 — Slice F 本体 ＋ pairs/slip carrier-drop 一般化**: `env_dirty`/`ensure_locals_synced`/
-  `sync_locals_from_env`/`saved_env_dirty` 削除（`docs/vm-single-store.md` Slice F）。同時に `pairs`/`slip`
-  carrier-drop を有効化（outer cell 共有で安全）。**前提=上の 65 ファイル依存が write-through/cell 共有で枯れること。**
+       `definite-return` `return-method`.
+    6. **closure** ≈3: `closure-container-capture` `closure-nested-writeback` `wrap-closure-capture`.
+    7. **misc** ≈10 (one-offs: dynamic-var/nil/catch/metaop/import/require/return-exception etc.).
+    **∴ Slice F is not "refining the boundary scalar/attr pulls" but a multi-session effort of folding the by-name
+    writers of the 7 categories above, one by one, into precise write-through / cell sharing.** In particular
+    categories 1/2 (carrier, concurrent carrier) share the root with the **deep-cell wall** that
+    docs/vm-single-store.md has repeatedly hit (pairs/slip carrier-drop breaking `element-bind-cell.t`), and
+    env↔locals container coherence (this document's §4-A outer cell sharing) is the prerequisite. **The global
+    deletion of `env_dirty` is the final move; until then the reverse pull remains as a backstop.** The benches'
+    "1–2 pulls" phrasing is perf-context only; this survey is the first statement of the correctness-side scale of
+    the dependence.
+    - **[2026-06-19 session 27, slice 1] lvalue-method writeback as call-site write-through (removing part of
+      category 3 from the dependence surface).**
+      Wired `MUTSU_NO_REVERSE_SYNC=1` through `vm_stats::reverse_sync_disabled()` (cached; zero cost in release) and
+      added a **permanent campaign diagnostic** that can skip the body of `sync_locals_from_env` (each slice's means
+      of verifying "this test no longer depends on the reverse pull"). First write-through conversion =
+      `__mutsu_assign_method_lvalue` / `__mutsu_index_assign_method_lvalue` (`$p.value = X`, `.value--`,
+      `@a.head=`/`.tail=`/`.first(...)=`, `%h.AT-KEY(k)=`, accessor-based nested index). These runtime builtins
+      mutated the target var by name via `self.env.insert(var, ...)` and left the local slot to the reverse pull.
+      On the VM call side (`exec_call_func`), **capture the target var name (args[4]) before dispatch → after
+      dispatch, write `env[var]` through to the local slot** (`HashSlotRef` slots are skipped, same as the reverse
+      pull). Result (`MUTSU_NO_REVERSE_SYNC=1`): `t/role-is-rw.t` and `t/pair-value-container.t` **turned fully
+      passing with OFF and are removed from the dependence surface**; `t/for-pairs-value-quanthash-writeback.t`
+      went 13→12 (`$p.value--` resolved; the remaining 12 are the for-loop topic path = a separate slice).
+      ON keeps all t/ green (the write-through equals the value the reverse pull would fetch = additive, no
+      regressions). pin=`t/lvalue-method-writeback-coherence.t` (12).
+    - **[2026-06-19 session 27, slice 2] for-loop topic writeback (`.value = X for $b.pairs`) as source-local
+      write-through.**
+      The body of `for $b.pairs { .value = X }` (mutable BagHash/MixHash/SetHash) emits
+      `__mutsu_assign_method_lvalue($_,"value",..)`, and inside the builtin calls
+      `quanthash_set_weight(&EMPTY_code, ...)` via `topic_source_var` (=`$b`). **Passing an empty `CompiledCode` is
+      because the builtin path has no bytecode** (stated in a comment in methods_mut.rs) → only env[$b] is updated
+      and the local slot is left to the reverse pull. Fix = in the for-loop (`exec_for_loop_body`, which holds the
+      real `code`), after the loop ends, when the source is a mutable QuantHash, write the final env value of
+      `container_binding` (=`$b`) through to the local slot (once at loop end, not per arm; `HashSlotRef` skipped).
+      Result (`MUTSU_NO_REVERSE_SYNC=1`): `t/for-pairs-value-quanthash-writeback.t` went 12→**0** (13→0 combined
+      with slice 1 = **the whole file removed from the dependence surface**). ON all t/ green (additive).
+      **The core of the remaining category 3 is the deep `:=` cell (element-bind-cell 9/28/41-47) = presupposes
+      §4-A outer cell sharing.**
+    - **[2026-06-19 session 28, slice 3] `is rw` / `is raw` parameter writeback as call-site write-through.**
+      `sub f($a is rw){ $a = 42 }; f($x)` was a **real bug** where `$x` never got updated (failing even with the
+      reverse pull ON). Root cause = the rw parameter `$a` is bound in the body to a slot-only local
+      (`GetLocal`/`SetLocal`), and `$a = 42` **never reaches env** (`flush_local_to_env` does not mirror
+      slot-only locals with `needs_env_sync=false`) → at return time `apply_rw_bindings_to_env` read a **stale
+      env[a]** and wrote it to the caller's source var. **(1) Correctness fix**: in the return path of
+      `call_compiled_function_named`, before `pop_call_frame` (while `self.locals` is still the callee's), flush
+      the rw parameters' final slot values to env → `apply_rw_bindings_to_env` writes the correct values.
+      **(2) Slice F (making OFF work)**: record the caller-source names that dispatch wrote back in the new field
+      `pending_rw_writeback_sources`, and the call-site op (which holds the caller's `code`) writes each source's
+      env value **through to the caller local slot** via `apply_pending_rw_writeback(code)` (`HashSlotRef` skipped).
+      Covers both the sub function dispatch (`call_compiled_function_named`) and pointy-block / closure dispatch
+      (`call_compiled_closure_with_topic`); draining is wired into each call site:
+      `exec_call_func`/`CallOnValue`/`CallOnCodeVar`/carrier (`ExecCall*`). The field is cleared at dispatch entry,
+      preventing leaks from sibling paths that never drain.
+      Result (`MUTSU_NO_REVERSE_SYNC=1`): `t/is-rw-traits.t` (sub rw, pointy-block rw) fully passes with OFF.
+      pin=`t/rw-param-writeback-coherence.t` (16: scalar/compound/nested-forward/is-raw/pointy-block/loop/2-rw/mixed;
+      ON=OFF=matches raku).
+      **Remaining category 3: lvalue sub/rw Proxy store (`sub () is rw`, `Proxy.new`), method rw params
+      (`vm_method_dispatch.rs` rw_writeback), pair-value element write-through (hash values, `$p.value<f>=`),
+      map captured-var.**
+    - **[2026-06-19 session 29, slice 4] `is rw` / `is raw` *method* parameter writeback as call-site write-through
+      (reusing slice 3's mechanism for method dispatch).**
+      `class C { method m($a is rw){ $a = 9 } }; C.m($x)` worked with ON but failed with OFF (reverse-pull
+      dependent). `call_compiled_method` (`vm_method_dispatch.rs`) writes the rw_writeback into the result of
+      `merge_method_env` at return time, updating env under the caller-source name, but the caller local slot was
+      left to the reverse pull. Reused slice 3's `pending_rw_writeback_sources` mechanism: `call_compiled_method`
+      records the rw_writeback source names in the field (cleared at entry; leak prevention) → the
+      `CallMethod`/`CallMethodMut`/`CallMethodDynamic(Mut)` ops (which hold the caller `code`) write through via
+      `apply_pending_rw_writeback(code)`. **Also fixed a pre-existing bug**: `has_rw_params` only tested `"rw"` and
+      missed `"raw"`, so a method with only `is raw` rode the fast path / merge skip and its writeback was dropped
+      (failing even with ON) → extended to `"rw" || "raw"` (symmetric with sub dispatch; raw is also written back
+      via rw_bindings when the arg is an lvalue).
+      Result (`MUTSU_NO_REVERSE_SYNC=1`): scalar/compound/swap/instance/raw method rw params fully pass with OFF.
+      pin=`t/method-rw-param-writeback-coherence.t` (13).
+      **Remaining category 3: lvalue sub/rw Proxy store (`sub () is rw`, `Proxy.new`), pair-value element hash form
+      (`$p.value<f>=` = §4-A container-identity deep wall; simple write-through impossible), map captured-var.**
+    - **[2026-06-19 session 30, slice 5 (closure category)] Closure captured-variable write-through.**
+      The captured scalar `$sum` of `@a.map({ $sum += $_ })` was ON=6 / OFF=0 (reverse-pull dependent).
+      `call_compiled_closure_with_topic` (`vm_closure_dispatch.rs`) writes changed free vars back to
+      `restored_env` (=`self.env`) at body end, but the caller local slot was left to the reverse pull. Reused the
+      `pending_rw_writeback_sources` mechanism of slices 3/4: right after the closure dispatch's caller-writeback
+      scan, compare against the entry-time snapshot (`free_at_entry`) and record in the field **the changed free
+      vars that are caller lexicals (`restored_env.contains_key_sym`)** (excluding `$_`/`@_`/params) → the
+      `CallMethod`/`CallOnValue`/`CallOnCodeVar`/`ExecCall` ops (holding the caller `code`; wired in slices 3/4)
+      write through via `apply_pending_rw_writeback(code)`. The field clear added at closure-dispatch entry in
+      slice 3 prevents leaks.
+      Result (`MUTSU_NO_REVERSE_SYNC=1`): direct `$blk()`, array `.map`, pointy blocks, per-iteration closures, and
+      captured `@`-push all pass with OFF.
+      pin=`t/closure-captured-var-writeback-coherence.t` (10); `t/map-native-rw.t` test 15 also resolved for OFF.
+      **This slice covers only the VM closure dispatch. Range `.map` / `.grep` go via interpreter dispatch
+      (`call_sub_value`) — a separate follow-up (captured hash element `%h{$k}=` via block fails even with ON =
+      pre-existing separate bug).**
+    - **[2026-06-19 session 30 second half, range map/grep DEFERRED] captured-var for range `.map` / `.grep` is
+      blocked by lazy eval.**
+      `(1..5).map({ $s += $_ })` returns a **lazy pipe** via `dispatch_map_method` →
+      `is_lazy_pipe_source`→`make_lazy_pipe`, and the block runs **at Seq forcing time (sink context)**, not at the
+      `.map` CallMethod op, so the CallMethod drain cannot capture the block's captured-var changes. Adding
+      recording to `call_sub_value` (both merge_all true/false branches) had no effect (block execution is deferred
+      to sink; different scope). **OFF coherence for lazy pipes needs a different design that drains at the
+      sink-forcing site = deferred.** The attempt was reverted.
+    - **[2026-06-19 session 31, slice 6] lvalue-return write-through for `is rw` subs.**
+      `my $f = sub () is rw { $v }; $f() = 9` updates `$v`, but only with ON (with OFF the `$v` slot is stale).
+      `$f() = 9` compiles to the `__mutsu_assign_callable_lvalue` builtin, and `assign_rw_target_expr`
+      (`builtins_lvalue.rs`) wrote the target var (`$v` / forwarded `$leaf()`→…→`$v` / `return-rw` target) by name
+      via `self.env.insert(name, value)`, leaving the caller slot to the reverse pull.
+      Record the var names written in `assign_rw_target_expr`'s `Expr::Var` and `return-rw` branches into
+      `pending_rw_writeback_sources` → the ExecCall drain of `__mutsu_assign_callable_lvalue` (wired in slice 3)
+      writes through to the caller slot. Forwarding (nested rw subs) reaches the final Var by recursion and records it.
+      Result (`MUTSU_NO_REVERSE_SYNC=1`): `t/lvalue-subroutines-rw-proxy.t` (5) fully passes with OFF.
+      pin=`t/rw-sub-lvalue-writeback-coherence.t` (8).
+    - **[2026-06-19 session 31, slice 7 (attribute-native-instance category)] receiver write-through for mutating
+      methods.**
+      For `class Stack is Array {}; my $s = Stack.new; $s.push(1)`, the receiver `$s` was coherent only with ON
+      (with OFF `$s.elems` is stale). The native mutator group of `exec_call_method_mut_op`
+      (`vm_call_method_mut_ops.rs`) (`$s.push`/`.pop`/`.unshift`/… on Array-/Hash-backed instances plus ~15
+      `env_mut().insert(target_name, ..)` branches) reassigned the receiver into env by name and left the caller
+      slot to the reverse pull.
+      In the `CallMethodMut` op (`vm.rs`; holds the caller `code` + `target_name_idx`), **push the receiver name
+      onto `pending_rw_writeback_sources` after dispatch** → the existing `apply_pending_rw_writeback(code)` drain
+      (wired in slices 3/4) writes through to the caller slot (the HashSlotRef-skip invariant same as the reverse
+      pull). Pushing the receiver name on every CallMethodMut = reproducing the reverse pull's per-slot behavior
+      restricted to 1 receiver (maximal blast radius, but no regressions across make test 9314 + a 181-file roast
+      sample).
+      Result (`MUTSU_NO_REVERSE_SYNC=1`): `t/native-array-backed-instance.t` (20) goes OFF 2→20, fully passing.
+      pin=`t/mut-method-receiver-writeback-coherence.t` (12: Array/Hash-backed instance, plain-array regression guard).
+    - **[slice: 0-arg fast-call captured-outer write-through (PR #3317)]**: calling
+      `sub bump { $acc = $acc + 5 }` as `bump()` (0-arg) left the captured-outer `$acc` writeback stale with OFF
+      (#3307 covered only closure dispatch; 0-arg named subs take the separate `call_compiled_function_fast` path).
+      At `call_compiled_function_fast` exit, push `cf.code.free_var_writes` (excluding topic `_`/`@_`/`%_`) onto
+      `pending_rw_writeback_sources` → drain at the fast-call site via `apply_pending_rw_writeback`.
+      **Single-level (direct caller) only.** **Multi-frame (nested 0-arg / 0-arg recursion) needs retention
+      (propagating un-placeable sources to ancestors), but retention perturbs lazy-iteration topics and makes
+      `grep(*.is-prime, 1..Inf)` loop forever = the same lazy-eval wall as session 30's range map/grep = deferred.**
+      Removed `t/single-store-slice-a.t` from the OFF dependence surface.
+      pin=`t/fast-call-captured-write-coherence.t` (10).
+- **★Dependence-surface re-measurement (session 32; important correction)**: "`t/` + whitelisted roast are 100%
+  reverse-sync independent" (the session-31 milestone) was **wrong due to a measurement error**. Trying Stage 3a
+  (disabling `sync_locals_from_env` by default) **regressed 65 `t/` files** (all ON pass / OFF fail = genuinely
+  dependent). The previous diff scan was a false negative — the `MUTSU_NO_REVERSE_SYNC` toggle had not actually
+  been taking effect.
+  Breakdown: concurrency 21, **ordinary language features 21** (catch-in-blocks/definite-return/statement-modifiers/
+  return-exception/slurpy/attr-trait/import/require/role-body etc.), env-dirty/overlay pins 14, carrier 6,
+  closure 5, deep-cell 2. **∴ Full Stage 3 removal is not "within a 2-4 session range"; a large grind remains of
+  folding the by-name writers of 65 files into write-through/cell sharing** (the "7 categories, ~80 files" framing
+  of survey #3299 is the correct one). Lesson: before believing "0 dependents", sanity-check that the toggle
+  actually changes behavior on a known-dependent case (`t/zeroarg-env-dirty.t`).
+- **Stage 3 — Slice F proper + pairs/slip carrier-drop generalization**: delete
+  `env_dirty`/`ensure_locals_synced`/`sync_locals_from_env`/`saved_env_dirty` (`docs/vm-single-store.md` Slice F).
+  Simultaneously enable the `pairs`/`slip` carrier-drop (safe with outer cell sharing). **Prerequisite = the
+  65-file dependence above dries up via write-through/cell sharing.**
 
-各 Stage は **`t/element-bind-cell.t`（54）/ `t/array-bind-cell.t` / `t/hash-bind-cell.t` / nested.t 43 ＋
-release roast の main-vs-branch 比較 ＋ int.t/method-call の wall-clock**（#2746 教訓: perf 回帰は make test で
-検出不能・CI release roast の timeout でのみ顕在化）で固める。
+Each Stage is pinned down with **`t/element-bind-cell.t` (54) / `t/array-bind-cell.t` / `t/hash-bind-cell.t` /
+nested.t 43, plus a main-vs-branch comparison of release roast, plus wall-clock of int.t/method-call**
+(the #2746 lesson: perf regressions are undetectable by make test and only surface as CI release roast timeouts).
 
-### [2026-06-20 第35セッション] deep-cell 壁の精密 root-cause（次 sub-slice のターゲット確定）
+### [2026-06-20 session 35] Precise root cause of the deep-cell wall (target of the next sub-slice fixed)
 
-`t/element-bind-cell.t` の OFF 失敗（test 9/28/30/31/41/42-47）を二分探索で root-cause した。**壁の入口は
-「scalar が container を保持し、その 2+レベルの要素を `:=` で LHS bind する」ケース**に正確に絞られる:
+Bisected and root-caused the OFF failures of `t/element-bind-cell.t` (tests 9/28/30/31/41/42-47). **The entrance to
+the wall is pinned down exactly to the case "a scalar holds a container, and a 2+-level element of it is LHS-bound
+with `:=`"**:
 
-- `@a[1] := $v`（**array VAR** レシーバ・任意深度）= OFF で動作（array var は既に env↔slot 共有 spine）。
-- `$s[1] := $v`（**scalar-holding-array**・1 レベル）= OFF で動作。
-- `$s[1][1] := $v`（scalar-holding-array・**2 レベル**）= OFF で **`$v=NEW` が element に伝播せず**（element は stale 旧値）。
-- `$s[1][1][0] := $v`（**3 レベル**）= 上記に加え **sibling `$s[1][1][1]` が `Nil` に破壊**（inner array 全体が乖離）。
+- `@a[1] := $v` (**array VAR** receiver, any depth) = works with OFF (array vars already have the env↔slot shared spine).
+- `$s[1] := $v` (**scalar-holding-array**, 1 level) = works with OFF.
+- `$s[1][1] := $v` (scalar-holding-array, **2 levels**) = with OFF, **`$v=NEW` does not propagate to the element**
+  (the element is the stale old value).
+- `$s[1][1][0] := $v` (**3 levels**) = in addition, **the sibling `$s[1][1][1]` is destroyed to `Nil`** (the whole
+  inner array diverges).
 
-**機構**: deep computed-target bind（`vm_var_assign_ops.rs:4933` `Phase 2 Stage 2`）は resolved `target`（inner container）を
-`arc_contents_mut` で in-place 変異させ cell を埋め込み、cell を source var `$v` に書き戻す。だが `target` は `$s` を辿って
-得た **env 側の copy**で、descent 中の `make_mut`/COW で `$s` の **slot 側 Arc と乖離**する。cell は env にのみ埋め込まれ、
-slot は stale。ON は次の `$s` read 時に reverse pull が slot を env から取り直して再収束するが、OFF は再収束しない。
-`@a[1]:=` が効くのは array var が `env_root_descended_mut` の共有 spine を辿るため。
+**Mechanism**: deep computed-target bind (`vm_var_assign_ops.rs:4933` `Phase 2 Stage 2`) mutates the resolved
+`target` (the inner container) in place via `arc_contents_mut` to embed the cell, and writes the cell back to the
+source var `$v`. But `target` is an **env-side copy** obtained by traversing `$s`, and `make_mut`/COW during the
+descent **diverges it from `$s`'s slot-side Arc**. The cell gets embedded only in env; the slot is stale. With ON,
+the next read of `$s` re-converges the slot from env via the reverse pull; with OFF it never re-converges.
+`@a[1]:=` works because array vars traverse the shared spine of `env_root_descended_mut`.
 
-**∴ 次の sub-slice（substrate）= 「deep `:=` element bind の root が scalar-holding-container のとき、その scalar を
-共有 `ContainerRef` cell に昇格（#3264 の scalar-array-sharing の `:=`-target 版）」**。これで bind descent
-（`env_root_descended_mut`）が env↔slot 共有 spine を辿り、cell 埋め込みが両ストアから見える。**高 blast-radius・
-要 escape 解析の `:=`-target 拡張 + descent の cell 昇格** = focused な独立セッションで着手すべき（終盤に急がない）。
-pin 候補 = `t/element-bind-cell.t` の OFF-clean 化（test 9/28/30/31/41/42-47）。**RHS bind（`$b := $s[1][1][0]`）は
-OFF で動作**＝LHS（element := scalar）だけが乖離。
+**∴ The next sub-slice (substrate) = "when the root of a deep `:=` element bind is a scalar-holding-container,
+promote that scalar to a shared `ContainerRef` cell (the `:=`-target version of #3264's scalar-array-sharing)"**.
+Then the bind descent (`env_root_descended_mut`) traverses the env↔slot shared spine, and the cell embedding is
+visible from both stores. **High blast radius; needs the `:=`-target extension of the escape analysis + cell
+promotion in the descent** = should be tackled in a focused independent session (do not rush it at the end of one).
+pin candidate = making `t/element-bind-cell.t` OFF-clean (tests 9/28/30/31/41/42-47). **RHS bind
+(`$b := $s[1][1][0]`) works with OFF** = only LHS (element := scalar) diverges.
 
 ---
 
-## 6. 着手前に解く open questions
+## 6. Open questions to settle before starting
 
-1. **outer コンテナ cell の decont 消費面の網羅**: 値 op で ContainerRef-outer が漏れる経路の完全棚卸し。
-   Phase 2 の leaf cell より広い（outer は iteration/slice/native method が直接 items を舐める）。
-2. **escape 判定の outer 拡張**: 既存 `captured_mutated_locals`/`needs_cell_locals`（scalar 中心）を Array/Hash
-   ローカルへ広げる。`@a` を closure 捕捉＋変異する頻出ケースの perf を timed 確認。
-3. **scoped overlay chain との相互作用**: outer cell が parent tier に居るとき scoped_child/flatten が cell を
-   どう扱うか（cell は Arc bump で生存するはずだが flatten の merged map で要確認）。
-4. **cross-thread**: `clone_for_thread` / `shared_vars` と outer cell（`Arc<Mutex>`）の整合（Track C と重なる）。
-5. **`env_dirty` の非コンテナ依存**: Slice B で判明した「`:=` bind 等の暗黙 reconcile 依存」（scalar 側）が
-   outer cell 化後も残るか。残るなら Slice F は scalar 側の精密化（Slice C/C′ の延長）も要する。
-
----
-
-## 7. 参照
-
-- `docs/vm-single-store.md` — 二重ストア統合の forward plan（Slice A–G）。本書は Slice F の前提条件の設計。
-- `docs/vm-dual-store.md` — 機構マップと撤回試行のアーカイブ。
-- `docs/container-identity.md` — 第一級コンテナ実装台帳（Phase 0/1/2/3）。outer cell 化は Phase 2 の延長。
-- `docs/slotref-removal-plan.md` — SlotRef 撤去（leaf cell 化の周辺）。
-- 失敗の実証: `t/element-bind-cell.t`（pairs/slip carrier-drop で 9/28/41/44/46/47 が壊れる）。
+1. **Coverage of the decont consumption surface for outer container cells**: a complete inventory of paths where a
+   ContainerRef-outer could leak in value ops. Broader than Phase 2's leaf cells (outers are directly walked by
+   iteration/slice/native methods over items).
+2. **Extending the escape verdict to outers**: widen the existing `captured_mutated_locals`/`needs_cell_locals`
+   (scalar-centric) to Array/Hash locals. Verify with timing the perf of the common case of a closure capturing and
+   mutating `@a`.
+3. **Interaction with the scoped overlay chain**: how scoped_child/flatten treat an outer cell that lives in a
+   parent tier (the cell should survive via Arc bump, but the flatten's merged map needs checking).
+4. **Cross-thread**: consistency of `clone_for_thread` / `shared_vars` with outer cells (`Arc<Mutex>`)
+   (overlaps with Track C).
+5. **Non-container dependence of `env_dirty`**: does the "implicit reconcile dependence of `:=` bind etc."
+   (scalar side) found in Slice B remain after outer cell-ification? If so, Slice F also needs the scalar-side
+   refinement (an extension of Slice C/C′).
 
 ---
 
-## 6. Multi-frame captured-outer 伝播 — 次の substrate handoff（2026-06-20・第36セッション偵察完了）
+## 7. References
 
-第36セッションで single-frame + deep-cell の OFF 依存を一掃（36→13）した後の残る最大の壁。
-**即着手用に canonical case・実験結果・次の調査点を固める。**
+- `docs/vm-single-store.md` — the forward plan of dual-store unification (Slices A–G). This document is the design
+  of Slice F's prerequisite.
+- `docs/vm-dual-store.md` — the mechanism map and the archive of retracted attempts.
+- `docs/container-identity.md` — the first-class container implementation ledger (Phases 0/1/2/3). Outer
+  cell-ification is an extension of Phase 2.
+- `docs/slotref-removal-plan.md` — SlotRef removal (adjacent to leaf cell-ification).
+- Demonstration of the failure: `t/element-bind-cell.t` (9/28/41/44/46/47 break under pairs/slip carrier-drop).
 
-### 6.1 Canonical case（残 OFF 依存の代表）
+---
+
+## 6. Multi-frame captured-outer propagation — the next substrate handoff (2026-06-20; session-36 reconnaissance complete)
+
+The largest remaining wall after session 36 swept the single-frame + deep-cell OFF dependences (36→13).
+**Pinning down the canonical case, experimental results, and next investigation points for immediate pickup.**
+
+### 6.1 Canonical case (representative of the remaining OFF dependences)
 
 ```raku
 my $acc = 0;
-sub bump-outer() { $acc = $acc + 10 }   # writer（最内フレーム・$acc は free var）
-sub via()        { bump-outer() }        # mid フレーム（$acc を持たない）
-via();                                    # ← 単独なら raku=10・OFF でも 10（既に正しい！）
+sub bump-outer() { $acc = $acc + 10 }   # writer (innermost frame; $acc is a free var)
+sub via()        { bump-outer() }        # mid frame (does not hold $acc)
+via();                                    # ← alone, raku=10; even OFF gives 10 (already correct!)
 via();
-say $acc;                                 # raku=20・OFF=10（accumulation 失敗）
+say $acc;                                 # raku=20; OFF=10 (accumulation failure)
 ```
 
-対象 OFF 依存ファイル（13 のうち6）: `closure-nested-writeback`(2) `multitier-overlay-env`(1)
-`scoped-overlay-env-dirty`(1) `wrap-closure-capture`(3) `zeroarg-env-dirty`(1) `slurpy-is-raw`(1)。
-いずれも "nested ... propagate captured mutation" 系。
+Affected OFF-dependent files (6 of the 13): `closure-nested-writeback`(2) `multitier-overlay-env`(1)
+`scoped-overlay-env-dirty`(1) `wrap-closure-capture`(3) `zeroarg-env-dirty`(1) `slurpy-is-raw`(1).
+All of the "nested ... propagate captured mutation" family.
 
-### 6.2 ★最重要の切り分け（第36セッション probe）
+### 6.2 ★The most important isolation (session-36 probe)
 
-- **単一 `via()` は OFF でも正しい**（`acc=10`）。∴ caller→mid→writer の **1 回の伝播は既存機構で動く**
-  （#3317 の 0-arg fast-call captured-write drain 等）。
-- **壊れるのは `via(); via()` の cross-call ACCUMULATION**（10 のまま・20 にならない）。
-  = 第34セッションの「method-invocant autothread の `our`-var cross-call 蓄積」壁（memory 第34節）と**同類**。
-  問題は「伝播が無い」のではなく「2 回目の呼び出しが 1 回目の書込を踏まえて累積できない」こと。
+- **A single `via()` is correct even with OFF** (`acc=10`). ∴ **one round of caller→mid→writer propagation works
+  with the existing mechanisms** (#3317's 0-arg fast-call captured-write drain, etc.).
+- **What breaks is the cross-call ACCUMULATION of `via(); via()`** (stays 10; never becomes 20).
+  = the **same kind** as session 34's "method-invocant autothread `our`-var cross-call accumulation" wall
+  (memory §34). The problem is not "no propagation" but "the second call cannot accumulate on top of the
+  first call's write".
 
-### 6.3 ★retention 実験の結論（第36セッション・revert 済）
+### 6.3 ★Conclusion of the retention experiment (session 36; reverted)
 
-`apply_pending_rw_writeback`（`vm_env_helpers.rs`）に **guarded retention** を試した:
-現フレームに無い source 名を `retained` に re-push（`call_frames` 非空 + topic/match 名除外 +
-`env.contains_key` のときのみ）→親フレーム drain が拾う。結果:
+Tried **guarded retention** in `apply_pending_rw_writeback` (`vm_env_helpers.rs`):
+re-push source names absent from the current frame onto `retained` (only when `call_frames` is non-empty +
+topic/match names excluded + `env.contains_key`) → the parent frame's drain picks them up. Results:
 
-1. **canonical case を直さない**（依然 `acc=10`）。∴ retention（reverse propagation の補強）は **的外れ**。
-   壁は forward 側（accumulation）にある。
-2. **#3317 の lazy ハングを再現しない**（`grep-lazy-range.t` exit 0）。
-   ∴ topic/match 除外 + `call_frames` ガードで **lazy-eval 衝突は回避可能**（#3317 の壁は de-risk 済）。
-   ——将来 retention が必要になったときの安全弁設計はこのガードで OK。
+1. **It does not fix the canonical case** (still `acc=10`). ∴ retention (reinforcing reverse propagation) is
+   **off target**. The wall is on the forward side (accumulation).
+2. **It does not reproduce #3317's lazy hang** (`grep-lazy-range.t` exits 0).
+   ∴ with the topic/match exclusion + `call_frames` guard, **the lazy-eval collision is avoidable** (#3317's wall
+   is de-risked). — If retention ever becomes necessary in the future, this guard is the right safety-valve design.
 
-### 6.4 次の調査点（forward accumulation 仮説）
+### 6.4 Next investigation points (forward-accumulation hypothesis)
 
-2 回目の `via()`→`bump-outer` が `$acc` を読むとき **stale な値（10 でなく 0、or env でなく locals）を読んで
-いる**疑いが濃厚。候補:
-- **call 入口の forward sync（locals→env）が env `$acc` を stale locals 値で上書き**してから writer が読む
-  → 1 回目で locals `$acc` が更新されない（reverse drain は `via` フレームに `$acc` local が無く no-op、
-  top-level drain は呼ばれるが…）→ 2 回目入口で stale locals が env に flush → writer が 0+10=10 を再書込。
-- ∴ 次セッションは **bump-outer の `$acc` read 値**と **via 入口/bump-outer 入口の env↔locals `$acc`** を
-  trace（`MUTSU_TRACE` or 一時 eprintln 1 パス）で確定 → forward sync の stale 上書きを塞ぐ筋。
-- 関連既存解析: session 34 の `our`-var cross-call（method-autothread・部分修正不可で revert）。同じ
-  accumulation 機構なら共通解の可能性。
+Strong suspicion that when the second `via()`→`bump-outer` reads `$acc`, it **reads a stale value (0 instead of 10,
+or locals instead of env)**. Candidates:
+- **The forward sync at call entry (locals→env) overwrites env `$acc` with a stale locals value** before the writer
+  reads it → after the 1st call, locals `$acc` is not updated (the reverse drain is a no-op because the `via` frame
+  has no `$acc` local; the top-level drain is called but…) → at the 2nd call's entry, the stale locals are flushed
+  to env → the writer re-writes 0+10=10.
+- ∴ next session: pin down **the `$acc` value bump-outer reads** and **env↔locals `$acc` at via entry /
+  bump-outer entry** with tracing (`MUTSU_TRACE` or one pass of temporary eprintln) → then plug the forward sync's
+  stale overwrite.
+- Related existing analysis: session 34's `our`-var cross-call (method-autothread; a partial fix was not viable and
+  was reverted). If it is the same accumulation mechanism, a common solution is possible.
 
-### 6.5 残り 13 の内訳（第36末・参考）
+### 6.5 Breakdown of the remaining 13 (end of session 36; for reference)
 
-- **multi-frame accumulation（本節・6 files）** ← 次の substrate。
-- **regex carrier（2）**: `regex-m-s` の `s///`-topic `$_` writeback・`regex-declarative-modifiers` の `:let`。
-- **並行 cell（5）**: `done-paren-stmt-modifier`/`gather-infinite-coroutine`/`react-whenever-last-next`/
-  `supply-on-demand-closing`/`supply-sync-infinite-emit`（別スレッド→caller slot 到達不可・§4-A cell 共有前提）。
+- **multi-frame accumulation (this section, 6 files)** ← the next substrate.
+- **regex carrier (2)**: `regex-m-s`'s `s///`-topic `$_` writeback, `regex-declarative-modifiers`'s `:let`.
+- **concurrent cell (5)**: `done-paren-stmt-modifier`/`gather-infinite-coroutine`/`react-whenever-last-next`/
+  `supply-on-demand-closing`/`supply-sync-infinite-emit` (another thread → caller slot unreachable; presupposes
+  §4-A cell sharing).
 
-### 6.6 ★第37セッション — multi-frame accumulation を解決（OFF 13→7）
+### 6.6 ★Session 37 — multi-frame accumulation solved (OFF 13→7)
 
-§6.4 の「forward accumulation 仮説」は **半分正しかった**。実トレース（`call_compiled_function_fast` の
-入口/出口 env・GETLOCAL/SETLOCAL `acc` slot）で判明した真因:
+§6.4's "forward accumulation hypothesis" was **half right**. The real cause, found via actual tracing
+(entry/exit env of `call_compiled_function_fast`, GETLOCAL/SETLOCAL of the `acc` slot):
 
-- canonical `via(); via()` で **top-level `$acc` は env のみならず local slot も持つ**（`code.locals=["acc"]`）。
-  `say $acc` は **GetLocal で slot を読む**。env は最終的に正しく 20 になるが slot が stale（10）。
-- **真因 = slow path と cached fast path の非対称**。slow `exec_call_func_op` は
-  `dispatch_func_call_inner` の後で `if env_dirty { reconcile_locals_from_env_at_site(code) }`
-  を呼び caller slot を env から再収束させる（この reconcile は `reverse_sync_disabled` トグルの**対象外**=
-  OFF でも動く）。だが **cached fast path（positional-light / light / 0-arg fast / OTF）と
-  closure 呼び出し（`exec_call_on_value_op`/`exec_call_on_code_var_op`）と wrap chain と
-  lexical-override は早期 return し、この reconcile を飛ばしていた**。よって 1 回目（cache cold=slow）は
-  reconcile されるが 2 回目（cache warm=fast）は飛ばされ、slot が 10 のまま固定。`apply_pending_rw_writeback`
-  は precise だが single-frame（nested callee の write は中間 `via` フレームで drain され 1 段深くで消える）
-  ので multi-frame には届かない。
-- **retention（§6.3）が canonical を直さなかった理由**: 壁は reverse-propagation ではなく
-  forward 側の **「cached fast-call site が env_dirty reconcile を持たない」非対称**だった。
+- In the canonical `via(); via()`, **top-level `$acc` has not only env but also a local slot** (`code.locals=["acc"]`).
+  `say $acc` **reads the slot via GetLocal**. env ends up correctly at 20, but the slot is stale (10).
+- **Real cause = asymmetry between the slow path and the cached fast path**. The slow `exec_call_func_op` calls
+  `if env_dirty { reconcile_locals_from_env_at_site(code) }` after `dispatch_func_call_inner`, re-converging the
+  caller slots from env (this reconcile is **not covered** by the `reverse_sync_disabled` toggle = it runs even
+  with OFF). But **the cached fast paths (positional-light / light / 0-arg fast / OTF), closure calls
+  (`exec_call_on_value_op`/`exec_call_on_code_var_op`), the wrap chain, and lexical-override return early and
+  skipped this reconcile**. So the 1st call (cache cold = slow) gets reconciled, but the 2nd (cache warm = fast)
+  skips it, freezing the slot at 10. `apply_pending_rw_writeback` is precise but single-frame (a nested callee's
+  write is drained at the intermediate `via` frame and vanishes one level too deep), so it does not reach
+  multi-frame.
+- **Why retention (§6.3) did not fix the canonical case**: the wall was not reverse propagation but the
+  forward-side **asymmetry "cached fast-call sites lack the env_dirty reconcile"**.
 
-**修正（PR #XXXX）**:
-1. ヘルパ `drain_and_reconcile_after_cached_call(code)`（`vm_env_helpers.rs`）=
-   `apply_pending_rw_writeback` + `if env_dirty { reconcile_locals_from_env_at_site }`。
-   slow path と byte-identical。env_dirty gate ＝ pure call（fib）は無コスト
-   （positional-light merge は captured-outer 書込時のみ env_dirty を立てる）。
-2. cached fast path 4 サイト（positional-light / light / 0-arg fast / OTF）を helper 化。
-3. closure 呼び出し（`exec_call_on_value_op`/`exec_call_on_code_var_op`）・wrap chain・lexical-override は
-   末尾で blanket `env_dirty=true` を立てる（callee の write を precise に追えない）ので
-   **無条件 reconcile**（その blanket dirtiness は ON で reverse pull が action する対象＝整合）。
-4. **carrier completeness（open-q#2 の rw-param 版）**: `lives-ok { f(@a, $x is raw) }` の rw writeback は
-   `apply_rw_bindings_to_env` で env を by-name 書込するが carrier set に未ログ→`writeback_carrier_writes` が
-   取りこぼし→`fully=true` で env_dirty が落ちる→slot stale。修正＝`call_compiled_function_named` の
-   rw-source 記録時に carrier アクティブなら `note_caller_env_write(source)` も呼ぶ。
+**Fix (PR #XXXX)**:
+1. Helper `drain_and_reconcile_after_cached_call(code)` (`vm_env_helpers.rs`) =
+   `apply_pending_rw_writeback` + `if env_dirty { reconcile_locals_from_env_at_site }`.
+   Byte-identical to the slow path. The env_dirty gate = pure calls (fib) pay nothing
+   (positional-light merge sets env_dirty only on captured-outer writes).
+2. Converted the 4 cached fast-path sites (positional-light / light / 0-arg fast / OTF) to the helper.
+3. Closure calls (`exec_call_on_value_op`/`exec_call_on_code_var_op`), the wrap chain, and lexical-override set a
+   blanket `env_dirty=true` at the end (the callee's writes cannot be tracked precisely), so they get an
+   **unconditional reconcile** (that blanket dirtiness is exactly what the reverse pull acts on with ON = consistent).
+4. **Carrier completeness (the rw-param version of open-q#2)**: the rw writeback of
+   `lives-ok { f(@a, $x is raw) }` writes env by name via `apply_rw_bindings_to_env` but is unlogged in the carrier
+   set → `writeback_carrier_writes` misses it → `fully=true` drops env_dirty → slot stale. Fix = when recording
+   rw-sources in `call_compiled_function_named`, also call `note_caller_env_write(source)` if a carrier is active.
 
-pin=`t/multi-frame-accumulation-coherence.t`（10・named/closure/positional/array/string/carrier-slurpy・ON=OFF=raku）。
-make test PASS（981 files/9587 tests）。OFF scan: **13→7**（残＝regex carrier 2 + 並行 cell 5＝既知の壁）。
+pin=`t/multi-frame-accumulation-coherence.t` (10: named/closure/positional/array/string/carrier-slurpy;
+ON=OFF=raku). make test PASS (981 files/9587 tests). OFF scan: **13→7** (remaining = regex carrier 2 +
+concurrent cell 5 = the known walls).
 
-**残 7 内訳（第37末）**:
-- **regex carrier（2）**: `regex-m-s`（`s///`-topic `$_`）・`regex-declarative-modifiers`（`:let`）。
-- **並行 cell（5）**: `done-paren-stmt-modifier`/`gather-infinite-coroutine`/`react-whenever-last-next`/
-  `supply-on-demand-closing`/`supply-sync-infinite-emit`（別スレッド→caller slot 到達不可・§4-A cell 共有前提）。
+**Breakdown of the remaining 7 (end of session 37)**:
+- **regex carrier (2)**: `regex-m-s` (`s///`-topic `$_`), `regex-declarative-modifiers` (`:let`).
+- **concurrent cell (5)**: `done-paren-stmt-modifier`/`gather-infinite-coroutine`/`react-whenever-last-next`/
+  `supply-on-demand-closing`/`supply-sync-infinite-emit` (another thread → caller slot unreachable; presupposes
+  §4-A cell sharing).
 
-### 6.7 ★第38セッション — regex carrier を解決（OFF 7→5・PR #3347）
+### 6.7 ★Session 38 — regex carrier solved (OFF 7→5; PR #3347)
 
-§6.6 の残 regex carrier 2 件を畳んだ。両者とも callee（substitution engine / declarative
-regex prefix）が caller lexical を `env` に**名前で**書き、VM の slot write-through を迂回していた。
+Folded the 2 remaining regex-carrier items from §6.6. In both, the callee (the substitution engine / the
+declarative regex prefix) wrote a caller lexical into `env` **by name**, bypassing the VM's slot write-through.
 
-- **bare `s///` の `$_` topic（`regex-m-s`）**: `write_subst_topic_checked`（`vm_string_regex_ops.rs`）が
-  modified topic を `env["_"]` に insert するだけで、`my $_` が `_` を compiled local slot に
-  していると slot が stale。修正＝同関数に `code` を渡し、env insert の後で
-  `update_local_if_exists(code, "_", &result)` で slot へ write-through ＋ `note_caller_env_write("_")`
-  で carrier/env_dirty を立てる。`$_` が `given`/`for` の source scalar を alias している
-  （`topic_source_var`）場合は、その source 名にも mirror（`$x ~~ s///` smartmatch path と対称）。
-- **`:let $x = ...` declarative modifier（`regex-declarative-modifiers`）**: declarative-regex prefix
-  handler（`runtime/regex/regex_match_public.rs`）が `:let` 値を `self.env` に直書き。match 成功時は
-  `restore_on_fail` を適用しないので値が永続するが、caller slot は未更新。修正＝match 成功時に
-  `restore_on_fail` のキー（＝`:let` 名）を現 env 値とともに `pending_local_updates`（+ carrier）へ
-  log → smartmatch site の `writeback_match_locals` が caller slot を reverse pull 抜きで再収束。
-  - **★注**: `t/regex-declarative-modifiers.t` test 4（`:let` 不成功 match 後の変数 restore で
-    `$a==1` を期待）は **raku 自身が `$a==5` を返す**＝`:let` の restore-on-overall-fail セマンティクスが
-    mutsu と Rakudo で乖離（dual-store とは無関係の別件）。pin test ではこの contested な値検査を外し、
-    match 結果（nok）のみ assert。
+- **Bare `s///`'s `$_` topic (`regex-m-s`)**: `write_subst_topic_checked` (`vm_string_regex_ops.rs`) only inserted
+  the modified topic into `env["_"]`, so when `my $_` has made `_` a compiled local slot, the slot goes stale.
+  Fix = pass `code` into the function and, after the env insert, write through to the slot via
+  `update_local_if_exists(code, "_", &result)` plus `note_caller_env_write("_")` to raise carrier/env_dirty.
+  When `$_` aliases the source scalar of a `given`/`for` (`topic_source_var`), also mirror to that source name
+  (symmetric with the `$x ~~ s///` smartmatch path).
+- **The `:let $x = ...` declarative modifier (`regex-declarative-modifiers`)**: the declarative-regex prefix
+  handler (`runtime/regex/regex_match_public.rs`) wrote `:let` values directly into `self.env`. On a successful
+  match it does not apply `restore_on_fail`, so the values persist, but the caller slots were never updated.
+  Fix = on match success, log the keys of `restore_on_fail` (= the `:let` names) together with their current env
+  values into `pending_local_updates` (+ carrier) → the smartmatch site's `writeback_match_locals` re-converges the
+  caller slots without a reverse pull.
+  - **★Note**: `t/regex-declarative-modifiers.t` test 4 (expecting `$a==1` after variable restore following an
+    unsuccessful `:let` match) — **raku itself returns `$a==5`** = the restore-on-overall-fail semantics of `:let`
+    diverge between mutsu and Rakudo (a separate matter, unrelated to the dual store). The pin test drops this
+    contested value check and asserts only the match result (nok).
 
-pin=`t/regex-carrier-writeback-coherence.t`（10・bare `s///`/`s:g///`/`$x ~~ s///`/`:let` 成功/`:let` 失敗・
-ON=OFF=raku）。make test PASS（984 files/9614 tests）。OFF scan: **7→5**。
+pin=`t/regex-carrier-writeback-coherence.t` (10: bare `s///`/`s:g///`/`$x ~~ s///`/`:let` success/`:let` failure;
+ON=OFF=raku). make test PASS (984 files/9614 tests). OFF scan: **7→5**.
 
-**残 5 内訳（第38末）— 全て並行 cell（§4-A cell 共有前提）**:
+**Breakdown of the remaining 5 (end of session 38) — all concurrent cell (presupposing §4-A cell sharing)**:
 `done-paren-stmt-modifier`/`gather-infinite-coroutine`/`react-whenever-last-next`/
-`supply-on-demand-closing`/`supply-sync-infinite-emit`。callee が別スレッドで走り、caller の
-local slot は別フレーム／別スタックにあるため write-through が物理的に届かない。唯一の解は
-captured outer を **shared cell（`Arc<Mutex<Value>>` 様）に昇格**し、両スレッドが同一 cell を
-参照する設計（§4-A）。これは single-frame write-through ファミリーとは別物の substrate 変更。
+`supply-on-demand-closing`/`supply-sync-infinite-emit`. The callee runs on another thread, and the caller's
+local slot lives in another frame / another stack, so a write-through physically cannot reach it. The only
+solution is the design that promotes captured outers to a **shared cell (`Arc<Mutex<Value>>`-like)** so both
+threads reference the same cell (§4-A). This is a substrate change distinct from the single-frame write-through
+family.
 
-次の substrate＝ 並行 cell 共有（§4-A）。single-frame / multi-frame / carrier の write-through 壁は
-これで全て消滅し、残るのはスレッド境界を跨ぐ cell 共有のみ。
+Next substrate = concurrent cell sharing (§4-A). The single-frame / multi-frame / carrier write-through walls are
+all gone with this; what remains is only cell sharing across thread boundaries.
 
-### 6.8 ★第38セッション後半 — 「並行 cell」は実は同期だった（OFF 5→0・PR #XXXX）
+### 6.8 ★Session 38 second half — the "concurrent cells" were actually synchronous (OFF 5→0; PR #XXXX)
 
-§6.6/§6.7 が「並行 cell（別スレッド→caller slot 到達不可・§4-A 前提）」と分類していた残 5 件は、
-**実測で全て同一 VM 上の同期実行**と判明した（reverse-sync ON が pull で直すのが動かぬ証拠＝
-別スレッド・別 env なら ON でも直らない）。`Supply.from-list` / `supply { emit }` の whenever
-callback も `gather` coroutine body も `&mut self` 上で compiled bytecode として走り、captured-outer
-caller lexical を `env` に名前で書く。よって single-frame write-through ファミリーと同じ機構で畳めた。
+The 5 remaining items that §6.6/§6.7 had classified as "concurrent cell (another thread → caller slot unreachable;
+presupposes §4-A)" turned out, **by actual measurement, to all be synchronous execution on the same VM** (the
+undeniable evidence being that reverse-sync ON fixes them via the pull = if they were another thread / another env,
+ON would not fix them either). The whenever callbacks of `Supply.from-list` / `supply { emit }` and `gather`
+coroutine bodies all run as compiled bytecode on `&mut self` and write captured-outer caller lexicals into `env`
+by name. So they could be folded with the same mechanism as the single-frame write-through family.
 
-- **react/whenever（4 件: `done-paren-stmt-modifier` / `react-whenever-last-next` /
-  `supply-on-demand-closing` / `supply-sync-infinite-emit`）**: `exec_react_scope_op`
-  （`vm_register_ops.rs`）の event-loop 後 reconcile が `sync_locals_from_env`（toggle 対象＝OFF で no-op）
-  だった。これを **toggle 非依存の `reconcile_locals_from_env_at_site(code)`** に差し替え（ON で byte-identical・
-  同一 HashSlotRef/`!attr` skip）。1 行で 4 件解決。
-- **gather coroutine（1 件: `gather-infinite-coroutine` の `.first` captured-`$c`）**: `try_lazy_gather_first`
-  （`vm_native_first.rs`）の incremental-pull ループで、matcher closure（`* >= 3`）が `exec` 経由で
-  `self.current_code` を**自フレームに上書き**して戻さない。`force_lazy_list_vm_n` はこの `current_code` を
-  「captured-outer write を reconcile する caller フレーム」として捕捉する（`reconcile_caller_after_lazy_force`）ので、
-  2 回目以降の force が matcher のフレームを reconcile し caller の `$c` slot が OFF で stale（c=1 のまま）。
-  ON では post-method の barrier pull がマスクしていた。修正＝ループ入口で caller `current_code` を pin し
-  **各 force の直前に restore**。`.head(n)` 系の captured-`$c` は ON でも 0（別件の gather-head 副作用
-  可視性の制約・dual-store 無関係・test も未アサート）。
+- **react/whenever (4 items: `done-paren-stmt-modifier` / `react-whenever-last-next` /
+  `supply-on-demand-closing` / `supply-sync-infinite-emit`)**: the post-event-loop reconcile of
+  `exec_react_scope_op` (`vm_register_ops.rs`) was `sync_locals_from_env` (toggle-covered = a no-op with OFF).
+  Replaced it with the **toggle-independent `reconcile_locals_from_env_at_site(code)`** (byte-identical with ON;
+  same HashSlotRef/`!attr` skips). One line resolved 4 items.
+- **gather coroutine (1 item: `gather-infinite-coroutine`'s `.first` captured-`$c`)**: in the incremental-pull loop
+  of `try_lazy_gather_first` (`vm_native_first.rs`), the matcher closure (`* >= 3`) **overwrites
+  `self.current_code` with its own frame** via `exec` and never restores it. `force_lazy_list_vm_n` captures this
+  `current_code` as "the caller frame in which to reconcile captured-outer writes"
+  (`reconcile_caller_after_lazy_force`), so the 2nd and later forces reconcile the matcher's frame and the caller's
+  `$c` slot goes stale with OFF (stuck at c=1). With ON, the post-method barrier pull was masking it. Fix = pin the
+  caller `current_code` at loop entry and **restore it right before each force**. The captured-`$c` of the
+  `.head(n)` family is 0 even with ON (a separate constraint on gather-head side-effect visibility; unrelated to
+  the dual store; the test does not assert it either).
 
-pin=`t/concurrent-cell-writeback-coherence.t`（8・react `++`/`+=`/`done()` 境界・supply emit・gather
-`.first` captured accumulation・ON=OFF=raku）。OFF scan（全 t/）: 残失敗は #3347 が直す regex 2 件のみ＝
-**両 PR 合算で OFF surface 7→0**。
+pin=`t/concurrent-cell-writeback-coherence.t` (8: react `++`/`+=`/`done()` boundary, supply emit, gather `.first`
+captured accumulation; ON=OFF=raku). OFF scan (all t/): the remaining failures are only the 2 regex items fixed
+by #3347 = **the two PRs together take the OFF surface 7→0**.
 
-**★結論: locals↔env coherence の write-through グラインドは完了**。第27〜38セッションで single-frame /
-multi-frame / carrier / 並行(=実は同期) の全カテゴリを `pending_rw_writeback_sources` /
-`reconcile_locals_from_env_at_site` / carrier ログの 3 機構へ畳み、OFF（`MUTSU_NO_REVERSE_SYNC=1`）で
-全 t/ が pass。`sync_locals_from_env`（reverse pull）は **もはや correctness に必要な箇所が無い**＝
-Stage 3（reverse-sync デフォルト無効化→機構削除）が初めて射程に入った。第32セッションで 65 ファイル
-回帰した壁は、本グラインドで全て write-through 化された。次の大物＝Stage 3 再挑戦
-（`sync_locals_from_env` デフォルト無効化を全 t/ + roast CI で検証）。
+**★Conclusion: the locals↔env coherence write-through grind is complete.** Sessions 27–38 folded all categories —
+single-frame / multi-frame / carrier / concurrent (= actually synchronous) — into the 3 mechanisms
+`pending_rw_writeback_sources` / `reconcile_locals_from_env_at_site` / carrier logging, and with OFF
+(`MUTSU_NO_REVERSE_SYNC=1`) all t/ pass. `sync_locals_from_env` (the reverse pull) **no longer has any place where
+it is needed for correctness** = Stage 3 (disabling reverse-sync by default → deleting the mechanism) is within
+range for the first time. The wall of 65 files that regressed in session 32 has been fully write-through-ified by
+this grind. The next big item = the Stage 3 retry (verify the default disabling of `sync_locals_from_env` across
+all t/ + roast CI).
 
-## 7. Stage 3 — reverse-sync デフォルト無効化（第38セッション末・進行中）
+## 7. Stage 3 — disabling reverse-sync by default (end of session 38; in progress)
 
-`reverse_sync_disabled()`（`vm_stats.rs`）の判定を反転＝**reverse pull はデフォルト OFF**。旧 escape hatch
-`MUTSU_NO_REVERSE_SYNC` は撤去し、opt-IN `MUTSU_REVERSE_SYNC=1`（旧挙動の再有効化＝A/B 診断用）に置換。
+Invert the verdict of `reverse_sync_disabled()` (`vm_stats.rs`) = **the reverse pull is OFF by default**. The old
+escape hatch `MUTSU_NO_REVERSE_SYNC` is removed, replaced by the opt-IN `MUTSU_REVERSE_SYNC=1` (re-enabling the old
+behavior = for A/B diagnostics).
 
-- **make test（全 t/）= PASS**（985 files / 9622 tests・OFF scan が clean だった通り）。
-- **★roast 側に t/ scan 非代表の OFF 依存が残存**（ローカル sample で判明）。t/ は exercise しない
-  rw-aliasing / coroutine-rw / lvalue-method-rw を roast が突く:
+- **make test (all t/) = PASS** (985 files / 9622 tests, as the clean OFF scan predicted).
+- **★OFF dependences unrepresented by the t/ scan remain on the roast side** (found via a local sample). roast
+  pokes at rw-aliasing / coroutine-rw / lvalue-method-rw that t/ does not exercise:
   - `roast/S04-statements/gather.t` test 36: `my $l = gather { take-rw my $ = 1 }; lives-ok { $l.AT-POS(0) = 42 }`
-    → **closure（`lives-ok {}`）内の take-rw gather 要素への rw 代入が OFF で外に伝播しない**。bare block
-    `{ }` / bare statement では伝播する（frame 跨ぎが壁）。coroutine が rw 取った匿名コンテナが
-    shared cell でなく coroutine env 経由＝reverse pull 前提。
-  - `roast/S04-blocks-and-statements/pointy-rw.t` test 8: `$pair.values should be rw (2)`＝lvalue-method
-    rw alias の frame 跨ぎ。
-- **方針（ユーザー選択: full Stage 3・CI を net に fix-forward）**: draft PR #3349。local `make roast`
-  で roast-only OFF 依存の完全リストを取得（**14 件**・flaky 除外後）→各々 toggle 非依存 reconcile で fix-forward。
+    → **an rw assignment to a take-rw gather element inside a closure (`lives-ok {}`) does not propagate outward
+    with OFF**. It propagates with a bare block `{ }` / a bare statement (the frame crossing is the wall). The
+    anonymous container the coroutine took rw is not a shared cell but goes via the coroutine env = reverse-pull
+    presupposing.
+  - `roast/S04-blocks-and-statements/pointy-rw.t` test 8: `$pair.values should be rw (2)` = the frame crossing of
+    an lvalue-method rw alias.
+- **Policy (user's choice: full Stage 3, fix-forward with CI as the net)**: draft PR #3349. Obtain the complete
+  list of roast-only OFF dependences via a local `make roast` (**14 items** after excluding flaky ones) → fix each
+  forward with a toggle-independent reconcile.
 
-### 7.1 roast OFF 依存 14 件の fix-forward（13/14 解決）
+### 7.1 Fix-forward of the 14 roast OFF dependences (13/14 solved)
 
-完全リスト（OFF=fail ON=pass を `MUTSU_REVERSE_SYNC=1` で確認・flaky の set/baghash/junctions/IO-Socket-Async 除外）:
+Complete list (OFF=fail ON=pass confirmed with `MUTSU_REVERSE_SYNC=1`; the flaky set/baghash/junctions/
+IO-Socket-Async excluded):
 
-| # | file | 真因 | 修正 |
+| # | file | root cause | fix |
 |---|------|------|------|
-| 1-9 | pointy-rw, gather(take-rw), S14-roles/{anonymous,parameterized-mixin,rw}, S12-meta/primitives, S04-terminator, S02-symbolic-deref, S32-hash/kv | **block-taking Test 関数**（`lives-ok{}`/`subtest`/`throws-like`）が `__mutsu_test_callsite_line` named arg のため `exec_exec_call_pairs_op` 経由→block を interpreter で実行→`is rw` for-alias 等を env に名前書き（carrier 未ログ）。pairs op の carrier fallback が env_dirty=true だけで reconcile せず | `exec_exec_call_pairs_op`（無条件）+ `exec_exec_call_op` の `!fully` 枝に `reconcile_locals_from_env_at_site` |
-| 10-11 | S14-roles/{mixin-6e,submethods-6e} | `$obj does/but Role` の `submethod BUILD/TWEAK` が captured outer を名前書き。`exec_does_op`/`exec_does_var_op` は **toggle-gated** `sync_locals_from_env`、`exec_but_mixin_op` は **sync 皆無** | does×2 を toggle 非依存 reconcile に差替、but に reconcile 追加（`ButMixin` op に `code` 渡す） |
-| 12 | S32-str/substr-rw | `$r := substr-rw($s); $r = v` の **Proxy STORE** が referent `$s` を名前書き | scalar-assign の Proxy STORE 3 サイト（`assign_proxy_lvalue` 後）に reconcile |
-| 13 | S03-operators/notandthen | `andthen`/`notandthen` の `OpCode::CallDefined` が **user `method defined`** を dispatch→captured `$calls++` | CallDefined の user-method 枝のみ reconcile（native check は pure 維持） |
-| **14** | **S32-str/val.t（解決済・第39セッション）** | **内側 `for (...) -> $string, \value` の multi-param 復元が env のみで local slot を復元せず**。当初「subtest closure の read-coherence 壁」と診断したが、最小化すると closure 不在の `for ... -> \value` 本体での bare read 自体が既に stale（`outer-read: 4_2 => -42`）＝診断は誤り。真因＝内側 for の sigilless `\value` 多パラメタが**外側 `\value` と同名＝同一 local slot を共有**し、ループ末の `saved_multi_params` 復元が env binding だけ戻して local slot を最終イテレーション値（-42）のまま残す→reverse pull OFF で次の外側イテレーションが element list を stale な `value` で再評価 | 多パラメタ復元ループ（`exec_for_loop_body`, vm_control_ops.rs:1218）に **local slot への write-through** を追加（`find_local_slot(code, name)` があれば `locals[slot] = v`）。ON で byte-identical。pin=`t/multiframe-sigilless-for-rebind-coherence.t`（4） |
+| 1-9 | pointy-rw, gather(take-rw), S14-roles/{anonymous,parameterized-mixin,rw}, S12-meta/primitives, S04-terminator, S02-symbolic-deref, S32-hash/kv | **Block-taking Test functions** (`lives-ok{}`/`subtest`/`throws-like`) go through `exec_exec_call_pairs_op` because of the `__mutsu_test_callsite_line` named arg → the block runs in the interpreter → `is rw` for-aliases etc. are written to env by name (unlogged in the carrier). The pairs op's carrier fallback only set env_dirty=true without reconciling | `exec_exec_call_pairs_op` (unconditional) + the `!fully` branch of `exec_exec_call_op` get `reconcile_locals_from_env_at_site` |
+| 10-11 | S14-roles/{mixin-6e,submethods-6e} | The `submethod BUILD/TWEAK` of `$obj does/but Role` writes captured outers by name. `exec_does_op`/`exec_does_var_op` used the **toggle-gated** `sync_locals_from_env`; `exec_but_mixin_op` had **no sync at all** | Replaced the two does ops with the toggle-independent reconcile; added a reconcile to but (passing `code` to the `ButMixin` op) |
+| 12 | S32-str/substr-rw | The **Proxy STORE** of `$r := substr-rw($s); $r = v` writes the referent `$s` by name | Added a reconcile to the 3 Proxy STORE sites of scalar-assign (after `assign_proxy_lvalue`) |
+| 13 | S03-operators/notandthen | `andthen`/`notandthen`'s `OpCode::CallDefined` dispatches a **user `method defined`** → captured `$calls++` | Reconcile only in CallDefined's user-method branch (the native check stays pure) |
+| **14** | **S32-str/val.t (solved; session 39)** | **The multi-param restore of the inner `for (...) -> $string, \value` restored only env, not the local slot.** Initially diagnosed as "the subtest-closure read-coherence wall", but minimization showed a bare read in the inner `for ... -> \value` body, with no closure present, was already stale (`outer-read: 4_2 => -42`) = the diagnosis was wrong. Real cause = the inner for's sigilless `\value` multi-param **shares the same name = the same local slot as the outer `\value`**, and the loop-end `saved_multi_params` restore only restored the env binding, leaving the local slot at the final iteration value (-42) → with the reverse pull OFF, the next outer iteration re-evaluates the element list with a stale `value` | Added a **write-through to the local slot** to the multi-param restore loop (`exec_for_loop_body`, vm_control_ops.rs:1218) (if `find_local_slot(code, name)` exists, `locals[slot] = v`). Byte-identical with ON. pin=`t/multiframe-sigilless-for-rebind-coherence.t` (4) |
 
-| **15** | **S03-junctions/autothreading.t（解決済・第39セッション・CI surface）** | **invocant junction の method autothread が captured-outer / `our` 変異を最後の eigenstate しか伝播しない**。`$junc.a`（`method a { $cnt++ }`）で各 eigenstate は env に正しく累積する（threaded 戻り値 `any(0,1,0)` が証明）が、per-call の pending writeback は**最後の eigenstate の source しか運ばない**→eigenstate が**異なる変数**を書くと（earlier=$cnt1・last=$cnt2）earlier の $cnt1 が caller local slot に届かず stale（0）。当初「method-invocant autothread `our`-var 蓄積壁」（第34節 deferred）と認識されローカル survey で「junctions flaky」と誤分類 | CallMethod / CallMethodMut **両** junction loop（vm_call_method_ops.rs / vm_call_method_mut_ops.rs）は normal post-dispatch reconcile の前に early-return するため、threading 後に `reconcile_locals_from_env_at_site(code)` を 1 回追加（env は全 eigenstate の累積値を保持済）。ON で byte-identical。pin=`t/junction-invocant-autothread-writeback-coherence.t`（6） |
+| **15** | **S03-junctions/autothreading.t (solved; session 39; CI surface)** | **Method autothreading over an invocant junction propagates captured-outer / `our` mutations only for the last eigenstate.** With `$junc.a` (`method a { $cnt++ }`), each eigenstate accumulates correctly in env (the threaded return value `any(0,1,0)` proves it), but the per-call pending writeback **carries only the last eigenstate's source** → when eigenstates write **different variables** (earlier=$cnt1, last=$cnt2), the earlier $cnt1 never reaches the caller local slot and stays stale (0). Previously recognized as the "method-invocant autothread `our`-var accumulation wall" (§34, deferred) and misclassified as "junctions flaky" in the local survey | Both junction loops of CallMethod / CallMethodMut (vm_call_method_ops.rs / vm_call_method_mut_ops.rs) return early before the normal post-dispatch reconcile, so added one `reconcile_locals_from_env_at_site(code)` after threading (env already holds the accumulated values of all eigenstates). Byte-identical with ON. pin=`t/junction-invocant-autothread-writeback-coherence.t` (6) |
 
-| **15.5** | **val.t 修正の過剰適用回帰（解決済・第39セッション・CI surface）** | #14 の local-slot write-through が `multi_param_names`（sigil 付き名も含む）全体に効き、**全 `for ... -> $a, $b` ループ**で実行→sigil 付き param の slot が保持していた **live rw/element alias を env-only 復元値で上書き**→文字列/ループ破損（`expected bc got c`/`expected abecd got abec`）。並列 CI ログが読めず（gh log 切り詰め）、**ローカル release `make roast` の Test Summary で特定** | write-through を **sigilless 名のみ**（`!name.starts_with(['$','@','%','&'])`）に制限。val.t バグは sigilless `\value` 固有なので保たれ、sigil 付きは（既に coherent な）env-only 復元へ戻る |
-| **16** | **S32-io/IO-Socket-Async.t（解決済・第39セッション）test 40 'listen tap is a Tap'** | `my $tap = do whenever $sup {…}` が tap を `env[target_var]` に直接書く（`run_whenever_with_value` 4 サイト）が caller local slot 未更新→**同 react block 内の後続 read**（`isa-ok $tap, Tap`）が stale slot（`do` block 自身の結果＝Supply）を読む。#3348 の react-scope-end reconcile は block 内 read に間に合わない。これも survey で「IO-Socket-Async flaky」と誤分類された決定論 OFF 依存 | `exec_whenever_scope_op`（env_dirty set 済）に `reconcile_locals_from_env_at_site(code)` 追加。ON で byte-identical。pin=`t/react-do-whenever-tap-coherence.t`（2） |
+| **15.5** | **Over-application regression of the val.t fix (solved; session 39; CI surface)** | #14's local-slot write-through applied to all of `multi_param_names` (including sigiled names) and ran for **every `for ... -> $a, $b` loop** → the slot of a sigiled param, which held a **live rw/element alias, got overwritten by the env-only restore value** → string/loop corruption (`expected bc got c`/`expected abecd got abec`). The parallel CI logs were unreadable (gh log truncation); **identified via the Test Summary of a local release `make roast`** | Restricted the write-through to **sigilless names only** (`!name.starts_with(['$','@','%','&'])`). The val.t bug is specific to the sigilless `\value`, so it is preserved; sigiled params go back to the (already coherent) env-only restore |
+| **16** | **S32-io/IO-Socket-Async.t (solved; session 39) test 40 'listen tap is a Tap'** | `my $tap = do whenever $sup {…}` writes the tap directly to `env[target_var]` (4 sites in `run_whenever_with_value`) but never updates the caller local slot → **a subsequent read within the same react block** (`isa-ok $tap, Tap`) reads the stale slot (the `do` block's own result = a Supply). #3348's react-scope-end reconcile is too late for reads inside the block. This too was a deterministic OFF dependence misclassified as "IO-Socket-Async flaky" in the survey | Added `reconcile_locals_from_env_at_site(code)` to `exec_whenever_scope_op` (env_dirty already set). Byte-identical with ON. pin=`t/react-do-whenever-tap-coherence.t` (2) |
 
-make test PASS（988 files / 9634 tests）。**Stage 3 の roast OFF 依存 16/16 全解決**（CI が val.t commit 後に
-14 survey から漏れた autothreading.t を、その後ローカル release roast が IO-Socket-Async.t を surface＝junctions/
-IO-Socket-Async は flaky でなく実依存だった。教訓: 並列 CI ログは gh で切り詰められ失敗特定不能→**ローカル release
-`make roast` の末尾 Test Summary が権威的**。set/baghash/mix は OFF 全 PASS・sethash.t は非 whitelist plan-abort でスコープ外）。
-**val.t は当初 multi-frame
-read-coherence 壁と思われたが、実態は #13 までと同じ単一パターン（interpreter-run/loop path が caller lexical
-を共有 slot に書くが復元/reconcile で slot を戻さない）の一発現**で、多パラメタ復元の env-only 復元に local
-write-through を足すだけで解けた（read-direction の独立 substrate ではなかった）。**Stage 3（reverse-sync
-デフォルト無効化）は全 t/ + roast OFF 依存クリアで merge 可能。**
+make test PASS (988 files / 9634 tests). **All 16/16 Stage 3 roast OFF dependences solved** (after the val.t
+commit, CI surfaced autothreading.t, which had slipped out of the 14-item survey; a subsequent local release roast
+surfaced IO-Socket-Async.t = junctions/IO-Socket-Async were not flaky but real dependences. Lesson: parallel CI
+logs get truncated by gh and failures cannot be pinpointed → **the trailing Test Summary of a local release
+`make roast` is authoritative**. set/baghash/mix fully PASS with OFF; sethash.t is a non-whitelisted plan-abort,
+out of scope). **val.t was initially thought to be a multi-frame read-coherence wall, but in reality it was one
+manifestation of the same single pattern as #1–13 (an interpreter-run/loop path writes a caller lexical to a shared
+slot but the restore/reconcile does not restore the slot)**, and it was solved just by adding a local write-through
+to the multi-param env-only restore (it was not an independent read-direction substrate). **Stage 3 (disabling
+reverse-sync by default) is mergeable with all t/ + roast OFF dependences cleared.**
 
-**教訓**: Stage 3 で surface した 14 件は t/ scan 非代表だったが、**13 件は単一パターン**（interpreter-run
-op が caller lexical を名前書きするが call-site で reconcile しない）の異なる発現で、各 op site に
-`reconcile_locals_from_env_at_site(code)` を足すだけで解けた（ON で byte-identical）。残り val.t だけが
-read-direction の multi-frame retention で質的に異なる。
+**Lesson**: the 14 items surfaced by Stage 3 were unrepresented by the t/ scan, but **13 of them were different
+manifestations of a single pattern** (an interpreter-run op writes caller lexicals by name but never reconciles at
+the call site), each solved just by adding `reconcile_locals_from_env_at_site(code)` at the op site
+(byte-identical with ON). Only the remaining val.t was qualitatively different, as read-direction multi-frame
+retention.
 
-### 7.2 Stage 3 機構削除 — 旧 reverse pull `sync_locals_from_env` の撤去（第40セッション）
+### 7.2 Stage 3 mechanism deletion — removal of the old reverse pull `sync_locals_from_env` (session 40)
 
-§7.1 で OFF 依存 16/16 が全解決し、`MUTSU_REVERSE_SYNC` のデフォルト無効化（#3349）が full roast CI を
-green で通過。これで旧 reverse pull は **default（＝唯一の shipping）build で dead code**（`reverse_sync_disabled()`
-が常に true → `sync_locals_from_env` が即 return）になった。本セッションで実際に削除:
+With all 16/16 OFF dependences solved in §7.1, the default disabling of `MUTSU_REVERSE_SYNC` (#3349) passed the
+full roast CI green. The old reverse pull thereby became **dead code in the default (= only shipping) build**
+(`reverse_sync_disabled()` always true → `sync_locals_from_env` returns immediately). Actually deleted in this
+session:
 
-- **削除した機構**:
-  - `sync_locals_from_env`（env→locals の blanket reverse pull・`vm_env_helpers.rs`）本体と全呼び出しサイト
-    （`ensure_locals_synced` 内・`vm_closure_dispatch.rs:633` の closure 末・`vm_comparison_ops.rs:1246` の
-    smartmatch 前）。
-  - `reverse_sync_disabled()` と opt-in `MUTSU_REVERSE_SYNC` の escape hatch（`vm_stats.rs`）。A/B 診断は役目終了。
-  - orphan 化した reverse-sync stats: `record_locals_pull` / `record_locals_pull_effective` / `record_stale_slot`、
-    statics `LOCALS_PULL{,_EFFECTIVE}` / `LOCALS_PULL_STALE_SLOTS` / `stale_slot_by_name`、`dump()` の
-    reverse-sync 行と stale-slot ヒストグラム。
-- **挙動同一性**: default build は既に reverse pull を no-op していた（#3349 後）ので、削除は runtime 挙動を変えない。
-  `ensure_locals_synced` は「pull → flag clear」から「flag clear のみ」へ縮退（pull は元々 no-op）。
-  smartmatch 前の `if env_dirty { sync; clear }` は `env_dirty = false` のみへ縮退。
-- **残した機構（＝新 load-bearing）**: `env_dirty` フラグは**残す**。`reconcile_locals_from_env_at_site` /
-  `drain_and_reconcile_after_cached_call` の `if env_dirty { reconcile }` ゲートとして機能し、pure call
-  （fib 等）で O(locals) ループを回避する perf 最適化でもある（reverse pull の代替ではなく、precise reconcile の
-  ゲート）。`apply_pending_rw_writeback` / carrier ログ / `note_caller_env_write` も全て継続。
-- make test PASS（988 files / 9634 tests・count 不変）。diff = 4 files / +36 −191。
-- **次の候補**: scattered な rationale コメント（~18 files の「without the reverse `sync_locals_from_env` pull」）は
-  歴史的に正確（pull は今や存在しない）なので focus 維持のため未編集。今後 `env_dirty` 自体の単純化（`saved_env_dirty`
-  の frame 保存が本当に必要か・deep-copy 経路の整理）は別 slice で評価。
+- **Deleted mechanisms**:
+  - The body of `sync_locals_from_env` (the blanket env→locals reverse pull, `vm_env_helpers.rs`) and all its call
+    sites (inside `ensure_locals_synced`; the closure tail at `vm_closure_dispatch.rs:633`; before smartmatch at
+    `vm_comparison_ops.rs:1246`).
+  - `reverse_sync_disabled()` and the opt-in `MUTSU_REVERSE_SYNC` escape hatch (`vm_stats.rs`). The A/B diagnostic
+    has served its purpose.
+  - Orphaned reverse-sync stats: `record_locals_pull` / `record_locals_pull_effective` / `record_stale_slot`, the
+    statics `LOCALS_PULL{,_EFFECTIVE}` / `LOCALS_PULL_STALE_SLOTS` / `stale_slot_by_name`, and `dump()`'s
+    reverse-sync lines and stale-slot histogram.
+- **Behavioral identity**: the default build was already no-op'ing the reverse pull (after #3349), so the deletion
+  does not change runtime behavior. `ensure_locals_synced` shrinks from "pull → flag clear" to "flag clear only"
+  (the pull was already a no-op). The pre-smartmatch `if env_dirty { sync; clear }` shrinks to just
+  `env_dirty = false`.
+- **Kept mechanisms (= the new load-bearing set)**: the `env_dirty` flag **stays**. It functions as the
+  `if env_dirty { reconcile }` gate of `reconcile_locals_from_env_at_site` /
+  `drain_and_reconcile_after_cached_call`, and is also a perf optimization avoiding the O(locals) loop on pure
+  calls (fib etc.) (not a replacement for the reverse pull, but the gate of the precise reconcile).
+  `apply_pending_rw_writeback` / carrier logging / `note_caller_env_write` all continue as well.
+- make test PASS (988 files / 9634 tests; count unchanged). diff = 4 files / +36 −191.
+- **Next candidates**: the scattered rationale comments (~18 files saying "without the reverse
+  `sync_locals_from_env` pull") are historically accurate (the pull no longer exists), so they were left unedited
+  to keep focus. Simplifying `env_dirty` itself (whether the `saved_env_dirty` frame save is really needed;
+  tidying the deep-copy paths) will be evaluated as a separate slice.
 
-### 7.3 `env_dirty` 物理削除の壁 — multi-frame accumulation（第40セッション・実証＆revert）
+### 7.3 The wall of physically deleting `env_dirty` — multi-frame accumulation (session 40; demonstrated & reverted)
 
-§7.2 で reverse pull を消した後、`env_dirty` 自体の削除を試み、**substrate 待ちと確定**した。
+After removing the reverse pull in §7.2, attempted the deletion of `env_dirty` itself, and **confirmed it is
+substrate-blocked**.
 
-- **`env_dirty` の現在の役割**: もはや correctness 機構ではなく、precise reconcile
-  （`reconcile_locals_from_env_at_site` / `drain_and_reconcile_after_cached_call`）の `if env_dirty { reconcile }`
-  ゲート＝pure call（fib）で O(locals) ループを回避する**安価な perf 最適化**に降格している。
-- **実証した壁**: `drain_and_reconcile_after_cached_call` の blanket reconcile を外すと
-  `t/multi-frame-accumulation-coherence.t` の 4 subtest が壊れる（`via(); via()` の cross-call 累積）。
-  この blanket reconcile が multi-frame accumulation を支える**唯一の機構**で、precise な single-frame
-  `apply_pending_rw_writeback` では届かない。
-- **retention 方式の失敗**: source を現フレームの local でないとき親フレームの drain へ持ち越す（re-push）retention を
-  `apply_pending_rw_writeback` に実装したが、**canonical を直せず**（実 trace で確認）。真因＝retention は**消費キュー**で
-  drain 順序に脆弱: 2 回目の `via()`（cached fast path）で、bump-outer の drain が `call_frames=0`・`code=via`（acc local 無し）
-  という中間点で走り、owner（top・acc local 有り）に到達する**前に source を drop**する。blanket reconcile は env を毎回
-  読んで該当 slot を直す**冪等な per-site pull**なので、この drain 順序問題が無く堅牢。retention（実験）は revert 済。
-  - §6.3 の「retention は canonical を直さない」を再確認した形（§6.6 の cached-path 修正後も同じ壁）。
-- **根本と次の一手**: 置き場が 2 つある限り「env を名前書きした→slot が stale かも」の目印は何らかの形で必要。
-  `env_dirty` を真に消すには **env を locals の派生ビュー化＝単一ストア化**が要り、それは **env↔locals が
-  同一コンテナ cell を共有する**こと（本書 §4-A outer cell 共有・`docs/container-identity.md` Phase 2 の延長・
-  Sub-slice 1b）が前提。∴ `env_dirty` 削除は単一の substrate（コンテナ cell 共有）にブロックされており、
-  「あと少しの掃除」ではなく substrate 着手が律速（PLAN.md §1-A / §2-C / §2-E に再編）。
+- **`env_dirty`'s current role**: no longer a correctness mechanism; it has been demoted to the
+  `if env_dirty { reconcile }` gate of the precise reconcile
+  (`reconcile_locals_from_env_at_site` / `drain_and_reconcile_after_cached_call`) = a **cheap perf optimization**
+  avoiding the O(locals) loop on pure calls (fib).
+- **The demonstrated wall**: removing the blanket reconcile from `drain_and_reconcile_after_cached_call` breaks
+  4 subtests of `t/multi-frame-accumulation-coherence.t` (the cross-call accumulation of `via(); via()`).
+  This blanket reconcile is **the only mechanism** holding up multi-frame accumulation; the precise single-frame
+  `apply_pending_rw_writeback` cannot reach it.
+- **Failure of the retention approach**: implemented retention in `apply_pending_rw_writeback` that carries a
+  source over to the parent frame's drain (re-push) when it is not a local of the current frame — but **it could
+  not fix the canonical case** (confirmed by actual tracing). Root cause = retention is a **consumption queue**,
+  fragile to drain order: on the 2nd `via()` (cached fast path), bump-outer's drain runs at an intermediate point
+  with `call_frames=0`, `code=via` (no acc local), and **drops the source before** reaching the owner (top; has
+  the acc local). The blanket reconcile is an **idempotent per-site pull** that reads env each time and fixes the
+  relevant slots, so it has no such drain-order problem and is robust. The retention (experiment) is reverted.
+  - This re-confirms §6.3's "retention does not fix the canonical case" (the same wall even after §6.6's
+    cached-path fix).
+- **The root, and the next move**: as long as there are 2 places to store, some form of the marker
+  "env was written by name → the slot may be stale" is necessary. Truly deleting `env_dirty` requires **making env
+  a derived view of locals = single-store-ification**, which presupposes **env↔locals sharing the same container
+  cell** (this document's §4-A outer cell sharing; an extension of `docs/container-identity.md` Phase 2;
+  Sub-slice 1b). ∴ the `env_dirty` deletion is blocked on a single substrate (container cell sharing); it is not
+  "a bit more cleanup" — starting the substrate is the rate-limiting step (reorganized into PLAN.md §1-A / §2-C /
+  §2-E).

--- a/docs/hashdata-migration-plan.md
+++ b/docs/hashdata-migration-plan.md
@@ -1,4 +1,4 @@
-# `Value::Hash` → `Arc<HashData>` migration (stable-container-ID, PLAN Q2 本筋)
+# `Value::Hash` → `Arc<HashData>` migration (stable-container-ID, PLAN Q2 mainline)
 
 > Goal: kill the `Arc::as_ptr`-keyed side tables (`hash_type_metadata`,
 > `register_hash_original_keys`, …) — the root of the intermittent typed-hash /

--- a/docs/is-rw-shared-cell-plan.md
+++ b/docs/is-rw-shared-cell-plan.md
@@ -11,7 +11,7 @@
 > `docs/container-identity.md` and the memory `phase2-element-containers-progress`.
 >
 > ⚠️ **High-risk: touches the hot call path.** The PLAN flags this explicitly
-> ("hot な call path 全体に触れる高リスク改修"). Gate the change so the common
+> ("a high-risk change touching the entire hot call path"). Gate the change so the common
 > (non-rw) path is byte-identical and zero-cost. Lean on CI's release roast.
 
 ## Target tests (definition of done)

--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -460,7 +460,7 @@ colliding, and (b) every remaining leaf writeback carries a compile-time slot
 fatal, so **§1.3 is the load-bearing prerequisite** — it must come before, or fused
 with, the default flip. The per-variable opcode leaf slices (S1–S9) are done; the
 remaining leaf sites are multi-var / runtime-derived and do not reduce class-1
-breakage. See ANALYSIS.md §1.4 調査メモ.
+breakage. See the ANALYSIS.md §1.4 investigation memo.
 
 ## §1.4 shadow-slot activation, gated (2026-07-03, branch `refactor/lexical-scope-1.4-shadow`)
 
@@ -615,7 +615,7 @@ done). Each remaining genuine regression is one of:
   `write_back_hyper_target_var` (`find_local_slot`/`locals_set_by_name` by name);
   needs a baked `target_slot` on the hyper opcode. Same shape as above.
 - **`my @a := EVAL "my $t @"`** (`native-str.t` #8): `:=` bind + EVAL carrier —
-  ANALYSIS §1.4 追記 case (3), genuinely hard (EVAL is a separate scope).
+  ANALYSIS §1.4 addendum case (3), genuinely hard (EVAL is a separate scope).
 - **class-1 / §1.3 (roast:0's sibling half):** `hash.t`, `Channel.t`, `wrap.t`
   (closure captures the wrong-slot lexical), `reverse.t` (`@a`/`$b`/`.=` aggregate
   coherence) — the name-keyed env can't hold two live bindings.

--- a/docs/nanbox-3b1-step-b-design.md
+++ b/docs/nanbox-3b1-step-b-design.md
@@ -48,7 +48,7 @@ because several variants share a pointee type (`Str`/`Regex` are both
 must reconstruct smart pointers by value. The flip therefore uses the **guard
 types** (`ArcRef<'a,T>`/`GcRef<'a,T>`: `ManuallyDrop` reconstructions that
 `Deref` without touching refcounts) that the wall kept as the documented exit
-(wall doc §2, ADR-0005 §2.1 "両出口"). Call sites are already deref-compatible
+(wall doc §2, ADR-0005 §2.1 "both exits kept open"). Call sites are already deref-compatible
 by the 3b-0 migration rule and `ValueView` is deliberately non-`Copy`, so this
 does not disturb the wall. The *rest* of the pointer-favored rationale stands:
 pointer deref pays one AND (vs. the Num-favored layout's win on `Num` only),

--- a/docs/perf-callpath-scouting.md
+++ b/docs/perf-callpath-scouting.md
@@ -6,7 +6,7 @@ the order they should be attempted. No design is committed here beyond what the
 data supports; every slice carries its own gate.
 
 The measurement discipline this document follows is
-[ADR-0006 §「実装スライスの計測プロトコル」](adr/0006-baseline-interpreter-optimizations.md)
+[ADR-0006 §"Measurement protocol for implementation slices"](adr/0006-baseline-interpreter-optimizations.md)
 (judge with `perf stat -e instructions:u` under `taskset -c <p-core>`; wall-clock
 and kernel-inclusive `instructions` swing 2–8% on this hybrid CPU and cannot
 decide a 3% change).

--- a/docs/treewalk-method-removal-plan.md
+++ b/docs/treewalk-method-removal-plan.md
@@ -85,8 +85,9 @@ redispatch (and `nextsame`/`callsame`/`nextwith`) of a `multi method` runs throu
 interpreter's **`method_dispatch_stack`** machinery (`dispatch.rs` ~1631-1670,
 `builtins_dispatch_next.rs`), which tree-walks each candidate body via
 `run_instance_method`. This is **exactly the blocker PLAN.md §2-D already flagged**
-("nextsame+rw チェーン … method 経路 … 単一スライス不可・§C の env↔locals/VM-frame cell
-共有を redispatch 境界へ広げる substrate 作業（要設計）", PLAN.md:193-209). So 91% of
+("nextsame+rw chain … method path … not doable as a single slice; substrate work
+extending §C's env↔locals/VM-frame cell sharing to the redispatch boundary (needs
+design)", PLAN.md:193-209). So 91% of
 tree-walk *volume* is this one deep substrate; it is the **capstone**, not the first
 slice.
 
@@ -112,7 +113,7 @@ tractable categories first; they share the same structural lever.
 Slice 1 was implemented (route a resolved, compilable, non-multi user method at the
 tree-walk site `methods_instance_ops.rs:867` through `dispatch_compiled_method` instead
 of `run_instance_method`) and **reverted**. Findings (the real substrate, confirmed
-empirically — this is *why* PLAN said "要設計"):
+empirically — this is *why* PLAN said "needs design"):
 
 - **`dispatch_compiled_method` is NOT byte-identical to `run_instance_method` for a
   method that mutates outer state.** It commits the receiver's *attributes* and fetches

--- a/docs/vm-dual-store.md
+++ b/docs/vm-dual-store.md
@@ -7,7 +7,7 @@
 > Kept because PLAN.md links here for the "what was tried" history.
 
 Tracking design for the highest-leverage VM-decoupling task
-(`ANALYSIS.md` §1.2, `PLAN.md` "🔴 最優先"). This is a high-blast-radius change,
+(`ANALYSIS.md` §1.2, `PLAN.md` "🔴 top priority"). This is a high-blast-radius change,
 so it is staged into small, individually-shippable slices. This file is the
 map; record each slice's before/after here.
 

--- a/docs/vm-interpreter-fallback-ledger.md
+++ b/docs/vm-interpreter-fallback-ledger.md
@@ -1,834 +1,838 @@
-# VM → Interpreter フォールバック台帳
+# VM → Interpreter fallback ledger
 
-最終ゴール「tree-walking Interpreter 実行パスの撤去 → dual-store 削除」（[PLAN.md](../PLAN.md) ①〜⑤）の
-**進捗台帳**。VM (`src/vm/`) が今も Interpreter (`src/runtime/`) に委譲しているサイトを 1 箇所ずつ列挙し、
-撲滅のたびに行を消す。関連: [vm-interpreter-dedup.md](vm-interpreter-dedup.md)（重複削除）、
-[vm-single-store.md](vm-single-store.md)（locals↔env 一本化の**現行設計** = Slice F）、
-[vm-dual-store.md](vm-dual-store.md)（同・撤回試行の履歴）、[vm-decoupling.md](vm-decoupling.md)（dispatch）。
-個々のフォールバック撲滅は今や Slice F（単一ストア収束）の前段ステップとして理解する。
+**Progress ledger** for the final goal "remove the tree-walking Interpreter execution path → delete the dual store"
+([PLAN.md](../PLAN.md) ①–⑤). It enumerates, one by one, the sites where the VM (`src/vm/`) still delegates
+to the Interpreter (`src/runtime/`), and deletes a row each time one is eliminated. Related:
+[vm-interpreter-dedup.md](vm-interpreter-dedup.md) (duplicate removal),
+[vm-single-store.md](vm-single-store.md) (the **current design** for unifying locals↔env = Slice F),
+[vm-dual-store.md](vm-dual-store.md) (history of the withdrawn attempts at the same), [vm-decoupling.md](vm-decoupling.md) (dispatch).
+Individual fallback eliminations are now understood as preliminary steps toward Slice F (single-store convergence).
 
-## 用語
+## Terminology
 
-- **真フォールバック** = 本来 bytecode で実行すべきだが今は tree-walk Interpreter に委譲しているもの。
-  コードに `// TODO: compile to bytecode` を付与。これらを撲滅するのが ①。
-- **CARRIER** = 撲滅対象ではない本質的委譲（reflection / MOP / EVAL サブ VM / メタプロ hook / mode 状態）。
-  Interpreter が共有レジストリ・実行状態を所有するための参照であって tree-walk ではない（④ で「分離 or 明示」）。
-  コードに `// CARRIER:` を付与。③で env/レジストリ所有が VM に移れば単なる共有参照になる。
+- **True fallback** = something that should be executed as bytecode but is currently delegated to the tree-walk Interpreter.
+  Marked in code with `// TODO: compile to bytecode`. Eliminating these is ①.
+- **CARRIER** = essential delegation that is not an elimination target (reflection / MOP / EVAL sub-VM / metaprogramming hooks / mode state).
+  It is a reference through which the Interpreter owns shared registries and execution state, not a tree-walk
+  (to be "separated or made explicit" in ④). Marked in code with `// CARRIER:`. Once env/registry ownership moves to the VM in ③, these become mere shared references.
 
-可視化の現状: `grep -rn "TODO: compile to bytecode" src/vm/` = 18 マーカー、`grep -rn "// CARRIER:" src/vm/` = 8 マーカー。
-（1 マーカーが近接する複数サイトを束ねる箇所あり。下表が正準。）
+Current state of the visualization: `grep -rn "TODO: compile to bytecode" src/vm/` = 18 markers, `grep -rn "// CARRIER:" src/vm/` = 8 markers.
+(Some markers bundle multiple adjacent sites. The tables below are canonical.)
 
-## §1 — メソッドディスパッチの真フォールバック（`call_method_with_values` / `_mut_`）
+## §1 — True fallbacks in method dispatch (`call_method_with_values` / `_mut_`)
 
-| file:line | 受け手 / メソッド | 難易度 | ブロッカー / 依存 |
+| file:line | receiver / method | difficulty | blocker / dependency |
 |---|---|---|---|
-| `vm_call_method_compiled.rs` native-method (非mut) | IO::Pipe/IO::Handle 等の組み込みクラスメソッド | HARD | ③（実装 `native_io_*` がファイルハンドル等の interpreter 所有状態を要求。当初「個別可」は誤り） |
-| `vm_call_method_compiled.rs` catch-all (非mut) | **native/Buf/Failure/MOP のみ**（ユーザーメソッドは全て bytecode 化済） | HARD | ③ state 所有移管。**③ PR-3 で実測訂正**: ここはユーザーメソッド tree-walk では**なかった** |
-| `vm_call_method_compiled.rs` native-method (mut) | 同上 mut | HARD | ③（同上） |
-| `vm_call_method_compiled.rs` catch-all (mut) | 同上 mut（native/Buf/Failure/MOP のみ） | HARD | ③ |
-| `vm_call_method_mut_ops.rs` catch-all | generic mut メソッド（plain untyped `@`-array mutators ＋ mutable Buf write methods は除く） | HARD | ③ |
-| ~~`vm_call_method_mut_ops.rs` plain `@`-array mutators~~ | ~~append/prepend/unshift/pop/shift~~ | — | **✅消化 (③ PR-5)**: `try_native_array_mut` で VM ネイティブ。typed/shaped/lazy/shared/constrained は interpreter 維持 |
-| ~~`vm_call_method_mut_ops.rs` mutable Buf write methods~~ | ~~write-bits/write-ubits/write-num*/write-int*/write-uint*~~ | — | **✅消化 (③ PR-7)**: `try_native_buf_mut` で VM ネイティブ。pure 変換は `builtins/{buf_bits,buf_write_num,buf_write_int}` に一本化。type-object/Blob/malformed-arity は interpreter 維持 |
-| ~~`vm_call_method_mut_ops.rs` 単純 array-backed Iterator~~ | ~~pull-one/skip-one/skip-at-least/skip-at-least-pull-one/sink-all~~ | — | **✅消化 (③ PR-9)**: `try_native_iterator` で VM ネイティブ（`$it.pull-one` は CallMethodMut＝mut パス）。`items`+`index` 自己完結のみ。squish（コールバック）/ lazy（gather/coroutine, `is_lazy`）/ push-*（外部バッファ）/ count-only/bool-only は interpreter 維持 |
-| ~~`vm_call_method_mut_ops.rs` array-backed instance~~ | ~~`is Array` storage の push/pop/shift~~ | — | **✅消化 (#3058)**: `native_array_storage_mut` で `is Array`-backed instance の backing storage への push/pop/shift/unshift/append/prepend を VM ネイティブ化。`write_back_array_storage_instance` で instance 再構築。richer メソッド（join/sort/map/splice/AT-POS 等）は interpreter 維持 |
-| `vm_data_ops.rs` shared push | `@a.push` (threaded) | HARD | lever B（共有セル所有） |
-| `vm_data_ops.rs` shaped push | shaped 配列 push | MEDIUM | shaped 次元メタ検査の VM 化 |
-| `vm_data_ops.rs` non-simple push | 非Array/非ContainerRef な ArrayPush ターゲット（cold） | LOW | **probe で cold 確認 (2026-06-14)**: ArrayPush opcode は単一引数 push かつ *local* array 限定で emit。closure-captured / multi-arg push は CallMethodMut へ流れ **#3060 で native 化済**（下記）。残る ArrayPush 非Array 分岐は whitelist で発火例ゼロ＝cold |
-| ~~`vm_call_method_mut_ops.rs` CallMethodMut push~~ | ~~closure-captured / multi-arg `@a.push`~~ | — | **✅消化 (#3060)**: `try_native_array_mut` に `push` arm を追加。`@a.push(x)` は単一引数 local のみ ArrayPush opcode、それ以外（captured / multi-arg）は CallMethodMut で来るのを VM ネイティブ化。typed/shaped/lazy/shared/constrained は interpreter 維持 |
-| ~~`vm_smart_match.rs` key-method~~ | ~~smartmatch のキーメソッド抽出~~ | — | **✅消化 (PR2)**: 統一 compiled-first へ |
-| ~~`vm_call_method_compiled.rs` QuantHash coercion~~ | ~~`.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/`.MixHash`（list-like 受け手）~~ | — | **✅消化 (③ PR-8 + MixHash slice)**: `try_native_quanthash_coerce` で VM ネイティブ。pure 折り畳みは `builtins/quanthash_coerce` に一本化。**`.MixHash` も追加**（旧除外理由「型メタ登録＝interpreter 所有 state」は #2952 のコンテナ値埋め込み化で stale＝`Value::Mix` の Arc にメタ埋め込みで pure value op・新 `to_mixhash`）。Instance/Package 受け手のみ interpreter 維持 |
-| `vm_call_helpers.rs` hyper temp | temp-bind した item への hyper メソッド | MEDIUM | 第一級コンテナ Phase 2 |
-| ~~`vm_register_ops.rs` react loop~~ | ~~`run_react_event_loop[_drain]` / `run_whenever_with_value`~~ | — | **✅消化 (Stage 1+2, #3010/#3027/#3029/#3031/#3038/#3039)**: 駆動ループの **4 箇所二重化**（react/await-promise/tap×2）を単一エンジンへ統合（tap×2→1 #3010、react↔await-promise を `SupplyDrivePolicy { React, Promise }` + `drive_react_subscriptions` へ #3027）。**Stage 2 = ループ所有権の逆転完了**: `run_react_event_loop`/`drive_react_subscriptions`/`run_react_consumer`/`replay_static_supply` を `impl Interpreter`→`impl VM`（新 `vm/vm_react_loop.rs`）へ移設 #3038、whenever body/LAST/CLOSE callback を `call_sub_value`(tree-walk)→`VM::call_react_callback`（`vm_call_map_block` でトピック束縛しつつコンパイル済みバイトコード実行）へ #3039。await/Promise 経路は薄い `Interpreter::drive_react_subscriptions` ブリッジ（mem::take/VM/restore）で到達。**Stage 3 follow-up = supply `QUIT` handler も VM ネイティブ化**: VM 駆動ループ内の 2 箇所（`vm_react_loop.rs` の React/Channel quit 経路）が `self.interpreter.call_supply_quit_handler`（tree-walk `call_sub_value`）へ戻っていたのを、`VM::call_supply_quit_handler`（`call_react_callback` 経由でコンパイル済みバイトコード実行）へ差し替え。**これで駆動ループのどのコールバックも tree-walk へ戻らない**。`Interpreter::call_supply_quit_handler` は Interpreter 単独の on-demand/tap supply 経路（`native_supplier_methods`/`native_supply_mut_methods`）からのみ使用（それ自体が別系の tree-walk runtime で、ここは対象外）。`supply_emit_buffer` は Interpreter field のまま（`self.interpreter.` 経由で VM から到達でき、global 化は不要）。 |
+| `vm_call_method_compiled.rs` native-method (non-mut) | built-in class methods such as IO::Pipe/IO::Handle | HARD | ③ (the implementations `native_io_*` require interpreter-owned state such as file handles. The initial "can be done individually" assessment was wrong) |
+| `vm_call_method_compiled.rs` catch-all (non-mut) | **native/Buf/Failure/MOP only** (user methods are all bytecode-compiled already) | HARD | ③ state ownership transfer. **Corrected by measurement in ③ PR-3**: this was **not** a user-method tree-walk after all |
+| `vm_call_method_compiled.rs` native-method (mut) | same as above, mut | HARD | ③ (same as above) |
+| `vm_call_method_compiled.rs` catch-all (mut) | same as above, mut (native/Buf/Failure/MOP only) | HARD | ③ |
+| `vm_call_method_mut_ops.rs` catch-all | generic mut methods (excluding plain untyped `@`-array mutators and mutable Buf write methods) | HARD | ③ |
+| ~~`vm_call_method_mut_ops.rs` plain `@`-array mutators~~ | ~~append/prepend/unshift/pop/shift~~ | — | **✅ Eliminated (③ PR-5)**: VM-native via `try_native_array_mut`. typed/shaped/lazy/shared/constrained stay on the interpreter |
+| ~~`vm_call_method_mut_ops.rs` mutable Buf write methods~~ | ~~write-bits/write-ubits/write-num*/write-int*/write-uint*~~ | — | **✅ Eliminated (③ PR-7)**: VM-native via `try_native_buf_mut`. Pure conversions unified into `builtins/{buf_bits,buf_write_num,buf_write_int}`. type-object/Blob/malformed-arity stay on the interpreter |
+| ~~`vm_call_method_mut_ops.rs` simple array-backed Iterator~~ | ~~pull-one/skip-one/skip-at-least/skip-at-least-pull-one/sink-all~~ | — | **✅ Eliminated (③ PR-9)**: VM-native via `try_native_iterator` (`$it.pull-one` is the CallMethodMut = mut path). Only self-contained `items`+`index` iterators. squish (callback) / lazy (gather/coroutine, `is_lazy`) / push-* (external buffer) / count-only/bool-only stay on the interpreter |
+| ~~`vm_call_method_mut_ops.rs` array-backed instance~~ | ~~push/pop/shift on `is Array` storage~~ | — | **✅ Eliminated (#3058)**: `native_array_storage_mut` makes push/pop/shift/unshift/append/prepend against the backing storage of an `is Array`-backed instance VM-native. Instance rebuilt via `write_back_array_storage_instance`. Richer methods (join/sort/map/splice/AT-POS etc.) stay on the interpreter |
+| `vm_data_ops.rs` shared push | `@a.push` (threaded) | HARD | lever B (shared cell ownership) |
+| `vm_data_ops.rs` shaped push | shaped array push | MEDIUM | VM-ify shaped dimension metadata checks |
+| `vm_data_ops.rs` non-simple push | ArrayPush targets that are neither Array nor ContainerRef (cold) | LOW | **Confirmed cold by probe (2026-06-14)**: the ArrayPush opcode is only emitted for single-argument push on a *local* array. Closure-captured / multi-arg push flows to CallMethodMut and **was made native in #3060** (below). The remaining ArrayPush non-Array branch has zero firing examples across the whitelist = cold |
+| ~~`vm_call_method_mut_ops.rs` CallMethodMut push~~ | ~~closure-captured / multi-arg `@a.push`~~ | — | **✅ Eliminated (#3060)**: added a `push` arm to `try_native_array_mut`. `@a.push(x)` uses the ArrayPush opcode only for single-argument local; everything else (captured / multi-arg) arrives via CallMethodMut and is now VM-native. typed/shaped/lazy/shared/constrained stay on the interpreter |
+| ~~`vm_smart_match.rs` key-method~~ | ~~key-method extraction for smartmatch~~ | — | **✅ Eliminated (PR2)**: moved to unified compiled-first |
+| ~~`vm_call_method_compiled.rs` QuantHash coercion~~ | ~~`.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/`.MixHash` (list-like receivers)~~ | — | **✅ Eliminated (③ PR-8 + MixHash slice)**: VM-native via `try_native_quanthash_coerce`. Pure folding unified into `builtins/quanthash_coerce`. **`.MixHash` also added** (the old exclusion reason "type metadata registration = interpreter-owned state" became stale with #2952's embedding of container values = metadata embedded in `Value::Mix`'s Arc makes it a pure value op; new `to_mixhash`). Only Instance/Package receivers stay on the interpreter |
+| `vm_call_helpers.rs` hyper temp | hyper method on a temp-bound item | MEDIUM | first-class containers Phase 2 |
+| ~~`vm_register_ops.rs` react loop~~ | ~~`run_react_event_loop[_drain]` / `run_whenever_with_value`~~ | — | **✅ Eliminated (Stage 1+2, #3010/#3027/#3029/#3031/#3038/#3039)**: unified the **4-way duplication** of the drive loop (react/await-promise/tap×2) into a single engine (tap×2→1 #3010; react↔await-promise into `SupplyDrivePolicy { React, Promise }` + `drive_react_subscriptions` #3027). **Stage 2 = loop ownership inversion complete**: moved `run_react_event_loop`/`drive_react_subscriptions`/`run_react_consumer`/`replay_static_supply` from `impl Interpreter` → `impl VM` (new `vm/vm_react_loop.rs`) #3038; switched whenever body/LAST/CLOSE callbacks from `call_sub_value` (tree-walk) → `VM::call_react_callback` (executing compiled bytecode while binding the topic via `vm_call_map_block`) #3039. The await/Promise path is reached via a thin `Interpreter::drive_react_subscriptions` bridge (mem::take/VM/restore). **Stage 3 follow-up = the supply `QUIT` handler is also now VM-native**: the 2 sites inside the VM drive loop (the React/Channel quit paths in `vm_react_loop.rs`) that fell back to `self.interpreter.call_supply_quit_handler` (tree-walk `call_sub_value`) were replaced with `VM::call_supply_quit_handler` (executing compiled bytecode via `call_react_callback`). **With this, no callback in the drive loop ever returns to tree-walk.** `Interpreter::call_supply_quit_handler` is used only from the Interpreter's standalone on-demand/tap supply path (`native_supplier_methods`/`native_supply_mut_methods`), which is itself a separate tree-walk runtime and out of scope here. `supply_emit_buffer` remains an Interpreter field (reachable from the VM via `self.interpreter.`; making it global is unnecessary). |
 
-## §2 — 関数ディスパッチの真フォールバック（`call_function` / `call_function_fallback`）
+## §2 — True fallbacks in function dispatch (`call_function` / `call_function_fallback`)
 
-| file:line | 文脈 | 難易度 | ブロッカー / 依存 |
+| file:line | context | difficulty | blocker / dependency |
 |---|---|---|---|
-| ~~`vm_var_get_ops.rs` 0-arg term~~ | ~~0引数のユーザ/multi 関数 term~~ | — | **✅消化 (PR3)**: cold fallback を統一 compiled-first へ（OTF compile 追加） |
-| ~~`vm_var_get_ops.rs` pkg-qualified~~ | ~~`Module::func` を term 位置で~~ | — | **✅消化 (PR3)**: 同上 |
-| `vm_call_func_ops.rs` builtin-shadow（slip + 通常 2 サイト） | ユーザ sub が同名 builtin を shadow / **非builtin モジュール/動的 single sub** | 部分消化 | **✅単一候補の compilable 分は ③ PR-2 で OTF compile 化**（builtin-shadow は `def_is_otf_compilable` strict）。**✅非builtin single も OTF 化（§D, #TBD）**: 新 `def_is_otf_compilable_module_single`（default 許可・name-cache 安全＝同名 builtin 無し）＋保守ゲート（state/sigilless/rw/raw/nested-routine/subtest/CATCH/CONTROL/phaser/start/EVAL/test-assertion を `module_otf_body_needs_interpreter` で除外）。module sub 100%→0%。pin `t/module-sub-otf-dispatch.t`(14)。proto/multi/複雑 sig は fallback 維持 |
-| `vm_call_func_ops.rs` multi-dispatch fork / final else | 非proto multi / `call_function` 末端 | 部分消化 | **✅非proto multi の unambiguous/OTF-compilable/非state 候補は ③ PR-4 で OTF compile 化＋where 候補も §D で OTF 化**（ambiguity/state-alternate/proto-body/末端は fallback 維持） |
-| `vm_call_func_ops.rs` proto sub dispatch（trivial body） | `proto foo {*}` / bodyless proto の `{*}` ディスパッチ | 部分消化 | **✅消化 (#3541)**: VM call site で `vm_resolve_trivial_proto_candidate`→`compile_and_call_function_def`。tree-walk proto body＋`__PROTO_DISPATCH__`＋候補 `run_block` を全バイパス。proto sig は `method_args_match` で gate。非trivial body / 非OTF候補 は fallback 維持 |
-| ~~`def_is_otf_compilable` の where 除外~~ | ~~where 制約付き multi/proto/single 候補~~ | — | **✅消化 (§D, #3543)**: `def_is_otf_compilable` から `where_constraint.is_none()` を撤去し where 候補も OTF compile 化。winner は resolve 時に `args_match_param_types` 経由で where 評価済＝解決 def は where を満たす。compiled binding が where 再検証＋`&name` captured env merge で byte-identical。light-call fast path は where 除外維持。fallback 77.8%→0%。**同 PR で `resolve_all_multi_candidates` を specificity 順ソート**（nextsame/callsame が複数マッチ候補で広い候補を先に拾う hash-seed flake を修正・defer-next.t）。pin `t/multi-where-otf-dispatch.t`(20) |
-| `def_is_otf_compilable` の default 除外 | default param 値を持つ multi/proto/single 候補 | DEFERRED | **PR #3546 close**: `default.is_none()` 単純撤去は make test + S06/S12 全緑だが release make roast で env.t/system.t/cur-current-distribution.t を回帰。root cause=builtin `run` を Test::Util の `our sub run(Str $code, Str $input='', *%o)` が shadow→builtin-shadow パスで OTF compile + name-cache 汚染→subtest 等 stateful 文脈で後続 core `run` を mis-bind。PR-2 builtin-shadow hazard の default-param 版。安全実装＝builtin-shadow 単一候補パスは default-param 除外維持・multi/非builtin 単一だけ許可（要 full roast 検証）。fallback 85.7%。impl+pin 保存=branch multi-dispatch-default-otf |
-| `vm_call_dispatch.rs` catch-all | `call_function_compiled_first` 末端（実測でほぼ枯渇＝下記 PR-6 注記） | HARD | ③（残=lexical-alias-to-builtin / `__mutsu_*` 内部 / 並行〔lever B〕/ no-match エラー生成） |
-| ~~`vm_dispatch_helpers.rs` Routine call_function~~ | ~~Routine 値の関数解決~~ | — | **✅消化 (③ PR-1)**: 3 サイトを統一 compiled-first へ（builtin 名 Routine は builtin 優先維持） |
+| ~~`vm_var_get_ops.rs` 0-arg term~~ | ~~0-argument user/multi function term~~ | — | **✅ Eliminated (PR3)**: cold fallback moved to unified compiled-first (added OTF compile) |
+| ~~`vm_var_get_ops.rs` pkg-qualified~~ | ~~`Module::func` in term position~~ | — | **✅ Eliminated (PR3)**: same as above |
+| `vm_call_func_ops.rs` builtin-shadow (slip + normal, 2 sites) | user sub shadows a same-named builtin / **non-builtin module / dynamically registered single sub** | partially eliminated | **✅ The compilable single-candidate portion was OTF-compiled in ③ PR-2** (builtin-shadow uses strict `def_is_otf_compilable`). **✅ Non-builtin singles also OTF'd (§D, #TBD)**: new `def_is_otf_compilable_module_single` (default-allow, name-cache safe = no same-named builtin) plus a conservative gate (`module_otf_body_needs_interpreter` excludes state/sigilless/rw/raw/nested-routine/subtest/CATCH/CONTROL/phaser/start/EVAL/test-assertion). module sub 100%→0%. pin `t/module-sub-otf-dispatch.t`(14). proto/multi/complex sigs keep the fallback |
+| `vm_call_func_ops.rs` multi-dispatch fork / final else | non-proto multi / `call_function` terminal | partially eliminated | **✅ Unambiguous/OTF-compilable/non-state candidates of non-proto multis were OTF-compiled in ③ PR-4, and where-constrained candidates were also OTF'd in §D** (ambiguity/state-alternate/proto-body/terminal keep the fallback) |
+| `vm_call_func_ops.rs` proto sub dispatch (trivial body) | `{*}` dispatch of `proto foo {*}` / bodyless proto | partially eliminated | **✅ Eliminated (#3541)**: at the VM call site, `vm_resolve_trivial_proto_candidate`→`compile_and_call_function_def`. Fully bypasses the tree-walk proto body + `__PROTO_DISPATCH__` + candidate `run_block`. Proto sigs are gated via `method_args_match`. Non-trivial bodies / non-OTF candidates keep the fallback |
+| ~~`def_is_otf_compilable` where exclusion~~ | ~~multi/proto/single candidates with where constraints~~ | — | **✅ Eliminated (§D, #3543)**: removed `where_constraint.is_none()` from `def_is_otf_compilable`, so where-constrained candidates are OTF-compiled too. The winner has already had its where evaluated via `args_match_param_types` at resolve time = the resolved def satisfies the where. Compiled binding re-validates where + merges the `&name` captured env, byte-identical. The light-call fast path keeps the where exclusion. fallback 77.8%→0%. **The same PR sorts `resolve_all_multi_candidates` in specificity order** (fixes the hash-seed flake where nextsame/callsame picked a broader candidate first among multiple matching candidates; defer-next.t). pin `t/multi-where-otf-dispatch.t`(20) |
+| `def_is_otf_compilable` default exclusion | multi/proto/single candidates with default param values | DEFERRED | **PR #3546 closed**: plainly removing `default.is_none()` is green on make test + all of S06/S12, but the release make roast regressed env.t/system.t/cur-current-distribution.t. Root cause = Test::Util's `our sub run(Str $code, Str $input='', *%o)` shadows the builtin `run` → OTF compile on the builtin-shadow path + name-cache pollution → in stateful contexts like subtest, subsequent core `run` calls get mis-bound. A default-param variant of the PR-2 builtin-shadow hazard. Safe implementation = keep the default-param exclusion on the builtin-shadow single-candidate path and allow only multi / non-builtin singles (needs full roast validation). fallback 85.7%. impl+pin preserved = branch multi-dispatch-default-otf |
+| `vm_call_dispatch.rs` catch-all | `call_function_compiled_first` terminal (nearly exhausted by measurement = see PR-6 note below) | HARD | ③ (remaining = lexical-alias-to-builtin / `__mutsu_*` internal / concurrency [lever B] / no-match error generation) |
+| ~~`vm_dispatch_helpers.rs` Routine call_function~~ | ~~function resolution of Routine values~~ | — | **✅ Eliminated (③ PR-1)**: 3 sites moved to unified compiled-first (Routines with builtin names keep builtin priority) |
 
-## §C — CARRIER（撲滅対象外・文書化して残す。④で確定）
+## §C — CARRIER (not elimination targets; documented and kept. Finalized in ④)
 
-| file:line | 種別 | 理由 |
+| file:line | kind | reason |
 |---|---|---|
-| `vm_call_method_compiled.rs` pseudo-method (非mut/mut) | MOP reflection | DEFINITE/WHAT/WHO/HOW/WHY/WHICH/WHERE/VAR は反射、bytecode 形なし |
-| `vm_call_method_compiled.rs` ^metamethod (非mut/mut) | MOP | `Foo.^bar` メタメソッドは MOP 所有 |
-| `vm_register_ops.rs` `.VAR` + `trait_mod:<is>` | コンテナ反射 + メタプロ hook | `.VAR` 反射 + ユーザ trait ハンドラ |
-| `vm_register_ops.rs` `trait_mod:<is>` 各サイト | メタプロ hook | sub/型/変数への is トレイト適用（複数箇所） |
-| `vm_var_get_ops.rs` pseudo-package | 反射スコープ解決 | `SETTING::`/`OUTER::`/`CALLER::`/`DYNAMIC::` |
-| `vm_var_get_ops.rs` test-function | mode 状態 | `make-temp-dir` 等の Test ハーネス dispatch |
+| `vm_call_method_compiled.rs` pseudo-method (non-mut/mut) | MOP reflection | DEFINITE/WHAT/WHO/HOW/WHY/WHICH/WHERE/VAR are reflection; no bytecode form |
+| `vm_call_method_compiled.rs` ^metamethod (non-mut/mut) | MOP | `Foo.^bar` metamethods are MOP-owned |
+| `vm_register_ops.rs` `.VAR` + `trait_mod:<is>` | container reflection + metaprogramming hook | `.VAR` reflection + user trait handlers |
+| `vm_register_ops.rs` `trait_mod:<is>` sites | metaprogramming hook | applying is traits to subs/types/variables (multiple sites) |
+| `vm_var_get_ops.rs` pseudo-package | reflective scope resolution | `SETTING::`/`OUTER::`/`CALLER::`/`DYNAMIC::` |
+| `vm_var_get_ops.rs` test-function | mode state | Test harness dispatch for `make-temp-dir` etc. |
 | `vm_var_get_ops.rs` call-chain | MOP dispatch stack | `callsame`/`nextsame`/`callwith`/`nextwith`/`nextcallee`/`lastcall` |
-| `vm_call_func_ops.rs` / `vm_call_dispatch.rs` carrier 分岐 | EVAL サブ VM | `EVAL`/`EVALFILE` は compile→サブ VM 実行。`is_interpreter_carrier_function` で runtime 判定済み |
+| `vm_call_func_ops.rs` / `vm_call_dispatch.rs` carrier branches | EVAL sub-VM | `EVAL`/`EVALFILE` are compile→sub-VM execution. Already runtime-detected via `is_interpreter_carrier_function` |
 
-## 進捗ログ
+## Progress log
 
-- **2026-06-08 (PR-1, #2755 merged)**: ① の起点。全フォールバックを `// TODO: compile to bytecode` / `// CARRIER:`
-  で可視化し本台帳を新設。併せて EASY 撲滅 1 件: `succ`/`pred`（`vm_var_assign_ops.rs` の `increment_value_smart`/
-  `decrement_value_smart`）の生 `interpreter.call_method_with_values` を統一 compiled-first ディスパッチ
-  `try_compiled_method_or_interpret` に差し替え（§1 から 2 サイト消化）。
-- **2026-06-08 (PR-2)**: 同手法で value-receiver の生 `call_method_with_values` をさらに 2 サイト消化 →
-  `vm_smart_match.rs` smartmatch キーメソッド、`vm_dispatch_helpers.rs` Routine の method-dispatch 分岐
-  （`&?ROUTINE.dispatcher()(self,…)`）を統一 compiled-first ディスパッチへ。ユーザ定義メソッドは compiled bytecode
-  実行になり、native/reflective のみが共有末端へ。t/smartmatch-method-dispatch.t 追加。S03-smartmatch 全 pass。
-  （補足: fat-arrow `$o ~~ (k => v)` が False を返すのは Pair 分岐到達前の別パースバグで本作業の対象外。コロンペアは正常。）
-- **2026-06-08 (PR-3)**: §2 の cold な term 位置フォールバック 2 件（`vm_var_get_ops.rs` の 0-arg term /
-  pkg-qualified）を生 `interpreter.call_function` から統一エントリ `call_function_compiled_first` へ寄せ、
-  単純ユーザ sub の OTF compile を追加（interpreter は終端のみ）。あわせて native-method 行を **③-blocked** に訂正
-  （`native_io_*` がファイルハンドル等の interpreter 所有状態を要求するため「個別可」は誤りだった）。
+- **2026-06-08 (PR-1, #2755 merged)**: starting point of ①. Made all fallbacks visible with `// TODO: compile to bytecode` / `// CARRIER:`
+  and created this ledger. Also one EASY elimination: replaced the raw `interpreter.call_method_with_values` for `succ`/`pred`
+  (`increment_value_smart`/`decrement_value_smart` in `vm_var_assign_ops.rs`) with the unified compiled-first dispatch
+  `try_compiled_method_or_interpret` (2 sites eliminated from §1).
+- **2026-06-08 (PR-2)**: eliminated 2 more value-receiver raw `call_method_with_values` sites with the same technique →
+  the `vm_smart_match.rs` smartmatch key-method and the `vm_dispatch_helpers.rs` Routine method-dispatch branch
+  (`&?ROUTINE.dispatcher()(self,…)`) now go through unified compiled-first dispatch. User-defined methods run as compiled
+  bytecode; only native/reflective reach the shared terminal. Added t/smartmatch-method-dispatch.t. All S03-smartmatch pass.
+  (Note: fat-arrow `$o ~~ (k => v)` returning False is a separate parse bug hit before the Pair branch is reached, out of scope for this work. Colon pairs are fine.)
+- **2026-06-08 (PR-3)**: moved the 2 cold term-position fallbacks of §2 (0-arg term / pkg-qualified in `vm_var_get_ops.rs`)
+  from raw `interpreter.call_function` to the unified entry `call_function_compiled_first`, and added OTF compile for
+  simple user subs (interpreter is terminal only). Also corrected the native-method row to **③-blocked**
+  (the "can be done individually" assessment was wrong because `native_io_*` requires interpreter-owned state such as file handles).
 
-- **2026-06-08 (② 抽出/read/write-through 完了, #2760-2772 + 本 PR)**: 宣言レジストリの VM 所有化（phase ②）が
-  PR-A（抽出・全フィールドを `Registry` へ）→ PR-B（lookup/MRO/型マッチを `impl Registry` メソッド化）→ PR-C
-  （`register_*_decl` の write-through 整理）まで完了。一次情報は `docs/vm-registry-ownership.md`。PR-C は
-  **登録パス＝CARRIER 性**（`register_class_decl`/`register_sub_decl`/`register_enum_decl`/`register_role_decl` は
-  登録中に `eval_block_value`/`run_block_raw`/`call_function`＝クラス本体・trait ハンドラ・属性デフォルト・enum 変種値・
-  パラメタ化 role 本体を実行する＝実行トリガ）を確認し、`registry()`/`registry_mut()` を**再入検出ラッパ guard**へ
-  差し替えて「RwLock ガードを再入を跨いで保持しない」規律を **debug ビルドで実行時に強制**（同一ロック再取得を
-  ブロッキング呼び出し手前で位置付き panic、ロックアドレスでキー付けして別 registry 同時保持の正当ケースは許容）。
-  これで §2 の関数 dispatch fallback（`vm_call_func_ops.rs` multi/sub 解決, `vm_dispatch_helpers.rs` Routine）撲滅の
-  構造前提（②）が整った。残る §1/§2 は ③（state 所有移管）が前提。
+- **2026-06-08 (② extraction/read/write-through complete, #2760-2772 + this PR)**: VM ownership of the declaration registries (phase ②)
+  completed through PR-A (extraction; all fields into `Registry`) → PR-B (lookup/MRO/type matching as `impl Registry` methods) → PR-C
+  (cleanup of the `register_*_decl` write-through). Primary source: `docs/vm-registry-ownership.md`. PR-C confirmed the
+  **registration path = CARRIER nature** (`register_class_decl`/`register_sub_decl`/`register_enum_decl`/`register_role_decl` execute
+  `eval_block_value`/`run_block_raw`/`call_function` during registration = class bodies, trait handlers, attribute defaults, enum variant values,
+  and parameterized role bodies = execution triggers), and replaced `registry()`/`registry_mut()` with a **re-entrancy-detecting wrapper guard**
+  enforcing at runtime, in debug builds, the discipline "never hold an RwLock guard across re-entry" (panics with position info right before a
+  blocking call on same-lock reacquisition; keyed by lock address so the legitimate case of holding a different registry concurrently is allowed).
+  This puts in place the structural prerequisite (②) for eliminating the §2 function dispatch fallbacks
+  (`vm_call_func_ops.rs` multi/sub resolution, `vm_dispatch_helpers.rs` Routine). The remaining §1/§2 require ③ (state ownership transfer).
 
-- **2026-06-08 (③ PR-1, Routine dispatch)**: ③設計を `docs/vm-state-ownership.md` に確定（③は②と異なり
-  **フォールバック撲滅駆動**＝共有ハンドル方式不可・env は plain field 終状態。状態×結合度マップ作成）。最初の
-  スライスとして `vm_dispatch_helpers.rs` の Routine 値 dispatch（vm_call_on_value）の 3 つの生
-  `interpreter.call_function`（qualified / bare / 末端）を統一エントリ `call_function_compiled_first` へ寄せ、
-  ユーザ定義 sub/multi/proto を compiled bytecode 実行に。**builtin 優先の保全**: `&SETTING::...::not` は
-  `Routine{GLOBAL, "not"}` に解決される（accessors.rs）＝ユーザ `sub not` が名前を shadow していても builtin を
-  指す意図。`Interpreter::is_builtin_function` ガードで、builtin 名を持つ Routine のみ `call_function` の
-  builtin 優先を維持（平の user `&not` は `Value::Sub` で Routine 枝に来ない）。最初の naive 変換で
-  `S02-names/SETTING-6e.t` が回帰（user `sub not` + `&SETTING::not`）し実証。pin = `t/routine-value-dispatch.t`(10)。
-  S06/S02-magicals/S02-names/S03-smartmatch whitelist 137 件緑。
+- **2026-06-08 (③ PR-1, Routine dispatch)**: finalized the ③ design in `docs/vm-state-ownership.md` (unlike ②, ③ is
+  **fallback-elimination-driven** = the shared-handle approach is not viable; env's terminal state is a plain field. Built the state×coupling map). As the first
+  slice, moved the 3 raw `interpreter.call_function` calls (qualified / bare / terminal) of the Routine value dispatch (vm_call_on_value)
+  in `vm_dispatch_helpers.rs` to the unified entry `call_function_compiled_first`, so user-defined sub/multi/proto run as compiled bytecode.
+  **Preserving builtin priority**: `&SETTING::...::not` resolves to `Routine{GLOBAL, "not"}` (accessors.rs) = it intends the builtin even when a
+  user `sub not` shadows the name. With the `Interpreter::is_builtin_function` guard, only Routines bearing builtin names keep `call_function`'s
+  builtin priority (a plain user `&not` is a `Value::Sub` and does not reach the Routine branch). The first naive conversion regressed
+  `S02-names/SETTING-6e.t` (user `sub not` + `&SETTING::not`), which proved the point. pin = `t/routine-value-dispatch.t`(10).
+  S06/S02-magicals/S02-names/S03-smartmatch whitelist 137 files green.
 
-- **2026-06-08 (③ PR-2, builtin-shadow fork)**: ユーザ定義 sub が同名 builtin を shadow する関数 dispatch
-  fork（`vm_call_func_ops.rs` の `exec_call_func_op` 通常パス + `exec_call_func_slip_op` の 2 サイト、
-  `user_function_matches_call` 枝）を、解決した def が **plain 単一候補かつ compilable** な場合のみ OTF compile
-  （`compile_and_call_function_def`）へ降ろし bytecode 実行に。native arm へは落とさない（shadow された builtin を
-  拾わないため）。compilable 判定は新ヘルパ `def_is_otf_compilable`（既存 OTF 枝のガードを集約）。**回帰を 2 段で発見・修正**:
-  ① 当初 proto/multi も `resolve_function_with_types` の単一候補を OTF compile してしまい、proto'd multi の候補
-  dispatch が壊れた（whitelisted S06-multi/proto・subsignature・type-based が mid-file abort = exit 255/Failed:0）→
-  `!has_proto && !has_multi_candidates` ガード追加。② **`user_function_matches_call` 枝は builtin-shadow 専用ではなく
-  「compiled_fns に無い（モジュール/動的登録）args 一致ユーザ sub」全般**が来る。`def_is_otf_compilable` は nested
-  `sub` 宣言内の `when` 制御フロー等を捕捉できず、Test::Util `is-deeply-junction`（nested `junction-guts` + `when`）が
-  OTF compile されると `when`-succeed が関数全体を脱出し eigenstate を取りこぼした（`t/test-util-is-deeply-junction.t`
-  / `throws-like-any` 回帰）→ **`Interpreter::is_builtin_function(name)` ガードで実際の builtin shadow に限定**
-  （非builtin のモジュール sub は従来通り tree-walk）。pin = `t/builtin-shadow-dispatch.t`(9)。S06 whitelist 86 件緑
-  （S32-str gb2312/shiftjis は main でも落ちる既存環境依存）。残: 非proto multi fork（VM 側 multi 候補解決が前提）、
-  catch-all 末端（③）、非builtin モジュール sub の tree-walk（compiled_fns 拡充 or 安全な汎用 OTF gate が前提）。
+- **2026-06-08 (③ PR-2, builtin-shadow fork)**: for the function dispatch fork where a user-defined sub shadows a same-named builtin
+  (2 sites: the `exec_call_func_op` normal path + `exec_call_func_slip_op` in `vm_call_func_ops.rs`,
+  `user_function_matches_call` branch), lowered to OTF compile (`compile_and_call_function_def`) and bytecode execution only when the resolved
+  def is a **plain single candidate and compilable**. It does not fall to the native arm (so as not to pick up the shadowed builtin).
+  Compilability is judged by the new helper `def_is_otf_compilable` (consolidating the guards of the existing OTF branches). **Found and fixed regressions in 2 stages**:
+  ① initially, proto/multi also got their single `resolve_function_with_types` candidate OTF-compiled, breaking candidate dispatch of proto'd multis
+  (whitelisted S06-multi/proto, subsignature, type-based went mid-file abort = exit 255/Failed:0) →
+  added the `!has_proto && !has_multi_candidates` guard. ② **the `user_function_matches_call` branch is not builtin-shadow-only: it receives
+  all "args-matching user subs absent from compiled_fns (module/dynamically registered)"**. `def_is_otf_compilable` cannot capture `when` control
+  flow etc. inside nested `sub` declarations, and when Test::Util's `is-deeply-junction` (nested `junction-guts` + `when`) was
+  OTF-compiled, the `when`-succeed escaped the whole function and dropped the eigenstates (`t/test-util-is-deeply-junction.t`
+  / `throws-like-any` regressions) → **limited to actual builtin shadows via the `Interpreter::is_builtin_function(name)` guard**
+  (non-builtin module subs stay tree-walk as before). pin = `t/builtin-shadow-dispatch.t`(9). S06 whitelist 86 files green
+  (S32-str gb2312/shiftjis also fail on main = pre-existing environment-dependent). Remaining: the non-proto multi fork (requires VM-side multi candidate resolution),
+  the catch-all terminal (③), tree-walk of non-builtin module subs (requires expanding compiled_fns or a safe generic OTF gate).
 
-- **2026-06-09 (③ PR-3, §1 catch-all = ユーザーメソッド compile-on-demand + 実態訂正)**: §1 catch-all
-  （`vm_call_method_compiled.rs` の `try_compiled_method_or_interpret` line 457 / `try_compiled_method_mut_or_interpret`
-  line ~919）の dispatch チョークポイントに、**解決済みユーザーメソッド def が `compiled_code == None` の場合の
-  compile-on-demand** を追加（新ヘルパ `populate_uncompiled_method`: `compile_class_methods`/`compile_role_methods`
-  で canonical registry を冪等に compile→再解決→`dispatch_compiled_method` で bytecode 実行。owner が user
-  class/role でない or 空ボディなら `None` で interpreter フォールバック温存）。pin `t/method-otf-dispatch.t`(14)。
-  **最大の収穫は実態の実測訂正**: `MUTSU_VM_STATS=1` + プローブで catch-all 到達集合を計測した結果、台帳が
-  「catch-all = 残る主 tree-walk（ユーザーメソッド）」としていたのは**誤りだった**。実際は:
-  ① **通常宣言メソッド（multi method 含む）・submethod・role 合成・継承・`.^add_method` は全て登録時に
-  `compile_class_methods` で bytecode 化済**（`.^add_method` は method リテラル Sub の `compiled_code` を引き継ぐ、
-  `methods_classhow.rs:640`）。② catch-all に来る Instance トラフィックは **native coercion（`Exception.Stringy`）/
-  MOP（`.does`/`.^does`）/ role-qualified（`WithAttr.AccessesAttr::meth` は resolve=None で resolved ブロックに
-  入らない）** のみ＝③/builtins/別解決バグ依存。③ `populate_uncompiled_method` が実際に発火する唯一の compile-gap は
-  **`.^add_multi_method`**（`compiled_code: None` 固定, `methods_classhow.rs:702`）＋将来の同種サイトの defensive
-  カバー。よって本 PR は §1 catch-all の**ユーザーメソッド分を確実に bytecode 化**（残りは native/MOP/別解決バグ）。
-  S12/S14/S06-multi/metamodel whitelist 全緑、make test PASS。**教訓: フォールバックカウンタは「tree-walk」ではなく
-  「interpreter ブリッジ経由」を数える**（ブリッジ先の `run_block_raw` 自体は VM compile ping-pong で実は bytecode）。
+- **2026-06-09 (③ PR-3, §1 catch-all = user-method compile-on-demand + correcting the actual picture)**: at the dispatch chokepoints of the §1 catch-all
+  (`try_compiled_method_or_interpret` line 457 / `try_compiled_method_mut_or_interpret` line ~919 in `vm_call_method_compiled.rs`), added
+  **compile-on-demand for resolved user method defs whose `compiled_code == None`** (new helper `populate_uncompiled_method`:
+  idempotently compiles the canonical registry via `compile_class_methods`/`compile_role_methods` → re-resolves → executes bytecode via `dispatch_compiled_method`.
+  If the owner is not a user class/role or the body is empty, returns `None` to preserve the interpreter fallback). pin `t/method-otf-dispatch.t`(14).
+  **The biggest yield was correcting the measured reality**: measuring the catch-all reach set with `MUTSU_VM_STATS=1` + a probe showed the ledger's claim that
+  "catch-all = the remaining primary tree-walk (user methods)" was **wrong**. In reality:
+  ① **normally declared methods (including multi methods), submethods, role composition, inheritance, and `.^add_method` are all bytecode-compiled at
+  registration time via `compile_class_methods`** (`.^add_method` inherits the `compiled_code` of the method-literal Sub,
+  `methods_classhow.rs:640`). ② The Instance traffic reaching the catch-all is **only native coercion (`Exception.Stringy`) /
+  MOP (`.does`/`.^does`) / role-qualified (`WithAttr.AccessesAttr::meth` resolves to None and never enters the resolved block)** = dependent on ③/builtins/a separate resolution bug. ③ The only compile-gap where `populate_uncompiled_method` actually fires is
+  **`.^add_multi_method`** (`compiled_code: None` fixed, `methods_classhow.rs:702`) plus defensive coverage of future sites of the same kind.
+  So this PR **reliably bytecode-compiles the user-method portion of the §1 catch-all** (the remainder is native/MOP/separate resolution bugs).
+  S12/S14/S06-multi/metamodel whitelist all green, make test PASS. **Lesson: the fallback counters count "via the interpreter bridge",
+  not "tree-walk"** (the `run_block_raw` on the far side of the bridge is actually bytecode via the VM compile ping-pong).
 
-- **2026-06-09 (③ PR-4, §2 非proto multi fork)**: `vm_call_func_ops.rs::dispatch_func_call_inner` の
-  非proto multi fork（`has_multi_candidates && !has_proto`）を、PR-2 の builtin-shadow 型と同様に
-  `resolve_function_with_types`（②で VM アクセス可能）で winner を解決 →`def_is_otf_compilable` かつ非state body なら
-  `compile_and_call_function_def` で OTF compile/bytecode 実行に。**関数パスの ambiguity は `None`+`pending_dispatch_error`
-  で表現される**（`dispatch.rs` choose_best_matching_candidate）ため `Some(def)` = unambiguous winner（メソッド側の
-  `dispatch_ambiguous` フラグとは別機構）。resolve 前に stale `pending_dispatch_error` を `take` でクリア（interpreter の
-  `resolve_function_with_alias` と同じ作法）。ambiguity/where/default/code-param/no-match/proto/末端は従来どおり
-  `call_function_fallback`（正規の `X::Multi::Ambiguous`/`X::Multi::NoMatch` を投げる）。**nextsame/callsame/callwith は
-  compiled 候補からでも正しく機能**（`compile_and_call_function_def` が interpreter と同じ `push_multi_dispatch_frame` を
-  張るため。実測で確認＝redispatch 除外は不要だった）。**2 つの落とし穴を対処**: ① **otf_call_cache の name 汚染** —
-  `compile_and_call_function_def` の name-cache insert を `!has_multi_candidates_cached` で条件化＋lookup 側にも同ガード
-  （type-blind な name cache が `f(5)`→Int 候補を後続 `f("hi")` に誤再利用するのを防止。fingerprint キーの
-  `otf_compile_cache` は per-候補で安全なので維持）。② **signature alternates の共有 state**（`(A)|(B){ state $x }` が
-  compile 時 state_group で 1 セル共有するが、OTF は body fingerprint＝per-alternate-sig キーで別 state になる）→
-  **state 宣言を含む multi body は OTF 除外**（新ヘルパ `function_body_declares_state` 再帰スキャン。`t/multi-signature-alternates.t`
-  回帰を発見・修正）。slip 経路（`exec_call_func_slip_op`）の multi は **既存の別バグで `|ms()` が Nil を返す**ため
-  本 PR では対象外（follow-up）。**③ 既存 flaky バグも修正**: `push_multi_dispatch_frame`（`accessors.rs`）が
-  callsame/nextsame の「remaining 候補」frame の current を `resolve_all_matching_candidates().first()`＝**HashMap 順
-  first match**で決めていたため、最狭候補が後宣言だと callsame が誤候補（or 同一候補）へ再ディスパッチし、
-  プロセスのハッシュシードで ~50% flake（`roast/S06-advanced/callsame.t` 等 whitelist が間欠 fail。CI #2788 の
-  失敗の実体）。**interpreter の inline frame と同じ決定的 winner（`resolve_function_with_alias`）で current を特定**する
-  よう修正（全 VM 経路 = Path A / otf cache / compile_and_call を一括で決定化）。これで callsame は OTF 候補からでも
-  正しく動くため redispatch 除外は不要に。pin `t/multi-otf-dispatch.t`(25, callsame-when-winner-declared-last 含む)。
-  実測 multi-probe で fallback 5→2（残2=nextsame/callsame builtin 自体）。S06/S12/S14 whitelist 全緑（10x 決定的）、
-  make test PASS。**教訓: 「自分の PR の CI fail」が既存 flaky の顕在化のこともある — シード依存の非決定性を実測で確定せよ。**
-  **さらに回帰を1件発見・修正（PR-2 の轍）**: multi fork が **native Test ルーチン**（is-eqv/is-deeply 等。Rust 実装だが
-  multi stub が registry に登録されている）を OTF compile し、native handler を迂回して `S16-io/words.t`・`S32-io/slurp.t` を
-  決定的に破壊（is-eqv 経由）。非-builtin OTF パスと同じ `!is_interpreter_handled_function(name)` ガードを multi fork にも
-  追加して解消（is-eqv は call_function_fallback → native test handler へ正しく回る）。ローカル full make roast PASS で確認。
+- **2026-06-09 (③ PR-4, §2 non-proto multi fork)**: for the non-proto multi fork of `vm_call_func_ops.rs::dispatch_func_call_inner`
+  (`has_multi_candidates && !has_proto`), like PR-2's builtin-shadow style: resolve the winner via
+  `resolve_function_with_types` (VM-accessible thanks to ②) → if `def_is_otf_compilable` and the body is non-state,
+  OTF compile / bytecode-execute via `compile_and_call_function_def`. **On the function path, ambiguity is expressed as `None`+`pending_dispatch_error`**
+  (`dispatch.rs` choose_best_matching_candidate), so `Some(def)` = unambiguous winner (a separate mechanism from the method side's
+  `dispatch_ambiguous` flag). A stale `pending_dispatch_error` is cleared with `take` before resolving (same etiquette as the interpreter's
+  `resolve_function_with_alias`). ambiguity/where/default/code-param/no-match/proto/terminal go through
+  `call_function_fallback` as before (throwing the canonical `X::Multi::Ambiguous`/`X::Multi::NoMatch`). **nextsame/callsame/callwith work correctly
+  even from compiled candidates** (because `compile_and_call_function_def` pushes the same `push_multi_dispatch_frame` as the interpreter;
+  confirmed by measurement = excluding redispatch was unnecessary). **Handled 2 pitfalls**: ① **name pollution of otf_call_cache** —
+  conditioned the name-cache insert of `compile_and_call_function_def` on `!has_multi_candidates_cached`, plus the same guard on the lookup side
+  (prevents the type-blind name cache from wrongly reusing `f(5)`→Int candidate for a subsequent `f("hi")`. The fingerprint-keyed
+  `otf_compile_cache` is per-candidate and safe, so it stays). ② **shared state of signature alternates** (`(A)|(B){ state $x }` shares
+  one cell via state_group at compile time, but OTF's body fingerprint = per-alternate-sig key would give separate states) →
+  **multi bodies containing state declarations are excluded from OTF** (new helper `function_body_declares_state` recursive scan. Found and fixed
+  the `t/multi-signature-alternates.t` regression). The slip path (`exec_call_func_slip_op`) multis are out of scope for this PR because
+  **an existing separate bug makes `|ms()` return Nil** (follow-up). **③ Also fixed an existing flaky bug**: `push_multi_dispatch_frame`
+  (`accessors.rs`) determined the current of the callsame/nextsame "remaining candidates" frame via `resolve_all_matching_candidates().first()` =
+  **HashMap-order first match**, so when the narrowest candidate was declared later, callsame redispatched to the wrong (or same) candidate,
+  flaking ~50% depending on the process hash seed (whitelisted files like `roast/S06-advanced/callsame.t` failed intermittently; the substance of the
+  CI #2788 failure). Fixed to **determine current with the same deterministic winner as the interpreter's inline frame (`resolve_function_with_alias`)**
+  (deterministic across all VM paths = Path A / otf cache / compile_and_call at once). callsame now works correctly even from OTF candidates,
+  so the redispatch exclusion became unnecessary. pin `t/multi-otf-dispatch.t`(25, including callsame-when-winner-declared-last).
+  Measured multi-probe fallback 5→2 (remaining 2 = the nextsame/callsame builtins themselves). S06/S12/S14 whitelist all green (10x deterministic),
+  make test PASS. **Lesson: "my PR's CI failure" can be an existing flake surfacing — pin down seed-dependent nondeterminism by measurement.**
+  **Also found and fixed 1 more regression (PR-2's rut)**: the multi fork OTF-compiled **native Test routines** (is-eqv/is-deeply etc. — Rust implementations,
+  but a multi stub is registered in the registry), bypassing the native handler and deterministically breaking `S16-io/words.t` and `S32-io/slurp.t`
+  (via is-eqv). Resolved by adding the same `!is_interpreter_handled_function(name)` guard as the non-builtin OTF path to the multi fork
+  (is-eqv correctly routes to call_function_fallback → the native test handler). Confirmed via local full make roast PASS.
 
-- **2026-06-09 (③ PR-5, §1 catch-all = plain `@`-array mutators の VM ネイティブ化)**: `MUTSU_VM_STATS` に
-  catch-all 受け手の型名（`Class.method`）を一時計測する計装を入れ、whitelist sample 全体で **catch-all 到達集合を実測**。
-  PR-3 が「残りは native/Buf/Failure」と推定していたが、**実態は Buf/Failure ではなく配列ミューテータ + iterator protocol + coercion**
-  だった（top: `Package.new`=38698〔③コンストラクタ・user BUILD/属性で③ブロック〕, `Array.append`=16721, `Array.shift`=5796,
-  `Any.AT-POS`=5795, iterator `pull-one`/`skip-one`/`push-exactly` 系, `Array.splice`=381, `List.Set/Bag/Mix` coercion …）。
-  `Package.new` を除く**最大の tractable カテゴリ＝配列ミューテータ**（append+shift+splice ≈ 22900）。本 PR は
-  `vm_call_method_mut_ops.rs::exec_call_method_mut_op` に `try_native_array_mut` を追加し、**plain untyped `@`-array
-  （`ArrayKind::Array`）への `append`/`prepend`/`unshift`/`pop`/`shift`** を VM ネイティブに（`env.get_mut` + `Arc::make_mut`
-  で interpreter の primary branch と同一セマンティクス、empty pop/shift は `make_empty_array_failure_what(..,"Array")`）。
-  **保守的フォールスルー**: typed（`var_type_constraint` Some）/ shaped / lazy（kind が `Array` 以外）/ shared
-  （`shared_vars_active`）/ metadata 持ち（`container_type_metadata` Some）/ 非env-bound receiver は interpreter 維持。
-  **落とし穴: type_metadata の Arc-ptr keying aliasing**（🟣第一級コンテナの既知ハザード）— `make_mut` 再確保で得た新 Arc
-  ポインタが、解放済み typed array の stale `array_type_metadata` エントリと衝突し untyped 配列が `Array[Int]` に誤型付け
-  （フルファイル文脈でのみ・アロケータ依存で間欠再現）。native path は untyped を保証済みなので、変異後の env 配列に対し
-  `unregister_container_type_metadata` で防御的に stale エントリを除去（安全＝生きた別配列が同ポインタを持つことは不可能）。
-  pin `t/native-array-mut.t`(31, aliasing ケース含む)。S32-array whitelist 全緑、make test PASS、array 系 whitelist 156/156。
-  **残る catch-all**: `Package.new`〔③〕, `Any.AT-POS`/iterator protocol〔値型/iterator state〕, coercion〔builtins 降ろし候補〕, splice。
+- **2026-06-09 (③ PR-5, §1 catch-all = making plain `@`-array mutators VM-native)**: added temporary instrumentation to `MUTSU_VM_STATS` recording the
+  catch-all receiver type names (`Class.method`), and **measured the catch-all reach set** over the whole whitelist sample.
+  PR-3 had estimated "the remainder is native/Buf/Failure", but **the reality was not Buf/Failure but array mutators + iterator protocol + coercion**
+  (top: `Package.new`=38698 [③ constructor; ③-blocked by user BUILD/attributes], `Array.append`=16721, `Array.shift`=5796,
+  `Any.AT-POS`=5795, iterator `pull-one`/`skip-one`/`push-exactly` family, `Array.splice`=381, `List.Set/Bag/Mix` coercion …).
+  Excluding `Package.new`, **the largest tractable category = array mutators** (append+shift+splice ≈ 22900). This PR adds
+  `try_native_array_mut` to `vm_call_method_mut_ops.rs::exec_call_method_mut_op`, making **`append`/`prepend`/`unshift`/`pop`/`shift` on plain
+  untyped `@`-arrays (`ArrayKind::Array`)** VM-native (`env.get_mut` + `Arc::make_mut`, identical semantics to the interpreter's primary branch;
+  empty pop/shift uses `make_empty_array_failure_what(..,"Array")`).
+  **Conservative fallthrough**: typed (`var_type_constraint` Some) / shaped / lazy (kind other than `Array`) / shared
+  (`shared_vars_active`) / metadata-bearing (`container_type_metadata` Some) / non-env-bound receivers stay on the interpreter.
+  **Pitfall: Arc-ptr keying aliasing of type_metadata** (🟣 a known first-class-container hazard) — a new Arc pointer obtained by a `make_mut` reallocation
+  collided with a stale `array_type_metadata` entry of a freed typed array, mis-typing an untyped array as `Array[Int]`
+  (reproduced only in full-file context, intermittently, allocator-dependent). Since the native path guarantees untyped, we defensively remove
+  the stale entry via `unregister_container_type_metadata` on the post-mutation env array (safe = no live other array can hold the same pointer).
+  pin `t/native-array-mut.t`(31, including the aliasing case). S32-array whitelist all green, make test PASS, array-related whitelist 156/156.
+  **Remaining catch-all**: `Package.new` [③], `Any.AT-POS`/iterator protocol [value types/iterator state], coercion [candidate for lowering to builtins], splice.
 
-- **2026-06-09 (③ PR-6, §2 catch-all 末端の実測 + junction constructor の builtins 降ろし)**: `vm_call_dispatch.rs:79`
-  の `call_function_compiled_first` 末端（`call_function` final else）に `END:` プレフィックス計装を入れ、whitelist sample
-  全体で**末端到達集合を実測**。結論: **末端はほぼ枯渇**（PR-1〜4 ＋ line 63-67 の「resolve できた def は全て OTF compile」
-  により、ユーザー関数はもう末端に来ない）。sample 全体で末端到達は diffuse で少量、内訳は ①`any`/`all`/`one`/`none`
-  junction constructor（pure builtin・本 PR で降ろし）, ②**lexical `&`-変数の名前経由呼び出し**（末端残余の*最大*カテゴリ。
-  `-> &op { … op(…) }` ＝S03-operators/set_*.t の `END:op`〔各348等〕で集合演算子 Callable をパラメータ束縛して呼ぶ、
-  および `my &junction = ::("&any"); junction(|$_)` ＝S03-junctions/autothreading.t の `END:junction=56`。束縛された Callable
-  〔user sub / 演算子 / builtin Routine〕を bareword 名で呼ぶため末端で lexical 解決＝正しく動作。将来スライス: VM 側で
-  lexical `&`-var 束縛を検出し既存 Routine/compiled dispatch へ寄せる）, ③`__mutsu_*` 内部（CAS 等・並行は lever B）,
-  ④no-match エラー生成（`notthere`＝末端で正規例外を投げるのが正しい）。
-  **高トラフィックの builtin は末端に残っていない**（`split`/`index`/`comb` 等は既に native か、他4サイト〔vm_call_func_ops〕
-  経由で Instance-guard fallback）。本 PR は唯一の pure-builtin カテゴリ＝**junction constructor を `builtins/functions.rs::build_junction`
-  へ降ろし**（one-arg flatten rule 込み・state 不使用）、`native_function` で any/all/one/none を全 arity ルート、interpreter の
-  `builtin_junction` も同 fn へ委譲して**重複実装を解消**（[[feedback_dedup_over_perf]]/[[feedback_placement_audit]]）。
-  junction 構築は型非依存で安全なので `try_native_function` の Instance-arg ガードを any/all/one/none に限り bypass
-  （`any($instance)` も native）。pin `t/native-junction-ctor.t`(24, Instance-arg 含む)。S03-junctions whitelist 全緑、make test PASS。
-  **結論: §2 末端は「高トラフィック撲滅」フェーズを終えた。残る最大カテゴリは lexical `&`-var の名前呼び出し（正しく動作・将来 VM 寄せ候補）、
-  他は③ state 所有〔並行 CAS〕/ エラー生成 carrier。**
+- **2026-06-09 (③ PR-6, §2 measuring the catch-all terminal + lowering the junction constructors to builtins)**: added `END:`-prefixed instrumentation to the
+  `call_function_compiled_first` terminal (`call_function` final else) at `vm_call_dispatch.rs:79` and **measured the terminal reach set** over the whole
+  whitelist sample. Conclusion: **the terminal is nearly exhausted** (thanks to PR-1..4 plus lines 63-67's "every resolvable def gets OTF-compiled",
+  user functions no longer reach the terminal). Across the sample, terminal reach is diffuse and small; the breakdown: ① the `any`/`all`/`one`/`none`
+  junction constructors (pure builtins; lowered in this PR), ② **name-based calls of lexical `&`-variables** (the *largest* terminal-residual category.
+  `-> &op { … op(…) }` = S03-operators/set_*.t's `END:op` [348 each etc.] binding set-operator Callables as parameters and calling them,
+  and `my &junction = ::("&any"); junction(|$_)` = S03-junctions/autothreading.t's `END:junction=56`. Since the bound Callable
+  [user sub / operator / builtin Routine] is called by bareword name, lexical resolution at the terminal = works correctly. Future slice: detect
+  lexical `&`-var bindings on the VM side and route to the existing Routine/compiled dispatch), ③ `__mutsu_*` internals (CAS etc.; concurrency is lever B),
+  ④ no-match error generation (`notthere` = throwing the canonical exception at the terminal is correct).
+  **No high-traffic builtins remain at the terminal** (`split`/`index`/`comb` etc. are already native or take the Instance-guard fallback via the other
+  4 sites [vm_call_func_ops]). This PR lowers the only pure-builtin category = **junction constructors into `builtins/functions.rs::build_junction`**
+  (including the one-arg flatten rule; no state used), routes any/all/one/none at all arities through `native_function`, and delegates the interpreter's
+  `builtin_junction` to the same fn, **resolving the duplicate implementation** ([[feedback_dedup_over_perf]]/[[feedback_placement_audit]]).
+  Junction construction is type-independent and safe, so the Instance-arg guard of `try_native_function` is bypassed for any/all/one/none only
+  (`any($instance)` is native too). pin `t/native-junction-ctor.t`(24, including Instance-arg). S03-junctions whitelist all green, make test PASS.
+  **Conclusion: the §2 terminal has finished its "high-traffic elimination" phase. The largest remaining category is name-based calls of lexical `&`-vars (works correctly; future candidate for moving into the VM);
+  the rest is ③ state ownership [concurrent CAS] / error-generation carrier.**
 
-- **2026-06-09 (③ PR-7, §1 catch-all = mutable Buf write methods の VM ネイティブ化 + builtins 降ろし)**: PR-5 と同型で
-  `vm_call_method_mut_ops.rs::exec_call_method_mut_op` に `try_native_buf_mut` を追加し、**mutable `Buf` インスタンスへの
-  `write-bits`/`write-ubits`/`write-num32|64`/`write-int8..128`/`write-uint8..128`** を VM ネイティブに（`overwrite_instance_bindings_by_identity`
-  ＋ `env.insert` ＝ interpreter の instance-mutate ブランチと同一 writeback。エイリアス〔同一 instance id を複数変数が保持〕も
-  正しく観測）。**保守的フォールスルー**: type-object 受け手（`buf8.write-...` は fresh buf を返す別経路）/ immutable `Blob`
-  （interpreter が "Cannot modify immutable Blob" を投げる）/ malformed arity・offset/bits parse 失敗は interpreter 維持＝
-  behavior-invariant。**dedup/placement（[[feedback_dedup_over_perf]]/[[feedback_placement_audit]]）**: 純粋バイト変換を
-  builtins へ一本化＝`src/builtins/buf_bits.rs` 新設（`read_bits`/`write_bits` を `impl Interpreter` から降ろし、methods_mut の
-  read-bits 重複も解消）＋ `buf_write_num.rs`/`buf_write_int.rs` を `runtime/` → `builtins/` へ移設（22 call-site path 更新）。
-  これで Buf バイナリ read/write 変換の authoritative home は `builtins/` に統一され、VM と interpreter が単一実装を共有。
-  実測: `read-write-bits.t` の write-bits/write-ubits fallback 3123→3（残3=type-object 形式）。pin `t/native-buf-mut.t`(23,
-  エイリアス/buf 伸長/Blob dies 含む)。S03-buf/S03-operators/S32-container/S02-types/signed-unsigned-native 全緑、cargo test 458/0。
-  （write-int.t は 128-bit 未対応の既知 pre-existing blocker＝非whitelist、本変更と無関係。）
+- **2026-06-09 (③ PR-7, §1 catch-all = making mutable Buf write methods VM-native + lowering to builtins)**: in the same shape as PR-5,
+  added `try_native_buf_mut` to `vm_call_method_mut_ops.rs::exec_call_method_mut_op`, making
+  **`write-bits`/`write-ubits`/`write-num32|64`/`write-int8..128`/`write-uint8..128` on mutable `Buf` instances** VM-native
+  (`overwrite_instance_bindings_by_identity` + `env.insert` = the same writeback as the interpreter's instance-mutate branch. Aliasing
+  [multiple variables holding the same instance id] is also observed correctly). **Conservative fallthrough**: type-object receivers
+  (`buf8.write-...` is a separate path returning a fresh buf) / immutable `Blob`
+  (the interpreter throws "Cannot modify immutable Blob") / malformed arity, offset/bits parse failures stay on the interpreter =
+  behavior-invariant. **dedup/placement ([[feedback_dedup_over_perf]]/[[feedback_placement_audit]])**: unified the pure byte transforms
+  into builtins = new `src/builtins/buf_bits.rs` (lowered `read_bits`/`write_bits` from `impl Interpreter`, also resolving the read-bits duplicate in
+  methods_mut) + moved `buf_write_num.rs`/`buf_write_int.rs` from `runtime/` → `builtins/` (22 call-site path updates).
+  The authoritative home of Buf binary read/write transforms is now unified under `builtins/`, and the VM and interpreter share a single implementation.
+  Measured: write-bits/write-ubits fallback of `read-write-bits.t` 3123→3 (remaining 3 = type-object form). pin `t/native-buf-mut.t`(23,
+  including aliasing / buf growth / Blob dies). S03-buf/S03-operators/S32-container/S02-types/signed-unsigned-native all green, cargo test 458/0.
+  (write-int.t is the known pre-existing 128-bit-unsupported blocker = non-whitelisted, unrelated to this change.)
 
-- **2026-06-09 (③ PR-8, §1 = QuantHash coercion の VM ネイティブ化 + builtins 降ろし)**: フォールバックの**広がり実測**
-  （whitelist 145 ファイル・distinct ファイル数）で `new`(63 files・③ ctor) に次ぐ tractable な pure カテゴリ＝
-  **`.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/`.MixHash`（~11 files）** を確認し着手。`vm_call_method_compiled.rs` の
-  catch-all 直前に `try_native_quanthash_coerce` を追加（PR-7/PR-5 と同位置＝ユーザーメソッド解決後なので shadow しない）。
-  **dedup/placement 降ろし**: `dispatch_to_set`/`dispatch_to_bag_with_what`/`dispatch_to_mix`（+ helpers `pair_weight`/
-  `mix_pair_weight`/`mix_add_item_with_keys`/nested `add_item`/`flatten_into`）を `impl Interpreter` の `&self` メソッド
-  （実体は self 非依存・相互再帰のみ）から **`src/builtins/quanthash_coerce.rs` の pure free fn** へ降ろし
-  （`to_set`/`to_bag`/`to_mix`）。interpreter の `dispatch_method_by_name_2` と `methods_dispatch_new`（mix_pair_weight）は
-  builtins へ委譲＝単一実装。`is_lazy_for_coerce`/`is_lazy_for_set_ops` は他 6 ファイルでも使うので runtime 据え置き
-  （`pub(crate)` 化して builtins から参照）。methods_collection.rs 961→315 行。**保守的フォールスルー**: `.MixHash`
-  （`register_container_type_metadata`＝interpreter 所有の型メタ登録が必要）/ Instance（`__baggy_data__`・user coercion）/
-  Package（型オブジェクト）受け手は interpreter 維持＝behavior-invariant。実測: set-op テストで Set/Bag/Mix fallback → 0。
-  pin `t/native-quanthash-coerce.t`(26)。whitelisted set/bag/mix 29 件全緑、cargo test 458/0。（set.t/bag.t の既知 fail は
-  BLOCKERS.md 記載の pre-existing〔bag.t 215=BigInt weight・252=Foo instance union, set.t 226=typed-hash bind〕で本変更と無関係。）
-  **次候補: iterator protocol（pull-one/skip-one/push-exactly）の VM ネイティブ化、または `AT-POS` native。本丸は `new`（③ ctor）。**
+- **2026-06-09 (③ PR-8, §1 = making QuantHash coercion VM-native + lowering to builtins)**: via **spread measurement of fallbacks**
+  (whitelist 145 files; distinct file counts), confirmed the next tractable pure category after `new` (63 files, ③ ctor) =
+  **`.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/`.MixHash` (~11 files)** and started on it. Added `try_native_quanthash_coerce` just before
+  the catch-all in `vm_call_method_compiled.rs` (same position as PR-7/PR-5 = after user-method resolution, so no shadowing).
+  **dedup/placement lowering**: lowered `dispatch_to_set`/`dispatch_to_bag_with_what`/`dispatch_to_mix` (+ helpers `pair_weight`/
+  `mix_pair_weight`/`mix_add_item_with_keys`/nested `add_item`/`flatten_into`) from `&self` methods of `impl Interpreter`
+  (actually self-independent; only mutually recursive) into **pure free fns in `src/builtins/quanthash_coerce.rs`**
+  (`to_set`/`to_bag`/`to_mix`). The interpreter's `dispatch_method_by_name_2` and `methods_dispatch_new` (mix_pair_weight)
+  delegate to builtins = single implementation. `is_lazy_for_coerce`/`is_lazy_for_set_ops` are used in 6 other files, so they stay in runtime
+  (made `pub(crate)` and referenced from builtins). methods_collection.rs 961→315 lines. **Conservative fallthrough**: `.MixHash`
+  (requires `register_container_type_metadata` = interpreter-owned type metadata registration) / Instance (`__baggy_data__`, user coercion) /
+  Package (type object) receivers stay on the interpreter = behavior-invariant. Measured: Set/Bag/Mix fallback in set-op tests → 0.
+  pin `t/native-quanthash-coerce.t`(26). All 29 whitelisted set/bag/mix files green, cargo test 458/0. (The known fails in set.t/bag.t are the
+  pre-existing ones listed in BLOCKERS.md [bag.t 215=BigInt weight, 252=Foo instance union, set.t 226=typed-hash bind], unrelated to this change.)
+  **Next candidates: making the iterator protocol (pull-one/skip-one/push-exactly) VM-native, or native `AT-POS`. The main prize is `new` (③ ctor).**
 
-- **2026-06-09 (③ PR-9, §1 = 単純 array-backed Iterator protocol の VM ネイティブ化)**: PR-8 の広がり実測で次点だった
-  iterator protocol（pull-one=2466/skip-one=2130 等、4-5 files・高カウント）を着手。`vm_call_method_mut_ops.rs` の
-  `try_native_buf_mut` の隣に `try_native_iterator` を追加し、**`items`(Array)+`index`(Int) 自己完結な `Iterator` インスタンス**への
-  `pull-one`/`skip-one`/`skip-at-least`/`skip-at-least-pull-one`/`sink-all` を VM ネイティブに（index 前進 →
-  `overwrite_instance_bindings_by_identity`(env) + `overwrite_instance_in_locals`(locals) で identity writeback＝interpreter の
-  mutating iterator dispatch と同一。エイリアス・sub ローカルスロットも正しく前進）。**重要な発見**: `$it.pull-one` は
-  **CallMethodMut にコンパイルされる**（`expr_method.rs:110` 変数受け手は全て CallMethodMut）＝当初 non-mut パスに置いて発火せず、
-  mut パスへ移して解決。**保守的フォールスルー**: squish iterator（`squish_source`＝ユーザー `as`/`with` コールバック）/ lazy
-  iterator（gather/coroutine＝`is_lazy` 属性、materialized items snapshot でなく interpreter コルーチン pull）/ push-*（外部
-  バッファ arg へ array-identity writeback が必要）/ count-only/bool-only（predictive 扱い）は interpreter 維持＝behavior-invariant。
-  **gather 回帰を1件発見・修正**: 初版が `is_lazy` 付き iterator も掴み `gather{...}.iterator.pull-one` が IterationEnd 即返し →
-  `is_lazy` 除外で解消（除外後は interpreter フォールスルー＝pre-existing 動作）。実測: List/Array/finite-Range iterator の pull-one
-  fallback → 0。pin `t/native-iterator.t`(18, エイリアス/sub ローカル/Range 含む)。S07-iterationbuffer/*-iterator 全緑、cargo test 458/0。
-  （gather.t の Failed:1 は BLOCKERS.md 記載の pre-existing take-rw〔test 38〕で本変更と無関係。）
-  **次候補: `AT-POS` native、coercion 以外の broad な §1、または本丸 `new`（③ ctor）の設計。**
+- **2026-06-09 (③ PR-9, §1 = making the simple array-backed Iterator protocol VM-native)**: started on the iterator protocol, the runner-up in PR-8's spread
+  measurement (pull-one=2466/skip-one=2130 etc., 4-5 files, high counts). Added `try_native_iterator` next to
+  `try_native_buf_mut` in `vm_call_method_mut_ops.rs`, making `pull-one`/`skip-one`/`skip-at-least`/`skip-at-least-pull-one`/`sink-all` on
+  **self-contained `Iterator` instances of `items`(Array)+`index`(Int)** VM-native (advance index →
+  identity writeback via `overwrite_instance_bindings_by_identity`(env) + `overwrite_instance_in_locals`(locals) = identical to the interpreter's
+  mutating iterator dispatch. Aliases and sub local slots also advance correctly). **Key discovery**: `$it.pull-one`
+  **compiles to CallMethodMut** (`expr_method.rs:110`: variable receivers are all CallMethodMut) = initially placed on the non-mut path it never fired;
+  moving it to the mut path resolved this. **Conservative fallthrough**: squish iterators (`squish_source` = user `as`/`with` callbacks) / lazy
+  iterators (gather/coroutine = `is_lazy` attribute; interpreter coroutine pull rather than a materialized items snapshot) / push-* (needs array-identity
+  writeback to an external buffer arg) / count-only/bool-only (treated as predictive) stay on the interpreter = behavior-invariant.
+  **Found and fixed 1 gather regression**: the first version also grabbed `is_lazy` iterators, making `gather{...}.iterator.pull-one` return IterationEnd immediately →
+  resolved with the `is_lazy` exclusion (after exclusion, interpreter fallthrough = pre-existing behavior). Measured: pull-one fallback of List/Array/finite-Range
+  iterators → 0. pin `t/native-iterator.t`(18, including aliases/sub locals/Range). S07-iterationbuffer/*-iterator all green, cargo test 458/0.
+  (gather.t's Failed:1 is the pre-existing take-rw [test 38] listed in BLOCKERS.md, unrelated to this change.)
+  **Next candidates: native `AT-POS`, broad §1 beyond coercion, or design of the main prize `new` (③ ctor).**
 
-- **2026-06-09 (③ PR-10, §1 catch-all = plain `@`-array `splice` の VM ネイティブ化)**: PR-5 の
-  `try_native_array_mut`（append/prepend/unshift/pop/shift）の姉妹として `vm_call_method_mut_ops.rs` に
-  `try_native_array_splice` を追加し、**plain untyped `@`-array（`ArrayKind::Array`）への `splice` の単純形**を VM
-  ネイティブに。interpreter の `methods_mut.rs` の `splice` 枝と同一の `drain`+`insert`（削除要素を `Value::real_array`
-  で返す）＋ `Arc::make_mut` writeback＋make_mut 再確保後の stale type-metadata 防御除去で behavior-invariant。
-  **保守的フォールスルー**（`None`→interpreter）: offset/count が plain 非負 `Int` 以外（WhateverCode/`Whatever`/
-  `Str`/`Num`）・offset 範囲外（`X::OutOfRange`）・count 負（`X::OutOfRange`）・lazy 置換（`X::Cannot::Lazy`）・
-  typed（`var_type_constraint` Some）/ shaped / shared（`shared_vars_active`）/ metadata 持ち配列。**実証**:
-  splice_check で 16 形全て raku 一致、`@j := @i` エイリアスは **interpreter splice 経路（WhateverCode offset で
-  fallthrough）も同じく `[1 2 3 4]`** ＝ pre-existing な container-identity ギャップ（🟣第一級コンテナ Phase 2）で
-  splice 固有でなく挙動不変。pin `t/native-array-splice.t`(28, 置換平坦化・末尾 splice・count クランプ・独立 removed
-  list・fallthrough X::OutOfRange/X::Cannot::Lazy 含む)。`S32-array/splice.t` の untyped 領域（最初60サブテスト）
-  not-ok ゼロ・push/pop/shift/unshift/S03-binding/arrays/S09-multidim/methods 全緑、cargo test 458/0、make test PASS。
-  （splice.t 全体は非whitelist の pre-existing fail＝`array[int]`/`array[int8]` typed-array メタデータ問題で、native
-  経路は typed array で必ず bail＝interpreter 維持のためカウント不変。）
+- **2026-06-09 (③ PR-10, §1 catch-all = making plain `@`-array `splice` VM-native)**: as a sister to PR-5's
+  `try_native_array_mut` (append/prepend/unshift/pop/shift), added `try_native_array_splice` to `vm_call_method_mut_ops.rs`,
+  making **the simple form of `splice` on plain untyped `@`-arrays (`ArrayKind::Array`)** VM-native.
+  Behavior-invariant with the same `drain`+`insert` as the `splice` branch of the interpreter's `methods_mut.rs` (returning removed elements via
+  `Value::real_array`) + `Arc::make_mut` writeback + defensive removal of stale type-metadata after make_mut reallocation.
+  **Conservative fallthrough** (`None`→interpreter): offset/count other than plain non-negative `Int` (WhateverCode/`Whatever`/
+  `Str`/`Num`), offset out of range (`X::OutOfRange`), negative count (`X::OutOfRange`), lazy replacement (`X::Cannot::Lazy`),
+  typed (`var_type_constraint` Some) / shaped / shared (`shared_vars_active`) / metadata-bearing arrays. **Verified**:
+  all 16 forms of splice_check match raku; the `@j := @i` alias case gives **`[1 2 3 4]` on the interpreter splice path too (fallthrough via
+  WhateverCode offset)** = a pre-existing container-identity gap (🟣 first-class containers Phase 2), not splice-specific, so behavior unchanged.
+  pin `t/native-array-splice.t`(28, including replacement flattening, tail splice, count clamping, independent removed
+  list, fallthrough X::OutOfRange/X::Cannot::Lazy). Zero not-oks in the untyped region of `S32-array/splice.t` (first 60 subtests);
+  push/pop/shift/unshift/S03-binding/arrays/S09-multidim/methods all green, cargo test 458/0, make test PASS.
+  (splice.t as a whole is a non-whitelisted pre-existing fail = the `array[int]`/`array[int8]` typed-array metadata problem; the native
+  path always bails on typed arrays = interpreter kept, so the count is unchanged.)
 
-- **2026-06-10 (③ PR-11, §1 = native default construction を typed `$` 属性へ拡張)**: §1 catch-all 最大カテゴリ
-  `Package.new`（コンストラクタ）の native 化範囲を拡張。`is_native_default_constructible`/`build_native_default_instance`
-  （`methods_object.rs`、VM の `try_compiled_method_or_interpret` と interpreter の `dispatch_new` が共有）が従来
-  **untyped `$` 属性のみ**だったのを、**simple class 制約付き `$` 属性**（`has Int $.x` 等）へ拡張。**保守的フォールスルー**で
-  divergence を全て interpreter に委ね behavior-invariant に保つ: ① 提供値が型不一致（`!type_matches_value`）→ None
-  （interpreter が `X::TypeCheck::Assignment`／coercion）、② arg も default も無い typed 属性 → None（未初期化 typed 属性は
-  **型オブジェクト**＝`Int` であり Nil でない。合成は interpreter）、③ typed default の値が型不一致 → None。ゲートは
-  **native/coercion/parametric 型を除外**（`is_simple_native_ctor_constraint`＝大文字始まり・`(` `[` なし）し、native
-  lowercase（`int`/`num`/`str`、default 0/""）は interpreter 維持。**重要な落とし穴を roast が捕捉**: 型制約の source of truth は
-  `ClassAttributeDef` tuple の制約スロットではなく `attribute_types` map（tuple 側は None）＝当初 tuple を読んで型チェックが
-  効かず `Int $.x = "str"` を受理する回帰 → `collect_attribute_type_constraints` 由来に修正。さらに **`is built` トレイト／MOP
-  `Attribute.set_build`**（カスタム build closure。`attribute_built` map ＋ registry `attribute_build_overrides`）を持つクラスは
-  pure-data 構築不可なのでゲートで除外（`S12-attributes/defaults.t` の set_build 実行時型チェック回帰を捕捉・修正）。
-  pin `t/native-ctor-typed-attrs.t`(30, 提供値/型オブジェクト未初期化/Str/Real/mixed/継承/相互参照 default/subset 型/
-  型不一致 dies/native int は interpreter/ループ構築)。S12/S14/S03-binding/roles whitelist 184 件全緑、cargo test 458/0。
-  **残: typed `@`/`%` 属性・required・where・coercion 型・native 型は依然 interpreter（本丸 ③ env 実行の手前で止める保守設計）。**
+- **2026-06-10 (③ PR-11, §1 = extending native default construction to typed `$` attributes)**: extending the native-construction coverage of the largest §1
+  catch-all category, `Package.new` (constructors). `is_native_default_constructible`/`build_native_default_instance`
+  (`methods_object.rs`; shared by the VM's `try_compiled_method_or_interpret` and the interpreter's `dispatch_new`), which previously covered
+  **only untyped `$` attributes**, was extended to **`$` attributes with simple class constraints** (`has Int $.x` etc.). All divergences are delegated
+  to the interpreter via **conservative fallthrough**, keeping it behavior-invariant: ① provided value fails the type check (`!type_matches_value`) → None
+  (interpreter does `X::TypeCheck::Assignment`/coercion), ② typed attribute with neither arg nor default → None (an uninitialized typed attribute is the
+  **type object** = `Int`, not Nil. Synthesis is left to the interpreter), ③ typed default value fails the type check → None. The gate
+  **excludes native/coercion/parametric types** (`is_simple_native_ctor_constraint` = starts uppercase, no `(` `[`); native
+  lowercase (`int`/`num`/`str`, defaults 0/"") stays on the interpreter. **An important pitfall caught by roast**: the source of truth for type constraints is
+  the `attribute_types` map, not the constraint slot of the `ClassAttributeDef` tuple (the tuple side is None) = reading the tuple initially meant the type check
+  didn't apply and `Int $.x = "str"` was accepted (regression) → fixed to derive from `collect_attribute_type_constraints`. In addition, classes with the
+  **`is built` trait / MOP `Attribute.set_build`** (custom build closures; the `attribute_built` map + registry `attribute_build_overrides`) cannot be
+  pure-data constructed, so they are excluded by the gate (caught and fixed the set_build runtime type-check regression in `S12-attributes/defaults.t`).
+  pin `t/native-ctor-typed-attrs.t`(30: provided values / type-object uninitialized / Str/Real/mixed / inheritance / mutually-referencing defaults / subset types /
+  type-mismatch dies / native int stays interpreter / loop construction). S12/S14/S03-binding/roles whitelist 184 files all green, cargo test 458/0.
+  **Remaining: typed `@`/`%` attributes, required, where, coercion types, native types still on the interpreter (a conservative design that stops short of the main prize, ③ env execution).**
 
-- **2026-06-10 (③ PR-12, §1 = native construction を untyped `@`/`%` 属性へ拡張)**: PR-11 の続きで native default
-  構築を **untyped `@`/`%`-sigil 属性**（`has @.items`/`has %.map`）へ拡張。**behavior-invariance の対象は raku ではなく
-  現 interpreter**（実測で `items => 5`→`5`〔scalar を wrap せず〕、typed `@.nums` の不正要素→NODIE〔構築時に要素型
-  チェックしない〕＝raku と異なる pre-existing 挙動）。interpreter 共有の `coerce_attr_value_by_sigil` を再利用するので
-  提供値 coercion（List/Range→Array, array-of-Pairs→Hash）が完全一致。未提供 default = 空 Array/Hash（型オブジェクト
-  合成不要＝`$` typed より単純）。**保守的フォールスルー**: typed 要素（`Int @.nums`＝container type metadata 登録が
-  必要・Arc-keying ハザード）/ `is Type` トレイト（`class_attribute_is_types`）/ **default_expr を持つ `@`/`%`**（shape は
-  default に encode＝`has @.a[2]`、提供有無に関わらず fallthrough）は interpreter 維持。**roast が shaped 落とし穴を捕捉**:
-  当初「default 持ち＋未提供」のみ fallthrough としたが、shaped `@.a[2]` が**提供された**場合 coerce で shape 喪失
-  （`S12-introspection/attributes.t` の `.a.shape`=(2,) 回帰）→「`@`/`%` が default_expr 持ちなら無条件 fallthrough」へ修正。
-  pin `t/native-ctor-array-attrs.t`(27, 空 default/list・array・range 提供/hash・pairs 提供/mixed typed-$/継承/defaulted
-  fallthrough/typed-element fallthrough/ループ構築)。S12/S14/binding/roles 184 件全緑、cargo test 458/0、make test PASS。
-  **残: typed `@`/`%`・`is Type`・shaped・required・where・coercion 型・native 型は依然 interpreter。**
+- **2026-06-10 (③ PR-12, §1 = extending native construction to untyped `@`/`%` attributes)**: continuing PR-11, extended native default
+  construction to **untyped `@`/`%`-sigil attributes** (`has @.items`/`has %.map`). **The target of behavior-invariance is the current interpreter,
+  not raku** (measured: `items => 5`→`5` [doesn't wrap the scalar]; invalid elements of typed `@.nums`→NODIE [no element type
+  check at construction] = pre-existing behavior differing from raku). Reuses the interpreter-shared `coerce_attr_value_by_sigil`, so
+  provided-value coercion (List/Range→Array, array-of-Pairs→Hash) matches exactly. Unprovided default = empty Array/Hash (no type-object
+  synthesis needed = simpler than typed `$`). **Conservative fallthrough**: typed elements (`Int @.nums` = requires container type metadata registration;
+  the Arc-keying hazard) / the `is Type` trait (`class_attribute_is_types`) / **`@`/`%` with a default_expr** (shape is
+  encoded in the default = `has @.a[2]`; falls through regardless of whether a value is provided) stay on the interpreter. **roast caught a shaped pitfall**:
+  initially only "has default + unprovided" fell through, but when a shaped `@.a[2]` **was provided**, coercion lost the shape
+  (regression of `.a.shape`=(2,) in `S12-introspection/attributes.t`) → fixed to "if `@`/`%` has a default_expr, fall through unconditionally".
+  pin `t/native-ctor-array-attrs.t`(27: empty default / list, array, range provided / hash, pairs provided / mixed typed-$ / inheritance / defaulted
+  fallthrough / typed-element fallthrough / loop construction). S12/S14/binding/roles 184 files all green, cargo test 458/0, make test PASS.
+  **Remaining: typed `@`/`%`, `is Type`, shaped, required, where, coercion types, native types still on the interpreter.**
 
-- **2026-06-10 (③ PR-13, §1 = native construction を `is required` 属性へ拡張)**: PR-11/12 の続きで native default
-  構築を **`is required` 属性**へ拡張（従来ゲートが `!is_required` で reject）。提供された required 属性は native 構築
-  （`$` typed は型チェック込み）、**未提供の required 属性は fallthrough**（interpreter が `X::Attribute::Required`）。
-  ゲートから `!is_required` を外し、build 先頭に「required かつ未 provided → None」検査を追加。**behavior-invariant**:
-  required `$` 未提供は interpreter が die（raku 一致）、required `@`/`%` 未提供は interpreter が **enforce しない**
-  （NODIE＝raku と異なる pre-existing ギャップだが native は fallthrough で interpreter 挙動に一致）。pin
-  `t/native-ctor-required-attrs.t`(14, 全 required 提供→build / 未提供 `$`→dies / 型不一致→dies / required `@`/`%`
-  提供→build / 継承 required)。S12/S14/binding/roles 184 件全緑、cargo test 458/0、make test PASS。
-  （pin 作成中に **連続 bare block `} { ` のパース不可**と **クラス名 `Q` のクォート演算子衝突**という 2 つの
-  pre-existing パーサ制約に遭遇＝テストをトップレベル構造＋非衝突名に変更して回避。本 slice とは無関係。）
-  **残: where・coercion 型・native 型・typed `@`/`%`・`is Type`・shaped は依然 interpreter。**
-- **2026-06-14 (③ ctor, §1 = native construction を定義性 smiley `:D`/`:U`/`:_` 属性へ拡張)**: TWEAK(#3028)/
-  where(#3030)/BUILD(#3032) に続く ctor slice。従来ゲートが `attribute_smileys.is_empty()` で reject していた
-  `has Int:D $.x` 等を native 構築。ゲートから smiley 検査を外し、build path で `enforce_attribute_smiley_constraints`
-  （full path と同一ヘルパ）を **where と同じ位置＝post-assembly/pre-BUILD で 1 回 + post-BUILD で再チェック**。
-  **interpreter baseline に厳密一致（raku ではなく）**: ① `:U` 提供 defined / `:D` 提供 undefined は die
-  （"default value of attribute" メッセージ＝interpreter の既存挙動。raku は "assignment to" だが本 slice の対象外の
-  pre-existing 差）、② **BUILD が smiley 違反 → die（post-BUILD 再チェック、full path 3929 に一致）**、
-  ③ **TWEAK が smiley 違反 → die しない**（interpreter は post-TWEAK で smiley を再チェックせず代入時チェックも
-  しないため、native も再チェックしない＝baseline 一致。raku は die）。bare `:D`（default 無し・required 無し）は
-  parse time に `X::Syntax::Variable::MissingInitializer` で弾かれ構築に到達しない。pin
-  `t/native-ctor-smiley-attrs.t`(21, `:D`/`:U`/`:_` × default/required/provided/継承/mixed/BUILD-dies/TWEAK-lives/
-  Str:D)。S12-attributes/smiley.t(54) + S12-class/attributes-required.t(11) 含む構築系 whitelist 118 件全緑、
-  cargo test 461/0、make test PASS。**残: coercion 型・native 型・typed `@`/`%`・`is Type`・shaped・同名再宣言・
-  does-Role 属性・CUnion・custom BUILDALL/new は依然 interpreter。**
+- **2026-06-10 (③ PR-13, §1 = extending native construction to `is required` attributes)**: continuing PR-11/12, extended native default
+  construction to **`is required` attributes** (the previous gate rejected with `!is_required`). Provided required attributes are built natively
+  (typed `$` with type check included); **unprovided required attributes fall through** (interpreter raises `X::Attribute::Required`).
+  Removed `!is_required` from the gate and added a "required and not provided → None" check at the start of build. **Behavior-invariant**:
+  unprovided required `$` dies in the interpreter (matches raku); unprovided required `@`/`%` is **not enforced** by the interpreter
+  (NODIE = a pre-existing gap differing from raku, but native falls through and matches interpreter behavior). pin
+  `t/native-ctor-required-attrs.t`(14: all required provided→build / unprovided `$`→dies / type mismatch→dies / required `@`/`%`
+  provided→build / inherited required). S12/S14/binding/roles 184 files all green, cargo test 458/0, make test PASS.
+  (While writing the pin, hit 2 pre-existing parser limitations: **consecutive bare blocks `} { ` unparseable** and **class name `Q` colliding with the quote operator**
+  = worked around by restructuring the test to top-level structure + non-colliding names. Unrelated to this slice.)
+  **Remaining: where, coercion types, native types, typed `@`/`%`, `is Type`, shaped still on the interpreter.**
+- **2026-06-14 (③ ctor, §1 = extending native construction to definedness smiley `:D`/`:U`/`:_` attributes)**: the ctor slice following TWEAK(#3028)/
+  where(#3030)/BUILD(#3032). Attributes like `has Int:D $.x`, previously rejected by the gate's `attribute_smileys.is_empty()`, are now built natively.
+  Removed the smiley check from the gate; on the build path, `enforce_attribute_smiley_constraints`
+  (the same helper as the full path) runs **at the same position as where = once post-assembly/pre-BUILD + a recheck post-BUILD**.
+  **Strictly matches the interpreter baseline (not raku)**: ① `:U` provided defined / `:D` provided undefined dies
+  (the "default value of attribute" message = the interpreter's existing behavior. raku says "assignment to", but that pre-existing difference is out of
+  scope for this slice), ② **BUILD violating the smiley → dies (post-BUILD recheck, matching full path 3929)**,
+  ③ **TWEAK violating the smiley → does not die** (the interpreter does not recheck smileys post-TWEAK nor check on assignment,
+  so native does not recheck either = baseline match. raku dies). A bare `:D` (no default, no required) is rejected at
+  parse time with `X::Syntax::Variable::MissingInitializer` and never reaches construction. pin
+  `t/native-ctor-smiley-attrs.t`(21: `:D`/`:U`/`:_` × default/required/provided/inheritance/mixed/BUILD-dies/TWEAK-lives/
+  Str:D). Construction-related whitelist 118 files all green including S12-attributes/smiley.t(54) + S12-class/attributes-required.t(11),
+  cargo test 461/0, make test PASS. **Remaining: coercion types, native types, typed `@`/`%`, `is Type`, shaped, same-name redeclaration,
+  does-Role attributes, CUnion, custom BUILDALL/new still on the interpreter.**
 
-- **2026-06-14 (③ ctor 第2波 = post-assembly フェーズ方式, #3028〜3036)**: 「pure-data only」原則を破り、pure-data
-  組み立て後に **submethod 実行 / 制約検証 / role mixin を post-assembly フェーズ**として走らせて user-code-running shape も
-  native 化。`.new` 本経路の各フェーズを共有ヘルパに抽出（`run_tweak_phase`/`run_build_phase`/`enforce_attribute_where_constraints`/
-  `apply_attribute_does_role_mixins`）し interpreter/native 両方から呼んで byte-identical 保証。**TWEAK(#3028)**（`TWEAK(:$y)`
-  引数渡し＝コンストラクタ2系統で扱い違い）→ **where(#3030)**（TWEAK 前後両方で enforce＝assignment-time セマンティクス）→
-  **BUILD(#3032)**（`fail`→Failure / カスタム BUILD で named-arg 自動代入抑制 / positional 拒否＝`S.new("pos")` pre-existing バグ
-  も修正）→ **is-rw(#3034)**（`ClassAttributeDef` pos3=is_rw を is_required と誤読していたバグ修正、未提供 is-rw が native 化＋
-  `@`/`%` required 強制も正しく）→ **does-Role(#3036)**（role を属性値に mixin、raku 非準拠の文書化済み近似なので native==interpreter
-  で検証）。各 pin テスト（`t/native-{tweak,where,build,isrw,doesrole}-construct.t`）。S12/S14 whitelist 全緑、make test PASS。
-  **★再計測（重要）**: ctor 5スライス後も whitelist sample の `new` method fallback はほぼ不変（5230→5225）。**大半（4686）は
-  単一テスト `S03-buf/read-write-bits.t` の `Buf.new`＝組み込み型コンストラクタ**（`is_native_default_constructible` は user 定義
-  `registry().classes` のみ対象なので正しく対象外）。**＝ユーザークラス ctor native 化は完遂。これ以上 ctor を削っても `new`
-  fallback 数は動かない。** 次の実質ターゲットは別カテゴリ: **組み込み型 `.new`**（Buf.new 等）/ **`name`=3257（MOP）** /
-  **`op`=1418（Routine 値 lexical &-var `&infix:<(|)>` 束縛、今回の Sub/WeakSub 限定 fix の除外分）** / iterator push-* protocol
-  （Track B）/ coercion（builtins 降ろし）。残る ctor 難ケース: required-after-BUILD / 未設定 class-typed + BUILD / `is built`/
-  MOP set_build / BUILDALL / custom new / CUnion。
-- **2026-06-23 (§1 = `.MixHash` coercion の VM ネイティブ化)**: §D（状態所有）の実測駆動スライス。`MUTSU_VM_STATS` で
-  catch-all の支配カテゴリを計測したところ、PR-8 が **明示的に除外**していた `.MixHash`（QuantHash coercion の唯一の
-  残り）が最頻だった。PR-8 の除外理由は「`.MixHash` は container type metadata を登録＝interpreter 所有 state」だったが、
-  **これは #2952〜2985 のコンテナ値メタ埋め込み化で stale**＝`.MixHash` が生む `Value::Mix` の型メタ（`value_type=Real`/
-  `declared_type=MixHash`）は **interpreter 副テーブルでなく Mix の `Arc<MixData>` に埋め込まれる**（`tag_container_metadata`
-  の `embed_type_info!` 経路。副テーブル `register_container_type_metadata` を踏むのは Instance 等の `other =>` 枝のみ）。
-  ∴ `.MixHash` は env/state を一切触らない pure value op で、`.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash` と同型に native 化可能。
-  新 pure fn `builtins::quanthash_coerce::to_mixhash`（`to_mix(_, "MixHash")` → mutable flip + メタ埋め込み）を VM の
-  `try_native_quanthash_coerce` に追加（method match に `"MixHash"` 追加）。**dedup**: interpreter の `dispatch_method_by_name_2`
-  の `Mix|MixHash` 分岐を `to_mixhash` 委譲へ（`tag_container_metadata` 直書きを撤去）＝**1 操作 = 1 実装**。受け手ゲートは
-  既存 5 兄弟と同一（list-like のみ native、Instance/Package は interpreter 維持）。変数受け手（`%h.MixHash`）は
-  `CallMethodMut` ルーティングで mut パスに行き 6 兄弟全て一律 fallback＝**既存挙動と完全 parity**（将来 mut パスへ
-  まとめて降ろす別スライス候補）。挙動不変（native==interpreter＝同一 `to_mixhash`）。pin `t/native-mixhash-coerce.t`(22,
-  raku/mutsu 双方 PASS・Str 要素で `.WHICH` キー差を回避)。mix.t 244/244・set.t・categorize 緑。
-  （bag.t 625 "Foo instance union" は BLOCKERS.md 記載の pre-existing で本変更と無関係。）
-- **2026-06-23 (§1 = QuantHash coercion を mut パスでも VM ネイティブ化)**: 上記 MixHash slice の follow-up。**変数受け手**
-  （`@a.Set`/`%h.MixHash`）は `CallMethodMut` にコンパイルされ非mut パスの `try_native_quanthash_coerce` を踏まず、
-  6 兄弟（`.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/`.MixHash`）が一律 mut catch-all で interpreter fallback していた
-  （MixHash slice の「parity」注記参照）。`vm_call_method_compiled.rs` の **mut catch-all**（`try_compiled_method_mut_or_interpret`
-  末尾・`try_native_first` の後）に同じ `Self::try_native_quanthash_coerce` を追加。coercion は**新しい** Set/Bag/Mix 値を返し
-  受け手変数を変異させない（writeback 不要）ので非mut パスと完全同型＝挙動不変。Instance/Package 受け手は fall through。
-  実測: `@a.{Set,Bag,Mix,SetHash,BagHash,MixHash}` の fallback 6→0（残 `^name` は MOP）。pin
-  `t/native-quanthash-coerce-mut-path.t`(19, raku/mutsu 双方 PASS)。mix.t 244/244・set.t・categorize 緑。
-  （bag.t 252 / classify.t 40〔junction classify・非whitelist〕は stash 確認で main でも fail＝pre-existing・本変更と無関係。）
-- **2026-06-23 (§1 = `.Map`/`.Hash` coercion の VM ネイティブ化 + builtins 降ろし)**: QuantHash coercion と同型の続き。
-  `.Map`/`.Hash` は **pure value op**（`dispatch_to_hash_impl`/`dispatch_to_map` は完全に `&self` 非依存＝env/registry/
-  state を触らず `Self::` 静的ヘルパー + `super::utils::` のみ・`.Map` の declared-type は `Value::Hash` の `Arc<HashData>`
-  に埋め込まれ #2952 以降副テーブル不使用）。**dedup 降ろし**: `dispatch_to_hash_impl`/`dispatch_to_map`/`items_to_hash`/
-  `make_odd_number_error` を新 `src/builtins/map_hash_coerce.rs`（pure free fn `to_hash(target, check_odd)`/`to_map(target)`）
-  へ移設。interpreter の `dispatch_to_hash` は委譲、`dispatch_to_map` は撤去（`dispatch_method_by_name_2` の `Map|Hash`
-  分岐が `to_map`/`to_hash` を直接呼び `tag_container_metadata` 直書きも撤去）＝**1 操作 = 1 実装**。VM に
-  `try_native_map_hash_coerce`（非mut + mut 両 catch-all）。受け手ゲートは list-like / Hash / QuantHash のみ native、
-  Instance（Match の named captures / `__baggy_data__`）/ Package（型オブジェクト）/ lowercase `.hash` は interpreter 維持。
-  挙動不変（`to_map` は embed して identity 保持＝`Map.Map === Map`、odd-count は `X::Hash::Store::OddNumber`）。pin
-  `t/native-map-hash-coerce.t`(21, raku/mutsu 双方 PASS)。mix.t 244/244・set.t・hash.t・categorize・classify-list 緑。
-- **2026-06-23 (§1 = `.Seq` coercion の structural 分岐を VM ネイティブ化)**: coercion drainage の締め。`.Seq` は
-  `dispatch_seq_coercion`（`&mut self`）だが **structural 分岐（Seq/Array/Slip/Range/bare scalar）は pure**、
-  Supply（on-demand callback 駆動）/ LazyList（lazy bridge force）/ Instance（Buf/Blob byte 読み・generic wrap）のみ
-  carrier/state 依存。pure 分岐を新 `src/builtins/seq_coerce.rs::to_seq_structural(target) -> Option<Value>` へ抽出
-  （Supply/LazyList/**全 Instance** は `None` で interpreter へ）。interpreter の `dispatch_seq_coercion` は冒頭で委譲、
-  VM は非mut + mut 両 catch-all で `method == "Seq"` 時に呼ぶ＝**1 操作 = 1 実装**。gather/lazy の `.Seq` は引き続き
-  interpreter carrier で正しく drain。pin `t/native-seq-coerce.t`(16, raku/mutsu 双方 PASS)。S32-list/seq.t・S17-supply/Seq.t・
-  integration/sequence.t 緑。**これで pure-coercion fallback カテゴリ（Set/Bag/Mix/MixHash/Map/Hash/List/Array/Slip/Seq）は
-  実測ドレイン完了**＝残る coercion fallback は `.Setty`/`.Baggy`/`.Mixy`（型オブジェクト返し・niche）のみ。
-- **2026-06-23 (§D = 純 lexical `IO::Path` メソッドの VM ネイティブ化)**: coercion ドレイン後の実測駆動スライス。
-  `MUTSU_VM_STATS` の **広がり計測（distinct ファイル数）** で method-fallback の最大カテゴリが `parent`(66 file)/
-  `add`(65 file)＝temp-file/dir ヘルパー（`make-temp-dir`/`make-temp-file`）経由で 60+ ファイルに分散する **IO::Path の
-  パス操作メソッド**と判明（カウント最大の `AT-POS`=5816 は単一 `read-int.t` の Buf 受け手に集中＝広がり 7 file のみで不適）。
-  `IO::Path` の `native_io_path`（`&mut self`・FS/cwd 依存）のうち **パス文字列だけを操作する純 lexical メソッド**
-  （`parent`/`add`/`child`(非secure)/`sibling`/`basename`/`dirname`/`volume`/`cleanup`/`parts`/`extension`/`succ`/`pred`/
-  `starts-with`/`is-absolute`/`is-relative`/`Str`/`gist`/`IO`/`SPEC`）を新 associated fn `Interpreter::try_io_path_lexical`
-  （`&self` 不要＝FS/cwd/env を一切触らない・static `Self::io_path_*` ヘルパーのみ使用）へ抽出。**dedup**: `native_io_path`
-  は冒頭でこれに委譲し移動済み arm を削除＝**1 操作 = 1 実装**（`child`/`add` の join は共有ヘルパー `io_path_join_child`
-  に切り出し、`child :secure` の FS-resolve のみ `native_io_path` に残す）。VM は **非mut + mut 両方**の `is_native_method`
-  バウンス**直前**で `Self::is_io_path_lexical_class`（組込 `IO::Path`/`::Unix`/`::Win32`/`::Cygwin`/`::QNX` 限定）＋
-  `try_io_path_lexical` を呼ぶ（fallback 記録は `is_native_method` バウンス〔vm_call_method_compiled.rs:201/1652〕で起きていた
-  ため catch-all でなくここに配置）。coercion 同様 **新しい IO::Path/string/bool を返し受け手を変異しない**＝writeback 不要。
-  FS/cwd 依存（`e`/`f`/`slurp`/`spurt`/`absolute`/`relative`/`resolve`/`CWD`/`raku`）と numeric coercion・`child :secure` は
-  `None` で interpreter 維持＝behavior-invariant。実測: `$p.{parent,add,basename,dirname,sibling,…}` の fallback → 0
-  （残るのは `Str.IO` coercion〔別操作・Str 受け手〕と `IO::Path::*.new`〔③ ctor〕）。pin `t/native-io-path-lexical.t`(40,
-  literal `.IO` + 変数受け手〔mut path〕+ Win32 subclass round-trip・raku/mutsu 双方 PASS)。io-path.t の既存 fail 2
-  （`.SPEC`/`.CWD` attribute）は main でも fail＝本変更と無関係。S16-io/S32-io/tmpdir/cwd/dir whitelist 全緑。
-- **2026-06-23 (§D = Cool scalar `.IO` coercion の VM ネイティブ化)**: IO::Path lexical スライス（上）の follow-up。
-  実測広がりで次点だった `.IO`(14 file・`"path".IO`/`$s.IO`/`42.IO`)＝Str/numeric を IO::Path へ coerce する fallback を
-  ドレイン。`.IO` は `dispatch_method_by_name` の arm（`make_io_path_instance(target.to_string_value())`＋null-byte check、
-  IO::Path 型オブジェクトは identity）で **`&self`＝`$*SPEC`/`$*CWD` を env から読む**＝pure ではないが VM は env を所有する
-  ので native 読み可。VM の非mut/mut 両 catch-all（iterator construct の後・最終 fallback 直前）に `try_native_io_coercion`
-  を追加し、**Str/Int/BigInt/Num/Rat/FatRat/Complex/Bool 受け手 + IO::Path(-subclass) 型オブジェクト identity** を native 化、
-  **同じ `make_io_path_instance` を呼ぶ**＝1 操作 = 1 実装（interpreter dispatch は無改修・同 fn 共有）。Instance（user `.IO`/
-  IO::Path/IO::Handle）/ 非IO Package / aggregate / **Junction（autothread）** は `None` で interpreter 維持＝behavior-invariant
-  （`("a"|"b").IO` は Junction を返し parity 確認）。新 IO::Path を返し受け手を変異しない＝writeback 不要。実測:
-  `$s.IO`/`42.IO` の fallback → 0。pin `t/native-io-coercion.t`(18, literal/変数/numeric/型オブジェクト identity/null-byte
-  dies/Junction autothread/`$*CWD` 継承・raku/mutsu 双方 PASS)。S16-io/S32-io/tmpdir/cwd whitelist 全緑。
-- **2026-06-23 (§D = `IO::Path.absolute`/`.relative` の VM ネイティブ化)**: IO::Path lexical スライスの cwd 依存 follow-up。
-  `.absolute`/`.relative` は path 文字列に **cwd**（`$*CWD`/instance `cwd` 属性/プロセス cwd）を組み合わせて文字列を導出するが、
-  cwd は `&self` の `resolve_path`/`get_cwd_path`/`apply_chroot` 経由で読み、これらは **純 lexical（FS stat なし）**＝`.IO` 同様
-  VM が env/cwd を所有するので native dispatch 可。新 `&self` メソッド `try_io_path_cwd_method`（win32/cygwin/posix の base 引数・
-  `$*CWD` fallback 全分岐を保持）へ抽出し、`native_io_path` は `try_io_path_lexical` の直後で委譲＝**1 操作 = 1 実装**（`absolute`/
-  `relative` arm を削除）。VM は IO::Path lexical dispatch の隣（`is_native_method` バウンス直前・非mut/mut 両 path）で呼ぶ。
-  `.resolve`（実 FS canonicalize）は `None` で `native_io_path` 維持。新 string を返し受け手非変異＝writeback 不要・behavior-invariant。
-  実測: `$p.absolute`/`.relative` の fallback → 0。pin `t/native-io-path-cwd.t`(14, `$*CWD`/instance cwd/explicit base/変数受け手/
-  round-trip・raku/mutsu 双方 PASS)。io-path.t の既存 fail 2（`.SPEC`/`.CWD`）は不変。S16-io/S32-io/tmpdir/cwd whitelist 全緑。
-- **2026-06-23 (§D = QuantHash / Map / Hash coercion を plain `Cool` scalar 受け手でも VM ネイティブ化)**: coercion ドレインの
-  残差掃除。method-fallback の広がり再計測（全 whitelist・distinct ファイル数）で **`Set`/`Bag`/`Mix`/`SetHash`/`BagHash`/
-  `MixHash` が各 8-11 file でまだ fallback** していたのを確認し受け手を特定＝`"a".Set`/`42.Set`/`"blue".Set` 等の **plain
-  scalar 受け手**（list-like aggregate でないため VM gate の `list_like` チェックで除外され interpreter に落ちていた）。
-  interpreter は scalar `.Set` を `dispatch_to_set_with_what`＝**`to_set` そのもの**（Set/Bag/Mix arm に Package 特別扱いすら無く
-  scalar を `other =>` catch-all で単一要素化）で処理する＝native gate を広げても **完全に同一実装で behavior-invariant**。
-  `try_native_quanthash_coerce`/`try_native_map_hash_coerce` 共通の `list_like` 判定を新ヘルパー
-  `coerce_receiver_native_eligible` に集約し、list-like aggregate に **Str/Int/BigInt/Num/Rat/FatRat/Complex/Bool** を追加
-  （非mut + mut 両 catch-all が共有）。`.Map`/`.Hash` の scalar（`42.Hash`）は同じ `to_hash`/`to_map` で `X::Hash::Store::OddNumber`
-  ＝raku/interpreter と一致（odd number）。**Instance（`__baggy_data__`/Match captures/user coercion）/ Package（型オブジェクト・
-  `.Map`/`.Hash` は型オブジェクト返し）/ Nil / Junction（autothread）は `None` で interpreter 維持**＝挙動不変。新しい
-  Set/Bag/Mix/Map/Hash 値を返し受け手を変異しない＝writeback 不要。実測: set.t/bag.t/mix.t の Set/Bag/Mix fallback
-  11/10/10 → 2/2/2（残 2 は `__baggy_data__` Instance / 型オブジェクト＝設計通り fall through）。pin
-  `t/native-scalar-quanthash-coerce.t`(39, literal/変数受け手 × Set/Bag/Mix/SetHash/BagHash/MixHash/Map/Hash・raku/mutsu
-  双方 PASS)。set.t 248/248・mix.t 244/244・categorize 28/28・hash.t 緑。（bag.t 252 "Foo instance union"・classify.t 40
-  "junction classify" は BLOCKERS.md 記載の pre-existing〔いずれも非whitelist〕で本変更と無関係。`(a=>1).Map` の odd-number
-  は Pair 受け手〔元から native gate 内〕の別 pre-existing バグで本スライス対象外。）
-- **2026-06-23 (§D = `IO::Path` の FS `stat`-only file test / accessor を VM ネイティブ化)**: coercion ドレイン枯渇後、③ IO
-  native メソッド**本丸**への最初の一歩。IO::Path lexical/cwd スライスが `None` で interpreter 維持していた **FS 接触メソッドの
-  うち `stat` 読みだけで完結する群**＝`e`/`f`/`d`/`l`/`r`/`w`/`x`/`rw`/`rwx`/`z` の file test と `mode`/`s`/`created`/`modified`/
-  `accessed`/`changed` の stat accessor を native 化（広がり計測で `e`=15/`d`=11 file 等・temp-file ヘルパー経由で分散）。これらは
-  **`io_handles` を一切確保せず content 読みも emit もしない**＝path を VM 所有 cwd（`resolve_path`/`apply_chroot`/`get_cwd_path`・
-  純 lexical）に対して解決した後 `fs::metadata`/`exists` を呼ぶだけ。新 `&self` メソッド `try_io_path_fs_stat`（path_buf 解決）＋
-  static `io_path_stat_result`（path_buf+p から全 16 arm の stat + Failure 整形）へ抽出し、`native_io_path` は `try_io_path_cwd_method`
-  の直後で委譲＝**1 操作 = 1 実装**（16 arm を match から削除）。VM は IO::Path lexical/cwd dispatch の隣（`is_native_method`
-  バウンス直前・非mut/mut 両 path）で呼ぶ。`slurp`/`lines`/`words`/`comb`（content 読み・encoding flag）/ `open`/`spurt`（`io_handles`
-  確保・FS write）は `None` で `native_io_path` 維持＝次スライス候補。新しい Bool/Int/Str/Failure を返し受け手非変異＝writeback 不要・
-  behavior-invariant（同一 stat ロジック）。実測: `$p.{e,f,d,s,modified,…}` の fallback → 0。pin `t/native-io-path-fs-stat.t`(30,
-  literal + 変数受け手〔mut path〕× 全 file test/accessor・missing-path Failure・raku/mutsu 双方 PASS。`.modified`/`.accessed`/
-  `.changed` は mutsu=Int / raku=Instant の別 pre-existing 型差を避け `> 0`/`.defined` で検証)。S16-io/S32-io/slurp/spurt whitelist
-  全緑（io-path.t の `.SPEC`/`.CWD` 既存 fail は非whitelist・不変）。**残る IO native = content 読み（slurp/lines）と handle 確保
-  （open/spurt）＝③ の `io_handles` 所有を直接触る本丸。**
-- **2026-06-23 (§D = `IO::Path` の whole-file content 読み `slurp`/`lines`/`words` を VM ネイティブ化)**: FS stat-only スライス
-  （上）の content-read follow-up。`slurp`(広がり 26 file)/`lines`(13)/`words` は **ファイル全体を読む**が、`io_handles` を一切
-  確保せず emit もしない＝path を VM 所有 cwd へ解決後 `fs::read[_to_string]` し、bytes を split/decode するだけ。flag 解析
-  （`parse_io_flags_values`）と encoding lookup（`decode_with_encoding`＝VM 所有の `encoding_registry` を読む）は全て `&self`
-  read なので native dispatch 可。新 `&self` ゲート `try_io_path_content_read`（`Option` 返し）＋ fallible 本体 `io_path_content_read`
-  （`?` を使うため分離）へ抽出。path_buf 解決は 3 サイト目になったので `resolve_io_path_buf` ヘルパーに集約し `try_io_path_fs_stat`
-  も委譲化（dedup）。`native_io_path` は stat 委譲の直後で content 委譲＝**1 操作 = 1 実装**（slurp/lines/words arm を match から削除）。
-  VM は stat dispatch の隣（非mut/mut 両 path）で呼ぶ。**`comb`（regex/closure dispatch が `&mut self` 必要）/ `open`/`spurt`
-  （`io_handles` 確保・FS write）は `None` で `native_io_path` 維持**＝次スライス（③ io_handles 本丸）。新しい Str/Buf/Seq を返し
-  受け手非変異＝writeback 不要・behavior-invariant（同一 read + split/decode、`:bin`/limit/`:!chomp`/非utf-8 decode 全分岐保持）。
-  実測: `$p.{slurp,lines,words}` の fallback → 0。pin `t/native-io-path-content-read.t`(24, literal + 変数受け手〔mut path〕×
-  slurp/lines/words・`:bin` Blob・utf-8 decode・limit・`:!chomp`・missing-path dies・raku/mutsu 双方 PASS)。S16-io/S32-io/slurp/
-  lines whitelist 全緑（io-path.t `.SPEC`/`.CWD` 既存 fail は非whitelist・不変）。**残る IO native = `comb`（&mut）と handle 確保
-  open/spurt＝③ の `io_handles` 所有本丸。**
-- **2026-06-23 (§D = `IO::Path` の単一パス FS 変異 `spurt`/`mkdir`/`rmdir`/`unlink`/`chmod` を VM ネイティブ化)**: content-read
-  スライスの **write 系 follow-up**（spurt 広がり 18 file）。これら 5 op は FS を**変異**するが `io_handles` を一切確保しない＝
-  path を VM 所有 cwd へ解決後 **一回限りの syscall**（`fs::write`/`create_dir_all`/`remove_dir`/`remove_file`/`set_permissions`）
-  を呼ぶだけ（`spurt` は open→write→即 drop でハンドルを残さない）。encoding lookup（`encode_with_encoding`＝VM 所有 registry
-  読み）は `&self`。新 `&self` ゲート `try_io_path_fs_mutate`（`Option` 返し）＋ fallible 本体 `io_path_fs_mutate`（`?` 用に分離・
-  `mkdir` は `class_name` で IO::Path を round-trip 返し）へ抽出。`native_io_path` は content 委譲の直後で委譲＝**1 操作 = 1 実装**
-  （5 arm を match から削除）。VM は content dispatch の隣（非mut/mut 両 path）で呼ぶ。**2-path op（`copy`/`rename`/`move`/`symlink`/
-  `link`・宛先 path 解決が必要）と handle-opening `open`（`io_handles` 確保＝`&mut self`）は `None` で `native_io_path` 維持**＝次の
-  ③ io_handles 本丸 capstone。新しい Bool/IO::Path/Failure を返し受け手非変異＝writeback 不要・behavior-invariant（同一 syscall +
-  `:append`/`:createonly`/`:enc`+BOM/Buf 全分岐保持）。実測: `$p.{spurt,mkdir,rmdir,unlink,chmod}` の fallback → 0。pin
-  `t/native-io-path-fs-mutate.t`(22, literal + 変数受け手〔mut path〕× 5 op・`:append`/`:createonly` Failure・Buf spurt・mkdir
-  recursive・非空 rmdir Failure・chmod mode・raku/mutsu 双方 PASS)。S16-io/S32-io/spurt/dir whitelist 全緑。（`.unlink` of missing
-  は mutsu=False/raku=True の別 pre-existing 差〔移動前 interpreter も `Err(NotFound)=>Bool(false)`〕で本スライス対象外＝pin 非対象。）
-  **残る IO native = `comb`（&mut）と `open`（`io_handles` 確保）＝③ の `io_handles` 所有 capstone。**
-- **2026-06-23 (§D ③ capstone = `IO::Path.open` を VM ネイティブ化＝VM が `io_handles` を直接確保)**: ③（state 所有）の
-  **象徴的マイルストーン**。`open` は IO::Path FS メソッドの中で唯一 **`io_handles` テーブルを変異**する（`open_file_handle`→
-  `insert_handle_state` で handle id 確保＝`&mut self`）。台帳が当初「native-method（IO 系）は ③ がブロック」としていた根拠が
-  まさにこれ＝`io_handles` が interpreter 所有 state だから、だった。だが #2760-2772 以降 `io_handles` は **`Arc<RwLock>` 共有
-  フィールドで VM が所有**＝unified struct の `self` から `open_file_handle` を直接呼べる。新 `&mut self` ゲート `try_io_path_open`
-  を抽出（`resolve_io_path_buf`(&self)/`parse_io_flags_values`(&self) は owned 値を返すので後続 `&mut self` `open_file_handle` と
-  借用衝突なし）し、`native_io_path` は fs_mutate 委譲の直後で委譲＝**1 操作 = 1 実装**（open arm を match から削除）。VM の
-  **非mut/mut 両 dispatch 関数はどちらも `&mut self`** なので（`try_compiled_method_or_interpret_inner`/
-  `try_compiled_method_mut_or_interpret`）、`"x".IO.open`（非mut）も `$p.open`（mut）も native 化。`:r`/`:w`/`:a`/`:rw`/`:bin`/
-  `:enc`/`:create`/`:exclusive` 全 flag と Failure-on-error 整形を保持＝behavior-invariant（同一 `open_file_handle`）。実測:
-  `$p.open` の fallback → 0。**∴ open→read/write→close の全ライフサイクルが catch-all バウンス無しで VM ネイティブに走る**
-  （handle メソッド get/lines/print/say/close/tell/eof/seek/flush 等は既に native）。pin `t/native-io-path-open.t`(20, literal +
-  変数受け手〔mut path〕× :r/:w/:a/:exclusive/:bin・missing/directory Failure・opened state・raku/mutsu 双方 PASS)。S16-io/S32-io/
-  open whitelist 全緑（io-handle.t `.say` 既存 fail は main でも fail＝非whitelist・本変更と無関係）。**残る IO native = `comb`
-  （regex/closure dispatch が `&mut self`）と 2-path op（copy/rename/move/symlink/link）のみ＝③ の IO native はほぼ完遂。**
-- **2026-06-23 (§D = `IO::Path` の 2-path FS ops `copy`/`rename`/`move`/`symlink`/`link` を VM ネイティブ化＝IO::Path FS 族の完結)**:
-  open capstone の follow-up＝IO::Path FS メソッド族の**最後の未 native**。これら 5 op は受け手 path と**宛先/リンク名 path の両方**を
-  VM 所有 cwd へ解決（`resolve_path`/`resolve_io_path_buf`・`&self`）後、一回限りの syscall（`fs::copy`/`fs::rename`/`unix_fs::symlink`/
-  `fs::hard_link`）を呼ぶだけ＝`io_handles` 不要・全 `&self`。新 `&self` ゲート `try_io_path_two_path_op`（`Option` 返し）＋ fallible
-  本体 `io_path_two_path_op`（`?` 用に分離）へ抽出。`native_io_path` は open 委譲の直後で委譲＝**1 操作 = 1 実装**（copy/rename|move/
-  symlink/link arm を match から削除・間の `dir`/`watch` は維持）。VM は open dispatch の隣（非mut/mut 両 path）で呼ぶ。同一/createonly
-  チェック・`X::IO::Copy`/`Rename`/`Move` Failure 整形・`:absolute` symlink・hard link 全分岐保持＝behavior-invariant。実測:
-  `$p.{copy,rename,move,symlink,link}` の fallback → 0。pin `t/native-io-path-two-path.t`(18, literal + 変数受け手〔mut path〕×
-  5 op・copy-onto-self/createonly Failure・symlink resolve・hard link・raku/mutsu 双方 PASS。stale ファイル混入を防ぐため毎回 dir を
-  クリーンに再生成)。S16-io/S32-io/copy/rename whitelist 全緑。**∴ IO::Path FS メソッド族（stat/content-read/fs-mutate/open/2-path）が
-  全て VM ネイティブ化完了＝§D ③ の IO native はほぼ完遂。残るは `comb`（regex/closure dispatch が `&mut self`・別軸）のみ。**
-- **2026-06-23 (§D = `.encode`/`.decode`（Str↔Buf 変換）を VM ネイティブ化)**: IO::Path 族の次の clean な native-method ドレイン
-  （広がり `encode`=16 file）。**明示エンコーディング形**（`"x".encode("utf-16")`/`$buf.decode("ascii")`）は `dispatch_method_by_name`
-  catch-all で interpreter にバウンスしていた（0-arg `.encode` は `methods_0arg` で既に native）。これらは VM 所有の `encoding_registry`
-  を読む（`find_encoding`/`encode_with_encoding`/`decode_with_encoding`＝全 `&self`）pure な Str↔Buf 変換で `io_handles` 不要。新
-  `pub(crate)` ヘルパー `try_native_encode_decode` を **`crate::runtime`（methods_io_dispatch.rs）側に**置き（`dispatch_encode`/
-  `dispatch_decode` が `pub(super)` なので同 crate::runtime から呼ぶ・IO::Path と同パターン）、VM の非mut/mut 両 catch-all（`try_native_io_coercion`
-  の直後・最終バウンス直前）から呼ぶ＝**1 操作 = 1 実装**。**保守的ゲート**: `.encode` は plain Cool scalar（Str/Int/BigInt/Num/Rat/
-  FatRat/Complex/Bool）のみ、`.decode` は `dispatch_decode` 自身が Buf/Blob Instance にゲート（それ以外 `None`）。user Instance（custom
-  `.encode`/`.decode` は compiled method で先に解決）・Supply（独自 chunk-encode・interpreter arm が除外）・Buf 受け手の `.encode` は
-  fall through＝behavior-invariant。新しい Buf/Str を返し受け手非変異＝writeback 不要。実測: `"x".encode("utf-16")`/`$buf.decode` の
-  fallback → 0。pin `t/native-encode-decode.t`(23, literal + 変数受け手〔mut path〕× encode utf-8/utf-16/ascii/latin-1・Int/Bool/Rat
-  encode・Buf/Blob decode・round-trip・raku/mutsu 双方 PASS。utf-16 `.elems`=16-bit ユニット数の注意込み)。encoding/buf/S32-str/encode
-  whitelist 全緑。
-- **2026-06-23 (§D = `IO::Path.comb` を VM ネイティブ化＝IO::Path FS 族 100% 完結 ＋ no-arg comb バグ修正)**: IO::Path FS メソッド
-  族の**最後の 1 メソッド**。`comb` はファイル全体を読んで content を comb するが、matcher dispatch（`dispatch_comb_with_args`）は
-  regex/closure matcher が match エンジンを走らせるため `&mut self`＝ただし `io_handles` は触らない。新 `&mut self` ヘルパー
-  `try_io_path_comb`（read→`?` 用に `match` で error 整形）へ抽出し `native_io_path` は two-path 委譲の直後で委譲＝**1 操作 = 1 実装**
-  （comb arm を match から削除）。VM は two-path dispatch の隣（非mut/mut 両 path）で呼ぶ。**同時に pre-existing バグも修正**: 引数なし
-  `$path.IO.comb`（matcher 無し）が空 Seq を返していた（旧 arm が `dispatch_comb_with_args` の `None` を空にマップ）→ content を
-  grapheme 分割（`Str.comb` no-arg / Rakudo と一致）。`dispatch_comb_with_args` の `None`-no-arg セマンティクスは generic caller
-  （methods_dispatch_match.rs:187）と共有なので**修正は IO::Path comb helper にローカル**に留めた（None→grapheme）。実測:
-  `$p.comb`/`$p.comb(/re/)`/`$p.comb(N)` の fallback → 0。pin `t/native-io-path-comb.t`(17, literal + 変数受け手〔mut path〕× no-arg
-  grapheme・regex・Int chunk・Str fixed・limit・empty file・unicode・raku/mutsu 双方 PASS)。S16-io/S32-io/comb whitelist 全緑。
-  **★∴ IO::Path FS メソッド族（stat/content-read/fs-mutate/open/2-path/comb）が 100% VM ネイティブ化完了＝§D ③ の IO native 完遂。**
-  **clean な pure-value native-method ドレインも枯渇**（残カテゴリ＝③ 組込型 ctor〔Buf.new 等〕/ MOP carrier〔WHAT/name/can〕/
-  landmine〔Instance.Str/.Stringy/.raku/.gist〕/ block-exec slow path〔map/grep〕/ concurrency〔Supply/tap〕/ typed-array mutator・
-  いずれも別軸 or 構造的ブロッカー前提）。次の §D は ③ 組込型 ctor か tree-walk dispatch chain 削除の substrate（要設計・大）。
-- **2026-06-23 (§D ③ = `::`-namespaced クラス／組込例外型の `.new` を VM ネイティブ化)**: ③ 組込型 ctor フォークの初スライス。
-  `is_native_default_constructible` の `cn_resolved.contains("::")` ガードが **全ての `::` namespaced クラス**（ユーザ `A::B`／
-  組込例外型 `X::AdHoc`・`X::TypeCheck::Binding` …）を native 構築から除外していた＝唯一のブロッカー。`[`（parametric）ガードは維持し
-  `::` ガードを削除。さらに組込例外型は registry に `attributes: Vec::new()`（宣言属性ゼロ・named args は `is_attribute_buildable` の
-  未宣言名 `true` フォールバックで attribute-bag 化）で登録されるため `has_attribute` が false → 末尾返却で除外されていた。MRO に
-  `Exception` を含むなら native 可（`build_native_default_instance` は同じ `is_attribute_buildable` で named args を格納＝interpreter と
-  byte-identical）として `has_attribute || is_exception` に変更。**VM call site（vm_call_method_compiled.rs:127）に
-  `materialize_exception_message_in_result` を追加**＝interpreter slow path（methods.rs:3369 が `dispatch_new` 後に呼ぶ）と等価に、
-  user `message` メソッドを構築時に1回走らせ `message` 属性へキャッシュ（built-in 例外・非例外は no-op）。user `message` を走らせる場合は
-  `method_dispatch_pure=false`（caller slot reconcile 保全）。`materialize_…` の可視性を `pub(super)`→`pub(crate)`。実測: `X::AdHoc.new`/
-  `X::TypeCheck::Binding.new`/`A::B.new`/`P::Q::R.new` の `new` fallback → 0。stash 比較で native==interpreter 出力完全一致を確認
-  （`message`/no-arg の raku 差異は変更前から存在する F-track `.message` 未実装ギャップで本変更と無関係）。pin
-  `t/native-namespaced-and-exception-ctor.t`(16)。make test 10971・S04/S12/S32 construction whitelist 全緑。**残 ③ ctor 候補＝
-  Promise 等並行型・misc 組込型（is_attribute_buildable で attribute-bag 化できない special 構築のもの）。**
-- **2026-06-23 (§D ③ = `Lock` 族（`Lock`/`Lock::Async`/`Lock::Soft`）の `.new` を VM ネイティブ化)**: ③ ctor フォークの 2 スライス目。
-  lock 構築は pure data（`next_lock_id()` の process-global カウンタ bump ＋ `Lock::Async` の `async` フラグ・env/registry/user code 不要）。
-  static `try_native_builtin_construct`（VM call site vm_call_method_compiled.rs:145 が呼び `method_dispatch_pure=true`）に Lock arm を追加し、
-  interpreter dispatch_new の既存 arm（`match base_class_name` 内）は `Slip`/`IterationBuffer` 等と同じ「Shared with the VM's native fast
-  path」二重実装の慣習に倣ってコメントのみ追加で残置（4 行・byte-identical）。実測 `Lock.new`/`Lock::Async.new`/`Lock::Soft.new` の `new`
-  fallback → 0。stash 比較で native==interpreter 一致確認。pin `t/native-lock-ctor.t`(9)。make test 10964。**★既知の別軸バグ（本変更と無関係・
-  main でも再現）: `$lock.protect({ $n++ })` の captured-outer `$n` writeback 落ち（`.protect` の closure capture writeback・ctor とは無関係）。**
-  **残 ③ ctor 候補＝Promise/Channel（SharedPromise/channel state）・QuantHash 族（Bag/Set/Mix/SetHash・element 計数）・Capture・misc。**
-- **2026-06-23 (§D ③ = `Promise`/`Channel`/`Supplier`/`Supplier::Preserving` の `.new` を VM ネイティブ化)**: ③ ctor フォークの 3 スライス目
-  ＝simple concurrency primitive。`Promise.new`=`Value::Promise(SharedPromise::new())`（空の planned promise・pure shared state）、
-  `Channel.new`=`Value::Channel(SharedChannel::new())`（空 channel）、`Supplier`/`Supplier::Preserving`=`{emitted:[], done:False,
-  supplier_id:next_supplier_id()}`（emission log ＋ process-global id）＝いずれも env/registry/user code 不要。static
-  `try_native_builtin_construct` に 3 arm 追加、interpreter dispatch_new の既存 arm はコメントのみ残置（byte-identical 二重実装の慣習）。
-  実測 4 種とも `new` fallback → 0。`$p.keep(42)`/`$c.send.list`/`$s.Supply.tap` 機能 raku 一致。pin `t/native-concurrency-ctor.t`(10)。
-  make test 10984。**★既知の別軸ギャップ（本変更と無関係）: `Supplier::Preserving` の tap 前 emit の late-tap replay 未実装（mutsu は
-  buffer/replay しない・construction とは無関係）。** **残 ③ ctor 候補＝QuantHash 族（Bag/Set/Mix/SetHash・element 計数＝`&mut self` type
-  check 要・static 不可）・Capture・Proxy（FETCH/STORE closure）・misc。** **★perf 注意=`SharedPromise::new()` 等の `pub(crate)` ctor を
-  VM static path から直接呼ぶ＝interpreter 委譲より 1 ホップ短い。**
-- **2026-06-24 (§D ③ = QuantHash 族（`Set`/`SetHash`/`Bag`/`BagHash`/`Mix`/`MixHash`）の `.new` を VM ネイティブ化)**: ③ ctor フォークの
-  4 スライス目。前 3 つと違い QuantHash 構築は **`&mut self`**（element 計数＋parameterized 型 check `type_matches_value`＋container metadata
-  `tag_container_metadata`）で static `try_native_builtin_construct` には載らない＝**dispatch_new の 3 arm（414 行）を新モジュール
-  `methods_quanthash_ctor.rs` の `&mut self` helper `try_native_quanthash_construct` に丸ごと抽出**（IO::Path family と同パターン・「1 操作 =
-  1 実装」）。dispatch_new の 3 arm は helper への delegation（`return self.try_native_quanthash_construct(*class_name, base_class_name,
-  &type_args, args)`）に置換＝**byte-identical な丸ごと移動でコピー無し**（前 3 スライスの「コメント残置二重実装」と異なり真の単一 impl）。VM
-  call site は新 wrapper `try_native_quanthash_construct_for_package(&[Value])`（parametric 名 strip → `is_quanthash_ctor_type` gate → match
-  時のみ args clone）を非mut/mut 両 path に追加（`Set[Int].new` の parametric も `parse_parametric_type_name` で base 解決）。env-pure
-  （値構築＋container metadata tag のみ）＝`method_dispatch_pure=true`。可視性: `strip_named_pair_args` を `pub(super)` に拡大（他の
-  `value_to_list`/`is_lazy_*`/`type_matches_value`/`tag_container_metadata`/`parse_parametric_type_name` は既に pub(super)/pub(crate)）。
-  実測 6 種とも `new` fallback → 0、parametric（`Bag[Int]`/`Set[Int]`）・type-check 失敗（`X::TypeCheck::Binding`）も raku 一致。pin
-  `t/native-quanthash-ctor.t`(18)。make test 11018・setbagmix/baggy/mix whitelist 全緑。**★残 ③ ctor 候補＝`Capture.new`（mutsu 未実装＝
-  別途実装要）・`Proxy`（FETCH/STORE closure）・`Match`/`FakeScheduler` 等の low-traffic static 候補・`Array`/`Hash`（shaped/container
-  metadata でより複雑）。clean な大物 QuantHash を消化したので、残りは小粒 or 未実装機能。**
-- **見送り（2026-06-23）: generic `Instance.Str`/`.Stringy` coercion**。広がり次点（`Stringy`=22/`Str`=11 file）だが、VM catch-all に
-  到達する Instance.Str は **generic object（`to_string_value()`）に限らず** built-in 型の特殊 stringification を含む（`Buf.Str`→
-  `X::Buf::AsStr` throw・`Attribute/BOOTSTRAPATTR.Str`→名前・`has $.Str` の public アクセサ→属性値）。これらは `is_native_method`
-  でゲートされず arm 1499 より前で interpreter 特殊処理されるため、`to_string_value()` で native 化すると壊れる（say.t/buf.t/
-  attributes.t で回帰確認）。`has_user_method`/`has_public_accessor`/built-in 型除外を足しても landmine が次々顕在化＝列挙不能で
-  安全に分離できないため見送り。clean な §D coercion 成果は IO::Path family（lexical/`.IO`/absolute-relative）で確定。
-- **2026-06-24 (§D ③ = `FakeScheduler`/`Proxy`/`Match` の `.new` を VM ネイティブ化)**: ③ ctor フォークの clean static 残掃き。3 つは
-  pure data assembly（`FakeScheduler` は process-global counter ＋ virtual-time 0.0 seed、`Proxy` は評価済み FETCH/STORE callable を包む、
-  `Match` は `orig[from..to]` を slice して positional/named captures を attribute 格納）＝env/registry/user code 不要。各構築を per-type
-  helper（`build_native_fakescheduler_value`/`build_native_proxy_value`/`build_native_match_value`）に抽出し、`try_native_builtin_construct`
-  と interpreter の `dispatch_new` arm の**両方が同 helper を呼ぶ**（true single impl・byte-identical）。実測 3 種とも `new` fallback → 0。
-  pin `t/native-misc-ctor.t`(14・Proxy/Match は raku parity 確認)。
-- **2026-06-24 (§D ③ = `Capture.new` を実装)**: `Capture` はそもそも constructor が無く `Capture.new` がエラーだった。raku セマンティクス
-  （検証済）＝default `Capture.new` は **empty Capture**。named arg は drop（Capture に buildable public 属性が無く `bless` が無視）、positional
-  arg は reject（named-only `Mu.new`＝"Default constructor for 'Capture' only takes named arguments"）。populated Capture は `\(...)` で作る。
-  named arg は `Value::Pair`、それ以外（リテラル・positional `"a" => 1` `ValuePair`）は positional で die。pure data ＝
-  `try_native_builtin_construct`。既知の不変ギャップ（非回帰）＝Capture **instance** 受け手の `.new`（`\(1).new`）は依然エラー＝built-in value
-  variant の instance `.new` 委譲という別軸の広いギャップ。pin `t/native-capture-ctor.t`(9・raku 双方 PASS)。
-- **2026-06-24 (§D ③ = `Array`/`List`/`Positional`/`array`/`Hash`/`Map` の `.new` を VM ネイティブ化)**: aggregate ctor のドレイン。pure-data
-  static と違い `&mut self`（shaped-dim 解析 `:shape(...)`＋`:data`/positional 投入＋X::Assignment shape エラー、Slip/Range/Seq flatten、
-  parameterized 型 check `Array[Int].new`/`Hash[Int].new`→`X::TypeCheck::Assignment`、container metadata tag）。QuantHash 同様、2 arm（~310 行）を
-  新モジュール `methods_aggregate_ctor.rs`（`try_native_array_construct`/`try_native_hash_construct`）に**丸ごと抽出**し、interpreter の
-  `dispatch_new` arm は delegation・VM は `try_native_aggregate_construct_for_package`（parametric 名→base+type_args 解決）経由で呼ぶ＝true single
-  impl・byte-identical。実測 6 種とも `new` fallback → 0。pin `t/native-aggregate-ctor.t`(16・raku parity subset。shaped/Hash-named-data の
-  mutsu 固有挙動は roast S02-types/array.t・hash.t・S09-typed-arrays/* がカバー)。**★これで `dispatch_new` の built-in 型 ctor のうち native 化
-  可能な clean 候補は枯渇。残る arm は state/FS/process 依存（IO::Socket::INET〔socket〕・Distribution/CompUnit::Repository〔FS〕・Proc::Async
-  〔process〕・Backtrace〔call stack〕・Seq〔predictive iterator carrier〕）か error-only（HyperWhatever/Whatever/Instant）。**
-- **2026-06-24 (§D ③ = allomorph〔`IntStr`/`NumStr`/`RatStr`/`ComplexStr`〕＋`ObjAt`/`ValueObjAt` の `.new` を VM ネイティブ化)**: ③ ctor フォークの
-  再計測（全 whitelist の `new` fallback receiver を一時プローブで実測）で、aggregate 後も残る最頻 receiver が **`dispatch_new` ではなく
-  `dispatch_new_and_constructors`（slow-path method dispatch）に在る**ことが判明: `RatStr`(892)/`IntStr`(306)/`ComplexStr`(176)/`NumStr`(125)
-  ＝allomorph、`ObjAt`/`ValueObjAt`(計18)。これらは完全 **pure-static**（args→instance・`&self` 一切不要＝registry/env/FS も触らない）。
-  allomorph `.new(numeric, string)` は inner numeric（allomorphic `Mixin` 引数なら unwrap）を `Str` override 付き `Value::mixin` に、`ObjAt`/
-  `ValueObjAt` `.new(which)` は first positional の stringify を `WHICH` 属性に格納するだけ。**static `try_native_builtin_construct`（VM call site
-  vm_call_method_compiled.rs:160/1788 が呼び `method_dispatch_pure=true`）に 2 arm 追加**し、新 static helper `build_native_allomorph_value`/
-  `build_native_objat_value` を `dispatch_new_and_constructors`（インライン実装を撤去）と両方が呼ぶ＝**1 操作 = 1 実装**（FakeScheduler/Proxy/Match
-  と同パターン）。arity エラー文言は mutsu 固有（"requires two arguments" / "Too few positionals"＝raku と異なる pre-existing 差）を抽出時に保持＝
-  byte-identical。実測 `IntStr.new`/`RatStr.new`/`ObjAt.new` 等の `new` fallback → 0（val.t の `new` が histogram から消失）。pin
-  `t/native-allomorph-objat-ctor.t`(23・raku/mutsu 双方 PASS)。S32-str/val.t・S03-operators/set_union.t・S32-num/rounders.t・rat.t・S02-types/num.t
-  whitelist 全緑。（allomorphic.t 107/113 の既存 fail は main でも同一＝`.ACCEPTS`/`.Numeric` の別軸ギャップで本変更と無関係。）**残 `new` fallback receiver
-  ＝Proc::Async〔process〕/Failure〔`$!` env 読み〕/IO::Socket::INET〔socket〕/IO::Path family〔registry・別スライス候補〕/CallFrame〔call stack〕/
-  Seq〔iterator carrier〕＝いずれも state 依存 or 別軸。**
-- **2026-06-24 (§D ③ = `IO::Path` family〔`IO::Path`/`::Unix`/`::Win32`/`::Cygwin`/`::QNX`〕の `.new` を VM ネイティブ化＝IO::Path ctor capstone)**:
-  IO::Path native 化テーマの締め＝メソッド族（stat/content-read/fs-mutate/open/2-path/comb・#3499〜3511）は 100% native 化済だが **ctor だけ
-  catch-all バウンス**していた（プローブ実測で `IO::Path::Win32`/`::Cygwin`/`::Unix`/`IO::Path` 計~112 occ）。`.new` は **pure path-string assembly**
-  ＝positional path / IO::Path instance（`path` 再利用）/ basename+dirname+volume の三つ組を SPEC 由来セパレータで join し、CWD/SPEC 属性を付与する
-  だけ。`&self` 依存は **registry 読み**（`class_mro`＝IO::Path-instance 引数判定）のみ＝VM 所有（phase ②）＝FS/cwd/env/user code 不要。`dispatch_new`
-  の IO::Path arm（~117 行）を新 `&mut self` helper `build_io_path_instance` に**丸ごと抽出**（interpreter arm は delegation・SPEC-variant subclass の
-  一回限り registry 登録も保持）。VM ゲート `try_native_io_path_construct` は **built-in IO::Path family のみ**（`is_io_path_lexical_class`＝lexical method
-  スライスと同一ゲート＝user subclass の custom new を侵さない）に絞り、非mut/mut 両 call site（aggregate ctor arm の直後・`method_dispatch_pure=true`）から
-  呼ぶ＝**1 操作 = 1 実装**・byte-identical。実測 `IO::Path.new`/`IO::Path::Win32.new` 等の `new` fallback → 0。pin `t/native-io-path-ctor.t`(19・
-  positional/triple/instance-arg/Win32-Unix-Cygwin subclass/CWD/empty-null dies・raku/mutsu 双方 PASS)。S32-io/S16-io/tmpdir/cwd/S11-compunit whitelist
-  全緑（io-path.t 34/35 の `.SPEC`/`.CWD` attribute 既存 fail は main でも同一＝非whitelist・本変更と無関係）。**残 `new` fallback＝Proc::Async/Failure
-  〔`$!` env〕/IO::Socket::INET/CallFrame/Seq＝state 依存 or 別軸。**
-- **2026-06-24 (§D ③ = `Failure.new($exception?)` を VM ネイティブ化)**: 残 `new` fallback の**最大カウント**（プローブ実測 2593・`fail`/明示構築駆動）。
-  `Failure.new` は **VM 所有 state のみ読む pure data assembly**＝明示 exception 引数（無ければ `$!` を env から、それも無ければ `X::AdHoc("Failed")`
-  デフォルト）を、既に `Exception`/`X::`/`CX::`（MRO 読み `mro_readonly`）でなければ `X::AdHoc` に wrap して `{exception, handled:false}` instance を作るだけ。
-  `&self` 依存は **env 読み（`$!`）＋ registry 読み（`mro_readonly`）**＝VM 所有（単一ストア化後 `self.env` は VM/interpreter で同一）＝FS/process/socket/
-  user code 不要。`dispatch_new_and_constructors` の Failure arm（~52 行）を新 `&self` helper `build_native_failure_value` に**丸ごと抽出**（interpreter arm は
-  delegation）。VM は非mut/mut 両 catch dispatch（IO::Path ctor arm の直後・`class_name=="Failure"` gate・`method_dispatch_pure=true`）から呼ぶ＝**1 操作 =
-  1 実装**・byte-identical。実測 `Failure.new`（明示/string-wrap/`$!`/argless 全パス）の `new` fallback → 0。pin `t/native-failure-ctor.t`(11・raku/mutsu
-  双方 PASS。`X::AdHoc` は `:payload` で構築＝`.message` が payload を読む pre-existing detail を回避)。S04-exceptions/S04-statement-modifiers/
-  S05-capture/named/S06-advanced whitelist 全緑。**残 `new` fallback の次スライス候補（2026-06-24 実測訂正・「state 依存」分類を訂正）**:
-  ① **`Proc::Async.new`＝実は完全 pure data**（プロセス spawn は `.start`・ctor は引数パース＋`next_supply_id()` free fn＋`SharedPromise::new()`＋
-  Supply 属性構築のみ・`&self` 依存ゼロ）＝`build_native_proc_async_value` static helper を `try_native_builtin_construct` に wire（Promise/Channel と同型・最易）。
-  ② **`IO::Socket::INET.new`＝io_handles 依存だが `IO::Path.open`（#3507）と同型**（`dispatch_socket_inet_new` が `insert_handle_state` で VM 所有 io_handle 確保）
-  ＝`try_native_socket_inet_construct` で既存 helper へ委譲。**真に構造ブロック（②まで land 後に ctor-fork 完了）**: `CallFrame`〔call stack carrier〕＝別軸。
-  （`Seq.new` は #3533 で native 化済＝下記。）**∴ ctor-fork 残=Proc::Async（pure）＋IO::Socket::INET（io_handles）の 2 件のみ。**
-- **2026-06-24 (§D ③ = `Seq.new($iterator?)` を VM ネイティブ化, #3533)**: 前エントリで「iterator carrier＝別軸（impure）」と保守的に分類していた `Seq.new` を再評価し
-  native 化。**carrier state 自体が VM 所有**（`predictive_seq_iters` フィールド ＋ env の `__mutsu_predictive_seq_iter::` 内部キー ＋ Seq の Arc を
-  キーにしたグローバル deferred-iter 副表）＝単一ストア化後 `self` は VM/interpreter 同一なので native gate から同じ書き込みができる。**構築は eager pull
-  しない**（PredictiveIterator は carrier に stash、materialized `items`/`stuff` instance は要素コピー、その他 iterator は deferred 登録、no-arg は
-  pre-consumed Seq）＝iterator 消費は後の consumption 時で構築とは別＝FS/process/user code 不要。`dispatch_new` の Seq arm（~46 行）を新 `&mut self`
-  helper `try_native_seq_construct` に**丸ごと抽出**（interpreter arm は delegation）。VM は非mut/mut 両 catch dispatch（Failure ctor arm の直後・
-  `class_name=="Seq"` gate・`method_dispatch_pure=true`）から呼ぶ＝**1 操作 = 1 実装**・byte-identical。user subclass（`class S is Seq`）は class_name が
-  自名に解決され gate に掛からず interpreter 維持。pin `t/native-seq-ctor.t`(11・raku/mutsu 双方 PASS。`.raku` の `$(...)` itemization 差は pre-existing・
-  無関係)。S32-list/seq.t(50)/skip.t/tail.t/rotor.t・S07-iterators/range-iterator.t(103) 全緑。**残 `new` fallback＝Proc::Async（pure・次）/
-  IO::Socket::INET（io_handles・次）/CallFrame〔call stack carrier・別軸〕。**
-- **2026-06-24 (§D ③ = `Proc::Async.new(@cmd, :w, :enc)` を VM ネイティブ化, #3535)**: 前々エントリで「state 依存」と保守分類していた
-  `Proc::Async.new` を再評価し native 化。**ctor は完全 pure data**＝引数パース（positional command ＋ `:w`/`:enc` flag）＋3 本の
-  process-global supply id（`next_supply_id`＝bare global counter）＋空の stdout/stderr/merged `Supply` instance 構築のみ。**実プロセス spawn は
-  `.start` 側**＝ctor 時は env/registry/io_handles/user code を一切触らない（`&self` 依存ゼロ）。`dispatch_new` の Proc::Async arm（~66 行）を新 static
-  helper `build_native_proc_async_value(class_name, args)` に**丸ごと抽出**（interpreter arm は delegation）し、VM は既存の `try_native_builtin_construct`
-  に `cn=="Proc::Async"` arm を `Promise`/`Channel`/`Supplier` と同型で wire＝**1 操作 = 1 実装**・byte-identical。pin `t/native-proc-async-ctor.t`(8・
-  raku/mutsu 双方 PASS。実 echo/cat round-trip ＋ exit code ＋ `:w` stdin 込み)。t/proc-async.t(23)・roast/S17-procasync/basic.t(47)/print.t(16) 全緑。
-  **残 `new` fallback＝IO::Socket::INET（io_handles・次・`IO::Path.open` と同型）/CallFrame〔call stack carrier・別軸〕。**
-- **2026-06-24 (§D ③ = `IO::Socket::INET.new(...)` を VM ネイティブ化, #3536)**: ③ ctor フォークの clean ラスト。`IO::Socket::INET.new`（`:listen`
-  server / client 両モード）の ctor は実 bind/connect を行うが、**書き込み先は VM 所有の `io_handles`**（`insert_handle_state`＝既に native 化済の
-  `IO::Path.open`〔#3507〕と同型）＝env/registry/user code は触らない。既存の `&mut self` helper `dispatch_socket_inet_new`（interpreter の `dispatch_new`
-  arm が呼んでいた単一 impl）を `pub(in crate::runtime)`→`pub(crate)` に広げ、VM の非mut/mut 両 catch dispatch（Seq ctor arm の直後・
-  `class_name=="IO::Socket::INET"` gate・`method_dispatch_pure=true`）から**同じ helper を直接呼ぶ**＝**1 操作 = 1 実装**・byte-identical（新規コピー無し）。
-  user subclass は class_name が自名に解決され gate に掛からず interpreter 維持。pin `t/native-socket-inet-ctor.t`(7・raku/mutsu 双方 PASS。実 loopback
-  client/server round-trip ＋ invalid port/family dies ＋ 独立 listener)。t/socket.t(3)・roast/S32-io/IO-Socket-INET.t(32)/IO-Socket-INET-UNIX.t(8)/
-  socket-accept-and-working-threads.t(15)/socket-fail-invalid-values.t(4)/socket-host-port-split.t(2) 全緑。**∴ ③ ctor フォーク完了**＝pure-value/
-  VM-owned-state な built-in ctor は全て native 化済。**残 `new` fallback＝CallFrame〔call stack carrier〕・error-only（HyperWhatever/Whatever/Instant）＝
-  別軸 or 構造ブロック。** 次は §D の本丸＝(b) tree-walk dispatch-chain 削除 substrate or multi-dispatch VM 化。
-- **2026-06-24 (§D multi-dispatch = proto sub dispatch（trivial body）の VM 化, #3541)**: ③ ctor 完了後の §D 次本丸＝multi-dispatch VM 化に着手。
-  実測（S06 sample・`MUTSU_VM_STATS`）で **bare multi は 0 fallback**（PR-4 で OTF 化済）だが **proto multi は 100% fallback**（2 層: proto sub 呼び出し自体
-  ＋内部 `__PROTO_DISPATCH__`、各候補 body は `call_proto_dispatch`→`run_block` で tree-walk）と判明。**trivial-body proto（`proto foo {*}` / bodyless）を
-  VM call site で直接ディスパッチ**: `dispatch_func_call_inner` の else ブロック先頭に proto fast-path を追加し、新ヘルパー `vm_resolve_trivial_proto_candidate`
-  が ① interpreter-handled 名を除外 ② proto def を `resolve_proto_function` で取得し body が trivial（`SetLine` marker 除外後に空 or `[Expr(Whatever)]`）か検証
-  ③ **proto 自身の sig を `method_args_match` で gate**（`proto f(Int) {*}` が Str を弾く・S06-multi/proto.t subtest 26 が捕捉した回帰を修正）④ `resolve_proto_candidate_with_types`
-  で winner 候補を解決（VM 所有レジストリ＝phase ②）⑤ OTF-compilable かつ非state なら返す。返れば `compile_and_call_function_def` で **候補 body を compiled 実行**
-  （tree-walk proto body＋`__PROTO_DISPATCH__` round-trip＋候補 `run_block` を全バイパス）。`nextsame`/`samewith`/`callwith` は同関数の `push_multi_dispatch_frame`＋
-  samewith context で動作（PR-4 で検証済の機構）。非trivial body / 非OTF候補 / where候補 / sig 不一致は `None` で従来の interpreter fallback 維持＝byte-identical。
-  可視性: `resolve_proto_candidate_with_types`/`resolve_proto_function`/`method_args_match` を `pub(crate)` に拡大。実測 `proto factorial` で fallback 100%→0%、
-  S06 sample の `__PROTO_DISPATCH__` 50→30（残 30 は where候補/非trivial body/非OTF候補で正しく fallback）。pin `t/proto-vm-dispatch.t`(12・raku/mutsu 双方 PASS=
-  recursion/型別候補/samewith/nextsame/proto-sig gate〔EVAL ラップ〕/非trivial body guard)。whitelisted S06 全 87 件＋roast/S06-multi/proto.t(27) 全緑、make test 11202。
-  **残 multi-dispatch fallback**: where 制約付き候補の OTF 化（候補側 `def_is_otf_compilable` が where 除外）/ 非trivial proto body の VM 化 / `@_` slurpy recursive
-  plain sub（別カテゴリ）。**★教訓: `{*}` proto body は登録時に `SetLine` marker が前置され body.len=2 になる＝trivial 判定は marker 除外が必須。proto 自身の sig は
-  候補 sig と独立の gate＝バイパス時は `method_args_match` で必ず検証（さもないと `proto f(Int)` の型検査が抜ける）。**
-- **2026-06-25 (§D = imported `is test-assertion` sub の OTF 化)**: `def_is_otf_compilable_module_single` の `!def.is_test_assertion` 除外を撤去
-  （`call_compiled_function_named` が test-assertion line context を push するので OTF compile しても assertion 失敗の caller 行報告は interpreter と同一）。
-  **ただし除外撤去だけでは効果ゼロ**: Test::Assuming/Test::Util の `is-primed-sig` 等は imported function として `Expr::Call` 経由で parse され、`Capture |cap` の
-  sub_signature で OTF ゲートに弾かれ続けていた。**鍵＝imported `is test-assertion` sub を using scope に再登録**（新 `InlineModuleExport.is_test_assertion`
-  フィールド・SubDecl から伝播・fallback regex も `is test-assertion` 検出）し、ローカル宣言の assertion helper と同じ parse 経路（`known_call_stmt`→`Stmt::Call`）に
-  載せる＝OTF-compilable dispatch に到達。実測 S06-currying の function-fallback 195（is-primed-sig=171/is-primed-call=21/priming-fails-bind-ok=3）→2。
-  `priming-fails-bind-ok`（body の `try`/`CATCH`）は保守ゲートに正しく残り byte-identical。pin `t/test-assertion-module-otf.t`(7)。make test 11471 PASS。
-  **★分離した別バグ（本 PR に含めず・要別作業）= `use` の export スキャン（`extract_exported_names`→`parse_program_partial`→`set_original_source(module_src)`）が
-  parser の `ORIGINAL_SOURCE` を module 一時 String（直後 drop）に上書き→dangling 化→以後 using ファイルの `current_line_number` が全 1 に潰れる汎用バグ。**
-  これを `snapshot_source_state`/`restore_source_state` で直すと caller 行は raku 一致になるが、**行番号正常化が「clobber 由来の行 1 で偶然 PASS していた」既存の
-  潜在バグを露出させる**（実測 2 件: S04-phasers/enter-leave.t#28〔`sub f(){ ENTER 'X' }` の ENTER-rvalue が Nil〕・keep-undo.t#10〔UNDO〕。standalone repro でも
-  Nil＝行番号非依存の真の phaser バグだが、テストは clobber された行 1 でだけ PASS していた）。blast-radius 不明（roast 全体に calibration-by-clobber が潜む可能性）なので
-  ORIGINAL_SOURCE 修正＋露出 phaser バグ群は本 PR から分離して別途対応。**★教訓: nested parse は SCOPES だけでなく `ORIGINAL_SOURCE` も clobber する。修正自体は正しいが、
-  長年 clobber に calibrate された「偶然 PASS」テスト群を露出させるので段階的に。**
-- **2026-06-25 (§D = `ORIGINAL_SOURCE` clobber 修正 ＋ 露出 phaser ブロック値バグの一般修正)**: 前エントリで分離した別バグを解消。
-  **(1)** `parse_program_partial`（module export スキャン / EVAL / pseudo-package の best-effort nested parse）が `primary::snapshot_source_state`/
-  `restore_source_state`（`ORIGINAL_SOURCE` + heredoc `LEAKED_REGIONS`）で caller の source state を save/restore するよう変更＝clobber 解消・
-  using ファイルの `current_line_number` が raku 一致に。**(2)** 露出した phaser バグ（**行番号非依存の真のバグ**）を一般修正: ①trailing ENTER phaser
-  がブロック/サブ/クロージャ/do-block の値になる（新 OpCode `PushEnterResult`/`LoadEnterResult` + VM `enter_result_stack`＝ENTER section の値を body
-  末尾に橋渡し。ENTER は value-result baseline 記録前に走るのでスタック直置きでは検出されない）②値決定文を「最後の非 `SetLine` 文」に変更（行番号正常化で
-  文間 `SetLine` が入り phaser-only ブロックの末尾 `SetLine` が偽 `True`→KEEP 誤発火していたのを UNDO に修正）。**(3)** 5 重複していた BlockScope phaser
-  圧縮（top-level / `Stmt::Block` / do-block / sub body / closure）を共有 `compile_phaser_block_scope(stmts, result_on_stack)` に集約（statement=topic /
-  do-block=stack の 2 モード）。pin `t/enter-phaser-rvalue.t`(18)。全 t/(11502)・S04-phasers whitelist(17)・`use Test::Util` whitelist 270 本・roast 1/3
-  サンプル 428 本いずれも回帰ゼロ。**★教訓: phaser ブロックの値は ENTER section とは別フェーズで実体化が要る（専用スタックで body 末尾に橋渡し）。do-block は
-  値をスタックで返す（`DoBlockExpr` が pop）が statement 文脈は topic 経由＝同じヘルパーをモードで分岐。**
-- **2026-06-25 (§D(b) tree-walk dispatch chain 削除 = `.starts-with`/`.ends-with`〔無印形〕の VM ネイティブ化)**: method-fallback の名前別実測で
-  `starts-with`(513) が catch-all バウンス上位（`name`/`WHAT`/`WHY`/`can`=MOP 反射・撲滅対象外、`tap`/`stdout`=concurrency 別軸、iterator protocol 群=lazy 別軸を除く）。
-  原因＝`starts-with`/`ends-with` は named-arg（`:i`/`:ignorecase`/`:m`/`:ignoremark`）対応のため slow path（`dispatch_prefix_suffix_check`）に置かれ、**named arg を持たない
-  `.starts-with($needle)` 一般形まで interpreter にバウンス**していた。`(false,false)` ケースは純 prefix/suffix 判定なので `native_method_1arg`（methods_narg.rs）に
-  Str-receiver gated arm を追加。named-arg 形は **2 引数（positional + Pair）なので 1-arg native path に到達せず**自然に slow path へフォールスルー＝byte-identical。
-  user 定義 `.starts-with` は VM が native 前に解決するため非shadow（既存 `contains` arm と同保証）。実測 `$s.starts-with` fallback 2→0。pin `t/starts-ends-with-native.t`(22)。
-  全 t/(11572)・S32-str/starts-with.t・ends-with.t・文字列 roast 70・1/5 roast サンプル 257 回帰ゼロ。**★教訓: named-arg 対応で slow path に置かれた純メソッドは、
-  named-arg が arity を増やして別 path に行くので「無印 1-arg ケースだけ」を native gate（受け手型で限定）すれば安全に drain できる。`substr-eq`(87・位置解決 Whatever/負数/Failure で複雑)
-  は次スライス候補。**
-- **2026-06-25 (§D(b) tree-walk dispatch chain 削除 = `.substr-eq($needle, Int $pos)` の VM ネイティブ化)**: starts-with と同パターンの 2 スライス目。`.substr-eq` は
-  named-arg（`:i`/`:m`）と Whatever/負数/範囲外の位置解決（Failure 生成）対応のため slow path（`dispatch_substr_eq`）に在った。**plain 2 引数形＋非負 in-bounds Int 位置＋Str
-  受け手**は純 substring 比較なので `native_method_2arg` に arm 追加。それ以外は全てフォールスルー: Whatever/非Int 位置（`arg2` が `Int` でない）→ interpreter 解決／負数・範囲外 →
-  interpreter Failure／named-arg 形（Pair 追加で arity 3）→ 2-arg native path 不到達／user 定義 `.substr-eq` は native 前に解決＝非shadow。1 引数形（位置 0 デフォルト）は稀でフォールスルー維持。
-  pin `t/substr-eq-native.t`(16)。全 t/(11566)・S32-str/substr-eq.t・indices.t・index.t 回帰ゼロ。**★残る clean な string drain は枯渇**: `comb` 単純形は既に native（survey の 93 は
-  regex/named-arg 形）、`trans`(65) は range（spec 文字列内 `a..z`）/list-pair/regex で複雑、`Int`/`Num`/`Str.new` は ctor 完了済み領域。残カテゴリ＝iterator protocol 群（lazy・別軸）/
-  MOP carrier（反射・撲滅対象外）/concurrency（tap/emit・別軸）で、いずれも §D(b) の純 drain でなく別 substrate 前提。**
-- **2026-06-25 (§D(b) tree-walk dispatch chain 削除 = `Buf.write-int*`/`.write-uint*`/`.write-num*` 族の VM ネイティブ化)**: method-fallback 再計測（全1285 whitelist
-  集計）で string drain 枯渇後の **最頻 clean-drain カテゴリ**が判明＝`write-int8/16/32/64/128`(各 3852) ＋ `write-uint*`(各 2220) ＋ `write-num32/64`(各 492)＝計 ~3 万 fallback。
-  発生源は **S03-buf/write-int.t / write-num.t**（`existing."$write"($off,$val[,$endian])` の `\sigilless` instance 形と `buf8."$write"(...)` の type-object 形＝両方 `"$write"`
-  **動的メソッド名**）。既存 native 化は **mut-bound `$`-var の static 名**（`try_native_buf_mut`・CallMethodMut）のみで、(1) type-object 形（`Value::Package` 受け手＝fresh buf 返し）
-  (2) `\sigilless`/`BareWord` instance 形（non-mut 動的 op `exec_call_method_dynamic_op`→`try_native_method` 経由・writeback 先 var 無し）(3) `$`-var 動的名（mut 動的 op
-  `exec_call_method_dynamic_mut_op`＝native fast path を一切試さず直接 `vm_call_method_mut_with_values`）の 3 経路が全て interpreter にバウンスしていた。**修正**＝新 pure helper
-  `buf_write_int::try_native_buf_write(target, method, args)` が type-object（fresh `make_buf_value`）と instance（shared cell へ `write_back_sharing`→`commit_attrs` で in-place commit
-  →全 binding が観測）の両形を 1 impl で扱う（byte transform は既存共有 `apply_write_int`/`apply_write_num`）。これを **`try_native_method` 冒頭**に wire（arity-keyed `native_method_*arg` は
-  3 引数〔offset,value,endian〕を dispatch 不可なので専用分岐が必須）→ 経路(1)(2) を drain。経路(3) は `exec_call_method_dynamic_mut_op` で generic fork 前に `try_native_buf_mut` を呼んで drain。
-  **フォールスルー維持**＝`Blob`/`blob8`（type-object はメソッド無し・instance は immutable で interpreter が "Cannot modify immutable Blob" を raise・現挙動 byte-identical）/非Int offset
-  （Whatever 位置解決）/負数・範囲外（`apply_write_int` が Err→`dies-ok` 維持）/arity≠2,3。**実測 write-int.t fallback 20240→0・write-num.t 656→0**（両 method-call fallback 完全消滅）。
-  全 t/(11615 PASS)・S03-buf 全緑・roast 108 サンプル回帰ゼロ。pin `t/buf-write-native.t`(27・type-object/scalar/sigilless 動的名/round-trip/error 全形)。**★教訓: 動的メソッド名
-  （`."$name"()`）には 2 つの専用 opcode（`CallMethodDynamic`〔BareWord/literal target〕/`CallMethodDynamicMut`〔`$`/`@`/`%`-var target〕）があり、後者は native fast path を一切試さない
-  ＝static 名で native 化済のメソッドも動的名だと全バウンス。動的名で呼ばれる native メソッド族を drain するには両 dynamic op に fast-path 呼び出しを足す要あり。instance mutator の non-mut
-  動的形は writeback 先 var が無くても shared attribute cell（`commit_attrs`）への in-place commit で `\sigilless`-bound に伝播する（env insert 不要）。**
-- **2026-06-25 (§D(b) tree-walk dispatch chain 削除 = `Str.contains($needle, $pos?, :i/:m?)` の named-arg/position 形の VM ネイティブ化)**: starts-with/substr-eq で
-  「named-arg 形は slow path 維持」と保守的に deferred していた string-method 族の **named-arg 形を初めて native 化**。`S32-str/contains.t`(survey 278) は全テストが
-  `invocant.contains(|c)` で **markings named-arg（`:i`/`:ignorecase`/`:!i`…）を必ず付ける**ため、無印 1-arg native 形（`native_method_1arg`）にほぼ到達せず、Pair 付き 2-arg or
-  position+Pair の 3-arg で arity-keyed dispatch（`native_method_2arg` 止まり・3arg path 無し）を素通りして 100% interpreter にバウンスしていた。**修正**＝新 variadic helper
-  `native_contains_with_options(target, args)` が positional/named を分離し、needle=positional[0]・start=positional[1]（Int/Num/Str-parse）・`i`/`ignorecase`/`m`/`ignoremark`
-  を全て lowercase 比較に畳む（`Interpreter::dispatch_contains` を厳密ミラー）。`try_native_method` の arity dispatch 直前に wire。**フォールスルー維持**＝非Str 受け手（**Match invocant** は
-  別軸の Match→Str coercion・instance-bypass 相互作用で defer）/Package needle/BigInt position（overflow→X::OutOfRange は interpreter）/負数・範囲外 position（X::OutOfRange Failure）/
-  未知 named arg。junction needle は `contains_value_recursive[_ci]` で thread。**実測 contains.t fallback 272→140**（残 140＝Match invocant・別軸）。全 t/(11610)・contains 11 形 byte-identical
-  （unicode CI・Str position 含む）・roast contains 系サンプル回帰ゼロ。pin `t/contains-options-native.t`(22)。**★教訓: starts-with/substr-eq で「named-arg は deferred」としたが、
-  named-arg 形こそが実テストの主トラフィックのことがある（contains.t は全形 markings 付き）。variadic helper（positional/named 分離→interpreter dispatch ミラー）を arity dispatch 前に
-  wire すれば named-arg 形も drain できる。受け手が Str 以外（Match 等 coercion 要）の半分は別軸で残る。**
-- **2026-06-25 (§D(b) tree-walk dispatch chain 削除 = `Str.starts-with`/`.ends-with`/`.substr-eq` の `:i` named-arg 形の VM ネイティブ化)**: contains slice で確立した
-  variadic-helper パターンを兄弟 string-method に横展開。`S32-str/{starts-with,ends-with,substr-eq}.t` も全形に markings named-arg を付ける（contains.t と同型）ため、無印
-  native 形（starts-with=1arg・substr-eq=2arg）が drain 済でも `:i` 付き形（Pair で arity 超過）は 100% interpreter にバウンスしていた。**修正**＝新ヘルパー `native_prefix_suffix_with_options`
-  （starts-with/ends-with）/ `native_substr_eq_with_options`（substr-eq）が共有 `split_string_match_args`（positional/named 分離・`i`/`ignorecase`=ci・`m`/`ignoremark`=mark・未知 named は
-  defer）で markings を解釈し、`dispatch_prefix_suffix_check`/`dispatch_substr_eq` を厳密ミラー。`try_native_method` の arity dispatch 直前（contains arm の隣）に wire。**フォールスルー維持**＝
-  非Str 受け手（**Match invocant**＝別軸）/Package needle/`:m`/`:ignoremark`（`strip_marks` decomposition は interpreter）/substr-eq の非Int-非Str position（Whatever resolution）・負数・範囲外
-  （X::OutOfRange Failure）/無印形（既存 1-/2-arg arm 維持）。**実測 starts-with.t 80→42・ends-with.t 80→42・substr-eq.t 86→48**（残＝Match invocant `:i` 形・別軸）。全 t/(11692)・
-  3 ファイル proper-harness PASS・10 named 形 byte-identical to raku（unicode CI・Str position 含む）・whitelist 回帰ゼロ。pin `t/starts-ends-substr-eq-named-native.t`(21)。**★教訓:
-  raku 参照実装は `"abc".ends-with("", :i)` で "Iteration past end of grapheme iterator" を投げる（空 needle+ci のバグ）が mutsu は正しく True を返す＝pin から該当形を除外（mutsu の方が正しい）。
-  ★string-method の `:m`/`:ignoremark` は `strip_marks`（NFD→combining-mark filter）で別処理だが、これらの roast テストは backend≠moar ゲートで `:m` 形を skip するので native 化不要・defer で十分。**
-- **2026-06-25 (§D(b) tree-walk dispatch chain 削除 = string-search 4 メソッドの Match invocant の VM ネイティブ化)**: 前 3 slice（contains/starts-with・ends-with・substr-eq）で
-  「Match invocant は別軸（Match→Str coercion・instance-bypass 相互作用）」と deferred していたが、精査で **低リスクな gate 緩和のみで解決可**と判明。①`is_native_method("Match", …)` は
-  **エントリ無し→false**＝Match.contains 等は instance-bypass block を通過し variadic helper（arity dispatch 直前）に到達する ②各 helper は既に `text = target.to_string_value()` で text を取得
-  ＝Match なら matched substring（`Cool.Str` と同一）。∴ 受け手 gate を `Value::Str(_)` のみ → 新述語 `is_str_or_match_receiver`（Str or `Instance{class_name=="Match"}`）に緩和するだけで
-  4 メソッド全形の Match invocant を drain。**失敗 match は `Any`/`Nil`（Match instance でない）→ gate 不通過→interpreter が "No such method" を raise**（byte-identical）。**実測 contains.t 140→6・
-  starts-with.t 42→8・ends-with.t 42→8・substr-eq.t 48→14**（残＝bare Match 形〔markings 無し・1-/2-arg arm が Str-gate〕＋テスト自身の `.match`/`$*PERL.compiler`）。全 t/(11710)・4 ファイル
-  proper-harness PASS・9 Match-invocant 形 byte-identical to raku（position・unicode CI 含む）・whitelist 回帰ゼロ。pin `t/str-search-match-invocant-native.t`(18)。**★教訓: 「別軸」と分類した
-  defer も、bypass 順序（`is_native_method` テーブルに対象クラスが無ければ通過）と既存の coercion（helper が `to_string_value` で text 取得）を精査すると 1 述語の gate 緩和に圧縮できることがある。
-  4 連続 string-search slice で `S32-str/{contains,starts-with,ends-with,substr-eq}.t` の method-fallback はほぼ枯渇（各 ≤14＝bare Match 形のみ）。**
-- **2026-06-25 (§D 状態所有 = atomic var/element RMW（`__mutsu_atomic_*`/`__mutsu_cas_*`）の VM ネイティブ dispatch)**: method-fallback の clean drain 枯渇後、**function-fallback** を全 whitelist 集計したところ
-  `__mutsu_atomic_add_var`(640001)/`__mutsu_atomic_post_inc_var`(320038)/`pre_inc`/`post_dec`/`pre_dec`(各 320001)/`__mutsu_cas_var`(282337)/`cas_hash_elem`(30000)/`cas_array_elem`(29420)＝
-  **計 ~250 万 fallback で function-fallback 全体を圧倒的に支配**（concurrency stress＝`⚛`-operators 駆動）。これは §D「状態所有」の直撃カテゴリ＝atomic op は VM 共有の `shared_vars`（`RwLock`）store と
-  per-attribute cell-CAS state（Phase 3）への RMW。既存 `builtin_atomic_*`/`builtin_cas_*` impl が既にその state を所有・操作しているが、**到達経路が generic な `call_function`（`vm_call_function`→`loan_env_for`→
-  ~数百 arm の名前 match）fallback だけ**だった（`try_native_function` は pure な `native_function` のみ呼ぶため `&mut self` の atomic op は素通り）。**修正**＝新 `try_native_atomic_function(name,args)`（`builtins_atomic.rs`・
-  `builtins.rs` の atomic arm 群を 1:1 ミラー・`cas_*` は `args.to_vec()`）を `try_native_function` 冒頭（Instance-arg bail より前＝`cas($x,$old,$obj)` の Instance 値も dispatch 可）で
-  `name.starts_with("__mutsu_atomic_"|"__mutsu_cas_")` 時に呼ぶ。`loan_env_for` は CP-3 collapse 後 `f(self)` の薄い passthrough＝env は両経路で同一 `self.env`・builtin は同一＝byte-identical。
-  **実測 atomic-ops.t/atomic.t の function-fallback：atomic markers が完全消滅**（cas.t stress=95003 opcodes 中 fallback 61＝残は `start`/`await`〔concurrency 別軸〕＋user-facing `cas`）。
-  全 t/(11725)・S17-lowlevel/{cas,cas-loop,cas-loop-int,atomic,atomic-ops}.t 全 PASS（atomic.t 34/34・atomic-ops.t 28/28＝debug は `for ^20000` stress で遅いが完走）・20 atomic 形 byte-identical to raku。
-  pin `t/atomic-ops-native-dispatch.t`(20)。**★教訓: method-fallback だけでなく function-fallback survey も §D の宝庫。`__mutsu_*` 内部マーカー（atomic/cas/hyper-prefix）は「pure でない（`&mut self`）」ため
-  `try_native_function`→`native_function`(pure) を素通りし generic `call_function` fallback に全部落ちていた。`try_native_function` 冒頭に `&mut self` builtin への直接 dispatch arm を足せば、巨大 stress 系の
-  fallback を一掃できる（state 所有は既に VM 側＝挙動不変の経路短絡）。**
-- **2026-06-25 (§D 状態所有 = builtin operator-as-function `infix:<op>(...)` の VM ネイティブ dispatch)**: atomic 後の function-fallback 集計で `infix:<op>` 族＝**44 演算子で計 ~5400 fallback**
-  （`&infix:<+>`・`[+]`/`[*]` reduce・`>>+>>` hyper・`reduce &infix:<…>` が lower する routine 形）。builtin operator は native Rust の `call_infix_routine`（`&mut self`・hyper/assignment-metaop/set-op/
-  全 binary op を dispatch）が impl だが、到達経路が `call_function_fallback` の infix arm 経由（tree-walk fallback 記録）だけだった。**修正**＝`dispatch_func_call_inner`（直接 Call 経路）と
-  `call_function_compiled_first`（hyper/reduce/string-regex 経路）の両方で、**全 user 演算子解決（compiled_fns / 非proto multi fork / `user_function_matches_call` / OTF）を試した後・terminal fallback の直前**に
-  `infix:<op>` を捕捉して `call_infix_routine(op,args)` を直接呼ぶ（U+2212 minus は `-` に正規化・arg_sources と `maybe_fetch_rw_proxy` は terminal else と同一処理＝byte-identical）。**user-override 厳守**＝
-  user `sub/multi infix:<…>` は上位ブランチで解決されるので native arm に到達せず（pin で `infix:<plus>`=103・`multi infix:<%%%>`=custom を検証）。**実測 直接 infix 呼び 100%→0**（user multi は正しく fallback 維持）。
-  全 t/(11765)・whitelist operator/metaops/junction 79 ファイル回帰ゼロ・20 infix 形 byte-identical to raku。pin `t/infix-function-native-dispatch.t`(22)。**★`call_infix_routine` を `pub(crate)` に拡大。
-  ★教訓: 直接 Call は `dispatch_func_call_inner`・hyper/reduce 等は `call_function_compiled_first` と fallback 記録サイトが 2 系統あるので、両方に同じ arm を置く要がある。user-override 系演算子の native 化は
-  「全 user 解決ブランチの後・fallback 記録の前」に挿入するのが鍵（先頭に置くと user 演算子を shadow する）。`<`/`>` を含む演算子名（`infix:«<»`）は別パーサ問題で CALL-ME エラー＝pin から除外。**
-- **2026-06-25 (§D 状態所有 ③ = file/FS builtin *関数* 形の VM ネイティブ dispatch)**: IO native **メソッド**族は drain 済（2026-06-23 群）だったが、**関数形**（`slurp($p)`/`open($p,:r)`/`unlink($p)`/
-  `spurt`/`close`/`dir`/`copy`/`rename`/`move`/`chmod`/`mkdir`/`rmdir`/`link`/`symlink`）は `call_function` fallback 経由のままだった（survey: unlink 1172/open 1017/slurp 569 他・計 ~3000）。これらは VM 所有
-  `io_handles` store ＋ filesystem への `&mut self`/`&self` 操作で、`builtin_*` impl が既に state を所有。**修正**＝新 `try_native_io_function(name,args)`（`builtins_io.rs`・`call_function` の IO arm を 1:1 ミラー）を
-  **infix と同じく user-override 安全な位置**で呼ぶ: `dispatch_func_call_inner` は全 user 解決後（lexical-amp の後・infix arm の前）の else-if、`call_function_compiled_first` は OTF 後・record 前。
-  **`try_native_function` には入れない**（call_function_compiled_first では user 解決〔OTF〕より前に走るので非compiled user `sub slurp` を shadow する＝atomic は `__mutsu_*` で user 定義不可だったので安全だった差）。
-  **除外**＝`indir`（callback block 実行）・`chdir`/`tmpdir`/`homedir`（process cwd/env 副状態）・`print`/`say`/`note`/`warn`/`sink`（出力/block）。FS 関数は rw param 無しなので arg_sources 不要・`maybe_fetch_rw_proxy(true)`
-  は terminal else と同一＝byte-identical。**実測 builtin IO 関数呼び 0 fallback**・user `sub slurp`/`sub unlink` は上位解決で正しく shadow（pin 検証）。全 t/(11806)・whitelist S32-io/S16-io 64 ファイル回帰ゼロ・
-  14 IO 形 byte-identical to raku。pin `t/io-function-native-dispatch.t`(14)。**★教訓: user-definable な builtin 名（IO/operator）の native 化は `try_native_function`（早すぎ）でなく、両 dispatch 経路の
-  「user 解決後・fallback record 前」に置く。`__mutsu_*` 内部マーカー（atomic）だけが `try_native_function` 先頭に置ける（user 定義不可ゆえ）。残 function-fallback＝concurrency（await/start・start は
-  `sync_env_from_locals` 要で別軸・flaky）/ MOP（samewith）/ heterogeneous 内部マーカー（feed/assign-lvalue・context-sensitive）＝clean homogeneous drain は枯渇。**
-- **2026-06-25 (§D(b) = 純 list/coercion builtin *関数* 形〔`val`/`list`/`slip`/`hash`〕の VM ネイティブ dispatch)**: IO 関数形と同パターンの follow-up。`val`(pure free-fn)/`list`/`slip`/`hash`(`&self`)は
-  collection constructor で、`call_function` fallback 経由のままだった（survey: slip 3824〔S07-hyperrace stress〕/val 1555/list 720/hash 336・計 ~6400）。新 `try_native_collection_function(name,args)`
-  （`builtins_collection.rs`・`call_function` arm を 1:1 ミラー）を **IO/infix と同じ user-override 安全位置**（`dispatch_func_call_inner` の IO arm の後・infix arm の前／`call_function_compiled_first` の IO arm の後）で呼ぶ。
-  pure/`&self` で rw param 無し＝byte-identical。**実測 builtin val/list/slip/hash 呼び 0 fallback**・user `sub list` は正しく shadow（pin 検証）。全 t/(11834)・whitelist S02/S07-slip/S32-list 132 ファイル回帰ゼロ・
-  raku byte-identical。pin `t/collection-function-native-dispatch.t`(14)。**★pin で判明した別軸（mutsu 既存挙動・本変更と無関係）: `list((1,2),3)` を mutsu の `builtin_list` は flatten するが raku は `((1,2),3)`（非flatten）/
-  block-scoped `sub list` が mutsu では outer に leak（raku は block-scope）＝両方 pin から除外。★function-fallback の clean drain（state-owning: atomic/IO ＋ pure dispatch: infix/collection）は実質枯渇。残＝concurrency
-  （await/start/Supply/tap・Promise/scheduler state・flaky）/ MOP（samewith・反射）/ user-class 構築（new/bless・構造 substrate 要設計）。**
+- **2026-06-14 (③ ctor 2nd wave = post-assembly phase approach, #3028–3036)**: broke the "pure-data only" principle and, after pure-data
+  assembly, ran **submethod execution / constraint validation / role mixin as post-assembly phases**, making user-code-running shapes
+  native too. Extracted each phase of the `.new` main path into shared helpers (`run_tweak_phase`/`run_build_phase`/`enforce_attribute_where_constraints`/
+  `apply_attribute_does_role_mixins`), called from both interpreter and native to guarantee byte-identical. **TWEAK(#3028)** (`TWEAK(:$y)`
+  argument passing = the two constructor lineages handled it differently) → **where(#3030)** (enforce both before and after TWEAK = assignment-time semantics) →
+  **BUILD(#3032)** (`fail`→Failure / custom BUILD suppresses named-arg auto-assignment / positional rejection = also fixed the pre-existing `S.new("pos")` bug) →
+  **is-rw(#3034)** (fixed the bug where `ClassAttributeDef` pos3=is_rw was misread as is_required; unprovided is-rw becomes native +
+  `@`/`%` required enforcement also correct) → **does-Role(#3036)** (mixin the role into the attribute value; a documented raku-non-compliant approximation, so
+  validated native==interpreter). Individual pin tests (`t/native-{tweak,where,build,isrw,doesrole}-construct.t`). S12/S14 whitelist all green, make test PASS.
+  **★ Re-measurement (important)**: after the 5 ctor slices, the whitelist sample's `new` method fallback is nearly unchanged (5230→5225). **Most (4686) is
+  `Buf.new` in a single test `S03-buf/read-write-bits.t` = a built-in type constructor** (`is_native_default_constructible` only targets user-defined
+  `registry().classes`, so it is correctly out of scope). **= User-class ctor native-ification is complete. Further ctor shaving will not move the `new`
+  fallback count.** The next real targets are other categories: **built-in type `.new`** (Buf.new etc.) / **`name`=3257 (MOP)** /
+  **`op`=1418 (Routine-value lexical &-var `&infix:<(|)>` binding, the exclusion from this round's Sub/WeakSub-limited fix)** / iterator push-* protocol
+  (Track B) / coercion (lowering to builtins). Remaining hard ctor cases: required-after-BUILD / unset class-typed + BUILD / `is built`/
+  MOP set_build / BUILDALL / custom new / CUnion.
+- **2026-06-23 (§1 = making `.MixHash` coercion VM-native)**: a measurement-driven slice of §D (state ownership). Measuring the dominant catch-all
+  categories with `MUTSU_VM_STATS` showed the most frequent was `.MixHash` (the only remainder of QuantHash coercion), which PR-8 had
+  **explicitly excluded**. PR-8's exclusion reason was "`.MixHash` registers container type metadata = interpreter-owned state", but
+  **this is stale since #2952–2985's embedding of container-value metadata** = the type metadata of the `Value::Mix` produced by `.MixHash`
+  (`value_type=Real`/`declared_type=MixHash`) is **embedded in the Mix's `Arc<MixData>`, not an interpreter side table** (the `embed_type_info!` path of
+  `tag_container_metadata`; only the `other =>` branch for Instance etc. hits the side table `register_container_type_metadata`).
+  ∴ `.MixHash` is a pure value op touching no env/state at all and can be made native in the same shape as `.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`.
+  Added the new pure fn `builtins::quanthash_coerce::to_mixhash` (`to_mix(_, "MixHash")` → mutable flip + metadata embedding) to the VM's
+  `try_native_quanthash_coerce` (added `"MixHash"` to the method match). **dedup**: the `Mix|MixHash` branch of the interpreter's `dispatch_method_by_name_2`
+  now delegates to `to_mixhash` (removed the direct `tag_container_metadata` write) = **1 operation = 1 implementation**. The receiver gate is
+  identical to the 5 existing siblings (only list-like is native; Instance/Package stay on the interpreter). Variable receivers (`%h.MixHash`) go to the
+  mut path via `CallMethodMut` routing where all 6 siblings uniformly fall back = **exact parity with existing behavior** (a future slice candidate is
+  lowering them into the mut path all at once). Behavior-invariant (native==interpreter = same `to_mixhash`). pin `t/native-mixhash-coerce.t`(22,
+  PASSing on both raku and mutsu; avoids the `.WHICH` key difference by using Str elements). mix.t 244/244, set.t, categorize green.
+  (bag.t 625 "Foo instance union" is pre-existing per BLOCKERS.md and unrelated to this change.)
+- **2026-06-23 (§1 = making QuantHash coercion VM-native on the mut path too)**: follow-up to the MixHash slice above. **Variable receivers**
+  (`@a.Set`/`%h.MixHash`) compile to `CallMethodMut` and never hit the non-mut path's `try_native_quanthash_coerce`, so all 6
+  siblings (`.Set`/`.Bag`/`.Mix`/`.SetHash`/`.BagHash`/`.MixHash`) uniformly fell back to the interpreter at the mut catch-all
+  (see the "parity" note of the MixHash slice). Added the same `Self::try_native_quanthash_coerce` to the **mut catch-all** in `vm_call_method_compiled.rs`
+  (end of `try_compiled_method_mut_or_interpret`, after `try_native_first`). Coercion returns a **new** Set/Bag/Mix value and
+  does not mutate the receiver variable (no writeback needed), so it's exactly the same shape as the non-mut path = behavior unchanged. Instance/Package receivers fall through.
+  Measured: fallback of `@a.{Set,Bag,Mix,SetHash,BagHash,MixHash}` 6→0 (remaining `^name` is MOP). pin
+  `t/native-quanthash-coerce-mut-path.t`(19, PASSing on both raku and mutsu). mix.t 244/244, set.t, categorize green.
+  (bag.t 252 / classify.t 40 [junction classify, non-whitelisted]: confirmed via stash they also fail on main = pre-existing, unrelated to this change.)
+- **2026-06-23 (§1 = making `.Map`/`.Hash` coercion VM-native + lowering to builtins)**: continuation in the same shape as QuantHash coercion.
+  `.Map`/`.Hash` are **pure value ops** (`dispatch_to_hash_impl`/`dispatch_to_map` are entirely `&self`-independent = they touch no env/registry/
+  state, only `Self::` static helpers + `super::utils::`; `.Map`'s declared-type is embedded in the `Value::Hash`'s `Arc<HashData>`,
+  no side table used since #2952). **dedup lowering**: moved `dispatch_to_hash_impl`/`dispatch_to_map`/`items_to_hash`/
+  `make_odd_number_error` into the new `src/builtins/map_hash_coerce.rs` (pure free fns `to_hash(target, check_odd)`/`to_map(target)`).
+  The interpreter's `dispatch_to_hash` delegates; `dispatch_to_map` is removed (the `Map|Hash`
+  branch of `dispatch_method_by_name_2` calls `to_map`/`to_hash` directly and the direct `tag_container_metadata` write is removed too) = **1 operation = 1 implementation**. Added to the VM
+  `try_native_map_hash_coerce` (both non-mut + mut catch-alls). Receiver gate: only list-like / Hash / QuantHash are native;
+  Instance (Match's named captures / `__baggy_data__`) / Package (type objects) / lowercase `.hash` stay on the interpreter.
+  Behavior unchanged (`to_map` embeds and keeps identity = `Map.Map === Map`; odd count gives `X::Hash::Store::OddNumber`). pin
+  `t/native-map-hash-coerce.t`(21, PASSing on both raku and mutsu). mix.t 244/244, set.t, hash.t, categorize, classify-list green.
+- **2026-06-23 (§1 = making the structural branch of `.Seq` coercion VM-native)**: capping the coercion drainage. `.Seq` is
+  `dispatch_seq_coercion` (`&mut self`), but **the structural branch (Seq/Array/Slip/Range/bare scalar) is pure**; only
+  Supply (on-demand callback-driven) / LazyList (lazy bridge force) / Instance (Buf/Blob byte reads, generic wrap) depend on
+  carrier/state. Extracted the pure branch into the new `src/builtins/seq_coerce.rs::to_seq_structural(target) -> Option<Value>`
+  (Supply/LazyList/**all Instance** return `None` to the interpreter). The interpreter's `dispatch_seq_coercion` delegates at the top;
+  the VM calls it on both non-mut + mut catch-alls when `method == "Seq"` = **1 operation = 1 implementation**. `.Seq` of gather/lazy continues to
+  drain correctly via the interpreter carrier. pin `t/native-seq-coerce.t`(16, PASSing on both raku and mutsu). S32-list/seq.t, S17-supply/Seq.t,
+  integration/sequence.t green. **This completes the measured drain of the pure-coercion fallback category (Set/Bag/Mix/MixHash/Map/Hash/List/Array/Slip/Seq)**
+  = the only remaining coercion fallbacks are `.Setty`/`.Baggy`/`.Mixy` (return type objects; niche).
+- **2026-06-23 (§D = making pure lexical `IO::Path` methods VM-native)**: measurement-driven slice after the coercion drain.
+  `MUTSU_VM_STATS` **spread measurement (distinct file counts)** showed the largest method-fallback category was `parent`(66 files)/
+  `add`(65 files) = **IO::Path path-manipulation methods** spread across 60+ files via the temp-file/dir helpers (`make-temp-dir`/`make-temp-file`)
+  (the highest raw count, `AT-POS`=5816, concentrates on the Buf receiver of a single `read-int.t` = spread of only 7 files, so unsuitable).
+  Of `IO::Path`'s `native_io_path` (`&mut self`, FS/cwd-dependent), extracted the **pure lexical methods that only manipulate the path string**
+  (`parent`/`add`/`child`(non-secure)/`sibling`/`basename`/`dirname`/`volume`/`cleanup`/`parts`/`extension`/`succ`/`pred`/
+  `starts-with`/`is-absolute`/`is-relative`/`Str`/`gist`/`IO`/`SPEC`) into the new associated fn `Interpreter::try_io_path_lexical`
+  (no `&self` needed = touches no FS/cwd/env at all; uses only static `Self::io_path_*` helpers). **dedup**: `native_io_path`
+  delegates to it at the top and the moved arms are deleted = **1 operation = 1 implementation** (the join of `child`/`add` is factored into the shared helper
+  `io_path_join_child`; only `child :secure`'s FS-resolve stays in `native_io_path`). The VM calls `Self::is_io_path_lexical_class`
+  (limited to built-in `IO::Path`/`::Unix`/`::Win32`/`::Cygwin`/`::QNX`) + `try_io_path_lexical` **immediately before** the `is_native_method`
+  bounce on **both non-mut + mut** (placed here rather than the catch-all because the fallback recording happened at the `is_native_method` bounce
+  [vm_call_method_compiled.rs:201/1652]). Like coercion, **returns a new IO::Path/string/bool and does not mutate the receiver** = no writeback needed.
+  FS/cwd-dependent (`e`/`f`/`slurp`/`spurt`/`absolute`/`relative`/`resolve`/`CWD`/`raku`), numeric coercion, and `child :secure` return
+  `None` and stay on the interpreter = behavior-invariant. Measured: fallback of `$p.{parent,add,basename,dirname,sibling,…}` → 0
+  (what remains is `Str.IO` coercion [a different operation, Str receiver] and `IO::Path::*.new` [③ ctor]). pin `t/native-io-path-lexical.t`(40,
+  literal `.IO` + variable receiver [mut path] + Win32 subclass round-trip; PASSing on both raku and mutsu). The 2 existing fails of io-path.t
+  (`.SPEC`/`.CWD` attributes) also fail on main = unrelated to this change. S16-io/S32-io/tmpdir/cwd/dir whitelist all green.
+- **2026-06-23 (§D = making Cool scalar `.IO` coercion VM-native)**: follow-up to the IO::Path lexical slice (above).
+  Drained the runner-up by measured spread, `.IO` (14 files: `"path".IO`/`$s.IO`/`42.IO`) = the fallback coercing Str/numeric to IO::Path.
+  `.IO` is an arm of `dispatch_method_by_name` (`make_io_path_instance(target.to_string_value())` + null-byte check;
+  IO::Path type objects are identity), which **reads `&self` = `$*SPEC`/`$*CWD` from env** = not pure, but the VM owns env,
+  so a native read is possible. Added `try_native_io_coercion` to both non-mut/mut catch-alls (after the iterator construct, immediately before the final
+  fallback), making **Str/Int/BigInt/Num/Rat/FatRat/Complex/Bool receivers + IO::Path(-subclass) type-object identity** native,
+  **calling the same `make_io_path_instance`** = 1 operation = 1 implementation (interpreter dispatch untouched; same fn shared). Instance (user `.IO`/
+  IO::Path/IO::Handle) / non-IO Package / aggregates / **Junction (autothread)** return `None` and stay on the interpreter = behavior-invariant
+  (`("a"|"b").IO` returns a Junction; parity confirmed). Returns a new IO::Path, does not mutate the receiver = no writeback. Measured:
+  fallback of `$s.IO`/`42.IO` → 0. pin `t/native-io-coercion.t`(18: literal/variable/numeric/type-object identity/null-byte
+  dies/Junction autothread/`$*CWD` inheritance; PASSing on both raku and mutsu). S16-io/S32-io/tmpdir/cwd whitelist all green.
+- **2026-06-23 (§D = making `IO::Path.absolute`/`.relative` VM-native)**: the cwd-dependent follow-up to the IO::Path lexical slice.
+  `.absolute`/`.relative` derive a string by combining the path string with the **cwd** (`$*CWD` / the instance `cwd` attribute / process cwd), but
+  the cwd is read via `&self`'s `resolve_path`/`get_cwd_path`/`apply_chroot`, which are **purely lexical (no FS stat)** = like `.IO`,
+  the VM owns env/cwd so native dispatch is possible. Extracted into the new `&self` method `try_io_path_cwd_method` (keeping all branches for
+  win32/cygwin/posix base arguments and the `$*CWD` fallback); `native_io_path` delegates right after `try_io_path_lexical` = **1 operation = 1 implementation**
+  (deleted the `absolute`/`relative` arms). The VM calls it next to the IO::Path lexical dispatch (immediately before the `is_native_method` bounce, both non-mut/mut paths).
+  `.resolve` (real FS canonicalize) returns `None` and stays in `native_io_path`. Returns a new string, receiver not mutated = no writeback, behavior-invariant.
+  Measured: fallback of `$p.absolute`/`.relative` → 0. pin `t/native-io-path-cwd.t`(14: `$*CWD`/instance cwd/explicit base/variable receiver/
+  round-trip; PASSing on both raku and mutsu). The 2 existing fails of io-path.t (`.SPEC`/`.CWD`) unchanged. S16-io/S32-io/tmpdir/cwd whitelist all green.
+- **2026-06-23 (§D = making QuantHash / Map / Hash coercion VM-native for plain `Cool` scalar receivers too)**: residual sweep of the coercion
+  drain. Re-measuring the method-fallback spread (whole whitelist, distinct file counts) confirmed **`Set`/`Bag`/`Mix`/`SetHash`/`BagHash`/
+  `MixHash` still falling back in 8-11 files each**; identified the receivers = **plain scalar receivers** such as `"a".Set`/`42.Set`/`"blue".Set`
+  (not list-like aggregates, so excluded by the VM gate's `list_like` check and dropping to the interpreter).
+  The interpreter handles scalar `.Set` via `dispatch_to_set_with_what` = **`to_set` itself** (the Set/Bag/Mix arm has no Package special-casing even;
+  scalars are single-element-ized by the `other =>` catch-all), so widening the native gate is **behavior-invariant with exactly the same implementation**.
+  Consolidated the `list_like` judgment shared by `try_native_quanthash_coerce`/`try_native_map_hash_coerce` into the new helper
+  `coerce_receiver_native_eligible`, adding **Str/Int/BigInt/Num/Rat/FatRat/Complex/Bool** to list-like aggregates
+  (shared by both non-mut + mut catch-alls). Scalar `.Map`/`.Hash` (`42.Hash`) gives `X::Hash::Store::OddNumber` via the same `to_hash`/`to_map`
+  = matches raku/interpreter (odd number). **Instance (`__baggy_data__`/Match captures/user coercion) / Package (type objects;
+  `.Map`/`.Hash` return type objects) / Nil / Junction (autothread) return `None` and stay on the interpreter** = behavior unchanged. Returns new
+  Set/Bag/Mix/Map/Hash values, does not mutate the receiver = no writeback. Measured: Set/Bag/Mix fallback in set.t/bag.t/mix.t
+  11/10/10 → 2/2/2 (the remaining 2 are `__baggy_data__` Instance / type object = falling through by design). pin
+  `t/native-scalar-quanthash-coerce.t`(39: literal/variable receivers × Set/Bag/Mix/SetHash/BagHash/MixHash/Map/Hash; PASSing on both raku and
+  mutsu). set.t 248/248, mix.t 244/244, categorize 28/28, hash.t green. (bag.t 252 "Foo instance union" and classify.t 40
+  "junction classify" are pre-existing per BLOCKERS.md [both non-whitelisted], unrelated to this change. The odd-number case of `(a=>1).Map`
+  is a separate pre-existing bug of the Pair receiver [already inside the native gate], out of scope for this slice.)
+- **2026-06-23 (§D = making `IO::Path`'s FS `stat`-only file tests / accessors VM-native)**: after the coercion drain was exhausted, the first step
+  toward the **main prize** of ③ IO native methods. Of the FS-touching methods that the IO::Path lexical/cwd slices kept on the interpreter with `None`,
+  made native the **group that completes with just a `stat` read** = the file tests `e`/`f`/`d`/`l`/`r`/`w`/`x`/`rw`/`rwx`/`z` and the stat accessors
+  `mode`/`s`/`created`/`modified`/`accessed`/`changed` (spread measurement: `e`=15/`d`=11 files etc., spread via the temp-file helpers). These
+  **acquire no `io_handles` at all, read no content, and emit nothing** = they just call `fs::metadata`/`exists` after resolving the path against the
+  VM-owned cwd (`resolve_path`/`apply_chroot`/`get_cwd_path`, purely lexical). Extracted into the new `&self` method `try_io_path_fs_stat` (path_buf resolution) +
+  static `io_path_stat_result` (from path_buf+p, stat + Failure shaping for all 16 arms); `native_io_path` delegates right after `try_io_path_cwd_method`
+  = **1 operation = 1 implementation** (deleted the 16 arms from the match). The VM calls it next to the IO::Path lexical/cwd dispatch (immediately before the
+  `is_native_method` bounce, both non-mut/mut paths). `slurp`/`lines`/`words`/`comb` (content reads, encoding flags) / `open`/`spurt` (`io_handles`
+  acquisition, FS writes) return `None` and stay in `native_io_path` = next slice candidates. Returns new Bool/Int/Str/Failure, receiver not mutated = no writeback,
+  behavior-invariant (same stat logic). Measured: fallback of `$p.{e,f,d,s,modified,…}` → 0. pin `t/native-io-path-fs-stat.t`(30,
+  literal + variable receivers [mut path] × all file tests/accessors, missing-path Failure; PASSing on both raku and mutsu. `.modified`/`.accessed`/
+  `.changed` avoid the separate pre-existing type difference mutsu=Int / raku=Instant by verifying with `> 0`/`.defined`). S16-io/S32-io/slurp/spurt whitelist
+  all green (io-path.t's `.SPEC`/`.CWD` existing fails are non-whitelisted, unchanged). **Remaining IO native = content reads (slurp/lines) and handle
+  acquisition (open/spurt) = the main prize directly touching ③'s `io_handles` ownership.**
+- **2026-06-23 (§D = making `IO::Path`'s whole-file content reads `slurp`/`lines`/`words` VM-native)**: the content-read follow-up to the FS stat-only slice
+  (above). `slurp` (spread 26 files)/`lines`(13)/`words` **read the whole file**, but acquire no `io_handles`
+  and emit nothing = after resolving the path against the VM-owned cwd, just `fs::read[_to_string]` and split/decode the bytes. Flag parsing
+  (`parse_io_flags_values`) and encoding lookup (`decode_with_encoding` = reading the VM-owned `encoding_registry`) are all `&self`
+  reads, so native dispatch is possible. Extracted into the new `&self` gate `try_io_path_content_read` (returning `Option`) + the fallible body `io_path_content_read`
+  (separated to use `?`). path_buf resolution became a 3rd site, so consolidated into the `resolve_io_path_buf` helper and delegated `try_io_path_fs_stat`
+  to it too (dedup). `native_io_path` delegates to content right after the stat delegation = **1 operation = 1 implementation** (deleted the slurp/lines/words arms from the match).
+  The VM calls it next to the stat dispatch (both non-mut/mut paths). **`comb` (regex/closure dispatch needs `&mut self`) / `open`/`spurt`
+  (`io_handles` acquisition, FS writes) return `None` and stay in `native_io_path`** = the next slice (the ③ io_handles main prize). Returns new Str/Buf/Seq,
+  receiver not mutated = no writeback, behavior-invariant (same read + split/decode; all branches for `:bin`/limit/`:!chomp`/non-utf-8 decode preserved).
+  Measured: fallback of `$p.{slurp,lines,words}` → 0. pin `t/native-io-path-content-read.t`(24: literal + variable receivers [mut path] ×
+  slurp/lines/words, `:bin` Blob, utf-8 decode, limit, `:!chomp`, missing-path dies; PASSing on both raku and mutsu). S16-io/S32-io/slurp/
+  lines whitelist all green (io-path.t `.SPEC`/`.CWD` existing fails are non-whitelisted, unchanged). **Remaining IO native = `comb` (&mut) and handle-acquiring
+  open/spurt = the main prize of ③'s `io_handles` ownership.**
+- **2026-06-23 (§D = making `IO::Path`'s single-path FS mutations `spurt`/`mkdir`/`rmdir`/`unlink`/`chmod` VM-native)**: the **write-family follow-up** to the
+  content-read slice (spurt spread 18 files). These 5 ops **mutate** the FS but acquire no `io_handles` at all =
+  after resolving the path against the VM-owned cwd, they just make **a one-shot syscall** (`fs::write`/`create_dir_all`/`remove_dir`/`remove_file`/`set_permissions`)
+  (`spurt` is open→write→immediate drop, leaving no handle). Encoding lookup (`encode_with_encoding` = reading the VM-owned registry)
+  is `&self`. Extracted into the new `&self` gate `try_io_path_fs_mutate` (returning `Option`) + the fallible body `io_path_fs_mutate` (separated for `?`;
+  `mkdir` round-trips an IO::Path via `class_name`). `native_io_path` delegates right after the content delegation = **1 operation = 1 implementation**
+  (deleted the 5 arms from the match). The VM calls it next to the content dispatch (both non-mut/mut paths). **2-path ops (`copy`/`rename`/`move`/`symlink`/
+  `link`; need destination path resolution) and handle-opening `open` (`io_handles` acquisition = `&mut self`) return `None` and stay in `native_io_path`** = the next
+  ③ io_handles capstone. Returns new Bool/IO::Path/Failure, receiver not mutated = no writeback, behavior-invariant (same syscall +
+  all branches for `:append`/`:createonly`/`:enc`+BOM/Buf preserved). Measured: fallback of `$p.{spurt,mkdir,rmdir,unlink,chmod}` → 0. pin
+  `t/native-io-path-fs-mutate.t`(22: literal + variable receivers [mut path] × 5 ops, `:append`/`:createonly` Failure, Buf spurt, mkdir
+  recursive, non-empty rmdir Failure, chmod mode; PASSing on both raku and mutsu). S16-io/S32-io/spurt/dir whitelist all green. (`.unlink` of missing
+  is a separate pre-existing difference mutsu=False/raku=True [the pre-move interpreter also did `Err(NotFound)=>Bool(false)`], out of scope for this slice = not pinned.)
+  **Remaining IO native = `comb` (&mut) and `open` (`io_handles` acquisition) = the capstone of ③'s `io_handles` ownership.**
+- **2026-06-23 (§D ③ capstone = making `IO::Path.open` VM-native = the VM acquires `io_handles` directly)**: the **symbolic milestone** of ③ (state ownership).
+  `open` is the only IO::Path FS method that **mutates the `io_handles` table** (`open_file_handle`→
+  `insert_handle_state` acquires a handle id = `&mut self`). The ledger's original rationale for "native-method (IO family) is ③-blocked" was
+  exactly this = `io_handles` being interpreter-owned state. But since #2760-2772, `io_handles` is **an `Arc<RwLock>` shared
+  field owned by the VM** = `open_file_handle` can be called directly from the unified struct's `self`. Extracted the new `&mut self` gate `try_io_path_open`
+  (`resolve_io_path_buf`(&self)/`parse_io_flags_values`(&self) return owned values, so no borrow conflict with the subsequent `&mut self` `open_file_handle`);
+  `native_io_path` delegates right after the fs_mutate delegation = **1 operation = 1 implementation** (deleted the open arm from the match). Since **both of the VM's
+  non-mut/mut dispatch functions are `&mut self`** (`try_compiled_method_or_interpret_inner`/
+  `try_compiled_method_mut_or_interpret`), both `"x".IO.open` (non-mut) and `$p.open` (mut) are native. All flags `:r`/`:w`/`:a`/`:rw`/`:bin`/
+  `:enc`/`:create`/`:exclusive` and the Failure-on-error shaping are preserved = behavior-invariant (same `open_file_handle`). Measured:
+  fallback of `$p.open` → 0. **∴ The whole open→read/write→close lifecycle runs VM-native without a catch-all bounce**
+  (the handle methods get/lines/print/say/close/tell/eof/seek/flush etc. are already native). pin `t/native-io-path-open.t`(20: literal +
+  variable receivers [mut path] × :r/:w/:a/:exclusive/:bin, missing/directory Failure, opened state; PASSing on both raku and mutsu). S16-io/S32-io/
+  open whitelist all green (io-handle.t's `.say` existing fail also fails on main = non-whitelisted, unrelated to this change). **Remaining IO native = `comb`
+  (regex/closure dispatch is `&mut self`) and the 2-path ops (copy/rename/move/symlink/link) only = ③'s IO native is nearly complete.**
+- **2026-06-23 (§D = making `IO::Path`'s 2-path FS ops `copy`/`rename`/`move`/`symlink`/`link` VM-native = completing the IO::Path FS family)**:
+  follow-up to the open capstone = **the last non-native members** of the IO::Path FS method family. These 5 ops resolve **both the receiver path and
+  the destination/link-name path** against the VM-owned cwd (`resolve_path`/`resolve_io_path_buf`, `&self`), then just make a one-shot syscall (`fs::copy`/`fs::rename`/`unix_fs::symlink`/
+  `fs::hard_link`) = no `io_handles` needed, all `&self`. Extracted into the new `&self` gate `try_io_path_two_path_op` (returning `Option`) + the fallible
+  body `io_path_two_path_op` (separated for `?`). `native_io_path` delegates right after the open delegation = **1 operation = 1 implementation** (deleted the copy/rename|move/
+  symlink/link arms from the match; the `dir`/`watch` in between kept). The VM calls it next to the open dispatch (both non-mut/mut paths). Same-file/createonly
+  checks, `X::IO::Copy`/`Rename`/`Move` Failure shaping, `:absolute` symlink, and all hard-link branches preserved = behavior-invariant. Measured:
+  fallback of `$p.{copy,rename,move,symlink,link}` → 0. pin `t/native-io-path-two-path.t`(18: literal + variable receivers [mut path] ×
+  5 ops, copy-onto-self/createonly Failure, symlink resolve, hard link; PASSing on both raku and mutsu. The dir is cleanly regenerated each run to
+  prevent stale file contamination). S16-io/S32-io/copy/rename whitelist all green. **∴ The IO::Path FS method family (stat/content-read/fs-mutate/open/2-path)
+  is now fully VM-native = §D ③'s IO native is nearly complete. Only `comb` remains (regex/closure dispatch is `&mut self`; a separate axis).**
+- **2026-06-23 (§D = making `.encode`/`.decode` (Str↔Buf conversion) VM-native)**: the next clean native-method drain after the IO::Path family
+  (spread: `encode`=16 files). **The explicit-encoding forms** (`"x".encode("utf-16")`/`$buf.decode("ascii")`) bounced to the interpreter at the
+  `dispatch_method_by_name` catch-all (0-arg `.encode` is already native in `methods_0arg`). These are pure Str↔Buf conversions reading the VM-owned
+  `encoding_registry` (`find_encoding`/`encode_with_encoding`/`decode_with_encoding` = all `&self`), no `io_handles` needed. Placed the new
+  `pub(crate)` helper `try_native_encode_decode` **on the `crate::runtime` side (methods_io_dispatch.rs)** (`dispatch_encode`/
+  `dispatch_decode` are `pub(super)` so it is called from the same crate::runtime; same pattern as IO::Path), called from the VM's non-mut/mut catch-alls
+  (right after `try_native_io_coercion`, immediately before the final bounce) = **1 operation = 1 implementation**. **Conservative gate**: `.encode` only for plain Cool scalars (Str/Int/BigInt/Num/Rat/
+  FatRat/Complex/Bool); `.decode` is gated by `dispatch_decode` itself to Buf/Blob Instances (otherwise `None`). User Instances (custom
+  `.encode`/`.decode` resolve earlier as compiled methods), Supply (its own chunk-encode; the interpreter arm excludes it), and `.encode` on Buf receivers
+  fall through = behavior-invariant. Returns new Buf/Str, receiver not mutated = no writeback. Measured: fallback of `"x".encode("utf-16")`/`$buf.decode` → 0.
+  pin `t/native-encode-decode.t`(23: literal + variable receivers [mut path] × encode utf-8/utf-16/ascii/latin-1, Int/Bool/Rat
+  encode, Buf/Blob decode, round-trip; PASSing on both raku and mutsu. Including the caveat that utf-16 `.elems` = the number of 16-bit units). encoding/buf/S32-str/encode
+  whitelist all green.
+- **2026-06-23 (§D = making `IO::Path.comb` VM-native = 100% completion of the IO::Path FS family + fixing the no-arg comb bug)**: **the last method** of the
+  IO::Path FS method family. `comb` reads the whole file and combs the content, but the matcher dispatch (`dispatch_comb_with_args`) needs `&mut self`
+  because regex/closure matchers run the match engine — yet `io_handles` is untouched. Extracted into the new `&mut self` helper
+  `try_io_path_comb` (read → error shaping via `match` for `?`); `native_io_path` delegates right after the two-path delegation = **1 operation = 1 implementation**
+  (deleted the comb arm from the match). The VM calls it next to the two-path dispatch (both non-mut/mut paths). **Also fixed a pre-existing bug at the same time**: argumentless
+  `$path.IO.comb` (no matcher) returned an empty Seq (the old arm mapped `dispatch_comb_with_args`'s `None` to empty) → now splits the content into
+  graphemes (matching no-arg `Str.comb` / Rakudo). The `None`-no-arg semantics of `dispatch_comb_with_args` are shared with the generic caller
+  (methods_dispatch_match.rs:187), so **the fix was kept local to the IO::Path comb helper** (None→graphemes). Measured:
+  fallback of `$p.comb`/`$p.comb(/re/)`/`$p.comb(N)` → 0. pin `t/native-io-path-comb.t`(17: literal + variable receivers [mut path] × no-arg
+  graphemes, regex, Int chunk, Str fixed, limit, empty file, unicode; PASSing on both raku and mutsu). S16-io/S32-io/comb whitelist all green.
+  **★ ∴ The IO::Path FS method family (stat/content-read/fs-mutate/open/2-path/comb) is 100% VM-native = §D ③'s IO native is complete.**
+  **The clean pure-value native-method drain is also exhausted** (remaining categories = ③ built-in type ctors [Buf.new etc.] / MOP carrier [WHAT/name/can] /
+  landmines [Instance.Str/.Stringy/.raku/.gist] / block-exec slow path [map/grep] / concurrency [Supply/tap] / typed-array mutators —
+  all premised on a different axis or a structural blocker). The next §D is either ③ built-in type ctors or the substrate for deleting the tree-walk dispatch chain (needs design; large).
+- **2026-06-23 (§D ③ = making `.new` of `::`-namespaced classes / built-in exception types VM-native)**: first slice of the ③ built-in ctor fork.
+  The `cn_resolved.contains("::")` guard in `is_native_default_constructible` excluded **all `::`-namespaced classes** (user `A::B` /
+  built-in exception types `X::AdHoc`, `X::TypeCheck::Binding` …) from native construction = the only blocker. Kept the `[` (parametric) guard and
+  deleted the `::` guard. Furthermore, built-in exception types are registered in the registry with `attributes: Vec::new()` (zero declared attributes;
+  named args become an attribute bag via `is_attribute_buildable`'s undeclared-name `true` fallback), so `has_attribute` was false → excluded by the tail return. Changed to
+  `has_attribute || is_exception`, allowing native if the MRO contains `Exception` (`build_native_default_instance` stores named args via the same
+  `is_attribute_buildable` = byte-identical with the interpreter). **Added `materialize_exception_message_in_result` at the VM call site
+  (vm_call_method_compiled.rs:127)** = equivalent to the interpreter slow path (methods.rs:3369 calls it after `dispatch_new`):
+  runs the user `message` method once at construction and caches it into the `message` attribute (no-op for built-in exceptions / non-exceptions). When running a user `message`,
+  `method_dispatch_pure=false` (preserving caller slot reconcile). Widened the visibility of `materialize_…` from `pub(super)`→`pub(crate)`. Measured: the `new` fallback of `X::AdHoc.new`/
+  `X::TypeCheck::Binding.new`/`A::B.new`/`P::Q::R.new` → 0. Confirmed via stash comparison that native==interpreter output matches exactly
+  (the raku differences on `message`/no-arg are the F-track `.message` unimplemented gap that predates this change, unrelated). pin
+  `t/native-namespaced-and-exception-ctor.t`(16). make test 10971; S04/S12/S32 construction whitelist all green. **Remaining ③ ctor candidates =
+  concurrency types like Promise, misc built-in types (those with special construction that `is_attribute_buildable` cannot attribute-bag-ify).**
+- **2026-06-23 (§D ③ = making `.new` of the `Lock` family (`Lock`/`Lock::Async`/`Lock::Soft`) VM-native)**: 2nd slice of the ③ ctor fork.
+  Lock construction is pure data (a process-global counter bump via `next_lock_id()` + the `async` flag of `Lock::Async`; no env/registry/user code needed).
+  Added a Lock arm to the static `try_native_builtin_construct` (called by the VM call site vm_call_method_compiled.rs:145 with `method_dispatch_pure=true`);
+  the interpreter dispatch_new's existing arm (inside `match base_class_name`) is left in place with only a comment added, following the
+  "Shared with the VM's native fast path" duplicated-implementation convention like `Slip`/`IterationBuffer` (4 lines, byte-identical). Measured: the `new`
+  fallback of `Lock.new`/`Lock::Async.new`/`Lock::Soft.new` → 0. Confirmed native==interpreter via stash comparison. pin `t/native-lock-ctor.t`(9). make test 10964. **★ A known separate-axis bug (unrelated to this change;
+  reproduces on main too): the captured-outer `$n` writeback drop in `$lock.protect({ $n++ })` (`.protect`'s closure capture writeback; nothing to do with the ctor).**
+  **Remaining ③ ctor candidates = Promise/Channel (SharedPromise/channel state), the QuantHash family (Bag/Set/Mix/SetHash; element counting), Capture, misc.**
+- **2026-06-23 (§D ③ = making `.new` of `Promise`/`Channel`/`Supplier`/`Supplier::Preserving` VM-native)**: 3rd slice of the ③ ctor fork
+  = simple concurrency primitives. `Promise.new`=`Value::Promise(SharedPromise::new())` (an empty planned promise; pure shared state),
+  `Channel.new`=`Value::Channel(SharedChannel::new())` (empty channel), `Supplier`/`Supplier::Preserving`=`{emitted:[], done:False,
+  supplier_id:next_supplier_id()}` (emission log + process-global id) = none need env/registry/user code. Added 3 arms to the static
+  `try_native_builtin_construct`; the interpreter dispatch_new's existing arms are left with comments only (the byte-identical duplicated-implementation convention).
+  Measured: the `new` fallback of all 4 kinds → 0. `$p.keep(42)`/`$c.send.list`/`$s.Supply.tap` functionality matches raku. pin `t/native-concurrency-ctor.t`(10).
+  make test 10984. **★ A known separate-axis gap (unrelated to this change): late-tap replay of pre-tap emits for `Supplier::Preserving` is unimplemented (mutsu does not
+  buffer/replay; nothing to do with construction).** **Remaining ③ ctor candidates = the QuantHash family (Bag/Set/Mix/SetHash; element counting = needs `&mut self` type
+  checks, not static), Capture, Proxy (FETCH/STORE closures), misc.** **★ perf note = calling `pub(crate)` ctors like `SharedPromise::new()`
+  directly from the VM static path = one hop shorter than delegating to the interpreter.**
+- **2026-06-24 (§D ③ = making `.new` of the QuantHash family (`Set`/`SetHash`/`Bag`/`BagHash`/`Mix`/`MixHash`) VM-native)**: 4th slice of the ③ ctor
+  fork. Unlike the previous 3, QuantHash construction is **`&mut self`** (element counting + parameterized type check `type_matches_value` + container metadata
+  `tag_container_metadata`), so it doesn't fit the static `try_native_builtin_construct` = **the 3 arms of dispatch_new (414 lines) were wholesale extracted into
+  the `&mut self` helper `try_native_quanthash_construct` of the new module `methods_quanthash_ctor.rs`** (same pattern as the IO::Path family; "1 operation =
+  1 implementation"). The 3 dispatch_new arms were replaced with a delegation to the helper (`return self.try_native_quanthash_construct(*class_name, base_class_name,
+  &type_args, args)`) = **a byte-identical wholesale move with no copy** (unlike the previous 3 slices' "comment-left duplicated implementation", a true single impl). The VM
+  call site adds the new wrapper `try_native_quanthash_construct_for_package(&[Value])` (parametric name strip → `is_quanthash_ctor_type` gate → clone args only on
+  match) to both non-mut/mut paths (the parametric `Set[Int].new` also resolves the base via `parse_parametric_type_name`). env-pure
+  (only value construction + container metadata tagging) = `method_dispatch_pure=true`. Visibility: widened `strip_named_pair_args` to `pub(super)` (the other
+  `value_to_list`/`is_lazy_*`/`type_matches_value`/`tag_container_metadata`/`parse_parametric_type_name` are already pub(super)/pub(crate)).
+  Measured: the `new` fallback of all 6 kinds → 0; parametric (`Bag[Int]`/`Set[Int]`) and type-check failure (`X::TypeCheck::Binding`) also match raku. pin
+  `t/native-quanthash-ctor.t`(18). make test 11018; setbagmix/baggy/mix whitelist all green. **★ Remaining ③ ctor candidates = `Capture.new` (unimplemented in mutsu =
+  needs separate implementation), `Proxy` (FETCH/STORE closures), low-traffic static candidates like `Match`/`FakeScheduler`, `Array`/`Hash` (more complex due to shaped/container
+  metadata). With the clean big fish QuantHash consumed, the remainder is small fry or unimplemented features.**
+- **Deferred (2026-06-23): generic `Instance.Str`/`.Stringy` coercion**. Runner-up by spread (`Stringy`=22/`Str`=11 files), but the Instance.Str reaching the VM
+  catch-all is **not limited to generic objects (`to_string_value()`)** — it includes special stringification of built-in types (`Buf.Str`→
+  `X::Buf::AsStr` throw, `Attribute/BOOTSTRAPATTR.Str`→name, `has $.Str`'s public accessor→attribute value). These are not gated by `is_native_method`
+  and get interpreter special-handling before arm 1499, so nativizing with `to_string_value()` breaks them (regressions confirmed in say.t/buf.t/
+  attributes.t). Even adding `has_user_method`/`has_public_accessor`/built-in type exclusions, landmines kept surfacing one after another = not enumerable and
+  cannot be safely separated, so deferred. The clean §D coercion results are settled with the IO::Path family (lexical/`.IO`/absolute-relative).
+- **2026-06-24 (§D ③ = making `.new` of `FakeScheduler`/`Proxy`/`Match` VM-native)**: the clean static leftover sweep of the ③ ctor fork. All 3 are
+  pure data assembly (`FakeScheduler` is a process-global counter + virtual-time 0.0 seed; `Proxy` wraps evaluated FETCH/STORE callables;
+  `Match` slices `orig[from..to]` and stores positional/named captures as attributes) = no env/registry/user code needed. Extracted each construction into per-type
+  helpers (`build_native_fakescheduler_value`/`build_native_proxy_value`/`build_native_match_value`), with **both** `try_native_builtin_construct`
+  and the interpreter's `dispatch_new` arm **calling the same helper** (true single impl, byte-identical). Measured: the `new` fallback of all 3 kinds → 0.
+  pin `t/native-misc-ctor.t`(14; Proxy/Match verified for raku parity).
+- **2026-06-24 (§D ③ = implementing `Capture.new`)**: `Capture` had no constructor at all and `Capture.new` was an error. raku semantics
+  (verified) = default `Capture.new` is an **empty Capture**. Named args are dropped (Capture has no buildable public attributes and `bless` ignores them); positional
+  args are rejected (named-only `Mu.new` = "Default constructor for 'Capture' only takes named arguments"). Populated Captures are made with `\(...)`.
+  Named args are `Value::Pair`; everything else (literals, positional `"a" => 1` `ValuePair`) dies as positional. Pure data =
+  `try_native_builtin_construct`. Known unchanged gap (not a regression) = `.new` on a Capture **instance** receiver (`\(1).new`) is still an error = a separate,
+  broader gap of instance `.new` delegation for built-in value variants. pin `t/native-capture-ctor.t`(9; PASSes on raku too).
+- **2026-06-24 (§D ③ = making `.new` of `Array`/`List`/`Positional`/`array`/`Hash`/`Map` VM-native)**: draining the aggregate ctors. Unlike the pure-data
+  statics, `&mut self` (shaped-dim parsing `:shape(...)` + `:data`/positional population + X::Assignment shape errors, Slip/Range/Seq flattening,
+  parameterized type check `Array[Int].new`/`Hash[Int].new`→`X::TypeCheck::Assignment`, container metadata tagging). Like QuantHash, the 2 arms (~310 lines) were
+  **wholesale extracted** into the new module `methods_aggregate_ctor.rs` (`try_native_array_construct`/`try_native_hash_construct`), the interpreter's
+  `dispatch_new` arms are delegations, and the VM calls via `try_native_aggregate_construct_for_package` (parametric name → base+type_args resolution) = true single
+  impl, byte-identical. Measured: the `new` fallback of all 6 kinds → 0. pin `t/native-aggregate-ctor.t`(16; raku parity subset. mutsu-specific behavior of
+  shaped/Hash-named-data is covered by roast S02-types/array.t, hash.t, S09-typed-arrays/*). **★ This exhausts the clean nativizable candidates among
+  `dispatch_new`'s built-in type ctors. The remaining arms are state/FS/process-dependent (IO::Socket::INET [socket], Distribution/CompUnit::Repository [FS], Proc::Async
+  [process], Backtrace [call stack], Seq [predictive iterator carrier]) or error-only (HyperWhatever/Whatever/Instant).**
+- **2026-06-24 (§D ③ = making `.new` of the allomorphs (`IntStr`/`NumStr`/`RatStr`/`ComplexStr`) + `ObjAt`/`ValueObjAt` VM-native)**: re-measuring the ③ ctor fork
+  (temporary probe of `new`-fallback receivers over the whole whitelist) revealed the most frequent receivers remaining after aggregate are
+  **in `dispatch_new_and_constructors` (slow-path method dispatch), not `dispatch_new`**: `RatStr`(892)/`IntStr`(306)/`ComplexStr`(176)/`NumStr`(125)
+  = allomorphs, `ObjAt`/`ValueObjAt` (18 total). These are fully **pure-static** (args→instance; no `&self` at all = touching no registry/env/FS either).
+  Allomorph `.new(numeric, string)` just makes the inner numeric (unwrapping if the arg is an allomorphic `Mixin`) into a `Value::mixin` with a `Str` override; `ObjAt`/
+  `ValueObjAt` `.new(which)` just stores the stringification of the first positional into the `WHICH` attribute. **Added 2 arms to the static `try_native_builtin_construct`
+  (called by VM call sites vm_call_method_compiled.rs:160/1788 with `method_dispatch_pure=true`)**, with the new static helpers `build_native_allomorph_value`/
+  `build_native_objat_value` called by both it and `dispatch_new_and_constructors` (inline implementation removed) = **1 operation = 1 implementation** (same pattern as FakeScheduler/Proxy/Match).
+  The arity error wording is mutsu-specific ("requires two arguments" / "Too few positionals" = a pre-existing difference from raku) and preserved during extraction =
+  byte-identical. Measured: the `new` fallback of `IntStr.new`/`RatStr.new`/`ObjAt.new` etc. → 0 (val.t's `new` vanished from the histogram). pin
+  `t/native-allomorph-objat-ctor.t`(23; PASSing on both raku and mutsu). S32-str/val.t, S03-operators/set_union.t, S32-num/rounders.t, rat.t, S02-types/num.t
+  whitelist all green. (The existing fails of allomorphic.t 107/113 are identical on main = a separate-axis gap in `.ACCEPTS`/`.Numeric`, unrelated to this change.) **Remaining `new` fallback receivers
+  = Proc::Async [process] / Failure [reads `$!` env] / IO::Socket::INET [socket] / IO::Path family [registry; separate slice candidate] / CallFrame [call stack] /
+  Seq [iterator carrier] = all state-dependent or a different axis.**
+- **2026-06-24 (§D ③ = making `.new` of the `IO::Path` family (`IO::Path`/`::Unix`/`::Win32`/`::Cygwin`/`::QNX`) VM-native = the IO::Path ctor capstone)**:
+  closing the IO::Path nativization theme = the method family (stat/content-read/fs-mutate/open/2-path/comb, #3499–3511) is 100% native, but **only the ctor
+  still bounced through the catch-all** (probe measured `IO::Path::Win32`/`::Cygwin`/`::Unix`/`IO::Path` ~112 occ total). `.new` is **pure path-string assembly**
+  = it joins the positional path / an IO::Path instance (reusing `path`) / the basename+dirname+volume triple with the SPEC-derived separator and attaches
+  CWD/SPEC attributes. The only `&self` dependency is a **registry read** (`class_mro` = detecting an IO::Path-instance argument) = VM-owned (phase ②) = no FS/cwd/env/user code.
+  The IO::Path arm of `dispatch_new` (~117 lines) was **wholesale extracted** into the new `&mut self` helper `build_io_path_instance` (the interpreter arm is a
+  delegation; the one-time registry registration of SPEC-variant subclasses is kept). The VM gate `try_native_io_path_construct` is restricted to **the built-in IO::Path family only**
+  (`is_io_path_lexical_class` = the same gate as the lexical method slice = does not intrude on user subclasses' custom new), called from both non-mut/mut call sites
+  (right after the aggregate ctor arm; `method_dispatch_pure=true`) = **1 operation = 1 implementation**, byte-identical. Measured: the `new` fallback of `IO::Path.new`/`IO::Path::Win32.new` etc. → 0. pin `t/native-io-path-ctor.t`(19;
+  positional/triple/instance-arg/Win32-Unix-Cygwin subclasses/CWD/empty-null dies; PASSing on both raku and mutsu). S32-io/S16-io/tmpdir/cwd/S11-compunit whitelist
+  all green (io-path.t 34/35's `.SPEC`/`.CWD` attribute existing fail is identical on main = non-whitelisted, unrelated to this change). **Remaining `new` fallback = Proc::Async/Failure
+  [`$!` env]/IO::Socket::INET/CallFrame/Seq = state-dependent or a different axis.**
+- **2026-06-24 (§D ③ = making `Failure.new($exception?)` VM-native)**: the **highest count** among the remaining `new` fallbacks (probe measured 2593; driven by `fail`/explicit construction).
+  `Failure.new` is **pure data assembly reading only VM-owned state** = it takes the explicit exception argument (else `$!` from env, else the default `X::AdHoc("Failed")`),
+  wraps it in `X::AdHoc` unless it's already `Exception`/`X::`/`CX::` (MRO read `mro_readonly`), and builds a `{exception, handled:false}` instance.
+  The `&self` dependencies are an **env read (`$!`) + a registry read (`mro_readonly`)** = VM-owned (after single-store-ification, `self.env` is identical for VM/interpreter) = no FS/process/socket/
+  user code. The Failure arm of `dispatch_new_and_constructors` (~52 lines) was **wholesale extracted** into the new `&self` helper `build_native_failure_value` (the interpreter arm is a
+  delegation). The VM calls it from both non-mut/mut catch dispatches (right after the IO::Path ctor arm; `class_name=="Failure"` gate; `method_dispatch_pure=true`) = **1 operation =
+  1 implementation**, byte-identical. Measured: the `new` fallback of `Failure.new` (explicit/string-wrap/`$!`/argless, all paths) → 0. pin `t/native-failure-ctor.t`(11; PASSing on both raku and
+  mutsu. `X::AdHoc` is constructed with `:payload` = avoiding the pre-existing detail that `.message` reads the payload). S04-exceptions/S04-statement-modifiers/
+  S05-capture/named/S06-advanced whitelist all green. **Next slice candidates among the remaining `new` fallbacks (2026-06-24 measured correction — correcting the "state-dependent" classification)**:
+  ① **`Proc::Async.new` = actually fully pure data** (process spawn is in `.start`; the ctor is just arg parsing + the `next_supply_id()` free fn + `SharedPromise::new()` +
+  Supply attribute construction; zero `&self` dependency) = wire a `build_native_proc_async_value` static helper into `try_native_builtin_construct` (same shape as Promise/Channel; easiest).
+  ② **`IO::Socket::INET.new` = io_handles-dependent but the same shape as `IO::Path.open` (#3507)** (`dispatch_socket_inet_new` acquires a VM-owned io_handle via `insert_handle_state`)
+  = delegate to the existing helper via `try_native_socket_inet_construct`. **Truly structurally blocked (ctor fork completes after ② lands)**: `CallFrame` [call stack carrier] = a different axis.
+  (`Seq.new` was made native in #3533 = below.) **∴ ctor-fork remainder = only 2 items: Proc::Async (pure) + IO::Socket::INET (io_handles).**
+- **2026-06-24 (§D ③ = making `Seq.new($iterator?)` VM-native, #3533)**: re-evaluated `Seq.new`, which the previous entry conservatively classified as "iterator carrier =
+  a different axis (impure)", and made it native. **The carrier state itself is VM-owned** (the `predictive_seq_iters` field + env's `__mutsu_predictive_seq_iter::` internal keys +
+  the global deferred-iter side table keyed by the Seq's Arc) = after single-store-ification `self` is identical for VM/interpreter, so the native gate can perform the same writes. **Construction does not
+  eagerly pull** (a PredictiveIterator is stashed in the carrier; materialized `items`/`stuff` instances are element copies; other iterators get deferred registration; no-arg is a
+  pre-consumed Seq) = iterator consumption happens later at consumption time, separate from construction = no FS/process/user code needed. The Seq arm of `dispatch_new` (~46 lines) was **wholesale extracted**
+  into the new `&mut self` helper `try_native_seq_construct` (the interpreter arm is a delegation). The VM calls it from both non-mut/mut catch dispatches (right after the Failure ctor arm;
+  `class_name=="Seq"` gate; `method_dispatch_pure=true`) = **1 operation = 1 implementation**, byte-identical. User subclasses (`class S is Seq`) resolve class_name to
+  their own name and miss the gate, staying on the interpreter. pin `t/native-seq-ctor.t`(11; PASSing on both raku and mutsu. The `.raku` `$(...)` itemization difference is pre-existing,
+  unrelated). S32-list/seq.t(50)/skip.t/tail.t/rotor.t, S07-iterators/range-iterator.t(103) all green. **Remaining `new` fallback = Proc::Async (pure; next) /
+  IO::Socket::INET (io_handles; next) / CallFrame [call stack carrier, a different axis].**
+- **2026-06-24 (§D ③ = making `Proc::Async.new(@cmd, :w, :enc)` VM-native, #3535)**: re-evaluated `Proc::Async.new`, conservatively classified as "state-dependent"
+  two entries earlier, and made it native. **The ctor is fully pure data** = arg parsing (positional command + `:w`/`:enc` flags) + 3
+  process-global supply ids (`next_supply_id` = a bare global counter) + construction of empty stdout/stderr/merged `Supply` instances only. **Actual process spawn is
+  on the `.start` side** = at ctor time env/registry/io_handles/user code are entirely untouched (zero `&self` dependency). The Proc::Async arm of `dispatch_new` (~66 lines) was
+  **wholesale extracted** into the new static helper `build_native_proc_async_value(class_name, args)` (the interpreter arm is a delegation), and the VM wires a
+  `cn=="Proc::Async"` arm into the existing `try_native_builtin_construct` in the same shape as `Promise`/`Channel`/`Supplier` = **1 operation = 1 implementation**, byte-identical.
+  pin `t/native-proc-async-ctor.t`(8; PASSing on both raku and mutsu. Includes a real echo/cat round-trip + exit code + `:w` stdin).
+  t/proc-async.t(23), roast/S17-procasync/basic.t(47)/print.t(16) all green.
+  **Remaining `new` fallback = IO::Socket::INET (io_handles; next; same shape as `IO::Path.open`) / CallFrame [call stack carrier, a different axis].**
+- **2026-06-24 (§D ③ = making `IO::Socket::INET.new(...)` VM-native, #3536)**: the clean finale of the ③ ctor fork. The ctor of `IO::Socket::INET.new` (both `:listen`
+  server and client modes) performs the real bind/connect, but **the write target is the VM-owned `io_handles`** (`insert_handle_state` = the same shape as the already-native
+  `IO::Path.open` [#3507]) = env/registry/user code untouched. Widened the existing `&mut self` helper `dispatch_socket_inet_new` (the single impl that the interpreter's `dispatch_new`
+  arm called) from `pub(in crate::runtime)`→`pub(crate)`, and the VM **calls the same helper directly** from both non-mut/mut catch dispatches (right after the Seq ctor arm;
+  `class_name=="IO::Socket::INET"` gate; `method_dispatch_pure=true`) = **1 operation = 1 implementation**, byte-identical (no new copy).
+  User subclasses resolve class_name to their own name and miss the gate, staying on the interpreter. pin `t/native-socket-inet-ctor.t`(7; PASSing on both raku and mutsu. Real loopback
+  client/server round-trip + invalid port/family dies + independent listener). t/socket.t(3), roast/S32-io/IO-Socket-INET.t(32)/IO-Socket-INET-UNIX.t(8)/
+  socket-accept-and-working-threads.t(15)/socket-fail-invalid-values.t(4)/socket-host-port-split.t(2) all green. **∴ The ③ ctor fork is complete** = every pure-value /
+  VM-owned-state built-in ctor is native. **Remaining `new` fallback = CallFrame [call stack carrier], error-only (HyperWhatever/Whatever/Instant) =
+  a different axis or structurally blocked.** Next is the §D main prize = (b) the tree-walk dispatch-chain removal substrate or VM-ification of multi-dispatch.
+- **2026-06-24 (§D multi-dispatch = VM-ification of proto sub dispatch (trivial body), #3541)**: started on the next §D main prize after ③ ctor completion = VM-ifying multi-dispatch.
+  Measurement (S06 sample, `MUTSU_VM_STATS`) showed **bare multis have 0 fallback** (OTF'd in PR-4) but **proto multis fall back 100%** (2 layers: the proto sub call itself
+  + the internal `__PROTO_DISPATCH__`; each candidate body tree-walks via `call_proto_dispatch`→`run_block`). **Trivial-body protos (`proto foo {*}` / bodyless) are
+  dispatched directly at the VM call site**: added a proto fast-path at the top of the else block of `dispatch_func_call_inner`; the new helper `vm_resolve_trivial_proto_candidate`
+  ① excludes interpreter-handled names ② fetches the proto def via `resolve_proto_function` and verifies the body is trivial (empty or `[Expr(Whatever)]` after excluding the `SetLine` marker)
+  ③ **gates on the proto's own sig via `method_args_match`** (`proto f(Int) {*}` rejects a Str — fixing the regression caught by S06-multi/proto.t subtest 26) ④ resolves the winner candidate via `resolve_proto_candidate_with_types`
+  (VM-owned registry = phase ②) ⑤ returns it if OTF-compilable and non-state. If returned, `compile_and_call_function_def` **executes the candidate body compiled**
+  (fully bypassing the tree-walk proto body + the `__PROTO_DISPATCH__` round-trip + the candidate `run_block`). `nextsame`/`samewith`/`callwith` work via the same function's `push_multi_dispatch_frame` +
+  samewith context (the mechanism verified in PR-4). Non-trivial bodies / non-OTF candidates / where candidates / sig mismatches return `None`, keeping the conventional interpreter fallback = byte-identical.
+  Visibility: widened `resolve_proto_candidate_with_types`/`resolve_proto_function`/`method_args_match` to `pub(crate)`. Measured: fallback of `proto factorial` 100%→0%,
+  `__PROTO_DISPATCH__` in the S06 sample 50→30 (the remaining 30 = where candidates / non-trivial bodies / non-OTF candidates, correctly falling back). pin `t/proto-vm-dispatch.t`(12; PASSing on both raku and mutsu =
+  recursion / per-type candidates / samewith / nextsame / proto-sig gate [EVAL-wrapped] / non-trivial body guard). All 87 whitelisted S06 files + roast/S06-multi/proto.t(27) green, make test 11202.
+  **Remaining multi-dispatch fallbacks**: OTF-ification of where-constrained candidates (the candidate-side `def_is_otf_compilable` excludes where) / VM-ification of non-trivial proto bodies / `@_` slurpy recursive
+  plain subs (a separate category). **★ Lesson: a `{*}` proto body gets a `SetLine` marker prepended at registration, making body.len=2 = the triviality check must exclude the marker. The proto's own sig is a
+  gate independent of the candidates' sigs = when bypassing, always validate with `method_args_match` (otherwise the type check of `proto f(Int)` is skipped).**
+- **2026-06-25 (§D = OTF-ification of imported `is test-assertion` subs)**: removed the `!def.is_test_assertion` exclusion from `def_is_otf_compilable_module_single`
+  (`call_compiled_function_named` pushes the test-assertion line context, so even when OTF-compiled, the caller-line reporting of assertion failures is identical to the interpreter).
+  **But removing the exclusion alone had zero effect**: Test::Assuming/Test::Util's `is-primed-sig` etc. are parsed via `Expr::Call` as imported functions, and kept being rejected by the OTF gate
+  due to the `Capture |cap` sub_signature. **The key = re-registering imported `is test-assertion` subs into the using scope** (new `InlineModuleExport.is_test_assertion`
+  field, propagated from SubDecl; the fallback regex also detects `is test-assertion`), putting them on the same parse path as locally declared assertion helpers (`known_call_stmt`→`Stmt::Call`)
+  = reaching OTF-compilable dispatch. Measured: the S06-currying function-fallback 195 (is-primed-sig=171/is-primed-call=21/priming-fails-bind-ok=3)→2.
+  `priming-fails-bind-ok` (the body's `try`/`CATCH`) correctly remains on the conservative gate, byte-identical. pin `t/test-assertion-module-otf.t`(7). make test 11471 PASS.
+  **★ A separate bug split off (not included in this PR; needs separate work) = `use`'s export scan (`extract_exported_names`→`parse_program_partial`→`set_original_source(module_src)`)
+  overwrites the parser's `ORIGINAL_SOURCE` with the module's temporary String (dropped immediately) → dangling → the using file's `current_line_number` collapses to all 1s — a general bug.**
+  Fixing this with `snapshot_source_state`/`restore_source_state` makes caller lines match raku, but **the line-number normalization exposes existing latent bugs that "accidentally PASSed
+  on the clobber-derived line 1"** (measured 2: S04-phasers/enter-leave.t#28 [the ENTER-rvalue of `sub f(){ ENTER 'X' }` is Nil] and keep-undo.t#10 [UNDO]. Standalone repros also give
+  Nil = genuine phaser bugs independent of line numbers, but the tests only PASSed on the clobbered line 1). Blast radius unknown (calibration-by-clobber may lurk throughout roast), so
+  the ORIGINAL_SOURCE fix + the exposed phaser bug group are split off from this PR to handle separately. **★ Lesson: nested parses clobber not just SCOPES but `ORIGINAL_SOURCE` too. The fix itself is correct, but
+  it exposes a group of "accidentally PASSing" tests calibrated to the clobber over the years, so proceed incrementally.**
+- **2026-06-25 (§D = fixing the `ORIGINAL_SOURCE` clobber + general fix for the exposed phaser block-value bugs)**: resolved the separate bug split off in the previous entry.
+  **(1)** `parse_program_partial` (best-effort nested parses for module export scanning / EVAL / pseudo-packages) now save/restores the caller's source state via
+  `primary::snapshot_source_state`/`restore_source_state` (`ORIGINAL_SOURCE` + heredoc `LEAKED_REGIONS`) = clobber resolved;
+  the using file's `current_line_number` now matches raku. **(2)** General fix for the exposed phaser bugs (**genuine bugs independent of line numbers**): ① a trailing ENTER phaser
+  becomes the value of a block/sub/closure/do-block (new OpCodes `PushEnterResult`/`LoadEnterResult` + VM `enter_result_stack` = bridging the ENTER section's value to the end of the
+  body. ENTER runs before the value-result baseline is recorded, so placing it directly on the stack is not detected) ② changed the value-determining statement to "the last non-`SetLine` statement" (line-number
+  normalization inserts `SetLine` between statements; the trailing `SetLine` of a phaser-only block was a spurious `True`→KEEP misfired, fixed to UNDO). **(3)** Consolidated the 5-fold duplicated BlockScope phaser
+  compression (top-level / `Stmt::Block` / do-block / sub body / closure) into the shared `compile_phaser_block_scope(stmts, result_on_stack)` (2 modes: statement=topic /
+  do-block=stack). pin `t/enter-phaser-rvalue.t`(18). All of t/ (11502), S04-phasers whitelist (17), the 270 `use Test::Util` whitelist files, and a 1/3 roast
+  sample of 428 files — zero regressions. **★ Lesson: the value of a phaser block needs materialization in a separate phase from the ENTER section (bridged to the end of the body via a dedicated stack). do-blocks
+  return the value on the stack (`DoBlockExpr` pops), but statement context goes via topic = the same helper branching on mode.**
+- **2026-06-25 (§D(b) tree-walk dispatch chain removal = making the unadorned forms of `.starts-with`/`.ends-with` VM-native)**: per-name measurement of method-fallbacks put
+  `starts-with`(513) high among catch-all bounces (excluding `name`/`WHAT`/`WHY`/`can`=MOP reflection — not elimination targets, `tap`/`stdout`=concurrency separate axis, the iterator-protocol group=lazy separate axis).
+  Cause = `starts-with`/`ends-with` sit on the slow path (`dispatch_prefix_suffix_check`) to support named args (`:i`/`:ignorecase`/`:m`/`:ignoremark`), so **even the general
+  `.starts-with($needle)` form without named args bounced to the interpreter**. The `(false,false)` case is a pure prefix/suffix check, so added a
+  Str-receiver-gated arm to `native_method_1arg` (methods_narg.rs). The named-arg form is **2 arguments (positional + Pair), so it never reaches the 1-arg native path**
+  and naturally falls through to the slow path = byte-identical. A user-defined `.starts-with` is resolved by the VM before native, so no shadowing (the same guarantee as the existing `contains` arm).
+  Measured: `$s.starts-with` fallback 2→0. pin `t/starts-ends-with-native.t`(22).
+  All of t/ (11572), S32-str/starts-with.t, ends-with.t, 70 string roast files, and a 1/5 roast sample of 257 — zero regressions. **★ Lesson: a pure method placed on the slow path for
+  named-arg support can be safely drained by native-gating "only the unadorned 1-arg case" (restricted by receiver type), since named args increase the arity and go down a different path. `substr-eq` (87; complex due to
+  Whatever/negative/Failure position resolution) is the next slice candidate.**
+- **2026-06-25 (§D(b) tree-walk dispatch chain removal = making `.substr-eq($needle, Int $pos)` VM-native)**: 2nd slice in the same pattern as starts-with. `.substr-eq` sat on the
+  slow path (`dispatch_substr_eq`) to support named args (`:i`/`:m`) and Whatever/negative/out-of-range position resolution (Failure generation). **The plain 2-argument form + a non-negative in-bounds Int position + a Str
+  receiver** is a pure substring comparison, so added an arm to `native_method_2arg`. Everything else falls through: Whatever/non-Int position (`arg2` not `Int`) → interpreter resolution / negative or out-of-range →
+  interpreter Failure / named-arg form (a Pair makes arity 3) → never reaches the 2-arg native path / user-defined `.substr-eq` resolves before native = no shadowing. The 1-argument form (position 0 default) is rare, fallthrough kept.
+  pin `t/substr-eq-native.t`(16). All of t/ (11566), S32-str/substr-eq.t, indices.t, index.t — zero regressions. **★ The clean string drains are exhausted**: the simple `comb` form is already native (the 93 in the survey are
+  regex/named-arg forms), `trans`(65) is complex (ranges in spec strings `a..z` / list-pair / regex), `Int`/`Num`/`Str.new` are in the completed ctor territory. Remaining categories = the iterator-protocol group (lazy, separate axis) /
+  MOP carrier (reflection, not elimination targets) / concurrency (tap/emit, separate axis) — all premised on a different substrate rather than a pure §D(b) drain.**
+- **2026-06-25 (§D(b) tree-walk dispatch chain removal = making the `Buf.write-int*`/`.write-uint*`/`.write-num*` family VM-native)**: re-measuring method-fallbacks (aggregated over all 1285 whitelist files)
+  revealed the **most frequent clean-drain category** after the string-drain exhaustion = `write-int8/16/32/64/128` (3852 each) + `write-uint*` (2220 each) + `write-num32/64` (492 each) = ~30k fallbacks total.
+  The source is **S03-buf/write-int.t / write-num.t** (the `\sigilless` instance form of `existing."$write"($off,$val[,$endian])` and the type-object form of `buf8."$write"(...)` = both **dynamic
+  method names** `"$write"`). The existing nativization covered only **static names on mut-bound `$`-vars** (`try_native_buf_mut`, CallMethodMut), so all 3 routes bounced to the interpreter:
+  (1) the type-object form (`Value::Package` receiver = returns a fresh buf),
+  (2) the `\sigilless`/`BareWord` instance form (via the non-mut dynamic op `exec_call_method_dynamic_op`→`try_native_method`; no writeback target var),
+  (3) the `$`-var dynamic-name form (the mut dynamic op `exec_call_method_dynamic_mut_op` = never tries the native fast path and goes straight to `vm_call_method_mut_with_values`). **Fix** = the new pure helper
+  `buf_write_int::try_native_buf_write(target, method, args)` handles both the type-object (fresh `make_buf_value`) and instance (in-place commit to the shared cell via `write_back_sharing`→`commit_attrs`
+  → observed by all bindings) forms in 1 impl (the byte transform is the existing shared `apply_write_int`/`apply_write_num`). Wired it into **the top of `try_native_method`** (the arity-keyed `native_method_*arg` cannot
+  dispatch 3 arguments [offset,value,endian], so a dedicated branch is required) → drains routes (1)(2). Route (3) is drained by calling `try_native_buf_mut` before the generic fork in `exec_call_method_dynamic_mut_op`.
+  **Fallthrough kept** = `Blob`/`blob8` (type-object has no such method; instances are immutable and the interpreter raises "Cannot modify immutable Blob"; current behavior byte-identical) / non-Int offsets
+  (Whatever position resolution) / negative or out-of-range (`apply_write_int` returns Err→`dies-ok` preserved) / arity≠2,3. **Measured: write-int.t fallback 20240→0, write-num.t 656→0**
+  (method-call fallbacks of both fully gone). All of t/ (11615 PASS), all S03-buf green, 108 roast samples zero regressions. pin `t/buf-write-native.t`(27: type-object/scalar/sigilless dynamic name/round-trip/error, all forms). **★ Lesson: dynamic method names
+  (`."$name"()`) have 2 dedicated opcodes (`CallMethodDynamic` [BareWord/literal target] / `CallMethodDynamicMut` [`$`/`@`/`%`-var target]), and the latter never tries the native fast path
+  = a method already nativized under a static name bounces entirely when called via a dynamic name. Draining a native-method family called via dynamic names requires adding fast-path calls to both dynamic ops. The non-mut
+  dynamic form of an instance mutator propagates to `\sigilless`-bound values via an in-place commit to the shared attribute cells (`commit_attrs`) even without a writeback target var (no env insert needed).**
+- **2026-06-25 (§D(b) tree-walk dispatch chain removal = making the named-arg/position forms of `Str.contains($needle, $pos?, :i/:m?)` VM-native)**: the first nativization of a
+  **named-arg form** of the string-method family that starts-with/substr-eq had conservatively deferred as "named-arg forms stay on the slow path". `S32-str/contains.t` (survey 278) has every test go through
+  `invocant.contains(|c)`, **always attaching markings named args (`:i`/`:ignorecase`/`:!i`…)**, so the unadorned 1-arg native form (`native_method_1arg`) is barely reached; the Pair-carrying 2-arg or
+  position+Pair 3-arg forms slipped past the arity-keyed dispatch (which stops at `native_method_2arg`, no 3-arg path) and bounced 100% to the interpreter. **Fix** = the new variadic helper
+  `native_contains_with_options(target, args)` separates positional/named, folding needle=positional[0], start=positional[1] (Int/Num/Str-parse), and `i`/`ignorecase`/`m`/`ignoremark`
+  all into a lowercase comparison (strictly mirroring `Interpreter::dispatch_contains`). Wired immediately before `try_native_method`'s arity dispatch. **Fallthrough kept** = non-Str receivers (**Match invocants** are
+  deferred over the separate-axis Match→Str coercion and instance-bypass interaction) / Package needle / BigInt position (overflow→X::OutOfRange goes to the interpreter) / negative or out-of-range positions (X::OutOfRange Failure) /
+  unknown named args. Junction needles thread via `contains_value_recursive[_ci]`. **Measured: contains.t fallback 272→140** (remaining 140 = Match invocants, separate axis). All of t/ (11610); 11 contains forms byte-identical
+  (including unicode CI and Str positions); roast contains-family samples zero regressions. pin `t/contains-options-native.t`(22). **★ Lesson: starts-with/substr-eq said "named args are deferred", but
+  the named-arg form can be the main traffic of real tests (contains.t attaches markings to every form). Wiring a variadic helper (positional/named separation → mirroring the interpreter dispatch) before the arity dispatch
+  drains the named-arg forms too. The half with non-Str receivers (Match etc., needing coercion) remains as a separate axis.**
+- **2026-06-25 (§D(b) tree-walk dispatch chain removal = making the `:i` named-arg forms of `Str.starts-with`/`.ends-with`/`.substr-eq` VM-native)**: rolling the
+  variadic-helper pattern established in the contains slice out to the sibling string methods. `S32-str/{starts-with,ends-with,substr-eq}.t` also attach markings named args to every form (same shape as contains.t), so
+  even with the unadorned native forms (starts-with=1arg, substr-eq=2arg) drained, the `:i` forms (arity exceeded by the Pair) bounced 100% to the interpreter. **Fix** = the new helpers `native_prefix_suffix_with_options`
+  (starts-with/ends-with) / `native_substr_eq_with_options` (substr-eq) interpret the markings via the shared `split_string_match_args` (positional/named separation; `i`/`ignorecase`=ci, `m`/`ignoremark`=mark; unknown named
+  = defer), strictly mirroring `dispatch_prefix_suffix_check`/`dispatch_substr_eq`. Wired immediately before `try_native_method`'s arity dispatch (next to the contains arm). **Fallthrough kept** =
+  non-Str receivers (**Match invocants** = separate axis) / Package needle / `:m`/`:ignoremark` (`strip_marks` decomposition is interpreter) / substr-eq's non-Int-non-Str positions (Whatever resolution), negative or out-of-range
+  (X::OutOfRange Failure) / unadorned forms (existing 1-/2-arg arms kept). **Measured: starts-with.t 80→42, ends-with.t 80→42, substr-eq.t 86→48** (remaining = Match-invocant `:i` forms, separate axis). All of t/ (11692);
+  3 files PASS under the proper harness; 10 named forms byte-identical to raku (including unicode CI and Str positions); whitelist zero regressions. pin `t/starts-ends-substr-eq-named-native.t`(21). **★ Lesson:
+  the raku reference implementation throws "Iteration past end of grapheme iterator" on `"abc".ends-with("", :i)` (an empty-needle+ci bug), while mutsu correctly returns True = excluded that form from the pin (mutsu is the correct one).
+  ★ The `:m`/`:ignoremark` of string methods is handled separately via `strip_marks` (NFD→combining-mark filter), but these roast tests skip the `:m` forms under a backend≠moar gate, so nativization is unnecessary — defer is sufficient.**
+- **2026-06-25 (§D(b) tree-walk dispatch chain removal = making the Match invocants of the 4 string-search methods VM-native)**: the previous 3 slices (contains / starts-with & ends-with / substr-eq) had
+  deferred "Match invocants are a separate axis (Match→Str coercion, instance-bypass interaction)", but closer inspection showed **it can be resolved with just a low-risk gate relaxation**: ① `is_native_method("Match", …)` has
+  **no entry → false** = Match.contains etc. pass through the instance-bypass block and reach the variadic helpers (immediately before the arity dispatch) ② each helper already obtains the text via `text = target.to_string_value()`
+  = for a Match that is the matched substring (identical to `Cool.Str`). ∴ Just relaxing the receiver gate from `Value::Str(_)` only → the new predicate `is_str_or_match_receiver` (Str or `Instance{class_name=="Match"}`) drains
+  the Match invocants of all forms of the 4 methods. **A failed match is `Any`/`Nil` (not a Match instance) → misses the gate → the interpreter raises "No such method"**
+  (byte-identical). **Measured: contains.t 140→6, starts-with.t 42→8, ends-with.t 42→8, substr-eq.t 48→14** (remaining = bare Match forms [no markings; the 1-/2-arg arms are Str-gated] + the tests' own `.match`/`$*PERL.compiler`).
+  All of t/ (11710); 4 files PASS under the proper harness; 9 Match-invocant forms byte-identical to raku (including positions and unicode CI); whitelist zero regressions. pin `t/str-search-match-invocant-native.t`(18). **★ Lesson: even a defer classified
+  as a "separate axis" can compress to a one-predicate gate relaxation when you scrutinize the bypass order (if the target class is absent from the `is_native_method` table, it passes through) and the existing coercion (the helper obtains text via `to_string_value`).
+  With 4 consecutive string-search slices, the method-fallbacks of `S32-str/{contains,starts-with,ends-with,substr-eq}.t` are nearly exhausted (≤14 each = bare Match forms only).**
+- **2026-06-25 (§D state ownership = VM-native dispatch of atomic var/element RMW (`__mutsu_atomic_*`/`__mutsu_cas_*`))**: after the exhaustion of clean method-fallback drains, aggregating
+  **function-fallbacks** over the whole whitelist showed
+  `__mutsu_atomic_add_var`(640001)/`__mutsu_atomic_post_inc_var`(320038)/`pre_inc`/`post_dec`/`pre_dec`(320001 each)/`__mutsu_cas_var`(282337)/`cas_hash_elem`(30000)/`cas_array_elem`(29420) =
+  **~2.5 million fallbacks in total, overwhelmingly dominating all function-fallbacks** (concurrency stress = driven by the `⚛` operators). This is the direct-hit category of §D "state ownership" = atomic ops are RMW against the
+  VM-shared `shared_vars` (`RwLock`) store and the per-attribute cell-CAS state (Phase 3). The existing `builtin_atomic_*`/`builtin_cas_*` impls already own and operate on that state, but **the only reach path was
+  the generic `call_function` fallback** (`vm_call_function`→`loan_env_for`→ a name match of ~hundreds of arms) (`try_native_function` only calls the pure `native_function`, so `&mut self` atomic ops slipped past). **Fix** = the new
+  `try_native_atomic_function(name,args)` (`builtins_atomic.rs`; a 1:1 mirror of the atomic arm group in `builtins.rs`; `cas_*` uses `args.to_vec()`) is called at the top of `try_native_function`
+  (before the Instance-arg bail = an Instance value in `cas($x,$old,$obj)` is dispatchable too) when `name.starts_with("__mutsu_atomic_"|"__mutsu_cas_")`.
+  `loan_env_for` after the CP-3 collapse is a thin `f(self)` passthrough = env is the same `self.env` on both paths, the builtin is identical = byte-identical.
+  **Measured: in atomic-ops.t/atomic.t, the atomic function-fallback markers vanished completely** (cas.t stress = 61 fallbacks out of 95003 opcodes = the remainder is `start`/`await` [concurrency, separate axis] + the user-facing `cas`).
+  All of t/ (11725); S17-lowlevel/{cas,cas-loop,cas-loop-int,atomic,atomic-ops}.t all PASS (atomic.t 34/34, atomic-ops.t 28/28 = debug is slow on the `for ^20000` stress but completes); 20 atomic forms byte-identical to raku.
+  pin `t/atomic-ops-native-dispatch.t`(20). **★ Lesson: not just method-fallbacks — the function-fallback survey is also a treasure trove for §D. The `__mutsu_*` internal markers (atomic/cas/hyper-prefix), being "not pure (`&mut self`)",
+  slipped past `try_native_function`→`native_function`(pure) and all fell into the generic `call_function` fallback. Adding a direct dispatch arm for `&mut self` builtins at the top of `try_native_function` can sweep away the fallbacks of
+  huge stress suites (state ownership is already on the VM side = a behavior-invariant path short-circuit).**
+- **2026-06-25 (§D state ownership = VM-native dispatch of builtin operator-as-function `infix:<op>(...)`)**: the function-fallback aggregation after atomic showed the `infix:<op>` family = **~5400 fallbacks across 44 operators**
+  (`&infix:<+>`, `[+]`/`[*]` reduce, `>>+>>` hyper, and the routine forms that `reduce &infix:<…>` lowers to). Builtin operators are implemented by the native Rust `call_infix_routine` (`&mut self`; dispatches hyper/assignment-metaop/set-op/
+  all binary ops), but the only reach path was via `call_function_fallback`'s infix arm (recorded as tree-walk fallback). **Fix** = in both `dispatch_func_call_inner` (the direct Call path) and
+  `call_function_compiled_first` (the hyper/reduce/string-regex path), **after trying all user operator resolution (compiled_fns / the non-proto multi fork / `user_function_matches_call` / OTF) and immediately before the terminal fallback**,
+  capture `infix:<op>` and call `call_infix_routine(op,args)` directly (U+2212 minus normalized to `-`; arg_sources and `maybe_fetch_rw_proxy` are the same handling as the terminal else = byte-identical). **User overrides strictly respected** =
+  user `sub/multi infix:<…>` resolve in the higher branches and never reach the native arm (the pin verifies `infix:<plus>`=103 and a custom `multi infix:<%%%>`). **Measured: direct infix calls 100%→0** (user multis correctly keep the fallback).
+  All of t/ (11765); 79 whitelist operator/metaops/junction files zero regressions; 20 infix forms byte-identical to raku. pin `t/infix-function-native-dispatch.t`(22). **★ Widened `call_infix_routine` to `pub(crate)`.
+  ★ Lesson: there are 2 fallback-recording lineages — direct Calls at `dispatch_func_call_inner`, hyper/reduce etc. at `call_function_compiled_first` — so the same arm must be placed in both. The key to nativizing user-overridable operators is
+  inserting "after all user resolution branches, before the fallback recording" (placing it at the top would shadow user operators). Operator names containing `<`/`>` (`infix:«<»`) hit a separate parser problem = CALL-ME error = excluded from the pin.**
+- **2026-06-25 (§D state ownership ③ = VM-native dispatch of the file/FS builtin *function* forms)**: the IO native **method** family was drained (the 2026-06-23 group), but the **function forms** (`slurp($p)`/`open($p,:r)`/`unlink($p)`/
+  `spurt`/`close`/`dir`/`copy`/`rename`/`move`/`chmod`/`mkdir`/`rmdir`/`link`/`symlink`) still went via the `call_function` fallback (survey: unlink 1172/open 1017/slurp 569 etc., ~3000 total). These are `&mut self`/`&self` operations against the
+  VM-owned `io_handles` store + the filesystem, and the `builtin_*` impls already own the state. **Fix** = the new `try_native_io_function(name,args)` (`builtins_io.rs`; a 1:1 mirror of `call_function`'s IO arms) is called
+  **at the same user-override-safe position as infix**: in `dispatch_func_call_inner`, the else-if after all user resolution (after lexical-amp, before the infix arm); in `call_function_compiled_first`, after OTF and before the record.
+  **Not placed in `try_native_function`** (in call_function_compiled_first it runs before user resolution [OTF], so it would shadow a non-compiled user `sub slurp` — the difference from atomic, which was safe because `__mutsu_*` cannot be user-defined).
+  **Exclusions** = `indir` (executes a callback block), `chdir`/`tmpdir`/`homedir` (process cwd/env side state), `print`/`say`/`note`/`warn`/`sink` (output/blocks). FS functions have no rw params so no arg_sources needed; `maybe_fetch_rw_proxy(true)`
+  is the same as the terminal else = byte-identical. **Measured: 0 fallbacks for builtin IO function calls**; user `sub slurp`/`sub unlink` are correctly shadowed by higher resolution (pin-verified). All of t/ (11806); 64 whitelist S32-io/S16-io files zero regressions;
+  14 IO forms byte-identical to raku. pin `t/io-function-native-dispatch.t`(14). **★ Lesson: nativization of user-definable builtin names (IO/operators) goes not in `try_native_function` (too early) but at
+  "after user resolution, before the fallback record" on both dispatch paths. Only the `__mutsu_*` internal markers (atomic) can sit at the top of `try_native_function` (because they cannot be user-defined). Remaining function-fallbacks = concurrency (await/start —
+  start needs `sync_env_from_locals`, separate axis, flaky) / MOP (samewith) / heterogeneous internal markers (feed/assign-lvalue, context-sensitive) = the clean homogeneous drains are exhausted.**
+- **2026-06-25 (§D(b) = VM-native dispatch of the pure list/coercion builtin *function* forms (`val`/`list`/`slip`/`hash`))**: a follow-up in the same pattern as the IO function forms. `val` (pure free-fn)/`list`/`slip`/`hash` (`&self`) are
+  collection constructors that still went via the `call_function` fallback (survey: slip 3824 [S07-hyperrace stress]/val 1555/list 720/hash 336, ~6400 total). The new `try_native_collection_function(name,args)`
+  (`builtins_collection.rs`; a 1:1 mirror of the `call_function` arms) is called at **the same user-override-safe position as IO/infix** (in `dispatch_func_call_inner` after the IO arm, before the infix arm / in `call_function_compiled_first` after the IO arm).
+  Pure/`&self` with no rw params = byte-identical. **Measured: 0 fallbacks for builtin val/list/slip/hash calls**; user `sub list` correctly shadowed (pin-verified). All of t/ (11834); 132 whitelist S02/S07-slip/S32-list files zero regressions;
+  byte-identical to raku. pin `t/collection-function-native-dispatch.t`(14). **★ Separate axes found via the pin (existing mutsu behavior, unrelated to this change): mutsu's `builtin_list` flattens `list((1,2),3)` but raku gives `((1,2),3)` (non-flattening) /
+  a block-scoped `sub list` leaks to the outer scope in mutsu (raku is block-scoped) = both excluded from the pin. ★ The clean function-fallback drains (state-owning: atomic/IO + pure dispatch: infix/collection) are effectively exhausted. Remaining = concurrency
+  (await/start/Supply/tap; Promise/scheduler state; flaky) / MOP (samewith; reflection) / user-class construction (new/bless; needs a structural substrate design).**
 
-### 重要な現状認識（2026-06-08, PR-3 時点）
-**「生ディスパッチを統一エントリへ降ろすだけ」で消せる安いサイトは枯渇した。** 残る §1/§2 のフォールバックは
-すべて構造的ブロッカー（②宣言レジストリ / ③state 所有移管 / 第一級コンテナ Phase 2 / lever B）が前提であり、
-個別の routing では消えない。とくに §1 の catch-all 群（残る主 tree-walk）と native-method（IO 系）は **③** が、
-mut 系 push/hyper/array-backed は **Phase 2** が、shared push/react は **lever B** が前提。
-**次の実質的進捗は ② または ③ の構造リファクタであり、設計を要する**（VM が `interpreter: Interpreter` を所有
-しつつ interpreter 側も同 state で tree-walk する双方向所有を解く必要がある）。
+### Important assessment of the current state (2026-06-08, as of PR-3)
+**The cheap sites removable by "just lowering raw dispatch into the unified entry" are exhausted.** The remaining §1/§2 fallbacks
+are all premised on structural blockers (② declaration registries / ③ state ownership transfer / first-class containers Phase 2 / lever B) and
+will not disappear through individual routing. In particular, the §1 catch-all group (the remaining primary tree-walk) and the native-methods (IO family) are premised on **③**,
+the mut-family push/hyper/array-backed on **Phase 2**, and shared push/react on **lever B**.
+**The next real progress is the structural refactor of ② or ③, which requires design** (the bidirectional ownership — the VM owning
+`interpreter: Interpreter` while the interpreter side also tree-walks over the same state — must be untangled).
 
-## 撲滅の順序（PLAN.md ①〜⑤ に対応）
+## Elimination order (corresponding to PLAN.md ①–⑤)
 
-1. ~~EASY/MEDIUM な §1/§2 の個別撲滅~~ — **枯渇（PR-1〜3 で消化）**。残りは下記の構造ブロッカー前提。
-2. ② 宣言レジストリ（class/role/enum/subset/sub/token）の VM 所有化。
-3. ③ env/型検査/readonly/let の VM 所有移管（最大の山。catch-all 群・native-method はここで消える）。
-4. ④ §C carrier の最終確定（所有が VM に移れば単なる共有参照）。
-5. ⑤ `env_dirty`/`saved_env_dirty`/`ensure_locals_synced`/`sync_locals_from_env` 削除。
+1. ~~Individual elimination of EASY/MEDIUM §1/§2~~ — **exhausted (consumed in PR-1..3)**. The remainder is premised on the structural blockers below.
+2. ② VM ownership of the declaration registries (class/role/enum/subset/sub/token).
+3. ③ Transferring ownership of env/type checks/readonly/let to the VM (the biggest mountain. The catch-all group and native-methods disappear here).
+4. ④ Final determination of the §C carriers (once ownership moves to the VM, they are mere shared references).
+5. ⑤ Deleting `env_dirty`/`saved_env_dirty`/`ensure_locals_synced`/`sync_locals_from_env`.

--- a/docs/vm-single-store.md
+++ b/docs/vm-single-store.md
@@ -2,7 +2,8 @@
 
 > **Status:** DESIGN (2026-06-17). No code yet. This document reopens the
 > dual-store question from the design level, as a *single authoritative store*
-> redesign, per the user directive ("単一権威ストア再設計として設計から問い直す").
+> redesign, per the user directive ("re-examine from the design level, as a
+> single-authoritative-store redesign").
 > It supersedes the **footprint-reduction-only** framing of
 > [docs/vm-dual-store.md](vm-dual-store.md) — read that file first for the full
 > mechanism map, the 151 `env_dirty` setters, and the slice history. This file is


### PR DESCRIPTION
## Summary

Fourth category of the English-only documentation cleanup (news/ + CLAUDE.md rule in #4546, ADRs in #4548, PLAN/TODO_roast in #4549). Translates 13 of 21 design documents under `docs/`:

- **Full translation** of the five large ledgers: vm-interpreter-fallback-ledger (129KB), captured-outer-cell-sharing (105KB), container-identity (91KB), env-locals-coherence (77KB), vm-dual-store (73KB).
- **Spot fixes** for eight documents that were already ~99% English and carried only a few Japanese quoted phrases (treewalk-method-removal-plan, lexical-scope-slot-campaign, vm-single-store, element-element-bind-plan, perf-callpath-scouting, hashdata-migration-plan, is-rw-shared-cell-plan, nanbox-3b1-step-b-design).

Cross-references were reconciled: the perf-callpath-scouting link now uses the merged English ADR-0006 heading, the nanbox-3b1 quote matches ADR-0005's "both exits kept open", and element-element-bind-plan points at container-identity's translated "Investigation record 2026-06-11" heading.

The remaining 8 docs/ files (vm-state-ownership, gc-level1-detailed-design, scalar-array-sharing, vm-io/registry/output-ownership, slotref-removal-plan, gc-post-3a-roadmap) follow in batch 2.

## Verification

- Zero Japanese characters remain in all 13 files.
- For the five large files: heading counts, PR-number multisets, table rows, code fences, and pin-test paths verified 1:1 against the originals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)