### PR TITLE
fix: parse a set-operator compound assignment on an indexed lvalue

### DIFF
--- a/docs/dist-compat-sweep.md
+++ b/docs/dist-compat-sweep.md
@@ -123,7 +123,7 @@ message). Work them one at a time.
 App::Rak · Astro::Utils · Audio::Liquidsoap · Bench · Configuration ·
 Cro::FCGI · CSS · CSV::Table · Deps · File-TreeBuilder · IP::Random ·
 Math::Matrix · ML::SparseMatrixRecommender · Pod::Contents ·
-SBOM::CycloneDX · SSH::LibSSH::Tunnel · Trie
+SBOM::CycloneDX · SSH::LibSSH::Tunnel
 
 Known root causes to date:
 
@@ -132,7 +132,8 @@ Known root causes to date:
 | SSH::LibSSH::Tunnel | `Cannot have a 'whenever' block outside the scope of a 'supply' or 'react' block` — a `whenever` reached at load time (likely a react/supply parse gap). |
 | SBOM::CycloneDX | `unparsed input, column 5: "}\n… @*ERRORS"` — a `@*ERRORS` dynamic var / trailing brace parse dead-end. |
 | CSS | inside a `grammar` ("angle index key") — grammar/regex-slang, heavier. |
-| Pod::Contents / Deps / Trie / Configuration / File-TreeBuilder / Bench / App::Rak / Astro::Utils / Audio::Liquidsoap / IP::Random / Math::Matrix / ML::SparseMatrixRecommender / CSV::Table / Cro::FCGI | generic `expected statement…` dead-end — each needs its own repro; several carry multiple blockers (bisect at balanced method boundaries). |
+| Pod::Contents / Deps / Configuration / File-TreeBuilder / Bench / App::Rak / Astro::Utils / Audio::Liquidsoap / IP::Random / Math::Matrix / ML::SparseMatrixRecommender / CSV::Table / Cro::FCGI | generic `expected statement…` dead-end — each needs its own repro; several carry multiple blockers (bisect at balanced method boundaries). |
+| ~~Trie~~ | **Cleared post-snapshot**: was a set-operator compound assignment on an indexed lvalue (`%!decendents{char} ∪= …`) the parser rejected. Parse error gone; now only lacks its `OrderedHash` dependency (missing_dep). |
 | ~~Prime::Factor~~ | **Cleared post-snapshot**: was a sigilless parameter (`\N`) carrying a `where` constraint (`multi divisors (Int \N where BIG, …)`) that the param parser rejected. Now loads and factors correctly. |
 
 ### runtime_error (14 remaining; Astro::Sunrise cleared post-snapshot)

