### PR TITLE
feat: RakuAST slice 10 — return/last/next in both .AST and EVAL

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -904,9 +904,13 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 9: EVAL of the bare `for @x { … }` form (a `Statement::For` with a plain `Block` body →
         `Stmt::For` with no named parameter; the body sees `$_`); `EVAL(Q[my $t=0; for 1..4 { $t=$t+$_ };
         $t].AST)` → 10. Tests in `t/rakuast-eval-bare-for.t`.
-  - [ ] Slice 10+: control flow (`return`/`last`/`next`), multi-param/typed/named/slurpy params — the
-        inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full lowering is a large
-        multi-slice effort mirroring Phase 2.)
+  - [x] Slice 10: `return`/`last`/`next` (both directions). raku models these as bare calls; the read
+        side emits `Call::Name` (WithoutParentheses, `args` omitted when empty) and the write side lowers
+        such a call back to `Stmt::Return`/`Last`/`Next`. `EVAL(Q[sub f($x){ if $x>0 { return 5 }; -1 };
+        f(3)].AST)` → 5. Tests in `t/rakuast-eval-return.t`.
+  - [ ] Slice 11+: multi-param/typed/named/slurpy params, `unless`/`until` — the inverse of the Phase-2
+        converter, grown cluster by cluster. (Phase 5 full lowering is a large multi-slice effort
+        mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -234,6 +234,13 @@ earlier ones.
     (not a `PointyBlock`) lowers to a `Stmt::For` with no named parameter, so the loop body sees the
     iterand as `$_`. `EVAL(Q[my $t = 0; for 1..4 { $t = $t + $_ }; $t].AST)` → `10`. Tests in
     `t/rakuast-eval-bare-for.t`. Next: control flow (`return`/`last`/`next`), multi/typed parameters.
+  - **Slice 10 (`return`/`last`/`next`) — done, both directions.** raku models these control-flow
+    statements as bare calls (`Call::Name` in WithoutParentheses form). The read side (`.AST`) now emits
+    that form — `Stmt::Return`/`Last`/`Next` → a `control_call` (the `args` field omitted when empty,
+    matching raku's bare-call gist) — and the write side (`EVAL`) lowers a `return`/`last`/`next` call
+    back to the internal control-flow statement. `EVAL(Q[sub f($x) { if $x > 0 { return 5 }; -1 }; f(3)].AST)`
+    → `5`; `last`/`next` control loops. Labelled `last LABEL`/`next LABEL` stay the boundary. Tests in
+    `t/rakuast-eval-return.t`. Next: multi/typed/named parameters, `unless`/`until`.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -58,6 +58,20 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
         Stmt::Put(args) => Ok(Some(statement_expression(listop_call("put", args)?))),
         Stmt::Print(args) => Ok(Some(statement_expression(listop_call("print", args)?))),
         Stmt::Note(args) => Ok(Some(statement_expression(listop_call("note", args)?))),
+        // `return`/`last`/`next` are control-flow statements in the internal AST;
+        // raku models them as bare calls. A bare `return` (a `Nil` literal) and an
+        // unlabelled `last`/`next` carry no arguments. Labelled `last LABEL` /
+        // `next LABEL` are deferred.
+        Stmt::Return(expr) => {
+            let args: &[Expr] = match expr {
+                Expr::Literal(v) if v.is_nil() => &[],
+                other => std::slice::from_ref(other),
+            };
+            Ok(Some(statement_expression(control_call("return", args)?)))
+        }
+        Stmt::Last(None) => Ok(Some(statement_expression(control_call("last", &[])?))),
+        Stmt::Next(None) => Ok(Some(statement_expression(control_call("next", &[])?))),
+        Stmt::Last(Some(_)) | Stmt::Next(Some(_)) => Err(unsupported("labelled last/next")),
         Stmt::VarDecl {
             name,
             expr,
@@ -1416,6 +1430,25 @@ fn call_name(
             node_field(Some("name"), name_node),
             node_field(Some("args"), arg_list),
         ],
+    })
+}
+
+/// A control-flow listop (`return`/`last`/`next`) — a `Call::Name` in
+/// WithoutParentheses form. Unlike [`listop_call`], the `args` field is omitted
+/// entirely when there are no arguments (matching raku's gist for a bare
+/// `return`/`last`/`next`).
+fn control_call(name: &'static str, args: &[Expr]) -> Result<RakuAstNode, RuntimeError> {
+    let name_node = RakuAstNode {
+        class: RakuAstClass::Name,
+        fields: vec![leaf_field(None, Value::str(name.to_string()))],
+    };
+    let mut fields = vec![node_field(Some("name"), name_node)];
+    if !args.is_empty() {
+        fields.push(node_field(Some("args"), arg_list(args)?));
+    }
+    Ok(RakuAstNode {
+        class: RakuAstClass::CallNameWithoutParentheses,
+        fields,
     })
 }
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -76,6 +76,13 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
                 "put" => Ok(Stmt::Put(args)),
                 "print" => Ok(Stmt::Print(args)),
                 "note" => Ok(Stmt::Note(args)),
