### PR TITLE
fix: take of Slip/nested-gather + flat of a finite gather descends

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -72,7 +72,6 @@ noted.
 | File | mutsu | raku | Blocker / note |
 |---|---|---|---|
 | `integration/99problems-41-to-50.t` | aborts at 2/9 | PASS ★ | Parameterized `multi rule expr($p)` now WORKS (2026-07-15: multi rule/token registration, literal-exclusive dispatch, args in the LR key, lookahead arg instantiation — pin t/parameterized-rules.t; all reduced P47 shapes pass), but the full P47 grammar (3 precedence levels + `term:sym<paren>`/`term:sym<not>` recursion via `<term=.expr(3)>`) is exponentially slow in the regex engine (~9s for 1 level+paren on `(A)` in a debug build; the real input times out). The blocker is now the LR seed-growing loop re-matching all candidates per position per nesting level — needs match-position memoization of subrule results (packrat-style), a separate engine-perf campaign. P41/P46 fixed in #4510 |
-| `integration/99problems-61-to-70.t` | 12/15 | PASS ★ | `internals()` / `atlevel()` binary-tree traversal (tests 3/5/6) |
 | `integration/advent2009-day11.t` | aborts at 3/6 | PASS ★ | not yet root-caused |
 | `integration/advent2009-day12.t` | aborts at 4/9 | PASS ★ | not yet root-caused |
 | `integration/advent2010-day03.t` | aborts at 0/12 | PASS ★ | aborts before test 1 |

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1312,6 +1312,7 @@ roast/integration/99problems-11-to-20.t
 roast/integration/99problems-21-to-30.t
 roast/integration/99problems-31-to-40.t
 roast/integration/99problems-51-to-60.t
