### PR TITLE
perf(vm): block exit becomes slot-authoritative under shadow slots (§1.3 endgame)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -436,6 +436,29 @@ block exit no longer re-seeds slots from the name-keyed env (the fib env-COW per
 payoff). See the fused §1.3 + §1.2 campaign notes below; that is the open work,
 not clone removal.
 
+## Block exit is slot-authoritative — DONE (2026-07-19, PR #4844)
+
+The first step of the "dual-store half": `exec_block_scope_op` no longer re-seeds
+**propagating** enclosing slots from the name-keyed `restored_env`. Under shadow
+slots every store already writes the slot (`exec_set_local_op_inner`), so a
+propagating enclosing var holds its live value in its own slot and the env re-seed
+is redundant. The restore now touches **only the non-propagating names**:
+block-declared fresh `my` → Nil (folds in the old separate Nil loop), and
+block-declared shadowing names / `$_` / `$*dyn` → their saved outer value (still in
+`restored_env` because propagation was skipped for them). The
+`MUTSU_NO_SHADOW_SLOTS` opt-out keeps the whole-array restore + full re-seed.
+
+Behavior-preserving (make test 18747, scoping/phaser/declaration roast 77/77, pin
+`t/block-restore-slot-authoritative.t`), and perf-neutral on its own — it is a
+**prerequisite**: it removes ONE of the four env-mirror dependencies (mechanism #1,
+block-restore's env pull-back) that block dropping the `needs_env_sync` blanket.
+The three still open: cross-thread shared-var copy, method-call caller-local
+coherence × the JIT inline GetLocal, and currying/priming capture (see
+[[memory: needs_env_sync blanket removal]] — the store-site gate breaks all four
+until each is freed). Only after all four are slot-authoritative can the
+unconditional per-store env write in `exec_set_local_op_inner` be gated for the
+env-COW payoff.
+
 ## §1.4 flip blast-radius measurement (2026-07-02, debug + release `prove t/`)
 
 A naive flip was implemented and measured, then reverted (branch

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -418,22 +418,39 @@ impl Interpreter {
         // The `MUTSU_NO_SHADOW_SLOTS` opt-out has no distinct shadow slots, so it
         // still needs the whole-array restore.
         if let Some(saved) = saved_locals {
+            // MUTSU_NO_SHADOW_SLOTS opt-out: no distinct shadow slots, so the
+            // whole-array restore is needed, and the propagated inner values are
+            // then re-applied from `restored_env` by name.
             self.locals = saved;
-        } else {
-            for sym in &block_declared {
-                if saved_env.contains_key_sym(*sym) {
-                    continue;
-                }
-                for idx in 0..code.locals.len().min(self.locals.len()) {
-                    if code.local_sym(idx) == Some(*sym) {
-                        self.locals[idx] = Value::NIL;
-                    }
+            for (idx, name) in code.locals.iter().enumerate() {
+                if let Some(val) = restored_env.get(name).cloned() {
+                    self.locals[idx] = val;
                 }
             }
-        }
-        for (idx, name) in code.locals.iter().enumerate() {
-            if let Some(val) = restored_env.get(name).cloned() {
-                self.locals[idx] = val;
+        } else {
+            // Shadow slots: slot-authoritative restore. A PROPAGATING enclosing
+            // var already holds its live in-block value in its own slot (every
+            // store writes the slot, `exec_set_local_op_inner`), so it needs no
+            // env re-seed — this drops block exit's dependency on the per-store
+            // env mirror for those slots (the §1.3 endgame's remaining coupling).
+            // Only NON-propagating names must be reverted:
+            //   - block-declared FRESH `my` (absent from `saved_env`, hence from
+            //     `restored_env`): reset to Nil so the declaration cannot leak
+            //     past the block / into a later iteration (its unique shadow
+            //     slot's pre-block value is Nil by induction — slice 1).
+            //   - block-declared SHADOWING names, the block topic `$_`, and
+            //     `$*dyn` (present in `saved_env`): restore the saved outer value,
+            //     which `restored_env` still holds because propagation was skipped
+            //     for these names in the loop above.
+            for (idx, name) in code.locals.iter().enumerate() {
+                let non_propagating = name == "_"
+                    || name.starts_with('*')
+                    || code
+                        .local_sym(idx)
+                        .is_some_and(|s| block_declared.contains(&s));
+                if non_propagating {
+                    self.locals[idx] = restored_env.get(name).cloned().unwrap_or(Value::NIL);
+                }
             }
         }
         // For `our`-scoped locals declared inside this block (or in the outer

--- a/t/block-restore-slot-authoritative.t
+++ b/t/block-restore-slot-authoritative.t
@@ -1,0 +1,83 @@
+use v6;
+use Test;
+
+# Pin for the §1.3 lexical-slot endgame slice: under shadow slots, block exit is
+# slot-authoritative — a propagating enclosing var keeps its live slot value
+# instead of being re-seeded from the name-keyed env, while non-propagating names
+# ($_, $*dyn, block-declared `my`) are still reverted. These cases exercise every
+# arm of the restore so a regression in either direction is caught.
+
+plan 11;
+
+# 1. A block-body write to an ENCLOSING scalar propagates out of the block.
+{
+    my $x = 1;
+    { $x = 2 }
+    is $x, 2, 'enclosing scalar modified in a bare block propagates';
+}
+
+# 2. A block-declared `my` does NOT leak past the block.
+{
+    my $seen = 'outer';
+    { my $seen = 'inner'; $seen ~= '!' }
+    is $seen, 'outer', 'block-declared my does not leak to the outer scope';
+}
+
+# 3. A block-declared `my` that shadows an enclosing name leaves the outer intact.
+{
+    my $v = 10;
+    { my $v = 99; $v++ }
+    is $v, 10, 'shadowing my inside a block leaves the outer binding untouched';
+}
+
+# 4. An enclosing @-array mutated in a block propagates (container identity).
+{
+    my @a = 1, 2, 3;
+    { @a.push(4) }
+    is @a.join(','), '1,2,3,4', 'enclosing array push propagates out of the block';
+}
+
+# 5. An enclosing %-hash key set in a block propagates.
+{
+    my %h = a => 1;
+    { %h<b> = 2 }
+    is %h<b>, 2, 'enclosing hash key set in a block propagates';
+}
+
+# 6. The topic $_ is block-scoped: an inner given does not leak $_ outward.
+{
+    $_ = 'top';
+    given 'inner' { }
+    is $_, 'top', 'given restores the outer topic on block exit';
+}
+
+# 7. Re-entering a block (loop) does not carry a block-declared my across iterations.
+{
+    my @collected;
+    for 1..3 -> $n {
+        my $tmp = $n * 10;
+        @collected.push($tmp);
+    }
+    is @collected.join(','), '10,20,30', 'block-declared my is fresh each loop iteration';
+}
+
+# 8. Nested blocks: innermost enclosing write propagates through both.
+{
+    my $d = 0;
+    { { $d = 5 } }
+    is $d, 5, 'enclosing write from a doubly-nested block propagates';
+}
+
+# 10. A dynamic variable is restored on block exit.
+{
+    my $*DYN = 'outer';
+    { my $*DYN = 'inner'; is $*DYN, 'inner', 'inner dynamic var is visible in-block' }
+    is $*DYN, 'outer', 'dynamic var restored to the outer value on block exit';
+}
+
+# 11. Assignment-through with an existing outer AND a computed value survives.
+{
+    my $sum = 0;
+    for 1..4 { $sum += $_ }
+    is $sum, 10, 'accumulator across a for-loop body propagates each iteration';
+}


### PR DESCRIPTION
## Summary
The lexical-slot endgame slice **after clone removal** (docs/lexical-scope-slot-campaign.md §1.3 plan step 4; ANALYSIS.md §1.3).

On block exit `exec_block_scope_op` re-seeded **every** local slot from the name-keyed `restored_env`. That re-seed is the block's remaining dependency on the per-store env mirror: a block-body write to an **enclosing** local only survived the block through its env entry.

Under shadow slots the re-seed is unnecessary — every store already writes the slot (`exec_set_local_op_inner`), so a propagating enclosing var already holds its live value in its own slot. This PR replaces the whole re-seed with a **targeted revert of only the non-propagating names**:

- block-declared fresh `my` (absent from `saved_env` → Nil, folding in the old separate Nil loop);
- block-declared shadowing names / the topic `$_` / `$*dyn` (restored to their saved outer value, which `restored_env` still holds because propagation was skipped for them).

Propagating enclosing slots keep their live slot value. The `MUTSU_NO_SHADOW_SLOTS` opt-out is unchanged (whole-array restore + full re-seed).

## Why
This is a **behavior-preserving prerequisite** (no perf change on its own): it removes one of the four env-mirror dependencies that block dropping the `needs_env_sync` blanket — the fib env-COW payoff that motivates the §1.3 campaign.

## Validation
- `make test` — 18747 tests, PASS
- scoping / phaser / declaration whitelisted roast subset — 77/77
- the 3 debug-slow integration files (advent2012-day21, deep-recursion-initing-native-array, weird-errors) confirmed pre-existing via a main A/B, not regressions
- new pin `t/block-restore-slot-authoritative.t` (11 cases, matches raku)

🤖 Generated with [Claude Code](https://claude.com/claude-code)