### PR TITLE
fix: paren-less listop call swallows a trailing comma (f $x, == f($x))

### DIFF
--- a/src/parser/primary/ident/listop.rs
+++ b/src/parser/primary/ident/listop.rs
@@ -128,13 +128,18 @@ pub(crate) fn parse_expr_listop_args(input: &str, name: String) -> PResult<'_, E
         }
         let r2 = &r2[1..];
         let (r2, _) = ws(r2)?;
-        // Stop at terminators
+        // Trailing comma: a Raku listop swallows a comma with no following
+        // argument (`f $x,` == `f($x)`), so consume it into the call's arg list
+        // rather than leaving it for the outer parser to read as a list comma
+        // (which would nest the call result: `my @b = f $x,` becoming
+        // `@b = (f($x),)`).
         if r2.is_empty()
             || r2.starts_with(';')
             || r2.starts_with('}')
             || r2.starts_with(')')
             || is_stmt_modifier_ahead(r2)
         {
+            r = r2;
             break;
         }
         let (r2, arg) = call_arg_expr(r2).map_err(|err| PError {
@@ -294,12 +299,14 @@ pub(crate) fn make_call_expr_from_listop_args<'a>(
         }
         let r2 = &r2[1..];
         let (r2, _) = ws(r2)?;
+        // Trailing comma: consume it into the call (see parse_expr_listop_args).
         if r2.is_empty()
             || r2.starts_with(';')
             || r2.starts_with('}')
             || r2.starts_with(')')
             || is_stmt_modifier_ahead(r2)
         {
+            r = r2;
             break;
         }
         let (r2, arg) = parse_listop_arg(r2).map_err(|err| PError {

--- a/t/listop-trailing-comma.t
+++ b/t/listop-trailing-comma.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+# A paren-less list operator (listop) call must swallow a trailing comma into
+# its own argument list, exactly like Rakudo: `f $x,` is `f($x)`, NOT
+# `(f($x),)`. When the call returns a container (Array/Hash), the wrong reading
+# nests the result on list-assignment (`my @a = f $x,` -> `[[...]]`).
+# Regression: Template::Mustache inheritable_partials relied on
+# `my @parsed = get-template .<val>, :delims(...), ;` staying flat.
+
+plan 8;
+
+sub arr($k) { return [ { :t($k) }, ]; }
+
+# single-line trailing comma
+my @a = arr 'x', ;
+is @a.elems, 1, 'trailing comma: elems stays 1 (not nested)';
+is @a[0].^name, 'Hash', 'trailing comma: [0] is the Hash, not an Array';
+
+# multiline trailing comma (module form)
+my @b = arr
+            'y',
+            ;
+is @b.elems, 1, 'multiline trailing comma: elems stays 1';
+is @b[0].^name, 'Hash', 'multiline trailing comma: [0] is the Hash';
+
+# with a named arg then trailing comma
+sub arn($k, :$d) { return [ { :t($k), :d($d) }, ]; }
+my @c = arn
+            'z',
+            :d('dd'),
+            ;
+is @c.elems, 1, 'named arg + trailing comma: elems stays 1';
+is @c[0]<t>, 'z', 'named arg + trailing comma: positional bound';
+is @c[0]<d>, 'dd', 'named arg + trailing comma: named bound';
+
+# no trailing comma still flat (control)
+my @d = arr 'w';
+is @d.elems, 1, 'no trailing comma: elems 1 (control)';


### PR DESCRIPTION
## Problem

A Raku list operator (a paren-less call) consumes its **entire** comma-separated
argument list, including a **trailing comma** with no following argument:
`f $x,` is `f($x)`, not `(f($x),)`.

mutsu's listop argument loop detected the comma-then-terminator case and broke
out of the loop **without advancing past the comma**, leaving it for the outer
expression parser to read as a list comma. For a call returning a container
this nested the result on list-assignment:

```raku
sub arr($k) { return [ { :t($k) }, ]; }
my @a = arr 'x', ;   # raku: [{:t("x")},]   mutsu (before): [[{:t("x")},],]
```

## Root cause

In `src/parser/primary/ident/listop.rs`, both `parse_expr_listop_args` and
`make_call_expr_from_listop_args` had the same bug: on `,` followed by a
terminator (`;`, `}`, `)`, EOF, or a statement modifier) they `break` but did
not update the remaining-input cursor `r`, so the comma escaped into the
enclosing parse.

## Fix

Consume the trailing comma into the call's argument list (`r = r2;`) before
breaking, in both functions. Paren **calls** (`f($x),`) are unaffected — that
comma is genuinely an outer-list comma and still nests, matching Rakudo.

## Impact

This was the final blocker for Template::Mustache's `inheritable_partials`
(`my @parsed = get-template .<val>, :delims(...), ;` was nesting the parsed
template array), taking the module's `91-specs` suite from **8/9 to 9/9** —
all spec files (comments, delimiters, inheritable_partials, inheritable_sections,
interpolation, inverted, partials, sections, ~lambdas) now pass.

Note: the earlier root-cause note called this a "scalar-itemization divergence";
it is actually a parser trailing-comma bug, isolated to a clean minimal repro.

## Tests

- New pin `t/listop-trailing-comma.t` (8 assertions: single-line / multiline /
  named-arg trailing comma, plus a no-comma control).
- Edge cases verified against `raku`: paren-call `f($x),` still nests, hash/array
  literal trailing commas, multi-arg listops.
- `make test`: PASS. Listop parser unit tests: 9 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)