### PR TITLE
chore: Step 4 GC-soundness tail — machine-check the strong==1 => unique invariant

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -373,8 +373,18 @@ the shared+identity case. So:
       (not correctness/feature) payoff, while 3a already closed the leak that made GC table-stakes;
       the residue is UB-by-letter + a cross-thread data race that has passed gc-stress/S17 so far.
       Write the Proposed ADR when this campaign is greenlit.
-- [ ] **Step 4 (independent, optional) — harden the buffered-clone / uniqueness invariant**:
-      machine-check the `strong == 1 ⟹ unique` argument beyond `MUTSU_GC_VERIFY` (ANALYSIS §2.1).
+- **✅ Step 4 (independent) DONE (2026-07-20)** — hardened the buffered-clone / uniqueness
+      invariant. `Gc::verify_unique_for_aliased_mut` machine-checks the `strong == 1 ⟹ unique`
+      argument that `make_mut` / `get_mut` and the three (a) `gc_contents_mut` sites rely on, by
+      asserting the backing `Arc`'s strong count equals the GC-visible `header.strong` at the moment
+      an aliased `&mut` is taken (they move in lockstep for every live handle; the candidate buffer
+      holds only `Weak`, so a divergence means a live reference the `strong == 1` fast path assumes
+      away). Reports via the same non-fatal `VERIFY FAIL` stderr line the collector uses (gc-stress
+      CI greps for it). Compiled out in release; verify-gated (`MUTSU_GC_VERIFY=1`), and skipped when
+      `collecting()` or `other_mutators_active()` so it is a hard signal only under the single-threaded
+      gc-stress CI and never trips a benign transient collector clone in a multithreaded verify run.
+      Pins: `gc_ptr` unit tests `arc_and_gc_strong_counts_stay_in_lockstep` /
+      `erased_clone_makes_arc_exceed_gc_strong`.
 
 ### 2.2 Lower-priority GC follow-ups (profile-driven; defer under 2.1)
 

--- a/docs/gc-contents-mut-inventory.md
+++ b/docs/gc-contents-mut-inventory.md
@@ -211,5 +211,11 @@ The primitive/definition/re-export layer, not production mutation sites:
    sites twice) and is a large, high-blast-radius campaign, not a slice. **DEFERRED** (user
    decision 2026-07-20): a large architectural commitment for a soundness-only payoff, while 3a
    already closed the GC leak. Write a Proposed ADR when greenlit.
