### PR TITLE
feat: allow `but` role mixin on class type objects

### DIFF
--- a/src/vm/vm_mixin_does_ops.rs
+++ b/src/vm/vm_mixin_does_ops.rs
@@ -34,7 +34,13 @@ impl Interpreter {
             _ => None,
         };
         if let Some(composed) = role_composed {
-            if let Some(tn) = &left_type_object {
+            // A role type object invocant has a ParametricRoleGroupHOW with no
+            // `mixin` metamethod (X::Method::NotFound). A *class* type object
+            // (builtin or user, incl. parametric like Array[Int]) is fine:
+            // `Int but R` creates the mixin type object `Int+{R}`.
+            if let Some(tn) = &left_type_object
+                && self.is_role_type_name(tn)
+            {
                 return Err(self.but_on_type_object_error(tn));
             }
             let composed = composed?;

--- a/t/but-on-role-type.t
+++ b/t/but-on-role-type.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 7;
+plan 11;
 
 # Applying `but` to a role type object carries a ParametricRoleGroupHOW, which
 # has no `mixin` metamethod, so raku reports X::Method::NotFound (NOT
@@ -27,11 +27,23 @@ throws-like 'Callable does role :: { }',
     X::Does::TypeObject,
     'does on a role type object stays X::Does::TypeObject';
 
-# `but` on a non-role (class) type object is a different, unimplemented feature
-# (anonymous subtype creation); it remains X::Does::TypeObject for now.
-throws-like 'my \x = Int but role :: { }',
-    X::Does::TypeObject,
-    'but on a class type object stays X::Does::TypeObject';
+# `but` on a non-role (class) type object creates a mixin type object
+# (`Int+{R}`), including parametric type objects like Array[Int].
+{
+    my \x = Int but role { method answer { 42 } };
+    is x.answer, 42, 'but on a class type object creates a mixin type object';
+    nok x.defined, 'the mixin type object is undefined';
+}
+{
+    my role Tagged { method tag { "tagged" } }
+    my constant T = Array[Int] but Tagged;
+    is T.^name, 'Array[Int]+{Tagged}',
+        'parametric base name is preserved in ^name';
+    my $a = T.new;
+    $a.push(5);
+    is $a.tag, 'tagged', 'instances made from the mixin type do the role';
+    is $a[0], 5, 'and keep the base type behavior';
+}
 
 # `but` mixing a concrete value into a type object is unaffected.
 lives-ok { my \x = Int but True; }, 'but with a concrete value still works';

--- a/t/does-but-type-errors.t
+++ b/t/does-but-type-errors.t
@@ -9,8 +9,11 @@ throws-like '(my $foo) does Int, Bool', X::Does::TypeObject,
     'does with a type-object list on a type object is illegal';
 throws-like 'Bool does role { method Str() { $.raku } }', X::Does::TypeObject,
     'does on the Bool type object is illegal';
-throws-like 'Int but role { method foo { 1 } }', X::Does::TypeObject,
-    'but on the Int type object is illegal';
+# `but` on a class type object is legal: it creates a mixin type object.
+{
+    my $t = Int but role { method foo { 1 } };
+    is $t.foo, 1, 'but on the Int type object creates a mixin type object';
+}
 
 # Mixing a non-composable type (a class / type object, not a role or a
 # concrete value) into a concrete object is illegal.


### PR DESCRIPTION
## Summary
- `Type but Role` on a *class* type object (builtin, user-defined, or parametric like `Array[META6]`) now creates a mixin type object instead of throwing X::Does::TypeObject, matching rakudo (`(Int but R).^name` → `Int+{R}`; `.new` instances do the role).
- The guard in `exec_but_mixin_op` now only rejects **role** type-object invocants (X::Method::NotFound via ParametricRoleGroupHOW, unchanged) — `does` on any type object stays X::Does::TypeObject.
- Updated the two local pins that had intentionally pinned the old "unimplemented feature" behavior (`t/but-on-role-type.t`, `t/does-but-type-errors.t`) with positive tests, including the parametric `Array[Int] but Role` shape.

## Motivation
META6 (mzef Test-phase frontier) `t/040-projects.t` aborted at CHECK with `Cannot use 'but' operator on a type object Array[META6]` on `my constant Projects = Array[META6] but JSON::Class;`. With this fix the file goes from abort to **908/908 pass**.

## Testing
- `make test` full PASS (17979 tests)
- Roast sweep of whitelisted `S14-roles/*` + `S12-construction/*` (32 files, 533 tests) PASS
- raku parity checked for `Int but R`, `Array[Int] but R`, undefined-scalar (`Any`) invocant, `Callable but R` (still X::Method::NotFound), `does` cases (still X::Does::TypeObject)

🤖 Generated with [Claude Code](https://claude.com/claude-code)