### PR TITLE
perf: extend the light call path to mixed positional+named signatures

### DIFF
--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -3690,14 +3690,35 @@ pub(crate) type CompiledFns = rustc_hash::FxHashMap<String, CompiledFunction>;
 /// Precomputed bind plan for the light named-call path: what
 /// `call_compiled_function_light`'s binding loop needs per call, derived once
 /// per `CompiledFunction` instead of re-deriving match keys / locals slots /
-/// env-mirror gates from strings on every call.
+/// env-mirror gates from strings on every call. Built whenever the signature
+/// has at least one named parameter (all-named or mixed positional+named).
 #[derive(Clone, Debug)]
 pub(crate) struct NamedCallPlan {
-    /// One entry per (named) parameter, in `param_defs` order.
-    pub(crate) params: Vec<NamedParamBind>,
+    /// One entry per parameter, in `param_defs` order.
+    pub(crate) params: Vec<LightParamBind>,
     /// Whether the body reads `@_` (has a `@_` local), so the caller's
     /// positional args must be materialized into it.
     pub(crate) uses_arg_array: bool,
+    /// Number of positional (non-named) parameters, for arity errors.
+    pub(crate) positional_count: usize,
+}
+
+/// One parameter's bind entry in a [`NamedCallPlan`].
+#[derive(Clone, Debug)]
+pub(crate) enum LightParamBind {
+    Positional(PositionalParamBind),
+    Named(NamedParamBind),
+}
+
+/// Per-positional-parameter entry of a [`NamedCallPlan`] (mixed signatures).
+#[derive(Clone, Debug)]
+pub(crate) struct PositionalParamBind {
+    /// The parameter's locals slot (by `pd.name`), when it has one.
+    pub(crate) slot: Option<usize>,
+    /// Whether the bound value must also be written into the overlay env.
+    pub(crate) needs_env: bool,
+    /// Whether the parameter is required (missing => arity error).
+    pub(crate) required: bool,
 }
 
 /// Per-parameter entry of a [`NamedCallPlan`].
