### PR TITLE
feat: RakuAST Phase 2 slice 9 — comma lists and := binding

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -771,11 +771,14 @@ so it is tracked separately from the roast backlog.
         params carry an implicit `type => RakuAST::Type::Setting(Any)`). Tests in `t/rakuast-sub.t`.
   - [x] Slice 8: C-style loops (`Statement::Loop` with setup/condition/increment) and `repeat`
         loops (`Statement::Loop::RepeatWhile`). Tests in `t/rakuast-loop.t`.
-  - [ ] Slice 9+: anonymous `sub { }` (no-param only — `sub ($x)`/`-> $x` share `AnonSubParams`
+  - [x] Slice 9: bare comma lists (`ApplyListInfix`) and `:=` binding (`ApplyInfix` over a plain
+        `Infix(":=")`). Tests in `t/rakuast-listinfix-bind.t`. (Parenthesised lists and compound
+        `+=` are desugared/dropped by mutsu — deferred, documented in ADR-0011.)
+  - [ ] Slice 10+: anonymous `sub { }` (no-param only — `sub ($x)`/`-> $x` share `AnonSubParams`
         so are indistinguishable), method decls (needs `RakuAST::Class`), labelled loops,
-        explicit-signature `for` (`for @a -> $x`), scoped/typed `my`, compound/`:=` assignment,
-        comma-list source (`ApplyListInfix`), method-call modifiers; then `.DEPARSE`; resolve the
-        constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu does not).
+        explicit-signature `for` (`for @a -> $x`), scoped/typed `my`, method-call modifiers; then
+        `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`,
+        mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -195,6 +195,15 @@ earlier ones.
   return types, operator subs (associativity/precedence), alternate signatures, and anonymous
   `sub { }` (deferred). Parameters reuse the slice-3 plain-positional boundary (typed/named/slurpy/
   `where`/… still error).
+- **Comma lists and `:=` binding (Phase 2 slice 9).** A bare comma list `1, 2, 3`
+  (`Expr::ArrayLiteral`) → `ApplyListInfix(infix => Infix(","), operands => (...))`. A `:=` bind
+  (`Stmt::Assign { op: Bind }`) → `ApplyInfix(left, infix => Infix(":="), right)` — a plain `Infix`,
+  unlike `=`'s special `Assignment` node. Divergences: a **parenthesised** list `(1, 2)` is
+  `Circumfix::Parentheses(SemiList(...))` in raku, but mutsu drops the parens at parse time, so it
+  renders as a bare `ApplyListInfix` (deferred). And a **compound** assignment `$x += 3` is
+  desugared by mutsu to `$x = $x + 3` (`op` stays `Assign`), so it renders as a plain `=` over a
+  binop rather than raku's `MetaInfix::Assign(Infix("+"))` (deferred, same collapse family as
+  `unless`/`until`).
 - **Single-param pointy sigil loss (Phase 2 slice 3).** mutsu parses a single-parameter pointy
   block to `Expr::Lambda { param: String }` with the sigil stripped, and does not preserve `@`/`%`
   for a single non-scalar param (`-> @a` becomes `param: "a"`). The converter therefore assumes `$`

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -291,14 +291,16 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 fields,
             })))
         }
-        Stmt::Assign { name, expr, op } => {
-            // Phase 2 slice 2 covers only plain `=`; `:=` (Bind) and match-assign
-            // map to distinct RakuAST nodes.
-            if !matches!(op, AssignOp::Assign) {
-                return Err(unsupported("non-`=` assignment"));
-            }
-            Ok(Some(statement_expression(assignment_infix(name, expr)?)))
-        }
+        Stmt::Assign { name, expr, op } => match op {
+            // `$x = EXPR` — the special `Assignment` infix (slice 2). Note mutsu
+            // desugars `$x += 3` to `$x = $x + 3` (op stays `Assign`), so a
+            // compound assignment renders as a plain `=` over a binop rather than
+            // raku's `MetaInfix::Assign` — a documented divergence.
+            AssignOp::Assign => Ok(Some(statement_expression(assignment_infix(name, expr)?))),
+            // `$x := EXPR` — a plain `:=` infix (slice 9).
+            AssignOp::Bind => Ok(Some(statement_expression(bind_infix(name, expr)?))),
+            AssignOp::MatchAssign => Err(unsupported("`~~` match-assignment")),
+        },
         other => Err(unsupported(&format!("{other:?}"))),
     }
 }
@@ -327,6 +329,28 @@ fn assignment_infix(name: &str, rhs: &Expr) -> Result<RakuAstNode, RuntimeError>
             node_field(Some("right"), convert_expr(rhs)?),
         ],
     })
+}
+
+/// `$x := EXPR` -> `ApplyInfix(left => Var::Lexical, infix => Infix(":="), right)`.
+/// Unlike `=`, binding uses a plain `Infix`, not the special `Assignment` node.
+fn bind_infix(name: &str, rhs: &Expr) -> Result<RakuAstNode, RuntimeError> {
+    let (sigil, desigil) = split_sigil(name);
+    Ok(RakuAstNode {
+        class: RakuAstClass::ApplyInfix,
+        fields: vec![
+            node_field(Some("left"), var_lexical(sigil, desigil)),
+            node_field(Some("infix"), plain_infix(":=")),
+            node_field(Some("right"), convert_expr(rhs)?),
+        ],
+    })
+}
+
+/// A plain `Infix.new("<op>")` node from a literal operator string.
+fn plain_infix(op: &str) -> RakuAstNode {
+    RakuAstNode {
+        class: RakuAstClass::Infix,
+        fields: vec![leaf_field(None, Value::str(op.to_string()))],
+    }
 }
 
 /// `my $x` / `my @a` / `my $x = EXPR` -> `VarDeclaration::Simple`. The sigil is
