### PR TITLE
feat: RakuAST Phase 2 slice 25 — reduction metaoperator

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -847,10 +847,11 @@ so it is tracked separately from the roast backlog.
         `t/rakuast-quoted-method.t`.
   - [x] Slice 24: list-associative infixes `andthen`/`orelse`/`notandthen` (flat `ApplyListInfix`).
         Tests in `t/rakuast-list-infix.t`.
-  - [ ] Slice 25+: attribute defaults (`Trait::WillBuild`), `Stmt::Label`-wrapped loops,
-        `.=` method-assign, coercion types (`Str()`), reduction `[+]`, hyper `>>.method`; then
-        `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`,
-        mutsu does not).
+  - [x] Slice 25: reduction metaoperator `[+]`/`[\+]` (`Term::Reduce`). Tests in
+        `t/rakuast-reduction.t`.
+  - [ ] Slice 26+: attribute defaults (`Trait::WillBuild`), `Stmt::Label`-wrapped loops,
+        `.=` method-assign, coercion types (`Str()`), hyper `>>.method`; then `.DEPARSE`; resolve
+        the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -232,6 +232,9 @@ earlier ones.
   `Trait::WillBuild` in raku (not an `initializer`), so it is deferred, along with `is rw`, type
   smileys (`:D`), `is required`, `where`, aliases (`has $x`), `my`/`our` attributes, delegation, and
   other traits.
+- **Reduction metaoperator (Phase 2 slice 25).** `[+] @a` (`Expr::Reduction`) → `Term::Reduce(
+  triangle => False, infix => Infix("+"), args => ArgList(@a))`. The triangle form `[\+] @a`
+  (mutsu stores its op as `"\+"`) sets `triangle => True` with the backslash stripped from the infix.
 - **List-associative infixes (Phase 2 slice 24).** `andthen` / `orelse` / `notandthen` render as a
   single flat `ApplyListInfix(infix => Infix("andthen"), operands => (...))` in raku, not the
   binary `ApplyInfix` used by ordinary operators. mutsu parses them left-associatively

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -819,6 +819,28 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
         // postfix => Postcircumfix::ArrayIndex(index => SemiList(...))).
         // Associative subscripts (`%h{...}` / `%h<...>`) are deferred: mutsu
         // cannot distinguish `<k>` (LiteralHashIndex) from `{"k"}` (HashIndex).
+        // Reduction metaop `[+] @a` / triangle `[\+] @a` -> Term::Reduce.
+        Expr::Reduction { op, expr } => {
+            let (triangle, infix_op) = match op.strip_prefix('\\') {
+                Some(stripped) => (true, stripped),
+                None => (false, op.as_str()),
+            };
+            let arglist = RakuAstNode {
+                class: RakuAstClass::ArgList,
+                fields: vec![node_field(None, convert_expr(expr)?)],
+            };
+            Ok(RakuAstNode {
+                class: RakuAstClass::TermReduce,
+                fields: vec![
+                    RakuAstField {
+                        name: Some("triangle"),
+                        value: RakuAstFieldValue::Node(Value::truth(triangle)),
+                    },
+                    node_field(Some("infix"), plain_infix(infix_op)),
+                    node_field(Some("args"), arglist),
+                ],
+            })
+        }
         Expr::Index {
             target,
             index,

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -114,6 +114,8 @@ pub enum RakuAstClass {
     // Phase 2 slice 22: positional subscripts.
     SemiList,
     PostcircumfixArrayIndex,
+    // Phase 2 slice 25: reduction metaoperator.
+    TermReduce,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -178,6 +180,7 @@ impl RakuAstClass {
             Ternary => "RakuAST::Ternary",
             SemiList => "RakuAST::SemiList",
             PostcircumfixArrayIndex => "RakuAST::Postcircumfix::ArrayIndex",
+            TermReduce => "RakuAST::Term::Reduce",
         }
     }
 

--- a/t/rakuast-reduction.t
+++ b/t/rakuast-reduction.t
@@ -1,0 +1,27 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 25 (ADR-0011): the reduction metaoperator `[+]`.
+# `[+] @a` -> Term::Reduce(triangle => False, infix, args); `[\+] @a` sets
+# triangle => True. Expected gists captured verbatim from Rakudo; this file
+# passes under BOTH mutsu and raku.
+
+plan 3;
+
+# --- ordinary reduction -----------------------------------------------------
+is Q[my @a; [+] @a].AST.gist.contains(q:to/FRAG/.chomp), True, '[+] @a -> Term::Reduce';
+        expression => RakuAST::Term::Reduce.new(
+          triangle => False,
+          infix    => RakuAST::Infix.new("+"),
+          args     => RakuAST::ArgList.new(
+            RakuAST::Var::Lexical.new("\@a")
+          )
+        )
+    FRAG
+
+# --- triangle reduction sets triangle => True -------------------------------
+is Q[my @a; [\+] @a].AST.gist.contains('triangle => True'), True, '[\+] @a -> triangle => True';
+
+# --- the infix operator is carried through ----------------------------------
+is Q[my @a; [*] @a].AST.gist.contains('infix    => RakuAST::Infix.new("*")'), True,
+    '[*] @a -> Infix("*")';


### PR DESCRIPTION
## Summary

Phase 2 slice 25 of RakuAST (ADR-0011): the reduction metaoperator. `[+] @a` (`Expr::Reduction`) now maps to `Term::Reduce(triangle => False, infix => Infix("+"), args => ArgList(@a))`, instead of hitting the coverage boundary.

```
[+] @a   -> Term::Reduce(triangle => False, infix => Infix("+"),  args => ArgList(Var("@a")))
[\+] @a  -> Term::Reduce(triangle => True,  infix => Infix("+"),  args => ArgList(Var("@a")))
```

The triangle form `[\+] @a` (mutsu stores its op as `"\+"`) sets `triangle => True` with the backslash stripped from the infix.

## Tests

`t/rakuast-reduction.t` — 3 assertions (`[+]` full fragment, `[\+]` triangle, `[*]` infix), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)