### PR TITLE
fix: interpolate `$.name()` self-accessor call in strings

### DIFF
--- a/src/parser/primary/string.rs
+++ b/src/parser/primary/string.rs
@@ -46,6 +46,6 @@ pub(crate) use interp_content::parse_single_quote_qq;
 pub(crate) use interp_content::try_embedded_qw;
 pub(crate) use interp_helpers::{
     has_malformed_angle_interpolation, parse_shell_words_index, try_double_sigil_interp,
-    try_parse_interp_call, try_parse_interp_method_call,
+    try_parse_interp_call, try_parse_interp_method_call, try_parse_interp_self_accessor_call,
 };
 pub(crate) use quotewords::parse_quotewords_items;

--- a/src/parser/primary/string/interp_helpers.rs
+++ b/src/parser/primary/string/interp_helpers.rs
@@ -51,6 +51,59 @@ pub(crate) fn try_parse_interp_call(input: &str, target: Expr) -> (Expr, &str) {
     )
 }
 
+/// Try to parse a call on an interpolated self-accessor: `"$.name()"` or `"$.name(args)"`.
+/// In Raku `$.name` is `self.name`, so `$.name()` is the same accessor called with explicit
+/// (empty) parens and `$.name(args)` passes arguments. Unlike `try_parse_interp_call` (which
+/// invokes the *value* of a scalar as a callable via `CallOn`), this rebuilds the accessor as a
+/// `MethodCall` on `self` — matching how `$.name(...)` parses outside a string. Only triggers when
+/// `(` immediately follows the accessor name.
+pub(crate) fn try_parse_interp_self_accessor_call<'a>(
+    input: &'a str,
+    attr_name: &str,
+) -> Option<(Expr, &'a str)> {
+    if !input.starts_with('(') {
+        return None;
+    }
+    let mut depth = 0usize;
+    let mut paren_end = None;
+    for (idx, ch) in input.char_indices() {
+        if ch == '(' {
+            depth += 1;
+        } else if ch == ')' {
+            depth -= 1;
+            if depth == 0 {
+                paren_end = Some(idx);
+                break;
+            }
+        }
+    }
+    let pe = paren_end?;
+    let args_str = &input[1..pe];
+    let after = &input[pe + 1..];
+    let args = if args_str.trim().is_empty() {
+        vec![]
+    } else {
+        let mut args = vec![];
+        for arg in crate::parser::primary::string::interp_var::split_top_level_commas(args_str) {
+            let arg = arg.trim();
+            if let Ok((_, e)) = crate::parser::expr::expression(arg) {
+                args.push(e);
+            }
+        }
+        args
+    };
+    Some((
+        Expr::MethodCall {
+            target: Box::new(Expr::BareWord("self".to_string())),
+            name: Symbol::intern(attr_name),
+            args,
+            modifier: None,
+            quoted: false,
+        },
+        after,
+    ))
+}
+
 /// Try to parse a method call chain on an interpolated variable: "$var.method()" or "$var.method".
 /// Only recognizes simple identifier method names followed by `()` (no args).
 /// Try to parse a method call chain on an interpolated variable: "$var.method()" or "$var.method".

--- a/src/parser/primary/string/interp_var.rs
+++ b/src/parser/primary/string/interp_var.rs
@@ -362,9 +362,18 @@ pub(crate) fn try_interpolate_var<'a>(
                     let end = after_dot
                         .find(|c: char| !c.is_alphanumeric() && c != '_' && c != '-')
                         .unwrap_or(after_dot.len());
