### PR TITLE
fix: bump Dockerfile builder to rust 1.96 for the 1.94 MSRV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # The final image contains NONE of the build toolchain or source tree.
 
 # ---- builder (build stage) --------------------------------------------------
-FROM rust:1.93-bookworm AS builder
+FROM rust:1.96-bookworm AS builder
 
 # pcre2 links the system libpcre2 (the pcre2 feature); libffi is built vendored
 # and statically linked into the binary, so it needs no runtime package.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ docker run --rm -v mutsu-home:/root ghcr.io/tokuhirom/mutsu \
 Pin a version with a tag (`ghcr.io/tokuhirom/mutsu:0.7.0`); `:latest` tracks the
 newest release and `:main` tracks the development branch.
 
-The image is a **two-stage build**: a `rust:1.93-bookworm` **builder** stage
+The image is a **two-stage build**: a `rust:1.96-bookworm` **builder** stage
 compiles the binaries, and the shipped `debian:bookworm-slim` **runtime** stage
 carries only the `mutsu`/`mzef` binaries, the bundled zef tree, and zef's
 shell-out tools (`curl`/`git`/`tar`/`unzip`) — no Rust toolchain or source. Build

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -98,6 +98,10 @@ Some crates raise the **minimum supported Rust version**. When a bump reports
     release/docs/version-bump builders. `tagpr.yml` is **SHA-pinned** (with a
     `# <version>` comment); resolve the new tag's commit with
     `gh api repos/dtolnay/rust-toolchain/commits/<version> --jq .sha`.
+- **`Dockerfile`** — the builder stage pins a `rust:<version>-bookworm` base
+  image (and `README.md` documents it). This is easy to forget because it is not
+  a `dtolnay/rust-toolchain` pin; grep the whole repo for the old version string
+  (`grep -rn "1\.93"`) after an MSRV bump to catch every pin.
 
 Keeping every builder on one toolchain (the version CI already validates) avoids
 a green `make test` on ci.yml while `release.yml` fails on an older pin — which


### PR DESCRIPTION
## Problem (regression from #4813)

The MSRV bump to **1.94** (for cranelift 0.133) missed the `Dockerfile`, whose builder stage still pinned `rust:1.93-bookworm`. cranelift 0.133 requires Rust 1.94, so the **container build** (`docker.yml`, which runs on `v*` tags and main push — **not** on PRs, so #4813's CI couldn't catch it) would fail on the next release/main push.

## Fix
- `Dockerfile`: builder base `rust:1.93-bookworm` → **`rust:1.96-bookworm`** (matches the workflow toolchains standardized in #4813).
- `README.md`: update the documented builder image.
- `docs/maintenance.md`: add the Dockerfile base image to the MSRV-coupling checklist — it's easy to miss because it isn't a `dtolnay/rust-toolchain` pin, so grep the whole repo for the old version string after an MSRV bump.

## Verification
Local `docker build --target builder` on `rust:1.96-bookworm` **succeeds** — the release compile (incl. cranelift 0.133) finishes and the builder image builds. `docker.yml` will exercise the full multi-arch build on the post-merge main push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)