### PR TITLE
fix: vouch for a :=-bound scalar captured by a closure even when passed to a call

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1030,6 +1030,16 @@ impl Compiler {
                 // var was marked readonly purely as a bind signal).
                 let is_bound_container_vardecl =
                     self.bind_vardecl && (name.starts_with('@') || name.starts_with('%'));
+                // A scalar `:=` bind (`my $x := EXPR`). Captured before the RHS
+                // branches consume `bind_vardecl`; recorded on the CompiledCode so
+                // `compute_free_vars` can vouch for it despite it reaching a call as
+                // an argument (an immutable binding never goes stale). Both the
+                // MarkBind form (`my $x := $y`, sets `bind_vardecl`) and the inline
+                // `__scalar_bind` trait form (`my $x := my $y`) count.
+                let is_scalar_colon_bind = (self.bind_vardecl || scalar_bind_decont)
+                    && !name.starts_with('@')
+                    && !name.starts_with('%')
+                    && !name.starts_with('&');
                 // A `constant` initializer is evaluated at BEGIN (compile) time,
                 // so an uncaught exception while evaluating it surfaces as
                 // X::Comp::BeginTime (with the original exception nested). Wrap
@@ -1178,6 +1188,12 @@ impl Compiler {
                     }
                 }
                 let slot = self.declare_local(name);
