### PR TITLE
feat: augment on builtin native classes (DateTime/Date) — JSON::Fast 14/14

### DIFF
--- a/docs/mzef-install-pipeline.md
+++ b/docs/mzef-install-pipeline.md
@@ -212,30 +212,31 @@ repro → general fix → `t/` pin):
   predicates. It now delegates to the same subset matcher `~~` uses. Pin:
   `t/subset-regex-return-check.t`.
 
-## Test-phase frontier (2026-07-18 refresh)
+## Test-phase frontier (CLOSED 2026-07-19 — all 11 suites PASS)
 
-**Per-suite standing (2026-07-18, after #4735 / #4738 / #4747 / #4756;
-staged-dist `prove` sweep with the full MUTSULIB chain,
-`tmp/e2e-suites.sh`): 10 PASS / 1 FAIL.** PASS: JSON::OptIn, JSON::Name,
+**Per-suite standing (2026-07-19; staged-dist `prove` sweep with the full
+MUTSULIB chain, `tmp/e2e-suites.sh`): 11 PASS / 0 FAIL.** PASS: JSON::OptIn, JSON::Name,
 JSON::Unmarshal (11 files / 101 tests), JSON::Marshal (14/85), JSON::Class
 (6/31), URI (14/222), META6 (9/969), License::SPDX (2/729), Test::META
-(3/26, #4756). FAIL: **JSON::Fast** only (native-JSON fidelity remnants;
-full parity is likely unnecessary for the pipeline). Within JSON::Fast,
-four PRs (#4762 AdditionalContent + strict grammar; #4765 options parity:
-`:immutable`/List+Map decode, `:enums-as-value`, `$*JSON_NAN_INF_SUPPORT`,
-import-list defaults `<immutable !pretty>`, `&from-json`/`.&from-json`
-code-object dispatch, uppercase surrogate escapes, Duration-as-Num;
-#4768 numerator/denominator-shadow: those builtins no longer claim every
-invocant, so the Rational role prelude's attr accessors work and a punned
-Rational serializes numerically; the JSONC/assoc-pos PR: `:allow-jsonc`
-comment skipping, Associative/Positional user instances serialize via
-`.list`, and `Foo::.values`/`Bool::.values` stash enumeration) brought
-the suite from 3/14 to **13/14 files green**; the only remaining file is
-07-datetime, blocked on `augment class DateTime` for a builtin native
-class (MONKEY-TYPING on Date/DateTime — campaign-sized, not JSON work).
-Known adjacent gap (not needed by the suite): an UNparameterized
-`Rational.new(6,4)` still fails binding (`expected NuT, got Int` — role
-type-param defaults `::NuT = Int` unresolved in method signatures).
+(3/26, #4756), **JSON::Fast** (**14/14 files / 931 tests** — five PRs,
+2026-07-19: #4762 AdditionalContent + strict grammar; #4765 options
+parity: `:immutable`/List+Map decode, `:enums-as-value`,
+`$*JSON_NAN_INF_SUPPORT`, import-list defaults `<immutable !pretty>`,
+`&from-json`/`.&from-json` code-object dispatch, uppercase surrogate
+escapes, Duration-as-Num; #4768 numerator/denominator-shadow: those
+builtins no longer claim every invocant, so the Rational role prelude's
+attr accessors work and a punned Rational serializes numerically; #4770
+`:allow-jsonc` comment skipping, Associative/Positional user instances
+serialize via `.list`, `Foo::.values`/`Bool::.values` stash enumeration;
+and the augment-builtin PR: `augment class DateTime/Date` on builtin
+native classes — an augmented `multi method new` candidate wins when it
+matches and falls back to the native ctor, Instant serializes as its
+`.DateTime` ISO string, and hyper `»=~=«`/`»=:=«` are no longer
+mis-stripped as `op=` assignments). **No suite in the Test::META chain
+fails anymore.** Known adjacent gap (not needed by the suite): an
+UNparameterized `Rational.new(6,4)` still fails binding (`expected NuT,
+got Int` — role type-param defaults `::NuT = Int` unresolved in method
+signatures).
 Test-Helpers ships no `t/` of its own (covered by mutsu's local
 `t/test-util-*.t`).
 

