### PR TITLE
feat: RakuAST slice 31 — the try statement prefix in .AST and EVAL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/PLAN.md
+++ b/PLAN.md
@@ -1017,9 +1017,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 30: the `do { … }` statement prefix (both directions) via a new `StatementPrefix::Do`
         node — `Expr::DoBlock` ↔ `StatementPrefix::Do(Block)`. `EVAL(Q{do { 1 + 2 }}.AST)` → 3. Tests in
         `t/rakuast-eval-do.t`.
-  - [ ] Slice 31+: `try`/CATCH, associative subscripts (`%h{…}` — read-ambiguous), WhateverCode
-        (`* + 1`), code-block (`{…}`) interpolation — the inverse of the Phase-2 converter, grown cluster
-        by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 31: the `try { … }` statement prefix (both directions) via a new `StatementPrefix::Try`
+        node — `Expr::Try` (no CATCH) ↔ `StatementPrefix::Try(Block)`. `EVAL(Q{try { 1 + 2 }}.AST)` → 3;
+        a failing try is undefined. Tests in `t/rakuast-eval-try.t`.
+  - [ ] Slice 32+: `die` (a control call), `gather`/`take`, CATCH blocks, WhateverCode (`* + 1`),
+        code-block (`{…}`) interpolation — the inverse of the Phase-2 converter, grown cluster by
+        cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -377,6 +377,13 @@ earlier ones.
     `EVAL(Q{do { 1 + 2 }}.AST)` → `3`; a multi-statement do block, a do block over a variable, and a do
     block composed inline in an expression all work. A labelled `do` stays the boundary. Tests in
     `t/rakuast-eval-do.t`.
+  - **Slice 31 (the `try` statement prefix) — done, both directions.** A new `StatementPrefix::Try`
+    node class models `try { … }`. The read side converts `Expr::Try` (without a `CATCH` block) to it
+    and the write side lowers it back to an `Expr::Try`. `EVAL(Q{try { 1 + 2 }}.AST)` → `3`, and a
+    *failing* try yields an undefined value (`EVAL(Q{try { (1/0).Int }}.AST).defined` → `False`) — the
+    exception is trapped. A `try` with a `CATCH` block (and a bare `die` statement inside) stay the
+    boundary. Tests in `t/rakuast-eval-try.t`. Next: `die` (a control call), `gather`/`take`,
+    code-block interpolation.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -779,6 +779,17 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
                 fields: vec![node_field(None, block_node(body)?)],
             })
         }
+        // `try { … }` -> `StatementPrefix::Try(Block)`. A `CATCH` block stays the
+        // boundary.
+        Expr::Try { body, catch } => {
+            if catch.is_some() {
+                return Err(unsupported("try with a CATCH block"));
+            }
+            Ok(RakuAstNode {
+                class: RakuAstClass::StatementPrefixTry,
+                fields: vec![node_field(None, block_node(body)?)],
+            })
+        }
         // A fat-arrow pair `a => 1` -> `FatArrow(key => "a", value => …)`. Only a
         // string-literal key is modelled (a computed key stays the boundary).
         Expr::PositionalPair(inner) => match &**inner {

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -580,6 +580,14 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
                 label: None,
             })
         }
+        // `try { … }` -> a try expression over the lowered block body.
+        RakuAstClass::StatementPrefixTry => {
+            let block = named_child_or_positional(node)?;
+            Ok(Expr::Try {
+                body: lower_block(block)?,
+                catch: None,
+            })
+        }
         // A fat-arrow pair `a => 1` -> a positional pair over a `FatArrow` binop.
         RakuAstClass::FatArrow => {
             let key = leaf_str(node, "key")?;

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -140,6 +140,8 @@ pub enum RakuAstClass {
     FatArrow,
     // Phase 2 slice 36: the `do` statement prefix.
     StatementPrefixDo,
+    // Phase 2 slice 37: the `try` statement prefix.
+    StatementPrefixTry,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -216,6 +218,7 @@ impl RakuAstClass {
             TermWhatever => "RakuAST::Term::Whatever",
             FatArrow => "RakuAST::FatArrow",
             StatementPrefixDo => "RakuAST::StatementPrefix::Do",
+            StatementPrefixTry => "RakuAST::StatementPrefix::Try",
         }
     }
 

--- a/t/rakuast-eval-try.t
+++ b/t/rakuast-eval-try.t
@@ -1,0 +1,25 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 31 (ADR-0011): the `try { … }` statement prefix, both directions.
+# `Expr::Try` (without a CATCH block) <-> `RakuAST::StatementPrefix::Try(Block)`.
+# Verified against Rakudo; passes under BOTH mutsu and raku.
+
+plan 5;
+
+# --- read side: `try { … }` renders as StatementPrefix::Try -----------------
+ok Q{my $y = 1; try { $y + 2 }}.AST.gist.contains('RakuAST::StatementPrefix::Try.new('),
+    'a try block renders as StatementPrefix::Try';
+
+# --- a successful try yields its value --------------------------------------
+is EVAL(Q{try { 1 + 2 }}.AST), 3, 'a successful try yields its value';
+is EVAL(Q{my $r = try { 5 * 2 }; $r}.AST), 10, 'a try assigned to a variable';
+
+# --- a multi-statement try --------------------------------------------------
+is EVAL(Q{try { my $a = 3; $a + 4 }}.AST), 7, 'a multi-statement try';
+
+# --- a failing try produces an undefined result -----------------------------
+nok EVAL(Q{try { (1/0).Int }}.AST).defined,
+    'a failing try yields an undefined value (the exception is trapped)';


### PR DESCRIPTION
## Summary

RakuAST slice 31 (ADR-0011): the `try { … }` statement prefix, **both directions**.

A new `StatementPrefix::Try` node class models `try { … }`:

- **Read (`.AST`, Phase 2):** `Expr::Try` (without a `CATCH` block) → `StatementPrefix::Try(Block)`.
- **Write (`EVAL`, Phase 5):** a `StatementPrefix::Try` → an `Expr::Try`.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q{try { 1 + 2 }}.AST)                   # 3
EVAL(Q{my $r = try { 5 * 2 }; $r}.AST)       # 10
EVAL(Q{try { (1/0).Int }}.AST).defined       # False  (the exception is trapped)
```

A `try` with a `CATCH` block (and a bare `die` statement inside the body) stay the boundary.

## Tests

`t/rakuast-eval-try.t` — 5 assertions (read-side gist is StatementPrefix::Try, successful try, try assigned to a var, multi-statement try, a failing try is undefined), **passing under BOTH mutsu and raku**. The read-side gist is byte-identical to Rakudo's. All 69 `t/rakuast-*.t` files (314 tests) still green.

Next: `die` (a control call), `gather`/`take`, CATCH blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)