### PR TITLE
perf(regex): memoize subrule candidate resolution+parse — drop the per-call ceremony

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/PLAN.md
+++ b/PLAN.md
@@ -424,13 +424,20 @@ unification / the malloc clusters from `Value` clone/drop and attribute material
       (was ~3.6×/pair exponential, now linear), and the capture-heavy alternation case
       `[ (<[ac]>) | (<[bc]>) ]*` over 40 chars went 372ms → 3.5ms. Pinned by
       `t/regex-sep-quantifier-ratchet.t`; tracked by `benchmarks/bench-grammar-parse.raku`
-      (mutsu ~5.9s vs raku ~0.5s, **~12×**). Remaining (why still 12×):
-      1. **Named-subrule per-call ceremony**: the singular matcher's `Named` arm
-         (`regex_match_capture.rs`) spawns a scratch sub-interpreter + copies the tail text
-         per candidate per call, so nested rules are multiplicative — `"matrix":[[1,2],[3,4]]`
-         style nesting costs seconds. Same root as the zef populate per-call cost (§1 B2).
-      2. The original general item: non-ratchet (`regex`) quantifier iterations still clone
-         `RegexCaptures` per backtrack step.
+      (mutsu ~5.9s vs raku ~0.5s, **~12×**). **Update 2026-07-15 (2): the Named-subrule
+      per-call ceremony is also FIXED** — subrule resolution+parse is memoized per
+      (pkg, name) in `PARSED_TOKEN_CANDIDATES` (invalidated by `TOKEN_DEFS_GEN`, same
+      discipline as `REGEX_PARSE_CACHE`): the per-reference registry walk
+      (`collect_token_patterns_for_scope` scanned every `token_defs` key), the per-candidate
+      `parse_regex` probe, the singular matcher's scratch sub-interpreter + tail-text
+      `String` copy, and the all-path's `tail.to_vec()` are all gone; the singular arm now
+      matches in place and wraps via the shared `build_named_candidates_from_inner`
+      (capture markers / silent-subrule action channel now behave identically on both
+      paths). bench-grammar-parse **5.9s → ~2.2s (~2.7×)**; nested `matrix` case 3.0s →
+      1.0s. Remaining (why still ~4-5×): allocation churn — profile is ~50%
+      malloc/memmove/free with `RegexCaptures::clone`+drop and `String::clone` on top =
+      the capture representation itself (String-keyed maps, full clones per DFS stack
+      push and per non-ratchet backtrack step). That is the original item of this bullet.
 - Targets (numbers from bench CI, main `c8955d2e`, 2026-07-13; parentheses = JIT-on series):
   method-call <1.5x (✅ 1.19x / jit 1.16x), bench-class <1.5x (✅ 1.02x / jit 1.00x),
   fib <10x (✅ **0.82x / jit 0.65x**), bench-fib (with type constraints) <2x

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -324,20 +324,24 @@ impl Interpreter {
                 };
                 values
             };
-            let candidates = self.resolve_named_regex_candidates_in_pkg(&spec, pkg, &arg_values);
+            // Resolve + parse the candidates once (memoized for the
+            // argument-less common case — see PARSED_TOKEN_CANDIDATES).
+            let (candidates, raw_empty) = self.parsed_subrule_candidates(&spec, pkg, &arg_values);
             // A subrule that resolves to no token/regex/rule but names a plain
             // METHOD of the grammar (`rule TOP { <.panic> }` where `method panic`
             // is defined) is a method-call subrule: invoke it. Its exception (e.g.
             // `die` inside the method) must propagate out of the parse rather than
             // being swallowed as a silent non-match.
