### PR TITLE
fix: unsupplied optional named param binds its default, not the caller's arg

### DIFF
--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -1080,13 +1080,21 @@ impl Interpreter {
                         format!("Required named parameter '{}' not passed", pd.name),
                     ));
                 } else if !found && !pd.name.is_empty() {
-                    // Only bind a default if the env doesn't already have a value
-                    // (e.g. BUILD/TWEAK attribute bindings pre-populate the env).
-                    if !self.env.contains_key(&pd.name) {
-                        let value = Self::missing_optional_param_value(pd);
-                        self.bind_param_value(&pd.name, value);
-                        self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
-                    }
+                    // An unsupplied optional named param binds its default (the
+                    // signature default expr, or the type object). It must do so
+                    // even when `self.env` ALREADY holds a value under the param
+                    // name: the callee's env is an overlay over the caller's, so a
+                    // caller's same-named named arg (`outer(:section)` calling
+                    // `inner()` whose `:$section` is unsupplied) is visible here and
+                    // would otherwise LEAK into the callee (Template::Mustache's
+                    // recursive `get(:section)` -> `format` -> `get(:encode)` had
+                    // the inner `$section` read the outer True). The one legitimate
+                    // pre-population is a BUILD/TWEAK submethod, whose attribute
+                    // bindings live under twigil'd keys (`$!x`/`!x`), not the bare
+                    // param name — so binding the default here does not disturb them.
+                    let value = Self::missing_optional_param_value(pd);
+                    self.bind_param_value(&pd.name, value);
+                    self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
                 }
                 // Check the where constraint against the *bound* value, whether it
                 // came from the supplied argument, the parameter default, or the

--- a/t/named-param-no-leak-from-caller.t
+++ b/t/named-param-no-leak-from-caller.t
@@ -1,0 +1,35 @@
+use Test;
+
+# An unsupplied optional named parameter must bind its OWN default (or type
+# object), not inherit the caller's same-named named argument. The callee's env
+# is an overlay over the caller's, so `outer(:section)` calling a sub whose
+# `:$section` is unsupplied would leak the caller's `True` in — Template::Mustache
+# rendered `<EarthFalse>` instead of `<Earth>` because a recursive `get(:section)`
+# leaked `:section` into an inner `get(:encode)` and returned a `($result,$lambda)`
+# tuple where a plain string was expected.
+
+plan 5;
+
+# Different callee sub with the same-named param.
+sub inner(Bool :$section) { $section }
+sub outer(Bool :$section) { inner() }
+nok outer(:section), "unsupplied :section does not inherit the caller's value";
+
+# Recursion into the SAME sub.
+sub rec($v, Bool :$flag) {
+    return $flag if $v == 0;
+    rec($v - 1);          # recurse WITHOUT :flag
+}
+nok rec(2, :flag), "recursion without the named arg resets it to the default";
+
+# A signature default still applies (not overwritten by a leaked value).
+sub d(Str :$mode = 'def') { $mode }
+sub call-d(Str :$mode) { d() }
+is call-d(mode => 'outer'), 'def', "the callee's own default wins over a leaked arg";
+
+# The value IS seen when actually passed.
+is inner(:section).so, True, "an explicitly passed named arg is still bound";
+
+# BUILD/TWEAK attribute defaults are unaffected (twigil'd keys, not the bare name).
+class C { has $.x; submethod BUILD(:$x = 'battr') { $!x = $x } }
+is C.new.x, 'battr', "a BUILD named param's default still applies";


### PR DESCRIPTION
An unsupplied optional named parameter skipped binding its default whenever `self.env` already held a value under the param name (`if !self.env.contains_key(&pd.name)`). But the callee's env is an **overlay over the caller's**, so a caller's same-named named argument is visible there — and leaked into the callee:

```raku
sub inner(Bool :$section) { $section }
sub outer(Bool :$section) { inner() }
outer(:section);   # mutsu (before): inner $section = True   raku / after: False
```

The leak crossed recursion and any nested call. Template::Mustache rendered `<EarthFalse>` instead of `<Earth>` because its recursive `get(@context, %val, :section)` → `resolve` → `format` → `get(@context, %val, :encode(...))` leaked `:section` into the inner call, so `$section ?? ($result,$lambda) !! $result` wrongly returned the 2-element tuple.

Fix: bind the default unconditionally for an unsupplied optional named param. The one legitimate pre-population — a `BUILD`/`TWEAK` submethod's attributes — lives under twigil'd keys (`$!x`/`!x`), not the bare param name, so it is unaffected (BUILD default test stays green).

## Testing
- `t/named-param-no-leak-from-caller.t` (new; verified against raku)
- 153 named/signature/BUILD/slurpy/default `t/` tests green
- Full `make test` (running locally before merge) + `make roast` via CI

This is one of two sub-bugs behind Template::Mustache's `~lambdas` section tests; the other (`%val<raw-contents>` coming back empty during parse) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)