### PR TITLE
feat: RakuAST Phase 4 slice 1 — literal construction

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -864,8 +864,13 @@ so it is tracked separately from the roast backlog.
         `t/rakuast-leaf-accessors.t`.
   - [x] Slice 4: semantic Expression/Term hierarchy (`IntLiteral isa RakuAST::Expression`/`Term`,
         `ApplyInfix isa Expression`). Tests in `t/rakuast-semantic-hierarchy.t`.
-  - [ ] Slice 5+: registering `RakuAST::*` as first-class type objects; `.WHAT`. Then Phase 4
-        (construction, `.new`), Phase 5 (EVAL: lower RakuAST → internal AST → existing compiler).
+  - [ ] Slice 5+: registering `RakuAST::*` as first-class type objects; `.WHAT`.
+- **Phase 4 (in progress)** — construction (`.new`).
+  - [x] Slice 1: literal constructors (`RakuAST::IntLiteral.new(42)`, `StrLiteral`, `RatLiteral`).
+        Tests in `t/rakuast-construct.t`.
+  - [ ] Slice 2+: `Name.from-identifier("x")`; multi-field constructors (`ApplyInfix.new(...)`,
+        `Statement::Expression.new(...)`, `StatementList.new(...)`) — a per-class field schema; then
+        Phase 5 (EVAL: lower RakuAST → internal AST → existing compiler).
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).
 - [ ] **Phase 5** — EVAL: lower RakuAST → internal AST → existing compiler (no new engine).
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -151,6 +151,12 @@ earlier ones.
     as first-class type objects (they currently resolve as bare type names).
 - **Phase 4 — Construction.** `.new` (and `.from-identifier`, …) on RakuAST type objects
   build `Value::RakuAst`, validating args against the per-class field schema.
+  - **Slice 1 (literals) — done.** `RakuAST::IntLiteral.new(42)` / `RatLiteral.new(3.5)` /
+    `StrLiteral.new("hi")` build a real node — renderable (`.gist` round-trips) and queryable
+    (`.value`, `~~`). A `rakuast::construct(class_name, method, args)` builds the node; it is
+    dispatched from the `.new`-on-a-`Package` handler (`methods_object_dispatch_new`) for any
+    `RakuAST::*` type-object bareword. Tests in `t/rakuast-construct.t`. Next: multi-field
+    constructors (Name.from-identifier, ApplyInfix.new(...), StatementList.new(...)).
 - **Phase 5 — EVAL / compilation.** `lower(RakuAstNode) -> Vec<Stmt>/Expr`, then the
   **existing** compiler. `EVAL($rakuast)` and any code that yields a RakuAST tree runs
   through this. No new execution engine.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -261,6 +261,36 @@ pub fn node_gist(node: &RakuAstNode) -> String {
     render::render_node(node, 0)
 }
 
