### PR TITLE
fix: three generic bugs surfaced by the Test::META suite

### DIFF
--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -348,7 +348,18 @@ impl Interpreter {
                     .iter()
                     .position(|(n, ..)| n.as_str() == &**key)
                 {
-                    Some(i) => attributes.insert(plan.attr_syms[i], value.clone()),
+                    Some(i) => {
+                        // Sigil-coerce like `dispatch_new` does: a `%`-attribute
+                        // provided as a (list of) Pair(s) becomes a Hash, a
+                        // `@`-attribute provided as a List becomes an Array
+                        // (META6's `multi method new(*%items) { self.bless(|%items) }`
+                        // passes `provides => ("Test::META" => "lib/...",)`).
+                        let sigil = plan.class_attrs[i].5;
+                        attributes.insert(
+                            plan.attr_syms[i],
+                            Self::coerce_attr_value_by_sigil(value.clone(), sigil),
+                        )
+                    }
                     None => attributes.insert(key.clone(), value.clone()),
                 };
             }

--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -130,14 +130,29 @@ impl Interpreter {
                     map.insert(k.clone(), v.clone());
                     Value::hash(map)
                 }
+                // A general-key Pair (`"A" => "b"` builds ValuePair, not the
+                // interned-Str-key Pair variant) coerces the same way, with the
+                // hash-key stringification `build_hash_from_items` uses.
+                ValueView::ValuePair(k, v) => {
+                    let mut map = HashMap::new();
+                    map.insert(Value::hash_key_encode(k), v.clone());
+                    Value::hash(map)
+                }
                 ValueView::Array(arr, _) => {
                     // Convert array of pairs to hash
                     let mut map = HashMap::new();
                     let mut has_pairs = false;
                     for item in arr.iter() {
-                        if let ValueView::Pair(k, v) = item.view() {
-                            map.insert(k.clone(), v.clone());
-                            has_pairs = true;
+                        match item.view() {
+                            ValueView::Pair(k, v) => {
+                                map.insert(k.clone(), v.clone());
+                                has_pairs = true;
+                            }
+                            ValueView::ValuePair(k, v) => {
+                                map.insert(Value::hash_key_encode(k), v.clone());
+                                has_pairs = true;
+                            }
+                            _ => {}
                         }
                     }
                     if has_pairs {

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -172,6 +172,49 @@ impl Interpreter {
         Some(candidate)
     }
 
+    /// Resolve a bare enum-member name through the current package chain
+    /// (`EnumC::Lists` for `Lists` read with `current_package == "EnumC"`).
+    /// Qualified enum-member env keys survive a loading module's package-block
+    /// rollback (only bare keys are dropped), so this recovers members that a
+    /// nested `use` made invisible under their bare name. Walks up the package
+    /// chain like `resolve_type_in_current_package`.
+    pub(super) fn resolve_enum_member_in_current_package(&self, name: &str) -> Option<Value> {
+        if name.is_empty() || name.contains("::") {
+            return None;
+        }
+        let probe_chain = |root: &str| -> Option<Value> {
+            let mut pkg: &str = root;
+            loop {
+                if pkg.is_empty() || pkg == "GLOBAL" {
+                    return None;
+                }
+                let qualified = format!("{pkg}::{name}");
+                if let Some(v) = self.env().get(&qualified)
+                    && matches!(v.view(), ValueView::Enum { .. })
+                {
+                    return Some(v.clone());
+                }
+                match pkg.rsplit_once("::") {
+                    Some((parent, _)) => pkg = parent,
+                    None => return None,
+                }
+            }
+        };
+        if let Some(v) = probe_chain(&self.current_package().to_string()) {
+            return Some(v);
+        }
+        // Inside a method body the runtime package is often GLOBAL; the
+        // declaring scope is the invocant's class (`self`), so probe its
+        // package chain too (`unit class EnumC; our enum HF <… Lists>;
+        // method new(:$h = Lists)` reads `Lists` as `EnumC::Lists`).
+        let invocant_class = match self.env().get("self").map(|v| v.view()) {
+            Some(ValueView::Instance { class_name, .. }) => Some(class_name.to_string()),
+            Some(ValueView::Package(p)) => Some(p.resolve().to_string()),
+            _ => None,
+        }?;
+        probe_chain(&invocant_class)
+    }
+
     /// Read a bare free-variable name from the enclosing package's variable
     /// store: the `our` store via the reconstructed `Pkg::name` key, or the
     /// package-block `my` lexical store (`package_lexicals`). Mirrors the

--- a/src/vm/vm_misc_reduction_scan.rs
+++ b/src/vm/vm_misc_reduction_scan.rs
@@ -291,6 +291,27 @@ impl Interpreter {
         for (k, v) in current_env.iter() {
             if !saved_env.contains_key_sym(*k) && !k.contains_str("::") && !k.starts_with("__") {
                 let bare = k.resolve();
+                // Per-frame special variables are never package-block lexicals a
+                // named sub closes over: the topic `$_` (env "_"), `$/` ("/"),
+                // `$!` ("!"), `?`-compile-time / `*`-dynamic names, `self`, and
+                // digit capture keys ("0", "1", ...). A `use`/`for`/`given` in
+                // the module body can leave a load-time topic in env; recording
+                // it would make `package_scope_lexical` (consulted BEFORE env in
+                // GetGlobal) permanently shadow every later per-call topic bind
+                // inside this package's subs (Test::META's
+                // `.map({ dist-dir.add($_) })` read the module-load leftover).
+                // Mirrors the class-body static exclusion in
+                // `register_class_decl`.
+                if bare == "_"
+                    || bare == "/"
+                    || bare == "self"
+                    || bare.starts_with('?')
+                    || bare.starts_with('!')
+                    || bare.starts_with('*')
+                    || bare.chars().next().is_some_and(|c| c.is_ascii_digit())
+                {
+                    continue;
+                }
                 // Record ONLY genuine `my` lexicals. An `our` package variable also
                 // leaves a bare env key here, but it has a qualified twin in the
                 // `our` store (`Pkg::name`) that is the authoritative value — and it

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -212,6 +212,17 @@ impl Interpreter {
             // class registered as `Foo::Params` and `mk` runs from another
             // package's call site.
             Value::package(Symbol::intern(&qualified))
+        } else if let Some(enum_val) = self.resolve_enum_member_in_current_package(name) {
+            // A bare enum member read from inside the package that declared the
+            // enum (`unit class URI::Query; our enum HashFormat <… Lists>;
+            // method new(:$h = Lists)`). The bare env key exists after a
+            // top-level `use`, but when the class was loaded inside another
+            // module's package block, that block's exit rolls back all new
+            // bare env keys (only `::`-qualified keys survive —
+            // `exec_package_scope_op`), so the member must resolve through the
+            // current package's qualified entry, not fall through to the Str
+            // fallback.
+            enum_val
         } else if self.wrap_sub_id_for_name(name).is_some()
             && let Some(sub_val) = self.get_wrapped_sub(name)
         {

--- a/t/bless-hash-attr-coercion.t
+++ b/t/bless-hash-attr-coercion.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+# `self.bless(|%items)` (META6's `multi method new(*%items)` shape) must
+# sigil-coerce named args exactly like the default constructor: a `%`-sigil
+# attribute provided as a (list of) Pair(s) becomes a Hash, and a Pair with a
+# non-simple key (`"Test::META" => ...` builds the general-key Pair variant)
+# coerces the same way.
+
+plan 8;
+
+class ViaBless {
+    has Str %.p;
+    has Str @.a;
+    multi method new(*%items) { self.bless(|%items) }
+}
+
+my $v = ViaBless.new(p => ("Test::META" => "lib/Test/META.rakumod",));
+ok $v.p ~~ Hash, 'bless-provided %-attr from a one-Pair list is a Hash';
+is $v.p<Test::META>, "lib/Test/META.rakumod", 'entry key/value are right';
+my @kv;
+for $v.p.kv -> $k, $val { @kv.push("$k=$val") }
+is @kv.join(","), "Test::META=lib/Test/META.rakumod", '.kv iterates keys and values';
+
+my $v2 = ViaBless.new(p => ("A" => "b", "C::D" => "d"));
+is $v2.p.elems, 2, 'two pairs make two entries';
+is $v2.p<C::D>, "d", 'general-key pair entry present';
+
+my $v3 = ViaBless.new(a => ("x", "y"));
+ok $v3.a ~~ Array, 'bless-provided @-attr from a list is an Array';
+is $v3.a.join(","), "x,y", 'array elements preserved';
+
+# Direct bless too, not just via a new multi.
+class DirectBless {
+    has Str %.p;
+}
+is DirectBless.bless(p => ("K" => "v",)).p<K>, "v", 'direct .bless coerces the %-attr as well';
+
+done-testing;

--- a/t/enum-member-nested-module-load.t
+++ b/t/enum-member-nested-module-load.t
@@ -1,0 +1,24 @@
+use v6;
+use lib $?FILE.IO.parent.child('lib').Str;
+use Test;
+
+# `unit class EnumHolder; our enum EHFormat <... EhLists>;` — when that class
+# is first loaded inside ANOTHER module's package block, the block exit drops
+# the bare enum-member env keys (only `::`-qualified keys survive). A bare
+# member read inside the declaring class's own methods (URI::Query's
+# `:$hash-format = Lists` default) must still resolve to the enum value, not
+# fall back to a Str.
+
+use EnumHolderWrap;
+use EnumHolder;
+
+plan 4;
+
+ok EnumHolderWrap::present(), 'wrapper module loaded';
+
+my $e = EnumHolder.new("x");
+nok $e.fmt ~~ Str, 'enum-typed attribute got the enum value, not the Str fallback';
+is $e.fmt, EnumHolder::EhLists, 'bare member in method default resolved to the right member';
+is EnumHolder.bare-member, EnumHolder::EhMixed, 'bare member read in a method body resolves';
+
+done-testing;

--- a/t/lib/EnumHolder.rakumod
+++ b/t/lib/EnumHolder.rakumod
@@ -1,0 +1,14 @@
+unit class EnumHolder;
+
+our enum EHFormat <EhNone EhMixed EhLists>;
+
+has EHFormat $.fmt is rw;
+
+multi method new(Str() $q) {
+    self.new(:fmt(EhLists));
+}
+
+method bare-member() {
+    # Bare enum member read inside the declaring class's own method.
+    EhMixed
+}

--- a/t/lib/EnumHolderWrap.rakumod
+++ b/t/lib/EnumHolderWrap.rakumod
@@ -1,0 +1,8 @@
+module EnumHolderWrap {
+    # Loading the enum-declaring class inside another module's package block
+    # rolls back the bare enum-member env keys on block exit (only qualified
+    # keys survive). The class's own methods must still resolve bare members.
+    use EnumHolder;
+
+    our sub present() { True }
+}

--- a/t/lib/TopicClassMod.rakumod
+++ b/t/lib/TopicClassMod.rakumod
@@ -1,0 +1,22 @@
+module TopicClassMod {
+    # The class makes the module body leave extra env keys; the package-block
+    # exit must not record per-frame specials (the topic `$_`) into
+    # `package_lexicals`, or every later call of these subs reads a stale topic.
+    class Helper {
+        has $.x;
+    }
+
+    our sub map-topic() {
+        <a b>.map({ "m:" ~ $_ }).list
+    }
+
+    our sub for-topic() {
+        my @r;
+        for <a b> { @r.push("f:" ~ $_) }
+        @r.List
+    }
+
+    our sub grep-topic() {
+        <a b a>.grep({ $_ eq "a" }).elems
+    }
+}

--- a/t/module-class-topic-binding.t
+++ b/t/module-class-topic-binding.t
@@ -1,0 +1,23 @@
+use v6;
+use lib $?FILE.IO.parent.child('lib').Str;
+use Test;
+
+# A module whose body registers a class (declared inline or via a nested
+# `use`) used to lose `$_` topic binding in map/for/grep blocks inside its
+# subs when they were called after the module finished loading: the module's
+# package-block exit recorded every new bare env key — including the
+# load-time topic — into `package_lexicals`, which GetGlobal consults BEFORE
+# env, permanently shadowing each per-iteration topic bind. (Test::META's
+# `get-meta` read the leftover `use URI` topic instead of its candidates.)
+
+use TopicClassMod;
+
+plan 4;
+
+is TopicClassMod::map-topic().join(","), "m:a,m:b", 'map topic binds per element';
+is TopicClassMod::for-topic().join(","), "f:a,f:b", 'for topic binds per element';
+is TopicClassMod::grep-topic(), 2, 'grep topic binds per element';
+# Second call still works (the first call must not poison the store either).
+is TopicClassMod::map-topic().join(","), "m:a,m:b", 'map topic still binds on the second call';
+
+done-testing;


### PR DESCRIPTION
## Summary

Running the Test::META-0.0.20 suite (mzef test-phase campaign) surfaced three generic mutsu bugs. All fixed generally; **Test::META 0/3 → 3/3 files (26 tests)**, bringing the mzef test-phase E2E standing to **10 PASS / 1 FAIL** (only JSON::Fast fidelity remains).

### 1. Module package-block exit poisons `package_lexicals` with per-frame specials

`exec_package_scope_op` recorded every new bare env key from the module body into `package_lexicals` — including the load-time topic (env `"_"`) left by a `use`/`for`/`given` in the body. Since `GetGlobal` consults `package_lexicals` BEFORE env, every per-iteration topic bind inside that module's subs was permanently shadowed: `map`/`for`/`grep` blocks read the stale load-time value on every call after the module finished loading (Test::META's `get-meta` mapped over `dist-dir.add($_)` where `$_` was the leftover `(URI)` package). The class-body static mirror already excluded specials; the package-block recorder now does too.

### 2. Bare enum members unresolvable in the declaring class after a nested load

When `unit class URI::Query; our enum HashFormat <… Lists>;` is first loaded inside **another module's** package block (`module Test::META { use URI; … }`), the block exit rolls back all new bare env keys — only `::`-qualified keys survive. A bare member read inside the class's own methods (`multi method new(Str() $query, :$hash-format = Lists)`) then fell through to the Str fallback, and every `URI.new` died with `expected HashFormat, got Str`. Bare members now resolve through the current package chain and the invocant's class chain, whose qualified entries survive the rollback.

### 3. `bless` skips sigil coercion of named args

`self.bless(|%items)` (META6's `multi method new(*%items)` shape) inserted named-arg values raw: a `%`-attribute provided as `provides => ("Test::META" => "lib/…",)` stayed a List, so `check-provides`'s `.kv` iterated `0 => Pair`. `dispatch_bless` now applies the same `coerce_attr_value_by_sigil` the default constructor uses, and that helper now also handles the general-key Pair variant (`ValuePair` — built by `"Test::META" => …`) in both its single-Pair and list arms.

## Verification

- `make test`: 1902 files / 18230 tests PASS
- Roast subset (S10-packages, S12-enums, S12-construction): 22 files / 372 tests PASS
- Test::META suite: 3/3 PASS; License::SPDX / JSON suites re-verified locally
- Pins verified against raku: `t/module-class-topic-binding.t`, `t/enum-member-nested-module-load.t`, `t/bless-hash-attr-coercion.t`

## Known issue (out of scope, noted)

A multi `method new(Str :$file)` (optional named) that calls `self.new(...)` can stack-overflow under mutsu when invoked with unrelated named args. META6 itself uses the required form (`Str :$file!`) and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)