### PR TITLE
feat: RakuAST Phase 2 slice 29 — coercion types Int()

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -855,10 +855,13 @@ so it is tracked separately from the roast backlog.
         Tests in `t/rakuast-attribute-default.t`.
   - [x] Slice 28: labelled `repeat` loops (`Stmt::Label`-wrapped). Tests in
         `t/rakuast-labelled-repeat.t`.
-  - [ ] Slice 29+: `.=` method-assign, coercion types (`Str()`), other hyper forms (`<<.m`,
-        `>>+<<`), signature return types; then `.DEPARSE`; resolve the constant-folding divergence
-        (`1+2` → raku folds to `IntLiteral(3)`, mutsu does not). **NOTE: read-coverage tail is thin
-        — consider the `.DEPARSE`/Phase 3 pivot.**
+  - [x] Slice 29: coercion types `Int()` (`Type::Coercion`). Tests in `t/rakuast-type-coercion.t`.
+  - [ ] Slice 30+ / pivot: the clean read-coverage tail is essentially exhausted. Remaining Phase 2
+        candidates carry divergences or complications (`.=` desugars to `$x=$x.m`; hyper `<<.m`/
+        `>>+<<`; signature return types). Next major options: **`.DEPARSE`** (a second renderer that
+        regenerates Raku source from a RakuAST node) or **Phase 3** (type-object registry: make
+        nodes `~~ RakuAST::Node`-matchable with `.^name`/accessors). Resolve the constant-folding
+        divergence (`1+2` → raku folds to `IntLiteral(3)`) whichever way is chosen.
 - [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
       `use experimental :rakuast` gate.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -293,7 +293,8 @@ earlier ones.
   => True/False)` via the shared `build_type_node` helper. Parameterised types (slice 21):
   `Array[Int]` / `Hash[Str, Int]` → `Type::Parameterized(base-type => Type::Simple, args => ArgList(
   <type args>))`, with each argument built recursively by `build_type_node` (so nesting composes).
-  Coercion (`Str()`) and `:_` types still defer.
+  Coercion types (slice 29): `Int()` → `Type::Coercion(base-type => Type::Simple(Int))`; a coercion
+  with an explicit target (`Str(Int)`) and `:_` types still defer.
 - **Single-param pointy sigil loss (Phase 2 slice 3).** mutsu parses a single-parameter pointy
   block to `Expr::Lambda { param: String }` with the sigil stripped, and does not preserve `@`/`%`
   for a single non-scalar param (`-> @a` becomes `param: "a"`). The converter therefore assumes `$`

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -683,6 +683,17 @@ fn build_type_node(t: &str) -> Result<RakuAstNode, RuntimeError> {
             ],
         });
     }
+    // `Int()` coercion -> Type::Coercion(base-type). A coercion with an explicit
+    // target (`Str(Int)`) is deferred.
+    if let Some(base) = t.strip_suffix("()") {
+        if !is_simple_type(base) {
+            return Err(unsupported("coercion type over a non-simple base"));
+        }
+        return Ok(RakuAstNode {
+            class: RakuAstClass::TypeCoercion,
+            fields: vec![node_field(Some("base-type"), simple_type_node(base))],
+        });
+    }
     // `Array[Int]` / `Hash[Str, Int]` -> Type::Parameterized(base-type, args).
     if let Some(open) = t.find('[') {
         let inner = t

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -101,6 +101,8 @@ pub enum RakuAstClass {
     TraitWillBuild,
     // Phase 2 slice 21: parameterised types (`Array[Int]`).
     TypeParameterized,
+    // Phase 2 slice 29: coercion types (`Int()`).
+    TypeCoercion,
     // Phase 2 slice 13: class and method declarations.
     Class,
     Method,
@@ -175,6 +177,7 @@ impl RakuAstClass {
             TypeDefinedness => "RakuAST::Type::Definedness",
             TraitWillBuild => "RakuAST::Trait::WillBuild",
             TypeParameterized => "RakuAST::Type::Parameterized",
+            TypeCoercion => "RakuAST::Type::Coercion",
             Class => "RakuAST::Class",
             Method => "RakuAST::Method",
             Role => "RakuAST::Role",

--- a/t/rakuast-type-coercion.t
+++ b/t/rakuast-type-coercion.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+# RakuAST Phase 2 slice 29 (ADR-0011): coercion types `Int()`.
+# A `Base()` coercion maps to Type::Coercion(base-type => Type::Simple).
+# Expected gists captured verbatim from Rakudo; this file passes under BOTH
+# mutsu and raku. A coercion with an explicit target (`Str(Int)`) is deferred.
+
+plan 2;
+
+# --- `Int()` coercion -------------------------------------------------------
+is Q[my Int() $x].AST.gist, q:to/END/.chomp, 'Int() -> Type::Coercion(base-type)';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::VarDeclaration::Simple.new(
+          type        => RakuAST::Type::Coercion.new(
+            base-type => RakuAST::Type::Simple.new(
+              RakuAST::Name.from-identifier("Int")
+            )
+          ),
+          sigil       => "\$",
+          desigilname => RakuAST::Name.from-identifier("x")
+        )
+      )
+    )
+    END
+
+# --- the base type is a nested Type::Simple ---------------------------------
+is Q[my Str() $s].AST.gist.contains('base-type => RakuAST::Type::Simple.new('), True,
+    'coercion base is a Type::Simple';


### PR DESCRIPTION
## Summary

Phase 2 slice 29 of RakuAST (ADR-0011): coercion types. A `Base()` coercion (`my Int() $x`) now maps to `Type::Coercion(base-type => Type::Simple(Int))`, via the shared `build_type_node` helper.

```
my Int() $x
  -> ...type => Type::Coercion(base-type => Type::Simple(Name("Int")))...
```

A coercion with an explicit target (`Str(Int)`) and `:_` types still defer.

## Tests

`t/rakuast-type-coercion.t` — 2 assertions (`Int()` full gist, coercion base is a `Type::Simple`), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green — plain/definite/parameterised types are byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)