### PR TITLE
fix: IO::Path.relative computes a real relative path (abs2rel)

### DIFF
--- a/src/runtime/native_io/io_path_stat.rs
+++ b/src/runtime/native_io/io_path_stat.rs
@@ -114,21 +114,69 @@ impl Interpreter {
                         .unwrap_or(&norm_p);
                     Ok(Value::str(rel.to_string()))
                 } else {
-                    let rel_base_arg = args.first().map(|v| v.to_string_value());
-                    let rel_base = rel_base_arg
-                        .as_ref()
-                        .map(PathBuf::from)
-                        .or_else(|| instance_cwd.as_ref().map(PathBuf::from))
-                        .unwrap_or_else(|| cwd_path.clone());
-                    let rel = path_buf
-                        .strip_prefix(&rel_base)
-                        .map(Self::stringify_path)
-                        .unwrap_or_else(|_| Self::stringify_path(&path_buf));
+                    // Compute a path relative to `base` (default `$*CWD`),
+                    // matching raku's `$*SPEC.abs2rel`: make both the receiver
+                    // and the base absolute, drop the common leading prefix, and
+                    // prepend a `..` for each remaining base component. A plain
+                    // `strip_prefix` only works when the base is a literal
+                    // ancestor of the path — for a sibling/relative base it must
+                    // walk up with `..` (raku returns e.g. `../A/x`), and the old
+                    // fall-through to the absolute path corrupted zef's extract
+                    // paths (it uses `$archive.relative($tmp)` to build `-C`).
+                    let base_buf = match args.first().map(|v| v.to_string_value()) {
+                        Some(base) => self.resolve_path(&base),
+                        None => instance_cwd
+                            .as_ref()
+                            .map(|c| self.resolve_path(c))
+                            .unwrap_or_else(|| cwd_path.clone()),
+                    };
+                    let rel = Self::lexical_abs2rel(&path_buf, &base_buf);
                     Ok(Value::str(rel))
                 }
             }
             _ => unreachable!(),
         })
+    }
+
+    /// Lexically compute the path of `target` relative to `base`, the core of
+    /// `IO::Path.relative` (raku's `$*SPEC.abs2rel`). Both are assumed absolute.
+    /// Purely lexical and the filesystem is never consulted (matching raku, which
+    /// does not resolve symlinks here). `.` segments are dropped but `..` is kept
+    /// as a literal component and compared verbatim — exactly what raku's
+    /// `abs2rel` does (it splits the two absolute strings and never collapses
+    /// `..`). Returns `.` when the two paths are equal.
+    pub(crate) fn lexical_abs2rel(target: &Path, base: &Path) -> String {
+        use std::path::Component;
+        // Component-name vector. The leading `/` (RootDir) is kept as a sentinel
+        // "" so two absolute paths always share it as a common prefix element.
+        // `Path::components()` already drops `.`; `..` stays as a `ParentDir`.
+        fn norm(p: &Path) -> Vec<String> {
+            let mut out: Vec<String> = Vec::new();
+            for c in p.components() {
+                match c {
+                    Component::RootDir => out.push(String::new()),
+                    Component::CurDir => {}
+                    Component::ParentDir => out.push("..".to_string()),
+                    Component::Normal(s) => out.push(s.to_string_lossy().to_string()),
+                    Component::Prefix(_) => {}
+                }
+            }
+            out
+        }
+        let t = norm(target);
+        let b = norm(base);
+        let mut i = 0;
+        while i < t.len() && i < b.len() && t[i] == b[i] {
+            i += 1;
+        }
+        let mut parts: Vec<String> = Vec::new();
+        parts.extend((i..b.len()).map(|_| "..".to_string()));
+        parts.extend(t[i..].iter().cloned());
+        if parts.is_empty() {
+            ".".to_string()
+        } else {
+            parts.join("/")
+        }
     }
 
     /// Filesystem `stat`-only predicates / accessors on an `IO::Path`

