### PR TITLE
fix: enum declaration in expression context no longer swallows the terminating `;`

### DIFF
--- a/src/parser/stmt/decl/enum_decl.rs
+++ b/src/parser/stmt/decl/enum_decl.rs
@@ -1,6 +1,6 @@
 use super::super::super::expr::expression;
 use super::super::super::helpers::{skip_balanced_parens, ws, ws1};
-use super::super::super::parse_result::{PError, PResult, opt_char, parse_char, take_while1};
+use super::super::super::parse_result::{PError, PResult, parse_char, take_while1};
 use super::super::{ident, keyword, qualified_ident};
 use super::take_while_opt;
 use crate::ast::{Expr, Stmt};
@@ -81,7 +81,12 @@ fn parse_anon_enum_body(input: &str) -> PResult<'_, Stmt> {
         return Err(PError::expected("anonymous enum variants"));
     };
     let (rest, _) = ws(rest)?;
-    let (rest, _) = opt_char(rest, ';');
+    // Do NOT consume a trailing `;` here: the statement layer's
+    // `consume_semicolons` already handles the terminator. Eating it in this
+    // parser breaks the expression-context use (`my $e = enum <a b c>; say $x`),
+    // where the swallowed `;` lets the expression parser absorb the following
+    // statement as an infix continuation. (The dynamic-enum paths above already
+    // return without consuming `;`.)
     Ok((
         rest,
         Stmt::EnumDecl {
@@ -363,7 +368,8 @@ pub(super) fn parse_enum_decl_body_with_type(
     };
 
     let (rest, _) = ws(rest)?;
-    let (rest, _) = opt_char(rest, ';');
+    // See parse_anon_enum_body: leave the trailing `;` for the statement layer
+    // so `enum` in expression context does not swallow the next statement.
     Ok((
         rest,
         Stmt::EnumDecl {

--- a/t/enum-expr-semicolon.t
+++ b/t/enum-expr-semicolon.t
@@ -1,0 +1,53 @@
+use v6;
+use Test;
+
+# An `enum` declaration used in expression position (on the RHS of an
+# assignment) must NOT swallow the terminating `;`. Previously the enum body
+# parser consumed the trailing `;`, letting the expression parser absorb the
+# next statement as an infix continuation (`my $e = enum <a b c>; say 42`
+# mis-parsed `say` as an infix operator).
+
+plan 8;
+
+# Anonymous enum on an assignment RHS, followed by an ordinary statement.
+{
+    my $e = enum <a b c>;
+    say 42;   # if absorbed, this line would be swallowed / mis-evaluated
+    ok True, 'anon enum RHS does not absorb the following statement';
+}
+
+# The enum values are still usable after the assignment.
+{
+    my $e = enum <x y z>;
+    is x.value, 0, 'anon enum first value';
+    is z.value, 2, 'anon enum third value';
+}
+
+# Named enum on an assignment RHS.
+{
+    my $e = enum Fruit <Apple Banana Cherry>;
+    is Fruit.^name, 'Fruit', 'named enum type name after RHS assignment';
+    is Banana.value, 1, 'named enum value after RHS assignment';
+}
+
+# Plain statement context still works (control): terminator handled by the
+# statement layer.
+{
+    enum Weekday <Mon Tue Wed>;
+    is Tue.value, 1, 'statement-context enum still works';
+}
+
+# Multiple statements after an enum assignment all execute.
+{
+    my $captured = 0;
+    my $e = enum <p q>;
+    $captured = $captured + 1;
+    $captured = $captured + 1;
+    is $captured, 2, 'statements after enum assignment all run';
+}
+
+# Method chain / bare value use right after the assignment separator.
+{
+    my $e = enum <one two>;
+    is (one, two).join(','), 'one,two', 'bare enum values usable after separator';
+}


### PR DESCRIPTION
## Problem

An `enum` declaration used on the RHS of an assignment mis-parsed the
following statement:

```raku
my $e = enum <a b c>; say 42;
```

raku prints `42`. mutsu instead printed the enum's Map gist and treated
`say` as an infix operator, because the enum body parser consumed the
trailing `;`, letting the expression parser continue past the statement
separator and absorb `say 42` as an infix continuation. AST dump showed the
whole thing parsed as `my $e = (enum <a b c> say $e.^name)`.

## Root cause

`parse_anon_enum_body` and `parse_enum_decl_body_with_type` each ended with
a redundant `opt_char(rest, ';')`. The statement layer already consumes
inter-statement `;` via `consume_semicolons`, and the dynamic-enum paths in
the same file already returned without eating `;`. In statement context the
extra consumption was harmless (double-consumed), but in expression context
it swallowed the terminator.

## Fix

Drop the `opt_char(rest, ';')` from both enum body parsers, leaving the
terminator for the statement layer. Statement-context parsing is unaffected.

## Testing

- New pin `t/enum-expr-semicolon.t` (passes under both raku and mutsu).
- Existing enum `t/` tests (108) and `roast/S12-enums/*` (179) all green.
- `make test` PASS (19518 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)