### PR TITLE
fix: uninames / uniprops / univals return a Seq, not a List

### DIFF
--- a/src/builtins/functions/dispatch_1arg.rs
+++ b/src/builtins/functions/dispatch_1arg.rs
@@ -354,7 +354,8 @@ pub(crate) fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Val
                 .chars()
                 .map(|ch| Value::str(crate::builtins::unicode::unicode_char_name(ch)))
                 .collect();
-            Some(Ok(Value::array(names)))
+            // `uninames` returns a Seq in raku (matters for `.raku`/`.WHAT`).
+            Some(Ok(Value::seq(names)))
         }
         "uniparse" | "parse-names" => {
             let s = arg.to_string_value();

--- a/src/builtins/methods_0arg/dispatch_core_unicode.rs
+++ b/src/builtins/methods_0arg/dispatch_core_unicode.rs
@@ -136,7 +136,8 @@ pub(super) fn dispatch(
                 .chars()
                 .map(|ch| Value::str(crate::builtins::unicode::unicode_char_name(ch)))
                 .collect();
-            Some(Some(Ok(Value::array(names))))
+            // `.uninames` returns a Seq in raku (matters for `.raku`/`.WHAT`).
+            Some(Some(Ok(Value::seq(names))))
         }
         "uniparse" | "parse-names" => {
             let s = target.to_string_value();
@@ -145,13 +146,14 @@ pub(super) fn dispatch(
         "uniprops" => {
             let s = target.to_string_value();
             if s.is_empty() {
-                return Some(Some(Ok(Value::array(vec![]))));
+                return Some(Some(Ok(Value::seq(vec![]))));
             }
             let props: Vec<Value> = s
                 .chars()
                 .map(|ch| Value::str(crate::builtins::unicode::unicode_general_category(ch)))
                 .collect();
-            Some(Some(Ok(Value::array(props))))
+            // `.uniprops` returns a Seq in raku.
+            Some(Some(Ok(Value::seq(props))))
         }
         "unival" => {
             // Type objects should throw an error
@@ -201,13 +203,13 @@ pub(super) fn dispatch(
                     if let Some(ch) = char::from_u32(i as u32) {
                         ch.to_string()
                     } else {
-                        return Some(Some(Ok(Value::array(Vec::new()))));
+                        return Some(Some(Ok(Value::seq(Vec::new()))));
                     }
                 }
                 _ => target.to_string_value(),
             };
             if s.is_empty() {
-                return Some(Some(Ok(Value::array(Vec::new()))));
+                return Some(Some(Ok(Value::seq(Vec::new()))));
             }
             let mut result = Vec::new();
             for ch in s.chars() {
@@ -221,7 +223,8 @@ pub(super) fn dispatch(
                     result.push(Value::num(f64::NAN));
                 }
             }
-            Some(Some(Ok(Value::array(result))))
+            // `.univals` returns a Seq in raku.
+            Some(Some(Ok(Value::seq(result))))
         }
         "chr" => {
             let (code, display) = match target.view() {

--- a/t/uni-methods-return-seq.t
+++ b/t/uni-methods-return-seq.t
@@ -1,0 +1,26 @@
+use v6;
+use Test;
+
+# `.uninames`, `.uniprops`, `.univals` (and the `uninames` sub form) return a
+# Seq in raku, not a List — this is observable via `.WHAT` and `.raku`
+# (`("...").Seq`). raku-doc/doc/Type/Cool.rakudoc.
+
+plan 9;
+
+is "abc".uninames.^name, 'Seq', '.uninames returns a Seq';
+is "abc".uniprops.^name, 'Seq', '.uniprops returns a Seq';
+is "12".univals.^name,   'Seq', '.univals returns a Seq';
+is uninames("ab").^name, 'Seq', 'uninames() sub form returns a Seq';
+
+# `.raku` renders the `.Seq` suffix.
+is "a".uninames.raku, '("LATIN SMALL LETTER A",).Seq', '.uninames.raku shows .Seq';
+
+# Empty invocant still yields an (empty) Seq, not a List.
+is "".uninames.^name, 'Seq', 'empty .uninames is still a Seq';
+is "".uniprops.^name, 'Seq', 'empty .uniprops is still a Seq';
+
+# Values are unchanged, only the container type.
+is-deeply "AB".uninames.List,
+    ("LATIN CAPITAL LETTER A", "LATIN CAPITAL LETTER B").List,
+    '.uninames values are correct';
+is "½".univals.List, (0.5,).List, '.univals value is correct';


### PR DESCRIPTION
## Problem

Surfaced by the QA doc-diff harness (PLAN.md §8) against `Type/Cool.rakudoc`. raku's `.uninames`, `.uniprops`, `.univals` (and the `uninames` sub form) all return a **Seq**, but mutsu returned a List. Observable via `.WHAT` and `.raku`:

- `"abc".uninames.raku` rendered `(...)` instead of raku's `(...).Seq`;
- `"Ḍ̇'oh".comb>>.uninames.raku` diverged element-wise.

## Fix

Return `Value::seq(...)` from all three coercers (both empty and populated paths), matching the sibling `.ords`/`.comb` which already return a Seq. Values are unchanged — only the container type. Both `Type/Cool.rakudoc` doc examples now match raku exactly.

## Tests

New pin `t/uni-methods-return-seq.t` (9 cases: `.^name` is Seq for all three + sub form, `.raku` `.Seq` suffix, empty invocant still Seq, values correct). Whitelisted `roast/S15-unicode-information/{uniprop,unival,uniname}.t` all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)