### PR TITLE
fix: parse an attribute `handles<...>` list with no leading space

### DIFF
--- a/src/parser/stmt/decl/has_decl.rs
+++ b/src/parser/stmt/decl/has_decl.rs
@@ -633,10 +633,13 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
         rest = r;
     }
 
-    // `handles` trait, e.g. `has $.x handles <a b>`
+    // `handles` trait, e.g. `has $.x handles <a b>` or `has $.x handles<a b>`
+    // (no space before the angle-word list is legal, so only optional
+    // whitespace is required after the keyword — `keyword` already guards the
+    // word boundary, so `handlesfoo` never matches here).
     let mut handles = Vec::new();
     while let Some(r) = keyword("handles", rest) {
-        let (r, _) = ws1(r)?;
+        let (r, _) = ws(r)?;
         parse_handle_specs(r, &mut handles, &mut rest)?;
         let (r, _) = ws(rest)?;
         rest = r;

--- a/t/attr-handles-angle-word.t
+++ b/t/attr-handles-angle-word.t
@@ -1,0 +1,56 @@
+use v6;
+use Test;
+
+# `handles<...>` (an angle-word delegation list with no space before the `<`)
+# on an attribute must parse. Previously the parser required whitespace after
+# the `handles` keyword, so `has $.x handles<a b>` failed to parse and the whole
+# `has` declaration fell back to expression parsing ("Variable $.x used where no
+# 'self' is available" / "Unsupported reduction operator"). Surfaced by
+# SQL::Abstract (`has Row:D $.values is required handles<elements>;`).
+
+plan 5;
+
+# 1. Delegation via a no-space angle-word list works.
+{
+    class Inner { method greet { "hi" } }
+    class C {
+        has Inner $.inner handles<greet> = Inner.new;
+    }
+    is C.new.greet, "hi", 'handles<name> (no space) delegates';
+}
+
+# 2. Multiple delegated methods.
+{
+    class Inner { method a { "A" }; method b { "B" } }
+    class C {
+        has Inner $.inner handles<a b> = Inner.new;
+    }
+    is C.new.a ~ C.new.b, "AB", 'handles<a b> delegates multiple methods';
+}
+
+# 3. The spaced form still works (unchanged).
+{
+    class Inner { method greet { "yo" } }
+    class C {
+        has Inner $.inner handles <greet> = Inner.new;
+    }
+    is C.new.greet, "yo", 'handles <name> (with space) still works';
+}
+
+# 4. A typed :D attribute with a trailing trait and a no-space handles list —
+#    the exact SQL::Abstract shape.
+{
+    class Row { method elements { <a b c> } }
+    class C {
+        has Row:D $.values is required handles<elements>;
+    }
+    is C.new(:values(Row.new)).elements.join, "abc",
+        'typed :D attr with is required + handles<elements>';
+}
+
+# 5. A single delegated method.
+{
+    class Inner { method only { 42 } }
+    class C { has $.inner handles<only> = Inner.new; }
+    is C.new.only, 42, 'handles<only> single method';
+}


### PR DESCRIPTION
## Summary

`has $.x handles<a b>` — an attribute delegation list written as an angle-word with **no space** before the `<` — failed to parse. The attribute parser required whitespace after the `handles` keyword (`ws1`), so `handles<...>` did not match, and the whole `has` declaration fell back to expression parsing:

- `has $.x handles<a b>;` → `Variable $.x used where no 'self' is available`
- `has Row:D $.values is required handles<elements>;` → `Unsupported reduction operator: ow` (the `<elements>` mis-read as a `< >` comparison / reduce metaop, splitting `Row` into a reverse-metaop `R` + `ow`)

## Fix

`keyword("handles", ...)` already guards the word boundary (`handlesfoo` never matches), so only **optional** whitespace is needed after it. Changing `ws1` → `ws` lets both `handles<a b>` and `handles <a b>` parse; `parse_handle_specs` already accepts a list starting immediately at `<`.

Surfaced by **SQL::Abstract** (`has Row:D $.values is required handles<elements>;`), which advances past this blocker.

## Tests

- Pin: `t/attr-handles-angle-word.t` (5 cases incl. real delegation dispatch and the spaced form).
- `make test` green; whitelisted handles/attribute roast tests still exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)