### PR TITLE
feat: add exits-ok Test function

### DIFF
--- a/src/compiler/helpers_call_args.rs
+++ b/src/compiler/helpers_call_args.rs
@@ -22,7 +22,13 @@ impl Compiler {
     pub(super) fn rewrite_stmt_call_args(name: &str, args: &[CallArg]) -> Vec<CallArg> {
         let rewrites_needed = matches!(
             name,
-            "lives-ok" | "dies-ok" | "throws-like" | "warns-like" | "doesn't-warn" | "is_run"
+            "lives-ok"
+                | "dies-ok"
+                | "exits-ok"
+                | "throws-like"
+                | "warns-like"
+                | "doesn't-warn"
+                | "is_run"
         );
         if !rewrites_needed {
             return args.to_vec();
@@ -33,7 +39,12 @@ impl Compiler {
                 CallArg::Positional(expr) => {
                     let rewritten = if matches!(
                         name,
-                        "lives-ok" | "dies-ok" | "throws-like" | "warns-like" | "doesn't-warn"
+                        "lives-ok"
+                            | "dies-ok"
+                            | "exits-ok"
+                            | "throws-like"
+                            | "warns-like"
+                            | "doesn't-warn"
                     ) && positional_index == 0
                     {
                         match expr {

--- a/src/parser/stmt/simple/compile_consts.rs
+++ b/src/parser/stmt/simple/compile_consts.rs
@@ -106,6 +106,7 @@ const TEST_ASSERTION_EXPORTS: &[&str] = &[
     "can-ok",
     "lives-ok",
     "dies-ok",
+    "exits-ok",
     "eval-lives-ok",
     "eval-dies-ok",
     "throws-like",

--- a/src/parser/stmt/simple/module_exports.rs
+++ b/src/parser/stmt/simple/module_exports.rs
@@ -411,6 +411,7 @@ const TEST_EXPORTS: &[&str] = &[
     "can-ok",
     "lives-ok",
     "dies-ok",
+    "exits-ok",
     "eval-lives-ok",
     "eval-dies-ok",
     "throws-like",

--- a/src/runtime/run_roast_preprocess.rs
+++ b/src/runtime/run_roast_preprocess.rs
@@ -98,6 +98,7 @@ impl Interpreter {
             "subtest(",
             "lives-ok",
             "dies-ok",
+            "exits-ok",
             "eval-lives-ok",
             "eval-dies-ok",
             "throws-like",

--- a/src/runtime/system_eval_string.rs
+++ b/src/runtime/system_eval_string.rs
@@ -188,6 +188,7 @@ impl Interpreter {
             "can-ok",
             "lives-ok",
             "dies-ok",
+            "exits-ok",
             "eval-lives-ok",
             "eval-dies-ok",
             "throws-like",

--- a/src/runtime/test_functions/eval_exception.rs
+++ b/src/runtime/test_functions/eval_exception.rs
@@ -82,6 +82,65 @@ impl Interpreter {
         Ok(Value::truth(ok))
     }
 
+    /// `exits-ok($code, $exit, $reason)` — passes iff running `$code` exits
+    /// (via `exit`) with the given `$exit` code (default 0). A block that
+    /// returns normally without calling `exit` fails, even when `$exit` is 0.
+    pub(crate) fn test_fn_exits_ok(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
+        let block = Self::positional_value_required(args, 0, "exits-ok expects block")?.clone();
+        let expected = Self::positional_value(args, 1)
+            .map(|v| match v.view() {
+                ValueView::Int(i) => i,
+                ValueView::Num(f) => f as i64,
+                _ => v.to_f64() as i64,
+            })
+            .unwrap_or(0);
+        let desc = Self::positional_string(args, 2);
+        let todo = Self::named_bool(args, "todo");
+        let ok = match block.view() {
+            ValueView::Sub(data) => {
+                self.push_caller_env();
+                // Save both "$_" (sigiled) and "_" (bare) since eval_block_value sets "_".
+                let saved_topic_sigil = self.env.get("$_").cloned();
+                let saved_topic_bare = self.env.get("_").cloned();
+                // Run the block with `exit` captured in-process. `nested_mode`
+                // makes `builtin_exit` set only `halted`/`exit_code` instead of
+                // raising the global exit flag or calling `std::process::exit`,
+                // so the surrounding test file keeps running afterwards.
+                let saved_nested = self.nested_mode;
+                let saved_exit_code = self.exit_code;
+                let saved_halted = self.halted;
+                self.nested_mode = true;
+                let _ = self.eval_test_block_value(&data.body);
+                let exited = self.halted;
+                let got = self.exit_code;
+                self.nested_mode = saved_nested;
+                self.exit_code = saved_exit_code;
+                self.halted = saved_halted;
+                match saved_topic_sigil {
+                    Some(v) => {
+                        self.env.insert("$_".to_string(), v);
+                    }
+                    None => {
+                        self.env.remove("$_");
+                    }
+                }
+                match saved_topic_bare {
+                    Some(v) => {
+                        self.env.insert("_".to_string(), v);
+                    }
+                    None => {
+                        self.env.remove("_");
+                    }
+                }
+                self.pop_caller_env();
+                exited && got == expected
+            }
+            _ => false,
+        };
+        self.test_ok(ok, &desc, todo)?;
+        Ok(Value::truth(ok))
+    }
+
     pub(crate) fn test_fn_isa_ok(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         // isa-ok uses the first non-named-pair arg as value.
         // We need special handling because positional_value filters out ALL Pairs,

--- a/src/runtime/test_functions/mod.rs
+++ b/src/runtime/test_functions/mod.rs
@@ -162,6 +162,7 @@ impl Interpreter {
                 | "is-approx"
                 | "lives-ok"
                 | "dies-ok"
+                | "exits-ok"
                 | "isa-ok"
                 | "force_todo"
                 | "force-todo"
@@ -228,6 +229,7 @@ impl Interpreter {
             "is-approx" => self.test_fn_is_approx(args).map(Some),
             "lives-ok" => self.test_fn_lives_ok(args).map(Some),
             "dies-ok" => self.test_fn_dies_ok(args).map(Some),
+            "exits-ok" => self.test_fn_exits_ok(args).map(Some),
             "isa-ok" => self.test_fn_isa_ok(args).map(Some),
             "force_todo" | "force-todo" => self.test_fn_force_todo(args).map(Some),
             "eval-lives-ok" => self.test_fn_eval_lives_ok(args).map(Some),

--- a/src/vm/vm_call_autothread.rs
+++ b/src/vm/vm_call_autothread.rs
@@ -53,6 +53,7 @@ impl Interpreter {
                     | "cmp-ok"
                     | "dies-ok"
                     | "lives-ok"
+                    | "exits-ok"
                     | "eval-dies-ok"
                     | "eval-lives-ok"
                     | "throws-like"

--- a/t/exits-ok.t
+++ b/t/exits-ok.t
@@ -1,0 +1,46 @@
+use Test;
+
+plan 13;
+
+# Basic: the block exits with the expected code.
+exits-ok({ exit 4 }, 4, "exits with code 4");
+
+# stdout produced before the exit is still emitted.
+exits-ok({ print ""; exit 2 }, 2, "exits with code 2 after output");
+
+# Explicit exit 0.
+exits-ok({ exit 0 }, 0, "exits with code 0");
+
+# A bare `exit` defaults to code 0.
+exits-ok({ exit }, 0, "bare exit defaults to code 0");
+
+# The expected-exit-code argument defaults to 0 when omitted.
+exits-ok({ exit 0 });
+
+# Block form without parentheses.
+exits-ok {
+    exit 3;
+}, 3, "block form exits with code 3";
+
+# High POSIX code.
+exits-ok({ exit 127 }, 127, "exits with code 127");
+
+# Return value is True on success, False on failure.
+my $ok = exits-ok({ exit 7 }, 7, "returns True on match");
+ok $ok, "exits-ok returns True when the code matches";
+
+# Negative cases are marked TODO so their failing TAP lines do not fail the plan,
+# while their return value is asserted to be False.
+{
+    my $bad;
+    todo "wrong exit code should not match";
+    $bad = exits-ok({ exit 5 }, 4, "wrong code does not match");
+    nok $bad, "exits-ok returns False when the code differs";
+}
+
+{
+    my $bad;
+    todo "block that never exits should not match";
+    $bad = exits-ok({ 42 }, 0, "no exit does not match even for code 0");
+    nok $bad, "exits-ok returns False when the block never exits";
+}


### PR DESCRIPTION
## Summary

Implements the `exits-ok` Test-module assertion.

```
multi exits-ok($code, $exit = 0, $reason)
```

`exits-ok` passes iff running `$code` exits (via `exit`) with the expected `$exit` code (default 0). A block that returns normally **without** calling `exit` fails, even when the expected code is 0 — matching Rakudo semantics.

## Implementation

- `test_fn_exits_ok` (`src/runtime/test_functions/eval_exception.rs`) runs the block in-process with `nested_mode` toggled on, so `builtin_exit` only sets the VM's `halted`/`exit_code` instead of raising the global exit flag or calling `std::process::exit`. The captured halt state is then restored so the surrounding test file keeps running.
- Registered the name in the Test-function recognizer/dispatch (`test_functions/mod.rs`), the block-arg → anon-sub rewrite (`compiler/helpers_call_args.rs`), the Test-export lists (`parser/.../compile_consts.rs`, `module_exports.rs`, `runtime/system_eval_string.rs`), the autothread allow-list (`vm/vm_call_autothread.rs`), and the roast `#?rakudo skip` statement-detector (`runtime/run_roast_preprocess.rs`).

## Tests

- `t/exits-ok.t` covers: matching exit codes (0, 2, 3, 4, 127), bare `exit` defaulting to 0, the default expected-code argument, the block form without parentheses, the `True`/`False` return value, and the two negative paths (wrong code, and a block that never exits) verified via `todo` + `nok`.

Reference: `raku-doc/doc/Type/Test.rakudoc` (`sub exits-ok`), `raku-doc/doc/Language/testing.rakudoc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)