### PR TITLE
feat: RakuAST Phase 3 slice 3 — positional-leaf accessors

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -866,9 +866,11 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 2: `~~ RakuAST::Node` / `.isa` hierarchy — base `RakuAST::Node` + `::`-namespace
         ancestors (`Statement::If isa RakuAST::Statement`). Tests in `t/rakuast-smartmatch.t`.
         (`use experimental :rakuast` already parsed as a no-op.)
-  - [ ] Slice 3+: positional leaf accessors (`IntLiteral.value`); the semantic Expression/Term
-        hierarchy (`IntLiteral isa RakuAST::Expression`); registering `RakuAST::*` as first-class
-        type objects; `.WHAT`. Then Phase 4 (construction), Phase 5 (EVAL).
+  - [x] Slice 3: positional-leaf accessors (`IntLiteral.value`, `Var::Lexical.name`). Tests in
+        `t/rakuast-leaf-accessors.t`.
+  - [ ] Slice 4+: the semantic Expression/Term hierarchy (`IntLiteral isa RakuAST::Expression`);
+        registering `RakuAST::*` as first-class type objects; `.WHAT`. Then Phase 4 (construction),
+        Phase 5 (EVAL).
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).
 - [ ] **Phase 5** — EVAL: lower RakuAST → internal AST → existing compiler (no new engine).
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -134,9 +134,14 @@ earlier ones.
     RakuAST::Statement`); the `::` boundary avoids a false `StatementList isa Statement`. The
     smartmatch path was already routing exact-class matches through `isa_check`; `type_matches_value`
     now delegates `RakuAST::*` constraints to `isa_check` instead of the static name table. Tests in
-    `t/rakuast-smartmatch.t`. Still pending: the semantic `IntLiteral isa RakuAST::Expression`
-    hierarchy (needs a per-class ancestor table), positional leaf accessors (`IntLiteral.value`),
-    registering `RakuAST::*` as first-class type objects (they currently resolve as bare type names).
+    `t/rakuast-smartmatch.t`.
+  - **Slice 3 (positional-leaf accessors) — done.** `IntLiteral.value` / `RatLiteral.value` /
+    `StrLiteral.value` return the literal payload, and `Var::Lexical.name` returns the sigil'd
+    variable string — the single positional field exposed under a class-specific accessor name. The
+    named-field lookup runs first, so `Call::Name.name` (a named `Name`-node field) is not shadowed.
+    Tests in `t/rakuast-leaf-accessors.t`. Still pending: the semantic `IntLiteral isa
+    RakuAST::Expression` hierarchy (needs a per-class ancestor table) and registering `RakuAST::*`
+    as first-class type objects (they currently resolve as bare type names).
 - **Phase 4 — Construction.** `.new` (and `.from-identifier`, …) on RakuAST type objects
   build `Value::RakuAst`, validating args against the per-class field schema.
 - **Phase 5 — EVAL / compilation.** `lower(RakuAstNode) -> Vec<Stmt>/Expr`, then the

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -251,6 +251,23 @@ pub fn node_accessor(node: &RakuAstNode, method: &str) -> Option<Value> {
             .collect();
         return Some(Value::array(items));
     }
+    // Positional-leaf accessors: a node whose single positional field is its
+    // payload exposes it under a class-specific name (`IntLiteral.value`,
+    // `Var::Lexical.name`). The named-field loop above runs first, so a class
+    // with a *named* field of the same name (e.g. `Call::Name.name`) is unaffected.
+    let positional_name = match node.class {
+        RakuAstClass::IntLiteral | RakuAstClass::RatLiteral | RakuAstClass::StrLiteral => {
+            Some("value")
+        }
+        RakuAstClass::VarLexical => Some("name"),
+        _ => None,
+    };
+    if positional_name == Some(method)
+        && let Some(f) = node.fields.first()
+        && f.name.is_none()
+    {
+        return Some(field_to_value(&f.value));
+    }
     None
 }
 

--- a/t/rakuast-leaf-accessors.t
+++ b/t/rakuast-leaf-accessors.t
@@ -1,0 +1,27 @@
+use v6;
+use Test;
+
+# RakuAST Phase 3 slice 3 (ADR-0011): positional-leaf accessors.
+# A literal node exposes its payload via `.value` (`IntLiteral.value` -> Int),
+# and `Var::Lexical.name` returns the sigil'd variable string. Verified against
+# Rakudo; this file passes under BOTH mutsu and raku.
+
+plan 6;
+
+# --- IntLiteral.value -------------------------------------------------------
+is Q[42].AST.statements[0].expression.value, 42, 'IntLiteral.value returns the Int';
+is Q[42].AST.statements[0].expression.value.^name, 'Int', 'IntLiteral.value is an Int';
+
+# --- RatLiteral.value / StrLiteral.value ------------------------------------
+is Q[3.5].AST.statements[0].expression.value, 3.5, 'RatLiteral.value returns the Rat';
+is Q["hi"].AST.statements[0].expression.segments[0].value, 'hi',
+    'StrLiteral.value returns the string';
+
+# --- Var::Lexical.name ------------------------------------------------------
+my $x;
+is Q[my $x; $x].AST.statements[1].expression.name, '$x',
+    'Var::Lexical.name returns the sigilled variable string';
+
+# --- a named accessor of the same spelling is NOT shadowed -------------------
+is Q[say 1].AST.statements[0].expression.name.^name, 'RakuAST::Name',
+    'Call::Name.name still returns the named Name node';


### PR DESCRIPTION
## Summary

Phase 3 slice 3 of RakuAST (ADR-0011): expose the payload of leaf nodes stored in a positional (name-less) field.

```raku
Q[42].AST.statements[0].expression.value      # 42  (Int)
Q[3.5].AST.statements[0].expression.value     # 3.5 (Rat)
Q["hi"].AST.statements[0].expression.segments[0].value  # "hi"
my $x; Q[my $x; $x].AST.statements[1].expression.name   # "$x"
```

`IntLiteral.value` / `RatLiteral.value` / `StrLiteral.value` return the literal value, and `Var::Lexical.name` returns the sigilled variable string.

The named-field lookup runs first, so a class with a **named** field of the same spelling — e.g. `Call::Name.name`, whose `.name` is a `Name`-node field — is **not** shadowed.

## Tests

`t/rakuast-leaf-accessors.t` — 6 assertions (`IntLiteral.value` + `.^name`, `RatLiteral`/`StrLiteral` value, `Var::Lexical.name`, `Call::Name.name` not shadowed), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)