### PR TITLE
fix: use-ok performs a real module load instead of a filesystem probe

### DIFF
--- a/docs/mzef-install-pipeline.md
+++ b/docs/mzef-install-pipeline.md
@@ -215,21 +215,48 @@ repro → general fix → `t/` pin):
 ## Test-phase frontier (2026-07-17, the current one)
 
 `zef install Test::META` (tests ON) runs all 16 dists' test suites
-concurrently and **13/16 FAIL** (OK: JSON::OptIn; the debug-build run also
-overran a 570s timeout — use release for E2E):
+concurrently; the baseline was **13/16 FAIL** (OK: JSON::OptIn; the
+debug-build run also overran a 570s timeout — use release for E2E). The
+2026-07-17 (late) session root-caused the dominant failures — none were
+environmental; all four were ordinary mutsu bugs, each fixed generally:
 
-- **The dominant symptom is environmental, not per-test**: nearly every
-  suite's `t/010-use.t` fails at `use-ok` ("JSON::Name module can be use-d
-  ok" etc.) even though the same `use` works interactively against the
-  installed repo. zef runs each suite in a subprocess against the STAGED
-  (pre-install) dist plus its already-installed dependencies; suspect the
-  `-I`/env handoff for that staging layout, or cross-contamination between
-  the 16 concurrent test subprocesses. Investigate one suite in isolation
-  first (`zef test <path>` or run the staged `prove` command by hand).
-- **Test::Async (vrurg) fails to parse**: `Failed to parse module
-  'Test::Async::Hub': X::Redeclaration: Redeclaration of symbol '$self'` —
-  a real language bug, plus sink-context warnings. Test::Async is the test
-  framework several vrurg dists use, so it gates their suites.
+- ~~`use-ok` never did a real load~~ (the "dominant symptom"): mutsu's
+  `use-ok` probed `lib_paths` for `Module/Name.rakumod` as literal files —
+  it could not see `inst#` installation repos, and the staged dist zef
+  tests against is exactly that, so every suite's `t/010-use.t` failed
+  while interactive `use` worked. Fixed: `use-ok` now delegates to the
+  real `use_module()` loader (Rakudo EVALs `use $module`). Pin:
+  `t/use-ok-real-load.t`.
+- ~~Test::Async (vrurg) `X::Redeclaration: '$self'`~~ (#4669): TWO
+  `::?CLASS` param bugs — a `\`-sigilless param after the pseudo-type fell
+  into the bare-invocant branch and created a second `self` param
+  (`create-suite(::?CLASS:D: ::?CLASS:U \suiteType = self.WHAT)`), and a
+  non-invocant `::?CLASS` constraint was type-checked as a literal string
+  so it never bound. Pin: `t/class-pseudo-type-param.t`. **Test::Async's
+  next blocker is custom Metamodel HOW inheritance**
+  (`'Test::Async::Metamodel::BundleHOW' cannot inherit from
+  'Metamodel::ParametricRoleHOW' because it is unknown`) — a real MOP
+  feature, campaign-sized; not started.
+- ~~a mixed-in role's composed roles invisible to `.does`/`~~`~~:
+  `role NamedAttribute does JSON::OptIn::OptedInAttribute` mixed into an
+  attribute answered False for the composed role, failing JSON::Name's
+  `t/020-trait.t` `does-ok`. Class composition already walked the role
+  graph; only the mixin path lost it. Pin:
+  `t/mixin-role-transitive-does.t`.
+- ~~map-block `my` clobbered a caller lexical → JSON::OptIn dropped from
+  prereqs~~: the inline map/grep/first paths run the block's body directly
+  in the enclosing frame's env, so `provides-specs`'s
+  `.map({ my $spec = ...; $spec })` overwrote `provides-spec-matcher`'s
+  `$spec` PARAMETER — `contains-spec` then matched the dist against itself
+  and `zef install JSON::Name` silently skipped installing JSON::OptIn
+  (cache-cold first call only, which made it look nondeterministic). Fixed
+  by recording each block's own `my` declarations
+  (`CompiledCode::my_declared_sym`) and masking them from the
+  closure-exit/inline writeback (a declared name that is also a free var
+  keeps its writeback). Pin: `t/map-block-my-shadow-leak.t`.
+
+Re-run the full `zef install Test::META` E2E after these land to get the
+new pass/fail count.
 
 Still open (load-side leftovers):
 

--- a/src/runtime/test_functions/eval_exception.rs
+++ b/src/runtime/test_functions/eval_exception.rs
@@ -424,23 +424,26 @@ impl Interpreter {
     pub(crate) fn test_fn_use_ok(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         let module = Self::positional_string(args, 0);
         let todo = Self::named_bool(args, "todo");
-        let desc = format!("{} module can be use-d ok", module);
-        let mut found = false;
-        let module_file = module.replace("::", "/");
-        for lib_path in &self.lib_paths.clone() {
-            for ext in &[".rakumod", ".pm6", ".pm"] {
-                let full = format!("{}/{}{}", lib_path, module_file, ext);
-                if std::path::Path::new(&full).exists() {
-                    found = true;
-                    break;
-                }
+        let desc = {
+            let explicit = Self::positional_string(args, 1);
+            if explicit.is_empty() {
+                format!("{} module can be use-d ok", module)
+            } else {
+                explicit
             }
-            if found {
-                break;
-            }
+        };
+        // Rakudo's use-ok EVALs `use $module`: the module must actually load
+        // (resolve through the full repo chain — plain dirs AND inst#
+        // installation repos — parse, and run its mainline), not merely exist
+        // as a file. The old filesystem probe here could not see inst# repos,
+        // so every staged-dist `use-ok` under `zef install` failed.
+        let load_result = self.use_module(&module);
+        let ok = load_result.is_ok();
+        self.test_ok(ok, &desc, todo)?;
+        if let Err(err) = load_result {
+            self.emit_output(&format!("# {}\n", err.message));
         }
-        self.test_ok(found, &desc, todo)?;
-        Ok(Value::truth(found))
+        Ok(Value::truth(ok))
     }
 
     pub(crate) fn test_fn_does_ok(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {

--- a/t/use-ok-real-load.t
+++ b/t/use-ok-real-load.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+plan 5;
+
+# use-ok must perform a REAL module load (Rakudo EVALs `use $module`), not a
+# filesystem probe of lib_paths. The old probe could not see inst#
+# installation repos, so under `zef install` every staged dist's
+# `use-ok 'Dist::Name'` failed even though `use Dist::Name` worked.
+# The fixture inst# repo provides SelTest (see t/use-dist-selectors.t).
+
+my $exe = $*EXECUTABLE;
+my $repo = 'inst#t/fixtures/dist-selectors';
+
+my $r = run($exe, '-I', $repo, '-e', 'use Test; plan 1; use-ok("SelTest")', :out, :err);
+my $out = $r.out.slurp(:close);
+like $out, /'ok 1 - SelTest module can be use-d ok'/,
+    'use-ok resolves a module through an inst# installation repo';
+is $r.exitcode, 0, 'and the suite exits 0';
+
+$r = run($exe, '-I', $repo, '-e', 'use Test; plan 1; use-ok("SelTest", "custom description")', :out, :err);
+$out = $r.out.slurp(:close);
+like $out, /'ok 1 - custom description'/, 'the optional second argument overrides the description';
+
+$r = run($exe, '-e', 'use Test; plan 1; use-ok("Nope::Not::There")', :out, :err);
+$out = $r.out.slurp(:close);
+like $out, /'not ok 1 - Nope::Not::There module can be use-d ok'/,
+    'use-ok on a missing module reports not ok';
+isnt $r.exitcode, 0, 'and the suite exits non-zero';


### PR DESCRIPTION
## Summary

mutsu's `use-ok` probed `lib_paths` for `Module/Name.rakumod` as literal file paths — it could not see `inst#` installation repos. The staged dist `zef install` runs test suites against is exactly that, so nearly every suite's `t/010-use.t` failed at `use-ok` while the same `use` worked interactively: the dominant symptom behind the 13/16 Test-phase failures in the mzef pipeline.

`use-ok` now delegates to the real `use_module()` loader (Rakudo's `use-ok` EVALs `use $module`): the module must resolve through the full repo chain (plain dirs AND `inst#` repos), parse, and run its mainline. A load failure reports not-ok with the error as a `#` diagnostic. The optional second positional argument (description override) is honored now too.

Verified E2E: with this, a staged dist's `t/010-use.t` passes under `zef install` (the failure moves on to genuine per-dist bugs, fixed separately).

Also updates `docs/mzef-install-pipeline.md`'s Test-phase frontier section with the root causes found this session.

## Testing

- Pin: `t/use-ok-real-load.t` (5 tests; resolution through the `t/fixtures/dist-selectors` inst# fixture repo, description override, missing-module not-ok + non-zero exit)
- `make test`: 1799 files / 17555 tests PASS (with the sibling fixes in tree)
- roast: `S24-testing/*` (17 whitelisted files) PASS; `S24-testing/1-basic.t` exercises use-ok directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)