### PR TITLE
feat: anonymous enum expression value is a Map, not a plain Hash

### DIFF
--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -1573,13 +1573,16 @@ impl Interpreter {
             }
         }
 
-        // For anonymous enums, return a Map (Hash) of key => value pairs
+        // The value of an anonymous `enum <a b c>` expression is a Map in raku
+        // (`.^name`/`.WHAT` is `Map`, `.raku` is `Map.new((...))`), not a plain
+        // Hash. Embed the `Map` declared-type via `to_map` so introspection and
+        // rendering match — the same tag the `%`-constant / `.Map` paths use.
         if is_anonymous {
             let mut map = HashMap::new();
             for (key, val) in &enum_variants {
                 map.insert(key.clone(), val.to_value());
             }
-            Ok(Value::hash(map))
+            crate::builtins::map_hash_coerce::to_map(Value::hash(map))
         } else {
             Ok(Value::NIL)
         }

--- a/t/anon-enum-value-map.t
+++ b/t/anon-enum-value-map.t
@@ -1,0 +1,57 @@
+use v6;
+use Test;
+
+# The value of an anonymous `enum <...>` expression is a Map in raku, not a
+# plain Hash: `.^name`/`.WHAT` report `Map` and `.raku`/`.gist` render as
+# `Map.new((...))`. Previously mutsu returned an untagged Hash.
+#
+# (Tests read the introspection into a separate variable rather than
+# `say $e.^name` on the same line as the enum declaration, so this pin does
+# not depend on the enum-in-expression `;` parse fix.)
+
+plan 10;
+
+# Word-list anon enum.
+{
+    my $e = enum <a b c>;
+    my $name = $e.^name;
+    is $name, 'Map', 'anon enum value .^name is Map';
+    my $what = $e.WHAT;
+    is $what.^name, 'Map', 'anon enum value .WHAT is the Map type';
+}
+
+# The enum members still get their auto-incremented Int values.
+{
+    my $e = enum <x y z>;
+    is x.value, 0, 'anon enum member x == 0';
+    is z.value, 2, 'anon enum member z == 2';
+}
+
+# Parenthesised anon enum with explicit values.
+{
+    my $e = enum (a => 5, b => 10);
+    my $name = $e.^name;
+    is $name, 'Map', 'paren-form anon enum value is a Map';
+    is a.value, 5, 'paren-form explicit value preserved';
+}
+
+# << >> anon enum.
+{
+    my $e = enum << p q >>;
+    my $name = $e.^name;
+    is $name, 'Map', '<< >> anon enum value is a Map';
+}
+
+# .raku / .gist render as Map.new((...)).
+{
+    my $m = (enum <p q>);
+    is $m.gist, 'Map.new((p => 0, q => 1))', 'anon enum gist is Map.new(...)';
+    ok $m.raku.contains('Map.new'), 'anon enum .raku mentions Map.new';
+}
+
+# A Map answers .Map identically (round-trip).
+{
+    my $e = enum <one two>;
+    my $mapped = $e.Map;
+    is $mapped.^name, 'Map', 'anon enum value .Map is still a Map';
+}


### PR DESCRIPTION
## Problem

The value of an anonymous `enum <a b c>` expression is a `Map` in raku, but
mutsu returned an untagged `Hash`:

```raku
my $e = enum <a b c>;
say $e.^name;   # raku: Map    mutsu (before): Hash
say $e.WHAT;    # raku: (Map)  mutsu (before): (Hash)
say $e.raku;    # raku: $(Map.new((:a(0),:b(1),:c(2))))
```

## Fix

`register_enum_decl` built the anon-enum result with a bare `Value::hash`.
Route it through `map_hash_coerce::to_map`, which embeds the `Map`
declared-type in the Hash Arc — the same tag the `%`-constant and `.Map`
coercion paths already use, so `.^name`/`.WHAT`/`.raku`/`.gist` all match
raku at once. The enum members' auto-incremented Int values are unchanged.

Named enum declarations used in expression position (which currently return
`Nil` and are not pushed by the compiler) are a separate, deeper change and
left for a follow-up.

## Testing

- New pin `t/anon-enum-value-map.t` (passes under both raku and mutsu),
  covering word-list / paren / `<< >>` forms and `.gist`/`.raku`/`.Map`.
- Existing enum `t/` tests (90) and `roast/S12-enums/*` (179) all green.
- `make test` PASS (19520 tests).

From the doc-diff QA campaign (typesystem/enum scan, finding [15]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)