### PR TITLE
tooling: add QA doc-diff harness (PLAN.md §8.1)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -931,14 +931,25 @@ was "effective with Rakudo 2026.01"). Prefer the stronger signal **"mutsu differ
 the documented expectation"** over a raw raku diff, so version skew and aspirational docs do not flood
 the backlog.
 
-### 8.1 Differential harness (the backbone — build first)
+### 8.1 Differential harness (the backbone) — ✅ prototype landed
 
-- [ ] Build a `raku`-vs-`mutsu` differential runner: feed a program to both, capture
-      stdout/stderr/exit, diff, and emit only mismatches with a minimal repro. This is the reusable
-      substrate for 8.2 / 8.3 / 8.4 and any future fuzz corpus. Handle version fudging and per-run
-      timeouts. **Gate before scaling:** first prototype it on a small corpus and confirm the signal is
-      dense enough to justify a full campaign — do not stand up a large agent fleet on an unmeasured
-      signal.
+- [x] **`scripts/doc-diff-harness.raku`** — a `raku`-vs-`mutsu` differential runner: feeds each
+      extracted `raku-doc` example to both, uses raku as the oracle (compares only blocks raku runs
+      cleanly), and reports mismatches as ready-made minimal repros, bucketing `raku-drift-from-doc`
+      (version drift) separately from true `output-mismatch` / `mutsu-error`. See
+      [docs/qa-doc-diff-harness.md](docs/qa-doc-diff-harness.md).
+      **Signal gate passed** (2026-07-18, 8 core Type files): 270 raku-clean comparisons → **50
+      high-signal divergences (18.5%)**, genuine and clustering by root cause. The premise holds; the
+      campaign is justified.
+- [ ] Reusable substrate for 8.2 / 8.3 / 8.4 and any future fuzz corpus — extend the corpus beyond the
+      core Type files (all of `Type/` + `Language/`, then a real-module corpus), and grow the
+      non-determinism / error-example skip heuristics as new noise shows up.
+- [ ] **First backlog item from the run: sequence/lazy argument truncation** — `1, 3 ... 11` (and lazy
+      `gather`/`Seq`) passed as a routine/method argument is materialised to only its first two
+      elements (`@foo.prepend: 1,3...11` → `[1 3 …]`; `600.polymod(lazy …)` → `(600)`). One root cause,
+      several doc examples. Other confirmed findings: autoviv-hole `.List`/`.Slip` renders `(Any)`
+      instead of `Nil`; empty-`Array` `pop` does not throw `X::Cannot::Empty`; lazy `.elems` does not
+      throw `X::Cannot::Lazy`.
 
 ### 8.2 Documented-surface coverage (doc examples + method matrix)
 

