### PR TITLE
fix: support :exists / :!exists on Match captures (`$<foo>:exists`)

### DIFF
--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -563,6 +563,25 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                 "X::Obsolete: Perl -> is dead. Please use '.' instead.".to_string(),
             ));
         }
+        // `:exists` / `:!exists` on a bare named match capture (`$<foo>:exists`)
+        // is sugar for `$/<foo>:exists`. The `<foo>` was already consumed while
+        // parsing the `$<foo>` term, so the adverb never reached the `<...>`
+        // subscript branch — rewrite the capture to the equivalent `$/{'foo'}`
+        // index target here so the shared exists-adverb machinery applies.
+        if let Expr::CaptureVar(name) = &expr
+            && (rest.starts_with(":exists") || rest.starts_with(":!exists"))
+        {
+            let target = Expr::Index {
+                target: Box::new(Expr::Var("/".to_string())),
+                index: Box::new(Expr::Literal(Value::str(name.clone()))),
+                is_positional: false,
+            };
+            if let Some((r, exists_expr)) = try_parse_exists_adverb(rest, target) {
+                expr = exists_expr;
+                rest = r;
+                continue;
+            }
+        }
         // Superscript power in method-call syntax: `2.²` == `2²` == `2 ** 2`
         // (also `.³`, `.⁻¹`, ...). Must run before the general `.method`
         // dispatch below, which would otherwise treat `²` as a method name.

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -343,6 +343,8 @@ impl Interpreter {
             "keys" if args.is_empty() => self.dispatch_keys_method(target),
             "values" if args.is_empty() => Some(self.dispatch_values_method(target)),
             "AT-KEY" if args.len() == 1 => self.dispatch_at_key_method(&target, &args),
+            "EXISTS-KEY" if args.len() == 1 => self.dispatch_match_exists_key(&target, &args),
+            "EXISTS-POS" if args.len() == 1 => self.dispatch_match_exists_pos(&target, &args),
             "rotate" => {
                 if matches!(target.view(), ValueView::Instance { class_name, .. } if class_name == "Supply")
                 {
@@ -794,6 +796,55 @@ impl Interpreter {
             ValueView::ValuePair(_, value) => Ok(Value::seq(vec![value.clone()])),
             _ => Ok(Value::seq(Vec::new())),
         }
+    }
+
+    /// Dispatch "EXISTS-KEY" on a Match: does the match have the named capture?
+    /// Returns None for non-Match targets so they fall through to other handlers.
+    fn dispatch_match_exists_key(
+        &self,
+        target: &Value,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if let ValueView::Instance {
+            class_name,
+            attributes,
+            ..
+        } = target.view()
+            && class_name == "Match"
+        {
+            let key = args[0].to_string_value();
+            let exists = matches!(
+                attributes.as_map().get("named").map(Value::view),
+                Some(ValueView::Hash(named)) if named.contains_key(key.as_str())
+            );
+            return Some(Ok(Value::truth(exists)));
+        }
+        None
+    }
+
+    /// Dispatch "EXISTS-POS" on a Match: is the positional capture index in range?
+    /// Returns None for non-Match targets so they fall through to other handlers.
+    fn dispatch_match_exists_pos(
+        &self,
+        target: &Value,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if let ValueView::Instance {
+            class_name,
+            attributes,
+            ..
+        } = target.view()
+            && class_name == "Match"
+        {
+            let idx = crate::runtime::to_int(&args[0]);
+            let exists = idx >= 0
+                && matches!(
+                    attributes.as_map().get("list").map(Value::view),
+                    Some(ValueView::Array(items, ..)) if (idx as usize) < items.len()
+                );
+            return Some(Ok(Value::truth(exists)));
+        }
+        None
     }
 
     /// Dispatch "AT-KEY" method.

--- a/t/match-capture-exists.t
+++ b/t/match-capture-exists.t
@@ -1,0 +1,38 @@
+use v6;
+use Test;
+
+# `:exists` / `:!exists` on Match captures — `$<foo>:exists`, `$/<foo>:exists`,
+# `$/{...}:exists`, `$/[i]:exists`, and the underlying EXISTS-KEY / EXISTS-POS
+# methods. Regression pin for dist Path::Map.
+
+"abc" ~~ /$<foo>=(.)/;
+
+# named capture via the `$<foo>` shorthand
+ok   $<foo>:exists,  '$<foo>:exists is True for a present named capture';
+nok  $<bar>:exists,  '$<bar>:exists is False for an absent named capture';
+nok  $<foo>:!exists, '$<foo>:!exists negates';
+ok   $<bar>:!exists, '$<bar>:!exists is True for an absent capture';
+
+# the same through the explicit $/ subscript forms
+ok   $/<foo>:exists,    '$/<foo>:exists';
+ok   $/{"foo"}:exists,  '$/{"foo"}:exists';
+nok  $/<bar>:exists,    '$/<bar>:exists is False';
+
+# EXISTS-KEY method directly
+ok   $/.EXISTS-KEY("foo"), '$/.EXISTS-KEY("foo")';
+nok  $/.EXISTS-KEY("bar"), '$/.EXISTS-KEY("bar")';
+
+# positional captures
+"xy" ~~ /(.)(.)/;
+ok   $/[0]:exists, '$/[0]:exists (positional in range)';
+ok   $/[1]:exists, '$/[1]:exists (positional in range)';
+nok  $/[5]:exists, '$/[5]:exists (positional out of range)';
+ok   $/.EXISTS-POS(0), '$/.EXISTS-POS(0)';
+nok  $/.EXISTS-POS(5), '$/.EXISTS-POS(5)';
+
+# usable as an `if` condition (the Path::Map idiom)
+"abc" ~~ /$<slurpy>=(.)/;
+if $<slurpy>:exists { pass 'named capture :exists usable in if condition' }
+else                { flunk 'named capture :exists usable in if condition' }
+
+done-testing;


### PR DESCRIPTION
## Problem

`$<foo>:exists` and `$/<foo>:exists` always returned `False`, and `rx` match objects had no `EXISTS-KEY` / `EXISTS-POS` methods at all. This blocked dist **Path::Map** from parsing (`if $<var>:exists { ... }`).

Two gaps:

1. **Parser** — `$<foo>` is parsed as a complete `CaptureVar` term, consuming `<foo>` *before* the postfix `<...>` subscript branch runs, so a trailing `:exists` never reached the exists-adverb machinery (unlike `%h<foo>:exists`, which does work). Rewrite `CaptureVar(name):exists` to the equivalent `$/{'name'}:exists` index target in the postfix loop.

2. **Runtime** — a `Match` is an `Instance` carrying named captures in its `named` hash and positional captures in its `list` array, but it defined no `EXISTS-KEY` / `EXISTS-POS`. The `:exists` dispatch calls those methods and, finding none, always fell back to `False`. Add both to the Match method dispatch (returning `None` for non-Match targets so nothing else regresses).

## Result — all match Rakudo

| expr | value |
|------|-------|
| `$<foo>:exists` (present) | `True` |
| `$<bar>:exists` (absent) | `False` |
| `$<foo>:!exists` | `False` |
| `$/<foo>:exists` / `$/{"foo"}:exists` | `True` |
| `$/[0]:exists` (in range) | `True` |
| `$/[5]:exists` (out of range) | `False` |
| `$/.EXISTS-KEY("foo")` / `$/.EXISTS-POS(0)` | `True` |

Path::Map now loads (mutsu and raku both succeed).

## Tests

- New pin `t/match-capture-exists.t` (15 assertions).
- `make test` passes (0 failures, 2075 files).
- Regression-checked whitelisted roast: `S05-capture/named.t`, `S05-match/capturing-contexts.t`, `S03-operators/subscript-adverbs.t`, `S05-metasyntax/litvar.t`, `S02-literals/subscript.t`, `S05-modifier/exhaustive.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)