### PR TITLE
fix: sequence operator (...) is looser than comma on an assignment RHS

### DIFF
--- a/src/parser/expr/precedence/assign.rs
+++ b/src/parser/expr/precedence/assign.rs
@@ -292,14 +292,32 @@ pub(crate) fn parse_assignment_rhs_mode(input: &str, mode: ExprMode) -> PResult<
         let (r2, _) = parse_char(cursor, ',')?;
         let (r2, _) = ws(r2)?;
         if r2.is_empty() || r2.starts_with(';') || r2.starts_with('}') || r2.starts_with(')') {
-            return Ok((r2, Expr::ArrayLiteral(items)));
+            return Ok((r2, finalize_assignment_rhs_list(items)));
         }
         let (r3, next) = ternary_mode(r2, mode)?;
         items.push(next);
         let (r3, _) = ws(r3)?;
         if !r3.starts_with(',') || r3.starts_with(",,") {
-            return Ok((r3, Expr::ArrayLiteral(items)));
+            return Ok((r3, finalize_assignment_rhs_list(items)));
         }
         cursor = r3;
     }
+}
+
+/// Build the RHS expression from a comma-separated assignment list.
+///
+/// The sequence operators (`...`/`…`/`...^`/`…^`) and list-infix meta-ops are
+/// LOOSER than comma, so `@a[^5] = 1.5, 2.5 ... 5.5` collapses the whole comma
+/// list into ONE sequence (seed `1.5, 2.5`), exactly like the declaration form
+/// `my @a = 1.5, 2.5 ... 5.5` (which routes through `parse_comma_or_expr`) and
+/// the argument-list case (#4755). `normalize_comma_list_items` folds the
+/// preceding seeds into the trailing sequence/meta-op; when it collapses to a
+/// single such expression we return it directly, otherwise keep the list.
+fn finalize_assignment_rhs_list(items: Vec<Expr>) -> Expr {
+    let original_len = items.len();
+    let normalized = crate::parser::stmt::assign::normalize_comma_list_items(items);
+    if normalized.len() == 1 && original_len > 1 {
+        return normalized.into_iter().next().unwrap();
+    }
+    Expr::ArrayLiteral(normalized)
 }

--- a/t/assign-rhs-sequence-op.t
+++ b/t/assign-rhs-sequence-op.t
@@ -1,0 +1,80 @@
+use Test;
+
+# The sequence operators (`...`/`…`/`...^`/`…^`) and list-infix meta-ops are
+# LOOSER than comma, so on an assignment RHS the whole comma list is the
+# sequence's seed and collapses into ONE sequence — the assignment-RHS twin of
+# the argument-list precedence fix (#4755). This must hold for the Index-LHS
+# (`@a[^5] = ...`) path, not only the declaration form (`my @a = ...`).
+
+plan 10;
+
+# Index-LHS slice assignment with a trailing sequence operator.
+{
+    my @a;
+    @a[^5] = 1.5, 2.5 ... 5.5;
+    is @a.raku, [1.5, 2.5, 3.5, 4.5, 5.5].raku, 'slice-assign: seed is the whole comma list';
+}
+
+# Declaration form still works (regression guard, routes through parse_comma_or_expr).
+{
+    my @a = 1.5, 2.5 ... 5.5;
+    is @a.raku, [1.5, 2.5, 3.5, 4.5, 5.5].raku, 'my @a = : declaration form unchanged';
+}
+
+# Plain `@a = ...` (no index) unchanged.
+{
+    my @a;
+    @a = 1.5, 2.5 ... 5.5;
+    is @a.raku, [1.5, 2.5, 3.5, 4.5, 5.5].raku, '@a = : plain assignment unchanged';
+}
+
+# Integer sequence via index-LHS assignment.
+{
+    my @a;
+    @a[^6] = 1, 3 ... 11;
+    is @a.raku, [1, 3, 5, 7, 9, 11].raku, 'integer seed list 1, 3 ... 11';
+}
+
+# Exclusive endpoint on the RHS.
+{
+    my @a;
+    @a[^5] = 1, 2 ...^ 6;
+    is @a.raku, [1, 2, 3, 4, 5].raku, 'exclusive endpoint ...^';
+}
+
+# A list-infix meta-op is also looser than comma on the RHS.
+{
+    my @a;
+    @a[^2] = 1, 2 Z+ 10, 20;
+    is @a.raku, [11, 22].raku, 'Z+ meta-op absorbs the whole comma level';
+}
+
+# A plain comma list (no top-level sequence op) is untouched.
+{
+    my @a;
+    @a[^3] = 1, 2, 3;
+    is @a.raku, [1, 2, 3].raku, 'plain comma list unaffected';
+}
+
+# A single element with a trailing comma stays a 1-element list (Range kept).
+{
+    my @a;
+    @a[0] = 1..5,;
+    is @a.raku, '[(1..5,),]', 'trailing comma keeps a 1-element list';
+}
+
+# Multiple whole-array assignments in a for-loop body (index reuse).
+{
+    my @out;
+    for 0..0 {
+        @out[^3] = 10, 20 ... 30;
+    }
+    is @out.raku, [10, 20, 30].raku, 'sequence in loop-body index assignment';
+}
+
+# Hash-index LHS also collapses the seed list.
+{
+    my %h;
+    %h<x> = 1, 3 ... 7;
+    is %h<x>.join(','), '1,3,5,7', 'hash-index assignment collapses the seed list';
+}


### PR DESCRIPTION
## Summary

The sequence operators (`...`/`…`/`...^`/`…^`) and list-infix meta-ops (`Z+`, `X~`, ...) have list-infix precedence, **looser than comma**. So an assignment RHS `@a[^5] = 1.5, 2.5 ... 5.5` collapses the whole comma list into ONE sequence (seed `1.5, 2.5`), exactly like the declaration form `my @a = 1.5, 2.5 ... 5.5` and the argument-list case (#4755).

Before:
```
$ mutsu -e 'my @a; @a[^5] = 1.5, 2.5 ... 5.5; say @a'
[1.5 (2.5 3.5 4.5 5.5) (Any) (Any) (Any)]     # wrong: seed was just 2.5
```
After (matches raku):
```
[1.5 2.5 3.5 4.5 5.5]
```

## Root cause

The declaration/plain-assignment forms already handled this via `parse_comma_or_expr` → `normalize_comma_list_items`. But the **Index-LHS** assignment path (`@a[...] = RHS`, `%h<k> = RHS`) routes through the expression-level `parse_assignment_rhs_mode`, which split the comma list first and produced `[1.5, (2.5 ... 5.5)]`. The fix routes its collected items through the same `normalize_comma_list_items` merge — collapsing to the single sequence/meta-op when it absorbs the whole level, and keeping an ordinary comma list (and the trailing-comma 1-element list) otherwise.

Found via the QA doc-diff harness (subscripts.rakudoc sibling of the #4755 arg-list fix).

## Test

Pin `t/assign-rhs-sequence-op.t` (10 cases: sequences, exclusive endpoints, meta-ops, plain lists, trailing-comma, hash-index). `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)