### PR TITLE
fix: $::($name)::x resolves OUTER:: against the lexical chain, like $OUTER::x

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -79,7 +79,7 @@ noted.
 | `APPENDICES/A02-some-day-maybe/multi-no-match.t` | 3/16 (2026-07-17) | PASS ★ | error-message quality for multi no-match: `.splice` with wrong offset/type, `Lock.protect` / `Lock::Async.protect` / `Proc::Async.new` with wrong args must give "sane errors" — ④-adjacent |
 | `6.c/APPENDICES/A03-older-specs/01-misc.t` | fails 4+ | 6/9 FAIL | `.open("-")` mapping to `$*IN`/`$*OUT`, deprecated `subst-mutate`. raku itself fails 3 of 9 = partially non-goal |
 | `6.c/MISC/bug-coverage-stress.t` | fails 4 | 13/14 FAIL | Supply.merge on signals, supply inside sock, SEGV-in-curries+with, &foo char collection. raku itself fails test 11 (rakudo GH#1535) = not fully passable upstream |
-| `6.c/S02-names/pseudo-6c.t` | 102/161 (2026-07-17, was 99 before #4667) | SORRY on ONE line | **The next slice here is the INDIRECT deref `$::($name)::x`.** #4667 (OUTER::/OUTERS::) took this 99 -> 102 and split the remaining failures cleanly: every DIRECT form now passes (128 `$OUTER::`, 129 `OUTER::.{}`, 131 `$OUTERS::` "keeps going until match", 133 `$OUTER::OUTER::`, 135, 138 `OUTER::<$*x>`) and only the `::("OUTER")` spelling of the SAME lookups fails (130/132/134/136/139) — i.e. a runtime-computed package name does not reach the compile-time scope walk `Compiler::emit_outer_var_access` now owns. Also failing: `OUR::`/`::("OUR")` vs GLOBAL, `::("UNIT")`, `::("SETTING")`, `::("PROCESS")`. **"No oracle" is about the FILE, not the constructs**: raku SORRYs only on line 67 (`$MY::z ::= $y`, `::=` NYI), so individual snippets are verifiable in raku exactly as #4667 did — do that first, this ledger's diagnoses have been wrong before (see news/2026-07.md) |
+| `6.c/S02-names/pseudo-6c.t` | fails 52/161 (2026-07-17, was 56 before the `$::()` slice) | SORRY on ONE line | **The next slice here is `CALLERS::` (tests 119-127, the largest remaining cluster).** The `$::($name)::x` deref is DONE for the OUTER family (130/132/134/136) — the `$::(...)::y` spelling now shares one scope-chain resolver with the literal `$OUTER::y` (`compiler/lex_scope.rs`), so the two cannot drift. What is left splits into two roads, and they are **different mechanisms — do not conflate them**: (a) the `$::($x)::y` road (SymbolicDeref, done for OUTER); (b) the `::($x)::('$y')` road, which parses to `IndirectTypeLookup($x).WHO.{'$y'}` — a *stash* lookup, and where `::("OUR")`/`::("CORE")`/`::("GLOBAL")`/`::("PROCESS")`/`::("CALLER")` (50/51/53/61/79/84/116/125/139) actually live. `CALLERS::` fails in BOTH spellings (119 direct, 121 indirect), so it is a missing *feature*, not a deref gap: it is to `CALLER` what `OUTERS` is to `OUTER` (walk callers outward to the first frame declaring the name), and `Interpreter::get_caller_var` is the place. Also failing: `::("UNIT")` (140 direct fails too), `::("SETTING")`, 137 `CALLER::OUTER::`. **"No oracle" is about the FILE, not the constructs**: raku SORRYs only on line 67 (`$MY::z ::= $y`, `::=` NYI), so individual snippets are verifiable in raku — do that first, this ledger's diagnoses have been wrong before (see news/2026-07.md). Two raku-verified facts worth keeping: a closure `{ $OUTER::c }` is itself a scope, so its OUTER is the block *enclosing the closure*, not the closure's caller; and an undeclared `$OUTER::x` is a `Failure` in raku but `Nil` in mutsu (open divergence, untested by this file) |
 | `APPENDICES/A02-some-day-maybe/misc.t` | aborts (no plan) | 5/6 FAIL | "some-day-maybe" spec aspirations; raku itself not full — non-goal |
 | `MISC/misc.t` | fails 4+ | ABORT 5/7 | `:sym<>` colonpair reservation on sub names, `$*ARGFILES` inside MAIN, native num default 0e0, `undefine` deprecation warning. raku itself aborts = partially non-goal |
 | `t/fudge.t`, `t/fudgeandrun.t` | n/a | n/a | **roast's own tooling tests, written in Perl 5** (run with `perl`, not raku/mutsu) — non-goal by definition |
@@ -199,13 +199,15 @@ not-yet-root-caused `integration/` aborts" — **all of those are whitelisted**,
 re-running it; this ledger's *diagnoses* have also been wrong (see `my-6c.t` in
 [news/2026-07.md](../news/2026-07.md), where "needs lexical hoisting" was simply false).
 
-1. **`6.c/S02-names/pseudo-6c.t` — the indirect deref `$::($name)::x`** (102/161, measured).
-   The most concrete slice left, and freshly halved: #4667 made every **direct** pseudo-package
-   lookup pass, so what remains is the **`::("OUTER")` spelling of the same lookups** plus the
-   `OUR::` / `UNIT::` / `SETTING::` / `PROCESS::` family. A runtime-computed package name does not
-   reach the compile-time scope walk that `Compiler::emit_outer_var_access` now owns — that gap
-   *is* the slice. Per-snippet oracles work (raku SORRYs only on line 67's `::=`); see the
-   inventory row.
+1. **`6.c/S02-names/pseudo-6c.t` — `CALLERS::`** (fails 52/161, measured). Still the most
+   concrete slice left. The `$::($name)::x` deref landed for the OUTER family, and the
+   *measurement it produced* reshapes what is left: the remaining failures are not one gap but
+   three, and the ledger previously lumped them together. `CALLERS::` (119-127, the largest
+   cluster) fails in the direct spelling too, so it is a missing feature — the caller-axis twin
+   of `OUTERS::`, belonging in `Interpreter::get_caller_var`. The `::("OUR")`/`::("CORE")`/
+   `::("GLOBAL")`/`::("PROCESS")` family is a *stash* road (`IndirectTypeLookup.WHO.{}`), not the
+   deref road, and is a separate slice again. Per-snippet oracles work (raku SORRYs only on line
+   67's `::=`); see the inventory row for the full split.
 2. **`APPENDICES/A02-some-day-maybe/multi-no-match.t`** (3/16, measured — NOT the 11/16 this
    file used to claim). The last ★ (raku full-pass, mutsu fails). Needs `X::Multi::NoMatch` from
    ~10 independent builtins (`.splice` / `Lock.protect` / `Lock::Async.protect` /

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -826,7 +826,11 @@ impl Compiler {
             Expr::SymbolicDeref { sigil, expr } => {
                 self.compile_expr(expr);
                 let sigil_idx = self.code.add_constant(Value::str(sigil.clone()));
-                self.code.emit(OpCode::SymbolicDeref(sigil_idx));
+                let scopes_idx = self.bake_lex_scope_chain();
+                self.code.emit(OpCode::SymbolicDeref {
+                    sigil_idx,
+                    scopes_idx,
+                });
             }
             Expr::SymbolicDerefAssign { sigil, expr, value } => {
                 self.compile_expr(value);

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -116,6 +116,7 @@ impl Compiler {
         let mut sub_compiler = Compiler::new();
         self.inherit_fold_ctx(&mut sub_compiler);
         self.inherit_outer_code_var_names(&mut sub_compiler);
+        self.inherit_enclosing_scopes(&mut sub_compiler);
         sub_compiler.is_routine = true;
         sub_compiler.lexically_in_routine = true;
         // A method body carries the synthetic `?CLASS` parameter injected by the
@@ -612,6 +613,7 @@ impl Compiler {
         let mut sub_compiler = Compiler::new();
         self.inherit_fold_ctx(&mut sub_compiler);
         self.inherit_outer_code_var_names(&mut sub_compiler);
+        self.inherit_enclosing_scopes(&mut sub_compiler);
         sub_compiler.is_routine = is_routine;
         // Make the names of all constants visible at this closure's definition
         // point known to the child compiler, so a `constant X` inside the body

--- a/src/compiler/lex_scope.rs
+++ b/src/compiler/lex_scope.rs
@@ -1,0 +1,155 @@
+//! The lexical-scope questions `OUTER::` / `OUTERS::` ask, in one place.
+//!
+//! `OUTER::` is a *lexical* construct, so which binding it names is settled by
+//! the shape of the source, not by anything the VM can observe while running:
+//! the compiler owns the answer (see [`Compiler::emit_outer_var_access`]). That
+//! works only as long as the pseudo-package is spelled literally. The indirect
+//! form `$::($name)::x` computes the very same lookup from a string that does
+//! not exist until run time, so the *decision* must be reachable from the VM
+//! while the *inputs* to it stay compile-time.
+//!
+//! This module is the seam: [`resolve_outer`] / [`resolve_outers`] take the
+//! scope chain as plain data, so the compiler calls them with its live fields
+//! and the VM calls them through a [`LexScopeChain`] baked into the code chunk
+//! at the emit point. Both hand over the same chain (`Compiler::full_scope_chain`),
+//! so one implementation answers both spellings and they cannot drift.
+
+use std::collections::HashMap;
+
+/// One compiled scope's declarations: name -> the slot recorded for it (`None`
+/// unless a shadow-slot build recorded one). Mirrors `Compiler::local_scopes`.
+pub(crate) type ScopeFrame = HashMap<String, Option<u32>>;
+
+/// What an `OUTER::` / `OUTERS::` lookup of one name resolves to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OuterResolution {
+    /// The named scope does not declare the name, so the lookup is Nil.
+    /// `OUTER` names exactly ONE scope (packages.rakudoc: "Symbols in the next
+    /// outer lexical scope"), so it must NOT fall back to whatever an enclosing
+    /// scope happens to bind under the same name -- that cascade is `OUTERS`.
+    NotDeclared,
+    /// Read the name from `depth` scopes out. `slot` is the emit-point slot of
+    /// the binding visible there; only shadow-slot builds consult it.
+    Read { depth: usize, slot: Option<u32> },
+}
+
+/// The slot of the binding `bare` has `depth` scopes out, as seen from the
+/// emit point: start at the currently-visible slot and undo each intervening
+/// scope's shadowing record, innermost first.
+fn resolve_slot(
+    scopes: &[ScopeFrame],
+    local_map: &HashMap<String, u32>,
+    name: &str,
+    depth: usize,
+) -> Option<u32> {
+    let n = scopes.len();
+    if depth >= n {
+        return None;
+    }
+    let target = n - 1 - depth;
+    let mut slot = local_map.get(name).copied();
+    for frame in scopes[target + 1..].iter().rev() {
+        if let Some(prev) = frame.get(name) {
+            slot = *prev;
+        }
+    }
+    slot
+}
+
+/// Resolve `OUTER::` at `depth` (`$OUTER::x` is depth 1, `$OUTER::OUTER::x` is 2).
+///
+/// Whenever the target scope is inside this compilation frame the answer is
+/// settled outright -- `scopes` records which names each scope declares, so
+/// "declared there?" needs no runtime guessing. Only a `depth` that crosses the
+/// outermost frame is unknowable here (the enclosing frame is a separate
+/// compilation), and is left to the runtime's captured-env walk in
+/// `Interpreter::get_outer_var`.
+pub(crate) fn resolve_outer(
+    scopes: &[ScopeFrame],
+    local_map: &HashMap<String, u32>,
+    bare: &str,
+    depth: usize,
+) -> OuterResolution {
+    let n = scopes.len();
+    // The topic is exempt: EVERY block and routine scope declares its own `$_`
+    // (a block's implicitly as `$_ is raw = OUTER::<$_>`, a routine's as a fresh
+    // undefined one), so "does the target scope declare it?" is always yes and
+    // the question is only ever what that `$_` holds -- which the runtime path
+    // answers. `_` is never in `scopes` because it is never spelled as a
+    // declaration, so without this it would resolve to a constant Nil.
+    let implicitly_declared = bare == "_";
+    if depth < n && !implicitly_declared && !scopes[n - 1 - depth].contains_key(bare) {
+        return OuterResolution::NotDeclared;
+    }
+    OuterResolution::Read {
+        depth,
+        slot: resolve_slot(scopes, local_map, bare, depth),
+    }
+}
+
+/// Resolve `OUTERS::` -- packages.rakudoc: "Symbols in any outer lexical scope".
+///
+/// Where `OUTER` names one scope, `OUTERS` searches outward and stops at the
+/// innermost ENCLOSING scope that declares the name; the current scope is
+/// excluded, so `my $y = 7; { my $y = 8; say $OUTERS::y }` is 7, not 8. That
+/// makes it exactly an `OUTER` at the depth of the first enclosing declaration,
+/// so the two share one implementation and only the choice of depth differs.
+pub(crate) fn resolve_outers(
+    scopes: &[ScopeFrame],
+    local_map: &HashMap<String, u32>,
+    bare: &str,
+) -> OuterResolution {
+    let n = scopes.len();
+    for depth in 1..n {
+        if scopes[n - 1 - depth].contains_key(bare) {
+            return resolve_outer(scopes, local_map, bare, depth);
+        }
+    }
+    // No enclosing scope of THIS frame declares it. The search continues in the
+    // enclosing frame, which is a separate compilation: depth `n` crosses this
+    // frame's boundary, which is precisely the case `get_outer_var` resolves
+    // against the captured env -- itself an outward cascade, i.e. OUTERS.
+    resolve_outer(scopes, local_map, bare, n)
+}
+
+/// The compile-time scope chain at one emit point, baked into the code chunk.
+///
+/// A literal `$OUTER::x` never needs this: the compiler resolves it and emits
+/// the answer. It exists for `$::($name)::x`, where the pseudo-package is only
+/// known at run time and the VM must therefore ask the question itself -- with
+/// the compiler's inputs, not the runtime scope stack, which is dynamic rather
+/// than lexical and would give a different (wrong) answer inside a closure.
+#[derive(Debug, Clone)]
+pub(crate) struct LexScopeChain {
+    scopes: Vec<ScopeFrame>,
+    local_map: HashMap<String, u32>,
+}
+
+impl LexScopeChain {
+    pub(crate) fn new(scopes: Vec<ScopeFrame>, local_map: HashMap<String, u32>) -> Self {
+        Self { scopes, local_map }
+    }
+
+    pub(crate) fn resolve_outer(&self, bare: &str, depth: usize) -> OuterResolution {
+        resolve_outer(&self.scopes, &self.local_map, bare, depth)
+    }
+
+    pub(crate) fn resolve_outers(&self, bare: &str) -> OuterResolution {
+        resolve_outers(&self.scopes, &self.local_map, bare)
+    }
+
+    /// Every name any scope in the chain declares — i.e. every name a lookup
+    /// through this chain could possibly land on.
+    ///
+    /// A literal `$OUTER::x` tells `CompiledCode::compute_free_vars` exactly which
+    /// enclosing binding a closure must snapshot under `__mutsu_outer::`. An
+    /// indirect `$::($name)::x` names it only at run time, far too late to
+    /// snapshot anything, so its site has to claim the whole chain instead. The
+    /// over-claim is cheap — a symbolic deref forces a whole-env capture anyway —
+    /// while an under-claim silently falls back to the dynamic scope stack.
+    pub(crate) fn declared_names(&self) -> impl Iterator<Item = &str> {
+        self.scopes
+            .iter()
+            .flat_map(|f| f.keys().map(String::as_str))
+    }
+}

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -52,6 +52,7 @@ mod helpers_ops;
 mod helpers_phasers;
 mod helpers_stmt_analysis;
 mod helpers_sub_body;
+pub(crate) mod lex_scope;
 mod stmt;
 
 #[derive(Clone)]
@@ -75,6 +76,13 @@ pub(crate) struct Compiler {
     /// slot resolution) and §1.3 (collapse the dual store). See ANALYSIS.md §1.4.
     /// Frame 0 is the compilation-unit / routine top level and is never popped.
     local_scopes: Vec<HashMap<String, Option<u32>>>,
+    /// The ENCLOSING compilation's scope chain (outermost first), for compilers
+    /// that are compiling a nested body. `local_scopes` stops at the routine /
+    /// closure boundary because slot allocation does, but the *lexical* chain does
+    /// not — and `$::($name)::x` has to be answered against the whole thing, since
+    /// it learns its target name too late to be answered any other way. Empty for a
+    /// compilation unit's own compiler. See [`lex_scope::LexScopeChain`].
+    enclosing_scopes: Vec<lex_scope::ScopeFrame>,
     /// Track type constraints for local variables (for compile-time literal checks).
     local_types: HashMap<String, String>,
     compiled_functions: CompiledFns,
@@ -266,6 +274,7 @@ impl Compiler {
             local_map: HashMap::new(),
             // Frame 0 = compilation-unit / routine top level; never popped.
             local_scopes: vec![HashMap::new()],
+            enclosing_scopes: Vec::new(),
             local_types: HashMap::new(),
             compiled_functions: CompiledFns::default(),
             current_package: "GLOBAL".to_string(),
@@ -465,31 +474,31 @@ impl Compiler {
         self.code.add_closure_code(compiled, esc)
     }
 
-    /// Resolve the local slot of the binding of `name` visible `depth` lexical
-    /// scopes out from the current one (`$OUTER::name` = depth 1), by unwinding
-    /// the shadow records in `local_scopes`: each frame that declares `name`
-    /// stores the pre-declaration slot (`Some(outer)` for a genuine ancestor
-    /// shadow, `None` for a first declaration), so unwinding the frames deeper
-    /// than the target scope leaves the slot the target scope sees. Returns
-    /// `None` when the depth crosses this frame's boundary or the name is not
-    /// a local binding at that scope (the runtime falls back to its existing
-    /// by-name / env resolution). §1.3 S14 (GetOuterVar slot bake) — only
-    /// meaningful under `MUTSU_SHADOW_SLOTS` (the default build records `None`
-    /// for every declaration, so this resolves `None` whenever a shadow is
-    /// involved, and the runtime read is gated anyway).
-    fn resolve_outer_var_slot(&self, name: &str, depth: usize) -> Option<u32> {
-        let n = self.local_scopes.len();
-        if depth >= n {
-            return None;
-        }
-        let target = n - 1 - depth;
-        let mut slot = self.local_map.get(name).copied();
-        for frame in self.local_scopes[target + 1..].iter().rev() {
-            if let Some(prev) = frame.get(name) {
-                slot = *prev;
-            }
-        }
-        slot
+    /// The full lexical scope chain visible right here, outermost first: the
+    /// enclosing compilation's scopes followed by this one's.
+    fn full_scope_chain(&self) -> Vec<lex_scope::ScopeFrame> {
+        self.enclosing_scopes
+            .iter()
+            .chain(self.local_scopes.iter())
+            .cloned()
+            .collect()
+    }
+
+    /// Hand a nested body's compiler the chain it is being compiled inside, so a
+    /// symbolic deref in that body still sees the enclosing scopes.
+    fn inherit_enclosing_scopes(&self, sub: &mut Compiler) {
+        sub.enclosing_scopes = self.full_scope_chain();
+    }
+
+    /// Bake the scope chain visible right here into the code chunk, and return
+    /// the index the reading opcode carries.
+    ///
+    /// Only the indirect spelling `$::($name)::x` needs this — see
+    /// [`lex_scope::LexScopeChain`]. It is emitted per symbolic-deref site, which
+    /// is a construct that appears a handful of times in a program at most.
+    fn bake_lex_scope_chain(&mut self) -> u32 {
+        let chain = lex_scope::LexScopeChain::new(self.full_scope_chain(), self.local_map.clone());
+        self.code.add_lex_scope_chain(chain)
     }
 
     /// Record the compiler-authoritative positional-parameter → local-slot map
@@ -621,64 +630,37 @@ impl Compiler {
 
     /// Emit a read of `bare` from the scope `depth` levels out (`$OUTER::x`,
     /// `OUTER::<$x>`, and their `OUTER::OUTER::` chains).
-    ///
-    /// `OUTER` names exactly ONE scope -- packages.rakudoc: "Symbols in the next
-    /// outer lexical scope" -- so a name the target scope does not declare is Nil,
-    /// NOT whatever an enclosing scope happens to bind under the same name (that
-    /// cascade is `OUTERS`). Whenever the target scope is inside this frame the
-    /// compiler settles the lookup outright: `local_scopes` records which names
-    /// each scope declares, so "declared there?" is answered exactly, with no
-    /// runtime guessing. Only a `depth` that crosses this frame's outermost scope
-    /// is unknowable here (the enclosing frame is a separate compilation), and is
-    /// left to the runtime's captured-env walk in `get_outer_var`.
     fn emit_outer_var_access(&mut self, bare: String, depth: usize) {
-        let n = self.local_scopes.len();
-        // The topic is exempt: EVERY block and routine scope declares its own `$_`
-        // (a block's implicitly as `$_ is raw = OUTER::<$_>`, a routine's as a fresh
-        // undefined one), so "does the target scope declare it?" is always yes and
-        // the question is only ever what that `$_` holds -- which the runtime path
-        // answers. `_` is never in `local_scopes` because it is never spelled as a
-        // declaration, so without this it would compile to a constant Nil.
-        let implicitly_declared = bare == "_";
-        if depth < n
-            && !implicitly_declared
-            && !self.local_scopes[n - 1 - depth].contains_key(&bare)
-        {
-            let idx = self.code.add_constant(Value::NIL);
-            self.code.emit(OpCode::LoadConst(idx));
-            return;
-        }
-        let slot = self.resolve_outer_var_slot(&bare, depth);
-        let name_idx = self.code.add_constant(Value::str(bare));
-        self.code.emit(OpCode::GetOuterVar {
-            name_idx,
-            depth: depth as u32,
-            slot,
-        });
+        let res = lex_scope::resolve_outer(&self.full_scope_chain(), &self.local_map, &bare, depth);
+        self.emit_outer_resolution(bare, res);
     }
 
-    /// Emit a read of `bare` via `OUTERS::` -- packages.rakudoc: "Symbols in any
-    /// outer lexical scope".
-    ///
-    /// Where `OUTER` names one scope, `OUTERS` searches outward and stops at the
-    /// innermost ENCLOSING scope that declares the name; the current scope is
-    /// excluded, so `my $y = 7; { my $y = 8; say $OUTERS::y }` is 7, not 8. That
-    /// makes it exactly an `OUTER` at the depth of the first enclosing declaration,
-    /// which is a question `local_scopes` already answers -- so the two spell the
-    /// same read, and only the choice of depth differs.
+    /// Emit a read of `bare` via `OUTERS::` ("Symbols in any outer lexical scope").
     fn emit_outers_var_access(&mut self, bare: String) {
-        let n = self.local_scopes.len();
-        for depth in 1..n {
-            if self.local_scopes[n - 1 - depth].contains_key(&bare) {
-                self.emit_outer_var_access(bare, depth);
-                return;
+        let res = lex_scope::resolve_outers(&self.full_scope_chain(), &self.local_map, &bare);
+        self.emit_outer_resolution(bare, res);
+    }
+
+    /// Emit the read [`lex_scope`] resolved to. A scope that does not declare the
+    /// name is settled here as a constant Nil rather than handed to the runtime:
+    /// `OUTER` names exactly one scope, and "does that scope declare it?" is a
+    /// lexical question the VM has no sound way to re-ask (see
+    /// [`lex_scope::LexScopeChain`]).
+    fn emit_outer_resolution(&mut self, bare: String, res: lex_scope::OuterResolution) {
+        match res {
+            lex_scope::OuterResolution::NotDeclared => {
+                let idx = self.code.add_constant(Value::NIL);
+                self.code.emit(OpCode::LoadConst(idx));
+            }
+            lex_scope::OuterResolution::Read { depth, slot } => {
+                let name_idx = self.code.add_constant(Value::str(bare));
+                self.code.emit(OpCode::GetOuterVar {
+                    name_idx,
+                    depth: depth as u32,
+                    slot,
+                });
             }
         }
-        // No enclosing scope of THIS frame declares it. The search continues in the
-        // enclosing frame, which is a separate compilation: depth `n` crosses this
-        // frame's boundary, which is precisely the case `get_outer_var` resolves
-        // against the captured env -- itself an outward cascade, i.e. OUTERS.
-        self.emit_outer_var_access(bare, n);
     }
 
     /// Compile this unit as an `EVAL`'d compilation unit's mainline.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1460,8 +1460,14 @@ pub(crate) enum OpCode {
     IndirectCodeLookup(u32),
 
     /// Symbolic variable dereference: pop name string from stack, look up variable by sigil+name.
-    /// The u32 indexes the constant pool for the sigil string ("$", "@", or "%").
-    SymbolicDeref(u32),
+    /// `sigil_idx` indexes the constant pool for the sigil string ("$", "@", or "%").
+    /// `scopes_idx` indexes [`CompiledCode::lex_scopes`] for the lexical scope chain
+    /// visible at this site, which the popped name needs when it turns out to spell
+    /// an `OUTER::` / `OUTERS::` lookup.
+    SymbolicDeref {
+        sigil_idx: u32,
+        scopes_idx: u32,
+    },
 
     /// Symbolic variable dereference store: pop value and name from stack, store value into variable.
     /// The u32 indexes the constant pool for the sigil string ("$", "@", or "%").
@@ -1642,6 +1648,12 @@ pub(crate) struct CompiledCode {
     /// record it (e.g. hand-built `CompiledCode::new()` chunks), in which case
     /// precompute falls back to the by-name search.
     pub(crate) param_local_slots: Vec<u32>,
+    /// Out-of-band lexical scope chains for `SymbolicDeref` sites (indexed by the
+    /// op's `scopes_idx`). `$::($name)::x` can only be recognised as an `OUTER::`
+    /// lookup once the name string exists, by which time the compile-time scope
+    /// shape it must be answered against is gone — so the emit point bakes it here.
+    /// See [`crate::compiler::lex_scope::LexScopeChain`].
+    pub(crate) lex_scopes: Vec<Arc<crate::compiler::lex_scope::LexScopeChain>>,
     /// Pre-compiled closure bodies embedded in this code chunk.
     pub(crate) closure_compiled_codes: Vec<Arc<CompiledCode>>,
     /// Out-of-band named-argument specs for `CallFuncNamed` sites (indexed by
@@ -2026,6 +2038,7 @@ impl CompiledCode {
             our_locals: Vec::new(),
             scalar_bind_locals: Vec::new(),
             param_local_slots: Vec::new(),
+            lex_scopes: Vec::new(),
             closure_compiled_codes: Vec::new(),
             named_arg_specs: Vec::new(),
             closure_escapes: Vec::new(),
@@ -2395,7 +2408,7 @@ impl CompiledCode {
                 OpCode::GetCallerVar { .. }
                 | OpCode::GetOuterVar { .. }
                 | OpCode::GetPseudoStash(_)
-                | OpCode::SymbolicDeref(_)
+                | OpCode::SymbolicDeref { .. }
                 | OpCode::SymbolicDerefStore(_)
                 | OpCode::IndirectCodeLookup(_) => true,
                 OpCode::CallFunc { name_idx, .. } | OpCode::CallFuncNamed { name_idx, .. } => {
@@ -2888,6 +2901,29 @@ impl CompiledCode {
                     free.insert(Symbol::intern(name));
                 }
             }
+            // `$::($name)::x` is the same lexical read, with the target name known
+            // only at run time — so, unlike the `GetOuterVar` case above, there is
+            // no single name to snapshot. Claim every name the site's baked scope
+            // chain declares, which is exactly the set the deref could resolve to.
+            // Without this the enclosing binding is never snapshotted and
+            // `get_outer_var` falls through to the runtime scope stack, which inside
+            // a stored closure holds the CALLER's blocks — dynamic scope, and a
+            // different answer than the literal spelling gives.
+            //
+            // Only `outer_ref_names` is claimed, not `free`: a symbolic deref sets
+            // the reflective-access flag, which already makes `capture_closure_env`
+            // fall back to a whole-env `clone_env`, so every enclosing name is in the
+            // captured env regardless. Adding them to `free` would buy nothing and
+            // would freeze snapshots of names the body never reads.
+            if let OpCode::SymbolicDeref { scopes_idx, .. } = op
+                && let Some(chain) = self.lex_scopes.get(*scopes_idx as usize)
+            {
+                for name in chain.declared_names() {
+                    if !outer_ref_names.iter().any(|n| n == name) {
+                        outer_ref_names.push(name.to_string());
+                    }
+                }
+            }
             // Self-capturing declaration: `my $f = -> $n { ... $f($n-1) ... }`.
             // The initializer's closure-creation op snapshots the env BEFORE the
             // declaration's store runs, so the closure captures `$f` while it is
@@ -3317,6 +3353,18 @@ impl CompiledCode {
         let idx = self.closure_compiled_codes.len() as u32;
         self.closure_compiled_codes.push(Arc::new(code));
         self.closure_escapes.push(escapes);
+        idx
+    }
+
+    /// Bake one emit point's lexical scope chain, returning the index a
+    /// `SymbolicDeref` carries. Not deduped: symbolic deref is rare, and two
+    /// sites almost never share a chain anyway.
+    pub(crate) fn add_lex_scope_chain(
+        &mut self,
+        chain: crate::compiler::lex_scope::LexScopeChain,
+    ) -> u32 {
+        let idx = self.lex_scopes.len() as u32;
+        self.lex_scopes.push(Arc::new(chain));
         idx
     }
 

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4011,8 +4011,11 @@ impl Interpreter {
                 self.exec_indirect_code_lookup_op(code, *name_idx);
                 *ip += 1;
             }
-            OpCode::SymbolicDeref(sigil_idx) => {
-                self.exec_symbolic_deref_op(code, *sigil_idx);
+            OpCode::SymbolicDeref {
+                sigil_idx,
+                scopes_idx,
+            } => {
+                self.exec_symbolic_deref_op(code, *sigil_idx, *scopes_idx);
                 *ip += 1;
             }
             OpCode::SymbolicDerefStore(sigil_idx) => {

--- a/src/vm/vm_misc_codevar.rs
+++ b/src/vm/vm_misc_codevar.rs
@@ -1,6 +1,17 @@
 use super::*;
+use crate::compiler::Compiler;
+use crate::compiler::lex_scope::OuterResolution;
 
 impl Interpreter {
+    /// The env/local key a symbolically-derefed `name` lives under. Scalars are
+    /// stored bare (`$::("x")` -> `x`); `@`/`%` keep their sigil.
+    fn sigiled_name(sigil: &str, name: &str) -> String {
+        match sigil {
+            "@" | "%" => format!("{}{}", sigil, name),
+            _ => name.to_string(),
+        }
+    }
+
     pub(super) fn exec_get_capture_var_op(&mut self, code: &CompiledCode, name_idx: u32) {
         let name = Self::const_str(code, name_idx);
         let val = if let Some(v) = self.env().get(name).cloned() {
@@ -90,7 +101,16 @@ impl Interpreter {
 
     /// Execute symbolic variable dereference: $::("name"), @::("name"), %::("name").
     /// Pops the name string from the stack, prepends the sigil, and looks up the variable.
-    pub(super) fn exec_symbolic_deref_op(&mut self, code: &CompiledCode, sigil_idx: u32) {
+    ///
+    /// The popped name can spell a pseudo-package the literal form resolves at
+    /// compile time (`$::($outer)::x` is the same lookup as `$OUTER::x`), so this
+    /// mirrors the prefix dispatch of `Compiler::emit_var_access`.
+    pub(super) fn exec_symbolic_deref_op(
+        &mut self,
+        code: &CompiledCode,
+        sigil_idx: u32,
+        scopes_idx: u32,
+    ) {
         let sigil = Self::const_str(code, sigil_idx).to_string();
         let name_val = self.stack.pop().unwrap_or(Value::NIL);
         let name = name_val.to_string_value();
@@ -111,24 +131,42 @@ impl Interpreter {
             remaining = rest;
         }
         if caller_depth > 0 {
-            let bare_name = match sigil.as_str() {
-                "$" => remaining.to_string(),
-                "@" => format!("@{}", remaining),
-                "%" => format!("%{}", remaining),
-                _ => remaining.to_string(),
-            };
             let val = self
-                .get_caller_var(&bare_name, caller_depth)
+                .get_caller_var(&Self::sigiled_name(&sigil, remaining), caller_depth)
                 .unwrap_or(Value::NIL);
             self.stack.push(val);
             return;
         }
-        let lookup_name = match sigil.as_str() {
-            "$" => name.to_string(),
-            "@" => format!("@{}", name),
-            "%" => format!("%{}", name),
-            _ => name.to_string(),
-        };
+        // OUTERS:: / OUTER:: — a lexical walk, so it is answered against the scope
+        // chain the compiler saw at this site (baked in `code.lex_scopes`), NOT the
+        // runtime scope stack: inside a stored closure the latter holds the CALLER's
+        // blocks, which is dynamic scope and would give a different answer. This is
+        // the same resolution `$OUTER::x` gets in `Compiler::emit_outer_var_access`;
+        // only the moment the name becomes known differs.
+        if let Some(chain) = code.lex_scopes.get(scopes_idx as usize) {
+            let resolution = if let Some(rest) = Compiler::parse_outers_prefix(&name) {
+                let bare = Self::sigiled_name(&sigil, &rest);
+                let res = chain.resolve_outers(&bare);
+                Some((bare, res))
+            } else if let Some((rest, depth)) = Compiler::parse_outer_prefix(&name) {
+                let bare = Self::sigiled_name(&sigil, &rest);
+                let res = chain.resolve_outer(&bare, depth);
+                Some((bare, res))
+            } else {
+                None
+            };
+            if let Some((bare, res)) = resolution {
+                let val = match res {
+                    OuterResolution::NotDeclared => Value::NIL,
+                    OuterResolution::Read { depth, slot } => {
+                        self.get_outer_var(code, &bare, depth, slot)
+                    }
+                };
+                self.stack.push(val);
+                return;
+            }
+        }
+        let lookup_name = Self::sigiled_name(&sigil, &name);
         let val = self
             .get_env_with_main_alias(&lookup_name)
             .unwrap_or(Value::NIL);

--- a/t/pseudo-outer-indirect.t
+++ b/t/pseudo-outer-indirect.t
@@ -1,0 +1,74 @@
+use v6;
+use Test;
+
+plan 12;
+
+# `$::($name)::x` is the same lookup as `$OUTER::x`, only spelled with a package
+# name that does not exist until run time. The invariant this file pins is that
+# the two spellings never drift: the indirect form must be answered against the
+# LEXICAL scope chain at the deref site, exactly as the compiler answers the
+# literal one. Assertions are written as "indirect eqv direct" wherever the
+# value itself is not the interesting part.
+
+my $outer  = 'OUTER';
+my $outers = 'OUTERS';
+
+my $x = 102;
+my $y = 103;
+{
+    my $x = 104;
+    is $::($outer)::x, 102, '::("OUTER") reads the next outer scope';
+    is $::($outer)::x, $OUTER::x, '::("OUTER") agrees with the literal spelling';
+
+    {
+        my $x = 105;
+        my $y = 106;
+        is $::($outers)::y, 103, '::("OUTERS") keeps going until a match';
+        is $::($outers)::y, $OUTERS::y, '::("OUTERS") agrees with the literal';
+        is $::($outer)::($outer)::x, 102, '::("OUTER")::("OUTER") walks two scopes';
+        is $::($outer)::($outer)::x, $OUTER::OUTER::x,
+            '::("OUTER")::("OUTER") agrees with the literal';
+    }
+}
+
+# OUTER names exactly ONE scope, so a name only an outer-outer scope declares is
+# not found -- the indirect form must not soften that into an OUTERS cascade.
+{
+    my $only-here = 'deep';
+    {
+        {
+            ok !defined($::($outer)::only-here), '::("OUTER") does not cascade';
+            is $::($outers)::only-here, 'deep', '::("OUTERS") does cascade';
+        }
+    }
+}
+
+# A block is itself a scope, so a closure's OUTER:: is the block that encloses
+# it lexically -- never its caller's scope, even though the caller's blocks are
+# what the runtime scope stack holds by the time the closure runs.
+sub call-it($f) { my $c = 'callee-scope'; $f() }
+{
+    my $c = 'outer-scope';
+    {
+        my $c = 'enclosing-scope';
+        is call-it({ $::($outer)::c }), 'enclosing-scope',
+            '::("OUTER") in a closure is lexical, not the caller';
+        is call-it({ $::($outer)::c }), call-it({ $OUTER::c }),
+            '... and agrees with the literal spelling';
+    }
+}
+
+# Parameters are declarations of their routine's scope.
+sub with-param($p) { { $::($outer)::p } }
+is with-param(42), 42, '::("OUTER") sees a parameter of the enclosing routine';
+
+# The pseudo-package name is a plain expression, not a literal.
+{
+    my $z = 7;
+    {
+        my $z = 8;
+        is $::('OUT' ~ 'ER')::z, 7, 'the package name can be computed';
+    }
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
## What

`$OUTER::x` is settled by the compiler: which binding it names is a *lexical* question, so `emit_outer_var_access` answers it from `local_scopes` and emits the answer (#4667). The indirect spelling `$::($name)::x` is the **same lookup** with the package name computed at run time, so it never reached that walk at all — it fell through to a plain env lookup and produced `Nil`.

```raku
my $outer = 'OUTER';
my $x = 102;
{
    my $x = 104;
    say $OUTER::x;        # 102  (both)
    say $::($outer)::x;   # 102 in raku; Nil in mutsu before this PR
}
```

## How

The fix is to give the VM the *compiler's inputs*, not a second implementation.

- **`compiler/lex_scope.rs`** — one resolver for `OUTER::`/`OUTERS::`, taking the scope chain as plain data. The compiler calls it with its live fields; a `SymbolicDeref` site bakes the chain into the code chunk (`CompiledCode::lex_scopes`) and the VM calls it with that. Both hand over the same chain (`Compiler::full_scope_chain`), so the two spellings cannot drift.
- **`Compiler::enclosing_scopes`** — carries the enclosing compilation's chain into a nested body's compiler. `local_scopes` stops at the closure boundary because slot allocation does, but the lexical chain does not, and a symbolic deref learns its target name far too late to be answered any other way. (The literal form dodged this only because its name is statically known.)
- **`compute_free_vars`** — a symbolic-deref site claims its whole chain for `outer_ref_names`, since there is no single name to snapshot. Without this the enclosing binding is never snapshotted and `get_outer_var` falls back to the runtime scope stack — which inside a stored closure holds the **CALLER's** blocks, i.e. dynamic scope. Only `outer_ref_names` is claimed, not `free`: a symbolic deref already forces a whole-env `clone_env` capture via the reflective-access flag.

## Results

`roast/6.c/S02-names/pseudo-6c.t`: **fails 56 → 52** (130 `::("OUTER")`, 132 `::("OUTERS")`, 134 `::("OUTER")::("OUTER")`, 136 `::("OUTER") is not CALLER::`).

`make test`: 1797 files / 17563 tests PASS. New pin: `t/pseudo-outer-indirect.t` (12 tests, green under raku too — assertions are written as "indirect eqv direct" so they pin the invariant rather than one spelling's value).

## Verified against raku

raku corrected two of my assumptions, both now recorded in `TODO_roast/BLOCKERS.md`:

- a closure `{ $OUTER::c }` **is itself a scope**, so its `OUTER` is the block *enclosing the closure*, not the closure's caller;
- an undeclared `$OUTER::x` is a **`Failure`** in raku but `Nil` in mutsu — a pre-existing divergence this PR leaves alone (untested by this roast file).

## BLOCKERS.md re-measured

The ledger claimed the remaining failures were one gap ("the indirect deref"). Measuring says three unrelated ones, so the row and the priority list are re-split:

- **`CALLERS::` (119-127)** fails in the **direct** spelling too → a missing *feature* (the caller-axis twin of `OUTERS::`, belonging in `get_caller_var`), not a deref gap. Largest remaining cluster and the next slice.
- **`::("OUR")`/`::("CORE")`/`::("GLOBAL")`/`::("PROCESS")`** parse to `IndirectTypeLookup($x).WHO.{'$y'}` — a **stash** road, a different mechanism from this PR's `SymbolicDeref` road.

🤖 Generated with [Claude Code](https://claude.com/claude-code)