### PR TITLE
chore(deps): migrate bincode 1 → 2 (serde API)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,11 +37,22 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
+ "bincode_derive",
  "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -670,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",
@@ -1194,6 +1205,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1227,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ console_error_panic_hook = { version = "0.1", optional = true }
 rustc-hash = "2.1.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-bincode = "1"
+bincode = { version = "2", features = ["serde"] }
 icu_collator = "2.1"
 icu_collator_data = "2.1"
 libloading = { version = "0.9", optional = true }

--- a/src/precomp.rs
+++ b/src/precomp.rs
@@ -34,8 +34,10 @@ use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-/// Magic bytes for the cache format.
-const CACHE_MAGIC: &[u8; 4] = b"MTSU";
+/// Magic bytes for the cache format. Bump the trailing byte whenever the
+/// on-disk encoding changes so stale caches are cleanly rejected by the magic
+/// check rather than mis-decoded. `MTS2` marks the bincode 2 (varint) encoding.
+const CACHE_MAGIC: &[u8; 4] = b"MTS2";
 
 /// The interpreter version stamp embedded in cache files.
 /// Cache is invalidated whenever this changes.
@@ -140,7 +142,8 @@ pub(crate) fn load_cached_ast(source_path: &Path) -> Option<Vec<Stmt>> {
         return None;
     }
 
-    let meta: CacheMetadata = bincode::deserialize(&rest[..meta_len]).ok()?;
+    let (meta, _): (CacheMetadata, usize) =
+        bincode::serde::decode_from_slice(&rest[..meta_len], bincode::config::standard()).ok()?;
     let ast_data = &rest[meta_len..];
 
     // Validate version
@@ -174,7 +177,9 @@ pub(crate) fn load_cached_ast(source_path: &Path) -> Option<Vec<Stmt>> {
     // But we already wrote the format above without format_version. Let me just embed
     // format_version in the metadata for simplicity.
 
-    bincode::deserialize(ast_data).ok()
+    bincode::serde::decode_from_slice(ast_data, bincode::config::standard())
+        .ok()
+        .map(|(stmts, _)| stmts)
 }
 
 /// Save a parsed AST to the cache for the given source file.
@@ -200,10 +205,10 @@ pub(crate) fn save_cached_ast(source_path: &Path, stmts: &[Stmt]) {
         version: interpreter_version(),
     };
 
-    let Ok(meta_bytes) = bincode::serialize(&meta) else {
+    let Ok(meta_bytes) = bincode::serde::encode_to_vec(&meta, bincode::config::standard()) else {
         return;
     };
-    let Ok(ast_bytes) = bincode::serialize(stmts) else {
+    let Ok(ast_bytes) = bincode::serde::encode_to_vec(stmts, bincode::config::standard()) else {
         return;
     };
 
@@ -354,8 +359,8 @@ mod tests {
             source_hash: source_content_hash(&source),
             version: "0.0.0+cf0+exe0".to_string(),
         };
-        let meta_bytes = bincode::serialize(&meta).unwrap();
-        let ast_bytes = bincode::serialize(&stmts).unwrap();
+        let meta_bytes = bincode::serde::encode_to_vec(&meta, bincode::config::standard()).unwrap();
+        let ast_bytes = bincode::serde::encode_to_vec(&stmts, bincode::config::standard()).unwrap();
         let mut data = Vec::new();
         data.extend_from_slice(CACHE_MAGIC);
         data.extend_from_slice(&(meta_bytes.len() as u32).to_le_bytes());


### PR DESCRIPTION
Moves the precomp AST cache off bincode 1.

## Why bincode 2 (not 3)
bincode 3.0.0 on crates.io ships with **no features** (no `serde`/`derive`/`std`) and is not the serde-based line. **bincode 2.0.1** is the maintained major with the documented serde migration path, so it's the correct target.

## Changes (`src/precomp.rs`)
bincode 2.0 removed the top-level `serialize`/`deserialize` free functions in favor of `Encode`/`Decode`, with serde-compatible helpers behind the `serde` feature:
- `bincode::serialize(&v)` → `bincode::serde::encode_to_vec(&v, bincode::config::standard())`
- `bincode::deserialize(&b)` → `bincode::serde::decode_from_slice(&b, bincode::config::standard())` (returns a `(T, usize)` tuple; the byte count is dropped)

The on-disk encoding changes (bincode 2 defaults to varint), so the cache magic is bumped **`MTSU` → `MTS2`** — stale caches are cleanly rejected by the magic check instead of risking a mis-decode.

## Verification
`cargo build` + `cargo clippy -- -D warnings` clean. precomp unit tests (round-trip + stale-version rejection) and `make test` green. **End-to-end**: a module load writes an `MTS2` cache and a second run reads it back correctly.

> Note: branch is named `bincode-v3` but the migration targets bincode **2** (3.0.0 is featureless, see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)