### PR TITLE
fix: accept Unicode operator aliases in a reduction metaop

### DIFF
--- a/src/parser/primary/misc/reduction.rs
+++ b/src/parser/primary/misc/reduction.rs
@@ -15,6 +15,10 @@ const REDUCTION_OPS: &[&str] = &[
     "unicmp", "~~", "min", "max", "gcd", "lcm", "and", "or", "not", "andthen", "orelse", "xor",
     ",", "after", "before", "X", "Z", "x", "xx", "&", "|", "^", "o", "∘", "⊍", "div", "mod",
     "minmax",
+    // Unicode operator aliases (each an alias of a listed ASCII op that mutsu
+    // folds identically in reduction form): × (*), ÷ (/), − (U+2212, -),
+    // ≤ (<=), ≥ (>=), ≠ (!=), ∪ (set union), ∩ (set intersection).
+    "×", "÷", "−", "≤", "≥", "≠", "∪", "∩",
 ];
 
 /// Find the matching `]` for a `[` at position 0, respecting nesting.

--- a/src/vm/vm_misc_reduction_exec.rs
+++ b/src/vm/vm_misc_reduction_exec.rs
@@ -32,10 +32,19 @@ impl Interpreter {
         } else {
             (false, op_no_scan)
         };
-        let mut base_op = if base_op == "∘" {
-            "o".to_string()
-        } else {
-            base_op
+        // Unicode operator aliases fold identically to their ASCII base op
+        // (matching `eval_reduction_operator_values`): ∘→o, ×→*, ÷→/,
+        // −(U+2212)→-, ≤→<=, ≥→>=, ≠→!=. Without this a `[×]`/`[÷]`/… fold
+        // reaches an `infix:<×>` lookup that does not exist.
+        let mut base_op = match base_op.as_str() {
+            "\u{2218}" => "o".to_string(),
+            "\u{00D7}" => "*".to_string(),
+            "\u{00F7}" => "/".to_string(),
+            "\u{2212}" => "-".to_string(),
+            "\u{2264}" => "<=".to_string(),
+            "\u{2265}" => ">=".to_string(),
+            "\u{2260}" => "!=".to_string(),
+            _ => base_op,
         };
         // Handle lazy-scan short-circuit reduction compiled from ArrayLiteral.
         // The operator has prefix "_sc_" and the operand is an array of thunks.

--- a/t/reduction-unicode-ops.t
+++ b/t/reduction-unicode-ops.t
@@ -1,0 +1,23 @@
+use v6;
+use Test;
+
+# A reduction metaop `[op]` must accept the Unicode operator aliases that mutsu
+# already handles as plain infixes (× ÷ − ≤ ≥ ≠ ∪ ∩). Previously `[×]` (and the
+# others) failed to parse ("expected expression after multiplicative operator")
+# because they were missing from the reduction-operator whitelist, and even once
+# parsed the fold reached a non-existent `infix:<×>` lookup. Surfaced by
+# Prime::Factor (`[×] .list for these «**« upto`).
+
+plan 9;
+
+is ([×] 6, 2, 3), 36,   '[×] reduces as multiplication';
+is ([÷] 24, 2, 3), 4,   '[÷] reduces as division';
+is ([−] 10, 2, 3), 5,   '[−] (U+2212) reduces as subtraction';
+is ([≤] 1, 2, 3), True, '[≤] reduces as chained <=';
+is ([≥] 3, 2, 1), True, '[≥] reduces as chained >=';
+is ([≠] 1, 2), True,    '[≠] reduces as !=';
+is-deeply ([∪] (1,2).Set, (2,3).Set), (1,2,3).Set, '[∪] reduces as set union';
+is-deeply ([∩] (1,2,3).Set, (2,3,4).Set), (2,3).Set, '[∩] reduces as set intersection';
+
+# The scan (triangular) form works too.
+is-deeply ([\×] 2, 3, 4).List, (2, 6, 24), '[\×] scan reduction';


### PR DESCRIPTION
## Summary

`[×]` (and `[÷]`, `[−]`, `[≤]`, `[≥]`, `[≠]`, `[∪]`, `[∩]`) failed to parse — `expected expression after multiplicative operator` — because the Unicode operator aliases were missing from the reduction-operator whitelist (`REDUCTION_OPS`), even though mutsu already handles each as a plain infix (`3 × 4` works).

Once whitelisted, the fold still reached a non-existent `infix:<×>` lookup: `exec_reduction_op` only normalized `∘`→`o`, not the arithmetic/comparison aliases that `eval_reduction_operator_values` already maps.

## Fix

- Add the aliases to `REDUCTION_OPS` (parser whitelist).
- Mirror the full Unicode→ASCII normalization (`×`→`*`, `÷`→`/`, `−`→`-`, `≤`→`<=`, `≥`→`>=`, `≠`→`!=`) in `exec_reduction_op`, so a `[×]` fold evaluates via the same base op as `[*]`. The scan form `[\×]` works too.

All outputs verified against `raku`.

Surfaced by **Prime::Factor** (`[×] .list for these «**« upto`), which advances past this blocker.

## Tests

- Pin: `t/reduction-unicode-ops.t` (9 cases incl. scan form).
- `make test` green; whitelisted reduction/metaop roast tests still exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)