### PR TITLE
fix: parse an empty colon method-call at the end of a block

### DIFF
--- a/docs/dist-compat-sweep.md
+++ b/docs/dist-compat-sweep.md
@@ -121,7 +121,7 @@ message). Work them one at a time.
 ### parse_error (18)
 
 App::Rak · Astro::Utils · Audio::Liquidsoap · Configuration ·
-Cro::FCGI · CSS · CSV::Table · Deps · File-TreeBuilder ·
+Cro::FCGI · CSS · Deps · File-TreeBuilder ·
 Math::Matrix · ML::SparseMatrixRecommender · Pod::Contents ·
 SBOM::CycloneDX · SSH::LibSSH::Tunnel
 
@@ -134,7 +134,8 @@ Known root causes to date:
 | CSS | inside a `grammar` ("angle index key") — grammar/regex-slang, heavier. |
 | ~~Bench~~ | **Cleared post-snapshot**: a tightly-bound `<=>` used as a quote-word / hash key / colonpair value (`:fill<=>`, `%h<=>`) was mis-parsed as the spaceship operator by three separate angle parsers. Now loads. |
 | ~~IP::Random~~ | **Cleared post-snapshot**: an interpolated array atom quantified with a `%` separator under an anchor (`m/^ @oct ** 4 % \. $/`) hit two bugs — the parser mis-read the `%` after the placeholder atom as a stray hash sigil (parse error), and the LTM string expansion folded the leading `^` anchor into the quantified atom (`^\d`), so the anchored `**N % sep` silently dropped the separator and matched contiguously. Both fixed; `use IP::Random` loads. (A separate `for named_exclude -> $p { $p.value… }` Hash-constant-iteration runtime bug remains, a Level-2 concern.) |
-| Pod::Contents / File-TreeBuilder / App::Rak / Astro::Utils / Audio::Liquidsoap / Math::Matrix / ML::SparseMatrixRecommender / CSV::Table / Cro::FCGI | generic `expected statement…` dead-end — each needs its own repro; several carry multiple blockers (bisect at balanced method boundaries). |
+| ~~CSV::Table~~ | **Cleared post-snapshot**: an empty colon method-call at the end of a block (`$!rowname-width = $row.rwid:` followed by a closing `}`) failed to parse — mutsu tried to parse a first argument after the `:` and errored with "right-hand expression after '='". Raku treats `.method:` before a block-closing `}` as a zero-arg `.method()`; mutsu now matches (only before `}` — before `;`/`)`/`]`/EOF Raku still demands a colon-pair). Now advances to `missing_dep` (JSON::Fast / YAMLish). |
+| Pod::Contents / File-TreeBuilder / App::Rak / Astro::Utils / Audio::Liquidsoap / Math::Matrix / ML::SparseMatrixRecommender / Cro::FCGI | generic `expected statement…` dead-end — each needs its own repro; several carry multiple blockers (bisect at balanced method boundaries). |
 | Configuration | **Partially cleared**: `Configuration::Utils` was blocked by an interpolated-string hash key inside a block (`.duckmap({ "{ .^name }Builder" => generate-builder-class $_ })`) that the block-vs-hash disambiguator mis-parsed; fixed (topic-referencing interpolated keys now force a block, topic-free ones stay a hash). `Configuration::Utils` loads; the main `Configuration` module still has a separate parse blocker (534-line file, unisolated). |
 | Deps | Needs several type-capture features mutsu lacks: a type-capture **with** a constraint in a signature (`::Type Any` — currently the constraint is mis-read as a literal match value), type-capture loop variables (`for … -> ::T {…}` — the capture is not bound), and multi-dispatch on type captures. Multi-feature; deferred. |
 | ~~Trie~~ | **Cleared post-snapshot**: was a set-operator compound assignment on an indexed lvalue (`%!decendents{char} ∪= …`) the parser rejected. Parse error gone; now only lacks its `OrderedHash` dependency (missing_dep). |

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -960,18 +960,31 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                         }
                     }
                     // If there was space before ':', treat as adverb (colon-pair)
