### PR TITLE
fix: equal-length string ranges expand as a per-position odometer

### DIFF
--- a/src/runtime/utils/list.rs
+++ b/src/runtime/utils/list.rs
@@ -149,6 +149,58 @@ pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
                             .map(|c| Value::str(c.to_string()))
                             .collect()
                     }
+                } else if !excl_start
+                    && !excl_end
+                    && a.chars().count() == b.chars().count()
+                    && a.chars().count() > 1
+                {
+                    // Equal-length inclusive string ranges use Raku's per-position
+                    // "odometer": each character position independently ranges from
+                    // a[i] to b[i] (ascending if a[i] <= b[i], else descending), and
+                    // the positions form a mixed-radix counter with the rightmost
+                    // varying fastest. E.g. "r2".."t3" is {r,s,t} x {2,3} =
+                    // (r2 r3 s2 s3 t2 t3), NOT the string-succ sequence
+                    // (r2 r3 r4 ... t3). A range whose start sorts after its end is
+                    // empty (e.g. "ba".."ab").
+                    if a.as_str() > b.as_str() {
+                        return Vec::new();
+                    }
+                    let axes: Vec<Vec<char>> = a
+                        .chars()
+                        .zip(b.chars())
+                        .map(|(lo, hi)| {
+                            let (lo, hi) = (lo as u32, hi as u32);
+                            if lo <= hi {
+                                (lo..=hi).filter_map(char::from_u32).collect()
+                            } else {
+                                (hi..=lo).rev().filter_map(char::from_u32).collect()
+                            }
+                        })
+                        .collect();
+                    let limit = MAX_RANGE_EXPAND as usize;
+                    let mut result = Vec::new();
+                    let mut idx = vec![0usize; axes.len()];
+                    'odometer: loop {
+                        if result.len() >= limit {
+                            break;
+                        }
+                        let s: String = idx.iter().zip(axes.iter()).map(|(&i, ax)| ax[i]).collect();
+                        result.push(Value::str(s));
+                        // Increment the odometer, rightmost wheel fastest.
+                        let mut pos = axes.len();
+                        loop {
+                            if pos == 0 {
+                                break 'odometer;
+                            }
+                            pos -= 1;
+                            idx[pos] += 1;
+                            if idx[pos] < axes[pos].len() {
+                                break;
+                            }
+                            idx[pos] = 0;
+                        }
+                    }
+                    result
                 } else {
                     let split_numeric_core = |s: &str| -> Option<(String, String, String)> {
                         let mut start_byte = None;

--- a/t/string-range-odometer.t
+++ b/t/string-range-odometer.t
@@ -1,0 +1,30 @@
+use Test;
+
+# Equal-length inclusive string ranges use Raku's per-position "odometer":
+# each character position independently ranges from a[i] to b[i] (ascending if
+# a[i] <= b[i], else descending), forming a mixed-radix counter with the
+# rightmost position varying fastest. mutsu previously used a string-succ
+# sequence, giving e.g. "r2".."t3" the wrong (r2 r3 r4 ... t3) expansion.
+# See raku-doc/doc/Language/traps.rakudoc and the QA doc-diff campaign.
+
+plan 12;
+
+is ~("r2".."t3"), 'r2 r3 s2 s3 t2 t3', 'r2..t3 is an odometer, not succ';
+is ~("a1".."c3"), 'a1 a2 a3 b1 b2 b3 c1 c2 c3', 'a1..c3 odometer';
+is ("az".."bc").elems, 48, 'az..bc: pos1 z..c descends (2 x 24)';
+is ~("19".."31"), '19 18 17 16 15 14 13 12 11 29 28 27 26 25 24 23 22 21 39 38 37 36 35 34 33 32 31',
+    '19..31: descending digit wheel';
+is ~("aa1".."bb3"), 'aa1 aa2 aa3 ab1 ab2 ab3 ba1 ba2 ba3 bb1 bb2 bb3', 'three-position odometer';
+is ~("a2".."a5"), 'a2 a3 a4 a5', 'fixed first position';
+is ~("ac".."ca"), 'ac ab aa bc bb ba cc cb ca', 'mixed ascending/descending wheels';
+
+# A range whose start sorts after its end is empty.
+is ("ba".."ab").elems, 0, 'ba..ab is empty (start after end)';
+
+# Cases where the odometer coincides with string succession stay correct.
+is ~("aa".."ad"), 'aa ab ac ad', 'common-prefix range (matches succ)';
+is ("aa".."zz").elems, 676, 'aa..zz full 26x26 grid';
+
+# Single-char and different-length ranges are unaffected.
+is ~("a".."e"), 'a b c d e', 'single-char range unchanged';
+is ~("Y".."AB"), '', 'different-length range stays empty';


### PR DESCRIPTION
## Problem

Raku expands an **equal-length inclusive** string range like `"r2".."t3"` as a
per-position *odometer*: each character position independently ranges from
`a[i]` to `b[i]` (ascending if `a[i] <= b[i]`, else descending), forming a
mixed-radix counter with the rightmost position varying fastest.

```raku
say ~("r2".."t3");   # raku: r2 r3 s2 s3 t2 t3       mutsu: r2 r3 r4 ... s0 ... t3
say ~("a1".."c3");   # raku: a1 a2 a3 b1 b2 b3 c1 c2 c3
say ("az".."bc").elems;  # raku: 48  ({a,b} x (z..c))
say ~("19".."31");   # raku: 19 18 ... 11 29 ... 21 39 ... 31  (descending digit wheel)
```

mutsu used a string-`succ` sequence, which overshoots a shorter non-leftmost
position to its class maximum (`'9'`/`'z'`) before carrying, so `"r2".."t3"`
wrongly expanded to `(r2 r3 r4 ... t3)`.

Surfaced by the QA doc-diff harness on `Language/traps.rakudoc` (findings that
the stale doc listed as `az, ba, bb, bc` — the old succ behavior — but current
raku produces the 48-element odometer).

## Fix

Add an equal-length inclusive branch in the `GenericRange` string expansion
(`src/runtime/utils/list.rs`) that builds each position's character axis and
iterates the odometer product (capped at `MAX_RANGE_EXPAND`). A range whose
start sorts after its end is empty (`"ba".."ab"`).

Unchanged paths:
- single-char (`"a".."e"`) — codepoint range
- different-length (`"Y".."AB"`) — succ / numeric-core (still `""`)
- exclusive-endpoint multi-char — existing behavior (raku's exclusive string
  semantics are quirky and rarely used)

The odometer **coincides** with succ for common-prefix / to-classmax ranges
(`"aa".."ad"` = 4, `"aa".."zz"` = 676), so those stay correct.

## Tests

- New pin `t/string-range-odometer.t` (12 cases, all verified against `raku`).
- `make test` PASS (All tests successful).
- `roast/S03-operators/range.t`, `roast/S02-types/range.t`,
  `roast/S03-operators/range-basic.t` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)