### PR TITLE
perf: wake the react drive loop from mpsc supply senders (ADR-0008 follow-up)

### DIFF
--- a/src/runtime/builtins_system_async.rs
+++ b/src/runtime/builtins_system_async.rs
@@ -451,8 +451,6 @@ impl Interpreter {
     /// `signal(SIGINT, ...)` — returns a Supply that emits Signal enum values
     /// when the process receives the specified OS signals.
     pub(super) fn builtin_signal(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
-        use std::sync::mpsc;
-
         // Extract signal numbers and their enum representations
         let signals: Vec<(i64, Value)> = args
             .iter()
@@ -466,7 +464,7 @@ impl Interpreter {
         let supply_id = super::native_methods::next_supply_id();
 
         // Create channel for the Supply
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = super::native_methods::supply_channel::supply_event_channel();
 
         // Register the channel in the supply channel map
         if let Ok(mut map) = super::native_methods::supply_channel_map_pub().lock() {

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1348,7 +1348,7 @@ impl Interpreter {
                 }
 
                 let supply_id = super::native_methods::next_supply_id();
-                let (tx, rx) = std::sync::mpsc::channel();
+                let (tx, rx) = super::native_methods::supply_channel::supply_event_channel();
                 if let Ok(mut map) = super::native_methods::supply_channel_map_pub().lock() {
                     map.insert(supply_id, rx);
                 }

--- a/src/runtime/methods_supply_dispatch.rs
+++ b/src/runtime/methods_supply_dispatch.rs
@@ -164,16 +164,17 @@ impl Interpreter {
     /// Create a channel-based zip supply when at least one source is channel-based.
     /// Spawns a coordination thread that reads from all sources and emits zipped values.
     fn create_channel_zip_supply(supplies: &[Value]) -> Result<Value, RuntimeError> {
+        use super::native_methods::supply_channel::{SupplyReceiver, supply_event_channel};
         use super::native_methods::{
             SupplyEvent, next_supply_id, supply_channel_map_pub, take_supply_channel,
         };
         use std::sync::mpsc;
 
         let zip_supply_id = next_supply_id();
-        let (zip_tx, zip_rx) = mpsc::channel();
+        let (zip_tx, zip_rx) = supply_event_channel();
 
         enum SourceKind {
-            Channel(mpsc::Receiver<SupplyEvent>),
+            Channel(SupplyReceiver),
             Static(Vec<Value>),
         }
         let mut sources: Vec<SourceKind> = Vec::with_capacity(supplies.len());
@@ -214,7 +215,16 @@ impl Interpreter {
                 }
             }
 
-            let timeout = std::time::Duration::from_millis(10);
+            // Sources poke this waker on every send/hangup; the loop blocks
+            // on it when a poll round makes no progress (the timeout is only
+            // a safety net, not the delivery latency).
+            let waker = crate::value::waker::ReactWaker::new();
+            for source in &sources {
+                if let SourceKind::Channel(rx) = source {
+                    rx.register_waker(&waker);
+                }
+            }
+            let timeout = std::time::Duration::from_millis(100);
 
             loop {
                 crate::gc::gc_park_point();
@@ -234,25 +244,30 @@ impl Interpreter {
                     return;
                 }
 
-                // Poll channel sources for new values
+                // Drain channel sources without blocking
+                let mut progressed = false;
                 for (i, source) in sources.iter().enumerate() {
                     if done[i] {
                         continue;
                     }
                     if let SourceKind::Channel(rx) = source {
-                        match rx.recv_timeout(timeout) {
-                            Ok(SupplyEvent::Emit(v)) => {
-                                buffers[i].push_back(v);
-                            }
-                            Ok(SupplyEvent::Done) => {
-                                done[i] = true;
-                            }
-                            Ok(SupplyEvent::Quit(_)) => {
-                                done[i] = true;
-                            }
-                            Err(mpsc::RecvTimeoutError::Timeout) => {}
-                            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                                done[i] = true;
+                        loop {
+                            match rx.try_recv() {
+                                Ok(SupplyEvent::Emit(v)) => {
+                                    buffers[i].push_back(v);
+                                    progressed = true;
+                                }
+                                Ok(SupplyEvent::Done) | Ok(SupplyEvent::Quit(_)) => {
+                                    done[i] = true;
+                                    progressed = true;
+                                    break;
+                                }
+                                Err(mpsc::TryRecvError::Empty) => break,
+                                Err(mpsc::TryRecvError::Disconnected) => {
+                                    done[i] = true;
+                                    progressed = true;
+                                    break;
+                                }
                             }
                         }
                     }
@@ -262,6 +277,9 @@ impl Interpreter {
                 if done.iter().all(|d| *d) {
                     let _ = zip_tx.send(SupplyEvent::Done);
                     return;
+                }
+                if !progressed {
+                    waker.wait_activity(timeout);
                 }
             }
         });

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1530,6 +1530,11 @@ pub struct Interpreter {
     /// promise resolves (the emitter signalled `done`), so per-tap
     /// `closing => { ... }` runs on the react thread rather than a worker thread.
     pub(super) pending_tap_closes: Vec<(crate::value::SharedPromise, Vec<Value>)>,
+    /// The waker of the innermost running react/await drive loop on this
+    /// thread, so sources wired up mid-loop (a nested `whenever` tapping an
+    /// async on-demand supply -> `pending_tap_closes`) can wake the loop when
+    /// they become ready instead of waiting out its idle cap.
+    pub(super) current_react_waker: Option<crate::value::waker::ReactWaker>,
     /// Shared variables between threads. When `start` spawns a thread,
     /// variables are stored here so both parent and child can see mutations.
     shared_vars: Arc<RwLock<HashMap<String, Value>>>,

--- a/src/runtime/native_io/native_io_path.rs
+++ b/src/runtime/native_io/native_io_path.rs
@@ -276,7 +276,7 @@ impl Interpreter {
             // `try_io_path_two_path_op`, which the VM also dispatches natively.
             "watch" => {
                 let supply_id = super::native_methods::next_supply_id();
-                let (tx, rx) = std::sync::mpsc::channel();
+                let (tx, rx) = super::native_methods::supply_channel::supply_event_channel();
                 if let Ok(mut map) = super::native_methods::supply_channel_map_pub().lock() {
                     map.insert(supply_id, rx);
                 }

--- a/src/runtime/native_methods/encoding.rs
+++ b/src/runtime/native_methods/encoding.rs
@@ -312,7 +312,7 @@ impl Interpreter {
     /// If the callback calls `exit`, terminates the entire process.
     pub(in crate::runtime) fn run_supply_act_loop(
         interp: &mut Interpreter,
-        rx: &std::sync::mpsc::Receiver<SupplyEvent>,
+        rx: &super::supply_channel::SupplyReceiver,
         cb: &Value,
         delay_seconds: f64,
     ) {

--- a/src/runtime/native_methods/interval_timer.rs
+++ b/src/runtime/native_methods/interval_timer.rs
@@ -16,7 +16,6 @@ use crate::runtime::native_methods::SupplyEvent;
 use crate::value::Value;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
-use std::sync::mpsc::Sender;
 use std::sync::{Condvar, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -139,7 +138,7 @@ pub(crate) fn clamp_delay_secs(secs: f64) -> Duration {
 pub(crate) fn register_interval(
     period: Duration,
     initial_delay: Duration,
-    tx: Sender<SupplyEvent>,
+    tx: super::supply_channel::SupplySender,
 ) {
     let mut tick: i64 = 0;
     register_entry(

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod state;
 pub(crate) mod state_lock;
 pub(crate) mod state_scheduler;
 pub(crate) mod state_supplier;
+pub(crate) mod supply_channel;
 mod system;
 
 // Re-export public items from state submodules so that

--- a/src/runtime/native_methods/socket_async.rs
+++ b/src/runtime/native_methods/socket_async.rs
@@ -2,7 +2,6 @@ use crate::runtime::*;
 use crate::symbol::Symbol;
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc;
 
 use super::state::*;
 use super::state_supplier::*;
@@ -352,7 +351,7 @@ impl Interpreter {
                 // Create a supply channel so the react event loop can
                 // receive accepted connections
                 let supply_id = next_supply_id();
-                let (tx, rx) = mpsc::channel::<SupplyEvent>();
+                let (tx, rx) = super::supply_channel::supply_event_channel();
                 if let Ok(mut map) = supply_channel_map().lock() {
                     map.insert(supply_id, rx);
                 }

--- a/src/runtime/native_methods/socket_async_conn.rs
+++ b/src/runtime/native_methods/socket_async_conn.rs
@@ -1,8 +1,6 @@
 use crate::runtime::*;
 use crate::symbol::Symbol;
 
-use std::sync::mpsc;
-
 use super::state::*;
 use crate::value::AttrMap;
 
@@ -118,7 +116,7 @@ impl Interpreter {
         // feeds the emitted value to `parse-http-request`, which expects a Blob.
         let is_bin = Self::named_bool(args, "bin");
         let supply_id = next_supply_id();
-        let (tx, rx) = mpsc::channel::<SupplyEvent>();
+        let (tx, rx) = super::supply_channel::supply_event_channel();
         if let Ok(mut map) = supply_channel_map().lock() {
             map.insert(supply_id, rx);
         }

--- a/src/runtime/native_methods/state.rs
+++ b/src/runtime/native_methods/state.rs
@@ -4,7 +4,6 @@ use std::net::TcpStream;
 use std::process::ChildStdin;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::mpsc;
 
 type StdinMap = std::sync::Mutex<HashMap<u32, Arc<std::sync::Mutex<Option<ChildStdin>>>>>;
 
@@ -127,7 +126,7 @@ fn udp_bound_socket_map() -> &'static UdpBoundSocketMap {
 
 /// Supply channel registry: supply_id -> Receiver for streaming data from
 /// Proc::Async stdout/stderr reader threads.
-type SupplyChannelMap = std::sync::Mutex<HashMap<u64, mpsc::Receiver<SupplyEvent>>>;
+type SupplyChannelMap = std::sync::Mutex<HashMap<u64, super::supply_channel::SupplyReceiver>>;
 
 pub(in crate::runtime) fn supply_channel_map() -> &'static SupplyChannelMap {
     static MAP: OnceLock<SupplyChannelMap> = OnceLock::new();
@@ -143,7 +142,7 @@ pub(crate) enum SupplyEvent {
 }
 
 /// Take a receiver from the supply channel registry (can only be consumed once)
-pub(crate) fn take_supply_channel(supply_id: u64) -> Option<mpsc::Receiver<SupplyEvent>> {
+pub(crate) fn take_supply_channel(supply_id: u64) -> Option<super::supply_channel::SupplyReceiver> {
     if let Ok(mut map) = supply_channel_map().lock() {
         map.remove(&supply_id)
     } else {
@@ -152,8 +151,7 @@ pub(crate) fn take_supply_channel(supply_id: u64) -> Option<mpsc::Receiver<Suppl
 }
 
 /// Public access to the supply channel map for signal registration
-pub(in crate::runtime) fn supply_channel_map_pub()
--> &'static std::sync::Mutex<HashMap<u64, mpsc::Receiver<SupplyEvent>>> {
+pub(in crate::runtime) fn supply_channel_map_pub() -> &'static SupplyChannelMap {
     supply_channel_map()
 }
 

--- a/src/runtime/native_methods/supply_channel.rs
+++ b/src/runtime/native_methods/supply_channel.rs
@@ -1,0 +1,110 @@
+//! Waker-aware `SupplyEvent` channel: an mpsc pair whose sender pokes every
+//! [`ReactWaker`] registered on the receiving end after each send (and on
+//! sender drop), so a react/await drive loop blocked on its waker wakes
+//! immediately instead of waiting out the poll-round idle cap (ADR-0008
+//! follow-up — these mpsc receiver sources were the last supply inputs that
+//! could only be observed by polling).
+//!
+//! The waker set is shared between all sender clones and the receiver;
+//! registration is idempotent per waker identity, and the drive loop
+//! unregisters on every exit path.
+use super::SupplyEvent;
+use crate::value::waker::ReactWaker;
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+
+type WakerSet = Arc<Mutex<Vec<ReactWaker>>>;
+
+fn notify_all(wakers: &WakerSet) {
+    if let Ok(ws) = wakers.lock() {
+        for w in ws.iter() {
+            w.notify();
+        }
+    }
+}
+
+/// Sending half. Cloneable like `mpsc::Sender`; every clone shares the
+/// receiver's waker set. Dropping the last live clone also pokes the wakers
+/// so a drive loop notices the disconnect promptly.
+#[derive(Debug)]
+pub(crate) struct SupplySender {
+    tx: mpsc::Sender<SupplyEvent>,
+    wakers: WakerSet,
+}
+
+impl Clone for SupplySender {
+    fn clone(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+            wakers: Arc::clone(&self.wakers),
+        }
+    }
+}
+
+impl SupplySender {
+    pub(crate) fn send(&self, event: SupplyEvent) -> Result<(), mpsc::SendError<SupplyEvent>> {
+        self.tx.send(event)?;
+        notify_all(&self.wakers);
+        Ok(())
+    }
+}
+
+impl Drop for SupplySender {
+    fn drop(&mut self) {
+        // A disconnected channel is an event too (the drive loop retires the
+        // subscription on `TryRecvError::Disconnected`): wake the consumer so
+        // it observes the hangup without waiting out its idle cap. Bare pokes
+        // from non-final clones are harmless.
+        notify_all(&self.wakers);
+    }
+}
+
+/// Receiving half. Non-blocking `try_recv` only — the drive loop's pacing
+/// comes from blocking on its waker, which senders poke.
+#[derive(Debug)]
+pub(crate) struct SupplyReceiver {
+    rx: mpsc::Receiver<SupplyEvent>,
+    wakers: WakerSet,
+}
+
+impl SupplyReceiver {
+    pub(crate) fn try_recv(&self) -> Result<SupplyEvent, mpsc::TryRecvError> {
+        self.rx.try_recv()
+    }
+
+    /// Blocking receive, for dedicated consumer threads (e.g. the
+    /// Proc::Async stdin feeder). Drive loops must use `try_recv` +
+    /// waker-blocking instead.
+    pub(crate) fn recv(&self) -> Result<SupplyEvent, mpsc::RecvError> {
+        self.rx.recv()
+    }
+
+    /// Register a drive-loop waker to poke on future sends (no-op if this
+    /// exact waker is already registered).
+    pub(crate) fn register_waker(&self, waker: &ReactWaker) {
+        if let Ok(mut ws) = self.wakers.lock()
+            && !ws.iter().any(|w| w.id() == waker.id())
+        {
+            ws.push(waker.clone());
+        }
+    }
+
+    pub(crate) fn unregister_waker(&self, waker_id: usize) {
+        if let Ok(mut ws) = self.wakers.lock() {
+            ws.retain(|w| w.id() != waker_id);
+        }
+    }
+}
+
+/// Create a waker-aware `SupplyEvent` channel pair.
+pub(crate) fn supply_event_channel() -> (SupplySender, SupplyReceiver) {
+    let (tx, rx) = mpsc::channel();
+    let wakers: WakerSet = Arc::new(Mutex::new(Vec::new()));
+    (
+        SupplySender {
+            tx,
+            wakers: Arc::clone(&wakers),
+        },
+        SupplyReceiver { rx, wakers },
+    )
+}

--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -3,7 +3,6 @@ use super::*;
 use crate::symbol::Symbol;
 use crate::value::AttrMap;
 use std::io::{Read, Write};
-use std::sync::mpsc;
 
 /// Create a Buf Value from raw bytes.
 fn make_buf_value(bytes: &[u8]) -> Value {
@@ -24,7 +23,7 @@ fn make_buf_value(bytes: &[u8]) -> Value {
 fn feed_utf8_incremental(
     pending: &mut Vec<u8>,
     new: &[u8],
-    tx: &Option<mpsc::Sender<SupplyEvent>>,
+    tx: &Option<super::native_methods::supply_channel::SupplySender>,
     collected: &mut String,
 ) -> bool {
     pending.extend_from_slice(new);
@@ -244,14 +243,16 @@ impl Interpreter {
 
                     // Send Quit to stdout/stderr supply channels so react blocks die
                     if let Some(sid) = stdout_supply_id {
-                        let (tx, rx) = mpsc::channel();
+                        let (tx, rx) =
+                            super::native_methods::supply_channel::supply_event_channel();
                         if let Ok(mut map) = supply_channel_map().lock() {
                             map.insert(sid, rx);
                         }
                         let _ = tx.send(SupplyEvent::Quit(os_error.clone()));
                     }
                     if let Some(sid) = stderr_supply_id {
-                        let (tx, rx) = mpsc::channel();
+                        let (tx, rx) =
+                            super::native_methods::supply_channel::supply_event_channel();
                         if let Ok(mut map) = supply_channel_map().lock() {
                             map.insert(sid, rx);
                         }
@@ -371,14 +372,14 @@ impl Interpreter {
                 // Create streaming channels for stdout/stderr
                 // These will be consumed by the react event loop
                 let stdout_channel = stdout_supply_id.map(|sid| {
-                    let (tx, rx) = mpsc::channel();
+                    let (tx, rx) = super::native_methods::supply_channel::supply_event_channel();
                     if let Ok(mut map) = supply_channel_map().lock() {
                         map.insert(sid, rx);
                     }
                     tx
                 });
                 let stderr_channel = stderr_supply_id.map(|sid| {
-                    let (tx, rx) = mpsc::channel();
+                    let (tx, rx) = super::native_methods::supply_channel::supply_event_channel();
                     if let Ok(mut map) = supply_channel_map().lock() {
                         map.insert(sid, rx);
                     }

--- a/src/runtime/native_supply_dispatch.rs
+++ b/src/runtime/native_supply_dispatch.rs
@@ -962,6 +962,9 @@ impl Interpreter {
 
                     if is_latest && has_channel {
                         // Channel-based zip-latest: spawn coordination thread
+                        use crate::runtime::native_methods::supply_channel::{
+                            SupplyReceiver, supply_event_channel,
+                        };
                         use crate::runtime::native_methods::{
                             SupplyEvent, next_supply_id, supply_channel_map_pub,
                             take_supply_channel,
@@ -969,10 +972,10 @@ impl Interpreter {
                         use std::sync::mpsc;
 
                         let zip_supply_id = next_supply_id();
-                        let (zip_tx, zip_rx) = mpsc::channel();
+                        let (zip_tx, zip_rx) = supply_event_channel();
 
                         enum SourceKind {
-                            Channel(mpsc::Receiver<SupplyEvent>),
+                            Channel(SupplyReceiver),
                             Static(Vec<Value>),
                         }
 
@@ -1006,7 +1009,16 @@ impl Interpreter {
                             let n = sources.len();
                             let mut latest: Vec<Option<Value>> = vec![None; n];
                             let mut done: Vec<bool> = vec![false; n];
-                            let timeout_dur = std::time::Duration::from_millis(10);
+                            // Sources poke this waker on every send/hangup;
+                            // the loop blocks on it when a poll round makes no
+                            // progress (the timeout is only a safety net).
+                            let waker = crate::value::waker::ReactWaker::new();
+                            for source in &sources {
+                                if let SourceKind::Channel(rx) = source {
+                                    rx.register_waker(&waker);
+                                }
+                            }
+                            let timeout_dur = std::time::Duration::from_millis(100);
 
                             // Pre-fill from static sources
                             for (i, source) in sources.iter().enumerate() {
@@ -1020,40 +1032,46 @@ impl Interpreter {
 
                             loop {
                                 crate::gc::gc_park_point();
-                                // Poll channel sources
+                                // Drain channel sources without blocking
+                                let mut progressed = false;
                                 for (i, source) in sources.iter().enumerate() {
                                     if done[i] {
                                         continue;
                                     }
                                     if let SourceKind::Channel(rx) = source {
-                                        match rx.recv_timeout(timeout_dur) {
-                                            Ok(SupplyEvent::Emit(v)) => {
-                                                latest[i] = Some(v);
-                                                // Emit if all sources have a value
-                                                if latest.iter().all(|v| v.is_some()) {
-                                                    let tuple: Vec<Value> = latest
-                                                        .iter()
-                                                        .map(|v| v.clone().unwrap())
-                                                        .collect();
-                                                    if zip_tx
-                                                        .send(SupplyEvent::Emit(Value::array(
-                                                            tuple,
-                                                        )))
-                                                        .is_err()
-                                                    {
-                                                        return;
+                                        loop {
+                                            match rx.try_recv() {
+                                                Ok(SupplyEvent::Emit(v)) => {
+                                                    progressed = true;
+                                                    latest[i] = Some(v);
+                                                    // Emit if all sources have a value
+                                                    if latest.iter().all(|v| v.is_some()) {
+                                                        let tuple: Vec<Value> = latest
+                                                            .iter()
+                                                            .map(|v| v.clone().unwrap())
+                                                            .collect();
+                                                        if zip_tx
+                                                            .send(SupplyEvent::Emit(Value::array(
+                                                                tuple,
+                                                            )))
+                                                            .is_err()
+                                                        {
+                                                            return;
+                                                        }
                                                     }
                                                 }
-                                            }
-                                            Ok(SupplyEvent::Done) => {
-                                                done[i] = true;
-                                            }
-                                            Ok(SupplyEvent::Quit(_)) => {
-                                                done[i] = true;
-                                            }
-                                            Err(mpsc::RecvTimeoutError::Timeout) => {}
-                                            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                                                done[i] = true;
+                                                Ok(SupplyEvent::Done)
+                                                | Ok(SupplyEvent::Quit(_)) => {
+                                                    done[i] = true;
+                                                    progressed = true;
+                                                    break;
+                                                }
+                                                Err(mpsc::TryRecvError::Empty) => break,
+                                                Err(mpsc::TryRecvError::Disconnected) => {
+                                                    done[i] = true;
+                                                    progressed = true;
+                                                    break;
+                                                }
                                             }
                                         }
                                     }
@@ -1063,6 +1081,9 @@ impl Interpreter {
                                 if done.iter().all(|d| *d) {
                                     let _ = zip_tx.send(SupplyEvent::Done);
                                     return;
+                                }
+                                if !progressed {
+                                    waker.wait_activity(timeout_dur);
                                 }
                             }
                         });

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -495,6 +495,12 @@ impl Interpreter {
                             } else if let Some(p) = close_done_promise {
                                 // Async body: the drive loop fires the callbacks
                                 // once the emitter's done-signal promise resolves.
+                                // Wake the loop when that happens so it doesn't
+                                // wait out its idle cap to notice.
+                                if let Some(w) = &self.current_react_waker {
+                                    let w = w.clone();
+                                    let _ = p.on_resolve(Box::new(move |_, _, _, _| w.notify()));
+                                }
                                 self.pending_tap_closes.push((p, own_close_cbs));
                                 if !outer_tap_registered
                                     && Self::supply_has_active_callback(&tap_cb)

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2102,6 +2102,7 @@ impl Interpreter {
             supply_stream_consumers: Vec::new(),
             react_active: 0,
             pending_tap_closes: Vec::new(),
+            current_react_waker: None,
             shared_vars: Arc::new(RwLock::new(HashMap::new())),
             shared_vars_active: false,
             sigilless_attrs_active: false,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -296,6 +296,7 @@ impl Interpreter {
             supply_stream_consumers: Vec::new(),
             react_active: 0,
             pending_tap_closes: Vec::new(),
+            current_react_waker: None,
             shared_vars: Arc::clone(&self.shared_vars),
             shared_vars_active: true,
             sigilless_attrs_active: self.sigilless_attrs_active,

--- a/src/runtime/signal_watcher.rs
+++ b/src/runtime/signal_watcher.rs
@@ -4,7 +4,6 @@
 /// and a reader thread picks it up and sends it through the Supply channel.
 use crate::runtime::native_methods::SupplyEvent;
 use crate::value::Value;
-use std::sync::mpsc;
 
 #[cfg(unix)]
 mod unix_impl {
@@ -15,7 +14,7 @@ mod unix_impl {
     struct SignalRegistration {
         #[allow(dead_code)]
         supply_id: u64,
-        tx: mpsc::Sender<SupplyEvent>,
+        tx: crate::runtime::native_methods::supply_channel::SupplySender,
         value: Value,
     }
 
@@ -96,7 +95,7 @@ mod unix_impl {
     pub(in crate::runtime) fn register_signal(
         signum: i32,
         supply_id: u64,
-        tx: mpsc::Sender<SupplyEvent>,
+        tx: crate::runtime::native_methods::supply_channel::SupplySender,
         value: Value,
     ) {
         // Ensure signal pipe is set up
@@ -131,7 +130,7 @@ pub(super) use unix_impl::register_signal;
 pub(super) fn register_signal(
     _signum: i32,
     _supply_id: u64,
-    _tx: mpsc::Sender<SupplyEvent>,
+    _tx: crate::runtime::native_methods::supply_channel::SupplySender,
     _value: Value,
 ) {
     // Signal handling is not available on non-Unix platforms

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -1,11 +1,10 @@
 use super::*;
-use crate::runtime::native_methods::SupplyEvent;
+use crate::runtime::native_methods::supply_channel::SupplyReceiver;
 use crate::symbol::Symbol;
-use std::sync::mpsc;
 
 /// A subscription registered by a `whenever` block inside a `react` block.
 pub(crate) struct ReactSubscription {
-    pub receiver: Option<mpsc::Receiver<SupplyEvent>>,
+    pub receiver: Option<SupplyReceiver>,
     pub supplier_id: Option<u64>,
     pub callback: Value,
     pub close_callbacks: Vec<Value>,

--- a/src/vm/vm_react_loop.rs
+++ b/src/vm/vm_react_loop.rs
@@ -26,7 +26,6 @@ use crate::runtime::native_methods::{
     SupplyEvent, next_supplier_id, supplier_register_promise, take_supply_channel,
 };
 use crate::runtime::subtest::{ReactSubscription, StreamConsumer, SupplyDrivePolicy};
-use std::sync::mpsc;
 
 impl Interpreter {
     /// Dispatch a `whenever` body or one of its `LAST` / `QUIT` / `CLOSE` phaser
@@ -377,7 +376,8 @@ impl Interpreter {
                     // Promise source
                     ValueView::Promise(shared) => {
                         // Create a one-shot channel for the promise
-                        let (tx, rx) = mpsc::channel();
+                        let (tx, rx) =
+                            crate::runtime::native_methods::supply_channel::supply_event_channel();
                         let shared_clone = shared.clone();
                         // Registered spawn: `wait()` clones the resolved
                         // result `Value` and the promise handle drops at

--- a/src/vm/vm_react_subscriptions.rs
+++ b/src/vm/vm_react_subscriptions.rs
@@ -19,11 +19,11 @@ use crate::value::waker::{ReactWaker, SinkEvent};
 use std::sync::mpsc;
 use std::time::Duration;
 
-/// Idle-wait cap for one drive-loop round. Supplier events, promise
-/// resolutions and channel sends wake the loop instantly; this cap only
-/// bounds the latency of the remaining polled sources (mpsc receivers,
-/// pending tap-close promises) and the Promise-policy deadline check.
-const REACT_IDLE_WAIT: Duration = Duration::from_millis(10);
+/// Idle-wait cap for one drive-loop round. Every source now wakes the loop
+/// (supplier sinks, promise/on-demand-done/tap-close `on_resolve` hooks,
+/// channel and mpsc-receiver `SupplySender` pokes), so this is a safety net
+/// against a missed wake-up, not a delivery-latency bound.
+const REACT_IDLE_WAIT: Duration = Duration::from_millis(250);
 
 impl Interpreter {
     /// Deliver every event queued on the drive loop's waker to its
@@ -216,25 +216,39 @@ impl Interpreter {
                 sink_regs.push((sid, supplier_sink_register(sid, i, &waker)));
             }
         }
-        // Promise / channel sources still deliver their payloads through the
-        // existing receiver / poll paths, but wake the loop instantly instead
-        // of waiting out the idle cap.
+        // Promise / channel / mpsc-receiver sources still deliver their
+        // payloads through the existing receiver / poll paths, but wake the
+        // loop instantly instead of waiting out the idle cap.
         for sub in &react_subs {
             if let Some(p) = &sub.promise {
+                let w = waker.clone();
+                let _ = p.on_resolve(Box::new(move |_, _, _, _| w.notify()));
+            }
+            if let Some(p) = &sub.on_demand_done {
                 let w = waker.clone();
                 let _ = p.on_resolve(Box::new(move |_, _, _, _| w.notify()));
             }
             if let Some(ch) = &sub.channel {
                 ch.register_waker(&waker);
             }
+            if let Some(rx) = &sub.receiver {
+                rx.register_waker(&waker);
+            }
         }
+        // Publish this loop's waker so sources wired up mid-loop (a nested
+        // `whenever` tapping an async on-demand supply) can wake it too.
+        let prev_waker = self.current_react_waker.replace(waker.clone());
         let result = self.drive_react_subscriptions_loop(&mut react_subs, policy, &waker);
+        self.current_react_waker = prev_waker;
         for (sid, sink_id) in sink_regs {
             supplier_sink_unregister(sid, sink_id);
         }
         for sub in &react_subs {
             if let Some(ch) = &sub.channel {
                 ch.unregister_waker(waker.id());
+            }
+            if let Some(rx) = &sub.receiver {
+                rx.unregister_waker(waker.id());
             }
         }
         result


### PR DESCRIPTION
PLAN §6 **ADR-0008 push-delivery follow-up** (second slice): the react/await drive loop still polled its mpsc receiver sources — interval ticks, Proc::Async stdout/stderr, zip outputs, signal watchers, `IO::Path.watch`, socket accept/read pumps — on a **10ms idle cap**, the last supply inputs observable only by polling.

## What changed

- **New `native_methods/supply_channel.rs`**: `SupplySender` / `SupplyReceiver` wrap the mpsc pair with a shared waker set. Every `send` (and the sender **drop**, so disconnects are noticed promptly) pokes each `ReactWaker` registered on the receiving end. All ~10 `SupplyEvent` channel construction sites and the `supply_channel_map` registry move to the wrapper — the type change makes the compiler prove no raw-mpsc supply channel remains.
- **Drive loop** registers its waker on every receiver-backed subscription (unregistering on all exit paths), hooks `on_demand_done` promises via `on_resolve`, and publishes the loop's waker on the Interpreter (`current_react_waker`) so a nested `whenever` tapping an async on-demand supply mid-loop wakes it when the pending tap-close resolves.
- **Zip / zip-latest coordinators** switch from per-source `recv_timeout(10ms)` round-robin to drain-all `try_recv` + blocking on one waker registered across all their sources.
- **`REACT_IDLE_WAIT` 10ms → 250ms**: every source now wakes the loop, so the cap is a missed-wakeup safety net, not a delivery-latency bound (per the PLAN slice: "removes the react drive loop's residual 10ms idle-wait cap").

## Measured

An idle react (`whenever Supply.interval(60) {}; whenever Promise.in(3) { done }`) drops from **887 → 340 futex calls (−62%)** under `strace -c` — the ~300 10ms-poll timeouts are gone.

## Verification

- `make test` green (1772 files).
- roast: S17-procasync (all 10 whitelisted), S17-supply syntax/zip/zip-latest/interval/batch/throttle all pass locally.
- gc-stress config (`MUTSU_GC=on MUTSU_GC_EVERY_CANDIDATE=50 MUTSU_GC_VERIFY=1`): `t/react-supplier-done.t` ×3 and `roast/S17-supply/syntax.t` pass, no VERIFY FAIL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)