### PR TITLE
refactor: delete the (B) per-store env-write gate (now permanent)

### DIFF
--- a/docs/lexical-scope-slot-campaign.md
+++ b/docs/lexical-scope-slot-campaign.md
@@ -893,12 +893,20 @@ Perf: while/loop hot paths drop the unconditional env write (−10…16% on a 5M
 loop); for/fib are unaffected (their frames `captures_env_by_name`, so every local
 is force-synced regardless).
 
-**Remaining: after the flip soaks in main, delete the gate** — the ~18
-`if gate_local_env_write()` sites become unconditional (the ON branch), and the
-OFF-side dead code (the env-mirror stores those sites guard, plus the
-`MUTSU_GATE_LOCAL_ENV_WRITE` env plumbing) is removed. That is a separate mechanical
-PR, taken only once the flip has demonstrably soaked. **Any future flip verification
-MUST include `MUTSU_JIT=on MUTSU_JIT_THRESHOLD=2`.**
+### Gate removal — `gate_local_env_write()` deleted (2026-07-21, post-soak)
+
+After the Plan A flip soaked in main (35 main commits across many green CI cycles
+with no latent flaky reports), the gate was deleted. The 9 `if gate_local_env_write()`
+sites became unconditional (their ON branch), the OFF-side dead code was removed
+(the env-mirror store in `exec_set_local_op_inner` is now always skipped for a
+slot-authoritative plain lexical; the block-restore / scope-restore OFF branches
+that re-seeded locals from env by name are gone), and the `gate_local_env_write()`
+function plus the `MUTSU_GATE_LOCAL_ENV_WRITE` env plumbing were removed. The (B)
+per-store env-write is now a permanent, unconditional behavior: the slot is the
+single source of truth for a plain lexical, and env-COW drops the mirror write.
+The `gate_local_slot`/`gate_local_slot_value` helpers keep their names but no longer
+gate on the flag (they now only check `plain_locals`). Pins: `t/gate-b-*.t` (18
+files) still cover every mechanism-consumer fold.
 
 ## §1.4 flip blast-radius measurement (2026-07-02, debug + release `prove t/`)
 

--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -61,12 +61,12 @@ impl Compiler {
     }
 
     /// Record that `var_name` reaches an atomic-op builtin (`⚛$x`, `$x ⚛= v`,
-    /// `cas($x, …)`) as the target variable, so the gated `compute_needs_env_sync`
+    /// `cas($x, …)`) as the target variable, so the `compute_needs_env_sync`
     /// fold keeps its env mirror current (the builtin resolves the target by name
     /// from env). No-op for a name that is not one of this frame's own locals
-    /// (an ancestor lexical / global / attribute is resolved differently). The
-    /// field is only consumed under `MUTSU_GATE_LOCAL_ENV_WRITE`, so the default
-    /// build is byte-identical.
+    /// (an ancestor lexical / global / attribute is resolved differently). Needed
+    /// because the (B) per-store env-write otherwise skips the mirror for a plain
+    /// lexical, leaving the builtin to read the decl-seed placeholder.
     pub(super) fn note_atomic_env_sync_target(&mut self, var_name: &str) {
         if let Some(&slot) = self.local_map.get(var_name)
             && !self.code.atomic_env_sync_locals.contains(&slot)

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -27,32 +27,6 @@ pub(crate) fn reflective_name_access_possible() -> bool {
     REFLECTIVE_NAME_ACCESS_SEEN.load(Ordering::Relaxed)
 }
 
-/// `(B)` per-store env-write gate (docs/lexical-scope-slot-campaign.md, "The
-/// `(B)` per-store env-write gate"). **Default ON since the Plan A flip
-/// (2026-07-20)**: `exec_set_local_op_inner` skips mirroring a slot-authoritative
-/// plain-lexical store (not captured/reflective/sync) into the name-keyed `env`,
-/// so the slot is the single source of truth and env-COW can drop the write.
-/// `MUTSU_GATE_LOCAL_ENV_WRITE=0` (or `off`) opts back out to the byte-identical
-/// pre-gate behavior (mirror every plain-lexical store). The flip landed once both
-/// the t/ and the full roast ON surveys were clean and all four env-mirror
-/// consumers (#1 block-restore, #2 cross-thread, #3 call-return reconcile, #4
-/// curry) were slot-authoritative. Once the flip soaks, the gate sites and the
-/// OFF path are deleted. Cached like `jit_enabled()`.
-#[inline]
-pub(crate) fn gate_local_env_write() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| {
-        // Plan A flip (2026-07-20): default ON now that the full t/ + roast ON
-        // survey is clean. `MUTSU_GATE_LOCAL_ENV_WRITE=0` (or `off`) opts back out
-        // to the byte-identical env-mirror-every-store behavior. Once the flip has
-        // soaked, the gate sites and the OFF path are deleted.
-        !matches!(
-            std::env::var("MUTSU_GATE_LOCAL_ENV_WRITE").ok().as_deref(),
-            Some("0") | Some("off") | Some("OFF")
-        )
-    })
-}
-
 /// Base binary operation for a fused compound-assignment opcode
 /// (`$x OP= rhs`). Each variant maps to the same `exec_*_op` the plain
 /// `Binary` path uses, so the fused op shares exact operator semantics.
