### PR TITLE
fix: parse a parenthesized colonpair value in a `«...»` word-quote enum

### DIFF
--- a/src/parser/stmt/decl/enum_decl.rs
+++ b/src/parser/stmt/decl/enum_decl.rs
@@ -1,5 +1,5 @@
 use super::super::super::expr::expression;
-use super::super::super::helpers::{ws, ws1};
+use super::super::super::helpers::{skip_balanced_parens, ws, ws1};
 use super::super::super::parse_result::{PError, PResult, opt_char, parse_char, take_while1};
 use super::super::{ident, keyword, qualified_ident};
 use super::take_while_opt;
@@ -150,10 +150,16 @@ fn parse_double_angle_enum_variants(input: &str) -> PResult<'_, Vec<(String, Opt
                 variants.push((key.to_string(), Some(expr)));
                 r = after_expr;
             } else if after_key.starts_with('(') {
-                // :key(expr) — parse as expression in parens
-                let (after_expr, expr) = expression(after_key)?;
+                // :key(expr) — parse the balanced-paren content as an expression.
+                // Parse only the text INSIDE the parens (via the balanced span),
+                // not `expression(after_key)` on the raw remainder: otherwise the
+                // enum's closing `»`/`>>` delimiter right after `)` is swallowed
+                // as a hyper operator (`«:one(1)»` mis-parsed as `(1)».(...)`).
+                let after_parens = skip_balanced_parens(after_key);
+                let inner = &after_key[1..after_key.len() - after_parens.len() - 1];
+                let (_, expr) = expression(inner.trim())?;
                 variants.push((key.to_string(), Some(expr)));
-                r = after_expr;
+                r = after_parens;
             } else {
                 // :key with no value — treat as boolean true (no explicit value)
                 variants.push((key.to_string(), None));

--- a/t/enum-double-angle-colonpair.t
+++ b/t/enum-double-angle-colonpair.t
@@ -1,0 +1,42 @@
+use Test;
+
+# A `«...»` / `<<...>>` quote-word enum body may contain colonpair variants
+# with a PARENTHESIZED value (`:one(1)`). Previously the value was parsed with
+# the full expression parser on the raw remainder, which swallowed the closing
+# `»`/`>>` delimiter as a hyper operator (`«:one(1)»` mis-parsed as `(1)».(…)`),
+# so the enum declaration failed entirely. Now only the balanced-paren content
+# is parsed.
+
+plan 9;
+
+enum A «:one(1) two three four»;
+is-deeply A.enums, Map.new((one => 1, two => 2, three => 3, four => 4)),
+    'colonpair(paren) value then auto-incrementing bare words';
+is two.value, 2, 'bare word after a valued colonpair auto-increments';
+
+enum B «:one(1)»;
+is-deeply B.enums, Map.new((:one(1))), 'single parenthesized colonpair';
+
+enum C «two :one(1)»;
+is-deeply C.enums, Map.new((two => 0, one => 1)), 'bare word before a valued colonpair';
+
+enum D «:a(5) b :c(9)»;
+is-deeply D.enums, Map.new((a => 5, b => 6, c => 9)), 'mixed valued colonpairs and bare word';
+
+# ASCII << >> form.
+enum E <<:one(1) two three>>;
+is-deeply E.enums, Map.new((one => 1, two => 2, three => 3)), 'ASCII << >> colonpair form';
+
+# An expression value inside the parens.
+enum F «:one(1+2) two»;
+is-deeply F.enums, Map.new((one => 3, two => 4)), 'expression value in colonpair parens';
+
+# The angle-bracket colonpair value (`:one<x>`) still works.
+enum G «:one<x> two»;
+is-deeply G.enums, Map.new((one => 'x', two => 'y')), 'angle-value colonpair still works';
+
+# Plain word-quote enum (no colonpair) is unaffected.
+enum H «a b c»;
+is-deeply H.enums, Map.new((a => 0, b => 1, c => 2)), 'plain word-quote enum unaffected';
+
+done-testing;


### PR DESCRIPTION
## Summary

`enum N «:one(1) two three»` failed to parse — the enum declaration bailed and `enum`/`N` fell back to bare words, so `N.enums` threw `No such method 'enums' for invocant of type 'Str'`.

```raku
enum N «:one(1) two three four»;
say N.enums;   # was a parse failure, now Map.new((one => 1, two => 2, three => 3, four => 4))
```

## Root cause

The `:key(expr)` branch of the double-angle enum-variant parser called `expression()` on the **raw remainder** after the key. That greedily consumed the closing `»`/`>>` delimiter right after the `)` as a hyper operator (`(1)»` parses as a hyper postfix), so the whole declaration was rejected.

## Fix

Parse only the balanced-paren content (via `skip_balanced_parens`) as the value expression, leaving the delimiter for the variant loop.

- The angle-value form (`:one<x>`) already worked (hand-rolled scan, not `expression()`).
- Bare-word and `<a b c>` forms are unaffected.
- Auto-increment after a valued colonpair (`:a(5) b` → `b => 6`) matches raku.
- ASCII `<<...>>` form and expression values (`:one(1+2)`) both covered.

## Provenance

From the doc-diff QA campaign (Language/typesystem.rakudoc finding [14]).

## Tests

- New pin: `t/enum-double-angle-colonpair.t`
- All 7 whitelisted `roast/S12-enums/*.t` still pass; local enum tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)