### PR TITLE
feat: RakuAST slice 23 — slurpy parameters in .AST and EVAL

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -968,7 +968,10 @@ so it is tracked separately from the roast backlog.
         list; the write side sets the `ParamDef` `named` flag, and the `x => 5` call arg (`FatArrow`)
         lowers too. `EVAL(Q[sub f(:$x) { $x*2 }; f(x => 5)].AST)` → 10. Tests in
         `t/rakuast-eval-named-param.t`.
-  - [ ] Slice 23+: bareword type terms, slurpy params (`*@a`), array/hash literals, code-block (`{…}`)
+  - [x] Slice 23: slurpy parameters `*@a`/`**@a` (both directions) via new `Parameter::Slurpy::
+        Flattened`/`Unflattened` bare-class-name nodes; the write side sets the `ParamDef` slurpy flag.
+        `EVAL(Q[sub f(*@a) { @a.elems }; f(1,2,3)].AST)` → 3. Tests in `t/rakuast-eval-slurpy.t`.
+  - [ ] Slice 24+: bareword type terms, array/hash literals, `+@a` onearg, code-block (`{…}`)
         interpolation — the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full
         lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -319,6 +319,14 @@ earlier ones.
     positional+named mix work, and an omitted named param is undefined. Typed/defaulted named params
     stay the boundary. Tests in `t/rakuast-eval-named-param.t`. Next: bareword type terms, slurpy
     parameters, array/hash literals.
+  - **Slice 23 (slurpy parameters) — done, both directions.** A slurpy parameter `*@a` (or `**@a`)
+    renders as a `Parameter` with a `slurpy => RakuAST::Parameter::Slurpy::Flattened` (resp.
+    `Unflattened`) marker — a new pair of node classes that render as a *bare class name* (no
+    constructor call, via `renders_bare()`). The write side sets the `ParamDef`'s `slurpy`/
+    `double_slurpy` flag. `EVAL(Q[sub f(*@a) { @a.elems }; f(1, 2, 3)].AST)` → `3`; a leading
+    positional plus a slurpy, `.sum` over the slurpy, and an empty slurpy all work. Typed slurpies and
+    `+@a` (onearg) stay the boundary. Tests in `t/rakuast-eval-slurpy.t`. Next: bareword type terms,
+    array/hash literals.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -1237,9 +1237,7 @@ fn signature(param_defs: &[ParamDef], type_setting: bool) -> Result<RakuAstNode,
 /// modelled; anything richer (typed, named, slurpy, `where`, sub-signature,
 /// traits, optional-marker, invocant, shaped) is the coverage boundary.
 fn parameter(pd: &ParamDef, type_setting: bool) -> Result<RakuAstNode, RuntimeError> {
-    if pd.slurpy
-        || pd.double_slurpy
-        || pd.onearg
+    if pd.onearg
         || pd.literal_value.is_some()
         || pd.sub_signature.is_some()
         || pd.where_constraint.is_some()
@@ -1253,6 +1251,13 @@ fn parameter(pd: &ParamDef, type_setting: bool) -> Result<RakuAstNode, RuntimeEr
         return Err(unsupported("non-trivial signature parameter"));
     }
     let (sigil, desigil) = split_sigil(&pd.name);
