### PR TITLE
fix: MOP archetypes, SetHash.set, and multi-dispatch narrowness for JSON::Unmarshal

### DIFF
--- a/src/runtime/dispatch_candidates.rs
+++ b/src/runtime/dispatch_candidates.rs
@@ -176,7 +176,16 @@ impl Interpreter {
         let typed_param_count = params
             .iter()
             .filter(|p| {
-                p.type_constraint.is_some()
+                // A bare `Mu`/`Any` constraint is no narrower than an
+                // unconstrained param (raku: unconstrained IS Any) — counting
+                // it made `(Any:D $j, Mu)` outrank `($j, @x)` wholesale
+                // (JSON::Unmarshal's fallback swallowing the Positional
+                // candidate). A smiley (`Any:D`) still counts.
+                let meaningful_type = p
+                    .type_constraint
+                    .as_deref()
+                    .is_some_and(|tc| !matches!(tc, "Mu" | "Any"));
+                meaningful_type
                     || (!p.slurpy
                         && (p.name.starts_with('@')
                             || p.name.starts_with('%')
@@ -302,6 +311,56 @@ impl Interpreter {
                         self.type_hierarchy_distance_with_var_type(base, &arg, var_type.as_deref());
                 }
             } else {
+                // An unconstrained `@`/`%` param carries an implicit
+                // Positional/Associative constraint: it must out-narrow a `Mu`
+                // candidate for a Positional/Associative argument
+                // (JSON::Unmarshal's `_unmarshal($json, @x)` vs `($json, Mu)`
+                // dispatching a `Positional[Dog]` attribute type).
+                if !pd.named && !pd.slurpy && (pd.name.starts_with('@') || pd.name.starts_with('%'))
+                {
+                    while pos_idx < args.len()
+                        && matches!(args[pos_idx].view(), ValueView::Pair(..))
+                    {
+                        pos_idx += 1;
+                    }
+                    if pos_idx < args.len() {
+                        let (arg, var_type) = self.unwrap_varref_for_dispatch(&args[pos_idx]);
+                        pos_idx += 1;
+                        let implicit = if pd.name.starts_with('@') {
+                            "Positional"
+                        } else {
+                            "Associative"
+                        };
+                        total += self.type_hierarchy_distance_with_var_type(
+                            implicit,
+                            &arg,
+                            var_type.as_deref(),
+                        );
+                        continue;
+                    }
+                }
+                // An unconstrained positional `$`-param is an implicit `Any`
+                // constraint (raku): rank it at the Any distance instead of a
+                // flat 1000, so `($j, @x)` can out-narrow `(Any:D $j, Mu)` on
+                // the SECOND param (JSON::Unmarshal's `_unmarshal($json, @x)`
+                // vs its `(Any:D $json, Mu)` fallback).
+                if !pd.named && !pd.slurpy && !pd.name.starts_with('&') {
+                    while pos_idx < args.len()
+                        && matches!(args[pos_idx].view(), ValueView::Pair(..))
+                    {
+                        pos_idx += 1;
+                    }
+                    if pos_idx < args.len() {
+                        let (arg, var_type) = self.unwrap_varref_for_dispatch(&args[pos_idx]);
+                        pos_idx += 1;
+                        total += self.type_hierarchy_distance_with_var_type(
+                            "Any",
+                            &arg,
+                            var_type.as_deref(),
+                        );
+                        continue;
+                    }
+                }
                 total += 1000;
                 if !pd.named {
                     pos_idx += 1;
@@ -374,17 +433,26 @@ impl Interpreter {
             if base == cn.as_str() {
                 return 0;
             }
-            if let Some(class_def) = self.registry().classes.get(cn.as_str()) {
-                for (i, ancestor) in class_def.mro.iter().enumerate() {
-                    if ancestor == base {
-                        return i;
+            // A parametric type object (`Positional[Dog]`) ranks by its base
+            // name: distance 0 to a `Positional` constraint (JSON::Unmarshal's
+            // `_unmarshal($json, @x)` receiving an attribute type).
+            let cn_base = cn.split('[').next().unwrap_or(cn.as_str());
+            if base == cn_base {
+                return 0;
+            }
+            for lookup in [cn.as_str(), cn_base] {
+                if let Some(class_def) = self.registry().classes.get(lookup) {
+                    for (i, ancestor) in class_def.mro.iter().enumerate() {
+                        if ancestor == base {
+                            return i;
+                        }
                     }
                 }
-            }
-            if let Some(roles) = self.registry().class_composed_roles.get(cn.as_str())
-                && roles.iter().any(|r| r == base)
-            {
-                return 1;
+                if let Some(roles) = self.registry().class_composed_roles.get(lookup)
+                    && roles.iter().any(|r| r == base)
+                {
+                    return 1;
+                }
             }
         }
         // Built-in type hierarchy (approximation of Raku MRO depths)

--- a/src/runtime/dispatch_candidates.rs
+++ b/src/runtime/dispatch_candidates.rs
@@ -441,11 +441,14 @@ impl Interpreter {
                 return 0;
             }
             for lookup in [cn.as_str(), cn_base] {
-                if let Some(class_def) = self.registry().classes.get(lookup) {
-                    for (i, ancestor) in class_def.mro.iter().enumerate() {
-                        if ancestor == base {
-                            return i;
-                        }
+                // `mro_readonly` walks the parent chain live — the registry's
+                // `ClassDef.mro` field is not populated for every class, which
+                // made `d(C1, Package(C2))` fall through to the 500 fallback
+                // (S14 parameter-subtyping: `(C1 @arr)` lost to a bare
+                // `(@arr)` once the bare sigil got a real implicit distance).
+                for (i, ancestor) in self.mro_readonly(lookup).iter().enumerate() {
+                    if ancestor == base {
+                        return i;
                     }
                 }
                 if let Some(roles) = self.registry().class_composed_roles.get(lookup)

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -3267,19 +3267,30 @@ impl Interpreter {
             return self.dispatch_classhow_method(method, how_args);
         }
 
-        // Archetypes.composable
+        // Archetypes flag accessors (composable/nominal/nominalizable/coercive/...)
         if let ValueView::Instance {
             class_name,
             attributes,
             ..
         } = target.view()
             && class_name == "Perl6::Metamodel::Archetypes"
-            && method == "composable"
+            && matches!(
+                method,
+                "composable"
+                    | "nominal"
+                    | "nominalizable"
+                    | "coercive"
+                    | "generic"
+                    | "parametric"
+                    | "inheritable"
+                    | "inheritalizable"
+                    | "definite"
+            )
             && args.is_empty()
         {
             return Ok(attributes
                 .as_map()
-                .get("composable")
+                .get(method)
                 .cloned()
                 .unwrap_or(Value::FALSE));
         }

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -258,11 +258,25 @@ impl Interpreter {
                     .split_once('[')
                     .map(|(base, _)| base)
                     .unwrap_or(invocant_name.as_str());
+                let is_role = self.registry().roles.contains_key(base_name);
+                let is_subset = self.registry().subsets.contains_key(base_name);
+                // A coercion type (`Str(Int)`) carries parens in its name.
+                let is_coercive = base_name.contains('(') || invocant_name.contains('(');
                 let mut attrs = HashMap::new();
+                attrs.insert("composable".to_string(), Value::truth(is_role));
+                // Classes, enums, and roles are nominal; subsets and coercion
+                // types are not (JSON::Unmarshal's ClassLike subset — rakudo
+                // reports roles as nominal too).
                 attrs.insert(
-                    "composable".to_string(),
-                    Value::truth(self.registry().roles.contains_key(base_name)),
+                    "nominal".to_string(),
+                    Value::truth(!is_subset && !is_coercive),
                 );
+                // Subsets and coercion types can be nominalized (^nominalize).
+                attrs.insert(
+                    "nominalizable".to_string(),
+                    Value::truth(is_subset || is_coercive),
+                );
+                attrs.insert("coercive".to_string(), Value::truth(is_coercive));
                 Ok(Value::make_instance(
                     Symbol::intern("Perl6::Metamodel::Archetypes"),
                     attrs,

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -251,6 +251,19 @@ impl Interpreter {
             && args.is_empty()
             && (target_var.starts_with('@') || target_var.starts_with('%'))
         {
+            // An `@`/`%` param bound to a parametric TYPE OBJECT
+            // (`sub g(@x) { @x.of }` called with `Positional[Dog]` — the
+            // JSON::Unmarshal attribute-type shape) reads the element type
+            // from the parametric name itself.
+            if let ValueView::Package(name) = target.view() {
+                let n = name.resolve();
+                if let Some(inner) = n
+                    .split_once('[')
+                    .and_then(|(_, rest)| rest.strip_suffix(']'))
+                {
+                    return Ok(Value::package(Symbol::intern(inner)));
+                }
+            }
             let type_name = self
                 .var_type_constraint(target_var)
                 .or_else(|| {
@@ -269,6 +282,32 @@ impl Interpreter {
             // Update the variable in the environment to reflect the mutation
             self.env.insert(target_var.to_string(), result.clone());
             return Ok(result);
+        }
+
+        // SetHash.set(*@keys) / SetHash.unset(*@keys) — add/remove keys in
+        // place (JSON::Unmarshal's `$used-json-keys.set($json-name)`).
+        if matches!(method, "set" | "unset")
+            && let ValueView::Set(data, true) = target.view()
+        {
+            let mut elements = data.elements.clone();
+            for arg in &args {
+                let keys: Vec<Value> = match arg.view() {
+                    ValueView::Array(items, _) => items.to_vec(),
+                    ValueView::Seq(items) | ValueView::Slip(items) => items.to_vec(),
+                    _ => vec![arg.clone()],
+                };
+                for key in keys {
+                    let k = key.to_string_value();
+                    if method == "set" {
+                        elements.insert(k);
+                    } else {
+                        elements.remove(&k);
+                    }
+                }
+            }
+            self.env
+                .insert(target_var.to_string(), Value::set_hash(elements));
+            return Ok(Value::NIL);
         }
 
         if let ValueView::Instance {

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -97,6 +97,19 @@ impl Interpreter {
             | ValueView::GenericRange { .. }
             | ValueView::Uni { .. }
             | ValueView::Nil => true,
+            // A Positional TYPE OBJECT binds too (`my @x := Positional[Dog]`,
+            // JSON::Unmarshal's attribute-type flow): raku accepts it and
+            // `.of` reads the parametric element type.
+            ValueView::Package(name) => {
+                let n = name.resolve();
+                let base = n.split('[').next().unwrap_or(&n);
+                matches!(
+                    base,
+                    "Positional" | "Array" | "List" | "Seq" | "Slip" | "Range" | "Buf" | "Blob"
+                ) || self
+                    .class_composed_roles(base)
+                    .is_some_and(|roles| roles.iter().any(|r| r == "Positional"))
+            }
             // Instance objects are Positional only if they implement
             // the Positional role (or Array subclass etc.), but not
             // Failure or arbitrary classes.

--- a/t/multi-dispatch-mu-rank.t
+++ b/t/multi-dispatch-mu-rank.t
@@ -1,0 +1,17 @@
+use v6;
+use Test;
+
+plan 2;
+
+# A bare `Mu`/`Any` constraint is no narrower than an unconstrained param;
+# it must not make a candidate outrank one with a genuinely narrow param
+# (JSON::Unmarshal's `($json, @x)` vs its `(Any:D $json, Mu)` fallback).
+class Dog {}
+
+multi f($j, @x) { "pos" }
+multi f(Any:D $j, Mu) { "mu" }
+
+my @a = (1,);
+is f(@a, Positional[Dog]), 'pos', 'the @-param candidate wins for a Positional arg';
+is f(1, 2), 'mu', 'non-Positional second arg reaches the fallback';
+

--- a/t/unmarshal-mop-support.t
+++ b/t/unmarshal-mop-support.t
@@ -1,0 +1,38 @@
+use v6;
+use Test;
+
+plan 10;
+
+# The MOP surface JSON::Unmarshal's ClassLike subset needs.
+class Dog { has Str $.name }
+
+ok Dog.HOW.archetypes.nominal, 'a class archetype is nominal';
+nok Dog.HOW.archetypes.nominalizable, 'a class is not nominalizable';
+role R {}
+ok R.HOW.archetypes.composable, 'a role archetype is composable';
+subset S of Str where { .chars > 1 };
+ok S.HOW.archetypes.nominalizable, 'a subset is nominalizable';
+nok S.HOW.archetypes.nominal, 'a subset is not nominal';
+
+# SetHash.set / .unset mutate in place.
+my SetHash $used .= new;
+$used.set('a');
+$used.set('b');
+ok $used<a> && $used<b>, 'SetHash.set adds keys';
+$used.unset('a');
+nok $used<a>, 'SetHash.unset removes a key';
+
+# Binding a Positional type object to an @-var keeps .of.
+my @x := Positional[Dog];
+is @x.of.^name, 'Dog', '@-bound Positional[T] exposes .of';
+
+# ... and through an @-sigiled parameter.
+sub g(@p) { @p.of.^name }
+is g(Positional[Dog]), 'Dog', '@-param bound to Positional[T] exposes .of';
+
+# The whole unmarshal-like flow: a nested typed collection dispatch.
+multi um($j, @x) { "els-" ~ @x.of.^name }
+multi um(Any:D $j, Mu) { "fallback" }
+my @vals = ({ n => 1 },);
+is um(@vals, Positional[Dog]), 'els-Dog',
+    'the @-candidate out-narrows the Any:D+Mu fallback';


### PR DESCRIPTION
## Summary

JSON::Unmarshal's `unmarshal($json, Person)` returned a bare Hash (the Test::META chain's isa-ok Person failure). Five general gaps, each raku-verified:

1. **`HOW.archetypes`** now carries `nominal`/`nominalizable`/`coercive` (classes, enums, and roles are nominal — rakudo reports roles nominal too; subsets and coercion types are nominalizable), and the Archetypes instance answers all flag accessors. This makes `subset ClassLike of Mu where { .HOW.archetypes.nominal && ... }` work.
2. **`SetHash.set(*@keys)` / `.unset(*@keys)`** mutate in place.
3. **`my @x := Positional[Dog]`** binds — a Positional type object is a valid `:=` target for an `@`-var, and `@x.of` reads the parametric element type (bound var and `@`-sigiled param both).
4. **Multi-dispatch narrowness** (three related fixes): a bare `Mu`/`Any` constraint no longer counts as a "typed param" in the specificity rank (`(Any:D $j, Mu)` wholesale outranked `($j, @x)`); unconstrained positional params rank at their implicit constraint's distance (`$`→Any, `@`→Positional, `%`→Associative) instead of a flat 1000; a parametric type-object argument (`Positional[Dog]`) measures distance by its base name.

With these, unmarshal builds real nested objects: `Person` with `has Dog @.dogs` / `has Str %.contact` round-trips. JSON-Unmarshal-0.18: 010-basic 24/25; 020-any/030-null/050-json-name/100-issue-7 fully green (remaining failures are separate features — block-`return` through a called closure, named-args error modes).

## Test plan

- [x] New pins `t/unmarshal-mop-support.t`, `t/multi-dispatch-mu-rank.t` green on raku and mutsu (raku-ambiguous cases excluded)
- [x] `make test` PASS
- [x] Roast subset S02-types + S03 + S06 + S12 + S32 (dispatch-heavy, 700+ files) via `scripts/run-roast-test.sh`: PASS
- [x] clippy `-D warnings` + fmt clean
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)