### PR TITLE
fix: (B)-gate method-lvalue writeback — env_changed guard on the caller-slot pull

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -598,6 +598,38 @@ The 2-file sigilless cluster splits into two independent roots:
    (sigilless-comma-decl only; sigilless-params stays; the two `let`/`temp` files are
    fixed separately by #4861).
 
+### method-lvalue self-writeback — env_changed guard (2026-07-19)
+
+Partial burndown of the `method-call / attr self-writeback` cluster. After an
+`__mutsu_assign_method_lvalue` call (`$x.attr = v`) the call site
+(`exec_call_func_op`, vm_call_func_ops.rs) pulls `env[target]` back into the
+caller's local slot to keep it coherent — assuming the lvalue builtin wrote
+`env[target]`. Some do NOT: `Failure.handled = True` only flips a global registry
+keyed by the instance id, leaving `env[target]` untouched. Under the gate
+`my $f = Failure.new` leaves env at its `Any` decl seed, so the unconditional pull
+clobbered the live instance slot with `Any` (`$f` became `Any`, then
+`No such method 'handled' for invocant of type 'Any'`). Fix: snapshot
+`env[target]` before dispatch and only apply the pull when it genuinely changed
+during the call — the same `env_changed` guard as
+`carrier_writeback_changed_aggregates` (mechanism #3). Gate OFF byte-identical
+(`make test` 18931 PASS): a builtin that writes `env[target]` always leaves
+`prev != val`, and one that does not leaves `prev == val ==` the live slot value
+(a no-op pull anyway). Fixes `object-subscript-protocol.t`, `native-failure-ctor.t`,
+`native-failure-accessors.t` ON standalone; `lvalue-method-rw.t` /
+`lvalue-subroutines-rw-proxy.t` need this PLUS the closure fold. Pin:
+`t/gate-b-method-lvalue-writeback.t`.
+
+**Still open (the deeper mechanism #3, dedicated session):** the general
+call-return reconcile clobbers a caller local from stale env for constructor and
+self-writeback calls too — `my $ct = CT.new(...); $ct.x` leaves `$ct` = `Any` under
+the gate (a `submethod TWEAK` attr write path), and `method-call-self-writeback.t`,
+`bind-self-attr-write.t`, `virtual-call-attr.t`, `native-tweak-construct.t`,
+`quanthash-immutable-ro.t`, `native-map-hash-coerce.t`,
+`sethash-baghash-mixhash-coerce-fn.t`, `nested-assoc-user-assign-key.t` still fail
+ON via that path. This is the load-bearing `drain_and_reconcile` /
+`apply_pending_rw_writeback` env-by-name pull — the mechanism-#3 core the memory
+flags as flaky-prone and dedicated-session scale.
+
 ## §1.4 flip blast-radius measurement (2026-07-02, debug + release `prove t/`)
 
 A naive flip was implemented and measured, then reverted (branch

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -790,6 +790,18 @@ impl Interpreter {
                 .filter(|s| !s.is_empty()),
             _ => None,
         };
+        // Snapshot the target's CURRENT env value so the writeback below can tell
+        // whether the lvalue builtin actually changed it. Some lvalue methods do
+        // NOT write `env[target]` at all (`Failure.handled = True` only flips a
+        // global registry keyed by the instance id; the instance in the slot is
+        // untouched). Under the `(B)` per-store env-write gate a preceding
+        // `my $f = Failure.new` leaves `env<f>` at its `Any` decl seed, so an
+        // unconditional pull would clobber the live instance slot with that stale
+        // `Any`. Mirrors the mechanism-#3 `env_changed` guard in
+        // `carrier_writeback_changed_aggregates`.
+        let lvalue_writeback_pre = lvalue_writeback_target
+            .as_ref()
+            .map(|t| self.env().get(t).cloned());
         let result = match self.dispatch_func_call_inner(
             code,
             &name,
@@ -814,6 +826,15 @@ impl Interpreter {
             // `HashEntryRef` binding slot with a plain env copy.
             && !matches!(self.locals[slot].view(), ValueView::HashEntryRef { .. })
             && let Some(val) = self.env().get(&target).cloned()
+            // Only apply when the lvalue builtin genuinely changed `env[target]`
+            // during the call (see the snapshot above). Gate OFF this is
+            // byte-identical: env tracks the slot, so a builtin that writes
+            // `env[target]` always leaves `prev != val`, and one that does not
+            // leaves `prev == val == the live slot value` (a no-op pull anyway).
+            && match lvalue_writeback_pre {
+                Some(Some(ref prev)) => !prev.same_variant(&val) || *prev != val,
+                _ => true,
+            }
         {
             self.locals[slot] = val;
         }

--- a/t/gate-b-method-lvalue-writeback.t
+++ b/t/gate-b-method-lvalue-writeback.t
@@ -1,0 +1,40 @@
+use Test;
+
+# Pin for the (B) per-store env-write gate method-lvalue self-writeback fix
+# (docs/lexical-scope-slot-campaign.md, "(B) per-store env-write gate — burndown",
+# method-lvalue cluster).
+#
+# After an `__mutsu_assign_method_lvalue` call (`$x.attr = v`), the call site pulls
+# `env[target]` back into the caller's local slot to keep it coherent — assuming the
+# lvalue builtin wrote `env[target]`. Some do NOT: `Failure.handled = True` only
+# flips a global registry keyed by the instance id, leaving `env[target]` untouched.
+# Under the MUTSU_GATE_LOCAL_ENV_WRITE gate `my $f = Failure.new` leaves env at its
+# `Any` decl seed, so the unconditional pull clobbered the live instance slot with
+# `Any` (`$f` became Any). The fix only applies the pull when the builtin genuinely
+# changed `env[target]` during the call (an env_changed guard). Passes gate-OFF
+# (default) and would fail gate-ON before the fix.
+
+plan 6;
+
+# Failure.handled = True does not write env[target]; the slot must survive.
+my $f = Failure.new("boom");
+$f.handled = True;
+is $f.handled, True, 'Failure.handled can be set';
+$f.so;
+isa-ok $f, Failure, 'the Failure instance slot survives the lvalue assign';
+
+# A normal lvalue writeback that DOES change env[target] still applies.
+my @a = 1, 2, 3;
+@a.head = 99;
+is @a, [99, 2, 3], 'array head lvalue writeback still lands';
+
+my %h = x => 1, y => 2;
+%h<x> = 5;
+is %h<x>, 5, 'hash element assign still lands';
+
+# Interleaving a Test-fn call between the lvalue assign and a later read.
+my $f2 = Failure.new("again");
+$f2.handled = True;
+ok $f2.handled, 'handled state persists across a following assertion';
+$f2.so;
+is $f2.exception.message, "again", 'the exception is still reachable on the slot';


### PR DESCRIPTION
Part of the `(B)` per-store env-write gate burndown (docs/lexical-scope-slot-campaign.md, §1.3 endgame). Partial burndown of the method-call/attr self-writeback cluster.

## Root cause
After an `__mutsu_assign_method_lvalue` call (`$x.attr = v`), the call site pulls `env[target]` back into the caller's local slot, assuming the lvalue builtin wrote `env[target]`. Some do **not**: `Failure.handled = True` only flips a global registry keyed by the instance id, leaving `env[target]` untouched. Under the `MUTSU_GATE_LOCAL_ENV_WRITE` gate `my $f = Failure.new` leaves env at its `Any` decl seed, so the unconditional pull clobbered the live instance slot with `Any`:

```raku
my $f = Failure.new("boom");
$f.handled = True;
say $f.handled;   # gate-ON before fix: "No such method 'handled' for invocant of type 'Any'"
```

## Fix
Snapshot `env[target]` before dispatch and only apply the pull when it genuinely changed during the call — the same `env_changed` guard as `carrier_writeback_changed_aggregates` (mechanism #3, #4859). Gate OFF byte-identical: a builtin that writes `env[target]` always leaves `prev != val`; one that does not leaves `prev == val ==` the live slot value (a no-op pull anyway).

## Verification
- `make test` (gate OFF, default): 18931 PASS, byte-identical count.
- Gate-ON: fixes `object-subscript-protocol.t`, `native-failure-ctor.t`, `native-failure-accessors.t` standalone; `lvalue-method-rw.t` / `lvalue-subroutines-rw-proxy.t` need this plus the closure-capture fold (#4869).
- Pin: `t/gate-b-method-lvalue-writeback.t` (passes OFF, ON, matches `raku`).

## Still open
The general call-return reconcile clobbers a caller local from stale env for constructor/self-writeback calls too (`my \$ct = CT.new(...); \$ct.x` leaves `\$ct` = Any via a `submethod TWEAK` path). That is the load-bearing mechanism-#3 `drain_and_reconcile` core — documented in the campaign doc as dedicated-session scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)