### PR TITLE
fix: a trailing comma in a `for` statement modifier builds a 1-element list

### DIFF
--- a/src/parser/stmt/modifier.rs
+++ b/src/parser/stmt/modifier.rs
@@ -395,6 +395,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
         let (r, iterable) = {
             let mut items = vec![first];
             let mut r = r;
+            let mut trailing_comma = false;
             loop {
                 let (r2, _) = ws(r)?;
                 if !r2.starts_with(',') {
@@ -404,13 +405,17 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
                 let (r2, _) = ws(r2)?;
                 if r2.is_empty() || r2.starts_with('}') || r2.starts_with(';') {
                     r = r2;
+                    trailing_comma = true;
                     break;
                 }
                 let (r2, next) = expression(r2)?;
                 items.push(next);
                 r = r2;
             }
-            if items.len() == 1 {
+            // A trailing comma builds a 1-element list even with a single item:
+            // `for @a,` iterates once over `(@a,)` (the array itemized), matching
+            // the parenthesized `for (@a,)` form, rather than flattening `@a`.
+            if items.len() == 1 && !trailing_comma {
                 (r, items.into_iter().next().unwrap())
             } else {
                 (r, Expr::ArrayLiteral(items))

--- a/t/for-modifier-trailing-comma.t
+++ b/t/for-modifier-trailing-comma.t
@@ -1,0 +1,57 @@
+use v6;
+use Test;
+
+# A trailing comma in a `for` statement modifier builds a 1-element list,
+# so `.say for @a,` iterates once over `(@a,)` (the array itemized) rather
+# than flattening `@a` into its elements. This matches the parenthesized
+# `for (@a,)` form.
+
+plan 7;
+
+# Single array with trailing comma -> one iteration over the whole array.
+{
+    my @a = 1, 2;
+    my @seen;
+    @seen.push($_.raku) for @a,;
+    is @seen.elems, 1, 'for @a, iterates once';
+    is @seen[0], '[1, 2]', 'topic is the whole array, itemized';
+}
+
+# Without the trailing comma the array flattens (two iterations).
+{
+    my @a = 1, 2;
+    my @seen;
+    @seen.push($_) for @a;
+    is @seen.elems, 2, 'for @a flattens (two iterations)';
+}
+
+# Scalar with trailing comma is still a single iteration.
+{
+    my @seen;
+    @seen.push($_) for 5,;
+    is-deeply @seen, [5], 'for 5, iterates once over (5,)';
+}
+
+# A trailing comma after a full list does not add an extra iteration.
+{
+    my @seen;
+    @seen.push($_) for 1, 2,;
+    is-deeply @seen, [1, 2], 'for 1, 2, iterates over both elements';
+}
+
+# Multiple arrays each iterated as itemized elements.
+{
+    my @a = 1, 2;
+    my @b = 3, 4;
+    my @seen;
+    @seen.push($_.raku) for @a, @b;
+    is-deeply @seen, ['[1, 2]', '[3, 4]'], 'for @a, @b keeps each array whole';
+}
+
+# A hash with a trailing comma iterates once over the whole hash.
+{
+    my %h = a => 1;
+    my $count = 0;
+    $count++ for %h,;
+    is $count, 1, 'for %h, iterates once over the whole hash';
+}


### PR DESCRIPTION
## Problem

`.say for @a,` should iterate once over `(@a,)` — the array `@a` itemized into a single-element list — and print `[1 2]`, matching the parenthesized `for (@a,)` form. Instead mutsu flattened `@a` and printed `1\n2`.

```
$ raku  -e 'my @a=1,2; .say for @a,;'
[1 2]
$ mutsu -e 'my @a=1,2; .say for @a,;'
1
2
```

The statement-modifier `for` parser (`src/parser/stmt/modifier.rs`) dropped a trailing comma entirely: when the loop consumed a `,` and found a terminator, it broke without recording that a comma was seen, so a single item was returned bare (`ArrayVar("a")`) — indistinguishable from `for @a`.

## Fix

Track whether a comma was consumed and force an `ArrayLiteral` (a 1-element list) when a trailing comma is present, even for a single item. This produces the same AST as the already-correct `for (@a,)` form.

Scalar cases (`for 5,`) are unaffected — `(5,)` still iterates once over `5`. Full lists with a trailing comma (`for 1, 2,`) were already handled.

## Test

Pin `t/for-modifier-trailing-comma.t` (7 assertions, matches reference raku). `make test` passes.

Surfaced by the doc-diff harness (PLAN.md §8) on `raku-doc/doc/Language/list.rakudoc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)