### PR TITLE
fix: $?LINE / $?TABSTOP substitute inside string interpolation

### DIFF
--- a/src/parser/primary/string/interp_var.rs
+++ b/src/parser/primary/string/interp_var.rs
@@ -330,6 +330,19 @@ pub(crate) fn try_interpolate_var<'a>(
             }
             let var_rest = &rest[1..];
             let (var_rest, var_name) = parse_var_name_from_str(var_rest);
+            // `$?LINE`/`$?TABSTOP` are compile-time constants substituted at their
+            // source position, exactly as the non-interpolated scalar-var parser
+            // does. Without this the interpolation produced a runtime `Var("?LINE")`
+            // that resolves to the empty string (`"line $?LINE"` -> `"line "`).
+            if var_name == "?LINE" {
+                let line = crate::parser::primary::current_line_number(rest);
+                parts.push(Expr::Literal(Value::int(line)));
+                return Some(var_rest);
+            }
+            if var_name == "?TABSTOP" {
+                parts.push(Expr::Literal(Value::int(8)));
+                return Some(var_rest);
+            }
             let (expr, var_rest) = parse_postcircumfix_index(var_rest, Expr::Var(var_name));
             // Handle postcircumfix call interpolation: "$var()" / "$var(args)"
             let (expr, var_rest) = try_parse_interp_call(var_rest, expr);

--- a/t/line-var-interpolation.t
+++ b/t/line-var-interpolation.t
@@ -1,0 +1,23 @@
+use Test;
+
+# `$?LINE` and `$?TABSTOP` are compile-time constants that must be substituted
+# at their source position even inside string interpolation. Previously the
+# interpolated form produced a runtime `Var("?LINE")` that resolved to the empty
+# string (`"line $?LINE"` -> `"line "`).
+
+plan 6;
+
+# Interpolated `$?LINE` equals the bare `$?LINE` on the same physical line.
+is "$?LINE".Int, $?LINE, 'bare $?LINE interpolation gives the source line';
+is "L=$?LINE", "L={$?LINE}", '$?LINE interpolation with surrounding text';
+
+# Two references on consecutive lines differ by exactly one.
+my $a = "$?LINE".Int;
+my $b = "$?LINE".Int;
+is $b - $a, 1, 'consecutive-line references differ by one';
+ok $a > 0, 'interpolated $?LINE is a positive line number';
+
+# A previously-empty result is now non-empty.
+isnt "$?LINE", '', '$?LINE interpolation is no longer the empty string';
+
+is "tab=$?TABSTOP", "tab=8", '$?TABSTOP interpolates to 8';


### PR DESCRIPTION
## Summary

`$?LINE` and `$?TABSTOP` are compile-time constants the non-interpolated scalar-var parser already substitutes at their source position. The **string interpolation** path did not — it produced a runtime `Var("?LINE")` that resolves to the empty string:

```
$ mutsu -e 'say "line $?LINE"'
line          # wrong: line number dropped
```

After (matches raku):
```
$ mutsu -e 'say "line $?LINE"'
line 1
```

## Change

Handle the two compile-time constants in `try_interpolate_var`:
- `$?LINE` → `current_line_number(rest)` (the interpolation slice points into the original source buffer, so the existing line-number machinery applies).
- `$?TABSTOP` → the constant `8`.

Mirrors the non-interpolated scalar-var parser (`primary/var/scalar.rs`).

Found via the QA doc-diff harness (variables.rakudoc `"$?FILE: $?LINE"`).

## Test

Pin `t/line-var-interpolation.t`. Existing `t/interp-*.t` green.

Note: heredoc `$?LINE` uses the leaked-region line base and is still off by the region offset (a pre-existing separate limitation), but now yields a number instead of empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)