### PR TITLE
fix: parse fat-arrow rename in attribute handles (a => 'b')

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -72,7 +72,6 @@ noted.
 | File | mutsu | raku | Blocker / note |
 |---|---|---|---|
 | `integration/99problems-41-to-50.t` | aborts at 2/9 | PASS ★ | Parameterized `multi rule expr($p)` now WORKS (2026-07-15: multi rule/token registration, literal-exclusive dispatch, args in the LR key, lookahead arg instantiation — pin t/parameterized-rules.t; all reduced P47 shapes pass), but the full P47 grammar (3 precedence levels + `term:sym<paren>`/`term:sym<not>` recursion via `<term=.expr(3)>`) is exponentially slow in the regex engine (~9s for 1 level+paren on `(A)` in a debug build; the real input times out). The blocker is now the LR seed-growing loop re-matching all candidates per position per nesting level — needs match-position memoization of subrule results (packrat-style), a separate engine-perf campaign. P41/P46 fixed in #4510 |
-| `integration/advent2009-day11.t` | aborts at 3/6 | PASS ★ | not yet root-caused |
 | `integration/advent2009-day12.t` | aborts at 4/9 | PASS ★ | not yet root-caused |
 | `integration/advent2010-day16.t` | aborts at 8/13 | PASS ★ | not yet root-caused |
 | `integration/advent2011-day11.t` | 7/9 | PASS ★ | error-message quality for a typo'd method call ("order total with typo" / "public method sanity") — ④-adjacent |

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1323,6 +1323,7 @@ roast/integration/advent2009-day07.t
 roast/integration/advent2009-day08.t
 roast/integration/advent2009-day09.t
 roast/integration/advent2009-day10.t
+roast/integration/advent2009-day11.t
 roast/integration/advent2009-day13.t
 roast/integration/advent2009-day14.t
 roast/integration/advent2009-day15.t

--- a/src/parser/stmt/decl/handles.rs
+++ b/src/parser/stmt/decl/handles.rs
@@ -46,6 +46,31 @@ fn parse_single_handle_spec<'a>(input: &'a str, specs: &mut Vec<HandleSpec>) -> 
         }
         return Err(PError::expected("handles pair value after colon-pair name"));
     }
+    // Fat-arrow pair: `exposed => 'target'` / `exposed => target`
+    // (`handles (dog_name => 'name')` — rename delegation, Rakudo syntax).
+    let (after_name, name) = take_while1(r, |c: char| c.is_alphanumeric() || c == '_' || c == '-')?;
+    let (after_name, _) = ws(after_name)?;
+    if let Some(after_arrow) = after_name.strip_prefix("=>") {
+        let (after_arrow, _) = ws(after_arrow)?;
+        let (rest, target) = if after_arrow.starts_with('\'') || after_arrow.starts_with('"') {
+            let quote = after_arrow.as_bytes()[0] as char;
+            let after_quote = &after_arrow[1..];
+            let end = after_quote
+                .find(quote)
+                .ok_or_else(|| PError::expected("closing quote in handles pair"))?;
+            (&after_quote[end + 1..], after_quote[..end].to_string())
+        } else {
+            let (r_target, target) = take_while1(after_arrow, |c: char| {
+                c.is_alphanumeric() || c == '_' || c == '-'
+            })?;
+            (r_target, target.to_string())
+        };
+        specs.push(HandleSpec::Rename {
+            exposed: name.to_string(),
+            target,
+        });
+        return Ok((rest, ()));
+    }
     Err(PError::expected("handle spec"))
 }
 

--- a/t/handles-fat-arrow-rename.t
+++ b/t/handles-fat-arrow-rename.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+plan 4;
+
+# NOTE: Rakudo only accepts a QUOTED target in a fat-arrow handles pair
+# (`exposed => 'target'`); a bare identifier is parsed as a term. This pin
+# uses quoted targets throughout.
+
+# `handles (exposed => 'target')` fat-arrow rename delegation on an attribute
+# (roast/integration/advent2009-day11.t). Previously only the colon-pair form
+# (`handles (:exposed<target>)`) parsed.
+class Dog { has $.name; }
+class DogWalker {
+    has $.name;
+    has Dog $.dog handles (dog_name => 'name');
+}
+my $fido = Dog.new(name => 'Fido');
+my $bob = DogWalker.new(name => 'Bob', dog => $fido);
+is $bob.name, 'Bob', 'own accessor still works';
+is $bob.dog_name, 'Fido', 'fat-arrow rename delegation (quoted target)';
+
+# Multiple pairs in one handles list.
+class Engine { has $.model; method start() { 'vroom' } }
+class Car {
+    has Engine $.engine handles (engine_model => 'model', ignite => 'start');
+}
+my $car = Car.new(engine => Engine.new(model => 'V8'));
+is $car.engine_model, 'V8', 'first fat-arrow rename in the list';
+is $car.ignite, 'vroom', 'second fat-arrow rename in the same list';


### PR DESCRIPTION
## Summary

The attribute `handles` trait parser only accepted the colon-pair rename form (`handles (:exposed<target>)`); the fat-arrow pair form `handles (dog_name => 'name')` failed to parse, so the whole attribute declaration was mis-parsed (`$.dog used where no self is available`).

Parse a `name => 'target'` item in the parenthesized `handles` list as a `HandleSpec::Rename`, mirroring the existing colon-pair handling.

## Impact

`roast/integration/advent2009-day11.t` (classes/attributes/methods) is now 6/6 (was 3/6, aborted at the `has Dog $.dog handles (dog_name => 'name')` declaration) and whitelisted.

## Tests

- Pin: `t/handles-fat-arrow-rename.t` (4 assertions, verified against raku)
- `make test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)