### PR TITLE
feat: RakuAST Phase 2 slice 16 — role declarations

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -790,10 +790,12 @@ so it is tracked separately from the roast backlog.
         deferred.)
   - [x] Slice 15: method-call modifiers `.?`/`.+`/`.*` (`Call::Method` gains a `dispatch` field).
         Tests in `t/rakuast-method-modifier.t`.
-  - [ ] Slice 16+: roles/grammars, labelled loops, parameterised/definite types
-        (`Array[Int]`/`Int:D`), attribute defaults (`Trait::WillBuild`), quoted method names; then
-        `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`,
-        mutsu does not).
+  - [x] Slice 16: role declarations (`RakuAST::Role` with a distinct `RoleBody`). Tests in
+        `t/rakuast-role.t`. (Grammars are `ClassDecl`+`parents=["Grammar"]` in mutsu — no distinct
+        node — so they defer.)
+  - [ ] Slice 17+: labelled loops, parameterised/definite types (`Array[Int]`/`Int:D`), attribute
+        defaults (`Trait::WillBuild`), quoted method names, given/when; then `.DEPARSE`; resolve the
+        constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -211,7 +211,14 @@ earlier ones.
   (parameters carry the implicit `type => Type::Setting(Any)`). Boundary (explicit `RuntimeError`):
   inheritance (`is`/`does`), `my`/`unit` scope, `repr`, `rw`, class traits; and for methods,
   private/submethod/multi/`our`/`my` forms, traits, delegation (`handles`), and return types.
-  Roles/grammars (`RakuAST::Role` with a distinct `RoleBody`) are deferred.
+  Roles are handled (slice 16). **Grammars are NOT mappable**: mutsu models `grammar G { }` as a
+  `Stmt::ClassDecl` with `parents = ["Grammar"]` (no distinct grammar node), so it hits the class
+  inheritance boundary rather than producing `RakuAST::Grammar`; deferred.
+- **Role declarations (Phase 2 slice 16).** `role NAME { body }` (`Stmt::RoleDecl`) →
+  `Statement::Expression(Role(name => Name, body => RoleBody(body => Blockoid(StatementList))))`.
+  Unlike a class, the body is wrapped in a distinct `RoleBody` node (not a plain `Block`); its
+  statements convert recursively (methods → `Method`, etc.). Boundary (explicit `RuntimeError`):
+  parameterised roles (`role R[::T]`), `is export`, `is rw`, and traits.
 - **Attributes (Phase 2 slice 14).** `has [Type] $.x` (`Stmt::HasDecl`) → a `VarDeclaration::Simple`
   with `scope => "has"` and a `twigil` leaf (`.` public accessor / `!` private), reusing the slice-10
   `var_declaration` helper (extended with a `twigil` field, and its initializer arg generalised to

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -392,6 +392,39 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 ],
             })))
         }
+        Stmt::RoleDecl {
+            name,
+            type_params,
+            is_export,
+            export_tags,
+            body,
+            is_rw,
+            custom_traits,
+            ..
+        } => {
+            // Plain `role NAME { body }`. Parameterised roles (`role R[::T]`),
+            // export, `rw`, and traits carry extra RakuAST shape, deferred. The
+            // role body is a `RoleBody` (not a plain `Block`).
+            if !type_params.is_empty()
+                || *is_export
+                || !export_tags.is_empty()
+                || *is_rw
+                || !custom_traits.is_empty()
+            {
+                return Err(unsupported("role with type params / export / traits"));
+            }
+            let role_body = RakuAstNode {
+                class: RakuAstClass::RoleBody,
+                fields: vec![node_field(Some("body"), blockoid(body)?)],
+            };
+            Ok(Some(statement_expression(RakuAstNode {
+                class: RakuAstClass::Role,
+                fields: vec![
+                    node_field(Some("name"), name_from_identifier(&name.resolve())),
+                    node_field(Some("body"), role_body),
+                ],
+            })))
+        }
         Stmt::HasDecl {
             name,
             is_public,

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -94,6 +94,9 @@ pub enum RakuAstClass {
     // Phase 2 slice 13: class and method declarations.
     Class,
     Method,
+    // Phase 2 slice 16: role declarations.
+    Role,
+    RoleBody,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -146,6 +149,8 @@ impl RakuAstClass {
             TypeSimple => "RakuAST::Type::Simple",
             Class => "RakuAST::Class",
             Method => "RakuAST::Method",
+            Role => "RakuAST::Role",
+            RoleBody => "RakuAST::RoleBody",
         }
     }
 

--- a/t/rakuast-role.t
+++ b/t/rakuast-role.t
@@ -1,0 +1,38 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 16 (ADR-0011): role declarations.
+# `role NAME { body }` -> RakuAST::Role(name, body => RoleBody(body => Blockoid)).
+# Unlike a class, the body is wrapped in a RoleBody (not a plain Block).
+# Expected gists captured verbatim from Rakudo; this file passes under BOTH
+# mutsu and raku. Distinct role names are used because `.AST` registers the
+# symbol.
+
+plan 3;
+
+# --- empty role -------------------------------------------------------------
+is Q[role R1 { }].AST.gist, q:to/END/.chomp, 'role -> Role(name, body => RoleBody)';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Role.new(
+          name => RakuAST::Name.from-identifier("R1"),
+          body => RakuAST::RoleBody.new(
+            body => RakuAST::Blockoid.new(
+              RakuAST::StatementList.new()
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- role with a method -----------------------------------------------------
+my $g = Q[role R2 { method m { 1 } }].AST.gist;
+ok $g.contains('expression => RakuAST::Role.new(')
+    && $g.contains('body => RakuAST::RoleBody.new(')
+    && $g.contains('expression => RakuAST::Method.new('),
+    'method in role body -> Method inside a RoleBody';
+
+# --- a role body is a RoleBody, not a Block ---------------------------------
+is Q[role R3 { }].AST.gist.contains('RakuAST::RoleBody.new('), True,
+    'role body node is RoleBody';


### PR DESCRIPTION
## Summary

Phase 2 slice 16 of RakuAST (ADR-0011): `role NAME { body }` (`Stmt::RoleDecl`) maps to `Statement::Expression(Role(name => Name, body => RoleBody(body => Blockoid(StatementList))))`.

```
role R { method m { 1 } }
  -> Role(name => Name("R"),
          body => RoleBody(body => Blockoid(StatementList(
                    Statement::Expression(Method(name => Name("m"), body => Blockoid(...)))))))
```

Unlike a class, the body is wrapped in a distinct **`RoleBody`** node (not a plain `Block`); its statements convert recursively (methods → `Method`, etc.).

## Coverage boundary (explicit `RuntimeError`)

Parameterised roles (`role R[::T]`), `is export`, `is rw`, and traits.

## Grammars are not mappable

mutsu models `grammar G { }` as a `Stmt::ClassDecl` with `parents = ["Grammar"]` (no distinct grammar node), so it hits the class-inheritance boundary rather than producing `RakuAST::Grammar` — a documented divergence, deferred.

## Tests

`t/rakuast-role.t` — 3 assertions (empty role, method in role body, RoleBody vs Block), **passing under BOTH mutsu and raku** (distinct role names per test since `.AST` registers the symbol). All existing `t/rakuast-*.t` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)