### PR TITLE
fix: CURI.install finds sources via the distribution's .content API

### DIFF
--- a/docs/mzef-install-pipeline.md
+++ b/docs/mzef-install-pipeline.md
@@ -30,14 +30,29 @@ Legend: ✅ works · ⏳ in progress · ⬜ not yet reached · 🔒 blocked
 | 2 | Resolve / find candidate | ✅ | `zef info Test::META` → full Identity/Source/Description |
 | 3 | **Fetch** (download archive) | ⏳ | Single-dist `zef fetch` downloads `https://360.zef.pm/.../*.tar.gz` via the **curl**/**wget** backends (`Proc::Async` shell-out — no native TLS). Unblocked by #4615 + #4617. **The concurrent multi-candidate fetch that `install` drives still fails** (see "Current frontier") |
 | 4 | **Extract** (untar) | ✅ | Untars the real dist after #4620 + #4622 + #4627 + #4635/#4641/#4642 |
-| 5 | Build | ⬜ | not reached |
-| 6 | Test | ⬜ | not reached |
-| 7 | Install into site repo | ⬜ | not reached — but the **install→`use` bridge is already done** (`t/compunit-repository-for-name.t`), so once a dist reaches here it should be resolvable |
+| 5 | Build | ✅ | reached; a pure-Raku dist has nothing to build and passes through |
+| 6 | Test | ⬜ | not exercised yet (runs have used `--/test`) |
+| 7 | Install into site repo | ✅ | **a dependency-free dist installs and is then `use`-able** (see below) |
 
-**So: ~4.5 of 8 phases.** Resolution, dependency collection, single-dist fetch
-and extract all work against the live ecosystem. `install` now gets all the way
-to fetching its 16 resolved candidates; the frontier is that those *concurrent*
-fetches clobber each other's URL.
+**So: ~6 of 8 phases for a dependency-free dist.** A real dist from the live fez
+ecosystem downloads, extracts, installs into the mutsu site repo, and `use`
+resolves it:
+
+```
+$ mutsu -e 'use JSON::OptIn'        # Could not find JSON::OptIn in: ...
+$ mutsu -I <zef>/lib <zef>/bin/zef install --/depends --/test JSON::OptIn
+===> Installing: JSON::OptIn:ver<0.0.2>:auth<zef:jonathanstowe>
+$ mutsu -e 'use JSON::OptIn; say "LOADED"'
+LOADED
+```
+
+**Pick a non-bundled dist when verifying this.** mutsu bundles JSON::Fast (and
+others), so `use JSON::Fast` succeeds on a clean HOME with no install at all and
+proves nothing. `JSON::OptIn` is not bundled.
+
+Dists **with dependencies** still fail earlier, at the concurrent-fetch collision
+("Current frontier" below) — that is now the only thing between mzef and a real
+`zef install Test::META`.
 
 ## Fixes that got us here (this campaign)
 
@@ -114,6 +129,30 @@ victim();    # Nil
 spawner();   # migrates `depends => True` into the global shared store
 victim();    # was Bool::True, now Nil
 ```
+
+### Install phase — the silent no-op (2026-07-17)
+
+`zef install` printed `===> Installing: …` and exited **0** having installed
+nothing loadable. Three false leads worth not repeating:
+
+- `.can("install")` returns **False** on `CompUnit::Repository::Installation` —
+  a false negative. `.can` does not know natively-dispatched methods; `install`
+  *was* implemented and *was* being called.
+- `@curs` was **not** empty (the `DBG cli-6 to=1` trace) — `===> Installing:` is
+  printed *before* the `for @curs` loop in `Zef::Client.install`, so an empty
+  `@curs` was the obvious suspect and the wrong one.
+- The install *did* write a file. `find $HOME -type f | head` showed only the
+  `.zef` store and precomp cache, which read as "nothing written" — the dist
+  JSON was further down the list.
+
+The real defect (#4655): install joined the dist's **`prefix` attribute** onto
+each `provides` address to find the sources, but `Zef::Distribution::Local` has
+`$.path`/`$.IO` and **no `prefix`**, so the join produced a relative path that
+never existed and `std::fs::copy(..).ok()` swallowed it — the metadata recorded
+`provides` entries naming files it had never copied. Fixed by resolving each
+address through the distribution's own `.content($name-path)` (the API every
+Distribution implements, S22), with the `prefix` join kept as a fallback.
+Pin: `t/cur-install-content-api.t`.
 
 ## Current frontier — concurrent fetch clobbers the URL
 

--- a/src/runtime/methods_distribution_cur_inst.rs
+++ b/src/runtime/methods_distribution_cur_inst.rs
@@ -12,9 +12,48 @@ use super::methods_distribution_helpers::{
 };
 
 impl Interpreter {
+    /// Resolve one of a distribution's addresses (a `provides` value such as
+    /// `lib/Foo.rakumod`, or `resources/...`) to an absolute path on disk.
+    ///
+    /// Goes through the distribution's own `.content($name-path)` — the API every
+    /// Distribution implements (`IO::Handle:D`, per S22) — rather than joining a
+    /// `prefix` attribute onto the address. Distribution classes do not agree on
+    /// that attribute: rakudo's `Distribution::Path` has `$.prefix`, but zef's
+    /// `Zef::Distribution::Local` has `$.path`/`$.IO` and no `prefix` at all, so
+    /// the join silently produced a relative path that never existed and the
+    /// install recorded `provides` entries pointing at files it never copied.
+    ///
+    /// Falls back to the `prefix` join for a distribution that has no `.content`.
+    fn dist_content_abs(
+        &mut self,
+        dist: &Value,
+        prefix: &str,
+        name_path: &str,
+    ) -> Option<std::path::PathBuf> {
+        let fallback = || {
+            let p = std::path::Path::new(prefix).join(name_path);
+            p.exists().then_some(p)
+        };
+        let Ok(handle) = self.call_method_with_values(
+            dist.clone(),
+            "content",
+            vec![Value::str(name_path.to_string())],
+        ) else {
+            return fallback();
+        };
+        let Ok(path) = self.call_method_with_values(handle, "path", vec![]) else {
+            return fallback();
+        };
+        let Ok(abs) = self.call_method_with_values(path, "absolute", vec![]) else {
+            return fallback();
+        };
+        let abs = std::path::PathBuf::from(abs.to_string_value());
+        if abs.exists() { Some(abs) } else { fallback() }
+    }
+
     /// Install a distribution.
     pub(crate) fn cur_inst_install(
-        &self,
+        &mut self,
         prefix: &str,
         dist: &Value,
     ) -> Result<Value, RuntimeError> {
@@ -83,37 +122,37 @@ impl Interpreter {
         if let Some(provides) = meta.hash_get_str("provides")
             && let ValueView::Hash(map) = provides.view()
         {
-            for (k, v) in map.iter() {
-                let source_path_str = v.to_string_value();
-                let source_full = std::path::Path::new(&dist_prefix).join(&source_path_str);
-                let source_id = format!("{:X}", hash_strings(&[k, &dist_id]));
+            let entries: Vec<(String, String)> = map
+                .iter()
+                .map(|(k, v)| (k.clone(), v.to_string_value()))
+                .collect();
+            for (k, source_path_str) in entries {
+                let source_id = format!("{:X}", hash_strings(&[&k, &dist_id]));
                 let dest = sources_dir.join(&source_id);
-                if source_full.exists() {
+                if let Some(source_full) =
+                    self.dist_content_abs(dist, &dist_prefix, &source_path_str)
+                {
                     std::fs::copy(&source_full, &dest).ok();
                 }
                 let mut inner = HashMap::new();
                 inner.insert("file".to_string(), Value::str(source_id));
-                installed_provides.insert(k.clone(), Value::hash_with_data(Value::hash_arc(inner)));
+                installed_provides.insert(k, Value::hash_with_data(Value::hash_arc(inner)));
             }
         }
         let mut installed_resources = HashMap::new();
         if let Some(resources_val) = meta.hash_get_str("resources")
             && let ValueView::Array(arr, _) = resources_val.view()
         {
-            for resource in arr.iter() {
-                let resource_str = resource.to_string_value();
-                let source_path = if resource_str.starts_with("libraries/") {
-                    let lib_name = resource_str.strip_prefix("libraries/").unwrap();
-                    let platform_name = platform_library_name(lib_name);
-                    std::path::Path::new(&dist_prefix)
-                        .join("resources")
-                        .join("libraries")
-                        .join(&platform_name)
+            let resources: Vec<String> = arr.iter().map(|r| r.to_string_value()).collect();
+            for resource_str in resources {
+                // A `libraries/` resource is named platform-independently in META
+                // but stored under its platform file name (libfoo.so / foo.dll).
+                let address = if let Some(lib_name) = resource_str.strip_prefix("libraries/") {
+                    format!("resources/libraries/{}", platform_library_name(lib_name))
                 } else {
-                    std::path::Path::new(&dist_prefix)
-                        .join("resources")
-                        .join(&resource_str)
+                    format!("resources/{resource_str}")
                 };
+                let source_path = self.dist_content_abs(dist, &dist_prefix, &address);
                 let hash_hex = format!("{:X}", hash_strings(&[&resource_str, &dist_id]));
                 // Preserve the file extension so installed paths look like HASH.ext
                 let ext = std::path::Path::new(&resource_str)
@@ -123,7 +162,7 @@ impl Interpreter {
                     .unwrap_or_default();
                 let resource_id = format!("{hash_hex}{ext}");
                 let dest = resources_dir.join(&resource_id);
-                if source_path.exists() {
+                if let Some(source_path) = source_path {
                     std::fs::copy(&source_path, &dest).ok();
                 }
                 installed_resources

--- a/t/cur-install-content-api.t
+++ b/t/cur-install-content-api.t
@@ -1,0 +1,59 @@
+use Test;
+
+plan 5;
+
+# CompUnit::Repository::Installation.install must locate a distribution's sources
+# through the distribution's own `.content($name-path)` (the API every
+# Distribution implements, S22), NOT by joining a `prefix` attribute onto the
+# address. Distribution classes disagree on that attribute: rakudo's
+# Distribution::Path has $.prefix, but zef's Zef::Distribution::Local has
+# $.path/$.IO and no `prefix` at all. With the join, install silently copied
+# nothing and still recorded `provides` entries pointing at files it never wrote.
+
+my $tmp = $*TMPDIR.child("mutsu-cur-install-{$*PID}");
+my $src = $tmp.child("dist");
+$src.child("lib").mkdir;
+$src.child("lib/Greet.rakumod").spurt("unit module Greet;\nsub hi() is export { 'hi' }\n");
+
+# A distribution exposing ONLY the content API — no `prefix` attribute.
+class ContentOnlyDist {
+    has $.path;
+    has $.IO;
+    has %.meta;
+    method content($name-path --> IO::Handle:D) {
+        IO::Handle.new: path => IO::Path.new($name-path, :CWD(self.IO));
+    }
+}
+
+my %meta =
+    name     => 'Greet',
+    ver      => '0.1',
+    auth     => 'test',
+    api      => '',
+    provides => { 'Greet' => 'lib/Greet.rakumod' },
+;
+my $dist = ContentOnlyDist.new(
+    path => $src.absolute,
+    IO   => $src.absolute.IO,
+    meta => %meta,
+);
+
+my $repo-dir = $tmp.child("repo");
+$repo-dir.mkdir;
+my $cur = CompUnit::RepositoryRegistry.repository-for-spec("inst#{$repo-dir.absolute}");
+ok $cur.defined, 'got an Installation repository for the temp prefix';
+
+lives-ok { $cur.install($dist) }, 'install of a prefix-less distribution lives';
+
+my $dist-json = $repo-dir.child('dist').dir.grep(*.extension eq 'json').head;
+ok $dist-json.defined, 'the dist metadata was written';
+
+# The point of the fix: the recorded source id must name a file that EXISTS.
+my %installed = Rakudo::Internals::JSON.from-json($dist-json.slurp);
+my $source-id = %installed<provides><Greet><file>;
+ok $source-id.defined, 'provides recorded a source id';
+ok $repo-dir.child('sources').child($source-id).e,
+    'the source file the metadata points at was actually copied';
+
+END { try $tmp.&rmdir-recursive if $tmp.e }
+sub rmdir-recursive($p) { for $p.dir { $_.d ?? rmdir-recursive($_) !! $_.unlink }; $p.rmdir }


### PR DESCRIPTION
Third in today's mzef chain, after #4650 (dependency resolution) and #4653
(`.hash` on a type object). **This one gets a real dist installed and loadable.**

## The bug

`CompUnit::Repository::Installation.install` located a distribution's sources by
joining the dist's `prefix` attribute onto each `provides` address. Distribution
classes do not agree on that attribute: rakudo's `Distribution::Path` has
`$.prefix`, but zef's `Zef::Distribution::Local` has `$.path`/`$.IO` and **no
`prefix` at all**.

For a zef distribution the join therefore produced a bare relative path that
never existed, `source_full.exists()` was false, and `std::fs::copy(..).ok()`
**swallowed it**. install went on to write the dist metadata with `provides`
entries naming source files it had never copied, and returned True:

```
===> Installing: JSON::Fast:ver<0.20.1>:auth<zef:timo>
$ echo $?
0
$ find ~/.local -type f
.../repo/site/dist/18C3055FA297F3280.json      # <- metadata only, no sources/
$ python -c "..." < that.json
provides: {"JSON::Fast": {"file": "29507633E0028396"}}   # <- points at nothing
```

An `exit 0` that installed nothing loadable, with metadata that lies.

## The fix

Resolve each address through the distribution's own `.content($name-path)` — the
API every Distribution implements (`IO::Handle:D`, S22) — keeping the `prefix`
join as the fallback for a distribution without `.content`. Applies to
`provides` and to `resources` (including the platform-name mapping for
`libraries/`). Verified beforehand that the `.content` → `.path` → `.absolute`
chain behaves identically in mutsu and raku.

## Result — a dist installs and is then use-able

`JSON::OptIn` is **not** bundled with mutsu, so this is a real end-to-end check
(the obvious candidate, JSON::Fast, *is* bundled and would have proved nothing):

```
$ mutsu -e 'use JSON::OptIn'        # Could not find JSON::OptIn in: ...
$ mutsu -I zef/lib zef/bin/zef install --/depends --/test JSON::OptIn
===> Installing: JSON::OptIn:ver<0.0.2>:auth<zef:jonathanstowe>
$ mutsu -e 'use JSON::OptIn; say "LOADED"'
LOADED
```

Downloaded from the live fez ecosystem, extracted, installed into the mutsu site
repo, and resolved by `use` — the pipeline's definition of done, for a
dependency-free dist. Dists **with** dependencies still fail earlier, at the
concurrent-fetch collision documented in #4652.

## Testing

- `t/cur-install-content-api.t` — new pin: installs a distribution exposing only
  the content API (no `prefix`) and asserts the source the metadata points at
  actually exists. **Test 5 fails on main**, verified by reverting.
- `make test`: 1785 files / 17461 tests, all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)