### PR TITLE
fix: (B)-gate fold a resume-safe CONTROL handler's frame into needs_env_sync

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -745,7 +745,26 @@ the env-centric body runs. Two guards keep it precise:
 Gate OFF: byte-identical (skipped early via `gate_local_env_write()`; `make test`
 19092 PASS). Pin: `t/gate-b-index-assign-slot-container.t` (OFF, ON, real raku).
 
-**Still open — ON survey residue (7 files, each a dedicated-session slice):**
+### resume-safe CONTROL handler — needs_env_sync fold (2026-07-20)
+
+`resumable-control-signal-indirect-call.t` cleared. A frame that installs a
+resume-safe CONTROL handler (`CONTROL { default { $out ~= .Str; .resume } }`)
+has its handler run INLINE at a deep `warn` raise site
+(`try_resume_safe_control_inline`, builtins_control_flow.rs), which reconstructs
+the installing frame's locals FROM ENV by name — `self.locals` is the deep
+raise-site frame, and env is the cross-frame store. Under the gate a plain
+`my $out = ''` in the installing frame skips its env mirror, so the handler
+reconstructed a stale `$out` and its `~=` was lost (`out=[]` not `out=[[direct]]`).
+Fix: extend the `compute_needs_env_sync` lazy-body fold
+(`RegisterSub`/`RegisterClass`/`RegisterRole`) to also match a
+`TryCatch { resume_safe: true }` op with a control range — keep every local of
+such a frame env-synced. Same shape as the #4869 named-sub fold and the #4889
+class/role-method fold: gated on `gate_local_env_write()` (the whole fold block
+is), so the default build is byte-identical and perf-neutral; the installing
+frame is a block/main frame, never a hot loop. Pin:
+`t/gate-b-control-handler-env-sync.t` (OFF, ON, real raku).
+
+**Still open — ON survey residue (6 files, each a dedicated-session slice):**
 `atomic-ops-native-dispatch.t`, `atomic-ops.t` (cross-thread/atomic, gc-stress-
 gated, flaky-prone); `nextsame-rw-redispatch.t`, `proto-method-rw-redispatch.t`
 (the `is rw`/`is raw` writeback chain through `apply_pending_rw_writeback`'s
@@ -755,9 +774,7 @@ one); `quanthash-immutable-ro.t` (coerce-RO: the failing `:delete` is inside a
 — array-hole tracking / nested-delete / `:=`-cell / whole-container-bind all assume
 env — so this one is a multi-site + closure-capture-container entanglement, NOT a
 single-site swap like inc/dec or the index-assign seed above); and
-`resumable-control-signal-indirect-call.t` (a `CONTROL {}` block captures an
-enclosing `$out` — #4869 closure-fold-adjacent), `test-assertion-line-number.t`
-(CALLER line) (misc).
+`test-assertion-line-number.t` (CALLER line) (misc).
 
 ## §1.4 flip blast-radius measurement (2026-07-02, debug + release `prove t/`)
 

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2484,7 +2484,27 @@ impl CompiledCode {
                     OpCode::RegisterSub(_) | OpCode::RegisterClass(_) | OpCode::RegisterRole(_)
                 )
             });
-            if defines_lazy_body {
+            // A frame that installs a *resume-safe* CONTROL handler
+            // (`CONTROL { default { $out ~= .Str; .resume } }`) has its handler run
+            // INLINE at a deep `warn` raise site (`try_resume_safe_control_inline`),
+            // which reconstructs the installing frame's locals FROM ENV by name (the
+            // cross-frame store) because `self.locals` is the deep raise-site frame.
+            // Under the gate a plain `my $out = ''` in this frame skips its env
+            // mirror, so the handler reconstructs a stale `$out` and its `~=` is
+            // lost. Keep every local of such a frame env-synced (gate-ON only; the
+            // installing frame is a block/main frame, never a hot loop).
+            let installs_resume_control = self.ops.iter().any(|op| {
+                matches!(
+                    op,
+                    OpCode::TryCatch {
+                        resume_safe: true,
+                        control_start,
+                        body_end,
+                        ..
+                    } if control_start < body_end
+                )
+            });
+            if defines_lazy_body || installs_resume_control {
                 self.needs_env_sync.iter_mut().for_each(|b| *b = true);
             }
         }

