### PR TITLE
docs: correct the recursive-start fix direction — `start` already uses per-binding cells

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -640,12 +640,52 @@ unification / the malloc clusters from `Value` clone/drop and attribute material
       fine (`sub a($x)` / `sub b($x)` interleaved, and `p(1); p(2); p(3)`, all match raku) — the
       corruption needs same-name frames simultaneously live across a thread boundary.
 
-      **Fix direction**: this is the name-keyed env that §1.3 exists to remove. `start` should
-      capture through the same per-binding cells as ordinary closures
-      (docs/captured-outer-cell-sharing.md) instead of the parallel name-keyed `shared_vars`
-      mechanism — i.e. "1 operation = 1 implementation". Worth doing before the worker-pool ADR
-      above: a silent wrong answer outranks a perf/footprint change, and the fix retires a
-      name-keyed mechanism rather than building on it.
+      Routing the value through a `my` instead of a parameter is **worse, not better**:
+      `sub g($m) { my $n = $m; start { $n <= 0 ?? "b" !! await(g($n-1)) ~ "|$n" } }` gives
+      `b|0|0|0` on the *first* call. `thread_redeclared_vars` (the `my` mask) is interpreter-global
+      and cleared at every spawn (`runtime_thread.rs:76`), so a recursive chain force-`insert`s the
+      innermost `n` and unmasks the parent — it is the same name-keyed disease, not a lever.
+
+      **Mechanism** (traced 2026-07-17). Each recursive frame *does* get a correct distinct slot and
+      env; the flat map and the writeback that feeds it back into slots are what corrupt them:
+      - **write**: every plain lexical store runs `flush_local_to_env` (`vm_env_helpers.rs:963`) →
+        `set_env_plain_lexical` → `set_shared_var_sym` (`runtime_shared_vars.rs:306-370`), so each
+        frame's `$n` bind overwrites `shared_vars["n"]` and marks it dirty.
+      - **read-back**: `await` calls `sync_shared_vars_to_env` (`runtime_shared_vars.rs:402-486`),
+        which pulls every dirty key into `env` *and* queues it in `pending_caller_var_writeback`;
+        `apply_pending_caller_var_writeback` (`vm_env_helpers.rs:1055-1074`) is retain-on-miss and
+        deliberately **walks up the frame chain** until some frame owns a slot named `"n"`.
+        Innermost write → every outer frame's slot. `k`/`g` are the `insert`-overwrite direction;
+        `f`'s 2nd call is the `or_insert_with` direction (the stale `3` from run 1 survives).
+
+      **Fix direction — narrower than it first looked; NOT the full §1.3 campaign.** `start` already
+      compiles its block argument as escaping (`compiler/expr_call.rs`, `escaping_args = name ==
+      "start"`), so `box_captured_lexicals` (`vm/vm_register_ops.rs:570-695`) already gives it
+      correct per-binding cells, and `$n` (read-only in the block) is correctly captured by value
+      per frame. `shared_vars`' plain-scalar lane runs **in parallel with a mechanism that already
+      works, and overwrites its correct answer** — precisely the "1 operation = 1 implementation"
+      violation. So the fix is to **retire the plain-scalar lane of `shared_vars`** and keep the
+      `@`/`%`, `__mutsu_*` atomic, and `state` lanes:
+      1. stop seeding bare-name scalar keys in `clone_for_thread` (`runtime_thread.rs:21-53`);
+      2. drop the scalar mirror in `set_shared_var_sym` (its `sv.contains_key` guard may make this a
+         no-op once seeding stops — verify);
+      3. `sync_shared_vars_to_env` then never marks a scalar param dirty, so the frame-walking
+         writeback stops force-feeding `"n"` into ancestor frames;
+      4. `thread_redeclared_vars` becomes scalar-only dead code (set only at
+         `vm_var_assign_set_local.rs:1723`) — delete it, retiring a *second* name-keyed mechanism.
+
+      Realistic edit surface ~5 files (the 49 `shared_vars` accesses across 9 files are mostly the
+      `@`/`%`/atomic/`state`/CAS lanes, which are untouched). **Pin these before touching the
+      seeding** — they are the shapes `box_captured_lexicals` declines to box, i.e. where
+      cross-thread scalar *mutation* visibility would regress: type-constrained scalars
+      (`my Int $c = 0; await start { $c = 5 }`, skipped at `vm_register_ops.rs:650-656`), scalars
+      holding `Instance`/`Proxy`/`Package` (`:669-679`), and the empty-`needs_cell_locals` early
+      return (`:601-607`). If the typed case regresses, the smallest honest patch is to relax the
+      `var_type_constraint` skip for the escaping-to-thread case, re-checking the constraint at the
+      `ContainerRef` write-through chokepoint.
+
+      Worth doing before the worker-pool ADR above: a silent wrong answer outranks a
+      perf/footprint change, and the fix retires name-keyed mechanisms rather than building on them.
 - [ ] Eliminate raw-pointer aliased writes: the old `arc_contents_mut` is dead code now, and the
       production path moved to `gc::gc_contents_mut` / `Gc::{get,make}_mut` (the unsoundness was
       moved, not resolved — ANALYSIS rev8 §2.1). With Track B T4–T6 done (news/2026-07.md), start

