### PR TITLE
fix: Hash set-membership honors value truthiness

### DIFF
--- a/src/vm/vm_set_ops.rs
+++ b/src/vm/vm_set_ops.rs
@@ -129,7 +129,12 @@ impl Interpreter {
             // Plain Hash keys are Str by default.
             return false;
         }
-        hash.contains_key(&needle.to_string_value())
+        // A Hash coerces to a Set of the keys whose values are truthy (that is
+        // how `.Set` and set membership treat it), so a key mapped to a falsy
+        // value (`0`, `Nil`, `""`) is NOT a member: `%(:a, b => 0) ∋ "b"` is
+        // False, matching `enum Foo «a b»; Foo.enums ∋ "a"` (a => 0).
+        hash.get(&needle.to_string_value())
+            .is_some_and(|v| v.truthy())
     }
 
     fn set_contains(&mut self, container: &Value, needle: &Value) -> bool {

--- a/t/hash-set-membership-truthy.t
+++ b/t/hash-set-membership-truthy.t
@@ -1,0 +1,31 @@
+use v6;
+use Test;
+
+# A Hash coerces to a Set of the keys whose values are truthy (the same rule
+# `.Set` uses). So set-membership operators (`∈`/`(elem)`, `∋`/`(cont)` and
+# their negations) treat a key mapped to a falsy value (0, Nil, "") as NOT a
+# member. Previously mutsu tested bare key existence, ignoring the value.
+
+plan 10;
+
+# The doc trap: enum values start at 0, so `a => 0` is a falsy pair and `a` is
+# not in the enum's Set.
+{
+    enum Foo «a b»;
+    nok Foo.enums ∋ 'a', 'enum key with value 0 is not a set member';
+    ok  Foo.enums ∋ 'b', 'enum key with value 1 is a set member';
+}
+
+# Direct hash membership honors value truthiness.
+ok  %(a => 1, b => 0) ∋ 'a', 'key with truthy value is a member (cont)';
+nok %(a => 1, b => 0) ∋ 'b', 'key with value 0 is not a member (cont)';
+ok  'a' ∈ %(a => 1, b => 0), 'truthy key is an element (elem)';
+nok 'b' ∈ %(a => 1, b => 0), 'value-0 key is not an element (elem)';
+
+# Falsy string/undef values also exclude the key.
+nok %(a => "") ∋ 'a', 'empty-string value is not a member';
+nok %(a => Nil) ∋ 'a', 'Nil value is not a member';
+
+# Negated operators flip correctly.
+ok %(a => 1, b => 0) ∌ 'b', 'value-0 key satisfies not-contains';
+ok 'b' ∉ %(a => 1, b => 0), 'value-0 key satisfies not-element';


### PR DESCRIPTION
## Problem

```
$ raku  -e 'enum Foo «a b»; say Foo.enums ∋ "a"'
False
$ mutsu -e 'enum Foo «a b»; say Foo.enums ∋ "a"'
True
```

A Hash coerces to a Set of the keys whose values are **truthy** (the same rule `.Set` uses), so a key mapped to a falsy value (`0`, `Nil`, `""`) is not a member. Enum values start at 0, so `a => 0` makes `a` absent from `Foo.enums.Set` (which raku reports as `Set.new("b")`). mutsu's `hash_contains` tested bare key existence, ignoring the value.

## Fix

Check that the key's value is truthy in `hash_contains`, mirroring the `Bag`/`Mix` arms just below it (which already test their weights). This fixes both `∈`/`(elem)` and `∋`/`(cont)` and their negations, since all route through `set_contains`.

`.Set` coercion of a hash was already correct (`%(a=>1,b=>0).Set` → `Set.new("a")`); only the membership operators diverged.

## Test

Pin `t/hash-set-membership-truthy.t` (10 assertions, matches reference raku). `make test` green; whitelisted set-operator (`set_elem`, `set_equality`, `set_subset`, `set_union`, ...), hash, and enum roast tests still pass.

Surfaced by the doc-diff harness (PLAN.md §8) on `raku-doc/doc/Language/traps.rakudoc` (finding [3]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)