### PR TITLE
fix: `use` dist selectors pick the right installed distribution; role adverbs may precede the signature

### DIFF
--- a/docs/mzef-install-pipeline.md
+++ b/docs/mzef-install-pipeline.md
@@ -168,19 +168,41 @@ found it is kept below.
 
 `zef install --/test Test::META` completes: 16 candidates resolve, fetch,
 extract, and **13 dists install** into the site repo. The frontier is now
-*using* them:
+*using* them. Fixed so far (each: minimal repro → general fix → `t/` pin):
 
-- **`use Test::META`** → `expected statement: … '{' or expression statement, at
-  -e:40` — a parse error inside one of the installed modules (line 40 of some
-  file in the `use` chain; identify which module by bisecting the chain:
-  `use META6`, `use License::SPDX`, … individually).
+- ~~`-> Mu \type { ... }` typed sigilless pointy param~~ (#4661) — unblocked
+  `use JSON::Unmarshal`'s `subset ... where` lambdas.
+- ~~sibling-role short-name composition inside a module~~ (#4661) — unblocked
+  JSON::Unmarshal's `CustomUnmarshaller` role family; JSON::Marshal loads.
+- ~~`use` dist selectors discarded / first-found dist loaded~~ — two installed
+  dists provide `JSON::Class` (zef:jonathanstowe vs zef:vrurg); resolution now
+  filters by `:auth`/`:ver`/`:api` and picks the highest version. Pin:
+  `t/use-dist-selectors.t`.
+- ~~`role Name:ver<...>:auth<...>[SIGNATURE]`~~ — adverbs before the parametric
+  signature failed to parse (jonathanstowe JSON::Class line 121). Pin:
+  `t/role-decl-adverbs-signature.t`.
+
+Still open, in chain order:
+
+- **Attribute role-mixin does not persist out of `trait_mod:<is>`** — blocks
+  `use License::SPDX` (its `is json-name(...)` attributes). Repro:
+  a custom `multi sub trait_mod:<is>(Attribute $a, :$myname!) { $a does R;
+  $a.n = $myname }` — the mixin/assignment do not survive onto
+  `C.^attributes[0]` (works via `my $attr = C.^attributes[0]; $attr does R`
+  outside a trait). tmp repro: `tmp/attr-does-rw2.raku`. Under the module's
+  imported multi the same shape errors `X::Assignment::RO: cannot assign
+  through .json-name on non-instance`.
+- **`use Test::META`** — not re-bisected past License::SPDX yet.
 - **`use URI; URI.new("https://raku.org/x").host`** → `Type check failed for
   return value; expected Host but got Str ("raku.org")` — a
-  coercion/subset-typed **return** value (`Host` is a URI subset/type) is
-  checked against the raw Str instead of coercing/accepting it.
-
-Both are ordinary language-compat bugs, unrelated to the install machinery.
-Follow the campaign method: minimal repro → general fix → `t/` pin → PR.
+  coercion/subset-typed **return** value is checked against the raw Str.
+- **vrurg JSON::Class (`use v6.e.PREVIEW`) line 40 parse error** — no longer
+  in the default chain (the selector fix routes to jonathanstowe's), but the
+  dist is installed and still cannot load.
+- **`R[:b]` named-arg role parameterization binds the Pair, not its value**
+  (mutsu prints `b => True` where raku prints `True`) — noticed while fixing
+  the role-adverb parse; harmless for truthiness uses like
+  `JSON::Class[:opt-in]` but wrong.
 
 ### Resolved: the extract matcher rejection was the shared-store parent-child clobber
 

--- a/src/parser/stmt/class/role_decl.rs
+++ b/src/parser/stmt/class/role_decl.rs
@@ -297,11 +297,20 @@ pub(crate) fn role_decl(input: &str) -> PResult<'_, Stmt> {
     let (rest, _) = ws1(rest)?;
     let (rest, name) = qualified_ident(rest)?;
     check_pseudo_package_in_decl(&name)?;
-    let (mut rest, (type_params, type_param_defs)) = parse_optional_role_type_params(rest)?;
+    let (mut rest, (mut type_params, mut type_param_defs)) = parse_optional_role_type_params(rest)?;
     // Parse optional type adverbs (:ver<...>, :auth<...>, :api<...>)
     let (rest2, traits) = parse_declarator_traits(rest)?;
     let (rest2, _) = ws(rest2)?;
     rest = rest2;
+    // The signature may also FOLLOW the adverbs — the order Raku itself uses:
+    // `role JSON::Class:ver<0.0.21>:auth<zef:jonathanstowe>[Bool :$opt-in]`.
+    if type_params.is_empty() && rest.starts_with('[') {
+        let (rest2, (tp, tpd)) = parse_optional_role_type_params(rest)?;
+        let (rest2, _) = ws(rest2)?;
+        type_params = tp;
+        type_param_defs = tpd;
+        rest = rest2;
+    }
     let mut parent_roles: Vec<String> = Vec::new();
     let mut is_hidden_role = false;
     let mut role_is_rw = false;

--- a/src/parser/stmt/decl/use_decl.rs
+++ b/src/parser/stmt/decl/use_decl.rs
@@ -67,6 +67,7 @@ pub(in crate::parser::stmt) fn use_stmt(input: &str) -> PResult<'_, Stmt> {
     let mut rest = rest;
     let mut use_tags: Vec<String> = Vec::new();
     let mut condition: Option<Box<Expr>> = None;
+    let mut dist_selectors = String::new();
     loop {
         if rest.starts_with(':') && !rest.starts_with("::") {
             let r = &rest[1..];
@@ -99,10 +100,14 @@ pub(in crate::parser::stmt) fn use_stmt(input: &str) -> PResult<'_, Stmt> {
                 // 'ver'` / `'auth'`).
                 let is_dist_selector = matches!(tag_name.as_str(), "ver" | "auth" | "api");
                 if is_dist_selector && r.starts_with('<') {
-                    let after = match r[1..].find('>') {
-                        Some(end) => &r[end + 2..],
+                    let (value, after) = match r[1..].find('>') {
+                        Some(end) => (&r[1..end + 1], &r[end + 2..]),
                         None => return Err(PError::expected("closing '>' in version adverb")),
                     };
+                    // Keep the literal selector: it refines which installed
+                    // distribution `use` resolves (`use JSON::Class:auth<...>`),
+                    // carried to the runtime appended to the module name.
+                    dist_selectors.push_str(&format!(":{}<{}>", tag_name, value));
                     let (after, _) = ws(after)?;
                     let after = after.strip_prefix(',').unwrap_or(after);
                     let (after, _) = ws(after)?;
@@ -154,6 +159,13 @@ pub(in crate::parser::stmt) fn use_stmt(input: &str) -> PResult<'_, Stmt> {
     }
     // Register exported function names so they are recognized as calls without parens.
     super::super::simple::register_module_exports(&module);
+    // Dist selectors ride on the module name (`Name:auth<...>:ver<...>`); the
+    // runtime's use_module splits them back off before any registry keying.
+    let module = if dist_selectors.is_empty() {
+        module
+    } else {
+        format!("{}{}", module, dist_selectors)
+    };
     Ok((
         rest,
         Stmt::Use {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1253,6 +1253,12 @@ pub struct Interpreter {
     /// happen after this flag is consumed, run the proto body again (matching raku).
     pub(crate) proto_method_skip: Option<String>,
     pending_dispatch_error: Option<RuntimeError>,
+    /// Distribution selectors (`:ver`/`:auth`/`:api`) of the `use` currently
+    /// being resolved, split off the module name by `use_module_with_tags` and
+    /// consulted by `resolve_module_path` to pick among installed dists that
+    /// provide the same short name. Saved/restored around each load so a
+    /// transitive `use` resolves with its own (usually absent) selectors.
+    pending_dist_selectors: Vec<(String, String)>,
     end_phasers: Vec<(Vec<Stmt>, Env)>,
     /// Tracks END phaser site_ids to ensure each is registered only once.
     end_phaser_sites: HashSet<u64>,

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -12,6 +12,13 @@ impl Interpreter {
         let extensions = [".rakumod", ".pm6", ".pm"];
 
         // Check inst# paths (CompUnit::Repository::Installation) first.
+        // Several installed dists may provide the same short name (two
+        // JSON::Class dists exist on fez, by different authors). Collect every
+        // candidate, filter by the `use` statement's dist selectors
+        // (`:ver`/`:auth`/`:api`, in pending_dist_selectors), and pick the
+        // highest version — the first-JSON-found behavior this replaces
+        // effectively loaded a random one.
+        let mut inst_candidates: Vec<(std::path::PathBuf, String)> = Vec::new();
         for base in &self.lib_paths {
             if let Some(prefix) = base.strip_prefix("inst#") {
                 let prefix_path = Path::new(prefix);
@@ -34,11 +41,21 @@ impl Interpreter {
                     {
                         let source_path = prefix_path.join("sources").join(&file_id);
                         if source_path.exists() {
-                            return Some((source_path, Some(json_str)));
+                            inst_candidates.push((source_path, json_str));
                         }
                     }
                 }
             }
+        }
+        if !inst_candidates.is_empty() {
+            if let Some((source_path, json_str)) =
+                self.select_dist_candidate(inst_candidates, &self.pending_dist_selectors)
+            {
+                return Some((source_path, Some(json_str)));
+            }
+            // Candidates existed but none matched the selectors: the dependency
+            // is unsatisfied, not "pick a wrong one".
+            return None;
         }
 
         let mut candidates: Vec<std::path::PathBuf> = Vec::new();
@@ -133,6 +150,70 @@ impl Interpreter {
             .into_iter()
             .find(|path| path.exists())
             .map(|p| (p, None))
+    }
+
+    /// Pick one installed dist among several that provide the requested module:
+    /// filter by the `use` statement's dist selectors (`:auth` = exact match,
+    /// `:ver`/`:api` = Version smartmatch, so `0.0.14+` means at-least), then
+    /// take the highest version. Returns None when selectors exclude them all.
+    fn select_dist_candidate(
+        &self,
+        candidates: Vec<(std::path::PathBuf, String)>,
+        selectors: &[(String, String)],
+    ) -> Option<(std::path::PathBuf, String)> {
+        let mut best: Option<(std::path::PathBuf, String, Vec<crate::value::VersionPart>)> = None;
+        for (path, json_str) in candidates {
+            let meta: serde_json::Value = serde_json::from_str(&json_str).unwrap_or_default();
+            let meta_str = |key: &str| -> String {
+                match &meta[key] {
+                    serde_json::Value::String(s) => s.clone(),
+                    serde_json::Value::Number(n) => n.to_string(),
+                    _ => String::new(),
+                }
+            };
+            let mut matches = true;
+            for (key, want) in selectors {
+                let have = meta_str(key);
+                match key.as_str() {
+                    "auth" => {
+                        if have != *want {
+                            matches = false;
+                        }
+                    }
+                    "ver" | "api" => {
+                        // The dist JSON stores the version under "version"
+                        // (zef/S22 meta), while the api is under "api".
+                        let have = if key == "ver" {
+                            meta_str("version")
+                        } else {
+                            have
+                        };
+                        let (want_parts, plus, minus) = Value::parse_version_string(want);
+                        let (have_parts, _, _) = Value::parse_version_string(&have);
+                        let have_val = Value::version(have_parts, false, false);
+                        if !Self::version_smart_match(&have_val, &want_parts, plus, minus) {
+                            matches = false;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            if !matches {
+                continue;
+            }
+            let (ver_parts, _, _) = Value::parse_version_string(&meta_str("version"));
+            let better = match &best {
+                None => true,
+                Some((_, _, best_parts)) => {
+                    crate::runtime::version_cmp_parts(&ver_parts, best_parts)
+                        == std::cmp::Ordering::Greater
+                }
+            };
+            if better {
+                best = Some((path, json_str, ver_parts));
+            }
+        }
+        best.map(|(p, j, _)| (p, j))
     }
 
     /// Default install directory for a well-known repository name
@@ -336,7 +417,6 @@ impl Interpreter {
             let prefix = base.strip_prefix("inst#")?;
             let prefix_path = Path::new(prefix);
             let dist_dir = prefix_path.join("dist");
-            let resources_dir = prefix_path.join("resources");
             if !dist_dir.is_dir() {
                 continue;
             }
@@ -357,52 +437,57 @@ impl Interpreter {
                 if let Some(provides) = meta_val.hash_get_str("provides")
                     && provides.hash_get_str(module).is_some()
                 {
-                    // Build a distribution instance with files resolved to absolute paths
-                    // Remap the "files" entries to full paths
-                    use std::collections::HashMap;
-
-                    let mut resolved_files: HashMap<String, Value> = HashMap::new();
-                    if let Some(files_val) = meta_val.hash_get_str("files")
-                        && let ValueView::Hash(fmap) = files_val.view()
-                    {
-                        for (k, v) in fmap.iter() {
-                            let hash_id = v.to_string_value();
-                            // Determine full path based on key prefix
-                            let full_path = if k.starts_with("resources/") {
-                                resources_dir.join(&hash_id).to_string_lossy().to_string()
-                            } else {
-                                prefix_path.join(&hash_id).to_string_lossy().to_string()
-                            };
-                            resolved_files.insert(k.clone(), Value::str(full_path));
-                        }
-                    }
-                    let mut meta_map = match meta_val.view() {
-                        ValueView::Hash(m) => m.map.clone(),
-                        _ => HashMap::new(),
-                    };
-                    meta_map.insert(
-                        "files".to_string(),
-                        Value::hash_with_data(Value::hash_arc(resolved_files)),
-                    );
-                    meta_map.insert("prefix".to_string(), Value::str(prefix.to_string()));
-                    let mut attrs = HashMap::new();
-                    attrs.insert(
-                        "meta".to_string(),
-                        Value::hash_with_data(Value::hash_arc(meta_map)),
-                    );
-                    attrs.insert("prefix".to_string(), Value::str(prefix.to_string()));
-                    return Some(Value::make_instance_without_destroy(
-                        crate::symbol::Symbol::intern("Distribution::Installation"),
-                        attrs,
-                    ));
+                    return Some(Self::build_inst_distribution(prefix, &meta_val));
                 }
             }
         }
         None
     }
 
+    /// Build a `Distribution::Installation` instance from an installed dist's
+    /// meta, with its "files" entries resolved to absolute paths under `prefix`.
+    fn build_inst_distribution(prefix: &str, meta_val: &Value) -> Value {
+        use std::collections::HashMap;
+        let prefix_path = Path::new(prefix);
+        let resources_dir = prefix_path.join("resources");
+        let mut resolved_files: HashMap<String, Value> = HashMap::new();
+        if let Some(files_val) = meta_val.hash_get_str("files")
+            && let ValueView::Hash(fmap) = files_val.view()
+        {
+            for (k, v) in fmap.iter() {
+                let hash_id = v.to_string_value();
+                // Determine full path based on key prefix
+                let full_path = if k.starts_with("resources/") {
+                    resources_dir.join(&hash_id).to_string_lossy().to_string()
+                } else {
+                    prefix_path.join(&hash_id).to_string_lossy().to_string()
+                };
+                resolved_files.insert(k.clone(), Value::str(full_path));
+            }
+        }
+        let mut meta_map = match meta_val.view() {
+            ValueView::Hash(m) => m.map.clone(),
+            _ => HashMap::new(),
+        };
+        meta_map.insert(
+            "files".to_string(),
+            Value::hash_with_data(Value::hash_arc(resolved_files)),
+        );
+        meta_map.insert("prefix".to_string(), Value::str(prefix.to_string()));
+        let mut attrs = HashMap::new();
+        attrs.insert(
+            "meta".to_string(),
+            Value::hash_with_data(Value::hash_arc(meta_map)),
+        );
+        attrs.insert("prefix".to_string(), Value::str(prefix.to_string()));
+        Value::make_instance_without_destroy(
+            crate::symbol::Symbol::intern("Distribution::Installation"),
+            attrs,
+        )
+    }
+
     pub(super) fn load_module(&mut self, module: &str) -> Result<(), RuntimeError> {
-        let (source_path, _inst_dist_json) = self
+        let (source_path, inst_dist_json) = self
             .resolve_module_path(module)
             .ok_or_else(|| RuntimeError::unsatisfied_dependency(module))?;
         // Track operator subs exported by this module so EVAL can see them.
@@ -415,8 +500,20 @@ impl Interpreter {
         // For installed modules (inst# paths), use the dist JSON directly.
         // Otherwise fall back to META6.json detection.
         let saved_distribution = self.current_distribution.clone();
-        // First try inst# installation repos (source files have no META6.json nearby)
-        let inst_dist = self.detect_inst_distribution(module);
+        // Prefer the dist JSON of the distribution resolve_module_path actually
+        // selected (selectors / highest-version pick): a by-name rescan could
+        // land on a DIFFERENT dist that also provides this short name. The
+        // source lives at <prefix>/sources/<id>, so prefix is two levels up.
+        let inst_dist = inst_dist_json
+            .and_then(|json_str| {
+                let prefix = source_path.parent()?.parent()?;
+                let meta_val = self.parse_json_to_value(&json_str).ok()?;
+                Some(Self::build_inst_distribution(
+                    &prefix.to_string_lossy(),
+                    &meta_val,
+                ))
+            })
+            .or_else(|| self.detect_inst_distribution(module));
         // Classes/roles this module declares belong to its distribution too, so a
         // later OTF compile of one of their methods can resolve `$?DISTRIBUTION`
         // (e.g. a role method reads `$?DISTRIBUTION.meta` — zef's `Pluggable`).

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2038,6 +2038,7 @@ impl Interpreter {
             proto_dispatch_stack: Vec::new(),
             proto_method_skip: None,
             pending_dispatch_error: None,
+            pending_dist_selectors: Vec::new(),
             end_phasers: Vec::new(),
             end_phaser_sites: HashSet::new(),
             chroot_root: None,

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -65,7 +65,45 @@ impl Interpreter {
         self.use_module_with_tags(module, &[])
     }
 
+    /// Split `Name:auth<zef:foo>:ver<0.0.20+>` into the bare module name and
+    /// its distribution selectors. The parser only appends the three dist
+    /// adverbs (`ver`/`auth`/`api`) in this literal angle form, so the split is
+    /// unambiguous: a `::`-qualified name never contains a lone `:`.
+    pub(crate) fn split_dist_selectors(module: &str) -> (&str, Vec<(String, String)>) {
+        let mut selectors = Vec::new();
+        let mut bare_end = module.len();
+        for key in ["ver", "auth", "api"] {
+            let pat = format!(":{}<", key);
+            if let Some(pos) = module.find(&pat) {
+                bare_end = bare_end.min(pos);
+                let after = &module[pos + pat.len()..];
+                if let Some(end) = after.find('>') {
+                    selectors.push((key.to_string(), after[..end].to_string()));
+                }
+            }
+        }
+        (&module[..bare_end], selectors)
+    }
+
     pub fn use_module_with_tags(
+        &mut self,
+        module: &str,
+        tags: &[String],
+    ) -> Result<(), RuntimeError> {
+        // The parser rides dist selectors on the module name
+        // (`JSON::Class:auth<zef:jonathanstowe>:api<1.0>`). Split them off here
+        // so every registry/loaded_modules key below uses the bare name, and
+        // only distribution resolution sees the constraints. Save/restore
+        // around the load: a transitive `use` inside the module body must
+        // resolve with ITS OWN (usually absent) selectors, not the outer ones.
+        let (module, dist_selectors) = Self::split_dist_selectors(module);
+        let saved = std::mem::replace(&mut self.pending_dist_selectors, dist_selectors);
+        let result = self.use_module_with_tags_inner(module, tags);
+        self.pending_dist_selectors = saved;
+        result
+    }
+
+    fn use_module_with_tags_inner(
         &mut self,
         module: &str,
         tags: &[String],

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -217,6 +217,7 @@ impl Interpreter {
             proto_dispatch_stack: Vec::new(),
             proto_method_skip: None,
             pending_dispatch_error: None,
+            pending_dist_selectors: Vec::new(),
             end_phasers: Vec::new(),
             end_phaser_sites: HashSet::new(),
             chroot_root: self.chroot_root.clone(),

--- a/t/fixtures/dist-selectors/dist/aaa-old.json
+++ b/t/fixtures/dist-selectors/dist/aaa-old.json
@@ -1,0 +1,11 @@
+{
+    "name": "SelTest",
+    "version": "0.0.6",
+    "auth": "zef:alice",
+    "api": "0",
+    "provides": {
+        "SelTest": {
+            "file": "seltest-alice"
+        }
+    }
+}

--- a/t/fixtures/dist-selectors/dist/bbb-new.json
+++ b/t/fixtures/dist-selectors/dist/bbb-new.json
@@ -1,0 +1,11 @@
+{
+    "name": "SelTest",
+    "version": "0.0.21",
+    "auth": "zef:bob",
+    "api": "1.0",
+    "provides": {
+        "SelTest": {
+            "file": "seltest-bob"
+        }
+    }
+}

--- a/t/fixtures/dist-selectors/sources/seltest-alice
+++ b/t/fixtures/dist-selectors/sources/seltest-alice
@@ -1,0 +1,3 @@
+unit module SelTest;
+
+sub sel-test-who is export { "alice-0.0.6" }

--- a/t/fixtures/dist-selectors/sources/seltest-bob
+++ b/t/fixtures/dist-selectors/sources/seltest-bob
@@ -1,0 +1,3 @@
+unit module SelTest;
+
+sub sel-test-who is export { "bob-0.0.21" }

--- a/t/role-decl-adverbs-signature.t
+++ b/t/role-decl-adverbs-signature.t
@@ -1,0 +1,33 @@
+use v6;
+use Test;
+
+plan 5;
+
+# A role declaration can carry BOTH dist adverbs and a parametric signature —
+# adverbs first, the order Raku itself uses:
+#   role JSON::Class:ver<0.0.21>:auth<zef:jonathanstowe>[Bool :$opt-in = False]
+# The parser used to try the signature only BEFORE the adverbs, so this shape
+# failed to parse (blocking `use JSON::Class` and everything above it:
+# License::SPDX, META6, Test::META).
+
+role R:ver<1.0>:auth<zef:test>[Bool :$b = False] {
+    method flagged { $b }
+}
+
+ok R.new.flagged === False, 'bare composition uses the parameter default';
+ok R.^name eq 'R', 'the role name excludes the adverbs';
+
+class WithDefault does R {
+}
+ok WithDefault.new.flagged === False, 'class does R (no args) gets the default';
+
+role S:api<2>[::T] {
+    method of-type { T.^name }
+}
+is S[Int].new.of-type, 'Int', 'adverb followed by a type-parameter signature';
+
+# Adverbs alone still parse (regression guard for the pre-existing shape).
+role Plain:ver<0.1> {
+    method p { 'p' }
+}
+is Plain.new.p, 'p', 'adverbs without a signature still parse';

--- a/t/use-dist-selectors.t
+++ b/t/use-dist-selectors.t
@@ -1,0 +1,27 @@
+use v6;
+use Test;
+
+plan 6;
+
+# `use Module:auth<...>:ver<...>:api<...>` refines WHICH installed distribution
+# is loaded when several provide the same short name (two JSON::Class dists
+# exist on fez, by different authors). The selectors used to be parsed and
+# DISCARDED, and the inst# repo scan returned whichever dist JSON read_dir
+# happened to yield first. Now candidates are filtered by the selectors and the
+# highest version wins. The fixture repo has two SelTest dists:
+#   alice 0.0.6 api<0>  /  bob 0.0.21 api<1.0>
+
+my $exe = $*EXECUTABLE;
+my $repo = 'inst#t/fixtures/dist-selectors';
+
+sub who(Str $use-stmt) {
+    my $r = run($exe, '-I', $repo, '-e', $use-stmt ~ '; say sel-test-who()', :out, :err);
+    $r.out.slurp(:close).trim ~ ($r.exitcode == 0 ?? '' !! ' [exit ' ~ $r.exitcode ~ ']')
+}
+
+is who('use SelTest:auth<zef:alice>'), 'alice-0.0.6', ':auth picks the matching dist';
+is who('use SelTest:auth<zef:bob>'), 'bob-0.0.21', ':auth picks the other dist';
+is who('use SelTest'), 'bob-0.0.21', 'no selector: the highest version wins';
+is who('use SelTest:ver<0.0.14+>'), 'bob-0.0.21', ':ver<0.0.14+> excludes the older dist';
+is who('use SelTest:ver<0.0.6>'), 'alice-0.0.6', 'an exact :ver picks the older dist';
+is who('use SelTest:api<1.0>'), 'bob-0.0.21', ':api selects like a version';


### PR DESCRIPTION
Two more mzef module-load blockers, hit by the Test::META dependency chain now that mzef installs it end-to-end (#4658, #4661).

## 1. `use Module:auth<...>:ver<...>:api<...>` picked a random dist

The selectors were parsed and **discarded**, and the inst# repo scan returned whichever dist JSON `read_dir` yielded first. Two installed dists provide `JSON::Class` (zef:jonathanstowe 0.0.21 api 1.0, zef:vrurg 0.0.6), so `use JSON::Class` — with or without selectors — loaded a random one; License::SPDX/META6/Test::META got vrurg's and died in its `use v6.e.PREVIEW` source.

Now:
- the parser keeps the literal selectors (riding on the module name, split back off in `use_module` before any registry keying, saved/restored around the load so transitive `use`s resolve with their own selectors);
- resolution collects **every** providing dist, filters by the selectors (`:auth` exact, `:ver`/`:api` Version-smartmatched so `0.0.14+` means at-least), and picks the **highest version**;
- candidates that all fail the selectors are an unsatisfied dependency, not a fallback;
- `$?DISTRIBUTION` builds from the dist JSON resolution actually selected, instead of a first-hit rescan that could disagree.

Pin: `t/use-dist-selectors.t` — a checked-in fixture inst# repo with two same-named dists (different auth/ver/api), exercised via subprocesses.

## 2. `role Name:ver<...>:auth<...>[SIGNATURE]` failed to parse

jonathanstowe's JSON::Class line 121 is `role JSON::Class:ver<0.0.21>:auth<zef:jonathanstowe>[Bool :$opt-in = False]` — dist adverbs **then** the parametric signature, the order Raku itself uses. The role declarator only tried the `[...]` signature before the adverbs. Re-try it after them.

Pin: `t/role-decl-adverbs-signature.t` (passes under raku).

## Result

`use JSON::Class` and the `:auth`-constrained uses in License::SPDX/META6 resolve the right dist; License::SPDX progresses to the next frontier bug (Attribute role-mixin persistence in `trait_mod:<is>`), tracked with the rest of the chain in docs/mzef-install-pipeline.md.

## Validation

- Both pins pass (dist-selector pin 6/6, role-adverb pin 5/5 under raku and mutsu)
- 86 use/module/import/export/role `t/` files: PASS
- 47 S10-packages/S11-modules/S14-roles roast files: PASS
- `zef --version` under the instrumented checkout still works (zef's own `:ver(...)` parenthesized selectors keep the discard path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)