### PR TITLE
feat: RakuAST Phase 2 slice 20 — definite types Int:D / Int:U

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -837,10 +837,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 18: given / when / default (`Statement::Given`/`When`/`Default`). Tests in
         `t/rakuast-given-when.t`.
   - [x] Slice 19: the ternary `?? !!` operator (`RakuAST::Ternary`). Tests in `t/rakuast-ternary.t`.
-  - [ ] Slice 20+: parameterised/definite types (`Array[Int]`/`Int:D`), attribute defaults
-        (`Trait::WillBuild`), quoted method names, `Stmt::Label`-wrapped loops, `andthen`/`orelse`,
-        `.=` method-assign; then `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku
-        folds to `IntLiteral(3)`, mutsu does not).
+  - [x] Slice 20: definite types `Int:D`/`Int:U` (`Type::Definedness` over a `Type::Simple` base).
+        Tests in `t/rakuast-type-definite.t`.
+  - [ ] Slice 21+: parameterised types (`Array[Int]`), attribute defaults (`Trait::WillBuild`),
+        quoted method names, `Stmt::Label`-wrapped loops, `andthen`/`orelse`, `.=` method-assign;
+        then `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to
+        `IntLiteral(3)`, mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -259,7 +259,10 @@ earlier ones.
   desigilname, initializer). Only plain (possibly `::`-qualified) type identifiers map to
   `Type::Simple`; parameterised (`Array[Int]`), definite (`Int:D`), and coercion (`Str()`) types,
   dynamic (`$*x`) declarations, `where` constraints, and real `is`/`does` traits are the coverage
-  boundary (explicit `RuntimeError`).
+  boundary (explicit `RuntimeError`). A `:D`/`:U` definiteness smiley (`my Int:D $x`) is handled
+  (slice 20): the `type` field becomes `Type::Definedness(base-type => Type::Simple(Name), definite
+  => True/False)` via the shared `build_type_node` helper. Parameterised (`Array[Int]`), coercion
+  (`Str()`), and `:_` types still defer.
 - **Single-param pointy sigil loss (Phase 2 slice 3).** mutsu parses a single-parameter pointy
   block to `Expr::Lambda { param: String }` with the sigil stripped, and does not preserve `@`/`%`
   for a single non-scalar param (`-> @a` becomes `param: "a"`). The converter therefore assumes `$`

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -78,11 +78,8 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             if custom_traits.iter().any(|(n, _)| n != "__has_initializer") {
                 return Err(unsupported("declaration with traits"));
             }
-            let type_name = match type_constraint.as_deref() {
-                Some(t) if is_simple_type(t) => Some(t),
-                Some(_) => return Err(unsupported("parameterised/definite/coercion type")),
-                None => None,
-            };
+            // build_type_node validates simple/definite and defers the rest.
+            let type_name = type_constraint.as_deref();
             let scope = if *is_our {
                 Some("our")
             } else if *is_state {
@@ -491,11 +488,9 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                     "attribute with default / traits / smiley / scope",
                 ));
             }
