### PR TITLE
fix: named param anonymous-scalar alias with sub-signature / required marker

### DIFF
--- a/src/parser/stmt/sub_param/param_inner.rs
+++ b/src/parser/stmt/sub_param/param_inner.rs
@@ -701,10 +701,16 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
             let (r3, sub_params) = super::super::sub::parse_param_list(r3)?;
             let (r3, _) = ws(r3)?;
             let (r3, _) = parse_char(r3, ')')?;
-            // If it's a single simple variable param, use its name; otherwise sub-signature
+            // If it's a single simple variable param, use its name; otherwise sub-signature.
+            // An anonymous scalar `$` parses to the name `__ANON_STATE__`; it is still a
+            // plain single variable, so accept it here (as the sigil-prefixed anonymous
+            // `@__ANON_ARRAY__` / `%__ANON_HASH__` already are). Without this, a named
+            // parameter with an anonymous scalar and a trailing sub-signature —
+            // `:literal($) ($payload, *@arguments)` (SQL::Abstract) — skipped this branch
+            // and the outer sub-signature went unparsed.
             if sub_params.len() == 1
                 && sub_params[0].sub_signature.is_none()
-                && !sub_params[0].name.starts_with("__")
+                && (!sub_params[0].name.starts_with("__") || sub_params[0].name == "__ANON_STATE__")
             {
                 let mut p = super::helpers::make_param(alias_name.clone());
                 p.named = true;
@@ -713,19 +719,24 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
                 p.onearg = onearg;
                 p.type_constraint = type_constraint;
                 p.sub_signature = Some(sub_params.clone());
-                // Check for a sub-signature after the alias: :x($r) (Str $g, Any $i)
+                // Check for a sub-signature after the alias: :x($r) (Str $g, Any $i).
+                // An optional `!`/`?` required marker may sit between the alias and
+                // the sub-signature (`:function($)! (Str :$over)`), so consume it
+                // first and re-check for the `(`.
                 let (r3, _) = ws(r3)?;
-                if r3.starts_with('(') {
-                    let (r4, _) = parse_char(r3, '(')?;
+                let (r3m, pre_required, pre_opt) = super::helpers::parse_required_suffix(r3);
+                let (r3m, _) = ws(r3m)?;
+                if r3m.starts_with('(') {
+                    let (r4, _) = parse_char(r3m, '(')?;
                     let (r4, _) = ws(r4)?;
                     let (r4, outer_sub) = super::super::sub::parse_param_list(r4)?;
                     let (r4, _) = ws(r4)?;
                     let (r3_new, _) = parse_char(r4, ')')?;
                     p.outer_sub_signature = Some(outer_sub);
-                    let (rest, alias_required, alias_opt_marker) =
+                    let (rest, post_required, post_opt) =
                         super::helpers::parse_required_suffix(r3_new);
-                    p.required = alias_required;
-                    p.optional_marker = alias_opt_marker;
+                    p.required = pre_required || post_required;
+                    p.optional_marker = pre_opt || post_opt;
                     let (rest, _) = ws(rest)?;
                     let mut param_traits = Vec::new();
                     let (mut rest, _) = ws(rest)?;
@@ -762,13 +773,11 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
                     p.default = default;
                     return Ok((rest, p));
                 }
-                // Handle optional (?) / required (!) suffix after alias
-                let (rest, alias_required, alias_opt_marker) =
-                    super::helpers::parse_required_suffix(r3);
-                p.required = alias_required;
-                p.optional_marker = alias_opt_marker;
+                // No outer sub-signature: any `!`/`?` marker was already consumed above.
+                p.required = pre_required;
+                p.optional_marker = pre_opt;
                 // Skip whitespace
-                let (rest, _) = ws(rest)?;
+                let (rest, _) = ws(r3m)?;
                 // Handle is copy, is rw, is readonly, is raw traits
                 let mut param_traits = Vec::new();
                 let (mut rest, _) = ws(rest)?;

--- a/t/named-param-anon-scalar-subsig.t
+++ b/t/named-param-anon-scalar-subsig.t
@@ -1,0 +1,26 @@
+use Test;
+
+# A named parameter whose alias is an anonymous scalar `$`, followed by a
+# sub-signature, and/or a `!`/`?` required marker between them:
+#   :literal($) ($payload, *@arguments)
+#   :function($)! (Str :$over, *%args)
+# The anonymous scalar parses to the internal name `__ANON_STATE__` (unlike
+# `@`/`%`, which keep a sigil prefix), so it was wrongly excluded from the
+# "single simple variable" alias branch and the trailing sub-signature went
+# unparsed. Separately, a `!`/`?` marker before the sub-signature was not
+# consumed. Found via the real-distribution compat sweep (SQL::Abstract,
+# docs/dist-compat-sweep.md).
+
+plan 8;
+
+# Parses (the load smoke test the dist needs)
+lives-ok { EVAL 'sub a(:foo($) ($x, $y)) { }' }, ':name($) with sub-signature parses';
+lives-ok { EVAL 'sub b(:foo($)! ($x, $y)) { }' }, ':name($)! (required marker before sub-sig)';
+lives-ok { EVAL 'sub c(:foo($)? ($x, $y)) { }' }, ':name($)? (optional marker before sub-sig)';
+lives-ok { EVAL 'sub d(Map :function($)! (Str :$over, *%args)) { }' }, 'typed named anon scalar with marker + sub-sig';
+lives-ok { EVAL 'sub e(:foo($p)! ($x, $y)) { }' }, ':name($var)! marker before sub-sig (named var)';
+
+# The already-working sibling forms still parse
+lives-ok { EVAL 'sub f(:foo(@) (@a)) { }' }, 'anonymous array alias still parses';
+lives-ok { EVAL 'sub g(:foo($)) { }' }, 'anonymous scalar alias with no sub-sig still parses';
+lives-ok { EVAL 'sub h(:foo($p) ($x, $y)) { }' }, 'named-var alias + sub-sig still parses';


### PR DESCRIPTION
Two related named-parameter parsing gaps, both blocking **SQL::Abstract** on
`use` (found via the real-distribution compat sweep,
[docs/dist-compat-sweep.md](../blob/main/docs/dist-compat-sweep.md)):

1. **`:literal($) ($payload, *@arguments)`** — a named parameter whose alias is an
   anonymous scalar `$`, followed by a sub-signature. The anonymous scalar parses
   to the internal name `__ANON_STATE__` (starts with `__`), so it was excluded
   from the "single simple variable" alias branch that also handles a trailing
   sub-signature. The sigil-prefixed anonymous `@`/`%` (`@__ANON_ARRAY__` /
   `%__ANON_HASH__`) were already accepted; only `$` failed. Now `__ANON_STATE__`
   is accepted there too.

2. **`:function($)! (Str :$over, *%args)`** — a `!`/`?` required marker *between*
   the alias and the outer sub-signature. The marker was only parsed *after* the
   sub-signature, so a marker before it left the `(...)` unparsed. Now an optional
   marker is consumed first, the `(` is re-checked, and any post-sig marker is
   OR-ed in.

SQL::Abstract uses both forms and now parses. Pin:
`t/named-param-anon-scalar-subsig.t`.

The runtime destructure binding of such an outer sub-signature is a separate
**pre-existing** gap (the named-var form `:foo($p) ($a, $b)` doesn't bind `$a`/`$b`
either) — it doesn't affect the load smoke test. Verified against `raku`; roast
`S06-signature/*` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)