### PR TITLE
fix: regex <graph> excludes Symbol/Mark categories, matching raku

### DIFF
--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -678,8 +678,18 @@ pub(super) fn matches_named_builtin(name: &str, c: char) -> bool {
         "cntrl" => c.is_control(),
         "punct" => check_unicode_property("Punctuation", c),
         "graph" => {
-            // graph: visible characters — not whitespace, not control, not unassigned surrogates
-            !c.is_whitespace() && !c.is_control()
+            // Raku's POSIX `graph` is Letters ∪ decimal digits (Nd) ∪ Punctuation.
+            // It EXCLUDES the Symbol categories (Sm/Sc/Sk/So — `^ $ ~ + = < > | °`),
+            // Marks, and non-decimal Number categories (No/Nl) — narrower than the
+            // C/POSIX "any visible char". Matching raku is required so `<+graph
+            // -punct>` (a common "word char" idiom) does not swallow `^`/`$`/…; e.g.
+            // Template::Mustache's grammar `token ident { <+ graph - punct> ... }`
+            // must reject the `^`/`$`/`<` sigils so `{{^inverted}}` / `{{<parent}}`
+            // tags dispatch to the section rule instead of the plain-var rule.
+            check_unicode_property("Letter", c)
+                || c == '_'
+                || check_unicode_property("Nd", c)
+                || check_unicode_property("Punctuation", c)
         }
         "print" => {
             // print: graph + space-like characters (but not control characters)

--- a/t/regex-graph-excludes-symbols.t
+++ b/t/regex-graph-excludes-symbols.t
@@ -1,0 +1,26 @@
+use Test;
+
+# Raku's POSIX `<graph>` character class is Letters ∪ decimal digits (Nd) ∪
+# Punctuation. Unlike the C/POSIX "any visible char", it EXCLUDES the Unicode
+# Symbol categories (Sm/Sc/Sk/So), Marks, and non-decimal Number categories.
+# mutsu previously matched every non-space/non-control char, so `<+graph -punct>`
+# (a common "word char" idiom) wrongly kept symbols like `^`/`$`, breaking e.g.
+# Template::Mustache's `token ident { <+ graph - punct> ... }`.
+
+plan 6;
+
+# Symbols (S*) are NOT graph.
+ok !('^' ~~ /^<+graph>$/), "caret (Sk) is not <graph>";
+ok !('\$' ~~ /^<+graph>$/), "dollar (Sc) is not <graph>";
+ok !('+' ~~ /^<+graph>$/), "plus (Sm) is not <graph>";
+
+# Letters, decimal digits, and P-punctuation ARE graph.
+ok ('a' ~~ /^<+graph>$/) && ('1' ~~ /^<+graph>$/) && ('#' ~~ /^<+graph>$/),
+    "letters, digits and P-punctuation are <graph>";
+
+# The `<+graph -punct>` idiom yields alphanumerics only (no symbols, no punct;
+# `_` is Connector Punctuation so it too is excluded).
+my @word = < a Z 3 >;
+my @nonword = ('^', '$', '~', '+', '=', '<', '>', '|', '#', '/', '_');
+ok @word.all ~~ /^<+ graph - punct>$/, "alphanumerics pass <+graph -punct>";
+ok @nonword.none ~~ /^<+ graph - punct>$/, "symbols and punct fail <+graph -punct>";


### PR DESCRIPTION
mutsu's POSIX `<graph>` character class matched every non-whitespace, non-control char (the C/POSIX "any visible char"). **Raku's `<graph>` is narrower**: Letters ∪ decimal digits (Nd) ∪ Punctuation — it EXCLUDES the Unicode Symbol categories (Sm/Sc/Sk/So: `^ $ ~ + = < > | °`), Marks, and non-decimal Number categories (No/Nl).

```raku
say ?('^' ~~ /^<+graph>$/);   # raku: False   mutsu (before): True
say ?('$' ~~ /^<+graph>$/);   # raku: False   mutsu (before): True
say ?('#' ~~ /^<+graph>$/);   # both: True (# is Po punctuation)
```

The gap breaks the common `<+ graph - punct>` "word char" idiom. Template::Mustache's grammar uses `token ident { <+ graph - punct> ... }`; with symbols wrongly counted as `graph`, `<ident>` swallowed the `^`/`<`/`$` section sigils, so `{{^inverted}}` / `{{<parent}}` / `{{$override}}` tags mis-dispatched to the plain-var rule instead of the section rule (LTM then never reached the section candidate).

Fix: `graph` = `Letter ∪ '_' ∪ Nd ∪ Punctuation`, reusing `check_unicode_property`. `<print>` is left as-is — it already matches raku (print *does* include symbols + space).

## Testing
- `t/regex-graph-excludes-symbols.t` (new; output verified byte-identical to raku)
- roast `S05-mass/stdrules.t` (193) and `S05-mass/properties-general.t` (615) stay green
- 94 regex + 55 grammar `t/` tests green
- Full `make test` + `make roast` via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)