### PR TITLE
fix: `orelse`/`andthen`/`notandthen` honor a mixin role `.defined` override

### DIFF
--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2307,6 +2307,20 @@ impl Interpreter {
             OpCode::CallDefined => {
                 self.sync_source_line(code, *ip);
                 let val = self.stack.pop().unwrap();
+                // A role-composed mixin (`but role { method defined {...} }`)
+                // keeps its `.defined` override in a role, not a class MRO, so
+                // the Instance/Package `has_user_method` path below can't see
+                // it. Route it through the shared dispatch helper (Mixin +
+                // caller reconciliation) exactly as `//` (`JumpIfNotNil`) does,
+                // so `orelse`/`andthen`/`notandthen` agree on the override.
+                if matches!(val.view(), ValueView::Mixin(..))
+                    && self.mixin_role_has_method(&val, "defined")
+                {
+                    let defined = self.value_is_defined_dispatch(&val);
+                    self.stack.push(Value::truth(defined));
+                    *ip += 1;
+                    return Ok(());
+                }
                 // Check if the value has a user-defined .defined method
                 let class_name = match val.view() {
                     ValueView::Package(name) => Some(name),

--- a/t/orelse-andthen-mixin-defined.t
+++ b/t/orelse-andthen-mixin-defined.t
@@ -1,0 +1,39 @@
+use Test;
+
+# `orelse`/`andthen`/`notandthen` (OpCode::CallDefined) must honor a
+# user-defined `.defined` method on a role-composed mixin (`but role {...}`),
+# just like `//` (JumpIfNotNil) does. The CallDefined path only looked up a
+# class-MRO `.defined` (Instance/Package), missing a role override.
+
+plan 7;
+
+# --- Mixin whose role reports it undefined --------------------------------
+{
+    my Int $i = 1 but role { method defined { False } };
+    is ($i orelse "z"), "z", 'orelse runs RHS when the mixin role .defined is False';
+    is ($i andthen "yes"), Nil, 'andthen skips RHS when the mixin role .defined is False';
+    is ($i notandthen "no"), "no", 'notandthen runs RHS when the mixin role .defined is False';
+}
+
+# --- Mixin whose role reports it defined ----------------------------------
+{
+    my Int $i = 5 but role { method defined { True } };
+    is ($i orelse "z"), 5, 'orelse keeps the value when the mixin role .defined is True';
+    is ($i andthen $_ + 1), 6, 'andthen runs RHS (with topic) when defined is True';
+}
+
+# --- A mutating `.defined` on the mixin runs exactly once per test --------
+{
+    my $calls = 0;
+    my $i = 1 but role { method defined { $calls++; True } };
+    $i andthen 1;
+    $i andthen 1;
+    is $calls, 2, 'the mixin .defined override runs once per andthen (caller lexical mutation propagates)';
+}
+
+# --- Instance (class-MRO) override still works via the existing path ------
+{
+    class C { method defined { False } }
+    my $c = C.new;
+    is ($c orelse "y"), "y", 'orelse honors a class instance .defined override';
+}


### PR DESCRIPTION
## Problem

```raku
my Int $i = 1 but role { method defined { False } };
say ($i orelse "z");      # mutsu: 1    raku: z
say ($i andthen "yes");   # mutsu: yes  raku: ()
say ($i notandthen "no"); # mutsu: no   raku: no  (agreed, but by luck)
```

Sibling of #4934 (which fixed the same divergence for `//`).

## Root cause

`orelse`/`andthen`/`notandthen` compile to `OpCode::CallDefined`, which resolved
a user `.defined` only through the class MRO
(`has_user_method` on Instance/Package). A role-composed mixin
(`but role { method defined {...} }`) keeps its override in a **role**, not a
class MRO, so it was invisible and the structural `value_is_defined`
(`Mixin => true`) won.

## Fix

Before the existing Instance/Package machinery, route a `Mixin` value whose
composed roles define `.defined` through the shared `value_is_defined_dispatch`
helper introduced in #4934 (Mixin dispatch + `reconcile_caller_after_internal_dispatch`).
The Instance/Package path — including its bespoke pre/post-env slot
reconciliation for a `.defined` that mutates a captured-outer lexical — is left
untouched.

## Tests

- Pin: `t/orelse-andthen-mixin-defined.t` (orelse/andthen/notandthen mixin
  override, defined-True case, a once-per-call mutating override, and the
  class-instance path).
- Targeted roast green: `andthen.t`, `notandthen.t`, `orelse.t`,
  `S32-scalar/defined.t`, `mixin-6c.t`, `mixin-6e.t`. `t/andthen-orelse-instance-rhs.t`
  and #4934's pin still pass.

Found via the doc-diff QA harness (Language/typesystem.rakudoc, finding [4] sibling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)