-4. **Buffered-clone invariant hardening** is independent of the above and can proceed in
-   parallel (PLAN §2.1 Step 4).
+4. **Buffered-clone invariant hardening — DONE (2026-07-20)**: `Gc::verify_unique_for_aliased_mut`
+   machine-checks the `strong == 1 ⟹ unique` argument at `make_mut` / `get_mut` and the three (a)
+   sites by asserting the backing `Arc` strong count equals the GC-visible `header.strong` (they move
+   in lockstep for every live handle; the candidate buffer holds only `Weak`). Verify-gated
+   (`MUTSU_GC_VERIFY=1`), compiled out in release, and skipped when `collecting()` /
+   `other_mutators_active()` so it is a hard signal only under the single-threaded gc-stress CI and
+   cannot false-positive on a transient collector clone in a multithreaded verify run. Reports via the
+   collector's non-fatal `VERIFY FAIL` stderr line (PLAN §2.1 Step 4).

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -322,6 +322,8 @@ impl<T: Trace + 'static> Gc<T> {
         // and only its own `drop_gc_edges` runs under `CollectGuard`.
         debug_assert!(!collecting(), "Gc::get_mut during a collect reclaim window");
         if self.inner.header.strong.load(Ordering::Relaxed) == 1 {
+            // The uniqueness claim — machine-check the backing `Arc` agrees (Step 4).
+            self.verify_unique_for_aliased_mut("Gc::get_mut");
             // SAFETY: sole live handle, so no other live-handle borrow into the
             // value exists. A buffered node's retained `Arc` never dereferences
             // the value except at a collect safepoint (same contract as
@@ -338,6 +340,57 @@ impl<T: Trace + 'static> Gc<T> {
     /// The GC-visible strong count (live `Gc` handles to this node).
     pub(crate) fn strong_count(&self) -> usize {
         self.inner.header.strong.load(Ordering::Relaxed)
+    }
+
+    /// Machine-check (GC-soundness-tail Step 4, PLAN §2.1) the
+    /// `strong == 1 ⟹ unique` argument that [`Gc::make_mut`] / [`Gc::get_mut`]
+    /// and the three bucket-(a) [`gc_contents_mut`] sites
+    /// (`docs/gc-contents-mut-inventory.md`) rely on before handing out an
+    /// aliased `&mut` into the node.
+    ///
+    /// Every *live* `Gc` handle bumps the backing `Arc`'s strong count and the
+    /// GC-visible `header.strong` in lockstep (`clone` / `Drop` / `make_mut`-COW
+    /// keep them paired), and the candidate buffer holds only `Weak` entries — so
+    /// outside a collect the two counts are exactly equal, and
+    /// `header.strong == 1` then genuinely implies a unique `Arc`. The one benign
+    /// way `Arc::strong_count` can exceed `header.strong` is a transient
+    /// [`Gc::erased`] strong clone the collector holds while it drains/scans.
+    /// That transient can only be observed by a mutator running on a DIFFERENT
+    /// thread than the collector (a collect and an aliased `&mut` never overlap
+    /// on one call stack), and the collector's pre-STW drain window
+    /// (`collect_cycles_at` holds the drained strong handles before the STW
+    /// engages) sits outside `collecting()`. So the check is a sound hard signal
+    /// only when NO other mutator thread is active — exactly the SINGLE-threaded
+    /// gc-stress CI (`MUTSU_GC_VERIFY=1`). It therefore skips both when
+    /// `collecting()` and when [`other_mutators_active`](crate::gc::stw::other_mutators_active),
+    /// so a multithreaded verify run (`threaded_cycle_churn`, S17) never trips it
+    /// on a benign transient.
+    ///
+    /// Compiled out in release (`cfg!(debug_assertions)`), verify-gated, and
+    /// skipped whenever a concurrent collector could hold a transient clone, so
+    /// the default `test` / roast / bench builds pay nothing and cannot go flaky.
+    /// A violation reports via the same non-fatal `VERIFY FAIL` stderr line the
+    /// collector uses (gc-stress CI greps for it); it never panics.
+    #[inline]
+    pub(crate) fn verify_unique_for_aliased_mut(&self, site: &str) {
+        if !cfg!(debug_assertions) {
+            return;
+        }
+        if !crate::gc::collect::verify_enabled()
+            || collecting()
+            || crate::gc::stw::other_mutators_active()
+        {
+            return;
+        }
+        let header = self.inner.header.strong.load(Ordering::Relaxed);
+        let arc = Arc::strong_count(&self.inner);
+        if arc != header {
+            eprintln!(
+                "[mutsu gc] VERIFY FAIL site={site} Gc uniqueness: Arc strong={arc} \
+                 != GC-visible strong={header} (a live handle desynced the two counts; \
+                 the strong==1 => unique argument is unsound at this aliased &mut)"
+            );
+        }
     }
 
     /// Raw `*const T` to the pointee, mirroring `Arc::as_ptr`. Used by
@@ -495,6 +548,10 @@ impl<T: Trace + Clone + 'static> Gc<T> {
                 header: GcHeader::fresh(),
                 value: cloned,
             });
+        } else {
+            // Fast path: reusing the existing node IS the `strong == 1 ⟹ unique`
+            // claim — machine-check the backing `Arc` agrees (Step 4).
+            self.verify_unique_for_aliased_mut("Gc::make_mut");
         }
         // Sole live handle. SAFETY / lint: see `Gc::get_mut`.
         let boxed = Arc::as_ptr(&self.inner) as *mut GcBox<T>;