+                // `return`/`last`/`next` are modelled as bare calls in RakuAST but
+                // are control-flow statements in the internal AST.
+                "return" => Ok(Stmt::Return(
+                    args.into_iter().next().unwrap_or(Expr::Literal(Value::NIL)),
+                )),
+                "last" => Ok(Stmt::Last(None)),
+                "next" => Ok(Stmt::Next(None)),
                 _ => Ok(Stmt::Expr(lower_expr(node)?)),
             }
         }

--- a/t/rakuast-eval-return.t
+++ b/t/rakuast-eval-return.t
@@ -1,0 +1,32 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 5 slice 10 (ADR-0011): EVAL of `return`/`last`/`next`.
+# raku models these control-flow statements as bare calls (`Call::Name` in
+# WithoutParentheses form); the read side (`.AST`) emits that form and the write
+# side (`EVAL`) lowers it back to the internal control-flow statement. Verified
+# against Rakudo; passes under BOTH mutsu and raku.
+
+plan 6;
+
+# --- read side: the gist round-trips through raku's call form ---------------
+ok Q[sub f { return 5 }].AST.gist.contains('RakuAST::Call::Name::WithoutParentheses.new('),
+    'return renders as a WithoutParentheses call';
+ok Q[sub f { return 5 }].AST.gist.contains('RakuAST::Name.from-identifier("return")'),
+    'the call name is "return"';
+
+# --- early return -----------------------------------------------------------
+is EVAL(Q[sub f($x) { if $x > 0 { return 5 }; -1 }; f(3)].AST), 5,
+    'early return: taken branch returns 5';
+is EVAL(Q[sub f($x) { if $x > 0 { return 5 }; -1 }; f(-3)].AST), -1,
+    'early return: fall-through returns -1';
+
+# --- last stops the loop ----------------------------------------------------
+is EVAL(Q[my $s = 0; for 1..10 -> $x { last if $x > 3; $s = $s + $x }; $s].AST), 6,
+    'last: sum 1+2+3 before breaking == 6';
+
+# --- next skips an iteration ------------------------------------------------
+is EVAL(Q[my $s = 0; for 1..5 -> $x { next if $x %% 2; $s = $s + $x }; $s].AST), 9,
+    'next: sum of odds 1+3+5 == 9';


### PR DESCRIPTION
## Summary

RakuAST slice 10 (ADR-0011): `return`/`last`/`next` in **both directions** of the model layer.

raku models these control-flow statements as bare calls (`Call::Name` in WithoutParentheses form), not dedicated nodes:

```raku
Q[sub f { return 5 }].AST   # ... Call::Name::WithoutParentheses(name => "return", args => (5))
```

- **Read (`.AST`, Phase 2):** `Stmt::Return`/`Last`/`Next` → a `control_call` — a `Call::Name` whose `args` field is omitted when empty, matching raku's gist for a bare `return`/`last`/`next`. A `return EXPR` carries the expression as its sole argument.
- **Write (`EVAL`, Phase 5):** a `return`/`last`/`next` call lowers back to the internal `Stmt::Return`/`Last`/`Next`.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[sub f($x) { if $x > 0 { return 5 }; -1 }; f(3)].AST)                         # 5
EVAL(Q[my $s = 0; for 1..10 -> $x { last if $x > 3; $s = $s + $x }; $s].AST)        # 6
EVAL(Q[my $s = 0; for 1..5 -> $x { next if $x %% 2; $s = $s + $x }; $s].AST)        # 9
```

Labelled `last LABEL`/`next LABEL` stay the coverage boundary.

## Tests

`t/rakuast-eval-return.t` — 6 assertions (read-side gist has the call form, early return taken/fall-through, `last`, `next`), **passing under BOTH mutsu and raku**. The read-side gist is byte-identical to Rakudo's for `sub f { return 5 }` and a bare `return`. All 48 `t/rakuast-*.t` files (211 tests) still green.

Next: multi/typed/named parameters, `unless`/`until`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)