### PR TITLE
fix: `$_` inside a WhateverCode stays the caller's topic in first/grep

### DIFF
--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::env::Env;
+use crate::value::SubData;
 
 /// The set a frame vouches for so a closure created inside it inherits
 /// authoritative (overwrite) capture (runtime transitive vouching — see
@@ -18,6 +20,54 @@ pub(crate) fn frame_authoritative_set(
     let mut fa = cc.authoritative_free_vars.clone();
     fa.extend(authoritative_captures.iter().copied());
     fa
+}
+
+/// Does this callable's `$_` stay at the caller's topic instead of being
+/// topicalized to the element a map/grep/first loop is visiting?
+///
+/// A WhateverCode whose body references `$_` (`*.new($_)`, `* eq $_`) compiles
+/// its `*` placeholder to a synthetic `__wc_N` param so the element binds
+/// there, NOT to `$_`; the body's `$_` must stay the caller's topic (S02 "no
+/// scoping issues when using topic variables": `do { $_ = 42; (Int).map(*.new($_)) }`
+/// -> `Int.new(42)`). A plain `*.abs` (no `$_` in the body) keeps `_` AS its
+/// placeholder param, so it must still receive the element — hence the
+/// `_`-is-not-a-param guard.
+pub(crate) fn whatever_code_keeps_outer_topic(data: &SubData) -> bool {
+    matches!(
+        data.env.get("__mutsu_callable_type").map(Value::view),
+        Some(ValueView::Str(kind)) if kind.as_str() == "WhateverCode"
+    ) && !data.params.iter().any(|p| p == "_")
+}
+
+/// Bind `$_`/`_` for one iteration of a batched map/grep/first loop.
+///
+/// For a `$_`-referencing WhateverCode the topic is held at `outer_topic` for
+/// every iteration (re-set, so a prior iteration's tail value cannot leak into
+/// the next one's `$_`); otherwise the element is the topic.
+/// See [`whatever_code_keeps_outer_topic`].
+pub(crate) fn bind_loop_topic(
+    env: &mut Env,
+    item: &Value,
+    keeps_outer_topic: bool,
+    outer_topic: &Option<Value>,
+) {
+    const UNDERSCORE: &str = "_";
+    const DOLLAR_TOPIC: &str = "$_";
+    if keeps_outer_topic {
+        match outer_topic {
+            Some(t) => {
+                env.insert(UNDERSCORE.to_string(), t.clone());
+                env.insert(DOLLAR_TOPIC.to_string(), t.clone());
+            }
+            None => {
+                env.remove(UNDERSCORE);
+                env.remove(DOLLAR_TOPIC);
+            }
+        }
+    } else {
+        env.insert(UNDERSCORE.to_string(), item.clone());
+        env.insert(DOLLAR_TOPIC.to_string(), item.clone());
+    }
 }
 
 /// Convert a `CallArg` to an `Expr` for expression-level call compilation,
@@ -314,21 +364,7 @@ impl Interpreter {
                 }
             }
 
-            // A WhateverCode whose body references `$_` (`*.new($_)`) compiles its
-            // `*` placeholder to a synthetic `__wc_N` param so the element binds
-            // there, NOT to `$_`; the body's `$_` must stay the caller's topic
-            // (S02 "no scoping issues when using topic variables":
-            // `do { $_ = 42; (Int).map(*.new($_)) }` -> `Int.new(42)`). So for such
-            // a WhateverCode, instead of topicalizing `$_`/`_` to the element, hold
-            // them at the caller's outer topic for every iteration (re-set so a
-            // prior iteration's tail value can't leak into the next one's `$_`).
-            // A plain `*.abs` (no `$_` in the body) keeps `_` AS its placeholder
-            // param, so it must still receive the element — hence the
-            // `_`-is-not-a-param guard.
-            let is_whatever_code = matches!(
-                data.env.get("__mutsu_callable_type").map(Value::view),
-                Some(ValueView::Str(kind)) if kind.as_str() == "WhateverCode"
-            ) && !data.params.iter().any(|p| p == "_");
+            let is_whatever_code = whatever_code_keeps_outer_topic(&data);
             let outer_topic = self.env.get("_").cloned();
 
             // CP-3 collapse: run the map loop with fresh execution registers
