### PR TITLE
fix: reduce/&[op] metaop trims whitespace when numifying a string

### DIFF
--- a/src/runtime/ops_reduction.rs
+++ b/src/runtime/ops_reduction.rs
@@ -171,7 +171,11 @@ impl Interpreter {
                         n as f64 / d as f64
                     }
                 }
-                ValueView::Str(s) => s.parse::<f64>().unwrap_or(0.0),
+                // Raku numeric-string coercion allows surrounding whitespace
+                // (`+"1 " == 1`), so trim before parsing — Rust's `f64::parse`
+                // rejects the trailing/leading space and would yield 0.0, making
+                // `&[==].("1 ", 1)` wrongly False vs the infix `==` path.
+                ValueView::Str(s) => s.trim().parse::<f64>().unwrap_or(0.0),
                 ValueView::Bool(b) => {
                     if b {
                         1.0

--- a/t/reduce-numeric-string-whitespace.t
+++ b/t/reduce-numeric-string-whitespace.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+# The reduction / `&[op]` metaop path numified a numeric string with `f64::parse`,
+# which rejects surrounding whitespace and silently fell back to 0.0 — so
+# `&[==].("1 ", 1)` was False even though the infix `"1 " == 1` is True (Raku
+# numeric-string coercion trims whitespace). This checks the two paths agree.
+
+plan 12;
+
+# &[==] as a callable agrees with infix ==.
+is (&[==].("1 ", 1)),  ("1 " == 1),  '&[==] trailing-space string vs Int';
+is (&[==].(" 1", 1)),  (" 1" == 1),  '&[==] leading-space string vs Int';
+is (&[==].("1", 1)),   ("1" == 1),   '&[==] no-space string vs Int';
+is (&[==].(1, "1 ")),  (1 == "1 "),  '&[==] Int vs trailing-space string';
+ok  (&[==].("  42  ", 42)),          '&[==] surrounding-space string';
+nok (&[==].("2 ", 1)),               '&[==] distinct values stay distinct';
+
+# The reduce form.
+ok  ([==] "1 ", 1, 1.0),  '[==] reduces a whitespace string with numeric peers';
+ok  (&[<].("1 ", 2)),     '&[<] numifies a whitespace string';
+
+# The unique/repeated doc examples that surfaced it (Type/Any.rakudoc).
+is ("1", 1, "1 ", 2).unique(with => &[==]).elems, 2,
+    '.unique(with => &[==]) dedups whitespace-numeric strings';
+is-deeply ("1", 1, "1 ", 2).unique(as => Int, with => &[==]).List, ("1", 2),
+    '.unique(as => Int, with => &[==]) matches raku';
+is-deeply (1, -1, 2, -2, 3).repeated(:as(&abs), :with(&[==])).List, (-1, -2),
+    '.repeated(:as, :with) over plain Ints';
+
+# Plain all-Int reductions are unaffected.
+ok ([==] 3, 3, 3), '[==] over equal Ints still True';


### PR DESCRIPTION
## Summary

The reduction / `&[op]` metaop path numified a numeric string with Rust's `f64::parse`, which rejects surrounding whitespace and silently fell back to `0.0`. So the `&[op]` callable disagreed with the plain infix operator:

```raku
"1 " == 1        # True  (infix — Raku numeric coercion trims whitespace)
&[==].("1 ", 1)  # False (before) — parsed "1 " as 0.0
```

This surfaced in `Type/Any.rakudoc`:

```raku
("1", 1, "1 ", 2).unique(as => Int, with => &[==]).say  # raku: (1 2); mutsu (before): (1 1  2)
```

## Fix

`.trim()` the string before `f64::parse` in the reduction `to_num` helper, matching the infix `==` path. Applies to every numeric reduction op (`==`, `<`, `>`, …) consistently.

## Not covered (separate root, deferred)

`&abs.(<-2>)` returns `0` in mutsu (an `&`-builtin callable numifying an allomorph to 0), so `.repeated(:as(&abs), :with(&[==]))` over `<...>` allomorph words is still wrong. The plain-Int form is correct. Tracked separately.

Found by the doc-diff harness (`scripts/doc-diff-harness.raku`, PLAN §8).

## Testing

- New pin: `t/reduce-numeric-string-whitespace.t` (12 subtests).
- `make test` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)