### PR TITLE
perf: store the resolved method owner as a Symbol in the resolve caches

### DIFF
--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -733,10 +733,10 @@ impl Interpreter {
                 skipped_chosen = true;
                 continue;
             }
-            if self.should_skip_defer_method_candidate(receiver_class, &owner) {
+            if self.should_skip_defer_method_candidate(receiver_class, owner.as_str()) {
                 continue;
             }
-            remaining.push((owner, def));
+            remaining.push((owner.resolve(), def));
         }
         let pushed = !remaining.is_empty();
         if pushed {

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -182,10 +182,10 @@ impl Interpreter {
                     skipped = true;
                     continue;
                 }
-                if this.should_skip_defer_method_candidate(receiver_class_name, &owner) {
+                if this.should_skip_defer_method_candidate(receiver_class_name, owner.as_str()) {
                     continue;
                 }
-                remaining.push((owner, def));
+                remaining.push((owner.resolve(), def));
             }
             remaining
         };
@@ -207,9 +207,9 @@ impl Interpreter {
         if self.has_any_wrap_chains()
             && !self.is_inside_wrap_dispatch()
             && let Some(cand_idx) =
-                self.find_method_candidate_index(&owner_class, method_name, &method_def)
+                self.find_method_candidate_index(owner_class.as_str(), method_name, &method_def)
             && let Some(chain) = self
-                .get_method_wrap_chain(&owner_class, method_name, cand_idx)
+                .get_method_wrap_chain(owner_class.as_str(), method_name, cand_idx)
                 .cloned()
         {
             let invocant_for_dispatch = make_invocant_for_dispatch(&invocant, attributes);
@@ -236,7 +236,7 @@ impl Interpreter {
             let mut orig_env = crate::env::Env::new();
             orig_env.insert("__mutsu_method_wrap_original".to_string(), Value::TRUE);
             let original_sub = Value::make_sub(
-                Symbol::intern(&owner_class),
+                owner_class,
                 Symbol::intern(method_name),
                 method_def.params.clone(),
                 method_def.param_defs.clone(),
@@ -307,7 +307,7 @@ impl Interpreter {
         // Check for `is DEPRECATED` trait on the method
         if let Some(ref msg) = method_def.deprecated_message {
             let cl = self.test_pending_callsite_line;
-            self.check_deprecation_for_method_with_line(method_name, &owner_class, msg, cl);
+            self.check_deprecation_for_method_with_line(method_name, owner_class.as_str(), msg, cl);
         }
         // §B: run the resolved (non-wrapped) candidate as compiled bytecode via the
         // VM-native `call_compiled_method` instead of the tree-walk
@@ -320,7 +320,7 @@ impl Interpreter {
         // the interpreter path.
         let result = self.run_resolved_method_celled(
             receiver_class_name,
-            &owner_class,
+            owner_class.as_str(),
             method_name,
             method_def,
             attributes,

--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -134,6 +134,7 @@ impl Interpreter {
                     self.resolve_all_methods_with_owner(bc, lookup_name, &args)
                         .into_iter()
                         .filter(|(_, d)| d.is_private == is_private_call)
+                        .map(|(o, d)| (o.resolve(), d))
                         .collect()
                 } else {
                     Vec::new()

--- a/src/runtime/methods_signature_shaped.rs
+++ b/src/runtime/methods_signature_shaped.rs
@@ -235,7 +235,7 @@ impl Interpreter {
                     );
                     let (result, updated) = self.run_resolved_method_compiled_or_treewalk(
                         &class_name.resolve(),
-                        &resolved_owner,
+                        resolved_owner.as_str(),
                         method,
                         method_def,
                         attrs,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1859,7 +1859,7 @@ pub struct Interpreter {
     pub(crate) method_resolve_cache:
         rustc_hash::FxHashMap<(Symbol, Symbol), crate::vm::MethodResolveEntry>,
     #[allow(clippy::type_complexity)]
-    pub(crate) last_method_resolve: Option<(Symbol, Symbol, String, Arc<MethodDef>)>,
+    pub(crate) last_method_resolve: Option<(Symbol, Symbol, Symbol, Arc<MethodDef>)>,
     pub(crate) fast_method_cache:
         rustc_hash::FxHashMap<(Symbol, Symbol), crate::vm::FastMethodCacheEntry>,
     /// Memoized `class -> NativeCtorPlan` for the native default constructor.
@@ -1876,7 +1876,7 @@ pub struct Interpreter {
     /// method caches when the registry changes.
     #[allow(clippy::type_complexity)]
     pub(crate) multi_resolve_cache:
-        rustc_hash::FxHashMap<(Symbol, Symbol, Vec<Symbol>), Option<(String, Arc<MethodDef>)>>,
+        rustc_hash::FxHashMap<(Symbol, Symbol, Vec<Symbol>), Option<(Symbol, Arc<MethodDef>)>>,
     /// Memoized `(class, method) -> is this multi's dispatch type+arity deterministic`
     /// (i.e. cacheable in `multi_resolve_cache`). Computed once by scanning the MRO
     /// candidates for value-dependent constraints.

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -87,7 +87,7 @@ impl Interpreter {
         class_name: &str,
         method_name: &str,
         arg_values: &[Value],
-    ) -> Option<(String, MethodDef)> {
+    ) -> Option<(Symbol, MethodDef)> {
         self.resolve_method_with_owner_impl(class_name, method_name, arg_values, None)
     }
 
@@ -97,7 +97,7 @@ impl Interpreter {
         method_name: &str,
         arg_values: &[Value],
         invocant: &Value,
-    ) -> Option<(String, MethodDef)> {
+    ) -> Option<(Symbol, MethodDef)> {
         self.resolve_method_with_owner_impl(class_name, method_name, arg_values, Some(invocant))
     }
 
@@ -107,13 +107,13 @@ impl Interpreter {
         method_name: &str,
         arg_values: &[Value],
         invocant: Option<&Value>,
-    ) -> Option<(String, MethodDef)> {
+    ) -> Option<(Symbol, MethodDef)> {
         self.dispatch_ambiguous = false;
         let role_bindings = self.registry().get_role_param_bindings(class_name);
         let mro = self.class_mro(class_name);
         // Collect all matching multi candidates across the MRO, then pick the
         // most specific one by type hierarchy distance.
-        let mut all_matches: Vec<(String, MethodDef)> = Vec::new();
+        let mut all_matches: Vec<(Symbol, MethodDef)> = Vec::new();
         // Track whether a non-multi submethod was found on an ancestor
         // (submethods block MRO search for their class but not for
         // descendants).
@@ -155,7 +155,7 @@ impl Interpreter {
                                 && pd.sub_signature.is_none()
                         })
                     {
-                        return Some((cn.resolve(), only.clone()));
+                        return Some((*cn, only.clone()));
                     }
                 }
                 for def in overloads {
@@ -182,9 +182,9 @@ impl Interpreter {
                             // Non-multi: return the first match immediately,
                             // but only if no multi candidates were already
                             // collected from a child class in the MRO.
-                            return Some((cn.resolve(), def));
+                            return Some((*cn, def));
                         }
-                        all_matches.push((cn.resolve(), def));
+                        all_matches.push((*cn, def));
                     }
                 }
                 // A non-multi submethod on an ancestor blocks the MRO search
@@ -198,7 +198,7 @@ impl Interpreter {
                 // For non-multi methods, stop here — a subclass override
                 // hides the parent's version.
                 if !any_multi && all_matches.is_empty() {
-                    return first_visible_non_multi.map(|def| (cn.resolve(), def));
+                    return first_visible_non_multi.map(|def| (*cn, def));
                 }
             }
         }
@@ -444,7 +444,7 @@ impl Interpreter {
         class_name: &str,
         method_name: &str,
         arg_values: &[Value],
-    ) -> Vec<(String, MethodDef)> {
+    ) -> Vec<(Symbol, MethodDef)> {
         let role_bindings = self.registry().get_role_param_bindings(class_name);
         let mro = self.class_mro(class_name);
         let mut matches = Vec::new();
@@ -485,7 +485,7 @@ impl Interpreter {
                         role_bindings.as_ref(),
                         None,
                     ) {
-                        matches.push((cn.resolve(), def));
+                        matches.push((*cn, def));
                     }
                 }
             }
@@ -501,9 +501,9 @@ impl Interpreter {
         class_name: &str,
         method_name: &str,
         arg_values: &[Value],
-    ) -> Vec<(String, MethodDef)> {
+    ) -> Vec<(Symbol, MethodDef)> {
         let mro = self.class_mro(class_name);
-        let mut defining_levels: Vec<String> = Vec::new();
+        let mut defining_levels: Vec<Symbol> = Vec::new();
         for cn in mro.iter() {
             let is_ancestor = cn.as_str() != class_name;
             if let Some(overloads) = self
@@ -514,7 +514,7 @@ impl Interpreter {
                     .iter()
                     .any(|d| !d.is_private && (!d.is_my || !is_ancestor));
                 if has_visible {
-                    defining_levels.push(cn.resolve());
+                    defining_levels.push(*cn);
                 }
             }
         }
@@ -535,7 +535,7 @@ impl Interpreter {
         let mut any_failed = false;
         for cn in &defining_levels {
             if let Some(resolved) =
-                self.resolve_method_with_owner_impl(cn, method_name, arg_values, None)
+                self.resolve_method_with_owner_impl(cn.as_str(), method_name, arg_values, None)
             {
                 matches.push(resolved);
             } else {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -13,7 +13,7 @@ use crate::value::{
 };
 use num_traits::{Signed, Zero};
 
-pub(crate) type MethodResolveEntry = Option<(String, Arc<crate::runtime::MethodDef>)>;
+pub(crate) type MethodResolveEntry = Option<(Symbol, Arc<crate::runtime::MethodDef>)>;
 
 thread_local! {
     /// Set while execution is inside the `Interpreter::run` catch_unwind boundary, so the

--- a/src/vm/vm_call_method_compiled_cache.rs
+++ b/src/vm/vm_call_method_compiled_cache.rs
@@ -125,7 +125,10 @@ impl Interpreter {
         method_sym: crate::symbol::Symbol,
         args: &[Value],
         target: &Value,
-    ) -> Option<(String, std::sync::Arc<crate::runtime::MethodDef>)> {
+    ) -> Option<(
+        crate::symbol::Symbol,
+        std::sync::Arc<crate::runtime::MethodDef>,
+    )> {
         // Non-multi resolution depends only on (class, method) — not on arg
         // types/values — so it can be memoized. This mirrors the cache hierarchy
         // already used by the interpret path (`vm_call_method_compiled_interpret`);
@@ -136,22 +139,22 @@ impl Interpreter {
         // / `last_method_resolve = None`).
 
         // 1. Monomorphic inline cache: single-entry check before any HashMap.
-        if let Some((cc, cm, ref co, ref cd)) = self.last_method_resolve
+        if let Some((cc, cm, co, ref cd)) = self.last_method_resolve
             && cc == class_sym
             && cm == method_sym
             && !cd.is_multi
         {
-            return Some((co.clone(), cd.clone()));
+            return Some((co, cd.clone()));
         }
         // 2. Non-multi HashMap cache.
         if let Some(hit) = self
             .method_resolve_cache
             .get(&(class_sym, method_sym))
             .cloned()
-            && let Some((ref owner, ref def)) = hit
+            && let Some((owner, ref def)) = hit
             && !def.is_multi
         {
-            self.last_method_resolve = Some((class_sym, method_sym, owner.clone(), def.clone()));
+            self.last_method_resolve = Some((class_sym, method_sym, owner, def.clone()));
             return hit;
         }
         // 3. Sound multi-method resolution cache (type+arity deterministic).
@@ -181,9 +184,8 @@ impl Interpreter {
         if resolved_arc.as_ref().is_none_or(|(_, def)| !def.is_multi) {
             self.method_resolve_cache
                 .insert((class_sym, method_sym), resolved_arc.clone());
-            if let Some((ref owner, ref def)) = resolved_arc {
-                self.last_method_resolve =
-                    Some((class_sym, method_sym, owner.clone(), def.clone()));
+            if let Some((owner, ref def)) = resolved_arc {
+                self.last_method_resolve = Some((class_sym, method_sym, owner, def.clone()));
             }
         }
         resolved_arc
@@ -207,7 +209,10 @@ impl Interpreter {
         method: &str,
         args: &[Value],
         target: &Value,
-    ) -> Option<(String, std::sync::Arc<crate::runtime::MethodDef>)> {
+    ) -> Option<(
+        crate::symbol::Symbol,
+        std::sync::Arc<crate::runtime::MethodDef>,
+    )> {
         // Both compile passes are no-ops if the name is absent from the
         // respective registry, so calling both safely covers class- and
         // role-owned methods. Neither re-enters user code (pure compilation),
@@ -334,7 +339,7 @@ impl Interpreter {
         &mut self,
         cache_key: (crate::symbol::Symbol, crate::symbol::Symbol),
         receiver_class: &str,
-        owner_class: &str,
+        owner_class: crate::symbol::Symbol,
         method_def: &std::sync::Arc<crate::runtime::MethodDef>,
         cc: &std::sync::Arc<CompiledCode>,
     ) {
@@ -368,7 +373,9 @@ impl Interpreter {
                     .as_ref()
                     .is_some_and(|tc| tc.contains('('))
         });
-        let has_role_bindings = self.class_role_param_bindings(owner_class).is_some()
+        let has_role_bindings = self
+            .class_role_param_bindings(owner_class.as_str())
+            .is_some()
             || self.class_role_param_bindings(receiver_class).is_some();
         if has_invocant_constraint || has_complex_params || has_role_bindings {
             return;
@@ -396,7 +403,7 @@ impl Interpreter {
         self.fast_method_cache.insert(
             cache_key,
             super::FastMethodCacheEntry {
-                owner_class: crate::symbol::Symbol::intern(owner_class),
+                owner_class,
                 method_def: method_def.clone(),
                 compiled_code: cc.clone(),
                 can_skip_merge,

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -493,44 +493,32 @@ impl Interpreter {
 
             if let Some((owner_class, method_def)) = {
                 // Monomorphic inline cache: single-entry check before HashMap.
-                if let Some((cc, cm, ref co, ref cd)) = self.last_method_resolve
+                if let Some((cc, cm, co, ref cd)) = self.last_method_resolve
                     && cc == class_sym
                     && cm == method_sym
                     && !cd.is_multi
                 {
-                    Some((co.clone(), cd.clone()))
+                    Some((co, cd.clone()))
                 } else {
                     let cached = self.method_resolve_cache.get(&cache_key).cloned();
-                    let result: Option<(String, std::sync::Arc<crate::runtime::MethodDef>)> =
-                        if let Some(ref hit) = cached
-                            && let Some((_, def)) = hit
-                            && !def.is_multi
-                        {
+                    let result: Option<(
+                        crate::symbol::Symbol,
+                        std::sync::Arc<crate::runtime::MethodDef>,
+                    )> = if let Some(ref hit) = cached
+                        && let Some((_, def)) = hit
+                        && !def.is_multi
+                    {
+                        hit.clone()
+                    } else if let Some(arg_keys) = Self::multi_arg_type_keys(&args)
+                        && self.multi_dispatch_type_cacheable(class_sym, method_sym, cn, method)
+                    {
+                        // Sound multi-method resolution cache (§B): a type+arity-
+                        // deterministic multi resolves as a function of (class,
+                        // method, positional arg types), so key it on those types
+                        // rather than re-running the MRO/specificity walk per call.
+                        let mkey = (class_sym, method_sym, arg_keys);
+                        if let Some(hit) = self.multi_resolve_cache.get(&mkey) {
                             hit.clone()
-                        } else if let Some(arg_keys) = Self::multi_arg_type_keys(&args)
-                            && self.multi_dispatch_type_cacheable(class_sym, method_sym, cn, method)
-                        {
-                            // Sound multi-method resolution cache (§B): a type+arity-
-                            // deterministic multi resolves as a function of (class,
-                            // method, positional arg types), so key it on those types
-                            // rather than re-running the MRO/specificity walk per call.
-                            let mkey = (class_sym, method_sym, arg_keys);
-                            if let Some(hit) = self.multi_resolve_cache.get(&mkey) {
-                                hit.clone()
-                            } else {
-                                let resolved = loan_env!(
-                                    self,
-                                    resolve_method_with_owner_invocant(cn, method, &args, &target)
-                                );
-                                let resolved_arc =
-                                    resolved.map(|(owner, def)| (owner, std::sync::Arc::new(def)));
-                                // Never cache an ambiguous multi resolution — it must
-                                // re-raise X::Multi::Ambiguous on every call.
-                                if !self.dispatch_ambiguous {
-                                    self.multi_resolve_cache.insert(mkey, resolved_arc.clone());
-                                }
-                                resolved_arc
-                            }
                         } else {
                             let resolved = loan_env!(
                                 self,
@@ -538,17 +526,31 @@ impl Interpreter {
                             );
                             let resolved_arc =
                                 resolved.map(|(owner, def)| (owner, std::sync::Arc::new(def)));
-                            if resolved_arc.as_ref().is_none_or(|(_, def)| !def.is_multi) {
-                                self.method_resolve_cache
-                                    .insert(cache_key, resolved_arc.clone());
+                            // Never cache an ambiguous multi resolution — it must
+                            // re-raise X::Multi::Ambiguous on every call.
+                            if !self.dispatch_ambiguous {
+                                self.multi_resolve_cache.insert(mkey, resolved_arc.clone());
                             }
                             resolved_arc
-                        };
-                    if let Some((ref owner, ref def)) = result
+                        }
+                    } else {
+                        let resolved = loan_env!(
+                            self,
+                            resolve_method_with_owner_invocant(cn, method, &args, &target)
+                        );
+                        let resolved_arc =
+                            resolved.map(|(owner, def)| (owner, std::sync::Arc::new(def)));
+                        if resolved_arc.as_ref().is_none_or(|(_, def)| !def.is_multi) {
+                            self.method_resolve_cache
+                                .insert(cache_key, resolved_arc.clone());
+                        }
+                        resolved_arc
+                    };
+                    if let Some((owner, ref def)) = result
                         && !def.is_multi
                     {
                         self.last_method_resolve =
-                            Some((class_sym, method_sym, owner.clone(), def.clone()));
+                            Some((class_sym, method_sym, owner, def.clone()));
                     }
                     result
                 }
@@ -564,7 +566,7 @@ impl Interpreter {
                 // ancestor, so gate the MRO walk on that cheap check. Defer to
                 // the slow path, whose `run_instance_method` accessor block
                 // resolves it.
-                if (method_def.role_origin.is_some() || owner_class != cn)
+                if (method_def.role_origin.is_some() || owner_class.as_str() != cn)
                     && !method_def.is_private
                     && matches!(target.view(), ValueView::Instance { .. })
                     && matches!(
@@ -576,7 +578,7 @@ impl Interpreter {
                 }
                 if let Some(result) = self.check_method_wrap_chain(
                     cn,
-                    &owner_class,
+                    owner_class.as_str(),
                     method,
                     &method_def,
                     &target,
@@ -590,41 +592,43 @@ impl Interpreter {
                 // `.^add_method`, ledger §1) and leave `compiled_code = None`;
                 // for those, compile on demand here so the method runs as
                 // bytecode instead of tree-walking through the interpreter.
-                let compiled_def: Option<(String, std::sync::Arc<crate::runtime::MethodDef>)> =
-                    if method_def.compiled_code.is_some() {
-                        Some((owner_class.clone(), method_def.clone()))
-                    } else if !method_def.body.is_empty()
-                        && let Some((owner, def)) = self.populate_uncompiled_method(
-                            cn,
-                            &owner_class,
-                            method,
-                            &args,
-                            &target,
-                        )
-                    {
-                        // Refresh the resolve caches so future calls take the
-                        // already-compiled fast path without re-resolving.
-                        self.method_resolve_cache
-                            .insert(cache_key, Some((owner.clone(), def.clone())));
-                        if !def.is_multi {
-                            self.last_method_resolve =
-                                Some((class_sym, method_sym, owner.clone(), def.clone()));
-                        }
-                        Some((owner, def))
-                    } else {
-                        None
-                    };
+                let compiled_def: Option<(
+                    crate::symbol::Symbol,
+                    std::sync::Arc<crate::runtime::MethodDef>,
+                )> = if method_def.compiled_code.is_some() {
+                    Some((owner_class, method_def.clone()))
+                } else if !method_def.body.is_empty()
+                    && let Some((owner, def)) = self.populate_uncompiled_method(
+                        cn,
+                        owner_class.as_str(),
+                        method,
+                        &args,
+                        &target,
+                    )
+                {
+                    // Refresh the resolve caches so future calls take the
+                    // already-compiled fast path without re-resolving.
+                    self.method_resolve_cache
+                        .insert(cache_key, Some((owner, def.clone())));
+                    if !def.is_multi {
+                        self.last_method_resolve =
+                            Some((class_sym, method_sym, owner, def.clone()));
+                    }
+                    Some((owner, def))
+                } else {
+                    None
+                };
                 if let Some((owner_class, method_def)) = compiled_def {
                     let cc = method_def.compiled_code.clone().expect("compiled_code set");
 
                     // Try to populate fast_method_cache for future calls
                     if !method_def.is_multi {
-                        self.try_populate_fast_cache(cache_key, cn, &owner_class, &method_def, &cc);
+                        self.try_populate_fast_cache(cache_key, cn, owner_class, &method_def, &cc);
                     }
 
                     return self.dispatch_compiled_method(
                         cn,
-                        &owner_class,
+                        owner_class.as_str(),
                         method,
                         &method_def,
                         &cc,

--- a/src/vm/vm_call_method_compiled_mut.rs
+++ b/src/vm/vm_call_method_compiled_mut.rs
@@ -368,23 +368,30 @@ impl Interpreter {
                     ),
                 );
             }
-            if let Some(result) =
-                self.check_method_wrap_chain(cn, &owner_class, method, &method_def, &target, &args)
-            {
+            if let Some(result) = self.check_method_wrap_chain(
+                cn,
+                owner_class.as_str(),
+                method,
+                &method_def,
+                &target,
+                &args,
+            ) {
                 return result;
             }
             // Resolve to a def carrying compiled bytecode, compiling on demand
             // for methods added after the registration compile pass (e.g.
             // `.^add_method`, ledger §1) so they run as bytecode rather than
             // tree-walking. None → native receiver, keep interpreter fallback.
-            let resolved: Option<(String, std::sync::Arc<crate::runtime::MethodDef>)> =
-                if method_def.compiled_code.is_some() {
-                    Some((owner_class, method_def))
-                } else if !method_def.body.is_empty() {
-                    self.populate_uncompiled_method(cn, &owner_class, method, &args, &target)
-                } else {
-                    None
-                };
+            let resolved: Option<(
+                crate::symbol::Symbol,
+                std::sync::Arc<crate::runtime::MethodDef>,
+            )> = if method_def.compiled_code.is_some() {
+                Some((owner_class, method_def))
+            } else if !method_def.body.is_empty() {
+                self.populate_uncompiled_method(cn, owner_class.as_str(), method, &args, &target)
+            } else {
+                None
+            };
             if let Some((owner_class, method_def)) = resolved {
                 let cc = method_def.compiled_code.clone().expect("compiled_code set");
                 let target_id = match target.view() {
@@ -412,7 +419,7 @@ impl Interpreter {
                 let empty_fns = CompiledFns::default();
                 let method_result = self.call_compiled_method(
                     cn,
-                    &owner_class,
+                    owner_class.as_str(),
                     method,
                     &method_def,
                     &cc,


### PR DESCRIPTION
## Summary

Slice 2 of the dispatch-signature Symbol campaign (follow-up to #4582; PLAN §1 B2 populate-perf frontier — "Symbol intern/as_str traffic in dispatch signatures").

`resolve_method_with_owner*` returned the owner class as an owned `String` — cloned from the MRO on every successful resolve — and the three resolve caches re-cloned that `String` on **every cache hit**, then re-interned it downstream (`Symbol::intern(&owner_class)` for the wrap-chain original_sub, `FastMethodCacheEntry` population).

## Changes

- `resolve_method_with_owner` / `_invocant` / `_impl`, `resolve_all_methods_with_owner`, `resolve_methods_per_mro_level` return `(Symbol, MethodDef)` — the MRO entry is a `Copy`, not a `String` clone.
- `MethodResolveEntry`, `last_method_resolve`, `multi_resolve_cache` store `(Symbol, Arc<MethodDef>)`: a monomorphic-cache hit no longer allocates.
- `try_populate_fast_cache` takes the owner `Symbol` directly (drops the per-population re-intern); the wrap-chain `original_sub` uses the owner Symbol without re-interning.
- Cold paths that genuinely need a `String` (deferral frames, introspection) `.resolve()` explicitly at the boundary.

## Measurements

- bench-ctor (release, `perf stat -r5 -e instructions:u`, P-core pinned): **2.543G → 2.499G retired instructions (-1.7%; -2.7% cumulative with #4582** from the 2.569G baseline).
- `make test` full PASS (1730 files / 17002 tests); OOP pins green.

## Note on the #4582 CI red (resolved)

The first CI run of #4582 failed `test` (S17-promise/nonblocking-await.t test 28) and `gc-stress` (one-off SEGV of MISC/bug-coverage-stress.t); both passed on re-run. Triage established both are pre-existing on main: the same nonblocking-await test 28 failure appears in main's own CI the same day (run 29406194579), and a worktree A/B against origin/main reproduces identical GC `VERIFY FAIL ... color=Purple` survivor violations under parallel gc-stress load on both binaries (existing soundness gap, likely the shared-Arc-wrapper phantom-edge class documented in value_gc.rs — worth its own issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)