### PR TITLE
fix: `my @a does R = <init>` keeps the role trait and runs the initializer

### DIFF
--- a/src/parser/stmt/decl/my_decl_assign.rs
+++ b/src/parser/stmt/decl/my_decl_assign.rs
@@ -198,13 +198,45 @@ pub(super) fn my_decl_assign_or_default(input: &str, s: MyDeclState) -> PResult<
         if let Some((op, r)) = mixin {
             let (r, _) = ws(r)?;
             if let Ok((r2, operand)) = expression(r) {
+                // `my @a does R = <a b>` — the operand parser greedily absorbs the
+                // `= <init>` as an assignment (`R = <a b>`). Split it back out: the
+                // role is the bareword LHS and the initializer assigns the declared
+                // variable AFTER the mixin (raku applies the trait, then inits).
+                let (role_operand, init_stmt) = match operand {
+                    Expr::AssignExpr {
+                        name: role_name,
+                        expr: init_expr,
+                        is_bind,
+                    } => {
+                        let assign = Stmt::Assign {
+                            name: s.name.clone(),
+                            expr: *init_expr,
+                            op: if is_bind {
+                                crate::ast::AssignOp::Bind
+                            } else {
+                                crate::ast::AssignOp::Assign
+                            },
+                        };
+                        (Expr::BareWord(role_name), Some(assign))
+                    }
+                    other => (other, None),
+                };
                 let mixin_expr = Expr::Binary {
                     left: Box::new(Expr::Var(s.name.clone())),
                     op: crate::token_kind::TokenKind::Ident(op.to_string()),
-                    right: Box::new(operand),
+                    right: Box::new(role_operand),
                 };
                 let stmt = wrap_with_will_leave(stmt, &s.name, s.will_phasers);
-                let block = Stmt::SyntheticBlock(vec![stmt, Stmt::Expr(mixin_expr)]);
+                // Assign the initializer BEFORE mixing the role in: the `does`
+                // desugar mixes the role into the value currently held by the
+                // variable and writes it back, so a later assignment would drop
+                // the mixin. Filling first, then mixing, keeps `Array+{R}`.
+                let mut block_stmts = vec![stmt];
+                if let Some(init_stmt) = init_stmt {
+                    block_stmts.push(init_stmt);
+                }
+                block_stmts.push(Stmt::Expr(mixin_expr));
+                let block = Stmt::SyntheticBlock(block_stmts);
                 if s.apply_modifier {
                     return parse_statement_modifier(r2, block);
                 }

--- a/t/decl-does-role-with-init.t
+++ b/t/decl-does-role-with-init.t
@@ -1,0 +1,33 @@
+use Test;
+
+# `my @a does R = <init>` applies the `does R` role trait to the freshly-declared
+# container AND then runs the `= <init>` initializer. mutsu's operand parser
+# greedily absorbed the `= <init>` into the role operand (`R = <a b>`), so the
+# role was lost and the statement mis-parsed to a Bool.
+
+plan 10;
+
+role R  { method greet { 'hi' } }
+role R2 { method bye   { 'bye' } }
+
+# Array
+my @a does R = <a b c>;
+is @a.^name, 'Array+{R}', 'array does-trait survives the initializer';
+is @a.elems, 3,           'array initializer filled the elements';
+is @a[1], 'b',            'array elements are correct';
+is @a.greet, 'hi',        'role method reachable on the array';
+
+# Array with comma-list initializer
+my @b does R = 1, 2, 3;
+is @b.^name, 'Array+{R}', 'comma-list initializer keeps the role';
+is @b.elems, 3,           'comma-list filled three elements';
+
+# Hash
+my %h does R = (x => 1, y => 2);
+is %h.^name, 'Hash+{R}', 'hash does-trait survives the initializer';
+is %h<x>, 1,             'hash initializer filled a pair';
+is %h.greet, 'hi',       'role method reachable on the hash';
+
+# The bare no-init form still works (regression guard)
+my @c does R2;
+is @c.^name, 'Array+{R2}', 'bare does-trait (no init) still works';


### PR DESCRIPTION
From the QA doc-diff campaign (PLAN.md §8) scanning `Language/objects.rakudoc` — finding [12].

## Problem

```raku
role R {};
my @positional does R = <a b>;
say @positional.^name;   # raku: Array+{R}   mutsu: Bool
```

The `does R` role trait on a `my`-declaration was lost when an initializer followed. mutsu's `does`/`but` operand parser greedily absorbed the `= <a b>` as an assignment (`R = <a b>`), so the role name was gone and the whole statement mis-parsed to a Bool.

## Fix

In the bare-declaration `does`/`but` desugar (my_decl_assign.rs), when the parsed operand is an `AssignExpr` (`R = <init>`), split it back apart: the bareword LHS is the role, the RHS initializes the declared variable. The initializer runs **before** the mixin — the `does` desugar mixes the role into the value currently held and writes it back, so a later assignment would drop the mixin; filling first, then mixing, keeps `Array+{R}`.

Works for `@`/`%` containers with `=` or `:=` initializers; the bare no-init form (`my @a does R`) is unchanged. Pin `t/decl-does-role-with-init.t` (10 cases).

`make test` passes (validated together with the sibling handles slice); S12-construction/roles, S14-roles, S04-declarations roast suites stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)