### PR TITLE
perf: native VM fork for bless + plan-cached class shape in dispatch_bless

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -152,10 +152,16 @@ Current state (details in news/2026-06.md and news/2026-07.md): ✅ CLI load + c
          (bless/TWEAK) Debug-traversed method-body ASTs looking for `.wrap` chains that don't
          exist; gated behind `has_any_wrap_chains()` + `Arc::ptr_eq` candidate matching.
          Combined with #4559 (subrule memoization): full fez populate = **6.5s** release
-         (raku ~1-2.8s); the 18-attr ctor microbench (tmp/ctor-bench.raku) went 35x → **2.9x**
-         vs raku over the session. Remaining (per-dist): `bless` still runs on the
-         `run_instance_method` slow-path fallback, TWEAK x2 via the resolver path, allocation
-         churn / SipHash on String-keyed maps / Symbol intern traffic in the flat profile.
+         (raku ~1-2.8s). Fourth fix (native-bless PR): `bless` no longer routes through the
+         interpreter's generic method-dispatch scan — the VM forks it straight to
+         `dispatch_bless`, which now reuses the cached per-class `NativeCtorPlan` (attribute
+         defs + BUILD/TWEAK probes, incl. 6.e role submethods) instead of re-collecting the
+         class shape per call; ctor microbench (benchmarks/bench-ctor.raku) 0.35 → 0.31s release,
+         **2.9x → 2.2x** vs raku. Remaining (per-dist): TWEAK x2 via the resolver path
+         (per-call `resolve_method_with_owner_invocant` + `build_remaining` fingerprints +
+         attributive-named-param full env path), allocation churn (~30% malloc/free in the
+         flat profile: AttrMap clones per phase, `!attr`/`.attr` env inserts) / Symbol intern
+         traffic.
       2. Nested `.raku` rendering: an Instance inside a collection renders as `Sp()` (type-object
          style) (`(C.new,).raku` → raku gives `(C.new(...),)`). The value itself is fine
          (semantically harmless; display only).

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -273,59 +273,59 @@ impl Interpreter {
                 "getcodename requires a concrete code object",
             ));
         }
-        // Initialize with default attribute values
+        // Initialize with default attribute values. The attribute defs and the
+        // BUILD/TWEAK probes come from the cached per-class NativeCtorPlan
+        // (shape-only data, invalidated with the dispatch caches) instead of
+        // being re-collected on every bless.
+        let plan = self.native_ctor_plan(class_name);
         let mut attributes = AttrMap::new();
