### PR TITLE
fix: a `*`-argument inside a where-block is not a malformed double closure

### DIFF
--- a/src/parser/stmt/sub_param/where_constraint.rs
+++ b/src/parser/stmt/sub_param/where_constraint.rs
@@ -9,7 +9,7 @@ pub(crate) fn parse_where_constraint_expr(input: &str) -> PResult<'_, Expr> {
     let (r, _) = ws(input)?;
     if r.starts_with('{') {
         let (r, body) = crate::parser::primary::parse_block_body(r)?;
-        if stmts_contain_whatever(&body) {
+        if stmts_lead_with_whatever(&body) {
             return Err(malformed_double_closure_error());
         }
         return Ok((
@@ -105,146 +105,76 @@ pub(crate) fn reject_placeholder_or_twigil_param(input: &str) -> Result<(), PErr
     Err(PError::fatal_with_exception(msg, Box::new(ex)))
 }
 
-pub(crate) fn stmts_contain_whatever(stmts: &[Stmt]) -> bool {
-    stmts.iter().any(stmt_contains_whatever)
+/// A `{ ... }` where-constraint is a "malformed double closure" only when its
+/// body would itself curry into a WhateverCode — i.e. when the LEADING term
+/// (leftmost leaf on the left spine) of a statement is a bare `*`. A `*` nested
+/// as a call/method ARGUMENT (`{ .grep: * > 2 }`, `{ $_.map(* + 1) }`) forms its
+/// own inner WhateverCode confined to that argument and does NOT make the block a
+/// WhateverCode, so it must not trip the guard. Matches raku, which SORRYs on
+/// `{ * > 2 }` (leads with `*`) but accepts `{ $_ > * }` / `{ .grep: * > 2 }`.
+pub(crate) fn stmts_lead_with_whatever(stmts: &[Stmt]) -> bool {
+    stmts.iter().any(stmt_leads_with_whatever)
 }
 
-fn stmt_contains_whatever(stmt: &Stmt) -> bool {
+fn stmt_leads_with_whatever(stmt: &Stmt) -> bool {
     match stmt {
         Stmt::Expr(expr)
         | Stmt::Return(expr)
         | Stmt::Take(expr, _)
         | Stmt::Die(expr)
-        | Stmt::Fail(expr) => expr_contains_whatever(expr),
-        Stmt::VarDecl {
-            expr,
-            where_constraint,
-            ..
-        } => {
-            expr_contains_whatever(expr)
-                || where_constraint
-                    .as_ref()
-                    .is_some_and(|wc| expr_contains_whatever(wc))
-        }
-        Stmt::Assign { expr, .. } => expr_contains_whatever(expr),
-        Stmt::Block(body) | Stmt::SyntheticBlock(body) | Stmt::Package { body, .. } => {
-            stmts_contain_whatever(body)
-        }
-        Stmt::SubDecl { body, .. } | Stmt::TokenDecl { body, .. } | Stmt::RuleDecl { body, .. } => {
-            stmts_contain_whatever(body)
-        }
-        Stmt::Label { stmt, .. } => stmt_contains_whatever(stmt),
+        | Stmt::Fail(expr) => expr_leads_with_whatever(expr),
+        Stmt::Label { stmt, .. } => stmt_leads_with_whatever(stmt),
         _ => false,
     }
 }
 
-fn expr_contains_whatever(expr: &Expr) -> bool {
+/// Walk the LEFT spine (left operand / receiver / base) to the leftmost leaf and
+/// report whether the block *leads* with a `*`. Does NOT descend into argument
+/// lists or right operands — a `*` there is self-contained and forms its own
+/// inner WhateverCode (`{ .grep: * > 2 }`, `{ $_ > * }`).
+///
+/// Currying rewrites the leading `*` in two shapes, both handled here:
+///   `{ * > 2 }`        -> topic-param `Lambda { is_whatever_code }` (the `*` is
+///                        the standalone leading operand; always a double closure)
+///   `{ * > 2 && * < 9 }`-> `AnonSubParams { is_whatever_code, params:[__wc_N] }`
+///                        whose body's leftmost leaf is a `__wc_N` placeholder
+/// vs the accepted `{ $_ > * }`, also `AnonSubParams`, but whose leftmost leaf is
+/// the genuine `$_` (`Var("_")`), not a `__wc_N` placeholder.
+fn expr_leads_with_whatever(expr: &Expr) -> bool {
     match expr {
         Expr::Whatever | Expr::HyperWhatever => true,
-        Expr::StringInterpolation(parts)
-        | Expr::ArrayLiteral(parts)
-        | Expr::BracketArray(parts, _)
-        | Expr::CaptureLiteral(parts) => parts.iter().any(expr_contains_whatever),
-        Expr::MethodCall { target, args, .. } | Expr::HyperMethodCall { target, args, .. } => {
-            expr_contains_whatever(target) || args.iter().any(expr_contains_whatever)
-        }
-        Expr::DynamicMethodCall {
-            target,
-            name_expr,
-            args,
+        // A curried whatever placeholder reached as the leftmost leaf.
+        Expr::Var(name) if name.starts_with("__wc_") => true,
+        // Topic-param WhateverCode: only produced by a standalone leading `*`.
+        Expr::Lambda {
+            is_whatever_code: true,
             ..
-        }
-        | Expr::HyperMethodCallDynamic {
-            target,
-            name_expr,
-            args,
+        } => true,
+        // `__wc_`-param WhateverCode: descend to its body's leftmost leaf, which
+        // is a `__wc_N` placeholder iff the block actually led with `*`.
+        Expr::AnonSubParams {
+            is_whatever_code: true,
+            body,
             ..
-        } => {
-            expr_contains_whatever(target)
-                || expr_contains_whatever(name_expr)
-                || args.iter().any(expr_contains_whatever)
-        }
-        Expr::Exists { target, arg, .. } => {
-            expr_contains_whatever(target)
-                || arg
-                    .as_ref()
-                    .is_some_and(|arg_expr| expr_contains_whatever(arg_expr))
-        }
-        Expr::ZenSlice(inner)
-        | Expr::PositionalPair(inner)
-        | Expr::Eager(inner)
+        } => body.first().is_some_and(stmt_leads_with_whatever),
+        Expr::Binary { left, .. }
+        | Expr::HyperOp { left, .. }
+        | Expr::MetaOp { left, .. }
+        | Expr::InfixFunc { left, .. } => expr_leads_with_whatever(left),
+        Expr::MethodCall { target, .. }
+        | Expr::HyperMethodCall { target, .. }
+        | Expr::DynamicMethodCall { target, .. }
+        | Expr::HyperMethodCallDynamic { target, .. }
+        | Expr::CallOn { target, .. }
+        | Expr::Index { target, .. }
+        | Expr::MultiDimIndex { target, .. }
+        | Expr::HyperSlice { target, .. } => expr_leads_with_whatever(target),
+        Expr::Unary { expr: inner, .. }
+        | Expr::PostfixOp { expr: inner, .. }
         | Expr::Itemize(inner)
-        | Expr::Reduction { expr: inner, .. }
-        | Expr::IndirectTypeLookup(inner)
-        | Expr::SymbolicDeref { expr: inner, .. } => expr_contains_whatever(inner),
-        Expr::Lambda { param, body, .. } => param == "_" || stmts_contain_whatever(body),
-        Expr::AnonSubParams { params, body, .. } => {
-            params.iter().any(|p| p.starts_with("__wc_")) || stmts_contain_whatever(body)
-        }
-        Expr::Block(body) | Expr::AnonSub { body, .. } | Expr::Gather(body) => {
-            stmts_contain_whatever(body)
-        }
-        Expr::CallOn { target, args } => {
-            expr_contains_whatever(target) || args.iter().any(expr_contains_whatever)
-        }
-        Expr::Index { target, index, .. } => {
-            expr_contains_whatever(target) || expr_contains_whatever(index)
-        }
-        Expr::MultiDimIndex { target, dimensions } => {
-            expr_contains_whatever(target) || dimensions.iter().any(expr_contains_whatever)
-        }
-        Expr::MultiDimIndexAssign {
-            target,
-            dimensions,
-            value,
-        } => {
-            expr_contains_whatever(target)
-                || dimensions.iter().any(expr_contains_whatever)
-                || expr_contains_whatever(value)
-        }
-        Expr::IndexAssign {
-            target,
-            index,
-            value,
-            ..
-        } => {
-            expr_contains_whatever(target)
-                || expr_contains_whatever(index)
-                || expr_contains_whatever(value)
-        }
-        Expr::Ternary {
-            cond,
-            then_expr,
-            else_expr,
-        } => {
-            expr_contains_whatever(cond)
-                || expr_contains_whatever(then_expr)
-                || expr_contains_whatever(else_expr)
-        }
-        Expr::AssignExpr { expr, .. } => expr_contains_whatever(expr),
-        Expr::Unary { expr, .. } | Expr::PostfixOp { expr, .. } => expr_contains_whatever(expr),
-        Expr::Binary { left, right, .. }
-        | Expr::HyperOp { left, right, .. }
-        | Expr::MetaOp { left, right, .. } => {
-            expr_contains_whatever(left) || expr_contains_whatever(right)
-        }
-        Expr::Call { args, .. } => args.iter().any(expr_contains_whatever),
-        Expr::Try { body, catch } => {
-            stmts_contain_whatever(body)
-                || catch
-                    .as_ref()
-                    .is_some_and(|branch| stmts_contain_whatever(branch))
-        }
-        Expr::InfixFunc { left, right, .. } => {
-            expr_contains_whatever(left) || right.iter().any(expr_contains_whatever)
-        }
-        Expr::DoBlock { body, .. } => stmts_contain_whatever(body),
-        Expr::DoStmt(stmt) => stmt_contains_whatever(stmt),
-        Expr::IndirectCodeLookup { package, .. } => expr_contains_whatever(package),
-        Expr::Hash(pairs) => pairs
-            .iter()
-            .any(|(_, value)| value.as_ref().is_some_and(expr_contains_whatever)),
-        Expr::HyperSlice { target, .. } => expr_contains_whatever(target),
+        | Expr::Eager(inner)
+        | Expr::Reduction { expr: inner, .. } => expr_leads_with_whatever(inner),
+        Expr::Ternary { cond, .. } => expr_leads_with_whatever(cond),
         _ => false,
     }
 }

--- a/t/where-constraint-whatever-arg.t
+++ b/t/where-constraint-whatever-arg.t
@@ -1,0 +1,49 @@
+use v6;
+use Test;
+
+# A `where { ... }` block-constraint is a "malformed double closure" ONLY when the
+# block *leads* with a bare `*` (`{ * > 2 }`), which curries the whole block into a
+# WhateverCode. A `*` used as a call/method ARGUMENT inside the block
+# (`{ .grep: * > 2 }`, `{ $_ > * }`) forms its own inner WhateverCode and must NOT
+# trip the guard. mutsu used to reject any block that contained a `*` anywhere.
+# Found via the real-dist compat sweep (Data::Dump's
+# `:%overrides where { !$_.values.grep: * !~~ Sub }`). See docs/dist-compat-sweep.md.
+
+plan 6;
+
+# --- the dist shape: `*` as a grep argument inside the where block ---
+{
+    sub only-subs(:%o where { !$_.values.grep: * !~~ Sub } = {}) { 'ok' }
+    is only-subs(o => { a => sub {} }), 'ok', '`grep: *` arg in where block is accepted';
+}
+
+# --- `*` as a method-call argument; block leads with the topic method ---
+{
+    sub big(@x where { .grep: * > 2 }) { @x.elems }
+    is big([3, 4, 5]), 3, '`.grep: * > 2` arg in where block is accepted';
+}
+
+# --- `*` as the RIGHT operand (block leads with `$_`) ---
+{
+    sub gt(:$n where { $_ > * .Int - 1 }) { $n }
+    # (`$_ > *...` leads with `$_`, so the block is a normal `$_` closure)
+    ok gt(n => 5).defined, '`$_ > *` (leads with $_) is accepted';
+}
+
+# --- the constraint actually runs and constrains ---
+{
+    sub pos($x where { $_.grep(* > 0) }) { $x }
+    is pos(7), 7, 'where-block with a `*`-arg predicate enforces (pass)';
+    dies-ok { pos(-3) }, 'where-block with a `*`-arg predicate enforces (fail)';
+}
+
+# --- a genuine leading-`*` double closure is still rejected ---
+{
+    my $err = '';
+    {
+        EVAL 'sub bad($x where { * > 2 }) { }';
+        CATCH { default { $err = .message } }
+    }
+    ok $err.contains('double closure'),
+        'leading `{ * > 2 }` is still rejected as a malformed double closure';
+}


### PR DESCRIPTION
## Problem

```raku
sub f(:%o where { !$_.values.grep: * !~~ Sub } = {}) { }   # Data::Dump
sub g($x where { .grep: * > 2 }) { }
```

both failed with:

```
Malformed double closure; WhateverCode is already a closure without curlies,
so either remove the curlies or use valid parameter syntax instead of *
```

— even though raku accepts them. A `*` used as a **call/method argument** inside a `where { ... }` block forms its own inner WhateverCode confined to that argument; it does not curry the whole block. Only a block that **leads** with a bare `*` (`{ * > 2 }`) is the double closure raku SORRYs on.

## Root cause

The guard used `stmts_contain_whatever` — true if a `*` appeared **anywhere** in the block AST — so it fired on legitimate `*`-arguments.

## Fix

Replace it with `stmts_lead_with_whatever`, which walks only the **left spine** to the leftmost leaf and reports whether the block *leads* with `*`. It handles both curried shapes and does not descend into argument lists / right operands:

| block | shape | leads with `*`? | verdict |
|---|---|---|---|
| `{ * > 2 }` | topic-param `Lambda{is_whatever_code}` | yes | reject |
| `{ * > 2 && * < 9 }` | `AnonSubParams`, leftmost leaf `__wc_0` | yes | reject |
| `{ $_ > * }` | `AnonSubParams`, leftmost leaf `$_` | no | accept |
| `{ .grep: * > 2 }` | `MethodCall`, `*` in args | no | accept |

Verified against raku on all seven shapes.

## Found via the real-distribution compat sweep

`docs/dist-compat-sweep.md` — Data::Dump. Pin: `t/where-constraint-whatever-arg.t`. (Data::Dump has a separate second blocker, `Two terms in a row`, noted in the dashboard.)

Regression: parser unit tests (346) + `t/*where*`/`t/*signature*`/`t/*whatever*`/`t/*param*` (1104 tests) pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)