### PR TITLE
feat: RakuAST slice 19 — assignment expressions in .AST and EVAL

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -955,9 +955,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 18: named infix operators — the write side maps `~~` → `SmartMatch` and any other
         operator name → the generic `Ident` token, so `x`/`xx`/`eq`/`ne`/`lt`/`gt`/`cmp`/… all lower.
         `EVAL(Q["ab" x 3].AST)` → `ababab`. Tests in `t/rakuast-eval-named-infix.t`.
-  - [ ] Slice 19+: bareword type terms (`Int` as a value/smartmatch RHS), named/slurpy params, C-style
-        `loop`, code-block (`{…}`) interpolation — the inverse of the Phase-2 converter, grown cluster
-        by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 19: assignment expressions `$x = EXPR` in value position (both directions) — an
+        `AssignExpr` ↔ `ApplyInfix(Assignment)`; `EVAL(Q[my $a; my $b; $a = $b = 5; $a + $b].AST)` → 10.
+        Tests in `t/rakuast-eval-assign-expr.t`.
+  - [ ] Slice 20+: C-style `loop`, parenthesisation (`Circumfix::Parentheses`), bareword type terms,
+        named/slurpy params, code-block (`{…}`) interpolation — the inverse of the Phase-2 converter,
+        grown cluster by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -292,6 +292,13 @@ earlier ones.
     `EVAL(Q["ab" x 3].AST)` → `ababab`; `EVAL(Q[my $x = 5; $x ~~ 5].AST)` → `True`. Bareword type terms
     (`Int` as a smartmatch RHS) stay the boundary. Tests in `t/rakuast-eval-named-infix.t`. Next:
     bareword type terms, named/slurpy parameters, C-style `loop`.
+  - **Slice 19 (assignment expressions) — done, both directions.** An `AssignExpr` in value position
+    (e.g. the inner `$b = 5` of a chained `$a = $b = 5`) converts to the same `ApplyInfix(Assignment)`
+    as a statement assignment (reusing `assignment_infix`), and the write side lowers an
+    `ApplyInfix(Assignment)` in expression position back to an `AssignExpr` (a shared `lower_assign_parts`
+    backs both the statement and expression forms). `EVAL(Q[my $a; my $b; $a = $b = 5; $a + $b].AST)` →
+    `10`. Explicitly-parenthesised `($x = 5)` (a `Circumfix::Parentheses`) and `:=` binding stay the
+    boundary. Tests in `t/rakuast-eval-assign-expr.t`. Next: C-style `loop`, bareword type terms.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -763,6 +763,18 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
         Expr::Literal(v) | Expr::LiteralSrc(v, _) => convert_literal(v),
         Expr::Call { name, args } => Ok(call_name(name.as_str(), args, false)?),
         Expr::Var(name) => Ok(var_lexical("$", name)),
+        // `($x = EXPR)` as an expression -> the same `ApplyInfix(Assignment)` as a
+        // statement assignment. `:=` binding stays the boundary.
+        Expr::AssignExpr {
+            name,
+            expr,
+            is_bind,
+        } => {
+            if *is_bind {
+                return Err(unsupported("`:=` binding expression"));
+            }
+            assignment_infix(name, expr)
+        }
         Expr::ArrayVar(name) => Ok(var_lexical("@", name)),
         Expr::HashVar(name) => Ok(var_lexical("%", name)),
         Expr::CodeVar(name) => Ok(var_lexical("&", name)),

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -352,9 +352,10 @@ fn infix_is_assignment(node: &RakuAstNode) -> bool {
         .unwrap_or(false)
 }
 