--- a/docs/qa-doc-diff-harness.md
+++ b/docs/qa-doc-diff-harness.md
@@ -1,0 +1,74 @@
+# QA doc-diff harness (PLAN.md §8.1)
+
+`scripts/doc-diff-harness.raku` is the differential tester for the finalization / QA
+campaign. It extracts runnable code examples from `raku-doc`, runs each through the
+reference `raku` and through `mutsu`, and reports only the cases where the two
+disagree.
+
+## How it works
+
+- **Oracle = `raku`.** A block is compared *only* when raku itself runs it cleanly
+  (exit 0, no compile `SORRY`, non-empty stdout). This naturally filters out doc
+  fragments, intentional-error snippets, and non-runnable examples — no hand-curation
+  needed. Run the harness with **system `raku`**, never mutsu, so the oracle is
+  independent of the code under test.
+- **Corpus = `raku-doc`.** Extracts explicit `=begin code`/`=end code` and `=for code`
+  blocks (honouring `:preamble<...>` and `:skip-test`) plus 4-space indented code
+  blocks. `raku-doc` is one corpus among several (see PLAN.md §8) — the same runner
+  works on any set of `.rakudoc` files or a real-module corpus.
+- **Noise control.**
+  - Non-deterministic examples (`rand`/`.pick`/`.roll`/`now`/`Supply`/…) and explicit
+    `# ERROR` examples are skipped by heuristic.
+  - Every mismatch is cross-checked against the block's own `# OUTPUT: «…»` annotation.
+    When raku no longer matches the doc, the finding is bucketed as
+    **`raku-drift-from-doc`** (raku changed since the doc was written; mutsu may well
+    match the doc) and de-prioritised versus a true `output-mismatch` where raku and the
+    doc agree but mutsu is wrong. This implements the §8.4 language-version caveat.
+
+## Usage
+
+```
+raku scripts/doc-diff-harness.raku [--mutsu=PATH] [--timeout=N] [--limit=N]
+                                   [--report=FILE] [FILES-OR-DIRS ...]
+```
+
+Defaults: `--mutsu=target/debug/mutsu`, `--timeout=10`, corpus =
+`raku-doc/doc/Type` + `raku-doc/doc/Language`, report = `tmp/doc-diff-report.txt`.
+The debug and release binaries produce identical output, so the debug build is fine
+for correctness triage (only speed differs).
+
+The report groups findings by kind (`output-mismatch`, `mutsu-error`,
+`raku-drift-from-doc`), each with the exact program, raku stdout, and mutsu
+stdout/stderr — i.e. a ready-made minimal repro.
+
+## First run (2026-07-18, 8 core Type files: Str/Array/List/Hash/Num/Rat/Range/Map)
+
+525 blocks extracted → 270 raku-clean comparisons → **50 high-signal divergences
+(18.5%)**: 25 `output-mismatch` + 25 `mutsu-error`, plus 8 low-priority
+`raku-drift-from-doc`. ~2 min wall-clock (debug mutsu). The signal is dense and the
+findings are genuine and cluster by root cause — validating §8.1's premise.
+
+### First root-cause cluster found: sequence/lazy argument truncation
+
+`1, 3 ... 11` (and lazy `gather`/`Seq`) passed as a **method/routine argument** is
+materialised to only its first two elements instead of being expanded:
+
+```raku
+my @foo = <a b c>;
+@foo.prepend: 1, 3 ... 11;
+say @foo;   # raku: [1 3 5 7 9 11 a b c]   mutsu: [1 3 a b c]
+say 600.polymod(lazy gather { take 3*$_ for 1..3 });
+            # raku: (0 2 6 3)               mutsu: (600)
+```
+
+Other confirmed real findings from the same run (for the backlog): autoviv-hole
+`.List`/`.Slip` renders `(Any)` instead of `Nil`/`(Int)` and drops separators; `pop`
+on an empty `Array` does not throw `X::Cannot::Empty`; `try [-∞...∞].elems` does not
+throw `X::Cannot::Lazy`.
+
+## Discovery-vs-fix discipline (PLAN.md §8)
+
+The harness is a **discovery** tool: its deliverable is a ranked backlog of minimal
+repros grouped by root cause. Interpreter fixes are a separate, controlled step — do
+not let a breadth-first pass bolt on slow-path fallbacks or special-cased outputs just
+to make a diff go green (see the standing rules in CLAUDE.md).

