### PR TITLE
fix: (elem)/∈ tests list membership by === identity, not stringification

### DIFF
--- a/src/vm/vm_set_ops.rs
+++ b/src/vm/vm_set_ops.rs
@@ -22,10 +22,6 @@ impl Interpreter {
         matches!(value.view(), ValueView::Instance { class_name, .. } if class_name == "Failure")
     }
 
-    fn value_matches_key(value: &Value, key: &str) -> bool {
-        value.to_string_value() == key
-    }
-
     fn range_contains(range: &Value, needle: &Value) -> bool {
         match range.view() {
             ValueView::Range(start, end) => {
@@ -147,7 +143,11 @@ impl Interpreter {
                 .as_list_items()
                 .unwrap()
                 .iter()
-                .any(|item| Self::value_matches_key(item, &key)),
+                // `∈`/`(elem)` coerces its RHS to a Set and tests membership by
+                // `===` (object identity / `.WHICH`), NOT by stringification.
+                // So `42 ∈ < 42 >` is False (Int vs the IntStr allomorph) and
+                // `"1" ∈ (1,)` is False (Str vs Int) — matching Rakudo.
+                .any(|item| crate::runtime::utils::values_identical(item, needle)),
             _ if container.is_range() => Self::range_contains(container, needle),
             _ => false,
         }

--- a/t/set-elem-identity.t
+++ b/t/set-elem-identity.t
@@ -1,0 +1,31 @@
+use Test;
+
+# `∈` / `(elem)` (and its reverse `∋` / `(cont)`) coerce the RHS to a Set and
+# test membership by `===` (object identity / `.WHICH`), NOT by stringification.
+# Regression: mutsu compared list elements by `.to_string_value()`, so an Int
+# `42` wrongly tested True against a list of IntStr allomorphs `< 42 >`, and a
+# Str `"1"` wrongly tested True against `(1,)`.
+
+plan 14;
+
+# Type-distinguished scalars are NOT identical
+nok 1 ∈ (1.0, 2), 'Int is not (elem) a list containing the Rat 1.0';
+ok  1 ∈ (1, 2),   'Int 1 (elem) (1, 2)';
+nok "1" ∈ (1, 2), 'Str "1" is not (elem) (1, 2)';
+nok 1 ∈ ("1", 2), 'Int 1 is not (elem) ("1", 2)';
+ok  1.0 ∈ (1.0, 2), 'Rat 1.0 (elem) (1.0, 2)';
+
+# Allomorph identity: a plain number is not identical to the allomorph word
+nok 42 ∈ < 42 43 >,   'Int 42 is not (elem) the IntStr word list < 42 43 >';
+ok  <42> ∈ < 42 43 >, 'IntStr <42> (elem) < 42 43 >';
+nok 42+0i ∈ < 42+0i 42 42e10 42.1 >, 'Complex is not (elem) allomorph words';
+nok 42.1  ∈ < 42+0i 42 42e10 42.1 >, 'Rat is not (elem) allomorph words';
+
+# (cont) is just the reverse and follows the same identity rule
+ok  < 42 43 > ∋ <42>, 'word list (cont) IntStr <42>';
+nok < 42 43 > ∋ 42,   'word list does not (cont) plain Int 42';
+
+# Set / Bag membership still works for identical elements
+ok  3 ∈ set(1, 2, 3), 'Int (elem) set of Ints';
+nok 5 ∈ set(1, 2, 3), 'absent Int not (elem) set';
+ok  2 ∈ bag(1, 2, 2), 'Int (elem) bag';


### PR DESCRIPTION
## Problem

`\$x (elem) \$list` / `\$x ∈ \$list` coerces the RHS to a Set and tests membership
by `===` (object identity / `.WHICH`), not by stringified value. mutsu compared
each list element against the needle via `.to_string_value()`, conflating
distinct values that share a `.Str`:

```
1   ∈ (1.0, 2)          # was True,  raku False  (Int vs Rat)
"1" ∈ (1, 2)            # was True,  raku False  (Str vs Int)
42  ∈ < 42 43 >         # was True,  raku False  (Int vs IntStr allomorph)
42  ∈ < 42+0i 42 ... >  # was True,  raku False
```

## Fix

The list-membership arm of `set_contains` now uses
`runtime::utils::values_identical` (the `===` implementation), which already
distinguishes allomorphs and numeric/string types exactly as Rakudo does. The
now-unused `value_matches_key` helper is removed. `(cont)`/∋ shares the same
path and is corrected too.

Set/Bag/Mix/Hash membership paths are **unchanged** — they key by
stringification, a separate and larger representation issue (e.g.
`(1, "1", 1.0).Set.elems` is 1 in mutsu vs 3 in raku) tracked for a future
WHICH-keyed rework.

Surfaced by the QA doc-diff harness (`Type/Allomorph.rakudoc` `∈` examples).

## Test

Pin: `t/set-elem-identity.t` (14 cases). `make test` green; set/bag/mix roast
tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)