### PR TITLE
feat: RakuAST Phase 2 slice 2 — = assignment and method calls

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -751,10 +751,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 1: Var::Lexical (all sigils), VarDeclaration::Simple + Initializer::Assign (plain
         `my $x [= expr]`), ApplyInfix/ApplyPrefix/ApplyPostfix + Infix/Prefix/Postfix. Tests in
         `t/rakuast-expr.t`.
-  - [ ] Slice 2+: assignment (`Assignment` node), method calls, blocks & pointy blocks,
-        `if`/`unless`/`with`, loops, sub declarations, signatures & parameters; scoped/typed
-        `my`; then `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to
-        `IntLiteral(3)`, mutsu does not).
+  - [x] Slice 2: `=` assignment (`Assignment` node, `:item` for scalar targets) and method
+        calls (`Call::Method` as an `ApplyPostfix`). Tests in `t/rakuast-calls-assign.t`.
+  - [ ] Slice 3+: blocks & pointy blocks, `if`/`unless`/`with`, loops, sub declarations,
+        signatures & parameters; scoped/typed `my`; compound/`:=` assignment; method-call
+        modifiers; then `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds
+        to `IntLiteral(3)`, mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -1,12 +1,13 @@
 //! Internal AST (`Stmt`/`Expr`) → RakuAST node tree (read direction, ADR-0011).
 //!
-//! Covered so far: the literal + say-call cluster (Phase 1) and variables,
-//! plain `my` declarations, and infix/prefix/postfix operators (Phase 2).
-//! Constructs outside that set produce an explicit `RuntimeError` (the
-//! documented coverage boundary) rather than a silently-wrong node.
+//! Covered so far: the literal + say-call cluster (Phase 1); and variables,
+//! plain `my` declarations, infix/prefix/postfix operators, `=` assignment, and
+//! method calls (Phase 2). Constructs outside that set produce an explicit
+//! `RuntimeError` (the documented coverage boundary) rather than a
+//! silently-wrong node.
 
 use super::{RakuAstClass, RakuAstField, RakuAstFieldValue, RakuAstNode};
-use crate::ast::{Expr, Stmt};
+use crate::ast::{AssignOp, Expr, Stmt};
 use crate::compiler::helpers_ops::token_kind_to_op_name;
 use crate::value::{RuntimeError, Value, ValueView};
 
@@ -87,8 +88,42 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 has_initializer,
             )?)))
         }
+        Stmt::Assign { name, expr, op } => {
+            // Phase 2 slice 2 covers only plain `=`; `:=` (Bind) and match-assign
+            // map to distinct RakuAST nodes.
+            if !matches!(op, AssignOp::Assign) {
+                return Err(unsupported("non-`=` assignment"));
+            }
+            Ok(Some(statement_expression(assignment_infix(name, expr)?)))
+        }
         other => Err(unsupported(&format!("{other:?}"))),
     }
+}
+
+/// `$x = EXPR` -> `ApplyInfix(left => Var::Lexical, infix => Assignment, right)`.
+/// The `Assignment` node carries `:item` for scalar (`$`) targets; the list form
+/// (`@`/`%`) has no adverb.
+fn assignment_infix(name: &str, rhs: &Expr) -> Result<RakuAstNode, RuntimeError> {
+    let (sigil, desigil) = split_sigil(name);
+    let assignment = RakuAstNode {
+        class: RakuAstClass::Assignment,
+        fields: if sigil == "$" {
+            vec![RakuAstField {
+                name: None,
+                value: RakuAstFieldValue::Adverb("item"),
+            }]
+        } else {
+            vec![]
+        },
+    };
+    Ok(RakuAstNode {
+        class: RakuAstClass::ApplyInfix,
+        fields: vec![
+            node_field(Some("left"), var_lexical(sigil, desigil)),
+            node_field(Some("infix"), assignment),
+            node_field(Some("right"), convert_expr(rhs)?),
+        ],
+    })
 }
 
 /// `my $x` / `my @a` / `my $x = EXPR` -> `VarDeclaration::Simple`. The sigil is
