### PR TITLE
feat: RakuAST slice 35 — calling a term ($f(...)) in .AST and EVAL

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1039,9 +1039,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 34: blocks as values — a `RakuAST::Block` in expression position lowers to a bare-block
         closure (`Expr::AnonSub`), unblocking `.map`/`.grep`/`.first`/… block arguments.
         `EVAL(Q{(1,2,3).map({ $_*2 }).sum}.AST)` → 12. Tests in `t/rakuast-eval-block-arg.t`.
-  - [ ] Slice 35+: placeholder blocks (`{ $^a }`), calling a code var (`$f(…)`), CATCH blocks,
-        WhateverCode (`* + 1`), code-block (`{…}`) interpolation — the inverse of the Phase-2 converter,
-        grown cluster by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 35: calling a term `$f(…)` (both directions) via a new `Call::Term` node — `Expr::CallOn`
+        ↔ `ApplyPostfix(operand, Call::Term(args))`. `EVAL(Q{my $f = { $_*2 }; $f(9)}.AST)` → 18. Tests
+        in `t/rakuast-eval-callterm.t`.
+  - [ ] Slice 36+: pointy/sub code values (`-> $x { … }` / `sub ($x) { … }` in expression position),
+        placeholder blocks (`{ $^a }`), CATCH blocks, WhateverCode (`* + 1`), code-block (`{…}`)
+        interpolation — the inverse of the Phase-2 converter, grown cluster by cluster.
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -404,6 +404,13 @@ earlier ones.
     `{a => 1}` lands here as a block too, matching raku's `.elems` == 1.) Placeholder-parameter blocks
     (`{ $^a <=> $^b }`) and calling a code variable (`$f(…)`) stay the boundary. Tests in
     `t/rakuast-eval-block-arg.t`. Next: placeholder blocks, CATCH blocks, code-block interpolation.
