### PR TITLE
feat: inline anonymous/named subset as a term

### DIFF
--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -572,6 +572,16 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                 return Ok((r, Expr::DoStmt(Box::new(stmt))));
             }
         }
+        "subset" => {
+            // Inline anonymous/named subset used as a TERM (an expression that
+            // yields the subset's type object), e.g.
+            // `$x ~~ (subset :: where Int|Str)`. The statement dispatcher handles
+            // a leading `subset` declaration before expression parsing, so this
+            // arm is only reached in genuine term position.
+            if let Ok((r, expr)) = crate::parser::stmt::decl::inline_subset_term(rest) {
+                return Ok((r, expr));
+            }
+        }
         "anon" => {
             // anon enum < ... > in expression context
             if let Ok((r, stmt)) = crate::parser::stmt::decl::anon_enum_decl(input) {

--- a/src/parser/stmt/decl/constant_subset.rs
+++ b/src/parser/stmt/decl/constant_subset.rs
@@ -284,3 +284,71 @@ pub(in crate::parser::stmt) fn subset_decl(input: &str) -> PResult<'_, Stmt> {
         },
     ))
 }
+
+/// Monotonic counter naming each anonymous inline subset uniquely.
+static ANON_SUBSET_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Parse an inline `subset` used as a TERM (an expression yielding the subset's
+/// type object), e.g. `$x ~~ (subset :: where Int|Str)` or a named
+/// `subset Foo where Int|Str`. `input` starts right after the `subset` keyword.
+///
+/// Lowered to `do { subset <name> …; <name> }`, reusing the ordinary subset
+/// declaration machinery — mutsu already evaluates a subset name in term
+/// position to its type object. `::` is the anonymous package name and gets a
+/// unique synthesized name. Requires a following `of`/`where` (a bare `subset`
+/// term is meaningless) so a stray `subset` bareword still falls through.
+pub(in crate::parser) fn inline_subset_term(input: &str) -> PResult<'_, Expr> {
+    let (rest, _) = ws1(input)?;
+    // Anonymous `::` name (standalone, followed by whitespace), or an explicit
+    // (qualified) name.
+    let (rest, name) = if let Some(r) = rest.strip_prefix("::")
+        && r.starts_with(char::is_whitespace)
+    {
+        let n = format!(
+            "__mutsu_anon_subset_{}",
+            ANON_SUBSET_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        );
+        (r, n)
+    } else {
+        qualified_ident(rest)?
+    };
+    let (rest, _) = ws(rest)?;
+    // Require `of` and/or `where` so a bare `subset` word is not misread as a term.
+    if keyword("of", rest).is_none() && keyword("where", rest).is_none() {
+        return Err(PError::expected("inline subset term"));
+    }
+    super::super::simple::register_user_type(&name);
+    let mut rest = rest;
+    let mut base: Option<String> = None;
+    if let Some(r) = keyword("of", rest) {
+        let (r, _) = ws1(r)?;
+        let (r, b) = parse_type_constraint_expr(r).ok_or_else(|| PError::expected("type"))?;
+        let (r, _) = ws(r)?;
+        base = Some(b);
+        rest = r;
+    }
+    let base = base.unwrap_or_else(|| "Any".to_string());
+    let (rest, predicate) = if let Some(r) = keyword("where", rest) {
+        let (r, _) = ws1(r)?;
+        let (r, pred) = expression(r)?;
+        (r, Some(pred))
+    } else {
+        (rest, None)
+    };
+    let decl = Stmt::SubsetDecl {
+        name: Symbol::intern(&name),
+        base,
+        predicate,
+        version: super::super::simple::current_language_version(),
+        is_export: false,
+        export_tags: Vec::new(),
+        is_my: false,
+    };
+    Ok((
+        rest,
+        Expr::DoBlock {
+            body: vec![decl, Stmt::Expr(Expr::BareWord(name))],
+            label: None,
+        },
+    ))
+}

--- a/src/parser/stmt/decl/mod.rs
+++ b/src/parser/stmt/decl/mod.rs
@@ -11,6 +11,7 @@ mod my_decl_helpers;
 mod use_decl;
 
 // Re-export public items that were previously accessible from the flat `decl` module.
