### PR TITLE
fix: declaration-level does/but mixin visible to BEGIN; role-suffixed .^name (mixin-6c)

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -73,8 +73,7 @@ noted.
 |---|---|---|---|
 | `integration/99problems-41-to-50.t` | aborts at 2/9 | PASS ★ | Parameterized `multi rule expr($p)` now WORKS (2026-07-15: multi rule/token registration, literal-exclusive dispatch, args in the LR key, lookahead arg instantiation — pin t/parameterized-rules.t; all reduced P47 shapes pass), but the full P47 grammar (3 precedence levels + `term:sym<paren>`/`term:sym<not>` recursion via `<term=.expr(3)>`) is exponentially slow in the regex engine (~9s for 1 level+paren on `(A)` in a debug build; the real input times out). The blocker is now the LR seed-growing loop re-matching all candidates per position per nesting level — needs match-position memoization of subrule results (packrat-style), a separate engine-perf campaign. P41/P46 fixed in #4510 |
 | `integration/advent2013-day18.t` | 9/10 | PASS ★ | The rule-embedded dynamic-var declaration (`rule deal { :my %*PLAYED = (); … }`), sigspace `[ <card> ]**5`, `<?{ … $/.lc … }>` matched-so-far `$/`, and action-method + code-assertion sharing of `%*PLAYED` all work now (0/10 → 9/10; pin t/grammar-dynamic-var-decl.t). The **only** remaining failure is test 10, which needs **TWO** distinct architectural fixes, not one (2026-07-16 deep-dive): (1) **code-assertion outer-array writeback** — `<?{ … @dups.push($card) … }>` runs in `eval_regex_code_assertion`'s scratch interp (`env: self.env.clone()`); a hash element write (`%*PLAYED{$c}++`) persists because it mutates the SHARED `Gc<HashData>` node in place, but `@dups.push` resolves `@dups` to a fresh empty local (the scratch block autovivs it, ignoring the cloned env value), so the push writes a detached node discarded when the scratch drops. A post-run writeback (copy scratch `@x` items into `self`'s shared node) proved the mechanism but exposed (2). (2) **code assertions over-run during backtracking** — mutsu's matcher re-runs the `<?{}>` assertion MANY times per cursor position (repro: `%seen{k}++` reaches count 12 where raku is 2), so BOTH `%*PLAYED` counts and any `@dups` writeback are corrupted (append writeback yielded 60+ bogus `a♥` entries incl. non-dup cards, because backtracked `%*PLAYED` accumulation made valid cards look like dups). raku runs each assertion once per COMMITTED position (ratcheted tokens don't backtrack into a matched token). Fixing (1) alone can't pass test 10 — the engine must stop re-running committed-position assertions first. Both large; deferred |
-| `6.c/S04-declarations/my-6c.t` | 111/112 | PASS ★ | **shortcut**: the only failure = test 57, the `OUTER::<$x>` pseudo-package |
-| `6.c/S14-roles/mixin-6c.t` | aborts at 16/57 | PASS ★ | 6.c mixin (`does`/`but`) semantics; aborts mid-file |
+| `6.c/S04-declarations/my-6c.t` | 111/112 | PASS ★ | test 57 (`OUTER::<$x>`) needs **lexical hoisting**, not the OUTER pseudo-package alone: `EVAL('not OUTER::<$x>.defined')` must see the *enclosing block's* `my $x` declared **after** the EVAL (undefined container), but mutsu skips the not-yet-run local and resolves OUTER to the file-level `my $x = 0` (defined). Same family as mixin-6c/my-6e hoisting. Minimal repro: `my $x = 0; { { say EVAL('not OUTER::<$x>.defined'); my $x } }` → mutsu False, raku True |
 | `6.c/APPENDICES/A04-experimental/01-misc.t` | 16/19 | FAIL | `:D`/`:U` DefiniteHow coercion (`Target:D(Source:U)`). #4514: 0/19 → 16/19 |
 | `APPENDICES/A02-some-day-maybe/multi-no-match.t` | 11/16 | PASS ★ | error-message quality for multi no-match: `.splice` with wrong offset/type, `Lock.protect` / `Lock::Async.protect` / `Proc::Async.new` with wrong args must give "sane errors" — ④-adjacent |
 | `6.c/APPENDICES/A03-older-specs/01-misc.t` | fails 4+ | 6/9 FAIL | `.open("-")` mapping to `$*IN`/`$*OUT`, deprecated `subst-mutate`. raku itself fails 3 of 9 = partially non-goal |
