### PR TITLE
fix: `&.name` accessor for a callable attribute

### DIFF
--- a/src/parser/primary/var/sigil_vars.rs
+++ b/src/parser/primary/var/sigil_vars.rs
@@ -364,6 +364,27 @@ pub(crate) fn hash_var(input: &str) -> PResult<'_, Expr> {
 /// lookups like `&::($expr)::name` or `&CALLER::($expr)::name`.
 pub(crate) fn code_var(input: &str) -> PResult<'_, Expr> {
     let (input, _) = parse_char(input, '&')?;
+    // `.` twigil: `&.name` → the public accessor of a `has &.name` callable
+    // attribute, i.e. `self.name`, mirroring `$.attr`. Desugaring to the method
+    // call (rather than a `.`-named CodeVar) reuses the accessor dispatch, so a
+    // following `.( ... )` invokes the returned callable (`&.function.($x)`).
+    if input.starts_with('.')
+        && input.len() > 1
+        && (input.as_bytes()[1].is_ascii_alphabetic() || input.as_bytes()[1] == b'_')
+    {
+        let after_dot = &input[1..];
+        let (rest, name) = parse_qualified_ident_with_hyphens(after_dot)?;
+        return Ok((
+            rest,
+            Expr::MethodCall {
+                target: Box::new(Expr::BareWord("self".to_string())),
+                name: crate::symbol::Symbol::intern(&name),
+                args: Vec::new(),
+                modifier: None,
+                quoted: false,
+            },
+        ));
+    }
     // Dereference callable stored in a variable/expression:
     // &$x, &@x, &%x, &($expr)
     if input.starts_with('$') {

--- a/t/ampersand-dot-accessor.t
+++ b/t/ampersand-dot-accessor.t
@@ -1,0 +1,38 @@
+use Test;
+
+# `&.name` is the public accessor of a `has &.name` callable attribute — i.e.
+# `self.name` — mirroring `$.attr`/`@.attr`/`%.attr`. mutsu parsed the scalar/
+# array/hash `.`-twigil accessors but not the `&` one, so `&.function.($x)`
+# failed to parse. Found via the real-distribution compat sweep (Metropolis,
+# docs/dist-compat-sweep.md), which calls `&.function.( $!x )`.
+
+plan 6;
+
+{
+    class C { has &.f; method run($x) { &.f.($x) } }
+    is C.new(f => *+1).run(5), 6, '&.attr.($x) invokes the callable attribute';
+}
+{
+    class C { has &.f = *+1; method m { &.f.(10) } }
+    is C.new.m, 11, '&.attr with a default callable';
+}
+{
+    class C { has &.jumper; method m { &.jumper.(mean => 5) } }
+    is C.new(jumper => -> :$mean { $mean }).m, 5, '&.attr.(named => v) passes named args';
+}
+{
+    # &.attr returns the callable itself (bare, no call)
+    class C { has &.f; method getit { &.f } }
+    my $c = C.new(f => { 42 });
+    is $c.getit.(), 42, '&.attr returns the Callable, invocable later';
+}
+{
+    # hyphenated attribute name
+    class C { has &.my-fn; method m { &.my-fn.(3) } }
+    is C.new(my-fn => *²).m, 9, '&.attr with a hyphenated name';
+}
+{
+    # $.attr accessor for a & attribute still works too
+    class C { has &.f = *+2; method m { $.f.(8) } }
+    is C.new.m, 10, '$.attr accessor for a callable attribute still works';
+}


### PR DESCRIPTION
`&.function.($x)` failed to parse.

mutsu handled the `.`-twigil public accessors for scalar/array/hash attributes
(`$.attr`, `@.attr`, `%.attr`) but not the `&` sigil, so a `has &.name` callable
attribute could not be read via `&.name`. Parse `&.name` as `self.name` (the
accessor method call), reusing the existing accessor dispatch, so a trailing
`.( ... )` invokes the returned callable and a bare `&.name` returns it.

Found via the real-distribution compat sweep
([docs/dist-compat-sweep.md](../blob/main/docs/dist-compat-sweep.md)):
**Metropolis** reads `&.function.( $!x )` and `&.jumper.( mean => $!x )`, and now
parses.

Pin: `t/ampersand-dot-accessor.t`. Verified against `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)