### PR TITLE
fix: a regex-where subset accepts matching return values

### DIFF
--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -396,23 +396,26 @@ impl Interpreter {
         let subset = self.registry().subsets.get(spec).cloned();
         if let Some(subset) = subset {
             // For subsets with coercion base types, coerce first then check predicate
-            let coerced = if subset.base.contains('(') && subset.base.ends_with(')') {
-                self.enforce_coercion_return(&subset.base, value)?
-            } else {
-                // Non-coercion subset: just check the base type
-                if !self.type_matches_value(&subset.base, &value) {
-                    return Err(self.throw_type_check_return(spec, &value));
+            if subset.base.contains('(') && subset.base.ends_with(')') {
+                let coerced = self.enforce_coercion_return(&subset.base, value)?;
+                if let Some(ref pred) = subset.predicate {
+                    let pred_clone = pred.clone();
+                    if !self.check_where_constraint(&pred_clone, &coerced) {
+                        return Err(self.throw_type_check_return(spec, &coerced));
+                    }
                 }
-                value
-            };
-            // Check the where predicate if present
-            if let Some(ref pred) = subset.predicate {
-                let pred_clone = pred.clone();
-                if !self.check_where_constraint(&pred_clone, &coerced) {
-                    return Err(self.throw_type_check_return(spec, &coerced));
-                }
+                return Ok(coerced);
             }
-            return Ok(coerced);
+            // Non-coercion subset: delegate base + predicate to the standard
+            // subset matcher (the `~~` path). The local check_where_constraint
+            // only understands callable predicates; a regex `where` (URI's
+            // `subset Host of Str where /^ ... $/`) evaluated through it came
+            // back false, failing every `--> Host` return while `~~ Host` was
+            // True.
+            if !self.type_matches_value(spec, &value) {
+                return Err(self.throw_type_check_return(spec, &value));
+            }
+            return Ok(value);
         }
 
         // Check if this is a coercion type like Str(Numeric:D) or Foo:D()

--- a/t/subset-regex-return-check.t
+++ b/t/subset-regex-return-check.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+plan 6;
+
+# A subset whose `where` is a REGEX (URI's `subset Host of Str
+# where /^ [ <IETF::RFC_Grammar::URI::host> ] $/`) passed `~~` but failed
+# every `--> Host` return type check: the return path had its own predicate
+# evaluator that only understood callable predicates, so the regex came back
+# false. The return check now delegates to the same subset matcher `~~` uses.
+
+grammar G {
+    token host { \w+ [ '.' \w+ ]* }
+}
+
+subset Host of Str where /^ [ <G::host> ] $/;
+subset AbLike of Str where /^ab/;
+
+ok "raku.org" ~~ Host, 'smartmatch against the grammar-regex subset';
+
+sub f(--> Host) { "raku.org" }
+is f(), "raku.org", 'a grammar-regex subset return type accepts a match';
+
+sub g(--> AbLike) { "abc" }
+is g(), "abc", 'a plain-regex subset return type accepts a match';
+
+sub bad(--> AbLike) { "zzz" }
+throws-like { bad() }, Exception, message => /'Type check failed for return value'/,
+    'a plain-regex subset return type still rejects a non-match';
+
+# The callable-predicate path keeps working.
+subset Long of Str where *.chars > 2;
+sub h(--> Long) { "abc" }
+is h(), "abc", 'a callable subset return type accepts';
+sub bad2(--> Long) { "a" }
+throws-like { bad2() }, Exception, message => /'Type check failed for return value'/,
+    'a callable subset return type still rejects';


### PR DESCRIPTION
`URI.new(...).host` died with `Type check failed for return value; expected Host but got Str` although the value smartmatched `Host` fine. URI declares

```raku
subset Host of Str where /^ [ <IETF::RFC_Grammar::URI::host> ] $/;
multi method host(URI:D: --> Host ) { ... }
```

The return-type check had its own predicate evaluator (`check_where_constraint`) that only understands **callable** predicates — a regex `where` evaluated through it came back false, so every `--> Host` return failed while `~~ Host` was True.

The non-coercion-subset branch of `enforce_return_type_constraint` now delegates base + predicate to `type_matches_value` — the same battle-tested matcher `~~` uses (cached compiled predicates included). The coercion-base subset branch keeps its coerce-then-check shape.

URI is in mzef's Test::META chain; with this, `use URI` + `.host`/`.port`/`.path` all work.

## Validation

- Pin: `t/subset-regex-return-check.t` (6 tests: grammar-token regex subset, plain regex subset accept/reject, callable subset accept/reject) — passes under raku and mutsu
- 170 subset/return/coerc/where/type `t/` files: PASS
- 60 S12-subset / S02-types / S06-signature roast files: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)