### PR TITLE
fix: six generic bugs surfaced by the META6 test suite

### DIFF
--- a/src/builtins/builtin_type_methods.rs
+++ b/src/builtins/builtin_type_methods.rs
@@ -335,6 +335,7 @@ const IO_HANDLE_METHODS: &[&str] = &[
     "path",
     "IO",
     "slurp",
+    "slurp-rest",
     "spurt",
     "lines",
     "words",

--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -181,21 +181,11 @@ impl Compiler {
                         return;
                     }
                     Stmt::Call { name, args } => {
-                        let positional: Option<Vec<Expr>> = args
-                            .iter()
-                            .map(|arg| match arg {
-                                crate::ast::CallArg::Positional(expr) => Some(expr.clone()),
-                                _ => None,
-                            })
-                            .collect();
-                        if let Some(positional_args) = positional {
-                            self.compile_expr(&Expr::Call {
-                                name: *name,
-                                args: positional_args,
-                            });
-                            self.pop_dynamic_scope_lexical(saved);
-                            return;
-                        }
+                        // Tail statement call is the block's value — including
+                        // named/slip args (compile_tail_stmt_call_value).
+                        self.compile_tail_stmt_call_value(*name, args);
+                        self.pop_dynamic_scope_lexical(saved);
+                        return;
                     }
                     Stmt::VarDecl {
                         name,

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -425,70 +425,7 @@ impl Compiler {
                         main_leaves_value = true;
                         continue;
                     } else if let Stmt::Call { name, args } = stmt {
-                        let rewritten_args = Self::rewrite_stmt_call_args(&name.resolve(), args);
-                        let positional_only = rewritten_args
-                            .iter()
-                            .all(|arg| matches!(arg, CallArg::Positional(_)));
-
-                        if positional_only {
-                            let expr_args: Vec<Expr> = rewritten_args
-                                .iter()
-                                .filter_map(|arg| match arg {
-                                    CallArg::Positional(expr) => Some(expr.clone()),
-                                    _ => None,
-                                })
-                                .collect();
-                            self.compile_expr(&Expr::Call {
-                                name: *name,
-                                args: expr_args,
-                            });
-                            main_leaves_value = true;
-                            continue;
-                        }
-
-                        for arg in &rewritten_args {
-                            match arg {
-                                CallArg::Positional(expr) => self.compile_call_arg(expr),
-                                CallArg::Named {
-                                    name,
-                                    value: Some(expr),
-                                } => {
-                                    self.compile_expr(&Expr::Literal(Value::str(name.clone())));
-                                    self.compile_expr(expr);
-                                    self.code.emit(OpCode::MakePair);
-                                }
-                                CallArg::Named { name, value: None } => {
-                                    self.compile_expr(&Expr::Literal(Value::str(name.clone())));
-                                    self.compile_expr(&Expr::Literal(Value::TRUE));
-                                    self.code.emit(OpCode::MakePair);
-                                }
-                                // `|EXPR` interpolates into the argument list:
-                                // MakeSlip builds the Slip and the call op spreads
-                                // it, so any number of `|` args work.
-                                CallArg::Slip(expr) => {
-                                    self.compile_expr(expr);
-                                    self.code.emit(OpCode::MakeSlip);
-                                }
-                                CallArg::Invocant(_) => unreachable!(),
-                            }
-                        }
-                        let name_idx = self.code.add_constant(Value::str(name.resolve()));
-                        let arg_sources_idx = rewritten_args
-                            .iter()
-                            .map(|arg| match arg {
-                                CallArg::Positional(expr) => Some(expr),
-                                _ => None,
-                            })
-                            .collect::<Option<Vec<&Expr>>>()
-                            .and_then(|exprs| {
-                                let owned: Vec<Expr> = exprs.into_iter().cloned().collect();
-                                self.add_arg_sources_constant(&owned)
-                            });
-                        self.code.emit(OpCode::CallFunc {
-                            name_idx,
-                            arity: rewritten_args.len() as u32,
-                            arg_sources_idx,
-                        });
+                        self.compile_tail_stmt_call_value(*name, args);
                         main_leaves_value = true;
                         continue;
                     }
@@ -548,6 +485,78 @@ impl Compiler {
             self.code.patch_jump(j);
         }
         self.pop_dynamic_scope_lexical(saved);
+    }
+
+    /// Compile a tail-position statement call (`Stmt::Call` as the last
+    /// statement of a body) so its value stays on the stack — the body's
+    /// result. Positional-only calls reuse the expression path; calls with
+    /// named/slip args compile exactly like the statement path (`MakePair`
+    /// pairs, `MakeSlip` + slip side table — a Slip an argument merely
+    /// *evaluates to* stays one argument) and dispatch via `ExecCallPairs
+    /// { keep_value: true }`, which pushes the call's value. Without this, a
+    /// tail call with named args fell to the value-less statement op and the
+    /// routine returned its topic instead (JSON::Marshal's `to-json($ret,
+    /// :$sorted-keys, :$pretty)` tail made `marshal` return Any on the
+    /// interpreter path).
+    pub(super) fn compile_tail_stmt_call_value(
+        &mut self,
+        name: crate::symbol::Symbol,
+        args: &[CallArg],
+    ) {
+        let rewritten_args = Self::rewrite_stmt_call_args(&name.resolve(), args);
+        let positional_only = rewritten_args
+            .iter()
+            .all(|arg| matches!(arg, CallArg::Positional(_)));
+
+        if positional_only {
+            let expr_args: Vec<Expr> = rewritten_args
+                .iter()
+                .filter_map(|arg| match arg {
+                    CallArg::Positional(expr) => Some(expr.clone()),
+                    _ => None,
+                })
+                .collect();
+            self.compile_expr(&Expr::Call {
+                name,
+                args: expr_args,
+            });
+            return;
+        }
+
+        for arg in &rewritten_args {
+            match arg {
+                CallArg::Positional(expr) => self.compile_call_arg(expr),
+                CallArg::Named {
+                    name,
+                    value: Some(expr),
+                } => {
+                    self.compile_expr(&Expr::Literal(Value::str(name.clone())));
+                    self.compile_expr(expr);
+                    self.code.emit(OpCode::MakePair);
+                }
+                CallArg::Named { name, value: None } => {
+                    self.compile_expr(&Expr::Literal(Value::str(name.clone())));
+                    self.compile_expr(&Expr::Literal(Value::TRUE));
+                    self.code.emit(OpCode::MakePair);
+                }
+                // `|EXPR` interpolates into the argument list: MakeSlip builds
+                // the Slip and the slip side table spreads exactly these
+                // positions.
+                CallArg::Slip(expr) => {
+                    self.compile_expr(expr);
+                    self.code.emit(OpCode::MakeSlip);
+                }
+                CallArg::Invocant(_) => unreachable!(),
+            }
+        }
+        let name_idx = self.code.add_constant(Value::str(name.resolve()));
+        let slip_positions_idx = self.add_slip_positions_constant(&rewritten_args);
+        self.code.emit(OpCode::ExecCallPairs {
+            name_idx,
+            arity: rewritten_args.len() as u32,
+            slip_positions_idx,
+            keep_value: true,
+        });
     }
 
     /// Classify a CONTROL block as "resume-safe": it always `.resume`s and
@@ -616,6 +625,12 @@ impl Compiler {
 
     /// The body of a `when`/`default` arm resumes iff its last meaningful
     /// statement is a `.resume` call (and it never `succeed`s before that).
+    /// A tail `if`/`unless` whose taken branch ends in `.resume` also counts
+    /// (`when CX::Warn { say .message; if .message ~~ /…/ { $n++; .resume } }`
+    /// — META6's t/030-versions.t): the inline mechanism treats a run that
+    /// falls through without resuming as resume-with-Nil, so the non-resuming
+    /// branch degrades to that existing approximation instead of losing the
+    /// deep continuation entirely on the resuming branch.
     fn control_block_body_resumes(body: &[Stmt]) -> bool {
         let meaningful: Vec<&Stmt> = body
             .iter()
@@ -624,7 +639,32 @@ impl Compiler {
         if meaningful.iter().any(|s| Self::stmt_exits_control_block(s)) {
             return false;
         }
-        matches!(meaningful.last(), Some(Stmt::Expr(e)) if Self::expr_is_resume_call(e))
+        match meaningful.last() {
+            Some(Stmt::Expr(e)) if Self::expr_is_resume_call(e) => true,
+            Some(Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            }) => {
+                let branch_resumes = |b: &[Stmt]| -> bool {
+                    let m: Vec<&Stmt> = b
+                        .iter()
+                        .filter(|s| !matches!(s, Stmt::SetLine(_)))
+                        .collect();
+                    !m.iter().any(|s| Self::stmt_exits_control_block(s))
+                        && matches!(m.last(), Some(Stmt::Expr(e)) if Self::expr_is_resume_call(e))
+                };
+                let else_ok = {
+                    let m: Vec<&Stmt> = else_branch
+                        .iter()
+                        .filter(|s| !matches!(s, Stmt::SetLine(_)))
+                        .collect();
+                    m.is_empty() || branch_resumes(else_branch)
+                };
+                branch_resumes(then_branch) && else_ok
+            }
+            _ => false,
+        }
     }
 
     fn when_cond_warn_class(cond: &Expr) -> WhenWarnClass {

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1422,21 +1422,12 @@ impl Compiler {
                             continue;
                         }
                         Stmt::Call { name, args } => {
-                            let positional: Option<Vec<Expr>> = args
-                                .iter()
-                                .map(|arg| match arg {
-                                    crate::ast::CallArg::Positional(expr) => Some(expr.clone()),
-                                    _ => None,
-                                })
-                                .collect();
-                            if let Some(positional_args) = positional {
-                                self.compile_expr(&Expr::Call {
-                                    name: *name,
-                                    args: positional_args,
-                                });
-                                self.code.emit(OpCode::SetTopic);
-                                continue;
-                            }
+                            // Tail call: its value is the body result, whether
+                            // the args are positional-only or carry named/slip
+                            // args (compile_tail_stmt_call_value handles both).
+                            self.compile_tail_stmt_call_value(*name, args);
+                            self.code.emit(OpCode::SetTopic);
+                            continue;
                         }
                         Stmt::Block(body) | Stmt::SyntheticBlock(body) => {
                             if Self::has_block_placeholders(body) {

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2165,6 +2165,7 @@ impl Compiler {
                     name_idx,
                     arity: rewritten_args.len() as u32,
                     slip_positions_idx,
+                    keep_value: false,
                 });
             }
             // Loop control

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -720,10 +720,14 @@ pub(crate) enum OpCode {
     /// positions written as `|EXPR`. Those — and only those — spread into the
     /// argument list: a Slip an ordinary argument merely evaluated to
     /// (`is-deeply $s.Slip, $t.Slip, 'name'`) stays one argument, as in Rakudo.
+    /// `keep_value` (tail position: the call's value is the body's result)
+    /// pushes the call result onto the stack; plain statement position leaves
+    /// the stack untouched.
     ExecCallPairs {
         name_idx: u32,
         arity: u32,
         slip_positions_idx: Option<u32>,
+        keep_value: bool,
     },
     BlockScope {
         pre_end: u32,

--- a/src/runtime/call_helpers.rs
+++ b/src/runtime/call_helpers.rs
@@ -24,9 +24,9 @@ impl Interpreter {
         &mut self,
         name: &str,
         args: Vec<Value>,
-    ) -> Result<(), RuntimeError> {
+    ) -> Result<Value, RuntimeError> {
         match self.call_function(name, args.clone()) {
-            Ok(_) => Ok(()),
+            Ok(v) => Ok(v),
             Err(e)
                 if e.message
                     .contains("Unknown function (call_function fallback disabled):") =>
@@ -41,11 +41,11 @@ impl Interpreter {
         &mut self,
         name: &str,
         args: Vec<Value>,
-    ) -> Result<(), RuntimeError> {
+    ) -> Result<Value, RuntimeError> {
         // For EVAL, route through call_function to handle named args like :check.
         if name == "EVAL" {
             return match self.call_function(name, args.clone()) {
-                Ok(_) => Ok(()),
+                Ok(v) => Ok(v),
                 Err(e)
                     if e.message
                         .contains("Unknown function (call_function fallback disabled):") =>

--- a/src/runtime/calls.rs
+++ b/src/runtime/calls.rs
@@ -276,12 +276,19 @@ impl Interpreter {
         finalized.and_then(|v| self.maybe_fetch_rw_proxy(v, def.is_rw))
     }
 
-    pub(crate) fn exec_call(&mut self, name: &str, args: Vec<Value>) -> Result<(), RuntimeError> {
+    /// Execute a statement-position call. Returns the call's value so a
+    /// tail-position statement call (`ExecCallPairs { keep_value: true }`) can
+    /// use it as the body result; plain statement sites ignore it.
+    pub(crate) fn exec_call(
+        &mut self,
+        name: &str,
+        args: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
         let (args, callsite_line) = self.sanitize_call_args(&args);
         self.test_pending_callsite_line = callsite_line;
         // Delegate test functions to the unified test_functions.rs
-        if let Some(_result) = self.call_test_function(name, &args)? {
-            return Ok(());
+        if let Some(result) = self.call_test_function(name, &args)? {
+            return Ok(result);
         }
         match name {
             "make" => {
@@ -303,11 +310,28 @@ impl Interpreter {
                     && let Some(sub_val) = self.get_wrapped_sub(name)
                 {
                     let result = self.call_sub_value(sub_val, args, false)?;
-                    self.env.insert("_".to_string(), result);
-                    return Ok(());
+                    self.env.insert("_".to_string(), result.clone());
+                    return Ok(result);
                 }
                 let def_opt = self.resolve_function_with_alias(name, &args);
                 if let Some(def) = def_opt {
+                    // The real JSON::Fast/JSON::Tiny `to-json`/`from-json` defs
+                    // resolve here, but their nqp-based bodies cannot run under
+                    // mutsu — the module-gated native must win, matching the
+                    // expression path (where those defs never compile). A
+                    // user-defined from-json in any other package still wins.
+                    let def_pkg = def.package.resolve();
+                    let is_json_module_pkg = ["JSON::Fast", "JSON::Tiny"].iter().any(|m| {
+                        def_pkg == *m
+                            || (def_pkg.starts_with(*m)
+                                && def_pkg[m.len()..].starts_with(':')
+                                && !def_pkg[m.len()..].starts_with("::"))
+                    });
+                    if is_json_module_pkg
+                        && let Some(result) = self.try_native_json_function(name, &args)
+                    {
+                        return result;
+                    }
                     self.check_deprecation_for_def(&def);
                     if def.empty_sig && !args.is_empty() {
                         return Err(Self::reject_args_for_empty_sig(&args));
@@ -406,7 +430,8 @@ impl Interpreter {
                         Ok(()) => Ok(implicit_return),
                         Err(e) => Err(e),
                     };
-                    self.finalize_return_with_spec(call_result, effective_return_spec.as_deref())?;
+                    return self
+                        .finalize_return_with_spec(call_result, effective_return_spec.as_deref());
                 } else if let Some(err) = self.take_pending_dispatch_error() {
                     return Err(err);
                 } else if self.has_proto(name) {
@@ -454,13 +479,13 @@ impl Interpreter {
                     // expression path dispatches these in vm_call_func_ops.
                     // Placed after user-sub resolution so a user-defined
                     // from-json still wins.
-                    result?;
+                    return result;
                 } else {
                     return Err(RuntimeError::new(format!("Unknown call: {}", name)));
                 }
             }
         }
-        Ok(())
+        Ok(Value::NIL)
     }
 
     /// Build the positional/named argument type-name list used for the

--- a/src/runtime/methods_classhow_attribute.rs
+++ b/src/runtime/methods_classhow_attribute.rs
@@ -147,12 +147,18 @@ impl Interpreter {
             .get(&(owner.to_string(), attr_name.clone()))
             .cloned();
         let full_name = format!("{}!{}", sigil, attr_name);
+        // Resolve a short declared type against the owner's package chain: a
+        // nested class (`class META6 { class Support {…}; has Support $.support }`)
+        // registers as `META6::Support`, and `.type` must report that resolved
+        // type (rakudo does) — JSON::Unmarshal constructs nested typed
+        // attributes from it.
         let raw_type_name = self
             .registry()
             .classes
             .get(owner)
             .and_then(|cd| cd.attribute_types.get(attr_name))
-            .cloned();
+            .cloned()
+            .map(|t| self.resolve_type_name_for_owner(owner, t));
         // For @ sigil, the exposed type is Positional[T]; for % it is Associative[T]
         let type_name = match sigil {
             '@' => {
@@ -258,6 +264,10 @@ impl Interpreter {
         type_constraint: Option<&str>,
     ) -> Value {
         let full_name = format!("{}!{}", sigil, attr_name);
+        // Same owner-chain resolution as `make_attribute_object`: a nested
+        // class's short name must resolve to its qualified registration.
+        let type_constraint =
+            type_constraint.map(|t| self.resolve_type_name_for_owner(owner, t.to_string()));
         let type_name = match sigil {
             '@' => type_constraint
                 .map(|t| format!("Positional[{}]", t))
@@ -265,7 +275,7 @@ impl Interpreter {
             '%' => type_constraint
                 .map(|t| format!("Associative[{}]", t))
                 .unwrap_or_else(|| "Associative".to_string()),
-            _ => type_constraint.unwrap_or("Mu").to_string(),
+            _ => type_constraint.unwrap_or_else(|| "Mu".to_string()),
         };
         let mut meta = HashMap::new();
         meta.insert("name".to_string(), Value::str(full_name));

--- a/src/runtime/native_io/io_handle.rs
+++ b/src/runtime/native_io/io_handle.rs
@@ -716,7 +716,10 @@ impl Interpreter {
                 let opened = self.with_handle_mut(&target_val, |state| Ok(state.is_opened()))?;
                 Ok(Value::truth(opened))
             }
-            "slurp" => {
+            // `slurp-rest` is the deprecated Rakudo spelling of "slurp the rest
+            // of the handle from the current position" — same behavior as
+            // `.slurp` here, which also reads from the current position.
+            "slurp" | "slurp-rest" => {
                 let has_bin_arg = Self::named_bool(&args, "bin");
                 let (is_bin, handle_encoding) = self.with_handle_mut(&target_val, |state| {
                     let bin = has_bin_arg || state.bin || state.encoding == "bin";

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -248,7 +248,7 @@ impl Interpreter {
                 .map(|&i| narrowness(&all_matches[i].1))
                 .max()
                 .unwrap_or(0);
-            let narrowed: Vec<usize> = tied
+            let mut narrowed: Vec<usize> = tied
                 .iter()
                 .copied()
                 .filter(|&i| narrowness(&all_matches[i].1) == best_where)
@@ -256,6 +256,36 @@ impl Interpreter {
             if let Some(&i) = narrowed.first() {
                 best_idx = i;
             }
+            // Explicit-named preference (rakudo): among otherwise-tied
+            // candidates, one that declares an explicit (non-slurpy) named
+            // parameter is narrower than one that does not — `(Int $a, :$x)`
+            // beats `(Int $a)` for `f(1)` regardless of declaration order.
+            let has_explicit_named = |def: &MethodDef| -> bool {
+                def.param_defs
+                    .iter()
+                    .any(|p| p.named && !p.slurpy && !p.double_slurpy)
+            };
+            if narrowed
+                .iter()
+                .any(|&i| has_explicit_named(&all_matches[i].1))
+                && narrowed
+                    .iter()
+                    .any(|&i| !has_explicit_named(&all_matches[i].1))
+            {
+                narrowed.retain(|&i| has_explicit_named(&all_matches[i].1));
+                if let Some(&i) = narrowed.first() {
+                    best_idx = i;
+                }
+            }
+            // Named parameters never make a dispatch ambiguous (rakudo): tied
+            // candidates that all declare explicit named params resolve by
+            // declaration order (`(Any :$file!)` vs `(Str :$file!)` picks the
+            // first; named types/requiredness are not compared). Only a tie
+            // among candidates with no explicit named params raises
+            // X::Multi::Ambiguous (`(Int $a)` x2, `(Int $a, *%o)` x2).
+            let all_named = narrowed
+                .iter()
+                .all(|&i| has_explicit_named(&all_matches[i].1));
             // Invocant specificity tie-break: candidates whose argument-type
             // distance is equal can still differ in how derived their owning
             // class is. A `multi method` defined on the receiver's own class is
@@ -292,7 +322,7 @@ impl Interpreter {
             // (same type distance, same number of `where` constraints, and the
             // same most-derived owner class) and none is marked `is default`.
             // Raku raises X::Multi::Ambiguous here.
-            if !default_winner && mro_narrowed.len() > 1 {
+            if !default_winner && mro_narrowed.len() > 1 && !all_named {
                 self.dispatch_ambiguous = true;
             }
         }
@@ -306,16 +336,25 @@ impl Interpreter {
         let mut total = 0usize;
         let mut arg_idx = 0;
         for pd in &def.param_defs {
-            if pd.is_invocant || pd.named || pd.name.starts_with("__type_capture__") {
+            if pd.is_invocant || pd.name.starts_with("__type_capture__") {
                 continue;
             }
             // Slurpy parameters (`*@x`, `*%h`, `**@x`) are less specific than a
             // required positional of the same type. When a single Positional
             // argument matches both `(@x)` and `(*@x)`, the non-slurpy candidate
             // must win rather than being treated as equally specific (ambiguous).
-            if pd.slurpy || pd.double_slurpy {
+            // This includes a user-written named-hash slurpy: `(*%items)` must
+            // lose to `(IO::Path :$file!)` for `.load(file => $path)` (META6's
+            // `multi method new` set). The implicit method `*%_` is on every
+            // candidate, so it carries no penalty.
+            if (pd.slurpy || pd.double_slurpy) && pd.name != "%_" && pd.name != "_" {
                 total += 2000;
-                arg_idx += 1;
+                if !pd.named && !pd.name.starts_with('%') {
+                    arg_idx += 1;
+                }
+                continue;
+            }
+            if pd.named || pd.slurpy || pd.double_slurpy {
                 continue;
             }
             if let Some(tc) = &pd.type_constraint {

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -723,6 +723,9 @@ impl Interpreter {
                     "encoding",
                     "opened",
                     "slurp",
+                    // Deprecated Rakudo alias for `.slurp` from the current
+                    // position (META6's `multi method new(IO::Handle :$file!)`).
+                    "slurp-rest",
                     "out-buffer",
                     "Supply",
                     "open",

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -292,6 +292,60 @@ impl Interpreter {
             })
     }
 
+    /// Resolve a short type name against the current package chain: inside
+    /// `module Foo { class Params {…}; sub mk { Params.new } }` the sub's
+    /// bareword `Params` names `Foo::Params` (registered fully qualified),
+    /// even when `mk` is called from another package (JSON::Marshal's
+    /// `MarshalParams`, reached through META6's `to-json`). Walks enclosing
+    /// packages outward (`A::B::name`, then `A::name`); GLOBAL is the normal
+    /// bare namespace, so it ends the walk.
+    pub(crate) fn resolve_type_in_current_package(&self, name: &str) -> Option<String> {
+        if name.contains("::") || name.is_empty() {
+            return None;
+        }
+        let pkg_owned = self.current_package().to_string();
+        let mut pkg: &str = &pkg_owned;
+        loop {
+            if pkg.is_empty() || pkg == "GLOBAL" {
+                return None;
+            }
+            let qualified = format!("{pkg}::{name}");
+            if self.has_type_direct(&qualified) {
+                return Some(qualified);
+            }
+            match pkg.rsplit_once("::") {
+                Some((parent, _)) => pkg = parent,
+                None => return None,
+            }
+        }
+    }
+
+    /// Resolve a short type name against a specific owner package's chain
+    /// (`owner = "META6"`, `name = "Support"` → `"META6::Support"` when that
+    /// nested class exists). A nested class lexically shadows a same-named
+    /// outer type inside its declaring class, so the qualified probe runs
+    /// first; an unresolvable name is returned unchanged.
+    pub(crate) fn resolve_type_name_for_owner(&self, owner: &str, name: String) -> String {
+        if name.contains("::") || name.is_empty() {
+            return name;
+        }
+        let mut pkg = owner;
+        loop {
+            if pkg.is_empty() {
+                break;
+            }
+            let qualified = format!("{pkg}::{name}");
+            if self.has_type_direct(&qualified) {
+                return qualified;
+            }
+            match pkg.rsplit_once("::") {
+                Some((parent, _)) => pkg = parent,
+                None => break,
+            }
+        }
+        name
+    }
+
     pub(crate) fn has_enum_type(&self, name: &str) -> bool {
         self.registry().enum_types.contains_key(name)
     }

--- a/src/vm/vm_call_exec_ops.rs
+++ b/src/vm/vm_call_exec_ops.rs
@@ -112,6 +112,7 @@ impl Interpreter {
         name_idx: u32,
         arity: u32,
         slip_positions_idx: Option<u32>,
+        keep_value: bool,
     ) -> Result<(), RuntimeError> {
         let name = Self::const_str(code, name_idx).to_string();
         let arity = arity as usize;
@@ -132,15 +133,21 @@ impl Interpreter {
         // Try compiled function dispatch first
         if let Some(cf) = self.find_compiled_function(compiled_fns, &name, &args) {
             let pkg = self.current_package().to_string();
-            self.call_compiled_function_named(cf, args, compiled_fns, &pkg, &name)?;
+            let v = self.call_compiled_function_named(cf, args, compiled_fns, &pkg, &name)?;
             // Slice F: drain any `is rw` param writeback into the caller's slots.
             self.apply_pending_rw_writeback(code);
             // call_compiled_function_named signals env_dirty precisely; no blanket.
+            if keep_value {
+                self.stack.push(v);
+            }
             return Ok(());
         }
         // Try native function (env-pure: no env_dirty mark).
         if let Some(native_result) = self.try_native_function(Symbol::intern(&name), &args) {
-            native_result?;
+            let v = native_result?;
+            if keep_value {
+                self.stack.push(v);
+            }
             return Ok(());
         }
         // Carrier fallback: precise scalar writeback + unconditional env_dirty net.
@@ -156,11 +163,20 @@ impl Interpreter {
         // `slot_carrier_overwritable`).
         let pre_env: Vec<Option<Value>> = self.snapshot_carrier_overwritable_env(code);
         let carrier_saved = self.begin_carrier();
+        // Tail position (`keep_value`) routes through the standard expression
+        // dispatcher first (call_function — same as exec_call_values) so the
+        // call's value is the real return value; the legacy exec_call carrier
+        // reconstructs an implicit return from the topic, which is unreliable
+        // for a value that must propagate (JSON::Marshal's tail
+        // `to-json($ret, :$sorted-keys, :$pretty)`).
         let exec_result = loan_env!(self, exec_call_pairs_values(&name, args));
         let written = self.end_carrier(carrier_saved);
-        exec_result?;
+        let v = exec_result?;
         self.writeback_carrier_writes(code, &written);
         self.carrier_writeback_changed_aggregates(code, &pre_env);
+        if keep_value {
+            self.stack.push(v);
+        }
         Ok(())
     }
 }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3131,6 +3131,7 @@ impl Interpreter {
                 name_idx,
                 arity,
                 slip_positions_idx,
+                keep_value,
             } => {
                 self.sync_source_line(code, *ip);
                 self.exec_exec_call_pairs_op(
@@ -3139,6 +3140,7 @@ impl Interpreter {
                     *name_idx,
                     *arity,
                     *slip_positions_idx,
+                    *keep_value,
                 )?;
                 *ip += 1;
             }

--- a/src/vm/vm_native_json.rs
+++ b/src/vm/vm_native_json.rs
@@ -25,8 +25,16 @@ impl Interpreter {
             return None;
         }
         // Strip the synthetic `__test_callsite_line` trailer (and any other
-        // call-site bookkeeping) the same way the Test path does.
+        // call-site bookkeeping) the same way the Test path does. Unwrap
+        // VarRef-wrapped args (a statement-position call compiles its variable
+        // args through `compile_call_arg`, which wraps them for rw detection)
+        // — the serializer would otherwise hit its opaque-value fallback and
+        // emit the *stringification* of the wrapped Hash.
         let (clean_args, _callsite_line) = self.sanitize_call_args(args);
+        let clean_args: Vec<Value> = clean_args
+            .into_iter()
+            .map(crate::runtime::types::unwrap_varref_value)
+            .collect();
         match name {
             "to-json" => Some(native_to_json(&clean_args)),
             "from-json" => Some(native_from_json(&clean_args)),

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -2238,6 +2238,32 @@ impl Interpreter {
                 let inner = self
                     .call_method_with_values(target, at, vec![inner_idx.clone()])?
                     .deref_container();
+                // The inner collection is itself a user-defined instance: route
+                // the outermost write through its ASSIGN-POS/ASSIGN-KEY
+                // (`$obj<support><source> = v` with both levels custom
+                // Associative — META6's AutoAssoc). The instance's attribute
+                // cell is shared, so the mutation is visible through the base.
+                if let ValueView::Instance {
+                    class_name: inner_cn,
+                    ..
+                } = inner.view()
+                {
+                    let icn = inner_cn.resolve();
+                    let assign = if outer_positional {
+                        "ASSIGN-POS"
+                    } else {
+                        "ASSIGN-KEY"
+                    };
+                    if self.has_user_method(&icn, assign) {
+                        self.call_method_with_values(
+                            inner,
+                            assign,
+                            vec![outer_idx.clone(), val.clone()],
+                        )?;
+                        self.stack.push(val);
+                        return Ok(());
+                    }
+                }
                 let idx_u = crate::runtime::to_int(&outer_idx) as usize;
                 let elem = match inner.view() {
                     ValueView::Array(items, _) => items.get(idx_u).cloned(),

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -206,6 +206,12 @@ impl Interpreter {
             || Self::is_type_with_smiley(name, self)
         {
             Value::package(Symbol::intern(Self::resolve_type_alias(name)))
+        } else if let Some(qualified) = self.resolve_type_in_current_package(name) {
+            // A short type name declared in the (dynamically) current package —
+            // `module Foo { class Params {…}; sub mk { Params.new } }` where the
+            // class registered as `Foo::Params` and `mk` runs from another
+            // package's call site.
+            Value::package(Symbol::intern(&qualified))
         } else if self.wrap_sub_id_for_name(name).is_some()
             && let Some(sub_val) = self.get_wrapped_sub(name)
         {

--- a/t/control-warn-conditional-resume.t
+++ b/t/control-warn-conditional-resume.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 4;
+
+# A CONTROL handler whose `when CX::Warn` arm resumes CONDITIONALLY (the
+# `.resume` sits at the tail of an `if` inside the arm) must still resume the
+# deep computation at the raise site — META6's t/030-versions.t counts
+# version-prefix warnings this way and the assignment after the warn was lost.
+sub make() { warn "W1"; 42 }
+my $obj;
+my $count = 0;
+{
+    CONTROL {
+        when CX::Warn {
+            if $_.message ~~ /W/ {
+                $count++;
+                $_.resume;
+            }
+        }
+    };
+    $obj = make();
+}
+is $obj, 42, 'the callee resumed and its return value survived';
+is $count, 1, 'the handler ran exactly once';
+
+# The unconditional form keeps working.
+my $obj2;
+my $count2 = 0;
+{
+    CONTROL {
+        when CX::Warn {
+            $count2++;
+            $_.resume;
+        }
+    };
+    $obj2 = make();
+}
+is $obj2, 42, 'unconditional resume arm still works';
+is $count2, 1, 'and ran once';
+
+done-testing;

--- a/t/io-handle-slurp-rest.t
+++ b/t/io-handle-slurp-rest.t
@@ -1,0 +1,21 @@
+use Test;
+
+plan 3;
+
+# `slurp-rest` is the deprecated Rakudo spelling of "slurp the rest of the
+# handle from the current position" (META6's
+# `multi method new(IO::Handle :$file!)` uses it).
+my $path = $*TMPDIR.add("mutsu-slurp-rest-{$*PID}.txt");
+$path.spurt("hello\nworld\n");
+END $path.unlink;
+
+my $h = $path.open;
+is $h.slurp-rest, "hello\nworld\n", 'slurp-rest reads the whole handle';
+$h.close;
+
+my $h2 = $path.open;
+is $h2.get, "hello", 'get reads the first line';
+is $h2.slurp-rest, "world\n", 'slurp-rest reads from the current position';
+$h2.close;
+
+done-testing;

--- a/t/lib/TailNamedCall.rakumod
+++ b/t/lib/TailNamedCall.rakumod
@@ -1,0 +1,13 @@
+use v6;
+
+# Fixture for t/tail-stmt-call-named-value.t: a module sub whose body ends in
+# a statement-position call with named arguments (JSON::Marshal's `marshal`
+# ends in `to-json($ret, :$sorted-keys, :$pretty)`).
+module TailNamedCall {
+    use JSON::Fast;
+
+    sub render(Any $obj, Bool :$pretty = True --> Str) is export {
+        my $ret = $obj;
+        to-json($ret, :$pretty);
+    }
+}

--- a/t/multi-method-named-dispatch.t
+++ b/t/multi-method-named-dispatch.t
@@ -1,0 +1,77 @@
+use Test;
+
+plan 15;
+
+# Multi-method dispatch on required named parameters must narrow by the named
+# argument's type and by required-named presence (META6's
+# `multi method new(Str :$file!)` / `(IO::Path :$file!)` / `(IO::Handle
+# :$file!)` / `(Str:D :$json!)` / `(*%items)` set was reported Ambiguous).
+class C {
+    multi method load(Str :$file!) { "str" }
+    multi method load(IO::Path :$file!) { "path" }
+    multi method load(IO::Handle :$file!) { "handle" }
+    multi method load(Str:D :$json!) { "json" }
+    multi method load(*%items) { "slurpy:" ~ %items.keys.sort.join(",") }
+}
+is C.load(file => "x".IO), "path", 'IO::Path named arg picks the IO::Path candidate';
+is C.load(file => "x"), "str", 'Str named arg picks the Str candidate';
+is C.load(json => "j"), "json", 'required named presence selects the json candidate';
+is C.load(a => 1, b => 2), "slurpy:a,b", 'unknown named args fall to the named slurpy';
+is C.load(), "slurpy:", 'no args fall to the named slurpy';
+
+# The same set as multi method new (constructor position).
+class D {
+    multi method new(Str :$file!) { "str" }
+    multi method new(IO::Path :$file!) { "path" }
+    multi method new(*%items) { "slurpy" }
+}
+is D.new(file => "x".IO), "path", 'multi method new dispatches on named arg type';
+is D.new(file => "s"), "str", 'multi method new picks Str candidate for Str';
+is D.new(a => 1), "slurpy", 'multi method new falls to slurpy for unknown named';
+
+# rakudo tie-break rules around named params:
+# - identical positional-only candidates stay ambiguous
+class T1 {
+    multi method f(Int $a) { "a" }
+    multi method f(Int $b) { "b" }
+}
+throws-like { T1.f(1) }, X::Multi::Ambiguous,
+    'identical positional candidates are ambiguous';
+# - candidates that differ only in named params resolve by declaration order
+class T2 {
+    multi method f(Int $a, :$x) { "x" }
+    multi method f(Int $a, :$y) { "y" }
+}
+is T2.f(1), "x", 'named-differing tie resolves to the first declared candidate';
+# - a candidate with an explicit named param beats one without, regardless of order
+class T3 {
+    multi method f(Int $a) { "plain" }
+    multi method f(Int $a, :$x) { "named" }
+}
+is T3.f(1), "named", 'explicit named param out-narrows a plain candidate';
+class T4 {
+    multi method f(Int $a, :$x) { "named" }
+    multi method f(Int $a) { "plain" }
+}
+is T4.f(1), "named", '... in either declaration order';
+# - named types are not compared: declaration order wins
+class T5 {
+    multi method h(Any :$file!) { "any" }
+    multi method h(Str :$file!) { "str" }
+}
+is T5.h(file => "s"), "any", 'named param types do not narrow (declaration order)';
+# - incomparable positionals stay ambiguous
+class T6 {
+    multi method f(Int $a, Any $b) { "ia" }
+    multi method f(Any $a, Int $b) { "ai" }
+}
+throws-like { T6.f(1, 2) }, X::Multi::Ambiguous,
+    'incomparable positional candidates stay ambiguous';
+# - a user-written named slurpy loses to a required named
+class T7 {
+    multi method h(*%items) { "slurpy" }
+    multi method h(IO::Path :$file!) { "path" }
+}
+is T7.h(file => "x".IO), "path", 'required named beats *%slurpy regardless of order';
+
+done-testing;

--- a/t/nested-assoc-user-assign-key.t
+++ b/t/nested-assoc-user-assign-key.t
@@ -1,0 +1,52 @@
+use Test;
+
+plan 4;
+
+# Chained subscript assignment where BOTH levels are user-defined Associative
+# instances: `$o<support><source> = v` must route the outer read through
+# AT-KEY and the innermost write through the inner instance's ASSIGN-KEY
+# (META6's AutoAssoc — t/050-assoc.t "Support is writable").
+role AA does Associative {
+    method AT-KEY($key) {
+        my $attr = self.^attributes(:local).grep({ .name eq '$!' ~ $key })[0];
+        $attr.defined ?? $attr.get_value(self) !! Nil;
+    }
+    method ASSIGN-KEY($key, \value) {
+        my $attr = self.^attributes(:local).grep({ .name eq '$!' ~ $key })[0];
+        $attr.set_value(self, value) if $attr.defined;
+    }
+}
+class Inner does AA {
+    has Str $.source is rw;
+}
+class Outer does AA {
+    has Inner $.support is rw;
+}
+my $o = Outer.new(support => Inner.new(source => "orig"));
+is $o<support><source>, "orig", 'chained read through two AT-KEY levels';
+$o<support><source> = 'spicy';
+is $o<support><source>, 'spicy', 'chained write reaches the inner ASSIGN-KEY';
+is $o.support.source, 'spicy', 'the attribute itself was mutated';
+
+# Positional inner level: ASSIGN-POS on a user Positional instance.
+role AP does Positional {
+    method AT-POS($i) {
+        my $attr = self.^attributes(:local)[0];
+        $attr.get_value(self)[$i];
+    }
+    method ASSIGN-POS($i, \value) {
+        my $attr = self.^attributes(:local)[0];
+        $attr.get_value(self)[$i] = value;
+    }
+}
+class Seat does AP {
+    has @.rows;
+}
+class Hall does AA {
+    has Seat $.seats is rw;
+}
+my $h = Hall.new(seats => Seat.new(rows => ["a", "b"]));
+$h<seats>[1] = "z";
+is $h.seats.rows[1], "z", 'chained write reaches the inner ASSIGN-POS';
+
+done-testing;

--- a/t/nested-class-short-name-resolution.t
+++ b/t/nested-class-short-name-resolution.t
@@ -1,0 +1,50 @@
+use Test;
+
+plan 5;
+
+# A class nested in a module registers fully qualified (`Foo::Params`); a sub
+# in the same module must resolve the short bareword `Params` at runtime even
+# when called from another package (JSON::Marshal's `MarshalParams.new` inside
+# `marshal`, reached through META6's `to-json`).
+module Foo {
+    class Params { has $.x }
+    my class Hidden { has $.y }
+    sub mk() is export { Params.new(x => 1) }
+    sub mk-hidden() is export { Hidden.new(y => 2) }
+}
+import Foo;
+is mk().x, 1, 'module sub resolves a sibling nested class by short name';
+is mk-hidden().y, 2, '... and a my-scoped nested class';
+
+# Attribute.type on an attribute whose declared type is a nested class must
+# report the resolved (qualified) type, as rakudo does — JSON::Unmarshal
+# constructs nested typed attributes from it (META6's `has Support $.support`).
+class OuterK {
+    class InnerK { has $.v }
+    has InnerK $.child is rw;
+}
+my $attr = OuterK.^attributes(:local).grep({ .name eq '$!child' })[0];
+is $attr.type.^name, 'OuterK::InnerK', 'Attribute.type resolves a nested class type';
+
+# The same via a custom attribute trait (the trait-time Attribute object path).
+module TraitMod {
+    multi sub trait_mod:<is> (Attribute $attr, :$tagged!) is export { }
+}
+import TraitMod;
+class OuterT {
+    class InnerT { has $.v }
+    has InnerT $.child is rw is tagged;
+}
+my $attr2 = OuterT.^attributes(:local).grep({ .name eq '$!child' })[0];
+is $attr2.type.^name, 'OuterT::InnerT', 'trait-time Attribute object resolves the type too';
+
+# A global same-named class does not shadow the nested one for the owner.
+class GShadow { has $.g }
+class OuterS {
+    class GShadow { has $.n }
+    has GShadow $.child is rw;
+}
+my $attr3 = OuterS.^attributes(:local).grep({ .name eq '$!child' })[0];
+is $attr3.type.^name, 'OuterS::GShadow', 'nested class shadows a same-named outer type';
+
+done-testing;

--- a/t/tail-stmt-call-named-value.t
+++ b/t/tail-stmt-call-named-value.t
@@ -1,0 +1,33 @@
+use v6;
+use lib 't/lib';
+use Test;
+use TailNamedCall;
+
+plan 5;
+
+# A statement-position call with NAMED arguments as the last statement of a
+# body must yield the call's value (the body result). It previously compiled
+# to a value-less statement op, so the routine returned its stale topic —
+# JSON::Marshal's `marshal` (tail `to-json($ret, :$sorted-keys, :$pretty)`)
+# returned Any and META6's `$m.to-json` died in the `--> Str` return check.
+
+sub f(:$x) { "v" ~ $x }
+
+my $r = do { f(:x(1)) };
+is $r, "v1", 'do-block tail named call yields the value';
+
+sub g(--> Str) { f(:x(2)) }
+is g(), "v2", 'sub tail named call yields the value';
+
+is render({b => 2}, :!pretty), Q<{"b":2}>, 'module sub with native tail named call returns its value';
+
+my $r2 = do { render({c => 3}, :!pretty) };
+is $r2, Q<{"c":3}>, 'do-block over the module sub keeps the value';
+
+role R {
+    method go(--> Str) { render(self.x, :!pretty) }
+}
+my class P does R { has $.x }
+is P.new(x => {d => 4}).go(), Q<{"d":4}>, 'role-method caller gets the module sub value';
+
+done-testing;


### PR DESCRIPTION
## Summary
META6-0.0.31 (the mzef Test-phase frontier, PLAN §1 B2) goes from **2/9 to 9/9 passing test files** on this branch (combined with the already-merged #4725). Every fix is a general-purpose language/runtime fix:

1. **Multi-method dispatch on named parameters** (`resolution_method.rs`): candidates narrow by a named argument's type and by required-named presence; a user-written named slurpy (`*%items`) is less specific than a required named; tied candidates that declare explicit named params resolve by declaration order instead of raising X::Multi::Ambiguous; a candidate with an explicit named param out-narrows a plain one. All rules verified against rakudo (8-case matrix in `t/multi-method-named-dispatch.t`). Unblocks META6's `multi method new(Str :$file!)/(IO::Path :$file!)/(IO::Handle :$file!)/(Str:D :$json!)/(*%items)` set, previously reported "Ambiguous".
2. **`IO::Handle.slurp-rest`**: deprecated Rakudo alias, slurps from the current position (META6's `new(IO::Handle :$file!)`).
3. **CONTROL/CX::Warn conditional resume** (`helpers_control_flow.rs`): a `when CX::Warn` arm whose `.resume` sits at the tail of an `if` is now classified resume-safe, so a deep warn resumes at the raise site instead of losing the callee's continuation (META6 t/030-versions.t counts version-prefix warnings this way).
4. **Tail-position statement calls with named args yield the call's value** (`ExecCallPairs { keep_value }` + `exec_call` returning the value): JSON::Marshal's tail `to-json($ret, :$sorted-keys, :$pretty)` made `marshal` return Any on the interpreter path (`--> Str` return check died). Slip-valued arguments keep statement-call semantics — only syntactic `|` spreads (pinned by the existing `t/slip-arg-flatten.t`). The real JSON::Fast/JSON::Tiny `to-json`/`from-json` defs now yield to the native implementation in `exec_call` (their nqp bodies cannot run under mutsu), and the native JSON entry unwraps VarRef-wrapped args.
5. **Chained subscript writes through user ASSIGN-KEY/ASSIGN-POS** (`$obj<support><source> = v` with both levels custom Associative — META6's AutoAssoc; t/050-assoc "Support is writable").
6. **Nested-class short-name resolution**: `Attribute.type` resolves a nested class's short name against the owner's package chain (`has Support $.support` → `META6::Support`, matching rakudo) on both the introspection and trait-time paths — JSON::Unmarshal then constructs the typed nested attribute; bareword type references inside module subs resolve through the current package chain the same way (JSON::Marshal's `my class MarshalParams`).

## Testing
- `make test` full PASS (18011 tests, includes 6 new pin files)
- Roast sweep of whitelisted S06-multi / S06-signature / S06-currying / S12-methods / S04-phasers / S32-io (142 files, 4013 tests) PASS
- META6 E2E: all 9 test files pass with deps staged via MUTSULIB
- rakudo parity confirmed per fix (multi-dispatch matrix, slurp-rest, warn-resume, Slip-arg binding, nested AT-KEY/ASSIGN-KEY, Attribute.type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)