### PR TITLE
fix: statement-form loop phasers share the enclosing scope; sub-body INIT lifts to init time

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -48,7 +48,7 @@ Definitions of the classifications:
 
 ## Current assumptions
 
-- The whitelist stands at **1412 / 1463** (2026-07-15, `wc -l roast-whitelist.txt`) = **51** files not whitelisted.
+- The whitelist stands at **1413 / 1463** (2026-07-15, `wc -l roast-whitelist.txt`) = **50** files not whitelisted.
 - **The S\* files (per-synopsis feature tests) are exhausted.** All of the former large campaigns
   (true lazy arrays / desugaring of dispatch and operator sugar / S17 concurrency & async /
   first-class-container container identity / cross-thread lexical writeback) are complete, and
@@ -71,7 +71,6 @@ noted.
 
 | File | mutsu | raku | Blocker / note |
 |---|---|---|---|
-| `integration/advent2012-day15.t` | 9/11 | PASS ★ | statement-form phasers create their own scope (`$best` in `NEXT (state $best) max= $_;` is not visible from `LAST`) / `INIT` runs after the mainline |
 | `integration/99problems-21-to-30.t` | aborts at 6/15 | PASS ★ | not yet root-caused (post-#4510/#4516 re-measure) |
 | `integration/99problems-31-to-40.t` | aborts at 44/67 | PASS ★ | not yet root-caused |
 | `integration/99problems-41-to-50.t` | fails | PASS ★ | P47 needs parameterized `multi rule expr($p)` (grammar rules taking arguments); P41/P46 fixed in #4510 |

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -32,6 +32,28 @@ July carried forward the momentum from late June, advancing the dispatch cluster
 Pins: `t/once-clone-scope.t` (10 cases), `t/once-phaser.t` (12);
 `roast/S04-statements/once.t` stays whitelisted.
 
+## 2026-07-15: statement-form loop-phaser scope + sub-body INIT lifting — advent2012-day15.t whitelisted (11/11)
+
+Three fixes, one per layer:
+
+- **Statement-form loop phasers share the enclosing block's scope** (rakudo
+  semantics): `NEXT (state $best) max= $score;` declares `$best` where the
+  loop body can see it, so `LAST say "BEST: $best"` works. The parser marks
+  the statement form as `[SyntheticBlock([stmt])]` (block form keeps its own
+  `Stmt::Block` scope in `expand_loop_phasers`); the phaser-reorder pass
+  preserves the marker instead of flattening it.
+- **INIT/CHECK inside a named sub body are program-init-time**: the phaser
+  lift now recurses into `Stmt::SubDecl` bodies, so `my $fh = INIT Open(...)`
+  calls Open before the mainline runs (and memoizes the value for call time).
+- **The I/O ops no longer seed not-yet-declared locals into env**: Say/Put/
+  Print/Note's pre-sync (`sync_env_from_locals_declared`) skips slots whose
+  name is absent from env — a premature seed made a later `state` declaration
+  in the same loop body record itself as a "shadowed outer binding", and the
+  loop-local restore wiped the variable at loop exit (the same guard the
+  regex-interpolation sync already had).
+
+Pin: t/phaser-stmt-form-scope.t.
+
 ## 2026-07-15: private-attr read on a wrong-class invocant throws — weird-errors.t whitelisted (36/36)
 
 Reading `$!x` inside a method whose concrete invocant's class neither carries

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1361,6 +1361,7 @@ roast/integration/advent2012-day06.t
 roast/integration/advent2012-day10.t
 roast/integration/advent2012-day12.t
 roast/integration/advent2012-day13.t
+roast/integration/advent2012-day15.t
 roast/integration/advent2012-day16.t
 roast/integration/advent2012-day19.t
 roast/integration/advent2012-day20.t

--- a/src/compiler/helpers_phasers.rs
+++ b/src/compiler/helpers_phasers.rs
@@ -33,6 +33,17 @@ impl Compiler {
         })
     }
 
