### PR TITLE
feat: RakuAST slice 28 — fat-arrow pairs in .AST and EVAL

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -988,7 +988,10 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 27: the `*` whatever term (both directions) via a new `Term::Whatever` node;
         `EVAL(Q{(1..*).head(3).join(",")}.AST)` → "1,2,3". WhateverCode (`* + 1`) stays the boundary.
         Tests in `t/rakuast-eval-whatever.t`.
-  - [ ] Slice 28+: hash literals (raku models `{a => 1}` as a `Block`), associative subscripts
+  - [x] Slice 28: fat-arrow pairs `a => 1` (both directions) via a new `FatArrow` node —
+        `Expr::PositionalPair(FatArrow binop)` ↔ `FatArrow(key, value)`. `EVAL(Q{(a => 5).value}.AST)` →
+        5. Tests in `t/rakuast-eval-pair.t`.
+  - [ ] Slice 29+: hash literals (raku models `{a => 1}` as a `Block`), associative subscripts
         (`%h{…}`), WhateverCode (`* + 1`), code-block (`{…}`) interpolation — the inverse of the Phase-2
         converter, grown cluster by cluster. (Phase 5 full lowering is a large multi-slice effort.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -355,6 +355,14 @@ earlier ones.
     → `"1,2,3"`; `*` closes an infinite range and a bare `*` is a `Whatever` value. `WhateverCode`
     (`* + 1`, `*-1`), which mutsu desugars to a closure, stays the boundary. Tests in
     `t/rakuast-eval-whatever.t`. Next: hash literals, code-block interpolation, WhateverCode.
+  - **Slice 28 (fat-arrow pairs) — done, both directions.** A new `FatArrow` node class models a pair
+    `a => 1` (`key` leaf + `value` node). The read side converts a `Expr::PositionalPair` over a
+    `FatArrow` binop with a string-literal key, and the write side lowers a `FatArrow` back to that
+    positional pair. `EVAL(Q{(a => 5).value}.AST)` → `5`; `.key`/`.kv` and an expression value work.
+    (A *bare* `a => 1` statement renders as an `ApplyInfix` in mutsu — matching the call-argument form —
+    so the pin checks round-tripped values rather than the gist.) A non-string-literal key stays the
+    boundary. Tests in `t/rakuast-eval-pair.t`. Next: hash literals, code-block interpolation,
+    WhateverCode.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -769,6 +769,31 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
             class: RakuAstClass::TermWhatever,
             fields: Vec::new(),
         }),
+        // A fat-arrow pair `a => 1` -> `FatArrow(key => "a", value => …)`. Only a
+        // string-literal key is modelled (a computed key stays the boundary).
+        Expr::PositionalPair(inner) => match &**inner {
+            Expr::Binary {
+                left,
+                op: crate::token_kind::TokenKind::FatArrow,
+                right,
+            } => {
+                let key = match &**left {
+                    Expr::Literal(v) | Expr::LiteralSrc(v, _) => match v.view() {
+                        ValueView::Str(s) => s.to_string(),
+                        _ => return Err(unsupported("non-string pair key")),
+                    },
+                    _ => return Err(unsupported("non-literal pair key")),
+                };
+                Ok(RakuAstNode {
+                    class: RakuAstClass::FatArrow,
+                    fields: vec![
+                        leaf_field(Some("key"), Value::str(key)),
+                        node_field(Some("value"), convert_expr(right)?),
+                    ],
+                })
+            }
+            _ => Err(unsupported("non-fat-arrow positional pair")),
+        },
         // A bare type name used as a term (`Int`, `Str`) -> `Type::Simple`. Only
         // known builtin types convert; a non-type bareword stays the boundary.
         Expr::BareWord(name) if is_known_type_constraint(name) => Ok(simple_type_node(name)),

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -572,6 +572,16 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
         }
         // The `*` whatever term.
         RakuAstClass::TermWhatever => Ok(Expr::Whatever),
