### PR TITLE
fix: (B)-gate seed a scalar-held container from the slot for indexed assignment

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -718,19 +718,46 @@ Two follow-ups landed the same day drove the ON survey **13 → 9**:
   env→slot mirror-back. Flips `sethash-baghash-mixhash-coerce-fn.t`. Pin:
   `t/gate-b-index-incdec-slot-container.t`.
 
-**Still open — ON survey residue (9 files, each a dedicated-session slice):**
+### index-assign scalar-held container — slot seed at handler entry (2026-07-20)
+
+Two of the coerce-RO cluster (`encode-utf8-is-blob.t`, `native-map-hash-coerce.t`)
+were fixed structurally. Root: a scalar local holding a container
+(`my $b = "hi".encode; $b[0] = 200`, `my $m = %h.Map; $m<c> = 9`) skips its env
+mirror under the gate, so `exec_index_assign_expr_named_op_inner` — which reads
+the target container from env in dozens of places — saw the stale `my`-decl seed
+(`Any`) instead of the live Blob/Map, and an immutable-container element/key
+assignment silently did NOT throw. Rather than slot-ify the dozens of env reads
+(the `:delete` attempt proved that whole-handler leaf reordering breaks other
+shapes), the fix **seeds env from the authoritative slot at handler entry**, before
+the env-centric body runs. Two guards keep it precise:
+
+- **Scalar targets only** (bare `var_name`, no `@`/`%` sigil). An aggregate keeps
+  its container in env (aggregate reads are env-first, and env may hold a
+  more-reified lazy/range representation than the slot). Seeding an aggregate from
+  the slot clobbered that — the first cut broke `lazy-array-reify.t` /
+  `lazy-array-reify-on-mutation.t` / `range-slice-assignment.t` (`@a[2] = 99` on a
+  lazy `@a` returned `(Any, Any, 99, Any, Any)`). The sigil guard is exact:
+  `@a[i]` compiles the name as `"@a"`, a scalar `$b[i]` as bare `"b"`.
+- **Variant differs** (`!env.same_variant(slot)`): the scalar decl seed is a type
+  object, so it always differs from a live container; a plain scalar (`Int`) matches
+  and is left untouched.
+
+Gate OFF: byte-identical (skipped early via `gate_local_env_write()`; `make test`
+19092 PASS). Pin: `t/gate-b-index-assign-slot-container.t` (OFF, ON, real raku).
+
+**Still open — ON survey residue (7 files, each a dedicated-session slice):**
 `atomic-ops-native-dispatch.t`, `atomic-ops.t` (cross-thread/atomic, gc-stress-
 gated, flaky-prone); `nextsame-rw-redispatch.t`, `proto-method-rw-redispatch.t`
 (the `is rw`/`is raw` writeback chain through `apply_pending_rw_writeback`'s
 env[source]→slot pull — needs the `env_changed` guard of #4859/#4873, the deepest
-one); `native-map-hash-coerce.t`, `quanthash-immutable-ro.t` (coerce-RO: the
-`:delete` and index-assign container reads are ALSO env-first, but a naive
-slot-first patch regressed 5 ON files — array-hole tracking / nested-delete /
-`:=`-cell / whole-container-bind all assume env, and the failing `:delete` is
-inside a `lives-ok { }` closure, so it also needs closure-capture-container
-coherence — so this cluster is a multi-site + closure entanglement, NOT a
-single-site swap like inc/dec); `encode-utf8-is-blob.t` (RO); and
-`resumable-control-signal-indirect-call.t`, `test-assertion-line-number.t` (misc).
+one); `quanthash-immutable-ro.t` (coerce-RO: the failing `:delete` is inside a
+`lives-ok { }` closure, and a naive slot-first `:delete` patch regressed 5 ON files
+— array-hole tracking / nested-delete / `:=`-cell / whole-container-bind all assume
+env — so this one is a multi-site + closure-capture-container entanglement, NOT a
+single-site swap like inc/dec or the index-assign seed above); and
+`resumable-control-signal-indirect-call.t` (a `CONTROL {}` block captures an
+enclosing `$out` — #4869 closure-fold-adjacent), `test-assertion-line-number.t`
+(CALLER line) (misc).
 
 ## §1.4 flip blast-radius measurement (2026-07-02, debug + release `prove t/`)
 

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -275,6 +275,35 @@ impl Interpreter {
         // The baked slot is for `original_var_name` (the pre-alias target name), so
         // the sigilless-alias write-back below uses it directly — also gated OFF.
         let orig_slot = if shadow_active { target_slot } else { None };
+        // (B) per-store env-write gate: a scalar-held container
+        // (`my $b = "hi".encode; $b[0] = 200`, `my $m = %h.Map; $m<c> = 9`) skips
+        // its env mirror under the gate, so the env reads throughout this
+        // env-centric handler would see the stale `my`-decl seed (Any) instead of
+        // the live Blob/Map — and an immutable-container element assignment would
+        // silently NOT throw. Seed env from the authoritative slot before the
+        // handler runs. Restricted to a SCALAR target (bare name, no `@`/`%`
+        // sigil): an `@`/`%` aggregate keeps its container in env (aggregate reads
+        // are env-first, and env may hold a more-reified lazy/range representation
+        // than the slot — seeding from the slot would clobber that). Only fires
+        // when the slot holds a real value whose variant differs from the env
+        // mirror (the scalar decl seed is a type object, so it always differs from
+        // a live container). Gate OFF: byte-identical (skipped).
+        if crate::opcode::gate_local_env_write()
+            && !var_name.starts_with('@')
+            && !var_name.starts_with('%')
+            && let Some(slot) = self.resolve_local_slot(code, eff_slot, &var_name)
+        {
+            let slot_val = self.locals[slot].clone();
+            if !slot_val.is_nil() {
+                let stale = match self.env().get(&var_name) {
+                    Some(e) => !e.same_variant(&slot_val),
+                    None => true,
+                };
+                if stale {
+                    self.set_env_with_main_alias(&var_name, slot_val);
+                }
+            }
+        }
         // Pre-compute fill value for native typed arrays (e.g. int->0, num->0e0, str->"")
         // Must be done before mutable borrows to avoid borrow conflicts.
         let native_fill = {

--- a/t/gate-b-index-assign-slot-container.t
+++ b/t/gate-b-index-assign-slot-container.t
@@ -1,0 +1,57 @@
+use Test;
+
+# (B) per-store env-write gate (MUTSU_GATE_LOCAL_ENV_WRITE) regression pin.
+#
+# A scalar local holding a container (`my $b = "hi".encode`, `my $m = %h.Map`)
+# skips its env mirror under the gate, so an indexed assignment
+# (`exec_index_assign_expr_named_op_inner`) that reads the container from env
+# would see the stale `my`-decl seed (Any) instead of the live Blob/Map. On an
+# immutable container that made the assignment silently NOT throw. The handler
+# now seeds env from the authoritative slot at entry (gated; OFF byte-identical).
+# This pin passes OFF, ON (MUTSU_GATE_LOCAL_ENV_WRITE=1), and under real raku.
+
+plan 8;
+
+# An encode result is an immutable Blob — element assignment throws.
+{
+    my $died = False;
+    { my $b = "hi".encode; $b[0] = 200; CATCH { default { $died = True } } }
+    ok $died, 'indexed assign on a scalar-held Blob throws (immutable)';
+}
+
+# A Map is immutable — key assignment throws.
+{
+    my %h = a => 1, b => 2;
+    my $m = %h.Map;
+    my $died = False;
+    { $m<c> = 9; CATCH { default { $died = True } } }
+    ok $died, 'indexed assign on a scalar-held Map throws (immutable)';
+}
+
+# A scalar-held mutable Array still assigns in place and is visible.
+{
+    my $a = [1, 2, 3];
+    $a[0] = 99;
+    is $a[0], 99, 'scalar-held Array element assign is visible';
+    is $a.elems, 3, 'scalar-held Array keeps its shape';
+}
+
+# A scalar-held mutable Hash still assigns in place and is visible.
+{
+    my $hh = { x => 1 };
+    $hh<y> = 2;
+    is $hh<x>, 1, 'scalar-held Hash keeps the old key';
+    is $hh<y>, 2, 'scalar-held Hash element assign is visible';
+}
+
+# Plain aggregate lexicals are unaffected (shared-Arc identity).
+{
+    my @arr = 10, 20, 30;
+    @arr[1] = 200;
+    is @arr[1], 200, 'plain @-array element assign is visible';
+}
+{
+    my %hsh = a => 1;
+    %hsh<b> = 2;
+    is %hsh.elems, 2, 'plain %-hash element assign is visible';
+}


### PR DESCRIPTION
## Summary

Part of the `(B)` per-store env-write gate burndown (§1.3, `docs/lexical-scope-slot-campaign.md`). Under `MUTSU_GATE_LOCAL_ENV_WRITE=1`, a scalar local holding a container (`my $b = "hi".encode`, `my $m = %h.Map`) skips its env mirror, so `exec_index_assign_expr_named_op_inner` — which reads the target container from env in many places — saw the stale `my`-decl seed (`Any`) instead of the live Blob/Map. On an immutable container that made an element/key assignment (`$b[0] = 200`, `$m<c> = 9`) silently **not** throw.

## Fix

Seed env from the authoritative slot at handler entry, before the env-centric body runs. Two guards keep it precise:

- **Scalar targets only** (bare name, no `@`/`%` sigil): an aggregate keeps its container in env (aggregate reads are env-first, and env may hold a more-reified lazy/range representation than the slot). Seeding an aggregate from the slot clobbered that — caught `lazy-array-reify` / `range-slice-assignment` on the first cut.
- **Variant differs**: the scalar decl seed is a type object, so it always differs from a live container; a plain scalar (`Int`) matches and is not touched.

Gate OFF: byte-identical (skipped early via `gate_local_env_write()`).

## Results

- `(B)`-gate ON survey: **9 → 7** failing `t/` files (`encode-utf8-is-blob`, `native-map-hash-coerce` cleared; no new regressions).
- `make test` 19092 PASS (OFF byte-identical).
- Pin: `t/gate-b-index-assign-slot-container.t` (OFF, ON, real raku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)