### PR TITLE
feat: RakuAST Phase 5 slice 3 — EVAL of variables and declarations

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -880,9 +880,11 @@ so it is tracked separately from the roast backlog.
         42, `EVAL(Q[42].AST)` round-trips). Tests in `t/rakuast-eval.t`.
   - [x] Slice 2: EVAL of `ApplyInfix`/`ApplyPrefix` (`op_name_to_token_kind` reverse map;
         `EVAL(Q[3 * 4 + 1].AST)` → 13). Tests in `t/rakuast-eval-infix.t`.
-  - [ ] Slice 3+: variables (`Var::Lexical` → `Expr::Var`), method calls, statements, declarations —
-        the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full lowering is a
-        large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 3: EVAL of `Var::Lexical` (→ `Expr::Var`/etc.) and `my $x = EXPR` (→ `Stmt::VarDecl`);
+        `EVAL(Q[my $x = 5; $x * 2].AST)` → 10. Tests in `t/rakuast-eval-var.t`.
+  - [ ] Slice 4+: method calls, `if`/loops, sub declarations — the inverse of the Phase-2 converter,
+        grown cluster by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring
+        Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -188,9 +188,15 @@ earlier ones.
     `Expr::Unary`; the operator string of the `Infix`/`Prefix` child maps back to a `TokenKind` via a
     new `op_name_to_token_kind` (the reverse of `token_kind_to_op_name`, covering the common
     arithmetic/comparison infixes). `EVAL(Q[3 * 4 + 1].AST)` → `13`. Operators outside the reverse map
-    are an explicit `RuntimeError`. Tests in `t/rakuast-eval-infix.t`. Next: variables (`Var::Lexical`
-    → `Expr::Var`), method calls, then statements/declarations — the inverse of the Phase-2 converter,
-    grown cluster by cluster.
+    are an explicit `RuntimeError`. Tests in `t/rakuast-eval-infix.t`.
+  - **Slice 3 (variables & declarations) — done.** `Var::Lexical("$x")` lowers to the sigil-specific
+    variable expression (`Expr::Var`/`ArrayVar`/`HashVar`/`CodeVar`), and a plain `my $x = EXPR`
+    (`VarDeclaration::Simple`) lowers to `Stmt::VarDecl` (declaration-inside-`Statement::Expression`
+    becomes its own statement, not a `Stmt::Expr`). `EVAL(Q[my $x = 5; $x * 2].AST)` → `10` — a
+    multi-statement program round-trips. Scoped/typed/attribute declarations and non-scalar
+    initializers (comma lists) stay the boundary. Tests in `t/rakuast-eval-var.t`. Next: method
+    calls, `if`/loops, sub declarations — the inverse of the Phase-2 converter, grown cluster by
+    cluster.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -35,11 +35,92 @@ pub fn lower(node: &RakuAstNode) -> Result<Vec<Stmt>, RuntimeError> {
 
 fn lower_stmt(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     match node.class {
-        RakuAstClass::StatementExpression => {
-            let expr = named_child(node, "expression")?;
-            Ok(Stmt::Expr(lower_expr(expr)?))
-        }
+        // A declaration wrapped in Statement::Expression lowers to its own
+        // statement (a `my $x = …` is a `Stmt::VarDecl`, not a `Stmt::Expr`).
+        RakuAstClass::StatementExpression => lower_stmt_inner(named_child(node, "expression")?),
+        _ => lower_stmt_inner(node),
+    }
+}
+
+fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    match node.class {
+        RakuAstClass::VarDeclarationSimple => lower_var_decl(node),
         _ => Ok(Stmt::Expr(lower_expr(node)?)),
+    }
+}
+
+/// Lower a plain `my $x = EXPR` declaration to `Stmt::VarDecl`. Scoped/typed/
+/// attribute forms (which carry `scope`/`type`/`twigil`/`traits` fields) are the
+/// coverage boundary.
+fn lower_var_decl(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    if node.fields.iter().any(|f| {
+        matches!(
+            f.name,
+            Some("scope") | Some("type") | Some("twigil") | Some("traits")
+        )
+    }) {
+        return Err(unsupported(node));
+    }
+    let sigil = leaf_str(node, "sigil")?;
+    let desigil_node = named_child(node, "desigilname")?;
+    let desigil = match positional_leaf(desigil_node)?.view() {
+        ValueView::Str(s) => s.to_string(),
+        _ => return Err(unsupported(node)),
+    };
+    let name = if sigil == "$" {
+        desigil
+    } else {
+        format!("{sigil}{desigil}")
+    };
+    // The initializer field is present only for `= EXPR`; without it a plain
+    // `my $x` declares an undefined value.
+    let (expr, has_initializer) = match node.fields.iter().find(|f| f.name == Some("initializer")) {
+        Some(_) => {
+            let init = named_child(node, "initializer")?;
+            (lower_expr(named_child_or_positional(init)?)?, true)
+        }
+        None => (Expr::Literal(Value::NIL), false),
+    };
+    let custom_traits = if has_initializer {
+        vec![("__has_initializer".to_string(), None)]
+    } else {
+        Vec::new()
+    };
+    Ok(Stmt::VarDecl {
+        name,
+        expr,
+        type_constraint: None,
+        is_state: false,
+        is_our: false,
+        is_dynamic: false,
+        is_export: false,
+        export_tags: Vec::new(),
+        custom_traits,
+        where_constraint: None,
+    })
+}
+
+/// The value of a leaf-valued named field (e.g. `sigil => "$"`), as a `String`.
+fn leaf_str(node: &RakuAstNode, name: &str) -> Result<String, RuntimeError> {
+    let field = node
+        .fields
+        .iter()
+        .find(|f| f.name == Some(name))
+        .ok_or_else(|| unsupported(node))?;
+    match &field.value {
+        RakuAstFieldValue::Node(v) => match v.view() {
+            ValueView::Str(s) => Ok(s.to_string()),
+            _ => Err(unsupported(node)),
+        },
+        _ => Err(unsupported(node)),
+    }
+}
+
+/// The child node of an `Initializer::Assign` — its single positional child.
+fn named_child_or_positional(node: &RakuAstNode) -> Result<&RakuAstNode, RuntimeError> {
+    match node.fields.first() {
+        Some(f) if f.name.is_none() => child_node(&f.value),
+        _ => Err(unsupported(node)),
     }
 }
 
