### PR TITLE
fix: closure in a map/grep block keeps lexical capture of an outer free var

### DIFF
--- a/src/runtime/methods_classhow_attribute.rs
+++ b/src/runtime/methods_classhow_attribute.rs
@@ -202,6 +202,7 @@ impl Interpreter {
                     source_line: None,
                     source_file: None,
                     owned_captures: Vec::new(),
+                    authoritative_captures: Vec::new(),
                     upvalues: Vec::new(),
                 };
                 meta.insert(

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -283,6 +283,20 @@ impl Interpreter {
         for ((attr_name, _is_public, default, _is_rw, _, sigil, _), &attr_sym) in
             plan.class_attrs.iter().zip(plan.attr_syms.iter())
         {
+            // A `@`/`%` attribute with no declared default that a bless named
+            // argument provides would get an empty container here only for the
+            // override loop below to immediately replace it — skip the throwaway
+            // allocation (and the GC-candidate churn its drop incurs). The args
+            // scan is cheap (bless calls carry few named args) relative to a
+            // HashData/ArrayData allocation per unfilled construction.
+            if default.is_none()
+                && (*sigil == '@' || *sigil == '%')
+                && args
+                    .iter()
+                    .any(|a| matches!(a.view(), ValueView::Pair(k, _) if k == attr_name))
+            {
+                continue;
+            }
             let val = if let Some(Expr::Literal(lit_val)) = default {
                 // Fast path: simple literal defaults (e.g. native type
                 // defaults like Int(0)) don't need interpretation.

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -73,6 +73,7 @@ impl Interpreter {
                 source_line: None,
                 source_file: None,
                 owned_captures: Vec::new(),
+                authoritative_captures: Vec::new(),
                 upvalues: Vec::new(),
             };
             // Store the routine name so call_sub_value can dispatch

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1709,6 +1709,15 @@ pub struct Interpreter {
     /// alongside `locals`. A `None` entry (or out-of-range index) makes
     /// `GetUpvalue` fall back to a by-name env read. Empty for non-closure frames.
     pub(crate) upvalues: Vec<Option<Value>>,
+    /// Free-var names the currently-running frame vouches for (its own
+    /// `authoritative_free_vars` plus any inherited via `owned_captures`). A
+    /// closure created in this frame inherits authoritative (overwrite) capture
+    /// for any of its free vars listed here — the runtime counterpart of the
+    /// compile-time `propagate_authoritative_down`, which does not reach a closure
+    /// created inside a `.map`/`.grep`-invoked block (its runtime CompiledCode is
+    /// a different copy than the one the compile-time propagation mutates). Set on
+    /// closure entry, saved/restored across call frames like `upvalues`.
+    pub(crate) frame_authoritative: Vec<crate::symbol::Symbol>,
     pub(crate) in_smartmatch_rhs: bool,
     pub(crate) transliterate_in_smartmatch: bool,
     pub(crate) substitution_in_smartmatch: bool,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2416,6 +2416,7 @@ mod tests {
             source_line: None,
             source_file: None,
             owned_captures: Vec::new(),
+            authoritative_captures: Vec::new(),
             upvalues: Vec::new(),
         });
 

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -418,6 +418,7 @@ impl Interpreter {
                 source_line: data.source_line,
                 source_file: data.source_file.clone(),
                 owned_captures: data.owned_captures.clone(),
+                authoritative_captures: data.authoritative_captures.clone(),
                 upvalues: data.upvalues.clone(),
             });
             new_env.insert(
@@ -482,7 +483,7 @@ impl Interpreter {
                     .map(|cc| {
                         super::resolution_map_grep::frame_authoritative_set(
                             cc,
-                            &data.owned_captures,
+                            &data.authoritative_captures,
                         )
                     })
                     .unwrap_or_default(),

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -466,7 +466,30 @@ impl Interpreter {
             // assigned it) would clobber the caller's live value on return.
             // Env is copy-on-write, so this clone is O(1) until the body forks it.
             let body_entry_env = self.env.clone();
-            let result = match self.eval_block_value(&data.body) {
+            // Runtime transitive vouching (see `Interpreter::frame_authoritative`):
+            // record the free-var names this block vouches for (its own
+            // `authoritative_free_vars` plus any inherited via `owned_captures`) so
+            // a closure created inside its body inherits authoritative (overwrite)
+            // capture. This is the interpreter-path (`.map`/`.grep` block) twin of
+            // the VM's `call_compiled_closure_with_topic` set; restored right after
+            // the body runs. Without it a closure created inside a map/grep block
+            // loses lexical capture of an outer free var when the block is invoked
+            // through a callee that has a same-named parameter.
+            let saved_frame_auth = std::mem::replace(
+                &mut self.frame_authoritative,
+                data.compiled_code
+                    .as_ref()
+                    .map(|cc| {
+                        super::resolution_map_grep::frame_authoritative_set(
+                            cc,
+                            &data.owned_captures,
+                        )
+                    })
+                    .unwrap_or_default(),
+            );
+            let body_result = self.eval_block_value(&data.body);
+            self.frame_authoritative = saved_frame_auth;
+            let result = match body_result {
                 Err(mut e) if e.is_leave => {
                     let routine_key = format!("{}::{}", data.package, data.name);
                     let matches_frame = if let Some(target_id) = e.leave_callable_id() {

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -1,5 +1,47 @@
 use super::*;
 
+/// The free-var names a map/grep block vouches for, so a closure created inside
+/// its body inherits authoritative (overwrite) capture (runtime transitive
+/// vouching — see `Interpreter::frame_authoritative`). Taken from the block's
+/// ORIGINAL compiled code: the inline map/grep fast paths re-compile the body,
+/// and that fresh copy lacks the enclosing frame's compile-time
+/// `propagate_authoritative_down`. Set on `vm.frame_authoritative` before running
+/// each iteration so a nested closure passed to a callee with a same-named
+/// parameter does not lose lexical capture of an outer free var.
+pub(super) fn block_frame_authoritative(
+    compiled_code: &Option<std::sync::Arc<CompiledCode>>,
+    owned_captures: &[crate::symbol::Symbol],
+) -> Vec<crate::symbol::Symbol> {
+    let Some(cc) = compiled_code.as_ref() else {
+        return Vec::new();
+    };
+    frame_authoritative_set(cc, owned_captures)
+}
+
+/// The set a frame vouches for so nested closures inherit authoritative
+/// (overwrite) capture: the block's own `authoritative_free_vars` plus the
+/// inherited-authoritative names carried in `owned_captures`, but NOT any free var
+/// this frame's subtree WRITES (`free_var_writes` / `free_var_container_writes`).
+/// Excluding written names is critical: `owned_captures` also holds per-iteration
+/// loop captures, and a loop var mutated concurrently (`for ^N { start { $c += 1 } }`)
+/// must stay a shared cell — overwrite-installing a frozen snapshot into each
+/// thread's frame loses updates (t/concurrent-compound-assign.t). A vouched
+/// (never-written) name is safe to overwrite; a written one must keep tracking the
+/// live cell. (`authoritative_free_vars` is already write-free by construction;
+/// only the added `owned_captures` need filtering.)
+pub(crate) fn frame_authoritative_set(
+    cc: &CompiledCode,
+    owned_captures: &[crate::symbol::Symbol],
+) -> Vec<crate::symbol::Symbol> {
+    let mut fa = cc.authoritative_free_vars.clone();
+    fa.extend(
+        owned_captures.iter().copied().filter(|s| {
+            !cc.free_var_writes.contains(s) && !cc.free_var_container_writes.contains(s)
+        }),
+    );
+    fa
+}
+
 /// Convert a `CallArg` to an `Expr` for expression-level call compilation,
 /// preserving named (`k => v`) and slip (`|v`) args. Mirrors the compiler's
 /// `call_args_to_expr_args`.
@@ -317,12 +359,16 @@ impl Interpreter {
             // loop's Result; `with_nested_registers` restores the outer registers
             // and flags env_dirty. The temporary-binding env restore (`saved`) is
             // hoisted to after the call — it ran on every old exit path.
+            // Runtime transitive vouching: see `block_frame_authoritative`.
+            let block_authoritative =
+                block_frame_authoritative(&data.compiled_code, &data.owned_captures);
             let loop_result: Result<Value, RuntimeError> = self.with_nested_registers(|vm| {
                 let mut i = 0usize;
                 while i < list_items.len() {
                     if arity > 1 && i + arity > list_items.len() {
                         return Err(RuntimeError::new("Not enough elements for map block arity"));
                     }
+                    vm.frame_authoritative = block_authoritative.clone();
                     {
                         let assumed_count = data.assumed_positional.len();
                         // Bind assumed positional args first

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -1,44 +1,22 @@
 use super::*;
 
-/// The free-var names a map/grep block vouches for, so a closure created inside
-/// its body inherits authoritative (overwrite) capture (runtime transitive
-/// vouching — see `Interpreter::frame_authoritative`). Taken from the block's
-/// ORIGINAL compiled code: the inline map/grep fast paths re-compile the body,
-/// and that fresh copy lacks the enclosing frame's compile-time
-/// `propagate_authoritative_down`. Set on `vm.frame_authoritative` before running
-/// each iteration so a nested closure passed to a callee with a same-named
-/// parameter does not lose lexical capture of an outer free var.
-pub(super) fn block_frame_authoritative(
-    compiled_code: &Option<std::sync::Arc<CompiledCode>>,
-    owned_captures: &[crate::symbol::Symbol],
-) -> Vec<crate::symbol::Symbol> {
-    let Some(cc) = compiled_code.as_ref() else {
-        return Vec::new();
-    };
-    frame_authoritative_set(cc, owned_captures)
-}
-
-/// The set a frame vouches for so nested closures inherit authoritative
-/// (overwrite) capture: the block's own `authoritative_free_vars` plus the
-/// inherited-authoritative names carried in `owned_captures`, but NOT any free var
-/// this frame's subtree WRITES (`free_var_writes` / `free_var_container_writes`).
-/// Excluding written names is critical: `owned_captures` also holds per-iteration
-/// loop captures, and a loop var mutated concurrently (`for ^N { start { $c += 1 } }`)
-/// must stay a shared cell — overwrite-installing a frozen snapshot into each
-/// thread's frame loses updates (t/concurrent-compound-assign.t). A vouched
-/// (never-written) name is safe to overwrite; a written one must keep tracking the
-/// live cell. (`authoritative_free_vars` is already write-free by construction;
-/// only the added `owned_captures` need filtering.)
+/// The set a frame vouches for so a closure created inside it inherits
+/// authoritative (overwrite) capture (runtime transitive vouching — see
+/// `Interpreter::frame_authoritative`): the block's own `authoritative_free_vars`
+/// plus the inherited-authoritative names it carries in `authoritative_captures`.
+/// Both are never-written by construction, so propagating them is always sound —
+/// unlike loop `owned_captures`, which may be concurrently-mutated shared cells
+/// and are deliberately NOT included (a reader thread would freeze a stale
+/// snapshot — `roast/S17-lowlevel/lock.t`'s condition-variable busy-wait). Set on
+/// `vm.frame_authoritative` before each inline map/grep iteration; the inline fast
+/// path re-compiles the block body, so the fresh copy would otherwise lack the
+/// enclosing frame's compile-time `propagate_authoritative_down`.
 pub(crate) fn frame_authoritative_set(
     cc: &CompiledCode,
-    owned_captures: &[crate::symbol::Symbol],
+    authoritative_captures: &[crate::symbol::Symbol],
 ) -> Vec<crate::symbol::Symbol> {
     let mut fa = cc.authoritative_free_vars.clone();
-    fa.extend(
-        owned_captures.iter().copied().filter(|s| {
-            !cc.free_var_writes.contains(s) && !cc.free_var_container_writes.contains(s)
-        }),
-    );
+    fa.extend(authoritative_captures.iter().copied());
     fa
 }
 
@@ -359,9 +337,12 @@ impl Interpreter {
             // loop's Result; `with_nested_registers` restores the outer registers
             // and flags env_dirty. The temporary-binding env restore (`saved`) is
             // hoisted to after the call — it ran on every old exit path.
-            // Runtime transitive vouching: see `block_frame_authoritative`.
-            let block_authoritative =
-                block_frame_authoritative(&data.compiled_code, &data.owned_captures);
+            // Runtime transitive vouching: see `frame_authoritative_set`.
+            let block_authoritative = data
+                .compiled_code
+                .as_ref()
+                .map(|cc| frame_authoritative_set(cc, &data.authoritative_captures))
+                .unwrap_or_default();
             let loop_result: Result<Value, RuntimeError> = self.with_nested_registers(|vm| {
                 let mut i = 0usize;
                 while i < list_items.len() {

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -145,12 +145,18 @@ impl Interpreter {
             // returns the loop's Result; `with_nested_registers` restores the
             // outer registers and flags env_dirty. The `saved`/`topic_key` env
             // restore is hoisted to after the call (ran on every old exit).
+            // Runtime transitive vouching: see `block_frame_authoritative`.
+            let block_authoritative = super::resolution_map_grep::block_frame_authoritative(
+                &data.compiled_code,
+                &data.owned_captures,
+            );
             let loop_result: Result<Value, RuntimeError> = self.with_nested_registers(|vm| {
                 let mut i = 0usize;
                 while i < list_items.len() {
                     if arity > 1 && i + arity > list_items.len() {
                         return Err(RuntimeError::new("Not enough elements for map block arity"));
                     }
+                    vm.frame_authoritative = block_authoritative.clone();
                     {
                         let assumed_count = data.assumed_positional.len();
                         for (idx, val) in data.assumed_positional.iter().enumerate() {
@@ -354,6 +360,11 @@ impl Interpreter {
             // returns Ok(()) / Err on the loop; `with_nested_registers` restores
             // the outer registers and flags env_dirty. The `saved` env restore is
             // hoisted to after the call (ran on every old exit path).
+            // Runtime transitive vouching: see `block_frame_authoritative`.
+            let block_authoritative = super::resolution_map_grep::block_frame_authoritative(
+                &data.compiled_code,
+                &data.owned_captures,
+            );
             let loop_result: Result<(), RuntimeError> = self.with_nested_registers(|vm| {
                 let mut i = 0usize;
                 let mut stop = false;
@@ -367,6 +378,7 @@ impl Interpreter {
                         list_items[i..i + arity].to_vec()
                     };
                     'body_redo: loop {
+                        vm.frame_authoritative = block_authoritative.clone();
                         {
                             let assumed_count = data.assumed_positional.len();
                             for (idx, val) in data.assumed_positional.iter().enumerate() {

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -145,11 +145,17 @@ impl Interpreter {
             // returns the loop's Result; `with_nested_registers` restores the
             // outer registers and flags env_dirty. The `saved`/`topic_key` env
             // restore is hoisted to after the call (ran on every old exit).
-            // Runtime transitive vouching: see `block_frame_authoritative`.
-            let block_authoritative = super::resolution_map_grep::block_frame_authoritative(
-                &data.compiled_code,
-                &data.owned_captures,
-            );
+            // Runtime transitive vouching: see `frame_authoritative_set`.
+            let block_authoritative = data
+                .compiled_code
+                .as_ref()
+                .map(|cc| {
+                    super::resolution_map_grep::frame_authoritative_set(
+                        cc,
+                        &data.authoritative_captures,
+                    )
+                })
+                .unwrap_or_default();
             let loop_result: Result<Value, RuntimeError> = self.with_nested_registers(|vm| {
                 let mut i = 0usize;
                 while i < list_items.len() {
@@ -360,11 +366,17 @@ impl Interpreter {
             // returns Ok(()) / Err on the loop; `with_nested_registers` restores
             // the outer registers and flags env_dirty. The `saved` env restore is
             // hoisted to after the call (ran on every old exit path).
-            // Runtime transitive vouching: see `block_frame_authoritative`.
-            let block_authoritative = super::resolution_map_grep::block_frame_authoritative(
-                &data.compiled_code,
-                &data.owned_captures,
-            );
+            // Runtime transitive vouching: see `frame_authoritative_set`.
+            let block_authoritative = data
+                .compiled_code
+                .as_ref()
+                .map(|cc| {
+                    super::resolution_map_grep::frame_authoritative_set(
+                        cc,
+                        &data.authoritative_captures,
+                    )
+                })
+                .unwrap_or_default();
             let loop_result: Result<(), RuntimeError> = self.with_nested_registers(|vm| {
                 let mut i = 0usize;
                 let mut stop = false;

--- a/src/runtime/run_main.rs
+++ b/src/runtime/run_main.rs
@@ -218,6 +218,7 @@ impl Interpreter {
             source_line: None,
             source_file: None,
             owned_captures: Vec::new(),
+            authoritative_captures: Vec::new(),
             upvalues: Vec::new(),
         }))
     }

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2151,6 +2151,7 @@ impl Interpreter {
             stack: Vec::new(),
             locals: Vec::new(),
             upvalues: Vec::new(),
+            frame_authoritative: Vec::new(),
             in_smartmatch_rhs: false,
             transliterate_in_smartmatch: false,
             substitution_in_smartmatch: false,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -346,6 +346,7 @@ impl Interpreter {
             stack: Vec::new(),
             locals: Vec::new(),
             upvalues: Vec::new(),
+            frame_authoritative: Vec::new(),
             in_smartmatch_rhs: false,
             transliterate_in_smartmatch: false,
             substitution_in_smartmatch: false,

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -662,6 +662,17 @@ pub struct SubData {
     /// the shared lexical name — Raku's per-iteration closure capture. Empty for
     /// non-loop closures and named subs.
     pub(crate) owned_captures: Vec<Symbol>,
+    /// Free variables this closure captures that the CREATING frame vouched for
+    /// (its `frame_authoritative` set): a never-written, lexically-authoritative
+    /// value. Like `owned_captures` they are installed with overwrite semantics at
+    /// call time (a same-named caller lexical must not shadow them), and they also
+    /// re-seed this frame's `frame_authoritative` so the vouch cascades to deeper
+    /// closures — the runtime counterpart of the compile-time
+    /// `propagate_authoritative_down`, which does not reach a closure the inline
+    /// `.map`/`.grep` fast path re-compiles. Kept SEPARATE from `owned_captures`
+    /// because loop captures may be concurrently mutated (shared cells) and must
+    /// NOT be propagated as authoritative — only these never-written names are.
+    pub(crate) authoritative_captures: Vec<Symbol>,
     /// Captured upvalue array, aligned with `compiled_code.upvalue_syms`. Built at
     /// closure-creation time (after `box_captured_lexicals`). An entry is
     /// `Some(cell)` only when the captured lexical is a shared `ContainerRef` cell

--- a/src/value/nanbox/tests.rs
+++ b/src/value/nanbox/tests.rs
@@ -228,6 +228,7 @@ fn sample_sub() -> Gc<SubData> {
         source_line: None,
         source_file: None,
         owned_captures: vec![],
+        authoritative_captures: vec![],
         upvalues: vec![],
     })
 }

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -668,6 +668,7 @@ mod tests {
             source_line: None,
             source_file: None,
             owned_captures: Vec::new(),
+            authoritative_captures: Vec::new(),
             upvalues: Vec::new(),
         }
     }

--- a/src/value/value_methods_b.rs
+++ b/src/value/value_methods_b.rs
@@ -344,6 +344,7 @@ impl Value {
             source_line: None,
             source_file: None,
             owned_captures: Vec::new(),
+            authoritative_captures: Vec::new(),
             upvalues: Vec::new(),
         }))
     }
@@ -379,6 +380,7 @@ impl Value {
             source_line: None,
             source_file: None,
             owned_captures: Vec::new(),
+            authoritative_captures: Vec::new(),
             upvalues: Vec::new(),
         }))
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -314,6 +314,11 @@ pub(crate) struct VmCallFrame {
     /// and get reverted at the caller's block exit — clobbering a same-named
     /// caller variable across a recursive call.
     pub saved_block_declared_vars: Vec<crate::runtime::NameSet>,
+    /// The caller frame's `frame_authoritative` set — the free-var names this
+    /// frame vouches for so a closure created inside it inherits authoritative
+    /// (overwrite) capture semantics (runtime transitive vouching). Saved here so
+    /// a nested call restores it, mirroring `saved_upvalues`.
+    pub saved_frame_authoritative: Vec<crate::symbol::Symbol>,
 }
 
 // CP-3 collapse: the bytecode Interpreter has been fully dissolved into the `Interpreter`

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -508,6 +508,15 @@ impl Interpreter {
         // it.) Out-of-range `GetUpvalue` indices fall back to env by name, so a
         // mismatched/empty array is always safe.
         self.upvalues = data.upvalues.clone();
+        // Runtime transitive vouching: record the free-var names this frame
+        // vouches for so a closure created inside its body inherits authoritative
+        // (overwrite) capture (see `Interpreter::frame_authoritative` and
+        // `frame_authoritative_set`), letting the vouch cascade arbitrarily deep —
+        // the compile-time `propagate_authoritative_down` does not reach a closure
+        // created inside a `.map`/`.grep`-invoked block. (`push_call_frame` saved
+        // the caller's set; `pop_call_frame` restores it.)
+        self.frame_authoritative =
+            crate::runtime::resolution_map_grep::frame_authoritative_set(cc, &data.owned_captures);
         // Load persisted state variable values using scoped keys
         // (state_scope_id is set to data.id above, so scoped_state_key
         // will generate closure-instance-specific keys automatically).

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -260,6 +260,16 @@ impl Interpreter {
                 self.env_mut().insert_sym(*sym, val);
             }
         }
+        // Runtime transitive vouching (see `SubData::authoritative_captures` and
+        // `Interpreter::frame_authoritative`): free vars this closure inherited as
+        // authoritative from its creating frame. Same overwrite-install as
+        // `authoritative_free_vars` above — a never-written, lexically-authoritative
+        // value that a same-named caller lexical must not shadow.
+        for sym in &data.authoritative_captures {
+            if let Some(val) = data.env.get_sym(*sym).cloned() {
+                self.env_mut().insert_sym(*sym, val);
+            }
+        }
         // Per-iteration loop captures (Raku fresh-binding semantics): these free
         // variables were declared in an enclosing loop body when this closure was
         // created, so each iteration's closure froze a distinct value in its
@@ -334,6 +344,7 @@ impl Interpreter {
             source_line: data.source_line,
             source_file: data.source_file.clone(),
             owned_captures: data.owned_captures.clone(),
+            authoritative_captures: data.authoritative_captures.clone(),
             upvalues: data.upvalues.clone(),
         });
         self.env_mut().insert(
@@ -515,8 +526,10 @@ impl Interpreter {
         // the compile-time `propagate_authoritative_down` does not reach a closure
         // created inside a `.map`/`.grep`-invoked block. (`push_call_frame` saved
         // the caller's set; `pop_call_frame` restores it.)
-        self.frame_authoritative =
-            crate::runtime::resolution_map_grep::frame_authoritative_set(cc, &data.owned_captures);
+        self.frame_authoritative = crate::runtime::resolution_map_grep::frame_authoritative_set(
+            cc,
+            &data.authoritative_captures,
+        );
         // Load persisted state variable values using scoped keys
         // (state_scope_id is set to data.id above, so scoped_state_key
         // will generate closure-instance-specific keys automatically).

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -59,6 +59,7 @@ impl Interpreter {
             saved_loop_local_vars: std::mem::take(&mut self.loop_local_vars),
             saved_loop_local_saved_env: std::mem::take(&mut self.loop_local_saved_env),
             saved_block_declared_vars: std::mem::take(&mut self.block_declared_vars),
+            saved_frame_authoritative: std::mem::take(&mut self.frame_authoritative),
         };
         self.call_frames.push(frame);
     }
@@ -82,6 +83,7 @@ impl Interpreter {
             saved_loop_local_vars: std::mem::take(&mut self.loop_local_vars),
             saved_loop_local_saved_env: std::mem::take(&mut self.loop_local_saved_env),
             saved_block_declared_vars: std::mem::take(&mut self.block_declared_vars),
+            saved_frame_authoritative: std::mem::take(&mut self.frame_authoritative),
         };
         self.call_frames.push(frame);
     }
@@ -103,6 +105,7 @@ impl Interpreter {
         self.loop_local_vars = std::mem::take(&mut frame.saved_loop_local_vars);
         self.loop_local_saved_env = std::mem::take(&mut frame.saved_loop_local_saved_env);
         self.block_declared_vars = std::mem::take(&mut frame.saved_block_declared_vars);
+        self.frame_authoritative = std::mem::take(&mut frame.saved_frame_authoritative);
         self.exit_readonly_frame(frame.readonly_mark);
         frame
     }

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -312,17 +312,40 @@ impl Interpreter {
         &self,
         compiled_code: &Option<std::sync::Arc<CompiledCode>>,
     ) -> Vec<Symbol> {
-        if self.loop_local_vars.is_empty() {
-            return Vec::new();
-        }
         let Some(cc) = compiled_code else {
             return Vec::new();
         };
-        cc.free_var_syms
-            .iter()
-            .filter(|sym| self.loop_local_vars.iter().any(|set| set.contains(*sym)))
-            .copied()
-            .collect()
+        let mut result: Vec<Symbol> = Vec::new();
+        // Per-iteration loop captures (Raku fresh-binding): a free var declared in
+        // an enclosing loop body froze a distinct value per iteration.
+        if !self.loop_local_vars.is_empty() {
+            result.extend(
+                cc.free_var_syms
+                    .iter()
+                    .filter(|sym| self.loop_local_vars.iter().any(|set| set.contains(*sym)))
+                    .copied(),
+            );
+        }
+        // Runtime transitive vouching: a free var this closure captures that the
+        // CREATING frame vouches for (`frame_authoritative`) carries the same
+        // frozen, never-mutated value here, so install it with overwrite semantics
+        // at call time — a same-named lexical in an eventual caller frame must not
+        // shadow it (lexical scoping, not dynamic). This is the runtime counterpart
+        // of the compile-time `propagate_authoritative_down`, which does not reach a
+        // closure created inside a `.map`/`.grep`-invoked block: that block's
+        // runtime CompiledCode is a distinct copy from the one the compile-time
+        // pass mutates, so the propagated `authoritative_free_vars` never arrives.
+        // Reusing `owned_captures` is sound here because the value is a vouched
+        // non-`ContainerRef` scalar — `freeze_readonly_owned_captures` skips it
+        // (it only freezes `ContainerRef` cells), leaving just the overwrite install.
+        if !self.frame_authoritative.is_empty() {
+            for sym in &cc.free_var_syms {
+                if self.frame_authoritative.contains(sym) && !result.contains(sym) {
+                    result.push(*sym);
+                }
+            }
+        }
+        result
     }
 
     /// Capture the closure's environment as an *upvalue snapshot* (single-store

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -127,6 +127,7 @@ impl Interpreter {
             let compiled_code = Self::resolve_closure_code(code, cc_idx);
             self.box_captured_lexicals(code, &compiled_code);
             let owned_captures = self.compute_owned_captures(&compiled_code);
+            let authoritative_captures = self.compute_authoritative_captures(&compiled_code);
             let mut upvalues = self.capture_upvalues(code, &compiled_code);
             let mut captured_env = self.capture_closure_env(code, &compiled_code);
             self.freeze_readonly_owned_captures(
@@ -158,6 +159,7 @@ impl Interpreter {
                 empty_sig: false,
                 is_bare_block: is_block,
                 owned_captures,
+                authoritative_captures,
                 upvalues,
                 compiled_code,
                 deprecated_message: None,
@@ -192,6 +194,7 @@ impl Interpreter {
             let compiled_code = Self::resolve_closure_code(code, cc_idx);
             self.box_captured_lexicals(code, &compiled_code);
             let owned_captures = self.compute_owned_captures(&compiled_code);
+            let authoritative_captures = self.compute_authoritative_captures(&compiled_code);
             let mut upvalues = self.capture_upvalues(code, &compiled_code);
             // Upvalue snapshot (single-store Slice E); see `capture_closure_env`.
             let mut env = self.capture_closure_env(code, &compiled_code);
@@ -234,6 +237,7 @@ impl Interpreter {
                 // stay `Sub`. (`WhateverCode` already overrides via callable_type.)
                 is_bare_block: compiled_code.as_ref().is_some_and(|cc| cc.is_pointy_block),
                 owned_captures,
+                authoritative_captures,
                 upvalues,
                 compiled_code,
                 deprecated_message: None,
@@ -312,40 +316,47 @@ impl Interpreter {
         &self,
         compiled_code: &Option<std::sync::Arc<CompiledCode>>,
     ) -> Vec<Symbol> {
+        if self.loop_local_vars.is_empty() {
+            return Vec::new();
+        }
         let Some(cc) = compiled_code else {
             return Vec::new();
         };
-        let mut result: Vec<Symbol> = Vec::new();
         // Per-iteration loop captures (Raku fresh-binding): a free var declared in
         // an enclosing loop body froze a distinct value per iteration.
-        if !self.loop_local_vars.is_empty() {
-            result.extend(
-                cc.free_var_syms
-                    .iter()
-                    .filter(|sym| self.loop_local_vars.iter().any(|set| set.contains(*sym)))
-                    .copied(),
-            );
+        cc.free_var_syms
+            .iter()
+            .filter(|sym| self.loop_local_vars.iter().any(|set| set.contains(*sym)))
+            .copied()
+            .collect()
+    }
+
+    /// Free vars this closure captures that the CREATING frame vouches for
+    /// (`frame_authoritative`) — a never-written, lexically-authoritative value.
+    /// Stored in `SubData::authoritative_captures`, installed with overwrite at
+    /// call time, and re-seeded into the callee's `frame_authoritative` so the
+    /// vouch cascades to deeper closures. This is the runtime counterpart of the
+    /// compile-time `propagate_authoritative_down`, which does not reach a closure
+    /// the inline `.map`/`.grep` fast path re-compiles (its runtime CompiledCode is
+    /// a distinct copy from the one the compile-time pass mutates). Kept separate
+    /// from loop `owned_captures`, which may be concurrently-mutated shared cells
+    /// and must NOT be propagated as authoritative (a reader thread would freeze a
+    /// stale snapshot — `roast/S17-lowlevel/lock.t`'s condition-variable busy-wait).
+    pub(super) fn compute_authoritative_captures(
+        &self,
+        compiled_code: &Option<std::sync::Arc<CompiledCode>>,
+    ) -> Vec<Symbol> {
+        if self.frame_authoritative.is_empty() {
+            return Vec::new();
         }
-        // Runtime transitive vouching: a free var this closure captures that the
-        // CREATING frame vouches for (`frame_authoritative`) carries the same
-        // frozen, never-mutated value here, so install it with overwrite semantics
-        // at call time — a same-named lexical in an eventual caller frame must not
-        // shadow it (lexical scoping, not dynamic). This is the runtime counterpart
-        // of the compile-time `propagate_authoritative_down`, which does not reach a
-        // closure created inside a `.map`/`.grep`-invoked block: that block's
-        // runtime CompiledCode is a distinct copy from the one the compile-time
-        // pass mutates, so the propagated `authoritative_free_vars` never arrives.
-        // Reusing `owned_captures` is sound here because the value is a vouched
-        // non-`ContainerRef` scalar — `freeze_readonly_owned_captures` skips it
-        // (it only freezes `ContainerRef` cells), leaving just the overwrite install.
-        if !self.frame_authoritative.is_empty() {
-            for sym in &cc.free_var_syms {
-                if self.frame_authoritative.contains(sym) && !result.contains(sym) {
-                    result.push(*sym);
-                }
-            }
-        }
-        result
+        let Some(cc) = compiled_code else {
+            return Vec::new();
+        };
+        cc.free_var_syms
+            .iter()
+            .filter(|sym| self.frame_authoritative.contains(sym))
+            .copied()
+            .collect()
     }
 
     /// Capture the closure's environment as an *upvalue snapshot* (single-store

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -24,6 +24,7 @@ impl Interpreter {
             let compiled_code = Self::resolve_closure_code(code, cc_idx);
             self.box_captured_lexicals(code, &compiled_code);
             let owned_captures = self.compute_owned_captures(&compiled_code);
+            let authoritative_captures = self.compute_authoritative_captures(&compiled_code);
             let upvalues = self.capture_upvalues(code, &compiled_code);
             // Upvalue snapshot (single-store Slice E); see `capture_closure_env`.
             let mut env = self.capture_closure_env(code, &compiled_code);
@@ -59,6 +60,7 @@ impl Interpreter {
                 // (`sub {...}`) have `is_pointy_block == false` and stay `Sub`.
                 is_bare_block: compiled_code.as_ref().is_some_and(|cc| cc.is_pointy_block),
                 owned_captures,
+                authoritative_captures,
                 upvalues,
                 compiled_code,
                 deprecated_message: None,
@@ -83,6 +85,7 @@ impl Interpreter {
             let compiled_code = Self::resolve_closure_code(code, cc_idx);
             self.box_captured_lexicals(code, &compiled_code);
             let owned_captures = self.compute_owned_captures(&compiled_code);
+            let authoritative_captures = self.compute_authoritative_captures(&compiled_code);
             let upvalues = self.capture_upvalues(code, &compiled_code);
             let cc_source_line = compiled_code
                 .as_ref()
@@ -105,6 +108,7 @@ impl Interpreter {
                 empty_sig: false,
                 is_bare_block: true,
                 owned_captures,
+                authoritative_captures,
                 upvalues,
                 compiled_code,
                 deprecated_message: None,

--- a/t/closure-map-block-free-var-capture.t
+++ b/t/closure-map-block-free-var-capture.t
@@ -1,0 +1,57 @@
+use Test;
+
+# A closure created inside a `.map`/`.grep` block must keep *lexical* capture of
+# an outer free variable even when the closure is later invoked through a callee
+# that happens to have a same-named parameter. Previously the closure's free var
+# degraded to dynamic scoping and resolved to the callee's parameter, because the
+# inline map/grep fast path re-compiles the block body and the fresh copy lost
+# the compile-time transitive "authoritative free var" propagation. This is
+# exactly what zef's install pipeline hits: `Zef::Extract.extract` maps over
+# backends and, inside `lock-file-protect(IO() $path, &code)` (whose parameter is
+# named `$path`), runs `start { $extractor.extract($path, ...) }` where `$path`
+# is the archive captured from the enclosing method — the leak made tar try to
+# extract the `.lock` file.
+
+plan 8;
+
+sub callee($path, &code) { code() }
+
+# --- map, one level of nesting ---
+sub map1($path) { <A B>.map(-> $b { callee("$path.lock", -> { "$b:$path" }) }) }
+is-deeply map1("REAL").Array, ["A:REAL", "B:REAL"], 'map block closure keeps outer $path (vs callee $path)';
+
+# --- grep uses the same capture path ---
+sub grep1($path) { (1, 2, 3).grep(-> $b { callee("X", -> { $path eq "REAL" }) }) }
+is-deeply grep1("REAL").Array, [1, 2, 3], 'grep block closure keeps outer $path';
+
+# --- List source (interpreter map path, not the native-array fast path) ---
+is-deeply (1, 2).map(-> $b { callee("$_.lock", -> { "$b" }) }).Array,
+    ["1", "2"], 'List.map inner closure runs (no leak)';
+
+# --- deep cascade: map -> inner block -> start {} thread, 3 levels ---
+sub deep($path) {
+    <A B>.map(-> $b {
+        callee("$path.lock", -> {
+            my $todo = start { "$b:$path" };
+            await $todo;
+            $todo.result;
+        });
+    });
+}
+is-deeply deep("REAL").Array, ["A:REAL", "B:REAL"], 'cascade through inner block + start keeps $path';
+
+# --- the non-map paths were always correct; guard them ---
+sub direct($path) { my &blk = -> $b { callee("$path.lock", -> { "$b:$path" }) }; blk("A") }
+is direct("REAL"), "A:REAL", 'direct closure call keeps $path';
+
+sub forloop($path) { my @r; for <A B> -> $b { @r.push(callee("X", -> { $path })) }; @r }
+is-deeply forloop("REAL").Array, ["REAL", "REAL"], 'for-loop closure keeps $path';
+
+# --- no collision: still correct ---
+sub nocollide($path) { <A>.map(-> $b { my $r; { my $lock = "L"; $r = "$b:$path"; }; $r }) }
+is nocollide("REAL")[0], "A:REAL", 'map block reads outer $path directly';
+
+# --- callee param renamed: no collision, must still work ---
+sub callee2($lock, &code) { code() }
+sub renamed($path) { <A>.map(-> $b { callee2("X", -> { "$b:$path" }) }) }
+is renamed("REAL")[0], "A:REAL", 'no-collision callee still fine';


### PR DESCRIPTION
## Problem

A closure created inside a `.map`/`.grep` block lost **lexical** capture of an outer free variable when later invoked through a callee that happened to have a same-named parameter — the free var degraded to dynamic scoping and resolved to the callee's parameter:

```raku
sub callee($path, &code) { code() }
sub f($path) { <A B>.map(-> $b { callee("$path.lock", -> { "$b:$path" }) }) }
f("REAL");   # was ("A:REAL.lock" ...), raku: ("A:REAL" ...)
```

## Root cause

The compile-time transitive `authoritative_free_vars` propagation (`propagate_authoritative_down`, #4510) never reaches such a closure. The inline map/grep fast paths **re-compile the block body**, and that fresh `CompiledCode` is a distinct copy from the one the compile-time pass mutates — verified by pointer (propagated nested cc ≠ runtime nested cc). So the nested closure's `authoritative_free_vars` stays empty, its captured value is installed with don't-overwrite semantics, and a same-named caller lexical shadows it.

## Fix — cascade the vouch at runtime

- New `Interpreter::frame_authoritative`: the free-var names the running frame vouches for (its own `authoritative_free_vars` plus inherited names carried in `owned_captures`, **minus any the subtree writes**).
- Set on every closure-body entry (`call_compiled_closure_with_topic`, `call_sub_value`, and the three inline map/grep loops); saved/restored across call frames like `upvalues`.
- Consulted by `compute_owned_captures` so a closure created in the frame inherits authoritative (overwrite) capture for the vouched free vars it captures. Reuses the existing `owned_captures` overwrite-install path — sound because a vouched value is a never-written plain scalar (`freeze_readonly_owned_captures` only freezes `ContainerRef` cells).

Written free vars are **excluded** from the cascade: a concurrently-mutated loop capture (`for ^N { start { \$c += 1 } }`) must stay a shared cell, or overwrite-installing a frozen per-thread snapshot loses updates (guarded by `t/concurrent-compound-assign.t`, which caught exactly this in an earlier iteration).

## Why it matters

Third language bug behind the **mzef install-pipeline extract phase**: zef's `Zef::Extract.extract` maps over backends and, inside `lock-file-protect(IO() \$path, &code)`, runs `start { \$extractor.extract(\$path, ...) }` — the leak made `tar` receive the `.lock` path instead of the archive. (A narrower zef sub-case where `\$path` is *also* passed as a call argument — triggering the conservative call-arg vouch veto — remains; tracked in `docs/mzef-install-pipeline.md`.)

## Tests

- `t/closure-map-block-free-var-capture.t` (new, 8 cases incl. a 3-level map→block→`start` cascade; passes identically under `raku`).
- Full `make test` PASS (1762 files / 17257 tests), including the concurrency guard.