### PR TITLE
feat: RakuAST slice 33 — gather/take in .AST and EVAL

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1033,9 +1033,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 32: `die`/`fail` (both directions) as control calls — `Stmt::Die`/`Stmt::Fail` ↔
         `Call::Name`. Unblocks `die` inside a `try`; `EVAL(Q{try { die "boom" }; $!.Str}.AST)` → "boom".
         Tests in `t/rakuast-eval-die.t`.
-  - [ ] Slice 33+: `gather`/`take`, CATCH blocks, WhateverCode (`* + 1`), code-block (`{…}`)
-        interpolation — the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5 full
-        lowering is a large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 33: `gather`/`take` (both directions) — `Expr::Gather` ↔ `StatementPrefix::Gather`, and
+        `take` is a bare call (like `die`). `EVAL(Q{gather { take 1; take 2; take 3 }.elems}.AST)` → 3.
+        Tests in `t/rakuast-eval-gather.t`.
+  - [ ] Slice 34+: more statement prefixes (`quietly`/`lazy`/`eager`), CATCH blocks, WhateverCode
+        (`* + 1`), code-block (`{…}`) interpolation — the inverse of the Phase-2 converter, grown cluster
+        by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -390,6 +390,12 @@ earlier ones.
     `die` inside a `try` body: `EVAL(Q{try { die "boom"; 1 }}.AST).defined` → `False`, and the message
     reaches `$!`. A conditional `die` is caught by a surrounding `try`. Tests in `t/rakuast-eval-die.t`.
     Next: `gather`/`take`, CATCH blocks, code-block interpolation.
+  - **Slice 33 (`gather`/`take`) — done, both directions.** `gather { … }` is a new
+    `StatementPrefix::Gather` node (like `do`/`try`), and `take EXPR` is a bare call (like `die`).
+    `Expr::Gather` and `Stmt::Take` convert (`take-rw` deferred) and lower back.
+    `EVAL(Q{gather { take 1; take 2; take 3 }.elems}.AST)` → `3`; `take` inside a loop gathers each
+    iteration, and a conditional `take` gathers a subset. Tests in `t/rakuast-eval-gather.t`. Next:
+    CATCH blocks, more statement prefixes (`quietly`/`lazy`/`eager`), code-block interpolation.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -82,6 +82,16 @@ fn convert_stmt(stmt: &Stmt) -> Result<Option<RakuAstNode>, RuntimeError> {
             "fail",
             std::slice::from_ref(expr),
         )?))),
+        // `take EXPR` is a bare call too; `take-rw` stays the boundary.
+        Stmt::Take(expr, is_rw) => {
+            if *is_rw {
+                return Err(unsupported("take-rw"));
+            }
+            Ok(Some(statement_expression(control_call(
+                "take",
+                std::slice::from_ref(expr),
+            )?)))
+        }
         Stmt::VarDecl {
             name,
             expr,
@@ -799,6 +809,11 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
                 fields: vec![node_field(None, block_node(body)?)],
             })
         }
+        // `gather { … }` -> `StatementPrefix::Gather(Block)`.
+        Expr::Gather(body) => Ok(RakuAstNode {
+            class: RakuAstClass::StatementPrefixGather,
+            fields: vec![node_field(None, block_node(body)?)],
+        }),
         // A fat-arrow pair `a => 1` -> `FatArrow(key => "a", value => …)`. Only a
         // string-literal key is modelled (a computed key stays the boundary).
         Expr::PositionalPair(inner) => match &**inner {

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -100,6 +100,10 @@ fn lower_stmt_inner(node: &RakuAstNode) -> Result<Stmt, RuntimeError> {
                 "fail" => Ok(Stmt::Fail(
                     args.into_iter().next().unwrap_or(Expr::Literal(Value::NIL)),
                 )),
+                "take" => Ok(Stmt::Take(
+                    args.into_iter().next().unwrap_or(Expr::Literal(Value::NIL)),
+                    false,
+                )),
                 _ => Ok(Stmt::Expr(lower_expr(node)?)),
             }
         }
