### PR TITLE
perf: record roast-wide raku-vs-mutsu speed baseline + re-prioritize the call path

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -403,9 +403,37 @@ unification / the malloc clusters from `Value` clone/drop and attribute material
       path were deleted** (scalar locals are stored without sigils, so `name.starts_with('$')` was
       always false = it had never executed)).
 
+      **★Re-baseline 2026-07-15 (roast-wide raku-vs-mutsu wall-clock, `scripts/roast-speed-diff.sh`
+      over the 1358 runnable whitelisted tests):** mutsu beats raku (Rakudo 2022.12) on ~1348/1358
+      tests, usually 2–30× (fast startup + JIT). The **only** files where mutsu is meaningfully
+      *slower* (clean single-run ratios, release):
+      `S04-declarations/state.t` **4.2×** (`for ^2000000 { $ = foo }`), `S06-signature/named-parameters.t`
+      **2.6×** (`for ^1000000 { foo(:color($_)) }`), `S07-iterators/range-iterator.t` **1.7×**,
+      `S12-methods/private.t` **1.6×**. Isolated micro-repro: a 1M-iteration loop calling a sub is
+      **1.85× slower** than raku positional / **2.6× slower** with a named arg. **All of these converge
+      on one root: the interpreter function-call path in hot loops.** The JIT *bails at the call
+      boundary* (proven: positional 1M loop is `MUTSU_JIT=on` 0.74s ≈ `off` 0.72s — JIT does nothing),
+      so any loop that calls a sub runs the interpreter call path, whose profile is **~15% malloc/free
+      churn per call** (frame + named-args structure + `Env::cow_mut` + `Arc::drop_slow`) plus per-call
+      `current_package`/`Env::get_sym`/param-binding (`exec_set_local_op_inner`). Named args add
+      disproportionate cost (mutsu **+46%** vs raku **+6%**) = a `String`-keyed named-args structure
+      rebuilt every call. **This is the highest-value perf target** — it hits real spec tests and the
+      most common real-world shape (a loop that calls a sub), unlike the two items below which polish
+      benchmarks mutsu already wins. (`bench-grammar-parse`'s synthetic 6.4× gap does NOT surface in
+      the roast whitelist — the whitelisted grammar tests are not pathological.) See memory
+      `project_roast_speed_measurement`.
+
       **Remaining (in order of attack)**:
