### PR TITLE
fix: a mixed-in role's composed roles satisfy .does/~~ checks

### DIFF
--- a/src/runtime/seq_helpers/role_type.rs
+++ b/src/runtime/seq_helpers/role_type.rs
@@ -15,10 +15,16 @@ impl Interpreter {
             }
             if let Some(parents) = self.registry().role_parents.get(&role) {
                 for parent in parents {
-                    if parent == rhs_role {
+                    // A parent may be recorded in parametric form ("P2[Int]");
+                    // compare and continue the walk on its base name.
+                    let parent_base = parent
+                        .split_once('[')
+                        .map(|(base, _)| base)
+                        .unwrap_or(parent.as_str());
+                    if parent_base == rhs_role {
                         return true;
                     }
-                    stack.push(parent.clone());
+                    stack.push(parent_base.to_string());
                 }
             }
         }

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -1085,6 +1085,18 @@ impl Interpreter {
             if mixins.contains_key(constraint) {
                 return true;
             }
+            // A mixed-in role may itself compose other roles
+            // (`role R1 does R2 {}`): `$x but R1` / `$attr does R1` must
+            // then match R2 as well. Walk the transitive role-composition
+            // graph from every mixed-in role marker.
+            for key in mixins.keys() {
+                if let Some(role_name) = key.strip_prefix("__mutsu_role__")
+                    && (self.role_is_subtype(role_name, effective_constraint)
+                        || self.role_is_subtype(role_name, constraint))
+                {
+                    return true;
+                }
+            }
         }
         // For Package (type object) values, use the package name as the type
         // so that e.g. Junction (which is Mu, not Any) is correctly rejected

--- a/t/mixin-role-transitive-does.t
+++ b/t/mixin-role-transitive-does.t
@@ -1,0 +1,35 @@
+use v6;
+use Test;
+
+# A role mixed into a VALUE (`but` / runtime `does`) may itself compose other
+# roles (`role R1 does R2 {}`); the mixed value must then match R2 too.
+# Class composition (`class C does R1`) already handled this — only the mixin
+# path lost the transitive roles. This is the JSON::Name t/020-trait.t shape:
+#   role NamedAttribute does JSON::OptIn::OptedInAttribute { ... }
+#   $attr does NamedAttribute;   # must then .does(OptedInAttribute)
+
+plan 8;
+
+role R3 { }
+role R2 does R3 { method r2m { "r2m" } }
+role R1 does R2 { }
+
+my $o = 42 but R1;
+ok $o.does(R1), 'mixin does the directly mixed role';
+ok $o.does(R2), 'mixin does the role composed by the mixed role';
+ok $o.does(R3), 'transitive composition is followed to any depth';
+ok $o ~~ R2, 'smartmatch follows the composed role too';
+is $o.r2m, 'r2m', 'a method from the composed role dispatches';
+
+class C { has $.a }
+my $attr = C.^attributes[0];
+$attr does R1;
+ok $attr.does(R2), 'runtime does on an Instance follows composed roles';
+
+role P2[::T] { }
+role P1 does P2[Int] { }
+my $p = 1 but P1;
+ok $p.does(P2), 'a parametric composed role matches by base name';
+
+role Other { }
+nok $o.does(Other), 'an unrelated role still does not match';


### PR DESCRIPTION
## Summary

`role R1 does R2 {}` composed onto a value at runtime (`42 but R1`, `$attr does R1`) answered **False** for `.does(R2)` / `~~ R2` — raku says True. Class composition (`class C does R1`) already walked the transitive role graph; only the **mixin** path lost it, because the Mixin branch of `type_matches_value` checked the direct `__mutsu_role__` markers only.

- The Mixin branch now walks the transitive role-composition graph (`role_is_subtype`) from every mixed-in role marker.
- `role_is_subtype` compares parametric parent entries (`P2[Int]`) by base name, so `role P1 does P2[Int]` matches `.does(P2)` and the walk continues through parametric parents.

This is the JSON::Name `t/020-trait.t` shape from the mzef Test-phase frontier: `role NamedAttribute does JSON::OptIn::OptedInAttribute` is applied to an attribute meta-object by the `json-name` trait, and the suite's `does-ok $attr, JSON::OptIn::OptedInAttribute` must pass. The staged suite passes 4/4 with this fix.

## Testing

- Pin: `t/mixin-role-transitive-does.t` (8 tests — direct/transitive/any-depth does, smartmatch, composed-role method dispatch, Instance mixin, parametric parent, negative case; output identical under `raku`)
- `make test`: 1799 files / 17555 tests PASS (with sibling fixes in tree)
- roast: S14-roles mixin/composition + S12 introspection subset (14 files / 500 tests) PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)