### PR TITLE
fix: accept an inline statement modifier in an array composer

### DIFF
--- a/src/parser/primary/container/array.rs
+++ b/src/parser/primary/container/array.rs
@@ -20,7 +20,7 @@ pub(crate) fn array_literal(input: &str) -> PResult<'_, Expr> {
     // sections move into `sections`.
     let mut sections: Vec<Vec<Expr>> = Vec::new();
     let mut saw_semicolon = false;
-    let (mut rest, first) = expression(input)?;
+    let (mut rest, first) = parse_array_element(input)?;
     items.push(first);
     loop {
         let (r, _) = ws(rest)?;
@@ -35,7 +35,7 @@ pub(crate) fn array_literal(input: &str) -> PResult<'_, Expr> {
             // After a separator we need another element or a closing `]`.
             // Hitting unparseable/end-of-input here means the array composer
             // was never closed (e.g. `[1,`): X::Comp::FailGoal.
-            let (r, next) = expression(r).map_err(|_| array_fail_goal(r))?;
+            let (r, next) = parse_array_element(r).map_err(|_| array_fail_goal(r))?;
             items.push(next);
             rest = r;
         } else if r.starts_with(';') && !r.starts_with(";;") {
@@ -50,7 +50,7 @@ pub(crate) fn array_literal(input: &str) -> PResult<'_, Expr> {
                     finalize_array_sections(sections, items, saw_semicolon, false),
                 ));
             }
-            let (r, next) = expression(r).map_err(|_| array_fail_goal(r))?;
+            let (r, next) = parse_array_element(r).map_err(|_| array_fail_goal(r))?;
             items.push(next);
             rest = r;
         } else {
@@ -76,6 +76,33 @@ pub(crate) fn array_literal(input: &str) -> PResult<'_, Expr> {
             ));
         }
     }
+}
+
+/// Parse one array-composer element: an expression optionally followed by inline
+/// statement modifiers (`[ EXPR for LIST ]`, `[ EXPR if COND ]`, and `;`-sectioned
+/// forms like `[ 'a' if $x; |@b if $y ]`). This is the composer analogue of the
+/// inline modifier a parenthesized list already accepts; without it the trailing
+/// `for`/`if` reads as a second term ("Two terms in a row" / "couldn't find final ']'").
+fn parse_array_element(input: &str) -> PResult<'_, Expr> {
+    let (rest, expr) = expression(input)?;
+    let (after_ws, _) = ws(rest)?;
+    if let Some(result) =
+        crate::parser::primary::container::meta_ops::try_inline_modifier(after_ws, expr.clone())
+    {
+        let (r, modified) = result?;
+        // A statement modifier consumes a trailing `;` (statement terminator) and
+        // any following whitespace. Inside an array composer that `;` is a
+        // *section separator* the caller's loop must still see
+        // (`[ 'a' if $x; |@b if $y ]`), so re-expose it from where it was eaten.
+        let consumed = &after_ws[..after_ws.len() - r.len()];
+        if let Some(semi_pos) = consumed.rfind(';')
+            && consumed[semi_pos + 1..].trim().is_empty()
+        {
+            return Ok((&after_ws[semi_pos..], modified));
+        }
+        return Ok((r, modified));
+    }
+    Ok((rest, expr))
 }
 
 /// Combine semicolon-separated sections of an array composer. With no semicolon

--- a/t/array-composer-statement-modifier.t
+++ b/t/array-composer-statement-modifier.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+plan 10;
+
+# An array composer accepts an inline statement modifier on its element(s):
+# `[ EXPR for LIST ]`, `[ EXPR if COND ]`, and `;`-sectioned forms where each
+# section carries its own modifier (`[ 'a' if $x; |@b if $y ]`). mutsu previously
+# parsed the element and read the trailing `for`/`if` as a second term
+# ("Two terms in a row" / "couldn't find final ']'"). Seen in the DataStar dist.
+
+is-deeply [ 5 for 1, 2 ],       [5, 5],       '[ EXPR for LIST ]';
+is-deeply [ $_ * 2 for 1..3 ],  [2, 4, 6],    '[ EXPR(topic) for LIST ]';
+is-deeply [ 5 if 1 ],           [5],          '[ EXPR if TRUE ]';
+is-deeply [ 5 if 0 ],           [],           '[ EXPR if FALSE ] is empty';
+
+# Semicolon-sectioned composer where sections carry modifiers.
+my $x = True;
+my $y = False;
+is-deeply [ 1 if $x; 2 if $x ], [1, 2],       'two sections, both modifiers true';
+is-deeply [ 1 if $x; 2 if $y ], [1],          'second section modifier false drops it';
+is-deeply [ 1 if $y; 2 if $x ], [2],          'first section modifier false drops it';
+
+# Slip with a modifier in a section (the DataStar pattern).
+my @b = 3, 4;
+is-deeply [ 'a' if $x; |@b if $x ], ['a', 3, 4], 'slip section with a modifier';
+
+# Plain composers are unchanged.
+is-deeply [1, 2, 3],  [1, 2, 3], 'plain comma list still works';
+is-deeply [1, 2; 3, 4], [(1, 2), (3, 4)], 'plain semicolon sections still work';


### PR DESCRIPTION
## Summary

`[ EXPR for LIST ]`, `[ EXPR if COND ]`, and `;`-sectioned forms where each section carries its own modifier (`[ 'a' if \$x; |@b if \$y ]`) are valid array composers — the composer analogue of `( EXPR for LIST )`, which already worked. mutsu's `array_literal` parsed the element with `expression()` and then read the trailing `for`/`if` as a **second term**, failing with `Two terms in a row` / `couldn't find final ']'`. Even `[ 5 for 1,2 ]` failed.

This blocked the **DataStar** dist:

```raku
my @attrs = [
    'data-effect="el.remove()"' if $auto-remove;
    |$attributes if $attributes
];
```

## Fix

Parse each composer element through a helper that applies inline statement modifiers (via the same `try_inline_modifier` the parenthesized-list parser uses). A statement modifier consumes its terminating `;`, but inside a composer that `;` is a **section separator** the sectioning loop must still see, so it is re-exposed.

DataStar advances past this parse blocker to `missing_dep` (JSON::Fast::Hyper), matching raku.

## Test

`t/array-composer-statement-modifier.t` — `for`/`if` modifiers, topic use, false-condition drop, multi-section `;` forms (each with a modifier), slip-with-modifier, and unchanged plain/`;`-sectioned composers. All 10 verified against `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)