### PR TITLE
feat: `is Array` subclass instances behave as Positional arrays

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -48,7 +48,7 @@ Definitions of the classifications:
 
 ## Current assumptions
 
-- The whitelist stands at **1414 / 1463** (2026-07-15, `wc -l roast-whitelist.txt`) = **49** files not whitelisted.
+- The whitelist stands at **1423 / 1463** (2026-07-16, `wc -l roast-whitelist.txt`) = **40** files not whitelisted.
 - **The S\* files (per-synopsis feature tests) are exhausted.** All of the former large campaigns
   (true lazy arrays / desugaring of dispatch and operator sugar / S17 concurrency & async /
   first-class-container container identity / cross-thread lexical writeback) are complete, and
@@ -76,7 +76,6 @@ noted.
 | `integration/advent2011-day14.t` | aborts at 4/8 | PASS ★ | AOP via `EXPORTHOW` + a custom `Metamodel::ClassHOW` subclass (`ClassWithAspectsHOW`) whose `compose` wraps every local method with entry/exit logging (`Advent::MetaBoundaryAspect`). Needs the `EXPORTHOW.WHO.<class> = ...` meta-class-override mechanism + `ClassHOW` subclassing + `self.methods($obj, :local)`/`$m.wrap`. Tests 1-4 (single/multi-inheritance EVAL) pass; abort at test 5 (`Example.double`) |
 | `integration/advent2012-day09.t` | fails 4+ | PASS ★ | grammar parse subtests ("greeting parse", "informal letter parse/greet/close") |
 | `integration/advent2012-day14.t` | aborts at 0/6 | PASS ★ | mutually-recursive `... *` sequence generators (`@primes = 2,3,5, -> $p {...} ... *` referencing `&is-prime-beta` before its declaration) + `is-prime-alpha($n) { $n %% none 2..sqrt $n }`. Aborts before test 1 building the lazy prime sequence |
-| `integration/advent2013-day08.t` | aborts at 0/11 | PASS ★ | `class Vector is Array` (subclassing `Array`) with `nextwith(\|@values)` in a custom `new`; the resulting instance must bind to `@vec` as `Positional` (mutsu: "Type check failed in binding; expected Positional but got Any"). Needs Array-subclass instances to be Positional-typed |
 | `integration/advent2013-day18.t` | aborts at 0/10 | PASS ★ | grammar with a rule-embedded dynamic-var declaration (`rule deal { :my %*PLAYED = (); <hand>+ % ';' }`) + `proto token suit {*}` / `token suit:sym<…>`. mutsu throws "Null regex not allowed" building the grammar. Aborts before test 1 |
 | `6.c/S04-declarations/my-6c.t` | 111/112 | PASS ★ | **shortcut**: the only failure = test 57, the `OUTER::<$x>` pseudo-package |
 | `6.c/S14-roles/mixin-6c.t` | aborts at 16/57 | PASS ★ | 6.c mixin (`does`/`but`) semantics; aborts mid-file |

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,36 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-16: `is Array` subclass instances behave as Positional arrays (integration/advent2013-day08.t)
+
+`class Vector is Array` with a custom `new` that redispatches its positional
+args to the base Array construction via `nextwith(|@values)` now produces a
+genuinely array-like instance. The elements live in the existing
+`__mutsu_array_storage` backing attribute; this slice made that storage the
+authority across every context the roast test exercises:
+
+- **Construction** — `dispatch_bless` now seeds `__mutsu_array_storage` from
+  the positional (non-Pair) args, so `nextwith(|@values)`/`callwith` inside a
+  subclass `new` (which lands as `bless` with positional args) reaches the
+  base `Array.new(1,2,3)` element semantics.
+- **Indexing read** — `$v[0]` routing through `try_compiled_method_or_interpret`
+  now delegates `AT-POS`/array methods to the storage (previously only the
+  CallMethod-opcode path delegated, so `$v.AT-POS(0)` worked but `$v[0]` was Nil).
+- **Indexing write / mutation** — `$v[1] = x`, `$v[1]--`, `$v[0]++` write into
+  the storage element in place through the shared instance cell, instead of the
+  associative path spuriously creating an attribute keyed by the index.
+- **rw accessor lvalue** — `method z() is rw { self[2] }` is now an assignable
+  lvalue that autovivifies `__mutsu_array_storage[2]`.
+- **List context / iteration** — `for @$v { ... }` and `@$v` flatten to the
+  storage elements (`value_to_list`), not the instance as one item.
+- **Hyper ops** — `self »-« @vec` / `self »**» 2` deitemize the instance to its
+  storage list so both sides line up by length.
+- **gist / raku** — an Array-subclass instance gists as `[1 2 3]` (delegating to
+  the storage), not the generic `Class.new`.
+
+Pin: `t/array-subclass-vector.t` (19 cases). Whitelisted
+`roast/integration/advent2013-day08.t` (0/11 abort → 11/11).
+
 ## 2026-07-16: grammar-parse — trail matcher landed (ADR-0007 Accepted, #4591)
 
 The by-value `RegexCaptures` threading through the backtracking search is gone:

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1380,6 +1380,7 @@ roast/integration/advent2013-day02.t
 roast/integration/advent2013-day04.t
 roast/integration/advent2013-day06.t
 roast/integration/advent2013-day07.t
