### PR TITLE
fix: compose every role in `1 but (R1, R2)` as a proper role mixin

### DIFF
--- a/src/vm/vm_mixin_does_ops.rs
+++ b/src/vm/vm_mixin_does_ops.rs
@@ -50,6 +50,28 @@ impl Interpreter {
             self.stack.push(composed);
             return Ok(());
         }
+        // A list of roles on the RHS (`1 but (R1,)` — the single-element tuple
+        // reaches here; `(R1, R2)` is split into per-element ops by the compiler).
+        // Compose every role in the list, so `.^name` renders `Int+{R1}`.
+        if let ValueView::Array(items, _) = right.view()
+            && !items.is_empty()
+            && items.iter().all(|e| match e.view() {
+                ValueView::Package(name) => self.has_role(&name.resolve()),
+                ValueView::Str(name) => self.has_role(&name),
+                _ => false,
+            })
+        {
+            if let Some(tn) = &left_type_object
+                && self.is_role_type_name(tn)
+            {
+                return Err(self.but_on_type_object_error(tn));
+            }
+            let roles: Vec<Value> = items.iter().cloned().collect();
+            let composed = loan_env!(self, eval_does_values_list(left, &roles))?;
+            self.carrier_writeback_changed_aggregates(code, &pre_env);
+            self.stack.push(composed);
+            return Ok(());
+        }
         // A type object / class (not a role) on the RHS: into a type-object
         // invocant it is X::Does::TypeObject; otherwise not composable.
         if matches!(right.view(), ValueView::Package(_)) {
@@ -68,6 +90,21 @@ impl Interpreter {
     pub(super) fn exec_but_mixin_tuple_elem_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
+        // A role element in the tuple (`1 but (R1, R2)`) is composed as a proper
+        // role mixin, not a value mixin: the single-role `but R` path composes
+        // via `eval_does_values` so `.^name` renders `Int+{R1,R2}`. Each tuple
+        // element pops the previous element's result as `left`, so composing
+        // role-by-role accumulates the mixed-in roles onto the same value.
+        let is_role = match right.view() {
+            ValueView::Package(name) => self.has_role(&name.resolve()),
+            ValueView::Str(name) => self.has_role(&name),
+            _ => false,
+        };
+        if is_role {
+            let composed = loan_env!(self, eval_does_values(left, right))?;
+            self.stack.push(composed);
+            return Ok(());
+        }
         let mixin_type = Self::mixin_type_for_value(&right);
         // Check for duplicate type conflict
         if let ValueView::Mixin(_, existing) = left.view()

--- a/t/but-role-list.t
+++ b/t/but-role-list.t
@@ -1,0 +1,28 @@
+use Test;
+
+# `1 but (R1, R2)` composes EVERY role in the parenthesized list as a proper
+# role mixin, so `.^name` renders `Int+{R1,R2}` and every role method is
+# reachable. Previously the tuple path applied each element as a plain value
+# mixin, dropping the roles entirely (`.^name` was just `Int`).
+
+plan 8;
+
+role R1 { method m { 'm!' } }
+role R2 { method n { 'n!' } }
+
+my $x = 1 but (R1, R2);
+is $x.^name, 'Int+{R1,R2}', 'both roles show in the mixin name';
+is $x.m, 'm!', 'R1 method reachable';
+is $x.n, 'n!', 'R2 method reachable';
+is $x + 4, 5, 'still numifies as the base Int';
+
+# A single role in parens is equivalent to the bare form
+my $y = 2 but (R1,);
+is $y.^name, 'Int+{R1}', 'single-role list composes R1';
+is $y.m, 'm!', 'single-role list method reachable';
+
+# Three roles
+role R3 { method o { 'o!' } }
+my $z = 3 but (R1, R2, R3);
+is $z.^name, 'Int+{R1,R2,R3}', 'three roles compose';
+is $z.o, 'o!', 'R3 method reachable';


### PR DESCRIPTION
From the QA doc-diff campaign (PLAN.md §8) scanning `Language/objects.rakudoc` — finding [13].

## Problem

```raku
role R1 { method m {} }
role R2 { method n {} }
say (1 but (R1, R2)).^name;   # raku: Int+{R1,R2}   mutsu: Int
```

mutsu applied each element of the parenthesized list as a plain **value** mixin (keyed by its type name), which dropped the roles entirely — `.^name` was just `Int` and the role methods were unreachable.

## Fix

- `exec_but_mixin_tuple_elem_op` (the per-element op the compiler emits for a multi-element tuple RHS): compose a role element via `eval_does_values` instead of `apply_single_mixin`. Each element pops the previous result as its left operand, so composing role-by-role accumulates the mixed-in roles.
- `exec_but_mixin_op`: the single-element tuple `1 but (R1,)` (which the compiler does not split, so it arrives here as an Array RHS) composes an all-roles list via `eval_does_values_list`.

Value tuples (`True but (1, "x")`) are unaffected. Pin `t/but-role-list.t` (8 cases). `make test` passes; S12-construction/roles and S14-roles roast suites stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)