### PR TITLE
fix: allow `our multi` candidates under an `our proto` in the same scope

### DIFF
--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -317,6 +317,17 @@ impl Compiler {
                     {
                         custom_traits.push(("__lexical_hoist".to_string(), None));
                     }
+                    // Mark every hoist-pass registration (including the mainline
+                    // hoist, which passes `lexical_hoist == false`) so the
+                    // `our multi` scope check can skip this early pass and instead
+                    // validate at in-sequence registration, where an `our proto`
+                    // declared later in the same scope is already registered.
+                    if !custom_traits
+                        .iter()
+                        .any(|(trait_name, _)| trait_name == "__hoisted")
+                    {
+                        custom_traits.push(("__hoisted".to_string(), None));
+                    }
                     // Strip user-defined custom traits during hoisting.
                     // Traits like `is description(...)` require types/roles to be
                     // registered first; they will be applied during the normal pass.

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -649,7 +649,17 @@ impl Interpreter {
         });
         if multi {
             let single_key = format!("{}::{}", self.current_package(), name);
-            if is_our_scoped && !self.registry().proto_subs.contains(&single_key) {
+            // Skip this check during the hoist pass. Sub declarations (including
+            // multi candidates) are hoisted and registered before the
+            // in-sequence `RegisterProtoSub` for an `our proto` runs, so at hoist
+            // time the proto is not yet in `proto_subs`. Each multi candidate is
+            // also re-registered in textual order, which runs *after* the proto;
+            // that in-sequence registration enforces the check with the proto
+            // present. (`is_lexical_hoist` only marks block-scope hoists; the
+            // mainline hoist uses the separate `__hoisted` marker.)
+            let is_hoisted =
+                is_lexical_hoist || custom_traits.iter().any(|(t, _)| t == "__hoisted");
+            if is_our_scoped && !is_hoisted && !self.registry().proto_subs.contains(&single_key) {
                 let mut attrs = std::collections::HashMap::new();
                 attrs.insert("scope".to_string(), Value::str("our".to_string()));
                 attrs.insert(

--- a/t/our-proto-multi.t
+++ b/t/our-proto-multi.t
@@ -1,0 +1,27 @@
+use v6;
+use Test;
+
+# `our multi sub` candidates are legal when an `our proto` for the same name is
+# declared in the same scope (rakudo: "Cannot use 'our' with individual multi
+# candidates. Please declare an our-scoped proto instead"). Regression: mutsu
+# hoists sub declarations (including multi candidates) before the in-sequence
+# `our proto` registration ran, so the scope check fired against an empty proto
+# table and rejected valid `our proto` + `our multi` groups (real dists such as
+# JavaScript::Google::Charts declare their API this way).
+
+plan 5;
+
+our proto sub gen($data, :$version) {*}
+our multi sub gen(Int $data, :$version = 'row') { "int:$version" }
+our multi sub gen(Str $data, :$version = 'col') { "str:$version" }
+
+is gen(1), 'int:row', 'our multi Int candidate dispatches';
+is gen('x'), 'str:col', 'our multi Str candidate dispatches';
+is gen('x', :version<z>), 'str:z', 'named arg reaches the our multi candidate';
+
+# proto declared textually before the candidates, candidates before use.
+is gen(42, :version<v>), 'int:v', 'first candidate honours the passed named arg';
+
+# An `our multi` with no proto at all is still rejected.
+throws-like 'our multi sub nope($x) { $x }', X::Declaration::Scope::Multi,
+    'our multi without an our proto is rejected';


### PR DESCRIPTION
## Summary

Rakudo rejects `our multi sub foo` only when **no** `our proto` for that name is declared. With an `our proto` present, the individual `our multi` candidates are legal — real fez dists such as **JavaScript::Google::Charts** declare their whole API this way:

```raku
our proto sub generate-code($data, :$version) {*}
our multi sub generate-code($data, :$version = 'row-by-row', ...) { ... }
```

mutsu rejected **every** `our multi` with `X::Declaration::Scope::Multi` ("Cannot declare individual multi candidates in 'our' scope"), even when a matching `our proto` was declared just above.

## Root cause

mutsu hoists sub declarations (including multi candidates) to the top of a scope and registers them **before** the in-sequence `RegisterProtoSub` for the `our proto` runs. The scope check therefore fired during the hoist pass against a still-empty proto table. The mainline hoist passes `lexical_hoist == false`, so the pre-existing `__lexical_hoist` marker did not cover it.

## Fix

Mark every hoist-pass sub registration with a `__hoisted` custom trait and skip the `our multi` scope check when it is set. Each multi candidate is **also** re-registered in textual order — that in-sequence registration runs *after* the `our proto` and enforces the check with the proto present, so an `our multi` with no proto at all is still correctly rejected.

## Impact

`JavaScript::Google::Charts` / `::DataTable` advance from `runtime_error` to `missing_dep` (`Data::TypeSystem`) in the dist-compat sweep — no longer a mutsu bug.

## Testing

- New pin: `t/our-proto-multi.t` (dispatch of `our multi` candidates under an `our proto`; `our multi` without a proto still rejected).
- `make test`: PASS (2013 files, 19117 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)