### PR TITLE
ci: bump GitHub Actions to Node 24-based major versions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     # 25 min gives headroom for a cold/partial cargo cache.
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
@@ -27,7 +27,7 @@ jobs:
           components: clippy, rustfmt
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -120,7 +120,7 @@ jobs:
         # diagnosed from the artifact even when the web log viewer truncates the
         # step. Retained briefly; this is a debugging aid, not a release artifact.
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: roast-log
           path: tmp/roast.log
@@ -131,14 +131,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@1.96.0
         with:
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -155,7 +155,7 @@ jobs:
           wasm-pack build --target web --no-default-features --features wasm
           mv pkg wasm-demo/pkg
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
 
@@ -205,14 +205,14 @@ jobs:
       # timed out on a loaded runner the first time this step ran blocking.
       MUTSU_ROAST_TIMEOUT_SCALE: "2"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
       - uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -291,7 +291,7 @@ jobs:
 
       - name: Upload GC stress logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gc-stress-logs
           path: |
@@ -317,14 +317,14 @@ jobs:
       MUTSU_JIT: "on"
       MUTSU_JIT_THRESHOLD: "2"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: true
 
       - uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -366,7 +366,7 @@ jobs:
 
       - name: Upload JIT stress logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: jit-stress-logs
           path: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@1.93.0
         with:
@@ -33,7 +33,7 @@ jobs:
           mv pkg wasm-demo/pkg
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: wasm-demo
 
@@ -46,4 +46,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,14 +30,14 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@1.93.0
         with:
           targets: ${{ matrix.target }}
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -59,7 +59,7 @@ jobs:
           tar czf ../../../mutsu-${{ github.ref_name }}-${{ matrix.archive_name }}.tar.gz mutsu
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mutsu-${{ matrix.archive_name }}
           path: mutsu-${{ github.ref_name }}-${{ matrix.archive_name }}.tar.gz
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           merge-multiple: true
 

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -13,13 +13,13 @@ jobs:
   tagpr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.TAGPR_APP_ID }}
           private-key: ${{ secrets.TAGPR_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
GitHub is deprecating the Node.js 20 runtime for actions. The runners now force Node 20-based actions to run on Node 24 and emit a deprecation warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4.

This bumps every first-party action to its latest Node 24-based major (`runs.using: node24`):

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/cache | v4 | v6 |
| actions/setup-node | v4 | v7 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |
| actions/create-github-app-token | v1.12.0 | v3.2.0 |

Notes:
- The SHA-pinned entries in `tagpr.yml` are re-pinned to the new tags' commit SHAs (checkout v7.0.0, create-github-app-token v3.2.0).
- `download-artifact@v8` defaults to erroring on hash mismatch and is content-type-aware for direct downloads; both are compatible with the release job's `merge-multiple` download of the uploaded tarballs.
- All target majors require a runner >= 2.327.1, satisfied by `ubuntu-latest` / GitHub-hosted runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)