@@ -1095,6 +1152,73 @@ mod tests {
             *alias,
             Cell(7),
             "the shared write is visible through the alias"
+        );
+    }
+
+    #[test]
+    fn arc_and_gc_strong_counts_stay_in_lockstep() {
+        // The invariant that `verify_unique_for_aliased_mut` (Step 4) machine-
+        // checks: every live `Gc` handle moves the backing `Arc`'s strong count
+        // and the GC-visible `header.strong` together, so `header.strong == 1`
+        // genuinely implies a unique `Arc`. Observed between operations, with no
+        // transient `erased()`/buffer clone outstanding, they are always equal.
+        let a = Gc::new(Cell(1));
+        assert_eq!(Arc::strong_count(&a.inner), a.strong_count());
+        assert_eq!(a.strong_count(), 1);
+
+        let alias = a.clone();
+        assert_eq!(Arc::strong_count(&a.inner), a.strong_count());
+        assert_eq!(a.strong_count(), 2, "clone bumps both counts in lockstep");
+
+        // COW on the aliased handle: `a` retargets to a fresh unique node, and
+        // the old node (held by `alias`) drops back to a paired (Arc, header).
+        let mut a = a;
+        *Gc::make_mut(&mut a) = Cell(3);
+        assert_eq!(
+            Arc::strong_count(&a.inner),
+            a.strong_count(),
+            "the fresh post-COW node is paired"
+        );
+        assert_eq!(a.strong_count(), 1);
+        assert_eq!(
+            Arc::strong_count(&alias.inner),
+            alias.strong_count(),
+            "the old shared node stays paired after the COW retarget"
+        );
+        assert_eq!(alias.strong_count(), 1);
+
+        drop(alias);
+        assert_eq!(Arc::strong_count(&a.inner), a.strong_count());
+
+        // The verify hook itself never panics on a genuinely-unique node (it is
+        // a no-op unless `MUTSU_GC_VERIFY=1`, but calling it must always be safe).
+        a.verify_unique_for_aliased_mut("unit-test");
+    }
+
+    #[test]
+    fn erased_clone_makes_arc_exceed_gc_strong() {
+        // The exact divergence `verify_unique_for_aliased_mut` flags: an
+        // `erased()` strong clone bumps the backing `Arc` but NOT the GC-visible
+        // `header.strong`, so while it is held Arc > GC-visible. In production
+        // this only happens transiently inside the collector (drain/scan), which
+        // is why the verify hook skips when a collector could be active; here we
+        // exhibit the divergence directly so the check's comparison is proven
+        // meaningful (not a dead no-op).
+        let a = Gc::new(Cell(1));
+        assert_eq!(Arc::strong_count(&a.inner), a.strong_count());
+        let erased = a.erased();
+        assert_eq!(a.strong_count(), 1, "GC-visible count unchanged by erased()");
+        assert_eq!(Arc::strong_count(&a.inner), 2, "backing Arc bumped");
+        assert_ne!(
+            Arc::strong_count(&a.inner),
+            a.strong_count(),
+            "this is the desync the verify hook detects"
+        );
+        drop(erased);
+        assert_eq!(
+            Arc::strong_count(&a.inner),
+            a.strong_count(),
+            "paired again once the transient clone drops"
         );
     }
 

