### PR TITLE
fix: (B)-gate let/temp cluster — save side reads the baked slot, not stale env

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -550,6 +550,21 @@ remaining 61 belong to the other mechanisms (#2 cross-thread, #4 curry, closure
 capture, rw-redispatch, `let`/`temp`, sigilless) — those are the next per-cluster
 name-folding targets.
 
+### `let`/`temp` cluster — DONE (2026-07-19, structural slot-read fix)
+
+The `let`/`temp` cluster (2 files: `let-temp.t`, `let-temp-restore-writeback-coherence.t`)
+was fixed **structurally**, not by folding into `needs_env_sync`. Root cause:
+`exec_let_save_op` (vm_misc_block.rs) snapshots the pre-scope value of the temporized
+variable by reading `env` by name first, falling back to the slot. Under the gate a
+plain-lexical assignment (`my $x = 1`) before the `temp`/`let` skips its env mirror, so
+the env-first read snapshots the `my $x` decl seed (`Any`) instead of `1`; the
+scope-exit restore then writes that `Any` back. The `LetSave` opcode already bakes the
+scalar's slot (`slot: Option<u32>`, index mode excepted), and the restore side
+(`restore_let_value`) already prefers it — so the save side now reads the baked slot
+first too (the slot is always current; `env` is only a mirror). Gate OFF the slot
+equals the env mirror, so this is byte-identical (`make test` 18827 PASS). Pin:
+`t/gate-b-let-temp-slot-save.t` (OFF + ON both pass). **ON-survey delta: 61 → 59.**
+
 ## §1.4 flip blast-radius measurement (2026-07-02, debug + release `prove t/`)
 
 A naive flip was implemented and measured, then reverted (branch

--- a/src/vm/vm_misc_block.rs
+++ b/src/vm/vm_misc_block.rs
@@ -285,15 +285,27 @@ impl Interpreter {
         if index_mode {
             let _idx_val = self.stack.pop().unwrap_or(Value::int(0));
         }
-        let old_val = self
-            .get_env_with_main_alias(&name)
-            .or_else(|| {
-                code.locals
-                    .iter()
-                    .position(|n| n == &name)
-                    .map(|i| self.locals[i].clone())
-            })
-            .unwrap_or(Value::NIL);
+        // §1.4/§1.5: when the compiler baked THIS frame's slot for `name`, read the
+        // pre-scope value straight from the live slot rather than from `env` by
+        // name. The slot is always current; `env` is only a mirror and can be stale
+        // when the per-store env write is gated (MUTSU_GATE_LOCAL_ENV_WRITE) — a
+        // plain-lexical assignment `$x = ...` before this `temp`/`let` may not have
+        // mirrored into `env`, so an env-first read would snapshot the decl-seed
+        // `Any` instead of the real value. With the gate OFF the slot equals the
+        // env mirror, so this is byte-identical to the former env-first read. The
+        // matching restore side (`restore_let_value`) already prefers the baked slot.
+        let old_val = match slot {
+            Some(s) if (s as usize) < self.locals.len() => self.locals[s as usize].clone(),
+            _ => self
+                .get_env_with_main_alias(&name)
+                .or_else(|| {
+                    code.locals
+                        .iter()
+                        .position(|n| n == &name)
+                        .map(|i| self.locals[i].clone())
+                })
+                .unwrap_or(Value::NIL),
+        };
         // A boxed (shared-cell) scalar saves its INNER value, decoupled from the
         // cell: otherwise the snapshot would be the same Arc that the dynamic-scope
         // write mutates, so the restore would see the modified value, not the

--- a/t/gate-b-let-temp-slot-save.t
+++ b/t/gate-b-let-temp-slot-save.t
@@ -1,0 +1,37 @@
+use Test;
+
+# Pin for the (B) per-store env-write gate `let`/`temp` cluster fix
+# (docs/lexical-scope-slot-campaign.md, "(B) per-store env-write gate — burndown").
+#
+# `exec_let_save_op` snapshots the pre-scope value of the temporized variable.
+# It used to read that value from `env` by name, falling back to the slot. Under
+# the MUTSU_GATE_LOCAL_ENV_WRITE gate a plain-lexical assignment `$x = 1` before
+# the `temp`/`let` skips its env mirror, so the env-first read would snapshot the
+# `my $x` decl seed (Any) instead of 1 — and the scope-exit restore would then
+# put Any back. The fix reads the baked slot first (always current). This passes
+# gate-OFF (the default) and would fail gate-ON before the fix.
+
+plan 6;
+
+{
+    my $x = 1;
+    { temp $x = 42; is $x, 42, 'temp: value set inside block' }
+    is $x, 1, 'temp: pre-scope slot value restored (not the stale env seed)';
+}
+
+{
+    my $x = 10;
+    { temp $x; $x = 99; is $x, 99, 'bare temp: value changed inside block' }
+    is $x, 10, 'bare temp: pre-scope slot value restored';
+}
+
+{
+    my $x = 7;
+    try { let $x = 42; die 'oops' }
+    is $x, 7, 'let: pre-scope slot value restored on exception';
+}
+
+{
+    my $x = 3;
+    { temp $x = 5; { temp $x = 9 }; is $x, 5, 'nested temp: inner restored to outer temp value' }
+}


### PR DESCRIPTION
Part of the `(B)` per-store env-write gate burndown (docs/lexical-scope-slot-campaign.md, §1.3 endgame). This lands the **`let`/`temp` cluster** (2 of the 61 remaining gate-ON regressions).

## Root cause
`exec_let_save_op` snapshots the pre-scope value of a temporized variable so the scope-exit restore can put it back. It read that value from `env` by name first, falling back to the slot. Under the `MUTSU_GATE_LOCAL_ENV_WRITE` gate a plain-lexical assignment (`my $x = 1`) before the `temp`/`let` skips its env mirror, so the env-first read snapshotted the `my $x` decl seed (`Any`) instead of the real value — and the restore wrote that `Any` back at scope exit.

```raku
my $x = 1;
{ temp $x = 42; say $x }   # 42
say $x;                    # gate-ON before fix: (empty/Any)   after fix: 1
```

## Fix (structural, not a `needs_env_sync` fold)
The `LetSave` opcode already bakes the scalar's slot (index mode excepted) and the restore side (`restore_let_value`) already prefers it. This makes the **save** side symmetric: read the baked slot first (always current); `env` is only a mirror. Gate OFF the slot equals the env mirror, so this is byte-identical.

## Verification
- `make test` (gate OFF, default): 18827 PASS, byte-identical count.
- Gate-ON survey delta: **61 → 59** (`let-temp.t`, `let-temp-restore-writeback-coherence.t` go green; no new failures).
- Pin: `t/gate-b-let-temp-slot-save.t` (passes both OFF and ON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)