### PR TITLE
feat: RakuAST Phase 5 slice 11 — EVAL of unless/until and prefix !/?

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -932,7 +932,10 @@ so it is tracked separately from the roast backlog.
         side emits `Call::Name` (WithoutParentheses, `args` omitted when empty) and the write side lowers
         such a call back to `Stmt::Return`/`Last`/`Next`. `EVAL(Q[sub f($x){ if $x>0 { return 5 }; -1 };
         f(3)].AST)` → 5. Tests in `t/rakuast-eval-return.t`.
-  - [ ] Slice 11+: multi-param/typed/named/slurpy params, `unless`/`until` — the inverse of the Phase-2
+  - [x] Slice 11: `unless`/`until` (which desugar to `if !X` / `while !X`) and the prefix `!`/`?`
+        operators (added to `op_name_to_token_kind`); `EVAL(Q[my $i=0; until $i>=3 { $i=$i+1 }; $i].AST)`
+        → 3. Tests in `t/rakuast-eval-unless-until.t`.
+  - [ ] Slice 12+: multi-param/typed/named/slurpy params, `repeat`/`while` — the inverse of the Phase-2
         converter, grown cluster by cluster. (Phase 5 full lowering is a large multi-slice effort
         mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -241,6 +241,11 @@ earlier ones.
     back to the internal control-flow statement. `EVAL(Q[sub f($x) { if $x > 0 { return 5 }; -1 }; f(3)].AST)`
     → `5`; `last`/`next` control loops. Labelled `last LABEL`/`next LABEL` stay the boundary. Tests in
     `t/rakuast-eval-return.t`. Next: multi/typed/named parameters, `unless`/`until`.
+  - **Slice 11 (`unless`/`until` + prefix `!`/`?`) — done.** mutsu desugars `unless X` to `if !X` and
+    `until X` to `while !X`, so lowering these only needed the prefix `!` (and `?`) operator added to the
+    reverse operator map (`op_name_to_token_kind`, used solely by the lowerer). `EVAL(Q[my $i = 0; until
+    $i >= 3 { $i = $i + 1 }; $i].AST)` → `3`; `EVAL(Q[my $x = 0; !$x].AST)` → `True`. Tests in
+    `t/rakuast-eval-unless-until.t`. Next: multi/typed/named parameters, `repeat`/`while`.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/compiler/helpers_ops.rs
+++ b/src/compiler/helpers_ops.rs
@@ -104,6 +104,10 @@ pub(crate) fn op_name_to_token_kind(name: &str) -> Option<TokenKind> {
         "//" => TokenKind::SlashSlash,
         ".." => TokenKind::DotDot,
         "..." => TokenKind::DotDotDot,
+        // Prefix-only operators (`!$x`, `?$x`). The prefixes shared with an infix
+        // spelling (`-`/`+`/`~`) already map above.
+        "!" => TokenKind::Bang,
+        "?" => TokenKind::Question,
         _ => return None,
     })
 }

--- a/t/rakuast-eval-unless-until.t
+++ b/t/rakuast-eval-unless-until.t
@@ -1,0 +1,29 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 5 slice 11 (ADR-0011): EVAL of `unless`/`until` and the prefix
+# `!`/`?` operators. mutsu desugars `unless X` to `if !X` and `until X` to
+# `while !X`, so lowering these only needed the prefix `!` (and `?`) operator in
+# the reverse operator map. Verified against Rakudo; passes under BOTH mutsu and
+# raku.
+
+plan 6;
+
+# --- unless (desugars to `if !cond`) ----------------------------------------
+is EVAL(Q[my $x = 0; my $r = 1; unless $x { $r = 5 }; $r].AST), 5,
+    'unless: body runs when the condition is false';
+is EVAL(Q[my $x = 7; my $r = 1; unless $x { $r = 5 }; $r].AST), 1,
+    'unless: body is skipped when the condition is true';
+
+# --- until (desugars to `while !cond`) --------------------------------------
+is EVAL(Q[my $i = 0; until $i >= 3 { $i = $i + 1 }; $i].AST), 3,
+    'until: loops until the condition becomes true';
+
+# --- prefix ! ---------------------------------------------------------------
+is EVAL(Q[my $x = 0; !$x].AST), True, 'prefix ! negates a falsy value to True';
+is EVAL(Q[my $x = 5; !$x].AST), False, 'prefix ! negates a truthy value to False';
+
+# --- prefix ? ---------------------------------------------------------------
+is EVAL(Q[my $x = 5; ?$x].AST), True, 'prefix ? booleanizes a truthy value';


### PR DESCRIPTION
## Summary

Phase 5 slice 11 of RakuAST (ADR-0011): `EVAL` of `unless`/`until` and the prefix `!`/`?` operators.

mutsu desugars `unless X` to `if !X` and `until X` to `while !X`, so a lowered `unless`/`until` is already a `Statement::If`/`Statement::Loop::While` whose condition is an `ApplyPrefix(!)`. The only missing piece was the prefix `!` (and `?`) operator in the reverse operator map: `op_name_to_token_kind` now maps `"!" => Bang` and `"?" => Question` (the `-`/`+`/`~` prefixes already share an infix spelling). That function is used solely by the lowerer, so the addition is self-contained.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[my $x = 0; my $r = 1; unless $x { $r = 5 }; $r].AST)          # 5
EVAL(Q[my $i = 0; until $i >= 3 { $i = $i + 1 }; $i].AST)           # 3
EVAL(Q[my $x = 0; !$x].AST)                                         # True
```

## Tests

`t/rakuast-eval-unless-until.t` — 6 assertions (unless taken/skipped, until loop, prefix `!` on falsy/truthy, prefix `?`), **passing under BOTH mutsu and raku**. All 49 `t/rakuast-*.t` files (217 tests) still green.

Next: multi/typed/named parameters, `repeat`/`while`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)