### PR TITLE
docs: survey ecosystem dependence on an NQP/compiler-guts layer

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -242,10 +242,24 @@ sessions).
   License::SPDX / Test::META) does not use Test::Async, so the "mzef installs real dists with tests
   on" milestone does not need it. Spending the campaign now would delay the mzef return for zero
   pipeline gain.
-- **Start trigger**: after the B2 test-phase frontier closes (or when a bundle-candidate module
-  hard-depends on Test::Async), start with a scouting session: inventory which HOW methods
-  Test::Async's BundleHOW/TestSuiteHOW actually override, and decide between (a) real HOW-subclass
-  dispatch in the MOP vs (b) a narrower compatibility shim for the handful of overridden hooks.
+- **Scouting done (2026-07-19) — the decision is (b), and B2b stays deferred on cost/benefit.**
+  Test::Async needs far more than "custom HOW inheritance": its `EXPORT` installs a **grammar slang**
+  (`define_slang` + custom `package_declarator:sym<test-bundle>` tokens that swap the role HOW mid-parse
+  via `set_how`), builds `QAST` nodes, and drives the `$*W` World / `NQPHLL` — the MoarVM compiler-guts
+  layer mutsu deliberately lacks. So **(a) real HOW-subclass dispatch is necessary but nowhere near
+  sufficient**; only **(b) a narrow per-declarator shim** (parse `test-bundle`/`test-hub`/`test-reporter`
+  as built-in role declarations with native bundle wiring, ignoring the NQP `EXPORT` grammar) is viable,
+  and it is still multi-session. Combined with the payoff: **Test::Async has 8 reverse-deps in the whole
+  fez ecosystem (1573 dists), all `test-depends` only, concentrated in one author's dists.**
+- **Ecosystem-wide justification for deferring the NQP layer generally**: a 150-dist random sample
+  (see [`docs/ecosystem-guts-dependency-survey.md`](../docs/ecosystem-guts-dependency-survey.md),
+  reproduce with `scripts/ecosystem-guts-survey.py`) finds only **~5% of dists are genuinely
+  compiler-guts blocked** (QAST/slang/macros/`Metamodel::Primitives`), vs **~81% pure Raku** and
+  **~9% NativeCall** (a separate layer mutsu already has an MVP of). The high-leverage work is B1/B4
+  over that ~90%, not an NQP/slang subsystem for the ~5% tail.
+- **Start trigger** (if a bundle-candidate module ever hard-depends on Test::Async): start from the (b)
+  shim above — prototype the `test-bundle` declarator as a built-in parse rule plus a native
+  BundleHOW-equivalent; do not attempt the general NQP/QAST/slang machinery.
 - Prerequisite groundwork already landed: `::?CLASS` param fixes (#4669). Detail and error text:
   `docs/mzef-install-pipeline.md` "Test-phase frontier" history block.
 

--- a/docs/ecosystem-guts-dependency-survey.md
+++ b/docs/ecosystem-guts-dependency-survey.md
@@ -1,0 +1,89 @@
+# Ecosystem survey: how much of the Raku ecosystem needs an NQP/compiler-guts layer?
+
+**Date:** 2026-07-19 · **Reproduce:** `scripts/ecosystem-guts-survey.py [SAMPLE_SIZE] [SEED]`
+
+## Question
+
+mutsu deliberately does **not** implement a MoarVM/NQP layer (no `nqp::` runtime,
+no `QAST`, no slang/grammar mutation, no `Metamodel::Primitives`). Before
+investing in one, we need to know: **how much of the ecosystem is actually
+blocked by needing that layer**, versus reachable by improving pure-Raku
+compatibility?
+
+This came up while scoping **Test::Async** (PLAN.md §1 B2b), which turned out to
+need the full guts stack (custom `package_declarator` slang tokens via
+`define_slang`, `QAST`, the `$*W` World, `NQPHLL`) — not merely "custom HOW
+inheritance". The natural follow-up: is Test::Async a lone outlier, or the tip of
+a large blocked-by-guts iceberg?
+
+## Method
+
+1. Read the local fez ecosystem index (`~/.zef/store/fez/fez.json`, the same
+   index `mzef`/zef uses — 7660 entries, **1573 unique distributions**).
+2. Keep the latest version per dist; draw a **fixed-seed random sample**.
+3. Download each dist tarball from the fez CDN and scan its Raku sources
+   (`.rakumod/.pm6/.raku/.rakutest/.t`), placing each dist in exactly **one**
+   bucket by decreasing severity:
+
+| Bucket | Signal | Reachability on mutsu |
+| --- | --- | --- |
+| `deep_guts` | `QAST`, `Metamodel::Primitives`, `NQPHLL`, `:from<NQP>`, `EXPORTHOW`, `define_slang`, `package_declarator:sym`, `experimental :macros`, `Slang::` | **Blocked** — needs the guts layer mutsu doesn't have (Test::Async class) |
+| `nativecall` | `use NativeCall`, `is native`, `:from<C>` | Needs the C FFI layer, which mutsu **has as an MVP** — partially reachable, **not** NQP-blocked |
+| `nqp_ops_only` | `use nqp` / `nqp::` (none of the deep signals) | A spectrum — many `nqp::` ops are simple and stubbable / perf-only |
+| `pure_raku` | none of the above | **Not guts-blocked** |
+
+## Results
+
+Two independent random samples, consistent:
+
+| Bucket | n=150 (seed 42) | n=60 (seed 20260719) |
+| --- | --- | --- |
+| `pure_raku` | **121 (81%)** | 41 (68%) |
+| `nativecall` | 14 (9%) | 11 (18%) |
+| `nqp_ops_only` | 8 (5%) | 5 (8%) |
+| **`deep_guts`** | **7 (5%)** | **3 (5%)** |
+
+`deep_guts` hits (n=150): `Slang::Roman`, `Slang::NumberBase`, `Grammar::Debugger`
+(custom slangs), `Data::Record` (macros), `App::Crag`, `Kind::Subset::Parametric`,
+`Backtrace::Files` — the same "compiler-guts" class as Test::Async.
+
+Reverse-dependency check for Test::Async specifically: **8 of 1573 dists** depend
+on it, **all as `test-depends` only** (needed to run those dists' own test
+suites, never at runtime/install), and concentrated in one author's (vrurg)
+ecosystem.
+
+## Interpretation
+
+- **The genuinely guts-blocked tail is small: ~5%** (at most ~10% if you count
+  every `nqp::`-touching dist as blocked, which overcounts — most such uses are
+  stubbable or perf-only).
+- **~81% of the ecosystem is pure Raku** and reachable purely by widening
+  mutsu's pure-Raku compatibility.
+- **~9% need NativeCall**, a *separate* native layer mutsu already has an MVP of
+  (real SQLite CRUD round-trips) — reachable by completing FFI, not by NQP.
+
+## Strategic conclusion
+
+Building a full NQP / QAST / slang layer would be an enormous effort to unlock
+only the ~5% `deep_guts` tail — the same poor cost/benefit that led us to defer
+Test::Async. The high-leverage work is the **~90%** that is pure Raku or
+NativeCall:
+
+- **Do** PLAN.md §1 **B1** (finalize + document the batteries bundle) and **B4**
+  (close pure-Raku compatibility gaps, surfaced by running real dists) — these
+  raise the reachable ceiling for the 81% majority.
+- **Do** keep improving **NativeCall** (the 9%), which needs no NQP layer.
+- **Defer** a general NQP/slang subsystem. When a specific high-value
+  `deep_guts` dist is wanted, prefer a **narrow per-feature shim** (e.g. treat a
+  custom declarator as a built-in parse rule) over a general guts emulator.
+
+## Caveats
+
+- fez ecosystem only (not the older github/CPAN Raku ecosystems).
+- A **signal scan, not execution**: `pure_raku` means "not guts-blocked", **not**
+  "runs on mutsu today" (a dist may still hit an unimplemented pure-Raku
+  feature). Conversely a `deep_guts` dist may use its guts feature only in a
+  cold path.
+- Sample ≈ 10% of the fez index; the 5% `deep_guts` figure has a sampling error
+  of a couple of points. Re-run `scripts/ecosystem-guts-survey.py 300` for a
+  tighter estimate.

--- a/scripts/ecosystem-guts-survey.py
+++ b/scripts/ecosystem-guts-survey.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+ecosystem-guts-survey.py — estimate how much of the Raku (fez) ecosystem needs a
+compiler-guts layer (NQP / QAST / slang / macros) that mutsu deliberately does
+not implement, versus how much is reachable by improving pure-Raku compatibility.
+
+Method: read the local fez ecosystem index (the same one `mzef`/zef downloads),
+take the latest version of each distribution, draw a fixed-seed random sample,
+download each dist tarball from the fez CDN, and scan its Raku sources for a set
+of signals. Each dist is placed in exactly ONE bucket by decreasing severity:
+
+  deep_guts    QAST / Metamodel::Primitives / NQPHLL / :from<NQP> / EXPORTHOW /
+               define_slang / package_declarator:sym / experimental :macros /
+               Slang::   -> genuinely needs the compiler-guts layer (Test::Async
+               class). Not reachable without an NQP/slang subsystem.
+  nativecall   use NativeCall / is native / :from<C>  -> needs the C FFI layer,
+               which mutsu HAS as an MVP. Partially reachable; NOT NQP-blocked.
+  nqp_ops_only use nqp / nqp::  (but none of the deep signals) -> a spectrum;
+               many nqp ops are simple and stubbable / perf-only.
+  pure_raku    none of the above -> not guts-blocked (does not by itself prove
+               mutsu runs it, only that no guts layer is required).
+
+Caveats: fez ecosystem only (not the older github/cpan ecosystems); a signal
+scan, not execution; "pure_raku" means "not guts-blocked", not "runs on mutsu".
+
+Usage:
+  scripts/ecosystem-guts-survey.py [SAMPLE_SIZE] [SEED]
+  # defaults: SAMPLE_SIZE=150 SEED=42 ; needs ~/.zef/store/fez/fez.json present
+  # (populate it once with any `mzef`/zef ecosystem operation).
+"""
+import json, os, re, sys, io, random, tarfile, urllib.request, collections
+
+FEZ_INDEX = os.path.expanduser("~/.zef/store/fez/fez.json")
+FEZ_CDN = "https://360.zef.pm/"
+
+DEEP = re.compile(
+    r"QAST|Metamodel::Primitives|NQPHLL|:from<NQP>|EXPORTHOW|define_slang|"
+    r"package_declarator:sym|use\s+experimental\s*:\s*macro|Slang::"
+)
+NQP = re.compile(r"\buse\s+nqp\b|nqp::")
+NATIVE = re.compile(r"\buse\s+NativeCall\b|:from<C>|\bis\s+native\b")
+SRC_RE = re.compile(r"\.(rakumod|pm6|pm|raku|rakutest|t)$")
+
+
+def version_key(v):
+    return [(0, int(x)) if x.isdigit() else (1, x) for x in re.split(r"[.\-+]", str(v))]
+
+
+def main():
+    size = int(sys.argv[1]) if len(sys.argv) > 1 else 150
+    seed = int(sys.argv[2]) if len(sys.argv) > 2 else 42
+    if not os.path.exists(FEZ_INDEX):
+        sys.exit(f"missing {FEZ_INDEX} — run an mzef/zef ecosystem op first")
+
+    idx = json.load(open(FEZ_INDEX))
+    best = {}
+    for m in idx:
+        if isinstance(m, dict) and m.get("name") and m.get("path"):
+            n = m["name"]
+            if n not in best or version_key(m.get("version", "0")) > version_key(
+                best[n].get("version", "0")
+            ):
+                best[n] = m
+
+    names = sorted(best)
+    random.seed(seed)
+    sample = random.sample(names, min(size, len(names)))
+
+    cat = collections.Counter()
+    deep = []
+    scanned = 0
+    for n in sample:
+        try:
+            data = urllib.request.urlopen(FEZ_CDN + best[n]["path"], timeout=40).read()
+            tf = tarfile.open(fileobj=io.BytesIO(data))
+            src = ""
+            for mem in tf.getmembers():
+                if mem.isfile() and SRC_RE.search(mem.name):
+                    try:
+                        src += tf.extractfile(mem).read().decode("utf8", "ignore")
+                    except Exception:
+                        pass
+            scanned += 1
+            if DEEP.search(src):
+                cat["deep_guts"] += 1
+                deep.append(n)
+            elif NATIVE.search(src):
+                cat["nativecall"] += 1
+            elif NQP.search(src):
+                cat["nqp_ops_only"] += 1
+            else:
+                cat["pure_raku"] += 1
+        except Exception:
+            cat["fetch_fail"] += 1
+
+    print(f"unique dists in index: {len(names)}")
+    print(f"sampled: {len(sample)}  scanned: {scanned}  seed: {seed}\n")
+    for k in ("pure_raku", "nativecall", "nqp_ops_only", "deep_guts"):
+        pct = 100 * cat[k] / scanned if scanned else 0
+        print(f"  {k:14} {cat[k]:3}/{scanned}  {pct:.0f}%")
+    print(f"\ndeep_guts (genuinely compiler-guts blocked): {deep}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Records a **data-driven answer** to "how many modules need an NQP-like layer to be usable?", prompted by the Test::Async (PLAN §1 B2b) scouting.

## Method
Random sample (fixed seed) of the fez ecosystem index (**1573 unique dists**), each tarball downloaded and its Raku sources scanned, bucketed by decreasing severity (`deep_guts` > `nativecall` > `nqp_ops_only` > `pure_raku`). Reproducible: `scripts/ecosystem-guts-survey.py [N] [SEED]`.

## Findings (n=150, corroborated by an n=60 run)
| Bucket | Share | Reachability |
|---|---|---|
| `pure_raku` | **~81%** | pure-Raku compat work |
| `nativecall` | ~9% | C FFI — mutsu **has an MVP**, not NQP-blocked |
| `nqp_ops_only` | ~5% | mostly stubbable / perf |
| **`deep_guts`** | **~5%** | genuinely needs QAST/slang/macros/`Metamodel::Primitives` |

Also: **Test::Async has 8 reverse-deps in the whole ecosystem, all `test-depends` only**, concentrated in one author's dists.

## Conclusion
A full NQP/QAST/slang subsystem is a huge effort for a ~5% tail — the leverage is **B1/B4 over the ~90%** that is pure Raku or NativeCall. B2b's decision is **(b) a narrow per-declarator shim**, and it stays deferred. Recorded in `PLAN.md` B2b + `docs/ecosystem-guts-dependency-survey.md`.

Docs/script only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)