### PR TITLE
feat: RakuAST Phase 2 slice 13 — class and method declarations

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -782,7 +782,10 @@ so it is tracked separately from the roast backlog.
         deferred.)
   - [x] Slice 12: explicit-signature `for @a -> $x` (body becomes a `PointyBlock` carrying the
         signature). Tests in `t/rakuast-for-signature.t`.
-  - [ ] Slice 13+: method decls (needs `RakuAST::Class`), labelled loops, method-call modifiers
+  - [x] Slice 13: class and method declarations (`RakuAST::Class`, `RakuAST::Method`; class body is
+        an ordinary `Block`, methods reuse the `Sub` routine helper). Tests in `t/rakuast-class.t`.
+        (Attributes `has $.x`, inheritance, roles/grammars deferred.)
+  - [ ] Slice 14+: attributes (`has $.x`), roles/grammars, labelled loops, method-call modifiers
         (`.?`/`.+`/`.*`), parameterised/definite types (`Array[Int]`/`Int:D`); then `.DEPARSE`;
         resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu does
         not).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -204,6 +204,15 @@ earlier ones.
   cannot distinguish from a multi-param pointy block (`-> $a, $b`), so a parameterised anonymous sub
   still renders as a `PointyBlock` — a documented divergence, unfixable without a distinguishing
   flag in the internal AST. `is rw` blocks remain the boundary.
+- **Class and method declarations (Phase 2 slice 13).** `class NAME { body }` (`Stmt::ClassDecl`)
+  → `Statement::Expression(Class(name => Name, body => Block(Blockoid(StatementList))))` — the class
+  body is an ordinary `Block` whose statements convert recursively. `method NAME (params) { body }`
+  (`Stmt::MethodDecl`) inside → `RakuAST::Method`, built by the same `routine_node` helper as `Sub`
+  (parameters carry the implicit `type => Type::Setting(Any)`). Boundary (explicit `RuntimeError`):
+  inheritance (`is`/`does`), `my`/`unit` scope, `repr`, `rw`, class traits; and for methods,
+  private/submethod/multi/`our`/`my` forms, traits, delegation (`handles`), and return types.
+  Attributes (`has $.x`, `Stmt::HasDecl`) are not yet converted, so a class body containing one hits
+  the boundary. Roles/grammars (`RakuAST::Role` with a distinct `RoleBody`) are deferred.
 - **Comma lists and `:=` binding (Phase 2 slice 9).** A bare comma list `1, 2, 3`
   (`Expr::ArrayLiteral`) → `ApplyListInfix(infix => Infix(","), operands => (...))`. A `:=` bind
   (`Stmt::Assign { op: Bind }`) → `ApplyInfix(left, infix => Infix(":="), right)` — a plain `Infix`,

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -302,18 +302,97 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                     "sub with traits / multi / export / return type",
                 ));
             }
-            let name_node = RakuAstNode {
-                class: RakuAstClass::Name,
-                fields: vec![leaf_field(None, Value::str(name.resolve()))],
-            };
-            let mut fields = vec![node_field(Some("name"), name_node)];
-            if !param_defs.is_empty() {
-                fields.push(node_field(Some("signature"), signature(param_defs, true)?));
+            Ok(Some(statement_expression(routine_node(
+                RakuAstClass::Sub,
+                &name.resolve(),
+                param_defs,
+                body,
+            )?)))
+        }
+        Stmt::MethodDecl {
+            name,
+            name_expr,
+            param_defs,
+            body,
+            multi,
+            is_rw,
+            is_private,
+            is_our,
+            is_my,
+            is_submethod,
+            our_variable_form,
+            return_type,
+            is_default_candidate,
+            deprecated_message,
+            handles,
+            custom_traits,
+            ..
+        } => {
+            // Plain `method NAME (params) { body }`. Private/submethod/multi/our/
+            // my forms, traits, delegation, and return types carry extra shape.
+            if name_expr.is_some()
+                || *multi
+                || *is_rw
+                || *is_private
+                || *is_our
+                || *is_my
+                || *is_submethod
+                || *our_variable_form
+                || return_type.is_some()
+                || *is_default_candidate
+                || deprecated_message.is_some()
+                || !handles.is_empty()
+                || !custom_traits.is_empty()
+            {
+                return Err(unsupported(
+                    "method with traits / private / multi / submethod",
+                ));
             }
-            fields.push(node_field(Some("body"), blockoid(body)?));
+            Ok(Some(statement_expression(routine_node(
+                RakuAstClass::Method,
+                &name.resolve(),
+                param_defs,
+                body,
+            )?)))
+        }
+        Stmt::ClassDecl {
+            name,
+            name_expr,
+            parents,
+            class_is_rw,
+            is_hidden,
+            is_lexical,
+            hidden_parents,
+            does_parents,
+            repr,
+            body,
+            custom_traits,
+            is_unit,
+            ..
+        } => {
+            // Plain `class NAME { body }`. Inheritance (`is`/`does`), `my`/unit
+            // scope, reprs, `rw`, and traits carry extra RakuAST shape, deferred.
+            if name_expr.is_some()
+                || !parents.is_empty()
+                || *class_is_rw
+                || *is_hidden
+                || *is_lexical
+                || !hidden_parents.is_empty()
+                || !does_parents.is_empty()
+                || repr.is_some()
+                || !custom_traits.is_empty()
+                || *is_unit
+            {
+                return Err(unsupported(
+                    "class with inheritance / scope / repr / traits",
+                ));
+            }
             Ok(Some(statement_expression(RakuAstNode {
-                class: RakuAstClass::Sub,
-                fields,
+                class: RakuAstClass::Class,
+                fields: vec![
+                    node_field(Some("name"), name_from_identifier(&name.resolve())),
+                    node_field(Some("body"), block_node(body)?),
+                ],
             })))
         }
         Stmt::Assign { name, expr, op } => match op {
@@ -719,6 +798,23 @@ fn pointy_block_from_lambda(param: &str, body: &[Stmt]) -> Result<RakuAstNode, R
             node_field(Some("body"), blockoid(body)?),
         ],
     })
