### PR TITLE
fix: `Compiler.id` is callable on the type object and returns a stable id

### DIFF
--- a/docs/dist-compat-sweep.md
+++ b/docs/dist-compat-sweep.md
@@ -159,7 +159,7 @@ Known root causes to date (one row per dist):
 | SQL::Abstract | `No matching candidate found for the parametric role` — advanced past four typename blockers by #4865; now blocked on parametric-role resolution in its `does Constant['…']` / `does Op::Prefix['…']` chains. |
 | PDF::Font::Loader::CSS | `X::Syntax::Perl5Var: Unsupported use of $? variable` — a genuine `$?`-in-regex Perl5-ism (verify against raku before "fixing"). |
 | uniname-words | `Odd number of elements found where hash initializer expected` (load-time) — an `nqp::hash(...)` in a `BEGIN` block; guts-bound, not pursued. |
-| Repository::Precomp::Cleanup | `No such method 'id' for invocant of type 'Compiler'`. |
+| ~~Repository::Precomp::Cleanup~~ | **Cleared post-snapshot**: `my str $compilation-id = Compiler.id;` failed because `Compiler.id` was not callable on the bare `Compiler` type object (only defined for an instance, where it returned an empty string). `Compiler.id` identifies the build and is a type-object method in Rakudo; mutsu now returns a stable per-build id for both forms. Loads. |
 | Test::Scheduler | `Scheduler is not composable, so Test::Scheduler cannot compose it`. |
 | Bits | `An exception occurred while evaluating a CHECK` (load-time CHECK phaser). |
 | ~~RakudoContainerfileBuilder~~ | **Not a mutsu bug** (sweep false positive): the module `is export`s a `MAIN`, and the sweep's `-e 'use …'` harness imports it, so raku auto-runs `MAIN` at mainline end and prints the same `Usage:` block. mutsu matches raku exactly (both exit 2, identical output). Should be excluded from the actionable count. |

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1299,6 +1299,12 @@ impl Interpreter {
                 // Shared with the VM's native class-method fast path.
                 return result;
             }
+            // `Compiler.id` is callable on the bare type object (it identifies the
+            // build, not an instance), matching Rakudo. Other Compiler methods are
+            // attribute accessors that legitimately need an instance.
+            if name == "Compiler" && method == "id" {
+                return Ok(Value::str(Self::compiler_id()));
+            }
             if name == "Supply" && method == "interval" {
                 let seconds = args.first().map_or(1.0, |value| {
                     if let Some(i) = value.as_int() {

--- a/src/runtime/native_methods/system.rs
+++ b/src/runtime/native_methods/system.rs
@@ -227,8 +227,21 @@ impl Interpreter {
 
     // --- Perl ---
 
+    /// A stable identifier for this compiler build. Rakudo's `Compiler.id`
+    /// returns the git SHA of the build; mutsu has no per-build SHA, so use the
+    /// crate version, which is stable across a build and distinct across
+    /// releases — enough for consumers that key precomp directories on it
+    /// (e.g. Repository::Precomp::Cleanup).
+    pub(in crate::runtime) fn compiler_id() -> String {
+        format!("mutsu-{}", env!("CARGO_PKG_VERSION"))
+    }
+
     pub(in crate::runtime) fn native_perl(&self, attributes: &AttrMap, method: &str) -> Value {
         match method {
+            // `Compiler.id` works on the type object (empty attributes) as well as
+            // on an instance, so answer it directly rather than reading the `id`
+            // attribute (which is absent on the bare type object).
+            "id" => Value::str(Self::compiler_id()),
             "compiler" => {
                 let mut compiler_attrs = HashMap::new();
                 compiler_attrs.insert("name".to_string(), Value::str_from("mutsu"));
@@ -259,7 +272,7 @@ impl Interpreter {
                 );
                 compiler_attrs.insert("release".to_string(), Value::str_from("0.1.0"));
                 compiler_attrs.insert("codename".to_string(), Value::str_from("mutsu"));
-                compiler_attrs.insert("id".to_string(), Value::str(String::new()));
+                compiler_attrs.insert("id".to_string(), Value::str(Self::compiler_id()));
                 Value::make_instance(Symbol::intern("Compiler"), compiler_attrs)
             }
             "backend" => Value::str_from("mutsu"),

--- a/t/compiler-id.t
+++ b/t/compiler-id.t
@@ -1,0 +1,21 @@
+use v6;
+use Test;
+
+plan 5;
+
+# `Compiler.id` is callable on the bare type object (it identifies the compiler
+# build, not an instance) and returns a defined Str. Rakudo returns the build's
+# git SHA; mutsu returns a stable per-build id. Regression: mutsu threw
+# "No such method 'id' for invocant of type 'Compiler'" (seen loading the
+# Repository::Precomp::Cleanup dist: `my str $id = Compiler.id;`).
+
+my $id = Compiler.id;
+isa-ok $id, Str, 'Compiler.id returns a Str';
+ok $id.defined, 'Compiler.id is defined';
+ok $id.chars > 0, 'Compiler.id is non-empty';
+
+# It is stable across calls (used as a directory-name key).
+is Compiler.id, $id, 'Compiler.id is stable across calls';
+
+# The compiler instance reachable via $*RAKU reports the same id.
+is $*RAKU.compiler.id, $id, '$*RAKU.compiler.id matches Compiler.id';


### PR DESCRIPTION
## Summary

`Compiler.id` identifies the compiler build (Rakudo returns the build's git SHA) and is callable on the bare `Compiler` **type object**, not only an instance. mutsu:

- threw `No such method 'id' for invocant of type 'Compiler'` for `Compiler.id` (type object), and
- returned an empty string for `$*RAKU.compiler.id` (instance).

This blocked the **Repository::Precomp::Cleanup** dist, whose first line is `my str $compilation-id = Compiler.id;`.

## Fix

Return a stable per-build id (`mutsu-<crate-version>`, e.g. `mutsu-0.12.0`) for both forms:

- answer `id` directly in `native_perl` so the empty type-object attribute map still resolves it, and
- route `Compiler.id` on the type object to it (like the existing `Instant`/`Supply` type-object special cases).

Other `Compiler` methods (`.name`, `.version`, …) are attribute accessors that legitimately need an instance, so they are untouched. Repository::Precomp::Cleanup now loads.

## Test

`t/compiler-id.t` — `Compiler.id` returns a defined, non-empty, stable `Str` on the type object, and matches `$*RAKU.compiler.id`. Verified against `raku` (all 5 subtests pass on both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)