### PR TITLE
fix: parse a tightly-bound `<=>` as a quote-word / key / colonpair value

### DIFF
--- a/docs/dist-compat-sweep.md
+++ b/docs/dist-compat-sweep.md
@@ -120,7 +120,7 @@ message). Work them one at a time.
 
 ### parse_error (18)
 
-App::Rak · Astro::Utils · Audio::Liquidsoap · Bench · Configuration ·
+App::Rak · Astro::Utils · Audio::Liquidsoap · Configuration ·
 Cro::FCGI · CSS · CSV::Table · Deps · File-TreeBuilder · IP::Random ·
 Math::Matrix · ML::SparseMatrixRecommender · Pod::Contents ·
 SBOM::CycloneDX · SSH::LibSSH::Tunnel
@@ -132,7 +132,8 @@ Known root causes to date:
 | SSH::LibSSH::Tunnel | `Cannot have a 'whenever' block outside the scope of a 'supply' or 'react' block` — a `whenever` reached at load time (likely a react/supply parse gap). |
 | SBOM::CycloneDX | `unparsed input, column 5: "}\n… @*ERRORS"` — a `@*ERRORS` dynamic var / trailing brace parse dead-end. |
 | CSS | inside a `grammar` ("angle index key") — grammar/regex-slang, heavier. |
-| Pod::Contents / Deps / Configuration / File-TreeBuilder / Bench / App::Rak / Astro::Utils / Audio::Liquidsoap / IP::Random / Math::Matrix / ML::SparseMatrixRecommender / CSV::Table / Cro::FCGI | generic `expected statement…` dead-end — each needs its own repro; several carry multiple blockers (bisect at balanced method boundaries). |
+| ~~Bench~~ | **Cleared post-snapshot**: a tightly-bound `<=>` used as a quote-word / hash key / colonpair value (`:fill<=>`, `%h<=>`) was mis-parsed as the spaceship operator by three separate angle parsers. Now loads. |
+| Pod::Contents / Deps / Configuration / File-TreeBuilder / App::Rak / Astro::Utils / Audio::Liquidsoap / IP::Random / Math::Matrix / ML::SparseMatrixRecommender / CSV::Table / Cro::FCGI | generic `expected statement…` dead-end — each needs its own repro; several carry multiple blockers (bisect at balanced method boundaries). |
 | ~~Trie~~ | **Cleared post-snapshot**: was a set-operator compound assignment on an indexed lvalue (`%!decendents{char} ∪= …`) the parser rejected. Parse error gone; now only lacks its `OrderedHash` dependency (missing_dep). |
 | ~~Prime::Factor~~ | **Cleared post-snapshot**: was a sigilless parameter (`\N`) carrying a `where` constraint (`multi divisors (Int \N where BIG, …)`) that the param parser rejected. Now loads and factors correctly. |
 