+    if pd.slurpy || pd.double_slurpy {
+        // A typed slurpy carries richer shape; defer for now.
+        if pd.type_constraint.is_some() {
+            return Err(unsupported("typed slurpy parameter"));
+        }
+        return slurpy_parameter(sigil, desigil, pd.double_slurpy);
+    }
     if pd.named {
         // A typed/defaulted named param carries richer shape; defer for now.
         if pd.type_constraint.is_some() || pd.default.is_some() {
@@ -1267,6 +1272,34 @@ fn parameter(pd: &ParamDef, type_setting: bool) -> Result<RakuAstNode, RuntimeEr
         pd.default.as_ref(),
         type_setting,
     )
+}
+
+/// A slurpy parameter `*@a` / `**@a` -> `Parameter(target => …, slurpy =>
+/// RakuAST::Parameter::Slurpy::{Flattened,Unflattened})`. A slurpy carries no
+/// `type`/`optional` field.
+fn slurpy_parameter(sigil: &str, desigil: &str, double: bool) -> Result<RakuAstNode, RuntimeError> {
+    let target = RakuAstNode {
+        class: RakuAstClass::ParameterTargetVar,
+        fields: vec![leaf_field(
+            Some("name"),
+            Value::str(format!("{sigil}{desigil}")),
+        )],
+    };
+    let slurpy = RakuAstNode {
+        class: if double {
+            RakuAstClass::ParameterSlurpyUnflattened
+        } else {
+            RakuAstClass::ParameterSlurpyFlattened
+        },
+        fields: Vec::new(),
+    };
+    Ok(RakuAstNode {
+        class: RakuAstClass::Parameter,
+        fields: vec![
+            node_field(Some("target"), target),
+            node_field(Some("slurpy"), slurpy),
+        ],
+    })
 }
 
 /// A named parameter `:$x` -> `Parameter(type => Type::Setting(Any),

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -219,14 +219,9 @@ fn signature_positional_params(
         let ValueView::RakuAst(p) = v.view() else {
             return Err(unsupported(node));
         };
-        // Named / slurpy / explicitly-optional parameters carry richer shape; defer.
-        // A `default` is handled below (an optional positional with a fallback).
-        if p.fields.iter().any(|f| {
-            matches!(
-                f.name,
-                Some("slurpy") | Some("named") | Some("optional_marker")
-            )
-        }) {
+        // An explicitly-optional parameter carries richer shape; defer.
+        // `named`/`slurpy`/`default` are handled below.
+        if p.fields.iter().any(|f| f.name == Some("optional_marker")) {
             return Err(unsupported(node));
         }
         let target = named_child(p, "target")?;
@@ -241,6 +236,21 @@ fn signature_positional_params(
         if p.fields.iter().any(|f| f.name == Some("names")) {
             def.named = true;
             def.required = false;
+        }
+        // A slurpy parameter `*@a` / `**@a` carries a `slurpy` marker node.
+        if let Some(s) = p.fields.iter().find(|f| f.name == Some("slurpy")) {
+            if let RakuAstFieldValue::Node(val) = &s.value
+                && let ValueView::RakuAst(marker) = val.view()
+            {
+                match marker.class {
+                    RakuAstClass::ParameterSlurpyFlattened => def.slurpy = true,
+                    RakuAstClass::ParameterSlurpyUnflattened => def.double_slurpy = true,
+                    _ => return Err(unsupported(node)),
+                }
+                def.required = false;
+            } else {
+                return Err(unsupported(node));
+            }
         }
         // `Int $x` -> a type constraint. `Type::Simple` (a plain type name) is
         // handled; the implicit `Type::Setting(Any)` on an untyped param is

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -129,6 +129,9 @@ pub enum RakuAstClass {
     TermEnum,
     // Phase 2 slice 31: parenthesised expressions (`($x = 5)`).
     CircumfixParentheses,
+    // Phase 2 slice 32: slurpy parameter markers (`*@a` / `**@a`).
+    ParameterSlurpyFlattened,
+    ParameterSlurpyUnflattened,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -199,6 +202,8 @@ impl RakuAstClass {
             TermReduce => "RakuAST::Term::Reduce",
             TermEnum => "RakuAST::Term::Enum",
             CircumfixParentheses => "RakuAST::Circumfix::Parentheses",
+            ParameterSlurpyFlattened => "RakuAST::Parameter::Slurpy::Flattened",
+            ParameterSlurpyUnflattened => "RakuAST::Parameter::Slurpy::Unflattened",
         }
     }
 
@@ -207,6 +212,16 @@ impl RakuAstClass {
     /// `StatementList` still prints `RakuAST::StatementList.new()`).
     pub fn empty_parens_omitted(self) -> bool {
         matches!(self, RakuAstClass::Assignment)
+    }
+
+    /// Whether the node renders as a bare class name with no constructor call at
+    /// all (e.g. `RakuAST::Parameter::Slurpy::Flattened`), unlike the usual
+    /// `Class.new(...)` / `Class.new` forms.
+    pub fn renders_bare(self) -> bool {
+        matches!(
+            self,
+            RakuAstClass::ParameterSlurpyFlattened | RakuAstClass::ParameterSlurpyUnflattened
+        )
     }
 
     pub fn constructor(self) -> Constructor {

--- a/src/rakuast/render.rs
+++ b/src/rakuast/render.rs
@@ -13,6 +13,11 @@ use crate::value::{Value, ValueView};
 
 pub(super) fn render_node(node: &RakuAstNode, indent: usize) -> String {
     let name = node.class.printed_name();
+    // A bare-class-name node (e.g. `RakuAST::Parameter::Slurpy::Flattened`) has no
+    // constructor call at all.
+    if node.class.renders_bare() {
+        return name.to_string();
+    }
     let ctor = match node.class.constructor() {
         Constructor::New => "new",
         Constructor::FromIdentifier => "from-identifier",

--- a/t/rakuast-eval-slurpy.t
+++ b/t/rakuast-eval-slurpy.t
@@ -1,0 +1,31 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 23 (ADR-0011): slurpy parameters `*@a`, both directions. A slurpy
+# `Parameter` carries a `slurpy => RakuAST::Parameter::Slurpy::Flattened` marker
+# (a bare class-name node); the write side sets the `ParamDef`'s `slurpy` flag.
+# Verified against Rakudo; passes under BOTH mutsu and raku.
+
+plan 5;
+
+# --- read side: the slurpy marker renders as a bare class name --------------
+ok Q[sub f(*@a) { @a }].AST.gist.contains('slurpy => RakuAST::Parameter::Slurpy::Flattened'),
+    'a slurpy parameter renders with the Flattened marker';
+
+# --- a slurpy collects all positional arguments -----------------------------
+is EVAL(Q[sub f(*@a) { @a.elems }; f(1, 2, 3)].AST), 3,
+    'a slurpy collects every positional argument';
+
+# --- a leading positional plus a slurpy -------------------------------------
+is EVAL(Q[sub f($first, *@rest) { $first + @rest.elems }; f(10, 1, 2, 3)].AST), 13,
+    'a leading positional plus a slurpy';
+
+# --- the slurpy array supports list methods ---------------------------------
+is EVAL(Q[sub total(*@n) { @n.sum }; total(1, 2, 3, 4)].AST), 10,
+    'the slurpy array is a real list';
+
+# --- an empty slurpy --------------------------------------------------------
+is EVAL(Q[sub f(*@a) { @a.elems }; f()].AST), 0,
+    'a slurpy with no arguments is empty';


### PR DESCRIPTION
## Summary

RakuAST slice 23 (ADR-0011): slurpy parameters `*@a` / `**@a` in **both directions**.

- **Read (`.AST`, Phase 2):** a slurpy renders as a `Parameter` with a `slurpy => RakuAST::Parameter::Slurpy::Flattened` (resp. `Unflattened`) marker. These are a new pair of node classes that render as a **bare class name** — no constructor call at all — via a new `renders_bare()` predicate.
- **Write (`EVAL`, Phase 5):** a `Parameter` carrying a `slurpy` marker sets the `ParamDef`'s `slurpy`/`double_slurpy` flag.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q[sub f(*@a) { @a.elems }; f(1, 2, 3)].AST)                        # 3
EVAL(Q[sub f($first, *@rest) { $first + @rest.elems }; f(10, 1, 2, 3)].AST)  # 13
EVAL(Q[sub total(*@n) { @n.sum }; total(1, 2, 3, 4)].AST)              # 10
```

Typed slurpies and `+@a` (onearg) stay the coverage boundary.

## Tests

`t/rakuast-eval-slurpy.t` — 5 assertions (read-side gist has the Flattened marker, slurpy collects positionals, leading positional + slurpy, `.sum` over the slurpy, empty slurpy), **passing under BOTH mutsu and raku**. The read-side gist is byte-identical to Rakudo's. All 61 `t/rakuast-*.t` files (275 tests) still green.

Next: bareword type terms, array/hash literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)