### PR TITLE
docs: real-distribution compatibility sweep dashboard + sandboxed sweep tool

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -292,6 +292,18 @@ sessions).
 
 ### B4. Remaining module-compatibility blockers (the base of batteries)
 
+- [ ] **★Real-dist compatibility sweep (systematic, dashboard-driven)** — actually
+      run real fez-ecosystem dists under mutsu and fix the general bugs they surface.
+      Live ledger: [`docs/dist-compat-sweep.md`](../docs/dist-compat-sweep.md)
+      (regenerate: `scripts/dist-compat-sweep.py`; **sandboxed via `bwrap` — no net,
+      read-only FS, throwaway HOME**, since dist code runs arbitrary load-time code).
+      First run (n=60, 2026-07-19): of the pure-Raku, dep-satisfiable dists, **~half
+      load, ~half hit a real mutsu bug on `use` alone**. Top recurring blocker:
+      `Assignment operators inside ?? !! are too loose` (2 dists). This is the
+      execution counterpart of the signal-only
+      [`docs/ecosystem-guts-dependency-survey.md`](../docs/ecosystem-guts-dependency-survey.md)
+      and the highest-leverage way to widen the batteries base. Workflow per bug:
+      minimal repro → general fix → `t/` pin → PR → re-check with `--only <Dist>`.
 - [ ] **NativeCall remainder**: ① `CArray[uint8]`, `CArray[Str]` ② `is repr('CStruct')` structs
       ③ callbacks (generic C callbacks). Everything from the MVP up to real SQLite CRUD is done
       (news/2026-06.md archive section).

