### PR TITLE
feat: RakuAST Phase 5 slice 7 — EVAL of sub declarations and named calls

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -892,7 +892,11 @@ so it is tracked separately from the roast backlog.
         `Statement::Elsif` folds into a nested `Stmt::If`), and comma lists (`ApplyListInfix` `,` →
         `Expr::ArrayLiteral`); `EVAL(Q[my $p=1; for (2,3,4) -> $n { $p=$p*$n }; $p].AST)` → 24. Tests
         in `t/rakuast-eval-for-elsif.t`.
-  - [ ] Slice 7+: sub declarations, `given`/`when`, `for @x { … }` (`$_`), multi-param blocks — the
+  - [x] Slice 7: EVAL of `sub` declarations (`RakuAST::Sub` with bare positional scalar params →
+        `Stmt::SubDecl`) and named calls (`Call::Name` → `Expr::Call`); a defined routine can be
+        invoked, including recursively — `EVAL(Q[sub fact($n) { … fact($n-1) }; fact(5)].AST)` → 120.
+        Tests in `t/rakuast-eval-sub.t`.
+  - [ ] Slice 8+: `given`/`when`, `for @x { … }` (`$_`), multi-param/typed/named/slurpy params — the
         inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full lowering is a large
         multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -216,6 +216,12 @@ earlier ones.
     `Expr::ArrayLiteral`. `EVAL(Q[my $p = 1; for (2, 3, 4) -> $n { $p = $p * $n }; $p].AST)` → `24`.
     The bare `for @x { … }` (`$_`) form, multi-parameter blocks, and non-comma list infixes (`Z`/`X`)
     stay the boundary. Tests in `t/rakuast-eval-for-elsif.t`. Next: sub declarations, `given`/`when`.
+  - **Slice 7 (`sub` declarations + named calls) — done.** `RakuAST::Sub` (with bare positional
+    scalar parameters) lowers to `Stmt::SubDecl`, and a `Call::Name` lowers to `Expr::Call`, so a
+    defined routine can be invoked — including recursively. `EVAL(Q[sub fact($n) { if $n < 2 { 1 } else
+    { $n * fact($n - 1) } }; fact(5)].AST)` → `120`. Typed/named/slurpy/defaulted parameters and
+    anonymous subs in expression position stay the boundary. Tests in `t/rakuast-eval-sub.t`. Next:
+    `given`/`when`, the bare `for @x { … }` (`$_`) form.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -7,7 +7,7 @@
 //! produce an explicit `RuntimeError` (the documented coverage boundary).
 
 use super::{RakuAstClass, RakuAstFieldValue, RakuAstNode};
-use crate::ast::{Expr, Stmt};
+use crate::ast::{Expr, ParamDef, Stmt};
 use crate::value::{RuntimeError, Value, ValueView};
 
 fn unsupported(node: &RakuAstNode) -> RuntimeError {
@@ -48,6 +48,7 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         RakuAstClass::StatementIf => lower_if(node),
         RakuAstClass::StatementLoopWhile => lower_while(node),
         RakuAstClass::StatementFor => lower_for(node),
+        RakuAstClass::Sub => lower_sub(node),
         // `$x = EXPR` is an `ApplyInfix` whose infix is an `Assignment` node; it is
         // a `Stmt::Assign`, not a general binary expression.
         RakuAstClass::ApplyInfix if infix_is_assignment(node) => lower_assign(node),
@@ -129,6 +130,99 @@ fn lower_for(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         rw_block: false,
         explicit_zero_params: false,
     })
+}
+
+/// Lower `sub NAME (SIG) { … }` to `Stmt::SubDecl`. Only bare positional scalar
+/// parameters are handled; typed/named/slurpy/defaulted parameters and anonymous
+/// subs in expression position are the current coverage boundary.
+fn lower_sub(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    let name = call_name_str(node)?;
+    let params = signature_positional_params(node)?;
+    let param_defs = params.iter().map(|n| positional_param(n)).collect();
+    // A Sub's `body` is the Blockoid directly (not a Block wrapping one).
+    let body = lower(named_child_or_positional(named_child(node, "body")?)?)?;
+    Ok(Stmt::SubDecl {
+        name: crate::symbol::Symbol::intern(&name),
+        name_expr: None,
+        params,
+        param_defs,
+        return_type: None,
+        associativity: None,
+        precedence_trait: None,
+        signature_alternates: Vec::new(),
+        body,
+        multi: false,
+        is_rw: false,
+        is_raw: false,
+        is_export: false,
+        export_tags: Vec::new(),
+        is_test_assertion: false,
+        supersede: false,
+        custom_traits: Vec::new(),
+    })
+}
+
+/// The positional scalar parameter names of a routine's `signature`, each with
+/// its `$` sigil stripped. A parameter carrying anything beyond a plain scalar
+/// `target` (a name, a slurpy/named marker, a default) is the coverage boundary.
+fn signature_positional_params(node: &RakuAstNode) -> Result<Vec<String>, RuntimeError> {
+    let Ok(sig) = named_child(node, "signature") else {
+        return Ok(Vec::new());
+    };
+    let params = match sig.fields.iter().find(|f| f.name == Some("parameters")) {
+        Some(f) => match &f.value {
+            RakuAstFieldValue::List(items) => items,
+            _ => return Err(unsupported(node)),
+        },
+        None => return Ok(Vec::new()),
+    };
+    let mut names = Vec::with_capacity(params.len());
+    for v in params {
+        let ValueView::RakuAst(p) = v.view() else {
+            return Err(unsupported(node));
+        };
+        // A named/slurpy/optional/defaulted parameter carries extra fields; defer.
+        if p.fields.iter().any(|f| {
+            matches!(
+                f.name,
+                Some("slurpy") | Some("named") | Some("default") | Some("optional_marker")
+            )
+        }) {
+            return Err(unsupported(node));
+        }
+        let target = named_child(p, "target")?;
+        if target.class != RakuAstClass::ParameterTargetVar {
+            return Err(unsupported(node));
+        }
+        let raw = leaf_str(target, "name")?;
+        names.push(raw.strip_prefix('$').map(str::to_string).unwrap_or(raw));
+    }
+    Ok(names)
+}
+
+/// A default positional (required, non-slurpy, untyped) `ParamDef` for `name`.
+fn positional_param(name: &str) -> ParamDef {
+    ParamDef {
+        name: name.to_string(),
+        default: None,
+        multi_invocant: true,
+        required: true,
+        named: false,
+        slurpy: false,
+        double_slurpy: false,
+        onearg: false,
+        sigilless: false,
+        type_constraint: None,
+        literal_value: None,
+        sub_signature: None,
+        where_constraint: None,
+        traits: Vec::new(),
+        optional_marker: false,
+        outer_sub_signature: None,
+        code_signature: None,
+        is_invocant: false,
+        shape_constraints: None,
+    }
 }
 
 /// The single loop variable of a pointy block's signature (`-> $x`), with its
