### PR TITLE
fix: DateTime.offset-in-minutes

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -74,7 +74,6 @@ noted.
 | `integration/99problems-41-to-50.t` | aborts at 2/9 | PASS ★ | Parameterized `multi rule expr($p)` now WORKS (2026-07-15: multi rule/token registration, literal-exclusive dispatch, args in the LR key, lookahead arg instantiation — pin t/parameterized-rules.t; all reduced P47 shapes pass), but the full P47 grammar (3 precedence levels + `term:sym<paren>`/`term:sym<not>` recursion via `<term=.expr(3)>`) is exponentially slow in the regex engine (~9s for 1 level+paren on `(A)` in a debug build; the real input times out). The blocker is now the LR seed-growing loop re-matching all candidates per position per nesting level — needs match-position memoization of subrule results (packrat-style), a separate engine-perf campaign. P41/P46 fixed in #4510 |
 | `integration/advent2009-day11.t` | aborts at 3/6 | PASS ★ | not yet root-caused |
 | `integration/advent2009-day12.t` | aborts at 4/9 | PASS ★ | not yet root-caused |
-| `integration/advent2010-day16.t` | aborts at 8/13 | PASS ★ | not yet root-caused |
 | `integration/advent2011-day11.t` | 7/9 | PASS ★ | error-message quality for a typo'd method call ("order total with typo" / "public method sanity") — ④-adjacent |
 | `integration/advent2011-day14.t` | aborts at 4/8 | PASS ★ | not yet root-caused |
 | `integration/advent2012-day09.t` | fails 4+ | PASS ★ | grammar parse subtests ("greeting parse", "informal letter parse/greet/close") |

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1344,6 +1344,7 @@ roast/integration/advent2010-day10.t
 roast/integration/advent2010-day11.t
 roast/integration/advent2010-day12.t
 roast/integration/advent2010-day14.t
+roast/integration/advent2010-day16.t
 roast/integration/advent2010-day19.t
 roast/integration/advent2010-day21.t
 roast/integration/advent2010-day22.t

--- a/src/builtins/methods_0arg/temporal_dispatch.rs
+++ b/src/builtins/methods_0arg/temporal_dispatch.rs
@@ -159,6 +159,28 @@ pub fn datetime_method_0arg(
             den /= gcd;
             Some(Ok(Value::rat_raw(num, den)))
         }
+        // `timezone` is the UTC offset in seconds; minutes divide it exactly
+        // for whole-minute offsets (`+0130` → 5400s → 90). Rakudo returns an
+        // Int for whole-minute offsets, a Rat otherwise.
+        "offset-in-minutes" => {
+            if timezone % 60 == 0 {
+                Some(Ok(Value::int(timezone / 60)))
+            } else {
+                let mut num = timezone;
+                let mut den = 60i64;
+                let mut a = num.abs();
+                let mut b = den;
+                while b != 0 {
+                    let t = b;
+                    b = a % b;
+                    a = t;
+                }
+                let gcd = a.max(1);
+                num /= gcd;
+                den /= gcd;
+                Some(Ok(Value::rat_raw(num, den)))
+            }
+        }
         "day-of-week" | "weekday" => Some(Ok(Value::int(day_of_week(days)))),
         "day-of-year" => Some(Ok(Value::int(day_of_year(year, month, day)))),
         "is-leap-year" => Some(Ok(Value::truth(is_leap_year(year)))),

--- a/t/datetime-offset-in-minutes.t
+++ b/t/datetime-offset-in-minutes.t
@@ -1,0 +1,17 @@
+use v6;
+use Test;
+
+plan 6;
+
+# DateTime.offset-in-minutes (roast/integration/advent2010-day16.t)
+my $p = DateTime.new('1963-11-23T17:15:00+0130');
+is $p.offset-in-minutes, 90, 'positive offset-in-minutes';
+is $p.offset-in-hours, 1.5, 'positive offset-in-hours';
+is $p.gist, '1963-11-23T17:15:00+01:30', 'positive offset gist';
+
+my $n = DateTime.new('1963-11-23T17:15:00-0145');
+is $n.offset-in-minutes, -105, 'negative offset-in-minutes';
+is $n.gist, '1963-11-23T17:15:00-01:45', 'negative offset gist';
+
+# UTC (zero offset)
+is DateTime.new(:year(1963)).offset-in-minutes, 0, 'utc offset-in-minutes is 0';


### PR DESCRIPTION
## Summary

Add the `offset-in-minutes` accessor (the minutes twin of the existing `offset-in-hours`): `timezone` is the UTC offset in seconds, so minutes = seconds / 60 — an `Int` for whole-minute offsets (`+0130` → 5400s → 90), a reduced `Rat` otherwise, matching Rakudo.

## Impact

`roast/integration/advent2010-day16.t` (time in Raku) is now 13/13 (was 8/13, aborted at the `.offset-in-minutes` call) and whitelisted.

## Tests

- Pin: `t/datetime-offset-in-minutes.t` (6 assertions, verified against raku)
- `make test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)