### PR TITLE
ci: publish mise-installable release binaries with mutsu + mzef

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - 'v*'
+  # Allow a manual build+package smoke test (all matrix targets, incl. macOS)
+  # without cutting a tag. The publish job below is gated on a tag ref, so a
+  # workflow_dispatch run uploads artifacts but does NOT create a release.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -11,6 +15,10 @@ permissions:
 jobs:
   build:
     strategy:
+      # Do not let one platform's failure cancel the others: a broken macOS
+      # toolchain build (e.g. the known libffi Mach-O CFI issue) must not stop
+      # the Linux binaries from publishing.
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
@@ -22,12 +30,18 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-latest
             archive_name: macos-x64
+            optional: true
           - target: aarch64-apple-darwin
             os: macos-latest
             archive_name: macos-arm64
+            optional: true
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    # macOS targets are best-effort for now (upstream libffi does not build
+    # cleanly under recent Xcode). A failure there is tolerated; Linux is
+    # required.
+    continue-on-error: ${{ matrix.optional || false }}
 
     steps:
       - uses: actions/checkout@v7
@@ -50,13 +64,34 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libpcre2-dev
 
-      - name: Build release binary
-        run: cargo build --release --target ${{ matrix.target }}
+      # Build both shipped binaries: the interpreter (`mutsu`) and the package
+      # manager shim (`mzef`).
+      - name: Build release binaries
+        run: cargo build --release --target ${{ matrix.target }} --bin mutsu --bin mzef
 
-      - name: Package binary
+      # Assemble the distribution tree so an unpacked release is self-contained
+      # and `mzef` finds the bundled zef with no configuration. `bin/` and
+      # `share/` sit at the archive ROOT (no wrapping version directory) so
+      # mise's github-backend autodetection finds `bin/` with zero config:
+      #
+      #   bin/mutsu
+      #   bin/mzef
+      #   share/mutsu/zef/...   <- mzef resolves this via ../share/mutsu/zef
+      #
+      # mise extracts the whole archive into the tool's install dir and exposes
+      # `bin/` on PATH, so both commands work after `mise use`.
+      - name: Package
         run: |
-          cd target/${{ matrix.target }}/release
-          tar czf ../../../mutsu-${{ github.ref_name }}-${{ matrix.archive_name }}.tar.gz mutsu
+          set -eu
+          pkg="mutsu-${{ github.ref_name }}-${{ matrix.archive_name }}"
+          stage="staging/$pkg"
+          mkdir -p "$stage/bin" "$stage/share/mutsu"
+          cp "target/${{ matrix.target }}/release/mutsu" "$stage/bin/"
+          cp "target/${{ matrix.target }}/release/mzef" "$stage/bin/"
+          cp -R vendor/zef "$stage/share/mutsu/zef"
+          tar -C "$stage" -czf "$pkg.tar.gz" bin share
+          echo "Packaged $pkg.tar.gz:"
+          tar tzf "$pkg.tar.gz" | head -20
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
@@ -67,6 +102,9 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    # Only publish a GitHub Release for a real tag push. workflow_dispatch runs
+    # stop after build (artifacts are available for inspection, no release).
+    if: ${{ github.ref_type == 'tag' }}
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v8
@@ -74,7 +112,7 @@ jobs:
           merge-multiple: true
 
       # Publish SHA256 checksums alongside the tarballs so downloaders (and the
-      # mise GitHub backend) can verify the binaries.
+      # mise github/ubi backend) can verify the binaries.
       - name: Generate checksums
         run: sha256sum mutsu-*.tar.gz > mutsu-${{ github.ref_name }}-SHA256SUMS.txt
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -251,9 +251,19 @@ sessions).
 
 ### B3. Distribution and tooling
 
-- [ ] **Binary distribution**: verify installation via the mise GitHub backend / automate GitHub
-      Releases. This is the entry point of "everything present just by installing", so design it
-      together with B1 vendoring (packaging of the binary + bundled module tree).
+- [x] **Binary distribution — release pipeline wired (2026-07-19)**: `release.yml` (on `v*` tag
+      push, or `workflow_dispatch` for a build-only smoke test) builds **both** `mutsu` and `mzef`
+      per target and packages a self-contained tarball — `bin/mutsu`, `bin/mzef`,
+      `share/mutsu/zef/...` at the archive root — so mise's github backend finds `bin/` with zero
+      config and `mzef` resolves the bundled zef via `../share/mutsu/zef`. Install:
+      `mise use -g github:tokuhirom/mutsu` → both commands on PATH (README "Install"). Matrix is
+      `fail-fast: false`; **Linux x64/arm64 are required, macOS is `continue-on-error`** (best-effort
+      — the pre-existing libffi Mach-O CFI build failure that had made *every* release since v0.3.1
+      publish nothing is thereby prevented from blocking the Linux artifacts). Verified locally: the
+      exact packaging tar reproduces a layout from which `mzef --version` and `mutsu -e` both run with
+      no env. Remaining: (a) the **macOS libffi** build (upstream Clang-17+ CFI issue; needs a
+      libffi/libffi-sys bump or a system-libffi build — unverifiable from Linux, so deferred); (b)
+      first real tag to confirm the GitHub Release + a live `mise use` end-to-end.
 - [ ] REPL / Debugger / native binary output / public WASM playground.
 
 ### B4. Remaining module-compatibility blockers (the base of batteries)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,36 @@ mutsu parses Raku source into an AST, compiles it to bytecode, and executes it o
 
 Try it in your browser: **https://tokuhirom.github.io/mutsu/** (WebAssembly demo)
 
