### PR TITLE
feat: RakuAST Phase 2 slice 27 — attribute build-time defaults

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -851,10 +851,11 @@ so it is tracked separately from the roast backlog.
         `t/rakuast-reduction.t`.
   - [x] Slice 26: hyper method calls `@a>>.method` (`MetaPostfix::Hyper`). Tests in
         `t/rakuast-hyper-method.t`.
-  - [ ] Slice 27+: attribute defaults (`Trait::WillBuild`), `Stmt::Label`-wrapped loops,
-        `.=` method-assign, coercion types (`Str()`), other hyper forms (`<<.m`, `>>+<<`); then
-        `.DEPARSE`; resolve the constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`,
-        mutsu does not).
+  - [x] Slice 27: attribute build-time defaults `has $.x = 5` (`Trait::WillBuild` + initializer).
+        Tests in `t/rakuast-attribute-default.t`.
+  - [ ] Slice 28+: `Stmt::Label`-wrapped loops, `.=` method-assign, coercion types (`Str()`), other
+        hyper forms (`<<.m`, `>>+<<`), signature return types; then `.DEPARSE`; resolve the
+        constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu does not).
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -255,6 +255,11 @@ earlier ones.
   deferred: mutsu marks both `is_positional == false` with no `<>`-vs-`{}` distinction, so it cannot
   tell `<k>` (raku `LiteralHashIndex` + a word-quoted `QuotedString`) from `{"k"}` (raku
   `HashIndex` + `SemiList`).
+- **Attribute build-time defaults (Phase 2 slice 27).** An explicit `has $.x = 5` default (deferred
+  in slice 14) now emits BOTH a `traits => (Trait::WillBuild(5),)` field and an `initializer =>
+  Initializer::Assign(5)`, matching raku. The implicit `BareWord(<TypeName>)` default of a typed
+  attribute (`has Int $.z`) is still filtered out and produces neither. `var_declaration` gained a
+  `will_build` parameter for the trait.
 - **Ternary `?? !!` (Phase 2 slice 19).** `COND ?? THEN !! ELSE` (`Expr::Ternary`) →
   `Ternary(condition, then, else)`. raku constant-folds a literal-condition ternary (`1 ?? 2 !! 3`
   → `IntLiteral(2)`) while mutsu does not — the same const-fold divergence tracked in Open questions;

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -92,7 +92,7 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 .any(|(name, _)| name == "__has_initializer");
             let init = has_initializer.then_some(expr);
             Ok(Some(statement_expression(var_declaration(
-                name, init, scope, type_name, None,
+                name, init, scope, type_name, None, None,
             )?)))
         }
         // A bare `{ ... }` block at statement level -> Statement::Expression(Block).
@@ -464,14 +464,16 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             // *implicit* `BareWord(<TypeName>)` default that is NOT a will-build
             // and must be ignored. Traits, type smileys, `required`, `where`,
             // aliases, and `my`/`our` attributes are also deferred.
-            let has_explicit_default = match default {
-                None => false,
-                // The implicit type default: `BareWord` equal to the type name.
-                Some(Expr::BareWord(w)) => type_constraint.as_deref() != Some(w.as_str()),
-                Some(_) => true,
+            // A typed attribute (`has Int $.z`) carries an *implicit*
+            // `BareWord(<TypeName>)` default that is NOT a real default; an
+            // *explicit* `= EXPR` default (slice 27) is a `Trait::WillBuild` and
+            // an `initializer`.
+            let explicit_default = match default {
+                None => None,
+                Some(Expr::BareWord(w)) if type_constraint.as_deref() == Some(w.as_str()) => None,
+                Some(e) => Some(e),
             };
-            if has_explicit_default
-                || !handles.is_empty()
+            if !handles.is_empty()
                 || *is_rw
                 || type_smiley.is_some()
                 || is_required.is_some()
@@ -484,9 +486,7 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
                 || deprecated_message.is_some()
                 || !unknown_traits.is_empty()
             {
-                return Err(unsupported(
-                    "attribute with default / traits / smiley / scope",
-                ));
+                return Err(unsupported("attribute with traits / smiley / scope"));
             }
             // Definite attributes carry `type_smiley` (guarded above), so the
             // type_constraint here is a bare type; build_type_node handles it.
@@ -499,10 +499,11 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             };
             Ok(Some(statement_expression(var_declaration(
                 &full_name,
-                None,
+                explicit_default,
                 Some("has"),
                 type_name,
                 Some(twigil),
+                explicit_default,
             )?)))
         }
         Stmt::Assign { name, expr, op } => match op {
@@ -576,11 +577,12 @@ fn var_declaration(
     scope: Option<&'static str>,
     type_name: Option<&str>,
     twigil: Option<&str>,
+    will_build: Option<&Expr>,
 ) -> Result<RakuAstNode, RuntimeError> {
     let (sigil, desigil) = split_sigil(name);
-    // Field order matches raku: scope, type, sigil, twigil, desigilname,
-    // initializer — each omitted when absent (scope defaults to `my`; twigil is
-    // present only on attributes).
+    // Field order matches raku: scope, type, sigil, twigil, desigilname, traits,
+    // initializer — each omitted when absent (scope defaults to `my`; twigil and
+    // traits appear only on attributes).
     let mut fields = Vec::new();
     if let Some(s) = scope {
         fields.push(leaf_field(Some("scope"), Value::str(s.to_string())));
@@ -596,6 +598,18 @@ fn var_declaration(
         Some("desigilname"),
         name_from_identifier(desigil),
     ));
+    if let Some(wb) = will_build {
+        // An attribute default (`has $.x = 5`) is a `Trait::WillBuild` (and also
+        // an `initializer`, emitted below).
+        let trait_node = RakuAstNode {
+            class: RakuAstClass::TraitWillBuild,
+            fields: vec![node_field(None, convert_expr(wb)?)],
+        };
+        fields.push(RakuAstField {
+            name: Some("traits"),
+            value: RakuAstFieldValue::List(vec![Value::rakuast(Box::new(trait_node))]),
+        });
+    }
     if let Some(init_expr) = init {
         let assign = RakuAstNode {
             class: RakuAstClass::InitializerAssign,
@@ -1013,7 +1027,7 @@ fn loop_setup_node(stmt: &Stmt) -> Result<RakuAstNode, RuntimeError> {
             return Err(unsupported("scoped/typed variable declaration"));
         }
         let init = (!expr_is_nil(expr)).then_some(expr);
-        return var_declaration(name, init, None, None, None);
+        return var_declaration(name, init, None, None, None, None);
     }
     // Assignment / expression setups convert normally, then get unwrapped.
     let node = convert_stmt(stmt)?.ok_or_else(|| unsupported("empty loop setup clause"))?;

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -97,6 +97,8 @@ pub enum RakuAstClass {
     TypeSimple,
     // Phase 2 slice 20: definite types (`Int:D` / `Int:U`).
     TypeDefinedness,
+    // Phase 2 slice 27: attribute build-time defaults.
+    TraitWillBuild,
     // Phase 2 slice 21: parameterised types (`Array[Int]`).
     TypeParameterized,
     // Phase 2 slice 13: class and method declarations.
@@ -171,6 +173,7 @@ impl RakuAstClass {
             ApplyListInfix => "RakuAST::ApplyListInfix",
             TypeSimple => "RakuAST::Type::Simple",
             TypeDefinedness => "RakuAST::Type::Definedness",
+            TraitWillBuild => "RakuAST::Trait::WillBuild",
             TypeParameterized => "RakuAST::Type::Parameterized",
             Class => "RakuAST::Class",
             Method => "RakuAST::Method",

--- a/t/rakuast-attribute-default.t
+++ b/t/rakuast-attribute-default.t
@@ -1,0 +1,27 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 27 (ADR-0011): attribute build-time defaults.
+# `has $.x = 5` -> the `= 5` becomes BOTH a `traits => (Trait::WillBuild(5),)`
+# and an `initializer`. Expected gists captured verbatim from Rakudo; this file
+# passes under BOTH mutsu and raku. Distinct class names because `.AST`
+# registers the symbol.
+
+plan 3;
+
+# --- an attribute with a default gets a WillBuild trait + initializer --------
+my $g = Q[class D1 { has $.x = 5 }].AST.gist;
+ok $g.contains('traits      => (')
+    && $g.contains('RakuAST::Trait::WillBuild.new(')
+    && $g.contains('initializer => RakuAST::Initializer::Assign.new(')
+    && $g.comb(/'RakuAST::IntLiteral.new(5)'/).elems == 2,   # WillBuild + initializer
+    'has $.x = 5 -> WillBuild trait and initializer, both carrying 5';
+
+# --- a typed attribute with a default still works ---------------------------
+is Q[class D2 { has Int $.z = 10 }].AST.gist.contains('RakuAST::Trait::WillBuild.new('), True,
+    'has Int $.z = 10 -> WillBuild trait present';
+
+# --- a plain attribute (no default) has neither trait nor initializer --------
+my $plain = Q[class D3 { has $.y }].AST.gist;
+is $plain.contains('WillBuild') || $plain.contains('initializer'), False,
+    'has $.y -> no WillBuild, no initializer';


### PR DESCRIPTION
## Summary

Phase 2 slice 27 of RakuAST (ADR-0011): attribute build-time defaults. An explicit `has $.x = 5` default (deferred in slice 14) now emits BOTH a `traits => (Trait::WillBuild(5),)` field and an `initializer => Initializer::Assign(5)`, matching raku.

```
class C { has $.x = 5 }
  -> ...VarDeclaration::Simple(scope => "has", sigil => "$", twigil => ".", desigilname => Name("x"),
                              traits => (Trait::WillBuild(IntLiteral(5)),),
                              initializer => Initializer::Assign(IntLiteral(5)))
```

The implicit `BareWord(<TypeName>)` default of a typed attribute (`has Int $.z`) is still filtered out and produces neither. `var_declaration` gained a `will_build` parameter for the trait.

## Tests

`t/rakuast-attribute-default.t` — 3 assertions (default → WillBuild + initializer both carrying 5, typed attribute with default, plain attribute has neither), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green (attributes without defaults unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)