### PR TITLE
feat: custom grammar metaclasses — Metamodel::GrammarHOW + EXPORTHOW find_method protocol

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -48,7 +48,7 @@ Definitions of the classifications:
 
 ## Current assumptions
 
-- The whitelist stands at **1408 / 1463** (2026-07-15, `wc -l roast-whitelist.txt`) = **55** files not whitelisted.
+- The whitelist stands at **1409 / 1463** (2026-07-15, `wc -l roast-whitelist.txt`) = **54** files not whitelisted.
 - **The S\* files (per-synopsis feature tests) are exhausted.** All of the former large campaigns
   (true lazy arrays / desugaring of dispatch and operator sugar / S17 concurrency & async /
   first-class-container container identity / cross-thread lexical writeback) are complete, and
@@ -71,7 +71,6 @@ noted.
 
 | File | mutsu | raku | Blocker / note |
 |---|---|---|---|
-| `integration/advent2011-day07.t` | fails | PASS ★ | `Metamodel::GrammarHOW` inheritance — `Advent::GrammarProfiler` requires `class ProfiledGrammarHOW is Metamodel::GrammarHOW` plus the equivalent of `^set_how` = **major metamodel work** |
 | `integration/precompiled.t` | fails | PASS ★ | precomp infrastructure |
 | `integration/error-reporting.t` | 28/33 | PASS ★ | **④ error-message quality.** Remaining 5 = backtrace frames for module files (15), Failure dual backtrace (20), return inside map (21), `%::{''}` (25), type-capture inheritance (30). Compile-time undeclared-routine detection (tests 5/23) is implemented (`check_undeclared_routines_mainline` — rakudo's CHECK-time X::Undeclared::Symbols + `Did you mean 'BEGIN'?` suggestion); #4539 implemented backtraces on all runtime errors, is_run = stderr identical to the CLI, Backtrace.new/full |
 | `integration/weird-errors.t` | 31/36 | PASS ★ | **④ error-message quality.** Remaining = `say(;:[])` (11), `::a`→X::NoSuchSymbol needs `::` info on BareWord (20), our method invocant type (29), `new Foo:` (32), `hash a=>1` (33) |

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -58,6 +58,43 @@ class and participates in the MRO like any other method (child accessor wins).
 
 Remaining populate hot spots (per dist): `bless` on the `run_instance_method` slow path,
 TWEAK x2 via the resolver path, allocation churn — see PLAN §1 B2.
+## 2026-07-15: custom grammar metaclasses (Metamodel::GrammarHOW + EXPORTHOW) — advent2011-day07.t whitelisted
+
+The last "major metamodel work" item of the integration cluster:
+`Advent::GrammarProfiler` (a grammar profiler that swaps in a custom metaclass
+via `EXPORTHOW.WHO.<grammar> = ProfiledGrammarHOW`) now works end to end, and
+`integration/advent2011-day07.t` passes (whitelist 1409/1463). Four general
+mechanisms, no test-specific hacks:
+
+1. **`Metamodel::GrammarHOW` is inheritable** (added to the builtin parent
+   list next to `Metamodel::ClassHOW`), and `callsame` from a user HOW method
+   now reaches the **native** metamodel implementation once the user MRO is
+   exhausted: `run_instance_method`/`push_method_dispatch_frame` record a
+   metamodel dispatch context (gated by a registry flag so ordinary programs
+   pay one bool read), and `dispatch_next_candidate` serves the default
+   `find_method` (via `classhow_find_method`) / `publish_method_cache` as the
+   final candidate.
+2. **EXPORTHOW installation**: a `grammar` declared while an
+   `EXPORTHOW::<grammar>` stash entry is visible gets an instance of that HOW
+   (`install_custom_grammar_how`) — recorded as its `.HOW` and, when the HOW
+   class defines a user `find_method`, in `Registry::grammar_custom_how`.
+3. **Token methods are callable**: `Routine { is_regex: true }` stubs (what
+   `^find_method` returns for a token) called as `$meth($cursor)` run the
+   token anchored at the cursor position and return a Match
+   (`try_call_token_method_value`, hooked into both `call_sub_value` and the
+   VM's `vm_call_on_value`).
+4. **Subrule dispatch routes through the custom HOW**: the regex engine's
+   named-subrule path consults `grammar_custom_how` and calls
+   `find_method(TypeObj, name)` in a scratch interpreter; a returned wrapper
+   closure is invoked with a cursor and its Match converted back into an
+   engine candidate (inner captures recovered via a thread-local side
+   channel). Module-level `our %timing` mutations inside the wrapper persist
+   because env values are shared cells.
+
+Pin: `t/exporthow-grammar-how.t`. Known simplifications (TODO comments in
+code): EXPORTHOW is approximated as globally visible rather than lexically
+scoped, and left-recursive rules bypass the LR seed-growing loop on the
+custom-HOW path.
 
 ## 2026-07-15: TODO_roast consolidated — S*.md retired, BLOCKERS.md is the single ledger
 

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1346,6 +1346,7 @@ roast/integration/advent2010-day23.t
 roast/integration/advent2011-day03.t
 roast/integration/advent2011-day04.t
 roast/integration/advent2011-day05.t
+roast/integration/advent2011-day07.t
 roast/integration/advent2011-day10.t
 roast/integration/advent2011-day15.t
 roast/integration/advent2011-day16.t

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -612,6 +612,55 @@ impl Interpreter {
         resolved
     }
 
+    /// True when `class_name`'s MRO (or direct parents) includes a builtin
+    /// metamodel class, i.e. the class is a user-defined HOW. Gated by the
+    /// registry-level `has_metamodel_how_classes` flag so programs that never
+    /// declare a HOW subclass pay a single bool read per method dispatch.
+    pub(crate) fn is_metamodel_how_class(&self, class_name: &str) -> bool {
+        let reg = self.registry();
+        if !reg.has_metamodel_how_classes {
+            return false;
+        }
+        reg.classes.get(class_name).is_some_and(|cd| {
+            cd.mro.iter().any(|c| Self::is_metamodel_class_name(c))
+                || cd.parents.iter().any(|c| Self::is_metamodel_class_name(c))
+        })
+    }
+
+    /// Name of a builtin metamodel class a user HOW can inherit from.
+    pub(crate) fn is_metamodel_class_name(name: &str) -> bool {
+        matches!(
+            name,
+            "Metamodel::ClassHOW"
+                | "Metamodel::GrammarHOW"
+                | "Perl6::Metamodel::ClassHOW"
+                | "Perl6::Metamodel::GrammarHOW"
+        )
+    }
+
+    /// Push the samewith context for a method dispatch, plus a metamodel
+    /// dispatch context when the receiver is a user-defined HOW class (so
+    /// `callsame` can reach the native metamodel method as the last
+    /// candidate). Always pair with `pop_method_samewith_context`.
+    pub(crate) fn push_method_samewith_context(
+        &mut self,
+        receiver_class: &str,
+        method_name: &str,
+        args: &[Value],
+        invocant: Option<Value>,
+    ) {
+        self.samewith_context_stack
+            .push((method_name.to_string(), invocant));
+        if self.is_metamodel_how_class(receiver_class) {
+            self.metamodel_dispatch_stack.push((
+                self.samewith_context_stack.len(),
+                receiver_class.to_string(),
+                method_name.to_string(),
+                args.to_vec(),
+            ));
+        }
+    }
+
     pub(crate) fn push_method_dispatch_frame(
         &mut self,
         receiver_class: &str,
@@ -620,8 +669,12 @@ impl Interpreter {
         invocant: Value,
     ) -> bool {
         // Always push samewith context so samewith() can find the method name/invocant
-        self.samewith_context_stack
-            .push((method_name.to_string(), Some(invocant.clone())));
+        self.push_method_samewith_context(
+            receiver_class,
+            method_name,
+            args,
+            Some(invocant.clone()),
+        );
         // Fast path: a name with at most one *structural* dispatch candidate across
         // the MRO can never produce a deferral frame (arg-matching only reduces the
         // candidate count), so skip the per-call `resolve_all_methods_with_owner`
@@ -735,9 +788,17 @@ impl Interpreter {
         self.method_dispatch_stack.pop();
     }
 
-    /// Pop the samewith context pushed by push_method_dispatch_frame.
+    /// Pop the samewith context pushed by push_method_dispatch_frame /
+    /// push_method_samewith_context.
     /// Must always be called after push_method_dispatch_frame, regardless of its return value.
     pub(crate) fn pop_method_samewith_context(&mut self) {
+        if self
+            .metamodel_dispatch_stack
+            .last()
+            .is_some_and(|(depth, ..)| *depth == self.samewith_context_stack.len())
+        {
+            self.metamodel_dispatch_stack.pop();
+        }
         self.samewith_context_stack.pop();
     }
 

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -114,6 +114,41 @@ impl Interpreter {
         ))
     }
 
+    /// When a user method on a subclass of a builtin metamodel class
+    /// (Metamodel::ClassHOW / Metamodel::GrammarHOW) exhausts the user-defined
+    /// MRO, provide the NATIVE metamodel implementation as the final
+    /// `callsame` candidate. Native metamodel methods are not `MethodDef`
+    /// candidates, so the regular MRO chain cannot reach them.
+    fn native_metamodel_next_candidate(
+        &mut self,
+        override_args: Option<&[Value]>,
+    ) -> Option<Result<Value, RuntimeError>> {
+        let (_depth, _receiver, method_name, orig_args) =
+            self.metamodel_dispatch_stack.last().cloned()?;
+        // Only fire when the innermost method dispatch is the metamodel method
+        // itself (not some helper method it called).
+        if self
+            .samewith_context_stack
+            .last()
+            .is_none_or(|(n, _)| n != &method_name)
+        {
+            return None;
+        }
+        let args: Vec<Value> = override_args.map(<[Value]>::to_vec).unwrap_or(orig_args);
+        match method_name.as_str() {
+            "find_method" => {
+                let obj = args.first()?.clone();
+                let name = args.get(1)?.to_string_value();
+                Some(Ok(self
+                    .classhow_find_method(&obj, &name)
+                    .unwrap_or(Value::NIL)))
+            }
+            // mutsu has no method cache to publish; the default is a no-op.
+            "publish_method_cache" => Some(Ok(Value::NIL)),
+            _ => None,
+        }
+    }
+
     /// Shared implementation for callsame/nextsame/callwith/nextwith.
     /// `override_args`: if Some, use these args instead of the original.
     /// `tail_call`: if true, raise a return-control exception with the result.
@@ -240,13 +275,21 @@ impl Interpreter {
             let (receiver_class, invocant, mut call_args, owner_class, mut method_def, rw_params) = {
                 let frame = &mut self.method_dispatch_stack[frame_idx];
                 let Some((owner_class, method_def)) = frame.remaining.first().cloned() else {
+                    // User MRO exhausted: a metamodel-HOW dispatch falls through
+                    // to the native metamodel implementation as the last
+                    // candidate before giving up.
+                    let result =
+                        match self.native_metamodel_next_candidate(override_args.as_deref()) {
+                            Some(res) => res?,
+                            None => Value::NIL,
+                        };
                     if tail_call {
                         return Err(RuntimeError {
-                            return_value: Some(Value::NIL),
+                            return_value: Some(result),
                             ..RuntimeError::new("")
                         });
                     }
-                    return Ok(Value::NIL);
+                    return Ok(result);
                 };
                 frame.remaining.remove(0);
                 let rw_params = frame.rw_params.clone();
@@ -546,6 +589,19 @@ impl Interpreter {
                     self.env.insert(first_param.clone(), val);
                 }
             }
+            if tail_call {
+                return Err(RuntimeError {
+                    return_value: Some(result),
+                    ..RuntimeError::new("")
+                });
+            }
+            return Ok(result);
+        }
+        // A metamodel-HOW method (user subclass of Metamodel::ClassHOW /
+        // Metamodel::GrammarHOW) with no user MRO frame at all: the native
+        // metamodel implementation is the next (and last) candidate.
+        if let Some(res) = self.native_metamodel_next_candidate(override_args.as_deref()) {
+            let result = res?;
             if tail_call {
                 return Err(RuntimeError {
                     return_value: Some(result),

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -159,8 +159,12 @@ impl Interpreter {
             let invocant_for_dispatch = make_invocant_for_dispatch(&invocant, &attributes);
             let remaining = build_remaining(self, &method_def);
             let pushed_dispatch = !remaining.is_empty();
-            self.samewith_context_stack
-                .push((method_name.to_string(), Some(invocant_for_dispatch.clone())));
+            self.push_method_samewith_context(
+                receiver_class_name,
+                method_name,
+                &args,
+                Some(invocant_for_dispatch.clone()),
+            );
             if pushed_dispatch {
                 let rw_params = super::builtins_dispatch_next::rw_scalar_positional_params(
                     &method_def.param_defs,
@@ -216,7 +220,7 @@ impl Interpreter {
                     }
                 }
             }
-            self.samewith_context_stack.pop();
+            self.pop_method_samewith_context();
             if pushed_dispatch {
                 self.method_dispatch_stack.pop();
             }
@@ -225,8 +229,12 @@ impl Interpreter {
         let invocant_for_dispatch = make_invocant_for_dispatch(&invocant, &attributes);
         let remaining = build_remaining(self, &method_def);
         let pushed_dispatch = !remaining.is_empty();
-        self.samewith_context_stack
-            .push((method_name.to_string(), Some(invocant_for_dispatch.clone())));
+        self.push_method_samewith_context(
+            receiver_class_name,
+            method_name,
+            &args,
+            Some(invocant_for_dispatch.clone()),
+        );
         if pushed_dispatch {
             let rw_params =
                 super::builtins_dispatch_next::rw_scalar_positional_params(&method_def.param_defs);
@@ -261,7 +269,7 @@ impl Interpreter {
             args,
             invocant,
         );
-        self.samewith_context_stack.pop();
+        self.pop_method_samewith_context();
         if pushed_dispatch {
             self.method_dispatch_stack.pop();
         }

--- a/src/runtime/metamodel.rs
+++ b/src/runtime/metamodel.rs
@@ -272,4 +272,48 @@ impl Interpreter {
         );
         false
     }
+
+    /// Install a custom metaclass on a just-declared grammar: instantiate the
+    /// EXPORTHOW-provided HOW type and record the instance as the grammar's
+    /// `.HOW`. When the HOW class (or an ancestor) defines a user
+    /// `find_method`, the grammar is also entered in `grammar_custom_how` so
+    /// the regex engine routes subrule dispatch through it
+    /// (Metamodel::GrammarHOW protocol).
+    pub(crate) fn install_custom_grammar_how(
+        &mut self,
+        grammar_name: &str,
+        how_type: Value,
+    ) -> Result<(), RuntimeError> {
+        let how_class = match how_type.view() {
+            ValueView::Package(sym) => sym.resolve(),
+            _ => return Ok(()),
+        };
+        // The HOW type must be a user-declared class (a stale/foreign stash
+        // entry is ignored rather than failing the grammar declaration).
+        if !self.registry().classes.contains_key(&how_class) {
+            return Ok(());
+        }
+        let instance = self.call_method_with_values(how_type, "new", Vec::new())?;
+        let has_user_find_method = self
+            .registry()
+            .classes
+            .get(&how_class)
+            .map(|cd| cd.mro.clone())
+            .unwrap_or_default()
+            .iter()
+            .any(|c| {
+                self.registry()
+                    .classes
+                    .get(c.as_str())
+                    .is_some_and(|cd| cd.methods.contains_key("find_method"))
+            });
+        let mut reg = self.registry_mut();
+        reg.class_how_values
+            .insert(grammar_name.to_string(), instance.clone());
+        if has_user_find_method {
+            reg.grammar_custom_how
+                .insert(grammar_name.to_string(), instance);
+        }
+        Ok(())
+    }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1539,6 +1539,16 @@ pub struct Interpreter {
     /// Each entry is (function_or_method_name, optional_invocant).
     /// Pushed whenever a multi sub or multi method is entered, popped on exit.
     samewith_context_stack: Vec<(String, Option<Value>)>,
+    /// Metamodel-method dispatch contexts:
+    /// (samewith_depth, receiver_class, method_name, args).
+    /// Pushed alongside the samewith context when the receiver's MRO includes
+    /// a builtin metamodel class (Metamodel::ClassHOW / Metamodel::GrammarHOW),
+    /// so a `callsame` in a user HOW method that exhausts the user MRO can
+    /// fall through to the NATIVE metamodel implementation (e.g. the default
+    /// `find_method`), which is not represented as a `MethodDef` candidate.
+    /// `samewith_depth` ties each entry to its samewith frame so the shared
+    /// pop helper knows whether the top entry belongs to the frame being popped.
+    metamodel_dispatch_stack: Vec<(usize, String, String, Vec<Value>)>,
     /// Wrap chains: sub_id -> stack of (handle_id, wrapper_sub). Outermost is last.
     wrap_chains: HashMap<u64, Vec<(u64, Value)>>,
     /// Maps sub_id to function name for named call wrap chain lookup.

--- a/src/runtime/regex/mod.rs
+++ b/src/runtime/regex/mod.rs
@@ -12,4 +12,5 @@ mod regex_match_find;
 mod regex_match_nocap;
 mod regex_match_public;
 mod regex_resolve;
+mod regex_token_method;
 mod regex_token_resolve;

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -338,6 +338,23 @@ impl Interpreter {
             {
                 return result;
             }
+            // A grammar declared under a custom EXPORTHOW metaclass with a user
+            // `find_method` routes subrule dispatch through it (the
+            // Metamodel::GrammarHOW protocol); `None` falls through to the
+            // normal engine path.
+            if !candidates.is_empty()
+                && !self.registry().grammar_custom_how.is_empty()
+                && let Some(result) = self.try_custom_how_subrule_dispatch(
+                    &spec,
+                    chars,
+                    pos,
+                    current_caps,
+                    pkg,
+                    &arg_values,
+                )
+            {
+                return result;
+            }
             if !candidates.is_empty() {
                 // Borrow the remaining text — a `.to_vec()` copy here cost
                 // O(remaining) per subrule reference (O(n^2) over a parse).

--- a/src/runtime/regex/regex_token_method.rs
+++ b/src/runtime/regex/regex_token_method.rs
@@ -1,0 +1,273 @@
+//! Token/rule methods as first-class callables, plus custom-HOW subrule
+//! dispatch (the Metamodel::GrammarHOW `find_method` protocol).
+//!
+//! `Grammar.^find_method("tok")` returns a `Routine { is_regex: true }` stub.
+//! Calling that stub with a Match cursor as the first argument must actually
+//! RUN the token at the cursor position (rakudo: regex methods take a cursor
+//! invocant and return a new cursor). This is what lets a custom grammar HOW's
+//! `find_method` wrap token dispatch in a profiling closure that itself calls
+//! `$meth($cursor)` (roast integration/advent2011-day07.t).
+
+use std::cell::RefCell;
+use std::collections::HashSet;
+
+use super::super::*;
+use super::regex_helpers::NamedRegexLookupSpec;
+
+/// The inner regex captures of the most recent token-method call
+/// (`run_token_method_at`), identified by (pkg, name, from, to) in the
+/// original string. The custom-HOW subrule hook uses this to rebuild the full
+/// capture structure from the Match a `find_method` wrapper returned — the
+/// Match value itself does not carry `RegexCaptures`.
+struct TokenMethodMatch {
+    pkg: String,
+    name: String,
+    from: usize,
+    to: usize,
+    caps: RegexCaptures,
+}
+
+thread_local! {
+    static LAST_TOKEN_METHOD_MATCH: RefCell<Option<TokenMethodMatch>> =
+        const { RefCell::new(None) };
+}
+
+impl Interpreter {
+    /// Call a grammar token/rule as a method value: `$meth($cursor, |args)`.
+    /// Returns `None` when this Routine does not name a token in `pkg` (the
+    /// caller falls through to regular Routine dispatch), `Some(Ok(Match))`
+    /// when the token matched at the cursor position, and `Some(Ok(Nil))` on
+    /// no match.
+    pub(crate) fn try_call_token_method_value(
+        &mut self,
+        pkg: &str,
+        name: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if pkg.is_empty() || pkg == "GLOBAL" {
+            return None;
+        }
+        if self.resolve_token_defs_in_pkg(name, pkg).is_empty() {
+            return None;
+        }
+        // Cursor: a Match instance (orig + to = current position) or a plain Str.
+        let (text, pos) = match args.first().map(Value::view) {
+            Some(ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            }) if class_name.resolve() == "Match" => {
+                let attrs = attributes.as_map();
+                let orig = attrs.get("orig").map(|v| v.to_string_value())?;
+                let to = attrs
+                    .get("to")
+                    .and_then(|v| v.as_int())
+                    .filter(|t| *t >= 0)
+                    .unwrap_or(0) as usize;
+                (orig, to)
+            }
+            Some(ValueView::Str(s)) => (s.to_string(), 0usize),
+            _ => return None,
+        };
+        Some(self.run_token_method_at(pkg, name, &args[1..], &text, pos))
+    }
+
+    /// Run token `pkg::name` anchored at char position `pos` of `text` and
+    /// build a Match value (from = pos). Publishes the inner `RegexCaptures`
+    /// to the thread-local side channel for the custom-HOW subrule hook.
+    fn run_token_method_at(
+        &mut self,
+        pkg: &str,
+        name: &str,
+        extra_args: &[Value],
+        text: &str,
+        pos: usize,
+    ) -> Result<Value, RuntimeError> {
+        let tail: String = text.chars().skip(pos).collect();
+        let saved_pkg = self.current_package();
+        let saved_topic = self.env.get("_").cloned();
+        self.set_current_package(pkg.to_string());
+        self.env.insert("_".to_string(), Value::str(tail.clone()));
+        let pattern_res = self.eval_token_call_values(name, extra_args);
+        self.set_current_package(saved_pkg);
+        match saved_topic {
+            Some(t) => {
+                self.env.insert("_".to_string(), t);
+            }
+            None => {
+                self.env.remove("_");
+            }
+        }
+        let Some(pattern) = pattern_res? else {
+            return Ok(Value::NIL);
+        };
+        let Some(parsed) = self.parse_regex(&pattern) else {
+            return Ok(Value::NIL);
+        };
+        let tail_chars: Vec<char> = tail.chars().collect();
+        let matches = self.regex_match_ends_from_caps_in_pkg(&parsed, &tail_chars, 0, pkg);
+        // Matches come HIGHEST FIRST: the first entry is the token's best
+        // (ratcheted) match, which is what a cursor method call returns.
+        let Some((end_rel, caps)) = matches.into_iter().next() else {
+            return Ok(Value::NIL);
+        };
+        let matched: String = tail_chars[..end_rel].iter().collect();
+        let m = Value::make_match_object_full_q(
+            matched,
+            pos as i64,
+            (pos + end_rel) as i64,
+            &caps.positional,
+            &caps.named,
+            &caps.named_subcaps,
+            &caps.positional_subcaps,
+            &caps.positional_quantified,
+            &caps.positional_nil,
+            Some(text),
+            &caps.named_quantified,
+        );
+        LAST_TOKEN_METHOD_MATCH.with(|slot| {
+            *slot.borrow_mut() = Some(TokenMethodMatch {
+                pkg: pkg.to_string(),
+                name: name.to_string(),
+                from: pos,
+                to: pos + end_rel,
+                caps,
+            });
+        });
+        Ok(m)
+    }
+
+    /// Custom-HOW subrule dispatch: when the dispatch package was declared as
+    /// a grammar under an EXPORTHOW metaclass with a user `find_method`, route
+    /// the subrule `<name>` through it (Metamodel::GrammarHOW protocol): call
+    /// `HOW.find_method(TypeObj, name)`; when it returns a wrapper CODE object
+    /// (not the plain method), invoke the wrapper with a cursor at `pos` and
+    /// convert the Match it returns back into an engine candidate.
+    ///
+    /// Returns `None` to fall through to the normal token path (no custom HOW,
+    /// or `find_method` returned the method unwrapped), `Some(vec![])` for a
+    /// dispatched non-match (or an error, published via PENDING_REGEX_ERROR),
+    /// and `Some(vec![(end, caps)])` for a dispatched match.
+    ///
+    /// TODO: left-recursive rules bypass the LR seed-growing loop on this
+    /// path; a left-recursive grammar under a profiling HOW would recurse.
+    pub(super) fn try_custom_how_subrule_dispatch(
+        &self,
+        spec: &NamedRegexLookupSpec,
+        chars: &[char],
+        pos: usize,
+        current_caps: &RegexCaptures,
+        pkg: &str,
+        arg_values: &[Value],
+    ) -> Option<Vec<(usize, RegexCaptures)>> {
+        let how = self.registry().grammar_custom_how.get(pkg).cloned()?;
+        if spec.lookup_name.is_empty()
+            || spec.lookup_name.contains("::")
+            || !spec
+                .lookup_name
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+        {
+            return None;
+        }
+        // Scratch interpreter (mirrors `try_regex_subrule_as_method`): the
+        // regex engine runs on `&self`, but user `find_method` / wrapper code
+        // needs a mutable interpreter. Shared-cell values (module `our` vars)
+        // keep mutations visible to the parent.
+        let mut interp = Interpreter {
+            env: self.env.clone(),
+            current_package: Arc::new(RwLock::new(pkg.to_string())),
+            ..Self::new_regex_scratch()
+        };
+        self.copy_full_registry_into(&mut interp);
+        if self.test_module_loaded() {
+            interp.loaded_modules = self.loaded_modules.clone();
+            interp.tap.ensure_state();
+        }
+        let typeobj = Value::package(crate::symbol::Symbol::intern(pkg));
+        let meth = match interp.call_method_with_values(
+            how,
+            "find_method",
+            vec![typeobj, Value::str(spec.lookup_name.clone())],
+        ) {
+            Ok(v) => v,
+            Err(e) => {
+                crate::runtime::regex_parse::PENDING_REGEX_ERROR
+                    .with(|slot| *slot.borrow_mut() = Some(e));
+                return Some(Vec::new());
+            }
+        };
+        // Only a wrapper CODE object diverts dispatch; the plain method value
+        // (a Routine stub) means "unwrapped" — use the normal engine path.
+        if !matches!(meth.view(), ValueView::Sub(_)) {
+            return None;
+        }
+        let text: String = chars.iter().collect();
+        let cursor = Value::make_match_object_full_q(
+            String::new(),
+            pos as i64,
+            pos as i64,
+            &[],
+            &HashMap::new(),
+            &HashMap::new(),
+            &[],
+            &[],
+            &[],
+            Some(&text),
+            &HashSet::new(),
+        );
+        let mut call_args = vec![cursor];
+        call_args.extend(arg_values.iter().cloned());
+        LAST_TOKEN_METHOD_MATCH.with(|slot| slot.borrow_mut().take());
+        let result = match interp.call_sub_value(meth, call_args, false) {
+            Ok(v) => v,
+            Err(e) => {
+                crate::runtime::regex_parse::PENDING_REGEX_ERROR
+                    .with(|slot| *slot.borrow_mut() = Some(e));
+                return Some(Vec::new());
+            }
+        };
+        let side = LAST_TOKEN_METHOD_MATCH.with(|slot| slot.borrow_mut().take());
+        // The wrapper must return a Match/cursor; read its extent.
+        let to_abs = if let ValueView::Instance { attributes, .. } = result.view() {
+            attributes
+                .as_map()
+                .get("to")
+                .and_then(|t| t.as_int())
+                .filter(|&t| t >= pos as i64 && t <= chars.len() as i64)
+                .map(|t| t as usize)
+        } else {
+            None
+        };
+        let Some(to_abs) = to_abs else {
+            return Some(Vec::new());
+        };
+        // Prefer the side-channel captures from the actual token run inside
+        // the wrapper; a wrapper that fabricated its own Match still advances
+        // the parse by its extent (with a plain-text capture).
+        let inner_caps = match side {
+            Some(t)
+                if t.pkg == pkg
+                    && t.name == spec.lookup_name
+                    && t.from == pos
+                    && t.to == to_abs =>
+            {
+                t.caps
+            }
+            _ => RegexCaptures {
+                matched: chars[pos..to_abs].iter().collect(),
+                to: to_abs - pos,
+                ..RegexCaptures::default()
+            },
+        };
+        let sym = inner_caps.sym.clone();
+        Some(Self::build_named_candidates_from_inner(
+            vec![(to_abs - pos, inner_caps)],
+            pos,
+            chars,
+            spec,
+            current_caps,
+            sym.as_ref(),
+        ))
+    }
+}

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -405,6 +405,8 @@ impl Interpreter {
             "Stash",
             "Metamodel::ClassHOW",
             "Perl6::Metamodel::ClassHOW",
+            "Metamodel::GrammarHOW",
+            "Perl6::Metamodel::GrammarHOW",
         ];
         let mut deferred_custom_traits: Vec<String> = Vec::new();
         for parent in parents {
@@ -2228,6 +2230,39 @@ impl Interpreter {
         if let Err(err) = self.validate_private_method_existence(name) {
             restore_previous_state(self);
             return Err(err);
+        }
+        // A user class inheriting a builtin metamodel class is a HOW subclass:
+        // arm the cheap per-dispatch gate for `is_metamodel_how_class`. Check
+        // the raw parent list too — builtin parents that are not registry
+        // classes may be absent from the computed MRO.
+        if !self.registry().has_metamodel_how_classes
+            && (parents.iter().any(|c| Self::is_metamodel_class_name(c))
+                || self
+                    .registry()
+                    .classes
+                    .get(name)
+                    .is_some_and(|cd| cd.mro.iter().any(|c| Self::is_metamodel_class_name(c))))
+        {
+            self.registry_mut().has_metamodel_how_classes = true;
+        }
+        // A grammar declared while an EXPORTHOW `grammar` metaclass mapping is
+        // installed (`EXPORTHOW.WHO.<grammar> = SomeHOW`, typically from a
+        // `use`d module) gets an instance of that HOW. The regex engine then
+        // routes the grammar's subrule dispatch through the HOW's user
+        // `find_method` (Metamodel::GrammarHOW protocol).
+        // TODO: EXPORTHOW should be lexically scoped to the `use`ing scope;
+        // mutsu approximates it with the (globally visible) EXPORTHOW package
+        // stash entry.
+        // The stash-assignment path stores the entry under a `$`-prefixed env
+        // key (`EXPORTHOW::$grammar`); check the sigil-less form too.
+        if parents.iter().any(|p| p == "Grammar")
+            && let Some(how_type) = self
+                .env
+                .get("EXPORTHOW::$grammar")
+                .or_else(|| self.env.get("EXPORTHOW::grammar"))
+                .cloned()
+        {
+            self.install_custom_grammar_how(name, how_type)?;
         }
         Ok(deferred_custom_traits)
     }

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -74,6 +74,15 @@ pub(crate) struct Registry {
     pub(crate) class_trusts: HashMap<String, HashSet<String>>,
     /// Per-class metaclass (`HOW`) value override.
     pub(crate) class_how_values: HashMap<String, Value>,
+    /// Grammars declared under a custom EXPORTHOW `grammar` metaclass whose HOW
+    /// class defines a user `find_method`: grammar name -> HOW instance. The
+    /// regex engine consults this to route subrule dispatch through the custom
+    /// `find_method` (Metamodel::GrammarHOW protocol).
+    pub(crate) grammar_custom_how: HashMap<String, Value>,
+    /// True once any user class inheriting a builtin metamodel class
+    /// (Metamodel::ClassHOW / Metamodel::GrammarHOW) has been declared. Cheap
+    /// gate for the per-dispatch `is_metamodel_how_class` check.
+    pub(crate) has_metamodel_how_classes: bool,
     /// Roles composed into each class: class -> [role names]. This is the
     /// FLATTENED set (includes roles reached transitively through a composed
     /// role's own `does`), used for `~~`/role-membership checks.

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -85,7 +85,21 @@ impl Interpreter {
             },
             _ => func,
         };
-        if let ValueView::Routine { package, name, .. } = func.view() {
+        if let ValueView::Routine {
+            package,
+            name,
+            is_regex,
+        } = func.view()
+        {
+            // A token/rule method value called with a cursor (`$meth($c)`,
+            // e.g. from a custom grammar HOW's `find_method` wrapper) runs
+            // the token at the cursor position and returns a Match.
+            if is_regex
+                && let Some(res) =
+                    self.try_call_token_method_value(&package.resolve(), &name.resolve(), &args)
+            {
+                return res;
+            }
             if !package.is_empty() && package != "GLOBAL" {
                 let fq = format!("{package}::{name}");
                 if self.resolve_function(&fq).is_some() {

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2132,6 +2132,7 @@ impl Interpreter {
             multi_dispatch_stack: Vec::new(),
             method_dispatch_stack: Vec::new(),
             samewith_context_stack: Vec::new(),
+            metamodel_dispatch_stack: Vec::new(),
             wrap_chains: HashMap::new(),
             wrap_sub_names: HashMap::new(),
             wrap_name_to_sub: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -307,6 +307,7 @@ impl Interpreter {
             multi_dispatch_stack: Vec::new(),
             method_dispatch_stack: Vec::new(),
             samewith_context_stack: Vec::new(),
+            metamodel_dispatch_stack: Vec::new(),
             wrap_chains: self.wrap_chains.clone(),
             wrap_sub_names: self.wrap_sub_names.clone(),
             wrap_name_to_sub: self.wrap_name_to_sub.clone(),

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -417,9 +417,21 @@ impl Interpreter {
         // priority is preserved because a bare builtin Routine (e.g. `&SETTING::not`
         // -> Routine{GLOBAL, "not"}) is not a declared user function, so it skips the
         // `has_function` branches and resolves natively in compiled-first.
-        if let ValueView::Routine { package, name, .. } = target.view() {
+        if let ValueView::Routine {
+            package,
+            name,
+            is_regex,
+        } = target.view()
+        {
             let pkg = package.resolve();
             let name_str = name.resolve();
+            // A token/rule method value called with a cursor (`$meth($c)`,
+            // e.g. from a custom grammar HOW's `find_method` wrapper) runs
+            // the token at the cursor position and returns a Match.
+            if is_regex && let Some(res) = self.try_call_token_method_value(&pkg, &name_str, &args)
+            {
+                return res;
+            }
             let empty_fns = CompiledFns::default();
             let fns = compiled_fns.unwrap_or(&empty_fns);
             if !pkg.is_empty() && pkg != "GLOBAL" {

--- a/t/exporthow-grammar-how.t
+++ b/t/exporthow-grammar-how.t
@@ -1,0 +1,44 @@
+use v6;
+use Test;
+use lib 't/lib';
+use GrammarProfilerFixture;
+
+# Pin for the Metamodel::GrammarHOW / EXPORTHOW custom-metaclass protocol
+# (roast integration/advent2011-day07.t):
+#  - `class X is Metamodel::GrammarHOW` (and ClassHOW) is inheritable
+#  - `callsame` in a user find_method reaches the native default find_method
+#  - EXPORTHOW.WHO.<grammar> makes later `grammar` declarations use the HOW
+#  - subrule dispatch routes through find_method; the wrapper's $meth($cursor)
+#    call runs the token and returns a Match
+
+plan 8;
+
+grammar ProfiledG {
+    rule TOP { <num> +% <op> }
+    token num { <[ 0..9 \. ]>+ }
+    token op { < + - * / = > }
+}
+
+is ProfiledG.HOW.^name, 'ProfiledGrammarHOW', 'grammar declared under EXPORTHOW gets the custom HOW';
+
+my $r = ProfiledG.parse("37 + 10 - 5 = 42");
+ok ?$r, 'parse still succeeds under the profiling HOW';
+is ~$r, "37 + 10 - 5 = 42", 'match covers the whole input';
+
+my %t = get-timing();
+ok %t<ProfiledG><num><calls>, 'num calls recorded';
+ok %t<ProfiledG><op><calls>, 'op calls recorded';
+ok %t<ProfiledG><num><time> ~~ Real:D, 'num time is a defined Real';
+
+# find_method exclusions return the method unwrapped: parse itself not profiled
+nok %t<ProfiledG><parse>:exists, 'excluded method names are not profiled';
+
+# a token method value called with a cursor runs the token at that position
+my class PlainHOW is Metamodel::GrammarHOW {
+    method find_method($obj, $name) { callsame }
+}
+my $meth = PlainHOW.new.find_method(ProfiledG, "num");
+my $m = $meth("42 x");
+is ~$m, "42", 'token method value matches at the cursor position';
+
+done-testing;

--- a/t/lib/GrammarProfilerFixture.rakumod
+++ b/t/lib/GrammarProfilerFixture.rakumod
@@ -1,0 +1,39 @@
+use v6;
+
+# Fixture for t/exporthow-grammar-how.t — a custom grammar metaclass in the
+# style of roast's Advent::GrammarProfiler (integration/advent2011-day07.t):
+# EXPORTHOW installs a Metamodel::GrammarHOW subclass whose find_method wraps
+# token dispatch in a profiling closure.
+
+our %timing;
+
+my class ProfiledGrammarHOW is Metamodel::GrammarHOW {
+
+    method find_method($obj, $name) {
+        my $meth := callsame;
+        substr($name, 0, 1) eq '!' || $name eq any(<parse CREATE Bool defined MATCH raku perl name BUILD TWEAK DESTROY new bless BUILDALL sink>) ??
+            $meth !!
+            -> $c, |args {
+                my $grammar = $obj.WHAT.raku;
+                %timing{$grammar} //= {};
+                %timing{$grammar}{$meth.name} //= {};
+                my %t := %timing{$grammar}{$meth.name};
+                my $start = now;
+                my $result := $meth($c, |args);
+                %t<time> += now - $start;
+                %t<calls>++;
+                $result
+            }
+    }
+
+    method publish_method_cache($obj) {
+        # no caching, so we always hit find_method
+    }
+
+}
+
+sub get-timing is export { %timing }
+sub reset-timing is export { %timing = () }
+
+my module EXPORTHOW { }
+EXPORTHOW.WHO.<grammar> = ProfiledGrammarHOW;


### PR DESCRIPTION
## Summary

Makes `roast/integration/advent2011-day07.t` (Advent::GrammarProfiler — a grammar profiler that swaps in a custom metaclass via `EXPORTHOW.WHO.<grammar> = ProfiledGrammarHOW`) pass end to end. This was the "major metamodel work" item of the integration cluster; whitelist 1408 → **1409 / 1463**.

Four general mechanisms, no test-specific hacks:

1. **`Metamodel::GrammarHOW` is inheritable** (added to the builtin parent list next to `Metamodel::ClassHOW`), and `callsame` from a user HOW method now reaches the **native** metamodel implementation once the user MRO is exhausted. `run_instance_method` / `push_method_dispatch_frame` record a metamodel dispatch context (`metamodel_dispatch_stack`, tied to the samewith frame by depth and gated by a registry flag so ordinary programs pay a single bool read per method dispatch); `dispatch_next_candidate` serves the default `find_method` (via `classhow_find_method`) / `publish_method_cache` as the final candidate.
2. **EXPORTHOW installation**: a `grammar` declared while an `EXPORTHOW::<grammar>` stash entry is visible gets an instance of that HOW (`install_custom_grammar_how`) — recorded as its `.HOW` and, when the HOW class defines a user `find_method`, in `Registry::grammar_custom_how`. (TODO in code: EXPORTHOW should be lexically scoped to the `use`ing scope; mutsu approximates it as globally visible.)
3. **Token methods are first-class callables**: `Routine { is_regex: true }` stubs (what `^find_method` returns for a token) called as `$meth($cursor)` run the token anchored at the cursor position and return a Match (`try_call_token_method_value`, hooked into both `call_sub_value` and the VM's `vm_call_on_value`).
4. **Subrule dispatch routes through the custom HOW**: the regex engine's named-subrule path consults `grammar_custom_how` and calls `find_method(TypeObj, name)` in a scratch interpreter; a returned wrapper closure is invoked with a cursor and its returned Match is converted back into an engine candidate (inner captures recovered via a thread-local side channel). Module-level `our %timing` mutations inside the wrapper persist because env values are shared cells. (TODO in code: left-recursive rules bypass the LR seed-growing loop on this path.)

## Test plan

- New pin: `t/exporthow-grammar-how.t` (+ fixture `t/lib/GrammarProfilerFixture.rakumod`) — HOW installation, parse-under-profiling, per-token call/time recording, find_method exclusion list, cursor-invocant token calls.
- `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/integration/advent2011-day07.t` → PASS (whitelisted).
- `make test` (1717 files / 16907 tests) passes locally.
- Dispatch-sensitive roast files verified locally: S06-advanced/wrap.t, S06-advanced/dispatching.t, S12-methods/defer-next.t, defer-call.t, lastcall.t, S12-construction/roles-6e.t, S12-meta/* (27 files), S05-grammar/* (whitelisted set), all whitelisted integration/ files (only pre-existing debug-build ABRT on deep-recursion-initing-native-array.t, reproduced identically on baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)