### PR TITLE
feat(json): JSON::Fast option parity — :immutable, :enums-as-value, NaN/Inf, import defaults, code-object dispatch

### DIFF
--- a/docs/mzef-install-pipeline.md
+++ b/docs/mzef-install-pipeline.md
@@ -221,13 +221,17 @@ JSON::Unmarshal (11 files / 101 tests), JSON::Marshal (14/85), JSON::Class
 (6/31), URI (14/222), META6 (9/969), License::SPDX (2/729), Test::META
 (3/26, #4756). FAIL: **JSON::Fast** only (native-JSON fidelity remnants;
 full parity is likely unnecessary for the pipeline). Within JSON::Fast,
-the X::JSON::AdditionalContent + strict string/number grammar PR brought
-`01-parse.t` (724 tests) and `10-multidocument.t` to full pass — 5/14
-files green (01, 06, 08, 09, 10); remaining: 02-structure (8/20),
-03-unicode (aborts at 11/14), 04-roundtrip (2/56), 05-unreasonable (3/7),
-07-datetime (`augment class DateTime`), 11-enum (6/16),
-12-assocpositional, 13-scopes (3/8), 14-comments (JSONC). Test-Helpers
-ships no `t/` of its own (covered by mutsu's local `t/test-util-*.t`).
+two PRs (#4762 AdditionalContent + strict grammar; the options-parity PR:
+`:immutable`/List+Map decode, `:enums-as-value`, `$*JSON_NAN_INF_SUPPORT`,
+import-list defaults `<immutable !pretty>`, `&from-json`/`.&from-json`
+code-object dispatch, uppercase surrogate escapes, Duration-as-Num)
+brought the suite from 3/14 to **10/14 files green**; remaining:
+04-roundtrip (1 fail: `Rational[Int,Int].new(3,10)` — role type-params
+`::NuT = Int` unresolved in method signatures, a general parametric-role
+bug), 07-datetime (`augment class DateTime`), 12-assocpositional
+(Positional+Associative instance serialization), 14-comments (JSONC).
+Test-Helpers ships no `t/` of its own (covered by mutsu's local
+`t/test-util-*.t`).
 
 The #4747 session's two generic fixes (License::SPDX 0/2 → 2/2): a trait
 argument with whitespace after the opening paren

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3036,13 +3036,32 @@ impl Compiler {
                 module,
                 tags,
                 condition,
-                ..
+                arg,
             } => {
                 let name_idx = self.code.add_constant(Value::str(module.clone()));
-                let tags_idx = if tags.is_empty() {
+                // The native JSON modules read their import list at run time to
+                // select per-scope defaults (`use JSON::Fast <immutable !pretty>`).
+                // The angle-list words parse into `arg`, not `tags`; ride them in
+                // the same tags constant (unused otherwise for native modules).
+                let mut entries = tags.iter().cloned().map(Value::str).collect::<Vec<Value>>();
+                if matches!(module.as_str(), "JSON::Fast" | "JSON::Tiny")
+                    && let Some(arg) = arg
+                {
+                    let words: &[Expr] = match arg {
+                        Expr::ArrayLiteral(items) => items,
+                        other => std::slice::from_ref(other),
+                    };
+                    for w in words {
+                        if let Expr::Literal(lit) = w
+                            && let ValueView::Str(s) = lit.view()
+                        {
+                            entries.push(Value::str(s.to_string()));
+                        }
+                    }
+                }
+                let tags_idx = if entries.is_empty() {
                     None
                 } else {
-                    let entries = tags.iter().cloned().map(Value::str).collect::<Vec<Value>>();
                     Some(self.code.add_constant(Value::array(entries)))
                 };
                 // `use Foo:if(EXPR)` (the `if` pragma): load the module only when

--- a/src/runtime/accessors_resolve.rs
+++ b/src/runtime/accessors_resolve.rs
@@ -346,6 +346,11 @@ impl Interpreter {
             // values so `my &fn = &is-deeply; fn(...)` dispatches through the
             // Routine call path, which routes test names to the Test dispatcher.
             Value::routine_parts(Symbol::intern("GLOBAL"), Symbol::intern(lookup_name), false)
+        } else if self.json_module_loaded() && matches!(lookup_name, "to-json" | "from-json") {
+            // Native JSON routines (runtime/json.rs) have no declared sub either;
+            // expose them as Routines so `&from-json` / `$str.&from-json` work.
+            // The Routine call path falls through to try_native_json_function.
+            Value::routine_parts(Symbol::intern("GLOBAL"), Symbol::intern(lookup_name), false)
         } else if bare_name.starts_with('*') {
             // Dynamic code vars (&*foo) can point to routines that are resolved
             // at call time (including builtins not listed in is_builtin_function).

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -824,6 +824,13 @@ impl Interpreter {
             return self.call_function(short_name, args.to_vec());
         }
 
+        // Native JSON routines invoked as code objects (`&from-json`,
+        // `$str.&from-json`) reach this generic fallback — they have no
+        // declared sub for the resolver above to find.
+        if let Some(result) = self.try_native_json_function(name, args) {
+            return result;
+        }
+
         let suggestions = self.suggest_routine_names(name);
         Err(RuntimeError::undeclared_routine_symbols(
             name,

--- a/src/runtime/json.rs
+++ b/src/runtime/json.rs
@@ -20,6 +20,11 @@ pub(crate) struct ToJsonOpts {
     pub pretty: bool,
     pub sorted_keys: bool,
     pub spacing: usize,
+    /// `:enums-as-value` — serialize enum values as their underlying payload
+    /// (`0` / `"Eins"`) instead of their short name.
+    pub enums_as_value: bool,
+    /// `$*JSON_NAN_INF_SUPPORT` — emit `NaN`/`Inf`/`-Inf` instead of `null`.
+    pub nan_inf_support: bool,
 }
 
 impl Default for ToJsonOpts {
@@ -28,7 +33,46 @@ impl Default for ToJsonOpts {
             pretty: true,
             sorted_keys: false,
             spacing: 2,
+            enums_as_value: false,
+            nan_inf_support: false,
         }
+    }
+}
+
+/// Per-`use` defaults selected by the import list of the native JSON modules
+/// (`use JSON::Fast <immutable !pretty sorted-keys>`). Rakudo scopes these
+/// lexically (the list picks which candidates are exported into the using
+/// scope); mutsu executes `use` at run time, so the latest `use` wins — which
+/// matches straight-line block-sequential usage.
+// TODO: model true lexical scoping if a real-world module needs interleaved
+// scopes with different JSON defaults.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct JsonImportDefaults {
+    pub immutable: bool,
+    pub not_pretty: bool,
+    pub sorted_keys: bool,
+    pub enums_as_value: bool,
+}
+
+impl JsonImportDefaults {
+    /// Parse import-list words (`immutable`, `!pretty`, ...) into defaults.
+    /// Unknown words are ignored (JSON::Fast also exports sub names there).
+    pub(crate) fn from_import_words(words: &[String]) -> Self {
+        let mut d = JsonImportDefaults::default();
+        for w in words {
+            let (name, on) = match w.strip_prefix('!') {
+                Some(rest) => (rest, false),
+                None => (w.as_str(), true),
+            };
+            match name {
+                "immutable" => d.immutable = on,
+                "pretty" => d.not_pretty = !on,
+                "sorted-keys" => d.sorted_keys = on,
+                "enums-as-value" => d.enums_as_value = on,
+                _ => {}
+            }
+        }
+        d
     }
 }
 
@@ -63,8 +107,18 @@ fn jsonify(val: &Value, opts: &ToJsonOpts, level: usize, out: &mut String) {
         ValueView::Num(f) => {
             if f.is_nan() || f.is_infinite() {
                 // JSON has no NaN/Inf; JSON::Fast emits `null` unless the dynamic
-                // var $*JSON_NAN_INF_SUPPORT is set (which mutsu does not model).
-                out.push_str("null");
+                // var $*JSON_NAN_INF_SUPPORT is set.
+                if opts.nan_inf_support {
+                    out.push_str(if f.is_nan() {
+                        "NaN"
+                    } else if f > 0.0 {
+                        "Inf"
+                    } else {
+                        "-Inf"
+                    });
+                } else {
+                    out.push_str("null");
+                }
             } else {
                 let s = val.to_string_value();
                 out.push_str(&s);
@@ -95,6 +149,31 @@ fn jsonify(val: &Value, opts: &ToJsonOpts, level: usize, out: &mut String) {
         ValueView::ValuePair(k, v) => {
             let key = k.to_string_value();
             jsonify_object(vec![(&key, v)], opts, level, out);
+        }
+        // Enum values: short name by default, underlying payload with
+        // `:enums-as-value` (JSON::Fast semantics).
+        ValueView::Enum { key, value, .. } => {
+            if opts.enums_as_value {
+                jsonify(&value.to_value(), opts, level, out);
+            } else {
+                out.push('"');
+                escape_str(&key.resolve(), out);
+                out.push('"');
+            }
+        }
+        // Duration is Real (a Rat-backed instance: `value` attr); JSON::Fast's
+        // Real:D candidate serializes it numerically as a Num (`57e0`).
+        ValueView::Instance {
+            class_name,
+            attributes,
+            ..
+        } if class_name.resolve() == "Duration" => {
+            let num = attributes
+                .as_map()
+                .get("value")
+                .map(|v| v.to_f64())
+                .unwrap_or(0.0);
+            jsonify(&Value::num(num), opts, level, out);
         }
         // Type objects / undefined values render as JSON null.
         ValueView::Nil | ValueView::Package(_) | ValueView::Whatever | ValueView::HyperWhatever => {
@@ -205,10 +284,12 @@ fn escape_str(s: &str, out: &mut String) {
                 out.push_str(&format!("\\u{:04x}", c as u32));
             }
             c if (c as u32) >= 0x10000 => {
+                // JSON::Fast's to-surrogate-pair uses .base(16): UPPERCASE hex
+                // (control-char escapes above stay lowercase, fmt "\u%04x").
                 let cp = c as u32 - 0x10000;
                 let hi = 0xD800 + (cp >> 10);
                 let lo = 0xDC00 + (cp & 0x3FF);
-                out.push_str(&format!("\\u{:04x}\\u{:04x}", hi, lo));
+                out.push_str(&format!("\\u{:04X}\\u{:04X}", hi, lo));
             }
             c => out.push(c),
         }
@@ -228,12 +309,14 @@ pub(crate) enum FromJsonError {
     },
 }
 
-/// Parse a JSON string into a `Value`.
-pub(crate) fn from_json(text: &str) -> Result<Value, FromJsonError> {
+/// Parse a JSON string into a `Value`. With `immutable`, arrays decode as
+/// `List` and objects as `Map` (JSON::Fast `:immutable`).
+pub(crate) fn from_json(text: &str, immutable: bool) -> Result<Value, FromJsonError> {
     let mut p = Parser {
         bytes: text.as_bytes(),
         chars: text,
         pos: 0,
+        immutable,
     };
     p.skip_ws();
     let value = p.parse_value().map_err(FromJsonError::Parse)?;
@@ -253,9 +336,35 @@ struct Parser<'a> {
     bytes: &'a [u8],
     chars: &'a str,
     pos: usize,
+    immutable: bool,
 }
 
 impl<'a> Parser<'a> {
+    /// Wrap a decoded JSON object: mutable `Hash` by default, `Map` with
+    /// `:immutable` (a Hash whose `declared_type` is "Map", mutsu's Map repr).
+    fn finish_object(&self, map: HashMap<String, Value>) -> Value {
+        if self.immutable {
+            let mut data: crate::value::HashData = map.into();
+            data.declared_type = Some("Map".to_string());
+            Value::hash_with_data(crate::gc::Gc::new(data))
+        } else {
+            Value::hash_with_data(Value::hash_arc(map))
+        }
+    }
+
+    /// Wrap a decoded JSON array: mutable `Array` by default, `List` with
+    /// `:immutable`.
+    fn finish_array(&self, items: Vec<Value>) -> Value {
+        if self.immutable {
+            Value::array_with_kind(
+                crate::gc::Gc::new(crate::value::ArrayData::new(items)),
+                crate::value::ArrayKind::List,
+            )
+        } else {
+            Value::real_array(items)
+        }
+    }
+
     fn skip_ws(&mut self) {
         while self.pos < self.bytes.len() {
             match self.bytes[self.pos] {
@@ -301,7 +410,7 @@ impl<'a> Parser<'a> {
         self.skip_ws();
         if self.peek() == Some(b'}') {
             self.pos += 1;
-            return Ok(Value::hash_with_data(Value::hash_arc(map)));
+            return Ok(self.finish_object(map));
         }
         loop {
             self.skip_ws();
@@ -323,7 +432,7 @@ impl<'a> Parser<'a> {
                 }
                 Some(b'}') => {
                     self.pos += 1;
-                    return Ok(Value::hash_with_data(Value::hash_arc(map)));
+                    return Ok(self.finish_object(map));
                 }
                 _ => return Err("Expected ',' or '}' in JSON object".to_string()),
             }
@@ -336,7 +445,7 @@ impl<'a> Parser<'a> {
         self.skip_ws();
         if self.peek() == Some(b']') {
             self.pos += 1;
-            return Ok(Value::real_array(items));
+            return Ok(self.finish_array(items));
         }
         loop {
             let val = self.parse_value()?;
@@ -348,7 +457,7 @@ impl<'a> Parser<'a> {
                 }
                 Some(b']') => {
                     self.pos += 1;
-                    return Ok(Value::real_array(items));
+                    return Ok(self.finish_array(items));
                 }
                 _ => return Err("Expected ',' or ']' in JSON array".to_string()),
             }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1713,6 +1713,9 @@ pub struct Interpreter {
     precomp_enabled: bool,
     /// When true, `augment class` is allowed (set by `use MONKEY-TYPING` or `use MONKEY`).
     monkey_typing: bool,
+    /// Defaults selected by the import list of the latest
+    /// `use JSON::Fast <...>` / `use JSON::Tiny` (see `runtime/json.rs`).
+    pub(crate) json_import_defaults: crate::runtime::json::JsonImportDefaults,
 
     // === Merged VM execution registers (CP-3 collapse: the bytecode VM was
     // dissolved into the Interpreter; these were the per-execution fields of the

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2150,6 +2150,7 @@ impl Interpreter {
             pending_regex_error: None,
             precomp_enabled: true,
             monkey_typing: false,
+            json_import_defaults: crate::runtime::json::JsonImportDefaults::default(),
 
             // Merged VM execution registers (CP-3 collapse) — same defaults the
             // former `VM::new` installed.

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -108,6 +108,14 @@ impl Interpreter {
         module: &str,
         tags: &[String],
     ) -> Result<(), RuntimeError> {
+        // Native JSON modules: the import list selects per-scope defaults
+        // (`use JSON::Fast <immutable !pretty>`). Every `use` re-selects them —
+        // including re-uses of the already-loaded module below — so this must
+        // run before the loaded_modules early return.
+        if matches!(module, "JSON::Fast" | "JSON::Tiny") {
+            self.json_import_defaults =
+                crate::runtime::json::JsonImportDefaults::from_import_words(tags);
+        }
         if self.loaded_modules.contains(module) {
             if module == "strict" {
                 self.strict_mode = true;

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -344,6 +344,7 @@ impl Interpreter {
             pending_regex_error: None,
             precomp_enabled: self.precomp_enabled,
             monkey_typing: self.monkey_typing,
+            json_import_defaults: self.json_import_defaults,
 
             // Merged VM execution registers (CP-3 collapse): a thread clone starts
             // with fresh per-execution registers, exactly as the former

--- a/src/vm/vm_native_json.rs
+++ b/src/vm/vm_native_json.rs
@@ -36,9 +36,30 @@ impl Interpreter {
             .map(crate::runtime::types::unwrap_varref_value)
             .collect();
         match name {
-            "to-json" => Some(native_to_json(&clean_args)),
-            "from-json" => Some(native_from_json(&clean_args)),
+            "to-json" => Some(native_to_json(&clean_args, self.base_to_json_opts())),
+            "from-json" => Some(native_from_json(
+                &clean_args,
+                self.json_import_defaults.immutable,
+            )),
             _ => None,
+        }
+    }
+
+    /// Base `to-json` options for this call site: the import-list defaults of
+    /// the latest `use JSON::Fast <...>`, plus the `$*JSON_NAN_INF_SUPPORT`
+    /// dynamic variable. Explicit named args override these in
+    /// `native_to_json`.
+    fn base_to_json_opts(&self) -> ToJsonOpts {
+        let d = self.json_import_defaults;
+        ToJsonOpts {
+            pretty: !d.not_pretty,
+            sorted_keys: d.sorted_keys,
+            enums_as_value: d.enums_as_value,
+            nan_inf_support: self
+                .get_dynamic_var("*JSON_NAN_INF_SUPPORT")
+                .map(|v| v.truthy())
+                .unwrap_or(false),
+            ..ToJsonOpts::default()
         }
     }
 
@@ -65,15 +86,15 @@ impl Interpreter {
         }
         let (clean_args, _) = self.sanitize_call_args(args);
         Some(match method {
-            "to-json" => native_to_json(&clean_args),
-            "from-json" => native_from_json(&clean_args),
+            "to-json" => native_to_json(&clean_args, self.base_to_json_opts()),
+            "from-json" => native_from_json(&clean_args, self.json_import_defaults.immutable),
             _ => unreachable!(),
         })
     }
 }
 
-fn native_to_json(args: &[Value]) -> Result<Value, RuntimeError> {
-    let mut opts = ToJsonOpts::default();
+fn native_to_json(args: &[Value], base_opts: ToJsonOpts) -> Result<Value, RuntimeError> {
+    let mut opts = base_opts;
     let mut subject: Option<&Value> = None;
     for arg in args {
         match arg.view() {
@@ -93,6 +114,7 @@ fn apply_to_json_named(opts: &mut ToJsonOpts, name: &str, val: &Value) {
     match name {
         "pretty" => opts.pretty = val.truthy(),
         "sorted-keys" => opts.sorted_keys = val.truthy(),
+        "enums-as-value" => opts.enums_as_value = val.truthy(),
         "spacing" => {
             if let ValueView::Int(n) = val.view() {
                 opts.spacing = n.max(0) as usize;
@@ -102,13 +124,25 @@ fn apply_to_json_named(opts: &mut ToJsonOpts, name: &str, val: &Value) {
     }
 }
 
-fn native_from_json(args: &[Value]) -> Result<Value, RuntimeError> {
-    let text = args
-        .iter()
-        .find(|a| !matches!(a.view(), ValueView::Pair(..) | ValueView::ValuePair(..)))
-        .map(|v| v.to_string_value())
-        .unwrap_or_default();
-    json::from_json(&text).map_err(|e| match e {
+fn native_from_json(args: &[Value], default_immutable: bool) -> Result<Value, RuntimeError> {
+    let mut immutable = default_immutable;
+    let mut text = String::new();
+    let mut have_text = false;
+    for arg in args {
+        match arg.view() {
+            ValueView::Pair(name, val) if name == "immutable" => immutable = val.truthy(),
+            ValueView::ValuePair(key, val) if key.to_string_value() == "immutable" => {
+                immutable = val.truthy()
+            }
+            ValueView::Pair(..) | ValueView::ValuePair(..) => {}
+            _ if !have_text => {
+                text = arg.to_string_value();
+                have_text = true;
+            }
+            _ => {}
+        }
+    }
+    json::from_json(&text, immutable).map_err(|e| match e {
         json::FromJsonError::Parse(msg) => RuntimeError::new(msg),
         json::FromJsonError::AdditionalContent {
             parsed,

--- a/t/json-fast-options.t
+++ b/t/json-fast-options.t
@@ -1,0 +1,60 @@
+use v6;
+use Test;
+
+# JSON::Fast option parity in the native implementation:
+# :immutable, :enums-as-value, $*JSON_NAN_INF_SUPPORT, import-list defaults,
+# code-object dispatch (&from-json / .&from-json), uppercase surrogate escapes,
+# and Real-instance (Duration) serialization.
+
+{
+    use JSON::Fast <immutable !pretty>;
+
+    is to-json((1, 2, 3).List), "[1,2,3]", "import-list !pretty default";
+    is to-json((1, 2, 3).List, :pretty), "[\n  1,\n  2,\n  3\n]",
+        "named :pretty overrides import default";
+
+    is-deeply from-json("[1,2,3]"), (1, 2, 3).List,
+        "import-list immutable default decodes arrays as List";
+    is-deeply from-json("[1,2,3]", :!immutable), [1, 2, 3],
+        "named :!immutable overrides import default";
+}
+
+{
+    use JSON::Fast;
+
+    is to-json((1, 2, 3).List), "[\n  1,\n  2,\n  3\n]",
+        "plain use restores pretty default";
+    is-deeply from-json("[1,2,3]"), [1, 2, 3],
+        "plain use restores mutable default";
+    is-deeply from-json("[1,2,3]", :immutable), (1, 2, 3).List,
+        "named :immutable decodes arrays as List";
+    is-deeply from-json('{"a": 1}', :immutable), Map.new((a => 1)),
+        "named :immutable decodes objects as Map";
+
+    enum Bloop <Squee Moo Meep>;
+    is to-json(Moo), '"Moo"', "enum serializes as short name by default";
+    is to-json(Moo, :enums-as-value), '1', "enums-as-value uses the payload";
+    enum Blerp (One => "Eins");
+    is to-json(One, :enums-as-value), '"Eins"', "string-valued enum payload";
+
+    is to-json(Inf), "null", "Inf is null by default";
+    {
+        my $*JSON_NAN_INF_SUPPORT = 1;
+        is to-json(Inf), "Inf", 'dynamic var enables Inf';
+        is to-json(-Inf), "-Inf", 'dynamic var enables -Inf';
+        is to-json(NaN), "NaN", 'dynamic var enables NaN';
+    }
+
+    is '["x"]'.&from-json[0], "x", 'code-object .&from-json dispatches';
+    my &decode = &from-json;
+    is decode('[7]')[0], 7, '&from-json is a callable Routine';
+
+    # Astral chars escape as UPPERCASE surrogate pairs (JSON::Fast .base(16)).
+    is to-json("\x[1D11E]", :!pretty), '"' ~ 92.chr ~ 'uD834' ~ 92.chr ~ 'uDD1E"',
+        'surrogate pair escapes are uppercase';
+
+    is to-json(Duration.new(57), :!pretty), '57e0',
+        'Duration serializes as a Num';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

Second JSON::Fast-parity slice in the native JSON implementation (follow-up to #4762), driven by the JSON::Fast test suite — the last failing dist in the mzef test-phase E2E.

- **`:immutable`** on `from-json` decodes arrays as `List` and objects as `Map` (also available as an import default).
- **`:enums-as-value`** on `to-json` serializes enum values as their underlying payload (`0` / `"Eins"`); the short name stays the default via an explicit `Enum` arm.
- **`$*JSON_NAN_INF_SUPPORT`**: `to-json` emits `NaN`/`Inf`/`-Inf` instead of `null` when the dynamic var is set.
- **Import-list defaults**: `use JSON::Fast <immutable !pretty sorted-keys>` selects per-use defaults. The angle-list words ride the existing `UseModule` tags constant; the latest `use` wins (matches Rakudo's lexical scoping for straight-line block-sequential code; TODO recorded for true lexical modeling).
- **Code-object dispatch**: `&from-json` and `$str.&from-json` now work — `resolve_code_var` exposes the native JSON routines as Routines (same pattern as the native Test functions), and the generic call fallback routes them to `try_native_json_function`.
- **Uppercase surrogate escapes**: astral chars escape as `𝄞` (JSON::Fast uses `.base(16)`); control-char escapes stay lowercase (`fmt "\u%04x"`).
- **Duration** serializes numerically as a Num (`57e0`), matching JSON::Fast's `Real:D` candidate.

## Results

- JSON::Fast suite: **5/14 → 10/14 files green** (01–06, 08–11, 13). Remaining, recorded in `docs/mzef-install-pipeline.md`: 04-roundtrip (1 fail — `Rational[Int,Int].new(3,10)`, a general parametric-role type-param bug, next slice), 07-datetime (`augment class DateTime`), 12-assocpositional (Positional+Associative instance serialization), 14-comments (JSONC).
- No regressions: `make test` 18294 PASS; JSON::Unmarshal (101) / JSON::Marshal (85) / JSON::Class (31) E2E suites PASS.

## Tests

- `t/json-fast-options.t` — 19 assertions covering every item above

🤖 Generated with [Claude Code](https://claude.com/claude-code)