### PR TITLE
feat: RakuAST Phase 2 slice 28 — labelled repeat loops

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -853,9 +853,12 @@ so it is tracked separately from the roast backlog.
         `t/rakuast-hyper-method.t`.
   - [x] Slice 27: attribute build-time defaults `has $.x = 5` (`Trait::WillBuild` + initializer).
         Tests in `t/rakuast-attribute-default.t`.
-  - [ ] Slice 28+: `Stmt::Label`-wrapped loops, `.=` method-assign, coercion types (`Str()`), other
-        hyper forms (`<<.m`, `>>+<<`), signature return types; then `.DEPARSE`; resolve the
-        constant-folding divergence (`1+2` → raku folds to `IntLiteral(3)`, mutsu does not).
+  - [x] Slice 28: labelled `repeat` loops (`Stmt::Label`-wrapped). Tests in
+        `t/rakuast-labelled-repeat.t`.
+  - [ ] Slice 29+: `.=` method-assign, coercion types (`Str()`), other hyper forms (`<<.m`,
+        `>>+<<`), signature return types; then `.DEPARSE`; resolve the constant-folding divergence
+        (`1+2` → raku folds to `IntLiteral(3)`, mutsu does not). **NOTE: read-coverage tail is thin
+        — consider the `.DEPARSE`/Phase 3 pivot.**
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -178,9 +178,10 @@ earlier ones.
   binding (`if EXPR -> $v` / `elsif EXPR -> $v`) remain the coverage boundary (explicit
   `RuntimeError`), deferred to a later slice. Loop labels are handled (slice 17): a
   `LABEL: while/for/loop` prepends a `labels => (Label(name => "..."),)` field (raku renders labels
-  first). mutsu stores the label inline on `while`/`for`/bare-`loop`, but wraps a labelled `repeat`
-  (and C-style `loop`) in a separate `Stmt::Label` node it does not yet convert (C-style-labelled
-  does not even parse), so those remain the boundary. Implicit-topic `for`
+  first). mutsu stores the label inline on `while`/`for`/bare-`loop`; a labelled `repeat` is wrapped
+  in a separate `Stmt::Label { name, stmt }` node (slice 28) — the converter converts the inner
+  statement and prepends its `labels` field. A labelled C-style `loop` does not parse in mutsu yet,
+  so it remains the boundary. Implicit-topic `for`
   is handled (slice 6): `for SRC { ... }` (no explicit signature) → `Statement::For(mode =>
   "serial", source, body)` where the body is a topic-taking `Block` marked `implicit-topic => True`
   / `required-topic => 1`. `with`/`without` are NOT mappable — mutsu desugars them at parse time

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -516,6 +516,18 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             AssignOp::Bind => Ok(Some(statement_expression(bind_infix(name, expr)?))),
             AssignOp::MatchAssign => Err(unsupported("`~~` match-assignment")),
         },
+        // A `LABEL: STMT` wrapper (mutsu uses this for labelled `repeat`/C-style
+        // loops, where the inner loop's own `label` field is None). Convert the
+        // inner statement and prepend its `labels` field — raku renders labels
+        // first, matching the inline-label loops of slice 17.
+        Stmt::Label { name, stmt } => {
+            let mut node =
+                convert_stmt(stmt)?.ok_or_else(|| unsupported("labelled empty statement"))?;
+            let mut fields = label_fields(&Some(name.clone()));
+            fields.append(&mut node.fields);
+            node.fields = fields;
+            Ok(Some(node))
+        }
         other => Err(unsupported(&format!("{other:?}"))),
     }
 }

--- a/t/rakuast-labelled-repeat.t
+++ b/t/rakuast-labelled-repeat.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 28 (ADR-0011): labelled `repeat` loops.
+# mutsu wraps a labelled repeat/C-style loop in a `Stmt::Label` node (unlike
+# `while`/`for`/bare-`loop`, which store the label inline); the converter
+# prepends the `labels` field to the inner statement. Expected gist captured
+# verbatim from Rakudo; this file passes under BOTH mutsu and raku.
+
+plan 2;
+
+# --- labelled repeat-while --------------------------------------------------
+is Q[L: repeat { 1 } while 2].AST.gist, q:to/END/.chomp, 'labelled repeat -> labels first';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Loop::RepeatWhile.new(
+        labels    => (
+          RakuAST::Label.new(
+            name => "L"
+          ),
+        ),
+        body      => RakuAST::Block.new(
+          body => RakuAST::Blockoid.new(
+            RakuAST::StatementList.new(
+              RakuAST::Statement::Expression.new(
+                expression => RakuAST::IntLiteral.new(1)
+              )
+            )
+          )
+        ),
+        condition => RakuAST::IntLiteral.new(2)
+      )
+    )
+    END
+
+# --- the label name is carried through --------------------------------------
+is Q[OUTER: repeat { 1 } while 5].AST.gist.contains('name => "OUTER"'), True,
+    'labelled repeat carries its Label name';


### PR DESCRIPTION
## Summary

Phase 2 slice 28 of RakuAST (ADR-0011): labelled `repeat` loops. `L: repeat { } while X` now converts.

mutsu wraps a labelled repeat/C-style loop in a `Stmt::Label { name, stmt }` node (unlike `while`/`for`/bare-`loop`, which store the label inline, slice 17); the converter converts the inner statement and prepends its `labels` field, so raku's labels-first order is matched.

```
L: repeat { 1 } while 2
  -> Statement::Loop::RepeatWhile(labels => (Label(name => "L"),), body => ..., condition => ...)
```

A labelled C-style `loop` still does not parse in mutsu, so it remains the boundary.

## Tests

`t/rakuast-labelled-repeat.t` — 2 assertions (labelled repeat-while full gist, label name), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green (inline-labelled loops unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)