### PR TITLE
fix: resolve a role method's sibling-type param by short name

### DIFF
--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -788,7 +788,17 @@ impl Interpreter {
                                 || (!tc.contains("::")
                                     && enclosing_prefixes.iter().any(|pfx| {
                                         self.is_resolvable_type(&format!("{pfx}::{tc}"))
-                                    }));
+                                    }))
+                                // Last resort: any registered type known by this
+                                // short name. A compound role name in a `unit
+                                // package` (`my role Packet::Empty`) leaves the
+                                // enclosing package out of both the role name and
+                                // `current_package`, so the prefix walk cannot
+                                // reach a sibling like `P::DecodeBuffer`; a
+                                // short-name match still finds it, mirroring how the
+                                // sub pre-pass accepts any type declared in the unit.
+                                || (!tc.contains("::")
+                                    && self.type_known_by_short_name(tc_base));
                             if !resolvable {
                                 let mut attrs = std::collections::HashMap::new();
                                 attrs.insert("type".to_string(), Value::str(tc.to_string()));

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -357,6 +357,25 @@ impl Interpreter {
             .is_some_and(|variants| variants.iter().any(|(k, _)| k == variant_name))
     }
 
+    /// Whether any registered class / role / subset / enum is known by the given
+    /// short name — either exactly, or as the last `::`-segment of a qualified
+    /// name (`P::DecodeBuffer` matches short `DecodeBuffer`). Used to relax the
+    /// role-method parameter-type validation so an unqualified reference to a
+    /// sibling type declared in an enclosing package is not falsely rejected,
+    /// mirroring how the sub-registration pre-pass accepts any type declared in
+    /// the compilation unit. A genuinely-undeclared name matches nothing.
+    pub(crate) fn type_known_by_short_name(&self, short: &str) -> bool {
+        if short.is_empty() {
+            return false;
+        }
+        let reg = self.registry();
+        let matches = |key: &str| key == short || key.ends_with(&format!("::{short}"));
+        reg.classes.keys().any(|k| matches(k))
+            || reg.roles.keys().any(|k| matches(k))
+            || reg.subsets.keys().any(|k| matches(k))
+            || reg.enum_types.keys().any(|k| matches(k))
+    }
+
     pub(crate) fn has_role(&self, name: &str) -> bool {
         self.registry().roles.contains_key(name)
     }

--- a/t/role-method-param-type-resolution.t
+++ b/t/role-method-param-type-resolution.t
@@ -4,9 +4,10 @@ use Test;
 # A role method parameter type constraint must resolve the same way a class
 # method's does. Previously the role-registration validation over-rejected
 # several valid forms with "Invalid typename '...' in parameter declaration."
-# (regressions surfaced by real ecosystem dists: IdClass, SQL::Abstract).
+# (regressions surfaced by real ecosystem dists: IdClass, SQL::Abstract,
+# Protocol::MQTT).
 
-plan 6;
+plan 7;
 
 # 1. A coercion type as a role method parameter (`Int()`).
 {
@@ -55,6 +56,21 @@ lives-ok {
     die "wrong" unless Impl.new.render(E.new) eq "rendered";
     CODE
 }, 'compound-role short-name sibling type (nested package)';
+
+# 6b. A compound-named role in a `unit package` (`my role Packet::Empty`)
+#     referencing a sibling class of the enclosing package by short name — the
+#     failing shape in Protocol::MQTT. The compound name leaves the enclosing
+#     package out of both the role name and the current package, so this only
+#     resolves via the "known by short name" fallback.
+#     The "Invalid typename" error fires at role *registration*, so exercising
+#     the declaration alone is enough to pin it.
+lives-ok {
+    EVAL q:to/CODE/;
+    unit package Outer6;
+    our class DecodeBuffer {}
+    my role Packet::Empty { method decode(DecodeBuffer $b) { "ok" } }
+    CODE
+}, 'compound-role short-name sibling in a unit package (Protocol::MQTT shape)';
 
 # 6. A genuinely undeclared type is still rejected.
 {


### PR DESCRIPTION
## Summary

Follow-up to #4865. A compound-named role declared in a `unit package` — `my role Packet::Empty` inside `unit package Protocol::MQTT` — that references a sibling class of the enclosing package by short name (`DecodeBuffer`) was still rejected with `Invalid typename 'DecodeBuffer' in parameter declaration.`.

The compound role name (`Packet::Empty`) leaves the enclosing package out of **both** the role's registered name and `current_package`, so #4865's enclosing-prefix walk cannot reach `Protocol::MQTT::DecodeBuffer`.

## Fix

Add `type_known_by_short_name` (matches any registered class/role/subset/enum by its last `::`-segment) and use it as the **final fallback** in the role method-param validation — mirroring how the sub-registration pre-pass already accepts any type declared in the compilation unit via `declared_types`. A genuinely-undeclared name matches nothing and is still rejected (verified: `TotallyBogusXYZ` and `roast/S14-roles/basic.t`).

Unblocks the typename layer for **Protocol::MQTT** — it now advances to the same parametric-role resolution frontier as SQL::Abstract (`No matching candidate found for the parametric role`), the next common blocker.

## Tests

- Pin: `t/role-method-param-type-resolution.t` case 6b (compound `my role` sibling in a `unit package`).
- `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)