### PR TITLE
fix: (B)-gate burn down the last two roast ON-survey regressions

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -811,16 +811,45 @@ the match cache uses, so a static regex folds nothing) — keep every local of s
 frame env-synced. Same gate-ON-only shape as the #4869 / #4889 / CONTROL folds; OFF
 byte-identical and perf-neutral. Pin: `t/gate-b-regex-interp-env-sync.t`.
 
-**Still open — ON survey residue (5 files, each a dedicated-session slice):**
-`atomic-ops-native-dispatch.t`, `atomic-ops.t` (cross-thread/atomic, gc-stress-
-gated, flaky-prone); `nextsame-rw-redispatch.t`, `proto-method-rw-redispatch.t`
-(the `is rw`/`is raw` writeback chain through `apply_pending_rw_writeback`'s
-env[source]→slot pull — needs the `env_changed` guard of #4859/#4873, the deepest
-one); and `quanthash-immutable-ro.t` (coerce-RO: the failing `:delete` is inside a
-`lives-ok { }` closure, and a naive slot-first `:delete` patch regressed 5 ON files
-— array-hole tracking / nested-delete / `:=`-cell / whole-container-bind all assume
-env — so this one is a multi-site + closure-capture-container entanglement, NOT a
-single-site swap like inc/dec or the index-assign seed above).
+### bare-call/local collision + `@$s` deref capture — the last two (2026-07-20)
+
+The **full roast ON survey is now clean** (release, `MUTSU_FUDGE=1
+MUTSU_GATE_LOCAL_ENV_WRITE=1 prove -j6` over all 1433 whitelisted files): every
+non-`ok` file is a documented load-flaky (`return-in-tap.t`, the `gb*/shiftjis`
+encode set, `CollationTest`, `smiley.t`) or a `# TODO` file (`wacky.t`) whose
+`not ok` set is byte-identical ON vs OFF. The two remaining genuine ON-only
+regressions were burned down:
+
+- **`S32-trig/e.t` — a bare call whose name collides with a same-named lexical.**
+  A scalar `$e` is stored under the bare name `e`, so `my $e = e; e()` collides:
+  the function-call fallback (`call_function_fallback`) reads `env[e]` to decide
+  whether `e()` is a bound-generic-type-parameter coercion (`T()` → `Int(Any)`).
+  Under the gate a plain `my $e` keeps only its decl-seed `Any` in env (its
+  initializing store's mirror is skipped), so the fallback saw `Package(Any)` and
+  resolved `e()` to `Any(Any)` instead of dying with X::Undeclared. Two gate-ON-only
+  fixes: (a) `compute_needs_env_sync` folds every local whose name matches a bare
+  call callee (`op_callee_name_const_idx`) so its env mirror stays live; (b)
+  `throws-like`'s nested-interpreter string path (which reconstructs the caller
+  scope from `self.env`) additionally *refreshes* the copied env entries from the
+  caller frame's LIVE slot values — restricted to names already present in the
+  copied env, so out-of-scope child-block locals (which `code.locals` still holds)
+  do NOT leak into the EVAL'd scope and break the `our.t`/`my-6c.t` out-of-scope
+  X::Undeclared checks.
+- **`S32-list/skip.t` — a `@$s` deref inside a `throws-like { }` block.** `@$s`
+  compiles to `GetArrayVar("@s")` (array-context spelling) but reads the sigil-less
+  scalar `s` by name at runtime. The closure-capture `needs_env_sync` fold matched
+  the free var `@s` against `locals_map` verbatim and missed the scalar `s`, so the
+  block read a stale (non-consumed) `$s` from env and `throws-like { @$s },
+  X::Seq::Consumed` did not fire. Fix: when matching a nested closure's free var
+  against this frame's locals, also try the sigil-stripped name (`@x`/`%x`/`&x` →
+  `x`). Gate-ON only, OFF byte-identical.
+
+Pin for both: `t/gate-b-callee-name-collision-and-deref-capture.t`.
+
+**Result: the (B)-gate ON survey (t/ and full roast) is green. The gate is ready
+for the default flip (Plan A: `gate_local_env_write()` default true,
+`MUTSU_GATE_LOCAL_ENV_WRITE=0` opt-out), then a gc-stress/jit-stress/roast CI soak,
+then removal of the ~18 gate sites and the OFF-side dead code.**
 
 ## §1.4 flip blast-radius measurement (2026-07-02, debug + release `prove t/`)
 

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -2481,9 +2481,42 @@ impl CompiledCode {
                     *b = true;
                 }
             }
