### PR TITLE
fix(gc): register runtime service threads as GC mutators

### DIFF
--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -15,6 +15,36 @@ where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
+    spawn_registered_thread(Some(USER_THREAD_STACK_SIZE), f)
+}
+
+/// Spawn a runtime service thread (timer, promise combinator, socket
+/// accept/read pump, supply emitter) as a REGISTERED GC mutator, with the
+/// default thread stack (these never run user VM code, so they need no deep
+/// recursion headroom).
+///
+/// Every thread that clones, drops, or creates `Gc` values MUST go through a
+/// registered spawn: the cycle collector's stop-the-world counts only
+/// registered threads toward quiescence, so an unregistered thread's
+/// `Gc::drop` can land mid-scan and corrupt trial deletion (seen as
+/// `MUTSU_GC_VERIFY` "survivor left inconsistent", strong N -> N-1 color
+/// Purple, when a `Promise.in` timer dropped its promise handle during a
+/// collect). Long blocking waits inside the closure (sleeps, blocking reads)
+/// must be wrapped in `gc::block_quiescent` so the thread does not starve the
+/// stop-the-world rendezvous.
+pub(crate) fn spawn_gc_helper_thread<F, T>(f: F) -> std::thread::JoinHandle<T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    spawn_registered_thread(None, f)
+}
+
+fn spawn_registered_thread<F, T>(stack_size: Option<usize>, f: F) -> std::thread::JoinHandle<T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
     // Register a mutator worker with the GC: the worker count is the
     // cooperative stop-the-world's quiescence target (trial deletion must not
     // race this thread's `Gc` mutations; see `gc::stw`). Raised here on the
@@ -26,8 +56,11 @@ where
     // without this a spawn burst starves every stop-the-world attempt — see
     // `gc::stw::preregister_worker_quiescent`.
     crate::gc::preregister_worker_quiescent();
