### PR TITLE
fix: uppercase named-param aliases with defaults, and loop{} then a new-line while

### DIFF
--- a/src/parser/stmt/control/loop_repeat.rs
+++ b/src/parser/stmt/control/loop_repeat.rs
@@ -283,9 +283,16 @@ pub(crate) fn loop_stmt(input: &str) -> PResult<'_, Stmt> {
     // Infinite loop
     let (rest, _) = ws(rest)?;
     let (rest, body) = block(rest)?;
-    // `loop {} while COND` is a syntax error — use `repeat while` instead
+    // `loop {} while COND` on the SAME line is a syntax error — a block-ending
+    // statement takes no `while`/`until` modifier (use `repeat while` instead).
+    // But a `while`/`until` on a NEW line begins a separate `while`-loop
+    // statement (`loop { } \n while $x { ... }`, Algorithm::Diff), so only error
+    // when no statement-ending newline separates the `}` from the keyword.
     let (check, _) = ws(rest)?;
-    if keyword("while", check).is_some() || keyword("until", check).is_some() {
+    let inter_ws = &rest[..rest.len() - check.len()];
+    if !inter_ws.contains('\n')
+        && (keyword("while", check).is_some() || keyword("until", check).is_some())
+    {
         return Err(PError::fatal(
             "X::Syntax::Confused: Strange text after block (missing semicolon or comma?)"
                 .to_string(),

--- a/src/parser/stmt/sub_param/param_inner.rs
+++ b/src/parser/stmt/sub_param/param_inner.rs
@@ -330,12 +330,18 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
         }
     }
 
-    // — those are named aliases like :x($r), not type constraints.
+    // — those are named aliases like :x($r), not type constraints. The external
+    // name may start with an uppercase letter too (`:PRUNED($p)`, `:ASTART($a)` in
+    // Algorithm::Diff): `:Name($var)` is always a named alias, never a type — a
+    // type constraint on a named param is written before the colon (`Int :$x`).
+    // Restricting this to lowercase let an uppercase alias fall into the
+    // type-constraint/coercion path, which returned without consuming a trailing
+    // default (`:ASTART($a) = 0`).
     let skip_type_for_named_alias = named
         && rest
             .as_bytes()
             .first()
-            .is_some_and(|b| b.is_ascii_lowercase())
+            .is_some_and(|b| b.is_ascii_alphabetic() || *b == b'_')
         && rest.contains('(');
     if type_constraint.is_none()
         && !skip_type_for_named_alias

--- a/t/named-alias-and-loop-then-while.t
+++ b/t/named-alias-and-loop-then-while.t
@@ -1,0 +1,44 @@
+use v6;
+use Test;
+
+# Two parser fixes needed to load dist Algorithm::Diff.
+
+# --- 1. Named parameter alias with an uppercase external name + default -------
+# `:NAME($var)` is always a named alias (never a type); the external name may be
+# uppercase (`:ASTART($a)`, `:PRUNED($p)`). Previously an uppercase alias with a
+# default (`:ASTART($a) = 0`) failed to parse.
+sub f(:ASTART($a) = 0, :AFINISH($z) = 10, :MATCHVEC(@m) = []) {
+    "$a/$z/{@m.elems}"
+}
+is f(), '0/10/0', 'uppercase named aliases with defaults use the defaults';
+is f(ASTART => 3, AFINISH => 7, MATCHVEC => [1, 2, 3]), '3/7/3',
+    'uppercase named aliases bind by external name';
+
+# the alias is a name, not a type: any value binds
+sub g(:Int($x) = 'def') { $x }
+is g(), 'def', ':Int($x) is an alias, not a type constraint (default)';
+is g(Int => 'hi'), 'hi', ':Int($x) binds a Str fine';
+
+# --- 2. `loop {}` followed by a `while`/`until` loop on a new line ------------
+# A block-ending `loop {}` is complete; a `while`/`until` on the NEXT line begins
+# a separate loop statement (not a `while` modifier).
+{
+    my $i = 0;
+    loop { last if $i > 3; $i++ }
+
+    while $i < 10 { $i++ }
+    is $i, 10, 'loop {} then a separate while-loop on a new line';
+}
+
+{
+    my $j = 0;
+    loop { last if $j > 2; $j++ }
+    until $j >= 8 { $j++ }
+    is $j, 8, 'loop {} then a separate until-loop on a new line';
+}
+
+# a same-line `while` modifier on a block is still rejected (Rakudo semantics)
+throws-like 'loop { } while $x;', X::Syntax::Confused,
+    'loop {} while COND; (same-line modifier) is still an error';
+
+done-testing;


### PR DESCRIPTION
Two parser gaps that block loading dist **Algorithm::Diff**.

## 1. Uppercase named-parameter alias with a default

`:NAME($var)` in a signature is always a named alias, never a type — a type constraint on a named param is written *before* the colon (`Int :$x`), and `:Int($x)` binds any value (a `Str` binds fine, so it is not a type check). But the "this is an alias, skip type-constraint parsing" guard only fired for **lowercase**-initial external names. An uppercase alias fell into the type-constraint/coercion path, which returned *without consuming a trailing default*, so `:ASTART($a) = 0` / `:MATCHVEC(@m) = []` failed to parse. Widened the guard to any alphabetic/`_` initial.

## 2. `loop {}` then a `while`/`until` loop on a new line

```raku
loop { ... }

while $cond { ... }   # a separate loop, not a modifier
```

was rejected as `Strange text after block`. A *same-line* `while`/`until` after a block IS a modifier error (Rakudo rejects `loop {} while $x;`), but a newline ends the statement, so a following `while`/`until` begins a new loop. Now the error only fires when no statement-ending newline separates the `}` from the keyword — matching Rakudo (newline → OK, same line → error).

## Tests

- New pin `t/named-alias-and-loop-then-while.t` (7 assertions, incl. the same-line modifier still throwing `X::Syntax::Confused`).
- `make test` passes (0 failures, 2077 files).
- Regression-checked whitelisted roast: `S04-statements/{loop,while,repeat}.t`, `S06-signature/{named-parameters,named-renaming}.t`.

Algorithm::Diff now loads (mutsu and raku both succeed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)