### PR TITLE
fix: quantified captures in subst closures; test-call `or` continuation

### DIFF
--- a/src/parser/stmt/simple/control_stmts.rs
+++ b/src/parser/stmt/simple/control_stmts.rs
@@ -484,6 +484,20 @@ pub(crate) fn known_call_stmt(input: &str) -> PResult<'_, Stmt> {
             ))),
         });
     }
+    // A trailing low-precedence word infix (`ok(...) or say "NO"`) means the
+    // call is the LEFT OPERAND of a larger expression — this statement-level
+    // parse would silently drop the ` or ...` tail (it is not a statement
+    // modifier). Bail to the expression-statement parser, which builds the
+    // full Binary.
+    {
+        let (after_ws, _) = ws(rest)?;
+        if ["or", "and", "andthen", "orelse", "notandthen"]
+            .iter()
+            .any(|kw| keyword(kw, after_ws).is_some())
+        {
+            return Err(PError::expected("known function call"));
+        }
+    }
     let stmt = Stmt::Call {
         name: Symbol::intern(&name),
         args,

--- a/src/runtime/methods_string_subst_repl.rs
+++ b/src/runtime/methods_string_subst_repl.rs
@@ -77,7 +77,18 @@ impl Interpreter {
                 .len()
                 .max(captures.positional.len());
             for i in 0..positional_len {
-                let value = if let Some(Some((capture, _, _))) = captures.positional_slots.get(i) {
+                // A quantified capture group (`( ... )+`) exposes the LIST of
+                // per-iteration matches as `$N`; the flat slot only holds the
+                // last iteration's text (t/uri-unescape shape:
+                // `.subst(:g, /['%' (<.xdigit>**2)]+/, -> $/ { $0.flatmap... })`).
+                let value = if let Some(Some(qlist)) = captures.positional_quantified.get(i) {
+                    Value::array(
+                        qlist
+                            .iter()
+                            .map(|(text, _, _, _)| Value::str(text.clone()))
+                            .collect(),
+                    )
+                } else if let Some(Some((capture, _, _))) = captures.positional_slots.get(i) {
                     Value::str(capture.clone())
                 } else if let Some(capture) = captures.positional.get(i) {
                     Value::str(capture.clone())

--- a/t/subst-closure-quantified-capture.t
+++ b/t/subst-closure-quantified-capture.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+plan 5;
+
+# Inside a .subst replacement closure, a quantified capture group must expose
+# the LIST of per-iteration matches as $0 — not just the last one. This is
+# the URI::Escape uri-unescape shape.
+my $out = '%7C%25abc'.subst(:g, / [ '%' (<.xdigit> ** 2) ]+ /, -> $/ {
+    $0.flatmap({ :16(~$_).chr }).join
+});
+is $out, '|%abc', 'quantified $0 in a subst closure carries all iterations';
+
+my $elems;
+'%41%42'.subst(:g, / [ '%' (<.xdigit> ** 2) ]+ /, -> $/ { $elems = $0.elems; '' });
+is $elems, 2, '$0.elems sees both iterations';
+
+# Buf-building form (the UTF-8 decode branch of uri-unescape).
+my $utf8 = '%C3%A5'.subst(:g, / [ '%' (<.xdigit> ** 2) ]+ /, -> $/ {
+    Buf.new($0.flatmap({ :16(~$_) })).decode('UTF-8')
+});
+is $utf8, 'å', 'quantified captures rebuild a UTF-8 sequence';
+
+# A non-quantified group keeps its scalar shape.
+is 'a1b'.subst(/ (\d) /, -> $/ { "<{$0}>" }), 'a<1>b',
+    'plain $0 in a subst closure still works';
+
+# Multiple groups where only the second is quantified.
+my $shape;
+'x-ababy' ~~ / (\w) '-' [ (ab) ]+ /;
+'x-abab'.subst(/ (\w) '-' [ (ab) ]+ /, -> $/ { $shape = "{$0}:{$1.elems}"; '' });
+is $shape, 'x:2', 'mixed plain + quantified groups keep their shapes';

--- a/t/test-call-or-continuation.t
+++ b/t/test-call-or-continuation.t
@@ -1,0 +1,24 @@
+use v6;
+use Test;
+
+plan 7;
+
+# `ok(...) or <expr>` — with Test loaded, `ok(...)` parses via the known-call
+# statement path, which must not swallow the trailing low-precedence infix
+# (URI's november-urlencoded.rakutest `ok(...) or say ...` shape).
+my $ran = False;
+ok(1 == 1, 'passing assertion') or $ran = True;
+nok $ran, 'or-branch does not run when the assertion passes';
+
+todo 'intentional failure to drive the or-branch';
+ok(1 == 2, 'failing assertion') or $ran = True;
+ok $ran, 'or-branch runs when the assertion fails';
+
+# `and` continuation.
+my $and-ran = False;
+ok(1 == 1, 'passing assertion for and') and $and-ran = True;
+ok $and-ran, 'and-branch runs when the assertion passes';
+
+# The statement-modifier forms still parse.
+my $n = 0;
+ok(1 == 1, 'modifier if') if $n == 0;


### PR DESCRIPTION
## Summary

Two more general bugs surfaced by the URI-0.3.8 dist suite (follow-up to #4683 / #4685):

1. **Quantified `$0` in subst closures** — inside `.subst(:g, / [ '%' (<.xdigit> ** 2) ]+ /, -> $/ { ... })`, `$0` held only the *last* iteration's text. The `$/` Match was already built with the full quantified list; the numbered env vars were separately re-derived from the flat slot strings. They now consult `positional_quantified` first, so URI::Escape's `uri-unescape` decodes every escape (both the latin-1 `.chr` branch and the `Buf.new(...).decode` UTF-8 branch).
2. **`ok(...) or say ...` dropped the tail with `use Test`** — the known-call statement parser consumed `ok(...)`, saw no statement modifier, and returned, leaving ` or say "NO"` to re-parse as a nonsense `"or" say "NO"` user-infix statement (it printed `or` and always ran the RHS). When a low-precedence word infix (`or`/`and`/`andthen`/`orelse`/`notandthen`) follows the call, the known-call path now bails to the expression-statement parser, which builds the proper short-circuiting Binary.

URI-0.3.8 after this + #4683 + #4685: **9/14 test files fully green** (was 3/14 at session start); `escape.rakutest` 11/11 and `november-urlencoded.rakutest` 13/13 now pass.

## Test plan

- [x] New pins `t/subst-closure-quantified-capture.t`, `t/test-call-or-continuation.t` green on raku and mutsu
- [x] `make test` PASS
- [x] Roast subset S24-testing + S02-literals + S06-signature + S32-list (Test-call-heavy) via `scripts/run-roast-test.sh`: PASS
- [x] clippy `-D warnings` + fmt clean
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)