### PR TITLE
feat: .dynamic method on Array/Hash reports variable dynamism

### DIFF
--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -323,6 +323,23 @@ pub(crate) fn native_method_0arg(
         return native_method_0arg(inner, method_sym);
     }
 
+    // `.dynamic` on a container VALUE — a literal `[1,2,3]`/`{a=>1}`, or an
+    // Array/Hash flowing as a value — is always False: only a dynamic *variable*
+    // (`@*a`/`%*h`) is dynamic, and that case is rewritten to `.VAR.dynamic` at
+    // compile time (`compile_expr_method_on_var`). Array and Hash carry a
+    // container descriptor and so define `.dynamic`; List/Int/Str/... do not
+    // (raku throws "No such method" there), so restrict this to real Array kinds
+    // (not `List`) and Hash and let everything else fall through.
+    if method == "dynamic" {
+        match target.view() {
+            ValueView::Array(_, kind) if !matches!(kind, crate::value::ArrayKind::List) => {
+                return Some(Ok(Value::FALSE));
+            }
+            ValueView::Hash(_) => return Some(Ok(Value::FALSE)),
+            _ => {}
+        }
+    }
+
     // Seq consumed/cached state checks.
     // Only handle operations that are fully dispatched here in native_method_0arg.
     // Do NOT pre-check methods that fall through to the runtime (like "iterator"),

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -70,6 +70,36 @@ impl Compiler {
             self.code.emit(OpCode::LoadConst(idx));
             return;
         }
+        // `.dynamic` on an array/hash variable reports whether the *variable* is
+        // a dynamic (`@*a`/`%*h`) one — the container's dynamism, exactly like
+        // `.VAR.dynamic` (which mutsu already resolves via `is_var_dynamic`).
+        // `$x.dynamic` operates on the contained value (Int/Str have no
+        // `.dynamic`), so only `@`/`%` — which pass the container itself to the
+        // method — are rerouted here; scalars fall to normal dispatch. A literal
+        // `[1,2,3].dynamic` (no variable) reaches the value-level `.dynamic`
+        // (native, always False), matching raku.
+        if name.resolve() == "dynamic"
+            && args.is_empty()
+            && modifier.is_none()
+            && !quoted
+            && matches!(target, Expr::ArrayVar(_) | Expr::HashVar(_))
+        {
+            let via_var = Expr::MethodCall {
+                target: Box::new(Expr::MethodCall {
+                    target: Box::new(target.clone()),
+                    name: Symbol::intern("VAR"),
+                    args: Vec::new(),
+                    modifier: None,
+                    quoted: false,
+                }),
+                name: Symbol::intern("dynamic"),
+                args: Vec::new(),
+                modifier: None,
+                quoted: false,
+            };
+            self.compile_expr(&via_var);
+            return;
+        }
         // Fast path: @arr.push(single_expr) with no modifiers → ArrayPush opcode
         // Only for local variables (not captured closures) to avoid COW env sync issues
         if name.resolve() == "push"

--- a/t/dynamic-method.t
+++ b/t/dynamic-method.t
@@ -1,0 +1,56 @@
+use Test;
+
+# `.dynamic` on an Array/Hash reports whether the underlying *variable* is a
+# dynamic one (declared with the `*` twigil: `@*a`, `%*h`). A plain `my @a` /
+# `my %h` is not dynamic, and a literal `[...]`/`{...}` is never dynamic.
+# `@`/`%` pass the container itself to the method, so `.dynamic` works directly
+# (unlike `$x`, where you need `$x.VAR.dynamic`). List/Int/Str have no
+# `.dynamic` at all.
+
+plan 13;
+
+# Array variables
+{
+    my @a;
+    is @a.dynamic, False, 'my @a is not dynamic';
+    my @*d;
+    is @*d.dynamic, True, 'my @*d is dynamic';
+}
+
+# Hash variables
+{
+    my %h;
+    is %h.dynamic, False, 'my %h is not dynamic';
+    my %*d;
+    is %*d.dynamic, True, 'my %*d is dynamic';
+}
+
+# Literals are never dynamic
+is [1, 2, 3].dynamic, False, '[1,2,3].dynamic is False';
+is { a => 1 }.dynamic, False, '{a=>1}.dynamic is False';
+
+# A dynamic variable is visible (and still dynamic) from an inner scope
+{
+    my @*dyn = 1, 2, 3;
+    sub reads-dyn { @*dyn.dynamic }
+    is reads-dyn(), True, 'dynamic array seen from inner sub is still dynamic';
+}
+
+# A routine parameter array is not dynamic
+{
+    sub takes(@x) { @x.dynamic }
+    is takes([1, 2, 3]), False, 'parameter array is not dynamic';
+}
+
+# `.dynamic` usable in boolean / expression context
+{
+    my @*x;
+    is (@*x.dynamic ?? 'dyn' !! 'not'), 'dyn', '.dynamic in ternary';
+    my @y;
+    is (@y.dynamic ?? 'dyn' !! 'not'), 'not', 'non-dynamic in ternary';
+}
+
+# List / Int / Str do NOT have `.dynamic`
+throws-like { (1, 2, 3).dynamic }, X::Method::NotFound, 'List has no .dynamic';
+throws-like { (42).dynamic },      X::Method::NotFound, 'Int has no .dynamic';
+throws-like { "foo".dynamic },     X::Method::NotFound, 'Str has no .dynamic';


### PR DESCRIPTION
## Summary

`.dynamic` on an Array/Hash threw "No such method" in mutsu; raku defines it on the container to report whether the underlying variable is a dynamic (`*`-twigil) one:

```
my @a;   say @a.dynamic;     # raku: False   mutsu (before): No such method
my @*a;  say @*a.dynamic;    # raku: True    mutsu (before): No such method
say [1,2,3].dynamic;         # raku: False
say {a=>1}.dynamic;          # raku: False
```

This is a QA doc-diff harness finding.

## Why `@`/`%` differ from `$`

`@`/`%` pass the container itself to a method, so `.dynamic` works directly. A scalar `$x` derefs to its value, so raku (and mutsu) require `$x.VAR.dynamic` — `$*x.dynamic` is "No such method" on the contained Int. mutsu already resolved `@*a.VAR.dynamic` correctly via `is_var_dynamic`; this PR just wires the direct form to it.

## Implementation

- **Compiler** (`compile_expr_method_on_var`): `@var.dynamic` / `%var.dynamic` (no args, no modifier) is rewritten to `@var.VAR.dynamic`, reusing the existing container-dynamism metadata — so `@*a.dynamic` is True, `my @a` is False, a routine parameter array is False.
- **Value path** (`native_method_0arg`): a container VALUE — a literal `[...]`/`{...}`, or an Array/Hash flowing as a value — answers `.dynamic` = False. Restricted to real Array kinds (not `List`) and Hash, so `(1,2,3).dynamic`, `(1).dynamic`, `"x".dynamic` still raise `X::Method::NotFound` exactly like raku.

## Tests

- New `t/dynamic-method.t` (13 tests): array/hash variables (plain vs `*`-twigil), literals, dynamic var seen from an inner sub, parameter array, ternary context, and the List/Int/Str `X::Method::NotFound` cases.
- Full `t/` prove suite: 1952 files / 18616 tests PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)