### PR TITLE
perf: skip apply_container_attribute_defaults for classes without is-default

### DIFF
--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -266,71 +266,94 @@ impl Interpreter {
         // computed for EVERY registered class, not just natively-constructible
         // ones: `dispatch_bless` consumes it too, and bless has no
         // native-eligibility gate (a custom `new` doesn't disqualify bless).
-        let (class_attrs, type_constraints, has_build, has_tweak, has_smiley, has_custom_bless) =
-            if registered {
-                let class_attrs = std::sync::Arc::new(self.collect_class_attributes(cn_resolved));
-                let type_constraints =
-                    std::sync::Arc::new(self.collect_attribute_type_constraints(cn_resolved));
-                let mro = self.mro_readonly(cn_resolved);
-                let registry = self.registry();
-                let mut has_build = mro.iter().any(|cls| {
-                    registry
-                        .classes
-                        .get(cls)
-                        .is_some_and(|cd| cd.methods.contains_key("BUILD"))
+        let (
+            class_attrs,
+            type_constraints,
+            has_build,
+            has_tweak,
+            has_smiley,
+            has_custom_bless,
+            has_container_defaults,
+        ) = if registered {
+            let class_attrs = std::sync::Arc::new(self.collect_class_attributes(cn_resolved));
+            let type_constraints =
+                std::sync::Arc::new(self.collect_attribute_type_constraints(cn_resolved));
+            let mro = self.mro_readonly(cn_resolved);
+            let registry = self.registry();
+            let mut has_build = mro.iter().any(|cls| {
+                registry
+                    .classes
+                    .get(cls)
+                    .is_some_and(|cd| cd.methods.contains_key("BUILD"))
+            });
+            let mut has_tweak = mro.iter().any(|cls| {
+                registry
+                    .classes
+                    .get(cls)
+                    .is_some_and(|cd| cd.methods.contains_key("TWEAK"))
+            });
+            let has_smiley = mro.iter().any(|cls| {
+                registry
+                    .classes
+                    .get(cls)
+                    .is_some_and(|cd| !cd.attribute_smileys.is_empty())
+            });
+            drop(registry);
+            // Role submethods are composed into the class's own method table
+            // only when both class and role are 6.c (`compose_submethods`); a
+            // 6.e role's BUILD/TWEAK is still run by the construction phases
+            // via `ordered_role_submethods_for_class`, so probe the composed
+            // roles too — otherwise the has_build/has_tweak gates would skip
+            // those phases for such classes.
+            if !has_build {
+                has_build = mro.iter().any(|cls| {
+                    !self
+                        .ordered_role_submethods_for_class(cls, "BUILD")
+                        .is_empty()
                 });
-                let mut has_tweak = mro.iter().any(|cls| {
-                    registry
-                        .classes
-                        .get(cls)
-                        .is_some_and(|cd| cd.methods.contains_key("TWEAK"))
+            }
+            if !has_tweak {
+                has_tweak = mro.iter().any(|cls| {
+                    !self
+                        .ordered_role_submethods_for_class(cls, "TWEAK")
+                        .is_empty()
                 });
-                let has_smiley = mro.iter().any(|cls| {
-                    registry
-                        .classes
-                        .get(cls)
-                        .is_some_and(|cd| !cd.attribute_smileys.is_empty())
-                });
-                drop(registry);
-                // Role submethods are composed into the class's own method table
-                // only when both class and role are 6.c (`compose_submethods`); a
-                // 6.e role's BUILD/TWEAK is still run by the construction phases
-                // via `ordered_role_submethods_for_class`, so probe the composed
-                // roles too — otherwise the has_build/has_tweak gates would skip
-                // those phases for such classes.
-                if !has_build {
-                    has_build = mro.iter().any(|cls| {
-                        !self
-                            .ordered_role_submethods_for_class(cls, "BUILD")
-                            .is_empty()
-                    });
-                }
-                if !has_tweak {
-                    has_tweak = mro.iter().any(|cls| {
-                        !self
-                            .ordered_role_submethods_for_class(cls, "TWEAK")
-                            .is_empty()
-                    });
-                }
-                let has_custom_bless = self.has_user_method(cn_resolved, "bless");
-                (
-                    class_attrs,
-                    type_constraints,
-                    has_build,
-                    has_tweak,
-                    has_smiley,
-                    has_custom_bless,
-                )
-            } else {
-                (
-                    std::sync::Arc::new(Vec::new()),
-                    std::sync::Arc::new(HashMap::new()),
-                    false,
-                    false,
-                    false,
-                    false,
-                )
-            };
+            }
+            let has_custom_bless = self.has_user_method(cn_resolved, "bless");
+            // Does any `is default(...)` element default exist keyed by this
+            // class? `apply_container_attribute_defaults` looks defaults up by
+            // the receiver class name only, so a key with a matching class is
+            // the exact necessary-and-sufficient condition for it to do work.
+            let registry = self.registry();
+            let has_container_defaults = registry
+                .class_attribute_defaults
+                .keys()
+                .any(|(c, _)| c == cn_resolved)
+                || registry
+                    .class_attribute_default_exprs
+                    .keys()
+                    .any(|(c, _)| c == cn_resolved);
+            drop(registry);
+            (
+                class_attrs,
+                type_constraints,
+                has_build,
+                has_tweak,
+                has_smiley,
+                has_custom_bless,
+                has_container_defaults,
+            )
+        } else {
+            (
+                std::sync::Arc::new(Vec::new()),
+                std::sync::Arc::new(HashMap::new()),
+                false,
+                false,
+                false,
+                false,
+                false,
+            )
+        };
         let attr_syms = std::sync::Arc::new(
             class_attrs
                 .iter()
@@ -347,6 +370,7 @@ impl Interpreter {
             has_tweak,
             has_smiley,
             has_custom_bless,
+            has_container_defaults,
         });
         // Don't freeze a plan for a class that is not (yet) registered: e.g. a
         // role punned to a class on first use would otherwise keep a stale

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -442,6 +442,13 @@ pub(crate) struct NativeCtorPlan {
     /// MRO — such a class must take the interpreter's generic dispatch instead
     /// of the native `bless` fork.
     pub(crate) has_custom_bless: bool,
+    /// True if this class declares an `is default(...)` element default on any
+    /// attribute (keyed by the receiver class name in `class_attribute_defaults`
+    /// / `class_attribute_default_exprs`). When false, `apply_container_attribute_defaults`
+    /// is a guaranteed no-op — every per-attribute registry probe returns `None` —
+    /// so the whole scan (its keys `Vec` plus the `(String, String)` registry-key
+    /// allocs) is skipped. The overwhelmingly common case.
+    pub(crate) has_container_defaults: bool,
 }
 
 /// Kind of declaration a doc comment is attached to.

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -327,6 +327,21 @@ impl Interpreter {
         class_name: &str,
         attributes: &mut crate::value::AttrMap,
     ) {
+        // Fast gate: a class with no `is default(...)` element default makes every
+        // per-attribute registry probe below return `None`, so the whole scan (the
+        // keys `Vec` plus a `(String, String)` registry-key allocation per container
+        // attribute) is pure waste. The per-class flag lives on the cached
+        // `NativeCtorPlan`; `dispatch_bless` fetches (and caches) the plan before
+        // calling here, so the cache hit covers every construction including the
+        // first. A cache miss (unregistered / not-yet-planned class) falls through
+        // to the full scan, which is safe.
+        let skip = self
+            .native_ctor_plan_cache
+            .get(&crate::symbol::Symbol::intern(class_name))
+            .is_some_and(|p| !p.has_container_defaults);
+        if skip {
+            return;
+        }
         let names: Vec<crate::symbol::Symbol> = attributes.keys().copied().collect();
         for attr_name in names {
             if !matches!(


### PR DESCRIPTION
## What

Layer-3 allocation reduction on the `bless` / construction path (PLAN §5), the mzef-ctor hot path.

Every `bless` (and native construct) calls `apply_container_attribute_defaults`, which iterates the instance's `@`/`%` attributes and, per attribute, probes the registry for an `is default(...)` element default:

```rust
self.class_attribute_default(class_name, attr_name.as_str())   // (class.to_string(), attr.to_string()) key
    .or_else(|| self.registry().class_attribute_default_exprs
        .get(&(class_name.to_string(), attr_name.resolve())).cloned()?  // another (String, String) key
        ...)
```

So a wide class like the `Zef::Distribution` shape (6 container attributes, **no** element defaults) paid, **per construction**: a keys `Vec` allocation + ~24 throwaway `String` allocations, every one returning `None`.

## Change

Precompute a per-class `NativeCtorPlan::has_container_defaults` flag — true iff either `class_attribute_defaults` or `class_attribute_default_exprs` holds a key for this class — and early-return from `apply_container_attribute_defaults` when it's false.

The function only ever looks defaults up by the **receiver class name**, so a key with a matching class is the exact necessary-and-sufficient condition for it to find anything. `dispatch_bless` fetches (and caches) the plan before calling here, so the cache hit covers every construction including the first; a cache miss (unregistered / not-yet-planned class) falls through to the full scan, which is safe. One gate inside the function covers all three call sites (`dispatch_bless`, the default-ctor, and `dispatch_new`).

## Validation

- **bench-ctor: 2.348G → 2.291G `instructions:u` (−2.4%)** — release, one P-core, `taskset`-pinned, deterministic (3 runs each, ±0.1%).
- Behaviour-neutral: `is default(...)` element defaults still apply — verified for empty containers **and** caller-provided containers (`C.new(a => [1,2]).a[5]` → the declared `42`).
- `make test`: **1748 files, 17164 tests — PASS**.
- `cargo clippy -- -D warnings`: clean.

Next layer-3 slices on this path: skip the empty-container alloc for attributes immediately overwritten by a named arg, and the `|%_` slip / `:meta(%_)` re-materialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)