### PR TITLE
fix: Array.List materializes autovivification holes as Nil

### DIFF
--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -335,7 +335,30 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             // A shaped array falls through to the slow path, which flattens all
             // dimensions and replaces Nil slots with the type-default.
             ValueView::Array(..) if crate::runtime::utils::is_shaped_array(target) => None,
-            ValueView::Array(items, _) => Some(Ok(Value::array(items.to_vec()))),
+            // `.List` materializes autovivification holes as `Nil` (raku:
+            // `my @a=[1]; @a[3]=3; @a.List` is `(1 Nil Nil 3)`), unlike the
+            // Array gist which shows the `(Any)` type object. A hole is a
+            // `Package("Any")` slot whose index is not in the `initialized`
+            // set (bulk-constructed arrays have `initialized == None` and thus
+            // no holes).
+            ValueView::Array(items, _) => {
+                let list = match &items.initialized {
+                    Some(set) => items
+                        .items
+                        .iter()
+                        .enumerate()
+                        .map(|(i, v)| {
+                            if !set.contains(&i) && matches!(v.view(), ValueView::Package(_)) {
+                                Value::NIL
+                            } else {
+                                v.clone()
+                            }
+                        })
+                        .collect(),
+                    None => items.to_vec(),
+                };
+                Some(Ok(Value::array(list)))
+            }
             ValueView::GenericRange {
                 start,
                 end,

--- a/t/array-list-holes-nil.t
+++ b/t/array-list-holes-nil.t
@@ -1,0 +1,36 @@
+use v6;
+use Test;
+
+# `.List` materializes autovivification holes as `Nil`, unlike the Array gist
+# which shows the `(Any)` type object. (raku-doc/doc/Type/Array.rakudoc)
+
+plan 8;
+
+my @a = [1];
+@a[3] = 3;
+is @a.List.raku, '(1, Nil, Nil, 3)', 'untyped autoviv holes become Nil in .List';
+is @a.gist, '[1 (Any) (Any) 3]', 'Array gist still shows (Any) for holes';
+
+my Int @b = [0];
+@b[3] = 3;
+is @b.List.raku, '(0, Nil, Nil, 3)', 'typed-array holes also become Nil in .List';
+
+my @c;
+@c[2] = 'x';
+is @c.List.raku, '(Nil, Nil, "x")', 'leading holes become Nil';
+
+# Bulk / literal arrays have no holes and are untouched.
+my @d = 1, 2, 3;
+is @d.List.raku, '(1, 2, 3)', 'bulk array .List is unchanged';
+is [<a b c>].List.raku, '("a", "b", "c")', 'literal array .List is unchanged';
+
+# An explicitly-assigned type object is NOT a hole (it is in the initialized set).
+my @e;
+@e[0] = Int;
+@e[2] = 5;
+is @e.List.raku, '(Int, Nil, 5)', 'assigned type object stays, gap becomes Nil';
+
+# No autoviv: a fully-populated element-wise array has no Nil.
+my @f;
+@f[0] = 10; @f[1] = 20;
+is @f.List.raku, '(10, 20)', 'contiguous element assignment has no holes';


### PR DESCRIPTION
## Problem

Surfaced by the QA doc-diff harness (PLAN.md §8) against `Type/Array.rakudoc`. In raku, `.List` turns an array's autovivification gaps into `Nil`:

```raku
my @a = [1]; @a[3] = 3;
say @a.List;   # (1 Nil Nil 3)   — holes are Nil
say @a;        # [1 (Any) (Any) 3] — the gist still shows (Any)
```

mutsu's `.List` copied the raw backing vector, so holes leaked through as `(Any)`, diverging from raku.

## Fix

In the `.List` Array arm, replace hole slots with `Nil`. A hole is a `Package(_)` element whose index is **not** in the `initialized` set — the same invariant `:exists`/`:k` already use. Bulk/literal arrays have `initialized == None` (no holes) and are untouched; an explicitly-assigned type object (`@a[0] = Int`) is in the set and correctly stays. Typed arrays (`my Int @a`) whose holes are `(Int)` are also converted, matching raku. The Array gist path is unchanged.

## Tests

New pin `t/array-list-holes-nil.t` (8 cases: untyped/typed holes → Nil, gist unchanged, leading holes, bulk/literal untouched, assigned-type-object stays, contiguous no-holes). Full local `make test` green; whitelisted `roast/S02-types/array.t`, `roast/S09-typed-arrays/arrays.t`, `roast/S32-array/create.t` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)