### PR TITLE
feat: RakuAST Phase 5 slice 8 — EVAL of given/when/default

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -896,9 +896,13 @@ so it is tracked separately from the roast backlog.
         `Stmt::SubDecl`) and named calls (`Call::Name` → `Expr::Call`); a defined routine can be
         invoked, including recursively — `EVAL(Q[sub fact($n) { … fact($n-1) }; fact(5)].AST)` → 120.
         Tests in `t/rakuast-eval-sub.t`.
-  - [ ] Slice 8+: `given`/`when`, `for @x { … }` (`$_`), multi-param/typed/named/slurpy params — the
-        inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full lowering is a large
-        multi-slice effort mirroring Phase 2.)
+  - [x] Slice 8: EVAL of `given`/`when`/`default` (`Statement::Given`/`When`/`Default` →
+        `Stmt::Given`/`When`/`Default`); a topicalizer runs and yields the matched clause's value.
+        Also fixed a latent `eval_block_value` bug where a non-tail `given` leaked its block value onto
+        the stack and shadowed the block's real tail value. Tests in `t/rakuast-eval-given.t`.
+  - [ ] Slice 9+: `for @x { … }` (`$_`), multi-param/typed/named/slurpy params, control flow
+        (`return`/`last`/`next`) — the inverse of the Phase-2 converter, grown cluster by cluster.
+        (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -222,6 +222,14 @@ earlier ones.
     { $n * fact($n - 1) } }; fact(5)].AST)` → `120`. Typed/named/slurpy/defaulted parameters and
     anonymous subs in expression position stay the boundary. Tests in `t/rakuast-eval-sub.t`. Next:
     `given`/`when`, the bare `for @x { … }` (`$_`) form.
+  - **Slice 8 (`given`/`when`/`default`) — done.** `Statement::Given`/`When`/`Default` lower to
+    `Stmt::Given`/`When`/`Default`, so a topicalizer block runs and yields the matched clause's value —
+    `EVAL(Q[my $x = 2; given $x { when 1 { 10 }; when 2 { 20 }; default { 30 } }].AST)` → `20`. This also
+    fixed a latent `eval_block_value` bug: `given`/`when`/`default` leave their block value on the value
+    stack even in sink position (the tail-statement arms rely on that leaked value being the block
+    result), so a *non-last* one shadowed the block's real tail value; `compile_unit` now pops it. Tests
+    in `t/rakuast-eval-given.t`. Next: the bare `for @x { … }` (`$_`) form, control flow (`return`/
+    `last`/`next`).
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1483,6 +1483,19 @@ impl Compiler {
                     }
                 }
                 self.compile_stmt(stmt);
+                // `given`/`when`/`default` leave their block value on the stack
+                // even in statement (sink) position — the tail-statement arms
+                // above rely on that leaked value being the block result. A
+                // *non-last* one must have it popped, or it would shadow the
+                // block's real tail value (the stack top wins over the topic).
+                if !is_last
+                    && matches!(
+                        stmt,
+                        Stmt::Given { .. } | Stmt::When { .. } | Stmt::Default(_)
+                    )
+                {
+                    self.code.emit(OpCode::Pop);
+                }
             }
         }
         self.code.compute_needs_env_sync();

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -49,6 +49,20 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         RakuAstClass::StatementLoopWhile => lower_while(node),
         RakuAstClass::StatementFor => lower_for(node),
         RakuAstClass::Sub => lower_sub(node),
+        // `given`/`when`/`default` — a `when`/`default` sits directly (not
+        // Statement::Expression-wrapped) in the enclosing `given` block, so it
+        // reaches this dispatch unwrapped.
+        RakuAstClass::StatementGiven => Ok(Stmt::Given {
+            topic: lower_expr(named_child(node, "source")?)?,
+            body: lower_block(named_child(node, "body")?)?,
+        }),
+        RakuAstClass::StatementWhen => Ok(Stmt::When {
+            cond: lower_expr(named_child(node, "condition")?)?,
+            body: lower_block(named_child(node, "body")?)?,
+        }),
+        RakuAstClass::StatementDefault => {
+            Ok(Stmt::Default(lower_block(named_child(node, "body")?)?))
+        }
         // `$x = EXPR` is an `ApplyInfix` whose infix is an `Assignment` node; it is
         // a `Stmt::Assign`, not a general binary expression.
         RakuAstClass::ApplyInfix if infix_is_assignment(node) => lower_assign(node),

--- a/t/rakuast-eval-given.t
+++ b/t/rakuast-eval-given.t
@@ -1,0 +1,29 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 5 slice 8 (ADR-0011): EVAL of `given`/`when`/`default`.
+# `Statement::Given`/`When`/`Default` lower to the topicalizer and its match
+# clauses, so a `given` block runs and yields the matched clause's value.
+# Verified against Rakudo; passes under BOTH mutsu and raku.
+
+plan 5;
+
+# --- given as the tail value: a matching `when` yields its value ------------
+is EVAL(Q[my $x = 2; given $x { when 1 { 10 }; when 2 { 20 }; default { 30 } }].AST), 20,
+    'given/when: the matching clause value is the given value';
+is EVAL(Q[my $x = 9; given $x { when 1 { 10 }; when 2 { 20 }; default { 30 } }].AST), 30,
+    'given/default: the default value when no when matches';
+
+# --- given as a non-tail statement: its value is sunk, the tail wins --------
+is EVAL(Q[given 2 { when 2 { 99 } }; 7].AST), 7,
+    'a non-tail given is sunk; the following statement is the value';
+
+# --- a `when` body with a side effect, read after the given -----------------
+is EVAL(Q[my $out = 0; given 2 { when 1 { $out = 100 }; when 2 { $out = 200 }; default { $out = 300 } }; $out].AST), 200,
+    'a when clause mutates a lexical visible after the given';
+
+# --- given inside a sub -----------------------------------------------------
+is EVAL(Q[sub classify($n) { given $n { when 0 { "zero" }; default { "nonzero" } } }; classify(0)].AST), 'zero',
+    'given inside a sub returns the matched clause value';


### PR DESCRIPTION
## Summary

Phase 5 slice 8 of RakuAST (ADR-0011): `EVAL` of the `given`/`when`/`default` topicalizer.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[my $x = 2; given $x { when 1 { 10 }; when 2 { 20 }; default { 30 } }].AST)   # 20
EVAL(Q[sub classify($n) { given $n { when 0 { "zero" }; default { "nonzero" } } }; classify(0)].AST)  # zero
```

- `Statement::Given`/`When`/`Default` → `Stmt::Given`/`When`/`Default`, so a `given` block runs and yields the matched clause's value.

## Compiler bug fixed along the way

`given`/`when`/`default` leave their block value on the value stack **even in statement (sink) position** — the tail-statement arms rely on that leaked value being the block result, and `run_compiled_block` returns the stack top over the topic. A **non-last** one therefore shadowed the block's real tail value (`given 2 { … }; 7` yielded the given's value instead of `7`). `compile_unit` now pops a non-last given/when/default's leaked value. The mainline discards its stack, so this was harmless there; it only bit value-blocks (`eval_block_value`).

## Tests

`t/rakuast-eval-given.t` — 5 assertions (matching when, default fallthrough, non-tail given sunk, when-clause mutation visible after, given inside a sub), **passing under BOTH mutsu and raku**. Full `make test` green (18194 tests); all given/when value-propagation `t/` tests still pass.

Next: the bare `for @x { … }` (`$_`) form, control flow (`return`/`last`/`next`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)