+  - **Slice 35 (calling a term) — done, both directions.** A new `Call::Term` node class models a call
+    on a term (`$f(1, 2)` — `ApplyPostfix(operand, Call::Term(args))`). The read side converts
+    `Expr::CallOn` to it and the write side lowers a `Call::Term` postfix back to an `Expr::CallOn`.
+    `EVAL(Q{my $f = { $_ * 2 }; $f(9)}.AST)` → `18`; a callback block passed to a sub and invoked, and
+    two term calls composed, work. Named-parameter code values (`sub ($x) { … }` / `-> $x { … }`) — the
+    `RakuAST::PointyBlock`/`Sub` in expression position — stay the boundary. Tests in
+    `t/rakuast-eval-callterm.t`. Next: pointy/sub code values, placeholder blocks, CATCH blocks.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/convert.rs
+++ b/src/rakuast/convert.rs
@@ -783,6 +783,20 @@ fn convert_expr(expr: &Expr) -> Result<RakuAstNode, RuntimeError> {
         Expr::Literal(v) | Expr::LiteralSrc(v, _) => convert_literal(v),
         Expr::Call { name, args } => Ok(call_name(name.as_str(), args, false)?),
         Expr::Var(name) => Ok(var_lexical("$", name)),
+        // Calling a term `$f(1, 2)` -> ApplyPostfix(operand, Call::Term(args)).
+        Expr::CallOn { target, args } => {
+            let call_term = RakuAstNode {
+                class: RakuAstClass::CallTerm,
+                fields: vec![node_field(Some("args"), arg_list(args)?)],
+            };
+            Ok(RakuAstNode {
+                class: RakuAstClass::ApplyPostfix,
+                fields: vec![
+                    node_field(Some("operand"), convert_expr(target)?),
+                    node_field(Some("postfix"), call_term),
+                ],
+            })
+        }
         // The `*` whatever term.
         Expr::Whatever => Ok(RakuAstNode {
             class: RakuAstClass::TermWhatever,

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -720,6 +720,11 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
                     modifier: None,
                     quoted: false,
                 }),
+                // `$f(EXPR)` -> Call::Term(args) -> a call on the operand term.
+                RakuAstClass::CallTerm => Ok(Expr::CallOn {
+                    target: Box::new(operand),
+                    args: arg_exprs(postfix)?,
+                }),
                 // `@a[EXPR]` -> Postcircumfix::ArrayIndex(index => SemiList(
                 // Statement::Expression(EXPR))).
                 RakuAstClass::PostcircumfixArrayIndex => {

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -144,6 +144,8 @@ pub enum RakuAstClass {
     StatementPrefixTry,
     // Phase 2 slice 38: the `gather` statement prefix.
     StatementPrefixGather,
+    // Phase 2 slice 39: calling a term (`$f(…)`).
+    CallTerm,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -222,6 +224,7 @@ impl RakuAstClass {
             StatementPrefixDo => "RakuAST::StatementPrefix::Do",
             StatementPrefixTry => "RakuAST::StatementPrefix::Try",
             StatementPrefixGather => "RakuAST::StatementPrefix::Gather",
+            CallTerm => "RakuAST::Call::Term",
         }
     }
 

--- a/t/rakuast-eval-callterm.t
+++ b/t/rakuast-eval-callterm.t
@@ -1,0 +1,32 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 35 (ADR-0011): calling a term `$f(…)`, both directions.
+# `$f(1, 2)` is `ApplyPostfix(operand, Call::Term(args))`; mutsu models it as
+# `Expr::CallOn`. The read side emits the `Call::Term` node and the write side
+# lowers it back. Verified against Rakudo; passes under BOTH mutsu and raku.
+#
+# Note: the callable is a bare block `{ … }` (a `$_` closure); named-parameter
+# code values (`sub ($x) { … }` / `-> $x { … }`) are a separate construct and
+# stay the coverage boundary.
+
+plan 5;
+
+# --- read side: `$f(9)` renders with a Call::Term postfix -------------------
+ok Q{my $f = 0; $f(9)}.AST.gist.contains('RakuAST::Call::Term.new('),
+    'calling a term renders as ApplyPostfix + Call::Term';
+
+# --- calling a block held in a variable -------------------------------------
+is EVAL(Q{my $f = { $_ * 2 }; $f(9)}.AST), 18, 'a block variable is callable';
+
+# --- calling with a different argument --------------------------------------
+is EVAL(Q{my $f = { $_ + 100 }; $f(5)}.AST), 105, 'the argument binds the block topic';
+
+# --- a block passed as a callback and invoked -------------------------------
+is EVAL(Q{sub twice($g) { $g(3) + $g(4) }; twice({ $_ * 10 })}.AST), 70,
+    'a callback block is invoked with each argument';
+
+# --- two calls in an expression ---------------------------------------------
+is EVAL(Q{my $f = { $_ * $_ }; $f(3) + $f(4)}.AST), 25, 'two term calls compose';


### PR DESCRIPTION
## Summary

RakuAST slice 35 (ADR-0011): calling a term `$f(…)`, **both directions**.

A new `Call::Term` node class models a call on a term (`$f(1, 2)` — `ApplyPostfix(operand, Call::Term(args))`):

- **Read (`.AST`, Phase 2):** `Expr::CallOn` → `ApplyPostfix(operand, Call::Term(args))`.
- **Write (`EVAL`, Phase 5):** a `Call::Term` postfix → an `Expr::CallOn`.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q{my $f = { $_ * 2 }; $f(9)}.AST)                        # 18
EVAL(Q{sub twice($g) { $g(3) + $g(4) }; twice({ $_ * 10 })}.AST)  # 70
EVAL(Q{my $f = { $_ * $_ }; $f(3) + $f(4)}.AST)              # 25
```

Named-parameter code values (`sub ($x) { … }` / `-> $x { … }` — a `RakuAST::PointyBlock`/`Sub` in expression position) stay the boundary.

## Tests

`t/rakuast-eval-callterm.t` — 5 assertions (read-side gist has Call::Term, calling a block var, argument binds the topic, a callback block invoked, two term calls composed), **passing under BOTH mutsu and raku**. The read-side gist is byte-identical to Rakudo's. All 73 `t/rakuast-*.t` files (334 tests) still green.

Next: pointy/sub code values, placeholder blocks, CATCH blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)