### PR TITLE
feat: per-composition generic class naming + typed-attribute element checks

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -89,7 +89,6 @@ noted.
 | Classification | File | mutsu | raku (v2026.06/6.d) | Blocker (one line) |
 |---|---|---|---|---|
 | Awaiting infrastructure | `S32-str/format.t` | aborts at 26/49 | **49/49 full pass** (SORRY on v2022.12) | Requires `Formatter::Syntax.parse`→Match and `Formatter.AST`→`RakuAST::Node` = **no RakuAST subsystem**. The raku update provided an oracle, but stubbing is forbidden, so it stays shelved |
-| Awaiting infrastructure | `S02-types/generics.t` | 0/1 | **1/1 full pass** (SORRY on v2022.12) | Needs 6.e coercion type terms + `Array[T]` subclassing. The raku update made reference verification possible, but the size of the required infrastructure is unchanged |
 | No oracle | `S02-names/pseudo-6d.t` | aborts at 116/159 | SORRY (`::=` NYI) | `::("CALLER")::<$*bar>` CALLER pseudo-package deref unsupported. Even on v2026.06 rakudo SORRYs because `::=` binding is unimplemented |
 | No oracle | `S02-names/pseudo-6e.t` | aborts at 79/202 | SORRY (`$?` constant twigil NYI) | Same as above (the 6.e version). Still SORRY on v2026.06 |
 | No oracle | `S02-names-vars/names.t` | 144/156, notok 3 | SORRY (unfudged line) | test 142 "Null PMC access when printing a var typed as ::foo" edge. raku SORRYs on a fudge-dependent line (a bare `$`) |
@@ -123,19 +122,6 @@ completed fix history lives in `news/`.
   (`::<$x> := $y`); `X::NoSuchSymbol` exception type; `is dynamic` trait for CALLERS visibility;
   `CORE::v6c/v6d/v6e` namespaces. Note: raku itself fails to parse this test due to `$?` twigil
   constants.
-- **`S02-types/generics.t`** — a deep multi-feature 6.e stack. Subtests 1-2 now PASS (progress
-  2026-07-18). Done: (1) **coercion type TERMS** — `Int()` -> `Int(Any)`, `Int:D()` ->
-  `Int:D(Any)`, and the same forms over a bound generic type parameter (`T()`, `T:D()`).
-  (2) **`class A is Array[Int] {}` subclassing** — a parametric native parent now contributes
-  its base type to the MRO, so `.push` and typed-element checks are inherited. (3) nested generic
-  class parent-substitution — `class A is Array[T] {}` inside a parametric role composes with the
-  concrete `Array[Int]` parent (type captures resolved at class registration).
-  Remaining blockers for subtests 3-6: (a) **per-composition parameterized naming** — the nested
-  class `.^name` is `G::A`, must be `R::G::A[Int]` (role-qualified + pinned to the instantiation
-  type; the nested `my package G` decl is not routed through the role package, and the class is
-  registered once globally rather than re-instantiated per composition); (b) **typed attribute
-  element checking from a generic class** — `has @.a is G::A` does not propagate `Array[Int]`'s
-  element type, so a wrong-typed `.new(a => <bad>)` is not rejected.
 - **`S05-mass/rx.t`** — the per-token ratchet (`:`) core is fixed (commits to the atom's
   highest-priority match; leading null `||`/`|` alternatives ignored). Remaining: `<commit>`
   named assertion is NYI and its runtime error aborts the file at test 20; later subtests need
@@ -226,5 +212,6 @@ re-running it; this ledger's *diagnoses* have also been wrong (see `my-6c.t` in
 
 - For the S\* table (non-goal / no-oracle / awaiting-infrastructure), advancing entries as a side
   effect of general mutsu improvements is fine, but do not make whitelisting those individual