--- a/src/compiler/expr_ops.rs
+++ b/src/compiler/expr_ops.rs
@@ -219,7 +219,10 @@ impl Compiler {
         // These need to compute with the base op and then assign back.
         let is_assign_op = op.ends_with('=')
             && op.len() > 1
-            && !matches!(op, "==" | "!=" | "<=" | ">=" | "===" | "!==" | "<=>");
+            && !matches!(
+                op,
+                "==" | "!=" | "<=" | ">=" | "===" | "!==" | "<=>" | "=~=" | "=:="
+            );
         // Hyper meta-assignment over a literal list of lvalues, e.g.
         // `($a, $b, $c) »~=» <pie tart>`: compute the element-wise result with
         // the base op, then distribute it back to each lvalue via the regular

--- a/src/runtime/builtins_operators_coerce.rs
+++ b/src/runtime/builtins_operators_coerce.rs
@@ -228,6 +228,10 @@ impl Interpreter {
                 self.resolve_function_with_types(&infix_name, &[l.clone(), r.clone()])
             {
                 self.call_function_def(&v, &[l, r])?
+            } else if inner == "=~=" || inner == "\u{2245}" {
+                // `=~=` needs $*TOLERANCE (self), so the static reduction table
+                // cannot host it (its `op=` catch-all would also mis-strip it).
+                self.approx_eq_values(l, r)?
             } else {
                 Self::apply_reduction_op(inner, &l, &r)?
             };

--- a/src/runtime/json.rs
+++ b/src/runtime/json.rs
@@ -177,6 +177,38 @@ fn jsonify(val: &Value, opts: &ToJsonOpts, level: usize, out: &mut String) {
                 out.push('"');
             }
         }
+        // Instant serializes as its `.DateTime` ISO string (JSON::Fast's
+        // Instant candidate: `"{.DateTime}"`), not the raw `Instant:...` gist.
+        ValueView::Instance {
+            class_name,
+            attributes,
+            ..
+        } if class_name.resolve() == "Instant" => {
+            use crate::builtins::methods_0arg::temporal;
+            let tai = attributes
+                .as_map()
+                .get("value")
+                .map(|v| v.to_f64())
+                .unwrap_or(0.0);
+            let posix = temporal::instant_to_posix(tai);
+            let total_i = posix.floor() as i64;
+            let frac = posix - total_i as f64;
+            let day_secs = total_i.rem_euclid(86400);
+            let epoch_days = (total_i - day_secs) / 86400;
+            let (y, m, d) = temporal::epoch_days_to_civil(epoch_days);
+            let iso = temporal::format_datetime(
+                y,
+                m,
+                d,
+                day_secs / 3600,
+                (day_secs % 3600) / 60,
+                (day_secs % 60) as f64 + frac,
+                0,
+            );
+            out.push('"');
+            escape_str(&iso, out);
+            out.push('"');
+        }
         // Duration is Real (a Rat-backed instance: `value` attr); JSON::Fast's
         // Real:D candidate serializes it numerically as a Num (`57e0`).
         ValueView::Instance {

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -44,6 +44,27 @@ fn constructor_positional_error(class_name: &str) -> RuntimeError {
 }
 
 impl Interpreter {
+    /// Try `.new` candidates a user `augment class` (MONKEY-TYPING) added to a
+    /// builtin native class (Date/DateTime). Returns `Ok(Some(v))` when a user
+    /// candidate matched, `Ok(None)` when there are no user candidates or none
+    /// matched (caller falls through to the native ctor), and `Err` for a real
+    /// error raised by the matched candidate.
+    fn try_augmented_builtin_new(
+        &mut self,
+        class_key: &str,
+        args: &[Value],
+    ) -> Result<Option<Value>, RuntimeError> {
+        if !self.has_user_method(class_key, "new") {
+            return Ok(None);
+        }
+        let empty_attrs = AttrMap::new();
+        match self.run_instance_method(class_key, empty_attrs, "new", args.to_vec(), None) {
+            Ok((result, _updated)) => Ok(Some(result)),
+            Err(e) if e.is_multi_no_match() => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
     /// Materialize a user `message` *method* into the `message` attribute of a
     /// freshly-constructed exception. raku computes `Exception.message` lazily,
     /// but mutsu's interpreter-less stringification (`join`, `sprintf "%s"`, `~`,
@@ -582,6 +603,12 @@ impl Interpreter {
                     return Ok(Self::build_native_strdistance_value(&args));
                 }
                 "Date" => {
+                    // An augmented `multi method new` (MONKEY-TYPING) wins when
+                    // a candidate matches; a no-match falls back to the native
+                    // ctor (mirrors the user-new dispatch further below).
+                    if let Some(result) = self.try_augmented_builtin_new(class_key, &args)? {
+                        return Ok(result);
+                    }
                     // Shared with the VM's native fast path. Only the formatter
                     // case needs `self` (it renders a user Callable).
                     let (date, formatter) = Self::build_native_date(&args)?;
@@ -591,6 +618,9 @@ impl Interpreter {
                     return Ok(date);
                 }
                 "DateTime" => {
+                    if let Some(result) = self.try_augmented_builtin_new(class_key, &args)? {
+                        return Ok(result);
+                    }
                     // Shared with the VM's native fast path. Only the
                     // `:formatter` case needs `self` (it renders a user
                     // Callable); the common case is built natively.

--- a/src/runtime/ops_reduction.rs
+++ b/src/runtime/ops_reduction.rs
@@ -798,9 +798,11 @@ impl Interpreter {
             )),
             "(==)" | "≡" => Ok(Value::truth(Self::apply_set_equality(left, right)?)),
             "≢" => Ok(Value::truth(!Self::apply_set_equality(left, right)?)),
-            _ if op.ends_with('=') && op.len() > 1 => {
+            _ if op.ends_with('=') && op.len() > 1 && op != "=~=" && op != "=:=" => {
                 // Compound assignment operator (e.g., "~=", "+=", "-=", "*=")
-                // Apply the base operator and return the result.
+                // Apply the base operator and return the result. `=~=`/`=:=`
+                // are comparison ops, not `op=` forms — mis-stripping them
+                // yields a bogus "Unsupported reduction operator: =~".
                 let base_op = &op[..op.len() - 1];
                 Self::apply_reduction_op(base_op, left, right)
             }

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -108,6 +108,11 @@ impl Interpreter {
                 "Endian",
                 "Proc",
                 "Capture",
+                "DateTime",
+                "Date",
+                "Dateish",
+                "Instant",
+                "Duration",
             ];
             if !BUILTIN_TYPES.contains(&name) {
                 let message = format!("You tried to augment class {}, but it does not exist", name);

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -78,6 +78,10 @@ impl Interpreter {
         // performs directly instead of routing through `dispatch_new`.
         if method == "new"
             && let ValueView::Package(class_name) = target.view()
+            // An augmented `multi method new` (MONKEY-TYPING on a builtin class,
+            // e.g. DateTime) must reach dispatch_new's candidate merge — skip
+            // the pure-native fork when user candidates exist.
+            && !self.has_user_method(&class_name.resolve(), "new")
             && let Some(result) =
                 crate::runtime::Interpreter::try_native_builtin_construct(class_name, &args)
         {

--- a/src/vm/vm_call_method_compiled_mut.rs
+++ b/src/vm/vm_call_method_compiled_mut.rs
@@ -26,6 +26,9 @@ impl Interpreter {
         // Native built-in construction (mut path twin of the above).
         if method == "new"
             && let ValueView::Package(class_name) = target.view()
+            // Augmented `multi method new` candidates must reach dispatch_new
+            // (see the non-mut twin).
+            && !self.has_user_method(&class_name.resolve(), "new")
             && let Some(result) =
                 crate::runtime::Interpreter::try_native_builtin_construct(class_name, &args)
         {

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -473,6 +473,18 @@ impl Interpreter {
     pub(super) fn exec_approx_eq_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
+        let result = self.approx_eq_values(left, right)?;
+        self.stack.push(result);
+        Ok(())
+    }
+
+    /// `=~=` on two values (shared by the ApproxEq opcode and the hyper/meta
+    /// paths, e.g. `»=~=«`). Honors `$*TOLERANCE`.
+    pub(crate) fn approx_eq_values(
+        &mut self,
+        left: Value,
+        right: Value,
+    ) -> Result<Value, RuntimeError> {
         let (left, right) = self.coerce_numeric_bridge_pair(left, right)?;
         let tolerance = loan_env!(self, get_dynamic_var("*TOLERANCE"))
             .ok()
@@ -505,7 +517,6 @@ impl Interpreter {
             diff / max_abs <= tolerance
         };
         let result = approx_f64(lr, rr) && approx_f64(li, ri);
-        self.stack.push(Value::truth(result));
-        Ok(())
+        Ok(Value::truth(result))
     }
 }

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -148,6 +148,11 @@ impl Interpreter {
             "\u{2260}" => "!=",
             other => other,
         };
+        // `=~=` needs $*TOLERANCE (self), so the static reduction table cannot
+        // host it (and its `op=` catch-all would mis-strip it to `=~`).
+        if normalized_op == "=~=" || normalized_op == "\u{2245}" {
+            return self.approx_eq_values(left.clone(), right.clone());
+        }
         match Interpreter::apply_reduction_op(normalized_op, left, right) {
             Ok(v) => Ok(v),
             Err(err) if err.message.starts_with("Unsupported reduction operator:") => {

--- a/t/augment-builtin-datetime.t
+++ b/t/augment-builtin-datetime.t
@@ -1,0 +1,34 @@
+use v6;
+use Test;
+
+# MONKEY-TYPING on builtin native classes (JSON::Fast t/07-datetime.t parity):
+# an augmented `multi method new` candidate wins when it matches, and falls
+# back to the native constructor otherwise.
+
+use MONKEY-TYPING;
+augment class DateTime { multi method new(Any:U) { $?CLASS } }
+augment class Date { multi method new(Any:U) { $?CLASS } }
+
+ok DateTime.new(Any) === DateTime, 'augmented DateTime.new(Any:U) candidate matches';
+ok Date.new(Any) === Date, 'augmented Date.new(Any:U) candidate matches';
+
+my $dt = DateTime.new(2026, 7, 19, 12, 34, 56);
+is $dt.year, 2026, 'native DateTime.new still works after augment';
+is Date.new("2026-07-19").day, 19, 'native Date.new still works after augment';
+dies-ok { DateTime.new }, 'no-arg DateTime.new still rejected';
+
+# Instant serializes as its .DateTime ISO string in to-json.
+{
+    use JSON::Fast;
+    my $i = now;
+    my $json = to-json([$i], :!pretty);
+    like $json, /'["' \d**4 '-' \d\d '-' \d\d 'T'/, 'Instant serializes as ISO datetime';
+    my $trip = DateTime.new(from-json($json)[0]).Instant;
+    ok $trip.to-posix[0] - $i.to-posix[0] < 1, 'Instant roundtrips through its DateTime string';
+}
+
+# Hyper forms of the comparison ops ending in `=` are not `op=` assignments.
+is-deeply ((1.0, 2.0) »=~=« (1.0, 2.0)).List, (True, True), 'hyper =~= works';
+is-deeply ((1, 2) »=:=« (1, 2)).List, (True, True), 'hyper =:= works';
+
+done-testing;


### PR DESCRIPTION
## Summary

MONKEY-TYPING on builtin native classes, driven by JSON::Fast `t/07-datetime.t` — the last red file in the mzef Test::META dependency chain. **JSON::Fast goes 13/14 → 14/14 (931 tests); no suite in the chain fails anymore**, so the real-zef tests-ON install should now complete without `--force-test`.

- **`augment class DateTime/Date/Dateish/Instant/Duration`** is accepted (added to the augmentable-builtin whitelist; a minimal registry entry is created).
- **Augmented `multi method new` participates in construction dispatch**: the native-ctor forks (both VM fast paths and `dispatch_new`'s Date/DateTime arms) first try the user candidates via `run_instance_method` and fall back to the native constructor on `X::Multi::NoMatch` — `DateTime.new(Any)` hits the augment while `DateTime.new(2026,7,19,…)` still builds natively.
- **Instant serializes as its `.DateTime` ISO string** in to-json (JSON::Fast's Instant candidate), not the raw `Instant:...` gist — this is what lets the roundtrip test compare instants.
- **Hyper `»=~=«` / `»=:=«` fixed**: comparison ops ending in `=` were mis-parsed as `op=` hyper-assignments (compiler) and mis-stripped again in the reduction fallback (`»=~=«` → base op `=~` → "Unsupported reduction operator"). Both strip sites now except them, and the hyper path routes `=~=` through a shared `approx_eq_values` (honors `$*TOLERANCE`, extracted from the ApproxEq opcode).

## Results

- JSON::Fast: **14/14 files** green. Test-phase frontier marked CLOSED in `docs/mzef-install-pipeline.md` (11/11 staged suites PASS).
- `make test` 18414 PASS.

## Tests

- `t/augment-builtin-datetime.t` — augment candidates match, native ctors keep working, no-arg still rejected, Instant ISO roundtrip, hyper `=~=`/`=:=`

🤖 Generated with [Claude Code](https://claude.com/claude-code)