-/// Lower `$x = EXPR` to `Stmt::Assign`. The `$` sigil is stripped (matching the
-/// parser's naming); `@`/`%`/`&` are kept.
-fn lower_assign(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+/// The `(name, right)` of an `ApplyInfix(Assignment)`: the target variable name
+/// (`$` sigil stripped to match the parser's naming; `@`/`%`/`&` kept) and the
+/// lowered right-hand side.
+fn lower_assign_parts(node: &RakuAstNode) -> Result<(String, Expr), RuntimeError> {
     let left = named_child(node, "left")?;
     if left.class != RakuAstClass::VarLexical {
         return Err(unsupported(node));
@@ -368,6 +369,12 @@ fn lower_assign(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         None => raw,
     };
     let expr = lower_expr(named_child(node, "right")?)?;
+    Ok((name, expr))
+}
+
+/// Lower `$x = EXPR` (statement position) to `Stmt::Assign`.
+fn lower_assign(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    let (name, expr) = lower_assign_parts(node)?;
     Ok(Stmt::Assign {
         name,
         expr,
@@ -519,6 +526,15 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
                 "%" => Expr::HashVar(bare.to_string()),
                 "&" => Expr::CodeVar(bare.to_string()),
                 _ => Expr::Var(bare.to_string()),
+            })
+        }
+        // `($x = EXPR)` in expression position -> an assignment expression.
+        RakuAstClass::ApplyInfix if infix_is_assignment(node) => {
+            let (name, expr) = lower_assign_parts(node)?;
+            Ok(Expr::AssignExpr {
+                name,
+                expr: Box::new(expr),
+                is_bind: false,
             })
         }
         RakuAstClass::ApplyInfix => {

--- a/t/rakuast-eval-assign-expr.t
+++ b/t/rakuast-eval-assign-expr.t
@@ -1,0 +1,31 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 19 (ADR-0011): assignment expressions `$x = EXPR` in value
+# position, both directions. mutsu's `AssignExpr` (e.g. the inner `$b = 5` of a
+# chained assignment `$a = $b = 5`) converts to the same `ApplyInfix(Assignment)`
+# as a statement assignment, and the write side lowers such an `ApplyInfix` in
+# expression position back to an `AssignExpr`. Verified against Rakudo; passes
+# under BOTH mutsu and raku.
+
+plan 4;
+
+# --- read side: a chained assignment round-trips through the gist ------------
+my $g = Q[my $a; my $b; $a = $b = 5].AST.gist;
+ok $g.contains('RakuAST::Assignment.new(:item)')
+    && ($g.indices('RakuAST::Assignment.new(:item)').elems == 2),
+    'a chained assignment renders two Assignment infixes';
+
+# --- a chained assignment sets both variables -------------------------------
+is EVAL(Q[my $a; my $b; $a = $b = 5; $a + $b].AST), 10,
+    'chained assignment sets both variables';
+
+# --- a longer chain ---------------------------------------------------------
+is EVAL(Q[my $a; my $b; my $c; $a = $b = $c = 7; $a + $b + $c].AST), 21,
+    'a three-deep assignment chain';
+
+# --- the assigned expression is evaluated once ------------------------------
+is EVAL(Q[my $a; my $b; $a = $b = 3 + 4; $a * $b].AST), 49,
+    'the chained value is a full expression';


### PR DESCRIPTION
## Summary

RakuAST slice 19 (ADR-0011): assignment expressions `$x = EXPR` in value position, **both directions**.

An assignment used as a value (`AssignExpr` — e.g. the inner `$b = 5` of a chained `$a = $b = 5`) is now covered:

- **Read (`.AST`, Phase 2):** `Expr::AssignExpr` → the same `ApplyInfix(Assignment)` as a statement assignment (reusing `assignment_infix`).
- **Write (`EVAL`, Phase 5):** an `ApplyInfix(Assignment)` in expression position → an `AssignExpr`. A shared `lower_assign_parts` extracts the `(name, rhs)` for both the statement (`Stmt::Assign`) and expression (`AssignExpr`) forms.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[my $a; my $b; $a = $b = 5; $a + $b].AST)               # 10
EVAL(Q[my $a; my $b; my $c; $a = $b = $c = 7; $a + $b + $c].AST)  # 21
```

Explicitly-parenthesised `($x = 5)` (a `Circumfix::Parentheses`) and `:=` binding stay the coverage boundary.

## Tests

`t/rakuast-eval-assign-expr.t` — 4 assertions (read-side gist has two Assignment infixes, chained assignment sets both vars, a three-deep chain, a full-expression RHS), **passing under BOTH mutsu and raku**. The read-side gist is byte-identical to Rakudo's. All 57 `t/rakuast-*.t` files (257 tests) still green.

Next: C-style `loop`, bareword type terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)