### PR TITLE
fix: keep .round($scale) exact for integer and rational operands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/builtins/arith.rs
+++ b/src/builtins/arith.rs
@@ -18,5 +18,5 @@ pub(crate) use mul_div_mod::{arith_div, arith_mod, arith_mul};
 pub(crate) use pow_negate::{arith_negate, arith_pow};
 
 // Helpers used by external callers (vm/, runtime/).
-pub(crate) use rat::real_to_rat;
+pub(crate) use rat::{exact_round_scaled, real_to_rat};
 pub(crate) use temporal::{is_temporal_operand, make_duration_value};

--- a/src/builtins/arith/rat.rs
+++ b/src/builtins/arith/rat.rs
@@ -211,3 +211,65 @@ pub(crate) fn real_to_rat(v: &Value) -> Value {
         }
     }
 }
+
+/// Extract exact `(numerator, denominator)` i128 parts of a Real value, or `None`
+/// when the value is inexact (Num/Complex) or too large to fit i128. Used to keep
+/// `.round($scale)` exact when both operands are integers/rationals.
+fn exact_rat_parts_i128(v: &ValueView<'_>) -> Option<(i128, i128)> {
+    match v {
+        ValueView::Int(i) => Some((*i as i128, 1)),
+        ValueView::BigInt(bi) => bi.to_i128().map(|n| (n, 1)),
+        ValueView::Rat(n, d) | ValueView::FatRat(n, d) if *d != 0 => Some((*n as i128, *d as i128)),
+        ValueView::BigRat(n, d) => {
+            let (n, d) = (n.to_i128()?, d.to_i128()?);
+            (d != 0).then_some((n, d))
+        }
+        _ => None,
+    }
+}
+
+/// Whether a Real value is an integer type (so `.round($scale)` yields an Int
+/// rather than a Rat).
+fn is_integer_scale(v: &ValueView<'_>) -> bool {
+    matches!(v, ValueView::Int(_) | ValueView::BigInt(_))
+}
+
+fn value_from_i128(n: i128) -> Value {
+    match i64::try_from(n) {
+        Ok(i) => Value::int(i),
+        Err(_) => Value::bigint(NumBigInt::from(n)),
+    }
+}
+
+/// Exact `(self / $scale + 1/2).floor * $scale` per Rakudo's `Real.round(Real)`,
+/// staying in exact Int/Rat arithmetic. Returns `None` when either operand is
+/// inexact (Num/Complex), the scale is zero, or i128 overflow would occur — the
+/// caller then falls back to the f64 path.
+pub(crate) fn exact_round_scaled(target: &Value, scale: &Value) -> Option<Value> {
+    let (tn, td) = exact_rat_parts_i128(&target.view())?;
+    let (sn, sd) = exact_rat_parts_i128(&scale.view())?;
+    if sn == 0 {
+        return None;
+    }
+    // r = self/scale + 1/2 = (2*tn*sd + td*sn) / (2*td*sn)
+    let num = tn
+        .checked_mul(sd)?
+        .checked_mul(2)?
+        .checked_add(td.checked_mul(sn)?)?;
+    let mut den = td.checked_mul(sn)?.checked_mul(2)?;
+    let mut num = num;
+    if den < 0 {
+        num = num.checked_neg()?;
+        den = den.checked_neg()?;
+    }
+    // floor(num/den) with den > 0
+    let floor_q = num.div_euclid(den);
+    // result = floor_q * scale = floor_q * sn / sd
+    let rn = floor_q.checked_mul(sn)?;
+    if is_integer_scale(&scale.view()) {
+        // sd == 1 for an integer scale, so the result is an exact integer.
+        Some(value_from_i128(rn.checked_div(sd)?))
+    } else {
+        Some(rat_from_i128_or_num(rn, sd))
+    }
+}

