### PR TITLE
fix: .polymod reifies a lazy divisor source (gather / .map Seq)

### DIFF
--- a/src/runtime/methods_collection_ops/first_polymod_tree.rs
+++ b/src/runtime/methods_collection_ops/first_polymod_tree.rs
@@ -200,9 +200,23 @@ impl Interpreter {
         let mut has_infinite = false;
         for arg in args {
             match arg.view() {
-                ValueView::LazyList(_) => {
-                    has_infinite = true;
-                    divisors.extend(flatten_to_list(arg));
+                ValueView::LazyList(ll) => {
+                    // A lazy divisor source (`gather {...}`, `.map`, a `…∞` sequence)
+                    // must be reified. An infinite sequence keeps a non-empty cache
+                    // of its produced prefix; polymod pulls from it and stops once n
+                    // reaches 0 (the has_infinite path below). A FINITE unforced
+                    // source (a plain `gather` block) has an empty cache, so force it
+                    // fully — otherwise its elements never become divisors and the
+                    // number falls through unchanged (`600.polymod(gather {...})`
+                    // wrongly returned `(600)`).
+                    let cached = ll.cache.lock().unwrap().clone().unwrap_or_default();
+                    if cached.is_empty() {
+                        let items = self.force_lazy_list_bridge(&ll)?;
+                        divisors.extend(items);
+                    } else {
+                        has_infinite = true;
+                        divisors.extend(cached);
+                    }
                 }
                 ValueView::Array(..) | ValueView::Seq(_) | ValueView::Slip(_) => {
                     divisors.extend(flatten_to_list(arg));

--- a/t/polymod-lazy-seq.t
+++ b/t/polymod-lazy-seq.t
@@ -1,0 +1,32 @@
+use Test;
+
+# `.polymod` must reify a LAZY divisor source (a `gather` block, `.map`, or a
+# `… ∞` sequence) before dividing. Previously an unforced finite lazy source (a
+# plain `gather {...}`) had an empty element cache, so none of its divisors were
+# applied and the number fell through unchanged: `600.polymod(gather {...})`
+# wrongly returned `(600)` instead of `(0 2 6 3)`.
+
+plan 8;
+
+is-deeply 600.polymod(gather { take 3 * $_ for 1..3 }).List, (0, 2, 6, 3),
+    'finite gather divisor list is reified';
+
+is-deeply 600.polymod(lazy gather { take 3 * $_ for 1..3 }).List, (0, 2, 6, 3),
+    'lazy-prefixed gather divisor list is reified';
+
+my $s = lazy gather { take 3 * $_ for 1..3 };
+is-deeply 600.polymod($s).List, (0, 2, 6, 3),
+    'gather Seq bound to a scalar is reified';
+
+is-deeply 600.polymod((1..3).map(* * 3)).List, (0, 2, 6, 3),
+    'a .map Seq divisor list is reified';
+
+# Eager and lazy List divisors were already fine — guard against regression.
+is-deeply 600.polymod(3, 6, 9).List, (0, 2, 6, 3), 'eager divisor list still works';
+is-deeply 600.polymod(lazy 3, 6, 9).List, (0, 2, 6, 3), 'lazy List divisor still works';
+
+# An infinite sequence divisor keeps its cached prefix; polymod pulls until n == 0.
+is-deeply 120.polymod((10, 100 … ∞)).List, (0, 12), 'infinite sequence divisor still works';
+
+# Plain scalar divisors are unaffected.
+is-deeply 1000.polymod(10, 10, 10).List, (0, 0, 0, 1), 'plain scalar divisors still work';


### PR DESCRIPTION
## Summary

`.polymod` flattened its divisor arguments by reading each lazy list's element cache directly, but a **finite unforced** lazy source — a plain `gather {...}` block or a `.map` Seq — has an empty cache until it is forced. So none of its divisors were applied and the number fell through unchanged:

```raku
say 600.polymod(gather { take 3*$_ for 1..3 });  # was (600), should be (0 2 6 3)
```

## Fix

Reify a `LazyList` divisor with `force_lazy_list_bridge` when its cache is empty (a finite source). An **infinite** sequence divisor keeps a non-empty produced prefix in its cache, so it still takes the existing `has_infinite` path (pull from the cache, stop once `n` reaches 0) and is unaffected — `120.polymod((10, 100 … ∞))` still gives `(0 12)`.

Verified against reference `raku`: `gather`, `lazy gather`, a gather Seq bound to a scalar, and `.map` Seq divisors now all reify; eager/lazy-List/scalar divisors and the infinite-sequence divisor are unchanged. `make test` passes.

## Provenance

Found by the QA doc-diff harness (PLAN.md §8.1). Pin: `t/polymod-lazy-seq.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)