### PR TITLE
fix: `.DEFINITE` on a concrete Failure instance is True

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -314,10 +314,13 @@ pub(super) fn dispatch(
                 }))))
             }
         }
+        // `.DEFINITE` is the concreteness primitive: True iff `target` is a
+        // concrete instance rather than a type object. It is NOT `.defined`
+        // (which Failure overrides to False) — a `Failure.new(...)` instance is
+        // still definite, so it must NOT be special-cased here.
         "DEFINITE" => Some(Some(Ok(Value::truth(match target.view() {
             ValueView::Nil | ValueView::Package(_) | ValueView::CustomType(..) => false,
             ValueView::Slip(items) if items.is_empty() => false,
-            ValueView::Instance { class_name, .. } if class_name == "Failure" => false,
             _ => true,
         })))),
         "WHICH" => {

--- a/t/failure-definite.t
+++ b/t/failure-definite.t
@@ -1,0 +1,26 @@
+use v6;
+use Test;
+
+# `.DEFINITE` is the concreteness primitive: True iff the object is a concrete
+# instance (not a type object). It is distinct from `.defined`, which Failure
+# overrides to return False. A `Failure.new(...)` is a concrete instance, so its
+# `.DEFINITE` is True even though its `.defined` is False.
+# From raku-doc Language/signatures.rakudoc (doc-diff finding [13]).
+
+plan 8;
+
+my $type-obj = Failure;              # type object
+my $instance = Failure.new("foo");   # concrete instance
+
+is $type-obj.DEFINITE, False, 'Failure type object: DEFINITE is False';
+is $instance.DEFINITE, True,  'Failure instance: DEFINITE is True (concrete)';
+is $type-obj.defined,  False, 'Failure type object: defined is False';
+is $instance.defined,  False, 'Failure instance: defined is False (override)';
+
+# The fix does not disturb DEFINITE for ordinary values / type objects.
+is 42.DEFINITE,  True,  'Int value: DEFINITE True';
+is Int.DEFINITE, False, 'Int type object: DEFINITE False';
+
+class C { }
+is C.new.DEFINITE, True,  'user instance: DEFINITE True';
+is C.DEFINITE,     False, 'user type object: DEFINITE False';


### PR DESCRIPTION
## Summary

`.DEFINITE` is the concreteness primitive: True iff the object is a concrete instance rather than a type object. It is distinct from `.defined`, which `Failure` overrides to return False. mutsu special-cased a `Failure` **instance** in the `.DEFINITE` handler, so `Failure.new("foo")` reported `.DEFINITE` as False even though it is a concrete instance.

Doc example from `raku-doc/doc/Language/signatures.rakudoc` (doc-diff finding [13]):

```raku
my $a = Failure;                # type object
my $b = Failure.new("foo");     # concrete instance
say $a.DEFINITE;   # False
say $b.DEFINITE;   # True   (mutsu was: False)
say $a.defined;    # False
say $b.defined;    # False  (.defined override — unchanged)
```

## Fix

Drop the `Failure` arm from the `.DEFINITE` match in `dispatch_core_coerce.rs`. `.defined` keeps its own separate `Failure` override (returns False and marks the failure handled), so definedness and failure semantics are unchanged.

## Tests

- Pin: `t/failure-definite.t`.
- `make test` (19195 tests) green; `S32-exceptions/*.t` roast green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)