### PR TITLE
feat: RakuAST Phase 2 slice 4 — if/else, while, and bare loop

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -756,11 +756,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 3: bare blocks (`Block`/`Blockoid`) and pointy blocks (`PointyBlock`/`Signature`/
         `Parameter`/`ParameterTarget::Var`, plain positional params only). Tests in
         `t/rakuast-blocks.t`. (PR #4684.)
-  - [ ] Slice 4: `if`/`unless` and `while`/`until`/`loop` statements (`Statement::If`/`Unless`/
-        `Loop::While`/`Loop::Until`/`Loop`), condition + `then`/`body` = `Block`, `if...else`.
-        Defer topic-taking blocks (`with`/`without`/`for` add `implicit-topic`/`required-topic`
-        Block fields), `elsif` chains, C-style `loop`, and postfix statement modifiers to slice 5.
-  - [ ] Slice 5+: `with`/`without`/`for`, `elsif`, sub declarations (`RakuAST::Sub`, reuse
+  - [x] Slice 4: `if`/`if...else`, `while`, and bare `loop` (`Statement::If`, `Statement::Loop::
+        While`, `Statement::Loop`), condition + `then`/`else`/`body` = `Block`. Tests in
+        `t/rakuast-control.t`. (mutsu desugars `unless`→`if !` and `until`→`while !`, so those
+        render with a negated condition — documented divergence, ADR-0011.)
+  - [ ] Slice 5+: `elsif` chains, C-style/`repeat`/labelled loops, topic-taking `with`/`without`/
+        `for` (Block `implicit-topic`/`required-topic`), sub declarations (`RakuAST::Sub`, reuse
         Signature), scoped/typed `my`, compound/`:=` assignment, method-call modifiers; then
         `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`,
         mutsu does not).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -157,6 +157,17 @@ earlier ones.
   operands. Leaning (a) for fidelity to *mutsu's* AST, revisited with data.
 - **`.AST` on `Code`/blocks (Phase 2+).** Phase 1 is `Str`-only; `.AST` on a `Block`/`Routine`
   needs the internal AST retained on the code object.
+- **`unless`/`until` fold to `if !`/`while !` (Phase 2 slice 4).** mutsu's parser desugars
+  `unless X { }` to `if !X { }` and `until X { }` to `while !X { }` at parse time — there is no
+  distinct `Unless`/`Until` node in the internal AST. So `unless X.AST` renders
+  `RakuAST::Statement::If` with a negated `ApplyPrefix(!)` condition (and `until` renders
+  `Statement::Loop::While` likewise), whereas raku keeps `RakuAST::Statement::Unless` /
+  `Loop::Until` with the bare condition. This is faithful to *mutsu's* AST (the desugaring is
+  lossless-but-collapsing: `if !X` and `unless X` are the same node), so reconstituting the
+  surface keyword would be a guess — deliberately not done. Narrows only if the parser grows
+  distinct `unless`/`until` statements. `elsif` chains, C-style/`repeat`/labelled loops, topic
+  binding (`if EXPR -> $v`), and topic-taking `with`/`without`/`for` are the coverage boundary
+  (explicit `RuntimeError`), deferred to a later slice.
 - **Single-param pointy sigil loss (Phase 2 slice 3).** mutsu parses a single-parameter pointy
   block to `Expr::Lambda { param: String }` with the sigil stripped, and does not preserve `@`/`%`
   for a single non-scalar param (`-> @a` becomes `param: "a"`). The converter therefore assumes `$`

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -90,6 +90,64 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
         }
         // A bare `{ ... }` block at statement level -> Statement::Expression(Block).
         Stmt::Block(body) => Ok(Some(statement_expression(block_node(body)?))),
