### PR TITLE
fix: private-attribute read on a wrong-class invocant throws (P6opaque parity)

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -48,7 +48,7 @@ Definitions of the classifications:
 
 ## Current assumptions
 
-- The whitelist stands at **1411 / 1463** (2026-07-15, `wc -l roast-whitelist.txt`) = **52** files not whitelisted.
+- The whitelist stands at **1412 / 1463** (2026-07-15, `wc -l roast-whitelist.txt`) = **51** files not whitelisted.
 - **The S\* files (per-synopsis feature tests) are exhausted.** All of the former large campaigns
   (true lazy arrays / desugaring of dispatch and operator sugar / S17 concurrency & async /
   first-class-container container identity / cross-thread lexical writeback) are complete, and
@@ -71,7 +71,6 @@ noted.
 
 | File | mutsu | raku | Blocker / note |
 |---|---|---|---|
-| `integration/weird-errors.t` | 35/36 | PASS ★ | **④ error-message quality.** Remaining 1 = test 29: `&B114672::foo(A114672.new)` where `our method foo(A114672:)` reads `$!x` must THROW (rakudo: P6opaque no-such-attribute on the wrong-class invocant); mutsu reads the missing `!x` env key as Nil. Needs "private-attr read on an instance whose class does not carry the attribute throws" — touches attr seeding in `call_compiled_method`, deferred as its own slice. Tests 11/20/32/33 fixed 2026-07-15: `:[...]` itemized-array colonpair + leading-`;` LoL argument slices (`say(;:[])` prints `()([])` like rakudo), `::lowercase` → runtime symbol lookup (X::NoSuchSymbol), indirect object notation `new Foo: args`, `hash` listop. Pin: t/weird-errors-parse-forms.t |
 | `integration/advent2012-day15.t` | 9/11 | PASS ★ | statement-form phasers create their own scope (`$best` in `NEXT (state $best) max= $_;` is not visible from `LAST`) / `INIT` runs after the mainline |
 | `integration/99problems-21-to-30.t` | aborts at 6/15 | PASS ★ | not yet root-caused (post-#4510/#4516 re-measure) |
 | `integration/99problems-31-to-40.t` | aborts at 44/67 | PASS ★ | not yet root-caused |
@@ -112,7 +111,7 @@ noted.
 | No oracle | `S02-types/array-shapes.t` | aborts at 35/43 | 38/43 (raku also aborts; same on v2026.06) | shaped array `.pairs`' `.value` does not return a writable container |
 | No oracle | `S05-metasyntax/longest-alternative.t` | 57/62, notok 5 | SORRY (`::` LTM stopper NYI) | LTM (longest-token-match) tie-break edge. Still SORRY on v2026.06 because rakudo has not implemented `::` |
 | No oracle | `S10-packages/basic.t` | 59/83, notok 9 | 6/83 (mutsu ahead; same on v2026.06) | Error-detection edges for the semicolon form of package declarations |
-| No oracle | `S12-attributes/trusts.t` | 9/15, notok 6 | SORRY (forward reference `trusts B`) | Cross-class private access via `trusts` unsupported. Still SORRY on v2026.06 |
+| No oracle | `S12-attributes/trusts.t` | 9/15, notok 4-9 | SORRY (forward reference `trusts B`) | Cross-class private access via `trusts` unsupported. Still SORRY on v2026.06. Failing set shifted 2026-07-15 (private-attr wrong-class throw): tests 4-9 read `$!an_A` which class B never declares (throws now, matching rakudo semantics — likely a typo for the lexical `$an_A` in the test), while the class-C "untrusted access dies" tests now pass |
 | No oracle | `S19-command-line-options/01-dash-uppercase-i.t` | 0/8 | 0/8 (`$*OS` unsupported; same on v2026.06) | `-I` + `@*INC` + `$*OS` introspection (is_run subprocess) |
 | No oracle | `S32-basics/xxPOS.t` | aborts at 11/64 | 53/64 (raku also aborts; same on v2026.06) | Aborts from test 12 onward due to deep features |
 | Non-goal | `S05-capture/hash.t` | rejected (matches raku) | SORRY (removed) | Hash captures in regexes `%<name>=(...)` are removed/reserved in the current spec. mutsu also gives a compile error, matching raku = **no implementation needed** |
@@ -211,9 +210,10 @@ completed fix history lives in `news/`.
 1. **Shortcuts**: `6.c/S04-declarations/my-6c.t` needs only the single `OUTER::<$x>` subtest
    (111/112). `integration/99problems-51-to-60.t` (35/37) and `99problems-61-to-70.t` (12/15)
    are close.
-2. **④ error-message quality** (`error-reporting.t` 28/33, `weird-errors.t` 31/36,
-   `advent2011-day11.t` 7/9, `multi-no-match.t` 11/16) — the same target as the identically
-   named task in PLAN §6, so it can be driven by roast pass/fail while working on that.
+2. **④ error-message quality** (`advent2011-day11.t` 7/9, `multi-no-match.t` 11/16) — the
+   same target as the identically named task in PLAN §6, so it can be driven by roast
+   pass/fail while working on that. (`error-reporting.t` and `weird-errors.t` reached the
+   whitelist 2026-07-15.)
 3. **The 11 not-yet-root-caused `integration/` aborts** (see inventory) — history says one root
    cause usually spans several files; re-run and diff against raku before picking features.
 4. `6.c/S14-roles/mixin-6c.t` (aborts at 16/57, raku full pass) — 6.c mixin semantics.

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -32,6 +32,20 @@ July carried forward the momentum from late June, advancing the dispatch cluster
 Pins: `t/once-clone-scope.t` (10 cases), `t/once-phaser.t` (12);
 `roast/S04-statements/once.t` stays whitelisted.
 
+## 2026-07-15: private-attr read on a wrong-class invocant throws — weird-errors.t whitelisted (36/36)
+
+Reading `$!x` inside a method whose concrete invocant's class neither carries
+the attribute in its instance cell nor declares it anywhere in its MRO now
+throws the rakudo-parity `P6opaque: no such attribute '$!x' on type ... in a
+... when trying to get a value` error instead of yielding Nil (weird-errors.t
+test 29: `our method foo(A114672:) { $!x }` called as `&B114672::foo(A114672.new)`).
+The check sits in the GetLocal Nil-fallback and after the GetGlobal cell-read
+miss (`missing_private_attr_read_error`), and is declaration-based — an
+attribute that is declared but merely unseeded still reads as Any, so no
+construction-order path can throw spuriously. Side effect: the class-C
+"untrusted access dies" tests of the no-oracle `S12-attributes/trusts.t` now
+pass (its failing set shifted; see BLOCKERS). Pin: t/private-attr-wrong-class.t.
+
 ## 2026-07-15: weird-errors.t 31/36 → 35/36 — four parse-form gaps closed
 
 Continuing the ★ list top-down. Four general parser/semantics fixes (each

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1408,4 +1408,5 @@ roast/integration/sequence.t
 roast/integration/substr-after-match-in-gather-in-for.t
 roast/integration/topic_in_double_loop.t
 roast/integration/variables-in-do.t
+roast/integration/weird-errors.t
 roast/t/test-util/01-is-eqv.t

--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -461,6 +461,19 @@ impl Interpreter {
         }
     }
 
+    /// Whether `class_name` (or any class in its MRO) declares an attribute
+    /// with the bare name `bare` (`"x"` for `$!x`/`$.x`). Used by the VM's
+    /// private-attribute read check: a read of an attribute that the invocant's
+    /// class neither carries nor declares throws (P6opaque no-such-attribute).
+    pub(crate) fn class_declares_attribute(&mut self, class_name: &str, bare: &str) -> bool {
+        self.class_mro(class_name).iter().any(|cn| {
+            self.registry()
+                .classes
+                .get(cn)
+                .is_some_and(|cd| cd.attributes.iter().any(|(n, ..)| n == bare))
+        })
+    }
+
     pub(super) fn collect_class_attributes(&mut self, class_name: &str) -> Vec<ClassAttributeDef> {
         let mro = self.class_mro(class_name);
         let mut attrs: Vec<ClassAttributeDef> = Vec::new();

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -239,6 +239,16 @@ impl Interpreter {
                     *ip += 1;
                     return Ok(());
                 }
+                // Rakudo parity: a private-attribute read on a concrete invocant
+                // whose class does not carry the attribute throws (P6opaque
+                // no-such-attribute) instead of yielding Nil.
+                if name.starts_with('!')
+                    && name.len() > 1
+                    && !name.starts_with("__")
+                    && let Some(err) = self.missing_private_attr_read_error(name)
+                {
+                    return Err(err);
+                }
                 // Fast scalar read (J4 helper hot path): the dominant GetGlobal
                 // shape is a plain env hit (topic `$_` reads in loop bodies,
                 // dynamic vars). Serve it through the memoized per-slot Symbol —

--- a/src/vm/vm_var_assign_computed_attr.rs
+++ b/src/vm/vm_var_assign_computed_attr.rs
@@ -199,6 +199,64 @@ impl Interpreter {
         map.get(key).cloned()
     }
 
+    /// The instance class `Symbol` and shared attribute cell for a `self` value,
+    /// unwrapping a `Mixin` like [`Self::self_instance_attrs`]. `None` for a
+    /// type object / non-instance.
+    fn instance_class_and_attrs(
+        val: &Value,
+    ) -> Option<(
+        crate::symbol::Symbol,
+        crate::gc::Gc<crate::value::InstanceAttrs>,
+    )> {
+        match val.view() {
+            ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } => Some((class_name, attributes.clone())),
+            ValueView::Mixin(inner, _) => Self::instance_class_and_attrs(inner),
+            _ => None,
+        }
+    }
+
+    /// Rakudo parity (weird-errors.t test 29): reading a private attribute
+    /// (`$!x`) on a concrete invocant whose class neither carries the attribute
+    /// in its cell nor declares it anywhere in its MRO throws the P6opaque
+    /// no-such-attribute error instead of yielding Nil — e.g. an
+    /// `our method foo(Parent:)` reading a Child-only `$!x`, called with a
+    /// Parent instance. `None` when the read may legally fall through: no
+    /// `self` in scope, a type-object invocant, the attribute present in the
+    /// cell, or declared on the instance's class (a seeding gap must not turn
+    /// into a spurious throw).
+    pub(super) fn missing_private_attr_read_error(&mut self, name: &str) -> Option<RuntimeError> {
+        let (bare, is_private) = Self::attr_twigil_base(name)?;
+        if !is_private {
+            return None;
+        }
+        let self_val = self.get_env_with_main_alias("self")?;
+        let (class_sym, attributes) = Self::instance_class_and_attrs(&self_val)?;
+        {
+            let map = attributes.as_map();
+            if self
+                .attr_key_in_map(crate::symbol::Symbol::intern(bare), true, &map)
+                .is_some()
+            {
+                return None;
+            }
+        }
+        let class_name = class_sym.as_str();
+        if self.class_declares_attribute(class_name, bare) {
+            return None;
+        }
+        let owner = self
+            .method_class_stack_top_str()
+            .unwrap_or(class_name)
+            .to_string();
+        Some(RuntimeError::new(format!(
+            "P6opaque: no such attribute '$!{bare}' on type {owner} in a {class_name} when trying to get a value"
+        )))
+    }
+
     /// Map a variable name to its canonical attribute-twigil form for cell access:
     /// a direct twigil (`!x`/`@.y`/…) maps to itself; a bare sigilless name
     /// (`has $x` → `Var("x")`) resolves through the runtime alias table to its

--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -212,6 +212,12 @@ impl Interpreter {
             // in the env (when skip_env_setup is active) but are still valid.
             let is_private_attr =
                 name.starts_with('!') && name.len() > 1 && !name.starts_with("__");
+            // Rakudo parity: a private-attribute read on a concrete invocant
+            // whose class does not carry the attribute throws (P6opaque
+            // no-such-attribute) instead of yielding Nil.
+            if is_private_attr && let Some(err) = self.missing_private_attr_read_error(name) {
+                return Err(err);
+            }
             if !is_internal && !is_special && !is_private_attr && !self.env().contains_key(name) {
                 return Err(RuntimeError::new(format!(
                     "X::Undeclared::Symbols: Variable '{name}' is not declared"

--- a/t/private-attr-wrong-class.t
+++ b/t/private-attr-wrong-class.t
@@ -1,0 +1,46 @@
+use v6;
+use Test;
+
+# Reading a private attribute on a concrete invocant whose class does not
+# carry the attribute must throw (rakudo: P6opaque no-such-attribute), not
+# yield Nil. roast/integration/weird-errors.t test 29 (old-issue-tracker #2879).
+
+plan 6;
+
+class A114672 {};
+class B114672 is A114672 {
+    has $!x = 5;
+    our method foo(A114672:) { $!x }
+};
+class C114672 is B114672 {};
+
+throws-like { &B114672::foo(A114672.new) }, Exception,
+    message => /'no such attribute'/,
+    'private attr read on an instance of a class without the attribute throws';
+
+is &B114672::foo(B114672.new), 5, 'exact-class invocant still reads the attribute';
+is &B114672::foo(C114672.new), 5, 'subclass instance reads the inherited attribute';
+
+# Normal method dispatch is unaffected.
+class WithAttr {
+    has $!y = 42;
+    method get-y() { $!y }
+}
+is WithAttr.new.get-y, 42, 'normal private attr read works';
+
+# An attribute assigned Nil still reads as Nil (present in the cell, no throw).
+class NilAttr {
+    has $!z;
+    method get-z() { $!z }
+}
+ok NilAttr.new.get-z === Any, 'declared-but-unset private attr reads as Any without throwing';
+
+# A closure inside the method reading the attribute also throws on a
+# wrong-class invocant (GetGlobal read path).
+class B2 is A114672 {
+    has $!w = 7;
+    our method bar(A114672:) { my $c = { $!w }; $c() }
+};
+throws-like { &B2::bar(A114672.new) }, Exception,
+    message => /'no such attribute'/,
+    'closure-captured private attr read on wrong-class invocant throws';


### PR DESCRIPTION
## Summary

Reading `$!x` inside a method whose concrete invocant's class neither carries the attribute in its instance cell nor declares it anywhere in its MRO now throws the rakudo-parity `P6opaque: no such attribute '$!x' on type ... in a ... when trying to get a value` error instead of yielding Nil.

This closes the last failing subtest (29) of `roast/integration/weird-errors.t` — `our method foo(A114672:) { $!x }` called as `&B114672::foo(A114672.new)` must die (old-issue-tracker #2879) — and the file reaches the whitelist at 36/36.

## Implementation

- `missing_private_attr_read_error` (vm_var_assign_computed_attr.rs): fires only when the name is a private attr twigil, `self` is a concrete instance (Mixin-unwrapped), the attribute is absent from the cell, **and** undeclared anywhere on the instance's MRO. Declaration-based gating means a declared-but-merely-unseeded attribute still reads as Any, so no construction-order path can throw spuriously.
- Hooked into the `GetLocal` Nil-fallback (the roast case) and after the `GetGlobal` cell-read miss (closure-captured `$!x` reads).
- `class_declares_attribute` added to runtime class introspection (`ClassDef.attributes` is private to the runtime module).

## Side effects

The no-oracle `S12-attributes/trusts.t` (raku: SORRY, not whitelisted) failing set shifted: tests 4-9 read `$!an_A`, an attribute class B never declares (likely a test typo for the lexical `$an_A`) — they now throw, matching rakudo semantics — while the class-C "untrusted access dies" tests now pass. Net 9/15 as before; BLOCKERS row updated.

## Testing

- `t/private-attr-wrong-class.t` (new pin): wrong-class throw, exact-class and subclass positive controls, declared-but-unset reads as Any, closure-read throw.
- `MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/integration/weird-errors.t` → 36/36 PASS.
- All 124 whitelisted S12-*/S14-* roast files PASS locally; `make test` (1727 files) PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)