### PR TITLE
fix: composite char-class subtraction and package-qualified subsets

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -928,6 +928,9 @@ pub(crate) enum Stmt {
         version: String,
         is_export: bool,
         export_tags: Vec<String>,
+        /// `my subset F ...` — lexically scoped: NOT reachable (nor
+        /// registered) under the enclosing package's qualified name.
+        is_my: bool,
     },
     Phaser {
         kind: PhaserKind,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -825,6 +825,9 @@ impl Compiler {
                             version: String::new(),
                             is_export: false,
                             export_tags: Vec::new(),
+                            // Anonymous where-subsets are internal; never
+                            // alias them under the enclosing package.
+                            is_my: true,
                         };
                         let idx = self.code.add_stmt(subset_stmt);
                         self.code.emit(OpCode::RegisterSubset(idx));

--- a/src/parser/stmt/decl/constant_subset.rs
+++ b/src/parser/stmt/decl/constant_subset.rs
@@ -267,6 +267,7 @@ pub(in crate::parser::stmt) fn subset_decl(input: &str) -> PResult<'_, Stmt> {
             version: super::super::simple::current_language_version(),
             is_export,
             export_tags,
+            is_my: false,
         },
     ))
 }

--- a/src/parser/stmt/decl/my_decl_dispatch.rs
+++ b/src/parser/stmt/decl/my_decl_dispatch.rs
@@ -125,6 +125,7 @@ pub(super) fn try_keyword_dispatch(
                     version: super::super::simple::current_language_version(),
                     is_export: false,
                     export_tags: Vec::new(),
+                    is_my: !is_our,
                 },
             )));
         }
