### PR TITLE
feat: RakuAST Phase 2 slice 19 — ternary ?? !!

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -798,10 +798,11 @@ so it is tracked separately from the roast backlog.
         node, deferred.)
   - [x] Slice 18: given / when / default (`Statement::Given`/`When`/`Default`). Tests in
         `t/rakuast-given-when.t`.
-  - [ ] Slice 19+: parameterised/definite types (`Array[Int]`/`Int:D`), attribute defaults
-        (`Trait::WillBuild`), quoted method names, `Stmt::Label`-wrapped loops, ternary/`andthen`;
-        then `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to
-        `IntLiteral(3)`, mutsu does not).
+  - [x] Slice 19: the ternary `?? !!` operator (`RakuAST::Ternary`). Tests in `t/rakuast-ternary.t`.
+  - [ ] Slice 20+: parameterised/definite types (`Array[Int]`/`Int:D`), attribute defaults
+        (`Trait::WillBuild`), quoted method names, `Stmt::Label`-wrapped loops, `andthen`/`orelse`,
+        `.=` method-assign; then `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku
+        folds to `IntLiteral(3)`, mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -232,6 +232,10 @@ earlier ones.
   `Trait::WillBuild` in raku (not an `initializer`), so it is deferred, along with `is rw`, type
   smileys (`:D`), `is required`, `where`, aliases (`has $x`), `my`/`our` attributes, delegation, and
   other traits.
+- **Ternary `?? !!` (Phase 2 slice 19).** `COND ?? THEN !! ELSE` (`Expr::Ternary`) →
+  `Ternary(condition, then, else)`. raku constant-folds a literal-condition ternary (`1 ?? 2 !! 3`
+  → `IntLiteral(2)`) while mutsu does not — the same const-fold divergence tracked in Open questions;
+  a non-constant condition renders identically.
 - **given / when / default (Phase 2 slice 18).** `given X { ... }` (`Stmt::Given`) →
   `Statement::Given(source, body => topic Block)` (the given body is a topic-taking `Block`, marked
   `implicit-topic`/`required-topic`). `when Y { ... }` (`Stmt::When`) → `Statement::When(condition,

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -685,6 +685,21 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
                 node_field(Some("postfix"), postfix_node(op)),
             ],
         }),
+        // `COND ?? THEN !! ELSE` -> Ternary(condition, then, else). Note raku
+        // constant-folds a literal-condition ternary (`1 ?? 2 !! 3` -> IntLiteral(2));
+        // mutsu does not, a documented divergence (the const-fold open question).
+        Expr::Ternary {
+            cond,
+            then_expr,
+            else_expr,
+        } => Ok(RakuAstNode {
+            class: RakuAstClass::Ternary,
+            fields: vec![
+                node_field(Some("condition"), convert_expr(cond)?),
+                node_field(Some("then"), convert_expr(then_expr)?),
+                node_field(Some("else"), convert_expr(else_expr)?),
+            ],
+        }),
         Expr::MethodCall {
             target,
             name,

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -103,6 +103,8 @@ pub enum RakuAstClass {
     StatementGiven,
     StatementWhen,
     StatementDefault,
+    // Phase 2 slice 19: ternary.
+    Ternary,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -161,6 +163,7 @@ impl RakuAstClass {
             StatementGiven => "RakuAST::Statement::Given",
             StatementWhen => "RakuAST::Statement::When",
             StatementDefault => "RakuAST::Statement::Default",
+            Ternary => "RakuAST::Ternary",
         }
     }
 

--- a/t/rakuast-ternary.t
+++ b/t/rakuast-ternary.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 19 (ADR-0011): the ternary `?? !!` operator.
+# `COND ?? THEN !! ELSE` -> Ternary(condition, then, else). Expected gists
+# captured verbatim from Rakudo; this file passes under BOTH mutsu and raku.
+#
+# Note: raku constant-folds a literal-condition ternary (`1 ?? 2 !! 3` folds to
+# IntLiteral(2)); mutsu does not (a documented divergence, the const-fold open
+# question), so only non-constant conditions are pinned here.
+
+plan 2;
+
+# --- non-constant condition -------------------------------------------------
+is Q[my $x; $x ?? 2 !! 3].AST.gist, q:to/END/.chomp, 'ternary -> Ternary(condition, then, else)';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => "\$",
+          desigilname => RakuAST::Name.from-identifier("x")
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Ternary.new(
+          condition => RakuAST::Var::Lexical.new("\$x"),
+          then      => RakuAST::IntLiteral.new(2),
+          else      => RakuAST::IntLiteral.new(3)
+        )
+      )
+    )
+    END
+
+# --- branches can be arbitrary expressions ----------------------------------
+my $t = Q[my $a; my $b; $a ?? $b !! $a].AST.gist;
+ok $t.contains('RakuAST::Ternary.new(')
+    && $t.contains('condition => RakuAST::Var::Lexical.new("\$a")')
+    && $t.contains('then      => RakuAST::Var::Lexical.new("\$b")')
+    && $t.contains('else      => RakuAST::Var::Lexical.new("\$a")'),
+    'ternary branches carry their operand expressions';


### PR DESCRIPTION
## Summary

Phase 2 slice 19 of RakuAST (ADR-0011): the ternary operator. `COND ?? THEN !! ELSE` (`Expr::Ternary`) maps to `RakuAST::Ternary(condition, then, else)`.

```
$x ?? 2 !! 3
  -> Ternary(condition => Var::Lexical("$x"), then => IntLiteral(2), else => IntLiteral(3))
```

## Divergence

raku constant-folds a literal-condition ternary (`1 ?? 2 !! 3` folds to `IntLiteral(2)`) while mutsu does not — the same const-fold divergence already tracked in ADR-0011 Open questions. A non-constant condition renders identically.

## Tests

`t/rakuast-ternary.t` — 2 assertions (non-constant ternary full gist, arbitrary branch expressions), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)