### PR TITLE
feat: RakuAST slice 26 — bareword type terms in .AST and EVAL

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -982,9 +982,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 25: positional subscripts `@a[EXPR]` (`ApplyPostfix` + `Postcircumfix::ArrayIndex` →
         `Expr::Index`); `EVAL(Q{my @a = 10, 20, 30; @a[1]}.AST)` → 20. Tests in
         `t/rakuast-eval-subscript.t`.
-  - [ ] Slice 26+: hash literals, associative subscripts (`%h{…}`), bareword type terms, code-block
-        (`{…}`) interpolation — the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5
-        full lowering is a large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 26: bareword type terms `Int`/`Str` as values (both directions) — a known type name
+        (`is_known_type_constraint`) ↔ `Type::Simple`; `EVAL(Q{5 ~~ Int}.AST)` → True, `Int.^name` →
+        "Int". Tests in `t/rakuast-eval-typeterm.t`.
+  - [ ] Slice 27+: hash literals (raku models `{a => 1}` as a `Block`), associative subscripts
+        (`%h{…}`), code-block (`{…}`) interpolation — the inverse of the Phase-2 converter, grown cluster
+        by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -341,6 +341,14 @@ earlier ones.
     `20`; a computed index, subscripting an array literal (`[10, 20, 30][2]`), and two subscripts in an
     expression work. Associative subscripts (`%h{…}`) and slices (`@a[1, 2]`) stay the boundary. Tests
     in `t/rakuast-eval-subscript.t`. Next: hash literals, bareword type terms, code-block interpolation.
+  - **Slice 26 (bareword type terms) — done, both directions.** A bare type name used as a value
+    (`Int`, `Str`) converts to a `Type::Simple` on the read side — but only when it is a *known* type
+    (`is_known_type_constraint`), so a non-type bareword (`foo`) stays the boundary — and the write side
+    lowers a `Type::Simple` in expression position back to a bareword term (which mutsu evaluates to the
+    type object). This closes the slice-18 `~~ Int` boundary: `EVAL(Q{5 ~~ Int}.AST)` → `True`,
+    `EVAL(Q{"x" ~~ Int}.AST)` → `False`; `Int.^name` → `"Int"`, and a type object can be stored in a
+    variable. User-defined types stay the boundary. Tests in `t/rakuast-eval-typeterm.t`. Next: hash
+    literals (raku models `{a => 1}` as a `Block`), code-block interpolation.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -9,6 +9,7 @@
 use super::{RakuAstClass, RakuAstField, RakuAstFieldValue, RakuAstNode};
 use crate::ast::{AssignOp, Expr, ForMode, ParamDef, Stmt};
 use crate::compiler::helpers_ops::token_kind_to_op_name;
+use crate::runtime::utils::is_known_type_constraint;
 use crate::value::{RuntimeError, Value, ValueView};
 
 fn unsupported(what: &str) -> RuntimeError {
@@ -763,6 +764,9 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
         Expr::Literal(v) | Expr::LiteralSrc(v, _) => convert_literal(v),
         Expr::Call { name, args } => Ok(call_name(name.as_str(), args, false)?),
         Expr::Var(name) => Ok(var_lexical("$", name)),
+        // A bare type name used as a term (`Int`, `Str`) -> `Type::Simple`. Only
+        // known builtin types convert; a non-type bareword stays the boundary.
+        Expr::BareWord(name) if is_known_type_constraint(name) => Ok(simple_type_node(name)),
         // `(EXPR)` -> `Circumfix::Parentheses(SemiList(Statement::Expression(...)))`.
         Expr::Grouped(inner) => {
             let semilist = RakuAstNode {

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -570,6 +570,15 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             };
             Ok(Expr::BracketArray(items, false))
         }
+        // A bare type name `Int` (a `Type::Simple`) in expression position -> a
+        // bareword term, which mutsu evaluates to the type object.
+        RakuAstClass::TypeSimple => {
+            let name_node = named_child_or_positional(node)?;
+            match positional_leaf(name_node)?.view() {
+                ValueView::Str(s) => Ok(Expr::BareWord(s.to_string())),
+                _ => Err(unsupported(node)),
+            }
+        }
         // `True`/`False` -> the Bool literal. Other enum identifiers are deferred.
         RakuAstClass::TermEnum => match positional_leaf(node)?.view() {
             ValueView::Str(s) if s.as_str() == "True" => Ok(Expr::Literal(Value::truth(true))),

--- a/t/rakuast-eval-typeterm.t
+++ b/t/rakuast-eval-typeterm.t
@@ -1,0 +1,27 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 26 (ADR-0011): bareword type terms `Int`/`Str`, both directions.
+# A known builtin type name used as a value converts to a `Type::Simple` (read)
+# and lowers back to a bareword term that evaluates to the type object (write).
+# Only known types convert — a non-type bareword stays the boundary. Verified
+# against Rakudo; passes under BOTH mutsu and raku.
+
+plan 5;
+
+# --- read side: a type term renders as Type::Simple -------------------------
+ok Q{my $t = Int}.AST.gist.contains('RakuAST::Type::Simple.new(')
+    && Q{my $t = Int}.AST.gist.contains('RakuAST::Name.from-identifier("Int")'),
+    'a bare type name renders as Type::Simple';
+
+# --- smartmatch against a type (the slice-18 boundary) ----------------------
+is EVAL(Q{5 ~~ Int}.AST), True, '5 smartmatches Int';
+is EVAL(Q{"x" ~~ Int}.AST), False, 'a string does not smartmatch Int';
+
+# --- introspection on the type object ---------------------------------------
+is EVAL(Q{Int.^name}.AST), 'Int', 'the type object has its name';
+
+# --- a type stored in a variable --------------------------------------------
+is EVAL(Q{my $t = Str; $t.^name}.AST), 'Str', 'a type object can be stored and reused';


### PR DESCRIPTION
## Summary

RakuAST slice 26 (ADR-0011): bareword type terms `Int`/`Str` used as values, **both directions**.

- **Read (`.AST`, Phase 2):** `Expr::BareWord` → `Type::Simple`, but **only** when the name is a *known* type (`is_known_type_constraint`), so a non-type bareword (`foo`) stays the boundary rather than being silently misconverted.
- **Write (`EVAL`, Phase 5):** a `Type::Simple` in expression position → a bareword term, which mutsu evaluates to the type object.

This closes the slice-18 `~~ Int` boundary:

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q{5 ~~ Int}.AST)          # True
EVAL(Q{"x" ~~ Int}.AST)        # False
EVAL(Q{Int.^name}.AST)         # "Int"
EVAL(Q{my $t = Str; $t.^name}.AST)  # "Str"
```

User-defined types stay the coverage boundary.

## Tests

`t/rakuast-eval-typeterm.t` — 5 assertions (read-side gist has Type::Simple, `5 ~~ Int`, `"x" ~~ Int`, `Int.^name`, a stored type object), **passing under BOTH mutsu and raku**. The read-side gist is byte-identical to Rakudo's. All 64 `t/rakuast-*.t` files (290 tests) still green.

Next: hash literals (raku models `{a => 1}` as a `Block`), code-block interpolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)