### PR TITLE
fix(index): list-of-needles support in the sub form of index()

### DIFF
--- a/src/builtins/functions/dispatch_2arg.rs
+++ b/src/builtins/functions/dispatch_2arg.rs
@@ -226,6 +226,11 @@ pub(crate) fn native_function_2arg(
             {
                 return None;
             }
+            // Fall through to runtime for arrays (list of needles): the runtime
+            // handler returns the smallest index at which any needle matches.
+            if matches!(arg2.view(), ValueView::Array(..)) {
+                return None;
+            }
             let s = arg1.to_string_value();
             let needle = arg2.to_string_value();
             Some(Ok(match s.find(&needle) {

--- a/t/index-needle-list.t
+++ b/t/index-needle-list.t
@@ -1,0 +1,40 @@
+use v6;
+use Test;
+
+# index() / .index with a *list* of needles returns the smallest index at which
+# any of the needles matches (rakudo issue #6104). rindex already supported this;
+# the sub form of index used to stringify the whole list and never match.
+
+plan 18;
+
+# --- sub form: index($str, @needles) ---------------------------------------
+is index("ab",  <ab b>),  0, "second needle contained in the first";
+is index("ab",  <b ab>),  0, "first needle contained in the second";
+is index("abc", <ab bc>), 0, "partial overlap, small index first";
+is index("abc", <bc ab>), 0, "partial overlap, large index first";
+is index("abcbc", <bc abc>), 0, "needle contained in another, twice in str";
+is index("abccbccbab", <ccbc bccb cbcc bcc bab ccbc>), 1, "many overlapping needles";
+is index("hello world", <world lo o>), 3, "earliest of several matches";
+
+# no match across all needles -> undefined
+nok index("aaa", <x y z>).defined, "no needle matches -> undefined (sub)";
+
+# a single-element list still works
+is index("abc", <bc>), 1, "single-element needle list";
+
+# start position is honoured with a needle list
+is index("abcabc", <bc>, 2), 4, "list needle with start position";
+
+# --- method form: $str.index(@needles) -------------------------------------
+is "abc".index(<bc ab>), 0, "method form: earliest match";
+is "abccbccbab".index(<ccbc bccb cbcc bcc bab ccbc>), 1, "method form: many overlapping";
+nok "aaa".index(<x y>).defined, "method form: no match -> undefined";
+
+# --- scalar needle unchanged (regression guard) ----------------------------
+is index("abc", "bc"), 1, "scalar needle still works (sub)";
+is "abc".index("bc"), 1, "scalar needle still works (method)";
+nok index("abc", "xyz").defined, "scalar no-match still undefined";
+
+# --- rindex list form (already worked; guard it) ---------------------------
+is rindex("abcbc", <bc abc>), 3, "rindex list form: rightmost match";
+is rindex("abccbccbab", <ccbc bccb cbcc bcc bab ccbc>), 7, "rindex list: many overlapping";


### PR DESCRIPTION
## What

`index($str, @needles)` (sub form, list of needles) stringified the whole list into a single needle and therefore never matched, returning `Nil`. Only `rindex` fell through to the runtime handler that understands array needles.

The runtime `dispatch_index` already implements the correct semantics — the **smallest index at which any of the needles matches** (rakudo [issue #6104](https://github.com/rakudo/rakudo/issues/6104)). This mirrors the `rindex` fast-path guard: when the second argument is an `Array`, fall through to the runtime handler instead of stringifying it.

```raku
index("abc", <bc ab>)                                   # was Nil, now 0
index("abccbccbab", <ccbc bccb cbcc bcc bab ccbc>)      # was Nil, now 1
index("hello world", <world lo o>)                      # was Nil, now 3
```

The method form `$str.index(@needles)` already worked (it goes straight to `dispatch_index`); the scalar-needle path is unchanged.

## Why now

First of four feature clusters needed before bumping vendored `roast` to upstream HEAD (see `PLAN.md` §4). The list-of-overlapping-needles subtests were added to `roast/S32-str/index.t` upstream; this makes mutsu pass the updated file (verified against an upstream clone: 254/254). The other three clusters (6.e sprintf flags, immutable QuantHash RO errors, `.assuming` priming gist) follow.

## Test

- New pin `t/index-needle-list.t` (18 assertions; passes under both mutsu and `raku`).
- New upstream `S32-str/index.t` (254 tests) passes under mutsu.
- Currently whitelisted `roast/S32-str/index.t` (248) and `rindex.t` (50) still pass — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)