### PR TITLE
fix: two generic bugs surfaced by the License::SPDX suite

### DIFF
--- a/src/parser/stmt/decl/has_decl.rs
+++ b/src/parser/stmt/decl/has_decl.rs
@@ -555,9 +555,9 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
                         _ => {}
                     }
                 }
-                let inner = &stripped[..idx];
+                let inner = stripped[..idx].trim();
                 let mut trait_arg: Option<Expr> = None;
-                if !inner.trim().is_empty()
+                if !inner.is_empty()
                     && let Ok((leftover, arg_expr)) = expression(inner)
                     && leftover.trim().is_empty()
                 {

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -270,12 +270,14 @@ impl Interpreter {
                     return Ok(Value::package(Symbol::intern(of_type)));
                 }
             }
+            // Embedded metadata first: it travels with the value, so it stays
+            // correct when a recursive call clobbers the name-keyed constraint
+            // store (`my @ret := Array[T].new` re-bound in an inner frame).
             let type_name = self
-                .var_type_constraint(target_var)
-                .or_else(|| {
-                    self.container_type_metadata(&target)
-                        .map(|info| info.value_type)
-                })
+                .container_type_metadata(&target)
+                .map(|info| info.value_type)
+                .filter(|t| !t.is_empty())
+                .or_else(|| self.var_type_constraint(target_var))
                 .unwrap_or_else(|| "Mu".to_string());
             return Ok(Value::package(Symbol::intern(&type_name)));
         }
