### PR TITLE
fix: indirect method call `$obj.$type` uses the type object's name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -15,6 +15,18 @@ impl Interpreter {
         }
     }
 
+    /// Derive the method name for an indirect call `$obj.$name`. A **type
+    /// object** used as the name specifier (`$string.$type` with `$type = Int`)
+    /// dispatches the method named by its short name (`.Int`), so use that name
+    /// rather than the type object's gist (`(Int)`). Any other value falls back
+    /// to its string form (mutsu treats a plain `Str` as a method name).
+    fn dynamic_method_name(name_val: &Value) -> String {
+        match name_val.view() {
+            ValueView::Package(name) => name.resolve(),
+            _ => name_val.to_string_value(),
+        }
+    }
+
     pub(super) fn exec_call_method_dynamic_op(
         &mut self,
         code: &CompiledCode,
@@ -43,7 +55,7 @@ impl Interpreter {
             RuntimeError::new("Interpreter stack underflow in CallMethodDynamic target")
         })?;
         // Force lazy IO lines for non-lazy-preserving methods
-        let method_name_str = name_val.to_string_value();
+        let method_name_str = Self::dynamic_method_name(&name_val);
         let method = Self::rewrite_method_name(&method_name_str, modifier);
         let target = if matches!(target.view(), ValueView::LazyIoLines { .. })
             && !matches!(method.as_str(), "kv" | "iterator" | "lazy")
@@ -80,7 +92,7 @@ impl Interpreter {
             call_args.extend(args);
             self.vm_call_on_value(name_val, call_args, None)
         } else {
-            let method = name_val.to_string_value();
+            let method = Self::dynamic_method_name(&name_val);
             // .return method: triggers a return from the enclosing sub
             if method == "return" && args.is_empty() {
                 let mut err = RuntimeError::new("return");
@@ -277,7 +289,7 @@ impl Interpreter {
         let target = self.stack.pop().ok_or_else(|| {
             RuntimeError::new("Interpreter stack underflow in CallMethodDynamicMut")
         })?;
-        let method_name_str = name_val.to_string_value();
+        let method_name_str = Self::dynamic_method_name(&name_val);
         let method = Self::rewrite_method_name(&method_name_str, modifier);
         // Handle .* and .+ modifiers
         match modifier {

--- a/t/dynamic-method-type-object.t
+++ b/t/dynamic-method-type-object.t
@@ -1,0 +1,36 @@
+use v6;
+use Test;
+
+# An indirect method call `$obj.$name` where `$name` is a TYPE OBJECT
+# dispatches the method named by the type's short name: `$string.$type` with
+# `$type = Int` calls `.Int`. mutsu previously stringified the type object to
+# its gist (`(Int)`) and threw "No such method '(Int)'".
+# From raku-doc Language/signatures.rakudoc (doc-diff finding [11]).
+
+plan 8;
+
+sub can-turn-into(Str $string, Any:U $type) {
+    so $string.$type
+}
+ok  can-turn-into("3",        Int), '"3".$Int is True';
+ok  can-turn-into("6.5",      Int), '"6.5".$Int is True';
+ok  can-turn-into("6.5",      Num), '"6.5".$Num is True';
+nok can-turn-into("a string", Num), '"a string".$Num is False';
+
+# The type object's method is really invoked (not just truthiness).
+my $t = Int;
+is "6.5".$t, 6, 'type object $Int calls .Int (6.5.Int == 6)';
+
+my $s = Str;
+is "6.5".$s, "6.5", 'type object $Str calls .Str';
+
+# A user-defined class type object resolves the method named by the class
+# (here `.Widget`), rather than the type object's gist `(Widget)`.
+class Widget { }
+my $w = Widget;
+throws-like { 42.$w }, X::Method::NotFound,
+    'user class type object looks up the class-named method (.Widget)';
+
+# A plain Str name specifier still names a method (mutsu extension, unchanged).
+my $m = "uc";
+is "abc".$m, "ABC", 'Str name specifier still dispatches by method name';


### PR DESCRIPTION
## Summary

An indirect method call `$obj.$name` where `$name` is a **type object** dispatches the method named by the type's short name: `$string.$type` with `$type = Int` calls `.Int`. mutsu stringified the name value with `to_string_value()`, which renders a type object as its gist (`(Int)`), so the call threw `No such method '(Int)'`.

Doc example from `raku-doc/doc/Language/signatures.rakudoc` (doc-diff finding [11]):

```raku
sub can-turn-into(Str $string, Any:U $type) {
   return so $string.$type;
}
say can-turn-into("3", Int);        # True   (was: No such method '(Int)')
say can-turn-into("6.5", Num);      # True
say can-turn-into("a string", Num); # False
```

## Fix

Derive the dynamic method name via a new `dynamic_method_name` helper (in `vm_call_method_mut_ops.rs`) that returns a `Package` (type object) value's **short name** and falls back to the string form for everything else. Applied at all three name-derivation sites in the `CallMethodDynamic`/`CallMethodDynamicMut` handlers.

A plain `Str` name specifier still names a method (an existing mutsu behavior), unchanged.

## Tests

- Pin: `t/dynamic-method-type-object.t`.
- `make test` (19164 tests) green; `S12-methods/*.t` roast green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)