### PR TITLE
fix: a real array's Nil cells render as Any in .raku

### DIFF
--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -298,6 +298,15 @@ fn raku_hash_value(v: &Value) -> String {
 }
 
 fn raku_value_as_element(v: &Value) -> String {
+    // A real array (`@`-sigiled) element is a Scalar container, so it can never
+    // actually hold Nil: assigning Nil reverts it to the element type's default,
+    // which for an untyped array is `Any`. A freshly-declared shaped array
+    // (`my @a[2,2]`) fills its cells with Nil for the same reason, so render
+    // such a cell as `Any` rather than `Nil`. (Typed arrays store the element
+    // type object in their cells, so they never reach this branch.)
+    if v.is_nil() {
+        return "Any".to_string();
+    }
     match v.view() {
         ValueView::Array(items, kind) => {
             let decontainerized = match kind {

--- a/t/shaped-array-raku-any.t
+++ b/t/shaped-array-raku-any.t
@@ -1,0 +1,43 @@
+use v6;
+use Test;
+
+# A real array's elements are Scalar containers, so a cell can never hold Nil:
+# a freshly-declared shaped array (`my @a[2,2]`) defaults its cells to the
+# element type (`Any` for an untyped array), and assigning Nil to a real-array
+# element reverts it to that default. `.raku` must therefore render such cells
+# as `Any`, not `Nil`. Lists (which are not `@`-sigiled) still keep a real Nil.
+
+plan 6;
+
+{
+    my @a[2,2];
+    is @a.raku, 'Array.new(:shape(2, 2), [Any, Any], [Any, Any])',
+        '2D shaped array cells render as Any';
+}
+
+{
+    my @b[3];
+    is @b.raku, 'Array.new(:shape(3,), [Any, Any, Any])',
+        '1D shaped array cells render as Any';
+}
+
+{
+    my @c = 1, 2, 3;
+    @c[1] = Nil;
+    is @c.raku, '[1, Any, 3]', 'Nil assigned to a real-array element renders as Any';
+}
+
+# A typed shaped array keeps the element type object in its cells (not Any).
+# (The `Array[Int]` vs `array[Int]` prefix casing is a separate known issue,
+# so only the cell contents are asserted here.)
+{
+    my Int @d[3];
+    ok @d.raku.contains('[Int, Int, Int]'),
+        'typed shaped array cells render as the element type, not Any';
+}
+
+# A List keeps a genuine Nil (it is not an @-sigiled container).
+is (1, Nil, 3).raku, '(1, Nil, 3)', 'a List preserves a real Nil element';
+
+# Nil itself still renders as Nil.
+is Nil.raku, 'Nil', 'bare Nil.raku is still Nil';


### PR DESCRIPTION
## Problem

A freshly-declared shaped array rendered its cells as `Nil` instead of `Any`:

```
$ raku  -e 'my @a[2,2]; say @a.raku'
Array.new(:shape(2, 2), [Any, Any], [Any, Any])
$ mutsu -e 'my @a[2,2]; say @a.raku'
Array.new(:shape(2, 2), [Nil, Nil], [Nil, Nil])
```

A real array (`@`-sigiled) element is a Scalar container, so it can never actually hold `Nil`: assigning `Nil` reverts it to the element type's default (`Any` for an untyped array), and `make_shaped_array` fills its cells with `Value::NIL` for the same reason. The same divergence affected `my @c = 1,2,3; @c[1] = Nil; @c.raku` (raku `[1, Any, 3]`).

## Fix

Render a `Nil` element as `Any` in `raku_value_as_element`, which is used only for real-array elements. Typed arrays store the element type object in their cells (never `Nil`), so they render the type name (e.g. `Int`) unchanged. A `List` renders via `raku_value` (not the element path), so it keeps a genuine `Nil`.

## Test

Pin `t/shaped-array-raku-any.t` (6 assertions, matches reference raku). Whitelisted array roast tests (`S02-types/array.t`, `S09-typed-arrays/{arrays,native-int,native-shape1-int}.t`, `S32-array/delete.t`) still pass; `make test` green (only the timing-flaky `t/proc-async.t` `.kill` subtest failed, unrelated, passes on re-run).

Surfaced by the doc-diff harness (PLAN.md §8) on `raku-doc/doc/Language/list.rakudoc` (finding [11]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)