### PR TITLE
fix: make &WHAT/&HOW/&VAR first-class callables

### DIFF
--- a/src/runtime/accessors_resolve.rs
+++ b/src/runtime/accessors_resolve.rs
@@ -339,6 +339,12 @@ impl Interpreter {
             sub_val
         } else if Self::is_builtin_function(lookup_name) {
             Value::routine_parts(Symbol::intern("GLOBAL"), Symbol::intern(lookup_name), false)
+        } else if Self::is_mop_macro_function(lookup_name) {
+            // The MOP pseudo-methods `WHAT`/`HOW`/`VAR` are also first-class
+            // callables in Raku — `&WHAT`, `.map(&WHAT)`, `my $f = &WHAT` — not
+            // just call-syntax macros. They dispatch through the builtin-function
+            // path (see `builtins.rs`), so expose them as Routine values here.
+            Value::routine_parts(Symbol::intern("GLOBAL"), Symbol::intern(lookup_name), false)
         } else if self.test_module_loaded() && Self::is_test_function_name(lookup_name) {
             // Test-framework functions (&is-deeply, &pass, ...) are implemented
             // as Rust methods (runtime/test_functions.rs), not declared subs, so

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -1025,6 +1025,15 @@ impl Interpreter {
         BUILTIN_FUNCTION_NAMES.contains(&name)
     }
 
+    /// MOP pseudo-methods (`WHAT`, `HOW`, `VAR`) that Raku also exposes as
+    /// first-class `&`-callables (`&WHAT`, `.map(&WHAT)`). They are dispatched as
+    /// bare functions (see the function-call handler), but are deliberately kept
+    /// out of `BUILTIN_FUNCTION_NAMES` so they do not shadow the same-named
+    /// methods in other resolution paths; `resolve_code_var` special-cases them.
+    pub(crate) fn is_mop_macro_function(name: &str) -> bool {
+        matches!(name, "WHAT" | "HOW" | "VAR")
+    }
+
     /// Builtin `skip(N, list)` function — skips N elements from the list.
     /// This is only called when the args look like a list-skip (not Test::skip).
     pub(crate) fn builtin_skip(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {

--- a/t/amp-what-callable.t
+++ b/t/amp-what-callable.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+# The MOP pseudo-methods WHAT/HOW/VAR are also first-class `&`-callables in
+# Raku: `&WHAT`, `.map(&WHAT)`, `my $f = &WHAT; $f($x)`. Previously mutsu only
+# handled the call-syntax forms (`WHAT($x)`), so `&WHAT` resolved to Any and
+# `.map(&WHAT)` threw "Cannot map a Any to a Seq".
+
+plan 8;
+
+# `&WHAT` is a usable callable value.
+{
+    my $f = &WHAT;
+    is $f(42).gist, '(Int)', 'my $f = &WHAT; $f(Int) works';
+    is $f("x").gist, '(Str)', 'the same callable applied to a Str';
+    is $f(3.14).gist, '(Rat)', 'the same callable applied to a Rat';
+}
+
+# `.map(&WHAT)` over a plain list.
+is (1, 2, 3).map(&WHAT).gist, '((Int) (Int) (Int))', '.map(&WHAT) over a List';
+
+# `.map(&WHAT)` over set/bag keys (the doc-example shape).
+is (set <a b c>).keys.map(&WHAT).sort.gist, '((Str) (Str) (Str))',
+    '.map(&WHAT) over Set keys';
+is (bag "a" => 0, "b" => 1).keys.map(&WHAT).gist, '((Pair) (Pair))',
+    '.map(&WHAT) over Bag keys built from Pairs';
+
+# `&HOW` and `&VAR` are likewise first-class.
+ok (&HOW.defined), '&HOW resolves to a defined callable';
+is (10, 20).map(&VAR).gist, '(10 20)', '.map(&VAR) returns the containers';


### PR DESCRIPTION
## Summary

The MOP pseudo-methods `WHAT`, `HOW`, `VAR` are also first-class `&`-callables in Raku — `&WHAT`, `.map(&WHAT)`, `my $f = &WHAT; $f($x)` — not just call-syntax macros. mutsu dispatched the call forms (`WHAT($x)`) but resolved the bare value `&WHAT` to `Any`, so `.map(&WHAT)` threw:

```
X::Cannot::Map: Cannot map a Any to a Seq
```

This hit **9 raku-doc examples** across `Set`/`Bag`/`Mix`/`SetHash`/`MixHash` of the shape `$coll.keys.map(&WHAT)`.

## Fix

`resolve_code_var` now returns a `Routine` value for these names (gated by a new `is_mop_macro_function`), matching how `&sqrt`/`&say` resolve. They are deliberately kept out of `BUILTIN_FUNCTION_NAMES` so they do not shadow the same-named methods in other resolution paths.

Found by the doc-diff harness (`scripts/doc-diff-harness.raku`, PLAN §8).

## Testing

- New pin: `t/amp-what-callable.t` (8 subtests).
- `make test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)