### PR TITLE
fix: accept a parenthesized string/bare-ident list in a `handles` trait

### DIFF
--- a/src/parser/stmt/decl/handles.rs
+++ b/src/parser/stmt/decl/handles.rs
@@ -6,6 +6,16 @@ use crate::ast::HandleSpec;
 /// Parse a single handle spec item (colon-pair, word list, regex, wildcard, etc.)
 fn parse_single_handle_spec<'a>(input: &'a str, specs: &mut Vec<HandleSpec>) -> PResult<'a, ()> {
     let r = input;
+    // Quoted method name inside a parenthesized list: `handles('title', "author")`.
+    if r.starts_with('\'') || r.starts_with('"') {
+        let quote = r.as_bytes()[0] as char;
+        let after_open = &r[1..];
+        let end = after_open
+            .find(quote)
+            .ok_or_else(|| PError::expected("closing quote in handles"))?;
+        specs.push(HandleSpec::Name(after_open[..end].to_string()));
+        return Ok((&after_open[end + 1..], ()));
+    }
     // Colon-pair: :exposed<target> or :exposed('target')
     if let Some(after_colon) = r.strip_prefix(':') {
         let (after_name, name) = take_while1(after_colon, |c: char| {
@@ -71,7 +81,10 @@ fn parse_single_handle_spec<'a>(input: &'a str, specs: &mut Vec<HandleSpec>) -> 
         });
         return Ok((rest, ()));
     }
-    Err(PError::expected("handle spec"))
+    // Bare identifier with no fat-arrow inside a parenthesized list is a plain
+    // method name: `handles(title, author)`.
+    specs.push(HandleSpec::Name(name.to_string()));
+    Ok((after_name, ()))
 }
 
 /// Parse handle specifications after the `handles` keyword.

--- a/t/handles-paren-strings.t
+++ b/t/handles-paren-strings.t
@@ -1,0 +1,45 @@
+use Test;
+
+# `handles(...)` with a *parenthesized* list of quoted method names (and bare
+# identifiers), optionally mixed with `exposed => 'target'` rename pairs, is
+# valid Rakudo syntax. mutsu only accepted the bare `handles <a b>` / `handles
+# "a"` forms; the parenthesized-string form failed to parse, so `handles(...)`
+# was misread as a call and the attribute reference lost its `self`.
+
+plan 9;
+
+class Book {
+    has Str  $.title;
+    has Str  $.author;
+    has Str  $.language;
+    has Cool $.publication;
+}
+
+class Product {
+    has Book $.book handles('title', 'author', 'language', year => 'publication');
+}
+
+my $book = Book.new(:title<Dune>, :author('Frank Herbert'),
+                    :language<English>, :publication<1965>);
+my $p = Product.new(:book($book));
+is $p.title,    'Dune',          'quoted string method delegates';
+is $p.author,   'Frank Herbert', 'second quoted string method delegates';
+is $p.language, 'English',       'third quoted string method delegates';
+is $p.year,     '1965',          'mixed fat-arrow rename delegates';
+
+# Bare identifiers in the list
+class P2 { has Book $.book handles(title, author); }
+my $p2 = P2.new(:book($book));
+is $p2.title,  'Dune',          'bare identifier method delegates';
+is $p2.author, 'Frank Herbert', 'second bare identifier delegates';
+
+# Private attribute with mixed rename + bare-string delegation (the Queue idiom)
+class Queue {
+    has @!q handles(enqueue => 'push', dequeue => 'shift', 'elems');
+    method contents { @!q.join(',') }
+}
+my $q = Queue.new;
+$q.enqueue($_) for 1..3;
+is $q.elems, 3, 'bare-string method on a private @-attribute';
+is $q.dequeue, 1, 'rename on a private @-attribute';
+is $q.contents, '2,3', 'remaining elements after dequeue';


### PR DESCRIPTION
From the QA doc-diff campaign (PLAN.md §8) scanning `Language/objects.rakudoc` — findings [3]/[4].

## Problem

```raku
class Product {
    has Book $.book handles('title', 'author', 'language', year => 'publication');
}
```

A parenthesized `handles` list that mixes quoted method names, bare identifiers, and `exposed => 'target'` rename pairs is valid Rakudo syntax, but mutsu failed to parse it: `parse_single_handle_spec` (called per element inside `handles(...)`) only handled colon-pairs (`:name<t>`) and fat-arrows (`n => t`). A bare quoted string or bare identifier fell through to a parse error, so the whole `handles(...)` was misread as a call and the attribute reference lost its self — `Variable $.book used where no 'self' is available`.

The non-parenthesized forms (`handles <a b>`, `handles "a"`) already worked.

## Fix

Add to `parse_single_handle_spec` (parser/stmt/decl/handles.rs):
- a quoted-string arm → `HandleSpec::Name`
- a bare-identifier fallback (an identifier with no following `=>` is a plain method name) → `HandleSpec::Name`

Pin `t/handles-paren-strings.t` (9 cases, incl. a private `@!q` attribute with mixed rename + bare-string delegation). `make test` passes; S12-attributes / S14-roles roast suites stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)