### PR TITLE
perf: regex matcher — single mutable capture store + undo-log trail (ADR-0007)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -517,24 +517,28 @@ unification / the malloc clusters from `Value` clone/drop and attribute material
       `RegexCaptures::clone`+drop ~10% → ~4% of samples; bench-grammar-parse ~9% faster
       (1.51s → 1.37s), a deep nested-JSON doc ~4-10% faster. Pinned by
       `t/regex-nested-subcaps-sharing.t`.
-      **Remaining (the real prize — a high constant factor, NOT O(n²)):** grammar parsing
-      is **linear** in document size but ~**30× slower than raku** per matched character
-      (~18 ms/char on the deep object-of-nested-arrays bench: P=2→2.04s … P=8→8.11s single
-      parse, intercept ≈0; raku flat ~0.26s). The cost is allocation churn from threading
-      the whole `RegexCaptures` struct by value and cloning it at nearly every step —
-      per-quantifier-iteration `current_caps = new_caps.clone()`
-      (`regex_match_core.rs:1096/1338/1419`), ~14 per-candidate clones in
-      `regex_match_capture.rs`, and zero-width/leaf atoms cloning the struct for nothing.
-      Profile of a ~6s deep parse: ~19% memmove + ~40% malloc/free, clone+drop ~4%,
-      `RegexCaptures::default` ~1.7%. **(An earlier "O(n²)/140×" note was a 3-iteration
-      benchmark-loop artefact — corrected.)** The sound fix is a single mutable capture
-      store + an **undo-log / trail** (mutate-forward, rewind-on-backtrack) replacing the
-      by-value CPS threading, which requires converting the all-ends enumeration producers
-      to depth-first-with-rewind generators. Design, structural blocker, mutation/trail
-      inventory, hazards, and a 4-phase plan are in
-      **[docs/adr/0007-grammar-parse-trail-matcher.md](docs/adr/0007-grammar-parse-trail-matcher.md)
-      (Proposed)** — the next grammar-parse lever. Bench: `benchmarks/bench-grammar-parse.raku`
-      (shallow) + `benchmarks/bench-grammar-parse-deep.raku` (deep).
+      **Update 2026-07-16 (4): the trail matcher (ADR-0007, Accepted) is LANDED (#4591)** —
+      the engine walks tokens depth-first over ONE mutable `RegexCaptures` store per
+      pattern level with an undo-log (`regex_trail.rs`: mark/apply-delta/rewind); atom
+      producers return deltas relative to an empty baseline instead of cloning the
+      accumulated caps per candidate, and quantifier chains grow/shrink on the store with
+      a mark per iteration. Per-step capture cost is O(delta), never O(accumulated).
+      Measured (local release A/B): deep bench ~×1.25 (memmove 15.4%→7.5% of samples,
+      `RegexCaptures::clone` 2.1%→1.0%), shallow ~×1.2.
+      **Remaining: per-subrule ceremony — still ~25× vs raku per matched character.**
+      The residual profile (~36% allocator + spread) is a constant cost per subrule
+      invocation, NOT accumulated-state churn: candidate `Vec`s + captured-text `String`s
+      + `Arc<RegexCaptures>` subcap allocs, HashMap+SipHash traffic on the caps maps
+      (~3%), a **runtime regex re-parse path** visible in-profile
+      (`parse_regex_uncached` + LTM expansion ~4% — bypasses `PARSED_TOKEN_CANDIDATES` /
+      `REGEX_PARSE_CACHE` somewhere; find it first, likely the cheapest big win),
+      `RegexCaptures::default` zeroing (~2%), one `snapshot()` per complete inner end.
+      Next slices: memoize the residual re-parse; FxHash (or a small-vec map) for the
+      caps maps; box cold `RegexCaptures` fields (shrinks default/memmove); intern trail
+      undo-record keys. Details in
+      **[docs/adr/0007-grammar-parse-trail-matcher.md](docs/adr/0007-grammar-parse-trail-matcher.md)**
+      §Implementation outcome. Bench: `benchmarks/bench-grammar-parse.raku` (shallow) +
+      `benchmarks/bench-grammar-parse-deep.raku` (deep).
 - Targets (numbers from bench CI, main `c8955d2e`, 2026-07-13; parentheses = JIT-on series):
   method-call <1.5x (✅ 1.19x / jit 1.16x), bench-class <1.5x (✅ 1.02x / jit 1.00x),
   fib <10x (✅ **0.82x / jit 0.65x**), bench-fib (with type constraints) <2x

--- a/docs/adr/0007-grammar-parse-trail-matcher.md
+++ b/docs/adr/0007-grammar-parse-trail-matcher.md
@@ -1,8 +1,31 @@
 # ADR-0007: Grammar/regex matcher — cursor + undo-log (trail) to kill capture-threading churn
 
-- **Status**: Proposed (2026-07-16)
+- **Status**: Accepted (2026-07-16) — implemented in #4591
 - **Context**: PLAN §5 grammar-parse performance. Follows the incremental Arc-shared
   sub-captures slice (#4586) and the exponential/ceremony fixes (#4556, #4559).
+
+## Implementation outcome (2026-07-16, #4591)
+
+The four phases landed as one PR: a key simplification made the split unnecessary.
+Every candidate producer only ever *appended* to the cloned accumulated caps, so
+converting them to delta output was mechanically `current_caps.clone()` →
+`RegexCaptures::default()` (~30 sites) with the per-branch merge-field subsets preserved
+exactly; the engine walk became a recursive DFS (`walk_tokens`) over a `CapStore`
+(`regex_trail.rs`) with mark/apply-delta/rewind, and the all-ends producers stayed
+materialized (their elements are now cheap deltas, so laziness — P2's concern — stopped
+being load-bearing). `quant_expand_greedy` became the trail-based `quant_alt_dfs`.
+
+Measured (local release A/B): deep bench ~×1.25, shallow ~×1.2; memmove 15.4% → 7.5% of
+samples, `RegexCaptures::clone` 2.1% → 1.0%. The per-step O(accumulated) clone is
+structurally gone — but the headline "~60–70% allocator churn" turned out to be only
+partly *accumulated-state* churn. The remainder (~36% of samples post-trail) is
+**per-subrule ceremony**, present on main too: candidate `Vec`s, captured-text `String`s,
+`Arc<RegexCaptures>` subcap allocations, HashMap+SipHash traffic on the caps maps,
+`RegexCaptures::default` zeroing (~2%), one `snapshot()` per complete inner end, and a
+still-unexplained **runtime regex re-parse** path (`parse_regex_uncached` + LTM expansion
+~4% in-profile). The ≥5× deep-bench target therefore needs the follow-up slices (find &
+memoize the residual re-parse; FxHash or small-map for caps maps; box cold
+`RegexCaptures` fields; intern trail-record keys) — tracked in PLAN §5.
 
 ## Problem
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,32 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-16: grammar-parse — trail matcher landed (ADR-0007 Accepted, #4591)
+
+The by-value `RegexCaptures` threading through the backtracking search is gone:
+the engine now walks pattern tokens depth-first over **one mutable capture
+store per pattern level with an undo-log** (`regex_trail.rs`: `CapStore`,
+`mark()`/`merge_delta()`/`rewind()`). Atom candidate producers return *deltas*
+relative to an empty baseline — the conversion was mechanically
+`current_caps.clone()` → `RegexCaptures::default()` (~30 sites) because every
+producer only ever appended to the cloned base — and the engine applies a
+candidate, descends, and rewinds on backtrack, so per-step capture cost is
+O(delta) instead of O(accumulated state). Quantifier chains grow/shrink on the
+store with a mark per iteration; `quant_expand_greedy` (full caps clone per
+tree node) became the trail-based `quant_alt_dfs`; the `$N=`/alias mid-vector
+surgery and quantified-capture folds are trailed store operations with
+value-level undo. Separated quantifiers moved to `regex_match_sep.rs`.
+
+Measured (local release A/B vs main): `bench-grammar-parse-deep` ~×1.25 (perf
+samples 11872 → 9449; memmove 15.4% → 7.5%; `RegexCaptures::clone` 2.1% → 1.0%),
+shallow ~×1.2. Validation: full `make test`, the 93-file S05 whitelist (5524
+subtests), and the exponential-backtracking pins all green; trail round-trips
+unit-tested. Lesson recorded in the ADR: the "~60–70% allocator churn" was only
+partly accumulated-state churn — the residual (~36%) is **per-subrule ceremony**
+(candidate vecs, captured Strings, Arc subcap allocs, SipHash map traffic, a
+still-unexplained runtime regex re-parse ~4%), so the ≥5× target needs the
+follow-up slices listed in PLAN §5.
+
 ## 2026-07-15: grammar-parse — nested sub-captures shared behind Arc (#4586)
 
 `RegexCaptures` threads by value through the entire backtracking DFS, and its

--- a/src/runtime/regex/mod.rs
+++ b/src/runtime/regex/mod.rs
@@ -11,6 +11,8 @@ mod regex_match_core;
 mod regex_match_find;
 mod regex_match_nocap;
 mod regex_match_public;
+mod regex_match_sep;
 mod regex_resolve;
 mod regex_token_method;
 mod regex_token_resolve;
+mod regex_trail;

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -51,9 +51,15 @@ impl Interpreter {
         pkg: &str,
         ignore_case: bool,
     ) -> Vec<(usize, RegexCaptures)> {
-        // Return value convention: LOWEST PRIORITY FIRST, HIGHEST PRIORITY LAST.
-        // Callers push this vec to a LIFO stack in order, so the last element
-        // is pushed last and sits on top (= tried first = highest priority).
+        // Return value convention: LOWEST PRIORITY FIRST, HIGHEST PRIORITY LAST
+        // (the engine iterates the vec in reverse, trying the highest-priority
+        // candidate first).
+        //
+        // Each candidate's captures are a DELTA relative to an EMPTY baseline
+        // (ADR-0007): the engine merges the chosen delta into its capture
+        // store and rewinds it on backtrack. `current_caps` is the engine's
+        // accumulated store, passed for READS only (backrefs, code assertions,
+        // subrule argument evaluation) — it must never be cloned into results.
 
         if let RegexAtom::Alternation(alternatives) = atom {
             // | (LTM): try all alternatives, longest match wins.
@@ -62,7 +68,7 @@ impl Interpreter {
                 if let Some((next, mut inner_caps)) =
                     self.regex_match_end_from_caps_in_pkg(alt, chars, pos, pkg)
                 {
-                    let mut new_caps = current_caps.clone();
+                    let mut new_caps = RegexCaptures::default();
                     for (k, v) in inner_caps.named.drain() {
                         new_caps.named.entry(k).or_default().extend(v);
                     }
@@ -110,7 +116,7 @@ impl Interpreter {
                 // convention). Reverse to LOWEST FIRST for our return convention.
                 let mut group = Vec::new();
                 for (next, mut inner_caps) in inner_matches {
-                    let mut new_caps = current_caps.clone();
+                    let mut new_caps = RegexCaptures::default();
                     for (k, v) in inner_caps.named.drain() {
                         new_caps.named.entry(k).or_default().extend(v);
                     }
@@ -146,7 +152,7 @@ impl Interpreter {
             // branch and, for each, require every other branch to match exactly
             // to that end.
             let Some((first, rest)) = branches.split_first() else {
-                return vec![(pos, current_caps.clone())];
+                return vec![(pos, RegexCaptures::default())];
             };
             let mut out: Vec<(usize, RegexCaptures)> = Vec::new();
             // first-branch candidates: HIGHEST-priority-first from ends fn.
@@ -154,7 +160,7 @@ impl Interpreter {
             let mut first_ends = self.regex_match_ends_from_caps_in_pkg(first, chars, pos, pkg);
             first_ends.reverse();
             for (end, first_caps) in first_ends {
-                let mut merged = merge_regex_captures(current_caps.clone(), first_caps);
+                let mut merged = merge_regex_captures(RegexCaptures::default(), first_caps);
                 let mut ok = true;
                 for branch in rest {
                     if let Some(bcaps) =
@@ -177,7 +183,7 @@ impl Interpreter {
             for (end, mut inner_caps) in
                 self.regex_match_ends_from_caps_in_pkg(pattern, chars, pos, pkg)
             {
-                let mut new_caps = current_caps.clone();
+                let mut new_caps = RegexCaptures::default();
                 for (k, v) in inner_caps.named.drain() {
                     new_caps.named.entry(k).or_default().extend(v);
                 }
@@ -229,7 +235,7 @@ impl Interpreter {
                 }
                 for (goal_end, goal_caps) in goal_matches {
                     let new_caps = merge_regex_captures(
-                        current_caps.clone(),
+                        RegexCaptures::default(),
                         merge_regex_captures(goal_caps, inner_caps.clone()),
                     );
                     out.push((goal_end, new_caps));
@@ -243,7 +249,7 @@ impl Interpreter {
                 self.regex_match_ends_from_caps_in_pkg(pattern, chars, pos, pkg)
             {
                 let captured: String = chars[pos..end].iter().collect();
-                let mut new_caps = current_caps.clone();
+                let mut new_caps = RegexCaptures::default();
                 let mut inner_caps = inner_caps;
                 // Named captures appearing inside a positional capture group belong
                 // to that group's sub-Match (`$/[0]<name>`), NOT to the parent
@@ -278,7 +284,7 @@ impl Interpreter {
                 for (end, mut inner_caps) in
                     self.regex_match_ends_from_caps_in_pkg(alt, chars, pos, pkg)
                 {
-                    let mut new_caps = current_caps.clone();
+                    let mut new_caps = RegexCaptures::default();
                     for (k, v) in inner_caps.named.drain() {
                         new_caps.named.entry(k).or_default().extend(v);
                     }
@@ -335,8 +341,7 @@ impl Interpreter {
             // `die` inside the method) must propagate out of the parse rather than
             // being swallowed as a silent non-match.
             if raw_empty
-                && let Some(result) =
-                    self.try_regex_subrule_as_method(&spec, chars, pos, current_caps, pkg)
+                && let Some(result) = self.try_regex_subrule_as_method(&spec, chars, pos, pkg)
             {
                 return result;
             }
@@ -346,14 +351,8 @@ impl Interpreter {
             // normal engine path.
             if !candidates.is_empty()
                 && !self.registry().grammar_custom_how.is_empty()
-                && let Some(result) = self.try_custom_how_subrule_dispatch(
-                    &spec,
-                    chars,
-                    pos,
-                    current_caps,
-                    pkg,
-                    &arg_values,
-                )
+                && let Some(result) =
+                    self.try_custom_how_subrule_dispatch(&spec, chars, pos, pkg, &arg_values)
             {
                 return result;
             }
@@ -406,12 +405,7 @@ impl Interpreter {
                     // returns items in the same order as input (HIGHEST FIRST).
                     // Caller expects LOWEST FIRST, so reverse.
                     let mut result = Self::build_named_candidates_from_inner(
-                        seed,
-                        pos,
-                        chars,
-                        &spec,
-                        current_caps,
-                        None, // no sym_key for seed
+                        seed, pos, chars, &spec, None, // no sym_key for seed
                     );
                     result.reverse();
                     return result;
@@ -508,14 +502,8 @@ impl Interpreter {
                 // best_raw is HIGHEST FIRST; build_named_candidates_from_inner returns in
                 // the same order (one-to-one), so result is HIGHEST FIRST.
                 // Caller expects LOWEST FIRST, so reverse.
-                let mut result = Self::build_named_candidates_from_inner(
-                    best_raw,
-                    pos,
-                    chars,
-                    &spec,
-                    current_caps,
-                    None,
-                );
+                let mut result =
+                    Self::build_named_candidates_from_inner(best_raw, pos, chars, &spec, None);
                 result.reverse();
                 result
             } else {
@@ -557,7 +545,6 @@ impl Interpreter {
         spec: &NamedRegexLookupSpec,
         chars: &[char],
         pos: usize,
-        current_caps: &RegexCaptures,
         pkg: &str,
     ) -> Option<Vec<(usize, RegexCaptures)>> {
         // Only plain, argument-less identifier subrules dispatched against a real
@@ -623,7 +610,7 @@ impl Interpreter {
                 {
                     let end = pos + to as usize;
                     if end <= chars.len() {
-                        return Some(vec![(end, current_caps.clone())]);
+                        return Some(vec![(end, RegexCaptures::default())]);
                     }
                 }
                 // Undefined / non-cursor return → treated as a non-match.
@@ -634,19 +621,19 @@ impl Interpreter {
 
     /// Build named regex candidates from inner match results (positions relative to tail).
     /// Wraps each inner match in the appropriate capture structure for the named regex call.
-    /// `pos` is the position of the named atom in `chars`.
+    /// `pos` is the position of the named atom in `chars`. Each candidate is a
+    /// capture DELTA relative to an empty baseline (ADR-0007).
     pub(super) fn build_named_candidates_from_inner(
         inner_matches: Vec<(usize, RegexCaptures)>,
         pos: usize,
         chars: &[char],
         spec: &NamedRegexLookupSpec,
-        current_caps: &RegexCaptures,
         sym_key: Option<&String>,
     ) -> Vec<(usize, RegexCaptures)> {
         let mut out = Vec::new();
         for (inner_end, inner_caps) in inner_matches {
             let end = pos + inner_end;
-            let mut new_caps = current_caps.clone();
+            let mut new_caps = RegexCaptures::default();
             let capture_name = spec
                 .capture_name
                 .as_deref()

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -3,6 +3,10 @@ use super::super::*;
 use super::regex_helpers::{is_word_char, matches_named_builtin, merge_regex_captures};
 
 impl Interpreter {
+    /// Single-candidate atom matcher: the atom's highest-priority match only.
+    /// The returned captures are a DELTA relative to an EMPTY baseline
+    /// (ADR-0007); `current_caps` is the engine's accumulated store, passed
+    /// for READS only (backrefs, code assertions, code-block contexts).
     pub(super) fn regex_match_atom_with_capture_in_pkg(
         &self,
         atom: &RegexAtom,
@@ -19,7 +23,7 @@ impl Interpreter {
                 return self
                     .regex_match_end_from_caps_in_pkg(pattern, chars, pos, pkg)
                     .map(|(next, mut inner_caps)| {
-                        let mut new_caps = current_caps.clone();
+                        let mut new_caps = RegexCaptures::default();
                         for (k, v) in inner_caps.named.drain() {
                             new_caps.named.entry(k).or_default().extend(v);
                         }
@@ -61,7 +65,7 @@ impl Interpreter {
                         self.regex_match_end_from_caps_in_pkg(goal, chars, inner_end, pkg)
                     {
                         let new_caps = merge_regex_captures(
-                            current_caps.clone(),
+                            RegexCaptures::default(),
                             merge_regex_captures(goal_caps, inner_caps),
                         );
                         return Some((goal_end, new_caps));
@@ -77,7 +81,7 @@ impl Interpreter {
                     if let Some((next, mut inner_caps)) =
                         self.regex_match_end_from_caps_in_pkg(alt, chars, pos, pkg)
                     {
-                        let mut new_caps = current_caps.clone();
+                        let mut new_caps = RegexCaptures::default();
                         for (k, v) in inner_caps.named.drain() {
                             new_caps.named.entry(k).or_default().extend(v);
                         }
@@ -132,7 +136,7 @@ impl Interpreter {
                     if let Some((next, mut inner_caps)) =
                         self.regex_match_end_from_caps_in_pkg(alt, chars, pos, pkg)
                     {
-                        let mut new_caps = current_caps.clone();
+                        let mut new_caps = RegexCaptures::default();
                         for (k, v) in inner_caps.named.drain() {
                             new_caps.named.entry(k).or_default().extend(v);
                         }
@@ -160,7 +164,7 @@ impl Interpreter {
             | RegexAtom::AtPosition(_) => {
                 return self
                     .regex_match_atom_in_pkg(atom, chars, pos, pkg, ignore_case)
-                    .map(|next| (next, current_caps.clone()));
+                    .map(|next| (next, RegexCaptures::default()));
             }
             RegexAtom::Lookaround {
                 pattern,
@@ -185,7 +189,7 @@ impl Interpreter {
                 };
                 let pass = if *negated { !matched } else { matched };
                 return if pass {
-                    Some((pos, current_caps.clone()))
+                    Some((pos, RegexCaptures::default()))
                 } else {
                     None
                 };
@@ -196,7 +200,7 @@ impl Interpreter {
                     self.regex_match_end_from_caps_in_pkg(pattern, chars, pos, pkg)
                 {
                     let captured: String = chars[pos..end].iter().collect();
-                    let mut new_caps = current_caps.clone();
+                    let mut new_caps = RegexCaptures::default();
                     // Named captures appearing inside a positional capture group
                     // belong to that group's sub-Match (`$/[0]<name>`), NOT to the
                     // parent Match's top-level named captures (`$/<name>`). They are
@@ -225,7 +229,7 @@ impl Interpreter {
                     let result = self.eval_regex_code_assertion(code, current_caps);
                     let pass = if *negated { !result } else { result };
                     if pass {
-                        let mut new_caps = current_caps.clone();
+                        let mut new_caps = RegexCaptures::default();
                         let matched_so_far: String =
                             chars[current_caps.match_from..pos].iter().collect();
                         new_caps.code_blocks.push(CodeBlockContext {
@@ -240,7 +244,7 @@ impl Interpreter {
                     }
                 }
                 // Plain { code } block — always succeeds, record for side effects
-                let mut new_caps = current_caps.clone();
+                let mut new_caps = RegexCaptures::default();
                 let matched_so_far: String = chars[current_caps.match_from..pos].iter().collect();
                 let ctx = CodeBlockContext {
                     code: code.clone(),
@@ -277,7 +281,7 @@ impl Interpreter {
                     if let Some((end, inner_caps)) =
                         self.regex_match_end_from_caps_in_pkg(&parsed, chars, pos, &pkg)
                     {
-                        let mut new_caps = current_caps.clone();
+                        let mut new_caps = RegexCaptures::default();
                         for v in &inner_caps.positional {
                             new_caps.positional.push(v.clone());
                         }
@@ -300,13 +304,17 @@ impl Interpreter {
                 return None;
             }
             RegexAtom::CaptureStartMarker => {
-                let mut new_caps = current_caps.clone();
-                new_caps.capture_start = Some(pos);
+                let new_caps = RegexCaptures {
+                    capture_start: Some(pos),
+                    ..Default::default()
+                };
                 return Some((pos, new_caps));
             }
             RegexAtom::CaptureEndMarker => {
-                let mut new_caps = current_caps.clone();
-                new_caps.capture_end = Some(pos);
+                let new_caps = RegexCaptures {
+                    capture_end: Some(pos),
+                    ..Default::default()
+                };
                 return Some((pos, new_caps));
             }
             RegexAtom::Backref(idx) => {
@@ -325,7 +333,7 @@ impl Interpreter {
                     if pos + ref_chars.len() <= chars.len()
                         && chars[pos..pos + ref_chars.len()] == ref_chars[..]
                     {
-                        return Some((pos + ref_chars.len(), current_caps.clone()));
+                        return Some((pos + ref_chars.len(), RegexCaptures::default()));
                     }
                 }
                 return None;
@@ -341,7 +349,7 @@ impl Interpreter {
                     if pos + ref_chars.len() <= chars.len()
                         && chars[pos..pos + ref_chars.len()] == ref_chars[..]
                     {
-                        return Some((pos + ref_chars.len(), current_caps.clone()));
+                        return Some((pos + ref_chars.len(), RegexCaptures::default()));
                     }
                 }
                 return None;
@@ -356,7 +364,7 @@ impl Interpreter {
                     };
                     self.copy_decl_registry_into(&mut interp);
                     let _ = interp.eval_block_value(&stmts);
-                    let mut new_caps = current_caps.clone();
+                    let mut new_caps = RegexCaptures::default();
                     for (k, v) in &interp.env {
                         if !self.env.contains_key_sym(*k) || self.env.get_sym(*k) != Some(v) {
                             new_caps.regex_vars.insert(k.resolve(), v.clone());
@@ -364,7 +372,7 @@ impl Interpreter {
                     }
                     return Some((pos, new_caps));
                 }
-                return Some((pos, current_caps.clone()));
+                return Some((pos, RegexCaptures::default()));
             }
             _ => {}
         }
@@ -447,7 +455,6 @@ impl Interpreter {
                         pos,
                         chars,
                         &spec,
-                        current_caps,
                         None,
                     )
                     .pop();
@@ -463,7 +470,7 @@ impl Interpreter {
                 if !at_boundary {
                     return None;
                 }
-                return Some((pos, current_caps.clone()));
+                return Some((pos, RegexCaptures::default()));
             }
             if spec.lookup_name == "ws" && !spec.token_lookup {
                 let mut end = pos;
@@ -475,7 +482,7 @@ impl Interpreter {
                 if before_is_word && after_is_word && end == pos {
                     return None;
                 }
-                let mut new_caps = current_caps.clone();
+                let mut new_caps = RegexCaptures::default();
                 if !spec.silent {
                     let captured: String = chars[pos..end].iter().collect();
                     new_caps
@@ -514,7 +521,7 @@ impl Interpreter {
                 && matches_named_builtin(&spec.lookup_name, chars[pos])
             {
                 let end = pos + 1;
-                let mut new_caps = current_caps.clone();
+                let mut new_caps = RegexCaptures::default();
                 let captured: String = chars[pos..end].iter().collect();
                 let capture_name = spec
                     .capture_name
@@ -587,7 +594,7 @@ impl Interpreter {
                     return None;
                 }
                 let end = pos + 1;
-                let mut new_caps = current_caps.clone();
+                let mut new_caps = RegexCaptures::default();
                 let captured: String = chars[pos..end].iter().collect();
                 let capture_name = spec
                     .capture_name
@@ -672,7 +679,7 @@ impl Interpreter {
                 }
                 if chars[pos..pos + name_chars.len()] == name_chars[..] {
                     let captured: String = name_chars.iter().collect();
-                    let mut new_caps = current_caps.clone();
+                    let mut new_caps = RegexCaptures::default();
                     let capture_name = spec.capture_name.unwrap_or(literal);
                     new_caps
                         .named
@@ -685,7 +692,7 @@ impl Interpreter {
             }
             _ => self
                 .regex_match_atom_in_pkg(atom, chars, pos, pkg, ignore_case)
-                .map(|next| (next, current_caps.clone())),
+                .map(|next| (next, RegexCaptures::default())),
         }
     }
 }

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -1,9 +1,32 @@
+//! The backtracking regex engine: a depth-first walk over pattern tokens with
+//! a single mutable capture store + undo trail (ADR-0007).
+//!
+//! Atom candidate producers (`regex_match_atom_all_with_capture_in_pkg`,
+//! `regex_match_atom_with_capture_in_pkg`, `match_separated_quantifier`)
+//! return `(end, delta)` pairs where the delta is a `RegexCaptures` relative
+//! to an EMPTY baseline. The walk applies a candidate with
+//! `CapStore::merge_delta`, descends to the next token, and rewinds the trail
+//! on backtrack — per-step capture cost is O(delta), never O(accumulated).
+
 use super::super::*;
 use super::regex_helpers::{
-    atom_contains_alternation, count_capture_groups, fold_quantified_captures,
-    is_named_atom_no_args, is_silent_named_atom, is_simple_atom, reserve_nil_capture_slots,
+    atom_contains_alternation, count_capture_groups, is_named_atom_no_args, is_silent_named_atom,
+    is_simple_atom,
 };
+use super::regex_trail::CapStore;
 use std::collections::HashSet;
+
+/// Read-only context shared by one engine invocation (one pattern level).
+struct WalkCtx<'a> {
+    pattern: &'a RegexPattern,
+    chars: &'a [char],
+    pkg: &'a str,
+    first_only: bool,
+}
+
+/// Node budget for the full-backtracking quantifier expansion over a
+/// variable-length alternation (mirrors the old 20k candidate bound).
+const QUANT_ALT_BUDGET: u32 = 20_000;
 
 impl Interpreter {
     /// Collect all named capture names inside a regex atom (recursively).
@@ -43,502 +66,13 @@ impl Interpreter {
     }
 
     /// Collect all named capture names from a regex token.
-    fn collect_quantified_names_for_token(token: &RegexToken) -> HashSet<String> {
+    pub(super) fn collect_quantified_names_for_token(token: &RegexToken) -> HashSet<String> {
         let mut names = HashSet::new();
         if let Some(name) = token.named_capture.as_ref() {
             names.insert(name.clone());
         }
         Self::collect_named_captures_in_atom(&token.atom, &mut names);
         names
-    }
-
-    /// Greedy backtracking expansion of a `*`/`+` quantified atom. Unlike the
-    /// fast greedy *chain* (which commits to a single highest-priority match per
-    /// iteration), this explores every per-iteration alternative so a later
-    /// constraint can force a shorter choice (`(a|b|bc|cde)+»` → `a,b,cde`).
-    ///
-    /// Results are appended to `out` in HIGHEST-priority-first order: at each
-    /// position the highest-priority atom match is tried first, and within a match
-    /// *more* iterations (deeper) outrank stopping there — matching Rakudo's
-    /// greedy semantics. Only used when the atom contains a variable-length
-    /// alternation (see `atom_contains_alternation`), so simple atoms keep the
-    /// cheap chain. Bounded to avoid catastrophic backtracking.
-    #[allow(clippy::too_many_arguments)]
-    fn quant_expand_greedy<FN, FH>(
-        &self,
-        token: &RegexToken,
-        chars: &[char],
-        pos: usize,
-        caps: &RegexCaptures,
-        pos_base: usize,
-        pkg: &str,
-        ignore_case: bool,
-        apply_named: &FN,
-        apply_hash: &FH,
-        out: &mut Vec<(usize, RegexCaptures)>,
-    ) where
-        FN: Fn(&RegexToken, usize, usize, usize, RegexCaptures) -> RegexCaptures,
-        FH: Fn(&RegexToken, usize, usize, usize, RegexCaptures) -> RegexCaptures,
-    {
-        if out.len() > 20_000 {
-            return;
-        }
-        // All atom matches at `pos`. `_all_` returns LOWEST-priority first; we
-        // want HIGHEST first so reverse.
-        let mut matches = self.regex_match_atom_all_with_capture_in_pkg(
-            &token.atom,
-            chars,
-            pos,
-            caps,
-            pkg,
-            ignore_case,
-        );
-        matches.reverse();
-        for (next, new_caps) in matches {
-            if next == pos {
-                continue; // zero-width: would loop forever
-            }
-            let iter_pos_base = caps.positional.len();
-            let new_caps = apply_hash(
-                token,
-                pos,
-                next,
-                iter_pos_base,
-                apply_named(token, pos, next, pos_base, new_caps),
-            );
-            // Greedy: prefer extending with more iterations before stopping here.
-            self.quant_expand_greedy(
-                token,
-                chars,
-                next,
-                &new_caps,
-                pos_base,
-                pkg,
-                ignore_case,
-                apply_named,
-                apply_hash,
-                out,
-            );
-            out.push((next, new_caps));
-        }
-    }
-    /// Match a separator quantifier (`atom +% sep`, `atom **N..M %% sep`, ...).
-    /// The atom is matched repeatedly with `sep` interleaved between iterations.
-    /// Each side's captures are accumulated into its own folded group: the atom's
-    /// positional captures occupy the first `atom_stride` indices and the
-    /// separator's the next `sep_stride` indices, matching Raku's Match layout.
-    ///
-    /// Returns `(end, caps)` pairs in LOWEST-priority-first order (for the LIFO
-    /// matching stack): shortest match first, longest (greedy) last.
-    pub(super) fn match_separated_quantifier(
-        &self,
-        token: &RegexToken,
-        chars: &[char],
-        start: usize,
-        base_caps: &RegexCaptures,
-        pkg: &str,
-        pattern: &RegexPattern,
-    ) -> Vec<(usize, RegexCaptures)> {
-        if token.ratchet {
-            return self
-                .match_separated_quantifier_ratchet(token, chars, start, base_caps, pkg, pattern);
-        }
-        let sep = token.separator.as_ref().expect("separator present");
-        let (min, max) = match &token.quant {
-            RegexQuant::OneOrMore => (1usize, None),
-            RegexQuant::ZeroOrMore => (0usize, None),
-            RegexQuant::Repeat(lo, hi) => (*lo, *hi),
-            // `?` / exact-one don't form a separator list; treat as one.
-            _ => (1usize, Some(1usize)),
-        };
-        let atom_stride = count_capture_groups(&token.atom);
-        let sep_stride: usize = sep
-            .pattern
-            .tokens
-            .iter()
-            .map(|t| count_capture_groups(&t.atom))
-            .sum();
-        let names = Self::collect_quantified_names_for_token(token);
-
-        // Enumerate every valid `atom (sep atom)*` chain via DFS, backtracking
-        // the separator. A purely greedy linear scan (match the first atom, then
-        // repeatedly take the separator's single highest-priority match followed
-        // by an atom) cannot admit more atoms when a frugal separator's minimal
-        // match blocks the next atom: e.g. `( 'a' || 'b' )* %% (.+?)` on "a x b"
-        // would stop after "a" because the frugal `(.+?)` matched just " " and
-        // "x b" is not an atom. Real backtracking expands the separator (" x ")
-        // so the following atom ("b") can match. `enumerate_separated_chains`
-        // performs that backtracking, returning chains highest-priority first
-        // (most atoms first for a greedy quantifier; within a step, the
-        // separator's own priority order from `regex_match_ends_from_caps_in_pkg`).
-        let chains = self.enumerate_separated_chains(token, chars, start, pkg, pattern, max);
-
-        // Turn each chain into result candidates (with optional trailing
-        // separator for `%%`), highest-priority first, then reverse so the
-        // caller's LIFO stack pops the highest-priority candidate first.
-        let mut out: Vec<(usize, RegexCaptures)> = Vec::new();
-        for (atom_caps, sep_caps, end) in &chains {
-            let count = atom_caps.len();
-            if count < min {
-                continue;
-            }
-            if let Some(m) = max
-                && count > m
-            {
-                continue;
-            }
-            let assemble = |trailing: Option<&RegexCaptures>, end: usize| {
-                let mut caps = base_caps.clone();
-                caps.named_quantified.extend(names.iter().cloned());
-                Self::append_separated_captures(
-                    &mut caps,
-                    atom_caps,
-                    sep_caps,
-                    trailing,
-                    atom_stride,
-                    sep_stride,
-                );
-                (end, caps)
-            };
-            // Optional trailing separator for `%%`: prefer "with trailing" over
-            // "without" (Rakudo greedily consumes a trailing separator). Each
-            // trailing length is a separate candidate so an outer anchor can pick
-            // the length that lets the whole pattern match (`... %% (.+?) $`).
-            if sep.allow_trailing {
-                for (ts_end, ts_caps) in
-                    self.regex_match_ends_from_caps_in_pkg(&sep.pattern, chars, *end, pkg)
-                {
-                    if ts_end >= *end {
-                        out.push(assemble(Some(&ts_caps), ts_end));
-                    }
-                }
-            }
-            out.push(assemble(None, *end));
-        }
-        // Zero iterations (when `min == 0`) is the lowest-priority outcome for a
-        // greedy quantifier, so it goes last in highest-priority-first order.
-        if min == 0 {
-            out.push((start, base_caps.clone()));
-        }
-        out.reverse();
-        out
-    }
-
-    /// Ratcheted (`token`/`rule`) separated quantifier: possessive linear scan.
-    /// Ratchet forbids backtracking into the quantifier, so each step commits
-    /// to the separator's and the atom's single highest-priority match and the
-    /// whole quantifier yields at most one candidate. This matches Rakudo:
-    /// `my token T { <[ab]>+ % ',' ',b' }` does NOT match "a,b" (the chain
-    /// possessively consumes all of it) while the backtracking `regex` variant
-    /// does. It is also what keeps grammar rules linear: the general DFS in
-    /// `enumerate_separated_chains` goes exponential when sigspace turns the
-    /// atom/separator into groups with several same-end candidates (a 6-pair
-    /// JSON object under `rule pairlist { <pair> * % \, }` took ~8s to parse;
-    /// this scan parses it in microseconds).
-    fn match_separated_quantifier_ratchet(
-        &self,
-        token: &RegexToken,
-        chars: &[char],
-        start: usize,
-        base_caps: &RegexCaptures,
-        pkg: &str,
-        pattern: &RegexPattern,
-    ) -> Vec<(usize, RegexCaptures)> {
-        let sep = token.separator.as_ref().expect("separator present");
-        let (min, max) = match &token.quant {
-            RegexQuant::OneOrMore => (1usize, None),
-            RegexQuant::ZeroOrMore => (0usize, None),
-            RegexQuant::Repeat(lo, hi) => (*lo, *hi),
-            // `?` / exact-one don't form a separator list; treat as one.
-            _ => (1usize, Some(1usize)),
-        };
-        // Frugal (`*? %`) under ratchet commits to the minimal count; greedy
-        // extends to `max` (or as far as the input allows).
-        let limit = if token.frugal { Some(min) } else { max };
-        let can_extend = |count: usize| limit.is_none_or(|m| count < m);
-
-        let empty = RegexCaptures::default();
-        let mut atom_caps: Vec<RegexCaptures> = Vec::new();
-        let mut sep_caps: Vec<RegexCaptures> = Vec::new();
-        let mut cur = start;
-        // Highest-priority atom match = the LAST candidate (the atom
-        // enumeration returns lowest priority first), mirroring the
-        // `RegexQuant::One` ratchet case. Deliberately the `_all_` enumeration
-        // and NOT the singular `regex_match_atom_with_capture_in_pkg`: the
-        // singular matcher's Named-atom path spawns a scratch sub-interpreter
-        // (plus a tail-text copy) per candidate per call, which is ~300x
-        // slower on nested grammar rules like `rule arraylist { <value> * %
-        // [\,] }` over `[[1,2,3],[4,5,6],[7,8,9]]`. A zero-width first atom
-        // means zero iterations (same zero-progress guard as the general
-        // path).
-        if can_extend(0)
-            && let Some((end, caps)) = self
-                .regex_match_atom_all_with_capture_in_pkg(
-                    &token.atom,
-                    chars,
-                    start,
-                    &empty,
-                    pkg,
-                    pattern.ignore_case,
-                )
-                .pop()
-            && end > start
-        {
-            atom_caps.push(caps);
-            cur = end;
-            while can_extend(atom_caps.len()) {
-                let Some((sep_end, scaps)) =
-                    self.regex_match_end_from_caps_in_pkg(&sep.pattern, chars, cur, pkg)
-                else {
-                    break;
-                };
-                let Some((atom_end, acaps)) = self
-                    .regex_match_atom_all_with_capture_in_pkg(
-                        &token.atom,
-                        chars,
-                        sep_end,
-                        &empty,
-                        pkg,
-                        pattern.ignore_case,
-                    )
-                    .pop()
-                else {
-                    break;
-                };
-                if atom_end <= cur {
-                    break;
-                }
-                sep_caps.push(scaps);
-                atom_caps.push(acaps);
-                cur = atom_end;
-            }
-        }
-        if atom_caps.len() < min {
-            // Ratchet cannot backtrack to satisfy `min`: the quantifier fails.
-            return Vec::new();
-        }
-        if atom_caps.is_empty() {
-            return vec![(start, base_caps.clone())];
-        }
-        let atom_stride = count_capture_groups(&token.atom);
-        let sep_stride: usize = sep
-            .pattern
-            .tokens
-            .iter()
-            .map(|t| count_capture_groups(&t.atom))
-            .sum();
-        let names = Self::collect_quantified_names_for_token(token);
-        let mut caps = base_caps.clone();
-        caps.named_quantified.extend(names.iter().cloned());
-        // Trailing separator for `%%`: Rakudo consumes it greedily, and
-        // ratchet commits to that single choice.
-        let mut end = cur;
-        let mut trailing: Option<RegexCaptures> = None;
-        if sep.allow_trailing
-            && let Some((ts_end, ts_caps)) =
-                self.regex_match_end_from_caps_in_pkg(&sep.pattern, chars, cur, pkg)
-            && ts_end >= cur
-        {
-            end = ts_end;
-            trailing = Some(ts_caps);
-        }
-        Self::append_separated_captures(
-            &mut caps,
-            &atom_caps,
-            &sep_caps,
-            trailing.as_ref(),
-            atom_stride,
-            sep_stride,
-        );
-        vec![(end, caps)]
-    }
-
-    /// Enumerate every `atom (sep atom)*` chain rooted at `start`, backtracking
-    /// the separator at each step. Each chain is `(atom_caps, sep_caps, end)`
-    /// with `sep_caps.len() == atom_caps.len() - 1`. Chains are returned
-    /// highest-priority first: for a greedy quantifier the longest chains come
-    /// first, and within a step separator matches follow their own priority
-    /// order. `max` bounds the atom count (atom count never exceeds `max`).
-    fn enumerate_separated_chains(
-        &self,
-        token: &RegexToken,
-        chars: &[char],
-        start: usize,
-        pkg: &str,
-        pattern: &RegexPattern,
-        max: Option<usize>,
-    ) -> Vec<(Vec<RegexCaptures>, Vec<RegexCaptures>, usize)> {
-        let mut chains: Vec<(Vec<RegexCaptures>, Vec<RegexCaptures>, usize)> = Vec::new();
-        let empty = RegexCaptures::default();
-        // First atom: enumerate EVERY match length (highest-priority first), not
-        // just the single highest-priority one. A frugal atom (`[[.]+?]`) matches
-        // as few chars as possible, but an outer anchor / goalpost following the
-        // separated quantifier (e.g. `'<' ~ '>' [<( [[.]+?]* %% SEP )>]`) may
-        // require the atom to expand. Taking only the shortest match would leave
-        // no candidate for that anchor and the whole pattern would fail to match.
-        let first_matches = self.regex_match_atom_all_with_capture_in_pkg(
-            &token.atom,
-            chars,
-            start,
-            &empty,
-            pkg,
-            pattern.ignore_case,
-        );
-        // `regex_match_atom_all_with_capture_in_pkg` returns lowest-priority
-        // first; iterate highest-priority first so the chains come out in
-        // highest-priority order for the caller's LIFO stack.
-        for (end, caps) in first_matches.into_iter().rev() {
-            if end == start {
-                continue;
-            }
-            let mut atom_caps = vec![caps];
-            let mut sep_caps: Vec<RegexCaptures> = Vec::new();
-            self.extend_separated_chain(
-                token,
-                chars,
-                end,
-                pkg,
-                pattern,
-                max,
-                &mut atom_caps,
-                &mut sep_caps,
-                &mut chains,
-            );
-        }
-        chains
-    }
-
-    /// Recursive worker for `enumerate_separated_chains`. Extends the chain at
-    /// `cur` by trying every separator match (in priority order) followed by an
-    /// atom, recursing greedily first, then records the chain that stops at
-    /// `cur`. Pushing the deeper (longer) chains before the shorter one yields a
-    /// highest-priority-first ordering for a greedy quantifier.
-    #[allow(clippy::too_many_arguments)]
-    fn extend_separated_chain(
-        &self,
-        token: &RegexToken,
-        chars: &[char],
-        cur: usize,
-        pkg: &str,
-        pattern: &RegexPattern,
-        max: Option<usize>,
-        atom_caps: &mut Vec<RegexCaptures>,
-        sep_caps: &mut Vec<RegexCaptures>,
-        out: &mut Vec<(Vec<RegexCaptures>, Vec<RegexCaptures>, usize)>,
-    ) {
-        // Bound the chain count to avoid catastrophic backtracking on a frugal
-        // separator over a long string (mirrors `quant_expand_greedy`).
-        if out.len() > 20_000 {
-            return;
-        }
-        let empty = RegexCaptures::default();
-        let can_extend = max.is_none_or(|m| atom_caps.len() < m);
-        if can_extend {
-            for (sep_end, scaps) in self.regex_match_ends_from_caps_in_pkg(
-                &token.separator.as_ref().unwrap().pattern,
-                chars,
-                cur,
-                pkg,
-            ) {
-                // Enumerate every atom-match length after this separator
-                // (highest-priority first), mirroring the first-atom enumeration
-                // so a frugal atom can expand to satisfy a following anchor.
-                let atom_matches = self.regex_match_atom_all_with_capture_in_pkg(
-                    &token.atom,
-                    chars,
-                    sep_end,
-                    &empty,
-                    pkg,
-                    pattern.ignore_case,
-                );
-                for (atom_end, acaps) in atom_matches.into_iter().rev() {
-                    if atom_end <= cur {
-                        continue;
-                    }
-                    atom_caps.push(acaps);
-                    sep_caps.push(scaps.clone());
-                    self.extend_separated_chain(
-                        token, chars, atom_end, pkg, pattern, max, atom_caps, sep_caps, out,
-                    );
-                    atom_caps.pop();
-                    sep_caps.pop();
-                }
-            }
-        }
-        out.push((atom_caps.clone(), sep_caps.clone(), cur));
-    }
-
-    /// Append captures from a separated quantifier into `caps`, folding each
-    /// side into its own positional/named group lists.
-    fn append_separated_captures(
-        caps: &mut RegexCaptures,
-        atom_caps: &[RegexCaptures],
-        sep_caps: &[RegexCaptures],
-        trailing_sep: Option<&RegexCaptures>,
-        atom_stride: usize,
-        sep_stride: usize,
-    ) {
-        // Positional captures: atom groups occupy the first `atom_stride` slots,
-        // separator groups the next `sep_stride`.
-        for g in 0..atom_stride {
-            let mut list: Vec<QuantifiedCaptureEntry> = Vec::new();
-            let mut last_text = String::new();
-            let mut last_sub: Option<std::sync::Arc<RegexCaptures>> = None;
-            for ac in atom_caps {
-                if let Some(text) = ac.positional.get(g) {
-                    let (from, to) = ac.positional_offsets.get(g).copied().unwrap_or((0, 0));
-                    let sub = ac.positional_subcaps.get(g).cloned().flatten();
-                    list.push((text.clone(), from, to, sub.clone()));
-                    last_text = text.clone();
-                    last_sub = sub;
-                }
-            }
-            caps.positional.push(last_text);
-            caps.positional_subcaps.push(last_sub);
-            caps.positional_quantified.push(Some(list));
-            caps.positional_offsets.push((0, 0));
-        }
-        let mut all_sep: Vec<&RegexCaptures> = sep_caps.iter().collect();
-        if let Some(ts) = trailing_sep {
-            all_sep.push(ts);
-        }
-        for g in 0..sep_stride {
-            let mut list: Vec<QuantifiedCaptureEntry> = Vec::new();
-            let mut last_text = String::new();
-            let mut last_sub: Option<std::sync::Arc<RegexCaptures>> = None;
-            for sc in &all_sep {
-                if let Some(text) = sc.positional.get(g) {
-                    let (from, to) = sc.positional_offsets.get(g).copied().unwrap_or((0, 0));
-                    let sub = sc.positional_subcaps.get(g).cloned().flatten();
-                    list.push((text.clone(), from, to, sub.clone()));
-                    last_text = text.clone();
-                    last_sub = sub;
-                }
-            }
-            caps.positional.push(last_text);
-            caps.positional_subcaps.push(last_sub);
-            caps.positional_quantified.push(Some(list));
-            caps.positional_offsets.push((0, 0));
-        }
-        // Named captures: merge every iteration's named captures (as arrays).
-        for src in atom_caps.iter().chain(all_sep.iter().copied()) {
-            for (k, v) in &src.named {
-                caps.named.entry(k.clone()).or_default().extend(v.clone());
-                caps.named_quantified.insert(k.clone());
-            }
-            for (k, v) in &src.named_subcaps {
-                caps.named_subcaps
-                    .entry(k.clone())
-                    .or_default()
-                    .extend(v.clone());
-            }
-            for (k, v) in &src.hash_captures {
-                caps.hash_captures
-                    .entry(k.clone())
-                    .or_default()
-                    .extend(v.clone());
-            }
-        }
     }
 
     pub(super) fn regex_match_end_from_caps_in_pkg(
@@ -549,11 +83,8 @@ impl Interpreter {
         pkg: &str,
     ) -> Option<(usize, RegexCaptures)> {
         // Only the first (highest-priority / greedy) complete match is needed
-        // here, and the backtracking DFS already discovers it first (matches are
-        // returned in DFS-completion order, unsorted), so stop as soon as one is
-        // found instead of exploring the whole backtracking tree. `matches[0]` is
-        // byte-identical to the all-ends result's first element, so this is
-        // semantics-preserving — it just skips work the `.next()` would discard.
+        // here, and the depth-first walk discovers it first, so stop as soon as
+        // one is found instead of exploring the whole backtracking tree.
         self.regex_match_ends_from_caps_in_pkg_impl(pattern, chars, start, pkg, true)
             .into_iter()
             .next()
@@ -571,9 +102,7 @@ impl Interpreter {
 
     /// Backtracking match returning the complete-match end positions (with
     /// captures) at `start`, in DFS-completion order (highest priority first).
-    /// When `first_only` is true the DFS stops after the first complete match —
-    /// `matches[0]` is unchanged, so callers that only take `.next()` get the
-    /// same answer for far less work.
+    /// When `first_only` is true the walk stops after the first complete match.
     fn regex_match_ends_from_caps_in_pkg_impl(
         &self,
         pattern: &RegexPattern,
@@ -609,158 +138,162 @@ impl Interpreter {
             }
             return results;
         }
-        let apply_named_capture = |token: &RegexToken,
-                                   from: usize,
-                                   to: usize,
-                                   pos_base: usize,
-                                   caps: RegexCaptures|
-         -> RegexCaptures {
-            let Some(name) = token.named_capture.as_ref() else {
-                return caps;
-            };
-            // Numbered scalar capture alias `$N=<atom>`: the alias name is all
-            // digits, so route the capture to positional index N (padding lower
-            // indices) and let subsequent groups continue numbering from N+1.
-            // (Named captures always start with a letter/underscore, so an
-            // all-digit name can only come from `$N=`.)
-            if let Ok(forced_idx) = name.parse::<usize>() {
-                let mut updated = caps;
-                let captured: String = chars[from..to].iter().collect();
-                // Drop the auto-positional entry a capturing group atom produced;
-                // the alias decides this capture's index explicitly.
-                if matches!(token.atom, RegexAtom::CaptureGroup(_))
-                    && updated.positional.len() > pos_base
-                {
-                    updated.positional.truncate(pos_base);
-                    updated.positional_subcaps.truncate(pos_base);
-                    updated.positional_quantified.truncate(pos_base);
-                    updated.positional_offsets.truncate(pos_base);
-                }
-                while updated.positional.len() < forced_idx {
-                    updated.positional.push(String::new());
-                    updated.positional_subcaps.push(None);
-                    updated.positional_quantified.push(None);
-                    updated.positional_offsets.push((0, 0));
-                }
-                if updated.positional.len() == forced_idx {
-                    updated.positional.push(captured);
-                    updated.positional_subcaps.push(None);
-                    updated.positional_quantified.push(None);
-                    updated.positional_offsets.push((from, to));
-                } else {
-                    updated.positional[forced_idx] = captured;
-                    if forced_idx < updated.positional_offsets.len() {
-                        updated.positional_offsets[forced_idx] = (from, to);
-                    }
-                    if forced_idx < updated.positional_subcaps.len() {
-                        updated.positional_subcaps[forced_idx] = None;
-                    }
-                    if forced_idx < updated.positional_quantified.len() {
-                        updated.positional_quantified[forced_idx] = None;
-                    }
-                }
-                return updated;
-            }
-            let mut updated = caps;
-            let captured: String = chars[from..to].iter().collect();
-            // A named capture group `$<x>=(...)` aliases the group to the name and
-            // does NOT consume a positional number (Raku: `/$<x>=(\w)(\d)/` makes
-            // `$<x>` the \w and `$0` the \d). When this named token's atom is itself
-            // a capturing group, it pushed a parent positional during matching;
-            // drop those entries so the following `(...)` keeps the next number.
-            // A named NON-capturing group `$<x>=[...]` leaves its inner captures'
-            // positional numbers intact (its atom is not a CaptureGroup), so this
-            // truncation correctly does not fire for it.
-            // When aliasing a capturing group, preserve the group's own inner
-            // captures (named subrules etc.) so e.g. `$<family>=(<ident>)` keeps
-            // `$<family><ident>` accessible — otherwise truncating the group's
-            // positional entry would discard its nested subcapture.
-            let mut group_subcap: Option<std::sync::Arc<RegexCaptures>> = None;
-            if matches!(token.atom, RegexAtom::CaptureGroup(_))
-                && updated.positional.len() > pos_base
-            {
-                group_subcap = updated.positional_subcaps.get(pos_base).cloned().flatten();
-                updated.positional.truncate(pos_base);
-                updated.positional_subcaps.truncate(pos_base);
-                updated.positional_quantified.truncate(pos_base);
-            }
-            updated
-                .named
-                .entry(name.clone())
-                .or_default()
-                .push(captured.clone());
-            // `@<name>=` array-sigil alias forces list context: mark the name as
-            // quantified so the Match builder always presents it as a List, even
-            // for a single non-quantified capture (`@<foo>=(.(.))` → `[«bc»]`).
-            if token.force_list_capture {
-                updated.named_quantified.insert(name.clone());
-            }
-            // Record a minimal sub-capture carrying the exact (from, to) span so
-            // the Match object gets the right offsets even for a zero-width match
-            // (e.g. `$<delim>=<[a..z]>*` matching empty). Without this the Match
-            // builder falls back to searching for the captured text, which yields
-            // offset 0 for an empty string and breaks `.caps`/`.chunks` ordering.
-            // Only do this when no richer sub-capture already aligns with this
-            // entry, so subrule-aliased captures keep their nested structure.
-            let name_count = updated.named.get(name).map(Vec::len).unwrap_or(0);
-            let subcaps = updated.named_subcaps.entry(name.clone()).or_default();
-            if subcaps.len() < name_count {
-                if let Some(mut gs) = group_subcap.take() {
-                    // Keep the group's nested captures, but pin the span/text to
-                    // the aliased group's extent.
-                    let gsm = std::sync::Arc::make_mut(&mut gs);
-                    gsm.from = from;
-                    gsm.to = to;
-                    gsm.match_from = from;
-                    gsm.matched = captured.clone();
-                    subcaps.push(gs);
-                } else {
-                    subcaps.push(std::sync::Arc::new(RegexCaptures {
-                        from,
-                        to,
-                        matched: captured.clone(),
-                        match_from: from,
-                        ..Default::default()
-                    }));
-                }
-            }
-            // Also capture under the secondary name (e.g., original builtin class name
-            // when using `$<alias>=<builtin_class>` syntax).
-            if let Some(secondary) = token.secondary_named_capture.as_ref() {
-                updated
-                    .named
-                    .entry(secondary.clone())
-                    .or_default()
-                    .push(captured);
-            }
-            updated
+        let mut store = CapStore::new(RegexCaptures {
+            match_from: start,
+            ..Default::default()
+        });
+        let mut matches = Vec::new();
+        let ctx = WalkCtx {
+            pattern,
+            chars,
+            pkg,
+            first_only,
         };
-        let apply_hash_capture = |token: &RegexToken,
-                                  _from: usize,
-                                  _to: usize,
-                                  pos_base: usize,
-                                  caps: RegexCaptures|
-         -> RegexCaptures {
-            let Some(name) = token.hash_capture.as_ref() else {
-                return caps;
+        self.walk_tokens(&ctx, 0, start, &mut store, &mut matches);
+        matches
+    }
+
+    /// Apply a `$<name>=` / `$N=` capture alias for `token` to the store.
+    /// `pos_base` is the store's positional length at token start.
+    fn store_apply_named_capture(
+        store: &mut CapStore,
+        chars: &[char],
+        token: &RegexToken,
+        from: usize,
+        to: usize,
+        pos_base: usize,
+    ) {
+        let Some(name) = token.named_capture.as_ref() else {
+            return;
+        };
+        // Numbered scalar capture alias `$N=<atom>`: the alias name is all
+        // digits, so route the capture to positional index N (padding lower
+        // indices) and let subsequent groups continue numbering from N+1.
+        // (Named captures always start with a letter/underscore, so an
+        // all-digit name can only come from `$N=`.)
+        if let Ok(forced_idx) = name.parse::<usize>() {
+            let captured: String = chars[from..to].iter().collect();
+            // Drop the auto-positional entry a capturing group atom produced;
+            // the alias decides this capture's index explicitly.
+            if matches!(token.atom, RegexAtom::CaptureGroup(_))
+                && store.caps().positional.len() > pos_base
+            {
+                store.truncate_positional_4(pos_base);
+            }
+            while store.caps().positional.len() < forced_idx {
+                store.push_positional(String::new(), None, None, (0, 0));
+            }
+            if store.caps().positional.len() == forced_idx {
+                store.push_positional(captured, None, None, (from, to));
+            } else {
+                store.overwrite_positional(forced_idx, captured, (from, to));
+            }
+            return;
+        }
+        let captured: String = chars[from..to].iter().collect();
+        // A named capture group `$<x>=(...)` aliases the group to the name and
+        // does NOT consume a positional number (Raku: `/$<x>=(\w)(\d)/` makes
+        // `$<x>` the \w and `$0` the \d). When this named token's atom is itself
+        // a capturing group, it pushed a parent positional during matching;
+        // drop those entries so the following `(...)` keeps the next number.
+        // A named NON-capturing group `$<x>=[...]` leaves its inner captures'
+        // positional numbers intact (its atom is not a CaptureGroup), so this
+        // truncation correctly does not fire for it.
+        // When aliasing a capturing group, preserve the group's own inner
+        // captures (named subrules etc.) so e.g. `$<family>=(<ident>)` keeps
+        // `$<family><ident>` accessible — otherwise truncating the group's
+        // positional entry would discard its nested subcapture.
+        let mut group_subcap: Option<std::sync::Arc<RegexCaptures>> = None;
+        if matches!(token.atom, RegexAtom::CaptureGroup(_))
+            && store.caps().positional.len() > pos_base
+        {
+            group_subcap = store
+                .caps()
+                .positional_subcaps
+                .get(pos_base)
+                .cloned()
+                .flatten();
+            store.truncate_positional_3(pos_base);
+        }
+        store.push_named(name, captured.clone());
+        // `@<name>=` array-sigil alias forces list context: mark the name as
+        // quantified so the Match builder always presents it as a List, even
+        // for a single non-quantified capture (`@<foo>=(.(.))` → `[«bc»]`).
+        if token.force_list_capture {
+            store.insert_named_quantified(name.clone());
+        }
+        // Record a minimal sub-capture carrying the exact (from, to) span so
+        // the Match object gets the right offsets even for a zero-width match
+        // (e.g. `$<delim>=<[a..z]>*` matching empty). Without this the Match
+        // builder falls back to searching for the captured text, which yields
+        // offset 0 for an empty string and breaks `.caps`/`.chunks` ordering.
+        // Only do this when no richer sub-capture already aligns with this
+        // entry, so subrule-aliased captures keep their nested structure.
+        let name_count = store.caps().named.get(name).map(Vec::len).unwrap_or(0);
+        let sub_count = store
+            .caps()
+            .named_subcaps
+            .get(name)
+            .map(Vec::len)
+            .unwrap_or(0);
+        if sub_count < name_count {
+            let sub = if let Some(mut gs) = group_subcap.take() {
+                // Keep the group's nested captures, but pin the span/text to
+                // the aliased group's extent.
+                let gsm = std::sync::Arc::make_mut(&mut gs);
+                gsm.from = from;
+                gsm.to = to;
+                gsm.match_from = from;
+                gsm.matched = captured.clone();
+                gs
+            } else {
+                std::sync::Arc::new(RegexCaptures {
+                    from,
+                    to,
+                    matched: captured.clone(),
+                    match_from: from,
+                    ..Default::default()
+                })
             };
-            let mut updated = caps;
+            store.push_named_subcap(name, sub);
+        }
+        // Also capture under the secondary name (e.g., original builtin class name
+        // when using `$<alias>=<builtin_class>` syntax).
+        if let Some(secondary) = token.secondary_named_capture.as_ref() {
+            store.push_named(secondary, captured);
+        }
+    }
+
+    /// Apply a `%<name>=(...)` hash capture for `token` to the store.
+    fn store_apply_hash_capture(
+        store: &mut CapStore,
+        chars: &[char],
+        token: &RegexToken,
+        from: usize,
+        to: usize,
+        pos_base: usize,
+    ) {
+        let Some(name) = token.hash_capture.as_ref() else {
+            return;
+        };
+        let (key, value) = {
+            let caps = store.caps();
             // Count how many new positional captures this atom produced
-            let new_count = updated.positional.len().saturating_sub(pos_base);
+            let new_count = caps.positional.len().saturating_sub(pos_base);
             // Look for inner subcaptures in positional_subcaps
             let subcap_idx = if new_count >= 1 {
                 pos_base
             } else {
-                updated.positional_subcaps.len()
+                caps.positional_subcaps.len()
             };
-            let inner_positionals = if subcap_idx < updated.positional_subcaps.len() {
-                updated.positional_subcaps[subcap_idx]
+            let inner_positionals = if subcap_idx < caps.positional_subcaps.len() {
+                caps.positional_subcaps[subcap_idx]
                     .as_ref()
                     .map(|sc| &sc.positional)
             } else {
                 None
             };
-            let (key, value) = if let Some(inner) = inner_positionals {
+            if let Some(inner) = inner_positionals {
                 if inner.len() >= 2 {
                     // Two+ inner subcaptures: first = key, second = value
                     (inner[0].clone(), Some(inner[1].clone()))
@@ -769,687 +302,598 @@ impl Interpreter {
                     (inner[0].clone(), None)
                 } else {
                     // No inner subcaptures in subcaps: use matched text
-                    let k: String = chars[_from.._to].iter().collect();
+                    let k: String = chars[from..to].iter().collect();
                     (k, None)
                 }
             } else {
                 // No subcaptures: use matched text
-                let k: String = chars[_from.._to].iter().collect();
+                let k: String = chars[from..to].iter().collect();
                 (k, None)
-            };
-            updated
-                .hash_captures
-                .entry(name.clone())
-                .or_default()
-                .push((key, value));
-            updated
-        };
-        let mut stack = Vec::new();
-        let init_caps = RegexCaptures {
-            match_from: start,
-            ..Default::default()
-        };
-        stack.push((0usize, start, init_caps));
-        let mut matches = Vec::new();
-        while let Some((idx, pos, caps)) = stack.pop() {
-            if idx == pattern.tokens.len() {
-                if !pattern.anchor_end || pos == chars.len() {
-                    matches.push((pos, caps));
-                    // Single-match callers (`regex_match_end_from_caps_in_pkg`)
-                    // only use `matches[0]`; the DFS visits highest priority
-                    // first, so the first complete match IS that element — stop
-                    // exploring the rest of the backtracking tree.
-                    if first_only {
-                        break;
-                    }
-                }
-                continue;
             }
-            let token = &pattern.tokens[idx];
-            let pos_base = caps.positional.len();
-            // Separator quantifiers (`atom +% sep`, `atom **N..M %% sep`, ...):
-            // match the atom with the separator interleaved between iterations,
-            // accumulating each side's captures into its own (folded) group.
-            if token.separator.is_some() {
-                for (next, new_caps) in
-                    self.match_separated_quantifier(token, chars, pos, &caps, pkg, pattern)
-                {
-                    stack.push((
-                        idx + 1,
-                        next,
-                        apply_named_capture(token, pos, next, pos_base, new_caps),
-                    ));
+        };
+        store.push_hash_capture(name, (key, value));
+    }
+
+    /// Fold the quantified capture block (if the atom captures) and descend to
+    /// the token after `idx`, rewinding the fold afterwards.
+    #[allow(clippy::too_many_arguments)]
+    fn descend_folded(
+        &self,
+        ctx: &WalkCtx,
+        idx: usize,
+        at: usize,
+        base_len: usize,
+        stride: usize,
+        store: &mut CapStore,
+        matches: &mut Vec<(usize, RegexCaptures)>,
+    ) -> bool {
+        let mf = store.mark();
+        if stride > 0 {
+            store.fold_quantified(base_len, stride);
+        }
+        let stop = self.walk_tokens(ctx, idx + 1, at, store, matches);
+        store.rewind(mf);
+        stop
+    }
+
+    /// Depth-first walk from token `idx` at position `pos`. Returns `true`
+    /// when the walk should stop (first_only found a match).
+    fn walk_tokens(
+        &self,
+        ctx: &WalkCtx,
+        idx: usize,
+        pos: usize,
+        store: &mut CapStore,
+        matches: &mut Vec<(usize, RegexCaptures)>,
+    ) -> bool {
+        if idx == ctx.pattern.tokens.len() {
+            if !ctx.pattern.anchor_end || pos == ctx.chars.len() {
+                matches.push((pos, store.snapshot()));
+                if ctx.first_only {
+                    return true;
                 }
-                continue;
             }
-            match token.quant {
-                RegexQuant::One => {
-                    let mut candidates = self.regex_match_atom_all_with_capture_in_pkg(
-                        &token.atom,
-                        chars,
-                        pos,
-                        &caps,
-                        pkg,
-                        pattern.ignore_case,
-                    );
-                    if token.ratchet {
-                        // Ratchet (`:`) commits to the atom's highest-priority match
-                        // and forbids backtracking into it. Candidates are returned in
-                        // "lowest priority first, highest priority last" order, so the
-                        // atom's preferred match is the last element: for `||` it is the
-                        // first alternative, for `|`/greedy quantifiers it is the longest
-                        // match — both already sit last. Keep only that one. (Sorting by
-                        // length here was wrong: it picked the longest match even for `||`,
-                        // letting `( ab || abc ): de` backtrack into the group.)
-                        if let Some(best) = candidates.pop() {
-                            candidates = vec![best];
-                        }
-                    }
-                    for (next, new_caps) in candidates {
-                        stack.push((
-                            idx + 1,
-                            next,
-                            apply_hash_capture(
-                                token,
-                                pos,
-                                next,
-                                pos_base,
-                                apply_named_capture(token, pos, next, pos_base, new_caps),
-                            ),
-                        ));
+            return false;
+        }
+        let token = &ctx.pattern.tokens[idx];
+        let pos_base = store.caps().positional.len();
+        // Separator quantifiers (`atom +% sep`, `atom **N..M %% sep`, ...):
+        // match the atom with the separator interleaved between iterations,
+        // accumulating each side's captures into its own (folded) group.
+        if token.separator.is_some() {
+            let cands =
+                self.match_separated_quantifier(token, ctx.chars, pos, ctx.pkg, ctx.pattern);
+            // Candidates come lowest-priority first; try highest first.
+            for (next, delta) in cands.into_iter().rev() {
+                let m = store.mark();
+                store.merge_delta(delta);
+                Self::store_apply_named_capture(store, ctx.chars, token, pos, next, pos_base);
+                let stop = self.walk_tokens(ctx, idx + 1, next, store, matches);
+                store.rewind(m);
+                if stop {
+                    return true;
+                }
+            }
+            return false;
+        }
+        match token.quant {
+            RegexQuant::One => {
+                let mut candidates = self.regex_match_atom_all_with_capture_in_pkg(
+                    &token.atom,
+                    ctx.chars,
+                    pos,
+                    store.caps(),
+                    ctx.pkg,
+                    ctx.pattern.ignore_case,
+                );
+                if token.ratchet && candidates.len() > 1 {
+                    // Ratchet (`:`) commits to the atom's highest-priority match
+                    // and forbids backtracking into it. Candidates are returned in
+                    // "lowest priority first, highest priority last" order, so the
+                    // atom's preferred match is the last element: for `||` it is the
+                    // first alternative, for `|`/greedy quantifiers it is the longest
+                    // match — both already sit last. Keep only that one. (Sorting by
+                    // length here was wrong: it picked the longest match even for `||`,
+                    // letting `( ab || abc ): de` backtrack into the group.)
+                    candidates.drain(..candidates.len() - 1);
+                }
+                for (next, delta) in candidates.into_iter().rev() {
+                    let m = store.mark();
+                    store.merge_delta(delta);
+                    Self::store_apply_named_capture(store, ctx.chars, token, pos, next, pos_base);
+                    Self::store_apply_hash_capture(store, ctx.chars, token, pos, next, pos_base);
+                    let stop = self.walk_tokens(ctx, idx + 1, next, store, matches);
+                    store.rewind(m);
+                    if stop {
+                        return true;
                     }
                 }
-                RegexQuant::ZeroOrOne => {
-                    // An unmatched `(x)?` reserves `zo_stride` Nil positional slots
-                    // so following captures keep their index (`(a)?(b)` → $0=Nil,$1=b).
-                    let zo_stride = count_capture_groups(&token.atom);
-                    let zero_caps = || {
-                        let mut zc = caps.clone();
-                        reserve_nil_capture_slots(&mut zc, zo_stride);
-                        zc
-                    };
-                    let mut candidates = self.regex_match_atom_all_with_capture_in_pkg(
-                        &token.atom,
-                        chars,
-                        pos,
-                        &caps,
-                        pkg,
-                        pattern.ignore_case,
-                    );
-                    if token.ratchet {
-                        // Same as the `One` case: commit to the atom's highest-priority
-                        // match (the last candidate), not the longest one.
-                        if let Some(best) = candidates.pop() {
-                            // Atom matched — commit to the match (no backtracking)
-                            candidates = vec![best];
-                        } else {
-                            // Atom didn't match — commit to "zero" (no match)
-                            stack.push((idx + 1, pos, zero_caps()));
-                            candidates.clear();
-                        }
-                    } else if token.frugal {
-                        // Frugal: prefer zero matches — push match first (low priority),
-                        // then zero (high priority, tried first from LIFO stack).
-                        for (next, new_caps) in &candidates {
-                            stack.push((
-                                idx + 1,
-                                *next,
-                                apply_hash_capture(
-                                    token,
-                                    pos,
-                                    *next,
-                                    pos_base,
-                                    apply_named_capture(
-                                        token,
-                                        pos,
-                                        *next,
-                                        pos_base,
-                                        new_caps.clone(),
-                                    ),
-                                ),
-                            ));
-                        }
-                        stack.push((idx + 1, pos, zero_caps()));
-                        candidates.clear();
-                    } else {
-                        stack.push((idx + 1, pos, zero_caps()));
+                false
+            }
+            RegexQuant::ZeroOrOne => {
+                // An unmatched `(x)?` reserves `zo_stride` Nil positional slots
+                // so following captures keep their index (`(a)?(b)` → $0=Nil,$1=b).
+                let zo_stride = count_capture_groups(&token.atom);
+                let mut candidates = self.regex_match_atom_all_with_capture_in_pkg(
+                    &token.atom,
+                    ctx.chars,
+                    pos,
+                    store.caps(),
+                    ctx.pkg,
+                    ctx.pattern.ignore_case,
+                );
+                if token.ratchet {
+                    if candidates.is_empty() {
+                        // Atom didn't match — commit to "zero" (no match).
+                        let m = store.mark();
+                        store.reserve_nil(zo_stride);
+                        let stop = self.walk_tokens(ctx, idx + 1, pos, store, matches);
+                        store.rewind(m);
+                        return stop;
                     }
-                    for (next, new_caps) in candidates {
-                        stack.push((
-                            idx + 1,
-                            next,
-                            apply_hash_capture(
-                                token,
-                                pos,
-                                next,
-                                pos_base,
-                                apply_named_capture(token, pos, next, pos_base, new_caps),
-                            ),
-                        ));
+                    // Atom matched — commit to the highest-priority match.
+                    candidates.drain(..candidates.len() - 1);
+                } else if token.frugal {
+                    // Frugal: prefer zero matches — try zero first.
+                    let m = store.mark();
+                    store.reserve_nil(zo_stride);
+                    let stop = self.walk_tokens(ctx, idx + 1, pos, store, matches);
+                    store.rewind(m);
+                    if stop {
+                        return true;
                     }
                 }
-                RegexQuant::ZeroOrMore => {
-                    // Fast path: ratcheted simple atom with no named capture
-                    // avoids all RegexCaptures cloning by only tracking position.
-                    if token.ratchet && token.named_capture.is_none() && is_simple_atom(&token.atom)
-                    {
-                        let mut current = pos;
-                        while let Some(next) = self.regex_match_atom_in_pkg(
-                            &token.atom,
-                            chars,
-                            current,
-                            pkg,
-                            pattern.ignore_case,
-                        ) {
-                            if next == current {
-                                break;
-                            }
-                            current = next;
-                        }
-                        stack.push((idx + 1, current, caps));
-                    } else if token.ratchet
-                        && token.named_capture.is_none()
-                        && is_silent_named_atom(&token.atom)
-                        && let Some((resolved, resolved_pkg)) =
-                            self.try_resolve_named_to_pattern(&token.atom, pkg)
-                    {
-                        // Fast path for ratcheted Named token: resolve pattern once,
-                        // match directly without creating new Interpreter per iteration.
-                        // Only used for silent atoms (e.g. <.ws>) that don't produce
-                        // implicit named captures.
-                        let mut current = pos;
-                        while current < chars.len() {
-                            if let Some(end) = self.regex_match_end_from_in_pkg(
-                                &resolved,
-                                chars,
-                                current,
-                                &resolved_pkg,
-                            ) {
-                                if end == current {
-                                    break;
-                                }
-                                current = end;
-                            } else {
-                                break;
-                            }
-                        }
-                        stack.push((idx + 1, current, caps));
-                    } else if token.ratchet
-                        && token.named_capture.is_none()
-                        && is_named_atom_no_args(&token.atom)
-                        && let Some((resolved, resolved_pkg)) =
-                            self.try_resolve_named_to_pattern(&token.atom, pkg)
-                    {
-                        // Fast path for ratcheted non-silent Named token (e.g. <huge>*).
-                        // Resolve the pattern once and loop directly, accumulating
-                        // named captures without re-parsing on each iteration.
-                        let capture_name = if let RegexAtom::Named(name) = &token.atom {
-                            name.trim().to_string()
-                        } else {
-                            String::new()
-                        };
-                        let mut current = pos;
-                        let mut current_caps = caps;
-                        if !capture_name.is_empty() {
-                            current_caps.named_quantified.insert(capture_name.clone());
-                        }
-                        while current < chars.len() {
-                            if let Some((end, inner_caps)) = self.regex_match_end_from_caps_in_pkg(
-                                &resolved,
-                                chars,
-                                current,
-                                &resolved_pkg,
-                            ) {
-                                if end == current {
-                                    break;
-                                }
-                                if !capture_name.is_empty() {
-                                    let captured: String = chars[current..end].iter().collect();
-                                    let mut subcap = inner_caps;
-                                    subcap.matched = captured.clone();
-                                    subcap.from = current;
-                                    subcap.to = end;
-                                    current_caps
-                                        .named_subcaps
-                                        .entry(capture_name.clone())
-                                        .or_default()
-                                        .push(std::sync::Arc::new(subcap));
-                                    current_caps
-                                        .named
-                                        .entry(capture_name.clone())
-                                        .or_default()
-                                        .push(captured);
-                                }
-                                current = end;
-                            } else {
-                                break;
-                            }
-                        }
-                        stack.push((idx + 1, current, current_caps));
-                    } else {
-                        let base_len = caps.positional.len();
-                        let stride = count_capture_groups(&token.atom);
-                        let mut caps = caps;
-                        caps.named_quantified
-                            .extend(Self::collect_quantified_names_for_token(token));
-                        let mut positions = Vec::new();
-                        // Zero-match candidate (lowest priority for greedy `*`).
-                        positions.push((pos, caps.clone()));
-                        if !token.ratchet && atom_contains_alternation(&token.atom) {
-                            // Full greedy backtracking so a later constraint can
-                            // force a shorter per-iteration alternative. Ratchet
-                            // skips this: it commits to the per-iteration
-                            // highest-priority choice, which is exactly the linear
-                            // chain below (the expansion would enumerate an
-                            // exponential tree only to keep its first leaf).
-                            let mut hi_first = Vec::new();
-                            self.quant_expand_greedy(
-                                token,
-                                chars,
-                                pos,
-                                &caps,
-                                pos_base,
-                                pkg,
-                                pattern.ignore_case,
-                                &apply_named_capture,
-                                &apply_hash_capture,
-                                &mut hi_first,
-                            );
-                            // hi_first is HIGHEST-first; `positions` is LOWEST-first
-                            // (greediest last, pushed to the LIFO stack last → tried
-                            // first), so reverse before appending after the zero entry.
-                            hi_first.reverse();
-                            positions.extend(hi_first);
-                        } else {
-                            let mut current = pos;
-                            let mut current_caps = caps.clone();
-                            while let Some((next, new_caps)) = self
-                                .regex_match_atom_with_capture_in_pkg(
-                                    &token.atom,
-                                    chars,
-                                    current,
-                                    &current_caps,
-                                    pkg,
-                                    pattern.ignore_case,
-                                )
-                            {
-                                if next == current {
-                                    break;
-                                }
-                                let iter_pos_base = current_caps.positional.len();
-                                let new_caps = apply_hash_capture(
-                                    token,
-                                    current,
-                                    next,
-                                    iter_pos_base,
-                                    apply_named_capture(token, current, next, pos_base, new_caps),
-                                );
-                                // Reduce-time grammar action: when a `<subrule>`
-                                // quantifier iteration commits inside an
-                                // action-driven parse whose matching depends on a
-                                // `$*` dynamic var, run this iteration's subrule
-                                // action now so any dyn-var write (e.g. a delimiter
-                                // finalizer) is visible to the next iteration's
-                                // pattern interpolation. Gated on the SEEN flag so
-                                // plain grammars pay nothing.
-                                self.maybe_run_reduce_time_dynvar_action(token, &new_caps);
-                                current_caps = new_caps.clone();
-                                positions.push((next, new_caps));
-                                current = next;
-                            }
-                        }
-                        if token.ratchet
-                            && let Some(last) = positions.last().cloned()
+                for (next, delta) in candidates.into_iter().rev() {
+                    let m = store.mark();
+                    store.merge_delta(delta);
+                    Self::store_apply_named_capture(store, ctx.chars, token, pos, next, pos_base);
+                    Self::store_apply_hash_capture(store, ctx.chars, token, pos, next, pos_base);
+                    let stop = self.walk_tokens(ctx, idx + 1, next, store, matches);
+                    store.rewind(m);
+                    if stop {
+                        return true;
+                    }
+                }
+                if !token.ratchet && !token.frugal {
+                    // Greedy: the zero candidate is tried last.
+                    let m = store.mark();
+                    store.reserve_nil(zo_stride);
+                    let stop = self.walk_tokens(ctx, idx + 1, pos, store, matches);
+                    store.rewind(m);
+                    if stop {
+                        return true;
+                    }
+                }
+                false
+            }
+            RegexQuant::ZeroOrMore => {
+                if let Some(stop) = self.walk_ratchet_fast_paths(ctx, idx, pos, 0, store, matches) {
+                    return stop;
+                }
+                if !token.ratchet && atom_contains_alternation(&token.atom) {
+                    // Full greedy backtracking so a later constraint can
+                    // force a shorter per-iteration alternative. Ratchet
+                    // skips this: it commits to the per-iteration
+                    // highest-priority choice, which is exactly the linear
+                    // chain (the expansion would enumerate an exponential
+                    // tree only to keep its first leaf).
+                    return self.walk_quant_alt(ctx, idx, pos, 0, store, matches);
+                }
+                self.walk_quant_chain(ctx, idx, pos, 0, None, true, store, matches)
+            }
+            RegexQuant::OneOrMore => {
+                if let Some(stop) = self.walk_ratchet_fast_paths(ctx, idx, pos, 1, store, matches) {
+                    return stop;
+                }
+                if !token.ratchet && atom_contains_alternation(&token.atom) {
+                    // Full greedy backtracking (`+` of a variable-length
+                    // alternation): explore every per-iteration choice so a
+                    // later constraint can force a shorter one.
+                    return self.walk_quant_alt(ctx, idx, pos, 1, store, matches);
+                }
+                self.walk_quant_chain(ctx, idx, pos, 1, None, true, store, matches)
+            }
+            RegexQuant::Repeat(..) | RegexQuant::RepeatCode(_) => {
+                let (min, max) = match &token.quant {
+                    RegexQuant::Repeat(min, max) => {
+                        // Block-less empty range: /x ** 2..1/ should throw
+                        if let Some(max_val) = *max
+                            && *min > max_val
                         {
-                            positions = vec![last];
-                        }
-                        // Frugal: reverse so shortest match is tried first (LIFO)
-                        if token.frugal {
-                            positions.reverse();
-                        }
-                        if stride > 0 {
-                            for (p, c) in positions {
-                                let mut c = c;
-                                fold_quantified_captures(&mut c, base_len, stride);
-                                stack.push((idx + 1, p, c));
-                            }
-                        } else {
-                            for (p, c) in positions {
-                                stack.push((idx + 1, p, c));
-                            }
-                        }
-                    }
-                }
-                RegexQuant::OneOrMore => {
-                    // Fast path: ratcheted simple atom with no named capture
-                    if token.ratchet && token.named_capture.is_none() && is_simple_atom(&token.atom)
-                    {
-                        let Some(mut current) = self.regex_match_atom_in_pkg(
-                            &token.atom,
-                            chars,
-                            pos,
-                            pkg,
-                            pattern.ignore_case,
-                        ) else {
-                            continue;
-                        };
-                        while let Some(next) = self.regex_match_atom_in_pkg(
-                            &token.atom,
-                            chars,
-                            current,
-                            pkg,
-                            pattern.ignore_case,
-                        ) {
-                            if next == current {
-                                break;
-                            }
-                            current = next;
-                        }
-                        stack.push((idx + 1, current, caps));
-                    } else if token.ratchet
-                        && token.named_capture.is_none()
-                        && is_silent_named_atom(&token.atom)
-                        && let Some((resolved, resolved_pkg)) =
-                            self.try_resolve_named_to_pattern(&token.atom, pkg)
-                    {
-                        // Fast path for ratcheted Named token.
-                        // Only used for silent atoms (e.g. <.ws>) that don't produce
-                        // implicit named captures.
-                        let Some(mut current) =
-                            self.regex_match_end_from_in_pkg(&resolved, chars, pos, &resolved_pkg)
-                        else {
-                            continue;
-                        };
-                        while current < chars.len() {
-                            if let Some(end) = self.regex_match_end_from_in_pkg(
-                                &resolved,
-                                chars,
-                                current,
-                                &resolved_pkg,
-                            ) {
-                                if end == current {
-                                    break;
-                                }
-                                current = end;
-                            } else {
-                                break;
-                            }
-                        }
-                        stack.push((idx + 1, current, caps));
-                    } else if token.ratchet
-                        && token.named_capture.is_none()
-                        && is_named_atom_no_args(&token.atom)
-                        && let Some((resolved, resolved_pkg)) =
-                            self.try_resolve_named_to_pattern(&token.atom, pkg)
-                    {
-                        // Fast path for ratcheted non-silent Named token (e.g. <huge>+).
-                        // Resolve the pattern once and loop directly.
-                        let capture_name = if let RegexAtom::Named(name) = &token.atom {
-                            name.trim().to_string()
-                        } else {
-                            String::new()
-                        };
-                        let Some((first_end, first_inner)) = self.regex_match_end_from_caps_in_pkg(
-                            &resolved,
-                            chars,
-                            pos,
-                            &resolved_pkg,
-                        ) else {
-                            continue;
-                        };
-                        let mut current = first_end;
-                        let mut current_caps = caps;
-                        if !capture_name.is_empty() {
-                            current_caps.named_quantified.insert(capture_name.clone());
-                            let captured: String = chars[pos..first_end].iter().collect();
-                            let mut subcap = first_inner;
-                            subcap.matched = captured.clone();
-                            subcap.from = pos;
-                            subcap.to = first_end;
-                            current_caps
-                                .named_subcaps
-                                .entry(capture_name.clone())
-                                .or_default()
-                                .push(std::sync::Arc::new(subcap));
-                            current_caps
-                                .named
-                                .entry(capture_name.clone())
-                                .or_default()
-                                .push(captured);
-                        }
-                        while current < chars.len() {
-                            if let Some((end, inner_caps)) = self.regex_match_end_from_caps_in_pkg(
-                                &resolved,
-                                chars,
-                                current,
-                                &resolved_pkg,
-                            ) {
-                                if end == current {
-                                    break;
-                                }
-                                if !capture_name.is_empty() {
-                                    let captured: String = chars[current..end].iter().collect();
-                                    let mut subcap = inner_caps;
-                                    subcap.matched = captured.clone();
-                                    subcap.from = current;
-                                    subcap.to = end;
-                                    current_caps
-                                        .named_subcaps
-                                        .entry(capture_name.clone())
-                                        .or_default()
-                                        .push(std::sync::Arc::new(subcap));
-                                    current_caps
-                                        .named
-                                        .entry(capture_name.clone())
-                                        .or_default()
-                                        .push(captured);
-                                }
-                                current = end;
-                            } else {
-                                break;
-                            }
-                        }
-                        stack.push((idx + 1, current, current_caps));
-                    } else {
-                        let base_len = caps.positional.len();
-                        let stride = count_capture_groups(&token.atom);
-                        let mut caps = caps;
-                        caps.named_quantified
-                            .extend(Self::collect_quantified_names_for_token(token));
-                        let mut positions = Vec::new();
-                        if !token.ratchet && atom_contains_alternation(&token.atom) {
-                            // Full greedy backtracking (`+` of a variable-length
-                            // alternation): explore every per-iteration choice so a
-                            // later constraint can force a shorter one. Ratchet
-                            // commits to the per-iteration highest-priority choice
-                            // instead — the linear chain below (see the `*` case).
-                            let mut hi_first = Vec::new();
-                            self.quant_expand_greedy(
-                                token,
-                                chars,
-                                pos,
-                                &caps,
-                                pos_base,
-                                pkg,
-                                pattern.ignore_case,
-                                &apply_named_capture,
-                                &apply_hash_capture,
-                                &mut hi_first,
+                            Self::set_quantifier_value_error(
+                                "empty-range",
+                                "Quantifier range is empty",
                             );
-                            if hi_first.is_empty() {
-                                continue; // no match → `+` fails here
-                            }
-                            // HIGHEST-first → LOWEST-first (greediest last for LIFO).
-                            hi_first.reverse();
-                            positions = hi_first;
-                        } else {
-                            let (mut current, mut current_caps) = match self
-                                .regex_match_atom_with_capture_in_pkg(
-                                    &token.atom,
-                                    chars,
-                                    pos,
-                                    &caps,
-                                    pkg,
-                                    pattern.ignore_case,
-                                ) {
-                                Some((next, new_caps)) => {
-                                    let new_caps = apply_hash_capture(
-                                        token,
-                                        pos,
-                                        next,
-                                        pos_base,
-                                        apply_named_capture(token, pos, next, pos_base, new_caps),
-                                    );
-                                    (next, new_caps)
-                                }
-                                None => continue,
-                            };
-                            positions.push((current, current_caps.clone()));
-                            while let Some((next, new_caps)) = self
-                                .regex_match_atom_with_capture_in_pkg(
-                                    &token.atom,
-                                    chars,
-                                    current,
-                                    &current_caps,
-                                    pkg,
-                                    pattern.ignore_case,
-                                )
-                            {
-                                if next == current {
-                                    break;
-                                }
-                                let iter_pos_base = current_caps.positional.len();
-                                let new_caps = apply_hash_capture(
-                                    token,
-                                    current,
-                                    next,
-                                    iter_pos_base,
-                                    apply_named_capture(token, current, next, pos_base, new_caps),
-                                );
-                                // Reduce-time grammar action: when a `<subrule>`
-                                // quantifier iteration commits inside an
-                                // action-driven parse whose matching depends on a
-                                // `$*` dynamic var, run this iteration's subrule
-                                // action now so any dyn-var write (e.g. a delimiter
-                                // finalizer) is visible to the next iteration's
-                                // pattern interpolation. Gated on the SEEN flag so
-                                // plain grammars pay nothing.
-                                self.maybe_run_reduce_time_dynvar_action(token, &new_caps);
-                                current_caps = new_caps.clone();
-                                positions.push((next, new_caps));
-                                current = next;
-                            }
+                            return false;
                         }
-                        if token.ratchet
-                            && let Some(last) = positions.last().cloned()
-                        {
-                            positions = vec![last];
-                        }
-                        // Frugal: reverse so shortest match is tried first (LIFO)
-                        if token.frugal {
-                            positions.reverse();
-                        }
-                        // Fold quantified captures for each position
-                        if stride > 0 {
-                            for (p, c) in positions {
-                                let mut c = c;
-                                fold_quantified_captures(&mut c, base_len, stride);
-                                stack.push((idx + 1, p, c));
-                            }
-                        } else {
-                            for (p, c) in positions {
-                                stack.push((idx + 1, p, c));
-                            }
+                        (*min, *max)
+                    }
+                    RegexQuant::RepeatCode(code) => {
+                        match self.eval_regex_repeat_code(code, store.caps()) {
+                            Some((min, max)) => (min, max),
+                            None => return false, // code eval failed, no match
                         }
                     }
-                }
-                RegexQuant::Repeat(..) | RegexQuant::RepeatCode(_) => {
-                    let (min, max) = match &token.quant {
-                        RegexQuant::Repeat(min, max) => {
-                            // Block-less empty range: /x ** 2..1/ should throw
-                            if let Some(max_val) = *max
-                                && *min > max_val
-                            {
-                                Self::set_quantifier_value_error(
-                                    "empty-range",
-                                    "Quantifier range is empty",
-                                );
-                                continue;
-                            }
-                            (*min, *max)
-                        }
-                        RegexQuant::RepeatCode(code) => {
-                            match self.eval_regex_repeat_code(code, &caps) {
-                                Some((min, max)) => (min, max),
-                                None => continue, // code eval failed, no match
-                            }
-                        }
-                        _ => unreachable!(),
-                    };
-                    let base_len = caps.positional.len();
-                    let stride = count_capture_groups(&token.atom);
-                    let mut caps = caps;
-                    caps.named_quantified
-                        .extend(Self::collect_quantified_names_for_token(token));
-                    let mut positions = Vec::new();
-                    if min == 0 {
-                        positions.push((pos, caps.clone()));
-                    }
-                    let mut current = pos;
-                    let mut current_caps = caps.clone();
-                    let mut count = 0usize;
-                    while max.is_none_or(|m| count < m) {
-                        match self.regex_match_atom_with_capture_in_pkg(
-                            &token.atom,
-                            chars,
-                            current,
-                            &current_caps,
-                            pkg,
-                            pattern.ignore_case,
-                        ) {
-                            Some((next, new_caps)) if next != current => {
-                                count += 1;
-                                let new_caps = apply_hash_capture(
-                                    token,
-                                    current,
-                                    next,
-                                    pos_base,
-                                    apply_named_capture(token, current, next, pos_base, new_caps),
-                                );
-                                current_caps = new_caps.clone();
-                                current = next;
-                                if count >= min {
-                                    positions.push((current, current_caps.clone()));
-                                }
-                            }
-                            _ => break,
-                        }
-                    }
-                    if count < min {
-                        continue;
-                    }
-                    if token.ratchet
-                        && let Some(last) = positions.last().cloned()
-                    {
-                        positions = vec![last];
-                    }
-                    if token.frugal {
-                        positions.reverse();
-                    }
-                    if stride > 0 {
-                        for (p, c) in positions {
-                            let mut c = c;
-                            fold_quantified_captures(&mut c, base_len, stride);
-                            stack.push((idx + 1, p, c));
-                        }
-                    } else {
-                        for (p, c) in positions {
-                            stack.push((idx + 1, p, c));
-                        }
-                    }
-                }
+                    _ => unreachable!(),
+                };
+                self.walk_quant_chain(ctx, idx, pos, min, max, false, store, matches)
             }
         }
-        matches
+    }
+
+    /// The three ratcheted `*`/`+` fast paths (simple atom / silent Named /
+    /// non-silent Named): possessive linear scans that avoid the general
+    /// chain. Returns `None` when no fast path applies.
+    fn walk_ratchet_fast_paths(
+        &self,
+        ctx: &WalkCtx,
+        idx: usize,
+        pos: usize,
+        min: usize,
+        store: &mut CapStore,
+        matches: &mut Vec<(usize, RegexCaptures)>,
+    ) -> Option<bool> {
+        let token = &ctx.pattern.tokens[idx];
+        if !token.ratchet || token.named_capture.is_some() {
+            return None;
+        }
+        if is_simple_atom(&token.atom) {
+            // Position-only scan: no captures are produced at all.
+            let mut current = pos;
+            let mut count = 0usize;
+            while let Some(next) = self.regex_match_atom_in_pkg(
+                &token.atom,
+                ctx.chars,
+                current,
+                ctx.pkg,
+                ctx.pattern.ignore_case,
+            ) {
+                if next == current {
+                    break;
+                }
+                current = next;
+                count += 1;
+            }
+            if count < min {
+                return Some(false);
+            }
+            return Some(self.walk_tokens(ctx, idx + 1, current, store, matches));
+        }
+        if is_silent_named_atom(&token.atom)
+            && let Some((resolved, resolved_pkg)) =
+                self.try_resolve_named_to_pattern(&token.atom, ctx.pkg)
+        {
+            // Ratcheted silent Named token (e.g. <.ws>): resolve the pattern
+            // once and match directly; silent atoms produce no captures.
+            let mut current = pos;
+            let mut count = 0usize;
+            while current < ctx.chars.len() {
+                if let Some(end) =
+                    self.regex_match_end_from_in_pkg(&resolved, ctx.chars, current, &resolved_pkg)
+                {
+                    if end == current {
+                        break;
+                    }
+                    current = end;
+                    count += 1;
+                } else {
+                    break;
+                }
+            }
+            if count < min {
+                return Some(false);
+            }
+            return Some(self.walk_tokens(ctx, idx + 1, current, store, matches));
+        }
+        if is_named_atom_no_args(&token.atom)
+            && let Some((resolved, resolved_pkg)) =
+                self.try_resolve_named_to_pattern(&token.atom, ctx.pkg)
+        {
+            // Ratcheted non-silent Named token (e.g. <huge>*): resolve the
+            // pattern once and loop directly, accumulating named captures on
+            // the store without re-parsing per iteration.
+            let capture_name = if let RegexAtom::Named(name) = &token.atom {
+                name.trim().to_string()
+            } else {
+                String::new()
+            };
+            let m = store.mark();
+            if !capture_name.is_empty() {
+                store.insert_named_quantified(capture_name.clone());
+            }
+            let mut current = pos;
+            let mut count = 0usize;
+            while current <= ctx.chars.len() {
+                let Some((end, inner_caps)) = self.regex_match_end_from_caps_in_pkg(
+                    &resolved,
+                    ctx.chars,
+                    current,
+                    &resolved_pkg,
+                ) else {
+                    break;
+                };
+                if end == current {
+                    break;
+                }
+                if !capture_name.is_empty() {
+                    let captured: String = ctx.chars[current..end].iter().collect();
+                    let mut subcap = inner_caps;
+                    subcap.matched = captured.clone();
+                    subcap.from = current;
+                    subcap.to = end;
+                    store.push_named_subcap(&capture_name, std::sync::Arc::new(subcap));
+                    store.push_named(&capture_name, captured);
+                }
+                current = end;
+                count += 1;
+                if current >= ctx.chars.len() {
+                    break;
+                }
+            }
+            if count < min {
+                store.rewind(m);
+                return Some(false);
+            }
+            let stop = self.walk_tokens(ctx, idx + 1, current, store, matches);
+            store.rewind(m);
+            return Some(stop);
+        }
+        None
+    }
+
+    /// General chain quantifier (`*`, `+`, `**min..max`) over a single-match
+    /// atom: grow the iteration chain on the store (one mark per iteration),
+    /// then descend longest-first (greedy) / shortest-first (frugal) /
+    /// longest-only (ratchet). `hash_per_iter` selects the `%<h>=` hash
+    /// capture base: per-iteration for `*`/`+` (which also run reduce-time
+    /// grammar actions per iteration), token-start for `**`.
+    #[allow(clippy::too_many_arguments)]
+    fn walk_quant_chain(
+        &self,
+        ctx: &WalkCtx,
+        idx: usize,
+        pos: usize,
+        min: usize,
+        max: Option<usize>,
+        hash_per_iter: bool,
+        store: &mut CapStore,
+        matches: &mut Vec<(usize, RegexCaptures)>,
+    ) -> bool {
+        let token = &ctx.pattern.tokens[idx];
+        let pos_base = store.caps().positional.len();
+        let stride = count_capture_groups(&token.atom);
+        let m_quant = store.mark();
+        for n in Self::collect_quantified_names_for_token(token) {
+            store.insert_named_quantified(n);
+        }
+        let grow_one = |store: &mut CapStore, current: usize| -> Option<usize> {
+            let iter_pos_base = store.caps().positional.len();
+            let (next, delta) = self.regex_match_atom_with_capture_in_pkg(
+                &token.atom,
+                ctx.chars,
+                current,
+                store.caps(),
+                ctx.pkg,
+                ctx.pattern.ignore_case,
+            )?;
+            if next == current {
+                return None;
+            }
+            store.merge_delta(delta);
+            Self::store_apply_named_capture(store, ctx.chars, token, current, next, pos_base);
+            let hash_base = if hash_per_iter {
+                iter_pos_base
+            } else {
+                pos_base
+            };
+            Self::store_apply_hash_capture(store, ctx.chars, token, current, next, hash_base);
+            if hash_per_iter {
+                // Reduce-time grammar action: when a `<subrule>` quantifier
+                // iteration commits inside an action-driven parse whose
+                // matching depends on a `$*` dynamic var, run this iteration's
+                // subrule action now so any dyn-var write (e.g. a delimiter
+                // finalizer) is visible to the next iteration's pattern
+                // interpolation. Gated on the SEEN flag so plain grammars pay
+                // nothing.
+                self.maybe_run_reduce_time_dynvar_action(token, store.caps());
+            }
+            Some(next)
+        };
+        if token.frugal && !token.ratchet {
+            // Frugal: try the shortest admissible length first, growing the
+            // chain one iteration at a time on demand.
+            let mut current = pos;
+            let mut count = 0usize;
+            loop {
+                if count >= min
+                    && self.descend_folded(ctx, idx, current, pos_base, stride, store, matches)
+                {
+                    store.rewind(m_quant);
+                    return true;
+                }
+                if max.is_some_and(|mx| count >= mx) {
+                    break;
+                }
+                let Some(next) = grow_one(store, current) else {
+                    break;
+                };
+                count += 1;
+                current = next;
+            }
+            store.rewind(m_quant);
+            return false;
+        }
+        // Greedy / ratchet: grow the full chain first, then descend.
+        let mut ends = vec![pos];
+        let mut iter_marks = vec![store.mark()];
+        let mut current = pos;
+        while max.is_none_or(|mx| ends.len() - 1 < mx) {
+            let Some(next) = grow_one(store, current) else {
+                break;
+            };
+            ends.push(next);
+            iter_marks.push(store.mark());
+            current = next;
+        }
+        let count = ends.len() - 1;
+        if count < min {
+            store.rewind(m_quant);
+            return false;
+        }
+        // Ratchet commits to the longest chain; greedy backtracks toward min.
+        let lo = if token.ratchet { count } else { min };
+        for i in (lo..=count).rev() {
+            store.rewind(iter_marks[i]);
+            if self.descend_folded(ctx, idx, ends[i], pos_base, stride, store, matches) {
+                store.rewind(m_quant);
+                return true;
+            }
+        }
+        store.rewind(m_quant);
+        false
+    }
+
+    /// Full-backtracking quantifier over a variable-length alternation atom
+    /// (`(a | b | bc | cde)+»`): explores every per-iteration alternative so a
+    /// later constraint can force a shorter choice. Greedy priority: at each
+    /// position the highest-priority atom match is tried first, and within a
+    /// match *more* iterations (deeper) outrank stopping there. Frugal is the
+    /// exact mirror. Bounded to avoid catastrophic backtracking.
+    fn walk_quant_alt(
+        &self,
+        ctx: &WalkCtx,
+        idx: usize,
+        pos: usize,
+        min: usize,
+        store: &mut CapStore,
+        matches: &mut Vec<(usize, RegexCaptures)>,
+    ) -> bool {
+        let token = &ctx.pattern.tokens[idx];
+        let pos_base = store.caps().positional.len();
+        let stride = count_capture_groups(&token.atom);
+        let m_quant = store.mark();
+        for n in Self::collect_quantified_names_for_token(token) {
+            store.insert_named_quantified(n);
+        }
+        let mut budget = QUANT_ALT_BUDGET;
+        let stop = if token.frugal {
+            // Frugal: zero iterations first, then shallow-before-deep.
+            (min == 0 && self.descend_folded(ctx, idx, pos, pos_base, stride, store, matches))
+                || self.quant_alt_dfs(
+                    ctx,
+                    idx,
+                    pos,
+                    0,
+                    min,
+                    pos_base,
+                    stride,
+                    true,
+                    &mut budget,
+                    store,
+                    matches,
+                )
+        } else {
+            // Greedy: deep-before-shallow, zero iterations last.
+            self.quant_alt_dfs(
+                ctx,
+                idx,
+                pos,
+                0,
+                min,
+                pos_base,
+                stride,
+                false,
+                &mut budget,
+                store,
+                matches,
+            ) || (min == 0 && self.descend_folded(ctx, idx, pos, pos_base, stride, store, matches))
+        };
+        store.rewind(m_quant);
+        stop
+    }
+
+    /// DFS worker for `walk_quant_alt`. At each node, applies one atom
+    /// candidate, then (greedy) recurses deeper before descending past the
+    /// quantifier at this length — or the mirror order for frugal.
+    #[allow(clippy::too_many_arguments)]
+    fn quant_alt_dfs(
+        &self,
+        ctx: &WalkCtx,
+        idx: usize,
+        current: usize,
+        count: usize,
+        min: usize,
+        pos_base: usize,
+        stride: usize,
+        frugal: bool,
+        budget: &mut u32,
+        store: &mut CapStore,
+        matches: &mut Vec<(usize, RegexCaptures)>,
+    ) -> bool {
+        if *budget == 0 {
+            return false;
+        }
+        let token = &ctx.pattern.tokens[idx];
+        let cands = self.regex_match_atom_all_with_capture_in_pkg(
+            &token.atom,
+            ctx.chars,
+            current,
+            store.caps(),
+            ctx.pkg,
+            ctx.pattern.ignore_case,
+        );
+        // Candidates come lowest-priority first: greedy iterates highest
+        // first, frugal keeps the producer order.
+        let iter: Box<dyn Iterator<Item = (usize, RegexCaptures)>> = if frugal {
+            Box::new(cands.into_iter())
+        } else {
+            Box::new(cands.into_iter().rev())
+        };
+        for (next, delta) in iter {
+            if next == current {
+                continue; // zero-width: would loop forever
+            }
+            if *budget == 0 {
+                return false;
+            }
+            *budget -= 1;
+            let iter_pos_base = store.caps().positional.len();
+            let m = store.mark();
+            store.merge_delta(delta);
+            Self::store_apply_named_capture(store, ctx.chars, token, current, next, pos_base);
+            Self::store_apply_hash_capture(store, ctx.chars, token, current, next, iter_pos_base);
+            // Greedy: recurse deeper first, then stop at this length.
+            // Frugal: the mirror — stop here first, then grow deeper.
+            let mut stop = false;
+            let order: [bool; 2] = if frugal { [true, false] } else { [false, true] };
+            for stop_here in order {
+                stop = if stop_here {
+                    count + 1 >= min
+                        && self.descend_folded(ctx, idx, next, pos_base, stride, store, matches)
+                } else {
+                    self.quant_alt_dfs(
+                        ctx,
+                        idx,
+                        next,
+                        count + 1,
+                        min,
+                        pos_base,
+                        stride,
+                        frugal,
+                        budget,
+                        store,
+                        matches,
+                    )
+                };
+                if stop {
+                    break;
+                }
+            }
+            store.rewind(m);
+            if stop {
+                return true;
+            }
+        }
+        false
     }
 }

--- a/src/runtime/regex/regex_match_nocap.rs
+++ b/src/runtime/regex/regex_match_nocap.rs
@@ -30,14 +30,9 @@ impl Interpreter {
             // the token as a plain count (so `(\d) ** 4 % '.'` fails to match
             // "1.2.3.4"). We only need the end positions here, so discard caps.
             if token.separator.is_some() {
-                for (next, _caps) in self.match_separated_quantifier(
-                    token,
-                    chars,
-                    pos,
-                    &RegexCaptures::default(),
-                    pkg,
-                    pattern,
-                ) {
+                for (next, _caps) in
+                    self.match_separated_quantifier(token, chars, pos, pkg, pattern)
+                {
                     stack.push((idx + 1, next));
                 }
                 continue;

--- a/src/runtime/regex/regex_match_sep.rs
+++ b/src/runtime/regex/regex_match_sep.rs
@@ -1,0 +1,424 @@
+//! Separator quantifiers (`atom +% sep`, `atom **N..M %% sep`, ...): the atom
+//! is matched repeatedly with `sep` interleaved between iterations, each
+//! side's captures accumulated into its own folded group.
+//!
+//! Candidates are returned as *deltas* — `RegexCaptures` relative to an empty
+//! baseline (ADR-0007); the engine merges the chosen candidate into its
+//! capture store and rewinds on backtrack.
+
+use super::super::*;
+use super::regex_helpers::count_capture_groups;
+
+impl Interpreter {
+    /// Match a separator quantifier at `start`. Returns `(end, delta)` pairs in
+    /// LOWEST-priority-first order (the engine iterates them in reverse):
+    /// shortest match first, longest (greedy) last.
+    pub(super) fn match_separated_quantifier(
+        &self,
+        token: &RegexToken,
+        chars: &[char],
+        start: usize,
+        pkg: &str,
+        pattern: &RegexPattern,
+    ) -> Vec<(usize, RegexCaptures)> {
+        if token.ratchet {
+            return self.match_separated_quantifier_ratchet(token, chars, start, pkg, pattern);
+        }
+        let sep = token.separator.as_ref().expect("separator present");
+        let (min, max) = match &token.quant {
+            RegexQuant::OneOrMore => (1usize, None),
+            RegexQuant::ZeroOrMore => (0usize, None),
+            RegexQuant::Repeat(lo, hi) => (*lo, *hi),
+            // `?` / exact-one don't form a separator list; treat as one.
+            _ => (1usize, Some(1usize)),
+        };
+        let atom_stride = count_capture_groups(&token.atom);
+        let sep_stride: usize = sep
+            .pattern
+            .tokens
+            .iter()
+            .map(|t| count_capture_groups(&t.atom))
+            .sum();
+        let names = Self::collect_quantified_names_for_token(token);
+
+        // Enumerate every valid `atom (sep atom)*` chain via DFS, backtracking
+        // the separator. A purely greedy linear scan (match the first atom, then
+        // repeatedly take the separator's single highest-priority match followed
+        // by an atom) cannot admit more atoms when a frugal separator's minimal
+        // match blocks the next atom: e.g. `( 'a' || 'b' )* %% (.+?)` on "a x b"
+        // would stop after "a" because the frugal `(.+?)` matched just " " and
+        // "x b" is not an atom. Real backtracking expands the separator (" x ")
+        // so the following atom ("b") can match. `enumerate_separated_chains`
+        // performs that backtracking, returning chains highest-priority first
+        // (most atoms first for a greedy quantifier; within a step, the
+        // separator's own priority order from `regex_match_ends_from_caps_in_pkg`).
+        let chains = self.enumerate_separated_chains(token, chars, start, pkg, pattern, max);
+
+        // Turn each chain into result candidates (with optional trailing
+        // separator for `%%`), highest-priority first, then reverse so the
+        // engine (iterating in reverse) tries the highest-priority candidate
+        // first.
+        let mut out: Vec<(usize, RegexCaptures)> = Vec::new();
+        for (atom_caps, sep_caps, end) in &chains {
+            let count = atom_caps.len();
+            if count < min {
+                continue;
+            }
+            if let Some(m) = max
+                && count > m
+            {
+                continue;
+            }
+            let assemble = |trailing: Option<&RegexCaptures>, end: usize| {
+                let mut caps = RegexCaptures::default();
+                caps.named_quantified.extend(names.iter().cloned());
+                Self::append_separated_captures(
+                    &mut caps,
+                    atom_caps,
+                    sep_caps,
+                    trailing,
+                    atom_stride,
+                    sep_stride,
+                );
+                (end, caps)
+            };
+            // Optional trailing separator for `%%`: prefer "with trailing" over
+            // "without" (Rakudo greedily consumes a trailing separator). Each
+            // trailing length is a separate candidate so an outer anchor can pick
+            // the length that lets the whole pattern match (`... %% (.+?) $`).
+            if sep.allow_trailing {
+                for (ts_end, ts_caps) in
+                    self.regex_match_ends_from_caps_in_pkg(&sep.pattern, chars, *end, pkg)
+                {
+                    if ts_end >= *end {
+                        out.push(assemble(Some(&ts_caps), ts_end));
+                    }
+                }
+            }
+            out.push(assemble(None, *end));
+        }
+        // Zero iterations (when `min == 0`) is the lowest-priority outcome for a
+        // greedy quantifier, so it goes last in highest-priority-first order.
+        if min == 0 {
+            out.push((start, RegexCaptures::default()));
+        }
+        out.reverse();
+        out
+    }
+
+    /// Ratcheted (`token`/`rule`) separated quantifier: possessive linear scan.
+    /// Ratchet forbids backtracking into the quantifier, so each step commits
+    /// to the separator's and the atom's single highest-priority match and the
+    /// whole quantifier yields at most one candidate. This matches Rakudo:
+    /// `my token T { <[ab]>+ % ',' ',b' }` does NOT match "a,b" (the chain
+    /// possessively consumes all of it) while the backtracking `regex` variant
+    /// does. It is also what keeps grammar rules linear: the general DFS in
+    /// `enumerate_separated_chains` goes exponential when sigspace turns the
+    /// atom/separator into groups with several same-end candidates (a 6-pair
+    /// JSON object under `rule pairlist { <pair> * % \, }` took ~8s to parse;
+    /// this scan parses it in microseconds).
+    fn match_separated_quantifier_ratchet(
+        &self,
+        token: &RegexToken,
+        chars: &[char],
+        start: usize,
+        pkg: &str,
+        pattern: &RegexPattern,
+    ) -> Vec<(usize, RegexCaptures)> {
+        let sep = token.separator.as_ref().expect("separator present");
+        let (min, max) = match &token.quant {
+            RegexQuant::OneOrMore => (1usize, None),
+            RegexQuant::ZeroOrMore => (0usize, None),
+            RegexQuant::Repeat(lo, hi) => (*lo, *hi),
+            // `?` / exact-one don't form a separator list; treat as one.
+            _ => (1usize, Some(1usize)),
+        };
+        // Frugal (`*? %`) under ratchet commits to the minimal count; greedy
+        // extends to `max` (or as far as the input allows).
+        let limit = if token.frugal { Some(min) } else { max };
+        let can_extend = |count: usize| limit.is_none_or(|m| count < m);
+
+        let empty = RegexCaptures::default();
+        let mut atom_caps: Vec<RegexCaptures> = Vec::new();
+        let mut sep_caps: Vec<RegexCaptures> = Vec::new();
+        let mut cur = start;
+        // Highest-priority atom match = the LAST candidate (the atom
+        // enumeration returns lowest priority first), mirroring the
+        // `RegexQuant::One` ratchet case. Deliberately the `_all_` enumeration
+        // and NOT the singular `regex_match_atom_with_capture_in_pkg`: the
+        // singular matcher's Named-atom path spawns a scratch sub-interpreter
+        // (plus a tail-text copy) per candidate per call, which is ~300x
+        // slower on nested grammar rules like `rule arraylist { <value> * %
+        // [\,] }` over `[[1,2,3],[4,5,6],[7,8,9]]`. A zero-width first atom
+        // means zero iterations (same zero-progress guard as the general
+        // path).
+        if can_extend(0)
+            && let Some((end, caps)) = self
+                .regex_match_atom_all_with_capture_in_pkg(
+                    &token.atom,
+                    chars,
+                    start,
+                    &empty,
+                    pkg,
+                    pattern.ignore_case,
+                )
+                .pop()
+            && end > start
+        {
+            atom_caps.push(caps);
+            cur = end;
+            while can_extend(atom_caps.len()) {
+                let Some((sep_end, scaps)) =
+                    self.regex_match_end_from_caps_in_pkg(&sep.pattern, chars, cur, pkg)
+                else {
+                    break;
+                };
+                let Some((atom_end, acaps)) = self
+                    .regex_match_atom_all_with_capture_in_pkg(
+                        &token.atom,
+                        chars,
+                        sep_end,
+                        &empty,
+                        pkg,
+                        pattern.ignore_case,
+                    )
+                    .pop()
+                else {
+                    break;
+                };
+                if atom_end <= cur {
+                    break;
+                }
+                sep_caps.push(scaps);
+                atom_caps.push(acaps);
+                cur = atom_end;
+            }
+        }
+        if atom_caps.len() < min {
+            // Ratchet cannot backtrack to satisfy `min`: the quantifier fails.
+            return Vec::new();
+        }
+        if atom_caps.is_empty() {
+            return vec![(start, RegexCaptures::default())];
+        }
+        let atom_stride = count_capture_groups(&token.atom);
+        let sep_stride: usize = sep
+            .pattern
+            .tokens
+            .iter()
+            .map(|t| count_capture_groups(&t.atom))
+            .sum();
+        let names = Self::collect_quantified_names_for_token(token);
+        let mut caps = RegexCaptures::default();
+        caps.named_quantified.extend(names.iter().cloned());
+        // Trailing separator for `%%`: Rakudo consumes it greedily, and
+        // ratchet commits to that single choice.
+        let mut end = cur;
+        let mut trailing: Option<RegexCaptures> = None;
+        if sep.allow_trailing
+            && let Some((ts_end, ts_caps)) =
+                self.regex_match_end_from_caps_in_pkg(&sep.pattern, chars, cur, pkg)
+            && ts_end >= cur
+        {
+            end = ts_end;
+            trailing = Some(ts_caps);
+        }
+        Self::append_separated_captures(
+            &mut caps,
+            &atom_caps,
+            &sep_caps,
+            trailing.as_ref(),
+            atom_stride,
+            sep_stride,
+        );
+        vec![(end, caps)]
+    }
+
+    /// Enumerate every `atom (sep atom)*` chain rooted at `start`, backtracking
+    /// the separator at each step. Each chain is `(atom_caps, sep_caps, end)`
+    /// with `sep_caps.len() == atom_caps.len() - 1`. Chains are returned
+    /// highest-priority first: for a greedy quantifier the longest chains come
+    /// first, and within a step separator matches follow their own priority
+    /// order. `max` bounds the atom count (atom count never exceeds `max`).
+    fn enumerate_separated_chains(
+        &self,
+        token: &RegexToken,
+        chars: &[char],
+        start: usize,
+        pkg: &str,
+        pattern: &RegexPattern,
+        max: Option<usize>,
+    ) -> Vec<(Vec<RegexCaptures>, Vec<RegexCaptures>, usize)> {
+        let mut chains: Vec<(Vec<RegexCaptures>, Vec<RegexCaptures>, usize)> = Vec::new();
+        let empty = RegexCaptures::default();
+        // First atom: enumerate EVERY match length (highest-priority first), not
+        // just the single highest-priority one. A frugal atom (`[[.]+?]`) matches
+        // as few chars as possible, but an outer anchor / goalpost following the
+        // separated quantifier (e.g. `'<' ~ '>' [<( [[.]+?]* %% SEP )>]`) may
+        // require the atom to expand. Taking only the shortest match would leave
+        // no candidate for that anchor and the whole pattern would fail to match.
+        let first_matches = self.regex_match_atom_all_with_capture_in_pkg(
+            &token.atom,
+            chars,
+            start,
+            &empty,
+            pkg,
+            pattern.ignore_case,
+        );
+        // `regex_match_atom_all_with_capture_in_pkg` returns lowest-priority
+        // first; iterate highest-priority first so the chains come out in
+        // highest-priority order for the engine.
+        for (end, caps) in first_matches.into_iter().rev() {
+            if end == start {
+                continue;
+            }
+            let mut atom_caps = vec![caps];
+            let mut sep_caps: Vec<RegexCaptures> = Vec::new();
+            self.extend_separated_chain(
+                token,
+                chars,
+                end,
+                pkg,
+                pattern,
+                max,
+                &mut atom_caps,
+                &mut sep_caps,
+                &mut chains,
+            );
+        }
+        chains
+    }
+
+    /// Recursive worker for `enumerate_separated_chains`. Extends the chain at
+    /// `cur` by trying every separator match (in priority order) followed by an
+    /// atom, recursing greedily first, then records the chain that stops at
+    /// `cur`. Pushing the deeper (longer) chains before the shorter one yields a
+    /// highest-priority-first ordering for a greedy quantifier.
+    #[allow(clippy::too_many_arguments)]
+    fn extend_separated_chain(
+        &self,
+        token: &RegexToken,
+        chars: &[char],
+        cur: usize,
+        pkg: &str,
+        pattern: &RegexPattern,
+        max: Option<usize>,
+        atom_caps: &mut Vec<RegexCaptures>,
+        sep_caps: &mut Vec<RegexCaptures>,
+        out: &mut Vec<(Vec<RegexCaptures>, Vec<RegexCaptures>, usize)>,
+    ) {
+        // Bound the chain count to avoid catastrophic backtracking on a frugal
+        // separator over a long string.
+        if out.len() > 20_000 {
+            return;
+        }
+        let empty = RegexCaptures::default();
+        let can_extend = max.is_none_or(|m| atom_caps.len() < m);
+        if can_extend {
+            for (sep_end, scaps) in self.regex_match_ends_from_caps_in_pkg(
+                &token.separator.as_ref().unwrap().pattern,
+                chars,
+                cur,
+                pkg,
+            ) {
+                // Enumerate every atom-match length after this separator
+                // (highest-priority first), mirroring the first-atom enumeration
+                // so a frugal atom can expand to satisfy a following anchor.
+                let atom_matches = self.regex_match_atom_all_with_capture_in_pkg(
+                    &token.atom,
+                    chars,
+                    sep_end,
+                    &empty,
+                    pkg,
+                    pattern.ignore_case,
+                );
+                for (atom_end, acaps) in atom_matches.into_iter().rev() {
+                    if atom_end <= cur {
+                        continue;
+                    }
+                    atom_caps.push(acaps);
+                    sep_caps.push(scaps.clone());
+                    self.extend_separated_chain(
+                        token, chars, atom_end, pkg, pattern, max, atom_caps, sep_caps, out,
+                    );
+                    atom_caps.pop();
+                    sep_caps.pop();
+                }
+            }
+        }
+        out.push((atom_caps.clone(), sep_caps.clone(), cur));
+    }
+
+    /// Append captures from a separated quantifier into `caps`, folding each
+    /// side into its own positional/named group lists.
+    fn append_separated_captures(
+        caps: &mut RegexCaptures,
+        atom_caps: &[RegexCaptures],
+        sep_caps: &[RegexCaptures],
+        trailing_sep: Option<&RegexCaptures>,
+        atom_stride: usize,
+        sep_stride: usize,
+    ) {
+        // Positional captures: atom groups occupy the first `atom_stride` slots,
+        // separator groups the next `sep_stride`.
+        for g in 0..atom_stride {
+            let mut list: Vec<QuantifiedCaptureEntry> = Vec::new();
+            let mut last_text = String::new();
+            let mut last_sub: Option<std::sync::Arc<RegexCaptures>> = None;
+            for ac in atom_caps {
+                if let Some(text) = ac.positional.get(g) {
+                    let (from, to) = ac.positional_offsets.get(g).copied().unwrap_or((0, 0));
+                    let sub = ac.positional_subcaps.get(g).cloned().flatten();
+                    list.push((text.clone(), from, to, sub.clone()));
+                    last_text = text.clone();
+                    last_sub = sub;
+                }
+            }
+            caps.positional.push(last_text);
+            caps.positional_subcaps.push(last_sub);
+            caps.positional_quantified.push(Some(list));
+            caps.positional_offsets.push((0, 0));
+        }
+        let mut all_sep: Vec<&RegexCaptures> = sep_caps.iter().collect();
+        if let Some(ts) = trailing_sep {
+            all_sep.push(ts);
+        }
+        for g in 0..sep_stride {
+            let mut list: Vec<QuantifiedCaptureEntry> = Vec::new();
+            let mut last_text = String::new();
+            let mut last_sub: Option<std::sync::Arc<RegexCaptures>> = None;
+            for sc in &all_sep {
+                if let Some(text) = sc.positional.get(g) {
+                    let (from, to) = sc.positional_offsets.get(g).copied().unwrap_or((0, 0));
+                    let sub = sc.positional_subcaps.get(g).cloned().flatten();
+                    list.push((text.clone(), from, to, sub.clone()));
+                    last_text = text.clone();
+                    last_sub = sub;
+                }
+            }
+            caps.positional.push(last_text);
+            caps.positional_subcaps.push(last_sub);
+            caps.positional_quantified.push(Some(list));
+            caps.positional_offsets.push((0, 0));
+        }
+        // Named captures: merge every iteration's named captures (as arrays).
+        for src in atom_caps.iter().chain(all_sep.iter().copied()) {
+            for (k, v) in &src.named {
+                caps.named.entry(k.clone()).or_default().extend(v.clone());
+                caps.named_quantified.insert(k.clone());
+            }
+            for (k, v) in &src.named_subcaps {
+                caps.named_subcaps
+                    .entry(k.clone())
+                    .or_default()
+                    .extend(v.clone());
+            }
+            for (k, v) in &src.hash_captures {
+                caps.hash_captures
+                    .entry(k.clone())
+                    .or_default()
+                    .extend(v.clone());
+            }
+        }
+    }
+}

--- a/src/runtime/regex/regex_token_method.rs
+++ b/src/runtime/regex/regex_token_method.rs
@@ -156,7 +156,6 @@ impl Interpreter {
         spec: &NamedRegexLookupSpec,
         chars: &[char],
         pos: usize,
-        current_caps: &RegexCaptures,
         pkg: &str,
         arg_values: &[Value],
     ) -> Option<Vec<(usize, RegexCaptures)>> {
@@ -266,7 +265,6 @@ impl Interpreter {
             pos,
             chars,
             spec,
-            current_caps,
             sym.as_ref(),
         ))
     }

--- a/src/runtime/regex/regex_trail.rs
+++ b/src/runtime/regex/regex_trail.rs
@@ -1,0 +1,630 @@
+//! Trail-based capture store for the backtracking regex engine (ADR-0007).
+//!
+//! One mutable `RegexCaptures` per pattern-level match, owned by the engine.
+//! Every mutation goes through `CapStore` methods, which push undo records
+//! onto the trail; `mark()` returns the current trail length and `rewind(mark)`
+//! pops records back to it, restoring the store to its state at the mark.
+//!
+//! Atom candidate producers return *deltas* — `RegexCaptures` values built
+//! relative to an empty baseline (typically an inner engine run's output plus
+//! small additions). The engine applies a candidate with `merge_delta`,
+//! descends, and rewinds on backtrack, so per-step capture cost is O(delta)
+//! instead of O(accumulated state).
+//!
+//! Thread-local side channels (`LR_MEMO`/`LR_ACTIVE`, `EAGER_CODE_BLOCKS`,
+//! `PENDING_REGEX_ERROR`, goal failures) are deliberately NOT trailed: errors
+//! and goal failures persist across backtracks by design.
+
+use super::super::*;
+
+/// Which string-keyed multi-map a `MapVec` undo record refers to.
+#[derive(Clone, Copy)]
+pub(super) enum MapId {
+    Named,
+    NamedSub,
+    HashCap,
+}
+
+/// Saved tails for a positional-block truncation (values moved out, moved
+/// back on rewind). Boxed to keep `Undo` small.
+pub(super) struct PosTailRec {
+    p_at: usize,
+    p: Vec<String>,
+    sc_at: usize,
+    sc: Vec<Option<Arc<RegexCaptures>>>,
+    q_at: usize,
+    q: Vec<Option<Vec<QuantifiedCaptureEntry>>>,
+    off_at: usize,
+    off: Vec<(usize, usize)>,
+}
+
+pub(super) enum Undo {
+    /// Truncate the positional block back to these lengths (undoes appends).
+    PosLens {
+        p: usize,
+        sc: usize,
+        q: usize,
+        off: usize,
+        nil: usize,
+    },
+    /// Restore previously truncated positional tails (truncate to `*_at`,
+    /// then re-extend with the saved values).
+    PosTail(Box<PosTailRec>),
+    /// Restore a single overwritten positional entry (`$N=` alias writes).
+    PosOverwrite {
+        idx: usize,
+        text: Option<String>,
+        sc: Option<Option<Arc<RegexCaptures>>>,
+        q: Option<Option<Vec<QuantifiedCaptureEntry>>>,
+        off: Option<(usize, usize)>,
+    },
+    /// Truncate `map[key]` to `len`; remove the key if it was newly created.
+    MapVecTrunc {
+        which: MapId,
+        key: String,
+        len: usize,
+        present: bool,
+    },
+    /// Remove a `named_quantified` entry that this frame inserted.
+    NamedQuantRemove(String),
+    /// Restore a `capture_alias_map` entry (None = remove).
+    AliasRestore {
+        key: String,
+        prev: Option<String>,
+    },
+    /// Restore a `regex_vars` entry (None = remove).
+    RegexVarRestore {
+        key: String,
+        prev: Option<Value>,
+    },
+    CodeBlocksLen(usize),
+    CaptureStart(Option<usize>),
+    CaptureEnd(Option<usize>),
+    Sym(Option<String>),
+}
+
+/// The engine's single mutable capture store + undo trail.
+pub(super) struct CapStore {
+    caps: RegexCaptures,
+    trail: Vec<Undo>,
+}
+
+impl CapStore {
+    pub(super) fn new(init: RegexCaptures) -> Self {
+        CapStore {
+            caps: init,
+            trail: Vec::new(),
+        }
+    }
+
+    /// Read access to the accumulated captures (backrefs, code assertions,
+    /// argument evaluation, pos_base reads).
+    #[inline]
+    pub(super) fn caps(&self) -> &RegexCaptures {
+        &self.caps
+    }
+
+    /// Clone the accumulated captures — used once per complete match to
+    /// materialize an engine result. Nested sub-captures are `Arc`-shared, so
+    /// this copies only this pattern level's own state.
+    pub(super) fn snapshot(&self) -> RegexCaptures {
+        self.caps.clone()
+    }
+
+    #[inline]
+    pub(super) fn mark(&self) -> usize {
+        self.trail.len()
+    }
+
+    /// Rewind the store to its state at `mark` by undoing records in reverse.
+    pub(super) fn rewind(&mut self, mark: usize) {
+        while self.trail.len() > mark {
+            let rec = self.trail.pop().expect("trail entry");
+            let caps = &mut self.caps;
+            match rec {
+                Undo::PosLens { p, sc, q, off, nil } => {
+                    caps.positional.truncate(p);
+                    caps.positional_subcaps.truncate(sc);
+                    caps.positional_quantified.truncate(q);
+                    caps.positional_offsets.truncate(off);
+                    caps.positional_nil.truncate(nil);
+                }
+                Undo::PosTail(rec) => {
+                    let r = *rec;
+                    caps.positional.truncate(r.p_at);
+                    caps.positional.extend(r.p);
+                    caps.positional_subcaps.truncate(r.sc_at);
+                    caps.positional_subcaps.extend(r.sc);
+                    caps.positional_quantified.truncate(r.q_at);
+                    caps.positional_quantified.extend(r.q);
+                    caps.positional_offsets.truncate(r.off_at);
+                    caps.positional_offsets.extend(r.off);
+                }
+                Undo::PosOverwrite {
+                    idx,
+                    text,
+                    sc,
+                    q,
+                    off,
+                } => {
+                    if let Some(text) = text
+                        && idx < caps.positional.len()
+                    {
+                        caps.positional[idx] = text;
+                    }
+                    if let Some(sc) = sc
+                        && idx < caps.positional_subcaps.len()
+                    {
+                        caps.positional_subcaps[idx] = sc;
+                    }
+                    if let Some(q) = q
+                        && idx < caps.positional_quantified.len()
+                    {
+                        caps.positional_quantified[idx] = q;
+                    }
+                    if let Some(off) = off
+                        && idx < caps.positional_offsets.len()
+                    {
+                        caps.positional_offsets[idx] = off;
+                    }
+                }
+                Undo::MapVecTrunc {
+                    which,
+                    key,
+                    len,
+                    present,
+                } => match which {
+                    MapId::Named => {
+                        if !present {
+                            caps.named.remove(&key);
+                        } else if let Some(v) = caps.named.get_mut(&key) {
+                            v.truncate(len);
+                        }
+                    }
+                    MapId::NamedSub => {
+                        if !present {
+                            caps.named_subcaps.remove(&key);
+                        } else if let Some(v) = caps.named_subcaps.get_mut(&key) {
+                            v.truncate(len);
+                        }
+                    }
+                    MapId::HashCap => {
+                        if !present {
+                            caps.hash_captures.remove(&key);
+                        } else if let Some(v) = caps.hash_captures.get_mut(&key) {
+                            v.truncate(len);
+                        }
+                    }
+                },
+                Undo::NamedQuantRemove(key) => {
+                    caps.named_quantified.remove(&key);
+                }
+                Undo::AliasRestore { key, prev } => match prev {
+                    Some(v) => {
+                        caps.capture_alias_map.insert(key, v);
+                    }
+                    None => {
+                        caps.capture_alias_map.remove(&key);
+                    }
+                },
+                Undo::RegexVarRestore { key, prev } => match prev {
+                    Some(v) => {
+                        caps.regex_vars.insert(key, v);
+                    }
+                    None => {
+                        caps.regex_vars.remove(&key);
+                    }
+                },
+                Undo::CodeBlocksLen(len) => caps.code_blocks.truncate(len),
+                Undo::CaptureStart(prev) => caps.capture_start = prev,
+                Undo::CaptureEnd(prev) => caps.capture_end = prev,
+                Undo::Sym(prev) => caps.sym = prev,
+            }
+        }
+    }
+
+    /// Record the current positional-block lengths so appends since this point
+    /// can be undone by truncation.
+    fn record_pos_lens(&mut self) {
+        self.trail.push(Undo::PosLens {
+            p: self.caps.positional.len(),
+            sc: self.caps.positional_subcaps.len(),
+            q: self.caps.positional_quantified.len(),
+            off: self.caps.positional_offsets.len(),
+            nil: self.caps.positional_nil.len(),
+        });
+    }
+
+    fn record_named_key(&mut self, key: &str) {
+        let (len, present) = match self.caps.named.get(key) {
+            Some(v) => (v.len(), true),
+            None => (0, false),
+        };
+        self.trail.push(Undo::MapVecTrunc {
+            which: MapId::Named,
+            key: key.to_string(),
+            len,
+            present,
+        });
+    }
+
+    fn record_named_sub_key(&mut self, key: &str) {
+        let (len, present) = match self.caps.named_subcaps.get(key) {
+            Some(v) => (v.len(), true),
+            None => (0, false),
+        };
+        self.trail.push(Undo::MapVecTrunc {
+            which: MapId::NamedSub,
+            key: key.to_string(),
+            len,
+            present,
+        });
+    }
+
+    fn record_hash_cap_key(&mut self, key: &str) {
+        let (len, present) = match self.caps.hash_captures.get(key) {
+            Some(v) => (v.len(), true),
+            None => (0, false),
+        };
+        self.trail.push(Undo::MapVecTrunc {
+            which: MapId::HashCap,
+            key: key.to_string(),
+            len,
+            present,
+        });
+    }
+
+    /// Apply a candidate delta (a `RegexCaptures` built relative to an empty
+    /// baseline) to the store, recording undo. Merges exactly the fields the
+    /// old by-value merge paths handled: named/named_subcaps/named_quantified,
+    /// capture_alias_map, the positional block (incl. offsets), code_blocks,
+    /// hash_captures, regex_vars, capture markers, and sym.
+    /// `positional_nil`/`positional_slots` and the per-level metadata
+    /// (matched/from/to/match_from) are intentionally NOT merged.
+    pub(super) fn merge_delta(&mut self, mut delta: RegexCaptures) {
+        for (k, v) in delta.named.drain() {
+            self.record_named_key(&k);
+            self.caps.named.entry(k).or_default().extend(v);
+        }
+        for (k, v) in delta.named_subcaps.drain() {
+            self.record_named_sub_key(&k);
+            self.caps.named_subcaps.entry(k).or_default().extend(v);
+        }
+        for k in delta.named_quantified.drain() {
+            self.insert_named_quantified(k);
+        }
+        for (k, v) in delta.capture_alias_map.drain() {
+            self.insert_alias(k, v);
+        }
+        if !delta.positional.is_empty()
+            || !delta.positional_subcaps.is_empty()
+            || !delta.positional_quantified.is_empty()
+            || !delta.positional_offsets.is_empty()
+        {
+            self.record_pos_lens();
+            self.caps.positional.append(&mut delta.positional);
+            self.caps
+                .positional_subcaps
+                .append(&mut delta.positional_subcaps);
+            self.caps
+                .positional_quantified
+                .append(&mut delta.positional_quantified);
+            self.caps
+                .positional_offsets
+                .append(&mut delta.positional_offsets);
+        }
+        if !delta.code_blocks.is_empty() {
+            self.trail
+                .push(Undo::CodeBlocksLen(self.caps.code_blocks.len()));
+            self.caps.code_blocks.append(&mut delta.code_blocks);
+        }
+        for (k, v) in delta.hash_captures.drain() {
+            self.record_hash_cap_key(&k);
+            self.caps.hash_captures.entry(k).or_default().extend(v);
+        }
+        for (k, v) in delta.regex_vars.drain() {
+            let prev = self.caps.regex_vars.insert(k.clone(), v);
+            self.trail.push(Undo::RegexVarRestore { key: k, prev });
+        }
+        if delta.capture_start.is_some() {
+            self.trail.push(Undo::CaptureStart(self.caps.capture_start));
+            self.caps.capture_start = delta.capture_start;
+        }
+        if delta.capture_end.is_some() {
+            self.trail.push(Undo::CaptureEnd(self.caps.capture_end));
+            self.caps.capture_end = delta.capture_end;
+        }
+        if delta.sym.is_some() {
+            self.trail.push(Undo::Sym(self.caps.sym.take()));
+            self.caps.sym = delta.sym;
+        }
+    }
+
+    pub(super) fn push_named(&mut self, key: &str, val: String) {
+        self.record_named_key(key);
+        self.caps
+            .named
+            .entry(key.to_string())
+            .or_default()
+            .push(val);
+    }
+
+    pub(super) fn push_named_subcap(&mut self, key: &str, sub: Arc<RegexCaptures>) {
+        self.record_named_sub_key(key);
+        self.caps
+            .named_subcaps
+            .entry(key.to_string())
+            .or_default()
+            .push(sub);
+    }
+
+    pub(super) fn insert_named_quantified(&mut self, name: String) {
+        if self.caps.named_quantified.insert(name.clone()) {
+            self.trail.push(Undo::NamedQuantRemove(name));
+        }
+    }
+
+    pub(super) fn insert_alias(&mut self, key: String, val: String) {
+        let prev = self.caps.capture_alias_map.insert(key.clone(), val);
+        self.trail.push(Undo::AliasRestore { key, prev });
+    }
+
+    pub(super) fn push_hash_capture(&mut self, key: &str, entry: (String, Option<String>)) {
+        self.record_hash_cap_key(key);
+        self.caps
+            .hash_captures
+            .entry(key.to_string())
+            .or_default()
+            .push(entry);
+    }
+
+    /// Append one positional entry (text + subcap + quantified + offsets).
+    pub(super) fn push_positional(
+        &mut self,
+        text: String,
+        subcap: Option<Arc<RegexCaptures>>,
+        quantified: Option<Vec<QuantifiedCaptureEntry>>,
+        offsets: (usize, usize),
+    ) {
+        self.record_pos_lens();
+        self.caps.positional.push(text);
+        self.caps.positional_subcaps.push(subcap);
+        self.caps.positional_quantified.push(quantified);
+        self.caps.positional_offsets.push(offsets);
+    }
+
+    /// Truncate the positional text/subcap/quantified vecs to `to`, saving the
+    /// removed tails so rewind can restore them (the `$<name>=(...)` alias
+    /// surgery drops the group's auto-positional entry). `positional_offsets`
+    /// is left untouched, mirroring the old named-alias path.
+    pub(super) fn truncate_positional_3(&mut self, to: usize) {
+        let p = split_off_clamped(&mut self.caps.positional, to);
+        let sc = split_off_clamped(&mut self.caps.positional_subcaps, to);
+        let q = split_off_clamped(&mut self.caps.positional_quantified, to);
+        self.trail.push(Undo::PosTail(Box::new(PosTailRec {
+            p_at: self.caps.positional.len(),
+            p,
+            sc_at: self.caps.positional_subcaps.len(),
+            sc,
+            q_at: self.caps.positional_quantified.len(),
+            q,
+            off_at: self.caps.positional_offsets.len(),
+            off: Vec::new(),
+        })));
+    }
+
+    /// Truncate all four positional vecs to `to` (the `$N=` alias path).
+    pub(super) fn truncate_positional_4(&mut self, to: usize) {
+        let p = split_off_clamped(&mut self.caps.positional, to);
+        let sc = split_off_clamped(&mut self.caps.positional_subcaps, to);
+        let q = split_off_clamped(&mut self.caps.positional_quantified, to);
+        let off = split_off_clamped(&mut self.caps.positional_offsets, to);
+        self.trail.push(Undo::PosTail(Box::new(PosTailRec {
+            p_at: self.caps.positional.len(),
+            p,
+            sc_at: self.caps.positional_subcaps.len(),
+            sc,
+            q_at: self.caps.positional_quantified.len(),
+            q,
+            off_at: self.caps.positional_offsets.len(),
+            off,
+        })));
+    }
+
+    /// Overwrite the positional entry at `idx` (`$N=` re-assigning an existing
+    /// slot), saving the previous values.
+    pub(super) fn overwrite_positional(&mut self, idx: usize, text: String, off: (usize, usize)) {
+        let caps = &mut self.caps;
+        let prev_text = if idx < caps.positional.len() {
+            Some(std::mem::replace(&mut caps.positional[idx], text))
+        } else {
+            None
+        };
+        let prev_off = if idx < caps.positional_offsets.len() {
+            Some(std::mem::replace(&mut caps.positional_offsets[idx], off))
+        } else {
+            None
+        };
+        let prev_sc = if idx < caps.positional_subcaps.len() {
+            Some(caps.positional_subcaps[idx].take())
+        } else {
+            None
+        };
+        let prev_q = if idx < caps.positional_quantified.len() {
+            Some(caps.positional_quantified[idx].take())
+        } else {
+            None
+        };
+        self.trail.push(Undo::PosOverwrite {
+            idx,
+            text: prev_text,
+            sc: prev_sc,
+            q: prev_q,
+            off: prev_off,
+        });
+    }
+
+    /// Trailed `reserve_nil_capture_slots` (unmatched `(x)?` Nil reservation).
+    pub(super) fn reserve_nil(&mut self, stride: usize) {
+        if stride == 0 {
+            return;
+        }
+        self.record_pos_lens();
+        super::regex_helpers::reserve_nil_capture_slots(&mut self.caps, stride);
+    }
+
+    /// Trailed `fold_quantified_captures`: save the unfolded tail, then fold.
+    pub(super) fn fold_quantified(&mut self, base_len: usize, stride: usize) {
+        if stride == 0 {
+            return;
+        }
+        // Save the whole tail from base_len (clamped per vec) so rewind can
+        // restore the unfolded state exactly, including the padding fold adds.
+        let p = split_off_clamped(&mut self.caps.positional, base_len);
+        let sc = split_off_clamped(&mut self.caps.positional_subcaps, base_len);
+        let q = split_off_clamped(&mut self.caps.positional_quantified, base_len);
+        let off = split_off_clamped(&mut self.caps.positional_offsets, base_len);
+        let rec = PosTailRec {
+            p_at: self.caps.positional.len(),
+            p,
+            sc_at: self.caps.positional_subcaps.len(),
+            sc,
+            q_at: self.caps.positional_quantified.len(),
+            q,
+            off_at: self.caps.positional_offsets.len(),
+            off,
+        };
+        // Re-extend with clones for fold to consume; the saved originals are
+        // the undo. Rewind truncates each vec to its `*_at` cut point (removing
+        // whatever fold produced above it) and re-extends the saved tail,
+        // restoring the exact unfolded state.
+        self.caps.positional.extend(rec.p.iter().cloned());
+        self.caps.positional_subcaps.extend(rec.sc.iter().cloned());
+        self.caps
+            .positional_quantified
+            .extend(rec.q.iter().cloned());
+        self.caps.positional_offsets.extend(rec.off.iter().cloned());
+        self.trail.push(Undo::PosTail(Box::new(rec)));
+        super::regex_helpers::fold_quantified_captures(&mut self.caps, base_len, stride);
+    }
+}
+
+/// `Vec::split_off` clamped: splitting at an index past the end returns empty.
+fn split_off_clamped<T>(v: &mut Vec<T>, at: usize) -> Vec<T> {
+    if at >= v.len() {
+        Vec::new()
+    } else {
+        v.split_off(at)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::RegexCaptures;
+    use super::CapStore;
+
+    fn store_with_base() -> CapStore {
+        let mut init = RegexCaptures::default();
+        init.positional.push("a".to_string());
+        init.positional_subcaps.push(None);
+        init.positional_quantified.push(None);
+        init.positional_offsets.push((0, 1));
+        init.named
+            .entry("x".to_string())
+            .or_default()
+            .push("v".to_string());
+        CapStore::new(init)
+    }
+
+    fn assert_base(store: &CapStore) {
+        assert_eq!(store.caps().positional, vec!["a".to_string()]);
+        assert_eq!(store.caps().positional_offsets, vec![(0, 1)]);
+        assert_eq!(store.caps().named.len(), 1);
+        assert_eq!(store.caps().named["x"], vec!["v".to_string()]);
+        assert!(store.caps().named_subcaps.is_empty());
+        assert!(store.caps().capture_start.is_none());
+        assert!(store.caps().sym.is_none());
+    }
+
+    #[test]
+    fn merge_delta_rewind_roundtrip() {
+        let mut store = store_with_base();
+        let m = store.mark();
+        let mut delta = RegexCaptures::default();
+        delta.positional.push("b".to_string());
+        delta.positional_subcaps.push(None);
+        delta.positional_quantified.push(None);
+        delta.positional_offsets.push((1, 2));
+        delta
+            .named
+            .entry("x".to_string())
+            .or_default()
+            .push("v2".to_string());
+        delta
+            .named
+            .entry("y".to_string())
+            .or_default()
+            .push("w".to_string());
+        delta.named_quantified.insert("y".to_string());
+        delta.capture_start = Some(3);
+        delta.sym = Some("s".to_string());
+        store.merge_delta(delta);
+        assert_eq!(store.caps().positional.len(), 2);
+        assert_eq!(store.caps().named["x"].len(), 2);
+        assert_eq!(store.caps().named["y"], vec!["w".to_string()]);
+        assert!(store.caps().named_quantified.contains("y"));
+        assert_eq!(store.caps().capture_start, Some(3));
+        assert_eq!(store.caps().sym.as_deref(), Some("s"));
+        store.rewind(m);
+        assert_base(&store);
+        assert!(!store.caps().named_quantified.contains("y"));
+    }
+
+    #[test]
+    fn truncate_and_overwrite_rewind() {
+        let mut store = store_with_base();
+        let m = store.mark();
+        store.push_positional("b".to_string(), None, None, (1, 2));
+        store.truncate_positional_4(0);
+        assert!(store.caps().positional.is_empty());
+        store.push_positional("c".to_string(), None, None, (5, 6));
+        store.overwrite_positional(0, "z".to_string(), (9, 9));
+        assert_eq!(store.caps().positional, vec!["z".to_string()]);
+        store.rewind(m);
+        assert_base(&store);
+    }
+
+    #[test]
+    fn fold_rewind_restores_unfolded() {
+        let mut store = store_with_base();
+        let m = store.mark();
+        // Two iterations of a 1-stride capture: entries at idx 1 and 2.
+        store.push_positional("b".to_string(), None, None, (1, 2));
+        store.push_positional("c".to_string(), None, None, (2, 3));
+        let mf = store.mark();
+        store.fold_quantified(1, 1);
+        assert_eq!(store.caps().positional.len(), 2); // folded into one slot
+        assert!(store.caps().positional_quantified[1].is_some());
+        store.rewind(mf);
+        assert_eq!(store.caps().positional.len(), 3);
+        assert_eq!(store.caps().positional[2], "c");
+        assert!(store.caps().positional_quantified[2].is_none());
+        store.rewind(m);
+        assert_base(&store);
+    }
+
+    #[test]
+    fn nested_marks_rewind_in_order() {
+        let mut store = store_with_base();
+        let m1 = store.mark();
+        store.push_named("k", "1".to_string());
+        let m2 = store.mark();
+        store.push_named("k", "2".to_string());
+        store.push_named_subcap("k", std::sync::Arc::new(RegexCaptures::default()));
+        store.rewind(m2);
+        assert_eq!(store.caps().named["k"], vec!["1".to_string()]);
+        assert!(store.caps().named_subcaps.is_empty());
+        store.rewind(m1);
+        assert!(!store.caps().named.contains_key("k"));
+    }
+}


### PR DESCRIPTION
Implements ADR-0007: replaces by-value `RegexCaptures` threading through the backtracking
search with **one mutable capture store per pattern level + an undo-log (trail)**.

## What changed

- **`regex_trail.rs` (new)**: `CapStore` — the engine's single mutable `RegexCaptures` +
  a `Vec<Undo>` trail. `mark()`/`rewind(mark)` restore the store exactly on backtrack.
  Undo vocabulary: positional-block length truncation, saved-tail restore (alias/fold
  surgery), `$N=` mid-vector overwrite restore, per-key map truncation, scalar restores.
  Unit-tested round-trips.
- **`regex_match_core.rs` (rewritten)**: the LIFO stack walk carrying owned caps per entry
  is now a recursive DFS over tokens: apply candidate delta → descend → rewind. Quantifier
  chains grow/shrink on the store with a mark per iteration (greedy descends longest-first
  by rewinding; frugal grows on demand); `quant_expand_greedy` (which materialized the
  whole per-iteration alternative tree with a full caps clone per node) is now the
  trail-based `quant_alt_dfs`. `apply_named_capture`/`apply_hash_capture` closures became
  store surgery with undo. Candidate priority order is preserved exactly (producers still
  return lowest-priority-first; the walk iterates in reverse).
- **Atom producers return deltas**: `regex_match_atom_all_with_capture_in_pkg`,
  `regex_match_atom_with_capture_in_pkg`, `match_separated_quantifier`, and
  `build_named_candidates_from_inner` now build candidates relative to an EMPTY baseline
  (`current_caps.clone()` → `RegexCaptures::default()`, ~30 sites). `current_caps` stays a
  read-only context (backrefs, code assertions, subrule-arg evaluation). Since every
  producer only ever *appended* to the cloned base, each branch's append code is unchanged
  — the per-branch merge-field subsets are preserved exactly.
- **`regex_match_sep.rs` (split from core)**: separated quantifiers, candidates as deltas
  (the per-candidate `base_caps.clone()` is gone).
- Thread-local side channels (`LR_MEMO`, `EAGER_CODE_BLOCKS`, `PENDING_REGEX_ERROR`,
  goal failures) are deliberately NOT rewound, per the ADR hazards section.

## Measured (local release A/B vs main, same machine)

- `bench-grammar-parse-deep`: ~×1.25 (perf sample count 11872 → 9449; memmove 15.4% → 7.5%
  of samples; `RegexCaptures::clone` 2.1% → 1.0%)
- `bench-grammar-parse` (shallow): ~×1.2
- The per-step O(accumulated) clone is structurally gone. The residual cost is per-subrule
  ceremony (allocator traffic ~36%: candidate vecs / captured Strings / Arc subcaps /
  HashMap+SipHash ops; runtime regex re-parse ~4% — also present on main) — follow-up
  slices tracked in PLAN §5.

## Validation

- `make test` full suite: PASS
- roast S05 whitelist (93 files, 5524 tests): PASS locally
- `t/` regex/grammar/match/subst (100 files, 884 tests): PASS
- `t/regex-sep-quantifier-ratchet.t` + `S04-exceptions/exceptions-alternatives.t`
  (the exponential-backtracking pins): PASS
- trail unit tests (mark/apply/rewind round-trips incl. fold and `$N=` overwrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)