### PR TITLE
perf: the parse-failure probe answers for every prefix in one walk, not one match per prefix

### DIFF
--- a/docs/adr/0009-regex-code-assertion-execution-model.md
+++ b/docs/adr/0009-regex-code-assertion-execution-model.md
@@ -170,6 +170,17 @@ no-ops and the probe measures the pattern's declarative skeleton. It deliberatel
 from `LTM_DECLARATIVE_MODE`: a plain `{ }` block does *not* stop the walk here, because
 the probe wants the longest prefix the skeleton accepts, not the LTM prefix.
 
+The per-prefix loop itself is gone too. "The pattern matches `text[0..end]` in full" is the
+same statement as "the pattern has a complete match starting at 0 that ends at `end`" once
+the trailing `$` is dropped — on a *truncated* string `$` is satisfied exactly when the
+match ends at the truncation point, which is what enumerating the ends already gives. So
+one all-ends walk (`regex_match_ends_from_caps_in_pkg` with `anchor_end: false`) answers
+for every prefix at once. The equality assumes success at a given end depends only on the
+characters consumed; a look-ahead near the boundary can see text the truncated string would
+not have, and may now succeed where the loop failed. The answer is a diagnostic position
+either way, and `roast/S05-grammar/parse_and_parsefile-6e.t` pins the exact numbers
+(`line == 3`, `pos == 14`, `pre == '# l3'`) — it still passes.
+
 Note the ordering interaction: **A made this worse before it was fixed.** Before A, an
 assertion-bearing candidate that failed its trial match was dropped by the LTM filter and
 `.parse` returned early with `pattern: None`, never reaching the probe. A keeps such
@@ -177,6 +188,15 @@ candidates (correctly — a declarative measurement cannot filter), which expose
 on exactly the grammars that have assertions. Measured on `token TOP { <group>**2 % ';' }`
 over an 18-char failing input: `a` ran **19** times, `z` **31**; after A2, 1 each — raku's
 numbers exactly.
