### PR TITLE
fix: skip quoted strings when matching a `{...}` interpolation's close brace

### DIFF
--- a/src/parser/primary/string/quoted.rs
+++ b/src/parser/primary/string/quoted.rs
@@ -233,11 +233,29 @@ pub(crate) fn double_quoted_string(input: &str) -> PResult<'_, Expr> {
             if !current.is_empty() {
                 parts.push(Expr::Literal(Value::str(std::mem::take(&mut current))));
             }
-            // Find matching close brace (tracking nesting)
+            // Find matching close brace (tracking nesting). Braces inside a
+            // quoted string within the block must NOT count — e.g.
+            // `"{ $x.subst(/'{' .+? $/, '') }"` carries a literal `{` inside a
+            // single-quoted string (here nested in a regex), and `"{ '}' }"`
+            // a literal `}`. Skip over `'...'` and `"..."` (honoring `\`
+            // escapes) so their braces don't unbalance the scan.
             let mut depth = 0;
             let mut end = 0;
+            let mut in_quote: Option<char> = None;
+            let mut escaped = false;
             for (i, c) in rest.char_indices() {
+                if let Some(q) = in_quote {
+                    if escaped {
+                        escaped = false;
+                    } else if c == '\\' {
+                        escaped = true;
+                    } else if c == q {
+                        in_quote = None;
+                    }
+                    continue;
+                }
                 match c {
+                    '\'' | '"' => in_quote = Some(c),
                     '{' => depth += 1,
                     '}' => {
                         depth -= 1;

--- a/t/interp-brace-in-quote.t
+++ b/t/interp-brace-in-quote.t
@@ -1,0 +1,23 @@
+use v6;
+use Test;
+
+plan 6;
+
+# A `{ ... }` block interpolation scans for its matching close brace. Braces that
+# appear inside a quoted string *within* the block must not count, or the scan
+# unbalances and the string looks unterminated ("couldn't find final '\"'") or
+# closes early. Regression: mutsu counted every `{`/`}` literally.
+
+is "a{ '{' }b", 'a{b', 'literal { inside a single-quoted string in interpolation';
+is "a{ '}' ~ 'x' }b", 'a}xb', 'literal } inside a single-quoted string in interpolation';
+is "[{ "}" }]", '[}]', 'literal } inside a nested double-quoted string';
+is "n={ '{}{}' .chars }", 'n=4', 'multiple literal braces in a quoted string';
+
+# The real-world trigger: a regex carrying a quoted brace inside interpolation
+# (from Data::Dump's `$obj.raku.subst(/'{' .+? $/, '')`).
+my $s = 'abc{def';
+is "[{ $s.subst(/'{' .+? $/, '') }]", '[abc]', 'quoted brace inside a regex inside interpolation';
+
+# A genuine nested code block (balanced braces) still works.
+my $n = 3;
+is "v={ $n > 0 ?? { "pos" }() !! "neg" }", 'v=pos', 'nested balanced code block still interpolates';


### PR DESCRIPTION
## Summary

The double-quote **block interpolation** scanner (`"...{ expr }..."`) found its matching close brace by counting `{`/`}` **literally**, so a brace inside a quoted string within the block unbalanced the scan:

```raku
say "a{ '{' }b";        # mutsu: "couldn't find final '"'"  (raku: a{b)
say "a{ '}' ~ 'x' }b";  # mutsu: closes early at the quoted } (raku: a}xb)
```

This blocked the **Data::Dump** dist, whose

```raku
$out ~= "{$obj.raku.subst(/'{' .+? $/, '')}\n";
```

carries a `'{'` inside a regex inside a `"{ ... }"` interpolation.

## Fix

Track single/double-quote state (honoring `\` escapes) in the brace scan so braces inside `'...'` / `"..."` do not count. Genuine nested balanced code blocks still work. Data::Dump now loads.

## Test

`t/interp-brace-in-quote.t` — literal `{`/`}` inside single- and double-quoted strings within interpolation, multiple braces, the regex-with-quoted-brace case, and a nested balanced code block. All verified against `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)