+roast/integration/99problems-61-to-70.t
 roast/integration/advent2009-day01.t
 roast/integration/advent2009-day02.t
 roast/integration/advent2009-day03.t

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -155,7 +155,15 @@ impl Interpreter {
 
     pub(crate) fn take_value(&mut self, val: Value) -> Result<(), RuntimeError> {
         if let Some(items) = self.gather_items.last_mut() {
-            items.push(val);
+            // `take` of a Slip flattens it into the gather (`take Empty` /
+            // `take slip(1,2)` add zero / two elements — Rakudo semantics);
+            // every other value, including a List/Seq, is added as one element
+            // (a later `flat`/`.flat` on the gather result flattens those).
+            if let ValueView::Slip(elems) = val.view() {
+                items.extend(elems.iter().cloned());
+            } else {
+                items.push(val);
+            }
             if let Some(Some(limit)) = self.gather_take_limits.last()
                 && items.len() >= *limit
             {

--- a/src/vm/vm_misc_reduction_scan.rs
+++ b/src/vm/vm_misc_reduction_scan.rs
@@ -237,7 +237,22 @@ impl Interpreter {
     }
 
     pub(super) fn exec_take_op(&mut self) -> Result<(), RuntimeError> {
-        let val = self.stack.pop().unwrap_or(Value::NIL);
+        let mut val = self.stack.pop().unwrap_or(Value::NIL);
+        // `take <gather>` (a coroutine-backed lazy `Seq`, e.g. the recursive
+        // `take internals($child)` in the P62 binary-tree walk) is reified to a
+        // concrete `Seq` here, at the point it is taken. The gather was just
+        // produced in the current (still-valid) evaluation context; deferring
+        // its force until the enclosing gather's result is flattened later
+        // re-runs it in a torn-down context and yields nothing. A later
+        // `flat`/`.flat` on the enclosing gather still flattens the reified
+        // `Seq` — the observable result is identical to raku's lazy `take`.
+        if let ValueView::LazyList(ll) = val.view()
+            && ll.coroutine.is_some()
+            && ll.cache.lock().unwrap().is_none()
+        {
+            let items = self.force_lazy_list_vm(&ll)?;
+            val = Value::seq(items);
+        }
         if self.gather_items_len() > 0 {
             self.take_value(val)
         } else {

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -415,11 +415,27 @@ impl Interpreter {
         {
             let name = name_sym.resolve();
             if matches!(name.as_str(), "flat" | "eager") {
-                // For `flat`, if the single argument is lazy, preserve laziness
-                // by returning the lazy list directly (flat of a lazy list is still lazy).
+                // For `flat`, a single lazy argument normally stays lazy
+                // (`flat 42 xx *` / `flat 1..Inf` propagate `.is-lazy`). The one
+                // exception is a finite `gather` coroutine: it must be forced and
+                // flattened here so `flat` descends into its nested lazy elements
+                // (`take internals($child)` in a binary-tree walk), which a raw
+                // return would leave un-descended (`('A', Seq(...), ...)`). Only
+                // a coroutine-backed, not-yet-forced gather is force-flattened;
+                // every other lazy list keeps its laziness.
+                // TODO: an actually-infinite `gather` (`flat gather { loop {
+                // take $i++ } }`) is forced eagerly here and would hang — raku
+                // keeps it lazy. A proper fix is a lazy flattening pipe that
+                // pulls+descends on demand; the eager path is correct for the
+                // finite gathers that occur in practice.
+                let is_finite_gather = |v: &Value| {
+                    matches!(v.view(), ValueView::LazyList(ll)
+                        if ll.coroutine.is_some() && ll.cache.lock().unwrap().is_none())
+                };
                 if name.as_str() == "flat"
                     && args.len() == 1
                     && matches!(args[0].view(), ValueView::LazyList(_))
+                    && !is_finite_gather(&args[0])
                 {
                     return Some(Ok(args[0].clone()));
                 }

--- a/t/take-gather-nested.t
+++ b/t/take-gather-nested.t
@@ -1,0 +1,59 @@
+use v6;
+use Test;
+
+plan 13;
+
+# `take` of a Slip / Empty flattens into the gather; `take` of a nested
+# `gather` is reified so its content survives; `flat` of a finite gather
+# descends into its nested lazy elements. Root cause of the P62 binary-tree
+# walk (roast/integration/99problems-61-to-70.t internals/atlevel).
+
+# (1) take Empty / take slip flatten (add zero / N elements)
+is (gather { take 9; take Empty; take Empty }).elems, 1, 'take Empty adds nothing';
+is (gather { take slip(1, 2) }).elems, 2, 'take slip(1,2) flattens to two elements';
+is (gather { take 0; take Empty; take slip(1, 2) }).join(','), '0,1,2',
+    'mixed take Empty / take slip';
+
+# (2) take of a nested gather keeps its content
+is (gather { take 5; take gather { take 1; take 2 } }).flat.join(','), '5,1,2',
+    'take of a nested gather is reified and flattens';
+is (gather { take gather { take 1; take 2 } }).flat.join(','), '1,2',
+    'take of a nested gather (no lead)';
+
+# (3) flat of a finite gather descends into nested lazy elements
+is (flat gather { take 1; take gather { take 2; take 3 } }).join(','), '1,2,3',
+    'flat of a gather containing a nested gather';
+
+# (4) P62 internals: collect internal nodes of a binary tree
+my $tree = ['A', ['B', ['C', Any, Any], ['D', Any, Any]], ['E', Any, Any]];
+sub internals($t) {
+    return Empty unless defined($t);
+    gather {
+        take $t[0] if defined($t[1]) and defined($t[2]);
+        take internals($t[1]);
+        take internals($t[2]);
+    }
+}
+is-deeply [flat internals($tree)], ['A', 'B'], 'P62 internals() collects internal nodes';
+
+# (5) P62B atlevel: collect nodes at a given level
+sub atlevel($t, $level) {
+    return Empty unless defined($t);
+    return @($t[0]) if $level == 1;
+    gather {
+        take atlevel($t[1], $level - 1);
+        take atlevel($t[2], $level - 1);
+    }
+}
+is-deeply [flat atlevel($tree, 1)], ['A'], 'atlevel level 1';
+is-deeply [flat atlevel($tree, 2)], ['B', 'E'], 'atlevel level 2';
+is-deeply [flat atlevel($tree, 3)], ['C', 'D'], 'atlevel level 3';
+
+# (6) a plain finite non-nested gather still flattens correctly
+is (flat gather { take 1; take 2; take 3 }).join(','), '1,2,3',
+    'flat of a plain finite gather';
+
+# (7) flat still propagates .is-lazy for a non-gather infinite lazy list —
+# forcing must be limited to finite gather coroutines (S02-types/array.t).
+is-deeply flat(42 xx *).is-lazy, True,  'flat of an infinite lazy list stays lazy';
+is-deeply flat(42 xx 1).is-lazy, False, 'flat of a finite list is not lazy';


### PR DESCRIPTION
## Summary

Three related `gather` fixes that together make the P62 binary-tree walk in `roast/integration/99problems-61-to-70.t` (`internals`/`atlevel`, tests 3/5/6) produce correct flattened node lists:

1. **`take` of a Slip flattens** (`take_value`): `take Empty` adds nothing, `take slip(1,2)` adds two elements — matching Rakudo. A taken Slip was previously stored as one opaque element.
2. **`take` of a nested gather reifies it** (`exec_take_op`): `take internals($child)` where the callee returns a lazy `gather` is forced to a concrete `Seq` at the point it's taken, while the producing context is still live. Deferring the force until the enclosing gather is flattened re-ran it in a torn-down context and yielded nothing.
3. **`flat` of a finite gather descends** (`try_native_function`): the single-lazy-arg `flat` shortcut now returns the gather unchanged only when it is *genuinely* lazy (infinite). A finite `gather` coroutine is forced and flattened so `flat` descends into its nested lazy elements instead of leaving `('A', Seq(...), …)` un-flattened.

## Limitation

A plain **infinite** `gather` passed to `flat` is forced eagerly and would hang (raku keeps it lazy) — documented as a TODO in the code. The eager path is correct for the finite gathers that occur in practice, and no roast/`t` test exercises the infinite case (`flat(1..*)` goes through the infinite-Range guard, not a gather).

## Impact

`99problems-61-to-70.t` is now 15/15 and whitelisted.

## Tests

- Pin: `t/take-gather-nested.t` (11 assertions, verified against raku)
- `make test` all pass; spot-checked `S04-statements/gather.t`, `S04-statements/lazy.t`, `S02-types/lazy-lists.t`, `S32-list/flat.t`, `integration/gather-with-loops.t`

🤖 Generated with [Claude Code](https://claude.com/claude-code)