### PR TITLE
fix: whenever valid anywhere lexically inside supply/react; add `supply whenever`

### DIFF
--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1388,6 +1388,15 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
         return Ok((r2, make_call_expr(name, input, vec![expr])));
     }
 
+    // `supply whenever EXPR { ... }` shorthand for `supply { whenever EXPR { ... } }`
+    // (mirrors `react whenever ...`). Lower through the same emitter wrapper so the
+    // whenever is lexically inside a supply scope.
+    if name == "supply"
+        && let Ok((r2, whenever)) = crate::parser::stmt::control::whenever_stmt(r)
+    {
+        return Ok((r2, supply_method_call(vec![whenever])));
+    }
+
     // `supply { ... }` expression: lower to `Supply.on-demand(-> $emitter { ... })`.
     if name == "supply"
         && r.starts_with('{')

--- a/src/parser/primary/ident/supply.rs
+++ b/src/parser/primary/ident/supply.rs
@@ -60,6 +60,15 @@ fn is_close_registration(stmt: &Stmt) -> bool {
 }
 
 fn rewrite_supply_stmt(stmt: Stmt, emitter_name: &str) -> Stmt {
+    // TODO: compile to bytecode / capture. `emit`/`done` inside a nested `my sub`
+    // defined within the supply body (`supply { my sub relay($s) { whenever $s {
+    // emit … } }; relay(…) }`, e.g. IO::Notification::Recursive) should forward to
+    // this supply's emitter, but rewriting the sub body to `$emitter.emit(...)`
+    // surfaces a closure-capture gap (the nested sub does not capture the on-demand
+    // Lambda's emitter parameter), so it is left unrewritten for now — such code
+    // parses (the whenever-scope check accepts it) but its nested-sub `emit` is a
+    // runtime no-op. Direct `supply { whenever … { emit } }` and the `supply
+    // whenever …` shorthand work.
     match stmt {
         Stmt::Expr(expr) => {
             if let Expr::Call { name, args } = &expr

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -197,7 +197,8 @@ pub(super) use given_when::{default_stmt, given_stmt, when_stmt};
 pub(super) use labeled_loop::labeled_loop_stmt;
 pub(super) use loop_repeat::{loop_stmt, repeat_stmt};
 pub(super) use pointy_param::parse_pointy_param;
-pub(super) use react::{react_stmt, whenever_stmt};
+pub(super) use react::react_stmt;
+pub(crate) use react::whenever_stmt;
 pub(super) use while_until::{until_stmt, while_stmt};
 pub(super) use with_stmt::with_stmt;
 

--- a/src/parser/whenever_scope.rs
+++ b/src/parser/whenever_scope.rs
@@ -4,28 +4,27 @@
 //! Rakudo raises a compile-time `X::Comp::WheneverOutOfScope`
 //! ("Cannot have a 'whenever' block outside the scope of a 'supply' or 'react'
 //! block") when a `whenever` is not lexically enclosed by a `react` block or a
-//! `supply` block. Crossing *any* routine boundary (a `sub`/`method`/pointy or
-//! anonymous closure) breaks that enclosure — only inline blocks (`for`, `if`,
-//! bare `{ }`, a `whenever` body, etc.) preserve it.
+//! `supply` block. The check is purely *lexical*: a `whenever` is valid as long
+//! as some `supply`/`react` block encloses it in the source, at any nesting
+//! depth — routine boundaries do NOT break the enclosure. So
+//! `supply { my sub g { whenever … } }` is valid (a `sub`/`method`/pointy/class
+//! nested inside a supply keeps the enclosure), while a `whenever` in a
+//! top-level `sub`/pointy with no supply/react ancestor is rejected.
 //!
 //! This walker mirrors that rule structurally on the AST. It tracks a single
-//! boolean `in_scope` ("are we lexically inside a react/supply block, without
-//! having crossed a routine boundary?"):
+//! boolean `in_scope` ("is there a react/supply block lexically enclosing here?"):
 //!
 //! * `react { ... }` sets it true for the body.
 //! * The emitter closure that `supply { ... }` lowers to (a `Lambda` whose
 //!   parameter name starts with `__mutsu_supply_emitter_`) sets it true.
-//! * A genuine routine boundary (named `sub`/`method` decl, `sub { }`, pointy
-//!   or parameterised closure, and any non-emitter `Lambda`) resets it to false.
-//! * Every other construct preserves it.
+//! * Every other construct — including routine/closure boundaries — preserves it,
+//!   so once inside a supply/react the enclosure holds through nested subs.
 //!
 //! When a `whenever` is reached with `in_scope == false`, we record its line.
 //!
 //! The walker is intentionally conservative: an unhandled container is simply
 //! not recursed into, which can only *miss* an out-of-scope `whenever` (a false
-//! negative). A legitimate `whenever` inside a `react`/`supply` block is never
-//! reachable behind a routine-boundary reset, so this can never produce a false
-//! positive that would reject valid concurrency code.
+//! negative), never produce a false positive that would reject valid code.
 
 use crate::ast::{Expr, Stmt};
 
@@ -63,13 +62,16 @@ fn walk_stmt(stmt: &Stmt, in_scope: bool, line: &mut i64, found: &mut Option<i64
             walk_stmts(body, true, line, found);
         }
 
-        // Routine / package boundaries: reset scope for the body.
+        // Routine / package boundaries do NOT break the enclosure: Rakudo's
+        // check is purely lexical, so a `whenever` inside a `sub`/`method`/class
+        // that is itself lexically nested in a `supply`/`react` block is valid
+        // (`supply { my sub g { whenever … } }`). Preserve the current scope.
         Stmt::SubDecl { body, .. }
         | Stmt::MethodDecl { body, .. }
         | Stmt::ClassDecl { body, .. }
         | Stmt::RoleDecl { body, .. }
         | Stmt::Package { body, .. } => {
-            walk_stmts(body, false, line, found);
+            walk_stmts(body, in_scope, line, found);
         }
 
         // Inline blocks / control flow: preserve scope.
@@ -116,17 +118,21 @@ fn walk_stmt(stmt: &Stmt, in_scope: bool, line: &mut i64, found: &mut Option<i64
 fn walk_expr(expr: &Expr, in_scope: bool, line: &mut i64, found: &mut Option<i64>) {
     match expr {
         // The `supply { }` sugar lowers to `Supply.on-demand(-> $emitter { ... })`
-        // where the emitter closure name marks a genuine supply scope.
+        // where the emitter closure name marks a genuine supply scope. A normal
+        // pointy/closure `Lambda` (`-> $x { }`) is a lexical boundary that does
+        // NOT break an existing supply/react enclosure, so preserve `in_scope`.
         Expr::Lambda { param, body, .. } => {
-            let opens_scope = param.starts_with(SUPPLY_EMITTER_PREFIX);
+            let opens_scope = in_scope || param.starts_with(SUPPLY_EMITTER_PREFIX);
             walk_stmts(body, opens_scope, line, found);
         }
-        // `sub { }` (is_block == false) is a routine boundary; a bare block
-        // `{ }` (is_block == true) is inline and preserves scope.
-        Expr::AnonSub { body, is_block, .. } => {
-            walk_stmts(body, in_scope && *is_block, line, found);
+        // A closure boundary is also purely lexical: a `whenever` inside an
+        // anonymous `sub { }` or a pointy `-> { }` nested in a `supply`/`react`
+        // block is valid, so preserve the current scope (a top-level closure
+        // still has `in_scope == false` and its `whenever` is still rejected).
+        Expr::AnonSub { body, .. } => {
+            walk_stmts(body, in_scope, line, found);
         }
-        Expr::AnonSubParams { body, .. } => walk_stmts(body, false, line, found),
+        Expr::AnonSubParams { body, .. } => walk_stmts(body, in_scope, line, found),
 
         // Inline block-valued expressions preserve scope.
         Expr::Block(body) | Expr::Gather(body) => walk_stmts(body, in_scope, line, found),

--- a/t/whenever-in-nested-routine.t
+++ b/t/whenever-in-nested-routine.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+plan 7;
+
+# Rakudo's `whenever`-scope check is purely lexical: a `whenever` is valid as
+# long as some `supply`/`react` block encloses it in the source, at ANY nesting
+# depth — routine/closure boundaries do NOT break the enclosure. mutsu reset the
+# scope at every sub/method/pointy boundary, wrongly rejecting valid code like
+# `supply { my sub g { whenever … } }` (seen in IO::Notification::Recursive).
+# It also lacked the `supply whenever …` statement shorthand (seen in AI::Gator).
+
+# --- Parse-acceptance: these must compile without X::Comp::WheneverOutOfScope. ---
+lives-ok { EVAL 'supply { my sub relay($s) { whenever $s -> $v { emit $v } }; relay(Supply.interval(1)); }' },
+    'whenever in a sub nested in a supply compiles';
+lives-ok { EVAL 'supply { my &f = -> $s { whenever $s -> $v { emit $v } }; f(Supply.interval(1)); }' },
+    'whenever in a pointy nested in a supply compiles';
+lives-ok { EVAL 'supply whenever Supply.interval(1) -> $v { emit $v }' },
+    'supply whenever shorthand compiles';
+
+# --- These must still be rejected (no supply/react ancestor). ---
+throws-like 'sub g($x) { whenever $x -> $e { } }; g(Supply.interval(1))',
+    X::Comp::WheneverOutOfScope,
+    'whenever in a top-level sub is rejected';
+throws-like 'my &f = -> $x { whenever $x -> $e { } }',
+    X::Comp::WheneverOutOfScope,
+    'whenever in a top-level pointy is rejected';
+
+# --- Runtime: the working forms emit correctly. ---
+my @a;
+my $s = supply whenever Supply.from-list(10, 20) -> $v { emit $v + 1 }
+$s.tap({ @a.push($_) });
+is-deeply @a, [11, 21], 'supply whenever shorthand emits';
+
+my @b;
+react whenever Supply.from-list(5, 6) -> $v { @b.push($v); }
+is-deeply @b, [5, 6], 'react whenever shorthand still works';


### PR DESCRIPTION
## Summary

Two related `whenever`-scope fixes surfaced by real dists.

### 1. Lexical `whenever` enclosure across routine boundaries

Rakudo's `whenever`-scope check is purely **lexical**: a `whenever` is valid as long as some `supply`/`react` block encloses it in the source at **any** nesting depth — routine/closure boundaries do NOT break the enclosure. mutsu's post-parse walker reset the scope at every `sub`/`method`/`class`/pointy/closure boundary, so it wrongly rejected:

```raku
supply {
    my sub relay($src) { whenever $src -> $v { emit $v } }   # was: WheneverOutOfScope
    relay($some-supply);
}
```

(seen in **IO::Notification::Recursive**). The walker now preserves the enclosing scope across those boundaries; a top-level `whenever` with no supply/react ancestor is still rejected.

### 2. `supply whenever …` shorthand

Added the `supply whenever EXPR { … }` statement shorthand (the analogue of `react whenever …`), lowering through the same emitter wrapper as `supply { whenever … }` (seen in **AI::Gator**). `whenever_stmt` is now `pub(crate)`.

Both dists advance from a parse error to `missing_dep`, matching raku.

## Known limitation

`emit` inside a nested `my sub` within a supply body is currently a runtime no-op — rewriting it to the emitter surfaces a closure-capture gap (a `TODO` is left in `supply.rs`). Such code **parses**; direct `supply { whenever { emit } }` and `supply whenever …` emit correctly.

## Test

`t/whenever-in-nested-routine.t` — parse-acceptance for whenever in a nested sub/pointy inside supply and the `supply whenever` shorthand; still-rejected top-level cases; and runtime emit for the working `supply whenever` / `react whenever` forms. Verified against `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)