### PR TITLE
fix: numeric builtin functions operate on allomorph inner value

### DIFF
--- a/src/builtins/functions/dispatch_1arg.rs
+++ b/src/builtins/functions/dispatch_1arg.rs
@@ -16,6 +16,40 @@ pub(crate) fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Val
     if let Some(err) = crate::runtime::Interpreter::lazy_guard_error(name, arg) {
         return Some(Err(err));
     }
+    // Numeric allomorphs (IntStr/NumStr/RatStr/ComplexStr) are `Mixin`s whose
+    // inner numeric drives arithmetic. A numeric/string function applied to one
+    // must operate on that inner value exactly as the equivalent method does
+    // (`abs($x)` == `$x.abs`). Several arms below `match arg.view()` against
+    // scalar-numeric variants only and fall to a `0`/`NaN` default for a
+    // `Mixin`, so `abs(<-2>)` wrongly returned 0. Delegate to the method
+    // dispatch, which already routes string methods to the Str part and numeric
+    // methods to the inner numeric. List/range-semantic functions differ between
+    // sub form (`combinations($n)` == `(^$n).combinations`) and method form, so
+    // they are excluded and handled by the normal `match` below.
+    if let ValueView::Mixin(inner, mixins) = arg.view()
+        && crate::value::types::allomorph_type_name(inner, mixins).is_some()
+        && !matches!(
+            name,
+            "combinations"
+                | "permutations"
+                | "srand"
+                | "elems"
+                | "reverse"
+                | "sort"
+                | "rotate"
+                | "flat"
+                | "first"
+                | "min"
+                | "max"
+                | "ords"
+                | "defined"
+                | "gist"
+        )
+        && let Some(res) =
+            crate::builtins::methods_0arg::native_method_0arg(arg, Symbol::intern(name))
+    {
+        return Some(res);
+    }
     match name {
         "combinations" => {
             // combinations($n) where $n is Int => (^$n).combinations (powerset)

--- a/t/numeric-func-on-allomorph.t
+++ b/t/numeric-func-on-allomorph.t
@@ -1,0 +1,44 @@
+use Test;
+
+# Numeric builtin *functions* applied to a numeric allomorph (IntStr / NumStr /
+# RatStr / ComplexStr) must operate on the inner numeric value, exactly as the
+# equivalent method does: `abs($x)` == `$x.abs`. Regression: several arms
+# (abs/sqrt/floor/ceiling/round/exp) matched only scalar-numeric variants and
+# fell to a `0`/`NaN` default for the `Mixin` allomorph, so `abs(<-2>)` was 0.
+
+plan 18;
+
+# abs
+is abs(<-2>), 2, 'abs(IntStr)';
+is abs(<-2.5>), 2.5, 'abs(RatStr) inner value';
+is &abs.(<-2>), 2, 'abs as &-callable on allomorph';
+is-deeply <-2 3 -4>.map(&abs).List, (2, 3, 4), 'map(&abs) over allomorph words';
+
+# floor / ceiling / round / truncate
+is floor(<-2.5>), -3, 'floor(RatStr)';
+is ceiling(<-2.5>), -2, 'ceiling(RatStr)';
+is round(<-2.4>), -2, 'round(RatStr)';
+is truncate(<-2.5>), -2, 'truncate(RatStr)';
+
+# exp / sqrt / log family
+is exp(<0>), 1, 'exp(IntStr)';
+is sqrt(<4>), 2, 'sqrt(IntStr)';
+is log2(<8>), 3, 'log2(IntStr)';
+is log10(<100>), 2, 'log10(IntStr)';
+
+# sign
+is sign(<-2>), -1, 'sign(IntStr)';
+
+# function == method
+is abs(<-7>), <-7>.abs, 'abs sub matches method on allomorph';
+is floor(<-7.3>), <-7.3>.floor, 'floor sub matches method on allomorph';
+
+# list/range-semantic functions are unaffected (sub form != method form)
+is elems(<-2>), 1, 'elems(allomorph) still 1';
+is-deeply combinations(3).List, ((), (0,), (1,), (2,), (0, 1), (0, 2), (1, 2), (0, 1, 2)),
+    'combinations($n) still the powerset of ^$n';
+
+# repeated/unique with an &-callable :as adverb over allomorph words.
+# `.repeated` returns the original (allomorph) elements, so compare by value.
+is <-2 3 -2 3>.repeated(:as(&abs)).map(*.Int).join(","), "-2,3",
+    'repeated(:as(&abs)) over words';


### PR DESCRIPTION
## Problem

Numeric allomorphs (`IntStr`/`NumStr`/`RatStr`/`ComplexStr`) are `Mixin`s whose
inner numeric value drives arithmetic. Several arms in `native_function_1arg`
matched only scalar-numeric `ValueView` variants and fell to a `0`/`NaN`
default for a `Mixin`:

```
abs(<-2>)              # was 0,        raku 2
<-2 3 -4>.map(&abs)    # was (0 0 0),  raku (2 3 4)
floor(<-2.5>)          # was 0,        raku -3
exp(<0>)               # was NaN,      raku 1
sqrt(<4>)              # was NaN,      raku 2
```

The **method** path (`<-2>.abs`) was already correct — only the **function**
path diverged (`abs($x)` should equal `$x.abs`).

## Fix

At the entry of `native_function_1arg`, delegate a numeric-allomorph argument to
the method dispatch, which already routes string methods to the Str part and
numeric methods to the inner numeric. List/range-semantic functions whose sub
form differs from the method form (`combinations($n)` == `(^$n).combinations`,
`elems`, `reverse`, `sort`, …) are explicitly excluded.

Surfaced by the QA doc-diff harness (`Type/Any.rakudoc` `.unique`/`.repeated`
examples using `&abs` over allomorph words).

## Test

Pin: `t/numeric-func-on-allomorph.t` (18 cases). `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)