### PR TITLE
feat: RakuAST Phase 5 slice 1 — EVAL of literals

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -874,10 +874,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 4: `Var::Lexical.new`, `ApplyPrefix`/`ApplyPostfix`, `Postfix.new(:operator)`. Tests in
         `t/rakuast-construct-more.t`.
   - [ ] Slice 5+: `StatementList` (children via `.add-statement` mutator — needs a mutable-node path),
-        block/sub/declaration constructors; then Phase 5 (EVAL: lower RakuAST → internal AST →
-        existing compiler).
-- [ ] **Phase 4** — construction (`.new`, `.from-identifier`, …).
-- [ ] **Phase 5** — EVAL: lower RakuAST → internal AST → existing compiler (no new engine).
+        block/sub/declaration constructors.
+- **Phase 5 (in progress)** — EVAL: lower RakuAST → internal AST → existing compiler (no new engine).
+  - [x] Slice 1: EVAL of the literal cluster (`src/rakuast/lower.rs`; `EVAL(IntLiteral.new(42))` →
+        42, `EVAL(Q[42].AST)` round-trips). Tests in `t/rakuast-eval.t`.
+  - [ ] Slice 2+: `ApplyInfix`/`ApplyPrefix` (operator-name → `TokenKind` reverse map), then
+        variables / statements / declarations.
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -177,6 +177,14 @@ earlier ones.
 - **Phase 5 — EVAL / compilation.** `lower(RakuAstNode) -> Vec<Stmt>/Expr`, then the
   **existing** compiler. `EVAL($rakuast)` and any code that yields a RakuAST tree runs
   through this. No new execution engine.
+  - **Slice 1 (literals) — done.** `src/rakuast/lower.rs` lowers a RakuAST node back to internal
+    `Stmt`/`Expr`; `builtin_eval` now recognises a `Value::RakuAst` first argument, lowers it, and
+    runs it via `eval_block_value` (the existing evaluator). `EVAL(RakuAST::IntLiteral.new(42))` →
+    `42`, and `EVAL(Q[42].AST)` round-trips source → node tree → value. Slice 1 lowers the literal
+    cluster (`IntLiteral`/`RatLiteral`/`StrLiteral`, single-segment `QuotedString`) plus the
+    `StatementList` / `Statement::Expression` wrappers; anything else is an explicit `RuntimeError`.
+    Tests in `t/rakuast-eval.t`. Next: `ApplyInfix`/`ApplyPrefix` (needs an operator-name →
+    `TokenKind` reverse map), then variables/statements/declarations.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -1,0 +1,112 @@
+//! RakuAST node tree → internal AST (`Stmt`/`Expr`) — the write direction that
+//! backs `EVAL($rakuast)` (ADR-0011 Phase 5). The lowered AST is fed to the
+//! existing compiler; there is no second execution engine.
+//!
+//! Slice 1 covers the literal cluster (and the `StatementList` /
+//! `Statement::Expression` wrappers around it). Constructs outside that set
+//! produce an explicit `RuntimeError` (the documented coverage boundary).
+
+use super::{RakuAstClass, RakuAstFieldValue, RakuAstNode};
+use crate::ast::{Expr, Stmt};
+use crate::value::{RuntimeError, Value, ValueView};
+
+fn unsupported(node: &RakuAstNode) -> RuntimeError {
+    RuntimeError::new(format!(
+        "RakuAST: EVAL does not yet support lowering `{}`",
+        node.class.printed_name()
+    ))
+}
+
+/// Lower a top-level RakuAST node to a statement list. A bare expression node
+/// (e.g. `EVAL(RakuAST::IntLiteral.new(42))`) becomes a single expression
+/// statement.
+pub fn lower(node: &RakuAstNode) -> Result<Vec<Stmt>, RuntimeError> {
+    match node.class {
+        RakuAstClass::StatementList => {
+            let mut stmts = Vec::with_capacity(node.fields.len());
+            for f in &node.fields {
+                stmts.push(lower_stmt(child_node(&f.value)?)?);
+            }
+            Ok(stmts)
+        }
+        _ => Ok(vec![lower_stmt(node)?]),
+    }
+}
+
+fn lower_stmt(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    match node.class {
+        RakuAstClass::StatementExpression => {
+            let expr = named_child(node, "expression")?;
+            Ok(Stmt::Expr(lower_expr(expr)?))
+        }
+        _ => Ok(Stmt::Expr(lower_expr(node)?)),
+    }
+}
+
+fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
+    match node.class {
+        RakuAstClass::IntLiteral | RakuAstClass::RatLiteral | RakuAstClass::StrLiteral => {
+            Ok(Expr::Literal(positional_leaf(node)?))
+        }
+        // `"..."` parses to a QuotedString wrapping StrLiteral segments; a single
+        // plain segment lowers to its string literal.
+        RakuAstClass::QuotedString => {
+            let segments = list_field(node, "segments")?;
+            if segments.len() == 1
+                && let ValueView::RakuAst(seg) = segments[0].view()
+                && seg.class == RakuAstClass::StrLiteral
+            {
+                return Ok(Expr::Literal(positional_leaf(seg)?));
+            }
+            Err(unsupported(node))
+        }
+        RakuAstClass::StatementExpression => lower_expr(named_child(node, "expression")?),
+        _ => Err(unsupported(node)),
+    }
+}
+
+/// The value of a node's single positional (name-less) leaf field.
+fn positional_leaf(node: &RakuAstNode) -> Result<Value, RuntimeError> {
+    match node.fields.first() {
+        Some(f) if f.name.is_none() => match &f.value {
+            RakuAstFieldValue::Node(v) => Ok(v.clone()),
+            _ => Err(unsupported(node)),
+        },
+        _ => Err(unsupported(node)),
+    }
+}
+
+/// The child RakuAST node of a named field.
+fn named_child<'a>(node: &'a RakuAstNode, name: &str) -> Result<&'a RakuAstNode, RuntimeError> {
+    node.fields
+        .iter()
+        .find(|f| f.name == Some(name))
+        .and_then(|f| match &f.value {
+            RakuAstFieldValue::Node(v) => match v.view() {
+                ValueView::RakuAst(child) => Some(child),
+                _ => None,
+            },
+            _ => None,
+        })
+        .ok_or_else(|| unsupported(node))
+}
+
+/// The child RakuAST node wrapped in a `Node` field value.
+fn child_node(fv: &RakuAstFieldValue) -> Result<&RakuAstNode, RuntimeError> {
+    if let RakuAstFieldValue::Node(v) = fv
+        && let ValueView::RakuAst(child) = v.view()
+    {
+        return Ok(child);
+    }
+    Err(RuntimeError::new("RakuAST: EVAL expected a child node"))
+}
+
+fn list_field<'a>(node: &'a RakuAstNode, name: &str) -> Result<&'a [Value], RuntimeError> {
+    match node.fields.iter().find(|f| f.name == Some(name)) {
+        Some(f) => match &f.value {
+            RakuAstFieldValue::List(items) => Ok(items),
+            _ => Err(unsupported(node)),
+        },
+        None => Err(unsupported(node)),
+    }
+}

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -11,7 +11,10 @@
 //! phasing (construction, EVAL, macros are later phases).
 
 mod convert;
