### PR TITLE
feat: RakuAST slice 30 — the do statement prefix in .AST and EVAL

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1014,9 +1014,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 29: hash literals `{a => 1}` — **read-only** (`.AST` gist). raku models `{...}` as a
         `Block` of `FatArrow` pairs; EVAL of that Block yields a block/Callable in raku itself, so the
         write direction is out of scope. Tests in `t/rakuast-hash-literal.t`.
-  - [ ] Slice 30+: associative subscripts (`%h{…}`), WhateverCode (`* + 1`), code-block (`{…}`)
-        interpolation — the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full
-        lowering is a large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 30: the `do { … }` statement prefix (both directions) via a new `StatementPrefix::Do`
+        node — `Expr::DoBlock` ↔ `StatementPrefix::Do(Block)`. `EVAL(Q{do { 1 + 2 }}.AST)` → 3. Tests in
+        `t/rakuast-eval-do.t`.
+  - [ ] Slice 31+: `try`/CATCH, associative subscripts (`%h{…}` — read-ambiguous), WhateverCode
+        (`* + 1`), code-block (`{…}`) interpolation — the inverse of the Phase-2 converter, grown cluster
+        by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -371,6 +371,12 @@ earlier ones.
     block-vs-hash distinction is a parse-time decision the RakuAST `Block` node does not carry — so the
     write direction is deliberately out of scope. Value-less keys (`{:a}`) stay the boundary. Tests in
     `t/rakuast-hash-literal.t`. Next: code-block interpolation, WhateverCode, associative subscripts.
+  - **Slice 30 (the `do` statement prefix) — done, both directions.** A new `StatementPrefix::Do` node
+    class models `do { … }`. The read side converts `Expr::DoBlock` to it (wrapping the block via
+    `block_node`) and the write side lowers it back to an `Expr::DoBlock` over the lowered block body.
+    `EVAL(Q{do { 1 + 2 }}.AST)` → `3`; a multi-statement do block, a do block over a variable, and a do
+    block composed inline in an expression all work. A labelled `do` stays the boundary. Tests in
+    `t/rakuast-eval-do.t`.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -769,6 +769,16 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
             class: RakuAstClass::TermWhatever,
             fields: Vec::new(),
         }),
+        // `do { … }` -> `StatementPrefix::Do(Block)`. A labelled do stays the boundary.
+        Expr::DoBlock { body, label } => {
+            if label.is_some() {
+                return Err(unsupported("labelled do block"));
+            }
+            Ok(RakuAstNode {
+                class: RakuAstClass::StatementPrefixDo,
+                fields: vec![node_field(None, block_node(body)?)],
+            })
+        }
         // A fat-arrow pair `a => 1` -> `FatArrow(key => "a", value => …)`. Only a
         // string-literal key is modelled (a computed key stays the boundary).
         Expr::PositionalPair(inner) => match &**inner {

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -572,6 +572,14 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
         }
         // The `*` whatever term.
         RakuAstClass::TermWhatever => Ok(Expr::Whatever),
+        // `do { … }` -> a do-block expression over the lowered block body.
+        RakuAstClass::StatementPrefixDo => {
+            let block = named_child_or_positional(node)?;
+            Ok(Expr::DoBlock {
+                body: lower_block(block)?,
+                label: None,
+            })
+        }
         // A fat-arrow pair `a => 1` -> a positional pair over a `FatArrow` binop.
         RakuAstClass::FatArrow => {
             let key = leaf_str(node, "key")?;

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -138,6 +138,8 @@ pub enum RakuAstClass {
     TermWhatever,
     // Phase 2 slice 35: fat-arrow pairs (`a => 1`).
     FatArrow,
+    // Phase 2 slice 36: the `do` statement prefix.
+    StatementPrefixDo,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -213,6 +215,7 @@ impl RakuAstClass {
             CircumfixArrayComposer => "RakuAST::Circumfix::ArrayComposer",
             TermWhatever => "RakuAST::Term::Whatever",
             FatArrow => "RakuAST::FatArrow",
+            StatementPrefixDo => "RakuAST::StatementPrefix::Do",
         }
     }
 

--- a/t/rakuast-eval-do.t
+++ b/t/rakuast-eval-do.t
@@ -1,0 +1,25 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 30 (ADR-0011): the `do { … }` statement prefix, both directions.
+# `Expr::DoBlock` <-> `RakuAST::StatementPrefix::Do(Block)`. Verified against
+# Rakudo; passes under BOTH mutsu and raku.
+
+plan 5;
+
+# --- read side: `do { … }` renders as StatementPrefix::Do -------------------
+ok Q{my $y = 1; do { $y + 2 }}.AST.gist.contains('RakuAST::StatementPrefix::Do.new('),
+    'a do block renders as StatementPrefix::Do';
+
+# --- a do block yields its final value --------------------------------------
+is EVAL(Q{do { 1 + 2 }}.AST), 3, 'a do block yields its expression value';
+is EVAL(Q{my $n = 3; do { $n * $n }}.AST), 9, 'a do block over a variable';
+
+# --- a multi-statement do block ---------------------------------------------
+is EVAL(Q{my $x = do { my $a = 5; $a * 2 }; $x}.AST), 10,
+    'a multi-statement do block returns its last value';
+
+# --- a do block used inline in an expression --------------------------------
+is EVAL(Q{1 + do { 2 * 3 }}.AST), 7, 'a do block composes in an expression';


### PR DESCRIPTION
## Summary

RakuAST slice 30 (ADR-0011): the `do { … }` statement prefix, **both directions**.

A new `StatementPrefix::Do` node class models `do { … }`:

```raku
Q{do { 1 + 2 }}.AST   # ... StatementPrefix::Do(Block(Blockoid(StatementList(...))))
```

- **Read (`.AST`, Phase 2):** `Expr::DoBlock` → `StatementPrefix::Do(Block)`.
- **Write (`EVAL`, Phase 5):** a `StatementPrefix::Do` → an `Expr::DoBlock` over the lowered block body.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q{do { 1 + 2 }}.AST)                            # 3
EVAL(Q{my $x = do { my $a = 5; $a * 2 }; $x}.AST)    # 10
EVAL(Q{1 + do { 2 * 3 }}.AST)                        # 7
```

A labelled `do` stays the boundary.

## Tests

`t/rakuast-eval-do.t` — 5 assertions (read-side gist is StatementPrefix::Do, do yields its value, do over a variable, multi-statement do, do composed inline), **passing under BOTH mutsu and raku**. All 68 `t/rakuast-*.t` files (309 tests) still green.

Next: `try`/CATCH, WhateverCode, code-block interpolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)