### PR TITLE
fix: parse a lowercase `is` trait on a unit class as a trait, not a parent

### DIFF
--- a/docs/dist-compat-sweep.md
+++ b/docs/dist-compat-sweep.md
@@ -134,7 +134,7 @@ Known root causes to date:
 | CSS | inside a `grammar` ("angle index key") — grammar/regex-slang, heavier. |
 | Prime::Factor / Pod::Contents / Deps / Trie / Configuration / File-TreeBuilder / Bench / App::Rak / Astro::Utils / Audio::Liquidsoap / IP::Random / Math::Matrix / ML::SparseMatrixRecommender / CSV::Table / Cro::FCGI | generic `expected statement…` dead-end — each needs its own repro; several carry multiple blockers (bisect at balanced method boundaries). |
 
-### runtime_error (15)
+### runtime_error (14 remaining; Astro::Sunrise cleared post-snapshot)
 
 | Dist | Root cause |
 |---|---|
@@ -144,7 +144,6 @@ Known root causes to date:
 | IDNA::Punycode | `Unexpected block in infix position (missing statement control word before the expression?)`. |
 | PDF::Font::Loader::CSS | `X::Syntax::Perl5Var: Unsupported use of $? variable` — a genuine `$?`-in-regex Perl5-ism (verify against raku before "fixing"). |
 | uniname-words | `Odd number of elements found where hash initializer expected` (load-time). |
-| Astro::Sunrise | `'Astro::Location' cannot inherit from 'export' because it is unknown` — an `is export` on a class mis-read as a parent. |
 | Repository::Precomp::Cleanup | `No such method 'id' for invocant of type 'Compiler'`. |
 | Test::Scheduler | `Scheduler is not composable, so Test::Scheduler cannot compose it`. |
 | Bits | `An exception occurred while evaluating a CHECK` (load-time CHECK phaser). |
@@ -184,10 +183,11 @@ cluster at once.
 ## load_ok — proven to load on mutsu (n=150, seed 7)
 
 The passing-dist report: every sampled distribution whose provided modules all
-`use` cleanly on mutsu (main + #4865). **44 of 150** (57% of the 77 whose deps
-are satisfiable).
+`use` cleanly on mutsu (main + #4865, plus post-snapshot fixes). **44 of 150**
+in the raw seed-7 run (57% of the 77 whose deps are satisfiable); Astro::Sunrise
+below was cleared after the snapshot by the `unit class … is export;` trait fix.
 
-Algorithm::LCS · Ask · Async::Command · Attribute::Predicate ·
+Algorithm::LCS · Ask · Astro::Sunrise · Async::Command · Attribute::Predicate ·
 Automata::Cellular · bird · CheckSocket · CLDR::List · CodeUnit · CSV::Parser ·
 Deepgrep · English · File::Ignore · Game::Covid19 · Grid · Hash::Agnostic ·
 Hash::Restricted · HTTP::HPACK · IdClass · Math::Interval · Math::Random ·

--- a/src/parser/stmt/class/package_decl.rs
+++ b/src/parser/stmt/class/package_decl.rs
@@ -4,7 +4,7 @@ use crate::ast::Stmt;
 use crate::symbol::Symbol;
 use crate::value::Value;
 
-use crate::parser::helpers::{ws, ws1};
+use crate::parser::helpers::{skip_balanced_parens, ws, ws1};
 use crate::parser::parse_result::{PError, PResult, opt_char, parse_char};
 use crate::parser::primary::var::is_pseudo_package;
 use crate::parser::stmt::sub::parse_sub_name;
@@ -172,11 +172,30 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
                 };
                 if parent == "rw" {
                     class_is_rw = true;
+                    let (r2, _) = ws(r2)?;
+                    r = r2;
+                    continue;
                 } else if parent == "hidden" {
                     is_hidden = true;
-                } else {
-                    parents.push(parent);
+                    let (r2, _) = ws(r2)?;
+                    r = r2;
+                    continue;
+                } else if parent.starts_with(|c: char| c.is_ascii_uppercase())
+                    || parent.starts_with("::")
+                {
+                    // Uppercase / indirect name is a superclass (possibly
+                    // parametric, e.g. `is Foo[Int]`).
+                    let (r2, bracket_suffix) = parse_optional_bracket_suffix(r2)?;
+                    parents.push(format!("{}{}", parent, bracket_suffix));
+                    let (r2, _) = ws(r2)?;
+                    r = r2;
+                    continue;
                 }
