### PR TITLE
fix: (B)-gate keep atomic-op target scalars env-synced

### DIFF
--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -33,6 +33,21 @@ impl Compiler {
     }
 
     pub(super) fn compile_expr_call(&mut self, name: &Symbol, args: &[Expr]) {
+        // Parser-rewritten atomic-op forms (`⚛$x`, `$x ⚛= v`, `$x⚛++`) arrive
+        // here already lowered to `__mutsu_atomic_*_var(<var-name-literal>, …)`
+        // (the explicit `atomic-fetch($x)` / `cas($x, …)` named forms are handled
+        // by their dedicated branches below). The builtin resolves its target by
+        // NAME from env, so record the target local for the gated
+        // `needs_env_sync` fold. Recording only; compilation proceeds normally.
+        name.with_str(|n| {
+            if ((n.starts_with("__mutsu_atomic_") && n.ends_with("_var")) || n == "__mutsu_cas_var")
+                && let Some(Expr::Literal(lit)) = args.first()
+                && let crate::value::ValueView::Str(vn) = lit.view()
+            {
+                let vn = vn.as_ref().clone();
+                self.note_atomic_env_sync_target(&vn);
+            }
+        });
         // (state $x) = expr  /  (state @x) = expr  /  (state %x) = expr
         // The parser emits __mutsu_assign_callable_lvalue(DoStmt(VarDecl{..}), [], rhs).
         // We compile this as: declare the state var, then unconditionally assign the RHS.
@@ -356,6 +371,7 @@ impl Compiler {
             let call_name_idx = self
                 .code
                 .add_constant(Value::str_from("__mutsu_atomic_fetch_var"));
+            self.note_atomic_env_sync_target(var_name);
             let arg_idx = self.code.add_constant(Value::str(var_name.clone()));
             self.code.emit(OpCode::LoadConst(arg_idx));
             self.code.emit(OpCode::CallFunc {
@@ -371,6 +387,7 @@ impl Compiler {
             let call_name_idx = self
                 .code
                 .add_constant(Value::str_from("__mutsu_atomic_store_var"));
+            self.note_atomic_env_sync_target(var_name);
             let arg_idx = self.code.add_constant(Value::str(var_name.clone()));
             self.code.emit(OpCode::LoadConst(arg_idx));
             self.compile_expr(&args[1]);
@@ -387,6 +404,7 @@ impl Compiler {
             let call_name_idx = self
                 .code
                 .add_constant(Value::str_from("__mutsu_atomic_post_inc_var"));
+            self.note_atomic_env_sync_target(var_name);
             let arg_idx = self.code.add_constant(Value::str(var_name.clone()));
             self.code.emit(OpCode::LoadConst(arg_idx));
             self.code.emit(OpCode::CallFunc {
@@ -402,6 +420,7 @@ impl Compiler {
             let call_name_idx = self
                 .code
                 .add_constant(Value::str_from("__mutsu_atomic_pre_inc_var"));
+            self.note_atomic_env_sync_target(var_name);
             let arg_idx = self.code.add_constant(Value::str(var_name.clone()));
             self.code.emit(OpCode::LoadConst(arg_idx));
             self.code.emit(OpCode::CallFunc {
@@ -417,6 +436,7 @@ impl Compiler {
             let call_name_idx = self
                 .code
                 .add_constant(Value::str_from("__mutsu_atomic_post_dec_var"));
+            self.note_atomic_env_sync_target(var_name);
             let arg_idx = self.code.add_constant(Value::str(var_name.clone()));
             self.code.emit(OpCode::LoadConst(arg_idx));
             self.code.emit(OpCode::CallFunc {
@@ -432,6 +452,7 @@ impl Compiler {
             let call_name_idx = self
                 .code
                 .add_constant(Value::str_from("__mutsu_atomic_pre_dec_var"));
+            self.note_atomic_env_sync_target(var_name);
             let arg_idx = self.code.add_constant(Value::str(var_name.clone()));
             self.code.emit(OpCode::LoadConst(arg_idx));
             self.code.emit(OpCode::CallFunc {
@@ -447,6 +468,7 @@ impl Compiler {
             let call_name_idx = self
                 .code
                 .add_constant(Value::str_from("__mutsu_atomic_fetch_add_var"));
+            self.note_atomic_env_sync_target(var_name);
             let arg_idx = self.code.add_constant(Value::str(var_name.clone()));
             self.code.emit(OpCode::LoadConst(arg_idx));
             self.compile_expr(&args[1]);
@@ -463,6 +485,7 @@ impl Compiler {
             let call_name_idx = self
                 .code
                 .add_constant(Value::str_from("__mutsu_atomic_add_var"));
+            self.note_atomic_env_sync_target(var_name);
             let arg_idx = self.code.add_constant(Value::str(var_name.clone()));
             self.code.emit(OpCode::LoadConst(arg_idx));
             self.compile_expr(&args[1]);
@@ -492,6 +515,7 @@ impl Compiler {
                     let call_name_idx = self
                         .code
                         .add_constant(Value::str_from("__mutsu_atomic_add_var"));
+                    self.note_atomic_env_sync_target(&var_name);
                     let name_idx = self.code.add_constant(Value::str(var_name.clone()));
                     self.code.emit(OpCode::LoadConst(name_idx));
                     self.compile_expr(&delta);
@@ -514,6 +538,7 @@ impl Compiler {
                 self.code.emit(OpCode::Pop);
             }
             let call_name_idx = self.code.add_constant(Value::str_from("__mutsu_cas_var"));
+            self.note_atomic_env_sync_target(&var_name);
             let name_idx = self.code.add_constant(Value::str(var_name.clone()));
             self.code.emit(OpCode::LoadConst(name_idx));
             for arg in &args[1..] {

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -60,6 +60,21 @@ impl Compiler {
         }
     }
 
+    /// Record that `var_name` reaches an atomic-op builtin (`⚛$x`, `$x ⚛= v`,
+    /// `cas($x, …)`) as the target variable, so the gated `compute_needs_env_sync`
+    /// fold keeps its env mirror current (the builtin resolves the target by name
+    /// from env). No-op for a name that is not one of this frame's own locals
+    /// (an ancestor lexical / global / attribute is resolved differently). The
+    /// field is only consumed under `MUTSU_GATE_LOCAL_ENV_WRITE`, so the default
+    /// build is byte-identical.
+    pub(super) fn note_atomic_env_sync_target(&mut self, var_name: &str) {
+        if let Some(&slot) = self.local_map.get(var_name)
+            && !self.code.atomic_env_sync_locals.contains(&slot)
+        {
+            self.code.atomic_env_sync_locals.push(slot);
+        }
+    }
+
     /// True if `name` is a plain env-named scalar suitable for fused
     /// compound-assignment (`$x OP= rhs`). Excludes twigil/attribute/special
     /// forms and package-qualified names; bare `$_` (name `_`) is allowed.

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1694,6 +1694,15 @@ pub(crate) struct CompiledCode {
     pub(crate) lex_scopes: Vec<Arc<crate::compiler::lex_scope::LexScopeChain>>,
     /// Pre-compiled closure bodies embedded in this code chunk.
     pub(crate) closure_compiled_codes: Vec<Arc<CompiledCode>>,
+    /// Own local slots that reach an atomic-op builtin (`⚛$x`, `$x ⚛= v`,
+    /// `cas($x, …)`) as the target VARIABLE. These builtins are compiled to a
+    /// `__mutsu_*_var(name_str, …)` call and resolve the target by NAME from env
+    /// (`atomic_current_value` falls back to `env.get(name)` for a non-`atomicint`
+    /// scalar). Under `MUTSU_GATE_LOCAL_ENV_WRITE` a plain `my Int $x = 1` skips
+    /// its env mirror, so the builtin reads the decl-seed placeholder. Consumed
+    /// ONLY by the gated `compute_needs_env_sync` fold, which marks these slots
+    /// env-synced; the default build never reads this field (byte-identical).
+    pub(crate) atomic_env_sync_locals: Vec<u32>,
     /// Out-of-band named-argument specs for `CallFuncNamed` sites (indexed by
     /// the op's `spec_idx`): which of the call's stack values are named-arg
     /// VALUES and under which keys. Lets a literal `:key(val)` call site skip
@@ -2088,6 +2097,7 @@ impl CompiledCode {
             param_local_slots: Vec::new(),
             lex_scopes: Vec::new(),
             closure_compiled_codes: Vec::new(),
+            atomic_env_sync_locals: Vec::new(),
             named_arg_specs: Vec::new(),
             closure_escapes: Vec::new(),
             is_routine: false,
@@ -2457,6 +2467,17 @@ impl CompiledCode {
         // off); the cost only lands with the gate, and it never touches a
         // hot-arithmetic loop local (those are not closure free variables).
         if gate_local_env_write() {
+            // Atomic-op targets (`⚛$x`, `$x ⚛= v`, `cas($x, …)`) resolve their
+            // variable by NAME from env in the `__mutsu_*_var` builtin. Keep the
+            // mirror current so a non-`atomicint` scalar is not read as its
+            // decl-seed placeholder under the gate. (Recorded at emit time in
+            // `atomic_env_sync_locals`; an `atomicint` reads the shared store
+            // first, so folding it here is harmless.)
+            for &slot in &self.atomic_env_sync_locals {
+                if let Some(b) = self.needs_env_sync.get_mut(slot as usize) {
+                    *b = true;
+                }
+            }
             for nested in &self.closure_compiled_codes {
                 for sym in &nested.free_var_syms {
                     if let Some(&slot) = sym.with_str(|s| locals_map.get(s)) {

--- a/t/gate-b-atomic-var-env-sync.t
+++ b/t/gate-b-atomic-var-env-sync.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+# (B)-gate regression pin: atomic ops (`⚛$x`, `$x ⚛= v`, `$x⚛++`, `cas($x, …)`)
+# are compiled to a `__mutsu_*_var(name_str, …)` builtin call that resolves the
+# target VARIABLE by NAME from env (`atomic_current_value` falls back to
+# `env.get(name)` for a non-`atomicint` scalar). Under MUTSU_GATE_LOCAL_ENV_WRITE
+# a plain `my Int $x = 1` skips its env mirror (the slot is authoritative), so
+# the builtin used to read the decl-seed type object. The emit sites now record
+# the target local in `atomic_env_sync_locals`, folded into needs_env_sync under
+# the gate. Must pass identically with the gate OFF (default) and ON.
+
+plan 8;
+
+# atomic fetch (⚛$x) on a plain Int scalar.
+my Int $x = 1;
+is ⚛$x, 1, 'atomic fetch reads the live scalar';
+
+# atomic assign (⚛=) returns and updates.
+is ($x ⚛= 2), 2, 'atomic assign returns assigned value';
+is ⚛$x, 2, 'atomic assign updated the variable';
+
+# cas 3-arg success path.
+my Int $y = 5;
+is cas($y, 5, 10), 5, 'cas returns the old value on success';
+is ⚛$y, 10, 'cas swapped the value';
+
+# cas 3-arg failed-compare path leaves the variable unchanged.
+my Int $z = 7;
+is cas($z, 999, 42), 7, 'cas returns current on failed compare';
+is ⚛$z, 7, 'cas left the variable unchanged on failed compare';
+
+# cross-thread atomicint increment still accumulates correctly (`⚛++` requires
+# an atomicint; its value lives in the shared store, so folding it is harmless).
+my atomicint $i = 0;
+await start { for ^1000 { $i⚛++; } } xx 4;
+is atomic-fetch($i), 4000, 'atomicint increment accumulates across start/await';


### PR DESCRIPTION
## Problem

Under `MUTSU_GATE_LOCAL_ENV_WRITE` (the (B)-gate burndown), the last two ON-only failures were `t/atomic-ops.t` and `t/atomic-ops-native-dispatch.t`:

- `my Int $x = 1; ⚛$x` read `(Int)` (the type object) instead of `1`.
- `cas($x, 5, 10)` compared against that placeholder and silently no-op'd.

Atomic ops (`⚛$x`, `$x ⚛= v`, `$x⚛++`, `cas($x, …)`) are compiled to a `__mutsu_*_var(name_str, …)` builtin that resolves its target **variable by NAME from env** — `atomic_current_value` falls back to `env.get(name)` for a non-`atomicint` scalar. With the gate on, a plain `my Int $x = 1` skips its env mirror (the slot is authoritative), leaving `env<x>` at its decl-seed type object.

## Fix

Record each atomic-op target local in a new `CompiledCode::atomic_env_sync_locals` field at emit time — covering both the explicit `atomic-fetch`/`cas` named-call branches and the parser-lowered `__mutsu_*_var(<name-literal>, …)` forms (`⚛` operators) — and fold those slots into `needs_env_sync` in the gated `compute_needs_env_sync` block, so the outer store keeps mirroring the live value.

An `atomicint` reads the process-wide shared store first, so folding it is harmless. The field is consumed ONLY under the gate, so the **default build is byte-identical and perf-neutral**.

## Verification

- `t/atomic-ops.t`, `t/atomic-ops-native-dispatch.t`: OFF PASS / ON PASS (were ON FAIL).
- **Full `t/` gate-ON survey is now clean** — this was the last cluster (after the closure-scalar-container delete fix #4910).
- Cross-thread `atomicint` increment (test 4: `await start { for ^1000 { $i⚛++ } } xx 4`) still accumulates to 4000 ON.
- Pin: `t/gate-b-atomic-var-env-sync.t` (⚛-fetch / ⚛= / cas success+fail / atomicint cross-thread — OFF/ON/raku all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)