### PR TITLE
fix: an enum value's `.WHICH` is `EnumType|ordinal`, a stable ValueObjAt

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -341,6 +341,7 @@ pub(super) fn dispatch(
                     | ValueView::Mix(_, _)
                     | ValueView::Junction { .. }
                     | ValueView::Nil
+                    | ValueView::Enum { .. }
             );
             let which_str = match target.view() {
                 ValueView::Package(name) => format!("{}|U{}", name.resolve(), name.id()),
@@ -355,6 +356,14 @@ pub(super) fn dispatch(
                 ValueView::Rat(n, d) => format!("Rat|{}/{}", n, d),
                 ValueView::FatRat(n, d) => format!("FatRat|{}/{}", n, d),
                 ValueView::Complex(r, i) => format!("Complex|{}+{}i", r, i),
+                // An enum value's identity is `{EnumType}|{ordinal}` (raku:
+                // `Bob.WHICH` is `Names|0`, using the position in the enum, not
+                // the underlying value). Without this arm an enum fell to the
+                // global-counter fallback, giving a non-deterministic `Int|N`
+                // that broke `Bob.WHICH eqv Bob.WHICH`.
+                ValueView::Enum {
+                    enum_type, index, ..
+                } => format!("{}|{}", enum_type.resolve(), index),
                 ValueView::Nil => format!("Nil|U{}", Symbol::intern("Nil").id()),
                 ValueView::Set(set, _) => {
                     let mut keys: Vec<&String> = set.iter().collect();

--- a/t/enum-value-which.t
+++ b/t/enum-value-which.t
@@ -1,0 +1,30 @@
+use Test;
+
+# An enum value's `.WHICH` identity is `{EnumType}|{ordinal}` (the position in
+# the enum), a ValueObjAt. Previously enum values fell to a global-counter
+# WHICH fallback, producing a non-deterministic `Int|N` that broke value
+# identity (`Bob.WHICH eqv Bob.WHICH` was False).
+
+plan 10;
+
+enum Names <Bob Alice Carol>;
+is Bob.WHICH.Str, 'Names|0', 'enum WHICH is EnumType|ordinal';
+is Alice.WHICH.Str, 'Names|1', 'second enum value WHICH';
+is Carol.WHICH.Str, 'Names|2', 'third enum value WHICH';
+is Bob.WHICH.^name, 'ValueObjAt', 'enum WHICH is a value type (ValueObjAt)';
+
+# Identity is deterministic and stable.
+ok Bob.WHICH eqv Bob.WHICH, 'same enum value has equal WHICH';
+nok Bob.WHICH eqv Alice.WHICH, 'different enum values have distinct WHICH';
+
+# The ordinal, not the underlying value, drives WHICH.
+enum Color (red => 5, green => 9);
+is red.WHICH.Str, 'Color|0', 'valued enum WHICH uses the ordinal, not the value';
+is green.WHICH.Str, 'Color|1', 'second valued enum WHICH ordinal';
+
+# String-valued enum.
+enum Foo (a => "x", b => "y");
+is a.WHICH.Str, 'Foo|0', 'string-valued enum WHICH ordinal';
+is b.WHICH.Str, 'Foo|1', 'string-valued enum WHICH second ordinal';
+
+done-testing;


### PR DESCRIPTION
## Summary

`Bob.WHICH` (for `enum Names <Bob Alice Carol>`) returned a non-deterministic `Int|N` from the global-counter WHICH fallback, so `Bob.WHICH eqv Bob.WHICH` was **False** and enum values had no stable identity.

Raku's identity for an enum value is `{EnumType}|{ordinal}` — the position in the enum, not the underlying value — and it is a value type (`.WHICH.^name` is `ValueObjAt`).

```raku
enum Names <Bob Alice Carol>;
say Bob.WHICH;             # was Int|<counter>, now Names|0
say Bob.WHICH eqv Bob.WHICH;   # was False, now True

enum Color (red => 5, green => 9);
say red.WHICH;            # Color|0  (ordinal, NOT the value 5)
```

## Change

- Add an `Enum` arm to the `WHICH` handler producing `{enum_type}|{index}`.
- Include `Enum` in the value-type set so `.WHICH` is a `ValueObjAt` (not `ObjAt`).

## Provenance

From the doc-diff QA campaign (Language/typesystem.rakudoc, enum-value identity — sibling of the `.^name` fix in #4926).

## Tests

- New pin: `t/enum-value-which.t`
- All 7 whitelisted `roast/S12-enums/*.t` still pass; local enum tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)