### PR TITLE
fix: a finite xx count up to 1M materializes eagerly (Raku parity)

### DIFF
--- a/src/runtime/builtins_operators_repeat.rs
+++ b/src/runtime/builtins_operators_repeat.rs
@@ -245,7 +245,8 @@ impl Interpreter {
                     acc = Value::str(repeated.nfc().collect::<String>());
                 }
                 "xx" => {
-                    const EAGER_LIMIT: usize = 10_000;
+                    // See exec_list_repeat_op for the eager/lazy rationale.
+                    const EAGER_LIMIT: usize = 1_000_000;
                     const LAZY_CACHE: usize = 4_096;
                     // Callable LHS is expensive (each iteration calls eval_call_on_value),
                     // so use a much smaller cache to avoid timeouts on `callable xx *`.

--- a/src/vm/vm_arith_int_ops.rs
+++ b/src/vm/vm_arith_int_ops.rs
@@ -451,8 +451,16 @@ impl Interpreter {
             ));
         }
 
-        const EAGER_LIMIT: usize = 10_000;
+        // A finite `xx` count is eager in Raku (materializes all N elements,
+        // `is-lazy` is False). We materialize any finite count up to
+        // EAGER_LIMIT so realistic repeats (e.g. `1 xx 999999`) reify fully.
+        // Above that, an astronomically large finite count (`42 xx 2**62`, up
+        // to `2⁹⁹⁹⁹⁹`) or a genuinely infinite one (`xx *`) must NOT be
+        // materialized — it keeps only a cache prefix plus the logical count.
+        const EAGER_LIMIT: usize = 1_000_000;
         const LAZY_CACHE: usize = 4_096;
+        // Callable LHS is expensive (each element calls `eval_call_on_value`),
+        // so it caches far fewer elements to avoid timeouts on `callable xx *`.
         const LAZY_CACHE_CALLABLE: usize = 256;
 
         let is_callable = matches!(

--- a/t/xx-finite-eager.t
+++ b/t/xx-finite-eager.t
@@ -1,0 +1,36 @@
+use Test;
+
+# A finite `xx` count is eager in Raku: the result materializes all N
+# elements and is NOT lazy. mutsu previously capped large finite repeats at a
+# 4096-element lazy cache (`.is-lazy` True, `.elems` wrong / truncated).
+# See raku-doc/doc/Language/traps.rakudoc (append trap) and the QA doc-diff campaign.
+
+plan 9;
+
+# Direct .elems on a large finite repeat (was: "Cannot .elems a lazy list").
+is (1 xx 999999).elems, 999999, 'finite xx: direct .elems is the full count';
+
+# Not lazy for a finite count.
+is (1 xx 999999).is-lazy, False, 'finite xx is not lazy';
+
+# Assigning to an array materializes all N.
+my @a = 1 xx 999999;
+is @a.elems, 999999, 'assigning finite xx to @a keeps all elements';
+
+# append of a large finite repeat (the traps.rakudoc example).
+my @b;
+@b.append: @a;
+is @b.elems, 999999, 'append of a 999999-element list keeps all';
+
+# Just past the old EAGER_LIMIT (10_000) boundary stays correct.
+is (1 xx 10001).elems, 10001, 'just past the old eager limit is eager';
+is (1 xx 10001).is-lazy, False, 'just past the old eager limit is not lazy';
+
+# Infinite repeat is still lazy (unchanged).
+is (1 xx *).is-lazy, True, 'infinite xx * stays lazy';
+is (1 xx *).head(3).raku, '(1, 1, 1).Seq', 'infinite xx * still yields elements';
+
+# do-block LHS re-evaluates once per finite element.
+my $i = 0;
+my @c = do { $i++ } xx 5;
+is @c.join(','), '0,1,2,3,4', 'do-block xx N re-evaluates eagerly N times';


### PR DESCRIPTION
## Problem

Raku's `xx` is **eager** for any finite count: `(1 xx 999999).is-lazy` is
`False` and it materializes all N elements. mutsu capped finite repeats at
`EAGER_LIMIT = 10_000` and above that produced a 4096-element lazy cache, so:

```raku
my @a = 1 xx 999999; say @a.elems;   # mutsu: 4096   raku: 999999
say (1 xx 999999).elems;             # mutsu: throws "Cannot .elems a lazy list"
say (1 xx 999999).is-lazy;           # mutsu: True    raku: False
```

Surfaced by the QA doc-diff harness on `Language/traps.rakudoc` (the
`@b.append: @a` trap where `@a = 1 xx 999999`).

## Fix

Raise `EAGER_LIMIT` to `1_000_000` (in both the VM `ListRepeat` path and the
runtime `call_repeat_infix` slow path) so realistic finite repeats reify fully,
while astronomically large finite counts (`42 xx 2**62`, up to `2⁹⁹⁹⁹⁹`) and
genuinely infinite ones (`xx *` / `xx Inf`) still stay cheap via the
lazy cache + logical `elems_count`.

The 1M ceiling keeps `roast/S03-operators/repeat.t`'s "sunk, plain value `xx`
sink cheaply" subtest passing: `42 xx 9999999999` / `42 xx 2**62` / `42 xx ∞`
must not be materialized, and their `.iterator.count-only` still reports the
exact (possibly big) logical count.

## Tests

- New pin `t/xx-finite-eager.t` (finite eager `.elems`/`.is-lazy`/array/append,
  the 1M boundary, infinite `xx *` stays lazy, `do`-block re-eval).
- `make test` PASS (1974 files, 18816 tests).
- `roast/S03-operators/repeat.t`, `S03-metaops/{hyper,reduce}.t` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)