### PR TITLE
feat: RakuAST Phase 3 slice 4 — semantic Expression/Term hierarchy

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -862,9 +862,10 @@ so it is tracked separately from the roast backlog.
         (`use experimental :rakuast` already parsed as a no-op.)
   - [x] Slice 3: positional-leaf accessors (`IntLiteral.value`, `Var::Lexical.name`). Tests in
         `t/rakuast-leaf-accessors.t`.
-  - [ ] Slice 4+: the semantic Expression/Term hierarchy (`IntLiteral isa RakuAST::Expression`);
-        registering `RakuAST::*` as first-class type objects; `.WHAT`. Then Phase 4 (construction),
-        Phase 5 (EVAL).
+  - [x] Slice 4: semantic Expression/Term hierarchy (`IntLiteral isa RakuAST::Expression`/`Term`,
+        `ApplyInfix isa Expression`). Tests in `t/rakuast-semantic-hierarchy.t`.
+  - [ ] Slice 5+: registering `RakuAST::*` as first-class type objects; `.WHAT`. Then Phase 4
+        (construction, `.new`), Phase 5 (EVAL: lower RakuAST → internal AST → existing compiler).
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).
 - [ ] **Phase 5** — EVAL: lower RakuAST → internal AST → existing compiler (no new engine).
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -139,8 +139,15 @@ earlier ones.
     `StrLiteral.value` return the literal payload, and `Var::Lexical.name` returns the sigil'd
     variable string — the single positional field exposed under a class-specific accessor name. The
     named-field lookup runs first, so `Call::Name.name` (a named `Name`-node field) is not shadowed.
