### PR TITLE
fix: keep the ` --> ` arrow spaced in a parameterless signature

### DIFF
--- a/src/value/signature.rs
+++ b/src/value/signature.rs
@@ -607,7 +607,10 @@ fn render_signature(info: &SigInfo) -> String {
     }
     if let Some(ref ret) = info.return_type {
         if params_str.is_empty() {
-            format!(":(--> {})", ret)
+            // Raku keeps the ` --> ` arrow spaced even with no parameters, so an
+            // empty positional list renders as `:( --> Int)` (leading space),
+            // not `:(--> Int)`.
+            format!(":( --> {})", ret)
         } else {
             format!(":({} --> {})", params_str, ret)
         }

--- a/t/signature-return-only-space.t
+++ b/t/signature-return-only-space.t
@@ -1,0 +1,26 @@
+use v6;
+use Test;
+
+# A signature with no parameters but a return type keeps the ` --> ` arrow
+# spaced: it renders as `( --> Int)` / `:( --> Int)`, not `(--> Int)`.
+# From raku-doc Language/signatures.rakudoc (doc-diff findings [2]/[3]).
+
+plan 6;
+
+sub foo() of Int { 42 }
+is &foo.signature.gist, '( --> Int)',  'return-only signature gist has spaced arrow';
+is &foo.signature.raku, ':( --> Int)', 'return-only signature raku has spaced arrow';
+
+my Int sub bar { 1 }
+is &bar.signature.gist, '( --> Int)',  'my Int sub: gist spaced arrow';
+
+# A parameterized signature is unaffected (space was already present).
+sub baz($x --> Int) { 1 }
+is &baz.signature.gist, '($x --> Int)', 'parameterized + return arrow unchanged';
+
+# No return type: no arrow, no spurious space.
+sub qux() { 1 }
+is &qux.signature.gist, '()', 'empty signature, no return type';
+
+sub quux($x) { 1 }
+is &quux.signature.gist, '($x)', 'param-only signature unchanged';


### PR DESCRIPTION
## Summary

A signature with no parameters but a return type rendered as `(--> Int)` (and `:(--> Int)`) in mutsu, but Raku keeps the `-->` arrow spaced even with an empty positional list: `( --> Int)` / `:( --> Int)`. A parameterized signature already had the space (after the last parameter).

Doc examples from `raku-doc/doc/Language/signatures.rakudoc` (doc-diff findings [2]/[3]):

```raku
sub foo() of Int { 42 };
say &foo.signature       # ( --> Int)   (mutsu was: (--> Int))

my Int sub bar { 1 };
say &bar.signature       # ( --> Int)
```

## Fix

The empty-params branch of `signature_to_string` (`src/value/signature.rs`) now emits `:( --> {ret})` with a leading space. The colon-less `.gist` is derived from this string (strips the leading `:`), so both the `.gist` and `.raku`/`.Str` forms are corrected by the one change.

## Tests

- Pin: `t/signature-return-only-space.t`.
- `make test` (19201 tests) green; `S06-signature/{introspection,types}.t` roast green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)