### PR TITLE
docs: refresh mzef test-phase standing and split Test::Async into PLAN §1 B2b

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -205,10 +205,34 @@ Current state (details in news/2026-06.md and news/2026-07.md): ✅ CLI load + c
       ("Current frontier") for the lead and the next steps.
 - [ ] **build/test execution**, an `mzef` binary shim + vendoring of zef itself + dependencies +
       config (debian's zef lacks `resources/bin/zef`; a known-good vendoring is needed). The test
-      phase (6) has not been exercised yet — runs have used `--/test`.
+      phase (6) now runs (`zef install` without `--/test` does `Testing [OK] → Installing`); the
+      per-suite standing for the Test::META dependency chain is **9 PASS / 2 FAIL** as of
+      2026-07-18 (#4735/#4738/#4747; remaining = JSON::Fast fidelity + 3 Test::META subtests —
+      see `docs/mzef-install-pipeline.md` "Test-phase frontier").
 
 **`docs/mzef-install-pipeline.md` is the live tracker** — phase table, what each fix unblocked, and
 the current frontier with its next steps. Read it before picking up mzef work.
+
+### B2b. Test::Async / custom Metamodel HOW inheritance (deferred campaign — NOT on the mzef critical path)
+
+**Decision (user, 2026-07-18): handled as its own section, decoupled from the B2 test-phase
+frontier.** Test::Async (vrurg's async test framework, used by newer ecosystem dists) is blocked on
+**custom Metamodel HOW inheritance**: `'Test::Async::Metamodel::BundleHOW' cannot inherit from
+'Metamodel::ParametricRoleHOW' because it is unknown`. That is a real MOP feature — user-visible
+subclasses of the built-in metamodel classes (ParametricRoleHOW / ClassHOW), with mutsu's role/class
+machinery dispatching through the user's HOW overrides — and is **campaign-sized** (multiple
+sessions).
+
+- **Why deferred**: the mzef install pipeline's dependency chain (JSON::* / META6 / URI /
+  License::SPDX / Test::META) does not use Test::Async, so the "mzef installs real dists with tests
+  on" milestone does not need it. Spending the campaign now would delay the mzef return for zero
+  pipeline gain.
+- **Start trigger**: after the B2 test-phase frontier closes (or when a bundle-candidate module
+  hard-depends on Test::Async), start with a scouting session: inventory which HOW methods
+  Test::Async's BundleHOW/TestSuiteHOW actually override, and decide between (a) real HOW-subclass
+  dispatch in the MOP vs (b) a narrower compatibility shim for the handful of overridden hooks.
+- Prerequisite groundwork already landed: `::?CLASS` param fixes (#4669). Detail and error text:
+  `docs/mzef-install-pipeline.md` "Test-phase frontier" history block.
 
 ### B3. Distribution and tooling
 

--- a/docs/mzef-install-pipeline.md
+++ b/docs/mzef-install-pipeline.md
@@ -212,13 +212,35 @@ repro → general fix → `t/` pin):
   predicates. It now delegates to the same subset matcher `~~` uses. Pin:
   `t/subset-regex-return-check.t`.
 
-## Test-phase frontier (2026-07-17, the current one)
+## Test-phase frontier (2026-07-18 refresh)
 
-`zef install Test::META` (tests ON) runs all 16 dists' test suites
-concurrently; the baseline was **13/16 FAIL** (OK: JSON::OptIn; the
-debug-build run also overran a 570s timeout — use release for E2E). The
-2026-07-17 (late) session root-caused the dominant failures — none were
-environmental; all four were ordinary mutsu bugs, each fixed generally:
+**Per-suite standing (2026-07-18, after #4735 / #4738 / #4747; staged-dist
+`prove` sweep with the full MUTSULIB chain, `tmp/e2e-suites.sh`): 9 PASS /
+2 FAIL.** PASS: JSON::OptIn, JSON::Name, JSON::Unmarshal (11 files / 101
+tests), JSON::Marshal (14/85), JSON::Class (6/31), URI (14/222), META6
+(9/969), License::SPDX (2/729). FAIL: **JSON::Fast** (native-JSON fidelity
+remnants — strict mode / unicode / datetime; full parity is likely
+unnecessary for the pipeline) and **Test::META** (3 concrete subtest
+failures: `020-internals.t` test 12 "check-provides with my own files" and
+test 24 "check-sources" / "non-git URI needn't must end in git", plus
+`030-my-meta.t` "don't have META file"). Test-Helpers ships no `t/` of its
+own (covered by mutsu's local `t/test-util-*.t`).
+
+The #4747 session's two generic fixes (License::SPDX 0/2 → 2/2): a trait
+argument with whitespace after the opening paren
+(`is unmarshalled-by( -> $d { ... })`) was silently dropped by the `has`
+parser, and recursive re-binding of a same-named typed container
+(`my @ret := Array[T].new` in JSON::Unmarshal's `_unmarshal` recursion)
+clobbered the name-keyed element-type constraint — element checks and `.of`
+now prefer the metadata embedded in the value. Pins:
+`t/attr-trait-paren-space.t`, `t/typed-bind-recursion.t`.
+
+History (2026-07-17): `zef install Test::META` (tests ON) runs all 16
+dists' test suites concurrently; the baseline was **13/16 FAIL** (OK:
+JSON::OptIn; the debug-build run also overran a 570s timeout — use release
+for E2E). The 2026-07-17 (late) session root-caused the dominant failures
+— none were environmental; all four were ordinary mutsu bugs, each fixed
+generally:
 
 - ~~`use-ok` never did a real load~~ (the "dominant symptom"): mutsu's
   `use-ok` probed `lib_paths` for `Module/Name.rakumod` as literal files —
@@ -255,8 +277,14 @@ environmental; all four were ordinary mutsu bugs, each fixed generally:
   closure-exit/inline writeback (a declared name that is also a free var
   keeps its writeback). Pin: `t/map-block-my-shadow-leak.t`.
 
-Re-run the full `zef install Test::META` E2E after these land to get the
-new pass/fail count.
+~~Re-run the full `zef install Test::META` E2E after these land to get the
+new pass/fail count.~~ Done 2026-07-18 — see the per-suite standing at the
+top of this section (9 PASS / 2 FAIL).
+
+**Test::Async is out of scope for this frontier** (PLAN.md §1 B5): its
+blocker is custom Metamodel HOW inheritance
+(`Metamodel::ParametricRoleHOW`), a campaign-sized MOP feature that the
+mzef dependency chain does not need.
 
 Still open (load-side leftovers):
 


### PR DESCRIPTION
Doc-only update.

- **docs/mzef-install-pipeline.md** — Test-phase frontier refreshed with the 2026-07-18 per-suite E2E standing (staged-dist prove sweep, full MUTSULIB chain): **9 PASS / 2 FAIL**. PASS: JSON::OptIn / JSON::Name / JSON::Unmarshal / JSON::Marshal / JSON::Class / URI / META6 / License::SPDX. FAIL: JSON::Fast (fidelity remnants) and Test::META (3 concrete subtests). Records the two generic #4747 fixes and closes the E2E-recount TODO.
- **PLAN.md** — B2 test-phase bullet updated; new **§1 B2b** section for the Test::Async / custom Metamodel HOW inheritance campaign (ParametricRoleHOW), explicitly deferred off the mzef critical path with a start trigger (user decision 2026-07-18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)