### PR TITLE
feat: RakuAST Phase 2 slice 26 — hyper method calls

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -849,9 +849,12 @@ so it is tracked separately from the roast backlog.
         Tests in `t/rakuast-list-infix.t`.
   - [x] Slice 25: reduction metaoperator `[+]`/`[\+]` (`Term::Reduce`). Tests in
         `t/rakuast-reduction.t`.
-  - [ ] Slice 26+: attribute defaults (`Trait::WillBuild`), `Stmt::Label`-wrapped loops,
-        `.=` method-assign, coercion types (`Str()`), hyper `>>.method`; then `.DEPARSE`; resolve
-        the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu does not).
+  - [x] Slice 26: hyper method calls `@a>>.method` (`MetaPostfix::Hyper`). Tests in
+        `t/rakuast-hyper-method.t`.
+  - [ ] Slice 27+: attribute defaults (`Trait::WillBuild`), `Stmt::Label`-wrapped loops,
+        `.=` method-assign, coercion types (`Str()`), other hyper forms (`<<.m`, `>>+<<`); then
+        `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`,
+        mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -232,6 +232,11 @@ earlier ones.
   `Trait::WillBuild` in raku (not an `initializer`), so it is deferred, along with `is rw`, type
   smileys (`:D`), `is required`, `where`, aliases (`has $x`), `my`/`our` attributes, delegation, and
   other traits.
+- **Hyper method calls (Phase 2 slice 26).** `@a>>.abs` (`Expr::HyperMethodCall`) → `ApplyPostfix(
+  operand, postfix => MetaPostfix::Hyper(Call::Method(...)))` — the inner `Call::Method` /
+  `Call::QuotedMethod` is built by the same `method_call_postfix` helper as a plain method call, then
+  wrapped in a `MetaPostfix::Hyper`. Other hyper forms (`<<.m`, `>>.m<<`, hyper infix `>>+<<`) are
+  the boundary.
 - **Reduction metaoperator (Phase 2 slice 25).** `[+] @a` (`Expr::Reduction`) → `Term::Reduce(
   triangle => False, infix => Infix("+"), args => ArgList(@a))`. The triangle form `[\+] @a`
   (mutsu stores its op as `"\+"`) sets `triangle => True` with the backslash stripped from the infix.

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -780,21 +780,34 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
             modifier,
             quoted,
         } => {
-            // Plain `.method(...)` and modifier forms (`.?`/`.+`/`.*`, slice 15);
-            // and quoted names (`."foo"()`, slice 23) -> Call::QuotedMethod.
-            let postfix = if *quoted {
-                if modifier.is_some() {
-                    return Err(unsupported("quoted method name with a modifier"));
-                }
-                call_quoted_method(name.as_str(), args)?
-            } else {
-                call_method(name.as_str(), args, *modifier)?
-            };
+            let postfix = method_call_postfix(name.as_str(), args, *modifier, *quoted)?;
             Ok(RakuAstNode {
                 class: RakuAstClass::ApplyPostfix,
                 fields: vec![
                     node_field(Some("operand"), convert_expr(target)?),
                     node_field(Some("postfix"), postfix),
+                ],
+            })
+        }
+        // Hyper method call `@a>>.abs` -> ApplyPostfix(operand,
+        // postfix => MetaPostfix::Hyper(Call::Method(...))).
+        Expr::HyperMethodCall {
+            target,
+            name,
+            args,
+            modifier,
+            quoted,
+        } => {
+            let inner = method_call_postfix(name.as_str(), args, *modifier, *quoted)?;
+            let hyper = RakuAstNode {
+                class: RakuAstClass::MetaPostfixHyper,
+                fields: vec![node_field(None, inner)],
+            };
+            Ok(RakuAstNode {
+                class: RakuAstClass::ApplyPostfix,
+                fields: vec![
+                    node_field(Some("operand"), convert_expr(target)?),
+                    node_field(Some("postfix"), hyper),
                 ],
             })
         }
@@ -1185,6 +1198,25 @@ fn simple_parameter(
         class: RakuAstClass::Parameter,
         fields,
     })
