### PR TITLE
feat: RakuAST Phase 2 slice 7 — named sub declarations

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -767,11 +767,12 @@ so it is tracked separately from the roast backlog.
         `implicit-topic`/`required-topic`). Tests in `t/rakuast-for.t`. (`with`/`without` are
         desugared by mutsu into temp-var + `.defined` + `if`, so no `Statement::With` node to
         recover — deferred, documented in ADR-0011.)
-  - [ ] Slice 7+: C-style/`repeat`/labelled loops, explicit-signature `for` (`for @a -> $x`),
-        sub declarations (`RakuAST::Sub`, reuse Signature), scoped/typed `my`, compound/`:=`
-        assignment, comma-list source (`ApplyListInfix`), method-call modifiers; then `.DEPARSE`;
-        resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu
-        does not).
+  - [x] Slice 7: named sub declarations (`RakuAST::Sub`, reusing `Signature`/`Parameter`; sub
+        params carry an implicit `type => RakuAST::Type::Setting(Any)`). Tests in `t/rakuast-sub.t`.
+  - [ ] Slice 8+: anonymous `sub { }`, C-style/`repeat`/labelled loops, explicit-signature `for`
+        (`for @a -> $x`), scoped/typed `my`, compound/`:=` assignment, comma-list source
+        (`ApplyListInfix`), method-call modifiers; then `.DEPARSE`; resolve the constant-folding
+        divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -179,6 +179,15 @@ earlier ones.
   topic-call form `.method` (i.e. `$_.method` written bare) is desugared by mutsu to `$_.method`
   (`ApplyPostfix` on `$_`), where raku keeps a distinct `Term::TopicCall` — a pre-existing
   method-call representation divergence, unrelated to `for`.
+- **Named sub declarations (Phase 2 slice 7).** `sub NAME (params) { body }` (`Stmt::SubDecl`) →
+  `Statement::Expression(Sub(name => Name, [signature => Signature], body => Blockoid))`. A
+  parameter-less sub (and an empty explicit `()` signature) omits the `signature` field. Sub/method
+  signature parameters carry an implicit `type => Type::Setting(Name.from-identifier("Any"))` that
+  pointy-block parameters do not — the `signature`/`parameter`/`simple_parameter` helpers thread a
+  `type_setting` flag to add it. Boundary (explicit `RuntimeError`): traits, `multi`, `is export`,
+  return types, operator subs (associativity/precedence), alternate signatures, and anonymous
+  `sub { }` (deferred). Parameters reuse the slice-3 plain-positional boundary (typed/named/slurpy/
+  `where`/… still error).
 - **Single-param pointy sigil loss (Phase 2 slice 3).** mutsu parses a single-parameter pointy
   block to `Expr::Lambda { param: String }` with the sigil stripped, and does not preserve `@`/`%`
   for a single non-scalar param (`-> @a` becomes `param: "a"`). The converter therefore assumes `$`

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -204,6 +204,60 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 ],
             }))
         }
