### PR TITLE
fix: allow a class to `does Scheduler` (composable built-in role)

### DIFF
--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -477,6 +477,10 @@ impl Interpreter {
             "Proc::Async",
             "Supply",
             "Supplier",
+            // Scheduler is a composable built-in role in Raku (ParametricRoleGroupHOW);
+            // a class may `does Scheduler` and supply its own `cue` (e.g. the
+            // Test::Scheduler dist: `class Test::Scheduler does Scheduler {...}`).
+            "Scheduler",
             "Setty",
             "Baggy",
             "Mixy",

--- a/t/does-scheduler-role.t
+++ b/t/does-scheduler-role.t
@@ -1,0 +1,21 @@
+use v6;
+use Test;
+
+plan 3;
+
+# `Scheduler` is a composable built-in role in Raku; a class may `does Scheduler`
+# and supply its own scheduling methods. mutsu previously registered Scheduler as
+# a plain class, so `class X does Scheduler {...}` failed with
+# "Scheduler is not composable, so X cannot compose it" (seen loading the
+# Test::Scheduler dist: `class Test::Scheduler does Scheduler {...}`).
+
+class MyScheduler does Scheduler {
+    method cue(&code, :$at, :$in, :$every, :$times = 1, :&stop, :&catch) { Nil }
+    method loads() { 0 }
+    method uncaught_handler is rw { my $h; $h }
+}
+
+my $s = MyScheduler.new;
+ok $s.defined, 'a class doing Scheduler instantiates';
+ok $s ~~ Scheduler, 'the instance smartmatches the Scheduler role';
+ok MyScheduler ~~ Scheduler, 'the type object smartmatches the Scheduler role';


### PR DESCRIPTION
## Summary

`Scheduler` is a composable built-in **role** in Raku (`Scheduler.HOW` is `ParametricRoleGroupHOW`): a class may `does Scheduler` and supply its own scheduling methods. mutsu registered `Scheduler` as a plain class and left it out of the built-in composable-types list, so:

```raku
class Test::Scheduler does Scheduler { ... }
```

failed with `Scheduler is not composable, so Test::Scheduler cannot compose it`. This blocked the **Test::Scheduler** dist.

## Fix

Add `Scheduler` to the `register_class` built-in-types list (a local `const` used only by the `does`-composability check). `Scheduler` is not in the non-composable denylist, so `does Scheduler` now composes and the class is recognized as a `Scheduler` (`X ~~ Scheduler` is true). Test::Scheduler loads.

Note: raku additionally *requires* a `does Scheduler` class to implement `cue`/`loads`/`uncaught_handler`; mutsu does not yet enforce built-in-role required methods (it composes an empty role def, as it already does for `Positional`/`Numeric`/…). That leniency is pre-existing and orthogonal — the real dist supplies all the methods anyway.

## Test

`t/does-scheduler-role.t` — a class doing `Scheduler` (with `cue`/`loads`/`uncaught_handler`, so `raku` accepts it too) instantiates and smartmatches `Scheduler` on both the instance and the type object. Verified against `raku` (all 3 subtests pass on both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)