### PR TITLE
fix: (B)-gate fold a closure's scalar-held container mutation into needs_env_sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2463,6 +2463,31 @@ impl CompiledCode {
                         self.needs_env_sync[slot] = true;
                     }
                 }
+                // A nested closure whose ONLY use of an outer SCALAR is an
+                // in-place container mutation (`$bh<a>:delete`, `$h<k> = v`,
+                // `$a[i]++`) never records that scalar in `free_var_syms`: those
+                // ops are classified as container mutations, and the
+                // container-write free-var set is filtered to `@`/`%` aggregates
+                // (a scalar holding a Bag/Hash/Array is neither). Under the gate
+                // the outer `my $bh = <a a b>.BagHash` skips its env mirror, so
+                // when the closure runs by-name in a carrier (`lives-ok { … }`)
+                // its `:delete` reads the decl-seed `Any` from env and the
+                // mutation vanishes. Fold such scalars into `needs_env_sync` too,
+                // so the outer store keeps mirroring the live container. Gate-ON
+                // only, so the default build is byte-identical / perf-neutral.
+                for op in &nested.ops {
+                    if let Some(idx) = nested.op_container_mutate_const_idx(op)
+                        && let Some(ValueView::Str(name)) =
+                            nested.constants.get(idx as usize).map(Value::view)
+                        && !name.starts_with('@')
+                        && !name.starts_with('%')
+                        && !name.starts_with('&')
+                        && !nested.locals.iter().any(|l| l.as_str() == name.as_str())
+                        && let Some(&slot) = locals_map.get(name.as_str())
+                    {
+                        self.needs_env_sync[slot] = true;
+                    }
+                }
             }
             // A NAMED sub (`sub f { ... }`) is not embedded in
             // `closure_compiled_codes` — it is registered from `stmt_pool` via a

--- a/t/gate-b-closure-scalar-container-delete.t
+++ b/t/gate-b-closure-scalar-container-delete.t
@@ -1,0 +1,34 @@
+use v6;
+use Test;
+
+# (B)-gate regression pin: a nested closure whose ONLY use of an outer SCALAR
+# is an in-place container mutation (`$bh<a>:delete`) never recorded that scalar
+# as a free variable (element-delete is classified as a container mutation, and
+# the container-write free-var set is filtered to `@`/`%` aggregates — a scalar
+# holding a Bag/Hash/Array is neither). Under MUTSU_GATE_LOCAL_ENV_WRITE the
+# outer `my $bh = <a a b>.BagHash` skips its env mirror, so when the closure ran
+# by-name inside a carrier (`lives-ok { ... }`) the `:delete` read the decl-seed
+# `Any` from env and the mutation vanished. Must pass identically with the gate
+# OFF (default) and ON.
+
+plan 8;
+
+# BagHash held in a scalar, deleted inside a lives-ok carrier closure.
+my $bh = <a a b>.BagHash;
+lives-ok { $bh<a>:delete }, 'BagHash :delete in carrier lives';
+is $bh<a>, 0, 'BagHash key removed through carrier closure';
+
+# Plain Hash held in a scalar.
+my $h = { a => 1, b => 2 };
+lives-ok { $h<a>:delete }, 'scalar Hash :delete in carrier lives';
+is $h.elems, 1, 'scalar Hash key removed through carrier closure';
+
+# SetHash held in a scalar.
+my $sh = <a b>.SetHash;
+lives-ok { $sh<a>:delete }, 'SetHash :delete in carrier lives';
+is $sh<a>, False, 'SetHash key removed through carrier closure';
+
+# Array element delete held in a scalar, mutated inside a carrier closure.
+my $a = [10, 20, 30];
+lives-ok { $a[1]:delete }, 'scalar Array [i]:delete in carrier lives';
+is $a[1]:exists, False, 'scalar Array element removed through carrier closure';


### PR DESCRIPTION
## Problem

Under `MUTSU_GATE_LOCAL_ENV_WRITE` (the (B)-gate burndown), `t/quanthash-immutable-ro.t` test 12 failed: a `BagHash` `:delete` inside a `lives-ok { ... }` carrier did not remove the key.

Root cause: a nested closure whose **only** use of an outer **scalar** is an in-place container mutation (`$bh<a>:delete`, `$h<k> = v`, `$a[i]++`) never recorded that scalar as a free variable. Element delete/assign/inc-dec are classified as *container mutations*, and the container-write free-var set is filtered to `@`/`%` aggregates — a scalar holding a Bag/Hash/Array is neither, so it fell through every free-var set.

With the gate on, the outer `my $bh = <a a b>.BagHash` skips its env mirror (the slot is authoritative), leaving `env<bh>` at its decl-seed `Any`. When the closure then ran by-name inside a carrier (`lives-ok`, which executes the block in the caller frame reading env by name), the `:delete` read that stale `Any` and the mutation vanished. Any ordinary read of `$bh` inside the closure re-seeded env and masked the bug — hence delete-only was the trigger.

## Fix

In the gated `compute_needs_env_sync` closure-capture fold, also scan each nested closure's ops for `op_container_mutate_const_idx` on an outer scalar (non-`@`/`%`/`&`, not one of the closure's own locals) and fold that scalar into `needs_env_sync`, so the outer store keeps mirroring the live container.

Gate-ON only — the default build stays byte-identical and perf-neutral.

## Verification

- `t/quanthash-immutable-ro.t`: OFF PASS / ON PASS (was ON FAIL on test 12).
- Full `t/` ON survey: only `atomic-ops*` remain (a separate cluster); quanthash resolved.
- Pin: `t/gate-b-closure-scalar-container-delete.t` (BagHash/Hash/SetHash/Array element delete inside a `lives-ok` carrier — OFF/ON/raku all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)