+}
+
+/// A named routine — `Sub` or `Method` — with an optional signature and a
+/// body. A parameter-less routine omits the `signature` field; parameters
+/// carry the implicit `type => Type::Setting(Any)` (`type_setting = true`).
+fn routine_node(
+    class: RakuAstClass,
+    name: &str,
+    param_defs: &[ParamDef],
+    body: &[Stmt],
+) -> Result<RakuAstNode, RuntimeError> {
+    let mut fields = vec![node_field(Some("name"), name_from_identifier(name))];
+    if !param_defs.is_empty() {
+        fields.push(node_field(Some("signature"), signature(param_defs, true)?));
+    }
+    fields.push(node_field(Some("body"), blockoid(body)?));
+    Ok(RakuAstNode { class, fields })
 }
 
 /// `Signature(parameters => (Parameter, ...))`. `type_setting` prepends the

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -91,6 +91,9 @@ pub enum RakuAstClass {
     ApplyListInfix,
     // Phase 2 slice 10: scoped/typed variable declarations.
     TypeSimple,
+    // Phase 2 slice 13: class and method declarations.
+    Class,
+    Method,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -141,6 +144,8 @@ impl RakuAstClass {
             StatementLoopRepeatWhile => "RakuAST::Statement::Loop::RepeatWhile",
             ApplyListInfix => "RakuAST::ApplyListInfix",
             TypeSimple => "RakuAST::Type::Simple",
+            Class => "RakuAST::Class",
+            Method => "RakuAST::Method",
         }
     }
 

--- a/t/rakuast-class.t
+++ b/t/rakuast-class.t
@@ -1,0 +1,62 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 13 (ADR-0011): class and method declarations
+# (RakuAST::Class, RakuAST::Method). Expected gists captured verbatim from
+# Rakudo; this file passes under BOTH mutsu and raku. Each test uses a distinct
+# class name because `.AST` registers the symbol and raku rejects redeclaration.
+
+plan 3;
+
+# --- empty class ------------------------------------------------------------
+is Q[class C1 { }].AST.gist, q:to/END/.chomp, 'class -> Class(name, body => Block)';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Class.new(
+          name => RakuAST::Name.from-identifier("C1"),
+          body => RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new()
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- class with a method ----------------------------------------------------
+is Q[class C2 { method m { 1 } }].AST.gist, q:to/END/.chomp, 'method in class body -> Method node';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Class.new(
+          name => RakuAST::Name.from-identifier("C2"),
+          body => RakuAST::Block.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new(
+                RakuAST::Statement::Expression.new(
+                  expression => RakuAST::Method.new(
+                    name => RakuAST::Name.from-identifier("m"),
+                    body => RakuAST::Blockoid.new(
+                      RakuAST::StatementList.new(
+                        RakuAST::Statement::Expression.new(
+                          expression => RakuAST::IntLiteral.new(1)
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- a method with a parameter carries the implicit Type::Setting -----------
+my $g = Q[class C3 { method m($x) { $x } }].AST.gist;
+ok $g.contains('expression => RakuAST::Method.new(')
+    && $g.contains('signature => RakuAST::Signature.new(')
+    && $g.contains('type     => RakuAST::Type::Setting.new(')
+    && $g.contains('name => "\$x"'),
+    'method with a parameter -> Method + Signature + Type::Setting';


### PR DESCRIPTION
## Summary

Phase 2 slice 13 of RakuAST (ADR-0011): `RakuAST::Class` and `RakuAST::Method`, opening OOP-declaration introspection.

- **`class NAME { body }`** (`Stmt::ClassDecl`) → `Statement::Expression(Class(name => Name, body => Block(Blockoid(StatementList))))`. The class body is an ordinary `Block` whose statements convert recursively.
- **`method NAME (params) { body }`** (`Stmt::MethodDecl`) inside → `RakuAST::Method`, built by a shared `routine_node` helper (also used by `Sub` now); method parameters carry the implicit `type => Type::Setting(Any)`.

```
class C { method m { 1 } }
  -> Class(name => Name("C"),
           body => Block(Blockoid(StatementList(
                     Statement::Expression(Method(name => Name("m"), body => Blockoid(...)))))))
```

## Coverage boundary (explicit `RuntimeError`)

Inheritance (`is`/`does`), `my`/`unit` scope, `repr`, `rw`, class traits; and for methods, private/submethod/multi/`our`/`my` forms, traits, delegation (`handles`), and return types. **Attributes** (`has $.x`, `Stmt::HasDecl`) are not yet converted, so a class body containing one hits the boundary. Roles/grammars (`RakuAST::Role`, distinct `RoleBody`) are deferred.

## Tests

`t/rakuast-class.t` — 3 assertions (empty class, class with a method, method-with-parameter `Type::Setting`), **passing under BOTH mutsu and raku** (distinct class names per test since `.AST` registers the symbol). All existing `t/rakuast-*.t` still green — the `Sub` refactor into `routine_node` is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)