### PR TITLE
fix: OUTER:: names the next outer scope, not every outer scope

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -48,7 +48,7 @@ Definitions of the classifications:
 
 ## Current assumptions
 
-- The whitelist stands at **1430 / 1463** (2026-07-17, `wc -l roast-whitelist.txt`) = **33** files not whitelisted.
+- The whitelist stands at **1431 / 1463** (2026-07-17, `wc -l roast-whitelist.txt`) = **32** files not whitelisted.
 - **The S\* files (per-synopsis feature tests) are exhausted.** All of the former large campaigns
   (true lazy arrays / desugaring of dispatch and operator sugar / S17 concurrency & async /
   first-class-container container identity / cross-thread lexical writeback) are complete, and
@@ -59,7 +59,7 @@ Definitions of the classifications:
   ([ADR-0009](../docs/adr/0009-regex-code-assertion-execution-model.md)). The former
   ①(stack overflow)/②(unparseable)/③(hang)/④(error-message) clusters are all cleared
   (history: [news/2026-07.md](../news/2026-07.md)).
-- **No cluster remains.** The 33 non-whitelisted files are nearly all non-goal / no-oracle /
+- **No cluster remains.** The 32 non-whitelisted files are nearly all non-goal / no-oracle /
   awaiting-infrastructure (see the tables below); the few ★achievable ones each need their own
   unrelated feature. **roast is no longer the productive axis** — prefer PLAN.md §1 (Batteries),
   §5 (perf) or §6, and pick up a roast file only when such work happens to unblock it.
@@ -75,7 +75,6 @@ noted.
 
 | File | mutsu | raku | Blocker / note |
 |---|---|---|---|
-| `6.c/S04-declarations/my-6c.t` | 111/112 | PASS ★ | test 57 (`OUTER::<$x>`) needs **lexical hoisting**, not the OUTER pseudo-package alone: `EVAL('not OUTER::<$x>.defined')` must see the *enclosing block's* `my $x` declared **after** the EVAL (undefined container), but mutsu skips the not-yet-run local and resolves OUTER to the file-level `my $x = 0` (defined). Same family as mixin-6c/my-6e hoisting. Minimal repro: `my $x = 0; { { say EVAL('not OUTER::<$x>.defined'); my $x } }` → mutsu False, raku True |
 | `6.c/APPENDICES/A04-experimental/01-misc.t` | 16/19 | FAIL | `:D`/`:U` DefiniteHow coercion (`Target:D(Source:U)`). #4514: 0/19 → 16/19 |
 | `APPENDICES/A02-some-day-maybe/multi-no-match.t` | 11/16 | PASS ★ | error-message quality for multi no-match: `.splice` with wrong offset/type, `Lock.protect` / `Lock::Async.protect` / `Proc::Async.new` with wrong args must give "sane errors" — ④-adjacent |
 | `6.c/APPENDICES/A03-older-specs/01-misc.t` | fails 4+ | 6/9 FAIL | `.open("-")` mapping to `$*IN`/`$*OUT`, deprecated `subst-mutate`. raku itself fails 3 of 9 = partially non-goal |
@@ -193,9 +192,11 @@ completed fix history lives in `news/`.
 
 ## Recommended order of attack right now
 