--- a/docs/dist-compat-sweep.md
+++ b/docs/dist-compat-sweep.md
@@ -1,0 +1,170 @@
+# Real-distribution compatibility sweep — dashboard
+
+The single ledger of **which real fez-ecosystem distributions actually run under
+mutsu, and why the rest fail**, tracked by root cause. Used to decide which
+general mutsu fix would unblock the most real dists at once — the batteries /
+compatibility counterpart of [`TODO_roast/BLOCKERS.md`](../TODO_roast/BLOCKERS.md).
+
+## Why this file exists
+
+[`docs/ecosystem-guts-dependency-survey.md`](ecosystem-guts-dependency-survey.md)
+established that **~81% of the ecosystem is pure Raku** (not compiler-guts
+blocked). But that is a *signal scan* — it explicitly does **not** mean "runs on
+mutsu". This sweep is the **execution** counterpart: it downloads each dist,
+points mutsu at the dist's own `lib`, and tries to `use` every module the dist
+`provides`, bucketing the outcome. It answers the question the guts survey could
+not: **of the reachable ~90%, how much runs today, and what are the top blockers?**
+
+The headline finding (first run, 2026-07-19): among the pure-Raku dists whose
+deps are satisfiable, **only about half load cleanly**; the other half hit a
+genuine mutsu parse/runtime bug on `use` alone. So real-dist compatibility, not
+roast, is the productive frontier for widening the batteries base (PLAN.md §1 B4).
+
+## ⚠️ Sandbox — this runs untrusted code
+
+`use <module>` on a real fez dist **executes arbitrary code** (BEGIN/CHECK
+phasers, load-time side effects), and the planned Level-2 test-suite runs execute
+even more. Running that unconfined on a dev machine is unsafe. The sweep therefore
+runs **every mutsu invocation inside a [bubblewrap](https://github.com/containers/bubblewrap)
+(`bwrap`) sandbox** by default:
+
+- **No network** (`--unshare-all` includes a fresh, empty network namespace — the
+  code cannot phone home or attack the LAN). Verified: `curl` inside exits 6.
+- **Read-only filesystem** (`--ro-bind / /`) — the code cannot modify the repo,
+  the binary, or anything on the host. Verified: `spurt` outside HOME → `os error 30`.
+- **Throwaway HOME** — a tmpfs is mounted over an isolated HOME dir, so precomp /
+  site-repo / any writes land in RAM and vanish; nothing reaches the host.
+- **Own PID namespace + `--die-with-parent`** (fork bombs are contained and reaped)
+  and **rlimits** (`ulimit -v`/`-u`: address-space and process-count caps).
+
+Downloading and extracting the tarball happen **outside** the sandbox (in Python);
+only the mutsu run — which needs no network — is confined. `bwrap` is required by
+default; `--sandbox none` disables it and **runs untrusted dist code unconfined —
+do not use it** except against dists you already trust.
+
+## How to regenerate
+
+```sh
+# release build recommended; needs ~/.zef/store/fez/fez.json (any mzef/zef op populates it)
+# sandboxed by default (bwrap); install: apt-get install bubblewrap
+MUTSU_BIN=target/release/mutsu scripts/dist-compat-sweep.py --n 60 --seed 42 --timeout 25
+# → tmp/dist-compat-sweep.tsv (per provided-module rows) + a bucket summary
+```
+
+- `--only Dist::Name` sweeps specific dists (repeatable); use it to re-check one
+  after a fix.
+- `--site-repo <HOME>` runs with that HOME's site repo on the path, so deps
+  installed by a prior `mzef install` collapse `missing_dep` into a real verdict.
+- `--include-guts` / `--include-native` un-skip those axes.
+- `--sandbox {auto,bwrap,none}` (default `auto` = bwrap if present).
+- Downloads are cached under `~/.cache/mutsu-dist-sweep/`.
+
+**This sweep only exercises `use <module>` (a load/compile smoke test).** A dist
+that loads can still fail at runtime or in its own test suite — that is a deeper
+level to be added later (run the dist's `t/`/`.rakutest` with deps installed).
+`load_ok` here means "parses, compiles, and loads", not "passes its tests".
+
+## Buckets
+
+| Bucket | Meaning | Reachable by |
+|---|---|---|
+| `load_ok` | every provided module loads | (already works) |
+| `missing_dep` | `Could not find <X>`, X is another dist | install X (dep sweep) — **not a mutsu bug** |
+| `parse_error` | `===SORRY!===` / `Confused` / parse failure | parser fix |
+| `runtime_error` | other non-zero exit / load-time exception | a general mutsu bug |
+| `panic` | Rust panic | VM/interpreter bug (**top priority**) |
+| `timeout` | exceeded the per-module timeout | hang / perf bug |
+| `skip_guts` / `skip_native` | carries a guts / NativeCall signal | separate axes (guts survey / NativeCall) |
+
+## Latest run — n=60, seed 42 (2026-07-19, sandboxed via bwrap)
+
+| Bucket | Count | % of 60 | % of executed pure (48) |
+|---|---|---|---|
+| `load_ok` | 15 | 25% | 31% |
+| `missing_dep` | 17 | 28% | 35% |
+| `parse_error` | 7 | 12% | 15% |
+| `runtime_error` | 9 | 15% | 19% |
+| `skip_guts` | 5 | 8% | — |
+| `skip_native` | 6 | 10% | — |
+| `no_provides` | 1 | 2% | — |
+
+**Executed pure dists = 48** (60 − 5 guts − 6 native − 1 no-provides). Of the
+**31** whose deps are satisfiable (48 − 17 missing_dep), **15 load (48%)** and
+**16 hit a real mutsu bug (52%)**. Those 16 are the actionable frontier below.
+
+## ★ Actionable — real mutsu bugs (parse_error + runtime_error)
+
+Grouped by root cause; a message hit by more than one dist is high-leverage.
+**Before fixing:** reduce to a minimal repro from the dist source, fix generally,
+add a `t/` pin, then re-check with `--only <Dist>`. (Same workflow as the mzef
+pipeline.)
+
+### Recurring (multiple dists — fix first)
+
+| Root cause | Dists | Notes |
+|---|---|---|
+| `Assignment operators inside ?? !! are too loose; parenthesize them` | **Web::App** (Web::Request::Multipart), **RakuAST::Utils** | mutsu rejects an assignment inside a ternary branch that raku accepts. Related trap: memory `and-ternary-precedence-trap`. Highest-leverage single fix in this run. |
+| `expected statement: expected expected statement…` (generic parse dead-end) | **Geo::Ellipsoid**, **CSS::Grammar**, **PDF::Combiner**, **Ecosystem::Archive**, **Taurus::CLI** | Not one bug — each needs its own minimal repro. **Also a cosmetic bug in the error itself**: the message doubles "expected expected" — worth fixing in the parse-error formatter. |
+
+### Singletons
+
+| Dist | Bucket | Root cause |
+|---|---|---|
+| Code::Coverable | runtime | `Unexpected block in infix position (missing statement control word…)` |
+| Abbreviations | parse | `Confused. Two terms in a row across lines (missing semicolon or comma?)` |
+| JavaScript::Google::Charts | runtime | `Cannot declare individual multi candidates in 'our' scope` |
+| Data::Dump | parse | `Malformed double closure; WhateverCode is already a closure…` |
+| Business::CreditCard | parse | `X::Syntax::CannotMeta: Cannot negate * because it is not iffy enough` |
+| VERS | runtime | `X::Undeclared::Symbols: Undeclared routine` (load-time) |
+| CSV-AutoClass | runtime | `Variable '$argstr' is not declared` (likely a signature/placeholder gap) |
+| JSON::RepositoryEvent | runtime | `An exception occurred while evaluating a CHECK` |
+| shorten-sub-commands | runtime | `Could not find as-cli-arguments` — self-provides / export resolution |
+
+## missing_dep — reachable once deps are present (not mutsu bugs)
+
+These fail only because a dependency dist is not on the path. Re-run with
+`--site-repo` after `mzef install`-ing the dep to get a real verdict. The dep is
+worth noting: a dep hit by many dists (e.g. **XML**, **Terminal::ANSI\***) is
+itself a high-value bundle/compat target.
+
+| Dist | Missing dep |
+|---|---|
+| deredere | HTTP::UserAgent |
+| HTML::Parser | XML |
+| File::Temp | File::Directory::Tree |
+| DB::Xoos::MySQL | DB::MySQL |
+| cro | File::Ignore |
+| Qwiratry::Location::HTTP | HTTP::Tiny |
+| Anolis | Terminal::ANSIParser |
+| Version::Conan | Version::Semverish |
+| FastCGI::NativeCall::Async | FastCGI::NativeCall |
+| Chatnik | LLM::Functions |
+| LLM::Prompts | XDG::BaseDirectory |
+| Stomp | Concurrent::Iterator |
+| Grammar::Message | Terminal::ANSIColor |
+| XML::Query | XML |
+| Net::Ethereum | Node::Ethereum::Keccak256::Native |
+| Printing::Jdf | XML |
+| Cro::HTTP::BodyParser::JSONClass | Cro::BodyParser |
+
+**Repeated deps** (candidate bundle / compat targets): `XML` (×3), `Terminal::*`
+(×2), `HTTP::Tiny` / `HTTP::UserAgent` (HTTP client — the known batteries gap).
+
+## load_ok — proven to load on mutsu (n=60, seed 42)
+
+App::FIT2GPX · App::SudokuHelper · Concurrent::Progress · CSV::Parser ·
+File::Copy · File::Find · ForwardIterables · HexDump::Tiny · HTTP::HPACK ·
+List::MoreUtils · List::Util · Modf · Staticish · Test::Builder · Test::Time
+
+(Load-only; not a claim their test suites pass.)
+
+## Planned deepenings
+
+1. **Level 2 — run each dist's own test suite** (not just `use`): after
+   `load_ok`, run `t/`/`.rakutest` under mutsu with deps installed. This catches
+   runtime (not just load) divergence and is the truer "runs on mutsu" measure.
+2. **Dep-closure sweep**: `mzef install` each sampled dist into a shared throwaway
+   HOME so `missing_dep` collapses and second-order bugs (deps that themselves
+   fail) surface.
+3. **Widen the sample / track over time**: re-run at larger `--n`, record the
+   bucket counts here per date to watch the load_ok rate climb as fixes land.

--- a/scripts/dist-compat-sweep.py
+++ b/scripts/dist-compat-sweep.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+dist-compat-sweep.py — actually RUN real fez-ecosystem distributions under mutsu
+and record, per dist, whether they load and why they fail.
+
+This is the execution counterpart to scripts/ecosystem-guts-survey.py. That tool
+only *signal-scans* sources ("pure_raku" = "not guts-blocked", explicitly NOT
+"runs on mutsu"). This tool downloads each dist, points mutsu at its own lib, and
+tries to `use` every module the dist `provides`, bucketing the outcome by root
+cause. The result feeds the live dashboard docs/dist-compat-sweep.md.
+
+Method, per sampled dist:
+  1. Read the local fez index (~/.zef/store/fez/fez.json — the same one mzef uses),
+     keep the latest version of each dist, draw a fixed-seed random sample.
+  2. Download the tarball from the fez CDN (cached under CACHE_DIR), extract it.
+  3. Read META6.json `provides` (Module::Name -> source path). Skip dists whose
+     sources carry a compiler-guts / NativeCall signal (a separate axis; see the
+     guts survey) unless --include-guts / --include-native.
+  4. For each provided module run:  mutsu -I <dist>/lib [-I <extra>...] -e 'use M'
+     with a timeout, and classify the FIRST failure:
+
+  Bucket        Meaning                                    Reachable by
+  ------------  -----------------------------------------  ----------------------
+  load_ok       every provided module loads                (already works)
+  missing_dep   `Could not find <X>` where X != this dist  install X first / dep sweep
+  parse_error   ===SORRY!=== / Confused / parse failure    parser fix
+  panic         Rust panic (thread '...' panicked)         VM/interpreter bug (top prio)
+  timeout       exceeded --timeout                          hang / perf bug
+  runtime_error any other non-zero exit                    a general mutsu bug
+
+`missing_dep` is real signal, not a mutsu bug: it says "reachable once its deps
+are present". Re-run with --site-repo pointing at a HOME whose site repo has the
+deps installed (e.g. after `mzef install`) to collapse those into load_ok/other.
+
+Usage:
+  scripts/dist-compat-sweep.py [--n N] [--seed S] [--timeout SEC]
+                               [--include-guts] [--include-native]
+                               [--site-repo DIR] [--extra-lib DIR]...
+                               [--tsv PATH] [--only NAME]...
+Output: a per-dist TSV (default tmp/dist-compat-sweep.tsv) + a summary + a
+markdown table block to paste into docs/dist-compat-sweep.md.
+
+Env: MUTSU_BIN (default target/release/mutsu).
+"""
+import argparse, collections, io, json, os, re, shutil, subprocess, sys, tarfile
+import tempfile, urllib.request
+
+FEZ_INDEX = os.path.expanduser("~/.zef/store/fez/fez.json")
+FEZ_CDN = "https://360.zef.pm/"
+CACHE_DIR = os.path.expanduser("~/.cache/mutsu-dist-sweep")
+
+DEEP = re.compile(
+    r"QAST|Metamodel::Primitives|NQPHLL|:from<NQP>|EXPORTHOW|define_slang|"
+    r"package_declarator:sym|use\s+experimental\s*:\s*macro|Slang::"
+)
+NATIVE = re.compile(r"\buse\s+NativeCall\b|:from<C>|\bis\s+native\b")
+SRC_RE = re.compile(r"\.(rakumod|pm6|pm|raku|rakutest|t)$")
+
+
+def version_key(v):
+    return [(0, int(x)) if x.isdigit() else (1, x) for x in re.split(r"[.\-+]", str(v))]
+
+
+def sandbox_wrap(cmd, root, sbx_home, mem_kb=6_000_000, nproc=400):
+    """Wrap `cmd` so untrusted dist code runs with NO network, a read-only
+    filesystem, an isolated throwaway HOME, its own PID namespace, and rlimits.
+    `sbx_home` must be an existing dir (a fresh tmpfs is mounted over it, so
+    nothing the code writes ever reaches the host). Requires bubblewrap (bwrap).
+
+    NOTE: `use <module>` executes arbitrary BEGIN/CHECK phasers and load-time
+    code from a real ecosystem dist — this is arbitrary code execution, hence
+    the sandbox. Download/extract happen OUTSIDE the sandbox (in Python); only
+    the mutsu run is confined, and it needs no network.
+    """
+    return [
+        "bwrap",
+        "--unshare-all",              # user+net+pid+ipc+uts+cgroup+mount (net = offline)
+        "--ro-bind", "/", "/",        # whole rootfs, read-only
+        "--dev", "/dev",
+        "--proc", "/proc",
+        "--tmpfs", "/run",
+        "--tmpfs", sbx_home,          # writable throwaway HOME (tmpfs over existing dir)
+        "--setenv", "HOME", sbx_home,
+        "--chdir", root,
+        "--die-with-parent",
+        "--new-session",
+        "bash", "-c", f"ulimit -v {mem_kb} -u {nproc} 2>/dev/null; exec \"$@\"", "_",
+    ] + cmd
+
+
+def have_bwrap():
+    return shutil.which("bwrap") is not None
+
+
+def load_index():
+    if not os.path.exists(FEZ_INDEX):
+        sys.exit(f"missing {FEZ_INDEX} — run an mzef/zef ecosystem op first")
+    best = {}
+    for m in json.load(open(FEZ_INDEX)):
+        if isinstance(m, dict) and m.get("name") and m.get("path"):
+            n = m["name"]
+            if n not in best or version_key(m.get("version", "0")) > version_key(
+                best[n].get("version", "0")
+            ):
+                best[n] = m
+    return best
+
+
+def fetch_tarball(meta):
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    cache = os.path.join(CACHE_DIR, meta["path"].replace("/", "_"))
+    if not os.path.exists(cache):
+        data = urllib.request.urlopen(FEZ_CDN + meta["path"], timeout=60).read()
+        with open(cache, "wb") as f:
+            f.write(data)
+    return cache
+
+
+def classify(module, dist_name, rc, out):
+    if rc == -9 or "SWEEP-TIMEOUT" in out:
+        return "timeout", "timed out"
+    if "panicked" in out or "RUST_BACKTRACE" in out:
+        first = next((l for l in out.splitlines() if "panicked" in l), out[:200])
+        return "panic", first.strip()
+    m = re.search(r"Could not find ([\w:]+) in", out)
+    if m and m.group(1) != dist_name and m.group(1) != module:
+        return "missing_dep", m.group(1)
+    if m:  # could not find the dist's own module — packaging/name mismatch
+        return "runtime_error", f"self-module not found: {m.group(1)}"
+    if "===SORRY!===" in out or "Confused" in out or "Unable to parse" in out:
+        first = next(
+            (l for l in out.splitlines() if l.strip() and "SORRY" not in l), ""
+        )
+        return "parse_error", first.strip()[:200]
+    if rc == 0:
+        return "load_ok", ""
+    first = next((l for l in out.splitlines() if l.strip()), "")
+    return "runtime_error", first.strip()[:200]
+
+
+def sweep_dist(name, meta, mutsu, extra_libs, timeout, include_guts, include_native,
+               sandbox):
+    try:
+        tar_path = fetch_tarball(meta)
+    except Exception as e:
+        return [(name, "?", "fetch_fail", str(e)[:120], "?")]
+    tmp = tempfile.mkdtemp(prefix="sweep-")
+    try:
+        with tarfile.open(tar_path) as tf:
+            tf.extractall(tmp, filter="data")
+        # dist root = the single top dir, or tmp itself
+        entries = [os.path.join(tmp, e) for e in os.listdir(tmp)]
+        roots = [e for e in entries if os.path.isdir(e)]
+        root = roots[0] if len(roots) == 1 and not os.path.exists(
+            os.path.join(tmp, "META6.json")
+        ) else tmp
+        meta6 = os.path.join(root, "META6.json")
+        if not os.path.exists(meta6):
+            return [(name, "?", "no_meta6", "no META6.json", "?")]
+        m6 = json.load(open(meta6))
+        provides = m6.get("provides", {})
+        if not provides:
+            return [(name, "?", "no_provides", "empty provides", "?")]
+
+        # signal-scan for guts/native (skip unless asked)
+        src = ""
+        for dirpath, _, files in os.walk(root):
+            for f in files:
+                if SRC_RE.search(f):
+                    try:
+                        src += open(os.path.join(dirpath, f), encoding="utf8",
+                                    errors="ignore").read()
+                    except Exception:
+                        pass
+        if DEEP.search(src) and not include_guts:
+            return [(name, m6.get("version", "?"), "skip_guts", "deep_guts signal", "guts")]
+        if NATIVE.search(src) and not include_native:
+            return [(name, m6.get("version", "?"), "skip_native", "nativecall signal", "native")]
+        axis = "guts" if DEEP.search(src) else ("native" if NATIVE.search(src) else "pure")
+
+        libs = ["-I", os.path.join(root, "lib")]
+        for e in extra_libs:
+            libs += ["-I", e]
+        sbx_home = os.path.join(tmp, "sbxhome")
+        os.makedirs(sbx_home, exist_ok=True)
+        rows = []
+        for module in sorted(provides):
+            base = [mutsu] + libs + ["-e", f"use {module}"]
+            cmd = sandbox_wrap(base, root, sbx_home) if sandbox else base
+            try:
+                p = subprocess.run(cmd, capture_output=True, text=True,
+                                   timeout=timeout, cwd=root)
+                out = (p.stdout + p.stderr)
+                bucket, detail = classify(module, name, p.returncode, out)
+            except subprocess.TimeoutExpired:
+                bucket, detail = "timeout", "timed out"
+            rows.append((name, m6.get("version", "?"), bucket, f"{module}: {detail}"
+                         if detail else module, axis))
+            if bucket != "load_ok":
+                break  # first failure represents the dist
+        return rows
+    finally:
+        subprocess.run(["rm", "-rf", tmp])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=100)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--timeout", type=int, default=25)
+    ap.add_argument("--include-guts", action="store_true")
+    ap.add_argument("--include-native", action="store_true")
+    ap.add_argument("--site-repo", help="a HOME dir whose site repo has deps installed")
+    ap.add_argument("--extra-lib", action="append", default=[])
+    ap.add_argument("--only", action="append", default=[], help="sweep just these dists")
+    ap.add_argument("--tsv", default="tmp/dist-compat-sweep.tsv")
+    ap.add_argument("--sandbox", choices=["auto", "bwrap", "none"], default="auto",
+                    help="confine each dist run (default auto = bwrap if present). "
+                         "'none' runs untrusted dist code UNSANDBOXED — avoid.")
+    args = ap.parse_args()
+
+    sandbox = args.sandbox != "none"
+    if sandbox and not have_bwrap():
+        if args.sandbox == "bwrap":
+            sys.exit("bwrap not found; install bubblewrap or pass --sandbox none")
+        print("warning: bwrap not found — running WITHOUT a sandbox (untrusted "
+              "dist code executes unconfined). Install bubblewrap.", file=sys.stderr)
+        sandbox = False
+    print(f"sandbox: {'bwrap (no net, ro-fs, throwaway HOME)' if sandbox else 'NONE'}",
+          file=sys.stderr)
+
+    mutsu = os.environ.get("MUTSU_BIN", "target/release/mutsu")
+    if not os.path.exists(mutsu):
+        sys.exit(f"mutsu binary not found: {mutsu} (build it or set MUTSU_BIN)")
+    mutsu = os.path.abspath(mutsu)  # runs are cwd'd into each dist root
+
+    extra_libs = [os.path.abspath(e) for e in args.extra_lib]
+    env_home = None
+    if args.site_repo:
+        env_home = os.path.abspath(args.site_repo)
+        os.environ["HOME"] = env_home  # so mutsu's default site repo resolves there
+
+    best = load_index()
+    if args.only:
+        sample = [n for n in args.only if n in best]
+        missing = [n for n in args.only if n not in best]
+        for n in missing:
+            print(f"warning: {n} not in index", file=sys.stderr)
+    else:
+        import random
+        names = sorted(best)
+        random.seed(args.seed)
+        sample = random.sample(names, min(args.n, len(names)))
+
+    os.makedirs(os.path.dirname(args.tsv) or ".", exist_ok=True)
+    cat = collections.Counter()
+    all_rows = []
+    for i, n in enumerate(sample, 1):
+        rows = sweep_dist(n, best[n], mutsu, extra_libs, args.timeout,
+                          args.include_guts, args.include_native, sandbox)
+        final = rows[-1]  # last row = first-failure or final load_ok
+        cat[final[2]] += 1
+        all_rows.extend(rows)
+        print(f"[{i}/{len(sample)}] {n:40} -> {final[2]}  {final[3][:70]}",
+              file=sys.stderr)
+
+    with open(args.tsv, "w") as f:
+        f.write("dist\tversion\tbucket\tdetail\taxis\n")
+        for r in all_rows:
+            f.write("\t".join(str(x) for x in r) + "\n")
+
+    print(f"\n=== dist-compat-sweep: {len(sample)} dists (seed {args.seed}) ===")
+    order = ["load_ok", "missing_dep", "parse_error", "runtime_error", "panic",
+             "timeout", "skip_guts", "skip_native", "no_meta6", "no_provides",
+             "fetch_fail"]
+    for k in order:
+        if cat[k]:
+            print(f"  {k:14} {cat[k]:3}  {100*cat[k]/len(sample):.0f}%")
+    print(f"\nTSV: {args.tsv}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a **systematic, dashboard-driven "does it actually run on mutsu?" ledger** for real fez-ecosystem distributions — the missing piece the user asked for (a BLOCKERS.md-style dashboard for the 実 dist 互換 sweep).

This is the **execution** counterpart of `docs/ecosystem-guts-dependency-survey.md`, which only *signal-scans* sources (it proves "not compiler-guts blocked", explicitly **not** "runs on mutsu"). This sweep downloads each dist, points mutsu at its own `lib`, and tries to `use` every provided module, bucketing the outcome by root cause.

## Sandbox (safety)

`use <module>` on a real dist **executes arbitrary load-time code** (BEGIN/CHECK phasers), so running it unconfined on a dev machine is unsafe. Every mutsu run is confined in **bubblewrap (`bwrap`)** by default:

- **No network** (`--unshare-all` = empty network namespace; `curl` inside exits 6)
- **Read-only rootfs** (`--ro-bind / /`; `spurt` outside HOME → `os error 30`)
- **Throwaway tmpfs HOME**, own **PID namespace** + `--die-with-parent`, and `ulimit` address-space/process caps

Download/extract happen **outside** the sandbox (in Python); only the network-free mutsu run is confined. `--sandbox none` opts out (discouraged).

## First run findings (n=60, seed 42)

Of the pure-Raku, dep-satisfiable dists, **~half load and ~half hit a real mutsu parse/runtime bug on `use` alone** — so real-dist compat (not roast) is the productive frontier for widening the batteries base (PLAN §1 B4).

Top recurring blocker: `Assignment operators inside ?? !! are too loose` (2 dists: Web::App, RakuAST::Utils).

## Files

- `scripts/dist-compat-sweep.py` — the sweep tool (sandboxed)
- `docs/dist-compat-sweep.md` — the live dashboard (buckets, actionable bugs by root cause, missing-dep chain, proven-loading dists, planned Level-2 test-suite deepening)
- `PLAN.md` §1 B4 — links the dashboard as the systematic real-dist compat frontier

No Rust changes; docs + tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)