### PR TITLE
fix: sequence operator (...) is looser than comma in argument lists

### DIFF
--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -936,6 +936,29 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     r.starts_with(' ') || r.starts_with('\t') || r.starts_with('\n');
                 let (r2, _) = ws(r)?;
                 if r2.starts_with(':') && !r2.starts_with("::") {
+                    // A sequence operator (`...`/`…`) is looser than comma, so a
+                    // colon-arg list `.m: a, b ... limit` is ONE sequence argument
+                    // (seed `a, b`). Absorb the whole comma level, matching the
+                    // parenthesized-list parser. (Only for the no-space colon-arg
+                    // form; a space before `:` is an adverb colon-pair.)
+                    if !has_space_before_colon {
+                        let after_colon = &r2[1..];
+                        let (after_colon, _) = ws(after_colon)?;
+                        if let Some(result) =
+                            crate::parser::primary::try_parse_sequence_arg_list(after_colon)
+                        {
+                            let (r_seq, seq) = result?;
+                            expr = Expr::MethodCall {
+                                target: Box::new(expr),
+                                name,
+                                args: vec![seq],
+                                modifier,
+                                quoted: false,
+                            };
+                            rest = r_seq;
+                            continue;
+                        }
+                    }
                     // If there was space before ':', treat as adverb (colon-pair)
                     let (r3, first_arg) = if has_space_before_colon {
                         colonpair_expr(r2)?

--- a/src/parser/primary/container.rs
+++ b/src/parser/primary/container.rs
@@ -33,3 +33,4 @@ pub(super) use sigil_context::{
 
 // pub(crate) re-exports — visible throughout the crate
 pub(crate) use allomorph::{angle_word_value, angle_word_value_full_allomorphic};
+pub(crate) use meta_ops::try_parse_sequence_arg_list;

--- a/src/parser/primary/container/meta_ops.rs
+++ b/src/parser/primary/container/meta_ops.rs
@@ -1,7 +1,9 @@
 use crate::ast::{Expr, Stmt};
-use crate::parser::expr::{contains_whatever, expression, expression_no_sequence};
+use crate::parser::expr::{
+    contains_whatever, expression, expression_no_sequence, wrap_whatevercode,
+};
 use crate::parser::helpers::ws;
-use crate::parser::parse_result::{PResult, parse_char};
+use crate::parser::parse_result::{PError, PResult, parse_char};
 use crate::parser::stmt::keyword;
 use crate::symbol::Symbol;
 use crate::token_kind::TokenKind;
@@ -455,6 +457,160 @@ pub(crate) fn try_parse_sequence_in_paren<'a>(
 
 pub(crate) fn starts_with_sequence_op(input: &str) -> bool {
     input.starts_with("...") || input.starts_with('\u{2026}')
+}
+
+fn maybe_wrap_whatever(expr: Expr) -> Expr {
+    if contains_whatever(&expr) && !matches!(expr, Expr::Whatever) {
+        wrap_whatevercode(&expr)
+    } else {
+        expr
+    }
+}
+
+/// Raku's list-infix precedence makes the sequence operators (`...`/`…`/`...^`/`…^`)
+/// LOOSER than comma, so in an argument list `a, b ... limit` the whole comma list
+/// `a, b` is the sequence's seed and the entire list collapses into ONE sequence
+/// argument (exactly like `(a, b ... limit)` in parentheses — see
+/// [`try_parse_sequence_in_paren`]). Call/listop sites parse each comma-separated
+/// argument individually, which would otherwise split the seed and drop the
+/// endpoint. This helper detects a sequence operator at the top comma level and,
+/// when present, returns the single sequence `Expr` spanning the whole list.
+///
+/// Returns `None` for an ordinary comma list with no top-level sequence operator,
+/// so the caller keeps its normal per-argument handling. Terminator-agnostic (it
+/// stops at the natural argument boundary via `expression_no_sequence`), so it
+/// serves parenthesized calls, unparenthesized listops, and the `meth: args`
+/// colon form alike.
+pub(crate) fn try_parse_sequence_arg_list(input: &str) -> Option<PResult<'_, Expr>> {
+    // A leading sequence operator with no seed is the `{ ... }`-style yada stub
+    // used as an argument (`f(...)`), not a sequence — leave it to the normal path.
+    if starts_with_sequence_op(input) {
+        return None;
+    }
+    let (mut rest, first) = expression_no_sequence(input).ok()?;
+    let mut seeds = vec![first];
+    let op_input = loop {
+        let (rws, _) = ws(rest).ok()?;
+        if starts_with_sequence_op(rws) {
+            break rws;
+        }
+        if !rws.starts_with(',') || rws.starts_with(",,") {
+            return None; // ordinary list — no top-level sequence operator
+        }
+        let after = &rws[1..];
+        let (after, _) = ws(after).ok()?;
+        // End of the argument list (trailing comma) before any sequence operator,
+        // or a colonpair / named argument — not a positional seed list.
+        if after.is_empty()
+            || after.starts_with(')')
+            || after.starts_with(';')
+            || after.starts_with('}')
+            || (after.starts_with(':') && !after.starts_with("::"))
+        {
+            return None;
+        }
+        let (r2, item) = expression_no_sequence(after).ok()?;
+        seeds.push(item);
+        rest = r2;
+    };
+    Some(build_sequence_from_seeds(op_input, seeds))
+}
+
+/// Build a sequence `Expr` from already-parsed `seeds`, with `input` positioned at
+/// the sequence operator. Parses the endpoint and any extra endpoint items
+/// (`a ... limit, extra`), stopping at the natural argument boundary. Unlike
+/// [`try_parse_sequence_in_paren`] it does NOT require a closing paren.
+fn build_sequence_from_seeds(input: &str, seeds: Vec<Expr>) -> PResult<'_, Expr> {
+    let (is_excl, rest) = if let Some(s) = input.strip_prefix("...^") {
+        (true, s)
+    } else if let Some(s) = input.strip_prefix("\u{2026}^") {
+        (true, s)
+    } else if input.starts_with("...") && !input.starts_with("....") {
+        (false, &input[3..])
+    } else if let Some(s) = input.strip_prefix('\u{2026}') {
+        (false, s)
+    } else {
+        return Err(PError::expected("expected sequence operator"));
+    };
+    let (rest, _) = ws(rest)?;
+    // Bare `*` endpoint = infinite sequence.
+    let (mut rest, endpoint) = if rest.starts_with('*')
+        && !rest[1..].starts_with(|c: char| c.is_alphanumeric() || c == '_')
+    {
+        let after_star = rest[1..].trim_start();
+        if after_star.is_empty()
+            || after_star.starts_with(')')
+            || after_star.starts_with(',')
+            || after_star.starts_with(';')
+            || after_star.starts_with('}')
+        {
+            (&rest[1..], Expr::Whatever)
+        } else {
+            expression_no_sequence(rest)?
+        }
+    } else {
+        expression_no_sequence(rest)?
+    };
+    // Extra endpoint items after the first (`a ... limit, extra1, extra2`) are
+    // absorbed into the sequence, since the operator owns the whole comma level.
+    // Parse each with the FULL expression parser (like `try_parse_sequence_in_paren`)
+    // so a chained/waypoint sequence in an extra (`1 ... 3, 5 ... 7`) is consumed;
+    // a nested `a ... b` waypoint becomes an `[a, b]` pair, matching the paren form.
+    let mut extra_items = Vec::new();
+    loop {
+        let (rws, _) = ws(rest)?;
+        if !rws.starts_with(',') || rws.starts_with(",,") {
+            rest = rws;
+            break;
+        }
+        let after = &rws[1..];
+        let (after_ws, _) = ws(after)?;
+        if after_ws.is_empty()
+            || after_ws.starts_with(')')
+            || after_ws.starts_with(';')
+            || after_ws.starts_with('}')
+            || (after_ws.starts_with(':') && !after_ws.starts_with("::"))
+        {
+            rest = rws; // leave the trailing comma for the caller
+            break;
+        }
+        let (r2, item) = expression(after_ws)?;
+        let item = match item {
+            Expr::Binary {
+                left,
+                op: TokenKind::DotDotDot | TokenKind::DotDotDotCaret,
+                right,
+            } => Expr::ArrayLiteral(vec![*left, *right]),
+            other => other,
+        };
+        extra_items.push(item);
+        rest = r2;
+    }
+    let op = if is_excl {
+        TokenKind::DotDotDotCaret
+    } else {
+        TokenKind::DotDotDot
+    };
+    let left = if seeds.len() == 1 {
+        maybe_wrap_whatever(seeds.into_iter().next().unwrap())
+    } else {
+        Expr::ArrayLiteral(seeds.into_iter().map(maybe_wrap_whatever).collect())
+    };
+    let right = if extra_items.is_empty() {
+        maybe_wrap_whatever(endpoint)
+    } else {
+        let mut v = vec![maybe_wrap_whatever(endpoint)];
+        v.extend(extra_items.into_iter().map(maybe_wrap_whatever));
+        Expr::ArrayLiteral(v)
+    };
+    Ok((
+        rest,
+        Expr::Binary {
+            left: Box::new(left),
+            op,
+            right: Box::new(right),
+        },
+    ))
 }
 
 /// Try to parse an inline statement modifier inside parenthesized expression.

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1398,6 +1398,19 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
             // List operators (grep, map, sort, etc.) parse full expressions as args
             // (up to comma/feed precedence), matching Raku's "list prefix" semantics.
             // e.g. `grep $_ == 1, 1, 2, 3` → `grep(($_ == 1), 1, 2, 3)`.
+            // A sequence operator (`...`/`…`) is looser than comma, so
+            // `say a, b ... limit` is ONE sequence argument (seed `a, b`). Absorb the
+            // whole comma level like the parenthesized-list parser, unless a method
+            // invocant colon follows (`name arg: ...`), which the normal path handles.
+            if let Some(result) = crate::parser::primary::try_parse_sequence_arg_list(r)
+                && !is_stmt_modifier_ahead(r)
+            {
+                let (r2, seq) = result?;
+                let (r2_ws, _) = ws(r2)?;
+                if !r2_ws.starts_with(':') || r2_ws.starts_with("::") {
+                    return Ok((r2, make_call_expr(name, input, vec![seq])));
+                }
+            }
             let parse_arg = |input| {
                 if is_stmt_modifier_ahead(input) {
                     return Err(PError::expected("listop argument"));

--- a/src/parser/primary/ident/listop.rs
+++ b/src/parser/primary/ident/listop.rs
@@ -109,6 +109,14 @@ pub(crate) fn parse_expr_listop_args(input: &str, name: String) -> PResult<'_, E
     // The list-infix operators (Z/X/meta/infix funcs) bind TIGHTER than the
     // listop's comma, so each argument is extended with them after the base
     // parse (`flat @a Z @b` is `flat(@a Z @b)`); feeds stay outside the call.
+    // A sequence operator (`...`/`…`) is looser than comma, so `say a, b ... limit`
+    // is ONE sequence argument (seed `a, b`), not `a` plus `b ... limit`. Absorb the
+    // whole comma level like the parenthesized-list parser does.
+    if let Some(result) = crate::parser::primary::try_parse_sequence_arg_list(input) {
+        let (r, seq) = result?;
+        return Ok((r, make_call_expr(name, input, vec![seq])));
+    }
+
     let (r, first) = call_arg_expr(input).map_err(|err| PError {
         messages: merge_expected_messages("expected listop argument expression", &err.messages),
         remaining_len: err.remaining_len.or(Some(input.len())),
@@ -272,6 +280,20 @@ pub(crate) fn make_call_expr_from_listop_args<'a>(
     input: &'a str,
     name: String,
 ) -> PResult<'a, Expr> {
+    // A sequence operator (`...`/`…`) is looser than comma, so `say a, b ... limit`
+    // is ONE sequence argument (seed `a, b`). Absorb the whole comma level like the
+    // parenthesized-list parser. (Guarded against the `meth: args` invocant-colon
+    // form below by requiring the list to actually contain a sequence operator.)
+    if let Some(result) = crate::parser::primary::try_parse_sequence_arg_list(rest) {
+        let (r, seq) = result?;
+        // Only when no invocant colon follows — a `name arg: ...` form is a method
+        // call, handled by the normal path.
+        let (r_ws, _) = ws(r)?;
+        if !r_ws.starts_with(':') || r_ws.starts_with("::") {
+            return Ok((r, make_call_expr(name, input, vec![seq])));
+        }
+    }
+
     let (r, first) = parse_listop_arg(rest).map_err(|err| PError {
         messages: merge_expected_messages("expected listop argument expression", &err.messages),
         remaining_len: err.remaining_len.or(Some(rest.len())),

--- a/src/parser/primary/mod.rs
+++ b/src/parser/primary/mod.rs
@@ -2,6 +2,7 @@ mod container;
 // Re-exported so other parser subtrees (e.g. crate::parser::expr postfix
 // parsing) can build the same X::Comp::FailGoal for unterminated brackets.
 pub(crate) use container::fail_goal_error_at;
+pub(crate) use container::try_parse_sequence_arg_list;
 pub(in crate::parser) mod ident;
 pub(in crate::parser) mod misc;
 mod number;

--- a/src/parser/primary/regex/call_args.rs
+++ b/src/parser/primary/regex/call_args.rs
@@ -105,6 +105,13 @@ pub(in crate::parser) fn parse_call_arg_list(input: &str) -> PResult<'_, Vec<Exp
     if input.starts_with(')') {
         return Ok((input, Vec::new()));
     }
+    // A sequence operator (`...`/`…`) is looser than comma, so `f(a, b ... limit)`
+    // is ONE sequence argument (seed `a, b`), not `a` plus `b ... limit`. Absorb the
+    // whole comma level into a single sequence, matching the parenthesized-list parser.
+    if let Some(result) = crate::parser::primary::try_parse_sequence_arg_list(input) {
+        let (rest, seq) = result?;
+        return Ok((rest, vec![seq]));
+    }
     // A LEADING semicolon starts with an empty group: `f(;x)` is the
     // two-slice list ((), (x,)) — rakudo's LoL argument form
     // (integration/weird-errors.t 11 EVALs `say(;:[])`).

--- a/src/parser/stmt/args.rs
+++ b/src/parser/stmt/args.rs
@@ -663,6 +663,15 @@ pub(super) fn parse_single_call_arg(input: &str) -> PResult<'_, CallArg> {
         }
     }
 
+    // A sequence operator (`...`/`…`) is looser than comma, so `f(a, b ... limit)`
+    // is ONE sequence argument (seed `a, b`), not `a` plus `b ... limit`. Detect and
+    // absorb the whole comma level into a single sequence expression, matching the
+    // parenthesized-list behaviour.
+    if let Some(result) = crate::parser::primary::try_parse_sequence_arg_list(input) {
+        let (rest, seq) = result?;
+        return Ok((rest, CallArg::Positional(seq)));
+    }
+
     // Positional argument — try assignment expression first ($x = expr).
     // But do not consume a prefix before a fat-arrow chain (e.g. `2 => "x" => {...}`).
     let parsed_expr = expression(input).or_else(|_| reduction_call_style_expr(input));

--- a/src/parser/stmt/simple/io_stmts.rs
+++ b/src/parser/stmt/simple/io_stmts.rs
@@ -152,6 +152,13 @@ pub(crate) fn parse_expr_list(input: &str) -> PResult<'_, Vec<Expr>> {
 }
 
 fn parse_io_expr_list(input: &str) -> PResult<'_, Vec<Expr>> {
+    // A sequence operator (`...`/`…`) is looser than comma, so `say a, b ... limit`
+    // is ONE sequence argument (seed `a, b`), not `a` plus `b ... limit`. Absorb the
+    // whole comma level like the parenthesized-list parser does.
+    if let Some(result) = crate::parser::primary::try_parse_sequence_arg_list(input) {
+        let (rest, seq) = result?;
+        return Ok((rest, vec![seq]));
+    }
     match parse_expr_list(input) {
         Ok(ok) => Ok(ok),
         Err(err)

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1575,7 +1575,7 @@ pub(crate) struct MapGrepSpec {
 }
 
 /// Index-based transform applied lazily to a positional source, used by
-/// `.pairs`/`.antipairs`/`.kv` over a lazy list so they don't force it.
+/// `.pairs`/`.antipairs`/`.kv`/`flat` over a lazy list so they don't force it.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum IndexTransform {
     /// `.pairs`: element `i` → `Pair(i, elem)`.
@@ -1584,6 +1584,10 @@ pub(crate) enum IndexTransform {
     AntiPairs,
     /// `.kv`: element `i` → two flat outputs `i, elem`.
     Kv,
+    /// `flat`: each pulled element is flattened (`flat_val` in List context),
+    /// so `flat [2,3,4], 10, 11 ... *` spills the nested array's elements
+    /// while the sequence stays lazy. The index is unused.
+    Flat,
 }
 
 /// What a [`CatPullSpec`] lazy list pulls from its backing `IO::CatHandle`.

--- a/src/vm/vm_helpers_lazy_pull.rs
+++ b/src/vm/vm_helpers_lazy_pull.rs
@@ -355,6 +355,11 @@ impl Interpreter {
                             vec![Value::value_pair(elem, idx)]
                         }
                         crate::value::IndexTransform::Kv => vec![idx, elem],
+                        crate::value::IndexTransform::Flat => {
+                            let mut out = Vec::new();
+                            crate::builtins::flat_val(&elem, &mut out, true);
+                            out
+                        }
                     };
                     {
                         let mut spec = list.lazy_pipe.as_ref().unwrap().lock().unwrap();

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -415,9 +415,9 @@ impl Interpreter {
         {
             let name = name_sym.resolve();
             if matches!(name.as_str(), "flat" | "eager") {
-                // For `flat`, a single lazy argument normally stays lazy
-                // (`flat 42 xx *` / `flat 1..Inf` propagate `.is-lazy`). The one
-                // exception is a finite `gather` coroutine: it must be forced and
+                // For `flat`, a single lazy argument stays lazy (`flat 42 xx *`
+                // / `flat 10,11 ... *` propagate `.is-lazy`). The one exception
+                // is a finite `gather` coroutine: it must be forced and
                 // flattened here so `flat` descends into its nested lazy elements
                 // (`take internals($child)` in a binary-tree walk), which a raw
                 // return would leave un-descended (`('A', Seq(...), ...)`). Only
@@ -425,18 +425,29 @@ impl Interpreter {
                 // every other lazy list keeps its laziness.
                 // TODO: an actually-infinite `gather` (`flat gather { loop {
                 // take $i++ } }`) is forced eagerly here and would hang — raku
-                // keeps it lazy. A proper fix is a lazy flattening pipe that
-                // pulls+descends on demand; the eager path is correct for the
-                // finite gathers that occur in practice.
+                // keeps it lazy. (A `lazy gather` takes the flattening-pipe
+                // path below and stays lazy.)
                 let is_finite_gather = |v: &Value| {
                     matches!(v.view(), ValueView::LazyList(ll)
                         if ll.coroutine.is_some() && ll.cache.lock().unwrap().is_none())
                 };
                 if name.as_str() == "flat"
                     && args.len() == 1
-                    && matches!(args[0].view(), ValueView::LazyList(_))
+                    && let ValueView::LazyList(ll) = args[0].view()
                     && !is_finite_gather(&args[0])
                 {
+                    // A genuinely-lazy list may hold nested arrays
+                    // (`flat [2,3,4], 10, 11 ... *`), so wrap it in a lazy
+                    // flattening pipe that pulls source elements on demand and
+                    // spills each through `flat_val` — flattened AND still lazy.
+                    if ll.is_genuinely_lazy() {
+                        return Some(Ok(Value::lazy_list(crate::gc::Gc::new(
+                            crate::value::LazyList::new_index_pipe(
+                                args[0].clone(),
+                                crate::value::IndexTransform::Flat,
+                            ),
+                        ))));
+                    }
                     return Some(Ok(args[0].clone()));
                 }
                 let mut forced_args = Vec::with_capacity(args.len());

--- a/t/flat-lazy-nested.t
+++ b/t/flat-lazy-nested.t
@@ -1,0 +1,33 @@
+use v6;
+use Test;
+
+# flat on a genuinely-lazy list must flatten nested arrays while staying
+# lazy (pin for the lazy flattening pipe; roast/S02-types/lazy-lists.t
+# test 27 is the upstream case).
+
+plan 6;
+
+{
+    my @l = flat [2, 3, 4], 10, 11 ... *;
+    is ~@l[^6], "2 3 4 10 11 12", 'flat spills a nested array inside an infinite sequence';
+}
+
+{
+    my $x = flat [2, 3, 4], 10, 11 ... *;
+    ok $x.is-lazy, 'flat of an infinite sequence stays lazy';
+    isa-ok $x, Seq, 'flat of an infinite sequence is a Seq';
+}
+
+{
+    is ~(flat [2, 3, 4], 10, 11 ... 15), "2 3 4 10 11 12 13 14 15",
+        'finite sequence flat still flattens';
+}
+
+{
+    is ~(flat 42 xx *).head(3), "42 42 42", 'flat of xx * stays lazy and yields elements';
+}
+
+{
+    my $g = flat lazy gather { take [1, 2]; take 3 };
+    is ~$g[^3], "1 2 3", 'flat of a lazy gather flattens its nested arrays';
+}

--- a/t/sequence-op-in-call-args.t
+++ b/t/sequence-op-in-call-args.t
@@ -1,0 +1,48 @@
+use Test;
+
+# The sequence operator (`...`/`…`) has "list infix" precedence, which is LOOSER
+# than comma. So in an argument list `a, b ... limit`, the whole comma list `a, b`
+# is the sequence's seed and the entire list collapses into ONE sequence argument,
+# exactly like `(a, b ... limit)` in parentheses. Previously mutsu split the comma
+# list first, so `f(1, 3 ... 11)` was parsed as `f(1, (3 ... 11))` (seed `3`) or
+# dropped the endpoint entirely. Results are compared as flattened, joined strings
+# to avoid Array/List/Seq `.raku` representation differences.
+
+plan 15;
+
+sub flat-str(*@a) { @a.join(",") }
+sub arg-count(**@a) { @a.elems }
+
+# --- parenthesized function call ---
+is flat-str(1, 3 ... 11), "1,3,5,7,9,11", 'paren call: seed is the whole comma list';
+is flat-str(2, 4 ... 10), "2,4,6,8,10",   'paren call: even step';
+is flat-str(1 ... 3, 9),  "1,2,3,9",      'paren call: single seed, extra endpoint';
+is flat-str(1, 3 ... 11, 20), "1,3,5,7,9,11,20", 'paren call: trailing extra after endpoint';
+is flat-str(1 ... 3, 5 ... 7), "1,2,3,5,7", 'paren call: chained waypoint sequences';
+is flat-str(1, 3 ...^ 11), "1,3,5,7,9",   'paren call: exclusive endpoint';
+
+# The whole sequence is ONE argument, not several.
+is arg-count(1, 3 ... 11), 1, 'sequence in a call is a single argument';
+is arg-count(1 ... 3, 9),  1, 'single-seed sequence with an extra is a single argument';
+
+# --- unparenthesized listop / IO statement ---
+is (1, 3 ... 11).join(","), "1,3,5,7,9,11", 'parenthesized sequence still works';
+
+# --- method colon-arg form: `.meth: a, b ... limit` ---
+my @a = <a b c>;
+@a.prepend: 1, 3 ... 11;
+is @a.join(","), "1,3,5,7,9,11,a,b,c", 'method colon-arg: prepend flattens the sequence';
+
+my @c = <x y>;
+@c.append: 2, 4 ... 8;
+is @c.join(","), "x,y,2,4,6,8", 'method colon-arg: append flattens the sequence';
+
+# --- method paren-arg form ---
+my @d = <a b>;
+@d.prepend(1, 3 ... 7);
+is @d.join(","), "1,3,5,7,a,b", 'method paren-arg: prepend flattens the sequence';
+
+# --- ordinary comma lists are unaffected (no regression) ---
+is flat-str(1, 2, 3), "1,2,3", 'plain comma list is unchanged';
+is flat-str(1), "1", 'single argument is unchanged';
+is arg-count("a", "b", "c"), 3, 'plain string args stay separate arguments';


### PR DESCRIPTION
## Summary

The sequence operators `...`/`…`/`...^`/`…^` have **"list infix" precedence, which is looser than comma**. So in an argument list `a, b ... limit`, the whole comma list `a, b` is the sequence's seed and the entire list collapses into **one** sequence argument — exactly like `(a, b ... limit)` in parentheses:

```raku
sub g($a, $b) { }
g(1, 3 ... 11);          # ONE argument (a Seq) → "too few positionals", not two args
@a.prepend: 1, 3 ... 11; # prepends 1 3 5 7 9 11 (seed is 1,3), not 1 3
```

mutsu split the comma level first and parsed each argument individually, so `f(1, 3 ... 11)` became `f(1, (3 ... 11))` (seed `3`, wrong step) and `@a.prepend: 1, 3 ... 11` dropped the endpoint entirely. The parenthesized-list parser already handled this via `try_parse_sequence_in_paren`; the call/listop paths did not.

## Fix

Add `try_parse_sequence_arg_list` (a terminator-agnostic sibling of the paren helper: it collects the comma seeds, then absorbs the sequence operator, its endpoint, and any extra endpoints), and wire it into **every** argument-list parser that lacked it:

- parenthesized calls — `parse_call_arg_list`
- no-paren user subs & builtin listops (`say`, `join`, …) — `identifier_call`
- expression listops & the no-paren invocant path — `listop`
- positional call args — `args`
- IO statements `say`/`print`/`put`/`note` — `io_stmts`
- the method colon-arg form `.m: a, b ... limit` — `postfix/loop_`

Ordinary comma lists (no top-level sequence operator) return `None` from the helper and are completely untouched.

Verified against reference `raku` across paren/no-paren/method/colon/chained-waypoint/exclusive-endpoint forms, and that plain comma lists, ranges, and string arg lists are unaffected. `make test` passes.

## Provenance

Found by the QA doc-diff harness (PLAN.md §8.1) as its **first root-cause cluster** — several Array/Int doc examples (`prepend`/`unshift`/`polymod` with a `a, b ... limit` argument) diverged from raku for this one reason.

Pin: `t/sequence-op-in-call-args.t`.

Note: `600.polymod(lazy gather {…})` is a *separate* bug (polymod not expanding a lazy Seq argument — a method-impl issue, not this parser fix) and is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)