### PR TITLE
feat(json): JSONC comments, Associative/Positional instance serialization, stash .values

### DIFF
--- a/docs/mzef-install-pipeline.md
+++ b/docs/mzef-install-pipeline.md
@@ -221,19 +221,21 @@ JSON::Unmarshal (11 files / 101 tests), JSON::Marshal (14/85), JSON::Class
 (6/31), URI (14/222), META6 (9/969), License::SPDX (2/729), Test::META
 (3/26, #4756). FAIL: **JSON::Fast** only (native-JSON fidelity remnants;
 full parity is likely unnecessary for the pipeline). Within JSON::Fast,
-three PRs (#4762 AdditionalContent + strict grammar; #4765 options parity:
+four PRs (#4762 AdditionalContent + strict grammar; #4765 options parity:
 `:immutable`/List+Map decode, `:enums-as-value`, `$*JSON_NAN_INF_SUPPORT`,
 import-list defaults `<immutable !pretty>`, `&from-json`/`.&from-json`
-code-object dispatch, uppercase surrogate escapes, Duration-as-Num; the
-numerator/denominator-shadow PR: those builtins no longer claim every
+code-object dispatch, uppercase surrogate escapes, Duration-as-Num;
+#4768 numerator/denominator-shadow: those builtins no longer claim every
 invocant, so the Rational role prelude's attr accessors work and a punned
-Rational serializes numerically) brought the suite from 3/14 to **11/14
-files green**; remaining: 07-datetime (`augment class DateTime`),
-12-assocpositional (Positional+Associative instance serialization),
-14-comments (JSONC). Known adjacent gap (not needed by the suite): an
-UNparameterized `Rational.new(6,4)` still fails binding (`expected NuT,
-got Int` — role type-param defaults `::NuT = Int` unresolved in method
-signatures).
+Rational serializes numerically; the JSONC/assoc-pos PR: `:allow-jsonc`
+comment skipping, Associative/Positional user instances serialize via
+`.list`, and `Foo::.values`/`Bool::.values` stash enumeration) brought
+the suite from 3/14 to **13/14 files green**; the only remaining file is
+07-datetime, blocked on `augment class DateTime` for a builtin native
+class (MONKEY-TYPING on Date/DateTime — campaign-sized, not JSON work).
+Known adjacent gap (not needed by the suite): an UNparameterized
+`Rational.new(6,4)` still fails binding (`expected NuT, got Int` — role
+type-param defaults `::NuT = Int` unresolved in method signatures).
 Test-Helpers ships no `t/` of its own (covered by mutsu's local
 `t/test-util-*.t`).
 

--- a/src/runtime/accessors_stash.rs
+++ b/src/runtime/accessors_stash.rs
@@ -288,6 +288,15 @@ impl Interpreter {
             return Self::make_stash_instance(package, symbols);
         }
 
