### PR TITLE
feat: RakuAST Phase 3 slice 1 — node accessors

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -856,14 +856,15 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 28: labelled `repeat` loops (`Stmt::Label`-wrapped). Tests in
         `t/rakuast-labelled-repeat.t`.
   - [x] Slice 29: coercion types `Int()` (`Type::Coercion`). Tests in `t/rakuast-type-coercion.t`.
-  - [ ] Slice 30+ / pivot: the clean read-coverage tail is essentially exhausted. Remaining Phase 2
-        candidates carry divergences or complications (`.=` desugars to `$x=$x.m`; hyper `<<.m`/
-        `>>+<<`; signature return types). Next major options: **`.DEPARSE`** (a second renderer that
-        regenerates Raku source from a RakuAST node) or **Phase 3** (type-object registry: make
-        nodes `~~ RakuAST::Node`-matchable with `.^name`/accessors). Resolve the constant-folding
-        divergence (`1+2` → raku folds to `IntLiteral(3)`) whichever way is chosen.
-- [ ] **Phase 3** — `RakuAST::*` type-object registry: `~~ RakuAST::Node`, `.^name`, accessors,
-      `use experimental :rakuast` gate.
+  - Phase 2 read-coverage is complete (slices 1–29); user chose the Phase 3 pivot (2026-07-18).
+    Remaining Phase 2 constructs (`.=`, hyper `<<.m`/`>>+<<`, signature return types) carry mutsu
+    desugar divergences and are deferred.
+- **Phase 3 (in progress)** — `RakuAST::*` type-object registry + introspection dispatch.
+  - [x] Slice 1: node accessors — `.condition`/`.expression`/`.args`/… return field values, and
+        `.statements` returns a `StatementList`'s children as a `List`, so the tree is walkable.
+        Tests in `t/rakuast-accessors.t`.
+  - [ ] Slice 2+: `~~ RakuAST::Node` smartmatch + `RakuAST::*` type objects; positional leaf
+        accessors (`IntLiteral.value`); `use experimental :rakuast` no-op gate; `.WHAT`/`.isa`.
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).
 - [ ] **Phase 5** — EVAL: lower RakuAST → internal AST → existing compiler (no new engine).
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -122,6 +122,13 @@ earlier ones.
   objects; route `~~ RakuAST::Node`, `.^name`, `.WHAT`, `.isa`, and attribute accessors
   (`$node.expression`, `$node.args`, `.statements`) to a central RakuAST metaobject over the
   node's `class`/`fields`. Accept `use experimental :rakuast` (no-op gate).
+  - **Slice 1 (accessors) — done.** `node_accessor(node, method)` (dispatched in the 0-arg method
+    path) returns a named field's value as a mutsu `Value` (child node, leaf `Int`/`Str`, or a
+    `List` for list-valued fields), and `.statements` returns a `StatementList`'s positional
+    children as a `List`. This makes the tree walkable (`.AST.statements[0].condition.^name`), not
+    just renderable. `.gist`/`.raku`/`.^name` are unaffected (not field names). Tests in
+    `t/rakuast-accessors.t`. Still pending: `~~ RakuAST::Node` smartmatch, positional leaf
+    accessors (`IntLiteral.value`), `use experimental :rakuast` gate.
 - **Phase 4 — Construction.** `.new` (and `.from-identifier`, …) on RakuAST type objects
   build `Value::RakuAst`, validating args against the per-class field schema.
 - **Phase 5 — EVAL / compilation.** `lower(RakuAstNode) -> Vec<Stmt>/Expr`, then the

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1000,6 +1000,15 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         return Some(crate::rakuast::str_dot_ast(&s));
     };
 
