### PR TITLE
fix: parenthesized accessor-lvalue assignment is legal in a ternary branch

### DIFF
--- a/src/parser/primary/container/paren.rs
+++ b/src/parser/primary/container/paren.rs
@@ -274,7 +274,19 @@ fn paren_expr_inner(input: &str) -> PResult<'_, Expr> {
             // wrapper is transparent everywhere else (consumers unwrap it, incl.
             // the for-loop rw-source detection). `@`/`%` vars are NOT wrapped.
             || matches!(&result, Expr::Var(_))
-        {
+            // A parenthesized ASSIGNMENT with a non-variable lvalue (a method /
+            // attribute-accessor LHS like `$.value = x` or `$.value ~= x`) reaches
+            // this fall-through because `try_parse_assign_expr` only handles
+            // `$`/`@`/`%` names, not `$.foo`. Wrap it so it matches the scalar path
+            // (which already yields `Grouped(AssignExpr)`): the parens make the
+            // assignment tight, so `cond ?? a !! ($.value = x)` is legal and must
+            // NOT trip the ternary "assignment too loose" guard.
+            || matches!(
+                &result,
+                Expr::AssignExpr { .. }
+                    | Expr::IndexAssign { .. }
+                    | Expr::MultiDimIndexAssign { .. }
+            ) {
             Expr::Grouped(Box::new(result))
         } else {
             result

--- a/t/ternary-paren-accessor-assign.t
+++ b/t/ternary-paren-accessor-assign.t
@@ -1,0 +1,62 @@
+use v6;
+use Test;
+
+# A parenthesized assignment is TIGHT, so it is legal in a ternary branch:
+#   cond ?? a !! ($x = y)
+# mutsu used to wrap only `$`/`@`/`%`-named lvalues in the transparent `Grouped`
+# node, so a method / attribute-accessor lvalue (`$.value = ...`, `$.value ~= ...`)
+# fell through as a BARE AssignExpr and tripped the ternary "Assignment operators
+# inside ?? !! are too loose" guard, even though the parens make it tight. Found
+# via the real-dist compat sweep (Web::App's Web::Request::Multipart and
+# RakuAST::Utils both hit it). See docs/dist-compat-sweep.md.
+
+plan 5;
+
+# --- simple assignment to an accessor lvalue in the else-branch ---
+{
+    my class C {
+        has $.value is rw;
+        method set-if($flag, $v) { $flag ?? 'skipped' !! ($.value = $v) }
+    }
+    my $c = C.new;
+    $c.set-if(False, 42);
+    is $c.value, 42, 'accessor `= ` in !! branch runs when cond is false';
+
+    my $c2 = C.new(value => 7);
+    $c2.set-if(True, 99);
+    is $c2.value, 7, 'accessor `= ` in !! branch is skipped when cond is true';
+}
+
+# --- compound assignment (~=) to an accessor lvalue, multi-line (the dist shape) ---
+{
+    my class M {
+        has $.value is rw = '';
+        method feed($done, $line) {
+            $done
+              ?? 'done'
+              !! ($.value ~= $line);
+        }
+    }
+    my $m = M.new;
+    $m.feed(False, 'a');
+    $m.feed(False, 'b');
+    is $m.value, 'ab', 'accessor `~=` in multi-line !! branch appends';
+}
+
+# --- accessor assignment in the then-branch too ---
+{
+    my class T {
+        has $.value is rw = 0;
+        method go($flag) { $flag ?? ($.value = 1) !! ($.value = 2) }
+    }
+    my $t = T.new;
+    $t.go(True);
+    is $t.value, 1, 'accessor `=` in ?? branch runs when cond is true';
+}
+
+# --- regression: parenthesized scalar stays a list-assignment target ---
+{
+    my $a;
+    ($a) = 1, 2, 3;
+    is $a.raku, '$(1, 2, 3)', 'parenthesized scalar still slurps the list (Grouped preserved)';
+}


### PR DESCRIPTION
## Problem

`cond ?? a !! ($.value = x)` (also `~=`, `+=`, …) failed to parse:

```
Assignment operators inside ?? !! are too loose; parenthesize them
```

— even though the assignment **is** parenthesized. A parenthesized assignment is tight, so raku accepts it in a ternary branch.

## Root cause

The paren parser wraps assignments in the transparent `Grouped` node so the ternary guard (`is_assignment_expr`, which matches only a **bare** `AssignExpr`) treats them as tight. `try_parse_assign_expr` produces `Grouped(AssignExpr)` for `$`/`@`/`%`-named lvalues, but it does **not** recognise a method / attribute-accessor LHS (`$.value`), so that case fell through to the general paren path and emerged as a **bare** `AssignExpr` — tripping the guard.

`($v = x)` → `Grouped(AssignExpr)` (OK) vs `($.value = x)` → bare `AssignExpr` (false positive).

## Fix

Wrap `AssignExpr`/`IndexAssign`/`MultiDimIndexAssign` reaching the paren fall-through in `Grouped` too, matching the scalar path exactly. The wrapper is transparent everywhere else (consumers already unwrap it, since the scalar path has always produced it).

## Found via the real-distribution compat sweep

This was the **top recurring blocker** in the first `docs/dist-compat-sweep.md` run, hit by **Web::App** (`Web::Request::Multipart`) and **RakuAST::Utils**. Both modules load after this fix.

Pin: `t/ternary-paren-accessor-assign.t` — covers `=`/`~=` in the else- and then-branch, plus the `($a) = 1,2,3` list-assign-target regression. Parser unit tests (346) and the `t/*ternary*`/`t/*paren*`/`t/*assign*` suites (~197+552 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)