+## Install
+
+### With [mise](https://mise.jdx.dev/) (recommended)
+
+Prebuilt binaries are published to GitHub Releases. mise installs them and puts
+**both** the `mutsu` interpreter and the bundled `mzef` package manager on your
+PATH:
+
+```bash
+mise use -g github:tokuhirom/mutsu       # latest release
+# or pin a version:
+mise use -g github:tokuhirom/mutsu@0.7.0
+
+mutsu -e 'say "Hello, World!"'
+mzef --version                            # the bundled Zef package manager
+```
+
+The release archive is self-contained: `bin/mutsu`, `bin/mzef`, and the
+vendored Zef tree at `share/mutsu/zef`. `mzef` is a thin shim that runs the
+bundled Zef under `mutsu`, so `mzef install <dist>` works out of the box with no
+extra setup. Linux (x64/arm64) binaries are published each release; macOS builds
+are best-effort while an upstream toolchain issue is resolved.
+
+### From source
+
+```bash
+cargo build --release
+./target/release/mutsu -e 'say "Hello, World!"'
+```
+
 ## Quick Start
 
 ```bash

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -29,6 +29,29 @@ and the real zef it drives lives **inside this repo** instead of an out-of-tree 
 - **B3 leftover**: the release artifact must place `vendor/zef` at `<prefix>/share/mutsu/zef`
   alongside `bin/mutsu` and `bin/mzef` — the shim already probes that path first.
 
+### Release pipeline: mise-installable binaries with `mutsu` + `mzef` (B3)
+
+Following the shim, wired the distribution so `mise use -g github:tokuhirom/mutsu` installs both
+commands. While doing so, found that **every Release run since v0.3.1 had failed** — the macOS
+ARM64 leg could not build vendored libffi (upstream Clang-17+ Mach-O CFI issue), and with the
+default `fail-fast` that cancelled the Linux legs and skipped the publish job. So no GitHub Release
+had ever carried a binary. Reworked `release.yml`:
+
+- Builds **both** `mutsu` and `mzef` per target and packages a self-contained tarball with
+  `bin/mutsu`, `bin/mzef`, and `share/mutsu/zef/...` at the **archive root** (no wrapping version
+  dir), so mise's github-backend autodetection finds `bin/` with zero config and `mzef` resolves
+  the bundled zef via `../share/mutsu/zef`.
+- `fail-fast: false`; **Linux x64/arm64 required, macOS `continue-on-error`** (best-effort) so a
+  broken macOS toolchain no longer blocks the Linux artifacts or the publish job.
+- Added a `workflow_dispatch` trigger that runs the build+package matrix (incl. macOS) without
+  cutting a tag; the publish job is gated on `github.ref_type == 'tag'`.
+- README gained an "Install" section (`mise use -g github:tokuhirom/mutsu`).
+
+Verified locally that the exact packaging tar reproduces a layout from which `mzef --version` and
+`mutsu -e` both run with no env var. Remaining: the macOS libffi build (needs a libffi/libffi-sys
+bump or a system-libffi build — unverifiable from a Linux dev box, deferred), and the first real
+tag to confirm the live GitHub Release + `mise use` end-to-end.
+
 ## 2026-07-18: vendored `roast` bumped `7f2d7508` → `b2cbe8a4` (2026-06-12, 34 commits ahead)
 
 Re-vendored the roast suite to upstream HEAD via `scripts/update-vendor.sh roast b2cbe8a4`. The


### PR DESCRIPTION
## Summary

Makes `mise use -g github:tokuhirom/mutsu` install prebuilt binaries with **both** the `mutsu` interpreter and the bundled `mzef` package manager on PATH — the distribution half of PLAN §1 B3 (follow-up to #4782).

## Root problem fixed

**Every Release run since v0.3.1 had failed** and no GitHub Release ever carried a binary. The macOS ARM64 leg cannot build vendored libffi (upstream Clang-17+ Mach-O CFI issue), and the default `fail-fast` cancelled the Linux legs and skipped the publish job.

## Changes to `release.yml`

- Build **both** `mutsu` and `mzef` per target; package a self-contained tarball with `bin/mutsu`, `bin/mzef`, and `share/mutsu/zef/...` at the **archive root** — so mise's github backend finds `bin/` with zero config and `mzef` resolves the bundled zef via `../share/mutsu/zef`.
- `fail-fast: false`; **Linux x64/arm64 required, macOS `continue-on-error`** (best-effort) so a broken macOS toolchain no longer blocks the Linux artifacts or the publish job.
- Add a `workflow_dispatch` trigger for a build+package smoke test without cutting a tag; the publish job is gated on `github.ref_type == 'tag'`.
- README: add an "Install" section.

## Verification

Reproduced the exact packaging tar locally; from the resulting install layout, `mzef --version` (→ 1.1.3) and `mutsu -e` both run with **no env var** (mzef resolves `../share/mutsu/zef`).

```
mise use -g github:tokuhirom/mutsu
mutsu -e 'say "Hello"'
mzef install <dist>
```

## Deferred

- **macOS libffi build** — needs a libffi/libffi-sys bump or a system-libffi build; unverifiable from a Linux dev box.
- **First real tag** to confirm the live GitHub Release + `mise use` end-to-end. `workflow_dispatch` can smoke-test the build matrix (incl. macOS) in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)