### PR TITLE
fix: push-based supply event delivery — react busy-spin, lost done/emit, per-interval timer threads (ADR-0008)

### DIFF
--- a/docs/adr/0008-push-based-supply-event-delivery.md
+++ b/docs/adr/0008-push-based-supply-event-delivery.md
@@ -1,0 +1,96 @@
+# 0008. Push-based supply event delivery (ReactWaker sinks)
+
+Date: 2026-07-17
+Status: Accepted
+
+## Context
+
+The react/supply drive loop (`drive_react_subscriptions_*`) and every other
+supply consumer (control waits, `supply_list_values`, `Promise.anyof`) were
+built on **snapshot polling**: consumers repeatedly cloned the supplier
+registry state (`supplier_snapshot_seqs`) or slept in 1ms/10ms
+`thread::sleep` loops, looking for new values. This architecture — one of the
+oldest concurrency mechanisms in the codebase — had four structural defects,
+all observed on real workloads (S17 CI flakes, `zef`, Cro-style pipelines):
+
+1. **Busy spin.** A react whose only sources were supplier-backed
+   subscriptions had *no blocking point at all*: the loop spun at 100% CPU
+   between snapshots (`react whenever $supplier.Supply { }` burned a full
+   core for its whole lifetime, and hammered the global supplier-registry
+   mutex, slowing the emitting threads too). Under CI load this is what
+   pushed `S17-supply/syntax.t` past the 30s roast timeout.
+2. **Lost events.** `Supplier.done` fires its callbacks and then
+   `supplier_reset`s the registry entry (so the supplier can be reused).
+   A polling consumer that had not yet observed the `done` flag — or the
+   values emitted just before it — lost them permanently:
+   `start { $s.emit(1); $s.emit(2); $s.done }` + `react whenever $s.Supply`
+   delivered only `1` and then hung forever. Poll-based readers cannot be
+   made sound against writer-side resets.
+3. **Quadratic churn.** `supplier_snapshot_seqs` cloned the *entire* emit
+   history per delivered value per subscription; a supply carrying 4000
+   emits cloned ~16M `Value`s inside the global registry lock.
+4. **Latency amplification under load.** Every 1ms/10ms `thread::sleep` poll
+   overshoots badly on an oversubscribed host, compounding across the many
+   loops involved in one supply pipeline (mutsu ran S17 tests 1.5–2× slower
+   than raku under CPU contention, flaking their fixed-sleep timing budgets).
+
+## Decision
+
+Supply events are **pushed to consumers**, never polled:
+
+- A new primitive, `crate::value::waker::ReactWaker`, is a cloneable
+  event queue + condvar. Producers `push(key, SinkEvent::{Emit,Done,Quit})`
+  or `notify()` (bare wake); the consumer `drain()`s and, when idle,
+  `wait_activity(cap)`s (GC-quiescent via `block_quiescent`).
+- The supplier registry keeps a list of **sinks** per supplier
+  (`supplier_sink_register/unregister`). `supplier_emit/done/quit` push to
+  every registered sink *under the registry lock*, so (a) push order equals
+  emit order across suppliers, and (b) a later `supplier_reset` cannot
+  un-publish an event. Registration replays the currently-buffered values
+  (and a pending done/quit) into the queue under the same lock acquisition,
+  so nothing falls between replay and subscription. The old cross-supplier
+  `emit_seqs` merge machinery is deleted — queue order *is* emit order.
+- The react drive loop consumes its waker queue for supplier-backed
+  subscriptions, and blocks on the waker when a round makes no progress.
+  `SharedPromise` sources wake it via `on_resolve`; `SharedChannel` sources
+  via a registered-waker poke on `send/close/fail`. The remaining polled
+  sources (mpsc receivers from tap/Proc/zip threads, pending tap-close
+  promises) bound the idle wait to 10ms — the same worst-case latency as
+  before, with zero spin and instant wake for the dominant sources.
+- `supply_list_values`, the throttle control waits, and `Promise.anyof`
+  drop their sleep-poll loops for the same sink/`on_resolve` mechanisms.
+- `Supply.interval` no longer spawns a sleep-loop OS thread per instance:
+  a single process-wide driver thread (`interval_timer.rs`) fires every
+  interval off a deadline min-heap, waiting on a condvar until the earliest
+  deadline (Rakudo-style single timer queue). S17-supply/syntax.t creates
+  2000 short-lived 1ms intervals; per-instance threads turned that into
+  ~195k `clock_nanosleep` calls per run (~42k/s), each wake-up paying
+  scheduler latency under load. With the shared timer the file makes zero
+  `clock_nanosleep` calls on interval-heavy sections.
+- `Supply.throttle(0, &block, :control)` runs its block with
+  `effective_limit`-way **real concurrency** (worker threads pulling from a
+  shared index, delivery serialized per Raku's per-tap guarantee, emission
+  order = completion order) instead of serially; the non-block path vents
+  its first batch immediately on receiving the control limit (Rakudo
+  semantics), doubling the timing margin of throttle.t's fixed-sleep tests.
+
+Lock ordering: supplier registry lock → waker mutex, everywhere (producers
+push under the registry lock; the consumer holds only the waker mutex while
+draining/waiting and never calls into the registry under it). Waker queues
+are GC root containers, visited via the supplier sinks in
+`visit_supply_state_roots`.
+
+## Consequences
+
+- `react whenever $supplier` waits at ~0% CPU and wakes in the emit's
+  lock-handoff time. The done/emit-loss race is structurally impossible.
+- Cross-thread `emit`s before a consumer registers are still delivered
+  (replay), matching the previous mutsu semantics that the late-registering
+  drive loop depends on (`react { whenever $sup {...}; $s.emit(...) }`).
+  Live-supply drops of pre-tap emits (Rakudo semantics) remain a known,
+  pre-existing divergence.
+- mpsc-receiver sources still poll at a 10ms cap; migrating them onto the
+  waker (routing tap channels through sinks) is the natural follow-up if
+  their latency ever matters.
+- Pinned by `t/react-supplier-done.t`; S17 roast (99 files) is the
+  regression net.

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,48 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-17: push-based supply event delivery — react busy-spin, lost done/emit, serial throttle all fixed (ADR-0008)
+
+The oldest concurrency mechanism in the codebase — snapshot-polling supply
+consumers — was replaced with push delivery (`ReactWaker` sinks; see
+[ADR-0008](../docs/adr/0008-push-based-supply-event-delivery.md)). Root-caused
+from the S17 CI load-flakiness investigation; the poll architecture had four
+structural defects:
+
+- **A react over supplier-backed sources busy-spun at 100% CPU** (no blocking
+  point in the drive loop at all). `react whenever $s.Supply { }` burned a
+  core for its lifetime and hammered the supplier-registry mutex.
+- **`Supplier.done` lost events**: it fires callbacks then resets the registry
+  entry, so a poller that hadn't seen the flag (or the values emitted just
+  before) lost them forever — `start { $s.emit(1); $s.emit(2); $s.done }` +
+  `react whenever $s.Supply` delivered only `1`, then hung. Now impossible by
+  construction: emit/done/quit are pushed into consumer queues under the
+  registry lock before any reset.
+- **Quadratic clone churn**: `supplier_snapshot_seqs` cloned the entire emit
+  history per delivered value (the `emit_seqs` merge machinery is deleted —
+  push order *is* emit order).
+- **1ms/10ms `thread::sleep` polls** (supply list wait, throttle control
+  waits, `Promise.anyof`) amplified wall time badly under CPU contention —
+  the mechanism behind mutsu running S17 1.5–2× slower than raku under load.
+  All converted to condvar waits (`wait_activity`, `on_resolve`, channel
+  wake hooks).
+
+`Supply.throttle(0, &block, :control)` also ran its block **serially**; it now
+runs `effective_limit`-way concurrent workers (emission = completion order,
+delivery serialized), and the non-block path vents its first batch immediately
+on receiving the control limit (Rakudo semantics) — throttle.t's fixed-sleep
+margins roughly doubled. `Supplier.quit(Str)` wraps its reason in `X::AdHoc`
+(instances pass through untouched, so `when MyException` still matches).
+
+`Supply.interval` moved onto a **shared timer thread** (deadline min-heap +
+condvar, `interval_timer.rs`) instead of one 1ms-sleep-loop OS thread per
+interval instance — syntax.t (2000 short-lived intervals) went from ~195k
+`clock_nanosleep` syscalls per run to zero on those sections, and its debug
+CPU time dropped from ~206s to under 30s.
+
+An idle `react whenever $supplier` now waits at ~0 CPU and wakes in the emit's
+lock-handoff time. Pin: `t/react-supplier-done.t`.
+
 ## 2026-07-16: integration/advent2012-day09 + advent2011-day11 whitelisted (frugal-ratchet + sigspace-capture + EVAL fixes)
 
 Two ★-frontier `integration/` files reached the whitelist (both full raku pass),

--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -69,30 +69,38 @@ impl Interpreter {
             } else {
                 None
             };
