### PR TITLE
fix: coercion-typed param dispatches native target method (IO::Path.Str)

### DIFF
--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -19,6 +19,11 @@ impl Interpreter {
             .class_has_method(class_name, method_name)
     }
 
+    pub(super) fn class_has_user_method(&mut self, class_name: &str, method_name: &str) -> bool {
+        self.registry_mut()
+            .class_has_user_method(class_name, method_name)
+    }
+
     /// Check whether the class (or its MRO ancestors) has a `new` method
     /// variant with a non-named positional parameter whose type matches the
     /// given value.  This is used by the coercion fallback: only try `new`

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -417,6 +417,24 @@ impl Registry {
         false
     }
 
+    /// Whether `class_name` (or any class in its MRO) defines `method_name` as a
+    /// *user-declared* method (i.e. present in `.methods`), ignoring native
+    /// builtin methods. Used by the coercion path to decide whether to run a
+    /// user coercion method (e.g. `method Str {...}`) via `run_instance_method`
+    /// versus routing a native builtin method (e.g. `IO::Path.Str`) through the
+    /// native dispatcher. Pure registry MRO walk.
+    pub(crate) fn class_has_user_method(&mut self, class_name: &str, method_name: &str) -> bool {
+        let mro = self.class_mro(class_name);
+        for cn in mro.iter() {
+            if let Some(class_def) = self.classes.get(cn.as_str())
+                && class_def.methods.contains_key(method_name)
+            {
+                return true;
+            }
+        }
+        false
+    }
+
     /// The method overloads named `method_name` defined directly on `class_name`
     /// (not inherited). Owned clone — `MethodDef` is `Arc`-backed so the clone is
     /// O(overload count) refcount bumps, matching the prior `.cloned()` call sites.

--- a/src/runtime/types/coercion.rs
+++ b/src/runtime/types/coercion.rs
@@ -178,7 +178,7 @@ impl Interpreter {
             attributes,
             ..
         } = value.view()
-            && self.class_has_method(&class_name.resolve(), base_target)
+            && self.class_has_user_method(&class_name.resolve(), base_target)
         {
             let (coerced, _) = self.run_instance_method(
                 &class_name.resolve(),

--- a/t/coercion-native-method-param.t
+++ b/t/coercion-native-method-param.t
@@ -1,0 +1,39 @@
+use Test;
+
+# A coercion-typed parameter (e.g. `Str() $x`) must dispatch the target
+# coercion method even when it is a *native* builtin method rather than a
+# user-declared one. IO::Path is the canonical case: `IO::Path.Str` is a
+# native method, so `sub f(Str() $uri) {...}; f($some-io-path)` used to fail
+# with "No such method 'Str' for invocant of type 'IO::Path'" because the
+# coercion path routed native methods through the user-method runner.
+# This is exactly what zef's `Zef::Service::Shell::tar.extract-matcher(Str() $uri)`
+# hits when passed a `$candi.uri` IO::Path during the install pipeline's
+# extract phase.
+
+plan 8;
+
+sub take-str(Str() $x --> Bool:D) { return so $x.lc.ends-with('.gz') }
+ok  take-str('/tmp/x.tar.gz'.IO), 'Str() param coerces IO::Path via native .Str (matches)';
+nok take-str('/tmp/x.tar'.IO),    'Str() param coerces IO::Path via native .Str (no match)';
+
+sub name-of(Str() $x) { $x.^name }
+is name-of('/a/b'.IO), 'Str', 'Str() coercion of IO::Path yields a Str';
+is name-of(42),        'Str', 'Str() coercion of Int still works';
+
+# User-declared coercion methods must keep working (regression guard for the
+# fix, which now only routes *user* methods through run_instance_method).
+class WithStr is Cool {
+    has $.a = 'coerced';
+    method Str() { $.a }
+}
+is name-of(WithStr.new), 'Str', 'Str() coercion still runs a user .Str method';
+ok take-str('archive.GZ'), 'plain Str arg to Str() param, .lc applied';
+
+# Int() coercion of a native type dispatches the native .Int method.
+sub int-of(Int() $x) { $x.^name }
+is int-of('42'), 'Int', 'Int() coercion of Str still works';
+
+# IO::Path.Int is a native method too; raku returns a Failure for a
+# non-numeric path, so a numeric-looking basename coerces cleanly.
+sub abs-int(Int() $x) { $x }
+is abs-int(7), 7, 'Int() coercion passes through an Int';


### PR DESCRIPTION
## Problem

A coercion-typed parameter such as `Str() $uri` failed to bind an argument whose target coercion method is a **native builtin** method rather than a user-declared one. The canonical case is `IO::Path`:

```raku
sub f(Str() $uri --> Bool:D) { so $uri.lc.ends-with('.gz') }
f('/tmp/x.tar.gz'.IO);
# X::TypeCheck::Binding::Parameter: No such method 'Str' for invocant of type 'IO::Path'
```

…even though `$path.Str` dispatches fine on its own.

## Root cause

`try_coerce_value_with_method` gated its "run the object's coercion method" branch on `class_has_method`, which returns true for **both** user methods and native builtin methods. For a native-only method (empty `.methods`, method listed in `.native_methods`) it then called `run_instance_method` — the user-method runner — which cannot dispatch a native builtin method and errored out. The generic fallback right below it (`coerce_value` + native `call_method_with_values`) already handles native methods correctly, but the branch shadowed it.

## Fix

Add `class_has_user_method` (checks only `.methods` across the MRO) and gate the branch on it, so:
- **native** builtin coercion methods (`IO::Path.Str`, `IO::Path.Int`, …) fall through to the generic native path;
- **user-declared** coercion methods (`method Str {...}`) keep running via `run_instance_method`.

Verified `mutsu` now matches `raku` on the repro and on `Int()`-of-`IO::Path` (both return a `Failure` for a non-numeric path).

## Why it matters

This unblocks the **mzef install pipeline's extract phase**. zef's `Zef::Service::Shell::tar.extract-matcher(Str() $uri)` is called with a `$candi.uri` `IO::Path`; the coercion failure was thrown inside `Zef::Extract.ls-files`, swallowed by the MAIN dispatcher, and surfaced only as a usage dump. With this fix, `zef fetch` now advances past `ls-files`/`extract-matcher` into the tar `.extract()` call (the next, separate frontier).

## Test

`t/coercion-native-method-param.t` (8 assertions; passes identically under `raku`). Existing coercion suite unaffected.