### PR TITLE
fix: a bracket-array literal over an infinite integer range stays lazy

### DIFF
--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -52,6 +52,19 @@ impl Interpreter {
                 // (Matches raku and `flat(set(...))`; `value_to_list` would
                 // otherwise decompose it into its key/True pairs.)
                 ValueView::Set(..) | ValueView::Bag(..) | ValueView::Mix(..) => elems.push(val),
+                // A single infinite *integer* range (`[1..Inf]`, `[1..*]`,
+                // `[^Inf]`, `[0..^*]`) keeps the `[...]` array lazy: build the
+                // same reify-on-demand lazy array `my @a = 1..Inf` produces, so
+                // `.is-lazy` is True and `.elems` throws `X::Cannot::Lazy`
+                // instead of materializing a MAX_RANGE_EXPAND-capped finite
+                // prefix. (n == 1 guarantees this is the whole array.)
+                _ if is_real_array
+                    && n == 1
+                    && let Some(lazy) = runtime::utils::infinite_int_range_to_lazy_array(&val) =>
+                {
+                    self.stack.push(lazy);
+                    return;
+                }
                 // In bracket-array literals (`[...]`), a single element is in
                 // list context and should flatten one level (e.g. `[2..6]`,
                 // `[@a]`, `[(1,2,3)]`), while multi-element forms keep each

--- a/t/lazy-array-elems.t
+++ b/t/lazy-array-elems.t
@@ -4,7 +4,7 @@ use Test;
 # X::Cannot::Lazy ("Cannot .elems a lazy list") rather than returning the capped
 # backing length.
 
-plan 8;
+plan 15;
 
 {
     my @a = 1..*;
@@ -26,6 +26,18 @@ plan 8;
     ok @a.is-lazy, 'still lazy';
 }
 
+# An anonymous bracket-array literal built from a single infinite integer range
+# (`[1..Inf]`, `[1..*]`, `[^Inf]`) is lazy too — like `my @a = 1..Inf` — instead
+# of being materialized to a MAX_RANGE_EXPAND-capped finite prefix.
+{
+    throws-like { [1..Inf].elems }, X::Cannot::Lazy, '[1..Inf].elems throws X::Cannot::Lazy';
+    throws-like { [1..*].elems },   X::Cannot::Lazy, '[1..*].elems throws X::Cannot::Lazy';
+    throws-like { [^Inf].elems },   X::Cannot::Lazy, '[^Inf].elems throws X::Cannot::Lazy';
+    ok [1..Inf].is-lazy, '[1..Inf] is lazy';
+    is [1..Inf][3], 4, '[1..Inf] still indexable';
+    is-deeply [1..Inf][^5], (1, 2, 3, 4, 5), '[1..Inf] slice works';
+}
+
 # finite arrays / ranges are unaffected
 {
     my @b = 1, 2, 3;
@@ -33,4 +45,6 @@ plan 8;
     is (1..10).elems, 10, 'finite range .elems works';
     my @c = 1..100;
     is @c.elems, 100, 'finite range-assigned array .elems works';
+    # a finite bracket-array literal stays eager
+    is [2..6].elems, 5, '[2..6].elems (finite bracket array) works';
 }


### PR DESCRIPTION
## Summary

`[1..Inf]`, `[1..*]`, `[^Inf]`, `[0..^*]` were materialized to a `MAX_RANGE_EXPAND`-capped finite prefix, while raku keeps them lazy:

```
# raku
[1..Inf].elems     # Cannot .elems a lazy list  (X::Cannot::Lazy)
[1..Inf].is-lazy   # True

# before (mutsu)
[1..Inf].elems     # 1000001
[1..Inf].is-lazy   # False
```

This is a QA doc-diff harness finding. Note `my @a = 1..Inf` **already** stayed lazy in mutsu (`.elems` threw); only the anonymous `[...]` literal diverged.

## Root cause

`exec_make_array_op`'s single-element flatten arm (`[...]` with one element) called `runtime::value_to_list`, which expands an infinite range up to `MAX_RANGE_EXPAND` (1_000_000), losing `ArrayKind::Lazy`.

## Fix

Reuse `infinite_int_range_to_lazy_array` — the same reify-on-demand lazy array the `my @a = 1..Inf` assignment path already builds — in the single-element arm, so `[...]` and assignment agree. Indexing/slicing/head still reify on demand:

- `[1..Inf][3]` == 4
- `[1..Inf][^5]` == (1, 2, 3, 4, 5)
- `[1..Inf].head(3)` == (1, 2, 3)
- `.WHAT` == `(Array)`, `.gist` == `[...]` — all match raku.

**Scope:** infinite *integer* ranges only, matching what the assignment path preserves lazily. Infinite non-integer sequences (`[1,2,4...Inf]`, `[-Inf...Inf]`) still materialize — a pre-existing limitation shared with `my @a = 1,2,4...Inf`, out of scope here.

## Tests

- Extended `t/lazy-array-elems.t` (8 → 15): `[1..Inf]`/`[1..*]`/`[^Inf]` `.elems` throw `X::Cannot::Lazy`, `[1..Inf].is-lazy` is True, indexing/slicing still work, and a finite `[2..6]` stays eager.
- Full `t/` prove suite: 1951 files / 18610 tests PASS.
- Related lazy/array tests (`lazy-array-numeric`, `lazy-array-gist`, `lazy-array-reify`, `nested-lazy-slice`, `eager-ops-cannot-lazy`, `flat-lazy-nested`, `slurpy-lazy-source`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)