--- a/t/io-path-relative-abs2rel.t
+++ b/t/io-path-relative-abs2rel.t
@@ -1,0 +1,36 @@
+use Test;
+
+# IO::Path.relative($base) computes the path relative to $base the way raku's
+# $*SPEC.abs2rel does: make both absolute, drop the common prefix, and prepend a
+# `..` for each remaining base component. A previous mutsu bug only handled the
+# case where $base is a literal ancestor (plain strip-prefix) and otherwise
+# returned the *absolute* path unchanged. That corrupted zef's install pipeline,
+# whose extract phase builds a `tar -C` target from `$archive.relative($tmp)`.
+
+plan 12;
+
+# sibling base -> walk up then down
+is "/tmp/A/x".IO.relative("/tmp/B"),     "../A/x",      'sibling base walks up with ..';
+# ancestor base -> plain descent
+is "/tmp/A/B/x".IO.relative("/tmp/A"),   "B/x",         'ancestor base descends';
+# equal paths -> "."
+is "/tmp/A/x".IO.relative("/tmp/A/x"),   ".",           'equal path is "."';
+# target is an ancestor of base -> all ..
+is "/tmp/A".IO.relative("/tmp/A/B/C"),   "../..",       'target above base is all ..';
+# only the root is common
+is "/a/b/c".IO.relative("/x/y"),         "../../a/b/c", 'only root common';
+# trailing slash on base is ignored
+is "/tmp/A/x".IO.relative("/tmp/A/"),    "x",           'trailing slash on base ignored';
+
+# relative receiver and/or relative base resolve against $*CWD first
+{
+    my $*CWD = "/base/dir".IO;
+    is "sub/f".IO.relative,               "sub/f",       'relative receiver, default base = $*CWD';
+    is "/base/dir/sub/f".IO.relative,     "sub/f",       'absolute receiver under $*CWD';
+    is "/base/x".IO.relative,             "../x",        'non-descendant walks up';
+    is "sub/f".IO.relative("/base"),      "dir/sub/f",   'relative receiver, absolute base';
+    is "/base/dir/a".IO.relative("dir2"), "../a",        'both resolved against $*CWD';
+}
+
+# `.` segments drop; `..` stays literal and is compared verbatim (raku abs2rel).
+is "/tmp/A/./x".IO.relative("/tmp/B/../A"), "../../../A/x", 'dot drops, dotdot literal';

--- a/t/native-io-path-cwd.t
+++ b/t/native-io-path-cwd.t
@@ -20,7 +20,7 @@ plan 14;
     # --- .relative ---
     is "/base/dir/sub/f".IO.relative,          "sub/f", "relative strips \$*CWD prefix";
     is "/base/dir/sub/f".IO.relative("/base"), "dir/sub/f", "relative with an explicit base";
-    is "/elsewhere/g".IO.relative,             "/elsewhere/g", "relative of a non-descendant is unchanged";
+    is "/elsewhere/g".IO.relative,             "../../elsewhere/g", "relative of a non-descendant walks up with ..";
 
     # --- variable receiver (mut dispatch path) ---
     my $p = "data/file".IO;


### PR DESCRIPTION
## Problem

`\$path.relative(\$base)` returned the **absolute** path whenever `\$base` was not a literal ancestor prefix of `\$path`. The implementation did a plain `strip_prefix`, so a sibling / `..`-reachable base — or a base passed as a relative string — fell through to the unchanged absolute path:

```raku
"/tmp/A/x".IO.relative("/tmp/B")   # was "/tmp/A/x",  raku: "../A/x"
"tmp/out".IO.relative("tmp")       # was "/abs/…/tmp/out", raku: "out"
```

## Fix

Reimplement as raku's `\$*SPEC.abs2rel`: resolve both the receiver and the base against `\$*CWD` to absolute, drop the common leading component prefix, and prepend a `..` for each remaining base component (`.` for equal paths). `.` segments drop and `..` stays a literal component, matching raku's component-wise compare (verified against `raku` across 12 cases, including the `..`-literal edge case).

## Why it matters

Second unblocker for the **mzef install pipeline extract phase**. zef builds the `tar -C` target and the staged archive path from `\$archive.relative(\$tmp)` / `\$extract-to.relative(\$cwd)`; the old absolute-path fallback corrupted those, aborting extraction with *"something went wrong extracting …"*.

## Tests

- `t/io-path-relative-abs2rel.t` (new, 12 assertions; passes identically under `raku`).
- `t/native-io-path-cwd.t`: updated the one assertion that encoded the old buggy "non-descendant is unchanged" behavior — raku returns `../../elsewhere/g`.