### PR TITLE
feat: RakuAST Phase 2 slice 10 — scoped and typed declarations

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -774,11 +774,14 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 9: bare comma lists (`ApplyListInfix`) and `:=` binding (`ApplyInfix` over a plain
         `Infix(":=")`). Tests in `t/rakuast-listinfix-bind.t`. (Parenthesised lists and compound
         `+=` are desugared/dropped by mutsu — deferred, documented in ADR-0011.)
-  - [ ] Slice 10+: anonymous `sub { }` (no-param only — `sub ($x)`/`-> $x` share `AnonSubParams`
+  - [x] Slice 10: scoped/typed declarations — `my`/`our`/`state` with an optional simple type
+        (`VarDeclaration::Simple` gains `scope` + `type => Type::Simple`). Tests in
+        `t/rakuast-vardecl-scoped.t`.
+  - [ ] Slice 11+: anonymous `sub { }` (no-param only — `sub ($x)`/`-> $x` share `AnonSubParams`
         so are indistinguishable), method decls (needs `RakuAST::Class`), labelled loops,
-        explicit-signature `for` (`for @a -> $x`), scoped/typed `my`, method-call modifiers; then
-        `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`,
-        mutsu does not).
+        explicit-signature `for` (`for @a -> $x`), method-call modifiers, parameterised/definite
+        types; then `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to
+        `IntLiteral(3)`, mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -204,6 +204,13 @@ earlier ones.
   desugared by mutsu to `$x = $x + 3` (`op` stays `Assign`), so it renders as a plain `=` over a
   binop rather than raku's `MetaInfix::Assign(Infix("+"))` (deferred, same collapse family as
   `unless`/`until`).
+- **Scoped/typed declarations (Phase 2 slice 10).** `my`/`our`/`state` with an optional simple
+  type: `VarDeclaration::Simple` gains a `scope` leaf (`"our"`/`"state"`; `my` is the default and
+  omitted) and a `type => Type::Simple(Name)` field, in raku's field order (scope, type, sigil,
+  desigilname, initializer). Only plain (possibly `::`-qualified) type identifiers map to
+  `Type::Simple`; parameterised (`Array[Int]`), definite (`Int:D`), and coercion (`Str()`) types,
+  dynamic (`$*x`) declarations, `where` constraints, and real `is`/`does` traits are the coverage
+  boundary (explicit `RuntimeError`).
 - **Single-param pointy sigil loss (Phase 2 slice 3).** mutsu parses a single-parameter pointy
   block to `Expr::Lambda { param: String }` with the sigil stripped, and does not preserve `@`/`%`
   for a single non-scalar param (`-> @a` becomes `param: "a"`). The converter therefore assumes `$`

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -69,16 +69,27 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             where_constraint,
             ..
         } => {
-            // Phase 2 covers only the plain `my $x [= expr]` form; scoped/typed
-            // declarations map to extra RakuAST fields not yet modelled.
-            if type_constraint.is_some()
-                || *is_state
-                || *is_our
-                || *is_dynamic
-                || where_constraint.is_some()
-            {
-                return Err(unsupported("scoped/typed variable declaration"));
+            // `my`/`our`/`state` with an optional simple type. Dynamic (`$*x`),
+            // `where` constraints, parameterised/definite/coercion types, and
+            // real `is`/`does` traits carry richer shape, deferred.
+            if *is_dynamic || where_constraint.is_some() {
+                return Err(unsupported("dynamic / where-constrained declaration"));
             }
+            if custom_traits.iter().any(|(n, _)| n != "__has_initializer") {
+                return Err(unsupported("declaration with traits"));
+            }
+            let type_name = match type_constraint.as_deref() {
+                Some(t) if is_simple_type(t) => Some(t),
+                Some(_) => return Err(unsupported("parameterised/definite/coercion type")),
+                None => None,
+            };
+            let scope = if *is_our {
+                Some("our")
+            } else if *is_state {
+                Some("state")
+            } else {
+                None
+            };
             let has_initializer = custom_traits
                 .iter()
                 .any(|(name, _)| name == "__has_initializer");
@@ -86,6 +97,8 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 name,
                 expr,
                 has_initializer,
+                scope,
+                type_name,
             )?)))
         }
         // A bare `{ ... }` block at statement level -> Statement::Expression(Block).
@@ -360,16 +373,28 @@ fn var_declaration(
     name: &str,
     init_expr: &Expr,
     has_initializer: bool,
+    scope: Option<&'static str>,
+    type_name: Option<&str>,
 ) -> Result<RakuAstNode, RuntimeError> {
     let (sigil, desigil) = split_sigil(name);
-    let name_node = RakuAstNode {
-        class: RakuAstClass::Name,
-        fields: vec![leaf_field(None, Value::str(desigil.to_string()))],
-    };
-    let mut fields = vec![
-        leaf_field(Some("sigil"), Value::str(sigil.to_string())),
-        node_field(Some("desigilname"), name_node),
-    ];
+    // Field order matches raku: scope, type, sigil, desigilname, initializer —
+    // with scope (default `my`) and type omitted when absent.
+    let mut fields = Vec::new();
+    if let Some(s) = scope {
+        fields.push(leaf_field(Some("scope"), Value::str(s.to_string())));
+    }
+    if let Some(t) = type_name {
+        let type_node = RakuAstNode {
+            class: RakuAstClass::TypeSimple,
+            fields: vec![node_field(None, name_from_identifier(t))],
+        };
+        fields.push(node_field(Some("type"), type_node));
+    }
+    fields.push(leaf_field(Some("sigil"), Value::str(sigil.to_string())));
+    fields.push(node_field(
+        Some("desigilname"),
+        name_from_identifier(desigil),
+    ));
     if has_initializer {
         let assign = RakuAstNode {
             class: RakuAstClass::InitializerAssign,
@@ -381,6 +406,25 @@ fn var_declaration(
         class: RakuAstClass::VarDeclarationSimple,
         fields,
     })
+}
+
+/// A `Name.from-identifier("<s>")` node.
+fn name_from_identifier(s: &str) -> RakuAstNode {
+    RakuAstNode {
+        class: RakuAstClass::Name,
+        fields: vec![leaf_field(None, Value::str(s.to_string()))],
+    }
+}
+
+/// True when a type constraint is a plain (possibly `::`-qualified) identifier
+/// (`Int`, `My::Type`) that maps to `Type::Simple`. Parameterised (`Array[Int]`),
+/// definite (`Int:D`), and coercion (`Str()`) types carry richer RakuAST shape,
+/// deferred — so each `::`-separated segment must be a bare identifier.
+fn is_simple_type(t: &str) -> bool {
+    !t.is_empty()
+        && t.split("::").all(|seg| {
+            !seg.is_empty() && seg.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        })
 }
 
 /// Split a declaration name into `(sigil, desigilname)`. mutsu keeps the sigil
@@ -574,7 +618,7 @@ fn loop_setup_node(stmt: &Stmt) -> Result<RakuAstNode, RuntimeError> {
         {
             return Err(unsupported("scoped/typed variable declaration"));
         }
-        return var_declaration(name, expr, !expr_is_nil(expr));
+        return var_declaration(name, expr, !expr_is_nil(expr), None, None);
     }
     // Assignment / expression setups convert normally, then get unwrapped.
     let node = convert_stmt(stmt)?.ok_or_else(|| unsupported("empty loop setup clause"))?;

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -89,6 +89,8 @@ pub enum RakuAstClass {
     StatementLoopRepeatWhile,
     // Phase 2 slice 9: `:=` binding and comma lists.
     ApplyListInfix,
+    // Phase 2 slice 10: scoped/typed variable declarations.
+    TypeSimple,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -138,6 +140,7 @@ impl RakuAstClass {
             TypeSetting => "RakuAST::Type::Setting",
             StatementLoopRepeatWhile => "RakuAST::Statement::Loop::RepeatWhile",
             ApplyListInfix => "RakuAST::ApplyListInfix",
+            TypeSimple => "RakuAST::Type::Simple",
         }
     }
 

--- a/t/rakuast-vardecl-scoped.t
+++ b/t/rakuast-vardecl-scoped.t
@@ -1,0 +1,55 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 10 (ADR-0011): scoped and typed variable declarations
+# (VarDeclaration::Simple gains `scope` and `type => Type::Simple`).
+# Expected gists captured verbatim from Rakudo; this file passes under BOTH
+# mutsu and raku.
+
+plan 5;
+
+# --- typed `my Int $x` ------------------------------------------------------
+is Q[my Int $x = 5].AST.gist, q:to/END/.chomp, 'my Int $x = 5 -> Type::Simple + initializer';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          type        => RakuAST::Type::Simple.new(
+            RakuAST::Name.from-identifier("Int")
+          ),
+          sigil       => "\$",
+          desigilname => RakuAST::Name.from-identifier("x"),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::IntLiteral.new(5)
+          )
+        )
+      )
+    )
+    END
+
+# --- `our $x` scope ---------------------------------------------------------
+is Q[our $x].AST.gist, q:to/END/.chomp, 'our $x -> scope => "our"';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          scope       => "our",
+          sigil       => "\$",
+          desigilname => RakuAST::Name.from-identifier("x")
+        )
+      )
+    )
+    END
+
+# --- `state $x` scope -------------------------------------------------------
+is Q[state $x].AST.gist.contains('scope       => "state"'), True, 'state $x -> scope => "state"';
+
+# --- `our Int $x`: scope then type ------------------------------------------
+is Q[our Int $x].AST.gist.contains(q:to/FRAG/.chomp), True, 'our Int $x -> scope then type';
+          scope       => "our",
+          type        => RakuAST::Type::Simple.new(
+            RakuAST::Name.from-identifier("Int")
+          ),
+    FRAG
+
+# --- plain `my $x` still has neither scope nor type -------------------------
+is Q[my $x].AST.gist.contains('scope') || Q[my $x].AST.gist.contains('type '), False,
+    'plain my $x omits scope and type';


### PR DESCRIPTION
## Summary

Phase 2 slice 10 of RakuAST (ADR-0011): `my`/`our`/`state` declarations with an optional simple type. `VarDeclaration::Simple` now emits, in raku's field order (scope, type, sigil, desigilname, initializer):

- a **`scope`** leaf (`"our"` / `"state"`; `my` is the default and omitted), and
- a **`type => RakuAST::Type::Simple(Name.from-identifier("…"))`** field.

```
my Int $x = 5
  -> VarDeclaration::Simple(type => Type::Simple(Name("Int")), sigil => "$",
                            desigilname => Name("x"), initializer => Initializer::Assign(...))
our Int $x
  -> VarDeclaration::Simple(scope => "our", type => Type::Simple(Name("Int")), ...)
```

## Coverage boundary (explicit `RuntimeError`)

Only plain (possibly `::`-qualified) type identifiers map to `Type::Simple`. Parameterised (`Array[Int]`), definite (`Int:D`), and coercion (`Str()`) types, dynamic (`$*x`) declarations, `where` constraints, and real `is`/`does` traits are deferred. (`is_simple_type` splits on `::` and requires each segment to be a bare identifier, so `Int:D` correctly defers.)

## Tests

`t/rakuast-vardecl-scoped.t` — 5 assertions (typed my, our, state, our+type ordering, plain my still bare), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green (plain `my $x`/`my @a` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)