### PR TITLE
fix: nested subrule captures report absolute .from/.to, not slice-relative

### DIFF
--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -619,6 +619,58 @@ impl Interpreter {
         }
     }
 
+    /// Shift every offset in a capture subtree by `delta`, including this node's
+    /// own `from`/`to`. Used when re-rooting an inner match (matched against a
+    /// `&chars[pos..]` slice, so its offsets are slice-relative) into the parent's
+    /// absolute coordinate system.
+    pub(super) fn shift_capture_tree(caps: &mut RegexCaptures, delta: usize) {
+        if delta == 0 {
+            return;
+        }
+        caps.from += delta;
+        caps.to += delta;
+        Self::shift_capture_descendants(caps, delta);
+    }
+
+    /// Shift the offsets of a capture node's descendants (its own positional
+    /// captures and every nested named/positional subcapture) by `delta`, WITHOUT
+    /// touching this node's own `from`/`to`. `build_named_candidates_from_inner`
+    /// sets the wrapper node's `from`/`to` explicitly (respecting `<( )>` capture
+    /// markers), then calls this so the slice-relative child offsets become
+    /// absolute — matching Rakudo, whose `.from`/`.to` are always absolute to the
+    /// original string even for a subrule matched deep inside a repetition.
+    pub(super) fn shift_capture_descendants(caps: &mut RegexCaptures, delta: usize) {
+        if delta == 0 {
+            return;
+        }
+        for (f, t) in caps.positional_offsets.iter_mut() {
+            *f += delta;
+            *t += delta;
+        }
+        for slot in caps.positional_slots.iter_mut().flatten() {
+            slot.1 += delta;
+            slot.2 += delta;
+        }
+        for entry in caps
+            .positional_quantified
+            .iter_mut()
+            .flatten()
+            .flat_map(|list| list.iter_mut())
+        {
+            entry.1 += delta;
+            entry.2 += delta;
+            if let Some(nested) = entry.3.as_mut() {
+                Self::shift_capture_tree(std::sync::Arc::make_mut(nested), delta);
+            }
+        }
+        for sub in caps.named_subcaps.values_mut().flat_map(|v| v.iter_mut()) {
+            Self::shift_capture_tree(std::sync::Arc::make_mut(sub), delta);
+        }
+        for sub in caps.positional_subcaps.iter_mut().flatten() {
+            Self::shift_capture_tree(std::sync::Arc::make_mut(sub), delta);
+        }
+    }
+
     /// Build named regex candidates from inner match results (positions relative to tail).
     /// Wraps each inner match in the appropriate capture structure for the named regex call.
     /// `pos` is the position of the named atom in `chars`. Each candidate is a
