### PR TITLE
fix: a `$` anchor closing a substitution pattern is not the `$/` variable

### DIFF
--- a/src/parser/primary/regex/lit.rs
+++ b/src/parser/primary/regex/lit.rs
@@ -24,7 +24,7 @@ use super::adverbs::{
 use super::call_args::{
     has_unescaped_statement_boundary, parse_call_arg_list, parse_colon_method_arg,
 };
-use super::scan::{scan_to_delim, scan_to_delim_p5};
+use super::scan::{scan_to_delim, scan_to_delim_p5, scan_to_delim_subst_pattern};
 use super::subst::{
     build_non_destructive_subst_expr, build_topic_subst_compound_expr, build_topic_subst_expr,
     parse_subst_replacement_expr, try_strip_subst_compound_assign,
@@ -268,10 +268,14 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
                     other => (other, false),
                 };
                 let r = &spec[open_ch.len_utf8()..];
+                // The substitution *pattern* half: a trailing `$` is the anchor,
+                // never `$/`, since the delimiter always separates pattern from
+                // replacement (`s/foo$/.bar/`). Use the subst-pattern scanner so
+                // the separator is not swallowed.
                 let scan_fn = if adverbs.perl5 {
                     scan_to_delim_p5
                 } else {
-                    scan_to_delim
+                    scan_to_delim_subst_pattern
                 };
                 if let Some((pattern, after_pat)) = scan_fn(r, open_ch, close_ch, is_paired) {
                     let r2 = if is_paired {
@@ -378,10 +382,14 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
                     other => (other, false),
                 };
                 let r = &spec[open_ch.len_utf8()..];
+                // The substitution *pattern* half: a trailing `$` is the anchor,
+                // never `$/`, since the delimiter always separates pattern from
+                // replacement (`s/foo$/.bar/`). Use the subst-pattern scanner so
+                // the separator is not swallowed.
                 let scan_fn = if adverbs.perl5 {
                     scan_to_delim_p5
                 } else {
-                    scan_to_delim
+                    scan_to_delim_subst_pattern
                 };
                 if let Some((pattern, after_pat)) = scan_fn(r, open_ch, close_ch, is_paired) {
                     // For paired delimiters, skip optional whitespace and opening delimiter
@@ -564,10 +572,14 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
                     other => (other, false),
                 };
                 let r = &spec[open_ch.len_utf8()..];
+                // The substitution *pattern* half: a trailing `$` is the anchor,
+                // never `$/`, since the delimiter always separates pattern from
+                // replacement (`s/foo$/.bar/`). Use the subst-pattern scanner so
+                // the separator is not swallowed.
                 let scan_fn = if adverbs.perl5 {
                     scan_to_delim_p5
                 } else {
-                    scan_to_delim
+                    scan_to_delim_subst_pattern
                 };
                 if let Some((pattern, after_pat)) = scan_fn(r, open_ch, close_ch, is_paired) {
                     let r2 = if is_paired {

--- a/src/parser/primary/regex/scan.rs
+++ b/src/parser/primary/regex/scan.rs
@@ -33,7 +33,23 @@ pub(in crate::parser) fn scan_to_delim(
     close_ch: char,
     is_paired: bool,
 ) -> Option<(&str, &str)> {
-    scan_to_delim_inner(input, open_ch, close_ch, is_paired, false)
+    scan_to_delim_inner(input, open_ch, close_ch, is_paired, false, false)
+}
+
+/// Like `scan_to_delim` but for the *pattern* half of a substitution
+/// (`s/pattern/replacement/`). There the closing delimiter is a mandatory
+/// separator, so a trailing `$` is always the end-of-string anchor — never the
+/// `$/` match variable. Disables the `$/` disambiguation heuristic that
+/// `scan_to_delim` applies for match regexes, which otherwise swallows the
+/// separator in `s/foo$/.bar/` (a `$` anchor followed by a replacement starting
+/// with `.`/`[`/`<`).
+pub(in crate::parser) fn scan_to_delim_subst_pattern(
+    input: &str,
+    open_ch: char,
+    close_ch: char,
+    is_paired: bool,
+) -> Option<(&str, &str)> {
+    scan_to_delim_inner(input, open_ch, close_ch, is_paired, false, true)
 }
 
 /// Like `scan_to_delim` but with an option to skip Raku-specific handling
@@ -45,7 +61,7 @@ pub(in crate::parser) fn scan_to_delim_p5(
     close_ch: char,
     is_paired: bool,
 ) -> Option<(&str, &str)> {
-    scan_to_delim_inner(input, open_ch, close_ch, is_paired, true)
+    scan_to_delim_inner(input, open_ch, close_ch, is_paired, true, false)
 }
 
 fn scan_to_delim_inner(
@@ -54,6 +70,7 @@ fn scan_to_delim_inner(
     close_ch: char,
     is_paired: bool,
     p5_mode: bool,
+    subst_pattern: bool,
 ) -> Option<(&str, &str)> {
     let mut depth = 1u32;
     let mut chars = input.char_indices();
@@ -252,12 +269,14 @@ fn scan_to_delim_inner(
                     None => return None,
                 }
             }
-        } else if !p5_mode && c == '$' && !is_paired {
+        } else if !p5_mode && !subst_pattern && c == '$' && !is_paired {
             // In non-paired delimiters (like /), $ followed by the close
             // delimiter MIGHT be a variable reference ($/ is the match variable)
             // or it might be the end-of-string anchor followed by the closing
             // delimiter. Disambiguate: if $/ is followed by [ or . or < it's
-            // the variable; otherwise it's anchor + close.
+            // the variable; otherwise it's anchor + close. Skipped for a
+            // substitution pattern, where the delimiter always separates and a
+            // trailing `$` is unambiguously the anchor (`s/foo$/.bar/`).
             let after = &input[i + 1..];
             if after.starts_with(close_ch) {
                 let after_delim = &after[close_ch.len_utf8()..];

--- a/t/subst-pattern-dollar-anchor.t
+++ b/t/subst-pattern-dollar-anchor.t
@@ -1,0 +1,26 @@
+use Test;
+
+# In a substitution `s/pattern/replacement/`, a trailing `$` in the pattern is
+# the end-of-string anchor and the following `/` is the mandatory separator.
+# mutsu's regex scanner mis-applied a match-regex heuristic that reads `$/` as
+# the match variable when the char after the delimiter is `.`/`[`/`<`, swallowing
+# the separator — so `s/foo$/.bar/` failed to parse. Found via the
+# real-distribution compat sweep (PDF::Combiner, docs/dist-compat-sweep.md),
+# which does `$outfile ~~ s/'.pdf'$/.{$Zip}dpi.pdf/`.
+
+plan 9;
+
+{ my $s = "x.pdf";  $s ~~ s/pdf$/.abc/;      is $s, "x..abc",  'anchor + replacement starting with `.`'; }
+{ my $s = "x.pdf";  $s ~~ s/pdf$/./;         is $s, "x..",     'anchor + replacement of a single `.`'; }
+{ my $s = "a[b";    $s ~~ s/b$/[z]/;         is $s, "a[[z]",   'anchor + replacement starting with `[`'; }
+{ my $s = "a b";    $s ~~ s/b$/<z>/;         is $s, "a <z>",   'anchor + replacement starting with `<`'; }
+{ my $Z = 150; my $s = "x.pdf"; $s ~~ s/'.pdf'$/.{$Z}dpi.pdf/; is $s, "x.150dpi.pdf", 'the PDF::Combiner idiom'; }
+
+# Non-destructive S/// and adverbial forms
+{ my $s = "foobar"; my $r = S/bar$/.X/ given $s; is $r, "foo.X", 'S/// non-destructive with anchor + `.`'; }
+{ my $s = "aXaX";   $s ~~ s:g/X$/.Y/;        is $s, "aXa.Y",   ':g still anchors only the final match'; }
+
+# The `$/` match variable inside a *match* regex is unaffected
+{ "abc" ~~ /b/; is $/.Str, "b", 'match regex still exposes $/'; }
+# A plain trailing-anchor substitution with a wordy replacement still works
+{ my $s = "cat"; $s ~~ s/t$/s/; is $s, "cas", 'anchor + wordy replacement unchanged'; }


### PR DESCRIPTION
`s/foo$/.bar/` failed to parse.

The regex scanner disambiguates a `$` that precedes a non-paired delimiter
(`/`): in a **match** regex `$/` may be the interpolated match variable, so when
`$/` is followed by `.`/`[`/`<` the scanner treats `$/` as the variable and does
**not** close the regex there. That heuristic is wrong for the **pattern** half
of a substitution, where the `/` is a mandatory separator and a trailing `$` is
unambiguously the end-of-string anchor. The separator got swallowed, so
`s/foo$/.bar/`, `s/foo$/./`, and `s/'.pdf'$/.{$x}dpi/` all failed to parse.

Fix: add `scan_to_delim_subst_pattern` (same scanner, minus the `$/` heuristic)
and use it for the pattern half of `s///`, `ss///`, and non-destructive `S///`.
The replacement half and match regexes are untouched, so `$/` inside a match
still resolves to the match variable.

Found via the real-distribution compat sweep
([docs/dist-compat-sweep.md](../blob/main/docs/dist-compat-sweep.md)):
**PDF::Combiner** does `$outfile ~~ s/'.pdf'$/.{$Zip}dpi.pdf/` — both its modules
(`PDF::Combiner`, `PDF::Combiner::Subs`) now parse.

Pin: `t/subst-pattern-dollar-anchor.t`. Every case verified against `raku`;
roast `S05-substitution/*` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)