### PR TITLE
feat: RakuAST Phase 2 slice 5 — elsif chains

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -760,11 +760,14 @@ so it is tracked separately from the roast backlog.
         While`, `Statement::Loop`), condition + `then`/`else`/`body` = `Block`. Tests in
         `t/rakuast-control.t`. (mutsu desugars `unless`→`if !` and `until`→`while !`, so those
         render with a negated condition — documented divergence, ADR-0011.)
-  - [ ] Slice 5+: `elsif` chains, C-style/`repeat`/labelled loops, topic-taking `with`/`without`/
-        `for` (Block `implicit-topic`/`required-topic`), sub declarations (`RakuAST::Sub`, reuse
-        Signature), scoped/typed `my`, compound/`:=` assignment, method-call modifiers; then
-        `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`,
-        mutsu does not).
+  - [x] Slice 5: `elsif` chains — mutsu nests each `elsif` as a single `if` in the else-branch;
+        flattened into raku's `elsifs` list (`Statement::Elsif`) with any trailing `else` block.
+        Tests in `t/rakuast-elsif.t`.
+  - [ ] Slice 6+: C-style/`repeat`/labelled loops, topic-taking `with`/`without`/`for` (Block
+        `implicit-topic`/`required-topic`), sub declarations (`RakuAST::Sub`, reuse Signature),
+        scoped/typed `my`, compound/`:=` assignment, method-call modifiers; then `.DEPARSE`;
+        resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu
+        does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -165,9 +165,12 @@ earlier ones.
   `Loop::Until` with the bare condition. This is faithful to *mutsu's* AST (the desugaring is
   lossless-but-collapsing: `if !X` and `unless X` are the same node), so reconstituting the
   surface keyword would be a guess — deliberately not done. Narrows only if the parser grows
-  distinct `unless`/`until` statements. `elsif` chains, C-style/`repeat`/labelled loops, topic
-  binding (`if EXPR -> $v`), and topic-taking `with`/`without`/`for` are the coverage boundary
-  (explicit `RuntimeError`), deferred to a later slice.
+  distinct `unless`/`until` statements. `elsif` chains are handled (slice 5): mutsu nests each
+  `elsif` as a single `if` inside the else-branch, and the converter flattens that chain into
+  raku's flat `elsifs` list (`Statement::Elsif`), with any trailing block as the final `else`.
+  C-style/`repeat`/labelled loops, topic binding (`if EXPR -> $v` / `elsif EXPR -> $v`), and
+  topic-taking `with`/`without`/`for` remain the coverage boundary (explicit `RuntimeError`),
+  deferred to a later slice.
 - **Single-param pointy sigil loss (Phase 2 slice 3).** mutsu parses a single-parameter pointy
   block to `Expr::Lambda { param: String }` with the sigil stripped, and does not preserve `@`/`%`
   for a single non-scalar param (`-> @a` becomes `param: "a"`). The converter therefore assumes `$`

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -102,15 +102,36 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             if binding_var.is_some() {
                 return Err(unsupported("`if EXPR -> $var` topic binding"));
             }
-            if is_elsif_chain(else_branch) {
-                return Err(unsupported("`elsif` chain"));
-            }
             let mut fields = vec![
                 node_field(Some("condition"), convert_expr(cond)?),
                 node_field(Some("then"), block_node(then_branch)?),
             ];
-            if else_branch.iter().any(|s| !matches!(s, Stmt::SetLine(_))) {
-                fields.push(node_field(Some("else"), block_node(else_branch)?));
+            // mutsu nests each `elsif` as a single `if` inside the else-branch.
+            // Flatten that chain into raku's `elsifs` list; whatever remains
+            // after the last `elsif` is the final `else` block.
+            let mut elsifs: Vec<Value> = Vec::new();
+            let mut tail: &[Stmt] = else_branch;
+            while let Some(Stmt::If {
+                cond,
+                then_branch,
+                else_branch,
+                binding_var,
+            }) = single_if_stmt(tail)
+            {
+                if binding_var.is_some() {
+                    return Err(unsupported("`elsif EXPR -> $var` topic binding"));
+                }
+                elsifs.push(Value::rakuast(Box::new(elsif_node(cond, then_branch)?)));
+                tail = else_branch;
+            }
+            if !elsifs.is_empty() {
+                fields.push(RakuAstField {
+                    name: Some("elsifs"),
+                    value: RakuAstFieldValue::List(elsifs),
+                });
+            }
+            if tail.iter().any(|s| !matches!(s, Stmt::SetLine(_))) {
+                fields.push(node_field(Some("else"), block_node(tail)?));
             }
             Ok(Some(RakuAstNode {
                 class: RakuAstClass::StatementIf,
@@ -325,15 +346,27 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
     }
 }
 
-/// True when an `if`'s else-branch is a single nested `if` — i.e. an `elsif`
-/// chain (mutsu nests `elsif` into `else_branch`). raku models these as a flat
-/// `elsifs` list, deferred to a later slice, so we treat it as the boundary
-/// rather than mis-render it as a plain `else => Block(If)`.
-fn is_elsif_chain(else_branch: &[Stmt]) -> bool {
-    let mut real = else_branch
-        .iter()
-        .filter(|s| !matches!(s, Stmt::SetLine(_)));
-    matches!(real.next(), Some(Stmt::If { .. })) && real.next().is_none()
+/// If `stmts` (ignoring `SetLine` bookkeeping) is exactly one `if` statement,
+/// return it — this is how mutsu nests an `elsif`. Anything else (a real
+/// `else` block, multiple statements, empty) returns `None`.
+fn single_if_stmt(stmts: &[Stmt]) -> Option<&Stmt> {
+    let mut real = stmts.iter().filter(|s| !matches!(s, Stmt::SetLine(_)));
+    let first = real.next()?;
+    if real.next().is_some() {
+        return None;
+    }
+    matches!(first, Stmt::If { .. }).then_some(first)
+}
+
+/// One `elsif` clause -> `Statement::Elsif(condition, then => Block)`.
+fn elsif_node(cond: &Expr, then_branch: &[Stmt]) -> Result<RakuAstNode, RuntimeError> {
+    Ok(RakuAstNode {
+        class: RakuAstClass::StatementElsif,
+        fields: vec![
+            node_field(Some("condition"), convert_expr(cond)?),
+            node_field(Some("then"), block_node(then_branch)?),
+        ],
+    })
 }
 
 /// A `{ ... }` block body wraps its `StatementList` in a `Blockoid`.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -78,6 +78,8 @@ pub enum RakuAstClass {
     StatementIf,
     StatementLoopWhile,
     StatementLoop,
+    // Phase 2 slice 5: elsif chains.
+    StatementElsif,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -121,6 +123,7 @@ impl RakuAstClass {
             StatementIf => "RakuAST::Statement::If",
             StatementLoopWhile => "RakuAST::Statement::Loop::While",
             StatementLoop => "RakuAST::Statement::Loop",
+            StatementElsif => "RakuAST::Statement::Elsif",
         }
     }
 

--- a/t/rakuast-elsif.t
+++ b/t/rakuast-elsif.t
@@ -1,0 +1,87 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 5 (ADR-0011): elsif chains.
+# mutsu nests each `elsif` as a single `if` inside the else-branch; this
+# flattens the chain into raku's `elsifs` list (Statement::Elsif), with any
+# trailing `else` block after the last `elsif`. Expected gists captured
+# verbatim from Rakudo; this file passes under BOTH mutsu and raku.
+
+plan 3;
+
+# --- single elsif, no else --------------------------------------------------
+is Q[if 1 {2} elsif 3 {4}].AST.gist, q:to/END/.chomp, 'if/elsif -> elsifs list';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::If.new(
+        condition => RakuAST::IntLiteral.new(1),
+        then      => RakuAST::Block.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::IntLiteral.new(2)
+              )
+            )
+          )
+        ),
+        elsifs    => (
+          RakuAST::Statement::Elsif.new(
+            condition => RakuAST::IntLiteral.new(3),
+            then      => RakuAST::Block.new(
+              body => RakuAST::Blockoid.new(
+                RakuAST::StatementList.new(
+                  RakuAST::Statement::Expression.new(
+                    expression => RakuAST::IntLiteral.new(4)
+                  )
+                )
+              )
+            )
+          ),
+        )
+      )
+    )
+    END
+
+# --- elsif followed by a trailing else --------------------------------------
+is Q[if 1 {2} elsif 3 {4} else {5}].AST.gist, q:to/END/.chomp, 'if/elsif/else -> elsifs then else';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::If.new(
+        condition => RakuAST::IntLiteral.new(1),
+        then      => RakuAST::Block.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::IntLiteral.new(2)
+              )
+            )
+          )
+        ),
+        elsifs    => (
+          RakuAST::Statement::Elsif.new(
+            condition => RakuAST::IntLiteral.new(3),
+            then      => RakuAST::Block.new(
+              body => RakuAST::Blockoid.new(
+                RakuAST::StatementList.new(
+                  RakuAST::Statement::Expression.new(
+                    expression => RakuAST::IntLiteral.new(4)
+                  )
+                )
+              )
+            )
+          ),
+        ),
+        else      => RakuAST::Block.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::IntLiteral.new(5)
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- two elsifs render as two elements of the flat list ---------------------
+is Q[if 1 {2} elsif 3 {4} elsif 5 {6} else {7}].AST.gist.comb(/'RakuAST::Statement::Elsif.new'/).elems, 2,
+    'two elsifs -> two Statement::Elsif nodes in the list';


### PR DESCRIPTION
## Summary

Phase 2 slice 5 of RakuAST (ADR-0011): extend `Str.AST` introspection to **`elsif` chains** (`RakuAST::Statement::Elsif`).

mutsu's parser nests each `elsif` as a single `if` statement inside the enclosing `if`'s `else_branch`. The converter now walks that nesting and **flattens** it into raku's flat `elsifs` list, leaving whatever remains after the last `elsif` as the final `else` block. This turns slice 4's `elsif`-chain coverage-boundary error into real support.

```
if 1 {2} elsif 3 {4} else {5}
  -> Statement::If(
       condition, then => Block,
       elsifs => ( Statement::Elsif(condition, then => Block), ),
       else   => Block )
```

## Still deferred

`elsif EXPR -> $var` topic binding (explicit `RuntimeError`, like `if EXPR -> $var`); C-style/`repeat`/labelled loops; topic-taking `with`/`without`/`for`; sub declarations.

## Tests

`t/rakuast-elsif.t` — 3 assertions (single elsif, elsif+else, two-elsif count), **passing under BOTH mutsu and raku** (raku is the oracle). All existing `t/rakuast-*.t` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)