-    std::thread::Builder::new()
-        .stack_size(USER_THREAD_STACK_SIZE)
+    let mut builder = std::thread::Builder::new();
+    if let Some(size) = stack_size {
+        builder = builder.stack_size(size);
+    }
+    builder
         .spawn(move || {
             struct WorkerGuard;
             impl Drop for WorkerGuard {

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1347,12 +1347,17 @@ impl Interpreter {
                     map.insert(supply_id, rx);
                 }
 
-                std::thread::spawn(move || {
+                // Registered spawn (emits `Value`s into a supply channel);
+                // the interval sleeps are quiescent safe regions — see
+                // `spawn_gc_helper_thread`.
+                crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
                     let period = std::time::Duration::from_secs_f64(period_secs);
                     let mut tick = 0i64;
                     // Initial delay before first emission (default 0 = immediate)
                     if initial_delay > 0.0 {
-                        std::thread::sleep(std::time::Duration::from_secs_f64(initial_delay));
+                        crate::gc::block_quiescent(|| {
+                            std::thread::sleep(std::time::Duration::from_secs_f64(initial_delay))
+                        });
                     }
                     loop {
                         if tx
@@ -1362,7 +1367,7 @@ impl Interpreter {
                             break;
                         }
                         tick = tick.saturating_add(1);
-                        std::thread::sleep(period);
+                        crate::gc::block_quiescent(|| std::thread::sleep(period));
                     }
                 });
 

--- a/src/runtime/methods_promise_class.rs
+++ b/src/runtime/methods_promise_class.rs
@@ -36,9 +36,14 @@ impl Interpreter {
             let secs = args.first().map(|v| v.to_f64()).unwrap_or(0.0).max(0.0);
             let promise = SharedPromise::new_with_class(Symbol::intern(&cls));
             let ret = Value::promise(promise.clone());
-            std::thread::spawn(move || {
+            // Registered spawn: this thread drops a `Gc` promise handle at
+            // exit (see `spawn_gc_helper_thread`); the sleep is a quiescent
+            // safe region so a long timer never starves a stop-the-world.
+            crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
                 if secs > 0.0 {
-                    std::thread::sleep(Duration::from_secs_f64(secs));
+                    crate::gc::block_quiescent(|| {
+                        std::thread::sleep(Duration::from_secs_f64(secs))
+                    });
                 }
                 promise.keep(Value::TRUE, String::new(), String::new());
             });
@@ -79,9 +84,12 @@ impl Interpreter {
             let delay = (at_time - now).max(0.0);
             let promise = SharedPromise::new_with_class(Symbol::intern(&cls));
             let ret = Value::promise(promise.clone());
-            std::thread::spawn(move || {
+            // Registered spawn + quiescent sleep — see `dispatch_promise_in`.
+            crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
                 if delay > 0.0 {
-                    std::thread::sleep(Duration::from_secs_f64(delay));
+                    crate::gc::block_quiescent(|| {
+                        std::thread::sleep(Duration::from_secs_f64(delay))
+                    });
                 }
                 promise.keep(Value::TRUE, String::new(), String::new());
             });
@@ -141,7 +149,10 @@ impl Interpreter {
                 promise.keep(Value::TRUE, String::new(), String::new());
                 return Some(Ok(ret));
             }
-            std::thread::spawn(move || {
+            // Registered spawn: `p.wait()` clones arbitrary result `Value`s
+            // and the thread drops its promise handles at exit (the waits
+            // themselves are already STW-aware / quiescent).
+            crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
                 for p in &promises {
                     p.wait();
                 }
@@ -169,7 +180,9 @@ impl Interpreter {
                 promise.keep(Value::TRUE, String::new(), String::new());
                 return Some(Ok(ret));
             }
-            std::thread::spawn(move || {
+            // Registered spawn + quiescent poll sleep — this thread drops its
+            // `Gc` promise handles at exit (see `spawn_gc_helper_thread`).
+            crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
                 // Poll until any promise resolves
                 loop {
                     for p in &promises {
@@ -178,7 +191,7 @@ impl Interpreter {
                             return;
                         }
                     }
-                    std::thread::sleep(Duration::from_millis(1));
+                    crate::gc::block_quiescent(|| std::thread::sleep(Duration::from_millis(1)));
                 }
             });
             return Some(Ok(ret));

--- a/src/runtime/native_io/native_io_path.rs
+++ b/src/runtime/native_io/native_io_path.rs
@@ -282,7 +282,10 @@ impl Interpreter {
                 }
 
                 let watched_path = path_buf.clone();
-                std::thread::spawn(move || {
+                // Registered spawn (emits `Value`s into a supply channel);
+                // the poll sleep is a quiescent safe region — see
+                // `spawn_gc_helper_thread`.
+                crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
                     let poll_interval = std::time::Duration::from_millis(10);
                     let mut last_state = fs::metadata(&watched_path).ok().map(|meta| {
                         let modified = meta
@@ -318,7 +321,7 @@ impl Interpreter {
                             last_state = state;
                         }
 
-                        std::thread::sleep(poll_interval);
+                        crate::gc::block_quiescent(|| std::thread::sleep(poll_interval));
                     }
                 });
 

--- a/src/runtime/native_methods/socket_async.rs
+++ b/src/runtime/native_methods/socket_async.rs
@@ -365,8 +365,11 @@ impl Interpreter {
 
                 let accept_host = host.clone();
                 let accept_enc = enc.clone();
-                // Start a background thread to accept connections
-                std::thread::spawn(move || {
+                // Start a background thread to accept connections.
+                // Registered spawn: it builds `Gc` values (the connection
+                // Instance) whose drop on a failed send must not race a cycle
+                // scan; the poll sleep is a quiescent safe region.
+                crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
                     // Use a short timeout on accept so we can check the closed flag
                     // TcpListener doesn't have set_timeout, so we use non-blocking + sleep
                     let _ = tcp_listener.set_nonblocking(true);
@@ -415,7 +418,9 @@ impl Interpreter {
                             }
                             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                                 // No pending connection, sleep briefly
-                                std::thread::sleep(std::time::Duration::from_millis(10));
+                                crate::gc::block_quiescent(|| {
+                                    std::thread::sleep(std::time::Duration::from_millis(10))
+                                });
                             }
                             Err(_) => {
                                 // Fatal accept error, stop

--- a/src/runtime/native_methods/socket_async_conn.rs
+++ b/src/runtime/native_methods/socket_async_conn.rs
@@ -126,11 +126,14 @@ impl Interpreter {
         if let Some(stream_arc) = get_tcp_stream(id) {
             let stream_clone = stream_arc.lock().ok().and_then(|s| s.try_clone().ok());
             if let Some(mut reader) = stream_clone {
-                std::thread::spawn(move || {
+                // Registered spawn: emits freshly built `Gc` values (Buf
+                // instances) whose drops on a failed send must not race a
+                // cycle scan; the blocking read is a quiescent safe region.
+                crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
                     use std::io::Read;
                     let mut buf = [0u8; 4096];
                     loop {
-                        match reader.read(&mut buf) {
+                        match crate::gc::block_quiescent(|| reader.read(&mut buf)) {
                             Ok(0) => {
                                 let _ = tx.send(SupplyEvent::Done);
                                 break;

--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -278,6 +278,11 @@ impl Interpreter {
                     }
                     if let Some(bytes) = stdin_bytes {
                         let stdin_arc = stdin_arc.clone();
+                        // Deliberately UNREGISTERED: this thread touches only
+                        // plain bytes (`Vec<u8>` + `Arc<Mutex<ChildStdin>>`),
+                        // never a `Gc` value, and the pipe write can block
+                        // indefinitely — registering it would starve the GC's
+                        // stop-the-world instead.
                         std::thread::spawn(move || {
                             if let Ok(mut guard) = stdin_arc.lock()
                                 && let Some(ref mut stdin) = *guard

--- a/src/vm/vm_react_loop.rs
+++ b/src/vm/vm_react_loop.rs
@@ -379,7 +379,11 @@ impl Interpreter {
                         // Create a one-shot channel for the promise
                         let (tx, rx) = mpsc::channel();
                         let shared_clone = shared.clone();
-                        std::thread::spawn(move || {
+                        // Registered spawn: `wait()` clones the resolved
+                        // result `Value` and the promise handle drops at
+                        // thread exit — both are `Gc` mutations that must not
+                        // race a cycle scan (the wait itself is STW-aware).
+                        crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
                             let (result, _, _) = shared_clone.wait();
                             let _ = tx.send(SupplyEvent::Emit(result));
                             let _ = tx.send(SupplyEvent::Done);

--- a/t/gc-promise-timer-stress.t
+++ b/t/gc-promise-timer-stress.t
@@ -1,0 +1,45 @@
+use v6;
+use Test;
+
+# Pin for the unregistered-timer-thread GC race: Promise.in/.at/.allof/.anyof
+# (and other runtime service threads) used to run on raw, GC-unregistered
+# threads, so a timer dropping its promise handle mid cycle-scan corrupted
+# trial deletion (MUTSU_GC_VERIFY "survivor left inconsistent", strong N->N-1
+# color Purple). Under the CI gc-stress job (MUTSU_GC=on +
+# MUTSU_GC_EVERY_CANDIDATE + MUTSU_GC_VERIFY) this workload made collects race
+# in-flight timers on nearly every run; the log gate fails on any VERIFY FAIL.
+
+plan 3;
+
+# Worker threads that build garbage cycles keep the candidate buffer busy so
+# collects run concurrently with the timer threads below.
+my @workers = (^4).map: {
+    start {
+        for ^200 {
+            my %h;
+            %h<self> := %h;
+            my @a;
+            @a[0] := @a;
+        }
+        True;
+    }
+};
+
+my @timers;
+for ^200 {
+    @timers.push: Promise.in(0.001 + rand * 0.01);
+    if @timers.elems > 40 {
+        await @timers.shift;
+    }
+    my %h;
+    %h<self> := %h;
+}
+await Promise.allof(@timers);
+ok True, 'overlapping Promise.in timers all resolved during GC churn';
+
+my $any = Promise.anyof(Promise.in(0.01), Promise.in(60));
+await $any;
+ok True, 'Promise.anyof resolved during GC churn';
+
+await Promise.allof(@workers);
+ok all(@workers.map(*.result)), 'cycle-churn workers all completed';


### PR DESCRIPTION
## Problem

The intermittent `MUTSU_GC_VERIFY` **survivor invariant violation** (`strong_before=2 strong_after=1 color=Purple`) — present on `main` and reproducible on nearly every `prove -j4` run of `roast/S17-promise/nonblocking-await.t` + `roast/MISC/bug-coverage-stress.t` on a 12-core machine — was caused by **GC-unregistered runtime service threads mutating the `Gc` graph mid cycle-scan**.

The cooperative stop-the-world counts only *registered* mutator threads toward its quiescence rendezvous. But several runtime service threads were spawned with raw `std::thread::spawn`:

- `Promise.in` / `Promise.at` timers — drop their `SharedPromise` (`Gc`) handle at thread exit
- `Promise.allof` / `Promise.anyof` combinators — `p.wait()` clones arbitrary result `Value`s, then drops `Gc` promise handles
- react-block Promise sources (`vm_react_loop`) — `wait()` result clone + handle drop
- `IO::Socket::Async` accept/read pump threads — build `Gc` values (connection Instances, Bufs)
- `IO::Path.watch` / `Supply.interval` emitters — emit `Value`s into supply channels

A collector could achieve "quiescence" while one of these threads was live; a timer firing mid-scan then dropped its promise handle, decrementing the survivor's strong count and re-buffering it Purple — exactly the observed signature. (A stray drop during trial deletion can also under-count a live node, so the one-off gc-stress SEGV in `bug-coverage-stress.t` — run 29417975573 — is plausibly the same root.)

## Fix

New `spawn_gc_helper_thread` in `builtins_system.rs`: the full registered-mutator protocol shared with `spawn_user_thread` (parent-side `enter_mutator_worker` + `preregister_worker_quiescent`, worker-side `worker_started`, panic-safe RAII unregister + TLS drop), but with the default stack — these threads never run user VM code. All the above threads now spawn through it, with long sleeps / blocking reads wrapped in `gc::block_quiescent` so a pending 60s timer or an idle socket read never starves the STW rendezvous. The child-stdin byte writer stays deliberately unregistered (pure `Vec<u8>`, no `Gc`, indefinitely-blocking pipe write).

## Verification

- **Pre-fix** (main release build): memory'd repro command → 2 VERIFY FAILs on many collect cycles, every run; minimal stress script → 3-8 violations per run; new pin test → violations in 2/3 runs.
- **Post-fix** (release): same repro command ×2, stress script ×5, pin test ×5 → **0 violations**.
- All 99 whitelisted S17 files pass under the gc-stress settings (`MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=1024 MUTSU_GC_VERIFY=1`, `-j4`) with **0 violations** — no STW-starvation regression from the newly registered threads.
- `cargo test`, full `prove t/` (1733 files), and the touched-area roast files (`S17-promise/{in,at,allof,anyof,nonblocking-await}.t`, `S16-io/watch.t`, `S17-supply/{interval,watch-path}.t`, `MISC/bug-coverage-stress.t`) all pass.
- Pin: `t/gc-promise-timer-stress.t` — under the CI gc-stress job the log gate (`VERIFY FAIL` grep) now has a workload that catches this bug class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)