+        Stmt::If {
+            cond,
+            then_branch,
+            else_branch,
+            binding_var,
+        } => {
+            // mutsu desugars `unless X` to `if !X`, so an `unless` renders as a
+            // `Statement::If` whose condition is `ApplyPrefix(!)` — a documented
+            // divergence (raku keeps `Statement::Unless` with the bare condition).
+            if binding_var.is_some() {
+                return Err(unsupported("`if EXPR -> $var` topic binding"));
+            }
+            if is_elsif_chain(else_branch) {
+                return Err(unsupported("`elsif` chain"));
+            }
+            let mut fields = vec![
+                node_field(Some("condition"), convert_expr(cond)?),
+                node_field(Some("then"), block_node(then_branch)?),
+            ];
+            if else_branch.iter().any(|s| !matches!(s, Stmt::SetLine(_))) {
+                fields.push(node_field(Some("else"), block_node(else_branch)?));
+            }
+            Ok(Some(RakuAstNode {
+                class: RakuAstClass::StatementIf,
+                fields,
+            }))
+        }
+        Stmt::While { cond, body, label } => {
+            // mutsu desugars `until X` to `while !X` (same as unless/if above).
+            if label.is_some() {
+                return Err(unsupported("loop label"));
+            }
+            Ok(Some(RakuAstNode {
+                class: RakuAstClass::StatementLoopWhile,
+                fields: vec![
+                    node_field(Some("condition"), convert_expr(cond)?),
+                    node_field(Some("body"), block_node(body)?),
+                ],
+            }))
+        }
+        Stmt::Loop {
+            init,
+            cond,
+            step,
+            body,
+            repeat,
+            label,
+        } => {
+            // Only the bare `loop { }` form; the C-style `loop (init; cond; step)`,
+            // `repeat` loops, and labelled loops carry extra RakuAST shape.
+            if init.is_some() || cond.is_some() || step.is_some() || *repeat || label.is_some() {
+                return Err(unsupported("C-style / repeat / labelled loop"));
+            }
+            Ok(Some(RakuAstNode {
+                class: RakuAstClass::StatementLoop,
+                fields: vec![node_field(Some("body"), block_node(body)?)],
+            }))
+        }
         Stmt::Assign { name, expr, op } => {
             // Phase 2 slice 2 covers only plain `=`; `:=` (Bind) and match-assign
             // map to distinct RakuAST nodes.
@@ -265,6 +323,17 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
         }
         other => Err(unsupported(&format!("{other:?}"))),
     }
+}
+
+/// True when an `if`'s else-branch is a single nested `if` — i.e. an `elsif`
+/// chain (mutsu nests `elsif` into `else_branch`). raku models these as a flat
+/// `elsifs` list, deferred to a later slice, so we treat it as the boundary
+/// rather than mis-render it as a plain `else => Block(If)`.
+fn is_elsif_chain(else_branch: &[Stmt]) -> bool {
+    let mut real = else_branch
+        .iter()
+        .filter(|s| !matches!(s, Stmt::SetLine(_)));
+    matches!(real.next(), Some(Stmt::If { .. })) && real.next().is_none()
 }
 
 /// A `{ ... }` block body wraps its `StatementList` in a `Blockoid`.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -74,6 +74,10 @@ pub enum RakuAstClass {
     Signature,
     Parameter,
     ParameterTargetVar,
+    // Phase 2 slice 4: conditionals and loops.
+    StatementIf,
+    StatementLoopWhile,
+    StatementLoop,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -114,6 +118,9 @@ impl RakuAstClass {
             Signature => "RakuAST::Signature",
             Parameter => "RakuAST::Parameter",
             ParameterTargetVar => "RakuAST::ParameterTarget::Var",
+            StatementIf => "RakuAST::Statement::If",
+            StatementLoopWhile => "RakuAST::Statement::Loop::While",
+            StatementLoop => "RakuAST::Statement::Loop",
         }
     }
 