-            let mut seen_emitted = 0usize;
-            loop {
-                let (emitted, done, quit_reason) =
-                    crate::runtime::native_methods::supplier_snapshot(supplier_id);
-                if emitted.len() > seen_emitted {
-                    items.extend_from_slice(&emitted[seen_emitted..]);
-                    seen_emitted = emitted.len();
+            // Consume the supplier through a push sink: registration replays
+            // the already-buffered values, then emit/done/quit arrive as
+            // events — a blocking wait instead of the old 1ms snapshot poll
+            // (which also lost a done that `Supplier.done`'s reset cleared
+            // before the next poll).
+            let waker = crate::value::waker::ReactWaker::new();
+            let sink_id =
+                crate::runtime::native_methods::supplier_sink_register(supplier_id, 0, &waker);
+            let collected: Result<(), RuntimeError> = 'collect: loop {
+                for (_, event) in waker.drain() {
+                    match event {
+                        crate::value::waker::SinkEvent::Emit(v) => items.push(v),
+                        crate::value::waker::SinkEvent::Quit(reason) => {
+                            let message = reason.to_string_value();
+                            let mut err = RuntimeError::new(message);
+                            err.exception = Some(Box::new(reason));
+                            break 'collect Err(err);
+                        }
+                        crate::value::waker::SinkEvent::Done => break 'collect Ok(()),
+                    }
                 }
-                if let Some(reason) = quit_reason {
-                    let message = reason.to_string_value();
-                    let mut err = RuntimeError::new(message);
-                    err.exception = Some(Box::new(reason));
-                    return Err(err);
+                let Some(limit) = deadline else {
+                    break Ok(());
+                };
+                let now = std::time::Instant::now();
+                if now >= limit {
+                    break Ok(());
                 }
-                if done || deadline.is_none() {
-                    break;
-                }
-                if let Some(limit) = deadline
-                    && std::time::Instant::now() >= limit
-                {
-                    break;
-                }
-                std::thread::sleep(std::time::Duration::from_millis(1));
-            }
+                waker.wait_activity((limit - now).min(std::time::Duration::from_millis(100)));
+            };
+            crate::runtime::native_methods::supplier_sink_unregister(supplier_id, sink_id);
+            collected?;
         }
 
         Ok(items)

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1353,29 +1353,14 @@ impl Interpreter {
                     map.insert(supply_id, rx);
                 }
 
-                // Registered spawn (emits `Value`s into a supply channel);
-                // the interval sleeps are quiescent safe regions — see
-                // `spawn_gc_helper_thread`.
-                crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
-                    let period = std::time::Duration::from_secs_f64(period_secs);
-                    let mut tick = 0i64;
-                    // Initial delay before first emission (default 0 = immediate)
-                    if initial_delay > 0.0 {
-                        crate::gc::block_quiescent(|| {
-                            std::thread::sleep(std::time::Duration::from_secs_f64(initial_delay))
-                        });
-                    }
-                    loop {
-                        if tx
-                            .send(super::native_methods::SupplyEvent::Emit(Value::int(tick)))
-                            .is_err()
-                        {
-                            break;
-                        }
-                        tick = tick.saturating_add(1);
-                        crate::gc::block_quiescent(|| std::thread::sleep(period));
-                    }
-                });
+                // Ticks are driven by the process-wide shared interval timer
+                // (one deadline-heap thread), not a sleep-loop thread per
+                // interval instance. The entry dies when the receiver drops.
+                super::native_methods::interval_timer::register_interval(
+                    std::time::Duration::from_secs_f64(period_secs),
+                    std::time::Duration::from_secs_f64(initial_delay),
+                    tx,
+                );
 
                 let mut attrs = HashMap::new();
                 attrs.insert("values".to_string(), Value::array(Vec::new()));

--- a/src/runtime/methods_promise_class.rs
+++ b/src/runtime/methods_promise_class.rs
@@ -180,20 +180,15 @@ impl Interpreter {
                 promise.keep(Value::TRUE, String::new(), String::new());
                 return Some(Ok(ret));
             }
-            // Registered spawn + quiescent poll sleep — this thread drops its
-            // `Gc` promise handles at exit (see `spawn_gc_helper_thread`).
-            crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
-                // Poll until any promise resolves
-                loop {
-                    for p in &promises {
-                        if p.status() != "Planned" {
-                            promise.keep(Value::TRUE, String::new(), String::new());
-                            return;
-                        }
-                    }
-                    crate::gc::block_quiescent(|| std::thread::sleep(Duration::from_millis(1)));
-                }
-            });
+            // Resolve on the first input to settle, via each input's
+            // `on_resolve` waiter queue — no polling thread. `try_keep` makes
+            // the first resolver win and later ones no-ops.
+            for p in &promises {
+                let anyof = promise.clone();
+                let _ = p.on_resolve(Box::new(move |_, _, _, _| {
+                    let _ = anyof.try_keep(Value::TRUE);
+                }));
+            }
             return Some(Ok(ret));
         }
         None

--- a/src/runtime/native_methods/interval_timer.rs
+++ b/src/runtime/native_methods/interval_timer.rs
@@ -1,0 +1,123 @@
+//! Shared interval timer: one process-wide thread drives every
+//! `Supply.interval` emitter off a deadline min-heap, instead of one
+//! 1ms-sleep-loop OS thread per interval instance (which multiplied into
+//! thousands of `clock_nanosleep` wake-ups per second on interval-heavy
+//! workloads — S17-supply/syntax.t creates 2000 short-lived 1ms intervals —
+//! and amplified badly under CPU contention). This mirrors how Rakudo's
+//! scheduler drives intervals from a single timer queue.
+//!
+//! An entry dies when its channel receiver is dropped (`send` fails), same
+//! lifecycle as the old per-instance thread.
+use crate::runtime::native_methods::SupplyEvent;
+use crate::value::Value;
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::sync::mpsc::Sender;
+use std::sync::{Condvar, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+struct IntervalEntry {
+    next: Instant,
+    period: Duration,
+    tick: i64,
+    tx: Sender<SupplyEvent>,
+}
+
+// BinaryHeap is a max-heap; order entries by Reverse(next) so `peek` is the
+// earliest deadline. Ties broken arbitrarily (registration order irrelevant).
+impl PartialEq for IntervalEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.next == other.next
+    }
+}
+impl Eq for IntervalEntry {}
+impl PartialOrd for IntervalEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for IntervalEntry {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        Reverse(self.next).cmp(&Reverse(other.next))
+    }
+}
+
+type TimerState = (Mutex<BinaryHeap<IntervalEntry>>, Condvar);
+
+fn timer_state() -> &'static TimerState {
+    static STATE: OnceLock<&'static TimerState> = OnceLock::new();
+    STATE.get_or_init(|| {
+        let state: &'static TimerState =
+            Box::leak(Box::new((Mutex::new(BinaryHeap::new()), Condvar::new())));
+        // One long-lived driver thread for the whole process. It only touches
+        // scalar `Value`s (`Value::int` ticks — no Gc payload), and parks
+        // quiescent while waiting, so it is safe as a GC helper.
+        crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
+            let (heap, cvar) = state;
+            let mut guard = heap.lock().unwrap();
+            loop {
+                let now = Instant::now();
+                match guard.peek() {
+                    None => {
+                        // Nothing scheduled: sleep until a registration pokes
+                        // us. Bounded waits keep the thread responsive to a
+                        // GC stop-the-world (block_quiescent would pin the
+                        // heap lock; short chunks avoid holding anything
+                        // during the actual wait).
+                        let (g, _) = crate::gc::block_quiescent(|| {
+                            cvar.wait_timeout(guard, Duration::from_millis(500))
+                                .unwrap()
+                        });
+                        guard = g;
+                    }
+                    Some(entry) if entry.next > now => {
+                        let wait = entry.next - now;
+                        let (g, _) =
+                            crate::gc::block_quiescent(|| cvar.wait_timeout(guard, wait).unwrap());
+                        guard = g;
+                    }
+                    Some(_) => {
+                        let mut entry = guard.pop().unwrap();
+                        if entry
+                            .tx
+                            .send(SupplyEvent::Emit(Value::int(entry.tick)))
+                            .is_ok()
+                        {
+                            entry.tick = entry.tick.saturating_add(1);
+                            // Fixed-rate schedule, but never a catch-up burst:
+                            // if we fell behind (loaded host), skip ahead.
+                            entry.next += entry.period;
+                            let now = Instant::now();
+                            if entry.next < now {
+                                entry.next = now + entry.period;
+                            }
+                            guard.push(entry);
+                        }
+                        // send failed → receiver gone → entry dropped.
+                    }
+                }
+            }
+        });
+        state
+    })
+}
+
+/// Register a new interval emitter: first emission after `initial_delay`
+/// (0 = as soon as the driver runs), then every `period`. Emits monotonically
+/// increasing ticks (0, 1, 2, ...) as `SupplyEvent::Emit(Int)` into `tx`
+/// until the receiver is dropped.
+pub(crate) fn register_interval(
+    period: Duration,
+    initial_delay: Duration,
+    tx: Sender<SupplyEvent>,
+) {
+    let (heap, cvar) = timer_state();
+    let mut guard = heap.lock().unwrap();
+    guard.push(IntervalEntry {
+        next: Instant::now() + initial_delay,
+        period,
+        tick: 0,
+        tx,
+    });
+    cvar.notify_all();
+}

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -1,6 +1,7 @@
 // Native method dispatch submodules, split from the original native_methods.rs
 mod concurrency;
 mod encoding;
+pub(crate) mod interval_timer;
 mod proc;
 mod scheduler;
 mod socket_async;
@@ -38,8 +39,8 @@ pub(in crate::runtime) use state::{
 };
 // Supplier registry accessors driven by the VM-side react/supply loop.
 pub(crate) use state::{
-    next_supplier_id, supplier_register_promise, supplier_snapshot, supplier_snapshot_seqs,
-    take_promise_combinator_sources,
+    next_supplier_id, supplier_register_promise, supplier_sink_register, supplier_sink_unregister,
+    supplier_snapshot, take_promise_combinator_sources,
 };
 pub(in crate::runtime) use state_lock::next_lock_id;
 pub(in crate::runtime) use state_lock::next_semaphore_id;