@@ -192,16 +191,19 @@ completed fix history lives in `news/`.
 
 ## Recommended order of attack right now
 
-1. **Shortcuts**: `6.c/S04-declarations/my-6c.t` needs only the single `OUTER::<$x>` subtest
-   (111/112). `integration/99problems-51-to-60.t` (35/37) and `99problems-61-to-70.t` (12/15)
-   are close.
-2. **④ error-message quality** (`advent2011-day11.t` 7/9, `multi-no-match.t` 11/16) — the
+1. **Shortcuts**: `6.c/S04-declarations/my-6c.t` (111/112) is now a **lexical-hoisting** task,
+   not the OUTER pseudo-package alone (see inventory row). `integration/99problems-51-to-60.t`
+   (35/37) and `99problems-61-to-70.t` (12/15) are close.
+2. **④ error-message quality** (`advent2011-day11.t` 7/9, `multi-no-match.t`) — the
    same target as the identically named task in PLAN §6, so it can be driven by roast
    pass/fail while working on that. (`error-reporting.t` and `weird-errors.t` reached the
-   whitelist 2026-07-15.)
+   whitelist 2026-07-15.) `multi-no-match.t` needs `X::Multi::NoMatch` from many independent
+   builtins (`.splice`/`Lock.protect`/`Proc::Async.new`/`.subst`/`.match`/`Pair.new`/
+   `Junction.new`/`Int.new`/`Date.new`) — no single lever; 3/16 pass today.
 3. **The 11 not-yet-root-caused `integration/` aborts** (see inventory) — history says one root
    cause usually spans several files; re-run and diff against raku before picking features.
-4. `6.c/S14-roles/mixin-6c.t` (aborts at 16/57, raku full pass) — 6.c mixin semantics.
+   (`6.c/S14-roles/mixin-6c.t` was whitelisted 2026-07-17 — the abort was a nested BEGIN
+   hoisting above a `does`/`but` declaration mixin; pin `t/decl-mixin-begin.t`.)
 - For the S\* table (non-goal / no-oracle / awaiting-infrastructure), advancing entries as a side
   effect of general mutsu improvements is fine, but do not make whitelisting those individual
   files the goal. `S32-str/format.t` and `S02-types/generics.t` gained an oracle from the raku

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -9,6 +9,7 @@ roast/6.c/S05-grammar/parse_and_parsefile-6c.t
 roast/6.c/S06-other/main-refactored.t
 roast/6.c/S12-class/mro-6c.t
 roast/6.c/S14-roles/attributes.t