+    /// The body of a FIRST/NEXT/LAST phaser as a single statement. A
+    /// statement-form phaser (parsed as `[SyntheticBlock([stmt])]`) shares the
+    /// enclosing block's lexical scope, so it is spliced in scope-less; a
+    /// block-form phaser gets its own `Stmt::Block` scope.
+    fn loop_phaser_body(body: &[Stmt]) -> Stmt {
+        match body {
+            [stmt @ Stmt::SyntheticBlock(_)] => stmt.clone(),
+            _ => Stmt::Block(body.to_vec()),
+        }
+    }
+
     fn next_targets_current_loop(
         next_label: &Option<String>,
         current_loop_label: Option<&str>,
@@ -230,9 +241,9 @@ impl Compiler {
                     PhaserKind::Leave => leave_ph.push(Stmt::Block(body.clone())),
                     PhaserKind::Keep => keep_ph.push(Stmt::Block(body.clone())),
                     PhaserKind::Undo => undo_ph.push(Stmt::Block(body.clone())),
-                    PhaserKind::First => first_ph.push(Stmt::Block(body.clone())),
-                    PhaserKind::Next => next_ph.push(Stmt::Block(body.clone())),
-                    PhaserKind::Last => last_ph.push(Stmt::Block(body.clone())),
+                    PhaserKind::First => first_ph.push(Self::loop_phaser_body(body)),
+                    PhaserKind::Next => next_ph.push(Self::loop_phaser_body(body)),
+                    PhaserKind::Last => last_ph.push(Self::loop_phaser_body(body)),
                     PhaserKind::Pre => pre_ph.push(stmt.clone()),
                     PhaserKind::Post => post_ph.push(stmt.clone()),
                     _ => body_main.push(stmt.clone()),

--- a/src/parser/stmt/simple/control_stmts.rs
+++ b/src/parser/stmt/simple/control_stmts.rs
@@ -214,7 +214,21 @@ pub(crate) fn phaser_stmt(input: &str) -> PResult<'_, Stmt> {
         block(rest)?
     } else {
         let (r, s) = statement(rest)?;
-        (r, vec![s])
+        // A statement-form LOOP phaser shares the enclosing block's lexical
+        // scope: `NEXT (state $best) max= $_;` declares `$best` in the loop
+        // body, visible to a `LAST` in the same block (advent2012-day15.t).
+        // Mark the form by wrapping in SyntheticBlock (which compiles
+        // scope-less); `expand_loop_phasers` splices it inline instead of
+        // wrapping it in a scoped Block. Other phaser kinds keep the plain
+        // single-statement body (their consumers pattern-match its shape).
+        if matches!(
+            kind,
+            PhaserKind::First | PhaserKind::Next | PhaserKind::Last
+        ) {
+            (r, vec![Stmt::SyntheticBlock(vec![s])])
+        } else {
+            (r, vec![s])
+        }
     };
     // `BEGIN $*RAKU.version` (and `$*PERL.version`) is a compile-time constant
     // equal to the language version of the current compilation unit. The parser

--- a/src/runtime/phasers.rs
+++ b/src/runtime/phasers.rs
@@ -264,6 +264,13 @@ fn lift_phasers_from_stmt(
         Stmt::Label { stmt: inner, .. } => {
             lift_phasers_from_stmt(inner, begin, check, init);
         }
+        // INIT/CHECK inside a named sub body run at program init/check time,
+        // not at first call (advent2012-day15.t: `my $fh = INIT Open(...)`
+        // must call Open before the mainline runs). The lifted DoBlock is
+        // assigned to a shared temp read by the sub body at call time.
+        Stmt::SubDecl { body, .. } => {
+            lift_phasers_from_closure_stmts(body, begin, check, init);
+        }
         _ => {}
     }
 }
