### PR TITLE
fix: `//` honors a user-defined `.defined` override

### DIFF
--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -294,6 +294,36 @@ impl Interpreter {
         }
     }
 
+    /// Evaluate Raku definedness, honoring a user-defined `.defined` method on
+    /// role-composed (`but role {...}`) mixins and on class instances. Used by
+    /// `//` (`JumpIfNotNil`) so it agrees with `.defined` and `orelse`
+    /// (`CallDefined`); the plain structural check ([`value_is_defined`]) can't
+    /// see a role/class override, so `1 but role { method defined { False } }
+    /// // "x"` wrongly kept the `1`. Scalars, `Nil`, and type objects have no
+    /// override to look up and hit the cheap structural check with no method
+    /// dispatch, so the hot path is unaffected.
+    ///
+    /// [`value_is_defined`]: crate::runtime::types::value_is_defined
+    pub(super) fn value_is_defined_dispatch(&mut self, val: &Value) -> bool {
+        let has_override = match val.view() {
+            ValueView::Mixin(..) => self.mixin_role_has_method(val, "defined"),
+            ValueView::Instance { class_name, .. } => {
+                let cn = class_name.resolve().to_string();
+                self.has_user_method(&cn, "defined")
+            }
+            _ => false,
+        };
+        if has_override {
+            let caller_code = self.current_code;
+            let result = self.try_compiled_method_or_interpret(val.clone(), "defined", vec![]);
+            self.reconcile_caller_after_internal_dispatch(caller_code);
+            if let Ok(result) = result {
+                return result.truthy();
+            }
+        }
+        crate::runtime::types::value_is_defined(val)
+    }
+
     /// Call a plain `Sub` map block, optionally with an explicit topic
     /// (Pair elements) and/or rw-topic capture (`$_`-mutating blocks).
     ///

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2296,8 +2296,8 @@ impl Interpreter {
             }
             OpCode::JumpIfNotNil(target) => {
                 Self::mark_failure_handled_on_stack(&mut self.stack);
-                let val = self.stack.last().unwrap();
-                if runtime::types::value_is_defined(val) {
+                let val = self.stack.last().unwrap().clone();
+                if self.value_is_defined_dispatch(&val) {
                     *ip = *target as usize;
                 } else {
                     *ip += 1;

--- a/src/vm/vm_jit_helpers.rs
+++ b/src/vm/vm_jit_helpers.rs
@@ -208,8 +208,8 @@ pub(super) unsafe extern "C" fn jump_if_true_cond(interp: *mut Interpreter) -> u
 pub(super) unsafe extern "C" fn jump_if_not_nil_cond(interp: *mut Interpreter) -> u32 {
     let interp = unsafe { &mut *interp };
     Interpreter::mark_failure_handled_on_stack(&mut interp.stack);
-    let val = interp.stack.last().unwrap();
-    if crate::runtime::types::value_is_defined(val) {
+    let val = interp.stack.last().unwrap().clone();
+    if interp.value_is_defined_dispatch(&val) {
         1
     } else {
         0

--- a/t/defined-or-user-defined-override.t
+++ b/t/defined-or-user-defined-override.t
@@ -1,0 +1,37 @@
+use Test;
+
+# `//` (JumpIfNotNil) must honor a user-defined `.defined` method, not just
+# the structural definedness check. A role-composed mixin (`but role {...}`)
+# and a class instance can both override `.defined`; `//` (and its JIT-compiled
+# form) previously read through the wrapper and kept the left value.
+
+plan 8;
+
+# --- Mixin (`but role {...}`) with a `.defined` override -------------------
+{
+    my Int $i = 1 but role { method defined { False } };
+    is $i.defined, False, 'mixin role .defined override returns False';
+    is $i // "x", "x", '`//` uses the mixin role .defined override (undefined -> fallback)';
+}
+
+{
+    my Int $i = 5 but role { method defined { True } };
+    is $i // "x", 5, '`//` keeps the value when the override reports defined';
+}
+
+# --- Class instance with a `.defined` override ----------------------------
+{
+    class C { method defined { False } }
+    my $c = C.new;
+    is $c.defined, False, 'instance .defined override returns False';
+    is $c // "y", "y", '`//` uses the instance .defined override (undefined -> fallback)';
+}
+
+# --- Plain values keep their ordinary `//` semantics ----------------------
+{
+    my $undef;
+    is $undef // "d", "d", 'undefined scalar falls back';
+    is 5 // "e", 5, 'defined scalar keeps its value';
+    my Int $typed;
+    is $typed // "f", "f", 'uninitialized typed scalar falls back';
+}


### PR DESCRIPTION
## Problem

```raku
my Int $i = 1 but role { method defined { False } };
say $i // "x";   # mutsu: 1   raku: x
```

`$i.defined` already returns `False` correctly, but `//` ignored it.

## Root cause

`//` compiles to `OpCode::JumpIfNotNil`. Both its interpreter arm
(`vm_exec_dispatch.rs`) and the JIT condition callback
(`vm_jit_helpers.rs::jump_if_not_nil_cond`) called
`runtime::types::value_is_defined` directly. That structural check reports a
`Mixin` / `Instance` as defined (`_ => true`), so a role- or class-level
`.defined` override was bypassed — inconsistent with `.defined` and `orelse`
(`CallDefined`), which do consult the user method.

## Fix

Add `value_is_defined_dispatch`, mirroring `eval_truthy`'s existing user-`Bool`
handling: a Mixin whose composed roles define `.defined`, or an Instance whose
class defines `.defined`, dispatches the method (through
`try_compiled_method_or_interpret` + caller reconciliation) and branches on its
truthiness. Every other value (scalars, `Nil`, type objects) hits the cheap
structural check with **no** method lookup, so the `//` hot path is unaffected.

Wired into both the `JumpIfNotNil` interpreter arm and the JIT
`jump_if_not_nil_cond` callback — the latter mirrors `jump_if_true_cond`, which
already routes truthiness through `eval_truthy`.

Found via the doc-diff QA harness (Language/typesystem.rakudoc, finding [4]).

## Tests

- Pin: `t/defined-or-user-defined-override.t` (mixin role override, instance
  override, and plain-value `//` semantics).
- `make test` green; targeted roast green: `andthen.t`, `notandthen.t`,
  `orelse.t`, `S32-scalar/defined.t`, `undefined-types.t`, `mixin-6c.t`,
  `mixin-6e.t`, `parameterized-mixin.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)