### PR TITLE
fix: item() function itemizes a Range/aggregate like the .item method

### DIFF
--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -664,7 +664,9 @@ impl Interpreter {
                     let val = args.first().cloned().unwrap_or(Value::NIL);
                     Ok(val.item())
                 } else {
-                    Ok(Value::array(args.clone()))
+                    // Multiple args become a single itemized list (`item(1,2,3)`
+                    // is `(1 2 3)` as ONE element, not three flattened elements).
+                    Ok(Value::array(args.clone()).item())
                 }
             }
             "list" => self.builtin_list(&args),

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -219,7 +219,11 @@ impl Value {
             // `HashData` `Gc` (no copy-on-write, so `.WHICH` identity and
             // `=`-shared mutation are preserved).
             ValueRepr::Hash(h, _) => Value::Hash(h, true),
-            other => Value::from_repr(other),
+            // Any other aggregate (Range, LazyList, Set/Bag/Mix, ...) is wrapped
+            // in a `Scalar` container so it becomes a single non-flattening
+            // element in list context (mirrors the `.item` method form in
+            // `dispatch_core_math.rs` — `for item(1..3)` must see ONE element).
+            other => Value::scalar(Value::from_repr(other)),
         }
     }
 

--- a/t/item-function-itemize.t
+++ b/t/item-function-itemize.t
@@ -1,0 +1,44 @@
+use v6;
+use Test;
+
+# The `item()` FUNCTION form must itemize its argument the same way the `.item`
+# METHOD form does: the result is a SINGLE non-flattening element in list
+# context. Previously `item(1..3)` and `item(1,2,3)` flattened under `for`.
+
+plan 11;
+
+# Single non-array aggregate (Range): stays whole, iterated as one element.
+{
+    my @seen;
+    @seen.push($_) for item(1..3);
+    is @seen.elems, 1, 'item(Range) is a single element under for';
+    is @seen[0].WHAT.^name, 'Range', 'the single element is the Range itself';
+}
+
+# Multiple args become a single itemized list.
+{
+    my @seen;
+    @seen.push($_) for item(1, 2, 3);
+    is @seen.elems, 1, 'item(1,2,3) is a single element under for';
+    is @seen[0].elems, 3, 'the single element holds all three values';
+}
+
+# .WHAT is preserved (itemization does not change the type object).
+is item(1..3).WHAT.^name, 'Range', 'item(Range).WHAT is Range';
+is item(1, 2, 3).WHAT.^name, 'List', 'item(1,2,3).WHAT is List';
+is item(42).WHAT.^name, 'Int', 'item(Int).WHAT is Int';
+
+# Scalars still numify/stringify transparently through the item container.
+is item(42) + 1, 43, 'item(Int) still participates in numeric ops';
+is item("abc"), "abc", 'item(Str) stringifies to itself';
+
+# A Hash stays a single element and keeps its identity.
+{
+    my %h = a => 1, b => 2;
+    my @seen;
+    @seen.push($_) for item(%h);
+    is @seen.elems, 1, 'item(Hash) is a single element under for';
+}
+
+# Matches the .item method form exactly.
+is-deeply item(1..3).WHAT, (1..3).item.WHAT, 'function and method item agree';


### PR DESCRIPTION
## Summary

The `item()` **function** form did not match the `.item` **method** form for non-Array/non-Hash values.

`Value::item()` returned a `Range` (or other aggregate) unchanged, so:
- `.say for item(1..3)` flattened the Range → printed `1\n2\n3` (raku prints `1..3`)
- `item(1,2,3)` returned a non-itemized `Array` → flattened under `for` (raku sees one `(1 2 3)` element)

The `.item` method form already wrapped non-Array values in a `Scalar` container (`dispatch_core_math.rs`), which is why `(1..3).item` already worked.

## Fix

- `Value::item()`: wrap the non-aggregate `other` arm in a `Scalar` container, mirroring the method form. Scalars still numify/stringify transparently and `.WHAT` is preserved.
- `item` builtin: itemize the multi-arg list (`item(1,2,3)` → one itemized `List`).

The sole caller of `Value::item()` is the `item()` builtin, so the change is localized to the function form.

## Provenance

From the doc-diff QA harness — `Language/contexts.rakudoc` finding:

```raku
.say for item( 1..3 );  # OUTPUT: «1..3␤»
```

Pin: `t/item-function-itemize.t`. `make test` passes; context/subscript roast tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)