### PR TITLE
fix: a map-block `my` no longer clobbers a same-named caller lexical

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -796,6 +796,14 @@ impl Compiler {
                 // do-block (string-interpolation `{...}`) so it can revert
                 // exactly its own block-local declarations on exit.
                 self.record_block_decl(name);
+                // Record the block's own `my` bindings so the closure-exit
+                // caller-writeback scan can tell them apart from mutated
+                // captured outers (see CompiledCode::my_declared_sym).
+                // `state`/`our`/dynamic declarations intentionally outlive or
+                // cross the frame and are excluded.
+                if !*is_state && !*is_our && !*is_dynamic && !name.starts_with('*') {
+                    self.code.my_declared_sym.insert(Symbol::intern(name));
+                }
                 // An inline `where` constraint on a scalar/sigilless variable
                 // (e.g. `my $x where * > 0`, `my Int $n where { $_ %% 2 }`,
                 // `my $v where &predicate`) is desugared into an anonymous subset

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1692,6 +1692,16 @@ pub(crate) struct CompiledCode {
     /// slot's writes instead. With the gate off `alloc_local` get-or-creates by
     /// name, so names are unique and this is all-false (byte-identical).
     pub(crate) dup_named_locals: Vec<bool>,
+    /// Names `my`-declared (or `constant`-declared) in THIS code's body — the
+    /// block's own fresh lexical bindings. The closure-exit caller-writeback
+    /// scan must not propagate them to a same-named caller lexical: with the
+    /// flattened env a `.map({ my $spec = ... })` inside a method otherwise
+    /// clobbers the calling method's `$spec` parameter on block exit (how
+    /// zef's `provides-spec-matcher` corrupted `contains-spec` and dropped
+    /// JSON::OptIn from the prereq list). A declared name that is ALSO a free
+    /// var (used before its declaration, so it refers to the outer binding)
+    /// keeps the writeback.
+    pub(crate) my_declared_sym: rustc_hash::FxHashSet<Symbol>,
     /// Free variables this code (and its nested closures) reference from an
     /// enclosing scope: names used via GetGlobal-family ops that are not this
     /// code's own locals. For a closure body this is the set of captured
@@ -2037,6 +2047,7 @@ impl CompiledCode {
             may_capture_outer_vars: false,
             needs_env_sync: Vec::new(),
             dup_named_locals: Vec::new(),
+            my_declared_sym: rustc_hash::FxHashSet::default(),
             free_var_syms: Vec::new(),
             free_var_parent_slots: Vec::new(),
             upvalue_parent_slots: Vec::new(),

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -144,6 +144,29 @@ pub(super) fn normalize_tail_stmt_for_value(body: &[crate::ast::Stmt]) -> Vec<cr
     }
 }
 
+/// The inline map/grep/first paths run the block's body directly in the
+/// enclosing frame's env, so the block's own `my` declarations write a
+/// bare-name entry there. When an enclosing lexical of the same name is
+/// visible through the flattened env, the block-local binding would leak into
+/// it on exit (zef's `provides-spec-matcher` clobbered the calling method's
+/// `$spec` param this way) — save/restore those names like the other
+/// temporaries. A declared name that is also a free var refers to the outer
+/// binding (used before its declaration) and is left alone.
+pub(crate) fn push_block_declared_keys(
+    touched_keys: &mut Vec<String>,
+    code: &crate::opcode::CompiledCode,
+) {
+    for k in &code.my_declared_sym {
+        if code.free_var_syms.contains(k) {
+            continue;
+        }
+        let name = k.resolve();
+        if !touched_keys.contains(&name) {
+            touched_keys.push(name);
+        }
+    }
+}
+
 impl Interpreter {
     pub(super) fn eval_map_over_items(
         &mut self,
@@ -352,6 +375,7 @@ impl Interpreter {
             if !touched_keys.iter().any(|k| k == "$_") {
                 touched_keys.push(dollar_topic.clone());
             }
+            push_block_declared_keys(&mut touched_keys, &code);
             let saved: Vec<(String, Option<Value>)> = touched_keys
                 .iter()
                 .map(|k| (k.clone(), self.env.get(k).cloned()))
@@ -600,6 +624,7 @@ impl Interpreter {
         if !touched_keys.iter().any(|k| k == "$_") {
             touched_keys.push(dollar_topic.clone());
         }
+        push_block_declared_keys(&mut touched_keys, &code);
         let saved: Vec<(String, Option<Value>)> = touched_keys
             .iter()
             .map(|k| (k.clone(), self.env.get(k).cloned()))

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -130,6 +130,7 @@ impl Interpreter {
             if !touched_keys.iter().any(|k| k == "$_") {
                 touched_keys.push(dollar_topic.clone());
             }
+            super::resolution_map_grep::push_block_declared_keys(&mut touched_keys, &code);
             let saved: Vec<(String, Option<Value>)> = touched_keys
                 .iter()
                 .map(|k| (k.clone(), self.env.get(k).cloned()))
@@ -352,6 +353,7 @@ impl Interpreter {
             if !touched_keys.iter().any(|k| k == &topic_source_key) {
                 touched_keys.push(topic_source_key.clone());
             }
+            super::resolution_map_grep::push_block_declared_keys(&mut touched_keys, &code);
             let saved: Vec<(String, Option<Value>)> = touched_keys
                 .iter()
                 .map(|k| (k.clone(), self.env.get(k).cloned()))

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -928,7 +928,7 @@ impl Interpreter {
                     // a local slot on this compile path. A declared name that
                     // is also a free var refers to the outer binding for its
                     // pre-declaration uses, so its writeback is kept.
-                    && !(cc.my_declared_sym.contains(k) && !cc.free_var_syms.contains(k))
+                    && (!cc.my_declared_sym.contains(k) || cc.free_var_syms.contains(k))
                     && (!local_names.contains(k) || captured_names.contains(k))
                 {
                     // Don't leak captured-only variables to callers that don't have

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -922,6 +922,13 @@ impl Interpreter {
                         || (meta_possible
                             && (k.starts_with("__mutsu_predictive_seq_iter::")
                                 || k.starts_with("__mutsu_sigilless_alias::!"))))
+                    // The block's own `my` binding shadows the caller's
+                    // same-named lexical (visible here through the flattened
+                    // env) — never write it back, whether or not the name got
+                    // a local slot on this compile path. A declared name that
+                    // is also a free var refers to the outer binding for its
+                    // pre-declaration uses, so its writeback is kept.
+                    && !(cc.my_declared_sym.contains(k) && !cc.free_var_syms.contains(k))
                     && (!local_names.contains(k) || captured_names.contains(k))
                 {
                     // Don't leak captured-only variables to callers that don't have

--- a/t/map-block-my-shadow-leak.t
+++ b/t/map-block-my-shadow-leak.t
@@ -1,0 +1,56 @@
+use v6;
+use Test;
+
+# A `my` declared inside a map/grep/first block is the block's own fresh
+# binding. It must NOT leak into a same-named lexical of the calling frame
+# (visible through the flattened env). zef hit this in Zef::Distribution:
+# `provides-specs` runs `.map({ my $spec = ...; $spec })` and the enclosing
+# `provides-spec-matcher($spec)` parameter got clobbered by the block-local
+# value, so `contains-spec` matched a dist against ITSELF and silently
+# dropped JSON::OptIn from the prereq list (only on the first, cache-cold
+# call — the cached second call skipped the map and behaved).
+
+plan 6;
+
+class Sp {
+    has $.name;
+    method m($o) { $.name eq $o.name }
+}
+
+class Dist {
+    has $.name;
+    has @!cache;
+    method specs {
+        return @!cache if @!cache.elems;
+        my @s = ($.name,).map({
+            my $spec = Sp.new(name => $_);
+            $spec;
+        });
+        @!cache = @s;
+        return @!cache;
+    }
+    method pm($spec) {
+        so self.specs.first({ $_.m($spec) })
+    }
+}
+
+my $d = Dist.new(name => 'A');
+nok $d.pm(Sp.new(name => 'B')), 'first call (cache-cold, map runs): no false match';
+nok $d.pm(Sp.new(name => 'B')), 'second call (cache-hit): still no false match';
+ok $d.pm(Sp.new(name => 'A')), 'a genuine match still matches';
+
+class D2 {
+    method specs { ('A',).map({ my $spec = Sp.new(name => $_); $spec }).eager }
+    method pm($spec) { self.specs; $spec.name }
+}
+is D2.new.pm(Sp.new(name => 'B')), 'B',
+    'a map-block my does not clobber the caller method param directly';
+
+# The legitimate captured-outer mutation writeback must survive.
+my $sum = 0;
+(1, 2, 3).map({ my $t = $_ * 2; $sum += $t }).eager;
+is $sum, 12, 'captured-outer mutation from a map block still writes back';
+
+my $x = 1;
+(1,).map({ $x = 5 }).eager;
+is $x, 5, 'plain captured assignment from a map block still writes back';


### PR DESCRIPTION
## Summary

The inline map/grep/first paths run the block's body directly in the enclosing frame's env, so a block-local `my $spec` wrote a bare-name env entry that survived block exit and propagated through the method-return merge into any same-named caller lexical (visible via the flattened env).

zef hit this in `Zef::Distribution`: `provides-specs` runs `.map({ my $spec = ...; $spec })`, which clobbered the enclosing `provides-spec-matcher`'s `$spec` **parameter** — `contains-spec` then matched the dist against **itself** (always True) and `zef install JSON::Name` silently dropped `JSON::OptIn` from the prereq list, so the staged suite died with `Could not find JSON::OptIn`. The `@!provides-specs` cache made only the cache-cold first call misbehave, which is why the drop looked nondeterministic (an identical grep chain inserted before it "fixed" it).

## Fix

Two layers sharing one new piece of compile-time truth:

- **`CompiledCode::my_declared_sym`** — the names `my`/`constant`-declared in THIS code's body, recorded when the VarDecl compiles (`state`/`our`/dynamic declarations intentionally outlive or cross the frame and are excluded).
- The **closure-exit caller-writeback scan** (`vm_closure_dispatch.rs`) and the **four inline map/grep/first `touched_keys` save/restore lists** (`resolution_map_grep.rs`, `resolution_map_grep_rw.rs`) both mask those names from propagation.

A declared name that is **also a free var** refers to the outer binding for its pre-declaration uses and keeps its writeback; ordinary captured-outer mutations (`$sum += $_`, `$x = 5`) are unaffected — pinned as negative cases.

## Testing

- Pin: `t/map-block-my-shadow-leak.t` (6 tests — the zef cache-cold/cache-hit shape, direct param-clobber probe, plus captured-mutation writeback preservation; output identical under `raku`)
- `make test`: 1799 files / 17555 tests PASS
- roast: closure/map/grep/first/phasers/let/temp/pointy + S14 mixin subset — 49 whitelisted files / 1358 tests PASS
- E2E: the isolated zef repro (`Zef::Distribution.contains-spec`) returns False correctly, and `needed:` retains `JSON::OptIn,Test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)