-                    let var_name = format!(".{}", &after_dot[..end]);
-                    let (expr, remainder) =
-                        parse_postcircumfix_index(&after_dot[end..], Expr::Var(var_name));
+                    let attr_name = &after_dot[..end];
+                    let var_name = format!(".{}", attr_name);
+                    let after_name = &after_dot[end..];
+                    // `$.name()` / `$.name(args)`: the accessor called with explicit parens.
+                    // Rebuild as `self.name(args)` (matching the non-interpolated parse) instead
+                    // of leaving the `()` as a literal string fragment.
+                    let (expr, after_name) =
+                        match try_parse_interp_self_accessor_call(after_name, attr_name) {
+                            Some((e, r)) => (e, r),
+                            None => (Expr::Var(var_name), after_name),
+                        };
+                    let (expr, remainder) = parse_postcircumfix_index(after_name, expr);
                     let (expr, remainder) = try_parse_interp_method_call(remainder, expr);
                     parts.push(expr);
                     return Some(remainder);

--- a/t/interp-self-accessor-call.t
+++ b/t/interp-self-accessor-call.t
@@ -1,0 +1,35 @@
+use Test;
+
+# `$.name()` in string interpolation is `self.name()` — the accessor called with
+# explicit parens. mutsu used to interpolate `$.name` but leave the trailing `()`
+# as a literal fragment (`Jane()`), diverging from raku. (Language/syntax.rakudoc.)
+
+plan 8;
+
+class Person {
+    has Str $.name = "Anon";
+    has @.items = (1, 2, 3);
+    method greet($who) { "hi $who" }
+
+    method m-bare      { "[$.name]" }
+    method m-parens    { "[$.name()]" }
+    method m-parens-x  { "[$.name()!]" }
+    method m-chain     { "[$.name.chars()]" }
+    method m-args      { "[$.greet('you')]" }
+    method m-elems     { "[$.items.elems()]" }
+    method m-no-parens { "[$.name.uc]" }   # no trailing parens => `.uc` stays literal
+}
+
+my $p = Person.new(:name<Jane>);
+
+is $p.m-bare,      "[Jane]",   'bare $.name interpolates';
+is $p.m-parens,    "[Jane]",   '$.name() interpolates (parens consumed)';
+is $p.m-parens-x,  "[Jane!]",  '$.name() followed by literal text';
+is $p.m-chain,     "[4]",      '$.name.chars() chained call';
+is $p.m-args,      "[hi you]", '$.method(args) with arguments';
+is $p.m-elems,     "[3]",      '$.items.elems() on an array attribute';
+is $p.m-no-parens, "[Jane.uc]",'trailing .uc without parens stays literal (raku parity)';
+
+# Unicode attribute value round-trips through the rebuilt method call.
+class Uni { has $.n = "Zoë"; method g { "<$.n()>" } }
+is Uni.new.g, "<Zoë>", 'unicode value via method-call parens';


### PR DESCRIPTION
## Summary

In Raku `$.name` is `self.name`, so `"$.name()"` calls the accessor with explicit
parens and interpolates the result, and `"$.name(args)"` passes arguments. mutsu
interpolated the `$.name` accessor but left the trailing `()` as a **literal string
fragment**, so a method like `method greet { say "Hello, $.name()!" }` printed
`Hello, Jane()!` instead of `Hello, Jane!`.

The scalar `$var` interpolation branch already ran `try_parse_interp_call` for a
trailing `()`, but the `$.attr` branch skipped it. Rather than reuse that helper
(which lowers to `CallOn` — invoking the accessor's *value* as a callable), this adds
`try_parse_interp_self_accessor_call`, which rebuilds `$.name(args)` as a
`MethodCall` on `self` — exactly how `$.name(...)` parses outside a string.

Forms verified against reference `raku`:

| interpolation | result |
|---|---|
| `$.name()` | accessor called, `()` consumed |
| `$.name(args)` | args passed to the method |
| `$.name.chars()` | chained call |
| `$.name.uc` (no parens) | `.uc` stays literal (raku parity) |

## Discovery

Found via the doc-diff QA harness (PLAN.md §8) on `Language/syntax.rakudoc`
(examples [15] and [24]).

## Test

Pin: `t/interp-self-accessor-call.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)