### PR TITLE
feat: RakuAST slice 14 — True/False literals in both .AST and EVAL

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -941,7 +941,10 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 13: `repeat { … } while/until C` (`Statement::Loop::RepeatWhile` → `Stmt::Loop` with
         `repeat => true`); the body always runs once. `EVAL(Q[my $i=0; repeat { $i=$i+1 } until $i>=5;
         $i].AST)` → 5. Tests in `t/rakuast-eval-repeat.t`.
-  - [ ] Slice 14+: `Bool` literals (read side), typed/named/slurpy params (need read + write), C-style
+  - [x] Slice 14: `True`/`False` literals (both directions) via a new `Term::Enum` node class
+        (`.from-identifier('True')`, single-quoted enum identifier). `EVAL(Q[my $i=0; while True { $i=
+        $i+1; last if $i>=3 }; $i].AST)` → 3. Tests in `t/rakuast-eval-bool.t`.
+  - [ ] Slice 15+: ternary lowering (`?? !!`), typed/named/slurpy params (need read + write), C-style
         `loop` — the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full lowering
         is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -259,6 +259,13 @@ earlier ones.
     share the write path. `EVAL(Q[my $i = 0; repeat { $i = $i + 1 } until $i >= 5; $i].AST)` → `5`, and
     the body always runs at least once. Tests in `t/rakuast-eval-repeat.t`. Next: `Bool` literals
     (read side), typed/named parameters (both directions), C-style `loop`.
+  - **Slice 14 (`True`/`False` literals) — done, both directions.** A new `Term::Enum` node class
+    models a boolean literal (`RakuAST::Term::Enum.from-identifier('True')` — the enum identifier is
+    single-quoted in raku's gist, unlike `Name.from-identifier("…")`). The read side (`.AST`) converts
+    a `Bool` literal to that node and the write side (`EVAL`) lowers `True`/`False` back to the Bool
+    value. `EVAL(Q[my $i = 0; while True { $i = $i + 1; last if $i >= 3 }; $i].AST)` → `3`. Other enum
+    identifiers stay the boundary. Tests in `t/rakuast-eval-bool.t`. Next: ternary lowering (`?? !!`),
+    typed/named parameters, C-style `loop`.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -1385,6 +1385,14 @@ fn convert_literal(v: &Value) -> Result<RakuAstNode, RuntimeError> {
             fields: vec![leaf_field(None, v.clone())],
         }),
         ValueView::Str(_) => Ok(quoted_string(v.clone())),
+        // `True`/`False` are enum values: `Term::Enum.from-identifier('True')`.
+        ValueView::Bool(b) => Ok(RakuAstNode {
+            class: RakuAstClass::TermEnum,
+            fields: vec![leaf_field(
+                None,
+                Value::str(if b { "True" } else { "False" }.to_string()),
+            )],
+        }),
         other => Err(unsupported(&format!("literal {other:?}"))),
     }
 }

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -469,6 +469,12 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             Err(unsupported(node))
         }
         RakuAstClass::StatementExpression => lower_expr(named_child(node, "expression")?),
