### PR TITLE
feat: RakuAST Phase 2 slice 24 — list-associative infixes

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -845,8 +845,10 @@ so it is tracked separately from the roast backlog.
         in `t/rakuast-subscript.t`. (Associative `%h{...}`/`%h<...>` deferred — indistinguishable.)
   - [x] Slice 23: quoted method names `$x."foo"()` (`Call::QuotedMethod`). Tests in
         `t/rakuast-quoted-method.t`.
-  - [ ] Slice 24+: attribute defaults (`Trait::WillBuild`), `Stmt::Label`-wrapped loops,
-        `andthen`/`orelse` (`ApplyListInfix`), `.=` method-assign, coercion types (`Str()`); then
+  - [x] Slice 24: list-associative infixes `andthen`/`orelse`/`notandthen` (flat `ApplyListInfix`).
+        Tests in `t/rakuast-list-infix.t`.
+  - [ ] Slice 25+: attribute defaults (`Trait::WillBuild`), `Stmt::Label`-wrapped loops,
+        `.=` method-assign, coercion types (`Str()`), reduction `[+]`, hyper `>>.method`; then
         `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`,
         mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -232,6 +232,11 @@ earlier ones.
   `Trait::WillBuild` in raku (not an `initializer`), so it is deferred, along with `is rw`, type
   smileys (`:D`), `is required`, `where`, aliases (`has $x`), `my`/`our` attributes, delegation, and
   other traits.
+- **List-associative infixes (Phase 2 slice 24).** `andthen` / `orelse` / `notandthen` render as a
+  single flat `ApplyListInfix(infix => Infix("andthen"), operands => (...))` in raku, not the
+  binary `ApplyInfix` used by ordinary operators. mutsu parses them left-associatively
+  (`a op b op c` → `(a op b) op c`), so the converter flattens a same-operator left chain into one
+  operand list.
 - **Quoted method names (Phase 2 slice 23).** `$x."foo"()` (`Expr::MethodCall` with `quoted ==
   true`) → `ApplyPostfix(operand, postfix => Call::QuotedMethod(name => QuotedString, [args =>
   ArgList]))` — unlike `Call::Method`, the name is a `QuotedString` (string literal) rather than a

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -715,6 +715,27 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
         Expr::ArrayVar(name) => Ok(var_lexical("@", name)),
         Expr::HashVar(name) => Ok(var_lexical("%", name)),
         Expr::CodeVar(name) => Ok(var_lexical("&", name)),
+        // List-associative infixes (`andthen`/`orelse`/`notandthen`) render as a
+        // single flat `ApplyListInfix` in raku; mutsu nests them left-associatively,
+        // so flatten a same-operator left chain into one operand list.
+        Expr::Binary { left, op, right } if is_list_infix(op) => {
+            let mut operands = Vec::new();
+            flatten_list_infix(op, left, right, &mut operands);
+            let mut nodes = Vec::with_capacity(operands.len());
+            for e in operands {
+                nodes.push(Value::rakuast(Box::new(convert_expr(e)?)));
+            }
+            Ok(RakuAstNode {
+                class: RakuAstClass::ApplyListInfix,
+                fields: vec![
+                    node_field(Some("infix"), operator_node(RakuAstClass::Infix, op)),
+                    RakuAstField {
+                        name: Some("operands"),
+                        value: RakuAstFieldValue::List(nodes),
+                    },
+                ],
+            })
+        }
         Expr::Binary { left, op, right } => Ok(RakuAstNode {
             class: RakuAstClass::ApplyInfix,
             fields: vec![
@@ -1200,6 +1221,41 @@ fn operator_node(class: RakuAstClass, op: &crate::token_kind::TokenKind) -> Raku
         class,
         fields: vec![leaf_field(None, Value::str(token_kind_to_op_name(op)))],
     }
+}
+
+/// True for the list-associative infixes raku renders as `ApplyListInfix`
+/// (`andthen` / `orelse` / `notandthen`).
+fn is_list_infix(op: &crate::token_kind::TokenKind) -> bool {
+    use crate::token_kind::TokenKind;
+    matches!(
+        op,
+        TokenKind::AndThen | TokenKind::OrElse | TokenKind::NotAndThen
+    )
+}
+
+/// Flatten a left-nested same-operator chain (`a op b op c` parsed as
+/// `(a op b) op c`) into a single operand list `[a, b, c]`.
+fn flatten_list_infix<'a>(
+    op: &crate::token_kind::TokenKind,
+    left: &'a Expr,
+    right: &'a Expr,
+    out: &mut Vec<&'a Expr>,
+) {
+    if let Expr::Binary {
+        left: ll,
+        op: lop,
+        right: lr,
+    } = left
+    {
+        if lop == op {
+            flatten_list_infix(op, ll, lr, out);
+        } else {
+            out.push(left);
+        }
+    } else {
+        out.push(left);
+    }
+    out.push(right);
 }
 
 /// `Postfix` — a single NAMED `operator` string (e.g. `Postfix.new(operator => "++")`).

--- a/t/rakuast-list-infix.t
+++ b/t/rakuast-list-infix.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 24 (ADR-0011): list-associative infixes
+# `andthen` / `orelse` / `notandthen`. These render as a single flat
+# ApplyListInfix in raku; mutsu nests them left-associatively, so a same-op
+# chain is flattened into one operand list. Expected gists captured verbatim
+# from Rakudo; this file passes under BOTH mutsu and raku.
+
+plan 3;
+
+# --- two-operand andthen ----------------------------------------------------
+is Q[my $a; my $b; $a andthen $b].AST.gist.contains(q:to/FRAG/.chomp), True, 'andthen -> ApplyListInfix';
+        expression => RakuAST::ApplyListInfix.new(
+          infix    => RakuAST::Infix.new("andthen"),
+          operands => (
+            RakuAST::Var::Lexical.new("\$a"),
+            RakuAST::Var::Lexical.new("\$b"),
+          )
+        )
+    FRAG
+
+# --- a three-operand chain flattens into one operand list -------------------
+my $chain = Q[my $a; my $b; my $c; $a andthen $b andthen $c].AST.gist;
+ok $chain.contains('RakuAST::ApplyListInfix.new(')
+    && $chain.contains('RakuAST::Infix.new("andthen")')
+    && $chain.comb(/'RakuAST::Var::Lexical'/).elems == 3,   # 3 flat operands
+    'a op b op c flattens into three operands (not nested)';
+
+# --- orelse also uses ApplyListInfix ----------------------------------------
+is Q[my $a; my $b; $a orelse $b].AST.gist.contains('RakuAST::Infix.new("orelse")'), True,
+    'orelse -> ApplyListInfix with the orelse infix';


### PR DESCRIPTION
## Summary

Phase 2 slice 24 of RakuAST (ADR-0011): the list-associative infixes `andthen` / `orelse` / `notandthen`. These render as a single flat `ApplyListInfix(infix => Infix("andthen"), operands => (...))` in raku, not the binary `ApplyInfix` used by ordinary operators.

```
$a andthen $b andthen $c
  -> ApplyListInfix(infix => Infix("andthen"), operands => (Var("$a"), Var("$b"), Var("$c")))
```

mutsu parses these **left-associatively** (`a op b op c` → `(a op b) op c`), so the converter flattens a same-operator left chain into one operand list — a two-operand `andthen` and a three-operand chain both produce a single flat `ApplyListInfix`.

## Tests

`t/rakuast-list-infix.t` — 3 assertions (two-operand `andthen` full fragment, three-operand chain flattens to three operands, `orelse` infix), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green (ordinary binary operators unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)