--- a/docs/probes/pool-recursive-start.raku
+++ b/docs/probes/pool-recursive-start.raku
@@ -4,8 +4,13 @@
 # (src/runtime/runtime_thread.rs:18-53), which cannot represent two
 # concurrently-live bindings of the same name -- i.e. a recursive frame chain.
 #
-# raku prints, in order: b|1|2|3 / b|1|2|3 / b|1|2 / b|1|2|3 / b|1|2|3 / 3 / 21
-# mutsu prints:          b|1|2|3 / b|3|3|3 / b|2|2 / b|1|1|1 / b|1|1|1 / <hangs>
+# raku : b|1|2|3 / b|1|2|3 / b|1|2 / b|1|2|3 / b|1|2|3 / b|1|2|3 / b|1|2|3 / 3 / 21
+# mutsu: b|1|2|3 / b|3|3|3 / b|2|2 / b|1|1|1 / b|1|1|1 / b|0|0|0 / b|1|1|1 / <hangs>
+#
+# NOTE: `start` already compiles its block as escaping (compiler/expr_call.rs),
+# so box_captured_lexicals ALREADY gives it correct per-binding cells. The flat
+# name-keyed shared_vars lane runs in parallel with that working mechanism and
+# overwrites its correct answer -- see PLAN.md §6 for the fix plan.
 
 # (1) await INSIDE the start block: first call correct, later calls corrupt.
 sub f($n) { start { $n <= 0 ?? "b" !! await(f($n - 1)) ~ "|$n" } }
@@ -18,7 +23,15 @@ sub k($n) { $n <= 0 ?? "b" !! (await start { k($n - 1) }) ~ "|$n" }
 say "k(3) 1st: ", k(3);         # raku b|1|2|3 | mutsu b|1|1|1   WRONG
 say "k(3) 2nd: ", k(3);         # raku b|1|2|3 | mutsu b|1|1|1   WRONG
 
-# (3) Two-branch recursion: hangs deterministically on mutsu (exit 124).
+# (3) Routing through a `my` instead of a parameter is WORSE, not better:
+#     wrong on the first call, and off-by-one further (b|0|0|0). The `my` mask
+#     (thread_redeclared_vars) is interpreter-global and cleared at every spawn.
+sub g($m) { my $n = $m; start { $n <= 0 ?? "b" !! await(g($n - 1)) ~ "|$n" } }
+say "g(3) via my: ", await g(3);   # raku b|1|2|3 | mutsu b|0|0|0  WRONG
+sub h($m) { my $n = $m; $n <= 0 ?? "b" !! (await start { h($n - 1) }) ~ "|$n" }
+say "h(3) via my: ", h(3);         # raku b|1|2|3 | mutsu b|1|1|1  WRONG
+
+# (4) Two-branch recursion: hangs deterministically on mutsu (exit 124).
 #     This is the symptom PLAN §6 used to record as the whole bug.
 sub fib($n) { start { $n < 2 ?? $n !! await(fib($n - 2)) + await(fib($n - 1)) } }
 say "fib(4): ", await fib(4);   # raku 3


