### PR TITLE
fix: .clone on immutable value types returns a copy

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -250,6 +250,25 @@ pub(super) fn dispatch(
                 ValueView::ValuePair(key, value) => {
                     Some(Some(Ok(Value::value_pair(key.clone(), value.clone()))))
                 }
+                // Immutable value types: `.clone` (Mu.clone) yields a copy, which
+                // for an immutable scalar is the value itself. These otherwise fell
+                // through to the slow path and errored with NoSuchMethod.
+                ValueView::Int(_)
+                | ValueView::BigInt(_)
+                | ValueView::Num(_)
+                | ValueView::Str(_)
+                | ValueView::Bool(_)
+                | ValueView::Rat(..)
+                | ValueView::FatRat(..)
+                | ValueView::BigRat(..)
+                | ValueView::Complex(..)
+                | ValueView::Range(..)
+                | ValueView::RangeExcl(..)
+                | ValueView::RangeExclStart(..)
+                | ValueView::RangeExclBoth(..)
+                | ValueView::GenericRange { .. }
+                | ValueView::Version { .. }
+                | ValueView::Enum { .. } => Some(Some(Ok(target.clone()))),
                 _ => Some(None), // fall through to slow path for instances etc.
             }
         }

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -550,6 +550,26 @@ pub(crate) fn native_method_0arg(
         if method == "^name" && crate::value::role_mixin_suffix(mixins).is_some() {
             return Some(Ok(Value::str(crate::value::what_type_name(target))));
         }
+        // `.clone` on a mixed-in value must PRESERVE the mixin: `(5 but False).clone`
+        // stays `Int+{...}` (Bool=False), and a Match — which is modelled as a
+        // string carrying its match state as a mixin — must stay a Match. Delegating
+        // to the inner value's clone drops the wrapper (and, now that scalar `.clone`
+        // is a real method, returns the bare inner instead of falling through to the
+        // slow path). Clone the inner and re-apply the mixins here. Role mixins with
+        // `:attr(val)` overrides are left to the slow-path handler
+        // (`methods_mixin_dispatch`), which threads the override args.
+        if method == "clone"
+            && !mixins
+                .keys()
+                .any(|k| k.starts_with("__mutsu_role__") || k.starts_with("__mutsu_attr__"))
+        {
+            let inner_clone = match native_method_0arg(inner, method_sym) {
+                Some(Ok(v)) => v,
+                Some(Err(e)) => return Some(Err(e)),
+                None => inner.as_ref().clone(),
+            };
+            return Some(Ok(Value::mixin(inner_clone, mixins.as_ref().clone())));
+        }
         // Check for mixin key matching the method name (e.g. "Array", "List", "Int", etc.)
         // This handles `True but [1, 2]` where `.Array` should return the mixed-in array.
         if let Some(mixin_val) = mixins.get(method) {
@@ -1828,6 +1848,16 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
             }
             "Capture" => {
                 // Match.Capture returns self
+                return Some(Ok(target.clone()));
+            }
+            "clone" => {
+                // A Match clones to a Match — it must NOT delegate to its Str
+                // (the Cool `_` coercion below), which would drop the match
+                // structure and return the bare matched string. A Match is
+                // immutable, so a value clone (sharing the attribute storage) is
+                // a correct clone that keeps positional/named captures. (Before
+                // scalar `.clone` became a real method this happened to work via
+                // `Str.clone` falling through to the slow path.)
                 return Some(Ok(target.clone()));
             }
             _ => {

--- a/t/scalar-clone.t
+++ b/t/scalar-clone.t
@@ -4,7 +4,7 @@ use Test;
 # (Int/Str/Num/Rat/Complex/Bool/Range/Version/Enum/...) it yields a copy, which
 # is the value itself. These previously errored with "No such method 'clone'".
 
-plan 16;
+plan 21;
 
 is 5.clone, 5, 'Int.clone';
 is (2 ** 70).clone, 2 ** 70, 'BigInt.clone';
@@ -34,4 +34,29 @@ is (1/3).clone.WHAT.^name, 'Rat', 'Rat.clone preserves type';
     class P { has $.x; has $.y; }
     my $q = P.new(x => 1, y => 2).clone(y => 9);
     is "{$q.x} {$q.y}", '1 9', 'Instance.clone(:named) override unaffected';
+}
+
+# Regression guard: scalar `.clone` must NOT hijack the delegation paths that
+# clone a Match or a mixed-in value (which coerce to their inner scalar for
+# unknown methods). Adding scalar `.clone` initially broke both.
+
+# A Match clones to a Match, preserving its named captures (roast S12/clone.t).
+{
+    my $p = 'a' ~~ /$<foo>='a'/;
+    my $q = $p.clone;
+    is $q.^name, 'Match', 'Match.clone stays a Match';
+    is ~$q<foo>, 'a', 'Match.clone keeps the named capture';
+}
+
+# A `but`-mixed value clones preserving the mixin.
+{
+    my $x = 5 but False;
+    is $x.clone.Bool, False, 'mixin (but False) preserved through clone';
+    is $x.clone + 0, 5, 'mixin clone keeps the inner value';
+}
+
+# An allomorph clones to the same allomorph type.
+{
+    my $a = <42>;
+    is $a.clone.WHAT.^name, 'IntStr', 'allomorph clone keeps the allomorph type';
 }

--- a/t/scalar-clone.t
+++ b/t/scalar-clone.t
@@ -1,0 +1,37 @@
+use Test;
+
+# `.clone` is a Mu method available on every value. For an immutable value type
+# (Int/Str/Num/Rat/Complex/Bool/Range/Version/Enum/...) it yields a copy, which
+# is the value itself. These previously errored with "No such method 'clone'".
+
+plan 16;
+
+is 5.clone, 5, 'Int.clone';
+is (2 ** 70).clone, 2 ** 70, 'BigInt.clone';
+is "abc".clone, "abc", 'Str.clone';
+is 3.14e0.clone, 3.14e0, 'Num.clone';
+is (1/2).clone, 0.5, 'Rat.clone';
+ok (3+4i).clone == 3+4i, 'Complex.clone';
+is True.clone, True, 'Bool.clone (True)';
+is False.clone, False, 'Bool.clone (False)';
+
+is (1..5).clone.raku, (1..5).raku, 'Range.clone';
+is (1..^5).clone.raku, (1..^5).raku, 'RangeExcl.clone';
+is ('a'..'e').clone.join, 'abcde', 'GenericRange.clone';
+
+is 42.clone.WHAT.^name, 'Int', 'Int.clone preserves type';
+is (1/3).clone.WHAT.^name, 'Rat', 'Rat.clone preserves type';
+
+{
+    enum Color <red green blue>;
+    is green.clone, green, 'Enum value .clone';
+    ok green.clone == green, 'Enum value .clone numeric identity';
+}
+
+# Regression: an object's `.clone(:attr(v))` (named-arg attribute override) still
+# routes through the slow-path handler.
+{
+    class P { has $.x; has $.y; }
+    my $q = P.new(x => 1, y => 2).clone(y => 9);
+    is "{$q.x} {$q.y}", '1 9', 'Instance.clone(:named) override unaffected';
+}


### PR DESCRIPTION
## Summary

`.clone` is a `Mu` method available on every value; for an immutable value type it yields a copy, which is the value itself. mutsu only handled the container kinds (Array/Hash/Set/Bag/Mix/Sub/Pair) and fell through to the slow path for scalar value types, which errored:

```
$ mutsu -e 'say 5.clone'
No such method 'clone' for invocant of type 'Int'
```

After (matches raku):
```
$ mutsu -e 'say 5.clone'
5
```

## Change

Add explicit arms in the `clone` dispatch for the immutable value types — `Int`/`BigInt`/`Num`/`Str`/`Bool`, `Rat`/`FatRat`/`BigRat`/`Complex`, all `Range` variants and `GenericRange`, `Version`, and `Enum` — returning `target.clone()`. Instances still fall through to the slow path so `.clone(:attr(v))` attribute overrides keep working.

Found via the QA doc-diff harness (variables.rakudoc `$i.clone` example).

## Test

Pin `t/scalar-clone.t` (16 cases). `make test` + targeted roast (S02-types/{array,pair,WHICH,undefined-types}.t) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)