### PR TITLE
feat: RakuAST slice 21 — parenthesised expressions in .AST and EVAL

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -961,9 +961,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 20: C-style `loop (setup; cond; increment) { … }` (`Statement::Loop` → `Stmt::Loop`, all
         three controls optional); `EVAL(Q[my $s=0; loop (my $i=0; $i<5; $i=$i+1) { $s=$s+$i }; $s].AST)`
         → 10. Tests in `t/rakuast-eval-cstyle-loop.t`.
-  - [ ] Slice 21+: parenthesisation (`Circumfix::Parentheses`), bareword type terms, named/slurpy
-        params, code-block (`{…}`) interpolation — the inverse of the Phase-2 converter, grown cluster
-        by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 21: parenthesised expressions `(EXPR)` (both directions) via a new
+        `Circumfix::Parentheses` node — `Expr::Grouped` ↔ `Circumfix::Parentheses(SemiList(...))`.
+        `EVAL(Q/my $x = 0; my $y = ($x = 5); $x + $y/.AST)` → 10. Tests in `t/rakuast-eval-paren.t`.
+  - [ ] Slice 22+: bareword type terms, named/slurpy params, array/hash literals, code-block (`{…}`)
+        interpolation — the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full
+        lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -305,6 +305,12 @@ earlier ones.
     $s = $s + $i }; $s].AST)` → `10`; a bare `loop { … }` broken by `last`, and `next`/`last` inside,
     all work. Tests in `t/rakuast-eval-cstyle-loop.t`. Next: bareword type terms, named/slurpy
     parameters, parenthesisation.
+  - **Slice 21 (parenthesised expressions) — done, both directions.** A new `Circumfix::Parentheses`
+    node class models a standalone `(EXPR)` (wrapping a single-statement `SemiList`). The read side
+    (`.AST`) converts `Expr::Grouped` to it and the write side (`EVAL`) unwraps it to the inner
+    expression. This closes the slice-19 boundary: `EVAL(Q/my $x = 0; my $y = ($x = 5); $x + $y/.AST)` →
+    `10`. Multi-statement parenthesised lists stay the boundary. Tests in `t/rakuast-eval-paren.t`.
+    Next: bareword type terms, named/slurpy parameters, array/hash literals.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -763,6 +763,17 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
         Expr::Literal(v) | Expr::LiteralSrc(v, _) => convert_literal(v),
         Expr::Call { name, args } => Ok(call_name(name.as_str(), args, false)?),
         Expr::Var(name) => Ok(var_lexical("$", name)),
+        // `(EXPR)` -> `Circumfix::Parentheses(SemiList(Statement::Expression(...)))`.
+        Expr::Grouped(inner) => {
+            let semilist = RakuAstNode {
+                class: RakuAstClass::SemiList,
+                fields: vec![node_field(None, statement_expression(convert_expr(inner)?))],
+            };
+            Ok(RakuAstNode {
+                class: RakuAstClass::CircumfixParentheses,
+                fields: vec![node_field(None, semilist)],
+            })
+        }
         // `($x = EXPR)` as an expression -> the same `ApplyInfix(Assignment)` as a
         // statement assignment. `:=` binding stays the boundary.
         Expr::AssignExpr {

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -535,6 +535,14 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             Ok(Expr::StringInterpolation(parts))
         }
         RakuAstClass::StatementExpression => lower_expr(named_child(node, "expression")?),
+        // `(EXPR)` -> its inner expression (parens are transparent for EVAL). The
+        // node wraps a `SemiList` of `Statement::Expression`s; only the
+        // single-statement form is handled.
+        RakuAstClass::CircumfixParentheses => {
+            let semilist = named_child_or_positional(node)?;
+            let inner = named_child_or_positional(semilist)?;
+            lower_expr(inner)
+        }
         // `True`/`False` -> the Bool literal. Other enum identifiers are deferred.
         RakuAstClass::TermEnum => match positional_leaf(node)?.view() {
             ValueView::Str(s) if s.as_str() == "True" => Ok(Expr::Literal(Value::truth(true))),

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -127,6 +127,8 @@ pub enum RakuAstClass {
     TermReduce,
     // Phase 2 slice 30: `True`/`False` (and other enum) literals.
     TermEnum,
+    // Phase 2 slice 31: parenthesised expressions (`($x = 5)`).
+    CircumfixParentheses,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -196,6 +198,7 @@ impl RakuAstClass {
             PostcircumfixArrayIndex => "RakuAST::Postcircumfix::ArrayIndex",
             TermReduce => "RakuAST::Term::Reduce",
             TermEnum => "RakuAST::Term::Enum",
+            CircumfixParentheses => "RakuAST::Circumfix::Parentheses",
         }
     }
 

--- a/t/rakuast-eval-paren.t
+++ b/t/rakuast-eval-paren.t
@@ -1,0 +1,28 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 21 (ADR-0011): parenthesised expressions `(EXPR)`, both
+# directions. A standalone `(EXPR)` is a `Circumfix::Parentheses` wrapping a
+# single-statement `SemiList`. The read side (`.AST`) emits that node and the
+# write side (`EVAL`) unwraps it to the inner expression. Verified against
+# Rakudo; passes under BOTH mutsu and raku.
+
+plan 4;
+
+# --- read side: the parens render as Circumfix::Parentheses -----------------
+ok Q/my $x; ($x = 5)/.AST.gist.contains('RakuAST::Circumfix::Parentheses.new('),
+    'a parenthesised expression renders as Circumfix::Parentheses';
+
+# --- a grouped assignment now round-trips (the slice-19 boundary) -----------
+is EVAL(Q/my $x = 0; my $y = ($x = 5); $x + $y/.AST), 10,
+    'a parenthesised assignment expression evaluates and returns its value';
+
+# --- a grouped arithmetic subexpression -------------------------------------
+is EVAL(Q/my $x = 3; my $y = ($x + 1); $y/.AST), 4,
+    'a parenthesised arithmetic expression';
+
+# --- a lone parenthesised variable ------------------------------------------
+is EVAL(Q/my $x = 7; ($x)/.AST), 7,
+    'a lone parenthesised variable is its value';


### PR DESCRIPTION
## Summary

RakuAST slice 21 (ADR-0011): parenthesised expressions `(EXPR)` in **both directions**.

A new `Circumfix::Parentheses` node class models a standalone parenthesised expression (which wraps a single-statement `SemiList`):

```raku
Q/my $x; ($x = 5)/.AST   # ... Circumfix::Parentheses(SemiList(Statement::Expression(ApplyInfix(Assignment))))
```

- **Read (`.AST`, Phase 2):** `Expr::Grouped` → `Circumfix::Parentheses(SemiList(Statement::Expression(inner)))`.
- **Write (`EVAL`, Phase 5):** a `Circumfix::Parentheses` unwraps to the inner expression (parens are transparent for evaluation).

This closes the slice-19 boundary — a grouped assignment expression now round-trips:

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q/my $x = 0; my $y = ($x = 5); $x + $y/.AST)   # 10
```

Multi-statement parenthesised lists stay the coverage boundary.

## Tests

`t/rakuast-eval-paren.t` — 4 assertions (read-side gist has Circumfix::Parentheses, a grouped assignment, a grouped arithmetic subexpression, a lone parenthesised variable), **passing under BOTH mutsu and raku**. The read-side gist is byte-identical to Rakudo's. All 59 `t/rakuast-*.t` files (265 tests) still green.

Next: bareword type terms, named/slurpy parameters, array/hash literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)