### PR TITLE
fix: `if/elsif EXPR -> $_` binds a fresh topic, not the given source

### DIFF
--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -134,6 +134,18 @@ impl Compiler {
         // statement-form desugar (`{ my $v = EXPR; if $v { ... } }`) that
         // `compile_do_if_expr_bound` uses. Without this a value-position pointy
         // `if`/`elsif` fell through to a Nil result (its branch value was lost).
+        // A pointy `if EXPR -> $_ { }` binds a FRESH lexical `$_` (like `for -> $_`,
+        // not like `my $_ = EXPR`), so its topic must NOT flow back to an enclosing
+        // `given $x`'s source variable. `EnterPointyTopic` saves + clears
+        // `topic_source_var` for the block; `ExitPointyTopic` (emitted after the if)
+        // restores it and the outer `$_`. Only needed when the binding var is the
+        // topic `$_` — a named pointy (`-> $v`) declares its own lexical.
+        let pointy_topic_scope = binding_var
+            .as_deref()
+            .is_some_and(|v| v.trim_start_matches('$') == "_");
+        if pointy_topic_scope {
+            self.code.emit(OpCode::EnterPointyTopic);
+        }
         if let Some(var_name) = binding_var {
             let bare_name = var_name.trim_start_matches('$').to_string();
             let var_decl = Stmt::VarDecl {
@@ -177,6 +189,9 @@ impl Compiler {
             self.compile_stmts_value(else_branch);
         }
         self.code.patch_jump(jump_end);
+        if pointy_topic_scope {
+            self.code.emit(OpCode::ExitPointyTopic);
+        }
     }
 
     /// Check if a list of statements contains a CATCH or CONTROL block.

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -107,6 +107,16 @@ impl Compiler {
         else_branch: &[Stmt],
         binding_var: &Option<String>,
     ) {
+        // A pointy `if EXPR -> $_ { }` binds a FRESH lexical `$_` (like `for ->
+        // $_`), so its topic must NOT flow back to an enclosing `given $x`'s source
+        // variable. `EnterPointyTopic` saves + clears `topic_source_var` for the
+        // branch; `ExitPointyTopic` (at the end) restores it and the outer `$_`.
+        let pointy_topic_scope = binding_var
+            .as_deref()
+            .is_some_and(|v| v.trim_start_matches('$') == "_");
+        if pointy_topic_scope {
+            self.code.emit(OpCode::EnterPointyTopic);
+        }
         if let Some(var_name) = binding_var {
             let bare_name = var_name.trim_start_matches('$').to_string();
             let var_decl = Stmt::VarDecl {
@@ -150,6 +160,9 @@ impl Compiler {
             self.compile_block_inline(else_branch);
         }
         self.code.patch_jump(jump_end);
+        if pointy_topic_scope {
+            self.code.emit(OpCode::ExitPointyTopic);
+        }
     }
 
     fn compile_collected_loop_body(&mut self, body: &[Stmt]) {

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1581,6 +1581,18 @@ impl Compiler {
                         return;
                     }
                 }
+                // A pointy `if EXPR -> $_ { }` binds a FRESH lexical `$_` (like
+                // `for -> $_`), so its topic must NOT flow back to an enclosing
+                // `given $x`'s source variable. `EnterPointyTopic` saves + clears
+                // `topic_source_var` for the branch; `ExitPointyTopic` (at the end)
+                // restores it and the outer `$_`. Only the topic var `$_` needs it —
+                // a named pointy (`-> $v`) declares its own lexical.
+                let pointy_topic_scope = binding_var
+                    .as_deref()
+                    .is_some_and(|v| v.trim_start_matches('$') == "_");
+                if pointy_topic_scope {
+                    self.code.emit(OpCode::EnterPointyTopic);
+                }
                 if let Some(var_name) = binding_var {
                     // Desugar: if EXPR -> $var { BODY } else { ELSE }
                     // into: { my $var = EXPR; if $var { BODY } else { ELSE } }
@@ -1646,6 +1658,9 @@ impl Compiler {
                         self.compile_body_with_implicit_try(else_branch);
                     }
                     self.code.patch_jump(jump_end);
+                }
+                if pointy_topic_scope {
+                    self.code.emit(OpCode::ExitPointyTopic);
                 }
             }
             Stmt::While { cond, body, label } => {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -300,6 +300,12 @@ pub(crate) enum OpCode {
     SetTopic,
     SaveTopic,
     RestoreTopic,
+    /// Enter a pointy-topic scope (`if COND -> $_`, `with COND -> $_`): save the
+    /// current `$_` and `topic_source_var`, then clear `topic_source_var` so the
+    /// fresh `$_` binding shadows an enclosing `given`'s topic without writing
+    /// back to its source variable. Paired with `ExitPointyTopic`.
+    EnterPointyTopic,
+    ExitPointyTopic,
     GetArrayVar(u32),
     GetHashVar(u32),
     GetBareWord(u32),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1714,6 +1714,12 @@ pub struct Interpreter {
     pub(crate) substitution_in_smartmatch: bool,
     pub(crate) last_topic_value: Option<Value>,
     pub(crate) topic_save_stack: Vec<Value>,
+    /// Saved `$_` + `topic_source_var` for a pointy-topic scope (`if COND -> $_`,
+    /// `with COND -> $_`). The pointy binding introduces a FRESH lexical `$_`
+    /// that shadows an enclosing `given`'s topic, so its writes must NOT flow
+    /// back to the given's source variable — `EnterPointyTopic` saves + clears
+    /// `topic_source_var` for the block, `ExitPointyTopic` restores it.
+    pub(crate) topic_source_save_stack: Vec<(Value, Option<String>)>,
     /// The named container the current topic/loop source came from
     /// (`TagContainerRef`), paired with its compile-time-baked local slot
     /// (§1.5; `None` = non-local or runtime-derived). The slot lets the

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2156,6 +2156,7 @@ impl Interpreter {
             substitution_in_smartmatch: false,
             last_topic_value: None,
             topic_save_stack: Vec::new(),
+            topic_source_save_stack: Vec::new(),
             container_ref_var: None,
             container_ref_reversed: false,
             topic_source_var: None,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -351,6 +351,7 @@ impl Interpreter {
             substitution_in_smartmatch: false,
             last_topic_value: None,
             topic_save_stack: Vec::new(),
+            topic_source_save_stack: Vec::new(),
             container_ref_var: None,
             container_ref_reversed: false,
             topic_source_var: None,

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1633,6 +1633,20 @@ impl Interpreter {
                 }
                 *ip += 1;
             }
+            OpCode::EnterPointyTopic => {
+                let saved_topic = self.env().get("_").cloned().unwrap_or(Value::NIL);
+                let saved_source = self.topic_source_var.take();
+                self.topic_source_save_stack
+                    .push((saved_topic, saved_source));
+                *ip += 1;
+            }
+            OpCode::ExitPointyTopic => {
+                if let Some((saved_topic, saved_source)) = self.topic_source_save_stack.pop() {
+                    self.env_mut().insert("_".to_string(), saved_topic);
+                    self.topic_source_var = saved_source;
+                }
+                *ip += 1;
+            }
 
             // -- Arithmetic --
             OpCode::Add => {

--- a/src/vm/vm_given_when_ops.rs
+++ b/src/vm/vm_given_when_ops.rs
@@ -69,7 +69,20 @@ impl Interpreter {
             self.mark_readonly("_");
         }
 
-        let restore = |this: &mut Self, write_back: bool| {
+        // Depth of the pointy-topic scope stack at body entry. A `when`-succeed (or
+        // other control break) inside a `given`-body `if EXPR -> $_ { ... }` unwinds
+        // past that if's `ExitPointyTopic`, leaving its `(saved $_, saved source)`
+        // on the stack — so `$_` would still hold the pointy value and the given's
+        // element writeback below would flush THAT (not the real topic) back to the
+        // source. Drain any such leftover scopes here, restoring `$_` and
+        // `topic_source_var` to the given's own topic before the writeback reads it.
+        let saved_pointy_depth = self.topic_source_save_stack.len();
+        let restore = move |this: &mut Self, write_back: bool| {
+            while this.topic_source_save_stack.len() > saved_pointy_depth {
+                let (saved_topic, saved_source) = this.topic_source_save_stack.pop().unwrap();
+                this.env_mut().insert("_".to_string(), saved_topic);
+                this.topic_source_var = saved_source;
+            }
             if mark_ro {
                 this.unmark_readonly("_");
             }

--- a/src/vm/vm_jit_support.rs
+++ b/src/vm/vm_jit_support.rs
@@ -129,6 +129,8 @@ pub(super) fn step_supported(op: &OpCode) -> bool {
             | OpCode::SetTopic
             | OpCode::SaveTopic
             | OpCode::RestoreTopic
+            | OpCode::EnterPointyTopic
+            | OpCode::ExitPointyTopic
             | OpCode::PushEnterResult
             | OpCode::LoadEnterResult
             // Always-throwing terminator (records its own resume point)

--- a/t/if-pointy-topic-under-given.t
+++ b/t/if-pointy-topic-under-given.t
@@ -1,0 +1,52 @@
+use Test;
+
+# `if/with EXPR -> $_ { }` binds a FRESH lexical `$_` (like `for -> $_`), so its
+# topic must NOT flow back to an enclosing `given $x`'s source variable. mutsu
+# lowered the pointy to `my $_ = EXPR`, whose write hit the given-topic writeback
+# and clobbered the source (a `given %h<type> { when ... { if COND -> $_ {} } }`
+# overwrote `%h<type>` with COND — Template::Mustache's section handler relies on
+# the hunk's `<type>` surviving `elsif ... $datum -> $_`).
+
+plan 6;
+
+# Scalar given topic.
+my $s = 'keep';
+given $s { if [1, 2] -> $_ { } }
+is $s, 'keep', "if -> \$_ does not clobber a scalar given topic";
+
+# `with` form. (The `with EXPR -> $_` desugar emits `my $_ = tmp` in the branch
+# via a separate parser path that still clobbers — tracked separately.)
+my $t = 'keep2';
+given $t { with [3, 4] -> $_ { } }
+todo 'with EXPR -> $_ desugar still clobbers the given topic';
+is $t, 'keep2', "with -> \$_ does not clobber the given topic";
+
+# Hash-element given topic (the Mustache shape).
+my %h = type => 'section', inverted => False;
+given %h<type> {
+    when 'section' {
+        if !%h<inverted> and [9, 9] -> $_ { }
+    }
+}
+is %h<type>, 'section', "if -> \$_ does not clobber a hash-element given topic";
+
+# elsif chain — the pointy is on a later arm.
+my %g = type => 'section', a => False, b => False, c => True;
+my $val = 'result';
+given %g<type> {
+    when 'section' {
+        $val = do {
+            if %g<a> { 'x' }
+            elsif %g<b> { 'y' }
+            elsif %g<c> -> $_ { 'z' }
+            else { 'w' }
+        };
+    }
+}
+is %g<type>, 'section', "elsif -> \$_ leaves the given topic intact";
+is $val, 'z', "the pointy elsif arm still runs and yields its value";
+
+# The bound `$_` inside the block IS the condition value.
+my $seen;
+given 'topic' { if [7, 8] -> $_ { $seen = $_ } }
+is-deeply $seen, [7, 8], "\$_ inside the pointy block is the condition value";

--- a/t/if-pointy-topic-under-given.t
+++ b/t/if-pointy-topic-under-given.t
@@ -7,7 +7,7 @@ use Test;
 # overwrote `%h<type>` with COND — Template::Mustache's section handler relies on
 # the hunk's `<type>` surviving `elsif ... $datum -> $_`).
 
-plan 6;
+plan 7;
 
 # Scalar given topic.
 my $s = 'keep';
@@ -50,3 +50,20 @@ is $val, 'z', "the pointy elsif arm still runs and yields its value";
 my $seen;
 given 'topic' { if [7, 8] -> $_ { $seen = $_ } }
 is-deeply $seen, [7, 8], "\$_ inside the pointy block is the condition value";
+
+# A `when`-succeed inside the pointy block unwinds past the pointy scope's
+# restore; the enclosing `given`'s element writeback must still flush the given's
+# OWN topic, not the leftover pointy `$_`. (Template::Mustache's nested `{{#.}}`
+# implicit iterator hit this — the shared section hunk's `<type>` was overwritten
+# with the iterated datum.)
+my %w = type => 'section', inverted => False;
+given %w<type> {
+    when 'section' {
+        if !%w<inverted> and [5, 6] -> $_ {
+            when Iterable { 'iter' }
+            default { 'def' }
+        }
+    }
+}
+is %w<type>, 'section',
+    "a when-succeed inside a pointy block leaves the given topic intact";


### PR DESCRIPTION
A pointy conditional (`if EXPR -> $_ { }`, `elsif EXPR -> $_ { }`) binds a **fresh** lexical `$_` to the condition value — exactly like `for -> $_` — so its topic must NOT flow back to an enclosing `given $x`'s source variable. mutsu lowered the pointy to `my $_ = EXPR`, whose store hit the `$_`→source writeback (`topic_source_var`) and clobbered the given's source:

```raku
my $s = 'keep';
given $s { if [1,2] -> $_ { } }
say $s;   # mutsu (before): "1 2"   raku / mutsu (after): "keep"
```

New zero-payload `EnterPointyTopic` / `ExitPointyTopic` opcodes save + clear `topic_source_var` (and `$_`) for the pointy branch and restore them after, so the fresh binding shadows the enclosing topic without writeback. Emitted in all three pointy-`if` lowerings (statement `Stmt::If`, value `compile_if_value`, tail/do-expr `compile_do_if_expr_bound`). `size_of::<OpCode>()` is unchanged (guard test green).

This is why Template::Mustache's section handler lost the hunk's `<type>` across `elsif !%val<inverted> and $datum -> $_` — the shared hunk hash had `<type>` overwritten with the section datum on the first iteration.

## Testing
- `t/if-pointy-topic-under-given.t` (new; verified against raku). The `with EXPR -> $_` desugar (a separate parser path emitting `my $_ = tmp`) still clobbers and is marked `todo` there — tracked as follow-up.
- 67 given/when/topic + 23 control-flow `t/` tests green
- Full `make test` + `make roast` via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)