### PR TITLE
perf(vm): skip operator resolution when no user infix is declared

### DIFF
--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -131,6 +131,16 @@ impl Interpreter {
         left: &Value,
         right: &Value,
     ) -> Result<Option<Value>, RuntimeError> {
+        // Fast bail when no `sub infix:<op>` is in scope. Without this, every
+        // arithmetic op that falls off the Int/Num fast paths (Rat, mixed-type,
+        // etc.) pays a full `resolve_function_with_types` -- which builds ~30
+        // `format!` lookup keys and probes the registry -- only to get `None`.
+        // `user_declared_infix_ops` is populated for every registered/imported
+        // `infix:<...>` sub, so an op absent from it can never resolve to a user
+        // infix; the set is empty in the overwhelming common case.
+        if !self.user_infix_override(op_name) {
+            return Ok(None);
+        }
         let args = vec![left.clone(), right.clone()];
         if let Some(def) = loan_env!(self, resolve_function_with_types(op_name, &args)) {
             let empty_fns = CompiledFns::default();

--- a/t/user-infix-non-int-operands.t
+++ b/t/user-infix-non-int-operands.t
@@ -1,0 +1,32 @@
+use Test;
+
+# A user-declared infix operator must override native arithmetic even when the
+# operands fall off the Int/Num fast paths (Rat, mixed types). This pins the
+# `try_user_infix` fast-bail guard: the guard skips full operator resolution
+# only when no `sub infix:<op>` is registered, so a registered one must still
+# win on every operand kind.
+
+plan 8;
+
+{
+    my sub infix:<*>(Int $a, Int $b) { "II($a,$b)" }
+    is 3 * 4, "II(3,4)", "user infix:<*> overrides Int * Int";
+}
+
+{
+    my sub infix:<*>($a, $b) { "MUL($a,$b)" }
+    is (1/2) * 4, "MUL(0.5,4)", "user infix:<*> overrides Rat * Int";
+    is (1/2) * (2/3), "MUL(0.5,0.666667)", "user infix:<*> overrides Rat * Rat";
+}
+
+{
+    my sub infix:</>($a, $b) { "DIV($a,$b)" }
+    is 10 / 2, "DIV(10,2)", "user infix:</> overrides Int / Int";
+    is 1.5 / 2, "DIV(1.5,2)", "user infix:</> overrides Rat / Int";
+}
+
+# No user infix declared: plain arithmetic that leaves the Int fast path must
+# still produce correct results (the guard bails to native arithmetic).
+is 355/113 * 2, 710/113, "plain Rat * Int is unchanged without a user infix";
+is 1/3 + 1/6, 1/2, "plain Rat + Rat is unchanged without a user infix";
+is 7 / 2, 3.5, "plain Int / Int -> Rat is unchanged without a user infix";


### PR DESCRIPTION
## Summary

`try_user_infix` called `resolve_function_with_types(op_name, args)` on **every** arithmetic op that fell off the Int/Num fast paths (Rat operands, mixed types) — even when no `sub infix:<op>` was ever declared. That resolution builds ~30 `format!` lookup keys and probes the registry only to return `None`, so ordinary Rat / mixed arithmetic paid a "format! bomb" on every operation.

`user_declared_infix_ops` is populated for every registered or imported `infix:<...>` sub, so an operator absent from that set can never resolve to a user infix. This PR bails out of `try_user_infix` early in that case (the set is empty in the overwhelming common case), falling straight through to native arithmetic.

## How this was found

The poly-call bench regressed ~+26% at `761212531` (J4d slice 4 — FxHash the dispatch tables). Runner-normalized (raku ratio) trend: before ≈0.43 → after ≈0.54, persistent.

Root-causing with P-core-pinned `perf stat` (instructions are deterministic, `+-0.00%`) showed the regression is **+240M instructions**, not a hash micro-cost — and reverting FxHash→SipHash at HEAD left instructions **identical** (1176M both), so the hash was never the instruction driver. `perf record` pointed at `resolve_function_with_types` + `alloc::fmt::format` dominating, with `infix:<*>` / `infix:</>` keys being formatted per op. The wasteful resolution ran all along; FxHash just made its probes more cache-unfriendly.

## Measurements (P-core-pinned, release)

| build | instructions | time |
|---|---|---|
| before-regression baseline (`d6d405cca`) | 936M | 0.092s |
| regressed HEAD (FxHash) | 1176M | 0.116s |
| **this fix** | **513M** | **0.060s** |

poly-call is now well below the pre-regression baseline (−56% instructions vs HEAD, −45% vs the old baseline).

## Correctness

- User-defined infix operators still override native arithmetic on every operand kind (Int×Int, Rat×Int, Rat×Rat, Int/Int, Rat/Int, custom ops) — pinned by new `t/user-infix-non-int-operands.t`.
- `roast/S06-operator-overloading/infix.t` (50 tests) and `prefix.t` stay green.
- `make test` passes (2069 files, 19582 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)