### PR TITLE
feat: RakuAST Phase 5 slice 20 — EVAL of the C-style loop

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -958,9 +958,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 19: assignment expressions `$x = EXPR` in value position (both directions) — an
         `AssignExpr` ↔ `ApplyInfix(Assignment)`; `EVAL(Q[my $a; my $b; $a = $b = 5; $a + $b].AST)` → 10.
         Tests in `t/rakuast-eval-assign-expr.t`.
-  - [ ] Slice 20+: C-style `loop`, parenthesisation (`Circumfix::Parentheses`), bareword type terms,
-        named/slurpy params, code-block (`{…}`) interpolation — the inverse of the Phase-2 converter,
-        grown cluster by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 20: C-style `loop (setup; cond; increment) { … }` (`Statement::Loop` → `Stmt::Loop`, all
+        three controls optional); `EVAL(Q[my $s=0; loop (my $i=0; $i<5; $i=$i+1) { $s=$s+$i }; $s].AST)`
+        → 10. Tests in `t/rakuast-eval-cstyle-loop.t`.
+  - [ ] Slice 21+: parenthesisation (`Circumfix::Parentheses`), bareword type terms, named/slurpy
+        params, code-block (`{…}`) interpolation — the inverse of the Phase-2 converter, grown cluster
+        by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -299,6 +299,12 @@ earlier ones.
     backs both the statement and expression forms). `EVAL(Q[my $a; my $b; $a = $b = 5; $a + $b].AST)` →
     `10`. Explicitly-parenthesised `($x = 5)` (a `Circumfix::Parentheses`) and `:=` binding stay the
     boundary. Tests in `t/rakuast-eval-assign-expr.t`. Next: C-style `loop`, bareword type terms.
+  - **Slice 20 (C-style `loop`) — done.** `Statement::Loop` (with optional `setup`/`condition`/
+    `increment`) lowers to a `Stmt::Loop`; the read side already works via the slice-19 assignment
+    expression (the `$i = $i + 1` increment). `EVAL(Q[my $s = 0; loop (my $i = 0; $i < 5; $i = $i + 1) {
+    $s = $s + $i }; $s].AST)` → `10`; a bare `loop { … }` broken by `last`, and `next`/`last` inside,
+    all work. Tests in `t/rakuast-eval-cstyle-loop.t`. Next: bareword type terms, named/slurpy
+    parameters, parenthesisation.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -47,6 +47,7 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
         RakuAstClass::VarDeclarationSimple => lower_var_decl(node),
         RakuAstClass::StatementIf => lower_if(node),
         RakuAstClass::StatementLoopWhile => lower_while(node),
+        RakuAstClass::StatementLoop => lower_cstyle_loop(node),
         // `repeat { … } while/until C` runs the body once before testing the
         // condition (`until` desugars to `while !C`, handled by the prefix `!`).
         RakuAstClass::StatementLoopRepeatWhile => Ok(Stmt::Loop {
@@ -334,6 +335,32 @@ fn lower_while(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
     Ok(Stmt::While {
         cond,
         body,
+        label: None,
+    })
+}
+
+/// Lower a C-style `loop (SETUP; COND; STEP) { … }` to `Stmt::Loop`. Each of the
+/// three controls is optional (a bare `loop { … }` has none).
+fn lower_cstyle_loop(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
+    let init = match node.fields.iter().any(|f| f.name == Some("setup")) {
+        true => Some(Box::new(lower_stmt_inner(named_child(node, "setup")?)?)),
+        false => None,
+    };
+    let cond = match node.fields.iter().any(|f| f.name == Some("condition")) {
+        true => Some(lower_expr(named_child(node, "condition")?)?),
+        false => None,
+    };
+    let step = match node.fields.iter().any(|f| f.name == Some("increment")) {
+        true => Some(lower_expr(named_child(node, "increment")?)?),
+        false => None,
+    };
+    let body = lower_block(named_child(node, "body")?)?;
+    Ok(Stmt::Loop {
+        init,
+        cond,
+        step,
+        body,
+        repeat: false,
         label: None,
     })
 }

--- a/t/rakuast-eval-cstyle-loop.t
+++ b/t/rakuast-eval-cstyle-loop.t
@@ -1,0 +1,28 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 5 slice 20 (ADR-0011): EVAL of the C-style `loop (…; …; …) { … }`.
+# `Statement::Loop` (with optional `setup`/`condition`/`increment`) lowers to a
+# `Stmt::Loop`. The read side already works via the slice-19 assignment
+# expression (the increment `$i = $i + 1`). Verified against Rakudo; passes under
+# BOTH mutsu and raku.
+
+plan 4;
+
+# --- a three-part C-style loop accumulates ----------------------------------
+is EVAL(Q[my $s = 0; loop (my $i = 0; $i < 5; $i = $i + 1) { $s = $s + $i }; $s].AST), 10,
+    'C-style loop: sum 0..4 == 10';
+
+# --- another with a product -------------------------------------------------
+is EVAL(Q[my $p = 1; loop (my $i = 1; $i <= 4; $i = $i + 1) { $p = $p * $i }; $p].AST), 24,
+    'C-style loop: 4! == 24';
+
+# --- `next` skips an iteration ----------------------------------------------
+is EVAL(Q[my $s = 0; loop (my $i = 0; $i < 6; $i = $i + 1) { next if $i %% 2; $s = $s + $i }; $s].AST), 9,
+    'C-style loop with next: sum of odds < 6 == 9';
+
+# --- a bare `loop { … }` broken by `last` -----------------------------------
+is EVAL(Q[my $i = 0; loop { $i = $i + 1; last if $i >= 4 }; $i].AST), 4,
+    'bare loop broken by last';


### PR DESCRIPTION
## Summary

Phase 5 slice 20 of RakuAST (ADR-0011): `EVAL` of the C-style `loop (…; …; …) { … }`.

`Statement::Loop` (with optional `setup`/`condition`/`increment`) lowers to a `Stmt::Loop`. The setup is a declaration statement, the condition/increment are expressions, and each control is independently optional (a bare `loop { … }` has none). The read side already works via the slice-19 assignment expression (the `$i = $i + 1` increment).

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[my $s = 0; loop (my $i = 0; $i < 5; $i = $i + 1) { $s = $s + $i }; $s].AST)   # 10
EVAL(Q[my $i = 0; loop { $i = $i + 1; last if $i >= 4 }; $i].AST)                    # 4
```

## Tests

`t/rakuast-eval-cstyle-loop.t` — 4 assertions (three-part sum, product/factorial, `next` skipping, a bare `loop` broken by `last`), **passing under BOTH mutsu and raku**. All 58 `t/rakuast-*.t` files (261 tests) still green.

Next: bareword type terms, named/slurpy parameters, parenthesisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)