### PR TITLE
feat: backtrace frames report module files; unhandled Failures print dual backtraces

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -48,7 +48,7 @@ Definitions of the classifications:
 
 ## Current assumptions
 
-- The whitelist stands at **1410 / 1463** (2026-07-15, `wc -l roast-whitelist.txt`) = **53** files not whitelisted.
+- The whitelist stands at **1411 / 1463** (2026-07-15, `wc -l roast-whitelist.txt`) = **52** files not whitelisted.
 - **The S\* files (per-synopsis feature tests) are exhausted.** All of the former large campaigns
   (true lazy arrays / desugaring of dispatch and operator sugar / S17 concurrency & async /
   first-class-container container identity / cross-thread lexical writeback) are complete, and
@@ -71,7 +71,6 @@ noted.
 
 | File | mutsu | raku | Blocker / note |
 |---|---|---|---|
-| `integration/error-reporting.t` | 31/33 | PASS ★ | **④ error-message quality.** Remaining 2 = backtrace frames for module files (15: a frame for a sub defined in a `use`d module must report `Foo.rakumod`, needs per-FunctionDef source-file tracking) and Failure dual backtrace (20: a thrown Failure prints the fail-site backtrace AND the throw-site backtrace). Tests 21/25/30 fixed 2026-07-15 (say no longer swallows return signals from lazy Seqs; `%::{''}` → X::Undeclared; type-capture inheritance → compile-time X::Inheritance::Unsupported; pin t/error-reporting-quality.t). Earlier: compile-time undeclared-routine detection (tests 5/23, `check_undeclared_routines_mainline`); #4539 backtraces on all runtime errors, is_run = stderr identical to the CLI, Backtrace.new/full |
 | `integration/weird-errors.t` | 31/36 | PASS ★ | **④ error-message quality.** Remaining = `say(;:[])` (11), `::a`→X::NoSuchSymbol needs `::` info on BareWord (20), our method invocant type (29), `new Foo:` (32), `hash a=>1` (33) |
 | `integration/advent2012-day15.t` | 9/11 | PASS ★ | statement-form phasers create their own scope (`$best` in `NEXT (state $best) max= $_;` is not visible from `LAST`) / `INIT` runs after the mainline |
 | `integration/99problems-21-to-30.t` | aborts at 6/15 | PASS ★ | not yet root-caused (post-#4510/#4516 re-measure) |

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,26 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-15: module-file backtrace frames + Failure dual backtraces — error-reporting.t whitelisted
+
+The last two ④ items land and `integration/error-reporting.t` passes 33/33
+(whitelist 1411/1463):
+
+- **Backtrace frames report the defining file** (test 15): `FunctionDef` (and
+  `CompiledFunction`) now carry `source_file`, recorded at registration time
+  from `?FILE` — which module loading scopes to the module path while the
+  module mainline runs. `RoutineFrame` gained `def_file`, and both backtrace
+  builders display a frame at its defining file, so a `use`d module's sub
+  reports `Foo.rakumod` while mainline frames keep the script path.
+- **Unhandled thrown Failures print rakudo's dual-backtrace form** (test 20):
+  the Failure's exception already carried the fail-site backtrace; the
+  unhandled-Failure error now threads it through
+  (`failure_original_backtrace`), and the throw-site attach renders
+  `<fail-site bt>\n\nActually thrown at:\n<throw-site bt>` — byte-identical
+  to rakudo on the roast program.
+
+Pin: t/backtrace-module-file.t (+ fixture t/lib/BacktraceFixture.rakumod).
+
 ## 2026-07-15: error-reporting quality slice — 3 of the 5 remaining error-reporting.t items (31/33)
 
 Working the ④ error-message-quality cluster top-down (integration/error-reporting.t

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1386,6 +1386,7 @@ roast/integration/advent2014-day16.t
 roast/integration/code-blocks-as-sub-args.t
 roast/integration/deep-recursion-initing-native-array.t
 roast/integration/diamond.t
+roast/integration/error-reporting.t
 roast/integration/eval-and-threads.t
 roast/integration/failure-and-callsame.t
 roast/integration/gather-with-loops.t

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -105,6 +105,12 @@ pub(crate) struct FunctionDef {
     /// `is DEPRECATED` trait message: None = not deprecated, Some(msg) = deprecated.
     /// Empty string means "something else", non-empty is the custom replacement text.
     pub(crate) deprecated_message: Option<String>,
+    /// Source file this routine was declared in (None = the main script).
+    /// Set at registration time from the interpreter's `?FILE` (which module
+    /// loading scopes to the module path), so backtrace frames for module subs
+    /// can report the module file (integration/error-reporting.t test 15).
+    #[serde(default)]
+    pub(crate) source_file: Option<String>,
 }
 
 /// A `fmt::Write` sink that streams formatted bytes straight into a `Hasher`,

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -387,6 +387,7 @@ impl Compiler {
         sub_compiler.code.compute_needs_env_sync();
         let mut cf = CompiledFunction {
             code: sub_compiler.code,
+            source_file: None,
             params: params.to_vec(),
             param_defs: param_defs.to_vec(),
             return_type: return_type.cloned(),

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -3683,6 +3683,9 @@ pub(crate) type CompiledFns = rustc_hash::FxHashMap<String, CompiledFunction>;
 #[derive(Debug, Clone)]
 pub(crate) struct CompiledFunction {
     pub(crate) code: CompiledCode,
+    /// Source file the routine was declared in (None = main script); flows
+    /// from `FunctionDef::source_file` for backtrace frame attribution.
+    pub(crate) source_file: Option<String>,
     pub(crate) params: Vec<String>,
     pub(crate) param_defs: Vec<ParamDef>,
     pub(crate) return_type: Option<String>,

--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -119,8 +119,30 @@ impl Interpreter {
             "Died".to_string()
         };
         let mut err = RuntimeError::new(&message);
+        // Carry the fail-site backtrace (recorded on the exception when `fail`
+        // ran) so the throw site renders rakudo's dual-backtrace form.
+        if let Some(orig) = Self::exception_backtrace_text(exception) {
+            err.set_failure_original_backtrace(Some(orig));
+        }
         err.exception = Some(Box::new(exception.clone()));
         err
+    }
+
+    /// The `.text` of a `Backtrace` stored on an exception instance's
+    /// `backtrace` attribute, if present and non-empty.
+    pub(crate) fn exception_backtrace_text(exception: &Value) -> Option<String> {
+        let ValueView::Instance { attributes, .. } = exception.view() else {
+            return None;
+        };
+        let bt = attributes.as_map().get("backtrace").cloned()?;
+        let ValueView::Instance {
+            attributes: bta, ..
+        } = bt.view()
+        else {
+            return None;
+        };
+        let text = bta.as_map().get("text").map(|v| v.to_string_value())?;
+        (!text.is_empty()).then_some(text)
     }
 
     pub(crate) fn failure_to_runtime_error_if_unhandled(

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -11,13 +11,16 @@ impl Interpreter {
     }
 
     /// Push a new routine frame. `line` and `file` record the call-site
-    /// in the *caller* (the line/file where this function was called from).
+    /// in the *caller* (the line/file where this function was called from);
+    /// `def_file` is the file the routine's body lives in (None = main
+    /// script), used by backtrace rendering.
     pub(crate) fn push_routine_with_location(
         &mut self,
         package: String,
         name: String,
         line: Option<u32>,
         file: Option<String>,
+        def_file: Option<String>,
     ) {
         self.routine_stack.push(super::RoutineFrame {
             package,
@@ -26,6 +29,7 @@ impl Interpreter {
             file,
             is_method: false,
             is_block: false,
+            def_file,
         });
     }
 
@@ -43,6 +47,7 @@ impl Interpreter {
             file,
             is_method: true,
             is_block: false,
+            def_file: None,
         });
     }
 
@@ -61,6 +66,7 @@ impl Interpreter {
             file,
             is_method: false,
             is_block: true,
+            def_file: None,
         });
     }
 

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -497,6 +497,7 @@ impl Interpreter {
                 file: None,
                 is_method: false,
                 is_block: false,
+                def_file: None,
             });
             // Set __mutsu_callable_id so blocks defined inside this routine
             // capture the correct target for non-local return.

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -199,6 +199,7 @@ impl Interpreter {
             file: None,
             is_method: false,
             is_block: false,
+            def_file: def.source_file.clone(),
         });
         // Set __mutsu_callable_id so blocks defined inside this routine
         // capture the correct target for non-local return.
