### PR TITLE
fix: resolve a coercion type whose target carries a definedness smiley

### DIFF
--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -478,13 +478,16 @@ impl Interpreter {
     /// Check if a constraint string refers to a known type (built-in or user-defined).
     /// Used for __type_only__ params to distinguish real type constraints (Str, Int)
     /// from sigilless parameter names (e1, e2) that look like type constraints.
-    pub(crate) fn is_resolvable_type(&self, constraint: &str) -> bool {
-        // Strip definedness smileys
-        let base = constraint
-            .strip_suffix(":D")
-            .or_else(|| constraint.strip_suffix(":U"))
-            .or_else(|| constraint.strip_suffix(":_"))
-            .unwrap_or(constraint);
+    pub(crate) fn is_resolvable_type<'a>(&self, constraint: &'a str) -> bool {
+        // Strip a definedness smiley that trails the whole constraint
+        // (`Foo:D`, and the outer smiley of `Foo(Bar):D`).
+        let strip_smiley = |s: &'a str| -> &'a str {
+            s.strip_suffix(":D")
+                .or_else(|| s.strip_suffix(":U"))
+                .or_else(|| s.strip_suffix(":_"))
+                .unwrap_or(s)
+        };
+        let base = strip_smiley(constraint);
         // Strip coercion: the resolvable part of a coercion type `Target(From)`
         // is the target type name before `(` (e.g. `Int()` -> `Int`,
         // `Identifier(Any)` -> `Identifier`). The from-type is validated
@@ -494,6 +497,9 @@ impl Interpreter {
         } else {
             base
         };
+        // The coercion target can itself carry a smiley (`Identifier:D(Any:D)`
+        // -> target `Identifier:D`); strip it too so the bare type name resolves.
+        let base = strip_smiley(base);
         // Strip parameterization: Array[Int] -> Array
         let base = if let Some(idx) = base.find('[') {
             &base[..idx]

--- a/t/coercion-target-smiley-param.t
+++ b/t/coercion-target-smiley-param.t
@@ -1,0 +1,44 @@
+use v6;
+use Test;
+
+# A coercion-type parameter whose *target* carries a definedness smiley
+# (`Identifier:D(Any:D)`, `Int:D(Any)`) must resolve. The role-registration
+# type validation stripped the trailing smiley before the coercion parens, so
+# for `Identifier:D(Any:D)` nothing was stripped (it ends in `)`), and after
+# taking the coercion target `Identifier:D` the smiley was left attached and the
+# bare type name never resolved -> "Invalid typename". Surfaced by SQL::Abstract.
+
+plan 4;
+
+# 1. A built-in coercion target with a smiley on both sides.
+{
+    role R { method f(Int:D(Any) $x) { $x + 1 } }
+    class C does R {}
+    is C.new.f("41"), 42, 'Int:D(Any) coercion param resolves and coerces';
+}
+
+# 2. A user-type coercion target with smileys on both sides.
+{
+    class Identifier { has $.v; method Str { "id-$!v" } }
+    role R2 { method g(Identifier:D(Any:D) $x) { $x.Str } }
+    class C2 does R2 {}
+    is C2.new.g(Identifier.new(:v(3))), "id-3",
+        'Identifier:D(Any:D) coercion param resolves';
+}
+
+# 3. The plain (no-smiley) coercion form still works.
+{
+    role R3 { method h(Int() $x) { $x } }
+    class C3 does R3 {}
+    is C3.new.h("7"), 7, 'Int() coercion param still resolves';
+}
+
+# 4. A genuinely undeclared coercion target is still rejected.
+{
+    my $ok = False;
+    try {
+        EVAL 'role RBad { method f(NoSuchXYZ:D(Any) $x) { 1 } }; 1';
+        $ok = True;
+    }
+    nok $ok, 'an undeclared coercion target with a smiley is still rejected';
+}


### PR DESCRIPTION
## Summary

`is_resolvable_type` stripped a trailing definedness smiley **before** taking the coercion target, so a coercion whose target has its own smiley (`Identifier:D(Any:D)`, `Int:D(Any)`) never resolved as a role method parameter type:

- the constraint ends in `)`, so the outer smiley-strip is a no-op;
- after slicing off the coercion `(...)`, the target `Identifier:D` still carried `:D`, and `has_class("Identifier:D")` was false → `Invalid typename 'Identifier:D(Any:D)' in parameter declaration.`

## Fix

Strip the definedness smiley **both** before the coercion (outer `Foo(Bar):D`) and from the coercion target itself (`Identifier:D(Any:D)` → target `Identifier:D` → `Identifier`). A genuinely undeclared target is still rejected.

Surfaced by **SQL::Abstract** (`method as(Identifier:D(Any:D) …)`), which advances past this blocker.

## Tests

- Pin: `t/coercion-target-smiley-param.t` (4 cases incl. real coercion dispatch + undeclared-still-rejected).
- `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)