+        // A fat-arrow pair `a => 1` -> a positional pair over a `FatArrow` binop.
+        RakuAstClass::FatArrow => {
+            let key = leaf_str(node, "key")?;
+            let value = lower_expr(named_child(node, "value")?)?;
+            Ok(Expr::PositionalPair(Box::new(Expr::Binary {
+                left: Box::new(Expr::Literal(Value::str(key))),
+                op: crate::token_kind::TokenKind::FatArrow,
+                right: Box::new(value),
+            })))
+        }
         // A bare type name `Int` (a `Type::Simple`) in expression position -> a
         // bareword term, which mutsu evaluates to the type object.
         RakuAstClass::TypeSimple => {

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -136,6 +136,8 @@ pub enum RakuAstClass {
     CircumfixArrayComposer,
     // Phase 2 slice 34: the `*` whatever term.
     TermWhatever,
+    // Phase 2 slice 35: fat-arrow pairs (`a => 1`).
+    FatArrow,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -210,6 +212,7 @@ impl RakuAstClass {
             ParameterSlurpyUnflattened => "RakuAST::Parameter::Slurpy::Unflattened",
             CircumfixArrayComposer => "RakuAST::Circumfix::ArrayComposer",
             TermWhatever => "RakuAST::Term::Whatever",
+            FatArrow => "RakuAST::FatArrow",
         }
     }
 

--- a/t/rakuast-eval-pair.t
+++ b/t/rakuast-eval-pair.t
@@ -1,0 +1,29 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 28 (ADR-0011): fat-arrow pairs `a => 1`, both directions. A
+# parenthesised/method-context pair is `Expr::PositionalPair` over a `FatArrow`
+# binop internally, and raku models it as a `RakuAST::FatArrow(key, value)` node.
+# The read side converts it and the write side lowers it back. Verified against
+# Rakudo; passes under BOTH mutsu and raku.
+#
+# Note: mutsu renders a *bare* `a => 1` statement as an `ApplyInfix` (matching the
+# call-argument form) rather than a `FatArrow` node, so this file checks the
+# round-tripped *values*, which agree, rather than the gist.
+
+plan 5;
+
+# --- the key and value of a pair --------------------------------------------
+is EVAL(Q{(a => 1).key}.AST), 'a', 'a pair exposes its key';
+is EVAL(Q{(a => 5).value}.AST), 5, 'a pair exposes its value';
+
+# --- a string-literal key ---------------------------------------------------
+is EVAL(Q{("x" => 10).value}.AST), 10, 'a string-literal key';
+
+# --- the value may be a full expression -------------------------------------
+is EVAL(Q{(a => 3 + 4).value}.AST), 7, 'the pair value is an expression';
+
+# --- .kv flattens to key and value ------------------------------------------
+is EVAL(Q{(a => 1).kv.join(",")}.AST), 'a,1', '.kv yields the key and value';


### PR DESCRIPTION
## Summary

RakuAST slice 28 (ADR-0011): fat-arrow pairs `a => 1`, **both directions**.

A new `FatArrow` node class models a pair (`key` leaf + `value` node):

```raku
(a => 1)   # ... FatArrow(key => "a", value => IntLiteral(1))  [in method/paren context]
```

- **Read (`.AST`, Phase 2):** a `Expr::PositionalPair` over a `FatArrow` binop with a string-literal key → `FatArrow(key => "a", value => …)`.
- **Write (`EVAL`, Phase 5):** a `FatArrow` node → that positional pair.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q{(a => 5).value}.AST)          # 5
EVAL(Q{(a => 1).key}.AST)            # "a"
EVAL(Q{(a => 3 + 4).value}.AST)      # 7
EVAL(Q{(a => 1).kv.join(",")}.AST)   # "a,1"
```

A *bare* `a => 1` statement renders as an `ApplyInfix` in mutsu (matching the call-argument form), so the pin checks round-tripped **values** rather than the gist. A non-string-literal key stays the boundary.

## Tests

`t/rakuast-eval-pair.t` — 5 assertions (`.key`, `.value`, string-literal key, expression value, `.kv`), **passing under BOTH mutsu and raku**. All 66 `t/rakuast-*.t` files (300 tests) still green.

Next: hash literals, code-block interpolation, WhateverCode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)