### PR TITLE
perf: key compiled_fns by Symbol (remove memcmp from light-call cache hit)

### DIFF
--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -459,7 +459,8 @@ impl Compiler {
             });
             self.code.escaping_our_sub_captures.push(esc);
         }
-        self.compiled_functions.insert(key, cf);
+        self.compiled_functions
+            .insert(crate::symbol::Symbol::intern(&key), cf);
     }
 
     fn compile_routine_body_stmts(
@@ -573,8 +574,8 @@ impl Compiler {
         params: &[String],
         body: &[Stmt],
     ) -> u32 {
-        let fn_keys_before: std::collections::HashSet<String> =
-            self.compiled_functions.keys().cloned().collect();
+        let fn_keys_before: std::collections::HashSet<crate::symbol::Symbol> =
+            self.compiled_functions.keys().copied().collect();
         let analysis = self.compile_closure_body(params, &[], body);
         self.compiled_functions
             .retain(|k, _| fn_keys_before.contains(k));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,11 +74,11 @@ pub fn dump_bytecode(input: &str) -> Result<String, RuntimeError> {
     };
     let _ = writeln!(out, "== mainline ==");
     disasm(&mut out, &code);
-    let mut names: Vec<&String> = compiled_fns.keys().collect();
-    names.sort();
+    let mut names: Vec<crate::symbol::Symbol> = compiled_fns.keys().copied().collect();
+    names.sort_by_key(|s| s.resolve());
     for name in names {
-        let cf = &compiled_fns[name];
-        let _ = writeln!(out, "== sub {} ==", name);
+        let cf = &compiled_fns[&name];
+        let _ = writeln!(out, "== sub {} ==", name.as_str());
         disasm(&mut out, &cf.code);
     }
     Ok(out)

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -3754,7 +3754,15 @@ impl CompiledCode {
 /// function call (ADR-0004 J4d), where std SipHash over the string key was a
 /// measured ~5% of a recursion-heavy workload. The keys are internal,
 /// compiler-generated strings, so HashDoS resistance buys nothing here.
-pub(crate) type CompiledFns = rustc_hash::FxHashMap<String, CompiledFunction>;
+///
+/// Keyed by `Symbol` (S1b, docs/perf-callpath-scouting.md §3.1): the formatted
+/// key strings are interned once at compile time, so a light-call cache hit
+/// compares a `u32` symbol id instead of memcmp-ing a ~20-byte key string, and
+/// the caches store the resolved key as a `Copy` `Symbol` (no per-entry `String`
+/// allocation). The slow resolution path probes candidate keys via
+/// `Symbol::lookup` (no interning of names that turn out not to exist), so a
+/// missed probe never grows the global symbol table.
+pub(crate) type CompiledFns = rustc_hash::FxHashMap<crate::symbol::Symbol, CompiledFunction>;
 
 /// Out-of-band named-argument spec for a `CallFuncNamed` site: which of the
 /// call's stack values are named-arg values, and under which keys.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1832,14 +1832,14 @@ pub struct Interpreter {
     pub(crate) state_scope_id: Option<u64>,
     #[allow(clippy::type_complexity)]
     pub(crate) fn_resolve_cache:
-        rustc_hash::FxHashMap<(Symbol, usize, Vec<String>), (String, u64, String)>,
+        rustc_hash::FxHashMap<(Symbol, usize, Vec<String>), (Symbol, u64, String)>,
     pub(crate) fn_resolve_gen: u64,
     pub(crate) fn_resolve_cache_gen: u64,
     pub(crate) multi_candidates_cache: rustc_hash::FxHashMap<Symbol, bool>,
     pub(crate) multi_candidates_cache_gen: u64,
-    pub(crate) light_call_cache: rustc_hash::FxHashMap<Symbol, (String, u64)>,
+    pub(crate) light_call_cache: rustc_hash::FxHashMap<Symbol, (Symbol, u64)>,
     pub(crate) light_call_cache_gen: u64,
-    pub(crate) pos_light_call_cache: rustc_hash::FxHashMap<Symbol, (String, u64)>,
+    pub(crate) pos_light_call_cache: rustc_hash::FxHashMap<Symbol, (Symbol, u64)>,
     pub(crate) pos_light_call_cache_gen: u64,
     /// Bare names that appear as a `&`-sigil parameter in some registered sub
     /// (e.g. `foo` from `sub callit(&foo) {...}`). A call to such a name may be

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -144,7 +144,7 @@ impl Interpreter {
         {
             let name_sym = code.const_sym(name_idx);
             if let Some((cached_key, cached_fp)) = self.light_call_cache.get(&name_sym)
-                && let Some(cf) = compiled_fns.get(cached_key.as_str())
+                && let Some(cf) = compiled_fns.get(cached_key)
                 && cf.fingerprint == *cached_fp
             {
                 let base = self.stack.len() - arity_usize;
@@ -294,7 +294,7 @@ impl Interpreter {
             let name_sym = code.const_sym(name_idx);
             if self.pos_light_call_cache_gen == self.fn_resolve_gen {
                 if let Some((cached_key, cached_fp)) = self.pos_light_call_cache.get(&name_sym)
-                    && let Some(cf) = compiled_fns.get(cached_key.as_str())
+                    && let Some(cf) = compiled_fns.get(cached_key)
                     && cf.fingerprint == *cached_fp
                 {
                     let arity_usize = arity as usize;
@@ -365,7 +365,7 @@ impl Interpreter {
             let name_sym = code.const_sym(name_idx);
             if self.light_call_cache_gen == self.fn_resolve_gen {
                 if let Some((cached_key, cached_fp)) = self.light_call_cache.get(&name_sym)
-                    && let Some(cf) = compiled_fns.get(cached_key.as_str())
+                    && let Some(cf) = compiled_fns.get(cached_key)
                     && cf.fingerprint == *cached_fp
                 {
                     let arity_usize = arity as usize;
@@ -581,7 +581,7 @@ impl Interpreter {
                 && self.wrap_sub_id_for_name(name_str).is_none()
                 && !loan_env!(self, routine_is_test_assertion_by_name(name_str, &[]))
                 && let Some((cached_key, cached_fp, _)) = self.fn_resolve_cache.get(&cache_key)
-                && let Some(cf) = compiled_fns.get(cached_key.as_str())
+                && let Some(cf) = compiled_fns.get(cached_key)
                 && cf.fingerprint == *cached_fp
                 && Self::is_fast_call_eligible(cf, name_str)
                 && !cf.is_raw
@@ -1175,7 +1175,7 @@ impl Interpreter {
                         for (key, func) in compiled_fns {
                             if std::ptr::eq(func, cf) {
                                 self.pos_light_call_cache
-                                    .insert(name_sym, (key.clone(), cf.fingerprint));
+                                    .insert(name_sym, (*key, cf.fingerprint));
                                 break;
                             }
                         }
@@ -1204,7 +1204,7 @@ impl Interpreter {
                         for (key, func) in compiled_fns {
                             if std::ptr::eq(func, cf) {
                                 self.light_call_cache
-                                    .insert(name_sym, (key.clone(), cf.fingerprint));
+                                    .insert(name_sym, (*key, cf.fingerprint));
                                 break;
                             }
                         }

--- a/src/vm/vm_call_resolve.rs
+++ b/src/vm/vm_call_resolve.rs
@@ -116,14 +116,20 @@ impl Interpreter {
                     .filter(|a| !matches!(a.view(), ValueView::Pair(..)))
                     .count()
             };
-            found_key = probe(&format!("{}::{}/{}:{}", pkg, name, arity, type_sig.join(",")))
-                .or_else(|| {
-                    probe(&format!(
-                        "{}::{}/{}#{:x}",
-                        pkg, name, arity, expected_fingerprint
-                    ))
-                })
-                .or_else(|| probe(&format!("{}::{}/{}", pkg, name, arity)));
+            found_key = probe(&format!(
+                "{}::{}/{}:{}",
+                pkg,
+                name,
+                arity,
+                type_sig.join(",")
+            ))
+            .or_else(|| {
+                probe(&format!(
+                    "{}::{}/{}#{:x}",
+                    pkg, name, arity, expected_fingerprint
+                ))
+            })
+            .or_else(|| probe(&format!("{}::{}/{}", pkg, name, arity)));
             if found_key.is_none() {
                 // `key_simple` (`Pkg::name`) and the positional-only-arity key are
                 // probed but their match is intentionally *not* kept here: the

--- a/src/vm/vm_call_resolve.rs
+++ b/src/vm/vm_call_resolve.rs
@@ -41,7 +41,7 @@ impl Interpreter {
         let use_cache = !self.has_multi_candidates_cached(name);
         if use_cache && self.fn_resolve_cache_gen == self.fn_resolve_gen {
             if let Some((cached_key, cached_fp, _)) = self.fn_resolve_cache.get(&cache_key)
-                && let Some(cf) = compiled_fns.get(cached_key.as_str())
+                && let Some(cf) = compiled_fns.get(cached_key)
                 && cf.fingerprint == *cached_fp
             {
                 return Some(cf);
@@ -67,32 +67,29 @@ impl Interpreter {
             })
             .unwrap_or(arity);
         let matches_resolved = |cf: &CompiledFunction| cf.fingerprint == expected_fingerprint;
+        // Probe a candidate key string. The map is keyed by `Symbol`; every real
+        // key was interned at compile time, so `Symbol::lookup` (no interning)
+        // finds it, and a candidate that turns out not to exist never grows the
+        // global symbol table. Returns the matched key's `Symbol`.
+        let probe = |key: &str| -> Option<Symbol> {
+            let sym = Symbol::lookup(key)?;
+            compiled_fns
+                .get(&sym)
+                .filter(|cf| matches_resolved(cf))
+                .map(|_| sym)
+        };
         let pkg = self.current_package();
         let type_sig: Vec<String> = args
             .iter()
             .map(|v| runtime::value_type_name(v).to_string())
             .collect();
         // Try all key patterns and remember which one matched for caching
-        let mut found_key: Option<String>;
+        let mut found_key: Option<Symbol>;
         if name.contains("::") {
-            let key_typed = format!("{name}/{arity}:{}", type_sig.join(","));
-            if compiled_fns.get(&key_typed).is_some_and(&matches_resolved) {
-                found_key = Some(key_typed);
-            } else {
-                let key_fp = format!("{name}/{}#{:x}", arity, expected_fingerprint);
-                if compiled_fns.get(&key_fp).is_some_and(&matches_resolved) {
-                    found_key = Some(key_fp);
-                } else {
-                    let key_arity = format!("{name}/{arity}");
-                    if compiled_fns.get(&key_arity).is_some_and(&matches_resolved) {
-                        found_key = Some(key_arity);
-                    } else if compiled_fns.get(name).is_some_and(&matches_resolved) {
-                        found_key = Some(name.to_string());
-                    } else {
-                        found_key = None;
-                    }
-                }
-            }
+            found_key = probe(&format!("{name}/{arity}:{}", type_sig.join(",")))
+                .or_else(|| probe(&format!("{name}/{}#{:x}", arity, expected_fingerprint)))
+                .or_else(|| probe(&format!("{name}/{arity}")))
+                .or_else(|| probe(name));
             // If not found directly, try qualifying with the current package
             // when the prefix package is visible in the current scope.
             if found_key.is_none() && pkg != "GLOBAL" {
@@ -107,117 +104,83 @@ impl Interpreter {
                 };
                 if prefix_visible {
                     let qname = format!("{}::{}", pkg, name);
-                    let key_typed = format!("{qname}/{arity}:{}", type_sig.join(","));
-                    if compiled_fns.get(&key_typed).is_some_and(&matches_resolved) {
-                        found_key = Some(key_typed);
-                    } else {
-                        let key_fp = format!("{qname}/{}#{:x}", arity, expected_fingerprint);
-                        if compiled_fns.get(&key_fp).is_some_and(&matches_resolved) {
-                            found_key = Some(key_fp);
-                        } else {
-                            let key_arity = format!("{qname}/{arity}");
-                            if compiled_fns.get(&key_arity).is_some_and(&matches_resolved) {
-                                found_key = Some(key_arity);
-                            } else if compiled_fns.get(&qname).is_some_and(&matches_resolved) {
-                                found_key = Some(qname);
-                            }
-                        }
-                    }
+                    found_key = probe(&format!("{qname}/{arity}:{}", type_sig.join(",")))
+                        .or_else(|| probe(&format!("{qname}/{}#{:x}", arity, expected_fingerprint)))
+                        .or_else(|| probe(&format!("{qname}/{arity}")))
+                        .or_else(|| probe(&qname));
                 }
             }
         } else {
-            let key_typed = format!("{}::{}/{}:{}", pkg, name, arity, type_sig.join(","));
-            if compiled_fns.get(&key_typed).is_some_and(&matches_resolved) {
-                found_key = Some(key_typed);
-            } else {
-                let key_fp = format!("{}::{}/{}#{:x}", pkg, name, arity, expected_fingerprint);
-                if compiled_fns.get(&key_fp).is_some_and(&matches_resolved) {
-                    found_key = Some(key_fp);
-                } else {
-                    let key_arity = format!("{}::{}/{}", pkg, name, arity);
-                    if compiled_fns.get(&key_arity).is_some_and(&matches_resolved) {
-                        found_key = Some(key_arity);
+            let pos_arity = || {
+                args.iter()
+                    .filter(|a| !matches!(a.view(), ValueView::Pair(..)))
+                    .count()
+            };
+            found_key = probe(&format!("{}::{}/{}:{}", pkg, name, arity, type_sig.join(",")))
+                .or_else(|| {
+                    probe(&format!(
+                        "{}::{}/{}#{:x}",
+                        pkg, name, arity, expected_fingerprint
+                    ))
+                })
+                .or_else(|| probe(&format!("{}::{}/{}", pkg, name, arity)));
+            if found_key.is_none() {
+                // `key_simple` (`Pkg::name`) and the positional-only-arity key are
+                // probed but their match is intentionally *not* kept here: the
+                // original control flow gates the global fallback on their result
+                // and then discards it (the `else { found_key = None }` below).
+                // Behaviour-preserving — the def-arity fallback re-resolves.
+                let simple_or_pos = probe(&format!("{}::{}", pkg, name)).or_else(|| {
+                    let pos = pos_arity();
+                    if pos != arity {
+                        probe(&format!(
+                            "{}::{}/{}#{:x}",
+                            pkg, name, pos, expected_fingerprint
+                        ))
                     } else {
-                        let key_simple = format!("{}::{}", pkg, name);
-                        if compiled_fns.get(&key_simple).is_some_and(&matches_resolved) {
-                            found_key = Some(key_simple);
-                        } else {
-                            // Try with positional-only arity (excluding Pair named args)
-                            let pos_arity = args
-                                .iter()
-                                .filter(|a| !matches!(a.view(), ValueView::Pair(..)))
-                                .count();
-                            if pos_arity != arity {
-                                let key_pos_fp = format!(
-                                    "{}::{}/{}#{:x}",
-                                    pkg, name, pos_arity, expected_fingerprint
-                                );
-                                if compiled_fns.get(&key_pos_fp).is_some_and(&matches_resolved) {
-                                    found_key = Some(key_pos_fp);
-                                } else {
-                                    found_key = None;
-                                }
-                            } else {
-                                found_key = None;
-                            }
-                        }
-                        if found_key.is_none() && pkg != "GLOBAL" {
-                            let key_fp_global =
-                                format!("GLOBAL::{}/{}#{:x}", name, arity, expected_fingerprint);
-                            if compiled_fns
-                                .get(&key_fp_global)
-                                .is_some_and(&matches_resolved)
-                            {
-                                found_key = Some(key_fp_global);
-                            } else {
-                                let key_global = format!("GLOBAL::{}", name);
-                                if compiled_fns.get(&key_global).is_some_and(&matches_resolved) {
-                                    found_key = Some(key_global);
-                                } else {
-                                    // Try with positional-only arity (excluding Pair named args)
-                                    let pos_arity = args
-                                        .iter()
-                                        .filter(|a| !matches!(a.view(), ValueView::Pair(..)))
-                                        .count();
-                                    if pos_arity != arity {
-                                        let key_pos = format!(
-                                            "GLOBAL::{}/{}#{:x}",
-                                            name, pos_arity, expected_fingerprint
-                                        );
-                                        if compiled_fns.get(&key_pos).is_some_and(&matches_resolved)
-                                        {
-                                            found_key = Some(key_pos);
-                                        } else {
-                                            found_key = None;
-                                        }
-                                    } else {
-                                        found_key = None;
-                                    }
-                                }
-                            }
-                        } else {
-                            found_key = None;
-                        }
+                        None
                     }
-                }
+                });
+                found_key = if simple_or_pos.is_none() && pkg != "GLOBAL" {
+                    probe(&format!(
+                        "GLOBAL::{}/{}#{:x}",
+                        name, arity, expected_fingerprint
+                    ))
+                    .or_else(|| probe(&format!("GLOBAL::{}", name)))
+                    .or_else(|| {
+                        // Try with positional-only arity (excluding Pair named args)
+                        let pos = pos_arity();
+                        if pos != arity {
+                            probe(&format!(
+                                "GLOBAL::{}/{}#{:x}",
+                                name, pos, expected_fingerprint
+                            ))
+                        } else {
+                            None
+                        }
+                    })
+                } else {
+                    None
+                };
             }
         }
         // Fallback: when call arity differs from definition arity (e.g. optional
         // params), try the definition's param count to find the compiled function.
         if found_key.is_none() && def_arity != arity {
-            let key_fp = format!("{}::{}/{}#{:x}", pkg, name, def_arity, expected_fingerprint);
-            if compiled_fns.get(&key_fp).is_some_and(&matches_resolved) {
-                found_key = Some(key_fp);
-            } else if pkg != "GLOBAL" {
-                let key_fp_global =
-                    format!("GLOBAL::{}/{}#{:x}", name, def_arity, expected_fingerprint);
-                if compiled_fns
-                    .get(&key_fp_global)
-                    .is_some_and(&matches_resolved)
-                {
-                    found_key = Some(key_fp_global);
+            found_key = probe(&format!(
+                "{}::{}/{}#{:x}",
+                pkg, name, def_arity, expected_fingerprint
+            ))
+            .or_else(|| {
+                if pkg != "GLOBAL" {
+                    probe(&format!(
+                        "GLOBAL::{}/{}#{:x}",
+                        name, def_arity, expected_fingerprint
+                    ))
+                } else {
+                    None
                 }
-            }
+            });
         }
         if let Some(key) = found_key {
             // Cache the resolution result for future lookups
@@ -226,7 +189,7 @@ impl Interpreter {
                 .unwrap_or_else(|| self.current_package().to_string());
             if use_cache {
                 self.fn_resolve_cache
-                    .insert(cache_key, (key.clone(), expected_fingerprint, cached_pkg));
+                    .insert(cache_key, (key, expected_fingerprint, cached_pkg));
             }
             compiled_fns.get(&key)
         } else {


### PR DESCRIPTION
## What

Perf scouting §3.1 **S1b** ([docs/perf-callpath-scouting.md](docs/perf-callpath-scouting.md)).

The compiled-function table `CompiledFns` was `FxHashMap<String, CompiledFunction>` (S1a already landed the FxHash), so the ultra-fast positional light-call **cache hit** on every function call still did:

```rust
let Some((cached_key, cached_fp)) = self.pos_light_call_cache.get(&name_sym)   // FxHashMap<Symbol, (String, u64)>
    && let Some(cf) = compiled_fns.get(cached_key.as_str())                    // FxHash + memcmp of a ~20-byte key
```

i.e. a monomorphic call that hits the cache re-derived the callee by **memcmp-ing a formatted key string**, and each cache entry owned a heap `String`.

## Change

Key the table by `Symbol`: `CompiledFns = FxHashMap<Symbol, CompiledFunction>`.

- The formatted keys (`Pkg::name/arity#fingerprint`) are interned **once at compile time**, so a cache hit compares a `u32` symbol id — the memcmp is gone.
- The three light-call caches (`pos_light_call_cache`, `light_call_cache`, `fn_resolve_cache`) store the resolved key as a `Copy` `Symbol` — no per-entry `String` allocation.
- The slow resolution path probes candidate keys via `Symbol::lookup` (**no interning**): every real key is interned by the compiler, so a lookup finds it, while a candidate that turns out not to exist never grows the global (append-only) symbol table.

Behaviour is preserved exactly, including the non-`::` branch's global-fallback gate that discards a bare `Pkg::name` / positional-arity match and re-resolves through the def-arity fallback.

## Validation

- `make test`: **1745 files, 17138 tests — PASS** (behaviour-neutral).
- `cargo clippy -- -D warnings`: clean.
- Targeted roast: `S06-signature/named-parameters.t`, `S06-multi/type-based.t`, `S06-multi/lexical-multis.t`, `S04-declarations/state.t` all PASS.
- The perf gain (memcmp → `u32` compare, plus dropped per-cache-entry `String`) is mechanical and predictable; the authoritative number comes from the bench CI (`bench-data`, `+jit` series) on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)