### PR TITLE
fix: bind nested named-parameter alias chains (`:type(:class($kind))`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -4171,7 +4171,15 @@ impl CompiledFunction {
             let mut alias_keys = Vec::new();
             let mut alias_binds = Vec::new();
             if let Some(ref sub_params) = pd.sub_signature {
-                for sub_pd in sub_params {
+                // A named alias can chain: `:type(:class($kind))` nests further
+                // renames. Walk every level so all caller-facing alias keys
+                // (`class`) match and the innermost variable (`$kind`, the one
+                // the body reads) is bound. A worklist avoids recursion here.
+                let mut worklist: Vec<&crate::ast::ParamDef> = sub_params.iter().collect();
+                let mut idx = 0;
+                while idx < worklist.len() {
+                    let sub_pd = worklist[idx];
+                    idx += 1;
                     if sub_pd.named {
                         alias_keys.push(
                             sub_pd
@@ -4184,6 +4192,9 @@ impl CompiledFunction {
                     // On a match (by any key), every sub-signature name is
                     // bound to the value — e.g. `:color(:$colour)` binds both.
                     alias_binds.push((sub_pd.name.clone(), slot_of(&sub_pd.name)));
+                    if let Some(ref nested) = sub_pd.sub_signature {
+                        worklist.extend(nested.iter());
+                    }
                 }
             }
             let mut outer_alias_keys = Vec::new();

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -443,7 +443,7 @@ impl Interpreter {
         let explicit_named_keys: rustc_hash::FxHashSet<String> = param_defs
             .iter()
             .filter(|pd| (pd.named || pd.name.starts_with(':')) && !pd.slurpy)
-            .map(|pd| {
+            .flat_map(|pd| {
                 let name = if pd.name.starts_with(':') {
                     &pd.name[1..]
                 } else if let Some(rest) = pd
@@ -465,7 +465,14 @@ impl Interpreter {
                 } else {
                     &pd.name
                 };
-                name.to_string()
+                // A nested alias chain (`:variety(:style(...))`) makes every
+                // level's name a valid caller key, so exclude them all from the
+                // slurpy `*%rest` capture too.
+                let mut keys = vec![name.to_string()];
+                if let Some(sub_params) = &pd.sub_signature {
+                    keys.extend(collect_nested_named_alias_keys(sub_params));
+                }
+                keys
             })
             .collect();
         let mut positional_idx = 0usize;
@@ -995,20 +1002,16 @@ impl Interpreter {
                         break;
                     }
                 }
-                // Alias matching: for :a(:$b), also accept b => val
+                // Alias matching: for :a(:$b), also accept b => val. A nested
+                // chain (`:variety(:style(:sort($x)))`) lets the caller use any
+                // level's name, so match against every alias key down the chain.
                 if !found && let Some(sub_params) = &pd.sub_signature {
-                    for sub_pd in sub_params {
-                        if found {
-                            break;
-                        }
-                        if !sub_pd.named {
-                            continue;
-                        }
-                        let inner_key = sub_pd.name.strip_prefix(':').unwrap_or(&sub_pd.name);
+                    let alias_keys = collect_nested_named_alias_keys(sub_params);
+                    'alias: for inner_key in &alias_keys {
                         for arg in args.iter().rev() {
                             let arg = unwrap_varref_value(arg.clone());
                             if let ValueView::Pair(key, inner_val) = arg.view()
-                                && key == inner_key
+                                && key == inner_key.as_str()
                             {
                                 self.bind_param_value(&pd.name, inner_val.clone());
                                 self.bind_param_type_constraint(
@@ -1017,7 +1020,7 @@ impl Interpreter {
                                 );
                                 bind_named_rename_sub_signature(self, sub_params, inner_val)?;
                                 found = true;
-                                break;
+                                break 'alias;
                             }
                         }
                     }
@@ -1093,8 +1096,15 @@ impl Interpreter {
                     // bindings live under twigil'd keys (`$!x`/`!x`), not the bare
                     // param name — so binding the default here does not disturb them.
                     let value = Self::missing_optional_param_value(pd);
-                    self.bind_param_value(&pd.name, value);
+                    self.bind_param_value(&pd.name, value.clone());
                     self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
+                    // A `:color(:$colour)` alias chain declares its inner
+                    // variable(s); bind them to the same unsupplied default so
+                    // the body's `$colour` read finds an (undefined) value
+                    // instead of throwing "not declared".
+                    if let Some(sub_params) = &pd.sub_signature {
+                        bind_named_rename_sub_signature(self, sub_params, &value)?;
+                    }
                 }
                 // Check the where constraint against the *bound* value, whether it
                 // came from the supplied argument, the parameter default, or the
@@ -1885,13 +1895,15 @@ impl Interpreter {
                         {
                             return true;
                         }
-                        // Also check inner named aliases from sub-signatures
-                        if let Some(sub_params) = &pd.sub_signature {
-                            for sp in sub_params {
-                                if sp.named && sp.name == *key {
-                                    return true;
-                                }
-                            }
+                        // Also check inner named aliases from sub-signatures,
+                        // descending a nested alias chain (`:variety(:style(...))`)
+                        // so a caller key at any level is recognized.
+                        if let Some(sub_params) = &pd.sub_signature
+                            && collect_nested_named_alias_keys(sub_params)
+                                .iter()
+                                .any(|k| k == key)
+                        {
+                            return true;
                         }
                         false
                     });

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -14,8 +14,9 @@ mod type_registry;
 // Re-export public items from submodules
 pub(crate) use coercion::{coerce_impossible_error, is_coercion_constraint, parse_coercion_type};
 pub(in crate::runtime) use signature::{
-    bind_named_rename_sub_signature, bind_sub_signature_from_value, encode_slurpy_rw_param,
-    flatten_into_slurpy, indexed_varref_from_value, sigilless_alias_key, sigilless_readonly_key,
+    bind_named_rename_sub_signature, bind_sub_signature_from_value,
+    collect_nested_named_alias_keys, encode_slurpy_rw_param, flatten_into_slurpy,
+    indexed_varref_from_value, sigilless_alias_key, sigilless_readonly_key,
     sub_signature_matches_value, sub_signature_target_from_remaining_args, varref_from_value,
     wrap_native_int_for_binding,
 };

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -483,6 +483,27 @@ pub(in crate::runtime) fn sub_signature_matches_value(
 
 /// Bind a named parameter's sub-signature for renaming (e.g., `:a(:$b)`).
 /// Unlike destructuring, the value is bound directly to each inner param.
+/// Collect every caller-facing named-alias key in a (possibly nested) named
+/// alias chain. `:variety(:style(:sort($x)))` yields `["style", "sort"]` — the
+/// outermost name (`variety`) is the param's own match key and is handled by the
+/// caller; every nested `:name(...)` level adds another key the caller may use.
+pub(in crate::runtime) fn collect_nested_named_alias_keys(sub_params: &[ParamDef]) -> Vec<String> {
+    let mut keys = Vec::new();
+    let mut worklist: Vec<&ParamDef> = sub_params.iter().collect();
+    let mut idx = 0;
+    while idx < worklist.len() {
+        let sp = worklist[idx];
+        idx += 1;
+        if sp.named {
+            keys.push(sp.name.strip_prefix(':').unwrap_or(&sp.name).to_string());
+        }
+        if let Some(nested) = &sp.sub_signature {
+            worklist.extend(nested.iter());
+        }
+    }
+    keys
+}
+
 pub(in crate::runtime) fn bind_named_rename_sub_signature(
     interpreter: &mut Interpreter,
     sub_params: &[ParamDef],
@@ -527,6 +548,12 @@ pub(in crate::runtime) fn bind_named_rename_sub_signature(
         }
         interpreter.bind_param_value(bind_name, value.clone());
         interpreter.set_var_type_constraint(bind_name, sub_pd.type_constraint.clone());
+        // A named alias can chain: `:type(:class($kind))` nests a further
+        // rename under this alias. The innermost variable (`$kind`) is the one
+        // the body actually reads, so recurse to bind every level down to it.
+        if let Some(nested) = &sub_pd.sub_signature {
+            bind_named_rename_sub_signature(interpreter, nested, value)?;
+        }
     }
     Ok(())
 }

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -271,6 +271,15 @@ impl Interpreter {
                             .insert(cf.param_defs[i].name.clone(), Value::NIL);
                     }
                 }
+                // A `:color(:$colour)` alias chain also declares its inner
+                // variable(s); when the param is unsupplied they must still be
+                // in scope (undefined), else the body's `$colour` read throws.
+                for (alias_name, alias_slot) in &npb.alias_binds {
+                    if let Some(slot) = alias_slot {
+                        self.locals[*slot] = Value::NIL;
+                    }
+                    self.env_mut().insert(alias_name.clone(), Value::NIL);
+                }
                 continue;
             };
             let v = v.clone();

--- a/t/nested-named-alias-param.t
+++ b/t/nested-named-alias-param.t
@@ -1,0 +1,41 @@
+use v6;
+use Test;
+
+# A named parameter's alias can chain: `:type(:class($kind))` nests a further
+# rename under the alias. The innermost variable (`$kind`) is the one the body
+# reads; every level's name (`type`, `class`) is a valid caller-facing key.
+# Regression: mutsu only bound/matched one alias level, so a two-or-more-level
+# chain threw "Variable 'kind' is not declared" (body) or "Unexpected named
+# argument" (deep caller key). See raku-doc Language/signatures.rakudoc.
+
+plan 12;
+
+# --- two-level chain (signatures.rakudoc example) ---
+sub two(:color(:$colour), :type(:class($kind))) {
+    "$colour $kind"
+}
+is two(color => "red",   type  => "A"), "red A",   "two-level: outer names";
+is two(colour => "green", type => "B"), "green B", "two-level: inner alias + outer";
+is two(color => "white", class => "C"), "white C", "two-level: deepest alias key";
+
+# --- five-level chain (signatures.rakudoc example) ---
+sub five(:color(:$colour),
+         :variety(:style(:sort(:type(:class($kind)))))) {
+    "$colour $kind"
+}
+is five(color => "red",    style   => "A"), "red A",   "five-level: mid key 'style'";
+is five(colour => "green", variety => "B"), "green B", "five-level: outermost key 'variety'";
+is five(color => "white",  class   => "C"), "white C", "five-level: deepest key 'class'";
+
+# Every level's name is accepted by the caller.
+for <variety style sort type class> -> $k {
+    my %args = ($k => "X");
+    is five(|%args), " X", "five-level: caller key '$k' binds \$kind";
+}
+
+# A consumed nested-alias key must not leak into a `*%rest` slurpy.
+sub with-rest(:type(:class($kind)), *%rest) {
+    "$kind " ~ %rest.keys.sort.join(",")
+}
+is with-rest(class => "C", other => 1), "C other",
+    "nested alias key excluded from *%rest";


### PR DESCRIPTION
## Summary

A named parameter's alias can chain: `:type(:class($kind))` nests a further rename under the alias. Raku lets the caller use **any** level's name (`type`, `class`) while the body reads the innermost variable (`$kind`). mutsu only handled a single alias level, so a two-or-more level chain threw:

- `X::Undeclared::Symbols: Variable 'kind' is not declared` when the body read the inner variable, or
- `Unexpected named argument 'class' passed` when the caller used a deeper alias key.

Both examples are from `raku-doc/doc/Language/signatures.rakudoc` (doc-diff QA findings [5] and [14]):

```raku
sub alias-named(:color(:$colour),
                :variety(:style(:sort(:type(:class($kind)))))) {
    return $colour ~ " " ~ $kind
}
say alias-named(color => "red", style => "A");   # red A
say alias-named(colour => "green", variety => "B"); # green B
say alias-named(color => "white", class => "C");  # white C
```

## Fixes

Named-param binding happens in three code paths; all needed the recursion, plus the missing-param seeding:

- **Fast named-light call plan** (`precompute_named_call_plan`, `opcode.rs`): walk the whole `sub_signature` chain so every alias key matches and every inner variable is bound (was one level).
- **Full binder** (`bind_named_rename_sub_signature`): recurse into a sub-param's own `sub_signature` so the innermost variable is bound.
- **Full binder alias matching**, the **unexpected-named-argument** check, and the **`*%rest` exclusion set**: match/exclude against every alias key down the chain via a new shared `collect_nested_named_alias_keys` helper.
- **Unsupplied optional nested-alias param** now seeds its inner variable(s) to the default (undefined) on both paths, so `$colour` reads as undefined instead of throwing — a pre-existing gap that also affected a single-level `:color(:$colour)` left unsupplied.

## Tests

- Pin: `t/nested-named-alias-param.t` (12 subtests: two- and five-level chains, every caller key level, `*%rest` exclusion).
- `make test` (19168 tests) green; `S06-signature/*.t` roast green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)