### PR TITLE
feat: RakuAST Phase 2 slice 1 — variables, my-declarations, operators

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -747,8 +747,14 @@ so it is tracked separately from the roast backlog.
 - [ ] **Phase 1 — introspection MVP**: `Value::RakuAst` + `RakuAstClass` enum + class-metadata table;
       `Q|...|.AST` on `Str` for the literal + say-call cluster; `.gist`/`.raku`/`.^name` renderer
       matching raku exactly. Tests in `t/rakuast-ast.t`.
-- [ ] **Phase 2** — read-coverage expansion (var/decl/ops/calls/blocks/conditionals/loops/subs/sigs)
-      + `.DEPARSE`; resolve the constant-folding divergence.
+- **Phase 2 (in progress)** — read-coverage expansion.
+  - [x] Slice 1: Var::Lexical (all sigils), VarDeclaration::Simple + Initializer::Assign (plain
+        `my $x [= expr]`), ApplyInfix/ApplyPrefix/ApplyPostfix + Infix/Prefix/Postfix. Tests in
+        `t/rakuast-expr.t`.
+  - [ ] Slice 2+: assignment (`Assignment` node), method calls, blocks & pointy blocks,
+        `if`/`unless`/`with`, loops, sub declarations, signatures & parameters; scoped/typed
+        `my`; then `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to
+        `IntLiteral(3)`, mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/src/compiler/helpers_ops.rs
+++ b/src/compiler/helpers_ops.rs
@@ -1,7 +1,7 @@
 use crate::token_kind::TokenKind;
 
 /// Convert a `TokenKind` to its operator name string for runtime dispatch.
-pub(super) fn token_kind_to_op_name(op: &TokenKind) -> String {
+pub(crate) fn token_kind_to_op_name(op: &TokenKind) -> String {
     match op {
         TokenKind::Ident(name) => name.clone(),
         TokenKind::Plus => "+".to_string(),

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -48,7 +48,7 @@ mod helpers_call_args;
 mod helpers_control_flow;
 mod helpers_do_expr;
 mod helpers_dynamic;
-mod helpers_ops;
+pub(crate) mod helpers_ops;
 mod helpers_phasers;
 mod helpers_stmt_analysis;
 mod helpers_sub_body;

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -1,11 +1,13 @@
 //! Internal AST (`Stmt`/`Expr`) → RakuAST node tree (read direction, ADR-0011).
 //!
-//! Phase 1 covers the literal + say-call cluster. Constructs outside that set
-//! produce an explicit `RuntimeError` (the documented Phase-1 boundary) rather
-//! than a silently-wrong node.
+//! Covered so far: the literal + say-call cluster (Phase 1) and variables,
+//! plain `my` declarations, and infix/prefix/postfix operators (Phase 2).
+//! Constructs outside that set produce an explicit `RuntimeError` (the
+//! documented coverage boundary) rather than a silently-wrong node.
 
 use super::{RakuAstClass, RakuAstField, RakuAstFieldValue, RakuAstNode};
 use crate::ast::{Expr, Stmt};
+use crate::compiler::helpers_ops::token_kind_to_op_name;
 use crate::value::{RuntimeError, Value, ValueView};
 
 fn unsupported(what: &str) -> RuntimeError {
@@ -55,7 +57,78 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
         Stmt::Put(args) => Ok(Some(statement_expression(listop_call("put", args)?))),
         Stmt::Print(args) => Ok(Some(statement_expression(listop_call("print", args)?))),
         Stmt::Note(args) => Ok(Some(statement_expression(listop_call("note", args)?))),
+        Stmt::VarDecl {
+            name,
+            expr,
+            type_constraint,
+            is_state,
+            is_our,
+            is_dynamic,
+            custom_traits,
+            where_constraint,
+            ..
+        } => {
+            // Phase 2 covers only the plain `my $x [= expr]` form; scoped/typed
+            // declarations map to extra RakuAST fields not yet modelled.
+            if type_constraint.is_some()
+                || *is_state
+                || *is_our
+                || *is_dynamic
+                || where_constraint.is_some()
+            {
+                return Err(unsupported("scoped/typed variable declaration"));
+            }
+            let has_initializer = custom_traits
+                .iter()
+                .any(|(name, _)| name == "__has_initializer");
+            Ok(Some(statement_expression(var_declaration(
+                name,
+                expr,
+                has_initializer,
+            )?)))
+        }
         other => Err(unsupported(&format!("{other:?}"))),
+    }
+}
+
+/// `my $x` / `my @a` / `my $x = EXPR` -> `VarDeclaration::Simple`. The sigil is
+/// implicit (`$`) when mutsu already stripped it from the name; otherwise the
+/// name carries its `@`/`%`/`&` sigil.
+fn var_declaration(
+    name: &str,
+    init_expr: &Expr,
+    has_initializer: bool,
+) -> Result<RakuAstNode, RuntimeError> {
+    let (sigil, desigil) = split_sigil(name);
+    let name_node = RakuAstNode {
+        class: RakuAstClass::Name,
+        fields: vec![leaf_field(None, Value::str(desigil.to_string()))],
+    };
+    let mut fields = vec![
+        leaf_field(Some("sigil"), Value::str(sigil.to_string())),
+        node_field(Some("desigilname"), name_node),
+    ];
+    if has_initializer {
+        let assign = RakuAstNode {
+            class: RakuAstClass::InitializerAssign,
+            fields: vec![node_field(None, convert_expr(init_expr)?)],
+        };
+        fields.push(node_field(Some("initializer"), assign));
+    }
+    Ok(RakuAstNode {
+        class: RakuAstClass::VarDeclarationSimple,
+        fields,
+    })
+}
+
+/// Split a declaration name into `(sigil, desigilname)`. mutsu keeps the sigil
+/// on `@`/`%`/`&` declarations but strips it from `$` ones.
+fn split_sigil(name: &str) -> (&str, &str) {
+    match name.as_bytes().first() {
+        Some(b'@') => ("@", &name[1..]),
+        Some(b'%') => ("%", &name[1..]),
+        Some(b'&') => ("&", &name[1..]),
+        _ => ("$", name),
     }
 }
 
@@ -70,7 +143,60 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
     match expr {
         Expr::Literal(v) | Expr::LiteralSrc(v, _) => convert_literal(v),
         Expr::Call { name, args } => Ok(call_name(name.as_str(), args, false)?),
+        Expr::Var(name) => Ok(var_lexical("$", name)),
+        Expr::ArrayVar(name) => Ok(var_lexical("@", name)),
+        Expr::HashVar(name) => Ok(var_lexical("%", name)),
+        Expr::CodeVar(name) => Ok(var_lexical("&", name)),
+        Expr::Binary { left, op, right } => Ok(RakuAstNode {
+            class: RakuAstClass::ApplyInfix,
+            fields: vec![
+                node_field(Some("left"), convert_expr(left)?),
+                node_field(Some("infix"), operator_node(RakuAstClass::Infix, op)),
+                node_field(Some("right"), convert_expr(right)?),
+            ],
+        }),
+        Expr::Unary { op, expr } => Ok(RakuAstNode {
+            class: RakuAstClass::ApplyPrefix,
+            fields: vec![
+                node_field(Some("prefix"), operator_node(RakuAstClass::Prefix, op)),
+                node_field(Some("operand"), convert_expr(expr)?),
+            ],
+        }),
+        Expr::PostfixOp { op, expr } => Ok(RakuAstNode {
+            class: RakuAstClass::ApplyPostfix,
+            fields: vec![
+                node_field(Some("operand"), convert_expr(expr)?),
+                node_field(Some("postfix"), postfix_node(op)),
+            ],
+        }),
         other => Err(unsupported(&format!("{other:?}"))),
+    }
+}
+
+/// `$x` / `@a` / `%h` / `&f` usage -> `Var::Lexical("<sigil><name>")`.
+fn var_lexical(sigil: &str, name: &str) -> RakuAstNode {
+    RakuAstNode {
+        class: RakuAstClass::VarLexical,
+        fields: vec![leaf_field(None, Value::str(format!("{sigil}{name}")))],
+    }
+}
+
+/// `Infix`/`Prefix` — a single positional operator string (e.g. `Infix.new("+")`).
+fn operator_node(class: RakuAstClass, op: &crate::token_kind::TokenKind) -> RakuAstNode {
+    RakuAstNode {
+        class,
+        fields: vec![leaf_field(None, Value::str(token_kind_to_op_name(op)))],
+    }
+}
+
+/// `Postfix` — a single NAMED `operator` string (e.g. `Postfix.new(operator => "++")`).
+fn postfix_node(op: &crate::token_kind::TokenKind) -> RakuAstNode {
+    RakuAstNode {
+        class: RakuAstClass::Postfix,
+        fields: vec![leaf_field(
+            Some("operator"),
+            Value::str(token_kind_to_op_name(op)),
+        )],
     }
 }
 

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -53,6 +53,16 @@ pub enum RakuAstClass {
     CallNameWithoutParentheses,
     Name,
     ArgList,
+    // Phase 2: variables, declarations, operators.
+    VarLexical,
+    VarDeclarationSimple,
+    InitializerAssign,
+    ApplyInfix,
+    Infix,
+    ApplyPrefix,
+    Prefix,
+    ApplyPostfix,
+    Postfix,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -76,6 +86,15 @@ impl RakuAstClass {
             CallNameWithoutParentheses => "RakuAST::Call::Name::WithoutParentheses",
             Name => "RakuAST::Name",
             ArgList => "RakuAST::ArgList",
+            VarLexical => "RakuAST::Var::Lexical",
+            VarDeclarationSimple => "RakuAST::VarDeclaration::Simple",
+            InitializerAssign => "RakuAST::Initializer::Assign",
+            ApplyInfix => "RakuAST::ApplyInfix",
+            Infix => "RakuAST::Infix",
+            ApplyPrefix => "RakuAST::ApplyPrefix",
+            Prefix => "RakuAST::Prefix",
+            ApplyPostfix => "RakuAST::ApplyPostfix",
+            Postfix => "RakuAST::Postfix",
         }
     }
 
@@ -97,6 +116,10 @@ impl RakuAstClass {
             StatementExpression => 10,                  // "expression"
             QuotedString => 10,                         // "processors" (unshown) > "segments"
             CallName | CallNameWithoutParentheses => 4, // "name" / "args"
+            VarDeclarationSimple => 11,                 // "desigilname" / "initializer"
+            ApplyInfix => 5,                            // "infix" / "right"
+            ApplyPrefix | ApplyPostfix => 7,            // "operand"
+            Postfix => 8,                               // "operator"
             _ => 0,
         }
     }

--- a/src/rakuast/render.rs
+++ b/src/rakuast/render.rs
@@ -3,8 +3,10 @@
 //! Reproduces raku's constructor-form gist exactly: 2-space indent per level,
 //! named-arg keys left-padded to the class's alignment width, and
 //! `List`-valued fields printed as a parenthesised trailing-comma list. A node
-//! whose every field is a leaf literal renders inline on one line; any child
-//! node or list forces the multi-line form.
+//! renders inline on one line iff every field is a positional leaf literal (no
+//! named field, no child node, no list); any named field, child node, or list
+//! forces the multi-line form (e.g. `Postfix.new(operator => "++")` is
+//! multi-line despite its single leaf, because the field is named).
 
 use super::{Constructor, RakuAstField, RakuAstFieldValue, RakuAstNode};
 use crate::value::{Value, ValueView};
@@ -16,7 +18,11 @@ pub(super) fn render_node(node: &RakuAstNode, indent: usize) -> String {
         Constructor::FromIdentifier => "from-identifier",
     };
 
-    if node.fields.iter().all(is_leaf_field) {
+    if node
+        .fields
+        .iter()
+        .all(|f| f.name.is_none() && is_leaf_field(f))
+    {
         let inner = node
             .fields
             .iter()
@@ -117,6 +123,8 @@ fn render_str_literal(s: &str) -> String {
             '"' => out.push_str("\\\""),
             '$' => out.push_str("\\$"),
             '@' => out.push_str("\\@"),
+            '%' => out.push_str("\\%"),
+            '&' => out.push_str("\\&"),
             _ => out.push(c),
         }
     }

--- a/t/rakuast-expr.t
+++ b/t/rakuast-expr.t
@@ -1,0 +1,102 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 (ADR-0011): read-coverage for variables, declarations, and
+# infix/prefix/postfix operators. Expected gists captured verbatim from Rakudo.
+
+plan 9;
+
+# --- variable declaration (no initializer) ----------------------------------
+is Q[my $x].AST.gist, q:to/END/.chomp, 'VarDeclaration::Simple, $ sigil';
+RakuAST::StatementList.new(
+  RakuAST::Statement::Expression.new(
+    expression => RakuAST::VarDeclaration::Simple.new(
+      sigil       => "\$",
+      desigilname => RakuAST::Name.from-identifier("x")
+    )
+  )
+)
+END
+
+# --- @ sigil ----------------------------------------------------------------
+is Q[my @a].AST.gist, q:to/END/.chomp, 'VarDeclaration::Simple, @ sigil';
+RakuAST::StatementList.new(
+  RakuAST::Statement::Expression.new(
+    expression => RakuAST::VarDeclaration::Simple.new(
+      sigil       => "\@",
+      desigilname => RakuAST::Name.from-identifier("a")
+    )
+  )
+)
+END
+
+# --- declaration with initializer -------------------------------------------
+is Q[my $x = 5].AST.gist, q:to/END/.chomp, 'VarDeclaration::Simple + Initializer::Assign';
+RakuAST::StatementList.new(
+  RakuAST::Statement::Expression.new(
+    expression => RakuAST::VarDeclaration::Simple.new(
+      sigil       => "\$",
+      desigilname => RakuAST::Name.from-identifier("x"),
+      initializer => RakuAST::Initializer::Assign.new(
+        RakuAST::IntLiteral.new(5)
+      )
+    )
+  )
+)
+END
+
+# --- lexical variable usage -------------------------------------------------
+is Q[my $x; $x].AST.gist.contains('RakuAST::Var::Lexical.new("\$x")'), True,
+    'Var::Lexical for $ usage';
+is Q[my @a; @a].AST.gist.contains('RakuAST::Var::Lexical.new("\@a")'), True,
+    'Var::Lexical for @ usage';
+
+# --- infix operator ---------------------------------------------------------
+is Q[my $x; $x + 2].AST.gist, q:to/END/.chomp, 'ApplyInfix + Infix';
+RakuAST::StatementList.new(
+  RakuAST::Statement::Expression.new(
+    expression => RakuAST::VarDeclaration::Simple.new(
+      sigil       => "\$",
+      desigilname => RakuAST::Name.from-identifier("x")
+    )
+  ),
+  RakuAST::Statement::Expression.new(
+    expression => RakuAST::ApplyInfix.new(
+      left  => RakuAST::Var::Lexical.new("\$x"),
+      infix => RakuAST::Infix.new("+"),
+      right => RakuAST::IntLiteral.new(2)
+    )
+  )
+)
+END
+
+# --- prefix operator --------------------------------------------------------
+is Q[my $x; -$x].AST.gist.contains(q:to/FRAG/.chomp), True, 'ApplyPrefix + Prefix';
+    expression => RakuAST::ApplyPrefix.new(
+      prefix  => RakuAST::Prefix.new("-"),
+      operand => RakuAST::Var::Lexical.new("\$x")
+    )
+FRAG
+
+# --- postfix operator (named field -> multi-line) ---------------------------
+is Q[my $x; $x++].AST.gist.contains(q:to/FRAG/.chomp), True, 'ApplyPostfix + Postfix';
+    expression => RakuAST::ApplyPostfix.new(
+      operand => RakuAST::Var::Lexical.new("\$x"),
+      postfix => RakuAST::Postfix.new(
+        operator => "++"
+      )
+    )
+FRAG
+
+# --- nested infix respects precedence ---------------------------------------
+is Q[my $x; $x * 2 + 1].AST.gist.contains(q:to/FRAG/.chomp), True, 'nested ApplyInfix';
+    expression => RakuAST::ApplyInfix.new(
+      left  => RakuAST::ApplyInfix.new(
+        left  => RakuAST::Var::Lexical.new("\$x"),
+        infix => RakuAST::Infix.new("*"),
+        right => RakuAST::IntLiteral.new(2)
+      ),
+      infix => RakuAST::Infix.new("+"),
+      right => RakuAST::IntLiteral.new(1)
+    )
+FRAG


### PR DESCRIPTION
## What

Second slice of **RakuAST** (ADR-0011), extending `.AST` read coverage beyond
the Phase-1 literal + say-call cluster (#4679) to variables, `my` declarations,
and infix/prefix/postfix operators. All output is **byte-for-byte identical to
Rakudo**.

```raku
say Q|my $x; $x * 2 + 1|.AST;
# ... RakuAST::ApplyInfix.new(
#       left  => RakuAST::ApplyInfix.new(
#         left  => RakuAST::Var::Lexical.new("\$x"),
#         infix => RakuAST::Infix.new("*"),
#         right => RakuAST::IntLiteral.new(2)
#       ),
#       infix => RakuAST::Infix.new("+"),
#       right => RakuAST::IntLiteral.new(1)) ...
```

## Coverage added

- **`Var::Lexical`** for `$`/`@`/`%`/`&` variable usage (mutsu's `Var`/`ArrayVar`/
  `HashVar`/`CodeVar` → the full sigil-name string).
- **`VarDeclaration::Simple`** (+ `Initializer::Assign`) for plain `my $x` and
  `my $x = EXPR`. Scoped/typed declarations (`state`/`our`/dynamic/type/`where`)
  remain an explicit `RuntimeError` — deferred to a later slice.
- **`ApplyInfix`/`ApplyPrefix`/`ApplyPostfix`** with `Infix`/`Prefix`/`Postfix`
  operator nodes (mutsu's `Binary`/`Unary`/`PostfixOp`), reusing the compiler's
  `token_kind_to_op_name` table (promoted to `pub(crate)`).

## Renderer refinements

- Inline-vs-multiline rule tightened: a node renders inline only when **every
  field is a positional leaf**, so `Postfix.new(operator => "++")` (a *named*
  leaf) correctly renders multi-line.
- String-leaf escaping gains `%` and `&` to match `Str.raku` (`"50\%"`, `"a\&b"`).

## Tests

`t/rakuast-expr.t` (9 assertions) — expected gists captured verbatim from Rakudo;
**passes under both mutsu and raku**. `make test` green (1806 files / 17627 tests),
Phase-1 `t/rakuast-ast.t` still green.

Follow-up slices (assignment, method calls, blocks, conditionals, loops, subs,
signatures, `.DEPARSE`, const-folding) are tracked in `PLAN.md §7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)