### PR TITLE
feat: RakuAST Phase 5 slice 13 — EVAL of repeat/while and repeat/until

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -938,9 +938,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 12: default sub parameters — a `Parameter` with a `default` expression lowers to an
         optional positional `ParamDef` (`required=false`, `default=Some(…)`); `EVAL(Q[sub f($x, $y=10)
         { $x+$y }; f(5)].AST)` → 15. Tests in `t/rakuast-eval-default-param.t`.
-  - [ ] Slice 13+: `repeat`/`while`, typed/named/slurpy params (need both read + write) — the inverse
-        of the Phase-2 converter, grown cluster by cluster. (Phase 5 full lowering is a large
-        multi-slice effort mirroring Phase 2.)
+  - [x] Slice 13: `repeat { … } while/until C` (`Statement::Loop::RepeatWhile` → `Stmt::Loop` with
+        `repeat => true`); the body always runs once. `EVAL(Q[my $i=0; repeat { $i=$i+1 } until $i>=5;
+        $i].AST)` → 5. Tests in `t/rakuast-eval-repeat.t`.
+  - [ ] Slice 14+: `Bool` literals (read side), typed/named/slurpy params (need read + write), C-style
+        `loop` — the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full lowering
+        is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -253,6 +253,12 @@ earlier ones.
     parameter (`$y = $x * 2`). Typed (`Int $x`) and named (`:$x`) parameters still lack read-side
     (`.AST`) support and stay the boundary. Tests in `t/rakuast-eval-default-param.t`. Next: `repeat`/
     `while`, typed/named parameters (both directions).
+  - **Slice 13 (`repeat`/`while` and `repeat`/`until`) — done.** `Statement::Loop::RepeatWhile` lowers
+    to a `Stmt::Loop` with `repeat => true`, which runs the body once before testing the condition.
+    `repeat … until C` desugars to `repeat … while !C` (the prefix `!` from slice 11), so both forms
+    share the write path. `EVAL(Q[my $i = 0; repeat { $i = $i + 1 } until $i >= 5; $i].AST)` → `5`, and
+    the body always runs at least once. Tests in `t/rakuast-eval-repeat.t`. Next: `Bool` literals
+    (read side), typed/named parameters (both directions), C-style `loop`.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -47,6 +47,16 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         RakuAstClass::VarDeclarationSimple => lower_var_decl(node),
         RakuAstClass::StatementIf => lower_if(node),
         RakuAstClass::StatementLoopWhile => lower_while(node),
+        // `repeat { … } while/until C` runs the body once before testing the
+        // condition (`until` desugars to `while !C`, handled by the prefix `!`).
+        RakuAstClass::StatementLoopRepeatWhile => Ok(Stmt::Loop {
+            init: None,
+            cond: Some(lower_expr(named_child(node, "condition")?)?),
+            step: None,
+            body: lower_block(named_child(node, "body")?)?,
+            repeat: true,
+            label: None,
+        }),
         RakuAstClass::StatementFor => lower_for(node),
         RakuAstClass::Sub => lower_sub(node),
         // `given`/`when`/`default` — a `when`/`default` sits directly (not

--- a/t/rakuast-eval-repeat.t
+++ b/t/rakuast-eval-repeat.t
@@ -1,0 +1,28 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 5 slice 13 (ADR-0011): EVAL of `repeat { … } while/until C`.
+# `Statement::Loop::RepeatWhile` lowers to a `Stmt::Loop` with `repeat => True`,
+# which runs the body once before testing the condition. `repeat … until C`
+# desugars to `repeat … while !C` (the prefix `!` from slice 11). Verified
+# against Rakudo; passes under BOTH mutsu and raku.
+
+plan 4;
+
+# --- repeat/while loops while the condition holds ---------------------------
+is EVAL(Q[my $i = 0; my $n = 0; repeat { $i = $i + 1; $n = $n + 1 } while $i < 3; $n].AST), 3,
+    'repeat/while runs the body 3 times';
+
+# --- the body runs at least once even when the condition starts false -------
+is EVAL(Q[my $n = 0; repeat { $n = $n + 1 } while $n > 100; $n].AST), 1,
+    'repeat/while runs the body once before the (already-false) test';
+
+# --- repeat/until loops until the condition becomes true --------------------
+is EVAL(Q[my $i = 0; repeat { $i = $i + 1 } until $i >= 5; $i].AST), 5,
+    'repeat/until loops until the condition is true';
+
+# --- repeat/until also runs at least once -----------------------------------
+is EVAL(Q[my $n = 0; repeat { $n = $n + 1 } until $n < 100; $n].AST), 1,
+    'repeat/until runs the body once before the (already-true) test';


### PR DESCRIPTION
## Summary

Phase 5 slice 13 of RakuAST (ADR-0011): `EVAL` of `repeat { … } while/until C`.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[my $i = 0; my $n = 0; repeat { $i = $i + 1; $n = $n + 1 } while $i < 3; $n].AST)   # 3
EVAL(Q[my $i = 0; repeat { $i = $i + 1 } until $i >= 5; $i].AST)                          # 5
EVAL(Q[my $n = 0; repeat { $n = $n + 1 } while $n > 100; $n].AST)                         # 1 (runs once)
```

`Statement::Loop::RepeatWhile` lowers to a `Stmt::Loop` with `repeat => true`, which runs the body once before testing the condition. `repeat … until C` desugars to `repeat … while !C` (the prefix `!` from slice 11), so both forms share the write path.

## Tests

`t/rakuast-eval-repeat.t` — 4 assertions (repeat/while loops N times, runs once with a false condition, repeat/until, runs once with a true condition), **passing under BOTH mutsu and raku**. All 51 `t/rakuast-*.t` files (225 tests) still green.

Next: `Bool` literals (read side), typed/named parameters (both directions), C-style `loop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)