+        // `True`/`False` -> the Bool literal. Other enum identifiers are deferred.
+        RakuAstClass::TermEnum => match positional_leaf(node)?.view() {
+            ValueView::Str(s) if s.as_str() == "True" => Ok(Expr::Literal(Value::truth(true))),
+            ValueView::Str(s) if s.as_str() == "False" => Ok(Expr::Literal(Value::truth(false))),
+            _ => Err(unsupported(node)),
+        },
         // `$x` / `@a` / `%h` / `&f` -> the sigil-specific variable expression.
         RakuAstClass::VarLexical => {
             let name = match positional_leaf(node)?.view() {

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -125,6 +125,8 @@ pub enum RakuAstClass {
     PostcircumfixArrayIndex,
     // Phase 2 slice 25: reduction metaoperator.
     TermReduce,
+    // Phase 2 slice 30: `True`/`False` (and other enum) literals.
+    TermEnum,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -193,6 +195,7 @@ impl RakuAstClass {
             SemiList => "RakuAST::SemiList",
             PostcircumfixArrayIndex => "RakuAST::Postcircumfix::ArrayIndex",
             TermReduce => "RakuAST::Term::Reduce",
+            TermEnum => "RakuAST::Term::Enum",
         }
     }
 
@@ -205,7 +208,7 @@ impl RakuAstClass {
 
     pub fn constructor(self) -> Constructor {
         match self {
-            RakuAstClass::Name => Constructor::FromIdentifier,
+            RakuAstClass::Name | RakuAstClass::TermEnum => Constructor::FromIdentifier,
             _ => Constructor::New,
         }
     }
@@ -320,6 +323,7 @@ fn single_positional_class(class_name: &str, method: &str) -> Option<RakuAstClas
         ("RakuAST::RatLiteral", "new") => RakuAstClass::RatLiteral,
         ("RakuAST::StrLiteral", "new") => RakuAstClass::StrLiteral,
         ("RakuAST::Name", "from-identifier") => RakuAstClass::Name,
+        ("RakuAST::Term::Enum", "from-identifier") => RakuAstClass::TermEnum,
         ("RakuAST::Infix", "new") => RakuAstClass::Infix,
         ("RakuAST::Prefix", "new") => RakuAstClass::Prefix,
         ("RakuAST::Var::Lexical", "new") => RakuAstClass::VarLexical,

--- a/src/rakuast/render.rs
+++ b/src/rakuast/render.rs
@@ -8,7 +8,7 @@
 //! forces the multi-line form (e.g. `Postfix.new(operator => "++")` is
 //! multi-line despite its single leaf, because the field is named).
 
-use super::{Constructor, RakuAstField, RakuAstFieldValue, RakuAstNode};
+use super::{Constructor, RakuAstClass, RakuAstField, RakuAstFieldValue, RakuAstNode};
 use crate::value::{Value, ValueView};
 
 pub(super) fn render_node(node: &RakuAstNode, indent: usize) -> String {
@@ -22,6 +22,16 @@ pub(super) fn render_node(node: &RakuAstNode, indent: usize) -> String {
     // empty parens (`RakuAST::Assignment.new`), unlike the generic `.new()`.
     if node.fields.is_empty() && node.class.empty_parens_omitted() {
         return format!("{name}.{ctor}");
+    }
+
+    // `Term::Enum.from-identifier('True')` — raku renders the enum identifier in
+    // single quotes (unlike `Name.from-identifier("say")`, which uses double).
+    if node.class == RakuAstClass::TermEnum
+        && let Some(f) = node.fields.first()
+        && let RakuAstFieldValue::Node(v) = &f.value
+        && let ValueView::Str(s) = v.view()
+    {
+        return format!("{name}.{ctor}('{}')", s.as_str());
     }
 
     // Inline when every field is a positional leaf or a colonpair adverb

--- a/t/rakuast-eval-bool.t
+++ b/t/rakuast-eval-bool.t
@@ -1,0 +1,36 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 14 (ADR-0011): `True`/`False` literals in both directions.
+# raku models a boolean literal as `RakuAST::Term::Enum.from-identifier('True')`
+# (single-quoted enum identifier). The read side (`.AST`) emits that node and the
+# write side (`EVAL`) lowers it back to the Bool value. Verified against Rakudo;
+# passes under BOTH mutsu and raku.
+
+plan 6;
+
+# --- read side: the gist uses the single-quoted enum form -------------------
+is Q[True].AST.gist.chomp, q:to/END/.chomp, 'True renders as Term::Enum';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Term::Enum.from-identifier('True')
+      )
+    )
+    END
+
+# --- write side: the literals evaluate to their Bool values -----------------
+is EVAL(Q[True].AST), True, 'EVAL of True is True';
+is EVAL(Q[False].AST), False, 'EVAL of False is False';
+
+# --- a boolean out of an if/else --------------------------------------------
+is EVAL(Q[sub even($n) { if $n %% 2 { True } else { False } }; even(4)].AST), True,
+    'a sub returning True/False from if/else';
+
+# --- a boolean drives a loop condition --------------------------------------
+is EVAL(Q[my $i = 0; while True { $i = $i + 1; last if $i >= 3 }; $i].AST), 3,
+    'while True with an explicit last';
+
+# --- negation of a False literal --------------------------------------------
+is EVAL(Q[my $f = False; !$f].AST), True, 'negating a False literal yields True';


### PR DESCRIPTION
## Summary

RakuAST slice 14 (ADR-0011): `True`/`False` literals in **both directions** of the model layer.

raku models a boolean literal as an enum term (note the single-quoted identifier, unlike a `Name`):

```raku
Q[True].AST   # ... RakuAST::Term::Enum.from-identifier('True')
```

This slice adds the `Term::Enum` node class:

- **Read (`.AST`, Phase 2):** a `Bool` literal converts to a `Term::Enum` node; the renderer special-cases it to emit the single-quoted `.from-identifier('True')` form.
- **Write (`EVAL`, Phase 5):** a `Term::Enum` whose identifier is `True`/`False` lowers back to the Bool value.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[True].AST)                                                            # True
EVAL(Q[my $i = 0; while True { $i = $i + 1; last if $i >= 3 }; $i].AST)      # 3
EVAL(Q[my $f = False; !$f].AST)                                             # True
```

Other enum identifiers stay the coverage boundary.

## Tests

`t/rakuast-eval-bool.t` — 6 assertions (read-side gist is the single-quoted enum form, `EVAL` of True/False, a boolean out of if/else, `while True` with `last`, negation of a False literal), **passing under BOTH mutsu and raku**. The read-side gist is byte-identical to Rakudo's. All 52 `t/rakuast-*.t` files (231 tests) still green.

Next: ternary lowering (`?? !!`), typed/named parameters, C-style `loop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)