@@ -354,6 +355,7 @@ impl Interpreter {
                         file: None,
                         is_method: false,
                         is_block: false,
+                        def_file: def.source_file.clone(),
                     });
                     self.prepare_definite_return_slot(return_spec.as_deref());
                     let result = self.run_block(&def.body);

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -171,6 +171,7 @@ impl Interpreter {
             file: None,
             is_method: false,
             is_block: false,
+            def_file: None,
         });
         let result = self.eval_block_value(&def.body);
         self.routine_stack.pop();

--- a/src/runtime/dispatch_proto.rs
+++ b/src/runtime/dispatch_proto.rs
@@ -188,6 +188,7 @@ impl Interpreter {
             file: None,
             is_method: false,
             is_block: false,
+            def_file: None,
         });
         self.proto_dispatch_stack
             .push((proto_name.to_string(), args.to_vec(), None));

--- a/src/runtime/dispatch_proto_call.rs
+++ b/src/runtime/dispatch_proto_call.rs
@@ -120,6 +120,7 @@ impl Interpreter {
             file: None,
             is_method: false,
             is_block: false,
+            def_file: None,
         });
         let result = self.run_block(&def.body);
         self.routine_stack.pop();

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1041,6 +1041,11 @@ pub(crate) struct RoutineFrame {
     pub is_method: bool,
     /// Whether this frame is a block/closure (not a named routine).
     pub is_block: bool,
+    /// The file this routine's BODY lives in (None = same as the caller /
+    /// main script). `line`/`file` above record the call-site; a backtrace
+    /// displays each frame at its defining file (module subs report the
+    /// module path, integration/error-reporting.t test 15).
+    pub def_file: Option<String>,
 }
 
 /// CompUnit::Repository::Installation runtime state. Boxed inside `Interpreter`

