### PR TITLE
fix: a real array's Nil cells gist as (Any)

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -537,13 +537,37 @@ pub(super) fn dispatch(
                     _ => leaf_gist(v),
                 }
             }
+            // A real array's (`@`-sigiled) elements are Scalar containers, so a
+            // cell can never hold Nil: assigning Nil reverts it to the element
+            // type default (`Any` for untyped), and a shaped array fills unused
+            // cells the same way. Gist such a cell as the type object `(Any)`.
+            // Lists/Seqs keep a genuine Nil, so this only applies to real arrays.
+            fn gist_real_array_item(v: &Value) -> String {
+                match v.view() {
+                    ValueView::Nil => "(Any)".to_string(),
+                    ValueView::Array(inner, kind) if kind.is_real_array() => {
+                        let elems = inner
+                            .iter()
+                            .map(gist_real_array_item)
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        gist_array_wrap(&elems, kind)
+                    }
+                    _ => gist_item(v),
+                }
+            }
+            let elem_render: fn(&Value) -> String = if kind.is_real_array() {
+                gist_real_array_item
+            } else {
+                gist_item
+            };
             // Shaped arrays: format with newlines between rows
             if kind == crate::value::ArrayKind::Shaped
                 && items
                     .iter()
                     .any(|v| matches!(v.view(), ValueView::Array(..)))
             {
-                let rows: Vec<String> = items.iter().map(gist_item).collect();
+                let rows: Vec<String> = items.iter().map(elem_render).collect();
                 let inner = rows.join("\n ");
                 return Some(Some(Ok(Value::str(format!("[{}]", inner)))));
             }
@@ -553,13 +577,13 @@ pub(super) fn dispatch(
             let inner = if items.len() > GIST_ELEM_CAP {
                 let mut s = items[..GIST_ELEM_CAP]
                     .iter()
-                    .map(gist_item)
+                    .map(elem_render)
                     .collect::<Vec<_>>()
                     .join(" ");
                 s.push_str(" ...");
                 s
             } else {
-                items.iter().map(gist_item).collect::<Vec<_>>().join(" ")
+                items.iter().map(elem_render).collect::<Vec<_>>().join(" ")
             };
             Some(Ok(Value::str(gist_array_wrap(&inner, kind))))
         }

--- a/src/runtime/utils/gist.rs
+++ b/src/runtime/utils/gist.rs
@@ -127,7 +127,24 @@ pub(crate) fn gist_value(value: &Value) -> String {
                     _ => "(...)".to_string(),
                 };
             }
-            let inner = items.iter().map(gist_value).collect::<Vec<_>>().join(" ");
+            // A real array's (`@`-sigiled) elements are Scalar containers, so a
+            // cell can never hold Nil: assigning Nil reverts it to the element
+            // type default (`Any` for untyped), and a shaped array fills unused
+            // cells the same way. Gist such a cell as the type object `(Any)`.
+            // Nested real arrays recurse through this same arm, so their cells
+            // are handled too; a List/Seq keeps a genuine Nil (its own arm).
+            let is_real = kind.is_real_array();
+            let inner = items
+                .iter()
+                .map(|v| {
+                    if is_real && v.is_nil() {
+                        "(Any)".to_string()
+                    } else {
+                        gist_value(v)
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
             SEEN_PTRS.with(|seen| pop_ptr(seen, ptr));
             match kind {
                 crate::value::ArrayKind::Array

--- a/t/gist-array-nil-any.t
+++ b/t/gist-array-nil-any.t
@@ -1,0 +1,45 @@
+use v6;
+use Test;
+
+# A real array's (`@`-sigiled) elements are Scalar containers, so a cell can
+# never hold Nil: assigning Nil reverts it to the element type default (`Any`
+# for an untyped array), and a shaped array fills unused cells the same way.
+# `.gist`/`say` must render such a cell as the type object `(Any)`, not `Nil`.
+# A List keeps a genuine Nil (it is not an @-sigiled container).
+
+plan 7;
+
+{
+    my @a = 4, 8, 15, 16;
+    @a[2] = Nil;
+    is @a.gist, '[4 8 (Any) 16]', 'Nil assigned to a real-array element gists as (Any)';
+}
+
+{
+    my @a[3];
+    is @a.gist, '[(Any) (Any) (Any)]', '1D shaped array cells gist as (Any)';
+}
+
+{
+    my @a[2,2];
+    is @a.gist, "[[(Any) (Any)]\n [(Any) (Any)]]", '2D shaped array cells gist as (Any)';
+}
+
+# Typed cells keep their type object, not Any.
+{
+    my Int @a[3];
+    is @a.gist, '[(Int) (Int) (Int)]', 'typed shaped array cells gist as the element type';
+}
+
+# Autoviv holes were already rendered as (Any) and stay that way.
+{
+    my @a;
+    @a[2] = 1;
+    is @a.gist, '[(Any) (Any) 1]', 'autoviv holes gist as (Any)';
+}
+
+# A List keeps a real Nil.
+is (1, Nil, 3).gist, '(1 Nil 3)', 'a List preserves a real Nil element in gist';
+
+# Bare Nil still gists as Nil.
+is Nil.gist, 'Nil', 'bare Nil.gist is still Nil';


### PR DESCRIPTION
## Problem

`say` / `.gist` of a real array rendered a `Nil` cell as `Nil` instead of `(Any)`:

```
$ raku  -e 'my @a = 4,8,15,16; @a[2] = Nil; say @a'
[4 8 (Any) 16]
$ mutsu -e 'my @a = 4,8,15,16; @a[2] = Nil; say @a'
[4 8 Nil 16]

$ raku  -e 'my @a[3]; say @a'
[(Any) (Any) (Any)]
$ mutsu -e 'my @a[3]; say @a'
[Nil Nil Nil]
```

A real array (`@`-sigiled) element is a Scalar container that can never hold `Nil`: assigning `Nil` reverts it to the element type's default (`Any` for an untyped array), and a shaped array fills unused cells the same way.

## Fix

Render a `Nil` element as `(Any)` for real-array kinds in both gist paths: the `gist_value` fast path used by `say`/`put` (`runtime/utils/gist.rs`) and the `.gist` method (`dispatch_core_repr.rs`). Nested real arrays recurse through the same arm, so shaped-array rows render correctly too (`my @a[2,2]` → `[[(Any) (Any)]\n [(Any) (Any)]]`). Typed arrays store the element type object in their cells (never `Nil`), so they render the type name (`[(Int) (Int) (Int)]`); a `List`/`Seq` keeps a genuine `Nil`.

This is the `.gist`/`say` companion to the `.raku` fix in #4840.

## Test

Pin `t/gist-array-nil-any.t` (7 assertions, matches reference raku). `make test` green; whitelisted array/nil roast tests still pass.

Surfaced by the doc-diff harness (PLAN.md §8) on `raku-doc/doc/Language/traps.rakudoc` (finding [1]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)