### PR TITLE
perf: single-candidate fast return in method resolution + gate the merge-path alias scan

### DIFF
--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -132,6 +132,32 @@ impl Interpreter {
                 // Check if all overloads are submethods on an ancestor class
                 let all_submethods = overloads.iter().all(|d| d.is_my);
                 let is_ancestor = cn != class_name;
+                // Single-visible-candidate fast return: with exactly one visible
+                // non-multi candidate (and no multi collected from a more-derived
+                // class), the outcome is invariant to the speculative argument
+                // match — a successful match returns this def, and a failed match
+                // falls through to the same def via `first_visible_non_multi`.
+                // Skip the match (env snapshot + speculative binding) entirely.
+                // Excluded: params carrying a `where` clause (user code whose
+                // dynamic-variable writes are observable side effects of the
+                // match), a type constraint (a subset's predicate is user code
+                // too), or a sub-signature. This is the hot shape of every
+                // BUILD/TWEAK construction dispatch.
+                if !any_multi && all_matches.is_empty() {
+                    let mut visible = overloads
+                        .iter()
+                        .filter(|d| !(d.is_private || (d.is_my && is_ancestor)));
+                    if let Some(only) = visible.next()
+                        && visible.next().is_none()
+                        && only.param_defs.iter().all(|pd| {
+                            pd.where_constraint.is_none()
+                                && pd.type_constraint.is_none()
+                                && pd.sub_signature.is_none()
+                        })
+                    {
+                        return Some((cn.clone(), only.clone()));
+                    }
+                }
                 for def in overloads {
                     if def.is_private {
                         continue;

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -102,6 +102,16 @@ impl Interpreter {
             && !cc.has_env_writes
             && !cc.has_calls;
 
+        // Whether any sigilless-attribute alias metadata is present. Computed
+        // once: the fast-path gate below needs it, and the merge path's
+        // `is_method_local` predicate uses it to skip the per-env-key
+        // `attr_alias_local` scan over ALL attributes (O(env keys x attrs) on
+        // every full-path method exit) in the overwhelmingly common no-alias
+        // case.
+        let has_attr_aliases = attributes
+            .keys()
+            .any(|k| k.starts_with(ATTR_ALIAS_META_PREFIX));
+
         // Fast path: bypass env entirely and populate locals directly from
         // source data. Avoids the ~12μs Arc::make_mut deep clone that the
         // first env_mut() call triggers.
@@ -110,9 +120,6 @@ impl Interpreter {
                 (pd.is_invocant || pd.traits.iter().any(|t| t == "invocant"))
                     && pd.type_constraint.is_some()
             });
-            let has_attr_aliases = attributes
-                .keys()
-                .any(|k| k.starts_with(ATTR_ALIAS_META_PREFIX));
             let has_role_bindings = self.class_role_param_bindings(owner_class).is_some()
                 || self
                     .class_role_param_bindings(receiver_class_name)
@@ -701,7 +708,7 @@ impl Interpreter {
                     || cc.locals.iter().any(|l| !l.is_empty() && l == s)
                     || cc.env_only_decls.iter().any(|n| n == s)
                     || attr_twigil_local(&attributes, s)
-                    || attr_alias_local(&attributes, s)
+                    || (has_attr_aliases && attr_alias_local(&attributes, s))
             };
             let rw_writeback: Vec<(String, Value)> = rw_bindings
                 .iter()


### PR DESCRIPTION
## Summary

Two dispatch-path cuts, both hot on the construction path (bless/BUILD/TWEAK run through the slow-path resolver on every instantiation — TWEAK resolves 10000 times in `benchmarks/bench-ctor.raku`). Follow-up to #4569 in the [mzef populate perf campaign](https://github.com/tokuhirom/mutsu/pull/4557).

### 1. Single-visible-candidate fast return (`resolve_method_with_owner_impl`)

With exactly one visible non-multi candidate (and no multi candidate collected from a more-derived MRO class), the resolution outcome is **invariant to the speculative argument match**: a successful match returns that def (the non-multi early return), and a failed match falls through to the very same def via `first_visible_non_multi`. So return it directly and skip `method_args_match_for_invocant` (env snapshot + speculative binding) entirely.

Conservatively excluded from the fast return:
- params with a `where` clause — user code whose dynamic-variable writes are observable side effects of the match (A01-limits/misc.t),
- params with any type constraint — a subset's predicate is user code too,
- params with a sub-signature.

### 2. Gate the merge-path alias scan (`call_compiled_method`)

The merge-path `is_method_local` predicate ran `attr_alias_local` — a scan over **all** attributes — for every merged env key (O(env keys × attrs) per full-path method exit; 1.6% of the ctor flat profile), even though `__mutsu_attr_alias::` metadata only exists for classes with sigilless attributes. The `has_attr_aliases` probe already existed inside the fast-path block; hoist it above and gate the scan on it.

## Measurements (local, release, pinned core, `perf stat -r 5`)

| bench | before (b3d17fd0) | after | delta |
|---|---|---|---|
| bench-ctor.raku | 0.360s | 0.330s | **-8.4%** |
| fez populate (tmp bench, 1 run) | 6.26s | 6.26s | ±0 (alloc/env-churn dominated) |

Behavior is unchanged: the fast return picks the identical candidate the full path would, and the alias scan can only match when alias metadata exists.

## Testing

- `make test` — 1725 files / 16967 tests, all PASS
- All 124 whitelisted S12/S14 roast files (2407 tests) PASS
- Targeted: `roast/S12-methods/{defer-next,multi,submethods}.t`, `roast/S12-construction/{BUILD,new,TWEAK,construction,destruction,roles-6e,named-params-in-BUILD}.t`, `roast/S14-roles/{submethods-6e,composition}.t`, `roast/S32-exceptions/misc.t`, `t/{accessor-mro-shadowing,submethod-defer,bless-native-fork,wrap,placeholder}.t`

🤖 Generated with [Claude Code](https://claude.com/claude-code)