### PR TITLE
perf: recognize ContainerRef elements in the loop-writeback unchanged guard

### DIFF
--- a/src/vm/vm_loop_writeback.rs
+++ b/src/vm/vm_loop_writeback.rs
@@ -134,6 +134,22 @@ impl Interpreter {
                 },
             ) => ta == tb && ka == kb && ia == ib,
             (ValueView::Nil, ValueView::Nil) => true,
+            // A shared `ContainerRef` element (the rw-alias cell `.grep` leaves
+            // in its source array, or a `:=`-bound element): mutations through
+            // the alias write through the cell itself, so the source element
+            // already observes them. The loop var holds either the same cell
+            // (Gc identity) or a dereferenced plain value — compare against the
+            // cell's current content in that case. Without these arms every
+            // iteration of a read-only `for` over a cell-holding array fell
+            // through to the O(n) source rebuild (O(n^2) overall; a 20k-element
+            // array took seconds instead of milliseconds).
+            (ValueView::ContainerRef(a), ValueView::ContainerRef(b)) => {
+                crate::gc::Gc::ptr_eq(&a, &b)
+            }
+            (_, ValueView::ContainerRef(cell)) => {
+                let inner = cell.lock().unwrap().clone();
+                Self::loop_var_unchanged(current, &inner)
+            }
             _ => false,
         }
     }

--- a/t/for-loop-cell-elements.t
+++ b/t/for-loop-cell-elements.t
@@ -1,0 +1,54 @@
+use v6;
+use Test;
+
+# Pin for the ContainerRef arms in loop_var_unchanged (vm_loop_writeback.rs):
+# `.grep` leaves shared rw-alias ContainerRef cells in its source array, and a
+# subsequent `for` over that array must (a) keep element-alias semantics and
+# (b) stay O(n) — the unchanged-value guard must recognize a cell whose content
+# still equals the loop var, instead of falling through to the O(n) source
+# rebuild every iteration (O(n^2): a 20k-element loop took ~9s instead of ~10ms).
+
+plan 6;
+
+# (a) semantics: read-only for over a cell-holding array
+{
+    my @a = 1, 2, 3, 4;
+    @a.grep(*.so).elems;
+    my $sum = 0;
+    for @a -> $x { $sum += $x }
+    is $sum, 10, 'read-only for over cell-holding array iterates values';
+    is-deeply @a, [1, 2, 3, 4], 'source array unchanged after read-only for';
+}
+
+# (a) semantics: topic rebind still writes back through/over the cell
+{
+    my @b = 1, 2, 3;
+    @b.grep(*.so).elems;
+    for @b { $_ = $_ + 100 }
+    is-deeply @b, [101, 102, 103], 'topic rebind writes back over cell elements';
+}
+
+# (a) semantics: named-param container mutation still propagates
+{
+    my @c = [1, 2], [3, 4];
+    @c.grep(*.so).elems;
+    for @c -> @row { @row.push(8) }
+    is @c[0][2], 8, 'container mutation through named param propagates (row 0)';
+    is @c[1][2], 8, 'container mutation through named param propagates (row 1)';
+}
+
+# (b) perf: the loop must be O(n), not O(n^2). With the guard broken this
+# takes ~9s release / much longer debug for 20k elements; healthy runs are
+# ~10ms. 15s leaves a wide margin for slow CI machines while still failing
+# decisively on an O(n^2) regression.
+{
+    my @big = (1..20000).map({ "s" ~ $_ });
+    @big.grep(*.so).elems;
+    my $t0 = now;
+    my $n = 0;
+    for @big -> $s { $n++ }
+    my $elapsed = now - $t0;
+    ok $elapsed < 15, "for over 20k cell-holding elements is O(n) ({$elapsed.round(0.01)}s)";
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

`.grep` leaves shared rw-alias `ContainerRef` cells in its source array (one per element). A subsequent `for` over that array fell through `loop_var_unchanged`'s catch-all `false` arm on **every iteration**, so the element-alias writeback rebuilt the whole backing array each time — O(n) per iteration, **O(n²) overall**.

- A bare `for` over a 20k-element array took **~9s** release (raku: ~10ms, ~7750×). Profile: ~90% ContainerRef refcount traffic (`nanbox gc_op<Mutex<Value>>` 48% + `Gc` drop glue 42%) from the per-iteration `Vec<Value>` clone.
- This is the same failure shape the existing `Instance` arm documents ("the dominant cost of bench-class's polymorphism loop") — the `ContainerRef` variant was missing.
- Found while profiling zef's Ecosystems populate (PLAN §1 B2): the populate loop iterates dist/name lists after `.grep`, so it paid this tax throughout.

## Fix

Two new arms in `loop_var_unchanged` (vm_loop_writeback.rs):
- same cell (`Gc::ptr_eq`) → provably unchanged (mutations write through the cell);
- loop var holds a dereferenced value → compare against the cell's current content (one short lock + an 8-byte clone; the lock is not held across the recursive compare).

A rebound/mutated loop var still falls through to the full writeback. Sibling callers (`given`/`with` topic writeback, QuantHash value writeback) share the fix through the same predicate.

## Measured (release)

| case | before | after |
|---|---|---|
| bare `for` over 20k cell-holding elements | 8.6s | **0.06s** |
| zef populate (tmp/populate-bench.raku, 7657 dists) | 6.69s | **5.52s** |
| bench-ctor instructions | 2.394G | 2.394G (±0.1%, no regression) |

## Verification

- Semantics vs raku (all identical): grep rw-alias liveness, `for` topic rebind writeback over cells, named-param container mutation, `given @a { .push }`, BagHash `.values` weight writeback.
- Related roast green: S04-statements/for.t, for-scope.t, given.t, S32-list/grep.t, first.t, S02-lists/indexing.t, S32-hash/pairs.t, S02-types/baghash.t.
- `make test`: 1738 files, only 2 socket-test flakes under parallel-session load (3/3 PASS on isolated re-run).
- Pin: `t/for-loop-cell-elements.t` (semantics + wide-margin O(n) time bound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)