### PR TITLE
perf: (B)-gate flip — MUTSU_GATE_LOCAL_ENV_WRITE default ON (Plan A)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -846,10 +846,24 @@ regressions were burned down:
 
 Pin for both: `t/gate-b-callee-name-collision-and-deref-capture.t`.
 
-**Result: the (B)-gate ON survey (t/ and full roast) is green. The gate is ready
-for the default flip (Plan A: `gate_local_env_write()` default true,
-`MUTSU_GATE_LOCAL_ENV_WRITE=0` opt-out), then a gc-stress/jit-stress/roast CI soak,
-then removal of the ~18 gate sites and the OFF-side dead code.**
+**Result: the (B)-gate ON survey (t/ and full roast) is green.**
+
+### Plan A flip — `gate_local_env_write()` default ON (2026-07-20)
+
+With both surveys clean, `gate_local_env_write()` was flipped to default **true**
+(one-line change: `!matches!(…, "0"|"off"|"OFF")`), with `MUTSU_GATE_LOCAL_ENV_WRITE=0`
+as the byte-identical opt-out. Local pre-check: `make test` (2041 files / 19338
+tests) green with the flip; the roast ON survey was already clean. The flip's CI run
+(full roast + **gc-stress + jit-stress**) is the concurrency/GC soak that the local
+`-j6` survey cannot exercise. Perf: while/loop hot paths drop the unconditional
+env write (memory recorded −10…16% on a 5M while loop); for/fib are unaffected
+(their frames `captures_env_by_name`, so every local is force-synced regardless).
+
+**Remaining: after the flip soaks in main, delete the gate** — the ~18
+`if gate_local_env_write()` sites become unconditional (the ON branch), and the
+OFF-side dead code (the env-mirror stores those sites guard, plus the
+`MUTSU_GATE_LOCAL_ENV_WRITE` env plumbing) is removed. That is a separate mechanical
+PR, taken only once the flip has demonstrably soaked.
 
 ## §1.4 flip blast-radius measurement (2026-07-02, debug + release `prove t/`)
 

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -28,24 +28,27 @@ pub(crate) fn reflective_name_access_possible() -> bool {
 }
 
 /// `(B)` per-store env-write gate (docs/lexical-scope-slot-campaign.md, "The
-/// `(B)` per-store env-write gate"). Default OFF is byte-identical to the
-/// pre-gate build: `exec_set_local_op_inner` mirrors every plain-lexical store
-/// into the name-keyed `env`. Under `MUTSU_GATE_LOCAL_ENV_WRITE=1` the mirror is
-/// skipped for slot-authoritative plain lexicals (not captured/reflective/sync),
-/// so the slot is the single source of truth and env-COW can drop the write. This
-/// is the burndown gate — flip and delete once all four env-mirror consumers
-/// (#1 block-restore, #2 cross-thread, #3 call-return reconcile, #4 curry) are
-/// slot-authoritative. The t/ ON survey is clean; the roast ON survey (2026-07-20)
-/// surfaced a residual set (mixhash/sethash `%h<a>--`, state-in-regex, interpolated
-/// phasers, WHICH/skip/e) being burned down before the default flip. Cached like
-/// `jit_enabled()`.
+/// `(B)` per-store env-write gate"). **Default ON since the Plan A flip
+/// (2026-07-20)**: `exec_set_local_op_inner` skips mirroring a slot-authoritative
+/// plain-lexical store (not captured/reflective/sync) into the name-keyed `env`,
+/// so the slot is the single source of truth and env-COW can drop the write.
+/// `MUTSU_GATE_LOCAL_ENV_WRITE=0` (or `off`) opts back out to the byte-identical
+/// pre-gate behavior (mirror every plain-lexical store). The flip landed once both
+/// the t/ and the full roast ON surveys were clean and all four env-mirror
+/// consumers (#1 block-restore, #2 cross-thread, #3 call-return reconcile, #4
+/// curry) were slot-authoritative. Once the flip soaks, the gate sites and the
+/// OFF path are deleted. Cached like `jit_enabled()`.
 #[inline]
 pub(crate) fn gate_local_env_write() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| {
-        matches!(
+        // Plan A flip (2026-07-20): default ON now that the full t/ + roast ON
+        // survey is clean. `MUTSU_GATE_LOCAL_ENV_WRITE=0` (or `off`) opts back out
+        // to the byte-identical env-mirror-every-store behavior. Once the flip has
+        // soaked, the gate sites and the OFF path are deleted.
+        !matches!(
             std::env::var("MUTSU_GATE_LOCAL_ENV_WRITE").ok().as_deref(),
-            Some("1") | Some("on") | Some("ON")
+            Some("0") | Some("off") | Some("OFF")
         )
     })
 }


### PR DESCRIPTION
Flip `gate_local_env_write()` to default **true** now that both the `t/` and the full roast ON surveys are clean (the last two ON-only regressions, `S32-trig/e.t` and `S32-list/skip.t`, were burned down in #4930).

## What the gate does
Under the gate, a slot-authoritative plain-lexical store (not captured / reflective / needs-sync) skips mirroring into the name-keyed `env`, so the slot is the single source of truth and env-COW can drop the write. Every gate-guarded fold was validated **ON == OFF** across the whole test corpus during the months-long burndown, so this is a **perf change, not a semantics change**.

`MUTSU_GATE_LOCAL_ENV_WRITE=0` (or `off`) opts back out to the byte-identical env-mirror-every-store path.

## The one-line flip
```rust
// before: Some("1") | Some("on") | Some("ON")  (default OFF)
// after:  !matches!(…, Some("0") | Some("off") | Some("OFF"))  (default ON)
```

## Perf
while/loop hot paths drop the unconditional per-store env write (~−10…16% on a 5M-iteration while loop); for/fib are unaffected (their frames capture env by name, so every local is force-synced regardless).

## Validation
- `make test` (2041 files / 19338 tests): green with the flip as default.
- Full roast ON survey (release, `-j6`, 1433 files): clean — zero genuine regressions (already confirmed in #4930).
- **This PR's CI (roast + gc-stress + jit-stress) is the concurrency/GC soak** that the local `-j6` survey cannot exercise.

Gate-site removal (making the ~18 `if gate_local_env_write()` sites unconditional and deleting the OFF-side dead code) follows as a **separate mechanical PR once this has soaked**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)