--- a/t/gate-b-control-handler-env-sync.t
+++ b/t/gate-b-control-handler-env-sync.t
@@ -1,0 +1,49 @@
+use Test;
+
+# (B) per-store env-write gate (MUTSU_GATE_LOCAL_ENV_WRITE) regression pin.
+#
+# A frame that installs a resume-safe CONTROL handler
+# (`CONTROL { default { ...; .resume } }`) has its handler run INLINE at a deep
+# `warn` raise site, which reconstructs the installing frame's locals FROM ENV by
+# name (self.locals is the deep raise-site frame). Under the gate a plain
+# `my $out = ''` in that frame skips its env mirror, so the handler reconstructs a
+# stale `$out` and its mutation is lost. compute_needs_env_sync now folds every
+# local of such a frame back into needs_env_sync (gated; OFF byte-identical).
+# This pin passes OFF, ON (MUTSU_GATE_LOCAL_ENV_WRITE=1), and under real raku.
+
+plan 5;
+
+{
+    my $out = '';
+    CONTROL { default { $out ~= "[{.message}]"; .resume; } }
+    warn "direct";
+    is $out, '[direct]', 'direct warn mutates the captured $out';
+    pass 'execution continues after a direct warn';
+}
+
+{
+    my $out = '';
+    CONTROL { default { $out ~= "[{.message}]"; .resume; } }
+    my $w = &warn;
+    $w.("indirect");
+    is $out, '[indirect]', 'indirect warn via &warn.() mutates $out';
+}
+
+{
+    my @seen;
+    CONTROL { default { @seen.push(.message); .resume; } }
+    my $w = &warn;
+    $w.("one");
+    $w.("two");
+    is @seen.join(','), 'one,two', 'consecutive indirect warns accumulate';
+}
+
+# A running counter mutated across several resumed warns.
+{
+    my $n = 0;
+    CONTROL { default { $n++; .resume; } }
+    warn "a";
+    warn "b";
+    warn "c";
+    is $n, 3, 'counter accumulates across three resumed warns';
+}


### PR DESCRIPTION
## Summary

Part of the `(B)` per-store env-write gate burndown (§1.3, `docs/lexical-scope-slot-campaign.md`). Under `MUTSU_GATE_LOCAL_ENV_WRITE=1`, a frame that installs a **resume-safe CONTROL handler** (`CONTROL { default { $out ~= .Str; .resume } }`) broke.

## Root cause

The handler is run **inline** at a deep `warn` raise site (`try_resume_safe_control_inline`), which reconstructs the installing frame's locals **from env by name** — `self.locals` is the deep raise-site frame, so env is the only cross-frame store available. A plain `my $out = ''` in the installing frame skips its env mirror under the gate, so the handler reconstructed a stale `$out` and its `~=` was lost:

```raku
my $out = '';
CONTROL { default { $out ~= "[{.message}]"; .resume; } }
warn "direct";
say "out=[$out]";   # gate ON: out=[]  (expected out=[[direct]])
```

## Fix

Extend the `compute_needs_env_sync` lazy-body fold (`RegisterSub`/`RegisterClass`/`RegisterRole`) to also match a `TryCatch { resume_safe: true }` op with a control range: keep every local of such a frame env-synced. Same shape as the #4869 named-sub fold and #4889 class/role-method fold — gated on `gate_local_env_write()` (the whole fold block already is), so the default build is byte-identical and perf-neutral; the installing frame is a block/main frame, never a hot loop.

## Results

- `(B)`-gate ON survey: `resumable-control-signal-indirect-call.t` clears (**7 → 6** on top of #4894).
- `make test` 19084 PASS (OFF byte-identical).
- Pin: `t/gate-b-control-handler-env-sync.t` (OFF, ON, real raku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)