### PR TITLE
docs: ADR-0007 grammar-parse trail matcher (prep) + deep bench

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -517,14 +517,24 @@ unification / the malloc clusters from `Value` clone/drop and attribute material
       `RegexCaptures::clone`+drop ~10% → ~4% of samples; bench-grammar-parse ~9% faster
       (1.51s → 1.37s), a deep nested-JSON doc ~4-10% faster. Pinned by
       `t/regex-nested-subcaps-sharing.t`.
-      **Remaining (the real prize — still O(n²) in document size):** a 552-char nested-JSON
-      doc takes mutsu ~38s vs raku ~0.27s (~140×). The quadratic is the by-value threading
-      of the *whole* caps struct: the hot `named` map (String keys + matched-text `String`s)
-      still deep-copies at every DFS step, and the ~450-byte struct is memmoved on every
-      stack push/pop and Vec element. Profile of a 4s deep parse: ~19% memmove + ~40%
-      malloc/free, `RegexCaptures::default` ~1.7%. The sound fix is a single mutable cursor
-      with an undo-log / trail (mutate-and-rewind) instead of by-value CPS — a larger
-      matcher rewrite, tracked as the next grammar-parse lever.
+      **Remaining (the real prize — a high constant factor, NOT O(n²)):** grammar parsing
+      is **linear** in document size but ~**30× slower than raku** per matched character
+      (~18 ms/char on the deep object-of-nested-arrays bench: P=2→2.04s … P=8→8.11s single
+      parse, intercept ≈0; raku flat ~0.26s). The cost is allocation churn from threading
+      the whole `RegexCaptures` struct by value and cloning it at nearly every step —
+      per-quantifier-iteration `current_caps = new_caps.clone()`
+      (`regex_match_core.rs:1096/1338/1419`), ~14 per-candidate clones in
+      `regex_match_capture.rs`, and zero-width/leaf atoms cloning the struct for nothing.
+      Profile of a ~6s deep parse: ~19% memmove + ~40% malloc/free, clone+drop ~4%,
+      `RegexCaptures::default` ~1.7%. **(An earlier "O(n²)/140×" note was a 3-iteration
+      benchmark-loop artefact — corrected.)** The sound fix is a single mutable capture
+      store + an **undo-log / trail** (mutate-forward, rewind-on-backtrack) replacing the
+      by-value CPS threading, which requires converting the all-ends enumeration producers
+      to depth-first-with-rewind generators. Design, structural blocker, mutation/trail
+      inventory, hazards, and a 4-phase plan are in
+      **[docs/adr/0007-grammar-parse-trail-matcher.md](docs/adr/0007-grammar-parse-trail-matcher.md)
+      (Proposed)** — the next grammar-parse lever. Bench: `benchmarks/bench-grammar-parse.raku`
+      (shallow) + `benchmarks/bench-grammar-parse-deep.raku` (deep).
 - Targets (numbers from bench CI, main `c8955d2e`, 2026-07-13; parentheses = JIT-on series):
   method-call <1.5x (✅ 1.19x / jit 1.16x), bench-class <1.5x (✅ 1.02x / jit 1.00x),
   fib <10x (✅ **0.82x / jit 0.65x**), bench-fib (with type constraints) <2x

