### PR TITLE
fix: don't gobble a block after a declared hyphenated type name

### DIFF
--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1535,7 +1535,21 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
             name.clone()
         };
         let next = r.chars().next().unwrap();
-        let hyphen_forward_call = !is_user_sub && name.contains('-');
+        // A hyphenated bareword that is NOT a declared sub is speculatively
+        // treated as a forward-referenced sub (`do-thing { ... }` where
+        // `do-thing` is defined later), so its listop arguments — including a
+        // block — are gobbled. But when the name is a declared *type* (class,
+        // role, grammar, enum), raku does NOT gobble a following block: it
+        // belongs to the enclosing construct (e.g. `$x ~~ Sub-Test { ... }`
+        // where `{ ... }` is the `if`/`when` body). Exclude declared types so
+        // the block is not consumed as an argument. A qualified reference
+        // (`TAP::Sub-Test`) registers under its short name, so also check the
+        // final `::` component.
+        let name_is_declared_type = crate::parser::stmt::simple::is_user_declared_type(&name)
+            || name
+                .rsplit_once("::")
+                .is_some_and(|(_, tail)| crate::parser::stmt::simple::is_user_declared_type(tail));
+        let hyphen_forward_call = !is_user_sub && !name_is_declared_type && name.contains('-');
         if is_user_prefix_sub {
             if let Ok((r2, arg)) = expression_no_sequence(r) {
                 return Ok((r2, make_call_expr(call_name.clone(), input, vec![arg])));

--- a/t/hyphenated-type-block-no-gobble.t
+++ b/t/hyphenated-type-block-no-gobble.t
@@ -1,0 +1,69 @@
+use v6;
+use Test;
+
+# A declared hyphenated type name (class/role/etc.) followed by whitespace and a
+# `{ ... }` block must NOT gobble the block as a call argument. The block belongs
+# to the enclosing construct (if/when/given). Only a hyphenated bareword that is
+# NOT a declared type — a forward-referenced sub — gobbles a block.
+# Regression: `$test ~~ TAP::Sub-Test { ... }` used to parse `Sub-Test { ... }`
+# as a Call and fail with "Confused / needs '{'".
+
+plan 8;
+
+class Foo-Bar { }
+
+my $five = 5;
+
+# smartmatch against a declared hyphenated type; block is the if-body
+if $five ~~ Foo-Bar {
+    flunk "5 should not smartmatch Foo-Bar";
+} else {
+    pass "if-block belongs to the if, not gobbled by Foo-Bar";
+}
+
+if Foo-Bar.new ~~ Foo-Bar {
+    pass "Foo-Bar instance smartmatches Foo-Bar";
+} else {
+    flunk "Foo-Bar.new should smartmatch Foo-Bar";
+}
+
+# given/when with a declared hyphenated type; block is the when-body
+my $branch = 'none';
+given $five {
+    when Foo-Bar { $branch = 'matched' }
+    default      { $branch = 'default' }
+}
+is $branch, 'default', "when Foo-Bar block is the when-body";
+
+given Foo-Bar.new {
+    when Foo-Bar { $branch = 'matched' }
+    default      { $branch = 'default' }
+}
+is $branch, 'matched', "when Foo-Bar matches an instance";
+
+# `my $x = Type ~~ Type { ... }` inside parens still resolves the block correctly
+my $r = do {
+    if $five ~~ Foo-Bar { 'yes' } else { 'no' }
+};
+is $r, 'no', "nested if with hyphenated type resolves block";
+
+# Qualified hyphenated type reference (short name registered under a module)
+role Baz-Role { }
+class Impl does Baz-Role { }
+if Impl.new ~~ Baz-Role {
+    pass "hyphenated role name does not gobble the block";
+} else {
+    flunk "Impl should do Baz-Role";
+}
+
+# A forward-referenced hyphenated sub still gobbles a block argument.
+my $ran = 0;
+run-it { $ran = 1 };
+is $ran, 1, "forward-referenced hyphenated sub still gobbles its block arg";
+sub run-it(&b) { b() }
+
+# A declared hyphenated sub with a block argument keeps working too.
+sub do-thing(&b) { b() }
+my $done = 0;
+do-thing { $done = 42 };
+is $done, 42, "declared hyphenated sub gobbles its block arg";


### PR DESCRIPTION
## Problem

A hyphenated bareword that is not a declared sub was speculatively treated as a forward-referenced sub, so any following `{ ... }` block was consumed as a call argument:

```raku
class Foo-Bar { }
if $x ~~ Foo-Bar { ... }   # parsed `Foo-Bar { ... }` as Call{Foo-Bar,[block]}
```

This misparsed the common `EXPR ~~ TAP::Sub-Test { ... }` shape (block belongs to the enclosing `if`/`when`/`given`) into a bogus call and failed with `Confused: expected '{'`. Non-hyphenated names never hit this path. Surfaced by the `TAP` distribution (`TAP.rakumod:734`, `$test ~~ TAP::Sub-Test {`).

## Fix

raku only gobbles a block for a real (forward-declared) sub; a declared *type* (class/role/grammar/enum) does not. Exclude declared types from the hyphenated forward-call heuristic, checking both the full name and its final `::` component so a qualified reference (`TAP::Sub-Test`, whose class registers under the short name `Sub-Test`) is recognized.

Forward-referenced hyphenated subs with a block argument still gobble, since an unknown name is not a declared type.

## Verification

- New pin `t/hyphenated-type-block-no-gobble.t` (8 subtests) — identical output under `raku` and `mutsu`.
- `make test`: PASS (19690 tests).
- `TAP.rakumod` now parses past this point (advances to a separate, pre-existing runtime blocker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)