### PR TITLE
fix: `.^parents` returns a List, not an Array

### DIFF
--- a/src/runtime/methods_classhow_parents.rs
+++ b/src/runtime/methods_classhow_parents.rs
@@ -44,7 +44,9 @@ impl Interpreter {
                 .map(|p| Value::package(Symbol::intern(&p)))
                 .collect()
         };
-        Ok(Value::real_array(parents))
+        // `.^parents` returns a List in raku (`.WHAT` is `(List)`, gists `(...)`),
+        // not an Array — matching `.^roles`/`.^mro`, which already build a List.
+        Ok(Value::array(parents))
     }
 
     fn parents_tree(&mut self, class_name: &str) -> Vec<Value> {

--- a/t/parents-list-render.t
+++ b/t/parents-list-render.t
@@ -1,0 +1,24 @@
+use Test;
+
+# `.^parents` returns a List in raku (its `.WHAT` is `(List)` and it gists with
+# parens `(...)`), like `.^roles` and `.^mro`. mutsu returned a real Array, so
+# it gisted as `[...]` and `.WHAT` was `(Array)`.
+
+plan 8;
+
+class Animal { }
+class Dog is Animal { }
+
+is Dog.^parents.WHAT.gist, '(List)', '.^parents is a List';
+is Dog.^parents.raku, '(Animal,)', '.^parents.raku uses List parens';
+is Dog.^parents.gist, '((Animal))', '.^parents gists with List parens';
+is Dog.new.^parents.WHAT.gist, '(List)', '.^parents on an instance is a List';
+
+# :all keeps the List type
+is Dog.^parents(:all).WHAT.gist, '(List)', '.^parents(:all) is a List';
+is Dog.^parents(:all).elems, 3, ':all lists Animal, Any, Mu';
+
+# Elements are still the parent type objects (assignment to @ works)
+my @p = Dog.^parents;
+ok @p[0] =:= Animal, 'first parent element is Animal';
+is @p.elems, 1, 'one immediate parent';


### PR DESCRIPTION
From the QA doc-diff campaign (PLAN.md §8) scanning `Language/objects.rakudoc` — finding [9].

## Problem

`.^parents` returns a **List** in raku (`.WHAT` is `(List)`, it gists with parens `(...)`), like `.^roles` and `.^mro`. mutsu returned a real Array:

```
Dog.^parents.gist   # raku: ((Animal))   mutsu: [(Animal)]
Dog.^parents.WHAT   # raku: (List)       mutsu: (Array)
Dog.^parents.raku   # raku: (Animal,)    mutsu: [Animal]
```

## Fix

`dispatch_classhow_parents` builds its result with `Value::array` (a List-kind array) instead of `Value::real_array`. Elements are unchanged, so assigning `.^parents` to a `@`-array and every `:all`/`:local`/`:excl` form behave the same; only the container type and gist/raku rendering are corrected.

Pin `t/parents-list-render.t` (8 cases). `make test` passes; whitelisted S12-introspection (parents.t/walk.t/meta-class.t/roles.t) and S12-meta roast tests stay green.

Note: the finding's specific `role A is Exception; class X::Ouch does A` case also needs role-exclusion from the class MRO (a role composed via `does` is wrongly kept in mutsu's MRO) — that is a separate, deeper class-registration fix, left for another slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)