### PR TITLE
fix: class-body trait multis reach nested classes; named @/% params require Positional/Associative

### DIFF
--- a/docs/mzef-install-pipeline.md
+++ b/docs/mzef-install-pipeline.md
@@ -164,38 +164,53 @@ All 16 candidates now fetch their own archive. See
 [ADR-0010](adr/0010-cross-thread-lexical-sharing-scope.md); the analysis that
 found it is kept below.
 
-## Current frontier — the installed dists don't all load
+## Current frontier — `use Test::META` LOADS; next is *running* it
 
-`zef install --/test Test::META` completes: 16 candidates resolve, fetch,
-extract, and **13 dists install** into the site repo. The frontier is now
-*using* them. Fixed so far (each: minimal repro → general fix → `t/` pin):
+`zef install --/test Test::META` completes (16 candidates resolve, fetch,
+extract, **13 dists install**), and the whole load chain is now fixed:
+**`use Test::META` loads**, as do JSON::Unmarshal, JSON::Marshal, JSON::Class
+(jonathanstowe), License::SPDX and META6. Load-frontier fixes (each: minimal
+repro → general fix → `t/` pin):
 
 - ~~`-> Mu \type { ... }` typed sigilless pointy param~~ (#4661) — unblocked
   `use JSON::Unmarshal`'s `subset ... where` lambdas.
 - ~~sibling-role short-name composition inside a module~~ (#4661) — unblocked
   JSON::Unmarshal's `CustomUnmarshaller` role family; JSON::Marshal loads.
-- ~~`use` dist selectors discarded / first-found dist loaded~~ — two installed
-  dists provide `JSON::Class` (zef:jonathanstowe vs zef:vrurg); resolution now
-  filters by `:auth`/`:ver`/`:api` and picks the highest version. Pin:
-  `t/use-dist-selectors.t`.
-- ~~`role Name:ver<...>:auth<...>[SIGNATURE]`~~ — adverbs before the parametric
-  signature failed to parse (jonathanstowe JSON::Class line 121). Pin:
-  `t/role-decl-adverbs-signature.t`.
+- ~~`use` dist selectors discarded / first-found dist loaded~~ (#4662) — two
+  installed dists provide `JSON::Class` (zef:jonathanstowe vs zef:vrurg);
+  resolution now filters by `:auth`/`:ver`/`:api` and picks the highest
+  version. Pin: `t/use-dist-selectors.t`.
+- ~~`role Name:ver<...>:auth<...>[SIGNATURE]`~~ (#4662) — adverbs before the
+  parametric signature failed to parse (jonathanstowe JSON::Class line 121).
+  Pin: `t/role-decl-adverbs-signature.t`.
+- ~~Attribute role-mixin dropped by `trait_mod:<is>`~~ (#4663) — three defects
+  (ephemeral Attribute object; short role name degrading `does` to a boolean
+  check that REBOUND `$a`; imported multi candidates from two modules
+  colliding on one key). Pin: `t/attr-trait-role-mixin.t`. Unblocked
+  License::SPDX.
+- ~~class-body trait multis invisible to nested classes~~ — during a nested
+  class's registration, multi lookup probed only current_package + GLOBAL, so
+  `class META6 { multi sub trait_mod:<is>(...) ...; class Support { has ...
+  is specification(Optional) } }` failed; the trait dispatch now walks up the
+  package chain. Pin: `t/class-body-trait-multi.t`. Unblocked META6 and with
+  it **Test::META**.
+- ~~a named ARRAY param matched a scalar value~~ — `:@specification!
+  (Optionality $o, Version $v)` out-dispatched `Optionality :$specification!`
+  for a single enum value and died in the destructure. Named `@`/`%` params
+  now require Positional/Associative arguments. Same pin.
 
-Still open, in chain order:
+Still open:
 
-- **Attribute role-mixin does not persist out of `trait_mod:<is>`** — blocks
-  `use License::SPDX` (its `is json-name(...)` attributes). Repro:
-  a custom `multi sub trait_mod:<is>(Attribute $a, :$myname!) { $a does R;
-  $a.n = $myname }` — the mixin/assignment do not survive onto
-  `C.^attributes[0]` (works via `my $attr = C.^attributes[0]; $attr does R`
-  outside a trait). tmp repro: `tmp/attr-does-rw2.raku`. Under the module's
-  imported multi the same shape errors `X::Assignment::RO: cannot assign
-  through .json-name on non-instance`.
-- **`use Test::META`** — not re-bisected past License::SPDX yet.
 - **`use URI; URI.new("https://raku.org/x").host`** → `Type check failed for
   return value; expected Host but got Str ("raku.org")` — a
   coercion/subset-typed **return** value is checked against the raw Str.
+- **Running Test::META's actual test functions** (`meta6-ok`) end-to-end is
+  unexercised — the next milestone is `zef install --/test` WITHOUT
+  `--/test`, i.e. the Test phase (pipeline row 6).
+- **CALLING a named-array destructure candidate** (`is specification([...])`)
+  still fails in binding (`Calling trait_mod:<is>(Any) will never work ...`,
+  then binds the whole Array to the first destructure param). Not used by
+  META6 itself; noted in `t/class-body-trait-multi.t`.
 - **vrurg JSON::Class (`use v6.e.PREVIEW`) line 40 parse error** — no longer
   in the default chain (the selector fix routes to jonathanstowe's), but the
   dist is installed and still cannot load.

--- a/src/runtime/methods_classhow_attribute.rs
+++ b/src/runtime/methods_classhow_attribute.rs
@@ -285,6 +285,37 @@ impl Interpreter {
         Value::make_instance(Symbol::intern("Attribute"), meta)
     }
 
+    /// The nearest package (walking `current_package` up through its `::`
+    /// ancestors, ending at the current package's registry view of GLOBAL) that
+    /// has a proto or multi candidates for `name`. None when no package in the
+    /// chain has a handler.
+    fn nearest_package_with_trait_handler(&self, name: &str) -> Option<String> {
+        let current = self.current_package();
+        let mut pkg = current.as_str();
+        // Local candidates only at each level — has_proto/has_multi_candidates
+        // also match GLOBAL, which would stop the walk at the innermost package
+        // whenever some module exported a same-named trait, hiding the
+        // enclosing package's own candidates. GLOBAL is the last resort; the
+        // dispatch probes {pkg}:: AND GLOBAL:: anyway, so dispatching as the
+        // nearest local package still sees the imported candidates too.
+        loop {
+            let local_proto = self
+                .registry()
+                .proto_subs
+                .contains(&format!("{}::{}", pkg, name));
+            if local_proto || self.registry().has_multi_function(pkg, name) {
+                return Some(pkg.to_string());
+            }
+            match pkg.rsplit_once("::") {
+                Some((parent, _)) => pkg = parent,
+                None => break,
+            }
+        }
+        (self.registry().has_proto("GLOBAL", name)
+            || self.registry().has_multi_candidates("GLOBAL", name))
+        .then(|| current.clone())
+    }
+
     /// Dispatch unknown attribute traits to user-defined `trait_mod:<...>` subs,
     /// or raise X::Comp::Trait::Unknown if no handler is registered. Called at
     /// class registration for each `has` declaration that carries unknown traits.
@@ -310,8 +341,15 @@ impl Interpreter {
                 continue;
             }
             let trait_mod_name = format!("trait_mod:<{}>", kind);
-            let has_handler =
-                self.has_proto(&trait_mod_name) || self.has_multi_candidates(&trait_mod_name);
+            // The trait multi may be declared in an ENCLOSING package's body:
+            // META6 declares `multi sub trait_mod:<is>(Attribute, Optionality
+            // :$specification!)` in `class META6`'s own body and uses it inside
+            // nested classes (current_package "META6::Support"). Multi lookup
+            // probes current_package + GLOBAL only, so walk up the package
+            // chain to the nearest package that has a handler and dispatch as
+            // that package.
+            let dispatch_pkg = self.nearest_package_with_trait_handler(&trait_mod_name);
+            let has_handler = dispatch_pkg.is_some();
             if has_handler {
                 // Reuse the Attribute meta-object across every trait applied to
                 // this attr, and store it in the registry: instance attrs are a
@@ -365,7 +403,14 @@ impl Interpreter {
                 let saved_wb_key = self.trait_mod_writeback_key.take();
                 self.trait_mod_writeback_key =
                     Some(format!("__mutsu_attr_trait__{}!{}", owner, attr_name_str));
+                let saved_pkg = self.current_package();
+                if let Some(pkg) = &dispatch_pkg
+                    && *pkg != saved_pkg
+                {
+                    self.set_current_package(pkg.clone());
+                }
                 let call_result = self.call_function(&trait_mod_name, args);
+                self.set_current_package(saved_pkg);
                 self.trait_mod_writeback_key = saved_wb_key;
                 if let Some(mixin_val) = self.trait_mod_writeback_value.take() {
                     self.registry_mut()

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -539,6 +539,20 @@ impl Interpreter {
                     }
                 }
 
+                // A named array/hash param can only bind a Positional/
+                // Associative argument. Without this, `:@specification!
+                // (Optionality $o, Version $v)` matched a single enum value and
+                // out-dispatched the `Optionality :$specification!` candidate
+                // (META6's trait pair), then died binding the destructure.
+                if let Some(ref val) = arg_val {
+                    if pd.name.starts_with('@') && !self.type_matches_value("Positional", val) {
+                        return false;
+                    }
+                    if pd.name.starts_with('%') && !self.type_matches_value("Associative", val) {
+                        return false;
+                    }
+                }
+
                 // Check where constraint on named param. When the named arg is
                 // absent, the constraint is still evaluated against the value the
                 // parameter would bind to (its default, or the type-object

--- a/t/class-body-trait-multi.t
+++ b/t/class-body-trait-multi.t
@@ -1,0 +1,55 @@
+use v6;
+use lib 't/lib';
+use AttrNameTrait;
+use Test;
+
+plan 4;
+
+# The META6 shape: a class declares `multi sub trait_mod:<is>` in its OWN body
+# and applies it to attributes both in that body and inside NESTED classes.
+# Two defects pinned here:
+#  1. during a nested class's registration current_package is the nested name
+#     ("M::Support"), and multi lookup probed only current_package + GLOBAL,
+#     so the enclosing class body's candidates were invisible ("No matching
+#     candidates" when a module also exported the proto, "unknown trait"
+#     otherwise). The dispatch now walks up the package chain.
+#  2. a named ARRAY param (`:@spec! (Opt $o, Version $v)`) matched a single
+#     non-Positional value, out-dispatching the scalar candidate
+#     (`Opt :$spec!`) and dying in the destructure binding.
+# (Actually CALLING the array-form candidate with `[Optional, v1.2]` is a
+# separate, still-open destructure-binding gap — see TODO_roast/BLOCKERS.md.)
+
+enum Optionality <Mandatory Optional>;
+
+class M {
+    role MetaAttribute {
+        has Optionality $.optionality is rw;
+        has Version $.spec-version is rw = Version.new(0);
+    }
+
+    multi sub trait_mod:<is> (Attribute $a, Optionality :$specification!) {
+        $a does MetaAttribute;
+        $a.optionality = $specification;
+    }
+
+    multi sub trait_mod:<is> (Attribute $a, :@specification! (Optionality $optionality, Version $spec-version)) {
+        $a does MetaAttribute;
+        $a.optionality = $optionality;
+        $a.spec-version = $spec-version;
+    }
+
+    class Support {
+        has Str $.source is rw is specification(Optional);
+    }
+
+    has Str $.name is rw is specification(Mandatory);
+}
+
+is M.^attributes[0].optionality, Mandatory,
+    'own-body attribute dispatches the enclosing-body trait multi';
+is M::Support.^attributes[0].optionality, Optional,
+    'nested-class attribute sees the enclosing class body trait multi';
+is M.^attributes[0].spec-version, v0,
+    'scalar form keeps the default spec-version';
+ok M::Support.^attributes[0] ~~ M::MetaAttribute,
+    'the mixed-in role smartmatches on the nested class attribute';


### PR DESCRIPTION
The last two blockers before `use Test::META` loads (mzef chain, continuing #4661/#4662/#4663).

## 1. Class-body trait multis were invisible to nested classes

META6 declares `multi sub trait_mod:<is>(Attribute, Optionality :$specification!)` in its **own class body** and applies it to attributes of **nested classes**. During the nested class's registration `current_package` is `META6::Support`, and multi lookup probes only current_package + GLOBAL, so the enclosing body's candidates were invisible ("No matching candidates" when a module also exported the proto, `X::Comp::Trait::Unknown` otherwise).

The attribute trait dispatch now walks up the package chain to the nearest package with **local** candidates (GLOBAL last — checking GLOBAL per level would stop the walk at the innermost package whenever any module exported a same-named trait) and dispatches as that package. The dispatch probes `{pkg}::` **and** `GLOBAL::`, so imported candidates stay visible too.

## 2. A named ARRAY param matched a scalar value

`:@specification! (Optionality $o, Version $v)` accepted the single enum value `Mandatory`, out-dispatched the scalar `Optionality :$specification!` candidate, and died binding the destructure ("expected Version, got Int"). Named `@`/`%` params now require a Positional/Associative argument in candidate matching, mirroring binding semantics.

## Result

`use META6` and **`use Test::META`** now load — the whole install→load chain for `zef install --/test Test::META`'s 13 dists works. Frontier status updated in docs/mzef-install-pipeline.md (next: `URI.host` coercion return, the Test phase, calling a named-array destructure candidate with a real array).

## Validation

- Pin: `t/class-body-trait-multi.t` (4 tests, passes under raku and mutsu)
- 352 trait/multi/dispatch/named/param/sig/attr/class `t/` files: PASS
- 87 S06-multi / S06-signature / S12 / S14-traits / S32-exceptions roast files: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)