### PR TITLE
fix: numerator/denominator/nude builtins no longer shadow instance attribute accessors

### DIFF
--- a/docs/mzef-install-pipeline.md
+++ b/docs/mzef-install-pipeline.md
@@ -221,15 +221,19 @@ JSON::Unmarshal (11 files / 101 tests), JSON::Marshal (14/85), JSON::Class
 (6/31), URI (14/222), META6 (9/969), License::SPDX (2/729), Test::META
 (3/26, #4756). FAIL: **JSON::Fast** only (native-JSON fidelity remnants;
 full parity is likely unnecessary for the pipeline). Within JSON::Fast,
-two PRs (#4762 AdditionalContent + strict grammar; the options-parity PR:
+three PRs (#4762 AdditionalContent + strict grammar; #4765 options parity:
 `:immutable`/List+Map decode, `:enums-as-value`, `$*JSON_NAN_INF_SUPPORT`,
 import-list defaults `<immutable !pretty>`, `&from-json`/`.&from-json`
-code-object dispatch, uppercase surrogate escapes, Duration-as-Num)
-brought the suite from 3/14 to **10/14 files green**; remaining:
-04-roundtrip (1 fail: `Rational[Int,Int].new(3,10)` — role type-params
-`::NuT = Int` unresolved in method signatures, a general parametric-role
-bug), 07-datetime (`augment class DateTime`), 12-assocpositional
-(Positional+Associative instance serialization), 14-comments (JSONC).
+code-object dispatch, uppercase surrogate escapes, Duration-as-Num; the
+numerator/denominator-shadow PR: those builtins no longer claim every
+invocant, so the Rational role prelude's attr accessors work and a punned
+Rational serializes numerically) brought the suite from 3/14 to **11/14
+files green**; remaining: 07-datetime (`augment class DateTime`),
+12-assocpositional (Positional+Associative instance serialization),
+14-comments (JSONC). Known adjacent gap (not needed by the suite): an
+UNparameterized `Rational.new(6,4)` still fails binding (`expected NuT,
+got Int` — role type-param defaults `::NuT = Int` unresolved in method
+signatures).
 Test-Helpers ships no `t/` of its own (covered by mutsu's local
 `t/test-util-*.t`).
 

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -7,19 +7,25 @@ use std::collections::HashMap;
 /// is-prime, isNaN, re, im, conj, reals, Complex, key, value, Slip, list/Array, Range
 pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, RuntimeError>> {
     match method {
+        // numerator/denominator/nude exist on Rational types (and Int via
+        // Rational[Int,Int]). Claiming every other invocant here (the old
+        // catch-all 0/1) shadowed same-named attribute accessors on user
+        // role/class instances (e.g. the Rational role prelude's
+        // `$.numerator`); return None so dispatch falls through to them.
         "numerator" => match target.view() {
             ValueView::Rat(n, _) => Some(Ok(Value::int(n))),
             ValueView::FatRat(n, _) => Some(Ok(Value::int(n))),
             ValueView::BigRat(n, _) => Some(Ok(Value::bigint(n.clone()))),
             ValueView::Int(i) => Some(Ok(Value::int(i))),
-            _ => Some(Ok(Value::int(0))),
+            ValueView::BigInt(i) => Some(Ok(Value::bigint(i.as_ref().clone()))),
+            _ => None,
         },
         "denominator" => match target.view() {
             ValueView::Rat(_, d) => Some(Ok(Value::int(d))),
             ValueView::FatRat(_, d) => Some(Ok(Value::int(d))),
             ValueView::BigRat(_, d) => Some(Ok(Value::bigint(d.clone()))),
-            ValueView::Int(_) => Some(Ok(Value::int(1))),
-            _ => Some(Ok(Value::int(1))),
+            ValueView::Int(_) | ValueView::BigInt(_) => Some(Ok(Value::int(1))),
+            _ => None,
         },
         "isNaN" => match target.view() {
             ValueView::Rat(0, 0) => Some(Ok(Value::TRUE)),
@@ -35,7 +41,11 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 Value::bigint(d.clone()),
             ]))),
             ValueView::Int(i) => Some(Ok(Value::array(vec![Value::int(i), Value::int(1)]))),
