### PR TITLE
fix: grammar tokens as instance methods; type-named scalar declarations

### DIFF
--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1970,6 +1970,33 @@ impl Interpreter {
                 {
                     return self.dispatch_classhow_method(method, args.to_vec());
                 }
+                // A grammar token/rule called as an instance method
+                // (`G.new.tok`, URI's `IETF::RFC_Grammar::URI.new()
+                // .TOP-non-empty`): rakudo runs the token against an
+                // empty-string cursor and returns the resulting Match cursor —
+                // falsy when the token cannot match the empty string. Run
+                // `subparse("", rule => method)`; a failed subparse yields a
+                // falsy value that smartmatches False like a failed cursor.
+                if args.is_empty()
+                    && let ValueView::Instance { class_name, .. } = target.view()
+                {
+                    let cn = class_name.resolve();
+                    let qualified = format!("{}::{}", cn, method);
+                    if self
+                        .resolve_token_defs(&qualified)
+                        .map(|d| !d.is_empty())
+                        .unwrap_or(false)
+                    {
+                        return self.dispatch_package_parse(
+                            &cn,
+                            "subparse",
+                            &[
+                                Value::str_from(""),
+                                Value::pair("rule".to_string(), Value::str(method.to_string())),
+                            ],
+                        );
+                    }
+                }
                 let type_name = match target.view() {
                     ValueView::Instance { class_name, .. } => class_name.resolve(),
                     ValueView::Package(name) => name.resolve(),

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -79,6 +79,15 @@ impl Interpreter {
                     }
                 }
             }
