### PR TITLE
feat: RakuAST Phase 2 slice 17 — loop labels

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -793,9 +793,13 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 16: role declarations (`RakuAST::Role` with a distinct `RoleBody`). Tests in
         `t/rakuast-role.t`. (Grammars are `ClassDecl`+`parents=["Grammar"]` in mutsu — no distinct
         node — so they defer.)
-  - [ ] Slice 17+: labelled loops, parameterised/definite types (`Array[Int]`/`Int:D`), attribute
-        defaults (`Trait::WillBuild`), quoted method names, given/when; then `.DEPARSE`; resolve the
-        constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu does not).
+  - [x] Slice 17: loop labels (`LABEL: while/for/loop` → `labels => (Label(...),)`). Tests in
+        `t/rakuast-loop-label.t`. (Labelled `repeat`/C-style loops use a separate `Stmt::Label`
+        node, deferred.)
+  - [ ] Slice 18+: given/when, parameterised/definite types (`Array[Int]`/`Int:D`), attribute
+        defaults (`Trait::WillBuild`), quoted method names, `Stmt::Label`-wrapped loops; then
+        `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`,
+        mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -176,7 +176,11 @@ earlier ones.
   `Statement::Loop::RepeatWhile(body, condition)`, with `repeat ... until X` folding to
   `RepeatWhile` + negated condition (same collapse as `until`/`while`). Labelled loops and topic
   binding (`if EXPR -> $v` / `elsif EXPR -> $v`) remain the coverage boundary (explicit
-  `RuntimeError`), deferred to a later slice. Implicit-topic `for`
+  `RuntimeError`), deferred to a later slice. Loop labels are handled (slice 17): a
+  `LABEL: while/for/loop` prepends a `labels => (Label(name => "..."),)` field (raku renders labels
+  first). mutsu stores the label inline on `while`/`for`/bare-`loop`, but wraps a labelled `repeat`
+  (and C-style `loop`) in a separate `Stmt::Label` node it does not yet convert (C-style-labelled
+  does not even parse), so those remain the boundary. Implicit-topic `for`
   is handled (slice 6): `for SRC { ... }` (no explicit signature) → `Statement::For(mode =>
   "serial", source, body)` where the body is a topic-taking `Block` marked `implicit-topic => True`
   / `required-topic => 1`. `with`/`without` are NOT mappable — mutsu desugars them at parse time

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -150,15 +150,12 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
         }
         Stmt::While { cond, body, label } => {
             // mutsu desugars `until X` to `while !X` (same as unless/if above).
-            if label.is_some() {
-                return Err(unsupported("loop label"));
-            }
+            let mut fields = label_fields(label);
+            fields.push(node_field(Some("condition"), convert_expr(cond)?));
+            fields.push(node_field(Some("body"), block_node(body)?));
             Ok(Some(RakuAstNode {
                 class: RakuAstClass::StatementLoopWhile,
-                fields: vec![
-                    node_field(Some("condition"), convert_expr(cond)?),
-                    node_field(Some("body"), block_node(body)?),
-                ],
+                fields,
             }))
         }
         Stmt::Loop {
@@ -169,9 +166,6 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             repeat,
             label,
         } => {
-            if label.is_some() {
-                return Err(unsupported("labelled loop"));
-            }
             if *repeat {
                 // `repeat { } while X`. mutsu desugars `repeat { } until X` to a
                 // negated `while` condition (same collapse as while/until), so
@@ -179,24 +173,26 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 let cond = cond
                     .as_ref()
                     .ok_or_else(|| unsupported("repeat loop without condition"))?;
+                let mut fields = label_fields(label);
+                fields.push(node_field(Some("body"), block_node(body)?));
+                fields.push(node_field(Some("condition"), convert_expr(cond)?));
                 return Ok(Some(RakuAstNode {
                     class: RakuAstClass::StatementLoopRepeatWhile,
-                    fields: vec![
-                        node_field(Some("body"), block_node(body)?),
-                        node_field(Some("condition"), convert_expr(cond)?),
-                    ],
+                    fields,
                 }));
             }
             if init.is_none() && cond.is_none() && step.is_none() {
                 // Bare `loop { }`.
+                let mut fields = label_fields(label);
+                fields.push(node_field(Some("body"), block_node(body)?));
                 return Ok(Some(RakuAstNode {
                     class: RakuAstClass::StatementLoop,
-                    fields: vec![node_field(Some("body"), block_node(body)?)],
+                    fields,
                 }));
             }
             // C-style `loop (init; cond; step) { }`. Each clause is optional and
             // present only when written.
-            let mut fields = Vec::new();
+            let mut fields = label_fields(label);
             if let Some(init) = init.as_deref() {
                 fields.push(node_field(Some("setup"), loop_setup_node(init)?));
             }
@@ -230,12 +226,8 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             // The explicit param names live in `param_def` / `params_def`; the
             // sigil-stripped `param` / `params` string lists are unused here.
             let _ = (param, params);
-            if label.is_some()
-                || *rw_block
-                || *explicit_zero_params
-                || !matches!(mode, ForMode::Normal)
-            {
-                return Err(unsupported("for loop with mode / rw / label"));
+            if *rw_block || *explicit_zero_params || !matches!(mode, ForMode::Normal) {
+                return Err(unsupported("for loop with mode / rw"));
             }
             // A single explicit param lives in `param_def`, multiple in
             // `params_def`. With none, the body is an implicit-topic Block; with
@@ -250,13 +242,14 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             } else {
                 pointy_block(explicit_defs, body)?
             };
+            // Field order matches raku: labels, mode, source, body.
+            let mut fields = label_fields(label);
+            fields.push(leaf_field(Some("mode"), Value::str("serial".to_string())));
+            fields.push(node_field(Some("source"), convert_expr(iterable)?));
+            fields.push(node_field(Some("body"), body_node));
             Ok(Some(RakuAstNode {
                 class: RakuAstClass::StatementFor,
-                fields: vec![
-                    leaf_field(Some("mode"), Value::str("serial".to_string())),
-                    node_field(Some("source"), convert_expr(iterable)?),
-                    node_field(Some("body"), body_node),
-                ],
+                fields,
             }))
         }
         Stmt::SubDecl {
@@ -799,6 +792,24 @@ fn block_node(body: &[Stmt]) -> Result<RakuAstNode, RuntimeError> {
         class: RakuAstClass::Block,
         fields: vec![node_field(Some("body"), blockoid(body)?)],
     })
