### PR TITLE
fix: rx// arbitrary delimiters and `:D`-before-parametrization param types

### DIFF
--- a/src/parser/primary/regex/lit.rs
+++ b/src/parser/primary/regex/lit.rs
@@ -128,20 +128,35 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
             ));
         }
         let (spec, _) = ws(spec)?;
-        let (open_ch, close_ch, is_paired) = if spec.starts_with('/') {
-            ('/', '/', false)
-        } else if spec.starts_with('{') {
-            ('{', '}', true)
-        } else if spec.starts_with('[') {
-            ('[', ']', true)
-        } else if spec.starts_with('(') {
-            ('(', ')', true)
-        } else if spec.starts_with('<') {
-            ('<', '>', true)
-        } else {
+        // rx allows any non-word character as its delimiter (e.g. `rx|...|`,
+        // `rx!...!`), matching the general rule used by `m//` and `s///` — not
+        // just the bracket pairs. Brackets nest; every other delimiter uses the
+        // same character to open and close.
+        let Some(open_ch) = spec.chars().next() else {
             return Err(PError::expected("regex delimiter"));
         };
-        let r = &spec[1..];
+        // `:` is never a delimiter — it starts an adverb (`rx :foo:` is an error).
+        let is_delim = !open_ch.is_alphanumeric()
+            && open_ch != '_'
+            && open_ch != ':'
+            && !open_ch.is_whitespace();
+        // Don't treat `rx.method` as a regex with a `.` delimiter when the `.`
+        // is followed by an identifier (a method call on a bare `rx`).
+        let looks_like_method = open_ch == '.'
+            && spec.len() > 2
+            && spec[1..].starts_with(|c: char| c.is_alphabetic() || c == '_')
+            && spec[2..].starts_with(|c: char| c.is_alphanumeric() || c == '_' || c == '-');
+        if !is_delim || looks_like_method {
+            return Err(PError::expected("regex delimiter"));
+        }
+        let (close_ch, is_paired) = match open_ch {
+            '{' => ('}', true),
+            '[' => (']', true),
+            '(' => (')', true),
+            '<' => ('>', true),
+            other => (other, false),
+        };
+        let r = &spec[open_ch.len_utf8()..];
         let scan_result = if adverbs.perl5 {
             scan_to_delim_p5(r, open_ch, close_ch, is_paired)
         } else {

--- a/src/parser/stmt/sub_param/type_constraint.rs
+++ b/src/parser/stmt/sub_param/type_constraint.rs
@@ -99,8 +99,18 @@ pub(crate) fn parse_type_constraint_expr(input: &str) -> Option<(&str, String)> 
         rest = r2;
     }
     if rest.starts_with(":D") || rest.starts_with(":U") || rest.starts_with(":_") {
-        type_name.push_str(&rest[..2]);
+        let smiley = &rest[..2];
         rest = &rest[2..];
+        // A definedness smiley may precede the parametrization (`Array:D[Int]`)
+        // as well as follow it (`Array[Int]:D`). Consume any `[...]` that trails
+        // the smiley and re-append the smiley last, so downstream type handling
+        // always sees the canonical `Name[params]:D` form.
+        while rest.starts_with('[') {
+            let (r2, suffix) = parse_generic_suffix(rest).ok()?;
+            type_name.push_str(&suffix);
+            rest = r2;
+        }
+        type_name.push_str(smiley);
     } else if rest.starts_with(':')
         && rest[1..]
             .chars()

--- a/t/rx-delimiters-and-smiley-param.t
+++ b/t/rx-delimiters-and-smiley-param.t
@@ -1,0 +1,38 @@
+use v6;
+use Test;
+
+# --- rx// with arbitrary (non-word) delimiters -------------------------------
+# `rx` accepts any non-word character as its delimiter, matching m// and s///.
+# Regression pin for dist Net::IP::Parse (`rx|^(\d+)...$|`).
+
+ok "1.2.3.4" ~~ rx|^(\d+).(\d+).(\d+).(\d+)$|, 'rx| | pipe delimiter matches';
+ok "axc" ~~ rx!a.c!, 'rx! ! bang delimiter matches';
+ok "axc" ~~ rx,a.c,, 'rx, , comma delimiter matches';
+nok "xyz" ~~ rx|^\d+$|, 'rx| | pipe delimiter negative';
+
+# a pipe-delimited rx literal bound to a variable then smartmatched
+my $m = rx|^(\d+)$|;
+ok "42" ~~ $m, 'pipe-delimited rx bound to a variable matches';
+
+# bracket delimiters still nest, slash still works
+ok "ab" ~~ rx/a/, 'rx/ / slash delimiter still works';
+ok "ab" ~~ rx{a}, 'rx{ } bracket delimiter still works';
+
+# --- definedness smiley before parametrization ------------------------------
+# `Array:D[Int]` (smiley then type params) is accepted in a signature, the same
+# as `Array[Int]:D`. Regression pin for Net::IP::Parse BUILD signature.
+
+sub f1(Array:D[Int] $x) { $x.elems }
+is f1([1, 2, 3]), 3, 'Array:D[Int] param (smiley before parametrization)';
+
+sub f2(Array[Int]:D $x) { $x.elems }
+is f2([1, 2, 3]), 3, 'Array[Int]:D param (smiley after parametrization) still works';
+
+sub f3(Hash:D[Int] $x) { $x.elems }
+is f3({ a => 1, b => 2 }), 2, 'Hash:D[Int] param';
+
+# combined with a where-clause junction, as in the dist
+sub f4(Array:D[Int] :$octets where $octets.elems == 4 | 16) { $octets.elems }
+is f4(octets => [1, 2, 3, 4]), 4, 'Array:D[Int] named param with where-junction';
+
+done-testing;


### PR DESCRIPTION
Two parser gaps that block loading dist **Net::IP::Parse**.

## 1. `rx//` with arbitrary delimiters

`rx//` only accepted `/ { [ ( <` as delimiters, so `rx|^(\d+)...$|` fell through and `rx` was parsed as a bareword (`Confused. expected right-hand expression after '='`). Aligned `rx` with the general rule already used by `m//` and `s///`: any non-word character is a valid delimiter (brackets nest, everything else self-closes). `:` is still excluded — it starts an adverb, so `rx :foo:` remains an error (pinned by `S05-metasyntax/regex.t`).

## 2. Definedness smiley before type parametrization

A `:D`/`:U`/`:_` smiley was only accepted *after* the parametrization (`Array[Int]:D`). Raku also allows it *before*: `Array:D[Int]`. `parse_type_constraint_expr` now consumes a `[...]` that trails the smiley and re-appends the smiley last, yielding the canonical `Name[params]:D` form the rest of the pipeline already understands.

## Result

Both fixes bring Net::IP::Parse to raku parity — mutsu and raku now both stop at the same missing `Subsets::Common` dependency (a real external dep, not bundled).

## Tests

- New pin `t/rx-delimiters-and-smiley-param.t` (11 assertions).
- `make test` passes (0 failures, 2074 files).
- Regression-checked whitelisted roast: `S05-metasyntax/{regex,delimiters,single-quotes,repeat}.t`, `S06-signature/types.t`, `S09-typed-arrays/native-int.t`, `S02-literals/{quoting,subscript}.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)