### PR TITLE
fix: hyper `>>.{}` slicing and angle-subscript bind chains (dist sweep)

### DIFF
--- a/docs/dist-compat-sweep.md
+++ b/docs/dist-compat-sweep.md
@@ -104,7 +104,7 @@ pipeline.)
 | Root cause | Dists | Notes |
 |---|---|---|
 | ~~`Assignment operators inside ?? !! are too loose`~~ **FIXED (#4833)** | Web::App, RakuAST::Utils | A parenthesized accessor-lvalue assignment (`cond ?? a !! ($.value = x)`) was mis-rejected. **RakuAST::Utils now `load_ok`; Web::App advances to `missing_dep` (MIME::Types).** Pin: `t/ternary-paren-accessor-assign.t`. |
-| `expected statement: expected expected statement…` (generic parse dead-end) | **Geo::Ellipsoid**, **CSS::Grammar**, **PDF::Combiner**, **Ecosystem::Archive**, **Taurus::CLI** | Not one bug — each needs its own minimal repro. **Also a cosmetic bug in the error itself**: the message doubles "expected expected" — worth fixing in the parse-error formatter. |
+| `expected statement: expected expected statement…` (generic parse dead-end) | **Geo::Ellipsoid**, **CSS::Grammar**, **PDF::Combiner**, ~~**Ecosystem::Archive**~~ (fixed), ~~**Taurus::CLI**~~ (fixed) | Not one bug — each needs its own minimal repro. **Taurus::CLI**: fixed — `>>.{...}` hyper associative subscript did not parse, and hyper subscripts with a Range/list index (`>>.[0..2]`, `>>.{0..4}`) returned Nil instead of slicing each element (pin `t/hyper-assoc-subscript.t`). **Ecosystem::Archive**: fixed — a chained bind through an angle-word hash subscript (`my $id := %h<key> := VALUE`) failed to parse because `<key>` was parsed as an expression, mis-reading `%h<b> := 5` as a `b > ...` comparison (pin `t/bind-angle-subscript-chain.t`). Remaining (Geo::Ellipsoid, CSS::Grammar (grammar slang), PDF::Combiner) each need their own repro. **Also a cosmetic bug in the error itself**: the message doubles "expected expected" — worth fixing in the parse-error formatter. |
 
 ### Singletons
 

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -25,6 +25,7 @@ use crate::token_kind::TokenKind;
 use crate::value::Value;
 
 use super::helpers::ws;
+pub(in crate::parser) use postfix::is_angle_key_char;
 pub(in crate::parser) use postfix::postfix_expr_continue;
 pub(in crate::parser) use postfix::without_pending_prefix;
 pub(in crate::parser) use postfix::{QuotedMethodName, parse_quoted_method_name};

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -2288,6 +2288,35 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                 rest = r;
                 continue;
             }
+            // Hyper associative indexing: expr»{key} / expr».{key} (or >> forms)
+            // => expr».AT-KEY(key). Mirrors the AT-POS block above but with braces.
+            let hyper_key_input = after_hyper
+                .strip_prefix(".{")
+                .or_else(|| after_hyper.strip_prefix('{'));
+            if let Some(r) = hyper_key_input {
+                let (r, _) = ws(r)?;
+                if let Some(after) = r.strip_prefix('}') {
+                    // A zen slice `»{}` is a no-op subscript over each element.
+                    rest = after;
+                    continue;
+                }
+                let (r, parsed) = parse_bracket_indices_inner(r)?;
+                let (r, _) = ws(r)?;
+                let (r, _) = parse_char(r, '}')?;
+                let args = match parsed {
+                    ParsedBracketIndex::Single(index) => vec![index],
+                    ParsedBracketIndex::MultiDim(dimensions) => dimensions,
+                };
+                expr = Expr::HyperMethodCall {
+                    target: Box::new(expr),
+                    name: Symbol::intern("AT-KEY"),
+                    args,
+                    modifier: None,
+                    quoted: false,
+                };
+                rest = r;
+                continue;
+            }
             // Hyper postfix with user-declared postfix operator: »??? / >>???
             // Only match when NOT preceded by dot (dotted form is a method call)
             if !after_hyper.starts_with('.')

--- a/src/parser/expr/postfix/mod.rs
+++ b/src/parser/expr/postfix/mod.rs
@@ -17,5 +17,6 @@ mod loop_;
 pub(in crate::parser::expr) use loop_::{postfix_expr_tight_pub, prefix_expr};
 
 pub(crate) use call_method::{QuotedMethodName, parse_quoted_method_name};
