### PR TITLE
fix: `once` fires exactly once across threads and repeated sub calls

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -256,10 +256,23 @@ itself = `def_is_otf_compilable_module_single` (`vm/vm_call_func_ops.rs`). The f
 - [ ] **OTF for sigilless scalar (`\x`) params**: caller writeback of raw aliases across EVAL needs a
       mechanism equivalent to #4091 (`is rw` compile-time caller slot)
       (FAIL pin = `t/sigilless-params.t` "sigilless aliases are writable through EVAL calls").
-- [ ] **Cross-thread duplicate firing of `once` (a real bug with the same behavior even under
-      tree-walk)**: `once_values` gets value-copied on thread clone and re-fires on each thread (raku
-      fires once globally). Fix = turn `once_values` into a shared cell (same pattern as the #4312
-      state cells).
+- [x] **Cross-thread (and repeated single-thread) duplicate firing of `once`** — DONE. The root
+      cause was deeper than "value-copied `once_values`": each worker re-OTF-compiles the routine and
+      the compile-time `once` site key drew from a global counter, so keys never matched across
+      threads; and a named sub's second call took a light call path that skipped the clone-id setup,
+      giving it a different key from the first call. Fix (this PR): the site key is now the `OnceExpr`
+      op's bytecode position (deterministic across recompiles), the store is an `Arc`-shared
+      `OnceStore` with a claim/condvar protocol (fires once even under a race), and `once`-bearing
+      routines are kept off the fast/light call paths so every call runs the clone-id setup the key
+      uses. Pins: `t/once-clone-scope.t`, `t/once-phaser.t`.
+- [ ] **`once` in a *method* still fires per call** (pre-existing; separate root cause): a method's
+      `__mutsu_callable_id` is a fresh per-call id (`next_instance_id()`), not a per-clone id, so a
+      method's `once` has no stable clone key. raku fires once per method clone (once per composing
+      class for role methods; the defining class's single clone for inheritance). The fix needs a
+      stable `(owner_class, method)` clone marker that does NOT disturb the per-call id recursive
+      `return`-targeting relies on, plus preventing that marker leaking into `once`s in closures
+      nested in the method. FAIL repro: `class C { method m() { once { say 1 } } }; my $c = C.new;
+      $c.m; $c.m` prints `1` twice (raku: once).
 - Intentionally excluded (decided not to do): default-param builtin-shadow single candidate
   (name-cache pollution risk; user policy) / `is encoded(...)` (NativeCall; zero practical harm) /
   `state` sharing across signature alternates (kept as an interpreter boundary).

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -290,17 +290,16 @@ impl Compiler {
     }
 
     /// Compile `once { ... }` expression.