+roast/integration/advent2013-day08.t
 roast/integration/advent2013-day09.t
 roast/integration/advent2013-day10.t
 roast/integration/advent2013-day12.t

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -339,6 +339,23 @@ impl Interpreter {
                 };
             }
         }
+        // Array-subclass construction: an `is Array` subclass reaches the base
+        // `Array.new(1, 2, 3)` semantics through `nextwith(|@values)` in its own
+        // `new`, which lands here as `bless` with positional (non-Pair) args.
+        // Those positional args become the elements of the backing array
+        // storage (which `Array` methods on the instance delegate to). Only
+        // touch the storage when there are positional args, so a plain
+        // named-args `bless` keeps the empty storage seeded by `dispatch_new`.
+        if self.class_mro(cn_resolved).iter().any(|n| n == "Array") {
+            let elems: Vec<Value> = args
+                .iter()
+                .filter(|a| !matches!(a.view(), ValueView::Pair(..)))
+                .cloned()
+                .collect();
+            if !elems.is_empty() || !attributes.contains_key("__mutsu_array_storage") {
+                attributes.insert("__mutsu_array_storage", Value::real_array(elems));
+            }
+        }
         // Embed `is default(...)` element defaults into `@`/`%` containers.
         self.apply_container_attribute_defaults(cn_resolved, &mut attributes);
         // Build the instance BEFORE the BUILD/TWEAK phases and thread its shared

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -933,6 +933,12 @@ impl Interpreter {
                 && args.is_empty()
                 && !self.has_user_method(&class_name.resolve(), method)
             {
+                // An `is Array` subclass instance gists/rakus as its backing
+                // array (`Vector.new(1,2,3).gist` → `[1 2 3]`), not the generic
+                // `Class.new`. Delegate to the storage array's own repr method.
+                if let Some(storage) = attributes.as_map().get("__mutsu_array_storage").cloned() {
+                    return self.call_method_with_values(storage, method, vec![]);
+                }
                 if class_name == Symbol::intern("ObjAt")
                     || class_name == Symbol::intern("ValueObjAt")
                 {

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -1199,6 +1199,37 @@ impl Interpreter {
             );
         }
 
+        // `method z() is rw { self[2] }` on an `is Array` subclass — assign into
+        // the invocant's backing array storage element. The index is a literal
+        // or a positional parameter of the method.
+        if attributes.contains_key("__mutsu_array_storage")
+            && let Some((index_expr, is_pos)) = Self::rw_method_self_index_target(&method_def.body)
+        {
+            let idx_val = match &index_expr {
+                Expr::Literal(v) => v.clone(),
+                Expr::Var(param) => match method_def
+                    .params
+                    .iter()
+                    .position(|p| p == param)
+                    .and_then(|pos| method_args.get(pos).cloned())
+                {
+                    Some(v) => v,
+                    None => self.eval_block_value(&[Stmt::Expr(index_expr.clone())])?,
+                },
+                other => self.eval_block_value(&[Stmt::Expr(other.clone())])?,
+            };
+            return self.assign_rw_indexed_attr(
+                &attributes,
+                class_name,
+                target_id,
+                target_var,
+                "__mutsu_array_storage",
+                idx_val,
+                is_pos,
+                value,
+            );
+        }
+
         // Check if this is a delegation method — forward assignment to delegate
         if let Some((ref attr_var_name, ref target_method)) = method_def.delegation
             && !attr_var_name.starts_with('&')

--- a/src/runtime/methods_mut_rw_attr.rs
+++ b/src/runtime/methods_mut_rw_attr.rs
@@ -65,6 +65,33 @@ impl Interpreter {
         None
     }
 
+    /// Detect an `is rw` method whose body returns an indexed element of the
+    /// invocant itself — `self[EXPR]` (or `self{EXPR}`) — as happens in an
+    /// `is Array` subclass accessor (`method z() is rw { self[2] }`). Returns
+    /// `(index_expr, is_positional)`; the element lives in the instance's
+    /// backing `__mutsu_array_storage`, so `$obj.z = v` writes storage[2].
+    pub(crate) fn rw_method_self_index_target(body: &[Stmt]) -> Option<(Expr, bool)> {
+        let first = body.iter().find(|s| !matches!(s, Stmt::SetLine(_)))?;
+        let expr = match first {
+            Stmt::Expr(e) | Stmt::Return(e) => e,
+            _ => return None,
+        };
+        let expr = match expr {
+            Expr::Call { name, args } if name == "return-rw" && args.len() == 1 => &args[0],
+            other => other,
+        };
+        if let Expr::Index {
+            target,
+            index,
+            is_positional,
+        } = expr
+            && matches!(target.as_ref(), Expr::BareWord(w) | Expr::Var(w) if w == "self")
+        {
+            return Some(((**index).clone(), *is_positional));
+        }
+        None
+    }
+
     /// Assign `value` into element `index_value` of the array/hash attribute
     /// `attr_name` on the instance, then write the updated instance back through
     /// `target_var`. Backs `$obj.rw-method(idx) = value` where the method

--- a/src/runtime/utils/gist.rs
+++ b/src/runtime/utils/gist.rs
@@ -196,6 +196,19 @@ pub(crate) fn gist_value(value: &Value) -> String {
             attributes,
             ..
         } if class_name == "Match" => match_gist(&(attributes).as_map(), 0),
+        // An `is Array` subclass instance gists as its backing array elements
+        // (`Vector.new(1,2,3).gist` → `[1 2 3]`), not the generic `Class.new`.
+        ValueView::Instance { attributes, .. }
+            if attributes.contains_key("__mutsu_array_storage") =>
+        {
+            gist_value(
+                &attributes
+                    .as_map()
+                    .get("__mutsu_array_storage")
+                    .cloned()
+                    .unwrap_or_else(|| crate::value::Value::real_array(Vec::new())),
+            )
+        }
         // `$(...)` itemized container: `.gist` never shows the itemization sigil,
         // so it gists exactly like its inner value (`${a=>1}.gist` → `{a => 1}`).
         ValueView::Scalar(inner) => gist_value(inner),

--- a/src/runtime/utils/list.rs
+++ b/src/runtime/utils/list.rs
@@ -426,6 +426,11 @@ pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
             {
                 return items.to_vec();
             }
+            // An `is Array` subclass instance is Positional: in list context it
+            // flattens to its backing storage elements (`for @$vec { ... }`).
+            if let Some(storage) = attributes.as_map().get("__mutsu_array_storage") {
+                return value_to_list(storage);
+            }
             vec![val.clone()]
         }
         // Nil is a single scalar item in list context (e.g. `for Nil { }` does

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -304,6 +304,27 @@ impl Interpreter {
             {
                 return result;
             }
+            // Array-subclass instance delegation: when the class inherits from
+            // `Array` and the method isn't user-defined, delegate array methods
+            // (AT-POS/elems/List/...) to the backing `__mutsu_array_storage`.
+            // This mirrors the CallMethod-opcode delegation (vm_call_method_ops)
+            // so callers that route through this entry (e.g. index `$v[0]` →
+            // AT-POS) also reach the storage instead of returning Nil.
+            if !self.has_user_method(class, method)
+                && let ValueView::Instance { attributes, .. } = target.view()
+                && attributes.contains_key("__mutsu_array_storage")
+                && self.mro_readonly(class).iter().any(|n| n == "Array")
+            {
+                let storage = attributes
+                    .as_map()
+                    .get("__mutsu_array_storage")
+                    .cloned()
+                    .unwrap_or(Value::real_array(Vec::new()));
+                if let Some(native_result) = self.try_native_method(&storage, method_sym, &args) {
+                    self.method_dispatch_pure = true;
+                    return native_result;
+                }
+            }
             // A user-defined subclass of a builtin type may override an inherited
             // native method (e.g. `class IO::Blob is IO::Handle { method get {…} }`).
             // The user override must win, so do not take the native fork when the

--- a/src/vm/vm_hyper_ops.rs
+++ b/src/vm/vm_hyper_ops.rs
@@ -161,6 +161,18 @@ impl Interpreter {
                 Value::array_with_kind(items.clone(), kind.decontainerize())
             }
             ValueView::Scalar(inner) => (*inner).clone(),
+            // An `is Array` subclass instance hypers as its backing array
+            // elements (`self »-« @vec` inside a Vector method): unwrap it to
+            // the `__mutsu_array_storage` list so both sides line up by length.
+            ValueView::Instance { attributes, .. }
+                if attributes.contains_key("__mutsu_array_storage") =>
+            {
+                attributes
+                    .as_map()
+                    .get("__mutsu_array_storage")
+                    .cloned()
+                    .unwrap_or_else(|| Value::real_array(Vec::new()))
+            }
             _ => v.clone(),
         }
     }

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -457,6 +457,37 @@ impl Interpreter {
         } else {
             val
         };
