### PR TITLE
feat: RakuAST slice 27 — the * whatever term in .AST and EVAL

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -985,9 +985,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 26: bareword type terms `Int`/`Str` as values (both directions) — a known type name
         (`is_known_type_constraint`) ↔ `Type::Simple`; `EVAL(Q{5 ~~ Int}.AST)` → True, `Int.^name` →
         "Int". Tests in `t/rakuast-eval-typeterm.t`.
-  - [ ] Slice 27+: hash literals (raku models `{a => 1}` as a `Block`), associative subscripts
-        (`%h{…}`), code-block (`{…}`) interpolation — the inverse of the Phase-2 converter, grown cluster
-        by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 27: the `*` whatever term (both directions) via a new `Term::Whatever` node;
+        `EVAL(Q{(1..*).head(3).join(",")}.AST)` → "1,2,3". WhateverCode (`* + 1`) stays the boundary.
+        Tests in `t/rakuast-eval-whatever.t`.
+  - [ ] Slice 28+: hash literals (raku models `{a => 1}` as a `Block`), associative subscripts
+        (`%h{…}`), WhateverCode (`* + 1`), code-block (`{…}`) interpolation — the inverse of the Phase-2
+        converter, grown cluster by cluster. (Phase 5 full lowering is a large multi-slice effort.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -349,6 +349,12 @@ earlier ones.
     `EVAL(Q{"x" ~~ Int}.AST)` → `False`; `Int.^name` → `"Int"`, and a type object can be stored in a
     variable. User-defined types stay the boundary. Tests in `t/rakuast-eval-typeterm.t`. Next: hash
     literals (raku models `{a => 1}` as a `Block`), code-block interpolation.
+  - **Slice 27 (the `*` whatever term) — done, both directions.** A new `Term::Whatever` node class
+    models a bare `*` (it renders as a bare `.new` — no parens — via `empty_parens_omitted`). The read
+    side converts `Expr::Whatever` to it and the write side lowers it back. `EVAL(Q{(1..*).head(3).join(",")}.AST)`
+    → `"1,2,3"`; `*` closes an infinite range and a bare `*` is a `Whatever` value. `WhateverCode`
+    (`* + 1`, `*-1`), which mutsu desugars to a closure, stays the boundary. Tests in
+    `t/rakuast-eval-whatever.t`. Next: hash literals, code-block interpolation, WhateverCode.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -764,6 +764,11 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
         Expr::Literal(v) | Expr::LiteralSrc(v, _) => convert_literal(v),
         Expr::Call { name, args } => Ok(call_name(name.as_str(), args, false)?),
         Expr::Var(name) => Ok(var_lexical("$", name)),
+        // The `*` whatever term.
+        Expr::Whatever => Ok(RakuAstNode {
+            class: RakuAstClass::TermWhatever,
+            fields: Vec::new(),
+        }),
         // A bare type name used as a term (`Int`, `Str`) -> `Type::Simple`. Only
         // known builtin types convert; a non-type bareword stays the boundary.
         Expr::BareWord(name) if is_known_type_constraint(name) => Ok(simple_type_node(name)),

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -570,6 +570,8 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             };
             Ok(Expr::BracketArray(items, false))
         }
+        // The `*` whatever term.
+        RakuAstClass::TermWhatever => Ok(Expr::Whatever),
         // A bare type name `Int` (a `Type::Simple`) in expression position -> a
         // bareword term, which mutsu evaluates to the type object.
         RakuAstClass::TypeSimple => {

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -134,6 +134,8 @@ pub enum RakuAstClass {
     ParameterSlurpyUnflattened,
     // Phase 2 slice 33: array-composer literal (`[1, 2, 3]`).
     CircumfixArrayComposer,
+    // Phase 2 slice 34: the `*` whatever term.
+    TermWhatever,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -207,6 +209,7 @@ impl RakuAstClass {
             ParameterSlurpyFlattened => "RakuAST::Parameter::Slurpy::Flattened",
             ParameterSlurpyUnflattened => "RakuAST::Parameter::Slurpy::Unflattened",
             CircumfixArrayComposer => "RakuAST::Circumfix::ArrayComposer",
+            TermWhatever => "RakuAST::Term::Whatever",
         }
     }
 
@@ -214,7 +217,7 @@ impl RakuAstClass {
     /// (`RakuAST::Assignment.new`), unlike the generic `.new()` (e.g. an empty
     /// `StatementList` still prints `RakuAST::StatementList.new()`).
     pub fn empty_parens_omitted(self) -> bool {
-        matches!(self, RakuAstClass::Assignment)
+        matches!(self, RakuAstClass::Assignment | RakuAstClass::TermWhatever)
     }
 
     /// Whether the node renders as a bare class name with no constructor call at

--- a/t/rakuast-eval-whatever.t
+++ b/t/rakuast-eval-whatever.t
@@ -1,0 +1,30 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 27 (ADR-0011): the `*` whatever term, both directions.
+# `Expr::Whatever` <-> `RakuAST::Term::Whatever` (a bare `.new` node). Verified
+# against Rakudo; passes under BOTH mutsu and raku.
+#
+# Note: `* + 1` (WhateverCode) desugars to a closure in mutsu and stays the
+# coverage boundary; only the bare `*` term is covered here.
+
+plan 5;
+
+# --- read side: `*` renders as Term::Whatever -------------------------------
+is Q{*}.AST.gist.chomp, q:to/END/.chomp, '`*` renders as Term::Whatever';
+    RakuAST::StatementList.new(
+      RakuAST::Statement::Expression.new(
+        expression => RakuAST::Term::Whatever.new
+      )
+    )
+    END
+
+# --- `*` closes an infinite range -------------------------------------------
+is EVAL(Q{(1..*).head(3).join(",")}.AST), '1,2,3', '`1..*` is an infinite range';
+is EVAL(Q{(1..*).head(5).sum}.AST), 15, 'the head of an infinite range sums';
+is EVAL(Q{(10..*).head(3).join("-")}.AST), '10-11-12', 'an infinite range from 10';
+
+# --- a bare `*` is a Whatever value -----------------------------------------
+is EVAL(Q{my $w = *; $w.WHAT.^name}.AST), 'Whatever', 'a bare `*` is a Whatever';


### PR DESCRIPTION
## Summary

RakuAST slice 27 (ADR-0011): the `*` whatever term, **both directions**.

A new `Term::Whatever` node class models a bare `*` (it renders as a bare `.new` — no parens — via `empty_parens_omitted`):

```raku
Q{*}.AST   # ... RakuAST::Term::Whatever.new
```

- **Read (`.AST`, Phase 2):** `Expr::Whatever` → `Term::Whatever`.
- **Write (`EVAL`, Phase 5):** `Term::Whatever` → `Expr::Whatever`.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q{(1..*).head(3).join(",")}.AST)     # "1,2,3"
EVAL(Q{(1..*).head(5).sum}.AST)           # 15
EVAL(Q{my $w = *; $w.WHAT.^name}.AST)     # "Whatever"
```

`WhateverCode` (`* + 1`, `*-1`), which mutsu desugars to a closure, stays the coverage boundary.

## Tests

`t/rakuast-eval-whatever.t` — 5 assertions (read-side gist is Term::Whatever, three infinite-range uses, a bare `*` value), **passing under BOTH mutsu and raku**. The read-side gist is byte-identical to Rakudo's. All 65 `t/rakuast-*.t` files (295 tests) still green.

Next: hash literals, code-block interpolation, WhateverCode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)