### PR TITLE
fix: (B)-gate sigilless cluster — typed sigilless bind reads from its slot

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -565,6 +565,39 @@ first too (the slot is always current; `env` is only a mirror). Gate OFF the slo
 equals the env mirror, so this is byte-identical (`make test` 18827 PASS). Pin:
 `t/gate-b-let-temp-slot-save.t` (OFF + ON both pass). **ON-survey delta: 61 → 59.**
 
+### `sigilless` cluster — typed-bind read fixed (2026-07-19), EVAL-rw deferred
+
+The 2-file sigilless cluster splits into two independent roots:
+
+1. **Typed sigilless bind read — DONE (structural).** `my Int \d := 7; is d, 7`
+   failed ON (`d` read as `(Int)`/`Any`). Root: a *typed* sigilless declaration
+   (`type_constraint.is_some()`) was emitted as a bare `VarDecl` with no sigilless
+   marker, so `d` never entered the compiler's `sigilless_locals` set and the
+   bare-word read compiled to `GetBareWord` (env lookup) instead of `GetLocal`
+   (slot). Under the gate the env is stale → `Any`. The untyped case
+   (`my \c := 42`) worked because it emits `MarkSigillessReadonly`. Fix: a new
+   non-readonly `Stmt::MarkSigilless(name)` marker (typed sigilless keeps container
+   mutability, so it must NOT be marked readonly), emitted by the typed `:=` and `=`
+   sigilless declaration paths and compiled to `sigilless_locals.insert` only. This
+   makes the read slot-addressed regardless of the gate. Gate OFF byte-identical
+   (`make test` 18891 PASS); `sigilless-comma-decl.t` goes green ON. (Pre-existing,
+   gate-independent: a typed sigilless bind to a container is not yet writable-through
+   — `my Mu \a := $x; a = 5` leaves `$x` unchanged in both modes; raku propagates.
+   Orthogonal to this cluster.)
+
+2. **EVAL rw caller-alias writeback — DEFERRED (the §1.1 hard case).**
+   `sub swap(\x,\y){ my $z=y; y=x; x=$z } my $a=5; my $b=3; EVAL 'swap($a,$b)'`
+   still fails ON (`sigilless-params.t` test 3). Narrowed: a *read-only* sigilless
+   sub via EVAL works ON (`two(\x,\y)` reads `5|3`); `our`-var args work ON; a
+   nested-sub (non-EVAL) swap works ON. Only a **my-lexical arg + rw sigilless param
+   + EVAL** breaks — and it breaks the initial *read* too (`x`/`y` empty on entry),
+   so the rw param binding routes the caller-lexical alias through the EVAL frame's
+   env by name (the `__mutsu_sigilless_alias::` chain), which the gate leaves stale.
+   This is the acknowledged §1.1 OTF-gate exclusion; needs the EVAL caller-frame
+   alias resolution made slot-addressed. **ON-survey delta for this PR: 61 → 60**
+   (sigilless-comma-decl only; sigilless-params stays; the two `let`/`temp` files are
+   fixed separately by #4861).
+
 ## §1.4 flip blast-radius measurement (2026-07-02, debug + release `prove t/`)
 
 A naive flip was implemented and measured, then reverted (branch

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -604,6 +604,11 @@ pub(crate) enum Stmt {
     MarkBind,
     /// Mark a sigilless variable as readonly via `__mutsu_sigilless_readonly::NAME` env key.
     MarkSigillessReadonly(String),
+    /// Register a sigilless variable name in the compiler's `sigilless_locals`
+    /// (so a bare-word read resolves to its local slot) WITHOUT marking it
+    /// readonly. Used for a *typed* sigilless bind (`my Int \d := 7`), which keeps
+    /// the container's mutability but must still read from the slot, not `env`.
+    MarkSigilless(String),
     Assign {
         name: String,
         expr: Expr,

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -482,9 +482,9 @@ impl Compiler {
                 self.compile_do_block_expr_scoped(inner, &None);
             }
             Stmt::SyntheticBlock(inner)
-                if inner
-                    .last()
-                    .is_some_and(|s| matches!(s, Stmt::MarkSigillessReadonly(_))) =>
+                if inner.last().is_some_and(|s| {
+                    matches!(s, Stmt::MarkSigillessReadonly(_) | Stmt::MarkSigilless(_))
+                }) =>
             {
                 self.compile_block_inline(inner);
             }

--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -109,7 +109,7 @@ impl Compiler {
                     // MarkSigillessReadonly at block-final position: compile
                     // the mark statement, then load the variable's value so
                     // `my \x = 42` used in expression context returns 42.
-                    Stmt::MarkSigillessReadonly(name) => {
+                    Stmt::MarkSigillessReadonly(name) | Stmt::MarkSigilless(name) => {
                         self.compile_stmt(stmt);
                         self.compile_expr(&Expr::BareWord(name.clone()));
                         self.pop_dynamic_scope_lexical(saved);

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -750,6 +750,13 @@ impl Compiler {
             Stmt::MarkBind => {
                 // Handled by SyntheticBlock detection; no-op when compiled standalone.
             }
+            Stmt::MarkSigilless(name) => {
+                // Track a sigilless local so BareWord compilation reads it from its
+                // slot (GetLocal), not via GetBareWord/env. Unlike
+                // MarkSigillessReadonly this does NOT set the readonly flag: a typed
+                // sigilless bind (`my Int \d := 7`) keeps container mutability.
+                self.sigilless_locals.insert(name.clone());
+            }
             Stmt::MarkSigillessReadonly(name) => {
                 // Track sigilless locals so BareWord compilation can
                 // distinguish them from `$`-sigiled variables.

--- a/src/parser/stmt/decl/my_decl_helpers.rs
+++ b/src/parser/stmt/decl/my_decl_helpers.rs
@@ -40,11 +40,13 @@ pub(super) fn parse_sigilless_decl(
         };
         // Sigilless variables without type constraint are always readonly.
         // With a type constraint (e.g. `my Mu \a := $a`), the variable
-        // binds to the container, preserving mutability.
+        // binds to the container, preserving mutability — but it must still be
+        // registered as a sigilless local so a bare-word read resolves to its
+        // slot (not `env`), so wrap it with the non-readonly `MarkSigilless`.
         let stmt = if type_constraint.is_none() {
             Stmt::SyntheticBlock(vec![decl, Stmt::MarkSigillessReadonly(name)])
         } else {
-            decl
+            Stmt::SyntheticBlock(vec![decl, Stmt::MarkSigilless(name)])
         };
         if apply_modifier {
             return parse_statement_modifier(r, stmt);
@@ -122,7 +124,7 @@ pub(super) fn parse_sigilless_decl(
         let stmt = if type_constraint.is_none() {
             Stmt::SyntheticBlock(vec![decl, Stmt::MarkSigillessReadonly(name)])
         } else {
-            decl
+            Stmt::SyntheticBlock(vec![decl, Stmt::MarkSigilless(name)])
         };
         if apply_modifier {
             return parse_statement_modifier(r, stmt);

--- a/t/gate-b-sigilless-typed-bind.t
+++ b/t/gate-b-sigilless-typed-bind.t
@@ -1,0 +1,31 @@
+use Test;
+
+# Pin for the (B) per-store env-write gate sigilless typed-bind fix
+# (docs/lexical-scope-slot-campaign.md, "(B) per-store env-write gate — burndown",
+# sigilless cluster #1).
+#
+# A *typed* sigilless declaration (`my Int \d := 7`) used to compile as a bare
+# VarDecl with no sigilless marker, so the bare-word read `d` resolved via
+# GetBareWord (env lookup) instead of GetLocal (slot). Under the
+# MUTSU_GATE_LOCAL_ENV_WRITE gate the env mirror is stale, so `d` read as `Any`.
+# The fix registers a typed sigilless name in `sigilless_locals` via the new
+# non-readonly `MarkSigilless` marker, making the read slot-addressed. This passes
+# gate-OFF (the default) and would fail gate-ON before the fix.
+
+plan 5;
+
+my Int \d := 7;
+is d, 7, 'typed sigilless := reads from its slot';
+
+my Str \s := 'hi';
+is s, 'hi', 'typed sigilless := with Str constraint reads from its slot';
+
+my Int \e = 42;
+is e, 42, 'typed sigilless = reads from its slot';
+
+# Untyped forms must keep working (regression guard for the shared code path).
+my \u := 99;
+is u, 99, 'untyped sigilless := still reads correctly';
+
+my \v = 3, 4, 5;
+is v[1], 4, 'untyped sigilless = keeps its comma-list RHS';


### PR DESCRIPTION
Part of the `(B)` per-store env-write gate burndown (docs/lexical-scope-slot-campaign.md, §1.3 endgame). This lands the **typed sigilless bind** half of the sigilless cluster (1 of the remaining gate-ON regressions).

## Root cause
A *typed* sigilless declaration (`my Int \d := 7`) was emitted as a bare `VarDecl` with no sigilless marker, so the bare-word read `d` compiled to `GetBareWord` (an env/package lookup) instead of `GetLocal` (the slot). Under the `MUTSU_GATE_LOCAL_ENV_WRITE` gate the env mirror is stale, so `d` read as `Any`. The untyped case (`my \c := 42`) worked because it emits `MarkSigillessReadonly`, which registers the name in the compiler's `sigilless_locals` set.

```raku
my Int \d := 7;
say d;   # gate-ON before fix: (Int)   after fix: 7
```

## Fix (structural)
Typed sigilless must keep container mutability, so it must **not** be marked readonly. Add a non-readonly `Stmt::MarkSigilless(name)` marker that only registers the name in `sigilless_locals`, emitted (wrapped in the usual SyntheticBlock) by the typed `:=` and `=` sigilless declaration paths. The read is now slot-addressed regardless of the gate.

## Verification
- `make test` (gate OFF, default): 18891 PASS, byte-identical count.
- Gate-ON survey: `sigilless-comma-decl.t` goes green (61 → 60 relative to the pre-let/temp baseline; no new failures).
- Pin: `t/gate-b-sigilless-typed-bind.t` (passes OFF, ON, and matches `raku`).

## Deferred
The EVAL rw caller-alias writeback case (`sigilless-params.t` test 3 — `EVAL 'swap($a,$b)'` with `my`-lexical args + rw sigilless params) is a separate root: the rw param binding routes the caller-lexical alias through the EVAL frame's env by name (the `__mutsu_sigilless_alias::` chain), which the gate leaves stale. This is the acknowledged §1.1 OTF-gate exclusion and remains deferred — documented in the campaign doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)