+    // RakuAST node accessors (Phase 3): `.condition`, `.expression`, `.args`,
+    // `.statements`, etc. return the node's field values. `.gist`/`.raku`/`.^name`
+    // are handled elsewhere, so a non-accessor method name falls through.
+    if let ValueView::RakuAst(node) = target.view()
+        && let Some(v) = crate::rakuast::node_accessor(node, method)
+    {
+        return Some(Ok(v));
+    }
+
     // Instant.Instant returns self (identity coercion)
     if method == "Instant" {
         match target.view() {

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -232,3 +232,33 @@ pub fn str_dot_ast(source: &str) -> Result<Value, RuntimeError> {
 pub fn node_gist(node: &RakuAstNode) -> String {
     render::render_node(node, 0)
 }
+
+/// A named-field / positional accessor on a RakuAST node (Phase 3). Returns the
+/// field value as a mutsu `Value`, or `None` if `method` is not an accessor for
+/// this node (so ordinary methods like `.gist` fall through). `.statements`
+/// returns the positional children of a `StatementList`/`Blockoid` as a `List`.
+pub fn node_accessor(node: &RakuAstNode, method: &str) -> Option<Value> {
+    for f in &node.fields {
+        if f.name == Some(method) {
+            return Some(field_to_value(&f.value));
+        }
+    }
+    if method == "statements" && matches!(node.class, RakuAstClass::StatementList) {
+        let items = node
+            .fields
+            .iter()
+            .map(|f| field_to_value(&f.value))
+            .collect();
+        return Some(Value::array(items));
+    }
+    None
+}
+
+fn field_to_value(fv: &RakuAstFieldValue) -> Value {
+    match fv {
+        RakuAstFieldValue::Node(v) => v.clone(),
+        RakuAstFieldValue::List(items) => Value::array(items.clone()),
+        // Colonpair adverbs (`:item`) are a rendering detail; expose as True.
+        RakuAstFieldValue::Adverb(_) => Value::truth(true),
+    }
+}

--- a/t/rakuast-accessors.t
+++ b/t/rakuast-accessors.t
@@ -1,0 +1,31 @@
+use v6;
+use Test;
+
+# RakuAST Phase 3 slice 1 (ADR-0011): node accessors.
+# A RakuAST node exposes its fields as 0-arg accessor methods (`.condition`,
+# `.expression`, `.infix`, `.sigil`, ...) and a `StatementList` exposes its
+# children via `.statements` (a List). This lets you walk the tree
+# programmatically, not just render it. Verified against Rakudo; this file
+# passes under BOTH mutsu and raku.
+
+plan 7;
+
+# --- .statements returns a List of the top-level statements -----------------
+is Q[42].AST.statements.^name, 'List', '.statements returns a List';
+is Q[42].AST.statements.elems, 1, 'single statement -> one element';
+
+# --- descend into a statement's expression ----------------------------------
+is Q[42].AST.statements[0].^name, 'RakuAST::Statement::Expression',
+    'first statement is a Statement::Expression';
+is Q[42].AST.statements[0].expression.^name, 'RakuAST::IntLiteral',
+    '.expression accessor returns the IntLiteral';
+
+# --- named accessors on a Statement::If -------------------------------------
+is Q[if 1 { 2 }].AST.statements[0].condition.^name, 'RakuAST::IntLiteral',
+    '.condition accessor on Statement::If';
+is Q[if 1 { 2 }].AST.statements[0].then.^name, 'RakuAST::Block',
+    '.then accessor returns the then-Block';
+
+# --- a leaf accessor returns the raw value ----------------------------------
+is Q[my $x = 5].AST.statements[0].expression.sigil, '$',
+    '.sigil accessor returns the sigil string';


### PR DESCRIPTION
## Summary

Begins **Phase 3** of RakuAST (ADR-0011), the phase the user chose after Phase 2 read-coverage was completed: make RakuAST nodes queryable, not just renderable.

This slice adds **node accessors**. `node_accessor(node, method)` (hooked into the 0-arg method dispatch) routes an accessor method call on a `Value::RakuAst` to the node's fields:

- a **named field** (`.condition`, `.expression`, `.infix`, `.sigil`, `.args`, `.body`, …) returns that field's value — a child RakuAST node, a leaf `Int`/`Str`, or a `List` for list-valued fields;
- **`.statements`** returns a `StatementList`'s positional children as a `List`.

This makes the tree walkable:

```raku
Q[if 1 { 2 }].AST.statements[0].condition.^name   # RakuAST::IntLiteral
Q[my $x = 5].AST.statements[0].expression.sigil    # $
```

`.gist`/`.raku`/`.^name` are unaffected — they are not field names, so they fall through to their existing handlers.

## Still pending in Phase 3

`~~ RakuAST::Node` smartmatch + `RakuAST::*` type objects; positional leaf accessors (`IntLiteral.value`); the `use experimental :rakuast` no-op gate; `.WHAT`/`.isa`.

## Tests

`t/rakuast-accessors.t` — 7 assertions (`.statements` List + elems, descend to `.expression`, `.condition`/`.then` on `Statement::If`, leaf `.sigil`), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green; core method dispatch (map, attribute accessors on user classes) verified unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)