### PR TITLE
feat: CompUnit need protocol pieces + per-param is-copy/is-rw in multi-param for loops

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -48,7 +48,7 @@ Definitions of the classifications:
 
 ## Current assumptions
 
-- The whitelist stands at **1409 / 1463** (2026-07-15, `wc -l roast-whitelist.txt`) = **54** files not whitelisted.
+- The whitelist stands at **1410 / 1463** (2026-07-15, `wc -l roast-whitelist.txt`) = **53** files not whitelisted.
 - **The S\* files (per-synopsis feature tests) are exhausted.** All of the former large campaigns
   (true lazy arrays / desugaring of dispatch and operator sugar / S17 concurrency & async /
   first-class-container container identity / cross-thread lexical writeback) are complete, and
@@ -71,7 +71,6 @@ noted.
 
 | File | mutsu | raku | Blocker / note |
 |---|---|---|---|
-| `integration/precompiled.t` | fails | PASS ★ | precomp infrastructure |
 | `integration/error-reporting.t` | 28/33 | PASS ★ | **④ error-message quality.** Remaining 5 = backtrace frames for module files (15), Failure dual backtrace (20), return inside map (21), `%::{''}` (25), type-capture inheritance (30). Compile-time undeclared-routine detection (tests 5/23) is implemented (`check_undeclared_routines_mainline` — rakudo's CHECK-time X::Undeclared::Symbols + `Did you mean 'BEGIN'?` suggestion); #4539 implemented backtraces on all runtime errors, is_run = stderr identical to the CLI, Backtrace.new/full |
 | `integration/weird-errors.t` | 31/36 | PASS ★ | **④ error-message quality.** Remaining = `say(;:[])` (11), `::a`→X::NoSuchSymbol needs `::` info on BareWord (20), our method invocant type (29), `new Foo:` (32), `hash a=>1` (33) |
 | `integration/advent2012-day15.t` | 9/11 | PASS ★ | statement-form phasers create their own scope (`$best` in `NEXT (state $best) max= $_;` is not visible from `LAST`) / `INIT` runs after the mainline |

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -58,6 +58,32 @@ class and participates in the MRO like any other method (child accessor wins).
 
 Remaining populate hot spots (per dist): `bless` on the `run_instance_method` slow path,
 TWEAK x2 via the resolver path, allocation churn — see PLAN §1 B2.
+## 2026-07-15: CompUnit `need` protocol + multi-param `is copy` fix — integration/precompiled.t whitelisted
+
+The "precomp infrastructure" ledger item turned out to be four small protocol
+gaps plus one general compiler bug (whitelist 1410/1463; with this and
+advent2011-day07.t below, both remaining cluster-⑤ items are done):
+
+- `$*REPO.precomp-repository` returns a `CompUnit::PrecompilationRepository::
+  Default` object (mutsu loads from source; the object exists so precomp-aware
+  callers like roast's `Test::Compile` can thread it through `need`).
+- `nqp::bindattr($obj, Type, '$!attr', $v)` joins the minimal nqp shim —
+  writes the attribute cell directly via `insert_through`/`commit_attrs`.
+- `PROCESS::<$REPO> := $repo` (the *bind* form) no longer stores the raw
+  `__mutsu_bind_index_value` marker Pair as the dynamic — the pseudo-stash
+  assignment path unwraps it.
+- **Compiler bug**: per-param `is copy` / `is rw` traits on MULTI-param pointy
+  for-loops were read only from the single-param def, so `-> $x is copy, $fn`
+  marked BOTH params readonly and the first write died with
+  X::Assignment::RO (this was what actually aborted precompiled.t's chained
+  compunit loads). Traits are now honored per param: `is copy` params are
+  assignable without writeback, `is rw` params write back (matches raku),
+  plain siblings stay readonly.
+
+`CompUnit::Repository::FileSystem.need` (from the zef campaign) already did
+the real loading. Pins: `t/compunit-need-protocol.t`,
+`t/for-multiparam-copy-rw.t`.
+
 ## 2026-07-15: custom grammar metaclasses (Metamodel::GrammarHOW + EXPORTHOW) — advent2011-day07.t whitelisted
 
 The last "major metamodel work" item of the integration cluster:

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1398,6 +1398,7 @@ roast/integration/no-indirect-new.t
 roast/integration/packages.t
 roast/integration/pair-in-array.t
 roast/integration/passing-pair-class-to-sub.t
+roast/integration/precompiled.t
 roast/integration/real-strings.t
 roast/integration/role-composition-vs-attribute.t
 roast/integration/rule-in-class-Str.t

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1754,12 +1754,17 @@ impl Compiler {
                 // don't mark it readonly, and write modifications back.
                 let has_sigilless = (**param_def).as_ref().is_some_and(|def| def.sigilless)
                     || params_def.iter().any(|def| def.sigilless);
-                // Determine if this for-loop has rw params (via `<->` or `is rw` trait)
+                // Determine if this for-loop has rw params (via `<->` or `is rw`
+                // trait) — for multi-param blocks the per-param defs live in
+                // `params_def`, not `param_def`.
                 let has_rw = *rw_block
                     || has_sigilless
                     || (**param_def)
                         .as_ref()
-                        .is_some_and(|def| def.traits.iter().any(|t| t == "rw"));
+                        .is_some_and(|def| def.traits.iter().any(|t| t == "rw"))
+                    || params_def
+                        .iter()
+                        .any(|def| def.traits.iter().any(|t| t == "rw"));
                 // `is copy` also makes the param writable (but without writeback)
                 let has_copy = (**param_def)
                     .as_ref()
@@ -1778,9 +1783,15 @@ impl Compiler {
                     // (unless the block uses `<->` or `is rw`).
                     // Skip @-sigil and %-sigil params: they bind to a mutable
                     // Array/Hash container, so assignments must be allowed.
+                    // Also skip params whose OWN def is writable (`is copy` /
+                    // `is rw` / sigilless) — `-> $x is copy, $fn` must leave
+                    // $x assignable while $fn stays readonly.
                     if !has_rw && !has_copy && !params.is_empty() {
-                        for p in params {
-                            if !p.starts_with('@') && !p.starts_with('%') {
+                        for (i, p) in params.iter().enumerate() {
+                            let per_param_writable = params_def.get(i).is_some_and(|d| {
+                                d.sigilless || d.traits.iter().any(|t| t == "rw" || t == "copy")
+                            });
+                            if !p.starts_with('@') && !p.starts_with('%') && !per_param_writable {
                                 bind_prefix.push(Stmt::MarkReadonly(p.clone()));
                             }
                         }

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -596,6 +596,26 @@ impl Interpreter {
                     _ => Ok(Value::NIL),
                 }
             }
+            // nqp::bindattr($obj, Type, '$!attr', value): write an attribute
+            // cell directly, bypassing accessors (roast's Test::Compile uses it
+            // to install a precomp repository into a CUR::FileSystem instance).
+            "nqp::bindattr" => {
+                let obj = args.first().cloned().unwrap_or(Value::NIL);
+                let attr = args.get(2).map(|v| v.to_string_value()).unwrap_or_default();
+                let val = args.get(3).cloned().unwrap_or(Value::NIL);
+                let attr_key = attr
+                    .trim_start_matches(['$', '@', '%', '&'])
+                    .trim_start_matches(['!', '.']);
+                if attr_key.is_empty() {
+                    return Err(RuntimeError::new("nqp::bindattr: empty attribute name"));
+                }
+                if let ValueView::Instance { attributes, .. } = obj.view() {
+                    let mut updated = attributes.to_map();
+                    updated.insert_through(attr_key, val.clone());
+                    attributes.commit_attrs(updated);
+                }
+                Ok(val)
+            }
             // Debug
             "dd" => self.builtin_dd(&args),
             // Collection constructors / queries

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -586,6 +586,16 @@ impl Interpreter {
             }
             if class_name == "CompUnit::Repository::FileSystem" {
                 match method {
+                    // mutsu loads modules from source (precompilation is a
+                    // parse-cache detail); expose the repository object the
+                    // CompUnit API promises so precomp-aware callers
+                    // (roast's Test::Compile) can thread it through `need`.
+                    "precomp-repository" => {
+                        return Ok(Value::make_instance(
+                            Symbol::intern("CompUnit::PrecompilationRepository::Default"),
+                            HashMap::new(),
+                        ));
+                    }
                     "candidates" => {
                         let prefix = attributes
                             .as_map()

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -1992,6 +1992,9 @@ impl Interpreter {
                 _ => format!("*{raw_key}"),
             };
             let val = self.stack.pop().unwrap_or(Value::NIL);
+            // `PROCESS::<$REPO> := $repo` arrives as a bind marker; unwrap it
+            // so the bound value (not the marker Pair) becomes the dynamic.
+            let (val, _bind_source) = Self::unwrap_bind_index_value(val);
             let val = if env_key.starts_with('@') {
                 runtime::coerce_to_array(val)
             } else if env_key.starts_with('%') {

--- a/t/compunit-need-protocol.t
+++ b/t/compunit-need-protocol.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+use nqp;
+
+# Pin for the CompUnit `need` protocol pieces used by roast's Test::Compile
+# (integration/precompiled.t): $*REPO.precomp-repository, nqp::bindattr,
+# binding a repository into PROCESS::<$REPO>, and FileSystem.need running a
+# module whose code writes a dynamic variable visible to the caller.
+
+plan 6;
+
+my $dir = "tmp/compunit-need-{$*PID}";
+mkdir $dir;
+END { try unlink "$dir/CompUnitNeedFixture.rakumod"; try rmdir $dir; }
+
+ok $*REPO.precomp-repository.defined, '$*REPO.precomp-repository returns a defined object';
+
+my $repo = CompUnit::Repository::FileSystem.new(:prefix($dir));
+my $pr = $*REPO.precomp-repository;
+nqp::bindattr($repo, CompUnit::Repository::FileSystem, '$!precomp', $pr);
+pass 'nqp::bindattr on a repository instance does not die';
+
+my $saved-repo = $*REPO;
+PROCESS::<$REPO> := $repo;
+ok $*REPO.prefix.Str.contains("compunit-need"), 'PROCESS::<$REPO> := binds the dynamic repository';
+
+"$dir/CompUnitNeedFixture.rakumod".IO.spurt('$*compunit_result = do { 42 };');
+
+my $*compunit_result = Nil;
+my $cu = $repo.need(CompUnit::DependencySpecification.new(:short-name<CompUnitNeedFixture>), $pr);
+ok $cu.defined, 'FileSystem.need loads a module from the prefix directory';
+is $*compunit_result, 42, 'module code sees and writes the caller dynamic variable';
+
+PROCESS::<$REPO> := $saved-repo;
+ok $*REPO === $saved-repo, 'PROCESS::<$REPO> can be restored';
+
+done-testing;

--- a/t/for-multiparam-copy-rw.t
+++ b/t/for-multiparam-copy-rw.t
@@ -1,0 +1,78 @@
+use v6;
+use Test;
+
+# Pin for per-param `is copy` / `is rw` traits on MULTI-param pointy-block for
+# loops. The compiler used to read traits only from the single-param def, so
+# `-> $x is copy, $fn` marked BOTH params readonly and the first write died
+# with X::Assignment::RO (this aborted roast/integration/precompiled.t, whose
+# Test::Compile chains compunits with exactly this loop shape).
+
+plan 8;
+
+# is copy on the first of two params: writable, no writeback
+{
+    my @a = <a b c d>;
+    my @seen;
+    for @a -> $x is copy, $y {
+        $x ~= "!";
+        @seen.push("$x$y");
+    }
+    is @seen.join(","), "a!b,c!d", 'is copy param is assignable in a 2-param for';
+    is @a.join(","), "a,b,c,d", 'is copy does not write back to the source';
+}
+
+# is copy actually executes the R~= shape used by roast Test::Compile
+{
+    my $last = '';
+    my @out;
+    for flat <a b> Z <f1 f2> -> $code is copy, $fn {
+        $code [R~]= "use $last;\n" if $last;
+        @out.push($code.lines.elems);
+        $last = $fn;
+    }
+    is @out.join(","), "1,2", 'R~= onto an is-copy param works across iterations';
+}
+
+# is rw on one param of two: writes back only through that param
+{
+    my @a = 1, 2, 3, 4;
+    for @a -> $x is rw, $y { $x += 10 }
+    is @a.join(","), "11,2,13,4", 'is rw param in a 2-param for writes back';
+}
+
+# <-> makes all params rw
+{
+    my @a = 1, 2, 3, 4;
+    for @a <-> $x, $y { $x += 10; $y += 20 }
+    is @a.join(","), "11,22,13,24", '<-> two-param loop writes back both';
+}
+
+# plain multi-params stay readonly
+{
+    my $died = False;
+    for <a b> -> $x, $y {
+        $x = "z";
+        CATCH { default { $died = True } }
+    }
+    ok $died, 'plain multi-param is still readonly';
+}
+
+# a plain sibling of an is-copy param stays readonly
+{
+    my $died = False;
+    for <a b> -> $x is copy, $y {
+        $y = "z";
+        CATCH { default { $died = True } }
+    }
+    ok $died, 'plain sibling of an is-copy param is still readonly';
+}
+
+# single-param is copy unchanged
+{
+    my @a = <a b>;
+    my @seen;
+    for @a -> $x is copy { $x ~= "!"; @seen.push($x) }
+    is @seen.join(","), "a!,b!", 'single-param is copy still works';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

Whitelists `roast/integration/precompiled.t` (1409 → **1410 / 1463**) — the last remaining cluster-⑤ integration item. The "precomp infrastructure" ledger blocker decomposed into four small protocol gaps plus one general compiler bug:

- **`$*REPO.precomp-repository`** returns a `CompUnit::PrecompilationRepository::Default` object. mutsu loads modules from source (precompilation is a parse-cache detail); the object exists so precomp-aware callers like roast's `Test::Compile` can thread it through `need`.
- **`nqp::bindattr($obj, Type, '$!attr', $v)`** joins the minimal nqp shim — writes the attribute cell directly (`insert_through` + `commit_attrs`), used by Test::Compile to install a precomp repository into a `CompUnit::Repository::FileSystem` instance.
- **`PROCESS::<$REPO> := $repo`** (the *bind* form) no longer stores the raw `__mutsu_bind_index_value` marker Pair as the dynamic — the pseudo-stash assignment path now unwraps it (the `=` form already worked).
- **Compiler bug (the actual file-stopper)**: per-param `is copy` / `is rw` traits on **multi-param** pointy for-loops were read only from the single-param def, so `-> $x is copy, $fn` marked BOTH params readonly and the first write died with X::Assignment::RO — which aborted precompiled.t's chained compunit loads. Traits are now honored per param: `is copy` params are assignable without writeback, `is rw` params write back (verified against raku: `for @a -> $x is rw, $y { $x += 10 }` → `[11 2 13 4]`), and plain siblings stay readonly.

`CompUnit::Repository::FileSystem.need` (from the zef campaign) already did the real loading — no new loader machinery.

## Test plan

- `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/integration/precompiled.t` → PASS 9/9 (was: aborted at 0/9).
- New pins: `t/compunit-need-protocol.t` (6 tests), `t/for-multiparam-copy-rw.t` (8 tests: copy/rw/`<->`/readonly-sibling/single-param matrix).
- `make test` (1720 files / 16930 tests) passes locally; clippy clean.
- Local roast regression sets: S04-statements/for*.t, S02-lists, S06-signature/* + S32-list/* (85 files), S10 use-with-class, S11 require — all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)