### PR TITLE
fix: an immutable Map gists as `Map.new((...))`, not `{...}`

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -502,7 +502,12 @@ pub(super) fn dispatch(
                             .iter()
                             .map(|k| format!("{} => {}", k, gist_item(&map[*k])))
                             .collect();
-                        format!("{{{}}}", parts.join(", "))
+                        // A nested immutable Map gists as `Map.new((...))`, not `{...}`.
+                        if map.declared_type.as_deref() == Some("Map") {
+                            format!("Map.new(({}))", parts.join(", "))
+                        } else {
+                            format!("{{{}}}", parts.join(", "))
+                        }
                     }
                     ValueView::Pair(k, v) => format!("{} => {}", k, gist_item(v)),
                     ValueView::ValuePair(k, v) => format!("{} => {}", gist_item(k), gist_item(v)),
@@ -614,7 +619,12 @@ pub(super) fn dispatch(
                             .iter()
                             .map(|k| format!("{} => {}", k, gist_item(&map[*k])))
                             .collect();
-                        format!("{{{}}}", parts.join(", "))
+                        // A nested immutable Map gists as `Map.new((...))`, not `{...}`.
+                        if map.declared_type.as_deref() == Some("Map") {
+                            format!("Map.new(({}))", parts.join(", "))
+                        } else {
+                            format!("{{{}}}", parts.join(", "))
+                        }
                     }
                     ValueView::Pair(k, v) => format!("{} => {}", k, gist_item(v)),
                     ValueView::ValuePair(k, v) => format!("{} => {}", gist_item(k), gist_item(v)),

--- a/src/runtime/utils/gist.rs
+++ b/src/runtime/utils/gist.rs
@@ -172,6 +172,12 @@ pub(crate) fn gist_value(value: &Value) -> String {
                 .map(|k| format!("{} => {}", k, gist_value(&items[*k])))
                 .collect();
             SEEN_PTRS.with(|seen| pop_ptr(seen, ptr));
+            // An immutable Map gists as `Map.new((k => v, ...))`, not `{...}`
+            // (matching raku and the `.raku` renderer). `Foo.enums`, `%h.Map`,
+            // and `Map.new(...)` all carry the `Map` declared-type tag.
+            if items.declared_type.as_deref() == Some("Map") {
+                return format!("Map.new(({}))", parts.join(", "));
+            }
             format!("{{{}}}", parts.join(", "))
         }
         ValueView::Set(..) | ValueView::Bag(..) | ValueView::Mix(..) => {

--- a/t/map-gist.t
+++ b/t/map-gist.t
@@ -1,0 +1,31 @@
+use Test;
+
+# An immutable Map gists as `Map.new((k => v, ...))` (sorted keys), not the
+# `{...}` hash form — matching raku and the `.raku` renderer. A plain Hash still
+# gists as `{...}`.
+
+plan 8;
+
+is Map.new((a => 1, b => 2)).gist, 'Map.new((a => 1, b => 2))', 'Map.gist uses Map.new(...)';
+is %(x => 10, y => 20).Map.gist, 'Map.new((x => 10, y => 20))', '.Map coercion gists as Map.new';
+
+# `Foo.enums` returns a Map
+enum Mass ( mg => 1/1000, g => 1/1, kg => 1000/1 );
+is Mass.enums.gist, 'Map.new((g => 1, kg => 1000, mg => 0.001))', 'enum .enums gists as Map.new';
+
+# put / Str is unchanged (tab-separated pairs)
+is Map.new((a => 1)).Str, "a\t1", 'Map.Str is tab-separated, not Map.new';
+
+# A plain Hash still gists as {...}
+is { a => 1, b => 2 }.gist, '{a => 1, b => 2}', 'plain Hash still gists as {...}';
+
+# Nested Maps in a list render recursively (both say and .gist paths)
+is [Map.new((a => 1)), Map.new((b => 2))].gist,
+   '[Map.new((a => 1)) Map.new((b => 2))]', 'nested Maps in a list (.gist method)';
+
+# Keys are sorted
+is Map.new((z => 1, a => 2, m => 3)).gist, 'Map.new((a => 2, m => 3, z => 1))', 'Map keys are sorted';
+
+# A Map nested inside a Hash value
+is { outer => Map.new((inner => 1)) }.gist, '{outer => Map.new((inner => 1))}',
+   'Map nested in a Hash value';


### PR DESCRIPTION
From the QA doc-diff campaign (PLAN.md §8) scanning `Language/typesystem.rakudoc` — finding [12].

## Problem

```raku
enum Mass ( mg => 1/1000, g => 1/1, kg => 1000/1 );
say Mass.enums;
# raku:  Map.new((g => 1, kg => 1000, mg => 0.001))
# mutsu: {g => 1, kg => 1000, mg => 0.001}
```

An immutable Map gisted as the `{...}` hash form. The `.raku` renderer already special-cased the `Map` declared-type tag; the gist paths did not.

## Fix

Add the same `declared_type == "Map"` check to:
- `gist_value` (runtime/utils/gist.rs) — the say/put/print/note fast path, and the `.gist` method for a non-empty Map (which routes through it);
- both `gist_item` nested renderers in the `.gist` method (dispatch_core_repr.rs), so a Map nested inside a list/array/hash also renders `Map.new((...))`.

A plain Hash still gists as `{...}`. Sorted keys, `key => value` form, matching raku. Pin `t/map-gist.t` (8 cases).

`make test` passes; S32-hash, S12-enums, S02-types/pair roast suites stay green.

Out of scope (separate pre-existing slow-path edge): an **empty** Map via the `.gist` **method** still renders `Map.new` without the `(())` — `say Map.new(())` (the fast path) is already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)