--- a/benchmarks/bench-grammar-parse-deep.raku
+++ b/benchmarks/bench-grammar-parse-deep.raku
@@ -1,0 +1,45 @@
+# Deep grammar-parse benchmark — exercises the O(n^2)-in-document-size pathology
+# that the shallow `bench-grammar-parse.raku` does NOT surface. The same JSON-like
+# grammar, but fed a document whose values are deeply nested arrays, so the
+# per-subrule `RegexCaptures` sub-match tree grows large and the by-value capture
+# threading (clone-per-DFS-step) pays O(tree) at every level.
+#
+# Sized so the current interpreter runs it in a few seconds (release). Compare
+# mutsu vs raku: raku is ~O(n) here, mutsu is ~O(n^2), so the gap widens sharply
+# with $PAIRS/$ARR. Use this for A/B when reworking the matcher (PLAN §5).
+grammar JsonLike {
+    token TOP       { \s* <value> \s* }
+    rule object     { '{' ~ '}' <pairlist>     }
+    rule pairlist   { <pair> * % \,            }
+    rule pair       { <string> ':' <value>     }
+    rule array      { '[' ~ ']' <arraylist>    }
+    rule arraylist  {  <value> * % [ \, ]        }
+
+    proto token value {*};
+    token value:sym<number> {
+        '-'?
+        [ 0 | <[1..9]> <[0..9]>* ]
+        [ \. <[0..9]>+ ]?
+        [ <[eE]> [\+|\-]? <[0..9]>+ ]?
+    }
+    token value:sym<true>    { <sym>    };
+    token value:sym<false>   { <sym>    };
+    token value:sym<null>    { <sym>    };
+    token value:sym<object>  { <object> };
+    token value:sym<array>   { <array>  };
+    token value:sym<string>  { <string> }
+
+    token string { ('"') ~ \" [ <str> | \\ <str=.str_escape> ]* }
+    token str { <-["\\\t\x[0A]]>+ }
+    token str_escape { <["\\/bfnrt]> | 'u' <utf16_codepoint>+ % '\u' }
+    token utf16_codepoint { <.xdigit>**4 }
+}
+
+my $PAIRS = 5;
+my $ARR   = 4;
+my $inner = '[' ~ (1..$ARR).map({ "[$_,$_]" }).join(',') ~ ']';
+my $doc   = '{' ~ (1..$PAIRS).map({ "\"k$_\":$inner" }).join(',') ~ '}';
+
+my $m = JsonLike.parse($doc);
+die "parse failed" unless $m;
+say "grammar-parse-deep: ok (doc {$doc.chars} chars, matched {$m.chars})";

--- a/docs/adr/0007-grammar-parse-trail-matcher.md
+++ b/docs/adr/0007-grammar-parse-trail-matcher.md
@@ -1,0 +1,211 @@
+# ADR-0007: Grammar/regex matcher — cursor + undo-log (trail) to kill capture-threading churn
+
+- **Status**: Proposed (2026-07-16)
+- **Context**: PLAN §5 grammar-parse performance. Follows the incremental Arc-shared
+  sub-captures slice (#4586) and the exponential/ceremony fixes (#4556, #4559).
+
+## Problem
+
+mutsu's grammar/regex matcher is **~30× slower than Rakudo on non-trivial grammar
+parses**, and the gap is entirely a **constant-factor allocation-churn** problem, not
+an algorithmic one.
+
+### Measured characterization (release build, 2026-07-16)
+
+Grammar: the JSON-like grammar from `benchmarks/bench-grammar-parse.raku`. Document:
+an object of `P` pairs, each value a nested array of 8 `[i,i]` sub-arrays.
+
+| P | chars | mutsu (single parse) | raku |
+|---|------:|---------------------:|-----:|
+| 2 | 111 | 2.04 s | 0.26 s |
+| 4 | 221 | 4.17 s | — |
+| 6 | 331 | 6.09 s | — |
+| 8 | 441 | 8.11 s | 0.26 s |
+
+The mutsu curve is **linear** (intercept ≈ 0, slope ≈ **18 ms per matched character**);
+raku is flat here (startup/compile-bound at these sizes, steady-state per-char cost
+negligible). So mutsu's asymptotics are fine — the *per-character work* is ~50–100×
+too expensive. (An earlier note claimed O(n²)/"140×"; that was an artefact of a
+3-iteration benchmark loop — corrected here and in PLAN/news.)
+
+### Root cause — profile of a ~6 s parse
+
+`perf` (release): **memmove ~19%, malloc ~17% + _int_malloc ~11%, free ~20%,
+finish_grow (Vec realloc) ~12%**, `RegexCaptures::clone`+drop ~4% (down from ~10%
+before #4586), `RegexCaptures::default` ~1.7%. So **~60–70% of the time is allocator
++ struct-copy churn**.
+
+The cause is architectural: `RegexCaptures` (mod.rs ~L848, `#[derive(Clone, Default)]`,
+~20 fields incl. 6 `HashMap`s / 7 `Vec`s, several hundred bytes) is **threaded by
+value through the entire backtracking search and cloned at nearly every step**:
+
+- Per **quantifier iteration**: `current_caps = new_caps.clone()` at
+  `regex_match_core.rs:1096/1338/1419` — a full clone of the *accumulated* caps on each
+  `*`/`+`/`**` iteration (locally O(iterations²)).
+- Per **candidate end**: ~14 `current_caps.clone()` sites in `regex_match_capture.rs`
+  and ~5 in `regex_match_atom.rs` (Alternation/SeqAlt/Group/CaptureGroup/Conjunction/
+  GoalMatch/Named), one clone per alternative × per inner end.
+- Per **separated-quantifier chain node**: `atom_caps.clone()/sep_caps.clone()` at
+  `regex_match_core.rs:468` (clones whole per-iteration cap vectors).
+- **Pure waste**: zero-width / leaf atoms clone the entire struct just to thread it
+  unchanged (`regex_match_capture.rs:163,188,466,688`).
+
+#4586 (Arc-shared nested sub-captures) removed the *deep-copy of sub-match subtrees*
+(clone+drop 10%→4%), but the **top-level struct clone still deep-copies every `Vec`/
+`HashMap` (and every `String` key)** at each step. That is the remaining churn.
+
+## Decision
+
+**Replace by-value capture threading with a single mutable capture store + an
+undo-log ("trail"): mutate forward as the cursor advances, and rewind the recorded
+deltas on backtrack.** This is how NQP/MoarVM (and classical backtracking engines)
+work, and it makes per-step capture cost O(delta) instead of O(accumulated state).
+
+Concretely:
+
+1. **One mutable `RegexCaptures` per top-level match**, owned by the engine, not cloned
+   per step.
+2. **A trail** — a `Vec` of undo records. Each mutation pushes a record describing how
+   to reverse it; `mark()` returns the current trail length; `rewind(mark)` pops and
+   applies undo records back to `mark`. Because the caps mutations are overwhelmingly
+   **append-only** (see the inventory below), most undo records are just "truncate Vec
+   *k* to length *n*" or "truncate the per-key Vec / remove the key". Only the
+   `$N=`/alias mid-vector overwrites (`regex_match_core.rs:626-686`) need value-level
+   undo records.
+3. **Convert the all-ends producers to depth-first-with-rewind generators.** This is the
+   load-bearing structural change (see "Structural blocker").
+
+### Why not the cheaper alternatives (rejected / insufficient)
+
+- **Leave it (ship only #4586).** Rejected: still ~30× off raku; the churn is the
+  headline grammar-parse cost and the batteries goal (§1) leans on real grammar parsing
+  (JSON::Tiny-style, zef metadata). Worth the rewrite.
+- **Box the cold `RegexCaptures` fields** (`Option<Box<ColdCaps>>`) to shrink the struct
+  and cut memmove. A contained win (~another single-digit %), but it does **not** remove
+  the per-step *malloc/free* of the hot `named`/`positional` collections — it only
+  shrinks the header memmove. Keep as a possible *complementary* micro-step, not the fix.
+- **Persistent/immutable caps (`im`/HAMT) with structural sharing.** Would make clones
+  cheap without a trail, but adds a dependency, changes every access site, and its
+  per-op constant factor is worse than plain `Vec`/`HashMap` for the common small maps.
+  The trail keeps the hot data structures as-is and pays only for real mutations.
+- **Full CPS→bytecode regex VM (NQP-style compiled regex).** The eventual ceiling, but
+  far larger than this ADR; the trail rewrite is the prerequisite step that de-risks it.
+
+## Current architecture (what the rewrite touches)
+
+Two backtracking mechanisms coexist (full map in the investigation notes):
+
+1. **Explicit LIFO stack** of `(idx, pos, RegexCaptures)` inside
+   `regex_match_ends_from_caps_in_pkg_impl` (`regex_match_core.rs:787`). A single linear
+   walk over `pattern.tokens`; each token pushes its continuations. **This is where the
+   cursor + trail lives** — it is already a stack machine; it just carries caps by value.
+2. **All-ends enumeration**: functions returning `Vec<(usize, RegexCaptures)>` — the
+   atom matcher (`regex_match_atom_all_with_capture_in_pkg`, atom.rs:45), the engine's
+   own `regex_match_ends_from_caps_in_pkg`, the separated-quantifier chain builders,
+   `quant_expand_greedy`, `build_named_candidates_from_inner`. Each element is a
+   *different capture state at the same call site*, all materialized at once.
+
+Single-match functions (`regex_match_end_from_caps_in_pkg`,
+`regex_match_atom_with_capture_in_pkg`) are already "first end only" and map cleanly onto
+"advance cursor, keep first success" — the easy cases.
+
+The **ratchet fast paths** (`regex_match_core.rs:934-1028`, `:1125-1252`) already thread
+only `pos` (or a single moved caps) with no cloning. **They are the model the trail
+generalizes** — preserve/subsume them, don't rewrite them.
+
+### Structural blocker (the crux)
+
+The trail assumes **one path explored at a time**. But the all-ends producers hand back
+N divergent capture states simultaneously (pushed onto the LIFO stack together at
+`regex_match_core.rs:814,848,893,917,1111,1117,1354,1360,1440,1446`). A single mutable
+store cannot hold N states at once. Each fan-out point must become: `let m = mark();`
+apply candidate *i* → descend to the next token → on backtrack `rewind(m)` → apply
+candidate *i+1*.
+
+The producers that genuinely require *all* ends (must become lazy generators over
+`(end, trail-delta)` rather than materialized owned-caps vectors):
+
+- **LTM longest-match `|`** (atom.rs:58) — evaluate every alt, pick longest, keep all for
+  outer backtracking.
+- **`||` sequential alternation** (atom.rs:92) — expose all lengths for recursive rules
+  (`r = <?> || x <r>` needs every r-length for an outer `$`).
+- **Outer-anchor backtracking into groups/subrules** (atom.rs:175,360) — a following
+  `$`/goalpost may only be satisfiable at one specific inner length.
+- **Frugal atoms / separators expanding for a following anchor** (core.rs:362 separated
+  chains, `quant_expand_greedy` core.rs:55) — shortest match must be able to grow.
+- **Conjunction `&`/`&&`** (atom.rs:141) — needs all first-branch ends to find one where
+  every other branch also ends.
+- **LTM protoregex / left-recursion seed growth** (atom.rs:424, `LR_MEMO`/`LR_ACTIVE`).
+
+### Hazards the trail must respect
+
+- **Thread-local side channels are NOT caps fields and must NOT be rewound**:
+  `LR_MEMO`/`LR_ACTIVE` (atom.rs:15), `EAGER_CODE_BLOCKS` (capture.rs:253),
+  `PENDING_REGEX_ERROR`/`PENDING_REGEX_GOAL_FAILURE` (errors/goal-failures deliberately
+  persist across backtracks). `REGEX_PRECEDING_CHAR` is already RAII-guarded. The trail
+  must explicitly exclude these.
+- **`apply_named_capture` mid-vector truncation/overwrite** (`$N=`/alias,
+  core.rs:626-686) is the one place a length-only truncate cannot rewind — needs
+  value-level undo records.
+- **`Arc::make_mut` on a stored subcap** (atom.rs:689, sets `action_name`) mutates
+  through the Arc — the trail record must restore the prior `action_name`, or (simpler)
+  this write moves before the Arc is shared.
+- **Sub-interpreter spawning** on Named/Code/VarDecl paths clones `self.env`+registry —
+  orthogonal to caps churn but part of the per-subrule cost; out of scope here, noted for
+  a later slice.
+
+### Trail-record shape (from the mutation inventory)
+
+Field writes are grouped in the investigation notes. The undo vocabulary is small:
+
+- `positional*` family, `code_blocks` — **append-only Vec growth** → undo = truncate to
+  saved length. (Plus the `$N=`/alias truncate-overwrite exceptions above.)
+- `named` / `named_subcaps` / `hash_captures` — **per-key Vec append** → undo = truncate
+  that key's Vec to saved length, or remove the key if newly created.
+- `named_quantified` (HashSet) — undo = remove-if-newly-inserted.
+- `sym`, `action_name`, `capture_start`/`capture_end`, `from`/`to` — scalar → undo =
+  restore prior value.
+- `matched`/`match_from` — set once at init / on subcap finalize, not mid-search.
+
+## Consequences
+
+- **Gain (per CLAUDE.md gain/risk):** removes the dominant band-aid (by-value CPS
+  threading) and makes the matcher *sound and fast* — the churn cannot come back because
+  there is no per-step clone. Target: bring grammar-parse per-char cost from ~18 ms/char
+  toward raku's steady state (aim ≥5× on the deep bench; the shallow bench should also
+  improve markedly). Directly serves the batteries goal (real grammar parsing).
+- **Risk:** it is a large, high-blast-radius matcher change. The semantics surface is
+  wide (capture markers `<( )>`, silent-action channel, aliases, `@<>`/`%<>` sigil
+  captures, `$N=`, LTM/`||`/`&`, ratchet, frugal, separated `%`/`%%`, code blocks,
+  backrefs, left recursion). Mitigation: CI's full roast S05 suite (67 whitelisted files,
+  2610 subtests) + the `t/` grammar/match suite are the safety net; the change lands on a
+  branch and fixes forward. This is exactly the "refactor boldly — CI + roast are the
+  safety net" case.
+
+## Phasing (proposed, to be confirmed before implementation)
+
+1. **P0 — scaffolding, behavior-preserving.** Introduce `struct CaptureTrail { marks }`
+   and `mark()/rewind()` next to a single owned `RegexCaptures`, but keep the existing
+   all-ends producers; use the trail only in the linear LIFO token walk where a single
+   path is already followed (ratchet-dominated grammars). Prove no regression + measure.
+2. **P1 — depth-first single-match core.** Convert `regex_match_ends_from_caps_in_pkg_impl`
+   to advance a cursor with `mark/rewind` for the common ratchet / single-candidate case;
+   fall back to the old all-ends path for the genuine multi-candidate producers.
+3. **P2 — lazy generators for the all-ends producers** (LTM `|`, `||`, groups, separated
+   chains, conjunction, LR): replace `Vec<(end, caps)>` with an iterator yielding
+   `(end, trail-mark)` so backtracking rewinds instead of discarding cloned states.
+4. **P3 — remove the by-value `RegexCaptures` threading** and the now-dead clone sites;
+   optionally box remaining cold fields.
+
+Each phase is independently shippable and roast-gated. Re-baseline against
+`benchmarks/bench-grammar-parse.raku` (shallow) and `bench-grammar-parse-deep.raku`
+(deep) at every phase; record numbers from bench CI, not local runs.
+
+## References
+
+- #4586 (Arc-shared sub-captures) — news/2026-07.md, PLAN §5.
+- Investigation map: the call graph, full clone inventory, and per-field mutation
+  inventory are summarized in this ADR; the exhaustive file:line list lives in the
+  2026-07-16 session notes and can be regenerated by reading `src/runtime/regex/`.
+- Benches: `benchmarks/bench-grammar-parse.raku` (shallow, 231 chars),
+  `benchmarks/bench-grammar-parse-deep.raku` (deep, object-of-nested-arrays).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,3 +25,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0004](0004-jit-strategy.md) | JIT — mechanism selection and phasing (Cranelift method JIT, no deopt) | Accepted |
 | [0005](0005-nanbox-representation-encoding.md) | NaN-boxing representation switch (3b-1) — encoding choice and newtype-seal integration | Accepted |
 | [0006](0006-baseline-interpreter-optimizations.md) | Baseline (classical) interpreter optimizations — adoption decisions and priorities | Accepted |
+| [0007](0007-grammar-parse-trail-matcher.md) | Grammar/regex matcher — cursor + undo-log (trail) to kill capture-threading churn | Proposed |

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -31,12 +31,17 @@ profiled samples; `benchmarks/bench-grammar-parse.raku` ~9% faster
 (67 files, 2610 subtests) and the `t/` grammar+match suite stay green.
 
 This is one slice of the grammar-parse allocation-churn item in PLAN §5. The
-remaining, larger prize is that grammar parsing is still ~O(n²) in document
-size (a 552-char nested-JSON doc: mutsu ~38s vs raku ~0.27s) because the hot
-`named` map + matched-text `String`s still deep-copy per DFS step and the
-~450-byte caps struct is memmoved on every by-value move. The sound fix is a
-mutable-cursor + undo-log (trail) matcher rather than by-value CPS threading —
-tracked in PLAN §5 as the next lever.
+remaining, larger prize: grammar parsing is **linear** in document size but
+~**30× slower than raku per matched character** (~18 ms/char on a deep
+object-of-nested-arrays bench; profile: ~19% memmove + ~40% malloc/free). It is
+a high constant-factor churn problem, **not** O(n²) — an earlier note to that
+effect was a 3-iteration benchmark-loop artefact and has been corrected. The
+sound fix is a single mutable capture store + undo-log (trail) matcher replacing
+the by-value CPS threading; the design, structural blocker (all-ends enumeration
+vs single-path rewind), full mutation/trail inventory, hazards, and a 4-phase
+plan are recorded in
+[docs/adr/0007-grammar-parse-trail-matcher.md](../docs/adr/0007-grammar-parse-trail-matcher.md)
+(Proposed) — the next grammar-parse lever.
 
 ## 2026-07-15: roast-wide raku-vs-mutsu speed measurement + perf re-baseline
 


### PR DESCRIPTION
Preparation for the next grammar-parse performance campaign (no code behavior change).

## What

- **`docs/adr/0007-grammar-parse-trail-matcher.md` (Proposed)** — the design decision to replace the matcher's by-value `RegexCaptures` threading with a single mutable capture store + an **undo-log (trail)**. Includes: measured characterization, root-cause profile, rejected alternatives, the current two-mechanism architecture, the **structural blocker** (all-ends enumeration returns N divergent capture states at once — incompatible with single-path mutate/rewind), the trail-record shape derived from a full per-field mutation inventory, the hazards (thread-local side channels that must NOT be rewound, `$N=` mid-vector overwrite, `Arc::make_mut`), and a 4-phase incremental plan.
- **`benchmarks/bench-grammar-parse-deep.raku`** — a deep object-of-nested-arrays parse that surfaces the allocation churn the shallow `bench-grammar-parse.raku` does not. Auto-discovered by `scripts/bench-ci.sh`.
- **PLAN §5 / news correction.**

## Correction to the earlier characterization

The #4586 notes claimed grammar parsing was still **O(n²)** (a "552-char doc → 38s vs raku 0.27s → 140×"). That was a **3-iteration benchmark-loop artefact**. A single parse is **linear** in document size (P=2→2.04s, P=4→4.17s, P=6→6.09s, P=8→8.11s single parse; intercept ≈ 0, ~18 ms/matched char), and raku is flat (~0.26s, startup-bound at these sizes). So the real problem is a **high constant factor (~30× raku per matched char), churn-bound** — not an algorithmic blowup. Profile of a ~6s parse: ~19% memmove + ~40% malloc/free, `RegexCaptures::clone`+drop ~4% (post-#4586), `default` ~1.7%.

The trail rewrite is the sound fix (mutate-forward / rewind-on-backtrack instead of clone-per-step). Phased so each step is roast-gated and independently shippable.

No source code changes; only docs + a new benchmark file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)