### PR TITLE
fix: while-gather pull resume at iteration boundary; lazy bodies run under their own readonly context

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -48,7 +48,7 @@ Definitions of the classifications:
 
 ## Current assumptions
 
-- The whitelist stands at **1413 / 1463** (2026-07-15, `wc -l roast-whitelist.txt`) = **50** files not whitelisted.
+- The whitelist stands at **1414 / 1463** (2026-07-15, `wc -l roast-whitelist.txt`) = **49** files not whitelisted.
 - **The S\* files (per-synopsis feature tests) are exhausted.** All of the former large campaigns
   (true lazy arrays / desugaring of dispatch and operator sugar / S17 concurrency & async /
   first-class-container container identity / cross-thread lexical writeback) are complete, and
@@ -72,7 +72,6 @@ noted.
 | File | mutsu | raku | Blocker / note |
 |---|---|---|---|
 | `integration/99problems-21-to-30.t` | 14/15 | PASS ★ | Root-caused 2026-07-15 and fixed 3 of 4: `return` in a sub callback via map (routine call path), recursive slice-arg index-rw temp corruption, `(<=)` Range coercion. Remaining 1 = test 13 (P27 `group`): the nested `map -> $g {...}` over the recursion's itemized-Seq result loses the inner group — mutsu's inner value is `$(($[[3],],),)` where raku builds `$((($[[3],],).Seq,).Seq)`, and the subsequent `|@$g` slips a different level. Needs the Seq-vs-List structure of nested map results aligned with raku |
-| `integration/99problems-31-to-40.t` | aborts at 44/67 | PASS ★ | not yet root-caused |
 | `integration/99problems-41-to-50.t` | fails | PASS ★ | P47 needs parameterized `multi rule expr($p)` (grammar rules taking arguments); P41/P46 fixed in #4510 |
 | `integration/99problems-51-to-60.t` | 35/37 | PASS ★ | test 8 (balanced-binary-tree branch dropping) and test 21; the P57 infinite recursion was fixed in #4516 |
 | `integration/99problems-61-to-70.t` | 12/15 | PASS ★ | `internals()` / `atlevel()` binary-tree traversal (tests 3/5/6) |

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -60,6 +60,31 @@ synthetic `bench-grammar-parse` 6.4× gap does not surface in the roast whitelis
 Pins: `t/once-clone-scope.t` (10 cases), `t/once-phaser.t` (12);
 `roast/S04-statements/once.t` stays whitelisted.
 