@@ -593,6 +597,11 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
                 body: lower_block(block)?,
                 catch: None,
             })
+        }
+        // `gather { … }` -> a gather expression over the lowered block body.
+        RakuAstClass::StatementPrefixGather => {
+            let block = named_child_or_positional(node)?;
+            Ok(Expr::Gather(lower_block(block)?))
         }
         // A fat-arrow pair `a => 1` -> a positional pair over a `FatArrow` binop.
         RakuAstClass::FatArrow => {

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -142,6 +142,8 @@ pub enum RakuAstClass {
     StatementPrefixDo,
     // Phase 2 slice 37: the `try` statement prefix.
     StatementPrefixTry,
+    // Phase 2 slice 38: the `gather` statement prefix.
+    StatementPrefixGather,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -219,6 +221,7 @@ impl RakuAstClass {
             FatArrow => "RakuAST::FatArrow",
             StatementPrefixDo => "RakuAST::StatementPrefix::Do",
             StatementPrefixTry => "RakuAST::StatementPrefix::Try",
+            StatementPrefixGather => "RakuAST::StatementPrefix::Gather",
         }
     }
 

--- a/t/rakuast-eval-gather.t
+++ b/t/rakuast-eval-gather.t
@@ -1,0 +1,30 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 33 (ADR-0011): `gather { … take … }`, both directions.
+# `gather` is a `StatementPrefix::Gather` (like `do`/`try`) and `take` is a bare
+# call (like `die`). `Expr::Gather` and `Stmt::Take` convert and lower back.
+# Verified against Rakudo; passes under BOTH mutsu and raku.
+
+plan 5;
+
+# --- read side: `gather` renders as StatementPrefix::Gather ------------------
+my $g = Q{gather { take 1; take 2 }}.AST.gist;
+ok $g.contains('RakuAST::StatementPrefix::Gather.new(')
+    && $g.contains('RakuAST::Name.from-identifier("take")'),
+    'gather renders as StatementPrefix::Gather with take calls';
+
+# --- gather collects each take ----------------------------------------------
+is EVAL(Q{gather { take 1; take 2; take 3 }.elems}.AST), 3,
+    'gather collects each take';
+is EVAL(Q{gather { take 10; take 20 }.sum}.AST), 30, 'the gathered values sum';
+
+# --- take inside a loop -----------------------------------------------------
+is EVAL(Q{gather { for 1..4 -> $x { take $x * $x } }.sum}.AST), 30,
+    'take inside a loop gathers each iteration';
+
+# --- a conditional take -----------------------------------------------------
+is EVAL(Q{gather { for 1..6 -> $x { take $x if $x %% 2 } }.join(",")}.AST), '2,4,6',
+    'a conditional take gathers a subset';


### PR DESCRIPTION
## Summary

RakuAST slice 33 (ADR-0011): `gather`/`take`, **both directions**.

`gather { … }` is a new `StatementPrefix::Gather` node (like `do`/`try`), and `take EXPR` is a bare call (like `die`):

- **Read (`.AST`, Phase 2):** `Expr::Gather` → `StatementPrefix::Gather(Block)`, and `Stmt::Take` (plain, not `take-rw`) → a `Call::Name`.
- **Write (`EVAL`, Phase 5):** a `StatementPrefix::Gather` → `Expr::Gather`, and a `take` call → `Stmt::Take`.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q{gather { take 1; take 2; take 3 }.elems}.AST)                 # 3
EVAL(Q{gather { for 1..4 -> $x { take $x * $x } }.sum}.AST)          # 30
EVAL(Q{gather { for 1..6 -> $x { take $x if $x %% 2 } }.join(",")}.AST)  # "2,4,6"
```

`take-rw` stays the boundary.

## Tests

`t/rakuast-eval-gather.t` — 5 assertions (read-side gist is StatementPrefix::Gather, gather collects each take, sum of gathered values, take in a loop, conditional take), **passing under BOTH mutsu and raku**. The read-side gist is byte-identical to Rakudo's. All 71 `t/rakuast-*.t` files (324 tests) still green.

Next: CATCH blocks, more statement prefixes, code-block interpolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)