### PR TITLE
fix: string interpolation recognizes Unicode letters in a var name

### DIFF
--- a/src/parser/primary/var/ident.rs
+++ b/src/parser/primary/var/ident.rs
@@ -95,13 +95,13 @@ pub(crate) fn parse_interpolation_qualified_ident_with_hyphens_or_empty(
     let mut full = String::new();
     let mut parsed_any = false;
     while let Some(first) = rest.chars().next() {
-        if !(first.is_ascii_alphabetic() || first == '_') {
+        if !is_raku_identifier_start(first) {
             break;
         }
         let mut end = first.len_utf8();
         let rest_bytes = rest.as_bytes();
         for c in rest[end..].chars() {
-            if c.is_ascii_alphanumeric() || c == '_' {
+            if is_raku_identifier_continue(c) {
                 end += c.len_utf8();
             } else if c == '-' {
                 // Kebab-case: hyphen is part of the identifier only when

--- a/t/interp-unicode-var-name.t
+++ b/t/interp-unicode-var-name.t
@@ -1,0 +1,52 @@
+use v6;
+use Test;
+
+# String interpolation must recognise Unicode letters in a variable name.
+# Previously the interpolation identifier scanner used is_ascii_alphabetic,
+# so `"$ν"` split into `$` + literal `ν` and never interpolated.
+
+plan 9;
+
+{
+    my $ν = 42;
+    is "$ν is here", "42 is here", 'Greek scalar var interpolates';
+}
+
+{
+    my $café = 1;
+    is "$café!", "1!", 'accented scalar var interpolates';
+}
+
+{
+    my $λ = 5;
+    is "value: $λ", "value: 5", 'lambda scalar var interpolates';
+}
+
+# Method-call interpolation on a Unicode-named var.
+{
+    my $ν = 42;
+    is "$ν.Str()", "42", 'method call on unicode var interpolates';
+}
+
+# A superscript digit still terminates the name (postfix exponent boundary):
+# "$x²" is variable $x followed by a literal "²".
+{
+    my $x = 3;
+    is "$x²", "3²", 'superscript digit ends the interpolated var name';
+    my $no = 5;
+    is "$no² done", "5² done", 'name stops before superscript, keeps the rest';
+}
+
+# Unicode array / hash interpolation still works.
+{
+    my @αβ = 1, 2, 3;
+    is "list: @αβ[]", "list: 1 2 3", 'unicode array var interpolates';
+    my %λ = a => 1;
+    is "%λ<a>", "1", 'unicode hash var interpolates';
+}
+
+# Plain ASCII interpolation is unaffected.
+{
+    my $name = "world";
+    is "hello $name", "hello world", 'ascii interpolation unaffected';
+}


### PR DESCRIPTION
## Summary

```raku
my $ν = 42;
say "$ν is here";   # raku: 42 is here   mutsu (before): ν is here
```

The interpolation identifier scanner used `is_ascii_alphabetic` / `is_ascii_alphanumeric`, so it stopped at the first non-ASCII letter and never captured a Unicode variable name (`$ν`, `$café`, `$λ`, …).

## Fix

Use the shared `is_raku_identifier_start` / `is_raku_identifier_continue` helpers (`parser/helpers.rs`) — the same predicates the main identifier parser uses. They accept Unicode letters and combining marks while still **excluding superscript digits**, so `"$x²"` keeps parsing as `$x` followed by a literal `²` (the postfix-exponent boundary).

## Verified

- `"$ν"`, `"$café"`, `"$λ"` interpolate; `"$ν.Str()"` method-call interpolation works.
- `"$x²"` → `3²` (superscript still ends the name).
- Unicode array/hash interpolation (`@αβ[]`, `%λ<a>`) and plain ASCII interpolation unaffected.

## Provenance

From the doc-diff QA harness — `Language/containers.rakudoc` finding [2]. Pin: `t/interp-unicode-var-name.t` (verified against both raku and mutsu). `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)