### PR TITLE
feat: RakuAST Phase 5 slice 9 — EVAL of the bare for @x { ... } ($_) form

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -901,9 +901,12 @@ so it is tracked separately from the roast backlog.
         `Stmt::Given`/`When`/`Default`); a topicalizer runs and yields the matched clause's value.
         Also fixed a latent `eval_block_value` bug where a non-tail `given` leaked its block value onto
         the stack and shadowed the block's real tail value. Tests in `t/rakuast-eval-given.t`.
-  - [ ] Slice 9+: `for @x { … }` (`$_`), multi-param/typed/named/slurpy params, control flow
-        (`return`/`last`/`next`) — the inverse of the Phase-2 converter, grown cluster by cluster.
-        (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 9: EVAL of the bare `for @x { … }` form (a `Statement::For` with a plain `Block` body →
+        `Stmt::For` with no named parameter; the body sees `$_`); `EVAL(Q[my $t=0; for 1..4 { $t=$t+$_ };
+        $t].AST)` → 10. Tests in `t/rakuast-eval-bare-for.t`.
+  - [ ] Slice 10+: control flow (`return`/`last`/`next`), multi-param/typed/named/slurpy params — the
+        inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full lowering is a large
+        multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -230,6 +230,10 @@ earlier ones.
     result), so a *non-last* one shadowed the block's real tail value; `compile_unit` now pops it. Tests
     in `t/rakuast-eval-given.t`. Next: the bare `for @x { … }` (`$_`) form, control flow (`return`/
     `last`/`next`).
+  - **Slice 9 (bare `for @x { … }` / `$_`) — done.** A `Statement::For` whose body is a plain `Block`
+    (not a `PointyBlock`) lowers to a `Stmt::For` with no named parameter, so the loop body sees the
+    iterand as `$_`. `EVAL(Q[my $t = 0; for 1..4 { $t = $t + $_ }; $t].AST)` → `10`. Tests in
+    `t/rakuast-eval-bare-for.t`. Next: control flow (`return`/`last`/`next`), multi/typed parameters.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -125,13 +125,16 @@ fn lower_if(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
 /// blocks are the current coverage boundary.
 fn lower_for(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     let iterable = lower_expr(named_child(node, "source")?)?;
-    let pointy = named_child(node, "body")?;
-    if pointy.class != RakuAstClass::PointyBlock {
-        return Err(unsupported(node));
-    }
-    let param = pointy_single_param(pointy)?;
-    // A PointyBlock, like a Block, wraps its statements in a `body` Blockoid.
-    let body = lower_block(pointy)?;
+    let block = named_child(node, "body")?;
+    // A pointy block (`-> $x { … }`) names the loop variable; a plain block
+    // (`for @x { … $_ }`) has no explicit parameter and the body sees `$_`.
+    let param = match block.class {
+        RakuAstClass::PointyBlock => pointy_single_param(block)?,
+        RakuAstClass::Block => None,
+        _ => return Err(unsupported(node)),
+    };
+    // Both a Block and a PointyBlock wrap their statements in a `body` Blockoid.
+    let body = lower_block(block)?;
     Ok(Stmt::For {
         iterable,
         param,

--- a/t/rakuast-eval-bare-for.t
+++ b/t/rakuast-eval-bare-for.t
@@ -1,0 +1,28 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 5 slice 9 (ADR-0011): EVAL of the bare `for @x { … }` form,
+# whose block has no explicit parameter and sees the loop value as `$_`.
+# `Statement::For` with a plain `Block` body (not a `PointyBlock`) lowers to a
+# `Stmt::For` with no named parameter. Verified against Rakudo; passes under BOTH
+# mutsu and raku.
+
+plan 4;
+
+# --- bare for over a range, using $_ ----------------------------------------
+is EVAL(Q[my $t = 0; for 1..4 { $t = $t + $_ }; $t].AST), 10,
+    'bare for: sum 1..4 via $_ == 10';
+
+# --- bare for over a list ---------------------------------------------------
+is EVAL(Q[my $p = 1; for (2, 3, 4) { $p = $p * $_ }; $p].AST), 24,
+    'bare for: product of a list via $_ == 24';
+
+# --- $_ drives a method call ------------------------------------------------
+is EVAL(Q[my $t = 0; for (-1, -2, -3) { $t = $t + $_.abs }; $t].AST), 6,
+    'bare for: $_.abs accumulates to 6';
+
+# --- the pointy form still works alongside ----------------------------------
+is EVAL(Q[my $s = 0; for 1..4 -> $x { $s = $s + $x }; $s].AST), 10,
+    'pointy for still lowers correctly';


### PR DESCRIPTION
## Summary

Phase 5 slice 9 of RakuAST (ADR-0011): `EVAL` of the bare `for @x { … }` loop form.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[my $t = 0; for 1..4 { $t = $t + $_ }; $t].AST)         # 10
EVAL(Q[my $t = 0; for (-1, -2, -3) { $t = $t + $_.abs }; $t].AST)  # 6
```

A `Statement::For` whose body is a plain `Block` (not a `PointyBlock`) lowers to a `Stmt::For` with no named parameter, so the loop body sees the iterand as `$_`. The pointy form (`-> $x`) still lowers as before.

## Tests

`t/rakuast-eval-bare-for.t` — 4 assertions (bare-for sum via `$_`, product over a list, `$_.abs` in the body, and the pointy form alongside), **passing under BOTH mutsu and raku**. All 47 `t/rakuast-*.t` files (205 tests) still green.

Next: control flow (`return`/`last`/`next`), multi/typed parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)