### PR TITLE
fix: an allomorph binds to a parameter typed as any of its component types

### DIFF
--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -403,6 +403,14 @@ impl Interpreter {
 
     /// Fast type check for common types.
     pub(super) fn fast_type_check(val: &Value, type_name: &str) -> bool {
+        // Allomorphs (`IntStr`/`NumStr`/`RatStr`/...) and other mixed-in values
+        // are `Mixin`s: an `IntStr` must satisfy `Int` (via its inner value) and
+        // `Str` (via its mixin), just like `~~` does. Delegate to the full
+        // `isa_check`, which already handles every allomorph/mixin case, rather
+        // than matching only the plain scalar variant below.
+        if matches!(val.view(), ValueView::Mixin(..)) {
+            return val.isa_check(type_name);
+        }
         match type_name {
             "Int" => matches!(val.view(), ValueView::Int(_) | ValueView::BigInt(_)),
             "Str" => matches!(val.view(), ValueView::Str(_)),

--- a/t/allomorph-param-type-check.t
+++ b/t/allomorph-param-type-check.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+# An allomorph binds to a parameter typed as any of its component types,
+# exactly like `~~` matches it. Regression: `sub foo(Int $x){}; foo <42>`
+# threw "Type check failed in binding $x: expected Int, got IntStr" because
+# the fast parameter type-check matched only the plain scalar variant and
+# never unwrapped the allomorph Mixin.
+
+plan 11;
+
+# IntStr satisfies Int, Str, Cool, Numeric, Any
+lives-ok { sub f(Int  $x) {}; f <42> }, 'IntStr binds Int';
+lives-ok { sub f(Str  $x) {}; f <42> }, 'IntStr binds Str';
+lives-ok { sub f(Cool $x) {}; f <42> }, 'IntStr binds Cool';
+lives-ok { sub f(Any  $x) {}; f <42> }, 'IntStr binds Any';
+
+# NumStr satisfies Num; RatStr satisfies Rat
+lives-ok { sub f(Num $x) {}; f <42e0> }, 'NumStr binds Num';
+lives-ok { sub f(Rat $x) {}; f <1/2> },  'RatStr binds Rat';
+
+# the bound value keeps its allomorphic identity
+sub name-of(Int $x) { $x.^name }
+is name-of(<42>), 'IntStr', 'bound value is still an IntStr';
+
+# `but`-mixed value still binds its base type
+lives-ok { sub f(Int $x) {}; f (42 but True) }, 'mixed Int binds Int';
+
+# negatives: a plain value must still be rejected against the wrong type
+dies-ok { sub f(Str $x) {}; f 42 },  'plain Int does not bind Str';
+dies-ok { sub f(Int $x) {}; f "x" }, 'plain Str does not bind Int';
+dies-ok { sub f(Int $x) {}; f <4e0> }, 'NumStr does not bind Int';


### PR DESCRIPTION
## Problem

```raku
sub foo(Int $x) { say $x.^name }
foo <42>;   # Type check failed in binding $x: expected Int, got IntStr
```

An allomorph (`IntStr`/`NumStr`/`RatStr`/`ComplexStr`) failed a parameter
type constraint for any of its component types, even though `<42> ~~ Int`
is `True`. Found via the doc-diff QA campaign (`Language/numerics.rakudoc`).

## Root cause

Allomorphs and other mixed-in values are `Mixin`s wrapping a base value.
The fast parameter type-check `fast_type_check` matched only the plain
scalar variant (`ValueView::Int`, `Str`, `Num`, ...) and never unwrapped
the `Mixin`, so an `IntStr` failed an `Int` constraint. The general
`isa_check` (used by `~~`) already handles every allomorph/mixin case
(inner base type + mixed-in roles), which is why smartmatch worked but
binding did not.

## Fix

Route `Mixin` values through `isa_check` in `fast_type_check`. Plain values
keep the fast path untouched. Now `IntStr` binds `Int`/`Str`/`Cool`/`Any`,
`NumStr` binds `Num`, `RatStr` binds `Rat`, and `42 but True` binds `Int` —
while plain values are still rejected against the wrong type
(`f 42` against `Str`, `<4e0>` against `Int`).

Pin: `t/allomorph-param-type-check.t`. Verified no regressions across the
`S06-signature/` roast suite (arity, types, type-capture, optional,
named-parameters, slurpy-params, ...) and `S02-types/{num,capture,WHICH}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)