### PR TITLE
fix: lexical &callwith/&callsame/... shadow the dispatcher builtin

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -79,7 +79,6 @@ noted.
 | `integration/advent2012-day14.t` | aborts at 0/6 | PASS ★ | aborts before test 1 |
 | `integration/advent2013-day08.t` | aborts at 0/11 | PASS ★ | aborts before test 1 |
 | `integration/advent2013-day18.t` | aborts at 0/10 | PASS ★ | aborts before test 1 |
-| `integration/advent2013-day21.t` | aborts at 19/24 | PASS ★ | not yet root-caused |
 | `6.c/S04-declarations/my-6c.t` | 111/112 | PASS ★ | **shortcut**: the only failure = test 57, the `OUTER::<$x>` pseudo-package |
 | `6.c/S14-roles/mixin-6c.t` | aborts at 16/57 | PASS ★ | 6.c mixin (`does`/`but`) semantics; aborts mid-file |
 | `6.c/APPENDICES/A04-experimental/01-misc.t` | 16/19 | FAIL | `:D`/`:U` DefiniteHow coercion (`Target:D(Source:U)`). #4514: 0/19 → 16/19 |

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1386,6 +1386,7 @@ roast/integration/advent2013-day14.t
 roast/integration/advent2013-day15.t
 roast/integration/advent2013-day19.t
 roast/integration/advent2013-day20.t
+roast/integration/advent2013-day21.t
 roast/integration/advent2013-day22.t
 roast/integration/advent2013-day23.t
 roast/integration/advent2014-day05.t

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -681,6 +681,28 @@ impl Interpreter {
             self.auto_fetch_proxy_args(args)?
         };
         loan_env!(self, set_pending_callsite_line(callsite_line));
+        // A lexically-bound `&callsame`/`&callwith`/`&nextsame`/`&nextwith`/
+        // `&samewith` (`my &callwith := -> ... { ... }`) shadows the built-in
+        // dispatcher routine of the same name (roast advent2013-day21.t pointy
+        // block). These names are control-flow builtins, so the normal
+        // `lexical_amp_var_callable` path excludes them; check the binding
+        // explicitly here and call it as an ordinary sub.
+        if matches!(
+            name.as_str(),
+            "callsame" | "callwith" | "nextsame" | "nextwith" | "samewith"
+        ) {
+            let ampname = format!("&{}", name);
+            if let Some(callable) = self
+                .locals_get_by_name(code, &ampname)
+                .or_else(|| self.env().get(&ampname).cloned())
+                .filter(|v| matches!(v.view(), ValueView::Sub(_) | ValueView::WeakSub(_)))
+            {
+                let result = self.vm_call_sub_value(callable, args, false)?;
+                self.apply_pending_rw_writeback(code);
+                self.stack.push(result);
+                return Ok(());
+            }
+        }
         // Check if there's a CALL-ME override from trait_mod mixin
         let call_me_override =
             self.env()

--- a/t/lexical-callwith-shadow.t
+++ b/t/lexical-callwith-shadow.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+plan 4;
+
+# A lexically-bound `&callwith` / `&callsame` / `&nextwith` / `&nextsame` /
+# `&samewith` shadows the built-in dispatcher routine of the same name
+# (roast/integration/advent2013-day21.t "pointy block syntax").
+{
+    my &callwith := -> *@pos, *%named { @pos => %named };
+    is-deeply callwith(10, 20, :a(30), :b(40)),
+        [10, 20] => {a => 30, b => 40},
+        'lexical &callwith shadows the dispatcher builtin';
+}
+{
+    my &callsame := -> $x { $x * 2 };
+    is callsame(21), 42, 'lexical &callsame shadows the dispatcher builtin';
+}
+{
+    my &samewith := -> $x, $y { $x ~ $y };
+    is samewith('a', 'b'), 'ab', 'lexical &samewith shadows the dispatcher builtin';
+}
+# The builtin still works when NOT shadowed (real dispatcher semantics).
+{
+    my $log = '';
+    multi fmt(Int $n) { $log ~= "int "; callsame }
+    multi fmt(Any $x) { $log ~= "any "; "[$x]" }
+    fmt(5);
+    is $log, 'int any ', 'unshadowed callsame still dispatches to the next candidate';
+}


### PR DESCRIPTION
## Summary

A lexically-bound `&callsame`/`&callwith`/`&nextsame`/`&nextwith`/`&samewith` (`my &callwith := -> *@pos, *%named { ... }`) must shadow the built-in dispatcher routine of the same name. These names are control-flow builtins, so the normal `lexical_amp_var_callable` path excludes them and the call resolved to the dispatcher — which then died with `callwith is not in the dynamic scope of a dispatcher`.

Check for a lexical `&name` Sub/WeakSub binding for the dispatcher family in `exec_call_func_op` and call it as an ordinary sub when present; the builtin dispatcher semantics are unchanged when no such binding exists (verified by the pin's unshadowed-`callsame` case).

## Impact

`roast/integration/advent2013-day21.t` (the `is-deeply` cheat sheet) is now 24/24 (was 19/24, aborted at the 'pointy block syntax' test) and whitelisted.

## Tests

- Pin: `t/lexical-callwith-shadow.t` (4 assertions incl. an unshadowed-dispatcher case, verified against raku)
- `make test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)