### PR TITLE
feat: RakuAST Phase 2 slice 23 — quoted method names

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -843,10 +843,12 @@ so it is tracked separately from the roast backlog.
         `ArgList` of type args). Tests in `t/rakuast-type-parameterized.t`.
   - [x] Slice 22: positional subscripts `@x[EXPR]` (`Postcircumfix::ArrayIndex` + `SemiList`). Tests
         in `t/rakuast-subscript.t`. (Associative `%h{...}`/`%h<...>` deferred — indistinguishable.)
-  - [ ] Slice 23+: attribute defaults (`Trait::WillBuild`), quoted method names, `Stmt::Label`-wrapped
-        loops, `andthen`/`orelse`, `.=` method-assign, coercion types (`Str()`); then `.DEPARSE`;
-        resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu does
-        not).
+  - [x] Slice 23: quoted method names `$x."foo"()` (`Call::QuotedMethod`). Tests in
+        `t/rakuast-quoted-method.t`.
+  - [ ] Slice 24+: attribute defaults (`Trait::WillBuild`), `Stmt::Label`-wrapped loops,
+        `andthen`/`orelse` (`ApplyListInfix`), `.=` method-assign, coercion types (`Str()`); then
+        `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`,
+        mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -232,6 +232,10 @@ earlier ones.
   `Trait::WillBuild` in raku (not an `initializer`), so it is deferred, along with `is rw`, type
   smileys (`:D`), `is required`, `where`, aliases (`has $x`), `my`/`our` attributes, delegation, and
   other traits.
+- **Quoted method names (Phase 2 slice 23).** `$x."foo"()` (`Expr::MethodCall` with `quoted ==
+  true`) → `ApplyPostfix(operand, postfix => Call::QuotedMethod(name => QuotedString, [args =>
+  ArgList]))` — unlike `Call::Method`, the name is a `QuotedString` (string literal) rather than a
+  `Name.from-identifier`. A quoted name combined with a `.?`/`.+`/`.*` modifier is the boundary.
 - **Positional subscripts (Phase 2 slice 22).** `@x[EXPR]` (`Expr::Index` with
   `is_positional == true`) → `ApplyPostfix(operand, postfix => Postcircumfix::ArrayIndex(index =>
   SemiList(Statement::Expression(EXPR))))`. Associative subscripts (`%h{...}` / `%h<...>`) are

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -759,19 +759,21 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
             modifier,
             quoted,
         } => {
-            // Plain `.method(...)` and modifier forms (`.?`/`.+`/`.*`, slice 15).
-            // A quoted method name (`."$name"()`) maps to a distinct node.
-            if *quoted {
-                return Err(unsupported("quoted method name"));
-            }
+            // Plain `.method(...)` and modifier forms (`.?`/`.+`/`.*`, slice 15);
+            // and quoted names (`."foo"()`, slice 23) -> Call::QuotedMethod.
+            let postfix = if *quoted {
+                if modifier.is_some() {
+                    return Err(unsupported("quoted method name with a modifier"));
+                }
+                call_quoted_method(name.as_str(), args)?
+            } else {
+                call_method(name.as_str(), args, *modifier)?
+            };
             Ok(RakuAstNode {
                 class: RakuAstClass::ApplyPostfix,
                 fields: vec![
                     node_field(Some("operand"), convert_expr(target)?),
-                    node_field(
-                        Some("postfix"),
-                        call_method(name.as_str(), args, *modifier)?,
-                    ),
+                    node_field(Some("postfix"), postfix),
                 ],
             })
         }
@@ -1163,6 +1165,23 @@ fn call_method(
     }
     Ok(RakuAstNode {
         class: RakuAstClass::CallMethod,
+        fields,
+    })
+}
+
+/// `."foo"` / `."foo"(args)` -> `Call::QuotedMethod(name => QuotedString,
+/// [args => ArgList])`. Unlike `Call::Method`, the name is a QuotedString
+/// (a string literal) rather than a `Name.from-identifier`.
+fn call_quoted_method(name: &str, args: &[Expr]) -> Result<RakuAstNode, RuntimeError> {
+    let mut fields = vec![node_field(
+        Some("name"),
+        quoted_string(Value::str(name.to_string())),
+    )];
+    if !args.is_empty() {
+        fields.push(node_field(Some("args"), arg_list(args)?));
+    }
+    Ok(RakuAstNode {
+        class: RakuAstClass::CallQuotedMethod,
         fields,
     })
 }

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -67,6 +67,8 @@ pub enum RakuAstClass {
     Postfix,
     Assignment,
     CallMethod,
+    // Phase 2 slice 23: quoted method names.
+    CallQuotedMethod,
     // Phase 2 slice 3: blocks & pointy blocks.
     Block,
     Blockoid,
@@ -146,6 +148,7 @@ impl RakuAstClass {
             Postfix => "RakuAST::Postfix",
             Assignment => "RakuAST::Assignment",
             CallMethod => "RakuAST::Call::Method",
+            CallQuotedMethod => "RakuAST::Call::QuotedMethod",
             Block => "RakuAST::Block",
             Blockoid => "RakuAST::Blockoid",
             PointyBlock => "RakuAST::PointyBlock",

--- a/t/rakuast-quoted-method.t
+++ b/t/rakuast-quoted-method.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 23 (ADR-0011): quoted method names `$x."foo"()`.
+# A quoted method call -> Call::QuotedMethod, whose name is a QuotedString
+# (a string literal) rather than a Name.from-identifier. Expected gists
+# captured verbatim from Rakudo; this file passes under BOTH mutsu and raku.
+
+plan 3;
+
+# --- quoted method, no args -------------------------------------------------
+my $q = Q[my $x; $x."foo"()].AST.gist;
+ok $q.contains('postfix => RakuAST::Call::QuotedMethod.new(')
+    && $q.contains('name => RakuAST::QuotedString.new(')
+    && $q.contains('RakuAST::StrLiteral.new("foo")')
+    && !$q.contains('Name.from-identifier("foo")'),
+    'quoted method -> Call::QuotedMethod with a QuotedString name';
+
+# --- quoted method with an argument -----------------------------------------
+my $a = Q[my $x; $x."bar"(1)].AST.gist;
+ok $a.contains('RakuAST::Call::QuotedMethod.new(')
+    && $a.contains('name => RakuAST::QuotedString.new(')
+    && $a.contains('RakuAST::StrLiteral.new("bar")')
+    && $a.contains('args => RakuAST::ArgList.new('),
+    'quoted method with args keeps its ArgList';
+
+# --- a plain (unquoted) method is still Call::Method -------------------------
+is Q[my $x; $x.plain].AST.gist.contains('RakuAST::Call::Method.new('), True,
+    'plain method call is still Call::Method';


### PR DESCRIPTION
## Summary

Phase 2 slice 23 of RakuAST (ADR-0011): quoted method names. `$x."foo"()` (`Expr::MethodCall` with `quoted == true`) now maps to `ApplyPostfix(operand, postfix => Call::QuotedMethod(name => QuotedString, [args => ArgList]))`.

```
$x."foo"(1)
  -> ...Call::QuotedMethod(name => QuotedString(segments => (StrLiteral("foo"),)),
                           args => ArgList(IntLiteral(1)))
```

Unlike `Call::Method`, the name is a **`QuotedString`** (string literal) rather than a `Name.from-identifier`. A quoted name combined with a `.?`/`.+`/`.*` modifier remains the boundary.

## Tests

`t/rakuast-quoted-method.t` — 3 assertions (quoted method → QuotedMethod, quoted with args, plain method still Call::Method), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green (plain method calls unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)