### PR TITLE
perf: skip the remaining-candidates pass for single-candidate submethod dispatch

### DIFF
--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -117,10 +117,21 @@ impl Interpreter {
                 &sigs,
             ));
         }
-        // Helper to build remaining candidates, skipping the chosen one
+        // Helper to build remaining candidates, skipping the chosen one.
+        // Submethod prefilter: a submethod is never inherited, so when the
+        // visible-candidate table holds at most one entry the remaining list is
+        // empty by construction — skip the full `resolve_all_methods_with_owner`
+        // pass (per-MRO-class overload-Vec clones + signature matching +
+        // fingerprints) that every construction-phase BUILD/TWEAK dispatch
+        // otherwise pays just to learn "nothing to defer to".
+        let skip_remaining = (method_def.is_my || method_def.is_submethod)
+            && self.count_visible_method_candidates(receiver_class_name, method_name) <= 1;
         let build_remaining = |this: &mut Self,
                                method_def: &MethodDef|
          -> Vec<(String, MethodDef)> {
+            if skip_remaining {
+                return Vec::new();
+            }
             let all = this.resolve_all_methods_with_owner(receiver_class_name, method_name, &args);
             let chosen_fp = this.method_def_fingerprint(method_def);
             let mut remaining = Vec::new();

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -374,6 +374,45 @@ impl Interpreter {
         500
     }
 
+    /// Count the visible (non-private, non-ancestor-submethod) overloads of
+    /// `method_name` across `class_name`'s MRO — the same visibility filter as
+    /// `resolve_all_methods_with_owner`, but without cloning any overload Vec
+    /// or running signature matching, and with an early-out at 2. Used to skip
+    /// the remaining-candidates pass entirely for single-candidate submethod
+    /// dispatch (BUILD/TWEAK on every construction).
+    pub(crate) fn count_visible_method_candidates(
+        &mut self,
+        class_name: &str,
+        method_name: &str,
+    ) -> usize {
+        let mro = self.class_mro(class_name);
+        let registry = self.registry();
+        let mut count = 0usize;
+        for cn in &mro {
+            let is_ancestor = cn != class_name;
+            let overloads = registry
+                .classes
+                .get(cn.as_str())
+                .and_then(|c| c.methods.get(method_name))
+                .or_else(|| {
+                    registry
+                        .roles
+                        .get(cn.as_str())
+                        .and_then(|r| r.methods.get(method_name))
+                });
+            if let Some(ovs) = overloads {
+                count += ovs
+                    .iter()
+                    .filter(|d| !(d.is_private || (d.is_my && is_ancestor)))
+                    .count();
+                if count > 1 {
+                    return count;
+                }
+            }
+        }
+        count
+    }
+
     pub(crate) fn resolve_all_methods_with_owner(
         &mut self,
         class_name: &str,

--- a/t/submethod-defer.t
+++ b/t/submethod-defer.t
@@ -1,0 +1,51 @@
+use v6;
+use Test;
+
+# Pin for deferral (nextsame/callsame) semantics in submethod dispatch.
+# The slow-path dispatcher skips building the remaining-candidates list for
+# single-candidate submethods (BUILD/TWEAK on every construction); these
+# cases pin that multi-submethod deferral within one class still works and
+# that a submethod never defers to an ancestor's submethod.
+
+plan 4;
+
+my @events;
+
+# nextsame in a TWEAK submethod must NOT re-run the ancestor's TWEAK
+# (submethods are not inherited); it terminates the submethod instead.
+class A { submethod TWEAK { @events.push('A') } }
+class B is A {
+    submethod TWEAK { @events.push('B-before'); nextsame; @events.push('B-after') }
+}
+
+@events = ();
+B.new;
+is @events.join(','), 'A,B-before',
+    'nextsame in TWEAK terminates without re-running ancestor TWEAK';
+
+# nextsame in a multi submethod defers to the next same-class candidate.
+class C {
+    multi submethod greet(Int $x) { @events.push('Int'); nextsame; @events.push('Int-after') }
+    multi submethod greet(Any $x) { @events.push('Any') }
+}
+
+@events = ();
+C.new.greet(42);
+is @events.join(','), 'Int,Any', 'nextsame defers to next multi submethod candidate';
+
+@events = ();
+C.new.greet('str');
+is @events.join(','), 'Any', 'multi submethod dispatch picks the narrower candidate set';
+
+# callsame in TWEAK likewise finds no ancestor candidate and resumes.
+class D { submethod TWEAK { @events.push('D') } }
+class E is D {
+    submethod TWEAK { @events.push('E'); callsame; @events.push('E-done') }
+}
+
+@events = ();
+E.new;
+is @events.join(','), 'D,E,E-done',
+    'callsame in TWEAK resumes without calling ancestor TWEAK';
+
+done-testing;


### PR DESCRIPTION
## Summary

Every slow-path instance-method dispatch (`run_instance_method`) built its nextsame/callsame remaining-candidates list via `resolve_all_methods_with_owner`: a full MRO walk cloning each class's overload `Vec<MethodDef>`, running signature matching, and fingerprinting every candidate — even for BUILD/TWEAK submethods, where the list is empty by construction (submethods are never inherited, so a single-overload submethod has nothing to defer to). Construction paid this twice per instance (TWEAK resolution per MRO class).

- New `count_visible_method_candidates`: the same visibility filter as `resolve_all_methods_with_owner` (non-private, non-ancestor-submethod) but with no cloning, no signature matching, and an early-out at 2.
- When the chosen candidate is a submethod and the count is <= 1, the remaining pass is skipped wholesale. Any other shape (multi submethods, an ancestor *regular* method sharing the name) takes the full pass unchanged, so deferral semantics are identical.

Same hygiene family as #4561 (wrap-chain prefilter): stop paying a per-construction scan to discover a statically-knowable empty result. Wall-clock on benchmarks/bench-ctor.raku is within noise (the remaining ctor cost is AttrMap/env allocation churn — PLAN frontier); this removes per-construction work that grows with MRO depth and candidate count.

## Test plan

- New pin: `t/submethod-defer.t` — nextsame/callsame in TWEAK terminate without re-running an ancestor's TWEAK; multi-submethod deferral within one class still walks the same-class candidate chain (verified against raku, PASS on both)
- `make test` PASS
- Behavior probes (bless/TWEAK nextsame) byte-identical before/after
- clippy (1.96.1) + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)