### PR TITLE
fix: statement-position from-json/to-json with named args dispatches

### DIFF
--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -442,6 +442,14 @@ impl Interpreter {
                         attrs,
                     )));
                     return Err(err);
+                } else if let Some(result) = self.try_native_json_function(name, &args) {
+                    // JSON::Fast/JSON::Tiny to-json/from-json in STATEMENT
+                    // position with named args (`from-json($t, :$immutable);`
+                    // inside a try) reaches exec_call via ExecCallPairs; the
+                    // expression path dispatches these in vm_call_func_ops.
+                    // Placed after user-sub resolution so a user-defined
+                    // from-json still wins.
+                    result?;
                 } else {
                     return Err(RuntimeError::new(format!("Unknown call: {}", name)));
                 }

--- a/src/vm/vm_native_json.rs
+++ b/src/vm/vm_native_json.rs
@@ -16,7 +16,7 @@ impl Interpreter {
     /// handled, `None` to let the caller fall through unchanged (so a
     /// user-defined `sub to-json { … }` still wins, since user resolution runs
     /// before this).
-    pub(super) fn try_native_json_function(
+    pub(crate) fn try_native_json_function(
         &mut self,
         name: &str,
         args: &[Value],

--- a/t/json-stmt-named-args.t
+++ b/t/json-stmt-named-args.t
@@ -1,0 +1,35 @@
+use v6;
+use JSON::Fast;
+use Test;
+
+# A native-module routine (from-json/to-json) called in STATEMENT position
+# with a named argument compiles to ExecCallPairs -> exec_call, which had no
+# native-JSON dispatch and died "Unknown call: from-json". This is the
+# JSON::Fast t/01-parse.t shape (mzef Test phase):
+#     try { from-json($t, :$immutable); $parsed = True; }
+
+plan 4;
+
+my $parsed = False;
+try {
+    from-json(Q<{ "a": 1 }>, :immutable(False));
+    $parsed = True;
+}
+ok $parsed, 'statement-position from-json with a named arg runs';
+
+sub run-one($t, Bool :$immutable) {
+    my Bool $ok = False;
+    try {
+        from-json($t, :$immutable);
+        $ok = True;
+    }
+    $ok;
+}
+ok run-one(Q<[1, 2]>), 'the forwarded-named-arg sub shape works';
+nok run-one(Q<[1, 2>), 'a genuinely broken document still fails';
+
+try {
+    to-json({ a => 1 }, :pretty(False));
+    $parsed = 'to-json-ok';
+}
+is $parsed, 'to-json-ok', 'statement-position to-json with a named arg runs';


### PR DESCRIPTION
## Summary

A native-module routine (`JSON::Fast`/`JSON::Tiny` `from-json`/`to-json`) called in **statement position with a named argument** compiles to `ExecCallPairs` → `exec_call`, which had no native-JSON dispatch and died `Unknown call: from-json`. The expression path already dispatched these via `try_native_json_function` in `vm_call_func_ops`.

This is JSON::Fast's own `t/01-parse.t` shape, hit in the mzef Test phase:

```raku
try {
    from-json($t, :$immutable);   # statement position + named arg
    $parsed = True;
}
```

The `try` swallowed the "Unknown call" error, `$parsed` stayed False, and every parse test reported failure.

The new hook sits **after** user-sub resolution in `exec_call`, so a user-defined `from-json` still wins — mirroring the expression path's ordering. (`try_native_json_function` visibility widened to `pub(crate)`.)

## Testing

- Pin: `t/json-stmt-named-args.t` (4 tests: statement-position from-json/to-json with named args, forwarded-named-arg sub shape, genuine-failure negative case)
- `make test`: 1798 files / 17563 tests PASS
- roast: S24-testing (17 files) PASS — exec_call is the Test-function statement path, so this subset covers the touched dispatch chain
- JSON::Fast's staged `t/01-parse.t`: all-fail → 664/724 (the remaining 60 are native-JSON strictness fidelity gaps — mutsu's native implementation accepts some invalid JSON the real parser rejects; tracked in the mzef pipeline doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)