### PR TITLE
ci: build the Docker image on version tags only, not every main push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,12 +4,17 @@ name: Docker
 # `docker run`. Multi-arch (amd64 + arm64) images are built natively on
 # per-arch runners, then combined into one manifest — no slow QEMU emulation of
 # the release compile.
+#
+# Trigger: version tags only (plus manual workflow_dispatch for smoke tests). We
+# deliberately do NOT build on every `main` push — a multi-arch release compile
+# per merge is expensive, the image rarely breaks between releases, and the
+# release-tag build already produces the published `:X.Y.Z`/`:latest` images
+# that users actually pull. (The `:main` rolling tag is dropped as a result; it
+# was redundant with `:latest` for anyone tracking releases.)
 on:
   push:
     tags:
       - 'v*'
-    branches:
-      - main
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## What

Remove the `push: branches: main` trigger from the Docker workflow. The image is now built on `v*` tags (releases) and manual `workflow_dispatch` only.

## Why

Per @tokuhirom: building the container on every `main` push is overkill — "building at release timing is enough, and it rarely breaks." Each main push triggered a full multi-arch (amd64 + arm64) native release compile across two runners. That's a lot of CI for an artifact that:

- rarely breaks between releases, and
- is already published as `:X.Y.Z` / `:latest` by the release-tag build (which is what users actually `docker pull`).

## Effect

- No Docker build on merges to `main` → less CI load / runner contention on every PR merge.
- The rolling `:main` tag is dropped (it was redundant with `:latest` for release-trackers).
- Release-tag builds and `workflow_dispatch` smoke tests are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)