### PR TITLE
feat: RakuAST Phase 5 slice 4 — EVAL of listop calls and method calls

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -882,9 +882,10 @@ so it is tracked separately from the roast backlog.
         `EVAL(Q[3 * 4 + 1].AST)` → 13). Tests in `t/rakuast-eval-infix.t`.
   - [x] Slice 3: EVAL of `Var::Lexical` (→ `Expr::Var`/etc.) and `my $x = EXPR` (→ `Stmt::VarDecl`);
         `EVAL(Q[my $x = 5; $x * 2].AST)` → 10. Tests in `t/rakuast-eval-var.t`.
-  - [ ] Slice 4+: method calls, `if`/loops, sub declarations — the inverse of the Phase-2 converter,
-        grown cluster by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring
-        Phase 2.)
+  - [x] Slice 4: EVAL of listop I/O calls (`say`/`put`/`print`/`note` → `Stmt::Say` etc.) and method
+        calls (`ApplyPostfix`/`Call::Method` → `Expr::MethodCall`). Tests in `t/rakuast-eval-call.t`.
+  - [ ] Slice 5+: `if`/loops, sub declarations — the inverse of the Phase-2 converter, grown cluster
+        by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -197,6 +197,13 @@ earlier ones.
     initializers (comma lists) stay the boundary. Tests in `t/rakuast-eval-var.t`. Next: method
     calls, `if`/loops, sub declarations — the inverse of the Phase-2 converter, grown cluster by
     cluster.
+  - **Slice 4 (calls) — done.** The listop I/O calls (`Call::Name`/`::WithoutParentheses` with name
+    `say`/`put`/`print`/`note`) lower to their statement forms (`Stmt::Say` etc.), and a postfix
+    method call (`ApplyPostfix` with a `Call::Method` postfix) lowers to `Expr::MethodCall`.
+    `EVAL(Q[my $x = -5; $x.abs].AST)` → `5`; chained calls and `say` as a side-effecting statement
+    work. (The *return value* of a bare trailing `say` differs between mutsu and raku — a pre-existing
+    mutsu EVAL behaviour also seen with a string EVAL, unrelated to RakuAST.) Tests in
+    `t/rakuast-eval-call.t`. Next: `if`/loops, sub declarations.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -45,7 +45,44 @@ fn lower_stmt(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
 fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     match node.class {
         RakuAstClass::VarDeclarationSimple => lower_var_decl(node),
+        // The listop I/O calls (`say`/`put`/`print`/`note`) are their own
+        // statements in the internal AST.
+        RakuAstClass::CallName | RakuAstClass::CallNameWithoutParentheses => {
+            let name = call_name_str(node)?;
+            let args = arg_exprs(node)?;
+            match name.as_str() {
+                "say" => Ok(Stmt::Say(args)),
+                "put" => Ok(Stmt::Put(args)),
+                "print" => Ok(Stmt::Print(args)),
+                "note" => Ok(Stmt::Note(args)),
+                _ => Ok(Stmt::Expr(lower_expr(node)?)),
+            }
+        }
         _ => Ok(Stmt::Expr(lower_expr(node)?)),
+    }
+}
+
+/// The identifier string of a call node's `name` (a `Name`) child.
+fn call_name_str(node: &RakuAstNode) -> Result<String, RuntimeError> {
+    match positional_leaf(named_child(node, "name")?)?.view() {
+        ValueView::Str(s) => Ok(s.to_string()),
+        _ => Err(unsupported(node)),
+    }
+}
+
+/// The lowered positional arguments of a call node's `args` (`ArgList`) child, or
+/// an empty vec when there are none.
+fn arg_exprs(node: &RakuAstNode) -> Result<Vec<Expr>, RuntimeError> {
+    match node.fields.iter().find(|f| f.name == Some("args")) {
+        Some(f) => {
+            let arglist = child_node(&f.value)?;
+            arglist
+                .fields
+                .iter()
+                .map(|af| lower_expr(child_node(&af.value)?))
+                .collect()
+        }
+        None => Ok(Vec::new()),
     }
 }
 
@@ -172,6 +209,22 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             Ok(Expr::Unary {
                 op,
                 expr: Box::new(operand),
+            })
+        }
+        // A postfix method call: `$x.abs` -> ApplyPostfix(operand, Call::Method).
+        // Subscripts / hyper-calls carry a different postfix and are deferred.
+        RakuAstClass::ApplyPostfix => {
+            let operand = lower_expr(named_child(node, "operand")?)?;
+            let postfix = named_child(node, "postfix")?;
+            if postfix.class != RakuAstClass::CallMethod {
+                return Err(unsupported(node));
+            }
+            Ok(Expr::MethodCall {
+                target: Box::new(operand),
+                name: crate::symbol::Symbol::intern(&call_name_str(postfix)?),
+                args: arg_exprs(postfix)?,
+                modifier: None,
+                quoted: false,
             })
         }
         _ => Err(unsupported(node)),

--- a/t/rakuast-eval-call.t
+++ b/t/rakuast-eval-call.t
@@ -1,0 +1,26 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 5 slice 4 (ADR-0011): EVAL of listop I/O calls and method calls.
+# `say`/`put`/`print`/`note` lower to their statement forms and `$x.method`
+# lowers to a MethodCall, so an effectful program runs. Verified against Rakudo;
+# this file passes under BOTH mutsu and raku.
+#
+# Note: the *return value* of a bare trailing `say` differs between mutsu and
+# raku (a pre-existing mutsu EVAL behaviour, also seen with a string EVAL), so
+# `say` is exercised as a side-effecting middle statement rather than the tail.
+
+plan 4;
+
+# --- method calls (values match) --------------------------------------------
+is EVAL(Q[my $x = -5; $x.abs].AST), 5, 'method call: (-5).abs == 5';
+is EVAL(Q[my $s = "hi"; $s.uc].AST), 'HI', 'method call: "hi".uc == "HI"';
+
+# --- a method call inside a say (say is a side effect; tail is a value) ------
+is EVAL(Q[my $x = 3; say $x; $x * 2].AST), 6,
+    'say runs as a side effect; the tail expression is the value';
+
+# --- a chained method call --------------------------------------------------
+is EVAL(Q[my $x = -3; $x.abs.Str].AST), '3', 'chained method calls lower and run';


### PR DESCRIPTION
## Summary

Phase 5 slice 4 of RakuAST (ADR-0011): `EVAL` of I/O listop calls and method calls.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[my $x = -5; $x.abs].AST)          # 5
EVAL(Q[my $x = 3; say $x; $x * 2].AST)   # prints 3, returns 6
```

- The listop I/O calls (`Call::Name` / `::WithoutParentheses` with name `say`/`put`/`print`/`note`) lower to their statement forms (`Stmt::Say` etc.).
- A postfix method call (`ApplyPostfix` with a `Call::Method` postfix) lowers to `Expr::MethodCall`; chained calls work.

## Note

The **return value** of a bare trailing `say` differs between mutsu and raku (a pre-existing mutsu EVAL behaviour — `EVAL("say 42")` string also returns `Nil` in mutsu vs `True` in raku — unrelated to RakuAST). The tests therefore exercise `say` as a side-effecting middle statement, not the tail.

## Tests

`t/rakuast-eval-call.t` — 4 assertions (`.abs`/`.uc` method calls, middle-`say` program, chained `.abs.Str`), **passing under BOTH mutsu and raku**. All existing `t/rakuast-*.t` still green.

Next: `if`/loops, sub declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)