### PR TITLE
fix: (B)-gate mechanism #3 — carrier aggregate writeback clobbers stale-env slots

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -521,22 +521,34 @@ The chain:
    the initializer runs).
 2. `$l = List.new(...)` is a plain-lexical `SetLocal`; the gate **skips its env
    write**, so the slot becomes the List but `env["l"]` stays `Any` (stale).
-3. `isa-ok $l` registers `l` as a pending writeback source, and on return the
-   call-boundary reconcile does `self.locals[slot] = self.env().get("l")`
-   (`apply_pending_rw_writeback` vm_env_helpers.rs:1089-1094, and the twin
-   `apply_pending_caller_var_writeback` :1124-1129) — **clobbering the good slot with
-   the stale `env["l"] = Any`**.
+3. `isa-ok $l` (a Test fn) dispatches through the **carrier fallback** in
+   `exec_exec_call_pairs_op`, whose post-carrier reconcile
+   `carrier_writeback_changed_aggregates` (vm_env_helpers.rs) writes a slot back from
+   env when the *current* env value differs in variant from the slot — the
+   "type change away from container" case (`$a does Role` turning a Hash into a
+   Mixin). With the gate ON that read is stale: `env["l"] = Any` (a `Package`) differs
+   in variant from the slot's `List` (an `Array`), so it **clobbers the good slot with
+   the decl-seed `Any`**.
 
-So the reconcile reading the caller slot **from env** is the shared root under every
-Test-using cluster (native-ctor, method/attr-writeback, and much of the io/misc
-bucket, all of which do `my $x = ...; is/isa-ok/ok $x...`). **Fix #3 first** — make
-`apply_pending_rw_writeback` / `apply_pending_caller_var_writeback` env-independent
-for a slot the callee did not actually write (gate the slot overwrite on the source
-being genuinely callee-written, i.e. env_dirty for that name, rather than
-unconditionally pulling `env.get(source)`). That one change is expected to clear a
-large fraction of the 75, after which the true #2 (cross-thread) / #4 (curry)
-residue is what remains. This reorders the burndown: **#3 (call-boundary reconcile)
-before the per-cluster name-folding.**
+**Correction (2026-07-19, verified):** the drill-down originally fingered
+`apply_pending_rw_writeback` (:1089/:1124). Instrumentation disproved that — on this
+repro both of those drain with **empty** source sets; the actual clobber is the
+`carrier_writeback_changed_aggregates` "type change away" branch, which did **not**
+check that env genuinely changed *during* the carrier (unlike its sibling overwritable
+branch, which already diffs against the pre-carrier `pre_env` snapshot).
+
+**Fix (landed):** require `env_changed` (a `pre_env[i] != cur` diff) before the
+type-change slot write, matching the overwritable branch. Gate OFF this is
+byte-identical — env tracks the slot, so a fired type-change always had
+`prev != cur` anyway; gate ON it suppresses the stale-`Any` clobber. Pin:
+`t/gate-b-carrier-aggregate-clobber.t`.
+
+**ON-survey delta:** 75 → **61** genuine ON-only regressions (all 61 pass OFF). The
+14 files cleared are exactly the "native ctor / `.Set/.Bag/.Mix`/hash coerce"
+cluster's carrier-writeback subset (`my $x = <aggregate>; is/isa-ok/ok $x`). The
+remaining 61 belong to the other mechanisms (#2 cross-thread, #4 curry, closure
+capture, rw-redispatch, `let`/`temp`, sigilless) — those are the next per-cluster
+name-folding targets.
 
 ## §1.4 flip blast-radius measurement (2026-07-02, debug + release `prove t/`)
 

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -27,6 +27,26 @@ pub(crate) fn reflective_name_access_possible() -> bool {
     REFLECTIVE_NAME_ACCESS_SEEN.load(Ordering::Relaxed)
 }
 
