### PR TITLE
feat: RakuAST Phase 2 slice 15 — method-call modifiers

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -788,10 +788,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 14: class attributes `has [Type] $.x` (`VarDeclaration::Simple` with `scope => "has"`
         and a `twigil`). Tests in `t/rakuast-attribute.t`. (Explicit defaults → `Trait::WillBuild`,
         deferred.)
-  - [ ] Slice 15+: roles/grammars, labelled loops, method-call modifiers (`.?`/`.+`/`.*`),
-        parameterised/definite types (`Array[Int]`/`Int:D`), attribute defaults (`Trait::WillBuild`);
-        then `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to
-        `IntLiteral(3)`, mutsu does not).
+  - [x] Slice 15: method-call modifiers `.?`/`.+`/`.*` (`Call::Method` gains a `dispatch` field).
+        Tests in `t/rakuast-method-modifier.t`.
+  - [ ] Slice 16+: roles/grammars, labelled loops, parameterised/definite types
+        (`Array[Int]`/`Int:D`), attribute defaults (`Trait::WillBuild`), quoted method names; then
+        `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`,
+        mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -221,6 +221,9 @@ earlier ones.
   `Trait::WillBuild` in raku (not an `initializer`), so it is deferred, along with `is rw`, type
   smileys (`:D`), `is required`, `where`, aliases (`has $x`), `my`/`our` attributes, delegation, and
   other traits.
+- **Method-call modifiers (Phase 2 slice 15).** `$x.?foo` / `$x.+foo` / `$x.*foo` (`Expr::MethodCall`
+  with a `modifier: Option<char>`) add a `dispatch => ".?"` / `".+"` / `".*"` leaf to the
+  `Call::Method`, after `name` and any `args`. A quoted method name (`."$n"()`) remains the boundary.
 - **Comma lists and `:=` binding (Phase 2 slice 9).** A bare comma list `1, 2, 3`
   (`Expr::ArrayLiteral`) → `ApplyListInfix(infix => Infix(","), operands => (...))`. A `:=` bind
   (`Stmt::Assign { op: Bind }`) → `ApplyInfix(left, infix => Infix(":="), right)` — a plain `Infix`,

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -645,16 +645,19 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
             modifier,
             quoted,
         } => {
-            // Phase 2 slice 2 covers only plain `.method(...)`; modifier forms
-            // (`.?`/`.+`/`.*`) and quoted names map to distinct RakuAST nodes.
-            if modifier.is_some() || *quoted {
-                return Err(unsupported("method call modifier / quoted name"));
+            // Plain `.method(...)` and modifier forms (`.?`/`.+`/`.*`, slice 15).
+            // A quoted method name (`."$name"()`) maps to a distinct node.
+            if *quoted {
+                return Err(unsupported("quoted method name"));
             }
             Ok(RakuAstNode {
                 class: RakuAstClass::ApplyPostfix,
                 fields: vec![
                     node_field(Some("operand"), convert_expr(target)?),
-                    node_field(Some("postfix"), call_method(name.as_str(), args)?),
+                    node_field(
+                        Some("postfix"),
+                        call_method(name.as_str(), args, *modifier)?,
+                    ),
                 ],
             })
         }
@@ -980,14 +983,23 @@ fn simple_parameter(
 }
 
 /// `.method` / `.method(args)` -> `Call::Method(name => Name, [args => ArgList])`.
-fn call_method(name: &str, args: &[Expr]) -> Result<RakuAstNode, RuntimeError> {
+fn call_method(
+    name: &str,
+    args: &[Expr],
+    modifier: Option<char>,
+) -> Result<RakuAstNode, RuntimeError> {
     let name_node = RakuAstNode {
         class: RakuAstClass::Name,
         fields: vec![leaf_field(None, Value::str(name.to_string()))],
     };
+    // Field order matches raku: name, args, dispatch.
     let mut fields = vec![node_field(Some("name"), name_node)];
     if !args.is_empty() {
         fields.push(node_field(Some("args"), arg_list(args)?));
+    }
+    if let Some(m) = modifier {
+        // `.?` / `.+` / `.*` become a `dispatch` string.
+        fields.push(leaf_field(Some("dispatch"), Value::str(format!(".{m}"))));
     }
     Ok(RakuAstNode {
         class: RakuAstClass::CallMethod,

--- a/t/rakuast-method-modifier.t
+++ b/t/rakuast-method-modifier.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 15 (ADR-0011): method-call modifiers `.?` / `.+` / `.*`.
+# A modifier adds a `dispatch => ".?"` (etc.) field to the Call::Method, after
+# the name and any args. Expected strings captured verbatim from Rakudo; this
+# file passes under BOTH mutsu and raku.
+
+plan 4;
+
+# --- `.?` maybe-dispatch ----------------------------------------------------
+my $maybe = Q[my $x; $x.?foo].AST.gist;
+ok $maybe.contains('postfix => RakuAST::Call::Method.new(')
+    && $maybe.contains('name     => RakuAST::Name.from-identifier("foo")')
+    && $maybe.contains('dispatch => ".?"'),
+    '$x.?foo -> Call::Method with dispatch ".?"';
+
+# --- `.+` all-dispatch ------------------------------------------------------
+is Q[my $x; $x.+foo].AST.gist.contains('dispatch => ".+"'), True, '$x.+foo -> dispatch ".+"';
+
+# --- `.*` all-dispatch (zero or more) ---------------------------------------
+is Q[my $x; $x.*foo].AST.gist.contains('dispatch => ".*"'), True, '$x.*foo -> dispatch ".*"';
+
+# --- a modifier call with arguments keeps args before dispatch --------------
+my $with-args = Q[my $x; $x.?foo(1)].AST.gist;
+ok $with-args.contains('args     => RakuAST::ArgList.new(')
+    && $with-args.contains('dispatch => ".?"')
+    && $with-args.index('args') < $with-args.index('dispatch'),
+    'modifier call keeps args, then dispatch';


### PR DESCRIPTION
## Summary

Phase 2 slice 15 of RakuAST (ADR-0011): the method-call modifiers `.?` / `.+` / `.*`. A modifier call (`Expr::MethodCall` with a `modifier: Option<char>`) now adds a `dispatch` leaf to the `Call::Method`, after the `name` and any `args`, instead of hitting the coverage boundary.

```
$x.?foo    -> ApplyPostfix(operand, postfix => Call::Method(name => Name("foo"), dispatch => ".?"))
$x.?foo(1) -> ...Call::Method(name => Name("foo"), args => ArgList(...), dispatch => ".?")
```

`.?` (maybe-dispatch), `.+` (all, ≥1), and `.*` (all, ≥0) all map to their respective `dispatch` strings. A quoted method name (`."$n"()`) remains the boundary.

## Tests

`t/rakuast-method-modifier.t` — 4 assertions (`.?`, `.+`, `.*`, modifier with args ordered before dispatch), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green (plain `.method` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)