@@ -643,6 +650,11 @@ fn lift_phasers_from_closure_stmt(
         Stmt::Label { stmt: inner, .. } => {
             lift_phasers_from_closure_stmt(inner, begin, check, init);
         }
+        // See the SubDecl arm of lift_phasers_from_stmt: sub-body INIT/CHECK
+        // are program-init-time, wherever the sub is declared.
+        Stmt::SubDecl { body, .. } => {
+            lift_phasers_from_closure_stmts(body, begin, check, init);
+        }
         Stmt::Call { args, .. } => {
             for arg in args.iter_mut() {
                 match arg {
@@ -943,8 +955,21 @@ fn recurse_into_stmt(stmt: &mut Stmt) {
         | Stmt::Package { body, .. } => {
             reorder_recursive(body, false);
         }
-        Stmt::Phaser { body, .. } => {
-            reorder_recursive(body, false);
+        Stmt::Phaser { kind, body } => {
+            // A statement-form loop phaser is marked as `[SyntheticBlock([stmt])]`
+            // (see phaser_stmt): it shares the enclosing block's lexical scope,
+            // and `expand_loop_phasers` reads the marker to splice it scope-less.
+            // Flattening the marker here would silently downgrade it to the
+            // scoped block form, so recurse into the inner statements instead.
+            if matches!(
+                kind,
+                PhaserKind::First | PhaserKind::Next | PhaserKind::Last
+            ) && let [Stmt::SyntheticBlock(inner)] = body.as_mut_slice()
+            {
+                reorder_recursive(inner, false);
+            } else {
+                reorder_recursive(body, false);
+            }
         }
         Stmt::If {
             cond,

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -852,6 +852,33 @@ impl Interpreter {
         }
     }
 
+    /// Like [`Self::sync_env_from_locals`], but skips slots whose name was
+    /// never introduced into env — a compile-time-allocated local whose
+    /// declaration has not run yet (e.g. a `state $b` later in the same loop
+    /// body). Prematurely seeding env with such a name makes the declaration,
+    /// when it does run, mistake the seeded entry for a live outer binding and
+    /// record it for the loop-local shadow restore — which then wipes the
+    /// variable at loop exit (advent2012-day15 FIRST/NEXT/LAST state loss).
+    /// Mirrors the identical guard in
+    /// [`Self::sync_regex_interpolation_env_from_locals`].
+    ///
+    /// Used by the I/O ops (Say/Put/Print/Note), whose pre-sync exists so a
+    /// user `$*OUT` override / `.gist` method sees fresh values of *live*
+    /// variables: any name such an override can legitimately reach via env is
+    /// either already present in env (declared, captured, `our`, dynamic) or
+    /// forced there by the reflective-access flag — never slot-only.
+    pub(super) fn sync_env_from_locals_declared(&mut self, code: &CompiledCode) {
+        for (i, name) in code.locals.iter().enumerate() {
+            if code.dup_named_locals.get(i).copied().unwrap_or(false) {
+                continue;
+            }
+            if !self.env().contains_key(name) {
+                continue;
+            }
+            self.set_env_with_main_alias(name, self.locals[i].clone());
+        }
+    }
+
     pub(super) fn sync_regex_interpolation_env_from_locals(&mut self, code: &CompiledCode) {
         for (i, name) in code.locals.iter().enumerate() {
             if name == "_"

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2782,25 +2782,25 @@ impl Interpreter {
             // -- I/O --
             OpCode::Say(n) => {
                 self.sync_source_line(code, *ip);
-                self.sync_env_from_locals(code);
+                self.sync_env_from_locals_declared(code);
                 self.exec_say_op(*n)?;
                 *ip += 1;
             }
             OpCode::Put(n) => {
                 self.sync_source_line(code, *ip);
-                self.sync_env_from_locals(code);
+                self.sync_env_from_locals_declared(code);
                 self.exec_put_op(*n)?;
                 *ip += 1;
             }
             OpCode::Print(n) => {
                 self.sync_source_line(code, *ip);
-                self.sync_env_from_locals(code);
+                self.sync_env_from_locals_declared(code);
                 self.exec_print_op(*n)?;
                 *ip += 1;
             }
             OpCode::Note(n) => {
                 self.sync_source_line(code, *ip);
-                self.sync_env_from_locals(code);
+                self.sync_env_from_locals_declared(code);
                 self.exec_note_op(*n)?;
                 *ip += 1;
             }

--- a/t/phaser-stmt-form-scope.t
+++ b/t/phaser-stmt-form-scope.t
@@ -1,0 +1,50 @@
+use v6;
+use Test;
+
+# Statement-form loop phasers share the enclosing block's lexical scope:
+# a `state` declared by a statement-form NEXT is visible to a LAST in the
+# same block (roast/integration/advent2012-day15.t FIRST/NEXT/LAST example).
+# INIT inside a sub body runs at program init time, before the mainline.
+
+plan 4;
+
+# 1. NEXT-declared state readable from LAST (the advent2012-day15 shape).
+{
+    my $out = '';
+    for (3, 2, 42) -> $score {
+        FIRST $out ~= "first;";
+        NEXT (state $best) max= $score;
+        LAST $out ~= "best=$best";
+    }
+    is $out, 'first;best=42', 'statement-form NEXT state is visible to LAST';
+}
+
+# 2. A say before the state declaration must not wipe the variable at loop
+#    exit (the premature env-seed regression behind the same test).
+{
+    my $got;
+    for (3, 2, 42) {
+        if $_ > 2 { say "# progress $_"; }
+        (state $b) max= $_;
+        LAST $got = $b;
+    }
+    is $got, 42, 'say before a state decl does not wipe it at loop exit';
+}
+
+# 3. Block-form phaser bodies keep their own scope for my-declarations.
+{
+    my $x = 'outer';
+    for 1..2 {
+        NEXT { my $x = 'inner'; }
+    }
+    is $x, 'outer', 'block-form NEXT my-decl stays in its own scope';
+}
+
+# 4. INIT expression inside a sub runs before the mainline.
+our $mainline-ran;
+$mainline-ran = True;
+sub init-probe() {
+    my $snap = INIT $mainline-ran.defined;
+    return $snap;
+}
+is init-probe(), False, 'INIT expr in a sub body runs before the mainline';


### PR DESCRIPTION
## Summary

Whitelists `roast/integration/advent2012-day15.t` (11/11) with three fixes:

### 1. Statement-form loop phasers share the enclosing block's lexical scope

Rakudo semantics: `NEXT (state $best) max= $score;` (no braces) declares `$best` in the loop body's scope, visible to a `LAST` in the same block — while `NEXT { ... }` (block form) keeps its own scope. The parser marks the statement form as `[SyntheticBlock([stmt])]`; `expand_loop_phasers` splices that marker scope-less and wraps block-form bodies in `Stmt::Block` as before. The phaser-reorder pass (`recurse_into_stmt`) preserves the marker for FIRST/NEXT/LAST instead of flattening it.

### 2. INIT/CHECK inside a named sub body run at program init time

The phaser lift now recurses into `Stmt::SubDecl` bodies, so `my $fh = INIT Open(...)` calls `Open` before the mainline runs (the test asserts `$run-time` is still undefined inside it) and memoizes the value for call time.

### 3. Say/Put/Print/Note no longer seed not-yet-declared locals into env

The I/O ops' pre-sync broadcast every `code.locals` slot into env — including compile-time-allocated slots whose declaration hadn't run yet. That premature seed made a later `state` declaration in the same loop body record itself as a "shadowed outer binding" (the seeded entry looked like a live outer binding with a coherent slot), and the loop-local shadow restore then wiped the variable at loop exit. The new `sync_env_from_locals_declared` skips names absent from env — the same guard `sync_regex_interpolation_env_from_locals` already used for this exact premature-introduction problem. Any name a downstream `$*OUT`/`.gist` override can legitimately reach via env is either already in env or forced there by the reflective-access flag, so the gate drops nothing live.

## Testing

- `t/phaser-stmt-form-scope.t` (new pin): NEXT-state visible to LAST, say-before-state no longer wipes, block-form scope isolation, INIT-in-sub timing. Validated against raku.
- `MUTSU_FUDGE=1 prove roast/integration/advent2012-day15.t` → 11/11 PASS.
- Local: `make test` (1730 files) PASS; whitelisted S04-phasers (17 files) PASS; S17-supply LAST-using files (collate/zip/throttle/syntax) PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)