### PR TITLE
feat: RakuAST Phase 2 slice 21 — parameterised types Array[Int]

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -839,10 +839,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 19: the ternary `?? !!` operator (`RakuAST::Ternary`). Tests in `t/rakuast-ternary.t`.
   - [x] Slice 20: definite types `Int:D`/`Int:U` (`Type::Definedness` over a `Type::Simple` base).
         Tests in `t/rakuast-type-definite.t`.
-  - [ ] Slice 21+: parameterised types (`Array[Int]`), attribute defaults (`Trait::WillBuild`),
-        quoted method names, `Stmt::Label`-wrapped loops, `andthen`/`orelse`, `.=` method-assign;
-        then `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to
-        `IntLiteral(3)`, mutsu does not).
+  - [x] Slice 21: parameterised types `Array[Int]`/`Hash[Str, Int]` (`Type::Parameterized` with an
+        `ArgList` of type args). Tests in `t/rakuast-type-parameterized.t`.
+  - [ ] Slice 22+: attribute defaults (`Trait::WillBuild`), quoted method names, `Stmt::Label`-wrapped
+        loops, `andthen`/`orelse`, `.=` method-assign, coercion types (`Str()`); then `.DEPARSE`;
+        resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu does
+        not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -261,8 +261,10 @@ earlier ones.
   dynamic (`$*x`) declarations, `where` constraints, and real `is`/`does` traits are the coverage
   boundary (explicit `RuntimeError`). A `:D`/`:U` definiteness smiley (`my Int:D $x`) is handled
   (slice 20): the `type` field becomes `Type::Definedness(base-type => Type::Simple(Name), definite
-  => True/False)` via the shared `build_type_node` helper. Parameterised (`Array[Int]`), coercion
-  (`Str()`), and `:_` types still defer.
+  => True/False)` via the shared `build_type_node` helper. Parameterised types (slice 21):
+  `Array[Int]` / `Hash[Str, Int]` → `Type::Parameterized(base-type => Type::Simple, args => ArgList(
+  <type args>))`, with each argument built recursively by `build_type_node` (so nesting composes).
+  Coercion (`Str()`) and `:_` types still defer.
 - **Single-param pointy sigil loss (Phase 2 slice 3).** mutsu parses a single-parameter pointy
   block to `Expr::Lambda { param: String }` with the sigil stripped, and does not preserve `@`/`%`
   for a single non-scalar param (`-> @a` becomes `param: "a"`). The converter therefore assumes `$`

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -638,8 +638,8 @@ fn simple_type_node(t: &str) -> RakuAstNode {
 
 /// Build the `type => ...` RakuAST node for a mutsu type-constraint string.
 /// A plain identifier -> `Type::Simple`; a `:D`/`:U` definiteness smiley ->
-/// `Type::Definedness(base-type => Type::Simple, definite => True/False)`.
-/// Parameterised (`Array[Int]`), coercion (`Str()`), and `:_` types defer.
+/// `Type::Definedness`; a `Base[Arg, ...]` -> `Type::Parameterized`. Coercion
+/// (`Str()`) and `:_` types defer.
 fn build_type_node(t: &str) -> Result<RakuAstNode, RuntimeError> {
     if let Some(base) = t.strip_suffix(":D").or_else(|| t.strip_suffix(":U")) {
         if !is_simple_type(base) {
@@ -657,10 +657,36 @@ fn build_type_node(t: &str) -> Result<RakuAstNode, RuntimeError> {
             ],
         });
     }
+    // `Array[Int]` / `Hash[Str, Int]` -> Type::Parameterized(base-type, args).
+    if let Some(open) = t.find('[') {
+        let inner = t
+            .strip_suffix(']')
+            .ok_or_else(|| unsupported("malformed parameterised type"))?;
+        let base = &t[..open];
+        let args_str = &inner[open + 1..];
+        if !is_simple_type(base) {
+            return Err(unsupported("parameterised type over a non-simple base"));
+        }
+        let mut args = Vec::new();
+        for a in args_str.split(',') {
+            args.push(node_field(None, build_type_node(a.trim())?));
+        }
+        let arglist = RakuAstNode {
+            class: RakuAstClass::ArgList,
+            fields: args,
+        };
+        return Ok(RakuAstNode {
+            class: RakuAstClass::TypeParameterized,
+            fields: vec![
+                node_field(Some("base-type"), simple_type_node(base)),
+                node_field(Some("args"), arglist),
+            ],
+        });
+    }
     if is_simple_type(t) {
         return Ok(simple_type_node(t));
     }
-    Err(unsupported("parameterised/coercion type"))
+    Err(unsupported("coercion type"))
 }
 
 /// Split a declaration name into `(sigil, desigilname)`. mutsu keeps the sigil

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -93,6 +93,8 @@ pub enum RakuAstClass {
     TypeSimple,
     // Phase 2 slice 20: definite types (`Int:D` / `Int:U`).
     TypeDefinedness,
+    // Phase 2 slice 21: parameterised types (`Array[Int]`).
+    TypeParameterized,
     // Phase 2 slice 13: class and method declarations.
     Class,
     Method,
@@ -158,6 +160,7 @@ impl RakuAstClass {
             ApplyListInfix => "RakuAST::ApplyListInfix",
             TypeSimple => "RakuAST::Type::Simple",
             TypeDefinedness => "RakuAST::Type::Definedness",
+            TypeParameterized => "RakuAST::Type::Parameterized",
             Class => "RakuAST::Class",
             Method => "RakuAST::Method",
             Role => "RakuAST::Role",

--- a/t/rakuast-type-parameterized.t
+++ b/t/rakuast-type-parameterized.t
@@ -1,0 +1,43 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 21 (ADR-0011): parameterised types `Array[Int]`.
+# A `Base[Arg, ...]` type maps to Type::Parameterized(base-type => Type::Simple,
+# args => ArgList(<type args>)). Expected gists captured verbatim from Rakudo;
+# this file passes under BOTH mutsu and raku.
+
+plan 3;
+
+# --- `Array[Int]` -----------------------------------------------------------
+is Q[my Array[Int] $x].AST.gist, q:to/END/.chomp, 'Array[Int] -> Type::Parameterized';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          type        => RakuAST::Type::Parameterized.new(
+            base-type => RakuAST::Type::Simple.new(
+              RakuAST::Name.from-identifier("Array")
+            ),
+            args      => RakuAST::ArgList.new(
+              RakuAST::Type::Simple.new(
+                RakuAST::Name.from-identifier("Int")
+              )
+            )
+          ),
+          sigil       => "\$",
+          desigilname => RakuAST::Name.from-identifier("x")
+        )
+      )
+    )
+    END
+
+# --- multi-argument `Hash[Str, Int]` ----------------------------------------
+my $h = Q[my Hash[Str, Int] $g].AST.gist;
+ok $h.contains('RakuAST::Type::Parameterized.new(')
+    && $h.contains('RakuAST::Name.from-identifier("Hash")')
+    && $h.contains('RakuAST::Name.from-identifier("Str")')
+    && $h.contains('RakuAST::Name.from-identifier("Int")'),
+    'Hash[Str, Int] -> two type args in the ArgList';
+
+# --- the base type is a nested Type::Simple ---------------------------------
+is Q[my Array[Str] $a].AST.gist.contains('base-type => RakuAST::Type::Simple.new('), True,
+    'parameterised base is a Type::Simple';


### PR DESCRIPTION
## Summary

Phase 2 slice 21 of RakuAST (ADR-0011): parameterised types. A `Base[Arg, ...]` type (`my Array[Int] $x`, `my Hash[Str, Int] $h`) now maps to `Type::Parameterized(base-type => Type::Simple, args => ArgList(<type args>))`, instead of hitting the coverage boundary.

```
my Array[Int] $x
  -> ...type => Type::Parameterized(base-type => Type::Simple(Name("Array")),
                                    args => ArgList(Type::Simple(Name("Int"))))...
```

## Implementation

Each type argument is built **recursively** by the shared `build_type_node` helper (slice 20), so nested/definite arguments compose naturally. Coercion (`Str()`) and `:_` types still defer.

## Tests

`t/rakuast-type-parameterized.t` — 3 assertions (`Array[Int]` full gist, multi-arg `Hash[Str, Int]`, base is a `Type::Simple`), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green — plain/definite types are byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)