### PR TITLE
fix: sort on a non-list value returns a one-element Seq

### DIFF
--- a/src/runtime/methods_collection_ops/sort.rs
+++ b/src/runtime/methods_collection_ops/sort.rs
@@ -665,7 +665,11 @@ pub(crate) fn sort_value_generic(
                 .collect();
             sort_value_generic(caller, Value::array(items), args)
         }
-        _ => Ok(target.clone()),
+        // Any non-list value sorts as a one-element list of itself: `Any.sort`
+        // is `self.list.sort`, so `"cba".sort` is `("cba",).Seq`, `42.sort` is
+        // `(42,).Seq`, etc. (Set/Bag/Mix/Hash and the list-ish kinds are handled
+        // above.) mutsu previously returned the scalar unchanged.
+        _ => Ok(Value::seq(vec![target.clone()])),
     }
 }
 

--- a/t/scalar-sort-seq.t
+++ b/t/scalar-sort-seq.t
@@ -1,0 +1,21 @@
+use Test;
+
+# `.sort` on any non-list value is `self.list.sort`: a one-element Seq of the
+# value itself. So "cba".sort is ("cba",).Seq, NOT the sorted characters, and
+# 42.sort is (42,).Seq. mutsu previously returned the scalar unchanged.
+# See raku-doc/doc/Language/traps.rakudoc (the "sort a string" trap).
+
+plan 8;
+
+is "cba".sort.elems, 1, 'Str.sort is a one-element list';
+is "cba".sort.raku, '("cba",).Seq', 'Str.sort wraps the whole string';
+is 42.sort.raku, '(42,).Seq', 'Int.sort is a one-element Seq';
+is (1/2).sort.raku, '(0.5,).Seq', 'Rat.sort is a one-element Seq';
+is (1 => 2).sort.raku, '(1 => 2,).Seq', 'Pair.sort is a one-element Seq';
+
+# The documented idiom to actually sort a string's characters still works.
+is "cba".comb.sort.join, 'abc', 'comb.sort.join sorts the characters';
+
+# List / hash sorting is unaffected.
+is (3, 1, 2).sort.join(','), '1,2,3', 'list sort still sorts';
+is %(b => 2, a => 1).sort.raku, '(:a(1), :b(2)).Seq', 'hash sort still sorts pairs';


### PR DESCRIPTION
## Problem

`Any.sort` is `self.list.sort`, so `.sort` on any non-list value yields a
**one-element Seq of the value itself**:

```raku
say "cba".sort;        # raku: (cba)          mutsu: cba
say 42.sort.raku;      # raku: (42,).Seq      mutsu: 42
say (1 => 2).sort.raku;# raku: (1 => 2,).Seq  mutsu: 1 => 2
```

The trap (per `Language/traps.rakudoc`) is that `"cba".sort` does NOT sort the
characters — it sorts a one-element list containing the whole string. mutsu's
`sort_value_generic` fallthrough (`_ => Ok(target.clone())`) returned the scalar
unchanged.

## Fix

Wrap the value in a one-element Seq in the fallthrough arm
(`src/runtime/methods_collection_ops/sort.rs`). Set/Bag/Mix/Hash and the
list-ish kinds (Array/Seq/Slip/Range) are handled by earlier arms and are
unaffected; the documented idiom `"cba".comb.sort.join` still sorts characters.

## Tests

- New pin `t/scalar-sort-seq.t` (Str/Int/Rat/Pair scalar sort, plus list/hash
  sort unaffected — all verified against `raku`).
- `make test` PASS (All tests successful).
- `roast/S32-list/sort.t`, `roast/S02-types/array.t`,
  `t/{setbagmix-sort,sort-native,sort-spaceship-numeric-coerce}.t` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)