+
+That LTM filter also bounds which grammars can reach the probe at all, which is why the
+cost is easy to mis-measure: if the declarative skeleton does not match, the candidate is
+dropped and `parse_failure_for_pattern` is called with `pattern: None`, so no probe runs.
+The probe is reached only when the skeleton matches but the real match fails — i.e. when a
+code atom rejects, day18's shape. On that shape (`^ <item>+ $`, `item` rejecting the final
+char), debug build, before → after: len 50 **234 ms / 149 assertion runs → 48 ms / 50**;
+len 400 **2165 ms / 1199 → 218 ms / 400**. The run count is now exactly the input length —
+raku's count.
 
 ### B. Code assertions run inline in the real interpreter
 

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -823,32 +823,46 @@ impl Interpreter {
     /// How far a failed `.parse` got, for the failure message: the longest prefix of
     /// the input that the pattern matches in full.
     ///
-    /// This re-matches the pattern once per prefix, so it must not execute the
-    /// grammar's code atoms — otherwise a `<?{ … }>` runs once per prefix, i.e.
-    /// O(input length) times, purely to build a diagnostic (ADR-0009). `advent2013-day18`
-    /// showed this exactly: its card assertion ran 15 times on a 14-char input and 31
-    /// times on a 31-char one. Under `CODE_ATOMS_INERT` the probe measures the
-    /// pattern's declarative skeleton instead, executing nothing.
+    /// This is a diagnostic, so it must not execute the grammar's code atoms —
+    /// otherwise a `<?{ … }>` runs purely to build an error message (ADR-0009).
+    /// `CODE_ATOMS_INERT` makes both kinds of code atom zero-width no-ops, so the
+    /// probe measures the pattern's declarative skeleton.
     ///
-    /// (The search is still O(input length) full matches on the failure path, and the
-    /// common case — no prefix matches — is the worst case. Pre-existing; not addressed
-    /// here.)
+    /// "The pattern matches `text[0..end]` in full" is the same statement as "the
+    /// pattern has a complete match starting at 0 that ends at `end`", once the
+    /// trailing `$` is dropped: on a *truncated* string `$` is satisfied exactly
+    /// when the match ends at the truncation point, which is what enumerating the
+    /// ends already gives. So one all-ends walk answers for every prefix at once,
+    /// replacing a per-prefix re-match loop that was O(input length) *full matches*
+    /// on the failure path — and whose common case (no prefix matches, so the loop
+    /// runs to the end) was its worst case.
+    ///
+    /// The equality assumes the pattern's success at a given end depends only on the
+    /// characters it consumed. A look-ahead near the boundary can see text the
+    /// truncated string would not have, so it may now succeed where the old loop
+    /// failed; the answer is a diagnostic position either way.
     pub(super) fn longest_complete_prefix_end(&mut self, pattern: &str, text: &str) -> usize {
         let saved = super::regex::regex_helpers::CODE_ATOMS_INERT.replace(true);
-        let chars: Vec<char> = text.chars().collect();
-        let mut best = 0;
-        for end in (0..=chars.len()).rev() {
-            let prefix: String = chars[..end].iter().collect();
-            if let Some(captures) = self.regex_match_with_captures(pattern, &prefix)
-                && captures.from == 0
-                && captures.to == end
-            {
-                best = end;
-                break;
-            }
-        }
+        let best = self.all_complete_match_ends_max(pattern, text);
         super::regex::regex_helpers::CODE_ATOMS_INERT.set(saved);
         best
+    }
+
+    fn all_complete_match_ends_max(&mut self, pattern: &str, text: &str) -> usize {
+        let Some(parsed) = self.parse_regex(pattern) else {
+            return 0;
+        };
+        let probe = RegexPattern {
+            anchor_end: false,
+            ..(*parsed).clone()
+        };
+        let chars: Vec<char> = text.chars().collect();
+        let pkg = self.current_package();
+        self.regex_match_ends_from_caps_in_pkg(&probe, &chars, 0, &pkg)
+            .into_iter()
+            .map(|(end, _)| end)
+            .max()
+            .unwrap_or(0)
     }
 
     pub(super) fn make_parse_failure_value(&self, text: &str, best_end: usize) -> Value {

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -103,7 +103,7 @@ impl Interpreter {
             .next()
     }
 
-    pub(super) fn regex_match_ends_from_caps_in_pkg(
+    pub(in crate::runtime) fn regex_match_ends_from_caps_in_pkg(
         &mut self,
         pattern: &RegexPattern,
         chars: &[char],

--- a/t/grammar-parse-failure-probe.t
+++ b/t/grammar-parse-failure-probe.t
@@ -1,13 +1,11 @@
 use v6;
 use Test;
 
-plan 7;
+plan 9;
 
-# A failed `.parse` reports how far it got by re-matching the pattern against
-# every prefix of the input (`longest_complete_prefix_end`). That is a
-# diagnostic, and computing it must not execute the grammar's code atoms —
-# otherwise a `<?{ … }>` runs once per prefix, i.e. O(input length) times.
-# See docs/adr/0009.
+# A failed `.parse` reports how far it got (`longest_complete_prefix_end`). That
+# is a diagnostic, so computing it must neither execute the grammar's code atoms
+# nor cost a re-match per prefix of the input. See docs/adr/0009.
 #
 # The tell is that the run count for a FIXED atom scales with the length of the
 # input, even though that atom is only ever reached once. raku runs it once
@@ -50,3 +48,23 @@ my $nshort = %n<a>;
 %n = ();
 nok Nested.parse("ab;zcdefghijklmnop").defined, 'nested: long input fails as expected';
 is %n<a>, $nshort, 'nested: run count does not scale with input length either';
+
+# The probe must also not re-match once per prefix. This is the shape that
+# reaches it: the declarative skeleton matches (so LTM keeps the candidate and the
+# real match runs) but the assertion rejects at the very end, and no prefix
+# matches in full either. Each item's assertion is reached exactly once by the
+# real match, so the total is the input length — in both implementations. A
+# per-prefix probe made it grow with n on top of that.
+our %total;
+sub runs_for($len) {
+    my grammar Late {
+        token TOP  { ^ <item>+ $ }
+        token item { (\w) <?{ %total<c>++; ~$0 ne 'z' }> }
+    }
+    %total = ();
+    Late.parse(('a' x ($len - 1)) ~ 'z');
+    return %total<c> // 0;
+}
+is runs_for(20), 20, 'assertion runs once per item, not once per item per prefix';
+is runs_for(40), 40, '...and it stays exactly the input length as the input grows';
+


### PR DESCRIPTION
`longest_complete_prefix_end` re-matched the pattern against every prefix of the
input, longest first, to report how far a failed `.parse` got — O(input length)
full matches on the failure path, and its common case (no prefix matches, so the
loop runs to the end) was its worst case.

"The pattern matches `text[0..end]` in full" is the same statement as "the pattern
has a complete match starting at 0 that ends at `end`", once the trailing `$` is
dropped: on a *truncated* string `$` is satisfied exactly when the match ends at
the truncation point, which is what enumerating the ends already gives. The engine
can enumerate every complete-match end in one walk, so one walk answers for every
prefix at once.

Measured on the shape that actually reaches the probe (see below), debug build:

| input len | before | after |
|---|---|---|
| 50 | 234 ms, 149 assertion runs | 48 ms, **50** |
| 400 | 2165 ms, 1199 assertion runs | 218 ms, **400** |

The run count is now exactly the input length — raku's count (raku: 50 and 400).

Which grammars reach the probe at all is easy to get wrong, and it took three
attempts to build a benchmark that did: if the declarative skeleton does not
match, the LTM filter drops the candidate and `parse_failure_for_pattern` is
called with `pattern: None`, so no probe runs. And if a prefix matches early
(`^ <item>+ $` over an even-length input), the loop broke after two iterations.
The probe is reached only when the skeleton matches but the real match fails —
i.e. when a code atom rejects, which is `advent2013-day18`'s shape.

The equality assumes a pattern's success at a given end depends only on the
characters it consumed. A look-ahead near the boundary can see text the truncated
string would not have, so it may now succeed where the loop failed; the answer is
a diagnostic position either way. `roast/S05-grammar/parse_and_parsefile-6e.t`
pins the exact numbers this feeds (`line == 3`, `pos == 14`, `pre == '# l3'`,
`post == '<EOL>'`) and still passes.

Extends the pin `t/grammar-parse-failure-probe.t` with the run-count-vs-length
property (passes under raku; fails on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)