### PR TITLE
feat: RakuAST Phase 2 slice 18 — given / when / default

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -796,10 +796,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 17: loop labels (`LABEL: while/for/loop` → `labels => (Label(...),)`). Tests in
         `t/rakuast-loop-label.t`. (Labelled `repeat`/C-style loops use a separate `Stmt::Label`
         node, deferred.)
-  - [ ] Slice 18+: given/when, parameterised/definite types (`Array[Int]`/`Int:D`), attribute
-        defaults (`Trait::WillBuild`), quoted method names, `Stmt::Label`-wrapped loops; then
-        `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`,
-        mutsu does not).
+  - [x] Slice 18: given / when / default (`Statement::Given`/`When`/`Default`). Tests in
+        `t/rakuast-given-when.t`.
+  - [ ] Slice 19+: parameterised/definite types (`Array[Int]`/`Int:D`), attribute defaults
+        (`Trait::WillBuild`), quoted method names, `Stmt::Label`-wrapped loops, ternary/`andthen`;
+        then `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to
+        `IntLiteral(3)`, mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -232,6 +232,11 @@ earlier ones.
   `Trait::WillBuild` in raku (not an `initializer`), so it is deferred, along with `is rw`, type
   smileys (`:D`), `is required`, `where`, aliases (`has $x`), `my`/`our` attributes, delegation, and
   other traits.
+- **given / when / default (Phase 2 slice 18).** `given X { ... }` (`Stmt::Given`) →
+  `Statement::Given(source, body => topic Block)` (the given body is a topic-taking `Block`, marked
+  `implicit-topic`/`required-topic`). `when Y { ... }` (`Stmt::When`) → `Statement::When(condition,
+  body => plain Block)`; `default { ... }` (`Stmt::Default`) → `Statement::Default(body => plain
+  Block)`. All reuse the existing `topic_block_node`/`block_node` helpers.
 - **Method-call modifiers (Phase 2 slice 15).** `$x.?foo` / `$x.+foo` / `$x.*foo` (`Expr::MethodCall`
   with a `modifier: Option<char>`) add a `dispatch => ".?"` / `".+"` / `".*"` leaf to the
   `Call::Method`, after `name` and any `args`. A quoted method name (`."$n"()`) remains the boundary.

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -252,6 +252,27 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 fields,
             }))
         }
+        // `given X { ... }` -> Statement::Given(source, body => topic Block).
+        Stmt::Given { topic, body } => Ok(Some(RakuAstNode {
+            class: RakuAstClass::StatementGiven,
+            fields: vec![
+                node_field(Some("source"), convert_expr(topic)?),
+                node_field(Some("body"), topic_block_node(body)?),
+            ],
+        })),
+        // `when Y { ... }` -> Statement::When(condition, body => plain Block).
+        Stmt::When { cond, body } => Ok(Some(RakuAstNode {
+            class: RakuAstClass::StatementWhen,
+            fields: vec![
+                node_field(Some("condition"), convert_expr(cond)?),
+                node_field(Some("body"), block_node(body)?),
+            ],
+        })),
+        // `default { ... }` -> Statement::Default(body => plain Block).
+        Stmt::Default(body) => Ok(Some(RakuAstNode {
+            class: RakuAstClass::StatementDefault,
+            fields: vec![node_field(Some("body"), block_node(body)?)],
+        })),
         Stmt::SubDecl {
             name,
             name_expr,

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -99,6 +99,10 @@ pub enum RakuAstClass {
     RoleBody,
     // Phase 2 slice 17: loop labels.
     Label,
+    // Phase 2 slice 18: given/when/default.
+    StatementGiven,
+    StatementWhen,
+    StatementDefault,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -154,6 +158,9 @@ impl RakuAstClass {
             Role => "RakuAST::Role",
             RoleBody => "RakuAST::RoleBody",
             Label => "RakuAST::Label",
+            StatementGiven => "RakuAST::Statement::Given",
+            StatementWhen => "RakuAST::Statement::When",
+            StatementDefault => "RakuAST::Statement::Default",
         }
     }
 

--- a/t/rakuast-given-when.t
+++ b/t/rakuast-given-when.t
@@ -1,0 +1,54 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 18 (ADR-0011): given / when / default.
+# `given X { when Y { } default { } }` -> Statement::Given(source, topic Block)
+# containing Statement::When(condition, Block) and Statement::Default(Block).
+# Expected gists captured verbatim from Rakudo; this file passes under BOTH
+# mutsu and raku.
+
+plan 4;
+
+# --- given + when -----------------------------------------------------------
+is Q[given 1 { when 2 { 3 } }].AST.gist, q:to/END/.chomp, 'given/when -> Given(source, topic Block) + When';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Given.new(
+        source => RakuAST::IntLiteral.new(1),
+        body   => RakuAST::Block.new(
+          implicit-topic => True,
+          required-topic => 1,
+          body           => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::When.new(
+                condition => RakuAST::IntLiteral.new(2),
+                body      => RakuAST::Block.new(
+                  body => RakuAST::Blockoid.new(
+                    RakuAST::StatementList.new(
+                      RakuAST::Statement::Expression.new(
+                        expression => RakuAST::IntLiteral.new(3)
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- given topic Block is topic-marked --------------------------------------
+is Q[given 1 { when 2 { 3 } }].AST.gist.contains('implicit-topic => True'), True,
+    'given body is a topic-taking Block';
+
+# --- default clause ---------------------------------------------------------
+is Q[given 1 { default { 4 } }].AST.gist.contains('RakuAST::Statement::Default.new('), True,
+    'default -> Statement::Default';
+
+# --- a `when` body is a plain Block (not topic-marked) ----------------------
+my $g = Q[given 1 { when 2 { 3 } }].AST.gist;
+ok $g.contains('RakuAST::Statement::When.new(')
+    && $g.contains('condition => RakuAST::IntLiteral.new(2)')
+    && $g.index('RakuAST::Statement::When') < $g.index('IntLiteral.new(3)'),
+    'when -> Statement::When(condition, body)';


### PR DESCRIPTION
## Summary

Phase 2 slice 18 of RakuAST (ADR-0011): the topicalizer control statements.

- **`given X { ... }`** (`Stmt::Given`) → `Statement::Given(source, body => topic Block)` — the given body is a topic-taking `Block` (marked `implicit-topic` / `required-topic`).
- **`when Y { ... }`** (`Stmt::When`) → `Statement::When(condition, body => plain Block)`.
- **`default { ... }`** (`Stmt::Default`) → `Statement::Default(body => plain Block)`.

```
given 1 { when 2 { 3 } default { 4 } }
  -> Statement::Given(source => IntLiteral(1),
       body => Block(implicit-topic => True, required-topic => 1, body => Blockoid(StatementList(
         Statement::When(condition => IntLiteral(2), body => Block(...)),
         Statement::Default(body => Block(...))))))
```

All three reuse the existing `topic_block_node` / `block_node` helpers.

## Tests

`t/rakuast-given-when.t` — 4 assertions (given/when full gist, given body topic-marked, default clause, when condition), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)