-    Tests in `t/rakuast-leaf-accessors.t`. Still pending: the semantic `IntLiteral isa
-    RakuAST::Expression` hierarchy (needs a per-class ancestor table) and registering `RakuAST::*`
+    Tests in `t/rakuast-leaf-accessors.t`.
+  - **Slice 4 (semantic Expression/Term hierarchy) — done.** `IntLiteral isa RakuAST::Expression`,
+    `IntLiteral isa RakuAST::Term`, `ApplyInfix isa RakuAST::Expression` (but not `Term`), etc. —
+    the ancestor names that don't appear in the printed class name. A `RakuAstClass::
+    semantic_ancestors` table (verified against Rakudo: literals/variables/`Term::Reduce`/`Sub`/
+    blocks/`Call::Name` are Terms-and-Expressions; `Apply*`/`Ternary` are Expressions-only; `Name`/
+    `ArgList`/`Signature`/statements/types are neither) is consulted by `isa_check`. Conservative:
+    only verified classes are listed, so an unlisted expression node is a missed match, never a
+    false positive. Tests in `t/rakuast-semantic-hierarchy.t`. Still pending: registering `RakuAST::*`
     as first-class type objects (they currently resolve as bare type names).
 - **Phase 4 — Construction.** `.new` (and `.from-identifier`, …) on RakuAST type objects
   build `Value::RakuAst`, validating args against the per-class field schema.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -219,6 +219,34 @@ impl RakuAstClass {
             _ => 0,
         }
     }
+
+    /// Extra `RakuAST::*` ancestor type names this node kind smartmatches beyond
+    /// its own class, its `::`-namespace ancestors, and the universal
+    /// `RakuAST::Node` — i.e. the *semantic* hierarchy (`RakuAST::Term` /
+    /// `RakuAST::Expression`) whose names don't appear in the printed class name.
+    /// Only classes verified against Rakudo are listed; an unlisted expression
+    /// node is a documented gap (a missed match), never a false positive.
+    pub fn semantic_ancestors(self) -> &'static [&'static str] {
+        use RakuAstClass::*;
+        // A Term is also an Expression.
+        const TERM: &[&str] = &["RakuAST::Term", "RakuAST::Expression"];
+        const EXPR: &[&str] = &["RakuAST::Expression"];
+        match self {
+            IntLiteral
+            | RatLiteral
+            | StrLiteral
+            | QuotedString
+            | VarLexical
+            | TermReduce
+            | Sub
+            | Block
+            | PointyBlock
+            | CallName
+            | CallNameWithoutParentheses => TERM,
+            ApplyInfix | ApplyPrefix | ApplyPostfix | ApplyListInfix | Ternary => EXPR,
+            _ => &[],
+        }
+    }
 }
 
 /// Entry point for `Str.AST`: parse the source, convert, wrap in `Value::RakuAst`.

--- a/src/value/types_isa.rs
+++ b/src/value/types_isa.rs
@@ -144,18 +144,22 @@ impl Value {
         if my_type == type_name {
             return true;
         }
-        // RakuAST node hierarchy (Phase 3): every node isa `RakuAST::Node`, and a
-        // node isa any `::`-namespace ancestor of its printed class name (e.g.
-        // `Statement::If` isa `RakuAST::Statement`). The `::` boundary avoids a
-        // false `StatementList isa Statement`. (The semantic Expression/Term
-        // hierarchy — `IntLiteral isa RakuAST::Expression` — is not yet modelled.)
-        if matches!(self.view(), ValueView::RakuAst(_)) {
+        // RakuAST node hierarchy (Phase 3): every node isa `RakuAST::Node`, a node
+        // isa any `::`-namespace ancestor of its printed class name (e.g.
+        // `Statement::If` isa `RakuAST::Statement`; the `::` boundary avoids a
+        // false `StatementList isa Statement`), and a node isa its semantic
+        // ancestors (`RakuAST::Term`/`RakuAST::Expression`) whose names are not
+        // part of the printed class name.
+        if let ValueView::RakuAst(node) = self.view() {
             if type_name == "RakuAST::Node" {
                 return true;
             }
             if let Some(rest) = my_type.strip_prefix(type_name)
                 && rest.starts_with("::")
             {
+                return true;
+            }
+            if node.class.semantic_ancestors().contains(&type_name) {
                 return true;
             }
         }

--- a/t/rakuast-semantic-hierarchy.t
+++ b/t/rakuast-semantic-hierarchy.t
@@ -1,0 +1,30 @@
+use v6;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 3 slice 4 (ADR-0011): the semantic Expression/Term hierarchy.
+# Beyond the base RakuAST::Node and `::`-namespace ancestors, expression nodes
+# also isa RakuAST::Expression, and the term subset (literals, variables, …)
+# also isa RakuAST::Term. Verified against Rakudo; this file passes under BOTH
+# mutsu and raku.
+
+plan 8;
+
+my $v;
+
+# --- literals are Terms (and Expressions) -----------------------------------
+ok Q[42].AST.statements[0].expression ~~ RakuAST::Expression, 'IntLiteral isa Expression';
+ok Q[42].AST.statements[0].expression ~~ RakuAST::Term, 'IntLiteral isa Term';
+ok Q["x"].AST.statements[0].expression ~~ RakuAST::Term, 'QuotedString isa Term';
+
+# --- variables are Terms ----------------------------------------------------
+ok Q[my $v; $v].AST.statements[1].expression ~~ RakuAST::Term, 'Var::Lexical isa Term';
+
+# --- operator applications are Expressions but NOT Terms --------------------
+ok Q[my $v; $v + 1].AST.statements[1].expression ~~ RakuAST::Expression, 'ApplyInfix isa Expression';
+nok Q[my $v; $v + 1].AST.statements[1].expression ~~ RakuAST::Term, 'ApplyInfix is NOT a Term';
+ok Q[my $v; $v ?? 1 !! 2].AST.statements[1].expression ~~ RakuAST::Expression, 'Ternary isa Expression';
+
+# --- non-expression nodes are neither ---------------------------------------
+nok Q[say 1].AST.statements[0].expression.name ~~ RakuAST::Expression,
+    'a Name is NOT an Expression';


### PR DESCRIPTION
## Summary

Phase 3 slice 4 of RakuAST (ADR-0011): the semantic Expression/Term hierarchy. A RakuAST node now smartmatches its semantic ancestors — `RakuAST::Expression` and `RakuAST::Term` — whose names do not appear in the printed class name.

```raku
use experimental :rakuast;
Q[42].AST.statements[0].expression ~~ RakuAST::Expression       # True
Q[42].AST.statements[0].expression ~~ RakuAST::Term             # True
Q[my $v; $v + 1].AST.statements[1].expression ~~ RakuAST::Expression  # True
Q[my $v; $v + 1].AST.statements[1].expression ~~ RakuAST::Term        # False (ApplyInfix is not a Term)
Q[say 1].AST.statements[0].expression.name ~~ RakuAST::Expression     # False (Name is neither)
```

## Implementation

A `RakuAstClass::semantic_ancestors` table — verified against Rakudo — is consulted by `isa_check` after the base-`Node` and `::`-namespace-ancestor checks:

- **Term (and Expression):** literals (`IntLiteral`/`RatLiteral`/`StrLiteral`/`QuotedString`), `Var::Lexical`, `Term::Reduce`, `Sub`, `Block`, `PointyBlock`, `Call::Name`(`::WithoutParentheses`).
- **Expression only:** `ApplyInfix`/`ApplyPrefix`/`ApplyPostfix`/`ApplyListInfix`, `Ternary`.
- **Neither:** `Name`, `ArgList`, `Signature`, statements, types, …

Conservative: only verified classes are listed, so an unlisted expression node is a missed match, never a false positive.

## Tests

`t/rakuast-semantic-hierarchy.t` — 8 assertions (literals as Term+Expression, variable as Term, `ApplyInfix`/`Ternary` as Expression-not-Term, `Name` as neither), **passing under BOTH mutsu and raku**. Core type-checks and all `t/rakuast-*.t` verified unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)