@@ -3830,7 +3851,7 @@ impl CompiledFunction {
 
     /// Pre-compute the light named-call bind plan (see [`NamedCallPlan`]).
     pub(crate) fn precompute_named_call_plan(&mut self) {
-        if self.param_defs.is_empty() || !self.param_defs.iter().all(|pd| pd.named) {
+        if self.param_defs.is_empty() || !self.param_defs.iter().any(|pd| pd.named) {
             return;
         }
         let slot_of = |name: &str| self.code.locals.iter().position(|n| n == name);
@@ -3842,7 +3863,21 @@ impl CompiledFunction {
             None => true,
         };
         let mut params = Vec::with_capacity(self.param_defs.len());
+        let mut positional_count = 0usize;
         for pd in &self.param_defs {
+            if !pd.named {
+                positional_count += 1;
+                let slot = slot_of(&pd.name);
+                params.push(LightParamBind::Positional(PositionalParamBind {
+                    slot,
+                    needs_env: needs_env_of(slot),
+                    // A positional is required unless explicitly optional
+                    // (`$x?`) or defaulted (`pd.required` is the NAMED `!`
+                    // marker and is false for a plain `$x`).
+                    required: !pd.optional_marker && pd.default.is_none(),
+                }));
+                continue;
+            }
             let match_key = pd
                 .name
                 .strip_prefix('@')
@@ -3883,7 +3918,7 @@ impl CompiledFunction {
                     );
                 }
             }
-            params.push(NamedParamBind {
+            params.push(LightParamBind::Named(NamedParamBind {
                 match_key,
                 slot,
                 needs_env: needs_env_of(slot),
@@ -3891,11 +3926,12 @@ impl CompiledFunction {
                 alias_keys,
                 alias_binds,
                 outer_alias_keys,
-            });
+            }));
         }
         self.named_call_plan = Some(Box::new(NamedCallPlan {
             params,
             uses_arg_array: self.code.locals.iter().any(|n| n == "@_"),
+            positional_count,
         }));
     }
 

--- a/src/vm/vm_call_eligibility.rs
+++ b/src/vm/vm_call_eligibility.rs
@@ -42,19 +42,19 @@ impl Interpreter {
     }
 
     /// Check if a compiled function is eligible for the light call path.
-    /// Light calls avoid the expensive env clone/restore cycle by directly
-    /// binding parameters and restoring them after the call. This is safe
-    /// for simple functions that don't need callframe/caller introspection,
-    /// don't have where constraints, state variables, or return type checks.
-    /// Check if a compiled function is eligible for the light call path.
     /// The light call skips the heavyweight env clone/restore, Sub value
     /// creation, block/routine push, and callable_id lookup. It does inline
-    /// argument binding with minimal overhead.
+    /// argument binding (via the precomputed `NamedCallPlan`) with minimal
+    /// overhead.
     ///
-    /// Currently restricted to functions where ALL param_defs are named
-    /// (no positional params) to avoid correctness issues with positional
-    /// argument binding edge cases (optional arrays, @_, VarRef unwrapping, etc.).
-    /// Also excludes functions with legacy placeholder params (cf.params).
+    /// Covers signatures with at least one named parameter — all-named or
+    /// mixed positional+named. (All-positional signatures take the
+    /// positional-light path instead; keeping them out of this one preserves
+    /// the existing routing.) Positional parameters are held to the
+    /// positional-light rules (no optionals/sub-signatures, fast-checkable
+    /// type constraints, plain `$` scalars only); named parameters to the
+    /// prior all-named light rules. Legacy placeholder params (`cf.params`)
+    /// never coexist with a non-empty `param_defs`, so they stay excluded.
     pub(super) fn is_light_call_eligible(cf: &CompiledFunction, fn_name: &str) -> bool {
         !fn_name.is_empty()
             && cf.return_type.is_none()
@@ -65,17 +65,38 @@ impl Interpreter {
             // A `once` needs the clone-id setup only the full call path performs.
             && !cf.code.has_once
             && !cf.param_defs.is_empty()
+            && cf.param_defs.iter().any(|pd| pd.named)
             && cf.param_defs.iter().all(|pd| {
-                pd.named
-                    && pd.where_constraint.is_none()
+                let common = pd.where_constraint.is_none()
                     && !pd.slurpy
                     && !pd.double_slurpy
                     && pd.default.is_none()
-                    && pd.type_constraint.is_none()
                     && pd.code_signature.is_none()
                     && !pd.sigilless
                     && !pd.is_invocant
-                    && pd.traits.is_empty()
+                    && pd.traits.is_empty();
+                if !common {
+                    return false;
+                }
+                if pd.named {
+                    pd.type_constraint.is_none()
+                } else {
+                    // Positional params in a mixed signature: the
+                    // positional-light constraints (see
+                    // `is_positional_light_call_eligible`).
+                    !pd.optional_marker
+                        && pd.sub_signature.is_none()
+                        && pd
+                            .type_constraint
+                            .as_deref()
+                            .is_none_or(Self::is_fast_type_name)
+                        && !pd.name.starts_with('@')
+                        && !pd.name.starts_with('%')
+                        && !pd.name.starts_with('&')
+                        && !pd.name.starts_with("__")
+                        && !pd.name.starts_with('*')
+                        && pd.name != "_"
+                }
             })
     }
 

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -295,8 +295,19 @@ impl Interpreter {
                             decoded.as_deref(),
                         )
                     };
+                    // Junction autothreading happens in the slow dispatch
+                    // (maybe_autothread_func_call), which this cache hit
+                    // bypasses. A Junction in a positional slot of a mixed
+                    // signature must still thread, so skip the fast path
+                    // (named-only signatures never autothread, but the scan
+                    // is one view check per arg either way).
+                    let has_junction = self.stack.len() >= arity_usize
+                        && self.stack[self.stack.len() - arity_usize..]
+                            .iter()
+                            .any(|v| matches!(v.view(), ValueView::Junction { .. }));
                     if self.stack.len() >= arity_usize
                         && !named_share
+                        && !has_junction
                         && !Self::call_shares_container_into_scalar_param(
                             cf,
                             &self.stack[self.stack.len() - arity_usize..],
@@ -313,7 +324,9 @@ impl Interpreter {
                         if cl.is_some() {
                             loan_env!(self, set_pending_callsite_line(cl));
                         }
-                        let result = self.call_compiled_function_light(cf, &args, compiled_fns);
+                        let name_str = Self::const_str(code, name_idx);
+                        let result =
+                            self.call_compiled_function_light(cf, &args, compiled_fns, name_str);
                         self.recycle_locals(args);
                         self.stack.push(result?);
                         // Slice F: drain captured-outer writes through to this
@@ -374,11 +387,17 @@ impl Interpreter {
                             &args,
                             decoded_sources.as_deref(),
                         );
+                        // A Junction arg must reach the slow dispatch, which
+                        // autothreads it (this cache hit bypasses that check).
+                        let has_junction = args
+                            .iter()
+                            .any(|v| matches!(v.view(), ValueView::Junction { .. }));
                         let result = if !share_into_scalar
                             && !named_share
+                            && !has_junction
                             && Self::is_light_call_eligible(&cf, name_str)
                         {
-                            self.call_compiled_function_light(&cf, &args, compiled_fns)
+                            self.call_compiled_function_light(&cf, &args, compiled_fns, name_str)
                         } else if !share_into_scalar
                             && !named_share
                             && Self::is_positional_light_call_eligible(&cf, name_str)
@@ -1103,7 +1122,7 @@ impl Interpreter {
                             }
                         }
                     }
-                    let result = self.call_compiled_function_light(cf, &args, compiled_fns);
+                    let result = self.call_compiled_function_light(cf, &args, compiled_fns, name);
                     let result = result?;
                     return loan_env!(self, maybe_fetch_rw_proxy(result, true));
                 }

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -402,7 +402,7 @@ impl Interpreter {
     }
 
     /// Fast type check for common types.
