### PR TITLE
fix: allow a `where` constraint on a sigilless parameter

### DIFF
--- a/docs/dist-compat-sweep.md
+++ b/docs/dist-compat-sweep.md
@@ -122,7 +122,7 @@ message). Work them one at a time.
 
 App::Rak · Astro::Utils · Audio::Liquidsoap · Bench · Configuration ·
 Cro::FCGI · CSS · CSV::Table · Deps · File-TreeBuilder · IP::Random ·
-Math::Matrix · ML::SparseMatrixRecommender · Pod::Contents · Prime::Factor ·
+Math::Matrix · ML::SparseMatrixRecommender · Pod::Contents ·
 SBOM::CycloneDX · SSH::LibSSH::Tunnel · Trie
 
 Known root causes to date:
@@ -132,7 +132,8 @@ Known root causes to date:
 | SSH::LibSSH::Tunnel | `Cannot have a 'whenever' block outside the scope of a 'supply' or 'react' block` — a `whenever` reached at load time (likely a react/supply parse gap). |
 | SBOM::CycloneDX | `unparsed input, column 5: "}\n… @*ERRORS"` — a `@*ERRORS` dynamic var / trailing brace parse dead-end. |
 | CSS | inside a `grammar` ("angle index key") — grammar/regex-slang, heavier. |
-| Prime::Factor / Pod::Contents / Deps / Trie / Configuration / File-TreeBuilder / Bench / App::Rak / Astro::Utils / Audio::Liquidsoap / IP::Random / Math::Matrix / ML::SparseMatrixRecommender / CSV::Table / Cro::FCGI | generic `expected statement…` dead-end — each needs its own repro; several carry multiple blockers (bisect at balanced method boundaries). |
+| Pod::Contents / Deps / Trie / Configuration / File-TreeBuilder / Bench / App::Rak / Astro::Utils / Audio::Liquidsoap / IP::Random / Math::Matrix / ML::SparseMatrixRecommender / CSV::Table / Cro::FCGI | generic `expected statement…` dead-end — each needs its own repro; several carry multiple blockers (bisect at balanced method boundaries). |
+| ~~Prime::Factor~~ | **Cleared post-snapshot**: was a sigilless parameter (`\N`) carrying a `where` constraint (`multi divisors (Int \N where BIG, …)`) that the param parser rejected. Now loads and factors correctly. |
 
 ### runtime_error (14 remaining; Astro::Sunrise cleared post-snapshot)
 

--- a/src/parser/stmt/sub_param/param_inner.rs
+++ b/src/parser/stmt/sub_param/param_inner.rs
@@ -648,6 +648,16 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
             let (rt, _) = ws(rt)?;
             r = rt;
         }
+        // A `where` constraint may follow a sigilless parameter, before the
+        // default value: `\N where * > 0`, `\N where BIG`.
+        let (r, sigilless_where) = if let Some(r2) = super::super::keyword("where", r) {
+            let (r2, _) = ws1(r2)?;
+            let (r2, constraint) = super::where_constraint::parse_where_constraint_expr(r2)?;
+            let (r2, _) = ws(r2)?;
+            (r2, Some(Box::new(constraint)))
+        } else {
+            (r, None)
+        };
         // Default value
         let (r, default) = if r.starts_with('=') && !r.starts_with("==") {
             let r = &r[1..];
@@ -666,6 +676,7 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
         p.default = default;
         p.type_constraint = type_constraint;
         p.traits = sigilless_traits;
+        p.where_constraint = sigilless_where;
         return Ok((r, p));
     }
 

--- a/t/sigilless-param-where.t
+++ b/t/sigilless-param-where.t
@@ -1,0 +1,53 @@
+use v6;
+use Test;
+
+# A sigilless parameter (`\N`) may carry a `where` constraint, before any
+# default value: `\N where * > 0`, `Int \N where BIG`. Regression: mutsu's
+# sigilless-param parser handled `is` traits and defaults but not a `where`
+# clause, so `sub f(\N where * > 0) {...}` died with "expected ')'".
+# (Hit by Prime::Factor's `multi divisors (Int \N where BIG, ...)`.)
+
+plan 7;
+
+# Basic sigilless where constraint.
+{
+    sub f(\N where * > 0) { N }
+    is f(5), 5, 'sigilless param with where * > 0 binds a matching arg';
+}
+
+# Typed sigilless where constraint against a constant.
+{
+    constant BIG = 3 .. *;
+    sub g(Int \N where BIG) { N }
+    is g(10), 10, 'typed sigilless param with where against a constant';
+}
+
+# where + default value together (`\N where C = D`).
+{
+    sub h(\N where * >= 0 = 42) { N }
+    is h(), 42, 'sigilless where + default uses the default';
+    is h(7), 7, 'sigilless where + default binds an explicit arg';
+}
+
+# The constraint is actually enforced via multi-dispatch.
+{
+    my @log;
+    multi m(\N where * > 0) { @log.push('pos') }
+    multi m(\N)            { @log.push('other') }
+    m(5);
+    m(-1);
+    is @log.join(','), 'pos,other', 'where constraint gates multi-dispatch';
+}
+
+# A where block ({ ... }) form on a sigilless param.
+{
+    sub b(\N where { $_ %% 2 }) { N }
+    is b(8), 8, 'sigilless param with a where { } block';
+}
+
+# Prime::Factor's exact shape: `multi divisors (Int \N where BIG, :s(:$sort))`.
+{
+    constant BIG = 100 .. *;
+    multi divisors(Int \N where BIG, :s(:$sort) = False) { $sort ?? 'sorted' ~ N !! 'big' ~ N }
+    is divisors(250), 'big250', 'sigilless where + named alias param parses & runs';
+}


### PR DESCRIPTION
## Problem

A sigilless parameter with a `where` constraint died at parse time:

```raku
sub f(\N where * > 0) { ... }
# ===SORRY!=== Confused. expected ')'
```

The sigilless-param parser (`\name`) handled `is` traits and a default value,
but had no branch for a `where` clause — so any constraint after `\N` was left
unconsumed, tripping the closing-paren check.

## Fix

Parse an optional `where` constraint between the `is` traits and the default
value — the Raku signature order `\N where C = D` — mirroring the sigil'd-param
branches. The constraint is stored on the param and enforced by dispatch.

## Impact

Unblocks **Prime::Factor** (`multi divisors (Int \N where BIG, :s(:$sort) = False)`)
in the real-distribution compatibility sweep — the module now loads and
`prime-factors(60)` returns `(2 2 3 5)`.

## Test

`t/sigilless-param-where.t` pins: `\N where * > 0`, typed `Int \N where BIG`,
`where` + default together, constraint-gated multi-dispatch, a `where { }` block
form, and Prime::Factor's exact `where` + named-alias shape. All 7 verified on
both `raku` and mutsu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)