### PR TITLE
fix: attribute writes reach the instance after binding self to an outer variable

### DIFF
--- a/src/vm/vm_var_assign_computed_attr.rs
+++ b/src/vm/vm_var_assign_computed_attr.rs
@@ -143,14 +143,22 @@ impl Interpreter {
     /// `Mixin` (runtime `$obj does Role`) to the wrapped instance. The
     /// Mixin's inner value is held in a shared `Arc`, and the instance's own cell is
     /// an `Arc<RwLock>` — so a write through this reference persists back to the
-    /// caller's Mixin (it shares the same inner instance). Returns `None` for a
-    /// type object / non-instance.
+    /// caller's Mixin (it shares the same inner instance). A `ContainerRef` is read
+    /// through: `$outer := self` rewrites the frame's `self` into the bind's shared
+    /// cell, and attribute writes after that bind must still reach the instance
+    /// (t/bind-self-attr-write.t). Returns `None` for a type object / non-instance.
     pub(crate) fn self_instance_attrs(
         val: &Value,
     ) -> Option<crate::gc::Gc<crate::value::InstanceAttrs>> {
         match val.view() {
             ValueView::Instance { attributes, .. } => Some(attributes.clone()),
             ValueView::Mixin(inner, _) => Self::self_instance_attrs(inner),
+            ValueView::ContainerRef(_) => val.with_deref(|inner| {
+                // The deref'd borrow is a different value than `val` (the lock
+                // guard's target), so this recursion terminates: a cell holding
+                // another cell unwraps one level per call.
+                Self::self_instance_attrs(inner)
+            }),
             _ => None,
         }
     }

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -147,10 +147,11 @@ impl Interpreter {
         if local_name.starts_with('!')
             && local_name.len() > 1
             && let Some(self_val) = self.get_env_with_main_alias("self")
-            && !matches!(
-                self_val.view(),
-                ValueView::Instance { .. } | ValueView::Mixin(..)
-            )
+            // Read through a ContainerRef: `$outer := self` rewrites the frame's
+            // `self` into the bind's shared cell, but it still holds the instance.
+            && !self_val.with_deref(|v| {
+                matches!(v.view(), ValueView::Instance { .. } | ValueView::Mixin(..))
+            })
         {
             // self is a type object - determine class name for error message
             let class_name = match self_val.view() {

--- a/t/bind-self-attr-write.t
+++ b/t/bind-self-attr-write.t
@@ -1,0 +1,62 @@
+use v6;
+use Test;
+
+# Binding `self` to an outer variable (`$outer := self`) rewrites the frame's
+# `self` entry into the bind's shared ContainerRef cell. The attribute WRITE
+# paths (the `$!x = ...` type-object guard and the shared-cell resolution in
+# `self_instance_attrs`) matched only Instance/Mixin, so after such a bind a
+# scalar attribute assignment died with "Cannot look up attributes in a C type
+# object" and an array attribute `.push` was silently lost from the instance
+# (reads kept working — they resolve through the local slot). All expectations
+# verified against raku.
+
+plan 7;
+
+my $s1;
+class ScalarWrite {
+    has $.x;
+    method m() { $s1 := self; $!x = 5; }
+}
+my $sw = ScalarWrite.new(x => 1);
+lives-ok { $sw.m }, 'attribute assignment after `$outer := self` does not die';
+is $sw.x, 5, 'the assignment reaches the instance';
+
+my $s2;
+class TweakPush {
+    has @.items;
+    submethod TWEAK() { $s2 := self; @!items.push("t"); }
+}
+is TweakPush.new.items.elems, 1, 'array attr .push after `:= self` in TWEAK reaches the instance';
+
+my $s3;
+class MethodPush {
+    has @.items;
+    method m() { $s3 := self; @!items.push("t"); }
+}
+my $mp = MethodPush.new;
+$mp.m;
+is $mp.items.elems, 1, 'array attr .push after `:= self` in a plain method reaches the instance';
+is $s3.items.elems, 1, 'the bound alias sees the push too';
+
+my $s4;
+class Mixed {
+    has $.a;
+    has $.b;
+    method m() { $s4 := self; $!a = "A"; $!b = "B"; }
+}
+my $mx = Mixed.new;
+$mx.m;
+is "{$mx.a}{$mx.b}", "AB", 'multiple attribute writes after the bind all land';
+
+# With the constructed-object identity fix (BUILD/TWEAK run against the object
+# `.new` returns), a `:=`-stored self alias tracks post-construction mutations.
+my $s5;
+class StoredAlias {
+    has $.x is rw;
+    submethod TWEAK() { $s5 := self; }
+}
+my $sa = StoredAlias.new(x => 1);
+$sa.x = 9;
+is $s5.x, 9, 'a `:=`-stored self alias from TWEAK sees post-construction mutations';
+
+done-testing;


### PR DESCRIPTION
## Summary

`$outer := self` rewrites the frame's `self` entry into the bind's shared `ContainerRef` cell. The attribute **write** paths matched only `Instance`/`Mixin` on `self`, so after such a bind:

- a scalar attribute assignment (`$!x = 5`) died with *"Cannot look up attributes in a C type object. Did you forget a '.new'?"* — the type-object guard in `exec_set_local_op_inner` saw a `ContainerRef`, not an `Instance`;
- an array/hash attribute mutation (`@!items.push`) was **silently lost** from the instance — `self_instance_attrs` returned `None`, so the per-op cell mirror had no cell to write to (reads kept working: they resolve through the local slot).

```raku
my $s;
class C {
    has @.items;
    submethod TWEAK() { $s := self; @!items.push("t"); }
}
say C.new.items.elems;   # raku: 1   mutsu(before): 0

class D {
    has $.x;
    method m() { $s := self; $!x = 5 }   # mutsu(before): dies "Cannot look up attributes in a D type object"
}
```

## Change

Read through the `ContainerRef` in both places:
- `self_instance_attrs` unwraps a `ContainerRef` level (alongside the existing `Mixin` unwrap) — this restores the shared-cell resolution for every attribute op;
- the type-object guard in `exec_set_local_op_inner` checks the deref'd view.

Found while pinning #4573 (constructed-object identity): the `:=`-stored-self case dropped an array push. The initial reconcile-false-positive theory in that PR's pin-test comment was wrong — the actual cause is this self-entry rewrite; this PR's pin also covers the `:=`-stored alias tracking post-construction mutations (which needs #4573's identity fix, now in main).

## Testing

- New pin: `t/bind-self-attr-write.t` (7 cases, verified against raku)
- `make test` — all PASS (0 failures)
- All 124 whitelisted S12/S14 roast files (2407 tests) PASS
- ContainerRef-sensitive locals: `t/wrap.t`, `t/lock.t`, `t/state-aggregate-shared-cell.t` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)