### PR TITLE
fix: embedded \qqw[...] / \qw[...] quote-words escapes in strings

### DIFF
--- a/src/parser/primary/quote_adverbs.rs
+++ b/src/parser/primary/quote_adverbs.rs
@@ -426,6 +426,16 @@ fn process_q_escape<'a>(
 ) -> Option<&'a str> {
     let input = *rest;
 
+    // \qqw[...] / \qw[...] — embedded quote-words (checked before \qq so the
+    // trailing `w` isn't consumed as a plain \qq delimiter).
+    if let Some((after, words)) = super::string::try_embedded_qw(input) {
+        if !current.is_empty() {
+            parts.push(Expr::Literal(Value::str(std::mem::take(current))));
+        }
+        parts.push(words);
+        return Some(after);
+    }
+
     // \qq[...] — interpolate inner content as qq
     if let Some(after_qq) = input.strip_prefix("\\qq")
         && let Some(r) = parse_inline_quote(after_qq, &QuoteFlags::qq_double())

--- a/src/parser/primary/string.rs
+++ b/src/parser/primary/string.rs
@@ -43,6 +43,7 @@ pub(crate) use helpers::{
 };
 pub(crate) use heredoc::parse_to_heredoc_with_flags;
 pub(crate) use interp_content::parse_single_quote_qq;
+pub(crate) use interp_content::try_embedded_qw;
 pub(crate) use interp_helpers::{
     has_malformed_angle_interpolation, parse_shell_words_index, try_double_sigil_interp,
     try_parse_interp_call, try_parse_interp_method_call,

--- a/src/parser/primary/string/interp_content.rs
+++ b/src/parser/primary/string/interp_content.rs
@@ -124,12 +124,61 @@ pub(crate) fn parse_braced_interpolation(input: &str) -> Option<(&str, &str)> {
     None
 }
 
+/// Try to consume an embedded `\qqw[...]` or `\qw[...]` quote-words escape at
+/// the start of `rest`. `\qqw` interpolates the body first, `\qw` keeps it
+/// literal; both then split on whitespace into a word list, which joins with
+/// single spaces in string context (matching raku). Returns the remainder and
+/// the word-list expression, or `None` when the marker does not match.
+pub(crate) fn try_embedded_qw(rest: &str) -> Option<(&str, Expr)> {
+    for &(marker, interpolate) in &[("\\qqw", true), ("\\qw", false)] {
+        let Some(after_marker) = rest.strip_prefix(marker) else {
+            continue;
+        };
+        let Some(open) = after_marker.chars().next() else {
+            continue;
+        };
+        if open.is_alphanumeric() || open.is_whitespace() {
+            continue;
+        }
+        let parsed = if let Some(close) = unicode_bracket_close(open) {
+            read_bracketed(after_marker, open, close, true).ok()
+        } else {
+            let body = &after_marker[open.len_utf8()..];
+            body.find(open)
+                .map(|end| (&body[end + open.len_utf8()..], &body[..end]))
+        };
+        let (after, inner) = parsed?;
+        let base = if interpolate {
+            interpolate_string_content(inner)
+        } else {
+            Expr::Literal(Value::str(inner.to_string()))
+        };
+        let words = Expr::MethodCall {
+            target: Box::new(base),
+            name: crate::symbol::Symbol::intern("words"),
+            args: vec![],
+            modifier: None,
+            quoted: false,
+        };
+        return Some((after, words));
+    }
+    None
+}
+
 pub(crate) fn parse_single_quote_qq(content: &str) -> Expr {
     let mut parts: Vec<Expr> = Vec::new();
     let mut current = String::new();
     let mut rest = content;
 
     while !rest.is_empty() {
+        if let Some((after, words)) = try_embedded_qw(rest) {
+            if !current.is_empty() {
+                parts.push(Expr::Literal(Value::str(std::mem::take(&mut current))));
+            }
+            parts.push(words);
+            rest = after;
+            continue;
+        }
         if let Some(after_qq) = rest.strip_prefix("\\qq")
             && let Some(open) = after_qq.chars().next()
             && !open.is_alphanumeric()

--- a/t/embedded-qqw-qw-escape.t
+++ b/t/embedded-qqw-qw-escape.t
@@ -1,0 +1,48 @@
+use v6;
+use Test;
+
+# The embedded quote-words escapes usable inside an otherwise-non-interpolating
+# string: the qqw form interpolates then word-splits; the qw form word-splits a
+# literal body. In string context the word list joins with single spaces.
+# Previously mutsu left them literal (or only handled the qq form).
+
+plan 8;
+
+# The doc example (Language/quoting.rakudoc): single-quoted string.
+{
+    my $animal = "quaggas";
+    is 'These animals are \qqw[$animal or zebras]',
+        'These animals are quaggas or zebras',
+        'single-quote qqw interpolates and word-splits';
+}
+
+# qw keeps the body literal (no interpolation), just word-splits.
+{
+    my $a = "x";
+    is 'no interp \qw[$a y]', 'no interp $a y', 'single-quote qw does not interpolate';
+}
+
+# Works inside q{...} the same as inside '...'.
+{
+    my $a = "x";
+    is q{a \qqw[$a y z] b}, 'a x y z b', 'q-braces qqw interpolates';
+    is q{a \qw[one two] b}, 'a one two b', 'q-braces qw word-splits';
+}
+
+# Existing qq form still works.
+{
+    my $a = "x";
+    is q{a \qq[$a] b}, 'a x b', 'q-braces qq still works';
+}
+
+# Q{...} is fully raw — the escape stays literal. (Build the expected value
+# with Q so the backslash sequence is not itself processed.)
+{
+    is Q{raw \qw[a b]}, Q{raw \qw[a b]}, 'Q-braces leaves the escape literal';
+    ok Q{raw \qw[a b]}.contains(Q{\qw}), 'Q-braces output still contains the raw escape';
+}
+
+# Angle delimiter form.
+{
+    is 'x \qw<one two three> y', 'x one two three y', 'qw with angle delimiter';
+}


### PR DESCRIPTION
## Summary

```raku
my $animal = "quaggas";
say 'These animals are \qqw[$animal or zebras]';
# raku: These animals are quaggas or zebras
# mutsu (before): These animals are \qqw[$animal or zebras]
```

mutsu handled the embedded `\qq[...]` escape but not the quote-words variants:
- `\qqw[...]` — interpolate the body, then word-split
- `\qw[...]` — word-split a literal body

The `\qq` scanner rejects `\qqw` because the char after `\qq` is `w` (alphanumeric), so the escape was left untouched.

## Fix

Add a `try_embedded_qw` helper (`interp_content.rs`) that reads the bracketed/delimited body, interpolates it (`\qqw`) or keeps it literal (`\qw`), and wraps the result in `.words`. A word list joins with single spaces in string context, matching raku.

Wired into both quote-content paths:
- `parse_single_quote_qq` — `'...'` and heredocs
- `process_q_escape` — `q{...}`

`Q{...}` stays fully raw (the escape remains literal).

## Provenance

From the doc-diff QA harness — `Language/quoting.rakudoc` finding [3]. Pin: `t/embedded-qqw-qw-escape.t` (verified against both raku and mutsu). fmt/clippy clean; quoting/interpolation roast tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)