--- a/src/parser/expr/postfix/helpers.rs
+++ b/src/parser/expr/postfix/helpers.rs
@@ -74,6 +74,11 @@ pub(crate) fn is_angle_key_char(c: char) -> bool {
         || c == '@'
         || c == '%'
         || c == '&'
+        // `=` is an ordinary character inside angle-word quoting, so a subscript
+        // key may contain it: `%h<=>` is the string key `=`, `%h<=foo>` is
+        // `=foo` (Rakudo). The tightly-bound `<...>` is always a subscript here,
+        // never the `<=`/`<=>` infix operator (which needs surrounding space).
+        || c == '='
         // Parentheses are ordinary characters inside angle-word quoting, so an
         // angle *subscript* key may contain them too: `%h<(default)>` is the
         // string key `(default)` (App::Rak). The `<...>` word-list literal

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -1395,11 +1395,10 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
 
         // Hash indexing with angle brackets: %hash<key>, $hash<key>, @a[0]<key>, etc.
         // Only match when content is a simple word key (alphanumeric, no operators)
-        if rest.starts_with('<')
-            && !rest.starts_with("<=")
-            && !rest.starts_with("<<")
-            && !rest.starts_with("<=>")
-        {
+        // A tightly-bound `<...>` after a term is always a subscript — including
+        // `<=>` / `<=foo>` (key `=` / `=foo`), which Rakudo also reads as a
+        // subscript, never the `<=`/`<=>` infix (those need surrounding space).
+        if rest.starts_with('<') && !rest.starts_with("<<") {
             let r = &rest[1..];
             let Some(end) = r.find('>') else {
                 return Err(PError::expected_at("closing '>'", r));

--- a/src/parser/primary/container/angle_words.rs
+++ b/src/parser/primary/container/angle_words.rs
@@ -33,17 +33,20 @@ fn parse_quote_word_list<'a>(
     let Some(input) = input.strip_prefix(open) else {
         return Err(PError::expected("quote-word list"));
     };
-    // For `<...>`, reject leading operator forms like <= and <=>.
-    // Allow negative words/numerics such as <-1/0> and word lists starting
-    // with a bare hyphen like <- a - b ->.
+    // For `<...>`, reject a leading `-` operator form. Allow negative
+    // words/numerics such as <-1/0> and word lists starting with a bare hyphen
+    // like <- a - b ->.
+    //
+    // A leading `=` is NOT rejected: this parser only runs in *term* position
+    // (the infix `<`/`<=`/`<=>` operators are parsed elsewhere, after a term),
+    // where `<=>`, `<==>`, `<=foo>` are ordinary quote-words (`'='`, `'=='`,
+    // `'=foo'`) — matching Rakudo. Rejecting `=` broke both the bare word-quote
+    // `<=>` and the hash subscript `%h<=>`.
     if reject_lt_operators
-        && (input.starts_with('=')
-            || (input.starts_with('-')
-                && !input.as_bytes().get(1).copied().is_some_and(|b| {
-                    b.is_ascii_alphanumeric()
-                        || b == b' '
-                        || matches!(b, b'_' | b'/' | b'.' | b'+' | b'-')
-                })))
+        && input.starts_with('-')
+        && !input.as_bytes().get(1).copied().is_some_and(|b| {
+            b.is_ascii_alphanumeric() || b == b' ' || matches!(b, b'_' | b'/' | b'.' | b'+' | b'-')
+        })
     {
         return Err(PError::expected("angle list"));
     }

--- a/src/parser/primary/misc/colonpair.rs
+++ b/src/parser/primary/misc/colonpair.rs
@@ -550,8 +550,11 @@ pub(crate) fn colonpair_expr(input: &str) -> PResult<'_, Expr> {
             },
         ));
     }
