### PR TITLE
docs+chore: inventory gc_contents_mut aliased-write sites; assert the 3 unique ones

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -328,32 +328,61 @@ sessions).
 
 ---
 
-## 2. ★ Phase B: GC → NaN-boxing → JIT (layers 3a, 3b, and layer-4 JIT all complete)
+## 2. ★ Phase B: GC → NaN-boxing → JIT — the headline layers are DONE; a soundness tail remains
 
-**GC (cycle collector on Arc, layer 3a) is done and default on** (2026-07-05 ADR-0003).
-**NaN-boxing (layer 3b, = §5 Lever 2) is also done** (2026-07-12 #4467 B-guards / #4469 B-flip;
-`size_of::<Value>()` 48→8B; GC counters match main; all benches 5–9% faster = gate met).
-History and details in [news/2026-07.md](news/2026-07.md). Remaining:
+**All four headline layers landed.** What is left is *not* another layer — it is the GC
+**soundness tail** (unsafe raw-pointer writes) plus minor perf/hardening. Do not restart a
+"GC campaign" from scratch; work the tail below in order.
 
-- **Layer 4 JIT (Cranelift, = §5 Lever 4) = done**: following J1–J5 (default on, 2026-07-13),
-      **all 6 J4d slices are complete, the gate was re-judged, and ADR-0004 is closed** (2026-07-15 —
-      #4527/#4528/#4529/#4534/#4537/#4540; bench CI: fib+jit ratio 0.34→0.28;
-      history = [news/2026-07.md](news/2026-07.md); judgment =
-      [ADR-0004](docs/adr/0004-jit-strategy.md) 2026-07-15 addendum).
-      The root fix for the remaining interpreter/JIT shared fixed costs (SetLocal env-mirror etc.)
-      belongs to the §6 lexical-slot campaign. The canonical source of bench numbers is the bench CI
-      (`bench-data` branch; the `+jit` series starts at #4480; from J5 onward the plain series pins
-      `MUTSU_JIT=off` explicitly as the interpreter baseline).
-- [ ] **3b-2 traffic pruning** ([docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md) §3.3):
-      now that clone/drop is an 8B copy, reduce needless clones themselves (overlaps with the
-      inventory of the 9022 `.clone()` calls). Lower priority than the JIT; profile-driven.
-- [ ] Layer 3a hardening (H1 continuous measurement through the H5 background-collect start trigger) =
-      see [docs/gc-post-3a-roadmap.md](docs/gc-post-3a-roadmap.md). Suppressing the candidate pushes
-      from grammar parsing themselves (~510k/200-parse) is not started (the real harm — memory
-      retention — was already fixed via `Weak`).
-- Layer 3c biased refcount = frozen (start trigger in gc-post-3a-roadmap §4).
-  Layer 4 JIT = [ADR-0004 (Accepted 2026-07-06)](docs/adr/0004-jit-strategy.md);
-  start condition = layer 3b gate met (§5 Lever 4).
+| Layer | Status |
+|-------|--------|
+| 3a — cycle collector on `Arc`, type-filtered | ✅ done, default on (2026-07-05, ADR-0003) |
+| 3b — NaN-boxing (`size_of::<Value>()` 48→8B) | ✅ done (2026-07-12, #4467 B-guards / #4469 B-flip; benches 5–9% faster = gate met) |
+| 4 — JIT (Cranelift) | ✅ done, default on (2026-07-15, all 6 J4d slices, ADR-0004 closed) |
+| 3c — biased refcount | 🧊 frozen (measured-trigger only; gc-post-3a-roadmap §4) |
+
+History/details in [news/2026-07.md](news/2026-07.md). JIT bench numbers come from the bench CI
+(`bench-data` branch; `+jit` series from #4480). The remaining interpreter/JIT shared fixed cost
+(SetLocal env-mirror) is the §6 lexical-slot campaign, not a GC item.
+
+### 2.1 GC soundness tail — the real remaining GC work
+
+The `gc::gc_contents_mut` / `Gc::{get,make}_mut` primitive writes through `Arc::as_ptr as
+*mut` — a provenance violation (Rust UB) + a data race when the target is genuinely shared.
+This is the only GC work with real payoff left; it is **soundness**, medium impact.
+
+**✅ Step 1 (inventory) DONE (2026-07-20)** — [docs/gc-contents-mut-inventory.md](docs/gc-contents-mut-inventory.md).
+Every production site was read and classified. Decisive result — **54 sites / 20 files**:
+**(a) provably-unique = 3** (cyclic-structure construction on freshly-created nodes),
+**(b) make_mut-COW-coverable = 0**, **(c) needs first-class cell = 51**, (?) = 0. Every guarded
+site *already* routes the unique case to `make_mut` and reserves `gc_contents_mut` strictly for
+the shared+identity case. So:
+
+- **`make_mut`-COW is a dead end** — it can retire zero sites. The earlier "route easy clusters
+  through COW" idea is empty; do not pursue it.
+- **✅ Step 2 (the 3 (a) sites) DONE (2026-07-20)**: `debug_assert_eq!(strong_count(), 1)` added
+  before each aliased `&mut` in `vm_var_assign_ops.rs` (fixup_circular_hash / replace_array_refs_in_value /
+  fixup_circular_array_refs) to document provable uniqueness. Zero behavior change (debug-only assert);
+  the truly-unaudited surface is now just the 51 (c) core.
+- [ ] **Step 3 — the 51 (c) sites = a `CellValue` / interior-mutability campaign** (large,
+      high-blast-radius, **not** a slice) — **DEFERRED (user decision 2026-07-20)**. A first-class
+      element cell (`UnsafeCell`/lock inside the container) makes identity-preserving in-place
+      mutation sound without the raw-pointer cast. **Fused with ADR-0001** (Track B / element cells +
+      GC — do not touch the sites twice); needs a Proposed ADR before starting. This is the only path
+      that removes the UB. Deferred because it is a large architectural commitment for a *soundness*
+      (not correctness/feature) payoff, while 3a already closed the leak that made GC table-stakes;
+      the residue is UB-by-letter + a cross-thread data race that has passed gc-stress/S17 so far.
+      Write the Proposed ADR when this campaign is greenlit.
+- [ ] **Step 4 (independent, optional) — harden the buffered-clone / uniqueness invariant**:
+      machine-check the `strong == 1 ⟹ unique` argument beyond `MUTSU_GC_VERIFY` (ANALYSIS §2.1).
+
+### 2.2 Lower-priority GC follow-ups (profile-driven; defer under 2.1)
+
+- [ ] **3b-2 clone-traffic pruning** (`gc-post-3a-roadmap` §3.3): clone/drop is now an 8B copy,
+      so reduce needless clones themselves (overlaps the ~9k `.clone()` inventory). Profile-driven.
+- [ ] **Layer 3a hardening H1–H5** (`gc-post-3a-roadmap`): suppressing grammar-parse candidate
+      pushes (~510k/200-parse) is unstarted — the real harm (memory retention) was already fixed
+      via `Weak`, so this is optimization, not a leak fix.
 
 ---
 

--- a/docs/gc-contents-mut-inventory.md
+++ b/docs/gc-contents-mut-inventory.md
@@ -1,0 +1,215 @@
+# Inventory: `gc_contents_mut` aliased-write call sites
+
+*(Step 1 of PLAN §2.1 — GC soundness tail. Generated 2026-07-20 by a close read of every
+production call site. Companion to ANALYSIS §2.1 and ADR-0001.)*
+
+`gc::gc_contents_mut(&Gc<T>) -> &mut T` (def: `src/gc/gc_ptr.rs:660`) performs a deliberate
+aliased in-place mutation through `Gc::as_ptr(gc) as *mut T`, used to preserve Raku
+**container identity** (a mutation through one alias is visible through every holder of the
+same `Gc` node). It is a provenance violation (Rust UB by the letter of Stacked Borrows) plus
+a genuine data race when the node is actually shared across threads.
+
+Safe alternatives already in the tree:
+- `Gc::make_mut(&mut self)` — COW: clones when strong-count > 1, so it does **not** preserve
+  identity across aliases.
+- `Gc::get_mut(&mut self)` — `Some` only if uniquely owned.
+
+## Classification legend
+
+- **(a) provably-unique** — the `Gc` is freshly owned here / not yet shared → a debug
+  `assert!(strong_count == 1)` documents it; safe as-is.
+- **(b) make_mut-COW-coverable** — identity NOT required → `Gc::make_mut` is semantically
+  equivalent; convertible with the existing mechanism, no new type.
+- **(c) needs-cell** — identity IS required AND the node can be genuinely shared → cannot use
+  `make_mut` without breaking identity; needs a first-class element cell / `CellValue`
+  (interior mutability).
+- **(?)** unsure.
+
+## Headline finding
+
+The production surface is almost entirely bucket **(c)**. **51 of 54** sites are
+identity-required shared writes; only **3** are bucket (a) (cyclic-structure construction on a
+just-created node). There are **zero (b)** and **zero (?)** sites. Every guarded site literally
+falls back to `make_mut` on the unique branch and reserves `gc_contents_mut` for the
+shared+identity case — which is the definition of (c).
+
+**Consequence:** `make_mut`-COW can retire **none** of the sites. The sound fix for the ~51
+(c) sites is a first-class element cell / `CellValue` (interior mutability inside the
+container), exactly the Track B / GC layer-3a fusion in ADR-0001. This is an architectural
+campaign, not a cleanup sweep. The only cheap wins are documenting the 3 (a) sites and
+hardening the buffered-clone uniqueness invariant (PLAN §2.1 Step 4).
+
+## Summary tally
+
+| Bucket | Count | Sites |
+|---|---|---|
+| (a) provably-unique | 3 | `vm_var_assign_ops.rs:375, 463, 516` |
+| (b) make_mut-COW-coverable | 0 | — |
+| (c) needs-cell | 51 | all other production sites |
+| (?) unsure | 0 | — |
+| **Total production** | **54** | across 20 files |
+
+**Only mixed file:** `vm/vm_var_assign_ops.rs` (3× (a) + 2× (c)). Every other file is pure (c).
+
+---
+
+## Per-file detail
+
+### `src/value/value_methods_a.rs` — pure (c)
+
+All operate on a `Value::Hash` from `self.view()` (a variable's/container's own, possibly
+aliased, hash); each is a documented container-identity autoviv/insert that must propagate.
+
+- `:279` — `store_through_cell` — insert `ContainerRef` at a `HashEntryRef` terminal — (c).
+- `:362` — `hash_autovivify` — insert empty Hash on missing key — (c).
+- `:395` — `hash_autovivify_cell` — promote scalar leaf to cell / autoviv — (c).
+- `:440` — `hash_slot_ref` — promote element to `ContainerRef` cell for `:=` — (c).
+- `:479` — `hash_assign_at` — `hash_insert_through` on shared hash — (c).
+- `:542` — `hash_entry_terminal` — walk-create intermediate hashes — (c).
+
+### `src/value/value_methods_b.rs` — pure (c)
+
+- `:10` — `hash_entry_write` — insert at terminal key — (c).
+- `:24` — `array_push_in_place` — `items.push` (the canonical shared-push) — (c).
+- `:45` — `ensure_array_child` — grow + vivify intermediate array element — (c).
+- `:99` — `array_slot_ref` — grow + promote element to cell — (c).
+
+### `src/value/view.rs` — pure (c)
+
+- `:605` — `with_array_inplace` — run `f` on shared `ArrayData`; the documented §3
+  container-identity chokepoint (explicitly rejects `make_mut`) — (c).
+
+### `src/vm/vm_var_assign_ops.rs` — MIXED (3× a + 2× c)
+
+- `:375` — `fixup_circular_hash` — self-referential hash cycle on freshly-created
+  `result_arc` (count == 1; raw ptr only because self-cycle clones the same `Gc` while a
+  `&mut` is live → borrow conflict, but node is provably unique) — **(a)**.
+- `:463` — `replace_array_refs_in_value` — self-ref insert on freshly-created `new_hash_arc` — **(a)**.
+- `:516` — `fixup_circular_array_refs` — self-ref cycle on freshly-created `result_arc` — **(a)**.
+- `:554` — `array_inplace_reassign` — `*old_gc = new_data` through the original backing (shared) — (c).
+- `:631` — `hash_inplace_reassign` — hash twin of the above — (c).
+
+### `src/vm/vm_var_assign_index_named.rs` — pure (c)
+
+- `:652` — scalar-list element write (mutable Scalar element inside a shared list) — (c).
+- `:1661` — hash key write, guarded `strong_count > 1` (`make_mut` on unique branch) — (c).
+- `:1759` — array element write, guarded `strong_count > 1` — (c).
+- `:2520` — nested `%h<x>{...}` outer-hash vivify/write (make_mut would relocate `.WHICH` metadata) — (c).
+- `:3092` — named hash key write (interior mutation, installs bind cell) — (c).
+- `:3110` — named array element write (interior mutation) — (c).
+
+### `src/vm/vm_var_assign_coerce.rs` — pure (c)
+
+- `:109` / `:122` / `:135` — `quanthash_store_preserving_identity` (Set / Bag / Mix): `*old =
+  data` into the variable's EXISTING QuantHash node (`old` from `env().get`), preserving node
+  identity for every holder (env mirror, `:=` binds, captures) — (c).
+
+### `src/vm/vm_var_assign_computed_attr.rs` — pure (c)
+
+- `:28` — `assign_into_computed_target` (Hash) — insert on resolved inner hash — (c).
+- `:35` — `assign_into_computed_target` (Array) — element assign on resolved inner array — (c).
+- `:74` — `materialize_bound_slot_to_cell` — install cell at token terminal — (c).
+
+### `src/vm/vm_var_assign_post_incdec.rs` — pure (c)
+
+- `:728` — hash `$h<k>++`, guarded `strong_count > 1` — (c).
+- `:751` — array `@a[i]++`, guarded `strong_count > 1` — (c).
+
+### `src/vm/vm_var_elem_mutate.rs` — pure (c)
+
+- `:150` — `tag_element_value_type_in_place` (Array) — set `value_type`/`declared_type` metadata — (c).
+- `:161` — same for Hash — (c).
+
+### `src/vm/vm_var_index_tracking.rs` — pure (c)
+
+- `:141` — record assigned index into embedded `initialized` set, guarded `strong_count > 1`
+  (pinned by `t/array-push-byref-coherence`) — (c).
+
+### `src/vm/vm_misc_assign.rs` — pure (c)
+
+- `:378` — name-based `HashEntryRef` materialization — install cell at token terminal — (c).
+
+### `src/vm/vm_exec_dispatch.rs` — pure (c)
+
+- `:1328` — SetGlobal `HashEntryRef` materialization — (c).
+- `:3294` / `:3298` — `UndefineAggregate` clear on env array / hash — (c).
+- `:3312` / `:3316` — same clear on locals-slot array / hash — (c).
+
+### `src/vm/vm_call_method_mut_ops.rs` — pure (c)
+
+- `:2054` — native `push`/`pop`/`shift`/`unshift`/`append` on env-bound array
+  (`env_root_descended_mut`) — (c).
+- `:2369` — native `splice` on env-bound array — (c).
+
+### `src/vm/vm_call_method_ops.rs` — pure (c)
+
+- `:1515` — `.shift`/`.pop` on a by-value receiver (`invocant = target.clone()` shares inner Gc) — (c).
+
+### `src/vm/vm_hyper_method_ops.rs` — pure (c)
+
+- `:635` — hyper write-back to non-variable target (`existing.items = items.clone()`) — (c).
+- `:1008` — twin site in `exec_hyper_method_call_op` — (c).
+
+### `src/runtime/methods_mut_dispatch.rs` — pure (c)
+
+All guarded by `strong_count > 1`, falling back to `make_mut` when unique.
+
+- `:1432` — `push`/`append` extend on env-bound array — (c).
+- `:1498` — `pop` — (c).
+- `:1539` — `unshift` insert — (c).
+- `:1573` — `prepend` insert — (c).
+- `:1624` — `shift` remove — (c).
+
+### `src/runtime/methods_call_dispatch.rs` — pure (c)
+
+- `:1002` — `%h.push(pairs)`, guarded `strong_count > 1` — (c).
+
+### `src/runtime/methods_mut_method_lvalue.rs` — pure (c)
+
+- `:350` — `$pair.value = X` where value is a live `HashEntryRef` (writes through to
+  `%h{$p.key}` on the shared hash) — (c).
+
+### `src/runtime/builtins_collection_deepmap.rs` — pure (c)
+
+- `:274` — deepmap leaf write-back into source array — (c).
+- `:358` — same into source hash — (c).
+
+### `src/runtime/utils/shaped.rs` — pure (c)
+
+- `:121` — `mark_shaped_array_items` — set `shape` metadata (shared by every holder;
+  replaces a pointer-keyed side table) — (c).
+
+---
+
+## Infra (`src/gc/` + the `aliased_mut` wrapper — not classified)
+
+The primitive/definition/re-export layer, not production mutation sites:
+
+- `src/gc/gc_ptr.rs:660` — the `gc_contents_mut` **definition** (the single `Gc::as_ptr as
+  *mut` cast). Doc/SAFETY refs at 315, 328, 344, 349, 396; unit test at 1086–1092.
+- `src/gc/mod.rs:34` — re-export.
+- `src/gc/safepoint.rs:5` — doc comment (re-entry boundary rule).
+- `src/value/aliased_mut.rs` — the audited wrapper module: `arc_contents_mut` (line 69,
+  dead-code Arc analogue), a shadow `gc_contents_mut` (line 84), and `gc_data_mut` (line 107,
+  branches `strong_count > 1 → gc_contents_mut` else `make_mut`). This module *is* the intended
+  single choke point; its module docs (1–35) already document the unsoundness and name Track B
+  / first-class container cells as the real fix.
+- `src/value/mod.rs:317` — `pub(crate) use crate::gc::gc_contents_mut;` re-export.
+
+---
+
+## What Step 1 tells the plan (PLAN §2.1)
+
+1. **`make_mut`-COW is a dead end (Step 2 is empty).** No production site is convertible;
+   every guarded site already uses `make_mut` for the unique case.
+2. **The 3 (a) sites — DONE (2026-07-20)**: `debug_assert_eq!(strong_count(), 1)` added before
+   each aliased `&mut` in `vm_var_assign_ops.rs` to document provable uniqueness. Zero behavior
+   change (debug-only); the truly-unaudited surface is now the 51 (c) core.
+3. **The 51 (c) sites require the `CellValue` / interior-mutability campaign** — a first-class
+   element cell (`UnsafeCell`/lock inside the container) so identity-preserving in-place
+   mutation is sound without a raw-pointer cast. This is fused with ADR-0001 (do not touch the
+   sites twice) and is a large, high-blast-radius campaign, not a slice. **DEFERRED** (user
+   decision 2026-07-20): a large architectural commitment for a soundness-only payoff, while 3a
+   already closed the GC leak. Write a Proposed ADR when greenlit.
+4. **Buffered-clone invariant hardening** is independent of the above and can proceed in
+   parallel (PLAN §2.1 Step 4).

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -372,6 +372,12 @@ impl Interpreter {
             // self-referential cycle requires the in-place write (a freshly
             // created Arc cannot be made cyclic via `get_mut`). See
             // `arc_contents_mut`; no borrow into the map is live across the write.
+            // Inventory bucket (a) — provably-unique (docs/gc-contents-mut-inventory.md).
+            debug_assert_eq!(
+                result_arc.strong_count(),
+                1,
+                "fixup_circular_hash: aliased &mut requires a uniquely-owned freshly-created node"
+            );
             let data = unsafe { crate::value::gc_contents_mut(&result_arc) };
             for key in &circular_keys {
                 data.map
@@ -460,6 +466,12 @@ impl Interpreter {
                 // SAFETY: new_hash_arc was just created here; the
                 // self-reference insert and the in-place recursive fixup must
                 // alias it. See `arc_contents_mut`.
+                // Inventory bucket (a) — provably-unique (docs/gc-contents-mut-inventory.md).
+                debug_assert_eq!(
+                    new_hash_arc.strong_count(),
+                    1,
+                    "replace_array_refs_in_value: aliased &mut requires a uniquely-owned freshly-created node"
+                );
                 let data = unsafe { crate::value::gc_contents_mut(&new_hash_arc) };
                 for key in &self_ref_keys {
                     data.map
@@ -513,6 +525,12 @@ impl Interpreter {
             // SAFETY: result_arc was just created here; building a
             // self-referential cycle and the in-place recursive fixup must alias
             // it. See `arc_contents_mut`.
+            // Inventory bucket (a) — provably-unique (docs/gc-contents-mut-inventory.md).
+            debug_assert_eq!(
+                result_arc.strong_count(),
+                1,
+                "fixup_circular_array_refs: aliased &mut requires a uniquely-owned freshly-created node"
+            );
             let data = unsafe { crate::value::gc_contents_mut(&result_arc) };
             for idx in &circular_indices {
                 data.items[*idx] = Value::array_with_kind(result_arc.clone(), *kind);


### PR DESCRIPTION
## Summary

**Step 1 of PLAN §2.1 (GC soundness tail).** Read and classified every production
`gc_contents_mut` call site — the raw-pointer aliased-write primitive (`Gc::as_ptr as *mut`, a
provenance violation + a data race when the node is genuinely shared).

Inventory (`docs/gc-contents-mut-inventory.md`) — **54 sites / 20 files**:

| Bucket | Count |
|---|---|
| (a) provably-unique | 3 |
| (b) make_mut-COW-coverable | **0** |
| (c) needs first-class cell | 51 |
| (?) unsure | 0 |

**Decisive finding:** `make_mut`-COW can retire *none* of the sites — every guarded site already
routes the unique case to `make_mut` and reserves `gc_contents_mut` strictly for the
shared+identity case. The 51 (c) sites require the deferred `CellValue` / interior-mutability
campaign (fused with ADR-0001), not a cleanup sweep.

## Changes

- **Step 2 (cheap win, done here):** `debug_assert_eq!(strong_count(), 1)` before each of the 3
  bucket-(a) aliased `&mut` in `vm_var_assign_ops.rs` (`fixup_circular_hash` /
  `replace_array_refs_in_value` / `fixup_circular_array_refs`), documenting provable uniqueness.
  Debug-only; **zero behavior change**.
- **`docs/gc-contents-mut-inventory.md`** (new) — the full per-site classification.
- **PLAN.md §2 restructured** — the headline GC layers (3a GC / 3b NaN-boxing / layer-4 JIT) are
  DONE; what remains is this soundness tail, now documented with an ordering. Step 3 (the 51 (c)
  sites) is **deferred per user decision** (a large architectural commitment for a soundness-only
  payoff, while GC layer 3a already closed the leak).

## Verification

- `cargo build` + `cargo clippy -D warnings` clean.
- Cyclic array/hash assignment (`@a = 42, @a` / self-referential hash) matches `raku`; the
  debug asserts never trip.
- `t/array-push-byref-coherence.t` + `roast/S32-array/perl.t` (circular `.raku.EVAL`) PASS.
- **`make test` fully green** (2054 files / 19472 tests / 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)