### PR TITLE
fix: multidim subscript recurses into a Pair value by key

### DIFF
--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -435,6 +435,22 @@ impl Interpreter {
                 return self.multi_dim_index_read(&inner, dims);
             }
         }
+        // A Pair is associative under a further dimension: `%h{"k";"sub"}`
+        // where `%h{"k"}` is a Pair indexes it by key. Reuse the hash-read
+        // logic against a one-entry map so key / `*` / slice dims all work
+        // (without this the Pair falls into the scalar-wrap below and the next
+        // key is treated as a positional index, collapsing to Nil).
+        let pair_map = match target.view() {
+            ValueView::Pair(k, v) => Some((k.clone(), (*v).clone())),
+            ValueView::ValuePair(k, v) => Some((k.to_string_value(), (*v).clone())),
+            _ => None,
+        };
+        if let Some((key, value)) = pair_map {
+            let mut m = std::collections::HashMap::new();
+            m.insert(key, value);
+            let dim = Self::normalize_multidim_dim(&dims[0]);
+            return self.multi_dim_hash_read(&m, &dim, &dims[1..]);
+        }
         // A non-positional value behaves as a single-element list when
         // subscripted in a further dimension: in `(10,20,30)[1,2;0]` each
         // selected scalar is indexed by the trailing `0`, and `20[0]` is `20`

--- a/t/multidim-hash-pair-subscript.t
+++ b/t/multidim-hash-pair-subscript.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+# A multi-dimensional hash subscript must recurse into a Pair value
+# associatively: `%h{"a","b";"k"}` where each `%h{key}` is a Pair should
+# index that Pair by "k". Previously the Pair was treated as a scalar leaf
+# and the trailing key collapsed to Nil.
+
+plan 4;
+
+# The doc example (Language/subscripts.rakudoc): pair-valued hash.
+{
+    my %pantheon = %('Baldr' => 'consort' => 'Nanna',
+                     'Bragi' => 'consort' => 'Iðunn',
+                     'Nótt'  => 'consort' => 'Dellingr');
+    is-deeply %pantheon{'Bragi', 'Nótt'; 'consort'}.List, ('Iðunn', 'Dellingr'),
+        'multidim subscript recurses into pair values by key';
+}
+
+# Whatever on the first dimension, then a key into each pair value.
+{
+    my %p = %(a => x => 1, b => x => 2, c => x => 3);
+    is-deeply %p{*; 'x'}.sort.List, (1, 2, 3),
+        'whatever first dim then a key into each pair value';
+}
+
+# Nested-hash values still work the same way (no regression).
+{
+    my %h = a => (x => 10, y => 20).Hash, b => (x => 30, y => 40).Hash;
+    is-deeply %h{'a', 'b'; 'x'}.List, (10, 30), 'multidim into nested hash values';
+}
+
+# Array-of-lists multidim subscript still works.
+{
+    my @a = (1, 2, 3), (4, 5, 6);
+    is-deeply @a[0, 1; 1].List, (2, 5), 'array multidim slice unaffected';
+}


### PR DESCRIPTION
## Summary

A multi-dimensional hash subscript did not recurse into a **Pair** value:

```raku
my %pantheon = %('Bragi' => 'consort' => 'Iðunn',
                 'Nótt'  => 'consort' => 'Dellingr');
say %pantheon{'Bragi', 'Nótt'; 'consort'};
# raku: (Iðunn Dellingr)   mutsu (before): (Nil Nil)
```

## Root cause

In `multi_dim_index_read` (`vm_var_multidim_ops.rs`), a target that is neither an Array nor a Hash is scalar-wrapped into a one-element list before the next dimension is applied. So the trailing `'consort'` key was treated as a **positional** index into `[Pair]` and collapsed to Nil.

A Pair is associative, though — `$pair{'consort'}` already works at a single level.

## Fix

Before the scalar-wrap, if the target is a `Pair`/`ValuePair`, build a one-entry map and delegate to `multi_dim_hash_read`, reusing the existing key / `*` / slice-dimension logic. Nested-hash values and array multidim slices are unaffected.

## Scope

Pre-existing gaps left alone (they affect the Hash path equally, not introduced here):
- a single-key multidim `%h{"a";"x"}` returns the bare scalar `1`, raku wraps it in a 1-element `List` `(1)`;
- a missing key via `.List` reads as `Any` in mutsu vs `Nil` in raku (both give `Any` when stored into a `@`-array).

## Provenance

From the doc-diff QA harness — `Language/subscripts.rakudoc` finding [8]. Pin: `t/multidim-hash-pair-subscript.t` (verified against both raku and mutsu). `make test` passes; subscript/typed-array roast tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)