### PR TITLE
feat: RakuAST Phase 5 slice 5 — EVAL of if/while and assignment

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -884,8 +884,13 @@ so it is tracked separately from the roast backlog.
         `EVAL(Q[my $x = 5; $x * 2].AST)` → 10. Tests in `t/rakuast-eval-var.t`.
   - [x] Slice 4: EVAL of listop I/O calls (`say`/`put`/`print`/`note` → `Stmt::Say` etc.) and method
         calls (`ApplyPostfix`/`Call::Method` → `Expr::MethodCall`). Tests in `t/rakuast-eval-call.t`.
-  - [ ] Slice 5+: `if`/loops, sub declarations — the inverse of the Phase-2 converter, grown cluster
-        by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 5: EVAL of `if`/`while` and `$x = EXPR` assignment (`Statement::If` → `Stmt::If`,
+        `Statement::Loop::While` → `Stmt::While`, `ApplyInfix`-with-`Assignment` → `Stmt::Assign`);
+        `EVAL(Q[my $n=5; my $f=1; while $n>1 { $f=$f*$n; $n=$n-1 }; $f].AST)` → 120. `elsif` chains stay
+        the boundary. Tests in `t/rakuast-eval-control.t`.
+  - [ ] Slice 6+: `for`/`given`, sub declarations, `elsif` chains — the inverse of the Phase-2
+        converter, grown cluster by cluster. (Phase 5 full lowering is a large multi-slice effort
+        mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -204,6 +204,12 @@ earlier ones.
     work. (The *return value* of a bare trailing `say` differs between mutsu and raku — a pre-existing
     mutsu EVAL behaviour also seen with a string EVAL, unrelated to RakuAST.) Tests in
     `t/rakuast-eval-call.t`. Next: `if`/loops, sub declarations.
+  - **Slice 5 (control flow + assignment) — done.** `Statement::If` lowers to `Stmt::If`,
+    `Statement::Loop::While` to `Stmt::While`, and an `ApplyInfix` whose infix is an `Assignment`
+    lowers to `Stmt::Assign` (its block bodies via a `lower_block` `Block → Blockoid → StatementList`
+    helper). `EVAL(Q[my $n = 5; my $f = 1; while $n > 1 { $f = $f * $n; $n = $n - 1 }; $f].AST)` → `120`.
+    `elsif` chains stay the boundary. Tests in `t/rakuast-eval-control.t`. Next: `for`/`given`, sub
+    declarations.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -45,6 +45,11 @@ fn lower_stmt(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
 fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     match node.class {
         RakuAstClass::VarDeclarationSimple => lower_var_decl(node),
+        RakuAstClass::StatementIf => lower_if(node),
+        RakuAstClass::StatementLoopWhile => lower_while(node),
+        // `$x = EXPR` is an `ApplyInfix` whose infix is an `Assignment` node; it is
+        // a `Stmt::Assign`, not a general binary expression.
+        RakuAstClass::ApplyInfix if infix_is_assignment(node) => lower_assign(node),
         // The listop I/O calls (`say`/`put`/`print`/`note`) are their own
         // statements in the internal AST.
         RakuAstClass::CallName | RakuAstClass::CallNameWithoutParentheses => {
@@ -60,6 +65,74 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         }
         _ => Ok(Stmt::Expr(lower_expr(node)?)),
     }
+}
+
+/// Lower `if COND { … } else { … }` to `Stmt::If`. `elsif` chains (which carry
+/// an `elsifs` list) are the current coverage boundary.
+fn lower_if(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    if node.fields.iter().any(|f| f.name == Some("elsifs")) {
+        return Err(unsupported(node));
+    }
+    let cond = lower_expr(named_child(node, "condition")?)?;
+    let then_branch = lower_block(named_child(node, "then")?)?;
+    let else_branch = match node.fields.iter().find(|f| f.name == Some("else")) {
+        Some(_) => lower_block(named_child(node, "else")?)?,
+        None => Vec::new(),
+    };
+    Ok(Stmt::If {
+        cond,
+        then_branch,
+        else_branch,
+        binding_var: None,
+    })
+}
+
+/// Lower `while COND { … }` to `Stmt::While`.
+fn lower_while(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    let cond = lower_expr(named_child(node, "condition")?)?;
+    let body = lower_block(named_child(node, "body")?)?;
+    Ok(Stmt::While {
+        cond,
+        body,
+        label: None,
+    })
+}
+
+/// Lower a `Block` (`body => Blockoid` wrapping a positional `StatementList`) to a
+/// statement list.
+fn lower_block(block: &RakuAstNode) -> Result<Vec<Stmt>, RuntimeError> {
+    let blockoid = named_child(block, "body")?;
+    lower(named_child_or_positional(blockoid)?)
+}
+
+/// Whether an `ApplyInfix`'s `infix` child is an `Assignment` node (`$x = …`).
+fn infix_is_assignment(node: &RakuAstNode) -> bool {
+    named_child(node, "infix")
+        .map(|c| c.class == RakuAstClass::Assignment)
+        .unwrap_or(false)
+}
+
+/// Lower `$x = EXPR` to `Stmt::Assign`. The `$` sigil is stripped (matching the
+/// parser's naming); `@`/`%`/`&` are kept.
+fn lower_assign(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    let left = named_child(node, "left")?;
+    if left.class != RakuAstClass::VarLexical {
+        return Err(unsupported(node));
+    }
+    let raw = match positional_leaf(left)?.view() {
+        ValueView::Str(s) => s.to_string(),
+        _ => return Err(unsupported(node)),
+    };
+    let name = match raw.strip_prefix('$') {
+        Some(bare) => bare.to_string(),
+        None => raw,
+    };
+    let expr = lower_expr(named_child(node, "right")?)?;
+    Ok(Stmt::Assign {
+        name,
+        expr,
+        op: crate::ast::AssignOp::Assign,
+    })
 }
 
 /// The identifier string of a call node's `name` (a `Name`) child.

--- a/t/rakuast-eval-control.t
+++ b/t/rakuast-eval-control.t
@@ -1,0 +1,32 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 5 slice 5 (ADR-0011): EVAL of `if`/`while` and `$x = EXPR`
+# assignment. `Statement::If` lowers to a conditional, `Statement::Loop::While`
+# to a while-loop, and an `ApplyInfix` whose infix is an `Assignment` lowers to
+# an assignment statement. Verified against Rakudo; passes under BOTH mutsu and
+# raku.
+
+plan 6;
+
+# --- if / else --------------------------------------------------------------
+is EVAL(Q[my $x = 5; if $x > 3 { 10 } else { 20 }].AST), 10,
+    'if: true branch is taken';
+is EVAL(Q[my $x = 1; if $x > 3 { 10 } else { 20 }].AST), 20,
+    'if: else branch is taken';
+
+# an if with no else and a false condition yields an undefined value
+nok EVAL(Q[my $x = 1; if $x > 3 { 10 }].AST).defined,
+    'if without else: false condition is undefined';
+
+# --- assignment mutates a lexical -------------------------------------------
+is EVAL(Q[my $s = 1; $s = $s + 4; $s].AST), 5,
+    'assignment mutates a lexical and the new value is visible';
+
+# --- while loop -------------------------------------------------------------
+is EVAL(Q[my $i = 0; my $s = 0; while $i < 3 { $s = $s + $i; $i = $i + 1 }; $s].AST), 3,
+    'while: accumulate 0 + 1 + 2 == 3';
+is EVAL(Q[my $n = 5; my $f = 1; while $n > 1 { $f = $f * $n; $n = $n - 1 }; $f].AST), 120,
+    'while: 5! == 120';


### PR DESCRIPTION
## Summary

Phase 5 slice 5 of RakuAST (ADR-0011): `EVAL` of control flow and mutation.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[my $x = 5; if $x > 3 { 10 } else { 20 }].AST)                          # 10
EVAL(Q[my $n = 5; my $f = 1; while $n > 1 { $f = $f * $n; $n = $n - 1 }; $f].AST)  # 120
```

- `Statement::If` → `Stmt::If` (`elsif` chains stay the coverage boundary).
- `Statement::Loop::While` → `Stmt::While`.
- An `ApplyInfix` whose infix is an `Assignment` node → `Stmt::Assign` (the `$` sigil is stripped to match the parser's naming; `@`/`%`/`&` are kept).
- Block bodies are lowered via a `lower_block` helper walking `Block → Blockoid → StatementList`.

## Tests

`t/rakuast-eval-control.t` — 6 assertions (if true/false branches, if-without-else undefined, assignment mutation, while accumulation, while factorial), **passing under BOTH mutsu and raku**. All 43 `t/rakuast-*.t` files (185 tests) still green.

Next: `for`/`given`, sub declarations, `elsif` chains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)