### PR DESCRIPTION
Docs only. Follow-up correcting #4643, which I merged earlier today with an inaccurate fix direction.

## What #4643 got wrong

It recorded: *"`start` should capture through the same per-binding cells as ordinary closures instead of the parallel name-keyed `shared_vars` mechanism"*.

**`start` already does.** `compiler/expr_call.rs` sets `escaping_args = name.resolve() == "start"`, so `box_captured_lexicals` (`vm/vm_register_ops.rs:570-695`) already gives it correct per-binding cells — and `$n`, being read-only inside the block, is already captured **by value, per frame**. Each recursive frame's slot and env are correct.

The real shape is both worse and narrower: **`shared_vars`' plain-scalar lane runs in parallel with a mechanism that already works, and overwrites its correct answer.** That makes it a "1 operation = 1 implementation" violation (PLAN's standing rule), and means the fix is to *retire that lane* — **not** to run the full §1.3 name-keyed-env campaign as #4643 implied.

## Mechanism, now traced

- **write**: every plain lexical store runs `flush_local_to_env` (`vm_env_helpers.rs:963`) → `set_env_plain_lexical` → `set_shared_var_sym` (`runtime_shared_vars.rs:306-370`), so each frame's `$n` bind overwrites `shared_vars["n"]`.
- **read-back**: `await` → `sync_shared_vars_to_env` (`runtime_shared_vars.rs:402-486`) pulls dirty keys into `env` *and* queues them in `pending_caller_var_writeback`, whose drain (`vm_env_helpers.rs:1055-1074`) is retain-on-miss and deliberately **walks up the frame chain** until a frame owns a slot named `"n"`. Innermost write → every outer frame's slot.

## New data point: `my` is worse, not better

```raku
sub g($m) { my $n = $m; start { $n <= 0 ?? "b" !! await(g($n-1)) ~ "|$n" } }
say await g(3);   # mutsu: b|0|0|0 on the FIRST call   (raku: b|1|2|3)
```

`thread_redeclared_vars` (the `my` mask) is interpreter-global and cleared at every spawn (`runtime_thread.rs:76`), so a recursive chain force-`insert`s the innermost `n` and unmasks the parent. It is the same name-keyed disease, not a lever — and it becomes dead code once the scalar lane goes, so the fix retires **two** name-keyed mechanisms.

## Fix plan recorded (~5 files)

Stop seeding bare-name scalars in `clone_for_thread` → drop the scalar mirror in `set_shared_var_sym` → the frame-walking writeback stops firing for scalars → delete `thread_redeclared_vars`. Keeps the `@`/`%`, `__mutsu_*` atomic, and `state` lanes untouched (that is where most of the 49 `shared_vars` accesses live).

**Pin first** — the shapes `box_captured_lexicals` declines to box, i.e. where cross-thread scalar *mutation* visibility could regress: type-constrained scalars (`my Int $c = 0; await start { $c = 5 }`, `vm_register_ops.rs:650-656`), `Instance`/`Proxy`/`Package` holders (`:669-679`), empty-`needs_cell_locals` early return (`:601-607`).

## Verification

Re-ran `docs/probes/pool-recursive-start.raku` (now including the `my` variant) against both implementations; the header's documented expected output matches both exactly — mutsu produces the 6 wrong answers then hangs (exit 124), raku is correct throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)