### PR TITLE
fix: subbuf-rw($from) without a length replaces the tail, not inserts

### DIFF
--- a/src/runtime/methods_mut_substr_buf.rs
+++ b/src/runtime/methods_mut_substr_buf.rs
@@ -118,8 +118,20 @@ impl Interpreter {
             Vec::new()
         };
 
-        let from = method_args.first().map(crate::runtime::to_int).unwrap_or(0) as usize;
-        let len = method_args.get(1).map(crate::runtime::to_int).unwrap_or(0) as usize;
+        let from = (method_args
+            .first()
+            .map(crate::runtime::to_int)
+            .unwrap_or(0)
+            .max(0) as usize)
+            .min(items.len());
+        // With no explicit length (or a `*` Whatever), `subbuf-rw($from)` spans
+        // from `$from` to the end of the buffer — replacing the whole tail, not
+        // inserting at `$from`.
+        let len = match method_args.get(1) {
+            Some(v) if matches!(v.view(), ValueView::Whatever) => items.len() - from,
+            Some(v) => crate::runtime::to_int(v).max(0) as usize,
+            None => items.len() - from,
+        };
 
         let new_bytes = if let ValueView::Instance { attributes, .. } = value.view()
             && let Some(ValueView::Array(new_items, ..)) =

--- a/t/subbuf-rw-tail.t
+++ b/t/subbuf-rw-tail.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+# `subbuf-rw($from)` with no length spans from `$from` to the end of the
+# buffer, so assigning replaces the whole tail (it does not insert at $from).
+# (raku-doc/doc/Type/Buf.rakudoc)
+
+plan 6;
+
+my Buf $b .= new(0..5);
+$b.subbuf-rw(3) = Buf.new(200);
+is $b.raku, 'Buf.new(0,1,2,200)', 'no-length subbuf-rw replaces the tail';
+
+my Buf $c .= new(0..5);
+$c.subbuf-rw(1, 2) = Buf.new(9);
+is $c.raku, 'Buf.new(0,9,3,4,5)', 'explicit length still removes exactly that many';
+
+my Buf $d .= new(0..5);
+$d.subbuf-rw(2, 0) = Buf.new(99);
+is $d.raku, 'Buf.new(0,1,99,2,3,4,5)', 'zero length inserts at $from';
+
+my Buf $e .= new(0..5);
+$e.subbuf-rw(6) = Buf.new(7, 8);
+is $e.raku, 'Buf.new(0,1,2,3,4,5,7,8)', 'subbuf-rw at end appends';
+
+my Buf $f .= new(0..5);
+$f.subbuf-rw(0) = Buf.new(42);
+is $f.raku, 'Buf.new(42)', 'from 0, no length replaces everything';
+
+my Buf $g .= new(0..5);
+$g.subbuf-rw(2) = Buf.new();
+is $g.raku, 'Buf.new(0,1)', 'replacing the tail with an empty Buf truncates';


### PR DESCRIPTION
## Problem

Surfaced by the QA doc-diff harness (PLAN.md §8) against `Type/Buf.rakudoc`. A lengthless `subbuf-rw($from)` spans from `$from` to the end of the buffer:

```raku
my Buf $b .= new(0..5);
$b.subbuf-rw(3) = Buf.new(200);
say $b.raku;   # mutsu: Buf.new(0,1,2,200,3,4,5)   raku: Buf.new(0,1,2,200)
```

mutsu defaulted the length to 0, so it *inserted* at `$from` and kept the trailing bytes.

## Fix

Default the length to `items.len() - from` when the second argument is absent (or a `*` Whatever), matching raku. `from` is clamped into range so the subtraction never underflows; an explicit length still removes exactly that many bytes.

## Tests

New pin `t/subbuf-rw-tail.t` (6 cases: tail replace, explicit length, zero-length insert, append at end, replace-all, truncate-with-empty). Whitelisted `roast/S03-operators/buf.t`, `roast/S32-container/buf.t`, `roast/S32-array/splice.t` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)