### PR TITLE
fix: custom attribute traits survive to ^attributes (the JSON::Name shape)

### DIFF
--- a/src/runtime/methods_classhow_attribute.rs
+++ b/src/runtime/methods_classhow_attribute.rs
@@ -134,6 +134,16 @@ impl Interpreter {
 
     fn make_attribute_object(&self, attr: &super::ClassAttributeDef, owner: &str) -> Value {
         let (ref attr_name, is_public, ref default, is_rw, _, sigil, _) = *attr;
+        // A custom trait_mod:<is> was applied to this attribute at class
+        // registration: serve the SAME meta-object it mutated (role mixins,
+        // values like JSON::Name's `$.json-name`), topped up below with the
+        // standard keys the ephemeral trait-time object lacks. Returning a
+        // fresh object instead would silently drop the trait's work.
+        let stored = self
+            .registry()
+            .class_attribute_trait_objects
+            .get(&(owner.to_string(), attr_name.clone()))
+            .cloned();
         let full_name = format!("{}!{}", sigil, attr_name);
         let raw_type_name = self
             .registry()
@@ -211,7 +221,26 @@ impl Interpreter {
                 );
             }
         }
-        Value::make_instance(Symbol::intern("Attribute"), meta)
+        match stored {
+            Some(stored) => {
+                // Top up the trait-time object with the standard keys it lacks
+                // (build, is_rw, ...) without overwriting anything the trait
+                // set, and return THAT object so its mixins/values survive.
+                // The stored value is a Mixin when the trait did `$a does R`;
+                // its inner Instance shares the original attr cell.
+                let inner = match stored.view() {
+                    ValueView::Mixin(inner, _) => inner.as_ref().clone(),
+                    _ => stored.clone(),
+                };
+                if let ValueView::Instance { attributes, .. } = inner.view() {
+                    for (k, v) in meta {
+                        attributes.insert_if_absent(k, v);
+                    }
+                }
+                stored
+            }
+            None => Value::make_instance(Symbol::intern("Attribute"), meta),
+        }
     }
 
     /// Build a minimal Attribute introspection object for a `has` declaration
