### PR TITLE
fix: accept a built-in enum value as a statement-level ternary then-branch

### DIFF
--- a/src/parser/expr/precedence/ternary.rs
+++ b/src/parser/expr/precedence/ternary.rs
@@ -183,6 +183,7 @@ pub(crate) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
             && let Expr::BareWord(name) = &then_expr
             && !name.contains("::")
             && !crate::runtime::utils::is_known_type_constraint(name)
+            && !crate::runtime::utils::is_builtin_enum_value(name)
             && !crate::parser::stmt::simple::is_user_declared_type(name)
             && !crate::parser::stmt::simple::is_user_declared_value_term(name)
         {

--- a/src/runtime/utils/type_constraints.rs
+++ b/src/runtime/utils/type_constraints.rs
@@ -179,6 +179,19 @@ pub(crate) fn is_known_type_constraint(constraint: &str) -> bool {
     )
 }
 
+/// Check if a bare identifier names a value of a built-in enum (`Order`,
+/// `Endian`, `Bool`). These are nullary value terms, not type names, so they are
+/// complete expressions on their own (e.g. the then-branch of `1 ?? More !! Less`).
+pub(crate) fn is_builtin_enum_value(name: &str) -> bool {
+    matches!(
+        name,
+        // Order
+        "Less" | "Same" | "More"
+        // Endian
+        | "LittleEndian" | "BigEndian" | "NativeEndian"
+    )
+}
+
 /// Check if a compound (`::`-separated) name is a known Raku standard type.
 pub(crate) fn is_known_compound_type(name: &str) -> bool {
     matches!(

--- a/t/ternary-builtin-enum-then.t
+++ b/t/ternary-builtin-enum-then.t
@@ -1,0 +1,35 @@
+use v6;
+use Test;
+
+# A built-in enum value (Order's Less/Same/More, Endian's *Endian) is a complete
+# nullary term, so it is a valid then-branch of a statement-level `?? !!` ternary
+# — it must not be mistaken for the head of a listop call that gobbles the `!!`.
+# Regression pin for dist Version::Semverish (`... ?? More !! Less` in sink context).
+
+# statement-level (sink) ternary — these previously failed to parse
+{
+    1 ?? More !! Less;
+    0 ?? More !! Less;
+    pass 'statement-level `?? More !! Less` parses';
+}
+
+# value is correct in expression context
+is (1 ?? More  !! Less), More, '1 ?? More !! Less is More';
+is (0 ?? More  !! Less), Less, '0 ?? More !! Less is Less';
+is (1 ?? Same  !! More), Same, 'Same as then-branch';
+
+# Endian enum values too
+is (1 ?? LittleEndian !! BigEndian), LittleEndian, 'Endian enum then-branch';
+
+# inside an else block (the Version::Semverish idiom)
+my $x = 1;
+my $r = do {
+    if $x == 2 { Same }
+    else       { $x == 1 ?? More !! Less }
+};
+is $r, More, 'ternary with enum branches inside an else block';
+
+# ordinary type-object then-branches still work
+is (1 ?? Int !! Str), Int, 'type object then-branch still works';
+
+done-testing;


### PR DESCRIPTION
## Problem

`1 ?? More !! Less` failed to parse at statement (sink) level, while the same expression parsed fine in paren or assignment context:

```
Confused. expected statement: expected use statement or import statement or ...
------>1 ?? More !! Less;
       ^
```

The `??` then-branch guard (`ternary_mode`, Full mode) rejects a bare identifier unless it is a known type or a user-declared type/value term — on the assumption that a bare identifier there is the head of a listop call whose `!!` was gobbled (`1 ?? is-deeply $x, $y !! ...`). But built-in enum **values** — `Order`'s `Less`/`Same`/`More` and `Endian`'s `LittleEndian`/`BigEndian`/`NativeEndian` — are complete nullary terms, not listop heads.

## Fix

Add an `is_builtin_enum_value` predicate and exclude those names from the guard. The runtime already resolves the bare terms correctly (`say (1 ?? More !! Less)` printed `More` before this change); only the parser guard was over-eager.

Unblocks dist **Version::Semverish** (`$i <= @rights.end ?? $default !! Same`, `$default == Less ?? More !! Less`). mutsu and raku now both load it.

## Tests

- New pin `t/ternary-builtin-enum-then.t` (7 assertions).
- `make test` passes (0 failures, 2076 files).
- Regression-checked whitelisted roast: `S03-operators/ternary.t`, `S03-operators/precedence.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)