### PR TITLE
fix: :=-bind of an indexed source in a loop no longer corrupts the prior element

### DIFF
--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -368,6 +368,18 @@ impl Compiler {
             let saved_term = self.bind_terminal;
             self.scalar_bind_autovivify = true;
             self.bind_terminal = true;
+            // Mark the RHS as a direct bind target so an Index source
+            // (`%h{k} := %d<t>`) takes the per-site `__mutsu_bind_index_ref`
+            // wrap in `compile_call_arg` instead of the `is rw` call-arg
+            // writeback temps (`__mutsu_index_rw_arg_N` + SetGlobal). Those
+            // temps are compile-time-fixed globals reused verbatim on every
+            // loop iteration, and their "write through the existing
+            // ContainerRef" semantics corrupt the PREVIOUS iteration's bound
+            // cell (a `for ... { %s{$k} := %d<t> }` loop had the first key's
+            // element track the latest source value). There is no function
+            // call after a bind RHS, so the writeback machinery is never
+            // needed here.
+            self.bind_target_direct = true;
             self.compile_expr(value);
             self.scalar_bind_autovivify = saved_av;
             self.bind_terminal = saved_term;

--- a/t/bind-hash-element-source-in-loop.t
+++ b/t/bind-hash-element-source-in-loop.t
@@ -1,0 +1,30 @@
+use Test;
+
+# `%h{$k} := %d<elem>` — binding a hash/array element TARGET to an indexed
+# SOURCE inside a loop. The RHS index compiled through the `is rw` call-arg
+# writeback temps (`__mutsu_index_rw_arg_N`), which are compile-time-fixed
+# globals reused verbatim on every loop iteration; their "write through the
+# existing ContainerRef" semantics made the first key's bound element track the
+# LATEST source value instead of the one it was bound to. (Template::Mustache's
+# `load-specs` does `%specs{.basename} := %data<tests>` in a loop, so the first
+# spec file got the LAST file's tests and a plan count of 0.)
+
+plan 4;
+
+my %s;
+for 1..5 -> $k {
+    my %d = t => [$k * 10];
+    %s{$k} := %d<t>;
+}
+is-deeply %s{1}<>, [10], "first bound element keeps its own source (hash source)";
+is-deeply %s{5}<>, [50], "last bound element is correct too";
+is %s.elems, 5, "all keys distinct";
+
+# Array-element target, array-element source, loop.
+my @a;
+for 0..3 -> $i {
+    my @d = $i * 100, $i * 100 + 1;
+    @a[$i] := @d[0];
+}
+is-deeply @a[0..3].map(*.self), (0, 100, 200, 300),
+    "first array element keeps its own source";


### PR DESCRIPTION
`%h{\$k} := %d<elem>` — binding a hash/array element **target** to an *indexed* **source** — routed the RHS index through the `is rw` call-argument writeback temps (`__mutsu_index_rw_arg_N` + `SetGlobal` + `pending_index_rw_writebacks`) instead of the per-site `__mutsu_bind_index_ref` wrap. Those temps are compile-time-fixed globals reused verbatim on every loop iteration, and their "write through the existing ContainerRef" writeback mutated the **previous** iteration's bound cell:

```raku
my %s; for 1..5 -> $k { my %d = t => [$k*10]; %s{$k} := %d<t> }
# mutsu (before): 1=[50] 2=[20] 3=[30] 4=[40] 5=[50]   ← key 1 tracks the LAST source
# raku / mutsu (after): 1=[10] 2=[20] 3=[30] 4=[40] 5=[50]
```

`compile_bind_index_value` now sets `bind_target_direct` for the `:=` RHS, so an Index source takes the safe per-site wrap in `compile_call_arg` (the branch already documented there as loop-safe). A bind RHS has no function call after it, so the rw-writeback machinery was never needed.

This is the last blocker for Template::Mustache's `load-specs`, whose `%specs{.basename} := %data<tests>` loop gave the first spec file the **last** file's tests and a plan count of 0 — so `comments.json` ran the lambdas tests and failed "planned 0, ran 10", but only in a full multi-file run (it passed in isolation). With this fix comments/delimiters/inheritable_sections/interpolation/inverted/partials all pass (6/9 spec files).

## Testing
- `t/bind-hash-element-source-in-loop.t` (new; verified identical to raku)
- 133 bind/alias/container + 212 index/hash/array/slice `t/` tests green
- Full `make test` + `make roast` via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)