### PR TITLE
fix: accept `$?` as an anonymous optional invocant (`method m($?: |)`)

### DIFF
--- a/src/parser/stmt/sub_param/param_inner.rs
+++ b/src/parser/stmt/sub_param/param_inner.rs
@@ -886,7 +886,13 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
                 || after_q.starts_with(')')
                 || after_q.starts_with(' ')
                 || after_q.starts_with('\t')
-                || after_q.starts_with('\n'))
+                || after_q.starts_with('\n')
+                // An anonymous optional invocant: `method m($?: |) { ... }` — the
+                // `:` (not `::`, which would be a package separator) is the
+                // invocant marker, left for the outer param-list loop. `;` is the
+                // multi-invocant separator.
+                || (after_q.starts_with(':') && !after_q.starts_with("::"))
+                || after_q.starts_with(';'))
         {
             let mut p = super::helpers::make_param(anon_name.to_string());
             p.named = named;

--- a/t/anon-optional-invocant.t
+++ b/t/anon-optional-invocant.t
@@ -1,0 +1,27 @@
+use v6;
+use Test;
+
+plan 5;
+
+# `$?` (and `@?` / `%?`) is a valid *anonymous optional parameter*, including in
+# invocant position: `method m($?: |c) { ... }` names no invocant but still binds
+# self. mutsu recognized `$?` as anonymous only before `,` / `)` / whitespace, so
+# `$?` followed by the invocant `:` fell through to scalar-var parsing and threw
+# "X::Syntax::Perl5Var: Unsupported use of $? variable". Seen in the
+# PDF::Font::Loader::CSS dist: `multi method find-font($?: |) { nextsame }`.
+
+class C {
+    method tag($?: |c) { "tag:" ~ c.list.join(",") }
+}
+
+is C.tag(1, 2, 3), 'tag:1,2,3', 'anonymous-invocant method binds self and captures args';
+is C.new.tag("a"), 'tag:a',     'anonymous-invocant method works on an instance too';
+
+# The plain (non-invocant) anonymous optional param still works.
+sub f($?) { "ok" }
+is f(),  'ok', 'anonymous optional param accepts zero args';
+is f(1), 'ok', 'anonymous optional param accepts one arg';
+
+# A bare `$?` term is still the unsupported Perl5 variable.
+throws-like { EVAL 'my $? = 5' }, X::Syntax::Perl5Var,
+    'bare $? term is still rejected as a Perl5 variable';


### PR DESCRIPTION
## Summary

`$?` (and `@?` / `%?`) is a valid **anonymous optional parameter**. In invocant position — `method m($?: |) { ... }` — it names no invocant but still binds `self`. mutsu recognized the anonymous optional sigil only when followed by `,`, `)`, or whitespace, so `$?` followed by the invocant `:` fell through to scalar-variable parsing and raised:

```
X::Syntax::Perl5Var: Unsupported use of $? variable
```

This blocked the **PDF::Font::Loader::CSS** dist:

```raku
multi method find-font($?: |) { nextsame; }
```

## Fix

In the anonymous-optional-sigil param branch, also accept a following invocant `:` (but **not** `::`, which is a package separator) and the multi-invocant `;`. A bare `$?` term is still rejected as the Perl5 child-error variable, and `$?FILE` / `$?LINE` compile-time vars still parse.

PDF::Font::Loader::CSS now advances past this parse blocker to `missing_dep` (PDF::Font::Loader), matching `raku` under `-I lib`.

## Test

`t/anon-optional-invocant.t` — an anonymous-invocant method (`$?: |c`) binds self and captures args on both the type object and an instance; the plain anonymous optional param `$?` still works; a bare `$?` term still throws `X::Syntax::Perl5Var`. Verified against `raku` (all subtests pass on both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)