### PR TITLE
feat: RakuAST slice 32 — die/fail in .AST and EVAL

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1020,9 +1020,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 31: the `try { … }` statement prefix (both directions) via a new `StatementPrefix::Try`
         node — `Expr::Try` (no CATCH) ↔ `StatementPrefix::Try(Block)`. `EVAL(Q{try { 1 + 2 }}.AST)` → 3;
         a failing try is undefined. Tests in `t/rakuast-eval-try.t`.
-  - [ ] Slice 32+: `die` (a control call), `gather`/`take`, CATCH blocks, WhateverCode (`* + 1`),
-        code-block (`{…}`) interpolation — the inverse of the Phase-2 converter, grown cluster by
-        cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 32: `die`/`fail` (both directions) as control calls — `Stmt::Die`/`Stmt::Fail` ↔
+        `Call::Name`. Unblocks `die` inside a `try`; `EVAL(Q{try { die "boom" }; $!.Str}.AST)` → "boom".
+        Tests in `t/rakuast-eval-die.t`.
+  - [ ] Slice 33+: `gather`/`take`, CATCH blocks, WhateverCode (`* + 1`), code-block (`{…}`)
+        interpolation — the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full
+        lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -384,6 +384,12 @@ earlier ones.
     exception is trapped. A `try` with a `CATCH` block (and a bare `die` statement inside) stay the
     boundary. Tests in `t/rakuast-eval-try.t`. Next: `die` (a control call), `gather`/`take`,
     code-block interpolation.
+  - **Slice 32 (`die`/`fail`) — done, both directions.** Like `return`/`last`/`next`, raku models
+    `die`/`fail` as bare calls. `Stmt::Die`/`Stmt::Fail` convert to a `Call::Name` (via `control_call`),
+    and the write side lowers a `die`/`fail` call back to the control-flow statement. This unblocks a
+    `die` inside a `try` body: `EVAL(Q{try { die "boom"; 1 }}.AST).defined` → `False`, and the message
+    reaches `$!`. A conditional `die` is caught by a surrounding `try`. Tests in `t/rakuast-eval-die.t`.
+    Next: `gather`/`take`, CATCH blocks, code-block interpolation.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -73,6 +73,15 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
         Stmt::Last(None) => Ok(Some(statement_expression(control_call("last", &[])?))),
         Stmt::Next(None) => Ok(Some(statement_expression(control_call("next", &[])?))),
         Stmt::Last(Some(_)) | Stmt::Next(Some(_)) => Err(unsupported("labelled last/next")),
+        // `die`/`fail EXPR` are also modelled as bare calls.
+        Stmt::Die(expr) => Ok(Some(statement_expression(control_call(
+            "die",
+            std::slice::from_ref(expr),
+        )?))),
+        Stmt::Fail(expr) => Ok(Some(statement_expression(control_call(
+            "fail",
+            std::slice::from_ref(expr),
+        )?))),
         Stmt::VarDecl {
             name,
             expr,

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -94,6 +94,12 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
                 )),
                 "last" => Ok(Stmt::Last(None)),
                 "next" => Ok(Stmt::Next(None)),
+                "die" => Ok(Stmt::Die(
+                    args.into_iter().next().unwrap_or(Expr::Literal(Value::NIL)),
+                )),
+                "fail" => Ok(Stmt::Fail(
+                    args.into_iter().next().unwrap_or(Expr::Literal(Value::NIL)),
+                )),
                 _ => Ok(Stmt::Expr(lower_expr(node)?)),
             }
         }

--- a/t/rakuast-eval-die.t
+++ b/t/rakuast-eval-die.t
@@ -1,0 +1,31 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 32 (ADR-0011): `die`/`fail`, both directions. raku models these
+# as bare calls (like `return`/`last`/`next`); `Stmt::Die`/`Stmt::Fail` convert
+# to a `Call::Name` and lower back. Verified against Rakudo; passes under BOTH
+# mutsu and raku.
+
+plan 5;
+
+# --- read side: `die` renders as a call -------------------------------------
+ok Q{die "boom"}.AST.gist.contains('RakuAST::Name.from-identifier("die")'),
+    'die renders as a call to "die"';
+
+# --- a die inside a try is trapped ------------------------------------------
+nok EVAL(Q{try { die "boom"; 1 }}.AST).defined,
+    'a die inside a try yields an undefined value';
+
+# --- the die message reaches $! ---------------------------------------------
+is EVAL(Q{try { die "boom" }; $!.Str}.AST), 'boom',
+    'the die message is available in $!';
+
+# --- fail is likewise trapped -----------------------------------------------
+nok EVAL(Q{try { fail "nope"; 1 }}.AST).defined,
+    'a fail inside a try yields an undefined value';
+
+# --- a conditional die drives control flow ----------------------------------
+is EVAL(Q{sub f($x) { die "neg" if $x < 0; $x * 2 }; try { f(-1) } // "caught"}.AST), 'caught',
+    'a conditional die is caught by a surrounding try';


### PR DESCRIPTION
## Summary

RakuAST slice 32 (ADR-0011): `die`/`fail`, **both directions**.

Like `return`/`last`/`next`, raku models `die`/`fail` as bare calls:

- **Read (`.AST`, Phase 2):** `Stmt::Die`/`Stmt::Fail` → a `Call::Name` (via `control_call`, carrying the message expression).
- **Write (`EVAL`, Phase 5):** a `die`/`fail` call → the control-flow statement.

This unblocks a `die` inside a `try` body:

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q{try { die "boom"; 1 }}.AST).defined                         # False
EVAL(Q{try { die "boom" }; $!.Str}.AST)                            # "boom"
EVAL(Q{sub f($x) { die "neg" if $x < 0; $x*2 }; try { f(-1) } // "caught"}.AST)  # "caught"
```

## Tests

`t/rakuast-eval-die.t` — 5 assertions (die renders as a call, die-in-try trapped, message in `$!`, fail-in-try trapped, a conditional die caught by try), **passing under BOTH mutsu and raku**. The read-side gist is byte-identical to Rakudo's. All 70 `t/rakuast-*.t` files (319 tests) still green.

Next: `gather`/`take`, CATCH blocks, code-block interpolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)