### PR TITLE
perf: literal named args travel out-of-band (CallFuncNamed, no Pair boxing)

### DIFF
--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -1131,15 +1131,58 @@ impl Compiler {
                 // shared `ContainerRef` cells (escape analysis). Compile its
                 // args in an escaping position.
                 let escaping_args = name.resolve() == "start";
-                for arg in args {
-                    self.compile_call_arg_with_escape(arg, escaping_args);
+                // Literal named args (`:key(val)` / `key => val` with a
+                // compile-time-known key) travel out-of-band: only the VALUE
+                // is compiled, and (position, key) goes into a NamedArgsSpec,
+                // so the call site never boxes a Pair. Constant pairs
+                // (`:flag`) stay in-band — loading them is a plain Arc bump,
+                // and the synthetic callsite-line marker must remain an
+                // in-band pair for `peek_callsite_line`.
+                let mut named_entries: Vec<crate::opcode::NamedArgEntry> = Vec::new();
+                for (i, arg) in args.iter().enumerate() {
+                    if let Expr::Binary {
+                        op: TokenKind::FatArrow,
+                        left,
+                        right,
+                    } = arg
+                        && let Expr::Literal(lit) = left.as_ref()
+                        && let crate::value::ValueView::Str(key) = lit.view()
+                    {
+                        named_entries.push(crate::opcode::NamedArgEntry {
+                            pos: i as u32,
+                            sym: Symbol::intern(&key),
+                            key: key.to_string(),
+                        });
+                        // Compile the value exactly as the in-band pair path
+                        // would: `compile_call_arg` wraps the whole pair expr
+                        // in with_escape + with_suppress_pair_capture, under
+                        // which the FatArrow compile is `left; right; MakePair`
+                        // — so the value side is a plain compile_expr.
+                        self.with_escape(escaping_args, |s| {
+                            s.with_suppress_pair_capture(true, |s| s.compile_expr(right))
+                        });
+                    } else {
+                        self.compile_call_arg_with_escape(arg, escaping_args);
+                    }
                 }
                 let name_idx = self.code.add_constant(Value::str(name.resolve()));
-                self.code.emit(OpCode::CallFunc {
-                    name_idx,
-                    arity,
-                    arg_sources_idx,
-                });
+                if named_entries.is_empty() {
+                    self.code.emit(OpCode::CallFunc {
+                        name_idx,
+                        arity,
+                        arg_sources_idx,
+                    });
+                } else {
+                    let spec_idx = self.code.add_named_arg_spec(crate::opcode::NamedArgsSpec {
+                        entries: named_entries,
+                    });
+                    self.code.emit(OpCode::CallFuncNamed {
+                        name_idx,
+                        arity,
+                        spec_idx,
+                        arg_sources_idx,
+                    });
+                }
                 // Emit writeback for any Index expressions that were passed
                 // as `is rw` arguments (temp variable -> original slot).
                 self.emit_index_rw_writebacks();

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -642,6 +642,18 @@ pub(crate) enum OpCode {
         arity: u32,
         arg_sources_idx: Option<u32>,
     },
+    /// Expression-level function call whose literal named args travel
+    /// out-of-band: `arity` values on the stack, of which the positions
+    /// listed in `CompiledCode::named_arg_specs[spec_idx]` are named-arg
+    /// VALUES (no Pair boxing at the call site). The light-call fast path
+    /// binds them by `Symbol`; every other dispatch route materializes the
+    /// Pairs in place on the stack and delegates to the `CallFunc` logic.
+    CallFuncNamed {
+        name_idx: u32,
+        arity: u32,
+        spec_idx: u32,
+        arg_sources_idx: Option<u32>,
+    },
     /// Expression-level function call with capture slip: pop 1 slip + `regular_arity` args,
     /// flatten the slip into the argument list, call name, push result.
     CallFuncSlip {
@@ -1633,6 +1645,11 @@ pub(crate) struct CompiledCode {
     pub(crate) param_local_slots: Vec<u32>,
     /// Pre-compiled closure bodies embedded in this code chunk.
     pub(crate) closure_compiled_codes: Vec<Arc<CompiledCode>>,
+    /// Out-of-band named-argument specs for `CallFuncNamed` sites (indexed by
+    /// the op's `spec_idx`): which of the call's stack values are named-arg
+    /// VALUES and under which keys. Lets a literal `:key(val)` call site skip
+    /// the per-call Pair boxing.
+    pub(crate) named_arg_specs: Vec<Arc<NamedArgsSpec>>,
     /// Parallel to `closure_compiled_codes`: `closure_escapes[i]` is true if the
     /// i-th child closure was created in an *escaping position* — its value is
     /// stored/returned/bound (assignment or `:=` RHS, `return`/`fail` operand,
@@ -2010,6 +2027,7 @@ impl CompiledCode {
             our_locals: Vec::new(),
             param_local_slots: Vec::new(),
             closure_compiled_codes: Vec::new(),
+            named_arg_specs: Vec::new(),
             closure_escapes: Vec::new(),
             is_routine: false,
             has_once: false,
@@ -2380,7 +2398,9 @@ impl CompiledCode {
                 | OpCode::SymbolicDeref(_)
                 | OpCode::SymbolicDerefStore(_)
                 | OpCode::IndirectCodeLookup(_) => true,
-                OpCode::CallFunc { name_idx, .. } | OpCode::CallFuncSlip { name_idx, .. } => {
+                OpCode::CallFunc { name_idx, .. }
+                | OpCode::CallFuncNamed { name_idx, .. }
+                | OpCode::CallFuncSlip { name_idx, .. } => {
                     matches!(
                         self.constants.get(*name_idx as usize).map(Value::view),
                         Some(ValueView::Str(name)) if name.as_str() == "EVAL" || name.as_str() == "EVALFILE"
@@ -2591,6 +2611,9 @@ impl CompiledCode {
             OpCode::CallFunc {
                 arg_sources_idx, ..
             }
+            | OpCode::CallFuncNamed {
+                arg_sources_idx, ..
+            }
             | OpCode::CallFuncSlip {
                 arg_sources_idx, ..
             }
@@ -2636,6 +2659,7 @@ impl CompiledCode {
     fn op_callee_name_const_idx(op: &OpCode) -> Option<u32> {
         match op {
             OpCode::CallFunc { name_idx, .. }
+            | OpCode::CallFuncNamed { name_idx, .. }
             | OpCode::CallFuncSlip { name_idx, .. }
             | OpCode::ExecCall { name_idx, .. }
             | OpCode::ExecCallSlip { name_idx, .. } => Some(*name_idx),
@@ -3273,6 +3297,7 @@ impl CompiledCode {
                 op,
                 OpCode::CallDefined
                     | OpCode::CallFunc { .. }
+                    | OpCode::CallFuncNamed { .. }
                     | OpCode::CallFuncSlip { .. }
                     | OpCode::CallMethod { .. }
                     | OpCode::CallMethodMut { .. }
@@ -3323,6 +3348,7 @@ impl CompiledCode {
                     | OpCode::MultiDimIndexAssign { .. }
                     | OpCode::MultiDimIndexAssignGeneric(_)
                     | OpCode::CallFunc { .. }
+                    | OpCode::CallFuncNamed { .. }
                     | OpCode::CallFuncSlip { .. }
                     | OpCode::CallMethod { .. }
                     | OpCode::CallMethodMut { .. }
@@ -3646,6 +3672,14 @@ impl CompiledCode {
         idx
     }
 
+    /// Register a `CallFuncNamed` site's out-of-band named-arg spec, returning
+    /// the index the op carries as `spec_idx`.
+    pub(crate) fn add_named_arg_spec(&mut self, spec: NamedArgsSpec) -> u32 {
+        let idx = self.named_arg_specs.len() as u32;
+        self.named_arg_specs.push(Arc::new(spec));
+        idx
+    }
+
     pub(crate) fn add_stmt(&mut self, stmt: Stmt) -> u32 {
         let idx = self.stmt_pool.len() as u32;
         // Record a declaration fingerprint for SubDecls so a re-executed
@@ -3687,6 +3721,25 @@ impl CompiledCode {
 /// compiler-generated strings, so HashDoS resistance buys nothing here.
 pub(crate) type CompiledFns = rustc_hash::FxHashMap<String, CompiledFunction>;
 
+/// Out-of-band named-argument spec for a `CallFuncNamed` site: which of the
+/// call's stack values are named-arg values, and under which keys.
+#[derive(Clone, Debug)]
+pub(crate) struct NamedArgsSpec {
+    /// In argument (stack) order.
+    pub(crate) entries: Vec<NamedArgEntry>,
+}
+
+/// One named argument of a [`NamedArgsSpec`].
+#[derive(Clone, Debug)]
+pub(crate) struct NamedArgEntry {
+    /// Position among the call's `arity` stack values.
+    pub(crate) pos: u32,
+    /// The interned key, for the light path's `Symbol` compare.
+    pub(crate) sym: Symbol,
+    /// The key string, for fallback Pair materialization.
+    pub(crate) key: String,
+}
+
 /// Precomputed bind plan for the light named-call path: what
 /// `call_compiled_function_light`'s binding loop needs per call, derived once
 /// per `CompiledFunction` instead of re-deriving match keys / locals slots /
@@ -3726,6 +3779,8 @@ pub(crate) struct PositionalParamBind {
 pub(crate) struct NamedParamBind {
     /// The key a caller's `:key(value)` pair must carry (sigil/twigil stripped).
     pub(crate) match_key: String,
+    /// `match_key` interned, for the spec-based (out-of-band) named lookup.
+    pub(crate) match_key_sym: Symbol,
     /// The parameter's locals slot (by `pd.name`), when it has one.
     pub(crate) slot: Option<usize>,
     /// Whether the bound value must also be written into the overlay env
@@ -3919,6 +3974,7 @@ impl CompiledFunction {
                 }
             }
             params.push(LightParamBind::Named(NamedParamBind {
+                match_key_sym: Symbol::intern(&match_key),
                 match_key,
                 slot,
                 needs_env: needs_env_of(slot),

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -112,6 +112,93 @@ impl Interpreter {
         })
     }
 
+    /// `CallFuncNamed`: a call site whose literal named args travel out-of-band
+    /// (bare values on the stack + a `NamedArgsSpec`). The light-call cache hit
+    /// binds them by `Symbol` with zero Pair boxing; every other route
+    /// materializes the Pairs in place on the stack and delegates to the
+    /// ordinary `exec_call_func_op`, so behavior off the fast path is
+    /// byte-identical to the old MakePair form.
+    pub(super) fn exec_call_func_named_op(
+        &mut self,
+        code: &CompiledCode,
+        name_idx: u32,
+        arity: u32,
+        spec_idx: u32,
+        arg_sources_idx: Option<u32>,
+        compiled_fns: &CompiledFns,
+    ) -> Result<(), RuntimeError> {
+        crate::vm::vm_stats::record_function_dispatch();
+        let arity_usize = arity as usize;
+        let spec = &code.named_arg_specs[spec_idx as usize];
+        // Fast path: light-call cache hit, spec-aware binding. Mirrors the
+        // CallFunc light-cache block, with the container/junction guards
+        // folded into one conservative scan (an Array/Hash value anywhere
+        // may need container sharing; a Junction may need autothreading —
+        // both fall back to the materializing slow path).
+        if self.light_call_cache_gen == self.fn_resolve_gen
+            && self.stack.len() >= arity_usize
+            && (self.amp_param_shadowed_names.is_empty()
+                || !self
+                    .amp_param_shadowed_names
+                    .contains(&code.const_sym(name_idx)))
+        {
+            let name_sym = code.const_sym(name_idx);
+            if let Some((cached_key, cached_fp)) = self.light_call_cache.get(&name_sym)
+                && let Some(cf) = compiled_fns.get(cached_key.as_str())
+                && cf.fingerprint == *cached_fp
+            {
+                let base = self.stack.len() - arity_usize;
+                let needs_slow = self.stack[base..].iter().any(|v| {
+                    fn is_guarded(v: &Value) -> bool {
+                        matches!(
+                            v.view(),
+                            ValueView::Array(..) | ValueView::Hash(..) | ValueView::Junction { .. }
+                        )
+                    }
+                    match v.view() {
+                        // A positional `$var` arg arrives VarRef-wrapped; the
+                        // guard is about the inner value's kind.
+                        ValueView::VarRef { value, .. } => is_guarded(value),
+                        _ => is_guarded(v),
+                    }
+                });
+                if !needs_slow {
+                    let mut args = self.take_locals_from_pool(0);
+                    args.extend(self.stack.drain(base..));
+                    let cl = crate::runtime::Interpreter::peek_callsite_line(&args);
+                    if cl.is_some() {
+                        loan_env!(self, set_pending_callsite_line(cl));
+                    }
+                    let name_str = Self::const_str(code, name_idx);
+                    let result = self.call_compiled_function_light_spec(
+                        cf,
+                        &args,
+                        compiled_fns,
+                        name_str,
+                        Some(spec),
+                    );
+                    self.recycle_locals(args);
+                    self.stack.push(result?);
+                    self.drain_and_reconcile_after_cached_call(code);
+                    return Ok(());
+                }
+            }
+        }
+        // Fallback: materialize the named Pairs in place, then run the
+        // ordinary CallFunc dispatch (which re-records the dispatch stat;
+        // subtract nothing — the double count is a stats-only artifact of
+        // the fallback and keeps this wrapper branch-free).
+        if self.stack.len() >= arity_usize {
+            let base = self.stack.len() - arity_usize;
+            for e in &spec.entries {
+                let slot = &mut self.stack[base + e.pos as usize];
+                let val = std::mem::replace(slot, Value::NIL);
+                *slot = Value::pair(e.key.clone(), val);
+            }
+        }
+        self.exec_call_func_op(code, name_idx, arity, arg_sources_idx, compiled_fns)
+    }
+
     pub(super) fn exec_call_func_op(
         &mut self,
         code: &CompiledCode,

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -12,6 +12,23 @@ impl Interpreter {
         compiled_fns: &CompiledFns,
         func_name: &str,
     ) -> Result<Value, RuntimeError> {
+        self.call_compiled_function_light_spec(cf, args, compiled_fns, func_name, None)
+    }
+
+    /// [`Self::call_compiled_function_light`] with an optional out-of-band
+    /// named-args spec (a `CallFuncNamed` site): the positions listed in the
+    /// spec are named-arg VALUES (never boxed into Pairs), everything else is
+    /// positional. In-band Pair args can coexist (e.g. a constant `:flag`);
+    /// on a duplicate key the higher argument position wins, matching the
+    /// all-in-band ordering.
+    pub(super) fn call_compiled_function_light_spec(
+        &mut self,
+        cf: &CompiledFunction,
+        args: &[Value],
+        compiled_fns: &CompiledFns,
+        func_name: &str,
+        named_spec: Option<&crate::opcode::NamedArgsSpec>,
+    ) -> Result<Value, RuntimeError> {
         // GC safepoint (§9.2a `call`): the light-call boundary skips
         // push_call_frame, so it emits the call safepoint itself.
         crate::gc::gc_safepoint(crate::gc::SafepointKind::Call);
@@ -77,16 +94,45 @@ impl Interpreter {
                 _ => arg,
             }
         }
-        // Find the value of the last argument pair whose key is `key`.
+        // Find the last in-band argument pair whose key is `key` (with its
+        // argument position, so a spec hit at a later position can win).
         #[inline]
-        fn find_named<'a>(args: &'a [Value], key: &str) -> Option<&'a Value> {
+        fn find_named_pos<'a>(args: &'a [Value], key: &str) -> Option<(usize, &'a Value)> {
             args.iter()
+                .enumerate()
                 .rev()
-                .find_map(|arg| match deref_arg(arg).view() {
-                    ValueView::Pair(k, v) if k.as_str() == key => Some(v),
+                .find_map(|(i, arg)| match deref_arg(arg).view() {
+                    ValueView::Pair(k, v) if k.as_str() == key => Some((i, v)),
                     _ => None,
                 })
         }
+        // Named lookup over BOTH sources — in-band Pair args and the
+        // out-of-band spec — with the higher argument position winning on a
+        // duplicate key (Raku's last-one-wins, preserved across the split).
+        // The spec compare is by `Symbol` when the caller has one interned
+        // (the plan's main match key); alias keys compare by string.
+        let find_named = |key_sym: Option<Symbol>, key: &str| -> Option<&Value> {
+            let inband = find_named_pos(args, key);
+            let spec_hit = named_spec.and_then(|s| {
+                s.entries
+                    .iter()
+                    .rev()
+                    .find(|e| match key_sym {
+                        Some(sym) => e.sym == sym,
+                        None => e.key == key,
+                    })
+                    .map(|e| (e.pos as usize, &args[e.pos as usize]))
+            });
+            match (inband, spec_hit) {
+                (Some((ip, iv)), Some((sp, sv))) => Some(if sp > ip { sv } else { iv }),
+                (Some((_, v)), None) | (None, Some((_, v))) => Some(v),
+                (None, None) => None,
+            }
+        };
+        // Whether argument position `pos` carries an out-of-band named value.
+        let in_spec = |pos: usize| {
+            named_spec.is_some_and(|s| s.entries.iter().any(|e| e.pos as usize == pos))
+        };
 
         // Bind parameters to their precomputed locals slots; mirror into
         // the overlay env only when a name-based reader needs it (reflective
@@ -119,12 +165,16 @@ impl Interpreter {
             let npb = match pb {
                 crate::opcode::LightParamBind::Named(npb) => npb,
                 crate::opcode::LightParamBind::Positional(ppb) => {
-                    // Advance past named-syntax Pair args (a parenthesized
-                    // Pair compiles to ValuePair and stays positional) and
-                    // the synthetic callsite-line marker (which can be a
-                    // ValuePair).
+                    // Advance past named args — in-band Pairs and out-of-band
+                    // spec positions — plus the synthetic callsite-line marker
+                    // (a parenthesized Pair compiles to ValuePair and stays
+                    // positional).
                     while positional_idx < args.len()
-                        && (matches!(deref_arg(&args[positional_idx]).view(), ValueView::Pair(..))
+                        && (in_spec(positional_idx)
+                            || matches!(
+                                deref_arg(&args[positional_idx]).view(),
+                                ValueView::Pair(..)
+                            )
                             || Self::is_callsite_line_marker(&args[positional_idx]))
                     {
                         positional_idx += 1;
@@ -155,8 +205,10 @@ impl Interpreter {
                     } else if ppb.required {
                         let got = args
                             .iter()
-                            .filter(|a| {
-                                !matches!(deref_arg(a).view(), ValueView::Pair(..))
+                            .enumerate()
+                            .filter(|(i, a)| {
+                                !in_spec(*i)
+                                    && !matches!(deref_arg(a).view(), ValueView::Pair(..))
                                     && !Self::is_callsite_line_marker(a)
                             })
                             .count();
@@ -177,10 +229,10 @@ impl Interpreter {
                     continue;
                 }
             };
-            let mut found_val: Option<&Value> = find_named(args, &npb.match_key);
+            let mut found_val: Option<&Value> = find_named(Some(npb.match_key_sym), &npb.match_key);
             if found_val.is_none() {
                 for key in &npb.alias_keys {
-                    found_val = find_named(args, key);
+                    found_val = find_named(None, key);
                     if found_val.is_some() {
                         break;
                     }
@@ -188,7 +240,7 @@ impl Interpreter {
             }
             if found_val.is_none() {
                 for key in &npb.outer_alias_keys {
-                    found_val = find_named(args, key);
+                    found_val = find_named(None, key);
                     if found_val.is_some() {
                         break;
                     }
@@ -238,14 +290,16 @@ impl Interpreter {
         if bind_err.is_none() && plan.positional_count > 0 {
             let mut idx = positional_idx;
             while idx < args.len() {
-                let is_named_or_marker =
-                    matches!(deref_arg(&args[idx]).view(), ValueView::Pair(..))
-                        || Self::is_callsite_line_marker(&args[idx]);
+                let is_named_or_marker = in_spec(idx)
+                    || matches!(deref_arg(&args[idx]).view(), ValueView::Pair(..))
+                    || Self::is_callsite_line_marker(&args[idx]);
                 if !is_named_or_marker {
                     let got = args
                         .iter()
-                        .filter(|a| {
-                            !matches!(deref_arg(a).view(), ValueView::Pair(..))
+                        .enumerate()
+                        .filter(|(i, a)| {
+                            !in_spec(*i)
+                                && !matches!(deref_arg(a).view(), ValueView::Pair(..))
                                 && !Self::is_callsite_line_marker(a)
                         })
                         .count();
@@ -303,9 +357,11 @@ impl Interpreter {
         if plan.uses_arg_array {
             let plain_args: Vec<Value> = args
                 .iter()
-                .map(deref_arg)
-                .filter(|a| !matches!(a.view(), ValueView::Pair(..)))
-                .cloned()
+                .enumerate()
+                .filter(|(i, a)| {
+                    !in_spec(*i) && !matches!(deref_arg(a).view(), ValueView::Pair(..))
+                })
+                .map(|(_, a)| deref_arg(a).clone())
                 .collect();
             self.env_mut()
                 .insert("@_".to_string(), Value::array(plain_args));

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2832,6 +2832,32 @@ impl Interpreter {
                 }
                 *ip += 1;
             }
+            OpCode::CallFuncNamed {
+                name_idx,
+                arity,
+                spec_idx,
+                arg_sources_idx,
+            } => {
+                self.sync_source_line(code, *ip);
+                match self.exec_call_func_named_op(
+                    code,
+                    *name_idx,
+                    *arity,
+                    *spec_idx,
+                    *arg_sources_idx,
+                    compiled_fns,
+                ) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        // Same resume-point recording as CallFunc.
+                        if !e.is_resume() && self.resume_ip.is_none() {
+                            self.resume_ip = Some(*ip + 1);
+                        }
+                        return Err(e);
+                    }
+                }
+                *ip += 1;
+            }
             OpCode::CallFuncSlip {
                 name_idx,
                 regular_arity,

--- a/src/vm/vm_jit_compile.rs
+++ b/src/vm/vm_jit_compile.rs
@@ -63,6 +63,7 @@ pub(super) fn compile_range(code: &CompiledCode, start: usize, end: usize) -> Op
             | OpCode::SetLocalDecl { .. }
             | OpCode::ContainerizePair
             | OpCode::CallFunc { .. }
+            | OpCode::CallFuncNamed { .. }
             | OpCode::CallMethod { .. }
             | OpCode::CallMethodMut { .. } => {}
             OpCode::Jump(t)
@@ -391,7 +392,7 @@ fn build(
                 )?;
                 check_status(&mut b, status);
             }
-            OpCode::CallFunc { .. } => {
+            OpCode::CallFunc { .. } | OpCode::CallFuncNamed { .. } => {
                 let opidx = b.ins().iconst(types::I32, i as i64);
                 let status = call_helper(
                     &mut b,

--- a/src/vm/vm_jit_helpers.rs
+++ b/src/vm/vm_jit_helpers.rs
@@ -363,16 +363,28 @@ pub(super) unsafe extern "C" fn call_func(
     fns: *const CompiledFns,
 ) -> u32 {
     let (interp, code, fns) = unsafe { (&mut *interp, &*code, &*fns) };
-    let OpCode::CallFunc {
-        name_idx,
-        arity,
-        arg_sources_idx,
-    } = &code.ops[op_idx as usize]
-    else {
-        unreachable!("jit call_func shim on a non-CallFunc opcode")
-    };
     interp.sync_source_line(code, op_idx as usize);
-    let r = interp.exec_call_func_op(code, *name_idx, *arity, *arg_sources_idx, fns);
+    let r = match &code.ops[op_idx as usize] {
+        OpCode::CallFunc {
+            name_idx,
+            arity,
+            arg_sources_idx,
+        } => interp.exec_call_func_op(code, *name_idx, *arity, *arg_sources_idx, fns),
+        OpCode::CallFuncNamed {
+            name_idx,
+            arity,
+            spec_idx,
+            arg_sources_idx,
+        } => interp.exec_call_func_named_op(
+            code,
+            *name_idx,
+            *arity,
+            *spec_idx,
+            *arg_sources_idx,
+            fns,
+        ),
+        _ => unreachable!("jit call_func shim on a non-CallFunc opcode"),
+    };
     interp.current_code = code as *const CompiledCode as usize;
     match r {
         Ok(()) => {


### PR DESCRIPTION
## Problem

Slice 3 of the named-args call-path campaign (#4590 → #4593). Every literal `:key(val)` / `key => val` argument at a function call site paid a **PairBox Arc allocation + drop per call** (`MakePair`), and the callee's binder re-found the value by string-comparing Pair keys — all compile-time-known work. This was the dominant residual of the named-call benchmark (~1350 instr/call over positional).

## Design

New `CallFuncNamed` opcode — the first piece of a named-args channel in the call ABI (the direction the eventual `|%h` hash pass-through needs):

- The generic call-site compile puts literal named-arg **values bare on the stack** and records `(position, key Symbol, key string)` in a per-site `NamedArgsSpec` (a new `CompiledCode` side table).
- **Fast path** (light-call cache hit; no Array/Hash/Junction args, detected through the `VarRef` wrapper positional args arrive in): binds named params straight from spec positions by `Symbol` compare — zero Pair boxing, zero key string compares. In-band Pair args (constant `:flag`s, the callsite-line marker, runtime re-dispatch) coexist; on duplicate keys the higher argument position wins, preserving Raku's last-one-wins across both channels.
- **Every other route** (native fns, multis, autothread, wrap chains, full binding) materializes the Pairs **in place on the stack** and delegates to the ordinary `exec_call_func_op` — off-fast-path behavior is byte-identical to the old MakePair form.
- The JIT's `call_func` shim decodes both op forms, so hot loops with named-arg calls keep their JIT eligibility.
- Constant pairs (`:flag`) deliberately stay in-band: loading them is a plain Arc bump, and the callsite-line marker must remain an in-band pair for `peek_callsite_line`.

## Numbers (perf stat -e instructions:u, taskset -c 0, release, 1M calls)

| bench | before (#4593) | after | Δ |
|---|---|---|---|
| named `foo(:color($_))` | 6.969G | **4.795G** | **-31.2%** — now cheaper than the positional twin |
| mixed `f($_, :color(1))` | 9.122G | **6.562G** | **-28.1%** |
| positional `foo($_)` | 5.602G | 5.549G | unchanged |

Session total for the named bench (pre-#4590 baseline → now): **8.507G → 4.795G (-43.6%)**; mixed: **62.06G → 6.56G (-89.4%)**.

## Verification

- Full `prove t/` (1737 files), `cargo test` (incl. jit_diff), all 35 `roast/S06-signature/*.t`, both light-call pin tests, clippy/fmt — all green
- Fallback parity spot-checked: multis, slurpy `*%h`, defaults, required-named X::AdHoc, EVAL, slip args, `is rw` named (pre-existing no-writeback behavior preserved; raku rejects that form at compile time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)