### PR TITLE
perf: batched setup-once .first matcher (compile once, run_reuse per element)

### DIFF
--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -470,8 +470,167 @@ impl Interpreter {
         list_items: &[Value],
         from_end: bool,
     ) -> Result<Option<(usize, Value)>, RuntimeError> {
+        if let Some(func_ref) = func.as_ref()
+            && let Some(res) = self.try_first_match_batched(func_ref, list_items, from_end)
+        {
+            return res;
+        }
         let mut matcher = InterpFirstMatcher(self);
         find_first_match_generic(&mut matcher, func.as_ref(), list_items, from_end)
+    }
+
+    /// Batched `.first` over a `Sub` matcher: one compile + closure-env setup,
+    /// then a bare `run_reuse` per element with an early exit on the first
+    /// match — the same setup-once shape as `eval_grep_over_items_with_mutated`.
+    /// The per-element full call machinery (`call_sub_value` /
+    /// `call_compiled_closure`: call frame, scoped overlay, captured-env merge,
+    /// `&?BLOCK` construction, full binder) costs ~25x more per element, which
+    /// made `.first(*.contains(...))` the single hottest line of zef's
+    /// Ecosystems populate.
+    ///
+    /// Returns `None` when the matcher needs the full per-element machinery
+    /// (destructuring sub-signature, composed callable, `.assuming` partials,
+    /// multi-param blocks), so the caller falls back unchanged.
+    pub(crate) fn try_first_match_batched(
+        &mut self,
+        func: &Value,
+        list_items: &[Value],
+        from_end: bool,
+    ) -> Option<Result<Option<(usize, Value)>, RuntimeError>> {
+        let ValueView::Sub(data) = func.view() else {
+            return None;
+        };
+        if list_items.is_empty() {
+            return Some(Ok(None));
+        }
+        let data = data.clone();
+        if data
+            .param_defs
+            .iter()
+            .any(|pd| pd.sub_signature.is_some() || pd.outer_sub_signature.is_some())
+        {
+            return None;
+        }
+        if !data.assumed_positional.is_empty() || !data.assumed_named.is_empty() {
+            return None;
+        }
+        if data.env.contains_key("__mutsu_compose_left")
+            && data.env.contains_key("__mutsu_compose_right")
+        {
+            return None;
+        }
+        // A multi-param matcher block would take element tuples; `.first` has
+        // no chunking semantics — keep it on the per-element generic path.
+        if data.params.len() > 1 {
+            return None;
+        }
+
+        // Compile once (mirrors grep: normalize the tail statement so the last
+        // expression lands on the stack as the predicate value).
+        let mut compiler = crate::compiler::Compiler::new();
+        compiler.lexically_in_routine = !self.routine_stack.is_empty();
+        let normalized_body = normalize_tail_stmt_for_value(&data.body);
+        let (code, compiled_fns) = compiler.compile(&normalized_body);
+
+        let underscore = "_".to_string();
+        let dollar_topic = "$_".to_string();
+        let mut touched_keys: Vec<String> = Vec::with_capacity(data.params.len() + 2);
+        for k in data.env.keys() {
+            if !self.env.contains_key_sym(*k) {
+                touched_keys.push(k.resolve());
+            }
+        }
+        for p in &data.params {
+            if !touched_keys.contains(p) {
+                touched_keys.push(p.clone());
+            }
+        }
+        if !touched_keys.iter().any(|k| k == "_") {
+            touched_keys.push(underscore.clone());
+        }
+        if !touched_keys.iter().any(|k| k == "$_") {
+            touched_keys.push(dollar_topic.clone());
+        }
+        let saved: Vec<(String, Option<Value>)> = touched_keys
+            .iter()
+            .map(|k| (k.clone(), self.env.get(k).cloned()))
+            .collect();
+
+        // Pre-insert closure env
+        for (k, v) in &data.env {
+            self.env.insert_sym(*k, v.clone());
+        }
+
+        let mut found: Option<(usize, Value)> = None;
+        let loop_result: Result<(), RuntimeError> = self.with_nested_registers(|vm| {
+            vm.set_topic_source_var(None);
+            let len = list_items.len();
+            for scan in 0..len {
+                let idx = if from_end { len - 1 - scan } else { scan };
+                let item = &list_items[idx];
+                // A Hash-sourced `Pair` element binds positionally (same as
+                // the generic path's `pair_as_positional`).
+                let call_item = crate::runtime::utils::pair_as_positional(item);
+                'body_redo: loop {
+                    if let Some(p) = data.params.first() {
+                        vm.env_mut().insert(p.clone(), call_item.clone());
+                    }
+                    vm.env_mut().insert(underscore.clone(), call_item.clone());
+                    vm.env_mut().insert(dollar_topic.clone(), call_item.clone());
+                    match vm.run_reuse(&code, &compiled_fns) {
+                        Ok(()) => {
+                            let pred = vm
+                                .last_stack_value()
+                                .cloned()
+                                .or_else(|| vm.env().get("_").cloned())
+                                .unwrap_or(Value::NIL);
+                            if pred.truthy() {
+                                found = Some((idx, item.clone()));
+                            }
+                            break 'body_redo;
+                        }
+                        Err(e) if e.is_redo() => continue 'body_redo,
+                        // `next` skips the element; `last` stops the scan and
+                        // returns the CURRENT element as the match (Rakudo
+                        // behaviour, mirrored from `find_first_match_generic`).
+                        Err(e) if e.is_next() => break 'body_redo,
+                        Err(e) if e.is_last() => {
+                            found = Some((idx, item.clone()));
+                            return Ok(());
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+                if found.is_some() {
+                    return Ok(());
+                }
+            }
+            Ok(())
+        });
+
+        for (k, orig) in saved {
+            match orig {
+                Some(v) => {
+                    self.env.insert(k, v);
+                }
+                None => {
+                    self.env.remove(&k);
+                }
+            }
+        }
+        // The matcher block may mutate a captured-outer lexical (`.first({
+        // $count++; ... })` — S32-list/first-kv.t "matcher got only executed
+        // once"). Its `$count++` landed in the shared `env` during the loop,
+        // but the caller's stale `locals` slot must be refreshed on return.
+        // Queue those free-var writes for the CallMethod op to drain, exactly
+        // as `eval_grep_over_items_with_mutated` does.
+        if loop_result.is_ok() {
+            self.record_eager_block_free_var_writeback(&code, &data.params);
+        }
+        match loop_result {
+            Ok(()) => Some(Ok(found)),
+            Err(e) => Some(Err(e)),
+        }
     }
 }
 

--- a/src/vm/vm_native_first.rs
+++ b/src/vm/vm_native_first.rs
@@ -82,6 +82,19 @@ impl Interpreter {
         }
 
         let items = crate::runtime::utils::value_to_list(target);
+        // Setup-once batched scan for a plain `Sub` matcher (one compile +
+        // env setup, bare `run_reuse` per element, early exit) — ~25x cheaper
+        // per element than the per-element closure call below. Falls through
+        // for matchers it cannot handle (sub-signature, composed, .assuming).
+        if let Some(func_ref) = func.as_ref()
+            && let Some(res) = self.try_first_match_batched(func_ref, &items, false)
+        {
+            return match res {
+                Ok(Some((_, value))) => Some(Ok(value)),
+                Ok(None) => Some(Ok(Value::NIL)),
+                Err(e) => Some(Err(e)),
+            };
+        }
         let mut matcher = VmFirstMatcher(self);
         match find_first_match_generic(&mut matcher, func.as_ref(), &items, false) {
             Ok(Some((_, value))) => Some(Ok(value)),

--- a/t/first-batched-matcher.t
+++ b/t/first-batched-matcher.t
@@ -1,0 +1,74 @@
+use v6;
+use Test;
+
+# Pin for the setup-once batched `.first` matcher path
+# (Interpreter::try_first_match_batched, resolution_map_grep.rs). A `Sub`
+# matcher is compiled once and run per element via a bare `run_reuse` with an
+# early exit, instead of the ~25x-more-expensive per-element `call_sub_value`
+# (call frame + scoped overlay + captured-env merge + full binder). This was
+# the single hottest line of zef's Ecosystems populate
+# (`.first(*.contains('<'))` over 7657 dists). The batched path must stay
+# byte-identical to the generic per-element path in every observable way.
+
+plan 15;
+
+# Basic match / no-match
+is (1, 2, 3, 4).first(* > 2), 3, 'first matches';
+is (1, 2, 3, 4).first(* > 10), Nil, 'first no-match returns Nil';
+
+# From the end
+is (1, 2, 3, 4).first(* > 2, :end), 4, 'first :end scans from the end';
+
+# Hash source: the Pair binds positionally to the block topic
+{
+    my %h = a => 1, b => 2, c => 3;
+    is %h.first({ .value == 2 }).key, 'b', 'first over a hash binds pairs positionally';
+}
+
+# `last` control: stop the scan, return the CURRENT element as the match
+is (5, 1, 2).first({ last if $_ == 1; $_ > 10 }), 1, 'last inside first returns the current element';
+
+# `next` control: skip the current element (treat as non-matching)
+is (1, 2, 3, 4).first({ next if $_ < 3; True }), 3, 'next inside first skips the element';
+
+# Closure captures an outer lexical
+{
+    my $threshold = 3;
+    is (1, 2, 3, 4, 5).first({ $_ > $threshold }), 4, 'first matcher captures outer lexical';
+}
+
+# Side effects run left-to-right, stopping at the first match
+{
+    my @seen;
+    my $r = (1, 2, 3, 4).first({ @seen.push($_); $_ == 3 });
+    is $r, 3, 'first stops at the match';
+    is-deeply @seen, [1, 2, 3], 'first ran the matcher exactly up to the match';
+}
+
+# Inside a sub (the compiled body must treat `return` correctly — here the
+# block has no return, but the enclosing sub does)
+{
+    sub find-big(@list) { @list.first(* > 100) // -1 }
+    is find-big([5, 200, 3]), 200, 'first inside a sub';
+}
+
+# Non-Sub matchers keep the generic path (regex / Str)
+is <foo bar baz>.first(/a/), 'bar', 'regex matcher still works (generic path)';
+is <foo bar baz>.first('bar'), 'bar', 'Str matcher still works (generic path)';
+
+# Empty list
+is ().first(* > 2), Nil, 'first over an empty list is Nil';
+
+# The matcher block may mutate a captured-outer lexical: its writes land in the
+# shared env during the batched loop and must be reflected in the caller's slot
+# on return (roast S32-list/first-kv.t "matcher got only executed once"). The
+# first element (1) matches `$^x % 2`, so the block runs exactly once.
+{
+    my @list = 1 ... 10;
+    my $count = 0;
+    my $r = @list.first({ $count++; $^x % 2 });
+    is $r, 1, 'first with a captured-outer-mutating matcher returns the match';
+    is $count, 1, 'the outer counter mutation is written back (matcher ran once)';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

`.first(&sub)` invoked the full per-element call machinery for **every** item (`call_sub_value` / `call_compiled_closure`: a call frame, scoped env overlay, captured-env merge, `&?BLOCK` construction, full signature binder — ~25× the per-element cost of a bare `run_reuse`).

`.first(*.contains('<'))` over 7657 dists was the **single hottest line** of zef's Ecosystems populate after the loop-writeback fix (#4597).

## Fix

Mirror what grep already does (`eval_grep_over_items_with_mutated`): compile the matcher body once, set up its closure env once, then run it per element via `run_reuse` under `with_nested_registers`, with an early exit on the first match.

A new `try_first_match_batched` fronts **both** dispatch routes:
- `find_first_match_over_items` (interpreter path — also feeds `.first` adverbs `:kv`/`:k`/`:p`/`:end`), and
- `try_native_first` (VM path).

so every `.first`-with-a-`Sub` route shares it. Matchers needing the full per-element machinery (destructuring sub-signature, composed / `.assuming` partials, multi-param blocks) return `None` and fall back unchanged; non-`Sub` matchers (regex / Str / type-object / junction) keep the generic `smart_match` path.

## Semantics preserved (byte-identical to the generic scan)

- `next` (skip element) / `last` (stop, current element is the match) / `redo` loop controls
- captured-outer lexical mutation written back to the caller's slot — like grep, via `record_eager_block_free_var_writeback` (roast **S32-list/first-kv.t** "matcher got only executed once" — caught and fixed a first-cut regression here)
- `return` inside the matcher escaping to the enclosing sub
- adverbs `:k`/`:kv`/`:p`/`:end` (they separate named args first, then run the Sub matcher through the shared batched scan)

## Measured (release)

| case | before | after |
|---|---|---|
| `.first(*.contains(...))` over 65k strings | 0.54s | **0.05s** (~10.8×, now grep-equal) |
| zef populate (tmp/populate-bench.raku, 7657 dists) | 5.52s | **4.23s** |
| bench-ctor instructions | 2.39G | 2.39G (no regression) |

## Verification

- Semantics vs raku (all identical): basic/no-match, `:end`, hash pairs, `next`/`last`/`redo`, outer capture + writeback, in-sub `return`, WhateverCode/regex/Str/junction, `:k`/`:kv`/`:p` adverbs.
- Roast green: all S32-list/first*.t (first, first-k/-kv/-p/-v/-end and end variants), S32-list/grep.t, S02-types/baghash.t.
- `make test`: PASS (full suite).
- Pin: `t/first-batched-matcher.t` (15 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)