### PR TITLE
docs: record the ADR-0008 follow-up slices that landed (#4638, #4639)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -551,11 +551,21 @@ unification / the malloc clusters from `Value` clone/drop and attribute material
 - [ ] **ADR-0008 push-delivery follow-ups** (the core landed in #4636 and the first two follow-up
       slices in #4638 / #4639, 2026-07-17; see docs/adr/0008-push-based-supply-event-delivery.md
       and news/2026-07.md). What is left:
-  - [ ] Move the repeating `cue(:every)` loop onto the shared deadline-heap timer. `:in`/`:at`
-        delays landed in #4638, but an `:every` cue still owns a worker thread that sleeps between
-        iterations. Each iteration runs user VM code, so it cannot fire on the timer driver itself —
-        the timer entry must hand off to a worker (and skip a tick if the previous one is still
-        running), which is why this was split out rather than done with the one-shot path.
+  - [ ] Get the repeating `cue(:every)` loop off its dedicated worker thread. `:in`/`:at` delays
+        landed in #4638, but an `:every` cue still owns a thread that sleeps between iterations, so
+        idle `:every` cues are expensive: 50 idle `cue(:every(60))` cost **RSS +21 MB / VmSize
+        +16.4 GB** (50 × the 256 MiB `USER_THREAD_STACK_SIZE`, since each iteration runs user VM
+        code and needs the deep-recursion headroom) versus raku's **+3 MB / +25 MB**.
+        **This needs a worker pool first, not just the timer.** A timer entry cannot fire user code
+        on the driver thread, so the deadline heap would have to spawn a fresh 256 MiB-stack worker
+        (plus a `clone_for_thread`) per tick — likely a regression for short periods, and no help at
+        all for the steady-state thread count. raku gets this right because its timer hands off to a
+        `ThreadPoolScheduler`; mutsu spawns a thread per task at all ~27 `spawn_user_thread` sites.
+        So the real slice is **a shared worker pool** (write a Proposed ADR: pool sizing, the
+        deep-stack requirement, GC-mutator registration per pooled thread, and which of the 27 sites
+        migrate), after which `:every` becomes a timer entry that enqueues onto it (skipping a tick
+        when the previous iteration is still running). Also decides whether `start`/`Promise.start`
+        stop paying a thread spawn each.
   - [ ] Watch CI for the residual under-load syntax.t flake (1 notok in 18 loaded runs locally,
         unreproduced in 14 follow-ups; raku's own fixed-sleep tests also wobble at that load).
 - [ ] **Remainder of true sharing for state/lexical aggregates**: only the lost-update on

--- a/PLAN.md
+++ b/PLAN.md
@@ -548,14 +548,14 @@ unification / the malloc clusters from `Value` clone/drop and attribute material
 
 ## 6. Concurrency (Track C leftovers) and structural refactoring (independent; mid-to-long term)
 
-- [ ] **ADR-0008 push-delivery follow-ups** (the core landed in #4636, 2026-07-17 — react/supply
-      snapshot polling replaced by `ReactWaker` sinks, shared interval timer, concurrent throttle;
-      see docs/adr/0008-push-based-supply-event-delivery.md and news/2026-07.md):
-  - [ ] Route the remaining mpsc receiver sources (tap channels, Proc::Async streams, zip outputs)
-        through `ReactWaker` sinks — removes the react drive loop's residual 10ms idle-wait cap
-        (today those senders cannot wake the loop, so idle rounds are capped at 10ms latency).
-  - [ ] Move `Promise.in` / scheduler `cue(:at/:in/:every)` timer threads onto the shared
-        deadline-heap timer (`native_methods/interval_timer.rs`) — one thread per pending timer today.
+- [ ] **ADR-0008 push-delivery follow-ups** (the core landed in #4636 and the first two follow-up
+      slices in #4638 / #4639, 2026-07-17; see docs/adr/0008-push-based-supply-event-delivery.md
+      and news/2026-07.md). What is left:
+  - [ ] Move the repeating `cue(:every)` loop onto the shared deadline-heap timer. `:in`/`:at`
+        delays landed in #4638, but an `:every` cue still owns a worker thread that sleeps between
+        iterations. Each iteration runs user VM code, so it cannot fire on the timer driver itself —
+        the timer entry must hand off to a worker (and skip a tick if the previous one is still
+        running), which is why this was split out rather than done with the one-shot path.
   - [ ] Watch CI for the residual under-load syntax.t flake (1 notok in 18 loaded runs locally,
         unreproduced in 14 follow-ups; raku's own fixed-sleep tests also wobble at that load).
 - [ ] **Remainder of true sharing for state/lexical aggregates**: only the lost-update on

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -77,9 +77,12 @@ the old model (PLAN §6):
   went from **887 to 340 futex calls (−62%)**.
 
 Still on the old model: a repeating `cue(:every)` owns a worker thread that
-sleeps between iterations. Each iteration runs user VM code, so it cannot fire
-on the timer driver itself — that slice needs a hand-off (and tick-skip when an
-iteration overruns) and is tracked in PLAN §6.
+sleeps between iterations (50 idle `cue(:every(60))` = RSS +21 MB / VmSize
++16.4 GB, against raku's +3 MB / +25 MB). Measuring it showed the timer is not
+the missing piece: each iteration runs user VM code, so a timer entry would
+have to spawn a fresh 256 MiB-stack worker per tick. raku wins here because its
+timer hands off to a thread pool, which mutsu does not have — tracked in PLAN
+§6 as a worker-pool slice, not a timer one.
 
 ## 2026-07-16: integration/advent2012-day09 + advent2011-day11 whitelisted (frugal-ratchet + sigspace-capture + EVAL fixes)
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -46,6 +46,41 @@ CPU time dropped from ~206s to under 30s.
 An idle `react whenever $supplier` now waits at ~0 CPU and wakes in the emit's
 lock-handoff time. Pin: `t/react-supplier-done.t`.
 
+**Follow-ups the same day** finished the two mechanisms the core PR had left on
+the old model (PLAN §6):
+
+- **Every timed event shares one driver thread** (#4638). `interval_timer.rs`
+  generalized from an interval-only heap into a deadline heap of closure
+  actions — an action returns `Some(period)` to reschedule (intervals) or
+  `None` to die (one-shot), and due actions run with the heap lock *released*
+  so an action may register further timers. `Promise.in`/`.at` and
+  `Scheduler.cue(:in/:at)` moved onto it: a pending timer no longer holds a
+  sleeping OS thread (**100 pending `Promise.in` = 102 → 3 threads**). Keeping
+  a promise from the driver is safe because `SharedPromise::keep` dispatches
+  waiters to their own thread rather than running user code on the resolver.
+  Fixes on the way: `Promise.in(Inf)` panicked in `Duration::from_secs_f64`
+  (now means never-resolve), and a cue's delay used to `sleep` un-quiesced on a
+  GC-registered thread, stalling any stop-the-world for its whole duration.
+  Pin: `t/timer-heap-threads.t` (passes on raku too).
+- **The last polled sources now wake the loop** (#4639). Interval ticks,
+  Proc::Async stdout/stderr, zip outputs, signal watchers, `IO::Path.watch` and
+  the socket pumps delivered through raw mpsc channels, which the drive loop
+  could only observe by re-polling every 10ms. `native_methods/supply_channel.rs`
+  wraps the mpsc pair as `SupplySender`/`SupplyReceiver` sharing a waker set;
+  every send — and the sender's *drop*, so hangups register too — pokes the
+  consumer's `ReactWaker`. Making the registry and `ReactSubscription` hold the
+  wrapper types let the compiler prove no raw supply channel was missed. The
+  zip/zip-latest coordinators likewise dropped their per-source
+  `recv_timeout(10ms)` round-robin for drain-all + one waker. With every source
+  now pushing, `REACT_IDLE_WAIT` is a missed-wakeup safety net (10ms → 250ms)
+  rather than a latency floor: an idle react (`interval(60)` + `Promise.in(3)`)
+  went from **887 to 340 futex calls (−62%)**.
+
+Still on the old model: a repeating `cue(:every)` owns a worker thread that
+sleeps between iterations. Each iteration runs user VM code, so it cannot fire
+on the timer driver itself — that slice needs a hand-off (and tick-skip when an
+iteration overruns) and is tracked in PLAN §6.
+
 ## 2026-07-16: integration/advent2012-day09 + advent2011-day11 whitelisted (frugal-ratchet + sigspace-capture + EVAL fixes)
 
 Two ★-frontier `integration/` files reached the whitelist (both full raku pass),


### PR DESCRIPTION
Both timer/waker follow-ups from PLAN §6 have landed, so their descriptions move from PLAN (future work) to news/2026-07.md (what happened), per the repo's PLAN/news split.

**The remaining `cue(:every)` slice is also corrected here, because measuring it changed what the slice is.** PLAN previously said "move the `:every` timer thread onto the shared deadline-heap timer". That is the wrong fix:

- 50 idle `cue(:every(60))` cost **RSS +21 MB / VmSize +16.4 GB** (50 × the 256 MiB `USER_THREAD_STACK_SIZE`) against raku's **+3 MB / +25 MB** — so the cost is real and worth fixing.
- But each `:every` iteration runs user VM code, so a timer entry can't fire it on the driver thread. The heap would have to spawn a fresh 256 MiB-stack worker (plus a `clone_for_thread`) per tick — a likely regression at short periods and no help to the steady-state thread count.
- raku gets this right because its timer hands off to a `ThreadPoolScheduler`. mutsu spawns a thread per task at all ~27 `spawn_user_thread` sites.

So §6 now records the real prerequisite: a shared worker pool (with a Proposed ADR covering pool sizing, the deep-stack requirement, per-pooled-thread GC-mutator registration, and which sites migrate), after which `:every` becomes a timer entry that enqueues onto it. The residual under-load syntax.t flake watch also stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)