### PR TITLE
feat: RakuAST Phase 4 slice 3 — multi-field construction

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -869,10 +869,11 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 1: literal constructors (`RakuAST::IntLiteral.new(42)`, `StrLiteral`, `RatLiteral`).
         Tests in `t/rakuast-construct.t`.
   - [x] Slice 2: `RakuAST::Name.from-identifier("x")`. Tests in `t/rakuast-construct-name.t`.
-  - [ ] Slice 3+: multi-field constructors (`ApplyInfix.new(:left, :infix, :right)`,
-        `Statement::Expression.new(:expression)`, `StatementList.new(...)`) — these take **named**
-        args (Pairs) per a per-class field schema; then Phase 5 (EVAL: lower RakuAST → internal AST →
-        existing compiler).
+  - [x] Slice 3: multi-field constructors (`Infix.new("+")`, `Statement::Expression.new(:expression)`,
+        `ApplyInfix.new(:left, :infix, :right)`). Tests in `t/rakuast-construct-multi.t`.
+  - [ ] Slice 4+: `StatementList.new`, `ApplyPrefix`/`ApplyPostfix`, `Var::Lexical.new`, block/sub/
+        statement constructors — extend the per-class schema; then Phase 5 (EVAL: lower RakuAST →
+        internal AST → existing compiler).
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).
 - [ ] **Phase 5** — EVAL: lower RakuAST → internal AST → existing compiler (no new engine).
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -160,9 +160,15 @@ earlier ones.
     node (its gist round-trips). Same single-positional builder as the literals. `.new` routes
     through `methods_object_dispatch_new`, but a non-`new` constructor like `from-identifier` reaches
     the terminal method-not-found fallback in `methods_instance_ops` instead, so the RakuAST
-    construct hook is placed there too. Tests in `t/rakuast-construct-name.t`. Next: multi-field
-    constructors (`ApplyInfix.new(:left, :infix, :right)`, `Statement::Expression.new(:expression)`,
-    `StatementList.new(...)`) — these take **named** args (Pairs) per a per-class field schema.
+    construct hook is placed there too. Tests in `t/rakuast-construct-name.t`.
+  - **Slice 3 (multi-field) — done.** Bare operator nodes (`Infix.new("+")`, `Prefix.new(...)`) use
+    the single-positional builder; named-field constructors (`Statement::Expression.new(expression =>
+    …)`, `ApplyInfix.new(left => …, infix => …, right => …)`) build fields from the `key => value`
+    args in a per-class schema order. Named args reach `construct` as `Pair`/`ValuePair` values;
+    `named_arg` finds them, and a missing one is a clear error. Constructed nodes nest, render (gist),
+    and are queryable (`.left.value`, `~~ RakuAST::Expression`). Tests in
+    `t/rakuast-construct-multi.t`. Next: `StatementList.new`, more operator/statement/declaration
+    constructors — then Phase 5 (EVAL) can lower a fully-constructed tree.
 - **Phase 5 — EVAL / compilation.** `lower(RakuAstNode) -> Vec<Stmt>/Expr`, then the
   **existing** compiler. `EVAL($rakuast)` and any code that yields a RakuAST tree runs
   through this. No new execution engine.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -13,7 +13,7 @@
 mod convert;
 mod render;
 
-use crate::value::{RuntimeError, Value};
+use crate::value::{RuntimeError, Value, ValueView};
 
 /// A single RakuAST node: its class plus ordered fields. Immutable tree.
 #[derive(Debug, Clone, PartialEq)]
