### PR TITLE
chore(deps): bump Rust MSRV to 1.94 and cranelift to 0.133

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@1.93.0
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           targets: wasm32-unknown-unknown
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@1.93.0
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -25,7 +25,7 @@ jobs:
 
       # tagpr bumps the version in Cargo.toml; keep Cargo.lock's `mutsu` entry in
       # sync so the release PR (and merged main) carries a coherent lockfile.
-      - uses: dtolnay/rust-toolchain@45f5412a0cc5dee553bb061a37369fc8e63fa137 # 1.93.0
+      - uses: dtolnay/rust-toolchain@191af2e1955bbe165f9bbacff2d2438002dff4d4 # 1.96.0
 
       - uses: Songmu/tagpr@e84001bd5dac8defa0c75b3913937d284a3b3660 # v1.20.0
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,27 +125,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.132.3"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d521bdbc6098937af83ef4ab6d5c07398126bc71878f7ef4ea9499977978ef5"
+checksum = "e06aeba2c965fc446d13c56a6ccb2631b78445d7544543dd9a25289977630914"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.132.3"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dde0b83164d4a497860af4236271178bc640512b067101e0853e4f74eaa4df5"
+checksum = "ee2d2dde4ec1352715595b5cfa6fe2e5b8ebb9da3457b3ee8db0aa2808c069aa"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.132.3"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0111d110b72b4efad69a372e29e21628652fd0bcab66967e5c8350ab679affd5"
+checksum = "03b4982ef9fa54ec9eee841e891e7ddc5434be1250e88de31572e000c888f30b"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -153,18 +153,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.132.3"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf01ecc92fc5499789d79c3b817299d5a8ddd828d31dcf0f9cc3cc66f38dbb36"
+checksum = "529143118c4eeb58c39ecb02319557d512be6c61348486422974ab8e3906b8a8"
 dependencies = [
  "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.132.3"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cd2563bead0090c3879a7ff7327f7550c9d59bb5d05ecc8cd7886977aa3125a"
+checksum = "b7780677247ad3577e3a6a3ebf43f39b325a11d6393db72b2c9968a910d4d13d"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.132.3"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9640d250d26f9381a73dc7f9862b27928d4809119aec73be0e556612e67b6a99"
+checksum = "ac9645250416cbf92454fe61160e17e026e0ce405906a54500b114f923ddffc9"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -201,24 +201,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.132.3"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07f156b90efc94371ddb3536f76e4ab671ad2e093bfa5511e10198cadbb0c47"
+checksum = "20ee8d222ff0fd3681791979afbf88586ac9f49010d3db96b3cbe4c96759aee3"
 
 [[package]]
 name = "cranelift-control"
-version = "0.132.3"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a76fd9dd37dcbc3d2d2e00abe3281a7e88adc035fba3b8114cc69981576ec"
+checksum = "591abe6f5312bd2c4220f1b3bead56c2ad00257c52668015ba013b85dcf2a17a"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.132.3"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eea22522144ba08c7e7ef94bfc25d474ef016c2771974b8ab1986734ac85965"
+checksum = "a5300c49cf940526fe771517b3b3eabd5d0ff164ee61698579cf403fe8d3af3c"
 dependencies = [
  "cranelift-bitset",
  "wasmtime-internal-core",
@@ -226,11 +226,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.132.3"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa2826c80dff1d93b19b3cfbcaf9fae44c78d739a98d146dd5bd89c51e14367"
+checksum = "da4adbf760207fdbbe130f1191cce01cdef66831a9f648b1f39ff2800d126d45"
 dependencies = [
  "cranelift-codegen",
+ "hashbrown 0.17.1",
  "log",
  "smallvec",
  "target-lexicon",
@@ -238,15 +239,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.132.3"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e238a69b95c5415456f22189494a12db94f313bb72b6ec9cc88ddf2f1056e28e"
+checksum = "8315b21ff018226a42a60a4702c2dd75f6447cac26e9bca622e14c22088c2ff5"
 
 [[package]]
 name = "cranelift-jit"
-version = "0.132.3"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7def01f2b14f97421558d1db33e396b97b97ab2ed40dedc8165ba00d13088e6"
+checksum = "acac8da2c71d03c39756866a4bbf31f43d912f054cf9cbbaacc33bf80360366a"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -265,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.132.3"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985df7eceefc91cb75bf7f51b32b7f1739d0fc0e25ddf023b1de407cb3c93d77"
+checksum = "dcbbdbe0c3c6cd97359ac2f6744187e89a48e202674e24200afc653f6aa9b7c2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -276,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.132.3"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eceb0ebd8d6aef6bb287e8d532a164b0db1c0062961211e9c22a91f67521c098"
+checksum = "d506ef23a60715bde451b06620b14402166ded3b648454fccbf04f3e46a4aa70"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -287,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.132.3"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004643f39a7bec553de5263d650db30e5b9caec1d5cbe065fd732b7ec9ae40d0"
+checksum = "48ed47e602652e3410f9387fc0db70fefadcee4d78a78881421aabcab4e26b89"
 
 [[package]]
 name = "displaydoc"
@@ -1264,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "45.0.3"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3073c03f97f871fe6400e68621c863b93ba79296f8e570285231952d23fcc804"
+checksum = "3fc28372e36eaf8cf70faa83b5779137f7e99c8d18569a125d1580e735cc9e4d"
 dependencies = [
  "hashbrown 0.17.1",
  "libm",
@@ -1274,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "45.0.3"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37dee05e8c35759826f6b926cd949c51f771b6a58619d8e60c63c3f3d3e5e59b"
+checksum = "eba651d44ab0faad4c58106b3adb45068189fb65ef50f0c404b6d9e3bf81a357"
 dependencies = [
  "cfg-if",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mutsu"
 version = "0.10.0"
 edition = "2024"
-rust-version = "1.93.0"
+rust-version = "1.94.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -48,11 +48,11 @@ icu_collator = "2.1"
 icu_collator_data = "2.1"
 libloading = { version = "0.9", optional = true }
 libffi = { version = "5", optional = true }
-cranelift-codegen = { version = "0.132", optional = true }
-cranelift-frontend = { version = "0.132", optional = true }
-cranelift-jit = { version = "0.132", optional = true }
-cranelift-module = { version = "0.132", optional = true }
-cranelift-native = { version = "0.132", optional = true }
+cranelift-codegen = { version = "0.133", optional = true }
+cranelift-frontend = { version = "0.133", optional = true }
+cranelift-jit = { version = "0.133", optional = true }
+cranelift-module = { version = "0.133", optional = true }
+cranelift-native = { version = "0.133", optional = true }
 
 [profile.release]
 debug = true

--- a/src/vm/vm_jit_tier_b.rs
+++ b/src/vm/vm_jit_tier_b.rs
@@ -19,7 +19,7 @@
 use super::vm_jit_layout::JitLayout;
 use crate::value::jit_words as w;
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
-use cranelift_codegen::ir::{InstBuilder, MemFlags, SigRef, Type, types};
+use cranelift_codegen::ir::{InstBuilder, MemFlagsData, SigRef, Type, types};
 use cranelift_frontend::FunctionBuilder;
 
 type CVal = cranelift_codegen::ir::Value;
@@ -65,8 +65,8 @@ pub(super) struct TierB {
 
 impl TierB {
     #[inline]
-    pub(super) fn mf() -> MemFlags {
-        MemFlags::trusted()
+    pub(super) fn mf() -> MemFlagsData {
+        MemFlagsData::trusted()
     }
 
     pub(super) fn stack_ptr(&self, b: &mut FunctionBuilder) -> CVal {
@@ -157,13 +157,13 @@ impl TierB {
     /// Decode an encoded Num word to an f64 SSA value.
     fn decode_num(&self, b: &mut FunctionBuilder, word: CVal) -> CVal {
         let bits = b.ins().iadd_imm(word, -(w::DOUBLE_OFFSET as i64));
-        b.ins().bitcast(types::F64, MemFlags::new(), bits)
+        b.ins().bitcast(types::F64, MemFlagsData::new(), bits)
     }
 
     /// Encode an f64 SSA value to a Num word (NaN collapsed to the canonical
     /// quiet-NaN word, exactly like `Value::num`).
     fn encode_num(&self, b: &mut FunctionBuilder, f: CVal) -> CVal {
-        let bits = b.ins().bitcast(types::I64, MemFlags::new(), f);
+        let bits = b.ins().bitcast(types::I64, MemFlagsData::new(), f);
         let word = b.ins().iadd_imm(bits, w::DOUBLE_OFFSET as i64);
         let not_nan = b.ins().fcmp(FloatCC::Equal, f, f);
         let nan_word = b.ins().iconst(types::I64, w::NUM_CANONICAL_NAN_WORD as i64);


### PR DESCRIPTION
Pairs the Rust toolchain bump with cranelift 0.133 (deferred from #4810, which noted cranelift 0.133 requires Rust 1.94).

## Changes
- **`Cargo.toml`**: `rust-version` 1.93.0 → **1.94.0** (the true floor, set by cranelift 0.133).
- **CI toolchain pins**: `release.yml` / `pages.yml` / `tagpr.yml` were pinned to 1.93.0 → bump to **1.96.0** so every builder matches `ci.yml` / `bench.yml` (the toolchain CI already validates). `tagpr.yml` is SHA-pinned: `191af2e1955bbe165f9bbacff2d2438002dff4d4` = the `1.96.0` tag.
- **cranelift-{codegen,frontend,jit,module,native}** 0.132 → **0.133**.

## cranelift 0.133 MemFlags rework
cranelift 0.133 turned `MemFlags` into an interned `u16` index; the old flag-value type is now **`MemFlagsData`** (which carries `trusted()`/`new()` and is what `InstBuilder::{load,store,bitcast}` accept via `Into<MemFlags>` — exactly how cranelift-frontend's own code passes it). Migrated the Tier-B JIT `mf()` helper and the two `bitcast` sites in `src/vm/vm_jit_tier_b.rs`.

## Verification
`cargo build` + `cargo clippy -- -D warnings` clean. `make test` (unit + `t/`) green. `MUTSU_JIT=on` numeric-loop smoke test — both the integer accumulator and the f64 (`bitcast`) path — produce correct results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)