### PR TITLE
fix: an enum value's `.^name` is its enum type name, not "Int"

### DIFF
--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -568,6 +568,10 @@ impl Interpreter {
             ValueView::Instance { class_name, .. } => {
                 crate::value::user_facing_type_name(&class_name.resolve()).to_string()
             }
+            // An enum VALUE names its enum type (`Bob.^name` is `Names`), not the
+            // underlying storage type — `value_type_name` reports "Int" for the
+            // int-backed representation, which is only the `.WHICH`/`.Int` view.
+            ValueView::Enum { enum_type, .. } => enum_type.resolve(),
             ValueView::Mixin(inner, _) => match inner.as_ref().view() {
                 ValueView::Instance { class_name, .. } => {
                     crate::value::user_facing_type_name(&class_name.resolve()).to_string()

--- a/t/enum-value-caret-name.t
+++ b/t/enum-value-caret-name.t
@@ -1,0 +1,30 @@
+use Test;
+
+# An enum VALUE reports its enum TYPE name from `.^name`, not the underlying
+# int/str storage type. Previously `Bob.^name` returned "Int" because the
+# caret-name dispatch fell through to `value_type_name`, which reports the
+# int-backed representation.
+
+plan 8;
+
+enum Names <Bob Alice Carol>;
+is Bob.^name, 'Names', 'enum value .^name is the enum type name';
+is Alice.^name, 'Names', 'another enum value .^name';
+
+my $x = Bob;
+is $x.^name, 'Names', '.^name through a variable';
+
+is Names.^name, 'Names', 'enum TYPE object .^name is unchanged';
+
+# The underlying int view is still available via .Int / .value.
+is Bob.Int, 0, '.Int still gives the underlying integer';
+is Alice.value, 1, '.value still gives the underlying value';
+
+# Named (index-valued) enums.
+enum Color (red => 1, green => 2);
+is green.^name, 'Color', 'named enum value .^name';
+
+# .^name maps over a list of enum values.
+is-deeply (Bob, Alice).map(*.^name).List, ('Names', 'Names'), '.^name via map';
+
+done-testing;


### PR DESCRIPTION
## Summary

`Bob.^name` (for `enum Names <Bob Alice Carol>`) returned `Int` instead of `Names`.

The caret-name dispatch (`dispatch_caret_name`) had no arm for `ValueView::Enum`, so it fell through to `value_type_name`, which reports the int-backed storage type (`Int`) — that is only the `.WHICH`/`.Int` view of an enum value, not the value's type. `.WHAT` was already correct (`(Names)`) via the enum method dispatch; this aligns `.^name` with it.

```raku
enum Names <Bob Alice Carol>;
say Bob.^name;   # was "Int", now "Names" (matches raku)
say Bob.WHAT;    # already "(Names)"
say Bob.Int;     # still 0 (underlying value unchanged)
```

## Provenance

From the doc-diff QA campaign (Language/typesystem.rakudoc finding [11], "enum-value type identity").

## Tests

- New pin: `t/enum-value-caret-name.t`
- All 7 whitelisted `roast/S12-enums/*.t` still pass; local enum tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)