@@ -424,6 +448,23 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
                 fields: vec![
                     node_field(Some("operand"), convert_expr(target)?),
                     node_field(Some("postfix"), call_method(name.as_str(), args)?),
+                ],
+            })
+        }
+        // A bare comma list `1, 2, 3` -> ApplyListInfix(infix => ",", operands).
+        Expr::ArrayLiteral(items) => {
+            let mut operands = Vec::with_capacity(items.len());
+            for it in items {
+                operands.push(Value::rakuast(Box::new(convert_expr(it)?)));
+            }
+            Ok(RakuAstNode {
+                class: RakuAstClass::ApplyListInfix,
+                fields: vec![
+                    node_field(Some("infix"), plain_infix(",")),
+                    RakuAstField {
+                        name: Some("operands"),
+                        value: RakuAstFieldValue::List(operands),
+                    },
                 ],
             })
         }

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -87,6 +87,8 @@ pub enum RakuAstClass {
     TypeSetting,
     // Phase 2 slice 8: C-style and repeat loops.
     StatementLoopRepeatWhile,
+    // Phase 2 slice 9: `:=` binding and comma lists.
+    ApplyListInfix,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -135,6 +137,7 @@ impl RakuAstClass {
             Sub => "RakuAST::Sub",
             TypeSetting => "RakuAST::Type::Setting",
             StatementLoopRepeatWhile => "RakuAST::Statement::Loop::RepeatWhile",
+            ApplyListInfix => "RakuAST::ApplyListInfix",
         }
     }
 

--- a/t/rakuast-listinfix-bind.t
+++ b/t/rakuast-listinfix-bind.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 9 (ADR-0011): comma lists (ApplyListInfix) and `:=`
+# binding (a plain `:=` Infix, unlike `=`'s special Assignment node).
+# Expected gists captured verbatim from Rakudo; this file passes under BOTH
+# mutsu and raku.
+
+plan 4;
+
+# --- bare comma list -> ApplyListInfix --------------------------------------
+is Q[1, 2, 3].AST.gist, q:to/END/.chomp, 'comma list -> ApplyListInfix(",", operands)';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyListInfix.new(
+          infix    => RakuAST::Infix.new(","),
+          operands => (
+            RakuAST::IntLiteral.new(1),
+            RakuAST::IntLiteral.new(2),
+            RakuAST::IntLiteral.new(3),
+          )
+        )
+      )
+    )
+    END
+
+# --- a two-element list -----------------------------------------------------
+is Q["a", "b"].AST.gist.contains(q:to/FRAG/.chomp), True, 'string list operands';
+        expression => RakuAST::ApplyListInfix.new(
+          infix    => RakuAST::Infix.new(","),
+          operands => (
+            RakuAST::QuotedString.new(
+    FRAG
+
+# --- `:=` binding -> a plain Infix, not Assignment --------------------------
+# The whole bind is an ApplyInfix over Infix(":=") with both var operands, and
+# crucially NOT the special Assignment node that `=` uses.
+my $bind = Q[my $x; my $y; $x := $y].AST.gist;
+ok $bind.contains('infix => RakuAST::Infix.new(":=")')
+    && $bind.contains('left  => RakuAST::Var::Lexical.new("\$x")')
+    && $bind.contains('right => RakuAST::Var::Lexical.new("\$y")')
+    && !$bind.contains('Assignment'),
+    'scalar bind -> ApplyInfix over Infix(":="), not Assignment';
+
+# --- array binding also uses a plain Infix (no :item, no Assignment) --------
+is Q[my @a; @a := 5].AST.gist.contains('infix => RakuAST::Infix.new(":=")'), True,
+    'array bind -> Infix(":=")';


### PR DESCRIPTION
## Summary

Phase 2 slice 9 of RakuAST (ADR-0011): two common, cleanly-mappable constructs.

- **Bare comma list** `1, 2, 3` (`Expr::ArrayLiteral`) → `ApplyListInfix(infix => Infix(","), operands => (...))`.
- **`:=` binding** (`Stmt::Assign { op: Bind }`) → `ApplyInfix(left, infix => Infix(":="), right)` — a plain `Infix`, unlike `=`'s special `Assignment` node.

## Documented divergences (deferred)

- A **parenthesised** list `(1, 2)` is `Circumfix::Parentheses(SemiList(...))` in raku, but mutsu drops the parens at parse time, so it renders as a bare `ApplyListInfix`.
- A **compound** assignment `$x += 3` is desugared by mutsu to `$x = $x + 3` (`op` stays `Assign`), so it renders as a plain `=` over a binop rather than raku's `MetaInfix::Assign(Infix("+"))` — the same collapse family as `unless`/`until`.

## Tests

`t/rakuast-listinfix-bind.t` — 4 assertions (comma list, string-operand list, scalar bind is `Infix(":=")` not `Assignment`, array bind), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)