### PR TITLE
fix: X::TypeCheck::Assignment message drops the class-name prefix

### DIFF
--- a/src/runtime/utils/errors.rs
+++ b/src/runtime/utils/errors.rs
@@ -59,12 +59,12 @@ pub(crate) fn type_check_assignment_error(var_name: &str, expected: &str, val: &
     let repr = value_short_repr(val);
     if repr.is_empty() {
         format!(
-            "X::TypeCheck::Assignment: Type check failed in assignment to {}; expected {} but got {}",
+            "Type check failed in assignment to {}; expected {} but got {}",
             display_name, expected, got_type
         )
     } else {
         format!(
-            "X::TypeCheck::Assignment: Type check failed in assignment to {}; expected {} but got {} {}",
+            "Type check failed in assignment to {}; expected {} but got {} {}",
             display_name, expected, got_type, repr
         )
     }
@@ -157,12 +157,12 @@ pub(crate) fn type_check_element_error(var_name: &str, expected: &str, val: &Val
     let repr = value_short_repr(val);
     if repr.is_empty() {
         format!(
-            "X::TypeCheck::Assignment: Type check failed for an element of {}; expected {} but got {}",
+            "Type check failed for an element of {}; expected {} but got {}",
             display_name, expected, got_type
         )
     } else {
         format!(
-            "X::TypeCheck::Assignment: Type check failed for an element of {}; expected {} but got {} {}",
+            "Type check failed for an element of {}; expected {} but got {} {}",
             display_name, expected, got_type, repr
         )
     }

--- a/t/typecheck-assignment-message-prefix.t
+++ b/t/typecheck-assignment-message-prefix.t
@@ -1,0 +1,68 @@
+use v6;
+use Test;
+
+# An X::TypeCheck::Assignment exception's `.message` / `.Str` / `.gist` must NOT
+# embed the `X::TypeCheck::Assignment: ` class-name prefix (raku puts the class
+# name nowhere in the message). Baking it in doubled the class name when user
+# code prints `.^name, ': ', .Str` -- the shape of the doc example in
+# Language/typesystem.rakudoc.
+
+plan 6;
+
+# Reassigning a wrong type to a declared typed scalar.
+{
+    my Int $x = 42;
+    $x = "hello";
+    CATCH {
+        default {
+            is .message,
+                'Type check failed in assignment to $x; expected Int but got Str ("hello")',
+                'scalar reassignment .message has no class prefix';
+        }
+    }
+}
+
+# Subset-constrained scalar (the doc example [18]).
+{
+    subset Positive of Int where * > -1;
+    my Positive $i = 1;
+    $i = -42;
+    CATCH {
+        default {
+            is .^name, 'X::TypeCheck::Assignment', 'subset typecheck .^name';
+            is .message,
+                'Type check failed in assignment to $i; expected Positive but got Int (-42)',
+                'subset typecheck .message has no class prefix';
+            # `.^name, ': ', .Str` must not double the class name.
+            is .^name ~ ': ' ~ .Str,
+                'X::TypeCheck::Assignment: Type check failed in assignment to $i; expected Positive but got Int (-42)',
+                'name + Str reads exactly once';
+        }
+    }
+}
+
+# Typed array element assignment.
+{
+    my Int @a;
+    @a[0] = "hi";
+    CATCH {
+        default {
+            is .message,
+                'Type check failed for an element of @a; expected Int but got Str ("hi")',
+                'element .message has no class prefix';
+        }
+    }
+}
+
+# `.Str` equals `.message` (no prefix on either).
+{
+    my Int $y = 1;
+    $y = "x";
+    CATCH {
+        default {
+            is .Str, .message, '.Str equals .message';
+        }
+    }
+}
+
+done-testing;

--- a/t/typed-var-assignment.t
+++ b/t/typed-var-assignment.t
@@ -65,5 +65,5 @@ plan 17;
 # Error message format
 {
     my Int $x = 42;
-    try { $x = "hello"; CATCH { default { is .message, "X::TypeCheck::Assignment: Type check failed in assignment to \$x; expected Int but got Str (\"hello\")", "error message matches expected format" } } }
+    try { $x = "hello"; CATCH { default { is .message, "Type check failed in assignment to \$x; expected Int but got Str (\"hello\")", "error message matches expected format" } } }
 }


### PR DESCRIPTION
## Summary

An `X::TypeCheck::Assignment` exception's `.message` (and `.Str` / `.gist`, plus the uncaught top-level display) embedded a redundant `X::TypeCheck::Assignment: ` class-name prefix, which raku never includes. This doubled the class name when user code prints `.^name, ': ', .Str` — the exact shape of the `Language/typesystem.rakudoc` example — and diverged from raku's `.message` for every subset / typed-container assignment failure.

```raku
subset Positive of Int where * > -1;
my Positive $i = 1;
$i = -42;
CATCH { default { put .^name, ': ', .Str } }
# raku : X::TypeCheck::Assignment: Type check failed in assignment to $i; expected Positive but got Int (-42)
# before: X::TypeCheck::Assignment: X::TypeCheck::Assignment: Type check failed …   (doubled)
```

## Fix

Drop the prefix from `type_check_assignment_error` and `type_check_element_error` (`runtime/utils/errors.rs`) — the `… but got …` builders used by subset and typed-container checks. The `error_typed.rs` `…, got …` builder already had no prefix.

The local `t/typed-var-assignment.t` had encoded the buggy prefix in its expectation; updated it to the raku-correct message (roast is authoritative). No roast test asserts the prefixed message.

From the doc-diff `Language/typesystem.rakudoc` corpus (finding [18]).

## Tests

- New pin `t/typecheck-assignment-message-prefix.t` (6 subtests: scalar reassign, subset, typed element, `.Str == .message`, and `.^name ~ ': ' ~ .Str` reads exactly once).
- `make test` PASS (2052 files / 19453 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)