### PR TITLE
fix(doc-diff-harness): per-process scratch file so parallel scans do not race

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1054,9 +1054,12 @@ the backlog.
       **Signal gate passed** (2026-07-18, 8 core Type files): 270 raku-clean comparisons → **50
       high-signal divergences (18.5%)**, genuine and clustering by root cause. The premise holds; the
       campaign is justified.
-- [ ] Reusable substrate for 8.2 / 8.3 / 8.4 and any future fuzz corpus — extend the corpus beyond the
-      core Type files (all of `Type/` + `Language/`, then a real-module corpus), and grow the
-      non-determinism / error-example skip heuristics as new noise shows up.
+- [x] Reusable substrate for 8.2 / 8.3 / 8.4 — the harness is parallel-safe (per-PID scratch file) and
+      `scripts/doc-diff-sweep.sh` fans the whole corpus out across worker processes. **First full-corpus
+      sweep landed (2026-07-21): 443 files, 156 with signal — 335 output-mismatch + 202 mutsu-crash +
+      134 raku-drift.** The ranked, tracked backlog is [docs/doc-diff-backlog.md](docs/doc-diff-backlog.md)
+      (the QA analogue of BLOCKERS.md; re-sweep to refresh). Still TODO: a real-module corpus, and growing
+      the non-determinism / error-example skip heuristics as new noise shows up.
 - [ ] **First backlog item from the run: sequence/lazy argument truncation** — `1, 3 ... 11` (and lazy
       `gather`/`Seq`) passed as a routine/method argument is materialised to only its first two
       elements (`@foo.prepend: 1,3...11` → `[1 3 …]`; `600.polymod(lazy …)` → `(600)`). One root cause,

