### PR TITLE
feat(assuming): reflect priming in a curried sub's signature

### DIFF
--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -462,20 +462,50 @@ impl Interpreter {
                 }
             }
         }
-        // When .assuming() is used with named args, all named params lose their
-        // defaults and where constraints in the signature display.
-        // Assumed params additionally become non-required.
-        if !assumed_named.is_empty() {
-            for pd in &mut param_defs {
-                if pd.named {
-                    pd.default = None;
-                    pd.where_constraint = None;
-                    if assumed_named.contains_key(&pd.name) {
-                        pd.required = false;
-                    }
-                }
+        // When .assuming() binds a named argument, that parameter is shown in
+        // the primed signature with the bound value as its default (and becomes
+        // optional, dropping any `!`). Named parameters that were NOT primed
+        // keep their original state, including their own defaults. A named
+        // parameter can be bound by any of its alias names (`:b(:c($a))` binds
+        // to either `b` or `c`).
+        for pd in &mut param_defs {
+            if pd.named
+                && let Some(value) = assumed_named_binding(pd, assumed_named)
+            {
+                pd.default = Some(crate::ast::Expr::Literal(value));
+                pd.required = false;
+                pd.optional_marker = false;
+                pd.where_constraint = None;
             }
         }
         Some(param_defs)
     }
+}
+
+/// Returns the bound value if `.assuming` primed this named parameter, matching
+/// on the parameter's primary name or any of its alias names (`:b(:c($a))` can
+/// be bound as either `b` or `c`). Mirrors `collect_named_names`: only nested
+/// named sub-signature params contribute alias names.
+fn assumed_named_binding(
+    pd: &ParamDef,
+    assumed_named: &std::collections::HashMap<String, Value>,
+) -> Option<Value> {
+    fn strip_sigil(name: &str) -> &str {
+        name.strip_prefix(['@', '%', '&']).unwrap_or(name)
+    }
+    if let Some(v) = assumed_named.get(strip_sigil(&pd.name)) {
+        return Some(v.clone());
+    }
+    let mut cur = pd;
+    while cur.named
+        && let Some(subs) = &cur.sub_signature
+        && subs.len() == 1
+        && subs[0].named
+    {
+        cur = &subs[0];
+        if let Some(v) = assumed_named.get(strip_sigil(&cur.name)) {
+            return Some(v.clone());
+        }
+    }
+    None
 }

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -449,6 +449,18 @@ impl Interpreter {
                         || matches!(v.view(), ValueView::Num(f) if f.is_infinite())
                         || matches!(v.view(), ValueView::Rat(_, 0))
                 };
+                // Type captures (`::T $a`) are declared by one parameter and
+                // referenced by later ones as a bare `T`, which is not a real
+                // type. Rakudo defers checking such capture-constrained params at
+                // priming time, so collect the declared capture names and skip
+                // them below (checking against the literal "T" would spuriously
+                // fail the bind).
+                let capture_decls: std::collections::HashSet<&str> = next
+                    .param_defs
+                    .iter()
+                    .filter_map(|pd| pd.type_constraint.as_deref())
+                    .filter_map(|t| t.strip_prefix("::"))
+                    .collect();
                 for (pos_idx, pd) in next
                     .param_defs
                     .iter()
@@ -469,6 +481,7 @@ impl Interpreter {
                     }
                     if let Some(constraint) = &pd.type_constraint
                         && !constraint.starts_with("::")
