### PR TITLE
perf: move Promise.in/.at and cue(:in/:at) delays onto the shared deadline-heap timer

### DIFF
--- a/src/runtime/methods_promise_class.rs
+++ b/src/runtime/methods_promise_class.rs
@@ -26,6 +26,22 @@ impl Interpreter {
         None
     }
 
+    /// Keep `promise` with True once `secs` have elapsed, via the shared
+    /// deadline-heap timer — no per-timer OS thread. `keep` never runs user
+    /// code on the resolver (waiters dispatch to their own thread), so it is
+    /// safe on the timer driver. `+Inf` means the promise never resolves.
+    fn keep_promise_after(promise: SharedPromise, secs: f64) {
+        if secs == f64::INFINITY {
+            return;
+        }
+        super::native_methods::interval_timer::register_once(
+            super::native_methods::interval_timer::clamp_delay_secs(secs),
+            Box::new(move || {
+                promise.keep(Value::TRUE, String::new(), String::new());
+            }),
+        );
+    }
+
     /// Promise.in dispatch
     pub(super) fn dispatch_promise_in(
         &mut self,
@@ -33,20 +49,10 @@ impl Interpreter {
         args: &[Value],
     ) -> Option<Result<Value, RuntimeError>> {
         if let Some(cls) = self.promise_class_name(target) {
-            let secs = args.first().map(|v| v.to_f64()).unwrap_or(0.0).max(0.0);
+            let secs = args.first().map(|v| v.to_f64()).unwrap_or(0.0);
             let promise = SharedPromise::new_with_class(Symbol::intern(&cls));
             let ret = Value::promise(promise.clone());
-            // Registered spawn: this thread drops a `Gc` promise handle at
-            // exit (see `spawn_gc_helper_thread`); the sleep is a quiescent
-            // safe region so a long timer never starves a stop-the-world.
-            crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
-                if secs > 0.0 {
-                    crate::gc::block_quiescent(|| {
-                        std::thread::sleep(Duration::from_secs_f64(secs))
-                    });
-                }
-                promise.keep(Value::TRUE, String::new(), String::new());
-            });
+            Self::keep_promise_after(promise, secs);
             return Some(Ok(ret));
         }
         None
@@ -81,18 +87,10 @@ impl Interpreter {
                 None => 0.0,
             };
             let now = crate::value::current_time_secs_f64();
-            let delay = (at_time - now).max(0.0);
+            let delay = at_time - now;
             let promise = SharedPromise::new_with_class(Symbol::intern(&cls));
             let ret = Value::promise(promise.clone());
-            // Registered spawn + quiescent sleep — see `dispatch_promise_in`.
-            crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
-                if delay > 0.0 {
-                    crate::gc::block_quiescent(|| {
-                        std::thread::sleep(Duration::from_secs_f64(delay))
-                    });
-                }
-                promise.keep(Value::TRUE, String::new(), String::new());
-            });
+            Self::keep_promise_after(promise, delay);
             return Some(Ok(ret));
         }
         None

--- a/src/runtime/native_methods/interval_timer.rs
+++ b/src/runtime/native_methods/interval_timer.rs
@@ -1,13 +1,17 @@
-//! Shared interval timer: one process-wide thread drives every
-//! `Supply.interval` emitter off a deadline min-heap, instead of one
-//! 1ms-sleep-loop OS thread per interval instance (which multiplied into
-//! thousands of `clock_nanosleep` wake-ups per second on interval-heavy
-//! workloads — S17-supply/syntax.t creates 2000 short-lived 1ms intervals —
-//! and amplified badly under CPU contention). This mirrors how Rakudo's
-//! scheduler drives intervals from a single timer queue.
+//! Shared deadline-heap timer: one process-wide thread drives every timed
+//! event — `Supply.interval` emitters, `Promise.in`/`Promise.at` keepers,
+//! scheduler `cue(:in/:at)` delays — off a deadline min-heap, instead of one
+//! sleeping OS thread per pending timer (which multiplied into thousands of
+//! `clock_nanosleep` wake-ups per second on interval-heavy workloads —
+//! S17-supply/syntax.t creates 2000 short-lived 1ms intervals — and amplified
+//! badly under CPU contention). This mirrors how Rakudo's scheduler drives
+//! timed events from a single timer queue.
 //!
-//! An entry dies when its channel receiver is dropped (`send` fails), same
-//! lifecycle as the old per-instance thread.
+//! An entry's action returns `Some(period)` to reschedule itself (interval
+//! semantics) or `None` to die (one-shot / receiver gone). Actions run with
+//! the heap lock RELEASED, so an action may itself register new timers.
+//! Actions must stay cheap (a channel send, a promise keep, a thread spawn) —
+//! never run user VM code on the driver thread.
 use crate::runtime::native_methods::SupplyEvent;
 use crate::value::Value;
 use std::cmp::Reverse;
