### PR TITLE
feat: RakuAST slice 24 — array-composer literals in .AST and EVAL

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -976,9 +976,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 23: slurpy parameters `*@a`/`**@a` (both directions) via new `Parameter::Slurpy::
         Flattened`/`Unflattened` bare-class-name nodes; the write side sets the `ParamDef` slurpy flag.
         `EVAL(Q[sub f(*@a) { @a.elems }; f(1,2,3)].AST)` → 3. Tests in `t/rakuast-eval-slurpy.t`.
-  - [ ] Slice 24+: bareword type terms, array/hash literals, `+@a` onearg, code-block (`{…}`)
-        interpolation — the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full
-        lowering is a large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 24: array-composer literals `[1, 2, 3]` (both directions) via a new
+        `Circumfix::ArrayComposer` node — `Expr::BracketArray` ↔ `Circumfix::ArrayComposer(SemiList(…))`.
+        `EVAL(Q{[1, 2, 3].sum}.AST)` → 6. Tests in `t/rakuast-eval-array-lit.t`.
+  - [ ] Slice 25+: positional subscripts (`@a[1]`), hash literals, bareword type terms, code-block
+        (`{…}`) interpolation — the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5
+        full lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -327,6 +327,14 @@ earlier ones.
     positional plus a slurpy, `.sum` over the slurpy, and an empty slurpy all work. Typed slurpies and
     `+@a` (onearg) stay the boundary. Tests in `t/rakuast-eval-slurpy.t`. Next: bareword type terms,
     array/hash literals.
+  - **Slice 24 (array-composer literals) — done, both directions.** A `[1, 2, 3]` literal renders as a
+    new `Circumfix::ArrayComposer` node wrapping a single-statement `SemiList` (a comma list — the
+    conversion reuses a shared `comma_list_node`). The read side converts `Expr::BracketArray` to it and
+    the write side unwraps it to an array literal (`Expr::BracketArray`). `EVAL(Q{[1, 2, 3].elems}.AST)`
+    → `3`; `.sum`/`.sort.join` over the literal and a single-element `[5]` work. This also fixes the
+    previous `[…].method` convert error. Positional subscripts (`@a[1]` — an `ApplyPostfix` with a
+    `Postcircumfix::ArrayIndex`) stay the boundary. Tests in `t/rakuast-eval-array-lit.t`. Next:
+    positional subscripts, hash literals, bareword type terms.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -886,20 +886,18 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
             })
         }
         // A bare comma list `1, 2, 3` -> ApplyListInfix(infix => ",", operands).
-        Expr::ArrayLiteral(items) => {
-            let mut operands = Vec::with_capacity(items.len());
-            for it in items {
-                operands.push(Value::rakuast(Box::new(convert_expr(it)?)));
-            }
+        Expr::ArrayLiteral(items) => comma_list_node(items),
+        // An array-composer literal `[1, 2, 3]` ->
+        // `Circumfix::ArrayComposer(SemiList(Statement::Expression(comma-list)))`.
+        Expr::BracketArray(items, _) => {
+            let inner = comma_list_node(items)?;
+            let semilist = RakuAstNode {
+                class: RakuAstClass::SemiList,
+                fields: vec![node_field(None, statement_expression(inner))],
+            };
             Ok(RakuAstNode {
-                class: RakuAstClass::ApplyListInfix,
-                fields: vec![
-                    node_field(Some("infix"), plain_infix(",")),
-                    RakuAstField {
-                        name: Some("operands"),
-                        value: RakuAstFieldValue::List(operands),
-                    },
-                ],
+                class: RakuAstClass::CircumfixArrayComposer,
+                fields: vec![node_field(None, semilist)],
             })
         }
         // Positional subscript `@x[EXPR]` -> ApplyPostfix(operand,
@@ -1590,6 +1588,24 @@ fn control_call(name: &'static str, args: &[Expr]) -> Result<RakuAstNode, Runtim
     Ok(RakuAstNode {
         class: RakuAstClass::CallNameWithoutParentheses,
         fields,
+    })
+}
+
+/// A comma list `1, 2, 3` -> `ApplyListInfix(infix => ",", operands)`.
+fn comma_list_node(items: &[Expr]) -> Result<RakuAstNode, RuntimeError> {
+    let mut operands = Vec::with_capacity(items.len());
+    for it in items {
+        operands.push(Value::rakuast(Box::new(convert_expr(it)?)));
+    }
+    Ok(RakuAstNode {
+        class: RakuAstClass::ApplyListInfix,
+        fields: vec![
+            node_field(Some("infix"), plain_infix(",")),
+            RakuAstField {
+                name: Some("operands"),
+                value: RakuAstFieldValue::List(operands),
+            },
+        ],
     })
 }
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -559,6 +559,17 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             let inner = named_child_or_positional(semilist)?;
             lower_expr(inner)
         }
