### PR TITLE
feat: enum types and values do the Enumeration role

### DIFF
--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -1261,6 +1261,28 @@ impl Interpreter {
                 let (base_type, smiley) =
                     super::super::types::strip_type_smiley(&type_name_resolved);
 
+                // Every enum type object and every enum value does the
+                // `Enumeration` role (`E ~~ Enumeration`, `E.pick ~~ Enumeration`).
+                if base_type == "Enumeration" {
+                    let is_enum = match left.view() {
+                        ValueView::Enum { .. } => true,
+                        ValueView::Package(n) => {
+                            self.registry().enum_types.contains_key(&*n.resolve())
+                        }
+                        _ => false,
+                    };
+                    if !is_enum {
+                        return false;
+                    }
+                    // An enum value is defined (:D); a bare enum type object is
+                    // undefined (:U).
+                    return match smiley {
+                        Some(":U") => matches!(left.view(), ValueView::Package(_)),
+                        Some(":D") => matches!(left.view(), ValueView::Enum { .. }),
+                        _ => true,
+                    };
+                }
+
                 // Enum type object smartmatch against enum values.
                 if self.registry().enum_types.contains_key(base_type) {
                     let enum_match = matches!(

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -324,6 +324,16 @@ impl Interpreter {
         {
             return true;
         }
+        if constraint == "Enumeration" {
+            // Every enum value and every enum type object does `Enumeration`.
+            return match value.view() {
+                ValueView::Enum { .. } => true,
+                ValueView::Package(name) => {
+                    self.registry().enum_types.contains_key(&*name.resolve())
+                }
+                _ => false,
+            };
+        }
         if constraint == "Inf" {
             return matches!(value.view(), ValueView::Num(n) if n.is_infinite() && n.is_sign_positive());
         }

--- a/src/runtime/utils/type_constraints.rs
+++ b/src/runtime/utils/type_constraints.rs
@@ -32,6 +32,7 @@ pub(crate) fn is_known_type_constraint(constraint: &str) -> bool {
             | "Mu"
             | "Any"
             | "Cool"
+            | "Enumeration"
             | "Nil"
             | "Pair"
             | "Map"

--- a/src/value/types_isa.rs
+++ b/src/value/types_isa.rs
@@ -61,7 +61,8 @@ impl Value {
             ValueView::Nil => "Nil",
             ValueView::Instance { .. } | ValueView::Package(_) => owned_name.as_deref().unwrap(),
             ValueView::Enum { enum_type, .. } => {
-                return enum_type.resolve() == type_name;
+                // Every enum value does the `Enumeration` role.
+                return type_name == "Enumeration" || enum_type.resolve() == type_name;
             }
             ValueView::Sub(data) => match data.env.get("__mutsu_callable_type").map(Value::view) {
                 Some(ValueView::Str(kind)) if kind.as_str() == "Method" => "Method",

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -337,6 +337,7 @@ impl Interpreter {
                 | "Stringy"
                 | "Positional"
                 | "Associative"
+                | "Enumeration"
                 | "Failure"
                 | "Exception"
                 | "Order"

--- a/t/enum-does-enumeration.t
+++ b/t/enum-does-enumeration.t
@@ -1,0 +1,54 @@
+use v6;
+use Test;
+
+# Every enum type object and every enum value does the `Enumeration` role:
+# `E ~~ Enumeration`, `E.pick ~~ Enumeration`, `.does(Enumeration)`, and a
+# `Enumeration $x` parameter all recognize enums. Previously `Enumeration` was
+# not even a known type (it stringified), so all of these were False / errors.
+
+plan 15;
+
+enum E <a b c>;
+
+# Bareword resolves to a type object, not a string.
+is Enumeration.^name, 'Enumeration', 'Enumeration is a type object';
+
+# Smartmatch: enum type object and enum value.
+ok (E ~~ Enumeration),  'enum type object ~~ Enumeration';
+ok (a ~~ Enumeration),  'enum value ~~ Enumeration';
+ok (b ~~ Enumeration),  'another enum value ~~ Enumeration';
+
+# Non-enums do NOT match.
+nok (5 ~~ Enumeration),      'Int does not ~~ Enumeration';
+nok ('x' ~~ Enumeration),    'Str does not ~~ Enumeration';
+class Plain {}
+nok (Plain ~~ Enumeration),  'a plain class does not ~~ Enumeration';
+
+# Definiteness smileys: a value is defined (:D), a type object is undefined (:U).
+ok  (a ~~ Enumeration:D),  'enum value ~~ Enumeration:D';
+nok (a ~~ Enumeration:U),  'enum value does not ~~ Enumeration:U';
+ok  (E ~~ Enumeration:U),  'enum type object ~~ Enumeration:U';
+
+# `.does`.
+ok a.does(Enumeration), 'enum value .does(Enumeration)';
+ok E.does(Enumeration), 'enum type object .does(Enumeration)';
+
+# A `Enumeration` parameter binds an enum value.
+{
+    sub takes-enum(Enumeration $x) { $x.key }
+    is takes-enum(a), 'a', 'Enumeration parameter binds an enum value';
+}
+
+# Works in a smartmatching context (grep / when).
+{
+    my @mixed = a, 5, b, 'x', c;
+    is @mixed.grep(Enumeration).elems, 3, 'grep(Enumeration) keeps the enum values';
+}
+
+# A non-Int-backed enum value still does Enumeration.
+{
+    enum Frac(:x(1.5), :y(2.5));
+    ok (x ~~ Enumeration), 'Rat-backed enum value ~~ Enumeration';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

`Enumeration` was not a known type in mutsu, so a bareword `Enumeration` stringified (`.^name` → `Str`) and every enum type/value check against it diverged from raku:

```raku
enum E <a b c>;
say E ~~ Enumeration;      # was False, raku True
say a ~~ Enumeration;      # was False, raku True
say a.does(Enumeration);   # was False, raku True
sub f(Enumeration $x) {};  # was "Invalid typename 'Enumeration'"
```

## Fix

Register `Enumeration` as a built-in type (`is_builtin_type`, `is_known_type_constraint`) and match every enum type object and enum value against it in the four type-check paths:

- **smartmatch** (`~~`): `smart_match.rs`, respecting `:D` (a value is defined) / `:U` (a bare type object is undefined);
- **runtime type match** (parameter binding, `.does`): `type_matches_value`;
- **pure value isa** (`isa_check`) for enum values.

Non-enums (Int, Str, plain classes) stay False.

From the doc-diff `Language/typesystem.rakudoc` corpus (finding [17]).

## Tests

- New pin `t/enum-does-enumeration.t` (15 subtests: smartmatch, `:D`/`:U`, `.does`, parameter binding, `grep`, Rat-backed enum value, non-enum negatives).
- `make test` PASS (2054 files / 19482 tests). Enum + type roast suites still green (`S12-enums/*`, `S02-types/type.t`).

## Out of scope (pre-existing)

- `x ~~ Rat` for a Rat-backed enum value is still False (the backing-type smartmatch only unwraps Int backings) — unrelated to Enumeration.
- `multi g(Enumeration $x) {}` vs `multi g(Int $x) {}` on an enum value: mutsu picks one, raku throws `X::Multi::Ambiguous` (multi-dispatch ambiguity detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)