### PR TITLE
perf: construct constant definite-return values directly instead of string-EVAL per return

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/PLAN.md
+++ b/PLAN.md
@@ -144,11 +144,15 @@ Current state (details in news/2026-06.md and news/2026-07.md): ✅ CLI load + c
       1. populate performance: the former "3-5 min" was dominated by an MRO dispatch bug, fixed
          2026-07-15 (accessor-MRO-shadowing PR): `Zef::Distribution.name` dispatched to the parent
          DependencySpecification's `method name` (a full REQUIRE identity-grammar parse per call,
-         ~4ms) instead of the child's `has $.name` accessor. After the fix, full fez populate
-         (7648 dists) = 19.5s release (raku 2.8s, ~7x); warm `zef info Zef` end-to-end = ~50s
-         (raku warm ~3.8s, ~13x). Remaining hot spots (per-dist): `bless` runs on the
-         `run_instance_method` slow-path fallback, TWEAK x2 via the resolver path, and
-         allocation churn (~25% of flat profile in malloc/free/memmove).
+         ~4ms) instead of the child's `has $.name` accessor. Second fix same day
+         (definite-return-eval PR): every return from a `--> Nil` routine (e.g.
+         Zef::Distribution's TWEAK) paid a full string EVAL whose setup clones the entire class
+         registry twice; constant specs (Nil/True/False/Empty/pi/int) are now constructed
+         directly. Combined: full fez populate = **11.9s** release (raku ~1-2.8s); an 18-attr
+         ctor microbench (tmp/ctor-bench.raku) went 35x → 5.8x vs raku. Remaining hot spots
+         (per-dist): `bless` runs on the `run_instance_method` slow-path fallback, TWEAK x2 via
+         the resolver path, allocation churn (malloc/free/memmove still dominate the flat
+         profile).
       2. Nested `.raku` rendering: an Instance inside a collection renders as `Sp()` (type-object
          style) (`(C.new,).raku` → raku gives `(C.new(...),)`). The value itself is fine
          (semantically harmless; display only).

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,26 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-15: `--> Nil` returns no longer pay a full string EVAL — zef ctor 6x, fez populate 19.5s → 11.9s
+
+Follow-up to the accessor-MRO fix below, attacking the next populate hot spot (PLAN §1 B2
+frontier). Profiling an 18-attribute constructor microbench (`Zef::Distribution.new` shape,
+`tmp/ctor-bench.raku`) showed **the whole `HashMap<String, ClassDef>` registry being cloned
+twice per constructor** plus `eval_eval_string` in the flat profile. The chain:
+`finalize_return_with_spec` on a routine declared `--> Nil` (a *definite* return spec, e.g.
+zef's `submethod TWEAK(... --> Nil)`) evaluated the spec by **string-EVALing `"Nil"` on
+every return**, and `eval_eval_string`'s setup snapshots the entire class registry (x2).
+
+Fix: `evaluate_definite_return_value` now constructs constant specs directly — `Nil` /
+`True` / `False` / `Empty` / `pi` / integer literals — and only falls back to EVAL for
+genuinely expression-shaped specs (verified byte-identical values vs raku; note raku
+rejects `--> -3` at compile time, a pre-existing mutsu laxness left untouched).
+
+Numbers (release): ctor microbench x5000 = 4.23s → **0.7s** (6x; 35x → 5.8x vs raku's
+0.12s); full fez populate (7657 dists) 19.5s → **11.9s**; short-name index parity holds
+(9260/9260 = raku). Remaining ctor cost: `bless` on the interpreter slow path, TWEAK x2
+via the resolver path, allocation churn.
+
 ## 2026-07-15: child-class attribute accessors now shadow parent methods (MRO-level accessor dispatch) — zef populate 3-5min → `zef info Zef` ~50s
 
 An mzef-campaign session (PLAN §1 B2) that turned out to be a general **method-dispatch

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -206,7 +206,27 @@ impl Interpreter {
         if let Some(name) = Self::return_spec_scalar_name(spec) {
             return Ok(self.env.get(&name).cloned().unwrap_or(Value::NIL));
         }
-        self.eval_eval_string(spec.trim())
+        let s = spec.trim();
+        // Constant specs are by far the common case (`--> Nil` on every
+        // mutating routine) and run once per RETURN: construct them directly
+        // instead of paying a full string EVAL (whose setup snapshots the
+        // entire class registry) on every call.
+        match s {
+            "Nil" => return Ok(Value::NIL),
+            "True" => return Ok(Value::TRUE),
+            "False" => return Ok(Value::FALSE),
+            "Empty" => return Ok(Value::slip_arc(std::sync::Arc::new(vec![]))),
+            "pi" => return Ok(Value::num(std::f64::consts::PI)),
+            _ => {}
+        }
+        if s.chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_digit() || c == '-')
+            && let Ok(i) = s.parse::<i64>()
+        {
+            return Ok(Value::int(i));
+        }
+        self.eval_eval_string(s)
     }
 
     fn sink_for_definite_return(&mut self, value: &Value) -> Result<(), RuntimeError> {


### PR DESCRIPTION
## Summary

A routine declared with a **definite return spec** (`--> Nil`, `--> True`, …) evaluated the spec via `eval_eval_string` on **every return** — and that EVAL's setup snapshots the entire `HashMap<String, ClassDef>` class registry **twice**. zef's `submethod TWEAK(... --> Nil)` paid this on every `Zef::Distribution` construction during Ecosystems populate (PLAN §1 B2 frontier #1, follow-up to #4557).

Found by profiling an 18-attribute constructor microbench shaped like `Zef::Distribution.new`: `RawTable<(String, ClassDef)>::clone` and `eval_eval_string` in the flat profile of a plain constructor loop.

## Fix

`evaluate_definite_return_value` now constructs the common constant specs directly — `Nil` / `True` / `False` / `Empty` / `pi` / integer literals — and only falls back to EVAL for genuinely expression-shaped specs.

Values verified byte-identical against raku for all fast-pathed specs. (Note: raku rejects `--> -3` at compile time; mutsu's pre-existing acceptance of it is untouched — the fast path returns the same value the EVAL did.)

## Numbers (release)

| bench | before | after |
|---|---|---|
| 18-attr ctor microbench x5000 | 4.23s | **0.70s** (6x; 35x → 5.8x vs raku 0.12s) |
| full fez populate (7657 dists) | 19.5s | **11.9s** (short-name index parity with raku holds, 9260/9260) |

## Testing

- `make test`: 1717 files / 16908 tests PASS
- Targeted: t/definite-return.t, t/return-value-spec-comp.t, t/return-constraint-malformed.t, t/signature-returns.t, t/returns-coercion-type.t, roast S06-signature/definite-return.t, S06-advanced/return.t, S06-advanced/return-prioritization.t — all PASS
- clippy (1.96.1) + fmt clean
- Cargo.lock: syncs the package version to 0.4.0 (main's lock was stale after the tagpr bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)