### PR TITLE
fix: slice assignment distributes a non-i64 range across the slice

### DIFF
--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -473,6 +473,11 @@ impl Interpreter {
                     (start..end).map(Value::int).collect()
                 }
             }
+            // Non-i64 ranges (string `"a".."z"`, Rat, `.succ`-driven) must also
+            // distribute across a slice, e.g. `@a[^10] = 'a'..'z'`. The i64
+            // variants above stay inline for speed; everything else expands via
+            // the shared `value_to_list` range walker.
+            ValueView::GenericRange { .. } => crate::runtime::utils::value_to_list(val),
             ValueView::LazyList(list) => self.force_lazy_list_vm(&list)?,
             _ => vec![val.clone()],
         })

--- a/t/slice-assign-generic-range.t
+++ b/t/slice-assign-generic-range.t
@@ -1,0 +1,48 @@
+use v6;
+use Test;
+
+# A slice assignment must distribute a NON-i64 range (string / Rat / .succ-driven)
+# across the slice, the same way an i64 range or a comma list already does.
+# Previously `@a[^10] = 'a'..'z'` stored the whole Range in slot 0.
+
+plan 8;
+
+{
+    my @letters;
+    @letters[^10] = 'a'..'z';
+    is-deeply @letters, ['a','b','c','d','e','f','g','h','i','j'],
+        'positional slice distributes a string range';
+}
+
+{
+    my @l;
+    @l[0, 1, 2] = 'a'..'z';
+    is-deeply @l, ['a','b','c'], 'explicit-index slice takes a range prefix';
+}
+
+{
+    my @l;
+    @l[^4] = 'aa'..'zz';
+    is-deeply @l, ['aa','ab','ac','ad'], 'two-char string range distributes';
+}
+
+{
+    my %h;
+    %h<a b c> = 'x'..'z';
+    is %h<a>, 'x', 'hash slice string range - first';
+    is %h<b>, 'y', 'hash slice string range - second';
+    is %h<c>, 'z', 'hash slice string range - third';
+}
+
+# i64 range and comma list still work (no regression).
+{
+    my @l;
+    @l[^3] = 1..100;
+    is-deeply @l, [1, 2, 3], 'i64 range slice still distributes';
+}
+
+{
+    my @l;
+    @l[^3] = 10, 20, 30, 40;
+    is-deeply @l, [10, 20, 30], 'comma list slice still distributes';
+}


### PR DESCRIPTION
## Summary

A slice assignment did not distribute a **non-i64 range** across the slice:

```raku
my @letters;
@letters[^10] = 'a'..'z';
say @letters;   # raku: [a b c d e f g h i j]
                # mutsu (before): ["a".."z" (Any) (Any) ...]
```

`%h<a b c> = 'x'..'z'` had the same problem.

## Root cause

`assignment_rhs_values` (`vm_var_assign_coerce.rs`) expanded the i64 `Range` / `RangeExcl*` variants inline, but a **`GenericRange`** (string range like `'a'..'z'`, `Rat`, or any `.succ`-driven range) fell through to `_ => vec![val.clone()]` and was stored whole in the first slot.

## Fix

Add a `GenericRange` arm expanding via the shared `crate::runtime::utils::value_to_list` range walker — the same helper the read side already uses. The i64 variants stay inline for speed.

## Scope

- Sibling still open (out of scope): `@a[^5] = 1.5, 2.5 ... 5.5` — the sequence-op `...` binds tighter than comma in an assignment RHS (the assignment-RHS twin of #4755's arg-list precedence fix).

## Provenance

From the doc-diff QA harness — `Language/subscripts.rakudoc` finding [1]. Pin: `t/slice-assign-generic-range.t`. `make test` passes; array/context roast tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)