### PR TITLE
fix: proceed inside a default block falls through instead of erroring

### DIFF
--- a/src/vm/vm_given_when_ops.rs
+++ b/src/vm/vm_given_when_ops.rs
@@ -334,6 +334,15 @@ impl Interpreter {
         let end = body_end as usize;
         match self.run_range(code, body_start, end, compiled_fns) {
             Ok(()) => {}
+            // `proceed` inside a `default` falls through WITHOUT the default
+            // matching: suppress the succeed signal and continue past the block
+            // (a `default` has no further candidate), so the enclosing `given`
+            // ends normally and execution resumes after it. Mirrors the
+            // `is_proceed` handling in `exec_when_op`.
+            Err(e) if e.is_proceed() => {
+                *ip = end;
+                return Ok(());
+            }
             Err(e) if e.is_succeed() => {
                 loan_env!(self, set_when_matched(true));
                 return Err(e);

--- a/t/proceed-in-default.t
+++ b/t/proceed-in-default.t
@@ -1,0 +1,46 @@
+use Test;
+
+# `proceed` inside a `default` block falls through WITHOUT the default matching:
+# it leaves the block (skipping the rest of it) and, since a `default` has no
+# further candidate, the enclosing `given` ends normally and execution resumes
+# after it. mutsu previously propagated the `proceed` control signal as an
+# unhandled runtime error. See raku-doc/doc/Language/control.rakudoc.
+
+plan 5;
+
+# proceed in default: rest of the block is skipped, program continues.
+my @out;
+given * {
+    default {
+        @out.push: 'in-default';
+        proceed;
+        @out.push: 'never';
+    }
+}
+@out.push: 'after-given';
+is @out.join(','), 'in-default,after-given', 'proceed in default skips rest and falls through';
+
+# A when that proceeds still reaches the default.
+my @seq;
+given 5 {
+    when Int { @seq.push: 'int'; proceed }
+    default  { @seq.push: 'def' }
+}
+is @seq.join(','), 'int,def', 'when proceed continues to default';
+
+# proceed in default after a non-matching when: default runs, then falls through.
+my @s2;
+given 'x' {
+    when Int  { @s2.push: 'int' }
+    default   { @s2.push: 'def'; proceed; @s2.push: 'never' }
+}
+@s2.push: 'done';
+is @s2.join(','), 'def,done', 'default proceed leaves given normally';
+
+# Normal default (no proceed) still matches and yields its value.
+my $v = do given 5 { default { 'matched' } };
+is $v, 'matched', 'plain default still returns its value';
+
+# succeed in default still returns the given value (unaffected by the fix).
+my $w = do given 5 { default { succeed 'S'; 'no' } };
+is $w, 'S', 'succeed in default still returns its argument';


### PR DESCRIPTION
## Problem

`proceed` in a `default` block should leave the block (skipping the rest of it)
without the default *matching*. Since a `default` has no further candidate, the
enclosing `given` then ends normally and execution resumes after it.

```raku
given * { default { proceed; "never".say } }; "This says".say
# raku:  This says
# mutsu: Runtime error   (the `proceed` control signal escaped unhandled)
```

## Fix

`exec_default_op` (`src/vm/vm_given_when_ops.rs`) propagated every non-succeed
error from the block body, including the `proceed` control signal. Handle
`is_proceed` the same way `exec_when_op` already does: suppress the default's
succeed signal and continue past the block.

## Tests

- New pin `t/proceed-in-default.t` (proceed-in-default fall-through, when→default
  proceed, plain default, `succeed` in default — all verified against `raku`).
- `make test` PASS (All tests successful).
- `roast/S04-statements/{given,when}.t`, `roast/S04-exception-handlers/control.t` PASS.

Surfaced by the QA doc-diff harness on `Language/control.rakudoc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)