### PR TITLE
fix: multiple placeholders in a for-block set the block arity

### DIFF
--- a/src/parser/stmt/control/for_loops.rs
+++ b/src/parser/stmt/control/for_loops.rs
@@ -262,13 +262,16 @@ fn for_stmt_with_mode(input: &str, mode: crate::ast::ForMode) -> PResult<'_, Stm
     // When no explicit params, collect placeholder variables from the body
     let (param, params) = if param.is_none() && params.is_empty() {
         let placeholders = collect_placeholders_shallow(&body);
-        if placeholders.is_empty() {
-            (param, params)
-        } else {
-            // Use the first placeholder as the loop param, rest as extra params
-            let first = placeholders[0].clone();
-            let rest_params = placeholders[1..].to_vec();
-            (Some(first), rest_params)
+        match placeholders.len() {
+            0 => (param, params),
+            // A single placeholder binds as the loop param (and also sets `$_`).
+            1 => (Some(placeholders[0].clone()), Vec::new()),
+            // Multiple placeholders make the block arity N, so the loop consumes
+            // N elements per iteration (`for 1..8 { $^a + $^b }` sums pairs).
+            // Bind them all as multi-params with `param = None`, matching the
+            // explicit `-> $^a, $^b` signature form; the single-`param` + extra
+            // `params` split does not correctly bind the 2nd+ placeholder.
+            _ => (None, placeholders),
         }
     } else {
         (param, params)

--- a/t/for-block-placeholders.t
+++ b/t/for-block-placeholders.t
@@ -1,0 +1,43 @@
+use v6;
+use Test;
+
+# Multiple placeholder variables (`$^a`, `$^b`, ...) in a `for` loop body make
+# the block's arity equal to the number of distinct placeholders, so the loop
+# consumes that many elements per iteration. Placeholders bind in alphabetical
+# order of their names. Previously mutsu bound only the first placeholder and
+# threw "Cannot assign to a readonly variable" on the second.
+
+plan 5;
+
+{
+    my @seen;
+    for 1..8 { @seen.push: $^a + $^b }
+    is-deeply @seen, [3, 7, 11, 15], 'two placeholders sum consecutive pairs';
+}
+
+{
+    my @seen;
+    for 1..4 { @seen.push: "$^a $^b" }
+    is-deeply @seen, ['1 2', '3 4'], 'two placeholders consume two per iteration';
+}
+
+{
+    my @seen;
+    for 1..6 { @seen.push: "$^a-$^b-$^c" }
+    is-deeply @seen, ['1-2-3', '4-5-6'], 'three placeholders consume three per iteration';
+}
+
+# Placeholders bind in alphabetical order of their names, regardless of the
+# order they appear in the source.
+{
+    my @seen;
+    for 1..4 { @seen.push: "$^one $^two $^three $^four" }
+    is-deeply @seen, ['2 4 3 1'], 'placeholders bind in alphabetical name order';
+}
+
+# A single placeholder still binds one element per iteration.
+{
+    my @seen;
+    for 1..3 { @seen.push: $^x }
+    is-deeply @seen, [1, 2, 3], 'a single placeholder binds one element';
+}


### PR DESCRIPTION
## Problem

Two or more placeholder variables (`$^a`, `$^b`, ...) in a `for` loop body make the block's arity equal to the placeholder count, so the loop consumes that many elements per iteration. mutsu threw instead:

```
$ raku  -e 'for 1..8 { say $^a + $^b }'
3
7
11
15
$ mutsu -e 'for 1..8 { say $^a + $^b }'
1
Cannot assign to a readonly variable (^b) or a value
```

The parser collected the body placeholders but split them: the first into the single `param` slot, the rest into `params`. The compiler's single-`param` binding path does not bind the 2nd+ placeholder, so `$^b` stayed readonly. (The explicit `-> $^a, $^b` signature form — which puts all names in `params` with `param = None` — already worked, as did `.map({ $^a + $^b })`.)

## Fix

When collecting body placeholders, bind them all as multi-params with `param = None` when there is more than one, matching the working explicit-signature form. A single placeholder keeps the single-`param` form (which also topicalizes `$_`).

Placeholders bind in alphabetical order of their names, so `for 1..4 { say "$^one $^two $^three $^four" }` prints `2 4 3 1` — this now matches raku.

## Test

Pin `t/for-block-placeholders.t` (5 assertions, matches reference raku). `make test` green (only the timing-flaky `t/proc-async.t` `.kill` subtest failed, unrelated, passes on re-run); whitelisted pointy/placeholder/signature roast tests still pass.

Surfaced by the doc-diff harness (PLAN.md §8) on `raku-doc/doc/Language/traps.rakudoc` (findings [22]/[23]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)