### PR TITLE
fix: nested/sequential for-loops in a lazily-pulled gather keep every element

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -72,7 +72,6 @@ noted.
 | File | mutsu | raku | Blocker / note |
 |---|---|---|---|
 | `integration/99problems-41-to-50.t` | aborts at 2/9 | PASS ★ | Parameterized `multi rule expr($p)` now WORKS (2026-07-15: multi rule/token registration, literal-exclusive dispatch, args in the LR key, lookahead arg instantiation — pin t/parameterized-rules.t; all reduced P47 shapes pass), but the full P47 grammar (3 precedence levels + `term:sym<paren>`/`term:sym<not>` recursion via `<term=.expr(3)>`) is exponentially slow in the regex engine (~9s for 1 level+paren on `(A)` in a debug build; the real input times out). The blocker is now the LR seed-growing loop re-matching all candidates per position per nesting level — needs match-position memoization of subrule results (packrat-style), a separate engine-perf campaign. P41/P46 fixed in #4510 |
-| `integration/99problems-51-to-60.t` | 35/37 | PASS ★ | test 8 (balanced-binary-tree branch dropping) and test 21; the P57 infinite recursion was fixed in #4516 |
 | `integration/99problems-61-to-70.t` | 12/15 | PASS ★ | `internals()` / `atlevel()` binary-tree traversal (tests 3/5/6) |
 | `integration/advent2009-day11.t` | aborts at 3/6 | PASS ★ | not yet root-caused |
 | `integration/advent2009-day12.t` | aborts at 4/9 | PASS ★ | not yet root-caused |

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1311,6 +1311,7 @@ roast/integration/99problems-01-to-10.t
 roast/integration/99problems-11-to-20.t
 roast/integration/99problems-21-to-30.t
 roast/integration/99problems-31-to-40.t
+roast/integration/99problems-51-to-60.t
 roast/integration/advent2009-day01.t
 roast/integration/advent2009-day02.t
 roast/integration/advent2009-day03.t

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2680,6 +2680,41 @@ impl CompiledCode {
         }
     }
 