+    ///
+    /// The once-site identity is the emitted `OnceExpr` op's bytecode position
+    /// (used at run time as the cache key together with the enclosing routine
+    /// clone id). Unlike the old global `STATE_COUNTER` key, the op position is
+    /// deterministic across every recompilation of the same routine body — in
+    /// particular, a worker thread that re-OTF-compiles the routine reaches the
+    /// same `once` under the same key, which (with the shared `once_values`
+    /// store) is what makes `once` fire once across threads.
     pub(super) fn compile_expr_once(&mut self, body: &[Stmt]) {
-        let key = format!(
-            "__once_{}::{}",
-            self.current_package,
-            STATE_COUNTER.fetch_add(1, Ordering::Relaxed)
-        );
-        let key_idx = self.code.add_constant(Value::str(key));
-        let once_idx = self.code.emit(OpCode::OnceExpr {
-            key_idx,
-            body_end: 0,
-        });
+        let once_idx = self.code.emit(OpCode::OnceExpr { body_end: 0 });
         self.compile_block_inline(body);
         self.code.patch_body_end(once_idx);
     }

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -786,7 +786,6 @@ pub(crate) enum OpCode {
         isolate_decls_idx: u32,
     },
     OnceExpr {
-        key_idx: u32,
         body_end: u32,
     },
     DoGivenExpr {
@@ -1849,6 +1848,11 @@ pub(crate) struct CompiledCode {
     /// the caller writeback even when its own free variables are unchanged.
     /// Distinct from `has_env_writes`, which lists only *some* call opcodes.
     pub(crate) has_calls: bool,
+    /// True if this code object directly contains a `once { ... }` (`OnceExpr`).
+    /// Set during `emit()`. Callers use it to keep `once`-bearing routines off the
+    /// fast/light call paths, which skip the routine clone-id setup the `once`
+    /// store keys on (see `once_scope_key`).
+    pub(crate) has_once: bool,
     /// True if this code runs an inline body that reads the frame's lexicals *by
     /// name* through a path the `free_var_syms` op-scan cannot see: loop/block
     /// bodies that thread control temps through `env` by name (`ForLoop`,
@@ -2008,6 +2012,7 @@ impl CompiledCode {
             closure_compiled_codes: Vec::new(),
             closure_escapes: Vec::new(),
             is_routine: false,
+            has_once: false,
             source_line: None,
             is_pointy_block: false,
             has_env_writes: false,
@@ -3256,6 +3261,9 @@ impl CompiledCode {
     }
 
     pub(crate) fn emit(&mut self, op: OpCode) -> usize {
+        if matches!(op, OpCode::OnceExpr { .. }) {
+            self.has_once = true;
+        }
         if !self.has_calls {
             // Every call opcode -- any of these can invoke a callee that writes
             // back an arbitrary captured variable into this frame's env. Keep

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -362,15 +362,34 @@ impl Interpreter {
             .retain(|(entry_id, _), _| *entry_id != id);
     }
 
-    pub(crate) fn current_once_scope(&self) -> Option<u64> {
-        // When inside a closure call, __mutsu_callable_id identifies the
-        // specific closure clone.  This must take priority over the
-        // once_scope_stack so that `once` blocks inside closures called from
-        // EVAL (where the stack depth > 1) still get a per-clone scope.
+    /// Build the shared-store key for a `once` site at bytecode position
+    /// `op_ip`. The key combines the enclosing code-object *clone* identity with
+    /// the op position, so a `once` fires once per clone (Raku semantics):
+    ///
+    /// - `__mutsu_callable_id` (set per-clone by the call dispatch) identifies a
+    ///   specific routine/closure clone and takes priority — this is what makes a
+    ///   fresh `my sub` clone per loop iteration re-fire, and (being stable across
+    ///   a routine's OTF recompiles on worker threads) what makes a sub's `once`
+    ///   agree across threads.
+    /// - Otherwise the innermost block/once scope (top-level / bare-block `once`).
+    ///
+    /// The `c`/`r` tag keeps the two id spaces from colliding numerically, and
+    /// `op_ip` is unique per `once` site within a single code object, so the key
+    /// is collision-free. Unlike the old global compile-time counter it is
+    /// deterministic across every recompilation of the same source.
+    pub(crate) fn once_scope_key(&self, op_ip: usize) -> String {
         match self.env.get("__mutsu_callable_id").map(Value::view) {
-            Some(ValueView::Int(id)) if id >= 0 => Some(id as u64),
-            _ => self.once_scope_stack.last().copied(),
+            Some(ValueView::Int(id)) if id >= 0 => format!("c{id}::{op_ip}"),
+            _ => format!(
+                "r{}::{op_ip}",
+                self.once_scope_stack.last().copied().unwrap_or(0)
+            ),
         }
+    }
+
+    /// The shared cross-thread `once` result store (see [`once_scope_key`]).
+    pub(crate) fn once_store(&self) -> &std::sync::Arc<crate::runtime::once_store::OnceStore> {
+        &self.once_values
     }
 
     pub(crate) fn push_once_scope(&mut self, scope: u64) {
@@ -385,14 +404,6 @@ impl Interpreter {
         let scope = self.next_once_scope_id;
         self.next_once_scope_id += 1;
         scope
-    }
-
-    pub(crate) fn get_once_value(&self, key: &str) -> Option<&Value> {
-        self.once_values.get(key)
-    }
-
-    pub(crate) fn set_once_value(&mut self, key: String, value: Value) {
-        self.once_values.insert(key, value);
     }
 
     pub(crate) fn when_matched(&self) -> bool {

--- a/src/runtime/gc_roots.rs
+++ b/src/runtime/gc_roots.rs
@@ -185,7 +185,8 @@ impl Interpreter {
         visit_map_values(visitor, &self.escaped_our_lexical_cells);
         visit_map_values(visitor, &self.state_vars);
         visit_map_values(visitor, &self.closure_captured_state);
-        visit_map_values(visitor, &self.once_values);
+        self.once_values
+            .visit_done_values(|v| visitor.visit_value(v));
         visit_map_values(visitor, &self.var_defaults);
         for (_, v, _, _) in &self.let_saves {
             visitor.visit_value(v);

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -280,6 +280,7 @@ mod native_supply_methods;
 mod native_supply_mut_methods;
 pub(crate) mod native_types;
 pub(crate) mod nativecall;
+pub(crate) mod once_store;
 mod ops_bits;
 mod ops_compare;
 mod ops_reduction;
@@ -1384,7 +1385,11 @@ pub struct Interpreter {
     /// `format!("__mutsu_closure_cap::{id}::{name}")` String allocation and the
     /// String hashing that dominated the closure dispatch profile.
     closure_captured_state: HashMap<(u64, Symbol), Value>,
-    once_values: HashMap<String, Value>,
+    /// Fired `once { ... }` results, keyed by `(routine-clone-id, op-position)`.
+    /// Shared by `Arc` handle into every spawned thread's clone so a `once` in a
+    /// sub run from multiple `start` blocks fires exactly once across threads
+    /// (see [`once_store::OnceStore`]).
+    once_values: Arc<once_store::OnceStore>,
     once_scope_stack: Vec<u64>,
     next_once_scope_id: u64,
     /// Variable dynamic-scope metadata used by `.VAR.dynamic`.

--- a/src/runtime/once_store.rs
+++ b/src/runtime/once_store.rs
@@ -1,0 +1,103 @@
+//! Cross-thread `once { ... }` result store.
+//!
+//! Raku's `once` fires exactly once per *clone* of the enclosing code object,
+//! and a clone is shared across every thread it runs on — so a `once` block in a
+//! sub called from `start { ... }` on several workers must fire only once in
+//! total. mutsu keys each `once` site by `(routine-clone-id, op-position)` and
+//! stores the fired result here. The store is wrapped in an `Arc` and shared by
+//! handle (not by value) into every spawned thread's interpreter clone, so all
+//! threads see one another's fires.
+//!
+//! To make "fires once" hold under a genuine race (two workers reaching the same
+//! `once` before either records a result), a claim protocol is used: the first
+//! thread to arrive installs a `Running` marker, runs the body with the lock
+//! released, then records `Done`; a second thread that finds `Running` waits on
+//! the condvar until the result appears. A thread that re-enters its own
+//! in-progress `once` (a recursive `once` body) does not deadlock — it is served
+//! `Nil` instead of blocking on itself.
+
+use crate::value::Value;
+use std::collections::HashMap;
+use std::sync::{Condvar, Mutex};
+use std::thread::ThreadId;
+
+/// The state of one `once` site.
+enum OnceSlot {
+    /// A thread is currently evaluating the body; carries the claimer's id so a
+    /// recursive re-entry from the same thread is not mistaken for a peer wait.
+    Running(ThreadId),
+    /// The body finished; carries its result value (reused by every later hit).
+    Done(Value),
+}
+
+/// Shared, thread-safe store of `once` results, keyed by site string.
+#[derive(Default)]
+pub(crate) struct OnceStore {
+    map: Mutex<HashMap<String, OnceSlot>>,
+    cv: Condvar,
+}
+
+/// Outcome of trying to claim a `once` site.
+pub(crate) enum OnceClaim {
+    /// The site already fired; here is its cached value.
+    Cached(Value),
+    /// This thread now owns the claim and must run the body, then call
+    /// [`OnceStore::fulfill`] (on success) or [`OnceStore::abandon`] (on error).
+    Claimed,
+}
+
+impl OnceStore {
+    /// Look up `key`; return its cached value, or claim it for this thread.
+    ///
+    /// If another thread holds the claim, block until it publishes a result (or
+    /// abandons it, in which case this thread takes over the claim).
+    pub(crate) fn claim(&self, key: &str) -> OnceClaim {
+        let tid = std::thread::current().id();
+        let mut map = self.map.lock().unwrap();
+        loop {
+            match map.get(key) {
+                Some(OnceSlot::Done(v)) => return OnceClaim::Cached(v.clone()),
+                // A recursive `once` body re-entering its own site: don't wait on
+                // ourselves. Treat as not-yet-produced and yield `Nil` upstream.
+                Some(OnceSlot::Running(owner)) if *owner == tid => {
+                    return OnceClaim::Cached(Value::NIL);
+                }
+                Some(OnceSlot::Running(_)) => {
+                    map = self.cv.wait(map).unwrap();
+                    // Re-check the slot: the owner may have fulfilled or abandoned.
+                }
+                None => {
+                    map.insert(key.to_string(), OnceSlot::Running(tid));
+                    return OnceClaim::Claimed;
+                }
+            }
+        }
+    }
+
+    /// Publish the result of a claimed site and wake any waiters.
+    pub(crate) fn fulfill(&self, key: &str, value: Value) {
+        let mut map = self.map.lock().unwrap();
+        map.insert(key.to_string(), OnceSlot::Done(value));
+        drop(map);
+        self.cv.notify_all();
+    }
+
+    /// Release a claimed site without a result (the body threw); a waiter — or a
+    /// later call — may retry it. Wakes waiters so one of them re-claims.
+    pub(crate) fn abandon(&self, key: &str) {
+        let mut map = self.map.lock().unwrap();
+        map.remove(key);
+        drop(map);
+        self.cv.notify_all();
+    }
+
+    /// Visit every fired result value (GC root marking).
+    pub(crate) fn visit_done_values(&self, mut f: impl FnMut(&Value)) {
+        let map = self.map.lock().unwrap();
+        for slot in map.values() {
+            if let OnceSlot::Done(v) = slot {
+                f(v);
+            }
+        }
+    }
+}

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2098,7 +2098,7 @@ impl Interpreter {
             state_vars: HashMap::new(),
             thread_redeclared_vars: std::collections::HashSet::new(),
             closure_captured_state: HashMap::new(),
-            once_values: HashMap::new(),
+            once_values: Arc::new(crate::runtime::once_store::OnceStore::default()),
             once_scope_stack: Vec::new(),
             next_once_scope_id: 1,
             var_dynamic_flags: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -261,7 +261,9 @@ impl Interpreter {
             // closure captured state (falls back to the captured-env initial
             // values), exactly as before this store existed.
             closure_captured_state: HashMap::new(),
-            once_values: self.once_values.clone(),
+            // Share the store by handle (not a per-thread copy) so a `once` in a
+            // sub run from several `start` blocks fires once across all threads.
+            once_values: Arc::clone(&self.once_values),
             once_scope_stack: Vec::new(),
             next_once_scope_id: self.next_once_scope_id,
             var_dynamic_flags: self.var_dynamic_flags.clone(),

--- a/src/vm/vm_call_eligibility.rs
+++ b/src/vm/vm_call_eligibility.rs
@@ -37,6 +37,8 @@ impl Interpreter {
             && cf.param_defs.is_empty()
             && cf.return_type.is_none()
             && !fn_name.is_empty()
+            // A `once` needs the clone-id setup only the full call path performs.
+            && !cf.code.has_once
     }
 
     /// Check if a compiled function is eligible for the light call path.
@@ -60,6 +62,8 @@ impl Interpreter {
             && !cf.is_rw
             && !cf.is_raw
             && !cf.empty_sig
+            // A `once` needs the clone-id setup only the full call path performs.
+            && !cf.code.has_once
             && !cf.param_defs.is_empty()
             && cf.param_defs.iter().all(|pd| {
                 pd.named
@@ -88,6 +92,8 @@ impl Interpreter {
             && cf.param_local_slots.is_some()
             // Exclude functions with inner closures/blocks (may use phasers, closures, etc.)
             && !cf.has_inner_subs
+            // A `once` needs the clone-id setup only the full call path performs.
+            && !cf.code.has_once
             // Only allow return types that light_return_type_check can handle
             && cf
                 .return_type

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4069,9 +4069,9 @@ impl Interpreter {
                     compiled_fns,
                 )?;
             }
-            OpCode::OnceExpr { key_idx, body_end } => {
+            OpCode::OnceExpr { body_end } => {
                 self.sync_source_line(code, *ip);
-                self.exec_once_expr_op(code, *key_idx, *body_end, ip, compiled_fns)?;
+                self.exec_once_expr_op(code, *body_end, ip, compiled_fns)?;
             }
             OpCode::DoGivenExpr { body_end } => {
                 self.sync_source_line(code, *ip);

--- a/src/vm/vm_misc_block.rs
+++ b/src/vm/vm_misc_block.rs
@@ -230,34 +230,47 @@ impl Interpreter {
     pub(super) fn exec_once_expr_op(
         &mut self,
         code: &CompiledCode,
-        key_idx: u32,
         body_end: u32,
         ip: &mut usize,
         compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
-        let scope =
-            loan_env!(self, current_once_scope()).unwrap_or_else(|| self.next_once_scope_id());
-        let site_key = Self::const_str(code, key_idx);
-        let cache_key = format!("{scope}::{site_key}");
-        if let Some(value) = self.get_once_value(&cache_key).cloned() {
-            self.stack.push(value);
-            *ip = body_end as usize;
-            return Ok(());
+        // The op's own bytecode position is the deterministic per-site id (stable
+        // across recompiles); the scope prefix is the enclosing code-object clone.
+        let cache_key = loan_env!(self, once_scope_key(*ip));
+        let store = std::sync::Arc::clone(self.once_store());
+        // Claim the site: get the cached result, or take ownership to run the body
+        // (blocking until a peer thread that owns the claim publishes its result).
+        match store.claim(&cache_key) {
+            crate::runtime::once_store::OnceClaim::Cached(value) => {
+                self.stack.push(value);
+                *ip = body_end as usize;
+                Ok(())
+            }
+            crate::runtime::once_store::OnceClaim::Claimed => {
+                let body_start = *ip + 1;
+                let end = body_end as usize;
+                let stack_base = self.stack.len();
+                match self.run_range(code, body_start, end, compiled_fns) {
+                    Ok(()) => {
+                        let value = if self.stack.len() > stack_base {
+                            self.stack.pop().unwrap_or(Value::NIL)
+                        } else {
+                            Value::NIL
+                        };
+                        store.fulfill(&cache_key, value.clone());
+                        self.stack.push(value);
+                        *ip = end;
+                        Ok(())
+                    }
+                    Err(e) => {
+                        // The body threw: release the claim so a retry or a waiting
+                        // peer can run it, then propagate the error.
+                        store.abandon(&cache_key);
+                        Err(e)
+                    }
+                }
+            }
         }
-
-        let body_start = *ip + 1;
-        let end = body_end as usize;
-        let stack_base = self.stack.len();
-        self.run_range(code, body_start, end, compiled_fns)?;
-        let value = if self.stack.len() > stack_base {
-            self.stack.pop().unwrap_or(Value::NIL)
-        } else {
-            Value::NIL
-        };
-        self.set_once_value(cache_key, value.clone());
-        self.stack.push(value);
-        *ip = end;
-        Ok(())
     }
 
     pub(super) fn exec_let_save_op(

--- a/t/once-clone-scope.t
+++ b/t/once-clone-scope.t
@@ -1,0 +1,55 @@
+use Test;
+
+# Regression pins for `once` clone-scope keying:
+#  * a named sub's `once` fires once no matter how many times it is called
+#    (the second call used to take a light call path that skipped the clone-id
+#    setup, giving it a different once key -> a spurious second fire);
+#  * a `once` in a sub run from several `start` blocks fires once across threads
+#    (the per-thread `once_values` copy + a non-deterministic compile-time key
+#    made every worker re-fire);
+#  * a fresh `my sub` clone per loop iteration re-fires (clone identity, not
+#    just the source site, drives the key).
+
+plan 5;
+
+# 1. Named sub called many times: exactly one fire.
+{
+    my $n = 0;
+    sub f() { once { $n++ } }
+    f(); f(); f(); f();
+    is $n, 1, 'once in a named sub fires once across many calls';
+}
+
+# 2. Two distinct named subs keep independent once state.
+{
+    my @log;
+    sub a() { once { @log.push: 'a' } }
+    sub b() { once { @log.push: 'b' } }
+    a(); a(); b(); b();
+    is-deeply @log, ['a', 'b'], 'distinct named subs have independent once state';
+}
+
+# 3. A fresh `my sub` clone per loop iteration re-fires (once per clone).
+{
+    my $c = 0;
+    for ^3 {
+        my sub inner() { once { $c++ } }
+        inner(); inner();
+    }
+    is $c, 3, 'a fresh my-sub clone per iteration re-fires once each';
+}
+
+# 4. once in a sub run from several start blocks: one fire across threads.
+{
+    my $count = 0;
+    sub worker() { once { $count++ } }
+    my @p = (^8).map: { start { worker() } };
+    await @p;
+    is $count, 1, 'once in a sub fires once across threads';
+}
+
+# 5. once still returns (and caches) its value as an rvalue in a sub.
+{
+    sub v() { my $x = once { 7 }; $x }
+    is v() + v(), 14, 'once rvalue value is cached and reused';
+}


### PR DESCRIPTION
## Summary

A `once { ... }` block in a sub called from several `start` blocks fired **once per worker**, and a plain named sub's `once` fired **twice** when called more than once. Only a single top-level call actually respected the "fires once" contract.

```raku
my $count = 0;
sub f() { once { $count++ } }
await (^4).map: { start { f() } };
say $count;   # was 4, raku gives 1 (now 1)

sub g() { once { say "fired" } }
g(); g();     # was "fired\nfired", raku gives one (now one)
```

## Root causes (deeper than the "value-copied `once_values`" note in PLAN §3)

1. **Non-deterministic site key.** `compile_expr_once` keyed the `once` cache on a global `STATE_COUNTER`. Each worker thread re-OTF-compiles the routine into a fresh body and drew a different counter, so a worker's key never matched a peer's fire. The key is now the emitted `OnceExpr` op's **bytecode position**, identical across every recompilation of the same routine body.
2. **Inconsistent clone scope.** The first call to a named sub took the named/OTF path (which sets `__mutsu_callable_id`, the routine clone id the key is scoped by); later calls took a fast/light path that skips that setup and keyed under the root scope instead → a second fire. `once`-bearing routines are now kept off the fast/light/positional call paths (`CompiledCode::has_once`, set in `emit`), so every call establishes the same clone id. Correctly, a fresh `my sub` clone per loop iteration still re-fires (clone identity, not just the source site, drives the key).
3. **Per-thread result copy.** `once_values` was cloned by value into each spawned thread. It is now an `Arc`-shared `OnceStore` with a **claim/condvar** protocol: the first thread runs the body with the lock released and publishes the result; a peer that finds the claim in progress waits for it, so `once` fires exactly once even under a genuine race (a thread re-entering its own in-progress `once` is served `Nil` rather than deadlocking).

The clone-scope key is `c`/`r`-tagged (callable-id vs block/once scope) so the two id spaces cannot collide numerically.

## Not fixed here (pre-existing, separate root cause)

`once` in a **method** still fires per call: a method's `__mutsu_callable_id` is a fresh per-call value (`next_instance_id()`), not a per-clone id, so it has no stable clone key. A proper fix needs a stable `(owner_class, method)` marker that does not disturb the per-call id recursive `return`-targeting relies on, plus preventing that marker leaking into `once`s in closures nested in the method. Tracked in PLAN §3.

## Testing

- New pin `t/once-clone-scope.t` (5 cases: repeated named-sub call, distinct subs, fresh-clone-per-iteration, cross-thread, rvalue caching) — stable across repeated runs.
- Existing `t/once-phaser.t` (12) and whitelisted `roast/S04-statements/once.t` (24) still pass.
- `make test` green (16946 tests); `cargo clippy -D warnings` / `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)