### PR TITLE
fix: ::?CLASS pseudo-type works on non-invocant parameters

### DIFF
--- a/src/parser/stmt/sub_param/param_inner.rs
+++ b/src/parser/stmt/sub_param/param_inner.rs
@@ -238,7 +238,12 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
             return Ok((r, p));
         }
         let (r, _) = ws(r)?;
-        if r.starts_with('$') || r.starts_with('@') || r.starts_with('%') {
+        if r.starts_with('$')
+            || r.starts_with('@')
+            || r.starts_with('%')
+            || r.starts_with('&')
+            || r.starts_with('\\')
+        {
             type_constraint = Some(tc);
             rest = r;
         } else {

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -1472,6 +1472,19 @@ impl Interpreter {
                     };
                     let mut effective_param_defs =
                         Self::effective_method_param_defs(param_defs, is_hidden);
+                    // Resolve the ::?CLASS pseudo-type in parameter type
+                    // constraints to the enclosing class (raku fixes ::?CLASS
+                    // at compile time to the declaring class), mirroring the
+                    // attribute-type resolution above. Without this, binding a
+                    // non-invocant `::?CLASS:U \t` param type-checks against
+                    // the literal string "::?CLASS:U" and always fails.
+                    for pd in effective_param_defs.iter_mut() {
+                        if let Some(tc) = &pd.type_constraint
+                            && tc.contains("::?CLASS")
+                        {
+                            pd.type_constraint = Some(tc.replace("::?CLASS", name));
+                        }
+                    }
                     // Auto-detect @_ usage in methods without explicit signatures
                     if param_defs.is_empty() {
                         let (use_positional, _) = Self::auto_signature_uses(method_body);

--- a/t/class-pseudo-type-param.t
+++ b/t/class-pseudo-type-param.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+# ::?CLASS as a NON-invocant parameter type constraint.
+#
+# Pins the Test::Async::Hub shape (mzef Test-phase frontier):
+#   method create-suite(::?CLASS:D: ::?CLASS:U \suiteType = self.WHAT, *%c)
+# which used to die at parse time with
+#   X::Redeclaration: Redeclaration of symbol '$self'
+# because a `\`-sigilless param after the ::?CLASS pseudo-type fell into the
+# bare-invocant branch and produced a second `self` param. Binding also
+# type-checked against the literal string "::?CLASS:U" and always failed.
+
+plan 8;
+
+class Foo {
+    method create-suite(::?CLASS:D: ::?CLASS:U \suiteType = self.WHAT, *%c) {
+        suiteType.^name
+    }
+}
+
+is Foo.new.create-suite(), 'Foo', 'invocant marker + ::?CLASS:U sigilless param with default parses and runs';
+is Foo.new.create-suite(Foo), 'Foo', 'explicit type-object argument binds';
+
+class A {
+    method m(::?CLASS:U \t = self.WHAT) { t.^name }
+    method sigiled(::?CLASS:U $t = self.WHAT) { $t.^name }
+}
+class B is A { }
+
+is A.new.m(), 'A', '::?CLASS:U sigilless param defaults from self.WHAT';
+is B.new.m(), 'B', 'inherited method: default resolves to the runtime class';
+is B.new.m(B), 'B', 'subclass type object satisfies the declaring-class constraint';
+is A.new.sigiled(), 'A', '::?CLASS:U on a $-sigiled param works too';
+
+class C { method n(::?CLASS:D $other) { $other.defined } }
+my $c = C.new;
+ok $c.n(C.new), '::?CLASS:D param accepts an instance of the class';
+dies-ok { C.new.n("nope") }, '::?CLASS:D param rejects a foreign value';


### PR DESCRIPTION
## Summary

Two defects found via Test::Async::Hub (the mzef Test-phase frontier). Its

```raku
method create-suite(::?CLASS:D: ::?CLASS:U \suiteType = self.WHAT, *%c) {...}
```

died at parse time with `X::Redeclaration: Redeclaration of symbol '$self'`.

- **Parser**: the `::?CLASS`/`::?ROLE` branch only recognized `$`/`@`/`%` after the pseudo-type, so a sigilless `\name` (or `&name`) parameter fell into the bare-invocant fallback and produced a *second* param named `self` — hence the bogus redeclaration. Same defect class as the `-> Mu \type` fix in #4661, in the pseudo-type branch.
- **Runtime**: even sigiled `::?CLASS:U $t` params never bound — the constraint was type-checked as the literal string `"::?CLASS:U"` and always failed (`expected ::?CLASS:U, got Package`). Now `::?CLASS` is resolved to the declaring class at class registration time (raku fixes `::?CLASS` at compile time to the declaring class), mirroring the attribute-type resolution already in the same function.

With this, `use Test::Async::Hub` moves past the parse failure; its next blocker is custom Metamodel HOW inheritance (`Metamodel::ParametricRoleHOW`), tracked in the mzef pipeline doc.

## Testing

- Pin: `t/class-pseudo-type-param.t` (8 tests, output identical under `raku`)
- `make test`: 1797 files / 17541 tests PASS
- roast subset: all 14 whitelisted files containing `::?CLASS` + all 17 whitelisted S24-testing files PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)