--- a/src/builtins/functions/dispatch_2arg.rs
+++ b/src/builtins/functions/dispatch_2arg.rs
@@ -324,6 +324,11 @@ pub(crate) fn native_function_2arg(
             Some(Ok(Value::complex(result_r, result_i)))
         }
         "round" => {
+            // Keep integer/rational rounding exact (e.g. `round(1000, 23.01)`
+            // == 989.43, not 989.4300000000001).
+            if let Some(exact) = crate::builtins::arith::exact_round_scaled(arg1, arg2) {
+                return Some(Ok(exact));
+            }
             let x = runtime::to_float_value(arg1)?;
             let scale = runtime::to_float_value(arg2)?;
             // Raku-style rounding: (x + 0.5).floor()

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -1113,6 +1113,20 @@ pub(crate) fn native_method_1arg(
             } else {
                 arg
             };
+            // Unwrap target allomorphic types for the exact fast path.
+            let exact_target = if let ValueView::Mixin(inner, _) = target.view() {
+                inner.as_ref()
+            } else {
+                target
+            };
+            // Keep integer/rational rounding exact (Rakudo's Real.round(Real)):
+            // avoids f64 precision loss for large Ints and Rat scales such as
+            // `round(1000, 23.01)` (== 989.43, not 989.4300000000001).
+            if let Some(exact) =
+                crate::builtins::arith::exact_round_scaled(exact_target, unwrapped_arg)
+            {
+                return Some(Ok(exact));
+            }
             // Determine the scale type category for return type selection
             // Int/IntStr -> Int, Num/NumStr/Complex/ComplexStr -> Num,
             // Rat/RatStr -> Rat

--- a/t/round-exact-scale.t
+++ b/t/round-exact-scale.t
@@ -1,0 +1,42 @@
+use v6;
+use Test;
+
+# `.round($scale)` / `round($x, $scale)` must stay exact for integer and
+# rational operands, matching Rakudo's `Real.round(Real)` semantics
+# `(self / $scale + 1/2).floor * $scale`, rather than routing through f64.
+
+plan 18;
+
+# Rat scale keeps the result an exact Rat (not 989.4300000000001).
+is round(1000, 23.01), 989.43,           'round(Int, Rat) is exact';
+is round(1000, 23.01).WHAT.^name, 'Rat', 'Rat scale yields a Rat';
+is 1.07.round(0.1), 1.1,                  'Rat target, Rat scale is exact';
+
+# Large Int must not lose precision through f64 (2^53 boundary).
+is 9930972392403501.round(1), 9930972392403501, 'large Int round(1) stays exact';
+is 9930972392403501.round(1).WHAT.^name, 'Int', 'Int scale yields an Int';
+
+# Integer-scale rounding.
+is 21.round(10), 20,      'round down to nearest 10';
+is 255.round(10), 260,   'round up to nearest 10';
+is (-21).round(10), -20, 'negative round to nearest 10';
+is 21.round(10).WHAT.^name, 'Int', 'integer scale yields Int';
+
+# Default scale (1).
+is 1.7.round, 2,     'round half up (positive)';
+is 2.5.round, 3,     'round .5 up';
+is (-2.5).round, -2, 'round -.5 toward +Inf';
+
+# Rat scale that lands on an integer value is still a Rat in Rakudo.
+is 10.round(2.5), 10,             '10.round(2.5) == 10';
+is 10.round(2.5).WHAT.^name, 'Rat', 'Rat scale keeps Rat even when integral';
+
+# Num scale falls back to the float path (matches Rakudo's Num result).
+is 9930972392403501.round(1e0).Int, 9930972392403500, 'Num scale uses float path';
+
+# Allomorph operands unwrap correctly.
+is <1000>.round(<10>), 1000, 'IntStr target and scale round exactly';
+
+# Function form matches the method form.
+is round(21, 10), 20,        'round() function form, integer scale';
+is round(1.07, 0.1), 1.1,    'round() function form, Rat scale';


### PR DESCRIPTION
## Problem

Surfaced by the QA doc-diff harness (PLAN.md §8) against `Type/Cool.rakudoc`. Rakudo's `Real.round(Real)` is defined as `(self / $scale + 1/2).floor * $scale` and stays in **exact** arithmetic for integer/rational operands. mutsu routed every `.round($scale)` / `round($x, $scale)` through `f64`, so:

- **large Ints lost precision past 2^53**: `9930972392403501.round(1)` → `9930972392403500` (should be exact `9930972392403501`);
- **Rat scales produced float noise**: `round(1000, 23.01)` → `989.4300000000001` (should be exact `989.43`).

## Fix

Add `arith::exact_round_scaled`, which computes the Rakudo formula in exact i128 rational arithmetic. It returns `None` (falling back to the existing f64 path) only when an operand is inexact (`Num`/`Complex`), the scale is zero, or i128 would overflow. Wired into both the method form (`methods_narg/dispatch_1arg`) and the function form (`functions/dispatch_2arg`).

Integer scales yield an `Int`, Rat scales a `Rat` — matching raku's result types. Both `Type/Cool.rakudoc` doc examples now match raku exactly.

## Tests

New pin `t/round-exact-scale.t` (18 cases: exactness, result types, negatives, allomorphs, Num-scale float fallback, function form). Whitelisted `roast/S32-num/{rounders,rat,real-bridge,complex,cool-num}.t` all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)