### PR TITLE
fix: honour a `%` separator on an anchored `**N` repeat quantifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/docs/dist-compat-sweep.md
+++ b/docs/dist-compat-sweep.md
@@ -121,7 +121,7 @@ message). Work them one at a time.
 ### parse_error (18)
 
 App::Rak · Astro::Utils · Audio::Liquidsoap · Configuration ·
-Cro::FCGI · CSS · CSV::Table · Deps · File-TreeBuilder · IP::Random ·
+Cro::FCGI · CSS · CSV::Table · Deps · File-TreeBuilder ·
 Math::Matrix · ML::SparseMatrixRecommender · Pod::Contents ·
 SBOM::CycloneDX · SSH::LibSSH::Tunnel
 
@@ -133,7 +133,8 @@ Known root causes to date:
 | SBOM::CycloneDX | `unparsed input, column 5: "}\n… @*ERRORS"` — the reported line (the `}` closing `method ingest`) is the last-good boundary, **not** the cause: the `@*ERRORS`/`with…else`/private-method-call constructs there all parse in isolation. The real desync is a still-unisolated construct in the tail `Map`/`Hash` methods (deep `mapify` ternary, `my role ordered-list[@NAMES]`, `$map but ordered-list[@keys]`) that forces the whole-role parse to backtrack. Investigating it surfaced a *separate* general bug — interpolated `.join(", ")` (a method arg carrying the string's own quote/comma) was mis-split, fixed separately — but that was not the SBOM blocker. Needs a finer tail-method repro. |
 | CSS | inside a `grammar` ("angle index key") — grammar/regex-slang, heavier. |
 | ~~Bench~~ | **Cleared post-snapshot**: a tightly-bound `<=>` used as a quote-word / hash key / colonpair value (`:fill<=>`, `%h<=>`) was mis-parsed as the spaceship operator by three separate angle parsers. Now loads. |
-| Pod::Contents / File-TreeBuilder / App::Rak / Astro::Utils / Audio::Liquidsoap / IP::Random / Math::Matrix / ML::SparseMatrixRecommender / CSV::Table / Cro::FCGI | generic `expected statement…` dead-end — each needs its own repro; several carry multiple blockers (bisect at balanced method boundaries). |
+| ~~IP::Random~~ | **Cleared post-snapshot**: an interpolated array atom quantified with a `%` separator under an anchor (`m/^ @oct ** 4 % \. $/`) hit two bugs — the parser mis-read the `%` after the placeholder atom as a stray hash sigil (parse error), and the LTM string expansion folded the leading `^` anchor into the quantified atom (`^\d`), so the anchored `**N % sep` silently dropped the separator and matched contiguously. Both fixed; `use IP::Random` loads. (A separate `for named_exclude -> $p { $p.value… }` Hash-constant-iteration runtime bug remains, a Level-2 concern.) |
+| Pod::Contents / File-TreeBuilder / App::Rak / Astro::Utils / Audio::Liquidsoap / Math::Matrix / ML::SparseMatrixRecommender / CSV::Table / Cro::FCGI | generic `expected statement…` dead-end — each needs its own repro; several carry multiple blockers (bisect at balanced method boundaries). |
 | Configuration | **Partially cleared**: `Configuration::Utils` was blocked by an interpolated-string hash key inside a block (`.duckmap({ "{ .^name }Builder" => generate-builder-class $_ })`) that the block-vs-hash disambiguator mis-parsed; fixed (topic-referencing interpolated keys now force a block, topic-free ones stay a hash). `Configuration::Utils` loads; the main `Configuration` module still has a separate parse blocker (534-line file, unisolated). |
 | Deps | Needs several type-capture features mutsu lacks: a type-capture **with** a constraint in a signature (`::Type Any` — currently the constraint is mis-read as a literal match value), type-capture loop variables (`for … -> ::T {…}` — the capture is not bound), and multi-dispatch on type captures. Multi-feature; deferred. |
 | ~~Trie~~ | **Cleared post-snapshot**: was a set-operator compound assignment on an indexed lvalue (`%!decendents{char} ∪= …`) the parser rejected. Parse error gone; now only lacks its `OrderedHash` dependency (missing_dep). |

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -14,6 +14,77 @@ impl Interpreter {
         self.parse_regex_uncached(pattern, mode)
     }
 
+    /// Consume (and validate) a `%` / `%%` separator modifier that follows a
+    /// repeating quantifier on an interpolation placeholder or backreference in
+    /// `Validate` mode (`@oct ** 4 % \.`). The normal atom path handles this
+    /// inline while building the token's `separator`, but placeholder/backref
+    /// atoms `continue` before reaching it, so their trailing separator would
+    /// otherwise be mis-parsed as a stray `%`. Returns `Some(())` when there is
+    /// no separator or a valid one was consumed, and `None` (with the pending
+    /// regex error already set by the recursive parse) when the separator
+    /// sub-pattern is itself invalid.
+    fn consume_placeholder_quantifier_separator(
+        &self,
+        chars: &mut std::iter::Peekable<std::str::Chars>,
+        mode: RegexParseMode,
+    ) -> Option<()> {
+        // Peek past whitespace for a `%`.
+        let mut lookahead = chars.clone();
+        while lookahead.peek().is_some_and(|c| c.is_whitespace()) {
+            lookahead.next();
+        }
+        // A `%` that begins a hash-alias capture for the FOLLOWING atom
+        // (`%<name>=...` or `%name=...`) is NOT a separator — mirror the normal
+        // path's guard so those still parse as aliases.
+        let is_hash_alias = {
+            let mut la = lookahead.clone();
+            if la.peek() == Some(&'%') {
+                la.next();
+                if la.peek() == Some(&'%') {
+                    false // `%%` is always a separator marker
+                } else if la.peek() == Some(&'<') {
+                    la.next();
+                    while la.peek().is_some_and(|&c| c != '>') {
+                        la.next();
+                    }
+                    la.next(); // '>'
+                    la.peek() == Some(&'=')
+                } else if la.peek().is_some_and(|&c| c.is_alphabetic() || c == '_') {
+                    while la.peek().is_some_and(|&c| c.is_alphanumeric() || c == '_') {
+                        la.next();
+                    }
+                    la.peek() == Some(&'=')
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        };
+        if lookahead.peek() != Some(&'%') || is_hash_alias {
+            return Some(());
+        }
+        // Commit: consume whitespace + `%` / `%%`.
+        while chars.peek().is_some_and(|c| c.is_whitespace()) {
+            chars.next();
+        }
+        chars.next(); // first '%'
+        if chars.peek() == Some(&'%') {
+            chars.next(); // `%%` allows an optional trailing separator
+        }
+        while chars.peek().is_some_and(|c| c.is_whitespace()) {
+            chars.next();
+        }
+        // Consume and validate the single separator atom.
+        let remaining: String = chars.clone().collect();
+        let sep_atom_str = Self::split_separator_atom(&remaining);
+        for _ in 0..sep_atom_str.chars().count() {
+            chars.next();
+        }
+        self.parse_regex_with_mode(sep_atom_str.trim(), mode)?;
+        Some(())
+    }
+
     pub(super) fn parse_regex_uncached(
         &self,
         pattern: &str,
@@ -865,6 +936,16 @@ impl Interpreter {
                     }
                     if chars.peek() == Some(&'?') {
                         chars.next();
+                    }
+                    // A repeating quantifier on an interpolation placeholder /
+                    // backref may carry a `%` / `%%` separator modifier
+                    // (`@oct ** 4 % \.`, `$0+ % ','`). The normal atom path
+                    // consumes this below, but placeholders `continue` early, so
+                    // consume (and validate) it here too; otherwise the `%` is
+                    // mis-parsed as a stray hash sigil and the whole regex fails
+                    // to compile. `?` (ZeroOrOne) is non-repeating and takes none.
+                    if matches!(c, '*' | '+') {
+                        self.consume_placeholder_quantifier_separator(&mut chars, mode)?;
                     }
                     continue;
                 }

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -814,6 +814,30 @@ impl Interpreter {
                 Self::expand_ltm_pattern(rest, sigspace)
             );
         }
+        // A leading `^` / `^^` start-of-string/line anchor is not part of the
+        // quantified atom. The whole-string LTM regexes below would otherwise
+        // fold it into the atom (`^\d ** 4 % '.'` -> atom `^\d`, which is not a
+        // single atom), defeating single-atom detection and mis-expanding the
+        // pattern as a bare `%` separator (so the anchored form silently dropped
+        // the separator). Hold the anchor aside, expand the rest, re-prepend it.
+        {
+            let anchor_len = if trimmed.starts_with("^^") {
+                2
+            } else if trimmed.starts_with('^') {
+                1
+            } else {
+                0
+            };
+            if anchor_len > 0 {
+                let lead_ws = &pattern[..pattern.len() - trimmed.len()];
+                let anchor = &trimmed[..anchor_len];
+                let rest = &trimmed[anchor_len..];
+                return format!(
+                    "{lead_ws}{anchor}{}",
+                    Self::expand_ltm_pattern(rest, sigspace)
+                );
+            }
+        }
         let compact: String = Self::compact_regex_whitespace(pattern);
         if compact.is_empty() {
             return pattern.to_string();

--- a/t/regex-anchored-separated-repeat.t
+++ b/t/regex-anchored-separated-repeat.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+# A `**N` / `**N..M` repeating quantifier carrying a `%` / `%%` separator must
+# still honour the separator when the pattern is anchored with a leading `^`.
+# Regression: the LTM string expansion folded the leading `^` anchor into the
+# quantified atom (`^\d`), which stopped being a "single atom", so the pattern
+# was mis-expanded as a bare `%` separator and the separator was silently
+# dropped (the anchored form matched contiguous digits instead).
+
+plan 12;
+
+ok "1.2"     ~~ m/^ \d ** 2 % \. $/,     'anchored **2 % . matches 2 dot-separated';
+ok "1.2.3.4" ~~ m/^ \d ** 4 % \. $/,     'anchored **4 % . matches 4 dot-separated';
+nok "12"     ~~ m/^ \d ** 2 % \. $/,     'anchored **2 % . rejects contiguous';
+nok "1.2.3"  ~~ m/^ \d ** 2 % \. $/,     'anchored **2 % . rejects 3 elements';
+ok "1,2,3"   ~~ m/^ \d ** 1..3 % \, $/,  'anchored **1..3 % , range matches';
+nok "1,2,3,4" ~~ m/^ \d ** 1..3 % \, $/, 'anchored **1..3 % , range rejects 4';
+ok "1.2.3"   ~~ m/^ \d ** 3 %% \. $/,    'anchored **3 %% . (trailing allowed) matches';
+ok "1.2.3."  ~~ m/^ \d ** 3 %% \. $/,    'anchored **3 %% . matches trailing separator';
+
+# An interpolated array atom quantified with `**N % sep` must PARSE (the
+# separator after a placeholder was previously mis-read as a stray `%`).
+my @oct = ^256;
+ok "1.2.3.4" ~~ m/^ @oct ** 4 % \. $/,   'interpolated array **4 % . matches an IPv4';
+nok "1.2.3"  ~~ m/^ @oct ** 4 % \. $/,   'interpolated array **4 % . rejects 3 octets';
+
+# The `+` / `*` anchored separator forms were already correct; keep them green.
+ok "a,b,c"   ~~ m/^ \w+ % \, $/,         'anchored + % , still matches';
+ok "1.2.3"   ~~ m/^ \d+ %% \. $/,        'anchored + %% . still matches';
+
+done-testing;


### PR DESCRIPTION
## Problem

`use IP::Random` failed to compile, and any regex of the form
`^ atom ** N % sep $` (an anchored repeat quantifier carrying a `%` / `%%`
separator) was broken. Two distinct bugs were involved.

### 1. Parse — separator after an interpolation placeholder

An interpolation placeholder / backref atom quantified with a separator
(`@oct ** 4 % \.`) `continue`d in the regex parser before reaching the
normal separator-parsing path, so the trailing `%` was mis-read as a stray
hash sigil and the whole regex failed to compile:

```
$ mutsu -e 'my @oct=^256; "1.2.3.4" ~~ m/^ @oct ** 4 % \. $/'
===SORRY!=== Confused.
```

Fixed by consuming (and validating) the `%`/`%%` separator in the
placeholder quantifier branch too, mirroring the guard the normal atom path
already uses.

### 2. Match — anchored `**N % sep` silently dropped the separator

`expand_ltm_pattern`'s whole-string LTM regexes folded a leading `^`/`^^`
anchor into the quantified atom (`^\d`), which then failed the single-atom
check and was mis-expanded as a *bare* `%` separator — so the anchored form
silently dropped the separator and matched contiguously:

```
# before (wrong):
"12"  ~~ m/^ \d ** 2 % \. $/   # matched   (raku: no)
"1.2" ~~ m/^ \d ** 2 % \. $/   # no match  (raku: 1.2)
```

Fixed by holding the leading anchor aside (as `expand_ltm_pattern` already
does for a leading embedded declaration), expanding the rest, and
re-prepending the anchor.

## Result

`m/^ @oct ** 4 % \. $/` now matches an IPv4 exactly as raku does, and
`use IP::Random` loads (moving it out of the dist-compat-sweep `parse_error`
bucket). The unanchored and `+`/`*` separator forms were already correct and
stay green.

Pin: `t/regex-anchored-separated-repeat.t`. All 71 `t/*regex*.t` tests and
the roast `S05-metasyntax` separator/repeat specs pass; `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)