### PR TITLE
fix: (B)-gate block-exit slot-authoritative — stop stale env re-seed clobbering a live outer slot

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -666,16 +666,45 @@ during the call — the same `env_changed` guard as
 `lvalue-subroutines-rw-proxy.t` need this PLUS the closure fold. Pin:
 `t/gate-b-method-lvalue-writeback.t`.
 
-**Still open (the deeper mechanism #3, dedicated session):** the general
-call-return reconcile clobbers a caller local from stale env for constructor and
-self-writeback calls too — `my $ct = CT.new(...); $ct.x` leaves `$ct` = `Any` under
-the gate (a `submethod TWEAK` attr write path), and `method-call-self-writeback.t`,
-`bind-self-attr-write.t`, `virtual-call-attr.t`, `native-tweak-construct.t`,
+### block-exit env re-seed — slot-authoritative under the gate (2026-07-20)
+
+The suspected "mechanism #3 core" for the constructor/self-writeback cluster
+(`my $ct = CT.new(...)` leaving `$ct` = `Any` under the gate) turned out to be a
+**block-exit env re-seed**, not the `drain_and_reconcile` / `apply_pending_rw_writeback`
+env-by-name pull. Instrumentation (a per-opcode `locals[0]` transition watch)
+pinned the clobber to the `DoBlockExpr { scope_isolate: true }` opcode that a
+string-interpolation `{ ... }` compiles to: `exec_do_block_expr_op`
+(`vm_misc_block.rs`) ended a scope-isolating block by `self.locals = saved_locals`
+followed by re-seeding EVERY slot from the restored `env` by name. Under the gate
+a `my $ct = CT.new(...)` skips its env mirror, so `env["ct"]` keeps the `my` decl
+seed (`Any`); the unconditional re-seed clobbered the live instance slot. In a
+single interpolation with two method calls (`"{$ct.x},{$ct.y}"`) the FIRST block's
+exit clobbered `$ct`, so the SECOND `$ct.y` died `No such method 'y' … Any`.
+(`say`/`is` with an intervening flush masked it — that is why the standalone
+one-liner passed and only the in-file two-call interpolation failed.)
+
+Fix (gated on `gate_local_env_write()`, gate OFF byte-identical): make the block
+exit **slot-authoritative** — a propagating outer var keeps its live in-block slot
+value (the block body read/mutated the slot directly), and only the block's OWN
+isolated declarations (`isolate_set`) plus internal/special/dynamic slots revert
+to their pre-block value from `saved_locals`. The same shape was applied to
+`exec_block_scope_op` (`vm_misc_scope.rs`) for the bare-`{ }` `BlockScope` opcode.
+**ON survey: 19 → 13** (`bind-self-attr-write.t`, `hyper-array-mutators.t`,
+`io-cathandle-malformed-utf8.t`, `is-lazy-io-lines.t`,
+`lines-words-allomorph-limit.t`, `native-tweak-construct.t` all flip green ON).
+Pin: `t/gate-b-doblock-exit-slot-authoritative.t`.
+
+**Still open (the deeper mechanism #3, dedicated session):** a residue of the
+constructor/self-writeback cluster survives via the call-return reconcile itself
+(not the block exit) — `method-call-self-writeback.t`, `virtual-call-attr.t`,
 `quanthash-immutable-ro.t`, `native-map-hash-coerce.t`,
 `sethash-baghash-mixhash-coerce-fn.t`, `nested-assoc-user-assign-key.t` still fail
-ON via that path. This is the load-bearing `drain_and_reconcile` /
-`apply_pending_rw_writeback` env-by-name pull — the mechanism-#3 core the memory
-flags as flaky-prone and dedicated-session scale.
+ON. This is the load-bearing `drain_and_reconcile` / `apply_pending_rw_writeback`
+env-by-name pull — the mechanism-#3 core the memory flags as flaky-prone and
+dedicated-session scale. Plus rw-redispatch (`nextsame`/`proto-method`),
+cross-thread/atomic (`atomic-ops*`, gc-stress), and a few io/misc
+(`encode-utf8-is-blob.t`, `resumable-control-signal-indirect-call.t`,
+`test-assertion-line-number.t`).
 
 ## §1.4 flip blast-radius measurement (2026-07-02, debug + release `prove t/`)
 

--- a/src/vm/vm_misc_block.rs
+++ b/src/vm/vm_misc_block.rs
@@ -204,21 +204,43 @@ impl Interpreter {
             for (name, value) in new_vars {
                 self.env_mut().insert_sym(name, value);
             }
-            self.locals = saved_locals;
-            // Re-read every local from env: after the block's env snapshot is
-            // restored above, env is the authoritative half of the dual store for
-            // this frame's names.
-            //
-            // This used to be guarded by "skip the locals whose slot is
-            // authoritative" — a condition on the old `simple_locals` flag that
-            // the compiler set for `$`-prefixed names only, and scalars are stored
-            // sigil-less (`my $x` -> `"x"`), so it was false for every slot and the
-            // skip never happened. The guard is gone rather than revived: this
-            // unconditional pull is the behavior every test has ever exercised, and
-            // it is why the env mirror (`flush_local_to_env`) is load-bearing here.
-            for (idx, name) in code.locals.iter().enumerate() {
-                if let Some(val) = self.env().get(name).cloned() {
-                    self.locals[idx] = val;
+            if crate::opcode::gate_local_env_write() {
+                // (B)-gate: the per-store env mirror is suppressed, so re-seeding
+                // every slot from the restored env (below) would clobber a
+                // propagating outer var's LIVE in-block value with its stale
+                // decl-time seed — e.g. `my $ct = CT.new(...)` whose slot never
+                // mirrored into env, so a second `$ct.x` inside one interpolation
+                // read `Any`. The live in-block `self.locals` already holds the
+                // correct value for a propagating outer name (the block body read
+                // /mutated the slot directly). Revert ONLY the block's OWN isolated
+                // declarations (reverted to their pre-block value so they don't
+                // leak) and internal/special/dynamic slots; leave every other slot
+                // at its live value. This mirrors the env-side keep/revert decision
+                // above without depending on the env mirror.
+                for (idx, name) in code.locals.iter().enumerate() {
+                    let revert =
+                        isolate_set.contains(&strip_sigil(name)) || !is_plain_user_var(name);
+                    if revert && let Some(val) = saved_locals.get(idx) {
+                        self.locals[idx] = val.clone();
+                    }
+                }
+            } else {
+                self.locals = saved_locals;
+                // Re-read every local from env: after the block's env snapshot is
+                // restored above, env is the authoritative half of the dual store for
+                // this frame's names.
+                //
+                // This used to be guarded by "skip the locals whose slot is
+                // authoritative" — a condition on the old `simple_locals` flag that
+                // the compiler set for `$`-prefixed names only, and scalars are stored
+                // sigil-less (`my $x` -> `"x"`), so it was false for every slot and the
+                // skip never happened. The guard is gone rather than revived: this
+                // unconditional pull is the behavior every test has ever exercised, and
+                // it is why the env mirror (`flush_local_to_env`) is load-bearing here.
+                for (idx, name) in code.locals.iter().enumerate() {
+                    if let Some(val) = self.env().get(name).cloned() {
+                        self.locals[idx] = val;
+                    }
                 }
             }
             self.stack.push(block_result);

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -418,13 +418,39 @@ impl Interpreter {
         // The `MUTSU_NO_SHADOW_SLOTS` opt-out has no distinct shadow slots, so it
         // still needs the whole-array restore.
         if let Some(saved) = saved_locals {
-            // MUTSU_NO_SHADOW_SLOTS opt-out: no distinct shadow slots, so the
-            // whole-array restore is needed, and the propagated inner values are
-            // then re-applied from `restored_env` by name.
-            self.locals = saved;
-            for (idx, name) in code.locals.iter().enumerate() {
-                if let Some(val) = restored_env.get(name).cloned() {
-                    self.locals[idx] = val;
+            if crate::opcode::gate_local_env_write() {
+                // (B)-gate: the per-store env mirror is suppressed, so
+                // `restored_env` (name-keyed, env-derived) holds a STALE value for
+                // any enclosing name assigned inside the block — re-seeding a
+                // propagating slot from it would clobber the live in-block value
+                // with the decl-time seed (the `my $ct = CT.new(...)` -> `Any`
+                // clobber that broke a second `$ct.x` inside one interpolation).
+                // Without distinct shadow slots the pre-block LIVE value for every
+                // slot is available in the `saved` locals snapshot, so this is
+                // slot-authoritative without depending on env: leave a PROPAGATING
+                // enclosing slot at its live in-block value (every store wrote the
+                // slot) and revert only NON-propagating slots to their pre-block
+                // value — a shadowing decl shares the outer slot, so `saved[idx]`
+                // IS the outer value; a fresh `my` slot's pre-block value is Nil.
+                for (idx, name) in code.locals.iter().enumerate() {
+                    let non_propagating = name == "_"
+                        || name.starts_with('*')
+                        || code
+                            .local_sym(idx)
+                            .is_some_and(|s| block_declared.contains(&s));
+                    if non_propagating {
+                        self.locals[idx] = saved.get(idx).cloned().unwrap_or(Value::NIL);
+                    }
+                }
+            } else {
+                // MUTSU_NO_SHADOW_SLOTS opt-out: no distinct shadow slots, so the
+                // whole-array restore is needed, and the propagated inner values are
+                // then re-applied from `restored_env` by name.
+                self.locals = saved;
+                for (idx, name) in code.locals.iter().enumerate() {
+                    if let Some(val) = restored_env.get(name).cloned() {
+                        self.locals[idx] = val;
+                    }
                 }
             }
         } else {

--- a/t/gate-b-doblock-exit-slot-authoritative.t
+++ b/t/gate-b-doblock-exit-slot-authoritative.t
@@ -1,0 +1,61 @@
+use Test;
+
+# Pin for the (B) per-store env-write gate block-exit clobber fix
+# (docs/lexical-scope-slot-campaign.md, "(B) per-store env-write gate — burndown").
+#
+# A scope-isolating do-block / string-interpolation block (`"{ $obj.a }"`) exits
+# through `exec_do_block_expr_op` (and a bare `{ ... }` through
+# `exec_block_scope_op`). Both used to end the block by restoring the whole
+# `locals` snapshot and then re-seeding EVERY slot from the restored `env` by
+# name. Under the MUTSU_GATE_LOCAL_ENV_WRITE gate a `my $obj = Class.new(...)`
+# skips its env mirror, so `env["obj"]` keeps the `my` decl seed (Any); the
+# unconditional re-seed then clobbered the live instance slot with Any. In a
+# single interpolation with two method calls (`"{ $obj.a },{ $obj.b }"`) the
+# FIRST block's exit clobbered `$obj`, so the SECOND `$obj.b` died
+# "No such method 'b' for invocant of type 'Any'".
+#
+# The fix makes the block exit slot-authoritative under the gate: a propagating
+# outer var keeps its live in-block slot value; only the block's own isolated
+# declarations and internal/special/dynamic slots revert. Gate OFF (the default)
+# is byte-identical (whole-array restore + env re-seed). This passes gate-OFF and
+# would fail gate-ON before the fix.
+
+plan 8;
+
+class Point {
+    has $.x;
+    has $.y;
+    submethod TWEAK { $!x = $!x * 2 }
+}
+
+# Two method calls on one instance inside a single interpolation — the exact
+# shape that regressed. Each `{ ... }` is a scope-isolating do-block; the first
+# one's exit must not clobber `$p`.
+my $p = Point.new(x => 3, y => 5);
+is "{$p.x},{$p.y}", "6,5", 'two method calls in one interpolation see a live instance';
+is "{$p.y}/{$p.x}/{$p.y}", "5/6/5", 'three method calls in one interpolation';
+
+# A base-first parent/child TWEAK constructor, then a two-call interpolation.
+class Parent { has $.a; submethod TWEAK { $!a *= 10 } }
+class Child is Parent { has $.b; submethod TWEAK(:$b) { $!b = $b + 1 } }
+my $c = Child.new(a => 4, b => 7);
+is "{$c.a}:{$c.b}", "40:8", 'parent/child TWEAK instance survives a two-call interpolation';
+
+# An outer-var mutation inside a bare block must still persist (not reverted).
+my $acc = 1;
+{ $acc = $acc + 100 }
+is $acc, 101, 'outer var mutated inside a bare block persists';
+
+# A block-local declaration must not leak past the block.
+my $outer = 'keep';
+{ my $outer = 'inner'; is $outer, 'inner', 'inner shadow visible inside block' }
+is $outer, 'keep', 'block-local declaration does not leak out';
+
+# Interpolation that both reads an instance and a plain scalar.
+my $n = 41;
+is "{$p.x}+{$n}", "6+41", 'interpolation mixes instance method call and plain scalar';
+
+# Method call inside a `do { }` block returning to a later use of the same var.
+my $q = Point.new(x => 10, y => 20);
+my $sum = do { $q.x } + do { $q.y };
+is $sum, 40, 'do-block method calls do not clobber the instance between blocks';


### PR DESCRIPTION
## Summary

Part of the `(B)` per-store env-write gate burndown (`MUTSU_GATE_LOCAL_ENV_WRITE`, docs/lexical-scope-slot-campaign.md). Default OFF is byte-identical; this drives the toggle-ON t/ survey **19 → 13**.

A scope-isolating do-block / string-interpolation block (`"{ $obj.a }"`) exits through `exec_do_block_expr_op`, and a bare `{ ... }` block through `exec_block_scope_op`. Both ended a block by restoring the whole `locals` snapshot and then **re-seeding every slot from the restored `env` by name**. Under the gate a `my $obj = Class.new(...)` skips its env mirror, so `env["obj"]` keeps the `my` decl seed (`Any`); the unconditional re-seed clobbered the live instance slot with `Any`. In a single interpolation with two method calls (`"{ $obj.a },{ $obj.b }"`) the first block's exit clobbered `$obj`, so the second `$obj.b` died `No such method 'b' for invocant of type 'Any'`. (A `say`/`is` with an intervening env flush masked it — that's why the standalone one-liner passed and only the in-file two-call interpolation failed.)

## Fix

Gated on `gate_local_env_write()` (gate OFF byte-identical): make the block exit **slot-authoritative** — a propagating outer var keeps its live in-block slot value (the block body read/mutated the slot directly); only the block's OWN isolated declarations (`isolate_set`) and internal/special/dynamic slots revert to their pre-block value from the `saved_locals` snapshot.

## Verification

- **Gate OFF (default / CI):** `make test` PASS (Files=2002, Tests=19020) — structurally byte-identical (the new branch only runs when the gate env-var is set).
- **Gate ON survey:** these 6 t/ files flip green: `bind-self-attr-write`, `hyper-array-mutators`, `io-cathandle-malformed-utf8`, `is-lazy-io-lines`, `lines-words-allomorph-limit`, `native-tweak-construct`.
- Pin: `t/gate-b-doblock-exit-slot-authoritative.t` (passes OFF, ON, and under `raku`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)