### PR TITLE
feat: RakuAST slice 36 — pointy code values (-> $x { ... }) under EVAL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/PLAN.md
+++ b/PLAN.md
@@ -1042,9 +1042,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 35: calling a term `$f(…)` (both directions) via a new `Call::Term` node — `Expr::CallOn`
         ↔ `ApplyPostfix(operand, Call::Term(args))`. `EVAL(Q{my $f = { $_*2 }; $f(9)}.AST)` → 18. Tests
         in `t/rakuast-eval-callterm.t`.
-  - [ ] Slice 36+: pointy/sub code values (`-> $x { … }` / `sub ($x) { … }` in expression position),
-        placeholder blocks (`{ $^a }`), CATCH blocks, WhateverCode (`* + 1`), code-block (`{…}`)
-        interpolation — the inverse of the Phase-2 converter, grown cluster by cluster.
+  - [x] Slice 36: pointy code values `-> $x { … }` (write) — a single-param `RakuAST::PointyBlock` in
+        expression position lowers to `Expr::Lambda`. `EVAL(Q{my $f = -> $x { $x*2 }; $f(9)}.AST)` → 18.
+        Tests in `t/rakuast-eval-pointy.t`.
+  - [ ] Slice 37+: `sub ($x) { … }` code values, placeholder blocks (`{ $^a }`), CATCH blocks,
+        WhateverCode (`* + 1`), code-block (`{…}`) interpolation — the inverse of the Phase-2 converter,
+        grown cluster by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -411,6 +411,12 @@ earlier ones.
     two term calls composed, work. Named-parameter code values (`sub ($x) { … }` / `-> $x { … }`) — the
     `RakuAST::PointyBlock`/`Sub` in expression position — stay the boundary. Tests in
     `t/rakuast-eval-callterm.t`. Next: pointy/sub code values, placeholder blocks, CATCH blocks.
+  - **Slice 36 (pointy code values) — done (write).** A single-parameter `RakuAST::PointyBlock` in
+    expression position (`-> $x { … }`) now lowers to a closure (`Expr::Lambda`), so a named-parameter
+    closure can be stored, passed, and called (with slice 35's `Call::Term`). `EVAL(Q{my $f = -> $x { $x
+    * 2 }; $f(9)}.AST)` → `18`; a pointy callback, a pointy `.map` argument, and a multi-statement pointy
+    body all work. Multi-/zero-parameter pointy blocks and `sub ($x) { … }` code values stay the
+    boundary. Tests in `t/rakuast-eval-pointy.t`. Next: `sub` code values, placeholder blocks, CATCH.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -569,6 +569,16 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             is_rw: false,
             is_block: true,
         }),
+        // A pointy block `-> $x { … }` in expression position is a single-parameter
+        // closure. Multi-/zero-parameter pointy blocks stay the boundary.
+        RakuAstClass::PointyBlock => match pointy_single_param(node)? {
+            Some(param) => Ok(Expr::Lambda {
+                param,
+                body: lower_block(node)?,
+                is_whatever_code: false,
+            }),
+            None => Err(unsupported(node)),
+        },
         // `(EXPR)` -> its inner expression (parens are transparent for EVAL). The
         // node wraps a `SemiList` of `Statement::Expression`s; only the
         // single-statement form is handled.

--- a/t/rakuast-eval-pointy.t
+++ b/t/rakuast-eval-pointy.t
@@ -1,0 +1,34 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 36 (ADR-0011): pointy blocks as code values (`-> $x { … }`).
+# A single-parameter `RakuAST::PointyBlock` in expression position lowers to a
+# closure (`Expr::Lambda`), so a named-parameter closure can be stored, passed,
+# and called. Verified against Rakudo; passes under BOTH mutsu and raku.
+#
+# Note: multi-/zero-parameter pointy blocks and `sub ($x) { … }` code values are
+# separate constructs and stay the coverage boundary.
+
+plan 5;
+
+# --- a pointy closure stored and called -------------------------------------
+is EVAL(Q{my $f = -> $x { $x * 2 }; $f(9)}.AST), 18,
+    'a pointy closure is stored and called';
+
+# --- the argument binds the named parameter ---------------------------------
+is EVAL(Q{my $f = -> $n { $n + 100 }; $f(5)}.AST), 105,
+    'the argument binds the pointy parameter';
+
+# --- a pointy passed as a callback ------------------------------------------
+is EVAL(Q{sub app($g) { $g(5) }; app(-> $n { $n + 1 })}.AST), 6,
+    'a pointy closure passed as a callback';
+
+# --- a pointy as a map block ------------------------------------------------
+is EVAL(Q{(1, 2, 3).map(-> $x { $x * $x }).sum}.AST), 14,
+    'a pointy block as a map argument';
+
+# --- a multi-statement pointy body ------------------------------------------
+is EVAL(Q{my $f = -> $x { my $y = $x + 1; $y * $y }; $f(3)}.AST), 16,
+    'a multi-statement pointy body';


### PR DESCRIPTION
## Summary

RakuAST slice 36 (ADR-0011): pointy blocks as code values (`-> $x { … }`) — write direction.

A single-parameter `RakuAST::PointyBlock` in expression position now lowers to a closure (`Expr::Lambda`), so a named-parameter closure can be stored, passed, and called (together with slice 35's `Call::Term`). The read side already emits the `PointyBlock` node; `lower_for` handles the loop case, so this `lower_expr` arm only affects pointy blocks used as expression values.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q{my $f = -> $x { $x * 2 }; $f(9)}.AST)                  # 18
EVAL(Q{sub app($g) { $g(5) }; app(-> $n { $n + 1 })}.AST)    # 6
EVAL(Q{(1, 2, 3).map(-> $x { $x * $x }).sum}.AST)            # 14
```

Multi-/zero-parameter pointy blocks and `sub ($x) { … }` code values stay the boundary.

## Tests

`t/rakuast-eval-pointy.t` — 5 assertions (stored+called, argument binds the parameter, pointy callback, pointy map argument, multi-statement pointy body), **passing under BOTH mutsu and raku**. All 74 `t/rakuast-*.t` files (339 tests) still green.

Next: `sub ($x) { … }` code values, placeholder blocks, CATCH blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)