### PR TITLE
fix: (B)-gate burn down roast ON-survey regressions (5 of 7)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -461,6 +461,37 @@ env-COW payoff.
 
 ## The `(B)` per-store env-write gate — burndown map (survey 2026-07-19, post-#4844)
 
+**STATUS 2026-07-20: t/ ON survey clean; roast ON survey found a residual set.**
+The t/ ON survey reached zero regressions (2026 files / 19216 tests pass with
+`MUTSU_GATE_LOCAL_ENV_WRITE=1`), folded by #4859/#4861/#4863/#4869/#4873/#4886/#4889/
+#4890/#4894/#4896/#4897/#4906/#4910/#4914. But the **first full roast whitelist ON
+survey** (1433 files, release) surfaced 7 genuine ON-only regressions that t/ never
+exercised (t/ omits roast's container/cycle edges):
+
+| roast file | symptom | class |
+|-----------|---------|-------|
+| S02-types/mixhash.t, sethash.t | `%h is MixHash; %h<a>--` reads a stale slot | #4890 fired slot-first for `%h`/`@a`, but only `plain_locals` scalars have a gated (slot-authoritative) store; aggregates keep the unconditional env writer, so slot-first read/mutate lost the update. Fixed by `gate_local_slot` (plain-locals guard). |
+| S04-declarations/state.t | `s/^(.)/{ $a++ }/` state var stale | state-in-interpolating-regex reads env by name (#4897/#4869 class) |
+| S04-phasers/interpolate.t | interpolated `END{$hist~=…}` reads stale top-level `my` | phaser block captured-outer fold (RegisterSub-fold #4869/#4889 extended to phasers) |
+| S02-types/WHICH.t | `%seen is SetHash; %seen{…}++` count | same SetHash inc/dec root — fixed by `gate_local_slot`. |
+| S32-trig/e.t | `throws-like 'e()'` with a caller `my $e` no longer dies | throws-like's fresh nested interpreter reconstructs caller scope from `self.env`; a `my $foo` scalar (env skipped under the gate) makes the string EVAL diverge. Direct `EVAL` is consistent ON/OFF — only the nested-interp path differs. NOT an env-by-name fold. **Deferred.** |
+| S32-list/skip.t | block-form `throws-like { @$s }, X::Seq::Consumed` not thrown | `my $s := (1..3).Seq; $s.skip` loses the Seq consumed-state across the `:=` bind under the gate. Distinct root (Seq consumption), block form. **Deferred.** |
+
+Fixed here (gate-ON-only folds, OFF byte-identical): **mixhash.t, sethash.t, WHICH.t**
+(`gate_local_slot` plain-locals guard on the index inc/dec read/mutate),
+**state.t** (`holds_dynamic_substitution` fold + per-slot env-first state save-back),
+**interpolate.t** (`PhaserEnd`/`CheckPhaser` added to `defines_lazy_body`). Still open:
+**e.t, skip.t** — both are throws-like caller-scope-under-gate corners, not env-by-name
+folds; each needs dedicated throws-like/Seq-consumption work.
+
+Release perf where the gate fires: `while`/`loop` bodies ~10-16% faster (JIT-off
+5.02→4.53s, JIT-on 3.37→2.84s on a 5M-iter while loop); `for` bodies are unaffected
+because a `ForLoop`-carrying frame sets `captures_env_by_name` and force-syncs all its
+locals (a separate future refinement: fold only the captured free vars). **Sequence:
+burn down the roast regressions as gate-ON-only folds (OFF byte-identical), re-run the
+roast ON survey to zero, then flip the default and finally delete the gate.** The map
+below is the t/ burndown record.
+
 `exec_block_scope_op` mechanism #1 is fixed (above), but mechanisms #2-#4 have **no
 independent behavior-preserving slice** — they are consumers of the per-store env
 mirror that only break when the store `(B)` is gated. So the remaining campaign is

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -35,7 +35,10 @@ pub(crate) fn reflective_name_access_possible() -> bool {
 /// so the slot is the single source of truth and env-COW can drop the write. This
 /// is the burndown gate — flip and delete once all four env-mirror consumers
 /// (#1 block-restore, #2 cross-thread, #3 call-return reconcile, #4 curry) are
-/// slot-authoritative. Cached like `jit_enabled()`.
+/// slot-authoritative. The t/ ON survey is clean; the roast ON survey (2026-07-20)
+/// surfaced a residual set (mixhash/sethash `%h<a>--`, state-in-regex, interpolated
+/// phasers, WHICH/skip/e) being burned down before the default flip. Cached like
+/// `jit_enabled()`.
 #[inline]
 pub(crate) fn gate_local_env_write() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
@@ -2527,7 +2530,19 @@ impl CompiledCode {
             let defines_lazy_body = self.ops.iter().any(|op| {
                 matches!(
                     op,
-                    OpCode::RegisterSub(_) | OpCode::RegisterClass(_) | OpCode::RegisterRole(_)
+                    OpCode::RegisterSub(_)
+                        | OpCode::RegisterClass(_)
+                        | OpCode::RegisterRole(_)
+                        // A deferred END body (`PhaserEnd`, run after the frame
+                        // exits) and a compile-time BEGIN/CHECK body (`CheckPhaser`)
+                        // reconstruct the installing frame's lexicals BY NAME from
+                        // env, not from `self.locals` — exactly like a lazy sub
+                        // body. Under the gate a top-level `my $hist` mutated only
+                        // through these phasers skips its env mirror, so each phaser
+                        // reads a stale value and the accumulation is lost (roast
+                        // S04-phasers/interpolate.t: END sees `E`, not `BCIE`).
+                        | OpCode::PhaserEnd { .. }
+                        | OpCode::CheckPhaser { .. }
                 )
             });
             // A frame that installs a *resume-safe* CONTROL handler
@@ -2567,7 +2582,41 @@ impl CompiledCode {
                         if !crate::runtime::regex_parse::regex_pattern_is_static(p.as_str())
                 )
             });
-            if defines_lazy_body || installs_resume_control || holds_interpolating_regex {
+            // A frame that runs a substitution with a DYNAMIC replacement
+            // (`s/^(.)/{ $a++ }/`, `s/x/$a/`) re-entrantly evaluates that
+            // replacement, which reads/writes the referenced lexicals BY NAME from
+            // the env (the closure-carried cross-frame store), not this frame's
+            // slots. `holds_interpolating_regex` only catches a dynamic *pattern*;
+            // a static pattern with a code/interpolated replacement slips past it.
+            // Under the gate a `state $a = 0` (or plain `my`) in this frame skips
+            // its env mirror, so the replacement reads a stale value and the
+            // closure's state save-back stores it back (roast S04-declarations/
+            // state.t: `state $a` bumped inside `s///` stays 0). Keep every local
+            // of such a frame env-synced (gate-ON only; a substitution frame is not
+            // a hot arithmetic loop). A purely literal replacement folds nothing.
+            let holds_dynamic_substitution = self.ops.iter().any(|op| {
+                let repl_idx = match op {
+                    OpCode::Subst {
+                        replacement_idx, ..
+                    }
+                    | OpCode::NonDestructiveSubst {
+                        replacement_idx, ..
+                    } => *replacement_idx,
+                    _ => return false,
+                };
+                self.constants
+                    .get(repl_idx as usize)
+                    .map(|c| match c.view() {
+                        ValueView::Str(s) => s.contains(['$', '@', '%', '&', '{']),
+                        _ => true,
+                    })
+                    .unwrap_or(false)
+            });
+            if defines_lazy_body
+                || installs_resume_control
+                || holds_interpolating_regex
+                || holds_dynamic_substitution
+            {
                 self.needs_env_sync.iter_mut().for_each(|b| *b = true);
             }
         }

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -739,10 +739,17 @@ impl Interpreter {
         // are mutated only through `env` by name (e.g. a `state` referenced from a
         // regex replacement part updates env, not the slot — roast state.t #16), so
         // OFF must keep the env-first read. Gate the slot-first order on the flag.
+        // A state var that IS env-synced (folded into `needs_env_sync` — e.g. this
+        // frame runs a dynamic `s///` whose replacement bumps the state by name)
+        // keeps its env mirror current, and that env value is the one the
+        // replacement actually wrote; read it env-first even under the gate so the
+        // bump is not lost (its slot stays at the pre-replacement value).
         let state_slot_first = crate::opcode::gate_local_env_write();
         for (slot, key) in &cc.state_locals {
             let local_name = &cc.locals[*slot];
-            let val = if state_slot_first {
+            let slot_authoritative =
+                state_slot_first && !cc.needs_env_sync.get(*slot).copied().unwrap_or(false);
+            let val = if slot_authoritative {
                 self.locals
                     .get(*slot)
                     .cloned()

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -1320,16 +1320,33 @@ impl Interpreter {
     /// autovivification it drives — is the right source). §1.5 helper — see
     /// docs/lexical-scope-slot-campaign.md.
     pub(super) fn gate_local_slot_value(&self, code: &CompiledCode, name: &str) -> Option<Value> {
-        if !crate::opcode::gate_local_env_write() {
-            return None;
-        }
-        let slot = self.find_local_slot(code, name)?;
+        let slot = self.gate_local_slot(code, name)?;
         let val = self.locals.get(slot)?;
         if val.is_nil() {
             None
         } else {
             Some(val.clone())
         }
+    }
+
+    /// Slot index of a `(B)`-gate-authoritative local, or `None`.
+    ///
+    /// Returns the slot only when the per-store env-write gate is ON **and** the
+    /// name is a `plain_locals` scalar — the only variables whose env mirror the
+    /// gate actually skips, making the slot the authoritative half. Aggregates
+    /// (`@a`/`%h`) always take the unconditional `set_env_with_main_alias` writer
+    /// (vm_var_assign_set_local.rs), so their env stays fresh while their slot may
+    /// hold a stale early snapshot — reading/mutating slot-first there would lose a
+    /// `%h is MixHash; %h<a>--` update (roast S02-types/mixhash.t, sethash.t).
+    pub(super) fn gate_local_slot(&self, code: &CompiledCode, name: &str) -> Option<usize> {
+        if !crate::opcode::gate_local_env_write() {
+            return None;
+        }
+        let slot = self.find_local_slot(code, name)?;
+        if !code.plain_locals.get(slot).copied().unwrap_or(false) {
+            return None;
+        }
+        Some(slot)
     }
 
     /// Resolve a local slot for `name`, preferring the compile-time-baked `slot`

--- a/src/vm/vm_var_assign_post_incdec.rs
+++ b/src/vm/vm_var_assign_post_incdec.rs
@@ -704,12 +704,9 @@ impl Interpreter {
         // slot's container directly under the gate; the slot is the authoritative
         // half (and its backing node is shared, so this is still in-place). Gate
         // OFF (default) uses `env.get_mut` exactly as before (byte-identical).
-        let gate_slot = if crate::opcode::gate_local_env_write() {
-            self.find_local_slot(code, &name)
-                .filter(|&s| !self.locals[s].is_nil())
-        } else {
-            None
-        };
+        let gate_slot = self
+            .gate_local_slot(code, &name)
+            .filter(|&s| !self.locals[s].is_nil());
         let modified_in_place = if let Some(container_value) = match gate_slot {
             Some(s) => self.locals.get_mut(s),
             None => self.env_mut().get_mut(&name),

--- a/t/gate-b-aggregate-index-incdec.t
+++ b/t/gate-b-aggregate-index-incdec.t
@@ -1,0 +1,49 @@
+# (B)-gate: `%h`/`@a` aggregate index inc/dec must stay env-authoritative.
+#
+# The per-store env-write gate (MUTSU_GATE_LOCAL_ENV_WRITE) only skips the env
+# mirror for `plain_locals` scalars, so a `%`/`@` aggregate keeps a fresh env
+# while its local slot may hold a stale early snapshot. #4890 read/mutated the
+# inc/dec container slot-first for every name, which lost a `%h is MixHash;
+# %h<a>--` update under the gate (roast S02-types/mixhash.t, sethash.t). The
+# `gate_local_slot` plain-locals guard restricts slot-first to scalars.
+#
+# Runs under both gate states (the harness may set MUTSU_GATE_LOCAL_ENV_WRITE);
+# results must be identical either way.
+use Test;
+
+plan 10;
+
+{
+    my %h is MixHash = a => 1, c => 1;
+    %h<c>++;
+    is %h<c>, 2, 'MixHash %h<c>++ increments';
+    %h<a>--;
+    is %h.keys.sort.join(','), 'c', 'MixHash %h<a>-- to zero removes the key';
+    %h<a>--;
+    is %h<a>, -1, 'MixHash %h<a>-- goes negative';
+    ok %h<a>:exists, 'MixHash negative key exists';
+}
+
+{
+    my %h is SetHash = a => True, c => True;
+    %h<c>--;
+    nok %h<c>:exists, 'SetHash %h<c>-- removes the member';
+    %h<b>++;
+    ok %h<b>:exists, 'SetHash %h<b>++ adds the member';
+}
+
+{
+    my @a = 10, 20, 30;
+    @a[1]++;
+    is @a[1], 21, 'plain @a[1]++ increments';
+    @a[4]++;
+    is @a[4], 1, 'plain @a autoviv element ++ from hole';
+}
+
+{
+    my %h = x => 5;
+    %h<x>--;
+    is %h<x>, 4, 'plain %h<x>-- decrements';
+    %h<y>++;
+    is %h<y>, 1, 'plain %h<y>++ autovivs to 1';
+}

--- a/t/gate-b-subst-and-phaser-fold.t
+++ b/t/gate-b-subst-and-phaser-fold.t
@@ -1,0 +1,47 @@
+# (B)-gate: dynamic-substitution and deferred/compile-time phaser folds.
+#
+# Under MUTSU_GATE_LOCAL_ENV_WRITE a plain-lexical store skips its env mirror.
+# Two roast ON-survey regressions relied on the mirror:
+#   * roast S04-declarations/state.t: a `state` var bumped inside a `s///`
+#     replacement block updates the var BY NAME through env (the replacement is
+#     evaluated re-entrantly), so a static-pattern substitution whose dynamic
+#     replacement references the var must keep the frame env-synced, and the
+#     closure's state save-back must read env-first for that (env-synced) var.
+#   * roast S04-phasers/interpolate.t: a top-level `my` var mutated only through
+#     END/BEGIN/CHECK phaser bodies (run deferred / at compile time, reconstructed
+#     from env by name) must keep the declaring frame env-synced.
+#
+# Both fixes are gate-ON-only folds; results are identical with the gate on or off.
+use Test;
+
+plan 4;
+
+# state var referenced from an s/// replacement part (state.t #16 shape)
+{
+    my $str = "abc";
+    my $re = { state $a = 0; $str ~~ s/^(.)/{ $a++ }/; };
+    $re(); $re(); $re();
+    is $str, "2bc", 'state var bumped inside s/// replacement accumulates';
+}
+
+# plain state accumulation is unaffected (the #4869 case the fold must not break)
+{
+    my $c = { state $s = 0; $s = $s + 10; $s };
+    is "{$c()},{$c()},{$c()}", "10,20,30", 'plain state accumulation still works';
+}
+
+# top-level my mutated through interpolated compile-time + deferred phasers
+# (interpolate.t shape: BEGIN/CHECK/INIT accumulate, END reads the total)
+my $hist;
+"{ BEGIN { $hist ~= 'B' } }";
+"{ CHECK { $hist ~= 'C' } }";
+"{ INIT  { $hist ~= 'I' } }";
+is $hist, 'BCI', 'interpolated BEGIN/CHECK/INIT accumulate into a top-level my';
+
+# a dynamic replacement that interpolates (not a code block) also folds
+{
+    my $s = "xyz";
+    my $n = 7;
+    $s ~~ s/^./$n/;
+    is $s, "7yz", 's/// with an interpolated replacement sees the live lexical';
+}


### PR DESCRIPTION
## Context

The `(B)` per-store env-write gate (`MUTSU_GATE_LOCAL_ENV_WRITE`, default OFF) skips the name-keyed `env` mirror for slot-authoritative plain lexicals — the perf/architecture prerequisite for env-COW and the eventual default flip. Its burndown had **only ever been surveyed against `t/`**. Running the **first full roast whitelist ON survey** (release, 1433 files) surfaced **7 genuine ON-only regressions** that `t/` never exercised (`t/` omits roast's container/cycle edges).

This PR burns down **5 of the 7**. All changes are **gate-ON-only folds / guards** and are **byte-identical with the gate off** (default build unaffected).

## Fixes

| roast file | root cause | fix |
|-----------|-----------|-----|
| `S02-types/mixhash.t`, `sethash.t`, `WHICH.t` | `%h is MixHash; %h<a>--` (and `%seen is SetHash; %seen{…}++`) read a stale slot. #4890 read/mutated the inc/dec container slot-first for **every** name, but only `plain_locals` scalars have a gated store; a `@`/`%` aggregate keeps the unconditional env writer, so its slot can be a stale early snapshot. | new `gate_local_slot` helper restricts slot-first to plain-locals (read + writeback) |
| `S04-declarations/state.t` | a `state` var bumped inside an `s///` replacement (`s/^(.)/{ \$a++ }/`) updates the var **by name** through env (replacement is re-entrant). `holds_interpolating_regex` only folds a dynamic *pattern*. | add `holds_dynamic_substitution` fold; make closure state save-back env-first for an env-synced state var |
| `S04-phasers/interpolate.t` | a top-level `my` mutated only through deferred END / compile-time BEGIN/CHECK phasers (reconstructed from env by name) lost its accumulation | add `PhaserEnd`/`CheckPhaser` to `defines_lazy_body` |

## Still open (deferred)

Two throws-like corners remain — **not env-by-name folds**, each needs dedicated work:
- `S32-trig/e.t` — string `throws-like 'e()'`: the fresh nested interpreter reconstructs caller scope from `self.env`, which the gate leaves incomplete for a `my $e` scalar. Direct `EVAL` is consistent ON/OFF; only the nested-interp path diverges.
- `S32-list/skip.t` — block `throws-like { @\$s }, X::Seq::Consumed`: `my \$s := (1..3).Seq; \$s.skip` loses the Seq consumed-state across the `:=` bind under the gate.

These **block the default flip**; the gate stays default OFF until they are cleared.

## Perf (why the flip is wanted)

Where the gate fires (release): `while`/`loop` bodies ~10–16% faster (JIT-off 5.02→4.53s, JIT-on 3.37→2.84s on a 5M-iter while loop). `for` bodies are unaffected (a `ForLoop`-carrying frame force-syncs all locals — a separate future refinement).

## Verification

- `t/` passes fully under **both** gate states (`prove t/` and `MUTSU_GATE_LOCAL_ENV_WRITE=1 prove t/`).
- Full roast whitelist ON survey residual is now **e.t + skip.t only** (down from 7).
- Pins: `t/gate-b-aggregate-index-incdec.t`, `t/gate-b-subst-and-phaser-fold.t` (both pass ON and OFF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)