+mod lower;
 mod render;
+
+pub use lower::lower;
 
 use crate::value::{RuntimeError, Value, ValueView};
 

--- a/src/runtime/builtins_eval_misc.rs
+++ b/src/runtime/builtins_eval_misc.rs
@@ -244,6 +244,14 @@ impl Interpreter {
     }
 
     pub(super) fn builtin_eval(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
+        // EVAL of a RakuAST node (ADR-0011 Phase 5): lower it to the internal AST
+        // and run it through the existing evaluator — no new execution engine.
+        if let Some(first_arg) = Self::positional_value(args, 0)
+            && let ValueView::RakuAst(node) = first_arg.view()
+        {
+            let stmts = crate::rakuast::lower(node)?;
+            return self.eval_block_value(&stmts);
+        }
         // EVAL only accepts strings (and Buf), not blocks
         if let Some(first_arg) = Self::positional_value(args, 0) {
             match first_arg.view() {

--- a/t/rakuast-eval.t
+++ b/t/rakuast-eval.t
@@ -1,0 +1,19 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 5 slice 1 (ADR-0011): EVAL of a RakuAST node lowers it to the
+# internal AST and runs it through the existing evaluator — no new engine.
+# Slice 1 covers the literal cluster. Verified against Rakudo; this file passes
+# under BOTH mutsu and raku.
+
+plan 4;
+
+# --- EVAL a constructed literal ---------------------------------------------
+is EVAL(RakuAST::IntLiteral.new(42)), 42, 'EVAL(IntLiteral.new(42)) == 42';
+is EVAL(RakuAST::StrLiteral.new("hi")), 'hi', 'EVAL(StrLiteral.new("hi")) == "hi"';
+is EVAL(RakuAST::RatLiteral.new(3.5)), 3.5, 'EVAL(RatLiteral.new(3.5)) == 3.5';
+
+# --- round-trip: source -> .AST -> EVAL -------------------------------------
+is EVAL(Q[42].AST), 42, 'EVAL(Q[42].AST) round-trips to 42';


### PR DESCRIPTION
## Summary

Begins **Phase 5** of RakuAST (ADR-0011): running a RakuAST tree via `EVAL`.

`src/rakuast/lower.rs` lowers a RakuAST node back to the internal `Stmt`/`Expr` AST, and `builtin_eval` now recognises a `Value::RakuAst` first argument, lowers it, and runs it through the **existing** evaluator (`eval_block_value`) — no new execution engine, per the ADR.

```raku
use MONKEY-SEE-NO-EVAL;
use experimental :rakuast;
EVAL(RakuAST::IntLiteral.new(42))    # 42
EVAL(Q[42].AST)                       # 42  (round-trips source -> node tree -> value)
```

Slice 1 lowers the **literal cluster** (`IntLiteral`/`RatLiteral`/`StrLiteral`, single-segment `QuotedString`) plus the `StatementList` / `Statement::Expression` wrappers; anything else is an explicit `RuntimeError` (the documented coverage boundary). EVAL of a string / Buf is unaffected.

## Tests

`t/rakuast-eval.t` — 4 assertions (EVAL of Int/Str/Rat literals, `EVAL(Q[42].AST)` round-trip), **passing under BOTH mutsu and raku**. Core `EVAL("1 + 2")` and all `t/rakuast-*.t` verified unaffected.

Next: `ApplyInfix`/`ApplyPrefix` (needs an operator-name → `TokenKind` reverse map), then variables / statements / declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)