### PR TITLE
fix: bind an enum value as a parametric-role type argument

### DIFF
--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -17,7 +17,24 @@ impl Interpreter {
                 ));
             }
             if should_treat_role_arg_as_type_expr(expr) {
-                values.push(Value::package(Symbol::intern(expr.trim())));
+                // A plain qualified name (`Type::Connect`, no brackets/parens)
+                // may be an *enum value* rather than a type — an enum value used
+                // as a role type argument (`class C does Packet[Type::Connect]`)
+                // must bind to a typed param (`role Packet[Type $t]`) as the value,
+                // not as a `Package` type object (which would fail the type check
+                // and yield "No matching candidate found for the parametric role").
+                // Try evaluating it; use the result only if it is an enum value.
+                let trimmed = expr.trim();
+                if !trimmed.contains(['[', '(', ' '])
+                    && trimmed.contains("::")
+                    && let Ok(value) = crate::parse_dispatch::parse_source(expr)
+                        .and_then(|(stmts, _)| self.eval_block_value(&stmts))
+                    && matches!(value.view(), ValueView::Enum { .. })
+                {
+                    values.push(value);
+                    continue;
+                }
+                values.push(Value::package(Symbol::intern(trimmed)));
                 continue;
             }
             match crate::parse_dispatch::parse_source(expr)

--- a/t/parametric-role-enum-arg.t
+++ b/t/parametric-role-enum-arg.t
@@ -1,0 +1,35 @@
+use v6;
+use Test;
+
+# A parametric role whose type parameter is constrained by an enum type, applied
+# with an enum *value* as the argument, must bind the value (not a Package type
+# object). Previously the role-argument evaluator treated any `Foo::Bar` name as
+# a type expression, so `does Packet[Type::Connect]` bound a Package and the
+# candidate failed with "No matching candidate found for the parametric role".
+# Surfaced by SQL::Abstract and Protocol::MQTT.
+
+plan 5;
+
+enum Type <Connect Publish Subscribe>;
+
+role Packet[Type $type] {
+    method kind { $type }
+}
+
+class Conn does Packet[Type::Connect] {}
+class Pub  does Packet[Type::Publish] {}
+
+is Conn.new.kind, Connect, 'enum-value role arg binds (Connect)';
+is Pub.new.kind,  Publish, 'enum-value role arg binds (Publish)';
+isa-ok Conn.new.kind, Type, 'the bound value is a Type enum value';
+
+# A string / literal type argument still works (unchanged behavior).
+role Named[Str $name] { method name { $name } }
+class Widget does Named["widget"] {}
+is Widget.new.name, "widget", 'string role arg still binds';
+
+# A genuine type argument (a class) still binds as a type object.
+class Element {}
+role Container[::T] { method elem-type { T } }
+class Box does Container[Element] {}
+is Box.new.elem-type.^name, "Element", 'class type role arg still binds as a type';


### PR DESCRIPTION
## Summary

A parametric role whose type parameter is constrained by an **enum type** (`role Packet[Type $type]`), applied with an enum **value** as the argument (`class Conn does Packet[Type::Connect]`), failed with `No matching candidate found for the parametric role`.

`eval_role_arg_values` treated any `Foo::Bar` role argument as a *type expression* and bound a `Package` type object without evaluating it. An enum value (`Type::Connect`) looks like a qualified name but is a value, so binding a `Package` failed the `Type $type` type check and no candidate matched.

## Fix

A plain qualified-name argument (no brackets/parens) is now evaluated first; if it yields an **enum value** it binds as that value, otherwise it falls back to the `Package` type form. Class/type arguments (`does Container[Element]`) and string/literal arguments (`does Named["widget"]`) are unchanged.

Surfaced by **SQL::Abstract** and **Protocol::MQTT** — both advance past the parametric-role frontier (SQL::Abstract to a separate reduction-operator bug; Protocol::MQTT fully unblocked once #4868's typename fix also lands).

## Tests

- Pin: `t/parametric-role-enum-arg.t` (5 cases: enum-value binds, string arg unchanged, class type arg unchanged).
- All whitelisted `S14-roles/*` and `S12-coercion/parameterized.t` still exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)