### PR TITLE
feat: RakuAST Phase 5 slice 25 — EVAL of positional subscripts

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -979,7 +979,10 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 24: array-composer literals `[1, 2, 3]` (both directions) via a new
         `Circumfix::ArrayComposer` node — `Expr::BracketArray` ↔ `Circumfix::ArrayComposer(SemiList(…))`.
         `EVAL(Q{[1, 2, 3].sum}.AST)` → 6. Tests in `t/rakuast-eval-array-lit.t`.
-  - [ ] Slice 25+: positional subscripts (`@a[1]`), hash literals, bareword type terms, code-block
+  - [x] Slice 25: positional subscripts `@a[EXPR]` (`ApplyPostfix` + `Postcircumfix::ArrayIndex` →
+        `Expr::Index`); `EVAL(Q{my @a = 10, 20, 30; @a[1]}.AST)` → 20. Tests in
+        `t/rakuast-eval-subscript.t`.
+  - [ ] Slice 26+: hash literals, associative subscripts (`%h{…}`), bareword type terms, code-block
         (`{…}`) interpolation — the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5
         full lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -335,6 +335,12 @@ earlier ones.
     previous `[…].method` convert error. Positional subscripts (`@a[1]` — an `ApplyPostfix` with a
     `Postcircumfix::ArrayIndex`) stay the boundary. Tests in `t/rakuast-eval-array-lit.t`. Next:
     positional subscripts, hash literals, bareword type terms.
+  - **Slice 25 (positional subscripts) — done.** An `ApplyPostfix` with a `Postcircumfix::ArrayIndex`
+    postfix (`@a[EXPR]`) lowers to `Expr::Index` (the index is the `SemiList`'s single
+    `Statement::Expression`); the read side already emits it. `EVAL(Q{my @a = 10, 20, 30; @a[1]}.AST)` →
+    `20`; a computed index, subscripting an array literal (`[10, 20, 30][2]`), and two subscripts in an
+    expression work. Associative subscripts (`%h{…}`) and slices (`@a[1, 2]`) stay the boundary. Tests
+    in `t/rakuast-eval-subscript.t`. Next: hash literals, bareword type terms, code-block interpolation.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -646,21 +646,34 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             }
             Ok(Expr::ArrayLiteral(items))
         }
-        // A postfix method call: `$x.abs` -> ApplyPostfix(operand, Call::Method).
-        // Subscripts / hyper-calls carry a different postfix and are deferred.
+        // A postfix method call (`$x.abs`) or a positional subscript (`@a[1]`).
+        // Hyper-calls and associative subscripts carry a different postfix and are
+        // deferred.
         RakuAstClass::ApplyPostfix => {
             let operand = lower_expr(named_child(node, "operand")?)?;
             let postfix = named_child(node, "postfix")?;
-            if postfix.class != RakuAstClass::CallMethod {
-                return Err(unsupported(node));
+            match postfix.class {
+                RakuAstClass::CallMethod => Ok(Expr::MethodCall {
+                    target: Box::new(operand),
+                    name: crate::symbol::Symbol::intern(&call_name_str(postfix)?),
+                    args: arg_exprs(postfix)?,
+                    modifier: None,
+                    quoted: false,
+                }),
+                // `@a[EXPR]` -> Postcircumfix::ArrayIndex(index => SemiList(
+                // Statement::Expression(EXPR))).
+                RakuAstClass::PostcircumfixArrayIndex => {
+                    let semilist = named_child(postfix, "index")?;
+                    let stmt_expr = named_child_or_positional(semilist)?;
+                    let index = lower_expr(stmt_expr)?;
+                    Ok(Expr::Index {
+                        target: Box::new(operand),
+                        index: Box::new(index),
+                        is_positional: true,
+                    })
+                }
+                _ => Err(unsupported(node)),
             }
-            Ok(Expr::MethodCall {
-                target: Box::new(operand),
-                name: crate::symbol::Symbol::intern(&call_name_str(postfix)?),
-                args: arg_exprs(postfix)?,
-                modifier: None,
-                quoted: false,
-            })
         }
         _ => Err(unsupported(node)),
     }

--- a/t/rakuast-eval-subscript.t
+++ b/t/rakuast-eval-subscript.t
@@ -1,0 +1,24 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 5 slice 25 (ADR-0011): EVAL of positional subscripts `@a[EXPR]`.
+# `ApplyPostfix` with a `Postcircumfix::ArrayIndex` postfix lowers to `Expr::Index`
+# (the read side already emits it). Verified against Rakudo; passes under BOTH
+# mutsu and raku.
+
+plan 5;
+
+# --- a variable subscript ---------------------------------------------------
+is EVAL(Q{my @a = 10, 20, 30; @a[1]}.AST), 20, 'a positional subscript on a variable';
+
+# --- the first and last elements --------------------------------------------
+is EVAL(Q{my @a = 10, 20, 30; @a[0]}.AST), 10, 'the first element';
+is EVAL(Q{my @a = 1, 2, 3, 4; @a[@a.elems - 1]}.AST), 4, 'a computed last-element index';
+
+# --- subscripting an array literal ------------------------------------------
+is EVAL(Q{[10, 20, 30][2]}.AST), 30, 'subscripting an array literal';
+
+# --- subscript result drives arithmetic -------------------------------------
+is EVAL(Q{my @a = 5, 6, 7; @a[0] + @a[2]}.AST), 12, 'two subscripts in an expression';


### PR DESCRIPTION
## Summary

Phase 5 slice 25 of RakuAST (ADR-0011): `EVAL` of positional subscripts `@a[EXPR]`.

An `ApplyPostfix` with a `Postcircumfix::ArrayIndex` postfix lowers to `Expr::Index` (the index is the `SemiList`'s single `Statement::Expression`). The read side already emits this node, so only the write side was missing.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q{my @a = 10, 20, 30; @a[1]}.AST)             # 20
EVAL(Q{[10, 20, 30][2]}.AST)                       # 30
EVAL(Q{my @a = 1, 2, 3, 4; @a[@a.elems - 1]}.AST)  # 4
```

Associative subscripts (`%h{…}`) and slices (`@a[1, 2]`) stay the coverage boundary.

## Tests

`t/rakuast-eval-subscript.t` — 5 assertions (variable subscript, first element, computed last index, subscripting an array literal, two subscripts in an expression), **passing under BOTH mutsu and raku**. All 63 `t/rakuast-*.t` files (285 tests) still green.

Next: hash literals, associative subscripts, bareword type terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)