### PR TITLE
docs: the mzef load frontier is closed; the Test phase is the new one

### DIFF
--- a/docs/mzef-install-pipeline.md
+++ b/docs/mzef-install-pipeline.md
@@ -31,7 +31,7 @@ Legend: ✅ works · ⏳ in progress · ⬜ not yet reached · 🔒 blocked
 | 3 | **Fetch** (download archive) | ✅ | Downloads via the **curl**/**wget** backends (`Proc::Async` shell-out — no native TLS). Unblocked by #4615 + #4617; the **concurrent** multi-candidate fetch `install` drives by #4658 (ADR-0010) — all 16 of Test::META's candidates now fetch their own archive |
 | 4 | **Extract** (untar) | ✅ | Single-dist: #4620 + #4622 + #4627 + #4635/#4641/#4642. Concurrent: fixed by restoring the #4650 `thread_redeclared_vars` gates on top of ADR-0010 (the "extract-matcher rejects the archive" symptom was a child `my` re-declaration clobbering the parent's staged path through the lineage chain) |
 | 5 | Build | ✅ | reached; a pure-Raku dist has nothing to build and passes through |
-| 6 | Test | ⬜ | not exercised yet (runs have used `--/test`) |
+| 6 | Test | ⏳ | The phase RUNS: `zef install JSON::OptIn` (no `--/test`) does `Testing [OK] → Installing`, and `zef install Test::META` runs all 16 dists' suites concurrently. But **13/16 suites FAIL** — see "Test-phase frontier" below |
 | 7 | Install into site repo | ✅ | **a dependency-free dist installs and is then `use`-able**; a dependency-ful one too: `zef install --/test Test::META` installs **all 13 dists** end-to-end |
 
 **So: the whole install pipeline works, including for a dependency-ful dist.**
@@ -52,9 +52,16 @@ $ mutsu -I <zef>/lib <zef>/bin/zef install --/test Test::META
 others), so `use JSON::Fast` succeeds on a clean HOME with no install at all and
 proves nothing. `JSON::OptIn` is not bundled.
 
-The frontier has moved past install, to **running what was installed** ("Current
-frontier" below): `use Test::META` hits a parse error in one of the installed
-modules, and `URI.host` hits a coercion-return-type bug.
+**The whole load chain works too** (as of #4661–#4665): `use Test::META` and
+every dist below it — JSON::Unmarshal, JSON::Marshal, JSON::Class
+(jonathanstowe), License::SPDX, META6, URI — load, and `URI.new(...).host`
+returns. The frontier is the **Test phase** ("Test-phase frontier" below).
+
+> **Verification trap:** `use Test::META; say "LOADED"` proves NOTHING on its
+> own — `use_module` has a compat branch that silently succeeds for any
+> missing `Test::*` module (runtime_module.rs). Verify with a symbol the
+> module actually exports: `::("&meta6-ok")` must not be an error. The
+> non-`Test::` dists in the chain (`use META6` etc.) fail honestly.
 
 ## Fixes that got us here (this campaign)
 
@@ -164,7 +171,7 @@ All 16 candidates now fetch their own archive. See
 [ADR-0010](adr/0010-cross-thread-lexical-sharing-scope.md); the analysis that
 found it is kept below.
 
-## Current frontier — `use Test::META` LOADS; next is *running* it
+## Load frontier — CLOSED (2026-07-17, #4661–#4665)
 
 `zef install --/test Test::META` completes (16 candidates resolve, fetch,
 extract, **13 dists install**), and the whole load chain is now fixed:
@@ -199,14 +206,33 @@ repro → general fix → `t/` pin):
   for a single enum value and died in the destructure. Named `@`/`%` params
   now require Positional/Associative arguments. Same pin.
 
-Still open:
+- ~~`use URI; URI.new(...).host` return type check~~ (#4665) — URI's
+  `subset Host of Str where /regex/` passed `~~` but failed every `--> Host`
+  return: the return check's own predicate evaluator only understood callable
+  predicates. It now delegates to the same subset matcher `~~` uses. Pin:
+  `t/subset-regex-return-check.t`.
 
-- **`use URI; URI.new("https://raku.org/x").host`** → `Type check failed for
-  return value; expected Host but got Str ("raku.org")` — a
-  coercion/subset-typed **return** value is checked against the raw Str.
-- **Running Test::META's actual test functions** (`meta6-ok`) end-to-end is
-  unexercised — the next milestone is `zef install --/test` WITHOUT
-  `--/test`, i.e. the Test phase (pipeline row 6).
+## Test-phase frontier (2026-07-17, the current one)
+
+`zef install Test::META` (tests ON) runs all 16 dists' test suites
+concurrently and **13/16 FAIL** (OK: JSON::OptIn; the debug-build run also
+overran a 570s timeout — use release for E2E):
+
+- **The dominant symptom is environmental, not per-test**: nearly every
+  suite's `t/010-use.t` fails at `use-ok` ("JSON::Name module can be use-d
+  ok" etc.) even though the same `use` works interactively against the
+  installed repo. zef runs each suite in a subprocess against the STAGED
+  (pre-install) dist plus its already-installed dependencies; suspect the
+  `-I`/env handoff for that staging layout, or cross-contamination between
+  the 16 concurrent test subprocesses. Investigate one suite in isolation
+  first (`zef test <path>` or run the staged `prove` command by hand).
+- **Test::Async (vrurg) fails to parse**: `Failed to parse module
+  'Test::Async::Hub': X::Redeclaration: Redeclaration of symbol '$self'` —
+  a real language bug, plus sink-context warnings. Test::Async is the test
+  framework several vrurg dists use, so it gates their suites.
+
+Still open (load-side leftovers):
+
 - **CALLING a named-array destructure candidate** (`is specification([...])`)
   still fails in binding (`Calling trait_mod:<is>(Any) will never work ...`,
   then binds the whole Array to the first destructure param). Not used by

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,46 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-17: mzef installs AND loads Test::META's whole dependency chain (#4658 + #4661–#4665)
+
+Six merged PRs took mzef from "the ADR-0010 branch is red in CI" to "`zef install --/test
+Test::META` installs all 13 dists and every one of them `use`s" — the install pipeline AND the
+load chain both work end-to-end. The Test phase now runs too (16 concurrent suites), which is the
+new frontier: 13/16 suites fail, dominated by an environmental `use-ok` failure in zef's staged
+test subprocesses (details in [docs/mzef-install-pipeline.md](../docs/mzef-install-pipeline.md)).
+
+- **#4658 — the ADR-0010 gates stay.** Lineage scoping isolates *siblings*; the #4650
+  `thread_redeclared_vars` gates handle *parent-child* shadowing — orthogonal, both needed. The
+  first draft removed the gates and a child's `my` re-declaration (`if INIFile.parse(...) ->
+  $parsed`, desugared to `my $parsed = ...`) wrote through the chain and replaced the parent's
+  Channel with a Match (`advent2013-day14.t`). Restoring the gates ALSO fixed the concurrent
+  extract-matcher rejection — same defect class corrupting zef workers' staged paths — which is
+  what completed the install pipeline. Eager store-side `declare` at `SetVarDynamic` was rejected:
+  the own-lineage entry would outlive its block and the dirty sync would resurrect the dead shadow.
+- **#4661 — two module-load blockers.** `-> Mu \type { ... }` (typed AND sigilless pointy param)
+  failed to parse — JSON::Unmarshal writes every `subset ... where` lambda this way; and a role
+  composing a sibling role by short name inside a module (`role Derived does Base` under
+  `unit module M`) failed with "Unknown role".
+- **#4662 — `use` dist selectors were parsed and DISCARDED**, and the inst# scan loaded whichever
+  same-named dist `read_dir` yielded first (two JSON::Class dists exist). Resolution now filters
+  by `:auth`/`:ver`/`:api` (Version-smartmatched, `0.0.14+` = at-least) and picks the highest
+  version. Plus: `role Name:ver<...>:auth<...>[SIGNATURE]` — adverbs before the parametric
+  signature — now parses.
+- **#4663 — the JSON::Name trait shape, three defects.** A custom `trait_mod:<is>` that does
+  `$a does NamedAttribute; $a.json-name = $v` lost all its work (ephemeral Attribute object);
+  the short role name failed to resolve at the runtime `does` and silently REBOUND `$a` to a
+  boolean; and two modules' exported trait multis collided on one import key (last `use` won).
+- **#4664 — class-body trait multis reach nested classes** (META6 declares its `trait_mod:<is>`
+  in its own body and uses it inside `class Support`); and a named `@` param no longer matches a
+  scalar value (it out-dispatched the correct scalar candidate and died in the destructure).
+- **#4665 — a regex-`where` subset accepts matching return values.** URI's `subset Host of Str
+  where /.../ ` passed `~~` but failed every `--> Host` return: the return check's private
+  predicate evaluator only understood callables. It now delegates to the `~~` matcher.
+
+**Verification trap for the next session:** `use Test::META; say "LOADED"` proves nothing —
+`use_module` silently succeeds for any missing `Test::*` module (compat branch). Verify with an
+exported symbol (`::("&meta6-ok")`).
+
 ## 2026-07-17: regex code assertions now run exactly once, on the real interpreter — `advent2013-day18.t` 10/10 (ADR-0009)
 
 `roast/integration/advent2013-day18.t` was the last `integration/` ★ blocker, stuck at


### PR DESCRIPTION
Pipeline tracker + news for the 2026-07-17 six-PR run (#4658, #4661–#4665): install works end-to-end, every dist in Test::META's chain loads, and the Test phase now actually runs (16 concurrent suites).

Records the Test phase's first measurements — 13/16 suites FAIL, dominated by an environmental `use-ok` failure inside zef's staged test subprocesses, plus Test::Async's `X::Redeclaration '$self'` parse failure — and the `use Test::*` silent-success verification trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)