-  files the goal. `S32-str/format.t` and `S02-types/generics.t` gained an oracle from the raku
-  update, but the size of the required infrastructure (RakuAST / 6.e generics) is unchanged.
+  files the goal. `S32-str/format.t` gained an oracle from the raku update, but the size of the
+  required infrastructure (RakuAST) is unchanged. (`S02-types/generics.t` was whitelisted
+  2026-07-18 — see `news/2026-07.md`.)

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,28 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-18: `S02-types/generics.t` fully whitelisted — per-composition generic class naming + typed-attribute element checks
+
+Following the coercion-type-terms landing (#4681, subtests 1-2), the remaining four subtests of
+this deep 6.e generics test now pass, so the file is whitelisted. Three general-purpose fixes:
+
+- **Parser: `is Type[params]` / `is Qualified::Name` container traits kept whole.** `has @.a is
+  Array[Int]` parsed as `is_type: "Array"` with the trailing `[Int]` misparsed as a *separate*
+  statement, so the parameterization was silently dropped (and `Foo.new(a => <bad>)` never
+  type-checked). The `has`-attribute trait parser now consumes `::`-qualified segments and a
+  balanced `[...]` parameterization into the type name. Pin: `t/generics-nominalizable-class.t`.
+- **Per-composition parameterized class naming.** A class declared inside a *parametric* role body
+  (`role R[::T] { my package G { class A is Array[T] {} } }`) becomes parametric over the role's
+  type args: composing `R[Int]` renames the nested class to `R::G::A[Int]` (and `R[Str]` to
+  `R::G::A[Str]`), so `.^name` and the coercion-term forms (`G::A:D`, `G::A()`) report the
+  instantiation-pinned name. Each composition renames the freshly-declared class and records an
+  alias so a bare `G::A` reference from a composed method still resolves.
+- **Typed-attribute element checking through a generic Array subclass.** A role attribute's `is
+  Type` container trait (`has @.a is G::A`) is now carried onto the consuming class, and
+  `coerce_value_to_is_type` resolves a subclass of `Array[T]` (directly or via the composition
+  alias) to its concrete element type — so a wrong-typed `.new(a => <bad>)` throws
+  `X::TypeCheck::Assignment`, exactly like a literal `is Array[Int]`.
+
 ## 2026-07-17: mzef installs AND loads Test::META's whole dependency chain (#4658 + #4661–#4665)
 
 Six merged PRs took mzef from "the ADR-0010 branch is red in CI" to "`zef install --/test

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -149,6 +149,7 @@ roast/S02-types/compact.t
 roast/S02-types/declare.t
 roast/S02-types/fatrat.t
 roast/S02-types/flattening.t
+roast/S02-types/generics.t
 roast/S02-types/hash.t
 roast/S02-types/hash_ref.t
 roast/S02-types/hyperwhatever.t

--- a/src/parser/stmt/decl/has_decl.rs
+++ b/src/parser/stmt/decl/has_decl.rs
@@ -487,9 +487,53 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
             .next()
             .is_some_and(|c| c.is_ascii_uppercase())
         {
-            // Uppercase-starting trait name: `is Buf`, `is BagHash`, etc.
-            // This is a container type trait for `@`/`%` attributes.
-            is_type = Some(trait_name.to_string());
+            // Uppercase-starting trait name: `is Buf`, `is BagHash`,
+            // `is Array[Int]`, `is G::A`, etc. This is a container type trait
+            // for `@`/`%` attributes. `ident` only captured the first segment,
+            // so pull in any `::`-qualified segments and a `[...]`
+            // parameterization to keep the full type name (`Array[Int]` /
+            // `R::G::A`); otherwise the trailing `[Int]` is misparsed as a
+            // separate statement.
+            let mut full = trait_name.to_string();
+            let mut tr = r;
+            while let Some(after) = tr.strip_prefix("::") {
+                match ident(after) {
+                    Ok((r2, seg)) => {
+                        full.push_str("::");
+                        full.push_str(&seg);
+                        tr = r2;
+                    }
+                    Err(_) => break,
+                }
+            }
+            if tr.starts_with('[') {
+                let mut depth = 0u32;
+                let mut end = None;
+                for (i, ch) in tr.char_indices() {
+                    match ch {
+                        '[' => depth += 1,
+                        ']' => {
+                            depth -= 1;
+                            if depth == 0 {
+                                end = Some(i);
+                                break;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                if let Some(end) = end {
+                    let inner = tr[1..end].trim();
+                    full.push('[');
+                    full.push_str(inner);
+                    full.push(']');
+                    tr = &tr[end + 1..];
+                }
+            }
+            is_type = Some(full);
+            let (r2, _) = ws(tr)?;
+            rest = r2;
+            continue;
         } else {
             // Unknown lowercase trait — dispatched to a custom `trait_mod:<is>`
             // at class registration, or X::Comp::Trait::Unknown if none exists.

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -492,21 +492,62 @@ impl Interpreter {
     /// element-type metadata + element type-check); any other container type is
     /// produced by dispatching to that type's `.new`, mirroring the uninitialized
     /// `is Type` path. A value that already matches the declared type is kept.
+    /// Resolve an `is Type` name that is (or aliases to) a subclass of `Array[T]`
+    /// to its concrete class name and element type. Handles a per-composition
+    /// alias (`has @.a is G::A` where `G::A` resolves to `R::G::A[Int]`, itself a
+    /// subclass of `Array[Int]`), so such an attribute type-checks its elements
+    /// exactly like a literal `is Array[Int]`. Returns `None` for a literal
+    /// `Array[...]` (handled directly) or a non-array type.
+    fn is_type_array_subclass_element(&mut self, type_name: &str) -> Option<(String, String)> {
+        if type_name.starts_with("Array[") || type_name.starts_with("array[") {
+            return None;
+        }
+        // A bare/aliased name may map to a concrete parameterized class through
+        // the env (the composition alias `G::A` -> `R::G::A[Int]`).
+        let resolved = match self.env.get(type_name).map(|v| v.view()) {
+            Some(ValueView::Package(name)) => name.resolve(),
+            _ => type_name.to_string(),
+        };
+        if !self.registry().classes.contains_key(&resolved) {
+            return None;
+        }
+        for anc in self.class_mro(&resolved).iter() {
+            let anc = anc.resolve();
+            if let Some(inner) = anc.strip_prefix("Array[").and_then(|s| s.strip_suffix(']')) {
+                return Some((resolved, inner.trim().to_string()));
+            }
+        }
+        None
+    }
+
     pub(crate) fn coerce_value_to_is_type(
         &mut self,
         type_name: &str,
         sigil: char,
         value: Value,
     ) -> Result<Value, RuntimeError> {
-        if self.type_matches_value(type_name, &value) {
+        // A parameterized `Array[T]` is handled below even when the provided
+        // value leniently matches (an untyped array whose current elements
+        // happen to be `T`): it must be rebuilt as a genuinely typed array so
+        // `.^name` is `Array[T]` and later element assignments are checked.
+        let is_parametric_array =
+            type_name.starts_with("Array[") || type_name.starts_with("array[");
+        let array_subclass = self.is_type_array_subclass_element(type_name);
+        if array_subclass.is_none()
+            && !is_parametric_array
+            && self.type_matches_value(type_name, &value)
+        {
             return Ok(value);
         }
-        if let Some(inner) = type_name
+        // The declared container name (for `.^name`) and the element type: a
+        // literal `Array[T]`, or a resolved subclass of `Array[T]`.
+        let array_target = type_name
             .strip_prefix("Array[")
             .or_else(|| type_name.strip_prefix("array["))
             .and_then(|s| s.strip_suffix(']'))
-        {
-            let inner = inner.trim().to_string();
+            .map(|inner| (type_name.to_string(), inner.trim().to_string()))
+            .or(array_subclass);
+        if let Some((declared, inner)) = array_target {
             let coerced = Self::coerce_attr_value_by_sigil(value, '@');
             let items = if let ValueView::Array(items, _) = coerced.view() {
                 (**items).clone()
@@ -528,7 +569,7 @@ impl Interpreter {
                 super::ContainerTypeInfo {
                     value_type: inner,
                     key_type: None,
-                    declared_type: Some(type_name.to_string()),
+                    declared_type: Some(declared),
                 },
             );
             Ok(arr)

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -6,6 +6,40 @@ use super::*;
 use crate::ast::{HandleSpec, ParamDef, PhaserKind};
 use crate::symbol::Symbol;
 
+/// Replace whole type-name tokens in `name` that exactly match a role type
+/// parameter with its concrete type name. Tokens are delimited by `[`, `]`,
+/// `,`, and whitespace, so `Array[TV]` with `TV -> Rat:D` becomes
+/// `Array[Rat:D]` while a nested-class name like `G::A` (no embedded param) is
+/// left untouched.
+fn substitute_type_param_tokens(name: &str, subs: &[(String, String)]) -> String {
+    if subs.is_empty() {
+        return name.to_string();
+    }
+    let mut result = String::with_capacity(name.len());
+    let mut token = String::new();
+    let flush = |token: &mut String, result: &mut String| {
+        if !token.is_empty() {
+            let replacement = subs
+                .iter()
+                .find(|(p, _)| p == token)
+                .map(|(_, r)| r.as_str())
+                .unwrap_or(token.as_str());
+            result.push_str(replacement);
+            token.clear();
+        }
+    };
+    for ch in name.chars() {
+        if matches!(ch, '[' | ']' | ',' | ' ') {
+            flush(&mut token, &mut result);
+            result.push(ch);
+        } else {
+            token.push(ch);
+        }
+    }
+    flush(&mut token, &mut result);
+    result
+}
+
 impl Interpreter {
     /// True for a categorical operator name such as `prefix:<~>`, `infix:<as>`,
     /// `postfix:<!>`, `circumfix:<[ ]>`, etc.
@@ -206,6 +240,49 @@ impl Interpreter {
             .insert(class_name.to_string(), class_def);
         self.clear_private_zeroarg_method_cache();
         Ok(())
+    }
+
+    /// Rename a class declared inside a parametric role body to its
+    /// per-composition parameterized name. `old_name` is the registry key it was
+    /// registered under while running the role's deferred body (`G::A` for a
+    /// class nested in `my package G`, `R::A` for a direct role-body class);
+    /// `role_name` is the composing role (`R`); `suffix` is the bracketed concrete
+    /// type args (`[Int]`). Returns the new registry key, or `None` when no rename
+    /// is needed.
+    fn rename_generic_composed_class(
+        &mut self,
+        old_name: &str,
+        role_name: &str,
+        suffix: &str,
+    ) -> Option<String> {
+        // Prefix the class with the role unless it is already role-qualified, so
+        // a `my package G` nested class (`G::A`) becomes `R::G::A` while a direct
+        // role-body class (`R::A`) keeps its single role prefix.
+        let role_prefix = format!("{role_name}::");
+        let base = if old_name.starts_with(&role_prefix) || old_name == role_name {
+            old_name.to_string()
+        } else {
+            format!("{role_prefix}{old_name}")
+        };
+        let new_name = format!("{base}{suffix}");
+        if new_name == old_name {
+            return None;
+        }
+        // Move the class definition to the new key with a cleared MRO cache so it
+        // recomputes with the new name as its head.
+        let mut def = self.registry_mut().classes.remove(old_name)?;
+        def.mro = std::sync::Arc::from(Vec::<Symbol>::new());
+        self.registry_mut().classes.insert(new_name.clone(), def);
+        if self.user_declared_classes.remove(old_name) {
+            self.user_declared_classes.insert(new_name.clone());
+        }
+        // Register the new type object so `R::G::A[Int]` resolves; the caller
+        // aliases the bare `G::A` reference to the same value.
+        self.env
+            .insert(new_name.clone(), Value::package(Symbol::intern(&new_name)));
+        // Prime the MRO for the new name.
+        self.class_mro(&new_name);
+        Some(new_name)
     }
 
     pub(crate) fn register_class_decl(
@@ -699,6 +776,28 @@ impl Interpreter {
                         .entry((name.to_string(), attr))
                         .or_insert(expr);
                 }
+                // Carry each composed-role attribute's `is Type` container trait
+                // (`has @.a is Array[TV]`, `has @.a is G::A`) onto the consuming
+                // class so its element type is enforced at construction. Type
+                // parameters embedded in the type name (`Array[TV]`) are resolved
+                // to their concrete args (`Array[Rat:D]`); a nested-class trait
+                // (`G::A`) has no embedded param and is repointed to the
+                // parameterized class by the rename pass below.
+                let role_is_types: Vec<(String, String)> = self
+                    .registry()
+                    .role_attribute_is_types
+                    .iter()
+                    .filter(|((r, _), _)| r == base_role_name)
+                    .map(|((_, attr), ty)| {
+                        (attr.clone(), substitute_type_param_tokens(ty, &type_subs))
+                    })
+                    .collect();
+                for (attr, ty) in role_is_types {
+                    self.registry_mut()
+                        .class_attribute_is_types
+                        .entry((name.to_string(), attr))
+                        .or_insert(ty);
+                }
                 for (mname, overloads) in &role.methods {
                     // Skip methods declared with `my` scope -- they are role-private
                     // and should not be composed into consuming classes.
@@ -763,6 +862,29 @@ impl Interpreter {
                     for (param_name, param_value) in &role_param_values {
                         self.bind_type_capture(param_name, param_value);
                     }
+                    // A class declared inside a *parametric* role body becomes
+                    // parametric over the role's type args: `class A is Array[T]`
+                    // in `role R[::T]` composed with `Int` is `R::A[Int]` (or
+                    // `R::G::A[Int]` when nested in `my package G`). Snapshot the
+                    // registry so the freshly-declared nested class(es) can be
+                    // renamed to their per-composition parameterized names below.
+                    let class_suffix: Option<String> = if role_arg_values.is_empty() {
+                        None
+                    } else {
+                        Some(format!(
+                            "[{}]",
+                            role_arg_values
+                                .iter()
+                                .map(type_value_name)
+                                .collect::<Vec<_>>()
+                                .join(",")
+                        ))
+                    };
+                    let classes_before: HashSet<String> = if class_suffix.is_some() {
+                        self.registry().classes.keys().cloned().collect()
+                    } else {
+                        HashSet::new()
+                    };
                     // Run a nested TYPE declaration (`my class CR2`) in the role
                     // body with the ROLE as the current package so it is named
                     // `R2::CR2`, not the composing class. Only type declarations get
@@ -780,6 +902,46 @@ impl Interpreter {
                             self.set_current_package(saved_body_pkg.clone());
                         }
                         r?;
+                    }
+                    // Rename each newly-declared nested class to its
+                    // per-composition parameterized name and record an alias so a
+                    // bare reference (`G::A`) from a composed method still resolves
+                    // to this instantiation's class.
+                    if let Some(suffix) = &class_suffix {
+                        let new_classes: Vec<String> = self
+                            .registry()
+                            .classes
+                            .keys()
+                            .filter(|k| !classes_before.contains(*k))
+                            .cloned()
+                            .collect();
+                        for old_name in new_classes {
+                            if let Some(new_name) = self.rename_generic_composed_class(
+                                &old_name,
+                                base_role_name,
+                                suffix,
+                            ) {
+                                // Repoint any attribute typed `is G::A` at the
+                                // parameterized class so its element type is
+                                // enforced at construction (`is_type_array_subclass_element`
+                                // resolves it via the registry, not a runtime env
+                                // alias that `.new` would have already reset).
+                                let attrs_to_fix: Vec<(String, String)> = self
+                                    .registry()
+                                    .class_attribute_is_types
+                                    .iter()
+                                    .filter(|((c, _), t)| c == name && *t == &old_name)
+                                    .map(|((c, a), _)| (c.clone(), a.clone()))
+                                    .collect();
+                                for key in attrs_to_fix {
+                                    self.registry_mut()
+                                        .class_attribute_is_types
+                                        .insert(key, new_name.clone());
+                                }
+                                class_role_param_bindings
+                                    .insert(old_name, Value::package(Symbol::intern(&new_name)));
+                            }
+                        }
                     }
                     // Remove type capture markers (but keep the variables
                     // created by the deferred stmts for method closures)

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -396,13 +396,21 @@ impl Interpreter {
                     is_our: _,
                     is_my: _,
                     is_default,
-                    is_type: _,
+                    is_type,
                     deprecated_message: _,
                     is_built: _,
                     unknown_traits: _,
                 } => {
                     let attr_name_str = attr_name.resolve();
                     role_def.own_attribute_names.insert(attr_name_str.clone());
+                    // Carry an `is Type` container trait (`has @.a is G::A`) so it
+                    // can be transferred to the consuming class at composition and
+                    // its element type enforced.
+                    if let Some(it) = is_type {
+                        self.registry_mut()
+                            .role_attribute_is_types
+                            .insert((name.to_string(), attr_name_str.clone()), it.clone());
+                    }
                     // `is default(...)` on a role attribute can reference the role's
                     // type parameters (`is default(T)`), so it cannot be evaluated
                     // until composition. Stash the expression keyed by (role, attr);

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -124,6 +124,11 @@ pub(crate) struct Registry {
     pub(crate) class_attribute_default_exprs: HashMap<(String, String), crate::ast::Expr>,
     /// Per-attribute declared type: (class, attr) -> type name.
     pub(crate) class_attribute_is_types: HashMap<(String, String), String>,
+    /// Per-attribute `is Type` container trait declared on a *role* attribute:
+    /// (role, attr) -> type name. Carried onto a consuming class's
+    /// `class_attribute_is_types` at composition (`has @.a is G::A` in a
+    /// parametric role) so the attribute's element type is enforced.
+    pub(crate) role_attribute_is_types: HashMap<(String, String), String>,
     /// Per-attribute `does Role` traits: (class, attr) -> role names mixed into
     /// the attribute's container (`has $.x does Foo`). Applied to the attribute's
     /// value at construction so `$o.x` does the role.

--- a/t/generics-nominalizable-class.t
+++ b/t/generics-nominalizable-class.t
@@ -1,0 +1,48 @@
+use v6.e.PREVIEW;
+use Test;
+
+# A class declared inside a parametric role body becomes parametric over the
+# role's type args: its `.^name` is per-composition (`R::G::A[Int]`), and an
+# attribute typed with it (`has @.a is G::A`) enforces the concrete element type.
+
+plan 11;
+
+my role R[::T] {
+    my package G {
+        class A is Array[T] {}
+    }
+    has @.a is G::A;
+    method a-nominalizables { G::A:D, G::A:U, G::A(), G::A:D() }
+}
+
+my class CInt does R[Int] { }
+my class CStr does R[Str] { }
+
+is CInt.a-nominalizables.map(*.^name).List,
+   ("R::G::A[Int]:D", "R::G::A[Int]:U", "R::G::A[Int](Any)", "R::G::A[Int]:D(Any)"),
+   "generic class instantiates over Int";
+is CStr.a-nominalizables.map(*.^name).List,
+   ("R::G::A[Str]:D", "R::G::A[Str]:U", "R::G::A[Str](Any)", "R::G::A[Str]:D(Any)"),
+   "generic class instantiates over Str";
+
+# Typed-attribute element checking flows through the generic class's Array[T] base.
+lives-ok { CInt.new(a => (1, 10, 20)) }, "CInt accepts Int elements";
+throws-like { CInt.new(a => <A B C>) }, X::TypeCheck::Assignment,
+    "CInt rejects Str elements";
+lives-ok { CStr.new(a => <A B C>) }, "CStr accepts Str elements";
+throws-like { CStr.new(a => (1, 2)) }, X::TypeCheck::Assignment,
+    "CStr rejects Int elements";
+
+# The plain (non-generic) `is Array[Int]` container trait keeps its
+# parameterization: the `[Int]` is not dropped as a separate statement.
+class Plain { has @.nums is Array[Int] }
+is Plain.new(a => Nil).defined, True, "Plain constructs";
+throws-like { Plain.new(nums => <x y>) }, X::TypeCheck::Assignment,
+    "is Array[Int] rejects wrong element types at construction";
+my $p = Plain.new(nums => [1, 2, 3]);
+is $p.nums.List, (1, 2, 3), "is Array[Int] keeps good values";
+is $p.nums.^name, "Array[Int]", "is Array[Int] tags the container type";
+
+# A `::`-qualified `is` container trait name is parsed whole.
+class Box { has @.items is Array[Int] }
+lives-ok { Box.new(items => [4, 5]) }, "qualified/parameterized is-type parses";


### PR DESCRIPTION
Fully whitelists `roast/S02-types/generics.t` (all 6 subtests). Following the coercion-type-terms landing (#4681, subtests 1-2), three general-purpose fixes clear the remaining subtests 3-6.

## Changes

- **Parser: `is Type[params]` / `is Qualified::Name` container traits kept whole.** `has @.a is Array[Int]` parsed as `is_type: "Array"` with the trailing `[Int]` misparsed as a *separate* statement, silently dropping the parameterization (so `Foo.new(a => <bad>)` was never element-checked). The `has`-attribute trait parser now consumes `::`-qualified segments and a balanced `[...]` parameterization into the type name.

- **Per-composition parameterized class naming.** A class declared inside a *parametric* role body (`role R[::T] { my package G { class A is Array[T] {} } }`) becomes parametric over the role's type args: composing `R[Int]` renames the nested class to `R::G::A[Int]` (and `R[Str]` to `R::G::A[Str]`), so `.^name` and the coercion-term forms (`G::A:D`, `G::A()`) report the instantiation-pinned name. Each composition renames the freshly-declared class and records an alias so a bare `G::A` reference from a composed method still resolves.

- **Typed-attribute element checking through a generic Array subclass.** A role attribute's `is Type` container trait (`has @.a is G::A`) is carried onto the consuming class, and `coerce_value_to_is_type` resolves a subclass of `Array[T]` to its concrete element type — so a wrong-typed `.new(a => <bad>)` throws `X::TypeCheck::Assignment`, exactly like a literal `is Array[Int]`.

## Tests

- `roast/S02-types/generics.t` — now fully passes, added to whitelist.
- Pin: `t/generics-nominalizable-class.t` (11 assertions).
- `make test` PASS, `cargo clippy -- -D warnings` clean, related roast (S09 typed-arrays / S12 attributes / all whitelisted S14 roles) — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)