@@ -653,6 +705,11 @@ impl Interpreter {
                 subcap.matched = captured.clone();
                 subcap.from = cs;
                 subcap.to = ce;
+                // The subrule body was matched against `&chars[pos..]`, so every
+                // descendant offset (its own $0/$1 positional captures and any
+                // nested subrule captures) is slice-relative. Rebase them by `pos`
+                // so `.from`/`.to` are absolute like Rakudo's.
+                Self::shift_capture_descendants(&mut subcap, pos);
                 // sym is already set on subcap from raw_out collection loop.
                 // Fall back to sym_key parameter for the is_active (seed) path.
                 if subcap.sym.is_none() && sym_key.is_some() {
@@ -722,6 +779,8 @@ impl Interpreter {
                 subcap.matched = captured;
                 subcap.from = cs;
                 subcap.to = ce;
+                // Rebase slice-relative descendant offsets to absolute (see above).
+                Self::shift_capture_descendants(&mut subcap, pos);
                 if subcap.sym.is_none() && sym_key.is_some() {
                     subcap.sym = sym_key.cloned();
                 }

--- a/t/regex-nested-subrule-absolute-offsets.t
+++ b/t/regex-nested-subrule-absolute-offsets.t
@@ -1,0 +1,41 @@
+use v6;
+use Test;
+
+# A subrule is matched against a `chars[pos..]` slice, so its captures come back
+# slice-relative. Rakudo's `.from`/`.to` are ALWAYS absolute to the original
+# string — even for a subrule matched deep inside a repetition. Regression test
+# for nested/positional offsets not being rebased to absolute (Template::Mustache
+# section lambdas depend on this: `$/.substr($f<pos>, $hunk<pos> - $f<pos>)`).
+
+plan 12;
+
+grammar G {
+    regex TOP  { ^ <hunk>* (.*) $ }
+    regex hunk { (.*?) <tag> }
+    proto regex tag {*}
+    regex tag:sym<x> { 'XX' }
+    regex tag:sym<y> { 'YY' }
+}
+
+my $m = G.parse('aXXbYY');
+my @h = $m<hunk>.list;
+
+# First hunk (matched at pos 0): offsets already absolute.
+is @h[0].from, 0, 'hunk[0].from';
+is @h[0].to,   3, 'hunk[0].to';
+is @h[0][0].from, 0, 'hunk[0] $0.from';
+is @h[0]<tag>.from, 1, 'hunk[0] tag.from';
+is @h[0]<tag>.to,   3, 'hunk[0] tag.to';
+
+# Second hunk (matched at slice pos 3): the nested tag and the subrule's own
+# $0 must be shifted to absolute, not left slice-relative.
+is @h[1].from, 3, 'hunk[1].from';
+is @h[1].to,   6, 'hunk[1].to';
+is @h[1][0].from, 3, 'hunk[1] $0.from (was slice-relative 0)';
+is @h[1][0].to,   4, 'hunk[1] $0.to (was slice-relative 1)';
+is @h[1]<tag>.from, 4, 'hunk[1] tag.from (was slice-relative 1)';
+is @h[1]<tag>.to,   6, 'hunk[1] tag.to (was slice-relative 3)';
+
+# The absolute offsets must make substr of the top string work.
+is $m.orig.substr(@h[1]<tag>.from, @h[1]<tag>.to - @h[1]<tag>.from), 'YY',
+    'substr with absolute nested offsets';


### PR DESCRIPTION
## Problem

A subrule (`<foo>`) is matched against a `&chars[pos..]` slice with an internal position of 0, so the captures it returns are **slice-relative**. `build_named_candidates_from_inner` rebased only the wrapper node's own `from`/`to` by `pos`, leaving:

- the subrule's own positional captures (`$0`, `$1`, ...) and
- every nested named/positional subcapture

at slice-relative offsets. Rakudo's `.from`/`.to` are **always absolute** to the original string, even for a subrule matched deep inside a repetition.

Minimal repro (`<hunk>` repeated inside `TOP`, `<tag>` nested inside `hunk`, string `aXXbYY`):

| | mutsu (before) | raku |
|---|---|---|
| 2nd hunk `$0.from` | 0 | 3 |
| 2nd hunk `<tag>.from` | 1 | 4 |
| 2nd hunk `<tag>.to` | 3 | 6 |

## Fix

Add `shift_capture_tree` / `shift_capture_descendants` and shift the whole descendant offset tree (`positional_offsets`, `positional_slots`, `positional_quantified`, and recursively `named_subcaps` / `positional_subcaps`) by `pos` when re-rooting an inner match into the parent's coordinates. LTM decisions are unaffected — they key on match *end*, not `.from`/`.to`.

## Impact

This is the root cause of Template::Mustache **section-lambda** breakage: `$/.substr($f<pos>, $hunk<pos> - $f<pos>)` computed a negative length because a repeated `<hunk>`'s nested `<tag>` reported `.from` relative to its slice. With the fix, `~lambdas.json` passes **10/10** and 91-specs reaches **8/9** files (only `inheritable_partials` remains).

## Test

Pin: `t/regex-nested-subrule-absolute-offsets.t`. Full `make test` green (17278 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)