### PR TITLE
feat: RakuAST slice 17 — typed positional parameters in .AST and EVAL

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -949,9 +949,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 16: interpolated strings `"a $x b"` (both directions) — `Expr::StringInterpolation` ↔ a
         `QuotedString` with a `StrLiteral`/interpolated-term segment per part. `EVAL(Q[my $x=5;
         "val=$x"].AST)` → `val=5`. Tests in `t/rakuast-eval-interp.t`.
-  - [ ] Slice 17+: typed/named/slurpy params (need read + write), C-style `loop`, code-block (`{…}`)
-        interpolation — the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full
-        lowering is a large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 17: typed positional parameters `Int $x` (both directions) — read emits `type =>
+        Type::Simple(Name)`, write extracts it into the `ParamDef` `type_constraint`; `EVAL(Q[sub f(Int
+        $x) { $x*2 }; f(5)].AST)` → 10, a mismatch throws. Tests in `t/rakuast-eval-typed-param.t`.
+  - [ ] Slice 18+: more infix operators (`x`/`xx`/`eq`/`ne`/…), named/slurpy params, C-style `loop`,
+        code-block (`{…}`) interpolation — the inverse of the Phase-2 converter, grown cluster by
+        cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -277,6 +277,14 @@ earlier ones.
     lowers a multi-segment `QuotedString` back to a `StringInterpolation`. `EVAL(Q[my $x = 5;
     "val=$x"].AST)` → `val=5`. Code-block (`{…}`) interpolation stays the boundary. Tests in
     `t/rakuast-eval-interp.t`. Next: typed/named parameters, C-style `loop`.
+  - **Slice 17 (typed positional parameters) — done, both directions.** A `Parameter` with an explicit
+    type (`Int $x`) now carries `type => Type::Simple(Name)` (replacing the implicit
+    `Type::Setting(Any)`) on the read side, and the write side extracts a `Type::Simple` name into the
+    `ParamDef`'s `type_constraint` (the implicit `Type::Setting` is ignored; definite/coercion/
+    parameterised type forms defer). `EVAL(Q[sub f(Int $x) { $x * 2 }; f(5)].AST)` → `10`; a type
+    mismatch throws, and a typed parameter can also carry a default. Tests in
+    `t/rakuast-eval-typed-param.t`. Next: named/slurpy parameters, more infix operators (`x`/`eq`/…),
+    C-style `loop`.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -1163,7 +1163,7 @@ fn pointy_block_from_lambda(param: &str, body: &[Stmt]) -> Result<RakuAstNode, R
         fields: vec![RakuAstField {
             name: Some("parameters"),
             value: RakuAstFieldValue::List(vec![Value::rakuast(Box::new(simple_parameter(
-                "$", param, None, false,
+                "$", param, None, None, false,
             )?))]),
         }],
     };
@@ -1218,7 +1218,6 @@ fn parameter(pd: &ParamDef, type_setting: bool) -> Result<RakuAstNode, RuntimeEr
         || pd.slurpy
         || pd.double_slurpy
         || pd.onearg
-        || pd.type_constraint.is_some()
         || pd.literal_value.is_some()
         || pd.sub_signature.is_some()
         || pd.where_constraint.is_some()
@@ -1232,7 +1231,13 @@ fn parameter(pd: &ParamDef, type_setting: bool) -> Result<RakuAstNode, RuntimeEr
         return Err(unsupported("non-trivial signature parameter"));
     }
     let (sigil, desigil) = split_sigil(&pd.name);
-    simple_parameter(sigil, desigil, pd.default.as_ref(), type_setting)
+    simple_parameter(
+        sigil,
+        desigil,
+        pd.type_constraint.as_deref(),
+        pd.default.as_ref(),
+        type_setting,
+    )
 }
 
 /// `Type::Setting.new(Name.from-identifier("Any"))` — the implicit default type
@@ -1254,6 +1259,7 @@ fn type_setting_any() -> RakuAstNode {
 fn simple_parameter(
     sigil: &str,
     desigil: &str,
+    type_constraint: Option<&str>,
     default: Option<&Expr>,
     type_setting: bool,
 ) -> Result<RakuAstNode, RuntimeError> {
@@ -1265,8 +1271,12 @@ fn simple_parameter(
         )],
     };
     let mut fields = Vec::new();