--- a/src/runtime/regex/regex_token_resolve.rs
+++ b/src/runtime/regex/regex_token_resolve.rs
@@ -195,6 +195,7 @@ impl Interpreter {
                     file: None,
                     is_method: false,
                     is_block: false,
+                    def_file: None,
                 });
                 let result = interp.eval_block_value(&def.body);
                 interp.routine_stack.pop();

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -99,6 +99,7 @@ impl Interpreter {
             return_type: None,
             is_default: false,
             deprecated_message: None,
+            source_file: self.current_source_file(),
         };
         // Register as a typed multi candidate under the class package, mirroring
         // the `multi sub` registration keys so `import` copies it and operator
@@ -1783,6 +1784,7 @@ impl Interpreter {
                             return_type: None,
                             is_default: *is_default_candidate,
                             deprecated_message: None,
+                            source_file: self.current_source_file(),
                         };
                         self.registry_mut().functions.insert(
                             Symbol::intern(&qualified_name),
@@ -1858,6 +1860,7 @@ impl Interpreter {
                             return_type: None,
                             is_default: *is_default_candidate,
                             deprecated_message: None,
+                            source_file: self.current_source_file(),
                         };
                         // Register under the short name (lexical scope)
                         self.registry_mut().functions.insert(
@@ -2043,6 +2046,7 @@ impl Interpreter {
                         return_type: None,
                         is_default: false,
                         deprecated_message: None,
+                        source_file: self.current_source_file(),
                     };
                     self.registry_mut()
                         .proto_methods

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -675,6 +675,7 @@ impl Interpreter {
             return_type: return_type.cloned(),
             is_default: custom_traits.iter().any(|(t, _)| t == "default"),
             deprecated_message,
+            source_file: self.current_source_file(),
         };
         let single_key = format!("{}::{}", self.current_package(), name);
         let multi_prefix = format!("{}::{}/", self.current_package(), name);
@@ -1057,6 +1058,7 @@ impl Interpreter {
             return_type: None,
             is_default: false,
             deprecated_message: None,
+            source_file: self.current_source_file(),
         };
         self.insert_token_def(name, def, multi);
     }
@@ -1113,6 +1115,7 @@ impl Interpreter {
                 return_type: None,
                 is_default: false,
                 deprecated_message: None,
+                source_file: self.current_source_file(),
             }),
         );
         Ok(())