@@ -16,90 +20,116 @@ use std::sync::mpsc::Sender;
 use std::sync::{Condvar, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
-struct IntervalEntry {
+/// Returns `Some(period)` to be rescheduled `period` after this deadline
+/// (fixed-rate, with catch-up skipping), or `None` to be dropped.
+type TimerAction = Box<dyn FnMut() -> Option<Duration> + Send>;
+
+struct TimerEntry {
     next: Instant,
-    period: Duration,
-    tick: i64,
-    tx: Sender<SupplyEvent>,
+    action: TimerAction,
 }
 
 // BinaryHeap is a max-heap; order entries by Reverse(next) so `peek` is the
 // earliest deadline. Ties broken arbitrarily (registration order irrelevant).
-impl PartialEq for IntervalEntry {
+impl PartialEq for TimerEntry {
     fn eq(&self, other: &Self) -> bool {
         self.next == other.next
     }
 }
-impl Eq for IntervalEntry {}
-impl PartialOrd for IntervalEntry {
+impl Eq for TimerEntry {}
+impl PartialOrd for TimerEntry {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
-impl Ord for IntervalEntry {
+impl Ord for TimerEntry {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         Reverse(self.next).cmp(&Reverse(other.next))
     }
 }
 
-type TimerState = (Mutex<BinaryHeap<IntervalEntry>>, Condvar);
+type TimerState = (Mutex<BinaryHeap<TimerEntry>>, Condvar);
 
 fn timer_state() -> &'static TimerState {
     static STATE: OnceLock<&'static TimerState> = OnceLock::new();
     STATE.get_or_init(|| {
         let state: &'static TimerState =
             Box::leak(Box::new((Mutex::new(BinaryHeap::new()), Condvar::new())));
-        // One long-lived driver thread for the whole process. It only touches
-        // scalar `Value`s (`Value::int` ticks — no Gc payload), and parks
-        // quiescent while waiting, so it is safe as a GC helper.
+        // One long-lived driver thread for the whole process. Actions may
+        // clone/drop `Gc` values (a kept promise handle), so the driver is a
+        // registered GC mutator; it parks quiescent while waiting.
         crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
             let (heap, cvar) = state;
             let mut guard = heap.lock().unwrap();
             loop {
                 let now = Instant::now();
-                match guard.peek() {
-                    None => {
+                // Collect every due entry first, then run the actions with
+                // the heap lock released: an action registering a new timer
+                // (or dropping a value whose finalizer does) must not
+                // re-enter the heap mutex.
+                let mut due = Vec::new();
+                while guard.peek().is_some_and(|e| e.next <= now) {
+                    due.push(guard.pop().unwrap());
+                }
+                if due.is_empty() {
+                    let wait = match guard.peek() {
                         // Nothing scheduled: sleep until a registration pokes
                         // us. Bounded waits keep the thread responsive to a
                         // GC stop-the-world (block_quiescent would pin the
                         // heap lock; short chunks avoid holding anything
                         // during the actual wait).
-                        let (g, _) = crate::gc::block_quiescent(|| {
-                            cvar.wait_timeout(guard, Duration::from_millis(500))
-                                .unwrap()
-                        });
-                        guard = g;
-                    }
-                    Some(entry) if entry.next > now => {
-                        let wait = entry.next - now;
-                        let (g, _) =
-                            crate::gc::block_quiescent(|| cvar.wait_timeout(guard, wait).unwrap());
-                        guard = g;
-                    }
-                    Some(_) => {
-                        let mut entry = guard.pop().unwrap();
-                        if entry
-                            .tx
-                            .send(SupplyEvent::Emit(Value::int(entry.tick)))
-                            .is_ok()
-                        {
-                            entry.tick = entry.tick.saturating_add(1);
-                            // Fixed-rate schedule, but never a catch-up burst:
-                            // if we fell behind (loaded host), skip ahead.
-                            entry.next += entry.period;
-                            let now = Instant::now();
-                            if entry.next < now {
-                                entry.next = now + entry.period;
-                            }
-                            guard.push(entry);
+                        None => Duration::from_millis(500),
+                        Some(entry) => entry.next - now,
+                    };
+                    let (g, _) =
+                        crate::gc::block_quiescent(|| cvar.wait_timeout(guard, wait).unwrap());
+                    guard = g;
+                    continue;
+                }
+                drop(guard);
+                let mut reschedule = Vec::new();
+                for mut entry in due {
+                    if let Some(period) = (entry.action)() {
+                        // Fixed-rate schedule, but never a catch-up burst:
+                        // if we fell behind (loaded host), skip ahead.
+                        entry.next += period;
+                        let now = Instant::now();
+                        if entry.next < now {
+                            entry.next = now + period;
                         }
-                        // send failed → receiver gone → entry dropped.
+                        reschedule.push(entry);
                     }
+                }
+                guard = heap.lock().unwrap();
+                for entry in reschedule {
+                    guard.push(entry);
                 }
             }
         });
         state
     })
+}
+
+fn register_entry(delay: Duration, action: TimerAction) {
+    let (heap, cvar) = timer_state();
+    let mut guard = heap.lock().unwrap();
+    guard.push(TimerEntry {
+        next: Instant::now() + delay,
+        action,
+    });
+    cvar.notify_all();
+}
+
+/// Clamp a user-supplied seconds value to a `Duration` that is safe to add to
+/// an `Instant`: non-finite and negative inputs become zero, and huge values
+/// are capped (~95 years) so `Instant + Duration` can never overflow.
+pub(crate) fn clamp_delay_secs(secs: f64) -> Duration {
+    const MAX_DELAY_SECS: f64 = 3.0e9;
+    if secs.is_finite() && secs > 0.0 {
+        Duration::from_secs_f64(secs.min(MAX_DELAY_SECS))
+    } else {
+        Duration::ZERO
+    }
 }
 
 /// Register a new interval emitter: first emission after `initial_delay`
@@ -111,13 +141,33 @@ pub(crate) fn register_interval(
     initial_delay: Duration,
     tx: Sender<SupplyEvent>,
 ) {
-    let (heap, cvar) = timer_state();
-    let mut guard = heap.lock().unwrap();
-    guard.push(IntervalEntry {
-        next: Instant::now() + initial_delay,
-        period,
-        tick: 0,
-        tx,
-    });
-    cvar.notify_all();
+    let mut tick: i64 = 0;
+    register_entry(
+        initial_delay,
+        Box::new(move || {
+            if tx.send(SupplyEvent::Emit(Value::int(tick))).is_ok() {
+                tick = tick.saturating_add(1);
+                Some(period)
+            } else {
+                // send failed → receiver gone → entry dropped.
+                None
+            }
+        }),
+    );
+}
+
+/// Register a one-shot action to run once `delay` from now. The action runs
+/// on the shared driver thread, so it must stay cheap (keep a promise, spawn
+/// a worker) — never run user VM code in it.
+pub(crate) fn register_once(delay: Duration, action: Box<dyn FnOnce() + Send>) {
+    let mut action = Some(action);
+    register_entry(
+        delay,
+        Box::new(move || {
+            if let Some(f) = action.take() {
+                f();
+            }
+            None
+        }),
+    );
 }

--- a/src/runtime/native_methods/scheduler.rs
+++ b/src/runtime/native_methods/scheduler.rs
@@ -3,6 +3,7 @@ use crate::symbol::Symbol;
 use crate::value::ValueView;
 use std::sync::atomic::Ordering;
 
+use super::interval_timer;
 use super::state::*;
 use super::state_lock::*;
 use super::state_scheduler::{self, *};
@@ -116,7 +117,9 @@ impl Interpreter {
         if delay == f64::NEG_INFINITY || delay <= 0.0 {
             return true; // run immediately
         }
-        std::thread::sleep(std::time::Duration::from_secs_f64(delay));
+        // Quiescent: a registered thread's raw sleep would starve a GC
+        // stop-the-world rendezvous.
+        crate::gc::block_quiescent(|| std::thread::sleep(interval_timer::clamp_delay_secs(delay)));
         true
     }
 
@@ -265,13 +268,34 @@ impl Interpreter {
                     // until the callback finishes (mark started before spawn so a
                     // racing `.loads` never undercounts).
                     state_scheduler::scheduler_task_started();
+                    // A finite :in/:at delay waits on the shared deadline-heap
+                    // timer instead of a sleeping worker thread; the worker is
+                    // spawned only once due. (An Inf delay keeps the direct
+                    // path — scheduler_sleep handles its run-once-for-:every
+                    // special case without sleeping.)
+                    let mut params = params;
+                    let delay = params.delay;
+                    let deferred = delay.is_finite() && delay > 0.0;
+                    if deferred {
+                        params.delay = 0.0;
+                    }
                     // Large user-code stack: the scheduled callback runs user VM
                     // code, which overflows the default thread stack on deep
                     // nesting. See `USER_THREAD_STACK_SIZE`.
-                    crate::runtime::builtins_system::spawn_user_thread(move || {
-                        thread_interp.scheduler_run_async(params);
-                        state_scheduler::scheduler_task_finished();
-                    });
+                    let run = move || {
+                        crate::runtime::builtins_system::spawn_user_thread(move || {
+                            thread_interp.scheduler_run_async(params);
+                            state_scheduler::scheduler_task_finished();
+                        });
+                    };
+                    if deferred {
+                        interval_timer::register_once(
+                            interval_timer::clamp_delay_secs(delay),
+                            Box::new(run),
+                        );
+                    } else {
+                        run();
+                    }
                 }
                 Ok(cancellation)
             }
@@ -414,7 +438,10 @@ impl Interpreter {
             if interval == f64::INFINITY {
                 break;
             } else if interval > 0.0 && interval.is_finite() {
-                std::thread::sleep(std::time::Duration::from_secs_f64(interval));
+                // Quiescent — see `scheduler_sleep`.
+                crate::gc::block_quiescent(|| {
+                    std::thread::sleep(std::time::Duration::from_secs_f64(interval))
+                });
             }
         }
         Ok(())

--- a/t/timer-heap-threads.t
+++ b/t/timer-heap-threads.t
@@ -1,0 +1,34 @@
+use v6;
+use Test;
+
+# Pin for the shared deadline-heap timer (PLAN §6, ADR-0008 follow-up):
+# pending Promise.in / Promise.at / cue(:in) timers wait on one process-wide
+# driver thread, not one sleeping OS thread each. Before the heap, 100
+# pending Promise.in timers held 100 OS threads alive for their full delay.
+
+plan 4;
+
+# None of these ever fire during the test (long delays); they must not
+# consume a thread each while pending.
+my @p;
+@p.push: Promise.in(600) for ^50;
+@p.push: Promise.at(now + 600) for ^50;
+$*SCHEDULER.cue({ ; }, :in(600)) for ^50;
+
+my $threads = "/proc/$*PID/status".IO.lines.first(*.starts-with('Threads:'));
+my $n = $threads.words[1].Int;
+ok $n < 40, "150 pending timers don't hold OS threads (got $n)"
+    or diag "Threads: $n — pending timers are consuming a thread each again";
+
+is @p.grep(*.status eq 'Planned').elems, 100, 'all long-delay promises still Planned';
+
+# The timers must still actually fire: short delays resolve promptly.
+my $fired = Promise.in(0.05);
+await Promise.anyof($fired, Promise.in(5));
+is $fired.status, 'Kept', 'short Promise.in fires while long timers pend';
+
+# A cued callback with :in still runs.
+my $p = Promise.new;
+$*SCHEDULER.cue({ $p.keep(42) }, :in(0.05));
+await Promise.anyof($p, Promise.in(5));
+is $p.result, 42, 'cue(:in) callback ran off the shared timer';


### PR DESCRIPTION
PLAN §6 **ADR-0008 push-delivery follow-up**: every pending timed event used to hold a sleeping OS thread for its full delay — 100 pending `Promise.in` = 100 OS threads (measured 102 → **3** with this change).

## What changed

- **`interval_timer.rs` generalized into a deadline-heap of closure actions.** Entries are `(deadline, action)` where the action returns `Some(period)` to reschedule itself (`Supply.interval` semantics, unchanged behavior) or `None` to die (one-shot). Due actions run with the heap lock **released**, so an action may itself register new timers without re-entering the heap mutex. New `register_once()` one-shot entry point; `clamp_delay_secs()` guards every `Duration` conversion against NaN/Inf/overflow panics.
- **`Promise.in` / `Promise.at`** keep via `register_once` directly on the driver thread — safe because `SharedPromise::keep` never runs user code on the resolver (waiters dispatch to their own thread, in order). `Promise.in(Inf)` now means never-resolve instead of a `from_secs_f64` panic.
- **`Scheduler.cue(:in/:at)`**: a finite positive delay waits on the heap and spawns the worker thread only once due. Side benefit: this removes a raw (non-quiescent) `sleep` on a GC-registered thread that could starve a stop-the-world rendezvous for the whole cue delay. The remaining scheduler sleeps (CurrentThreadScheduler sync path, `:every` inter-iteration) are now wrapped in `block_quiescent`.

## Verification

- `make test` green (1772 files); roast S17-promise (in/at/allof/anyof/then), S17-scheduler (all 5), S17-supply syntax/interval/batch/throttle all pass locally.
- gc-stress config (`MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=50 MUTSU_GC_VERIFY=1`): `t/gc-promise-timer-stress.t` and `t/promise-scheduler.t` 3× each, no VERIFY FAIL — the promise-handle-drop-on-timer-thread race this file pins stays fixed with handles now living in the shared heap.
- New pin: `t/timer-heap-threads.t` — 150 pending timers stay under 40 OS threads while short timers still fire; passes on raku too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)