### PR TITLE
feat: RakuAST Phase 4 slice 4 — more operator constructors

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -871,9 +871,11 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 2: `RakuAST::Name.from-identifier("x")`. Tests in `t/rakuast-construct-name.t`.
   - [x] Slice 3: multi-field constructors (`Infix.new("+")`, `Statement::Expression.new(:expression)`,
         `ApplyInfix.new(:left, :infix, :right)`). Tests in `t/rakuast-construct-multi.t`.
-  - [ ] Slice 4+: `StatementList.new`, `ApplyPrefix`/`ApplyPostfix`, `Var::Lexical.new`, block/sub/
-        statement constructors — extend the per-class schema; then Phase 5 (EVAL: lower RakuAST →
-        internal AST → existing compiler).
+  - [x] Slice 4: `Var::Lexical.new`, `ApplyPrefix`/`ApplyPostfix`, `Postfix.new(:operator)`. Tests in
+        `t/rakuast-construct-more.t`.
+  - [ ] Slice 5+: `StatementList` (children via `.add-statement` mutator — needs a mutable-node path),
+        block/sub/declaration constructors; then Phase 5 (EVAL: lower RakuAST → internal AST →
+        existing compiler).
 - [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).
 - [ ] **Phase 5** — EVAL: lower RakuAST → internal AST → existing compiler (no new engine).
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -167,8 +167,13 @@ earlier ones.
     args in a per-class schema order. Named args reach `construct` as `Pair`/`ValuePair` values;
     `named_arg` finds them, and a missing one is a clear error. Constructed nodes nest, render (gist),
     and are queryable (`.left.value`, `~~ RakuAST::Expression`). Tests in
-    `t/rakuast-construct-multi.t`. Next: `StatementList.new`, more operator/statement/declaration
-    constructors — then Phase 5 (EVAL) can lower a fully-constructed tree.
+    `t/rakuast-construct-multi.t`.
+  - **Slice 4 (more operators) — done.** `Var::Lexical.new("$x")` (positional), `ApplyPrefix.new(
+    prefix => …, operand => …)`, `ApplyPostfix.new(operand => …, postfix => …)`, and `Postfix.new(
+    operator => …)` (whose `operator` is a *named* string field). Tests in
+    `t/rakuast-construct-more.t`. Next: `StatementList` (its children are added via the `.add-statement`
+    *mutator*, which needs a mutable-node path), block/sub/declaration constructors — then Phase 5
+    (EVAL) can lower a fully-constructed tree.
 - **Phase 5 — EVAL / compilation.** `lower(RakuAstNode) -> Vec<Stmt>/Expr`, then the
   **existing** compiler. `EVAL($rakuast)` and any code that yields a RakuAST tree runs
   through this. No new execution engine.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -319,6 +319,7 @@ fn single_positional_class(class_name: &str, method: &str) -> Option<RakuAstClas
         ("RakuAST::Name", "from-identifier") => RakuAstClass::Name,
         ("RakuAST::Infix", "new") => RakuAstClass::Infix,
         ("RakuAST::Prefix", "new") => RakuAstClass::Prefix,
+        ("RakuAST::Var::Lexical", "new") => RakuAstClass::VarLexical,
         _ => return None,
     })
 }
@@ -335,6 +336,11 @@ fn multi_field_schema(
         ("RakuAST::ApplyInfix", "new") => {
             (RakuAstClass::ApplyInfix, &["left", "infix", "right"][..])
         }
+        ("RakuAST::ApplyPrefix", "new") => (RakuAstClass::ApplyPrefix, &["prefix", "operand"][..]),
+        ("RakuAST::ApplyPostfix", "new") => {
+            (RakuAstClass::ApplyPostfix, &["operand", "postfix"][..])
+        }
+        ("RakuAST::Postfix", "new") => (RakuAstClass::Postfix, &["operator"][..]),
         _ => return None,
     })
 }

--- a/t/rakuast-construct-more.t
+++ b/t/rakuast-construct-more.t
@@ -1,0 +1,43 @@
+use v6;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 4 slice 4 (ADR-0011): more constructors — Var::Lexical,
+# ApplyPrefix, ApplyPostfix, Postfix. Verified against Rakudo; this file passes
+# under BOTH mutsu and raku.
+
+plan 4;
+
+# --- Var::Lexical (positional) ----------------------------------------------
+is RakuAST::Var::Lexical.new("\$x").gist, 'RakuAST::Var::Lexical.new("\$x")',
+    'Var::Lexical.new gist round-trips';
+
+# --- ApplyPrefix (prefix, operand) ------------------------------------------
+is RakuAST::ApplyPrefix.new(
+    prefix  => RakuAST::Prefix.new("-"),
+    operand => RakuAST::IntLiteral.new(5),
+).gist, q:to/END/.chomp, 'ApplyPrefix.new(:prefix, :operand)';
+    RakuAST::ApplyPrefix.new(
+      prefix  => RakuAST::Prefix.new("-"),
+      operand => RakuAST::IntLiteral.new(5)
+    )
+    END
+
+# --- ApplyPostfix + Postfix (operator is a NAMED field) ---------------------
+is RakuAST::ApplyPostfix.new(
+    operand => RakuAST::IntLiteral.new(5),
+    postfix => RakuAST::Postfix.new(operator => "++"),
+).gist, q:to/END/.chomp, 'ApplyPostfix.new(:operand, :postfix) with Postfix(:operator)';
+    RakuAST::ApplyPostfix.new(
+      operand => RakuAST::IntLiteral.new(5),
+      postfix => RakuAST::Postfix.new(
+        operator => "++"
+      )
+    )
+    END
+
+# --- a constructed node is queryable ----------------------------------------
+is RakuAST::ApplyPrefix.new(
+    prefix  => RakuAST::Prefix.new("-"),
+    operand => RakuAST::IntLiteral.new(5),
+).operand.value, 5, 'accessor reads the operand of a constructed ApplyPrefix';


### PR DESCRIPTION
## Summary

Phase 4 slice 4 of RakuAST (ADR-0011): construction of more node kinds.

```raku
use experimental :rakuast;
RakuAST::Var::Lexical.new("\$x")
RakuAST::ApplyPrefix.new(prefix => RakuAST::Prefix.new("-"), operand => RakuAST::IntLiteral.new(5))
RakuAST::ApplyPostfix.new(operand => RakuAST::IntLiteral.new(5), postfix => RakuAST::Postfix.new(operator => "++"))
```

- `Var::Lexical.new("$x")` — single positional.
- `ApplyPrefix.new(:prefix, :operand)` / `ApplyPostfix.new(:operand, :postfix)` — named fields.
- `Postfix.new(operator => …)` — its `operator` is a **named** string field.

All extend the existing single-positional / multi-field-named builders. Constructed nodes render (`.gist` round-trips) and are queryable (`.operand.value`).

## Tests

`t/rakuast-construct-more.t` — 4 assertions (`Var::Lexical`, `ApplyPrefix`, `ApplyPostfix`+`Postfix`, accessor on a constructed node), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green.

Next: `StatementList` (children via the `.add-statement` mutator — needs a mutable-node path), then Phase 5 (EVAL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)