-                    let (r3, first_arg) = if has_space_before_colon {
-                        colonpair_expr(r2)?
+                    let mut args = Vec::new();
+                    let r3 = if has_space_before_colon {
+                        let (r3, first_arg) = colonpair_expr(r2)?;
+                        args.push(first_arg);
+                        r3
                     } else {
                         let r3 = &r2[1..];
                         let (r3, _) = ws(r3)?;
-                        // A colon-method arg list (`.m: a, b`) is a comma-list at
-                        // listop precedence, so each element stops before the loose
-                        // word-logical ops (`andthen`/`and`/`or`): `.m: $x andthen $y`
-                        // is `(.m: $x) andthen $y`, not `.m($x andthen $y)`.
-                        listop_arg_expr(r3)?
+                        // `.method:` immediately before a block-closing `}` is an
+                        // empty colon-arg call — a plain `.method()`. Raku accepts
+                        // the zero-arg colon form only here (`$w = $r.rwid:` then a
+                        // closing `}` in CSV::Table); before `;` / `)` / `]` / EOF it
+                        // still demands a colon-pair, so those keep parsing an arg.
+                        if r3.starts_with('}') {
+                            r3
+                        } else {
+                            // A colon-method arg list (`.m: a, b`) is a comma-list at
+                            // listop precedence, so each element stops before the loose
+                            // word-logical ops (`andthen`/`and`/`or`): `.m: $x andthen $y`
+                            // is `(.m: $x) andthen $y`, not `.m($x andthen $y)`.
+                            let (r3, first_arg) = listop_arg_expr(r3)?;
+                            args.push(first_arg);
+                            r3
+                        }
                     };
-                    let mut args = vec![first_arg];
                     let mut r_inner = r3;
                     loop {
                         let (r4, _) = ws(r_inner)?;

--- a/t/method-call-colon-empty-args.t
+++ b/t/method-call-colon-empty-args.t
@@ -1,0 +1,56 @@
+use v6;
+use Test;
+
+# The colon method-call form `$obj.method:` takes the rest of the statement as
+# its argument list. When the colon sits immediately before a block-closing `}`
+# (an empty argument list at the end of a block), Raku treats it as a plain
+# zero-argument `.method()` call. mutsu previously tried to parse a first
+# argument and failed with "right-hand expression after '='" — the blocker
+# behind CSV::Table's `$!rowname-width = $row.rwid:` followed by a closing `}`.
+#
+# NOTE: Raku accepts the empty colon form ONLY before `}`; before `;`, `)`, `]`
+# or end of input it still demands a colon-pair. This pin matches that.
+
+plan 6;
+
+class C {
+    has $.v = 5;
+    method twice($n = 1) { $!v * $n }
+}
+
+my $r = C.new;
+
+# Empty colon-call before a closing brace (the CSV::Table shape).
+my $w;
+if 1 {
+    $w = $r.v:
+}
+is $w, 5, 'empty colon-call before } is a no-arg call';
+
+# Empty colon-call before `}` on the same line.
+my $w2;
+if 1 { $w2 = $r.v: }
+is $w2, 5, 'empty colon-call before } on one line is a no-arg call';
+
+# Empty colon-call on a method with an optional param uses the default.
+my $y;
+if 1 {
+    $y = $r.twice:
+}
+is $y, 5, 'empty colon-call uses the parameter default';
+
+# A bare (non-assignment) empty colon-call statement before `}`.
+my $seen;
+if 1 {
+    $seen = $r.twice:
+}
+is $seen, 5, 'bare empty colon-call before } works';
+
+# The non-empty colon-arg forms must still work (parenthesised so the colon
+# form does not swallow the test description as an argument).
+is ($r.twice: 3), 15, 'colon-call with a positional arg still works';
+
+my @list = <a b c>;
+is (@list.join: '-'), 'a-b-c', 'colon-call with a string arg still works';
+
+done-testing;


### PR DESCRIPTION
## Problem

The colon method-call form `\$obj.method:` takes the rest of the statement as
its argument list. When the colon sits immediately before a block-closing `}`
— an empty argument list at the end of a block — Raku treats it as a plain
zero-argument `.method()` call:

```raku
if $row.rwid > $!rowname-width {
    $!rowname-width = $row.rwid:
}
```

mutsu instead tried to parse a first argument after the `:`, hit the `}`, and
failed with `Confused. expected right-hand expression after '='`. This was the
parse blocker behind **CSV::Table**.

## Fix

Handle the empty case in the postfix colon-arg parser: `.method:` immediately
before a block-closing `}` is a no-arg call.

This matches Raku's exact rule — the zero-arg colon form is accepted **only**
before a block-closing `}`; before `;` / `)` / `]` / end of input Raku still
demands a colon-pair (verified against `raku`), so those keep parsing an
argument as before. Non-empty colon-arg calls (`.m: 1, 2`, `.join: '-'`) are
unchanged.

## Result

`use CSV::Table` now advances past the parse error to `missing_dep`
(JSON::Fast / YAMLish — the same deps raku needs). Pin:
`t/method-call-colon-empty-args.t` (cross-checked against raku). All
`t/*method*` / `*colon*` / `*listop*` tests and `make test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)