+        Stmt::SubDecl {
+            name,
+            name_expr,
+            param_defs,
+            return_type,
+            associativity,
+            precedence_trait,
+            signature_alternates,
+            body,
+            multi,
+            is_rw,
+            is_raw,
+            is_export,
+            export_tags,
+            is_test_assertion,
+            supersede,
+            custom_traits,
+            ..
+        } => {
+            // Phase 2 slice 7 covers the plain named `sub NAME (params) { body }`
+            // form. Traits, multi, export, return type, operator subs, and
+            // alternate signatures carry extra RakuAST shape, deferred.
+            if name_expr.is_some()
+                || return_type.is_some()
+                || associativity.is_some()
+                || precedence_trait.is_some()
+                || !signature_alternates.is_empty()
+                || *multi
+                || *is_rw
+                || *is_raw
+                || *is_export
+                || !export_tags.is_empty()
+                || *is_test_assertion
+                || *supersede
+                || !custom_traits.is_empty()
+            {
+                return Err(unsupported(
+                    "sub with traits / multi / export / return type",
+                ));
+            }
+            let name_node = RakuAstNode {
+                class: RakuAstClass::Name,
+                fields: vec![leaf_field(None, Value::str(name.resolve()))],
+            };
+            let mut fields = vec![node_field(Some("name"), name_node)];
+            if !param_defs.is_empty() {
+                fields.push(node_field(Some("signature"), signature(param_defs, true)?));
+            }
+            fields.push(node_field(Some("body"), blockoid(body)?));
+            Ok(Some(statement_expression(RakuAstNode {
+                class: RakuAstClass::Sub,
+                fields,
+            })))
+        }
         Stmt::Assign { name, expr, op } => {
             // Phase 2 slice 2 covers only plain `=`; `:=` (Bind) and match-assign
             // map to distinct RakuAST nodes.
@@ -445,7 +499,7 @@ fn topic_block_node(body: &[Stmt]) -> Result<RakuAstNode, RuntimeError> {
 fn pointy_block(param_defs: &[ParamDef], body: &[Stmt]) -> Result<RakuAstNode, RuntimeError> {
     let mut fields = Vec::new();
     if !param_defs.is_empty() {
-        fields.push(node_field(Some("signature"), signature(param_defs)?));
+        fields.push(node_field(Some("signature"), signature(param_defs, false)?));
     }
     fields.push(node_field(Some("body"), blockoid(body)?));
     Ok(RakuAstNode {
@@ -464,7 +518,7 @@ fn pointy_block_from_lambda(param: &str, body: &[Stmt]) -> Result<RakuAstNode, R
         fields: vec![RakuAstField {
             name: Some("parameters"),
             value: RakuAstFieldValue::List(vec![Value::rakuast(Box::new(simple_parameter(
-                "$", param, None,
+                "$", param, None, false,
             )?))]),
         }],
     };
@@ -477,11 +531,13 @@ fn pointy_block_from_lambda(param: &str, body: &[Stmt]) -> Result<RakuAstNode, R
     })
 }
 
-/// `Signature(parameters => (Parameter, ...))`.
-fn signature(param_defs: &[ParamDef]) -> Result<RakuAstNode, RuntimeError> {
+/// `Signature(parameters => (Parameter, ...))`. `type_setting` prepends the
+/// implicit `type => Type::Setting(Any)` on each parameter — present in
+/// sub/method signatures, absent in pointy-block signatures.
+fn signature(param_defs: &[ParamDef], type_setting: bool) -> Result<RakuAstNode, RuntimeError> {
     let mut params = Vec::with_capacity(param_defs.len());
     for pd in param_defs {
-        params.push(Value::rakuast(Box::new(parameter(pd)?)));
+        params.push(Value::rakuast(Box::new(parameter(pd, type_setting)?)));
     }
     Ok(RakuAstNode {
         class: RakuAstClass::Signature,
@@ -495,7 +551,7 @@ fn signature(param_defs: &[ParamDef]) -> Result<RakuAstNode, RuntimeError> {
 /// One `Parameter`. Only plain positional params (name + optional default) are
 /// modelled; anything richer (typed, named, slurpy, `where`, sub-signature,
 /// traits, optional-marker, invocant, shaped) is the coverage boundary.
-fn parameter(pd: &ParamDef) -> Result<RakuAstNode, RuntimeError> {
+fn parameter(pd: &ParamDef, type_setting: bool) -> Result<RakuAstNode, RuntimeError> {
     if pd.named
         || pd.slurpy
         || pd.double_slurpy
@@ -514,15 +570,30 @@ fn parameter(pd: &ParamDef) -> Result<RakuAstNode, RuntimeError> {
         return Err(unsupported("non-trivial signature parameter"));
     }
     let (sigil, desigil) = split_sigil(&pd.name);
-    simple_parameter(sigil, desigil, pd.default.as_ref())
+    simple_parameter(sigil, desigil, pd.default.as_ref(), type_setting)
+}
+
+/// `Type::Setting.new(Name.from-identifier("Any"))` — the implicit default type
+/// carried by every sub/method-signature parameter.
+fn type_setting_any() -> RakuAstNode {
+    let name = RakuAstNode {
+        class: RakuAstClass::Name,
+        fields: vec![leaf_field(None, Value::str("Any".to_string()))],
+    };
+    RakuAstNode {
+        class: RakuAstClass::TypeSetting,
+        fields: vec![node_field(None, name)],
+    }
 }
 
 /// Build a `Parameter(target => ParameterTarget::Var, ...)`. A param with a
 /// default renders `default => <expr>`; a required one renders `optional => False`.
+/// `type_setting` prepends `type => Type::Setting(Any)` (sub/method params).
 fn simple_parameter(
     sigil: &str,
     desigil: &str,
     default: Option<&Expr>,
+    type_setting: bool,
 ) -> Result<RakuAstNode, RuntimeError> {
     let target = RakuAstNode {
         class: RakuAstClass::ParameterTargetVar,
@@ -531,7 +602,11 @@ fn simple_parameter(
             Value::str(format!("{sigil}{desigil}")),
         )],
     };
-    let mut fields = vec![node_field(Some("target"), target)];
+    let mut fields = Vec::new();
+    if type_setting {
+        fields.push(node_field(Some("type"), type_setting_any()));
+    }
+    fields.push(node_field(Some("target"), target));
     match default {
         Some(d) => fields.push(node_field(Some("default"), convert_expr(d)?)),
         None => fields.push(RakuAstField {

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -82,6 +82,9 @@ pub enum RakuAstClass {
     StatementElsif,
     // Phase 2 slice 6: for loops (implicit topic).
     StatementFor,
+    // Phase 2 slice 7: named sub declarations.
+    Sub,
+    TypeSetting,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -127,6 +130,8 @@ impl RakuAstClass {
             StatementLoop => "RakuAST::Statement::Loop",
             StatementElsif => "RakuAST::Statement::Elsif",
             StatementFor => "RakuAST::Statement::For",
+            Sub => "RakuAST::Sub",
+            TypeSetting => "RakuAST::Type::Setting",
         }
     }
 

--- a/t/rakuast-sub.t
+++ b/t/rakuast-sub.t
@@ -1,0 +1,77 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 7 (ADR-0011): named sub declarations.
+# `sub NAME (params) { body }` -> Statement::Expression(Sub(name, [signature],
+# body)). Sub/method signature parameters carry an implicit
+# `type => Type::Setting(Any)` (pointy-block params do not). A parameter-less
+# sub omits the `signature` field. Expected gists captured verbatim from
+# Rakudo; this file passes under BOTH mutsu and raku.
+
+plan 4;
+
+# --- named sub with one typed-by-default parameter ---------------------------
+is Q[sub foo($x) { $x }].AST.gist, q:to/END/.chomp, 'sub -> Sub(name, signature w/ Type::Setting, body)';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Sub.new(
+          name      => RakuAST::Name.from-identifier("foo"),
+          signature => RakuAST::Signature.new(
+            parameters => (
+              RakuAST::Parameter.new(
+                type     => RakuAST::Type::Setting.new(
+                  RakuAST::Name.from-identifier("Any")
+                ),
+                target   => RakuAST::ParameterTarget::Var.new(
+                  name => "\$x"
+                ),
+                optional => False
+              ),
+            )
+          ),
+          body      => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::Var::Lexical.new("\$x")
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- parameter-less sub omits the signature field ---------------------------
+is Q[sub foo { 42 }].AST.gist, q:to/END/.chomp, 'parameter-less sub omits signature';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Sub.new(
+          name => RakuAST::Name.from-identifier("foo"),
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::IntLiteral.new(42)
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- an empty explicit signature `()` also omits the signature field --------
+is Q[sub foo() { 42 }].AST.gist, Q[sub foo { 42 }].AST.gist,
+    'empty () signature renders like no signature';
+
+# --- a defaulted parameter renders `default =>`, still typed ----------------
+is Q[sub g($x = 5) { $x }].AST.gist.contains(q:to/FRAG/.chomp), True, 'defaulted sub param keeps its Type::Setting';
+              RakuAST::Parameter.new(
+                type    => RakuAST::Type::Setting.new(
+                  RakuAST::Name.from-identifier("Any")
+                ),
+                target  => RakuAST::ParameterTarget::Var.new(
+                  name => "\$x"
+                ),
+                default => RakuAST::IntLiteral.new(5)
+              ),
+    FRAG


### PR DESCRIPTION
## Summary

Phase 2 slice 7 of RakuAST (ADR-0011): extend `Str.AST` introspection to **named `sub` declarations** — `RakuAST::Sub` (plus `RakuAST::Type::Setting` for the implicit parameter type).

```
sub foo($x) { $x }
  -> Statement::Expression(Sub(
       name      => Name.from-identifier("foo"),
       signature => Signature(parameters => ( Parameter(type => Type::Setting(Any), target, optional), )),
       body      => Blockoid(...) ))
```

## Key detail: sub params are typed by default

Sub/method signature parameters carry an implicit `type => RakuAST::Type::Setting(Name.from-identifier("Any"))` that **pointy-block** parameters do not. The `signature`/`parameter`/`simple_parameter` helpers now thread a `type_setting` flag to add it — pointy blocks (slices 3/6) pass `false`, subs pass `true`. A parameter-less sub (and an empty explicit `()` signature) omits the `signature` field.

## Coverage boundary (explicit `RuntimeError`, deferred)

Traits, `multi`, `is export`, return types, operator subs (associativity/precedence), alternate signatures, and anonymous `sub { }`. Parameters reuse the slice-3 plain-positional boundary (typed/named/slurpy/`where`/… still error).

## Tests

`t/rakuast-sub.t` — 4 assertions (typed param, param-less sub omits signature, empty `()` == no signature, defaulted param keeps its type), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green (pointy-block params verified to still have NO type field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)