### PR TITLE
fix: raw stores for the is-rw element-arg writeback temps (JSON::Unmarshal 11/11)

### DIFF
--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -285,10 +285,17 @@ impl Compiler {
             let orig = format!("__mutsu_index_rw_orig_{}", self.code.constants.len());
             let tmp_idx = self.code.add_constant(Value::str(tmp.clone()));
             let orig_idx = self.code.add_constant(Value::str(orig.clone()));
+            // RAW stores: these compile-time-fixed temp names are re-used on
+            // every execution of this call site (each loop iteration). The
+            // element snapshot may be a promoted `ContainerRef` cell; a plain
+            // SetGlobal would then WRITE THROUGH the previous execution's cell
+            // (corrupting that element in its source hash/array — the
+            // `%args{$k} := f(%j{$k})` loop clobbered `%j` at the first key
+            // with each later iteration's value) instead of replacing the temp.
             self.code.emit(OpCode::Dup);
-            self.code.emit(OpCode::SetGlobal(tmp_idx));
+            self.code.emit(OpCode::SetGlobalRaw(tmp_idx));
             self.code.emit(OpCode::Dup);
-            self.code.emit(OpCode::SetGlobal(orig_idx));
+            self.code.emit(OpCode::SetGlobalRaw(orig_idx));
             self.pending_index_rw_writebacks
                 .push((arg.clone(), tmp.clone(), orig.clone()));
             let name_idx = self.code.add_constant(Value::str(tmp));
@@ -349,10 +356,12 @@ impl Compiler {
                 is_positional,
             } = &index_expr
             {
-                // Save the call result
+                // Save the call result. RAW store — same fixed-name reuse
+                // hazard as the arg/orig temps above: a cell-valued result
+                // must replace the temp, not write through a stale cell.
                 let result_tmp = format!("__mutsu_call_result_{}", self.code.constants.len());
                 let result_idx = self.code.add_constant(Value::str(result_tmp));
-                self.code.emit(OpCode::SetGlobal(result_idx));
+                self.code.emit(OpCode::SetGlobalRaw(result_idx));
 
                 // Compare current temp value with original value.
                 // If they're identical (===), skip writeback.

--- a/t/index-rw-arg-temp-reuse.t
+++ b/t/index-rw-arg-temp-reuse.t
@@ -1,0 +1,45 @@
+use Test;
+
+plan 6;
+
+# The `is rw` element-arg writeback temps (`__mutsu_index_rw_arg_N`) are
+# compile-time-fixed global names, re-used on every execution of the call
+# site. Storing the element snapshot with a write-through SetGlobal wrote
+# each later loop iteration's value THROUGH the previous iteration's
+# promoted element cell, corrupting the source hash at the first key
+# (JSON::Unmarshal 040 "DateTime as a definite": %json degraded to an Int).
+
+sub f($x) { $x }
+
+{
+    my %j = a => 1, b => 2, c => 3;
+    my %args;
+    for <a b c> -> $k {
+        %args{$k} := f(%j{$k});
+    }
+    is-deeply %j, {a => 1, b => 2, c => 3}, 'source hash intact after bind loop';
+    is-deeply %args, {a => 1, b => 2, c => 3}, 'target hash bound correctly';
+}
+
+# Same shape with an array source.
+{
+    my @src = 10, 20, 30;
+    my @out;
+    for 0, 1, 2 -> $i {
+        @out[$i] := f(@src[$i]);
+    }
+    is-deeply @src, [10, 20, 30], 'source array intact after bind loop';
+    is-deeply @out, [10, 20, 30], 'target array bound correctly';
+}
+
+# A genuine `is rw` element arg must still write back.
+{
+    sub bump($x is rw) { $x++ }
+    my %h = n => 5;
+    bump(%h<n>);
+    is %h<n>, 6, 'is rw element writeback still works';
+
+    my @a = 1, 2;
+    for 0, 1 -> $i { bump(@a[$i]) }
+    is-deeply @a, [2, 3], 'is rw element writeback in a loop';
+}


### PR DESCRIPTION
## Summary

Root-causes and fixes the last JSON::Unmarshal failure (040-types subtest 12, "DateTime as a definite") — **the suite is now 11/11 files, 101/101 subtests**.

The `is rw` element-argument writeback machinery snapshots `%h{$k}`-style call arguments into compile-time-fixed global temps (`__mutsu_index_rw_arg_N` / `__mutsu_index_rw_orig_N` / `__mutsu_call_result_N`). When the element had been promoted to a `ContainerRef` cell (an element passed as an argument inside a `:=` bind RHS), the next execution of the same call site — e.g. the next loop iteration — stored its snapshot with a plain `SetGlobal`, which took the write-through-existing-cell arm: it wrote the new iteration's value **through the previous iteration's cell**, corrupting the source container at the first key. The env entry kept pointing at the stale cell, so every later iteration clobbered that same element (last value wins):

```raku
my %j = a => 1, b => 2; my %args;
sub f($x) { $x }
for <a b> -> $k { %args{$k} := f(%j{$k}) }
# before: %j ended as {:a(2), :b(2)} — now stays {:a(1), :b(2)}
```

Fix: emit `SetGlobalRaw` for these internal temps so each execution replaces the snapshot instead of writing through it. Genuine `is rw` element writeback is unchanged (identity/eqv guards + explicit IndexAssign writeback still run).

In JSON::Unmarshal this corrupted `%json` inside the ClassLike `_unmarshal` loop (`%args{$attr-name} := _unmarshal(%json{$json-name}, ...)`), degrading the hash to an Int after the first attribute — only `hour` survived into the DateTime.

## Test plan

- New pin `t/index-rw-arg-temp-reuse.t` (raku-verified): hash/array bind loops keep sources intact; `is rw` element writeback (single and looped) still works.
- `make test` PASS; roast subset (54 files: S06 signature/multi, S09 subscript, 99problems-21) PASS.
- JSON::Unmarshal dist suite: 11/11 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)