### PR TITLE
fix: two mzef module-load blockers - typed sigilless pointy params, sibling-role short-name composition

### DIFF
--- a/src/parser/stmt/control/for_params.rs
+++ b/src/parser/stmt/control/for_params.rs
@@ -263,8 +263,31 @@ pub(crate) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
 }
 
 fn parse_for_pointy_param(input: &str) -> PResult<'_, ParamDef> {
+    let rest = input;
+    let mut type_constraint = None;
+    // Use parse_type_constraint_expr so coercion types (`IO()`, `Int(Str)`),
+    // qualified names, generics (`Array[Int]`) and definedness smileys (:D/:U)
+    // are all consumed before the loop variable (e.g. `-> IO() $current`).
+    // A sigilless param (`\name`) may also carry one: `-> Mu \type { ... }`.
+    let rest = if let Some((r, tc)) = super::super::sub_param::parse_type_constraint_expr(rest) {
+        let (r2, _) = ws(r)?;
+        if r2.starts_with('$')
+            || r2.starts_with('@')
+            || r2.starts_with('%')
+            || r2.starts_with('&')
+            || r2.starts_with('\\')
+        {
+            type_constraint = Some(tc);
+            r2
+        } else {
+            rest
+        }
+    } else {
+        rest
+    };
+
     // Sigilless parameter: \name
-    if let Some(r) = input.strip_prefix('\\') {
+    if let Some(r) = rest.strip_prefix('\\') {
         let (rest, name) = ident(r)?;
         return Ok((
             rest,
@@ -278,7 +301,7 @@ fn parse_for_pointy_param(input: &str) -> PResult<'_, ParamDef> {
                 double_slurpy: false,
                 onearg: false,
                 sigilless: true,
-                type_constraint: None,
+                type_constraint,
                 literal_value: None,
                 sub_signature: None,
                 where_constraint: None,
@@ -291,24 +314,6 @@ fn parse_for_pointy_param(input: &str) -> PResult<'_, ParamDef> {
             },
         ));
     }
-
-    let rest = input;
-    let mut type_constraint = None;
-    // Use parse_type_constraint_expr so coercion types (`IO()`, `Int(Str)`),
-    // qualified names, generics (`Array[Int]`) and definedness smileys (:D/:U)
-    // are all consumed before the loop variable (e.g. `-> IO() $current`).
-    let rest = if let Some((r, tc)) = super::super::sub_param::parse_type_constraint_expr(rest) {
-        let (r2, _) = ws(r)?;
-        if r2.starts_with('$') || r2.starts_with('@') || r2.starts_with('%') || r2.starts_with('&')
-        {
-            type_constraint = Some(tc);
-            r2
-        } else {
-            rest
-        }
-    } else {
-        rest
-    };
 
     let for_original_sigil = rest.as_bytes().first().copied().unwrap_or(b'$');
     let (r, name) = var_name(rest)?;

--- a/src/parser/stmt/control/pointy_param.rs
+++ b/src/parser/stmt/control/pointy_param.rs
@@ -1,34 +1,6 @@
 use super::*;
 
 pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
-    // Sigilless parameter: \name
-    if let Some(r) = input.strip_prefix('\\') {
-        let (rest, name) = ident(r)?;
-        return Ok((
-            rest,
-            ParamDef {
-                name,
-                default: None,
-                multi_invocant: true,
-                required: false,
-                named: false,
-                slurpy: false,
-                double_slurpy: false,
-                onearg: false,
-                sigilless: true,
-                type_constraint: None,
-                literal_value: None,
-                sub_signature: None,
-                outer_sub_signature: None,
-                code_signature: None,
-                where_constraint: None,
-                traits: Vec::new(),
-                optional_marker: false,
-                is_invocant: false,
-                shape_constraints: None,
-            },
-        ));
-    }
     // Positional destructuring sub-signature: `-> [$a, $b] { ... }`.
     // A bare `[...]` binds a single Positional argument and unpacks it — an
     // anonymous `@` param carrying the sub-signature (mirrors `sub f([$a,$b])`).