+/// `(B)` per-store env-write gate (docs/lexical-scope-slot-campaign.md, "The
+/// `(B)` per-store env-write gate"). Default OFF is byte-identical to the
+/// pre-gate build: `exec_set_local_op_inner` mirrors every plain-lexical store
+/// into the name-keyed `env`. Under `MUTSU_GATE_LOCAL_ENV_WRITE=1` the mirror is
+/// skipped for slot-authoritative plain lexicals (not captured/reflective/sync),
+/// so the slot is the single source of truth and env-COW can drop the write. This
+/// is the burndown gate — flip and delete once all four env-mirror consumers
+/// (#1 block-restore, #2 cross-thread, #3 call-return reconcile, #4 curry) are
+/// slot-authoritative. Cached like `jit_enabled()`.
+#[inline]
+pub(crate) fn gate_local_env_write() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        matches!(
+            std::env::var("MUTSU_GATE_LOCAL_ENV_WRITE").ok().as_deref(),
+            Some("1") | Some("on") | Some("ON")
+        )
+    })
+}
+
 /// Base binary operation for a fused compound-assignment opcode
 /// (`$x OP= rhs`). Each variant maps to the same `exec_*_op` the plain
 /// `Binary` path uses, so the fused op shares exact operator semantics.

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -715,7 +715,24 @@ impl Interpreter {
                 //   Hash assignment was silently dropped, JSON::Marshal
                 //   t/030-trait.t / t/080-type-constraints.t). A pre-carrier
                 //   divergence (a live-cell copy) keeps the skip.
-                if !self.locals[i].same_variant(&cur) {
+                //
+                // The type-change write must additionally require that env
+                // genuinely CHANGED during the carrier (mechanism #3, the `(B)`
+                // per-store env-write gate): with the gate ON a plain-lexical
+                // store leaves env stale (the slot is authoritative), so a
+                // preceding `my $l = List.new` leaves `env<l>` at its `Any` decl
+                // seed while the slot holds the List. Without the `env_changed`
+                // guard, any Test-fn carrier (`isa-ok $l, …`) would read that
+                // stale `Any` as a "type change away" and clobber the live List.
+                // Gate OFF this is byte-identical: env tracks the slot, so a
+                // fired type-change here always had `prev != cur` anyway.
+                let env_changed = match pre_env.get(i) {
+                    Some(Some(prev)) => !prev.same_variant(&cur) || *prev != cur,
+                    // No prior env value snapshotted (a name the carrier
+                    // introduced): treat as a genuine change.
+                    _ => true,
+                };
+                if env_changed && !self.locals[i].same_variant(&cur) {
                     self.locals[i] = cur;
                 } else if let Some(Some(prev)) = pre_env.get(i)
                     && *prev == self.locals[i]

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1608,6 +1608,20 @@ impl Interpreter {
         if matches!(val.view(), ValueView::LazyThunk(..)) {
             self.mark_readonly(name);
         }
+        // `(B)` per-store env-write gate (docs/lexical-scope-slot-campaign.md).
+        // Default OFF (byte-identical). Under `MUTSU_GATE_LOCAL_ENV_WRITE=1` a
+        // slot-authoritative plain lexical skips its env mirror: the slot is the
+        // single source of truth. Excludes binds/constants (env-shape carriers),
+        // captured/reflective frames (read the caller's env by name), and names
+        // still in `needs_env_sync` (a mechanism consumer). The term-symbol block
+        // and `:=` alias chain below stay unconditional.
+        let skip_env_write = crate::opcode::gate_local_env_write()
+            && !is_bind
+            && !is_constant
+            && !code.captures_env_by_name
+            && !code.needs_env_sync.get(idx).copied().unwrap_or(true)
+            && !crate::opcode::reflective_name_access_possible()
+            && Self::term_symbol_from_name(name).is_none();
         if (is_bind || is_constant) && name.starts_with('@') {
             // For `:=` bind and `constant @x`, bypass set_shared_var's
             // List->Array normalization so the container type is preserved.
@@ -1618,8 +1632,10 @@ impl Interpreter {
             // unreachable, so take the one-Symbol-insert writer and skip the
             // per-store `Symbol::intern` + `Main::` probe (J4d; profiled at
             // ~12% of a hot Num loop). Same writer flush_local_to_env uses.
-            let sym = code.locals_sym.get(idx).copied();
-            self.set_env_plain_lexical(name, sym, val.clone());
+            if !skip_env_write {
+                let sym = code.locals_sym.get(idx).copied();
+                self.set_env_plain_lexical(name, sym, val.clone());
+            }
         } else {
             self.set_env_with_main_alias(name, val.clone());
         }

--- a/t/gate-b-carrier-aggregate-clobber.t
+++ b/t/gate-b-carrier-aggregate-clobber.t
@@ -1,0 +1,27 @@
+use Test;
+
+# Pin for the (B) per-store env-write gate mechanism #3 fix
+# (docs/lexical-scope-slot-campaign.md, "Root-cause drill-down").
+#
+# A scalar local holding an aggregate must survive a Test-fn call that follows
+# it. Under the MUTSU_GATE_LOCAL_ENV_WRITE gate the plain-lexical store skips its
+# env mirror, so env keeps the `my $x` decl seed (Any). The Test fn dispatches
+# through the carrier fallback, whose `carrier_writeback_changed_aggregates`
+# "type change away from container" branch would read that stale Any and clobber
+# the live aggregate slot. The fix requires env to have genuinely changed during
+# the carrier before that write. This test passes gate-OFF (the default) and
+# would fail gate-ON before the fix.
+
+plan 6;
+
+my $l = List.new(1, 2, 3);
+isa-ok $l, List, 'List local isa List after a Test-fn call';
+is $l.elems, 3, 'List local keeps its elements across the Test-fn call';
+
+my @a = 1, 2, 3, 4;
+ok @a.elems == 4, 'Array local survives a preceding Test-fn assertion';
+is @a.elems, 4, 'Array local still has 4 elems after another Test-fn call';
+
+my %h = a => 1, b => 2;
+isa-ok %h, Hash, 'Hash local isa Hash after a Test-fn call';
+is %h.elems, 2, 'Hash local keeps its pairs across the Test-fn call';


### PR DESCRIPTION
## Summary

The `(B)` per-store env-write gate (`MUTSU_GATE_LOCAL_ENV_WRITE`, default OFF; docs/lexical-scope-slot-campaign.md) skips the env mirror for slot-authoritative plain lexicals. Under the gate a preceding `my $x = List.new(...)` leaves the slot holding the List while `env<x>` keeps its `Any` decl seed. A following Test-fn call (`isa-ok $x, List`) dispatches through the carrier fallback in `exec_exec_call_pairs_op`, whose post-carrier reconcile `carrier_writeback_changed_aggregates` has a **"type change away from container"** branch that wrote a container slot back from env whenever the *current* env value differs in variant from the slot — **without checking that env genuinely changed during the carrier**. With the gate ON that read is the stale `Any`, so it clobbered the live List (`.elems` → 1).

This is the campaign's **mechanism #3**. The Root-cause drill-down originally fingered `apply_pending_rw_writeback`; instrumentation disproved that (both drains run with **empty** source sets on the repro) — the real clobber is this aggregate writeback, which unlike its sibling *overwritable* branch did not diff against the pre-carrier `pre_env` snapshot.

## Fix

Require an `env_changed` diff (`pre_env[i] != cur`) before the type-change slot write, matching the overwritable branch. **Gate OFF this is byte-identical** — env tracks the slot, so a fired type-change always had `prev != cur` anyway; gate ON it suppresses the stale-`Any` clobber.

Also reconstructs the `(B)` gate in `exec_set_local_op_inner` (default OFF, byte-identical) and adds `gate_local_env_write()` so the ON survey can be re-run.

## Validation

- **ON-survey delta** (debug, `MUTSU_GATE_LOCAL_ENV_WRITE=1 prove -j4 t/`): **75 → 61** genuine ON-only regressions (all 61 also pass OFF). The 14 cleared are the native ctor / `.Set/.Bag/.Mix`/hash-coerce cluster's carrier-writeback subset.
- **`make test` (OFF, default): 18827 tests PASS**, byte-identical.
- gc-stress (`MUTSU_GC=on GC_VERIFY=1`) clean on the affected carrier-writeback tests locally; full gc-stress runs in CI.
- Pin: `t/gate-b-carrier-aggregate-clobber.t` (passes OFF and ON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)