--- a/t/rakuast-control.t
+++ b/t/rakuast-control.t
@@ -1,0 +1,100 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 4 (ADR-0011): conditionals and loops
+# (Statement::If, Statement::Loop::While, Statement::Loop).
+# Expected gists captured verbatim from Rakudo; this file passes under BOTH
+# mutsu and raku, so raku is the oracle.
+#
+# Note: mutsu desugars `unless X` to `if !X` and `until X` to `while !X`, so
+# those render as Statement::If / Loop::While with a negated condition (a
+# documented divergence from raku, ADR-0011) and are intentionally not pinned
+# here — this file only asserts constructs mutsu and raku render identically.
+
+plan 5;
+
+# --- if without else --------------------------------------------------------
+is Q[if 1 { 2 }].AST.gist, q:to/END/.chomp, 'if -> Statement::If(condition, then)';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::If.new(
+        condition => RakuAST::IntLiteral.new(1),
+        then      => RakuAST::Block.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::IntLiteral.new(2)
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- if with else -----------------------------------------------------------
+is Q[if 1 { 2 } else { 3 }].AST.gist, q:to/END/.chomp, 'if/else -> Statement::If(condition, then, else)';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::If.new(
+        condition => RakuAST::IntLiteral.new(1),
+        then      => RakuAST::Block.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::IntLiteral.new(2)
+              )
+            )
+          )
+        ),
+        else      => RakuAST::Block.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::IntLiteral.new(3)
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- while ------------------------------------------------------------------
+is Q[while 1 { 2 }].AST.gist, q:to/END/.chomp, 'while -> Statement::Loop::While(condition, body)';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Loop::While.new(
+        condition => RakuAST::IntLiteral.new(1),
+        body      => RakuAST::Block.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::IntLiteral.new(2)
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- bare loop --------------------------------------------------------------
+is Q[loop { 1 }].AST.gist, q:to/END/.chomp, 'bare loop -> Statement::Loop(body)';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Loop.new(
+        body => RakuAST::Block.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::IntLiteral.new(1)
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- condition and body carry arbitrary expressions -------------------------
+is Q[my $x; while $x { $x.abs }].AST.gist.contains(q:to/FRAG/.chomp), True, 'loop condition/body nest expressions';
+      RakuAST::Statement::Loop::While.new(
+        condition => RakuAST::Var::Lexical.new("\$x"),
+    FRAG


### PR DESCRIPTION
## Summary

Phase 2 slice 4 of RakuAST (ADR-0011): extend `Str.AST` introspection to the **conditional/loop cluster** — `RakuAST::Statement::If`, `Statement::Loop::While`, and `Statement::Loop`.

## What's covered

- **`if` / `if ... else`** → `Statement::If(condition, then => Block, [else => Block])`.
- **`while`** → `Statement::Loop::While(condition, body => Block)`.
- **bare `loop { }`** → `Statement::Loop(body => Block)`.

Reuses the `Block`/`Blockoid` machinery from slice 3 (#4684) for the branch/body bodies.

## Coverage boundary (explicit `RuntimeError`, deferred to slice 5)

`elsif` chains (mutsu nests them into `else_branch`; raku uses a flat `elsifs` list), C-style / `repeat` / labelled loops, `if EXPR -> $v` topic binding, and topic-taking `with`/`without`/`for` blocks.

## Documented divergence

mutsu's parser desugars `unless X` → `if !X` and `until X` → `while !X` at parse time — there is no distinct `Unless`/`Until` node in the internal AST. So `unless X.AST` renders `Statement::If` with a negated `ApplyPrefix(!)` condition (and `until` → `Loop::While` likewise), whereas raku keeps `Statement::Unless` / `Loop::Until` with the bare condition. This is faithful to mutsu's collapsed AST (`if !X` and `unless X` are the same node); reconstituting the surface keyword would be a guess and is deliberately not done. Recorded in ADR-0011 Open questions.

## Tests

`t/rakuast-control.t` — 5 assertions, **passing under BOTH mutsu and raku** (raku is the oracle). Existing `t/rakuast-{ast,expr,calls-assign,blocks}.t` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)