### PR TITLE
feat: RakuAST Phase 2 slice 8 — C-style and repeat loops

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -769,10 +769,13 @@ so it is tracked separately from the roast backlog.
         recover — deferred, documented in ADR-0011.)
   - [x] Slice 7: named sub declarations (`RakuAST::Sub`, reusing `Signature`/`Parameter`; sub
         params carry an implicit `type => RakuAST::Type::Setting(Any)`). Tests in `t/rakuast-sub.t`.
-  - [ ] Slice 8+: anonymous `sub { }`, C-style/`repeat`/labelled loops, explicit-signature `for`
-        (`for @a -> $x`), scoped/typed `my`, compound/`:=` assignment, comma-list source
-        (`ApplyListInfix`), method-call modifiers; then `.DEPARSE`; resolve the constant-folding
-        divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu does not).
+  - [x] Slice 8: C-style loops (`Statement::Loop` with setup/condition/increment) and `repeat`
+        loops (`Statement::Loop::RepeatWhile`). Tests in `t/rakuast-loop.t`.
+  - [ ] Slice 9+: anonymous `sub { }` (no-param only — `sub ($x)`/`-> $x` share `AnonSubParams`
+        so are indistinguishable), method decls (needs `RakuAST::Class`), labelled loops,
+        explicit-signature `for` (`for @a -> $x`), scoped/typed `my`, compound/`:=` assignment,
+        comma-list source (`ApplyListInfix`), method-call modifiers; then `.DEPARSE`; resolve the
+        constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -168,8 +168,15 @@ earlier ones.
   distinct `unless`/`until` statements. `elsif` chains are handled (slice 5): mutsu nests each
   `elsif` as a single `if` inside the else-branch, and the converter flattens that chain into
   raku's flat `elsifs` list (`Statement::Elsif`), with any trailing block as the final `else`.