+/// Construction (Phase 4): build a `Value::RakuAst` from a `RakuAST::*.new(...)`
+/// / `.from-identifier(...)` call. Returns `Ok(None)` when the class/method is
+/// not a supported constructor yet (so normal dispatch handles it). Slice 1
+/// covers the single-value literals.
+pub fn construct(
+    class_name: &str,
+    method: &str,
+    args: &[Value],
+) -> Result<Option<Value>, RuntimeError> {
+    let class = match (class_name, method) {
+        ("RakuAST::IntLiteral", "new") => RakuAstClass::IntLiteral,
+        ("RakuAST::RatLiteral", "new") => RakuAstClass::RatLiteral,
+        ("RakuAST::StrLiteral", "new") => RakuAstClass::StrLiteral,
+        _ => return Ok(None),
+    };
+    if args.len() != 1 {
+        return Err(RuntimeError::new(format!(
+            "{class_name}.new expects a single argument"
+        )));
+    }
+    let node = RakuAstNode {
+        class,
+        fields: vec![RakuAstField {
+            name: None,
+            value: RakuAstFieldValue::Node(args[0].clone()),
+        }],
+    };
+    Ok(Some(Value::rakuast(Box::new(node))))
+}
+
 /// A named-field / positional accessor on a RakuAST node (Phase 3). Returns the
 /// field value as a mutsu `Value`, or `None` if `method` is not an accessor for
 /// this node (so ordinary methods like `.gist` fall through). `.statements`

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -2127,8 +2127,15 @@ impl Interpreter {
                 self.builtin_callframe(&args, depth)
             }
             ValueView::Package(name) => {
+                // RakuAST construction (Phase 4): `RakuAST::IntLiteral.new(42)`.
+                let resolved = name.resolve();
+                if resolved.starts_with("RakuAST::")
+                    && let Some(node) = crate::rakuast::construct(&resolved, "new", &args)?
+                {
+                    return Ok(node);
+                }
                 // Built-in type objects: .new creates a default defined instance
-                match name.resolve().as_str() {
+                match resolved.as_str() {
                     // Shared with the VM's native fast path.
                     "Int" => Self::build_native_int_value(&args),
                     "Str" => Ok(Value::str(String::new())),

--- a/t/rakuast-construct.t
+++ b/t/rakuast-construct.t
@@ -1,0 +1,25 @@
+use v6;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 4 slice 1 (ADR-0011): construction of literal nodes via `.new`.
+# `RakuAST::IntLiteral.new(42)` builds a real RakuAST node — renderable (`.gist`)
+# and queryable (`.value`, `~~`). Verified against Rakudo; this file passes
+# under BOTH mutsu and raku.
+
+plan 6;
+
+# --- IntLiteral -------------------------------------------------------------
+is RakuAST::IntLiteral.new(42).gist, 'RakuAST::IntLiteral.new(42)',
+    'IntLiteral.new gist round-trips';
+is RakuAST::IntLiteral.new(42).value, 42, 'constructed IntLiteral.value is 42';
+ok RakuAST::IntLiteral.new(42) ~~ RakuAST::Expression, 'a constructed node isa Expression';
+
+# --- StrLiteral -------------------------------------------------------------
+is RakuAST::StrLiteral.new("hi").gist, 'RakuAST::StrLiteral.new("hi")',
+    'StrLiteral.new gist round-trips';
+is RakuAST::StrLiteral.new("hi").value, 'hi', 'constructed StrLiteral.value is "hi"';
+
+# --- RatLiteral -------------------------------------------------------------
+is RakuAST::RatLiteral.new(3.5).gist, 'RakuAST::RatLiteral.new(3.5)',
+    'RatLiteral.new gist round-trips';


### PR DESCRIPTION
## Summary

Begins **Phase 4** of RakuAST (ADR-0011): building RakuAST nodes programmatically via `.new`.

```raku
use experimental :rakuast;
RakuAST::IntLiteral.new(42).gist    # RakuAST::IntLiteral.new(42)  (round-trips)
RakuAST::IntLiteral.new(42).value   # 42
RakuAST::IntLiteral.new(42) ~~ RakuAST::Expression   # True
RakuAST::StrLiteral.new("hi").gist  # RakuAST::StrLiteral.new("hi")
RakuAST::RatLiteral.new(3.5).gist   # RakuAST::RatLiteral.new(3.5)
```

`RakuAST::IntLiteral.new(42)` / `RatLiteral.new(3.5)` / `StrLiteral.new("hi")` now construct a real `Value::RakuAst` — renderable **and** queryable (accessors, `~~`) — the same node kind `.AST` produces.

## Implementation

A `rakuast::construct(class_name, method, args)` builds the node. It is dispatched from the `.new`-on-a-`Package` handler (`methods_object_dispatch_new`), for any `RakuAST::*` type-object bareword, **before** the built-in-type `.new` match. Core `.new` (user classes, `Int`/`Str`/…) is unaffected.

## Tests

`t/rakuast-construct.t` — 6 assertions (`.gist` round-trip + `.value` for Int/Str/Rat, constructed node `~~ RakuAST::Expression`), **passing under BOTH mutsu and raku**. Core `.new` (user classes, built-in types) and all `t/rakuast-*.t` verified unaffected.

Next: `Name.from-identifier("x")` and multi-field constructors (`ApplyInfix.new(...)`, `StatementList.new(...)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)