+    /// Names this code declares itself: `my` declarations (`SetVarDynamic`)
+    /// and `for`-loop parameters (`ForLoop`). A lazily-forced `gather` body
+    /// uses this to keep its OWN declarations out of the pull-site env merge —
+    /// a body loop var that shadows a consumer-scope lexical of the same name
+    /// (`for f() -> $a { ... }` pulling a gather whose body also loops `-> $a`)
+    /// must not clobber the consumer's binding. Mirrors the scan in
+    /// `CompiledFunction::compute_declared_locals`.
+    pub(crate) fn self_declared_names(&self) -> rustc_hash::FxHashSet<Symbol> {
+        let mut declared: rustc_hash::FxHashSet<Symbol> = rustc_hash::FxHashSet::default();
+        for op in &self.ops {
+            match op {
+                OpCode::SetVarDynamic { name_idx, .. } => {
+                    if let Some(ValueView::Str(name)) =
+                        self.constants.get(*name_idx as usize).map(Value::view)
+                    {
+                        declared.insert(Symbol::intern(&name));
+                    }
+                }
+                OpCode::ForLoop(spec) => {
+                    if let Some(idx) = spec.param_idx
+                        && let Some(ValueView::Str(name)) =
+                            self.constants.get(idx as usize).map(Value::view)
+                    {
+                        declared.insert(Symbol::intern(&name));
+                    }
+                    for name in &spec.multi_param_names {
+                        declared.insert(Symbol::intern(name));
+                    }
+                }
+                _ => {}
+            }
+        }
+        declared
+    }
+
     pub(crate) fn compute_free_vars(&mut self) {
         let own: std::collections::HashSet<&str> = self.locals.iter().map(|s| s.as_str()).collect();
         let mut free: std::collections::HashSet<Symbol> = std::collections::HashSet::new();

--- a/src/runtime/gc_roots.rs
+++ b/src/runtime/gc_roots.rs
@@ -92,8 +92,14 @@ impl Interpreter {
         // `Value` — LazyList's internal Value graph is traced starting in the
         // third wave (design doc §11 step 10); revisit once
         // `LazyList::visit_gc_children` exists.
-        if let Some(ForLoopResumeState::List { items, .. }) = &self.gather_for_loop_resume {
-            visit_slice(visitor, items);
+        // Walk the whole nested-resume chain: any level may be a List holding
+        // Values (see ForLoopResumeState::inner_state).
+        let mut cur = self.gather_for_loop_resume.as_ref();
+        while let Some(state) = cur {
+            if let ForLoopResumeState::List { items, .. } = state {
+                visit_slice(visitor, items);
+            }
+            cur = state.inner_state();
         }
     }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1977,6 +1977,10 @@ pub struct Interpreter {
     pub(crate) otf_call_cache_gen: u64,
     pub(crate) check_phaser_depth: u32,
     pub(crate) gather_for_loop_resume: Option<crate::value::ForLoopResumeState>,
+    /// Transient hand-off from a consumed `ForLoopResumeState` to its loop
+    /// executor: the mid-body ip the resumed iteration's first body run
+    /// starts at (see `ForLoopResumeState::resume_body_ip`).
+    pub(crate) gather_resume_body_ip: Option<usize>,
     /// Set by `take_value` when a lazy pull's take limit is reached inside a
     /// condition-driven loop (`while`/`until`/C-style `loop`): the suspension
     /// is DEFERRED to that loop's next iteration boundary, where re-entering

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2226,6 +2226,7 @@ impl Interpreter {
             otf_call_cache_gen: 0,
             check_phaser_depth: 0,
             gather_for_loop_resume: None,
+            gather_resume_body_ip: None,
             gather_suspend_pending: false,
             lazy_take_boundary_defer: false,
             rw_map_topic_capture: None,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -425,6 +425,7 @@ impl Interpreter {
             otf_call_cache_gen: 0,
             check_phaser_depth: 0,
             gather_for_loop_resume: None,
+            gather_resume_body_ip: None,
             gather_suspend_pending: false,
             lazy_take_boundary_defer: false,
             rw_map_topic_capture: None,

--- a/src/value/error.rs
+++ b/src/value/error.rs
@@ -107,6 +107,12 @@ pub struct RuntimeErrorCold {
     /// with the current stack as rakudo's dual-backtrace form
     /// ("...\n\nActually thrown at:\n...").
     pub failure_original_backtrace: Option<String>,
+    /// For the lazy-gather take-limit signal: the code identity (ops pointer)
+    /// and ip of the `Take` opcode that raised it. The innermost enclosing
+    /// for-loop handler in the SAME code consumes it as the exact mid-body
+    /// resume point (`resume_body_ip = ip + 1`), so statements after the take
+    /// in the same iteration are not lost on coroutine resume.
+    pub take_suspend_site: Option<(usize, usize)>,
 }
 
 #[derive(Debug)]
@@ -246,6 +252,14 @@ impl RuntimeError {
 
     pub(crate) fn set_failure_original_backtrace(&mut self, v: Option<String>) {
         self.cold_mut().failure_original_backtrace = v;
+    }
+
+    /// See `RuntimeErrorCold::take_suspend_site`.
+    pub(crate) fn take_suspend_site(&self) -> Option<(usize, usize)> {
+        self.cold.as_ref().and_then(|c| c.take_suspend_site)
+    }
+    pub(crate) fn set_take_suspend_site(&mut self, v: Option<(usize, usize)>) {
+        self.cold_mut().take_suspend_site = v;
     }
 
     /// `return` control signal (non-local return carrying `return_value`).

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1595,6 +1595,15 @@ pub(crate) struct CatPullSpec {
 }
 
 /// Saved for-loop state for resuming a gather coroutine mid-iteration.
+///
+/// `inner` chains the resume state of a loop NESTED inside this one: when the
+/// take-limit signal propagates out of nested loops, each enclosing loop wraps
+/// the already-saved deeper state instead of overwriting the single resume
+/// slot (which lost the inner position and dropped elements — see
+/// t/gather-nested-loop-pull.t). A state carrying an `inner` re-enters its
+/// CURRENT iteration so the nested loop can continue; a leaf state (no inner)
+/// advances to the next element as before. Consumers restore `inner` into the
+/// resume slot for the next loop op encountered during the body replay.
 #[derive(Debug, Clone)]
 pub(crate) enum ForLoopResumeState {
     /// Resume an integer-range for loop at the given current value.
@@ -1602,22 +1611,92 @@ pub(crate) enum ForLoopResumeState {
         current: i64,
         end_val: i64,
         inclusive: bool,
+        code_id: usize,
+        loop_ip: usize,
+        resume_body_ip: Option<usize>,
+        inner: Option<Box<ForLoopResumeState>>,
     },
     /// Resume a list-based for loop at the given index.
     List {
         items: Vec<Value>,
         next_index: usize,
+        code_id: usize,
+        loop_ip: usize,
+        resume_body_ip: Option<usize>,
+        inner: Option<Box<ForLoopResumeState>>,
     },
     /// Resume a lazy-gather for loop at the given element index.
     LazyGather {
         lazy_list: crate::gc::Gc<LazyList>,
         next_index: usize,
+        code_id: usize,
+        loop_ip: usize,
+        resume_body_ip: Option<usize>,
+        inner: Option<Box<ForLoopResumeState>>,
     },
     /// Resume a C-style / `loop` / `while` loop. These loops carry no iteration
     /// index — their state lives entirely in locals/env — so the marker only
     /// signals "we suspended inside this loop; re-enter it" and keeps the VM ip
     /// parked on the loop opcode across a gather coroutine suspend.
-    CStyleLoop,
+    CStyleLoop {
+        inner: Option<Box<ForLoopResumeState>>,
+    },
+}
+
+impl ForLoopResumeState {
+    /// The chained resume state of the loop nested inside this one, if any.
+    pub(crate) fn inner_state(&self) -> Option<&ForLoopResumeState> {
+        match self {
+            ForLoopResumeState::IntRange { inner, .. }
+            | ForLoopResumeState::List { inner, .. }
+            | ForLoopResumeState::LazyGather { inner, .. }
+            | ForLoopResumeState::CStyleLoop { inner } => inner.as_deref(),
+        }
+    }
+
+    /// The ip of the compound loop opcode this state belongs to. A loop op
+    /// only consumes a state carrying its own ip, so a state destined for a
+    /// sibling or nested loop is never mis-applied. `CStyleLoop` markers are
+    /// positionless (their loop keeps state in locals/env) and return `None`.
+    pub(crate) fn loop_ip(&self) -> Option<usize> {
+        match self {
+            ForLoopResumeState::IntRange { loop_ip, .. }
+            | ForLoopResumeState::List { loop_ip, .. }
+            | ForLoopResumeState::LazyGather { loop_ip, .. } => Some(*loop_ip),
+            ForLoopResumeState::CStyleLoop { .. } => None,
+        }
+    }
+
+    /// The identity (ops pointer) of the code object holding this loop.
+    /// `CStyleLoop` markers are positionless and return `None`.
+    pub(crate) fn code_id(&self) -> Option<usize> {
+        match self {
+            ForLoopResumeState::IntRange { code_id, .. }
+            | ForLoopResumeState::List { code_id, .. }
+            | ForLoopResumeState::LazyGather { code_id, .. } => Some(*code_id),
+            ForLoopResumeState::CStyleLoop { .. } => None,
+        }
+    }
+
+    /// True when this state's loop is lexically nested inside the body range
+    /// `[body_start, loop_end)` of a loop in code `code_id` — the only case in
+    /// which an enclosing loop chains it (re-entering its current iteration to
+    /// continue the nested loop). A state from a DIFFERENT code object (reached
+    /// via a sub call) or outside the range is a foreign suspension the
+    /// enclosing loop must NOT chain — it advances normally, exactly as it did
+    /// before nested-resume chaining existed (roast advent2010-day11.t: a
+    /// `take` inside a sub called from `gather for @a {...}`).
+    pub(crate) fn is_lexically_nested_in(
+        &self,
+        code_id: usize,
+        body_start: usize,
+        loop_end: usize,
+    ) -> bool {
+        self.code_id() == Some(code_id)
+            && self
+                .loop_ip()
+                .is_some_and(|lip| lip >= body_start && lip < loop_end)
+    }
 }
 
 /// Pre-compiled fast-path body for a closure sequence generator: the compiled

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -284,9 +284,15 @@ impl Interpreter {
         // re-entering from the top (cond re-check) continues correctly.
         if matches!(
             self.gather_for_loop_resume,
-            Some(crate::value::ForLoopResumeState::CStyleLoop)
+            Some(crate::value::ForLoopResumeState::CStyleLoop { .. })
         ) {
-            self.gather_for_loop_resume = None;
+            // Restore the chained inner state (a loop nested in this body)
+            // into the slot so the next loop op encountered resumes too.
+            if let Some(crate::value::ForLoopResumeState::CStyleLoop { inner }) =
+                self.gather_for_loop_resume.take()
+            {
+                self.gather_for_loop_resume = inner.map(|b| *b);
+            }
         } else if !code.state_locals.is_empty() {
             // Fresh entry to the loop statement: state variables declared in
             // the condition or body re-initialize (fresh block clone per
@@ -305,7 +311,10 @@ impl Interpreter {
             // the condition on resume continues correctly.
             if self.gather_suspend_pending {
                 self.gather_suspend_pending = false;
-                self.gather_for_loop_resume = Some(crate::value::ForLoopResumeState::CStyleLoop);
+                let nested = self.gather_for_loop_resume.take();
+                self.gather_for_loop_resume = Some(crate::value::ForLoopResumeState::CStyleLoop {
+                    inner: nested.map(Box::new),
+                });
                 self.pop_loop_local_scope(code);
                 return Err(RuntimeError::new(
                     crate::runtime::Interpreter::LAZY_GATHER_TAKE_LIMIT_SIGNAL,
@@ -417,8 +426,11 @@ impl Interpreter {
                         // Park a marker so the outer forcer keeps `*ip` on this
                         // loop opcode (it stays unchanged on this Err path),
                         // letting us re-enter and continue from locals/env state.
+                        let nested = self.gather_for_loop_resume.take();
                         self.gather_for_loop_resume =
-                            Some(crate::value::ForLoopResumeState::CStyleLoop);
+                            Some(crate::value::ForLoopResumeState::CStyleLoop {
+                                inner: nested.map(Box::new),
+                            });
                         self.pop_loop_local_scope(code);
                         return Err(e);
                     }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3790,7 +3790,17 @@ impl Interpreter {
             // -- Take --
             OpCode::Take => {
                 self.sync_source_line(code, *ip);
-                self.exec_take_op()?;
+                if let Err(mut e) = self.exec_take_op() {
+                    // Stamp the take-limit suspension with this op's exact
+                    // location so the innermost enclosing for-loop can resume
+                    // the SAME iteration right after this take (statements
+                    // after it must not be lost). Keyed by code identity so a
+                    // loop in a different code object never claims it.
+                    if e.message == crate::runtime::Interpreter::LAZY_GATHER_TAKE_LIMIT_SIGNAL {
+                        e.set_take_suspend_site(Some((code.ops.as_ptr() as usize, *ip)));
+                    }
+                    return Err(e);
+                }
                 *ip += 1;
             }
 

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -18,6 +18,18 @@ impl Interpreter {
         // continuation in `exec_for_loop_op` must NOT pick up newly-pushed tail
         // elements after an early exit).
         let mut completed_all = true;
+        // Nested-resume entry: when the slot holds a state for a loop nested
+        // INSIDE this body (its loop_ip lies in the body range), the resumed
+        // iteration's first body run starts AT that loop op — re-running the
+        // ops before it would replay completed sibling loops / side effects.
+        let this_code_id = code.ops.as_ptr() as usize;
+        let mut nested_entry: Option<usize> = self.gather_resume_body_ip.take().or_else(|| {
+            self.gather_for_loop_resume
+                .as_ref()
+                .filter(|s| s.code_id() == Some(this_code_id))
+                .and_then(|s| s.loop_ip())
+                .filter(|lip| *lip > body_start && *lip < loop_end)
+        });
         let param_name = spec
             .param_idx
             .map(|idx| match code.constants[idx as usize].view() {
@@ -271,7 +283,8 @@ impl Interpreter {
                 self.env_mut().insert(key, Value::FALSE);
             }
             'body_redo: loop {
-                let mut body_result = self.run_range(code, body_start, loop_end, compiled_fns);
+                let run_start = nested_entry.take().unwrap_or(body_start);
+                let mut body_result = self.run_range(code, run_start, loop_end, compiled_fns);
                 // An immutable Mix/Set/Bag source yields immutable weights: if the
                 // body modified a sigilless/rw alias, Raku throws X::Assignment::RO.
                 // Detect it here (writeback is already suppressed above) and convert
@@ -562,10 +575,40 @@ impl Interpreter {
                             == crate::runtime::Interpreter::LAZY_GATHER_TAKE_LIMIT_SIGNAL =>
                     {
                         // Save for-loop state for gather coroutine resumption.
+                        // A state already in the slot belongs to a loop nested
+                        // inside this body: chain it (and re-enter the CURRENT
+                        // iteration so that loop can continue) instead of
+                        // overwriting it. A take-suspend site directly in this
+                        // body likewise re-enters the CURRENT iteration, right
+                        // after the take.
+                        let mut e = e;
+                        let code_id = code.ops.as_ptr() as usize;
+                        let nested = if self.gather_for_loop_resume.as_ref().is_some_and(|st| {
+                            st.is_lexically_nested_in(code_id, body_start, loop_end)
+                        }) {
+                            self.gather_for_loop_resume.take()
+                        } else {
+                            None
+                        };
+                        let take_site = e.take_suspend_site().filter(|(cid, t)| {
+                            *cid == code_id && *t >= body_start && *t < loop_end
+                        });
+                        if take_site.is_some() {
+                            e.set_take_suspend_site(None);
+                        }
+                        let resume_body_ip = take_site.map(|(_, t)| t + 1);
                         self.gather_for_loop_resume =
                             Some(crate::value::ForLoopResumeState::List {
                                 items: items.to_vec(),
-                                next_index: idx + 1,
+                                next_index: if nested.is_some() || resume_body_ip.is_some() {
+                                    idx
+                                } else {
+                                    idx + 1
+                                },
+                                code_id,
+                                loop_ip: body_start - 1,
+                                resume_body_ip,
+                                inner: nested.map(Box::new),
                             });
                         if topic_readonly {
                             self.unmark_readonly("_");

--- a/src/vm/vm_for_loop_dispatch.rs
+++ b/src/vm/vm_for_loop_dispatch.rs
@@ -38,12 +38,18 @@ impl Interpreter {
         ip: &mut usize,
         compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
-        // Check for gather coroutine resume state. A `CStyleLoop` marker belongs
-        // to a `loop`/`while` opcode, not this for-loop, so leave it in place.
-        if !matches!(
-            self.gather_for_loop_resume,
-            Some(crate::value::ForLoopResumeState::CStyleLoop)
-        ) && let Some(resume) = self.gather_for_loop_resume.take()
+        // Check for gather coroutine resume state. A state is consumed only by
+        // the loop op it belongs to (`loop_ip`): a `CStyleLoop` marker belongs
+        // to a `loop`/`while` opcode and a positional state carrying another
+        // ip belongs to a sibling loop — both are left in place. Each resume
+        // restores its chained `inner` state (a loop nested in this body) into
+        // the slot so the nested loop op reached during the replay resumes too.
+        let this_code_id = code.ops.as_ptr() as usize;
+        if self
+            .gather_for_loop_resume
+            .as_ref()
+            .is_some_and(|s| s.code_id() == Some(this_code_id) && s.loop_ip() == Some(*ip))
+            && let Some(resume) = self.gather_for_loop_resume.take()
         {
             let body_start = *ip + 1;
             let loop_end = spec.body_end as usize;
@@ -52,7 +58,12 @@ impl Interpreter {
                     current,
                     end_val,
                     inclusive,
+                    resume_body_ip,
+                    inner,
+                    ..
                 } => {
+                    self.gather_for_loop_resume = inner.map(|b| *b);
+                    self.gather_resume_body_ip = resume_body_ip;
                     self.exec_for_loop_int_range(
                         code,
                         spec,
@@ -66,7 +77,15 @@ impl Interpreter {
                     *ip = loop_end;
                     return Ok(());
                 }
-                crate::value::ForLoopResumeState::List { items, next_index } => {
+                crate::value::ForLoopResumeState::List {
+                    items,
+                    next_index,
+                    resume_body_ip,
+                    inner,
+                    ..
+                } => {
+                    self.gather_for_loop_resume = inner.map(|b| *b);
+                    self.gather_resume_body_ip = resume_body_ip;
                     let _ = self.exec_for_loop_body(
                         code,
                         spec,
@@ -82,7 +101,12 @@ impl Interpreter {
                 crate::value::ForLoopResumeState::LazyGather {
                     lazy_list,
                     next_index,
+                    resume_body_ip,
+                    inner,
+                    ..
                 } => {
+                    self.gather_for_loop_resume = inner.map(|b| *b);
+                    self.gather_resume_body_ip = resume_body_ip;
                     self.exec_for_loop_lazy_gather_from(
                         code,
                         spec,
@@ -96,7 +120,7 @@ impl Interpreter {
                     return Ok(());
                 }
                 // Guarded out above: a CStyleLoop marker is never taken here.
-                crate::value::ForLoopResumeState::CStyleLoop => unreachable!(),
+                crate::value::ForLoopResumeState::CStyleLoop { .. } => unreachable!(),
             }
         }
 

--- a/src/vm/vm_for_loop_intrange.rs
+++ b/src/vm/vm_for_loop_intrange.rs
@@ -47,14 +47,36 @@ impl Interpreter {
         // them per-iteration (owned_captures). Balanced by pop on every exit.
         self.push_loop_local_scope();
 
-        // When resuming a gather coroutine, start from the saved position.
-        let mut i = if let Some(crate::value::ForLoopResumeState::IntRange { current, .. }) =
-            self.gather_for_loop_resume.take()
+        // When resuming a gather coroutine, start from the saved position and
+        // restore the chained inner state (a loop nested in this body) into
+        // the slot so the next loop op encountered resumes too. A state with a
+        // different `loop_ip` belongs to a different loop op — leave it there.
+        let mut i = start;
+        let this_code_id = code.ops.as_ptr() as usize;
+        if self.gather_for_loop_resume.as_ref().is_some_and(|s| {
+            s.code_id() == Some(this_code_id) && s.loop_ip() == Some(body_start - 1)
+        }) && let Some(crate::value::ForLoopResumeState::IntRange {
+            current,
+            resume_body_ip,
+            inner,
+            ..
+        }) = self.gather_for_loop_resume.take()
         {
-            current
-        } else {
-            start
-        };
+            i = current;
+            self.gather_for_loop_resume = inner.map(|b| *b);
+            self.gather_resume_body_ip = resume_body_ip;
+        }
+        // Nested-resume entry: when the slot holds a state for a loop nested
+        // INSIDE this body (its loop_ip lies in the body range), the resumed
+        // iteration's first body run starts AT that loop op — re-running the
+        // ops before it would replay completed sibling loops / side effects.
+        let mut nested_entry: Option<usize> = self.gather_resume_body_ip.take().or_else(|| {
+            self.gather_for_loop_resume
+                .as_ref()
+                .filter(|s| s.code_id() == Some(this_code_id))
+                .and_then(|s| s.loop_ip())
+                .filter(|lip| *lip > body_start && *lip < loop_end)
+        });
 
         // Pre-mark readonly before the loop to avoid per-iteration HashSet
         // insertions. The for loop parameter is readonly for the duration.
@@ -119,7 +141,8 @@ impl Interpreter {
                 self.locals[slot as usize] = item.clone();
             }
             'body_redo: loop {
-                let body_res = self.run_range(code, body_start, loop_end, compiled_fns);
+                let run_start = nested_entry.take().unwrap_or(body_start);
+                let body_res = self.run_range(code, run_start, loop_end, compiled_fns);
                 // State mutations persist on every exit path (`next`/`redo`/
                 // `last`/exception), not just normal completion.
                 if !code.state_locals.is_empty() {
@@ -174,11 +197,39 @@ impl Interpreter {
                             == crate::runtime::Interpreter::LAZY_GATHER_TAKE_LIMIT_SIGNAL =>
                     {
                         // Save for-loop state for gather coroutine resumption.
+                        // A state already in the slot belongs to a loop nested
+                        // inside this body: chain it (and re-enter the CURRENT
+                        // iteration so that loop can continue) instead of
+                        // overwriting it.
+                        let mut e = e;
+                        let code_id = code.ops.as_ptr() as usize;
+                        let nested = if self.gather_for_loop_resume.as_ref().is_some_and(|st| {
+                            st.is_lexically_nested_in(code_id, body_start, loop_end)
+                        }) {
+                            self.gather_for_loop_resume.take()
+                        } else {
+                            None
+                        };
+                        let take_site = e.take_suspend_site().filter(|(cid, t)| {
+                            *cid == code_id && *t >= body_start && *t < loop_end
+                        });
+                        if take_site.is_some() {
+                            e.set_take_suspend_site(None);
+                        }
+                        let resume_body_ip = take_site.map(|(_, t)| t + 1);
                         self.gather_for_loop_resume =
                             Some(crate::value::ForLoopResumeState::IntRange {
-                                current: i.saturating_add(1),
+                                current: if nested.is_some() || resume_body_ip.is_some() {
+                                    i
+                                } else {
+                                    i.saturating_add(1)
+                                },
                                 end_val,
                                 inclusive,
+                                code_id,
+                                loop_ip: body_start - 1,
+                                resume_body_ip,
+                                inner: nested.map(Box::new),
                             });
                         if !spec.is_rw
                             && let Some(ref name) = param_name

--- a/src/vm/vm_for_loop_lazy.rs
+++ b/src/vm/vm_for_loop_lazy.rs
@@ -62,6 +62,18 @@ impl Interpreter {
         // them as one chunk, exactly as the eager path does.
         let arity = spec.arity.max(1) as usize;
         let mut idx: usize = start_idx;
+        // Nested-resume entry: when the slot holds a state for a loop nested
+        // INSIDE this body (its loop_ip lies in the body range), the resumed
+        // iteration's first body run starts AT that loop op — re-running the
+        // ops before it would replay completed sibling loops / side effects.
+        let this_code_id = code.ops.as_ptr() as usize;
+        let mut nested_entry: Option<usize> = self.gather_resume_body_ip.take().or_else(|| {
+            self.gather_for_loop_resume
+                .as_ref()
+                .filter(|s| s.code_id() == Some(this_code_id))
+                .and_then(|s| s.loop_ip())
+                .filter(|lip| *lip > body_start && *lip < loop_end)
+        });
         'for_loop: loop {
             // Force enough elements for one iteration's chunk
             let items = self.force_lazy_list_vm_n(ll, idx + arity)?;
@@ -94,7 +106,8 @@ impl Interpreter {
                 self.env_mut().insert(key, Value::FALSE);
             }
             'body_redo: loop {
-                let body_res = self.run_range(code, body_start, loop_end, compiled_fns);
+                let run_start = nested_entry.take().unwrap_or(body_start);
+                let body_res = self.run_range(code, run_start, loop_end, compiled_fns);
                 // State mutations persist on every exit path (`next`/`redo`/
                 // `last`/exception), not just normal completion.
                 if !code.state_locals.is_empty() {
@@ -138,10 +151,38 @@ impl Interpreter {
                             == crate::runtime::Interpreter::LAZY_GATHER_TAKE_LIMIT_SIGNAL =>
                     {
                         // Save lazy-gather for-loop state for coroutine resumption.
+                        // A state already in the slot belongs to a loop nested
+                        // inside this body: chain it (and re-enter the CURRENT
+                        // chunk, which starts at idx - arity, so that loop can
+                        // continue) instead of overwriting it.
+                        let mut e = e;
+                        let code_id = code.ops.as_ptr() as usize;
+                        let nested = if self.gather_for_loop_resume.as_ref().is_some_and(|st| {
+                            st.is_lexically_nested_in(code_id, body_start, loop_end)
+                        }) {
+                            self.gather_for_loop_resume.take()
+                        } else {
+                            None
+                        };
+                        let take_site = e.take_suspend_site().filter(|(cid, t)| {
+                            *cid == code_id && *t >= body_start && *t < loop_end
+                        });
+                        if take_site.is_some() {
+                            e.set_take_suspend_site(None);
+                        }
+                        let resume_body_ip = take_site.map(|(_, t)| t + 1);
                         self.gather_for_loop_resume =
                             Some(crate::value::ForLoopResumeState::LazyGather {
                                 lazy_list: ll_arc.clone(),
-                                next_index: idx,
+                                next_index: if nested.is_some() || resume_body_ip.is_some() {
+                                    idx.saturating_sub(arity)
+                                } else {
+                                    idx
+                                },
+                                code_id,
+                                loop_ip: body_start - 1,
+                                resume_body_ip,
+                                inner: nested.map(Box::new),
                             });
                         if !spec.is_rw
                             && let Some(ref name) = param_name

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -363,8 +363,15 @@ impl Interpreter {
         // still propagating genuine side effects (e.g., `$x += 1`).
         let gather_result_env = self.env().clone();
         let mut merged_env = saved_env.clone();
+        // The body's OWN declarations (`my`, `for`-loop params) never merge
+        // back: a body loop var shadowing a same-named consumer lexical would
+        // otherwise clobber it (see CompiledCode::self_declared_names).
+        let body_declared = cc.self_declared_names();
         for (k, v) in gather_result_env.iter() {
             if !saved_env.contains_key_sym(*k) {
+                continue;
+            }
+            if body_declared.contains(k) {
                 continue;
             }
             if let Some(initial) = list.env.get_sym(*k) {

--- a/src/vm/vm_helpers_lazy_pull.rs
+++ b/src/vm/vm_helpers_lazy_pull.rs
@@ -245,8 +245,15 @@ impl Interpreter {
         let gather_result_env = self.env().clone();
         let initial_env = &list.env;
         let mut merged_env = saved_env.clone();
+        // The body's OWN declarations (`my`, `for`-loop params) never merge
+        // back: a body loop var shadowing a same-named consumer lexical would
+        // otherwise clobber it (see CompiledCode::self_declared_names).
+        let body_declared = cc.self_declared_names();
         for (k, v) in gather_result_env.iter() {
             if !saved_env.contains_key_sym(*k) {
+                continue;
+            }
+            if body_declared.contains(k) {
                 continue;
             }
             if let Some(initial) = initial_env.get_sym(*k) {

--- a/src/vm/vm_loop_cstyle_repeat.rs
+++ b/src/vm/vm_loop_cstyle_repeat.rs
@@ -40,9 +40,15 @@ impl Interpreter {
         // so re-entering from the top (cond re-check) continues correctly.
         if matches!(
             self.gather_for_loop_resume,
-            Some(crate::value::ForLoopResumeState::CStyleLoop)
+            Some(crate::value::ForLoopResumeState::CStyleLoop { .. })
         ) {
-            self.gather_for_loop_resume = None;
+            // Restore the chained inner state (a loop nested in this body)
+            // into the slot so the next loop op encountered resumes too.
+            if let Some(crate::value::ForLoopResumeState::CStyleLoop { inner }) =
+                self.gather_for_loop_resume.take()
+            {
+                self.gather_for_loop_resume = inner.map(|b| *b);
+            }
         } else if !code.state_locals.is_empty() {
             // Fresh entry to the loop statement: state variables declared in
             // the condition, body or step re-initialize (fresh block clone per
@@ -60,7 +66,10 @@ impl Interpreter {
             // re-entering from the condition on resume continues correctly.
             if self.gather_suspend_pending {
                 self.gather_suspend_pending = false;
-                self.gather_for_loop_resume = Some(crate::value::ForLoopResumeState::CStyleLoop);
+                let nested = self.gather_for_loop_resume.take();
+                self.gather_for_loop_resume = Some(crate::value::ForLoopResumeState::CStyleLoop {
+                    inner: nested.map(Box::new),
+                });
                 self.pop_loop_local_scope(code);
                 return Err(RuntimeError::new(
                     crate::runtime::Interpreter::LAZY_GATHER_TAKE_LIMIT_SIGNAL,
@@ -139,8 +148,11 @@ impl Interpreter {
                             self.pop_loop_local_scope(code);
                             return Err(step_err);
                         }
+                        let nested = self.gather_for_loop_resume.take();
                         self.gather_for_loop_resume =
-                            Some(crate::value::ForLoopResumeState::CStyleLoop);
+                            Some(crate::value::ForLoopResumeState::CStyleLoop {
+                                inner: nested.map(Box::new),
+                            });
                         self.pop_loop_local_scope(code);
                         return Err(e);
                     }

--- a/t/gather-nested-loop-pull.t
+++ b/t/gather-nested-loop-pull.t
@@ -1,0 +1,125 @@
+use v6;
+use Test;
+
+plan 14;
+
+# Lazy pull/resume of a gather whose body contains NESTED or SEQUENTIAL for
+# loops, or several takes per iteration. The single resume slot used to be
+# overwritten by each enclosing loop as the take-limit signal propagated out,
+# losing the inner loop's position (and statements after a take were skipped
+# on resume). Root cause of roast/integration/99problems-51-to-60.t tests 8/21
+# (P55 cbal-tree / P59 hbal-tree).
+
+# (1) body loop var must not leak into the consumer scope on pull
+# (.gist comparison: the itemization of the pulled element in .raku is a
+# separate open issue and not what this pins)
+sub leak() { gather { for [Any] -> $a { take ['y', $a] } } }
+my @pairs;
+for leak() -> $a {
+    for leak() -> $b {
+        push @pairs, ($a.gist ~ '|' ~ $b.gist);
+    }
+}
+is @pairs.elems, 1, 'nested pull over same sub: one pair';
+is @pairs[0], '[y (Any)]|[y (Any)]', 'consumer loop vars not clobbered by body loop var';
+
+# (2) multiple takes per iteration survive lazy pull
+sub multi-take() { gather { for 1, 2 -> $x { take $x; take $x * 10 } } }
+is multi-take().join(','), '1,10,2,20', 'multi-take: full force';
+my @mt; for multi-take() -> $v { push @mt, $v }
+is @mt.join(','), '1,10,2,20', 'multi-take: lazy pull keeps takes after the suspending take';
+
+# (3) nested eager loops inside a pulled gather
+sub nested-eager() { gather { for 1, 2 -> $a { for 3, 4 -> $b { take $a * 10 + $b } } } }
+my @ne; for nested-eager() -> $v { push @ne, $v }
+is @ne.join(','), '13,14,23,24', 'nested eager loops: inner position survives suspend';
+
+# (4) recursive gather: nested lazy-gather loops
+sub u(Int $n) {
+    return (1, 2) if $n == 0;
+    gather {
+        for u($n - 1) -> $a {
+            for u($n - 1) -> $b {
+                take $a * 10 + $b;
+            }
+        }
+    }
+}
+is u(1).join(','), '11,12,21,22', 'recursive gather depth 1';
+is +u(2), 16, 'recursive gather depth 2: all 16 combinations';
+
+# (5) conditional multi-take in the second sequential loop (P59 shape)
+sub g6(Int $n) {
+    return (1, 2) if $n == 0;
+    gather {
+        for g6($n - 1) -> $a {
+            for g6($n - 1) -> $b {
+                take $a * 10 + $b;
+            }
+            for g6($n - 1) -> $b {
+                if $b % 2 == 0 {
+                    take $a * 100 + $b;
+                    take $b * 100 + $a;
+                }
+            }
+        }
+    }
+}
+is g6(1).join(','), '11,12,102,201,21,22,202,202', 'sequential loops + conditional double take: depth 1';
+is +g6(2), 144, 'sequential loops + conditional double take: depth 2';
+
+# (6) P55 cbal-tree shape: gather over recursion, is-deeply on structure
+sub cbal-tree(Int $n) {
+    return [Any] if $n == 0;
+    gather {
+        if $n % 2 == 1 {
+            my $k = ($n - 1) div 2;
+            for cbal-tree($k) -> $a {
+                for cbal-tree($k) -> $b {
+                    take ['x', $a, $b],;
+                }
+            }
+        } else {
+            my $k = $n div 2;
+            for cbal-tree($k) -> $a {
+                for cbal-tree($k - 1) -> $b {
+                    take ['x', $a, $b],;
+                }
+            }
+            for cbal-tree($k - 1) -> $a {
+                for cbal-tree($k) -> $b {
+                    take ['x', $a, $b],;
+                }
+            }
+        }
+    }
+}
+is-deeply [ cbal-tree(3) ], [['x', ['x', Any, Any], ['x', Any, Any]],],
+    'P55 cbal-tree(3): outer loop var intact through recursion';
+is +cbal-tree(4), 4, 'P55 cbal-tree(4) count';
+
+# (7) int-range loop nested in a pulled gather
+sub ir() { gather { for 1..2 -> $a { for 1..2 -> $b { take $a * 10 + $b } } } }
+my @ir; for ir() -> $v { push @ir, $v }
+is @ir.join(','), '11,12,21,22', 'nested int-range loops under lazy pull';
+
+# (8) a take inside a SUB called from the gather's for-body must NOT make the
+# enclosing for-loop re-enter its current iteration (which would re-run the sub
+# and duplicate its side effects). Regression guard for roast advent2010-day11.t.
+sub push-take(@values, $new, $n) {
+    @values.push($new);
+    @values.shift if +@values > $n;
+    if +@values == $n {
+        for @values { take $_ }
+    }
+}
+sub sliding(@a, $n) {
+    my @values;
+    gather for @a -> $x { push-take(@values, $x, $n) }
+}
+my @windows;
+for sliding(<a b c d e>, 3) -> $p, $q, $r {
+    push @windows, "$p$q$r";
+}
+is @windows.join(' '), 'abc bcd cde', 'take inside a sub called from gather-for: no duplicated side effects';
+is @windows.elems, 3, 'sliding-window produced the right number of windows';


### PR DESCRIPTION
## Summary

A `gather` whose body contains **nested or sequential `for`-loops** (or several `take`s per iteration) dropped elements when pulled lazily (`for gather {...} -> $x`). The single `gather_for_loop_resume` slot was overwritten as the take-limit suspension signal propagated out through each enclosing loop:

- Each enclosing loop clobbered the **inner loop's saved position**, so the inner loop restarted (or was skipped) on resume.
- **Statements after the suspending `take`** in the same iteration were lost (resume always re-entered at `body_start`).
- A body `for`-loop variable that **shadowed a same-named consumer lexical** leaked back into the consumer through the pull-site env merge.

## Fix

1. `ForLoopResumeState` variants now carry `loop_ip` (owning loop op), `inner` (chained resume state of a nested loop), and `resume_body_ip` (exact mid-body re-entry ip). A loop op consumes only the state whose `loop_ip` matches, restoring the chained `inner` for the nested loop reached during body replay. Enclosing loops re-enter their **current** iteration when an inner/take-site resume is pending.
2. The `Take` opcode stamps its exact `(code-identity, ip)` on the take-limit signal; the innermost enclosing for-loop consumes it as `resume_body_ip = ip + 1`, so post-take statements run on resume.
3. The gather force/pull env merge excludes the body's OWN declared names (`my`, for-loop params) via `CompiledCode::self_declared_names`.

## Impact

`roast/integration/99problems-51-to-60.t` tests 8 (P55 cbal-tree) and 21 (P59 hbal-tree) now pass — the file is 37/37 and whitelisted.

## Tests

- Pin: `t/gather-nested-loop-pull.t` (12 assertions, verified against raku)
- `make test` all pass; spot-checked `S04-statements/gather.t`, `S04-statements/lazy.t`, `S02-types/lazy-lists.t`, `integration/gather-with-loops.t`, `t/gather-while-pull-resume.t`

🤖 Generated with [Claude Code](https://claude.com/claude-code)