-            _ => Some(Ok(Value::array(vec![Value::int(0), Value::int(1)]))),
+            ValueView::BigInt(i) => Some(Ok(Value::array(vec![
+                Value::bigint(i.as_ref().clone()),
+                Value::int(1),
+            ]))),
+            _ => None,
         },
         "norm" => match target.view() {
             ValueView::Rat(n, d) => Some(Ok(make_rat(n, d))),

--- a/src/runtime/json.rs
+++ b/src/runtime/json.rs
@@ -133,7 +133,23 @@ fn jsonify(val: &Value, opts: &ToJsonOpts, level: usize, out: &mut String) {
             out.push('"');
         }
         ValueView::Scalar(inner) => jsonify(inner, opts, level, out),
-        ValueView::Mixin(inner, _) => jsonify(inner, opts, level, out),
+        ValueView::Mixin(inner, mixins) => {
+            // A punned Rational-role instance is Real; JSON::Fast's Real:D
+            // candidate serializes it numerically (0.3), not as an opaque
+            // string. Its attrs ride in the mixin map.
+            if mixins.contains_key("__mutsu_role__Rational")
+                && let (Some(n), Some(d)) = (
+                    mixins.get("__mutsu_attr__numerator"),
+                    mixins.get("__mutsu_attr__denominator"),
+                )
+            {
+                let rat =
+                    crate::value::make_rat(n.as_int().unwrap_or(0), d.as_int().unwrap_or(1).max(1));
+                jsonify(&rat, opts, level, out);
+            } else {
+                jsonify(inner, opts, level, out);
+            }
+        }
         ValueView::Array(arr, _) => jsonify_seq(&arr.items, opts, level, out),
         ValueView::Seq(items)
         | ValueView::Slip(items)

--- a/t/role-attr-shadows-builtin-method.t
+++ b/t/role-attr-shadows-builtin-method.t
@@ -1,0 +1,48 @@
+use v6;
+use Test;
+
+# The numerator/denominator/nude builtins used to claim EVERY invocant with a
+# catch-all (0 / 1 / (0,1)), shadowing same-named attribute accessors on user
+# role/class instances — the Rational role prelude's $.numerator read as 0.
+
+role MyRat[::NuT = Int, ::DeT = Int] does Real {
+    has NuT $.numerator = 0;
+    has DeT $.denominator = 1;
+    method nude { self.numerator, self.denominator }
+}
+
+my $r = MyRat[Int,Int].new(3, 10);
+is $r.numerator, 3, 'role instance attr numerator wins over builtin';
+is $r.denominator, 10, 'role instance attr denominator wins over builtin';
+is-deeply $r.nude.List, (3, 10), 'user nude method wins over builtin';
+
+# The builtin Rational prelude itself now works.
+my $q = Rational[Int,Int].new(3, 10);
+is $q.numerator, 3, 'Rational prelude numerator';
+is $q.denominator, 10, 'Rational prelude denominator';
+
+class WithNum {
+    has $.numerator = 42;
+}
+is WithNum.new.numerator, 42, 'class attr numerator accessor still works';
+
+# Builtins keep working on real numeric types.
+is (3/10).numerator, 3, 'Rat numerator';
+is (3/10).denominator, 10, 'Rat denominator';
+is-deeply (3/10).nude.List, (3, 10), 'Rat nude';
+is 7.numerator, 7, 'Int numerator';
+is 7.denominator, 1, 'Int denominator';
+is (2**70).numerator, 2**70, 'BigInt numerator';
+is (2**70).denominator, 1, 'BigInt denominator';
+
+# A punned Rational instance is Real: to-json serializes it numerically
+# (JSON::Fast t/04-roundtrip.t), not as an opaque string.
+{
+    use JSON::Fast;
+    is to-json([Rational[Int,Int].new(3, 10)], :!pretty), '[0.3]',
+        'Rational instance serializes numerically';
+    is-deeply from-json(to-json([Rational[Int,Int].new(3, 10)], :!pretty)),
+        [0.3], 'Rational roundtrips as Rat';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

The `numerator`/`denominator`/`nude` 0-arg builtins claimed **every** invocant with a catch-all arm (`0` / `1` / `(0,1)`), so a user role/class instance with a same-named attribute or method could never reach its own accessor. The built-in `Rational` role prelude was the visible casualty: `Rational[Int,Int].new(3,10).numerator` read `0` no matter what was stored (surfaced by JSON::Fast `t/04-roundtrip.t`), and even `"str".denominator` answered `1`.

- The three builtins now match numeric invocants explicitly (Rat, FatRat, BigRat, Int, and newly **BigInt**) and return `None` otherwise, letting dispatch fall through to instance attributes / user methods.
- `to-json` serializes a punned Rational-role instance numerically (`0.3`) via its mixin-carried numerator/denominator attrs, matching JSON::Fast's `Real:D` candidate — the mixin arm previously forwarded to the inner instance and hit the opaque-string fallback.

## Results

- JSON::Fast suite: **10/14 → 11/14 files green** (04-roundtrip 56/56). Remaining, per `docs/mzef-install-pipeline.md`: 07-datetime (`augment`), 12-assocpositional, 14-comments (JSONC).
- `make test` 18353 PASS.
- Known adjacent gap recorded in docs (not needed by the suite): unparameterized `Rational.new(6,4)` still fails binding — role type-param defaults (`::NuT = Int`) unresolved in method signatures.

## Tests

- `t/role-attr-shadows-builtin-method.t` — 15 assertions: role/class attr accessors win, builtins keep working on Rat/Int/BigInt, Rational serializes and roundtrips numerically

🤖 Generated with [Claude Code](https://claude.com/claude-code)