@@ -354,6 +448,12 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
                 expr: Box::new(operand),
             })
         }
+        // A named call `f(1, 2)` -> Expr::Call (the listop I/O calls are handled
+        // as statements in `lower_stmt_inner`; here they are ordinary calls too).
+        RakuAstClass::CallName | RakuAstClass::CallNameWithoutParentheses => Ok(Expr::Call {
+            name: crate::symbol::Symbol::intern(&call_name_str(node)?),
+            args: arg_exprs(node)?,
+        }),
         // A comma list `1, 2, 3` (or parenthesised `(1, 2, 3)`) -> ApplyListInfix
         // with a `,` infix. Other list infixes (`Z`/`X`/...) are deferred.
         RakuAstClass::ApplyListInfix => {

--- a/t/rakuast-eval-sub.t
+++ b/t/rakuast-eval-sub.t
@@ -1,0 +1,32 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 5 slice 7 (ADR-0011): EVAL of `sub` declarations and named calls.
+# `RakuAST::Sub` (with bare positional scalar parameters) lowers to a sub
+# declaration and a `Call::Name` lowers to a named call, so a defined routine can
+# be invoked — including recursively. Verified against Rakudo; passes under BOTH
+# mutsu and raku.
+
+plan 5;
+
+# --- a one-parameter sub, then call it --------------------------------------
+is EVAL(Q[sub dbl($x) { $x * 2 }; dbl(21)].AST), 42,
+    'sub with one parameter is declared and called';
+
+# --- two parameters ---------------------------------------------------------
+is EVAL(Q[sub add($a, $b) { $a + $b }; add(3, 4)].AST), 7,
+    'sub with two parameters';
+
+# --- a multi-statement body -------------------------------------------------
+is EVAL(Q[sub poly($x) { my $s = $x * $x; $s + $x }; poly(4)].AST), 20,
+    'sub with a multi-statement body';
+
+# --- recursion (sub + if/else + call all compose) ---------------------------
+is EVAL(Q[sub fact($n) { if $n < 2 { 1 } else { $n * fact($n - 1) } }; fact(5)].AST), 120,
+    'recursive sub: 5! == 120';
+
+# --- a call as an argument to another call ----------------------------------
+is EVAL(Q[sub inc($n) { $n + 1 }; sub dbl($n) { $n * 2 }; dbl(inc(9))].AST), 20,
+    'a call nested as an argument';


### PR DESCRIPTION
## Summary

Phase 5 slice 7 of RakuAST (ADR-0011): `EVAL` of user-defined `sub` declarations and named calls.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[sub dbl($x) { $x * 2 }; dbl(21)].AST)                                        # 42
EVAL(Q[sub fact($n) { if $n < 2 { 1 } else { $n * fact($n - 1) } }; fact(5)].AST)   # 120
```

- `RakuAST::Sub` (with bare positional scalar parameters) → `Stmt::SubDecl`. Parameter names come from the signature's `Parameter` targets (`$` sigil stripped, matching the parser), each backed by a default positional `ParamDef`. A Sub's `body` is the `Blockoid` directly (not a `Block` wrapping one).
- A named call `f(1, 2)` (`Call::Name`) → `Expr::Call`.

Together a defined routine can be invoked, **including recursively**. Typed/named/slurpy/defaulted parameters and anonymous subs in expression position stay the coverage boundary.

## Tests

`t/rakuast-eval-sub.t` — 5 assertions (one/two params, multi-statement body, recursive factorial, a call nested as an argument), **passing under BOTH mutsu and raku**. All 45 `t/rakuast-*.t` files (196 tests) still green.

Next: `given`/`when`, the bare `for @x { … }` (`$_`) form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)