### PR TITLE
fix: anon class/role/grammar as an expression evaluates to the type object

### DIFF
--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -579,6 +579,18 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
             }
             // anon method (...) { ... } in expression context
             let (r_ws, _) = ws(rest)?;
+            // anon class/role/grammar { ... } in expression context. The
+            // anonymous-package expression parsers (also used for `my class { }`)
+            // build the type object as a value; `anon` just means it is not
+            // installed in the namespace, which the `{...}` form already is.
+            // Without this `anon class { ... }` fell through and `anon` was parsed
+            // as a BareWord, leaving `sub`/`class` as a separate declaration.
+            if let Ok((r, expr)) = anon_grammar_expr(r_ws)
+                .or_else(|_| anon_class_expr(r_ws))
+                .or_else(|_| anon_role_expr(r_ws))
+            {
+                return Ok((r, expr));
+            }
             if let Some(after_method) = keyword("method", r_ws) {
                 let (r, _) = ws(after_method)?;
                 if r.starts_with('(') {

--- a/t/anon-package-expr.t
+++ b/t/anon-package-expr.t
@@ -1,0 +1,50 @@
+use Test;
+
+# `anon class { ... }` / `anon role { ... }` / `anon grammar { ... }` as an
+# expression must evaluate to the (anonymous) type object. Previously the `anon`
+# keyword was not handled in expression context: it parsed as a BareWord and the
+# `class`/`role`/`grammar` declaration split off, so `my $c = anon class { ... }`
+# stored the string "anon".
+
+plan 8;
+
+# anon class stored in a scalar, then instantiated.
+{
+    my $c = anon class { has $.bar; };
+    is $c.new(:3bar).bar, 3, 'anon class instance attribute';
+}
+
+# A method that references the class type via ::?CLASS works on an anon class.
+{
+    my $c = anon class {
+        has $.bar;
+        method equal(::?CLASS $foo) { $foo.bar == $.bar }
+    };
+    ok $c.new(:3bar).equal($c.new(:3bar)), 'anon class ::?CLASS param';
+    nok $c.new(:3bar).equal($c.new(:9bar)), 'anon class ::?CLASS param (false case)';
+}
+
+# anon class with a method.
+{
+    my $obj = (anon class { method greet { 'hi' } }).new;
+    is $obj.greet, 'hi', 'anon class method call';
+}
+
+# The stored value is a type object, not a string.
+{
+    my $c = anon class { };
+    isnt $c.^name, 'Str', 'anon class value is a type object, not Str';
+    ok $c.new.defined, 'anon class .new produces a defined instance';
+}
+
+# anon grammar parses.
+{
+    my $g = anon grammar { token TOP { \d+ } };
+    ok $g.parse('123'), 'anon grammar .parse succeeds';
+}
+
+# anon role evaluates to a role type object (not a string).
+{
+    my $r = anon role { method tag { 'R' } };
+    isnt $r.^name, 'Str', 'anon role value is a type object, not Str';
+}


### PR DESCRIPTION
## Summary

`anon class { ... }` / `anon role { ... }` / `anon grammar { ... }` used as an **expression** was not handled:

```
$ mutsu -e 'my $c = anon class { has $.bar }; say $c.new(:3bar).bar'
No such method 'bar' for invocant of type 'Str'   # $c held the string "anon"
```

The `anon` keyword arm in expression context only knew `anon enum` / `anon method` / `anon sub`, so `anon class { ... }` fell through, `anon` parsed as a BareWord, and the `class { ... }` split off as a separate declaration.

After (matches raku):
```
$ mutsu -e 'my $c = anon class { has $.bar }; say $c.new(:3bar).bar'
3
```

## Change

Wire the anonymous-package expression parsers (`anon_class_expr` / `anon_role_expr` / `anon_grammar_expr`, already used for `my class { ... }` in expression context) into the `anon` arm. This also fixes `::?CLASS`-typed method params on an anon class (they resolved to `Str` because the whole class was never a class).

Found via the QA doc-diff harness (variables.rakudoc anon-class `::?CLASS` example).

## Test

Pin `t/anon-package-expr.t` (8 cases: anon class instance/method/`::?CLASS`, anon grammar `.parse`, anon role). Existing `t/anon-*.t` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)