-        if self.registry().classes.contains_key(&class_name.resolve()) {
-            for (attr_name, _is_public, default, _is_rw, _, sigil, _) in
-                self.collect_class_attributes(&class_name.resolve())
-            {
-                let val = if let Some(Expr::Literal(ref lit_val)) = default {
-                    // Fast path: simple literal defaults (e.g. native type
-                    // defaults like Int(0)) don't need interpretation.
-                    lit_val.clone()
-                } else if let Some(expr) = default {
-                    self.eval_block_value(&[Stmt::Expr(expr)])?
-                } else if sigil == '@' {
-                    // A `@`-sigil attribute with no default is an empty Array,
-                    // not Nil (matches `dispatch_new`). Leaving it Nil makes
-                    // `@!attr.elems` return 1 (Any.elems) and corrupts guards.
-                    let mut arr = Value::real_array(Vec::new());
-                    let tc = self
-                        .registry()
-                        .classes
-                        .get(&class_name.resolve())
-                        .and_then(|cd| cd.attribute_types.get(&attr_name))
-                        .cloned();
-                    if let Some(tc) = tc {
-                        arr = self.tag_container_metadata(
-                            arr,
-                            super::ContainerTypeInfo {
-                                value_type: tc,
-                                key_type: None,
-                                declared_type: None,
-                            },
-                        );
-                    }
-                    arr
-                } else if sigil == '%' {
-                    // A `%`-sigil attribute with no default is an empty Hash.
-                    Value::hash(HashMap::new())
-                } else {
-                    // Native types have zero/empty defaults instead of Nil
-                    let type_constraint =
-                        self.get_attr_type_constraint(&class_name.resolve(), &attr_name);
-                    match type_constraint.as_deref() {
-                        Some(
-                            "int" | "int8" | "int16" | "int32" | "int64" | "uint" | "uint8"
-                            | "uint16" | "uint32" | "uint64" | "byte" | "atomicint",
-                        ) => Value::int(0),
-                        Some("num" | "num32" | "num64") => Value::num(0.0),
-                        Some("str") => Value::str("".to_string()),
-                        _ => Value::NIL,
-                    }
-                };
-                attributes.insert(attr_name, val);
-            }
+        for (attr_name, _is_public, default, _is_rw, _, sigil, _) in plan.class_attrs.iter() {
+            let val = if let Some(Expr::Literal(lit_val)) = default {
+                // Fast path: simple literal defaults (e.g. native type
+                // defaults like Int(0)) don't need interpretation.
+                lit_val.clone()
+            } else if let Some(expr) = default {
+                self.eval_block_value(&[Stmt::Expr(expr.clone())])?
+            } else if *sigil == '@' {
+                // A `@`-sigil attribute with no default is an empty Array,
+                // not Nil (matches `dispatch_new`). Leaving it Nil makes
+                // `@!attr.elems` return 1 (Any.elems) and corrupts guards.
+                let mut arr = Value::real_array(Vec::new());
+                let tc = self
+                    .registry()
+                    .classes
+                    .get(&class_name.resolve())
+                    .and_then(|cd| cd.attribute_types.get(attr_name))
+                    .cloned();
+                if let Some(tc) = tc {
+                    arr = self.tag_container_metadata(
+                        arr,
+                        super::ContainerTypeInfo {
+                            value_type: tc,
+                            key_type: None,
+                            declared_type: None,
+                        },
+                    );
+                }
+                arr
+            } else if *sigil == '%' {
+                // A `%`-sigil attribute with no default is an empty Hash.
+                Value::hash(HashMap::new())
+            } else {
+                // Native types have zero/empty defaults instead of Nil
+                let type_constraint =
+                    self.get_attr_type_constraint(&class_name.resolve(), attr_name);
+                match type_constraint.as_deref() {
+                    Some(
+                        "int" | "int8" | "int16" | "int32" | "int64" | "uint" | "uint8" | "uint16"
+                        | "uint32" | "uint64" | "byte" | "atomicint",
+                    ) => Value::int(0),
+                    Some("num" | "num32" | "num64") => Value::num(0.0),
+                    Some("str") => Value::str("".to_string()),
+                    _ => Value::NIL,
+                }
+            };
+            attributes.insert(attr_name.clone(), val);
         }
         // Override with named args from bless call
         for arg in &args {
@@ -335,7 +335,62 @@ impl Interpreter {
         }
         // Embed `is default(...)` element defaults into `@`/`%` containers.
         self.apply_container_attribute_defaults(&class_name.resolve(), &mut attributes);
-        // Run BUILD/TWEAK submethods in MRO order (base-first)
+        // Run BUILD/TWEAK submethods in MRO order (base-first). The whole BUILD
+        // walk (per-MRO-class registry probes + role-submethod ordering) is
+        // skipped when the plan says no class or composed role declares one.
+        if plan.has_build {
+            self.run_bless_build_phase(class_name, &mut attributes, &args)?;
+        }
+        // `bless` passes its named arguments through to BUILD and TWEAK (as
+        // `BUILDALL` does), so a `submethod BUILD(:$!attr!)` with a required named
+        // parameter binds -- the args are also pre-folded into `attributes` above
+        // for the common no-explicit-BUILD case.
+        let attributes = if plan.has_tweak {
+            self.run_tweak_phase(class_name, attributes, &args)?
+        } else {
+            attributes
+        };
+        Ok(Value::make_instance(class_name, attributes))
+    }
+
+    /// Native `bless` entry for the VM: dispatch straight to `dispatch_bless`,
+    /// skipping the interpreter's generic method-dispatch scan (lever A).
+    /// Only a registered class with no user-defined (or role-composed) `bless`
+    /// override qualifies; everything else returns `None` and falls back to
+    /// the interpreter, whose scan handles user overrides / builtin receivers.
+    pub(crate) fn try_native_bless(
+        &mut self,
+        target: &Value,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        let class_name = match target.view() {
+            ValueView::Package(name) => name,
+            ValueView::Instance { class_name, .. } => class_name,
+            _ => return None,
+        };
+        if !self.registry().classes.contains_key(class_name.as_str()) {
+            return None;
+        }
+        // The user-`bless`-override probe is cached in the per-class plan (an
+        // MRO + registry scan otherwise paid on every construction).
+        if self.native_ctor_plan(class_name).has_custom_bless {
+            return None;
+        }
+        Some(self.dispatch_bless(target, args.to_vec()))
+    }
+
+    /// The BUILD phase of `bless`: invoke every BUILD submethod (own and
+    /// role-composed) across the MRO in base-first order, threading the
+    /// (possibly mutated) attribute map through each call. Extracted verbatim
+    /// from `dispatch_bless` so the `plan.has_build` gate can skip it wholesale.
+    /// (Unlike `run_build_phase`, a `fail` inside BUILD propagates as an error
+    /// here — the historical `bless` behavior.)
+    fn run_bless_build_phase(
+        &mut self,
+        class_name: Symbol,
+        attributes: &mut AttrMap,
+        args: &[Value],
+    ) -> Result<(), RuntimeError> {
         let mro = self.class_mro(&class_name.resolve());
         // Determine the class's language revision for submethod dispatch rules.
         let class_lang_rev = self
@@ -399,10 +454,10 @@ impl Interpreter {
                     "BUILD",
                     method_def,
                     attributes.clone(),
-                    args.clone(),
+                    args.to_vec(),
                     Some(Value::make_instance(class_name, attributes.clone())),
                 )?;
-                attributes = updated;
+                *attributes = updated;
             }
             // Call the class's BUILD if it has one that wasn't already handled
             // by ordered_role_submethods_for_class. Role submethods (is_my=true,
@@ -424,18 +479,13 @@ impl Interpreter {
                     mro_class,
                     attributes.clone(),
                     "BUILD",
-                    args.clone(),
+                    args.to_vec(),
                     Some(Value::make_instance(class_name, attributes.clone())),
                 )?;
-                attributes = updated;
+                *attributes = updated;
             }
         }
