### PR TITLE
feat: RakuAST Phase 5 slice 15 — EVAL of the ternary ?? !!

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -944,9 +944,11 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 14: `True`/`False` literals (both directions) via a new `Term::Enum` node class
         (`.from-identifier('True')`, single-quoted enum identifier). `EVAL(Q[my $i=0; while True { $i=
         $i+1; last if $i>=3 }; $i].AST)` → 3. Tests in `t/rakuast-eval-bool.t`.
-  - [ ] Slice 15+: ternary lowering (`?? !!`), typed/named/slurpy params (need read + write), C-style
-        `loop` — the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full lowering
-        is a large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 15: ternary lowering (`RakuAST::Ternary` → `Expr::Ternary`); `EVAL(Q[1 ?? 10 !! 20].AST)`
+        → 10, nested right-associative ternaries work. Tests in `t/rakuast-eval-ternary.t`.
+  - [ ] Slice 16+: typed/named/slurpy params (need read + write), C-style `loop`, string interpolation
+        — the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full lowering is a
+        large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -266,6 +266,10 @@ earlier ones.
     value. `EVAL(Q[my $i = 0; while True { $i = $i + 1; last if $i >= 3 }; $i].AST)` → `3`. Other enum
     identifiers stay the boundary. Tests in `t/rakuast-eval-bool.t`. Next: ternary lowering (`?? !!`),
     typed/named parameters, C-style `loop`.
+  - **Slice 15 (ternary `?? !!`) — done.** `RakuAST::Ternary` lowers to `Expr::Ternary`, so a
+    conditional expression evaluates its chosen branch. `EVAL(Q[sub even($n) { $n %% 2 ?? True !! False
+    }; even(4)].AST)` → `True`; nested (right-associative) ternaries work. Tests in
+    `t/rakuast-eval-ternary.t`. Next: typed/named parameters, C-style `loop`.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -507,6 +507,12 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
                 expr: Box::new(operand),
             })
         }
+        // `COND ?? THEN !! ELSE` -> the ternary expression.
+        RakuAstClass::Ternary => Ok(Expr::Ternary {
+            cond: Box::new(lower_expr(named_child(node, "condition")?)?),
+            then_expr: Box::new(lower_expr(named_child(node, "then")?)?),
+            else_expr: Box::new(lower_expr(named_child(node, "else")?)?),
+        }),
         // A named call `f(1, 2)` -> Expr::Call (the listop I/O calls are handled
         // as statements in `lower_stmt_inner`; here they are ordinary calls too).
         RakuAstClass::CallName | RakuAstClass::CallNameWithoutParentheses => Ok(Expr::Call {

--- a/t/rakuast-eval-ternary.t
+++ b/t/rakuast-eval-ternary.t
@@ -1,0 +1,24 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 5 slice 15 (ADR-0011): EVAL of the ternary `COND ?? THEN !! ELSE`.
+# `RakuAST::Ternary` lowers to `Expr::Ternary`. Verified against Rakudo; passes
+# under BOTH mutsu and raku.
+
+plan 5;
+
+# --- a plain ternary picks the branch by the condition ----------------------
+is EVAL(Q[1 ?? 10 !! 20].AST), 10, 'ternary: true condition picks THEN';
+is EVAL(Q[0 ?? 10 !! 20].AST), 20, 'ternary: false condition picks ELSE';
+
+# --- a ternary returning booleans -------------------------------------------
+is EVAL(Q[sub even($n) { $n %% 2 ?? True !! False }; even(4)].AST), True,
+    'ternary yields True for an even number';
+is EVAL(Q[sub even($n) { $n %% 2 ?? True !! False }; even(5)].AST), False,
+    'ternary yields False for an odd number';
+
+# --- a nested ternary (right-associative) -----------------------------------
+is EVAL(Q[sub sgn($n) { $n > 0 ?? 1 !! $n < 0 ?? -1 !! 0 }; sgn(-5)].AST), -1,
+    'nested ternary: sgn(-5) == -1';


### PR DESCRIPTION
## Summary

Phase 5 slice 15 of RakuAST (ADR-0011): `EVAL` of the ternary `COND ?? THEN !! ELSE`.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[1 ?? 10 !! 20].AST)                                              # 10
EVAL(Q[sub even($n) { $n %% 2 ?? True !! False }; even(4)].AST)         # True
EVAL(Q[sub sgn($n) { $n > 0 ?? 1 !! $n < 0 ?? -1 !! 0 }; sgn(-5)].AST)  # -1
```

`RakuAST::Ternary` lowers to `Expr::Ternary`, so a conditional expression evaluates its chosen branch; nested (right-associative) ternaries work.

## Tests

`t/rakuast-eval-ternary.t` — 5 assertions (true/false branch selection, boolean results, nested ternary), **passing under BOTH mutsu and raku**. All 53 `t/rakuast-*.t` files (236 tests) still green.

Next: typed/named parameters, C-style `loop`, string interpolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)