### PR TITLE
fix: recognize an enum type as a valid role-method param constraint

### DIFF
--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -626,6 +626,13 @@ impl Interpreter {
         if self.has_role(base) {
             return true;
         }
+        // An enum type name is a valid parameter/attribute constraint (and a valid
+        // coercion target, `Join::Type(Str)`). `is_resolvable_type` is called with
+        // the coercion already stripped to the base, so a qualified enum used as a
+        // coercion target in a role-method param resolves here.
+        if self.has_enum_type(base) {
+            return true;
+        }
         // Check if it starts with uppercase (heuristic for type names)
         // This handles cases like user-defined enum types that may not be registered as classes
         false

--- a/t/role-enum-coercion-param-type.t
+++ b/t/role-enum-coercion-param-type.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+plan 4;
+
+# An enum type name is a valid parameter constraint (and coercion target) in a
+# role method — `method m(EnumType $x)` and `method m(EnumType(Str) $x)`. The
+# role method param-type validation only recognized classes/roles/built-ins, so a
+# (qualified) enum used in a role method param was rejected as
+# "Invalid typename 'EnumType(Str)' in parameter declaration". Seen in the
+# SQL::Abstract dist (`Join::Type(Str) :$type` inside a role).
+
+enum J::Type (:Inner<inner>, :Left<left>);
+
+role Src {
+    method plain(J::Type $t) { $t.key }
+    method coerced(J::Type(Str) $t) { $t.key }
+}
+class C does Src {}
+
+pass 'a role with an enum-typed / enum-coercion method param compiles';
+is C.new.plain(J::Type::Inner), 'Inner', 'plain enum param binds an enum value';
+
+# An unqualified enum in a role param works too.
+enum Flag <On Off>;
+role R2 { method f(Flag $x) { $x.Int } }
+class D does R2 {}
+is D.new.f(On), 0, 'unqualified enum param in a role binds';
+
+# The class-method form (non-role) still works, unchanged.
+class E { method g(J::Type $t) { $t.key } }
+is E.g(J::Type::Left), 'Left', 'enum param in a plain class method still works';


### PR DESCRIPTION
## Summary

`is_resolvable_type` recognized built-in types, user classes, and roles, but **not enum types**. So a (qualified) enum used as a parameter constraint — or a coercion target — in a **role** method was rejected by the role param-type validation:

```raku
enum Join::Type (:Inner<inner>, :Left<left>);
role Source {
    method j(Join::Type(Str) :$type) { ... }   # Invalid typename 'Join::Type(Str)'
}
```

This blocked the **SQL::Abstract** dist (`Join::Type(Str) :$type` inside a role). The class-method form already worked; only the role validation path was stricter.

## Fix

Accept an enum type name in `is_resolvable_type` via the existing `has_enum_type`. The coercion suffix (`(Str)`) and smiley are already stripped to the base before the check, so a qualified enum coercion target resolves.

SQL::Abstract advances past this blocker (it has further deep blockers — typed-array coercions, `COERCE` multis — so it does not yet load; tracked separately).

## Test

`t/role-enum-coercion-param-type.t` — a role with an enum-typed param and an `EnumType(Str)` coercion param compiles and binds; unqualified enum params and the plain class-method form still work. Verified against `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)