### PR TITLE
feat: RakuAST slice 16 — interpolated strings in both .AST and EVAL

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -946,9 +946,12 @@ so it is tracked separately from the roast backlog.
         $i+1; last if $i>=3 }; $i].AST)` → 3. Tests in `t/rakuast-eval-bool.t`.
   - [x] Slice 15: ternary lowering (`RakuAST::Ternary` → `Expr::Ternary`); `EVAL(Q[1 ?? 10 !! 20].AST)`
         → 10, nested right-associative ternaries work. Tests in `t/rakuast-eval-ternary.t`.
-  - [ ] Slice 16+: typed/named/slurpy params (need read + write), C-style `loop`, string interpolation
-        — the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full lowering is a
-        large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 16: interpolated strings `"a $x b"` (both directions) — `Expr::StringInterpolation` ↔ a
+        `QuotedString` with a `StrLiteral`/interpolated-term segment per part. `EVAL(Q[my $x=5;
+        "val=$x"].AST)` → `val=5`. Tests in `t/rakuast-eval-interp.t`.
+  - [ ] Slice 17+: typed/named/slurpy params (need read + write), C-style `loop`, code-block (`{…}`)
+        interpolation — the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full
+        lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -270,6 +270,13 @@ earlier ones.
     conditional expression evaluates its chosen branch. `EVAL(Q[sub even($n) { $n %% 2 ?? True !! False
     }; even(4)].AST)` → `True`; nested (right-associative) ternaries work. Tests in
     `t/rakuast-eval-ternary.t`. Next: typed/named parameters, C-style `loop`.
+  - **Slice 16 (interpolated strings) — done, both directions.** An interpolated string `"a $x b"` is a
+    `QuotedString` with one segment per part (a literal run is a `StrLiteral`, an interpolated term
+    keeps its own node). The read side (`.AST`) converts `Expr::StringInterpolation` to that node (a
+    literal segment stays a bare `StrLiteral`, not a nested `QuotedString`) and the write side (`EVAL`)
+    lowers a multi-segment `QuotedString` back to a `StringInterpolation`. `EVAL(Q[my $x = 5;
+    "val=$x"].AST)` → `val=5`. Code-block (`{…}`) interpolation stays the boundary. Tests in
+    `t/rakuast-eval-interp.t`. Next: typed/named parameters, C-style `loop`.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -976,7 +976,38 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
             }
             pointy_block(param_defs, body)
         }
+        // An interpolated string `"a $x b"` -> QuotedString with a segment per
+        // part (a literal run is a `StrLiteral`, an interpolated term keeps its
+        // own node).
+        Expr::StringInterpolation(parts) => {
+            let mut segments = Vec::with_capacity(parts.len());
+            for p in parts {
+                segments.push(Value::rakuast(Box::new(interp_segment(p)?)));
+            }
+            Ok(RakuAstNode {
+                class: RakuAstClass::QuotedString,
+                fields: vec![RakuAstField {
+                    name: Some("segments"),
+                    value: RakuAstFieldValue::List(segments),
+                }],
+            })
+        }
         other => Err(unsupported(&format!("{other:?}"))),
+    }
+}
+
+/// One segment of an interpolated string. A literal-string part is a bare
+/// `StrLiteral` (not a nested `QuotedString`); any other part keeps its normal
+/// converted node.
+fn interp_segment(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
+    match expr {
+        Expr::Literal(v) | Expr::LiteralSrc(v, _) if matches!(v.view(), ValueView::Str(_)) => {
+            Ok(RakuAstNode {
+                class: RakuAstClass::StrLiteral,
+                fields: vec![leaf_field(None, v.clone())],
+            })
+        }
+        other => convert_expr(other),
     }
 }
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -466,7 +466,16 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             {
                 return Ok(Expr::Literal(positional_leaf(seg)?));
             }
-            Err(unsupported(node))
+            // A multi-segment (interpolated) string -> StringInterpolation of the
+            // lowered segments (`StrLiteral` runs and interpolated terms alike).
+            let mut parts = Vec::with_capacity(segments.len());
+            for s in segments {
+                let ValueView::RakuAst(seg) = s.view() else {
+                    return Err(unsupported(node));
+                };
+                parts.push(lower_expr(seg)?);
+            }
+            Ok(Expr::StringInterpolation(parts))
         }
         RakuAstClass::StatementExpression => lower_expr(named_child(node, "expression")?),
         // `True`/`False` -> the Bool literal. Other enum identifiers are deferred.

--- a/t/rakuast-eval-interp.t
+++ b/t/rakuast-eval-interp.t
@@ -1,0 +1,35 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 16 (ADR-0011): interpolated strings `"a $x b"`, both directions.
+# raku models these as a `QuotedString` with one segment per part (a literal run
+# is a `StrLiteral`, an interpolated term keeps its own node). The read side
+# (`.AST`) emits that node and the write side (`EVAL`) lowers it back to a
+# `StringInterpolation`. Verified against Rakudo; passes under BOTH mutsu and raku.
+
+plan 5;
+
+# --- read side: the gist has one StrLiteral + one Var::Lexical segment -------
+my $g = Q[my $x = 5; "val=$x"].AST.gist;
+ok $g.contains('RakuAST::QuotedString.new(')
+    && $g.contains('RakuAST::StrLiteral.new("val=")')
+    && $g.contains('RakuAST::Var::Lexical.new("\$x")'),
+    'an interpolated string renders as a QuotedString with segments';
+
+# --- a literal prefix followed by a variable --------------------------------
+is EVAL(Q[my $x = 5; "val=$x"].AST), 'val=5',
+    'interpolation of a trailing variable';
+
+# --- two variables with literal runs between/around -------------------------
+is EVAL(Q[my $a = 2; my $b = 3; "$a+$b"].AST), '2+3',
+    'interpolation of two variables';
+
+# --- a single interpolated variable, no literal runs ------------------------
+is EVAL(Q[my $x = 42; "$x"].AST), '42',
+    'interpolation of a lone variable stringifies it';
+
+# --- a literal run after the variable too -----------------------------------
+is EVAL(Q[my $n = 7; "n is $n!"].AST), 'n is 7!',
+    'interpolation with literal text on both sides';


### PR DESCRIPTION
## Summary

RakuAST slice 16 (ADR-0011): interpolated strings `"a $x b"` in **both directions**.

An interpolated string is a `QuotedString` with one segment per part (a literal run is a `StrLiteral`, an interpolated term keeps its own node):

```raku
Q[my $x = 5; "val=$x"].AST   # ... QuotedString(segments => (StrLiteral("val="), Var::Lexical("$x")))
```

- **Read (`.AST`, Phase 2):** `Expr::StringInterpolation` → `QuotedString`; a literal-string part becomes a bare `StrLiteral` (not a nested `QuotedString`), matching raku's segment shape.
- **Write (`EVAL`, Phase 5):** a multi-segment `QuotedString` → `StringInterpolation` of its lowered segments (the single-`StrLiteral` case still folds to a plain string literal).

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[my $x = 5; "val=$x"].AST)            # "val=5"
EVAL(Q[my $a = 2; my $b = 3; "$a+$b"].AST)  # "2+3"
```

Code-block (`{…}`) interpolation stays the coverage boundary.

## Tests

`t/rakuast-eval-interp.t` — 5 assertions (read-side gist has the segments, trailing var, two vars, lone var, literal text on both sides), **passing under BOTH mutsu and raku**. The read-side gist is byte-identical to Rakudo's. All 54 `t/rakuast-*.t` files (241 tests) still green.

Next: typed/named parameters, C-style `loop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)