### PR TITLE
fix: a hyper-prefix operator can open a no-paren listop argument

### DIFF
--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -31,6 +31,24 @@ use crate::parser::stmt::keyword;
 use crate::symbol::Symbol;
 use crate::value::{Value, ValueView};
 
+/// Whether `s` starts with a hyper-prefix operator such as `+«`, `-«`, `~«`,
+/// `?«`, `!«`, `+^«`, or their ASCII `<<` forms (`+<<`, `-<<`, ...). A symbolic
+/// prefix operator immediately followed by a hyper marker (`«` / `<<`) is an
+/// unambiguous term start — the marker can never begin an infix continuation —
+/// so it may open a no-paren listop argument (`unique +«(1,2,3)`). A bare
+/// `+`/`-` is deliberately excluded: distinguishing `pi - 1` (subtraction) from
+/// a prefixed argument needs term-vs-listop knowledge unavailable at this gate.
+fn starts_hyper_prefix_op(s: &str) -> bool {
+    let rest = match s.as_bytes().first() {
+        Some(b'+') | Some(b'-') | Some(b'~') | Some(b'?') | Some(b'!') => &s[1..],
+        _ => return false,
+    };
+    // Optional bit-negation meta char (`+^«`, `~^«`, `?^«`).
+    let rest = rest.strip_prefix('^').unwrap_or(rest);
+    // `+<` alone is the numeric shift-left infix, so require the doubled `<<`.
+    rest.starts_with('\u{00AB}') || rest.starts_with("<<")
+}
+
 /// When `do STMT` parses its inner statement via the full statement parser, a
 /// statement modifier (`do $_ for @list`) or assignment consumes the trailing
 /// `;`. In expression context the `;` belongs to the *outer* statement, so if it
@@ -1528,6 +1546,12 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
             // stranding the fraction as a separate statement.
             || crate::builtins::unicode::unicode_rat_value(next).is_some()
             || crate::builtins::unicode::unicode_numeric_int_value(next).is_some()
+            // A hyper-prefix operator (`+«`, `-«`, `~«`, `+<<`, ...) is an
+            // unambiguous term start — the hyper marker can never begin an
+            // infix continuation — so `unique +«(1,2,2,3)` parses as a call.
+            // (A bare `+`/`-` is left out on purpose: `pi - 1` must stay a
+            // subtraction, which needs term-vs-listop knowledge we lack here.)
+            || starts_hyper_prefix_op(r)
             || starts_with_term_keyword(r)
             || crate::parser::stmt::simple::match_user_declared_term_symbol(r).is_some()
             || hyphen_forward_call

--- a/t/listop-hyper-prefix-arg.t
+++ b/t/listop-hyper-prefix-arg.t
@@ -1,0 +1,23 @@
+use v6;
+use Test;
+
+# A hyper-prefix operator (`+«`, `-«`, `~«`, and the ASCII `+<<` forms) is an
+# unambiguous term start, so it may open a no-paren argument to a list operator:
+# `unique +«(1,2,2,3)` parses as `unique(+«(1,2,2,3))`. Previously the general
+# listop-argument gate only recognized sigils/parens/digits and rejected the
+# leading `+`, so the whole expression failed to parse.
+
+plan 7;
+
+is-deeply unique(+«(1,2,2,3)), (1,2,3), 'paren form baseline';
+
+# No-paren forms.
+is-deeply (unique +«(1,2,2,3)), (1,2,3), 'unique +« (Unicode marker)';
+is-deeply (unique +<<(1,2,2,3)), (1,2,3), 'unique +<< (ASCII marker)';
+is-deeply (unique -«(1,-1,2)), (-1,1,-2), 'unique -« negates then dedups';
+is-deeply (unique ~«(1,2,3)), ('1','2','3'), 'unique ~« stringifies';
+
+# The narrow gate must not disturb a bare prefix/infix on a 0-ary term:
+# `pi - 1` stays a subtraction, and `+<` stays the shift-left infix.
+is (pi - 1).round(1e-6), 2.141593, 'pi - 1 is still subtraction';
+is (3 +< 2), 12, '3 +< 2 is still shift-left';


### PR DESCRIPTION
## Problem

`unique +«(1,2,2,3)` failed to parse, even though `+«(1,2,2,3)` on its own parses fine:

```
$ raku  -e 'say unique +«(1,2,2,3)'
(1 2 3)
$ mutsu -e 'say unique +«(1,2,2,3)'
===SORRY!=== Confused. expected statement ...
```

The general no-paren listop-argument gate in `identifier_call.rs` recognized sigils, parens, quotes, and digits as valid term starts, but not a leading `+`, so a hyper-prefix operator (`+«`, `-«`, `~«`, `+<<`, ...) argument was rejected.

## Fix

Add `starts_hyper_prefix_op`: a symbolic prefix operator (`+`, `-`, `~`, `?`, `!`, optionally with a `^` bit-negation meta char) immediately followed by a hyper marker (`«` U+00AB, or ASCII `<<`) is an unambiguous term start — the marker can never begin an infix continuation — so it may open a listop argument.

A bare `+`/`-` is deliberately **excluded**: `pi - 1` must stay a subtraction and `3 +< 2` must stay the shift-left infix. Distinguishing those from a prefixed argument needs term-vs-listop knowledge unavailable at this gate. (Raku does parse a bare `unique +$x` as a call, but that broader case is left as a known gap.)

## Test

Pin `t/listop-hyper-prefix-arg.t` (7 assertions, matches reference raku), including regression guards for `pi - 1` and `3 +< 2`. `make test` passes; whitelisted S03-operators tests still pass.

Surfaced by the doc-diff harness (PLAN.md §8) on `raku-doc/doc/Language/numerics.rakudoc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)