### PR TITLE
fix: parse a word-operator compound assignment as a loose-operator operand

### DIFF
--- a/src/parser/expr/operators.rs
+++ b/src/parser/expr/operators.rs
@@ -209,6 +209,18 @@ pub(super) fn parse_additive_op(r: &str) -> Option<(AdditiveOp, usize)> {
     }
 }
 
+/// Whether `r` starts with the word infix `kw` (`div`/`mod`/`gcd`/`lcm`) as an
+/// operator: it must be a whole word (not a longer identifier) and must not be
+/// the start of a compound assignment (`div=` etc.). Mirrors how the symbolic
+/// multiplicative ops guard against `*=` / `%=`, so a word compound assignment
+/// like `$n div= $p` — including as the operand of a looser operator such as
+/// `and` — is left for the assignment parser instead of being eaten as `div`.
+fn word_infix_at(r: &str, kw: &str) -> bool {
+    r.starts_with(kw)
+        && !is_ident_char(r.as_bytes().get(kw.len()).copied())
+        && r.as_bytes().get(kw.len()).copied() != Some(b'=')
+}
+
 pub(super) fn parse_multiplicative_op(r: &str) -> Option<(MultiplicativeOp, usize)> {
     // Unicode: multiply (U+00D7) -- skip if user-defined infix exists
     if r.starts_with('\u{00D7}') && !super::super::stmt::simple::is_user_defined_infix("\u{00D7}") {
@@ -237,13 +249,13 @@ pub(super) fn parse_multiplicative_op(r: &str) -> Option<(MultiplicativeOp, usiz
         Some((MultiplicativeOp::Mod, 1))
     } else if r.starts_with("%%") {
         Some((MultiplicativeOp::DivisibleBy, 2))
-    } else if r.starts_with("div") && !is_ident_char(r.as_bytes().get(3).copied()) {
+    } else if word_infix_at(r, "div") {
         Some((MultiplicativeOp::IntDiv, 3))
-    } else if r.starts_with("mod") && !is_ident_char(r.as_bytes().get(3).copied()) {
+    } else if word_infix_at(r, "mod") {
         Some((MultiplicativeOp::IntMod, 3))
-    } else if r.starts_with("gcd") && !is_ident_char(r.as_bytes().get(3).copied()) {
+    } else if word_infix_at(r, "gcd") {
         Some((MultiplicativeOp::Gcd, 3))
-    } else if r.starts_with("lcm") && !is_ident_char(r.as_bytes().get(3).copied()) {
+    } else if word_infix_at(r, "lcm") {
         Some((MultiplicativeOp::Lcm, 3))
     } else {
         None

--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -1,8 +1,9 @@
 use super::super::helpers::{is_ident_char, ws};
 use super::super::parse_result::{PError, PResult, merge_expected_messages, parse_char, parse_tag};
 use super::super::stmt::assign::{
-    build_compound_assign_expr, compound_assign_op_from_name, compound_assigned_value_expr,
-    parse_assign_expr_or_comma, parse_compound_assign_op, parse_meta_compound_assign_op,
+    build_compound_assign_expr, build_custom_compound_assign_expr, compound_assign_op_from_name,
+    compound_assigned_value_expr, parse_assign_expr_or_comma, parse_compound_assign_op,
+    parse_custom_compound_assign_op, parse_meta_compound_assign_op,
 };
 
 use crate::ast::{Expr, Stmt};

--- a/src/parser/expr/precedence/custom_infix.rs
+++ b/src/parser/expr/precedence/custom_infix.rs
@@ -20,7 +20,14 @@ pub(crate) fn parse_custom_infix_word(input: &str) -> Option<(String, usize)> {
         // `uc INFIX:<term> ...` instead of the listop call `uc(term)`.
         let is_declared_term = crate::parser::stmt::simple::match_user_declared_term_symbol(input)
             .is_some_and(|(_, consumed, _)| consumed == end);
-        if !is_reserved_infix_word(name) && !is_declared_term {
+        // A word immediately followed by `=` (but not `==`/`=>`) is a word
+        // compound assignment (`div=`, `x=`, a user `op=`), not an infix use —
+        // leave it for the assignment parser so `$n div= $p` parses, including
+        // as the operand of a looser operator like `and`.
+        let is_compound_assign = input[end..].starts_with('=')
+            && !input[end..].starts_with("==")
+            && !input[end..].starts_with("=>");
+        if !is_reserved_infix_word(name) && !is_declared_term && !is_compound_assign {
             word_match = Some((name.to_string(), end));
         }
     }

--- a/src/parser/expr/precedence/logic.rs
+++ b/src/parser/expr/precedence/logic.rs
@@ -149,6 +149,21 @@ pub(crate) fn assign_not_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
         }
     }
 
+    // Word-operator compound assignment (`div=`, `mod=`, `gcd=`, `x=`, and
+    // user-declared operators). Handled here — not only at the statement level —
+    // so it parses as the operand of a looser operator, e.g. the right side of
+    // `and`/`or`: `@f.push($p) and $n div= $p while ...` (surfaced by
+    // Prime::Factor). The multiplicative parser leaves `div=` alone (see
+    // `word_infix_at`), so `not_expr_mode` above returns the bare lvalue here.
+    if let Some((after_op, op_name)) = parse_custom_compound_assign_op(r) {
+        let (after_ws, _) = ws(after_op)?;
+        if let Ok((r, rhs)) = parse_assignment_rhs_mode(after_ws, mode)
+            && let Ok(result) = build_custom_compound_assign_expr(expr.clone(), op_name, rhs)
+        {
+            return Ok((r, result));
+        }
+    }
+
     // Binding (`:=`) is an expression-level operator at item-assignment
     // precedence (raku), so it must work unparenthesized after `return`, in a
     // declarator RHS, etc. -- e.g. `return @!specs := @specs`. mutsu otherwise

--- a/t/word-compound-assign-loose-operand.t
+++ b/t/word-compound-assign-loose-operand.t
@@ -1,0 +1,44 @@
+use v6;
+use Test;
+
+# A word-operator compound assignment (`div=`, `mod=`, `gcd=`, `lcm=`) must
+# parse as the operand of a looser operator such as `and`/`or`, e.g.
+# `@f.push($p) and $n div= $p while ...`. Previously the multiplicative /
+# custom-infix parsers ate the bare `div` (leaving a stray `= 2`), so the whole
+# expression failed to parse. Surfaced by Prime::Factor.
+
+plan 8;
+
+{
+    my $n = 12;
+    1 and $n div= 2;
+    is $n, 6, 'div= as the RHS of `and`';
+}
+{
+    my $n = 17;
+    1 and $n mod= 5;
+    is $n, 2, 'mod= as the RHS of `and`';
+}
+{
+    my $n = 12;
+    0 or $n gcd= 8;
+    is $n, 4, 'gcd= as the RHS of `or`';
+}
+{
+    my $n = 4;
+    1 and $n lcm= 6;
+    is $n, 12, 'lcm= as the RHS of `and`';
+}
+{
+    # The exact Prime::Factor shape: a statement-modifier `while` around an
+    # `and` whose RHS is a word compound assignment.
+    my @factors;
+    my $n = 12;
+    @factors.push(2) and $n div= 2 while $n %% 2;
+    is @factors.join(','), '2,2', 'push and div= while — factors collected';
+    is $n, 3, 'push and div= while — n reduced';
+}
+
+# Regressions: the word operators still parse as plain infixes.
+is (17 div 5), 3, 'div infix still works';
+is (12 gcd 8), 4, 'gcd infix still works';


### PR DESCRIPTION
## Summary

`@f.push($p) and $n div= $p while $n %% $p` failed to parse. The multiplicative parser and the custom word-infix parser both ate the bare `div` (and `mod`/`gcd`/`lcm`), leaving a stray `= $p`. A standalone `$n div= 2` worked only because the statement-level assignment parser checks the compound op first; as the operand of a looser operator like `and`/`or`, it went through the expression parsers, which had no `=` guard.

## Fix

- **`parse_multiplicative_op`**: guard `div`/`mod`/`gcd`/`lcm` with a new `word_infix_at` helper that (like the symbolic `*=`/`%=` guards) declines the word when immediately followed by `=`.
- **`parse_custom_infix_word`**: likewise decline a word immediately followed by `=` (but not `==`/`=>`), leaving a word/user compound assignment for the assignment parser.
- **`assign_not_expr_mode`**: after the symbolic compound-assign attempt, also try `parse_custom_compound_assign_op` + `build_custom_compound_assign_expr`, so the word compound assignment binds at expression level (the operand of `and`/`or`).

Word operators still parse as plain infixes (`17 div 5`, `12 gcd 8`).

Surfaced by **Prime::Factor** (`@factors.push($p) and $n div= $p while $n %% $p`), which advances past this blocker.

## Tests

- Pin: `t/word-compound-assign-loose-operand.t` (8 cases incl. the exact Prime::Factor shape + infix regressions).
- `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)