+}
+
+/// The leading `labels => (Label(name => "..."),)` field for a labelled loop,
+/// or an empty vec when unlabelled. raku always renders labels first.
+fn label_fields(label: &Option<String>) -> Vec<RakuAstField> {
+    match label {
+        None => Vec::new(),
+        Some(name) => {
+            let label_node = RakuAstNode {
+                class: RakuAstClass::Label,
+                fields: vec![leaf_field(Some("name"), Value::str(name.clone()))],
+            };
+            vec![RakuAstField {
+                name: Some("labels"),
+                value: RakuAstFieldValue::List(vec![Value::rakuast(Box::new(label_node))]),
+            }]
+        }
+    }
 }
 
 /// A C-style loop `setup` clause renders its node unwrapped — raku shows the

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -97,6 +97,8 @@ pub enum RakuAstClass {
     // Phase 2 slice 16: role declarations.
     Role,
     RoleBody,
+    // Phase 2 slice 17: loop labels.
+    Label,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -151,6 +153,7 @@ impl RakuAstClass {
             Method => "RakuAST::Method",
             Role => "RakuAST::Role",
             RoleBody => "RakuAST::RoleBody",
+            Label => "RakuAST::Label",
         }
     }
 

--- a/t/rakuast-loop-label.t
+++ b/t/rakuast-loop-label.t
@@ -1,0 +1,49 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 17 (ADR-0011): loop labels.
+# A `LABEL: while/for/loop` prepends a `labels => (Label(name => "..."),)`
+# field. Expected gists captured verbatim from Rakudo; this file passes under
+# BOTH mutsu and raku.
+#
+# Note: mutsu stores the label inline on `while`/`for`/bare-`loop`, but wraps a
+# labelled `repeat` (and C-style `loop`) in a separate `Stmt::Label` node it
+# does not yet parse/convert, so those remain the coverage boundary.
+
+plan 3;
+
+# --- labelled while ---------------------------------------------------------
+is Q[LABEL: while 1 { 2 }].AST.gist, q:to/END/.chomp, 'labelled while -> labels first';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Loop::While.new(
+        labels    => (
+          RakuAST::Label.new(
+            name => "LABEL"
+          ),
+        ),
+        condition => RakuAST::IntLiteral.new(1),
+        body      => RakuAST::Block.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::IntLiteral.new(2)
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- labelled for: labels before mode ---------------------------------------
+my $for = Q[my @a; LOOP: for @a { 1 }].AST.gist;
+ok $for.contains('RakuAST::Statement::For.new(')
+    && $for.contains('labels => (')
+    && $for.contains('RakuAST::Label.new(')
+    && $for.contains('name => "LOOP"')
+    && $for.index('labels') < $for.index('mode'),
+    'labelled for -> labels before mode';
+
+# --- labelled bare loop -----------------------------------------------------
+is Q[L: loop { 1 }].AST.gist.contains('name => "L"'), True,
+    'labelled bare loop carries its Label';


### PR DESCRIPTION
## Summary

Phase 2 slice 17 of RakuAST (ADR-0011): loop labels. A `LABEL: while/for/loop` now prepends a `labels => (RakuAST::Label.new(name => "LABEL"),)` field (raku renders labels first), instead of hitting the coverage boundary.

```
LABEL: while 1 { 2 }
  -> Statement::Loop::While(labels => (Label(name => "LABEL"),), condition => ..., body => ...)
LOOP: for @a { 1 }
  -> Statement::For(labels => (...), mode => "serial", source => ..., body => ...)
```

## Coverage boundary

mutsu stores the label inline on `while` / `for` / bare-`loop` (`label: Option<String>`), so those convert cleanly. A labelled `repeat` (and C-style `loop`) is wrapped in a separate `Stmt::Label` node mutsu does not yet convert (C-style-labelled does not even parse), so those remain the boundary.

## Tests

`t/rakuast-loop-label.t` — 3 assertions (labelled while full gist, labelled for with labels-before-mode ordering, labelled bare loop), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green (unlabelled loops unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)