+            // A Match/cursor on the RHS accepts by its own success, regardless
+            // of the LHS (rakudo: `$str ~~ G.new.tok` is the cursor's Bool —
+            // URI's missing-components smartmatches strings against the
+            // cursor a grammar-token instance-method call returns).
+            (ValueView::Str(_), ValueView::Instance { class_name, .. })
+                if class_name == "Match" =>
+            {
+                right.truthy()
+            }
             (
                 ValueView::Instance {
                     class_name: left_class,

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -279,7 +279,7 @@ impl Interpreter {
     /// `has_type` without short-name alias resolution — checks the type
     /// registries directly (classes/roles/enums/subsets, including parametric
     /// base names).
-    fn has_type_direct(&self, name: &str) -> bool {
+    pub(crate) fn has_type_direct(&self, name: &str) -> bool {
         self.registry().classes.contains_key(name)
             || self.registry().roles.contains_key(name)
             || self.registry().enum_types.contains_key(name)

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -101,9 +101,21 @@ impl Interpreter {
             // Pseudo-package names (MY, CORE, OUTER, CALLER, etc.) resolve to
             // Package values so that .WHO/.WHAT etc. work correctly.
             Value::package(Symbol::intern(name))
-        } else if (self.has_type(name) || Self::is_builtin_type(name))
-            && matches!(self.env().get(name).map(Value::view), Some(ValueView::Nil))
-        {
+        } else if match self.env().get(name).map(Value::view) {
+            Some(ValueView::Nil) => self.has_type(name) || Self::is_builtin_type(name),
+            // A `my $Buf = Buf.new` declaration pre-seeds env["Buf"] with the
+            // placeholder `Package(Any)` before its RHS runs (closure
+            // capture-by-reference support in SetVarDynamic); the RHS bareword
+            // still names the TYPE — without this it fell into the alias
+            // branch below and returned Any. `has_type_direct` (no alias
+            // resolution) is required here: the plain `has_type` treats the
+            // very placeholder as an import alias to Any and reports ANY name
+            // as a type (`my $x .= new` would resolve `x` to Package("x")).
+            Some(ValueView::Package(p)) if p == "Any" && name != "Any" => {
+                Self::is_builtin_type(name) || self.has_type_direct(name)
+            }
+            _ => false,
+        } {
             // A bareword that names a type resolves to the type object. A same-named
             // `$`-sigiled scalar (`my $foo` where a class `foo` exists) is stored
             // sigil-stripped under the same env key; while it is still unassigned

--- a/t/grammar-token-instance-method.t
+++ b/t/grammar-token-instance-method.t
@@ -1,0 +1,34 @@
+use v6;
+use Test;
+
+plan 6;
+
+# Calling a grammar token as an instance method runs it against an
+# empty-string cursor; the result smartmatches by the cursor's success
+# (URI's missing-components: `'foo' ~~ IETF::...URI.new().TOP-non-empty`).
+grammar G {
+    token maybe-empty { a* }
+    token non-empty   { a+ }
+}
+
+ok "anything" ~~ G.new.maybe-empty,
+    'a token matching the empty string smartmatches True';
+nok "anything" ~~ G.new.non-empty,
+    'a token NOT matching the empty string smartmatches False';
+ok "other" ~~ G.new.maybe-empty,
+    'the LHS string does not affect the cursor verdict';
+
+# The URI shape: qualified cross-module grammar rules.
+grammar H {
+    token TOP-non-empty { <.alpha>+ }
+    token any-at-all { <.alpha>* }
+}
+nok 'foo' ~~ H.new().TOP-non-empty, 'non-empty rule rejects (URI shape)';
+ok '#foo' ~~ H.new().any-at-all, 'empty-matching rule accepts (URI shape)';
+
+# Real methods still win over tokens of the same name.
+grammar K {
+    token t { a }
+    method regular() { 'method-result' }
+}
+is K.new.regular, 'method-result', 'real methods dispatch normally';

--- a/t/type-named-scalar-decl.t
+++ b/t/type-named-scalar-decl.t
@@ -1,0 +1,22 @@
+use v6;
+use Test;
+
+plan 5;
+
+# `my $Buf = Buf.new` — the declaration pre-seeds env with a placeholder
+# before the RHS runs; the RHS bareword `Buf` must still resolve to the
+# TYPE, not the placeholder (URI::Escape's `my $Buf = Buf.new` loop).
+my $Buf = Buf.new;
+isa-ok $Buf, Buf, 'RHS bareword resolves to the type in its own declaration';
+$Buf.push('ab'.encode('utf8'));
+is $Buf.elems, 2, 'the constructed Buf works';
+
+my $Str = Str;
+ok $Str === Str, 'a type-named scalar can hold the type object';
+
+my $Int = Int.new(42);
+is $Int, 42, 'Int-named scalar constructs an Int';
+
+# The distinct-symbol rule still holds after assignment.
+my $Bag = 5;
+is $Bag + 1, 6, 'a type-named scalar holds its assigned value';


### PR DESCRIPTION
## Summary

The last two URI-0.3.8 test files (`missing-components`, `utf8-c8`):

1. **Grammar token as instance method** — `G.new.tok` (URI's `IETF::RFC_Grammar::URI.new().TOP-non-empty`) now runs the token against an empty-string cursor via `subparse(\"\", rule => method)` as a final dispatch fallback. Rakudo returns the resulting cursor Match, falsy when the token cannot match empty. A new smartmatch arm makes `Str ~~ <Match cursor>` accept by the cursor's own success regardless of the LHS (rakudo-verified: a successful cursor accepts any string, `pos(-3)` failure cursors reject all).
2. **`my $Buf = Buf.new` resolved `Buf` to Any** — the declaration pre-seeds `env[\"Buf\"]` with a placeholder `Package(Any)` (closure capture-by-reference support in SetVarDynamic); the bareword alias branch returned it verbatim, and `has_type`'s alias resolution treated the same placeholder as an import alias to Any — reporting *any* name as a type. The type-resolution branch now also fires on the placeholder, gated on the new `pub(crate) has_type_direct` (no alias resolution), so `my $x .= new` keeps its `Any.new` semantics (`t/method-call-assign-untyped-decl.t` stays green — it caught the first over-broad version of this fix).

## Milestone

**URI-0.3.8: 14/14 test files pass — the whole dist suite is green.** (3/14 at campaign start; #4683, #4685, #4688, #4694 landed the other 25+ general fixes.)

## Test plan

- [x] New pins `t/grammar-token-instance-method.t`, `t/type-named-scalar-decl.t` green on raku and mutsu
- [x] `make test` PASS (incl. `t/method-call-assign-untyped-decl.t`)
- [x] Roast subset S02-types + S03-smartmatch + S05 + S06 + S12 + S32-str via `scripts/run-roast-test.sh`: PASS
- [x] clippy `-D warnings` + fmt clean
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)