### PR TITLE
perf: BlockScope drops whole-locals restore clone for targeted Nil-reset (lexical-slot endgame slice 3)

### DIFF
--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -175,7 +175,17 @@ impl Interpreter {
         let end = end as usize;
         let routine_snapshot = self.snapshot_routine_registry();
         let saved_env = self.env().clone();
-        let saved_locals = self.locals.clone();
+        // Under shadow slots (default) the block exit uses a targeted Nil-reset of
+        // just the block's own fresh declarations, so no whole-`locals` snapshot
+        // is taken (lexical-slot endgame slice 3). The `MUTSU_NO_SHADOW_SLOTS`
+        // opt-out lacks distinct shadow slots, so it still needs the full
+        // snapshot both to restore `locals` on exit and to back `$OUTER::`.
+        let shadow_slots = crate::compiler::shadow_slots_active();
+        let saved_locals = if shadow_slots {
+            None
+        } else {
+            Some(self.locals.clone())
+        };
         let once_scope = self.next_once_scope_id();
         // Track variables declared within this block scope.
         self.block_declared_vars
@@ -193,10 +203,11 @@ impl Interpreter {
         // O(locals) clone on the default build (lexical-slot endgame slice 2).
         // The `MUTSU_NO_SHADOW_SLOTS` opt-out has no baked outer slot and still
         // needs the real snapshot.
-        if crate::compiler::shadow_slots_active() {
+        if shadow_slots {
             self.outer_scope_locals.push(Vec::new());
         } else {
-            self.outer_scope_locals.push(saved_locals.clone());
+            self.outer_scope_locals
+                .push(saved_locals.as_ref().expect("opt-out snapshot").clone());
         }
         // Baseline for the ENTER-result stack: any value captured by this block's
         // ENTER section (PushEnterResult) must be cleared on exit even if the body
@@ -389,7 +400,37 @@ impl Interpreter {
                 restored_env.insert_sym(k, v);
             }
         }
-        self.locals = saved_locals;
+        // Lexical-slot endgame slice 3: under shadow slots, a targeted reset
+        // instead of restoring a whole-`locals` clone. `restored_env` already
+        // holds the correct post-block value for every enclosing name — the
+        // propagated inner value for a plain assignment-through, or the saved
+        // outer value for names that must not propagate (`$_`, `$*dyn`,
+        // block-declared `my`) — so re-seeding each such slot from it reproduces
+        // exactly what the old whole-array restore + re-seed produced. The only
+        // slots `restored_env` cannot cover are the block's own FRESH `my`
+        // declarations (a name with no outer binding): those are absent from
+        // `restored_env`, so Nil them here to stop the declaration leaking past
+        // the block / into a later iteration (their unique shadow slot's
+        // pre-block value is Nil by induction — see slice 1). A shadowing
+        // declaration keeps a live untouched outer slot and a dead-post-block
+        // inner slot, so it needs no reset.
+        //
+        // The `MUTSU_NO_SHADOW_SLOTS` opt-out has no distinct shadow slots, so it
+        // still needs the whole-array restore.
+        if let Some(saved) = saved_locals {
+            self.locals = saved;
+        } else {
+            for sym in &block_declared {
+                if saved_env.contains_key_sym(*sym) {
+                    continue;
+                }
+                for idx in 0..code.locals.len().min(self.locals.len()) {
+                    if code.local_sym(idx) == Some(*sym) {
+                        self.locals[idx] = Value::NIL;
+                    }
+                }
+            }
+        }
         for (idx, name) in code.locals.iter().enumerate() {
             if let Some(val) = restored_env.get(name).cloned() {
                 self.locals[idx] = val;


### PR DESCRIPTION
**Headline slice** of the lexical-slot endgame (ANALYSIS.md §1.3 roadmap #1; `docs/lexical-scope-slot-campaign.md`). Follows #4818, #4821.

## What
`exec_block_scope_op` cloned the **entire `locals` vec** on every block entry (`saved_locals`) purely to restore it wholesale on exit (`self.locals = saved_locals`) and re-seed each slot from the restored env. This removes that clone under shadow slots (the default), replacing the whole-array restore with a **targeted Nil-reset**.

## Why it's sound under shadow slots
- `restored_env` already holds the correct post-block value for **every enclosing name** — the propagated inner value for a plain assignment-through, or the saved outer value for names that must not propagate (`$_`, `$*dyn`, block-declared `my`). The pre-existing re-seed loop reproduces exactly what the whole-array restore produced for every slot it covers.
- The only slots re-seed cannot cover are the block's own **fresh `my` declarations** (a name with no outer binding), absent from `restored_env`. Those are Nil'd directly — their unique shadow slot's pre-block value is `Nil` by induction (the slice-1 technique). A shadowing declaration keeps a live untouched outer slot and a dead-post-block inner slot, so it needs no reset.

The snapshot is now taken **only** on the `MUTSU_NO_SHADOW_SLOTS` opt-out (which lacks distinct shadow slots and still needs the whole-array restore + `$OUTER::` snapshot). The default build takes **no per-block locals clone at all** in `exec_block_scope_op`. This clears the restore-side blocker for slice 4 (dropping the `needs_env_sync` blanket — the fib env-COW perf payoff).

## Validation
Behaviour verified **identical to main** (not just to raku) on the subtle cases:
- enclosing assign-through `my $y=1; { $y=5 }; say $y` → `5`;
- nested shadowing `my $a=1;{my $a=2;{my $a=3;say $a};say $a};say $a` → `3,2,1`;
- `$_` / `$*dyn` block scoping → `5,1` on **both** main and this branch (a pre-existing raku divergence, unchanged here);
- loop-fresh per-iteration decls → `1,1,1`; `do`-block values; `our`-refresh — all unchanged vs main.

Canaries `t/block-lexical-scope.t`, `t/phasers.t`, `t/dualstore-slot-local-gate.t`, `t/closure.t`, roast `roles-6e.t` (the by-value flake canary) PASS. `make test`: **18678 PASS**. clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)