### PR TITLE
perf: BlockScope skips $OUTER:: locals snapshot clone under shadow slots (lexical-slot endgame slice 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -181,7 +181,23 @@ impl Interpreter {
         self.block_declared_vars
             .push(crate::runtime::NameSet::default());
         // Push saved locals for $OUTER:: variable access.
-        self.outer_scope_locals.push(saved_locals.clone());
+        //
+        // Under shadow slots (default) an in-frame `$OUTER::x` resolves through
+        // the compiler-baked outer slot directly against the LIVE `locals`
+        // (`get_outer_var`'s shadow fast path), and a cross-frame one resolves
+        // against the captured `__mutsu_outer::` env — neither consults this
+        // snapshot. So push an *empty* frame: it keeps the stack-depth
+        // bookkeeping every `OUTER::` depth calculation relies on, while the
+        // `slot < saved.len()` guard in `get_outer_var` makes the snapshot path a
+        // no-op that falls through to those two paths. This drops the per-block
+        // O(locals) clone on the default build (lexical-slot endgame slice 2).
+        // The `MUTSU_NO_SHADOW_SLOTS` opt-out has no baked outer slot and still
+        // needs the real snapshot.
+        if crate::compiler::shadow_slots_active() {
+            self.outer_scope_locals.push(Vec::new());
+        } else {
+            self.outer_scope_locals.push(saved_locals.clone());
+        }
         // Baseline for the ENTER-result stack: any value captured by this block's
         // ENTER section (PushEnterResult) must be cleared on exit even if the body
         // throws before reaching LoadEnterResult, so no stale value leaks upward.


### PR DESCRIPTION
Second slice of the **lexical-slot endgame** (ANALYSIS.md §1.3 roadmap #1; `docs/lexical-scope-slot-campaign.md`). Follows #4818.

## What
`exec_block_scope_op` pushed a **full clone of the `locals` vec** onto `outer_scope_locals` on every block entry to back `$OUTER::` variable access. This makes that push an **empty frame** under shadow slots (the default), eliminating the clone.

## Why the snapshot is dead under shadow slots
`$OUTER::` no longer reads `outer_scope_locals` on the default build:
- **in-frame** `$OUTER::x` resolves through the compiler-baked outer slot directly against the **live** `locals` — `get_outer_var`'s shadow fast path (`vm_var_get_ops.rs:423`), because `resolve_outer` (`lex_scope.rs`) already computes the emit-point outer slot under shadow slots;
- **cross-frame** `$OUTER::x` (stored closures, reaching past the compilation frame) resolves against the captured `__mutsu_outer::` env.

Neither path consults the snapshot. Pushing an **empty** frame keeps the stack-depth bookkeeping every `OUTER::` depth calculation relies on, while the `slot < saved.len()` guard in `get_outer_var` makes the old snapshot path a no-op that falls through to the two paths above. The `MUTSU_NO_SHADOW_SLOTS` opt-out (no baked outer slot) keeps the real snapshot.

This removes one of the **two** per-block `O(locals)` clones in `exec_block_scope_op`; the restore-side clone (`self.locals.clone()` → `self.locals = saved_locals`) stays until slice 3 converts it to a targeted Nil-reset.

## Validation
- `$OUTER::` cases match baseline: nested `$OUTER::x`/`$OUTER::OUTER::x` → `2`/`1`; assign-through → `1`; stored-closure `$OUTER::x` → `20`.
- `t/outer-topic.t`, `t/outer-pseudo-package.t`, `t/pseudo-outer-indirect.t`, `t/shadow-slot-outer-var.t` PASS; roast `variables-and-packages.t`, `dollar-underscore.t` PASS.
- Non-whitelisted `pseudo-6d.t`/`pseudo-6e.t` failure counts **unchanged vs main** (45/97 — pre-existing).
- `make test`: **18637 PASS**. clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)