### PR TITLE
fix: (B)-gate read/mutate a scalar-held container from the slot for indexed inc/dec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -1311,6 +1311,27 @@ impl Interpreter {
         }
     }
 
+    /// Under the (B) per-store env-write gate, return this frame's live local slot
+    /// value for `name` when the slot holds a real (non-Nil) value — the slot is
+    /// the authoritative half while the env mirror is suppressed. Returns None
+    /// when the gate is off (so callers fall back to the env read and stay
+    /// byte-identical), when there is no local slot for `name`, or when the slot
+    /// is Nil (an uninitialized/absent local, where the env read — and any
+    /// autovivification it drives — is the right source). §1.5 helper — see
+    /// docs/lexical-scope-slot-campaign.md.
+    pub(super) fn gate_local_slot_value(&self, code: &CompiledCode, name: &str) -> Option<Value> {
+        if !crate::opcode::gate_local_env_write() {
+            return None;
+        }
+        let slot = self.find_local_slot(code, name)?;
+        let val = self.locals.get(slot)?;
+        if val.is_nil() {
+            None
+        } else {
+            Some(val.clone())
+        }
+    }
+
     /// Resolve a local slot for `name`, preferring the compile-time-baked `slot`
     /// (scope-correct even once a name occupies several `code.locals` slots) and
     /// falling back to the by-name search when the caller has no baked slot.

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -409,7 +409,18 @@ impl Interpreter {
             .as_deref()
             .is_some_and(|t| t == "SetHash");
         let idx_val = self.stack.pop().unwrap_or(Value::NIL);
-        let container = self.get_env_with_main_alias(&name);
+        // Read the base container for the `$c[i]++` / `$h<k>++` mutation. Prefer
+        // this frame's live local slot under the (B) per-store env-write gate:
+        // `my $bh = BagHash(...)` writes the slot but skips the env mirror, so an
+        // env-first read would snapshot the `my` decl seed (Any/absent) and the
+        // increment would operate on an empty base and be lost (`$bh<a>++` read
+        // back as its old weight). The writeback below already refreshes the slot
+        // (`update_local_if_exists`), so the slot is the authoritative half here.
+        // Gate OFF (default) is byte-identical: the slot equals the env mirror, so
+        // the env read is used exactly as before.
+        let container = self
+            .gate_local_slot_value(code, &name)
+            .or_else(|| self.get_env_with_main_alias(&name));
         // Resolve a WhateverCode / Whatever index (`@a[*-1]++`, `@a[*-2]--`)
         // against the container's length before using it as the key — otherwise
         // the raw closure stringifies to a bogus key and the increment is lost.
@@ -685,7 +696,24 @@ impl Interpreter {
         // Modify the container in-place in the env to preserve Arc sharing
         // (e.g. when two variables reference the same array via Arc).
         // First try to modify via env_mut().get_mut() to avoid clone.
-        let modified_in_place = if let Some(container_value) = self.env_mut().get_mut(&name) {
+        //
+        // (B) per-store env-write gate: `my $bh = BagHash(...)` writes this frame's
+        // local slot but skips the env mirror, so `env.get_mut(name)` would be a
+        // stale `Any`/absent — the in-place `$bh<a>++` would land in env (or not at
+        // all) and the slot's live container would never see the bump. Mutate the
+        // slot's container directly under the gate; the slot is the authoritative
+        // half (and its backing node is shared, so this is still in-place). Gate
+        // OFF (default) uses `env.get_mut` exactly as before (byte-identical).
+        let gate_slot = if crate::opcode::gate_local_env_write() {
+            self.find_local_slot(code, &name)
+                .filter(|&s| !self.locals[s].is_nil())
+        } else {
+            None
+        };
+        let modified_in_place = if let Some(container_value) = match gate_slot {
+            Some(s) => self.locals.get_mut(s),
+            None => self.env_mut().get_mut(&name),
+        } {
             if let Some(done) = container_value.with_hash_mut(|h| {
                 // Mirror the array arm below: when the hash Arc is shared
                 // (strong_count > 1) via a scalar-bound `ContainerRef` cell
@@ -838,8 +866,12 @@ impl Interpreter {
             false
         };
         if modified_in_place {
-            // Update local slot to match the modified env value
-            if let Some(val) = self.env().get(&name).cloned() {
+            // Update local slot to match the modified env value. Under the gate the
+            // mutation already landed in the slot (above), and `env` is the stale
+            // half, so pulling env->slot here would clobber the live slot — skip it.
+            if gate_slot.is_none()
+                && let Some(val) = self.env().get(&name).cloned()
+            {
                 self.update_local_if_exists(code, &name, &val);
             }
             // Inside a critical section, propagate the whole mutated aggregate to
@@ -884,9 +916,16 @@ impl Interpreter {
                     }
                     _ => unreachable!(),
                 };
-                self.env_mut().insert(name.clone(), new_container);
-                if let Some(val) = self.env().get(&name).cloned() {
-                    self.update_local_if_exists(code, &name, &val);
+                // Under the gate, write the autovivified container straight to the
+                // slot (the authoritative half); env stays suppressed. Otherwise
+                // insert into env and mirror to the slot as before.
+                if let Some(s) = gate_slot {
+                    self.locals[s] = new_container;
+                } else {
+                    self.env_mut().insert(name.clone(), new_container);
+                    if let Some(val) = self.env().get(&name).cloned() {
+                        self.update_local_if_exists(code, &name, &val);
+                    }
                 }
             }
         }

--- a/t/gate-b-index-incdec-slot-container.t
+++ b/t/gate-b-index-incdec-slot-container.t
@@ -1,0 +1,52 @@
+use Test;
+
+# Pin for the (B) per-store env-write gate index inc/dec container-read fix
+# (docs/lexical-scope-slot-campaign.md, "(B) per-store env-write gate — burndown").
+#
+# `$c[i]++` / `$h<k>++` (OpCode::PostIncrementIndex / PreIncrementIndex) read the
+# base container from `env` by name (`get_env_with_main_alias`) and mutate it in
+# place via `env.get_mut(name)`. Under MUTSU_GATE_LOCAL_ENV_WRITE a
+# `my $bh = BagHash(...)` writes the local slot but skips the env mirror, so the
+# env-first read snapshotted the `my` decl seed (Any/absent): the bump landed in
+# env (or nowhere) and the slot's live container never saw it, so `$bh<a>` read
+# back as its old weight. The fix reads and mutates the slot's container under the
+# gate (the authoritative half). Gate OFF (default) is byte-identical. This passes
+# gate-OFF and would fail gate-ON before the fix.
+
+plan 8;
+
+# BagHash weight bump through a scalar-held coerced container.
+my $bh = BagHash(<a a>);
+$bh<a>++;
+is $bh<a>, 3, 'BagHash($x)<k>++ bumps the slot-held container';
+
+# MixHash weight set/bump.
+my $mh = MixHash(<a>);
+$mh<b>++;
+is $mh<b>, 1, 'MixHash($x)<k>++ on a slot-held container';
+
+# SetHash element add via ++ (Bool-valued).
+my $sh = SetHash(<a b>);
+$sh<c>++;
+ok $sh<c>, 'SetHash($x)<k>++ adds the key';
+is $sh.elems, 3, 'SetHash gained the element';
+
+# Plain Hash element inc through a scalar container.
+my $h = %( a => 1 );
+$h<a>++;
+is $h<a>, 2, 'scalar-held Hash <k>++';
+
+# Array element inc through a scalar container.
+my $arr = [10, 20, 30];
+$arr[1]++;
+is $arr[1], 21, 'scalar-held Array [i]++';
+
+# Prefix increment on a slot-held container.
+my $bh2 = BagHash(<x x x>);
+++$bh2<x>;
+is $bh2<x>, 4, 'prefix ++$bh<k> on a slot-held container';
+
+# Decrement removes a Bag weight down to 0.
+my $bh3 = BagHash(<y>);
+$bh3<y>--;
+is $bh3<y>, 0, 'BagHash <k>-- clamps to 0';


### PR DESCRIPTION
## Summary

Part of the `(B)` per-store env-write gate burndown (`MUTSU_GATE_LOCAL_ENV_WRITE`, docs/lexical-scope-slot-campaign.md). Default OFF is byte-identical.

`$c[i]++` / `$h<k>++` (`OpCode::PostIncrementIndex` / `PreIncrementIndex`, handled by `exec_inc_dec_index_op`) read the base container from `env` by name (`get_env_with_main_alias`) and mutate it in place via `env.get_mut(name)`. Under the gate a `my $bh = BagHash(...)` writes the local slot but skips the env mirror, so the env-first read snapshotted the `my` decl seed (`Any`/absent): the bump landed in env (or nowhere) and the slot's live container never saw it, so `$bh<a>` read back as its old weight.

## Fix

Read and mutate the slot's container under the gate (the authoritative half; its backing node is shared, so the write is still in place), and skip the env→slot mirror-back that would clobber the live slot. New helper `gate_local_slot_value` for the gated slot-first read. Gated on `gate_local_env_write()`, so the default build is byte-identical (the gate slot is None → every path uses the original env read/mutate/mirror).

## Verification

- **Gate OFF (default / CI):** `make test` PASS (Files=2007, Tests=19054).
- **Gate ON:** `sethash-baghash-mixhash-coerce-fn.t` flips green.
- Pin: `t/gate-b-index-incdec-slot-container.t` (passes OFF, ON, and under `raku`).

Independent of #4886 and #4889 (different files). The `:delete` (`DeleteIndexNamed`) and index-assign container reads share the same env-first pattern and are left as follow-ups (`quanthash-immutable-ro.t`, `native-map-hash-coerce.t`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)