--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -1,0 +1,226 @@
+# doc-diff backlog — raku-doc differential findings
+
+Tracked ledger of every `raku-doc` example where **mutsu** diverges from reference
+**raku**, produced by the doc-diff harness. This is the "ranked backlog of minimal
+repros" that [PLAN.md](../PLAN.md) §8.1 calls for — the QA-campaign analogue of
+[TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
+
+- Harness + method: [docs/qa-doc-diff-harness.md](qa-doc-diff-harness.md)
+- Tools: `scripts/doc-diff-harness.raku` (one run), `scripts/doc-diff-sweep.sh` (whole corpus, parallel)
+
+## How to refresh
+
+```
+cargo build
+scripts/doc-diff-sweep.sh              # -j8 over Type/ + Language/, ~15 min
+```
+
+Outputs (all under `tmp/sweep/`, gitignored): `reports/<file>.txt` (per-file
+minimal-repro reports), `progress.txt` (one stats line per file), `summary.txt`
+(files ranked by `mismatch + crash`). Regenerate the survey table below from
+`summary.txt`, and the counts drop as fixes land — that is the visible progress
+signal.
+
+**Always re-verify a finding directly before treating it as a real bug.** The
+harness oracle-gates on raku, but doc examples drift and the harness can only compare
+`# OUTPUT:`-style blocks. `raku-drift` findings (raku itself no longer matches the
+doc) are version skew, not mutsu bugs — lowest priority.
+
+## Corpus snapshot
+
+- **Date:** 2026-07-21 · debug `mutsu` at main ≈ `0292015a` (includes #4963/#4967/#4979)
+- **443 files scanned · 156 have signal**
+- **match = 1959 · output-mismatch = 335 · mutsu-crash = 202 · raku-drift = 134**
+- High-signal total (mismatch + crash) by corpus: **Type 287 · Language 250**
+
+> Historical note: before the harness was made parallel-safe (#4982), sweeps run
+> concurrently raced on a shared scratch file and manufactured phantom divergences
+> (e.g. `syntax.rakudoc` reported 19 mismatches, only 3 real). Any pre-#4982 scan
+> numbers — and memory/notes calling a file "block-misalignment garbage" — are
+> unreliable; re-sweep instead.
+
+## Triaged
+
+### Resolved (will drop from the next sweep)
+- `$.name()` self-accessor interpolation left `()` literal — **#4979**.
+- Harness scratch-file race producing phantom findings — **#4982** (this is why the
+  survey below supersedes every earlier scan).
+
+### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
+These root causes account for a large share of the survey's `mism`/`crash` and are
+intentionally deferred; see PLAN.md §8.5 and the ADRs:
+- **Nil-vs-Any identity knot** — `Nil.rakudoc`, `Mu.rakudoc`, uninit-scalar `.raku`/gist. No clean safe subset (closed #4822 twice).
+- **Lazy-list / container-repr (Track-B, fused with GC per ADR-0001)** — `List.rakudoc`, `Iterator.rakudoc`, `Iterable.rakudoc`, `Seq.rakudoc`, `list.rakudoc` (`loop`/`while`-as-lazy-list, flat-itemization depth).
+- **`and`/`or`/`not` word-logical precedence** — `operators.rakudoc`, `control.rakudoc`, `traps.rakudoc` (looser than list-prefix; needs statement-level re-association).
+- **FatRat-vs-Rat repr tag** — `Rat`/`FatRat`/`numerics` (`.^name` of a big FatRat is `Rat`).
+- **WHICH-keyed QuantHash storage** — `QuantHash.rakudoc`, `Baggy`, `setbagmix` (Set/Bag key by stringification).
+- **Custom `does Iterable`/`does Iterator` protocol** — `iterating.rakudoc`, `Iterator.rakudoc`.
+
+### Untriaged
+Everything in the survey below not listed above. The per-file minimal repros live in
+`tmp/sweep/reports/<file>.txt` after a sweep — start from the highest-signal file and
+re-verify each block against `raku` before writing a fix.
+
+## Survey — files with divergences (high-signal first)
+
+`mism` = output-mismatch · `crash` = mutsu exited non-zero where raku succeeded ·
+`drift` = raku-drift-from-doc (version skew, low priority).
+
+| file (under raku-doc/doc/) | mism | crash | drift |
+|---|---:|---:|---:|
+| Language/regexes.rakudoc | 20 | 9 | 3 |
+| Language/operators.rakudoc | 13 | 13 | 1 |
+| Type/Any.rakudoc | 8 | 10 | 4 |
+| Language/traps.rakudoc | 15 | 2 | 4 |
+| Type/List.rakudoc | 3 | 12 | 3 |
+| Language/control.rakudoc | 6 | 7 | 1 |
+| Type/Str.rakudoc | 9 | 3 | 0 |
+| Language/variables.rakudoc | 7 | 4 | 5 |
+| Type/IO/Path.rakudoc | 9 | 1 | 1 |
+| Language/list.rakudoc | 6 | 3 | 3 |
+| Language/structures.rakudoc | 6 | 3 | 2 |
+| Type/Iterator.rakudoc | 4 | 5 | 2 |
+| Language/objects.rakudoc | 5 | 3 | 3 |
+| Language/perl-nutshell.rakudoc | 7 | 0 | 1 |
+| Language/typesystem.rakudoc | 6 | 1 | 3 |
+| Type/Test.rakudoc | 6 | 1 | 0 |
+| Type/Capture.rakudoc | 6 | 1 | 0 |
+| Type/IO/Handle.rakudoc | 5 | 1 | 2 |
+| Language/subscripts.rakudoc | 5 | 1 | 0 |
+| Language/py-nutshell.rakudoc | 5 | 1 | 0 |
+| Language/mop.rakudoc | 4 | 2 | 0 |
+| Language/functions.rakudoc | 4 | 2 | 0 |
+| Type/Match.rakudoc | 3 | 3 | 0 |
+| Type/Range.rakudoc | 2 | 4 | 0 |
+| Type/independent-routines.rakudoc | 1 | 5 | 2 |
+| Type/Parameter.rakudoc | 1 | 5 | 1 |
+| Language/numerics.rakudoc | 5 | 0 | 2 |
+| Type/Mu.rakudoc | 4 | 1 | 2 |
+| Language/concurrency.rakudoc | 4 | 1 | 1 |
+| Language/grammars.rakudoc | 3 | 2 | 2 |
+| Type/Proc/Async.rakudoc | 3 | 2 | 0 |
+| Language/syntax.rakudoc | 3 | 2 | 0 |
+| Type/Cool.rakudoc | 1 | 4 | 5 |
+| Language/nativecall.rakudoc | 1 | 4 | 0 |
+| Type/Dateish.rakudoc | 0 | 5 | 0 |
+| Language/experimental.rakudoc | 0 | 5 | 0 |
+| Type/IO/CatHandle.rakudoc | 4 | 0 | 1 |
+| Type/CallFrame.rakudoc | 4 | 0 | 1 |
+| Language/unicode.rakudoc | 4 | 0 | 1 |
+| Language/hashmap.rakudoc | 4 | 0 | 1 |
+| Type/Routine.rakudoc | 3 | 1 | 1 |
+| Type/Pair.rakudoc | 3 | 1 | 1 |
+| Language/faq.rakudoc | 3 | 1 | 0 |
+| Type/DateTime.rakudoc | 2 | 2 | 1 |
+| Type/Backtrace.rakudoc | 1 | 3 | 0 |
+| Type/Enumeration.rakudoc | 0 | 4 | 1 |
+| Language/containers.rakudoc | 3 | 0 | 4 |
+| Type/IO/Spec/Win32.rakudoc | 3 | 0 | 2 |
+| Type/IO/Spec/Unix.rakudoc | 3 | 0 | 2 |
+| Type/Nil.rakudoc | 3 | 0 | 1 |
+| Type/Array.rakudoc | 3 | 0 | 1 |
+| Type/Version.rakudoc | 3 | 0 | 0 |
+| Type/QuantHash.rakudoc | 3 | 0 | 0 |
+| Type/Iterable.rakudoc | 3 | 0 | 0 |
+| Type/IO/Path/Parts.rakudoc | 3 | 0 | 0 |
+| Language/perl-var.rakudoc | 3 | 0 | 0 |
+| Type/Hash.rakudoc | 2 | 1 | 2 |
+| Type/Metamodel/DefiniteHOW.rakudoc | 2 | 1 | 0 |
+| Type/Label.rakudoc | 2 | 1 | 0 |
+| Language/js-nutshell.rakudoc | 2 | 1 | 0 |
+| Language/signatures.rakudoc | 1 | 2 | 7 |
+| Type/Attribute.rakudoc | 1 | 2 | 1 |
+| Type/Metamodel/EnumHOW.rakudoc | 1 | 2 | 0 |
+| Type/Code.rakudoc | 0 | 3 | 3 |
+| Type/Metamodel/Mixins.rakudoc | 0 | 3 | 0 |
+| Language/nativetypes.rakudoc | 0 | 3 | 0 |
+| Type/Junction.rakudoc | 2 | 0 | 3 |
+| Type/Map.rakudoc | 2 | 0 | 2 |
+| Type/Baggy.rakudoc | 2 | 0 | 2 |
+| Type/Seq.rakudoc | 2 | 0 | 1 |
+| Type/Scalar.rakudoc | 2 | 0 | 1 |
+| Type/Real.rakudoc | 2 | 0 | 0 |
+| Type/IO/Spec/Cygwin.rakudoc | 2 | 0 | 0 |
+| Language/statement-prefixes.rakudoc | 2 | 0 | 0 |
+| Language/phasers.rakudoc | 2 | 0 | 0 |
+| Language/perl-func.rakudoc | 2 | 0 | 0 |
+| Language/iterating.rakudoc | 2 | 0 | 0 |
+| Language/glossary.rakudoc | 2 | 0 | 0 |
+| Language/exceptions.rakudoc | 2 | 0 | 0 |
+| Type/SetHash.rakudoc | 1 | 1 | 2 |
+| Type/Sub.rakudoc | 1 | 1 | 1 |
+| Type/Metamodel/MethodContainer.rakudoc | 1 | 1 | 1 |
+| Type/X/AdHoc.rakudoc | 1 | 1 | 0 |
+| Type/Metamodel/ParametricRoleHOW.rakudoc | 1 | 1 | 0 |
+| Type/Metamodel/ParametricRoleGroupHOW.rakudoc | 1 | 1 | 0 |
+| Type/Metamodel/Documenting.rakudoc | 1 | 1 | 0 |
+| Language/traits.rakudoc | 1 | 1 | 0 |
+| Language/pod.rakudoc | 1 | 1 | 0 |
+| Language/classtut.rakudoc | 1 | 1 | 0 |
+| Type/Unicode.rakudoc | 0 | 2 | 0 |
+| Type/Method.rakudoc | 0 | 2 | 0 |
+| Type/Metamodel/Trusting.rakudoc | 0 | 2 | 0 |
+| Type/Lock/Async.rakudoc | 0 | 2 | 0 |
+| Type/Formatter.rakudoc | 0 | 2 | 0 |
+| Type/Date.rakudoc | 0 | 2 | 0 |
+| Type/Mix.rakudoc | 1 | 0 | 2 |
+| Type/Setty.rakudoc | 1 | 0 | 1 |
+| Type/Set.rakudoc | 1 | 0 | 1 |
+| Language/io-guide.rakudoc | 1 | 0 | 1 |
+| Language/contexts.rakudoc | 1 | 0 | 1 |
+| Type/X/TypeCheck/Binding.rakudoc | 1 | 0 | 0 |
+| Type/X/TypeCheck/Assignment.rakudoc | 1 | 0 | 0 |
+| Type/X/Str/Match/x.rakudoc | 1 | 0 | 0 |
+| Type/X/Proc/Async/MustBeStarted.rakudoc | 1 | 0 | 0 |
+| Type/X/Proc/Async/CharsOrBytes.rakudoc | 1 | 0 | 0 |
+| Type/X/Phaser/PrePost.rakudoc | 1 | 0 | 0 |
+| Type/X/Numeric/CannotConvert.rakudoc | 1 | 0 | 0 |
+| Type/X/Mixin/NotComposable.rakudoc | 1 | 0 | 0 |
+| Type/X/Method/InvalidQualifier.rakudoc | 1 | 0 | 0 |
+| Type/X/Cannot/Empty.rakudoc | 1 | 0 | 0 |
+| Type/Variable.rakudoc | 1 | 0 | 0 |
+| Type/StrDistance.rakudoc | 1 | 0 | 0 |
+| Type/Slip.rakudoc | 1 | 0 | 0 |
+| Type/Signature.rakudoc | 1 | 0 | 0 |
+| Type/Signal.rakudoc | 1 | 0 | 0 |
+| Type/Sequence.rakudoc | 1 | 0 | 0 |
+| Type/Proc.rakudoc | 1 | 0 | 0 |
+| Type/Metamodel/PackageHOW.rakudoc | 1 | 0 | 0 |
+| Type/Metamodel/MultipleInheritance.rakudoc | 1 | 0 | 0 |
+| Type/Grammar.rakudoc | 1 | 0 | 0 |
+| Type/Exception.rakudoc | 1 | 0 | 0 |
+| Type/Complex.rakudoc | 1 | 0 | 0 |
+| Type/Buf.rakudoc | 1 | 0 | 0 |
+| Type/Block.rakudoc | 1 | 0 | 0 |
+| Type/Associative.rakudoc | 1 | 0 | 0 |
+| Type/Allomorph.rakudoc | 1 | 0 | 0 |
+| Language/using-modules/introduction.rakudoc | 1 | 0 | 0 |
+| Language/regexes-best-practices.rakudoc | 1 | 0 | 0 |
+| Language/rb-nutshell.rakudoc | 1 | 0 | 0 |
+| Language/quoting.rakudoc | 1 | 0 | 0 |
+| Language/pragmas.rakudoc | 1 | 0 | 0 |
+| Language/math.rakudoc | 1 | 0 | 0 |
+| Language/ipc.rakudoc | 1 | 0 | 0 |
+| Language/haskell-to-p6.rakudoc | 1 | 0 | 0 |
+| Language/grammar_tutorial.rakudoc | 1 | 0 | 0 |
+| Type/BagHash.rakudoc | 0 | 1 | 4 |
+| Type/Metamodel/TypePretense.rakudoc | 0 | 1 | 1 |
+| Type/Compiler.rakudoc | 0 | 1 | 1 |
+| Type/X/TypeCheck/Splice.rakudoc | 0 | 1 | 0 |
+| Type/X/ControlFlow.rakudoc | 0 | 1 | 0 |
+| Type/Proxy.rakudoc | 0 | 1 | 0 |
+| Type/PositionalBindFailover.rakudoc | 0 | 1 | 0 |
+| Type/Metamodel/Versioning.rakudoc | 0 | 1 | 0 |
+| Type/Metamodel/Stashing.rakudoc | 0 | 1 | 0 |
+| Type/Lock/ConditionVariable.rakudoc | 0 | 1 | 0 |
+| Type/IO/Special.rakudoc | 0 | 1 | 0 |
+| Type/IO/Notification/Change.rakudoc | 0 | 1 | 0 |
+| Type/IO/ArgFiles.rakudoc | 0 | 1 | 0 |
+| Type/HyperWhatever.rakudoc | 0 | 1 | 0 |
+| Type/CompUnit/Repository/FileSystem.rakudoc | 0 | 1 | 0 |
+| Type/Callable.rakudoc | 0 | 1 | 0 |
+| Type/Bool.rakudoc | 0 | 1 | 0 |
+| Language/using-modules/code.rakudoc | 0 | 1 | 0 |
+| Language/unicode_entry.rakudoc | 0 | 1 | 0 |
+| Language/optut.rakudoc | 0 | 1 | 0 |
+| Language/newline.rakudoc | 0 | 1 | 0 |

--- a/docs/qa-doc-diff-harness.md
+++ b/docs/qa-doc-diff-harness.md
@@ -41,6 +41,27 @@ The report groups findings by kind (`output-mismatch`, `mutsu-error`,
 `raku-drift-from-doc`), each with the exact program, raku stdout, and mutsu
 stdout/stderr — i.e. a ready-made minimal repro.
 
+The harness writes each candidate program to a per-PID scratch file
+(`tmp/ddh/prog-<pid>.raku`), so multiple invocations may run **concurrently**
+without clobbering each other.
+
+### Sweeping the whole corpus in parallel
+
+A single invocation processes its files serially, so the full ~440-file corpus
+takes hours. `scripts/doc-diff-sweep.sh` fans the corpus out across worker
+processes (one report per file) and writes an aggregate ranked by signal:
+
+```
+scripts/doc-diff-sweep.sh [-j N] [-o OUTDIR] [-m MUTSU] [ROOT ...]
+```
+
+Defaults: `-j8`, `-o tmp/sweep`, `-m target/debug/mutsu`, corpus = Type +
+Language. Outputs `OUTDIR/reports/<file>.txt` (per file), `OUTDIR/progress.txt`
+(one stats line per file), and `OUTDIR/summary.txt` (corpus totals + files
+ranked by `mismatch + crash`, high-signal first). Always re-verify a finding
+directly before treating it as a real bug — doc examples drift, and version
+drift is bucketed separately as `raku-drift-from-doc`.
+
 ## First run (2026-07-18, 8 core Type files: Str/Array/List/Hash/Num/Rat/Range/Map)
 
 525 blocks extracted → 270 raku-clean comparisons → **50 high-signal divergences

--- a/scripts/doc-diff-harness.raku
+++ b/scripts/doc-diff-harness.raku
@@ -32,6 +32,10 @@ sub MAIN(
     note "Extracted { +@blocks } candidate code blocks.";
 
     mkdir 'tmp/ddh' unless 'tmp/ddh'.IO.d;
+    # Per-process scratch file so concurrent harness invocations (a parallel sweep
+    # over many files) never clobber each other's program between the raku run and
+    # the mutsu run — a shared path races and yields phantom "divergences".
+    my $prog-path = "tmp/ddh/prog-{$*PID}.raku";
 
     my %stat = skipped-marker => 0, skipped-nondet => 0,
                no-oracle => 0, match => 0, mismatch => 0,
@@ -53,7 +57,7 @@ sub MAIN(
         }
 
         my $program = %b<preamble> ?? %b<preamble> ~ "\n" ~ %b<code> !! %b<code>;
-        my $path = "tmp/ddh/prog.raku";
+        my $path = $prog-path;
         spurt $path, $program;
 
         my $r = run-capture('raku', $path, $timeout);
@@ -93,6 +97,7 @@ sub MAIN(
         }
     }
 
+    unlink $prog-path if $prog-path.IO.e;
     write-report($report, %stat, @findings);
     print-summary(%stat, @findings, $report);
 }

--- a/scripts/doc-diff-sweep.sh
+++ b/scripts/doc-diff-sweep.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# doc-diff-sweep.sh — run the doc-diff harness over the WHOLE raku-doc corpus in
+# parallel, one report per file, plus an aggregate summary sorted by signal.
+#
+# The harness (scripts/doc-diff-harness.raku) compares each runnable raku-doc
+# example under reference `raku` (the oracle) vs `mutsu` and reports divergences.
+# A single harness invocation processes its files serially, so sweeping the full
+# ~440-file corpus that way takes hours. This driver fans the corpus out across
+# `-P` worker processes; the harness writes to a per-PID scratch file
+# (tmp/ddh/prog-<pid>.raku) so concurrent workers never race.
+#
+# Usage:
+#   scripts/doc-diff-sweep.sh [-j N] [-o OUTDIR] [-m MUTSU] [ROOT ...]
+#     -j N       parallel workers          (default: 8)
+#     -o OUTDIR  report directory          (default: tmp/sweep)
+#     -m MUTSU   mutsu binary              (default: target/debug/mutsu)
+#     ROOT ...   files or dirs to scan     (default: raku-doc/doc/Type
+#                                                    raku-doc/doc/Language)
+#
+# Outputs:
+#   OUTDIR/reports/<sanitized-path>.txt   one harness report per file
+#   OUTDIR/progress.txt                   "<file> :: # stats: ..." per file
+#   OUTDIR/summary.txt                    corpus totals + files ranked by
+#                                         (mismatch + crash), high-signal first
+#
+# Re-verify each finding directly before treating it as a real bug — the oracle
+# gate keeps the report honest, but doc examples drift and some divergences are
+# raku-version drift (bucketed separately as `raku-drift-from-doc`).
+set -u
+
+JOBS=8
+OUTDIR="tmp/sweep"
+MUTSU="target/debug/mutsu"
+while getopts "j:o:m:" opt; do
+  case "$opt" in
+    j) JOBS="$OPTARG" ;;
+    o) OUTDIR="$OPTARG" ;;
+    m) MUTSU="$OPTARG" ;;
+    *) echo "usage: $0 [-j N] [-o OUTDIR] [-m MUTSU] [ROOT ...]" >&2; exit 2 ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+ROOTS=("$@")
+if [ "${#ROOTS[@]}" -eq 0 ]; then
+  ROOTS=(raku-doc/doc/Type raku-doc/doc/Language)
+fi
+
+REPORTS="$OUTDIR/reports"
+mkdir -p "$REPORTS"
+FILELIST="$OUTDIR/all-files.txt"
+find "${ROOTS[@]}" -name '*.rakudoc' | sort > "$FILELIST"
+echo "Sweeping $(wc -l < "$FILELIST") files with -j$JOBS ..." >&2
+
+run_one() {
+  local f="$1"
+  local safe out stats
+  safe=$(echo "$f" | sed 's|raku-doc/doc/||; s|/|__|g; s|\.rakudoc$||')
+  out="$REPORTS/${safe}.txt"
+  timeout 300 raku scripts/doc-diff-harness.raku --mutsu="$MUTSU" --report="$out" "$f" >/dev/null 2>&1
+  stats=$(grep -m1 'stats:' "$out" 2>/dev/null || echo "# stats: (no report)")
+  echo "${f} :: ${stats}"
+}
+export -f run_one
+export REPORTS MUTSU
+
+xargs -P "$JOBS" -I{} bash -c 'run_one "$@"' _ {} < "$FILELIST" \
+  > "$OUTDIR/progress.txt" 2>&1
+
+# Aggregate: corpus totals + files ranked by (mismatch + crash), high-signal first.
+# Portable token parse (no gawk 3-arg match); the stats line is a run of key=value
+# tokens, so split and read each key.
+awk '
+  / :: / {
+    idx = index($0, " :: "); file = substr($0, 1, idx - 1)
+    m = 0; mm = 0; cr = 0; dr = 0
+    nn = split(substr($0, idx), T, " ")
+    for (k = 1; k <= nn; k++) {
+      if      (T[k] ~ /^match=/)        { s = T[k]; sub(/^match=/, "", s);        m  = s + 0 }
+      else if (T[k] ~ /^mismatch=/)     { s = T[k]; sub(/^mismatch=/, "", s);     mm = s + 0 }
+      else if (T[k] ~ /^mutsu-crash=/)  { s = T[k]; sub(/^mutsu-crash=/, "", s);  cr = s + 0 }
+      else if (T[k] ~ /^raku-drift=/)   { s = T[k]; sub(/^raku-drift=/, "", s);   dr = s + 0 }
+    }
+    tm += m; tmm += mm; tcr += cr; tdr += dr
+    sig = mm + cr
+    if (sig > 0) printf "%4d  mism=%-3d crash=%-3d drift=%-3d  %s\n", sig, mm, cr, dr, file
+  }
+  END { printf "\n==== corpus totals ====\nmatch=%d  mismatch=%d  crash=%d  raku-drift=%d\n", tm, tmm, tcr, tdr }
+' "$OUTDIR/progress.txt" | sort -rn > "$OUTDIR/summary.txt"
+
+echo "SWEEP-DONE" >> "$OUTDIR/progress.txt"
+echo "Reports: $REPORTS/    Summary: $OUTDIR/summary.txt" >&2


### PR DESCRIPTION
## Summary

The doc-diff QA harness (`scripts/doc-diff-harness.raku`, PLAN.md §8) spurted every
candidate program to a single shared path `tmp/ddh/prog.raku`, then ran `raku` and
`mutsu` against it in sequence. When several harness invocations run **concurrently**
(a parallel sweep over many doc files), one process overwrites `prog.raku` between
another's raku-run and mutsu-run, so mutsu executes the *wrong* program and the
harness reports a **phantom divergence** — e.g. a `%*ENV<PATH>` dump attributed to
`if True { say "Hello" }`.

Fix: use a per-PID scratch file (`tmp/ddh/prog-<pid>.raku`) and unlink it at the end.

## Impact

Measured on a 3-way parallel scan of `Language/syntax.rakudoc`:

| | match | mismatch | crash |
|---|---|---|---|
| shared path (racing) | 13 | 19 | 3 |
| per-process path | 36 | 3 | 2 |

~16 of the 19 "mismatches" were race artifacts, not real mutsu bugs. This unblocks a
reliable **parallel** sweep of the whole raku-doc corpus (it also explains several
past scan reports that were written off as "block-misalignment garbage" — they were
this race).

No mutsu behavior change; harness-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)