### PR TITLE
fix: is required("reason") includes the custom reason in the error message

### DIFF
--- a/src/value/error_construct.rs
+++ b/src/value/error_construct.rs
@@ -21,19 +21,21 @@ impl RuntimeError {
         let mut attrs = HashMap::new();
         attrs.insert("name".to_string(), Value::str(name.to_string()));
         let why_str = why.unwrap_or("Required").to_string();
-        attrs.insert("why".to_string(), Value::str(why_str.clone()));
-        attrs.insert(
-            "message".to_string(),
-            Value::str(format!(
-                "The attribute '{}' is required, but you did not provide a value for it.",
-                name
-            )),
-        );
+        attrs.insert("why".to_string(), Value::str(why_str));
+        // A custom reason (`is required("it is a good idea")`) is woven into the
+        // message; a bare `is required` uses the plain form. Matches Rakudo's
+        // X::Attribute::Required, including the newline before "but you did...".
+        let message = match why {
+            Some(reason) => format!(
+                "The attribute '{name}' is required because {reason},\nbut you did not provide a value for it."
+            ),
+            None => format!(
+                "The attribute '{name}' is required, but you did not provide a value for it."
+            ),
+        };
+        attrs.insert("message".to_string(), Value::str(message.clone()));
         let ex = Value::make_instance(Symbol::intern("X::Attribute::Required"), attrs);
-        let mut err = Self::new(format!(
-            "The attribute '{}' is required, but you did not provide a value for it.",
-            name
-        ));
+        let mut err = Self::new(message);
         err.exception = Some(Box::new(ex));
         err
     }

--- a/t/attribute-required-reason.t
+++ b/t/attribute-required-reason.t
@@ -1,0 +1,27 @@
+use v6;
+use Test;
+
+# `is required("reason")` weaves the custom reason into the
+# X::Attribute::Required message; a bare `is required` uses the plain form.
+# (raku-doc/doc/Type/Attribute.rakudoc)
+
+plan 5;
+
+class D { has $.a is required("it is a good idea") }
+try D.new;
+my $reasoned = $!;
+is $reasoned.^name, 'X::Attribute::Required', 'reasoned: right exception type';
+is $reasoned.Str,
+    "The attribute '\$!a' is required because it is a good idea,\nbut you did not provide a value for it.",
+    'reasoned message includes "because <reason>," and the newline';
+
+class E { has $.a is required }
+try E.new;
+my $bare = $!;
+is $bare.^name, 'X::Attribute::Required', 'bare: right exception type';
+is $bare.Str,
+    "The attribute '\$!a' is required, but you did not provide a value for it.",
+    'bare message uses the plain form';
+
+# Providing the value avoids the exception entirely.
+lives-ok { D.new(a => 1) }, 'providing the required attribute lives';


### PR DESCRIPTION
## Problem

Surfaced by the QA doc-diff harness (PLAN.md §8) against `Type/Attribute.rakudoc`. `has $.a is required("it is a good idea")` should produce:

```
The attribute '$!a' is required because it is a good idea,
but you did not provide a value for it.
```

but mutsu dropped the reason and always used the bare form (`... is required, but you did not ...`). The reason string was already threaded to `attribute_required` (stored in the `why` attribute) — it was just ignored when building the message.

## Fix

Weave the custom reason into the message (`... is required because <reason>,\nbut ...`), matching Rakudo's `X::Attribute::Required` including the embedded newline. A bare `is required` keeps the plain form.

## Tests

New pin `t/attribute-required-reason.t` (5 cases: reasoned type + message, bare type + message, providing the value lives). Whitelisted `roast/S12-class/attributes-required.t` and the S06 signature required-param tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)