### PR TITLE
feat: RakuAST Phase 5 slice 18 — EVAL of named infix operators

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -952,9 +952,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 17: typed positional parameters `Int $x` (both directions) — read emits `type =>
         Type::Simple(Name)`, write extracts it into the `ParamDef` `type_constraint`; `EVAL(Q[sub f(Int
         $x) { $x*2 }; f(5)].AST)` → 10, a mismatch throws. Tests in `t/rakuast-eval-typed-param.t`.
-  - [ ] Slice 18+: more infix operators (`x`/`xx`/`eq`/`ne`/…), named/slurpy params, C-style `loop`,
-        code-block (`{…}`) interpolation — the inverse of the Phase-2 converter, grown cluster by
-        cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 18: named infix operators — the write side maps `~~` → `SmartMatch` and any other
+        operator name → the generic `Ident` token, so `x`/`xx`/`eq`/`ne`/`lt`/`gt`/`cmp`/… all lower.
+        `EVAL(Q["ab" x 3].AST)` → `ababab`. Tests in `t/rakuast-eval-named-infix.t`.
+  - [ ] Slice 19+: bareword type terms (`Int` as a value/smartmatch RHS), named/slurpy params, C-style
+        `loop`, code-block (`{…}`) interpolation — the inverse of the Phase-2 converter, grown cluster
+        by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -285,6 +285,13 @@ earlier ones.
     mismatch throws, and a typed parameter can also carry a default. Tests in
     `t/rakuast-eval-typed-param.t`. Next: named/slurpy parameters, more infix operators (`x`/`eq`/…),
     C-style `loop`.
+  - **Slice 18 (named infix operators) — done.** The read side already renders `$a x $b` as
+    `Infix.new("x")`; the write side now maps `~~` to `SmartMatch` and any other operator name to
+    mutsu's generic `Ident` token (the inverse of `token_kind_to_op_name`'s `Ident(name) => name`), so
+    `x`/`xx`/`eq`/`ne`/`lt`/`gt`/`le`/`ge`/`cmp`/`leg`/`div`/`mod`/… all lower at once.
+    `EVAL(Q["ab" x 3].AST)` → `ababab`; `EVAL(Q[my $x = 5; $x ~~ 5].AST)` → `True`. Bareword type terms
+    (`Int` as a smartmatch RHS) stay the boundary. Tests in `t/rakuast-eval-named-infix.t`. Next:
+    bareword type terms, named/slurpy parameters, C-style `loop`.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/compiler/helpers_ops.rs
+++ b/src/compiler/helpers_ops.rs
@@ -108,6 +108,11 @@ pub(crate) fn op_name_to_token_kind(name: &str) -> Option<TokenKind> {
         // spelling (`-`/`+`/`~`) already map above.
         "!" => TokenKind::Bang,
         "?" => TokenKind::Question,
-        _ => return None,
+        "~~" => TokenKind::SmartMatch,
+        // Any remaining operator name is a named infix (`x`, `xx`, `eq`, `ne`,
+        // `lt`/`gt`/`le`/`ge`, `cmp`, `leg`, `div`, `mod`, ...), which mutsu
+        // represents with a generic `Ident` token (the inverse of
+        // `token_kind_to_op_name`'s `Ident(name) => name`).
+        name => TokenKind::Ident(name.to_string()),
     })
 }

--- a/t/rakuast-eval-named-infix.t
+++ b/t/rakuast-eval-named-infix.t
@@ -1,0 +1,31 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 5 slice 18 (ADR-0011): EVAL of named infix operators.
+# raku already renders `$a x $b` as `Infix.new("x")`; the write side now maps any
+# named infix (`x`/`xx`/`eq`/`ne`/`lt`/`gt`/`cmp`/...) back to its generic `Ident`
+# token, plus `~~` to `SmartMatch`. Verified against Rakudo; passes under BOTH
+# mutsu and raku.
+
+plan 7;
+
+# --- string repetition (x) --------------------------------------------------
+is EVAL(Q["ab" x 3].AST), 'ababab', 'x repeats a string';
+
+# --- list repetition (xx) ---------------------------------------------------
+is EVAL(Q[(1 xx 3).elems].AST), 3, 'xx repeats into a list';
+
+# --- string equality (eq / ne) ----------------------------------------------
+is EVAL(Q["a" eq "a"].AST), True, 'eq compares strings for equality';
+is EVAL(Q["a" ne "b"].AST), True, 'ne compares strings for inequality';
+
+# --- string ordering (lt) ---------------------------------------------------
+is EVAL(Q["a" lt "b"].AST), True, 'lt orders strings';
+
+# --- three-way compare (cmp) ------------------------------------------------
+is EVAL(Q[(3 cmp 5).Str].AST), 'Less', 'cmp yields an Order';
+
+# --- smartmatch against a value (~~) ----------------------------------------
+is EVAL(Q[my $x = 5; $x ~~ 5].AST), True, '~~ smartmatches against a value';


### PR DESCRIPTION
## Summary

Phase 5 slice 18 of RakuAST (ADR-0011): `EVAL` of named infix operators.

The read side already renders a named infix `$a x $b` as `Infix.new("x")`. This slice closes the write-side gap: `op_name_to_token_kind` now maps `~~` to `SmartMatch` and falls back to mutsu's generic `Ident` token for any other operator name (the inverse of `token_kind_to_op_name`'s `Ident(name) => name`), so `x`/`xx`/`eq`/`ne`/`lt`/`gt`/`le`/`ge`/`cmp`/`leg`/`div`/`mod`/… all lower at once.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q["ab" x 3].AST)              # "ababab"
EVAL(Q["a" lt "b"].AST)           # True
EVAL(Q[(3 cmp 5).Str].AST)        # "Less"
EVAL(Q[my $x = 5; $x ~~ 5].AST)   # True
```

That function is used solely by the lowerer, and every prefix operator is mapped explicitly above the fallback, so the `Ident` fallback only ever applies to named infixes. Bareword type terms (`Int` as a smartmatch RHS) stay the coverage boundary.

## Tests

`t/rakuast-eval-named-infix.t` — 7 assertions (`x`, `xx`, `eq`, `ne`, `lt`, `cmp`, `~~`), **passing under BOTH mutsu and raku**. All 56 `t/rakuast-*.t` files (253 tests) still green.

Next: bareword type terms, named/slurpy parameters, C-style `loop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)