### PR TITLE
perf: cache the class MRO as interned symbols (Arc<[Symbol]>)

### DIFF
--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -474,8 +474,8 @@ impl Interpreter {
         }
         let mro = self.class_mro(class_name);
         let mut count = 0usize;
-        'outer: for cn in &mro {
-            let is_ancestor = cn != class_name;
+        'outer: for cn in mro.iter() {
+            let is_ancestor = cn.as_str() != class_name;
             let registry = self.registry();
             let overloads = registry
                 .classes
@@ -646,7 +646,9 @@ impl Interpreter {
             return false;
         }
         reg.classes.get(class_name).is_some_and(|cd| {
-            cd.mro.iter().any(|c| Self::is_metamodel_class_name(c))
+            cd.mro
+                .iter()
+                .any(|c| Self::is_metamodel_class_name(c.as_str()))
                 || cd.parents.iter().any(|c| Self::is_metamodel_class_name(c))
         })
     }

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -64,16 +64,16 @@ impl Interpreter {
             // class declaration revision, not the globally-current version.
             let is_6e = self.type_decl_is_6e(&instance_class);
             // Collect the MRO so we call DESTROY on each class in order (child → parent).
-            let mro: Vec<String> = self
+            let mro: std::sync::Arc<[crate::symbol::Symbol]> = self
                 .registry()
                 .classes
                 .get(&instance_class)
                 .map(|cd| cd.mro.clone())
-                .unwrap_or_default();
+                .unwrap_or_else(|| [].into());
             // Track attributes across DESTROY calls so mutations are visible
             let mut current_attrs = item.attributes.clone();
             // Walk the MRO; submethods are per-class, not inherited.
-            for mro_class in &mro {
+            for mro_class in mro.iter().map(|s| s.as_str()) {
                 // Skip role entries in MRO
                 if self.registry().roles.contains_key(mro_class)
                     && !self.registry().classes.contains_key(mro_class)

--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -29,7 +29,7 @@ impl Interpreter {
         value: &Value,
     ) -> bool {
         let mro = self.class_mro(class_name);
-        for cn in &mro {
+        for cn in mro.iter() {
             let methods = match self.registry().classes.get(cn.as_str()) {
                 Some(cd) => cd.methods.get("new").cloned(),
                 None => None,
@@ -204,8 +204,8 @@ impl Interpreter {
             return true;
         }
         let mro = self.class_mro(class_name);
-        for cn in mro {
-            if let Some(class_def) = self.registry().classes.get(&cn)
+        for cn in mro.iter() {
+            if let Some(class_def) = self.registry().classes.get(cn.as_str())
                 && class_def.native_methods.contains(method_name)
             {
                 return true;
@@ -216,8 +216,8 @@ impl Interpreter {
 
     pub(crate) fn has_user_method(&mut self, class_name: &str, method_name: &str) -> bool {
         let mro = self.class_mro(class_name);
-        for cn in mro {
-            if let Some(class_def) = self.registry().classes.get(&cn)
+        for cn in mro.iter() {
+            if let Some(class_def) = self.registry().classes.get(cn.as_str())
                 && let Some(defs) = class_def.methods.get(method_name)
             {
                 return defs.iter().any(|d| !d.is_private);
@@ -251,8 +251,8 @@ impl Interpreter {
         method_name: &str,
     ) -> Option<UserMethodOrAccessor> {
         let mro = self.class_mro(class_name);
-        for cn in &mro {
-            let is_ancestor = cn != class_name;
+        for cn in mro.iter() {
+            let is_ancestor = cn.as_str() != class_name;
             let (has_local_method, has_role_method, has_attr) = {
                 let registry = self.registry();
                 if let Some(class_def) = registry.classes.get(cn.as_str()) {
@@ -322,8 +322,9 @@ impl Interpreter {
         if !is_rw {
             return None;
         }
-        for cn in self.class_mro(class_name) {
-            if let Some(tc) = self.get_attr_type_constraint(&cn, method_name) {
+        let mro = self.class_mro(class_name);
+        for cn in mro.iter() {
+            if let Some(tc) = self.get_attr_type_constraint(cn.as_str(), method_name) {
                 return Some(Some(tc));
             }
         }
@@ -345,9 +346,9 @@ impl Interpreter {
         let mro = if let Some(cd) = self.registry().classes.get(class_name) {
             cd.mro.clone()
         } else {
-            Vec::new()
+            [].into()
         };
-        for parent in &mro {
+        for parent in mro.iter().map(|p| p.as_str()) {
             if parent == class_name {
                 continue;
             }
@@ -380,7 +381,7 @@ impl Interpreter {
         }
         // Walk MRO for inherited class-level attributes
         let mro = self.class_mro(class_name);
-        for parent in &mro {
+        for parent in mro.iter().map(|s| s.as_str()) {
             if parent == class_name {
                 continue;
             }
@@ -417,7 +418,7 @@ impl Interpreter {
         }
         // Walk MRO
         let mro = self.class_mro(class_name);
-        for parent in &mro {
+        for parent in mro.iter().map(|s| s.as_str()) {
             if parent == class_name {
                 continue;
             }
@@ -437,8 +438,8 @@ impl Interpreter {
     pub(super) fn collect_wildcard_handles(&mut self, class_name: &str) -> Vec<String> {
         let mro = self.class_mro(class_name);
         let mut result = Vec::new();
-        for cn in &mro {
-            if let Some(class_def) = self.registry().classes.get(cn) {
+        for cn in mro.iter() {
+            if let Some(class_def) = self.registry().classes.get(cn.as_str()) {
                 result.extend(class_def.wildcard_handles.iter().cloned());
             }
         }
@@ -449,8 +450,8 @@ impl Interpreter {
     /// (no twigil), so the method call dispatch can set up bidirectional aliases.
     pub(super) fn add_alias_attribute_metadata(&mut self, class_name: &str, attrs: &mut AttrMap) {
         let mro = self.class_mro(class_name);
-        for cn in &mro {
-            if let Some(class_def) = self.registry().classes.get(cn) {
+        for cn in mro.iter() {
+            if let Some(class_def) = self.registry().classes.get(cn.as_str()) {
                 for attr_name in &class_def.alias_attributes {
                     attrs.insert(
                         format!("__mutsu_attr_alias::{}", attr_name),
@@ -469,7 +470,7 @@ impl Interpreter {
         self.class_mro(class_name).iter().any(|cn| {
             self.registry()
                 .classes
-                .get(cn)
+                .get(cn.as_str())
                 .is_some_and(|cd| cd.attributes.iter().any(|(n, ..)| n == bare))
         })
     }
@@ -478,7 +479,7 @@ impl Interpreter {
         let mro = self.class_mro(class_name);
         let mut attrs: Vec<ClassAttributeDef> = Vec::new();
         for cn in mro.iter().rev() {
-            if let Some(class_def) = self.registry().classes.get(cn) {
+            if let Some(class_def) = self.registry().classes.get(cn.as_str()) {
                 for attr in &class_def.attributes {
                     if let Some(pos) = attrs.iter().position(|(n, ..)| n == &attr.0) {
                         attrs.remove(pos);
@@ -504,19 +505,19 @@ impl Interpreter {
         let mut result: Vec<(String, ClassAttributeDef)> = Vec::new();
         // Track which attribute names appear in multiple classes (need qualified storage)
         let mut attr_counts: HashMap<String, usize> = HashMap::new();
-        for cn in &mro {
-            if let Some(class_def) = self.registry().classes.get(cn) {
+        for cn in mro.iter() {
+            if let Some(class_def) = self.registry().classes.get(cn.as_str()) {
                 for attr in &class_def.attributes {
                     *attr_counts.entry(attr.0.clone()).or_insert(0) += 1;
                 }
             }
         }
         // Only include attrs that appear in multiple classes (duplicated across hierarchy)
-        for cn in &mro {
-            if let Some(class_def) = self.registry().classes.get(cn) {
+        for cn in mro.iter() {
+            if let Some(class_def) = self.registry().classes.get(cn.as_str()) {
                 for attr in &class_def.attributes {
                     if attr_counts.get(&attr.0).copied().unwrap_or(0) > 1 {
-                        result.push((cn.clone(), attr.clone()));
+                        result.push((cn.resolve(), attr.clone()));
                     }
                 }
             }

--- a/src/runtime/dispatch_proto.rs
+++ b/src/runtime/dispatch_proto.rs
@@ -223,7 +223,7 @@ impl Interpreter {
             return None;
         }
         let mro = self.class_mro(class_name);
-        for cn in mro {
+        for cn in mro.iter().map(|s| s.resolve()) {
             if let Some(f) = self
                 .registry()
                 .proto_methods

--- a/src/runtime/methods_classhow_attribute.rs
+++ b/src/runtime/methods_classhow_attribute.rs
@@ -42,11 +42,11 @@ impl Interpreter {
             {
                 class_def.mro.clone()
             } else {
-                vec![class_name.to_string()]
+                [crate::symbol::Symbol::intern(class_name)].into()
             };
             let mut result = Vec::new();
             let mut seen_names = std::collections::HashSet::new();
-            for cn in &mro {
+            for cn in mro.iter().map(|s| s.as_str()) {
                 if cn == "Any" || cn == "Mu" {
                     continue;
                 }

--- a/src/runtime/methods_classhow_builtin_methods.rs
+++ b/src/runtime/methods_classhow_builtin_methods.rs
@@ -64,7 +64,7 @@ impl Interpreter {
             // Walk MRO (already includes the class itself)
             let mro = self.class_mro(&class_name);
 
-            for cn in &mro {
+            for cn in mro.iter().map(|s| s.as_str()) {
                 if !all && (cn == "Any" || cn == "Mu") {
                     continue;
                 }

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -209,7 +209,9 @@ impl Interpreter {
                     }
                 }
                 let mro = self.class_mro(&class_name.resolve());
-                Ok(Value::truth(mro.iter().any(|p| p == &other_resolved)))
+                Ok(Value::truth(
+                    mro.iter().any(|p| p.as_str() == other_resolved),
+                ))
             }
             "mro" if !args.is_empty() => {
                 let mut include_roles = false;
@@ -465,7 +467,7 @@ impl Interpreter {
                             alias_attributes: HashSet::new(),
                             methods: HashMap::new(),
                             native_methods: HashSet::new(),
-                            mro: vec![class_name.clone()],
+                            mro: sym_mro(&[&class_name]),
                             wildcard_handles: vec![],
                             class_level_attrs: HashMap::new(),
                         },
@@ -790,7 +792,7 @@ impl Interpreter {
                 }
                 if !local_only {
                     let mro = self.class_mro(&class_name);
-                    for cn in &mro[1..] {
+                    for cn in mro[1..].iter().map(|s| s.as_str()) {
                         if let Some(result) = check_transitive(
                             &self.registry().class_composed_roles,
                             &self.registry().role_parents,

--- a/src/runtime/methods_classhow_mro.rs
+++ b/src/runtime/methods_classhow_mro.rs
@@ -10,6 +10,9 @@ impl Interpreter {
         };
         let mut mro = if self.registry().classes.contains_key(&class_name) {
             self.class_mro(&class_name)
+                .iter()
+                .map(|s| s.resolve())
+                .collect()
         } else {
             // Built-in type hierarchies for types that are not user-defined classes.
             // Any/Mu are appended unconditionally below, so the table lists the

--- a/src/runtime/methods_classhow_parents.rs
+++ b/src/runtime/methods_classhow_parents.rs
@@ -184,9 +184,9 @@ impl Interpreter {
             {
                 cd.mro.clone()
             } else {
-                vec![class_name.to_string()]
+                [crate::symbol::Symbol::intern(class_name)].into()
             };
-            for cn in &mro {
+            for cn in mro.iter().map(|s| s.as_str()) {
                 if cn == "Any" || cn == "Mu" {
                     continue;
                 }

--- a/src/runtime/methods_collection_ops/socket_inet_proc.rs
+++ b/src/runtime/methods_collection_ops/socket_inet_proc.rs
@@ -411,7 +411,7 @@ impl Interpreter {
                     Some("Promise".to_string())
                 } else if self
                     .class_mro(&name.resolve())
-                    .contains(&"Promise".to_string())
+                    .contains(&crate::symbol::Symbol::intern("Promise"))
                 {
                     Some(name.resolve())
                 } else {

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -419,7 +419,7 @@ impl Interpreter {
                 }
             });
         let class_is_6e = class_lang_rev != "c";
-        for mro_class in mro.iter().rev() {
+        for mro_class in mro.iter().rev().map(|s| s.as_str()) {
             if mro_class == "Any" || mro_class == "Mu" {
                 continue;
             }
@@ -549,7 +549,7 @@ impl Interpreter {
                 }
             });
         let class_is_6e = class_lang_rev != "c";
-        for mro_class in mro.iter().rev() {
+        for mro_class in mro.iter().rev().map(|s| s.as_str()) {
             if mro_class == "Any" || mro_class == "Mu" {
                 continue;
             }
@@ -671,7 +671,7 @@ impl Interpreter {
                 }
             });
         let class_is_6e = class_lang_rev != "c";
-        for mro_class in mro.iter().rev() {
+        for mro_class in mro.iter().rev().map(|s| s.as_str()) {
             if mro_class == "Any" || mro_class == "Mu" {
                 continue;
             }

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -852,7 +852,8 @@ impl Interpreter {
                     return Ok(Value::FALSE);
                 }
                 return Ok(Value::truth(
-                    self.class_mro(&class_name.resolve()).contains(&target_name),
+                    self.class_mro(&class_name.resolve())
+                        .contains(&crate::symbol::Symbol::intern(&target_name)),
                 ));
             }
             // `X::AdHoc.payload` returns the value passed to `die` (mutsu stores
@@ -1757,7 +1758,8 @@ impl Interpreter {
                     }
                 }
                 Ok(Value::truth(
-                    self.class_mro(&pkg_name).contains(&target_name),
+                    self.class_mro(&pkg_name)
+                        .contains(&crate::symbol::Symbol::intern(&target_name)),
                 ))
             }
             "REPR" if args.is_empty() => {
@@ -1949,7 +1951,8 @@ impl Interpreter {
         let mut classes = vec![type_name.clone()];
         classes.extend(
             self.class_mro(&type_name)
-                .into_iter()
+                .iter()
+                .map(|s| s.resolve())
                 .filter(|c| c != &type_name),
         );
         let name_val = Value::str(method.to_string());
@@ -2127,7 +2130,11 @@ impl Interpreter {
     fn are_specific_candidate_type_names(&mut self, value: &Value) -> Vec<String> {
         match value.view() {
             ValueView::Package(name) => vec![name.resolve()],
-            ValueView::Instance { class_name, .. } => self.class_mro(&class_name.resolve()),
+            ValueView::Instance { class_name, .. } => self
+                .class_mro(&class_name.resolve())
+                .iter()
+                .map(|s| s.resolve())
+                .collect(),
             _ => vec![crate::runtime::utils::value_type_name(value).to_string()],
         }
     }

--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -307,9 +307,9 @@ impl Interpreter {
             }
             // Delegate to inner value's isa check using class MRO
             let result = match inner.as_ref().view() {
-                ValueView::Instance { class_name, .. } => {
-                    self.class_mro(&class_name.resolve()).contains(&target_name)
-                }
+                ValueView::Instance { class_name, .. } => self
+                    .class_mro(&class_name.resolve())
+                    .contains(&crate::symbol::Symbol::intern(&target_name)),
                 _ => inner.isa_check(&target_name),
             };
             return Some(Ok(Value::truth(result)));

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -79,11 +79,12 @@ impl Interpreter {
     /// the child; the instance's bare attribute key mirrors this class's value
     /// (what a public `$.attr` accessor reads). Returns `None` if undeclared.
     fn most_derived_attr_declarer(&mut self, class_name: &str, attr: &str) -> Option<String> {
-        for cn in self.class_mro(class_name) {
-            if let Some(cd) = self.registry().classes.get(&cn)
+        let mro = self.class_mro(class_name);
+        for cn in mro.iter() {
+            if let Some(cd) = self.registry().classes.get(cn.as_str())
                 && cd.attributes.iter().any(|a| a.0 == attr)
             {
-                return Some(cn);
+                return Some(cn.resolve());
             }
         }
         None

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -395,7 +395,7 @@ impl Interpreter {
             .registry()
             .class_attribute_does_roles
             .iter()
-            .filter(|((c, _), _)| mro.contains(c))
+            .filter(|((c, _), _)| mro.iter().any(|s| s.as_str() == c.as_str()))
             .map(|((_, a), roles)| (a.clone(), roles.clone()))
             .collect();
         for (attr_name, roles) in does_attrs {
@@ -417,7 +417,7 @@ impl Interpreter {
             .registry()
             .class_attribute_container_mixins
             .iter()
-            .filter(|((c, _), _)| mro.contains(c))
+            .filter(|((c, _), _)| mro.iter().any(|s| s.as_str() == c.as_str()))
             .map(|((_, a), maps)| (a.clone(), maps.clone()))
             .collect();
         for (attr_name, override_maps) in container_mixins {

--- a/src/runtime/methods_object_attr_constraints.rs
+++ b/src/runtime/methods_object_attr_constraints.rs
@@ -100,8 +100,9 @@ impl Interpreter {
         class_name: &str,
     ) -> HashMap<String, String> {
         let mut constraints = HashMap::new();
-        for owner in self.class_mro(class_name) {
-            if let Some(class_def) = self.registry().classes.get(&owner) {
+        let mro = self.class_mro(class_name);
+        for owner in mro.iter() {
+            if let Some(class_def) = self.registry().classes.get(owner.as_str()) {
                 for (attr_name, tc) in &class_def.attribute_types {
                     constraints
                         .entry(attr_name.clone())
@@ -173,7 +174,7 @@ impl Interpreter {
         let mut required_attrs: std::collections::HashSet<String> =
             std::collections::HashSet::new();
         let mro = self.class_mro(class_name);
-        for mro_class in &mro {
+        for mro_class in mro.iter().map(|s| s.as_str()) {
             if let Some(class_def) = self.registry().classes.get(mro_class) {
                 for (attr_name, smiley) in &class_def.attribute_smileys {
                     smileys

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -414,7 +414,7 @@ impl Interpreter {
                         attributes: Vec::new(),
                         methods: HashMap::new(),
                         native_methods: std::collections::HashSet::new(),
-                        mro: Vec::new(),
+                        mro: [].into(),
                         attribute_types: HashMap::new(),
                         attribute_smileys: HashMap::new(),
                         attribute_built: HashMap::new(),
@@ -1443,7 +1443,7 @@ impl Interpreter {
                 let class_mro = self.class_mro(class_key);
                 // When BUILD is defined, it controls attribute initialization,
                 // so we skip automatic named-arg-to-attribute mapping.
-                let any_build = class_mro.iter().any(|cn| {
+                let any_build = class_mro.iter().map(|s| s.as_str()).any(|cn| {
                     cn != "Any"
                         && cn != "Mu"
                         && self
@@ -1500,7 +1500,7 @@ impl Interpreter {
                             class_name: src_class,
                             attributes: src_attrs,
                             ..
-                        } if class_mro.iter().any(|name| name == &src_class.resolve()) => {
+                        } if class_mro.contains(&src_class) => {
                             for (attr, value) in src_attrs.as_map().iter() {
                                 attrs.insert(*attr, value.clone());
                             }
@@ -1838,7 +1838,7 @@ impl Interpreter {
                     Err(failure) => return Ok(failure),
                 }
                 // Check required attributes after all BUILDs have run
-                let any_build = mro.iter().any(|cn| {
+                let any_build = mro.iter().map(|s| s.as_str()).any(|cn| {
                     cn != "Any"
                         && cn != "Mu"
                         && self
@@ -1849,7 +1849,7 @@ impl Interpreter {
                             .is_some()
                 });
                 // Also check role BUILD submethods for required attribute enforcement
-                let any_role_build = mro.iter().any(|cn| {
+                let any_role_build = mro.iter().map(|s| s.as_str()).any(|cn| {
                     cn != "Any"
                         && cn != "Mu"
                         && !self
@@ -1877,7 +1877,7 @@ impl Interpreter {
                     self.enforce_attribute_where_constraints(class_key, &class_attrs_info, &attrs)?;
                     self.enforce_attribute_smiley_constraints(class_key, &attrs)?;
                 }
-                let any_tweak = mro.iter().any(|cn| {
+                let any_tweak = mro.iter().map(|s| s.as_str()).any(|cn| {
                     cn != "Any"
                         && cn != "Mu"
                         && (self

--- a/src/runtime/methods_object_native_ctors_io.rs
+++ b/src/runtime/methods_object_native_ctors_io.rs
@@ -24,7 +24,7 @@ impl Interpreter {
                     attributes: Vec::new(),
                     methods: HashMap::new(),
                     native_methods: std::collections::HashSet::new(),
-                    mro: Vec::new(),
+                    mro: [].into(),
                     attribute_types: HashMap::new(),
                     attribute_smileys: HashMap::new(),
                     attribute_built: HashMap::new(),

--- a/src/runtime/methods_promise.rs
+++ b/src/runtime/methods_promise.rs
@@ -290,7 +290,9 @@ impl Interpreter {
                     || target_name == "Promise"
                     || target_name == "Any"
                     || target_name == "Mu"
-                    || self.class_mro(&cn).contains(&target_name);
+                    || self
+                        .class_mro(&cn)
+                        .contains(&crate::symbol::Symbol::intern(&target_name));
                 Ok(Value::truth(is_match))
             }
             _ => Err(RuntimeError::new(format!(

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -75,12 +75,12 @@ impl Interpreter {
         // Check that the qualifier class/role is in the instance's MRO or composed roles
         let inst_cn_str = inst_class.resolve();
         let inst_mro = self.class_mro(&inst_cn_str);
-        let in_mro = inst_mro.iter().any(|c| c == qualifier);
+        let in_mro = inst_mro.iter().any(|c| c.as_str() == qualifier);
         let in_composed_roles = if !in_mro {
             inst_mro.iter().any(|c| {
                 self.registry()
                     .class_composed_roles
-                    .get(c)
+                    .get(c.as_str())
                     .is_some_and(|roles| {
                         roles.iter().any(|r| {
                             r == qualifier
@@ -498,7 +498,7 @@ impl Interpreter {
             self.class_mro(cn).iter().any(|c| {
                 self.registry()
                     .class_composed_roles
-                    .get(c)
+                    .get(c.as_str())
                     .is_some_and(|roles| {
                         roles.iter().any(|r| {
                             r == qualifier
@@ -575,12 +575,12 @@ impl Interpreter {
         {
             let inst_cn_str = inner_cn.resolve();
             let inst_mro = self.class_mro(&inst_cn_str);
-            let in_mro = inst_mro.iter().any(|c| c == qualifier);
+            let in_mro = inst_mro.iter().any(|c| c.as_str() == qualifier);
             let in_composed_roles = !in_mro
                 && inst_mro.iter().any(|c| {
                     self.registry()
                         .class_composed_roles
-                        .get(c)
+                        .get(c.as_str())
                         .is_some_and(|roles| {
                             roles.iter().any(|r| {
                                 r == qualifier

--- a/src/runtime/methods_walk.rs
+++ b/src/runtime/methods_walk.rs
@@ -483,7 +483,9 @@ impl Interpreter {
 
     /// Read-only variant of class_mro for use from non-mut helpers.
     fn class_mro_readonly(&self, class_name: &str) -> Option<Vec<String>> {
-        self.registry().class_mro_cached(class_name)
+        self.registry()
+            .class_mro_cached(class_name)
+            .map(|mro| mro.iter().map(|s| s.resolve()).collect())
     }
 
     /// Direct (declared) parent classes of `class_name`, in declaration order,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -474,6 +474,15 @@ impl DocComment {
     }
 }
 
+/// Intern a static name list into the `Arc<[Symbol]>` shape used by
+/// [`ClassDef::mro`]. Registration-time helper (not a dispatch hot path).
+pub(crate) fn sym_mro(names: &[&str]) -> std::sync::Arc<[crate::symbol::Symbol]> {
+    names
+        .iter()
+        .map(|s| crate::symbol::Symbol::intern(s))
+        .collect()
+}
+
 #[derive(Clone, Default)]
 pub(crate) struct ClassDef {
     parents: Vec<String>,
@@ -487,7 +496,7 @@ pub(crate) struct ClassDef {
     alias_attributes: HashSet<String>,
     methods: HashMap<String, Vec<MethodDef>>, // name -> overloads
     native_methods: HashSet<String>,
-    mro: Vec<String>,
+    mro: std::sync::Arc<[crate::symbol::Symbol]>,
     /// Attribute var names (e.g. "!foo") that have `handles *` wildcard delegation.
     wildcard_handles: Vec<String>,
     /// Class-level attributes declared with `our $.x` or `my $.x` (shared across instances).

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -284,20 +284,23 @@ impl Interpreter {
         ) {
             Some(class_name.to_string())
         } else {
-            self.class_mro(class_name).into_iter().find(|candidate| {
-                matches!(
-                    candidate.as_str(),
-                    "Promise"
-                        | "Channel"
-                        | "Supply"
-                        | "Supplier"
-                        | "Proc"
-                        | "Proc::Async"
-                        | "Encoding::Decoder"
-                        | "ThreadPoolScheduler"
-                        | "CurrentThreadScheduler"
-                )
-            })
+            self.class_mro(class_name)
+                .iter()
+                .map(|s| s.resolve())
+                .find(|candidate| {
+                    matches!(
+                        candidate.as_str(),
+                        "Promise"
+                            | "Channel"
+                            | "Supply"
+                            | "Supplier"
+                            | "Proc"
+                            | "Proc::Async"
+                            | "Encoding::Decoder"
+                            | "ThreadPoolScheduler"
+                            | "CurrentThreadScheduler"
+                    )
+                })
         };
         match dispatch_class.as_deref().unwrap_or(class_name) {
             "IO::Handle" => self.native_io_handle_mut(attributes, method, args),
@@ -368,42 +371,45 @@ impl Interpreter {
         ) {
             Some(class_name.to_string())
         } else {
-            self.class_mro(class_name).into_iter().find(|candidate| {
-                matches!(
-                    candidate.as_str(),
-                    "IO::Path"
-                        | "IO::Handle"
-                        | "IO::Special"
-                        | "IO::Socket::INET"
-                        | "IO::Socket::Async"
-                        | "IO::Socket::Async::Listener"
-                        | "IO::Pipe"
-                        | "Lock"
-                        | "Lock::Async"
-                        | "Lock::ConditionVariable"
-                        | "Distro"
-                        | "Kernel"
-                        | "Perl"
-                        | "Compiler"
-                        | "Promise"
-                        | "Promise::Vow"
-                        | "Channel"
-                        | "Thread"
-                        | "Proc::Async"
-                        | "Proc"
-                        | "Supply"
-                        | "Supplier"
-                        | "Tap"
-                        | "ThreadPoolScheduler"
-                        | "CurrentThreadScheduler"
-                        | "FakeScheduler"
-                        | "Cancellation"
-                        | "Encoding::Builtin"
-                        | "Encoding::Encoder"
-                        | "Encoding::Decoder"
-                        | "VM"
-                )
-            })
+            self.class_mro(class_name)
+                .iter()
+                .map(|s| s.resolve())
+                .find(|candidate| {
+                    matches!(
+                        candidate.as_str(),
+                        "IO::Path"
+                            | "IO::Handle"
+                            | "IO::Special"
+                            | "IO::Socket::INET"
+                            | "IO::Socket::Async"
+                            | "IO::Socket::Async::Listener"
+                            | "IO::Pipe"
+                            | "Lock"
+                            | "Lock::Async"
+                            | "Lock::ConditionVariable"
+                            | "Distro"
+                            | "Kernel"
+                            | "Perl"
+                            | "Compiler"
+                            | "Promise"
+                            | "Promise::Vow"
+                            | "Channel"
+                            | "Thread"
+                            | "Proc::Async"
+                            | "Proc"
+                            | "Supply"
+                            | "Supplier"
+                            | "Tap"
+                            | "ThreadPoolScheduler"
+                            | "CurrentThreadScheduler"
+                            | "FakeScheduler"
+                            | "Cancellation"
+                            | "Encoding::Builtin"
+                            | "Encoding::Encoder"
+                            | "Encoding::Decoder"
+                            | "VM"
+                    )
+                })
         };
         match dispatch_class.as_deref().unwrap_or(class_name) {
             "IO::Path" => self.native_io_path(attributes, class_name, method, args),

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -114,11 +114,11 @@ impl Interpreter {
     ) -> usize {
         let mut count = 0usize;
         let mro = self.class_mro(class_name);
-        for parent in mro.into_iter().skip(1) {
+        for parent in mro.iter().skip(1) {
             // No user-code re-entry in this loop body (only static helpers), so a
             // let-bound guard is safe.
             let registry = self.registry();
-            let Some(class_def) = registry.classes.get(&parent) else {
+            let Some(class_def) = registry.classes.get(parent.as_str()) else {
                 continue;
             };
             let Some(defs) = class_def.methods.get(method_name) else {

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -547,7 +547,7 @@ impl Interpreter {
             attribute_built: HashMap::new(),
             methods: all_methods,
             native_methods: HashSet::new(),
-            mro: vec![role_name.to_string(), "Any".to_string(), "Mu".to_string()],
+            mro: super::sym_mro(&[role_name, "Any", "Mu"]),
             wildcard_handles: Vec::new(),
             alias_attributes: HashSet::new(),
             class_level_attrs: HashMap::new(),

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -591,7 +591,7 @@ impl Interpreter {
             attribute_built: HashMap::new(),
             methods: HashMap::new(),
             native_methods: HashSet::new(),
-            mro: Vec::new(),
+            mro: [].into(),
             wildcard_handles: Vec::new(),
             alias_attributes: HashSet::new(),
             class_level_attrs: HashMap::new(),
@@ -974,7 +974,7 @@ impl Interpreter {
                     attribute_built: HashMap::new(),
                     methods: HashMap::new(),
                     native_methods: HashSet::new(),
-                    mro: Vec::new(),
+                    mro: [].into(),
                     wildcard_handles: Vec::new(),
                     alias_attributes: HashSet::new(),
                     class_level_attrs: HashMap::new(),
@@ -1910,7 +1910,7 @@ impl Interpreter {
                     {
                         if !class_def.parents.iter().any(|p| p == &role_name_str) {
                             class_def.parents.insert(0, role_name_str.clone());
-                            class_def.mro.clear();
+                            class_def.mro = [].into();
                         }
                         continue;
                     }
@@ -1968,7 +1968,7 @@ impl Interpreter {
                     if !class_def.parents.iter().any(|p| p == &role_name_str) {
                         // Keep role composition visible in MRO introspection.
                         class_def.parents.insert(0, role_name_str.clone());
-                        class_def.mro.clear();
+                        class_def.mro = [].into();
                     }
                     // Transfer role's own parents (from `is` declarations) to the class
                     if let Some(rparents) =
@@ -1980,7 +1980,7 @@ impl Interpreter {
                                 && !class_def.parents.iter().any(|p| p == &rp)
                             {
                                 class_def.parents.push(rp.clone());
-                                class_def.mro.clear();
+                                class_def.mro = [].into();
                             }
                         }
                     }
@@ -2241,11 +2241,11 @@ impl Interpreter {
         // classes may be absent from the computed MRO.
         if !self.registry().has_metamodel_how_classes
             && (parents.iter().any(|c| Self::is_metamodel_class_name(c))
-                || self
-                    .registry()
-                    .classes
-                    .get(name)
-                    .is_some_and(|cd| cd.mro.iter().any(|c| Self::is_metamodel_class_name(c))))
+                || self.registry().classes.get(name).is_some_and(|cd| {
+                    cd.mro
+                        .iter()
+                        .any(|c| Self::is_metamodel_class_name(c.as_str()))
+                }))
         {
             self.registry_mut().has_metamodel_how_classes = true;
         }

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -209,7 +209,7 @@ impl Registry {
         if let Some(class_def) = self.classes.get(class_name)
             && !class_def.mro.is_empty()
         {
-            return Ok(class_def.mro.clone());
+            return Ok(class_def.mro.iter().map(|s| s.resolve()).collect());
         }
         stack.push(class_name.to_string());
         let explicit_parents = self
@@ -314,58 +314,43 @@ impl Registry {
     /// when present, the hardcoded hierarchy for built-in types that are not
     /// user-defined classes, and otherwise computing + caching via
     /// [`Registry::compute_class_mro`]. Single write guard for the whole op.
-    pub(crate) fn class_mro(&mut self, class_name: &str) -> Vec<String> {
+    pub(crate) fn class_mro(&mut self, class_name: &str) -> std::sync::Arc<[Symbol]> {
         // Built-in type hierarchies for types that are not user-defined classes
         if !self.classes.contains_key(class_name) {
-            let builtin_mro: Option<Vec<&str>> = match class_name {
-                "Match" => Some(vec!["Match", "Capture", "Cool", "Any", "Mu"]),
-                "Capture" => Some(vec!["Capture", "Any", "Mu"]),
-                "IO::Spec" => Some(vec!["IO::Spec", "Any", "Mu"]),
-                "IO::Spec::Unix" => Some(vec!["IO::Spec::Unix", "IO::Spec", "Any", "Mu"]),
+            let builtin_mro: Option<&[&str]> = match class_name {
+                "Match" => Some(&["Match", "Capture", "Cool", "Any", "Mu"]),
+                "Capture" => Some(&["Capture", "Any", "Mu"]),
+                "IO::Spec" => Some(&["IO::Spec", "Any", "Mu"]),
+                "IO::Spec::Unix" => Some(&["IO::Spec::Unix", "IO::Spec", "Any", "Mu"]),
                 // Win32/Cygwin/QNX specialize the Unix spec (Raku MRO).
-                "IO::Spec::Win32" => Some(vec![
-                    "IO::Spec::Win32",
-                    "IO::Spec::Unix",
-                    "IO::Spec",
-                    "Any",
-                    "Mu",
-                ]),
-                "IO::Spec::Cygwin" => Some(vec![
+                "IO::Spec::Win32" => {
+                    Some(&["IO::Spec::Win32", "IO::Spec::Unix", "IO::Spec", "Any", "Mu"])
+                }
+                "IO::Spec::Cygwin" => Some(&[
                     "IO::Spec::Cygwin",
                     "IO::Spec::Unix",
                     "IO::Spec",
                     "Any",
                     "Mu",
                 ]),
-                "IO::Spec::QNX" => Some(vec![
-                    "IO::Spec::QNX",
-                    "IO::Spec::Unix",
-                    "IO::Spec",
-                    "Any",
-                    "Mu",
-                ]),
-                "Distribution::Path" => {
-                    Some(vec!["Distribution::Path", "Distribution", "Any", "Mu"])
+                "IO::Spec::QNX" => {
+                    Some(&["IO::Spec::QNX", "IO::Spec::Unix", "IO::Spec", "Any", "Mu"])
                 }
-                "Distribution::Hash" => {
-                    Some(vec!["Distribution::Hash", "Distribution", "Any", "Mu"])
+                "Distribution::Path" => Some(&["Distribution::Path", "Distribution", "Any", "Mu"]),
+                "Distribution::Hash" => Some(&["Distribution::Hash", "Distribution", "Any", "Mu"]),
+                "Distribution::Installation" => {
+                    Some(&["Distribution::Installation", "Distribution", "Any", "Mu"])
                 }
-                "Distribution::Installation" => Some(vec![
-                    "Distribution::Installation",
-                    "Distribution",
-                    "Any",
-                    "Mu",
-                ]),
                 "CompUnit::DependencySpecification" => {
-                    Some(vec!["CompUnit::DependencySpecification", "Any", "Mu"])
+                    Some(&["CompUnit::DependencySpecification", "Any", "Mu"])
                 }
-                "CompUnit::Repository::FileSystem" => Some(vec![
+                "CompUnit::Repository::FileSystem" => Some(&[
                     "CompUnit::Repository::FileSystem",
                     "CompUnit::Repository",
                     "Any",
                     "Mu",
                 ]),
-                "CompUnit::Repository::Installation" => Some(vec![
+                "CompUnit::Repository::Installation" => Some(&[
                     "CompUnit::Repository::Installation",
                     "CompUnit::Repository::Installable",
                     "CompUnit::Repository::Locally",
@@ -376,7 +361,7 @@ impl Registry {
                 _ => None,
             };
             if let Some(mro) = builtin_mro {
-                return mro.into_iter().map(String::from).collect();
+                return mro.iter().map(|s| Symbol::intern(s)).collect();
             }
         }
         if !self.classes.contains_key(class_name)
@@ -384,9 +369,9 @@ impl Registry {
             && class_name.ends_with(']')
             && self.classes.contains_key(base)
         {
-            let mut mro = vec![class_name.to_string()];
-            mro.extend(self.class_mro(base));
-            return mro;
+            let mut mro = vec![Symbol::intern(class_name)];
+            mro.extend(self.class_mro(base).iter().copied());
+            return mro.into();
         }
         if let Some(class_def) = self.classes.get(class_name)
             && !class_def.mro.is_empty()
@@ -396,32 +381,33 @@ impl Registry {
         let mut stack = Vec::new();
         match self.compute_class_mro(class_name, &mut stack) {
             Ok(mro) => {
+                let mro: std::sync::Arc<[Symbol]> = mro.iter().map(|s| Symbol::intern(s)).collect();
                 if let Some(class_def) = self.classes.get_mut(class_name) {
                     class_def.mro = mro.clone();
                 }
                 mro
             }
-            Err(_) => vec![class_name.to_string()],
+            Err(_) => [Symbol::intern(class_name)].into(),
         }
     }
 
     /// Read-only MRO lookup: the cached `ClassDef::mro` when present, otherwise a
     /// single-element MRO `[class_name]`. Returns `None` when the class is not
     /// registered. Used by non-`&mut` helpers that must not trigger computation.
-    pub(crate) fn class_mro_cached(&self, class_name: &str) -> Option<Vec<String>> {
+    pub(crate) fn class_mro_cached(&self, class_name: &str) -> Option<std::sync::Arc<[Symbol]>> {
         let class_def = self.classes.get(class_name)?;
         if !class_def.mro.is_empty() {
             return Some(class_def.mro.clone());
         }
-        Some(vec![class_name.to_string()])
+        Some([Symbol::intern(class_name)].into())
     }
 
     /// Whether `class_name` (or any class in its MRO) defines `method_name`
     /// either as a user method or a native method. Pure registry MRO walk.
     pub(crate) fn class_has_method(&mut self, class_name: &str, method_name: &str) -> bool {
         let mro = self.class_mro(class_name);
-        for cn in mro {
-            if let Some(class_def) = self.classes.get(&cn)
+        for cn in mro.iter() {
+            if let Some(class_def) = self.classes.get(cn.as_str())
                 && (class_def.methods.contains_key(method_name)
                     || class_def.native_methods.contains(method_name))
             {
@@ -522,7 +508,7 @@ impl Registry {
     /// parametric suffix is stripped (`R[Int]` -> `R`). Push order is load-bearing
     /// — the caller consumes this LIFO via `.pop()` and relies on first-match-wins,
     /// so this method MUST NOT dedup or sort (dedup happens during the walk).
-    pub(crate) fn composed_roles_seed(&self, mro: &[String]) -> Vec<String> {
+    pub(crate) fn composed_roles_seed(&self, mro: &[Symbol]) -> Vec<String> {
         let mut seed = Vec::new();
         for cn in mro {
             if let Some(composed) = self.class_composed_roles.get(cn.as_str()) {

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -176,7 +176,7 @@ impl Interpreter {
     pub(crate) fn class_parents_readonly(&self, class_name: &str) -> Vec<String> {
         if let Some(class_def) = self.registry().classes.get(class_name) {
             if !class_def.mro.is_empty() {
-                return class_def.mro.clone();
+                return class_def.mro.iter().map(|s| s.resolve()).collect();
             }
             return class_def.parents.clone();
         }
@@ -199,7 +199,7 @@ impl Interpreter {
         if let Some(class_def) = self.registry().classes.get(class_name)
             && !class_def.mro.is_empty()
         {
-            return class_def.mro.clone();
+            return class_def.mro.iter().map(|s| s.resolve()).collect();
         }
         // Fallback: built-in/unregistered classes, or a registered class whose
         // MRO has not been computed yet (parents-only walk).

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -118,7 +118,7 @@ impl Interpreter {
         // (submethods block MRO search for their class but not for
         // descendants).
         let mut submethod_blocks = false;
-        for cn in &mro {
+        for cn in mro.iter() {
             // Hoist the clone to a `let` so the registry read guard drops here,
             // before method_args_match_for_invocant re-enters (&mut self). An
             // `if let` scrutinee would otherwise keep the temporary guard alive
@@ -131,7 +131,7 @@ impl Interpreter {
                 let mut first_visible_non_multi: Option<MethodDef> = None;
                 // Check if all overloads are submethods on an ancestor class
                 let all_submethods = overloads.iter().all(|d| d.is_my);
-                let is_ancestor = cn != class_name;
+                let is_ancestor = cn.as_str() != class_name;
                 // Single-visible-candidate fast return: with exactly one visible
                 // non-multi candidate (and no multi collected from a more-derived
                 // class), the outcome is invariant to the speculative argument
@@ -155,7 +155,7 @@ impl Interpreter {
                                 && pd.sub_signature.is_none()
                         })
                     {
-                        return Some((cn.clone(), only.clone()));
+                        return Some((cn.resolve(), only.clone()));
                     }
                 }
                 for def in overloads {
@@ -182,9 +182,9 @@ impl Interpreter {
                             // Non-multi: return the first match immediately,
                             // but only if no multi candidates were already
                             // collected from a child class in the MRO.
-                            return Some((cn.clone(), def));
+                            return Some((cn.resolve(), def));
                         }
-                        all_matches.push((cn.clone(), def));
+                        all_matches.push((cn.resolve(), def));
                     }
                 }
                 // A non-multi submethod on an ancestor blocks the MRO search
@@ -198,7 +198,7 @@ impl Interpreter {
                 // For non-multi methods, stop here — a subclass override
                 // hides the parent's version.
                 if !any_multi && all_matches.is_empty() {
-                    return first_visible_non_multi.map(|def| (cn.clone(), def));
+                    return first_visible_non_multi.map(|def| (cn.resolve(), def));
                 }
             }
         }
@@ -414,8 +414,8 @@ impl Interpreter {
         let mro = self.class_mro(class_name);
         let registry = self.registry();
         let mut count = 0usize;
-        for cn in &mro {
-            let is_ancestor = cn != class_name;
+        for cn in mro.iter() {
+            let is_ancestor = cn.as_str() != class_name;
             let overloads = registry
                 .classes
                 .get(cn.as_str())
@@ -448,7 +448,7 @@ impl Interpreter {
         let role_bindings = self.registry().get_role_param_bindings(class_name);
         let mro = self.class_mro(class_name);
         let mut matches = Vec::new();
-        for cn in &mro {
+        for cn in mro.iter() {
             // An MRO entry may be a regular class or a punned role used as a
             // parent (`class Foo is R1 { ... }`). Role methods are stored in
             // `self.registry().roles`, so fall back there when the entry is not a class.
@@ -469,7 +469,7 @@ impl Interpreter {
                     .cloned()
             };
             if let Some(overloads) = overloads {
-                let is_ancestor = cn != class_name;
+                let is_ancestor = cn.as_str() != class_name;
                 for def in overloads {
                     if def.is_private {
                         continue;
@@ -485,7 +485,7 @@ impl Interpreter {
                         role_bindings.as_ref(),
                         None,
                     ) {
-                        matches.push((cn.clone(), def));
+                        matches.push((cn.resolve(), def));
                     }
                 }
             }
@@ -504,8 +504,8 @@ impl Interpreter {
     ) -> Vec<(String, MethodDef)> {
         let mro = self.class_mro(class_name);
         let mut defining_levels: Vec<String> = Vec::new();
-        for cn in &mro {
-            let is_ancestor = cn != class_name;
+        for cn in mro.iter() {
+            let is_ancestor = cn.as_str() != class_name;
             if let Some(overloads) = self
                 .registry()
                 .get_method_overloads(cn.as_str(), method_name)
@@ -514,7 +514,7 @@ impl Interpreter {
                     .iter()
                     .any(|d| !d.is_private && (!d.is_my || !is_ancestor));
                 if has_visible {
-                    defining_levels.push(cn.clone());
+                    defining_levels.push(cn.resolve());
                 }
             }
         }

--- a/src/runtime/resolution_private_method.rs
+++ b/src/runtime/resolution_private_method.rs
@@ -22,12 +22,12 @@ impl Interpreter {
     ) -> Option<(String, MethodDef)> {
         let role_bindings = self.registry().get_role_param_bindings(class_name);
         let mro = self.class_mro(class_name);
-        for cn in mro {
+        for cn in mro.iter().map(|s| s.as_str()) {
             if cn != owner_class {
                 continue;
             }
             // Hoist clone to a `let` so the guard drops before re-entry (&mut self).
-            let overloads = self.registry().get_method_overloads(&cn, method_name);
+            let overloads = self.registry().get_method_overloads(cn, method_name);
             if let Some(overloads) = overloads {
                 for def in overloads {
                     if !def.is_private {
@@ -40,7 +40,7 @@ impl Interpreter {
                         role_bindings.as_ref(),
                         None,
                     ) {
-                        return Some((cn.clone(), def));
+                        return Some((cn.to_string(), def));
                     }
                 }
             }
@@ -71,11 +71,11 @@ impl Interpreter {
             // overloads Vec — only the single matched def is cloned), find the
             // candidate, then drop the guard before mutating the cache.
             let mut resolved: Option<(String, MethodDef)> = None;
-            'scan: for cn in &mro {
+            'scan: for cn in mro.iter() {
                 let registry = self.registry();
                 if let Some(overloads) = registry
                     .classes
-                    .get(cn)
+                    .get(cn.as_str())
                     .and_then(|c| c.methods.get(method_name))
                 {
                     // First pass: skip stubs
@@ -91,7 +91,7 @@ impl Interpreter {
                             .iter()
                             .all(|p| p.is_invocant || p.traits.iter().any(|t| t == "invocant"))
                         {
-                            resolved = Some((cn.clone(), def.clone()));
+                            resolved = Some((cn.resolve(), def.clone()));
                             break 'scan;
                         }
                     }
@@ -105,7 +105,7 @@ impl Interpreter {
                             .iter()
                             .all(|p| p.is_invocant || p.traits.iter().any(|t| t == "invocant"))
                         {
-                            resolved = Some((cn.clone(), def.clone()));
+                            resolved = Some((cn.resolve(), def.clone()));
                             break 'scan;
                         }
                     }
@@ -119,9 +119,9 @@ impl Interpreter {
                 return Some(resolved);
             }
         }
-        for cn in mro {
+        for cn in mro.iter().map(|s| s.as_str()) {
             // Hoist clone to a `let` so the guard drops before re-entry (&mut self).
-            let overloads = self.registry().get_method_overloads(&cn, method_name);
+            let overloads = self.registry().get_method_overloads(cn, method_name);
             if let Some(overloads) = overloads {
                 for def in &overloads {
                     if !def.is_private {
@@ -137,7 +137,7 @@ impl Interpreter {
                         role_bindings.as_ref(),
                         None,
                     ) {
-                        return Some((cn.clone(), def.clone()));
+                        return Some((cn.to_string(), def.clone()));
                     }
                 }
                 for def in overloads {
@@ -151,7 +151,7 @@ impl Interpreter {
                         role_bindings.as_ref(),
                         None,
                     ) {
-                        return Some((cn.clone(), def));
+                        return Some((cn.to_string(), def));
                     }
                 }
             }
@@ -181,7 +181,10 @@ impl Interpreter {
 
     /// Resolve the MRO for `class_name`. Delegates to [`Registry::class_mro`],
     /// which holds a single write guard for the whole compute-and-cache op.
-    pub(crate) fn class_mro(&mut self, class_name: &str) -> Vec<String> {
+    /// Returns the cached interned-symbol MRO — an `Arc` clone, no per-call
+    /// `String` allocations (the old `Vec<String>` clone was a per-dispatch
+    /// allocation hot spot).
+    pub(crate) fn class_mro(&mut self, class_name: &str) -> std::sync::Arc<[Symbol]> {
         self.registry_mut().class_mro(class_name)
     }
 }

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -74,7 +74,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Mu".to_string()],
+                mro: sym_mro(&["Mu"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -90,7 +90,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Any".to_string(), "Mu".to_string()],
+                mro: sym_mro(&["Any", "Mu"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -106,11 +106,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec![
-                    "IterationBuffer".to_string(),
-                    "Any".to_string(),
-                    "Mu".to_string(),
-                ],
+                mro: sym_mro(&["IterationBuffer", "Any", "Mu"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -129,7 +125,7 @@ impl Interpreter {
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),
-                mro: vec!["Promise".to_string()],
+                mro: sym_mro(&["Promise"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -145,7 +141,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: ["keep", "break"].iter().map(|s| s.to_string()).collect(),
-                mro: vec!["Promise::Vow".to_string()],
+                mro: sym_mro(&["Promise::Vow"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -164,7 +160,7 @@ impl Interpreter {
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),
-                mro: vec!["Channel".to_string()],
+                mro: sym_mro(&["Channel"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -180,7 +176,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Collation".to_string()],
+                mro: sym_mro(&["Collation"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -196,7 +192,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: ["finish", "id"].iter().map(|s| s.to_string()).collect(),
-                mro: vec!["Thread".to_string()],
+                mro: sym_mro(&["Thread"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -243,7 +239,7 @@ impl Interpreter {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
-                mro: vec!["Supply".to_string()],
+                mro: sym_mro(&["Supply"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -259,7 +255,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["utf8".to_string()],
+                mro: sym_mro(&["utf8"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -275,7 +271,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["utf16".to_string()],
+                mro: sym_mro(&["utf16"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -291,7 +287,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Blob".to_string(), "Any".to_string(), "Mu".to_string()],
+                mro: sym_mro(&["Blob", "Any", "Mu"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -307,12 +303,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec![
-                    "Buf".to_string(),
-                    "Blob".to_string(),
-                    "Any".to_string(),
-                    "Mu".to_string(),
-                ],
+                mro: sym_mro(&["Buf", "Blob", "Any", "Mu"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -337,7 +328,7 @@ impl Interpreter {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
-                mro: vec!["Supplier".to_string()],
+                mro: sym_mro(&["Supplier"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -353,7 +344,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Supplier::Preserving".to_string(), "Supplier".to_string()],
+                mro: sym_mro(&["Supplier::Preserving", "Supplier"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -391,7 +382,7 @@ impl Interpreter {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
-                mro: vec!["Proc::Async".to_string()],
+                mro: sym_mro(&["Proc::Async"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -413,7 +404,7 @@ impl Interpreter {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
-                mro: vec!["Proc".to_string()],
+                mro: sym_mro(&["Proc"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -432,7 +423,7 @@ impl Interpreter {
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),
-                mro: vec!["Tap".to_string()],
+                mro: sym_mro(&["Tap"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -448,7 +439,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: ["cue"].iter().map(|s| s.to_string()).collect(),
-                mro: vec!["Scheduler".to_string()],
+                mro: sym_mro(&["Scheduler"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -467,7 +458,7 @@ impl Interpreter {
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),
-                mro: vec!["ThreadPoolScheduler".to_string()],
+                mro: sym_mro(&["ThreadPoolScheduler"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -486,7 +477,7 @@ impl Interpreter {
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),
-                mro: vec!["CurrentThreadScheduler".to_string()],
+                mro: sym_mro(&["CurrentThreadScheduler"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -505,7 +496,7 @@ impl Interpreter {
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),
-                mro: vec!["FakeScheduler".to_string(), "Scheduler".to_string()],
+                mro: sym_mro(&["FakeScheduler", "Scheduler"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -521,7 +512,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: ["cancel"].iter().map(|s| s.to_string()).collect(),
-                mro: vec!["Cancellation".to_string()],
+                mro: sym_mro(&["Cancellation"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -540,7 +531,7 @@ impl Interpreter {
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),
-                mro: vec!["Lock".to_string()],
+                mro: sym_mro(&["Lock"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -556,7 +547,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Lock::Async".to_string(), "Lock".to_string()],
+                mro: sym_mro(&["Lock::Async", "Lock"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -572,7 +563,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Lock::Soft".to_string(), "Lock".to_string()],
+                mro: sym_mro(&["Lock::Soft", "Lock"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -591,7 +582,7 @@ impl Interpreter {
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),
-                mro: vec!["Lock::ConditionVariable".to_string()],
+                mro: sym_mro(&["Lock::ConditionVariable"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -610,7 +601,7 @@ impl Interpreter {
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),
-                mro: vec!["Semaphore".to_string()],
+                mro: sym_mro(&["Semaphore"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -693,7 +684,7 @@ impl Interpreter {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
-                mro: vec!["IO::Path".to_string()],
+                mro: sym_mro(&["IO::Path"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -743,7 +734,7 @@ impl Interpreter {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
-                mro: vec!["IO::Handle".to_string()],
+                mro: sym_mro(&["IO::Handle"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -811,7 +802,7 @@ impl Interpreter {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
-                mro: vec!["IO::CatHandle".to_string()],
+                mro: sym_mro(&["IO::CatHandle"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -827,7 +818,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Backtrace".to_string()],
+                mro: sym_mro(&["Backtrace"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -843,7 +834,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["CompUnit::Repository::FileSystem".to_string()],
+                mro: sym_mro(&["CompUnit::Repository::FileSystem"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -862,7 +853,7 @@ impl Interpreter {
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),
-                mro: vec!["IO::Pipe".to_string()],
+                mro: sym_mro(&["IO::Pipe"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -895,7 +886,7 @@ impl Interpreter {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
-                mro: vec!["IO::Socket::INET".to_string()],
+                mro: sym_mro(&["IO::Socket::INET"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -925,7 +916,7 @@ impl Interpreter {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
-                mro: vec!["IO::Socket::Async".to_string()],
+                mro: sym_mro(&["IO::Socket::Async"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -941,7 +932,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: ["tap", "act"].iter().map(|s| s.to_string()).collect(),
-                mro: vec!["IO::Socket::Async::Listener".to_string()],
+                mro: sym_mro(&["IO::Socket::Async::Listener"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -973,7 +964,7 @@ impl Interpreter {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
-                mro: vec!["Distro".to_string()],
+                mro: sym_mro(&["Distro"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1008,7 +999,7 @@ impl Interpreter {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
-                mro: vec!["Perl".to_string()],
+                mro: sym_mro(&["Perl"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1045,7 +1036,7 @@ impl Interpreter {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
-                mro: vec!["Kernel".to_string()],
+                mro: sym_mro(&["Kernel"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1074,7 +1065,7 @@ impl Interpreter {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
-                mro: vec!["VM".to_string()],
+                mro: sym_mro(&["VM"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1106,7 +1097,7 @@ impl Interpreter {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
-                mro: vec!["Compiler".to_string()],
+                mro: sym_mro(&["Compiler"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1125,7 +1116,7 @@ impl Interpreter {
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),
-                mro: vec!["Encoding::Builtin".to_string()],
+                mro: sym_mro(&["Encoding::Builtin"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1141,7 +1132,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: ["encode-chars"].iter().map(|s| s.to_string()).collect(),
-                mro: vec!["Encoding::Encoder".to_string()],
+                mro: sym_mro(&["Encoding::Encoder"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1168,7 +1159,7 @@ impl Interpreter {
                 .iter()
                 .map(|s| s.to_string())
                 .collect(),
-                mro: vec!["Encoding::Decoder".to_string()],
+                mro: sym_mro(&["Encoding::Decoder"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1184,7 +1175,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: ["find", "register"].iter().map(|s| s.to_string()).collect(),
-                mro: vec!["Encoding::Registry".to_string()],
+                mro: sym_mro(&["Encoding::Registry"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1200,7 +1191,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Pod::Block".to_string()],
+                mro: sym_mro(&["Pod::Block"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1216,7 +1207,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Pod::Block::Code".to_string(), "Pod::Block".to_string()],
+                mro: sym_mro(&["Pod::Block::Code", "Pod::Block"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1232,7 +1223,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Pod::FormattingCode".to_string(), "Pod::Block".to_string()],
+                mro: sym_mro(&["Pod::FormattingCode", "Pod::Block"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1248,7 +1239,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Pod::Block::Comment".to_string(), "Pod::Block".to_string()],
+                mro: sym_mro(&["Pod::Block::Comment", "Pod::Block"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1264,7 +1255,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Pod::Block::Para".to_string(), "Pod::Block".to_string()],
+                mro: sym_mro(&["Pod::Block::Para", "Pod::Block"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1280,7 +1271,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Pod::Block::Named".to_string(), "Pod::Block".to_string()],
+                mro: sym_mro(&["Pod::Block::Named", "Pod::Block"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1296,7 +1287,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Pod::Heading".to_string(), "Pod::Block".to_string()],
+                mro: sym_mro(&["Pod::Heading", "Pod::Block"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1312,7 +1303,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Pod::Block::Table".to_string(), "Pod::Block".to_string()],
+                mro: sym_mro(&["Pod::Block::Table", "Pod::Block"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1328,7 +1319,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Pod::Config".to_string()],
+                mro: sym_mro(&["Pod::Config"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1344,7 +1335,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Pod::Item".to_string(), "Pod::Block".to_string()],
+                mro: sym_mro(&["Pod::Item", "Pod::Block"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1360,7 +1351,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["Exception".to_string()],
+                mro: sym_mro(&["Exception"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1376,7 +1367,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["X::AdHoc".to_string(), "Exception".to_string()],
+                mro: sym_mro(&["X::AdHoc", "Exception"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1392,7 +1383,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["X::TypeCheck".to_string(), "Exception".to_string()],
+                mro: sym_mro(&["X::TypeCheck", "Exception"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1408,11 +1399,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec![
-                    "X::TypeCheck::Binding".to_string(),
-                    "X::TypeCheck".to_string(),
-                    "Exception".to_string(),
-                ],
+                mro: sym_mro(&["X::TypeCheck::Binding", "X::TypeCheck", "Exception"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1428,12 +1415,12 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec![
-                    "X::TypeCheck::Binding::Parameter".to_string(),
-                    "X::TypeCheck::Binding".to_string(),
-                    "X::TypeCheck".to_string(),
-                    "Exception".to_string(),
-                ],
+                mro: sym_mro(&[
+                    "X::TypeCheck::Binding::Parameter",
+                    "X::TypeCheck::Binding",
+                    "X::TypeCheck",
+                    "Exception",
+                ]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1449,7 +1436,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["X::Parameter".to_string(), "Exception".to_string()],
+                mro: sym_mro(&["X::Parameter", "Exception"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1465,11 +1452,11 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec![
-                    "X::Parameter::InvalidConcreteness".to_string(),
-                    "X::Parameter".to_string(),
-                    "Exception".to_string(),
-                ],
+                mro: sym_mro(&[
+                    "X::Parameter::InvalidConcreteness",
+                    "X::Parameter",
+                    "Exception",
+                ]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1485,7 +1472,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["X::Supply::Combinator".to_string(), "Exception".to_string()],
+                mro: sym_mro(&["X::Supply::Combinator", "Exception"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1501,11 +1488,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec![
-                    "X::TypeCheck::Argument".to_string(),
-                    "X::TypeCheck".to_string(),
-                    "Exception".to_string(),
-                ],
+                mro: sym_mro(&["X::TypeCheck::Argument", "X::TypeCheck", "Exception"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1521,11 +1504,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec![
-                    "X::TypeCheck::Assignment".to_string(),
-                    "X::TypeCheck".to_string(),
-                    "Exception".to_string(),
-                ],
+                mro: sym_mro(&["X::TypeCheck::Assignment", "X::TypeCheck", "Exception"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1541,7 +1520,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["X::Numeric::Real".to_string(), "Exception".to_string()],
+                mro: sym_mro(&["X::Numeric::Real", "Exception"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1557,7 +1536,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["X::TypeCheck::Return".to_string(), "Exception".to_string()],
+                mro: sym_mro(&["X::TypeCheck::Return", "Exception"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1573,7 +1552,7 @@ impl Interpreter {
                 attributes: Vec::new(),
                 methods: HashMap::new(),
                 native_methods: HashSet::new(),
-                mro: vec!["X::Coerce::Impossible".to_string(), "Exception".to_string()],
+                mro: sym_mro(&["X::Coerce::Impossible", "Exception"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),
                 attribute_built: HashMap::new(),
@@ -1603,6 +1582,7 @@ impl Interpreter {
             if !mro.contains(&"Exception".to_string()) {
                 mro.push("Exception".to_string());
             }
+            let mro: std::sync::Arc<[Symbol]> = mro.iter().map(|s| Symbol::intern(s)).collect();
             classes.insert(
                 name.to_string(),
                 ClassDef {
@@ -1767,9 +1747,12 @@ impl Interpreter {
             if !def.parents.iter().any(|p| p == "X::AdHoc") {
                 def.parents.push("X::AdHoc".to_string());
             }
-            if !def.mro.iter().any(|m| m == "X::AdHoc") {
+            let x_adhoc = Symbol::intern("X::AdHoc");
+            if !def.mro.contains(&x_adhoc) {
                 let insert_at = def.mro.len().saturating_sub(1);
-                def.mro.insert(insert_at, "X::AdHoc".to_string());
+                let mut mro: Vec<Symbol> = def.mro.to_vec();
+                mro.insert(insert_at, x_adhoc);
+                def.mro = mro.into();
             }
         }
 

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -1092,7 +1092,7 @@ impl Interpreter {
                         let parent_mro = self.class_mro(&parent);
                         if parent_mro
                             .iter()
-                            .any(|p| Self::type_matches(&rhs_resolved, p))
+                            .any(|p| Self::type_matches(&rhs_resolved, p.as_str()))
                         {
                             return true;
                         }

--- a/src/runtime/test_functions/eval_exception.rs
+++ b/src/runtime/test_functions/eval_exception.rs
@@ -92,7 +92,7 @@ impl Interpreter {
         // For Package values, also check full MRO (handles grammar/class inheritance)
         if !ok && let ValueView::Package(name) = value.view() {
             let mro = self.class_mro(&name.resolve());
-            ok = mro.contains(&type_name);
+            ok = mro.contains(&crate::symbol::Symbol::intern(&type_name));
         }
         self.test_ok(ok, &desc, todo)?;
         Ok(Value::truth(ok))

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -595,35 +595,34 @@ impl Interpreter {
         };
 
         // Check if the exception matches any of the provided types
-        let type_ok =
-            match &result {
-                Ok(_) => false,
-                Err(err) => {
-                    let ex_class = err.exception.as_ref().and_then(|ex| {
-                        if let ValueView::Instance { class_name, .. } = ex.as_ref().view() {
-                            Some(class_name.resolve().to_string())
-                        } else {
-                            None
-                        }
-                    });
-                    type_names.iter().any(|expected: &String| -> bool {
-                        if expected.is_empty() || expected == "Exception" {
-                            return true;
-                        }
-                        if let Some(cls) = &ex_class
-                            && (cls == expected
-                                || cls.starts_with(&format!("{}::", expected))
-                                || self.registry().classes.get(cls).is_some_and(|def| {
-                                    def.mro.iter().any(|parent| parent == expected)
-                                }))
-                        {
-                            return true;
-                        }
-                        // Fallback: message-based matching
-                        err.message.contains(expected.as_str())
-                    })
-                }
-            };
+        let type_ok = match &result {
+            Ok(_) => false,
+            Err(err) => {
+                let ex_class = err.exception.as_ref().and_then(|ex| {
+                    if let ValueView::Instance { class_name, .. } = ex.as_ref().view() {
+                        Some(class_name.resolve().to_string())
+                    } else {
+                        None
+                    }
+                });
+                type_names.iter().any(|expected: &String| -> bool {
+                    if expected.is_empty() || expected == "Exception" {
+                        return true;
+                    }
+                    if let Some(cls) = &ex_class
+                        && (cls == expected
+                            || cls.starts_with(&format!("{}::", expected))
+                            || self.registry().classes.get(cls).is_some_and(|def| {
+                                def.mro.iter().any(|parent| parent.as_str() == expected)
+                            }))
+                    {
+                        return true;
+                    }
+                    // Fallback: message-based matching
+                    err.message.contains(expected.as_str())
+                })
+            }
+        };
 
         let type_display = type_names.join(", ");
 

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -853,7 +853,7 @@ impl Interpreter {
             let mro = self.class_mro(&package_name.resolve());
             if mro
                 .iter()
-                .any(|parent| Self::type_matches(effective_constraint, parent))
+                .any(|parent| Self::type_matches(effective_constraint, parent.as_str()))
             {
                 return true;
             }
@@ -933,7 +933,7 @@ impl Interpreter {
                     let parent_mro = self.class_mro(&parent);
                     if parent_mro
                         .iter()
-                        .any(|p| Self::type_matches(effective_constraint, p))
+                        .any(|p| Self::type_matches(effective_constraint, p.as_str()))
                     {
                         return true;
                     }
@@ -1001,7 +1001,7 @@ impl Interpreter {
             let mro = self.class_mro(&class_name.resolve());
             if mro
                 .iter()
-                .any(|parent| Self::type_matches(constraint, parent))
+                .any(|parent| Self::type_matches(constraint, parent.as_str()))
             {
                 return true;
             }

--- a/src/vm/vm_call_method_compiled_cache.rs
+++ b/src/vm/vm_call_method_compiled_cache.rs
@@ -60,8 +60,11 @@ impl Interpreter {
         let mro = self.class_mro(class_name);
         let mut any_multi = false;
         let mut value_dependent = false;
-        'outer: for cn in &mro {
-            let Some(overloads) = self.registry().get_method_overloads(cn, method_name) else {
+        'outer: for cn in mro.iter() {
+            let Some(overloads) = self
+                .registry()
+                .get_method_overloads(cn.as_str(), method_name)
+            else {
                 continue;
             };
             for def in &overloads {


### PR DESCRIPTION
## Summary

Base slice of the dispatch-signature Symbol campaign (PLAN §1 B2 populate-perf frontier / §5: Symbol intern/as_str traffic in dispatch signatures).

`Registry::class_mro` returned `ClassDef::mro` **by value** — a fresh `Vec<String>` (one `String` allocation per MRO entry) on every call, *even on a cache hit* — and every dispatch-path caller immediately re-borrowed each element with `.as_str()`. This per-dispatch clone plus the Symbol→resolve→String→re-intern round-trips around it are what the ctor/populate profiles show as Symbol `as_str` ~4.3% + intern ~1.9% and part of the ~19% malloc cluster.

## Changes

- `ClassDef::mro` is now `Arc<[Symbol]>`; `class_mro` / `class_mro_cached` return an Arc clone — **zero allocations on the cached path**.
- Builtin-type MROs intern static name lists; the C3 computation itself stays on `Vec<String>` (cold) and converts once when the cache is filled.
- All ~84 `class_mro` call sites + ~25 direct `.mro` field uses now iterate `Symbol`s and use the allocation-free `Symbol::as_str()` for registry lookups. Sites that genuinely need owned `String`s (introspection output, resolver owner results) call `.resolve()` explicitly — no worse than the old per-call clone.
- `composed_roles_seed` takes `&[Symbol]`; `runtime_init` class tables build MRO entries via a `sym_mro` helper.

## Measurements

- bench-ctor (release, `perf stat -r5 -e instructions:u`, P-core pinned): **2.569G → 2.543G retired instructions (-1.0%)**. Small here because the native-ctor plan cache already shields most `class_mro` calls; the resolve-miss/introspection paths (zef populate) are the real beneficiaries.
- fez populate (7657 dists): 6.2s, index names 9260 = unchanged correctness.
- `make test` full PASS (1730 files / 17002 tests); OOP pins (accessor-mro-shadowing, ctor-self-identity, bless-native-fork, augment-class) green.

## Follow-ups (same campaign, next PRs)

1. Store the owner as `Symbol` in the method-resolve caches (`MethodResolveEntry`, `last_method_resolve`, `multi_resolve_cache`) — removes the owner-`String` clone on every cache hit and the `Symbol::intern(&owner_class)` re-intern.
2. Symbol-key the class registry (`classes: HashMap<String, ClassDef>`) so receivers pass the `Symbol` they already hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)