### PR TITLE
fix: JIT CallMethodMut shim guards the receiver writeback on rebind (mechanism #3)

### DIFF
--- a/src/vm/vm_jit_helpers.rs
+++ b/src/vm/vm_jit_helpers.rs
@@ -313,6 +313,23 @@ pub(super) unsafe extern "C" fn call_method_mut(
     };
     interp.sync_source_line(code, op_idx as usize);
     let pre = interp.array_hash_attr_env_snapshot(code, *target_name_idx);
+    // The receiver's env binding before the call, so the writeback below can
+    // tell whether this method actually rebound it. Mirrors the interpreter's
+    // `CallMethodMut` arm (vm_exec_dispatch.rs): only push the receiver for a
+    // writeback when the call REBOUND `env[receiver]`. Without this guard the
+    // JIT path unconditionally pulls `env[receiver]` into the caller's slot,
+    // which is wrong when the callee env merely inherited a same-named binding
+    // from its caller (a self-recursive `$tree` reverting to the caller's node)
+    // and, under the `MUTSU_GATE_LOCAL_ENV_WRITE` per-store env-write gate, when
+    // `env[receiver]` is a stale decl-seed while the live value lives only in
+    // the slot (a hot `$io .= succ` loop frozen by a stale `env[io]` pull).
+    let receiver_before: Option<Option<Value>> =
+        (!Interpreter::const_str(code, *target_name_idx).is_empty()).then(|| {
+            interp
+                .env()
+                .get_sym(code.const_sym(*target_name_idx))
+                .cloned()
+        });
     let r = interp.exec_call_method_mut_op(
         code,
         *name_idx,
@@ -325,12 +342,17 @@ pub(super) unsafe extern "C" fn call_method_mut(
     interp.current_code = code as *const CompiledCode as usize;
     match r {
         Ok(()) => {
-            {
-                let target_name = Interpreter::const_str(code, *target_name_idx);
-                if !target_name.is_empty() {
+            if let Some(before) = receiver_before {
+                let after = interp.env().get_sym(code.const_sym(*target_name_idx));
+                let rebound = match (&before, after) {
+                    (Some(b), Some(a)) => !b.same_binding(a),
+                    (None, None) => false,
+                    _ => true,
+                };
+                if rebound {
                     interp
                         .pending_rw_writeback_sources
-                        .push(target_name.to_string());
+                        .push(Interpreter::const_str(code, *target_name_idx).to_string());
                 }
             }
             interp.apply_pending_rw_writeback(code);

--- a/t/gate-b-jit-method-mut-writeback.t
+++ b/t/gate-b-jit-method-mut-writeback.t
@@ -1,0 +1,46 @@
+# (B)-gate mechanism #3: the JIT'd `CallMethodMut` shim must only write the
+# receiver back to the caller's local slot when the method actually REBOUND
+# `env[receiver]` — mirroring the interpreter's `CallMethodMut` arm. Without the
+# `rebound` guard the JIT path unconditionally pulls `env[receiver]` into the
+# slot, which freezes a hot `$io .= succ` loop under the
+# MUTSU_GATE_LOCAL_ENV_WRITE per-store env-write gate (the live value lives only
+# in the slot; `env[io]` is a stale decl-seed). This runs green in every
+# gate/JIT configuration; CI exercises the JIT threshold via the jit-stress lane.
+use Test;
+plan 6;
+
+sub w($io is copy) {
+    my @seen;
+    until @seen.elems >= 3 { @seen.push: $io.Str; $io .= succ }
+    @seen
+}
+is w(1).join(","), "1,2,3", ".=succ hot loop progresses (Int)";
+
+sub upcaser($s is copy) {
+    my @r;
+    for ^3 { @r.push: $s; $s .= succ }
+    @r
+}
+is upcaser("a").join(","), "a,b,c", ".=succ hot loop progresses (Str)";
+
+sub counter() {
+    my $i = 0;
+    my @r;
+    loop { last if @r.elems >= 6; @r.push: $i; $i .= succ }
+    @r
+}
+is counter().join(","), "0,1,2,3,4,5", ".=succ on a plain loop variable";
+
+# A mutating method (.push) on an array receiver inside a hot loop must still
+# reach the caller's slot (this genuinely rebinds env[@a] for is-Array backends).
+sub grower() { my @a; for ^5 { @a.push($_) }; @a }
+is grower().join(","), "0,1,2,3,4", ".push on an array receiver in a loop";
+
+# Self-recursive descent with a method call on the param: the guard prevents the
+# unconditional pull from reverting `$tree` to the caller's node (99problems P57).
+sub depth($tree) { $tree.defined ?? 1 + depth($tree[1]) !! 0 }
+is depth([1, [2, [3, Nil]]]), 3, "self-recursive descent does not revert the param";
+
+# A method-assign whose receiver is an outer lexical, across iterations.
+sub outer-mut() { my $x = 10; my @r; for ^3 { @r.push: $x; $x .= succ }; @r }
+is outer-mut().join(","), "10,11,12", "method-assign on a lexical across iterations";


### PR DESCRIPTION
## Summary

The JIT'd `CallMethodMut` shim (`vm_jit_helpers.rs::call_method_mut`) unconditionally pushed the receiver name onto `pending_rw_writeback_sources` after the call, so `apply_pending_rw_writeback` always pulled `env[receiver]` into the caller's local slot.

The interpreter's own `CallMethodMut` arm (`vm_exec_dispatch.rs`) had already been narrowed to push the writeback **only when the call actually REBOUND `env[receiver]`** (`!before.same_binding(after)`). That guard fixes a self-recursive `$tree` descent that otherwise reverts the param to the caller's node and runs to a stack overflow (`integration/99problems-51-to-60.t` P57). The JIT shim never received the same guard — this PR brings it to parity.

## Why it matters (mechanism #3 of the (B)-gate burndown)

This is the last outstanding blocker for the `MUTSU_GATE_LOCAL_ENV_WRITE` per-store env-write gate. With the gate on, a plain scalar store skips the env mirror, so `env[receiver]` is a stale decl-seed while the live value lives only in the slot. A hot `$io .= succ` loop that JIT-compiles then had its live slot clobbered by the stale `env[io]` pull every iteration and froze:

```raku
sub w($io is copy) { my @seen; until @seen.elems >= 3 { @seen.push: $io.Str; $io .= succ }; @seen }
say w(1);   # gate-on + JIT: [1 2 2] (wrong)  ->  now [1 2 3]
```

With the rebind guard the unchanged env is never pulled, so the loop progresses correctly under **every** gate/JIT configuration.

## Safety

The change is **un-gated** — it mirrors the interpreter's existing, CI-green logic, so gate-off behavior is unchanged:
- a method that rebinds the receiver in env → writeback still fires;
- an in-place `Gc` mutation leaves `same_binding` true and was already a no-op pull.

`same_binding` is a raw-bits comparison of the `Value` repr, so container in-place mutation (same `Gc`) is correctly treated as "not rebound".

## Verification

- `make test` — PASS (Files=2046, Tests=19380).
- Pin `t/gate-b-jit-method-mut-writeback.t` — green in default / `MUTSU_JIT_THRESHOLD=2` / gate-on + JIT-2.
- `99problems-51-to-60.t`, `S12-construction/BUILD.t`, `S06-currying/positional.t` — PASS at default and JIT threshold 2.
- Confirmed the modified shim is genuinely on the hot path (`MUTSU_VM_STATS`: `jit compiles=2 entries=5 bailouts=0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)