### PR TITLE
fix: (B)-gate fold class/role-method captured-outer lexicals into needs_env_sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2469,16 +2469,22 @@ impl CompiledCode {
             // `RegisterSub` op and compiled lazily, so this frame cannot see which
             // enclosing lexicals its body reads by name. Such a sub reads an outer
             // lexical (`my $base = 100; sub f { $base + 1 }`) from this frame's env
-            // by name at call time, which the gate would leave stale. Without the
-            // sub's free-var set available here, conservatively keep every local of
-            // a sub-defining frame env-synced. Gate-ON only, so the default build is
-            // byte-identical/perf-neutral; the top-level/main frame (the usual
-            // sub-defining frame) is never a hot arithmetic loop.
-            let defines_named_sub = self
-                .ops
-                .iter()
-                .any(|op| matches!(op, OpCode::RegisterSub(_)));
-            if defines_named_sub {
+            // by name at call time, which the gate would leave stale. A class/role
+            // METHOD body captures an outer lexical the same way (`my $base = 100;
+            // class T { method calc($n) { $base + $n } }`) and is likewise compiled
+            // lazily off the class/role registration op, invisible here. Without the
+            // body's free-var set available, conservatively keep every local of a
+            // frame that defines a named sub or a class/role env-synced. Gate-ON
+            // only, so the default build is byte-identical/perf-neutral; the
+            // top-level/main frame (the usual definer) is never a hot arithmetic
+            // loop.
+            let defines_lazy_body = self.ops.iter().any(|op| {
+                matches!(
+                    op,
+                    OpCode::RegisterSub(_) | OpCode::RegisterClass(_) | OpCode::RegisterRole(_)
+                )
+            });
+            if defines_lazy_body {
                 self.needs_env_sync.iter_mut().for_each(|b| *b = true);
             }
         }

--- a/t/gate-b-class-method-outer-lexical.t
+++ b/t/gate-b-class-method-outer-lexical.t
@@ -1,0 +1,53 @@
+use Test;
+
+# Pin for the (B) per-store env-write gate class/role-method captured-outer fix
+# (docs/lexical-scope-slot-campaign.md, "(B) per-store env-write gate — burndown").
+#
+# A class/role METHOD body is compiled lazily off its `RegisterClass`/`RegisterRole`
+# op, so the defining frame's `compute_needs_env_sync` cannot see which enclosing
+# lexicals the body reads by name. Such a body reads an outer lexical
+# (`my $base = 100; class T { method calc($n) { $base + $n } }`) from the defining
+# frame's env by name at call time. Under MUTSU_GATE_LOCAL_ENV_WRITE the outer
+# `my $base = 100` store skips its env mirror, so the method read the decl seed
+# (Any/0) instead of 100. The fix folds every local of a class/role-defining frame
+# into `needs_env_sync` under the gate (mirroring the named-sub fold), keeping the
+# store's env mirror current. Gate OFF (default) is byte-identical. This passes
+# gate-OFF and would fail gate-ON before the fix.
+
+plan 5;
+
+# Class method reads a captured outer scalar.
+my $base = 100;
+class T { method calc(Int $n) { $base + $n } }
+class D { has $.v; method run(Int $n) { $!v = T.calc($n); $!v } }
+is D.new.run(5), 105, 'class method reads a captured outer lexical';
+
+# Type-object method with a captured outer, result stored to an attribute.
+my @registry;
+class Status { has Int $.code; method CALL-ME(Status:U: Int $n) { @registry[$n] } }
+@registry[7] = Status.new(code => 77);
+class Response {
+    has $.status;
+    method set-status(Int $n) { $!status = Status($n); self }
+}
+is Response.new.set-status(7).status.code, 77,
+    'attr assigned from a CALL-ME-on-type-object that reads a captured outer';
+
+# Captured outer array read from inside a method.
+my @vals = 10, 20, 30;
+class Sum { method total { @vals.sum } }
+is Sum.total, 60, 'class method reads a captured outer array';
+
+# Role method reads a captured outer lexical.
+my $mult = 3;
+role Scale { method scale(Int $n) { $n * $mult } }
+class Widget does Scale { }
+is Widget.scale(4), 12, 'role method reads a captured outer lexical';
+
+# Captured outer mutated between two method calls stays live.
+my $offset = 1;
+class Adder { method add(Int $n) { $n + $offset } }
+my $a = Adder.add(10);
+$offset = 5;
+my $b = Adder.add(10);
+is "$a,$b", "11,15", 'captured outer mutation is visible to a later method call';


### PR DESCRIPTION
## Summary

Part of the `(B)` per-store env-write gate burndown (`MUTSU_GATE_LOCAL_ENV_WRITE`, docs/lexical-scope-slot-campaign.md). Default OFF is byte-identical.

A class/role **method** body is compiled lazily off its `RegisterClass`/`RegisterRole` op, so the defining frame's `compute_needs_env_sync` cannot see which enclosing lexicals the body reads by name — exactly like a named sub registered via `RegisterSub`. Such a body reads an outer lexical (`my $base = 100; class T { method calc($n) { $base + $n } }`) from the defining frame's env by name at call time. Under the gate the outer `my $base = 100` store skips its env mirror, so the method read the decl seed (`Any`/0) instead of 100.

## Fix

Extend the existing named-sub fold (#4869) to also treat a frame that emits `RegisterClass` / `RegisterRole` as a lazy-body definer: conservatively keep every local of such a frame env-synced under the gate. Gated on `gate_local_env_write()`, so the default build is byte-identical and perf-neutral (the definer is the top-level/main frame, never a hot arithmetic loop).

## Verification

- **Gate OFF (default / CI):** `make test` PASS (Files=2005, Tests=19038) — structurally byte-identical.
- **Gate ON survey vs main:** −5 t/ files (`bind-self-attr-write`, `method-call-self-writeback`, `native-tweak-construct`, `nested-assoc-user-assign-key`, `virtual-call-attr`), no regressions.
- Pin: `t/gate-b-class-method-outer-lexical.t` (passes OFF, ON, and under `raku`).

Independent of #4886 (block-exit slot-authoritative) — different files; the two together take the ON survey 19 → 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)