### PR TITLE
feat: RakuAST slice 34 — blocks as values (map/grep/first block args)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1036,9 +1036,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 33: `gather`/`take` (both directions) — `Expr::Gather` ↔ `StatementPrefix::Gather`, and
         `take` is a bare call (like `die`). `EVAL(Q{gather { take 1; take 2; take 3 }.elems}.AST)` → 3.
         Tests in `t/rakuast-eval-gather.t`.
-  - [ ] Slice 34+: more statement prefixes (`quietly`/`lazy`/`eager`), CATCH blocks, WhateverCode
-        (`* + 1`), code-block (`{…}`) interpolation — the inverse of the Phase-2 converter, grown cluster
-        by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 34: blocks as values — a `RakuAST::Block` in expression position lowers to a bare-block
+        closure (`Expr::AnonSub`), unblocking `.map`/`.grep`/`.first`/… block arguments.
+        `EVAL(Q{(1,2,3).map({ $_*2 }).sum}.AST)` → 12. Tests in `t/rakuast-eval-block-arg.t`.
+  - [ ] Slice 35+: placeholder blocks (`{ $^a }`), calling a code var (`$f(…)`), CATCH blocks,
+        WhateverCode (`* + 1`), code-block (`{…}`) interpolation — the inverse of the Phase-2 converter,
+        grown cluster by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -396,6 +396,14 @@ earlier ones.
     `EVAL(Q{gather { take 1; take 2; take 3 }.elems}.AST)` → `3`; `take` inside a loop gathers each
     iteration, and a conditional `take` gathers a subset. Tests in `t/rakuast-eval-gather.t`. Next:
     CATCH blocks, more statement prefixes (`quietly`/`lazy`/`eager`), code-block interpolation.
+  - **Slice 34 (blocks as values) — done (write).** A `RakuAST::Block` in expression position (e.g. the
+    `{ … }` argument to `.map`/`.grep`/`.first`/…) now lowers to a bare-block closure
+    (`Expr::AnonSub { is_block: true }`), so higher-order list methods run. `EVAL(Q{(1, 2, 3).map({ $_ *
+    2 }).sum}.AST)` → `12`; `.grep`/`.first`, multi-statement blocks, and chained `map`/`grep` all work.
+    (This is also consistent with raku, which EVALs any `Block` node to a `Callable` — so a hash-shaped
+    `{a => 1}` lands here as a block too, matching raku's `.elems` == 1.) Placeholder-parameter blocks
+    (`{ $^a <=> $^b }`) and calling a code variable (`$f(…)`) stay the boundary. Tests in
+    `t/rakuast-eval-block-arg.t`. Next: placeholder blocks, CATCH blocks, code-block interpolation.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -561,6 +561,14 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             Ok(Expr::StringInterpolation(parts))
         }
         RakuAstClass::StatementExpression => lower_expr(named_child(node, "expression")?),
+        // A `Block` in expression position (e.g. the `{ … }` argument to `.map`) is
+        // a bare-block closure value. (raku itself EVALs a `Block` node to a
+        // Callable, so a hash-shaped `{a => 1}` also lands here as a block.)
+        RakuAstClass::Block => Ok(Expr::AnonSub {
+            body: lower_block(node)?,
+            is_rw: false,
+            is_block: true,
+        }),
         // `(EXPR)` -> its inner expression (parens are transparent for EVAL). The
         // node wraps a `SemiList` of `Statement::Expression`s; only the
         // single-statement form is handled.

--- a/t/rakuast-eval-block-arg.t
+++ b/t/rakuast-eval-block-arg.t
@@ -1,0 +1,31 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 34 (ADR-0011): blocks as values (`{ … }` arguments to `.map`,
+# `.grep`, `.first`, …). A `RakuAST::Block` in expression position lowers to a
+# bare-block closure (`Expr::AnonSub`), so higher-order list methods run. Verified
+# against Rakudo; passes under BOTH mutsu and raku.
+#
+# Note: placeholder-parameter blocks (`{ $^a <=> $^b }`) and calling a code
+# variable (`$f(…)`) are separate constructs and stay the coverage boundary.
+
+plan 5;
+
+# --- map with a topic block -------------------------------------------------
+is EVAL(Q{(1, 2, 3).map({ $_ * 2 }).sum}.AST), 12, 'map with a { $_ } block';
+
+# --- grep with a topic block ------------------------------------------------
+is EVAL(Q{(1..6).grep({ $_ %% 2 }).join(",")}.AST), '2,4,6', 'grep with a { $_ } block';
+
+# --- first with a predicate block -------------------------------------------
+is EVAL(Q{(3, 7, 2, 9).first({ $_ > 5 })}.AST), 7, 'first with a predicate block';
+
+# --- a multi-statement block ------------------------------------------------
+is EVAL(Q{(1, 2, 3).map({ my $y = $_ * $_; $y + 1 }).join(",")}.AST), '2,5,10',
+    'a multi-statement block';
+
+# --- chained higher-order calls ---------------------------------------------
+is EVAL(Q{(1..5).map({ $_ * $_ }).grep({ $_ > 5 }).join(",")}.AST), '9,16,25',
+    'chained map/grep blocks';


### PR DESCRIPTION
## Summary

RakuAST slice 34 (ADR-0011): blocks as values.

A `RakuAST::Block` in expression position — most importantly the `{ … }` argument to a higher-order list method like `.map`/`.grep`/`.first` — now lowers to a bare-block closure (`Expr::AnonSub { is_block: true }`), so those methods run under EVAL. The read side already emits the `Block` node.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q{(1, 2, 3).map({ $_ * 2 }).sum}.AST)                    # 12
EVAL(Q{(1..6).grep({ $_ %% 2 }).join(",")}.AST)              # "2,4,6"
EVAL(Q{(1..5).map({ $_ * $_ }).grep({ $_ > 5 }).join(",")}.AST)  # "9,16,25"
```

This is consistent with raku itself, which EVALs any `Block` node to a `Callable` — so a hash-shaped `{a => 1}` lands here as a block too (matching raku's `.elems` == 1 on the EVAL'd result), which is why slice 29 kept the hash literal read-only.

Placeholder-parameter blocks (`{ $^a <=> $^b }`) and calling a code variable (`$f(…)`) are separate constructs and stay the boundary.

## Tests

`t/rakuast-eval-block-arg.t` — 5 assertions (map, grep, first, a multi-statement block, chained map/grep), **passing under BOTH mutsu and raku**. All 72 `t/rakuast-*.t` files (329 tests) still green.

Next: placeholder blocks, calling a code var, CATCH blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)