### PR TITLE
perf: convert hot per-call Symbol/String sets off SipHash (mzef ctor -10%)

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
@@ -286,7 +286,12 @@ pub struct Env {
     /// behave correctly under a scoped overlay. `None` for flat envs (no scope to
     /// shadow). Tombstones are dropped with the overlay on return and are never
     /// merged back (a callee-local removal must not delete the caller's key).
-    tombstones: Option<HashSet<Symbol>>,
+    // Keyed by interned `Symbol`; use `FxHashSet` (non-cryptographic hash over
+    // the small integer key), not the default `SipHash`. `is_tombstoned` runs on
+    // every env lookup that misses the overlay and walks the parent chain, so a
+    // `SipHash` here showed up as ~5% of self time on method-heavy benchmarks
+    // (mzef ctor) — the same reason `SymMap` is `FxHashMap`.
+    tombstones: Option<rustc_hash::FxHashSet<Symbol>>,
     /// Number of parent tiers below this env (0 for a flat env). Used to bound
     /// the chain length: a recursive function would otherwise grow the chain one
     /// tier per call, making `get`/`Drop`/`flattened` recurse to the recursion
@@ -611,7 +616,9 @@ impl Env {
                 .cloned();
             if parent_val.is_some() {
                 let visible = from_overlay.or(parent_val);
-                self.tombstones.get_or_insert_with(HashSet::new).insert(key);
+                self.tombstones
+                    .get_or_insert_with(rustc_hash::FxHashSet::default)
+                    .insert(key);
                 return visible;
             }
         }

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -355,7 +355,8 @@ impl Interpreter {
                     }
                 })
                 .collect();
-            let mut consumed_named = std::collections::HashSet::new();
+            let mut consumed_named: rustc_hash::FxHashSet<String> =
+                rustc_hash::FxHashSet::default();
             let mut positional_idx = 0usize;
             for param in params.iter() {
                 // Named placeholder: $:f, @:f, %:f -- match by Pair key
@@ -439,7 +440,7 @@ impl Interpreter {
         }
         // Pre-compute the set of explicit named parameter keys so that
         // slurpy hash (*%rest) can exclude args already bound to named params.
-        let explicit_named_keys: std::collections::HashSet<String> = param_defs
+        let explicit_named_keys: rustc_hash::FxHashSet<String> = param_defs
             .iter()
             .filter(|pd| (pd.named || pd.name.starts_with(':')) && !pd.slurpy)
             .map(|pd| {

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -764,7 +764,11 @@ impl Interpreter {
         // writeback scan below compare Symbols directly (a u32 compare + hash)
         // instead of resolving every env key back to a &str via `with_str` --
         // that Symbol-to-string churn dominated the writeback profile.
-        let mut param_names: std::collections::HashSet<Symbol> = std::collections::HashSet::new();
+        // FxHashSet, not the default SipHash: the caller-writeback scan below
+        // probes these Symbol sets against EVERY env key (~100) on every closure
+        // call, so a cryptographic hash over the small integer key dominated the
+        // profile (~5% of mzef-ctor self time in `SipHasher::hash_one<Symbol>`).
+        let mut param_names: rustc_hash::FxHashSet<Symbol> = rustc_hash::FxHashSet::default();
         for p in &data.params {
             param_names.insert(Symbol::intern(p));
         }
@@ -842,18 +846,17 @@ impl Interpreter {
         // (and the `__mutsu_*` prefix checks below) are skipped entirely.
         let meta_possible = crate::env::closure_meta_keys_possible();
         if needs_caller_writeback {
-            let rw_sources: std::collections::HashSet<Symbol> = rw_bindings
+            let rw_sources: rustc_hash::FxHashSet<Symbol> = rw_bindings
                 .iter()
                 .map(|(_, source)| Symbol::intern(source))
                 .collect();
-            let captured_names: std::collections::HashSet<Symbol> =
-                data.env.keys().copied().collect();
+            let captured_names: rustc_hash::FxHashSet<Symbol> = data.env.keys().copied().collect();
             // Write back captured-variable changes, but NOT the closure's own
             // parameters/locals (which live in cc.locals).  Without this filter,
             // recursive &?BLOCK calls clobber the outer frame's $n, etc.
             // `cc.locals_sym` is `cc.locals` pre-interned at compile time, so
             // this avoids re-interning every local on every call.
-            let local_names: std::collections::HashSet<Symbol> =
+            let local_names: rustc_hash::FxHashSet<Symbol> =
                 cc.locals_sym.iter().copied().collect();
             let underscore_sym = Symbol::intern("_");
             let at_underscore_sym = Symbol::intern("@_");
@@ -869,7 +872,7 @@ impl Interpreter {
             // integration/99problems-41-to-50.t P46 evaluated `and(...)` as `or(...)`
             // from the second truth-table row on). A free var the body *did* change
             // is still written back — that check is what `free_at_entry` is for.
-            let unchanged_free: std::collections::HashSet<Symbol> = cc
+            let unchanged_free: rustc_hash::FxHashSet<Symbol> = cc
                 .free_var_syms
                 .iter()
                 .zip(free_at_entry.iter())


### PR DESCRIPTION
## Summary

The closure-dispatch caller-writeback scan iterates the entire working env (~100 entries) and probes each key against several `HashSet<Symbol>` (`param_names`, `rw_sources`, `captured_names`, `local_names`, `unchanged_free`). These sets used the default `RandomState` (SipHash), so a cryptographic hash over the small-integer `Symbol` key ran ~500 times per closure call — **~5% of self time** on the mzef `Zef::Distribution` construction path (`hash_one::<Symbol>` in the profile). This is the same reason `env::SymMap` is already `FxHashMap`.

This PR switches those sets — plus the env tombstone set and two per-call signature-binder membership sets (`consumed_named`, `explicit_named_keys`) — to `FxHashSet`. Iteration order of a membership-only set never affects output, so the change is **behaviour-neutral**.

## Measurement

`Zef::Distribution.new(|%meta)` over 2000 fez.json metas (`perf stat -e instructions:u`, `taskset -c 2`, release):

| | instructions |
|---|---|
| before | 6.864G |
| after | 6.160G (**-10.3%**) |

Populate layers (`tmp/zef-upstream`, 7657 dists): L1 ctor-only 2.14s → 2.0s, L4 full 4.64s → 4.35s.

The closure-dispatch conversion is the dominant win; the tombstone/binder conversions are the same trivially-correct SipHash→Fx pattern applied to the remaining hot per-call sets.

## Testing

- `make test` — 17093 tests PASS
- Closure/binder-heavy roast subset (S06 currying/slurpy, S12 roles-6e, integration/99problems P46 truth-table) — green; `99problems-41-to-50.t` still aborts at 2/9 exactly as documented in BLOCKERS.md (P47 grammar engine-perf, unrelated).
- Full `make roast` via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)