### PR TITLE
fix: child-class attribute accessors must shadow parent methods (per-MRO-level accessor dispatch)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -141,16 +141,23 @@ Current state (details in news/2026-06.md and news/2026-07.md): ✅ CLI load + c
       fez index (7648 dists) — all the way to Identity/Provides/Depends output** (stable across 2
       release runs; pin t/hyper-array-mutators.t).
       Current frontier:
-      1. populate performance: after the fold, a full fez+rea populate takes ~3-5 minutes in release
-         (raku takes seconds). Remaining = per-call cost of plain Named subrule invocation +
-         Distribution/Identity construction.
+      1. populate performance: the former "3-5 min" was dominated by an MRO dispatch bug, fixed
+         2026-07-15 (accessor-MRO-shadowing PR): `Zef::Distribution.name` dispatched to the parent
+         DependencySpecification's `method name` (a full REQUIRE identity-grammar parse per call,
+         ~4ms) instead of the child's `has $.name` accessor. After the fix, full fez populate
+         (7648 dists) = 19.5s release (raku 2.8s, ~7x); warm `zef info Zef` end-to-end = ~50s
+         (raku warm ~3.8s, ~13x). Remaining hot spots (per-dist): `bless` runs on the
+         `run_instance_method` slow-path fallback, TWEAK x2 via the resolver path, and
+         allocation churn (~25% of flat profile in malloc/free/memmove).
       2. Nested `.raku` rendering: an Instance inside a collection renders as `Sp()` (type-object
          style) (`(C.new,).raku` → raku gives `(C.new(...),)`). The value itself is fine
          (semantically harmless; display only).
       3. `zef list --installed` runs to exit 0 with no output (reasonable while the mutsu-side site
          repo is empty).
-      4. Small index-name-count difference: with 7648 fez metas, raku has 9259 keys / mutsu 9256
-         (3 entries; name-fail on 2-3 dists).
+      4. ~~Small index-name-count difference~~ RESOLVED 2026-07-15: the 3 missing keys were the same
+         accessor bug (`.name` returned the identity-grammar parse result instead of the attribute;
+         dists whose name fails to parse were dropped). mutsu now indexes 9259/9259 keys, exactly
+         matching raku.
       5. (Watch) the old observation "with GC on, the 2nd Ecosystems reads an empty `$!name`" did not
          reproduce in 2 release runs after #4466. If it recurs, investigate independently as
          GC × thread state corruption.

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,41 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-15: child-class attribute accessors now shadow parent methods (MRO-level accessor dispatch) — zef populate 3-5min → `zef info Zef` ~50s
+
+An mzef-campaign session (PLAN §1 B2) that turned out to be a general **method-dispatch
+correctness bug**: mutsu treated "user-defined method beats auto-generated accessor" as a
+global rule, so a **parent class's explicit method shadowed a child class's `has $.x`
+accessor** of the same name. In Raku the accessor is an ordinary method of its declaring
+class and participates in the MRO like any other method (child accessor wins).
+
+- **Impact on zef**: `Zef::Distribution has $.name`, but its parent
+  `Zef::Distribution::DependencySpecification` declares `method name` = spec-parts =
+  `Zef::Identity.new` = a full REQUIRE identity-grammar parse (~4ms/call, plus `.Str`/`.trans`
+  churn). Every `.name` read during Ecosystems populate paid a grammar parse. This — not the
+  suspected "plain Named subrule per-call cost" — was the bulk of the populate slowdown.
+- **Fix**: new `resolve_user_method_or_accessor` (class_introspection.rs) decides the winner
+  **per MRO level**: explicit class-local method > public attribute accessor > role-composed
+  method (class prioritization, 6.c S14-roles/attributes.t), walking the MRO once so a
+  more-derived accessor beats a less-derived method. Applied at 4 dispatch sites: the
+  interpreter instance-dispatch gate (methods_instance_ops), the fast accessor read
+  (vm_call_method_ops — the shadowing case now takes the *fast* attribute read), the
+  compiled-path defer check (vm_call_method_compiled_interpret, prefiltered to
+  role-origin/ancestor-owned resolutions so the hot path stays cheap), and the lvalue
+  assignment path (methods_mut_method_lvalue — a shadowing `is rw` accessor is writable).
+  Replaced the old `has_class_local_method` MRO-blind predicate.
+- **Numbers** (release, real fez index 7648 dists): `.name` micro-stage 1.31s → 0.02s (300
+  dists, 65x); full fez populate ~60s → **19.5s** (raku 2.8s); warm `zef info Zef`
+  end-to-end **~50s** (raku warm ~3.8s). Bonus: the short-name index now has **9259/9259
+  keys, exactly matching raku** — the former 3-key diff was the same bug (dists whose
+  identity fails to parse lost their `.name`).
+- pin = `t/accessor-mro-shadowing.t` (9 cases: shadowing both directions, same-level
+  method-suppresses-accessor, role-vs-class prioritization both levels, rw write path,
+  deep hierarchy).
+
+Remaining populate hot spots (per dist): `bless` on the `run_instance_method` slow path,
+TWEAK x2 via the resolver path, allocation churn — see PLAN §1 B2.
+
 ## 2026-07-15: TODO_roast consolidated — S*.md retired, BLOCKERS.md is the single ledger
 
 The 17 per-synopsis `TODO_roast/S*.md` checklists were retired and merged into

