### PR TITLE
feat: RakuAST slice 22 — named parameters in .AST and EVAL

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -964,7 +964,11 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 21: parenthesised expressions `(EXPR)` (both directions) via a new
         `Circumfix::Parentheses` node — `Expr::Grouped` ↔ `Circumfix::Parentheses(SemiList(...))`.
         `EVAL(Q/my $x = 0; my $y = ($x = 5); $x + $y/.AST)` → 10. Tests in `t/rakuast-eval-paren.t`.
-  - [ ] Slice 22+: bareword type terms, named/slurpy params, array/hash literals, code-block (`{…}`)
+  - [x] Slice 22: named parameters `:$x` (both directions) — a named `Parameter` carries a `names`
+        list; the write side sets the `ParamDef` `named` flag, and the `x => 5` call arg (`FatArrow`)
+        lowers too. `EVAL(Q[sub f(:$x) { $x*2 }; f(x => 5)].AST)` → 10. Tests in
+        `t/rakuast-eval-named-param.t`.
+  - [ ] Slice 23+: bareword type terms, slurpy params (`*@a`), array/hash literals, code-block (`{…}`)
         interpolation — the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full
         lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -311,6 +311,14 @@ earlier ones.
     expression. This closes the slice-19 boundary: `EVAL(Q/my $x = 0; my $y = ($x = 5); $x + $y/.AST)` →
     `10`. Multi-statement parenthesised lists stay the boundary. Tests in `t/rakuast-eval-paren.t`.
     Next: bareword type terms, named/slurpy parameters, array/hash literals.
