### PR TITLE
fix: `once` in a method fires once per clone (not per call)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -262,23 +262,6 @@ itself = `def_is_otf_compilable_module_single` (`vm/vm_call_func_ops.rs`). The f
 - [ ] **OTF for sigilless scalar (`\x`) params**: caller writeback of raw aliases across EVAL needs a
       mechanism equivalent to #4091 (`is rw` compile-time caller slot)
       (FAIL pin = `t/sigilless-params.t` "sigilless aliases are writable through EVAL calls").
-- [x] **Cross-thread (and repeated single-thread) duplicate firing of `once`** — DONE. The root
-      cause was deeper than "value-copied `once_values`": each worker re-OTF-compiles the routine and
-      the compile-time `once` site key drew from a global counter, so keys never matched across
-      threads; and a named sub's second call took a light call path that skipped the clone-id setup,
-      giving it a different key from the first call. Fix (this PR): the site key is now the `OnceExpr`
-      op's bytecode position (deterministic across recompiles), the store is an `Arc`-shared
-      `OnceStore` with a claim/condvar protocol (fires once even under a race), and `once`-bearing
-      routines are kept off the fast/light call paths so every call runs the clone-id setup the key
-      uses. Pins: `t/once-clone-scope.t`, `t/once-phaser.t`.
-- [ ] **`once` in a *method* still fires per call** (pre-existing; separate root cause): a method's
-      `__mutsu_callable_id` is a fresh per-call id (`next_instance_id()`), not a per-clone id, so a
-      method's `once` has no stable clone key. raku fires once per method clone (once per composing
-      class for role methods; the defining class's single clone for inheritance). The fix needs a
-      stable `(owner_class, method)` clone marker that does NOT disturb the per-call id recursive
-      `return`-targeting relies on, plus preventing that marker leaking into `once`s in closures
-      nested in the method. FAIL repro: `class C { method m() { once { say 1 } } }; my $c = C.new;
-      $c.m; $c.m` prints `1` twice (raku: once).
 - Intentionally excluded (decided not to do): default-param builtin-shadow single candidate
   (name-cache pollution risk; user policy) / `is encoded(...)` (NativeCall; zero practical harm) /
   `state` sharing across signature alternates (kept as an interpreter boundary).

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,34 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-15: `once` fires exactly once per clone (threads, repeated calls, methods)
+
+`once { ... }` broke in three independent ways (PLAN §3). Fixed across two PRs:
+
+- **Subs / closures / threads (#4567).** The site key was built from a global
+  compile-time counter, so a worker thread — which re-OTF-compiles the routine
+  into a fresh body — drew a different key and never matched a peer's fire; and
+  a named sub's second call took a fast/light call path that skipped the
+  clone-id setup, keying under the root scope and re-firing. The site key is now
+  the `OnceExpr` op's **bytecode position** (deterministic across recompiles),
+  the store is an `Arc`-shared `OnceStore` with a **claim/condvar** protocol
+  (fires once even under a genuine race — a thread re-entering its own
+  in-progress `once` is served `Nil` rather than deadlocking), and
+  `once`-bearing routines are kept off the fast/light paths via
+  `CompiledCode::has_once` so every call runs the same clone-id setup.
+- **Methods (this PR).** A method's `__mutsu_callable_id` is a fresh *per-call*
+  id, so a method's `once` had no stable clone key and re-fired every call.
+  `once_scope_key` now derives a method's clone key from the innermost routine
+  frame's `(owning class, method)` — stable per clone, and consulting the
+  *innermost* frame means a `once` in a closure nested in the method still keys
+  on that inner clone. This matches Rakudo: once total for a normal/inherited
+  method (the defining class's single clone), once per composing class for a
+  role method, and it leaves the per-call id recursive `return`-targeting relies
+  on untouched. `once` now also fires once across threads for methods.
+
+Pins: `t/once-clone-scope.t` (10 cases), `t/once-phaser.t` (12);
+`roast/S04-statements/once.t` stays whitelisted.
+
 ## 2026-07-15: module-file backtrace frames + Failure dual backtraces — error-reporting.t whitelisted
 
 The last two ④ items land and `integration/error-reporting.t` passes 33/33

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -366,18 +366,31 @@ impl Interpreter {
     /// `op_ip`. The key combines the enclosing code-object *clone* identity with
     /// the op position, so a `once` fires once per clone (Raku semantics):
     ///
-    /// - `__mutsu_callable_id` (set per-clone by the call dispatch) identifies a
-    ///   specific routine/closure clone and takes priority — this is what makes a
+    /// - Inside a **method**, the clone is identified by `(owning class, method)`
+    ///   — a stable, per-clone key (unlike the method's per-*call*
+    ///   `__mutsu_callable_id`, which is a fresh id every invocation). A method
+    ///   fires once per clone: once total for a normal/inherited method (the
+    ///   defining class's single clone), and once per composing class for a role
+    ///   method (`owner_class` is the composing class there). The innermost
+    ///   routine frame is consulted, so a `once` in a closure/sub *nested* in a
+    ///   method still keys on that inner clone, not the method's.
+    /// - Otherwise `__mutsu_callable_id` (set per-clone by the sub/closure call
+    ///   dispatch) identifies a specific routine/closure clone — this makes a
     ///   fresh `my sub` clone per loop iteration re-fire, and (being stable across
-    ///   a routine's OTF recompiles on worker threads) what makes a sub's `once`
-    ///   agree across threads.
+    ///   a routine's OTF recompiles on worker threads) makes a sub's `once` agree
+    ///   across threads.
     /// - Otherwise the innermost block/once scope (top-level / bare-block `once`).
     ///
-    /// The `c`/`r` tag keeps the two id spaces from colliding numerically, and
+    /// The `m`/`c`/`r` tag keeps the id spaces from colliding numerically, and
     /// `op_ip` is unique per `once` site within a single code object, so the key
     /// is collision-free. Unlike the old global compile-time counter it is
     /// deterministic across every recompilation of the same source.
     pub(crate) fn once_scope_key(&self, op_ip: usize) -> String {
+        if let Some(frame) = self.routine_stack.last()
+            && frame.is_method
+        {
+            return format!("m{}::{}::{op_ip}", frame.package, frame.name);
+        }
         match self.env.get("__mutsu_callable_id").map(Value::view) {
             Some(ValueView::Int(id)) if id >= 0 => format!("c{id}::{op_ip}"),
             _ => format!(

--- a/t/once-clone-scope.t
+++ b/t/once-clone-scope.t
@@ -10,7 +10,7 @@ use Test;
 #  * a fresh `my sub` clone per loop iteration re-fires (clone identity, not
 #    just the source site, drives the key).
 
-plan 5;
+plan 10;
 
 # 1. Named sub called many times: exactly one fire.
 {
@@ -52,4 +52,52 @@ plan 5;
 {
     sub v() { my $x = once { 7 }; $x }
     is v() + v(), 14, 'once rvalue value is cached and reused';
+}
+
+# 6. once in a method fires once per clone (once total for a normal method,
+#    across instances and repeated calls) — the clone key is (class, method),
+#    not the method's per-call callable id.
+{
+    my $n = 0;
+    my class C { method m() { once { $n++ } } }
+    my $a = C.new; my $b = C.new;
+    $a.m; $a.m; $b.m; $b.m;
+    is $n, 1, 'once in a method fires once across instances and calls';
+}
+
+# 7. A role method fires once per composing class (a distinct clone each).
+{
+    my @log;
+    my role Loud { method shout() { once { @log.push: self.^name } } }
+    my class D does Loud {}
+    my class E does Loud {}
+    my $d = D.new; my $e = E.new;
+    $d.shout; $d.shout; $e.shout; $e.shout;
+    is-deeply @log.sort.List, ('D', 'E'), 'role method once fires once per composing class';
+}
+
+# 8. Two once-bearing methods in one class keep independent state.
+{
+    my @log;
+    my class F { method a() { once { @log.push: 'a' } }; method b() { once { @log.push: 'b' } } }
+    my $f = F.new;
+    $f.a; $f.a; $f.b; $f.b;
+    is-deeply @log, ['a', 'b'], 'distinct methods have independent once state';
+}
+
+# 9. A closure created per-iteration inside a once-method keeps its own per-clone
+#    once state (the method's clone key must not leak into the nested closure).
+{
+    my $method-fires = 0;
+    my $closure-fires = 0;
+    my class G {
+        method go() {
+            once { $method-fires++ }
+            for ^3 { my &c = { once { $closure-fires++ } }; c(); c(); }
+        }
+    }
+    my $g = G.new;
+    $g.go; $g.go;
+    is $method-fires, 1, 'method once fires once even when it wraps nested closures';
+    is $closure-fires, 6, 'nested per-iteration closure once fires once per clone';
 }


### PR DESCRIPTION
## Summary

Follow-up to #4567. A `once { ... }` in a **method** fired on every call:

```raku
class C { method m() { once { say 1 } } }
my $c = C.new;
$c.m; $c.m;   # was "1\n1", raku prints "1" once (now fixed)
```

The cause is a separate one from #4567: a method's `__mutsu_callable_id` — the value the `once` store keys its clone scope on — is a fresh `next_instance_id()` generated **per invocation**, not a per-clone id, so a method's `once` never had a stable key.

## Fix

`once_scope_key` now derives a method's clone key from the **innermost routine frame's `(owning class, method)`** instead of `__mutsu_callable_id`. That identity is stable across calls and threads, and both method dispatch bodies already push it (`push_method_routine_with_location`) before running the body.

Consulting the **innermost** frame is what keeps a `once` in a closure nested inside the method keyed on that inner closure clone (the closure pushes an `is_method: false` block frame) — so the method's key does not leak into it.

This matches Rakudo's once-per-clone semantics:
- normal / inherited method → once total (the defining class's single clone);
- role method → once per composing class (`owner_class` is the composing class);
- recursive method → once, and the per-call id its `return`-targeting relies on is left untouched (no change to `__mutsu_callable_id`).

`once` in a method now also fires once **across threads** (the frame-derived key is identical on every worker; the store is already `Arc`-shared).

## Testing

Extends `t/once-clone-scope.t` from 5 → 10 cases (basic method across instances/calls, role-per-composing-class, distinct methods collision-safe, method-wrapping-nested-closures non-leak — all verified against `raku`). `make test` green; clippy/fmt clean. Closes the last `once` item in PLAN §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)