### PR TITLE
fix: run proto on mut-path handles delegation; scope rw-writeback slot to its frame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -2369,8 +2369,19 @@ impl Interpreter {
                 };
                 let temp_var = format!("{}__mutsu_delegation_tmp__", sigil);
                 self.env.insert(temp_var.clone(), delegate.clone());
-                let result =
-                    self.call_method_mut_with_values(&temp_var, delegate, target_method, args)?;
+                // A delegated method whose target class declares a `proto method`
+                // must run that proto body first (its `{*}` dispatches to the
+                // matching multi). The mut dispatch below
+                // (`call_method_mut_with_values`) skips the proto, so intercept it
+                // here — mirroring the non-mut `forward_resolved_delegation` path,
+                // which forwards through `call_method_with_values` (proto-aware).
+                let result = if let Some(proto_result) =
+                    self.try_proto_method_body(&delegate, target_method, &args)
+                {
+                    proto_result?
+                } else {
+                    self.call_method_mut_with_values(&temp_var, delegate, target_method, args)?
+                };
                 // Read back the potentially-updated delegate
                 let updated_delegate = self.env.get(&temp_var).cloned().unwrap_or(Value::NIL);
                 self.env.remove(&temp_var);

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -993,12 +993,35 @@ impl Interpreter {
                 // this drain. A blanket clear would wrongly drop an OUTER call's
                 // still-pending slot when a NESTED call drains first (`f($a)` whose
                 // body calls `g($b)` — g's drain must not lose f's `a` slot).
-                let baked = self
+                let baked_raw = self
                     .pending_rw_writeback_slots
                     .remove(&source)
-                    .map(|s| s as usize)
-                    .filter(|&s| s < self.locals.len());
-                if let Some(slot) = baked.or_else(|| self.find_local_slot(code, &source)) {
+                    .map(|s| s as usize);
+                // A baked slot index is only meaningful in the frame it was baked
+                // in. When a NESTED call drains a source whose slot was baked for an
+                // ANCESTOR frame (`f(@a, %h)` whose body calls `@a.map(...)` — the
+                // `.map` mut-op drains f's still-pending `@a`/`%h` writeback), that
+                // caller-frame index can collide with THIS frame's `locals` range
+                // (`s < locals.len()`) yet name a *different* variable — writing the
+                // wrong value into an unrelated slot (a Hash param clobbered by an
+                // Array source). Trust the baked slot only when THIS frame's `code`
+                // actually holds `source` at it; otherwise the source belongs to a
+                // frame further up the stack, so retain it for that frame's own
+                // drain rather than mis-applying (or draining early by name) here.
+                let baked = baked_raw.filter(|&s| {
+                    s < self.locals.len() && code.locals.get(s).is_some_and(|n| n == &source)
+                });
+                let slot = if baked.is_some() {
+                    baked
+                } else if baked_raw.is_some() {
+                    // Baked for a different frame: retain for the owning frame.
+                    None
+                } else {
+                    // No baked slot (a captured-outer free-var write, …): resolve
+                    // the owning slot by name within this frame's code.
+                    self.find_local_slot(code, &source)
+                };
+                if let Some(slot) = slot {
                     if !matches!(self.locals[slot].view(), ValueView::HashEntryRef { .. })
                         && let Some(val) = self.env().get(&source).cloned()
                     {

--- a/t/handles-proto-dispatch-mut-invocant.t
+++ b/t/handles-proto-dispatch-mut-invocant.t
@@ -1,0 +1,50 @@
+use Test;
+
+# A `handles`-delegated method whose target class declares a `proto` must run
+# that proto body (its `{*}` dispatches to a multi) even when the delegating
+# object is reached through a *variable* invocant (`$obj.meth` / `self.meth`
+# inside a method), which routes through the mut method-dispatch path. That path
+# previously forwarded the delegation straight to a multi candidate, skipping the
+# proto (Template::Mustache Logger.log filtering broke as a result).
+
+plan 4;
+
+my @log;
+
+class Inner {
+    proto method note(:$level = 'Info', |) {
+        @log.push("proto:$level");
+        return if $level eq 'Skip';
+        {*}
+    }
+    multi method note(:$level = 'Info', *@msg) {
+        @log.push("multi:$level:{@msg.join}");
+    }
+}
+
+class Outer {
+    has $.inner handles <note>;
+    submethod TWEAK { $!inner //= Inner.new }
+    method go-self  { self.note(:level<Run>, "x") }
+}
+
+my $o = Outer.new;
+
+# Fresh-expression invocant (non-mut path): proto then multi.
+Outer.new.note(:level<Run>, "a");
+is @log, ["proto:Run", "multi:Run:a"], "fresh invocant runs proto";
+
+# Variable invocant (mut path): proto must still run.
+@log = [];
+$o.note(:level<Run>, "b");
+is @log, ["proto:Run", "multi:Run:b"], "variable invocant runs proto";
+
+# `self.meth` inside a method (mut path via self): proto must run.
+@log = [];
+$o.go-self;
+is @log, ["proto:Run", "multi:Run:x"], "self.meth inside a method runs proto";
+
+# The proto can short-circuit (its `return` filters the multi out).
+@log = [];
+$o.note(:level<Skip>, "c");
+is @log, ["proto:Skip"], "proto short-circuit is honored on the mut path";

--- a/t/map-nested-call-rw-writeback-slot.t
+++ b/t/map-nested-call-rw-writeback-slot.t
@@ -1,0 +1,28 @@
+use Test;
+
+# A sub with plain `@`/`%` container params registers an exit-time rw-writeback
+# keyed by the CALLER frame's compiled slot index. A nested mut-method call in
+# the body (`@ctx.map(...)`, a CallMethodMut) drains that still-pending writeback
+# early; the caller-frame slot index could collide with THIS frame's `locals`
+# range and clobber an unrelated same-index local — e.g. a `%val` Hash param
+# overwritten by the `@context` Array. (Template::Mustache `format(%val,@context)`
+# hit this via `for @context.map({visit($^ctx,...)}) { $ctx ~~ Promise }`.)
+
+plan 3;
+
+sub get(@context, %val) {
+    # Nested mut-method call whose block uses a placeholder + a smartmatch,
+    # forcing the interpreter map fallback and then a topic-writeback op.
+    for @context.map({ $^ctx }) -> $ctx {
+        my $ = ($ctx ~~ Int);
+    }
+    # %val must still be the Hash we were passed, not @context's Array.
+    return %val<val>;
+}
+
+my %val = type => 'section', val => 'boolean';
+my @context = [ (b => True), ];
+
+is get(@context, %val), 'boolean', "container param not clobbered by nested map";
+is %val.^name, 'Hash', "caller %val stays a Hash after the call";
+is @context.^name, 'Array', "caller \@context stays an Array after the call";


### PR DESCRIPTION
Two independent VM correctness bugs, both found while working through Template::Mustache's spec suite (`91-specs.rakutest`). Each has a deterministic minimal reproduction and a pin test.

## 1. `handles`-delegated `proto` skipped on the mut invocant path

A `handles`-delegated method whose target class declares a `proto` ran the multi directly — skipping the proto body — when the delegating object was reached through a **variable** invocant (`$obj.meth`, or `self.meth` inside a method). Those route through the mut method-dispatch path, which forwarded the delegation via `call_method_mut_with_values` (proto-unaware), unlike the non-mut `forward_resolved_delegation` which uses the proto-aware `call_method_with_values`.

```raku
class Inner { proto method note(:$level,|){ ...; {*} }  multi method note(:$level,*@m){ ... } }
class Outer { has $.inner handles <note>; method go { self.note(:level<x>, "a") } }
Outer.new.note(...);   # ran proto  (fresh invocant → non-mut path)
my $o = Outer.new; $o.note(...);   # skipped proto (variable → mut path)  ← bug
```

Template::Mustache's `Logger.log` filters log levels **in the proto body**, so skipping it made every render throw a spurious `sprintf` error. Fix: intercept `try_proto_method_body` in the mut-path delegation branch, mirroring the non-mut path (closes a standing TODO in `dispatch_proto.rs`).

## 2. rw-writeback baked slot leaked across frames

A sub with plain `@`/`%` container params registers an exit-time rw-writeback keyed by the **caller** frame's compiled slot index. A nested mut-method call in the body (`@ctx.map(...)`, a `CallMethodMut`) drained that still-pending writeback early; the caller-frame slot index could pass the `s < self.locals.len()` range check yet name a **different** variable in the callee frame, writing the wrong value into an unrelated local — e.g. a `%val` Hash param clobbered by the `@context` Array.

Fix: in `apply_pending_rw_writeback`, trust a baked slot only when **this** frame's `code.locals` actually holds the source name at it; otherwise the source belongs to an ancestor frame, so retain it for that frame's own drain instead of mis-applying (or draining early by name) here.

## Result

Mustache spec suite goes from *every subtest erroring* to `comments` / `interpolation` / `inheritable_sections` passing and `sections` down to a single remaining failure. The rest of the Mustache remainder (inverted-section grammar, partials, delimiter persistence, lambdas) is unrelated and tracked separately.

## Testing

- `t/handles-proto-dispatch-mut-invocant.t`, `t/map-nested-call-rw-writeback-slot.t` (new pin tests)
- `cargo test` green; 154 relevant existing `t/` tests (map/grep/handles/closure/container/proto/multi) green
- Full `make test` + `make roast` via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)