@@ -169,8 +204,44 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
                 node_field(Some("postfix"), postfix_node(op)),
             ],
         }),
+        Expr::MethodCall {
+            target,
+            name,
+            args,
+            modifier,
+            quoted,
+        } => {
+            // Phase 2 slice 2 covers only plain `.method(...)`; modifier forms
+            // (`.?`/`.+`/`.*`) and quoted names map to distinct RakuAST nodes.
+            if modifier.is_some() || *quoted {
+                return Err(unsupported("method call modifier / quoted name"));
+            }
+            Ok(RakuAstNode {
+                class: RakuAstClass::ApplyPostfix,
+                fields: vec![
+                    node_field(Some("operand"), convert_expr(target)?),
+                    node_field(Some("postfix"), call_method(name.as_str(), args)?),
+                ],
+            })
+        }
         other => Err(unsupported(&format!("{other:?}"))),
     }
+}
+
+/// `.method` / `.method(args)` -> `Call::Method(name => Name, [args => ArgList])`.
+fn call_method(name: &str, args: &[Expr]) -> Result<RakuAstNode, RuntimeError> {
+    let name_node = RakuAstNode {
+        class: RakuAstClass::Name,
+        fields: vec![leaf_field(None, Value::str(name.to_string()))],
+    };
+    let mut fields = vec![node_field(Some("name"), name_node)];
+    if !args.is_empty() {
+        fields.push(node_field(Some("args"), arg_list(args)?));
+    }
+    Ok(RakuAstNode {
+        class: RakuAstClass::CallMethod,
+        fields,
+    })
 }
 
 /// `$x` / `@a` / `%h` / `&f` usage -> `Var::Lexical("<sigil><name>")`.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -36,6 +36,8 @@ pub enum RakuAstFieldValue {
     Node(Value),
     /// A parenthesised, trailing-comma list of child nodes (e.g. `segments`).
     List(Vec<Value>),
+    /// A boolean colonpair adverb rendered as `:name` (e.g. `Assignment.new(:item)`).
+    Adverb(&'static str),
 }
 
 /// Every known RakuAST node kind. Exhaustive `match` on this in the converter
@@ -63,6 +65,8 @@ pub enum RakuAstClass {
     Prefix,
     ApplyPostfix,
     Postfix,
+    Assignment,
+    CallMethod,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -95,7 +99,16 @@ impl RakuAstClass {
             Prefix => "RakuAST::Prefix",
             ApplyPostfix => "RakuAST::ApplyPostfix",
             Postfix => "RakuAST::Postfix",
+            Assignment => "RakuAST::Assignment",
+            CallMethod => "RakuAST::Call::Method",
         }
+    }
+
+    /// raku's `Assignment` gist omits the empty `()` for the list form
+    /// (`RakuAST::Assignment.new`), unlike the generic `.new()` (e.g. an empty
+    /// `StatementList` still prints `RakuAST::StatementList.new()`).
+    pub fn empty_parens_omitted(self) -> bool {
+        matches!(self, RakuAstClass::Assignment)
     }
 
     pub fn constructor(self) -> Constructor {
@@ -120,6 +133,7 @@ impl RakuAstClass {
             ApplyInfix => 5,                            // "infix" / "right"
             ApplyPrefix | ApplyPostfix => 7,            // "operand"
             Postfix => 8,                               // "operator"
+            CallMethod => 4,                            // "name" / "args"
             _ => 0,
         }
     }

--- a/src/rakuast/render.rs
+++ b/src/rakuast/render.rs
@@ -18,10 +18,19 @@ pub(super) fn render_node(node: &RakuAstNode, indent: usize) -> String {
         Constructor::FromIdentifier => "from-identifier",
     };
 
