### PR TITLE
feat: RakuAST Phase 2 slice 12 — explicit-signature for loops

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -780,8 +780,10 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 11: anonymous parameter-less `sub { }` (`RakuAST::Sub` with no name). Tests in
         `t/rakuast-anon-sub.t`. (`sub ($x)` shares `AnonSubParams` with pointy blocks, still
         deferred.)
-  - [ ] Slice 12+: method decls (needs `RakuAST::Class`), labelled loops, explicit-signature `for`
-        (`for @a -> $x`), method-call modifiers, parameterised/definite types; then `.DEPARSE`;
+  - [x] Slice 12: explicit-signature `for @a -> $x` (body becomes a `PointyBlock` carrying the
+        signature). Tests in `t/rakuast-for-signature.t`.
+  - [ ] Slice 13+: method decls (needs `RakuAST::Class`), labelled loops, method-call modifiers
+        (`.?`/`.+`/`.*`), parameterised/definite types (`Array[Int]`/`Int:D`); then `.DEPARSE`;
         resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu does
         not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -182,7 +182,10 @@ earlier ones.
   / `required-topic => 1`. `with`/`without` are NOT mappable — mutsu desugars them at parse time
   into a temp-var + `.defined` check + `if` (`__with_tmp_0`), so there is no `Statement::With` node
   to recover (same collapse as `unless`/`until`); deferred. Explicit-signature `for` (`for @a ->
-  $x`), hyper/race/lazy modes, `<->` rw blocks, and labels also remain the boundary. Note the
+  $x`) is handled (slice 12): the body becomes a `PointyBlock` carrying the signature (reusing the
+  slice-3 pointy-block logic, no `Type::Setting`) instead of a topic-marked `Block`; a single param
+  lives in mutsu's `For.param_def`, multiple in `For.params_def`. Hyper/race/lazy modes, `<->` rw
+  blocks, and labels remain the boundary. Note the
   topic-call form `.method` (i.e. `$_.method` written bare) is desugared by mutsu to `$_.method`
   (`ApplyPostfix` on `$_`), where raku keeps a distinct `Term::TopicCall` — a pre-existing
   method-call representation divergence, unrelated to `for`.

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -227,26 +227,38 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             rw_block,
             explicit_zero_params,
         } => {
-            // Phase 2 slice 6 covers the implicit-topic form (`for SRC { ... $_ }`)
-            // only. An explicit signature (`for @a -> $x`), hyper/race/lazy modes,
-            // `<->` rw blocks, and labels carry extra RakuAST shape, deferred.
-            if param.is_some()
-                || param_def.is_some()
-                || !params.is_empty()
-                || !params_def.is_empty()
-                || label.is_some()
+            // Implicit-topic (`for SRC { ... $_ }`, slice 6) and explicit-signature
+            // (`for @a -> $x`, slice 12) forms. Hyper/race/lazy modes, `<->` rw
+            // blocks, and labels carry extra RakuAST shape, deferred.
+            // The explicit param names live in `param_def` / `params_def`; the
+            // sigil-stripped `param` / `params` string lists are unused here.
+            let _ = (param, params);
+            if label.is_some()
                 || *rw_block
                 || *explicit_zero_params
                 || !matches!(mode, ForMode::Normal)
             {
-                return Err(unsupported("for loop with explicit params / mode / label"));
+                return Err(unsupported("for loop with mode / rw / label"));
             }
+            // A single explicit param lives in `param_def`, multiple in
+            // `params_def`. With none, the body is an implicit-topic Block; with
+            // an explicit signature, it is a PointyBlock (matching raku).
+            let single = (**param_def).as_ref();
+            let explicit_defs: &[ParamDef] = match single {
+                Some(pd) => std::slice::from_ref(pd),
+                None => params_def,
+            };
+            let body_node = if explicit_defs.is_empty() {
+                topic_block_node(body)?
+            } else {
+                pointy_block(explicit_defs, body)?
+            };
             Ok(Some(RakuAstNode {
                 class: RakuAstClass::StatementFor,
                 fields: vec![
                     leaf_field(Some("mode"), Value::str("serial".to_string())),
                     node_field(Some("source"), convert_expr(iterable)?),
-                    node_field(Some("body"), topic_block_node(body)?),
+                    node_field(Some("body"), body_node),
                 ],
             }))
         }

--- a/t/rakuast-for-signature.t
+++ b/t/rakuast-for-signature.t
@@ -1,0 +1,27 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 12 (ADR-0011): explicit-signature `for @a -> $x { }`.
+# Unlike an implicit-topic `for` (whose body is a topic-marked Block, slice 6),
+# an explicit signature makes the body a PointyBlock carrying that signature.
+# Expected gists captured verbatim from Rakudo; this file passes under BOTH
+# mutsu and raku.
+
+plan 3;
+
+# --- single explicit parameter ----------------------------------------------
+# The `for` body is a PointyBlock carrying the signature (NOT an implicit-topic
+# Block), with the loop variable as its single parameter target.
+my $sig-for = Q[my @a; for @a -> $x { $x }].AST.gist;
+ok $sig-for.contains('body   => RakuAST::PointyBlock.new(')
+    && $sig-for.contains('name => "\$x"')
+    && !$sig-for.contains('implicit-topic'),
+    'explicit-signature for -> PointyBlock body with the loop variable';
+
+# --- two explicit parameters render two Parameters --------------------------
+is Q[my @a; for @a -> $a, $b { $a }].AST.gist.comb(/'RakuAST::Parameter.new'/).elems, 2,
+    'for -> $a, $b -> two Parameters in the signature';
+
+# --- implicit-topic for (no signature) is unchanged -------------------------
+is Q[for 1..3 { $_ }].AST.gist.contains('implicit-topic => True'), True,
+    'implicit-topic for still uses a topic Block, not a PointyBlock';


### PR DESCRIPTION
## Summary

Phase 2 slice 12 of RakuAST (ADR-0011): `for @a -> $x { }` (an explicit-signature `for`) now maps its body to a `RakuAST::PointyBlock` carrying that signature, instead of the implicit-topic `Block` used by the slice-6 `for SRC { ... $_ }` form.

```
for @a -> $x { $x }
  -> Statement::For(mode => "serial", source => Var("@a"),
                    body => PointyBlock(signature => Signature(...), body => Blockoid(...)))
```

## Implementation

A single explicit parameter lives in mutsu's `For.param_def`, multiple in `For.params_def`; both feed the existing pointy-block signature logic (no `Type::Setting`, matching raku's `for` parameters — unlike sub parameters). Implicit-topic `for` (no signature) is unchanged (still a topic-marked `Block`).

## Still deferred

Hyper/race/lazy modes, `<->` rw blocks, and labels.

## Tests

`t/rakuast-for-signature.t` — 3 assertions (single param → PointyBlock body, two params → two Parameters, implicit-topic `for` unchanged), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)