--- a/src/parser/expr/precedence_meta_ops/set_ops.rs
+++ b/src/parser/expr/precedence_meta_ops/set_ops.rs
@@ -207,6 +207,25 @@ pub(crate) fn structural_expr(input: &str) -> PResult<'_, Expr> {
         }
         // Set operators: (|), (&), (-), (^), (<=), (>=), (<), (>), (elem), (cont)
         if let Some((tok, len)) = parse_set_op(r) {
+            // `∪=`, `(&)=`, `(-)=`, … are set-operator *compound assignments*
+            // (`lhs OP= rhs`), not an infix set op followed by a stray `=`.
+            // Stop here so the assignment handler parses the whole statement;
+            // otherwise the infix branch consumes `∪` and chokes on `=`.
+            let after_op = &r[len..];
+            if matches!(
+                tok,
+                TokenKind::SetUnion
+                    | TokenKind::SetIntersect
+                    | TokenKind::SetMultiply
+                    | TokenKind::SetDiff
+                    | TokenKind::SetSymDiff
+                    | TokenKind::SetAddition
+            ) && after_op.starts_with('=')
+                && !after_op.starts_with("==")
+                && !after_op.starts_with("=>")
+            {
+                break;
+            }
             let r = &r[len..];
             let (r, _) = ws(r)?;
             let (r, right) = concat_expr(r).map_err(|err| {

--- a/src/parser/stmt/simple_expr_stmt/core.rs
+++ b/src/parser/stmt/simple_expr_stmt/core.rs
@@ -9,7 +9,7 @@ use crate::parser::parse_result::{
 use crate::parser::primary::parse_call_arg_list;
 use crate::parser::stmt::assign::{
     CompoundAssignOp, compound_assigned_value_expr, parse_assign_expr_or_comma,
-    parse_comma_or_expr, parse_compound_assign_op,
+    parse_comma_or_expr, parse_compound_assign_op, parse_set_compound_assign_op,
 };
 use crate::parser::stmt::modifier::{is_stmt_modifier_keyword, parse_statement_modifier};
 use crate::parser::stmt::simple::{
@@ -1199,6 +1199,115 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
             ];
             return parse_statement_modifier(r, Stmt::Block(stmts));
         }
+    }
+
+    // Set-operator compound assignment on a non-plain-variable lvalue:
+    // `%h<k> ∪= $s`, `@a[0] (&)= $s`, `.key ⊖= $s`. These operators
+    // (`∪=`/`∩=`/`(-)=`/…) are parsed by `parse_set_compound_assign_op` and
+    // carry a raw `TokenKind`, so they are not reached by the
+    // `CompoundAssignOp` path below. Desugar `lhs OP= rhs` to
+    // `lhs = lhs OP rhs`, evaluating the index once for an `Index` lvalue.
+    if !matches!(expr, Expr::AssignExpr { .. })
+        && let Some((stripped, set_tok)) = parse_set_compound_assign_op(rest)
+    {
+        let (r, _) = ws(stripped)?;
+        let (r, rhs) = parse_assign_expr_or_comma(r).map_err(|err| PError {
+            messages: merge_expected_messages(
+                "expected right-hand expression after compound assignment",
+                &err.messages,
+            ),
+            remaining_len: err.remaining_len.or(Some(r.len())),
+            exception: None,
+        })?;
+        if let Expr::Index {
+            target,
+            index,
+            is_positional,
+            ..
+        } = &expr
+        {
+            let tmp_idx = format!(
+                "__mutsu_idx_{}",
+                TMP_INDEX_COUNTER.fetch_add(1, Ordering::Relaxed)
+            );
+            let tmp_idx_expr = Expr::Var(tmp_idx.clone());
+            let lhs_expr = Expr::Index {
+                target: target.clone(),
+                index: Box::new(tmp_idx_expr.clone()),
+                is_positional: *is_positional,
+            };
+            let assigned_value = Expr::Binary {
+                left: Box::new(lhs_expr),
+                op: set_tok,
+                right: Box::new(rhs),
+            };
+            let stmt = Stmt::Expr(Expr::DoBlock {
+                body: vec![
+                    Stmt::VarDecl {
+                        name: tmp_idx.clone(),
+                        expr: (*index.clone()),
+                        type_constraint: None,
+                        is_state: false,
+                        is_our: false,
+                        is_dynamic: false,
+                        is_export: false,
+                        export_tags: Vec::new(),
+                        custom_traits: Vec::new(),
+                        where_constraint: None,
+                    },
+                    Stmt::Expr(Expr::IndexAssign {
+                        target: target.clone(),
+                        index: Box::new(tmp_idx_expr),
+                        value: Box::new(assigned_value),
+                        is_positional: *is_positional,
+                    }),
+                ],
+                label: None,
+            });
+            return parse_statement_modifier(r, stmt);
+        }
+        if let Expr::MethodCall {
+            ref target,
+            ref name,
+            ref args,
+            ref modifier,
+            ..
+        } = expr
+        {
+            let assigned_value = Expr::Binary {
+                left: Box::new(expr.clone()),
+                op: set_tok,
+                right: Box::new(rhs),
+            };
+            let topic_name = if let Expr::Var(ref v) = **target {
+                v.clone()
+            } else {
+                "_".to_string()
+            };
+            let method_name = if *modifier == Some('!') {
+                format!("!{}", name.resolve())
+            } else {
+                name.resolve()
+            };
+            let stmt = Stmt::Expr(Expr::Call {
+                name: Symbol::intern("__mutsu_assign_method_lvalue"),
+                args: vec![
+                    (**target).clone(),
+                    Expr::Literal(crate::value::Value::str(method_name)),
+                    Expr::ArrayLiteral(args.clone()),
+                    assigned_value,
+                    Expr::Literal(crate::value::Value::str(topic_name)),
+                ],
+            });
+            return parse_statement_modifier(r, stmt);
+        }
+        // Fallback for any other lvalue shape: `lhs = lhs OP rhs`.
+        let stmt = Stmt::Expr(Expr::Binary {
+            left: Box::new(expr),
+            op: set_tok,
+            right: Box::new(rhs),
+        });
+        return parse_statement_modifier(r, stmt);
     }
 
     // Generic compound assignment on non-variable lhs (e.g. `.key //= ++$i`).

--- a/t/set-op-compound-assign-indexed.t
+++ b/t/set-op-compound-assign-indexed.t
@@ -1,0 +1,82 @@
+use v6;
+use Test;
+
+# Set-operator compound assignment (`∪=`, `∩=`, `(-)=`, `(^)=`, `(+)=`, `(.)=`
+# and their Unicode/ASCII variants) on an *indexed* lvalue — a hash element,
+# array element, or attribute subscript. Regression: mutsu handled the scalar
+# form (`$x ∪= $s`) but the infix set-op parser consumed `∪` in `%h<k> ∪= $s`
+# and choked on the trailing `=`, so `%h<k> ∪= …` died with "expected
+# expression after set operator". (Hit by Trie's `%!decendents{char} ∪= …`.)
+#
+# Sets/Bags are unordered, so compare a canonical sorted view, not `.gist`.
+
+plan 9;
+
+sub set-canon($s)  { $s.keys.sort.join(',') }
+sub bag-canon($b)  { $b.pairs.map({ "{.key}:{.value}" }).sort.join(',') }
+
+# Hash element, Unicode union.
+{
+    my %h; %h<a> = (1, 2).Set;
+    %h<a> ∪= (3,).Set;
+    is set-canon(%h<a>), '1,2,3', 'hash element ∪= (union)';
+}
+
+# Hash element, ASCII union.
+{
+    my %h; %h<a> = (1, 2).Set;
+    %h<a> (|)= (3,).Set;
+    is set-canon(%h<a>), '1,2,3', 'hash element (|)= (ASCII union)';
+}
+
+# Array element, intersection.
+{
+    my @a; @a[0] = (1, 2, 3).Set;
+    @a[0] (&)= (2, 3, 4).Set;
+    is set-canon(@a[0]), '2,3', 'array element (&)= (intersection)';
+}
+
+# Hash element, set difference (Unicode).
+{
+    my %h; %h<a> = (1, 2, 3).Set;
+    %h<a> ∖= (2,).Set;
+    is set-canon(%h<a>), '1,3', 'hash element ∖= (set difference)';
+}
+
+# Hash element, symmetric difference (ASCII).
+{
+    my %h; %h<a> = (1, 2, 3).Set;
+    %h<a> (^)= (3, 4).Set;
+    is set-canon(%h<a>), '1,2,4', 'hash element (^)= (symmetric difference)';
+}
+
+# Bag element, baggy addition.
+{
+    my %h; %h<a> = (1, 1, 2).Bag;
+    %h<a> (+)= (2, 3).Bag;
+    is bag-canon(%h<a>), '1:2,2:2,3:1', 'bag element (+)= (baggy addition)';
+}
+
+# Attribute hash element inside a method (method-call lvalue path).
+{
+    class C {
+        has %.h;
+        method add-to($k, $s) { %!h{$k} ∪= $s }
+    }
+    my $c = C.new;
+    $c.h<x> = (1,).Set;
+    $c.add-to('x', (5, 6).Set);
+    is set-canon($c.h<x>), '1,5,6', 'attribute hash element ∪= inside a method';
+}
+
+# The scalar form still works (no regression).
+{
+    my $x = (1, 2).Set;
+    $x ∪= (5,).Set;
+    is set-canon($x), '1,2,5', 'scalar ∪= still works';
+}
+
+# Plain infix ∪ (not a compound assign) still works (no regression).
+{
+    is set-canon((1, 2).Set ∪ (3,).Set), '1,2,3', 'plain infix ∪ still works';
+}


### PR DESCRIPTION
## Problem

Set-operator compound assignment on a hash/array element or attribute
subscript died at parse time:

```raku
my %h; %h<a> = (1,2).Set;
%h<a> ∪= (3,).Set;    # ===SORRY!=== expected expression after set operator
```

Two gaps combined:

1. The infix set-operator parser (`structural_expr`) greedily consumed `∪` in
   `%h<a> ∪= …` and then choked on the trailing `=` — unlike the arithmetic
   infix parsers, it did not stop when a set op was immediately followed by `=`.
2. The indexed/method-call compound-assignment desugar only tried
   `parse_compound_assign_op` (arithmetic/word ops), never
   `parse_set_compound_assign_op` — so even past the infix parser, set ops on an
   indexed lvalue had no handler. (The scalar `$x ∪= $s` form already worked.)

## Fix

- `structural_expr` breaks before an assignable set op followed by `=`
  (`∪`/`∩`/`(-)`/`(^)`/`(+)`/`(.)` and glyph variants), leaving the statement to
  the assignment handler.
- The indexed/method-call compound-assign desugar gains a set-op branch that
  lowers `lhs OP= rhs` → `lhs = lhs OP rhs`, evaluating an `Index` subscript
  once. Plain infix `∪` and the scalar form are unchanged.

## Impact

Unblocks **Trie** (`%!decendents{char} ∪= [$child, |@gchild].[i]`) — its parse
error is gone; it now only lacks the `OrderedHash` dependency (moved
parse_error → missing_dep).

## Test

`t/set-op-compound-assign-indexed.t` pins union/intersection/difference/sym-diff
/baggy-addition on hash and array elements, an attribute element inside a method,
and the scalar + plain-infix no-regression cases. All 9 verified on both `raku`
and mutsu (compared order-independently, since Sets/Bags are unordered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)