### PR TITLE
fix: Buf.splice coerces a list of replacement values to bytes

### DIFF
--- a/src/runtime/methods_mut_substr_buf.rs
+++ b/src/runtime/methods_mut_substr_buf.rs
@@ -452,7 +452,12 @@ impl Interpreter {
                                 replacement.extend(items.iter().cloned());
                             }
                         }
-                        ValueView::Array(items, ..) => replacement.extend(items.iter().cloned()),
+                        // A plain list/array of replacement values (`<3 2 1>`,
+                        // `(3, 2, 1)`): coerce each element to a byte, matching
+                        // the scalar arm — otherwise Str elements leak into the
+                        // Buf and render as 0.
+                        ValueView::Array(items, ..) => replacement
+                            .extend(items.iter().map(|it| Value::int(resolve(it) & 0xff))),
                         _ => replacement.push(Value::int(resolve(arg) & 0xff)),
                     }
                 }

--- a/t/buf-splice-list-bytes.t
+++ b/t/buf-splice-list-bytes.t
@@ -1,0 +1,31 @@
+use v6;
+use Test;
+
+# Buf.splice with a plain list/array of replacement values must coerce each
+# element to a byte, matching the scalar/Buf arms. A word-list of numeric
+# strings (`<3 2 1>`) previously leaked Str values into the Buf, rendering
+# as 0. (raku-doc/doc/Type/Buf.rakudoc)
+
+plan 6;
+
+my $b = Buf.new(1, 1, 2, 3, 5);
+my $removed = $b.splice: 0, 3, <3 2 1>;
+is $removed.raku, 'Buf.new(1,1,2)', 'splice returns the removed bytes';
+is $b.raku, 'Buf.new(3,2,1,3,5)', 'numeric-string list replacement coerces to bytes';
+
+my $c = Buf.new(1, 2, 3);
+$c.splice: 1, 1, (9, 10);
+is $c.raku, 'Buf.new(1,9,10,3)', 'Int list replacement works';
+
+my $d = Buf.new(1, 2, 3);
+$d.splice: 1, 0, Buf.new(7, 8);
+is $d.raku, 'Buf.new(1,7,8,2,3)', 'Buf replacement (insert) works';
+
+my $e = Buf.new(10, 20, 30);
+$e.splice: 1, 2, <1 2>;
+is $e.raku, 'Buf.new(10,1,2)', 'string-list replacement on the tail';
+
+# Values > 255 wrap to a byte, like the scalar arm.
+my $f = Buf.new(0);
+$f.splice: 0, 1, (257,);
+is $f.raku, 'Buf.new(1)', 'replacement value is masked to a byte';


### PR DESCRIPTION
## Problem

Surfaced by the QA doc-diff harness (PLAN.md §8) against `Type/Buf.rakudoc`. `Buf.splice($off, $count, <3 2 1>)` should insert bytes 3, 2, 1, but mutsu extended the byte vector with the raw `Str` elements of the list, which render as 0:

```raku
my $b = Buf.new(1,1,2,3,5);
$b.splice: 0, 3, <3 2 1>;
say $b.raku;   # mutsu: Buf.new(0,0,0,3,5)   raku: Buf.new(3,2,1,3,5)
```

## Fix

The Array/list replacement arm now coerces each element to a byte (`resolve(it) & 0xff`), matching the existing scalar arm. Int lists and Buf replacements are unaffected, and out-of-range values wrap to a byte like raku (`257` → `1`).

## Tests

New pin `t/buf-splice-list-bytes.t` (6 cases: numeric-string list, Int list, Buf insert, tail replacement, byte-mask, removed-bytes return). Whitelisted `roast/S32-container/buf.t` and `roast/S32-array/splice.t` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)