### PR TITLE
fix: an angle-word subscript key may contain parentheses

### DIFF
--- a/src/parser/expr/postfix/helpers.rs
+++ b/src/parser/expr/postfix/helpers.rs
@@ -74,6 +74,12 @@ pub(crate) fn is_angle_key_char(c: char) -> bool {
         || c == '@'
         || c == '%'
         || c == '&'
+        // Parentheses are ordinary characters inside angle-word quoting, so an
+        // angle *subscript* key may contain them too: `%h<(default)>` is the
+        // string key `(default)` (App::Rak). The `<...>` word-list literal
+        // already accepts them; this aligns the subscript path.
+        || c == '('
+        || c == ')'
         || is_non_breaking_space(c)
         || (!c.is_ascii() && !c.is_whitespace())
 }

--- a/t/angle-subscript-parens.t
+++ b/t/angle-subscript-parens.t
@@ -1,0 +1,37 @@
+use Test;
+
+# Parentheses are ordinary characters inside angle-word quoting, so an angle
+# *subscript* key may contain them: `%h<(default)>` is the string key
+# `(default)`. mutsu's `<...>` word-list literal already accepted parens, but the
+# subscript path rejected them. Found via the real-distribution compat sweep
+# (App::Rak, docs/dist-compat-sweep.md), which does `%hash<(default)>`.
+
+plan 6;
+
+{
+    my %h = '(default)' => 42, 'x' => 1;
+    is %h<(default)>, 42, 'angle subscript key containing parens';
+}
+{
+    my %h = '(a)' => 1, '(b)' => 2;
+    is-deeply %h<(a) (b)>, (1, 2), 'multi-word angle subscript with parens';
+}
+{
+    my %h = '(k)' => 0;
+    if %h<(default)> -> $d { flunk 'should not enter' } else { pass 'missing paren key is falsy' }
+}
+{
+    # the angle-bind chain (from an earlier fix) still works with a paren key
+    my %h;
+    my $x := %h<(k)> := 7;
+    is %h<(k)>, 7, 'bind through a paren angle subscript';
+}
+{
+    # `.<key>` dotted form
+    my %h = '(z)' => 9;
+    is %h.<(z)>, 9, 'dotted angle subscript with parens';
+}
+{
+    # a real chained comparison (no subscript) is unaffected
+    ok !(1 < 2 > 3), 'chained `<`/`>` comparison still parses as comparison';
+}


### PR DESCRIPTION
`%h<(default)>` failed to parse.

Parentheses are ordinary characters inside angle-word quoting, so an angle
**subscript** key may contain them — `<(default)>` is the string key `(default)`.
The `<...>` word-list **literal** already accepted parens (`<(a) (b)>` →
`("(a)", "(b)")`); only the subscript path rejected them, because
`is_angle_key_char` (which gates whether `<...>` is a subscript vs a comparison)
omitted `(` and `)`. Adding them aligns the subscript path with the literal and
with raku. A real chained comparison (`1 < 2 > 3`, whitespace-separated) is
unaffected, since whitespace is not an angle-key char.

Found via the real-distribution compat sweep
([docs/dist-compat-sweep.md](../blob/main/docs/dist-compat-sweep.md)): App::Rak
does `%hash<(default)>` (it has a further, unrelated blocker at another line).

Pin: `t/angle-subscript-parens.t` (subscript, `.<...>` dotted, multi-word, and
bind-chain forms, plus the comparison non-regression). Verified against `raku`;
roast `S09-subscript/*` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)