-            let type_name = match type_constraint.as_deref() {
-                Some(t) if is_simple_type(t) => Some(t),
-                Some(_) => return Err(unsupported("parameterised/definite attribute type")),
-                None => None,
-            };
+            // Definite attributes carry `type_smiley` (guarded above), so the
+            // type_constraint here is a bare type; build_type_node handles it.
+            let type_name = type_constraint.as_deref();
             let twigil = if *is_public { "." } else { "!" };
             let full_name = if *sigil == '$' {
                 name.resolve()
@@ -591,11 +586,7 @@ fn var_declaration(
         fields.push(leaf_field(Some("scope"), Value::str(s.to_string())));
     }
     if let Some(t) = type_name {
-        let type_node = RakuAstNode {
-            class: RakuAstClass::TypeSimple,
-            fields: vec![node_field(None, name_from_identifier(t))],
-        };
-        fields.push(node_field(Some("type"), type_node));
+        fields.push(node_field(Some("type"), build_type_node(t)?));
     }
     fields.push(leaf_field(Some("sigil"), Value::str(sigil.to_string())));
     if let Some(tw) = twigil {
@@ -627,14 +618,49 @@ fn name_from_identifier(s: &str) -> RakuAstNode {
 }
 
 /// True when a type constraint is a plain (possibly `::`-qualified) identifier
-/// (`Int`, `My::Type`) that maps to `Type::Simple`. Parameterised (`Array[Int]`),
-/// definite (`Int:D`), and coercion (`Str()`) types carry richer RakuAST shape,
-/// deferred — so each `::`-separated segment must be a bare identifier.
+/// (`Int`, `My::Type`) that maps to `Type::Simple`. Parameterised (`Array[Int]`)
+/// and coercion (`Str()`) types carry richer RakuAST shape, deferred — so each
+/// `::`-separated segment must be a bare identifier.
 fn is_simple_type(t: &str) -> bool {
     !t.is_empty()
         && t.split("::").all(|seg| {
             !seg.is_empty() && seg.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
         })
+}
+
+/// A bare simple type `Int` -> `Type::Simple(Name.from-identifier("Int"))`.
+fn simple_type_node(t: &str) -> RakuAstNode {
+    RakuAstNode {
+        class: RakuAstClass::TypeSimple,
+        fields: vec![node_field(None, name_from_identifier(t))],
+    }
+}
+
+/// Build the `type => ...` RakuAST node for a mutsu type-constraint string.
+/// A plain identifier -> `Type::Simple`; a `:D`/`:U` definiteness smiley ->
+/// `Type::Definedness(base-type => Type::Simple, definite => True/False)`.
+/// Parameterised (`Array[Int]`), coercion (`Str()`), and `:_` types defer.
+fn build_type_node(t: &str) -> Result<RakuAstNode, RuntimeError> {
+    if let Some(base) = t.strip_suffix(":D").or_else(|| t.strip_suffix(":U")) {
+        if !is_simple_type(base) {
+            return Err(unsupported("definite type over a non-simple base"));
+        }
+        let definite = t.ends_with(":D");
+        return Ok(RakuAstNode {
+            class: RakuAstClass::TypeDefinedness,
+            fields: vec![
+                node_field(Some("base-type"), simple_type_node(base)),
+                RakuAstField {
+                    name: Some("definite"),
+                    value: RakuAstFieldValue::Node(Value::truth(definite)),
+                },
+            ],
+        });
+    }
+    if is_simple_type(t) {
+        return Ok(simple_type_node(t));
+    }
+    Err(unsupported("parameterised/coercion type"))
 }
 
 /// Split a declaration name into `(sigil, desigilname)`. mutsu keeps the sigil

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -91,6 +91,8 @@ pub enum RakuAstClass {
     ApplyListInfix,
     // Phase 2 slice 10: scoped/typed variable declarations.
     TypeSimple,
+    // Phase 2 slice 20: definite types (`Int:D` / `Int:U`).
+    TypeDefinedness,
     // Phase 2 slice 13: class and method declarations.
     Class,
     Method,
@@ -155,6 +157,7 @@ impl RakuAstClass {
             StatementLoopRepeatWhile => "RakuAST::Statement::Loop::RepeatWhile",
             ApplyListInfix => "RakuAST::ApplyListInfix",
             TypeSimple => "RakuAST::Type::Simple",
+            TypeDefinedness => "RakuAST::Type::Definedness",
             Class => "RakuAST::Class",
             Method => "RakuAST::Method",
             Role => "RakuAST::Role",

--- a/t/rakuast-type-definite.t
+++ b/t/rakuast-type-definite.t
@@ -1,0 +1,42 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 20 (ADR-0011): definite types `Int:D` / `Int:U`.
+# A `:D`/`:U` smiley makes the `type` field a Type::Definedness wrapping the
+# base Type::Simple. Expected gists captured verbatim from Rakudo; this file
+# passes under BOTH mutsu and raku. (raku requires an initializer for a `:D`
+# variable, so the pinned cases use one.)
+
+plan 3;
+
+# --- `Int:D` -> definite => True --------------------------------------------
+is Q[my Int:D $x = 5].AST.gist, q:to/END/.chomp, 'Int:D -> Type::Definedness(definite => True)';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          type        => RakuAST::Type::Definedness.new(
+            base-type => RakuAST::Type::Simple.new(
+              RakuAST::Name.from-identifier("Int")
+            ),
+            definite  => True
+          ),
+          sigil       => "\$",
+          desigilname => RakuAST::Name.from-identifier("x"),
+          initializer => RakuAST::Initializer::Assign.new(
+            RakuAST::IntLiteral.new(5)
+          )
+        )
+      )
+    )
+    END
+
+# --- `Int:U` -> definite => False -------------------------------------------
+is Q[my Int:U $x].AST.gist.contains('definite  => False'), True, 'Int:U -> definite => False';
+
+# --- the base type is a nested Type::Simple ---------------------------------
+my $g = Q[my Str:D $s = "hi"].AST.gist;
+ok $g.contains('type        => RakuAST::Type::Definedness.new(')
+    && $g.contains('base-type => RakuAST::Type::Simple.new(')
+    && $g.contains('RakuAST::Name.from-identifier("Str")')
+    && $g.contains('definite  => True'),
+    'Str:D -> Definedness over a Type::Simple base';


### PR DESCRIPTION
## Summary

Phase 2 slice 20 of RakuAST (ADR-0011): definite/undefined types. A `:D`/`:U` smiley on a declaration type (`my Int:D $x = 5`) now makes the `type` field a `Type::Definedness` wrapping the base `Type::Simple`, instead of hitting the coverage boundary.

```
my Int:D $x = 5
  -> ...type => Type::Definedness(base-type => Type::Simple(Name("Int")), definite => True)...
my Int:U $x
  -> ...definite => False...
```

## Implementation

The `type => ...` node construction is now a shared `build_type_node` helper (used by both the `my`/`our`/`state` and `has` paths): a plain identifier → `Type::Simple`, a `:D`/`:U` suffix → `Type::Definedness`. Parameterised (`Array[Int]`), coercion (`Str()`), and `:_` types still defer.

## Tests

`t/rakuast-type-definite.t` — 3 assertions (`Int:D` full gist, `Int:U` → `definite => False`, `Str:D` base type), **passing under BOTH mutsu and raku** (raku requires an initializer for a `:D` variable, so the cases use one). All existing `t/rakuast-*.t` still green — plain `Int` types and the `has`-attribute path are byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)