@@ -363,21 +399,7 @@ impl Interpreter {
                             if let Some(p) = data.params.get(assumed_count) {
                                 vm.env_mut().insert(p.clone(), item.clone());
                             }
-                            if is_whatever_code {
-                                match &outer_topic {
-                                    Some(t) => {
-                                        vm.env_mut().insert(underscore.clone(), t.clone());
-                                        vm.env_mut().insert(dollar_topic.clone(), t.clone());
-                                    }
-                                    None => {
-                                        vm.env_mut().remove(&underscore);
-                                        vm.env_mut().remove(&dollar_topic);
-                                    }
-                                }
-                            } else {
-                                vm.env_mut().insert(underscore.clone(), item.clone());
-                                vm.env_mut().insert(dollar_topic.clone(), item);
-                            }
+                            bind_loop_topic(vm.env_mut(), &item, is_whatever_code, &outer_topic);
                         } else {
                             for (idx, p) in data.params.iter().skip(assumed_count).enumerate() {
                                 if i + idx < list_items.len() {
@@ -588,6 +610,9 @@ impl Interpreter {
             self.env.insert_sym(*k, v.clone());
         }
 
+        let keeps_outer_topic = whatever_code_keeps_outer_topic(&data);
+        let outer_topic = self.env.get("_").cloned();
+
         let mut found: Option<(usize, Value)> = None;
         let loop_result: Result<(), RuntimeError> = self.with_nested_registers(|vm| {
             vm.set_topic_source_var(None);
@@ -602,8 +627,7 @@ impl Interpreter {
                     if let Some(p) = data.params.first() {
                         vm.env_mut().insert(p.clone(), call_item.clone());
                     }
-                    vm.env_mut().insert(underscore.clone(), call_item.clone());
-                    vm.env_mut().insert(dollar_topic.clone(), call_item.clone());
+                    bind_loop_topic(vm.env_mut(), &call_item, keeps_outer_topic, &outer_topic);
                     match vm.run_reuse(&code, &compiled_fns) {
                         Ok(()) => {
                             let pred = vm

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::runtime::resolution_map_grep::bind_loop_topic;
 use crate::value::ValueView;
 
 impl Interpreter {
@@ -361,6 +362,10 @@ impl Interpreter {
                 self.env.insert_sym(*k, v.clone());
             }
 
+            let keeps_outer_topic =
+                super::resolution_map_grep::whatever_code_keeps_outer_topic(&data);
+            let outer_topic = self.env.get("_").cloned();
+
             // CP-3 collapse: run the grep loop with fresh execution registers
             // (replaces the `mem::take(self)` + `VM::new` sub-VM). The closure
             // returns Ok(()) / Err on the loop; `with_nested_registers` restores
@@ -402,21 +407,35 @@ impl Interpreter {
                                 if let Some(p) = data.params.get(assumed_count) {
                                     vm.env_mut().insert(p.clone(), chunk[0].clone());
                                 }
-                                vm.env_mut().insert(underscore.clone(), chunk[0].clone());
-                                vm.env_mut().insert(dollar_topic.clone(), chunk[0].clone());
-                                vm.env_mut()
-                                    .insert(topic_source_key.clone(), chunk[0].clone());
+                                bind_loop_topic(
+                                    vm.env_mut(),
+                                    &chunk[0],
+                                    keeps_outer_topic,
+                                    &outer_topic,
+                                );
+                                if !keeps_outer_topic {
+                                    vm.env_mut()
+                                        .insert(topic_source_key.clone(), chunk[0].clone());
+                                }
                             } else {
                                 for (idx, p) in data.params.iter().skip(assumed_count).enumerate() {
                                     if idx < chunk.len() {
                                         vm.env_mut().insert(p.clone(), chunk[idx].clone());
                                     }
                                 }
-                                vm.env_mut().insert(underscore.clone(), chunk[0].clone());
-                                vm.env_mut().insert(dollar_topic.clone(), chunk[0].clone());
+                                bind_loop_topic(
+                                    vm.env_mut(),
+                                    &chunk[0],
+                                    keeps_outer_topic,
+                                    &outer_topic,
+                                );
                             }
                         }
-                        vm.set_topic_source_var((arity == 1).then_some(topic_source_key.clone()));
+                        // `$_` holding the caller's topic is not an alias for the
+                        // element, so it must not write back to it.
+                        vm.set_topic_source_var(
+                            (arity == 1 && !keeps_outer_topic).then_some(topic_source_key.clone()),
+                        );
                         match vm.run_reuse(&code, &compiled_fns) {
                             Ok(()) => {
                                 let pred = vm

--- a/t/whatever-code-topic.t
+++ b/t/whatever-code-topic.t
@@ -1,0 +1,58 @@
+use Test;
+
+plan 14;
+
+# A WhateverCode whose body mentions `$_` binds the element to its `*`
+# placeholder, so `$_` keeps referring to the CALLER's topic. Only a bare block
+# (`{ ... }`) topicalizes `$_` to the element.
+
+my @a = <x y>;
+
+{
+    $_ = 'y';
+    is @a.first(* eq $_), 'y', 'first: $_ in a WhateverCode is the outer topic';
+    is @a.first(* eq $_, :k), 1, 'first :k: $_ in a WhateverCode is the outer topic';
+    is-deeply @a.grep(* eq $_).List, ('y',), 'grep: $_ in a WhateverCode is the outer topic';
+    is-deeply @a.map(* eq $_).List, (False, True), 'map: $_ in a WhateverCode is the outer topic';
+}
+
+{
+    $_ = 'x';
+    is @a.first(* eq $_), 'x', 'first: follows the outer topic when it changes';
+    is-deeply @a.grep(* eq $_).List, ('x',), 'grep: follows the outer topic when it changes';
+}
+
+# A bare block still topicalizes to the element.
+{
+    $_ = 'y';
+    is @a.first({ $_ eq 'x' }), 'x', 'first: a bare block topicalizes $_ to the element';
+    is-deeply @a.grep({ $_ eq 'x' }).List, ('x',), 'grep: a bare block topicalizes $_ to the element';
+}
+
+# A WhateverCode with no `$_` in its body keeps `*` as the element.
+is @a.first(*.chars == 1), 'x', 'first: a $_-less WhateverCode still receives the element';
+is-deeply @a.grep(*.chars == 1).List, ('x', 'y'), 'grep: a $_-less WhateverCode still receives the element';
+
+# The outer topic is the enclosing block's, not a leftover from a prior
+# iteration of the loop that is doing the calling.
+my @out = <p q>.map({ my @n = <p q>; @n.first(* eq $_) });
+is-deeply @out.List, ('p', 'q'), 'nested: each iteration sees its own topic';
+
+# No outer topic at all: `$_` is undefined inside the WhateverCode.
+sub no-topic() { return @a.grep(* eq ($_ // 'none')).elems }
+is no-topic(), 0, 'grep: no outer topic leaves $_ undefined';
+
+# The zef shape this came from: a spec is kept unless some dist claims it.
+class Dist {
+    has $.name;
+    method contains-spec($spec) { $spec eq $.name }
+}
+my @skip = Dist.new(name => 'Test::META');
+my @specs = <Test META6 URI>;
+is-deeply @specs.grep({ not @skip.first(*.contains-spec($_)) }).List,
+    ('Test', 'META6', 'URI'),
+    'nested first(*.method($_)) inside a grep block sees the grep topic';
+my @skip2 = Dist.new(name => 'META6');
+is-deeply @specs.grep({ not @skip2.first(*.contains-spec($_)) }).List,
+    ('Test', 'URI'),
+    'nested first(*.method($_)) filters the matching spec only';


### PR DESCRIPTION
## Problem

`@a.first(* eq $_)` bound `$_` to the element instead of leaving it at the caller's topic, so the WhateverCode compared the element against itself and matched unconditionally:

```raku
my @a = <x y>;
$_ = 'y';
say @a.first(* eq $_);   # mutsu: "x"   raku: "y"
say @a.grep(* eq $_);    # mutsu: (x y) raku: (y)
```

A WhateverCode whose body mentions `$_` binds the element to its `*` placeholder (a synthetic `__wc_N` param), so `$_` must keep referring to the enclosing block's topic. Only a bare block topicalizes `$_` to the element.

## Why only first/grep

`map` already implemented this rule, as do the generic `call_sub_value` paths — only `first`'s and `grep`'s **batched fast paths** topicalized unconditionally, which is why the two disagreed. The rule now lives in `whatever_code_keeps_outer_topic` / `bind_loop_topic` and is used from all three loops rather than gaining a third copy.

In the rw grep loop, a `$_` holding the caller's topic is not an alias for the element, so it no longer sets `topic_source_var` and cannot write back to it.

## How it was found

zef's `Zef::Client`:

```raku
.grep({ not @skip.first(*.contains-spec($_)) })   # Client.rakumod:406
```

asked each skip-list dist whether it contained *itself* — always true — so every dependency looked already-satisfied and `find-prereq-candidates` returned none. zef now resolves the dependency tree recursively (`Test::META` → `META6`/`URI`/`License::SPDX` → `JSON::Marshal`/`JSON::Unmarshal`/`AttrX::Mooish`/...).

## Testing

- Pin: `t/whatever-code-topic.t` (14 cases, each verified against `raku` first).
- `make test`: 1775 files / 17377 tests PASS.
- roast subset (S02/S03/S04/S05/S06/S32-list/S29, release build): 620 files / 51964 tests PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)