### PR TITLE
feat: RakuAST Phase 5 slice 12 — EVAL of default sub parameters

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -935,9 +935,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 11: `unless`/`until` (which desugar to `if !X` / `while !X`) and the prefix `!`/`?`
         operators (added to `op_name_to_token_kind`); `EVAL(Q[my $i=0; until $i>=3 { $i=$i+1 }; $i].AST)`
         → 3. Tests in `t/rakuast-eval-unless-until.t`.
-  - [ ] Slice 12+: multi-param/typed/named/slurpy params, `repeat`/`while` — the inverse of the Phase-2
-        converter, grown cluster by cluster. (Phase 5 full lowering is a large multi-slice effort
-        mirroring Phase 2.)
+  - [x] Slice 12: default sub parameters — a `Parameter` with a `default` expression lowers to an
+        optional positional `ParamDef` (`required=false`, `default=Some(…)`); `EVAL(Q[sub f($x, $y=10)
+        { $x+$y }; f(5)].AST)` → 15. Tests in `t/rakuast-eval-default-param.t`.
+  - [ ] Slice 13+: `repeat`/`while`, typed/named/slurpy params (need both read + write) — the inverse
+        of the Phase-2 converter, grown cluster by cluster. (Phase 5 full lowering is a large
+        multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -246,6 +246,13 @@ earlier ones.
     reverse operator map (`op_name_to_token_kind`, used solely by the lowerer). `EVAL(Q[my $i = 0; until
     $i >= 3 { $i = $i + 1 }; $i].AST)` → `3`; `EVAL(Q[my $x = 0; !$x].AST)` → `True`. Tests in
     `t/rakuast-eval-unless-until.t`. Next: multi/typed/named parameters, `repeat`/`while`.
+  - **Slice 12 (default sub parameters) — done.** A `Parameter` carrying a `default` expression now
+    lowers to an optional positional `ParamDef` (`required = false`, `default = Some(…)`) instead of
+    being deferred, so a defaulted parameter uses its fallback when the argument is omitted.
+    `EVAL(Q[sub f($x, $y = 10) { $x + $y }; f(5)].AST)` → `15`; a default may reference an earlier
+    parameter (`$y = $x * 2`). Typed (`Int $x`) and named (`:$x`) parameters still lack read-side
+    (`.AST`) support and stay the boundary. Tests in `t/rakuast-eval-default-param.t`. Next: `repeat`/
+    `while`, typed/named parameters (both directions).
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -161,8 +161,7 @@ fn lower_for(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
 /// subs in expression position are the current coverage boundary.
 fn lower_sub(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     let name = call_name_str(node)?;
-    let params = signature_positional_params(node)?;
-    let param_defs = params.iter().map(|n| positional_param(n)).collect();
+    let (params, param_defs) = signature_positional_params(node)?;
     // A Sub's `body` is the Blockoid directly (not a Block wrapping one).
     let body = lower(named_child_or_positional(named_child(node, "body")?)?)?;
     Ok(Stmt::SubDecl {
@@ -189,27 +188,32 @@ fn lower_sub(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
 /// The positional scalar parameter names of a routine's `signature`, each with
 /// its `$` sigil stripped. A parameter carrying anything beyond a plain scalar
 /// `target` (a name, a slurpy/named marker, a default) is the coverage boundary.
-fn signature_positional_params(node: &RakuAstNode) -> Result<Vec<String>, RuntimeError> {
+#[allow(clippy::type_complexity)]
+fn signature_positional_params(
+    node: &RakuAstNode,
+) -> Result<(Vec<String>, Vec<ParamDef>), RuntimeError> {
     let Ok(sig) = named_child(node, "signature") else {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), Vec::new()));
     };
     let params = match sig.fields.iter().find(|f| f.name == Some("parameters")) {
         Some(f) => match &f.value {
             RakuAstFieldValue::List(items) => items,
             _ => return Err(unsupported(node)),
         },
-        None => return Ok(Vec::new()),
+        None => return Ok((Vec::new(), Vec::new())),
     };
     let mut names = Vec::with_capacity(params.len());
+    let mut defs = Vec::with_capacity(params.len());
     for v in params {
         let ValueView::RakuAst(p) = v.view() else {
             return Err(unsupported(node));
         };
-        // A named/slurpy/optional/defaulted parameter carries extra fields; defer.
+        // Named / slurpy / explicitly-optional parameters carry richer shape; defer.
+        // A `default` is handled below (an optional positional with a fallback).
         if p.fields.iter().any(|f| {
             matches!(
                 f.name,
-                Some("slurpy") | Some("named") | Some("default") | Some("optional_marker")
+                Some("slurpy") | Some("named") | Some("optional_marker")
             )
         }) {
             return Err(unsupported(node));
@@ -219,9 +223,24 @@ fn signature_positional_params(node: &RakuAstNode) -> Result<Vec<String>, Runtim
             return Err(unsupported(node));
         }
         let raw = leaf_str(target, "name")?;
-        names.push(raw.strip_prefix('$').map(str::to_string).unwrap_or(raw));
+        let name = raw.strip_prefix('$').map(str::to_string).unwrap_or(raw);
+        let mut def = positional_param(&name);
+        // `$y = EXPR` -> an optional positional with a default value.
+        if let Some(d) = p.fields.iter().find(|f| f.name == Some("default")) {
+            let default_node = match &d.value {
+                RakuAstFieldValue::Node(val) => match val.view() {
+                    ValueView::RakuAst(child) => child,
+                    _ => return Err(unsupported(node)),
+                },
+                _ => return Err(unsupported(node)),
+            };
+            def.default = Some(lower_expr(default_node)?);
+            def.required = false;
+        }
+        names.push(name);
+        defs.push(def);
     }
-    Ok(names)
+    Ok((names, defs))
 }
 
 /// A default positional (required, non-slurpy, untyped) `ParamDef` for `name`.

--- a/t/rakuast-eval-default-param.t
+++ b/t/rakuast-eval-default-param.t
@@ -1,0 +1,27 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 5 slice 12 (ADR-0011): EVAL of sub parameters with defaults.
+# A `Parameter` carrying a `default` expression lowers to an optional positional
+# `ParamDef` whose default is used when the argument is omitted. Verified against
+# Rakudo; passes under BOTH mutsu and raku.
+
+plan 4;
+
+# --- default is used when the argument is omitted ---------------------------
+is EVAL(Q[sub f($x, $y = 10) { $x + $y }; f(5)].AST), 15,
+    'default parameter value is used when the argument is omitted';
+
+# --- default is overridden by an explicit argument --------------------------
+is EVAL(Q[sub f($x, $y = 10) { $x + $y }; f(5, 20)].AST), 25,
+    'an explicit argument overrides the default';
+
+# --- a default expression may reference an earlier parameter ----------------
+is EVAL(Q[sub f($x, $y = $x * 2) { $x + $y }; f(5)].AST), 15,
+    'a default expression can reference an earlier parameter';
+
+# --- a plain (non-defaulted) multi-parameter sub still works ----------------
+is EVAL(Q[sub add($a, $b) { $a + $b }; add(3, 4)].AST), 7,
+    'a plain multi-parameter sub still lowers correctly';


### PR DESCRIPTION
## Summary

Phase 5 slice 12 of RakuAST (ADR-0011): `EVAL` of `sub` parameters with defaults.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[sub f($x, $y = 10) { $x + $y }; f(5)].AST)       # 15  (default used)
EVAL(Q[sub f($x, $y = 10) { $x + $y }; f(5, 20)].AST)   # 25  (default overridden)
EVAL(Q[sub f($x, $y = $x * 2) { $x + $y }; f(5)].AST)   # 15  (default references $x)
```

A signature `Parameter` carrying a `default` expression now lowers to an optional positional `ParamDef` (`required = false`, `default = Some(lowered)`) instead of being deferred. `signature_positional_params` builds the parameter names and their `ParamDef`s together so the default can be attached.

Typed (`Int $x`) and named (`:$x`) parameters still lack read-side (`.AST`) support and stay the boundary.

## Tests

`t/rakuast-eval-default-param.t` — 4 assertions (default used, default overridden, default references an earlier parameter, plain multi-param still works), **passing under BOTH mutsu and raku**. All 50 `t/rakuast-*.t` files (221 tests) still green.

Next: `repeat`/`while`, typed/named parameters (both directions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)