### PR TITLE
fix: a subset's `is` trait may follow `of BaseType`

### DIFF
--- a/src/parser/stmt/decl/constant_subset.rs
+++ b/src/parser/stmt/decl/constant_subset.rs
@@ -217,38 +217,51 @@ pub(in crate::parser::stmt) fn subset_decl(input: &str) -> PResult<'_, Stmt> {
     let (mut rest, _) = ws(rest)?;
     let mut is_export = false;
     let mut export_tags: Vec<String> = Vec::new();
-    while let Some(r) = keyword("is", rest) {
-        let (r, _) = ws1(r)?;
-        let (r, trait_name) = ident(r)?;
-        if trait_name == "export" {
-            is_export = true;
-            let (r2, tags) = parse_export_trait_tags(r)?;
-            if tags.is_empty() {
-                if !export_tags.iter().any(|t| t == "DEFAULT") {
-                    export_tags.push("DEFAULT".to_string());
-                }
-            } else {
-                for tag in tags {
-                    if !export_tags.iter().any(|t| t == &tag) {
-                        export_tags.push(tag);
+    let mut base: Option<String> = None;
+    // `of Base` and `is trait` may appear in either order before `where`:
+    // `subset S of T is export where …` and `subset S is export of T where …`
+    // both occur in the wild (Business::CreditCard uses the former). Loop over
+    // `of`/`is` until neither matches, so a trait after `of` is not left
+    // unparsed (which stranded the following `where …` as a bare statement).
+    loop {
+        if base.is_none()
+            && let Some(r) = keyword("of", rest)
+        {
+            let (r, _) = ws1(r)?;
+            let (r, b) = parse_type_constraint_expr(r).ok_or_else(|| PError::expected("type"))?;
+            let (r, _) = ws(r)?;
+            base = Some(b);
+            rest = r;
+            continue;
+        }
+        if let Some(r) = keyword("is", rest) {
+            let (r, _) = ws1(r)?;
+            let (r, trait_name) = ident(r)?;
+            if trait_name == "export" {
+                is_export = true;
+                let (r2, tags) = parse_export_trait_tags(r)?;
+                if tags.is_empty() {
+                    if !export_tags.iter().any(|t| t == "DEFAULT") {
+                        export_tags.push("DEFAULT".to_string());
+                    }
+                } else {
+                    for tag in tags {
+                        if !export_tags.iter().any(|t| t == &tag) {
+                            export_tags.push(tag);
+                        }
                     }
                 }
+                let (r2, _) = ws(r2)?;
+                rest = r2;
+            } else {
+                let (r, _) = ws(r)?;
+                rest = r;
             }
-            let (r2, _) = ws(r2)?;
-            rest = r2;
-        } else {
-            let (r, _) = ws(r)?;
-            rest = r;
+            continue;
         }
+        break;
     }
-    let (rest, base) = if let Some(r) = keyword("of", rest) {
-        let (r, _) = ws1(r)?;
-        let (r, base) = parse_type_constraint_expr(r).ok_or_else(|| PError::expected("type"))?;
-        let (r, _) = ws(r)?;
-        (r, base)
-    } else {
-        (rest, "Any".to_string())
-    };
+    let base = base.unwrap_or_else(|| "Any".to_string());
     let (rest, predicate) = if let Some(r) = keyword("where", rest) {
         let (r, _) = ws1(r)?;
         let (r, pred) = expression(r)?;

--- a/t/subset-trait-after-of.t
+++ b/t/subset-trait-after-of.t
@@ -1,0 +1,39 @@
+use Test;
+
+# A subset declaration may place the `is export` (and other `is`) traits AFTER
+# the `of BaseType`, not only before it:  `subset S of T is export where …`.
+# mutsu only parsed the `is` traits before `of`, so a trait after `of` was left
+# unparsed and the following `where …` was stranded as a bare statement (which
+# then failed to parse). Found via the real-distribution compat sweep
+# (Business::CreditCard, docs/dist-compat-sweep.md): it declares
+# `my subset CreditCard of Str() is export where !*.contains(/…/)`.
+
+plan 8;
+
+# `of` then `is export` then `where` — the Business::CreditCard order
+{
+    my subset Pos of Int is export where * > 0;
+    ok 5 ~~ Pos, 'subset (of … is export where) accepts a matching value';
+    nok -5 ~~ Pos, 'subset (of … is export where) rejects a non-matching value';
+}
+
+# `is export` before `of` still works (unchanged path)
+{
+    my subset Neg is export of Int where * < 0;
+    ok -3 ~~ Neg, 'subset (is export … of … where) accepts';
+    nok 3 ~~ Neg, 'subset (is export … of … where) rejects';
+}
+
+# `of … is export` with no where clause
+{
+    my subset AStr of Str is export;
+    ok 'hi' ~~ AStr, 'subset (of … is export) with no where accepts a Str';
+    nok 5 ~~ AStr, 'subset (of … is export) rejects a non-Str';
+}
+
+# Tagged export after `of`
+{
+    my subset Big of Int is export(:MATH) where * > 100;
+    ok 200 ~~ Big, 'subset (of … is export(:tag) where) accepts';
+    nok 50 ~~ Big, 'subset (of … is export(:tag) where) rejects';
+}


### PR DESCRIPTION
`subset S of T is export where …` (the `of` **before** the trait) left the
`is export` trait — and, fatally, the following `where …` predicate — unparsed.
`subset_decl` only scanned `is` traits **before** `of`, so anything after `of`
fell through, stranding `is export where …` as a bare statement that then failed
to parse (`expected expression statement`, or the `where`'s `!*` whatever
tripping `X::Syntax::CannotMeta`).

Now `of BaseType` and `is <trait>` parse in either order in a single loop before
`where`. Both orders are accepted:

- `subset S of T is export where …`  (previously broken)
- `subset S is export of T where …`  (already worked)
- `subset S of T is export;`         (trait after `of`, no where — previously broken)

Found via the real-distribution compat sweep
([docs/dist-compat-sweep.md](../blob/main/docs/dist-compat-sweep.md)):
**Business::CreditCard** declares
`my subset CreditCard of Str() is export where !*.contains(/…/)` and no longer
hits a parse error. (A separate latent regex char-class bug in its predicate —
`<-[\d x _ \  -]>` matching — is unrelated to the declaration parse and only
bites when a value is validated, so the module still loads.)

Pin: `t/subset-trait-after-of.t`. Every case verified against `raku`; roast
`S12-subset/*` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)