### PR TITLE
feat: RakuAST Phase 2 slice 3 — bare blocks and pointy blocks

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -753,10 +753,17 @@ so it is tracked separately from the roast backlog.
         `t/rakuast-expr.t`.
   - [x] Slice 2: `=` assignment (`Assignment` node, `:item` for scalar targets) and method
         calls (`Call::Method` as an `ApplyPostfix`). Tests in `t/rakuast-calls-assign.t`.
-  - [ ] Slice 3+: blocks & pointy blocks, `if`/`unless`/`with`, loops, sub declarations,
-        signatures & parameters; scoped/typed `my`; compound/`:=` assignment; method-call
-        modifiers; then `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds
-        to `IntLiteral(3)`, mutsu does not).
+  - [x] Slice 3: bare blocks (`Block`/`Blockoid`) and pointy blocks (`PointyBlock`/`Signature`/
+        `Parameter`/`ParameterTarget::Var`, plain positional params only). Tests in
+        `t/rakuast-blocks.t`. (PR #4684.)
+  - [ ] Slice 4: `if`/`unless` and `while`/`until`/`loop` statements (`Statement::If`/`Unless`/
+        `Loop::While`/`Loop::Until`/`Loop`), condition + `then`/`body` = `Block`, `if...else`.
+        Defer topic-taking blocks (`with`/`without`/`for` add `implicit-topic`/`required-topic`
+        Block fields), `elsif` chains, C-style `loop`, and postfix statement modifiers to slice 5.
+  - [ ] Slice 5+: `with`/`without`/`for`, `elsif`, sub declarations (`RakuAST::Sub`, reuse
+        Signature), scoped/typed `my`, compound/`:=` assignment, method-call modifiers; then
+        `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`,
+        mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -157,6 +157,12 @@ earlier ones.
   operands. Leaning (a) for fidelity to *mutsu's* AST, revisited with data.
 - **`.AST` on `Code`/blocks (Phase 2+).** Phase 1 is `Str`-only; `.AST` on a `Block`/`Routine`
   needs the internal AST retained on the code object.
+- **Single-param pointy sigil loss (Phase 2 slice 3).** mutsu parses a single-parameter pointy
+  block to `Expr::Lambda { param: String }` with the sigil stripped, and does not preserve `@`/`%`
+  for a single non-scalar param (`-> @a` becomes `param: "a"`). The converter therefore assumes `$`
+  for `Lambda`, so `-> @a { }`/`-> %h { }` render `ParameterTarget::Var(name => "$a")` instead of
+  raku's `"@a"`. Multi-parameter pointy blocks (`Expr::AnonSubParams`) keep the sigil and render
+  correctly. Documented divergence; narrows if `Lambda` grows a sigil field.
 - **GC promotion of `Value::RakuAst`** — deferred until profiling shows clone churn (see note
   above).
 - **`.Str` / string context (Phase 1 simplification).** raku's RakuAST `.Str` (and bare string

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -7,7 +7,7 @@
 //! silently-wrong node.
 
 use super::{RakuAstClass, RakuAstField, RakuAstFieldValue, RakuAstNode};
-use crate::ast::{AssignOp, Expr, Stmt};
+use crate::ast::{AssignOp, Expr, ParamDef, Stmt};
 use crate::compiler::helpers_ops::token_kind_to_op_name;
 use crate::value::{RuntimeError, Value, ValueView};
 
@@ -88,6 +88,8 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 has_initializer,
             )?)))
         }
+        // A bare `{ ... }` block at statement level -> Statement::Expression(Block).
+        Stmt::Block(body) => Ok(Some(statement_expression(block_node(body)?))),
         Stmt::Assign { name, expr, op } => {
             // Phase 2 slice 2 covers only plain `=`; `:=` (Bind) and match-assign
             // map to distinct RakuAST nodes.
@@ -224,8 +226,166 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
                 ],
             })
         }
+        // A bare `{ ... }` block in expression position.
+        Expr::Block(body) => block_node(body),
+        Expr::AnonSub {
+            body,
+            is_rw,
+            is_block,
+        } => {
+            // Only the bare-block form maps to `RakuAST::Block`; `sub { }`
+            // (is_block == false) is `RakuAST::Sub`, deferred to the sub slice.
+            if *is_rw || !*is_block {
+                return Err(unsupported("`sub {}` / `is rw` block"));
+            }
+            block_node(body)
+        }
+        Expr::Lambda {
+            param,
+            body,
+            is_whatever_code,
+        } => {
+            if *is_whatever_code {
+                return Err(unsupported("Whatever-code closure"));
+            }
+            pointy_block_from_lambda(param, body)
+        }
+        Expr::AnonSubParams {
+            param_defs,
+            body,
+            is_rw,
+            is_whatever_code,
+            return_type,
+            ..
+        } => {
+            if *is_rw || *is_whatever_code || return_type.is_some() {
+                return Err(unsupported("`is rw` / Whatever / typed pointy block"));
+            }
+            pointy_block(param_defs, body)
+        }
         other => Err(unsupported(&format!("{other:?}"))),
     }
+}
+
+/// A `{ ... }` block body wraps its `StatementList` in a `Blockoid`.
+fn blockoid(body: &[Stmt]) -> Result<RakuAstNode, RuntimeError> {
+    Ok(RakuAstNode {
+        class: RakuAstClass::Blockoid,
+        fields: vec![node_field(None, statement_list(body)?)],
+    })
+}
+
+/// A bare `{ ... }` block -> `Block(body => Blockoid)`.
+fn block_node(body: &[Stmt]) -> Result<RakuAstNode, RuntimeError> {
+    Ok(RakuAstNode {
+        class: RakuAstClass::Block,
+        fields: vec![node_field(Some("body"), blockoid(body)?)],
+    })
+}
+
+/// A multi/zero-parameter pointy block (`-> $a, $b { }`, `-> { }`). An empty
+/// parameter list omits the `signature` field entirely (matching raku).
+fn pointy_block(param_defs: &[ParamDef], body: &[Stmt]) -> Result<RakuAstNode, RuntimeError> {
+    let mut fields = Vec::new();
+    if !param_defs.is_empty() {
+        fields.push(node_field(Some("signature"), signature(param_defs)?));
+    }
+    fields.push(node_field(Some("body"), blockoid(body)?));
+    Ok(RakuAstNode {
+        class: RakuAstClass::PointyBlock,
+        fields,
+    })
+}
+
+/// A single-parameter pointy block (`-> $x { }`). mutsu's `Lambda` node strips
+/// the sigil from its single param and does NOT preserve `@`/`%` for a single
+/// non-scalar param (`-> @a` becomes `param: "a"`), so we assume `$` — a
+/// documented divergence from raku, which shows the real sigil.
+fn pointy_block_from_lambda(param: &str, body: &[Stmt]) -> Result<RakuAstNode, RuntimeError> {
+    let sig = RakuAstNode {
+        class: RakuAstClass::Signature,
+        fields: vec![RakuAstField {
+            name: Some("parameters"),
+            value: RakuAstFieldValue::List(vec![Value::rakuast(Box::new(simple_parameter(
+                "$", param, None,
+            )?))]),
+        }],
+    };
+    Ok(RakuAstNode {
+        class: RakuAstClass::PointyBlock,
+        fields: vec![
+            node_field(Some("signature"), sig),
+            node_field(Some("body"), blockoid(body)?),
+        ],
+    })
+}
+
+/// `Signature(parameters => (Parameter, ...))`.
+fn signature(param_defs: &[ParamDef]) -> Result<RakuAstNode, RuntimeError> {
+    let mut params = Vec::with_capacity(param_defs.len());
+    for pd in param_defs {
+        params.push(Value::rakuast(Box::new(parameter(pd)?)));
+    }
+    Ok(RakuAstNode {
+        class: RakuAstClass::Signature,
+        fields: vec![RakuAstField {
+            name: Some("parameters"),
+            value: RakuAstFieldValue::List(params),
+        }],
+    })
+}
+
+/// One `Parameter`. Only plain positional params (name + optional default) are
+/// modelled; anything richer (typed, named, slurpy, `where`, sub-signature,
+/// traits, optional-marker, invocant, shaped) is the coverage boundary.
+fn parameter(pd: &ParamDef) -> Result<RakuAstNode, RuntimeError> {
+    if pd.named
+        || pd.slurpy
+        || pd.double_slurpy
+        || pd.onearg
+        || pd.type_constraint.is_some()
+        || pd.literal_value.is_some()
+        || pd.sub_signature.is_some()
+        || pd.where_constraint.is_some()
+        || !pd.traits.is_empty()
+        || pd.optional_marker
+        || pd.is_invocant
+        || pd.shape_constraints.is_some()
+        || pd.code_signature.is_some()
+        || pd.outer_sub_signature.is_some()
+    {
+        return Err(unsupported("non-trivial signature parameter"));
+    }
+    let (sigil, desigil) = split_sigil(&pd.name);
+    simple_parameter(sigil, desigil, pd.default.as_ref())
+}
+
+/// Build a `Parameter(target => ParameterTarget::Var, ...)`. A param with a
+/// default renders `default => <expr>`; a required one renders `optional => False`.
+fn simple_parameter(
+    sigil: &str,
+    desigil: &str,
+    default: Option<&Expr>,
+) -> Result<RakuAstNode, RuntimeError> {
+    let target = RakuAstNode {
+        class: RakuAstClass::ParameterTargetVar,
+        fields: vec![leaf_field(
+            Some("name"),
+            Value::str(format!("{sigil}{desigil}")),
+        )],
+    };
+    let mut fields = vec![node_field(Some("target"), target)];
+    match default {
+        Some(d) => fields.push(node_field(Some("default"), convert_expr(d)?)),
+        None => fields.push(RakuAstField {
+            name: Some("optional"),
+            value: RakuAstFieldValue::Node(Value::truth(false)),
+        }),
+    }
+    Ok(RakuAstNode {
+        class: RakuAstClass::Parameter,
+        fields,
+    })
 }
 
 /// `.method` / `.method(args)` -> `Call::Method(name => Name, [args => ArgList])`.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -67,6 +67,13 @@ pub enum RakuAstClass {
     Postfix,
     Assignment,
     CallMethod,
+    // Phase 2 slice 3: blocks & pointy blocks.
+    Block,
+    Blockoid,
+    PointyBlock,
+    Signature,
+    Parameter,
+    ParameterTargetVar,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -101,6 +108,12 @@ impl RakuAstClass {
             Postfix => "RakuAST::Postfix",
             Assignment => "RakuAST::Assignment",
             CallMethod => "RakuAST::Call::Method",
+            Block => "RakuAST::Block",
+            Blockoid => "RakuAST::Blockoid",
+            PointyBlock => "RakuAST::PointyBlock",
+            Signature => "RakuAST::Signature",
+            Parameter => "RakuAST::Parameter",
+            ParameterTargetVar => "RakuAST::ParameterTarget::Var",
         }
     }
 
@@ -118,22 +131,15 @@ impl RakuAstClass {
         }
     }
 
-    /// Field width for aligning named `key => value` fields. raku's gist pads to
-    /// the max length over ALL of the class's declared attributes — including
-    /// ones omitted when at their default (e.g. `QuotedString` pads `segments`
-    /// to 10 to align with its unshown `processors`). These constants are
-    /// captured from raku's output; 0 = the class has no named fields.
-    pub fn named_align_width(self) -> usize {
-        use RakuAstClass::*;
+    /// Minimum width for aligning named `key => value` fields. raku's gist pads
+    /// keys to the max length over the *shown* named fields of a node (computed
+    /// per-instance in the renderer), but a few classes pad further to align
+    /// with a declared-but-omitted attribute. `QuotedString` pads `segments`
+    /// (8) to 10 to align with its unshown `processors`. This floor captures
+    /// those exceptions; 0 = no floor (use the shown-field max directly).
+    pub fn min_align_width(self) -> usize {
         match self {
-            StatementExpression => 10,                  // "expression"
-            QuotedString => 10,                         // "processors" (unshown) > "segments"
-            CallName | CallNameWithoutParentheses => 4, // "name" / "args"
-            VarDeclarationSimple => 11,                 // "desigilname" / "initializer"
-            ApplyInfix => 5,                            // "infix" / "right"
-            ApplyPrefix | ApplyPostfix => 7,            // "operand"
-            Postfix => 8,                               // "operator"
-            CallMethod => 4,                            // "name" / "args"
+            RakuAstClass::QuotedString => 10, // "processors" (unshown) > "segments"
             _ => 0,
         }
     }

--- a/src/rakuast/render.rs
+++ b/src/rakuast/render.rs
@@ -41,7 +41,7 @@ pub(super) fn render_node(node: &RakuAstNode, indent: usize) -> String {
         return format!("{name}.{ctor}({inner})");
     }
 
-    let width = node.class.named_align_width();
+    let width = field_align_width(node);
     let mut s = format!("{name}.{ctor}(\n");
     let child_indent = indent + 2;
     let pad = " ".repeat(child_indent);
@@ -56,6 +56,19 @@ pub(super) fn render_node(node: &RakuAstNode, indent: usize) -> String {
     s.push_str(&" ".repeat(indent));
     s.push(')');
     s
+}
+
+/// The `key => value` alignment width for a node: the max length over its
+/// *shown* named-field keys, floored by the class's `min_align_width` (which
+/// covers the few classes that pad to a declared-but-omitted attribute).
+fn field_align_width(node: &RakuAstNode) -> usize {
+    let shown = node
+        .fields
+        .iter()
+        .filter_map(|f| f.name.map(str::len))
+        .max()
+        .unwrap_or(0);
+    shown.max(node.class.min_align_width())
 }
 
 fn is_inline_field(f: &RakuAstField) -> bool {

--- a/t/rakuast-blocks.t
+++ b/t/rakuast-blocks.t
@@ -1,0 +1,163 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 3 (ADR-0011): bare blocks and pointy blocks
+# (Block, Blockoid, PointyBlock, Signature, Parameter, ParameterTarget::Var).
+# Expected gists captured verbatim from Rakudo; this file passes under BOTH
+# mutsu and raku, so raku is the oracle.
+
+plan 6;
+
+# --- bare block -------------------------------------------------------------
+is Q[{ 42 }].AST.gist, q:to/END/.chomp, 'bare block -> Block(body => Blockoid)';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Block.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::IntLiteral.new(42)
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- single-parameter pointy block ------------------------------------------
+is Q[-> $x { $x }].AST.gist, q:to/END/.chomp, 'pointy block -> PointyBlock + Signature';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::PointyBlock.new(
+          signature => RakuAST::Signature.new(
+            parameters => (
+              RakuAST::Parameter.new(
+                target   => RakuAST::ParameterTarget::Var.new(
+                  name => "\$x"
+                ),
+                optional => False
+              ),
+            )
+          ),
+          body      => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::Var::Lexical.new("\$x")
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- zero-parameter pointy block omits the signature field ------------------
+is Q[-> { 1 }].AST.gist, q:to/END/.chomp, 'zero-param pointy block omits signature';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::PointyBlock.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::IntLiteral.new(1)
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- multi-parameter pointy: a default renders `default =>`, no `optional` ---
+# The per-node alignment width differs between the two Parameters (the required
+# one pads to "optional" = 8, the defaulted one to "default" = 7).
+is Q[-> $a, $b = 7 { $a }].AST.gist, q:to/END/.chomp, 'default param -> default field, alignment per node';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::PointyBlock.new(
+          signature => RakuAST::Signature.new(
+            parameters => (
+              RakuAST::Parameter.new(
+                target   => RakuAST::ParameterTarget::Var.new(
+                  name => "\$a"
+                ),
+                optional => False
+              ),
+              RakuAST::Parameter.new(
+                target  => RakuAST::ParameterTarget::Var.new(
+                  name => "\$b"
+                ),
+                default => RakuAST::IntLiteral.new(7)
+              ),
+            )
+          ),
+          body      => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::Var::Lexical.new("\$a")
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- a block body carries a full StatementList (declaration + expression) ----
+is Q[{ my $x = 1; $x }].AST.gist, q:to/END/.chomp, 'block body is a multi-statement StatementList';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Block.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::VarDeclaration::Simple.new(
+                  sigil       => "\$",
+                  desigilname => RakuAST::Name.from-identifier("x"),
+                  initializer => RakuAST::Initializer::Assign.new(
+                    RakuAST::IntLiteral.new(1)
+                  )
+                )
+              ),
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::Var::Lexical.new("\$x")
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- a method call inside a pointy block body -------------------------------
+is Q[-> $x { $x.abs }].AST.gist, q:to/END/.chomp, 'method call nests in pointy block body';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::PointyBlock.new(
+          signature => RakuAST::Signature.new(
+            parameters => (
+              RakuAST::Parameter.new(
+                target   => RakuAST::ParameterTarget::Var.new(
+                  name => "\$x"
+                ),
+                optional => False
+              ),
+            )
+          ),
+          body      => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::ApplyPostfix.new(
+                  operand => RakuAST::Var::Lexical.new("\$x"),
+                  postfix => RakuAST::Call::Method.new(
+                    name => RakuAST::Name.from-identifier("abs")
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    END


### PR DESCRIPTION
## Summary

Phase 2 slice 3 of RakuAST (ADR-0011): extend `Str.AST` introspection to the **block cluster** — `RakuAST::Block`, `Blockoid`, `PointyBlock`, `Signature`, `Parameter`, and `ParameterTarget::Var`.

## What's covered

- **Bare `{ ... }` blocks** (`Stmt::Block`, `Expr::Block`, `Expr::AnonSub` bare-block form) → `Block(body => Blockoid(StatementList))`.
- **Pointy blocks**: single-param (`Expr::Lambda`) and multi/zero-param (`Expr::AnonSubParams`) → `PointyBlock`. A zero-param `-> { }` omits the `signature` field entirely, matching raku.
- **Parameters** model the plain positional form (name + optional default): a required param renders `optional => False`, a defaulted one renders `default => <expr>`. Richer params (typed/named/slurpy/`where`/sub-signature/trait/optional-marker/invocant/shaped) hit the documented coverage boundary (explicit `RuntimeError`), not a silently-wrong node.

## Renderer change

The named-field alignment width is now computed **per node instance** as the max over its *shown* named keys, floored by a per-class minimum (only `QuotedString`, which pads to its hidden `processors`). This replaces the per-class constant table and is required because raku's `Parameter` gist aligns differently per instance (a required param pads to `optional`=8, a defaulted one to `default`=7). Every previously-covered class's width is unchanged.

## Documented divergence

mutsu's single-param `Lambda` strips the sigil and does not preserve `@`/`%`, so `-> @a { }` renders `name => "$a"` instead of raku's `"@a"`. Multi-param pointy blocks keep the sigil and render byte-for-byte. Recorded in ADR-0011 Open questions.

## Tests

`t/rakuast-blocks.t` — 6 full-gist / fragment assertions, **passing under BOTH mutsu and raku** (raku is the oracle). Existing `t/rakuast-{ast,expr,calls-assign}.t` still green after the width refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)