### PR TITLE
feat: RakuAST Phase 3 slice 2 — smartmatch type hierarchy

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -863,8 +863,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 1: node accessors — `.condition`/`.expression`/`.args`/… return field values, and
         `.statements` returns a `StatementList`'s children as a `List`, so the tree is walkable.
         Tests in `t/rakuast-accessors.t`.
-  - [ ] Slice 2+: `~~ RakuAST::Node` smartmatch + `RakuAST::*` type objects; positional leaf
-        accessors (`IntLiteral.value`); `use experimental :rakuast` no-op gate; `.WHAT`/`.isa`.
+  - [x] Slice 2: `~~ RakuAST::Node` / `.isa` hierarchy — base `RakuAST::Node` + `::`-namespace
+        ancestors (`Statement::If isa RakuAST::Statement`). Tests in `t/rakuast-smartmatch.t`.
+        (`use experimental :rakuast` already parsed as a no-op.)
+  - [ ] Slice 3+: positional leaf accessors (`IntLiteral.value`); the semantic Expression/Term
+        hierarchy (`IntLiteral isa RakuAST::Expression`); registering `RakuAST::*` as first-class
+        type objects; `.WHAT`. Then Phase 4 (construction), Phase 5 (EVAL).
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).
 - [ ] **Phase 5** — EVAL: lower RakuAST → internal AST → existing compiler (no new engine).
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -127,8 +127,16 @@ earlier ones.
     `List` for list-valued fields), and `.statements` returns a `StatementList`'s positional
     children as a `List`. This makes the tree walkable (`.AST.statements[0].condition.^name`), not
     just renderable. `.gist`/`.raku`/`.^name` are unaffected (not field names). Tests in
