### PR TITLE
perf: gate wrap-chain candidate scan off the slow dispatch path

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -148,11 +148,14 @@ Current state (details in news/2026-06.md and news/2026-07.md): ✅ CLI load + c
          (definite-return-eval PR): every return from a `--> Nil` routine (e.g.
          Zef::Distribution's TWEAK) paid a full string EVAL whose setup clones the entire class
          registry twice; constant specs (Nil/True/False/Empty/pi/int) are now constructed
-         directly. Combined: full fez populate = **11.9s** release (raku ~1-2.8s); an 18-attr
-         ctor microbench (tmp/ctor-bench.raku) went 35x → 5.8x vs raku. Remaining hot spots
-         (per-dist): `bless` runs on the `run_instance_method` slow-path fallback, TWEAK x2 via
-         the resolver path, allocation churn (malloc/free/memmove still dominate the flat
-         profile).
+         directly. Third fix (wrap-chain-prefilter PR): every slow-path instance call
+         (bless/TWEAK) Debug-traversed method-body ASTs looking for `.wrap` chains that don't
+         exist; gated behind `has_any_wrap_chains()` + `Arc::ptr_eq` candidate matching.
+         Combined with #4559 (subrule memoization): full fez populate = **6.5s** release
+         (raku ~1-2.8s); the 18-attr ctor microbench (tmp/ctor-bench.raku) went 35x → **2.9x**
+         vs raku over the session. Remaining (per-dist): `bless` still runs on the
+         `run_instance_method` slow-path fallback, TWEAK x2 via the resolver path, allocation
+         churn / SipHash on String-keyed maps / Symbol intern traffic in the flat profile.
       2. Nested `.raku` rendering: an Instance inside a collection renders as `Sp()` (type-object
          style) (`(C.new,).raku` → raku gives `(C.new(...),)`). The value itself is fine
          (semantically harmless; display only).

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,28 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-15: wrap-chain candidate scan gated off the slow dispatch path — zef ctor another ~3x
+
+Third slice of the zef-constructor hot path (PLAN §1 B2). After the definite-return fix, the
+ctor profile still showed ~6% AST `Debug` formatting: `run_instance_method` (the slow path
+every `bless`/TWEAK takes) checks for a method-level `.wrap` chain via
+`find_method_candidate_index`, which structurally fingerprints the target **and every
+candidate** — a Debug traversal of whole method bodies — on **every call**, even in the
+overwhelmingly common program with zero `.wrap`s.
+
+- Added the `has_any_wrap_chains()` prefilter to the slow path (`class_dispatch.rs`) and the
+  `nextsame` fall-through (`builtins_dispatch_next.rs`) — the compiled path already had it
+  (`vm_call_method_compiled.rs`).
+- `find_method_candidate_index` itself now tries `Arc::ptr_eq` on the body first (a resolved
+  MethodDef is a clone of a registry entry, so pointer identity finds the candidate without
+  touching the AST); the fingerprint scan survives only as a fallback for defs rebuilt with a
+  fresh body Arc.
+
+ctor microbench (release, x5000): 0.70s → **0.35s** (raku 0.12s — 35x → 2.9x over the whole
+session); full fez populate (7657 dists, together with #4559's subrule memoization landed in
+parallel) 11.9s → **6.5s**. Session total: populate went from the "3-5 minutes" frontier
+description to 6.5s.
+
 ## 2026-07-15: `--> Nil` returns no longer pay a full string EVAL — zef ctor 6x, fez populate 19.5s → 11.9s
 
 Follow-up to the accessor-MRO fix below, attacking the next populate hot spot (PLAN §1 B2

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -720,6 +720,18 @@ impl Interpreter {
         let registry = self.registry();
         let class_def = registry.classes.get(class_name)?;
         let defs = class_def.methods.get(method_name)?;
+        // Fast path: a resolved MethodDef is a clone of a registry entry, so
+        // its body Arc points at the same allocation — pointer identity finds
+        // the candidate without traversing any AST. The structural-fingerprint
+        // scan below (which Debug-traverses every candidate's whole body)
+        // remains only as a fallback for defs rebuilt with a fresh body Arc
+        // (e.g. on-demand recompilation).
+        if let Some(idx) = defs
+            .iter()
+            .position(|d| std::sync::Arc::ptr_eq(&d.body, &method_def.body))
+        {
+            return Some(idx);
+        }
         let target_fp = crate::ast::function_body_fingerprint(
             &method_def.params,
             &method_def.param_defs,

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -197,6 +197,7 @@ impl Interpreter {
                         .map(|(n, _)| n.clone())
                         .unwrap_or_default();
                     if !method_name_now.is_empty()
+                        && self.has_any_wrap_chains()
                         && let Some(cand_idx) = self.find_method_candidate_index(
                             &owner_class,
                             &method_name_now,

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -148,8 +148,13 @@ impl Interpreter {
                     Value::make_instance(Symbol::intern(receiver_class_name), attributes.clone())
                 }
             };
-        // Check for method-level wrap chain on this candidate
-        if !self.is_inside_wrap_dispatch()
+        // Check for method-level wrap chain on this candidate. The
+        // `has_any_wrap_chains` prefilter matters: without it every slow-path
+        // instance call (e.g. every bless/TWEAK) pays a candidate-index scan
+        // even though no `.wrap` exists in the whole program (mirrors the
+        // compiled path's guard in vm_call_method_compiled.rs).
+        if self.has_any_wrap_chains()
+            && !self.is_inside_wrap_dispatch()
             && let Some(cand_idx) =
                 self.find_method_candidate_index(&owner_class, method_name, &method_def)
             && let Some(chain) = self


### PR DESCRIPTION
## Summary

Third slice of the zef-constructor hot path (PLAN §1 B2, after #4557/#4558). A flat profile of an 18-attribute constructor loop still showed **~6% of time in AST `Debug` formatting**: `run_instance_method` (the slow path every `bless`/TWEAK takes) checks for a method-level `.wrap` chain via `find_method_candidate_index`, which structurally fingerprints the target **and every candidate of that name** — a Debug traversal of whole method bodies — on **every call**, even in the overwhelmingly common program with zero `.wrap`s.

## Fix

- Add the `has_any_wrap_chains()` prefilter to the slow dispatch path (`class_dispatch.rs`) and the `nextsame` fall-through (`builtins_dispatch_next.rs`). The compiled path already had exactly this guard (`vm_call_method_compiled.rs:267`) — this brings the interpreter path in line.
- `find_method_candidate_index` itself now tries `Arc::ptr_eq` on the body first: a resolved `MethodDef` is a clone of a registry entry, so pointer identity finds the candidate without touching the AST. The structural-fingerprint scan survives only as a fallback for defs rebuilt with a fresh body Arc (e.g. on-demand recompilation).

## Numbers (release)

| bench | before | after |
|---|---|---|
| 18-attr ctor microbench x5000 | 0.70s | **0.35s** (raku 0.12s; session total 35x → 2.9x) |
| full fez populate (7657 dists) | 11.9s | **6.5s** (together with #4559's subrule memoization) |

## Testing

- `make test`: 1717 files / 16908 tests PASS
- Targeted: t/wrap.t, t/wrap-recursive-redispatch.t, t/accessor-mro-shadowing.t, t/definite-return.t, roast S06-advanced/wrap.t, S12-methods/defer-next.t, S12-methods/defer-call.t — all PASS
- clippy (1.96.1) + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)