+        // Bool is a built-in enum whose members are not registered through the
+        // usual enum path; its stash still exposes them (`Bool::.values`).
+        if package_name == "Bool" {
+            let mut symbols: HashMap<String, Value> = HashMap::new();
+            symbols.insert("False".to_string(), Value::FALSE);
+            symbols.insert("True".to_string(), Value::TRUE);
+            return Self::make_stash_instance(package, symbols);
+        }
+
         if let Some((module, tag)) = Self::package_export_tag_parts(package) {
             let mut symbols: HashMap<String, Value> = HashMap::new();
             if let Some(subs) = self.exported_subs.get(module) {

--- a/src/runtime/json.rs
+++ b/src/runtime/json.rs
@@ -326,13 +326,19 @@ pub(crate) enum FromJsonError {
 }
 
 /// Parse a JSON string into a `Value`. With `immutable`, arrays decode as
-/// `List` and objects as `Map` (JSON::Fast `:immutable`).
-pub(crate) fn from_json(text: &str, immutable: bool) -> Result<Value, FromJsonError> {
+/// `List` and objects as `Map` (JSON::Fast `:immutable`). With `allow_jsonc`,
+/// `//` line and `/* */` block comments are skipped (JSONC).
+pub(crate) fn from_json(
+    text: &str,
+    immutable: bool,
+    allow_jsonc: bool,
+) -> Result<Value, FromJsonError> {
     let mut p = Parser {
         bytes: text.as_bytes(),
         chars: text,
         pos: 0,
         immutable,
+        allow_jsonc,
     };
     p.skip_ws();
     let value = p.parse_value().map_err(FromJsonError::Parse)?;
@@ -353,6 +359,7 @@ struct Parser<'a> {
     chars: &'a str,
     pos: usize,
     immutable: bool,
+    allow_jsonc: bool,
 }
 
 impl<'a> Parser<'a> {
@@ -385,6 +392,25 @@ impl<'a> Parser<'a> {
         while self.pos < self.bytes.len() {
             match self.bytes[self.pos] {
                 b' ' | b'\t' | b'\n' | b'\r' => self.pos += 1,
+                b'/' if self.allow_jsonc => {
+                    // JSONC comments: `// ...` to end of line, `/* ... */`
+                    // (non-overlapping: `/*/` is NOT a complete comment). An
+                    // invalid or unterminated comment leaves pos at the `/` so
+                    // the value parser reports it as an unexpected character.
+                    if self.bytes.get(self.pos + 1) == Some(&b'/') {
+                        self.pos += 2;
+                        while self.pos < self.bytes.len() && self.bytes[self.pos] != b'\n' {
+                            self.pos += 1;
+                        }
+                    } else if self.bytes.get(self.pos + 1) == Some(&b'*') {
+                        match self.chars[self.pos + 2..].find("*/") {
+                            Some(end) => self.pos += 2 + end + 2,
+                            None => break,
+                        }
+                    } else {
+                        break;
+                    }
+                }
                 _ => break,
             }
         }

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -770,6 +770,19 @@ impl Interpreter {
     /// Dispatch "values" method.
     fn dispatch_values_method(&self, target: Value) -> Result<Value, RuntimeError> {
         match target.view() {
+            // `Foo::.values` — the stash's symbol values (enum members, nested
+            // packages, ...), mirroring the Stash arm of dispatch_keys_method.
+            ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } if class_name == "Stash" => {
+                let vals = match attributes.as_map().get("symbols").map(Value::view) {
+                    Some(ValueView::Hash(map)) => map.values().cloned().collect(),
+                    _ => Vec::new(),
+                };
+                Ok(Value::seq(vals))
+            }
             ValueView::Capture { positional, named } => {
                 let mut vals = positional.clone();
                 vals.extend(named.values().cloned());

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -173,7 +173,7 @@ impl Interpreter {
                         | "stderr"
                         | "Supply"
                 ))
-            || (matches!(method, "AT-KEY" | "keys")
+            || (matches!(method, "AT-KEY" | "keys" | "values")
                 && matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Stash"))
             || (method == "keys"
                 && args.is_empty()

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -916,7 +916,7 @@ impl Interpreter {
             }
         }
         if !skip_native
-            && matches!(method.as_str(), "AT-KEY" | "keys")
+            && matches!(method.as_str(), "AT-KEY" | "keys" | "values")
             && matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Stash")
         {
             skip_native = true;

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -789,7 +789,7 @@ impl Interpreter {
             }
         }
         if !skip_native
-            && matches!(method, "AT-KEY" | "keys")
+            && matches!(method, "AT-KEY" | "keys" | "values")
             && matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Stash")
         {
             skip_native = true;

--- a/src/vm/vm_native_json.rs
+++ b/src/vm/vm_native_json.rs
@@ -36,12 +36,129 @@ impl Interpreter {
             .map(crate::runtime::types::unwrap_varref_value)
             .collect();
         match name {
-            "to-json" => Some(native_to_json(&clean_args, self.base_to_json_opts())),
+            "to-json" => {
+                let clean_args = self.prepare_to_json_args(clean_args);
+                Some(native_to_json(&clean_args, self.base_to_json_opts()))
+            }
             "from-json" => Some(native_from_json(
                 &clean_args,
                 self.json_import_defaults.immutable,
             )),
             _ => None,
+        }
+    }
+
+    /// Pre-convert to-json subject args: user instances doing Associative
+    /// (or Positional) serialize via their `.list` (JSON::Fast's
+    /// pretty/unpretty-associative and -positional iterate exactly that), so
+    /// deep-replace them with plain Hash/Array values the pure serializer
+    /// understands. Named (Pair) args are left alone.
+    fn prepare_to_json_args(&mut self, args: Vec<Value>) -> Vec<Value> {
+        args.into_iter()
+            .map(|a| match a.view() {
+                ValueView::Pair(..) | ValueView::ValuePair(..) => a,
+                _ if self.json_subject_needs_prepare(&a) => self.prepare_to_json_subject(&a),
+                _ => a,
+            })
+            .collect()
+    }
+
+    /// Cheap read-only scan: does the subject contain an Associative/Positional
+    /// user instance anywhere? Avoids deep-rebuilding plain data.
+    fn json_subject_needs_prepare(&mut self, val: &Value) -> bool {
+        match val.view() {
+            ValueView::Instance { .. }
+            | ValueView::Mixin(..)
+            | ValueView::CustomTypeInstance(..) => {
+                self.type_matches_value("Associative", val)
+                    || self.type_matches_value("Positional", val)
+            }
+            ValueView::Array(arr, _) => {
+                let items = arr.items.clone();
+                items.iter().any(|i| self.json_subject_needs_prepare(i))
+            }
+            ValueView::Seq(items) | ValueView::Slip(items) => {
+                let items = items.to_vec();
+                items.iter().any(|i| self.json_subject_needs_prepare(i))
+            }
+            ValueView::Hash(h) => {
+                let values: Vec<Value> = h.map.values().cloned().collect();
+                values.iter().any(|v| self.json_subject_needs_prepare(v))
+            }
+            ValueView::Scalar(inner) => {
+                let inner = inner.clone();
+                self.json_subject_needs_prepare(&inner)
+            }
+            _ => false,
+        }
+    }
+
+    fn prepare_to_json_subject(&mut self, val: &Value) -> Value {
+        match val.view() {
+            ValueView::Instance { .. }
+            | ValueView::Mixin(..)
+            | ValueView::CustomTypeInstance(..) => {
+                let assoc = self.type_matches_value("Associative", val);
+                let positional = self.type_matches_value("Positional", val);
+                if !assoc && !positional {
+                    return val.clone();
+                }
+                let Ok(listed) = self.call_method_with_values(val.clone(), "list", vec![]) else {
+                    return val.clone();
+                };
+                let items: Vec<Value> = match listed.view() {
+                    ValueView::Array(arr, _) => arr.items.clone(),
+                    ValueView::Seq(items) | ValueView::Slip(items) => items.to_vec(),
+                    _ => return val.clone(),
+                };
+                if assoc {
+                    // Associative wins over Positional (JSON::Fast dispatch
+                    // order); elements are Pairs.
+                    let mut map = std::collections::HashMap::new();
+                    for item in &items {
+                        match item.view() {
+                            ValueView::Pair(k, v) => {
+                                map.insert(k.clone(), self.prepare_to_json_subject(v));
+                            }
+                            ValueView::ValuePair(k, v) => {
+                                map.insert(k.to_string_value(), self.prepare_to_json_subject(v));
+                            }
+                            _ => {}
+                        }
+                    }
+                    Value::hash_with_data(Value::hash_arc(map))
+                } else {
+                    let items = items
+                        .iter()
+                        .map(|i| self.prepare_to_json_subject(i))
+                        .collect();
+                    Value::real_array(items)
+                }
+            }
+            ValueView::Array(arr, kind) => {
+                let items: Vec<Value> = arr
+                    .items
+                    .iter()
+                    .map(|i| self.prepare_to_json_subject(i))
+                    .collect();
+                Value::array_with_kind(
+                    crate::gc::Gc::new(crate::value::ArrayData::new(items)),
+                    kind,
+                )
+            }
+            ValueView::Hash(h) => {
+                let map: std::collections::HashMap<String, Value> = h
+                    .map
+                    .iter()
+                    .map(|(k, v)| (k.clone(), self.prepare_to_json_subject(v)))
+                    .collect();
+                Value::hash_with_data(Value::hash_arc(map))
+            }
+            ValueView::Scalar(inner) => {
+                let inner = inner.clone();
+                self.prepare_to_json_subject(&inner)
+            }
+            _ => val.clone(),
         }
     }
 
@@ -126,15 +243,18 @@ fn apply_to_json_named(opts: &mut ToJsonOpts, name: &str, val: &Value) {
 
 fn native_from_json(args: &[Value], default_immutable: bool) -> Result<Value, RuntimeError> {
     let mut immutable = default_immutable;
+    let mut allow_jsonc = false;
     let mut text = String::new();
     let mut have_text = false;
+    let mut named = |name: &str, val: &Value| match name {
+        "immutable" => immutable = val.truthy(),
+        "allow-jsonc" => allow_jsonc = val.truthy(),
+        _ => {}
+    };
     for arg in args {
         match arg.view() {
-            ValueView::Pair(name, val) if name == "immutable" => immutable = val.truthy(),
-            ValueView::ValuePair(key, val) if key.to_string_value() == "immutable" => {
-                immutable = val.truthy()
-            }
-            ValueView::Pair(..) | ValueView::ValuePair(..) => {}
+            ValueView::Pair(name, val) => named(name, val),
+            ValueView::ValuePair(key, val) => named(&key.to_string_value(), val),
             _ if !have_text => {
                 text = arg.to_string_value();
                 have_text = true;
@@ -142,7 +262,7 @@ fn native_from_json(args: &[Value], default_immutable: bool) -> Result<Value, Ru
             _ => {}
         }
     }
-    json::from_json(&text, immutable).map_err(|e| match e {
+    json::from_json(&text, immutable, allow_jsonc).map_err(|e| match e {
         json::FromJsonError::Parse(msg) => RuntimeError::new(msg),
         json::FromJsonError::AdditionalContent {
             parsed,

--- a/t/json-assoc-pos-instance.t
+++ b/t/json-assoc-pos-instance.t
@@ -1,0 +1,31 @@
+use v6;
+use Test;
+use JSON::Fast;
+
+# to-json on user instances doing Associative/Positional serializes via .list
+# (JSON::Fast t/12-assocpositional.t parity). Associative wins when both.
+
+class Both does Positional does Associative {
+    method list { List.new(|do Pair.new($_.Str, $_) for 3 ... 1) }
+    method sort(|c) { self.list.sort(|c) }
+    method of { self.Positional::of() }
+}
+
+my $expected = %( do $_.Str => $_ for 3 ... 1 );
+for Bool::.values X Bool::.values -> ($pretty, $sorted-keys) {
+    is-deeply from-json(to-json(Both.new, :$pretty, :$sorted-keys)), $expected,
+        "roundtrip with :pretty($pretty) :sorted-keys($sorted-keys)";
+}
+
+class PosOnly does Positional {
+    method list { (10, 20, 30) }
+    method of { Mu }
+}
+is-deeply from-json(to-json(PosOnly.new, :!pretty)), $[10, 20, 30],
+    'Positional-only instance serializes as an array';
+
+# Nested inside plain data too.
+is-deeply from-json(to-json([1, PosOnly.new], :!pretty)), $[1, $[10, 20, 30]],
+    'instance nested in an array is converted';
+
+done-testing;

--- a/t/json-jsonc.t
+++ b/t/json-jsonc.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+use JSON::Fast;
+
+# :allow-jsonc — JSONC comments (JSON::Fast t/14-comments.t parity).
+
+my $json = Q:to/JSON/;
+{
+  /* block comment */
+  "foo": "bar",  // line comment
+  "n": 42,
+  // "gone": 1,
+  "array": [1, 2, /* 4, */ 3]
+}
+JSON
+
+is-deeply from-json($json, :allow-jsonc),
+    { :foo("bar"), :n(42), :array($[1, 2, 3]) },
+    'comments are skipped with :allow-jsonc';
+
+dies-ok { from-json($json) }, 'comments are rejected without :allow-jsonc';
+
+dies-ok { from-json(Q<{"k": /*/ 1}>, :allow-jsonc) },
+    '/*/ is not a complete block comment';
+
+dies-ok { from-json(Q<{"k": /* unterminated 1}>, :allow-jsonc) },
+    'unterminated block comment is rejected';
+
+is-deeply from-json("[1] // trailing", :allow-jsonc), $[1],
+    'trailing line comment after the document';
+
+done-testing;

--- a/t/stash-values.t
+++ b/t/stash-values.t
@@ -1,0 +1,24 @@
+use v6;
+use Test;
+
+# `Foo::.values` returns the stash's symbol values. The native `.values` fast
+# path used to claim the Stash instance and return (the stash itself,).
+
+enum Day <Mon Tue Wed>;
+
+is-deeply Day::.values.sort, (Mon, Tue, Wed).sort.List,
+    'enum stash .values yields the enum members';
+is-deeply Day::.keys.sort.List, ("Mon", "Tue", "Wed"),
+    'enum stash .keys yields the member names';
+
+# Bool is a built-in enum; its stash exposes False/True.
+is Bool::.values.elems, 2, 'Bool stash has two values';
+ok Bool::.values.grep(* === True), 'Bool stash values include True';
+ok Bool::.values.grep(* === False), 'Bool stash values include False';
+is-deeply Bool::.keys.sort.List, ("False", "True"), 'Bool stash keys';
+
+# The X cross of stash values iterates all combinations (JSON::Fast t/12).
+my @combos = Bool::.values X Bool::.values;
+is @combos.elems, 4, 'X over Bool stash values gives 4 combos';
+
+done-testing;


### PR DESCRIPTION
## Summary

Third JSON::Fast-parity slice plus a generic Stash fix — the suite goes **11/14 → 13/14 files green**; the only remaining file is 07-datetime, blocked on `augment class DateTime` for a builtin native class (MONKEY-TYPING on Date/DateTime — campaign-sized, not JSON work).

- **`:allow-jsonc`** on `from-json` skips `// ...` line and `/* ... */` block comments (JSONC). Non-overlapping: `/*/` is not a complete comment, and an invalid/unterminated comment leaves the `/` for the value parser to reject (t/14-comments.t all green).
- **Associative/Positional user instances** serialize via their `.list`, matching JSON::Fast's pretty/unpretty-associative and -positional candidates (Associative wins when both are done). Implemented as an interpreter-side pre-pass that deep-replaces such instances with plain Hash/Array values, gated by a cheap needs-prepare scan so plain data pays nothing (t/12-assocpositional.t all green).
- **`Foo::.values`** on a package stash returns the symbol values (enum members etc.) — the native `.values` fast path used to claim the Stash instance and return `(the stash,)`. All three Stash bypass copies now include `values`, and `dispatch_values_method` grew the Stash arm mirroring `keys`.
- **`Bool::` stash** exposes its built-in enum members `False`/`True` (it used to be empty), so `Bool::.values X Bool::.values` iterates all four combinations — this is what let t/12 run its full plan.

## Results

- JSON::Fast: 13/14 files green (07-datetime only). Standing recorded in `docs/mzef-install-pipeline.md`.
- `make test` 18396 PASS.

## Tests

- `t/json-jsonc.t` — comment skipping, `/*/` and unterminated rejection, plain-path rejection
- `t/json-assoc-pos-instance.t` — both/Positional-only instances, nesting, all pretty×sorted combos
- `t/stash-values.t` — enum stash values/keys, Bool stash, X-cross iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)