@@ -1215,6 +1218,7 @@ impl Interpreter {
             return_type: return_type.cloned(),
             is_default: false,
             deprecated_message: None,
+            source_file: self.current_source_file(),
         };
         let single_key = format!("GLOBAL::{}", name);
         let single_key_sym = Symbol::intern(&single_key);
@@ -1357,6 +1361,7 @@ impl Interpreter {
                 return_type: None,
                 is_default: false,
                 deprecated_message: None,
+                source_file: self.current_source_file(),
             }),
         );
         Ok(())

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -446,6 +446,7 @@ impl Interpreter {
                 file: None,
                 is_method: false,
                 is_block: true,
+                def_file: None,
             });
             self.block_stack.push(block_sub);
             let return_spec = data

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -480,7 +480,23 @@ impl Interpreter {
             // severs the shared `state` cell). Compiled under GLOBAL, matching the
             // package the module body runs under here.
             self.capture_module_compiled_fns(&stmts);
+            // Scope `?FILE` to the module path while its mainline runs, so
+            // routine registration records the module as each sub's
+            // `source_file` (module backtrace frames, error-reporting.t 15).
+            let saved_qfile = self.env.get("?FILE").cloned();
+            self.env.insert(
+                "?FILE".to_string(),
+                Value::str(source_path.to_string_lossy().to_string()),
+            );
             let result = self.run_block(&stmts);
+            match saved_qfile {
+                Some(f) => {
+                    self.env.insert("?FILE".to_string(), f);
+                }
+                None => {
+                    self.env.remove("?FILE");
+                }
+            }
             if pushed_unit {
                 self.unit_module_loading_stack.pop();
             }

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -214,6 +214,7 @@ impl Interpreter {
                         file: None,
                         is_method: false,
                         is_block: false,
+                        def_file: None,
                     });
                     if let Some(captures) = self.regex_match_with_captures(&pat, &text) {
                         // Set positional captures before executing code blocks

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -172,6 +172,16 @@ impl Interpreter {
                                 // so a pure lazy sequence/range is never driven.
                                 // A force error IS the thrown exception: surface it
                                 // as the eval result so the type matcher sees it.
+                                // The nested `run` has returned: its bytecode
+                                // frames are gone, so clear the frame
+                                // bookkeeping the force would reconcile against
+                                // (`current_code` is a raw pointer into the
+                                // dropped CompiledCode; leftover rw-writeback
+                                // sources name its dead slots). Dereferencing
+                                // it SEGVs on the release build
+                                // (`gather for ^3 -> $a, $b { take 1 }`).
+                                nested.current_code = 0;
+                                nested.pending_rw_writeback_sources.clear();
                                 if let ValueView::LazyList(ll) = last_val.view()
                                     && ll.coroutine.is_some()
                                     && let Err(e) = nested.force_lazy_list_vm(&ll)
@@ -551,6 +561,16 @@ impl Interpreter {
                                 // so a pure lazy sequence/range is never driven.
                                 // A force error IS the thrown exception: surface it
                                 // as the eval result so the type matcher sees it.
+                                // The nested `run` has returned: its bytecode
+                                // frames are gone, so clear the frame
+                                // bookkeeping the force would reconcile against
+                                // (`current_code` is a raw pointer into the
+                                // dropped CompiledCode; leftover rw-writeback
+                                // sources name its dead slots). Dereferencing
+                                // it SEGVs on the release build
+                                // (`gather for ^3 -> $a, $b { take 1 }`).
+                                nested.current_code = 0;
+                                nested.pending_rw_writeback_sources.clear();
                                 if let ValueView::LazyList(ll) = last_val.view()
                                     && ll.coroutine.is_some()
                                     && let Err(e) = nested.force_lazy_list_vm(&ll)

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -102,6 +102,11 @@ pub struct RuntimeErrorCold {
     pub container_name: Option<String>,
     /// Formatted backtrace string from the call stack at the point of error.
     pub backtrace: Option<String>,
+    /// For an error raised by USING an unhandled Failure: the backtrace
+    /// captured when `fail` originally ran. The throw-site attach combines it
+    /// with the current stack as rakudo's dual-backtrace form
+    /// ("...\n\nActually thrown at:\n...").
+    pub failure_original_backtrace: Option<String>,
 }
 
 #[derive(Debug)]
@@ -231,6 +236,16 @@ impl RuntimeError {
     }
     pub(crate) fn set_backtrace(&mut self, v: Option<String>) {
         self.cold_mut().backtrace = v;
+    }
+
+    pub(crate) fn failure_original_backtrace(&self) -> Option<&str> {
+        self.cold
+            .as_ref()
+            .and_then(|c| c.failure_original_backtrace.as_deref())
+    }
+
+    pub(crate) fn set_failure_original_backtrace(&mut self, v: Option<String>) {
+        self.cold_mut().failure_original_backtrace = v;
     }
 
     /// `return` control signal (non-local return carrying `return_value`).

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -154,6 +154,7 @@ impl Interpreter {
         });
         let mut cf = CompiledFunction {
             code: cc,
+            source_file: def.source_file.clone(),
             params: def.params.clone(),
             param_defs: def.param_defs.clone(),
             return_type: def.return_type.clone(),

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -74,6 +74,7 @@ impl Interpreter {
             routine_push_name,
             self.current_source_line(),
             self.current_source_file(),
+            cf.source_file.clone(),
         );
         let mut callable_id: Option<u64> = None;
         if !fn_name.is_empty() {

--- a/src/vm/vm_data_io_ops.rs
+++ b/src/vm/vm_data_io_ops.rs
@@ -87,6 +87,11 @@ fn check_unhandled_failure(v: &Value) -> Result<(), RuntimeError> {
         if !handled && let Some(ex) = attributes.as_map().get("exception").cloned() {
             let ex = crate::runtime::Interpreter::as_exception_value(ex);
             let mut err = RuntimeError::new(ex.to_string_value());
+            // Fail-site backtrace for the dual-backtrace rendering (see
+            // `failure_value_to_error`).
+            if let Some(orig) = crate::runtime::Interpreter::exception_backtrace_text(&ex) {
+                err.set_failure_original_backtrace(Some(orig));
+            }
             err.exception = Some(Box::new(ex));
             return Err(err);
         }

--- a/src/vm/vm_helpers.rs
+++ b/src/vm/vm_helpers.rs
@@ -73,6 +73,9 @@ impl Interpreter {
                 let inner_frame = reversed[i - 1];
                 (inner_frame.line, inner_frame.file.clone())
             };
+            // A routine defined in another file (a `use`d module) displays at
+            // its defining file; the call-site line is within that file.
+            let file = frame.def_file.clone().or(file);
             let location = Self::format_location(file.as_deref(), line);
             if frame.name.is_empty() || frame.name == "<unit>" || frame.name == "<pointy-block>" {
                 lines.push(format!("  in block <unit>{}", location));
@@ -158,6 +161,9 @@ impl Interpreter {
                 let inner_frame = reversed[i - 1];
                 (inner_frame.line, inner_frame.file.clone())
             };
+            // Module routines display at their defining file (see
+            // `build_backtrace_string`).
+            let file = frame.def_file.clone().or(file);
             // A genuine bare-block callframe (is_block + empty name) is an
             // anonymous block in Raku: its `.subname` is the empty string (so
             // `.is-routine` is False and `.code.name` is empty), distinct from
@@ -350,7 +356,14 @@ impl Interpreter {
     pub(super) fn attach_backtrace_to_error(&self, err: &mut RuntimeError) {
         if err.backtrace().is_none() {
             let backtrace_str = self.build_backtrace_string();
-            if !backtrace_str.is_empty() {
+            // An error raised by USING an unhandled Failure renders rakudo's
+            // dual-backtrace form: the fail-site backtrace (carried from the
+            // Failure's exception) plus where it was actually thrown.
+            if let Some(orig) = err.failure_original_backtrace().map(str::to_string) {
+                err.set_backtrace(Some(format!(
+                    "{orig}\n\nActually thrown at:\n{backtrace_str}"
+                )));
+            } else if !backtrace_str.is_empty() {
                 err.set_backtrace(Some(backtrace_str));
             }
         }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -9,7 +9,7 @@ impl Interpreter {
     }
 
     /// Get the current source file from the interpreter env.
-    pub(super) fn current_source_file(&self) -> Option<String> {
+    pub(crate) fn current_source_file(&self) -> Option<String> {
         self.env().get("?FILE").and_then(|v| match v.view() {
             ValueView::Str(s) => Some(s.to_string()),
             _ => None,

--- a/t/backtrace-module-file.t
+++ b/t/backtrace-module-file.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+use lib 't/lib';
+use BacktraceFixture;
+
+# Pins for the last two integration/error-reporting.t items:
+#  - test 15: a backtrace frame for a sub defined in a use'd module reports
+#    the module file (FunctionDef.source_file -> RoutineFrame.def_file)
+#  - test 20: an unhandled thrown Failure prints the fail-site backtrace AND
+#    an "Actually thrown at:" section with the throw-site backtrace
+
+plan 6;
+
+try fixture-dies();
+ok $!, 'module sub died';
+my $bt = $!.backtrace;
+ok any($bt>>.file) ~~ /BacktraceFixture\.rakumod/,
+    'backtrace frame reports the module file';
+ok any($bt>>.file) ~~ /'backtrace-module-file'\./,
+    'backtrace still includes the script file';
+
+my $code = q:b/sub s1 {\nsub s2 {\nfail("foo")\n}\ns2() }\nmy $a = s1();\nsay $a/;
+my $p = run $*EXECUTABLE, '-e', $code, :err, :out;
+isnt $p.exitcode, 0, 'using an unhandled Failure dies';
+my $err = $p.err.slurp(:close);
+like $err, rx/sub\ss2.*sub\ss1.*thrown/, 'dual backtraces: fail site then thrown marker';
+like $err, rx/'Actually thrown at:'/, 'the thrown section is labelled like rakudo';
+
+done-testing;

--- a/t/lib/BacktraceFixture.rakumod
+++ b/t/lib/BacktraceFixture.rakumod
@@ -1,0 +1,5 @@
+unit module BacktraceFixture;
+
+sub fixture-dies() is export {
+    die "fixture boom";
+}


### PR DESCRIPTION
## Summary

Whitelists `roast/integration/error-reporting.t` (33/33; whitelist 1410 → **1411 / 1463**) by landing the last two items of the ④ error-message-quality file:

- **Backtrace frames report the defining file** (test 15): `FunctionDef` and `CompiledFunction` now carry `source_file`, recorded at registration time from `?FILE` — which module loading now scopes to the module path while the module mainline runs. `RoutineFrame` gained `def_file` (the routine body's file, distinct from the call-site `file`), and both backtrace builders display a frame at its defining file. A `use`d module's sub reports `Foo.rakumod`; mainline frames keep the script path.
- **Unhandled thrown Failures print rakudo's dual-backtrace form** (test 20): the Failure's exception already carried the fail-site backtrace (from #4539's attach machinery); the unhandled-Failure error now threads it through (`failure_original_backtrace` on RuntimeError), and the throw-site attach renders `<fail-site bt>\n\nActually thrown at:\n<throw-site bt>` — byte-identical to rakudo on the roast program (`fail` in nested subs, thrown by a later `say`).

## Test plan

- `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/integration/error-reporting.t` → **PASS 33/33** (was 31/33), whitelisted.
- New pin: `t/backtrace-module-file.t` (6 tests) + fixture `t/lib/BacktraceFixture.rakumod`.
- `make test` (1722 files / 16942 tests) passes locally; clippy clean.
- Local roast regression: S32-exceptions / S04-exceptions / S06-advanced whitelisted sets (17 files, 830 tests) all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)