### PR TITLE
feat: RakuAST Phase 5 slice 6 — EVAL of for, elsif chains, and comma lists

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -888,9 +888,13 @@ so it is tracked separately from the roast backlog.
         `Statement::Loop::While` → `Stmt::While`, `ApplyInfix`-with-`Assignment` → `Stmt::Assign`);
         `EVAL(Q[my $n=5; my $f=1; while $n>1 { $f=$f*$n; $n=$n-1 }; $f].AST)` → 120. `elsif` chains stay
         the boundary. Tests in `t/rakuast-eval-control.t`.
-  - [ ] Slice 6+: `for`/`given`, sub declarations, `elsif` chains — the inverse of the Phase-2
-        converter, grown cluster by cluster. (Phase 5 full lowering is a large multi-slice effort
-        mirroring Phase 2.)
+  - [x] Slice 6: EVAL of `for` (single-param pointy block → `Stmt::For`), `elsif` chains (each
+        `Statement::Elsif` folds into a nested `Stmt::If`), and comma lists (`ApplyListInfix` `,` →
+        `Expr::ArrayLiteral`); `EVAL(Q[my $p=1; for (2,3,4) -> $n { $p=$p*$n }; $p].AST)` → 24. Tests
+        in `t/rakuast-eval-for-elsif.t`.
+  - [ ] Slice 7+: sub declarations, `given`/`when`, `for @x { … }` (`$_`), multi-param blocks — the
+        inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full lowering is a large
+        multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -210,6 +210,12 @@ earlier ones.
     helper). `EVAL(Q[my $n = 5; my $f = 1; while $n > 1 { $f = $f * $n; $n = $n - 1 }; $f].AST)` → `120`.
     `elsif` chains stay the boundary. Tests in `t/rakuast-eval-control.t`. Next: `for`/`given`, sub
     declarations.
+  - **Slice 6 (`for` + `elsif` chains + comma lists) — done.** `Statement::For` (single-parameter
+    pointy block) lowers to `Stmt::For`; each `Statement::Elsif` in an `if`'s `elsifs` list folds into
+    a nested `Stmt::If` in the enclosing `else`; and an `ApplyListInfix` with a `,` infix lowers to
+    `Expr::ArrayLiteral`. `EVAL(Q[my $p = 1; for (2, 3, 4) -> $n { $p = $p * $n }; $p].AST)` → `24`.
+    The bare `for @x { … }` (`$_`) form, multi-parameter blocks, and non-comma list infixes (`Z`/`X`)
+    stay the boundary. Tests in `t/rakuast-eval-for-elsif.t`. Next: sub declarations, `given`/`when`.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -47,6 +47,7 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         RakuAstClass::VarDeclarationSimple => lower_var_decl(node),
         RakuAstClass::StatementIf => lower_if(node),
         RakuAstClass::StatementLoopWhile => lower_while(node),
+        RakuAstClass::StatementFor => lower_for(node),
         // `$x = EXPR` is an `ApplyInfix` whose infix is an `Assignment` node; it is
         // a `Stmt::Assign`, not a general binary expression.
         RakuAstClass::ApplyInfix if infix_is_assignment(node) => lower_assign(node),
@@ -67,24 +68,93 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     }
 }
 
-/// Lower `if COND { … } else { … }` to `Stmt::If`. `elsif` chains (which carry
-/// an `elsifs` list) are the current coverage boundary.
+/// Lower `if COND { … } elsif … { … } else { … }` to `Stmt::If`. Each `elsif`
+/// clause becomes a nested `Stmt::If` in the enclosing `else` branch, folded
+/// innermost-last so the source order is preserved.
 fn lower_if(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
-    if node.fields.iter().any(|f| f.name == Some("elsifs")) {
-        return Err(unsupported(node));
-    }
     let cond = lower_expr(named_child(node, "condition")?)?;
     let then_branch = lower_block(named_child(node, "then")?)?;
-    let else_branch = match node.fields.iter().find(|f| f.name == Some("else")) {
+    // The base `else` (the outer `else { … }` block, or empty).
+    let mut else_branch = match node.fields.iter().find(|f| f.name == Some("else")) {
         Some(_) => lower_block(named_child(node, "else")?)?,
         None => Vec::new(),
     };
+    // Fold the `elsif` clauses in reverse into nested `if`s in the `else`.
+    if let Some(field) = node.fields.iter().find(|f| f.name == Some("elsifs"))
+        && let RakuAstFieldValue::List(items) = &field.value
+    {
+        for item in items.iter().rev() {
+            let ValueView::RakuAst(clause) = item.view() else {
+                return Err(unsupported(node));
+            };
+            let econd = lower_expr(named_child(clause, "condition")?)?;
+            let ethen = lower_block(named_child(clause, "then")?)?;
+            else_branch = vec![Stmt::If {
+                cond: econd,
+                then_branch: ethen,
+                else_branch,
+                binding_var: None,
+            }];
+        }
+    }
     Ok(Stmt::If {
         cond,
         then_branch,
         else_branch,
         binding_var: None,
     })
+}
+
+/// Lower `for SOURCE -> $x { … }` to `Stmt::For`. Only a single-parameter pointy
+/// block is handled; the bare `for @x { … }` (`$_`) form and multi-parameter
+/// blocks are the current coverage boundary.
+fn lower_for(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    let iterable = lower_expr(named_child(node, "source")?)?;
+    let pointy = named_child(node, "body")?;
+    if pointy.class != RakuAstClass::PointyBlock {
+        return Err(unsupported(node));
+    }
+    let param = pointy_single_param(pointy)?;
+    // A PointyBlock, like a Block, wraps its statements in a `body` Blockoid.
+    let body = lower_block(pointy)?;
+    Ok(Stmt::For {
+        iterable,
+        param,
+        param_def: Box::new(None),
+        params: Vec::new(),
+        params_def: Vec::new(),
+        body,
+        label: None,
+        mode: crate::ast::ForMode::Normal,
+        rw_block: false,
+        explicit_zero_params: false,
+    })
+}
+
+/// The single loop variable of a pointy block's signature (`-> $x`), with its
+/// `$` sigil stripped, or `None` when the block takes no explicit parameter.
+fn pointy_single_param(pointy: &RakuAstNode) -> Result<Option<String>, RuntimeError> {
+    let Ok(sig) = named_child(pointy, "signature") else {
+        return Ok(None);
+    };
+    let params = list_field(sig, "parameters")?;
+    match params.len() {
+        0 => Ok(None),
+        1 => {
+            let ValueView::RakuAst(p0) = params[0].view() else {
+                return Err(unsupported(pointy));
+            };
+            let target = named_child(p0, "target")?;
+            if target.class != RakuAstClass::ParameterTargetVar {
+                return Err(unsupported(pointy));
+            }
+            let raw = leaf_str(target, "name")?;
+            Ok(Some(
+                raw.strip_prefix('$').map(str::to_string).unwrap_or(raw),
+            ))
+        }
+        _ => Err(unsupported(pointy)),
+    }
 }
 
 /// Lower `while COND { … }` to `Stmt::While`.
@@ -283,6 +353,23 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
                 op,
                 expr: Box::new(operand),
             })
