### PR TITLE
fix: canonical `.HOW` identity and metaobject `.name($obj)` on a variable

### DIFF
--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -3269,14 +3269,15 @@ impl Interpreter {
             && Self::is_classhow_method(method)
         {
             let mut how_args = args.to_vec();
-            if !matches!(
-                how_args.first().map(|v| v.view()),
-                Some(ValueView::Package(_))
-                    | Some(ValueView::Instance { .. })
-                    | Some(ValueView::ParametricRole { .. })
-                    | Some(ValueView::Mixin(_, _))
-            ) && let Some(ValueView::Str(type_name)) =
-                attributes.as_map().get("name").map(|v| v.view())
+            // A HOW method takes the introspected object as its first argument
+            // (`$obj.^name` desugars to `$obj.HOW.name($obj)`). When the explicit
+            // `$obj.HOW.name(...)` form is called with NO object argument, supply
+            // the type name recorded on the HOW so `Int.HOW.name` still works.
+            // Only do this when no argument was passed — an explicitly-passed
+            // object may be any value (e.g. `1.HOW.name(1)`), not just a Package.
+            if how_args.is_empty()
+                && let Some(ValueView::Str(type_name)) =
+                    attributes.as_map().get("name").map(|v| v.view())
             {
                 how_args.insert(0, Value::package(Symbol::intern(&type_name)));
             }

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -1995,6 +1995,18 @@ impl Interpreter {
             } => Some((class_name, attributes.clone(), id)),
             _ => None,
         } {
+            // A metaobject method (`$metaobject.name($obj)`) on a HOW instance is a
+            // ClassHOW method, NOT an rw-accessor write. The HOW instance stores a
+            // `name` attribute, so without this the `args.len() == 1` rw-accessor
+            // setter below would treat `$mo.name(1)` as `name = 1` and return the
+            // argument. Route it to the ClassHOW dispatcher (which mirrors the
+            // non-mut `dispatch_instance_and_fallback` classhow path).
+            if Self::is_classhow_method(method)
+                && (Self::is_metamodel_how(&class_name)
+                    || self.is_metamodel_how_class(&class_name.resolve()))
+            {
+                return self.dispatch_classhow_method(method, args.to_vec());
+            }
             if crate::runtime::utils::is_buf_like_class(&class_name.resolve())
                 && matches!(method, "write-ubits" | "write-bits")
                 && args.len() == 3

--- a/src/runtime/utils/shaped.rs
+++ b/src/runtime/utils/shaped.rs
@@ -264,6 +264,18 @@ pub(crate) fn values_identical(left: &Value, right: &Value) -> bool {
                 let a_val = a_attrs.as_map().get("WHICH").map(|v| v.to_string_value());
                 let b_val = b_attrs.as_map().get("WHICH").map(|v| v.to_string_value());
                 a_val == b_val
+            } else if a_name == b_name
+                && a_name.starts_with("Perl6::Metamodel::")
+                && a_name.ends_with("HOW")
+            {
+                // A metaobject (`.HOW`) is canonical per introspected type in raku:
+                // `1.HOW === 2.HOW === Int.HOW` are all True (the same ClassHOW),
+                // while `1.HOW === Num.HOW` is False. mutsu allocates a fresh HOW
+                // instance per `.HOW` call, so compare by the introspected type
+                // name (stored in the `name` attribute) rather than instance id.
+                let a_val = a_attrs.as_map().get("name").map(|v| v.to_string_value());
+                let b_val = b_attrs.as_map().get("name").map(|v| v.to_string_value());
+                a_val == b_val
             } else {
                 a_id == b_id
             }

--- a/t/how-metaobject-identity.t
+++ b/t/how-metaobject-identity.t
@@ -1,0 +1,34 @@
+use Test;
+
+# A metaobject (`.HOW`) is canonical per introspected type: `1.HOW` and
+# `2.HOW` are the same ClassHOW, so `===` compares them by the introspected
+# type, not by a fresh allocation. And `$how.name($obj)` is a ClassHOW method
+# (`$obj.^name` desugars to `$obj.HOW.name($obj)`), not an rw-accessor write.
+
+plan 12;
+
+# HOW identity (=== over metaobjects)
+ok  1.HOW === 2.HOW,   'same-type instances share the metaobject';
+ok  1.HOW === Int.HOW, 'instance and type object share the metaobject';
+nok 1.HOW === Num.HOW, 'different types have distinct metaobjects';
+ok  "a".HOW === "b".HOW, 'two Str instances share the Str metaobject';
+nok "a".HOW === 1.HOW,   'Str and Int metaobjects differ';
+
+# .name($obj) on a metaobject, inline chain
+is 1.HOW.name(1), 'Int', 'inline 1.HOW.name(1) is Int';
+is 1.^name,       'Int', '1.^name is Int';
+
+# .name($obj) on a metaobject held in a variable (was misread as an rw setter)
+my $object     = 1;
+my $metaobject = 1.HOW;
+is $metaobject.name($object), 'Int', 'variable $metaobject.name($object) is Int';
+
+my $h = Int.HOW;
+is $h.name(Int), 'Int', 'variable Int.HOW held, .name(Int) is Int';
+
+# Works for a user class too
+class Foo { has $.x }
+my $fh = Foo.HOW;
+is $fh.name(Foo), 'Foo', 'user-class metaobject .name is Foo';
+ok Foo.HOW === Foo.new.HOW, 'user-class type object and instance share metaobject';
+nok Foo.HOW === Int.HOW,    'user-class and Int metaobjects differ';


### PR DESCRIPTION
From the QA doc-diff campaign (PLAN.md §8), scanning `Language/objects.rakudoc` — findings [15]/[16]/[17].

## Problem

Two related metaobject (MOP) divergences:

**[15] `.HOW` identity.** `1.HOW === 2.HOW === Int.HOW` are all True in raku (one canonical ClassHOW per introspected type), `1.HOW === Num.HOW` False. mutsu allocated a fresh HOW instance per `.HOW` call and `===` compared by instance id → always False.

**[16]/[17] `$metaobject.name($obj)`.** `$obj.^name` desugars to `$obj.HOW.name($obj)`, so `.name($obj)` is a ClassHOW method. But the HOW instance stores a `name` attribute, so on a **variable** receiver (compiles to `CallMethodMut`) the `args.len() == 1` rw-accessor setter treated `$mo.name(1)` as `name = 1` and returned the argument (`1`, not `Int`). The inline `1.HOW.name(1)` chain also broke because the arg guard inserted the type-name Package whenever the first arg was not Package-like, breaking the `.name` arity match.

## Fix

- `values_identical` (utils/shaped.rs): compare two `Perl6::Metamodel::*HOW` instances by their introspected type name rather than instance id.
- `call_method_mut_with_values` (methods_mut_dispatch.rs): route a classhow method on a metamodel-HOW instance to `dispatch_classhow_method` before the rw-accessor setter.
- `call_method_with_values` (methods_call_dispatch.rs): insert the type-name Package into a classhow method's args only when no object argument was passed.

Pin `t/how-metaobject-identity.t` (12 cases). `make test` passes; whitelisted S12-introspection / S12-meta roast tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)