+    // A class-specific gist quirk: raku's `Assignment` list form omits even the
+    // empty parens (`RakuAST::Assignment.new`), unlike the generic `.new()`.
+    if node.fields.is_empty() && node.class.empty_parens_omitted() {
+        return format!("{name}.{ctor}");
+    }
+
+    // Inline when every field is a positional leaf or a colonpair adverb
+    // (`Assignment.new(:item)`); any named field, child node, or list forces
+    // the multi-line form.
     if node
         .fields
         .iter()
-        .all(|f| f.name.is_none() && is_leaf_field(f))
+        .all(|f| f.name.is_none() && is_inline_field(f))
     {
         let inner = node
             .fields
@@ -49,17 +58,19 @@ pub(super) fn render_node(node: &RakuAstNode, indent: usize) -> String {
     s
 }
 
-fn is_leaf_field(f: &RakuAstField) -> bool {
+fn is_inline_field(f: &RakuAstField) -> bool {
     match &f.value {
         RakuAstFieldValue::List(_) => false,
         RakuAstFieldValue::Node(v) => !matches!(v.view(), ValueView::RakuAst(_)),
+        RakuAstFieldValue::Adverb(_) => true,
     }
 }
 
 fn render_inline_field(f: &RakuAstField) -> String {
     let val = match &f.value {
         RakuAstFieldValue::Node(v) => render_leaf(v),
-        // Unreachable while all fields are leaves, but keep it total.
+        RakuAstFieldValue::Adverb(name) => return format!(":{name}"),
+        // Unreachable while all fields are inline leaves, but keep it total.
         RakuAstFieldValue::List(_) => "()".to_string(),
     };
     match f.name {
@@ -83,6 +94,7 @@ fn render_field_value(fv: &RakuAstFieldValue, indent: usize) -> String {
             _ => render_leaf(v),
         },
         RakuAstFieldValue::List(items) => render_paren_list(items, indent),
+        RakuAstFieldValue::Adverb(name) => format!(":{name}"),
     }
 }
 

--- a/t/rakuast-calls-assign.t
+++ b/t/rakuast-calls-assign.t
@@ -1,0 +1,85 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 2 (ADR-0011): assignment and method calls.
+# Expected gists captured verbatim from Rakudo.
+
+plan 8;
+
+# --- scalar assignment carries :item ----------------------------------------
+is Q[my $x; $x = 3].AST.gist.contains(q:to/FRAG/.chomp), True, 'scalar assignment -> Assignment.new(:item)';
+    expression => RakuAST::ApplyInfix.new(
+      left  => RakuAST::Var::Lexical.new("\$x"),
+      infix => RakuAST::Assignment.new(:item),
+      right => RakuAST::IntLiteral.new(3)
+    )
+FRAG
+
+# --- array assignment: list form has no adverb, no parens -------------------
+is Q[my @a; @a = 1].AST.gist.contains(q:to/FRAG/.chomp), True, 'array assignment -> Assignment.new';
+    expression => RakuAST::ApplyInfix.new(
+      left  => RakuAST::Var::Lexical.new("\@a"),
+      infix => RakuAST::Assignment.new,
+      right => RakuAST::IntLiteral.new(1)
+    )
+FRAG
+
+# --- hash assignment: also the list form ------------------------------------
+is Q[my %h; %h = 1].AST.gist.contains('infix => RakuAST::Assignment.new,'), True,
+    'hash assignment -> Assignment.new';
+
+# --- method call, no args ---------------------------------------------------
+is Q[my $x; $x.abs].AST.gist.contains(q:to/FRAG/.chomp), True, 'no-arg method call -> Call::Method';
+    expression => RakuAST::ApplyPostfix.new(
+      operand => RakuAST::Var::Lexical.new("\$x"),
+      postfix => RakuAST::Call::Method.new(
+        name => RakuAST::Name.from-identifier("abs")
+      )
+    )
+FRAG
+
+# --- method call with args --------------------------------------------------
+is Q[my $x; $x.round(2)].AST.gist.contains(q:to/FRAG/.chomp), True, 'method call with args -> ArgList';
+      postfix => RakuAST::Call::Method.new(
+        name => RakuAST::Name.from-identifier("round"),
+        args => RakuAST::ArgList.new(
+          RakuAST::IntLiteral.new(2)
+        )
+      )
+FRAG
+
+# --- method call on a literal -----------------------------------------------
+is Q["hi".uc].AST.gist.contains(q:to/FRAG/.chomp), True, 'method call on a QuotedString operand';
+    expression => RakuAST::ApplyPostfix.new(
+      operand => RakuAST::QuotedString.new(
+        segments   => (
+          RakuAST::StrLiteral.new("hi"),
+        )
+      ),
+      postfix => RakuAST::Call::Method.new(
+        name => RakuAST::Name.from-identifier("uc")
+      )
+    )
+FRAG
+
+# --- explicit empty parens still render no args -----------------------------
+is Q[my $x; $x.abs()].AST.gist.contains('RakuAST::Call::Method.new('), True,
+    'method call with empty parens';
+
+# --- chained method calls nest as postfix-on-postfix ------------------------
+is Q[my $x; $x.round(2).abs].AST.gist.contains(q:to/FRAG/.chomp), True, 'chained method calls nest';
+    expression => RakuAST::ApplyPostfix.new(
+      operand => RakuAST::ApplyPostfix.new(
+        operand => RakuAST::Var::Lexical.new("\$x"),
+        postfix => RakuAST::Call::Method.new(
+          name => RakuAST::Name.from-identifier("round"),
+          args => RakuAST::ArgList.new(
+            RakuAST::IntLiteral.new(2)
+          )
+        )
+      ),
+      postfix => RakuAST::Call::Method.new(
+        name => RakuAST::Name.from-identifier("abs")
+      )
+    )
+FRAG


### PR DESCRIPTION
## What

Third slice of **RakuAST** (ADR-0011), extending `.AST` read coverage to `=`
assignment and method calls. All output is **byte-for-byte identical to Rakudo**.

```raku
say Q|my $x; $x.round(2).abs|.AST;
# ... RakuAST::ApplyPostfix.new(
#       operand => RakuAST::ApplyPostfix.new(
#         operand => RakuAST::Var::Lexical.new("\$x"),
#         postfix => RakuAST::Call::Method.new(
#           name => RakuAST::Name.from-identifier("round"),
#           args => RakuAST::ArgList.new(RakuAST::IntLiteral.new(2)))),
#       postfix => RakuAST::Call::Method.new(
#         name => RakuAST::Name.from-identifier("abs"))) ...
```

## Coverage added

- **`=` assignment**: `$x = EXPR` → `ApplyInfix(left, infix => Assignment, right)`.
  The `Assignment` node carries the `:item` adverb for scalar (`$`) targets and
  renders as the bare `RakuAST::Assignment.new` (no parens) for the list form
  (`@`/`%`), matching raku's class-specific gist. `:=` (bind) and match-assign
  stay an explicit `RuntimeError`.
- **Method calls**: `$x.foo` / `$x.foo(args)` → `ApplyPostfix(operand, postfix =>
  Call::Method(name => Name, [args => ArgList]))`. Chained calls nest as
  postfix-on-postfix. Modifier forms (`.?`/`.+`/`.*`) and quoted names stay an
  explicit `RuntimeError`.

## Renderer additions

- `RakuAstFieldValue::Adverb` — colonpair boolean shorthand (`:item`).
- Per-class `empty_parens_omitted` flag for `Assignment`'s no-parens list form
  (an empty `StatementList` still prints the generic `.new()`).
- Inline rule now admits adverb fields.

## Tests

`t/rakuast-calls-assign.t` (8 assertions) — expected gists captured verbatim from
Rakudo; **passes under both mutsu and raku**. `make test` green; the Phase-1/2
`t/rakuast-*.t` files stay green.

Follow-up slices (blocks, conditionals, loops, subs, signatures, `.DEPARSE`,
const-folding) are tracked in `PLAN.md §7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)