-    if type_setting {
-        fields.push(node_field(Some("type"), type_setting_any()));
+    // An explicit type constraint (`Int $x`) replaces the implicit
+    // `Type::Setting(Any)` that untyped sub/method params carry.
+    match type_constraint {
+        Some(tc) => fields.push(node_field(Some("type"), build_type_node(tc)?)),
+        None if type_setting => fields.push(node_field(Some("type"), type_setting_any())),
+        None => {}
     }
     fields.push(node_field(Some("target"), target));
     match default {

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -235,6 +235,29 @@ fn signature_positional_params(
         let raw = leaf_str(target, "name")?;
         let name = raw.strip_prefix('$').map(str::to_string).unwrap_or(raw);
         let mut def = positional_param(&name);
+        // `Int $x` -> a type constraint. `Type::Simple` (a plain type name) is
+        // handled; the implicit `Type::Setting(Any)` on an untyped param is
+        // ignored, and richer type forms (definite/coercion/parameterised) defer.
+        if let Some(t) = p.fields.iter().find(|f| f.name == Some("type")) {
+            if let RakuAstFieldValue::Node(val) = &t.value
+                && let ValueView::RakuAst(type_node) = val.view()
+            {
+                match type_node.class {
+                    RakuAstClass::TypeSimple => {
+                        let name_node = named_child_or_positional(type_node)?;
+                        if let ValueView::Str(s) = positional_leaf(name_node)?.view() {
+                            def.type_constraint = Some(s.to_string());
+                        } else {
+                            return Err(unsupported(node));
+                        }
+                    }
+                    RakuAstClass::TypeSetting => {} // implicit `Any`
+                    _ => return Err(unsupported(node)),
+                }
+            } else {
+                return Err(unsupported(node));
+            }
+        }
         // `$y = EXPR` -> an optional positional with a default value.
         if let Some(d) = p.fields.iter().find(|f| f.name == Some("default")) {
             let default_node = match &d.value {

--- a/t/rakuast-eval-typed-param.t
+++ b/t/rakuast-eval-typed-param.t
@@ -1,0 +1,33 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 17 (ADR-0011): typed positional parameters `Int $x`, both
+# directions. A `Parameter` carrying a `type => Type::Simple(Name)` lowers to a
+# `ParamDef` with that type constraint (and the read side emits it). Verified
+# against Rakudo; passes under BOTH mutsu and raku.
+
+plan 5;
+
+# --- read side: the gist has the Type::Simple constraint --------------------
+my $g = Q[sub f(Int $x) { $x }].AST.gist;
+ok $g.contains('RakuAST::Type::Simple.new(')
+    && $g.contains('RakuAST::Name.from-identifier("Int")'),
+    'a typed parameter renders with a Type::Simple';
+
+# --- a typed parameter is accepted and used --------------------------------
+is EVAL(Q[sub f(Int $x) { $x * 2 }; f(5)].AST), 10,
+    'a typed Int parameter is bound and used';
+
+# --- two typed parameters of different types --------------------------------
+is EVAL(Q[sub g(Int $x, Str $s) { $s ~ $x }; g(3, "n=")].AST), 'n=3',
+    'two typed parameters of different types';
+
+# --- a typed parameter with a default ---------------------------------------
+is EVAL(Q[sub h(Int $x, Int $y = 10) { $x + $y }; h(5)].AST), 15,
+    'a typed parameter can also carry a default';
+
+# --- a type mismatch is rejected --------------------------------------------
+throws-like { EVAL(Q[sub f(Int $x) { $x }; f("hi")].AST) }, Exception,
+    'passing the wrong type throws';


### PR DESCRIPTION
## Summary

RakuAST slice 17 (ADR-0011): typed positional parameters `Int $x` in **both directions**.

A signature parameter with an explicit type carries `type => Type::Simple(Name)` (replacing the implicit `Type::Setting(Any)`):

```raku
Q[sub f(Int $x) { $x }].AST   # ... Parameter(type => Type::Simple(Name("Int")), target => ...)
```

- **Read (`.AST`, Phase 2):** `simple_parameter` takes the type name and builds the node via `build_type_node`, so definite/coercion/parameterised forms compose too.
- **Write (`EVAL`, Phase 5):** `signature_positional_params` extracts a `Type::Simple` name into the `ParamDef`'s `type_constraint` (the implicit `Type::Setting(Any)` is ignored; other type forms defer).

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[sub f(Int $x) { $x * 2 }; f(5)].AST)                 # 10
EVAL(Q[sub h(Int $x, Int $y = 10) { $x + $y }; h(5)].AST)   # 15
EVAL(Q[sub f(Int $x) { $x }; f("hi")].AST)                  # throws (type mismatch)
```

## Tests

`t/rakuast-eval-typed-param.t` — 5 assertions (read-side gist has Type::Simple, a typed Int param, two typed params of different types, typed+default, a type-mismatch throws), **passing under BOTH mutsu and raku**. The read-side gist is byte-identical to Rakudo's. All 55 `t/rakuast-*.t` files (246 tests) still green.

Next: more infix operators (`x`/`eq`/…), named/slurpy params, C-style `loop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)