### PR TITLE
test: add bench-ctor.raku (Zef::Distribution-shaped heavy constructor) to the benchmark suite

### DIFF
--- a/benchmarks/bench-ctor.raku
+++ b/benchmarks/bench-ctor.raku
@@ -1,0 +1,63 @@
+# Heavy-constructor benchmark: the Zef::Distribution shape. Exercises the
+# slow-dispatch construction path that dominated zef's Ecosystems populate
+# (PLAN §1 B2): a wide class (20 attributes, @/%-sigil defaults, private
+# attributes) inheriting from a parent, `method new(*%_)` delegating to
+# `self.bless(|%_, ...)`, and TWEAK submethods at two MRO levels — the child
+# one declared `--> Nil` (a definite return spec) with attributive
+# parameters. Unlike bench-class.raku (light 3-attr classes, accessor and
+# method-call heavy), this stresses bless attribute initialization, submethod
+# dispatch, and definite-return finalization.
+#
+# History: 2026-07-15 this shape was 35x slower than raku; #4557 (accessor
+# MRO shadowing), #4558 (per-return string-EVAL of `--> Nil`), and #4561
+# (wrap-chain candidate scan on every bless/TWEAK) brought it to ~3x.
+
+class Spec {
+    has $.spec;
+    submethod TWEAK(:$!spec) { }
+}
+
+class Dist is Spec {
+    has $.meta-version;
+    has $.name;
+    has $.auth;
+    has $.author;
+    has $.authority;
+    has $.api;
+    has $.ver;
+    has $.version;
+    has $.description;
+    has $.depends;
+    has %.provides;
+    has %.files;
+    has $.source-url;
+    has $.license;
+    has $.build-depends;
+    has $.test-depends;
+    has @.resources;
+    has %.support;
+    has $.builder;
+    has %!meta;
+    has %.metainfo is rw;
+
+    method new(*%_) { self.bless(|%_, :meta(%_)) }
+    submethod TWEAK(:%!meta, :@!resources --> Nil) {
+        @!resources = @!resources.map(*.flat);
+    }
+}
+
+my $checksum = 0;
+for 1..5000 -> $i {
+    my $d = Dist.new(
+        name => "Example::Dist",
+        auth => "zef:someone",
+        version => "0.0.$i",
+        description => "a dist",
+        provides => { "Example::Dist" => "lib/Example/Dist.rakumod" },
+        depends => ["Other::Dist"],
+    );
+    $checksum += $d.name.chars;
+    $checksum += $d.provides.elems;
+}
+
+say "checksum = $checksum";


### PR DESCRIPTION
## Summary

Adds the constructor microbench used throughout today's zef-populate campaign (#4557 / #4558 / #4561) to `benchmarks/` so the bench CI tracks it permanently (`scripts/bench-ci.sh` picks up `benchmarks/*.raku` automatically; both the interpreter and `+jit` series get recorded, with a same-runner raku ratio).

## What it pins

The `Zef::Distribution` constructor shape: a 20-attribute class (@/%-sigil attributes, private `%!meta`, `is rw`) inheriting from a parent, `method new(*%_)` delegating to `self.bless(|%_, :meta(%_))`, and TWEAK submethods at two MRO levels — the child one declared `--> Nil` with attributive parameters (`:%!meta`, `:@!resources`).

This is deliberately different from `bench-class.raku` (light 3-attribute classes, accessor/method-call heavy): it stresses bless attribute initialization, submethod dispatch, and definite-return finalization. This shape was **35x slower than raku** at the start of 2026-07-15 and is ~3x after #4557/#4558/#4561 — a regression in any of those fixes shows up in this bench's history.

## Verification

- Output checksum byte-identical under raku
- Current local timing (release): mutsu 0.38s / raku 0.34s wall

🤖 Generated with [Claude Code](https://claude.com/claude-code)