+## 2026-07-15: while-gather pull resume + lazy readonly context — 99problems-31-to-40.t whitelisted (67/67)
+
+Two fixes, root-caused from the file's abort at 44/67 (P37 Euler's totient):
+
+- **Lazily-forced gather bodies run under their own readonly context**: the
+  force paths swap out the whole readonly state (`take_readonly_state`), so
+  a body writing its `is copy` param (`sub f($n is copy) { gather { $n div=
+  2 } }`) no longer false-positives against a consumer frame's same-named
+  readonly param (`sub phi($n) { for f($n) {...} }` threw "Cannot assign to
+  a readonly variable (n)").
+- **Condition-driven-loop gathers suspend at the iteration boundary**: the
+  at-take suspension resumed a `while`/`loop` body by re-entering from the
+  condition, replaying the statements from the iteration start to the take —
+  `while $n > 1 { take $n; $n div= 2 }` pulled 6,6,6... forever. A take-limit
+  hit inside `while`/`until`/C-style/`repeat` now defers the suspension
+  (`gather_suspend_pending`, armed per loop kind via
+  `lazy_take_boundary_defer`) to the loop's next iteration boundary, where
+  the condition re-entry is exact. `for`-shaped bodies keep the immediate
+  at-take suspension: their positional resume (`next_index`) is exact for
+  values, and roast pins the side-effect timing (S04-statements/gather.t
+  "gather is lazy"). An overshoot backstop (limit+64) still bounds loop-less
+  recursive-take shapes.
+
+Pin: t/gather-while-pull-resume.t.
+
 ## 2026-07-15: map routine callbacks, recursive index-rw temp corruption, (<=) Range — 99problems-21-to-30.t 6/15 → 14/15
 
 Three general fixes root-caused from the file's abort:

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1309,6 +1309,7 @@ roast/S32-trig/tan.t
 roast/S32-trig/tanh.t
 roast/integration/99problems-01-to-10.t
 roast/integration/99problems-11-to-20.t
+roast/integration/99problems-31-to-40.t
 roast/integration/advent2009-day01.t
 roast/integration/advent2009-day02.t
 roast/integration/advent2009-day03.t

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -159,9 +159,25 @@ impl Interpreter {
             if let Some(Some(limit)) = self.gather_take_limits.last()
                 && items.len() >= *limit
             {
-                return Err(RuntimeError::new(
-                    "__mutsu_lazy_gather_take_limit_reached__",
-                ));
+                if self.lazy_take_boundary_defer {
+                    // Inside a condition-driven loop: defer the suspension to
+                    // the loop's iteration boundary (`gather_suspend_pending`)
+                    // — suspending at the take itself replays the statements
+                    // between the take and the iteration end on resume. The
+                    // overshoot backstop still signals here if no boundary is
+                    // ever reached.
+                    self.gather_suspend_pending = true;
+                    if items.len() >= limit.saturating_add(64) {
+                        self.gather_suspend_pending = false;
+                        return Err(RuntimeError::new(
+                            "__mutsu_lazy_gather_take_limit_reached__",
+                        ));
+                    }
+                } else {
+                    return Err(RuntimeError::new(
+                        "__mutsu_lazy_gather_take_limit_reached__",
+                    ));
+                }
             }
         }
         Ok(())

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -398,6 +398,14 @@ pub(crate) enum ReadonlyUndo {
     Scope,
 }
 
+/// The full readonly state swapped out around a lazily-forced body run — see
+/// `Interpreter::take_readonly_state` / `restore_readonly_state`.
+pub(crate) struct SavedReadonlyState {
+    pub(crate) vars: ReadonlySet,
+    pub(crate) undo: Vec<ReadonlyUndo>,
+    pub(crate) frames: u32,
+}
+
 /// A set of variable names (`block_declared_vars` / `loop_local_vars`), keyed by
 /// the interned `Symbol` rather than an owned `String`.
 ///
@@ -1959,6 +1967,22 @@ pub struct Interpreter {
     pub(crate) otf_call_cache_gen: u64,
     pub(crate) check_phaser_depth: u32,
     pub(crate) gather_for_loop_resume: Option<crate::value::ForLoopResumeState>,
+    /// Set by `take_value` when a lazy pull's take limit is reached inside a
+    /// condition-driven loop (`while`/`until`/C-style `loop`): the suspension
+    /// is DEFERRED to that loop's next iteration boundary, where re-entering
+    /// from the condition on resume is exact. Suspending at the `take` itself
+    /// replayed the statements between the take and the iteration end
+    /// (`while $n > 1 { take $n; $n div= 2 }` yielded 6,6,6... —
+    /// 99problems-31-to-40.t P37).
+    pub(crate) gather_suspend_pending: bool,
+    /// True while the innermost enclosing loop op is condition-driven
+    /// (`while`/`until`/C-style/`repeat`), i.e. a take-limit hit should defer
+    /// to its iteration boundary (`gather_suspend_pending`). `for` loops keep
+    /// the immediate at-take signal: their positional resume state
+    /// (`next_index`) makes the at-take suspension exact for element values,
+    /// and roast pins its side-effect timing (S04-statements/gather.t
+    /// "gather is lazy"). Saved/restored on loop-op entry/exit.
+    pub(crate) lazy_take_boundary_defer: bool,
     pub(crate) rw_map_topic_capture: Option<Value>,
 }
 

--- a/src/runtime/resolution_lazy.rs
+++ b/src/runtime/resolution_lazy.rs
@@ -103,7 +103,11 @@ impl Interpreter {
         self.env = list.env.clone();
         self.gather_items.push(Vec::new());
         self.gather_take_limits.push(Some(needed_len));
+        self.gather_suspend_pending = false;
         let run_res = self.run_block(&list.body);
+        // Clear the deferred-suspension flag on exit — see the matching clear
+        // in force_lazy_list_vm_n_inner.
+        self.gather_suspend_pending = false;
         let mut items = self.gather_items.pop().unwrap_or_default();
         self.gather_take_limits.pop();
         while self.gather_items.len() > saved_len {

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2226,6 +2226,8 @@ impl Interpreter {
             otf_call_cache_gen: 0,
             check_phaser_depth: 0,
             gather_for_loop_resume: None,
+            gather_suspend_pending: false,
+            lazy_take_boundary_defer: false,
             rw_map_topic_capture: None,
         };
         interpreter.init_io_environment();

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -425,6 +425,8 @@ impl Interpreter {
             otf_call_cache_gen: 0,
             check_phaser_depth: 0,
             gather_for_loop_resume: None,
+            gather_suspend_pending: false,
+            lazy_take_boundary_defer: false,
             rw_map_topic_capture: None,
         };
         // Raku gives each start block fresh $/ and $! (they are lexically scoped).

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -169,6 +169,31 @@ impl Interpreter {
         self.readonly_undo.pop();
     }
 
+    /// Swap out the whole readonly state for a lazily-forced body run
+    /// (gather / lazy list). The body was compiled and captured in its OWN
+    /// frame's readonly context, but at force time the CONSUMER frame's marks
+    /// are in effect — so a same-named writable variable of the body
+    /// (`sub f($n is copy) { gather { $n div= 2 } }` forced inside
+    /// `sub phi($n)`) false-positives the readonly check
+    /// (99problems-31-to-40.t P37). Clearing for the duration of the force
+    /// loses in-body protection of captured outer readonly names (rare) but
+    /// never blocks the body's own writes. Restore with
+    /// [`Self::restore_readonly_state`] on every exit path.
+    pub(crate) fn take_readonly_state(&mut self) -> super::SavedReadonlyState {
+        super::SavedReadonlyState {
+            vars: std::mem::take(&mut self.readonly_vars),
+            undo: std::mem::take(&mut self.readonly_undo),
+            frames: std::mem::replace(&mut self.readonly_frames, 0),
+        }
+    }
+
+    /// Restore the readonly state saved by [`Self::take_readonly_state`].
+    pub(crate) fn restore_readonly_state(&mut self, saved: super::SavedReadonlyState) {
+        self.readonly_vars = saved.vars;
+        self.readonly_undo = saved.undo;
+        self.readonly_frames = saved.frames;
+    }
+
     /// Check if a variable is readonly.
     pub(crate) fn is_readonly(&self, name: &str) -> bool {
         self.is_readonly_sym(Symbol::intern(name))

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -254,6 +254,21 @@ impl Interpreter {
         ip: &mut usize,
         compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
+        // Condition-driven loop: a lazy-pull take limit defers its suspension
+        // to this loop's iteration boundary (see `lazy_take_boundary_defer`).
+        let saved_defer = std::mem::replace(&mut self.lazy_take_boundary_defer, true);
+        let r = self.exec_while_loop_op_inner(code, spec, ip, compiled_fns);
+        self.lazy_take_boundary_defer = saved_defer;
+        r
+    }
+
+    fn exec_while_loop_op_inner(
+        &mut self,
+        code: &CompiledCode,
+        spec: &WhileLoopSpec,
+        ip: &mut usize,
+        compiled_fns: &CompiledFns,
+    ) -> Result<(), RuntimeError> {
         let cond_start = *ip + 1;
         let body_start = spec.cond_end as usize;
         let loop_end = spec.body_end as usize;
@@ -285,6 +300,17 @@ impl Interpreter {
         self.push_loop_local_scope();
 
         'while_loop: loop {
+            // Deferred lazy-pull suspension (see `gather_suspend_pending`):
+            // an iteration boundary is the exact point where re-entering from
+            // the condition on resume continues correctly.
+            if self.gather_suspend_pending {
+                self.gather_suspend_pending = false;
+                self.gather_for_loop_resume = Some(crate::value::ForLoopResumeState::CStyleLoop);
+                self.pop_loop_local_scope(code);
+                return Err(RuntimeError::new(
+                    crate::runtime::Interpreter::LAZY_GATHER_TAKE_LIMIT_SIGNAL,
+                ));
+            }
             self.loop_cond_active = true;
             let cond_res = self.run_range(code, cond_start, body_start, compiled_fns);
             self.loop_cond_active = false;

--- a/src/vm/vm_for_loop_dispatch.rs
+++ b/src/vm/vm_for_loop_dispatch.rs
@@ -15,12 +15,19 @@ impl Interpreter {
         // sibling loop). Gated on the compile-time flag so the overwhelmingly
         // common no-`sub` loop body pays zero cost. Snapshot happens once per
         // loop entry, not per iteration.
-        if !spec.body_declares_routines {
-            return self.exec_for_loop_op_inner(code, spec, ip, compiled_fns);
-        }
-        let snapshot = self.snapshot_routine_registry();
-        let result = self.exec_for_loop_op_inner(code, spec, ip, compiled_fns);
-        self.restore_routine_registry(snapshot);
+        // A `for` loop keeps the immediate at-take lazy suspension (its
+        // positional resume state makes that exact) — see
+        // `lazy_take_boundary_defer`.
+        let saved_defer = std::mem::replace(&mut self.lazy_take_boundary_defer, false);
+        let result = if !spec.body_declares_routines {
+            self.exec_for_loop_op_inner(code, spec, ip, compiled_fns)
+        } else {
+            let snapshot = self.snapshot_routine_registry();
+            let result = self.exec_for_loop_op_inner(code, spec, ip, compiled_fns);
+            self.restore_routine_registry(snapshot);
+            result
+        };
+        self.lazy_take_boundary_defer = saved_defer;
         result
     }
 

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -176,7 +176,11 @@ impl Interpreter {
         // GC safepoint (§9.2a `lazy_force`): the strict-force entry boundary.
         crate::gc::gc_safepoint(crate::gc::SafepointKind::LazyForce);
         let caller_code = self.current_code;
+        // The body runs under its OWN readonly context, not the consumer
+        // frame's (see take_readonly_state).
+        let saved_readonly = self.take_readonly_state();
         let r = self.force_lazy_list_vm_inner(list);
+        self.restore_readonly_state(saved_readonly);
         self.reconcile_caller_after_lazy_force(caller_code);
         r
     }
@@ -410,7 +414,11 @@ impl Interpreter {
         // GC safepoint (§9.2a `lazy_force`): the bounded pull/resume boundary.
         crate::gc::gc_safepoint(crate::gc::SafepointKind::LazyForce);
         let caller_code = self.current_code;
+        // The body runs under its OWN readonly context, not the consumer
+        // frame's (see take_readonly_state).
+        let saved_readonly = self.take_readonly_state();
         let r = self.force_lazy_list_vm_n_inner(list, needed);
+        self.restore_readonly_state(saved_readonly);
         self.reconcile_caller_after_lazy_force(caller_code);
         r
     }

--- a/src/vm/vm_helpers_lazy_pull.rs
+++ b/src/vm/vm_helpers_lazy_pull.rs
@@ -134,6 +134,9 @@ impl Interpreter {
 
         // Push gather items collector with the take limit
         let saved_gather_len = self.gather_items_len();
+        // A stale deferred-suspension flag from an enclosing pull must not
+        // fire this run's first loop boundary.
+        self.gather_suspend_pending = false;
 
         // If resuming, restore already-cached items into the gather collector
         // so that the take_value limit check accounts for them.
@@ -194,6 +197,10 @@ impl Interpreter {
             body_finished = true;
         }
 
+        // The body may finish (or error) with the deferred-suspension flag
+        // still set (straight-line takes, last iteration); it must not leak
+        // into an unrelated later loop.
+        self.gather_suspend_pending = false;
         // Collect gather items
         let items = self.pop_gather_items().unwrap_or_default();
         self.pop_gather_take_limit();

--- a/src/vm/vm_loop_cstyle_repeat.rs
+++ b/src/vm/vm_loop_cstyle_repeat.rs
@@ -9,6 +9,21 @@ impl Interpreter {
         ip: &mut usize,
         compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
+        // Condition-driven loop: a lazy-pull take limit defers its suspension
+        // to this loop's iteration boundary (see `lazy_take_boundary_defer`).
+        let saved_defer = std::mem::replace(&mut self.lazy_take_boundary_defer, true);
+        let r = self.exec_cstyle_loop_op_inner(code, spec, ip, compiled_fns);
+        self.lazy_take_boundary_defer = saved_defer;
+        r
+    }
+
+    fn exec_cstyle_loop_op_inner(
+        &mut self,
+        code: &CompiledCode,
+        spec: &CStyleLoopSpec,
+        ip: &mut usize,
+        compiled_fns: &CompiledFns,
+    ) -> Result<(), RuntimeError> {
         let cond_start = *ip + 1;
         let body_start = spec.cond_end as usize;
         let step_begin = spec.step_start as usize;
@@ -40,6 +55,17 @@ impl Interpreter {
         self.push_loop_local_scope();
 
         'c_loop: loop {
+            // Deferred lazy-pull suspension (see `gather_suspend_pending`):
+            // the iteration boundary (post-step) is the exact point where
+            // re-entering from the condition on resume continues correctly.
+            if self.gather_suspend_pending {
+                self.gather_suspend_pending = false;
+                self.gather_for_loop_resume = Some(crate::value::ForLoopResumeState::CStyleLoop);
+                self.pop_loop_local_scope(code);
+                return Err(RuntimeError::new(
+                    crate::runtime::Interpreter::LAZY_GATHER_TAKE_LIMIT_SIGNAL,
+                ));
+            }
             self.loop_cond_active = true;
             let cond_res = self.run_range(code, cond_start, body_start, compiled_fns);
             self.loop_cond_active = false;
@@ -141,6 +167,23 @@ impl Interpreter {
     }
 
     pub(super) fn exec_repeat_loop_op(
+        &mut self,
+        code: &CompiledCode,
+        cond_end: u32,
+        body_end: u32,
+        label: &Option<String>,
+        ip: &mut usize,
+        compiled_fns: &CompiledFns,
+    ) -> Result<(), RuntimeError> {
+        // Condition-driven loop: see exec_cstyle_loop_op.
+        let saved_defer = std::mem::replace(&mut self.lazy_take_boundary_defer, true);
+        let r = self.exec_repeat_loop_op_inner(code, cond_end, body_end, label, ip, compiled_fns);
+        self.lazy_take_boundary_defer = saved_defer;
+        r
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn exec_repeat_loop_op_inner(
         &mut self,
         code: &CompiledCode,
         cond_end: u32,

--- a/t/gather-while-pull-resume.t
+++ b/t/gather-while-pull-resume.t
@@ -1,0 +1,70 @@
+use v6;
+use Test;
+
+# Lazy pulls from a gather whose take sits inside a condition-driven loop
+# (`while`/`loop`) suspend at the loop's iteration boundary, so the resumed
+# iteration neither replays nor drops the statements after the take
+# (99problems-31-to-40.t P37: `while $n > 1 { take $n; $n div= 2 }` yielded
+# 6,6,6... on indexed pulls). Also: a lazily-forced gather body runs under
+# its own readonly context, not the consumer frame's.
+
+plan 6;
+
+{
+    sub halves(Int $n is copy) {
+        gather { while $n > 1 { take $n; $n div= 2; } }
+    }
+    my $s = halves(6);
+    is $s[0], 6, 'first pulled element';
+    is $s[1], 3, 'second pulled element continues the loop state';
+    is-deeply $s.List, (6, 3), 'full force matches the pulls';
+}
+
+{
+    # for-loop iteration over the lazy while-gather (the P37 shape).
+    sub pfm(Int $n is copy) {
+        gather {
+            my $cond = 2;
+            my $count = 0;
+            while $n > 1 {
+                if $n % $cond == 0 { $count++; $n div= $cond; }
+                else {
+                    if $count > 0 { take [$cond, $count]; $count = 0; }
+                    $cond++;
+                }
+            }
+            take [$cond, $count];
+        }
+    }
+    my @got;
+    for pfm(12) -> @a { @got.push(@a.join('^')) }
+    is @got.join(' '), '2^2 3^1', 'iterating a lazy while-gather yields each factor once';
+}
+
+{
+    # The gather body's `is copy` param stays writable when forced inside a
+    # consumer routine with a same-named readonly param.
+    sub gen(Int $n is copy) {
+        gather { while $n > 0 { take $n; $n--; } }
+    }
+    sub consume($n) {
+        my @out;
+        for gen($n) -> $x { @out.push($x) }
+        @out.join(',');
+    }
+    is consume(3), '3,2,1', 'lazy body write is not blocked by consumer readonly marks';
+}
+
+{
+    # for-shaped gather bodies keep the at-take suspension (roast
+    # S04-statements/gather.t "gather is lazy" pins the side-effect timing).
+    my $count = 0;
+    my @list := gather {
+        for 1 .. 10 -> $a {
+            take $a;
+            $count++;
+        }
+    }.List;
+    my $ = @list[2];
+    is $count, 2, 'for-shaped gather still suspends at the take';
+}


### PR DESCRIPTION
## Summary

Whitelists `roast/integration/99problems-31-to-40.t` (**67/67**; previously aborted at 44 and, once unmasked, hung). Both fixes were root-caused from P37 (Euler's totient via a gather-based `prime_factors_mult`).

### 1. Lazily-forced gather bodies run under their own readonly context

The force paths (`force_lazy_list_vm`/`_vm_n`, interpreter prefix bridge) now swap out the whole readonly state (`take_readonly_state`/`restore_readonly_state`). A gather body writing its `is copy` param (`sub f($n is copy) { gather { $n div= 2 } }`) executes at force time inside the CONSUMER's frame, whose same-named readonly param (`sub phi($n) { for f($n) {...} }`) made the write throw "Cannot assign to a readonly variable (n)".

### 2. Condition-driven-loop gathers suspend at the iteration boundary

The at-take suspension resumed a `while`/`loop` body by re-entering from the condition, replaying the statements between the iteration start and the take: `while $n > 1 { take $n; $n div= 2 }` pulled 6,6,6... forever (`$n div= 2` never ran before each re-take). A take-limit hit inside `while`/`until`/C-style/`repeat` now defers the suspension to the loop's next iteration boundary (`gather_suspend_pending`, armed per loop kind via `lazy_take_boundary_defer` save/restore on loop-op entry), where the condition re-entry is exact.

`for`-shaped bodies deliberately keep the immediate at-take suspension: their positional resume state (`next_index`) is exact for element values, and roast pins the at-take side-effect timing (S04-statements/gather.t test 12 "gather is lazy": $count == 2 after pulling the 3rd element). An overshoot backstop (limit+64) still bounds loop-less recursive-take shapes that never reach a loop boundary.

## Testing

- `t/gather-while-pull-resume.t` (new pin): indexed pulls over a while-gather, the P37 for-iteration shape, readonly-context isolation, and the roast-pinned for-shape timing.
- `99problems-31-to-40.t` 67/67 in ~0.2s; `make test` (1732 files) PASS; 98 whitelisted S04-statements/S04-phasers/S32-list/99problems roast files PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)