### PR TITLE
ci: cache deps via Swatinem/rust-cache in bench and release workflows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -33,17 +33,15 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@1.96.0
 
-      - name: Cache cargo
-        uses: actions/cache@v6
+      # rust-cache restores the registry + built dependencies (small, reliable)
+      # instead of the whole multi-GB target/. Deliberately NOT mold-linked: this
+      # job produces the numbers recorded in the perf trend, and switching the
+      # linker would shift the binary layout, injecting a one-time step into that
+      # trend. Keep the default linker so the recorded series stays continuous.
+      - name: Cache cargo (rust-cache)
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-bench-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            cargo-bench-${{ runner.os }}-
-            cargo-${{ runner.os }}-
+          shared-key: "ci-bench"
 
       - name: Install rakudo (for the ratio baseline)
         # Best-effort: if the package is unavailable the script records NA

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,15 +51,15 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Cache cargo
-        uses: actions/cache@v6
+      # rust-cache restores the registry + built dependencies instead of the
+      # whole multi-GB target/, which is faster and far more reliable than the
+      # raw actions/cache (which frequently overran the cache-size limit and
+      # missed). `shared-key` is the target triple so each matrix leg keeps its
+      # own cache (the four targets produce incompatible artifacts).
+      - name: Cache cargo (rust-cache)
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-release-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-release-${{ matrix.target }}-
+          shared-key: ${{ matrix.target }}
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
## What

Replace the raw `actions/cache` (of `~/.cargo` + the whole multi-GB `target/`) with `Swatinem/rust-cache` in both remaining workflows.

- **bench.yml** — single `ci-bench` cache. **No mold**: this job produces the numbers recorded in the perf trend (the source of truth for perf docs), so switching the linker would shift binary layout and inject a one-time step into that series. Linker stays default; only the cache layer changes.
- **release.yml** — per-target cache keyed by the matrix triple, since the four cross-compile targets (linux x64/arm64, macOS x64/arm64) produce incompatible artifacts.

## Why

rust-cache stores the registry + built *dependencies* (pruning the workspace crate) for a small, reliable restore, instead of stuffing the entire `target/` into `actions/cache` — which was slow and frequently overran the cache-size limit and missed entirely.

## Scope note

This completes the CI-cache migration started in #4902 (which handled `ci.yml`). mold was intentionally left out of both: bench for perf-trend integrity, release because conditional mold across a macOS-inclusive matrix adds risk for a rare, tag-only job where the dependency-cache restore is the real win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)