### PR TITLE
perf: BlockLocalScope drops whole-locals clone for targeted Nil-reset (lexical-slot endgame slice 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -207,14 +207,21 @@ impl Interpreter {
         // Snapshot the env keys present before the branch runs so that on exit
         // we can tell a *fresh* block-local `my` (no outer binding of that name)
         // apart from one that merely *shadows* an existing outer binding (which
-        // `pop_loop_local_scope` already restores). Snapshot the slots too so a
-        // removed fresh declaration's frame slot can be reset to its pre-branch
-        // value. Both are cheap relative to a full `BlockScope` env restore and
-        // are only paid when the branch actually declares a block-local.
-        // The env is Symbol-keyed, so the snapshot is a set of `Copy` u32s — no
-        // per-key String allocation.
+        // `pop_loop_local_scope` already restores). Cheap relative to a full
+        // `BlockScope` env restore and only paid when the branch declares a
+        // block-local. The env is Symbol-keyed, so the snapshot is a set of
+        // `Copy` u32s — no per-key String allocation.
+        //
+        // We do NOT snapshot the whole `locals` vec: a fresh (non-shadow) block
+        // declaration gets its own shadow slot, and that slot's pre-branch value
+        // is provably `Nil` (`locals` is initialised to `Value::NIL` and nothing
+        // but this declaration ever writes its unique slot — so the reset below
+        // that Nils it on exit keeps the pre-branch value Nil by induction across
+        // repeated runs / loop iterations). Resetting to `Nil` is therefore
+        // identical to restoring a snapshotted pre-branch value, at O(declared)
+        // instead of an O(locals) clone. This is the lexical-slot endgame's
+        // targeted-reset technique (docs/lexical-scope-slot-campaign.md §1.3).
         let env_had_before: crate::runtime::NameSet = self.env().keys().copied().collect();
-        let saved_locals = self.locals.clone();
         self.push_loop_local_scope();
         // Track `my` declarations made directly in this branch.
         self.block_declared_vars
@@ -238,7 +245,9 @@ impl Interpreter {
             self.env_mut().remove_sym(*sym);
             for idx in 0..code.locals.len().min(self.locals.len()) {
                 if code.local_sym(idx) == Some(*sym) {
-                    self.locals[idx] = saved_locals.get(idx).cloned().unwrap_or(Value::NIL);
+                    // Fresh declaration's slot is unique to it; its pre-branch
+                    // value is Nil (see the entry comment), so reset to Nil.
+                    self.locals[idx] = Value::NIL;
                 }
             }
         }


### PR DESCRIPTION
First landable slice of the **lexical-slot endgame** (ANALYSIS.md §1.3 roadmap #1; `docs/lexical-scope-slot-campaign.md`).

## What
`exec_block_local_scope_op` (the `BlockLocalScope` opcode — `if`/`unless`/`else` branch bodies that declare a block-local `my`) cloned the **entire `locals` vec** on entry (`self.locals.clone()`) solely to restore a handful of fresh block-local slots on exit. This replaces that with a **targeted Nil-reset**.

## Why it's sound
Under shadow slots (default ON since 2026-07-12), each fresh (non-shadow) `my` declaration owns a **unique** slot. That slot's pre-branch value is provably `Nil`:
- `locals` is initialised to `Value::NIL`;
- nothing but the declaration itself ever writes its unique slot;
- the exit reset Nils it, so across repeated runs / loop iterations the pre-branch value stays `Nil` by induction (base case: initial `Nil`).

So restoring a snapshotted pre-branch value is **identical** to resetting to `Nil`, at O(declared) instead of an O(locals) clone. Shadowed (non-fresh) declarations are unaffected — they are restored by `pop_loop_local_scope`, which uses its own `loop_local_saved_env`, not this clone.

This also establishes the targeted-reset technique that the much larger `BlockScope` clone removal (slice 3) will reuse.

## Validation
- `make test`: **18637 tests PASS**, no regressions (the `t/die-on-fail.t` "Failed test" lines are that test's intentional failure-output checks; it passes standalone).
- Targeted: `t/block-lexical-scope.t`, `t/dualstore-slot-local-gate.t`, `t/phasers.t` all PASS.
- Inline sanity: `my $x=99; if True { my $x=5; say $x }; say $x` → `5` then `99`; loop-nested branch-locals correct.
- clippy `-D warnings` clean, `cargo fmt` applied.

## Follow-up slices (tracked)
2. `$OUTER::` resolves to the outer live slot (the shadow-slot path already exists in `get_outer_var` but is dormant), dropping the `outer_scope_locals` clone.
3. `BlockScope` whole-locals clone → targeted Nil-reset (the headline cost).
4. Drop the `needs_env_sync` blanket → the fib env-COW perf payoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)