### PR TITLE
fix: allow a newline before a `qq:to`/`q:to` heredoc delimiter

### DIFF
--- a/docs/dist-compat-sweep.md
+++ b/docs/dist-compat-sweep.md
@@ -137,27 +137,35 @@ Known root causes to date:
 | ~~Trie~~ | **Cleared post-snapshot**: was a set-operator compound assignment on an indexed lvalue (`%!decendents{char} ∪= …`) the parser rejected. Parse error gone; now only lacks its `OrderedHash` dependency (missing_dep). |
 | ~~Prime::Factor~~ | **Cleared post-snapshot**: was a sigilless parameter (`\N`) carrying a `where` constraint (`multi divisors (Int \N where BIG, …)`) that the param parser rejected. Now loads and factors correctly. |
 
-### runtime_error (14 remaining; Astro::Sunrise cleared post-snapshot)
+### runtime_error (12 remaining; Astro::Sunrise / JavaScript::Google::Charts / App::pixelpick cleared post-snapshot)
 
 | Dist | Root cause |
 |---|---|
 | Protocol::MQTT | `Invalid typename 'DecodeBuffer' in parameter declaration.` — a sibling type in the enclosing package (same family as #4865; `DecodeBuffer` is likely nested deeper / declared via a form the prefix-walk still misses). |
 | SQL::Abstract | `No matching candidate found for the parametric role` — advanced past four typename blockers by #4865; now blocked on parametric-role resolution in its `does Constant['…']` / `does Op::Prefix['…']` chains. |
-| JavaScript::Google::Charts | `Cannot declare individual multi candidates in 'our' scope`. |
 | PDF::Font::Loader::CSS | `X::Syntax::Perl5Var: Unsupported use of $? variable` — a genuine `$?`-in-regex Perl5-ism (verify against raku before "fixing"). |
-| uniname-words | `Odd number of elements found where hash initializer expected` (load-time). |
+| uniname-words | `Odd number of elements found where hash initializer expected` (load-time) — an `nqp::hash(...)` in a `BEGIN` block; guts-bound, not pursued. |
 | Repository::Precomp::Cleanup | `No such method 'id' for invocant of type 'Compiler'`. |
 | Test::Scheduler | `Scheduler is not composable, so Test::Scheduler cannot compose it`. |
 | Bits | `An exception occurred while evaluating a CHECK` (load-time CHECK phaser). |
-| App::pixelpick | `X::Undeclared::Symbols: Undeclared routine` (load-time). |
 | RakudoContainerfileBuilder | prints a `Usage:` block at load — a MAIN/`is export` interaction. |
 | App::fix.raku / Lingua::NumericWordForms | `self-module not found` — packaging/name-mismatch (provided module name ≠ what `use` resolves). |
 | Testo | non-zero exit with no diagnostic captured — needs a direct run to classify. |
 
-**Cleared post-snapshot:** IDNA::Punycode (was `Unexpected block in infix
-position` — a statement label on a C-style `loop (init; cond; step)` that the
-labeled-loop parser did not handle) now loads; its `decode_punycode` still hits
-a separate list-assignment runtime bug, a Level-2 concern.
+**Cleared post-snapshot:**
+
+- IDNA::Punycode (was `Unexpected block in infix position` — a statement label
+  on a C-style `loop (init; cond; step)` that the labeled-loop parser did not
+  handle) now loads; its `decode_punycode` still hits a separate
+  list-assignment runtime bug, a Level-2 concern.
+- JavaScript::Google::Charts (was `Cannot declare individual multi candidates in
+  'our' scope` — mutsu hoisted the `our multi` candidates before the in-sequence
+  `our proto` registered, so the scope check fired against an empty proto table;
+  fixed in #4895) now advances to `missing_dep` (`Data::TypeSystem`).
+- App::pixelpick (was `X::Undeclared::Symbols: Undeclared routine: qq:to` — a
+  `say qq:to` heredoc whose quoted delimiter sits on the next line; mutsu's
+  delimiter scanner trimmed only spaces, not the newline) now advances to
+  `missing_dep` (`Color::Names`).
 
 ## missing_dep — reachable once deps are present (not mutsu bugs)
 

--- a/src/parser/primary/string/heredoc.rs
+++ b/src/parser/primary/string/heredoc.rs
@@ -43,9 +43,17 @@ fn logical_line_end(r: &str) -> Option<usize> {
 }
 
 pub(crate) fn parse_to_heredoc_delimiter(input: &str) -> PResult<'_, &'_ str> {
-    // Raku allows optional whitespace before the delimiter in q:to/Q:to
-    // forms, e.g. q:to /END/;
-    let input = input.trim_start_matches(' ');
+    // Raku allows optional whitespace — including a newline — before the
+    // delimiter in q:to/qq:to forms, e.g. `q:to /END/;` and the form where the
+    // quoted delimiter sits on the next line:
+    //     say qq:to
+    //     '====='
+    //     body
+    //     =====
+    // The delimiter itself must still be a non-alphanumeric quote/bracket char
+    // (a bareword after the whitespace is rejected below, matching rakudo's
+    // "Alphanumeric character is not allowed as a delimiter").
+    let input = input.trim_start();
     let open = input
         .chars()
         .next()

--- a/t/heredoc-newline-delimiter.t
+++ b/t/heredoc-newline-delimiter.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+# A `qq:to` / `q:to` heredoc may have whitespace — including a newline — between
+# the `:to` adverb and the quoted delimiter, e.g. when the delimiter sits on the
+# line below in list-op / parenthesised argument position:
+#
+#     say qq:to
+#     '====='
+#     body
+#     =====
+#
+# Real dists (App::pixelpick's USAGE block) write their heredocs this way.
+# Regression: mutsu's delimiter scanner only trimmed spaces, so a newline before
+# the delimiter made it reject the heredoc and mis-parse `qq:to` as a routine
+# call ("Undeclared routine: qq:to").
+
+plan 4;
+
+my $a = (qq:to
+"END"
+hello world
+END
+);
+is $a.chomp, 'hello world', 'qq:to with a newline before a "-delimiter';
+
+my $b = (q:to
+'====='
+plain text
+=====
+);
+is $b.chomp, 'plain text', "q:to with a newline before a '-delimiter";
+
+# Interpolation still works in the newline form.
+my $who = 'raku';
+my $c = (qq:to
+"STOP"
+hi $who
+STOP
+);
+is $c.chomp, 'hi raku', 'interpolation works in the newline-delimiter form';
+
+# The classic inline form is unaffected.
+my $d = qq:to/FIN/;
+inline body
+FIN
+is $d.chomp, 'inline body', 'inline qq:to/FIN/ still works';


### PR DESCRIPTION
## Summary

Raku accepts a `:to` heredoc whose quoted delimiter sits on the line **below** the `:to` adverb, when the construct is in list-op / parenthesised argument position:

```raku
say qq:to
'====='
body
=====
```

Real fez dists write their `USAGE` blocks this way (**App::pixelpick**). mutsu rejected it with `X::Undeclared::Symbols: Undeclared routine: qq:to used at line 1`.

## Root cause

mutsu's heredoc delimiter scanner (`parse_to_heredoc_delimiter`) trimmed only **spaces** (`trim_start_matches(' ')`) before the delimiter. A newline therefore left the scanner looking at `\n`, which it rejects as whitespace, so the whole `qq:to` failed to parse as a heredoc and fell back to being parsed as a routine call.

## Fix

Trim **all** leading whitespace (including the newline / tab) before the delimiter. A bareword after the whitespace is still rejected — the delimiter must be a non-alphanumeric quote/bracket char — matching rakudo's "Alphanumeric character is not allowed as a delimiter". This only *expands* acceptance to the whitespace-before-delimiter case; every previously valid parse is unchanged.

## Impact

App::pixelpick advances from `runtime_error` to `missing_dep` (`Color::Names`) in the dist-compat sweep. Also refreshes the dashboard to mark App::pixelpick and JavaScript::Google::Charts (#4895) cleared post-snapshot.

## Testing

- New pin `t/heredoc-newline-delimiter.t` — passes identically under `raku` and `mutsu` (the `"`- and `'`-delimiter newline forms, interpolation, and the classic inline `qq:to/FIN/`).
- `make test`: PASS.
- `roast/S02-literals/{heredocs,quoting}.t`, `roast/S03-operators/adverbial-modifiers.t`: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)