-1. **Shortcuts**: `6.c/S04-declarations/my-6c.t` (111/112) is now a **lexical-hoisting** task,
-   not the OUTER pseudo-package alone (see inventory row). `integration/99problems-51-to-60.t`
-   (35/37) and `99problems-61-to-70.t` (12/15) are close.
+1. **Shortcuts**: `integration/99problems-51-to-60.t` (35/37) and
+   `99problems-61-to-70.t` (12/15) are close. (`6.c/S04-declarations/my-6c.t` reached the
+   whitelist 2026-07-17 — its test 57 was NOT the lexical-hoisting task this ledger claimed:
+   `OUTER::` was simply implemented as `OUTERS::`, cascading through every enclosing scope.
+   See news/2026-07.md; pin `t/outer-pseudo-package.t`.)
 2. **④ error-message quality** (`advent2011-day11.t` 7/9, `multi-no-match.t`) — the
    same target as the identically named task in PLAN §6, so it can be driven by roast
    pass/fail while working on that. (`error-reporting.t` and `weird-errors.t` reached the

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -43,6 +43,81 @@ test subprocesses (details in [docs/mzef-install-pipeline.md](../docs/mzef-insta
 **Verification trap for the next session:** `use Test::META; say "LOADED"` proves nothing —
 `use_module` silently succeeds for any missing `Test::*` module (compat branch). Verify with an
 exported symbol (`::("&meta6-ok")`).
+## 2026-07-17: `OUTER::` names ONE scope, not every outer scope — `my-6c.t` 112/112
+
+`roast/6.c/S04-declarations/my-6c.t` sat at 111/112 on test 57:
+
+```raku
+{
+    ok EVAL('not OUTER::<$x>.defined'), 'OUTER::<$x>';   # mutsu: False.  raku: True
+    my $x;
+}
+```
+
+BLOCKERS.md recorded this as needing **lexical hoisting** — the claim being that
+`OUTER::<$x>` had to see the enclosing block's `my $x` declared *after* the EVAL as an
+undefined container. That diagnosis was wrong, and the hoisting it asked for would not
+have fixed the test. Measuring `OUTER::` against rakudo first (rather than implementing
+the recorded root cause) showed three real defects instead — the same lesson as
+`advent2013-day18.t` the same day.
+
+`packages.rakudoc` defines the pair:
+
+```
+OUTER       Symbols in the next outer lexical scope
+OUTERS      Symbols in any outer lexical scope
+```
+
+mutsu implemented `OUTER` as `OUTERS`. `exec_get_pseudo_stash_op` answered `OUTER::<$x>`
+by building a hash of the **whole flat `env`**, which has no notion of scope levels at
+all: one scope out happened to be right, and every scope beyond it was wrong in a way
+that returned a *defined, unrelated* value. Test 57 fell out of exactly that — the
+file-scope `my $x = 0` from two scopes away answered a lookup that should have found
+nothing. The three defects:
+
+1. **`OUTER::` cascaded.** `my $y = 7; { { OUTER::<$y> } }` gave 7; raku gives Nil. The
+   fix is to resolve the name in the target scope *only*. This is a lexical, compile-time
+   question, and the compiler already tracks it: `local_scopes` records which names each
+   scope declares, so `emit_outer_var_access` now settles the lookup outright and emits a
+   Nil constant when the target scope does not declare the name. Nothing was added to the
+   VM — an earlier attempt to enforce this in `get_outer_var` had to be reverted, because
+   `outer_scope_locals` is only reset by `run()`, not by the fast call paths, so inside a
+   stored closure it still holds the *caller's* blocks: dynamic, not lexical.
+2. **The two spellings had diverged.** `$OUTER::x` compiled to `GetOuterVar` (depth-aware);
+   `OUTER::<$x>` never reached it, because the compiler special-cased only `CALLER::<$x>`
+   and had no `parse_outer_prefix` sibling. Both spellings now share one path, so
+   `OUTER::OUTER::<$y>` works (it returned Nil before) and `OUTER::<@a>` / `OUTER::<%h>`
+   resolve (only `$` is stripped from a stash key; `@`/`%`/`&` stay in the env key).
+3. **`OUTERS::` was unimplemented** (always Nil). It is now the innermost *enclosing*
+   scope that declares the name — excluding the current scope, so
+   `my $y = 7; { my $y = 8; $OUTERS::y }` is 7 — which is just `OUTER` at a depth
+   `local_scopes` can find, so it reuses the same emit path.
+
+Two supporting pieces were needed to make "does the target scope declare this name?"
+answerable:
+
+- **Parameters are declarations of their routine's scope** (`declare_param`):
+  `sub f($p) { { $OUTER::p } }` sees 42. Plain `alloc_local` deliberately still does not
+  record, since it is also how a *free* variable gets a slot, and a free variable merely
+  mentioned in a body is not declared by it (raku:
+  `my $y = 7; sub f { say $y; { say $OUTER::y } }` prints 7 then Nil).
+- **EVAL'd units are compiled behind an empty wrapper scope** (`mark_as_eval_unit`).
+  rakudo does not splice an EVAL'd unit into the invoking scope; it runs it behind
+  wrapper scopes holding no user lexicals, so `EVAL 'OUTER::.keys'` is empty and
+  `my $y = 7; { EVAL(q{OUTER::<$y>}) }` is Nil even with `$y` right there. This is the
+  lexical-axis twin of `push_eval_caller_frames`, which already modelled the same layout
+  on the caller axis for `CALLER::`. Plain lookups are unaffected — EVAL still shares the
+  runtime env with its caller, so `my $z = 3; { EVAL(q{$z}) }` is still 3. **This, not
+  hoisting, is what test 57 needed**: the enclosing `my $x` is irrelevant, because an
+  EVAL'd unit cannot see the invoking scope through `OUTER::` at all.
+
+The topic is exempt from the compile-time check: every block and routine scope declares
+its own `$_` (a block's implicitly as `$_ is raw = OUTER::<$_>`, a routine's as a fresh
+undefined one), so the question is only ever what that `$_` holds. Without the exemption
+`$OUTER::_` compiled to Nil and regressed `t/outer-topic.t`.
+
+Pin: `t/outer-pseudo-package.t` (23 assertions, every expectation checked against rakudo
+first — the file passes under `raku` as well as mutsu). Whitelist 1430 → 1431.
 
 ## 2026-07-17: regex code assertions now run exactly once, on the real interpreter — `advent2013-day18.t` 10/10 (ADR-0009)
 

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -4,6 +4,7 @@ roast/6.c/MISC/misc-6.c.t
 roast/6.c/S02-names/SETTING-6c.t
 roast/6.c/S02-types/subset-6c.t
 roast/6.c/S03-operators/set_precedes.t
+roast/6.c/S04-declarations/my-6c.t
 roast/6.c/S05-grammar/methods.t
 roast/6.c/S05-grammar/parse_and_parsefile-6c.t
 roast/6.c/S06-other/main-refactored.t

--- a/src/compiler/expr_data.rs
+++ b/src/compiler/expr_data.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::compiler::helpers_dynamic::OuterStash;
 use crate::value::ValueView;
 
 impl Compiler {
@@ -375,6 +376,31 @@ impl Compiler {
                 name_idx,
                 depth: depth as u32,
             });
+            self.bind_terminal = saved_terminal;
+            return;
+        }
+
+        // Special case: OUTER::<$x> / OUTERS::<$x> stash-subscript access resolves a
+        // lexical of an enclosing scope, exactly like the `$OUTER::x` / `$OUTERS::x`
+        // symbolic forms. Route both spellings to the same scope walk; without this
+        // the stash form degrades to a flat-env hash scan, which silently cascades
+        // through every outer scope (i.e. answers OUTER:: with OUTERS:: semantics)
+        // and leaves OUTERS:: itself unresolved. Supports OUTER::OUTER::<$x> too.
+        if let Expr::PseudoStash(stash) = target
+            && let Some(scope) = Self::parse_outer_stash(stash)
+            && let Expr::Literal(lit) = index
+            && let ValueView::Str(key) = lit.view()
+        {
+            // Only `$` is stripped: a scalar lives in `locals`/`env` under its bare
+            // name, while `@a`/`%h`/`&f` keep their sigil in the key.
+            let bare: String = match key.chars().next() {
+                Some('$') => key.chars().skip(1).collect(),
+                _ => key.as_ref().clone(),
+            };
+            match scope {
+                OuterStash::At(depth) => self.emit_outer_var_access(bare, depth),
+                OuterStash::Any => self.emit_outers_var_access(bare),
+            }
             self.bind_terminal = saved_terminal;
             return;
         }

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -547,15 +547,14 @@ impl Compiler {
             });
             return;
         }
