### PR TITLE
fix: Cool numeric functions raise X::Str::Numeric on a non-numeric string

### DIFF
--- a/src/builtins/functions/dispatch_1arg.rs
+++ b/src/builtins/functions/dispatch_1arg.rs
@@ -90,11 +90,25 @@ pub(crate) fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Val
                 | "cotan"
                 | "narrow"
         )
-        && let Some(coerced) = crate::runtime::str_numeric::parse_raku_str_to_numeric(&s)
-        && let Some(res) =
-            crate::builtins::methods_0arg::native_method_0arg(&coerced, Symbol::intern(name))
     {
-        return Some(res);
+        match crate::runtime::str_numeric::parse_raku_str_to_numeric(&s) {
+            Some(coerced) => {
+                if let Some(res) = crate::builtins::methods_0arg::native_method_0arg(
+                    &coerced,
+                    Symbol::intern(name),
+                ) {
+                    return Some(res);
+                }
+            }
+            // A non-numeric string cannot be coerced: raise X::Str::Numeric the
+            // way `+"abc"` does, instead of falling through to a NaN/0 default
+            // (`sqrt "abc"` was NaN, `floor "abc"` was 0).
+            None => {
+                if let Err(e) = crate::runtime::utils::check_str_numeric(arg) {
+                    return Some(Err(e));
+                }
+            }
+        }
     }
     match name {
         "combinations" => {

--- a/src/runtime/utils/rat.rs
+++ b/src/runtime/utils/rat.rs
@@ -3,10 +3,12 @@ use super::*;
 /// Build an `X::Str::Numeric` error for a string that cannot be used as a
 /// number, carrying rakudo's `source`, `pos` and `reason` attributes.
 pub(crate) fn str_numeric_error(source: &str, pos: usize, reason: &str) -> RuntimeError {
-    let msg = format!(
-        "Cannot convert string to number: {} in '{}'",
-        reason, source
-    );
+    // Match Rakudo's `X::Str::Numeric.message`, which embeds the `⏏` position
+    // marker via the source-indicator (e.g. `... in '5⏏ foo' (indicated by ⏏)`),
+    // keeping this path consistent with `str_numeric_exception_attrs` (used by
+    // the `.Int`/`.Num` coercions).
+    let source_indicator = crate::runtime::str_numeric::build_source_indicator(source, pos);
+    let msg = format!("Cannot convert string to number: {reason} {source_indicator}");
     let mut attrs = std::collections::HashMap::new();
     attrs.insert("source".to_string(), Value::str(source.to_string()));
     attrs.insert("pos".to_string(), Value::int(pos as i64));
@@ -14,9 +16,7 @@ pub(crate) fn str_numeric_error(source: &str, pos: usize, reason: &str) -> Runti
     attrs.insert("target-name".to_string(), Value::str("Numeric".to_string()));
     attrs.insert(
         "source-indicator".to_string(),
-        Value::str(crate::runtime::str_numeric::build_source_indicator(
-            source, pos,
-        )),
+        Value::str(source_indicator.clone()),
     );
     attrs.insert("message".to_string(), Value::str(msg.clone()));
     let ex = Value::make_instance(crate::symbol::Symbol::intern("X::Str::Numeric"), attrs);

--- a/t/numeric-fn-string-coercion.t
+++ b/t/numeric-fn-string-coercion.t
@@ -5,7 +5,7 @@ use Test;
 # (`f("x")` == `"x".f`). Regression: sqrt/floor/ceiling/round function arms
 # matched scalar variants and fell to NaN/0 for a Str argument.
 
-plan 16;
+plan 25;
 
 # sqrt / floor / ceiling / round on integer & decimal strings
 is sqrt("4"),        2,  'sqrt "4" -> 2';
@@ -30,3 +30,25 @@ is sign("4"),   1, 'sign "4" -> 1';
 # a string function is NOT hijacked by numeric coercion
 is chars("6+8i"), 4, 'chars "6+8i" -> 4 (string length)';
 is chars("123"),  3, 'chars "123" -> 3 (string length)';
+
+# A non-numeric string cannot be coerced: a Cool numeric *function* must raise
+# X::Str::Numeric (matching `+"abc"`), NOT fall through to a NaN/0 default.
+# Regression: `sqrt "abc"` was NaN, `floor "abc"` / `sign "abc"` were 0.
+throws-like { sqrt "abc" },  X::Str::Numeric, 'sqrt "abc" throws X::Str::Numeric';
+throws-like { sin "abc" },   X::Str::Numeric, 'sin "abc" throws X::Str::Numeric';
+throws-like { floor "abc" }, X::Str::Numeric, 'floor "abc" throws X::Str::Numeric';
+throws-like { sign "abc" },  X::Str::Numeric, 'sign "abc" throws X::Str::Numeric';
+throws-like { log "abc" },   X::Str::Numeric, 'log "abc" throws X::Str::Numeric';
+throws-like { abs "xyz" },   X::Str::Numeric, 'abs "xyz" throws X::Str::Numeric';
+
+# the raised exception carries rakudo's reason/pos, and the message embeds the
+# position marker the same way the numeric operators do.
+throws-like { sqrt "abc" }, X::Str::Numeric,
+    reason => 'base-10 number must begin with valid digits or \'.\'',
+    'sqrt "abc" reports the leading-digit reason';
+throws-like { sqrt "5 foo" }, X::Str::Numeric,
+    reason => 'trailing characters after number',
+    'sqrt "5 foo" reports the trailing-characters reason';
+
+# a numeric string still works after the change (regression guard)
+is sqrt("16"), 4, 'sqrt "16" -> 4 (numeric string still coerces)';


### PR DESCRIPTION
## Summary

`sqrt "abc"`, `floor "abc"`, `sign "abc"` (and the other Cool numeric functions) returned `NaN`/`0` for a string that cannot be numified, while raku raises `X::Str::Numeric`:

```
$ raku -e 'say sqrt "abc"'
Cannot convert string to number: base-10 number must begin with valid digits or '.' in '<HERE>abc' (indicated by <HERE>)

# before (mutsu):
$ mutsu -e 'say sqrt "abc"'
NaN
```

This is one of the QA doc-diff harness findings — the function form diverged from both raku and mutsu's own method form (`"abc".sqrt` already threw).

## Root cause

The Str-coercion pre-pass in `native_function_1arg` only delegated to method dispatch when `parse_raku_str_to_numeric` **succeeded**; on failure the whole `if let ... && let Some(coerced) = ...` short-circuited and fell through to the numeric `match`, whose Str arms default to `NaN`/`0` (`sqrt` → `f64::NAN`, `floor`/`sign` → `0`). The infix operators (`+`, `-`, `==`, …) already handle this via `check_str_numeric`.

## Fix

- Handle the parse-failure branch explicitly, raising `X::Str::Numeric` through the shared `check_str_numeric` helper (the same one the numeric operators use).
- Align `str_numeric_error` (the `check_str_numeric` path) with `str_numeric_exception_attrs` (the `.Int`/`.Num` path): its message now embeds the `⏏` position marker via the source-indicator (`... in '5⏏ foo' (indicated by ⏏)`) instead of the marker-less `in '5 foo'`, so both X::Str::Numeric construction paths render identically.

## Tests

- Extended `t/numeric-fn-string-coercion.t` (16 → 25) with `throws-like … X::Str::Numeric` for `sqrt`/`sin`/`floor`/`sign`/`log`/`abs` on non-numeric strings, plus `.reason` assertions (leading-digit vs trailing-characters) and a numeric-string regression guard.
- Full `t/` prove suite: 1951 files / 18612 tests PASS.
- Whitelisted X::Str::Numeric roast tests (`S32-str/numeric.t`, `S32-exceptions/misc.t`, `S15-literals/numbers.t`, `S02-literals/radix.t`, `S03-metaops/reduce.t`, `S32-str/parse-base.t`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)