### PR TITLE
fix: parse ASCII `<<...>>` postcircumfix subscript (interpolating word-quote)

### DIFF
--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -496,6 +496,31 @@ fn postfix_expr_inner(input: &str, allow_ws_dot: bool) -> PResult<'_, Expr> {
     postfix_expr_loop(rest, expr, allow_ws_dot)
 }
 
+/// Build the index expression for an interpolating angle subscript (`«...»` / `<<...>>`).
+/// Each whitespace-separated word is interpolated: a bare `$name` reads that variable,
+/// anything else is a literal string key. A single word yields a scalar key; multiple
+/// words yield a slice (matching Rakudo's `%h<<$a b>>` semantics).
+fn angle_words_index_expr(content: &str) -> Expr {
+    fn word_expr(word: &str) -> Expr {
+        if let Some(name) = word.strip_prefix('$')
+            && !name.is_empty()
+            && name
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+        {
+            Expr::Var(name.to_string())
+        } else {
+            Expr::Literal(Value::str(word.to_string()))
+        }
+    }
+    let words = split_angle_words(content);
+    if words.len() == 1 {
+        word_expr(words[0])
+    } else {
+        Expr::ArrayLiteral(words.iter().map(|w| word_expr(w)).collect())
+    }
+}
+
 fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PResult<'_, Expr> {
     loop {
         // Allow whitespace before dotty postfix call in expression context:
@@ -1490,19 +1515,28 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
             if let Some(end) = r.find('\u{00BB}') {
                 let content = &r[..end];
                 let r = &r[end + '\u{00BB}'.len_utf8()..];
-                let keys = split_angle_words(content);
-                let index_expr = if keys.len() == 1 {
-                    Expr::Literal(Value::str(keys[0].to_string()))
-                } else {
-                    Expr::ArrayLiteral(
-                        keys.into_iter()
-                            .map(|k| Expr::Literal(Value::str(k.to_string())))
-                            .collect(),
-                    )
-                };
                 expr = Expr::Index {
                     target: Box::new(expr),
-                    index: Box::new(index_expr),
+                    index: Box::new(angle_words_index_expr(content)),
+                    is_positional: false,
+                };
+                rest = r;
+                continue;
+            }
+        }
+
+        // ASCII `<<...>>` postcircumfix subscript: expr<<key>> — the ASCII twin of `«key»`,
+        // an interpolating word-quote subscript (e.g. `%h<<$key>>`, `%h<<a b>>`). Must be
+        // checked here (tight, no leading whitespace) before the outer expression parser
+        // treats `<<` as an infix hyper operator (which requires surrounding whitespace).
+        if rest.starts_with("<<") {
+            let r = &rest[2..];
+            if let Some(end) = r.find(">>") {
+                let content = &r[..end];
+                let r = &r[end + 2..];
+                expr = Expr::Index {
+                    target: Box::new(expr),
+                    index: Box::new(angle_words_index_expr(content)),
                     is_positional: false,
                 };
                 rest = r;

--- a/t/angle-subscript-ascii.t
+++ b/t/angle-subscript-ascii.t
@@ -1,0 +1,34 @@
+use v6;
+use Test;
+
+# ASCII `<<...>>` postcircumfix subscript is the interpolating twin of `«...»`
+# (Rakudo word-quote subscript semantics). Regression pin for dist Resource::Wrangler.
+
+my $key = "a";
+my %h = a => 1, b => 2, literal => 3;
+
+# single interpolated key
+is %h<<$key>>, 1, '%h<<$key>> interpolates the variable';
+is %h«$key», 1, '%h«$key» interpolates the variable';
+
+# with surrounding whitespace inside the brackets
+is %h<< $key >>, 1, '%h<< $key >> tolerates inner whitespace';
+
+# multi-word slice with interpolation
+is-deeply %h<<$key literal>>.List, (1, 3), '%h<<$key literal>> slices with interpolation';
+is-deeply %h<<$key b>>.List, (1, 2), '%h<<$key b>> slices two interpolated/literal keys';
+is-deeply %h«$key literal».List, (1, 3), '%h«$key literal» slices with interpolation';
+
+# literal (non-interpolating) single-angle stays literal
+is %h<literal>, 3, '%h<literal> uses the literal key';
+
+# infix hyper operators (needing surrounding whitespace) are unaffected
+my @a = 1, 2, 3;
+my @b = 10, 20, 30;
+is-deeply (@a <<+>> @b).List, (11, 22, 33), 'infix <<+>> hyper op still works';
+
+# chained subscripts
+my %nested = a => { x => 42 };
+is %nested<<$key>><x>, 42, 'chained <<$key>><x> subscript';
+
+done-testing;


### PR DESCRIPTION
## Problem

`%h<<\$key>>` is the ASCII twin of `%h«\$key»` — an interpolating word-quote subscript (Rakudo semantics). The postfix loop only recognised the guillemet form (`«...»`), so a tight `<<...>>` fell through to the outer expression parser, which treated `<<` as an infix hyper operator and failed:

```
Confused. expected statement: expected expression after hyper operator or ...
```

This blocked dist **Resource::Wrangler** (`self.resources<< \$key >>;`).

## Fix

Add a `<<...>>` branch in the postfix loop alongside the existing `«...»` one — both are checked *tight* (no leading whitespace), before infix hyper ops which require surrounding whitespace, so `@a <<+>> @b` is unaffected. Both branches now route through a shared `angle_words_index_expr` helper that interpolates each whitespace-separated word: a bare `\$name` reads that variable, everything else is a literal key; one word yields a scalar key, multiple words a slice.

This also fixes the pre-existing guillemet bug where `%h«\$key»` did **not** interpolate (it returned the value at literal key `"\$key"`).

Verified matching Rakudo:

| expr | value |
|------|-------|
| `%h<<\$key>>` | `1` |
| `%h<<\$key literal>>` | `(1 3)` |
| `%h«\$key literal»` | `(1 3)` |
| `%h<literal>` | `3` (literal, unchanged) |
| `@a <<+>> @b` | `[11 22 33]` (infix hyper, unchanged) |

## Tests

- New pin `t/angle-subscript-ascii.t`.
- `make test` passes (0 failures).
- Relevant whitelisted roast tests pass: `S02-literals/subscript.t`, `S03-metaops/hyper.t`, `S03-metaops/eager-hyper.t`, `S03-operators/subscript-vs-lt.t`, `S03-operators/subscript-adverbs.t`, `S02-literals/{hash,string}-interpolation.t`, `S07-hyperrace/basics.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)