### PR TITLE
fix(json): X::JSON::AdditionalContent + strict string/number grammar in native from-json

### DIFF
--- a/docs/mzef-install-pipeline.md
+++ b/docs/mzef-install-pipeline.md
@@ -214,17 +214,20 @@ repro → general fix → `t/` pin):
 
 ## Test-phase frontier (2026-07-18 refresh)
 
-**Per-suite standing (2026-07-18, after #4735 / #4738 / #4747; staged-dist
-`prove` sweep with the full MUTSULIB chain, `tmp/e2e-suites.sh`): 9 PASS /
-2 FAIL.** PASS: JSON::OptIn, JSON::Name, JSON::Unmarshal (11 files / 101
-tests), JSON::Marshal (14/85), JSON::Class (6/31), URI (14/222), META6
-(9/969), License::SPDX (2/729). FAIL: **JSON::Fast** (native-JSON fidelity
-remnants — strict mode / unicode / datetime; full parity is likely
-unnecessary for the pipeline) and **Test::META** (3 concrete subtest
-failures: `020-internals.t` test 12 "check-provides with my own files" and
-test 24 "check-sources" / "non-git URI needn't must end in git", plus
-`030-my-meta.t` "don't have META file"). Test-Helpers ships no `t/` of its
-own (covered by mutsu's local `t/test-util-*.t`).
+**Per-suite standing (2026-07-18, after #4735 / #4738 / #4747 / #4756;
+staged-dist `prove` sweep with the full MUTSULIB chain,
+`tmp/e2e-suites.sh`): 10 PASS / 1 FAIL.** PASS: JSON::OptIn, JSON::Name,
+JSON::Unmarshal (11 files / 101 tests), JSON::Marshal (14/85), JSON::Class
+(6/31), URI (14/222), META6 (9/969), License::SPDX (2/729), Test::META
+(3/26, #4756). FAIL: **JSON::Fast** only (native-JSON fidelity remnants;
+full parity is likely unnecessary for the pipeline). Within JSON::Fast,
+the X::JSON::AdditionalContent + strict string/number grammar PR brought
+`01-parse.t` (724 tests) and `10-multidocument.t` to full pass — 5/14
+files green (01, 06, 08, 09, 10); remaining: 02-structure (8/20),
+03-unicode (aborts at 11/14), 04-roundtrip (2/56), 05-unreasonable (3/7),
+07-datetime (`augment class DateTime`), 11-enum (6/16),
+12-assocpositional, 13-scopes (3/8), 14-comments (JSONC). Test-Helpers
+ships no `t/` of its own (covered by mutsu's local `t/test-util-*.t`).
 
 The #4747 session's two generic fixes (License::SPDX 0/2 → 2/2): a trait
 argument with whitespace after the opening paren
@@ -279,7 +282,7 @@ generally:
 
 ~~Re-run the full `zef install Test::META` E2E after these land to get the
 new pass/fail count.~~ Done 2026-07-18 — see the per-suite standing at the
-top of this section (9 PASS / 2 FAIL).
+top of this section (10 PASS / 1 FAIL).
 
 **Test::Async is out of scope for this frontier** (PLAN.md §1 B5): its
 blocker is custom Metamodel HOW inheritance

--- a/src/parser/stmt/simple/module_exports.rs
+++ b/src/parser/stmt/simple/module_exports.rs
@@ -19,6 +19,12 @@ pub(crate) fn register_module_exports(module: &str) {
     } else if module == "JSON::Fast" || module == "JSON::Tiny" {
         // Native modules: `to-json`/`from-json` are implemented in Rust
         // (runtime/json.rs), so there is no source file to scan for exports.
+        // JSON::Fast also exports the X::JSON::AdditionalContent exception
+        // class; register it as a declared type so `when X::JSON::AdditionalContent {`
+        // is not misread as an undeclared-bareword block gobble.
+        if module == "JSON::Fast" {
+            register_user_type("X::JSON::AdditionalContent");
+        }
         ["to-json", "from-json"]
             .iter()
             .map(|s| InlineModuleExport {

--- a/src/runtime/json.rs
+++ b/src/runtime/json.rs
@@ -215,18 +215,36 @@ fn escape_str(s: &str, out: &mut String) {
     }
 }
 
-/// Parse a JSON string into a `Value`. Returns an error message on malformed input.
-pub(crate) fn from_json(text: &str) -> Result<Value, String> {
+/// Error from `from_json`: either a plain malformed-input message, or the
+/// JSON::Fast `X::JSON::AdditionalContent` condition — the document parsed
+/// cleanly but was followed by more non-whitespace text. Positions are in
+/// characters (Raku `substr` semantics), not bytes.
+pub(crate) enum FromJsonError {
+    Parse(String),
+    AdditionalContent {
+        parsed: Value,
+        parsed_length: usize,
+        rest_position: usize,
+    },
+}
+
+/// Parse a JSON string into a `Value`.
+pub(crate) fn from_json(text: &str) -> Result<Value, FromJsonError> {
     let mut p = Parser {
         bytes: text.as_bytes(),
         chars: text,
         pos: 0,
     };
     p.skip_ws();
-    let value = p.parse_value()?;
+    let value = p.parse_value().map_err(FromJsonError::Parse)?;
+    let parsed_length = text[..p.pos].chars().count();
     p.skip_ws();
     if p.pos != p.bytes.len() {
-        return Err("JSON Input contained additional text after the document".to_string());
+        return Err(FromJsonError::AdditionalContent {
+            parsed: value,
+            parsed_length,
+            rest_position: text[..p.pos].chars().count(),
+        });
     }
     Ok(value)
 }
@@ -361,30 +379,53 @@ impl<'a> Parser<'a> {
                         b't' => result.push('\t'),
                         b'u' => {
                             let cp = self.parse_unicode_escape()?;
-                            // Handle surrogate pairs.
+                            // A high surrogate must be followed by an escaped low
+                            // surrogate (JSON transports astral chars as pairs);
+                            // anything else — including a lone low surrogate — is
+                            // malformed (JSON::Fast rejects it too).
                             if (0xD800..=0xDBFF).contains(&cp) {
-                                if self.chars[self.pos..].starts_with("\\u") {
-                                    self.pos += 2;
-                                    let lo = self.parse_unicode_escape()?;
-                                    let combined = 0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00);
-                                    if let Some(ch) = char::from_u32(combined) {
-                                        result.push(ch);
-                                    }
-                                } else if let Some(ch) = char::from_u32(cp) {
-                                    result.push(ch);
+                                if !self.chars[self.pos..].starts_with("\\u") {
+                                    return Err(
+                                        "Lone surrogate \\u escape in JSON string".to_string()
+                                    );
                                 }
-                                continue;
+                                self.pos += 1; // consume '\\'; parse_unicode_escape eats the 'u'
+                                let lo = self.parse_unicode_escape()?;
+                                if !(0xDC00..=0xDFFF).contains(&lo) {
+                                    return Err("Invalid surrogate pair in JSON string".to_string());
+                                }
+                                let combined = 0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00);
+                                match char::from_u32(combined) {
+                                    Some(ch) => result.push(ch),
+                                    None => {
+                                        return Err(
+                                            "Invalid surrogate pair in JSON string".to_string()
+                                        );
+                                    }
+                                }
+                            } else if (0xDC00..=0xDFFF).contains(&cp) {
+                                return Err("Lone surrogate \\u escape in JSON string".to_string());
                             } else if let Some(ch) = char::from_u32(cp) {
                                 result.push(ch);
                             }
                             continue;
                         }
-                        other => {
-                            result.push('\\');
-                            result.push(other as char);
+                        _ => {
+                            return Err(format!(
+                                "Invalid backslash escape in JSON string at position {}",
+                                self.pos
+                            ));
                         }
                     }
                     self.pos += 1;
+                }
+                c if c < 0x20 => {
+                    // Raw control characters (tab, newline, ...) must be escaped
+                    // inside JSON strings.
+                    return Err(format!(
+                        "Unescaped control character in JSON string at position {}",
+                        self.pos
+                    ));
                 }
                 _ => {
                     // Copy the full UTF-8 character.
@@ -427,6 +468,11 @@ impl<'a> Parser<'a> {
         if self.peek() == Some(b'.') {
             is_rat = true;
             self.pos += 1;
+            // JSON's number grammar requires at least one digit after the
+            // decimal point: `1.` / `2.e3` are malformed.
+            if !matches!(self.peek(), Some(c) if c.is_ascii_digit()) {
+                return Err("Missing digits after decimal point in JSON number".to_string());
+            }
             while matches!(self.peek(), Some(c) if c.is_ascii_digit()) {
                 self.pos += 1;
             }

--- a/src/vm/vm_native_json.rs
+++ b/src/vm/vm_native_json.rs
@@ -108,5 +108,31 @@ fn native_from_json(args: &[Value]) -> Result<Value, RuntimeError> {
         .find(|a| !matches!(a.view(), ValueView::Pair(..) | ValueView::ValuePair(..)))
         .map(|v| v.to_string_value())
         .unwrap_or_default();
-    json::from_json(&text).map_err(RuntimeError::new)
+    json::from_json(&text).map_err(|e| match e {
+        json::FromJsonError::Parse(msg) => RuntimeError::new(msg),
+        json::FromJsonError::AdditionalContent {
+            parsed,
+            parsed_length,
+            rest_position,
+        } => {
+            // Mirror JSON::Fast's X::JSON::AdditionalContent so multi-document
+            // consumers can catch it and resume from `.rest-position`.
+            let msg = format!(
+                "JSON Input contained additional text after the document \
+                 (parsed {parsed_length} chars, next non-whitespace lives at {rest_position})"
+            );
+            let ex = Value::make_exception(
+                "X::JSON::AdditionalContent",
+                &[
+                    ("parsed", parsed),
+                    ("parsed-length", Value::int(parsed_length as i64)),
+                    ("rest-position", Value::int(rest_position as i64)),
+                    ("message", Value::str(msg.clone())),
+                ],
+            );
+            let mut err = RuntimeError::new(msg);
+            err.exception = Some(Box::new(ex));
+            err
+        }
+    })
 }

--- a/t/json-additional-content.t
+++ b/t/json-additional-content.t
@@ -1,0 +1,48 @@
+use v6;
+use JSON::Fast;
+use Test;
+
+# from-json with trailing content must throw X::JSON::AdditionalContent
+# carrying .parsed / .parsed-length / .rest-position, so multi-document
+# consumers can resume from the rest position (JSON::Fast t/10-multidocument.t).
+
+my $input = q«[1, 2, 3]{"a": 99, "b": 123} "foo"»;
+my @results;
+my $rounds = 0;
+
+loop {
+    $rounds++;
+    last if $rounds > 100;
+
+    @results.push: from-json($input);
+
+    CATCH {
+        when X::JSON::AdditionalContent {
+            @results.push: .parsed;
+            $input = $input.substr(.rest-position)
+        }
+    }
+    last
+};
+
+is $rounds, 3, "right number of parses";
+is-deeply @results[0], $[1, 2, 3], "first result";
+is-deeply @results[1], ${"a" => 99, "b" => 123}, "second result";
+is-deeply @results[2], "foo", "third result";
+
+# Attribute details: parsed-length counts chars before trailing whitespace,
+# rest-position is the index of the next non-whitespace character.
+{
+    from-json(q«[1]   42»);
+    CATCH {
+        when X::JSON::AdditionalContent {
+            is .parsed-length, 3, "parsed-length is chars parsed";
+            is .rest-position, 6, "rest-position skips whitespace";
+        }
+    }
+}
+
+# Clean input still parses without any exception.
+is-deeply from-json("[4, 5]"), $[4, 5], "clean parse unaffected";
+
+done-testing;

--- a/t/json-strict-parse.t
+++ b/t/json-strict-parse.t
@@ -1,0 +1,51 @@
+use v6;
+use Test;
+use JSON::Fast;
+
+# Strict JSON grammar in native from-json (JSON::Fast t/01-parse.t parity).
+# Note: \u escape sequences are assembled from chr(92) so this file stays ASCII
+# and no host-language escape processing can mangle them.
+
+my $bs = 92.chr;
+sub u(*@cps) { @cps.map({ $bs ~ 'u' ~ $_ }).join('') }
+
+# Surrogate pairs decode to the combined code point.
+{
+    my $r = from-json('["' ~ u('D801', 'DC37') ~ '"]');
+    is $r[0].ord, 0x10437, 'surrogate pair decodes to astral char';
+    is $r[0].chars, 1, 'pair produces a single character';
+}
+{
+    my $r = from-json('["' ~ u('D83D', 'DE39') ~ u('D83D', 'DC8D') ~ '"]');
+    is $r[0].ords.list, (0x1F639, 0x1F48D), 'two consecutive pairs decode';
+}
+
+# Lone / mismatched surrogates are rejected.
+for 'DFAA', 'D800' -> $cp {
+    dies-ok { from-json('["' ~ u($cp) ~ '"]') }, "lone surrogate $cp rejected";
+}
+dies-ok { from-json('["' ~ u('DD1E', 'D834') ~ '"]') },
+    'low-then-high surrogate order rejected';
+dies-ok { from-json('["' ~ u('D800') ~ 'abc"]') },
+    'high surrogate followed by plain text rejected';
+
+# Invalid backslash escapes are rejected.
+dies-ok { from-json('["' ~ $bs ~ 'a"]') }, 'backslash-a escape rejected';
+dies-ok { from-json('["' ~ $bs ~ 'x15"]') }, 'backslash-x escape rejected';
+
+# Raw control characters inside strings are rejected.
+dies-ok { from-json('["' ~ 9.chr ~ '"]') }, 'raw tab in string rejected';
+dies-ok { from-json('["' ~ 10.chr ~ '"]') }, 'raw newline in string rejected';
+
+# Escaped control characters still parse.
+is from-json('["' ~ $bs ~ 't"]')[0], "\t", 'escaped tab parses';
+is from-json('["' ~ u('0000') ~ '"]')[0], 0.chr, 'escaped NUL parses';
+
+# Numbers require a digit after the decimal point.
+for '[1.]', '[-2.]', '[0.e1]', '[2.e3]' -> $t {
+    dies-ok { from-json($t) }, "malformed number $t rejected";
+}
+is-deeply from-json('[1.5, -0.25, 2e3]'), $[1.5, -0.25, 2e3],
+    'well-formed numbers still parse';
+
+done-testing;


### PR DESCRIPTION
## Summary

Three JSON::Fast-parity fixes in the native JSON implementation (`runtime/json.rs` / `vm_native_json.rs`), driven by the JSON::Fast test suite — the last failing dist in the mzef test-phase E2E (10 PASS / 1 FAIL).

- **`X::JSON::AdditionalContent`**: `from-json` with trailing content now throws the typed exception with `.parsed` / `.parsed-length` / `.rest-position` (char-based, JSON::Fast semantics: parsed-length before trailing whitespace, rest-position after), so multi-document consumers can catch it and resume. `use JSON::Fast` also registers the class as a declared type at parse time, fixing the false-positive block-gobble error (`X::Comp::Group: Missing block`) on `when X::JSON::AdditionalContent { ... }` — the reserved-`X::`-namespace heuristic in `when_stmt` could not know a native module's exception type.
- **Surrogate-pair decode was off by one byte**: the pair branch advanced past `\u` with `pos += 2` and then `parse_unicode_escape` consumed a hex digit as the `'u'`, corrupting every astral-plane escape (`𐐷` → "Invalid \u escape"). Lone or mismatched surrogates were silently *dropped*; they are now rejected per JSON grammar.
- **Strict string/number grammar**: raw control characters in strings, invalid backslash escapes (`\a`, `\x15`, ...), and numbers with no digit after the decimal point (`1.`, `2.e3`) are now rejected — JSON::Fast/JSONTestSuite behavior.

## Results

- JSON::Fast suite: **3/14 → 5/14 files** — `01-parse.t` (724 tests) and `10-multidocument.t` now fully pass; `03-unicode.t` abort resolved (8-abort → 11/14 run).
- No regressions: `make test` 18275 PASS; E2E module sweep (`tmp/e2e-suites.sh`) unchanged — JSON::Unmarshal / Marshal / Class, META6, License::SPDX, URI, Test::META all PASS; roast pin `S32-exceptions/misc.t` (BlockGobbled) PASS.

## Tests

- `t/json-additional-content.t` — multi-document resume loop + attribute semantics
- `t/json-strict-parse.t` — surrogate pairs, lone-surrogate/escape/control-char rejection, number grammar

🤖 Generated with [Claude Code](https://claude.com/claude-code)