### PR TITLE
fix: non-numeric Str.Complex / Str.FatRat yield an X::Str::Numeric Failure

### DIFF
--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -155,13 +155,19 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 )))
             }
             // `"1+2i".Complex` parses the numeric string (raku: <1+2i>), not 0+0i.
+            // A non-numeric string yields the same lazy `X::Str::Numeric` Failure
+            // that `.Int`/`.Num` produce (`"foo".Complex.^name` is `Failure`).
             ValueView::Str(s) => {
                 match crate::runtime::str_numeric::parse_raku_str_to_numeric(s.trim()) {
                     Some(v) => match v.view() {
                         ValueView::Complex(..) => Some(Ok(v)),
                         _ => Some(Ok(Value::complex(v.to_f64(), 0.0))),
                     },
-                    None => Some(Ok(Value::complex(0.0, 0.0))),
+                    None => Some(Ok(
+                        crate::builtins::methods_0arg::dispatch_core_coerce::str_numeric_failure(
+                            s.as_str(),
+                        ),
+                    )),
                 }
             }
             _ => Some(Ok(Value::complex(0.0, 0.0))),

--- a/src/builtins/methods_0arg/dispatch_core_math.rs
+++ b/src/builtins/methods_0arg/dispatch_core_math.rs
@@ -480,6 +480,15 @@ pub(super) fn dispatch(
                     }
                 }
             }
+            // A non-numeric string yields the same lazy `X::Str::Numeric` Failure
+            // `.Int`/`.Num` produce (`"foo".FatRat.^name` is `Failure`).
+            ValueView::Str(s)
+                if crate::runtime::str_numeric::parse_raku_str_to_numeric(s.trim()).is_none() =>
+            {
+                Some(Ok(
+                    crate::builtins::methods_0arg::dispatch_core_coerce::str_numeric_failure(&s),
+                ))
+            }
             ValueView::Str(s) => {
                 let rat = str_to_rat(&s);
                 match rat.view() {

--- a/t/coerce-nonnumeric-str-failure.t
+++ b/t/coerce-nonnumeric-str-failure.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+# Coercing a non-numeric string to Complex or FatRat must produce the same lazy
+# X::Str::Numeric Failure that `.Int`/`.Num` already do — not a bogus 0 value.
+# (raku-doc/doc/Type/Cool.rakudoc examples for `.Complex` and `.FatRat`.)
+
+plan 14;
+
+# The soft Failure surfaces as `Failure` from `.^name` (not thrown until used).
+is "foo".Complex.^name, 'Failure', 'non-numeric Str.Complex is a Failure';
+is "foo".FatRat.^name,  'Failure', 'non-numeric Str.FatRat is a Failure';
+is "12abc".Complex.^name, 'Failure', 'trailing-garbage Str.Complex is a Failure';
+is "12abc".FatRat.^name, 'Failure', 'trailing-garbage Str.FatRat is a Failure';
+# An empty string coerces to 0 (raku parity), not a Failure.
+is "".Complex, <0+0i>, 'empty Str.Complex is 0+0i';
+is "".FatRat, 0,       'empty Str.FatRat is 0';
+
+# Sinking / using the Failure throws X::Str::Numeric.
+throws-like { "foo".Complex.Str }, X::Str::Numeric, 'using the Complex Failure throws';
+throws-like { "foo".FatRat.Str }, X::Str::Numeric, 'using the FatRat Failure throws';
+
+# Genuine numeric strings still coerce correctly.
+is "1+2i".Complex, <1+2i>,   'numeric string still coerces to Complex';
+is <1.3>.Complex, 1.3+0i,    'RatStr coerces to Complex';
+is "3/4".FatRat, 0.75,       'fraction string coerces to FatRat';
+is "1.3".FatRat, 1.3,        'decimal string coerces to FatRat';
+is "1e2".FatRat, 100,        'exponent string coerces to FatRat';
+is "1.3".FatRat.^name, 'FatRat', 'FatRat coercion result type is FatRat';


### PR DESCRIPTION
## Problem

Surfaced by the QA doc-diff harness (PLAN.md §8) against `Type/Cool.rakudoc`. `.Int`/`.Num` already return a lazy `X::Str::Numeric` `Failure` when coercing a non-numeric string, but `.Complex` and `.FatRat` fabricated a bogus `0` value instead:

- `"foo".Complex.^name` was `Complex` (raku: `Failure`)
- `"foo".FatRat.^name` was `FatRat` (raku: `Failure`)

## Fix

Guard both coercion arms with `parse_raku_str_to_numeric`; on a non-numeric string return the shared `str_numeric_failure(...)` — the same lazy `X::Str::Numeric` Failure `.Int` produces (it only throws when the Failure is used/sunk). Genuine numeric strings (`"1+2i"`, `"3/4"`, `"1.3"`, `"1e2"`) and the empty string (which coerces to `0`, matching raku) are unaffected.

The two `Type/Cool.rakudoc` doc examples now match raku exactly.

## Tests

New pin `t/coerce-nonnumeric-str-failure.t` (14 cases: soft Failure via `.^name`, throwing on use via `throws-like`, genuine-string parity, empty-string-is-0, result type). Whitelisted `roast/S32-num/{complex,rat,cool-num,real-bridge}.t` all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)