### PR TITLE
fix: Complex.UInt coerces via the real part

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -631,6 +631,38 @@ pub(super) fn dispatch(
                 ValueView::BigInt(_) => Some(target.clone()),
                 ValueView::Num(f) if f.is_finite() => Some(Value::int(f.trunc() as i64)),
                 ValueView::Rat(n, d) if d != 0 => Some(Value::int(n / d)),
+                // A Complex coerces to UInt via its real part (`(5+0i).UInt` is 5);
+                // a non-zero imaginary part is not Real and throws X::Numeric::Real
+                // (mirroring the `sign`/`.Int` Complex coercion).
+                ValueView::Complex(re, im) => {
+                    if im != 0.0 {
+                        let rendered = if im >= 0.0 {
+                            format!("{re}+{im}i")
+                        } else {
+                            format!("{re}{im}i")
+                        };
+                        let mut attrs = std::collections::HashMap::new();
+                        attrs.insert(
+                            "message".to_string(),
+                            Value::str(format!(
+                                "Cannot convert {rendered} to Real: imaginary part not zero"
+                            )),
+                        );
+                        attrs.insert("target".to_string(), Value::package(Symbol::intern("Real")));
+                        attrs.insert("source".to_string(), target.clone());
+                        let ex = Value::make_instance(Symbol::intern("X::Numeric::Real"), attrs);
+                        let mut err = RuntimeError::new(
+                            "Cannot convert Complex to Real: imaginary part not zero",
+                        );
+                        err.exception = Some(Box::new(ex));
+                        return Some(Some(Err(err)));
+                    }
+                    if re.is_finite() {
+                        Some(Value::int(re.trunc() as i64))
+                    } else {
+                        None
+                    }
+                }
                 ValueView::Bool(b) => Some(Value::int(if b { 1 } else { 0 })),
                 ValueView::Str(s) if s.trim().is_empty() => Some(Value::int(0)),
                 ValueView::Str(s) => {

--- a/t/complex-uint-coerce.t
+++ b/t/complex-uint-coerce.t
@@ -1,0 +1,21 @@
+use Test;
+
+# Complex.UInt coerces via the real part (a purely-real Complex), truncating
+# like .Int; a non-zero imaginary part is not Real and throws X::Numeric::Real.
+# Regression: `(5+0i).UInt` was "No such method 'UInt' for Complex".
+
+plan 6;
+
+is (5 + 0i).UInt,   5, '(5+0i).UInt -> 5';
+is (5.7 + 0i).UInt, 5, '(5.7+0i).UInt truncates -> 5';
+is (0 + 0i).UInt,   0, '(0+0i).UInt -> 0';
+
+# non-zero imaginary part is not Real
+throws-like { (5 + 2i).UInt }, X::Numeric::Real,
+    'UInt of a Complex with imaginary part throws X::Numeric::Real';
+
+# a purely-real Complex still coerces even when written with -0i
+is (42 - 0i).UInt, 42, '(42-0i).UInt -> 42';
+
+# .UInt matches .Int on the real value for a real Complex
+is (9 + 0i).UInt, (9 + 0i).Int, 'Complex.UInt matches .Int for a real Complex';


### PR DESCRIPTION
## Problem

`(5+0i).UInt` threw *No such method 'UInt' for invocant of type 'Complex'*. The
`UInt` coercion matched scalar `ValueView` variants but had no `Complex` arm.

## Fix

A purely-real Complex coerces to `UInt` via its real part (truncating like
`.Int`, then the existing non-negative check applies):

```
(5+0i).UInt    # 5
(5.7+0i).UInt  # 5
(5+2i).UInt    # throws X::Numeric::Real (imaginary part not zero)
```

The imaginary-part rejection mirrors the existing `sign`/`.Int` Complex coercion.

Surfaced by the QA doc-diff harness (Type/Complex coercion example).

## Test

Pin: `t/complex-uint-coerce.t` (6 cases). `make test` green; whitelisted
`S32-num/complex.t` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)