### PR TITLE
feat: RakuAST Phase 5 slice 2 — EVAL of infix/prefix operators

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -878,8 +878,11 @@ so it is tracked separately from the roast backlog.
 - **Phase 5 (in progress)** — EVAL: lower RakuAST → internal AST → existing compiler (no new engine).
   - [x] Slice 1: EVAL of the literal cluster (`src/rakuast/lower.rs`; `EVAL(IntLiteral.new(42))` →
         42, `EVAL(Q[42].AST)` round-trips). Tests in `t/rakuast-eval.t`.
-  - [ ] Slice 2+: `ApplyInfix`/`ApplyPrefix` (operator-name → `TokenKind` reverse map), then
-        variables / statements / declarations.
+  - [x] Slice 2: EVAL of `ApplyInfix`/`ApplyPrefix` (`op_name_to_token_kind` reverse map;
+        `EVAL(Q[3 * 4 + 1].AST)` → 13). Tests in `t/rakuast-eval-infix.t`.
+  - [ ] Slice 3+: variables (`Var::Lexical` → `Expr::Var`), method calls, statements, declarations —
+        the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full lowering is a
+        large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -183,8 +183,14 @@ earlier ones.
     `42`, and `EVAL(Q[42].AST)` round-trips source → node tree → value. Slice 1 lowers the literal
     cluster (`IntLiteral`/`RatLiteral`/`StrLiteral`, single-segment `QuotedString`) plus the
     `StatementList` / `Statement::Expression` wrappers; anything else is an explicit `RuntimeError`.
-    Tests in `t/rakuast-eval.t`. Next: `ApplyInfix`/`ApplyPrefix` (needs an operator-name →
-    `TokenKind` reverse map), then variables/statements/declarations.
+    Tests in `t/rakuast-eval.t`.
+  - **Slice 2 (infix/prefix) — done.** `ApplyInfix` lowers to `Expr::Binary` and `ApplyPrefix` to
+    `Expr::Unary`; the operator string of the `Infix`/`Prefix` child maps back to a `TokenKind` via a
+    new `op_name_to_token_kind` (the reverse of `token_kind_to_op_name`, covering the common
+    arithmetic/comparison infixes). `EVAL(Q[3 * 4 + 1].AST)` → `13`. Operators outside the reverse map
+    are an explicit `RuntimeError`. Tests in `t/rakuast-eval-infix.t`. Next: variables (`Var::Lexical`
+    → `Expr::Var`), method calls, then statements/declarations — the inverse of the Phase-2 converter,
+    grown cluster by cluster.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/compiler/helpers_ops.rs
+++ b/src/compiler/helpers_ops.rs
@@ -76,3 +76,34 @@ pub(crate) fn token_kind_to_op_name(op: &TokenKind) -> String {
         _ => format!("{:?}", op),
     }
 }
+
+/// Reverse of [`token_kind_to_op_name`] for the common infix operators, used to
+/// lower a `RakuAST::Infix("...")` back to a `TokenKind` (ADR-0011 Phase 5).
+/// Returns `None` for operators not yet handled by the RakuAST lowerer.
+pub(crate) fn op_name_to_token_kind(name: &str) -> Option<TokenKind> {
+    Some(match name {
+        "+" => TokenKind::Plus,
+        "-" => TokenKind::Minus,
+        "*" => TokenKind::Star,
+        "**" => TokenKind::StarStar,
+        "/" => TokenKind::Slash,
+        "%" => TokenKind::Percent,
+        "%%" => TokenKind::PercentPercent,
+        "~" => TokenKind::Tilde,
+        "==" => TokenKind::EqEq,
+        "!=" => TokenKind::BangEq,
+        "<" => TokenKind::Lt,
+        "<=" => TokenKind::Lte,
+        ">" => TokenKind::Gt,
+        ">=" => TokenKind::Gte,
+        "<=>" => TokenKind::LtEqGt,
+        "===" => TokenKind::EqEqEq,
+        "&&" => TokenKind::AndAnd,
+        "||" => TokenKind::OrOr,
+        "^^" => TokenKind::XorXor,
+        "//" => TokenKind::SlashSlash,
+        ".." => TokenKind::DotDot,
+        "..." => TokenKind::DotDotDot,
+        _ => return None,
+    })
+}

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -61,8 +61,36 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             Err(unsupported(node))
         }
         RakuAstClass::StatementExpression => lower_expr(named_child(node, "expression")?),