+pub(in crate::parser) use constant_subset::inline_subset_term;
 pub(in crate::parser::stmt) use constant_subset::{constant_decl, subset_decl};
 pub(crate) use enum_decl::{anon_enum_decl, enum_decl};
 pub(in crate::parser::stmt) use handles::parse_handle_specs;

--- a/t/inline-subset-term.t
+++ b/t/inline-subset-term.t
@@ -1,0 +1,52 @@
+use v6;
+use Test;
+
+# An inline `subset` (anonymous `::` or named) used as a TERM: an expression
+# that yields the subset's type object, usable on the RHS of `~~`, bound to a
+# variable, or nested in a `where` clause. Previously each form died with a
+# `Confused` parse error.
+
+plan 12;
+
+# Anonymous inline subset on the RHS of a smartmatch.
+is (42  ~~ (subset :: where Int|Str)), True,  'anon subset term: Int matches';
+is (4.2 ~~ (subset :: where Int|Str)), False, 'anon subset term: Rat fails';
+is ("x" ~~ (subset :: where Int|Str)), True,  'anon subset term: Str matches';
+
+# Bound to a variable and reused.
+{
+    my $s = (subset :: where Int|Str);
+    is (42  ~~ $s), True,  'bound anon subset: Int';
+    is (4.2 ~~ $s), False, 'bound anon subset: Rat';
+}
+
+# `of Base` with a `where` predicate.
+is (5 ~~ (subset :: of Real where * > 3)),  True,  'of Real where * > 3: 5';
+is (2 ~~ (subset :: of Real where * > 3)),  False, 'of Real where * > 3: 2';
+
+# `of` alone (no predicate).
+is (5   ~~ (subset :: of Int)), True,  'of Int only: Int';
+is (5.0 ~~ (subset :: of Int)), False, 'of Int only: Rat';
+
+# A named inline subset registers its name for later use.
+{
+    my $s = (subset InlineNamed where Int);
+    is (7 ~~ InlineNamed), True, 'named inline subset usable by name';
+}
+
+# Nested inside a signature `where` clause (the doc example shape).
+{
+    my enum E1 <A B>;
+    my enum E2 <C D>;
+    sub g(@a where { .all ~~ subset :: where E1|E2 }) { @a.elems }
+    is g([A, C]), 2, 'inline subset inside a signature where clause';
+}
+
+# `.grep` with an inline subset predicate.
+{
+    my @vals = 1, "x", 4.2, 3;
+    my $s = subset :: where Int|Str;
+    is @vals.grep(* ~~ $s).elems, 3, 'inline subset in a grep predicate';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

An inline `subset` used as an expression — an anonymous `subset :: where …` or a named `subset Foo where …` in term position — now yields the subset's type object, usable on the RHS of `~~`, bound to a variable, or nested in a `where` clause. Previously each form died with a `Confused` parse error.

```raku
say 42  ~~ (subset :: where Int|Str);   # True
say 4.2 ~~ (subset :: where Int|Str);   # False
my $s = (subset :: of Real where * > 3); say 5 ~~ $s;   # True
```

Resolves the documented example from `Language/typesystem.rakudoc`:

```raku
my enum E1 <A B>;
my enum E2 <C D>;
sub g(@a where { .all ~~ subset :: where E1|E2 } ) { say @a }
g([A, C]);   # [A C]
```

## Fix

Parse `subset` in term position (in `identifier_call`, only reached after the statement dispatcher has already claimed a leading `subset` declaration) and lower it to `do { subset <name> …; <name> }`, reusing the ordinary subset declaration machinery — mutsu already evaluates a subset name in term position to its type object.

- `::` is the anonymous package name and gets a unique synthesized internal name.
- `of Base` and `where PRED` are both supported.
- A following `of`/`where` is required so a stray `subset` bareword still falls through.

From the doc-diff `Language/typesystem.rakudoc` corpus (finding [19]).

## Tests

- New pin `t/inline-subset-term.t` (12 subtests).
- `make test` PASS (2052 files / 19459 tests). Subset roast tests still green: `S12-subset/type-subset.t`, `S02-types/subset-6e.t`, `6.c/S02-types/subset-6c.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)