### PR TITLE
fix: numeric builtin functions coerce a numeric Str argument

### DIFF
--- a/src/builtins/functions/dispatch_1arg.rs
+++ b/src/builtins/functions/dispatch_1arg.rs
@@ -50,16 +50,15 @@ pub(crate) fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Val
     {
         return Some(res);
     }
-    // A Str that numifies to a Complex/Rat (not a plain i64/f64) must coerce
-    // fully before a numeric function runs, matching the method form:
-    // `abs "6+8i"` is 10, `conj "1+2i"` is 1-2i. The numeric arms below match
-    // scalar variants and fall to `0`/`NaN` for such a Str. Plain integer/float
-    // strings are handled correctly by those arms, so only the richer Complex/Rat
-    // coercions are delegated to the method dispatch here. Restricted to the
-    // Cool numeric functions — `chars "6+8i"` must stay a string length.
+    // A numeric Str must coerce to its Numeric value before a Cool numeric
+    // function runs, matching the method form (`f("x")` == `"x".f`). The numeric
+    // arms below match scalar `ValueView` variants and fall to a `0`/`NaN`
+    // default for a Str, so `sqrt "4"` was NaN and `floor "4"` was 0 (while
+    // `abs "6+8i"` was 0). Delegate any numeric Str to the method dispatch, which
+    // coerces Int/Num/Rat/Complex uniformly; a non-numeric Str yields `None` and
+    // falls through. Restricted to the Cool numeric functions so a string
+    // function like `chars "6+8i"` stays a string length.
     if let ValueView::Str(s) = arg.view()
-        && s.parse::<i64>().is_err()
-        && s.parse::<f64>().is_err()
         && matches!(
             name,
             "abs"
@@ -92,12 +91,10 @@ pub(crate) fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Val
                 | "narrow"
         )
         && let Some(coerced) = crate::runtime::str_numeric::parse_raku_str_to_numeric(&s)
-        && matches!(
-            coerced.view(),
-            ValueView::Complex(..) | ValueView::Rat(..) | ValueView::FatRat(..)
-        )
+        && let Some(res) =
+            crate::builtins::methods_0arg::native_method_0arg(&coerced, Symbol::intern(name))
     {
-        return crate::builtins::methods_0arg::native_method_0arg(&coerced, Symbol::intern(name));
+        return Some(res);
     }
     match name {
         "combinations" => {

--- a/t/numeric-fn-string-coercion.t
+++ b/t/numeric-fn-string-coercion.t
@@ -1,0 +1,32 @@
+use Test;
+
+# A numeric Str coerces to its Numeric value before a Cool numeric *function*
+# runs, so `sqrt "4"` is 2 and `floor "4.5"` is 4 — matching the method form
+# (`f("x")` == `"x".f`). Regression: sqrt/floor/ceiling/round function arms
+# matched scalar variants and fell to NaN/0 for a Str argument.
+
+plan 16;
+
+# sqrt / floor / ceiling / round on integer & decimal strings
+is sqrt("4"),        2,  'sqrt "4" -> 2';
+is sqrt("4.0"),      2,  'sqrt "4.0" -> 2';
+is floor("4"),       4,  'floor "4" -> 4';
+is floor("4.7"),     4,  'floor "4.7" -> 4';
+is floor("-2.5"),   -3,  'floor "-2.5" -> -3';
+is ceiling("4"),     4,  'ceiling "4" -> 4';
+is ceiling("4.2"),   5,  'ceiling "4.2" -> 5';
+is round("4.6"),     5,  'round "4.6" -> 5';
+is round("4.4"),     4,  'round "4.4" -> 4';
+
+# function form matches the method form
+is sqrt("9"),   "9".sqrt,   'sqrt sub matches method on string';
+is floor("7.8"), "7.8".floor, 'floor sub matches method on string';
+
+# still-correct cases (regression guard)
+is abs("-5"),   5, 'abs "-5" -> 5';
+is abs("6+8i"), 10, 'abs "6+8i" -> 10 (Complex string)';
+is sign("4"),   1, 'sign "4" -> 1';
+
+# a string function is NOT hijacked by numeric coercion
+is chars("6+8i"), 4, 'chars "6+8i" -> 4 (string length)';
+is chars("123"),  3, 'chars "123" -> 3 (string length)';


### PR DESCRIPTION
## Problem

`sqrt`/`floor`/`ceiling`/`round` (and the other Cool numeric functions) matched
scalar `ValueView` variants and fell to a `NaN`/`0` default for a `Str`
argument, while the method form coerced correctly:

| expression | before | raku |
|---|---|---|
| `sqrt "4"` | `NaN` | `2` |
| `floor "4.7"` | `0` | `4` |
| `ceiling "4.2"` | `0` | `5` |
| `round "4.6"` | `0` | `5` |
| `"4".sqrt` (method) | `2` ✓ | `2` |

## Fix

Broaden the entry delegation in `native_function_1arg` (added for Complex/Rat
strings in #4794) to delegate **any** numeric `Str` on a Cool numeric function
to the method dispatch, which coerces Int/Num/Rat/Complex uniformly. A
non-numeric Str yields `None` from `parse_raku_str_to_numeric` and falls through
to the existing arm; the delegation stays restricted to the Cool numeric
function names so `chars "6+8i"` keeps its string length (4).

## Test

Pin: `t/numeric-fn-string-coercion.t` (16 cases). `make test` green;
`S32-num/complex.t`, `S02-types/num.t`, `S32-num/power.t` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)