+            // A bare call whose callee name collides with one of this frame's own
+            // declared lexicals (`my $e; e()` — `$e` is stored under the bare name
+            // `e`) reaches the function-call fallback, which reads `env[e]` to decide
+            // whether the call is a bound-generic-type-parameter coercion
+            // (`T()` -> `Int(Any)`). Under the gate a plain `my $e` keeps only its
+            // decl-seed `Any` in env (its initializing store's mirror is skipped), so
+            // the fallback sees `Package(Any)` and resolves `e()` to `Any(Any)`
+            // instead of dying with X::Undeclared (roast S32-trig/e.t). Fold every
+            // such colliding local back into `needs_env_sync` so its env mirror stays
+            // live and the fallback reads the real value. Gate-ON only, so the
+            // default build is byte-identical / perf-neutral.
+            for op in &self.ops {
+                if let Some(idx) = Self::op_callee_name_const_idx(op)
+                    && let Some(ValueView::Str(name)) =
+                        self.constants.get(idx as usize).map(Value::view)
+                    && let Some(&slot) = locals_map.get(name.as_str())
+                {
+                    self.needs_env_sync[slot] = true;
+                }
+            }
             for nested in &self.closure_compiled_codes {
                 for sym in &nested.free_var_syms {
-                    if let Some(&slot) = sym.with_str(|s| locals_map.get(s)) {
+                    let slot = sym.with_str(|s| {
+                        locals_map.get(s).copied().or_else(|| {
+                            // A `@$x` / `%$x` deref of a scalar records its free var
+                            // as `@x` / `%x` (the array/hash-context spelling), but the
+                            // underlying lexical is the sigil-less scalar `x`. Fall back
+                            // to the stripped name so the deref keeps `x`'s env mirror
+                            // live — the closure's `GetArrayVar`/`GetHashVar` reads it
+                            // by name (roast S32-list/skip.t: `throws-like { @$s }` must
+                            // see the consumed Seq bound to `$s`).
+                            s.strip_prefix(['@', '%', '&'])
+                                .and_then(|bare| locals_map.get(bare).copied())
+                        })
+                    });
+                    if let Some(slot) = slot {
                         self.needs_env_sync[slot] = true;
                     }
                 }

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -70,6 +70,45 @@ impl Interpreter {
                     nested.env.insert_sym(*k, v.clone());
                     shared_var_names.push(*k);
                 }
+                // Under the (B) per-store env-write gate the caller's plain lexicals
+                // keep only their decl-seed `Any` in `self.env` (their initializing
+                // store's env mirror is skipped — the slot is authoritative). The
+                // env-copy above therefore seeds the nested interpreter with a stale
+                // `Any` for `my $e = e`, so the EVAL'd `e()` resolves against a
+                // `Package(Any)` and returns `Any(Any)` instead of dying with
+                // X::Undeclared (roast S32-trig/e.t). Override those entries with the
+                // caller frame's LIVE slot values so the nested scope matches Raku's
+                // "EVAL runs in the caller's lexical scope". Gate-ON only; when off,
+                // env already carries the live values (byte-identical).
+                if crate::opcode::gate_local_env_write() && self.current_code != 0 {
+                    // SAFETY: `self.current_code` is the CompiledCode of the frame
+                    // synchronously invoking this `throws-like` Test routine.
+                    let code =
+                        unsafe { &*(self.current_code as *const crate::opcode::CompiledCode) };
+                    for (slot, lname) in code.locals.iter().enumerate() {
+                        if lname.contains("::") {
+                            continue;
+                        }
+                        if !code.plain_locals.get(slot).copied().unwrap_or(false) {
+                            continue;
+                        }
+                        let sym = Symbol::intern(lname);
+                        // Only REFRESH an entry the env-copy above already seeded —
+                        // i.e. a lexical in scope at this call site (present in
+                        // `self.env`). `code.locals` also holds slots for lexicals
+                        // declared in child blocks that have since exited; those are
+                        // out of scope and must stay invisible to the EVAL'd code
+                        // (roast S04-declarations/our.t, my-6c.t verify that an
+                        // out-of-scope `$b` is X::Undeclared). Adding them here would
+                        // leak them into the nested scope.
+                        if nested.env.get_sym(sym).is_none() {
+                            continue;
+                        }
+                        if let Some(v) = self.locals.get(slot) {
+                            nested.env.insert_sym(sym, v.clone());
+                        }
+                    }
+                }
                 // Pre-check for undeclared names (compile-time errors in Raku).
                 // Parse the code and check for undeclared type names before running.
                 // Also collect the names the code re-declares with `my`/`state` at

--- a/t/gate-b-callee-name-collision-and-deref-capture.t
+++ b/t/gate-b-callee-name-collision-and-deref-capture.t
@@ -1,0 +1,52 @@
+use Test;
+
+# Pin for two (B) per-store env-write gate fixes
+# (docs/lexical-scope-slot-campaign.md, "(B) per-store env-write gate — burndown").
+#
+# 1. Bare call vs. same-named local ("e.t"): a scalar `$e` is stored under the
+#    bare name `e`, so `my $e = e; e()` collides — the function-call fallback
+#    reads `env[e]` to decide whether `e()` is a bound-generic-type-parameter
+#    coercion (`T()` -> `Int(Any)`). Under the gate a plain `my $e` keeps only
+#    its decl-seed `Any` in env (its initializing store's mirror is skipped), so
+#    the fallback saw `Package(Any)` and returned `Any(Any)` instead of dying
+#    with X::Undeclared. The fix folds every such colliding local back into
+#    `needs_env_sync` (compute_needs_env_sync) AND seeds throws-like's nested
+#    interpreter from the caller frame's LIVE slot values.
+#
+# 2. `@$s` / `%$s` deref capture ("skip.t"): a `@$s` deref records its closure
+#    free var as `@s`, but the underlying lexical is the sigil-less scalar `s`,
+#    so the closure-capture env-sync fold missed it. Under the gate a
+#    `throws-like { @$s }` block read a stale (non-consumed) `$s` from env. The
+#    fix strips the sigil when matching the free var against this frame's locals.
+#
+# Gate OFF (default) is byte-identical (both folds are gate-ON only). These pass
+# gate-OFF and would fail gate-ON before the fix.
+
+plan 6;
+
+# --- 1. bare call colliding with a same-named local (roast S32-trig/e.t) ---
+my $e = e;
+throws-like 'e()', X::Undeclared, 'e() with a same-named local $e still dies';
+is $e, e, '$e still holds the constant e';
+
+# --- 2. @$s / %$s deref capture in a throws-like block ---
+{
+    my $s := (1..3).Seq;
+    my $skipped := $s.skip;
+    throws-like { @$s }, X::Seq::Consumed, 'consumed Seq via @$s deref in a block';
+    is-deeply @$skipped, (2, 3), 'skipped has right content';
+}
+
+# The @$s deref inside a plain closure sees the live bound container.
+{
+    my $a := [10, 20, 30];
+    my &b = { @$a };
+    is-deeply b().List, (10, 20, 30), '@$a deref closure captures the live array';
+}
+
+# %$h deref inside a closure sees the live bound hash.
+{
+    my $h := {a => 1, b => 2};
+    my &b = { (%$h){'a'} };
+    is b(), 1, '%$h deref closure captures the live hash';
+}


### PR DESCRIPTION
Burns down the final two genuine ON-only regressions under `MUTSU_GATE_LOCAL_ENV_WRITE=1`, so the **full roast ON survey is now clean** — every remaining non-`ok` file is a documented load-flaky (`return-in-tap.t`, the `gb*/shiftjis` encode set, `CollationTest`, `smiley.t`) or a `# TODO` file (`wacky.t`) whose `not ok` set is byte-identical ON vs OFF.

This is the last burndown slice before the `(B)`-gate default flip (Plan A).

## Fixes (all gate-ON only, default OFF byte-identical)

### `S32-trig/e.t` — bare call colliding with a same-named lexical
A scalar `$e` is stored under the bare name `e`, so `my $e = e; e()` collides: the function-call fallback reads `env[e]` to decide whether `e()` is a bound-generic-type-parameter coercion (`T()` → `Int(Any)`). Under the gate a plain `my $e` keeps only its decl-seed `Any` in env (its initializing store's mirror is skipped), so the fallback saw `Package(Any)` and resolved `e()` to `Any(Any)` instead of dying with `X::Undeclared`. Two fixes:
- `compute_needs_env_sync` folds every local whose name matches a bare-call callee (`op_callee_name_const_idx`) so its env mirror stays live.
- `throws-like`'s nested-interpreter string path (which reconstructs the caller scope from `self.env`) *refreshes* the copied env entries from the caller frame's LIVE slot values — restricted to names already present in the copied env, so out-of-scope child-block locals (which `code.locals` still holds) do NOT leak into the EVAL'd scope and break the `our.t`/`my-6c.t` out-of-scope `X::Undeclared` checks.

### `S32-list/skip.t` — `@$s` deref inside a `throws-like { }` block
`@$s` compiles to `GetArrayVar("@s")` (array-context spelling) but reads the sigil-less scalar `s` by name at runtime. The closure-capture `needs_env_sync` fold matched the free var `@s` against `locals_map` verbatim and missed the scalar `s`, so the block read a stale (non-consumed) `$s` from env and `throws-like { @\$s }, X::Seq::Consumed` did not fire. Fix: when matching a nested closure's free var against this frame's locals, also try the sigil-stripped name (`@x`/`%x`/`&x` → `x`).

## Verification
- `make test` (OFF): 19338 PASS, byte-identical.
- Full roast ON survey (release, `MUTSU_FUDGE=1 MUTSU_GATE_LOCAL_ENV_WRITE=1 prove -j6`, 1433 files): clean — zero genuine regressions.
- Pin: `t/gate-b-callee-name-collision-and-deref-capture.t` (passes raku / OFF / ON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)