### PR TITLE
fix: string bitwise compound assign (`~&=`/`~|=`/`~^=`) matches infix semantics

### DIFF
--- a/src/vm/vm_bitwise_ops.rs
+++ b/src/vm/vm_bitwise_ops.rs
@@ -178,64 +178,37 @@ impl Interpreter {
             .push(Value::truth(left.truthy() ^ right.truthy()));
     }
 
-    /// String bitwise AND (~&): AND corresponding bytes of two strings.
-    pub(super) fn exec_str_bit_and_op(&mut self) {
+    /// String bitwise AND (~&): AND corresponding codepoints of two strings.
+    /// Delegates to the shared `str_bitwise_op` so the opcode path (used by
+    /// `$x ~&= …`) matches the `infix:<~&>` builtin exactly: codepoint-wise
+    /// (not byte-wise), truncating to the **shorter** operand (`~&` does not
+    /// pad), with NFC normalization. Also handles `Buf` operands.
+    pub(super) fn exec_str_bit_and_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
-        let l = left.to_string_value();
-        let r = right.to_string_value();
-        let lb = l.as_bytes();
-        let rb = r.as_bytes();
-        let len = lb.len().max(rb.len());
-        let result: Vec<u8> = (0..len)
-            .map(|i| {
-                let a = lb.get(i).copied().unwrap_or(0);
-                let b = rb.get(i).copied().unwrap_or(0);
-                a & b
-            })
-            .collect();
-        self.stack
-            .push(Value::str(String::from_utf8_lossy(&result).into_owned()));
+        let result = Self::str_bitwise_op(&left, &right, |a, b| a & b, false)?;
+        self.stack.push(result);
+        Ok(())
     }
 
-    /// String bitwise OR (~|): OR corresponding bytes of two strings.
-    pub(super) fn exec_str_bit_or_op(&mut self) {
+    /// String bitwise OR (~|): OR corresponding codepoints; pads to the longer
+    /// operand. Delegates to the shared `str_bitwise_op` (see `~&` above).
+    pub(super) fn exec_str_bit_or_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
-        let l = left.to_string_value();
-        let r = right.to_string_value();
-        let lb = l.as_bytes();
-        let rb = r.as_bytes();
-        let len = lb.len().max(rb.len());
-        let result: Vec<u8> = (0..len)
-            .map(|i| {
-                let a = lb.get(i).copied().unwrap_or(0);
-                let b = rb.get(i).copied().unwrap_or(0);
-                a | b
-            })
-            .collect();
-        self.stack
-            .push(Value::str(String::from_utf8_lossy(&result).into_owned()));
+        let result = Self::str_bitwise_op(&left, &right, |a, b| a | b, true)?;
+        self.stack.push(result);
+        Ok(())
     }
 