--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -5,6 +5,14 @@
 
 use super::*;
 
+/// Winner of the per-MRO-level race between an explicit user method and a
+/// public attribute accessor (see `resolve_user_method_or_accessor`).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum UserMethodOrAccessor {
+    Method,
+    Accessor,
+}
+
 impl Interpreter {
     pub(super) fn class_has_method(&mut self, class_name: &str, method_name: &str) -> bool {
         self.registry_mut()
@@ -218,32 +226,81 @@ impl Interpreter {
         false
     }
 
-    /// Whether the class hierarchy defines `method_name` *directly* (a method
-    /// written in a class body), as opposed to only inheriting it from a
-    /// composed role. Entities defined in a class are prioritized over role
-    /// entities: a role method must NOT shadow the class's own attribute
-    /// accessor of the same name (6.c S14-roles/attributes.t "Class
-    /// prioritization"). `role_origin.is_none()` marks a class-local method.
-    pub(crate) fn has_class_local_method(&mut self, class_name: &str, method_name: &str) -> bool {
-        let mro = self.class_mro(class_name);
-        for cn in mro {
-            if let Some(class_def) = self.registry().classes.get(&cn)
-                && let Some(defs) = class_def.methods.get(method_name)
-            {
-                return defs
-                    .iter()
-                    .any(|d| !d.is_private && d.role_origin.is_none());
-            }
-        }
-        false
-    }
-
     /// Check if a class has a public attribute accessor for the given name.
     pub(crate) fn has_public_accessor(&mut self, class_name: &str, method_name: &str) -> bool {
         let attrs = self.collect_class_attributes(class_name);
         attrs
             .iter()
             .any(|(attr_name, is_public, ..)| *is_public && attr_name == method_name)
+    }
+
+    /// Decide, per MRO level, whether an explicit user method or a public
+    /// attribute accessor handles `method_name` for `class_name`.
+    ///
+    /// In Raku the auto-generated accessor for `has $.x` is an ordinary method
+    /// of its declaring class, so it participates in the MRO like any other
+    /// method: a child's accessor shadows a parent's explicit method of the
+    /// same name (Zef::Distribution's `has $.name` vs its parent
+    /// DependencySpecification's `method name`). Within a single class level
+    /// the priority is: explicit class-local method > public attribute
+    /// accessor > role-composed method (class entities are prioritized over
+    /// role entities — 6.c S14-roles/attributes.t "Class prioritization").
+    pub(crate) fn resolve_user_method_or_accessor(
+        &mut self,
+        class_name: &str,
+        method_name: &str,
+    ) -> Option<UserMethodOrAccessor> {
+        let mro = self.class_mro(class_name);
+        for cn in &mro {
+            let is_ancestor = cn != class_name;
+            let (has_local_method, has_role_method, has_attr) = {
+                let registry = self.registry();
+                if let Some(class_def) = registry.classes.get(cn.as_str()) {
+                    let (mut local, mut role) = (false, false);
+                    if let Some(defs) = class_def.methods.get(method_name) {
+                        for d in defs {
+                            if d.is_private || (d.is_my && is_ancestor) {
+                                continue;
+                            }
+                            if d.role_origin.is_none() {
+                                local = true;
+                            } else {
+                                role = true;
+                            }
+                        }
+                    }
+                    let attr = class_def
+                        .attributes
+                        .iter()
+                        .any(|(n, is_public, ..)| *is_public && n == method_name);
+                    (local, role, attr)
+                } else if let Some(role_def) = registry.roles.get(cn.as_str()) {
+                    // A punned role used as a parent class: its own methods
+                    // and attribute accessors sit at this MRO level.
+                    let local = role_def
+                        .methods
+                        .get(method_name)
+                        .is_some_and(|defs| defs.iter().any(|d| !d.is_private));
+                    let attr = role_def
+                        .attributes
+                        .iter()
+                        .any(|(n, is_public, ..)| *is_public && n == method_name);
+                    (local, false, attr)
+                } else {
+                    (false, false, false)
+                }
+            };
+            if has_local_method {
+                return Some(UserMethodOrAccessor::Method);
+            }
+            if has_attr {
+                return Some(UserMethodOrAccessor::Accessor);
+            }
+            if has_role_method {
+                return Some(UserMethodOrAccessor::Method);
+            }
+        }
+        None
     }
 
     /// Accessor-slot promotion gate: when `method_name` is a public `is rw`

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1069,16 +1069,19 @@ impl Interpreter {
                 };
                 return self.call_method_with_values(bridged, "log", vec![base]);
             }
-            // User-defined methods take priority over auto-generated accessors,
-            // EXCEPT a method that comes ONLY from a composed role does not
-            // shadow the class's own attribute accessor of the same name
-            // (class entities are prioritized over role entities). In that case
-            // fall through to the accessor block below; a role method with no
-            // competing accessor still runs here.
+            // User-defined methods take priority over auto-generated accessors
+            // only when they win the per-MRO-level race: a child class's
+            // accessor shadows a parent's explicit method, and a method that
+            // comes ONLY from a composed role does not shadow the class's own
+            // attribute accessor at the same level (class entities are
+            // prioritized over role entities). When the accessor wins, fall
+            // through to the accessor block below.
             let cn_resolved = class_name.resolve();
-            let role_only_shadowing_accessor = !self.has_class_local_method(&cn_resolved, method)
-                && self.has_public_accessor(&cn_resolved, method);
-            if !role_only_shadowing_accessor && self.has_user_method(&cn_resolved, method) {
+            let accessor_wins = matches!(
+                self.resolve_user_method_or_accessor(&cn_resolved, method),
+                Some(UserMethodOrAccessor::Accessor)
+            );
+            if !accessor_wins && self.has_user_method(&cn_resolved, method) {
                 let (result, updated) = self.run_instance_method(
                     &class_name.resolve(),
                     attributes.to_map(),

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -876,8 +876,19 @@ impl Interpreter {
             }
         };
 
-        let method_def = if let Some(def) =
-            self.resolve_method(&class_name.resolve(), method, &method_args)
+        // When the public attribute accessor wins the per-MRO-level race
+        // against user methods of this name (a child's accessor shadows a
+        // parent's explicit method), assignment must go through the accessor
+        // branch below, not the shadowed method (which would reject with
+        // "not rw" when the parent method lacks `is rw`).
+        let accessor_wins = method_args.is_empty()
+            && matches!(
+                self.resolve_user_method_or_accessor(&class_name.resolve(), method),
+                Some(UserMethodOrAccessor::Accessor)
+            );
+        let method_def = if let Some(def) = (!accessor_wins)
+            .then(|| self.resolve_method(&class_name.resolve(), method, &method_args))
+            .flatten()
         {
             def
         } else if method_args.is_empty() {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -171,6 +171,7 @@ mod calls;
 mod class;
 mod class_dispatch;
 mod class_introspection;
+pub(crate) use class_introspection::UserMethodOrAccessor;
 pub(crate) mod deprecation;
 pub(crate) mod did_you_mean;
 mod dispatch;

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -534,18 +534,24 @@ impl Interpreter {
                     result
                 }
             } {
-                // Entities defined in a class are prioritized over role
-                // entities: when resolution lands on a method that comes ONLY
-                // from a composed role (`role_origin` set) but the class has a
-                // public attribute accessor of the same name, the accessor wins.
-                // (If a class-local method of that name existed, resolution would
-                // have picked it and `role_origin` would be None.) Defer to the
-                // slow path, whose `run_instance_method` accessor block resolves
-                // it — 6.c S14-roles/attributes.t "Class prioritization".
-                if method_def.role_origin.is_some()
+                // A public attribute accessor can win over the method that
+                // resolution picked: a child class's accessor shadows a
+                // parent's explicit method (the accessor is a method at the
+                // child's MRO level), and a class accessor beats a
+                // role-composed method at its own level — 6.c
+                // S14-roles/attributes.t "Class prioritization". Both cases
+                // require an accessor candidate, which is only possible when
+                // the resolved method is role-composed or owned by an
+                // ancestor, so gate the MRO walk on that cheap check. Defer to
+                // the slow path, whose `run_instance_method` accessor block
+                // resolves it.
+                if (method_def.role_origin.is_some() || owner_class != cn)
                     && !method_def.is_private
                     && matches!(target.view(), ValueView::Instance { .. })
-                    && self.has_public_accessor(cn, method)
+                    && matches!(
+                        self.resolve_user_method_or_accessor(cn, method),
+                        Some(crate::runtime::UserMethodOrAccessor::Accessor)
+                    )
                 {
                     return self.call_method_with_values(target, method, args);
                 }

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -123,20 +123,20 @@ impl Interpreter {
             return None;
         }
         let cn = class_name.resolve();
-        // A class-locally-defined method of this name overrides the accessor, so
-        // bail to full dispatch. A method that comes ONLY from a composed role
-        // does NOT: class entities (here, the public attribute accessor) are
-        // prioritized over role entities, so the fast accessor read proceeds
-        // (6.c S14-roles/attributes.t "Class prioritization").
-        if self.has_class_local_method(&cn, method) {
-            return None;
-        }
-        // Only a *public* accessor reads through the fast path. Gating on this
-        // first is essential: a private attribute (`has $!secret`) is stored
-        // under the `secret!` key, so reading it by the bare name must fall
-        // through to the interpreter (which denies the access) rather than
-        // leaking the private value.
-        if !self.has_public_accessor(&cn, method) {
+        // The fast accessor read proceeds only when the public attribute
+        // accessor wins the per-MRO-level race against user methods of the
+        // same name: an explicit method at the same or a more-derived level
+        // overrides the accessor (bail to full dispatch), while a child's
+        // accessor shadows a parent's method and a class accessor beats a
+        // role-composed method at its own level (6.c S14-roles/attributes.t
+        // "Class prioritization"). This gate also keeps private attributes
+        // private: `has $!secret` is stored under the `secret!` key and never
+        // reports as a public accessor, so reading it by the bare name falls
+        // through to the interpreter (which denies the access).
+        if !matches!(
+            self.resolve_user_method_or_accessor(&cn, method),
+            Some(crate::runtime::UserMethodOrAccessor::Accessor)
+        ) {
             return None;
         }
         // Public accessor confirmed. Read its backing value, stored under the

--- a/t/accessor-mro-shadowing.t
+++ b/t/accessor-mro-shadowing.t
@@ -1,0 +1,61 @@
+use v6;
+use Test;
+
+plan 9;
+
+# The auto-generated accessor for `has $.x` is an ordinary method of its
+# declaring class, so it participates in the MRO like any other method.
+# Regression coverage for zef's Zef::Distribution, whose `has $.name`
+# accessor was shadowed by the parent DependencySpecification's expensive
+# `method name` (a full identity-grammar parse per call).
+
+# 1. Child attr accessor shadows parent explicit method
+class P1 { method name { "parent" } }
+class C1 is P1 { has $.name }
+is C1.new(name => "attr").name, "attr",
+    "child attribute accessor shadows parent method";
+
+# 2. Child explicit method beats parent attr accessor
+class P2 { has $.name }
+class C2 is P2 { method name { "method" } }
+is C2.new(name => "attr").name, "method",
+    "child method beats parent attribute accessor";
+
+# 3. Same class: explicit method suppresses the accessor
+class B3 { has $.x; method x { "method" } }
+is B3.new(x => "attr").x, "method",
+    "same-class explicit method suppresses accessor";
+
+# 4. Role method vs class attr at same level: attr wins (class prioritization)
+role R4 { method y { "role" } }
+class C4 does R4 { has $.y }
+is C4.new(y => "attr").y, "attr",
+    "class accessor beats role-composed method at same level";
+
+# 5. Role method composed into child vs parent attr: role method wins
+class P5 { has $.z }
+role R5 { method z { "role" } }
+class C5 is P5 does R5 { }
+is C5.new(z => "attr").z, "role",
+    "role method composed into child beats parent accessor";
+
+# 6. Accessor in the middle of a deeper hierarchy wins over grandparent method
+class G6 { method w { "grand" } }
+class M6 is G6 { has $.w }
+class C6 is M6 { }
+is C6.new(w => "attr").w, "attr",
+    "inherited accessor shadows grandparent method";
+
+# 7. Child rw attr shadows parent method: write path goes through the accessor
+class P7 { method v { "parent" } }
+class C7 is P7 { has $.v is rw }
+my $c7 = C7.new(v => "init");
+lives-ok { $c7.v = "written" }, "assignment through shadowing rw accessor lives";
+is $c7.v, "written", "assignment through shadowing rw accessor sticks";
+
+# 8. Parent method still reachable when child declares no attribute
+class P8 { method u { "parent" } }
+class C8 is P8 { }
+is C8.new.u, "parent", "parent method still dispatches without a shadowing attribute";
+
+done-testing;


### PR DESCRIPTION
## Summary

In Raku the auto-generated accessor for `has $.x` is an ordinary method of its declaring class, so it participates in the MRO like any other method: **a child's accessor shadows a parent's explicit method of the same name**. mutsu treated "user-defined method beats auto-generated accessor" as a global rule, so the parent's method won.

```raku
class P { method name { "parent" } }
class C is P { has $.name }
C.new(name => "attr").name;   # raku: attr / mutsu (before): parent
```

## Impact on zef (PLAN §1 B2 mzef campaign)

`Zef::Distribution` declares `has $.name`, but its parent `Zef::Distribution::DependencySpecification` declares `method name` → spec-parts → `Zef::Identity.new` → a full REQUIRE identity-grammar parse (~4ms/call). Every `.name` read during Ecosystems populate paid a grammar parse. This was the bulk of the "populate takes 3-5 min" frontier item:

- `.name` micro-stage (300 dists, release): 1.31s → **0.02s** (65x)
- Full fez populate (7648 dists, release): ~60s → **19.5s** (raku 2.8s)
- Warm `zef info Zef` end-to-end: ~3-5 min → **~50s** (raku warm ~3.8s)
- Bonus: the short-name index now has **9259/9259 keys, exactly matching raku** — the former 3-key diff (PLAN B2 frontier #4) was the same bug (dists whose identity string fails to parse lost their `.name`)

## Fix

New `resolve_user_method_or_accessor` (class_introspection.rs) decides the winner **per MRO level**: explicit class-local method > public attribute accessor > role-composed method (class prioritization, 6.c S14-roles/attributes.t). Replaces the MRO-blind `has_class_local_method` predicate at 4 dispatch sites:

1. **Instance dispatch gate** (methods_instance_ops.rs) — accessor-wins falls through to the accessor block
2. **Fast accessor read** (vm_call_method_ops.rs) — the shadowing case now takes the *fast* attribute read instead of bailing to full dispatch
3. **Compiled-path defer check** (vm_call_method_compiled_interpret.rs) — prefiltered to role-origin/ancestor-owned resolutions so the monomorphic hot path stays cheap
4. **Lvalue assignment path** (methods_mut_method_lvalue.rs) — a shadowing `is rw` accessor is writable (previously X::Assignment::RO from the parent's non-rw method)

## Testing

- pin: `t/accessor-mro-shadowing.t` — 9 cases (shadowing both directions, same-level method-suppresses-accessor, role-vs-class prioritization at both levels, rw write path, deep hierarchy); verified byte-identical behavior under raku
- `make test`: 1715 files / 16888 tests PASS
- Spot-checked roast: 6.c/S14-roles/attributes.t, S12-attributes/{instance,inheritance,mutators,class}.t, S12-methods/{accessors,instance}.t + S12-class/inheritance.t — all PASS
- clippy (1.96.1) + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)