@@ -61,6 +142,20 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             Err(unsupported(node))
         }
         RakuAstClass::StatementExpression => lower_expr(named_child(node, "expression")?),
+        // `$x` / `@a` / `%h` / `&f` -> the sigil-specific variable expression.
+        RakuAstClass::VarLexical => {
+            let name = match positional_leaf(node)?.view() {
+                ValueView::Str(s) => s.to_string(),
+                _ => return Err(unsupported(node)),
+            };
+            let (sigil, bare) = name.split_at(name.chars().next().map_or(0, char::len_utf8));
+            Ok(match sigil {
+                "@" => Expr::ArrayVar(bare.to_string()),
+                "%" => Expr::HashVar(bare.to_string()),
+                "&" => Expr::CodeVar(bare.to_string()),
+                _ => Expr::Var(bare.to_string()),
+            })
+        }
         RakuAstClass::ApplyInfix => {
             let left = lower_expr(named_child(node, "left")?)?;
             let right = lower_expr(named_child(node, "right")?)?;

--- a/t/rakuast-eval-var.t
+++ b/t/rakuast-eval-var.t
@@ -1,0 +1,18 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 5 slice 3 (ADR-0011): EVAL of variable declarations and uses.
+# `my $x = EXPR` lowers to Stmt::VarDecl and `$x` to a variable expression, so a
+# multi-statement program round-trips through .AST and runs. Verified against
+# Rakudo; this file passes under BOTH mutsu and raku.
+
+plan 4;
+
+is EVAL(Q[my $x = 5; $x * 2].AST), 10, 'declare, then use: $x * 2 == 10';
+is EVAL(Q[my $a = 3; my $b = 4; $a + $b].AST), 7, 'two declarations sum to 7';
+is EVAL(Q[my $n = 10; $n - 1].AST), 9, 'declare 10, then $n - 1 == 9';
+
+# --- a bare Var::Lexical lowers on its own ----------------------------------
+is EVAL(Q[my $x = 42; $x].AST), 42, 'a variable use round-trips to its value';


### PR DESCRIPTION
## Summary

Phase 5 slice 3 of RakuAST (ADR-0011): `EVAL` of variable declarations and uses.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[my $x = 5; $x * 2].AST)          # 10
EVAL(Q[my $a = 3; my $b = 4; $a + $b].AST)  # 7
```

- `Var::Lexical("$x")` lowers to the sigil-specific variable expression (`Expr::Var` / `ArrayVar` / `HashVar` / `CodeVar`).
- a plain `my $x = EXPR` (`VarDeclaration::Simple`) lowers to `Stmt::VarDecl` — a declaration wrapped in `Statement::Expression` becomes its own statement, not a `Stmt::Expr`.

A multi-statement program round-trips through the node tree and runs. Scoped/typed/attribute declarations and non-scalar initializers (comma lists / `ApplyListInfix`) stay the coverage boundary.

## Tests

`t/rakuast-eval-var.t` — 4 assertions (declare-then-use, two declarations, `$n - 1`, bare variable use), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green.

Next: method calls, `if`/loops, sub declarations — the inverse of the Phase-2 converter, grown cluster by cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)