@@ -271,26 +271,81 @@ pub fn construct(
     method: &str,
     args: &[Value],
 ) -> Result<Option<Value>, RuntimeError> {
-    let class = match (class_name, method) {
+    // Single-positional-argument constructors: the literals, `Name.from-identifier`,
+    // and the bare operator nodes (`Infix.new("+")`).
+    if let Some(class) = single_positional_class(class_name, method) {
+        if args.len() != 1 {
+            return Err(RuntimeError::new(format!(
+                "{class_name}.{method} expects a single argument"
+            )));
+        }
+        return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
+            class,
+            fields: vec![RakuAstField {
+                name: None,
+                value: RakuAstFieldValue::Node(args[0].clone()),
+            }],
+        }))));
+    }
+    // Multi-field named constructors: the named args map to same-named fields in
+    // the class's schema order (`ApplyInfix.new(left => …, infix => …, right => …)`).
+    if let Some((class, schema)) = multi_field_schema(class_name, method) {
+        let mut fields = Vec::with_capacity(schema.len());
+        for &fname in schema {
+            let value = named_arg(args, fname).ok_or_else(|| {
+                RuntimeError::new(format!(
+                    "{class_name}.{method} requires a `{fname}` argument"
+                ))
+            })?;
+            fields.push(RakuAstField {
+                name: Some(fname),
+                value: RakuAstFieldValue::Node(value),
+            });
+        }
+        return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
+            class,
+            fields,
+        }))));
+    }
+    Ok(None)
+}
+
+/// The class for a single-positional-argument constructor, or `None`.
+fn single_positional_class(class_name: &str, method: &str) -> Option<RakuAstClass> {
+    Some(match (class_name, method) {
         ("RakuAST::IntLiteral", "new") => RakuAstClass::IntLiteral,
         ("RakuAST::RatLiteral", "new") => RakuAstClass::RatLiteral,
         ("RakuAST::StrLiteral", "new") => RakuAstClass::StrLiteral,
         ("RakuAST::Name", "from-identifier") => RakuAstClass::Name,
-        _ => return Ok(None),
-    };
-    if args.len() != 1 {
-        return Err(RuntimeError::new(format!(
-            "{class_name}.{method} expects a single argument"
-        )));
-    }
-    let node = RakuAstNode {
-        class,
-        fields: vec![RakuAstField {
-            name: None,
-            value: RakuAstFieldValue::Node(args[0].clone()),
-        }],
-    };
-    Ok(Some(Value::rakuast(Box::new(node))))
+        ("RakuAST::Infix", "new") => RakuAstClass::Infix,
+        ("RakuAST::Prefix", "new") => RakuAstClass::Prefix,
+        _ => return None,
+    })
+}
+
+/// The class and ordered named-field schema for a multi-field constructor.
+fn multi_field_schema(
+    class_name: &str,
+    method: &str,
+) -> Option<(RakuAstClass, &'static [&'static str])> {
+    Some(match (class_name, method) {
+        ("RakuAST::Statement::Expression", "new") => {
+            (RakuAstClass::StatementExpression, &["expression"][..])
+        }
+        ("RakuAST::ApplyInfix", "new") => {
+            (RakuAstClass::ApplyInfix, &["left", "infix", "right"][..])
+        }
+        _ => return None,
+    })
+}
+
+/// Find a named (`key => value`) constructor argument, returning its value.
+fn named_arg(args: &[Value], name: &str) -> Option<Value> {
+    args.iter().find_map(|a| match a.view() {
+        ValueView::Pair(k, v) => (k.as_str() == name).then(|| v.clone()),
+        ValueView::ValuePair(k, v) => (k.to_string_value() == name).then(|| v.clone()),
+        _ => None,
+    })
 }
 
 /// A named-field / positional accessor on a RakuAST node (Phase 3). Returns the

--- a/t/rakuast-construct-multi.t
+++ b/t/rakuast-construct-multi.t
@@ -1,0 +1,40 @@
+use v6;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 4 slice 3 (ADR-0011): multi-field construction.
+# Bare operator nodes (`Infix.new("+")`) and named-field constructors
+# (`ApplyInfix.new(:left, :infix, :right)`, `Statement::Expression.new(:expression)`)
+# build real, nestable, queryable nodes. Verified against Rakudo; this file
+# passes under BOTH mutsu and raku.
+
+plan 5;
+
+# --- Infix (positional operator string) -------------------------------------
+is RakuAST::Infix.new("+").gist, 'RakuAST::Infix.new("+")', 'Infix.new gist round-trips';
+
+# --- Statement::Expression (one named field) --------------------------------
+is RakuAST::Statement::Expression.new(expression => RakuAST::IntLiteral.new(1)).gist,
+    q:to/END/.chomp, 'Statement::Expression.new(:expression)';
+    RakuAST::Statement::Expression.new(
+      expression => RakuAST::IntLiteral.new(1)
+    )
+    END
+
+# --- ApplyInfix (three named fields) ----------------------------------------
+my $add = RakuAST::ApplyInfix.new(
+    left  => RakuAST::IntLiteral.new(1),
+    infix => RakuAST::Infix.new("+"),
+    right => RakuAST::IntLiteral.new(2),
+);
+is $add.gist, q:to/END/.chomp, 'ApplyInfix.new(:left, :infix, :right)';
+    RakuAST::ApplyInfix.new(
+      left  => RakuAST::IntLiteral.new(1),
+      infix => RakuAST::Infix.new("+"),
+      right => RakuAST::IntLiteral.new(2)
+    )
+    END
+
+# --- a constructed node is queryable ----------------------------------------
+is $add.left.value, 1, 'accessor reads a field of a constructed node';
+ok $add ~~ RakuAST::Expression, 'a constructed ApplyInfix isa Expression';


### PR DESCRIPTION
## Summary

Phase 4 slice 3 of RakuAST (ADR-0011): construction of nodes with more than one field.

```raku
use experimental :rakuast;
RakuAST::Infix.new("+")
RakuAST::Statement::Expression.new(expression => RakuAST::IntLiteral.new(1))
RakuAST::ApplyInfix.new(
  left  => RakuAST::IntLiteral.new(1),
  infix => RakuAST::Infix.new("+"),
  right => RakuAST::IntLiteral.new(2),
)
```

- **Bare operator nodes** (`Infix.new("+")`, `Prefix.new(...)`) use the existing single-positional builder.
- **Named-field constructors** (`Statement::Expression.new(expression => …)`, `ApplyInfix.new(left => …, infix => …, right => …)`) build their fields from the `key => value` args in a per-class schema order.

Named args reach `construct` as `Pair`/`ValuePair` values; a `named_arg` helper finds them by key, and a missing required arg is a clear error. Constructed nodes **nest**, render (`.gist` round-trips), and are queryable (`.left.value`, `~~ RakuAST::Expression`) — a fully hand-built tree behaves like one from `.AST`.

## Tests

`t/rakuast-construct-multi.t` — 5 assertions (`Infix` positional, `Statement::Expression` single named field, `ApplyInfix` three named fields, accessor on a constructed node, constructed node `~~ RakuAST::Expression`), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)