+}
+
+/// The postfix `Call::Method` / `Call::QuotedMethod` node shared by plain and
+/// hyper method calls: a quoted name -> `Call::QuotedMethod` (no modifier), an
+/// unquoted name -> `Call::Method` (with an optional `.?`/`.+`/`.*` dispatch).
+fn method_call_postfix(
+    name: &str,
+    args: &[Expr],
+    modifier: Option<char>,
+    quoted: bool,
+) -> Result<RakuAstNode, RuntimeError> {
+    if quoted {
+        if modifier.is_some() {
+            return Err(unsupported("quoted method name with a modifier"));
+        }
+        call_quoted_method(name, args)
+    } else {
+        call_method(name, args, modifier)
+    }
 }
 
 /// `.method` / `.method(args)` -> `Call::Method(name => Name, [args => ArgList])`.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -69,6 +69,8 @@ pub enum RakuAstClass {
     CallMethod,
     // Phase 2 slice 23: quoted method names.
     CallQuotedMethod,
+    // Phase 2 slice 26: hyper method calls.
+    MetaPostfixHyper,
     // Phase 2 slice 3: blocks & pointy blocks.
     Block,
     Blockoid,
@@ -151,6 +153,7 @@ impl RakuAstClass {
             Assignment => "RakuAST::Assignment",
             CallMethod => "RakuAST::Call::Method",
             CallQuotedMethod => "RakuAST::Call::QuotedMethod",
+            MetaPostfixHyper => "RakuAST::MetaPostfix::Hyper",
             Block => "RakuAST::Block",
             Blockoid => "RakuAST::Blockoid",
             PointyBlock => "RakuAST::PointyBlock",

--- a/t/rakuast-hyper-method.t
+++ b/t/rakuast-hyper-method.t
@@ -1,0 +1,33 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 26 (ADR-0011): hyper method calls `@a>>.method`.
+# `@a>>.abs` -> ApplyPostfix(operand, postfix => MetaPostfix::Hyper(
+# Call::Method(...))). Expected gists captured verbatim from Rakudo; this file
+# passes under BOTH mutsu and raku.
+
+plan 3;
+
+# --- hyper method, no args --------------------------------------------------
+is Q[my @a; @a>>.abs].AST.gist.contains(q:to/FRAG/.chomp), True, 'hyper method -> MetaPostfix::Hyper';
+        expression => RakuAST::ApplyPostfix.new(
+          operand => RakuAST::Var::Lexical.new("\@a"),
+          postfix => RakuAST::MetaPostfix::Hyper.new(
+            RakuAST::Call::Method.new(
+              name => RakuAST::Name.from-identifier("abs")
+            )
+          )
+        )
+    FRAG
+
+# --- hyper method with an argument ------------------------------------------
+my $r = Q[my @a; @a>>.round(2)].AST.gist;
+ok $r.contains('postfix => RakuAST::MetaPostfix::Hyper.new(')
+    && $r.contains('RakuAST::Call::Method.new(')
+    && $r.contains('RakuAST::Name.from-identifier("round")')
+    && $r.contains('args => RakuAST::ArgList.new('),
+    'hyper method with args wraps a Call::Method + ArgList';
+
+# --- a plain method call is not hyper ---------------------------------------
+is Q[my $x; $x.abs].AST.gist.contains('MetaPostfix::Hyper'), False,
+    'plain method call is not wrapped in MetaPostfix::Hyper';


### PR DESCRIPTION
## Summary

Phase 2 slice 26 of RakuAST (ADR-0011): hyper method calls. `@a>>.abs` (`Expr::HyperMethodCall`) now maps to `ApplyPostfix(operand, postfix => MetaPostfix::Hyper(Call::Method(...)))`.

```
@a>>.abs   -> ApplyPostfix(operand => Var("@a"), postfix => MetaPostfix::Hyper(Call::Method(name => Name("abs"))))
@a>>.round(2) -> ...MetaPostfix::Hyper(Call::Method(name => Name("round"), args => ArgList(IntLiteral(2))))
```

The inner `Call::Method` / `Call::QuotedMethod` is built by the same `method_call_postfix` helper as a plain method call (now extracted and shared), then wrapped in a `MetaPostfix::Hyper`. Other hyper forms (`<<.m`, `>>.m<<`, hyper infix `>>+<<`) remain the boundary.

## Tests

`t/rakuast-hyper-method.t` — 3 assertions (hyper method fragment, hyper with args, plain method not hyper), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green (plain method calls unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)