-    // :name<value> (angle-bracket colonpair, equivalent to :name("value"))
-    if rest.starts_with('<') && !rest.starts_with("<<") && !rest.starts_with("<=") {
+    // :name<value> (angle-bracket colonpair, equivalent to :name("value")).
+    // A tightly-bound `<...>` is always the colonpair value — including `<=>` /
+    // `<=foo>` (`name => '='` / `name => '=foo'`), which Rakudo also reads this
+    // way, never as the `<=`/`<=>` infix (those need surrounding space).
+    if rest.starts_with('<') && !rest.starts_with("<<") {
         let inner = &rest[1..];
         if let Some(close) = crate::parser::primary::container::find_nested_angle_close_pub(inner) {
             let content = &inner[..close];

--- a/t/angle-spaceship-quote-word.t
+++ b/t/angle-spaceship-quote-word.t
@@ -1,0 +1,42 @@
+use v6;
+use Test;
+
+# A tightly-bound angle bracket `<=>` (and `<=foo>`, `<==>`) in *term*,
+# *subscript*, and *colonpair-value* position is an ordinary quote-word / key /
+# value (`'='`, `'=foo'`, `'=='`), NOT the `<=>` spaceship / `<=` infix operator
+# (those need surrounding whitespace). Regression: three separate angle parsers
+# each rejected a leading `=`, so `<=>`, `%h<=>`, and `:name<=>` all failed to
+# parse or bound the wrong value. (Hit by Bench's `:fill<=>` / `%h<=>` usage.)
+
+plan 12;
+
+# Term-position quote-word.
+is <=>, '=',        'bare <=> quote-word is the string "="';
+is <==>, '==',      'bare <==> quote-word is "=="';
+is <=foo>, '=foo',  'bare <=foo> quote-word is "=foo"';
+
+# Hash subscript with `=` key.
+{
+    my %h = ('=' => 9, '=foo' => 3);
+    is %h<=>, 9,      'hash subscript %h<=> keys on "="';
+    is %h<=foo>, 3,   'hash subscript %h<=foo> keys on "=foo"';
+}
+
+# Colonpair angle value.
+{
+    sub f(:$fill?) { $fill }
+    is f(:fill<=>), '=',       'colonpair :fill<=> is fill => "="';
+    is f(:fill<=foo>), '=foo', 'colonpair :fill<=foo> is fill => "=foo"';
+}
+
+# Colonpair in a hash literal.
+{
+    my %h = (:sep<=>);
+    is %h<sep>, '=', 'hash-literal colonpair :sep<=> is sep => "="';
+}
+
+# The `<=>` spaceship and `<=` operators still work (whitespace-separated).
+is (1 <=> 2), Order::Less,  'spaceship 1 <=> 2 is Less';
+is (5 <=> 5), Order::Same,  'spaceship 5 <=> 5 is Same';
+ok (3 <= 5),                'infix 3 <= 5 is True';
+is ([<=] 1, 2, 3), True,    'reduction [<=] still works';


### PR DESCRIPTION
## Problem

A `<=>` (or `<=foo>`, `<==>`) directly attached to a term, hash subscript, or
colonpair was rejected or mis-parsed as the `<=>` spaceship / `<=` infix
operator, when it is an ordinary quote-word / key / value:

```raku
say <=>;          # ===SORRY!===  (should be the string '=')
my %h = '=' => 9;
say %h<=>;        # ===SORRY!===  (should be $h{'='} = 9)
sub f(:$fill) {…}
f(:fill<=>);      # fill bound to Nil (should be fill => '=')
```

Three independent angle parsers each guarded against a leading `=`:

- `angle_words.rs` (term-position `<...>` word-quote) rejected input starting
  with `=` → broke bare `<=>`/`<==>`/`<=foo>`.
- `postfix/loop_.rs` (hash `<key>` subscript) skipped the subscript branch on
  `<=`/`<=>`, and `is_angle_key_char` did not accept `=`.
- `colonpair.rs` (`:name<value>`) rejected `<=`, so `:name<=>` fell back to a
  bare boolean colonpair plus a stray subscript.

## Fix

Rakudo reads all three tightly-bound forms as quote-words (`<=>` → `'='`,
`%h<=>` → `$h{'='}`, `:fill<=>` → `fill => '='`). The spaceship / `<=`
operators apply only in **infix** position (after a term, with surrounding
space), parsed elsewhere — so these term/subscript/colonpair `=` guards were
pure false rejections. Drop them and accept `=` as an angle key char.

## Impact

Unblocks **Bench** (`say $sep(:fill<=>)`, `%results{$res-key}`) in the
dist-compat sweep — the module now parses and loads.

## Test

`t/angle-spaceship-quote-word.t` pins the three positions (`<=>`/`<=foo>`/`<==>`
term, `%h<=>` subscript, `:fill<=>` colonpair + hash-literal) and the
no-regression operator cases (`1 <=> 2`, `3 <= 5`, `[<=] …`). All 12 verified
on both `raku` and mutsu. Full `make test` green locally; 14 angle/colonpair
regression files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)