--- a/src/runtime/native_methods/state.rs
+++ b/src/runtime/native_methods/state.rs
@@ -160,22 +160,24 @@ pub(in crate::runtime) fn supply_channel_map_pub()
 #[derive(Debug, Default)]
 struct SupplierRuntimeState {
     emitted: Vec<Value>,
-    /// Global monotonic sequence number for each emitted value, parallel to
-    /// `emitted`. Assigned at `emit` time from a process-wide counter so the
-    /// react drive loop can merge values from several supplier-backed
-    /// subscriptions (e.g. two `whenever $s.grep(...)` derived supplies) back
-    /// into their original cross-supplier emit order.
-    emit_seqs: Vec<u64>,
     done: bool,
     quit_reason: Option<Value>,
     pending_promises: Vec<SharedPromise>,
+    /// Push sinks registered by consuming drive loops (react / `await
+    /// $supply` / control waits). Every emit/done/quit is pushed to each
+    /// registered sink under this registry's lock, so a later
+    /// `supplier_reset` cannot un-publish an event — the old snapshot-polling
+    /// scheme both busy-spun consumers and lost events when `Supplier.done`
+    /// reset the state before the consumer's next poll.
+    sinks: Vec<SupplierSink>,
 }
 
-/// Process-wide monotonic counter handing out an emit sequence number for every
-/// `supplier_emit`, so cross-supplier delivery order can be reconstructed.
-pub(crate) fn next_emit_seq() -> u64 {
-    static COUNTER: AtomicU64 = AtomicU64::new(1);
-    COUNTER.fetch_add(1, Ordering::Relaxed)
+#[derive(Debug)]
+struct SupplierSink {
+    sink_id: u64,
+    /// The consumer-side subscription index this sink feeds.
+    key: usize,
+    waker: crate::value::waker::ReactWaker,
 }
 
 type SupplierStateMap = std::sync::Mutex<HashMap<u64, SupplierRuntimeState>>;
@@ -189,6 +191,45 @@ pub(in crate::runtime) fn supplier_id_from_attrs(attributes: &AttrMap) -> Option
     match attributes.get("supplier_id").and_then(|v| v.as_int()) {
         Some(id) if id > 0 => Some(id as u64),
         _ => None,
+    }
+}
+
+/// Register a push sink on a supplier: replay everything a fresh polling
+/// subscription would have observed (the buffered values, then a pending
+/// done/quit), then subscribe the waker to all future emit/done/quit events.
+/// Replay and subscription happen under one lock acquisition, so no event can
+/// fall between them. Returns a sink id for `supplier_sink_unregister`.
+pub(crate) fn supplier_sink_register(
+    supplier_id: u64,
+    key: usize,
+    waker: &crate::value::waker::ReactWaker,
+) -> u64 {
+    static SINK_IDS: AtomicU64 = AtomicU64::new(1);
+    let sink_id = SINK_IDS.fetch_add(1, Ordering::Relaxed);
+    if let Ok(mut map) = supplier_state_map().lock() {
+        let state = map.entry(supplier_id).or_default();
+        for v in &state.emitted {
+            waker.push(key, crate::value::waker::SinkEvent::Emit(v.clone()));
+        }
+        if let Some(reason) = &state.quit_reason {
+            waker.push(key, crate::value::waker::SinkEvent::Quit(reason.clone()));
+        } else if state.done {
+            waker.push(key, crate::value::waker::SinkEvent::Done);
+        }
+        state.sinks.push(SupplierSink {
+            sink_id,
+            key,
+            waker: waker.clone(),
+        });
+    }
+    sink_id
+}
+
+pub(crate) fn supplier_sink_unregister(supplier_id: u64, sink_id: u64) {
+    if let Ok(mut map) = supplier_state_map().lock()
+        && let Some(state) = map.get_mut(&supplier_id)
+    {
+        state.sinks.retain(|s| s.sink_id != sink_id);
     }
 }
 
@@ -241,6 +282,9 @@ pub(in crate::runtime) fn visit_supply_state_roots(visitor: &mut dyn crate::gc::
             }
             for p in &state.pending_promises {
                 visitor.visit_value(&Value::promise(p.clone()));
+            }
+            for s in &state.sinks {
+                s.waker.visit_roots(visitor);
             }
         }
     }
@@ -341,32 +385,16 @@ pub(crate) fn supplier_register_promise(supplier_id: u64, promise: SharedPromise
 }
 
 pub(in crate::runtime) fn supplier_emit(supplier_id: u64, value: Value) {
-    let seq = next_emit_seq();
     if let Ok(mut map) = supplier_state_map().lock() {
         let state = map.entry(supplier_id).or_default();
         if state.done || state.quit_reason.is_some() {
             return;
         }
+        for s in &state.sinks {
+            s.waker
+                .push(s.key, crate::value::waker::SinkEvent::Emit(value.clone()));
+        }
         state.emitted.push(value);
-        state.emit_seqs.push(seq);
-    }
-}
-
-/// Like [`supplier_snapshot`], but also returns the per-value emit sequence
-/// numbers (parallel to the values), for cross-supplier order reconstruction.
-pub(crate) fn supplier_snapshot_seqs(
-    supplier_id: u64,
-) -> (Vec<Value>, Vec<u64>, bool, Option<Value>) {
-    if let Ok(mut map) = supplier_state_map().lock() {
-        let state = map.entry(supplier_id).or_default();
-        (
-            state.emitted.clone(),
-            state.emit_seqs.clone(),
-            state.done,
-            state.quit_reason.clone(),
-        )
-    } else {
-        (Vec::new(), Vec::new(), false, None)
     }
 }
 
@@ -377,6 +405,9 @@ pub(in crate::runtime) fn supplier_done(supplier_id: u64) {
             return;
         }
         state.done = true;