-    fn fast_type_check(val: &Value, type_name: &str) -> bool {
+    pub(super) fn fast_type_check(val: &Value, type_name: &str) -> bool {
         match type_name {
             "Int" => matches!(val.view(), ValueView::Int(_) | ValueView::BigInt(_)),
             "Str" => matches!(val.view(), ValueView::Str(_)),

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -10,18 +10,24 @@ impl Interpreter {
         cf: &CompiledFunction,
         args: &[Value],
         compiled_fns: &CompiledFns,
+        func_name: &str,
     ) -> Result<Value, RuntimeError> {
         // GC safepoint (§9.2a `call`): the light-call boundary skips
         // push_call_frame, so it emits the call safepoint itself.
         crate::gc::gc_safepoint(crate::gc::SafepointKind::Call);
         self.record_cf_deprecation(cf);
-        // Eligibility (`is_light_call_eligible`) guarantees every param is
-        // named, which is exactly when the plan is precomputed. A hand-built
+        // Eligibility (`is_light_call_eligible`) guarantees at least one named
+        // param, which is exactly when the plan is precomputed. A hand-built
         // chunk without one takes the full named dispatch instead.
         let Some(plan) = cf.named_call_plan.as_deref() else {
             let pkg = self.current_package().to_string();
-            let name = String::new();
-            return self.call_compiled_function_named(cf, args.to_vec(), compiled_fns, &pkg, &name);
+            return self.call_compiled_function_named(
+                cf,
+                args.to_vec(),
+                compiled_fns,
+                &pkg,
+                func_name,
+            );
         };
         // Save caller locals and create callee locals
         let saved_locals = std::mem::take(&mut self.locals);
@@ -82,13 +88,95 @@ impl Interpreter {
                 })
         }
 
-        // Bind named parameters to their precomputed locals slots; mirror into
+        // Bind parameters to their precomputed locals slots; mirror into
         // the overlay env only when a name-based reader needs it (reflective
         // access anywhere / closure capture via needs_env_sync) or when the
         // value is `Nil` (the GetLocal handler treats a `Nil` slot as
         // possibly-undeclared and verifies via env.contains_key).
         let write_all_params = crate::opcode::reflective_name_access_possible();
-        for (i, npb) in plan.params.iter().enumerate() {
+        let mut positional_idx = 0usize;
+        let mut bind_err: Option<RuntimeError> = None;
+        'bind: for (i, pb) in plan.params.iter().enumerate() {
+            // Bind this param's value into slot + (gated) env under its name.
+            macro_rules! bind_value {
+                ($slot:expr, $needs_env:expr, $v:expr) => {{
+                    let v: Value = $v;
+                    if let Some(slot) = $slot {
+                        self.locals[slot] = v.clone();
+                    }
+                    if write_all_params || $needs_env || v.is_nil() {
+                        match cf.param_name_syms.get(i) {
+                            Some(sym) => {
+                                self.env_mut().insert_sym(*sym, v);
+                            }
+                            None => {
+                                self.env_mut().insert(cf.param_defs[i].name.clone(), v);
+                            }
+                        }
+                    }
+                }};
+            }
+            let npb = match pb {
+                crate::opcode::LightParamBind::Named(npb) => npb,
+                crate::opcode::LightParamBind::Positional(ppb) => {
+                    // Advance past named-syntax Pair args (a parenthesized
+                    // Pair compiles to ValuePair and stays positional) and
+                    // the synthetic callsite-line marker (which can be a
+                    // ValuePair).
+                    while positional_idx < args.len()
+                        && (matches!(deref_arg(&args[positional_idx]).view(), ValueView::Pair(..))
+                            || Self::is_callsite_line_marker(&args[positional_idx]))
+                    {
+                        positional_idx += 1;
+                    }
+                    if positional_idx < args.len() {
+                        let val = deref_arg(&args[positional_idx]).clone();
+                        positional_idx += 1;
+                        if let Some(ref tc) = cf.param_defs[i].type_constraint
+                            && !Self::fast_type_check(&val, tc)
+                        {
+                            let got = runtime::value_type_name(&val);
+                            let msg = format!(
+                                "Type check failed in binding ${}: expected {}, got {}",
+                                cf.param_defs[i].name, tc, got
+                            );
+                            let mut attrs = Self::type_check_argument_attrs(
+                                func_name,
+                                &cf.param_defs,
+                                args,
+                                msg,
+                            );
+                            attrs.insert("expected".to_string(), Value::str(tc.to_string()));
+                            attrs.insert("got".to_string(), Value::str(got.to_string()));
+                            bind_err = Some(RuntimeError::typed("X::TypeCheck::Argument", attrs));
+                            break 'bind;
+                        }
+                        bind_value!(ppb.slot, ppb.needs_env, val);
+                    } else if ppb.required {
+                        let got = args
+                            .iter()
+                            .filter(|a| {
+                                !matches!(deref_arg(a).view(), ValueView::Pair(..))
+                                    && !Self::is_callsite_line_marker(a)
+                            })
+                            .count();
+                        let msg = format!(
+                            "Too few positionals passed; expected {} arguments but got {}",
+                            plan.positional_count, got
+                        );
+                        bind_err = Some(RuntimeError::typed(
+                            "X::TypeCheck::Argument",
+                            Self::type_check_argument_attrs(func_name, &cf.param_defs, args, msg),
+                        ));
+                        break 'bind;
+                    } else {
+                        // Missing optional positional: shadow like the named
+                        // case below.
+                        bind_value!(ppb.slot, true, Value::NIL);
+                    }
+                    continue;
+                }
+            };
             let mut found_val: Option<&Value> = find_named(args, &npb.match_key);
             if found_val.is_none() {
                 for key in &npb.alias_keys {
@@ -108,27 +196,15 @@ impl Interpreter {
             }
             let Some(v) = found_val else {
                 if npb.required {
-                    // Unwind (missing required named param => runtime X::AdHoc).
-                    match caller_env {
-                        Some(caller_env) => self.set_env(caller_env),
-                        None => {
-                            if !self.env().overlay_is_shared_empty() {
-                                self.env_mut().retain_overlay(|_, _| false);
-                            }
-                        }
-                    }
-                    let used = std::mem::replace(&mut self.locals, saved_locals);
-                    self.recycle_locals(used);
-                    self.loop_local_vars = saved_loop_local_vars;
-                    self.loop_local_saved_env = saved_loop_local_saved_env;
-                    self.block_declared_vars = saved_block_declared_vars;
-                    return Err(RuntimeError::typed_msg(
+                    // Missing required named param => runtime X::AdHoc.
+                    bind_err = Some(RuntimeError::typed_msg(
                         "X::AdHoc",
                         format!(
                             "Required named parameter '{}' not passed",
                             cf.param_defs[i].name
                         ),
                     ));
+                    break 'bind;
                 }
                 // Missing optional named param: bind `Nil` into the overlay
                 // env so the param SHADOWS a same-named caller lexical (the
@@ -154,19 +230,54 @@ impl Interpreter {
                 }
                 self.env_mut().insert(alias_name.clone(), v.clone());
             }
-            if let Some(slot) = npb.slot {
-                self.locals[slot] = v.clone();
+            bind_value!(npb.slot, npb.needs_env, v);
+        }
+        // Surplus positional args are an arity error (mixed signatures only —
+        // all-named signatures keep their historical lax behavior for a stray
+        // positional; the full dispatch path is just as lax there).
+        if bind_err.is_none() && plan.positional_count > 0 {
+            let mut idx = positional_idx;
+            while idx < args.len() {
+                let is_named_or_marker =
+                    matches!(deref_arg(&args[idx]).view(), ValueView::Pair(..))
+                        || Self::is_callsite_line_marker(&args[idx]);
+                if !is_named_or_marker {
+                    let got = args
+                        .iter()
+                        .filter(|a| {
+                            !matches!(deref_arg(a).view(), ValueView::Pair(..))
+                                && !Self::is_callsite_line_marker(a)
+                        })
+                        .count();
+                    let msg = format!(
+                        "Too many positionals passed; expected {} arguments but got {}",
+                        plan.positional_count, got
+                    );
+                    bind_err = Some(RuntimeError::typed(
+                        "X::TypeCheck::Argument",
+                        Self::type_check_argument_attrs(func_name, &cf.param_defs, args, msg),
+                    ));
+                    break;
+                }
+                idx += 1;
             }
-            if write_all_params || npb.needs_env || v.is_nil() {
-                match cf.param_name_syms.get(i) {
-                    Some(sym) => {
-                        self.env_mut().insert_sym(*sym, v);
-                    }
-                    None => {
-                        self.env_mut().insert(cf.param_defs[i].name.clone(), v);
+        }
+        if let Some(e) = bind_err {
+            // Unwind: restore the caller frame exactly as the success path does.
+            match caller_env {
+                Some(caller_env) => self.set_env(caller_env),
+                None => {
+                    if !self.env().overlay_is_shared_empty() {
+                        self.env_mut().retain_overlay(|_, _| false);
                     }
                 }
             }
+            let used = std::mem::replace(&mut self.locals, saved_locals);
+            self.recycle_locals(used);
+            self.loop_local_vars = saved_loop_local_vars;
+            self.loop_local_saved_env = saved_loop_local_saved_env;
+            self.block_declared_vars = saved_block_declared_vars;
+            return Err(e);
         }
 
         // Mark parameters as readonly (eligibility excludes `is rw/copy/raw`

--- a/t/mixed-light-call-binding.t
+++ b/t/mixed-light-call-binding.t
@@ -1,0 +1,57 @@
+use v6;
+use Test;
+
+# Pin for the mixed positional+named light call path (NamedCallPlan with
+# LightParamBind::Positional entries): a sub with both positional and named
+# params used to take the full dispatch on every call; the light path must
+# preserve its semantics — binding order, arity errors, type checks, junction
+# autothreading, and parenthesized-Pair-as-positional.
+
+plan 14;
+
+sub f($x, :$c) { "$x/" ~ ($c // "-") }
+is f(1), "1/-", 'positional only';
+is f(1, :c(2)), "1/2", 'positional + named';
+is f(:c(2), 1), "1/2", 'named before positional';
+
+# Repeated calls through the light-call cache.
+my @seen;
+for ^3 { @seen.push(f($_, :c(9))) }
+is-deeply @seen, ["0/9", "1/9", "2/9"], 'cached mixed calls bind fresh each time';
+
+# Arity errors survive the cached fast path.
+my $too-few;
+{ f(); CATCH { default { $too-few = $_ } } }
+ok $too-few.defined && $too-few.message.contains('Too few positionals'),
+    'missing required positional is an arity error';
+my $too-many;
+{ f(1, 2); CATCH { default { $too-many = $_ } } }
+ok $too-many.defined && $too-many.message.contains('Too many positionals'),
+    'surplus positional is an arity error';
+
+# A parenthesized Pair is a positional argument, not a named one.
+sub pos-pair($x, :$a) { "x=" ~ ($x.^name eq 'Pair' ?? "pair" !! $x) ~ " a=" ~ ($a // "-") }
+is pos-pair((:a(5))), "x=pair a=-", 'parenthesized Pair binds positionally';
+is pos-pair(1, :a(5)), "x=1 a=5", 'named syntax binds the named param';
+
+# Fast type constraint on the positional param.
+sub typed(Int $n, :$m) { $n + ($m // 0) }
+is typed(41, :m(1)), 42, 'typed positional binds';
+my $type-err;
+{ typed("s"); CATCH { default { $type-err = $_ } } }
+ok $type-err.defined, 'type mismatch on positional raises';
+
+# Junction in the positional slot still autothreads through the cached path.
+is-deeply f(1|2, :c(0)).gist, any("1/0", "2/0").gist,
+    'junction positional autothreads (cached light call)';
+
+# Required named param on a mixed signature.
+sub g($a, :$k!) { "$a $k" }
+is g(1, :k(2)), "1 2", 'mixed with required named binds';
+my $missing-named;
+{ g(1); CATCH { default { $missing-named = $_ } } }
+ok $missing-named ~~ X::AdHoc, 'missing required named on mixed throws X::AdHoc';
+
+# Closure capture of both kinds of params.
+sub cap($x, :$mult) { my $cl = { $x * ($mult // 1) }; $cl() }
+is cap(21, :mult(2)), 42, 'closure captures positional and named params';


### PR DESCRIPTION
## Problem

Campaign continuation of #4590 (PLAN §perf item -1, the interpreter call path). A sub with both positional and named params — `sub f($x, :$c)`, the most common real-world signature shape and the mzef cost class — was ineligible for **every** fast path: each call took the full named dispatch (`push_call_frame`, a callframe Sub value with a **flattened env clone**, block/routine pushes, callable-id env probes, `bind_function_args_values`, full return merge). A 1M-iteration loop calling one costs **62.06G instructions** (~62,000/call — 11× the positional twin).

## Fix

Extend the `NamedCallPlan` (from #4590) to mixed signatures:

- Plan entries become a `LightParamBind` enum (`Positional { slot, needs_env, required } | Named(...)`), built whenever the signature has ≥1 named param.
- `is_light_call_eligible` accepts mixed shapes: positional params held to the positional-light rules (no optionals/defaults/sub-signatures, fast-checkable type constraints, plain `$` scalars), named params to the prior rules. All-positional signatures keep routing to the positional-light path (no routing change).
- The binding loop walks positional args past named-syntax Pairs (a parenthesized Pair compiles to `ValuePair` and correctly stays positional) and the callsite-line marker, fast-type-checks, and raises arity errors — too-few and (new for the light path) **too-many positionals**, matching the full path's phrasing. A positional is required unless optional/defaulted (`pd.required` is the named-`!` marker and is false for plain `$x` — caught in testing).
- **Junction guard**: autothreading lives in the slow dispatch, which the light/OTF cache hits bypass. Mixed calls were previously uncached (every call autothreaded); the cache-hit sites now scan for a Junction arg and fall through to the slow path, preserving threading (pinned).

## Numbers (perf stat -e instructions:u, taskset -c 0, release, 1M calls)

| bench | before | after | Δ |
|---|---|---|---|
| mixed `f($_, :color(1))` | 62.062G | **9.122G** | **-85.3%** (wall 7.32s → 0.76s) |
| named `foo(:color($_))` | 6.833G | 6.969G | +2.0% (enum branch; accepted against the mixed win) |
| positional `foo($_)` | 5.602G | 5.602G | unchanged |
| fez populate | — | 5.65s | method-dispatch bound; the method-side twin of this plan is the follow-up |

## Verification

- `prove t/` full suite (1737 files) PASS; `cargo test` PASS; clippy/fmt clean
- roast: all 35 `S06-signature/*.t` PASS
- New pin: `t/mixed-light-call-binding.t` (14 cases: binding order, arity errors through the cached path, parenthesized-Pair-as-positional, junction autothreading, type checks, closure capture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)