### PR TITLE
feat: RakuAST Phase 2 slice 6 — implicit-topic for loops

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -763,9 +763,13 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 5: `elsif` chains — mutsu nests each `elsif` as a single `if` in the else-branch;
         flattened into raku's `elsifs` list (`Statement::Elsif`) with any trailing `else` block.
         Tests in `t/rakuast-elsif.t`.
-  - [ ] Slice 6+: C-style/`repeat`/labelled loops, topic-taking `with`/`without`/`for` (Block
-        `implicit-topic`/`required-topic`), sub declarations (`RakuAST::Sub`, reuse Signature),
-        scoped/typed `my`, compound/`:=` assignment, method-call modifiers; then `.DEPARSE`;
+  - [x] Slice 6: implicit-topic `for` (`Statement::For` with topic-taking `Block` marked
+        `implicit-topic`/`required-topic`). Tests in `t/rakuast-for.t`. (`with`/`without` are
+        desugared by mutsu into temp-var + `.defined` + `if`, so no `Statement::With` node to
+        recover — deferred, documented in ADR-0011.)
+  - [ ] Slice 7+: C-style/`repeat`/labelled loops, explicit-signature `for` (`for @a -> $x`),
+        sub declarations (`RakuAST::Sub`, reuse Signature), scoped/typed `my`, compound/`:=`
+        assignment, comma-list source (`ApplyListInfix`), method-call modifiers; then `.DEPARSE`;
         resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu
         does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -168,9 +168,17 @@ earlier ones.
   distinct `unless`/`until` statements. `elsif` chains are handled (slice 5): mutsu nests each
   `elsif` as a single `if` inside the else-branch, and the converter flattens that chain into
   raku's flat `elsifs` list (`Statement::Elsif`), with any trailing block as the final `else`.
-  C-style/`repeat`/labelled loops, topic binding (`if EXPR -> $v` / `elsif EXPR -> $v`), and
-  topic-taking `with`/`without`/`for` remain the coverage boundary (explicit `RuntimeError`),
-  deferred to a later slice.
+  C-style/`repeat`/labelled loops and topic binding (`if EXPR -> $v` / `elsif EXPR -> $v`) remain
+  the coverage boundary (explicit `RuntimeError`), deferred to a later slice. Implicit-topic `for`
+  is handled (slice 6): `for SRC { ... }` (no explicit signature) → `Statement::For(mode =>
+  "serial", source, body)` where the body is a topic-taking `Block` marked `implicit-topic => True`
+  / `required-topic => 1`. `with`/`without` are NOT mappable — mutsu desugars them at parse time
+  into a temp-var + `.defined` check + `if` (`__with_tmp_0`), so there is no `Statement::With` node
+  to recover (same collapse as `unless`/`until`); deferred. Explicit-signature `for` (`for @a ->
+  $x`), hyper/race/lazy modes, `<->` rw blocks, and labels also remain the boundary. Note the
+  topic-call form `.method` (i.e. `$_.method` written bare) is desugared by mutsu to `$_.method`
+  (`ApplyPostfix` on `$_`), where raku keeps a distinct `Term::TopicCall` — a pre-existing
+  method-call representation divergence, unrelated to `for`.
 - **Single-param pointy sigil loss (Phase 2 slice 3).** mutsu parses a single-parameter pointy
   block to `Expr::Lambda { param: String }` with the sigil stripped, and does not preserve `@`/`%`
   for a single non-scalar param (`-> @a` becomes `param: "a"`). The converter therefore assumes `$`

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -7,7 +7,7 @@
 //! silently-wrong node.
 
 use super::{RakuAstClass, RakuAstField, RakuAstFieldValue, RakuAstNode};
-use crate::ast::{AssignOp, Expr, ParamDef, Stmt};
+use crate::ast::{AssignOp, Expr, ForMode, ParamDef, Stmt};
 use crate::compiler::helpers_ops::token_kind_to_op_name;
 use crate::value::{RuntimeError, Value, ValueView};
 
