### PR TITLE
fix: don't register a `proto method` as a package proto sub

### DIFF
--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -411,11 +411,24 @@ impl Interpreter {
             body,
             is_export,
             custom_traits,
+            is_method,
             ..
         } = stmt
         {
             let name_str = name.resolve();
-            self.register_proto_decl(&name_str, params, param_defs, body)?;
+            // A `proto method`/`proto submethod` (`is_method`) is a *method*-level
+            // proto: its `{*}` dispatches over the type's multi-method candidates
+            // via the class method table, not the package-level proto-sub table.
+            // Registering it as a package proto sub is not only unnecessary but
+            // breaks role composition: the role body's `RegisterProtoSub` runs once
+            // when the role is declared and again when a class does the role, so the
+            // second registration hits the already-present `GLOBAL::<name>` proto and
+            // wrongly raises `X::Redeclaration` (lizmat's `Enumify` proto+multi
+            // pattern, SBOM::CycloneDX). Skip the package-level registration for
+            // method protos; the method-table path already handles them.
+            if !*is_method {
+                self.register_proto_decl(&name_str, params, param_defs, body)?;
+            }
             if *is_export {
                 self.register_proto_decl_as_global(&name_str, params, param_defs, body)?;
                 // Record the export so consumers/MAIN-dispatch see the whole multi

--- a/t/proto-multi-method-role-composition.t
+++ b/t/proto-multi-method-role-composition.t
@@ -1,0 +1,57 @@
+use Test;
+
+# A role that declares a `proto method` together with `multi method`
+# candidates of the same name, composed into a class. Previously the role
+# body's proto registration ran once at role declaration and again when a
+# class did the role; the second run hit the already-registered package proto
+# and wrongly raised `X::Redeclaration` ("Did you mean to declare a
+# multi-sub?"). A `proto method` is a method-level proto (dispatched via the
+# type's method table), so it must not be registered as a package proto sub.
+# Regression for lizmat's `Enumify` proto+multi pattern (SBOM::CycloneDX).
+
+plan 7;
+
+# proto + single multi method in a role, composed into a class.
+{
+    role R1 {
+        proto method setup(|) {*}
+        multi method setup(Str:D $key) { "str:$key" }
+    }
+    my class C1 does R1 { }
+    is C1.setup("a"), 'str:a', 'role proto + single multi method composes and dispatches';
+}
+
+# proto + multiple multi methods in a role, composed.
+{
+    role R2 {
+        proto method setup(|) {*}
+        multi method setup(Str:D $key) { "str" }
+        multi method setup(@x) { "arr" }
+    }
+    my class C2 does R2 { }
+    is C2.setup("a"), 'str', 'role proto + multiple multi methods (Str candidate)';
+    is C2.setup([1, 2]), 'arr', 'role proto + multiple multi methods (@ candidate)';
+}
+
+# proto method declared directly in a class (no role) still works.
+{
+    class C3 {
+        proto method calc(|) {*}
+        multi method calc(Int:D $n) { $n * 2 }
+        multi method calc(Str:D $s) { $s.uc }
+    }
+    is C3.calc(5), 10, 'class proto + multi method dispatches on Int';
+    is C3.calc("hi"), 'HI', 'class proto + multi method dispatches on Str';
+}
+
+# Two classes composing the same role independently (the proto runs per class).
+{
+    role R4 {
+        proto method label(|) {*}
+        multi method label(Int:D $n) { "n=$n" }
+    }
+    my class A4 does R4 { }
+    my class B4 does R4 { }
+    is A4.label(1), 'n=1', 'first class composing the role dispatches';
+    is B4.label(2), 'n=2', 'second class composing the same role dispatches';
+}


### PR DESCRIPTION
## Problem

A role that declares a `proto method` alongside `multi method` candidates of the same name failed to compose into a class:

```raku
role R {
    proto method setup(|) {*}
    multi method setup(Str:D $key) { ... }
}
class C does R { }   # X::Redeclaration: Redeclaration of routine 'setup'. Did you mean to declare a multi-sub?
```

Minimal reproduction — the error fires at the class composition, not the role:

```raku
role R { proto method setup(|) {*}; multi method setup(Str:D $k) { "str" } }
class C does R { }
say C.setup("a");   # ===SORRY!=== on mutsu; "str" on raku
```

## Root cause

`RegisterProtoSub` always routed a `ProtoDecl` through `register_proto_decl`, which installs a **package**-level proto sub keyed by `<package>::<name>`. A `proto method` (`is_method`) is a *method*-level proto — its `{*}` dispatches over the type's multi-method candidates via the class method table, not the package proto-sub table.

Registering it at package level is unnecessary, and it breaks role composition: the role body's `RegisterProtoSub` runs once when the role is declared and again when a class does the role, so the second run hits the already-present `GLOBAL::<name>` proto and wrongly raises `X::Redeclaration` (confirmed with a debug trace: two registrations of `GLOBAL::setup`, the second with `proto_has=true`).

## Fix

`RegisterProtoSub` now skips the package-level registration for method protos (`is_method`); the method-table path already handles them. A `proto method` declared directly in a class (no role) still dispatches correctly.

## Result

Unblocks lizmat's `Enumify` proto+multi role pattern (used across the SBOM::CycloneDX dist family and others) — the spurious redeclaration is gone.

New pin test `t/proto-multi-method-role-composition.t` (7 cases, verified identical output under `raku`). All 78 existing proto/role/multi `t/` tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)