### PR TITLE
fix: (B)-gate fold an interpolating-regex frame into needs_env_sync

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -764,17 +764,32 @@ is), so the default build is byte-identical and perf-neutral; the installing
 frame is a block/main frame, never a hot loop. Pin:
 `t/gate-b-control-handler-env-sync.t` (OFF, ON, real raku).
 
-**Still open — ON survey residue (6 files, each a dedicated-session slice):**
+### interpolating regex matched cross-frame — needs_env_sync fold (2026-07-20)
+
+`test-assertion-line-number.t` cleared. A regex literal that interpolates a lexical
+(`/ ... $script ... /`) may be matched in a DIFFERENT frame: `like $err, / ...
+$script ... /` passes the regex to `like`, which runs `$err ~~ $regex` internally,
+and `interpolate_regex_scalars` resolves `$script` from the name-keyed env (the
+cross-frame store), not the constructing frame's slots. Under the gate a plain
+`my $script = ...` skips its env mirror, so the interpolation read a stale/empty
+value and the match failed (the test's caller-line regex, whose `$script` filename
+never reached the match inside `like`). Fix: extend the `compute_needs_env_sync`
+fold to also match a frame whose constant pool holds an *interpolating* regex value
+(`ValueView::Regex` with `!regex_pattern_is_static` — the same conservative check
+the match cache uses, so a static regex folds nothing) — keep every local of such a
+frame env-synced. Same gate-ON-only shape as the #4869 / #4889 / CONTROL folds; OFF
+byte-identical and perf-neutral. Pin: `t/gate-b-regex-interp-env-sync.t`.
+
+**Still open — ON survey residue (5 files, each a dedicated-session slice):**
 `atomic-ops-native-dispatch.t`, `atomic-ops.t` (cross-thread/atomic, gc-stress-
 gated, flaky-prone); `nextsame-rw-redispatch.t`, `proto-method-rw-redispatch.t`
 (the `is rw`/`is raw` writeback chain through `apply_pending_rw_writeback`'s
 env[source]→slot pull — needs the `env_changed` guard of #4859/#4873, the deepest
-one); `quanthash-immutable-ro.t` (coerce-RO: the failing `:delete` is inside a
+one); and `quanthash-immutable-ro.t` (coerce-RO: the failing `:delete` is inside a
 `lives-ok { }` closure, and a naive slot-first `:delete` patch regressed 5 ON files
 — array-hole tracking / nested-delete / `:=`-cell / whole-container-bind all assume
 env — so this one is a multi-site + closure-capture-container entanglement, NOT a
-single-site swap like inc/dec or the index-assign seed above); and
-`test-assertion-line-number.t` (CALLER line) (misc).
+single-site swap like inc/dec or the index-assign seed above).
 
 ## §1.4 flip blast-radius measurement (2026-07-02, debug + release `prove t/`)
 

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2504,7 +2504,24 @@ impl CompiledCode {
                     } if control_start < body_end
                 )
             });
-            if defines_lazy_body || installs_resume_control {
+            // A frame that constructs a regex value which interpolates a lexical
+            // (`/ ... $script ... /`) may have that regex matched in a DIFFERENT
+            // frame — e.g. `like $err, / ... $script ... /` matches inside `like`,
+            // whose `interpolate_regex_scalars` resolves `$script` from the
+            // name-keyed env (the cross-frame store), not this frame's slots. Under
+            // the gate a plain `my $script = ...` skips its env mirror, so the
+            // interpolation reads a stale/empty value. Keep every local of a frame
+            // that holds an interpolating regex constant env-synced (gate-ON only;
+            // the pattern is checked with the same conservative `regex_pattern_is_
+            // static` used for the match cache, so a static regex folds nothing).
+            let holds_interpolating_regex = self.constants.iter().any(|c| {
+                matches!(
+                    c.view(),
+                    ValueView::Regex(p)
+                        if !crate::runtime::regex_parse::regex_pattern_is_static(p.as_str())
+                )
+            });
+            if defines_lazy_body || installs_resume_control || holds_interpolating_regex {
                 self.needs_env_sync.iter_mut().for_each(|b| *b = true);
             }
         }

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -65,7 +65,7 @@ pub(crate) static TOKEN_DEFS_GEN: std::sync::atomic::AtomicU64 =
 /// `$<name>` capture forms, or `@$var` derefs. This stays a conservative
 /// superset of what the parser substitutes; false "dynamic" only costs cache
 /// misses, never correctness.