@@ -55,6 +27,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
             || r2.starts_with('%')
             || r2.starts_with('&')
             || r2.starts_with('*')
+            || r2.starts_with('\\')
             || (r2.starts_with(':')
                 && r2.len() > 1
                 && matches!(r2.as_bytes()[1], b'$' | b'@' | b'%' | b'&'))
@@ -103,6 +76,36 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
     } else {
         rest
     };
+
+    // Sigilless parameter: \name, optionally preceded by a type constraint
+    // (`-> Mu \type { ... }` — how JSON::Unmarshal writes its `where` lambdas).
+    if let Some(r) = rest.strip_prefix('\\') {
+        let (rest, name) = ident(r)?;
+        return Ok((
+            rest,
+            ParamDef {
+                name,
+                default: None,
+                multi_invocant: true,
+                required: false,
+                named: false,
+                slurpy: false,
+                double_slurpy: false,
+                onearg: false,
+                sigilless: true,
+                type_constraint,
+                literal_value: None,
+                sub_signature: None,
+                outer_sub_signature: None,
+                code_signature: None,
+                where_constraint: None,
+                traits: Vec::new(),
+                optional_marker: false,
+                is_invocant: false,
+                shape_constraints: None,
+            },
+        ));
+    }
 
     // Slurpy marker for pointy params: *@a, *%h, *$x, *&cb, and double-slurpy variants.
     let mut slurpy = false;

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -478,6 +478,25 @@ impl Interpreter {
                             .push(hidden_name.to_string());
                         continue;
                     }
