### PR TITLE
fix: :a / :h quote adverbs interpolate a method call on the array/hash

### DIFF
--- a/src/parser/primary/quote_adverbs.rs
+++ b/src/parser/primary/quote_adverbs.rs
@@ -596,7 +596,8 @@ fn try_interpolate_with_flags<'a>(
 
     if rest.starts_with('@') && flags.interp_array() {
         if !flags.qq_mode {
-            // In selective :a mode, require postcircumfix []
+            // In selective :a mode, a bare `@name` stays literal; it interpolates
+            // only when followed by a postcircumfix `[...]` or a `.method` call.
             let after_at = &rest[1..];
             if after_at.starts_with('*') || after_at.starts_with('!') || after_at.starts_with('?') {
                 // twigil — skip to name
@@ -608,8 +609,8 @@ fn try_interpolate_with_flags<'a>(
                     return None;
                 }
                 let after_name = &after_at[name_end..];
-                if !after_name.starts_with('[') {
-                    return None; // bare @name without postcircumfix
+                if !after_name.starts_with('[') && !after_name.starts_with('.') {
+                    return None; // bare @name without postcircumfix or method call
                 }
             }
         }
@@ -618,7 +619,8 @@ fn try_interpolate_with_flags<'a>(
 
     if rest.starts_with('%') && flags.interp_hash() {
         if !flags.qq_mode {
-            // In selective :h mode, require postcircumfix <> or {}
+            // In selective :h mode, a bare `%name` stays literal; it interpolates
+            // only with a postcircumfix `<...>` / `{...}` or a `.method` call.
             let after_pct = &rest[1..];
             let name_end = after_pct
                 .find(|c: char| !c.is_alphanumeric() && c != '_' && c != '-')
@@ -627,7 +629,10 @@ fn try_interpolate_with_flags<'a>(
                 return None;
             }
             let after_name = &after_pct[name_end..];
-            if !after_name.starts_with('<') && !after_name.starts_with('{') {
+            if !after_name.starts_with('<')
+                && !after_name.starts_with('{')
+                && !after_name.starts_with('.')
+            {
                 return None;
             }
         }

--- a/t/q-adverb-array-method-interp.t
+++ b/t/q-adverb-array-method-interp.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+# The :a / :h quoting adverbs enable @-/%-sigil interpolation. A bare `@a`
+# stays literal, but `@a[...]` (postcircumfix) AND `@a.method()` (method call)
+# must interpolate. Previously mutsu required a postcircumfix and left a
+# method call literal.
+
+plan 8;
+
+# The doc example (Language/quoting.rakudoc): method call on a Unicode array.
+{
+    my @þ = <33 44>;
+    is Q:a "Array contains @þ.elems()", "Array contains 2",
+        ':a interpolates a method call on the array';
+}
+
+{
+    my @a = <x y z>;
+    is Q:a "n=@a.elems()", "n=3", ':a method call interpolates';
+    is Q:a "arr @a[]", "arr x y z", ':a postcircumfix still interpolates';
+    is Q:a "bare @a end", "bare @a end", ':a leaves a bare array literal';
+    is Q:a "dot @a. text", "dot @a. text", ':a leaves array + non-method dot literal';
+}
+
+# :h hash adverb, same rule.
+{
+    my %h = a => 1, b => 2;
+    is Q:h "n=%h.elems()", "n=2", ':h interpolates a method call on the hash';
+    is Q:h "v=%h<a>", "v=1", ':h postcircumfix still interpolates';
+    is Q:h "bare %h end", "bare %h end", ':h leaves a bare hash literal';
+}


### PR DESCRIPTION
## Summary

```raku
my @þ = <33 44>;
say Q:a "Array contains @þ.elems()";
# raku: Array contains 2
# mutsu (before): Array contains @þ.elems()
```

In selective `:a` / `:h` mode mutsu required a postcircumfix (`@a[...]` / `%h<...>` / `%h{...}`) and left a `.method()` call literal. raku interpolates `@a.method()` and `%h.method()` too (a bare `@a` / `%h` still stays literal).

## Fix

Allow a leading `.` after the variable name in the `:a` and `:h` interpolation gates (`quote_adverbs.rs`). `try_interpolate_var` already parses the method call and correctly declines a non-method dot, so `@a. text` (dot-space) stays literal.

## Verified

- `Q:a "@a.elems()"` → interpolates; `Q:a "@a[]"` still works; bare `Q:a "@a"` stays literal.
- `Q:h "%h.elems()"` → interpolates; `Q:h "%h<a>"` still works; bare `Q:h "%h"` stays literal.
- `Q:a "@a. text"` (non-method dot) stays literal.

## Provenance

From the doc-diff QA harness — `Language/quoting.rakudoc` finding [1]. Pin: `t/q-adverb-array-method-interp.t` (verified against both raku and mutsu). fmt/clippy clean; interpolation/quoting roast tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)