+  - **Slice 22 (named parameters) — done, both directions.** A named parameter `:$x` renders as a
+    `Parameter` with a `names` list (and no `optional`, since named params are optional by default);
+    the write side sets the `ParamDef`'s `named` flag. The `x => 5` call argument (a `FatArrow` infix,
+    which renders with its Debug name) also lowers now (`op_name_to_token_kind` maps `"FatArrow"`).
+    `EVAL(Q[sub f(:$x) { $x * 2 }; f(x => 5)].AST)` → `10`; the `:x(7)` colonpair form and a
+    positional+named mix work, and an omitted named param is undefined. Typed/defaulted named params
+    stay the boundary. Tests in `t/rakuast-eval-named-param.t`. Next: bareword type terms, slurpy
+    parameters, array/hash literals.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/compiler/helpers_ops.rs
+++ b/src/compiler/helpers_ops.rs
@@ -109,6 +109,9 @@ pub(crate) fn op_name_to_token_kind(name: &str) -> Option<TokenKind> {
         "!" => TokenKind::Bang,
         "?" => TokenKind::Question,
         "~~" => TokenKind::SmartMatch,
+        // `x => 5` — the pair constructor renders with its Debug name (there is
+        // no `=>` spelling in `token_kind_to_op_name`).
+        "FatArrow" => TokenKind::FatArrow,
         // Any remaining operator name is a named infix (`x`, `xx`, `eq`, `ne`,
         // `lt`/`gt`/`le`/`ge`, `cmp`, `leg`, `div`, `mod`, ...), which mutsu
         // represents with a generic `Ident` token (the inverse of

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -1237,8 +1237,7 @@ fn signature(param_defs: &[ParamDef], type_setting: bool) -> Result<RakuAstNode,
 /// modelled; anything richer (typed, named, slurpy, `where`, sub-signature,
 /// traits, optional-marker, invocant, shaped) is the coverage boundary.
 fn parameter(pd: &ParamDef, type_setting: bool) -> Result<RakuAstNode, RuntimeError> {
-    if pd.named
-        || pd.slurpy
+    if pd.slurpy
         || pd.double_slurpy
         || pd.onearg
         || pd.literal_value.is_some()
@@ -1254,6 +1253,13 @@ fn parameter(pd: &ParamDef, type_setting: bool) -> Result<RakuAstNode, RuntimeEr
         return Err(unsupported("non-trivial signature parameter"));
     }
     let (sigil, desigil) = split_sigil(&pd.name);
+    if pd.named {
+        // A typed/defaulted named param carries richer shape; defer for now.
+        if pd.type_constraint.is_some() || pd.default.is_some() {
+            return Err(unsupported("typed/defaulted named parameter"));
+        }
+        return named_parameter(sigil, desigil, type_setting);
+    }
     simple_parameter(
         sigil,
         desigil,
@@ -1261,6 +1267,36 @@ fn parameter(pd: &ParamDef, type_setting: bool) -> Result<RakuAstNode, RuntimeEr
         pd.default.as_ref(),
         type_setting,
     )
+}
+
+/// A named parameter `:$x` -> `Parameter(type => Type::Setting(Any),
+/// names => ("x",), target => ParameterTarget::Var)`. Named params are optional
+/// by default, so no `optional`/`default` field is emitted.
+fn named_parameter(
+    sigil: &str,
+    desigil: &str,
+    type_setting: bool,
+) -> Result<RakuAstNode, RuntimeError> {
+    let target = RakuAstNode {
+        class: RakuAstClass::ParameterTargetVar,
+        fields: vec![leaf_field(
+            Some("name"),
+            Value::str(format!("{sigil}{desigil}")),
+        )],
+    };
+    let mut fields = Vec::new();
+    if type_setting {
+        fields.push(node_field(Some("type"), type_setting_any()));
+    }
+    fields.push(RakuAstField {
+        name: Some("names"),
+        value: RakuAstFieldValue::List(vec![Value::str(desigil.to_string())]),
+    });
+    fields.push(node_field(Some("target"), target));
+    Ok(RakuAstNode {
+        class: RakuAstClass::Parameter,
+        fields,
+    })
 }
 
 /// `Type::Setting.new(Name.from-identifier("Any"))` — the implicit default type

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -236,6 +236,12 @@ fn signature_positional_params(
         let raw = leaf_str(target, "name")?;
         let name = raw.strip_prefix('$').map(str::to_string).unwrap_or(raw);
         let mut def = positional_param(&name);
+        // A named parameter `:$x` carries a `names` list; it binds by name and is
+        // optional by default.
+        if p.fields.iter().any(|f| f.name == Some("names")) {
+            def.named = true;
+            def.required = false;
+        }
         // `Int $x` -> a type constraint. `Type::Simple` (a plain type name) is
         // handled; the implicit `Type::Setting(Any)` on an untyped param is
         // ignored, and richer type forms (definite/coercion/parameterised) defer.

--- a/t/rakuast-eval-named-param.t
+++ b/t/rakuast-eval-named-param.t
@@ -1,0 +1,32 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 22 (ADR-0011): named parameters `:$x`, both directions. A named
+# `Parameter` carries a `names` list (and no `optional`, since named params are
+# optional by default); the write side sets the `ParamDef`'s `named` flag. The
+# `x => 5` call argument (a `FatArrow` infix) also lowers now. Verified against
+# Rakudo; passes under BOTH mutsu and raku.
+
+plan 5;
+
+# --- read side: a named parameter renders with a `names` list ---------------
+ok Q[sub f(:$x) { $x }].AST.gist.contains('names  => ('),
+    'a named parameter renders with a names list';
+
+# --- a named argument binds the parameter -----------------------------------
+is EVAL(Q[sub f(:$x) { $x * 2 }; f(x => 5)].AST), 10,
+    'a `key => value` argument binds a named parameter';
+
+# --- the colonpair argument form --------------------------------------------
+is EVAL(Q[sub f(:$x) { $x * 2 }; f(:x(7))].AST), 14,
+    'a `:x(value)` argument binds a named parameter';
+
+# --- a positional and a named parameter together ----------------------------
+is EVAL(Q[sub g($a, :$b) { $a + $b }; g(3, b => 4)].AST), 7,
+    'a positional and a named parameter combine';
+
+# --- an omitted named parameter is undefined --------------------------------
+is EVAL(Q[sub f(:$x) { $x.defined }; f()].AST), False,
+    'an omitted named parameter is undefined';


### PR DESCRIPTION
## Summary

RakuAST slice 22 (ADR-0011): named parameters `:$x` in **both directions**.

- **Read (`.AST`, Phase 2):** a named parameter renders as a `Parameter` with a `names` list (and no `optional`/`default` — named params are optional by default).
- **Write (`EVAL`, Phase 5):** a `Parameter` carrying a `names` field sets the `ParamDef`'s `named` flag.

The `x => 5` call argument (a `FatArrow` infix, which renders with its Debug name) also lowers now: `op_name_to_token_kind` maps `"FatArrow"` to `TokenKind::FatArrow`.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[sub f(:$x) { $x * 2 }; f(x => 5)].AST)          # 10
EVAL(Q[sub f(:$x) { $x * 2 }; f(:x(7))].AST)           # 14
EVAL(Q[sub g($a, :$b) { $a + $b }; g(3, b => 4)].AST)  # 7
EVAL(Q[sub f(:$x) { $x.defined }; f()].AST)            # False
```

Typed/defaulted named params stay the coverage boundary.

## Tests

`t/rakuast-eval-named-param.t` — 5 assertions (read-side gist has the names list, `key => value` binding, `:x(value)` colonpair, positional+named mix, omitted-is-undefined), **passing under BOTH mutsu and raku**. The read-side gist is byte-identical to Rakudo's. All 60 `t/rakuast-*.t` files (270 tests) still green.

Next: bareword type terms, slurpy parameters, array/hash literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)