### PR TITLE
fix: six generic bugs surfaced by the JSON::Class / JSON::Marshal suites

### DIFF
--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -141,6 +141,16 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     0.0,
                 )))
             }
+            // `"1+2i".Complex` parses the numeric string (raku: <1+2i>), not 0+0i.
+            ValueView::Str(s) => {
+                match crate::runtime::str_numeric::parse_raku_str_to_numeric(s.trim()) {
+                    Some(v) => match v.view() {
+                        ValueView::Complex(..) => Some(Ok(v)),
+                        _ => Some(Ok(Value::complex(v.to_f64(), 0.0))),
+                    },
+                    None => Some(Ok(Value::complex(0.0, 0.0))),
+                }
+            }
             _ => Some(Ok(Value::complex(0.0, 0.0))),
         },
         "Pair" => match target.view() {

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -419,7 +419,9 @@ impl Interpreter {
             "samewith" => self.builtin_samewith(&args),
             "nextcallee" => self.builtin_nextcallee(),
             // Type coercion
-            "Int" | "Num" | "Str" | "Bool" | "Uni" => self.builtin_coerce(name, &args),
+            "Int" | "Num" | "Str" | "Bool" | "Uni" | "Rat" | "FatRat" | "Complex" => {
+                self.builtin_coerce(name, &args)
+            }
             "Array" | "List" | "Hash" => self.builtin_container_coerce(name, &args),
             "UNBASE" => self.builtin_unbase(&args),
             "RADIX_LIST" => self.builtin_radix_list(&args),

--- a/src/runtime/builtins_coerce.rs
+++ b/src/runtime/builtins_coerce.rs
@@ -49,6 +49,13 @@ impl Interpreter {
             return Ok(Value::package(Symbol::intern(&format!("{name}({source})"))));
         }
         let coerced = match name {
+            // `Rat($x)` / `FatRat($x)` / `Complex($x)` delegate to the method
+            // form (`$x.Rat` …), which carries the full native coercion logic
+            // incl. Failure semantics for invalid strings (JSON::Unmarshal's
+            // `multi _unmarshal(Any:D $json, Rat) { Rat($json) }`).
+            "Rat" | "FatRat" | "Complex" => {
+                return self.call_method_with_values(value.clone(), name, vec![]);
+            }
             "Int" => match value.view() {
                 ValueView::Int(i) => Value::int(i),
                 ValueView::Num(f) => Value::int(f as i64),

--- a/src/runtime/methods_classhow_attribute.rs
+++ b/src/runtime/methods_classhow_attribute.rs
@@ -195,6 +195,17 @@ impl Interpreter {
             Value::package(Symbol::intern(&type_name)),
         );
         meta.insert("has_accessor".to_string(), Value::truth(is_public));
+        // `is_built`: whether `.new` initializes the attribute from a named
+        // arg — true for public attrs, false for `has $!x` privates, and
+        // overridable by the `is built(...)` trait (rakudo; JSON::Marshal's
+        // `_marshal` probes it to include `has $!half-priv is built`).
+        let is_built = self
+            .registry()
+            .classes
+            .get(owner)
+            .and_then(|cd| cd.attribute_built.get(attr_name).copied())
+            .unwrap_or(is_public);
+        meta.insert("is_built".to_string(), Value::truth(is_built));
         if let Some(default_expr) = default {
             meta.insert("__mutsu_has_build".to_string(), Value::TRUE);
             if let crate::ast::Expr::Literal(v) = default_expr {
@@ -289,6 +300,7 @@ impl Interpreter {
         );
         meta.insert("is_public".to_string(), Value::truth(is_public));
         meta.insert("has_accessor".to_string(), Value::truth(is_public));
+        meta.insert("is_built".to_string(), Value::truth(is_public));
         meta.insert("sigil".to_string(), Value::str(sigil.to_string()));
         meta.insert(
             "type".to_string(),

--- a/src/runtime/methods_collection_ops/grep.rs
+++ b/src/runtime/methods_collection_ops/grep.rs
@@ -8,6 +8,9 @@ impl Interpreter {
         target: Value,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
+        // A role mixin over a list-ish value greps the inner elements (see
+        // mixin_iteration_target on the map dispatch).
+        let target = Self::mixin_iteration_target(target);
         fn stmt_contains_last(stmt: &Stmt) -> bool {
             match stmt {
                 Stmt::Last(_) => true,

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -394,11 +394,45 @@ impl Interpreter {
     }
 
     /// Dispatch the "map" method.
+    /// Iteration methods (`.map`/`.grep`) on a role mixin over a list-ish
+    /// value iterate the INNER value's elements — including an itemized inner
+    /// (`my $x = (1,2); $x does R; $x.map(...)` iterates 1, 2 in raku).
+    /// A mixin over a scalar stays the single item. Without this,
+    /// JSON::Marshal's `_marshal(Positional:D)` received the whole mixin back
+    /// from `.map` and recursed to a stack overflow (JSON::Class
+    /// t/050-array.t: `Array[TestObject] but JSON::Class`).
+    pub(crate) fn mixin_iteration_target(target: Value) -> Value {
+        if let ValueView::Mixin(inner, _) = target.view()
+            && matches!(
+                inner.view(),
+                ValueView::Array(..)
+                    | ValueView::Seq(_)
+                    | ValueView::HyperSeq(_)
+                    | ValueView::RaceSeq(_)
+                    | ValueView::Slip(_)
+                    | ValueView::LazyList(_)
+                    | ValueView::Hash(_)
+                    | ValueView::Range(..)
+                    | ValueView::RangeExcl(..)
+                    | ValueView::RangeExclStart(..)
+                    | ValueView::RangeExclBoth(..)
+                    | ValueView::GenericRange { .. }
+                    | ValueView::Set(..)
+                    | ValueView::Bag(..)
+                    | ValueView::Mix(..)
+            )
+        {
+            return inner.as_ref().clone();
+        }
+        target
+    }
+
     fn dispatch_map_method(
         &mut self,
         target: Value,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
+        let target = Self::mixin_iteration_target(target);
         if let ValueView::Instance {
             class_name,
             attributes,

--- a/src/runtime/ops_compare.rs
+++ b/src/runtime/ops_compare.rs
@@ -4,6 +4,31 @@ impl Interpreter {
     pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
         match val.view() {
             ValueView::Array(_, kind) if kind.is_itemized() => vec![val.clone()],
+            // A role mixin over a (non-itemized) list-ish value lists as the
+            // inner value does; itemized/scalar inners keep one item (and the
+            // mixin identity). Mirrors utils::value_to_list.
+            ValueView::Mixin(inner, _)
+                if matches!(
+                    inner.view(),
+                    ValueView::Array(_, kind) if !kind.is_itemized()
+                ) || matches!(
+                    inner.view(),
+                    ValueView::Seq(_)
+                        | ValueView::Slip(_)
+                        | ValueView::LazyList(_)
+                        | ValueView::Range(..)
+                        | ValueView::RangeExcl(..)
+                        | ValueView::RangeExclStart(..)
+                        | ValueView::RangeExclBoth(..)
+                        | ValueView::GenericRange { .. }
+                        | ValueView::Set(..)
+                        | ValueView::Bag(..)
+                        | ValueView::Mix(..)
+                ) || (matches!(inner.view(), ValueView::Hash(_))
+                    && !inner.hash_is_itemized()) =>
+            {
+                Self::value_to_list(inner)
+            }
             ValueView::Array(items, ..) => items.to_vec(),
             ValueView::Seq(items) => items.to_vec(),
             ValueView::LazyList(ll) => ll.cache.lock().unwrap().clone().unwrap_or_default(),

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -1025,8 +1025,16 @@ impl Interpreter {
         {
             Some(Value::package(Symbol::intern(name)))
         } else if let Some(val) = self.env.get(name) {
-            // Also check env for type objects (e.g. lexical roles/classes)
-            if matches!(val.view(), ValueView::Package(_)) {
+            // Also check env for type objects (e.g. lexical roles/classes).
+            // Exclude the `my TYPE $name` declaration placeholder: SetVarType
+            // seeds env[name] with the TYPE object under the scalar's key, but
+            // that does not make `name` a type — `my Str $json;` in scope must
+            // not turn the `is json` attribute trait into a positional-type
+            // dispatch (JSON::Marshal t/140-opt-in.t). A declared variable is
+            // recognizable by its recorded type constraint.
+            if matches!(val.view(), ValueView::Package(_))
+                && (self.var_type_constraint(name).is_none() || self.has_type_direct(name))
+            {
                 Some(val.clone())
             } else {
                 None

--- a/src/runtime/run_dist.rs
+++ b/src/runtime/run_dist.rs
@@ -20,22 +20,22 @@ impl Interpreter {
         // Priority 1: the executing routine's defining package (innermost first).
         for frame in self.routine_stack.iter().rev() {
             if let Some(dist) = self.package_distributions.get(&frame.package) {
-                return Self::build_resources_from_dist(dist);
+                return self.build_resources_from_dist(&dist.clone());
             }
         }
         // Priority 2: current_distribution (set during module loading) — the
         // right answer for top-level module code that is not inside any routine.
         if let Some(dist) = &self.current_distribution {
-            return Self::build_resources_from_dist(dist);
+            return self.build_resources_from_dist(&dist.clone());
         }
         // Priority 3: Look up by current package
         if let Some(dist) = self.package_distributions.get(&self.current_package()) {
-            return Self::build_resources_from_dist(dist);
+            return self.build_resources_from_dist(&dist.clone());
         }
         Value::hash_with_data(Value::hash_arc(HashMap::new()))
     }
 
-    fn build_resources_from_dist(dist: &Value) -> Value {
+    fn build_resources_from_dist(&self, dist: &Value) -> Value {
         use std::collections::HashMap;
 
         let meta = match dist.view() {
@@ -77,7 +77,10 @@ impl Interpreter {
                     if let Some(ref fv) = files_val
                         && let Some(path_val) = fv.hash_get_str(&files_key)
                     {
-                        result.insert(key, path_val);
+                        // IO::Path-like entry: `%?RESOURCES<x>.slurp` works
+                        // (rakudo's Distribution::Resource — License::SPDX
+                        // slurps its licenses.json this way).
+                        result.insert(key, self.make_io_path_instance(&path_val.to_string_value()));
                         continue;
                     }
                     let actual_path = if key.starts_with("libraries/") {
@@ -99,7 +102,7 @@ impl Interpreter {
                     } else {
                         format!("{prefix}/resources/{key}")
                     };
-                    result.insert(key, Value::str(actual_path));
+                    result.insert(key, self.make_io_path_instance(&actual_path));
                 }
             }
             ValueView::Hash(map) => {

--- a/src/runtime/utils/list.rs
+++ b/src/runtime/utils/list.rs
@@ -51,6 +51,35 @@ pub(crate) fn walk_list_candidates(attributes: &crate::value::InstanceAttrs) -> 
 pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
     match val.view() {
         ValueView::Array(_, kind) if kind.is_itemized() => vec![val.clone()],
+        // A role mixin over a (non-itemized) list-ish value lists as the inner
+        // value does. An itemized inner keeps one item — `for $x` where
+        // `my $x = (1,2); $x does R` iterates once, like the plain itemized
+        // scalar — and a scalar mixin stays one item with its mixin identity.
+        // Iteration METHODS (`.map`/`.grep`) unwrap itemization separately via
+        // `Interpreter::mixin_iteration_target`.
+        ValueView::Mixin(inner, _)
+            if matches!(
+                inner.view(),
+                ValueView::Array(_, kind) if !kind.is_itemized()
+            ) || matches!(
+                inner.view(),
+                ValueView::Seq(_)
+                    | ValueView::HyperSeq(_)
+                    | ValueView::RaceSeq(_)
+                    | ValueView::Slip(_)
+                    | ValueView::LazyList(_)
+                    | ValueView::Range(..)
+                    | ValueView::RangeExcl(..)
+                    | ValueView::RangeExclStart(..)
+                    | ValueView::RangeExclBoth(..)
+                    | ValueView::GenericRange { .. }
+                    | ValueView::Set(..)
+                    | ValueView::Bag(..)
+                    | ValueView::Mix(..)
+            ) || (matches!(inner.view(), ValueView::Hash(_)) && !inner.hash_is_itemized()) =>
+        {
+            value_to_list(inner)
+        }
         ValueView::Array(items, ..) => items.to_vec(),
         ValueView::Seq(items) | ValueView::HyperSeq(items) | ValueView::RaceSeq(items) => {
             items.to_vec()

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -611,8 +611,11 @@ impl Interpreter {
     }
 
     /// Snapshot the slot-backing env values before a `lives-ok`/`dies-ok` carrier
-    /// runs, for the locals whose slot is overwritable. `None` entries (cell /
-    /// Array / Hash slots, or absent env keys) are never written back.
+    /// runs. Overwritable slots use it for the changed-value diff; plain
+    /// Array/Hash slots also snapshot (their writeback additionally requires
+    /// the pre-carrier env to have been in sync with the slot — see
+    /// `carrier_writeback_changed_aggregates`). `None` entries (binding cells,
+    /// `!attr`, absent env keys) are never written back.
     pub(super) fn snapshot_carrier_overwritable_env(
         &self,
         code: &CompiledCode,
@@ -621,7 +624,12 @@ impl Interpreter {
             .iter()
             .enumerate()
             .map(|(i, name)| {
-                if name.starts_with('!') || !Self::slot_carrier_overwritable(&self.locals[i]) {
+                if name.starts_with('!')
+                    || matches!(
+                        self.locals[i].view(),
+                        ValueView::HashEntryRef { .. } | ValueView::ContainerRef(_)
+                    )
+                {
                     None
                 } else {
                     self.carrier_env_value(name)
@@ -654,11 +662,22 @@ impl Interpreter {
             if !Self::slot_carrier_overwritable(&self.locals[i]) {
                 // A plain Array/Hash slot: overwriting from env normally risks
                 // clobbering a live interior `:=` element cell (env may hold a
-                // COW-detached copy). The one safe case is a *type change away* from
-                // the container — `$a does Role` turns a Hash `$a` into a `Mixin`,
-                // discarding the old container wholesale — so write through only
-                // when the env value's variant differs from the slot's.
+                // COW-detached copy). Two safe cases:
+                // - a *type change away* from the container (`$a does Role`
+                //   turns a Hash `$a` into a `Mixin`), discarding the old
+                //   container wholesale;
+                // - a clean observed REBIND: the slot and env were in sync
+                //   before the carrier and the carrier produced a different
+                //   value (`lives-ok { $parsed = %h{$k} }` re-run — the second
+                //   Hash assignment was silently dropped, JSON::Marshal
+                //   t/030-trait.t / t/080-type-constraints.t). A pre-carrier
+                //   divergence (a live-cell copy) keeps the skip.
                 if !self.locals[i].same_variant(&cur) {
+                    self.locals[i] = cur;
+                } else if let Some(Some(prev)) = pre_env.get(i)
+                    && *prev == self.locals[i]
+                    && *prev != cur
+                {
                     self.locals[i] = cur;
                 }
                 continue;

--- a/t/attribute-is-built.t
+++ b/t/attribute-is-built.t
@@ -1,0 +1,20 @@
+use Test;
+
+plan 4;
+
+# Attribute.is_built: true for public attrs, false for `has $!x` privates,
+# overridable by the `is built` trait (JSON::Marshal skips private attributes
+# via `.has_accessor || .is_built`).
+class C {
+    has Str $.pub;
+    has Str $!priv = 'p';
+    has Int $!half is built = 42;
+}
+
+my %by-name = C.^attributes(:local).map({ .name => $_ });
+ok %by-name<$!pub>.is_built, 'public attribute is_built';
+nok %by-name<$!priv>.is_built, 'plain private attribute is not is_built';
+ok %by-name<$!half>.is_built, 'is built trait makes a private attribute built';
+ok %by-name<$!pub>.has_accessor, 'has_accessor still true for public';
+
+done-testing;

--- a/t/carrier-container-rebind-writeback.t
+++ b/t/carrier-container-rebind-writeback.t
@@ -1,0 +1,27 @@
+use Test;
+
+plan 6;
+
+# A container REBIND inside a test-function block (`lives-ok { $parsed = ... }`)
+# must reach the caller's slot even when the slot already holds a container:
+# the second Hash assignment was silently dropped (the carrier writeback
+# protected container slots wholesale), so JSON::Marshal's
+# t/030-trait.t / t/080-type-constraints.t re-parses kept the FIRST result.
+my $key = "one";
+my %h = one => { x => 1 }, two => { x => 2 };
+my $parsed;
+lives-ok { $parsed = %h{$key} }, 'first assignment lives';
+is $parsed<x>, 1, 'first hash value arrived';
+$key = "two";
+lives-ok { $parsed = %h{$key} }, 'second assignment lives';
+is $parsed<x>, 2, 'the REBOUND hash value arrived (not the stale first)';
+
+# Arrays too.
+my $sel = "a";
+my %arrs = a => [1, 2], b => [3, 4];
+my $got;
+lives-ok { $got = %arrs{$sel} }, 'array pick lives';
+$sel = "b";
+lives-ok { $got = %arrs{$sel} }, 'second array pick lives';
+
+done-testing;

--- a/t/mixin-list-iteration.t
+++ b/t/mixin-list-iteration.t
@@ -1,0 +1,25 @@
+use Test;
+
+plan 6;
+
+# A role mixin over a list-ish value iterates as the inner value does
+# (JSON::Marshal's `_marshal(Positional:D)` recursed to a stack overflow when
+# `.map` handed the whole mixin back as one item — JSON::Class t/050-array.t).
+role R { method tag { "R" } }
+
+my $x = (1, 2);
+$x does R;
+is $x.map({ $_.^name ~ ":" ~ $_ }).join("|"), "Int:1|Int:2",
+    '.map on a mixed-in list iterates the elements';
+is $x.grep(* > 1).join(","), "2", '.grep iterates the elements';
+is $x.join("/"), "1/2", '.join iterates the elements';
+my $n = 0;
+for $x -> $e { $n++ }
+is $n, 1, 'for over the itemized mixin scalar iterates once (like a plain $x)';
+
+# A mixin over a scalar stays a single item and keeps its mixin identity.
+my $y = 42 but R;
+is $y.map({ $_.^name }).join(","), Q[Int+{R}], 'scalar mixin maps as one item';
+is $y.tag, "R", 'and keeps the role';
+
+done-testing;

--- a/t/trait-name-typed-var-collision.t
+++ b/t/trait-name-typed-var-collision.t
@@ -1,0 +1,23 @@
+use Test;
+
+plan 2;
+
+# A typed `my TYPE $name;` declaration seeds env[name] with the TYPE object at
+# hoist time; that placeholder must not make a same-named attribute TRAIT look
+# like a type, which turned the trait's named-arg dispatch into a
+# positional-type dispatch and killed the multi (JSON::Marshal t/140-opt-in.t:
+# `my Str $json;` in scope broke every `is json` attribute).
+multi sub trait_mod:<is> (Attribute $a, :$mark!) { }
+
+class T {
+    has Str $.a is mark;
+}
+pass 'class with a custom named attribute trait registered';
+
+my Str $mark;
+class T2 {
+    has Str $.b is mark;
+}
+pass '... even with a same-named typed variable in scope';
+
+done-testing;

--- a/t/type-coercion-functions.t
+++ b/t/type-coercion-functions.t
@@ -1,0 +1,14 @@
+use Test;
+
+plan 6;
+
+# Function-form type coercions delegate to the method form
+# (JSON::Unmarshal's `multi _unmarshal(Any:D $json, Rat) { Rat($json) }`).
+is Rat(4.2), 4.2, 'Rat(Num-ish)';
+isa-ok Rat("3.5"), Rat, 'Rat(Str) parses';
+is Rat("3.5"), 3.5, '... to the right value';
+isa-ok FatRat(0.5), FatRat, 'FatRat() coerces';
+is Complex("1+2i"), Complex.new(1, 2), 'Complex(Str) parses the complex string';
+is "1+2i".Complex, Complex.new(1, 2), '.Complex on Str parses too';
+
+done-testing;


### PR DESCRIPTION
## Summary
zef Test-phase frontier: **JSON::Class 4/6 → 6/6** and **JSON::Marshal 10/14 → 14/14** test files pass. Six general fixes:

1. **Mixin-over-list iteration**: a role mixin over a list-ish value iterates as its inner value in `.map`/`.grep`/`.join`/list context (rakudo-verified matrix incl. `for` keeping itemization and scalar mixins staying single). Root cause of a **Rust stack overflow**: `_marshal(Positional:D)` received the whole mixin back from `.map` and recursed forever (`Array[TestObject] but JSON::Class`, JSON::Class t/050-array.t).
2. **`Attribute.is_built`**: public → true, private → false, `is built` trait overrides (JSON::Marshal skips privates via `.has_accessor || .is_built`).
3. **Function-form coercions `Rat()` / `FatRat()` / `Complex()`** delegate to the method form (JSON::Unmarshal's `Rat($json)` died "Unknown function"); `"1+2i".Complex` now parses the complex string.
4. **Typed-var hoist placeholder vs trait names**: `my Str $json;` anywhere in scope seeded env["json"] with the type object, so `resolve_type_object` turned every `is json` attribute trait into a positional-type dispatch → X::Multi::NoMatch before the first test (JSON::Marshal t/140-opt-in.t). A declared variable (recognized by its recorded type constraint) no longer masquerades as a type.
5. **Carrier container-rebind writeback**: `lives-ok { $parsed = %h{$k} }` re-run silently dropped the second Hash/Array assignment when the caller's slot already held a container (the writeback protected container slots wholesale to guard live `:=` cells). A clean observed rebind — pre-carrier env in sync with the slot, carrier produced a different value — now writes through; pre-carrier divergence keeps the protection (S03-binding/nested.t + t/element-bind-cell.t stay green). Fixed JSON::Marshal t/030-trait.t and t/080-type-constraints.t, which re-parsed and kept the FIRST result.
6. **`%?RESOURCES` entries are IO::Path instances** so `%?RESOURCES<data/licenses.json>.slurp` works (rakudo's Distribution::Resource; unblocks License::SPDX's data load — its remaining failure is a separate unmarshal bug).

## Testing
- `make test` PASS (18132 tests; one known-flaky S17-style supply test passed 3/3 on retry)
- Roast sweep: whitelisted S03-binding / S02-types(list/hash/bag/mix) / S02-lists / S04-statements / S14-roles / S32-list (127 files, 4941 tests) PASS
- 5 new pin files, each raku-verified
- E2E: JSON::Class 6/6, JSON::Marshal 14/14, META6 9/9 with deps staged via MUTSULIB

🤖 Generated with [Claude Code](https://claude.com/claude-code)