### PR TITLE
feat: RakuAST Phase 2 slice 11 — anonymous parameter-less sub

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -777,11 +777,13 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 10: scoped/typed declarations — `my`/`our`/`state` with an optional simple type
         (`VarDeclaration::Simple` gains `scope` + `type => Type::Simple`). Tests in
         `t/rakuast-vardecl-scoped.t`.
-  - [ ] Slice 11+: anonymous `sub { }` (no-param only — `sub ($x)`/`-> $x` share `AnonSubParams`
-        so are indistinguishable), method decls (needs `RakuAST::Class`), labelled loops,
-        explicit-signature `for` (`for @a -> $x`), method-call modifiers, parameterised/definite
-        types; then `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to
-        `IntLiteral(3)`, mutsu does not).
+  - [x] Slice 11: anonymous parameter-less `sub { }` (`RakuAST::Sub` with no name). Tests in
+        `t/rakuast-anon-sub.t`. (`sub ($x)` shares `AnonSubParams` with pointy blocks, still
+        deferred.)
+  - [ ] Slice 12+: method decls (needs `RakuAST::Class`), labelled loops, explicit-signature `for`
+        (`for @a -> $x`), method-call modifiers, parameterised/definite types; then `.DEPARSE`;
+        resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu does
+        not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -195,6 +195,12 @@ earlier ones.
   return types, operator subs (associativity/precedence), alternate signatures, and anonymous
   `sub { }` (deferred). Parameters reuse the slice-3 plain-positional boundary (typed/named/slurpy/
   `where`/… still error).
+- **Anonymous parameter-less `sub { }` (Phase 2 slice 11).** `sub { ... }` with no signature
+  (`Expr::AnonSub { is_block: false }`) → `RakuAST::Sub(body => Blockoid)` with no `name` field.
+  Only the no-parameter form is handled: `sub ($x) { }` parses to `Expr::AnonSubParams`, which mutsu
+  cannot distinguish from a multi-param pointy block (`-> $a, $b`), so a parameterised anonymous sub
+  still renders as a `PointyBlock` — a documented divergence, unfixable without a distinguishing
+  flag in the internal AST. `is rw` blocks remain the boundary.
 - **Comma lists and `:=` binding (Phase 2 slice 9).** A bare comma list `1, 2, 3`
   (`Expr::ArrayLiteral`) → `ApplyListInfix(infix => Infix(","), operands => (...))`. A `:=` bind
   (`Stmt::Assign { op: Bind }`) → `ApplyInfix(left, infix => Infix(":="), right)` — a plain `Infix`,

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -519,12 +519,22 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
             is_rw,
             is_block,
         } => {
-            // Only the bare-block form maps to `RakuAST::Block`; `sub { }`
-            // (is_block == false) is `RakuAST::Sub`, deferred to the sub slice.
-            if *is_rw || !*is_block {
-                return Err(unsupported("`sub {}` / `is rw` block"));
+            if *is_rw {
+                return Err(unsupported("`is rw` block"));
             }
-            block_node(body)
+            if *is_block {
+                // A bare `{ ... }` block.
+                block_node(body)
+            } else {
+                // An anonymous, parameter-less `sub { ... }`. (`sub ($x) { }`
+                // parses to `AnonSubParams`, which mutsu cannot distinguish from
+                // a multi-param pointy block, so those still render as
+                // `PointyBlock` — a documented divergence.)
+                Ok(RakuAstNode {
+                    class: RakuAstClass::Sub,
+                    fields: vec![node_field(Some("body"), blockoid(body)?)],
+                })
+            }
         }
         Expr::Lambda {
             param,

--- a/t/rakuast-anon-sub.t
+++ b/t/rakuast-anon-sub.t
@@ -1,0 +1,54 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 11 (ADR-0011): anonymous parameter-less `sub { }`.
+# `sub { ... }` (no signature) -> RakuAST::Sub(body => Blockoid), with no
+# `name` field. Expected gists captured verbatim from Rakudo; this file passes
+# under BOTH mutsu and raku.
+#
+# Note: `sub ($x) { }` parses to the same internal node as a multi-param pointy
+# block, which mutsu cannot distinguish, so a parameterised anonymous sub still
+# renders as a PointyBlock (a documented divergence, ADR-0011) and is not
+# pinned here.
+
+plan 2;
+
+# --- anonymous sub as an initializer ----------------------------------------
+is Q[my $f = sub { 42 }].AST.gist, q:to/END/.chomp, 'anon sub -> Sub(body), no name';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => "\$",
+          desigilname => RakuAST::Name.from-identifier("f"),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::Sub.new(
+              body => RakuAST::Blockoid.new(
+                RakuAST::StatementList.new(
+                  RakuAST::Statement::Expression.new(
+                    expression => RakuAST::IntLiteral.new(42)
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- a bare-statement anonymous sub -----------------------------------------
+is Q[sub { 42 }].AST.gist, q:to/END/.chomp, 'bare anon sub statement -> Statement::Expression(Sub)';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Sub.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::IntLiteral.new(42)
+              )
+            )
+          )
+        )
+      )
+    )
+    END


### PR DESCRIPTION
## Summary

Phase 2 slice 11 of RakuAST (ADR-0011): an anonymous, parameter-less `sub { ... }` (`Expr::AnonSub` with `is_block == false`) now maps to `RakuAST::Sub(body => Blockoid)` with no `name` field, instead of hitting the coverage boundary. The bare `{ ... }` block form (`is_block == true`) is unchanged (`Block`).

```
my $f = sub { 42 }
  -> VarDeclaration::Simple(..., initializer => Initializer::Assign(Sub(body => Blockoid(...))))
```

## Still deferred

Only the **no-parameter** form is handled. `sub ($x) { }` parses to `Expr::AnonSubParams`, which mutsu cannot distinguish from a multi-param pointy block (`-> $a, $b`), so a parameterised anonymous sub still renders as a `PointyBlock` — an unfixable-without-a-flag divergence. `is rw` blocks remain the boundary.

## Tests

`t/rakuast-anon-sub.t` — 2 assertions (anon sub as initializer, bare-statement anon sub), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green (bare `{ 42 }` still renders as `Block`, not `Sub`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)