### PR TITLE
fix: `.hash` on a type object is the empty hash, not "Odd number of elements"

### DIFF
--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -351,14 +351,21 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 None
             }
             // Type objects for setty/baggy types: .hash returns empty hash
-            ValueView::Package(name)
-                if matches!(
-                    name.resolve().as_str(),
-                    "Set" | "SetHash" | "Bag" | "BagHash" | "Mix" | "MixHash"
-                ) =>
-            {
-                Some(Ok(Value::hash(std::collections::HashMap::new())))
-            }
+            // A type object has no contents, so `Any.hash` (which every type
+            // object below Any inherits) is the empty hash — NOT a one-element
+            // hash initializer, which is what the list path below would make of
+            // it ("Odd number of elements ... last element seen: (Any)").
+            ValueView::Package(name) => match name.resolve().as_str() {
+                // Mu is the root type and does not inherit Any's `.hash` at all.
+                // Raise here rather than returning None: the slow-path `.hash`
+                // would take over and report the "Odd number of elements" error
+                // instead of the missing method.
+                "Mu" => Some(Err(RuntimeError::method_not_found("hash", "Mu"))),
+                // An Associative's `.hash` is itself, and the Hash *type object*
+                // is no exception (`Hash.hash` is `Hash`, not `{}`).
+                "Hash" => Some(Ok(target.clone())),
+                _ => Some(Ok(Value::hash(std::collections::HashMap::new()))),
+            },
             // `.hash` on a hash (`%$h`) IS that hash in Associative context:
             // return it de-itemized (a `$`-held itemized hash contextualized as
             // `%$h` spills to the hash, not an opaque single element), preserving

--- a/t/type-object-hash.t
+++ b/t/type-object-hash.t
@@ -1,0 +1,29 @@
+use Test;
+
+plan 11;
+
+# A type object has no contents, so `.hash` (inherited from Any) is the empty
+# hash. mutsu used to route it through the list path, which treated the type
+# object as a one-element hash initializer and threw
+# "Odd number of elements found where hash initializer expected".
+# zef hit this in `Zef::Client`: `$dist.meta<files>.hash.keys` on a dist whose
+# META has no `files` key.
+
+is-deeply Any.hash, {}, 'Any.hash is the empty hash';
+is-deeply Int.hash, {}, 'Int.hash is the empty hash';
+is-deeply Str.hash, {}, 'Str.hash is the empty hash';
+is-deeply Array.hash, {}, 'Array.hash is the empty hash';
+is-deeply Set.hash, {}, 'Set.hash is the empty hash';
+
+is Any.hash.^name, 'Hash', 'the result is a real Hash';
+is Any.hash.elems, 0, 'the result is empty';
+is-deeply Any.hash.keys.List, ().List, 'keys of a type-object hash is empty';
+
+# An Associative's `.hash` is itself, and the Hash type object is no exception.
+is Hash.hash, Hash, 'Hash.hash is the Hash type object, not an empty hash';
+
+class Foo {}
+is-deeply Foo.hash, {}, 'a user class type object hashes to the empty hash';
+
+# Mu is the root type and does not inherit Any's `.hash` at all.
+throws-like { Mu.hash }, X::Method::NotFound, 'Mu.hash has no such method';


### PR DESCRIPTION
## What

A type object has no contents, so the `.hash` every type object inherits from
`Any` is the empty hash. mutsu only special-cased the setty type objects
(`Set`/`Bag`/`Mix`/…) and let everything else fall to the list path, which treated
the type object as a one-element hash initializer:

```
$ mutsu -e 'say Any.hash.raku'
Odd number of elements found where hash initializer expected: found 1 element(s); last element seen: (Any)
$ raku -e 'say Any.hash.raku'
{}
```

Found while running the real zef: `Zef::Client`'s `bin-names` does
`$dist.meta<files>.hash.keys` on a dist whose META has no `files` key, which
aborted `zef install` at the install step.

## Parity details

| expression | raku | before | after |
|---|---|---|---|
| `Any.hash` / `Int.hash` / `Array.hash` | `{}` | throws | `{}` |
| a user class type object | `{}` | throws | `{}` |
| `Hash.hash` | `Hash` | throws | `Hash` |
| `Mu.hash` | X::Method::NotFound | throws odd-number | X::Method::NotFound |

`Mu` is the root type and does not inherit Any's `.hash` at all. It raises here
rather than returning `None`, because the slow-path `.hash` would otherwise take
over and report the odd-number error instead of the missing method.

Two known divergences are left alone as out of scope, both pre-existing and
neither newly introduced here: `Nil.hash` yields `Nil` (raku: `{}`) via the
separate Nil-fallback path, and `Junction.hash` now yields `{}` where raku yields
`Mu` — previously it threw, so this is strictly closer.

## Testing

- `t/type-object-hash.t` — new pin, 11 tests, **passes under real `raku` too**.
- `make test`: 1784 files / 17456 tests, all pass.
- roast subset most likely to touch `.hash` (S02-types, S03-operators, S32-hash,
  S12, S06 — 337 files / 26785 tests): all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)