### PR TITLE
fix: allow a statement label on a C-style `loop (init; cond; step)`

### DIFF
--- a/docs/dist-compat-sweep.md
+++ b/docs/dist-compat-sweep.md
@@ -141,7 +141,6 @@ Known root causes to date:
 | Protocol::MQTT | `Invalid typename 'DecodeBuffer' in parameter declaration.` — a sibling type in the enclosing package (same family as #4865; `DecodeBuffer` is likely nested deeper / declared via a form the prefix-walk still misses). |
 | SQL::Abstract | `No matching candidate found for the parametric role` — advanced past four typename blockers by #4865; now blocked on parametric-role resolution in its `does Constant['…']` / `does Op::Prefix['…']` chains. |
 | JavaScript::Google::Charts | `Cannot declare individual multi candidates in 'our' scope`. |
-| IDNA::Punycode | `Unexpected block in infix position (missing statement control word before the expression?)`. |
 | PDF::Font::Loader::CSS | `X::Syntax::Perl5Var: Unsupported use of $? variable` — a genuine `$?`-in-regex Perl5-ism (verify against raku before "fixing"). |
 | uniname-words | `Odd number of elements found where hash initializer expected` (load-time). |
 | Astro::Sunrise | `'Astro::Location' cannot inherit from 'export' because it is unknown` — an `is export` on a class mis-read as a parent. |
@@ -152,6 +151,11 @@ Known root causes to date:
 | RakudoContainerfileBuilder | prints a `Usage:` block at load — a MAIN/`is export` interaction. |
 | App::fix.raku / Lingua::NumericWordForms | `self-module not found` — packaging/name-mismatch (provided module name ≠ what `use` resolves). |
 | Testo | non-zero exit with no diagnostic captured — needs a direct run to classify. |
+
+**Cleared post-snapshot:** IDNA::Punycode (was `Unexpected block in infix
+position` — a statement label on a C-style `loop (init; cond; step)` that the
+labeled-loop parser did not handle) now loads; its `decode_punycode` still hits
+a separate list-assignment runtime bug, a Level-2 concern.
 
 ## missing_dep — reachable once deps are present (not mutsu bugs)
 

--- a/src/parser/stmt/control/labeled_loop.rs
+++ b/src/parser/stmt/control/labeled_loop.rs
@@ -85,20 +85,33 @@ pub(crate) fn labeled_loop_stmt(input: &str) -> PResult<'_, Stmt> {
             },
         ));
     }
-    if let Some(r) = keyword("loop", rest) {
-        let (r, _) = ws(r)?;
-        let (r, body) = block(r)?;
-        return Ok((
-            r,
-            Stmt::Loop {
-                init: None,
-                cond: None,
-                step: None,
-                body,
-                repeat: false,
-                label: Some(label),
-            },
-        ));
+    if keyword("loop", rest).is_some() {
+        // Delegate to `loop_stmt` so both the C-style `loop (init; cond; step)
+        // { ... }` header and the infinite `loop { ... }` form are handled, then
+        // stamp the label onto the returned loop node.
+        let (r, stmt) = loop_stmt(rest)?;
+        if let Stmt::Loop {
+            init,
+            cond,
+            step,
+            body,
+            repeat,
+            ..
+        } = stmt
+        {
+            return Ok((
+                r,
+                Stmt::Loop {
+                    init,
+                    cond,
+                    step,
+                    body,
+                    repeat,
+                    label: Some(label),
+                },
+            ));
+        }
+        return Ok((r, stmt));
     }
 
     // Label before `do` block: `A: do { ... }`

--- a/t/labeled-c-style-loop.t
+++ b/t/labeled-c-style-loop.t
@@ -1,0 +1,76 @@
+use v6;
+use Test;
+
+# A statement label on a C-style `loop (init; cond; step) { ... }` must parse.
+# Regression: mutsu's labeled-loop parser only handled the infinite `loop { }`
+# form after a label, so `LABEL: loop (my $i = 0; $i < 3; $i++) { ... }` died
+# with "Confused. expected statement". Labels on `for`/`while`/infinite-`loop`
+# already worked; the C-style header was the gap. (Hit by IDNA::Punycode.)
+
+plan 6;
+
+# Basic labeled C-style loop runs to completion.
+{
+    my @seen;
+    LOOP1:
+    loop (my $i = 0; $i < 3; $i++) {
+        @seen.push($i);
+    }
+    is @seen.join(','), '0,1,2', 'labeled C-style loop iterates';
+}
+
+# `last LABEL` from a labeled C-style loop exits it.
+{
+    my @seen;
+    LOOP2:
+    loop (my $i = 0; $i < 10; $i++) {
+        last LOOP2 if $i == 2;
+        @seen.push($i);
+    }
+    is @seen.join(','), '0,1', 'last LABEL exits a labeled C-style loop';
+}
+
+# `next LABEL` continues the labeled C-style loop.
+{
+    my @seen;
+    LOOP3:
+    loop (my $i = 0; $i < 4; $i++) {
+        next LOOP3 if $i == 1;
+        @seen.push($i);
+    }
+    is @seen.join(','), '0,2,3', 'next LABEL continues a labeled C-style loop';
+}
+
+# `last OUTERLOOP` from an inner labeled C-style loop breaks the outer loop.
+{
+    my @seen;
+    OUTERLOOP:
+    for 1..3 -> $x {
+        INNERLOOP:
+        loop (my $k = 0; $k < 3; $k++) {
+            last OUTERLOOP if $x == 2 && $k == 1;
+            @seen.push("$x-$k");
+        }
+    }
+    is @seen.join(','), '1-0,1-1,1-2,2-0', 'last OUTERLOOP from inner C-style loop';
+}
+
+# Label on the same line as the C-style loop also parses.
+{
+    my @seen;
+    SAME: loop (my $i = 0; $i < 2; $i++) { @seen.push($i); }
+    is @seen.join(','), '0,1', 'same-line label on C-style loop';
+}
+
+# The infinite `loop { }` label form still works (no regression).
+{
+    my @seen;
+    my $i = 0;
+    INF:
+    loop {
+        last INF if $i == 3;
+        @seen.push($i);
+        $i++;
+    }
+    is @seen.join(','), '0,1,2', 'labeled infinite loop still works';
+}


### PR DESCRIPTION
## Problem

A statement label on a C-style `loop` died at parse time:

```raku
LOOP: loop (my $i = 0; $i < 3; $i++) { ... }
# ===SORRY!=== Confused. expected statement
```

The labeled-loop parser handled labels on `for`, `while`, `until`, and the
infinite `loop { }` form, but its `loop` branch consumed the `loop` keyword and
then expected a `{` block directly — so the C-style `(init; cond; step)` header
was never parsed.

## Fix

Delegate the labeled `loop` branch to `loop_stmt`, which already parses both the
C-style and infinite forms, then stamp the label onto the returned `Stmt::Loop`.
This reuses the existing header logic rather than duplicating it.

## Impact

Unblocks **IDNA::Punycode** (`LOOP:\nloop (my $k = BASE; 1; $k += BASE) { ... }`)
in the real-distribution compatibility sweep — the module now loads. (Its
`decode_punycode` still hits a separate list-assignment runtime bug, a Level-2
concern noted on the dashboard.)

## Test

`t/labeled-c-style-loop.t` pins: iteration, `last LABEL`, `next LABEL`, a
cross-level `last OUTERLOOP` from an inner labeled C-style loop, a same-line
label, and the infinite-loop label form (no regression). All 6 verified on both
`raku` and mutsu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)