--- a/scripts/doc-diff-harness.raku
+++ b/scripts/doc-diff-harness.raku
@@ -1,0 +1,316 @@
+#!/usr/bin/env raku
+# doc-diff-harness.raku — differential tester for the QA / finalization campaign (PLAN.md §8.1).
+#
+# It extracts runnable code examples from raku-doc, runs each through the REFERENCE
+# `raku` and through `mutsu`, and reports only the cases where the two disagree.
+# `raku` is the oracle: a block is compared *only* when raku itself runs it cleanly
+# (exit 0, no compile SORRY, and some stdout), which naturally filters out
+# doc fragments, intentional-error examples, and non-runnable snippets.
+#
+# This is intentionally NOT dependent on mutsu being correct — run it with system raku.
+#
+# Usage:
+#   raku scripts/doc-diff-harness.raku [--mutsu=PATH] [--timeout=N] [--limit=N]
+#                                      [--report=FILE] [FILES-OR-DIRS ...]
+# Defaults: mutsu=target/debug/mutsu, timeout=10s, corpus=raku-doc/doc/Type + Language.
+
+sub MAIN(
+    *@paths,
+    Str  :$mutsu   = 'target/debug/mutsu',
+    Int  :$timeout = 10,
+    Int  :$limit   = 0,                          # 0 = no cap
+    Str  :$report  = 'tmp/doc-diff-report.txt',
+    Bool :$verbose = False,
+) {
+    my @files = collect-files(@paths);
+    note "Scanning { +@files } .rakudoc files ...";
+
+    my @blocks;
+    for @files -> $file {
+        @blocks.append: extract-blocks($file);
+    }
+    note "Extracted { +@blocks } candidate code blocks.";
+
+    mkdir 'tmp/ddh' unless 'tmp/ddh'.IO.d;
+
+    my %stat = skipped-marker => 0, skipped-nondet => 0,
+               no-oracle => 0, match => 0, mismatch => 0,
+               mutsu-crash => 0, raku-drift => 0;
+    my @findings;
+
+    my $i = 0;
+    for @blocks -> %b {
+        last if $limit > 0 && $i >= $limit;
+        $i++;
+
+        if %b<skip> {
+            %stat<skipped-marker>++;
+            next;
+        }
+        if nondeterministic(%b<code>) {
+            %stat<skipped-nondet>++;
+            next;
+        }
+
+        my $program = %b<preamble> ?? %b<preamble> ~ "\n" ~ %b<code> !! %b<code>;
+        my $path = "tmp/ddh/prog.raku";
+        spurt $path, $program;
+
+        my $r = run-capture('raku', $path, $timeout);
+        # Oracle gate: raku must run it cleanly and produce output.
+        unless $r<exit> == 0 && $r<out>.chars > 0 && $r<err> !~~ /SORRY/ {
+            %stat<no-oracle>++;
+            next;
+        }
+
+        my $m = run-capture($mutsu, $path, $timeout);
+
+        if normalize($m<out>) eq normalize($r<out>) {
+            %stat<match>++;
+        }
+        elsif $m<exit> != 0 {
+            %stat<mutsu-crash>++;
+            @findings.push: finding(%b, $program, $r, $m, 'mutsu-error');
+        }
+        else {
+            # Cross-check against the doc's own `# OUTPUT:` annotation. When raku
+            # itself no longer matches the doc, this is version drift (raku changed
+            # since the doc was written) and mutsu may well match the doc — lower
+            # priority than a case where raku and the doc agree but mutsu is wrong.
+            my $expected = doc-expected(%b<code>);
+            if $expected.defined && normalize($expected) ne normalize($r<out>) {
+                %stat<raku-drift>++;
+                @findings.push: finding(%b, $program, $r, $m, 'raku-drift-from-doc');
+            }
+            else {
+                %stat<mismatch>++;
+                @findings.push: finding(%b, $program, $r, $m, 'output-mismatch');
+            }
+        }
+
+        if $verbose && $i %% 50 {
+            note "  [$i/{ +@blocks }] match=%stat<match> mismatch=%stat<mismatch> crash=%stat<mutsu-crash> no-oracle=%stat<no-oracle>";
+        }
+    }
+
+    write-report($report, %stat, @findings);
+    print-summary(%stat, @findings, $report);
+}
+
+#| Expand paths (files or dirs) to a list of .rakudoc files. Default corpus if empty.
+sub collect-files(@paths) {
+    my @roots = @paths
+        ?? @paths
+        !! <raku-doc/doc/Type raku-doc/doc/Language>;
+    my @files;
+    for @roots -> $p {
+        my $io = $p.IO;
+        if $io.d {
+            @files.append: walk-rakudoc($io);
+        }
+        elsif $io.f {
+            @files.push: $io.Str;
+        }
+    }
+    @files.unique.sort;
+}
+
+sub walk-rakudoc(IO::Path $dir) {
+    my @out;
+    for $dir.dir -> $e {
+        if $e.d {
+            @out.append: walk-rakudoc($e);
+        }
+        elsif $e.f && $e.Str.ends-with('.rakudoc') {
+            @out.push: $e.Str;
+        }
+    }
+    @out;
+}
+
+#| Extract code blocks from one .rakudoc file.
+#| Handles explicit `=begin code`/`=end code`, `=for code`, and 4-space indented blocks.
+#| Returns a list of hashes: { file, line, code, preamble, skip }.
+sub extract-blocks(Str $file) {
+    my @lines = $file.IO.lines;
+    my @blocks;
+    my $n = @lines.elems;
+    my $i = 0;
+
+    # Track ranges consumed by explicit blocks so the indented-scan skips them.
+    my @consumed = False xx $n;
+
+    while $i < $n {
+        my $line = @lines[$i];
+
+        # =begin code [adverbs] ... =end code
+        if $line ~~ /^ \h* '=begin' \h+ 'code' \h* $<adv>=(.*) $/ {
+            my $adv = ~$<adv>;
+            my $start = $i;
+            my @body;
+            $i++;
+            while $i < $n && @lines[$i] !~~ /^ \h* '=end' \h+ 'code' / {
+                @body.push: @lines[$i];
+                @consumed[$i] = True;
+                $i++;
+            }
+            $i++; # skip =end code
+            @blocks.push: mk-block($file, $start + 1, dedent(@body), $adv);
+            next;
+        }
+
+        # =for code [adverbs]  (paragraph until blank line or next directive)
+        if $line ~~ /^ \h* '=for' \h+ 'code' \h* $<adv>=(.*) $/ {
+            my $adv = ~$<adv>;
+            my $start = $i;
+            my @body;
+            $i++;
+            while $i < $n && @lines[$i].trim ne '' && @lines[$i] !~~ /^ \h* '=' / {
+                @body.push: @lines[$i];
+                @consumed[$i] = True;
+                $i++;
+            }
+            @blocks.push: mk-block($file, $start + 1, dedent(@body), $adv);
+            next;
+        }
+
+        $i++;
+    }
+
+    # Indented (4-space) code blocks over the not-yet-consumed lines.
+    $i = 0;
+    while $i < $n {
+        if !@consumed[$i] && @lines[$i] ~~ /^ \h ** 4..* \S/ {
+            my $start = $i;
+            my @body;
+            while $i < $n && (@consumed[$i].not) &&
+                  (@lines[$i] ~~ /^ \h ** 4..* \S/ || @lines[$i].trim eq '') {
+                # stop the group if a blank line is followed by a non-indented line
+                last if @lines[$i].trim eq '' &&
+                        ($i + 1 >= $n || @lines[$i + 1] !~~ /^ \h ** 4..* \S/);
+                @body.push: @lines[$i];
+                $i++;
+            }
+            # strip trailing blanks
+            @body.pop while @body && @body[*-1].trim eq '';
+            @blocks.push: mk-block($file, $start + 1, dedent(@body), '')
+                if @body;
+        }
+        else {
+            $i++;
+        }
+    }
+
+    @blocks;
+}
+
+sub mk-block(Str $file, Int $line, Str $code, Str $adv) {
+    my $skip = $adv.contains('skip-test');
+    # Non-raku languages (`:lang<...>` other than raku/perl6): skip.
+    $skip ||= so $adv ~~ /':lang<' <-[>]>* '>'/ && $adv !~~ /':lang<raku>'/ && $adv !~~ /':lang<perl6>'/;
+    my $preamble = '';
+    if $adv ~~ /':preamble<' $<p>=(<-[>]>*) '>'/ {
+        $preamble = ~$<p>;
+    }
+    { :$file, :$line, :$code, :$preamble, :$skip };
+}
+
+#| Remove the common leading indentation from a set of lines.
+sub dedent(@lines) {
+    my @nonblank = @lines.grep(*.trim ne '');
+    return @lines.join("\n") unless @nonblank;
+    my $min = @nonblank.map({ $_ ~~ /^ $<ws>=(\h*) / ?? (~$<ws>).chars !! 0 }).min;
+    @lines.map({ .chars >= $min ?? .substr($min) !! $_ }).join("\n");
+}
+
+#| Heuristic: skip code whose output is inherently non-deterministic, or that is
+#| explicitly an error-demonstration example (comment says ERROR / dies).
+sub nondeterministic(Str $code) {
+    so $code ~~ /
+        << 'rand' >> | '.rand' | '.pick' | '.roll' | << 'now' >> | << 'time' >> |
+        'DateTime.now' | 'Instant' | '.WHERE' | 'nqp::' | 'Telemetry' |
+        'BEGIN' \h* 'note' | 'CALLER' | 'Backtrace' | 'Supply' | 'react' | 'Channel' |
+        '# ERROR' | '#ERROR' | 'Whatever' \h* 'star' | '.raku' \h* '#' \h* 'OUTPUT' \h* '«' \h* '.'
+    /;
+}
+
+#| Concatenate the expected output from a block's inline `# OUTPUT: «...»` annotations,
+#| turning the ␤ newline symbol into a real newline. Returns Nil when the block has none.
+sub doc-expected(Str $code) {
+    my @outs;
+    for $code.match(/'# OUTPUT:' \h* '«' $<body>=(<-[»]>*) '»'/, :g) -> $m {
+        @outs.push: (~$m<body>).subst('␤', "\n", :g);
+    }
+    return Nil unless @outs;
+    @outs.join;
+}
+
+#| Run a program through `timeout N bin file`, returning { out, err, exit }.
+sub run-capture(Str $bin, Str $file, Int $timeout) {
+    my $proc = run 'timeout', "$timeout", $bin, $file, :out, :err;
+    my $out = $proc.out.slurp(:close);
+    my $err = $proc.err.slurp(:close);
+    { out => $out, err => $err, exit => $proc.exitcode };
+}
+
+#| Normalize output for comparison: strip trailing whitespace on each line and overall.
+sub normalize(Str $s) {
+    $s.lines.map(*.trim-trailing).join("\n").trim-trailing;
+}
+
+sub finding(%b, Str $program, %raku, %mutsu, Str $kind) {
+    {
+        kind     => $kind,
+        file     => %b<file>,
+        line     => %b<line>,
+        program  => $program,
+        raku-out => %raku<out>,
+        mutsu-out => %mutsu<out>,
+        mutsu-err => %mutsu<err>,
+        mutsu-exit => %mutsu<exit>,
+    };
+}
+
+sub write-report(Str $report, %stat, @findings) {
+    my $fh = open $report, :w;
+    $fh.say: "# doc-diff-harness report";
+    $fh.say: "# stats: ", %stat.sort».fmt('%s=%s').join('  ');
+    $fh.say: "";
+    for @findings.kv -> $idx, %f {
+        $fh.say: "=" x 78;
+        $fh.say: "[{ $idx + 1 }] { %f<kind> }  { %f<file> }:{ %f<line> }";
+        $fh.say: "--- program ---";
+        $fh.say: %f<program>;
+        $fh.say: "--- raku stdout ---";
+        $fh.say: %f<raku-out>.trim-trailing;
+        $fh.say: "--- mutsu stdout (exit { %f<mutsu-exit> }) ---";
+        $fh.say: %f<mutsu-out>.trim-trailing;
+        if %f<kind> eq 'mutsu-error' && %f<mutsu-err>.trim ne '' {
+            $fh.say: "--- mutsu stderr ---";
+            $fh.say: %f<mutsu-err>.trim-trailing.lines.head(6).join("\n");
+        }
+        $fh.say: "";
+    }
+    $fh.close;
+}
+
+sub print-summary(%stat, @findings, Str $report) {
+    my $compared = %stat<match> + %stat<mismatch> + %stat<mutsu-crash>;
+    say "";
+    say "==== doc-diff-harness summary ====";
+    say "  skipped (marker):        %stat<skipped-marker>";
+    say "  skipped (nondet):        %stat<skipped-nondet>";
+    say "  no oracle (raku unclean): %stat<no-oracle>";
+    say "  ------------------------------------";
+    say "  compared (raku-clean):   $compared";
+    say "    match:                 %stat<match>";
+    say "    output mismatch (★real): %stat<mismatch>";
+    say "    mutsu error/crash (★real): %stat<mutsu-crash>";
+    say "    raku drifted from doc:  %stat<raku-drift>   (lower priority — raku changed since doc)";
+    if $compared > 0 {
+        my $real = %stat<mismatch> + %stat<mutsu-crash>;
+        my $rate = (100 * $real / $compared).round(0.1);
+        say "  ★high-signal divergence: $rate%  ($real/$compared)";
+    }
+    say "  findings written to:     $report";
+}


