### PR TITLE
fix: keep quoted/comma args when interpolating a method call in a string

### DIFF
--- a/docs/dist-compat-sweep.md
+++ b/docs/dist-compat-sweep.md
@@ -130,7 +130,7 @@ Known root causes to date:
 | Dist | Root cause |
 |---|---|
 | SSH::LibSSH::Tunnel | `Cannot have a 'whenever' block outside the scope of a 'supply' or 'react' block` — a `whenever` reached at load time (likely a react/supply parse gap). |
-| SBOM::CycloneDX | `unparsed input, column 5: "}\n… @*ERRORS"` — a `@*ERRORS` dynamic var / trailing brace parse dead-end. |
+| SBOM::CycloneDX | `unparsed input, column 5: "}\n… @*ERRORS"` — the reported line (the `}` closing `method ingest`) is the last-good boundary, **not** the cause: the `@*ERRORS`/`with…else`/private-method-call constructs there all parse in isolation. The real desync is a still-unisolated construct in the tail `Map`/`Hash` methods (deep `mapify` ternary, `my role ordered-list[@NAMES]`, `$map but ordered-list[@keys]`) that forces the whole-role parse to backtrack. Investigating it surfaced a *separate* general bug — interpolated `.join(", ")` (a method arg carrying the string's own quote/comma) was mis-split, fixed separately — but that was not the SBOM blocker. Needs a finer tail-method repro. |
 | CSS | inside a `grammar` ("angle index key") — grammar/regex-slang, heavier. |
 | ~~Bench~~ | **Cleared post-snapshot**: a tightly-bound `<=>` used as a quote-word / hash key / colonpair value (`:fill<=>`, `%h<=>`) was mis-parsed as the spaceship operator by three separate angle parsers. Now loads. |
 | Pod::Contents / Deps / Configuration / File-TreeBuilder / App::Rak / Astro::Utils / Audio::Liquidsoap / IP::Random / Math::Matrix / ML::SparseMatrixRecommender / CSV::Table / Cro::FCGI | generic `expected statement…` dead-end — each needs its own repro; several carry multiple blockers (bisect at balanced method boundaries). |

--- a/src/parser/primary/string/interp_helpers.rs
+++ b/src/parser/primary/string/interp_helpers.rs
@@ -132,18 +132,28 @@ pub(crate) fn try_parse_interp_method_call(input: &str, target: Expr) -> (Expr, 
         chain.push((method_name.to_string(), is_quoted, method_prefix));
         // Check if followed by (...) — parse args
         if after_name.starts_with('(') {
-            // Find matching closing paren
+            // Find the matching closing paren, skipping any parens that appear
+            // inside a quoted string argument (e.g. `.join(", ")` or
+            // `.subst(")", "")`) so the delimiter-matching quote does not close
+            // the arg list early.
             let mut depth = 0usize;
             let mut paren_end = None;
+            let mut in_s = false;
+            let mut in_d = false;
             for (idx, ch) in after_name.char_indices() {
-                if ch == '(' {
-                    depth += 1;
-                } else if ch == ')' {
-                    depth -= 1;
-                    if depth == 0 {
-                        paren_end = Some(idx);
-                        break;
+                match ch {
+                    '\'' if !in_d => in_s = !in_s,
+                    '"' if !in_s => in_d = !in_d,
+                    _ if in_s || in_d => {}
+                    '(' => depth += 1,
+                    ')' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            paren_end = Some(idx);
+                            break;
+                        }
                     }
+                    _ => {}
                 }
             }
             if let Some(pe) = paren_end {
@@ -152,12 +162,18 @@ pub(crate) fn try_parse_interp_method_call(input: &str, target: Expr) -> (Expr, 
                 // Build the full chain
                 for (i, (name, quoted, modifier)) in chain.iter().enumerate() {
                     let args = if i == chain.len() - 1 {
-                        // Last method gets the args
+                        // Last method gets the args. Split on top-level commas
+                        // only — a comma inside a quoted arg (`.join(", ")`) or a
+                        // nested bracket must not split the argument list.
                         if args_str.trim().is_empty() {
                             vec![]
                         } else {
                             let mut args = vec![];
-                            for arg in args_str.split(',') {
+                            for arg in
+                                crate::parser::primary::string::interp_var::split_top_level_commas(
+                                    args_str,
+                                )
+                            {
                                 let arg = arg.trim();
                                 if let Ok((_, e)) = crate::parser::expr::expression(arg) {
                                     args.push(e);

--- a/src/parser/primary/string/interp_var.rs
+++ b/src/parser/primary/string/interp_var.rs
@@ -10,7 +10,7 @@ use crate::value::Value;
 /// `"%h{$x, $y}"` interpolation builds a slice rather than parsing only the
 /// first index. Returns the original string as a single part when there is no
 /// top-level comma.
-fn split_top_level_commas(content: &str) -> Vec<&str> {
+pub(crate) fn split_top_level_commas(content: &str) -> Vec<&str> {
     let mut parts = Vec::new();
     let mut depth = 0i32;
     let mut start = 0usize;

--- a/t/interp-method-arg-quotes.t
+++ b/t/interp-method-arg-quotes.t
@@ -1,0 +1,33 @@
+use v6;
+use Test;
+
+# A method call interpolated in a string may take arguments that contain the
+# string's own delimiter quote and/or a comma, e.g. `"@a.join(", ")"`. mutsu's
+# interpolation parser split the argument list on every comma (splitting the
+# quoted `", "` literal into two broken fragments) and did not skip quotes when
+# matching the closing paren, so the separator argument was dropped and
+# `.join(", ")` behaved like `.join()`.
+
+plan 6;
+
+my @a = <a b c>;
+is "list: @a.join(", ")!", 'list: a, b, c!',
+    'interpolated .join with a quoted "," argument keeps the separator';
+
+is "x: @a.join(" | ")", 'x: a | b | c',
+    'interpolated .join with a spaced quoted separator';
+
+my $s = 'a)b)c';
+is "y: $s.subst(")", "-")", 'y: a-b)c',
+    'interpolated .subst with a close-paren inside a quoted argument';
+
+# Single-quoted argument inside a double-quoted string.
+is "z: @a.join(', ')", 'z: a, b, c',
+    'interpolated .join with a single-quoted separator';
+
+# A comma-free quoted argument still works (no regression).
+is "u: @a.join("-")", 'u: a-b-c',
+    'interpolated .join with a simple quoted separator';
+
+# No-arg method chains (with parens) are unaffected.
+is "v: @a.elems()", 'v: 3', 'interpolated no-arg method call still works';


### PR DESCRIPTION
## Summary

A method call interpolated in a string may take arguments containing the string's own delimiter quote and/or a comma:

```raku
my @a = <a b c>;
say "list: @a.join(", ")!";   # raku: "list: a, b, c!"   mutsu: "list: abc!"
```

mutsu dropped such arguments, so `.join(", ")` behaved like `.join()`.

## Root cause

In the string-interpolation method-call parser (`try_parse_interp_method_call`):

1. The closing-paren scan for `.method(...)` did not skip quoted strings.
2. The argument list was split with `args_str.split(',')`, so a comma inside a quoted argument (`", "`) tore the string literal into two broken fragments, both of which failed to parse as expressions → the argument vanished.

## Fix

- Make the paren scan quote-aware (track `'`/`"` state), so a `)` inside a quoted argument (`.subst(")", "-")`) doesn't close the arg list early.
- Split the interpolated argument list on **top-level** commas only, reusing the existing `split_top_level_commas` helper (now `pub(crate)`), which already respects quotes and nested brackets.

## Testing

- New pin `t/interp-method-arg-quotes.t` — passes identically under `raku` and `mutsu` (quoted `,` separator, spaced separator, close-paren inside a quoted arg, single-quoted arg, simple arg, no-arg chain).
- `make test`: PASS.
- `roast/S02-literals/{quoting,quoting-unicode,array-interpolation,hash-interpolation,misc-interpolation,string-interpolation,fmt-interpolation}.t`: PASS.

Found while investigating **SBOM::CycloneDX** (a separate, still-unisolated tail-method parse blocker — the `.join(", ")` mis-parse was a red herring there but a genuine general bug); dashboard note refined accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)