### PR TITLE
docs: record the ctor cell-threading campaign (#4571/#4573/#4575/#4576) in news and PLAN

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -157,11 +157,17 @@ Current state (details in news/2026-06.md and news/2026-07.md): ✅ CLI load + c
          `dispatch_bless`, which now reuses the cached per-class `NativeCtorPlan` (attribute
          defs + BUILD/TWEAK probes, incl. 6.e role submethods) instead of re-collecting the
          class shape per call; ctor microbench (benchmarks/bench-ctor.raku) 0.35 → 0.31s release,
-         **2.9x → 2.2x** vs raku. Remaining (per-dist): TWEAK x2 via the resolver path
-         (per-call `resolve_method_with_owner_invocant` + `build_remaining` fingerprints +
-         attributive-named-param full env path), allocation churn (~30% malloc/free in the
-         flat profile: AttrMap clones per phase, `!attr`/`.attr` env inserts) / Symbol intern
-         traffic.
+         **2.9x → 2.2x** vs raku. Fifth round (2026-07-15, #4571/#4573/#4575/#4576 —
+         see news/2026-07.md): single-visible-candidate fast return in method
+         resolution (skips the speculative match for the BUILD/TWEAK dispatch shape),
+         and the construction phases thread the constructed instance's shared
+         attribute cell (no more per-step AttrMap clones / phantom intermediate
+         instances; also a raku-compat fix — `self` inside BUILD/TWEAK IS the returned
+         object). bench-ctor 0.341 → 0.299s local. Remaining (per-dist): the
+         attributive-named-param full env path of TWEAK (`:%!meta` forces
+         `call_compiled_method`'s full env setup + merge — §5 item 0 / §1.5 territory),
+         MakePair/named-arg re-materialization (`|%_` slip), Symbol intern/as_str
+         traffic in dispatch signatures.
       2. Nested `.raku` rendering: an Instance inside a collection renders as `Sp()` (type-object
          style) (`(C.new,).raku` → raku gives `(C.new(...),)`). The value itself is fine
          (semantically harmless; display only).

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -463,6 +463,43 @@ recovered by cutting the fixed costs of the light-call path shared by interprete
 (rounds 5 and 6) — on the profile, call ceremony was more than 3x the dispatch probe. The
 root fix for the remaining on/off-shared fixed costs (SetLocal env-mirror etc.) belongs to
 the §6 lexical-slot campaign.
+## 2026-07-15: ctor dispatch/identity campaign — constructed-object cell threading (#4571 / #4573 / #4575 / #4576)
+
+Continuation of the mzef-populate constructor work (#4557/#4558/#4561/#4566/#4569).
+bench-ctor 0.341s → 0.299s (**-12.5%** local A/B, pinned core) plus a raku-compatibility
+fix family:
+
+- **#4571** — single-visible-candidate fast return in `resolve_method_with_owner_impl`:
+  with exactly one visible non-multi candidate the outcome is invariant to the
+  speculative argument match (a failed match falls through to the same def), so the
+  match (env snapshot + speculative binding) is skipped entirely; excluded when a param
+  carries `where`/a type constraint/a sub-signature. Also gated the merge-path
+  `attr_alias_local` scan (O(env keys x attrs) per full-path method exit) on the
+  precomputed `has_attr_aliases`.
+- **#4573** — **BUILD/TWEAK run against the constructed object itself**: the phases now
+  thread the instance's shared attribute cell instead of building a phantom intermediate
+  instance per step (2 AttrMap clones + an exit `to_map()` + a spurious DESTROY queue
+  entry each). raku semantics restored: `self` inside BUILD/TWEAK IS the returned object
+  (identity, and two-way visibility of mutations through a stored `self`). Supporting
+  refactor: `call_compiled_method` takes `&AttrMap`; `run_instance_method` /
+  `run_resolved_method_compiled_or_treewalk` split into cell-authoritative `_celled`
+  cores returning `(value, Option<AttrMap>)` (`None` = the live cell is authoritative)
+  plus map-in/map-out compat wrappers. Pin: t/ctor-self-identity.t.
+- **#4575** — attribute writes reach the instance after `$outer := self`: the bind
+  rewrites the frame's `self` into the bind's ContainerRef cell, and the write paths
+  (the `$!x =` type-object guard, `self_instance_attrs`) matched only Instance/Mixin —
+  a scalar assignment died with "Cannot look up attributes in a ... type object" and an
+  array `.push` was silently lost. Both now read through the ContainerRef. Pin:
+  t/bind-self-attr-write.t.
+- **#4576** — the legacy full-`.new` path (non-native-eligible classes) delegates its
+  ~200-line inline BUILD/TWEAK MRO walks to the shared celled phases ("1 operation = 1
+  implementation", -195/+48 lines), extending the identity fix to those classes; and
+  `self_instance_attrs` unwraps ContainerRef/Mixin levels **iteratively without holding
+  the cell lock** (capped at 8) — #4575's recursion inside `with_deref` held the Mutex
+  across levels, the suspected trigger of its jit-stress SEGV (S17-supply/syntax.t,
+  Signal 11; 28 hardened-build runs under the CI's exact jit-stress conditions show no
+  SEGV, only the documented S17 load-flaky shape once).
+
 ## 2026-07-15: BLOCKERS cluster 5 (individual feature gaps) — 8 files whitelisted, 2 remain
 
 Whitelisted 8 of the 10 individual-feature-gap files under `integration/` in one day (#4533 /


### PR DESCRIPTION
Records today's constructor dispatch/identity campaign in news/2026-07.md and refreshes PLAN.md §1 B2's "Remaining (per-dist)" list (resolver fast return + AttrMap phase clones are done; what remains is the attributive-named-param full env path (§1.5), named-arg re-materialization, and Symbol traffic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)