@@ -284,13 +313,32 @@ impl Interpreter {
             let has_handler =
                 self.has_proto(&trait_mod_name) || self.has_multi_candidates(&trait_mod_name);
             if has_handler {
-                let attr_obj = self.make_trait_attribute_object(
-                    attr_name_str,
-                    sigil,
-                    is_public,
-                    owner,
-                    type_constraint,
-                );
+                // Reuse the Attribute meta-object across every trait applied to
+                // this attr, and store it in the registry: instance attrs are a
+                // shared cell, so whatever the trait sub does to `$a`
+                // (`$a does NamedAttribute; $a.json-name = $v` — JSON::Name)
+                // lands in this object, and `^attributes` serves it back.
+                let attr_key = (owner.to_string(), attr_name_str.to_string());
+                let attr_obj = if let Some(existing) = self
+                    .registry()
+                    .class_attribute_trait_objects
+                    .get(&attr_key)
+                    .cloned()
+                {
+                    existing
+                } else {
+                    let fresh = self.make_trait_attribute_object(
+                        attr_name_str,
+                        sigil,
+                        is_public,
+                        owner,
+                        type_constraint,
+                    );
+                    self.registry_mut()
+                        .class_attribute_trait_objects
+                        .insert(attr_key, fresh.clone());
+                    fresh
+                };
                 let trait_arg_val = if let Some(arg_expr) = trait_arg {
                     Some(self.eval_block_value(&[crate::ast::Stmt::Expr(arg_expr.clone())])?)
                 } else {
@@ -308,7 +356,23 @@ impl Interpreter {
                         Value::pair(trait_name.clone(), trait_arg_val.unwrap_or(Value::TRUE));
                     args.push(named_val);
                 }
-                self.call_function(&trait_mod_name, args)?;
+                // `$a does SomeRole` inside the trait produces a Mixin wrapper
+                // bound only to the trait sub's local `$a` — arm the same
+                // writeback DoesVar uses for `&sub` trait targets (see
+                // registration_sub.rs) and store the captured Mixin as this
+                // attribute's meta-object, so the mixin's methods/values
+                // survive to `^attributes` (JSON::Name's `is json-name`).
+                let saved_wb_key = self.trait_mod_writeback_key.take();
+                self.trait_mod_writeback_key =
+                    Some(format!("__mutsu_attr_trait__{}!{}", owner, attr_name_str));
+                let call_result = self.call_function(&trait_mod_name, args);
+                self.trait_mod_writeback_key = saved_wb_key;
+                if let Some(mixin_val) = self.trait_mod_writeback_value.take() {
+                    self.registry_mut()
+                        .class_attribute_trait_objects
+                        .insert((owner.to_string(), attr_name_str.to_string()), mixin_val);
+                }
+                call_result?;
                 continue;
             }
             let msg = format!(

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -838,11 +838,20 @@ impl Interpreter {
                         },
                         value.clone(),
                     );
+                    let new_mixin =
+                        Value::mixin_parts(inner.clone(), std::sync::Arc::new(updated_mixins));
                     if let Some(var_name) = target_var {
-                        self.env.insert(
-                            var_name.to_string(),
-                            Value::mixin_parts(inner.clone(), std::sync::Arc::new(updated_mixins)),
-                        );
+                        self.env.insert(var_name.to_string(), new_mixin.clone());
+                    }
+                    // Inside a trait_mod the rebuilt Mixin must also refresh the
+                    // writeback capture (same convention as DoesVar): the value
+                    // DoesVar captured predates this assignment and would hand
+                    // the trait's caller a mixin missing it (JSON::Name's
+                    // `$a.json-name = $json-name` right after `$a does ...`).
+                    if self.trait_mod_writeback_key.is_some()
+                        && self.trait_mod_writeback_value.is_some()
+                    {
+                        self.trait_mod_writeback_value = Some(new_mixin);
                     }
                     return Ok(value);
                 }
@@ -852,11 +861,17 @@ impl Interpreter {
             if mixins.contains_key(&mixin_attr_key) {
                 let mut updated_mixins = (**mixins).clone();
                 updated_mixins.insert(mixin_attr_key, value.clone());
+                let new_mixin =
+                    Value::mixin_parts(inner.clone(), std::sync::Arc::new(updated_mixins));
                 if let Some(var_name) = target_var {
-                    self.env.insert(
-                        var_name.to_string(),
-                        Value::mixin_parts(inner.clone(), std::sync::Arc::new(updated_mixins)),
-                    );
+                    self.env.insert(var_name.to_string(), new_mixin.clone());
+                }
+                // See the role-attribute branch above: refresh the trait_mod
+                // writeback capture so the assignment survives past the trait.
+                if self.trait_mod_writeback_key.is_some()
+                    && self.trait_mod_writeback_value.is_some()
+                {
+                    self.trait_mod_writeback_value = Some(new_mixin);
                 }
                 return Ok(value);
             }

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -137,6 +137,12 @@ pub(crate) struct Registry {
         HashMap<(String, String), Vec<HashMap<String, Value>>>,
     /// Per-attribute `is DEPRECATED` message: (class, attr) -> message.
     pub(crate) class_attribute_deprecated: HashMap<(String, String), String>,
+    /// The Attribute meta-object a custom `trait_mod:<is>` was applied to,
+    /// per (class, attr). Instance attrs are a shared cell, so mutations the
+    /// trait made (`$a does JSON::Name::NamedAttribute; $a.json-name = ...`)
+    /// live in this stored object; `^attributes` returns it (topped up with
+    /// the standard meta keys) so the mixin state survives introspection.
+    pub(crate) class_attribute_trait_objects: HashMap<(String, String), crate::value::Value>,
 
     // ----- roles (PR-A slice 4) -----
     /// User/builtin role definitions: role name -> [`RoleDef`] (methods,

--- a/src/runtime/runtime_module_exports.rs
+++ b/src/runtime/runtime_module_exports.rs
@@ -3,6 +3,45 @@ use super::*;
 impl Interpreter {
     /// Record a trait-modified routine value for an exported sub, so that
     /// `import_module` can restore the `&name` env binding with the role mixed in.
+    /// Install an imported multi candidate under `target_key`, merging with
+    /// candidates other modules already installed there: strip any `__mN`
+    /// suffix to the base key, then walk base, `__m1`, `__m2`, ... and insert
+    /// at the first vacant slot. A slot already holding this exact `Arc`
+    /// (same-module re-import) makes the call a no-op.
+    fn import_multi_candidate_merged(&mut self, target_key: &str, def: Arc<FunctionDef>) {
+        let base = match target_key.rfind("__m") {
+            Some(pos)
+                if pos + 3 < target_key.len()
+                    && target_key[pos + 3..].chars().all(|c| c.is_ascii_digit()) =>
+            {
+                &target_key[..pos]
+            }
+            _ => target_key,
+        };
+        let mut registry = self.registry_mut();
+        let funcs = &mut registry.functions;
+        let mut idx = 0usize;
+        loop {
+            let key = if idx == 0 {
+                base.to_string()
+            } else {
+                format!("{}__m{}", base, idx)
+            };
+            match funcs.entry(Symbol::intern(&key)) {
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(def);
+                    return;
+                }
+                std::collections::hash_map::Entry::Occupied(entry) => {
+                    if Arc::ptr_eq(entry.get(), &def) {
+                        return;
+                    }
+                }
+            }
+            idx += 1;
+        }
+    }
+
     pub(crate) fn record_exported_sub_value(&mut self, package: String, name: String, val: Value) {
         self.exported_sub_values
             .entry(package)
@@ -279,7 +318,20 @@ impl Interpreter {
                 }
             }
             for (k, v) in function_entries {
-                self.registry_mut().functions.insert(k, v);
+                let ks = k.resolve();
+                if ks.contains('/') {
+                    // A multi candidate. Two modules exporting candidates of the
+                    // same multi (JSON::OptIn / JSON::Name / JSON::Class each
+                    // export a `trait_mod:<is>`) land on the SAME target key
+                    // (`GLOBAL::trait_mod:<is>/2`), so a plain insert would let
+                    // the last `use` overwrite every earlier module's
+                    // candidates. Chain into the first free `__mN` slot
+                    // instead, and skip candidates already installed (a
+                    // re-import of the same module must stay idempotent).
+                    self.import_multi_candidate_merged(&ks, v);
+                } else {
+                    self.registry_mut().functions.insert(k, v);
+                }
             }
 
             let proto_entries: Vec<(Symbol, Arc<FunctionDef>)> = self

--- a/src/runtime/types/roles.rs
+++ b/src/runtime/types/roles.rs
@@ -267,8 +267,34 @@ impl Interpreter {
             ValueView::Str(name) if self.registry().roles.contains_key(name.as_str()) => {
                 Some((name.to_string(), Vec::new()))
             }
+            // A module-scoped role referenced by its short name at runtime
+            // (`$a does NamedAttribute` inside `module NameTrait`'s
+            // trait_mod:<is>, where the role registered as
+            // `NameTrait::NamedAttribute`). Without this, `does` silently
+            // degrades to the boolean conformance check and REBINDS the
+            // variable to True/False — how JSON::Name's trait corrupted `$a`.
+            ValueView::Package(name) => self.resolve_short_role_name(&name.resolve()),
+            ValueView::Str(name) => self.resolve_short_role_name(name.as_str()),
             _ => None,
         }
+    }
+
+    /// Resolve a short role name to its registered (possibly package-qualified)
+    /// form: the current package's `{pkg}::{name}` first (the sub executing a
+    /// `does` runs with its defining module as the current package), then the
+    /// general declared-type resolution. None when neither names a role.
+    fn resolve_short_role_name(&self, name: &str) -> Option<(String, Vec<Value>)> {
+        if !name.contains("::") {
+            let qualified = format!("{}::{}", self.current_package(), name);
+            if self.registry().roles.contains_key(&qualified) {
+                return Some((qualified, Vec::new()));
+            }
+        }
+        let resolved = self.resolve_declared_type_name(name);
+        self.registry()
+            .roles
+            .contains_key(&resolved)
+            .then(|| (resolved, Vec::new()))
     }
 
     fn compose_role_on_value(

--- a/t/attr-trait-role-mixin.t
+++ b/t/attr-trait-role-mixin.t
@@ -1,0 +1,54 @@
+use v6;
+use lib 't/lib';
+use Test;
+use AttrOptTrait;
+use AttrNameTrait;
+
+plan 7;
+
+# The JSON::Name shape: a custom trait_mod:<is> mixes a role into the
+# Attribute meta-object and assigns one of the role's rw attributes.
+# Three separate defects used to break it (each pinned here):
+#  1. the mixin/assignment happened on an ephemeral Attribute object and was
+#     dropped — ^attributes never saw it;
+#  2. inside a module's trait sub, the short role name (`NamedAttribute`)
+#     failed to resolve to `AttrNameTrait::NamedAttribute`, so `does` silently
+#     degraded to a boolean conformance check and REBOUND `$a` to True;
+#  3. two modules exporting trait_mod:<is> candidates collided on the same
+#     multi key at import — the second `use` overwrote the first's candidates
+#     ("No matching candidates for proto sub: trait_mod:<is>").
+
+# In-file trait (defect 1 alone):
+my role Tagged {
+    has Str $.tag is rw;
+}
+multi sub trait_mod:<is>(Attribute $a, Str :$tagged!) {
+    $a does Tagged;
+    $a.tag = $tagged;
+}
+class InFile {
+    has Bool $.b is tagged("from-in-file");
+}
+is InFile.^attributes[0].tag, "from-in-file",
+    'in-file custom trait: role mixin + value survive to ^attributes';
+
+# Cross-module trait (defects 1+2), with BOTH modules imported (defect 3):
+class C {
+    has Bool $.b is json-name("isDeprecated");
+    has Str  $.o is opted;
+}
+is C.^attributes[0].json-name, "isDeprecated",
+    'imported custom trait: mixin value survives to ^attributes';
+ok C.^attributes[0] ~~ AttrNameTrait::NamedAttribute,
+    'the attribute smartmatches the mixed-in role';
+ok C.^attributes[1] ~~ AttrOptTrait::OptedIn,
+    'the other module trait applied to the sibling attribute';
+nok C.^attributes[1] ~~ AttrNameTrait::NamedAttribute,
+    'roles do not leak across attributes';
+
+# Both traits on ONE attribute (candidates from both modules dispatch):
+class D {
+    has Str $.x is opted is json-name("xx");
+}
+ok D.^attributes[0] ~~ AttrOptTrait::OptedIn, 'first trait of two applied';
+is D.^attributes[0].json-name, "xx", 'second trait of two applied';

--- a/t/lib/AttrNameTrait.rakumod
+++ b/t/lib/AttrNameTrait.rakumod
@@ -1,0 +1,12 @@
+use v6;
+
+module AttrNameTrait {
+    role NamedAttribute {
+        has Str $.json-name is rw;
+    }
+
+    multi sub trait_mod:<is>(Attribute $a, Str :$json-name!) is export(:DEFAULT){
+        $a does NamedAttribute;
+        $a.json-name = $json-name;
+    }
+}

--- a/t/lib/AttrOptTrait.rakumod
+++ b/t/lib/AttrOptTrait.rakumod
@@ -1,0 +1,10 @@
+use v6;
+
+module AttrOptTrait {
+    role OptedIn {
+    }
+
+    multi sub trait_mod:<is>(Attribute $a, :$opted!) is export(:DEFAULT){
+        $a does OptedIn;
+    }
+}


### PR DESCRIPTION
`use License::SPDX` (mzef's Test::META chain) died with `No matching candidates for proto sub: trait_mod:<is>`. Peeling it back found three independent defects around JSON::Name's trait shape:

```raku
multi sub trait_mod:<is>(Attribute $a, Str :$json-name!) {
    $a does NamedAttribute;
    $a.json-name = $json-name;
}
```

## 1. The trait's work was dropped

The trait ran against an **ephemeral** Attribute object discarded on return, so the mixin and assignment never reached `^attributes`. The trait-time object is now stored per (class, attr) in the registry; the DoesVar `trait_mod` writeback capture (the same mechanism `&sub` trait targets already use) stores the Mixin the trait built, the mixin-attr assignment path refreshes that capture (the captured value predates the assignment), and `make_attribute_object` serves the stored object back, topped up with the standard meta keys.

## 2. Short role names failed to resolve inside a module's trait sub

`NamedAttribute` (registered as `AttrNameTrait::NamedAttribute`) missed at the runtime `does`, which silently degraded to the boolean conformance check and **rebound `$a` to True** — the "cannot assign through .json-name on non-instance" symptom. `extract_role_application` now resolves short names through the current package and `resolve_declared_type_name`.

## 3. Imported multi candidates from two modules overwrote each other

JSON::OptIn / JSON::Name / JSON::Class each export a `trait_mod:<is>` candidate; at import they collided on the same multi key (`GLOBAL::trait_mod:<is>/2`) and the second `use` clobbered the first's. Imported multi candidates now chain into the first free `__mN` slot (mirroring `insert_multi_overload`), skipping already-installed `Arc`s so same-module re-imports stay idempotent.

## Result

`use JSON::Marshal` and `use License::SPDX` now load. META6 stops one bug later (trait multis declared inside the class body that uses them), tracked in docs/mzef-install-pipeline.md.

## Validation

- Pin: `t/attr-trait-role-mixin.t` — 7 tests (in-file trait, cross-module trait, two-module candidate merge, two traits on one attribute), passes under raku and mutsu
- 186 trait/role/mixin/does/multi/import/module `t/` files: PASS
- 97 S06-multi / S14-roles / S14-traits / S12 / S10 / S11 roast files: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)