--- a/src/gc/gc_ptr.rs
+++ b/src/gc/gc_ptr.rs
@@ -1207,7 +1207,11 @@ mod tests {
         let a = Gc::new(Cell(1));
         assert_eq!(Arc::strong_count(&a.inner), a.strong_count());
         let erased = a.erased();
-        assert_eq!(a.strong_count(), 1, "GC-visible count unchanged by erased()");
+        assert_eq!(
+            a.strong_count(),
+            1,
+            "GC-visible count unchanged by erased()"
+        );
         assert_eq!(Arc::strong_count(&a.inner), 2, "backing Arc bumped");
         assert_ne!(
             Arc::strong_count(&a.inner),

--- a/src/vm/vm_var_assign_ops.rs
+++ b/src/vm/vm_var_assign_ops.rs
@@ -378,6 +378,7 @@ impl Interpreter {
                 1,
                 "fixup_circular_hash: aliased &mut requires a uniquely-owned freshly-created node"
             );
+            result_arc.verify_unique_for_aliased_mut("fixup_circular_hash");
             let data = unsafe { crate::value::gc_contents_mut(&result_arc) };
             for key in &circular_keys {
                 data.map
@@ -472,6 +473,7 @@ impl Interpreter {
                     1,
                     "replace_array_refs_in_value: aliased &mut requires a uniquely-owned freshly-created node"
                 );
+                new_hash_arc.verify_unique_for_aliased_mut("replace_array_refs_in_value");
                 let data = unsafe { crate::value::gc_contents_mut(&new_hash_arc) };
                 for key in &self_ref_keys {
                     data.map
@@ -531,6 +533,7 @@ impl Interpreter {
                 1,
                 "fixup_circular_array_refs: aliased &mut requires a uniquely-owned freshly-created node"
             );
+            result_arc.verify_unique_for_aliased_mut("fixup_circular_array_refs");
             let data = unsafe { crate::value::gc_contents_mut(&result_arc) };
             for idx in &circular_indices {
                 data.items[*idx] = Value::array_with_kind(result_arc.clone(), *kind);


### PR DESCRIPTION
Completes **PLAN §2.1 Step 4** (the last independent item of the GC-soundness tail; Step 3 stays deferred pending ADR-0013).

## What

Adds `Gc::verify_unique_for_aliased_mut`, hardening the buffered-clone uniqueness argument that `make_mut` / `get_mut` and the three bucket-(a) `gc_contents_mut` sites rely on before handing out an aliased `&mut`.

Every live `Gc` handle bumps the backing `Arc`'s strong count and the GC-visible `header.strong` in lockstep (`clone` / `Drop` / `make_mut`-COW keep them paired), and the candidate buffer holds only `Weak` entries — so **outside a collect the two counts are exactly equal**, and `header.strong == 1` genuinely implies a unique `Arc`. The hook asserts that equality at the moment an aliased `&mut` is taken; a divergence means a live reference the `strong == 1` fast path assumes away.

## Why it can't go flaky

- **Verify-gated** (`MUTSU_GC_VERIFY=1`) and **compiled out in release** (`cfg!(debug_assertions)`), so the default `test` / roast / bench builds pay nothing (the multithreaded `test` job never sets the flag).
- **Skipped when `collecting()` or `other_mutators_active()`**: the only benign way `Arc` can exceed `header.strong` is a transient `erased()` clone the collector holds while it drains/scans, observable only from another thread. So the check is a hard signal exactly under the **single-threaded gc-stress CI** and never trips a benign transient in a multithreaded verify run (verified: `cargo test --test gc_stress` — the multithreaded `threaded_cycle_churn` false-positive that the naive check produced is gone once `other_mutators_active()` gates it).
- Reports via the same non-fatal `VERIFY FAIL` stderr line the collector already uses (gc-stress CI greps for it); **never panics**.

## Wiring

`make_mut`'s unique fast path, `get_mut`'s `Some` branch, and the three (a) sites in `vm_var_assign_ops.rs` (alongside the existing Step-2 `debug_assert_eq!(strong_count(), 1)`).

## Tests

- `gc_ptr::arc_and_gc_strong_counts_stay_in_lockstep` — pins the invariant across clone / drop / make_mut-COW.
- `gc_ptr::erased_clone_makes_arc_exceed_gc_strong` — proves the compared quantities really can diverge (via `erased()`), so the check is not a dead no-op.
- Manually verified: `MUTSU_GC=on MUTSU_GC_VERIFY=1` single-threaded over self-referential structures + heavy push/pop/hash mutation emits **zero** `VERIFY FAIL`; the coherence pins (`array-push-byref-coherence`, `array-bind-cell`, `array-value-path-mutation`, ...) pass under the same config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)