+        // $OUTERS:: variable access ("any outer lexical scope")
+        if let Some(bare_name) = Self::parse_outers_prefix(name) {
+            self.emit_outers_var_access(bare_name);
+            return;
+        }
         // $OUTER:: / $OUTER::OUTER:: variable access
         if let Some((bare_name, depth)) = Self::parse_outer_prefix(name) {
-            let slot = self.resolve_outer_var_slot(&bare_name, depth);
-            let name_idx = self.code.add_constant(Value::str(bare_name));
-            self.code.emit(OpCode::GetOuterVar {
-                name_idx,
-                depth: depth as u32,
-                slot,
-            });
+            self.emit_outer_var_access(bare_name, depth);
             return;
         }
         // $DYNAMIC:: variable access

--- a/src/compiler/helpers_dynamic.rs
+++ b/src/compiler/helpers_dynamic.rs
@@ -2,6 +2,16 @@ use super::*;
 use crate::symbol::Symbol;
 use crate::value::ValueView;
 
+/// Which enclosing lexical scope an `OUTER::` / `OUTERS::` access names
+/// (packages.rakudoc: "OUTER  Symbols in the next outer lexical scope" /
+/// "OUTERS  Symbols in any outer lexical scope").
+pub(crate) enum OuterStash {
+    /// `OUTER::` (chained: `OUTER::OUTER::` is depth 2) -- exactly `depth` scopes out.
+    At(usize),
+    /// `OUTERS::` -- the innermost enclosing scope that declares the name.
+    Any,
+}
+
 /// Snapshot of the compiler's lexical-scope-sensitive state, saved on block
 /// entry and restored on block exit.
 pub(super) struct LexicalScopeSnapshot {
@@ -201,6 +211,29 @@ impl Compiler {
         } else {
             None
         }
+    }
+
+    /// Which lexical-scope walk an `OUTER::` / `OUTERS::` pseudo-stash names.
+    /// Returns `None` for any other stash (`MY::`, `CORE::`, a real package, ...).
+    pub(crate) fn parse_outer_stash(stash: &str) -> Option<OuterStash> {
+        if let Some((rest, depth)) = Self::parse_outer_prefix(stash)
+            && rest.is_empty()
+        {
+            return Some(OuterStash::At(depth));
+        }
+        if Self::parse_outers_prefix(stash).is_some_and(|rest| rest.is_empty()) {
+            return Some(OuterStash::Any);
+        }
+        None
+    }
+
+    /// Parse a single `OUTERS::` prefix from a variable name, returning the bare
+    /// name. Unlike `OUTER::`, `OUTERS::` does not chain: it already means "any
+    /// outer scope", so raku reports `$OUTERS::OUTERS::y` as Nil. Stripping only
+    /// the one prefix reproduces that -- the leftover `OUTERS::y` is not a
+    /// declared name anywhere, so the lookup misses.
+    pub(crate) fn parse_outers_prefix(name: &str) -> Option<String> {
+        name.strip_prefix("OUTERS::").map(str::to_string)
     }
 
     /// Parse `OUTER::` / `OUTER::OUTER::` prefix from a variable name.

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -7,7 +7,7 @@ impl Compiler {
     fn alloc_sub_signature_locals(compiler: &mut Compiler, sub_params: &[crate::ast::ParamDef]) {
         for sp in sub_params {
             if !sp.name.is_empty() {
-                compiler.alloc_local(&sp.name);
+                compiler.declare_param(&sp.name);
             }
             if let Some(nested) = &sp.sub_signature {
                 Self::alloc_sub_signature_locals(compiler, nested);
@@ -168,12 +168,12 @@ impl Compiler {
         sub_compiler.set_current_package(state_scope);
         // Pre-allocate locals for parameters
         for param in params {
-            sub_compiler.alloc_local(param);
+            sub_compiler.declare_param(param);
         }
         // Also allocate from param_defs in case param names differ
         for pd in param_defs {
             if !pd.name.is_empty() {
-                sub_compiler.alloc_local(&pd.name);
+                sub_compiler.declare_param(&pd.name);
                 // Track sigilless parameters so BareWord resolution uses
                 // GetLocal for them but not for `$`-sigiled params.
                 if pd.sigilless {
@@ -659,11 +659,11 @@ impl Compiler {
         sub_compiler.set_current_package(closure_package);
         // Pre-allocate locals for parameters
         for param in params {
-            sub_compiler.alloc_local(param);
+            sub_compiler.declare_param(param);
         }
         for pd in param_defs {
             if !pd.name.is_empty() {
-                sub_compiler.alloc_local(&pd.name);
+                sub_compiler.declare_param(&pd.name);
                 if pd.sigilless {
                     sub_compiler.sigilless_locals.insert(pd.name.clone());
                 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -600,6 +600,106 @@ impl Compiler {
         slot
     }
 
+    /// Declaration entry point for a routine/block PARAMETER.
+    ///
+    /// Slot allocation is plain [`alloc_local`], exactly as before; the added work
+    /// is recording the name in the innermost [`local_scopes`] frame, because a
+    /// parameter *is* a declaration of its routine's scope. `OUTER::` resolution
+    /// asks that question directly ("does the target scope declare this name?"),
+    /// and a signature binding must answer yes: `sub f($p) { { $OUTER::p } }` sees
+    /// 42. Plain [`alloc_local`] deliberately does NOT record, since it is also how
+    /// a *free* variable and compiler temporaries get a slot, and a free variable
+    /// mentioned in a body is not a declaration of it (raku: `my $y = 7;
+    /// sub f { say $y; { say $OUTER::y } }` prints 7 then Nil).
+    fn declare_param(&mut self, name: &str) -> u32 {
+        let slot = self.alloc_local(name);
+        if let Some(frame) = self.local_scopes.last_mut() {
+            frame.entry(name.to_string()).or_insert(None);
+        }
+        slot
+    }
+
+    /// Emit a read of `bare` from the scope `depth` levels out (`$OUTER::x`,
+    /// `OUTER::<$x>`, and their `OUTER::OUTER::` chains).
+    ///
+    /// `OUTER` names exactly ONE scope -- packages.rakudoc: "Symbols in the next
+    /// outer lexical scope" -- so a name the target scope does not declare is Nil,
+    /// NOT whatever an enclosing scope happens to bind under the same name (that
+    /// cascade is `OUTERS`). Whenever the target scope is inside this frame the
+    /// compiler settles the lookup outright: `local_scopes` records which names
+    /// each scope declares, so "declared there?" is answered exactly, with no
+    /// runtime guessing. Only a `depth` that crosses this frame's outermost scope
+    /// is unknowable here (the enclosing frame is a separate compilation), and is
+    /// left to the runtime's captured-env walk in `get_outer_var`.
+    fn emit_outer_var_access(&mut self, bare: String, depth: usize) {
+        let n = self.local_scopes.len();
+        // The topic is exempt: EVERY block and routine scope declares its own `$_`
+        // (a block's implicitly as `$_ is raw = OUTER::<$_>`, a routine's as a fresh
+        // undefined one), so "does the target scope declare it?" is always yes and
+        // the question is only ever what that `$_` holds -- which the runtime path
+        // answers. `_` is never in `local_scopes` because it is never spelled as a
+        // declaration, so without this it would compile to a constant Nil.
+        let implicitly_declared = bare == "_";
+        if depth < n
+            && !implicitly_declared
+            && !self.local_scopes[n - 1 - depth].contains_key(&bare)
+        {
+            let idx = self.code.add_constant(Value::NIL);
+            self.code.emit(OpCode::LoadConst(idx));
+            return;
+        }
+        let slot = self.resolve_outer_var_slot(&bare, depth);
+        let name_idx = self.code.add_constant(Value::str(bare));
+        self.code.emit(OpCode::GetOuterVar {
+            name_idx,
+            depth: depth as u32,
+            slot,
+        });
+    }
+
+    /// Emit a read of `bare` via `OUTERS::` -- packages.rakudoc: "Symbols in any
+    /// outer lexical scope".
+    ///
+    /// Where `OUTER` names one scope, `OUTERS` searches outward and stops at the
+    /// innermost ENCLOSING scope that declares the name; the current scope is
+    /// excluded, so `my $y = 7; { my $y = 8; say $OUTERS::y }` is 7, not 8. That
+    /// makes it exactly an `OUTER` at the depth of the first enclosing declaration,
+    /// which is a question `local_scopes` already answers -- so the two spell the
+    /// same read, and only the choice of depth differs.
+    fn emit_outers_var_access(&mut self, bare: String) {
+        let n = self.local_scopes.len();
+        for depth in 1..n {
+            if self.local_scopes[n - 1 - depth].contains_key(&bare) {
+                self.emit_outer_var_access(bare, depth);
+                return;
+            }
+        }
+        // No enclosing scope of THIS frame declares it. The search continues in the
+        // enclosing frame, which is a separate compilation: depth `n` crosses this
+        // frame's boundary, which is precisely the case `get_outer_var` resolves
+        // against the captured env -- itself an outward cascade, i.e. OUTERS.
+        self.emit_outer_var_access(bare, n);
+    }
+
+    /// Compile this unit as an `EVAL`'d compilation unit's mainline.
+    ///
+    /// Rakudo does not splice an EVAL'd unit straight into the invoking scope: it
+    /// runs the compiled unit behind wrapper scopes that hold no user lexicals, so
+    /// `OUTER::` from EVAL'd mainline code finds nothing (`EVAL 'OUTER::.keys'` is
+    /// empty, and `my $y = 7; { say EVAL(q{OUTER::<$y>}) }` is Nil even though `$y`
+    /// is right there in the invoking block). Model that by giving the unit an
+    /// empty enclosing scope frame: the unit's own declarations then land one frame
+    /// in, and an `OUTER::` reaching past them lands on the empty wrapper -- Nil,
+    /// exactly as raku reports. Plain (unqualified) lookups are unaffected: they
+    /// resolve through the runtime env, which EVAL still shares with its caller, so
+    /// `my $z = 3; { say EVAL(q{$z}) }` still prints 3.
+    ///
+    /// This is the lexical-axis twin of [`Interpreter::push_eval_caller_frames`],
+    /// which already models the same layout on the caller axis for `CALLER::`.
+    pub(crate) fn mark_as_eval_unit(&mut self) {
+        self.push_local_scope();
+    }
+
     /// Enter a nested lexical scope for local-slot allocation. Paired with
     /// [`pop_local_scope`]; driven by the block-boundary hooks
     /// (`push_dynamic_scope_lexical`/`pop_dynamic_scope_lexical`).

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -91,7 +91,20 @@ impl Interpreter {
         &self,
         body: &[Stmt],
     ) -> (crate::opcode::CompiledCode, crate::opcode::CompiledFns) {
+        self.compile_block_value_opts(body, false)
+    }
+
+    /// `compile_block_value`, with `is_eval_unit` marking the body as an EVAL'd
+    /// compilation unit's mainline (see `Compiler::mark_as_eval_unit`).
+    pub(crate) fn compile_block_value_opts(
+        &self,
+        body: &[Stmt],
+        is_eval_unit: bool,
+    ) -> (crate::opcode::CompiledCode, crate::opcode::CompiledFns) {
         let mut compiler = crate::compiler::Compiler::new();
+        if is_eval_unit {
+            compiler.mark_as_eval_unit();
+        }
         compiler.is_routine = !self.routine_stack.is_empty();
         compiler.lexically_in_routine = !self.routine_stack.is_empty();
         let scope = if let Some(frame) = self.routine_stack.last() {
@@ -114,6 +127,16 @@ impl Interpreter {
     }
 
     pub(crate) fn eval_block_value(&mut self, body: &[Stmt]) -> Result<Value, RuntimeError> {
+        self.eval_block_value_opts(body, false)
+    }
+
+    /// `eval_block_value`, with `is_eval_unit` marking `body` as an EVAL'd
+    /// compilation unit's mainline (see `Compiler::mark_as_eval_unit`).
+    pub(crate) fn eval_block_value_opts(
+        &mut self,
+        body: &[Stmt],
+        is_eval_unit: bool,
+    ) -> Result<Value, RuntimeError> {
         if body.is_empty() {
             return Ok(Value::NIL);
         }
@@ -149,7 +172,7 @@ impl Interpreter {
             .filter(|(k, _)| k.starts_with("&") || k.starts_with("__mutsu_callable_id::"))
             .map(|(k, v)| (*k, v.clone()))
             .collect();
-        let (code, compiled_fns) = self.compile_block_value(body);
+        let (code, compiled_fns) = self.compile_block_value_opts(body, is_eval_unit);
         // Multi-frame coherence (env_dirty-deletion path): box any captured-outer
         // scalar this carrier body writes into a shared cell across env + saved
         // frames, so the by-name write survives the owner frame's env restore.

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -142,7 +142,7 @@ impl Interpreter {
                 // private call in the EVAL'd string errors even if a preceding
                 // `return` would short-circuit it at runtime.
                 self.validate_private_calls_against_self(&stmts)?;
-                let value = self.eval_block_value(&stmts)?;
+                let value = self.eval_block_value_opts(&stmts, true)?;
                 if self.eval_result_is_unresolved_bareword(&stmts, &value) {
                     return Err(RuntimeError::undeclared_symbols("Undeclared name"));
                 }

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -382,6 +382,18 @@ impl Interpreter {
         // Inline nested-block path: `outer_scope_locals` (runtime-saved slots)
         // reflects the lexical structure of nested bare blocks executed in place,
         // so it distinguishes multiple same-named `my $a` bindings by depth.
+        //
+        // Whether the target scope actually DECLARES `name` is not decided here:
+        // `OUTER::` names exactly one scope (packages.rakudoc), and that is a
+        // lexical, compile-time question, so `Compiler::emit_outer_var_access`
+        // settles it and emits a Nil constant instead of this opcode when the
+        // target scope does not declare the name. Re-deciding it here is not
+        // possible anyway: this stack is only reset by `run()`, not by the fast
+        // call paths, so inside a stored closure it still holds the CALLER's
+        // blocks -- dynamic, not lexical. By the time a `GetOuterVar` executes,
+        // the name is either declared in the target scope or the target lies
+        // outside this frame (a separate compilation), which is what the captured
+        // env below resolves.
         if stack_len > 0 && depth <= stack_len {
             let idx = stack_len - depth;
             let saved = &self.outer_scope_locals[idx];

--- a/t/outer-pseudo-package.t
+++ b/t/outer-pseudo-package.t
@@ -1,0 +1,100 @@
+use v6;
+use Test;
+
+# `OUTER::` names exactly ONE scope and `OUTERS::` names any outer scope
+# (packages.rakudoc: "OUTER  Symbols in the next outer lexical scope" /
+# "OUTERS  Symbols in any outer lexical scope"). Both spellings -- the symbolic
+# `$OUTER::x` and the stash subscript `OUTER::<$x>` -- must agree.
+# Every expectation below is the value rakudo prints for the same snippet.
+
+plan 23;
+
+# --- OUTER:: reaches exactly one scope out -------------------------------
+my $y = 7;
+{
+    is $OUTER::y, 7, '$OUTER::y one scope out';
+    is OUTER::<$y>, 7, 'OUTER::<$y> one scope out';
+}
+{
+    {
+        # Two scopes out is NOT OUTER's business: the enclosing block declares
+        # no $y, so the answer is Nil -- not the file-scope $y.
+        nok $OUTER::y.defined, '$OUTER::y does not cascade past one scope';
+        nok OUTER::<$y>.defined, 'OUTER::<$y> does not cascade past one scope';
+        is $OUTER::OUTER::y, 7, '$OUTER::OUTER::y reaches two scopes out';
+        is OUTER::OUTER::<$y>, 7, 'OUTER::OUTER::<$y> reaches two scopes out';
+    }
+}
+
+# --- a shadowing declaration is what the enclosing scope binds ------------
+{
+    my $y = 8;
+    {
+        is $OUTER::y, 8, '$OUTER::y sees the enclosing shadow';
+        is OUTER::<$y>, 8, 'OUTER::<$y> sees the enclosing shadow';
+    }
+}
+
+# --- @ and % keep their sigil in the stash key ---------------------------
+my @a = 1, 2;
+my %h = a => 1;
+{
+    is-deeply OUTER::<@a>, [1, 2], 'OUTER::<@a> resolves an array';
+    is-deeply OUTER::<%h>, {a => 1}, 'OUTER::<%h> resolves a hash';
+}
+
+# --- routine scopes count as scopes --------------------------------------
+sub one-out { $OUTER::y }
+is one-out(), 7, '$OUTER::y from a routine body reaches the declaring scope';
+
+sub nested-in-routine { { $OUTER::y } }
+nok nested-in-routine().defined,
+    '$OUTER::y in a routine-nested block stops at the routine body';
+
+sub param-outer($p) { { $OUTER::p } }
+is param-outer(42), 42, 'a parameter is a declaration of its routine scope';
+
+my $closure = { $OUTER::y };
+is $closure(), 7, '$OUTER::y from a stored closure reaches its declaring scope';
+
+# A free variable merely *mentioned* in a body is not declared by it.
+sub mentions-free { my $seen = $y; { $OUTER::y } }
+nok mentions-free().defined,
+    'a free variable used in a body is not a declaration of that body';
+
+# --- OUTERS:: cascades outward -------------------------------------------
+{
+    {
+        is $OUTERS::y, 7, '$OUTERS::y cascades to any outer scope';
+        is OUTERS::<$y>, 7, 'OUTERS::<$y> cascades to any outer scope';
+    }
+}
+{
+    my $y = 8;
+    # OUTERS excludes the *current* scope, so this is the file-scope 7.
+    is $OUTERS::y, 7, 'OUTERS:: excludes the current scope';
+    {
+        is $OUTERS::y, 8, 'OUTERS:: stops at the innermost enclosing declaration';
+    }
+}
+nok $OUTERS::OUTERS::y.defined, 'OUTERS:: does not chain';
+
+# --- EVAL'd units sit behind a scope with no user lexicals ---------------
+# rakudo runs an EVAL'd unit behind wrapper scopes holding no user lexicals,
+# so OUTER:: from EVAL'd mainline code finds nothing -- even for a variable
+# sitting in the block that called EVAL. Plain lookups still see the caller.
+{
+    ok EVAL(q{not OUTER::<$y>.defined}), 'OUTER:: from an EVAL unit is empty';
+    is EVAL(q{$y}), 7, 'a plain lookup in an EVAL unit still sees the caller';
+}
+{
+    # The my-6c.t:216 shape: the enclosing block declares $x *after* the EVAL.
+    my $x = 0;
+    {
+        {
+            ok EVAL(q{not OUTER::<$x>.defined}),
+                'OUTER::<$x> from EVAL does not resolve to an enclosing $x';
+            my $x; #OK not used
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`roast/6.c/S04-declarations/my-6c.t` sat at 111/112 on test 57:

```raku
{
    ok EVAL('not OUTER::<$x>.defined'), 'OUTER::<$x>';   # mutsu: False.  raku: True
    my $x;
}
```

`TODO_roast/BLOCKERS.md` recorded this as needing **lexical hoisting** — that `OUTER::<$x>` had to see the enclosing block's `my $x` declared *after* the EVAL as an undefined container. That diagnosis was wrong, and the hoisting it asked for would not have fixed the test. Measuring `OUTER::` against rakudo *first* (instead of implementing the recorded root cause) turned up three real defects.

`packages.rakudoc` defines a pair that mutsu had collapsed into one:

```
OUTER       Symbols in the next outer lexical scope
OUTERS      Symbols in any outer lexical scope
```

`exec_get_pseudo_stash_op` answered `OUTER::<$x>` by building a hash of the **whole flat `env`**, which has no notion of scope levels at all. One scope out was right by luck; every scope beyond it was wrong in a way that returned a *defined, unrelated* value. Test 57 fell out of exactly that — the file-scope `my $x = 0` from two scopes away answered a lookup that should have found nothing.

## What changed

| expression | before | after / raku |
|---|---|---|
| `my $y = 7; { { OUTER::<$y> } }` | `7` | `Nil` |
| `my $y = 7; { { OUTER::OUTER::<$y> } }` | `Nil` | `7` |
| `my @a = 1,2; { OUTER::<@a> }` | unresolved | `[1, 2]` |
| `my $y = 7; { { OUTERS::<$y> } }` | `Nil` | `7` |
| `my $y = 7; { EVAL(q{OUTER::<$y>}) }` | `7` | `Nil` |

- **`OUTER::` no longer cascades.** Whether the target scope *declares* the name is a lexical, compile-time question, and the compiler already tracks it (`local_scopes`), so `emit_outer_var_access` settles the lookup outright and emits a Nil constant when it does not. **Nothing was added to the VM** — an earlier attempt to enforce this in `get_outer_var` had to be reverted, because `outer_scope_locals` is only reset by `run()`, not by the fast call paths, so inside a stored closure it still holds the *caller's* blocks: dynamic, not lexical.
- **The two spellings now share one path.** `$OUTER::x` compiled to the depth-aware `GetOuterVar`; `OUTER::<$x>` never reached it, because the compiler special-cased only `CALLER::<$x>` and had no `parse_outer_prefix` sibling.
- **`OUTERS::` is implemented** (it was always `Nil`): the innermost *enclosing* scope that declares the name, excluding the current scope, so `my $y = 7; { my $y = 8; $OUTERS::y }` is 7.
- **Parameters are declarations of their routine's scope** (`declare_param`): `sub f($p) { { $OUTER::p } }` sees 42. Plain `alloc_local` deliberately still does not record — it is also how a *free* variable gets a slot, and a free variable merely mentioned in a body is not declared by it (raku: `my $y = 7; sub f { say $y; { say $OUTER::y } }` prints 7 then Nil).
- **EVAL'd units compile behind an empty wrapper scope** (`mark_as_eval_unit`). rakudo does not splice an EVAL'd unit into the invoking scope; it runs it behind wrapper scopes holding no user lexicals, so `EVAL 'OUTER::.keys'` is empty. This is the lexical-axis twin of the existing `push_eval_caller_frames`, which already models the same layout on the caller axis for `CALLER::`. **This, not hoisting, is what test 57 needed** — the enclosing `my $x` is irrelevant, because an EVAL'd unit cannot see the invoking scope through `OUTER::` at all. Plain lookups are unaffected: `my $z = 3; { EVAL(q{$z}) }` is still 3.

The topic is exempt from the compile-time check: every block and routine scope declares its own `$_` (a block's implicitly as `$_ is raw = OUTER::<$_>`, a routine's as a fresh undefined one), so only its *value* is ever in question. Without the exemption `$OUTER::_` compiled to Nil and regressed `t/outer-topic.t`.

## Test plan

- **`roast/6.c/S04-declarations/my-6c.t` 111/112 → 112/112**, added to the whitelist (1430 → 1431).
- New pin `t/outer-pseudo-package.t`: 23 assertions covering both spellings, depth, shadowing, `@`/`%`, routine/closure/parameter scopes, `OUTERS::`, and EVAL. **Every expectation was checked against rakudo first — the file passes under `raku` as well as mutsu.**
- `make test`: 1791 files / 17523 tests pass.
- `roast/S02-names-vars/names.t` still fails tests 18/142/144 — verified identical on `main` (pre-existing, not whitelisted).