### PR TITLE
feat: RakuAST slice 37 — multi-parameter closures under EVAL

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1045,9 +1045,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 36: pointy code values `-> $x { … }` (write) — a single-param `RakuAST::PointyBlock` in
         expression position lowers to `Expr::Lambda`. `EVAL(Q{my $f = -> $x { $x*2 }; $f(9)}.AST)` → 18.
         Tests in `t/rakuast-eval-pointy.t`.
-  - [ ] Slice 37+: `sub ($x) { … }` code values, placeholder blocks (`{ $^a }`), CATCH blocks,
-        WhateverCode (`* + 1`), code-block (`{…}`) interpolation — the inverse of the Phase-2 converter,
-        grown cluster by cluster. (Phase 5 full lowering is a large multi-slice effort mirroring Phase 2.)
+  - [x] Slice 37: multi-parameter closures — `sub ($a, $b) { … }` / `-> $a, $b { … }` (both a
+        multi-param `PointyBlock`) lower to `Expr::AnonSubParams`; a default parameter composes.
+        `EVAL(Q{my $add = sub ($a, $b) { $a+$b }; $add(3, 4)}.AST)` → 7. Tests in `t/rakuast-eval-anonsub.t`.
+  - [ ] Slice 38+: placeholder blocks (`{ $^a }`), CATCH blocks, WhateverCode (`* + 1`), code-block
+        (`{…}`) interpolation — the inverse of the Phase-2 converter, grown cluster by cluster. (Phase 5
+        full lowering is a large multi-slice effort mirroring Phase 2.)
 - [ ] **Phase 6** — macros / `quasi` / unquoting (built on 4+5; may defer indefinitely).
 
 ---

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -417,6 +417,13 @@ earlier ones.
     * 2 }; $f(9)}.AST)` → `18`; a pointy callback, a pointy `.map` argument, and a multi-statement pointy
     body all work. Multi-/zero-parameter pointy blocks and `sub ($x) { … }` code values stay the
     boundary. Tests in `t/rakuast-eval-pointy.t`. Next: `sub` code values, placeholder blocks, CATCH.
+  - **Slice 37 (multi-parameter closures) — done (write).** Both `sub ($a, $b) { … }` and `-> $a, $b {
+    … }` render as a multi-parameter `PointyBlock` in mutsu's `.AST`, so the `PointyBlock` lowering now
+    handles them: a single parameter → `Expr::Lambda` (slice 36), several → `Expr::AnonSubParams`
+    (extracting `params`/`param_defs` via `signature_positional_params`, so a default parameter composes
+    too). `EVAL(Q{my $add = sub ($a, $b) { $a + $b }; $add(3, 4)}.AST)` → `7`; a two-parameter callback
+    and a `$y = 10` default work. A zero-parameter block stays the boundary. Tests in
+    `t/rakuast-eval-anonsub.t`. Next: placeholder blocks, CATCH blocks, code-block interpolation.
 - **Phase 6 — Macros / `quasi`.** `macro`, `quasi { … }`, unquoting `{{{ … }}}`, AST
   splicing — built entirely on Phases 4+5. Most complex; may be deferred indefinitely.
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -569,16 +569,30 @@ fn lower_expr(node: &RakuAstNode) -> Result<Expr, RuntimeError> {
             is_rw: false,
             is_block: true,
         }),
-        // A pointy block `-> $x { … }` in expression position is a single-parameter
-        // closure. Multi-/zero-parameter pointy blocks stay the boundary.
-        RakuAstClass::PointyBlock => match pointy_single_param(node)? {
-            Some(param) => Ok(Expr::Lambda {
-                param,
-                body: lower_block(node)?,
-                is_whatever_code: false,
-            }),
-            None => Err(unsupported(node)),
-        },
+        // A pointy block / anonymous sub in expression position (`-> $x { … }`,
+        // `sub ($a, $b) { … }` — both render as a `PointyBlock`) is a closure. A
+        // single parameter lowers to `Expr::Lambda`; several to `AnonSubParams`. A
+        // zero-parameter block stays the boundary.
+        RakuAstClass::PointyBlock => {
+            let (params, param_defs) = signature_positional_params(node)?;
+            let body = lower_block(node)?;
+            match params.len() {
+                0 => Err(unsupported(node)),
+                1 => Ok(Expr::Lambda {
+                    param: params.into_iter().next().unwrap(),
+                    body,
+                    is_whatever_code: false,
+                }),
+                _ => Ok(Expr::AnonSubParams {
+                    params,
+                    param_defs,
+                    return_type: None,
+                    body,
+                    is_rw: false,
+                    is_whatever_code: false,
+                }),
+            }
+        }
         // `(EXPR)` -> its inner expression (parens are transparent for EVAL). The
         // node wraps a `SemiList` of `Statement::Expression`s; only the
         // single-statement form is handled.

--- a/t/rakuast-eval-anonsub.t
+++ b/t/rakuast-eval-anonsub.t
@@ -1,0 +1,33 @@
+use v6;
+use MONKEY-SEE-NO-EVAL;
+use experimental :rakuast;
+use Test;
+
+# RakuAST slice 37 (ADR-0011): multi-parameter closures (`sub ($a, $b) { … }` and
+# `-> $a, $b { … }`, which both render as a multi-parameter `PointyBlock`) lower
+# to `Expr::AnonSubParams`, extending slice 36's single-parameter case. Verified
+# against Rakudo; passes under BOTH mutsu and raku.
+#
+# Note: zero-parameter blocks stay the coverage boundary.
+
+plan 5;
+
+# --- a two-parameter anonymous sub ------------------------------------------
+is EVAL(Q{my $add = sub ($a, $b) { $a + $b }; $add(3, 4)}.AST), 7,
+    'a two-parameter anonymous sub';
+
+# --- a two-parameter pointy block -------------------------------------------
+is EVAL(Q{my $mul = -> $a, $b { $a * $b }; $mul(3, 4)}.AST), 12,
+    'a two-parameter pointy block';
+
+# --- a default parameter in an anonymous sub --------------------------------
+is EVAL(Q{my $f = sub ($x, $y = 10) { $x + $y }; $f(5)}.AST), 15,
+    'a default parameter in an anonymous sub';
+
+# --- a multi-parameter closure passed as a callback -------------------------
+is EVAL(Q{sub apply2($g) { $g(6, 7) }; apply2(-> $a, $b { $a * $b })}.AST), 42,
+    'a two-parameter closure passed as a callback';
+
+# --- the single-parameter case (slice 36) still works -----------------------
+is EVAL(Q{my $f = -> $x { $x * 2 }; $f(9)}.AST), 18,
+    'a single-parameter pointy block still lowers';


### PR DESCRIPTION
## Summary

RakuAST slice 37 (ADR-0011): multi-parameter closures.

Both `sub ($a, $b) { … }` and `-> $a, $b { … }` render as a multi-parameter `PointyBlock` in mutsu's `.AST`, so the `PointyBlock` lowering now handles them: a single parameter → `Expr::Lambda` (slice 36), several → `Expr::AnonSubParams` (extracting `params`/`param_defs` via `signature_positional_params`, so a default parameter composes too). The dead-code `Sub` arm is dropped.

```raku
use MONKEY-SEE-NO-EVAL;
EVAL(Q{my $add = sub ($a, $b) { $a + $b }; $add(3, 4)}.AST)            # 7
EVAL(Q{my $mul = -> $a, $b { $a * $b }; $mul(3, 4)}.AST)              # 12
EVAL(Q{my $f = sub ($x, $y = 10) { $x + $y }; $f(5)}.AST)            # 15
EVAL(Q{sub apply2($g) { $g(6, 7) }; apply2(-> $a, $b { $a * $b })}.AST)  # 42
```

A zero-parameter block stays the boundary.

## Tests

`t/rakuast-eval-anonsub.t` — 5 assertions (two-param anon sub, two-param pointy, default parameter, two-param callback, the single-param slice-36 case still works), **passing under BOTH mutsu and raku**. All 75 `t/rakuast-*.t` files (344 tests) still green.

Next: placeholder blocks, CATCH blocks, code-block interpolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)