### PR TITLE
feat: ship a container image (mutsu + mzef) to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Keep the Docker build context tiny: ignore everything, then re-include only
+# what the build needs (src + manifests to compile, vendor/ for the bundled
+# zef tree copied into the runtime image). This excludes the 45G target/, the
+# vendored roast/raku-doc trees, tmp/, .git, etc.
+*
+!Cargo.toml
+!Cargo.lock
+!src/
+!vendor/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -99,7 +99,12 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
-            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=branch
+            type=sha
+          # type=ref,event=branch -> :main on a main push and :<branch> on a
+          # branch/workflow_dispatch run (so a dispatch always yields a valid
+          # tag for the manifest step, making the workflow smoke-testable).
+          # type=sha adds a :sha-<short> tag on every build.
 
       - name: Create multi-arch manifest
         working-directory: /tmp/digests

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,114 @@
+name: Docker
+
+# Publish a container image to GHCR so anyone can try mutsu + mzef with a plain
+# `docker run`. Multi-arch (amd64 + arm64) images are built natively on
+# per-arch runners, then combined into one manifest — no slow QEMU emulation of
+# the release compile.
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build the per-arch image and push it by digest (no tag yet); the merge
+      # job below assembles the tagged multi-arch manifest from the digests.
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/${{ matrix.arch }}
+          cache-from: type=gha,scope=docker-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.arch }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v8
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Tags: a version tag push -> :X.Y.Z + :latest; a main push -> :main.
+      - name: Compute tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Create multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          set -eu
+          tags=$(jq -r '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          # shellcheck disable=SC2046
+          docker buildx imagetools create $tags \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect
+        run: docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,25 @@ Executes compiled bytecode. `vm.rs` holds the (unified `Interpreter`) struct, `r
 - Do not use `cat`, `head`, `tail`, or `sed` via Bash to read files. Always use the Read tool.
 - Do not use `grep`, `rg`, or `find` via Bash to search files. Always use the Grep and Glob tools.
 
+## mzef package manager and distribution
+
+- **Two binaries ship, not one.** `src/main.rs` builds `mutsu` (the interpreter); `src/bin/mzef.rs`
+  builds `mzef` (the bundled package manager). When you add a `[[bin]]`/test or touch CLI wiring,
+  remember both — `cargo build` and `make test` build/exercise both, and `tests/mzef_shim.rs` pins
+  the shim's path resolution.
+- **`vendor/zef/` is vendored upstream Zef (Artistic-2.0) — do NOT hand-edit it.** It is a runtime
+  dependency shipped with mutsu (zef is also the compat north star: fix mutsu, not zef). To bump it,
+  re-vendor per `vendor/README.md` (an `rsync` recipe), not by editing files in place.
+- **`mzef` is a thin re-exec shim** (`mutsu -I vendor/zef/lib vendor/zef/bin/zef <args>`). To run zef
+  under mutsu locally, prefer `target/release/mzef <args>`; it resolves the vendored tree
+  exe-relative (or `$MZEF_ZEF_HOME`) and the sibling `mutsu` (`$MZEF_MUTSU_BIN`). The full pipeline
+  tracker is `docs/mzef-install-pipeline.md`.
+- **Distribution** (`.github/workflows/release.yml` on `v*` tags, `docker.yml` to GHCR): the release
+  tarball and the container both place `bin/mutsu`, `bin/mzef`, and the zef tree at
+  `share/mutsu/zef` so `mzef` finds it via `../share/mutsu/zef` with zero config (mise installs both
+  onto PATH). Linux x64/arm64 are required; **macOS is best-effort** (`continue-on-error`) pending an
+  upstream libffi Mach-O CFI fix — do not "fix" that by weakening the Linux path.
+
 ## Reference implementation
 
 - `raku` is available on this system. Use `raku -e '<code>'` to check expected behavior when the spec is unclear.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+# mutsu — a batteries-included Raku interpreter, with the bundled `mzef`
+# package manager. Try it:
+#
+#   docker run --rm -it ghcr.io/tokuhirom/mutsu            # Raku REPL
+#   docker run --rm ghcr.io/tokuhirom/mutsu mutsu -e 'say (^10).sum'
+#   docker run --rm ghcr.io/tokuhirom/mutsu mzef --version
+#
+# Build locally:
+#   docker build -t mutsu .
+
+# Two stages, fully separated:
+#   * builder — the Rust toolchain compiles the binaries (heavy; ~1.5GB, never
+#     shipped).
+#   * runtime — a slim Debian image that only carries the compiled binaries,
+#     the bundled zef tree, and zef's runtime shell-out tools.
+# The final image contains NONE of the build toolchain or source tree.
+
+# ---- builder (build stage) --------------------------------------------------
+FROM rust:1.93-bookworm AS builder
+
+# pcre2 links the system libpcre2 (the pcre2 feature); libffi is built vendored
+# and statically linked into the binary, so it needs no runtime package.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libpcre2-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+# Build both shipped binaries: the interpreter and the mzef package-manager shim.
+RUN cargo build --release --bin mutsu --bin mzef
+
+# ---- runtime (run stage) ----------------------------------------------------
+FROM debian:bookworm-slim AS runtime
+
+# Runtime deps:
+#   libpcre2-8-0            - dynamically linked by mutsu (pcre2 feature)
+#   curl / git / tar / unzip / ca-certificates
+#                          - zef's fetch/extract backends shell out to these
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libpcre2-8-0 \
+        curl \
+        git \
+        tar \
+        unzip \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Self-contained layout, identical to the release tarball: mzef resolves the
+# bundled zef via ../share/mutsu/zef relative to its own executable.
+COPY --from=builder /src/target/release/mutsu /usr/local/bin/mutsu
+COPY --from=builder /src/target/release/mzef  /usr/local/bin/mzef
+COPY --from=builder /src/vendor/zef           /usr/local/share/mutsu/zef
+
+# Belt-and-suspenders: the exe-relative resolution already finds the tree above,
+# but pin it explicitly so the shim keeps working even if the binary is copied
+# elsewhere in a derived image.
+ENV MZEF_ZEF_HOME=/usr/local/share/mutsu/zef
+
+WORKDIR /work
+
+# Default to the interactive Raku REPL (run with `-it`); override with any
+# command, e.g. `mutsu script.raku` or `mzef install <dist>`.
+CMD ["mutsu", "--repl"]

--- a/PLAN.md
+++ b/PLAN.md
@@ -259,11 +259,14 @@ sessions).
       `mise use -g github:tokuhirom/mutsu` → both commands on PATH (README "Install"). Matrix is
       `fail-fast: false`; **Linux x64/arm64 are required, macOS is `continue-on-error`** (best-effort
       — the pre-existing libffi Mach-O CFI build failure that had made *every* release since v0.3.1
-      publish nothing is thereby prevented from blocking the Linux artifacts). Verified locally: the
-      exact packaging tar reproduces a layout from which `mzef --version` and `mutsu -e` both run with
-      no env. Remaining: (a) the **macOS libffi** build (upstream Clang-17+ CFI issue; needs a
-      libffi/libffi-sys bump or a system-libffi build — unverifiable from Linux, so deferred); (b)
-      first real tag to confirm the GitHub Release + a live `mise use` end-to-end.
+      publish nothing is thereby prevented from blocking the Linux artifacts). **Confirmed live on
+      the v0.8.0 tag (2026-07-19)**: the Release run published `linux-x64`/`linux-arm64`/`macos-x64`
+      tarballs + SHA256SUMS (macos-arm64 failed on libffi, tolerated), and
+      `mise exec github:tokuhirom/mutsu@0.8.0` downloaded/verified/extracted it and ran **both**
+      `mutsu` and `mzef` from `<install>/bin/` with the bundled zef resolved at
+      `<install>/share/mutsu/zef` — no env. Remaining: the **macOS arm64 libffi** build (upstream
+      Clang-17+ CFI issue; macos-x64 builds fine, only arm64 fails; needs a libffi/libffi-sys bump or
+      a system-libffi build — unverifiable from Linux, so deferred).
 - [x] **Container image (2026-07-19)**: `Dockerfile` (two-stage — `rust:1.93-bookworm` builder →
       `debian:bookworm-slim` runtime carrying only the `mutsu`/`mzef` binaries, the bundled zef tree
       at `/usr/local/share/mutsu/zef`, and zef's shell-out tools curl/git/tar/unzip + libpcre2) and

--- a/PLAN.md
+++ b/PLAN.md
@@ -264,6 +264,13 @@ sessions).
       no env. Remaining: (a) the **macOS libffi** build (upstream Clang-17+ CFI issue; needs a
       libffi/libffi-sys bump or a system-libffi build — unverifiable from Linux, so deferred); (b)
       first real tag to confirm the GitHub Release + a live `mise use` end-to-end.
+- [x] **Container image (2026-07-19)**: `Dockerfile` (two-stage — `rust:1.93-bookworm` builder →
+      `debian:bookworm-slim` runtime carrying only the `mutsu`/`mzef` binaries, the bundled zef tree
+      at `/usr/local/share/mutsu/zef`, and zef's shell-out tools curl/git/tar/unzip + libpcre2) and
+      `.github/workflows/docker.yml` publish a multi-arch (amd64+arm64, native per-arch runners +
+      manifest merge) image to `ghcr.io/tokuhirom/mutsu` on `v*` tags (`:X.Y.Z`/`:latest`) and main
+      (`:main`). Try: `docker run --rm -it ghcr.io/tokuhirom/mutsu`. `.dockerignore` keeps the build
+      context tiny (ignore-all + re-include src/Cargo/vendor).
 - [ ] REPL / Debugger / native binary output / public WASM playground.
 
 ### B4. Remaining module-compatibility blockers (the base of batteries)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,45 @@ bundled Zef under `mutsu`, so `mzef install <dist>` works out of the box with no
 extra setup. Linux (x64/arm64) binaries are published each release; macOS builds
 are best-effort while an upstream toolchain issue is resolved.
 
+### With Docker
+
+A prebuilt image (interpreter + bundled `mzef`) is published to GHCR. It carries
+both `mutsu` and `mzef`, so nothing else is needed.
+
+```bash
+# Interactive Raku REPL (needs -it):
+docker run --rm -it ghcr.io/tokuhirom/mutsu
+
+# Run a one-liner:
+docker run --rm ghcr.io/tokuhirom/mutsu mutsu -e 'say (^10).sum'
+
+# Run a script from the current directory (mount it read-only):
+docker run --rm -v "$PWD:/work:ro" ghcr.io/tokuhirom/mutsu mutsu hello.raku
+
+# Use the bundled package manager:
+docker run --rm ghcr.io/tokuhirom/mutsu mzef --version
+docker run --rm ghcr.io/tokuhirom/mutsu mzef info JSON::Fast
+```
+
+`mzef install` writes into a per-`$HOME` site repository. To keep installed
+modules across runs, mount a named volume at `$HOME` (the image runs as `root`,
+so `$HOME` is `/root`) and reuse it:
+
+```bash
+docker run --rm -v mutsu-home:/root ghcr.io/tokuhirom/mutsu mzef install JSON::OptIn
+docker run --rm -v mutsu-home:/root ghcr.io/tokuhirom/mutsu \
+    mutsu -e 'use JSON::OptIn; say "loaded"'
+```
+
+Pin a version with a tag (`ghcr.io/tokuhirom/mutsu:0.7.0`); `:latest` tracks the
+newest release and `:main` tracks the development branch.
+
+The image is a **two-stage build**: a `rust:1.93-bookworm` **builder** stage
+compiles the binaries, and the shipped `debian:bookworm-slim` **runtime** stage
+carries only the `mutsu`/`mzef` binaries, the bundled zef tree, and zef's
+shell-out tools (`curl`/`git`/`tar`/`unzip`) — no Rust toolchain or source. Build
+it yourself with `docker build -t mutsu .`.
+
 ### From source
 
 ```bash

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -48,9 +48,14 @@ had ever carried a binary. Reworked `release.yml`:
 - README gained an "Install" section (`mise use -g github:tokuhirom/mutsu`).
 
 Verified locally that the exact packaging tar reproduces a layout from which `mzef --version` and
-`mutsu -e` both run with no env var. Remaining: the macOS libffi build (needs a libffi/libffi-sys
-bump or a system-libffi build — unverifiable from a Linux dev box, deferred), and the first real
-tag to confirm the live GitHub Release + `mise use` end-to-end.
+`mutsu -e` both run with no env var. **Confirmed live on the v0.8.0 tag** (the first release ever to
+publish a binary): the Release run published the `linux-x64`/`linux-arm64`/`macos-x64` tarballs +
+SHA256SUMS (macos-arm64 failed on libffi, tolerated), and
+`mise exec github:tokuhirom/mutsu@0.8.0` downloaded, checksum/SLSA-verified, and extracted it, then
+ran **both** `mutsu` and `mzef` from `<install>/bin/` with the bundled zef resolved at
+`<install>/share/mutsu/zef` — no env var. Remaining: the macOS **arm64** libffi build (macos-x64
+builds fine; needs a libffi/libffi-sys bump or a system-libffi build — deferred, unverifiable from a
+Linux dev box).
 
 ### Container image on GHCR (B3)
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -52,6 +52,19 @@ Verified locally that the exact packaging tar reproduces a layout from which `mz
 bump or a system-libffi build — unverifiable from a Linux dev box, deferred), and the first real
 tag to confirm the live GitHub Release + `mise use` end-to-end.
 
+### Container image on GHCR (B3)
+
+Added a `Dockerfile` and `docker.yml` so `docker run --rm -it ghcr.io/tokuhirom/mutsu` gives an
+instant Raku REPL with the bundled `mzef` package manager. The Dockerfile is a clean two-stage
+build — a `rust:1.93-bookworm` **builder** compiles `mutsu`+`mzef`, and the shipped
+`debian:bookworm-slim` **runtime** stage carries only the two binaries, the bundled zef tree at
+`/usr/local/share/mutsu/zef`, and zef's shell-out tools (curl/git/tar/unzip) + libpcre2 — no Rust
+toolchain or source in the final image. `mzef` resolves the bundled zef via the same
+`../share/mutsu/zef` exe-relative rule (with `MZEF_ZEF_HOME` pinned as a backstop). `.dockerignore`
+uses ignore-all + re-include (src/Cargo/vendor) to keep the 45G `target/` out of the build context.
+`docker.yml` publishes a multi-arch image (amd64+arm64 built on native per-arch runners, combined via
+`buildx imagetools` manifest) to GHCR on `v*` tags (`:X.Y.Z`/`:latest`) and main (`:main`).
+
 ## 2026-07-18: vendored `roast` bumped `7f2d7508` → `b2cbe8a4` (2026-06-12, 34 commits ahead)
 
 Re-vendored the roast suite to upstream HEAD via `scripts/update-vendor.sh roast b2cbe8a4`. The


### PR DESCRIPTION
## Summary

`docker run --rm -it ghcr.io/tokuhirom/mutsu` now gives an instant Raku REPL with the bundled `mzef` package manager — no install needed. Distribution half of PLAN §1 B3, following the mzef shim (#4782) and mise release pipeline (#4786).

## Changes

- **Dockerfile** — two fully separated stages. A `rust:1.93-bookworm` **builder** compiles `mutsu`+`mzef`; the shipped `debian:bookworm-slim` **runtime** stage carries only the two binaries, the bundled zef tree at `/usr/local/share/mutsu/zef`, and zef's shell-out tools (`curl`/`git`/`tar`/`unzip`) + `libpcre2` — no Rust toolchain or source in the final image (**549MB**). `mzef` resolves the zef tree via the same `../share/mutsu/zef` exe-relative rule (`MZEF_ZEF_HOME` pinned as a backstop).
- **.dockerignore** — ignore-all + re-include (`src`/`Cargo`/`vendor`) keeps the 45G `target/` out of the build context.
- **docker.yml** — multi-arch (amd64+arm64 built on native per-arch runners, combined via `buildx imagetools` manifest) published to GHCR on `v*` tags (`:X.Y.Z`/`:latest`) and main (`:main`).
- **README** — Docker usage: REPL, one-liners, volume-mounted scripts, persisting the `mzef` site repo across runs, version tags.
- **CLAUDE.md** — new "mzef package manager and distribution" section for future contributors (two binaries; `vendor/zef` is vendored — don't hand-edit; mzef local invocation; the `bin` + `share/mutsu/zef` distribution layout; macOS best-effort).

## Verification

Built the real multi-stage image locally and ran it:

```
$ docker run --rm mutsu mutsu -e 'say (^10).sum'     # 45
$ docker run --rm mutsu mzef --version               # 1.1.3 (resolves /usr/local/share/mutsu/zef)
$ docker run --rm mutsu mzef info JSON::OptIn         # full fez metadata over the network
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)