@@ -167,6 +167,41 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             Ok(Some(RakuAstNode {
                 class: RakuAstClass::StatementLoop,
                 fields: vec![node_field(Some("body"), block_node(body)?)],
+            }))
+        }
+        Stmt::For {
+            iterable,
+            param,
+            param_def,
+            params,
+            params_def,
+            body,
+            label,
+            mode,
+            rw_block,
+            explicit_zero_params,
+        } => {
+            // Phase 2 slice 6 covers the implicit-topic form (`for SRC { ... $_ }`)
+            // only. An explicit signature (`for @a -> $x`), hyper/race/lazy modes,
+            // `<->` rw blocks, and labels carry extra RakuAST shape, deferred.
+            if param.is_some()
+                || param_def.is_some()
+                || !params.is_empty()
+                || !params_def.is_empty()
+                || label.is_some()
+                || *rw_block
+                || *explicit_zero_params
+                || !matches!(mode, ForMode::Normal)
+            {
+                return Err(unsupported("for loop with explicit params / mode / label"));
+            }
+            Ok(Some(RakuAstNode {
+                class: RakuAstClass::StatementFor,
+                fields: vec![
+                    leaf_field(Some("mode"), Value::str("serial".to_string())),
+                    node_field(Some("source"), convert_expr(iterable)?),
+                    node_field(Some("body"), topic_block_node(body)?),
+                ],
             }))
         }
         Stmt::Assign { name, expr, op } => {
@@ -382,6 +417,26 @@ fn block_node(body: &[Stmt]) -> Result<RakuAstNode, RuntimeError> {
     Ok(RakuAstNode {
         class: RakuAstClass::Block,
         fields: vec![node_field(Some("body"), blockoid(body)?)],
+    })
+}
+
+/// A topic-taking block body (the `{ ... }` of an implicit-topic `for`), which
+/// raku marks with `implicit-topic => True` and `required-topic => 1` before
+/// the `body` field.
+fn topic_block_node(body: &[Stmt]) -> Result<RakuAstNode, RuntimeError> {
+    Ok(RakuAstNode {
+        class: RakuAstClass::Block,
+        fields: vec![
+            RakuAstField {
+                name: Some("implicit-topic"),
+                value: RakuAstFieldValue::Node(Value::truth(true)),
+            },
+            RakuAstField {
+                name: Some("required-topic"),
+                value: RakuAstFieldValue::Node(Value::int(1)),
+            },
+            node_field(Some("body"), blockoid(body)?),
+        ],
     })
 }
 

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -80,6 +80,8 @@ pub enum RakuAstClass {
     StatementLoop,
     // Phase 2 slice 5: elsif chains.
     StatementElsif,
+    // Phase 2 slice 6: for loops (implicit topic).
+    StatementFor,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -124,6 +126,7 @@ impl RakuAstClass {
             StatementLoopWhile => "RakuAST::Statement::Loop::While",
             StatementLoop => "RakuAST::Statement::Loop",
             StatementElsif => "RakuAST::Statement::Elsif",
+            StatementFor => "RakuAST::Statement::For",
         }
     }
 

--- a/t/rakuast-for.t
+++ b/t/rakuast-for.t
@@ -1,0 +1,46 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 6 (ADR-0011): implicit-topic `for` loops.
+# A `for SRC { ... }` with no explicit signature -> Statement::For(mode,
+# source, body), where the body is a topic-taking Block marked
+# `implicit-topic => True` / `required-topic => 1`. Expected gists captured
+# verbatim from Rakudo; this file passes under BOTH mutsu and raku.
+
+plan 3;
+
+# --- for over a Range, implicit topic ---------------------------------------
+is Q[for 1..3 { $_ }].AST.gist, q:to/END/.chomp, 'for -> Statement::For with topic Block';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::For.new(
+        mode   => "serial",
+        source => RakuAST::ApplyInfix.new(
+          left  => RakuAST::IntLiteral.new(1),
+          infix => RakuAST::Infix.new(".."),
+          right => RakuAST::IntLiteral.new(3)
+        ),
+        body   => RakuAST::Block.new(
+          implicit-topic => True,
+          required-topic => 1,
+          body           => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::Var::Lexical.new("\$_")
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- the topic marking is present even when the body ignores $_ -------------
+is Q[for 1..3 { 5 }].AST.gist.contains(q:to/FRAG/.chomp), True, 'implicit-topic marked regardless of $_ usage';
+        body   => RakuAST::Block.new(
+          implicit-topic => True,
+          required-topic => 1,
+    FRAG
+
+# --- for over a declared array ----------------------------------------------
+is Q[my @a; for @a { $_ }].AST.gist.contains('source => RakuAST::Var::Lexical.new("\@a")'), True,
+    'for over @a -> source is the array variable';


### PR DESCRIPTION
## Summary

Phase 2 slice 6 of RakuAST (ADR-0011): extend `Str.AST` introspection to the **implicit-topic `for` loop** — `RakuAST::Statement::For`.

A `for SRC { ... }` with no explicit signature maps to:

```
Statement::For(
  mode   => "serial",
  source => <expr>,
  body   => Block(
    implicit-topic => True,
    required-topic => 1,
    body           => Blockoid(...) ) )
```

The topic-taking `Block` (new `topic_block_node` helper) carries the `implicit-topic`/`required-topic` markers before its `body`; the per-instance field-alignment width introduced in slice 3 already handles the wider keys (14).

## Coverage boundary (explicit `RuntimeError`, deferred)

Explicit-signature `for` (`for @a -> $x`), hyper/race/lazy modes, `<->` rw blocks, labels, and comma-list sources (`for 1,2,3` → `ApplyListInfix`, an expr-level gap).

## `with`/`without` intentionally not handled

mutsu desugars `with X { }` at parse time into a temp-var + `.defined` check + `if` (`__with_tmp_0`), so there is no `Statement::With`/`Without` node to recover — the same parser-level collapse as `unless`/`until`. Documented in ADR-0011.

## Tests

`t/rakuast-for.t` — 3 assertions (Range source with topic Block, topic marking present regardless of `$_` usage, `for @a` source), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)