+        for s in &state.sinks {
+            s.waker.push(s.key, crate::value::waker::SinkEvent::Done);
+        }
         let result = state.emitted.last().cloned().unwrap_or(Value::NIL);
         let pending = std::mem::take(&mut state.pending_promises);
         for promise in pending {
@@ -397,6 +428,9 @@ pub(in crate::runtime) fn supplier_done_deferred(
             return Vec::new();
         }
         state.done = true;
+        for s in &state.sinks {
+            s.waker.push(s.key, crate::value::waker::SinkEvent::Done);
+        }
         let result = state.emitted.last().cloned().unwrap_or(Value::NIL);
         let pending = std::mem::take(&mut state.pending_promises);
         pending.into_iter().map(|p| (p, result.clone())).collect()
@@ -412,6 +446,10 @@ pub(in crate::runtime) fn supplier_quit(supplier_id: u64, reason: Value) {
             return;
         }
         state.quit_reason = Some(reason.clone());
+        for s in &state.sinks {
+            s.waker
+                .push(s.key, crate::value::waker::SinkEvent::Quit(reason.clone()));
+        }
         let pending = std::mem::take(&mut state.pending_promises);
         for promise in pending {
             promise.break_with(reason.clone(), String::new(), String::new());
@@ -427,7 +465,6 @@ pub(in crate::runtime) fn supplier_reset(supplier_id: u64) {
         state.done = false;
         state.quit_reason = None;
         state.emitted.clear();
-        state.emit_seqs.clear();
     }
 }
 

--- a/src/runtime/native_supplier_methods.rs
+++ b/src/runtime/native_supplier_methods.rs
@@ -371,10 +371,21 @@ impl Interpreter {
                 Ok(Value::NIL)
             }
             "quit" => {
+                // Raku wraps a non-exception quit reason (a plain Str) in
+                // X::AdHoc, so a `QUIT { default { .message } }` handler works
+                // either way. Object instances (user exception classes like
+                // `my class OMGBears is Exception`) pass through untouched —
+                // `as_exception_value`'s name-based check cannot see `is
+                // Exception` ancestry, so gate on the value shape instead.
                 let reason = args
                     .first()
                     .cloned()
                     .unwrap_or_else(|| Value::str_from("Died"));
+                let reason = if matches!(reason.view(), ValueView::Instance { .. }) {
+                    reason
+                } else {
+                    Self::as_exception_value(reason)
+                };
                 if let Some(supplier_id) = supplier_id_from_attrs(attributes) {
                     supplier_quit(supplier_id, reason.clone());
                     close_supplier_channel_taps(supplier_id, Some(reason.clone()));
@@ -803,10 +814,21 @@ impl Interpreter {
                 Ok((Value::NIL, attrs))
             }
             "quit" => {
+                // Raku wraps a non-exception quit reason (a plain Str) in
+                // X::AdHoc, so a `QUIT { default { .message } }` handler works
+                // either way. Object instances (user exception classes like
+                // `my class OMGBears is Exception`) pass through untouched —
+                // `as_exception_value`'s name-based check cannot see `is
+                // Exception` ancestry, so gate on the value shape instead.
                 let reason = args
                     .first()
                     .cloned()
                     .unwrap_or_else(|| Value::str_from("Died"));
+                let reason = if matches!(reason.view(), ValueView::Instance { .. }) {
+                    reason
+                } else {
+                    Self::as_exception_value(reason)
+                };
                 attrs.insert("done".to_string(), Value::TRUE);
                 attrs.insert("quit_reason".to_string(), reason.clone());
                 if let Some(supplier_id) = supplier_id_from_attrs(&attrs) {

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -7,7 +7,6 @@ use std::sync::mpsc;
 pub(crate) struct ReactSubscription {
     pub receiver: Option<mpsc::Receiver<SupplyEvent>>,
     pub supplier_id: Option<u64>,
-    pub supplier_next_index: usize,
     pub callback: Value,
     pub close_callbacks: Vec<Value>,
     pub last_callbacks: Vec<Value>,
@@ -44,7 +43,6 @@ impl ReactSubscription {
         ReactSubscription {
             receiver: None,
             supplier_id: None,
-            supplier_next_index: 0,
             callback,
             close_callbacks: Vec::new(),
             last_callbacks: Vec::new(),

--- a/src/runtime/supply_transform.rs
+++ b/src/runtime/supply_transform.rs
@@ -5,6 +5,33 @@ use super::*;
 use crate::symbol::Symbol;
 use crate::value::AttrMap;
 
+/// Block until the control supplier emits a `limit:N` directive (or the 30s
+/// bound elapses), consuming it through a push sink — registration replays a
+/// directive that was emitted before we started listening, and later emits
+/// wake the wait instantly (the old 10ms snapshot poll both lagged and could
+/// miss a directive cleared by a supplier reset).
+fn wait_for_control_limit(ctrl_id: u64) -> i64 {
+    let waker = crate::value::waker::ReactWaker::new();
+    let sink_id = supplier_sink_register(ctrl_id, 0, &waker);
+    let mut current_limit: i64 = 0;
+    let start = std::time::Instant::now();
+    while current_limit == 0 && start.elapsed() < std::time::Duration::from_secs(30) {
+        for (_, event) in waker.drain() {
+            if let crate::value::waker::SinkEvent::Emit(val) = event
+                && let Some(rest) = val.to_string_value().strip_prefix("limit:")
+                && let Ok(n) = rest.trim().parse::<i64>()
+            {
+                current_limit = n;
+            }
+        }
+        if current_limit == 0 {
+            waker.wait_activity(std::time::Duration::from_millis(100));
+        }
+    }
+    supplier_sink_unregister(ctrl_id, sink_id);
+    current_limit
+}
+
 impl Interpreter {
     /// Implement Supply.throttle($limit, $seconds-or-block, :$control, :$status)
     pub(super) fn supply_throttle(
@@ -49,51 +76,77 @@ impl Interpreter {
                 let blk = block;
                 let mut thread_interp = self.clone_for_thread();
                 // Runs a full interpreter (VM safepoints park it during
-                // execution): registered GC mutator; idle poll sleeps are
-                // quiescent safe regions.
+                // execution): registered GC mutator; the control wait and the
+                // worker joins are quiescent safe regions.
                 crate::runtime::builtins_system::spawn_user_thread(move || {
-                    let mut current_limit: i64 = 0;
-                    let start = std::time::Instant::now();
-                    while current_limit == 0 && start.elapsed() < std::time::Duration::from_secs(30)
-                    {
-                        let (emitted, _, _) = supplier_snapshot(ctrl_id);
-                        for val in &emitted {
-                            let s = val.to_string_value();
-                            if let Some(rest) = s.strip_prefix("limit:")
-                                && let Ok(n) = rest.trim().parse::<i64>()
-                            {
-                                current_limit = n;
-                            }
-                        }
-                        if current_limit == 0 {
-                            crate::gc::block_quiescent(|| {
-                                std::thread::sleep(std::time::Duration::from_millis(10))
-                            });
-                        }
-                    }
+                    let current_limit = wait_for_control_limit(ctrl_id);
                     let effective_limit = if current_limit > 0 {
                         current_limit
                     } else {
                         vals.len() as i64
                     };
-                    let mut emitted_count = 0i64;
-                    for val in &vals {
-                        if let Ok(result) =
-                            thread_interp.call_sub_value(blk.clone(), vec![val.clone()], false)
-                        {
-                            let promise = SharedPromise::new_kept(result);
-                            let pval = Value::promise(promise);
-                            supplier_emit(out_supplier_id, pval.clone());
-                            let actions = supplier_emit_callbacks(out_supplier_id, &pval);
-                            for action in actions {
-                                if let SupplierEmitAction::Call(tap, emitted, delay) = action {
-                                    Self::sleep_for_supply_delay(delay);
-                                    let _ = thread_interp.call_sub_value(tap, vec![emitted], true);
+                    // Run the process block with `effective_limit`-way
+                    // concurrency (Raku semantics: throttle limits how many
+                    // jobs run at once, it does not serialize them). Each
+                    // completed job emits its kept promise immediately, so
+                    // emission order is completion order; delivery itself is
+                    // serialized per Raku's per-tap guarantee.
+                    let n_workers = (effective_limit.max(1) as usize).min(vals.len().max(1));
+                    let next_idx = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+                    let emit_lock = Arc::new(std::sync::Mutex::new(()));
+                    let emitted_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+                    let vals = Arc::new(vals);
+                    let mut handles = Vec::with_capacity(n_workers);
+                    for _ in 0..n_workers {
+                        let mut winterp = thread_interp.clone_for_thread();
+                        let vals = Arc::clone(&vals);
+                        let blk = blk.clone();
+                        let next_idx = Arc::clone(&next_idx);
+                        let emit_lock = Arc::clone(&emit_lock);
+                        let emitted_count = Arc::clone(&emitted_count);
+                        handles.push(crate::runtime::builtins_system::spawn_user_thread(
+                            move || {
+                                loop {
+                                    let idx =
+                                        next_idx.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                    if idx >= vals.len() {
+                                        break;
+                                    }
+                                    if let Ok(result) = winterp.call_sub_value(
+                                        blk.clone(),
+                                        vec![vals[idx].clone()],
+                                        false,
+                                    ) {
+                                        let promise = SharedPromise::new_kept(result);
+                                        let pval = Value::promise(promise);
+                                        let _guard = emit_lock.lock().unwrap();
+                                        supplier_emit(out_supplier_id, pval.clone());
+                                        let actions =
+                                            supplier_emit_callbacks(out_supplier_id, &pval);
+                                        for action in actions {
+                                            if let SupplierEmitAction::Call(tap, emitted, delay) =
+                                                action
+                                            {
+                                                Self::sleep_for_supply_delay(delay);
+                                                let _ = winterp.call_sub_value(
+                                                    tap,
+                                                    vec![emitted],
+                                                    true,
+                                                );
+                                            }
+                                        }
+                                        emitted_count
+                                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                    }
                                 }
-                            }
-                            emitted_count += 1;
-                        }
+                            },
+                        ));
                     }
+                    for handle in handles {
+                        let _ = crate::gc::block_quiescent(|| handle.join());
+                    }
+                    let emitted_count =
+                        emitted_count.load(std::sync::atomic::Ordering::Relaxed) as i64;
                     if let Some(status_id) = status_sid {
                         let mut status_hash = HashMap::new();
                         status_hash.insert("allowed".to_string(), Value::int(effective_limit));
@@ -151,34 +204,20 @@ impl Interpreter {
             let vals = source_values;
             let secs = seconds;
             let mut thread_interp = self.clone_for_thread();
-            // Registered GC mutator (runs a full interpreter); idle poll
-            // sleeps are quiescent safe regions.
+            // Registered GC mutator (runs a full interpreter); the control
+            // wait is a quiescent safe region.
             crate::runtime::builtins_system::spawn_user_thread(move || {
-                let mut current_limit: i64 = 0;
-                let start = std::time::Instant::now();
-                while current_limit == 0 && start.elapsed() < std::time::Duration::from_secs(30) {
-                    let (emitted, _, _) = supplier_snapshot(ctrl_id);
-                    for val in &emitted {
-                        let s = val.to_string_value();
-                        if let Some(rest) = s.strip_prefix("limit:")
-                            && let Ok(n) = rest.trim().parse::<i64>()
-                        {
-                            current_limit = n;
-                        }
-                    }
-                    if current_limit == 0 {
-                        crate::gc::block_quiescent(|| {
-                            std::thread::sleep(std::time::Duration::from_millis(10))
-                        });
-                    }
-                }
+                let current_limit = wait_for_control_limit(ctrl_id);
                 let effective_limit = if current_limit > 0 {
                     current_limit as usize
                 } else {
                     vals.len()
                 };
                 for (idx, val) in vals.iter().enumerate() {
-                    if secs > 0.0 && effective_limit > 0 && idx % effective_limit == 0 {
+                    // The first batch vents immediately once the limit is
+                    // known (Rakudo emits as soon as capacity allows); the
+                    // inter-batch delay applies between subsequent batches.
+                    if secs > 0.0 && effective_limit > 0 && idx > 0 && idx % effective_limit == 0 {
                         Self::sleep_for_supply_delay(secs);
                     }
                     supplier_emit(out_supplier_id, val.clone());

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -313,6 +313,7 @@ mod value_methods_b;
 mod value_methods_c;
 mod value_setbagmix;
 mod view;
+pub(crate) mod waker;
 pub(crate) use crate::gc::gc_contents_mut;
 pub(crate) use aliased_mut::arc_contents_mut;
 pub(crate) use aliased_mut::gc_data_mut;
@@ -1884,6 +1885,9 @@ struct ChannelState {
     failure: Option<Value>,
     closed_promise: SharedPromise,
     supplier_ids: Vec<u64>,
+    /// Drive-loop wakers to poke on every send/close/fail, so a react
+    /// polling this channel wakes immediately instead of on its poll cap.
+    wakers: Vec<crate::value::waker::ReactWaker>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/value/value_async.rs
+++ b/src/value/value_async.rs
@@ -262,6 +262,7 @@ impl SharedChannel {
                     failure: None,
                     closed_promise,
                     supplier_ids: Vec::new(),
+                    wakers: Vec::new(),
                 }),
                 Condvar::new(),
             )),
@@ -276,6 +277,9 @@ impl SharedChannel {
         }
         state.queue.push_back(value);
         cvar.notify_one();
+        for w in &state.wakers {
+            w.notify();
+        }
     }
 
     fn finish_if_drained(state: &mut ChannelState) {
@@ -335,6 +339,9 @@ impl SharedChannel {
         state.send_closed = true;
         Self::finish_if_drained(&mut state);
         cvar.notify_all();
+        for w in &state.wakers {
+            w.notify();
+        }
     }
 
     pub(crate) fn fail(&self, error: Value) {
@@ -344,6 +351,9 @@ impl SharedChannel {
         state.failure = Some(error);
         Self::finish_if_drained(&mut state);
         cvar.notify_all();
+        for w in &state.wakers {
+            w.notify();
+        }
     }
 
     pub(crate) fn closed_promise(&self) -> SharedPromise {
@@ -366,6 +376,22 @@ impl SharedChannel {
     pub(crate) fn is_drained_closed(&self) -> bool {
         let (lock, _) = &*self.inner;
         lock.lock().unwrap().drained_closed
+    }
+
+    /// Register a drive-loop waker to poke on future send/close/fail (no-op
+    /// if this exact waker is already registered).
+    pub(crate) fn register_waker(&self, waker: &crate::value::waker::ReactWaker) {
+        let (lock, _) = &*self.inner;
+        let mut state = lock.lock().unwrap();
+        if !state.wakers.iter().any(|w| w.id() == waker.id()) {
+            state.wakers.push(waker.clone());
+        }
+    }
+
+    pub(crate) fn unregister_waker(&self, waker_id: usize) {
+        let (lock, _) = &*self.inner;
+        let mut state = lock.lock().unwrap();
+        state.wakers.retain(|w| w.id() != waker_id);
     }
 
     pub(crate) fn add_supplier(&self, supplier_id: u64) {

--- a/src/value/waker.rs
+++ b/src/value/waker.rs
@@ -1,0 +1,109 @@
+//! `ReactWaker`: a per-consumer event queue + condvar used to deliver supply
+//! events (emit/done/quit) from producer threads to a consuming drive loop
+//! (`react`, `await $supply`, throttle control waits, ...) without polling.
+//!
+//! Producers push events (or bare wake-ups) under their own registry lock;
+//! the consumer drains the queue and blocks on the condvar when idle. This
+//! replaces the old snapshot-polling scheme, which both busy-spun the
+//! consumer thread and could *lose* events when a producer reset its state
+//! (e.g. `Supplier.done` clearing the emitted buffer) before the consumer's
+//! next poll observed it. Pushed events are owned by the queue, so a
+//! producer-side reset can no longer un-publish them.
+//!
+//! Lock ordering: a producer may take a registry lock (e.g. the supplier
+//! state map) and then this queue's mutex. The consumer takes only this
+//! queue's mutex while draining/waiting, and never calls back into producer
+//! registries while holding it.
+use crate::value::Value;
+use std::collections::VecDeque;
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Duration;
+
+/// One event delivered to a consumer. `key` (stored alongside in the queue)
+/// identifies which subscription of the consumer the event belongs to.
+#[derive(Debug, Clone)]
+pub(crate) enum SinkEvent {
+    Emit(Value),
+    Done,
+    Quit(Value),
+}
+
+#[derive(Debug, Default)]
+struct WakerState {
+    events: VecDeque<(usize, SinkEvent)>,
+    /// Set by `notify()` (a bare wake-up with no event payload, e.g. a
+    /// promise resolving or a channel send). Cleared by the next wait.
+    poked: bool,
+}
+
+/// Cloneable handle; all clones share the same queue.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ReactWaker {
+    inner: Arc<(Mutex<WakerState>, Condvar)>,
+}
+
+impl ReactWaker {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Identity of the shared queue, for registry deduplication/removal.
+    pub(crate) fn id(&self) -> usize {
+        Arc::as_ptr(&self.inner) as usize
+    }
+
+    /// Queue an event for subscription `key` and wake the consumer.
+    pub(crate) fn push(&self, key: usize, event: SinkEvent) {
+        let (lock, cvar) = &*self.inner;
+        let mut state = lock.lock().unwrap();
+        state.events.push_back((key, event));
+        cvar.notify_all();
+    }
+
+    /// Bare wake-up: no event payload, just make the current/next
+    /// `wait_activity` return promptly so the consumer re-polls its
+    /// non-queue sources.
+    pub(crate) fn notify(&self) {
+        let (lock, cvar) = &*self.inner;
+        let mut state = lock.lock().unwrap();
+        state.poked = true;
+        cvar.notify_all();
+    }
+
+    /// Take all queued events (non-blocking).
+    pub(crate) fn drain(&self) -> Vec<(usize, SinkEvent)> {
+        let (lock, _) = &*self.inner;
+        let mut state = lock.lock().unwrap();
+        state.events.drain(..).collect()
+    }
+
+    /// Block until an event is queued, a `notify()` lands, or `timeout`
+    /// elapses. Counts the thread GC-quiescent for the duration (the wait
+    /// touches no `Gc` state). Consumes a pending poke.
+    pub(crate) fn wait_activity(&self, timeout: Duration) {
+        crate::gc::block_quiescent(|| {
+            let (lock, cvar) = &*self.inner;
+            let mut state = lock.lock().unwrap();
+            if state.events.is_empty() && !state.poked {
+                let (guard, _) = cvar.wait_timeout(state, timeout).unwrap();
+                state = guard;
+            }
+            state.poked = false;
+        });
+    }
+
+    /// Visit every `Value` held in queued events, for GC root enumeration
+    /// (this queue is a root container like the supplier registries: the
+    /// collector never frees it, but must see the `Value`s it keeps alive).
+    pub(crate) fn visit_roots(&self, visitor: &mut dyn crate::gc::RootVisitor) {
+        let (lock, _) = &*self.inner;
+        if let Ok(state) = lock.lock() {
+            for (_, ev) in &state.events {
+                match ev {
+                    SinkEvent::Emit(v) | SinkEvent::Quit(v) => visitor.visit_value(v),
+                    SinkEvent::Done => {}
+                }
+            }
+        }
+    }
+}

--- a/src/vm/vm_react_subscriptions.rs
+++ b/src/vm/vm_react_subscriptions.rs
@@ -1,132 +1,125 @@
 //! Shared react/supply subscription drive loop (`drive_react_subscriptions_nested`),
 //! split from `vm_react_loop` (§7-8 file split).
+//!
+//! Supplier-backed subscriptions are driven **push-style**: the drive loop
+//! registers a [`ReactWaker`] sink on each subscribed supplier, and every
+//! `emit`/`done`/`quit` is pushed into the waker's queue by the producer (under
+//! the supplier registry lock, so cross-supplier push order matches emit
+//! order). The loop drains that queue and blocks on the waker when idle. This
+//! replaces the old snapshot-polling scheme, which busy-spun a core per idle
+//! react and lost events when `Supplier.done` reset the registry state before
+//! the loop's next poll (roast S17: `react whenever $s { }` hung forever when
+//! `$s.done` raced the poll).
 use super::*;
 use crate::runtime::native_methods::{
-    SupplyEvent, supplier_snapshot_seqs, take_promise_combinator_sources,
+    SupplyEvent, supplier_sink_register, supplier_sink_unregister, take_promise_combinator_sources,
 };
 use crate::runtime::subtest::{ReactSubscription, SupplyDrivePolicy};
+use crate::value::waker::{ReactWaker, SinkEvent};
 use std::sync::mpsc;
 use std::time::Duration;
 
+/// Idle-wait cap for one drive-loop round. Supplier events, promise
+/// resolutions and channel sends wake the loop instantly; this cap only
+/// bounds the latency of the remaining polled sources (mpsc receivers,
+/// pending tap-close promises) and the Promise-policy deadline check.
+const REACT_IDLE_WAIT: Duration = Duration::from_millis(10);
+
 impl Interpreter {
-    /// Deliver every value currently buffered across all supplier-backed
-    /// subscriptions to their `whenever` consumers, merged into a single global
-    /// emit order (by each value's emit sequence number), then honour any
-    /// per-supplier `done`/`quit` signals. Returns `Ok(true)` if a consumer
-    /// raised react `done`; propagates `Err` for an unhandled supplier `quit`.
-    ///
-    /// Global-order merge (rather than draining one supplier fully before the
-    /// next) is what makes sibling `whenever $s.grep(...)` derived supplies
-    /// interleave the way Raku delivers them — each value reaches its consumer
-    /// in the order it was `emit`ted into the source, across suppliers. It also
-    /// honours Raku's ordering guarantee that values emitted before a later
-    /// terminating event are still delivered, since the polling loop calls this
-    /// both at the top of each iteration and just before running a receiver
-    /// (Promise / `start`) source's consumer.
-    fn drain_supplier_subs_ordered(
+    /// Deliver every event queued on the drive loop's waker to its
+    /// subscription's consumer, in push order (== the order producers
+    /// emitted, across suppliers: pushes happen under the one supplier
+    /// registry lock). Re-drains until the queue is quiet, since a consumer
+    /// may synchronously emit more. Sets `*progressed` when at least one
+    /// event was dispatched. Returns `Ok(true)` if a consumer raised react
+    /// `done`; propagates `Err` for an unhandled supplier `quit`.
+    fn dispatch_waker_events(
         &mut self,
+        waker: &ReactWaker,
         react_subs: &mut [ReactSubscription],
+        progressed: &mut bool,
     ) -> Result<bool, RuntimeError> {
-        // Deliver the globally-earliest pending value, one at a time; re-scan
-        // each round because a consumer may emit more or mark subs done.
         loop {
-            let mut best: Option<(u64, usize, Value)> = None;
-            for (i, sub) in react_subs.iter().enumerate() {
-                if sub.done {
+            let events = waker.drain();
+            if events.is_empty() {
+                return Ok(false);
+            }
+            *progressed = true;
+            for (key, event) in events {
+                if key >= react_subs.len() || react_subs[key].done {
                     continue;
                 }
-                let Some(sid) = sub.supplier_id else {
-                    continue;
-                };
-                if let Some(limit) = sub.head_limit
-                    && sub.emit_count >= limit
-                {
-                    continue;
-                }
-                let (values, seqs, _done, _quit) = supplier_snapshot_seqs(sid);
-                let idx = sub.supplier_next_index;
-                if idx < values.len() {
-                    let seq = seqs.get(idx).copied().unwrap_or(0);
-                    if best.as_ref().is_none_or(|(bseq, _, _)| seq < *bseq) {
-                        best = Some((seq, i, values[idx].clone()));
-                    }
-                }
-            }
-            let Some((_seq, i, value)) = best else {
-                break;
-            };
-            react_subs[i].supplier_next_index += 1;
-            if react_subs[i].is_lines {
-                let chunk = value.to_string_value();
-                react_subs[i].line_buffer.push_str(&chunk);
-                while let Some(pos) = react_subs[i].line_buffer.find('\n') {
-                    let line = react_subs[i].line_buffer[..pos].to_string();
-                    react_subs[i].line_buffer = react_subs[i].line_buffer[pos + 1..].to_string();
-                    if self.run_react_consumer(&mut react_subs[i], Value::str(line))? {
-                        return Ok(true);
-                    }
-                    if react_subs[i].done {
-                        break;
-                    }
-                    react_subs[i].emit_count += 1;
-                    if self.head_limit_reached(&mut react_subs[i])? {
-                        break;
-                    }
-                }
-            } else {
-                if self.run_react_consumer(&mut react_subs[i], value)? {
-                    return Ok(true);
-                }
-                if !react_subs[i].done {
-                    react_subs[i].emit_count += 1;
-                    self.head_limit_reached(&mut react_subs[i])?;
-                }
-            }
-        }
-        // All pending values delivered — now honour per-supplier done/quit.
-        for i in 0..react_subs.len() {
-            if react_subs[i].done {
-                continue;
-            }
-            let Some(sid) = react_subs[i].supplier_id else {
-                continue;
-            };
-            let (values, _seqs, done, quit) = supplier_snapshot_seqs(sid);
-            if react_subs[i].supplier_next_index < values.len() {
-                continue;
-            }
-            if let Some(error) = quit {
-                let mut handled = false;
-                for quit_cb in react_subs[i].quit_callbacks.clone() {
-                    self.call_supply_quit_handler(quit_cb, error.clone())?;
-                    handled = true;
-                }
-                if handled {
-                    react_subs[i].done = true;
-                    continue;
-                }
-                Self::run_react_close_callbacks(self, react_subs);
-                let quit_err = crate::runtime::Interpreter::runtime_error_from_supply_reason(error);
-                return Err(crate::runtime::Interpreter::wrap_react_died(quit_err));
-            }
-            if done {
-                if react_subs[i].is_lines && !react_subs[i].line_buffer.is_empty() {
-                    let remaining = std::mem::take(&mut react_subs[i].line_buffer);
-                    let cb = react_subs[i].callback.clone();
-                    match self.call_react_callback(&cb, vec![Value::str(remaining)]) {
-                        Err(e) if e.is_react_done() => return Ok(true),
-                        other => {
-                            other?;
+                match event {
+                    SinkEvent::Emit(value) => {
+                        if let Some(limit) = react_subs[key].head_limit
+                            && react_subs[key].emit_count >= limit
+                        {
+                            continue;
+                        }
+                        if react_subs[key].is_lines {
+                            let chunk = value.to_string_value();
+                            react_subs[key].line_buffer.push_str(&chunk);
+                            while let Some(pos) = react_subs[key].line_buffer.find('\n') {
+                                let line = react_subs[key].line_buffer[..pos].to_string();
+                                react_subs[key].line_buffer =
+                                    react_subs[key].line_buffer[pos + 1..].to_string();
+                                if self
+                                    .run_react_consumer(&mut react_subs[key], Value::str(line))?
+                                {
+                                    return Ok(true);
+                                }
+                                if react_subs[key].done {
+                                    break;
+                                }
+                                react_subs[key].emit_count += 1;
+                                if self.head_limit_reached(&mut react_subs[key])? {
+                                    break;
+                                }
+                            }
+                        } else {
+                            if self.run_react_consumer(&mut react_subs[key], value)? {
+                                return Ok(true);
+                            }
+                            if !react_subs[key].done {
+                                react_subs[key].emit_count += 1;
+                                self.head_limit_reached(&mut react_subs[key])?;
+                            }
                         }
                     }
+                    SinkEvent::Done => {
+                        if react_subs[key].is_lines && !react_subs[key].line_buffer.is_empty() {
+                            let remaining = std::mem::take(&mut react_subs[key].line_buffer);
+                            let cb = react_subs[key].callback.clone();
+                            match self.call_react_callback(&cb, vec![Value::str(remaining)]) {
+                                Err(e) if e.is_react_done() => return Ok(true),
+                                other => {
+                                    other?;
+                                }
+                            }
+                        }
+                        for cb in react_subs[key].last_callbacks.clone() {
+                            self.call_react_callback(&cb, Vec::new())?;
+                        }
+                        react_subs[key].done = true;
+                    }
+                    SinkEvent::Quit(error) => {
+                        let mut handled = false;
+                        for quit_cb in react_subs[key].quit_callbacks.clone() {
+                            self.call_supply_quit_handler(quit_cb, error.clone())?;
+                            handled = true;
+                        }
+                        if handled {
+                            react_subs[key].done = true;
+                            continue;
+                        }
+                        Self::run_react_close_callbacks(self, react_subs);
+                        let quit_err =
+                            crate::runtime::Interpreter::runtime_error_from_supply_reason(error);
+                        return Err(crate::runtime::Interpreter::wrap_react_died(quit_err));
+                    }
                 }
-                for cb in react_subs[i].last_callbacks.clone() {
-                    self.call_react_callback(&cb, Vec::new())?;
-                }
-                react_subs[i].done = true;
             }
         }
-        Ok(false)
     }
 
     /// If `sub` has reached its `head`/`.head(N)` limit, fire its LAST callbacks
@@ -146,8 +139,8 @@ impl Interpreter {
 
     /// Shared subscription drive loop backing both `react { ... }` and the
     /// `await $supply` / `$supply.Promise` paths. `react`-built and
-    /// promise-built subscriptions poll through here; `policy` selects how each
-    /// emitted value is dispatched and when the loop completes (see
+    /// promise-built subscriptions are driven through here; `policy` selects
+    /// how each emitted value is dispatched and when the loop completes (see
     /// [`SupplyDrivePolicy`]).
     pub(crate) fn drive_react_subscriptions_nested(
         &mut self,
@@ -172,10 +165,12 @@ impl Interpreter {
     /// tap whose emitter has signalled `done`/`quit`, on the current (main react)
     /// thread. Draining removes each serviced entry so a callback runs once per
     /// tap. Runs both each drive-loop poll and once when the loop exits.
-    fn fire_ready_tap_closes(&mut self) -> Result<(), RuntimeError> {
+    /// Returns whether any callback fired.
+    fn fire_ready_tap_closes(&mut self) -> Result<bool, RuntimeError> {
         if self.pending_tap_closes.is_empty() {
-            return Ok(());
+            return Ok(false);
         }
+        let mut fired = false;
         let mut i = 0;
         while i < self.pending_tap_closes.len() {
             if self.pending_tap_closes[i].0.is_resolved() {
@@ -183,17 +178,21 @@ impl Interpreter {
                 for cb in cbs {
                     let _ = self.call_react_callback(&cb, Vec::new());
                 }
+                fired = true;
             } else {
                 i += 1;
             }
         }
-        Ok(())
+        Ok(fired)
     }
 
+    /// Waker-registration wrapper: registers push sinks / wake hooks on every
+    /// subscription source, runs the drive loop, and unregisters on all exit
+    /// paths (normal completion, react `done`, propagated errors).
     fn drive_react_subscriptions_inner(
         &mut self,
         mut react_subs: Vec<ReactSubscription>,
-        mut policy: SupplyDrivePolicy,
+        policy: SupplyDrivePolicy,
     ) -> Result<(), RuntimeError> {
         if react_subs.is_empty() {
             if let SupplyDrivePolicy::Promise {
@@ -208,10 +207,47 @@ impl Interpreter {
             return Ok(());
         }
 
-        // Event loop: poll all subscriptions
-        let timeout = Duration::from_millis(10);
+        let waker = ReactWaker::new();
+        // Supplier-backed subscriptions: register push sinks (this also
+        // replays any already-buffered values into the queue).
+        let mut sink_regs: Vec<(u64, u64)> = Vec::new();
+        for (i, sub) in react_subs.iter().enumerate() {
+            if let Some(sid) = sub.supplier_id {
+                sink_regs.push((sid, supplier_sink_register(sid, i, &waker)));
+            }
+        }
+        // Promise / channel sources still deliver their payloads through the
+        // existing receiver / poll paths, but wake the loop instantly instead
+        // of waiting out the idle cap.
+        for sub in &react_subs {
+            if let Some(p) = &sub.promise {
+                let w = waker.clone();
+                let _ = p.on_resolve(Box::new(move |_, _, _, _| w.notify()));
+            }
+            if let Some(ch) = &sub.channel {
+                ch.register_waker(&waker);
+            }
+        }
+        let result = self.drive_react_subscriptions_loop(&mut react_subs, policy, &waker);
+        for (sid, sink_id) in sink_regs {
+            supplier_sink_unregister(sid, sink_id);
+        }
+        for sub in &react_subs {
+            if let Some(ch) = &sub.channel {
+                ch.unregister_waker(waker.id());
+            }
+        }
+        result
+    }
+
+    fn drive_react_subscriptions_loop(
+        &mut self,
+        react_subs: &mut [ReactSubscription],
+        mut policy: SupplyDrivePolicy,
+        waker: &ReactWaker,
+    ) -> Result<(), RuntimeError> {
         'react_loop: loop {
-            // GC park point: an idle react loop polls `recv_timeout` without
+            // GC park point: an idle react loop blocks on the waker without
             // dispatching bytecode, so it would never reach the backedge
             // safepoint — park here so a stop-the-world can proceed while the
             // loop waits for events. (Unconditional: `gc_safepoint` below only
@@ -219,6 +255,7 @@ impl Interpreter {
             crate::gc::gc_park_point();
             // GC safepoint (§9.2a `react_poll`): one drive-loop poll unit.
             crate::gc::gc_safepoint(crate::gc::SafepointKind::ReactPoll);
+            let mut progressed = false;
             if let SupplyDrivePolicy::Promise {
                 promise, deadline, ..
             } = &policy
@@ -234,15 +271,16 @@ impl Interpreter {
                     return Ok(());
                 }
             }
-            // Phase 1: deliver all buffered supplier values in global emit order
-            // (so sibling `whenever $s.grep(...)` supplies interleave correctly),
-            // and honour supplier done/quit.
-            if self.drain_supplier_subs_ordered(&mut react_subs)? {
+            // Phase 1: deliver all queued supplier events in push (= emit)
+            // order, honouring per-supplier done/quit.
+            if self.dispatch_waker_events(waker, react_subs, &mut progressed)? {
                 break 'react_loop;
             }
             // Service any nested-`whenever` on-demand taps whose emitter finished,
             // firing their `closing => { ... }` callbacks on this thread.
-            self.fire_ready_tap_closes()?;
+            if self.fire_ready_tap_closes()? {
+                progressed = true;
+            }
             // Phase 2: poll the non-supplier subscriptions (on-demand / channel /
             // receiver sources).
             let mut all_done = true;
@@ -251,7 +289,7 @@ impl Interpreter {
                 if sub.done {
                     continue;
                 }
-                // Supplier-backed subs were fully serviced in phase 1.
+                // Supplier-backed subs are fully serviced by the waker queue.
                 if sub.supplier_id.is_some() {
                     all_done = false;
                     continue;
@@ -276,6 +314,7 @@ impl Interpreter {
                         }
                     }
                     sub.done = true;
+                    progressed = true;
                     continue;
                 }
                 // Handle Channel sources: poll values directly
@@ -286,6 +325,7 @@ impl Interpreter {
                                 break 'react_loop;
                             }
                             sub.emit_count += 1;
+                            progressed = true;
                         }
                         Ok(None) => {
                             // No value available yet. Only mark done once the
@@ -303,10 +343,12 @@ impl Interpreter {
                                     self.call_react_callback(&callback.clone(), Vec::new())?;
                                 }
                                 sub.done = true;
+                                progressed = true;
                             }
                         }
                         Err(_err) => {
                             sub.done = true;
+                            progressed = true;
                         }
                     }
                     continue;
@@ -323,90 +365,95 @@ impl Interpreter {
                     }
                     continue;
                 }
-                // Poll the receiver with a short timeout. The `Result` is owned, so
+                // Poll the receiver without blocking: the idle wait at the end
+                // of the round provides the pacing. The `Result` is owned, so
                 // the borrow of the receiver ends on this line — freeing
                 // `react_subs` for the pre-drain below.
-                let poll = react_subs[si]
-                    .receiver
-                    .as_ref()
-                    .map(|r| r.recv_timeout(timeout));
+                let poll = react_subs[si].receiver.as_ref().map(|r| r.try_recv());
                 // Raku ordering guarantee: values `emit`ted into a supplier
                 // *before* the event this receiver just delivered are causally
                 // earlier and must reach their `whenever`s first — even when that
                 // event's callback ends the react (e.g. `whenever start { emit … }`
                 // finishing while a sibling `whenever` calls `done`, so the sibling
                 // supplier's already-emitted values would otherwise be lost). Drain
-                // every supplier subscription before running this receiver's
-                // consumer, so their pending values are delivered in source order.
+                // the waker queue before running this receiver's consumer, so
+                // their pending values are delivered in source order.
                 if matches!(poll, Some(Ok(SupplyEvent::Emit(_))))
                     && matches!(policy, SupplyDrivePolicy::React)
-                    && self.drain_supplier_subs_ordered(&mut react_subs)?
+                    && self.dispatch_waker_events(waker, react_subs, &mut progressed)?
                 {
                     break 'react_loop;
                 }
                 let sub = &mut react_subs[si];
-                // Try to receive with a short timeout
                 match poll {
-                    Some(Ok(SupplyEvent::Emit(value))) => match &mut policy {
-                        SupplyDrivePolicy::Promise {
-                            promise,
-                            last_value,
-                            ..
-                        } => {
-                            // Capture values the whenever block `emit`s so a
-                            // later `done` resolves the promise with the last one.
-                            self.supply_emit_buffer.push(Vec::new());
-                            let cb_result =
-                                self.call_react_callback(&sub.callback.clone(), vec![value]);
-                            let emitted = self.supply_emit_buffer.pop().unwrap_or_default();
-                            if let Some(last) = emitted.last() {
-                                *last_value = last.clone();
-                            }
-                            if promise.is_resolved() {
-                                return Ok(());
-                            }
-                            if let Err(err) = cb_result {
-                                // `done`/`last` inside the whenever complete the
-                                // supply: keep the promise with the last emitted
-                                // value immediately rather than spinning to the
-                                // deadline.
-                                if err.is_react_done() || err.is_last() {
-                                    promise.keep(last_value.clone(), String::new(), String::new());
+                    Some(Ok(SupplyEvent::Emit(value))) => {
+                        progressed = true;
+                        match &mut policy {
+                            SupplyDrivePolicy::Promise {
+                                promise,
+                                last_value,
+                                ..
+                            } => {
+                                // Capture values the whenever block `emit`s so a
+                                // later `done` resolves the promise with the last one.
+                                self.supply_emit_buffer.push(Vec::new());
+                                let cb_result =
+                                    self.call_react_callback(&sub.callback.clone(), vec![value]);
+                                let emitted = self.supply_emit_buffer.pop().unwrap_or_default();
+                                if let Some(last) = emitted.last() {
+                                    *last_value = last.clone();
+                                }
+                                if promise.is_resolved() {
                                     return Ok(());
                                 }
-                                // `next`/`redo` are loop control, not completion.
-                                if !err.is_next() && !err.is_redo() {
-                                    // A `die` quits the supply: break with the cause.
-                                    let cause = err
-                                        .exception
-                                        .as_deref()
-                                        .cloned()
-                                        .unwrap_or_else(|| Value::str(err.message.clone()));
-                                    promise.break_with(cause, String::new(), String::new());
-                                    return Ok(());
+                                if let Err(err) = cb_result {
+                                    // `done`/`last` inside the whenever complete the
+                                    // supply: keep the promise with the last emitted
+                                    // value immediately rather than spinning to the
+                                    // deadline.
+                                    if err.is_react_done() || err.is_last() {
+                                        promise.keep(
+                                            last_value.clone(),
+                                            String::new(),
+                                            String::new(),
+                                        );
+                                        return Ok(());
+                                    }
+                                    // `next`/`redo` are loop control, not completion.
+                                    if !err.is_next() && !err.is_redo() {
+                                        // A `die` quits the supply: break with the cause.
+                                        let cause = err
+                                            .exception
+                                            .as_deref()
+                                            .cloned()
+                                            .unwrap_or_else(|| Value::str(err.message.clone()));
+                                        promise.break_with(cause, String::new(), String::new());
+                                        return Ok(());
+                                    }
+                                }
+                            }
+                            SupplyDrivePolicy::React => {
+                                if sub.is_lines {
+                                    let chunk = value.to_string_value();
+                                    sub.line_buffer.push_str(&chunk);
+                                    while let Some(pos) = sub.line_buffer.find('\n') {
+                                        let line = sub.line_buffer[..pos].to_string();
+                                        sub.line_buffer = sub.line_buffer[pos + 1..].to_string();
+                                        if self.run_react_consumer(sub, Value::str(line))? {
+                                            break 'react_loop;
+                                        }
+                                        if sub.done {
+                                            break;
+                                        }
+                                    }
+                                } else if self.run_react_consumer(sub, value)? {
+                                    break 'react_loop;
                                 }
                             }
                         }
-                        SupplyDrivePolicy::React => {
-                            if sub.is_lines {
-                                let chunk = value.to_string_value();
-                                sub.line_buffer.push_str(&chunk);
-                                while let Some(pos) = sub.line_buffer.find('\n') {
-                                    let line = sub.line_buffer[..pos].to_string();
-                                    sub.line_buffer = sub.line_buffer[pos + 1..].to_string();
-                                    if self.run_react_consumer(sub, Value::str(line))? {
-                                        break 'react_loop;
-                                    }
-                                    if sub.done {
-                                        break;
-                                    }
-                                }
-                            } else if self.run_react_consumer(sub, value)? {
-                                break 'react_loop;
-                            }
-                        }
-                    },
+                    }
                     Some(Ok(SupplyEvent::Done)) => {
+                        progressed = true;
                         if matches!(policy, SupplyDrivePolicy::Promise { .. }) {
                             // Inner supply done: the promise resolves through the
                             // supplier registry, not the channel close — just
@@ -432,6 +479,7 @@ impl Interpreter {
                         }
                     }
                     Some(Ok(SupplyEvent::Quit(error))) => {
+                        progressed = true;
                         if matches!(policy, SupplyDrivePolicy::Promise { .. }) {
                             // On the await path an inner quit just retires the
                             // receiver; the promise is resolved/broken elsewhere.
@@ -454,9 +502,10 @@ impl Interpreter {
                             }
                         }
                     }
-                    Some(Err(mpsc::RecvTimeoutError::Timeout)) | None => {}
-                    Some(Err(mpsc::RecvTimeoutError::Disconnected)) => {
+                    Some(Err(mpsc::TryRecvError::Empty)) | None => {}
+                    Some(Err(mpsc::TryRecvError::Disconnected)) => {
                         sub.done = true;
+                        progressed = true;
                     }
                 }
             }
@@ -479,9 +528,27 @@ impl Interpreter {
                     }
                 }
             }
+            // Nothing moved this round: block until a producer wakes us (or
+            // the cap elapses, for the sources that still poll). Bounded by
+            // the Promise-policy deadline so a stalled source cannot oversleep
+            // the await's completion check.
+            if !progressed {
+                let mut cap = REACT_IDLE_WAIT;
+                if let SupplyDrivePolicy::Promise { deadline, .. } = &policy {
+                    let now = std::time::Instant::now();
+                    cap = if *deadline > now {
+                        cap.min(*deadline - now)
+                    } else {
+                        Duration::ZERO
+                    };
+                }
+                if !cap.is_zero() {
+                    waker.wait_activity(cap);
+                }
+            }
         }
 
-        Self::run_react_close_callbacks(self, &react_subs);
+        Self::run_react_close_callbacks(self, react_subs);
         Ok(())
     }
 }

--- a/t/react-supplier-done.t
+++ b/t/react-supplier-done.t
@@ -1,0 +1,68 @@
+use v6;
+use Test;
+
+plan 4;
+
+# Push-based supplier event delivery: values emitted (and the done) from
+# another thread must all reach a `react whenever` and end the react, even
+# when `Supplier.done`'s internal state reset races the drive loop. The old
+# snapshot-polling loop lost the trailing emit + done here (delivered only
+# the first value, then hung until timeout, busy-spinning a core).
+{
+    my $s = Supplier.new;
+    my $sup = $s.Supply;
+    my @got;
+    start { sleep 0.2; $s.emit(1); $s.emit(2); $s.done; }
+    react {
+        whenever $sup {
+            @got.push($_);
+        }
+    }
+    is @got, [1, 2], 'both cross-thread emits delivered to the whenever';
+}
+
+# Same shape with the Supply created inline in the whenever.
+{
+    my $s = Supplier.new;
+    my @got;
+    start { sleep 0.2; $s.emit(42); $s.done; }
+    react {
+        whenever $s.Supply {
+            @got.push($_);
+        }
+    }
+    is @got, [42], 'inline .Supply whenever sees the emit and ends on done';
+}
+
+# A value emitted inside the react body itself (after the whenever) is
+# delivered: the whenever's tap is already active. In mutsu the sink is
+# registered when the drive loop starts (after the body ran), so this relies
+# on registration replaying the values buffered in between.
+{
+    my $s = Supplier.new;
+    my $sup = $s.Supply;
+    my @got;
+    react {
+        whenever $sup {
+            @got.push($_);
+            done if $_ eq 'last';
+        }
+        $s.emit('body');
+        $s.emit('last');
+    }
+    is @got, ['body', 'last'], 'emits from the react body reach the whenever';
+}
+
+# A cross-thread quit reaches the whenever's QUIT handler.
+{
+    my $s = Supplier.new;
+    my $sup = $s.Supply;
+    my $quit-message = '';
+    start { sleep 0.2; $s.emit(7); $s.quit('boom'); }
+    react {
+        whenever $sup {
+            QUIT { default { $quit-message = .message; done } }
+        }
+    }
+    is $quit-message, 'boom', 'cross-thread quit delivered to the QUIT handler';
+}


### PR DESCRIPTION
## Summary

Replaces the poll-based supply event architecture (the oldest concurrency
mechanism in the codebase) with push-based delivery — **ADR-0008**. This was
root-caused from the S17 CI load-flakiness investigation (throttle.t tests
5/9, syntax.t timeout); the polling design had four structural defects:

1. **Busy spin**: a react whose live sources were all supplier-backed had no
   blocking point — `react whenever $s.Supply { }` burned a core at 100% CPU
   for its whole lifetime while hammering the supplier-registry mutex.
2. **Lost events**: `Supplier.done` fires callbacks then resets the registry
   entry, so a poller that hadn't observed the done flag (or the emits just
   before it) lost them forever. Minimal repro (raku: prints both values and
   exits in 1.2s; mutsu before: printed only `1`, hung forever at 100% CPU):
   ```raku
   my $s = Supplier.new; my $sup = $s.Supply;
   start { sleep .2; $s.emit(1); $s.emit(2); $s.done; }
   react { whenever $sup { .say } }
   ```
3. **Quadratic churn**: `supplier_snapshot_seqs` cloned the entire emit
   history per delivered value inside the global registry lock.
4. **1ms/10ms sleep-poll loops** (supply list wait, throttle control waits,
   `Promise.anyof`) and **one 1ms-sleep-loop OS thread per `Supply.interval`
   instance** — syntax.t creates 2000 short-lived 1ms intervals, totalling
   ~195k `clock_nanosleep` syscalls per run, each wake paying scheduler
   latency under load. This is why mutsu ran S17 1.5–2× slower than raku
   under CPU contention (the mechanism behind the 30s roast timeouts).

## Mechanism

- New primitive `crate::value::waker::ReactWaker`: event queue + condvar
  (GC-quiescent wait). Producers push `Emit/Done/Quit` or poke.
- The supplier registry keeps **sinks** per supplier; `supplier_emit/done/
  quit` push to every sink *under the registry lock* — push order == emit
  order, and a later reset cannot un-publish an event. Registration replays
  buffered values under the same lock acquisition. The `emit_seqs`
  cross-supplier merge machinery is deleted.
- The react drive loop consumes its waker queue and blocks when idle;
  `SharedPromise.on_resolve` and `SharedChannel` send/close poke it. The
  remaining mpsc-polled sources bound the idle wait at 10ms (same worst case
  as before, zero spin).
- `Supply.interval` is driven by **one process-wide timer thread** off a
  deadline min-heap (Rakudo-style single timer queue) instead of a
  sleep-loop thread per instance.
- `Supply.throttle(0, &block, :control)` runs its block with
  `effective_limit`-way real concurrency (was: fully serial — the actual
  cause of throttle.t test 9's thin margin); the non-block path vents its
  first batch immediately on receiving the control limit (Rakudo semantics),
  doubling test 5's margin. `Supplier.quit(Str)` wraps its reason in
  `X::AdHoc` (object instances pass through, so `when MyException` still
  matches).

## Measurements (release, 12-core box)

| metric | before (main) | after |
|---|---|---|
| idle `react whenever $supplier` waiting 1s | 100% CPU + hang | ~0 CPU, exits correctly |
| syntax.t idle: wall / CPU | 3.15s / 14.8s | 2.5s / 4.0s (raku: 3.3s wall) |
| syntax.t under 11 busy loops | 13.9–19.4s | 11.9–13.1s (raku: 6.9–12.4s) |
| syntax.t `clock_nanosleep` calls | ~195k | 0 on interval sections |
| throttle.t under 18 busy loops | (CI-flaked) | 0/12 failed (raku 0/12) |

## Testing

- New pin: `t/react-supplier-done.t` (4 tests, raku-validated).
- `make test`: 1771 files / 17321 tests PASS; `cargo test`: 574 PASS.
- All 99 whitelisted S17 roast files PASS (1603 tests).
- Known pre-existing divergence kept: mutsu replays pre-registration
  buffered values (raku live supplies drop pre-tap emits) — load-bearing for
  `react { whenever $sup {...}; $s.emit(...) }` because mutsu registers
  sinks when the drive loop starts, after the react body ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
