### PR TITLE
fix: honor Proc::Async.start(:cwd, :ENV) — set child working dir + environment

### DIFF
--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -193,6 +193,34 @@ impl Interpreter {
                     cmd.stdin(Stdio::piped());
                 }
 
+                // Honor `.start(:$cwd, :$ENV)`. zef's tar/git/curl shell-outs run
+                // with `:cwd($archive.parent)` and a *relative* path
+                // (`./foo.tar.gz`), so an ignored `:cwd` made every `zef` extract
+                // (and any relative-path child) run in the wrong directory and
+                // fail. `:ENV` replaces the child's whole environment with the
+                // given hash (Raku semantics), matching Rakudo's `Proc::Async`.
+                for arg in &args {
+                    if let ValueView::Pair(key, val) = arg.view() {
+                        match key.as_str() {
+                            "cwd" => {
+                                let dir = val.to_string_value();
+                                if !dir.is_empty() {
+                                    cmd.current_dir(dir);
+                                }
+                            }
+                            "ENV" => {
+                                if let ValueView::Hash(map) = val.view() {
+                                    cmd.env_clear();
+                                    for (env_key, env_val) in map.iter() {
+                                        cmd.env(env_key, env_val.to_string_value());
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+
                 let child_result = cmd.spawn();
 
                 // If spawn failed, break all promises with X::OS and return

--- a/t/proc-start-cwd-env.t
+++ b/t/proc-start-cwd-env.t
@@ -1,0 +1,41 @@
+use Test;
+
+# Proc::Async.start(:$cwd, :$ENV) must set the child process's working directory
+# and environment. zef's tar/git/curl shell-outs run with `:cwd($archive.parent)`
+# and a *relative* archive path (`./foo.tar.gz`), so an ignored :cwd made every
+# `zef` extract fail. Regression pin.
+
+plan 4;
+
+my $dir = $*TMPDIR.child("mutsu-proc-cwd-{$*PID}");
+mkdir($dir);
+$dir.child("marker.txt").spurt("hello-from-cwd\n");
+
+# A relative path only resolves if :cwd is honored.
+{
+    my $out = Buf.new;
+    my $passed;
+    react {
+        my $proc = Proc::Async.new('cat', 'marker.txt');
+        whenever $proc.stdout(:bin) { $out.append($_) }
+        whenever $proc.stderr(:bin) { }
+        whenever $proc.start(:cwd($dir)) { $passed = $_.so }
+    }
+    ok $passed, ':cwd — child ran successfully with a relative path';
+    is $out.decode.trim, 'hello-from-cwd', ':cwd — child resolved the relative path against :cwd';
+}
+
+# :ENV replaces the child environment.
+{
+    my $out = Buf.new;
+    my $passed;
+    my %env = MUTSU_PROC_CWD_TEST => 'env-value-123';
+    react {
+        my $proc = Proc::Async.new('sh', '-c', 'printf %s "$MUTSU_PROC_CWD_TEST"');
+        whenever $proc.stdout(:bin) { $out.append($_) }
+        whenever $proc.stderr(:bin) { }
+        whenever $proc.start(:ENV(%env)) { $passed = $_.so }
+    }
+    ok $passed, ':ENV — child ran successfully';
+    is $out.decode, 'env-value-123', ':ENV — child saw the provided environment variable';
+}


### PR DESCRIPTION
## What

`Proc::Async.start(:$cwd, :$ENV)` **ignored both named arguments** — the child process was always spawned in mutsu's own working directory with mutsu's own environment.

This broke the real `zef` **extract** phase: zef's shell-out backends (`Zef::Service::Shell::tar` / `git` / `curl`) run with `:cwd($archive.parent)` and a **relative** archive path (`./foo.tar.gz`, a deliberate workaround for zef issue #444). With `:cwd` ignored, `tar -t -f ./foo.tar.gz` ran in the wrong directory and silently failed (0 bytes of output, non-zero exit), so extraction aborted.

## Change

In the `Proc::Async` `.start` handler, read the `:cwd` / `:ENV` Pairs from the call arguments and apply them to the spawned `Command`:
- `:cwd` → `Command::current_dir`
- `:ENV` → `Command::env_clear` + the provided hash (Rakudo replaces the child's whole environment with the given hash).

## Validation

- New pin **`t/proc-start-cwd-env.t`** (4 cases, passes under mutsu and raku): a relative path resolves only when `:cwd` is honored; the child sees the `:ENV` variable.
- Isolated repro of zef's `tar -t -f ./x.tar.gz` shape: mutsu now returns the file list (was 0 bytes / failed).
- `make test`: **1750 files, 17181 tests — PASS**.
- `cargo clippy -- -D warnings`: clean.

Part of the mzef install-pipeline push (fetch over curl already works; this unblocks extract). Follows #4615 (HyperSeq typed-array reify, which unblocked fetch→extract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)