-  C-style/`repeat`/labelled loops and topic binding (`if EXPR -> $v` / `elsif EXPR -> $v`) remain
-  the coverage boundary (explicit `RuntimeError`), deferred to a later slice. Implicit-topic `for`
+  C-style and `repeat` loops are handled (slice 8): `loop (init; cond; step) { }` →
+  `Statement::Loop(setup, condition, increment, body)` (each clause present only when written; the
+  `setup` renders its `VarDeclaration`/expression node **unwrapped**, not inside a
+  `Statement::Expression` — and because the loop-init parse path does not set `__has_initializer`,
+  the initializer is detected from a non-`Nil` `expr`); `repeat { } while X` →
+  `Statement::Loop::RepeatWhile(body, condition)`, with `repeat ... until X` folding to
+  `RepeatWhile` + negated condition (same collapse as `until`/`while`). Labelled loops and topic
+  binding (`if EXPR -> $v` / `elsif EXPR -> $v`) remain the coverage boundary (explicit
+  `RuntimeError`), deferred to a later slice. Implicit-topic `for`
   is handled (slice 6): `for SRC { ... }` (no explicit signature) → `Statement::For(mode =>
   "serial", source, body)` where the body is a topic-taking `Block` marked `implicit-topic => True`
   / `required-topic => 1`. `with`/`without` are NOT mappable — mutsu desugars them at parse time

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -159,14 +159,47 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             repeat,
             label,
         } => {
-            // Only the bare `loop { }` form; the C-style `loop (init; cond; step)`,
-            // `repeat` loops, and labelled loops carry extra RakuAST shape.
-            if init.is_some() || cond.is_some() || step.is_some() || *repeat || label.is_some() {
-                return Err(unsupported("C-style / repeat / labelled loop"));
+            if label.is_some() {
+                return Err(unsupported("labelled loop"));
             }
+            if *repeat {
+                // `repeat { } while X`. mutsu desugars `repeat { } until X` to a
+                // negated `while` condition (same collapse as while/until), so
+                // this always renders as `Loop::RepeatWhile`.
+                let cond = cond
+                    .as_ref()
+                    .ok_or_else(|| unsupported("repeat loop without condition"))?;
+                return Ok(Some(RakuAstNode {
+                    class: RakuAstClass::StatementLoopRepeatWhile,
+                    fields: vec![
+                        node_field(Some("body"), block_node(body)?),
+                        node_field(Some("condition"), convert_expr(cond)?),
+                    ],
+                }));
+            }
+            if init.is_none() && cond.is_none() && step.is_none() {
+                // Bare `loop { }`.
+                return Ok(Some(RakuAstNode {
+                    class: RakuAstClass::StatementLoop,
+                    fields: vec![node_field(Some("body"), block_node(body)?)],
+                }));
+            }
+            // C-style `loop (init; cond; step) { }`. Each clause is optional and
+            // present only when written.
+            let mut fields = Vec::new();
+            if let Some(init) = init.as_deref() {
+                fields.push(node_field(Some("setup"), loop_setup_node(init)?));
+            }
+            if let Some(cond) = cond {
+                fields.push(node_field(Some("condition"), convert_expr(cond)?));
+            }
+            if let Some(step) = step {
+                fields.push(node_field(Some("increment"), convert_expr(step)?));
+            }
+            fields.push(node_field(Some("body"), block_node(body)?));
             Ok(Some(RakuAstNode {
                 class: RakuAstClass::StatementLoop,
-                fields: vec![node_field(Some("body"), block_node(body)?)],
+                fields,
             }))
         }
         Stmt::For {
@@ -472,6 +505,56 @@ fn block_node(body: &[Stmt]) -> Result<RakuAstNode, RuntimeError> {
         class: RakuAstClass::Block,
         fields: vec![node_field(Some("body"), blockoid(body)?)],
     })
+}
+
+/// A C-style loop `setup` clause renders its node unwrapped — raku shows the
+/// `VarDeclaration::Simple` / `ApplyInfix` directly, not inside a
+/// `Statement::Expression`. mutsu's init is a full statement.
+fn loop_setup_node(stmt: &Stmt) -> Result<RakuAstNode, RuntimeError> {
+    // A `my $i = 0` init is a special case: the loop-init parse path does NOT
+    // set the `__has_initializer` trait the top-level VarDecl handler relies on,
+    // so detect the initializer from a non-Nil `expr` instead.
+    if let Stmt::VarDecl {
+        name,
+        expr,
+        type_constraint,
+        is_state,
+        is_our,
+        is_dynamic,
+        where_constraint,
+        ..
+    } = stmt
+    {
+        if type_constraint.is_some()
+            || *is_state
+            || *is_our
+            || *is_dynamic
+            || where_constraint.is_some()
+        {
+            return Err(unsupported("scoped/typed variable declaration"));
+        }
+        return var_declaration(name, expr, !expr_is_nil(expr));
+    }
+    // Assignment / expression setups convert normally, then get unwrapped.
+    let node = convert_stmt(stmt)?.ok_or_else(|| unsupported("empty loop setup clause"))?;
+    if node.class != RakuAstClass::StatementExpression {
+        return Ok(node);
+    }
+    if let Some(RakuAstField {
+        value: RakuAstFieldValue::Node(v),
+        ..
+    }) = node.fields.into_iter().next()
+        && let ValueView::RakuAst(inner) = v.view()
+    {
+        return Ok(inner.clone());
+    }
+    Err(unsupported("loop setup clause"))
+}
+
+/// True when `expr` is a `Nil` literal (mutsu's placeholder for a `my $x` with
+/// no initializer in a loop-setup clause).
+fn expr_is_nil(expr: &Expr) -> bool {
+    matches!(expr, Expr::Literal(v) | Expr::LiteralSrc(v, _) if v.is_nil())
 }
 
 /// A topic-taking block body (the `{ ... }` of an implicit-topic `for`), which

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -85,6 +85,8 @@ pub enum RakuAstClass {
     // Phase 2 slice 7: named sub declarations.
     Sub,
     TypeSetting,
+    // Phase 2 slice 8: C-style and repeat loops.
+    StatementLoopRepeatWhile,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -132,6 +134,7 @@ impl RakuAstClass {
             StatementFor => "RakuAST::Statement::For",
             Sub => "RakuAST::Sub",
             TypeSetting => "RakuAST::Type::Setting",
+            StatementLoopRepeatWhile => "RakuAST::Statement::Loop::RepeatWhile",
         }
     }
 

