### PR TITLE
feat: RakuAST Phase 4 slice 2 — Name.from-identifier construction

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -868,9 +868,11 @@ so it is tracked separately from the roast backlog.
 - **Phase 4 (in progress)** — construction (`.new`).
   - [x] Slice 1: literal constructors (`RakuAST::IntLiteral.new(42)`, `StrLiteral`, `RatLiteral`).
         Tests in `t/rakuast-construct.t`.
-  - [ ] Slice 2+: `Name.from-identifier("x")`; multi-field constructors (`ApplyInfix.new(...)`,
-        `Statement::Expression.new(...)`, `StatementList.new(...)`) — a per-class field schema; then
-        Phase 5 (EVAL: lower RakuAST → internal AST → existing compiler).
+  - [x] Slice 2: `RakuAST::Name.from-identifier("x")`. Tests in `t/rakuast-construct-name.t`.
+  - [ ] Slice 3+: multi-field constructors (`ApplyInfix.new(:left, :infix, :right)`,
+        `Statement::Expression.new(:expression)`, `StatementList.new(...)`) — these take **named**
+        args (Pairs) per a per-class field schema; then Phase 5 (EVAL: lower RakuAST → internal AST →
+        existing compiler).
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).
 - [ ] **Phase 5** — EVAL: lower RakuAST → internal AST → existing compiler (no new engine).
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -155,8 +155,14 @@ earlier ones.
     `StrLiteral.new("hi")` build a real node — renderable (`.gist` round-trips) and queryable
     (`.value`, `~~`). A `rakuast::construct(class_name, method, args)` builds the node; it is
     dispatched from the `.new`-on-a-`Package` handler (`methods_object_dispatch_new`) for any
-    `RakuAST::*` type-object bareword. Tests in `t/rakuast-construct.t`. Next: multi-field
-    constructors (Name.from-identifier, ApplyInfix.new(...), StatementList.new(...)).
+    `RakuAST::*` type-object bareword. Tests in `t/rakuast-construct.t`.
+  - **Slice 2 (`Name.from-identifier`) — done.** `RakuAST::Name.from-identifier("x")` builds a Name
+    node (its gist round-trips). Same single-positional builder as the literals. `.new` routes
+    through `methods_object_dispatch_new`, but a non-`new` constructor like `from-identifier` reaches
+    the terminal method-not-found fallback in `methods_instance_ops` instead, so the RakuAST
+    construct hook is placed there too. Tests in `t/rakuast-construct-name.t`. Next: multi-field
+    constructors (`ApplyInfix.new(:left, :infix, :right)`, `Statement::Expression.new(:expression)`,
+    `StatementList.new(...)`) — these take **named** args (Pairs) per a per-class field schema.
 - **Phase 5 — EVAL / compilation.** `lower(RakuAstNode) -> Vec<Stmt>/Expr`, then the
   **existing** compiler. `EVAL($rakuast)` and any code that yields a RakuAST tree runs
   through this. No new execution engine.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -263,8 +263,9 @@ pub fn node_gist(node: &RakuAstNode) -> String {
 
 /// Construction (Phase 4): build a `Value::RakuAst` from a `RakuAST::*.new(...)`
 /// / `.from-identifier(...)` call. Returns `Ok(None)` when the class/method is
-/// not a supported constructor yet (so normal dispatch handles it). Slice 1
-/// covers the single-value literals.
+/// not a supported constructor yet (so normal dispatch handles it). Covers the
+/// single-positional-argument constructors: the literals (`.new`) and
+/// `Name.from-identifier`.
 pub fn construct(
     class_name: &str,
     method: &str,
@@ -274,11 +275,12 @@ pub fn construct(
         ("RakuAST::IntLiteral", "new") => RakuAstClass::IntLiteral,
         ("RakuAST::RatLiteral", "new") => RakuAstClass::RatLiteral,
         ("RakuAST::StrLiteral", "new") => RakuAstClass::StrLiteral,
+        ("RakuAST::Name", "from-identifier") => RakuAstClass::Name,
         _ => return Ok(None),
     };
     if args.len() != 1 {
         return Err(RuntimeError::new(format!(
-            "{class_name}.new expects a single argument"
+            "{class_name}.{method} expects a single argument"
         )));
     }
     let node = RakuAstNode {

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -2002,6 +2002,14 @@ impl Interpreter {
                     ValueView::Package(name) => name.resolve(),
                     _ => crate::runtime::utils::value_type_name(&target).to_string(),
                 };
+                // RakuAST construction via a non-`new` constructor (Phase 4),
+                // e.g. `RakuAST::Name.from-identifier("x")` (`.new` is handled
+                // earlier in methods_object_dispatch_new).
+                if type_name.starts_with("RakuAST::")
+                    && let Some(node) = crate::rakuast::construct(&type_name, method, &args)?
+                {
+                    return Ok(node);
+                }
                 Err(make_method_not_found_error(method, &type_name, false))
             }
         }

--- a/t/rakuast-construct-name.t
+++ b/t/rakuast-construct-name.t
@@ -1,0 +1,21 @@
+use v6;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 4 slice 2 (ADR-0011): `RakuAST::Name.from-identifier("x")`.
+# The `.from-identifier` constructor builds a Name node whose gist round-trips.
+# Verified against Rakudo; this file passes under BOTH mutsu and raku.
+
+plan 3;
+
+is RakuAST::Name.from-identifier("x").gist, 'RakuAST::Name.from-identifier("x")',
+    'Name.from-identifier gist round-trips';
+
+is RakuAST::Name.from-identifier("foo").^name, 'RakuAST::Name',
+    'the constructed node is a RakuAST::Name';
+
+# --- a constructed Name can be used as the name of a constructed call --------
+# (round-trips through gist as a Name inside its container is future work; here
+# we just confirm the node is a first-class RakuAST value.)
+ok RakuAST::Name.from-identifier("x") ~~ RakuAST::Node,
+    'a constructed Name isa RakuAST::Node';


### PR DESCRIPTION
## Summary

Phase 4 slice 2 of RakuAST (ADR-0011): `RakuAST::Name.from-identifier("x")` now builds a `Name` node whose gist round-trips.

```raku
use experimental :rakuast;
RakuAST::Name.from-identifier("x").gist    # RakuAST::Name.from-identifier("x")
RakuAST::Name.from-identifier("x").^name   # RakuAST::Name
RakuAST::Name.from-identifier("x") ~~ RakuAST::Node   # True
```

Same single-positional builder as the literal `.new` constructors (slice 1).

## Implementation

`.new` on a `Package` routes through `methods_object_dispatch_new`, but a **non-`new`** constructor like `from-identifier` reaches the terminal method-not-found fallback in `methods_instance_ops` instead — so the RakuAST construct hook is placed there too. (The dead `exec_call_method_op` hook from an earlier attempt is removed.)

## Tests

`t/rakuast-construct-name.t` — 3 assertions (gist round-trip, `.^name`, `~~ RakuAST::Node`), **passing under BOTH mutsu and raku**. Core method-not-found (`5.nonexistent-method`) and all `t/rakuast-*.t` verified unaffected.

Next: multi-field constructors (`ApplyInfix.new(:left, :infix, :right)`, `Statement::Expression.new(:expression)`) — these take **named** args.

🤖 Generated with [Claude Code](https://claude.com/claude-code)