### PR TITLE
perf: precomputed bind plan for the light named-call path

### DIFF
--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -402,7 +402,7 @@ impl Compiler {
             param_local_slots: None,
             has_inner_subs: false,
             declares_inner_routines: false,
-            named_param_slots: None,
+            named_call_plan: None,
             deprecated_info,
             declared_locals: None,
             param_name_syms: Vec::new(),
@@ -411,7 +411,7 @@ impl Compiler {
             package: self.current_package.clone(),
         };
         cf.precompute_param_local_slots();
-        cf.precompute_named_param_slots();
+        cf.precompute_named_call_plan();
         cf.precompute_param_name_syms();
         cf.detect_inner_subs();
         cf.compute_declared_locals();

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -3687,6 +3687,41 @@ impl CompiledCode {
 /// compiler-generated strings, so HashDoS resistance buys nothing here.
 pub(crate) type CompiledFns = rustc_hash::FxHashMap<String, CompiledFunction>;
 
+/// Precomputed bind plan for the light named-call path: what
+/// `call_compiled_function_light`'s binding loop needs per call, derived once
+/// per `CompiledFunction` instead of re-deriving match keys / locals slots /
+/// env-mirror gates from strings on every call.
+#[derive(Clone, Debug)]
+pub(crate) struct NamedCallPlan {
+    /// One entry per (named) parameter, in `param_defs` order.
+    pub(crate) params: Vec<NamedParamBind>,
+    /// Whether the body reads `@_` (has a `@_` local), so the caller's
+    /// positional args must be materialized into it.
+    pub(crate) uses_arg_array: bool,
+}
+
+/// Per-parameter entry of a [`NamedCallPlan`].
+#[derive(Clone, Debug)]
+pub(crate) struct NamedParamBind {
+    /// The key a caller's `:key(value)` pair must carry (sigil/twigil stripped).
+    pub(crate) match_key: String,
+    /// The parameter's locals slot (by `pd.name`), when it has one.
+    pub(crate) slot: Option<usize>,
+    /// Whether the bound value must also be written into the overlay env
+    /// (a name-based reader exists for the slot / the param has no slot).
+    pub(crate) needs_env: bool,
+    /// Whether the parameter is required (missing => X::AdHoc).
+    pub(crate) required: bool,
+    /// `sub_signature` alias keys that also match this param
+    /// (e.g. `colour` for `:color(:$colour)`).
+    pub(crate) alias_keys: Vec<String>,
+    /// On a match, every `sub_signature` name is additionally bound to the
+    /// value: (bind name, its locals slot).
+    pub(crate) alias_binds: Vec<(String, Option<usize>)>,
+    /// `outer_sub_signature` alias keys (sigils trimmed) that also match.
+    pub(crate) outer_alias_keys: Vec<String>,
+}
+
 /// A compiled function body (SubDecl compiled to bytecode).
 #[derive(Debug, Clone)]
 pub(crate) struct CompiledFunction {
@@ -3720,11 +3755,12 @@ pub(crate) struct CompiledFunction {
     /// returns. A `my sub` nested inside a `{ }` block within the body is not
     /// counted here: `BlockScope` already restores the registry for it.
     pub(crate) declares_inner_routines: bool,
-    /// Pre-computed mapping for named parameters: (match_key, local_slot, sub_sig_slots).
-    /// sub_sig_slots is a list of (inner_key, inner_slot) for sub_signature aliases.
-    /// Used by the OTF named call fast path to avoid name-based lookup per call.
-    #[allow(clippy::type_complexity)]
-    pub(crate) named_param_slots: Option<Vec<(String, usize, Vec<(String, usize)>)>>,
+    /// Pre-computed bind plan for the light named-call path
+    /// (`call_compiled_function_light`): per-parameter match keys, locals
+    /// slots, and env-mirror gates that the binding loop would otherwise
+    /// recompute from strings on every call. `Some` exactly when every
+    /// parameter is named (the light path's eligibility precondition).
+    pub(crate) named_call_plan: Option<Box<NamedCallPlan>>,
     /// Deprecation info: (kind, name, package, message).
     /// When set, every call records a deprecation event.
     pub(crate) deprecated_info: Option<(String, String, String, String)>,
@@ -3792,12 +3828,20 @@ impl CompiledFunction {
         }
     }
 
-    /// Pre-compute the mapping for named parameters: match_key -> (local_slot, sub_sig_slots).
-    pub(crate) fn precompute_named_param_slots(&mut self) {
+    /// Pre-compute the light named-call bind plan (see [`NamedCallPlan`]).
+    pub(crate) fn precompute_named_call_plan(&mut self) {
         if self.param_defs.is_empty() || !self.param_defs.iter().all(|pd| pd.named) {
             return;
         }
-        let mut slots = Vec::new();
+        let slot_of = |name: &str| self.code.locals.iter().position(|n| n == name);
+        // A slot's bound value must be mirrored into the overlay env when a
+        // name-based reader exists for it (same compile-time analysis the
+        // body's SetLocal flush uses); a param with no slot is env-only.
+        let needs_env_of = |slot: Option<usize>| match slot {
+            Some(s) => self.code.needs_env_sync.get(s).copied().unwrap_or(true),
+            None => true,
+        };
+        let mut params = Vec::with_capacity(self.param_defs.len());
         for pd in &self.param_defs {
             let match_key = pd
                 .name
@@ -3809,38 +3853,50 @@ impl CompiledFunction {
                 .or_else(|| match_key.strip_prefix('.'))
                 .unwrap_or(match_key)
                 .to_string();
-            let slot = self
-                .code
-                .locals
-                .iter()
-                .position(|n| n == &pd.name)
-                .unwrap_or(0);
-            // Pre-compute sub_signature alias slots
-            let mut sub_sig_slots = Vec::new();
+            let slot = slot_of(&pd.name);
+            let mut alias_keys = Vec::new();
+            let mut alias_binds = Vec::new();
             if let Some(ref sub_params) = pd.sub_signature {
                 for sub_pd in sub_params {
-                    if !sub_pd.named {
-                        continue;
+                    if sub_pd.named {
+                        alias_keys.push(
+                            sub_pd
+                                .name
+                                .strip_prefix(':')
+                                .unwrap_or(&sub_pd.name)
+                                .to_string(),
+                        );
                     }
-                    let inner_key = sub_pd
-                        .name
-                        .strip_prefix(':')
-                        .unwrap_or(&sub_pd.name)
-                        .to_string();
-                    let inner_slot = self
-                        .code
-                        .locals
-                        .iter()
-                        .position(|n| n == &sub_pd.name)
-                        .unwrap_or(0);
-                    sub_sig_slots.push((inner_key, inner_slot));
+                    // On a match (by any key), every sub-signature name is
+                    // bound to the value — e.g. `:color(:$colour)` binds both.
+                    alias_binds.push((sub_pd.name.clone(), slot_of(&sub_pd.name)));
                 }
             }
-            slots.push((match_key, slot, sub_sig_slots));
+            let mut outer_alias_keys = Vec::new();
+            if let Some(ref outer) = pd.outer_sub_signature {
+                for outer_pd in outer {
+                    outer_alias_keys.push(
+                        outer_pd
+                            .name
+                            .trim_start_matches(|c: char| "$@%&".contains(c))
+                            .to_string(),
+                    );
+                }
+            }
+            params.push(NamedParamBind {
+                match_key,
+                slot,
+                needs_env: needs_env_of(slot),
+                required: pd.required,
+                alias_keys,
+                alias_binds,
+                outer_alias_keys,
+            });
         }
-        if !slots.is_empty() {
-            self.named_param_slots = Some(slots);
-        }
+        self.named_call_plan = Some(Box::new(NamedCallPlan {
+            params,
+            uses_arg_array: self.code.locals.iter().any(|n| n == "@_"),
+        }));
     }
 
     /// Detect whether the function body contains inner sub declarations or closures.

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -165,14 +165,14 @@ impl Interpreter {
             param_local_slots: None,
             has_inner_subs: false,
             declares_inner_routines: false,
-            named_param_slots: None,
+            named_call_plan: None,
             deprecated_info,
             declared_locals: None,
             param_name_syms: Vec::new(),
             package: pkg.clone(),
         };
         cf.precompute_param_local_slots();
-        cf.precompute_named_param_slots();
+        cf.precompute_named_call_plan();
         cf.precompute_param_name_syms();
         cf.detect_inner_subs();
         cf.compute_declared_locals();

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -303,14 +303,19 @@ impl Interpreter {
                         )
                     {
                         let start = self.stack.len() - arity_usize;
-                        let args: Vec<Value> = self.stack.drain(start..).collect();
+                        // Pooled args buffer (J4d): `drain(..).collect()` was one
+                        // malloc/free per call; borrow the locals pool's recycled
+                        // `Vec<Value>` instead (mirrors the positional cached path).
+                        let mut args = self.take_locals_from_pool(0);
+                        args.extend(self.stack.drain(start..));
                         // Extract callsite line for deprecation tracking
                         let cl = crate::runtime::Interpreter::peek_callsite_line(&args);
                         if cl.is_some() {
                             loan_env!(self, set_pending_callsite_line(cl));
                         }
-                        let result = self.call_compiled_function_light(cf, args, compiled_fns)?;
-                        self.stack.push(result);
+                        let result = self.call_compiled_function_light(cf, &args, compiled_fns);
+                        self.recycle_locals(args);
+                        self.stack.push(result?);
                         // Slice F: drain captured-outer writes through to this
                         // caller frame's local slots (see the positional-light
                         // cached path above). The env_dirty-gated reconcile also
@@ -373,7 +378,7 @@ impl Interpreter {
                             && !named_share
                             && Self::is_light_call_eligible(&cf, name_str)
                         {
-                            self.call_compiled_function_light(&cf, args, compiled_fns)
+                            self.call_compiled_function_light(&cf, &args, compiled_fns)
                         } else if !share_into_scalar
                             && !named_share
                             && Self::is_positional_light_call_eligible(&cf, name_str)
@@ -1098,7 +1103,7 @@ impl Interpreter {
                             }
                         }
                     }
-                    let result = self.call_compiled_function_light(cf, args, compiled_fns);
+                    let result = self.call_compiled_function_light(cf, &args, compiled_fns);
                     let result = result?;
                     return loan_env!(self, maybe_fetch_rw_proxy(result, true));
                 }

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::runtime::types::unwrap_varref_value;
 
 impl Interpreter {
     /// Lightweight compiled function call that avoids the heavyweight frame
@@ -9,13 +8,21 @@ impl Interpreter {
     pub(super) fn call_compiled_function_light(
         &mut self,
         cf: &CompiledFunction,
-        args: Vec<Value>,
+        args: &[Value],
         compiled_fns: &CompiledFns,
     ) -> Result<Value, RuntimeError> {
         // GC safepoint (§9.2a `call`): the light-call boundary skips
         // push_call_frame, so it emits the call safepoint itself.
         crate::gc::gc_safepoint(crate::gc::SafepointKind::Call);
         self.record_cf_deprecation(cf);
+        // Eligibility (`is_light_call_eligible`) guarantees every param is
+        // named, which is exactly when the plan is precomputed. A hand-built
+        // chunk without one takes the full named dispatch instead.
+        let Some(plan) = cf.named_call_plan.as_deref() else {
+            let pkg = self.current_package().to_string();
+            let name = String::new();
+            return self.call_compiled_function_named(cf, args.to_vec(), compiled_fns, &pkg, &name);
+        };
         // Save caller locals and create callee locals
         let saved_locals = std::mem::take(&mut self.locals);
         // Isolate the caller's loop-body-local declaration scope (mirrors
@@ -34,164 +41,137 @@ impl Interpreter {
         // Scoped-overlay (docs/vm-dual-store.md Slice 6): install an empty
         // born-owned overlay over the caller. Param / alias / @_ env writes below
         // land in a fresh map and are discarded by dropping the overlay on return
-        // (callee-local names) or merged overlay-only (captured-outer writes),
-        // replacing the per-key save/restore the `modified_env_keys` list did.
-        let parent = self.env().clone();
-        let caller_env = std::mem::replace(self.env_mut(), crate::env::Env::scoped_child(parent));
+        // (callee-local names) or merged overlay-only (captured-outer writes).
+        //
+        // Frame reuse (ADR-0004 J4d, mirrored from the positional-light path):
+        // when the caller's live env is itself a scoped child whose overlay is
+        // still the process-shared empty singleton, keep it in place — the
+        // clone + scoped_child + drop round-trip is pure overhead. The shared
+        // singleton doubles as a write detector: the body's first by-name write
+        // un-shares it, and the unwind arm below replays the return merge in
+        // place.
+        let caller_env = if self.env().overlay_is_shared_empty() {
+            None
+        } else {
+            let parent = self.env().clone();
+            Some(std::mem::replace(
+                self.env_mut(),
+                crate::env::Env::scoped_child(parent),
+            ))
+        };
 
         let num_locals = cf.code.locals.len();
         self.locals = self.take_locals_from_pool(num_locals);
 
-        // Bind parameters directly to locals slots and the overlay env.
-        let mut positional_idx = 0usize;
-        for pd in &cf.param_defs {
-            let param_name = &pd.name;
-            let value = if pd.named {
-                // Named parameter: search args for matching Pair
-                let match_key = pd
-                    .name
-                    .strip_prefix('@')
-                    .or_else(|| pd.name.strip_prefix('%'))
-                    .unwrap_or(&pd.name);
-                let match_key = match_key
-                    .strip_prefix('!')
-                    .or_else(|| match_key.strip_prefix('.'))
-                    .unwrap_or(match_key);
-
-                let mut found_val: Option<Value> = None;
-
-                // Try matching the param name directly
-                for arg in args.iter().rev() {
-                    let arg = unwrap_varref_value(arg.clone());
-                    if let ValueView::Pair(key, val) = arg.view()
-                        && key.as_str() == match_key
-                    {
-                        found_val = Some(val.clone());
-                        break;
-                    }
-                }
-
-                // Try alias matching via sub_signature (e.g. :color(:$colour))
-                if found_val.is_none()
-                    && let Some(ref sub_params) = pd.sub_signature
-                {
-                    for sub_pd in sub_params {
-                        if found_val.is_some() {
-                            break;
-                        }
-                        if !sub_pd.named {
-                            continue;
-                        }
-                        let inner_key = sub_pd.name.strip_prefix(':').unwrap_or(&sub_pd.name);
-                        for arg in args.iter().rev() {
-                            let arg = unwrap_varref_value(arg.clone());
-                            if let ValueView::Pair(key, val) = arg.view()
-                                && key.as_str() == inner_key
-                            {
-                                found_val = Some(val.clone());
-                                break;
-                            }
-                        }
-                    }
-                }
-                // Try outer_sub_signature aliases
-                if found_val.is_none()
-                    && let Some(ref outer) = pd.outer_sub_signature
-                {
-                    for outer_pd in outer {
-                        if found_val.is_some() {
-                            break;
-                        }
-                        let outer_name = outer_pd
-                            .name
-                            .trim_start_matches(|c: char| "$@%&".contains(c));
-                        for arg in args.iter().rev() {
-                            let arg = unwrap_varref_value(arg.clone());
-                            if let ValueView::Pair(key, val) = arg.view()
-                                && key.as_str() == outer_name
-                            {
-                                found_val = Some(val.clone());
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                if let Some(v) = found_val {
-                    // If there's a sub_signature (rename), also bind inner params.
-                    // e.g. :color(:$colour) — bind both "color" and "colour".
-                    if let Some(ref sub_params) = pd.sub_signature {
-                        for sub_pd in sub_params {
-                            let sub_name = &sub_pd.name;
-                            if let Some(slot) = cf.code.locals.iter().position(|n| n == sub_name) {
-                                self.locals[slot] = v.clone();
-                            }
-                            self.env_mut().insert(sub_name.clone(), v.clone());
-                        }
-                    }
-                    Some(v)
-                } else if pd.required {
-                    self.set_env(caller_env);
-                    let used = std::mem::replace(&mut self.locals, saved_locals);
-                    self.recycle_locals(used);
-                    self.loop_local_vars = saved_loop_local_vars;
-                    self.loop_local_saved_env = saved_loop_local_saved_env;
-                    self.block_declared_vars = saved_block_declared_vars;
-                    // Missing required named parameter is a runtime X::AdHoc in
-                    // Raku (see binding.rs); carry the typed exception so it does
-                    // not fall back to the bare "Exception" default.
-                    return Err(RuntimeError::typed_msg(
-                        "X::AdHoc",
-                        format!("Required named parameter '{}' not passed", param_name),
-                    ));
-                } else {
-                    None
-                }
-            } else {
-                // Positional parameter: skip Pair args (they are named)
-                while positional_idx < args.len() {
-                    let unwrapped = unwrap_varref_value(args[positional_idx].clone());
-                    if !matches!(unwrapped.view(), ValueView::Pair(..)) {
-                        break;
-                    }
-                    positional_idx += 1;
-                }
-                if positional_idx < args.len() {
-                    let val = unwrap_varref_value(args[positional_idx].clone());
-                    positional_idx += 1;
-                    Some(val)
-                } else if pd.required {
-                    self.set_env(caller_env);
-                    let used = std::mem::replace(&mut self.locals, saved_locals);
-                    self.recycle_locals(used);
-                    self.loop_local_vars = saved_loop_local_vars;
-                    self.loop_local_saved_env = saved_loop_local_saved_env;
-                    self.block_declared_vars = saved_block_declared_vars;
-                    return Err(RuntimeError::new(format!(
-                        "Too few positionals passed; expected {} arguments but got {}",
-                        cf.param_defs.iter().filter(|p| !p.named).count(),
-                        args.iter()
-                            .filter(|a| !matches!(a.view(), ValueView::Pair(..)))
-                            .count()
-                    )));
-                } else {
-                    None
-                }
-            };
-
-            // Set both locals slot and env for the param.
-            // Locals are needed for GetLocal (fast path), env is needed for
-            // closures that capture the variable and for GetLocal's Nil
-            // fallback check (which errors on undeclared variables).
-            let bound_val = value.unwrap_or(Value::NIL);
-            if let Some(slot) = cf.code.locals.iter().position(|n| n == param_name) {
-                self.locals[slot] = bound_val.clone();
+        // Borrow-deref a possibly-VarRef-wrapped argument without cloning it.
+        #[inline]
+        fn deref_arg(arg: &Value) -> &Value {
+            match arg.view() {
+                ValueView::VarRef { value, .. } => value,
+                _ => arg,
             }
-            self.env_mut().insert(param_name.clone(), bound_val);
+        }
+        // Find the value of the last argument pair whose key is `key`.
+        #[inline]
+        fn find_named<'a>(args: &'a [Value], key: &str) -> Option<&'a Value> {
+            args.iter()
+                .rev()
+                .find_map(|arg| match deref_arg(arg).view() {
+                    ValueView::Pair(k, v) if k.as_str() == key => Some(v),
+                    _ => None,
+                })
         }
 
-        // Mark parameters as readonly (by default, params are immutable in Raku).
-        // Save existing readonly state so we can restore it after the call.
+        // Bind named parameters to their precomputed locals slots; mirror into
+        // the overlay env only when a name-based reader needs it (reflective
+        // access anywhere / closure capture via needs_env_sync) or when the
+        // value is `Nil` (the GetLocal handler treats a `Nil` slot as
+        // possibly-undeclared and verifies via env.contains_key).
+        let write_all_params = crate::opcode::reflective_name_access_possible();
+        for (i, npb) in plan.params.iter().enumerate() {
+            let mut found_val: Option<&Value> = find_named(args, &npb.match_key);
+            if found_val.is_none() {
+                for key in &npb.alias_keys {
+                    found_val = find_named(args, key);
+                    if found_val.is_some() {
+                        break;
+                    }
+                }
+            }
+            if found_val.is_none() {
+                for key in &npb.outer_alias_keys {
+                    found_val = find_named(args, key);
+                    if found_val.is_some() {
+                        break;
+                    }
+                }
+            }
+            let Some(v) = found_val else {
+                if npb.required {
+                    // Unwind (missing required named param => runtime X::AdHoc).
+                    match caller_env {
+                        Some(caller_env) => self.set_env(caller_env),
+                        None => {
+                            if !self.env().overlay_is_shared_empty() {
+                                self.env_mut().retain_overlay(|_, _| false);
+                            }
+                        }
+                    }
+                    let used = std::mem::replace(&mut self.locals, saved_locals);
+                    self.recycle_locals(used);
+                    self.loop_local_vars = saved_loop_local_vars;
+                    self.loop_local_saved_env = saved_loop_local_saved_env;
+                    self.block_declared_vars = saved_block_declared_vars;
+                    return Err(RuntimeError::typed_msg(
+                        "X::AdHoc",
+                        format!(
+                            "Required named parameter '{}' not passed",
+                            cf.param_defs[i].name
+                        ),
+                    ));
+                }
+                // Missing optional named param: bind `Nil` into the overlay
+                // env so the param SHADOWS a same-named caller lexical (the
+                // locals seed below reads through to the caller otherwise)
+                // and so GetLocal's Nil-slot "declared?" probe finds it.
+                match cf.param_name_syms.get(i) {
+                    Some(sym) => {
+                        self.env_mut().insert_sym(*sym, Value::NIL);
+                    }
+                    None => {
+                        self.env_mut()
+                            .insert(cf.param_defs[i].name.clone(), Value::NIL);
+                    }
+                }
+                continue;
+            };
+            let v = v.clone();
+            // A sub_signature rename (`:color(:$colour)`) binds every inner
+            // name to the value as well.
+            for (alias_name, alias_slot) in &npb.alias_binds {
+                if let Some(slot) = alias_slot {
+                    self.locals[*slot] = v.clone();
+                }
+                self.env_mut().insert(alias_name.clone(), v.clone());
+            }
+            if let Some(slot) = npb.slot {
+                self.locals[slot] = v.clone();
+            }
+            if write_all_params || npb.needs_env || v.is_nil() {
+                match cf.param_name_syms.get(i) {
+                    Some(sym) => {
+                        self.env_mut().insert_sym(*sym, v);
+                    }
+                    None => {
+                        self.env_mut().insert(cf.param_defs[i].name.clone(), v);
+                    }
+                }
+            }
+        }
+
+        // Mark parameters as readonly (eligibility excludes `is rw/copy/raw`
+        // traits, so every param is immutable). Save the existing readonly
+        // state to restore after the call.
         let saved_readonly = self.enter_readonly_frame();
         for (i, pd) in cf.param_defs.iter().enumerate() {
             if !pd.name.is_empty()
@@ -199,90 +179,49 @@ impl Interpreter {
                 && !pd.name.starts_with('!')
                 && !pd.name.starts_with('.')
             {
-                let has_mutable_trait = pd
-                    .traits
-                    .iter()
-                    .any(|t| t == "rw" || t == "copy" || t == "raw");
                 // `param_name_syms` is `param_defs[i].name` pre-interned; fall
                 // back to interning for a chunk that never precomputed it.
-                let sym = cf.param_name_syms.get(i).copied();
-                if !has_mutable_trait {
-                    match sym {
-                        Some(sym) => self.mark_readonly_sym(sym),
-                        None => self.mark_readonly(&pd.name),
-                    }
-                } else {
-                    // `is copy`/`is rw`/`is raw` params are writable. The readonly
-                    // set is keyed by bare name and shared across frames, so a
-                    // caller's same-named readonly param (e.g. an outer `$d`) would
-                    // otherwise leak in and make this writable param appear readonly.
-                    // Unmark it; `restore_readonly_vars` reinstates the caller's
-                    // state after the call.
-                    match sym {
-                        Some(sym) => self.unmark_readonly_sym(sym),
-                        None => self.unmark_readonly(&pd.name),
-                    }
+                match cf.param_name_syms.get(i) {
+                    Some(sym) => self.mark_readonly_sym(*sym),
+                    None => self.mark_readonly(&pd.name),
                 }
             }
         }
 
-        // Set @_ only if the function body uses it (has @_ in locals)
-        if cf.code.locals.iter().any(|n| n == "@_") {
+        // Set @_ only if the function body uses it (has a @_ local).
+        if plan.uses_arg_array {
             let plain_args: Vec<Value> = args
                 .iter()
-                .filter(|a| {
-                    !matches!(
-                        unwrap_varref_value((*a).clone()).view(),
-                        ValueView::Pair(..)
-                    )
-                })
-                .map(|a| unwrap_varref_value(a.clone()))
+                .map(deref_arg)
+                .filter(|a| !matches!(a.view(), ValueView::Pair(..)))
+                .cloned()
                 .collect();
             self.env_mut()
                 .insert("@_".to_string(), Value::array(plain_args));
         }
 
-        // Handle legacy placeholder params (e.g. $^a, $^b from cf.params)
-        if cf.param_defs.is_empty() && !cf.params.is_empty() {
-            let mut placeholder_pos = 0usize;
-            let plain_args: Vec<Value> = args
-                .iter()
-                .filter(|a| {
-                    !matches!(
-                        unwrap_varref_value((*a).clone()).view(),
-                        ValueView::Pair(..)
-                    )
-                })
-                .map(|a| unwrap_varref_value(a.clone()))
-                .collect();
-            for param in &cf.params {
-                if placeholder_pos < plain_args.len() {
-                    let val = plain_args[placeholder_pos].clone();
-                    placeholder_pos += 1;
-                    // Set in locals
-                    if let Some(slot) = cf.code.locals.iter().position(|n| n == param) {
-                        self.locals[slot] = val.clone();
-                    }
-                    // Also set in (overlay) env for the placeholder and its alias
-                    self.env_mut().insert(param.clone(), val.clone());
-                    // Create de-careted alias: ^foo -> foo, ^k -> k
-                    if let Some(bare) = param.strip_prefix('^') {
-                        let bare = bare.to_string();
-                        if let Some(slot) = cf.code.locals.iter().position(|n| *n == bare) {
-                            self.locals[slot] = val.clone();
-                        }
-                        self.env_mut().insert(bare, val);
-                    }
+        // Seed the remaining (non-param) locals by reading through to the
+        // caller env, matching the prior env().get() semantics. `locals_sym`
+        // is `locals` pre-interned at finalize(), so the seed hashes a `u32`
+        // per local instead of the name string. A slot already bound above is
+        // non-Nil unless the bound value itself was Nil — in which case the
+        // param was also mirrored into the overlay env (the `is_nil` gate), so
+        // the read-through finds that same value and stays coherent.
+        if cf.code.locals_sym.len() == num_locals {
+            for (i, sym) in cf.code.locals_sym.iter().enumerate() {
+                if self.locals[i].is_nil()
+                    && let Some(val) = self.env().get_sym(*sym)
+                {
+                    self.locals[i] = val.clone();
                 }
             }
-        }
-
-        // For any locals not yet set from params, try to initialize from env
-        for (i, local_name) in cf.code.locals.iter().enumerate() {
-            if self.locals[i].is_nil()
-                && let Some(val) = self.env().get(local_name)
-            {
-                self.locals[i] = val.clone();
+        } else {
+            for (i, local_name) in cf.code.locals.iter().enumerate() {
+                if self.locals[i].is_nil()
+                    && let Some(val) = self.env().get(local_name)
+                {
+                    self.locals[i] = val.clone();
+                }
             }
         }
 
@@ -379,19 +318,40 @@ impl Interpreter {
         // param of this function) persists in the caller; the function's
         // params/locals/aliases are dropped with the overlay. This replaces the
         // per-key `modified_env_keys` save/restore.
-        {
-            let scoped = std::mem::replace(self.env_mut(), caller_env);
-            for (k, v) in scoped.overlay_iter() {
-                if *k == "_"
-                    || *k == "@_"
-                    || *k == "%_"
-                    || *k == "__mutsu_callable_id"
-                    || k.with_str(|s| s.starts_with('?'))
-                {
-                    continue;
+        match caller_env {
+            Some(caller_env) => {
+                let scoped = std::mem::replace(self.env_mut(), caller_env);
+                for (k, v) in scoped.overlay_iter() {
+                    if *k == "_"
+                        || *k == "@_"
+                        || *k == "%_"
+                        || *k == "__mutsu_callable_id"
+                        || k.with_str(|s| s.starts_with('?'))
+                    {
+                        continue;
+                    }
+                    if !cf.is_callee_local_sym(*k) {
+                        self.env_mut().insert_sym(*k, v.clone());
+                    }
                 }
-                if !cf.is_callee_local_sym(*k) {
-                    self.env_mut().insert_sym(*k, v.clone());
+            }
+            None => {
+                // Reused frame: the caller's overlay was the shared empty
+                // singleton at entry. If the latch is still armed the body
+                // never wrote env — nothing to merge or restore. Otherwise
+                // every overlay entry is a write made by this call; replay the
+                // swap path's return merge in place — keep captured-outer
+                // writes (already sitting in the caller's env) and drop
+                // callee-locals and the per-frame private names.
+                if !self.env().overlay_is_shared_empty() {
+                    self.env_mut().retain_overlay(|k, _| {
+                        !(*k == "_"
+                            || *k == "@_"
+                            || *k == "%_"
+                            || *k == "__mutsu_callable_id"
+                            || k.with_str(|s| s.starts_with('?'))
+                            || cf.is_callee_local_sym(*k))
+                    });
                 }
             }
         }

--- a/t/named-light-call-binding.t
+++ b/t/named-light-call-binding.t
@@ -1,0 +1,54 @@
+use v6;
+use Test;
+
+# Pin for the light named-call bind plan (call_compiled_function_light):
+# precomputed Symbol/slot binding must preserve the string-scan path's
+# semantics — param shadowing of same-named caller lexicals, sub-signature
+# renames, alias binding, required-param X::AdHoc, closure capture of a named
+# param, and last-pair-wins duplicate handling.
+
+plan 12;
+
+# A missing optional named param shadows a same-named caller lexical (it must
+# NOT read through to the caller's $color).
+my $color = "outer";
+sub f(:$color) { $color // "unset" }
+is f(), "unset", 'missing optional named param shadows caller lexical';
+is f(:color<in>), "in", 'passed named param binds';
+is $color, "outer", 'caller lexical untouched after the call';
+
+# Repeated calls through the light-call cache keep the same binding behavior.
+my @seen;
+for ^3 { @seen.push(f()) }
+is-deeply @seen, ["unset", "unset", "unset"], 'cached calls rebind fresh each time';
+
+# sub_signature rename: :color(:$colour) — both keys match, inner name binds.
+sub g(:color(:$colour)) { $colour }
+is g(:color<c1>), "c1", 'rename matches the outer key';
+is g(:colour<c2>), "c2", 'rename matches the inner key';
+
+# Required named param: missing => X::AdHoc at runtime.
+sub h(:$x!) { $x }
+is h(:x(1)), 1, 'required named param binds';
+my $err;
+{ h(); CATCH { default { $err = $_ } } }
+ok $err ~~ X::AdHoc, 'missing required named param throws X::AdHoc';
+
+# A closure inside the body captures the named param by name.
+sub k(:$a) { my $c = { $a * 2 }; $c() }
+is k(:a(21)), 42, 'closure captures named param';
+
+# Duplicate named args: the last one wins.
+sub dup(:$v) { $v }
+is dup(:v(1), :v(2)), 2, 'last duplicate named arg wins';
+
+# A named param whose caller passes a variable (VarRef-wrapped arg).
+sub via-var(:$n) { $n + 1 }
+my $m = 41;
+is via-var(:n($m)), 42, 'named arg from a variable binds through VarRef';
+
+# Captured-outer write from a named-param sub persists in the caller.
+my $acc = 0;
+sub bump(:$by) { $acc += $by }
+bump(:by(5)); bump(:by(7));
+is $acc, 12, 'captured-outer writes persist across light named calls';


### PR DESCRIPTION
## Problem

PLAN §perf item -1 (2026-07-15 re-baseline): the interpreter function-call path in hot loops is the top perf target, and **named args add disproportionate cost** — a 1M-iteration loop calling `sub foo(:$color)` with `foo(:color($_))` spends **~2900 instructions/call more** than the positional twin (raku: +6%). This is also the mzef ctor/populate cost class (named-arg re-materialization per dispatch).

The light named path (`call_compiled_function_light`) re-derived everything from strings on every call:
- match keys recomputed from the param name (sigil/twigil strip per call)
- locals slots found by `locals.iter().position(|n| n == name)` linear string scan
- every param unconditionally inserted into the overlay env (String clone + intern + SipHash)
- each Pair probe **cloned the argument** before viewing it
- `@_` presence re-scanned from the locals table per call
- a fresh scoped-child env built even when the caller's frame was reusable
- the cache-hit call site paid a `drain().collect()` malloc per call

Meanwhile `named_param_slots` was precomputed on every CompiledFunction **but never read** (dead since its consumer was refactored away).

## Fix

Replace `named_param_slots` with a `NamedCallPlan` built once per CompiledFunction (both construction sites): per-param match key, locals slot, env-mirror gate (from the compiler's `needs_env_sync` analysis — the same gate the positional light path trusts), required flag, sub-signature/outer alias keys, and a uses-`@_` bit.

The binding loop now scans args borrow-only (zero clones per probe), binds by slot, and mirrors into env only when a name-based reader exists — preserving the string-scan path's semantics exactly:
- a Nil-valued bind is still mirrored so GetLocal's declared-probe finds it
- a **missing optional named param still writes Nil** so it shadows a same-named caller lexical instead of reading through to it (caught in self-review; pinned)
- sub-signature renames bind every inner name; last duplicate pair wins; required-missing throws X::AdHoc

Also ports the positional path's frame-reuse latch (skip `scoped_child` when the caller's overlay is the shared empty singleton) and pooled args buffer to the named cache-hit site.

## Numbers (perf stat -e instructions:u, taskset -c 0, release)

| bench (1M calls) | before | after | Δ |
|---|---|---|---|
| `foo(:color($_))` | 8.507G | **6.833G** | **-19.7%** (per-call named overhead 2900 → 1228 instr) |
| `foo($_)` (positional) | 5.607G | 5.605G | unchanged (no regression) |

Remaining named-call overhead is the caller-side `MakePair` PairBox allocation per call — that needs a call-ABI change (separate named-args channel) and is a follow-up slice.

## Verification

- `prove t/` full suite (1736 files) PASS; `cargo test` PASS; clippy/fmt clean
- roast: all 35 `S06-signature/*.t` files PASS (incl. `named-parameters.t`, `named-renaming.t`)
- New pin: `t/named-light-call-binding.t` (12 cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)