+                    // A sibling role referenced by its short name (`role Derived
+                    // does Base` inside `unit module M`, where Base is registered
+                    // as `M::Base`) must resolve to its qualified name — the same
+                    // resolution the class-body DoesDecl path already does.
+                    // JSON::Unmarshal composes all its CustomUnmarshaller roles
+                    // this way.
+                    let role_name_str = if !self.registry().roles.contains_key(&role_name_str)
+                        && !self.registry().classes.contains_key(&role_name_str)
+                        && !role_name_str.contains('[')
+                    {
+                        let resolved = self.resolve_declared_type_name(&role_name_str);
+                        if self.registry().roles.contains_key(&resolved) {
+                            resolved
+                        } else {
+                            role_name_str
+                        }
+                    } else {
+                        role_name_str
+                    };
                     if self.registry().classes.contains_key(&role_name_str) {
                         self.registry_mut()
                             .role_parents

--- a/t/pointy-param-typed-sigilless.t
+++ b/t/pointy-param-typed-sigilless.t
@@ -1,0 +1,35 @@
+use v6;
+use Test;
+
+plan 8;
+
+# A pointy-block parameter can be sigilless (\name) AND carry a type
+# constraint: `-> Mu \type { ... }`. The parser used to accept the two only
+# separately (`-> \t` / `-> Mu $t`), failing on the combination — which is how
+# JSON::Unmarshal writes every `where` lambda (`subset ClassLike of Mu
+# where -> Mu \type { ... }`), blocking `use JSON::Unmarshal` entirely.
+
+# expression position (lambda assigned to a variable)
+my &f = -> Int \t { t + 1 };
+is f(41), 42, 'expression-position pointy with typed sigilless param';
+
+# for-loop position
+my @got;
+for 1, 2 -> Mu \t { @got.push(t) }
+is-deeply @got, [1, 2], 'for-loop pointy with typed sigilless param';
+
+# subset where clause taking such a lambda (the JSON::Unmarshal shape)
+subset PosInt of Mu where -> Mu \type { type ~~ Int && type > 0 };
+ok 42 ~~ PosInt, 'subset where pointy lambda accepts';
+nok -1 ~~ PosInt, 'subset where pointy lambda rejects by predicate';
+nok "x" ~~ PosInt, 'subset where pointy lambda rejects by type expr';
+
+# multi-line layout, as written in the wild
+subset Defined of Mu
+    where -> Mu \type { type.defined };
+ok 42 ~~ Defined, 'multi-line subset where pointy lambda (defined)';
+nok Mu ~~ Defined, 'multi-line subset where pointy lambda (type object)';
+
+# the type constraint is enforced, not just parsed
+my &g = -> Int \t { t };
+dies-ok { g("x") }, 'typed sigilless pointy param still type-checks';

--- a/t/role-does-sibling-in-unit-module.t
+++ b/t/role-does-sibling-in-unit-module.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+plan 6;
+
+# Inside a module body, a role is registered under its qualified name
+# (`M::Base`). A sibling role composing it by short name (`role Derived does
+# Base`) must resolve through the module prefix — the class-body `does` path
+# already did; the role-body path errored with "Unknown role: Base".
+# JSON::Unmarshal composes all its CustomUnmarshaller roles this way
+# (under `unit module JSON::Unmarshal`), which blocked `use JSON::Unmarshal`
+# (and with it JSON::Marshal / Test::META).
+
+module RoleSib {
+    role Base {
+        method b { "base" }
+    }
+
+    role Derived does Base {
+        method d { "derived" }
+    }
+
+    role Third does Derived {
+        method t { "third" }
+    }
+
+    class UsesThird does Third {
+    }
+}
+
+my $x = RoleSib::UsesThird.new;
+is $x.b, "base", 'grandparent role method via short-name chain';
+is $x.d, "derived", 'parent role method via short-name chain';
+is $x.t, "third", 'directly-composed role method';
+ok $x ~~ RoleSib::Base, 'smartmatch against the qualified base role';
+ok $x ~~ RoleSib::Derived, 'smartmatch against the qualified middle role';
+ok $x ~~ RoleSib::Third, 'smartmatch against the qualified composed role';


### PR DESCRIPTION
Two fixes on the same mzef frontier: with #4658 merged, `zef install --/test Test::META` installs all 13 dists end-to-end, and the frontier moved to *loading* what was installed. These are the first two loading blockers.

## 1. `-> Mu \type { ... }` — a pointy-block param can be typed AND sigilless

`-> \t { }` parsed. `-> Mu $t { }` parsed. `-> Mu \t { }` — "Confused".

Both pointy-param parsers (`parse_pointy_param` for expression-position lambdas, `parse_for_pointy_param` for for-loops) checked the sigilless `\name` branch before the optional type constraint, and their type-constraint acceptance list did not include `\`. Parse the constraint first, accept `\` after it, attach the constraint to the sigilless `ParamDef`; binding already enforces it.

JSON::Unmarshal writes every `where` lambda this way (`subset ClassLike of Mu where -> Mu \type { ... }`), so `use JSON::Unmarshal` died at parse.

Pin: `t/pointy-param-typed-sigilless.t` (8 tests, passes under raku).

## 2. `role Derived does Base` inside a module — sibling-role short-name resolution

Inside a module body, `role Base` registers as `M::Base`. A sibling role composing it by short name failed with "Unknown role: Base": the role-body `DoesDecl` path looked the name up verbatim, while the class-body path already resolved short names via `resolve_declared_type_name`. Apply the same resolution.

JSON::Unmarshal composes its three `CustomUnmarshaller` roles this way under `unit module JSON::Unmarshal`.

Pin: `t/role-does-sibling-in-unit-module.t` (fails "Unknown role: B" before, 6/6 after; passes under raku).

## Result

`use JSON::Unmarshal` and `use JSON::Marshal` now load (both previously died). The next loading blockers (vrurg JSON::Class BEGIN-block parse, `URI.host` coercion return type) are tracked in docs/mzef-install-pipeline.md.

## Validation

- Both pins pass under raku and mutsu
- 150 pointy/for/lambda/param/subset/where/block `t/` files: PASS
- 86 role/module/does/mixin/import `t/` files: PASS
- 66 signature/subset + 70 roles/classes/modules roast files: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
