### PR TITLE
feat: RakuAST Phase 2 slice 22 — positional subscripts

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -841,7 +841,9 @@ so it is tracked separately from the roast backlog.
         Tests in `t/rakuast-type-definite.t`.
   - [x] Slice 21: parameterised types `Array[Int]`/`Hash[Str, Int]` (`Type::Parameterized` with an
         `ArgList` of type args). Tests in `t/rakuast-type-parameterized.t`.
-  - [ ] Slice 22+: attribute defaults (`Trait::WillBuild`), quoted method names, `Stmt::Label`-wrapped
+  - [x] Slice 22: positional subscripts `@x[EXPR]` (`Postcircumfix::ArrayIndex` + `SemiList`). Tests
+        in `t/rakuast-subscript.t`. (Associative `%h{...}`/`%h<...>` deferred — indistinguishable.)
+  - [ ] Slice 23+: attribute defaults (`Trait::WillBuild`), quoted method names, `Stmt::Label`-wrapped
         loops, `andthen`/`orelse`, `.=` method-assign, coercion types (`Str()`); then `.DEPARSE`;
         resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu does
         not).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -232,6 +232,12 @@ earlier ones.
   `Trait::WillBuild` in raku (not an `initializer`), so it is deferred, along with `is rw`, type
   smileys (`:D`), `is required`, `where`, aliases (`has $x`), `my`/`our` attributes, delegation, and
   other traits.
+- **Positional subscripts (Phase 2 slice 22).** `@x[EXPR]` (`Expr::Index` with
+  `is_positional == true`) → `ApplyPostfix(operand, postfix => Postcircumfix::ArrayIndex(index =>
+  SemiList(Statement::Expression(EXPR))))`. Associative subscripts (`%h{...}` / `%h<...>`) are
+  deferred: mutsu marks both `is_positional == false` with no `<>`-vs-`{}` distinction, so it cannot
+  tell `<k>` (raku `LiteralHashIndex` + a word-quoted `QuotedString`) from `{"k"}` (raku
+  `HashIndex` + `SemiList`).
 - **Ternary `?? !!` (Phase 2 slice 19).** `COND ?? THEN !! ELSE` (`Expr::Ternary`) →
   `Ternary(condition, then, else)`. raku constant-folds a literal-condition ternary (`1 ?? 2 !! 3`
   → `IntLiteral(2)`) while mutsu does not — the same const-fold divergence tracked in Open questions;

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -792,6 +792,34 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
                 ],
             })
         }
+        // Positional subscript `@x[EXPR]` -> ApplyPostfix(operand,
+        // postfix => Postcircumfix::ArrayIndex(index => SemiList(...))).
+        // Associative subscripts (`%h{...}` / `%h<...>`) are deferred: mutsu
+        // cannot distinguish `<k>` (LiteralHashIndex) from `{"k"}` (HashIndex).
+        Expr::Index {
+            target,
+            index,
+            is_positional,
+        } => {
+            if !is_positional {
+                return Err(unsupported("associative subscript"));
+            }
+            let semilist = RakuAstNode {
+                class: RakuAstClass::SemiList,
+                fields: vec![node_field(None, statement_expression(convert_expr(index)?))],
+            };
+            let array_index = RakuAstNode {
+                class: RakuAstClass::PostcircumfixArrayIndex,
+                fields: vec![node_field(Some("index"), semilist)],
+            };
+            Ok(RakuAstNode {
+                class: RakuAstClass::ApplyPostfix,
+                fields: vec![
+                    node_field(Some("operand"), convert_expr(target)?),
+                    node_field(Some("postfix"), array_index),
+                ],
+            })
+        }
         // A bare `{ ... }` block in expression position.
         Expr::Block(body) => block_node(body),
         Expr::AnonSub {

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -109,6 +109,9 @@ pub enum RakuAstClass {
     StatementDefault,
     // Phase 2 slice 19: ternary.
     Ternary,
+    // Phase 2 slice 22: positional subscripts.
+    SemiList,
+    PostcircumfixArrayIndex,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -170,6 +173,8 @@ impl RakuAstClass {
             StatementWhen => "RakuAST::Statement::When",
             StatementDefault => "RakuAST::Statement::Default",
             Ternary => "RakuAST::Ternary",
+            SemiList => "RakuAST::SemiList",
+            PostcircumfixArrayIndex => "RakuAST::Postcircumfix::ArrayIndex",
         }
     }
 

--- a/t/rakuast-subscript.t
+++ b/t/rakuast-subscript.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 22 (ADR-0011): positional subscripts `@x[EXPR]`.
+# `@x[0]` -> ApplyPostfix(operand, postfix => Postcircumfix::ArrayIndex(index =>
+# SemiList(Statement::Expression(EXPR)))). Expected gists captured verbatim from
+# Rakudo; this file passes under BOTH mutsu and raku.
+#
+# Note: associative subscripts (`%h{...}` / `%h<...>`) are deferred — mutsu
+# cannot distinguish `<k>` (LiteralHashIndex) from `{"k"}` (HashIndex).
+
+plan 3;
+
+# --- literal index ----------------------------------------------------------
+is Q[my @x; @x[0]].AST.gist, q:to/END/.chomp, 'positional subscript -> ArrayIndex + SemiList';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          sigil       => "\@",
+          desigilname => RakuAST::Name.from-identifier("x")
+        )
+      ),
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::Var::Lexical.new("\@x"),
+          postfix => RakuAST::Postcircumfix::ArrayIndex.new(
+            index => RakuAST::SemiList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::IntLiteral.new(0)
+              )
+            )
+          )
+        )
+      )
+    )
+    END
+
+# --- variable index ---------------------------------------------------------
+my $v = Q[my @x; my $i; @x[$i]].AST.gist;
+ok $v.contains('postfix => RakuAST::Postcircumfix::ArrayIndex.new(')
+    && $v.contains('index => RakuAST::SemiList.new(')
+    && $v.contains('expression => RakuAST::Var::Lexical.new("\$i")'),
+    'variable index nests inside the SemiList';
+
+# --- the operand is the indexed variable ------------------------------------
+is Q[my @x; @x[0]].AST.gist.contains('operand => RakuAST::Var::Lexical.new("\@x")'), True,
+    'subscript operand is the array variable';


### PR DESCRIPTION
## Summary

Phase 2 slice 22 of RakuAST (ADR-0011): positional subscripts. `@x[EXPR]` (`Expr::Index` with `is_positional == true`) now maps to `ApplyPostfix(operand, postfix => Postcircumfix::ArrayIndex(index => SemiList(Statement::Expression(EXPR))))`, instead of hitting the coverage boundary.

```
@x[0]
  -> ApplyPostfix(operand => Var::Lexical("@x"),
                  postfix => Postcircumfix::ArrayIndex(index => SemiList(
                    Statement::Expression(IntLiteral(0)))))
```

## Deferred

Associative subscripts (`%h{...}` / `%h<...>`) are deferred: mutsu marks both `is_positional == false` with no `<>`-vs-`{}` distinction, so it cannot tell `<k>` (raku `LiteralHashIndex` + a word-quoted `QuotedString`) from `{"k"}` (raku `HashIndex` + `SemiList`).

## Tests

`t/rakuast-subscript.t` — 3 assertions (literal index full gist, variable index in the SemiList, operand is the array variable), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)