### PR TITLE
fix: (B)-gate read the first-candidate rw value slot-first on redispatch

### DIFF
--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -152,6 +152,27 @@ impl Interpreter {
     /// Shared implementation for callsame/nextsame/callwith/nextwith.
     /// `override_args`: if Some, use these args instead of the original.
     /// `tail_call`: if true, raise a return-control exception with the result.
+    /// Read the FIRST candidate's live rw-param value during a nextsame/callsame
+    /// redispatch. The first candidate's body ran `$x = ...` before deferring, and
+    /// under the (B) env-write gate that mutation lands only in its VM local slot
+    /// (the env write is skipped) — so read the slot of the currently-executing
+    /// frame (`self.current_code`/`self.locals`) first and fall back to env.
+    /// Under gate OFF, env mirrors the slot, so returning env directly is
+    /// byte-identical.
+    fn first_candidate_rw_value(&self, first_param: &str) -> Option<Value> {
+        if crate::opcode::gate_local_env_write() && self.current_code != 0 {
+            // SAFETY: `self.current_code` is the CompiledCode of the frame that is
+            // synchronously executing this nextsame/callsame — the first candidate.
+            let code = unsafe { &*(self.current_code as *const crate::opcode::CompiledCode) };
+            if let Some(slot) = code.locals.iter().position(|n| n == first_param)
+                && let Some(val) = self.locals.get(slot)
+            {
+                return Some(val.clone());
+            }
+        }
+        self.env.get(first_param).cloned()
+    }
+
     fn dispatch_next_candidate(
         &mut self,
         func_name: &str,
@@ -343,7 +364,7 @@ impl Interpreter {
                     if *pos >= call_args.len() {
                         continue;
                     }
-                    if let Some(cur) = self.env.get(first_param).cloned() {
+                    if let Some(cur) = self.first_candidate_rw_value(first_param) {
                         call_args[*pos] = crate::runtime::types::unwrap_varref_value(cur);
                     }
                     rw_sources[*pos] = Some(first_param.clone());
@@ -514,7 +535,7 @@ impl Interpreter {
                     let caller_source =
                         crate::runtime::types::indexed_varref_from_value(&arg).map(|(n, _, _)| n);
                     // The first candidate's live (body-mutated) param value.
-                    if let Some(cur) = self.env.get(first_param).cloned() {
+                    if let Some(cur) = self.first_candidate_rw_value(first_param) {
                         call_args[*pos] =
                             match crate::runtime::types::indexed_varref_from_value(&arg) {
                                 Some((name, _, index)) => {

--- a/src/runtime/dispatch_proto_call.rs
+++ b/src/runtime/dispatch_proto_call.rs
@@ -15,18 +15,30 @@ impl Interpreter {
             // `{*}` rw-redispatch for a proto *method* (ledger §D): like the proto
             // *sub* path (`vm_call_proto_dispatch`), Rakudo redispatches with the
             // proto's CURRENT (body-mutated) parameter, and a candidate's `is rw`
-            // param needs a writable argument. The interpreter binds method params
-            // by name into env, so the current value lives in env (`code = None`).
-            // Rebuild the rw args + arg_sources so the candidate matches and its
-            // writeback chains back through the proto method param to the caller.
+            // param needs a writable argument. The proto method body runs compiled
+            // (`compile_method_def_in_place`), so its `$x = ...` mutation lands in a
+            // VM local slot; under the (B) env-write gate that write is not mirrored
+            // to env, so the live value must be read from the currently-executing
+            // proto-body frame's slot. Pass its `CompiledCode` (via `self.current_code`,
+            // which is exactly that frame at the `{*}`/`__PROTO_DISPATCH__` point) so
+            // `proto_rw_redispatch_args` reads slot-first. Gate OFF keeps `None`
+            // (env mirrors the slot, byte-identical).
             let invocant_class = match ctx.invocant.view() {
                 ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
                 _ => None,
             };
+            let proto_body_code: Option<&CompiledCode> =
+                if crate::opcode::gate_local_env_write() && self.current_code != 0 {
+                    // SAFETY: `self.current_code` is the CompiledCode of the compiled
+                    // proto-method body synchronously executing this `{*}` dispatch.
+                    Some(unsafe { &*(self.current_code as *const CompiledCode) })
+                } else {
+                    None
+                };
             let (args, rw_sources) = match invocant_class
                 .and_then(|cn| self.lookup_proto_method(&cn, &proto_name))
                 .and_then(|(_, proto)| {
-                    self.proto_rw_redispatch_args(&proto.param_defs, &args, None)
+                    self.proto_rw_redispatch_args(&proto.param_defs, &args, proto_body_code)
                 }) {
                 Some((rebuilt, sources)) => (rebuilt, Some(sources)),
                 None => (args, None),

--- a/t/gate-b-rw-redispatch-slot-read.t
+++ b/t/gate-b-rw-redispatch-slot-read.t
@@ -1,0 +1,100 @@
+use Test;
+
+# Pin for the (B) per-store env-write gate rw-redispatch slot-read fix
+# (docs/lexical-scope-slot-campaign.md, "(B) per-store env-write gate — burndown").
+#
+# A nextsame/callsame (multi sub or multi method) or a proto `{*}` redispatch must
+# forward the FIRST candidate's / proto body's CURRENT (body-mutated) rw parameter
+# value to the next candidate. That candidate body runs compiled, so its `$x = ...`
+# mutation lands in a VM local slot. Under MUTSU_GATE_LOCAL_ENV_WRITE the store's
+# env mirror is skipped, so the redispatch used to read the STALE env value (the
+# entry-time / decl-seed value) and forward it, breaking the rw chain:
+#   - nextsame sub:    `$v` ended 1010 instead of 1011 (first `+1` not chained)
+#   - proto method:    candidate saw the caller value 1 instead of the body's 30
+# The fix reads the live value slot-first from the currently-executing frame
+# (`self.current_code`/`self.locals`) — `first_candidate_rw_value` on the
+# nextsame/callsame path, and passing the compiled proto-body `CompiledCode` to
+# `proto_rw_redispatch_args` on the `{*}` path. Gate OFF (default) is byte-identical
+# (env mirrors the slot). This file passes gate-OFF and would fail gate-ON before
+# the fix.
+
+plan 8;
+
+# --- nextsame in a multi SUB chains the first candidate's rw write ---
+{
+    multi pr(Int $x is rw) { $x = $x + 1; nextsame }
+    multi pr($x is rw)     { $x = $x + 1000 }
+    my $v = 10;
+    pr($v);
+    is $v, 1011, 'nextsame sub chains the first candidate rw write';
+}
+
+# --- three-candidate nextsame chain in a multi SUB ---
+{
+    multi tri(Int $x is rw where * < 100)   { $x = $x + 1;   nextsame }
+    multi tri(Int $x is rw where * < 10000) { $x = $x + 100; nextsame }
+    multi tri($x is rw)                     { $x = $x + 1000 }
+    my $v = 5;
+    tri($v);
+    is $v, 1106, 'three-candidate nextsame+rw chain in a sub';
+}
+
+# --- differently-named rw params still chain (source routes by position) ---
+{
+    multi nm(Int $a is rw) { $a = $a + 1; nextsame }
+    multi nm($b is rw)     { $b = $b + 1000 }
+    my $v = 10;
+    nm($v);
+    is $v, 1011, 'differently-named rw params chain in a sub';
+}
+
+# --- nextsame in a multi METHOD chains the rw write ---
+{
+    class C {
+        multi method pr(Int $x is rw) { $x = $x + 1; nextsame }
+        multi method pr($x is rw)     { $x = $x + 1000 }
+    }
+    my $v = 10;
+    C.pr($v);
+    is $v, 1011, 'nextsame method chains the first candidate rw write';
+}
+
+# --- proto METHOD body mutation is visible to the candidate ---
+{
+    class C1 {
+        proto method m($x is rw) { $x = 30; {*} }
+        multi method m(Int $x is rw) { $x = $x + 3 }
+    }
+    my $v = 1; C1.new.m($v);
+    is $v, 33, 'proto method body mutation reaches the candidate';
+}
+
+# --- proto method aliases by position, not by name ---
+{
+    class C2 {
+        proto method m($a is rw) { $a = 10; {*} }
+        multi method m(Int $b is rw) { $b = $b * 5 }
+    }
+    my $v = 2; C2.new.m($v);
+    is $v, 50, 'proto method redispatch aliases by position';
+}
+
+# --- proto method with no body mutation; candidate mutates from caller value ---
+{
+    class C3 {
+        proto method m($x is rw) { {*} }
+        multi method m(Int $x is rw) { $x = $x + 9 }
+    }
+    my $v = 4; C3.new.m($v);
+    is $v, 13, 'proto method candidate rw write propagates without body mutation';
+}
+
+# --- `is raw` proto method param chains like `is rw` ---
+{
+    class C5 {
+        proto method m($x is raw) { $x = 7; {*} }
+        multi method m(Int $x is raw) { $x = $x + 1 }
+    }
+    my $v = 1; C5.new.m($v);
+    is $v, 8, 'is raw proto method param chains like is rw';
+}


### PR DESCRIPTION
## Summary

Part of the (B) per-store env-write gate burndown (`MUTSU_GATE_LOCAL_ENV_WRITE`, docs/lexical-scope-slot-campaign.md). Fixes the **rw-redispatch** cluster: a `nextsame`/`callsame` redispatch (multi sub or multi method) and a proto `{*}` redispatch forwarded a **stale** rw-parameter value to the next candidate, breaking the `is rw`/`is raw` writeback chain.

Repro under the gate:
- `multi pr(Int $x is rw){$x=$x+1;nextsame} multi pr($x is rw){$x=$x+1000}` → `$v` ended **1010** instead of **1011**.
- `proto method m($x is rw){$x=30;{*}} multi method m(Int $x is rw){$x=$x+3}` → candidate saw **1** (caller value) instead of **30** → **4** instead of **33**.

## Root cause

The winning/proto candidate body runs compiled, so its `$x = ...` mutation lands in a VM local slot. Under the gate the store's env mirror is skipped, but the redispatch read the first candidate's *current* value from `self.env` by name → the pre-mutation (decl-seed / entry-time) value.

## Fix (both gated on `gate_local_env_write()`, gate OFF byte-identical)

- `dispatch_next_candidate` reads the first candidate's live rw value via a new `first_candidate_rw_value` helper — slot of the currently-executing frame (`self.current_code`/`self.locals`) first, then env. Covers the `multi_dispatch_stack` (sub) and `method_dispatch_stack` (method) arms.
- `call_proto_dispatch` passes the compiled proto-body `CompiledCode` (`self.current_code` at the `{*}`/`__PROTO_DISPATCH__` point) to `proto_rw_redispatch_args` so it reads slot-first instead of falling back to a stale env value.

Gate OFF (default, used by CI `make test`/`make roast`) is byte-identical — env mirrors the slot, so both paths read the same value they did before.

## Verification

- Gate-ON t/ survey: **5 → 3** remaining failures (both `t/nextsame-rw-redispatch.t` and `t/proto-method-rw-redispatch.t` now pass under the gate).
- Gate OFF: 54 dispatch/proto/multi/nextsame/callsame/samewith tests pass; new pin passes both modes.
- Pin: `t/gate-b-rw-redispatch-slot-read.t` (passes gate-OFF and gate-ON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)