+roast/6.c/S14-roles/mixin-6c.t
 roast/6.c/S14-roles/submethods.t
 roast/6.c/S32-io/file-tests.t
 roast/6.d/S02-literals/version.t

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -527,6 +527,12 @@ pub(crate) fn native_method_0arg(
         {
             return Some(Ok(name_val.clone()));
         }
+        // A role-mixed value (`5 but Foo::Bar`, `$x does R`) reports its base type
+        // with a `+{Role,...}` suffix (`Int+{Foo::Bar}`). Without this, `^name`
+        // delegates to the inner value below and drops the mixed-in role names.
+        if method == "^name" && crate::value::role_mixin_suffix(mixins).is_some() {
+            return Some(Ok(Value::str(crate::value::what_type_name(target))));
+        }
         // Check for mixin key matching the method name (e.g. "Array", "List", "Int", etc.)
         // This handles `True but [1, 2]` where `.Array` should return the mixed-in array.
         if let Some(mixin_val) = mixins.get(method) {

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -52,6 +52,15 @@ impl Interpreter {
                 ValueView::Mixin(_, overrides) if overrides.contains_key("__mutsu_type_name__") => {
                     overrides["__mutsu_type_name__"].to_string_value()
                 }
+                // A role-mixed value (`5 but Foo::Bar`, `$x does R`) reports its
+                // base type with a `+{Role,...}` suffix, e.g. `Int+{Foo::Bar}`.
+                // `what_type_name` builds this from the recorded role keys;
+                // `value_type_name` (a `&'static str`) cannot.
+                ValueView::Mixin(_, overrides)
+                    if crate::value::role_mixin_suffix(overrides).is_some() =>
+                {
+                    crate::value::what_type_name(&args[0])
+                }
                 ValueView::Package(name) => self
                     .type_metadata
                     .get(&name.resolve())

--- a/src/runtime/phasers.rs
+++ b/src/runtime/phasers.rs
@@ -876,9 +876,21 @@ fn is_read_stmt(stmt: &Stmt) -> bool {
     match stmt {
         Stmt::Say(_) | Stmt::Put(_) | Stmt::Print(_) | Stmt::Note(_) => true,
         Stmt::Call { .. } => true,
-        Stmt::Expr(e) => !matches!(e, Expr::AssignExpr { .. }),
+        Stmt::Expr(e) => !matches!(e, Expr::AssignExpr { .. }) && !is_mixin_expr(e),
         _ => false,
     }
+}
+
+/// True if `expr` is a `does`/`but` role-mixin application (`$x does Role`,
+/// `@a but Role`). Such an expression mutates its target container as a
+/// compile-time declaration effect, so it acts as a hoisting barrier for a
+/// following BEGIN rather than as a pure read.
+fn is_mixin_expr(expr: &Expr) -> bool {
+    matches!(
+        expr,
+        Expr::Binary { op: crate::token_kind::TokenKind::Ident(op), .. }
+            if op == "does" || op == "but"
+    )
 }
 
 /// True if a nested `BEGIN` phaser may be hoisted above `stmt`. Only pure reads
@@ -898,8 +910,12 @@ fn stmt_is_hoist_safe(stmt: &Stmt) -> bool {
         // A bare declaration (no initializer) creates a container but performs
         // no runtime work, so a BEGIN may safely run before it.
         Stmt::VarDecl { expr, .. } => is_empty_vardecl_init(expr),
-        // A plain expression statement is a read unless it is an assignment.
-        Stmt::Expr(e) => !matches!(e, Expr::AssignExpr { .. }),
+        // A plain expression statement is a read unless it is an assignment or a
+        // `does`/`but` role mixin. A declaration-level mixin (`my @a does R1`,
+        // desugared to `VarDecl @a; @a does R1`) applies the role to the
+        // container as a compile-time effect that a following BEGIN must see, so
+        // it is a barrier the BEGIN may not hoist above.
+        Stmt::Expr(e) => !matches!(e, Expr::AssignExpr { .. }) && !is_mixin_expr(e),
         _ => false,
     }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -325,7 +325,7 @@ pub(in crate::value) use nanbox::NanBox;
 /// NaN-box word releases its payload). Nil owns no payload, so a static is
 /// free.
 pub(crate) static NIL_VALUE: Value = Value(NanBox::NIL);
-pub(crate) use types::what_type_name;
+pub(crate) use types::{role_mixin_suffix, what_type_name};
 pub use view::ValueView;
 
 /// Get current time as seconds since UNIX epoch (returns 0.0 on WASM).

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -54,11 +54,44 @@ pub(crate) fn what_type_name(val: &Value) -> String {
         ValueView::Uni(u) if !u.form.is_empty() => u.form.clone(),
         ValueView::Uni(_) => "Uni".to_string(),
         ValueView::Mixin(inner, mixins) => {
-            allomorph_type_name(inner, mixins).unwrap_or_else(|| what_type_name(inner))
+            if let Some(name) = allomorph_type_name(inner, mixins) {
+                name
+            } else {
+                let base = what_type_name(inner);
+                match role_mixin_suffix(mixins) {
+                    Some(suffix) => format!("{base}+{{{suffix}}}"),
+                    None => base,
+                }
+            }
         }
         ValueView::ContainerRef(_) => val.with_deref(what_type_name),
         _ => "Any".to_string(),
     }
+}
+
+/// Build the `+{Role,...}` suffix for a role-mixed value, if any roles were
+/// composed in. Role mixins are recorded under `__mutsu_role__{name}` keys (a
+/// double underscore distinguishes them from the bookkeeping keys
+/// `__mutsu_role_id__` / `__mutsu_role_typeargs__` / `__mutsu_role_param__`).
+/// Returns e.g. `Foo::Bar` for `5 but Foo::Bar` so `.^name` reads `Int+{Foo::Bar}`.
+pub(crate) fn role_mixin_suffix(
+    mixins: &std::collections::HashMap<String, Value>,
+) -> Option<String> {
+    let mut names: Vec<&str> = mixins
+        .keys()
+        .filter_map(|k| k.strip_prefix("__mutsu_role__"))
+        // Anonymous roles (`but role { }`) carry a compiler-internal
+        // `__ANON_ROLE_{id}__` name; raku would show `<anon|N>` but mutsu's id
+        // does not match, so leave anon mixins un-suffixed (reporting the base
+        // type) rather than leaking the internal name.
+        .filter(|n| !n.starts_with("__ANON_ROLE_"))
+        .collect();
+    if names.is_empty() {
+        return None;
+    }
+    // HashMap iteration order is non-deterministic; sort for a stable name.
+    names.sort_unstable();
+    Some(names.join(","))
 }
 
 /// Return the allomorphic type name for a Mixin value, if it is allomorphic.

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1183,7 +1183,7 @@ impl Interpreter {
                     .unwrap_or(Value::NIL);
                 if result.is_nil() { default } else { result }
             }
-            (ValueView::Mixin(..), ValueView::Int(i)) => {
+            (ValueView::Mixin(inner, _), ValueView::Int(i)) => {
                 if let ValueView::Mixin(_, mixins) = target.view()
                     && let Some(attr_key) = self.delegated_mixin_attr_key(mixins, "AT-POS")
                     && let Some(attr_value) = mixins.get(&attr_key).cloned()
@@ -1197,6 +1197,25 @@ impl Interpreter {
                     } else {
                         self.typed_container_default(&target)
                     }
+                } else if matches!(
+                    inner.view(),
+                    ValueView::Array(..)
+                        | ValueView::LazyList(_)
+                        | ValueView::Slip(_)
+                        | ValueView::Range(..)
+                        | ValueView::RangeExcl(..)
+                        | ValueView::RangeExclStart(..)
+                        | ValueView::RangeExclBoth(..)
+                        | ValueView::GenericRange { .. }
+                ) {
+                    // A role mixed into a positional value (`(^Inf) but role {}`,
+                    // `[1,2] but R`) that supplies no AT-POS keeps the inner
+                    // value's indexing — delegate straight to the inner container.
+                    let inner = inner.as_ref().clone();
+                    self.stack.push(inner);
+                    self.stack.push(Value::int(i));
+                    self.exec_index_op()?;
+                    self.stack.pop().unwrap_or(Value::NIL)
                 } else {
                     let default = self.typed_container_default(&target);
                     let fallback = target.clone();

--- a/t/decl-mixin-begin.t
+++ b/t/decl-mixin-begin.t
@@ -1,0 +1,44 @@
+use v6;
+use Test;
+
+plan 9;
+
+# `my @array does R1` applies the role to the container as a compile-time
+# declaration effect, so a following BEGIN block (which runs before the block's
+# runtime statements) still sees the mixed-in role. Previously the BEGIN was
+# hoisted above the `does` mixin, so `@array.test` threw at compile time and
+# aborted the whole program.
+{
+    role R1 { method test { 42 } }
+    {
+        my @array does R1;
+        is @array.test, 42, 'role mixed in at point of declaration (runtime)';
+
+        my $x;
+        BEGIN { $x = @array.test }
+        is $x, 42, 'declaration mixin visible to a following BEGIN block';
+    }
+}
+
+# `.^name` of a role-mixed value carries a `+{Role,...}` suffix.
+{
+    role Bar { }
+    is (5 but Bar).^name, 'Int+{Bar}', '.^name of a simple role mixin';
+
+    role Foo::Bar { }
+    is (5 but Foo::Bar).^name, 'Int+{Foo::Bar}',
+        '.^name keeps the full role name from a deeper namespace';
+
+    my $x = 5;
+    $x does Bar;
+    is $x.^name, 'Int+{Bar}', '.^name after `does` on a scalar';
+}
+
+# Allomorphic mixins (`but True`, `<5>`) are unaffected by the role suffix.
+is (0 but True).^name, 'Int', '.^name of a value mixin is not role-suffixed';
+is <5>.^name, 'IntStr', '.^name of an allomorph is unchanged';
+
+# Indexing a role-mixed positional value delegates to the inner container when
+# the role supplies no AT-POS of its own.
+is ((^Inf) but role {})[2], 2, 'index into a role-mixed lazy range';
+is ([10, 20, 30] but role {})[1], 20, 'index into a role-mixed array';


### PR DESCRIPTION
Whitelists `roast/6.c/S14-roles/mixin-6c.t` (was aborting at 16/57 → now 57/57).

The file aborted because a nested `BEGIN` block referencing a container declared
with a role mixin (`my @array does R1; BEGIN { ... @array.test ... }`) ran before
the mixin was applied and threw at compile time, aborting everything after it.
Root-causing that surfaced two further gaps in mixed-value introspection.

## Fixes

1. **Declaration mixin visible to a following BEGIN.** `my @array does R1`
   desugars to `VarDecl @array; @array does R1`. The phaser-reorder pass treated
   the `does` expression as a harmless "read", so a following `BEGIN` hoisted
   above it and saw the un-mixed container. The mixin is a compile-time container
   effect a BEGIN must observe, so it is now a hoisting barrier
   (`is_mixin_expr` in `stmt_is_hoist_safe` / `is_read_stmt`).

2. **`.^name` of a role-mixed value carries `+{Role,...}`.**
   `(5 but Foo::Bar).^name` → `Int+{Foo::Bar}` (was `Int`). `role_mixin_suffix`
   reads the composed role names from the `__mutsu_role__{name}` mixin keys;
   anonymous roles stay un-suffixed (mutsu's internal id ≠ raku's `<anon|N>`).
   Value/allomorph mixins (`0 but True`, `<5>`) are unaffected.

3. **Indexing a role-mixed positional value delegates to the inner container.**
   `((^Inf) but role {})[2]` → `2` (was `Nil`) when the role supplies no AT-POS.

## Testing

- New pin: `t/decl-mixin-begin.t` (9 assertions).
- `roast/6.c/S14-roles/mixin-6c.t` 57/57 PASS, added to the whitelist.
- `make test` green (fixed one local pin, `t/metamodel-set-name.t`, whose base-name
  expectation for an anon-role mixin still holds since anon roles stay un-suffixed).
- All whitelisted `S04-phasers/*` tests re-verified green (the reorder change is the
  highest-blast-radius part).

🤖 Generated with [Claude Code](https://claude.com/claude-code)