-    `t/rakuast-accessors.t`. Still pending: `~~ RakuAST::Node` smartmatch, positional leaf
-    accessors (`IntLiteral.value`), `use experimental :rakuast` gate.
+    `t/rakuast-accessors.t`.
+  - **Slice 2 (smartmatch hierarchy) — done.** `$node ~~ RakuAST::TypeName` and `.isa(...)` now
+    honour the RakuAST hierarchy: `isa_check` returns true for the base `RakuAST::Node` (any node)
+    and for any `::`-namespace ancestor of the node's printed class (`Statement::If isa
+    RakuAST::Statement`); the `::` boundary avoids a false `StatementList isa Statement`. The
+    smartmatch path was already routing exact-class matches through `isa_check`; `type_matches_value`
+    now delegates `RakuAST::*` constraints to `isa_check` instead of the static name table. Tests in
+    `t/rakuast-smartmatch.t`. Still pending: the semantic `IntLiteral isa RakuAST::Expression`
+    hierarchy (needs a per-class ancestor table), positional leaf accessors (`IntLiteral.value`),
+    registering `RakuAST::*` as first-class type objects (they currently resolve as bare type names).
 - **Phase 4 — Construction.** `.new` (and `.from-identifier`, …) on RakuAST type objects
   build `Value::RakuAst`, validating args against the per-class field schema.
 - **Phase 5 — EVAL / compilation.** `lower(RakuAstNode) -> Vec<Stmt>/Expr`, then the

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -1112,6 +1112,12 @@ impl Interpreter {
                 }
             }
         }
+        // RakuAST nodes carry their own hierarchy (base `RakuAST::Node`, plus
+        // `::`-namespace ancestors); route through `isa_check` rather than the
+        // static `type_matches` name table (Phase 3).
+        if matches!(value.view(), ValueView::RakuAst(_)) && constraint.starts_with("RakuAST::") {
+            return value.isa_check(constraint);
+        }
         // For Package (type object) values, use the package name as the type
         // so that e.g. Junction (which is Mu, not Any) is correctly rejected
         // when the constraint is Any.

--- a/src/value/types_isa.rs
+++ b/src/value/types_isa.rs
@@ -144,6 +144,21 @@ impl Value {
         if my_type == type_name {
             return true;
         }
+        // RakuAST node hierarchy (Phase 3): every node isa `RakuAST::Node`, and a
+        // node isa any `::`-namespace ancestor of its printed class name (e.g.
+        // `Statement::If` isa `RakuAST::Statement`). The `::` boundary avoids a
+        // false `StatementList isa Statement`. (The semantic Expression/Term
+        // hierarchy — `IntLiteral isa RakuAST::Expression` — is not yet modelled.)
+        if matches!(self.view(), ValueView::RakuAst(_)) {
+            if type_name == "RakuAST::Node" {
+                return true;
+            }
+            if let Some(rest) = my_type.strip_prefix(type_name)
+                && rest.starts_with("::")
+            {
+                return true;
+            }
+        }
         // The X::Await::Died role is mixed into the original exception when
         // `await` observes a broken Promise (see `await_died_error`): the cause
         // keeps its own class but also does X::Await::Died.

--- a/t/rakuast-smartmatch.t
+++ b/t/rakuast-smartmatch.t
@@ -1,0 +1,25 @@
+use v6;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 3 slice 2 (ADR-0011): the RakuAST type hierarchy under `~~`.
+# Every node isa RakuAST::Node; a node isa any `::`-namespace ancestor of its
+# class (Statement::If isa RakuAST::Statement). Verified against Rakudo; this
+# file passes under BOTH mutsu and raku.
+
+plan 6;
+
+# --- every node isa RakuAST::Node -------------------------------------------
+ok Q[42].AST ~~ RakuAST::Node, 'a StatementList isa RakuAST::Node';
+ok Q[42].AST.statements[0].expression ~~ RakuAST::Node, 'a leaf node isa RakuAST::Node';
+
+# --- exact class match ------------------------------------------------------
+ok Q[42].AST.statements[0].expression ~~ RakuAST::IntLiteral, 'IntLiteral ~~ RakuAST::IntLiteral';
+nok Q[42].AST.statements[0].expression ~~ RakuAST::StrLiteral, 'IntLiteral !~~ RakuAST::StrLiteral';
+
+# --- `::`-namespace ancestor ------------------------------------------------
+ok Q[if 1 { 2 }].AST.statements[0] ~~ RakuAST::Statement,
+    'Statement::If isa RakuAST::Statement';
+
+# --- the `::` boundary avoids a false StatementList ~~ Statement -------------
+nok Q[42].AST ~~ RakuAST::Statement, 'StatementList is NOT a RakuAST::Statement';


### PR DESCRIPTION
## Summary

Phase 3 slice 2 of RakuAST (ADR-0011): the RakuAST type hierarchy under `~~` / `.isa`. A RakuAST node now smartmatches its type ancestors, not just its exact class.

```raku
use experimental :rakuast;
Q[42].AST ~~ RakuAST::Node                         # True  (base)
Q[if 1 {2}].AST.statements[0] ~~ RakuAST::Statement # True  (Statement::If isa Statement)
Q[42].AST ~~ RakuAST::Statement                      # False (StatementList is not a Statement)
Q[42].AST.statements[0].expression ~~ RakuAST::IntLiteral  # True  (exact)
```

## Implementation

`isa_check` returns true for the base `RakuAST::Node` (any node) and for any `::`-namespace ancestor of the node's printed class name. The `::` boundary check avoids a false `StatementList isa Statement`. The smartmatch path already routed exact-class matches through `isa_check`; `type_matches_value` now delegates `RakuAST::*` constraints to `isa_check` instead of the static name-hierarchy table, so the base/ancestor checks reach `~~` too.

## Still pending in Phase 3

The semantic `IntLiteral isa RakuAST::Expression` hierarchy (needs a per-class ancestor table); positional leaf accessors (`IntLiteral.value`); registering `RakuAST::*` as first-class type objects. (`use experimental :rakuast` already parses as a no-op.)

## Tests

`t/rakuast-smartmatch.t` — 6 assertions (Node base for two node kinds, exact match + non-match, `Statement` ancestor, StatementList-not-Statement boundary), **passing under BOTH mutsu and raku**. Core type-checks (`5 ~~ Int`, `~~ Numeric`, `~~ Positional`) and all `t/rakuast-*.t` verified unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)