-        // `bless` passes its named arguments through to BUILD and TWEAK (as
-        // `BUILDALL` does), so a `submethod BUILD(:$!attr!)` with a required named
-        // parameter binds -- the args are also pre-folded into `attributes` above
-        // for the common no-explicit-BUILD case.
-        let attributes = self.run_tweak_phase(class_name, attributes, &args)?;
-        Ok(Value::make_instance(class_name, attributes))
+        Ok(())
     }
 
     /// Run the TWEAK phase of construction: invoke every TWEAK submethod (own and

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -262,47 +262,75 @@ impl Interpreter {
         let is_cunion = self.registry().cunion_classes.contains(cn_resolved);
         let registered = self.registry().classes.contains_key(cn_resolved);
         let eligible = !is_cunion && self.is_native_default_constructible(cn_resolved);
-        let (class_attrs, type_constraints, has_build, has_tweak, has_smiley) = if eligible {
-            let class_attrs = std::sync::Arc::new(self.collect_class_attributes(cn_resolved));
-            let type_constraints =
-                std::sync::Arc::new(self.collect_attribute_type_constraints(cn_resolved));
-            let mro = self.mro_readonly(cn_resolved);
-            let registry = self.registry();
-            let has_build = mro.iter().any(|cls| {
-                registry
-                    .classes
-                    .get(cls)
-                    .is_some_and(|cd| cd.methods.contains_key("BUILD"))
-            });
-            let has_tweak = mro.iter().any(|cls| {
-                registry
-                    .classes
-                    .get(cls)
-                    .is_some_and(|cd| cd.methods.contains_key("TWEAK"))
-            });
-            let has_smiley = mro.iter().any(|cls| {
-                registry
-                    .classes
-                    .get(cls)
-                    .is_some_and(|cd| !cd.attribute_smileys.is_empty())
-            });
-            drop(registry);
-            (
-                class_attrs,
-                type_constraints,
-                has_build,
-                has_tweak,
-                has_smiley,
-            )
-        } else {
-            (
-                std::sync::Arc::new(Vec::new()),
-                std::sync::Arc::new(HashMap::new()),
-                false,
-                false,
-                false,
-            )
-        };
+        // The class shape (attribute defs, BUILD/TWEAK/smiley probes) is
+        // computed for EVERY registered class, not just natively-constructible
+        // ones: `dispatch_bless` consumes it too, and bless has no
+        // native-eligibility gate (a custom `new` doesn't disqualify bless).
+        let (class_attrs, type_constraints, has_build, has_tweak, has_smiley, has_custom_bless) =
+            if registered {
+                let class_attrs = std::sync::Arc::new(self.collect_class_attributes(cn_resolved));
+                let type_constraints =
+                    std::sync::Arc::new(self.collect_attribute_type_constraints(cn_resolved));
+                let mro = self.mro_readonly(cn_resolved);
+                let registry = self.registry();
+                let mut has_build = mro.iter().any(|cls| {
+                    registry
+                        .classes
+                        .get(cls)
+                        .is_some_and(|cd| cd.methods.contains_key("BUILD"))
+                });
+                let mut has_tweak = mro.iter().any(|cls| {
+                    registry
+                        .classes
+                        .get(cls)
+                        .is_some_and(|cd| cd.methods.contains_key("TWEAK"))
+                });
+                let has_smiley = mro.iter().any(|cls| {
+                    registry
+                        .classes
+                        .get(cls)
+                        .is_some_and(|cd| !cd.attribute_smileys.is_empty())
+                });
+                drop(registry);
+                // Role submethods are composed into the class's own method table
+                // only when both class and role are 6.c (`compose_submethods`); a
+                // 6.e role's BUILD/TWEAK is still run by the construction phases
+                // via `ordered_role_submethods_for_class`, so probe the composed
+                // roles too — otherwise the has_build/has_tweak gates would skip
+                // those phases for such classes.
+                if !has_build {
+                    has_build = mro.iter().any(|cls| {
+                        !self
+                            .ordered_role_submethods_for_class(cls, "BUILD")
+                            .is_empty()
+                    });
+                }
+                if !has_tweak {
+                    has_tweak = mro.iter().any(|cls| {
+                        !self
+                            .ordered_role_submethods_for_class(cls, "TWEAK")
+                            .is_empty()
+                    });
+                }
+                let has_custom_bless = self.has_user_method(cn_resolved, "bless");
+                (
+                    class_attrs,
+                    type_constraints,
+                    has_build,
+                    has_tweak,
+                    has_smiley,
+                    has_custom_bless,
+                )
+            } else {
+                (
+                    std::sync::Arc::new(Vec::new()),
+                    std::sync::Arc::new(HashMap::new()),
+                    false,
+                    false,
+                    false,
+                    false,
+                )
+            };
         let plan = std::sync::Arc::new(super::NativeCtorPlan {
             is_cunion,
             eligible,
@@ -311,6 +339,7 @@ impl Interpreter {
             has_build,
             has_tweak,
             has_smiley,
+            has_custom_bless,
         });
         // Don't freeze a plan for a class that is not (yet) registered: e.g. a
         // role punned to a class on first use would otherwise keep a stale

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -425,6 +425,10 @@ pub(crate) struct NativeCtorPlan {
     pub(crate) has_build: bool,
     pub(crate) has_tweak: bool,
     pub(crate) has_smiley: bool,
+    /// A user-defined (or role-composed) public `bless` method anywhere in the
+    /// MRO — such a class must take the interpreter's generic dispatch instead
+    /// of the native `bless` fork.
+    pub(crate) has_custom_bless: bool,
 }
 
 /// Kind of declaration a doc comment is attached to.

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -159,6 +159,25 @@ impl Interpreter {
             self.method_dispatch_pure = true;
             return self.dispatch_socket_inet_new(&args);
         }
+        // Native `bless`: route straight to the interpreter's single
+        // `dispatch_bless` impl (attribute assembly + BUILD/TWEAK phases),
+        // skipping the generic method-dispatch scan (lever A). Gated inside
+        // `try_native_bless`: registered class, no user `bless` override.
+        // Construction runs user code only through BUILD/TWEAK (and non-literal
+        // attribute defaults, same as the native `.new` fork above), so the
+        // dispatch is env-pure exactly when the plan has neither phase.
+        if method == "bless"
+            && let Some(result) = loan_env!(self, try_native_bless(&target, &args))
+        {
+            let class_sym = match target.view() {
+                ValueView::Package(name) => name,
+                ValueView::Instance { class_name, .. } => class_name,
+                _ => unreachable!("try_native_bless only fires on Package/Instance"),
+            };
+            let plan = self.native_ctor_plan(class_sym);
+            self.method_dispatch_pure = !(plan.has_build || plan.has_tweak);
+            return result;
+        }
         // Native built-in *class* method (a pure type-object method other than
         // `.new`, e.g. `Instant.from-posix`) — built directly instead of routing
         // through the interpreter's class-method dispatch.

--- a/src/vm/vm_call_method_compiled_mut.rs
+++ b/src/vm/vm_call_method_compiled_mut.rs
@@ -89,6 +89,25 @@ impl Interpreter {
             self.method_dispatch_pure = true;
             return result;
         }
+        // Native `bless` (mut path twin — `self.bless(...)` has a variable
+        // receiver, so it lands here): route straight to the interpreter's
+        // single `dispatch_bless` impl, skipping the generic method-dispatch
+        // scan (lever A). Gated inside `try_native_bless`: registered class, no
+        // user `bless` override. bless builds a *new* instance and never
+        // mutates the receiver, so there is no writeback; the dispatch is
+        // env-pure exactly when the plan has no BUILD/TWEAK phase.
+        if method == "bless"
+            && let Some(result) = loan_env!(self, try_native_bless(&target, &args))
+        {
+            let class_sym = match target.view() {
+                ValueView::Package(name) => name,
+                ValueView::Instance { class_name, .. } => class_name,
+                _ => unreachable!("try_native_bless only fires on Package/Instance"),
+            };
+            let plan = self.native_ctor_plan(class_sym);
+            self.method_dispatch_pure = !(plan.has_build || plan.has_tweak);
+            return result;
+        }
         if let ValueView::Instance { class_name, .. } = target.view() {
             let class = class_name.as_str();
             // Interpreter-native pure-handle IO dispatch (PLAN.md ③ native IO PR-C/PR-D),

--- a/t/bless-native-fork.t
+++ b/t/bless-native-fork.t
@@ -1,0 +1,81 @@
+use v6;
+use Test;
+
+# Pin for the native `bless` VM fork (skips the interpreter's generic
+# method-dispatch scan and reuses the cached per-class NativeCtorPlan).
+# These cases exercise every gate of the fork: plain bless, bless with
+# role-composed BUILD/TWEAK submethods, bless with attribute defaults and
+# typed containers, a user-defined `bless` override (must NOT take the
+# fork), and bless from a custom `new` on a subclass.
+
+plan 11;
+
+my @events;
+
+role R {
+    submethod BUILD { @events.push('role-BUILD') }
+    submethod TWEAK { @events.push('role-TWEAK') }
+}
+
+class WithRole does R {
+    has $.y;
+    method new(*%_) { self.bless(|%_) }
+}
+
+@events = ();
+my $wr = WithRole.new(:7y);
+is @events.join(','), 'role-BUILD,role-TWEAK',
+    'role-composed BUILD and TWEAK submethods run during bless';
+
+class Base {
+    has $.p = 10;
+}
+
+class WithDefaults is Base {
+    has Int @.nums;
+    has $.z = 3;
+    has %.map;
+    method new(*%_) { self.bless(|%_) }
+}
+
+my $wd = WithDefaults.new(:nums([1, 2, 3]));
+is ~$wd.nums, '1 2 3', 'typed @ attribute set through bless';
+is $wd.z, 3, 'literal scalar default applied by bless';
+is $wd.p, 10, 'inherited attribute default applied by bless';
+is $wd.map.elems, 0, '% attribute with no default is an empty hash';
+is WithDefaults.new(:5z).z, 5, 'bless folds named args into attributes';
+
+class CustomBless {
+    has $.w;
+    method bless(*%_) {
+        @events.push('custom-bless');
+        callsame;
+    }
+    method new(*%_) { self.bless(|%_) }
+}
+
+@events = ();
+my $cb = CustomBless.new(:9w);
+is @events.join(','), 'custom-bless',
+    'user-defined bless override still dispatches (no native fork)';
+
+class TweakOnly {
+    has $.spec;
+    has @.resources;
+    submethod TWEAK(:$!spec, :@!resources --> Nil) {
+        @!resources = @!resources.map(* x 2);
+    }
+    method new(*%_) { self.bless(|%_) }
+}
+
+my $to = TweakOnly.new(:spec('s'), :resources(['a', 'b']));
+is $to.spec, 's', 'attributive named TWEAK param binds through bless';
+is-deeply $to.resources, ['aa', 'bb'], 'TWEAK mutates @!attr during bless';
+
+# bless called directly on the type object (no custom new in between).
+class DirectBless { has $.v = 5 }
+my $db = DirectBless.bless(:11v);
+is $db.v, 11, 'direct Type.bless(...) works';
+is DirectBless.bless().v, 5, 'direct Type.bless() applies defaults';
+
+done-testing;


### PR DESCRIPTION
## Summary

`self.bless(...)` (every Zef::Distribution-style constructor) previously fell back from the VM to the interpreter's generic method-dispatch scan (~3300 sequential checks in `call_method_with_values`) on every call, and `dispatch_bless` then re-derived the whole class shape per call: `collect_class_attributes` (an MRO walk cloning every attribute def including default `Expr`s), per-MRO-class BUILD probes + role-submethod ordering even when no BUILD exists anywhere, and an unconditional `run_tweak_phase` MRO walk even for TWEAK-less classes.

- **New `try_native_bless`**: the VM's CallMethod/CallMethodMut compiled dispatch forks `bless` straight to `dispatch_bless` for a registered class with no user `bless` override (probe cached in the plan as `has_custom_bless`). Purity is derived from the plan's `has_build`/`has_tweak`, so BUILD/TWEAK-running constructions still reconcile caller slots.
- **`NativeCtorPlan` now carries the class shape for every registered class** (attribute defs, type constraints, BUILD/TWEAK/smiley probes), not just natively-constructible ones, so `dispatch_bless` reuses the cached shape instead of re-collecting per call.
- **has_build/has_tweak gate gap fixed**: role submethods are composed into the class method table only for 6.c class+role pairs, so a 6.e role's BUILD/TWEAK was invisible to the old `cd.methods`-only probes (latent gap shared with the native `.new` path). The probes now also check `ordered_role_submethods_for_class`.
- `dispatch_bless`'s BUILD loop is extracted into `run_bless_build_phase` and skipped wholesale (as is `run_tweak_phase`) when the plan has no BUILD/TWEAK anywhere in the MRO or composed roles.

## Numbers (release, local perf-stat style A/B — bench CI is the document source of truth)

- `benchmarks/bench-ctor.raku` (18-attr Zef::Distribution-shaped ctor x5000): **0.35s → 0.31s**, raku ratio 2.9x → **2.2x**
- bless interpreter fallbacks on the bench: **5000 → 0** (`method-fallback by name` no longer lists bless)
- fez populate (7657 dists): 6.5s → 6.39s (populate is TWEAK/alloc-churn dominated; expected small)

Remaining per-ctor cost (PLAN frontier updated): TWEAK x2 via the resolver path (`resolve_method_with_owner_invocant` + `build_remaining` fingerprints per call, attributive-named-param full env path) and allocation churn (~30% malloc/free in the flat profile).

## Test plan

- `make test` PASS (16947 tests, includes the new pin)
- New pin: `t/bless-native-fork.t` — role BUILD/TWEAK submethods via bless, typed/defaulted attributes, custom-bless override gate (must NOT take the fork), direct `Type.bless`; verified against raku
- 27 construction-related whitelisted roast files (S12-construction/*, S12-attributes/*, S12-class basics, S14-roles attributes/submethods incl. roles-6e.t): all PASS
- Behavior probe (`tmp/bless-probe.raku`) byte-identical before/after
- clippy (1.96.1) + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)