-    /// String bitwise XOR (~^): XOR corresponding bytes of two strings.
-    pub(super) fn exec_str_bit_xor_op(&mut self) {
+    /// String bitwise XOR (~^): XOR corresponding codepoints; pads to the longer
+    /// operand. Delegates to the shared `str_bitwise_op` (see `~&` above).
+    pub(super) fn exec_str_bit_xor_op(&mut self) -> Result<(), RuntimeError> {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
-        let l = left.to_string_value();
-        let r = right.to_string_value();
-        let lb = l.as_bytes();
-        let rb = r.as_bytes();
-        let len = lb.len().max(rb.len());
-        let result: Vec<u8> = (0..len)
-            .map(|i| {
-                let a = lb.get(i).copied().unwrap_or(0);
-                let b = rb.get(i).copied().unwrap_or(0);
-                a ^ b
-            })
-            .collect();
-        self.stack
-            .push(Value::str(String::from_utf8_lossy(&result).into_owned()));
+        let result = Self::str_bitwise_op(&left, &right, |a, b| a ^ b, true)?;
+        self.stack.push(result);
+        Ok(())
     }
 
     /// String bitwise shift left (~<): treat the left string's bytes as a

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2154,15 +2154,15 @@ impl Interpreter {
                 *ip += 1;
             }
             OpCode::StrBitAnd => {
-                self.exec_str_bit_and_op();
+                self.exec_str_bit_and_op()?;
                 *ip += 1;
             }
             OpCode::StrBitOr => {
-                self.exec_str_bit_or_op();
+                self.exec_str_bit_or_op()?;
                 *ip += 1;
             }
             OpCode::StrBitXor => {
-                self.exec_str_bit_xor_op();
+                self.exec_str_bit_xor_op()?;
                 *ip += 1;
             }
             OpCode::StrShiftLeft => {

--- a/t/str-bitwise-compound-assign.t
+++ b/t/str-bitwise-compound-assign.t
@@ -1,0 +1,66 @@
+use v6;
+use Test;
+
+# String bitwise compound assignment (`~&=`, `~|=`, `~^=`) is the only path that
+# reaches the VM's StrBitAnd/Or/Xor opcodes (plain `~&` uses the infix builtin).
+# The opcode used to operate byte-wise and pad every operator to the *longer*
+# length, so `$x ~&= "ab"` on "abc" produced "ab\0" instead of "ab". It now
+# delegates to the same `str_bitwise_op` the builtin uses: codepoint-wise,
+# truncating to the shorter operand for `~&` and padding to the longer for
+# `~|` / `~^`, with NFC normalization.
+
+plan 12;
+
+# ~&= truncates to the shorter operand (no null padding).
+{
+    my $x = "abc";
+    $x ~&= "ab";
+    is $x, ("abc" ~& "ab"), '~&= matches the infix builtin';
+    is $x.chars, 2, '~&= truncates to the shorter operand';
+}
+{
+    my $x = "ab";
+    $x ~&= "abcd";
+    is $x.chars, 2, '~&= truncates regardless of which side is shorter';
+}
+
+# ~|= pads to the longer operand.
+{
+    my $x = "abcd";
+    $x ~|= "ab";
+    is $x, ("abcd" ~| "ab"), '~|= matches the infix builtin';
+    is $x.chars, 4, '~|= pads to the longer operand';
+}
+
+# ~^= pads to the longer operand.
+{
+    my $x = "abcd";
+    $x ~^= "ab";
+    is $x, ("abcd" ~^ "ab"), '~^= matches the infix builtin';
+    is $x.chars, 4, '~^= pads to the longer operand';
+}
+
+# Codepoint-wise, not byte-wise: a multi-byte char must not be split.
+{
+    my $x = "café";
+    $x ~&= "ab";
+    is $x, ("café" ~& "ab"), '~&= is codepoint-wise for multi-byte input';
+    is $x.chars, 2, '~&= counts codepoints, not bytes';
+}
+
+# Concrete value checks (independent of the builtin, against known results).
+{
+    my $x = "abc";
+    $x ~|= "AB";
+    is $x, "abc", '~|= concrete value (lowercase bits already set)';
+}
+{
+    my $x = "abc";
+    $x ~&= "abc";
+    is $x, "abc", '~&= equal-length identity';
+}
+{
+    my $x = "abc";
+    $x ~^= "abc";
+    is $x.ords.all, 0, '~^= of equal strings is all-NUL';
+}


### PR DESCRIPTION
## Problem

The VM's `StrBitAnd` / `StrBitOr` / `StrBitXor` opcodes — reached **only** by the string bitwise compound-assignment forms (`$x ~&= …`; plain `~&` compiles to the `infix:<~&>` builtin instead) — operated **byte-wise** and padded **every** operator to the *longer* operand with NUL:

```raku
my $x = "abc"; $x ~&= "ab";   # was "ab\0"  (3 chars) — should be "ab" (2)
```

`~&` must truncate to the *shorter* operand (only `~|` / `~^` pad), and all three must operate on codepoints (not bytes) with NFC normalization. The opcode diverged from the builtin because they were two separate implementations.

## Fix

Route the three opcodes through the same `str_bitwise_op` helper the infix builtin already uses (`pad_to_max = false` for `~&`, `true` for `~|` / `~^`). The two implementations can no longer diverge, and Buf operands are handled too.

## Testing

- New `t/str-bitwise-compound-assign.t` (12 subtests) — length rules, codepoint-vs-byte, concrete values; passes on both mutsu and `raku`.
- `make test`: all 19356 tests pass.

Found while fixing #4931 (compound assign on indexed lvalues); this is the orthogonal runtime half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)