### PR TITLE
fix: eight general bugs surfaced by the URI dist test suite

### DIFF
--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -123,6 +123,32 @@ impl Interpreter {
                     })
             });
             if has_visible_method {
+                // `self.new(:named)` on a concrete invocant whose class declares
+                // user multi `new` candidates that don't match: Mu.new(*%attrinit)
+                // is always available as a fallback multi candidate, exactly as
+                // `dispatch_new` provides for type-object targets. An explicit
+                // `proto method new` owns dispatch, so no fallback then. Gated on
+                // a concrete invocant: `dispatch_new`'s own user-new probe runs
+                // with a Package invocant and must surface no-match to reach its
+                // default-constructor fall-through (not recurse through here).
+                if method_name == "new"
+                    && matches!(
+                        inv_value.view(),
+                        ValueView::Instance { .. } | ValueView::Mixin(..)
+                    )
+                    && self
+                        .lookup_proto_method(receiver_class_name, "new")
+                        .is_none()
+                    && args
+                        .iter()
+                        .all(|a| matches!(a.view(), ValueView::Pair(..) | ValueView::ValuePair(..)))
+                {
+                    let v = self.dispatch_new(
+                        Value::package(crate::symbol::Symbol::intern(receiver_class_name)),
+                        args,
+                    )?;
+                    return Ok((v, None));
+                }
                 let sigs =
                     self.format_method_candidate_signatures(receiver_class_name, method_name);
                 let profile = self.format_call_arg_profile(&args);

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -250,6 +250,25 @@ impl Interpreter {
             .map(Vec::len)
             .unwrap_or(0);
         if sub_count < name_count {
+            // An aliased subrule call (`$<pl> = <G::list>`) must carry the
+            // called rule's full sub-match tree, not just its text: the rule
+            // already merged its rich subcap into the store under its own
+            // capture key, so clone that entry (span-checked) for the alias.
+            // Raku keeps BOTH captures (`$/.keys` is `(G::list pl)`).
+            let subrule_subcap = if group_subcap.is_none()
+                && let RegexAtom::Named(atom_name) = &token.atom
+            {
+                let spec = Self::parse_named_regex_lookup_spec(atom_name);
+                let own_key = spec
+                    .capture_name
+                    .clone()
+                    .or_else(|| (!spec.silent).then(|| spec.lookup_name.clone()));
+                own_key
+                    .and_then(|k| store.caps().named_subcaps.get(&k)?.last().cloned())
+                    .filter(|sc| sc.from == from && sc.to == to)
+            } else {
+                None
+            };
             let sub = if let Some(mut gs) = group_subcap.take() {
                 // Keep the group's nested captures, but pin the span/text to
                 // the aliased group's extent.
@@ -259,6 +278,8 @@ impl Interpreter {
                 gsm.match_from = from;
                 gsm.matched = captured.clone();
                 gs
+            } else if let Some(sc) = subrule_subcap {
+                sc
             } else {
                 std::sync::Arc::new(RegexCaptures {
                     from,

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -579,9 +579,14 @@ impl Interpreter {
                 (min_val, Some(parse_num(max_str)))
             }
         } else {
-            let exact = parse_num(count_str);
-            let exact = if exact == 0 { 1 } else { exact };
-            (exact, Some(exact))
+            // `** 0` is a valid "exactly zero times" quantifier (RFC 3986's
+            // `token path-empty { <.pchar> ** 0 }`); only an unparsable count
+            // falls back to 1.
+            let cleaned: String = count_str.chars().filter(|c| *c != '_').collect();
+            match cleaned.parse::<usize>() {
+                Ok(exact) => (exact, Some(exact)),
+                Err(_) => (1, Some(1)),
+            }
         }
     }
 

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -468,16 +468,16 @@ impl Interpreter {
     }
 
     /// Get the type constraint for a class attribute, searching MRO.
-    pub(super) fn get_attr_type_constraint(
+    pub(crate) fn get_attr_type_constraint(
         &self,
         class_name: &str,
         attr_name: &str,
     ) -> Option<String> {
-        if let Some(class_def) = self.registry().classes.get(class_name) {
-            for (name, _is_public, _default, _is_rw, _, _, _) in &class_def.attributes {
-                if name == attr_name {
-                    return class_def.attribute_types.get(attr_name).cloned();
-                }
+        for cls in self.mro_readonly(class_name) {
+            if let Some(class_def) = self.registry().classes.get(&cls)
+                && let Some(tc) = class_def.attribute_types.get(attr_name)
+            {
+                return Some(tc.clone());
             }
         }
         None

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -352,6 +352,18 @@ impl Interpreter {
     /// Compute the type hierarchy distance between a constraint and a value.
     /// 0 = exact match, larger = less specific.
     fn builtin_type_distance(constraint: &str, value: &Value) -> usize {
+        // `value_type_name(Nil)` reports "Any", so a Nil argument needs its own
+        // MRO here: a `(Nil)` candidate must out-narrow e.g. `(Str() $s)` for a
+        // literal Nil argument (URI's `authority(Nil)`).
+        if matches!(value.view(), ValueView::Nil) {
+            let nil_mro: &[&str] = &["Nil", "Cool", "Any", "Mu"];
+            for (i, &ancestor) in nil_mro.iter().enumerate() {
+                if ancestor == constraint {
+                    return i;
+                }
+            }
+            return 500;
+        }
         let value_type = super::value_type_name(value);
         if constraint == value_type {
             return 0;

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -36,6 +36,20 @@ impl Interpreter {
         }
     }
 
+    /// Stringify the smartmatch LHS for a regex match. An Instance whose class
+    /// defines a user `Str` method must match against that string (e.g. a
+    /// `URI::Path` object with `multi method Str` smartmatched against a path
+    /// regex); everything else keeps the plain value stringification.
+    fn regex_match_text(&mut self, left: &Value) -> String {
+        if let ValueView::Instance { class_name, .. } = left.view()
+            && self.has_user_method(&class_name.resolve(), "Str")
+            && let Ok(v) = self.call_method_with_values(left.clone(), "Str", vec![])
+        {
+            return v.to_string_value();
+        }
+        left.to_string_value()
+    }
+
     pub(crate) fn smart_match(&mut self, left: &Value, right: &Value) -> bool {
         // A first-class element container on the LHS (`ContainerRef`, e.g. a
         // `.grep(...).head` rw alias / `:=`-bound slot) is transparent to
@@ -205,7 +219,7 @@ impl Interpreter {
                     .extract_token_regex_pattern(&qualified)
                     .or_else(|| self.extract_token_regex_pattern(&name.resolve()))
                 {
-                    let text = left.to_string_value();
+                    let text = self.regex_match_text(left);
                     // Push routine frame so &?ROUTINE resolves inside code blocks
                     self.routine_stack.push(super::super::RoutineFrame {
                         package: package.resolve(),
@@ -266,7 +280,7 @@ impl Interpreter {
                 let pattern = &a.pattern;
                 let raw_nth = a.nth.as_ref().unwrap();
                 let perl5 = &a.perl5;
-                let text = left.to_string_value();
+                let text = self.regex_match_text(left);
                 let pattern = if *perl5 {
                     self.interpolate_regex_pattern(pattern)
                 } else {
@@ -393,7 +407,7 @@ impl Interpreter {
                 if a.continue_ && !a.global && !a.exhaustive && !a.overlap =>
             {
                 let pat = &a.pattern;
-                let text = left.to_string_value();
+                let text = self.regex_match_text(left);
                 let pat = pat.to_string();
                 let start_pos = self.get_match_to_position();
                 if let Some(captures) = self.regex_match_with_captures_from(&pat, &text, start_pos)
@@ -409,7 +423,7 @@ impl Interpreter {
                 if a.pos && !a.global && !a.exhaustive && !a.overlap =>
             {
                 let pat = &a.pattern;
-                let text = left.to_string_value();
+                let text = self.regex_match_text(left);
                 let pat = pat.to_string();
                 let start_pos = self.get_match_to_position();
                 if let Some(captures) = self.regex_match_with_captures_at(&pat, &text, start_pos) {
@@ -427,7 +441,7 @@ impl Interpreter {
                 let pattern = &a.pattern;
                 let needed = &a.repeat.unwrap();
                 let perl5 = &a.perl5;
-                let text = left.to_string_value();
+                let text = self.regex_match_text(left);
                 let pattern = if *perl5 {
                     self.interpolate_regex_pattern(pattern)
                 } else {
@@ -460,7 +474,7 @@ impl Interpreter {
                 let pattern = &a.pattern;
                 let repeat = &a.repeat;
                 let perl5 = &a.perl5;
-                let text = left.to_string_value();
+                let text = self.regex_match_text(left);
                 let pattern = if *perl5 {
                     self.interpolate_regex_pattern(pattern)
                 } else {
@@ -519,7 +533,7 @@ impl Interpreter {
             (_, ValueView::RegexWithAdverbs(a)) if a.overlap => {
                 let pattern = &a.pattern;
                 let perl5 = &a.perl5;
-                let text = left.to_string_value();
+                let text = self.regex_match_text(left);
                 let pattern = if *perl5 {
                     self.interpolate_regex_pattern(pattern)
                 } else {
@@ -562,7 +576,7 @@ impl Interpreter {
                 let pattern = &a.pattern;
                 let repeat = &a.repeat;
                 let perl5 = &a.perl5;
-                let text = left.to_string_value();
+                let text = self.regex_match_text(left);
                 let pattern = if *perl5 {
                     self.interpolate_regex_pattern(pattern)
                 } else {
@@ -648,7 +662,7 @@ impl Interpreter {
                     ValueView::RegexWithAdverbs(a) => a.pattern.to_string(),
                     _ => unreachable!(),
                 };
-                let text = left.to_string_value();
+                let text = self.regex_match_text(left);
                 // Set $_ to the match target so $( $_ ) works inside regex
                 let saved_topic = self.env.get("_").cloned();
                 self.env.insert("_".to_string(), Value::str(text.clone()));
@@ -765,7 +779,7 @@ impl Interpreter {
                 if !a.global && !a.exhaustive && !a.overlap && a.perl5 =>
             {
                 let pat = &a.pattern;
-                let text = left.to_string_value();
+                let text = self.regex_match_text(left);
                 let pat = self.interpolate_regex_pattern(pat);
                 #[cfg(feature = "pcre2")]
                 let result = self.regex_match_with_captures_p5(&pat, &text);

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -330,6 +330,15 @@ impl Interpreter {
         if constraint == "NaN" {
             return matches!(value.view(), ValueView::Num(n) if n.is_nan());
         }
+        if constraint == "Nil" {
+            // A `Nil` parameter/constraint accepts only Nil itself (and
+            // Failure, which is a Nil subclass) — NOT arbitrary undefined
+            // values. Needed so `multi method m(Nil)` out-narrows a coercion
+            // candidate like `m(Str() $s)` for a literal Nil argument.
+            return matches!(value.view(), ValueView::Nil)
+                || matches!(value.view(), ValueView::Instance { class_name, .. } if class_name.as_str() == "Failure")
+                || matches!(value.view(), ValueView::Package(name) if name == "Nil");
+        }
         if constraint == "UInt" {
             return match value.view() {
                 ValueView::Int(i) => i >= 0,

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1061,7 +1061,14 @@ impl Interpreter {
                     // not a Hash with element-level type errors.
                     self.coerce_hash_var_value(&name, raw_val)?
                 } else if name.starts_with('@') {
-                    runtime::coerce_to_array(raw_val)
+                    if is_bind_ctx || is_rebind {
+                        // `:=` bind (e.g. `@!attr := @x.List`, `our @a := ...`)
+                        // preserves the container type instead of copying into
+                        // a fresh Array — same semantics as the SetLocal path.
+                        self.bind_positional_value(&name, &raw_val)?
+                    } else {
+                        runtime::coerce_to_array(raw_val)
+                    }
                 } else {
                     raw_val
                 };

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -841,10 +841,47 @@ impl Interpreter {
             && !name.contains("__mutsu")
             && self.var_default(name).is_none()
         {
+            // A typed scalar attribute (`has Foo $.f; ... $!f = Nil`) resets to
+            // its own type object, not Any. Attribute vars reach this untyped
+            // branch because their type lives in the class registry, not in a
+            // per-var constraint.
+            if let Some(attr) = name.strip_prefix('!').or_else(|| name.strip_prefix('.'))
+                && !attr.is_empty()
+                && let Some(tc) = self.self_attr_type_constraint(attr)
+            {
+                return Value::package(crate::symbol::Symbol::intern(&tc));
+            }
             Value::package(crate::symbol::Symbol::intern("Any"))
         } else {
             val
         }
+    }
+
+    /// Look up the declared type constraint of an attribute of the current
+    /// `self` instance, walking the MRO.
+    fn self_attr_type_constraint(&self, attr_name: &str) -> Option<String> {
+        let self_val = self.get_env_with_main_alias("self")?;
+        let class_name = self_val.with_deref(|v| match v.view() {
+            crate::value::ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
+            crate::value::ValueView::Mixin(inner, _) => match inner.view() {
+                crate::value::ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
+                _ => None,
+            },
+            _ => None,
+        })?;
+        let tc = self.get_attr_type_constraint(&class_name, attr_name)?;
+        // A nested class type (`class URI { class Authority {}; has Authority
+        // $.authority }`) is declared by its short name but registered fully
+        // qualified — resolve it so the reset type object dispatches methods.
+        if !self.registry().classes.contains_key(&tc) {
+            for cls in self.mro_readonly(&class_name) {
+                let qualified = format!("{}::{}", cls, tc);
+                if self.registry().classes.contains_key(&qualified) {
+                    return Some(qualified);
+                }
+            }
+        }
+        Some(tc)
     }
 
     /// De-itemize a `for … -> @a` chunk element while preserving its element

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -68,6 +68,121 @@ impl Interpreter {
         Some(Ok(()))
     }
 
+    /// `:=` bind of a Positional value to an `@`-sigiled target: preserves the
+    /// container type (e.g. List stays List) instead of copying into a fresh
+    /// Array. Shared by the SetLocal path (`my @x := ...`) and the SetGlobal
+    /// path (`@!attr := ...`, `our @x := ...`).
+    ///
+    /// Type-check: only Positional values can be bound to @-sigiled vars.
+    /// A single-index terminal element bind (`@x := @array[2]`) may arrive
+    /// here as a `ContainerRef` cell (promoted so a later whole-array
+    /// assignment writes through the source element) — decont it first so the
+    /// Positional check inspects the actual bound value, not the cell wrapper.
+    pub(crate) fn bind_positional_value(
+        &mut self,
+        name: &str,
+        raw_popped: &Value,
+    ) -> Result<Value, RuntimeError> {
+        let decontained_popped = raw_popped.deref_container();
+        let is_positional = match decontained_popped.view() {
+            ValueView::Array(..)
+            | ValueView::LazyList(_)
+            | ValueView::LazyIoLines { .. }
+            | ValueView::Seq(_)
+            | ValueView::Slip(_)
+            | ValueView::Range(..)
+            | ValueView::RangeExcl(..)
+            | ValueView::RangeExclStart(..)
+            | ValueView::RangeExclBoth(..)
+            | ValueView::GenericRange { .. }
+            | ValueView::Uni { .. }
+            | ValueView::Nil => true,
+            // Instance objects are Positional only if they implement
+            // the Positional role (or Array subclass etc.), but not
+            // Failure or arbitrary classes.
+            ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } => {
+                let cn = class_name.resolve();
+                matches!(
+                    cn.as_str(),
+                    "Array"
+                        | "List"
+                        | "Slip"
+                        | "Seq"
+                        | "Range"
+                        | "Buf"
+                        | "Blob"
+                        | "utf8"
+                        | "buf8"
+                        | "buf16"
+                        | "buf32"
+                ) || self
+                    .class_composed_roles(&cn)
+                    .is_some_and(|roles| roles.iter().any(|r| r == "Positional"))
+                    || attributes.contains_key("__mutsu_array_storage")
+            }
+            _ => false,
+        };
+        if !is_positional {
+            let got_type = crate::runtime::utils::value_type_name(raw_popped);
+            let mut attrs = std::collections::HashMap::new();
+            attrs.insert("got".to_string(), raw_popped.clone());
+            attrs.insert(
+                "expected".to_string(),
+                Value::package(crate::symbol::Symbol::intern("Positional")),
+            );
+            attrs.insert("symbol".to_string(), Value::str_from(name));
+            attrs.insert(
+                "message".to_string(),
+                Value::str(format!(
+                    "Type check failed in binding; expected Positional but got {}",
+                    got_type
+                )),
+            );
+            let ex = Value::make_instance(
+                crate::symbol::Symbol::intern("X::TypeCheck::Binding"),
+                attrs,
+            );
+            let mut err = RuntimeError::new(format!(
+                "Type check failed in binding; expected Positional but got {}",
+                got_type
+            ));
+            err.exception = Some(Box::new(ex));
+            return Err(err);
+        }
+        Ok(match raw_popped.view() {
+            // `:=` binds the container itself rather than copying values
+            // into a fresh Array, so — unlike plain `=` assignment, which
+            // must stay conservative about mutation support (see
+            // docs/lazy-arrays.md L2) — ANY genuinely-lazy list (gather
+            // coroutine, infinite sequence/closure spec, lazy pipe, scan)
+            // can be bound without forcing. A *plain* (non-`lazy`-marked)
+            // gather is `.is-lazy` False (`is_genuinely_lazy()` alone
+            // would miss it) but binding must still not force it — that
+            // is the whole point of `:=` vs `=` (t/gather-lazy.t tests
+            // 1/3) — so `coroutine.is_some()` is checked too. Tag it as
+            // living in `@` array context so gist/`.WHAT` render
+            // `[...]`/`Array` rather than `(...)`/`Seq`.
+            ValueView::LazyList(list) if list.coroutine.is_some() || list.is_genuinely_lazy() => {
+                Value::lazy_list(crate::gc::Gc::new(list.with_array_context()))
+            }
+            ValueView::LazyList(list) => Value::real_array(self.force_lazy_list_vm(&list)?),
+            ValueView::LazyIoLines { .. } => {
+                let forced = self.force_if_lazy_io_lines(raw_popped.clone())?;
+                Value::real_array(runtime::value_to_list(&forced))
+            }
+            // `@a := $x` strips the Scalar container: the @-var binds the
+            // Array itself (same backing data, plain kind), not the item.
+            ValueView::Array(items, kind) if kind.is_itemized() => {
+                Value::array_with_kind(items.clone(), kind.decontainerize())
+            }
+            _ => raw_popped.clone(),
+        })
+    }
+
     pub(super) fn exec_set_local_op(
         &mut self,
         code: &CompiledCode,
@@ -715,113 +830,7 @@ impl Interpreter {
                     ),
                 }
             } else if is_bind {
-                // `:=` binding preserves the container type (e.g. List stays List).
-                // Type-check: only Positional values can be bound to @-sigiled vars.
-                // A single-index terminal element bind (`@x := @array[2]`) may
-                // arrive here as a `ContainerRef` cell (promoted so a later
-                // whole-array assignment writes through the source element) —
-                // decont it first so the Positional check inspects the actual
-                // bound value, not the cell wrapper.
-                let decontained_popped = raw_popped.deref_container();
-                let is_positional = match decontained_popped.view() {
-                    ValueView::Array(..)
-                    | ValueView::LazyList(_)
-                    | ValueView::LazyIoLines { .. }
-                    | ValueView::Seq(_)
-                    | ValueView::Slip(_)
-                    | ValueView::Range(..)
-                    | ValueView::RangeExcl(..)
-                    | ValueView::RangeExclStart(..)
-                    | ValueView::RangeExclBoth(..)
-                    | ValueView::GenericRange { .. }
-                    | ValueView::Uni { .. }
-                    | ValueView::Nil => true,
-                    // Instance objects are Positional only if they implement
-                    // the Positional role (or Array subclass etc.), but not
-                    // Failure or arbitrary classes.
-                    ValueView::Instance {
-                        class_name,
-                        attributes,
-                        ..
-                    } => {
-                        let cn = class_name.resolve();
-                        matches!(
-                            cn.as_str(),
-                            "Array"
-                                | "List"
-                                | "Slip"
-                                | "Seq"
-                                | "Range"
-                                | "Buf"
-                                | "Blob"
-                                | "utf8"
-                                | "buf8"
-                                | "buf16"
-                                | "buf32"
-                        ) || self
-                            .class_composed_roles(&cn)
-                            .is_some_and(|roles| roles.iter().any(|r| r == "Positional"))
-                            || attributes.contains_key("__mutsu_array_storage")
-                    }
-                    _ => false,
-                };
-                if !is_positional {
-                    let got_type = crate::runtime::utils::value_type_name(&raw_popped);
-                    let mut attrs = std::collections::HashMap::new();
-                    attrs.insert("got".to_string(), raw_popped.clone());
-                    attrs.insert(
-                        "expected".to_string(),
-                        Value::package(crate::symbol::Symbol::intern("Positional")),
-                    );
-                    attrs.insert("symbol".to_string(), Value::str(name.clone()));
-                    attrs.insert(
-                        "message".to_string(),
-                        Value::str(format!(
-                            "Type check failed in binding; expected Positional but got {}",
-                            got_type
-                        )),
-                    );
-                    let ex = Value::make_instance(
-                        crate::symbol::Symbol::intern("X::TypeCheck::Binding"),
-                        attrs,
-                    );
-                    let mut err = RuntimeError::new(format!(
-                        "Type check failed in binding; expected Positional but got {}",
-                        got_type
-                    ));
-                    err.exception = Some(Box::new(ex));
-                    return Err(err);
-                }
-                match raw_popped.view() {
-                    // `:=` binds the container itself rather than copying values
-                    // into a fresh Array, so — unlike plain `=` assignment, which
-                    // must stay conservative about mutation support (see
-                    // docs/lazy-arrays.md L2) — ANY genuinely-lazy list (gather
-                    // coroutine, infinite sequence/closure spec, lazy pipe, scan)
-                    // can be bound without forcing. A *plain* (non-`lazy`-marked)
-                    // gather is `.is-lazy` False (`is_genuinely_lazy()` alone
-                    // would miss it) but binding must still not force it — that
-                    // is the whole point of `:=` vs `=` (t/gather-lazy.t tests
-                    // 1/3) — so `coroutine.is_some()` is checked too. Tag it as
-                    // living in `@` array context so gist/`.WHAT` render
-                    // `[...]`/`Array` rather than `(...)`/`Seq`.
-                    ValueView::LazyList(list)
-                        if list.coroutine.is_some() || list.is_genuinely_lazy() =>
-                    {
-                        Value::lazy_list(crate::gc::Gc::new(list.with_array_context()))
-                    }
-                    ValueView::LazyList(list) => Value::real_array(self.force_lazy_list_vm(&list)?),
-                    ValueView::LazyIoLines { .. } => {
-                        let forced = self.force_if_lazy_io_lines(raw_popped.clone())?;
-                        Value::real_array(runtime::value_to_list(&forced))
-                    }
-                    // `@a := $x` strips the Scalar container: the @-var binds the
-                    // Array itself (same backing data, plain kind), not the item.
-                    ValueView::Array(items, kind) if kind.is_itemized() => {
-                        Value::array_with_kind(items.clone(), kind.decontainerize())
-                    }
-                    _ => raw_popped.clone(),
-                }
+                self.bind_positional_value(name, &raw_popped)?
             } else {
                 match raw_popped.view() {
                     ValueView::LazyList(list) => {

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -149,7 +149,12 @@ impl Interpreter {
                     self.call_function_compiled_first(name, Vec::new(), compiled_fns)?
                 }
             } else if !name.starts_with('$') && !name.starts_with('@') && !name.starts_with('%') {
-                v.clone()
+                // A sigilless bind (`given ... -> \ex`, `ex := $_`) stores a
+                // shared ContainerRef cell in env; the bareword read must
+                // deliver the cell's value, not the wrapper — method dispatch
+                // on a raw ContainerRef misresolves (e.g. `ex.raku` on a bound
+                // instance rendered the type object).
+                v.deref_container()
             } else {
                 Value::str(name.to_string())
             }

--- a/t/attr-bind-list.t
+++ b/t/attr-bind-list.t
@@ -1,0 +1,46 @@
+use v6;
+use Test;
+
+plan 6;
+
+# An @-sigil attribute bound (`:=`) to a List keeps List-ness (URI::Path).
+class WithSegments {
+    has @.segments;
+    submethod BUILD(:@segments = ()) {
+        @!segments := @segments.List;
+    }
+}
+
+my $p = WithSegments.new(segments => ('', 'a', 'b'));
+isa-ok $p.segments, List, 'bound .List attribute is a List';
+is-deeply $p.segments, $('', 'a', 'b'), 'is-deeply sees a List, not an Array';
+
+# Plain assignment still coerces to Array.
+class WithArray {
+    has @.items;
+    submethod BUILD(:@items = ()) {
+        @!items = @items.List;
+    }
+}
+isa-ok WithArray.new(items => (1, 2)).items, Array, 'plain = assignment stays Array';
+
+# %-sigil bind keeps Map (regression guard for the sibling branch).
+class WithMap {
+    has %.h;
+    submethod BUILD(:%h = {}) {
+        %!h := %h.Map;
+    }
+}
+isa-ok WithMap.new(h => {a => 1}).h, Map, 'bound .Map attribute is a Map';
+
+# Binding a non-Positional to an @ attribute dies with X::TypeCheck::Binding.
+class BadBind {
+    has @.a;
+    method go() { @!a := 42 }
+}
+throws-like { BadBind.new.go }, X::TypeCheck::Binding,
+    'binding a non-Positional to @!attr throws X::TypeCheck::Binding';
+
+# `my @x := <list>` (SetLocal path) still preserves List.
+my @x := (1, 2, 3);
+isa-ok @x, List, 'my @x := (1,2,3) stays a List';

--- a/t/attr-nil-reset-typed.t
+++ b/t/attr-nil-reset-typed.t
@@ -1,0 +1,53 @@
+use v6;
+use Test;
+
+plan 7;
+
+# Assigning Nil to a typed scalar attribute resets it to the attribute's
+# own type object, not Any (URI's `$!authority = Nil`).
+class Foo {}
+class C {
+    has Foo $.f is rw;
+    multi method get(C:D: --> Foo) { $!f }
+    method reset() { $!f = Nil }
+}
+
+my $c = C.new;
+ok $c.get === Foo, 'unset typed attribute is its type object';
+$c.f = Foo.new;
+ok $c.get.defined, 'assigned attribute is defined';
+$c.reset;
+ok $c.get === Foo, '$!f = Nil resets to the type object';
+lives-ok { $c.get }, 'a --> Foo return constraint accepts the reset value';
+
+# Untyped attribute still resets to Any.
+class U {
+    has $.u is rw;
+    method reset() { $!u = Nil }
+}
+my $u = U.new(u => 42);
+$u.reset;
+ok $u.u === Any, 'untyped attribute resets to Any';
+
+# Nested class type: the reset type object dispatches methods (`.= new`).
+class Outer {
+    class Inner { has $.x }
+    has Inner $.i is rw;
+    method reset() { $!i = Nil }
+    method mk() { $!i .= new(x => 1) }
+}
+my $o = Outer.new;
+$o.reset;
+$o.mk;
+is $o.i.x, 1, 'reset nested-class attribute can .= new';
+
+# Inherited typed attribute resets via MRO walk (the reset method lives on
+# the parent; self is the Derived instance, so the type lookup walks the MRO).
+class Base {
+    has Foo $.g is rw;
+    method reset() { $!g = Nil }
+}
+class Derived is Base { }
+my $d = Derived.new(g => Foo.new);
+$d.reset;
+ok $d.g === Foo, 'inherited typed attribute resets to its type object';

--- a/t/given-sigilless-instance.t
+++ b/t/given-sigilless-instance.t
@@ -1,0 +1,24 @@
+use v6;
+use Test;
+
+plan 8;
+
+# `given EXPR -> \ex { }` binds the raw value; an object invocant must keep
+# its instance identity (URI's `given X::URI::Path::Invalid.new(...) -> \ex`).
+class K { has $.v }
+
+given K.new(v => 3) -> \ex {
+    is ex.^name, 'K', 'sigilless given param has the instance type';
+    is ex.v, 3, 'attribute access works on the bound instance';
+    is ex.raku, 'K.new(v => 3)', '.raku renders the instance';
+    ok ex === ex, 'repeated reads give the same value';
+}
+
+given X::AdHoc.new(payload => 'boom') -> \ex {
+    is ex.^name, 'X::AdHoc', 'exception instance binds correctly';
+    throws-like { ex.throw }, X::AdHoc, 'ex.throw throws the bound exception';
+}
+
+# Non-instance values keep working.
+given 42 -> \n { is n, 42, 'Int topic still binds' }
+given 'str' -> \s { is s.^name, 'Str', 'Str topic still binds' }

--- a/t/instance-regex-smartmatch.t
+++ b/t/instance-regex-smartmatch.t
@@ -1,0 +1,24 @@
+use v6;
+use Test;
+
+plan 6;
+
+# Smartmatching an object against a regex stringifies via the user `Str`
+# method (URI::Path smartmatched against the path grammar).
+class P {
+    has $.s;
+    multi method Str(P:D: --> Str) { $!s }
+}
+
+my $p = P.new(s => '/a/b/c');
+ok $p ~~ /a/, 'instance with user Str matches a regex';
+nok $p ~~ /zz/, 'non-matching pattern fails';
+ok $p ~~ m/'/a/'/, 'm// form stringifies too';
+is ($p ~~ /(\w)/)[0].Str, 'a', 'captures come from the Str-ified text';
+
+# :g form
+is ($p ~~ m:g/\w/).elems, 3, ':g matches against the Str-ified text';
+
+# Instances without a user Str keep prior behavior (no dispatch crash).
+class NoStr { has $.v }
+nok NoStr.new(v => 1) ~~ /abc/, 'instance without Str still smartmatches quietly';

--- a/t/multi-new-default-fallback.t
+++ b/t/multi-new-default-fallback.t
@@ -1,0 +1,33 @@
+use v6;
+use Test;
+
+plan 6;
+
+# When a class declares user multi `new` candidates that don't match a
+# named-args call, Mu.new(*%attrinit) is still available as a fallback —
+# including from a concrete invocant (URI::Path's `self.new: :$path`).
+class A {
+    has $.x;
+    multi method new(A:U: Int $s) { self.new(x => $s) }
+    method go() { self.new(x => 9) }
+}
+
+is A.new(x => 5).x, 5, 'named-args new falls back to the default constructor';
+is A.new(7).x, 7, 'the user multi candidate still dispatches';
+is A.new(x => 5).go.x, 9, 'self.new(:named) from a :D invocant falls back too';
+
+# An explicit proto owns dispatch: no default-constructor fallback.
+class P {
+    has $.x;
+    proto method new($) {*}
+    multi method new(Int $s) { self.bless(x => $s) }
+}
+is P.new(3).x, 3, 'proto-owned multi new dispatches';
+dies-ok { P.new(x => 3) }, 'proto-owned new does not fall back to Mu.new';
+
+# Positional args with no matching candidate still die.
+class R {
+    has $.x;
+    multi method new(R:U: Int $s) { self.new(x => $s) }
+}
+dies-ok { R.new('str', 'extra') }, 'unmatched positional args still die';

--- a/t/multi-nil-param-dispatch.t
+++ b/t/multi-nil-param-dispatch.t
@@ -1,0 +1,24 @@
+use v6;
+use Test;
+
+plan 5;
+
+# A literal `Nil` parameter must out-narrow other candidates for a Nil
+# argument regardless of declaration order (URI's `authority(Nil)`).
+class A {
+    multi method m(Str() $s) { "str:$s" }
+    multi method m(Nil) { "nil" }
+    multi method m() { "none" }
+}
+
+is A.new.m(Nil), 'nil', 'Nil argument picks the (Nil) candidate';
+is A.new.m('x'), 'str:x', 'Str argument picks the coercion candidate';
+is A.new.m(), 'none', 'no argument picks the nullary candidate';
+
+# Order-independence: Nil candidate declared last still wins.
+class B {
+    multi method m($x) { "any" }
+    multi method m(Nil) { "nil" }
+}
+is B.new.m(Nil), 'nil', '(Nil) wins over ($x) for a Nil argument';
+is B.new.m(42), 'any', 'non-Nil argument still reaches ($x)';

--- a/t/regex-alias-subrule-captures.t
+++ b/t/regex-alias-subrule-captures.t
@@ -1,0 +1,28 @@
+use v6;
+use Test;
+
+plan 7;
+
+grammar G {
+    token list { <nz> [ '/' <seg> ]* }
+    token seg { \w* }
+    token nz { \w+ }
+}
+
+# A `$<name> = <subrule>` alias must carry the called rule's full sub-match
+# tree, not just its text (URI's `$<path-abempty> = <IETF::...::path-abempty>`).
+ok 'a/b/c' ~~ /^ $<pl> = <G::list> $/, 'aliased qualified subrule matches';
+is ~$<pl>, 'a/b/c', 'alias captures the text';
+is-deeply $<pl><seg>.map(~*).List, ('b', 'c'),
+    'alias keeps the nested quantified captures';
+ok $<G::list>.defined, 'the subrule own capture is kept alongside the alias';
+is-deeply $<G::list><seg>.map(~*).List, ('b', 'c'),
+    'the subrule own capture keeps nested captures too';
+
+# Same via a lexical `my regex` wrapper (the URI path-scheme shape).
+my regex wrap {
+    [ $<pl> = <G::list> ]
+}
+ok 'x/y' ~~ /^ <wrap> $/, 'my-regex wrapper matches';
+is-deeply $<wrap><pl><seg>.map(~*).List, ('y',),
+    'nested captures survive through the wrapper alias';

--- a/t/regex-repeat-zero.t
+++ b/t/regex-repeat-zero.t
@@ -1,0 +1,21 @@
+use v6;
+use Test;
+
+plan 6;
+
+# `** 0` is a valid "exactly zero times" quantifier (RFC 3986's
+# `token path-empty { <.pchar> ** 0 }`).
+grammar G {
+    token empty { <.c> ** 0 }
+    token c { \w }
+}
+
+ok G.parse('', rule => 'empty'), 'token with ** 0 matches the empty string';
+nok G.parse('x', rule => 'empty'), '** 0 does not consume characters';
+
+my regex wrap { [ $<pe> = <G::empty> ] }
+ok '' ~~ /^ <wrap> $/, '** 0 subrule matches via an aliasing wrapper';
+
+ok 'ab' ~~ /a ** 0 b/, 'a ** 0 b matches the b (zero a-s)';
+nok 'aab' ~~ /^ a ** 0 $/, 'anchored ** 0 fails when characters remain';
+ok 'aab' ~~ /^ a ** 2 b $/, 'plain ** N still works';


### PR DESCRIPTION
## Summary

Running the URI-0.3.8 dist tests end-to-end (a Test::META prerequisite in the mzef campaign) surfaced eight independent interpreter bugs. Each is fixed generally and pinned by a new `t/` test (all verified against raku first):

1. **`@!attr := <List>` lost List-ness** — the SetGlobal `@`-sigil path ignored the bind context and ran `coerce_to_array`. The SetLocal `:=` logic is extracted into a shared `bind_positional_value` helper used by both paths. Pin: `t/attr-bind-list.t`.
2. **`$!attr = Nil` on a typed attribute reset to Any** — now resets to the attribute's declared type object, walking the MRO and resolving nested-class short names (`has Authority $.authority` inside `class URI`). `get_attr_type_constraint` now actually walks the MRO as its doc claimed. Pin: `t/attr-nil-reset-typed.t`.
3. **`$<name> = <subrule>` alias dropped nested captures** — the alias stored a minimal text-only Match; it now clones the subrule's rich subcap (span-checked), keeping both captures like rakudo. Pin: `t/regex-alias-subrule-captures.t`.
4. **`given $obj -> \ex { ... }` broke instances** — the bareword read of a sigilless binding returned the raw ContainerRef cell, so method dispatch misresolved (type object on first read, Any after). The read now derefs the cell. Pin: `t/given-sigilless-instance.t`.
5. **Instance ~~ regex ignored the user `Str` method** — regex smartmatch now stringifies via the class's `Str` when one is declared. Pin: `t/instance-regex-smartmatch.t`.
6. **`self.new(:named)` on a `:D` invocant lost the Mu.new fallback** when user multi `new` candidates didn't match. The instance-dispatch no-match path now falls back to the default constructor (proto-owned `new` still excluded, positional args still die). Pin: `t/multi-new-default-fallback.t`.
7. **`(Nil)` multi candidates dispatched by declaration order** — Nil's type distance was the unknown-type constant (`value_type_name(Nil)` is "Any"), so `(Nil)` vs `(Str() $s)` tied. Nil now has its own MRO in the distance function. Pin: `t/multi-nil-param-dispatch.t`.
8. **`x ** 0` was rewritten to `x ** 1`** — an explicit zero count is valid (RFC 3986's `token path-empty { <.pchar> ** 0 }`); only an unparsable count falls back. Pin: `t/regex-repeat-zero.t`.

URI-0.3.8 dist tests: **3/14 → 7/14 files fully passing** (`authority`, `directory`, `issue-43`, `path`, `rel2abs`, `require`, `rfc-3986-examples`).

Remaining URI failures are tracked for the next slice: composite char-class subtraction (`<+unenc-pchar - [:]>` currently matches any char), subset where-regex smartmatch, %XX decode fidelity, grammar tokens as instance methods.

## Test plan

- [x] 8 new pin tests green on both raku and mutsu
- [x] `make test` PASS
- [x] 404-file roast subset (S03/S04/S05/S06/S12/S32-str) via `scripts/run-roast-test.sh`: green (one debug-parallel-load timeout on `S12-methods/private.t`, 1.1s standalone in release)
- [x] clippy `-D warnings` + fmt clean
- [ ] Full CI (`make test` + `make roast`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)