-      0. **★Removing the `needs_env_sync` blanket (the next main target; suited to a dedicated
-         session)** — currently `captures_env_by_name` (true if the frame contains even one
+      -1. **★Function-call path in hot loops (NEW top priority, from the re-baseline above)** — reduce
+         the per-call allocation churn: reuse the call frame / named-args storage, cut `Arc::drop_slow`
+         on teardown, cache `current_package`, and avoid rebuilding the `String`-keyed named-args
+         structure each call (intern the param names, bind by `Symbol`/slot). Because the JIT bails at
+         calls, this is interpreter-path work that no amount of JIT progress will subsume. Pins:
+         `roast/S04-declarations/state.t`, `roast/S06-signature/named-parameters.t`; micro-repro in the
+         re-baseline note.
+      0. **★Removing the `needs_env_sync` blanket (a dedicated-session fused campaign; NOT a
+         standalone change — see the four-mechanism breakage below)** — currently `captures_env_by_name`
+         (true if the frame contains even one
          `ForLoop`/`BlockScope`/`MakeGather`/`WheneverScope`) **makes every local in the frame an env
          mirror target**, so locals never read by name — like a loop body's `my $ts` — are written to
          env on every store. **Update 2026-07-15 (probed, then clean-reverted):** the actual per-store

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,34 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-15: roast-wide raku-vs-mutsu speed measurement + perf re-baseline
+
+Measured wall-clock of raku vs mutsu (release) across all 1358 runnable
+whitelisted roast tests (`scripts/roast-speed-diff.sh`, single-run; ratio =
+mutsu/raku, so <1.0 = mutsu faster). **mutsu beats raku (Rakudo 2022.12) on
+~1348/1358 tests, usually 2–30×** thanks to fast startup + JIT. The only files
+where mutsu is meaningfully slower all converge on **one root cause — the
+interpreter function-call path in hot loops**:
+
+- `S04-declarations/state.t` **4.2×** (`for ^2000000 { $ = foo }`),
+  `S06-signature/named-parameters.t` **2.6×** (`for ^1000000 { foo(:color($_)) }`),
+  `S07-iterators/range-iterator.t` **1.7×**, `S12-methods/private.t` **1.6×**.
+- Isolated micro-repro: a 1M-iteration loop calling a sub is **1.85× slower**
+  than raku (positional) / **2.6× slower** (named arg).
+- **The JIT bails at the call boundary** — the positional 1M loop runs at
+  `MUTSU_JIT=on` 0.74s ≈ `off` 0.72s (JIT contributes nothing), so any loop that
+  calls a sub runs the interpreter call path. Its profile is **~15% malloc/free
+  churn per call** (frame + named-args structure + `Env::cow_mut` +
+  `Arc::drop_slow`) plus per-call `current_package` / `Env::get_sym` /
+  param-binding. Named args cost mutsu **+46%** vs raku **+6%** — a
+  `String`-keyed named-args structure rebuilt every call.
+
+This re-baselines the §5 perf roadmap: the call path is now the top perf target
+(it hits real spec tests and the most common real-world shape), while the
+`needs_env_sync` blanket and the `BlockScope` declone — both investigated the
+same day — turned out to polish benchmarks mutsu already wins (see below). The
+synthetic `bench-grammar-parse` 6.4× gap does not surface in the roast whitelist.
+
 ## 2026-07-15: `once` fires exactly once per clone (threads, repeated calls, methods)
 
 `once { ... }` broke in three independent ways (PLAN §3). Fixed across two PRs:

--- a/scripts/roast-speed-diff.sh
+++ b/scripts/roast-speed-diff.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Single-pass wall-clock comparison of raku vs mutsu (release) across the
+# whitelisted roast tests, to surface where mutsu is *slower* than raku.
+#
+# Rationale: mutsu starts in ~0.01s and raku recompiles its setting + Test
+# module on every invocation (~0.3-0.6s), so on short tests mutsu wins purely on
+# startup. The interesting signal is therefore `ratio > 1` -- a file where mutsu
+# is slower *despite* that startup advantage is a genuine engine-execution gap.
+#
+# This is a COARSE, single-run measurement (the goal is finding obvious gaps,
+# not precise timing). Run it serially -- do NOT launch two copies at once, or
+# they contend for CPU and the absolute times become noise (the per-row ratio,
+# measured back-to-back, stays usable). Re-confirm any outlier with a clean,
+# isolated single run before acting on the absolute number.
+#
+# Usage: cargo build --release && scripts/roast-speed-diff.sh
+# Output: tmp/roast-speed.tsv  (path, mutsu_s, raku_s, ratio, status)
+# Analyse: sort -t$'\t' -k4 -rn tmp/roast-speed.tsv | awk -F'\t' '$4>1'
+set -u
+cd "$(dirname "$0")/.." || exit 1
+BIN="${MUTSU_BIN:-target/release/mutsu}"
+INC=roast/packages/Test-Helpers/lib
+OUT="${OUT:-tmp/roast-speed.tsv}"
+CAP="${CAP:-30}"          # uniform per-run timeout (sleep-bound tests hit this)
+LIST="${1:-roast-whitelist.txt}"
+mkdir -p "$(dirname "$OUT")"
+echo -e "path\tmutsu_s\traku_s\tratio\tstatus" > "$OUT"
+n=0
+while IFS= read -r f; do
+  [ -f "$f" ] || continue
+  n=$((n+1))
+  t0=$(date +%s.%N); timeout "$CAP" env MUTSU_FUDGE=1 "$BIN" "$f" >/dev/null 2>&1; mrc=$?; t1=$(date +%s.%N)
+  r0=$(date +%s.%N); timeout "$CAP" raku -I "$INC" "$f" >/dev/null 2>&1; rrc=$?; r1=$(date +%s.%N)
+  st="ok"
+  [ $mrc -eq 124 ] && st="mutsu_timeout"
+  [ $rrc -eq 124 ] && st="raku_timeout"
+  awk -v f="$f" -v a=$t0 -v b=$t1 -v c=$r0 -v d=$r1 -v s="$st" \
+    'BEGIN{m=b-a;r=d-c;printf "%s\t%.3f\t%.3f\t%s\t%s\n",f,m,r,(r>0.001?sprintf("%.2f",m/r):"NA"),s}' >> "$OUT"
+  [ $((n % 100)) -eq 0 ] && echo "…$n done" >&2
+done < "$LIST"
+echo "DONE: $n files -> $OUT" >&2


### PR DESCRIPTION
## Summary

Measured wall-clock of **raku vs mutsu (release)** across all 1358 runnable whitelisted roast tests (`scripts/roast-speed-diff.sh`, single-run; ratio = mutsu/raku, so <1.0 = mutsu faster).

**mutsu beats raku (Rakudo 2022.12) on ~1348/1358 tests, usually 2–30×** (fast startup + JIT). The only files where mutsu is meaningfully slower all converge on **one root cause — the interpreter function-call path in hot loops**:

| roast test | ratio | hot inner |
|---|---|---|
| `S04-declarations/state.t` | **4.2×** | `for ^2000000 { $ = foo }` |
| `S06-signature/named-parameters.t` | **2.6×** | `for ^1000000 { foo(:color($_)) }` |
| `S07-iterators/range-iterator.t` | 1.7× | range iteration |
| `S12-methods/private.t` | 1.6× | private method dispatch |

- Isolated micro-repro: a 1M-iteration loop calling a sub is **1.85× slower** than raku (positional) / **2.6× slower** (named arg).
- **The JIT bails at the call boundary** — the positional 1M loop runs at `MUTSU_JIT=on` 0.74s ≈ `off` 0.72s (JIT contributes nothing). So any loop that calls a sub runs the interpreter call path, whose profile is **~15% malloc/free churn per call** (frame + named-args structure + `Env::cow_mut` + `Arc::drop_slow`) plus per-call `current_package` / `Env::get_sym` / param-binding. Named args cost mutsu **+46%** vs raku **+6%** (a `String`-keyed named-args structure rebuilt every call).

## Changes (docs + tooling only, no source)

- `scripts/roast-speed-diff.sh` — reusable single-pass raku-vs-mutsu timer over the whitelist.
- `PLAN.md` §5 — re-baselines the perf roadmap: the call path is the new top target; records that the `needs_env_sync` blanket and `BlockScope` declone (investigated the same day) polish benchmarks mutsu already wins.
- `news/2026-07.md` — the measurement writeup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)