### PR TITLE
fix: named enum expression value is a Map, not Any

### DIFF
--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -461,8 +461,10 @@ impl Compiler {
                 let name_idx = self.code.add_constant(Value::str(name.resolve()));
                 self.code.emit(OpCode::GetBareWord(name_idx));
             }
-            Stmt::EnumDecl { name, .. } if name.resolve().is_empty() => {
-                // Anonymous enum: RegisterEnum pushes the Map result
+            Stmt::EnumDecl { .. } => {
+                // Both the anonymous (`enum <a b c>`) and named (`enum Foo <a b c>`)
+                // forms yield a Map in expression position; RegisterEnum pushes that
+                // Map as the declaration's value.
                 self.compile_stmt(stmt);
             }
             Stmt::Whenever { supply, .. } => {

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -1573,18 +1573,18 @@ impl Interpreter {
             }
         }
 
-        // The value of an anonymous `enum <a b c>` expression is a Map in raku
-        // (`.^name`/`.WHAT` is `Map`, `.raku` is `Map.new((...))`), not a plain
-        // Hash. Embed the `Map` declared-type via `to_map` so introspection and
-        // rendering match — the same tag the `%`-constant / `.Map` paths use.
-        if is_anonymous {
-            let mut map = HashMap::new();
-            for (key, val) in &enum_variants {
-                map.insert(key.clone(), val.to_value());
-            }
-            crate::builtins::map_hash_coerce::to_map(Value::hash(map))
-        } else {
-            Ok(Value::NIL)
+        // The value of an `enum <a b c>` / `enum Foo <a b c>` expression is a Map in
+        // raku (`.^name`/`.WHAT` is `Map`, `.raku` is `Map.new((...))`), not a plain
+        // Hash — for BOTH the anonymous and named forms. Embed the `Map` declared-type
+        // via `to_map` so introspection and rendering match — the same tag the
+        // `%`-constant / `.Map` paths use. The named form also installs the type and
+        // its values above; this return value is only consumed when the declaration is
+        // used in expression position (`my $e = enum Foo <a b c>`) — a bare statement
+        // pushes it as a harmless sink (see `exec_register_enum_op`).
+        let mut map = HashMap::new();
+        for (key, val) in &enum_variants {
+            map.insert(key.clone(), val.to_value());
         }
+        crate::builtins::map_hash_coerce::to_map(Value::hash(map))
     }
 }

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -25,10 +25,12 @@ impl Interpreter {
             if !name.resolve().is_empty() {
                 self.store_language_revision_from_version(&name.resolve(), language_version);
             }
-            // For anonymous enums, push the Map result onto the stack
-            if name.resolve().is_empty() {
-                self.stack.push(result);
-            }
+            // Push the enum's Map value. In expression position — `my $e = enum Foo
+            // <a b c>` or a bare `enum <a b c>` — this Map is the declaration's value;
+            // in statement position it is a harmless sink absorbed at the frame's stack
+            // base (the anonymous form has always pushed unconditionally this way, so
+            // the named form is symmetric).
+            self.stack.push(result);
             Ok(())
         } else {
             Err(RuntimeError::new("RegisterEnum expects EnumDecl"))

--- a/t/named-enum-value-map.t
+++ b/t/named-enum-value-map.t
@@ -1,0 +1,53 @@
+use v6;
+use Test;
+
+# The value of a NAMED `enum Foo <...>` expression is a Map in raku, just like
+# the anonymous form: `.^name`/`.WHAT` report `Map` and `.raku` renders as
+# `$(Map.new((...)))`. Previously mutsu returned Any for the named form (the
+# expression-position result was never pushed for a named enum). See
+# t/anon-enum-value-map.t for the anonymous companion.
+
+plan 13;
+
+# Word-list named enum used in expression position.
+{
+    my $e = enum Foo <a b c>;
+    is $e.^name, 'Map', 'named enum value .^name is Map';
+    is $e.WHAT.^name, 'Map', 'named enum value .WHAT is the Map type';
+    is $e.raku, '$(Map.new((:a(0),:b(1),:c(2))))', 'named enum value .raku matches raku';
+}
+
+# The named type and its members still install correctly.
+{
+    my $e = enum Bar <x y z>;
+    is Bar.^name, 'Bar', 'named enum type name installed';
+    is x.^name, 'Bar', 'enum member reports the enum type as its name';
+    is x.value, 0, 'named enum member x == 0';
+    is z.value, 2, 'named enum member z == 2';
+}
+
+# Parenthesised named enum with explicit values.
+{
+    my $e = enum Nums (one => 1, two => 2);
+    is $e.^name, 'Map', 'paren-form named enum value is a Map';
+    is $e.raku, '$(Map.new((:one(1),:two(2))))', 'paren-form named enum value .raku';
+    is one.value, 1, 'paren-form explicit value preserved';
+    is Nums.^name, 'Nums', 'paren-form named type installed';
+}
+
+# A named enum as a bare statement must not corrupt the stack (the pushed Map
+# is a harmless sink).
+{
+    sub f() { enum Colours <red green blue>; 42 }
+    is f(), 42, 'named enum as a non-tail statement does not corrupt the return value';
+}
+
+# A named enum declared as a bare file-scope statement still installs its members.
+{
+    enum Planets <mercury venus earth>;
+    is earth.value, 2, 'the statement-form named enum still installed its members';
+}
+
+# Note: `my $e = do { enum Foo <...> }` (an EXPLICIT do-block wrapper) still yields
+# Any, not the Map — a separate pre-existing gap in the scope-isolating DoBlock
+# value path that affects the anonymous form too, out of scope for this fix.


### PR DESCRIPTION
`my $e = enum Foo <a b c>` gave `$e` = Any in mutsu; raku yields the same itemized Map as the anonymous form (`$(Map.new((:a(0),:b(1),:c(2))))`, `.^name` == "Map"). The named `enum` type and its member values were already installed correctly — only the expression-position *value* of the declaration was lost.

**Root cause:** `register_enum_decl` returned `Value::NIL` for the named form and `exec_register_enum_op` pushed the Map result only for the anonymous form, so a named enum used in expression position (`DoStmt(EnumDecl)`) produced no value.

**Fix** (mirrors #4955's anonymous-form fix):
- `register_enum_decl` builds and returns the `to_map`-tagged Map for the named form too (the same itemized Map the anonymous form already produced).
- `exec_register_enum_op` pushes that Map unconditionally; in statement position it is a harmless sink absorbed at the frame's stack base — exactly as the anonymous form has always pushed unconditionally (verified: sub return value, `do {}` tail, comma-list element all stay correct).
- `compile_do_block_result_expr` handles the named `EnumDecl` arm so the pushed Map becomes the declaration's expression value.

From the `typesystem.rakudoc` doc-diff scan (finding [15]). Pin `t/named-enum-value-map.t`.

**Out of scope** (pre-existing, affects the anonymous form too): a named/anonymous enum wrapped in an EXPLICIT `do { enum Foo <...> }` block still yields Any — a separate gap in the scope-isolating DoBlock value path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)