### PR TITLE
fix: dir returns Seq, map/grep flatten a Seq arg, IO::Handle.gist format

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -75,7 +75,6 @@ noted.
 | `integration/99problems-61-to-70.t` | 12/15 | PASS ★ | `internals()` / `atlevel()` binary-tree traversal (tests 3/5/6) |
 | `integration/advent2009-day11.t` | aborts at 3/6 | PASS ★ | not yet root-caused |
 | `integration/advent2009-day12.t` | aborts at 4/9 | PASS ★ | not yet root-caused |
-| `integration/advent2010-day03.t` | aborts at 0/12 | PASS ★ | aborts before test 1 |
 | `integration/advent2010-day16.t` | aborts at 8/13 | PASS ★ | not yet root-caused |
 | `integration/advent2011-day11.t` | 7/9 | PASS ★ | error-message quality for a typo'd method call ("order total with typo" / "public method sanity") — ④-adjacent |
 | `integration/advent2011-day14.t` | aborts at 4/8 | PASS ★ | not yet root-caused |

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1334,6 +1334,7 @@ roast/integration/advent2009-day21.t
 roast/integration/advent2009-day22.t
 roast/integration/advent2009-day23.t
 roast/integration/advent2009-day24.t
+roast/integration/advent2010-day03.t
 roast/integration/advent2010-day04.t
 roast/integration/advent2010-day06.t
 roast/integration/advent2010-day07.t

--- a/src/runtime/builtins_collection_mapgrep.rs
+++ b/src/runtime/builtins_collection_mapgrep.rs
@@ -30,7 +30,14 @@ impl Interpreter {
                 .is_some_and(|name| {
                     !name.starts_with('@') && !name.starts_with('%') && !name.starts_with('&')
                 });
-            if !is_itemized && crate::runtime::utils::is_shaped_array(arg) {
+            // A `Seq` always flattens as a map list argument, even from a
+            // scalar `$` source (`my $s = (1,2,3).Seq; map {...}, $s` iterates
+            // its three elements in Rakudo) — a Seq is a sequence, not an
+            // itemizable container. `dir` returns a Seq, so `map {...}, dir`
+            // must iterate the IO::Path entries, not the whole Seq.
+            if let ValueView::Seq(items) = arg.view() {
+                list_items.extend(items.iter().cloned());
+            } else if !is_itemized && crate::runtime::utils::is_shaped_array(arg) {
                 list_items.extend(crate::runtime::utils::shaped_array_leaves(arg));
             } else if is_itemized {
                 // Itemized containers (from $ variables) are NOT flattened

--- a/src/runtime/builtins_io_fs.rs
+++ b/src/runtime/builtins_io_fs.rs
@@ -97,7 +97,10 @@ impl Interpreter {
             let basename = entry.file_name().to_string_lossy().to_string();
             push_entry(&basename);
         }
-        Ok(Value::array(entries))
+        // `dir` returns a `Seq` in Rakudo (`dir.^name eq 'Seq'`), so it
+        // flattens as a listop argument (`map { ... }, dir`). A plain `List`
+        // would be treated as a single item by the listop map/grep arg path.
+        Ok(Value::seq(entries))
     }
 
     pub(super) fn builtin_copy(&self, args: &[Value]) -> Result<Value, RuntimeError> {

--- a/src/runtime/native_io/io_handle.rs
+++ b/src/runtime/native_io/io_handle.rs
@@ -105,7 +105,7 @@ impl Interpreter {
                 }
                 Ok(Value::NIL)
             }
-            "Str" | "gist" => {
+            "Str" => {
                 if let Some(path_val) = target.get("path") {
                     let path = match path_val.view() {
                         ValueView::Instance {
@@ -122,6 +122,30 @@ impl Interpreter {
                     return Ok(Value::str(path));
                 }
                 Ok(Value::str_from("IO::Handle()"))
+            }
+            // Rakudo: `IO::Handle<"path".IO>(opened|closed)` — distinct from
+            // `.Str` (the bare path). The path is rendered via IO::Path.raku
+            // (`"path".IO`); the open/closed suffix reflects the live state.
+            "gist" => {
+                let opened = self
+                    .with_handle_mut(&target_val, |state| Ok(state.is_opened()))
+                    .unwrap_or(false);
+                let state = if opened { "opened" } else { "closed" };
+                if let Some(path_val) = target.get("path") {
+                    let path_raku = self
+                        .call_method_with_values(path_val.clone(), "raku", vec![])
+                        .map(|v| v.to_string_value())
+                        .unwrap_or_else(|_| {
+                            format!(
+                                "{}.IO",
+                                crate::builtins::methods_0arg::raku_repr::escape_raku_str(
+                                    &path_val.to_string_value()
+                                )
+                            )
+                        });
+                    return Ok(Value::str(format!("IO::Handle<{path_raku}>({state})")));
+                }
+                Ok(Value::str(format!("IO::Handle<>({state})")))
             }
             "raku" | "perl" => {
                 // Reconstructable but deliberately *unopened*: matches rakudo's

--- a/t/dir-seq-map-gist.t
+++ b/t/dir-seq-map-gist.t
@@ -1,0 +1,26 @@
+use v6;
+use Test;
+
+plan 8;
+
+# dir returns a Seq (Rakudo: dir.^name eq 'Seq'), so it flattens as a listop
+# argument.
+is dir.^name, 'Seq', 'dir returns a Seq';
+ok (map { .relative }, dir).elems > 0, 'map over dir iterates its entries';
+ok (map { .relative }, dir).all ~~ Str, 'each mapped dir entry is a relative Str';
+
+# A Seq flattens as a map/grep list argument even from a scalar $ source.
+# (a fresh Seq per use — a Seq is single-shot)
+my $sm = (1, 2, 3).Seq;
+is (map { $_ + 1 }, $sm).join(','), '2,3,4', 'map over a Seq in a $ var flattens';
+my $sg = (1, 2, 3).Seq;
+is (grep { $_ > 1 }, $sg).join(','), '2,3', 'grep over a Seq in a $ var flattens';
+
+# IO::Handle.gist vs .Str
+my $tmp = 'tmp/dir-seq-map-gist-handle.txt';
+my $fh = open $tmp, :w;
+ok $fh.gist.starts-with('IO::Handle<'), 'open handle .gist starts with IO::Handle<';
+ok $fh.gist.ends-with('(opened)'), 'open handle .gist ends with (opened)';
+$fh.close;
+ok $fh.gist.ends-with('(closed)'), 'closed handle .gist ends with (closed)';
+unlink $tmp;


### PR DESCRIPTION
## Summary

Three fixes that together make `roast/integration/advent2010-day03.t` (file operations) pass 12/12 (was 0/12, aborted before test 1):

1. **`dir` returns a `Seq`** (was a `List`). Rakudo's `dir.^name` is `Seq`, so `map { .relative }, dir` iterates the `IO::Path` entries. As a `List` it was treated as a single item by the listop map arg path.
2. **`map`/`grep` flatten a `Seq` list-argument even from a scalar `$` source.** `my $s = (1,2,3).Seq; map {...}, $s` iterates the three elements in Rakudo — a `Seq` is a sequence, not an itemizable container, so the arg-source `$`-itemization heuristic must not treat it as one item.
3. **`IO::Handle.gist`** renders `IO::Handle<"path".IO>(opened|closed)` (distinct from `.Str`, the bare path), reflecting the live open state. Previously `.gist` returned the raw path string.

## Impact

`advent2010-day03.t` is now 12/12 and whitelisted.

## Tests

- Pin: `t/dir-seq-map-gist.t` (8 assertions, verified against raku)
- `make test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)