+        // `[1, 2, 3]` -> an array literal. The composer wraps a `SemiList` of a
+        // single `Statement::Expression` (a comma list, or a lone element).
+        RakuAstClass::CircumfixArrayComposer => {
+            let semilist = named_child_or_positional(node)?;
+            let inner = named_child_or_positional(semilist)?;
+            let items = match lower_expr(inner)? {
+                Expr::ArrayLiteral(items) => items,
+                other => vec![other],
+            };
+            Ok(Expr::BracketArray(items, false))
+        }
         // `True`/`False` -> the Bool literal. Other enum identifiers are deferred.
         RakuAstClass::TermEnum => match positional_leaf(node)?.view() {
             ValueView::Str(s) if s.as_str() == "True" => Ok(Expr::Literal(Value::truth(true))),

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -132,6 +132,8 @@ pub enum RakuAstClass {
     // Phase 2 slice 32: slurpy parameter markers (`*@a` / `**@a`).
     ParameterSlurpyFlattened,
     ParameterSlurpyUnflattened,
+    // Phase 2 slice 33: array-composer literal (`[1, 2, 3]`).
+    CircumfixArrayComposer,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -204,6 +206,7 @@ impl RakuAstClass {
             CircumfixParentheses => "RakuAST::Circumfix::Parentheses",
             ParameterSlurpyFlattened => "RakuAST::Parameter::Slurpy::Flattened",
             ParameterSlurpyUnflattened => "RakuAST::Parameter::Slurpy::Unflattened",
+            CircumfixArrayComposer => "RakuAST::Circumfix::ArrayComposer",
         }
     }
 

--- a/t/rakuast-eval-array-lit.t
+++ b/t/rakuast-eval-array-lit.t
@@ -1,0 +1,26 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 24 (ADR-0011): array-composer literals `[1, 2, 3]`, both
+# directions. raku models `[…]` as a `Circumfix::ArrayComposer` wrapping a
+# single-statement `SemiList` (a comma list). The read side (`.AST`) emits that
+# node and the write side (`EVAL`) lowers it to an array literal. Verified against
+# Rakudo; passes under BOTH mutsu and raku.
+
+plan 5;
+
+# --- read side: the literal renders as Circumfix::ArrayComposer -------------
+ok Q{[1, 2, 3]}.AST.gist.contains('RakuAST::Circumfix::ArrayComposer.new('),
+    'an array literal renders as Circumfix::ArrayComposer';
+
+# --- element count ----------------------------------------------------------
+is EVAL(Q{[1, 2, 3].elems}.AST), 3, 'a three-element array literal';
+
+# --- a list method on the literal -------------------------------------------
+is EVAL(Q{[1, 2, 3].sum}.AST), 6, 'sum over an array literal';
+is EVAL(Q{[3, 1, 2].sort.join(",")}.AST), '1,2,3', 'sort/join over an array literal';
+
+# --- a single-element literal -----------------------------------------------
+is EVAL(Q{[5].elems}.AST), 1, 'a single-element array literal';


### PR DESCRIPTION
## Summary

RakuAST slice 24 (ADR-0011): array-composer literals `[1, 2, 3]` in **both directions**.

A new `Circumfix::ArrayComposer` node class models `[…]` (wrapping a single-statement `SemiList` — a comma list):

```raku
Q{[1, 2, 3]}.AST   # ... Circumfix::ArrayComposer(SemiList(Statement::Expression(ApplyListInfix(","))))
```

- **Read (`.AST`, Phase 2):** `Expr::BracketArray` → `Circumfix::ArrayComposer(SemiList(…))`. The comma-list build is factored into a shared `comma_list_node`.
- **Write (`EVAL`, Phase 5):** a `Circumfix::ArrayComposer` unwraps to the inner comma list, producing an `Expr::BracketArray`.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q{[1, 2, 3].elems}.AST)          # 3
EVAL(Q{[1, 2, 3].sum}.AST)            # 6
EVAL(Q{[3, 1, 2].sort.join(",")}.AST) # "1,2,3"
```

This also fixes the previous convert error on `[…].method`. Positional subscripts (`@a[1]`) stay the coverage boundary.

## Tests

`t/rakuast-eval-array-lit.t` — 5 assertions (read-side gist has ArrayComposer, element count, `.sum`, `.sort.join`, single-element `[5]`), **passing under BOTH mutsu and raku**. The read-side gist is byte-identical to Rakudo's. All 62 `t/rakuast-*.t` files (280 tests) still green.

Next: positional subscripts, hash literals, bareword type terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)