### PR TITLE
fix: reify HyperSeq/RaceSeq/Slip when assigned to a typed array

### DIFF
--- a/src/vm/vm_misc_typecheck.rs
+++ b/src/vm/vm_misc_typecheck.rs
@@ -38,6 +38,24 @@ impl Interpreter {
             value = Value::real_array(items);
             *self.stack.last_mut().unwrap() = value.clone();
         }
+        // A parallel sequence RHS (`.hyper`/`.race`) or a `Slip` bound to a typed
+        // array is reified to a real array here so the eager-array element check
+        // below inspects each element, instead of type-checking the whole
+        // `HyperSeq`/`RaceSeq`/`Slip` against the element type ("expected T, got
+        // HyperSeq"). Replace the stack value too so the following SetLocal stores
+        // the reified array. Mirrors the `LazyList` reify just above.
+        if var_name.is_some_and(|name| name.starts_with('@')) {
+            let reified = match value.view() {
+                ValueView::HyperSeq(items) | ValueView::RaceSeq(items) | ValueView::Slip(items) => {
+                    Some(items.to_vec())
+                }
+                _ => None,
+            };
+            if let Some(items) = reified {
+                value = Value::real_array(items);
+                *self.stack.last_mut().unwrap() = value.clone();
+            }
+        }
         // Lazy values cannot be stored in native typed arrays
         if var_name.is_some_and(|name| name.starts_with('@'))
             && crate::runtime::native_types::is_native_array_element_type(base_constraint)

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -170,6 +170,23 @@ impl Interpreter {
             }
             None
         };
+        // A parallel/lazy sequence RHS (`my T @a = seq.hyper.map(...)` /
+        // `.race` / a plain `Seq`/`Slip`) must be reified to its elements so the
+        // typed-array element coercion below type-checks each element, instead of
+        // rejecting the whole `HyperSeq`/`RaceSeq` as one opaque value ("expected
+        // T, got HyperSeq"). `Seq`/`Slip` are usually already reified to an Array
+        // upstream, but normalizing them here too is harmless. Only for `@` vars.
+        let value = if var_name.starts_with('@') {
+            match value.view() {
+                ValueView::HyperSeq(items)
+                | ValueView::RaceSeq(items)
+                | ValueView::Seq(items)
+                | ValueView::Slip(items) => Value::real_array(items.to_vec()),
+                _ => value,
+            }
+        } else {
+            value
+        };
         if var_name.starts_with('@')
             && let Some(constraint) = loan_env!(self, var_type_constraint(var_name))
             && let ValueView::Array(items, kind) = value.view()

--- a/t/hyperseq-typed-array.t
+++ b/t/hyperseq-typed-array.t
@@ -1,0 +1,50 @@
+use Test;
+
+# A parallel/lazy sequence RHS (`.hyper` / `.race` / `Slip`) assigned to a
+# typed array must reify its elements and type-check each — not reject the whole
+# HyperSeq/RaceSeq against the element type. Regression: `zef fetch` builds
+# `my Candidate @fetched = @candidates.hyper(...).map(...)` (Zef::Client).
+
+plan 11;
+
+class C { has $.n }
+
+# Declaration with initializer (goes through the TypeCheck opcode).
+my C @a = (^3).hyper.map({ C.new(n => $_) });
+is @a.elems, 3, 'HyperSeq -> typed array declaration: elems';
+is @a.map(*.n).sort.join(','), '0,1,2', 'HyperSeq -> typed array declaration: elements type-checked and stored';
+
+my C @b = (^3).race.map({ C.new(n => $_) });
+is @b.elems, 3, 'RaceSeq -> typed array declaration: elems';
+
+my C @c = (^4).hyper(:batch(1), :degree(2)).map({ C.new(n => $_) });
+is @c.elems, 4, 'HyperSeq with :batch/:degree (the zef shape): elems';
+
+# Plain assignment (goes through the SetLocal / coerce path, not TypeCheck).
+my C @d;
+@d = (^3).hyper.map({ C.new(n => $_) });
+is @d.elems, 3, 'HyperSeq -> typed array assignment: elems';
+
+# Native element type.
+my Int @e = (^5).hyper.map({ $_ * 2 });
+is @e.elems, 5, 'HyperSeq -> native Int typed array: elems';
+is @e.sum, 20, 'HyperSeq -> native Int typed array: values';
+
+my Int @f = (^5).race.map(* + 1);
+is @f.sort.join(','), '1,2,3,4,5', 'RaceSeq -> native Int typed array: values';
+
+# A type mismatch must still be caught after reification.
+my $died = False;
+try {
+    my Int @g = (^3).hyper.map({ "not an int" });
+    CATCH { default { $died = True } }
+}
+ok $died, 'HyperSeq element type mismatch is still rejected after reification';
+
+# Untyped array baseline still works.
+my @h = (^3).hyper.map({ C.new(n => $_) });
+is @h.elems, 3, 'HyperSeq -> untyped array still works';
+
+# Slip into a typed array.
+my Int @i = (|(1, 2, 3),);
+is @i.elems, 3, 'Slip into a native typed array reifies its elements';


### PR DESCRIPTION
## What

`my Candidate @fetched = @candidates.hyper(...).map(...)` — the exact shape `Zef::Client` uses on the **`zef fetch`** path — failed under mutsu with:

```
Type check failed in assignment to @fetched; expected Candidate, got HyperSeq
```

A parallel/lazy sequence RHS (`.hyper` / `.race` / a `Slip`) was type-checked as a **single opaque value** against the array's element type, instead of having its elements reified and type-checked one by one (which raku does, and which mutsu already did for `Array`/`Seq`).

## Change

Two independent code paths recognized only `Array`/`Seq`:

- **Declaration** (`my T @a = seq.hyper.map(...)`) emits a `TypeCheck` opcode before the store. Its `@`-array branch matched only `Array`/`Seq`, so a `HyperSeq`/`RaceSeq`/`Slip` fell through to the scalar element check → error. Now reify it to a real array (mirroring the existing `LazyList` reify right above) and replace the stack value so the following `SetLocal` stores the reified array.
- **Assignment** (`@a = seq.hyper.map(...)`) runs `coerce_typed_container_assignment`, whose `@` branch also only recognized `ValueView::Array`. Reify the parallel/lazy sequence kinds to a real array first.

A genuine element type mismatch is still rejected after reification.

## Why it matters (mzef)

This unblocks the **real `zef fetch` pipeline** past its post-fetch candidate assignment. Confirmed against the vendored zef: `zef fetch Test::META` now fetches the tarball over HTTPS (via curl — **no native TLS needed in mutsu**) and proceeds to the **extraction** phase (the next blocker), where before it aborted at this assignment.

## Validation

- New pin **`t/hyperseq-typed-array.t`** (11 cases; passes under both mutsu and raku): declaration + assignment paths, native and object element types, `:batch`/`:degree` (the zef shape), a still-rejected type mismatch, and `Slip`.
- `make test`: **1748 files, 17164 tests — PASS**.
- `cargo clippy -- -D warnings`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)