@@ -660,7 +662,7 @@ impl Interpreter {
             match method {
                 "push" => {
                     let normalized_args = Self::normalize_push_unshift_args(args);
-                    self.check_container_element_types(&key, &normalized_args)?;
+                    self.check_container_element_types(&key, &target, &normalized_args)?;
                     let result = self.push_to_shared_var(&key, normalized_args, &target);
                     self.reattach_array_type_metadata(&key, &saved_meta);
                     return Ok(result);
@@ -671,7 +673,7 @@ impl Interpreter {
                     // are flattened. With multiple arguments, each is appended
                     // as-is (no recursive flattening).
                     let flat_values = flatten_append_args(args);
-                    self.check_container_element_types(&key, &flat_values)?;
+                    self.check_container_element_types(&key, &target, &flat_values)?;
                     let result = if let Some(slot) = self.env.get_mut(&key)
                         && let Some(r) = slot.with_array_mut(|arc_items, kind| {
                             let kind = *kind;
@@ -696,7 +698,7 @@ impl Interpreter {
                 }
                 "unshift" => {
                     let normalized_args = Self::normalize_push_unshift_args(args);
-                    self.check_container_element_types(&key, &normalized_args)?;
+                    self.check_container_element_types(&key, &target, &normalized_args)?;
                     let result = if let Some(slot) = self.env.get_mut(&key)
                         && let Some(r) = slot.with_array_mut(|arc_items, kind| {
                             let kind = *kind;
@@ -724,7 +726,7 @@ impl Interpreter {
                 }
                 "prepend" => {
                     let flat_values = flatten_append_args(args);
-                    self.check_container_element_types(&key, &flat_values)?;
+                    self.check_container_element_types(&key, &target, &flat_values)?;
                     let result = if let Some(slot) = self.env.get_mut(&key)
                         && let Some(r) = slot.with_array_mut(|arc_items, kind| {
                             let kind = *kind;
@@ -936,7 +938,7 @@ impl Interpreter {
                     // Type-check splice replacement values against the array's
                     // declared element type (`my Int @a` splice must reject a Str),
                     // mirroring the element check applied to typed-array assignment.
-                    if let Some(constraint) = self.var_type_constraint(&key)
+                    if let Some(constraint) = self.element_constraint_for(&key, &target)
                         && !matches!(constraint.as_str(), "" | "Any" | "Mu")
                     {
                         for arg in args.iter().skip(2) {

--- a/src/runtime/runtime_container.rs
+++ b/src/runtime/runtime_container.rs
@@ -313,15 +313,35 @@ impl Interpreter {
         self.var_type_constraints = snapshot;
     }
 
+    /// Element type constraint for a container variable, preferring the
+    /// metadata embedded in the value itself over the name-keyed
+    /// `var_type_constraints` side table. The embedded metadata travels with
+    /// the value through frame save/restore, so it stays correct when a
+    /// recursive call re-binds a same-named variable to a differently-typed
+    /// container (`my @ret := Array[T].new` in a recursive sub) — the
+    /// name-keyed store is clobbered by the inner frame in that case.
+    pub(crate) fn element_constraint_for(&self, var_name: &str, value: &Value) -> Option<String> {
+        if let Some(info) = self.container_type_metadata(value) {
+            if info.value_type.is_empty() {
+                return None;
+            }
+            return Some(info.value_type);
+        }
+        self.var_type_constraint(var_name)
+    }
+
     /// Check that all values satisfy the element type constraint for a
     /// container variable (e.g. `my Int @a`). Returns Ok(()) if no constraint
     /// exists or all values pass; returns a type-check error otherwise.
+    /// `target` is the variable's current value: its embedded metadata takes
+    /// priority over the name-keyed constraint (see `element_constraint_for`).
     pub(crate) fn check_container_element_types(
         &mut self,
         var_name: &str,
+        target: &Value,
         values: &[Value],
     ) -> Result<(), RuntimeError> {
-        if let Some(constraint) = self.var_type_constraint(var_name) {
+        if let Some(constraint) = self.element_constraint_for(var_name, target) {
             for val in values {
                 if !val.is_nil() && !self.type_matches_value(&constraint, val) {
                     return Err(crate::runtime::utils::type_check_element_typed_error(

--- a/t/attr-trait-paren-space.t
+++ b/t/attr-trait-paren-space.t
@@ -1,0 +1,33 @@
+use v6;
+use Test;
+
+# A custom attribute trait argument must survive whitespace between the
+# opening paren and the argument expression:
+#   has Date $.d is unmarshalled-by( -> $d { ... });
+# The parser used to hand the un-trimmed inner text to the expression parser,
+# which failed on the leading space and silently dropped the argument
+# (License::SPDX's `is unmarshalled-by( -> $d { DateTime.new($d).Date })`).
+
+plan 6;
+
+my %seen;
+
+multi sub trait_mod:<is> (Attribute $attr, :&by!) {
+    %seen{$attr.name} = &by;
+}
+
+class C {
+    has Str $.tight is by(-> $v { "tight:$v" });
+    has Str $.space is by( -> $v { "space:$v" });
+    has Str $.both is by(  -> $v { "both:$v" }  );
+}
+
+ok %seen<$!tight>.defined, 'trait arg without space is captured';
+ok %seen<$!space>.defined, 'trait arg with leading space is captured';
+ok %seen<$!both>.defined, 'trait arg with leading and trailing space is captured';
+
+is %seen<$!tight>.('a'), 'tight:a', 'no-space closure is callable';
+is %seen<$!space>.('b'), 'space:b', 'leading-space closure is callable';
+is %seen<$!both>.('c'), 'both:c', 'both-space closure is callable';
+
+done-testing;

--- a/t/typed-bind-recursion.t
+++ b/t/typed-bind-recursion.t
@@ -1,0 +1,35 @@
+use v6;
+use Test;
+
+# A recursive sub that binds a same-named lexical to a differently-typed
+# container in each frame (`my @ret := Array[T].new`) must keep each frame's
+# element type. The name-keyed constraint store is clobbered by the inner
+# frame; the element checks and `.of` must read the metadata embedded in the
+# value instead (JSON::Unmarshal's `_unmarshal($json, @x)` recursion, hit by
+# License::SPDX via nested `has Str @.see-also` inside `has License @.licenses`).
+
+plan 6;
+
+sub go-array(Int $depth) {
+    my @ret := Array[$depth == 0 ?? Str !! Int].new;
+    if $depth > 0 {
+        go-array($depth - 1);
+        is @ret.of.^name, 'Int', "array depth $depth keeps of=Int after recursion";
+        lives-ok { @ret.append($depth) }, "array depth $depth append Int still passes";
+    }
+    else {
+        @ret.append("leaf");
+    }
+    @ret
+}
+my $top = go-array(2);
+is $top.raku, 'Array[Int].new(2)', 'outermost array has its own value and type';
+
+sub go-hash(Int $depth) {
+    my %ret := Hash[$depth == 0 ?? Str !! Int].new;
+    if $depth > 0 { go-hash($depth - 1); }
+    %ret.of.^name
+}
+is go-hash(1), 'Int', 'hash keeps of=Int after recursion';
+
+done-testing;


### PR DESCRIPTION
## Summary

Two generic bugs found by running the License::SPDX-3.28.0 test suite (mzef E2E campaign). Both are general-purpose fixes; no module-specific logic.

### 1. Parser: trait argument dropped when whitespace follows the opening paren

`has Date $.release-date is unmarshalled-by( -> $d { DateTime.new($d).Date });`

The `has`-declaration trait parser handed the un-trimmed paren contents to `expression()`, which fails on the leading space; the failure was swallowed and the trait silently degraded to the no-argument form. JSON::Unmarshal's `trait_mod:<is> (Attribute $attr, :&unmarshalled-by!)` then received no closure, and unmarshalling died with `No such method 'CALL-ME' for invocant of type 'Any'`. Fix: trim the captured text before parsing (`src/parser/stmt/decl/has_decl.rs`).

### 2. Recursion clobbers the name-keyed element-type constraint

```raku
sub go(Int $depth) {
    my @ret := Array[$depth == 0 ?? Str !! Int].new;
    if $depth > 0 { go($depth - 1); @ret.append($depth) }  # died: expected Str
    else          { @ret.append("leaf") }
    @ret
}
```

Element type checks (push/append/unshift/prepend/splice) and `.of` consulted the name-keyed `var_type_constraints` side table first. An inner frame of the same sub re-binding the same name to a differently-typed container overwrites that entry (both the global map and the env-scoped `__mutsu_type::` key are frame-blind), so after the inner call returned the outer frame checked against the wrong element type. This is exactly JSON::Unmarshal's `_unmarshal($json, @x)` recursion (nested `has Str @.see-also` inside `has License @.licenses`).

Fix: prefer the type metadata **embedded in the container value** — it travels with the frame's saved locals, so it is always the current frame's truth — and keep the name-keyed store as a fallback for values whose embedded metadata was lost by an intermediate operation (the existing `reattach_array_type_metadata` scenario). This also moves further toward the documented architecture ("type metadata embedded in backing data structs — no side tables").

## Results

- License::SPDX: 0/2 → **2/2 files, 729 tests PASS**
- JSON::Unmarshal stays 11/11; JSON suites and typed-array/splice roast subset verified locally
- `make test`: 1897 files / 18196 tests PASS

## Pins

- `t/attr-trait-paren-space.t` — trait args with leading/trailing paren whitespace reach the trait_mod (verified against raku)
- `t/typed-bind-recursion.t` — per-frame element type survives recursion for `Array[T]`/`Hash[T]` binds (verified against raku)

🤖 Generated with [Claude Code](https://claude.com/claude-code)