### PR TITLE
fix: a Unicode numeric literal starts a no-paren listop argument

### DIFF
--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1523,6 +1523,11 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
             || next == '('
             || (next == '\\' && r.starts_with("\\("))
             || next.is_ascii_digit()
+            // A Unicode numeric literal (vulgar fraction `⅔`, superscript, ...)
+            // also starts a term, so `atan2 ⅔, ⅓` parses as a call rather than
+            // stranding the fraction as a separate statement.
+            || crate::builtins::unicode::unicode_rat_value(next).is_some()
+            || crate::builtins::unicode::unicode_numeric_int_value(next).is_some()
             || starts_with_term_keyword(r)
             || crate::parser::stmt::simple::match_user_declared_term_symbol(r).is_some()
             || hyphen_forward_call

--- a/t/listop-unicode-numeric-arg.t
+++ b/t/listop-unicode-numeric-arg.t
@@ -1,0 +1,26 @@
+use v6;
+use Test;
+
+# A Unicode numeric literal (vulgar fraction / superscript) as the FIRST
+# argument of a no-paren listop call must parse as an argument, not strand
+# the fraction as a separate statement.
+# Regression: `atan2 ⅔, ⅓` used to leave `atan2` as a bare word.
+
+plan 8;
+
+is-approx atan2(⅔, ⅓), atan2(2/3, 1/3), 'atan2 ⅔, ⅓ (paren baseline)';
+
+# no-paren listop, fraction first arg + comma
+is-approx (atan2 ⅔, ⅓), atan2(2/3, 1/3), 'atan2 ⅔, ⅓ no-paren';
+is-approx (atan2 ⅔, 1), atan2(2/3, 1), 'atan2 ⅔, 1 no-paren';
+is-approx (atan2 ½, ¼), atan2(1/2, 1/4), 'atan2 ½, ¼ no-paren';
+
+# single-arg named unary with a fraction still works
+is-approx (sqrt ¼), 0.5, 'sqrt ¼ no-paren';
+is-approx (cos ⅓), cos(1/3), 'cos ⅓ no-paren';
+
+# plain-number path unaffected
+is-approx (atan2 1, 2), atan2(1, 2), 'atan2 1, 2 no-paren (unchanged)';
+
+# postfix superscript exponent unaffected by the new term-start rule
+is 2², 4, 'superscript exponent 2² still parses';


### PR DESCRIPTION
## Problem

`atan2 ⅔, ⅓` (Unicode vulgar fraction as the first argument of a no-paren
listop call) stranded `atan2` as a bare word and evaluated `⅔, ⅓` as a
separate statement, printing "Useless use of constant rational ... in sink
context" instead of `1.1071487177940904`.

From the doc-diff QA campaign (finding [89], `Type/` corpus vs reference raku).

## Root cause

The no-paren listop-argument gate in `identifier_call.rs` recognized an ASCII
digit as a term-start (`next.is_ascii_digit()`) but not a Unicode numeric
literal (vulgar fraction, superscript). Functions already in `is_listop`
(e.g. `abs`) take an earlier code path and were unaffected, so only the
general fallback gate — covering `atan2` and other non-`is_listop` builtins —
misparsed. `atan2 ⅔` (single arg) and `atan2 0.5, 1` (decimal) already worked;
only a Unicode-fraction first arg on a non-`is_listop` builtin broke.

## Fix

Extend the gate to also treat a leading char with a Unicode rational/integer
value (`unicode_rat_value` / `unicode_numeric_int_value`) as a term-start,
matching exactly what `unicode_numeric_literal` parses. The gate only *adds*
a parse attempt (`&& let Ok(...)`), so it falls through harmlessly when the
arg does not actually parse.

Postfix superscript exponent (`2²`) is unaffected — that path is a postfix
operator, not a term-start.

Pin: `t/listop-unicode-numeric-arg.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)