+                // A lowercase `is` name on a `unit class` is a trait
+                // (`export`, `repr('CStruct')`, `DEPRECATED`, custom trait_mod,
+                // ...), NOT a parent class. Skip it and any parenthesized
+                // argument rather than mis-recording it as a superclass.
+                let r2 = skip_balanced_parens(r2);
                 let (r2, _) = ws(r2)?;
                 r = r2;
                 continue;

--- a/t/unit-class-is-export.t
+++ b/t/unit-class-is-export.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+# `unit class Foo is export;` — `is export` (and other lowercase traits) on a
+# unit-scoped class must be parsed as a trait, NOT as a superclass named
+# `export`. Regression: mutsu mis-recorded `export` as a parent and died with
+# "cannot inherit from 'export' because it is unknown".
+#
+# EVAL of a `unit class ...;` compilation unit returns the class type object,
+# so we instantiate it after the fact to check the trait/parent handling.
+
+plan 5;
+
+# A lowercase `is export` trait on a unit class must not be treated as a parent.
+{
+    my $t = EVAL 'unit class UC0 is export; has $.x = 42;';
+    is $t.new.x, 42, 'unit class is export loads and constructs';
+}
+
+# `is repr(...)` on a unit class is a trait, not a parent.
+{
+    my $t = EVAL q{unit class UC1 is repr('P6opaque'); has $.y = 7;};
+    is $t.new.y, 7, 'unit class is repr(...) is a trait, not a parent';
+}
+
+# A genuine parent on a unit class still works (uppercase name -> superclass).
+{
+    class UCBase { method greet { "hi" } }
+    my $t = EVAL 'unit class UCChild is UCBase;';
+    is $t.new.greet, 'hi', 'unit class is Parent still inherits';
+}
+
+# A parametric parent on a unit class keeps its bracket suffix.
+{
+    my $t = EVAL 'unit class UCList is Array[Int];';
+    my $a = $t.new;
+    $a.push(1); $a.push(2);
+    is $a.elems, 2, 'unit class is Parent[Type] keeps parametric suffix';
+}
+
+# `is rw` on a unit class stays a trait, not a parent.
+{
+    my $t = EVAL 'unit class UCrw is rw; has $.z is rw = 1;';
+    my $o = $t.new;
+    $o.z = 5;
+    is $o.z, 5, 'unit class is rw stays a trait';
+}


### PR DESCRIPTION
## Problem

`unit class Foo is export;` died at load time with:

```
'Foo' cannot inherit from 'export' because it is unknown.
```

The `unit class` parser (`unit_module_stmt`) special-cased only `is rw` and
`is hidden`, then pushed every other `is <name>` onto the parent list —
including `export`, `repr(...)`, `DEPRECATED`, and custom `trait_mod:<is>`
traits. The block form (`class Foo is export { ... }`) already handled these
correctly via `class_decl_body`; the unit form did not, so `is export` was
mis-recorded as a superclass named `export`.

## Fix

Mirror the block-form `is`-clause logic in the unit path:

- an uppercase / `::`-qualified name is a **superclass** (keeping any `[Type]`
  parametric suffix, e.g. `is Array[Int]`);
- a lowercase name is a **trait**, skipped along with any parenthesized
  argument rather than treated as a parent.

## Impact

Unblocks **Astro::Sunrise** (`unit class Astro::Location is export;`) in the
real-distribution compatibility sweep — both `Astro::Location` and
`Astro::Sunrise` now load cleanly. Dashboard updated.

## Test

`t/unit-class-is-export.t` pins: `is export`, `is repr(...)`, a real
`is Parent`, a parametric `is Parent[Type]`, and `is rw` on unit classes.
Verified against `raku` (all 5 pass on both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)