### PR TITLE
fix: `@a.map` returns a Seq on the rw path, and nested hyper results are itemized

### DIFF
--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -1599,6 +1599,12 @@ impl Interpreter {
                 Self::value_to_list(&target)
             };
             let result = self.eval_map_over_items_rw(args.first().cloned(), &mut items)?;
+            // `.map` returns a Seq (same contract as `dispatch_map_method` and the
+            // native fast path); only the rw writeback below is special here.
+            let result = match result.view() {
+                ValueView::Array(items, _) => Value::seq_arc(std::sync::Arc::new(items.to_vec())),
+                _ => result.clone(),
+            };
             // Write mutated elements back to the source array. `.map(* *= 2)`
             // rw-binds `$_` to each element, so element mutations persist (Raku
             // semantics). A shaped array keeps its shape/structure — only the leaf

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -1,6 +1,26 @@
 use super::*;
 use crate::symbol::Symbol;
 
+/// Itemize the hyper result of an element the hyper *descended into*.
+///
+/// Rakudo's `deepmap` (which non-nodal `>>.foo` is built on) recurses into an
+/// element that is `Iterable` and itemizes what comes back, but applies the
+/// method directly to a leaf and leaves that result alone. So `((1,),)>>.succ`
+/// is `($(2,),)` while `(1,2)>>.Array` stays `([1], [2])` — the deciding factor
+/// is the *source* element's shape, not the result's.
+fn itemize_if_descended(source: &Value, result: Value) -> Value {
+    if !matches!(
+        source.view(),
+        ValueView::Array(..) | ValueView::Seq(_) | ValueView::Slip(_) | ValueView::Hash(_)
+    ) {
+        return result;
+    }
+    match result.view() {
+        ValueView::Array(items, kind) => Value::array_with_kind(items.clone(), kind.itemize()),
+        _ => Value::scalar(result.clone()),
+    }
+}
+
 impl Interpreter {
     /// Write a mutating hyper's result back to its *named* `@`/`%` target
     /// variable precisely. If the variable is bound (holds a shared
@@ -368,7 +388,10 @@ impl Interpreter {
                     // (e.g., .join, .elems, .sort, .reverse, .unique, .squish).
                     let is_iterable_item = matches!(
                         item.view(),
-                        ValueView::Array(..) | ValueView::Seq(..) | ValueView::Slip(..)
+                        ValueView::Array(..)
+                            | ValueView::Seq(..)
+                            | ValueView::Slip(..)
+                            | ValueView::Hash(..)
                     );
                     // A qualified dispatch (`».Any::elems`) still names a
                     // plain list-native method once the owner prefix is
@@ -486,6 +509,7 @@ impl Interpreter {
                             &item_args,
                             skip_native,
                         )?;
+                        let sub_result = itemize_if_descended(item, sub_result);
                         *item = sub_mutated;
                         results.push(sub_result);
                     } else if !skip_native
@@ -727,7 +751,7 @@ impl Interpreter {
                 for sub in elems.iter() {
                     let (r, m) =
                         self.hyper_method_apply_recursive(sub, method, args, skip_native)?;
-                    results.push(r);
+                    results.push(itemize_if_descended(sub, r));
                     mutated.push(m);
                 }
                 Ok((
@@ -747,7 +771,7 @@ impl Interpreter {
                 for sub in elems.iter() {
                     let (r, m) =
                         self.hyper_method_apply_recursive(sub, method, args, skip_native)?;
-                    results.push(r);
+                    results.push(itemize_if_descended(sub, r));
                     mutated.push(m);
                 }
                 Ok((
@@ -769,7 +793,7 @@ impl Interpreter {
                     let v = map.get(&k).cloned().unwrap_or(Value::NIL);
                     let (r, m) =
                         self.hyper_method_apply_recursive(&v, method, args, skip_native)?;
-                    res_map.insert(k.clone(), r);
+                    res_map.insert(k.clone(), itemize_if_descended(&v, r));
                     mut_map.insert(k, m);
                 }
                 Ok((

--- a/src/vm/vm_native_map.rs
+++ b/src/vm/vm_native_map.rs
@@ -46,9 +46,9 @@ impl Interpreter {
         let ValueView::Sub(data) = args[0].view() else {
             return None;
         };
-        // Only a plain concrete array (`my @a = ...`, `ArrayKind::Array`). On
-        // such an array mutsu's `.map` returns a `List`. Every other kind needs
-        // the interpreter's specialized dispatch and must NOT come here:
+        // Only a plain concrete array (`my @a = ...`, `ArrayKind::Array`).
+        // Every other kind needs the interpreter's specialized dispatch and must
+        // NOT come here:
         // `Shaped` maps over *leaves* (not the raw items), `Lazy` must stay lazy
         // (eager iteration could hang on an infinite source), `ItemArray`/`List`
         // and ranges/seqs have their own one-arg-rule / Seq-returning semantics.

--- a/t/hyper-method-on-nil.t
+++ b/t/hyper-method-on-nil.t
@@ -25,7 +25,9 @@ is (1, 2)>>.succ.raku,     '(2, 3)',         'ordinary hyper dispatch unaffected
 dies-ok { (Any,)>>.no-such-method-anywhere }, 'Any (not Nil) still throws for an unknown method';
 dies-ok { Any.no-such-method-anywhere },      'scalar Any still throws for an unknown method';
 
-# Nested Iterables recurse to the leaves, and Nil leaves absorb there too.
-is ((Nil,), (Nil,))>>.ast.raku, '((Nil,), (Nil,))', 'nested hyper reaches Nil leaves';
+# Nested Iterables recurse to the leaves, and Nil leaves absorb there too. Each
+# descent itemizes its result, so the sub-lists come back as `$(Nil,)` — see
+# t/hyper-nested-itemize.t.
+is ((Nil,), (Nil,))>>.ast.raku, '($(Nil,), $(Nil,))', 'nested hyper reaches Nil leaves';
 
 # vim: expandtab shiftwidth=4

--- a/t/hyper-nested-itemize.t
+++ b/t/hyper-nested-itemize.t
@@ -1,0 +1,31 @@
+use v6;
+use Test;
+
+plan 12;
+
+# Rakudo's `deepmap` (which non-nodal `>>.foo` builds on) recurses into an
+# element that is Iterable and itemizes what comes back, but applies the method
+# straight to a leaf and leaves that result alone.
+
+is (((1,),)>>.succ).raku, '($(2,),)', 'a nested one-element list result is itemized';
+is (((1,2),(3,))>>.succ).raku, '($(2, 3), $(4,))', 'every nested list result is itemized';
+is ((((1,),),)>>.succ).raku, '($($(2,),),)', 'itemization applies at every depth';
+is (((1,).Seq,)>>.succ).raku, '($(2,),)', 'a nested Seq result is itemized too';
+
+# A leaf is not descended into, so a list-returning method on a leaf keeps its
+# result un-itemized.
+is ((1,2)>>.succ).raku, '(2, 3)', 'a flat list of leaves is not itemized';
+is ((1,2)>>.Array).raku, '([1], [2])', 'a list result from a leaf method is not itemized';
+
+# Hash values are Iterable positions as well.
+is (({a => (1,2)}>>.succ)).raku, '{:a($(2, 3))}', 'a hash value list result is itemized';
+is (((%(a => 1),)>>.succ)).raku, '(${:a(2)},)', 'hyper descends into a nested hash';
+is ((({a=>1}, {b=>2})>>.succ)).raku, '(${:a(2)}, ${:b(3)})', 'each nested hash is descended and itemized';
+
+# Nodal methods still apply to the container itself, not its leaves.
+is (((%(a => 1),)>>.keys)).raku, '(("a",).Seq,)', 'a nodal method is not descended';
+is ((((1,2),(3,))>>.List)).raku, '((1, 2), (3,))', '.List is nodal';
+
+# An Array prints its (always-itemized) elements without the `$` sigil.
+my @a = (1,), (2,3);
+is (@a>>.succ).raku, '[(2,), (3, 4)]', 'an Array target keeps Array shape';

--- a/t/map-returns-seq.t
+++ b/t/map-returns-seq.t
@@ -1,0 +1,26 @@
+use v6;
+use Test;
+
+plan 8;
+
+# `.map` returns a Seq regardless of which dispatch path runs it. An `@`-variable
+# receiver takes the rw-writeback path (mutations to `$_` write back to the
+# source), which used to hand back a List whenever the block body was too complex
+# for the native fast path.
+my @l = <a b>;
+
+is (@l.map({ (1,2).Seq })).WHAT.^name, 'Seq', 'simple block body';
+is (@l.map({ (1,2).map({$_}) })).WHAT.^name, 'Seq', 'body with a nested .map';
+is (@l.map({ (1,2).grep({1}) })).WHAT.^name, 'Seq', 'body with a nested .grep';
+is (@l.map({ my $q = (1,2).map({$_}); $q })).WHAT.^name, 'Seq', 'body with a declaration';
+is (@l.map(-> $x { (1,2).map(-> $z { $z }) })).WHAT.^name, 'Seq', 'pointy block body';
+is (@l.map({ 7 })).WHAT.^name, 'Seq', 'constant body';
+
+# The rw writeback that this path exists for still works. `map` is lazy in
+# Rakudo, so force the Seq before checking the source (mutsu maps eagerly, which
+# is why it writes back straight away).
+my @n = 1, 2, 3;
+my $mapped = @n.map({ $_++; (1,2).map({$_}) });
+is $mapped.WHAT.^name, 'Seq', 'a $_-mutating block still returns a Seq';
+$mapped.eager;
+is-deeply @n, [2, 3, 4], '$_ mutation still writes back to the source array';


### PR DESCRIPTION
Two independent bugs, each A/B-verified against raku.

1. `@a.map({ ... })` returned a List instead of a Seq whenever the block body
   was too complex for the native fast path (`src/runtime/methods_mut_dispatch.rs`).

   An `@`-variable receiver takes a dedicated rw-writeback path (so `$_`
   mutations reach the source elements), and that path returned
   `eval_map_over_items_rw`'s raw array — it never applied the Seq conversion
   that `dispatch_map_method` does on its tail. The native fast path
   (`vm_native_map.rs`) already returned a Seq, so the type depended on whether
   the block body happened to be classifiable:

       my @l = <a b>;
       @l.map({ (1,2).Seq       }).WHAT   # Seq (fast path)
       @l.map({ (1,2).map({$_}) }).WHAT   # List (rw path) -- raku: Seq

   Also drops a stale comment in `vm_native_map.rs` claiming `.map` on a
   concrete array returns a List.

2. A non-nodal hyper did not itemize the results of the elements it descended
   into (`src/vm/vm_hyper_method_ops.rs`).

       ((1,),)>>.succ        # was ((2,),)         raku: ($(2,),)
       ((1,2),(3,))>>.succ   # was ((2, 3), (4,))  raku: ($(2, 3), $(4,))

   Rakudo's `deepmap` (what non-nodal `>>.foo` builds on) recurses into an
   element that is Iterable and itemizes what comes back, but applies the method
   straight to a leaf and leaves that result alone — so the deciding factor is
   the *source* element's shape, not the result's, and `(1,2)>>.Array` correctly
   stays `([1], [2])`. `itemize_if_descended` encodes exactly that rule and is
   applied at the top-level loop and in each recursive branch.

   While here: the top-level loop's `is_iterable_item` omitted Hash, so a hash
   nested in a list was never descended into (`(%(a=>1),)>>.succ` yielded
   `({:a(1)},)` instead of `(${:a(2)},)`) even though the recursion already
   handles Hash values. Nodal methods are unaffected — `keys` and friends are
   already gated by `is_list_native_method`.

`t/hyper-method-on-nil.t` test 10 pinned the un-itemized output from bug 2; raku
fails that assertion too, so the test is corrected to raku's answer.

New pins: `t/map-returns-seq.t`, `t/hyper-nested-itemize.t` (both pass under raku
as well as mutsu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)