+pub(in crate::parser) use helpers::is_angle_key_char;
 pub(in crate::parser) use loop_::postfix_expr_continue;
 pub(crate) use loop_::without_pending_prefix;

--- a/src/parser/stmt/assign/try_assign.rs
+++ b/src/parser/stmt/assign/try_assign.rs
@@ -30,38 +30,67 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
     }
     let (r, var) = var_name(input)?;
 
-    // Handle subscripted lvalues: @a[1] = ..., %h{key} = ..., $a[0] = ...
+    // Handle subscripted lvalues: @a[1] = ..., %h{key} = ..., %h<key> = ...
     if r.starts_with('[') || r.starts_with('{') || r.starts_with('<') {
-        let closing = match r.as_bytes()[0] {
-            b'[' => ']',
-            b'{' => '}',
-            _ => '>',
-        };
-        let (r_idx, _) = parse_char(r, r.as_bytes()[0] as char)?;
-        let (r_idx, _) = ws(r_idx)?;
-        // Parse comma-separated index expressions inside brackets
-        let (r_idx, first_expr) = expression(r_idx)?;
-        let (mut r_idx, _) = ws(r_idx)?;
-        let index_expr = if r_idx.starts_with(',') {
-            let mut items = vec![first_expr];
-            while r_idx.starts_with(',') {
-                let (r2, _) = parse_char(r_idx, ',')?;
-                let (r2, _) = ws(r2)?;
-                if r2.starts_with(closing) {
-                    r_idx = r2;
-                    break;
-                }
-                let (r2, next) = expression(r2)?;
-                items.push(next);
-                let (r2, _) = ws(r2)?;
-                r_idx = r2;
+        let (r_after, index_expr) = if let Some(inner) = r.strip_prefix('<') {
+            // `<...>` is word-quoting (a literal string key), NOT an expression.
+            // Parsing the inside as an expression mis-reads `%h<b> := 5` — `b>`
+            // is taken as a `b > ...` comparison, so the chained bind never
+            // parses. Split the content into angle words instead, exactly as the
+            // postfix `<key>` subscript parser does. `<=`, `<<`, `<=>`, and any
+            // non-word content fall through to Err (a real comparison / not an
+            // lvalue), letting the caller re-parse as an expression.
+            let Some(end) = inner.find('>') else {
+                return Err(PError::expected("assignment expression"));
+            };
+            let keys = crate::parser::helpers::split_angle_words(&inner[..end]);
+            if keys.is_empty()
+                || !keys
+                    .iter()
+                    .all(|k| !k.is_empty() && k.chars().all(crate::parser::expr::is_angle_key_char))
+            {
+                return Err(PError::expected("assignment expression"));
             }
-            Expr::ArrayLiteral(items)
+            let index_expr = if keys.len() == 1 {
+                Expr::Literal(Value::str(keys[0].to_string()))
+            } else {
+                Expr::ArrayLiteral(
+                    keys.into_iter()
+                        .map(|k| Expr::Literal(Value::str(k.to_string())))
+                        .collect(),
+                )
+            };
+            let (r_after, _) = ws(&inner[end + 1..])?;
+            (r_after, index_expr)
         } else {
-            first_expr
+            let closing = if r.as_bytes()[0] == b'[' { ']' } else { '}' };
+            let (r_idx, _) = parse_char(r, r.as_bytes()[0] as char)?;
+            let (r_idx, _) = ws(r_idx)?;
+            // Parse comma-separated index expressions inside brackets
+            let (r_idx, first_expr) = expression(r_idx)?;
+            let (mut r_idx, _) = ws(r_idx)?;
+            let index_expr = if r_idx.starts_with(',') {
+                let mut items = vec![first_expr];
+                while r_idx.starts_with(',') {
+                    let (r2, _) = parse_char(r_idx, ',')?;
+                    let (r2, _) = ws(r2)?;
+                    if r2.starts_with(closing) {
+                        r_idx = r2;
+                        break;
+                    }
+                    let (r2, next) = expression(r2)?;
+                    items.push(next);
+                    let (r2, _) = ws(r2)?;
+                    r_idx = r2;
+                }
+                Expr::ArrayLiteral(items)
+            } else {
+                first_expr
+            };
+            let (r_idx, _) = parse_char(r_idx, closing)?;
+            let (r_after, _) = ws(r_idx)?;
+            (r_after, index_expr)
         };
-        let (r_idx, _) = parse_char(r_idx, closing)?;
-        let (r_after, _) = ws(r_idx)?;
         // Check for binding assignment (:= or ::=)
         if let Some(stripped) = r_after
             .strip_prefix("::=")

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -8,6 +8,27 @@ use crate::symbol::Symbol;
 /// method directly to a leaf and leaves that result alone. So `((1,),)>>.succ`
 /// is `($(2,),)` while `(1,2)>>.Array` stays `([1], [2])` — the deciding factor
 /// is the *source* element's shape, not the result's.
+/// Whether a hyper subscript index is a *slice* (a Range or multi-element list),
+/// as opposed to a single scalar key/position. `@a>>.[0..2]` / `%h>>.{1,2}`
+/// desugar to `AT-POS`/`AT-KEY`, but a slice index must apply the postcircumfix
+/// subscript (which slices) to each element, not the single-element accessor
+/// method (which would return Nil). A scalar index keeps the plain method path.
+fn hyper_subscript_index_is_slice(v: &Value) -> bool {
+    match v.view() {
+        ValueView::Range(..)
+        | ValueView::RangeExcl(..)
+        | ValueView::RangeExclStart(..)
+        | ValueView::RangeExclBoth(..)
+        | ValueView::GenericRange { .. }
+        | ValueView::Seq(..)
+        | ValueView::Slip(..) => true,
+        // A bare list `{1,2}` is a slice; an *itemized* list `$(1,2)` is a single
+        // key (matching `exec_index_op_with_positional`'s itemization rule).
+        ValueView::Array(_, kind) => !matches!(kind, crate::value::ArrayKind::ItemList),
+        _ => false,
+    }
+}
+
 fn itemize_if_descended(source: &Value, result: Value) -> Value {
     if !matches!(
         source.view(),
@@ -380,6 +401,24 @@ impl Interpreter {
                             Err(_) => results.push(Value::array(vec![])),
                         }
                     }
+                }
+                _ if modifier.is_none()
+                    && item_args.len() == 1
+                    && matches!(method.as_str(), "AT-POS" | "AT-KEY")
+                    && hyper_subscript_index_is_slice(&item_args[0]) =>
+                {
+                    // Hyper subscript with a slice index (`@a>>.[0..2]`,
+                    // `%h>>.{1,2}`): apply the postcircumfix subscript to each
+                    // element (which slices) rather than the single-key accessor
+                    // method (which returns Nil for a Range/list key).
+                    let is_positional = method == "AT-POS";
+                    self.stack.push(item.clone());
+                    self.stack.push(item_args[0].clone());
+                    self.exec_index_op_with_positional(is_positional)?;
+                    results.push(self.stack.pop().unwrap_or(Value::NIL));
+                    // AT-POS/AT-KEY are nodal: the hyper result is a List even
+                    // over an Array target (see `result_kind` below).
+                    method_is_nodal = true;
                 }
                 _ => {
                     // Hyper method dispatch on nested list/array/seq items.

--- a/t/bind-angle-subscript-chain.t
+++ b/t/bind-angle-subscript-chain.t
@@ -1,0 +1,44 @@
+use Test;
+
+# Chained bind whose middle target is an angle-word hash subscript:
+#   my $x := %h<key> := VALUE
+# The `<key>` postcircumfix is word-quoting (a literal string key), not an
+# expression, so `%h<key> := ...` must parse it as a word. mutsu previously
+# parsed the inside of `<...>` as an expression, mis-reading `%h<b> := 5` as a
+# `b > ...` comparison, so any chained bind through an angle subscript failed to
+# parse. Found via the real-distribution compat sweep (Ecosystem::Archive,
+# docs/dist-compat-sweep.md), which uses `my $id := %distribution<dist> := ...`.
+
+plan 8;
+
+# The Ecosystem::Archive idiom: bind a scalar to an angle-subscript bind
+{
+    my %d = dist => 'old';
+    my $id := %d<dist> := 'new';
+    is $id, 'new', 'scalar bound to angle-subscript bind sees the bound value';
+    is %d<dist>, 'new', 'the angle subscript was bound';
+}
+
+# Chained assignment (=) through an angle subscript still works
+{
+    my %h;
+    my $x := %h<a> = 9;
+    is %h<a>, 9, 'angle subscript assignment in a bind chain';
+    is $x, 9, 'the bind sees the assigned value';
+}
+
+# Multi-word angle subscript bind
+{
+    my %h;
+    %h<a b> := (1, 2);
+    is %h<a>, 1, 'multi-word angle bind, first key';
+    is %h<b>, 2, 'multi-word angle bind, second key';
+}
+
+# A real comparison `<` (not a subscript) is unaffected
+{
+    my $x = 3;
+    ok $x < 5, 'bare `<` still parses as numeric comparison';
+    my %h = a => 1;
+    ok %h<a> < 5, 'angle subscript followed by a comparison still works';
+}

--- a/t/hyper-assoc-subscript.t
+++ b/t/hyper-assoc-subscript.t
@@ -1,0 +1,38 @@
+use Test;
+
+# `>>.{...}` / `»{...}` hyper associative subscript (postcircumfix `{}` hypered).
+# Regression: mutsu failed to parse `>>.{key}` at all, and hyper subscripts with
+# a Range/list (slice) index returned Nil instead of slicing each element.
+# Found via the real-distribution compat sweep (Taurus::CLI, docs/dist-compat-sweep.md).
+
+plan 10;
+
+my @h = {a => 1, b => 2}, {a => 3, b => 4};
+
+# Single scalar key
+is-deeply @h>>.{'a'}.List, (1, 3), 'hyper .{scalar} extracts one key per element';
+is-deeply @h>>.<a>.List, (1, 3), 'hyper .<a> (angle) still works';
+
+# Dotless form
+is-deeply (@h>>{'b'}).List, (2, 4), 'hyper {scalar} (dotless) works';
+
+# Range slice per element (the Taurus::CLI case)
+my @rows = {0 => 'a', 1 => 'b', 2 => 'c', 3 => 'd'},
+           {0 => 'A', 1 => 'B', 2 => 'C', 3 => 'D'};
+is-deeply @rows>>.{0..2}, (('a', 'b', 'c'), ('A', 'B', 'C')), 'hyper .{range} slices each element';
+
+# Multi-key list slice
+is-deeply @h>>.{'a', 'b'}, ((1, 2), (3, 4)), 'hyper .{list} slices each element';
+
+# Positional hyper slice (twin fix)
+my @cells = [10, 20, 30, 40], [11, 21, 31, 41];
+is-deeply @cells>>.[1..2], ((20, 30), (21, 31)), 'hyper .[range] slices each element';
+is-deeply @cells>>.[0], (10, 11), 'hyper .[scalar] extracts one position per element';
+is-deeply @cells>>.[0, 3], ((10, 40), (11, 41)), 'hyper .[list] slices each element';
+
+# Hyper result of a nodal subscript is a List even over an Array target
+my @arr = {x => 1}, {x => 2};
+isa-ok (@arr>>.{'x'}), List, 'hyper subscript over Array yields a List';
+
+# Guillemet form parses and slices
+is-deeply (@rows>>.{1..2}), (('b', 'c'), ('B', 'C')), 'hyper .{range} via >> form';


### PR DESCRIPTION
Two parser gaps surfaced by the real-distribution compat sweep
([docs/dist-compat-sweep.md](../blob/main/docs/dist-compat-sweep.md)), each
blocking a pure-Raku dist on `use` alone.

## 1. Hyper associative subscript / hyper slice — Taurus::CLI

- `@a>>.{key}` (hyper of the postcircumfix `{}` subscript) did not parse at all.
  The hyper postfix loop handled `>>.[idx]` (AT-POS) and `>>.<a>` (AT-KEY angle)
  but not `>>.{key}`. Added the brace form, mapping to `AT-KEY`.
- A hyper subscript with a **slice** index — a Range or multi-element list
  (`@a>>.[0..2]`, `%h>>.{0..4}`, `%h>>.{1,2}`) — returned `Nil`, because the
  desugared `AT-POS`/`AT-KEY` single-key accessor does not slice. Such slice
  indices now route through the index op (postcircumfix semantics), which slices
  each element; the hyper result is marked nodal so it is a `List` over an Array
  target (matching raku).

## 2. Chained bind through an angle-word hash subscript — Ecosystem::Archive

`my $id := %h<key> := VALUE` failed to parse. `try_parse_assign_expr` parsed the
`<...>` subscript content as an *expression*, so `%h<b> := 5` was mis-read as a
`b > ...` comparison and the chained bind never parsed. `<...>` is word-quoting
(a literal string key), so it is now parsed with `split_angle_words` exactly as
the postfix `<key>` subscript parser does. `<=`/`<<`/`<=>` and non-word content
fall through, so a real comparison still parses as one. Ecosystem::Archive uses
`my $identity := %distribution<dist> := build-identity(...)`.

Both dists now parse/load. Every case verified against `raku`.

Pins: `t/hyper-assoc-subscript.t`, `t/bind-angle-subscript-chain.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)