### PR TITLE
fix: role method param type resolution for coercion / self / sibling types

### DIFF
--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -725,6 +725,41 @@ impl Interpreter {
                     Self::validate_attr_declared_in_class(&role_attr_ctx, method_body)?;
                     // Validate that type constraints in method parameters are resolvable.
                     // Undeclared types like A::C should throw X::Parameter::InvalidType.
+                    // A role nested in an enclosing package (e.g. `unit class A`)
+                    // registers sibling classes under the qualified name
+                    // (`A::Identifier`), but a method param may reference them by
+                    // their short name. The role's own registered name carries the
+                    // enclosing namespace (`SQL::Abstract::Renderer::SQL`); collect
+                    // every `::`-prefix of it (`SQL::Abstract::Renderer`,
+                    // `SQL::Abstract`, `SQL`) so an unqualified sibling type resolves
+                    // under whichever enclosing package actually declared it. The
+                    // role's own short name can itself be compound (`Renderer::SQL`),
+                    // so a single rsplit is not enough.
+                    let mut enclosing_prefixes: Vec<String> = Vec::new();
+                    {
+                        let mut rest = name;
+                        while let Some((pfx, _)) = rest.rsplit_once("::") {
+                            enclosing_prefixes.push(pfx.to_string());
+                            rest = pfx;
+                        }
+                    }
+                    // The role's registered short name may omit the enclosing
+                    // package (a compound role like `Renderer::SQL` is stored
+                    // without the `unit class` prefix), so also qualify with the
+                    // current package and its own `::`-prefixes.
+                    {
+                        let cur = self.current_package();
+                        let mut rest = cur.as_str();
+                        loop {
+                            if !rest.is_empty() && !enclosing_prefixes.iter().any(|p| p == rest) {
+                                enclosing_prefixes.push(rest.to_string());
+                            }
+                            match rest.rsplit_once("::") {
+                                Some((pfx, _)) => rest = pfx,
+                                None => break,
+                            }
+                        }
+                    }
                     for pd in param_defs {
                         if let Some(tc) = pd.type_constraint.as_deref() {
                             // Skip type captures (::T), invocant markers, and role type params
@@ -734,7 +769,27 @@ impl Interpreter {
                             {
                                 continue;
                             }
-                            if !self.is_resolvable_type(tc) {
+                            // Base name of the constraint: strip definedness smiley,
+                            // coercion `(...)`, and parameterization `[...]`.
+                            let tc_base = tc
+                                .strip_suffix(":D")
+                                .or_else(|| tc.strip_suffix(":U"))
+                                .or_else(|| tc.strip_suffix(":_"))
+                                .unwrap_or(tc);
+                            let tc_base = tc_base.split(['(', '[']).next().unwrap_or(tc_base);
+                            // A role may reference its own type in a method param
+                            // (`role R { method f(R:D $x) }`); the role is not yet in
+                            // the registry while its methods validate, so accept its
+                            // own name (full or short) explicitly.
+                            let self_short = name.rsplit_once("::").map(|(_, s)| s).unwrap_or(name);
+                            let resolvable = tc_base == name
+                                || tc_base == self_short
+                                || self.is_resolvable_type(tc)
+                                || (!tc.contains("::")
+                                    && enclosing_prefixes.iter().any(|pfx| {
+                                        self.is_resolvable_type(&format!("{pfx}::{tc}"))
+                                    }));
+                            if !resolvable {
                                 let mut attrs = std::collections::HashMap::new();
                                 attrs.insert("type".to_string(), Value::str(tc.to_string()));
                                 attrs.insert(

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -485,6 +485,15 @@ impl Interpreter {
             .or_else(|| constraint.strip_suffix(":U"))
             .or_else(|| constraint.strip_suffix(":_"))
             .unwrap_or(constraint);
+        // Strip coercion: the resolvable part of a coercion type `Target(From)`
+        // is the target type name before `(` (e.g. `Int()` -> `Int`,
+        // `Identifier(Any)` -> `Identifier`). The from-type is validated
+        // separately at parse time.
+        let base = if let Some(idx) = base.find('(') {
+            &base[..idx]
+        } else {
+            base
+        };
         // Strip parameterization: Array[Int] -> Array
         let base = if let Some(idx) = base.find('[') {
             &base[..idx]

--- a/t/role-method-param-type-resolution.t
+++ b/t/role-method-param-type-resolution.t
@@ -1,0 +1,67 @@
+use v6;
+use Test;
+
+# A role method parameter type constraint must resolve the same way a class
+# method's does. Previously the role-registration validation over-rejected
+# several valid forms with "Invalid typename '...' in parameter declaration."
+# (regressions surfaced by real ecosystem dists: IdClass, SQL::Abstract).
+
+plan 6;
+
+# 1. A coercion type as a role method parameter (`Int()`).
+{
+    role R1 { method f(Int() $x --> Str) { "$x" } }
+    class C1 does R1 {}
+    is C1.new.f("42"), "42", 'coercion-type param in a role method';
+}
+
+# 2. A coercion type with an explicit from-type target (`Identifier(Any)`),
+#    where the target is a user class forward-declared before the role.
+{
+    class Identifier { ... }
+    role R2 { method as(Identifier(Any) $x) { "ok" } }
+    class Identifier { method Str { "i" } }
+    class C2 does R2 {}
+    is C2.new.as(Identifier.new), "ok", 'user-type coercion param in a role method';
+}
+
+# 3. A role that references its own type in a method parameter.
+{
+    role Expression { method chain(Expression:D $x) { "chained" } }
+    class C3 does Expression {}
+    is C3.new.chain(C3.new), "chained", 'self-referential role type param';
+}
+
+# 4. A sibling type of an enclosing package, referenced by its short name.
+lives-ok {
+    EVAL q:to/CODE/;
+    unit class Outer4;
+    class Sibling {}
+    role R4 { method take(Sibling $s) { "took" } }
+    class Impl does R4 {}
+    die "wrong" unless Impl.new.take(Sibling.new) eq "took";
+    CODE
+}, 'sibling short-name type in a role method (nested package)';
+
+# 5. A compound-named role (`Renderer::SQL`) referencing an enclosing-package
+#    sibling by short name — the failing shape in SQL::Abstract.
+lives-ok {
+    EVAL q:to/CODE/;
+    unit class Outer5;
+    role Expression {}
+    role Renderer::SQL { method render(Expression:D $e) { "rendered" } }
+    class Impl does Renderer::SQL {}
+    class E does Expression {}
+    die "wrong" unless Impl.new.render(E.new) eq "rendered";
+    CODE
+}, 'compound-role short-name sibling type (nested package)';
+
+# 6. A genuinely undeclared type is still rejected.
+{
+    my $ok = False;
+    try {
+        EVAL 'role RBad { method f(NoSuchTypeXYZ $x) { 1 } }; 1';
+        $ok = True;
+    }
+    nok $ok, 'an undeclared role method param type is still rejected';
+}


### PR DESCRIPTION
## Summary

A role method parameter's type constraint was validated by `register_role_decl` with a stricter resolver than the equivalent class-method path, over-rejecting several valid forms with `Invalid typename '...' in parameter declaration.`. Surfaced by real fez-ecosystem dists via `scripts/dist-compat-sweep.py`:

- **`IdClass`** — `method !to-base64(Int() $int --> Str)` inside a `role` — now **load_ok**.
- **`SQL::Abstract`** — advances past four consecutive typename blockers (`Identifier(Any)`, self-referential `Expression:D`, sibling short-names in the compound-named `role Renderer::SQL`). A remaining parametric-role blocker is deferred.

## Fixes

1. **Coercion type target** (`Int()`, `Identifier(Any)`): `is_resolvable_type` did not strip the coercion `(...)` suffix, so the target type name was never resolved. Fixed generally in `is_resolvable_type` — `Target(From)` → `Target` — which also benefits the sub-registration path.
2. **Self-referential role type** (`role R { method f(R:D $x) }`): the role is not yet in the registry while its methods validate; its own name (full and short) is now accepted explicitly.
3. **Sibling type of an enclosing package by short name** (`unit class A; class Id {}; role R { method f(Id $x) }`): the role's registered name and the current package are walked for every `::`-prefix so `A::Id` resolves. A compound role name (`Renderer::SQL`, whose short name omits the enclosing prefix) is handled via the current package.

Genuinely-undeclared types are still rejected (verified against `roast/S14-roles/basic.t` "undeclared type in signature in role results in X::Parameter::InvalidType").

## Tests

- Pin: `t/role-method-param-type-resolution.t` (6 cases).
- `make test` green; whitelisted `S14-roles/basic.t`, `S12-subset/subtypes.t`, `S06-signature/introspection.t` still exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)