### PR TITLE
fix: Complex.isNaN checks both parts; Str->Complex/Rat Cool coercion

### DIFF
--- a/src/builtins/functions/dispatch_1arg.rs
+++ b/src/builtins/functions/dispatch_1arg.rs
@@ -50,6 +50,55 @@ pub(crate) fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Val
     {
         return Some(res);
     }
+    // A Str that numifies to a Complex/Rat (not a plain i64/f64) must coerce
+    // fully before a numeric function runs, matching the method form:
+    // `abs "6+8i"` is 10, `conj "1+2i"` is 1-2i. The numeric arms below match
+    // scalar variants and fall to `0`/`NaN` for such a Str. Plain integer/float
+    // strings are handled correctly by those arms, so only the richer Complex/Rat
+    // coercions are delegated to the method dispatch here. Restricted to the
+    // Cool numeric functions — `chars "6+8i"` must stay a string length.
+    if let ValueView::Str(s) = arg.view()
+        && s.parse::<i64>().is_err()
+        && s.parse::<f64>().is_err()
+        && matches!(
+            name,
+            "abs"
+                | "sign"
+                | "exp"
+                | "log"
+                | "log2"
+                | "log10"
+                | "sqrt"
+                | "ceiling"
+                | "floor"
+                | "truncate"
+                | "round"
+                | "conj"
+                | "cis"
+                | "sin"
+                | "cos"
+                | "tan"
+                | "asin"
+                | "acos"
+                | "atan"
+                | "sinh"
+                | "cosh"
+                | "tanh"
+                | "re"
+                | "im"
+                | "sec"
+                | "cosec"
+                | "cotan"
+                | "narrow"
+        )
+        && let Some(coerced) = crate::runtime::str_numeric::parse_raku_str_to_numeric(&s)
+        && matches!(
+            coerced.view(),
+            ValueView::Complex(..) | ValueView::Rat(..) | ValueView::FatRat(..)
+        )
+    {
+        return crate::builtins::methods_0arg::native_method_0arg(&coerced, Symbol::intern(name));
+    }
     match name {
         "combinations" => {
             // combinations($n) where $n is Int => (^$n).combinations (powerset)

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -31,6 +31,9 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             ValueView::Rat(0, 0) => Some(Ok(Value::TRUE)),
             ValueView::FatRat(0, 0) => Some(Ok(Value::TRUE)),
             ValueView::Num(f) => Some(Ok(Value::truth(f.is_nan()))),
+            // A Complex is NaN when EITHER its real or imaginary part is NaN
+            // (`(NaN+5i).isNaN` is True) — Complex.isNaN is `re.isNaN || im.isNaN`.
+            ValueView::Complex(re, im) => Some(Ok(Value::truth(re.is_nan() || im.is_nan()))),
             _ => Some(Ok(Value::FALSE)),
         },
         "nude" => match target.view() {

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -549,11 +549,16 @@ pub(crate) fn native_method_0arg(
             | "acos" | "atan" | "sinh" | "cosh" | "tanh" | "sec" | "cosec" | "cotan" | "asec"
             | "acosec" | "acotan" | "sech" | "cosech" | "cotanh" | "asech" | "acosech"
             | "acotanh" | "atan2" | "narrow" | "polymod" | "base" | "chr" | "expmod" | "lsb"
-            | "msb" | "is-int" => {
+            | "msb" | "is-int" | "re" | "im" => {
                 let coerced = if let Ok(i) = s.parse::<i64>() {
                     Value::int(i)
                 } else if let Ok(f) = s.parse::<f64>() {
                     Value::num(f)
+                } else if let Some(v) = crate::runtime::str_numeric::parse_raku_str_to_numeric(&s) {
+                    // A Str that numifies to a Complex/Rat (`"6+8i"`, `"1/2"`)
+                    // must coerce fully before the numeric method runs, so
+                    // `abs "6+8i"` is 10 and `"1+2i".conj` is 1-2i.
+                    v
                 } else {
                     parse_raku_int_from_str(&s)?
                 };

--- a/t/complex-cool-coercion.t
+++ b/t/complex-cool-coercion.t
@@ -1,0 +1,37 @@
+use Test;
+
+# Two Complex/Cool coercion fixes surfaced by the QA doc-diff harness:
+#
+#  1. Complex.isNaN is True when EITHER part is NaN (Type/Complex.rakudoc).
+#  2. A Str that numifies to a Complex/Rat coerces fully before a Cool numeric
+#     method/function runs, so `abs "6+8i"` is 10 and `"1+2i".conj` is 1-2i
+#     (Type/Cool.rakudoc). Previously the numeric arms matched scalar variants
+#     only and fell to a 0/NaN default for such a Str.
+
+plan 16;
+
+# --- Complex.isNaN ---
+ok  (NaN + 5i).isNaN,        'isNaN: NaN real part';
+ok  (7 + NaN\i).isNaN,       'isNaN: NaN imaginary part';
+ok  (NaN + NaN\i).isNaN,     'isNaN: both parts NaN';
+nok (7 + 5i).isNaN,          'isNaN: finite Complex is not NaN';
+nok (0 + 0i).isNaN,          'isNaN: zero Complex is not NaN';
+
+# --- Str -> Complex coercion, method form ---
+is "6+8i".abs, 10,           '"6+8i".abs -> 10';
+is "3-4i".abs, 5,            '"3-4i".abs -> 5';
+is "1+2i".conj, 1 - 2i,      '"1+2i".conj -> 1-2i';
+is "6+8i".re, 6,             '"6+8i".re -> 6';
+is "6+8i".im, 8,             '"6+8i".im -> 8';
+
+# --- Str -> Complex coercion, function form ---
+is abs("6+8i"), 10,          'abs "6+8i" -> 10';
+is abs("3-4i"), 5,           'abs "3-4i" -> 5';
+
+# --- Str -> Rat coercion still works ---
+is abs("1/2"), 0.5,          'abs "1/2" -> 0.5 (Rat coercion)';
+is abs("-3/4"), 0.75,        'abs "-3/4" -> 0.75';
+
+# --- plain integer/float strings unaffected; string ops not hijacked ---
+is abs("-5"), 5,             'abs "-5" -> 5 (plain int string)';
+is chars("6+8i"), 4,         'chars "6+8i" -> 4 (string length, NOT coerced)';


### PR DESCRIPTION
## Problem

Two Complex/Cool coercion gaps surfaced by the QA doc-diff harness:

1. **`Complex.isNaN` always returned False.** It is True when EITHER the real
   or imaginary part is NaN (`(NaN+5i).isNaN` → True) — `Type/Complex.rakudoc`.

2. **A `Str` that numifies to a Complex/Rat did not coerce** before a Cool
   numeric method/function ran; the numeric arms match scalar `ValueView`
   variants and fell to a `0`/`NaN` default (`Type/Cool.rakudoc`):

   | expression | before | raku |
   |---|---|---|
   | `abs "6+8i"` | `0` | `10` |
   | `"1+2i".conj` | *No such method for Str* | `1-2i` |
   | `"6+8i".re` / `.im` | `0` | `6` / `8` |

## Fix

- `isNaN` gains a `Complex` arm: `re.is_nan() \|\| im.is_nan()`.
- The Str→numeric coercion block (method path) also tries
  `parse_raku_str_to_numeric` (which parses Complex/Rat) and now covers
  `re`/`im`.
- The function path delegates such a Str to the method dispatch, **restricted to
  the Cool numeric functions** so `chars "6+8i"` stays a string length (4).
- Plain integer/float strings keep their existing fast path.

## Test

Pin: `t/complex-cool-coercion.t` (16 cases). `make test` green; whitelisted
`S32-num/complex.t` and `S03-smartmatch/any-complex.t` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)