--- a/t/rakuast-loop.t
+++ b/t/rakuast-loop.t
@@ -1,0 +1,78 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 8 (ADR-0011): C-style and repeat loops
+# (Statement::Loop with setup/condition/increment, Statement::Loop::RepeatWhile).
+# Expected gists captured verbatim from Rakudo; this file passes under BOTH
+# mutsu and raku.
+#
+# Note: mutsu desugars `repeat { } until X` to a negated `while` condition, so
+# it renders as Loop::RepeatWhile with a `!`-prefixed condition (a documented
+# divergence from raku's Loop::RepeatUntil, ADR-0011) and is not pinned here.
+
+plan 4;
+
+# --- C-style loop: setup / condition / increment / body ---------------------
+is Q[loop (my $i = 0; $i < 3; $i++) { $i }].AST.gist, q:to/END/.chomp, 'C-style loop -> Statement::Loop(setup, condition, increment, body)';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Loop.new(
+        setup     => RakuAST::VarDeclaration::Simple.new(
+          sigil       => "\$",
+          desigilname => RakuAST::Name.from-identifier("i"),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::IntLiteral.new(0)
+          )
+        ),
+        condition => RakuAST::ApplyInfix.new(
+          left  => RakuAST::Var::Lexical.new("\$i"),
+          infix => RakuAST::Infix.new("<"),
+          right => RakuAST::IntLiteral.new(3)
+        ),
+        increment => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::Var::Lexical.new("\$i"),
+          postfix => RakuAST::Postfix.new(
+            operator => "++"
+          )
+        ),
+        body      => RakuAST::Block.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::Var::Lexical.new("\$i")
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- C-style loop with an un-initialised setup omits the initializer --------
+is Q[loop (my $i; $i < 3; $i++) { $i }].AST.gist.contains(q:to/FRAG/.chomp), True, 'no-init setup omits initializer';
+        setup     => RakuAST::VarDeclaration::Simple.new(
+          sigil       => "\$",
+          desigilname => RakuAST::Name.from-identifier("i")
+        ),
+    FRAG
+
+# --- repeat-while loop: body before condition -------------------------------
+is Q[repeat { 1 } while 2].AST.gist, q:to/END/.chomp, 'repeat/while -> Loop::RepeatWhile(body, condition)';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Loop::RepeatWhile.new(
+        body      => RakuAST::Block.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::IntLiteral.new(1)
+              )
+            )
+          )
+        ),
+        condition => RakuAST::IntLiteral.new(2)
+      )
+    )
+    END
+
+# --- a bare `loop { }` is unchanged (no setup/condition/increment) -----------
+is Q[loop { 1 }].AST.gist.contains('RakuAST::Statement::Loop.new('), True,
+    'bare loop still renders as plain Statement::Loop';


### PR DESCRIPTION
## Summary

Phase 2 slice 8 of RakuAST (ADR-0011): extend `Str.AST` introspection to the remaining loop forms, completing the loop family.

- **C-style** `loop (init; cond; step) { }` → `Statement::Loop(setup, condition, increment, body)`. Each clause is present only when written.
- **repeat** `repeat { } while X` → `Statement::Loop::RepeatWhile(body, condition)` (note: body before condition).

## Notable details

- The `setup` clause renders its `VarDeclaration`/expression node **unwrapped** — raku shows it directly, not inside a `Statement::Expression`, so the converter peels off the wrapper.
- The loop-init parse path does **not** set the `__has_initializer` trait the top-level `my`-decl handler relies on, so for a loop setup the initializer is detected from a non-`Nil` `expr` (`loop (my $i = 0; …)` gets an `Initializer::Assign`, `loop (my $i; …)` does not).
- `repeat { } until X` folds to `RepeatWhile` + a negated condition — the same parser-level collapse as `until`/`while`, a documented divergence from raku's `Loop::RepeatUntil`.
- Bare `loop { }` (slice 4) is unchanged.

## Tests

`t/rakuast-loop.t` — 4 assertions (full C-style loop, no-init setup omits initializer, repeat-while, bare loop unchanged), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)