### PR TITLE
fix: a %-sigiled constant coerces a non-Associative RHS to a Map

### DIFF
--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -525,17 +525,35 @@ impl Interpreter {
                 return Ok(());
             }
         }
-        // Map containers are immutable - prevent assignment and binding to keys
+        // Map containers are immutable - prevent assignment and binding to keys.
+        // A `constant %M = (a => 1)` is now a Map (declared_type "Map"), but its
+        // element assignment must die with the VALUE-level X::Assignment::RO
+        // ("Cannot modify an immutable Int (1)"), not the container-level
+        // "immutable Map" message — that is what raku reports and what the
+        // dedicated readonly-`%`-constant path further below produces. Defer to
+        // that path for a readonly, non-`:=`-bound `%`-constant hash; only a
+        // genuine bound Map value (`:=`) uses the container-level message here.
         if declared_type.as_deref().is_some_and(|t| t == "Map") {
-            if bind_mode {
-                return Err(RuntimeError::typed(
-                    "X::Bind",
-                    [("target".to_string(), Value::str(var_name.clone()))]
-                        .into_iter()
-                        .collect(),
-                ));
-            } else {
-                return Err(RuntimeError::assignment_ro_typename("Map", "Map"));
+            let is_ro_constant_hash = var_name.starts_with('%')
+                && self.is_readonly(&var_name)
+                && !self
+                    .env()
+                    .contains_key(&format!("__mutsu_bound::{}", var_name))
+                && matches!(
+                    self.env().get(&var_name).map(Value::view),
+                    Some(ValueView::Hash(_))
+                );
+            if !is_ro_constant_hash {
+                if bind_mode {
+                    return Err(RuntimeError::typed(
+                        "X::Bind",
+                        [("target".to_string(), Value::str(var_name.clone()))]
+                            .into_iter()
+                            .collect(),
+                    ));
+                } else {
+                    return Err(RuntimeError::assignment_ro_typename("Map", "Map"));
+                }
             }
         }
         // Mix/Set/Bag: prevent auto-vivification of undefined typed variables.

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1030,7 +1030,15 @@ impl Interpreter {
         }
         // Skip typed container coercion for `:=` binding — it would create
         // a new Arc and lose container identity (e.g. Map metadata).
-        if !is_bind && (name.starts_with('@') || name.starts_with('%')) {
+        //
+        // Also skip it for a `constant` declaration: `@`/`%` constants are
+        // always untyped (a typed one is rejected as X::ParametricConstant at
+        // compile time), so `coerce_typed_container_assignment` can only ever
+        // rebuild the hash into a plain `Value::hash(...)` — dropping the
+        // `declared_type: "Map"` metadata that `coerce_constant_hash_value`
+        // just embedded. A `constant %h = <a b>` must render as `Map.new(...)`,
+        // and the coercion above already produced the final value.
+        if !is_bind && !is_constant && (name.starts_with('@') || name.starts_with('%')) {
             val = self.coerce_typed_container_assignment(name, val, has_explicit_initializer)?;
         }
         if let Some(constraint) = loan_env!(self, var_type_constraint(name))
@@ -1493,7 +1501,14 @@ impl Interpreter {
         // (`my @a = @typed`), and an untyped declaration must not present its
         // value as typed. Skip for attribute variables (.h, !h) which get
         // typed metadata from the class definition, not var_type_constraints.
+        //
+        // Also skip for a `constant %h` / `constant @a`: its `declared_type`
+        // ("Map" for a `%`-sigil list-coerced constant, per
+        // `coerce_constant_hash_value`) is the deliberate final type of the
+        // value, not stale element/key metadata inherited from a typed source.
+        // Clearing it would demote `constant %h = <a b>` back to a plain Hash.
         if !is_bind
+            && !is_constant
             && (name.starts_with('%') || name.starts_with('@'))
             && !name.contains('.')
             && !name.contains('!')

--- a/t/constant-hash-map.t
+++ b/t/constant-hash-map.t
@@ -1,0 +1,34 @@
+use v6;
+use Test;
+
+# A `%`-sigiled constant auto-coerces a non-Associative RHS (a List) to an
+# immutable Map via `.Map` (terms.rakudoc), while an already-Associative RHS
+# (a Hash literal or a Pair) is preserved as-is.
+
+plan 11;
+
+# List RHS -> Map
+constant %foo = <foo bar>;
+is %foo.WHAT.gist, '(Map)', 'constant % from a List is a Map';
+is %foo.raku, 'Map.new((:foo("bar")))', 'Map .raku rendering';
+is %foo<foo>, 'bar', 'Map value is readable';
+
+# Odd/even list coercion
+constant %pair = <a 1 b 2>;
+is %pair.WHAT.gist, '(Map)', 'multi-element List constant is a Map';
+is %pair<a>, '1', 'first key';
+is %pair<b>, '2', 'second key';
+
+# Hash literal RHS stays a mutable Hash
+constant %bar = {:10foo, :72bar};
+is %bar.WHAT.gist, '(Hash)', 'constant % from a Hash literal stays a Hash';
+is %bar<foo>, 10, 'hash literal value';
+
+# Pair RHS stays a Pair (already Associative)
+constant %baz = :72baz;
+is %baz.WHAT.gist, '(Pair)', 'constant % from a Pair stays a Pair';
+
+# @-sigiled constant stays a List (unaffected by this fix)
+constant @foo = 42;
+is @foo.WHAT.gist, '(List)', 'constant @ is a List';
+is @foo.raku, '(42,)', 'List constant .raku';


### PR DESCRIPTION
## Summary

`constant %h = <a b>` must render as `Map.new((:a("b")))` per terms.rakudoc: a `%`-sigil constant auto-coerces a non-Associative RHS (a List) to an immutable **Map** via `.Map`, while an already-Associative RHS (a Hash literal or a Pair) is preserved as-is. mutsu was rendering it as a plain `Hash` (`{...}`, `.WHAT` = Hash).

Found via the QA doc-diff harness (terms.rakudoc finding [1]).

## Root cause

`coerce_constant_hash_value` already tagged the coerced hash `declared_type: "Map"`, but two downstream steps in `exec_set_local` stripped it:

1. `coerce_typed_container_assignment` rebuilt the `%` hash via `Value::hash(...)`, dropping the metadata — skipped now for `is_constant` (a `@`/`%` constant is always untyped; a typed one is X::ParametricConstant at compile time, so the call was a pure metadata-stripping no-op for constants).
2. The untyped-`%`/`@` metadata-clear block (meant for `my @a = @typed` not inheriting element types) also ran for constants — gated with `!is_constant`.

Because a `constant %M = (a => 1)` is now a Map, its element assignment hit the container-level "Cannot modify an immutable Map" early return. raku reports the **value-level** `X::Assignment::RO` ("Cannot modify an immutable Int (1)"); the Map-immutable check now defers a readonly, non-`:=`-bound `%`-constant hash to the existing value-level RO path.

## Tests

- New pin `t/constant-hash-map.t`.
- `t/constant-hash-element-ro.t` still passes (value-level RO message preserved).
- Whitelisted `roast/S04-declarations/constant-6.d.t` (asserts `is-deeply %c, Map.new(...)`) and `constant.t` still pass.
- Full `make test` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)