-pub(super) fn regex_pattern_is_static(pattern: &str) -> bool {
+pub(crate) fn regex_pattern_is_static(pattern: &str) -> bool {
     fn starts_variable_form(c: char) -> bool {
         c.is_alphanumeric() || matches!(c, '_' | '{' | '(' | '<' | '*' | '?' | '^' | '.' | '!')
     }

--- a/t/gate-b-regex-interp-env-sync.t
+++ b/t/gate-b-regex-interp-env-sync.t
@@ -1,0 +1,43 @@
+use Test;
+
+# (B) per-store env-write gate (MUTSU_GATE_LOCAL_ENV_WRITE) regression pin.
+#
+# A regex literal that interpolates a lexical (`/ ... $script ... /`) may be
+# matched in a DIFFERENT frame — e.g. `like $err, / ... $script ... /` matches
+# inside `like`, whose interpolate_regex_scalars resolves `$script` from the
+# name-keyed env (the cross-frame store), not the constructing frame's slots.
+# Under the gate a plain `my $script = ...` skips its env mirror, so the
+# interpolation read a stale/empty value and the match failed. compute_needs_env_sync
+# now folds every local of a frame holding an interpolating regex constant back
+# into needs_env_sync (gated; OFF byte-identical). Passes OFF, ON, and real raku.
+
+plan 5;
+
+# The failing shape from test-assertion-line-number.t: a lexical interpolated
+# into a regex matched by the `like` builtin (a different frame).
+{
+    my $script = 'myfile.raku';
+    my $err := "at myfile.raku line 4\n";
+    like $err, /'at ' $script ' line ' 4/, 'lexical interpolated in a like regex';
+}
+
+# Direct cross-frame match via a user sub.
+{
+    my $needle = 'wanted';
+    sub finds($hay, $rx) { $hay ~~ $rx }
+    ok finds("has wanted here", /$needle/), 'lexical interpolated in a regex matched cross-frame';
+}
+
+# Inline match in the same frame still works.
+{
+    my $pat = 'abc';
+    ok 'xabcx' ~~ /$pat/, 'inline interpolated regex match';
+}
+
+# The interpolated value tracks reassignment.
+{
+    my $p = 'one';
+    $p = 'two';
+    ok 'the two here' ~~ /$p/, 'reassigned lexical interpolates its live value';
+    nok 'the one here' ~~ /$p/, 'old value no longer matches';
+}


### PR DESCRIPTION
## Summary

Part of the `(B)` per-store env-write gate burndown (§1.3, `docs/lexical-scope-slot-campaign.md`). Under `MUTSU_GATE_LOCAL_ENV_WRITE=1`, a regex literal that interpolates a lexical (`/ ... $script ... /`) broke when the regex was matched in a **different frame**.

## Root cause

`like $err, / ... $script ... /` passes the regex to `like`, which runs `$err ~~ $regex` internally. `interpolate_regex_scalars` resolves `$script` from the name-keyed env (the cross-frame store), not the constructing frame's slots. A plain `my $script = ...` skips its env mirror under the gate, so the interpolation read a stale/empty value and the match failed — the exact shape of `test-assertion-line-number.t`, whose `$script` filename never reached the match inside `like`:

```raku
my $script = 'myfile.raku';
my $err := "at myfile.raku line 4\n";
like $err, /'at ' $script ' line ' 4/, '...';   # gate ON: not ok
```

## Fix

Extend the `compute_needs_env_sync` fold to also match a frame whose constant pool holds an **interpolating** regex value (`ValueView::Regex` with `!regex_pattern_is_static` — the same conservative check the match cache uses, so a static regex folds nothing): keep every local of such a frame env-synced. Same gate-ON-only shape as the #4869 / #4889 / CONTROL-handler folds; OFF byte-identical and perf-neutral (the scan is inside the existing `if gate_local_env_write()` block).

## Results

- `(B)`-gate ON survey: `test-assertion-line-number.t` clears (**6 → 5** on top of #4896).
- `make test` 19146 PASS (OFF byte-identical).
- Pin: `t/gate-b-regex-interp-env-sync.t` (OFF, ON, real raku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)