+        }
+        // A comma list `1, 2, 3` (or parenthesised `(1, 2, 3)`) -> ApplyListInfix
+        // with a `,` infix. Other list infixes (`Z`/`X`/...) are deferred.
+        RakuAstClass::ApplyListInfix => {
+            let infix = named_child(node, "infix")?;
+            match positional_leaf(infix)?.view() {
+                ValueView::Str(s) if s.as_str() == "," => {}
+                _ => return Err(unsupported(node)),
+            }
+            let mut items = Vec::new();
+            for v in list_field(node, "operands")? {
+                let ValueView::RakuAst(child) = v.view() else {
+                    return Err(unsupported(node));
+                };
+                items.push(lower_expr(child)?);
+            }
+            Ok(Expr::ArrayLiteral(items))
         }
         // A postfix method call: `$x.abs` -> ApplyPostfix(operand, Call::Method).
         // Subscripts / hyper-calls carry a different postfix and are deferred.

--- a/t/rakuast-eval-for-elsif.t
+++ b/t/rakuast-eval-for-elsif.t
@@ -1,0 +1,29 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 5 slice 6 (ADR-0011): EVAL of `for` loops and `elsif` chains.
+# `Statement::For` (with a single-parameter pointy block) lowers to a for-loop,
+# and each `Statement::Elsif` in an `if`'s `elsifs` list folds into a nested
+# conditional. Verified against Rakudo; passes under BOTH mutsu and raku.
+
+plan 6;
+
+# --- elsif chain (each branch reached via a fresh EVAL) ----------------------
+is EVAL(Q[my $x = 5; if $x > 3 { 1 } elsif $x > 1 { 2 } else { 3 }].AST), 1,
+    'elsif: first (if) branch';
+is EVAL(Q[my $x = 2; if $x > 3 { 1 } elsif $x > 1 { 2 } else { 3 }].AST), 2,
+    'elsif: middle (elsif) branch';
+is EVAL(Q[my $x = 0; if $x > 3 { 1 } elsif $x > 1 { 2 } else { 3 }].AST), 3,
+    'elsif: final (else) branch';
+
+# two elsif clauses fold in source order
+is EVAL(Q[my $x = 2; if $x > 5 { 10 } elsif $x > 3 { 20 } elsif $x > 1 { 30 } else { 40 }].AST), 30,
+    'elsif: second of two elsif clauses';
+
+# --- for loop with a pointy parameter ---------------------------------------
+is EVAL(Q[my $s = 0; for 1..4 -> $x { $s = $s + $x }; $s].AST), 10,
+    'for: sum 1..4 == 10';
+is EVAL(Q[my $p = 1; for (2, 3, 4) -> $n { $p = $p * $n }; $p].AST), 24,
+    'for: product of a list == 24';


### PR DESCRIPTION
## Summary

Phase 5 slice 6 of RakuAST (ADR-0011): `EVAL` of `for` loops, `elsif` chains, and comma lists.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[my $s = 0; for 1..4 -> $x { $s = $s + $x }; $s].AST)                  # 10
EVAL(Q[my $p = 1; for (2, 3, 4) -> $n { $p = $p * $n }; $p].AST)            # 24
EVAL(Q[my $x = 2; if $x > 3 { 1 } elsif $x > 1 { 2 } else { 3 }].AST)       # 2
```

- `Statement::For` with a single-parameter pointy block → `Stmt::For` (loop variable from the block signature's sole `Parameter`).
- Each `Statement::Elsif` in an `if`'s `elsifs` list folds — innermost-last — into a nested `Stmt::If` in the enclosing `else`, preserving source order.
- `ApplyListInfix` with a `,` infix → `Expr::ArrayLiteral`, so a parenthesised/comma list source works.

The bare `for @x { … }` (`$_`) form, multi-parameter blocks, and non-comma list infixes (`Z`/`X`) stay the coverage boundary.

## Tests

`t/rakuast-eval-for-elsif.t` — 6 assertions (three elsif branches, a two-clause elsif chain, a `for` sum over a range, a `for` product over a list), **passing under BOTH mutsu and raku**. All 44 `t/rakuast-*.t` files (191 tests) still green.

Next: sub declarations, `given`/`when`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)