@@ -230,7 +231,14 @@ pub(super) fn try_keyword_dispatch(
     }
     // my subset Name of BaseType where ...
     if keyword("subset", rest).is_some() {
-        return subset_decl(rest).map(Some);
+        return subset_decl(rest)
+            .map(|(r, mut stmt)| {
+                if !is_our && let Stmt::SubsetDecl { is_my, .. } = &mut stmt {
+                    *is_my = true;
+                }
+                (r, stmt)
+            })
+            .map(Some);
     }
     // my constant $x = ...
     if keyword("constant", rest).is_some() {

--- a/src/runtime/regex_parse_charclass.rs
+++ b/src/runtime/regex_parse_charclass.rs
@@ -686,6 +686,14 @@ impl Interpreter {
                 out.extend(class.items.iter().cloned());
                 true
             }
+            // A subtraction-free CompositeClass (e.g. a token whose body is
+            // itself a combined class, `token unenc-pchar { <[:@] +unreserved
+            // +sub-delims> }`) is a plain union of its items. Only reached for
+            // closed patterns, so any NamedBuiltin items are true builtins.
+            RegexAtom::CompositeClass { positive, negative } if negative.is_empty() => {
+                out.extend(positive.iter().cloned());
+                true
+            }
             RegexAtom::Group(inner) => Self::pattern_single_char_items(inner, out),
             RegexAtom::Alternation(branches) | RegexAtom::SequentialAlternation(branches) => {
                 branches
@@ -869,14 +877,55 @@ impl Interpreter {
         // `CompositeClass` (not a negated `CharClass`) so that negated
         // grammar-token items resolve at match time; the CompositeClass matcher
         // treats an empty `positive` as "any char" (see its `pos_match` fallback).
-        let class_atom = if positive_items.is_empty() && negative_items.is_empty() {
+        //
+        // With subrule/inline branches present, negative items that FOLLOW a
+        // positive part are a SUBTRACTION from the built-up class (`<+pc -
+        // [:]>` = pc's charset minus ':'), not a standalone "any char except
+        // ..." branch — that reading would make the class match almost
+        // anything. Emit them as a negative lookahead guarding every branch,
+        // and only keep the class atom when positive single-char items carry
+        // it. A class whose FIRST part is negative (`<-restricted +name-sep>`,
+        // zef's REQUIRE name) starts from the full character set instead: its
+        // negatives form the classic any-char-except branch, and the positive
+        // subrules are plain unions with no guard.
+        let first_part_negative = input.trim_start().starts_with('-');
+        let neg_guard = if first_part_negative || negative_items.is_empty() {
             None
         } else {
-            Some(RegexAtom::CompositeClass {
-                positive: positive_items,
-                negative: negative_items,
+            Some(RegexAtom::Lookaround {
+                pattern: RegexPattern {
+                    tokens: vec![RegexToken {
+                        atom: RegexAtom::CompositeClass {
+                            positive: negative_items.clone(),
+                            negative: vec![],
+                        },
+                        quant: RegexQuant::One,
+                        named_capture: None,
+                        secondary_named_capture: None,
+                        hash_capture: None,
+                        force_list_capture: false,
+                        ratchet: false,
+                        frugal: false,
+                        separator: None,
+                    }],
+                    anchor_start: false,
+                    anchor_end: false,
+                    ignore_case: false,
+                    ignore_mark: false,
+                },
+                negated: true,
+                is_behind: false,
             })
         };
+        let class_atom =
+            if positive_items.is_empty() && (negative_items.is_empty() || !first_part_negative) {
+                None
+            } else {
+                Some(RegexAtom::CompositeClass {
+                    positive: positive_items,
+                    negative: negative_items,
+                })
+            };
         // Desugar an enumerated class carrying positive user-subrules into an
         // LTM alternation: `<-restricted +name-sep>` -> `[ <name-sep> | <-restricted> ]`.
         // The subrule branches are non-capturing (char classes never capture).
@@ -897,15 +946,35 @@ impl Interpreter {
             ignore_case: false,
             ignore_mark: false,
         };
+        // Prepend the subtraction guard (if any) to a branch pattern.
+        let guard_pattern = |mut p: RegexPattern| {
+            if let Some(guard) = &neg_guard {
+                p.tokens.insert(
+                    0,
+                    RegexToken {
+                        atom: guard.clone(),
+                        quant: RegexQuant::One,
+                        named_capture: None,
+                        secondary_named_capture: None,
+                        hash_capture: None,
+                        force_list_capture: false,
+                        ratchet: false,
+                        frugal: false,
+                        separator: None,
+                    },
+                );
+            }
+            p
+        };
         let mut branches: Vec<RegexPattern> = subrule_branches
             .into_iter()
             // Prefix with `.` so the subrule is matched *silently* (no named
             // capture) — a character class never captures.
-            .map(|name| make_pattern(RegexAtom::Named(format!(".{name}"))))
+            .map(|name| guard_pattern(make_pattern(RegexAtom::Named(format!(".{name}")))))
             .collect();
         // Statically-folded token bodies join the alternation directly (they
         // are closed patterns: no captures, no runtime resolution).
-        branches.extend(inline_branches);
+        branches.extend(inline_branches.into_iter().map(guard_pattern));
         if let Some(atom) = class_atom {
             branches.push(make_pattern(atom));
         }

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -322,6 +322,7 @@ impl Interpreter {
         base: &str,
         predicate: Option<&Expr>,
         version: &str,
+        is_my: bool,
     ) {
         // When the predicate is `* ~~ <expr>` (Whatever on LHS of SmartMatch),
         // the parser doesn't wrap it as WhateverCode (to avoid breaking other
@@ -350,14 +351,29 @@ impl Interpreter {
         // Drop any cached compiled predicate for this name so a redeclaration
         // recompiles against the new predicate (see `subset_predicate_cache`).
         self.subset_predicate_cache.remove(name);
-        self.registry_mut().subsets.insert(
-            name.to_string(),
-            SubsetDef {
-                base: base.to_string(),
-                predicate,
-                version: version.to_string(),
-            },
-        );
+        let def = SubsetDef {
+            base: base.to_string(),
+            predicate,
+            version: version.to_string(),
+        };
+        // A subset defaults to `our` scope: declared inside a package/class/
+        // module it is also reachable by its qualified name (`URI::Scheme`),
+        // so register that alias too — smartmatch resolves the constraint by
+        // the exact name it was referenced with. A `my subset` is lexical and
+        // must NOT get the package-qualified alias (S12-subset/type-subset.t).
+        let pkg = self.current_package();
+        if !is_my && !name.contains("::") && !pkg.is_empty() && pkg != "GLOBAL" && pkg != "Main" {
+            let qualified = format!("{}::{}", pkg, name);
+            self.subset_predicate_cache.remove(&qualified);
+            self.registry_mut()
+                .subsets
+                .insert(qualified.clone(), def.clone());
+            self.env.insert(
+                qualified.clone(),
+                Value::package(Symbol::intern(&qualified)),
+            );
+        }
+        self.registry_mut().subsets.insert(name.to_string(), def);
         self.env
             .insert(name.to_string(), Value::package(Symbol::intern(name)));
     }

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -545,12 +545,13 @@ impl Interpreter {
             version,
             is_export,
             export_tags,
+            is_my,
         } = stmt
         {
             let resolved_name = name.resolve();
             loan_env!(
                 self,
-                register_subset_decl(&resolved_name, base, predicate.as_ref(), version,)
+                register_subset_decl(&resolved_name, base, predicate.as_ref(), version, *is_my)
             );
             // When a subset is declared `is export` inside a module, record it
             // in the export table so `import M` (and `use M`) can find it.

--- a/t/module-export-import.t
+++ b/t/module-export-import.t
@@ -9,7 +9,9 @@ plan 8;
     ok Even ~~ Any, 'imported subset is a known type';
     my Even $x = 4;
     is $x, 4, 'value matching the subset predicate is accepted';
-    is Even.^name, 'Even', 'subset type name is correct after import';
+    # A subset declared in a module carries its package-qualified name
+    # (rakudo: `Even.^name` is "M1::Even" even via the imported bare name).
+    is Even.^name, 'M1::Even', 'subset type name is correct after import';
 }
 
 # A subset declared `is export(:tag)` is importable via that tag.

--- a/t/regex-composite-class-subtraction.t
+++ b/t/regex-composite-class-subtraction.t
@@ -1,0 +1,28 @@
+use v6;
+use Test;
+
+plan 8;
+
+# A combined char class referencing a grammar token with a subtraction
+# (`<+pc - [:]>`) subtracts from the WHOLE class — it must not degenerate
+# into "token OR any-char-except" (RFC 3986's segment-nz-nc shape).
+grammar G {
+    token pc { <[:@] +alpha> }
+    token nc { <+pc - [:]>+ }
+    token pl { <+pc>+ }
+}
+
+nok G.parse('ab:c', rule => 'nc'), 'subtracted char stops the match';
+nok G.parse('a/b', rule => 'nc'), 'chars outside the class never match';
+ok G.parse('ab', rule => 'nc'), 'plain members still match';
+ok G.parse('a@b', rule => 'nc'), 'non-subtracted set chars still match';
+nok G.parse('a/b', rule => 'pl'), 'subtraction-free composite stays exact';
+ok G.parse('a:b', rule => 'pl'), 'subtraction-free composite keeps its members';
+
+# Nested token references fold through (unenc-pchar -> unreserved shape).
+grammar H {
+    token un { <[\-._~] +alpha> }
+    token seg { <+un - [.]>+ }
+}
+ok H.parse('a-b_c', rule => 'seg'), 'nested composite class matches';
+nok H.parse('a.b', rule => 'seg'), 'nested composite class honors subtraction';

--- a/t/subset-qualified-smartmatch.t
+++ b/t/subset-qualified-smartmatch.t
@@ -1,0 +1,22 @@
+use v6;
+use Test;
+
+plan 6;
+
+# A subset defaults to `our` scope: declared inside a package it is also
+# reachable — and smartmatchable — by its qualified name (URI::Scheme).
+class C {
+    our subset Sch of Str where { .chars > 2 };
+    our subset Rx of Str where /^ \w+ $/;
+}
+
+ok 'http' ~~ C::Sch, 'qualified subset smartmatch (block where)';
+nok 'x' ~~ C::Sch, 'qualified subset rejects non-members';
+ok 'abc' ~~ C::Rx, 'qualified subset smartmatch (regex where)';
+nok '-x' ~~ C::Rx, 'qualified regex subset rejects non-members';
+
+is C::Sch.^name, 'C::Sch', 'the qualified type object carries its name';
+
+# A subset declared at top level keeps its bare-name behavior.
+subset Top of Str where { .chars == 2 };
+ok 'ab' ~~ Top, 'top-level subset still smartmatches by bare name';


### PR DESCRIPTION
## Summary

Two more general bugs surfaced by the URI-0.3.8 dist tests (follow-up to #4683):

1. **Composite char-class subtraction** — `<+unenc-pchar - [:]>` (RFC 3986's `segment-nz-nc`) degraded into "token OR any-char-except-':'": the subtracted set became a standalone CompositeClass branch with an empty positive, which the matcher treats as *any char*. So the class matched `/` and relative-path `segments` collapsed to one string.
   - Subtractions that **follow** a positive part now compile to a negative lookahead guarding every subrule/inline branch (true set subtraction).
   - A subtraction-free CompositeClass now folds through `pattern_single_char_items`, so nested token bodies (`unenc-pchar` → `unreserved` → `uri-alphanum`) statically resolve to plain class items.
   - A class whose **first** part is negative (zef's `<-restricted +name-sep>` REQUIRE grammar) keeps the existing full-set semantics: negatives stay the any-char-except branch, positive subrule unions get no guard. (`t/regex-charclass-subrule-union.t` / `t/regex-charclass-token-fold.t` pin this and stay green.)
2. **Package-qualified subsets** — `class URI { our subset Scheme ... }` was registered only under its bare name, so `'http' ~~ URI::Scheme` silently returned False (URI's `mutate.rakutest` 1-3). Subsets default to `our` scope, so the qualified alias is now registered too. `my subset` stays lexical via a new `is_my` flag on `SubsetDecl` (set by the `my`-declaration parser and for anonymous where-subsets), preserving `S12-subset/type-subset.t` 9.1 ("'my' scoped subset in a module is unavailable outside the module").
3. `t/module-export-import.t` expected `Even.^name` eq "Even" after `import M1`; rakudo reports **"M1::Even"** — updated the local test to the rakudo behavior (raku-verified).

With #4683, URI's `01.rakutest` reaches 47/50 and `mutate.rakutest` 30/33; remaining failures are query-form parsing, %XX decode fidelity, and grammar-token-as-instance-method (tracked for the next slice).

## Test plan

- [x] New pins `t/regex-composite-class-subtraction.t`, `t/subset-qualified-smartmatch.t` green on raku and mutsu
- [x] `make test` PASS (1817 files)
- [x] Roast subset S05 + S12-subset + S02-types/subset via `scripts/run-roast-test.sh`: PASS
- [x] `roast/S12-subset/type-subset.t` (the my-subset scoping test) green
- [x] clippy `-D warnings` + fmt clean
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)