### PR TITLE
perf: construction inserts attributes by pre-interned Symbol (NativeCtorPlan.attr_syms)

### DIFF
--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -278,8 +278,11 @@ impl Interpreter {
         // (shape-only data, invalidated with the dispatch caches) instead of
         // being re-collected on every bless.
         let plan = self.native_ctor_plan(class_name);
+        let cn_resolved = class_name.as_str();
         let mut attributes = AttrMap::new();
-        for (attr_name, _is_public, default, _is_rw, _, sigil, _) in plan.class_attrs.iter() {
+        for ((attr_name, _is_public, default, _is_rw, _, sigil, _), &attr_sym) in
+            plan.class_attrs.iter().zip(plan.attr_syms.iter())
+        {
             let val = if let Some(Expr::Literal(lit_val)) = default {
                 // Fast path: simple literal defaults (e.g. native type
                 // defaults like Int(0)) don't need interpretation.
@@ -291,13 +294,7 @@ impl Interpreter {
                 // not Nil (matches `dispatch_new`). Leaving it Nil makes
                 // `@!attr.elems` return 1 (Any.elems) and corrupts guards.
                 let mut arr = Value::real_array(Vec::new());
-                let tc = self
-                    .registry()
-                    .classes
-                    .get(&class_name.resolve())
-                    .and_then(|cd| cd.attribute_types.get(attr_name))
-                    .cloned();
-                if let Some(tc) = tc {
+                if let Some(tc) = plan.type_constraints.get(attr_name).cloned() {
                     arr = self.tag_container_metadata(
                         arr,
                         super::ContainerTypeInfo {
@@ -312,10 +309,10 @@ impl Interpreter {
                 // A `%`-sigil attribute with no default is an empty Hash.
                 Value::hash(HashMap::new())
             } else {
-                // Native types have zero/empty defaults instead of Nil
-                let type_constraint =
-                    self.get_attr_type_constraint(&class_name.resolve(), attr_name);
-                match type_constraint.as_deref() {
+                // Native types have zero/empty defaults instead of Nil.
+                // The plan's type_constraints carry the same MRO-wide map
+                // `get_attr_type_constraint` would walk per attribute.
+                match plan.type_constraints.get(attr_name).map(String::as_str) {
                     Some(
                         "int" | "int8" | "int16" | "int32" | "int64" | "uint" | "uint8" | "uint16"
                         | "uint32" | "uint64" | "byte" | "atomicint",
@@ -325,16 +322,25 @@ impl Interpreter {
                     _ => Value::NIL,
                 }
             };
-            attributes.insert(attr_name.clone(), val);
+            attributes.insert(attr_sym, val);
         }
-        // Override with named args from bless call
+        // Override with named args from bless call. A key that names a declared
+        // attribute reuses its pre-interned Symbol (the common case — `|%_`
+        // passthrough in a user `new`); anything else interns as before.
         for arg in &args {
             if let ValueView::Pair(key, value) = arg.view() {
-                attributes.insert(key.clone(), value.clone());
+                match plan
+                    .class_attrs
+                    .iter()
+                    .position(|(n, ..)| n.as_str() == &**key)
+                {
+                    Some(i) => attributes.insert(plan.attr_syms[i], value.clone()),
+                    None => attributes.insert(key.clone(), value.clone()),
+                };
             }
         }
         // Embed `is default(...)` element defaults into `@`/`%` containers.
-        self.apply_container_attribute_defaults(&class_name.resolve(), &mut attributes);
+        self.apply_container_attribute_defaults(cn_resolved, &mut attributes);
         // Build the instance BEFORE the BUILD/TWEAK phases and thread its shared
         // attribute cell through them (raku semantics: `self` inside BUILD/TWEAK
         // IS the constructed object — same identity, mutations through a stored

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -331,10 +331,17 @@ impl Interpreter {
                     false,
                 )
             };
+        let attr_syms = std::sync::Arc::new(
+            class_attrs
+                .iter()
+                .map(|(n, ..)| crate::symbol::Symbol::intern(n))
+                .collect::<Vec<_>>(),
+        );
         let plan = std::sync::Arc::new(super::NativeCtorPlan {
             is_cunion,
             eligible,
             class_attrs,
+            attr_syms,
             type_constraints,
             has_build,
             has_tweak,

--- a/src/runtime/methods_object_default_ctor.rs
+++ b/src/runtime/methods_object_default_ctor.rs
@@ -27,13 +27,10 @@ impl Interpreter {
         let class_attrs = &*plan.class_attrs;
         let type_constraints = &*plan.type_constraints;
 
-        let sigil_of = |name: &str| -> char {
-            class_attrs
-                .iter()
-                .find(|(n, ..)| n == name)
-                .map(|(_, _, _, _, _, s, _)| *s)
-                .unwrap_or('$')
-        };
+        let attr_idx_of =
+            |name: &str| -> Option<usize> { class_attrs.iter().position(|(n, ..)| n == name) };
+        let sigil_of =
+            |name: &str| -> char { attr_idx_of(name).map(|i| class_attrs[i].5).unwrap_or('$') };
 
         // A custom BUILD replaces the default named-argument → attribute binding:
         // with a BUILD present, a provided `:attr(value)` is NOT auto-assigned to
@@ -52,6 +49,7 @@ impl Interpreter {
             if let ValueView::Pair(key, val) = arg.view()
                 && self.is_attribute_buildable(cn_resolved, key)
             {
+                let key_sym = attr_idx_of(key).map(|i| plan.attr_syms[i]);
                 match sigil_of(key) {
                     '@' | '%' => {
                         // A `%`-attribute bound to a non-Hash object is
@@ -69,10 +67,11 @@ impl Interpreter {
                         }
                         // Coerce exactly as the interpreter's shared helper does
                         // (List/Range -> Array, array-of-Pairs -> Hash, …).
-                        attrs.insert(
-                            key.clone(),
-                            Self::coerce_attr_value_by_sigil(val.clone(), sigil_of(key)),
-                        );
+                        let coerced = Self::coerce_attr_value_by_sigil(val.clone(), sigil_of(key));
+                        match key_sym {
+                            Some(s) => attrs.insert(s, coerced),
+                            None => attrs.insert(key.clone(), coerced),
+                        };
                     }
                     _ => {
                         // A provided value that does not already match its
@@ -91,7 +90,10 @@ impl Interpreter {
                         {
                             return None;
                         }
-                        attrs.insert(key.clone(), val.clone());
+                        match key_sym {
+                            Some(s) => attrs.insert(s, val.clone()),
+                            None => attrs.insert(key.clone(), val.clone()),
+                        };
                     }
                 }
             }
@@ -148,8 +150,10 @@ impl Interpreter {
         // that fast path made a 20k-iteration native-attr loop time out.
         let mut eval_error: Option<RuntimeError> = None;
         let mut typed_default_mismatch = false;
-        for (attr_name, _is_public, default_expr, _, _, sigil, _) in class_attrs.iter() {
-            if attrs.contains_key(attr_name) {
+        for ((attr_name, _is_public, default_expr, _, _, sigil, _), &attr_sym) in
+            class_attrs.iter().zip(plan.attr_syms.iter())
+        {
+            if attrs.contains_key(attr_sym) {
                 continue;
             }
             match default_expr {
@@ -157,7 +161,7 @@ impl Interpreter {
                 // The interpreter stores it without a type check, so we do too.
                 Some(Expr::Literal(lit_val)) => {
                     attrs.insert(
-                        attr_name.clone(),
+                        attr_sym,
                         Self::coerce_attr_value_by_sigil(lit_val.clone(), *sigil),
                     );
                 }
@@ -254,10 +258,7 @@ impl Interpreter {
                         typed_default_mismatch = true;
                         break;
                     }
-                    attrs.insert(
-                        attr_name.clone(),
-                        Self::coerce_attr_value_by_sigil(val, *sigil),
-                    );
+                    attrs.insert(attr_sym, Self::coerce_attr_value_by_sigil(val, *sigil));
                 }
                 None => {
                     // Uninitialized: `@` -> empty Array, `%` -> empty Hash. For
@@ -272,7 +273,7 @@ impl Interpreter {
                             .and_then(|c| Self::native_scalar_default(c))
                             .unwrap_or(Value::NIL),
                     };
-                    attrs.insert(attr_name.clone(), empty);
+                    attrs.insert(attr_sym, empty);
                 }
             }
         }
@@ -289,7 +290,9 @@ impl Interpreter {
         // `coerce_value_for_constraint` is the exact path the interpreter uses, so
         // the result is identical; the gate already excluded user-class targets,
         // so only built-in coercion logic runs here.
-        for (attr_name, _, _, _, _, sigil, _) in class_attrs.iter() {
+        for ((attr_name, _, _, _, _, sigil, _), &attr_sym) in
+            class_attrs.iter().zip(plan.attr_syms.iter())
+        {
             if *sigil != '$' {
                 continue;
             }
@@ -298,7 +301,7 @@ impl Interpreter {
                 && let Some(val) = attrs.remove(attr_name)
             {
                 let coerced = self.coerce_value_for_constraint(tc, val);
-                attrs.insert(attr_name.clone(), coerced);
+                attrs.insert(attr_sym, coerced);
             }
         }
         // Tag typed `@`/`%` attributes (`has Int @.nums`) with element-type
@@ -313,7 +316,9 @@ impl Interpreter {
         // container flattens it (just like `my @a = |@x` yields an `Array`, not a
         // `Slip`), so materialize it into a plain mutable `Array` here. Without
         // this the attribute keeps a `Slip` whose `.^name` is `Slip`.
-        for (attr_name, _, _, _, _, sigil, _) in class_attrs.iter() {
+        for ((attr_name, _, _, _, _, sigil, _), &attr_sym) in
+            class_attrs.iter().zip(plan.attr_syms.iter())
+        {
             if *sigil != '@' {
                 continue;
             }
@@ -324,10 +329,12 @@ impl Interpreter {
                     crate::gc::Gc::new(crate::value::ArrayData::new((**items).clone())),
                     crate::value::ArrayKind::Array,
                 );
-                attrs.insert(attr_name.clone(), flattened);
+                attrs.insert(attr_sym, flattened);
             }
         }
-        for (attr_name, _, _, _, _, sigil, _) in class_attrs.iter() {
+        for ((attr_name, _, _, _, _, sigil, _), &attr_sym) in
+            class_attrs.iter().zip(plan.attr_syms.iter())
+        {
             if !matches!(sigil, '@' | '%') {
                 continue;
             }
@@ -339,7 +346,7 @@ impl Interpreter {
                     // Hashes embed the element type in `HashData`, so store the
                     // tagged value back into the attrs that move into the instance.
                     Ok(tagged) => {
-                        attrs.insert(attr_name.clone(), tagged);
+                        attrs.insert(attr_sym, tagged);
                     }
                     Err(e) => return Some(Err(e)),
                 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -422,6 +422,10 @@ pub(crate) struct NativeCtorPlan {
     pub(crate) is_cunion: bool,
     pub(crate) eligible: bool,
     pub(crate) class_attrs: Arc<Vec<ClassAttributeDef>>,
+    /// Interned attribute names, same order as `class_attrs`. Construction
+    /// inserts attributes by Symbol so the per-bless per-attribute
+    /// `String` clone + re-intern is paid once per class, not per instance.
+    pub(crate) attr_syms: Arc<Vec<crate::symbol::Symbol>>,
     pub(crate) type_constraints: Arc<HashMap<String, String>>,
     pub(crate) has_build: bool,
     pub(crate) has_tweak: bool,


### PR DESCRIPTION
## Summary

Slice 3 of the dispatch-signature Symbol campaign (#4582, #4583; PLAN §1 B2 populate-perf frontier). The ctor profile after #4583 still showed `Symbol::intern` 2.65% + `memcmp` 1.95%: the bless/native-ctor loops re-interned every attribute name on **every constructed instance**.

## Changes

- `NativeCtorPlan` gains `attr_syms: Arc<Vec<Symbol>>` — attribute names interned once per class (plan is already cached/invalidated with the dispatch caches).
- `dispatch_bless`: inserts defaults by Symbol (was `attr_name.clone()` + re-intern per attr); the named-arg fold reuses the declared attribute's Symbol when the key names one (the `|%_` passthrough case); the `@`-default tag and native-zero probes read `plan.type_constraints` (same MRO-wide map `get_attr_type_constraint` walks) instead of re-querying the registry per attribute; the class name resolves once via `as_str` (no String allocs).
- `build_native_default_instance`: Symbol inserts in the named-arg fold, default fill, coercion, slip-flatten, and typed-container passes.

## Measurements (release, `perf stat -r5 -e instructions:u`, P-core pinned)

| | bench-ctor retired instructions |
|---|---|
| baseline (pre-#4582) | 2.569G |
| #4582 (MRO Arc<[Symbol]>) | 2.543G |
| #4583 (owner Symbol in caches) | 2.499G |
| **this PR** | **2.387G (-4.5%; -7.1% cumulative)** |

`make test` full PASS (1731 files / 17010 tests); bless/ctor pins green (accessor-mro-shadowing, ctor-self-identity, bless-native-fork, bless-container-attr-defaults, bless-passes-args-to-build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)