### PR DESCRIPTION
## Summary

Implements the §8.1 differential harness — the backbone of the QA / finalization campaign.

`scripts/doc-diff-harness.raku` extracts runnable code examples from `raku-doc`, runs each through the reference `raku` and through `mutsu`, and reports only the cases where they disagree, as ready-made minimal repros.

- **Oracle = raku**: a block is compared only when raku runs it cleanly (exit 0 / no `SORRY` / non-empty stdout), which auto-filters fragments and intentional-error snippets. Run with system `raku` — the harness does not depend on mutsu being correct.
- **Noise control**: non-deterministic / `# ERROR` examples are skipped; every mismatch is cross-checked against the block's own `# OUTPUT: «…»`, so **version drift** (raku changed since the doc) is bucketed as `raku-drift-from-doc` and de-prioritised versus a true `output-mismatch` / `mutsu-error`. This implements the §8.4 language-version caveat.

## Signal gate (measured before scaling, per §8.1)

8 core Type files (Str/Array/List/Hash/Num/Rat/Range/Map): 525 blocks → 270 raku-clean comparisons → **50 high-signal divergences (18.5%)** (25 output-mismatch + 25 mutsu-error), plus 8 low-priority drifts. ~2 min wall-clock (debug mutsu). The findings are genuine and cluster by root cause → the campaign is justified.

**First root-cause cluster found**: sequence/lazy arguments (`1, 3 ... 11`, lazy `gather`/`Seq`) passed to a routine/method are truncated to their first two elements (`@foo.prepend: 1,3...11` → `[1 3 …]`; `600.polymod(lazy …)` → `(600)`). Other confirmed findings: autoviv-hole `.List`/`.Slip` renders `(Any)` instead of `Nil`; empty-`Array` `pop` doesn't throw `X::Cannot::Empty`; lazy `.elems` doesn't throw `X::Cannot::Lazy`.

## Contents

- `scripts/doc-diff-harness.raku` — the runner (tool; reports to `tmp/`, gitignored).
- `docs/qa-doc-diff-harness.md` — how it works, usage, first-run results, discovery-vs-fix discipline.
- `PLAN.md` §8.1 — marked prototype-landed with the measured result and first backlog items.

Tooling + docs only; no interpreter change. (The bugs it found are backlog, fixed under separate controlled PRs.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)