### PR TITLE
fix: %quanthash{*} returns all values for a Set/Bag/Mix

### DIFF
--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1346,11 +1346,9 @@ impl Interpreter {
                 Self::mix_weight_as_value(*m.get(key.as_str()).unwrap_or(&0.0))
             }
             // `%mix{*}` returns all values (the element weights).
-            (ValueView::Mix(m, _), ValueView::Whatever) => Value::array(
-                m.values()
-                    .map(|w| Self::mix_weight_as_value(*w))
-                    .collect(),
-            ),
+            (ValueView::Mix(m, _), ValueView::Whatever) => {
+                Value::array(m.values().map(|w| Self::mix_weight_as_value(*w)).collect())
+            }
             (ValueView::Mix(m, _), _) => {
                 Self::mix_weight_as_value(*m.get(&index.to_string_value()).unwrap_or(&0.0))
             }

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1313,6 +1313,10 @@ impl Interpreter {
                     .collect(),
             ),
             (ValueView::Set(s, _), ValueView::Str(key)) => Value::truth(s.contains(key.as_str())),
+            // `%set{*}` returns all values (each element's membership is True).
+            (ValueView::Set(s, _), ValueView::Whatever) => {
+                Value::array(s.iter().map(|_| Value::truth(true)).collect())
+            }
             (ValueView::Set(s, _), _) => Value::truth(s.contains(&index.to_string_value())),
             (ValueView::Bag(b, _), ValueView::Array(keys, ..)) => Value::array(
                 keys.iter()
@@ -1323,6 +1327,10 @@ impl Interpreter {
             ),
             (ValueView::Bag(b, _), ValueView::Str(key)) => {
                 Value::from_bigint(b.get(key.as_str()).cloned().unwrap_or_default())
+            }
+            // `%bag{*}` returns all values (the element weights/counts).
+            (ValueView::Bag(b, _), ValueView::Whatever) => {
+                Value::array(b.values().map(|c| Value::from_bigint(c.clone())).collect())
             }
             (ValueView::Bag(b, _), _) => {
                 Value::from_bigint(b.get(&index.to_string_value()).cloned().unwrap_or_default())
@@ -1337,6 +1345,12 @@ impl Interpreter {
             (ValueView::Mix(m, _), ValueView::Str(key)) => {
                 Self::mix_weight_as_value(*m.get(key.as_str()).unwrap_or(&0.0))
             }
+            // `%mix{*}` returns all values (the element weights).
+            (ValueView::Mix(m, _), ValueView::Whatever) => Value::array(
+                m.values()
+                    .map(|w| Self::mix_weight_as_value(*w))
+                    .collect(),
+            ),
             (ValueView::Mix(m, _), _) => {
                 Self::mix_weight_as_value(*m.get(&index.to_string_value()).unwrap_or(&0.0))
             }

--- a/t/quanthash-whatever-subscript.t
+++ b/t/quanthash-whatever-subscript.t
@@ -1,0 +1,45 @@
+use v6;
+use Test;
+
+# `%quanthash{*}` (whatever subscript) returns ALL values of a Set/Bag/Mix:
+# - Set: each element's membership value (True)
+# - Bag/Mix: the element weights
+# Previously a Bag/Mix `{*}` fell through to the scalar-key arm and returned 0
+# (the Whatever `*` stringified to a non-existent key).
+
+plan 10;
+
+# Bag: all weights (order is unordered, so compare sorted).
+{
+    my $bag = (orange => 1, apple => 3).Bag;
+    is-deeply $bag{*}.sort.List, (1, 3), 'Bag{*} returns all weights';
+    is $bag{*}.sum, 4, 'Bag{*} weights sum to total';
+    is $bag{*}.WHAT.^name, 'List', 'Bag{*} is a List';
+    is-deeply $bag{()}.List, ().List, 'Bag{()} is empty';
+}
+
+# Set: all membership values are True.
+{
+    my $set = <a b c>.Set;
+    is $set{*}.elems, 3, 'Set{*} has one value per element';
+    ok $set{*}.all === True, 'Set{*} values are all True';
+}
+
+# Mix: all weights (may be fractional).
+{
+    my $mix = (a => 1.5, b => 2.5).Mix;
+    is-deeply $mix{*}.sort.List, (1.5, 2.5), 'Mix{*} returns all weights';
+    is $mix{*}.sum, 4.0, 'Mix{*} weights sum';
+}
+
+# Bound-hash form (the doc example uses `:=`).
+{
+    my %bag := (x => 2, y => 5).Bag;
+    is-deeply %bag{*}.sort.List, (2, 5), 'bound Bag{*} returns all weights';
+}
+
+# Plain Hash {*} still returns values (no regression).
+{
+    my %h = a => 1, b => 2;
+    is-deeply %h{*}.sort.List, (1, 2), 'plain Hash{*} unaffected';
+}


### PR DESCRIPTION
## Summary

A whatever subscript on a Set/Bag/Mix returned the wrong result:

```raku
my %bag := (orange => 1, apple => 3).Bag;
say %bag{*};   # raku: (1 3)   mutsu (before): 0
```

The `%bag{*}` fell through to the scalar-key arm, where the Whatever `*` stringified to a non-existent key, so `.get` returned `0`.

## Fix

Add a `ValueView::Whatever` arm before the scalar-key catch-all for each QuantHash in `vm_var_index_ops.rs`:

- **Set** → one `True` per element (membership value)
- **Bag** → the element counts
- **Mix** → the element weights

The result is a `List` (matching raku's `.WHAT`). Plain `Hash{*}` already worked via its own Whatever arm.

## Provenance

From the doc-diff QA harness — `Language/subscripts.rakudoc` finding [6]. Pin: `t/quanthash-whatever-subscript.t`. `make test` passes; bag/set/mix/subscripts roast tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)