+        // `$vec[1] = x` / `$vec[1]--` on an `is Array` subclass instance held in
+        // a scalar: write into the backing `__mutsu_array_storage` element in
+        // place, instead of the associative path treating the instance as a hash
+        // store (which would spuriously create an attribute keyed by the index).
+        if is_positional
+            && !bind_mode
+            && let Some(inst) = self.env().get(&var_name).cloned()
+            && let ValueView::Instance { attributes, .. } = inst.view()
+            && attributes.contains_key("__mutsu_array_storage")
+        {
+            let idx_i = crate::runtime::utils::to_int(&idx);
+            if idx_i >= 0 {
+                let idx_u = idx_i as usize;
+                attributes.with_attr_mut("__mutsu_array_storage", |storage| {
+                    let (mut items, kind) = match storage.view() {
+                        ValueView::Array(items, kind) => ((**items).clone(), kind),
+                        _ => (
+                            crate::value::ArrayData::new(Vec::new()),
+                            crate::value::ArrayKind::Array,
+                        ),
+                    };
+                    if idx_u >= items.items.len() {
+                        items.items.resize(idx_u + 1, Value::NIL);
+                    }
+                    items.items[idx_u] = val.clone();
+                    *storage = Value::array_with_kind(crate::gc::Gc::new(items), kind);
+                });
+                self.stack.push(val);
+                return Ok(());
+            }
+        }
         // Map containers are immutable - prevent assignment and binding to keys
         if declared_type.as_deref().is_some_and(|t| t == "Map") {
             if bind_mode {

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -419,6 +419,56 @@ impl Interpreter {
             idx_val
         };
         let key = idx_val.to_string_value();
+        // `$vec[1]++` / `$vec[1]--` on an `is Array` subclass instance held in a
+        // scalar: inc/dec the element inside the backing `__mutsu_array_storage`
+        // in place, so the write is visible through the shared instance cell.
+        // (The generic Array/Hash paths below only match plain containers, so an
+        // instance would otherwise read Nil and lose the write.)
+        if let Some(cont) = container.clone()
+            && let ValueView::Instance { attributes, .. } = cont.view()
+            && attributes.contains_key("__mutsu_array_storage")
+            && let Ok(i) = key.parse::<usize>()
+        {
+            let storage = attributes
+                .as_map()
+                .get("__mutsu_array_storage")
+                .cloned()
+                .unwrap_or_else(|| Value::real_array(Vec::new()));
+            let old = match storage.view() {
+                ValueView::Array(items, ..) => items.get(i).cloned().unwrap_or(Value::NIL),
+                _ => Value::NIL,
+            };
+            let effective = Self::normalize_incdec_source(if old.is_nil() {
+                self.var_default(&name)
+                    .cloned()
+                    .filter(|d| !d.is_nil())
+                    .unwrap_or(Value::int(0))
+            } else {
+                old
+            });
+            let new_val = if increment {
+                self.increment_value_smart(&effective)?
+            } else {
+                self.decrement_value_smart(&effective)?
+            };
+            attributes.with_attr_mut("__mutsu_array_storage", |st| {
+                let (mut items, kind) = match st.view() {
+                    ValueView::Array(items, kind) => ((**items).clone(), kind),
+                    _ => (
+                        crate::value::ArrayData::new(Vec::new()),
+                        crate::value::ArrayKind::Array,
+                    ),
+                };
+                if i >= items.items.len() {
+                    items.items.resize(i + 1, Value::NIL);
+                }
+                items.items[i] = new_val.clone();
+                *st = Value::array_with_kind(crate::gc::Gc::new(items), kind);
+            });
+            self.stack
+                .push(if return_new { new_val } else { effective });
+            return Ok(());
+        }
         // `$c[0]++` / `$c<a>++` on a Capture: when the element is a shared
         // `ContainerRef` cell (built from `\($a)` / `\(:$a)`), increment *through*
         // the cell so the original variable observes the change. The generic

--- a/t/array-subclass-vector.t
+++ b/t/array-subclass-vector.t
@@ -1,0 +1,90 @@
+use Test;
+plan 19;
+
+# `class ... is Array` subclass with a custom `new` that redispatches the
+# positional args to the base Array construction via `nextwith(|@values)`.
+# The instance must behave as a Positional/Array: indexing, list context,
+# gist, hyper ops, and rw-accessor / index element mutation all delegate to
+# the backing storage. (roast integration/advent2013-day08.t)
+class Vector is Array {
+    method new (*@values is copy, *%named) {
+        @values[0] = %named<x> if %named<x> :exists;
+        @values[1] = %named<y> if %named<y> :exists;
+        @values[2] = %named<z> if %named<z> :exists;
+        nextwith(|@values);
+    }
+    method x () is rw { self[0] }
+    method y () is rw { self[1] }
+    method z () is rw { self[2] }
+    method magnitude () { sqrt [+] self »**» 2 }
+    method subtract (@vec) { self.new( self »-« @vec ) }
+}
+
+my @vec := Vector.new(1, 2, 3);
+is @vec.WHAT.gist, '(Vector)', 'binds to @-sigil as Positional';
+is @vec[0], 1, 'index 0';
+is @vec[2], 3, 'index 2';
+is @vec.elems, 3, 'elems delegates to storage';
+
+my @vec-wrong = Vector.new(1, 2, 3);
+is @vec-wrong.WHAT.gist, '(Array)', 'assignment (not binding) flattens to Array';
+
+my $vec := Vector.new(1, 2, 3);
+is $vec.WHAT.gist, '(Vector)', 'scalar bind keeps Vector type';
+is $vec.gist, '[1 2 3]', 'gist shows the elements';
+is $vec.List.gist, '(1 2 3)', 'List delegates to storage';
+
+my @position := Vector.new(1, 2);
+my @destination = 4, 6;
+is @position.subtract(@destination).magnitude, 5, 'hyper op + reduce chain';
+
+{
+    my $v = Vector.new(0, 1);
+    is $v.magnitude, 1, 'magnitude of (0,1)';
+}
+
+# rw accessor returning self[N] is an assignable lvalue.
+{
+    my $v = Vector.new(1, 2);
+    $v.z = 3;
+    is $v.gist, '[1 2 3]', 'rw accessor self[2] assign autovivifies';
+}
+
+# named-arg construction path.
+{
+    my $v = Vector.new(:x(1), :y(2));
+    $v.z = 3;
+    is $v.gist, '[1 2 3]', 'named-arg construction + rw z';
+}
+
+# direct index assignment and post-inc/dec on the instance.
+{
+    my $v = Vector.new(1, 2, 3);
+    $v[1] = 99;
+    is $v.gist, '[1 99 3]', 'direct index assign writes storage';
+    $v[1]--;
+    is $v.gist, '[1 98 3]', 'index post-decrement writes storage';
+    $v[0]++;
+    is $v.gist, '[2 98 3]', 'index post-increment writes storage';
+    $v.x++;
+    is $v.gist, '[3 98 3]', 'rw accessor post-increment';
+}
+
+# list context iterates the elements, not the instance as one item.
+{
+    my $v = Vector.new(:y(3), 0);
+    $v.x++;
+    $v[1]--;
+    $v.z = 3;
+    my @seen;
+    @seen.push($_) for @$v;
+    is-deeply @seen, [1, 2, 3], 'for @$v iterates storage elements';
+}
+
+# push still works and grows storage.
+{
+    my $v = Vector.new(1, 2);
+    $v.push(3);
+    is $v.elems, 3, 'push grows storage';
+    is $v[2], 3, 'pushed element readable';
+}


### PR DESCRIPTION
## Summary

`class Vector is Array` with a custom `new` that redispatches its positional args to the base Array construction via `nextwith(|@values)` now yields a genuinely array-like instance. The elements live in the existing `__mutsu_array_storage` backing attribute; this slice makes that storage the authority across every context `roast/integration/advent2013-day08.t` exercises.

## What changed

- **Construction** — `dispatch_bless` seeds `__mutsu_array_storage` from the positional (non-Pair) args, so `nextwith(|@values)` / `callwith` inside a subclass `new` (which lands as `bless` with positional args) reaches the base `Array.new(1,2,3)` element semantics.
- **Indexing read** — `$v[0]` routing through `try_compiled_method_or_interpret` delegates `AT-POS`/array methods to the storage (previously only the CallMethod-opcode path delegated, so `$v.AT-POS(0)` worked but `$v[0]` was Nil).
- **Indexing write / mutation** — `$v[1] = x`, `$v[1]--`, `$v[0]++` write the storage element in place through the shared instance cell, instead of the associative path spuriously creating an attribute keyed by the index.
- **rw accessor lvalue** — `method z() is rw { self[2] }` is now an assignable lvalue that autovivifies `__mutsu_array_storage[2]`.
- **List context / iteration** — `for @\$v { ... }` and `@\$v` flatten to the storage elements (`value_to_list`).
- **Hyper ops** — `self »-« @vec` / `self »**» 2` deitemize the instance to its storage list so both sides line up by length.
- **gist / raku** — gists as `[1 2 3]`, not the generic `Class.new`.

## Testing

- Pin: `t/array-subclass-vector.t` (19 cases).
- Whitelists `roast/integration/advent2013-day08.t` (0/11 abort → 11/11).
- `make test` PASS (17164 tests); `cargo clippy -D warnings` + `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)