### PR TITLE
docs: record the array-shapes.t slice and shaped-native coercion perf trap

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -315,12 +315,13 @@ answer cannot be confirmed), or *awaiting infrastructure* (RakuAST for `S32-str/
 6.e generics for `S02-types/generics.t`). The genuinely ★achievable ones are few and each
 needs its own unrelated feature:
 
-- [ ] `6.c/S04-declarations/my-6c.t` — **111/112**. The one failure (`OUTER::<$x>`) needs
-      **lexical hoisting**, not the OUTER pseudo-package alone; same family as
-      mixin-6c / my-6e hoisting, so it has leverage beyond this file.
-- [ ] `APPENDICES/A02-some-day-maybe/multi-no-match.t` — **11/16**. Error-message quality for
-      multi no-match across ~10 builtins (`.splice`, `Lock.protect`, `Proc::Async.new`, …).
-      No single lever; steady per-builtin work.
+- [ ] `S02-types/array-shapes.t` — aborts at 36/43 (full oracle: raku is 43/43 with fudge). T43
+      (`my Int @a[2.5]` Rat shape, #4730) and general `Z=` (element-wise zip-assign, #4733) are done.
+      Remaining: (1) **native-typed shaped `Z=`** (`my int @a[2;3] Z= 0..5`) — the typed-array element
+      coercion does not recurse into shaped rows when the value's top `ArrayKind` is normalized to
+      `Array`, and the two obvious fixes both make `deep-recursion-initing-native-array.t` ~150× slower
+      (keeping the array on the `kind==Shaped` path); needs a recurse-without-kind==Shaped rework.
+      (2) **T31** multi-dim `.pairs` `.value=` writeback (tuple key vs 1-D `key.parse::<usize>()`).
 - [ ] `6.c/APPENDICES/A04-experimental/01-misc.t` — 16/19. `:D`/`:U` DefiniteHow coercion.
 
 **Implication for planning: roast is no longer the productive axis.** Prefer §1 (Batteries /

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -29,6 +29,45 @@ the bump landed with **no whitelist edits** — all 28 whitelisted-and-changed f
 The new `S02-types/quanthash.t` remains non-whitelisted: it needs `.^parameterize` on Set/Bag/Mix
 (parameterized QuantHash types) which mutsu lacks — recorded in `TODO_roast/BLOCKERS.md`.
 
+## 2026-07-18: `S02-types/array-shapes.t` slice — Rat shape dims (#4730) and element-wise `Z=` (#4733); shaped-native `Z=` deferred
+
+`array-shapes.t` is a full oracle under fudge (raku passes 43/43; its unfudged run only aborts at
+the `#?rakudo skip` "partially dimensioned views NYI" block, which is skipped for rakudo). Two of
+its three blockers landed:
+
+- **T43 — Rat shape dimensions** (#4730): `my Int @a[2.5]` now yields a 2-element shaped array
+  (`[(Int) (Int)]`) instead of throwing `X::TypeCheck::Assignment`. `shaped_dims_from_new_args`
+  handled `Int`/`Num`/`BigInt`/enum shape dims but had no `Rat` arm, so a rational literal fell
+  through and the `shape => 2.5` Pair leaked as element data. Added a `Rat` arm (truncate toward Int,
+  `> 0` guard) to both the single-value extraction and the per-dimension loop; negative/zero-truncating
+  rationals still raise `X::IllegalDimensionInShape`, matching raku. Pin `t/shaped-array-rat-shape.t`.
+- **General `Z=` — element-wise zip-metaop assignment** (#4733): `@a Z= rhs` now assigns element-wise
+  (`@a[i] = rhs[i]` for the zipped prefix, trailing `@a` elements kept), matching raku, instead of
+  replacing `@a` with the truncated zip result. Compiled to `__mutsu_zip_assign`; the parser rewrites
+  `@a Z= rhs` (assign_stmt) and `my @a Z= rhs` (my_decl_assign — checked *before* the custom `op=`
+  operator, else the leading `Z` is taken as a user operator). Only `Z=` (op `=`) is rewritten;
+  `Z=>` / `Z+=` keep their MetaOp path. Untyped shaped `my @a[2;3] Z= 0..5` works. Pin
+  `t/zip-metaassign.t`.
+
+**Deferred — native-typed shaped `Z=` and the coercion perf trap.** The roast file's tests 36-38 use
+`my int @a[2;3] Z= 0..5` (a *native-typed* shaped array), which still throws
+`X::TypeCheck::Assignment: expected int but got Array` on the result assignment: the typed-array
+element coercion (`coerce_typed_array_elements`) recurses into shaped rows only when the top-level
+`ArrayKind == Shaped`, but the value arrives with its top kind normalized to `Array` (each row keeps
+the `Shaped` mark). **Two fixes were tried and both reverted** — (a) a per-item `is_shaped_array(item)`
+in the recursion, and (b) forcing `kind == Shaped` via a top-level shape re-mark — because **both
+caused a ~150× perf regression** on `roast/integration/deep-recursion-initing-native-array.t` (a
+100M-element `my int @a[N;N]`): keeping the array on the `kind == Shaped` path slows the whole
+native-array pipeline. `vm_var_assign_typed.rs` was left identical to main. The correct fix must
+recurse into shaped rows *without* keeping the array on the slow `kind == Shaped` path; it is deferred
+and recorded in `TODO_roast/BLOCKERS.md`. (Measurement note for the next attempt: element index
+assignment `@a[$r;$c] = X` does **not** call `coerce_typed_container_assignment` — a `for` loop
+benchmark misleadingly does, via its whole-array sync, so measure the real recursion pattern.)
+
+The file's third blocker, **T31** (`for @a.pairs -> $p { $p.value = X }` on a multi-dim shaped array,
+tuple pair key vs the 1-D `key.parse::<usize>()` writeback), is also still open. `array-shapes.t`
+remains non-whitelisted (aborts at test 36); fixing the shaped-native coercion + T31 whitelists it.
+
 ## 2026-07-18: `APPENDICES/A02-some-day-maybe/multi-no-match.t` fully whitelisted — X::Multi::NoMatch for wrong-argument builtins
 
 The last ★ roast file (raku full-pass, mutsu was 3/16) is now whitelisted. It asserts that a set


### PR DESCRIPTION
## Summary

Documentation-only. Records this session's `S02-types/array-shapes.t` work and — most importantly — the coercion/perf trap that made the native-typed shaped `Z=` case a dead end, so a future attempt doesn't repeat the multi-hour investigation.

- **news/2026-07.md** — entry covering the Rat shape-dimension fix (#4730), the general element-wise `Z=` (#4733), and the deferred native-typed shaped `Z=`: the two obvious coercion fixes both make `deep-recursion-initing-native-array.t` (a 100M-element `my int @a[N;N]`) ~150× slower because they keep the array on the `kind == Shaped` path. Includes the measurement note that element index assignment does not call `coerce_typed_container_assignment` (a `for`-loop benchmark misleadingly does).
- **PLAN.md** — refresh the §4 achievable list: `my-6c.t` and `multi-no-match.t` are whitelisted (drop them); add `array-shapes.t` with its two remaining blockers (native-typed shaped `Z=` rework, T31 multi-dim `.pairs` writeback).

The `TODO_roast/BLOCKERS.md` row already carries the detailed diagnosis (landed with #4733).

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)