### PR TITLE
fix: map routine-callback returns, recursive index-rw temp corruption, (<=) Range coercion

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -71,7 +71,7 @@ noted.
 
 | File | mutsu | raku | Blocker / note |
 |---|---|---|---|
-| `integration/99problems-21-to-30.t` | aborts at 6/15 | PASS ★ | not yet root-caused (post-#4510/#4516 re-measure) |
+| `integration/99problems-21-to-30.t` | 14/15 | PASS ★ | Root-caused 2026-07-15 and fixed 3 of 4: `return` in a sub callback via map (routine call path), recursive slice-arg index-rw temp corruption, `(<=)` Range coercion. Remaining 1 = test 13 (P27 `group`): the nested `map -> $g {...}` over the recursion's itemized-Seq result loses the inner group — mutsu's inner value is `$(($[[3],],),)` where raku builds `$((($[[3],],).Seq,).Seq)`, and the subsequent `|@$g` slips a different level. Needs the Seq-vs-List structure of nested map results aligned with raku |
 | `integration/99problems-31-to-40.t` | aborts at 44/67 | PASS ★ | not yet root-caused |
 | `integration/99problems-41-to-50.t` | fails | PASS ★ | P47 needs parameterized `multi rule expr($p)` (grammar rules taking arguments); P41/P46 fixed in #4510 |
 | `integration/99problems-51-to-60.t` | 35/37 | PASS ★ | test 8 (balanced-binary-tree branch dropping) and test 21; the P57 infinite recursion was fixed in #4516 |

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -60,6 +60,33 @@ synthetic `bench-grammar-parse` 6.4× gap does not surface in the roast whitelis
 Pins: `t/once-clone-scope.t` (10 cases), `t/once-phaser.t` (12);
 `roast/S04-statements/once.t` stays whitelisted.
 
+## 2026-07-15: map routine callbacks, recursive index-rw temp corruption, (<=) Range — 99problems-21-to-30.t 6/15 → 14/15
+
+Three general fixes root-caused from the file's abort:
+
+- **`return` in a `sub` callback invoked via map ends that call** (routine
+  semantics): `map $f, @xs` / `@xs.map($f)` with a compiled routine `$f` now
+  routes through `call_sub_value` instead of the inline bare-block fast path
+  (whose escaping return signal surfaced as X::ControlFlow::Return). Bare/
+  pointy blocks, WhateverCode, and placeholder blocks (`{ $^x }` — Blocks,
+  not Routines, and Pair elements must not bind as named args) stay on the
+  fast path.
+- **Recursive slice-arg writeback corruption**: the call-site Index-argument
+  `is rw` writeback temps (`__mutsu_index_rw_*`) are compile-time-fixed
+  global names, so a recursive execution of the same call site (or the
+  callee's env merge) clobbered the caller's pending compare, firing a bogus
+  `@xs[1..*] = ...` that exploded on an immutable List (P26 `combination`).
+  Fixed on both ends: the cross-frame env merges (compiled-call, method,
+  interpreter-sub) never copy `__mutsu_index_rw_*`/`__mutsu_call_result_*`
+  back to the caller, and the writeback adds an `eqv`-against-current-slot
+  guard so a no-op difference does not fire.
+- **`(<=)` enumerates a Range operand**: `coerce_value_to_quanthash` lacked
+  the Range arm its `coerce_to_set` sibling had, so `@n (<=) (1..49)` built a
+  one-element Set of the string "1..49".
+
+Remaining 1 subtest (P27 nested-map Seq structure) is recorded in BLOCKERS.
+Pin: t/map-sub-return-index-rw.t.
+
 ## 2026-07-15: statement-form loop-phaser scope + sub-body INIT lifting — advent2012-day15.t whitelisted (11/11)
 
 Three fixes, one per layer:

--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -363,8 +363,28 @@ impl Compiler {
                 self.code.emit(OpCode::StrictEq);
                 // If equal (True), skip writeback
                 let skip_idx = self.code.emit(OpCode::JumpIfTrue(0));
-                // Values differ: pop comparison result and do the writeback
+                // Values differ: pop comparison result
                 self.code.emit(OpCode::Pop); // pop False from StrictEq
+                // Second guard: the tmp/orig globals are compile-time-fixed
+                // names, so a RECURSIVE execution of this same call site inside
+                // the callee clobbers them (and the callee's plain-@-param exit
+                // merge writes its final param value into tmp). If tmp is
+                // structurally `eqv` to what the source slot holds RIGHT NOW,
+                // there is no real mutation to apply — writing back would
+                // re-assign the slot with its own value, which explodes on an
+                // immutable List source (`g(@xs[1..*])` recursion,
+                // 99problems-21-to-30.t P26). A genuine `is rw` mutation leaves
+                // tmp differing from the (not-yet-updated) slot, so it still
+                // writes back.
+                self.code.emit(OpCode::GetGlobal(tmp_idx));
+                self.compile_expr(&Expr::Index {
+                    target: target.clone(),
+                    index: index.clone(),
+                    is_positional: *is_positional,
+                });
+                self.code.emit(OpCode::Eqv);
+                let skip2_idx = self.code.emit(OpCode::JumpIfTrue(0));
+                self.code.emit(OpCode::Pop); // pop False from Eqv
                 let writeback = Expr::IndexAssign {
                     target: target.clone(),
                     index: index.clone(),
@@ -374,9 +394,10 @@ impl Compiler {
                 self.compile_expr(&writeback);
                 self.code.emit(OpCode::Pop); // discard assignment result
                 let jump_to_restore = self.code.emit(OpCode::Jump(0));
-                // Skip target: pop True from StrictEq
+                // Skip targets: pop the True left by StrictEq / Eqv
                 self.code.patch_jump(skip_idx);
-                self.code.emit(OpCode::Pop); // pop True from StrictEq
+                self.code.patch_jump(skip2_idx);
+                self.code.emit(OpCode::Pop); // pop True
                 // Restore point
                 self.code.patch_jump(jump_to_restore);
                 self.code.emit(OpCode::GetGlobal(result_idx));

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -537,6 +537,12 @@ impl Interpreter {
             let mut captured_outer_writes: Vec<String> = Vec::new();
             if merge_all {
                 for (k, v) in self.env.iter() {
+                    // Per-call-site index-rw temps are frame-internal; merging a
+                    // callee's same-named entries corrupts the caller's pending
+                    // post-call writeback compare (see is_index_rw_call_temp).
+                    if k.with_str(crate::runtime::utils::is_index_rw_call_temp) {
+                        continue;
+                    }
                     if k != "_"
                         && k != "@_"
                         && (merged.contains_key_sym(*k) || k.starts_with("__mutsu_var_meta::"))
@@ -568,6 +574,10 @@ impl Interpreter {
                 }
                 for (k, v) in self.env.iter() {
                     if k == "_" || k == "@_" || subsig_names.contains(&k.resolve()) {
+                        continue;
+                    }
+                    // See the merge_all branch: index-rw temps never merge back.
+                    if k.with_str(crate::runtime::utils::is_index_rw_call_temp) {
                         continue;
                     }
                     if matches!(v.view(), ValueView::Array(..)) {

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -94,7 +94,28 @@ impl Interpreter {
                     || pd.code_signature.is_some()
                     || pd.shape_constraints.is_some()
             });
-            if requires_full_binding {
+            // A routine callback (`map $f, @xs` / `@xs.map($f)` where `$f` is a
+            // `sub`) must run through the real call path so a `return` in its
+            // body ends THAT call with the returned value (routine semantics).
+            // The inline fast path below runs the body as a bare block, so the
+            // return signal would escape the map VM and surface as
+            // X::ControlFlow::Return (99problems-21-to-30.t P23 `$compress`).
+            // A WhateverCode is expression-shaped (it cannot contain `return`)
+            // and needs the fast path's outer-topic handling for its `$_`.
+            let is_routine_callback = !data.is_bare_block
+                && data.compiled_code.as_ref().is_some_and(|cc| cc.is_routine)
+                && !matches!(
+                    data.env.get("__mutsu_callable_type").map(Value::view),
+                    Some(ValueView::Str(kind)) if kind.as_str() == "WhateverCode"
+                )
+                // A placeholder block (`{ $^x.value }`) is a Block, not a
+                // Routine, even though its compile path currently flags
+                // is_routine (it compiles as a named-anon-sub body). It must
+                // stay on the fast path: the general call machinery binds a
+                // Pair element as a NAMED argument, leaving the placeholder
+                // positional unbound (t/map-native-pairs.t).
+                && crate::ast::collect_placeholders_shallow(&data.body).is_empty();
+            if requires_full_binding || is_routine_callback {
                 // `map` batches the source by the block's `.count` (the number of
                 // positional parameters it will bind): a multi-positional block
                 // such as `-> \a, \b { }` consumes a chunk of that many elements

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -25,7 +25,24 @@ impl Interpreter {
                     || pd.code_signature.is_some()
                     || pd.shape_constraints.is_some()
             });
+            // A routine callback must run through the real call path so a
+            // `return` in its body ends THAT call with the returned value
+            // (routine semantics) — see the same gate in `eval_map_over_items`.
+            let is_routine_callback = !data.is_bare_block
+                && data.compiled_code.as_ref().is_some_and(|cc| cc.is_routine)
+                && !matches!(
+                    data.env.get("__mutsu_callable_type").map(Value::view),
+                    Some(ValueView::Str(kind)) if kind.as_str() == "WhateverCode"
+                )
+                // A placeholder block (`{ $^x.value }`) is a Block, not a
+                // Routine, even though its compile path currently flags
+                // is_routine (it compiles as a named-anon-sub body). It must
+                // stay on the fast path: the general call machinery binds a
+                // Pair element as a NAMED argument, leaving the placeholder
+                // positional unbound (t/map-native-pairs.t).
+                && crate::ast::collect_placeholders_shallow(&data.body).is_empty();
             if requires_full_binding
+                || is_routine_callback
                 || data.env.contains_key("__mutsu_routine_name")
                 || data.env.contains_key("__mutsu_compose_left")
             {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -40,6 +40,21 @@ pub(crate) fn bound_array_slice_key(name: &str) -> String {
     format!("__mutsu_bound_array_slice::{name}")
 }
 
+/// True for the per-call-site internal temp names of the Index-argument `is rw`
+/// writeback machinery (`__mutsu_index_rw_arg_N` / `__mutsu_index_rw_orig_N` /
+/// `__mutsu_call_result_N`, see `compile_call_arg_with_escape` /
+/// `emit_index_rw_writebacks`). The names are compile-time-fixed, so a callee
+/// that executes a same-named call site of its own (recursion, or an accidental
+/// cross-chunk numbering collision) holds entries under the SAME names — the
+/// cross-frame env merges must never copy them back into the caller, or the
+/// caller's pending post-call compare reads the callee's values and fires a
+/// bogus writeback (`g(@xs[1..*])` recursion assigning into an immutable List,
+/// 99problems-21-to-30.t P26/P27). The designed writeback channel
+/// (`apply_rw_bindings_to_env`) is separate and unaffected.
+pub(crate) fn is_index_rw_call_temp(name: &str) -> bool {
+    name.starts_with("__mutsu_index_rw_") || name.starts_with("__mutsu_call_result_")
+}
+
 /// Build the `Failure` value raku yields when a count/numeric coercion is
 /// attempted on a lazy iterable (e.g. `(1..*).elems` / `.Int` / `+@a`):
 /// `X::Cannot::Lazy` with the message `Cannot .<action> a lazy list`.

--- a/src/runtime/utils/set_coerce.rs
+++ b/src/runtime/utils/set_coerce.rs
@@ -154,6 +154,16 @@ pub(crate) fn coerce_value_to_quanthash(val: &Value) -> Value {
             }
             Value::set(set)
         }
+        // A Range enumerates its elements (`@n (<=) (1..49)`), mirroring
+        // `coerce_to_set` above — without this arm it fell to the scalar
+        // catch-all and became a one-element Set of the string "1..49".
+        _ if val.is_range() => {
+            let mut set = HashSet::new();
+            for item in value_to_list(val) {
+                set.insert(item.to_string_value());
+            }
+            Value::set(set)
+        }
         _ => {
             let mut set = HashSet::new();
             let sv = val.to_string_value();

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -457,7 +457,13 @@ impl Interpreter {
                 }
                 if restored_env.contains_key_sym(*k)
                     && !cf.is_callee_local_sym(*k)
-                    && !k.with_str(|s| rw_sources.contains(s))
+                    && !k.with_str(|s| {
+                        rw_sources.contains(s)
+                            // Per-call-site index-rw temps are frame-internal;
+                            // merging a callee's same-named entries corrupts the
+                            // caller's pending post-call writeback compare.
+                            || crate::runtime::utils::is_index_rw_call_temp(s)
+                    })
                 {
                     restored_env.insert_sym(*k, v.clone());
                 }

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1644,7 +1644,13 @@ fn merge_method_env(
             // names, replacing the former per-call materialized
             // `HashSet<String>` (~dozens of String allocations per non-pure
             // method call for a set consulted only against the few overlay keys).
-            if k.with_str(|s| is_method_local(s)) {
+            if k.with_str(|s| {
+                is_method_local(s)
+                    // Per-call-site index-rw temps are frame-internal; merging a
+                    // callee's same-named entries corrupts the caller's pending
+                    // post-call writeback compare (see is_index_rw_call_temp).
+                    || crate::runtime::utils::is_index_rw_call_temp(s)
+            }) {
                 return None;
             }
             let keep = saved.contains_key_sym(*k)

--- a/t/map-sub-return-index-rw.t
+++ b/t/map-sub-return-index-rw.t
@@ -1,0 +1,59 @@
+use v6;
+use Test;
+
+# 99problems-21-to-30.t fixes (P23/P26/P22-range):
+# - `return` in a `sub` callback invoked via map ends that call (routine
+#   semantics), instead of escaping as X::ControlFlow::Return.
+# - Recursive calls passing a slice of an immutable List param no longer
+#   corrupt the call-site index-rw writeback temps (which fired a bogus
+#   `@xs[1..*] = ...` on the immutable List).
+# - The (<=) subset operator enumerates a Range operand.
+
+plan 8;
+
+{
+    my $f = sub ($x) { return $x * 2; };
+    is-deeply (map $f, (1, 2, 3)).List, (2, 4, 6), 'return in sub callback via listop map';
+    is-deeply (1, 2, 3).map($f).List, (2, 4, 6), 'return in sub callback via .map';
+
+    my $compress = sub ($x) {
+        state $previous = '';
+        return $x ne $previous ?? ($previous = $x) !! ();
+    }
+    my @r = map $compress, <a b c>;
+    is @r.elems, 3, 'state + conditional return in sub callback (P23 shape)';
+}
+
+{
+    sub g(@xs) {
+        if @xs == 0 { () }
+        else { @xs[0], g(@xs[1..*]).Slip }
+    }
+    is-deeply g((3, 4, 5)).List, (3, 4, 5),
+        'recursion over immutable List slices does not fire a bogus writeback';
+
+    sub combination($n, @xs) {
+        if $n > @xs { () }
+        elsif $n == 0 { ([],) }
+        elsif $n == @xs { ([@xs],) }
+        else {
+            combination($n-1, @xs[1..*]).map({ [@xs[0], |$_ ] }).Slip,
+                combination($n, @xs[1..*]).Slip;
+        }
+    }
+    is combination(2, (1..3)).elems, 3, 'P26 combination over a Range-derived List';
+}
+
+{
+    # A genuine `is rw` mutation through an index argument still writes back.
+    sub bump($x is rw) { $x = 99 }
+    my @a = 1, 2, 3;
+    bump(@a[0]);
+    is-deeply @a, [99, 2, 3], 'is rw index-arg writeback still works';
+}
+
+{
+    my @n = (1..49).pick(6);
+    ok ?(@n (<=) (1..49)), '(<=) enumerates a Range RHS';
+    ok !(?((0, 1) (<=) (1..49))), '(<=) with Range RHS rejects out-of-range elements';
+}


### PR DESCRIPTION
## Summary

Three general fixes root-caused from `roast/integration/99problems-21-to-30.t`, which aborted at 6/15 and now reaches **14/15** (the remaining P27 nested-map Seq-structure subtest is recorded in BLOCKERS with analysis).

### 1. `return` in a `sub` callback invoked via map ends that call

`map $f, @xs` / `@xs.map($f)` with a compiled routine `$f` ran the body on the inline bare-block fast path, so a `return` escaped the map VM and surfaced as `X::ControlFlow::Return` (P23's `$compress`). Routine callbacks now route through `call_sub_value` (both `eval_map_over_items` and the rw variant). Deliberately kept on the fast path: bare/pointy blocks, WhateverCode (needs the outer-topic `$_` handling), and placeholder blocks (`{ $^x }` — Blocks, not Routines; the general call machinery would bind a Pair element as a *named* arg and leave the placeholder positional unbound — pinned by t/map-native-pairs.t).

### 2. Recursive Index-arg writeback temp corruption

The call-site Index-argument `is rw` writeback temps (`__mutsu_index_rw_arg_N`/`_orig_N`) are compile-time-fixed global names. A recursive execution of the same call site (`g(@xs[1..*])`) clobbered them, and the callee's cross-frame env merge copied its same-named entries back — so the caller's pending post-call compare saw values from the wrong frame and fired a bogus `@xs[1..*] = ...`, exploding with "Cannot modify an immutable List" (P26 `combination`). Fixed on both ends:
- the cross-frame env merges (compiled-call `vm_call_named_inner`, `merge_method_env`, interpreter `call_sub_value`) never copy `__mutsu_index_rw_*`/`__mutsu_call_result_*` names back to the caller (new `is_index_rw_call_temp` predicate), and
- `emit_index_rw_writebacks` gains an `eqv`-against-current-slot guard, so a "difference" that matches what the slot already holds does not fire. A genuine `is rw` mutation (tmp differing from the not-yet-updated slot) still writes back.

### 3. `(<=)` enumerates a Range operand

`coerce_value_to_quanthash` lacked the Range arm its `coerce_to_set` sibling had, so `@n (<=) (1..49)` built a one-element Set of the string "1..49" and always answered False.

## Testing

- `t/map-sub-return-index-rw.t` (new pin, validated against raku): map returns via listop/method, P23 state+conditional-return shape, recursion over immutable List slices, P26 combination, genuine `is rw` index-arg writeback, `(<=)` with Range.
- `make test` (1731 files) PASS locally; 286 whitelisted S02/S03/S06/S32-list roast files PASS; 99problems-21-to-30.t 14/15 (was abort at 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)