+                if is_scalar_colon_bind {
+                    let sym = Symbol::intern(name);
+                    if !self.code.scalar_bind_locals.contains(&sym) {
+                        self.code.scalar_bind_locals.push(sym);
+                    }
+                }
                 if *is_state {
                     if let Some((guard_idx, key, key_idx)) = state_guard_idx {
                         // Patch the guard jump target to the StateVarInit instruction

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1640,6 +1640,13 @@ pub(crate) struct CompiledCode {
     /// Maps local slot indices to qualified package names for `our` variables.
     /// Used by BlockScope restoration to sync local slots from their global values.
     pub(crate) our_locals: Vec<(usize, String)>,
+    /// Scalar locals declared with a `:=` bind (`my $x := EXPR`). Such a binding
+    /// is immutable — the local is never reassigned — so its captured snapshot in
+    /// a closure can never go stale, even when the local is also handed to a call
+    /// (which would otherwise veto it from `authoritative_free_vars` for fear of an
+    /// `is rw` writeback). See the `own_call_arg_sources` exception in
+    /// `compute_free_vars`.
+    pub(crate) scalar_bind_locals: Vec<Symbol>,
     /// Compiler-authoritative positional-parameter → local-slot mapping, in the
     /// order `precompute_param_local_slots` expects (positional `param_defs`, or
     /// `params` when `param_defs` is empty). Baked at emit time from the
@@ -2031,6 +2038,7 @@ impl CompiledCode {
             plain_locals: Vec::new(),
             state_locals: Vec::new(),
             our_locals: Vec::new(),
+            scalar_bind_locals: Vec::new(),
             param_local_slots: Vec::new(),
             closure_compiled_codes: Vec::new(),
             named_arg_specs: Vec::new(),
@@ -3158,8 +3166,19 @@ impl CompiledCode {
                     // Mutated in place as a container — invisible to `self_mutated`,
                     // but a `%h<k> = v` that copy-on-writes still strands the capture.
                     && !own_container_writes.contains(sym)
-                    // Handed to a call, where an `is rw` param can write it back.
-                    && !own_call_arg_sources.contains(sym)
+                    // Handed to a call, where an `is rw` param can write it back —
+                    // making a by-value overwrite-install go stale (`my $x = ...;
+                    // my $c = -> { $x }; mutate($x); $c()` must see the writeback).
+                    // EXCEPTION: a `:=`-bound scalar is an immutable binding — it is
+                    // never reassigned and (when bound to a value/attribute result,
+                    // the zef `my $path := $candi.uri` shape) has no source container
+                    // an rw param could write through, so its captured snapshot can
+                    // never go stale. Vouching for it lets a closure that carries it
+                    // into a foreign frame with a same-named parameter still resolve
+                    // its own lexical binding (the misresolution otherwise picks up
+                    // the callee's `$path`). See `scalar_bind_locals`.
+                    && (!own_call_arg_sources.contains(sym)
+                        || self.scalar_bind_locals.contains(sym))
             })
             .collect();
         for nested in &mut self.closure_compiled_codes {

--- a/t/closure-callarg-source-cell.t
+++ b/t/closure-callarg-source-cell.t
@@ -1,0 +1,102 @@
+use Test;
+
+# A `:=`-bound scalar (`my $path := EXPR`) is an immutable binding, so its
+# captured snapshot in a closure can never go stale — even when the local is
+# also handed to a call as an argument (which normally vetoes it from
+# `authoritative_free_vars` for fear of an `is rw` writeback). Vouching for it
+# lets a closure that carries it into a FOREIGN frame with a same-named parameter
+# still resolve its own lexical binding, instead of dynamically picking up the
+# callee's parameter. Regression: zef's Zef::Extract.extract, where
+# `my $path := $candi.uri` reached `self!extractors($path)` and was captured by
+# `.map(-> $ex { lock-file-protect(IO() $path, -> { ... $ex.extract($path) }) })`
+# and mis-resolved to lock-file-protect's own `$path` parameter (the `.lock`
+# file), so tar tried to untar the lock file. This is a by-value overwrite-install
+# (no boxing), so scalars holding Set/Bag/Mix/Pair or an `is default` trait are
+# untouched.
+
+plan 6;
+
+# 1) The core misresolution: a `:=`-bound $path captured through map -> block,
+#    must keep its lexical value, not the callee's same-named parameter.
+{
+    sub other1($p) { 1 }
+    sub callee1($path, &code) { code() }
+    sub extract1($candi) {
+        my $path := $candi;
+        other1($path);
+        <A B>.map(-> $b { callee1("$path.lock", -> { "$b:$path" }) })
+    }
+    is extract1("REAL").join(","), "A:REAL,B:REAL",
+        "captured :=-bound call-arg-source keeps lexical value, not callee param";
+}
+
+# 2) Three-level nesting (map -> block -> start), as in zef.
+{
+    sub other2($p) { 1 }
+    sub callee2($path, &code) { code() }
+    sub extract2($candi) {
+        my $path := $candi;
+        other2($path);
+        <A B>.map(-> $b { callee2("$path.lock", -> { await start { "$b:$path" } }) })
+    }
+    is extract2("REAL").join(","), "A:REAL,B:REAL",
+        "three-level nested capture (map/block/start) resolves lexically";
+}
+
+# 3) The value is a reference type (an Instance): by-value overwrite-install works
+#    without boxing (the box path skips reference types, so the old cell approach
+#    could not fix this).
+{
+    class Cand3 { has $.uri }
+    class Ex3 { method extract($archive) { "GOT:" ~ $archive.basename } }
+    sub lock3($path, &code) { code() }
+    sub extract3($candi) {
+        my $path := $candi.uri;
+        my Ex3 @ex = Ex3.new;
+        @ex.map(-> $e {
+            lock3("$path.lock", -> { my $t = start { $e.extract($path) }; await $t; $t.result })
+        }).head;
+    }
+    is extract3(Cand3.new(uri => "/tmp/REAL.tar.gz".IO)), "GOT:REAL.tar.gz",
+        "Instance-valued :=-bound path resolves lexically (no boxing needed)";
+}
+
+# 4) The veto is still honored for `=`-assigned scalars: a genuine `is rw`
+#    writeback after capture must be observed (by-value would go stale, so those
+#    must NOT be made authoritative).
+{
+    sub mutate4($x is rw) { $x = "NEW" }
+    sub f4() {
+        my $x = "orig";
+        my $c = -> { $x };
+        mutate4($x);
+        $c();
+    }
+    is f4(), "NEW", "an =-assigned rw-writeback is still seen (veto preserved)";
+}
+
+# 5) grep block variant (separate inline recompile path).
+{
+    sub other5($p) { 1 }
+    sub callee5($path, &code) { code() }
+    sub extract5($candi) {
+        my $path := $candi;
+        other5($path);
+        <A B>.grep(-> $b { callee5("$path.lock", -> { "$b:$path" eq "A:REAL" }) })
+    }
+    is extract5("REAL").join(","), "A",
+        "grep block capture of a :=-bound call-arg-source resolves lexically";
+}
+
+# 6) No over-vouch: a same-named local in a sibling frame is untouched.
+{
+    sub other6($p) { 1 }
+    sub callee6($path, &code) { code() }
+    sub extract6($candi) {
+        my $path := $candi;
+        other6($path);
+        callee6("shadow", -> { $path });
+    }
+    is extract6("live"), "live",
+        "closure invoked from a same-named foreign frame keeps its own binding";
+}


### PR DESCRIPTION
## Summary

A closure's captured free variable could dynamically resolve to a same-named **parameter** of a foreign frame that invokes the closure, instead of its own lexical binding. The #4510 `authoritative_free_vars` mechanism fixes that by overwrite-installing a vouched capture at closure entry, but a local handed to a call as an argument is vetoed from vouching (`own_call_arg_sources`): an `is rw` / `is raw` parameter could write it back, which would make a by-value overwrite-install go stale (`my $x = ...; my $c = -> { $x }; mutate($x); $c()` must observe the writeback — the veto is load-bearing for `=`-assigned scalars, e.g. the cas-style tests).

But a **`:=`-bound scalar** (`my $path := $candi.uri`) is an immutable binding: never reassigned, and when bound to a value / attribute result there is no source container an rw parameter could write through, so its captured snapshot can never go stale. This PR exempts such locals from the call-arg-source veto so the closure resolves its own lexical binding.

## Why not the ContainerRef cell approach (closed #4632)

A ContainerRef cell-ification of these captures **over-boxed** exactly the scalars that hold `Set`/`Bag`/`Mix`/`Pair` or carry an `is default` trait (regressing `bag`/`mix`/`pair`/`is_default` roast tests), **and** could not fix reference-typed values at all — `box_captured_lexicals` skips `Instance`/`Array`/`Hash`/… so an `IO::Path`-valued `$path` was never boxed. This fix is a pure by-value overwrite-install (no boxing), so it is correct for reference types and leaves special containers untouched.

## Mechanism

The compiler records scalar `:=` decls (`bind_vardecl` / the inline `__scalar_bind` trait) in `CompiledCode::scalar_bind_locals`; `compute_free_vars` consults it in the `vouched` filter.

## Context

Regression fixed: zef's `Zef::Extract.extract` binds `my $path := $candi.uri`, hands it to `self!extractors($path)`, then captures it in `.map(-> $ex { lock-file-protect(IO() $path, -> { ... $ex.extract($path) }) })`. `$path` (an `IO::Path`) mis-resolved to `lock-file-protect`'s own `$path` parameter (the `.lock` file), so tar tried to untar the lock file. With this fix the extract phase **completes end-to-end** against real `zef fetch Test::META` (verified: `tar ... passed=True`, extract output exists).

## Test

`t/closure-callarg-source-cell.t` — 6 cases: the core misresolution, three-level nesting (map/block/start, the zef shape), an `Instance`-valued path (which the cell approach could not fix), the preserved `=`-assigned rw-writeback (veto still honored), the grep inline path, and no over-vouch of a same-named foreign binding. `make test` passes (17k+ tests); previously-regressed `bag`/`mix`/`pair`/`sethash`/`is_default` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)