### PR TITLE
fix: .clone on a role mixin keeps its attributes instead of dropping them

### DIFF
--- a/src/runtime/methods_mixin_dispatch.rs
+++ b/src/runtime/methods_mixin_dispatch.rs
@@ -14,6 +14,45 @@ impl Interpreter {
             return None;
         };
 
+        // `.clone` on a role mixin. A punned role's attributes live in
+        // `__mutsu_attr__*` mixin markers, not the inner instance's attr map (see
+        // `dispatch_new` — a bare-role `.new` returns `Mixin(empty-instance,
+        // {__mutsu_attr__x: ...})`). The generic instance clone unwraps to the
+        // inner value and drops every marker, so the clone lost all attributes
+        // (`Zef::Client.fetch`'s `$candi.clone(:$dist)` then had no `.as`). Clone
+        // the mixin instead: recursively clone the inner value, copy every marker,
+        // and apply each `:attr(val)` override to its `__mutsu_attr__` marker.
+        // Restricted to role mixins (a `__mutsu_role__`/`__mutsu_attr__` marker is
+        // present) so allomorph / non-role `but` mixins keep their existing path.
+        if method == "clone"
+            && mixins
+                .keys()
+                .any(|k| k.starts_with("__mutsu_role__") || k.starts_with("__mutsu_attr__"))
+        {
+            let inner_owned = inner.as_ref().clone();
+            let mut new_mixins: HashMap<String, Value> = mixins.as_ref().clone();
+            // An override names either a role attribute (a `__mutsu_attr__`
+            // marker) or an attribute of the inner class. Apply the former to the
+            // marker; forward the rest to the inner clone so `$w.clone(:id(99))`
+            // on a `Widget but Named` still overrides Widget's own `$.id`.
+            let mut inner_args: Vec<Value> = Vec::new();
+            for arg in &args {
+                if let ValueView::Pair(key, val) = arg.view()
+                    && let std::collections::hash_map::Entry::Occupied(mut e) =
+                        new_mixins.entry(format!("__mutsu_attr__{}", key))
+                {
+                    e.insert(val.clone());
+                    continue;
+                }
+                inner_args.push(arg.clone());
+            }
+            let inner_clone = match self.call_method_with_values(inner_owned, "clone", inner_args) {
+                Ok(v) => v,
+                Err(e) => return Some(Err(e)),
+            };
+            return Some(Ok(Value::mixin(inner_clone, new_mixins)));
+        }
+
         if args.is_empty() {
             if let Some(mixin_val) = mixins.get(method) {
                 return Some(Ok(mixin_val.clone()));

--- a/t/punned-role-clone-attrs.t
+++ b/t/punned-role-clone-attrs.t
@@ -1,0 +1,52 @@
+use Test;
+
+# A punned role's attributes live in `__mutsu_attr__*` mixin markers rather than
+# the inner instance's attribute map: a bare-role `.new` returns
+# `Mixin(empty-instance, {__mutsu_attr__x => ...})`. `.clone` fell through to the
+# generic instance clone, which unwraps to the (empty) inner value and drops every
+# marker — so the clone lost ALL attributes. Regression: zef's `Zef::Client.fetch`
+# does `$candi.clone(:$dist)` on a `Zef::Candidate` (a punned role), and the clone
+# then had no `.as`, so `zef fetch` died with "No such method 'as'".
+
+plan 8;
+
+# 1) Punned-role clone preserves non-overridden attributes and applies the override.
+{
+    role R1 { has $.dist; has Str $.as; has $.uri is rw; }
+    my $b = R1.new(dist => "d1", as => "REQ", uri => "u1");
+    my $c = $b.clone(dist => "d2");
+    is $c.as, "REQ", "punned-role clone keeps a non-overridden attribute";
+    is $c.uri, "u1", "punned-role clone keeps a second non-overridden attribute";
+    is $c.dist, "d2", "punned-role clone applies the override";
+}
+
+# 2) A no-arg clone copies everything, including an rw-mutated attribute.
+{
+    role R2 { has $.as; has $.uri is rw; }
+    my $b = R2.new(as => "REQ", uri => "u1");
+    $b.uri = "MUT";
+    my $c = $b.clone;
+    is $c.uri, "MUT", "no-arg punned-role clone keeps an rw-mutated attribute";
+    is $c.as, "REQ", "no-arg punned-role clone keeps a new-time attribute";
+}
+
+# 3) The clone is independent of the original (fresh containers).
+{
+    role R3 { has $.uri is rw; }
+    my $b = R3.new(uri => "orig");
+    my $c = $b.clone;
+    $c.uri = "changed";
+    is $b.uri, "orig", "mutating the clone does not affect the original";
+}
+
+# 4) A `but Role` mixin over a real class: the role attribute AND the inner
+#    class's own attribute both survive, and an override of either works.
+{
+    role Named { has $.name is rw; }
+    class Widget { has $.id; }
+    my $w = Widget.new(id => 1) but Named;
+    $w.name = "hi";
+    my $w2 = $w.clone(id => 99);
+    is $w2.name, "hi", "but-mixin clone keeps the role attribute";
+    is $w2.id, 99, "but-mixin clone forwards an inner-class attribute override";
+}


### PR DESCRIPTION
## Summary

A punned role's attributes live in `__mutsu_attr__*` **mixin markers**, not in the inner instance's attribute map: a bare-role `.new` returns `Mixin(empty-instance, {__mutsu_attr__x => ...})` (see `dispatch_new`). `.clone` was not handled for mixins, so it fell through to the generic instance clone, which unwrapped to the (empty) inner value and dropped every marker — **the clone came back with no attributes at all**, and as a bare `Instance` rather than a `Mixin`.

## Fix

Handle `clone` in `dispatch_mixin_method_call`:
- recursively clone the inner value,
- copy every mixin marker,
- apply each `:attr(val)` override to its matching `__mutsu_attr__` marker,
- forward overrides that do *not* name a role attribute to the inner clone, so `$w.clone(:id(99))` on a `Widget but Named` still overrides Widget's own `$.id`.

Restricted to role mixins (a `__mutsu_role__`/`__mutsu_attr__` marker is present) so allomorph and non-role mixins keep their existing path.

## Context

Regression fixed: zef's `Zef::Client.fetch` does `$candi.clone(:$dist)` on a `Zef::Candidate` (a punned role), and the clone then had no `.as`, so `zef fetch` died with `No such method 'as' for invocant of type 'Zef::Candidate'` — the blocker immediately after the extract phase (which #4635 unblocked).

## Known remaining gap

`.^attributes`, `$!priv` access and `.raku` are still blind to the `__mutsu_attr__` storage for punned roles (e.g. `R.new(as=>"x").raku` shows `R.new`, and `.^attributes` is empty). The deeper fix is to pun a role into a real class with a normal attribute map; this PR fixes only the clone path.

## Test

`t/punned-role-clone-attrs.t` — 8 cases: punned-role clone keeps non-overridden attrs and applies the override, no-arg clone keeps rw-mutated and new-time attrs, clone independence (mutating the clone does not affect the original), and `but Role` mixins keep the role attribute while forwarding an inner-class override.

`make test` passes. Role/construction roast (`S14-roles/basic`, `composition`, `instantiation`, `mixin-6e`, `parameterized-mixin`, `parameterized-basic`, `rw`, `S12-construction/roles-6e`, `new`, `construction`) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)