+                        && !capture_decls.contains(constraint.as_str())
                         && !self.type_matches_value(constraint, assumed)
                     {
                         // Add $ sigil to the symbol name if it's bare

--- a/t/assuming-signature-gist.t
+++ b/t/assuming-signature-gist.t
@@ -1,0 +1,60 @@
+use Test;
+
+# A primed (`.assuming`) sub's signature reflects the priming: a bound named
+# parameter is shown with the bound value as its default and becomes optional;
+# unprimed named parameters keep their own state.
+
+plan 15;
+
+sub named2(:$a, :$b) {}
+is &named2.assuming(:a).signature.gist, '(:$a = Bool::True, :$b)',
+    'primed named param shows bound value as default';
+is &named2.assuming(:b).signature.gist, '(:$a, :$b = Bool::True)',
+    'unprimed named param keeps its state';
+
+sub required(:$a!) {}
+is &required.assuming(:a).signature.gist, '(:$a = Bool::True)',
+    'required named loses its ! when primed';
+
+sub withdefault(:$a = 2, :$b = 4) {}
+is &withdefault.assuming(:a).signature.gist, '(:$a = Bool::True, :$b = 4)',
+    'primed value replaces the original default; other keeps it';
+
+sub nonbool(:$a) {}
+is &nonbool.assuming(a => 42).signature.gist, '(:$a = 42)',
+    'bound value other than True is rendered';
+
+# Alias names: :b(:c($a)) can be bound by either b or c.
+sub aliased(:b(:c($a))!) {}
+is &aliased.assuming(:b).signature.gist, '(:b(:c($a)) = Bool::True)',
+    'primed by primary alias name';
+is &aliased.assuming(:c).signature.gist, '(:b(:c($a)) = Bool::True)',
+    'primed by nested alias name';
+
+# Positional priming removes consumed params and resolves type captures.
+sub caps(::T $a, T $b, T :$c) {}
+is &caps.assuming(1, 1).signature.gist, '(Int :$c)',
+    'type capture resolves for the remaining named param';
+
+my $primed = &caps.assuming(1, 1);
+nok $primed.can('Failure'), 'valid type-capture priming does not fail the bind';
+
+# Rakudo defers type-capture constraint checks, so priming a capture-constrained
+# param with a mismatching value does NOT fail at priming time.
+sub caps2(::T $a, T $b) {}
+nok &caps2.assuming(1, "x").can('Failure'),
+    'capture-constrained bind is deferred, not eagerly failed';
+
+# A genuine (non-capture) positional type mismatch still fails the bind.
+sub typed(Int $a) {}
+ok &typed.assuming("str").can('Failure'), 'real type mismatch fails the bind';
+nok &typed.assuming(3).can('Failure'), 'matching positional binds fine';
+
+# Priming still calls through correctly.
+sub add($x, $y) { $x + $y }
+is &add.assuming(10)(5), 15, 'primed positional then called';
+
+sub greet(:$greeting = "Hi", :$name) { "$greeting, $name!" }
+is &greet.assuming(:greeting<Yo>)(:name<Bee>), "Yo, Bee!", 'primed named then called';
+is &greet.assuming(:name<Ann>).signature.gist, '(:$greeting = "Hi", :$name = "Ann")',
+    'string default preserved, primed name defaulted';


### PR DESCRIPTION
A `.assuming`-primed sub's `.signature` now reflects the priming, matching Rakudo's RakuAST currying. This is a pure addition: the `roast/S06-currying/*.t` tests previously carried `#?rakudo todo` markers for these cases, which upstream removes.

## What changed

- **Bound named parameters render with the bound value as their default** and become optional:
  - `sub (:$a) {}.assuming(:a).signature` → `:(:$a = Bool::True)`
  - `.assuming(a => 42)` → `:(:$a = 42)`
  - Required `:$a!` loses its `!` when primed.
  - **Unprimed** named parameters keep their own state and defaults (previously *all* named defaults were cleared).
- **Alias-name priming**: a named parameter can be bound by any of its alias names — `sub (:b(:c($a))!) {}` binds by either `b` or `c` (new `assumed_named_binding`, mirroring `collect_named_names`).
- **Type-capture references are deferred**: positional priming no longer eagerly fails a parameter constrained by a bare type-capture reference (`T` where `::T` is declared elsewhere). Rakudo defers these, so `sub (::T $a, T $b) {}.assuming(1, "x")` does not fail at priming time. Genuine (non-capture) type mismatches still fail the bind.

## Tests

- All five `roast/S06-currying/*.t` (named/slurpy/misc/positional/assuming-and-mmd) pass against the current upstream versions.
- New pin: `t/assuming-signature-gist.t` (15 cases).
- `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)