-            if candidates.is_empty()
+            if raw_empty
                 && let Some(result) =
                     self.try_regex_subrule_as_method(&spec, chars, pos, current_caps, pkg)
             {
                 return result;
             }
             if !candidates.is_empty() {
-                let tail: Vec<char> = chars[pos..].to_vec();
+                // Borrow the remaining text — a `.to_vec()` copy here cost
+                // O(remaining) per subrule reference (O(n^2) over a parse).
+                let tail = &chars[pos..];
                 // The subrule candidates match `tail` (a slice from `pos`) at
                 // position 0, so publish the char before the slice for look-behind
                 // anchors (`^^`). At `pos == 0` inherit the current value (this
@@ -403,40 +407,25 @@ impl Interpreter {
                     let mut raw_out: Vec<(usize, RegexCaptures)> = Vec::new();
                     let mut has_proto = false;
 
-                    for (sub_pat, sub_pkg, sym_key) in &candidates {
+                    for (parsed, sub_pkg, sym_key) in candidates.iter() {
                         if sym_key.is_some() {
                             has_proto = true;
                         }
-                        // Parse the candidate's body in its OWN package so that
-                        // nested unqualified token references (notably char-class
-                        // `<+name>` items) resolve against the grammar that
-                        // defines them, not the outer caller's package.
-                        let saved_pkg = self.current_package();
-                        let switch_pkg = saved_pkg.as_str() != sub_pkg.as_str();
-                        if switch_pkg {
-                            self.set_current_package_shared(sub_pkg.clone());
-                        }
-                        let parsed_opt = self.parse_regex(sub_pat);
-                        if switch_pkg {
-                            self.set_current_package_shared(saved_pkg);
-                        }
-                        if let Some(parsed) = parsed_opt {
-                            let all_matches =
-                                self.regex_match_ends_from_caps_in_pkg(&parsed, &tail, 0, sub_pkg);
-                            // all_matches: HIGHEST FIRST.
-                            let matches_to_use: Vec<_> = if sym_key.is_some() {
-                                all_matches.into_iter().take(1).collect()
-                            } else {
-                                all_matches
-                            };
-                            // Preserve sym_key in each match so build_named_candidates_from_inner
-                            // can set subcap.sym correctly for action method dispatch.
-                            for (end, mut caps) in matches_to_use {
-                                if sym_key.is_some() {
-                                    caps.sym = sym_key.clone();
-                                }
-                                raw_out.push((end, caps));
+                        let all_matches =
+                            self.regex_match_ends_from_caps_in_pkg(parsed, tail, 0, sub_pkg);
+                        // all_matches: HIGHEST FIRST.
+                        let matches_to_use: Vec<_> = if sym_key.is_some() {
+                            all_matches.into_iter().take(1).collect()
+                        } else {
+                            all_matches
+                        };
+                        // Preserve sym_key in each match so build_named_candidates_from_inner
+                        // can set subcap.sym correctly for action method dispatch.
+                        for (end, mut caps) in matches_to_use {
+                            if sym_key.is_some() {
+                                caps.sym = sym_key.clone();
                             }
+                            raw_out.push((end, caps));
                         }
                     }
 
@@ -614,7 +603,7 @@ impl Interpreter {
     /// Build named regex candidates from inner match results (positions relative to tail).
     /// Wraps each inner match in the appropriate capture structure for the named regex call.
     /// `pos` is the position of the named atom in `chars`.
-    fn build_named_candidates_from_inner(
+    pub(super) fn build_named_candidates_from_inner(
         inner_matches: Vec<(usize, RegexCaptures)>,
         pos: usize,
         chars: &[char],

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -391,14 +391,20 @@ impl Interpreter {
             } else {
                 self.eval_regex_arg_list(&spec.arg_exprs, current_caps)?
             };
-            let candidates = self.resolve_named_regex_candidates_in_pkg(&spec, pkg, &arg_values);
+            // Resolve + parse the candidates once (memoized for the
+            // argument-less common case). Patterns are matched in place with
+            // `self` against the `&chars[pos..]` borrow — the previous
+            // implementation built a fresh scratch sub-interpreter (plus a
+            // tail-text `String`) per candidate per call, which dominated
+            // nested-grammar matching.
+            let (candidates, _raw_empty) = self.parsed_subrule_candidates(&spec, pkg, &arg_values);
             if !candidates.is_empty() {
-                let tail: Vec<char> = chars[pos..].to_vec();
-                // The subrule matches `tail` (a slice starting at `pos`) in a fresh
-                // sub-interpreter, where slice-position 0 is not the original text
-                // start. Publish the char before the slice so look-behind anchors
-                // (`^^`) in the subrule see the real context. At `pos == 0` inherit
-                // the current value (this slice may itself be a nested subrule).
+                let tail = &chars[pos..];
+                // The subrule matches a slice starting at `pos`, where
+                // slice-position 0 is not the original text start. Publish the
+                // char before the slice so look-behind anchors (`^^`) in the
+                // subrule see the real context. At `pos == 0` inherit the
+                // current value (this slice may itself be a nested subrule).
                 let saved_prev = super::regex_helpers::REGEX_PRECEDING_CHAR.with(|c| c.get());
                 let slice_prev = if pos > 0 {
                     Some(chars[pos - 1])
@@ -409,96 +415,40 @@ impl Interpreter {
                 let _restore_prev = super::regex_helpers::RegexPrecedingCharGuard(saved_prev);
                 let mut best: Option<(usize, RegexCaptures)> = None;
                 let mut best_sym: Option<String> = None;
-                for (sub_pat, sub_pkg, sym_key) in candidates {
-                    let tail_text: String = tail.iter().collect();
-                    let mut interp = Interpreter {
-                        env: self.env.clone(),
-                        current_package: Arc::new(RwLock::new(sub_pkg.clone())),
-                        var_dynamic_flags: self.var_dynamic_flags.clone(),
-                        var_type_constraints: self.var_type_constraints.clone(),
-                        state_vars: self.state_vars.clone(),
-                        ..Self::new_regex_scratch()
-                    };
-                    self.copy_decl_registry_into(&mut interp);
-                    if let Some(mut inner_caps) =
-                        interp.regex_match_with_captures(&sub_pat, &tail_text)
+                for (parsed, sub_pkg, sym_key) in candidates.iter() {
+                    if let Some((inner_end, inner_caps)) =
+                        self.regex_match_end_from_caps_in_pkg(parsed, tail, 0, sub_pkg)
                     {
-                        if inner_caps.from != 0 {
-                            continue;
-                        }
-                        let inner_end = inner_caps.to;
                         let better = best
                             .as_ref()
                             .map(|(best_end, _)| inner_end > *best_end)
                             .unwrap_or(true);
                         if better {
+                            let mut inner_caps = inner_caps;
                             inner_caps.from = 0;
                             inner_caps.to = inner_end;
                             best = Some((inner_end, inner_caps));
-                            best_sym = sym_key;
+                            best_sym = sym_key.clone();
                         }
                     }
                 }
-                if let Some((inner_end, inner_caps)) = best {
-                    let end = pos + inner_end;
-                    let mut new_caps = current_caps.clone();
-                    let capture_name = spec
-                        .capture_name
-                        .as_deref()
-                        .or_else(|| (!spec.silent).then_some(spec.lookup_name.as_str()));
-                    if let Some(capture_name) = capture_name {
-                        let captured: String = chars[pos..end].iter().collect();
-                        // Store inner captures as subcaptures (nested)
-                        let mut subcap = inner_caps;
-                        subcap.matched = captured.clone();
-                        subcap.from = pos;
-                        subcap.to = end;
-                        // Store :sym<> variant in subcapture
-                        if best_sym.is_some() {
-                            subcap.sym = best_sym;
-                        }
-                        new_caps.code_blocks.extend(subcap.code_blocks.clone());
-                        new_caps
-                            .named_subcaps
-                            .entry(capture_name.to_string())
-                            .or_default()
-                            .push(subcap);
-                        new_caps
-                            .named
-                            .entry(capture_name.to_string())
-                            .or_default()
-                            .push(captured);
-                        if spec.capture_name.is_some() && capture_name != spec.lookup_name {
-                            new_caps
-                                .capture_alias_map
-                                .insert(capture_name.to_string(), spec.lookup_name.clone());
-                            if let Some(subcaps) = new_caps.named_subcaps.get_mut(capture_name)
-                                && let Some(last) = subcaps.last_mut()
-                            {
-                                last.action_name = Some(spec.lookup_name.clone());
-                            }
-                        }
-                    } else {
-                        // No capture name — merge inner captures flat
-                        let mut inner_caps = inner_caps;
-                        for (k, v) in inner_caps.named.drain() {
-                            new_caps.named.entry(k).or_default().extend(v);
-                        }
-                        new_caps
-                            .named_quantified
-                            .extend(inner_caps.named_quantified.drain());
-                        for v in inner_caps.positional.drain(..) {
-                            new_caps.positional.push(v);
-                        }
-                        new_caps
-                            .positional_subcaps
-                            .append(&mut inner_caps.positional_subcaps);
-                        new_caps
-                            .positional_quantified
-                            .append(&mut inner_caps.positional_quantified);
-                        new_caps.code_blocks.extend(inner_caps.code_blocks);
+                // Wrap the winning inner match via the shared builder (the same
+                // one the all-candidates path uses), so capture markers
+                // (`<( )>`), alias double-registration and the silent-subrule
+                // action channel behave identically on both paths.
+                if let Some((inner_end, mut inner_caps)) = best {
+                    if best_sym.is_some() {
+                        inner_caps.sym = best_sym;
                     }
-                    return Some((end, new_caps));
+                    return Self::build_named_candidates_from_inner(
+                        vec![(inner_end, inner_caps)],
+                        pos,
+                        chars,
+                        &spec,
+                        current_caps,
+                        None,
+                    )
+                    .pop();
                 }
                 return None;
             }

--- a/src/runtime/regex/regex_match_public.rs
+++ b/src/runtime/regex/regex_match_public.rs
@@ -118,13 +118,15 @@ impl Interpreter {
         if !spec.arg_exprs.is_empty() {
             return None;
         }
-        let candidates = self.resolve_token_patterns_static_in_pkg(&spec.lookup_name, pkg);
+        // Memoized resolution+parse (PARSED_TOKEN_CANDIDATES); this fast path
+        // runs per quantifier iteration, so the per-call registry walk it used
+        // to do was pure overhead. None (non-static pattern) → no fast path.
+        let (candidates, _raw_empty) = self.parsed_subrule_candidates(&spec, pkg, &[]);
         if candidates.len() != 1 {
             return None;
         }
-        let (sub_pat, sub_pkg, _sym_key) = &candidates[0];
-        let parsed = self.parse_regex(sub_pat)?;
-        Some((parsed, sub_pkg.clone()))
+        let (parsed, sub_pkg, _sym_key) = &candidates[0];
+        Some((std::sync::Arc::clone(parsed), sub_pkg.clone()))
     }
 
     pub(in crate::runtime) fn regex_match_with_captures_core(

--- a/src/runtime/regex/regex_token_resolve.rs
+++ b/src/runtime/regex/regex_token_resolve.rs
@@ -2,7 +2,114 @@ use super::super::*;
 use super::regex_helpers::NamedRegexLookupSpec;
 use crate::symbol::Symbol;
 
+/// A resolved-and-parsed subrule candidate: (parsed pattern, dispatch package,
+/// `:sym<...>` key for proto candidates).
+pub(super) type ParsedTokenCandidate = (std::sync::Arc<RegexPattern>, String, Option<String>);
+
+/// Cache slot: the `TOKEN_DEFS_GEN` the entry was built under + the candidates.
+type CachedCandidates = (u64, std::sync::Arc<Vec<ParsedTokenCandidate>>);
+
+thread_local! {
+    /// Memoized argument-less subrule resolution: (pkg, name) → candidates
+    /// with their patterns already parsed. Rebuilding this on every
+    /// `<subrule>` reference dominated grammar matching (the registry walk in
+    /// `collect_token_patterns_for_scope` scans every `token_defs` key, plus a
+    /// `parse_regex` cache probe per candidate — together ~18% of a
+    /// JSON-grammar parse profile). Entries record the `TOKEN_DEFS_GEN` they
+    /// were built under; a stale generation rebuilds (same invalidation
+    /// discipline as `REGEX_PARSE_CACHE` and the charclass cache).
+    static PARSED_TOKEN_CANDIDATES: std::cell::RefCell<
+        rustc_hash::FxHashMap<(String, String), CachedCandidates>,
+    > = std::cell::RefCell::new(rustc_hash::FxHashMap::default());
+}
+
 impl Interpreter {
+    /// Resolve an argument-less subrule to parsed candidates, memoized per
+    /// (pkg, name). Returns `None` when any candidate's pattern is non-static
+    /// (its parse depends on runtime variable interpolation) or fails to
+    /// parse — callers fall back to the uncached per-call path.
+    fn resolve_parsed_token_candidates_in_pkg(
+        &self,
+        name: &str,
+        pkg: &str,
+    ) -> Option<std::sync::Arc<Vec<ParsedTokenCandidate>>> {
+        let tok_gen =
+            crate::runtime::regex_parse::TOKEN_DEFS_GEN.load(std::sync::atomic::Ordering::Relaxed);
+        if let Some(hit) = PARSED_TOKEN_CANDIDATES.with(|c| {
+            c.borrow()
+                .get(&(pkg.to_string(), name.to_string()))
+                .filter(|(cached_gen, _)| *cached_gen == tok_gen)
+                .map(|(_, v)| std::sync::Arc::clone(v))
+        }) {
+            return Some(hit);
+        }
+        let raw = self.resolve_token_patterns_static_in_pkg(name, pkg);
+        let mut parsed_list = Vec::with_capacity(raw.len());
+        for (sub_pat, sub_pkg, sym_key) in raw {
+            if !crate::runtime::regex_parse::regex_pattern_is_static(&sub_pat) {
+                return None;
+            }
+            let parsed = self.parse_candidate_in_pkg(&sub_pat, &sub_pkg)?;
+            parsed_list.push((parsed, sub_pkg, sym_key));
+        }
+        let arc = std::sync::Arc::new(parsed_list);
+        PARSED_TOKEN_CANDIDATES.with(|c| {
+            c.borrow_mut().insert(
+                (pkg.to_string(), name.to_string()),
+                (tok_gen, std::sync::Arc::clone(&arc)),
+            );
+        });
+        Some(arc)
+    }
+
+    /// Parse a candidate's pattern in its OWN package so nested unqualified
+    /// token references (notably char-class `<+name>` items) resolve against
+    /// the grammar that defines them, not the outer caller's package.
+    fn parse_candidate_in_pkg(
+        &self,
+        sub_pat: &str,
+        sub_pkg: &str,
+    ) -> Option<std::sync::Arc<RegexPattern>> {
+        let saved_pkg = self.current_package();
+        let switch_pkg = saved_pkg.as_str() != sub_pkg;
+        if switch_pkg {
+            self.set_current_package_shared(sub_pkg.to_string());
+        }
+        let parsed = self.parse_regex(sub_pat);
+        if switch_pkg {
+            self.set_current_package_shared(saved_pkg);
+        }
+        parsed
+    }
+
+    /// Parsed candidates for a subrule reference: memoized fast path for the
+    /// argument-less case, per-call resolution + parse otherwise (candidates
+    /// whose pattern fails to parse are skipped, as before). The second value
+    /// reports whether the RAW resolution found nothing — that (not an empty
+    /// parsed list) drives the method-subrule fallback.
+    pub(super) fn parsed_subrule_candidates(
+        &self,
+        spec: &NamedRegexLookupSpec,
+        pkg: &str,
+        arg_values: &[Value],
+    ) -> (std::sync::Arc<Vec<ParsedTokenCandidate>>, bool) {
+        if arg_values.is_empty()
+            && let Some(hit) = self.resolve_parsed_token_candidates_in_pkg(&spec.lookup_name, pkg)
+        {
+            let raw_empty = hit.is_empty();
+            return (hit, raw_empty);
+        }
+        let raw = self.resolve_named_regex_candidates_in_pkg(spec, pkg, arg_values);
+        let raw_empty = raw.is_empty();
+        let mut parsed_list = Vec::with_capacity(raw.len());
+        for (sub_pat, sub_pkg, sym_key) in raw {
+            if let Some(parsed) = self.parse_candidate_in_pkg(&sub_pat, &sub_pkg) {
+                parsed_list.push((parsed, sub_pkg, sym_key));
+            }
+        }
+        (std::sync::Arc::new(parsed_list), raw_empty)
+    }
+
     pub(super) fn resolve_token_defs_in_pkg(&self, name: &str, pkg: &str) -> Vec<Arc<FunctionDef>> {
         let mut out = Vec::new();
         if name.contains("::") {


### PR DESCRIPTION
Follow-up to #4556, addressing the residual gap it documented: **the Named-subrule per-call ceremony**.

## What every `<subrule>` reference used to pay

1. `collect_token_patterns_for_scope` walked **every** `token_defs` registry key (string-resolve + prefix match), plus per-scope HashSet clones in the MRO merge — per reference, during matching (~13% cumulative of a JSON-grammar parse).
2. A `parse_regex` cache probe per candidate (`format!`-built key, ~5%) — and the left-recursion growth loop re-did it per iteration.
3. The **singular** matcher's `Named` arm additionally built a scratch sub-interpreter (env clone + decl-registry copy) and a tail-text `String` **per candidate per call** — the ~300x nested-rule cliff documented in #4556.
4. The all-candidates arm copied the remaining text (`tail.to_vec()`) per reference — O(n²) over a parse.

## Fix

- **`PARSED_TOKEN_CANDIDATES`**: thread-local memo `(pkg, name) → Arc<Vec<(Arc<RegexPattern>, pkg, sym)>>`, invalidated by `TOKEN_DEFS_GEN` — the same discipline as `REGEX_PARSE_CACHE` and the charclass cache. Non-static patterns (runtime interpolation) are never cached; `my $x = "ab"; my token t { $x }` still tracks $x changes (raku-verified).
- **`parsed_subrule_candidates()`** is the shared entry for all three consumers: the all-candidates arm, the singular arm, and `try_resolve_named_to_pattern` (the ratchet fast path — it resolved + parsed **per quantifier iteration**).
- The **singular arm matches in place** with `self` against a `&chars[pos..]` borrow — no scratch interpreter, no String copy — and wraps the winner through the shared `build_named_candidates_from_inner`. That also aligns semantics the old inline wrap predated: `<( )>` capture markers, alias double-registration (`<x=num>` fills both `$<x>` and `$<num>`), and the silent-subrule action channel now behave identically on both paths.
- The all-candidates arm borrows the tail instead of copying it.

## Numbers (release, same machine)

| case | #4556 | this PR |
|---|---|---|
| bench-grammar-parse | ~5.9s | **~2.2s (2.7x)** |
| nested `matrix":[[1,2],[3,4]]` construct | 3.0s | 1.0s |
| entries (array of objects) | 6.7s | 3.7s |
| exceptions-alternatives.t | 0.83s | 0.70s |

Remaining gap vs raku (~4-5x on the bench) is allocation churn in the capture representation itself (`RegexCaptures` String-keyed maps, full clones per DFS push) — updated in PLAN.md §5. Same root as the zef populate per-call cost (§1 B2), which this PR should also help; not re-measured here.

## Verification

- `make test`: 1716 files / 16896 tests, all green.
- All **93 whitelisted S05 roast files** (5524 tests) pass — captures, grammars, proto-regex, match objects, substitution.
- Cache-invalidation probes: runtime grammar definition via EVAL after cache warm; dynamic (interpolated) token bypass with post-cache value change — both match raku.

🤖 Generated with [Claude Code](https://claude.com/claude-code)