### PR TITLE
fix: say/put/print/note keep a Slip VALUE whole (**@ slurpy semantics)

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -762,9 +762,23 @@ impl Compiler {
         }
     }
 
-    fn compile_exprs(&mut self, exprs: &[Expr]) {
+    /// Compile arguments for a `**@`-slurpy output routine (`say`/`put`/`print`/
+    /// `note`). Such a routine keeps each argument whole: a `.Slip`/`slip(...)`
+    /// VALUE prints as a list (`say @a.Slip` → `(1 2 3)`), it does NOT flatten
+    /// into separate arguments. Only an explicit `|EXPR` pipe flattens at the
+    /// call site (`say |@a` → `123`). So every non-pipe argument gets a `DeSlip`
+    /// that demotes a top-level Slip value to a Seq, dodging the op's
+    /// Slip-flatten pass; `|EXPR` args (already a `MakeSlip`) are left to flatten.
+    fn compile_slurpy_out_args(&mut self, exprs: &[Expr]) {
         for expr in exprs {
             self.compile_expr(expr);
+            let is_pipe = matches!(
+                expr,
+                Expr::Unary { op, .. } if *op == crate::token_kind::TokenKind::Pipe
+            );
+            if !is_pipe {
+                self.code.emit(OpCode::DeSlip);
+            }
         }
     }
 

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -762,19 +762,19 @@ impl Compiler {
                 self.code.emit(OpCode::SetGlobal(key_idx));
             }
             Stmt::Say(exprs) => {
-                self.compile_exprs(exprs);
+                self.compile_slurpy_out_args(exprs);
                 self.code.emit(OpCode::Say(exprs.len() as u32));
             }
             Stmt::Put(exprs) => {
-                self.compile_exprs(exprs);
+                self.compile_slurpy_out_args(exprs);
                 self.code.emit(OpCode::Put(exprs.len() as u32));
             }
             Stmt::Print(exprs) => {
-                self.compile_exprs(exprs);
+                self.compile_slurpy_out_args(exprs);
                 self.code.emit(OpCode::Print(exprs.len() as u32));
             }
             Stmt::Note(exprs) => {
-                self.compile_exprs(exprs);
+                self.compile_slurpy_out_args(exprs);
                 self.code.emit(OpCode::Note(exprs.len() as u32));
             }
             Stmt::VarDecl {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -323,7 +323,11 @@ pub(crate) enum OpCode {
     BoolBitNeg, // ?^ prefix: boolean bitwise negation
     StrBitNeg,  // ~^ prefix: string/buffer bitwise negation
     MakeSlip,   // | prefix: convert array/list to Slip for flattening
-    Decont,     // strip ONE level of Scalar for slurpy flattening (NOT the
+    DeSlip,     // demote a top-level Slip VALUE to a Seq so it is NOT flattened
+    // by a `**@`-slurpy consumer (say/put/print/note). A `|EXPR` pipe-slip is
+    // left untouched (still flattens); an ordinary `.Slip`/`slip(...)` value is
+    // kept whole. See exec_say_op / flatten_slip_args.
+    Decont, // strip ONE level of Scalar for slurpy flattening (NOT the
     // recursive Value::descalarize; touches no ArrayKind flag — see decont family note)
     /// Itemize (containerize) an Array/List value so it behaves as a single
     /// item in list context. Emitted when `$` variable values are used inside

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1700,6 +1700,20 @@ impl Interpreter {
                 self.exec_make_slip_op()?;
                 *ip += 1;
             }
+            OpCode::DeSlip => {
+                // A `.Slip`/`slip(...)` VALUE handed to a `**@`-slurpy consumer
+                // (say/put/print/note) stays a single argument and gists as a
+                // list `(...)`. Demote it to a Seq so the consumer's Slip-flatten
+                // pass leaves it whole; `|EXPR` pipe-slips skip this op and still
+                // flatten. Non-slip values pass through untouched.
+                let val = self.stack.pop().unwrap_or(Value::NIL);
+                let demoted = match val.view() {
+                    ValueView::Slip(items) => Value::seq(items.iter().cloned().collect()),
+                    _ => val,
+                };
+                self.stack.push(demoted);
+                *ip += 1;
+            }
             OpCode::Decont => {
                 self.exec_decont_op();
                 *ip += 1;

--- a/t/say-slip-nonflatten.t
+++ b/t/say-slip-nonflatten.t
@@ -1,0 +1,55 @@
+use Test;
+
+# say/put/print/note are `**@`-slurpy: a `.Slip`/`slip(...)` VALUE passed as an
+# argument stays whole (prints as a list), it does NOT flatten into separate
+# arguments. Only an explicit `|EXPR` pipe flattens at the call site.
+# Regression: mutsu flattened every Slip argument, so `say @a.Slip` printed
+# "123" instead of "(1 2 3)".
+#
+# We drive real subprocesses (via $*EXECUTABLE) and compare captured stdout,
+# because the flatten-vs-whole distinction is only observable in the output.
+
+plan 15;
+
+my $mutsu = $*EXECUTABLE.absolute;
+my $n = 0;
+
+sub out-of($code) {
+    my $base = $*TMPDIR.add("slip-test-{$*PID}-{$n++}").absolute;
+    spurt "$base.code", $code;
+    shell "$mutsu $base.code > $base.out 2> $base.err";
+    my $o = slurp "$base.out";
+    unlink "$base.code"; unlink "$base.out"; unlink "$base.err";
+    $o
+}
+
+# say / note gist the whole Slip as a list; put / print use its Str
+is out-of('my @a=1,2,3; say @a.Slip'),   "(1 2 3)\n", 'say .Slip value -> (1 2 3)';
+is out-of('my @a=1,2,3; put @a.Slip'),   "1 2 3\n",   'put .Slip value -> 1 2 3';
+is out-of('my @a=1,2,3; print @a.Slip'), "1 2 3",     'print .Slip value -> 1 2 3';
+
+# An explicit `|EXPR` pipe DOES flatten into the argument list
+is out-of('my @a=1,2,3; say |@a'),   "123\n", 'say |@a flattens -> 123';
+is out-of('my @a=1,2,3; put |@a'),   "123\n", 'put |@a flattens -> 123';
+is out-of('my @a=1,2,3; print |@a'), "123",   'print |@a flattens -> 123';
+
+# slip(...) / (list).Slip / a scalar holding a Slip all stay whole
+is out-of('say (1,2,3).Slip'),                "(1 2 3)\n", 'say (list).Slip -> (1 2 3)';
+is out-of('say slip(1,2,3)'),                 "(1 2 3)\n", 'say slip(...) -> (1 2 3)';
+is out-of('my $s = (1,2,3).Slip; say $s'),    "(1 2 3)\n", 'say $s (Slip in scalar) -> (1 2 3)';
+
+# A Slip argument does not swallow later arguments
+is out-of('my @a=1,2; say @a.Slip, "X"'), "(1 2)X\n", 'Slip value + trailing arg';
+is out-of('my @a=1,2,3; my @b=8,9; say |@a, @b.Slip'), "123(8 9)\n",
+    'mixed pipe (flatten) + Slip value (whole)';
+
+# empty Slip
+is out-of('my @a=(); say @a.Slip'), "()\n", 'say empty .Slip -> ()';
+
+# a typed-array hole renders through the whole Slip (doc: Type/Array.rakudoc)
+is out-of('my Int @a=[0]; @a[3]=3; say @a.Slip'), "(0 (Int) (Int) 3)\n",
+    'typed-array hole via say .Slip';
+
+# a plain (non-slip) argument is unaffected
+is out-of('my @a=1,2,3; say @a'), "[1 2 3]\n", 'say @a (array) unaffected';
+is out-of('say 1, 2, 3'),         "123\n",     'say with three plain args -> 123';


### PR DESCRIPTION
## Problem

`say`/`put`/`print`/`note` are `**@`-slurpy: a `.Slip`/`slip(...)` **value**
passed as an argument stays a single argument and renders as a list — it does
**not** flatten into separate arguments. Only an explicit `|EXPR` pipe flattens
at the call site. mutsu flattened *every* Slip argument:

| expression | mutsu (before) | raku |
|---|---|---|
| `say @a.Slip` | `123` | `(1 2 3)` |
| `say (1,2,3).Slip` | `123` | `(1 2 3)` |
| `my $s = @a.Slip; say $s` | `123` | `(1 2 3)` |
| `put @a.Slip` | `123` | `1 2 3` |
| `say \|@a` (pipe) | `123` | `123` ✓ (must stay) |

## Fix

A new `DeSlip` opcode demotes a top-level Slip value to a `Seq`. The say-family
statement compiler emits it after every non-`|` argument, so a
`.Slip`/`slip(...)`/scalar-held Slip value is kept whole (the op's Slip-flatten
pass no longer sees it), while a `|EXPR` pipe-slip (a `MakeSlip`) is left to
flatten as before.

Converting to a `Seq` reproduces raku's rendering for all four routines
(say/note gist `(...)`, put/print use `.Str`), identical to `say (list)` /
`put (list)`.

Surfaced by the QA doc-diff harness (`Type/Array.rakudoc` typed-array-hole
`.Slip` example: `say @a.Slip` → `(0 (Int) (Int) 3)`).

## Test

Pin: `t/say-slip-nonflatten.t` (15 cases, driving real subprocesses).
`make test` green; S07-slip / S32-io / allomorphic roast tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)