+        RakuAstClass::ApplyInfix => {
+            let left = lower_expr(named_child(node, "left")?)?;
+            let right = lower_expr(named_child(node, "right")?)?;
+            let op = infix_token(named_child(node, "infix")?)?;
+            Ok(Expr::Binary {
+                left: Box::new(left),
+                op,
+                right: Box::new(right),
+            })
+        }
+        RakuAstClass::ApplyPrefix => {
+            let operand = lower_expr(named_child(node, "operand")?)?;
+            let op = infix_token(named_child(node, "prefix")?)?;
+            Ok(Expr::Unary {
+                op,
+                expr: Box::new(operand),
+            })
+        }
         _ => Err(unsupported(node)),
     }
+}
+
+/// The `TokenKind` for an `Infix`/`Prefix` operator node (its positional operator
+/// string), or an error for an operator the lowerer doesn't handle yet.
+fn infix_token(node: &RakuAstNode) -> Result<crate::token_kind::TokenKind, RuntimeError> {
+    let name = positional_leaf(node)?;
+    let ValueView::Str(s) = name.view() else {
+        return Err(unsupported(node));
+    };
+    crate::compiler::helpers_ops::op_name_to_token_kind(&s).ok_or_else(|| unsupported(node))
 }
 
 /// The value of a node's single positional (name-less) leaf field.

--- a/t/rakuast-eval-infix.t
+++ b/t/rakuast-eval-infix.t
@@ -1,0 +1,32 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 5 slice 2 (ADR-0011): EVAL of infix/prefix operator nodes.
+# `ApplyInfix` lowers to an internal Binary expression (the `Infix("+")` operator
+# string maps back to a TokenKind). Verified against Rakudo; this file passes
+# under BOTH mutsu and raku.
+
+plan 5;
+
+sub apply-add($a, $b) {
+    RakuAST::ApplyInfix.new(
+        left  => RakuAST::IntLiteral.new($a),
+        infix => RakuAST::Infix.new("+"),
+        right => RakuAST::IntLiteral.new($b),
+    )
+}
+
+# --- EVAL a constructed ApplyInfix ------------------------------------------
+is EVAL(apply-add(1, 2)), 3, 'EVAL(ApplyInfix 1 + 2) == 3';
+is EVAL(RakuAST::ApplyInfix.new(
+    left  => RakuAST::IntLiteral.new(4),
+    infix => RakuAST::Infix.new("*"),
+    right => RakuAST::IntLiteral.new(5),
+)), 20, 'EVAL(ApplyInfix 4 * 5) == 20';
+
+# --- round-trip a source expression through .AST ----------------------------
+is EVAL(Q[3 * 4 + 1].AST), 13, 'EVAL(Q[3 * 4 + 1].AST) == 13';
+is EVAL(Q[2 ** 8].AST), 256, 'EVAL(Q[2 ** 8].AST) == 256';
+is EVAL(Q[10 - 3 - 2].AST), 5, 'EVAL(Q[10 - 3 - 2].AST) == 5';


### PR DESCRIPTION
## Summary

Phase 5 slice 2 of RakuAST (ADR-0011): `EVAL` of an operator-application node.

```raku
use MONKEY-SEE-NO-EVAL;
use experimental :rakuast;
EVAL(RakuAST::ApplyInfix.new(
  left  => RakuAST::IntLiteral.new(1),
  infix => RakuAST::Infix.new("+"),
  right => RakuAST::IntLiteral.new(2)))     # 3
EVAL(Q[3 * 4 + 1].AST)                       # 13  (source -> node tree -> value)
```

`ApplyInfix` lowers to `Expr::Binary` and `ApplyPrefix` to `Expr::Unary`; the operator string of the `Infix`/`Prefix` child maps back to a `TokenKind` via a new `op_name_to_token_kind` (the reverse of `token_kind_to_op_name`, covering the common arithmetic/comparison infixes). Operators outside the reverse map are an explicit `RuntimeError`.

## Tests

`t/rakuast-eval-infix.t` — 5 assertions (constructed `ApplyInfix` for `+`/`*`, source round-trips for `3*4+1`, `2**8`, `10-3-2`), **passing under BOTH mutsu and raku**. Core arithmetic and all `t/rakuast-*.t` verified unaffected.

Next: variables (`Var::Lexical` → `Expr::Var`), method calls, then statements/declarations — the inverse of the Phase-2 converter, grown cluster by cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)