### PR TITLE
feat: RakuAST Phase 2 slice 14 — class attributes

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -785,10 +785,13 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 13: class and method declarations (`RakuAST::Class`, `RakuAST::Method`; class body is
         an ordinary `Block`, methods reuse the `Sub` routine helper). Tests in `t/rakuast-class.t`.
         (Attributes `has $.x`, inheritance, roles/grammars deferred.)
-  - [ ] Slice 14+: attributes (`has $.x`), roles/grammars, labelled loops, method-call modifiers
-        (`.?`/`.+`/`.*`), parameterised/definite types (`Array[Int]`/`Int:D`); then `.DEPARSE`;
-        resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu does
-        not).
+  - [x] Slice 14: class attributes `has [Type] $.x` (`VarDeclaration::Simple` with `scope => "has"`
+        and a `twigil`). Tests in `t/rakuast-attribute.t`. (Explicit defaults → `Trait::WillBuild`,
+        deferred.)
+  - [ ] Slice 15+: roles/grammars, labelled loops, method-call modifiers (`.?`/`.+`/`.*`),
+        parameterised/definite types (`Array[Int]`/`Int:D`), attribute defaults (`Trait::WillBuild`);
+        then `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to
+        `IntLiteral(3)`, mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -211,8 +211,16 @@ earlier ones.
   (parameters carry the implicit `type => Type::Setting(Any)`). Boundary (explicit `RuntimeError`):
   inheritance (`is`/`does`), `my`/`unit` scope, `repr`, `rw`, class traits; and for methods,
   private/submethod/multi/`our`/`my` forms, traits, delegation (`handles`), and return types.
-  Attributes (`has $.x`, `Stmt::HasDecl`) are not yet converted, so a class body containing one hits
-  the boundary. Roles/grammars (`RakuAST::Role` with a distinct `RoleBody`) are deferred.
+  Roles/grammars (`RakuAST::Role` with a distinct `RoleBody`) are deferred.
+- **Attributes (Phase 2 slice 14).** `has [Type] $.x` (`Stmt::HasDecl`) → a `VarDeclaration::Simple`
+  with `scope => "has"` and a `twigil` leaf (`.` public accessor / `!` private), reusing the slice-10
+  `var_declaration` helper (extended with a `twigil` field, and its initializer arg generalised to
+  `Option<&Expr>`). A **typed** attribute (`has Int $.z`) carries an *implicit*
+  `BareWord(<TypeName>)` default in mutsu's AST that is NOT an initializer and is filtered out
+  (compared against the type name); an **explicit** default (`has $.x = 5`) becomes a
+  `Trait::WillBuild` in raku (not an `initializer`), so it is deferred, along with `is rw`, type
+  smileys (`:D`), `is required`, `where`, aliases (`has $x`), `my`/`our` attributes, delegation, and
+  other traits.
 - **Comma lists and `:=` binding (Phase 2 slice 9).** A bare comma list `1, 2, 3`
   (`Expr::ArrayLiteral`) → `ApplyListInfix(infix => Infix(","), operands => (...))`. A `:=` bind
   (`Stmt::Assign { op: Bind }`) → `ApplyInfix(left, infix => Infix(":="), right)` — a plain `Infix`,

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -93,12 +93,9 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             let has_initializer = custom_traits
                 .iter()
                 .any(|(name, _)| name == "__has_initializer");
+            let init = has_initializer.then_some(expr);
             Ok(Some(statement_expression(var_declaration(
-                name,
-                expr,
-                has_initializer,
-                scope,
-                type_name,
+                name, init, scope, type_name, None,
             )?)))
         }
         // A bare `{ ... }` block at statement level -> Statement::Expression(Block).
@@ -395,6 +392,77 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 ],
             })))
         }
+        Stmt::HasDecl {
+            name,
+            is_public,
+            default,
+            handles,
+            is_rw,
+            type_constraint,
+            type_smiley,
+            is_required,
+            sigil,
+            where_constraint,
+            is_alias,
+            is_our,
+            is_my,
+            is_default,
+            is_type,
+            deprecated_message,
+            unknown_traits,
+            ..
+        } => {
+            // A plain `has [Type] $.x` attribute -> a `VarDeclaration::Simple`
+            // with `scope => "has"` and a `twigil` (`.` public accessor / `!`
+            // private). An *explicit* attribute default (`has $.x = 5`) becomes a
+            // `Trait::WillBuild` in raku (not an `initializer`), so it is
+            // deferred; but a typed attribute (`has Int $.z`) carries an
+            // *implicit* `BareWord(<TypeName>)` default that is NOT a will-build
+            // and must be ignored. Traits, type smileys, `required`, `where`,
+            // aliases, and `my`/`our` attributes are also deferred.
+            let has_explicit_default = match default {
+                None => false,
+                // The implicit type default: `BareWord` equal to the type name.
+                Some(Expr::BareWord(w)) => type_constraint.as_deref() != Some(w.as_str()),
+                Some(_) => true,
+            };
+            if has_explicit_default
+                || !handles.is_empty()
+                || *is_rw
+                || type_smiley.is_some()
+                || is_required.is_some()
+                || where_constraint.is_some()
+                || *is_alias
+                || *is_our
+                || *is_my
+                || is_default.is_some()
+                || is_type.is_some()
+                || deprecated_message.is_some()
+                || !unknown_traits.is_empty()
+            {
+                return Err(unsupported(
+                    "attribute with default / traits / smiley / scope",
+                ));
+            }
+            let type_name = match type_constraint.as_deref() {
+                Some(t) if is_simple_type(t) => Some(t),
+                Some(_) => return Err(unsupported("parameterised/definite attribute type")),
+                None => None,
+            };
+            let twigil = if *is_public { "." } else { "!" };
+            let full_name = if *sigil == '$' {
+                name.resolve()
+            } else {
+                format!("{}{}", sigil, name.resolve())
+            };
+            Ok(Some(statement_expression(var_declaration(
+                &full_name,
+                None,
+                Some("has"),
+                type_name,
+                Some(twigil),
+            )?)))
+        }
         Stmt::Assign { name, expr, op } => match op {
             // `$x = EXPR` — the special `Assignment` infix (slice 2). Note mutsu
             // desugars `$x += 3` to `$x = $x + 3` (op stays `Assign`), so a
@@ -462,14 +530,15 @@ fn plain_infix(op: &str) -> RakuAstNode {
 /// name carries its `@`/`%`/`&` sigil.
 fn var_declaration(
     name: &str,
-    init_expr: &Expr,
-    has_initializer: bool,
+    init: Option<&Expr>,
     scope: Option<&'static str>,
     type_name: Option<&str>,
+    twigil: Option<&str>,
 ) -> Result<RakuAstNode, RuntimeError> {
     let (sigil, desigil) = split_sigil(name);
-    // Field order matches raku: scope, type, sigil, desigilname, initializer —
-    // with scope (default `my`) and type omitted when absent.
+    // Field order matches raku: scope, type, sigil, twigil, desigilname,
+    // initializer — each omitted when absent (scope defaults to `my`; twigil is
+    // present only on attributes).
     let mut fields = Vec::new();
     if let Some(s) = scope {
         fields.push(leaf_field(Some("scope"), Value::str(s.to_string())));
@@ -482,11 +551,14 @@ fn var_declaration(
         fields.push(node_field(Some("type"), type_node));
     }
     fields.push(leaf_field(Some("sigil"), Value::str(sigil.to_string())));
+    if let Some(tw) = twigil {
+        fields.push(leaf_field(Some("twigil"), Value::str(tw.to_string())));
+    }
     fields.push(node_field(
         Some("desigilname"),
         name_from_identifier(desigil),
     ));
-    if has_initializer {
+    if let Some(init_expr) = init {
         let assign = RakuAstNode {
             class: RakuAstClass::InitializerAssign,
             fields: vec![node_field(None, convert_expr(init_expr)?)],
@@ -719,7 +791,8 @@ fn loop_setup_node(stmt: &Stmt) -> Result<RakuAstNode, RuntimeError> {
         {
             return Err(unsupported("scoped/typed variable declaration"));
         }
-        return var_declaration(name, expr, !expr_is_nil(expr), None, None);
+        let init = (!expr_is_nil(expr)).then_some(expr);
+        return var_declaration(name, init, None, None, None);
     }
     // Assignment / expression setups convert normally, then get unwrapped.
     let node = convert_stmt(stmt)?.ok_or_else(|| unsupported("empty loop setup clause"))?;

--- a/t/rakuast-attribute.t
+++ b/t/rakuast-attribute.t
@@ -1,0 +1,35 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 14 (ADR-0011): class attributes (`has $.x`).
+# An attribute is a VarDeclaration::Simple with `scope => "has"` and a `twigil`
+# (`.` public accessor / `!` private). Expected gists captured verbatim from
+# Rakudo; this file passes under BOTH mutsu and raku. Distinct class names are
+# used because `.AST` registers the symbol.
+
+plan 4;
+
+# --- public attribute `$.x` -------------------------------------------------
+my $pub = Q[class A1 { has $.x }].AST.gist;
+ok $pub.contains('expression => RakuAST::VarDeclaration::Simple.new(')
+    && $pub.contains('scope       => "has"')
+    && $pub.contains('sigil       => "\$"')
+    && $pub.contains('twigil      => "."')
+    && $pub.contains('desigilname => RakuAST::Name.from-identifier("x")'),
+    'has $.x -> VarDeclaration::Simple with scope has and twigil .';
+
+# --- private attribute `$!y` uses the `!` twigil ----------------------------
+is Q[class A2 { has $!y }].AST.gist.contains('twigil      => "!"'), True, 'has $!y -> twigil !';
+
+# --- typed attribute keeps its Type::Simple (implicit type default ignored) --
+my $typed = Q[class A3 { has Int $.z }].AST.gist;
+ok $typed.contains('scope       => "has"')
+    && $typed.contains('type        => RakuAST::Type::Simple.new(')
+    && $typed.contains('RakuAST::Name.from-identifier("Int")')
+    && $typed.contains('twigil      => "."')
+    && !$typed.contains('initializer'),
+    'has Int $.z -> Type::Simple, no spurious initializer';
+
+# --- array attribute `@.items` ----------------------------------------------
+is Q[class A4 { has @.items }].AST.gist.contains('sigil       => "\@"'), True,
+    'has @.items -> array sigil';


### PR DESCRIPTION
## Summary

Phase 2 slice 14 of RakuAST (ADR-0011): class attributes. `has [Type] $.x` (`Stmt::HasDecl`) maps to a `VarDeclaration::Simple` with `scope => "has"` and a `twigil` leaf (`.` for the public-accessor form, `!` for private).

```
class C { has Int $.z }
  -> ...VarDeclaration::Simple(scope => "has", type => Type::Simple(Name("Int")),
                               sigil => "$", twigil => ".", desigilname => Name("z"))
```

## Implementation notes

- `var_declaration` gained a `twigil` field and its initializer argument was generalised to `Option<&Expr>` (cleaner for attributes, which carry no explicit initializer node).
- A **typed** attribute (`has Int $.z`) carries an *implicit* `BareWord(<TypeName>)` default in mutsu's AST that is **not** an initializer; it is filtered out by comparing against the type name (so no spurious `initializer` field is emitted).

## Coverage boundary (explicit `RuntimeError`)

An **explicit** default (`has $.x = 5`) becomes a `Trait::WillBuild` in raku (not an `initializer`), so it is deferred — along with `is rw`, type smileys (`:D`), `is required`, `where`, aliases (`has $x`), `my`/`our` attributes, delegation, and other traits.

## Tests

`t/rakuast-attribute.t` — 4 assertions (public `$.x`, private `$!y` twigil, typed `Int $.z` with no spurious initializer, array `@.items`), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green (the `var_declaration` refactor is byte-identical for plain declarations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)