@@ -1710,10 +1684,10 @@ pub(crate) struct CompiledCode {
     /// `cas($x, …)`) as the target VARIABLE. These builtins are compiled to a
     /// `__mutsu_*_var(name_str, …)` call and resolve the target by NAME from env
     /// (`atomic_current_value` falls back to `env.get(name)` for a non-`atomicint`
-    /// scalar). Under `MUTSU_GATE_LOCAL_ENV_WRITE` a plain `my Int $x = 1` skips
-    /// its env mirror, so the builtin reads the decl-seed placeholder. Consumed
-    /// ONLY by the gated `compute_needs_env_sync` fold, which marks these slots
-    /// env-synced; the default build never reads this field (byte-identical).
+    /// scalar). Under the (B) per-store env-write a plain `my Int $x = 1` skips
+    /// its env mirror, so the builtin would read the decl-seed placeholder.
+    /// Consumed by the `compute_needs_env_sync` fold, which marks these slots
+    /// env-synced so their mirror stays live for the by-name builtin.
     pub(crate) atomic_env_sync_locals: Vec<u32>,
     /// Out-of-band named-argument specs for `CallFuncNamed` sites (indexed by
     /// the op's `spec_idx`): which of the call's stack values are named-arg
@@ -2470,15 +2444,13 @@ impl CompiledCode {
         // consumer — the `.map`/`.grep` fast loop, for instance, pre-inserts the
         // closure's captured env into `self.env` only for keys ABSENT there, so it
         // reads a captured free var back from THIS frame's env by name — the env
-        // mirror must be current. Under `MUTSU_GATE_LOCAL_ENV_WRITE` a plain
+        // mirror must be current. Under the (B) per-store env-write a plain
         // lexical's store skips that mirror, leaving the decl-seed `Any`, so the
         // consumer reads a stale value. Fold every nested-closure free var that is
         // one of this frame's own locals back into `needs_env_sync` so its store
-        // keeps mirroring. Gated on the flag so the default build is byte-identical
-        // AND perf-neutral (no extra `flush_local_to_env` work when the gate is
-        // off); the cost only lands with the gate, and it never touches a
-        // hot-arithmetic loop local (those are not closure free variables).
-        if gate_local_env_write() {
+        // keeps mirroring. It never touches a hot-arithmetic loop local (those are
+        // not closure free variables).
+        {
             // Atomic-op targets (`⚛$x`, `$x ⚛= v`, `cas($x, …)`) resolve their
             // variable by NAME from env in the `__mutsu_*_var` builtin. Keep the
             // mirror current so a non-`atomicint` scalar is not read as its

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -154,13 +154,11 @@ impl Interpreter {
     /// `tail_call`: if true, raise a return-control exception with the result.
     /// Read the FIRST candidate's live rw-param value during a nextsame/callsame
     /// redispatch. The first candidate's body ran `$x = ...` before deferring, and
-    /// under the (B) env-write gate that mutation lands only in its VM local slot
+    /// under the (B) env-write policy that mutation lands only in its VM local slot
     /// (the env write is skipped) — so read the slot of the currently-executing
     /// frame (`self.current_code`/`self.locals`) first and fall back to env.
-    /// Under gate OFF, env mirrors the slot, so returning env directly is
-    /// byte-identical.
     fn first_candidate_rw_value(&self, first_param: &str) -> Option<Value> {
-        if crate::opcode::gate_local_env_write() && self.current_code != 0 {
+        if self.current_code != 0 {
             // SAFETY: `self.current_code` is the CompiledCode of the frame that is
             // synchronously executing this nextsame/callsame — the first candidate.
             let code = unsafe { &*(self.current_code as *const crate::opcode::CompiledCode) };

--- a/src/runtime/dispatch_proto_call.rs
+++ b/src/runtime/dispatch_proto_call.rs
@@ -27,14 +27,13 @@ impl Interpreter {
                 ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
                 _ => None,
             };
-            let proto_body_code: Option<&CompiledCode> =
-                if crate::opcode::gate_local_env_write() && self.current_code != 0 {
-                    // SAFETY: `self.current_code` is the CompiledCode of the compiled
-                    // proto-method body synchronously executing this `{*}` dispatch.
-                    Some(unsafe { &*(self.current_code as *const CompiledCode) })
-                } else {
-                    None
-                };
+            let proto_body_code: Option<&CompiledCode> = if self.current_code != 0 {
+                // SAFETY: `self.current_code` is the CompiledCode of the compiled
+                // proto-method body synchronously executing this `{*}` dispatch.
+                Some(unsafe { &*(self.current_code as *const CompiledCode) })
+            } else {
+                None
+            };
             let (args, rw_sources) = match invocant_class
                 .and_then(|cn| self.lookup_proto_method(&cn, &proto_name))
                 .and_then(|(_, proto)| {

--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -78,9 +78,8 @@ impl Interpreter {
                 // `Package(Any)` and returns `Any(Any)` instead of dying with
                 // X::Undeclared (roast S32-trig/e.t). Override those entries with the
                 // caller frame's LIVE slot values so the nested scope matches Raku's
-                // "EVAL runs in the caller's lexical scope". Gate-ON only; when off,
-                // env already carries the live values (byte-identical).
-                if crate::opcode::gate_local_env_write() && self.current_code != 0 {
+                // "EVAL runs in the caller's lexical scope".
+                if self.current_code != 0 {
                     // SAFETY: `self.current_code` is the CompiledCode of the frame
                     // synchronously invoking this `throws-like` Test routine.
                     let code =

--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -730,25 +730,19 @@ impl Interpreter {
                 .or_else(|| self.env().get("__mutsu_rw_map_topic__").cloned());
         }
 
-        // Sync state variables back using scoped keys. Under the
-        // MUTSU_GATE_LOCAL_ENV_WRITE gate a plain-lexical `state $s = $s + 10`
-        // skips its env mirror, so an env-first read would persist the pre-update
-        // value and the state would never accumulate — read the live SLOT first
-        // (seeded from the state store on entry, updated by the body's writes).
-        // The gate is NOT byte-neutral here in the default build: some state vars
-        // are mutated only through `env` by name (e.g. a `state` referenced from a
-        // regex replacement part updates env, not the slot — roast state.t #16), so
-        // OFF must keep the env-first read. Gate the slot-first order on the flag.
-        // A state var that IS env-synced (folded into `needs_env_sync` — e.g. this
-        // frame runs a dynamic `s///` whose replacement bumps the state by name)
-        // keeps its env mirror current, and that env value is the one the
-        // replacement actually wrote; read it env-first even under the gate so the
-        // bump is not lost (its slot stays at the pre-replacement value).
-        let state_slot_first = crate::opcode::gate_local_env_write();
+        // Sync state variables back using scoped keys. Under the (B) per-store
+        // env-write policy a plain-lexical `state $s = $s + 10` skips its env
+        // mirror, so an env-first read would persist the pre-update value and the
+        // state would never accumulate — read the live SLOT first (seeded from the
+        // state store on entry, updated by the body's writes). A state var that IS
+        // env-synced (folded into `needs_env_sync` — e.g. this frame runs a dynamic
+        // `s///` whose replacement bumps the state by name) keeps its env mirror
+        // current, and that env value is the one the replacement actually wrote;
+        // read it env-first so the bump is not lost (its slot stays at the
+        // pre-replacement value — roast state.t #16).
         for (slot, key) in &cc.state_locals {
             let local_name = &cc.locals[*slot];
-            let slot_authoritative =
-                state_slot_first && !cc.needs_env_sync.get(*slot).copied().unwrap_or(false);
+            let slot_authoritative = !cc.needs_env_sync.get(*slot).copied().unwrap_or(false);
             let val = if slot_authoritative {
                 self.locals
                     .get(*slot)

--- a/src/vm/vm_env_helpers.rs
+++ b/src/vm/vm_env_helpers.rs
@@ -1311,14 +1311,13 @@ impl Interpreter {
         }
     }
 
-    /// Under the (B) per-store env-write gate, return this frame's live local slot
+    /// Under the (B) per-store env-write, return this frame's live local slot
     /// value for `name` when the slot holds a real (non-Nil) value — the slot is
     /// the authoritative half while the env mirror is suppressed. Returns None
-    /// when the gate is off (so callers fall back to the env read and stay
-    /// byte-identical), when there is no local slot for `name`, or when the slot
-    /// is Nil (an uninitialized/absent local, where the env read — and any
-    /// autovivification it drives — is the right source). §1.5 helper — see
-    /// docs/lexical-scope-slot-campaign.md.
+    /// when there is no `plain_locals` slot for `name`, or when the slot is Nil (an
+    /// uninitialized/absent local, where the env read — and any autovivification it
+    /// drives — is the right source), so callers fall back to the env read. §1.5
+    /// helper — see docs/lexical-scope-slot-campaign.md.
     pub(super) fn gate_local_slot_value(&self, code: &CompiledCode, name: &str) -> Option<Value> {
         let slot = self.gate_local_slot(code, name)?;
         let val = self.locals.get(slot)?;
@@ -1331,17 +1330,14 @@ impl Interpreter {
 
     /// Slot index of a `(B)`-gate-authoritative local, or `None`.
     ///
-    /// Returns the slot only when the per-store env-write gate is ON **and** the
-    /// name is a `plain_locals` scalar — the only variables whose env mirror the
-    /// gate actually skips, making the slot the authoritative half. Aggregates
-    /// (`@a`/`%h`) always take the unconditional `set_env_with_main_alias` writer
-    /// (vm_var_assign_set_local.rs), so their env stays fresh while their slot may
-    /// hold a stale early snapshot — reading/mutating slot-first there would lose a
-    /// `%h is MixHash; %h<a>--` update (roast S02-types/mixhash.t, sethash.t).
+    /// Returns the slot only when the name is a `plain_locals` scalar — the only
+    /// variables whose env mirror the per-store env-write skips, making the slot
+    /// the authoritative half. Aggregates (`@a`/`%h`) always take the
+    /// unconditional `set_env_with_main_alias` writer (vm_var_assign_set_local.rs),
+    /// so their env stays fresh while their slot may hold a stale early snapshot —
+    /// reading/mutating slot-first there would lose a `%h is MixHash; %h<a>--`
+    /// update (roast S02-types/mixhash.t, sethash.t).
     pub(super) fn gate_local_slot(&self, code: &CompiledCode, name: &str) -> Option<usize> {
-        if !crate::opcode::gate_local_env_write() {
-            return None;
-        }
         let slot = self.find_local_slot(code, name)?;
         if !code.plain_locals.get(slot).copied().unwrap_or(false) {
             return None;

--- a/src/vm/vm_jit_helpers.rs
+++ b/src/vm/vm_jit_helpers.rs
@@ -320,7 +320,7 @@ pub(super) unsafe extern "C" fn call_method_mut(
     // JIT path unconditionally pulls `env[receiver]` into the caller's slot,
     // which is wrong when the callee env merely inherited a same-named binding
     // from its caller (a self-recursive `$tree` reverting to the caller's node)
-    // and, under the `MUTSU_GATE_LOCAL_ENV_WRITE` per-store env-write gate, when
+    // and, under the (B) per-store env-write, when
     // `env[receiver]` is a stale decl-seed while the live value lives only in
     // the slot (a hot `$io .= succ` loop frozen by a stale `env[io]` pull).
     let receiver_before: Option<Option<Value>> =

--- a/src/vm/vm_misc_block.rs
+++ b/src/vm/vm_misc_block.rs
@@ -204,43 +204,21 @@ impl Interpreter {
             for (name, value) in new_vars {
                 self.env_mut().insert_sym(name, value);
             }
-            if crate::opcode::gate_local_env_write() {
-                // (B)-gate: the per-store env mirror is suppressed, so re-seeding
-                // every slot from the restored env (below) would clobber a
-                // propagating outer var's LIVE in-block value with its stale
-                // decl-time seed — e.g. `my $ct = CT.new(...)` whose slot never
-                // mirrored into env, so a second `$ct.x` inside one interpolation
-                // read `Any`. The live in-block `self.locals` already holds the
-                // correct value for a propagating outer name (the block body read
-                // /mutated the slot directly). Revert ONLY the block's OWN isolated
-                // declarations (reverted to their pre-block value so they don't
-                // leak) and internal/special/dynamic slots; leave every other slot
-                // at its live value. This mirrors the env-side keep/revert decision
-                // above without depending on the env mirror.
-                for (idx, name) in code.locals.iter().enumerate() {
-                    let revert =
-                        isolate_set.contains(&strip_sigil(name)) || !is_plain_user_var(name);
-                    if revert && let Some(val) = saved_locals.get(idx) {
-                        self.locals[idx] = val.clone();
-                    }
-                }
-            } else {
-                self.locals = saved_locals;
-                // Re-read every local from env: after the block's env snapshot is
-                // restored above, env is the authoritative half of the dual store for
-                // this frame's names.
-                //
-                // This used to be guarded by "skip the locals whose slot is
-                // authoritative" — a condition on the old `simple_locals` flag that
-                // the compiler set for `$`-prefixed names only, and scalars are stored
-                // sigil-less (`my $x` -> `"x"`), so it was false for every slot and the
-                // skip never happened. The guard is gone rather than revived: this
-                // unconditional pull is the behavior every test has ever exercised, and
-                // it is why the env mirror (`flush_local_to_env`) is load-bearing here.
-                for (idx, name) in code.locals.iter().enumerate() {
-                    if let Some(val) = self.env().get(name).cloned() {
-                        self.locals[idx] = val;
-                    }
+            // (B) per-store env-write: the env mirror is suppressed, so re-seeding
+            // every slot from the restored env would clobber a propagating outer
+            // var's LIVE in-block value with its stale decl-time seed — e.g.
+            // `my $ct = CT.new(...)` whose slot never mirrored into env, so a second
+            // `$ct.x` inside one interpolation read `Any`. The live in-block
+            // `self.locals` already holds the correct value for a propagating outer
+            // name (the block body read/mutated the slot directly). Revert ONLY the
+            // block's OWN isolated declarations (reverted to their pre-block value so
+            // they don't leak) and internal/special/dynamic slots; leave every other
+            // slot at its live value. This mirrors the env-side keep/revert decision
+            // above without depending on the env mirror.
+            for (idx, name) in code.locals.iter().enumerate() {
+                let revert = isolate_set.contains(&strip_sigil(name)) || !is_plain_user_var(name);
+                if revert && let Some(val) = saved_locals.get(idx) {
+                    self.locals[idx] = val.clone();
                 }
             }
             self.stack.push(block_result);
@@ -310,12 +288,11 @@ impl Interpreter {
         // §1.4/§1.5: when the compiler baked THIS frame's slot for `name`, read the
         // pre-scope value straight from the live slot rather than from `env` by
         // name. The slot is always current; `env` is only a mirror and can be stale
-        // when the per-store env write is gated (MUTSU_GATE_LOCAL_ENV_WRITE) — a
-        // plain-lexical assignment `$x = ...` before this `temp`/`let` may not have
-        // mirrored into `env`, so an env-first read would snapshot the decl-seed
-        // `Any` instead of the real value. With the gate OFF the slot equals the
-        // env mirror, so this is byte-identical to the former env-first read. The
-        // matching restore side (`restore_let_value`) already prefers the baked slot.
+        // under the (B) per-store env-write — a plain-lexical assignment
+        // `$x = ...` before this `temp`/`let` may not have mirrored into `env`, so
+        // an env-first read would snapshot the decl-seed `Any` instead of the real
+        // value. The matching restore side (`restore_let_value`) already prefers the
+        // baked slot.
         let old_val = match slot {
             Some(s) if (s as usize) < self.locals.len() => self.locals[s as usize].clone(),
             _ => self

--- a/src/vm/vm_misc_scope.rs
+++ b/src/vm/vm_misc_scope.rs
@@ -418,39 +418,28 @@ impl Interpreter {
         // The `MUTSU_NO_SHADOW_SLOTS` opt-out has no distinct shadow slots, so it
         // still needs the whole-array restore.
         if let Some(saved) = saved_locals {
-            if crate::opcode::gate_local_env_write() {
-                // (B)-gate: the per-store env mirror is suppressed, so
-                // `restored_env` (name-keyed, env-derived) holds a STALE value for
-                // any enclosing name assigned inside the block — re-seeding a
-                // propagating slot from it would clobber the live in-block value
-                // with the decl-time seed (the `my $ct = CT.new(...)` -> `Any`
-                // clobber that broke a second `$ct.x` inside one interpolation).
-                // Without distinct shadow slots the pre-block LIVE value for every
-                // slot is available in the `saved` locals snapshot, so this is
-                // slot-authoritative without depending on env: leave a PROPAGATING
-                // enclosing slot at its live in-block value (every store wrote the
-                // slot) and revert only NON-propagating slots to their pre-block
-                // value — a shadowing decl shares the outer slot, so `saved[idx]`
-                // IS the outer value; a fresh `my` slot's pre-block value is Nil.
-                for (idx, name) in code.locals.iter().enumerate() {
-                    let non_propagating = name == "_"
-                        || name.starts_with('*')
-                        || code
-                            .local_sym(idx)
-                            .is_some_and(|s| block_declared.contains(&s));
-                    if non_propagating {
-                        self.locals[idx] = saved.get(idx).cloned().unwrap_or(Value::NIL);
-                    }
-                }
-            } else {
-                // MUTSU_NO_SHADOW_SLOTS opt-out: no distinct shadow slots, so the
-                // whole-array restore is needed, and the propagated inner values are
-                // then re-applied from `restored_env` by name.
-                self.locals = saved;
-                for (idx, name) in code.locals.iter().enumerate() {
-                    if let Some(val) = restored_env.get(name).cloned() {
-                        self.locals[idx] = val;
-                    }
+            // MUTSU_NO_SHADOW_SLOTS opt-out: no distinct shadow slots. The (B)
+            // per-store env-write suppresses the env mirror, so `restored_env`
+            // (name-keyed, env-derived) holds a STALE value for any enclosing name
+            // assigned inside the block — re-seeding a propagating slot from it
+            // would clobber the live in-block value with the decl-time seed (the
+            // `my $ct = CT.new(...)` -> `Any` clobber that broke a second `$ct.x`
+            // inside one interpolation). Without distinct shadow slots the pre-block
+            // LIVE value for every slot is available in the `saved` locals snapshot,
+            // so this is slot-authoritative without depending on env: leave a
+            // PROPAGATING enclosing slot at its live in-block value (every store
+            // wrote the slot) and revert only NON-propagating slots to their
+            // pre-block value — a shadowing decl shares the outer slot, so
+            // `saved[idx]` IS the outer value; a fresh `my` slot's pre-block value
+            // is Nil.
+            for (idx, name) in code.locals.iter().enumerate() {
+                let non_propagating = name == "_"
+                    || name.starts_with('*')
+                    || code
+                        .local_sym(idx)
+                        .is_some_and(|s| block_declared.contains(&s));
+                if non_propagating {
+                    self.locals[idx] = saved.get(idx).cloned().unwrap_or(Value::NIL);
                 }
             }
         } else {

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -275,21 +275,19 @@ impl Interpreter {
         // The baked slot is for `original_var_name` (the pre-alias target name), so
         // the sigilless-alias write-back below uses it directly — also gated OFF.
         let orig_slot = if shadow_active { target_slot } else { None };
-        // (B) per-store env-write gate: a scalar-held container
+        // (B) per-store env-write: a scalar-held container
         // (`my $b = "hi".encode; $b[0] = 200`, `my $m = %h.Map; $m<c> = 9`) skips
-        // its env mirror under the gate, so the env reads throughout this
-        // env-centric handler would see the stale `my`-decl seed (Any) instead of
-        // the live Blob/Map — and an immutable-container element assignment would
-        // silently NOT throw. Seed env from the authoritative slot before the
-        // handler runs. Restricted to a SCALAR target (bare name, no `@`/`%`
-        // sigil): an `@`/`%` aggregate keeps its container in env (aggregate reads
-        // are env-first, and env may hold a more-reified lazy/range representation
-        // than the slot — seeding from the slot would clobber that). Only fires
-        // when the slot holds a real value whose variant differs from the env
-        // mirror (the scalar decl seed is a type object, so it always differs from
-        // a live container). Gate OFF: byte-identical (skipped).
-        if crate::opcode::gate_local_env_write()
-            && !var_name.starts_with('@')
+        // its env mirror, so the env reads throughout this env-centric handler
+        // would see the stale `my`-decl seed (Any) instead of the live Blob/Map —
+        // and an immutable-container element assignment would silently NOT throw.
+        // Seed env from the authoritative slot before the handler runs. Restricted
+        // to a SCALAR target (bare name, no `@`/`%` sigil): an `@`/`%` aggregate
+        // keeps its container in env (aggregate reads are env-first, and env may
+        // hold a more-reified lazy/range representation than the slot — seeding from
+        // the slot would clobber that). Only fires when the slot holds a real value
+        // whose variant differs from the env mirror (the scalar decl seed is a type
+        // object, so it always differs from a live container).
+        if !var_name.starts_with('@')
             && !var_name.starts_with('%')
             && let Some(slot) = self.resolve_local_slot(code, eff_slot, &var_name)
         {

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1623,15 +1623,13 @@ impl Interpreter {
         if matches!(val.view(), ValueView::LazyThunk(..)) {
             self.mark_readonly(name);
         }
-        // `(B)` per-store env-write gate (docs/lexical-scope-slot-campaign.md).
-        // Default OFF (byte-identical). Under `MUTSU_GATE_LOCAL_ENV_WRITE=1` a
-        // slot-authoritative plain lexical skips its env mirror: the slot is the
-        // single source of truth. Excludes binds/constants (env-shape carriers),
-        // captured/reflective frames (read the caller's env by name), and names
-        // still in `needs_env_sync` (a mechanism consumer). The term-symbol block
-        // and `:=` alias chain below stay unconditional.
-        let skip_env_write = crate::opcode::gate_local_env_write()
-            && !is_bind
+        // `(B)` per-store env-write: a slot-authoritative plain lexical skips its
+        // env mirror — the slot is the single source of truth, so env-COW drops
+        // the write (docs/lexical-scope-slot-campaign.md). Excludes binds/constants
+        // (env-shape carriers), captured/reflective frames (read the caller's env
+        // by name), and names still in `needs_env_sync` (a mechanism consumer). The
+        // term-symbol block and `:=` alias chain below stay unconditional.
+        let skip_env_write = !is_bind
             && !is_constant
             && !code.captures_env_by_name
             && !code.needs_env_sync.get(idx).copied().unwrap_or(true)


### PR DESCRIPTION
## Summary

The Plan A flip (#4942, 2026-07-20) made `gate_local_env_write()` default ON, and it has now soaked in `main` across many green CI cycles (gc-stress / jit-stress / roast) with no latent flaky reports. This PR deletes the gate: the **(B) per-store env-write** is now a permanent, unconditional behavior — a slot-authoritative plain lexical skips its env mirror, the slot is the single source of truth, and env-COW drops the write.

## What changed

- **Unconditionalize the 9 `gate_local_env_write()` sites** (keeping their ON branch): the env-mirror store skip in `exec_set_local_op_inner` (the core site), the `compute_needs_env_sync` closure-capture / lazy-body fold, the nextsame/proto rw-redispatch slot-first reads, the `throws-like` nested-scope slot refresh, the block-restore / scope-restore slot-authoritative reverts, the state-var slot-first save-back, the `gate_local_slot` helper, and the index-assign scalar-container env seed.
- **Delete the OFF-side dead code**: the env-mirror-every-store branch and the by-name re-seed branches that were only reachable via `MUTSU_GATE_LOCAL_ENV_WRITE=0`.
- **Remove the `gate_local_env_write()` function** and the `MUTSU_GATE_LOCAL_ENV_WRITE` env plumbing; refresh the doc comments that referenced the (now nonexistent) env var.

## Risk

Behavior is **identical to current `main`'s default** (gate ON) — this only removes the opt-out path (dead code). The shadow-slots gate (`MUTSU_SHADOW_SLOTS`, §1.4) is untouched.

## Testing

- `make test` PASS (Files=2081, Tests=19687).
- All 18 `t/gate-b-*.t` pins pass (they cover every mechanism-consumer fold).
- JIT-sensitive pins pass under `MUTSU_JIT=on MUTSU_JIT_THRESHOLD=2` (mechanism #3 parity).
- CI's full roast + gc-stress + jit-stress is the comprehensive net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)