### PR TITLE
fix: block-scoped module re-import keeps the module's source definitions

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -72,7 +72,6 @@ noted.
 | File | mutsu | raku | Blocker / note |
 |---|---|---|---|
 | `integration/99problems-41-to-50.t` | aborts at 2/9 | PASS ★ | Parameterized `multi rule expr($p)` now WORKS (2026-07-15: multi rule/token registration, literal-exclusive dispatch, args in the LR key, lookahead arg instantiation — pin t/parameterized-rules.t; all reduced P47 shapes pass), but the full P47 grammar (3 precedence levels + `term:sym<paren>`/`term:sym<not>` recursion via `<term=.expr(3)>`) is exponentially slow in the regex engine (~9s for 1 level+paren on `(A)` in a debug build; the real input times out). The blocker is now the LR seed-growing loop re-matching all candidates per position per nesting level — needs match-position memoization of subrule results (packrat-style), a separate engine-perf campaign. P41/P46 fixed in #4510 |
-| `integration/advent2009-day12.t` | aborts at 4/9 | PASS ★ | not yet root-caused |
 | `integration/advent2011-day11.t` | 7/9 | PASS ★ | error-message quality for a typo'd method call ("order total with typo" / "public method sanity") — ④-adjacent |
 | `integration/advent2011-day14.t` | aborts at 4/8 | PASS ★ | not yet root-caused |
 | `integration/advent2012-day09.t` | fails 4+ | PASS ★ | grammar parse subtests ("greeting parse", "informal letter parse/greet/close") |

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1324,6 +1324,7 @@ roast/integration/advent2009-day08.t
 roast/integration/advent2009-day09.t
 roast/integration/advent2009-day10.t
 roast/integration/advent2009-day11.t
+roast/integration/advent2009-day12.t
 roast/integration/advent2009-day13.t
 roast/integration/advent2009-day14.t
 roast/integration/advent2009-day15.t

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -27,9 +27,22 @@ impl Interpreter {
             monkey_typing,
         )) = self.import_scope_stack.pop()
         {
-            self.registry_mut()
-                .functions
-                .retain(|key, _| func_snapshot.contains(key));
+            // Remove functions added since the push, EXCEPT a module's own
+            // fully-qualified source definitions (`Fancy::Utilities::lolgreet`,
+            // `Fancy::Utilities::EXPORT::ALL::lolgreet`). Those persist as long
+            // as the module is loaded — a later block-scoped `use Fancy...` in a
+            // sibling block re-imports from them (`import_module`), and dropping
+            // them left the re-import with nothing to alias ("Unknown function").
+            // The IMPORTED aliases (bare names and `GLOBAL::name`) are still
+            // removed, so a bare call after the block exits still dies (roast
+            // S11-modules/lexical.t: `{ use Foo } EVAL('foo()')`).
+            self.registry_mut().functions.retain(|key, _| {
+                if func_snapshot.contains(key) {
+                    return true;
+                }
+                let ks = key.resolve();
+                ks.contains("::") && !ks.starts_with("GLOBAL::")
+            });
             self.registry_mut()
                 .classes
                 .retain(|key, _| class_snapshot.contains(key));

--- a/t/use-block-scope-reimport.t
+++ b/t/use-block-scope-reimport.t
@@ -1,0 +1,21 @@
+use v6;
+use Test;
+use lib $*PROGRAM.parent(2).add("roast/packages/Fancy/lib").Str;
+
+plan 3;
+
+# A module `use`d with import tags inside one block, then `use`d again in a
+# sibling block, must re-import correctly. Popping the first block's import
+# scope used to drop the module's OWN fully-qualified source definitions, so
+# the second block's re-import had nothing to alias ("Unknown function").
+# Root cause of roast/integration/advent2009-day12.t.
+
+{
+    use Fancy::Utilities :greet;
+    is lolgreet('A'), 'O HAI A', 'first block: :greet exports lolgreet';
+}
+{
+    use Fancy::Utilities :greet, :lolcat;
+    is lolgreet('B'), 'O HAI B', 'second block re-imports lolgreet';
+    is lolrequest('Cake'), 'I CAN HAZ A CAKE?', 'second block :lolcat export';
+}


### PR DESCRIPTION
## Summary

Popping a lexical import scope (a `{ use Foo :tag; ... }` block) removed ALL functions registered since the scope was pushed — including the module's OWN fully-qualified source definitions (`Fancy::Utilities::lolgreet` and its `::EXPORT::ALL::` aliases), not just the imported bare/`GLOBAL::` names. A sibling block that `use`d the same module again then re-imported from nothing (`Unknown function`), because the module stayed in `loaded_modules` (so it took the already-loaded fast path) but its exports had been dropped.

`pop_import_scope` now retains qualified (`::`-containing) non-`GLOBAL::` keys — the module's persistent source definitions — while still removing the imported aliases (bare names and `GLOBAL::name`), so a bare call after the block still dies (S11-modules/lexical.t).

## Impact

`roast/integration/advent2009-day12.t` (modules and exporting) is now 9/9 (was 4/9, aborted at the second block's re-import) and whitelisted.

## Tests

- Pin: `t/use-block-scope-reimport.t` (3 assertions, verified against raku)
- `make test` all pass; all whitelisted `S11-modules` tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)