### PR TITLE
fix: dividing a Rat by a BigInt uses exact big-rational arithmetic

### DIFF
--- a/src/builtins/arith/mul_div_mod.rs
+++ b/src/builtins/arith/mul_div_mod.rs
@@ -140,7 +140,17 @@ pub(crate) fn arith_div(left: Value, right: Value) -> Result<Value, RuntimeError
         let has_fat_rat = is_fat_rat_like(&l) || is_fat_rat_like(&r);
         let has_big_rat = matches!(l.view(), ValueView::BigRat(_, _))
             || matches!(r.view(), ValueView::BigRat(_, _));
-        if (has_fat_rat || has_big_rat)
+        // A plain (i64-based) Rat divided by a BigInt (a value that does not fit
+        // in i64) also needs the exact big-rational path: the i64 rat_div_checked
+        // below cannot represent the operand, and to_rat_parts of the BigInt
+        // returns None, so without this the pair falls through to `Value::int(0)`.
+        // make_big_rat_arith degrades to Num when the denominator exceeds u64,
+        // matching Rakudo (`42.5 / 9999999999999999999` is `4.25e-18`, a Num).
+        let rat_over_bigint = (matches!(l.view(), ValueView::Rat(_, _))
+            && matches!(r.view(), ValueView::BigInt(_)))
+            || (matches!(l.view(), ValueView::BigInt(_))
+                && matches!(r.view(), ValueView::Rat(_, _)));
+        if (has_fat_rat || has_big_rat || rat_over_bigint)
             && let (Some((an, ad)), Some((bn, bd))) = (to_big_rat_parts(&l), to_big_rat_parts(&r))
         {
             let result = if has_fat_rat {

--- a/t/rat-div-bigint.t
+++ b/t/rat-div-bigint.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+# Dividing a Rat by a BigInt (an integer literal that does not fit in a 64-bit
+# int) must use exact big-rational arithmetic, degrading to Num when the
+# resulting denominator exceeds uint64 — matching Rakudo. Previously mutsu fell
+# through to a `0` (Int) result because neither the i64 Rat path nor the
+# BigInt-integer path handled the mixed Rat/BigInt pair.
+
+plan 8;
+
+# Denominator overflows uint64 -> degrade to Num (Rakudo gives 4.25e-18).
+is (42.5 / 9999999999999999999).^name, 'Num', 'Rat / BigInt overflows to Num';
+is-approx (42.5 / 9999999999999999999), 4.25e-18, 'Rat / BigInt value is correct';
+
+# Written as an explicit ratio, same result.
+is (85 / 2 / 9999999999999999999).^name, 'Num', '85/2 / BigInt is Num';
+
+# BigInt / Rat keeps a representable Rat (denominator 85 fits).
+is (9999999999999999999 / 42.5).^name, 'Rat', 'BigInt / Rat stays Rat';
+is (9999999999999999999 / 42.5), 235294117647058823.505882, 'BigInt / Rat value';
+
+# Denominator still fits uint64 after reduction -> stays an exact Rat.
+is (42.5 / 10000000000000000000).^name, 'Rat', 'Rat / BigInt within uint64 stays Rat';
+
+# The result is never a bare Int 0.
+isnt (42.5 / 9999999999999999999), 0, 'result is not truncated to 0';
+
+# Multiplication with a BigInt was already exact and stays a Rat.
+is (42.5 * 9999999999999999999).^name, 'Rat', 'Rat * BigInt stays Rat';


### PR DESCRIPTION
## Problem

Dividing a `Rat` by a large integer literal (one that exceeds i64 range, stored internally as a `BigInt`) returned `0` as an `Int` instead of the correct rational/Num result:

```
$ raku  -e 'say (42.5 / 9999999999999999999); say (42.5 / 9999999999999999999).^name'
4.25e-18
Num
$ mutsu -e 'say (42.5 / 9999999999999999999); say (42.5 / 9999999999999999999).^name'
0
Int
```

In `arith_div`, a `Rat`/`BigInt` pair is neither a fat/big-rat (so it skips the big-rational path) nor representable by the i64 `rat_div_checked` (`to_rat_parts` of the BigInt returns `None`), so it fell through to the `_ => Value::int(0)` arm.

## Fix

Route a plain (i64-based) `Rat` divided by a `BigInt` (in either operand order) through `make_big_rat_arith`, which reduces exactly and degrades to `Num` when the denominator exceeds uint64 — matching Rakudo. `FatRat`/`BigRat` operands already took the big-rational path; only the plain-`Rat`/`BigInt` pair was unhandled. Multiplication, addition, subtraction, and modulo were already correct for this operand mix.

## Test

Pin `t/rat-div-bigint.t` (8 assertions, matches reference raku). Whitelisted numeric roast tests (`S02-types/num.t`, `S02-types/fatrat.t`, `S03-operators/arith.t`, `S32-num/rat.t`) still pass.

Surfaced by the doc-diff harness (PLAN.md §8) on `raku-doc/doc/Language/numerics.rakudoc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)