### PR TITLE
fix: PROCESS:: compound assignment (`//=`/`+=`) reaches the dynamic store

### DIFF
--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -462,6 +462,21 @@ impl Compiler {
             });
             return;
         }
+        // Runtime-key PROCESS:: assignment (`PROCESS::{$k} = v`), notably how a
+        // `//=` / `||=` compound assignment desugars its subscript into a temp
+        // variable. Without this it would fall through to the generic path, which
+        // writes into a throwaway `build_pseudo_stash` hash and silently drops the
+        // store. Route it to the same env dynamic-var write as the literal-key op.
+        if let Expr::PseudoStash(stash_name) = target
+            && stash_name == "PROCESS::"
+        {
+            self.compile_expr(value);
+            self.compile_expr(index);
+            let stash_name_idx = self.code.add_constant(Value::str(stash_name.clone()));
+            self.code
+                .emit(OpCode::IndexAssignPseudoStashKeyed { stash_name_idx });
+            return;
+        }
         if let Some(name) = Self::index_assign_target_name(target) {
             let target_slot = self.local_map.get(&name).copied();
             if Self::index_assign_target_requires_eval(target) {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -981,6 +981,12 @@ pub(crate) enum OpCode {
         stash_name_idx: u32,
         key_name_idx: u32,
     },
+    /// Runtime-key variant of `IndexAssignPseudoStashNamed` (e.g.
+    /// `PROCESS::{$k} = v`, how a `//=`/`||=` compound assign desugars the
+    /// subscript into a temp). Stack: `[..., value, key]`.
+    IndexAssignPseudoStashKeyed {
+        stash_name_idx: u32,
+    },
     /// Element-for-mutation load for `@a[i].push(...)` / `%h<k>.pop` etc.:
     /// read the element like a plain subscript; with `autoviv` set (push/
     /// append/unshift/prepend), a missing element (Nil / Any / Mu hole) is
@@ -2776,6 +2782,7 @@ impl CompiledCode {
             | OpCode::PreDecrementIndex(name_idx) => Some(*name_idx),
             OpCode::DeleteIndexNamed(name_idx, _) => Some(*name_idx),
             OpCode::IndexAssignPseudoStashNamed { stash_name_idx, .. } => Some(*stash_name_idx),
+            OpCode::IndexAssignPseudoStashKeyed { stash_name_idx } => Some(*stash_name_idx),
             OpCode::ArrayPush {
                 target_name_idx, ..
             } => Some(*target_name_idx),
@@ -3648,6 +3655,7 @@ impl CompiledCode {
                     | OpCode::IndexAssignDeepNested { .. }
                     | OpCode::IndexAssignGeneric
                     | OpCode::IndexAssignPseudoStashNamed { .. }
+                    | OpCode::IndexAssignPseudoStashKeyed { .. }
                     | OpCode::IndexElemAutoviv { .. }
                     | OpCode::PostIncrement(..)
                     | OpCode::PostDecrement(..)

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3368,6 +3368,10 @@ impl Interpreter {
                 self.exec_index_assign_pseudo_stash_named_op(code, *stash_name_idx, *key_name_idx)?;
                 *ip += 1;
             }
+            OpCode::IndexAssignPseudoStashKeyed { stash_name_idx } => {
+                self.exec_index_assign_pseudo_stash_keyed_op(code, *stash_name_idx)?;
+                *ip += 1;
+            }
             OpCode::IndexAssignExprNested {
                 name_idx,
                 outer_positional,

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -2085,6 +2085,59 @@ impl Interpreter {
         Ok(())
     }
 
+    /// Store `PROCESS::<$name> = value` as the process-level dynamic variable, so
+    /// a later `$*name` (stored in the env as `*name`) resolves to it. This is
+    /// how `Rakudo::Internals.REGISTER-DYNAMIC` installs defaults (e.g.
+    /// DBIish's `$*DBI-DEFS`). Returns the (coerced) stored value for the
+    /// expression result. Shared by the literal-key (`PROCESS::<$x>`) and
+    /// runtime-key (`PROCESS::{$k}`) assignment paths.
+    pub(super) fn store_process_dynamic(
+        &mut self,
+        raw_key: &str,
+        val: Value,
+    ) -> Result<Value, RuntimeError> {
+        // Map the sigiled stash key to the env dynamic-var key:
+        //   $name → *name, @name → @*name, %name → %*name, name → *name
+        let env_key = match raw_key.chars().next() {
+            Some('$') => format!("*{}", &raw_key[1..]),
+            Some('@') => format!("@*{}", &raw_key[1..]),
+            Some('%') => format!("%*{}", &raw_key[1..]),
+            _ => format!("*{raw_key}"),
+        };
+        // `PROCESS::<$REPO> := $repo` arrives as a bind marker; unwrap it
+        // so the bound value (not the marker Pair) becomes the dynamic.
+        let (val, _bind_source) = Self::unwrap_bind_index_value(val);
+        let val = if env_key.starts_with('@') {
+            runtime::coerce_to_array(val)
+        } else if env_key.starts_with('%') {
+            self.coerce_hash_var_value(&env_key, val)?
+        } else {
+            Self::itemize_scalar_store(&env_key, Self::normalize_scalar_assignment_value(val))
+        };
+        self.env_mut().insert(env_key, val.clone());
+        Ok(val)
+    }
+
+    /// Runtime-key variant of `IndexAssignPseudoStashNamed`: the subscript key is
+    /// computed at runtime (e.g. `PROCESS::{$k} = value`, which is how a `//=` /
+    /// `||=` compound assignment desugars its index into a temp variable). Stack:
+    /// `[..., value, key]`.
+    pub(super) fn exec_index_assign_pseudo_stash_keyed_op(
+        &mut self,
+        code: &CompiledCode,
+        stash_name_idx: u32,
+    ) -> Result<(), RuntimeError> {
+        let stash_name = Self::const_str(code, stash_name_idx);
+        // The compiler only emits this op for PROCESS:: (see compile_index_assign).
+        debug_assert_eq!(stash_name, "PROCESS::");
+        let key = self.stack.pop().unwrap_or(Value::NIL);
+        let val = self.stack.pop().unwrap_or(Value::NIL);
+        let raw_key = key.to_string_value();
+        let stored = self.store_process_dynamic(&raw_key, val)?;
+        self.stack.push(stored);
+        Ok(())
+    }
+
     pub(super) fn exec_index_assign_pseudo_stash_named_op(
         &mut self,
         code: &CompiledCode,
@@ -2098,30 +2151,12 @@ impl Interpreter {
         // DBIish's `$*DBI-DEFS`).
         if stash_name == "PROCESS::" {
             let raw_key = Self::const_str(code, key_name_idx).to_string();
-            // Map the sigiled stash key to the env dynamic-var key:
-            //   $name → *name, @name → @*name, %name → %*name, name → *name
-            let env_key = match raw_key.chars().next() {
-                Some('$') => format!("*{}", &raw_key[1..]),
-                Some('@') => format!("@*{}", &raw_key[1..]),
-                Some('%') => format!("%*{}", &raw_key[1..]),
-                _ => format!("*{raw_key}"),
-            };
             let val = self.stack.pop().unwrap_or(Value::NIL);
-            // `PROCESS::<$REPO> := $repo` arrives as a bind marker; unwrap it
-            // so the bound value (not the marker Pair) becomes the dynamic.
-            let (val, _bind_source) = Self::unwrap_bind_index_value(val);
-            let val = if env_key.starts_with('@') {
-                runtime::coerce_to_array(val)
-            } else if env_key.starts_with('%') {
-                self.coerce_hash_var_value(&env_key, val)?
-            } else {
-                Self::itemize_scalar_store(&env_key, Self::normalize_scalar_assignment_value(val))
-            };
-            self.env_mut().insert(env_key, val.clone());
+            let stored = self.store_process_dynamic(&raw_key, val)?;
             // An assignment is an expression: leave the assigned value on the
             // stack so `Rakudo::Internals.REGISTER-DYNAMIC`'s block (whose body is
             // `PROCESS::<$x> = ...`) returns it.
-            self.stack.push(val);
+            self.stack.push(stored);
             return Ok(());
         }
         if stash_name != "MY::" {

--- a/t/process-stash-compound-assign.t
+++ b/t/process-stash-compound-assign.t
@@ -1,0 +1,42 @@
+use v6;
+use Test;
+
+# PROCESS::<$name> compound assignment (//=, ||=, +=) desugars its subscript
+# into a runtime-key `PROCESS::{$temp}` assignment. That runtime-key write must
+# reach the process-level dynamic store, not a throwaway pseudo-stash hash.
+
+plan 9;
+
+# //= on a fresh key installs the default and reads it back.
+PROCESS::<$MUTSU_A> //= 5;
+is PROCESS::<$MUTSU_A>, 5, '//= on fresh PROCESS key stores the value';
+is $*MUTSU_A, 5, '//= write is visible via $*MUTSU_A dynamic read';
+
+# //= on an already-defined key keeps the existing value.
+PROCESS::<$MUTSU_B> = 3;
+PROCESS::<$MUTSU_B> //= 99;
+is PROCESS::<$MUTSU_B>, 3, '//= keeps the existing defined value';
+
+# += compound assignment.
+PROCESS::<$MUTSU_C> = 10;
+PROCESS::<$MUTSU_C> += 5;
+is PROCESS::<$MUTSU_C>, 15, '+= compound assign on PROCESS key';
+
+# ||= replaces a falsy value.
+PROCESS::<$MUTSU_D> = 0;
+PROCESS::<$MUTSU_D> ||= 42;
+is PROCESS::<$MUTSU_D>, 42, '||= replaces a falsy PROCESS value';
+
+# The assignment is an expression and returns the (possibly-installed) value.
+my $r = (PROCESS::<$MUTSU_E> //= 77);
+is $r, 77, '//= returns the installed value as an expression';
+
+# Runtime-key subscript spelling ({$k}) writes to the same place as <$name>.
+my $k = '$MUTSU_F';
+PROCESS::{$k} = 8;
+is PROCESS::{$k}, 8, 'runtime-key {$k} write is readable via {$k}';
+is PROCESS::<$MUTSU_F>, 8, 'runtime-key {$k} write is readable via <$name>';
+
+# GLOBAL:: compound assignment still works (regression guard).
+GLOBAL::<$MUTSU_G> //= 21;
+is GLOBAL::<$MUTSU_G>, 21, '//= on GLOBAL key stores the value';


### PR DESCRIPTION
## Problem

`PROCESS::<\$name> //= v` (and `||=`, `+=`, ...) desugars its subscript into a runtime-key `PROCESS::{\$temp} = ...` assignment. The compiler only routed the **literal-key** form (`PROCESS::<\$name> = v`) to the process-level env dynamic-var store; the **runtime-key** form fell through to the generic index-assign path, which builds a throwaway `build_pseudo_stash` hash and writes into that — silently dropping the store.

Result: `PROCESS::<\$X> //= 5; say PROCESS::<\$X>` printed `Nil` instead of `5`, even though `GLOBAL::`, a plain hash, and the manual literal-key form all worked.

```raku
PROCESS::<$X> //= 5;
say PROCESS::<$X>;   # was: Nil    now: 5  (matches raku)
```

## Fix

- Add an `IndexAssignPseudoStashKeyed { stash_name_idx }` opcode that pops the runtime key + value and routes PROCESS:: writes through the same env dynamic-var store as the literal-key op.
- Extract that env-write into a shared `store_process_dynamic` helper used by both the literal-key and runtime-key paths.
- The compiler emits the new op for runtime-key PROCESS:: assignments before the generic fallback.

## Testing

- New `t/process-stash-compound-assign.t` (9 subtests) — output matches `raku`.
- `make test`: all 19336 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)