### PR TITLE
chore: remove stray tmp-lock-test artifact and gitignore its pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ wip.txt
 handle-between-threads-*
 proc-async-*
 _tmp-io-colon-invocant-*
+tmp-lock-test-*.txt
 
 target-local/
 .claude/worktrees/


### PR DESCRIPTION
## Summary

`tmp-lock-test-1519563.txt` (an empty file) was accidentally committed in #4811. `t/io-handle-lock.t` writes `tmp-lock-test-{$*PID}.txt` and unlinks it in a `LEAVE` block, but an interrupted/killed test run left one behind, and a `git add -A` during that PR picked it up.

- Remove the stray file.
- Add `tmp-lock-test-*.txt` to `.gitignore` so a leftover artifact can never be committed again.

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)