### PR TITLE
fix: bracket meta-op compound assign on indexed lvalues; is export on grammars

### DIFF
--- a/src/parser/expr/precedence/list_infix_loop.rs
+++ b/src/parser/expr/precedence/list_infix_loop.rs
@@ -195,7 +195,13 @@ fn parse_list_infix_loop_impl<'a>(
             }
         }
         // Bracket infix operators: [+], [R-], [Z*], [Z[cmp]], [blue], etc.
-        if let Some(bracket_infix) = parse_bracket_infix_op(r) {
+        // But `[op]=` (immediately followed by `=`, not `==`) is a bracket
+        // meta-op *compound assignment* (`%h<k> [R//]= $v`), not an infix op —
+        // bail so the enclosing assignment handler consumes it. Without this the
+        // loop would grab `[R//]` as an infix and choke on the trailing `=`.
+        if crate::parser::stmt::assign::parse_bracket_meta_assign_op(r).is_none()
+            && let Some(bracket_infix) = parse_bracket_infix_op(r)
+        {
             match bracket_infix {
                 BracketInfix::PlainOp(op, len) => {
                     let r = &r[len..];

--- a/src/parser/expr/precedence/logic.rs
+++ b/src/parser/expr/precedence/logic.rs
@@ -149,6 +149,26 @@ pub(crate) fn assign_not_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
         }
     }
 
+    // Bracket meta-op compound assignment on an *indexed* lvalue: `%h<k> [R//]= $v`,
+    // `@a[$i] [+]= 1`. A bare-variable LHS is handled by the dedicated
+    // statement-level / call-argument assign paths (which need `expression()` to
+    // NOT swallow the `[op]=`, so their comma-boundary logic keeps working) — only
+    // subscripted lvalues, which reach here as the parsed `expr`, need this branch.
+    // The list-infix / arithmetic loops above bail on `[op]=` so `r` still starts
+    // with it.
+    if matches!(expr, Expr::Index { .. } | Expr::MultiDimIndex { .. })
+        && let Some((after_op, meta, op)) =
+            crate::parser::stmt::assign::parse_bracket_meta_assign_op(r)
+    {
+        let (after_ws, _) = ws(after_op)?;
+        if let Ok((r, rhs)) = parse_assignment_rhs_mode(after_ws, mode)
+            && let Ok(result) =
+                crate::parser::stmt::assign::build_meta_assign_expr(expr.clone(), meta, op, rhs)
+        {
+            return Ok((r, result));
+        }
+    }
+
     // Word-operator compound assignment (`div=`, `mod=`, `gcd=`, `x=`, and
     // user-declared operators). Handled here — not only at the statement level —
     // so it parses as the operand of a looser operator, e.g. the right side of

--- a/src/parser/expr/precedence_meta_ops/arith.rs
+++ b/src/parser/expr/precedence_meta_ops/arith.rs
@@ -92,8 +92,12 @@ fn try_bracket_op_at_level(input: &str, level: &OpPrecedence) -> Option<(String,
             return Some((meta, op, len));
         }
     }
-    // Try [op] bracket infix
-    if let Some(bracket_infix) = parse_bracket_infix_op(input) {
+    // Try [op] bracket infix — but `[op]=` (a bracket meta-op compound
+    // assignment like `@a[$i] [+]= 1`) is not an infix operator; leave it for
+    // the assignment handler so the trailing `=` is not stranded.
+    if crate::parser::stmt::assign::parse_bracket_meta_assign_op(input).is_none()
+        && let Some(bracket_infix) = parse_bracket_infix_op(input)
+    {
         match &bracket_infix {
             BracketInfix::PlainOp(op, len) => {
                 if std::mem::discriminant(&classify_base_op(op)) == std::mem::discriminant(level) {

--- a/src/parser/stmt/class/grammar_module.rs
+++ b/src/parser/stmt/class/grammar_module.rs
@@ -142,9 +142,23 @@ pub(crate) fn grammar_decl(input: &str) -> PResult<'_, Stmt> {
     while let Some(r2) = keyword("is", r) {
         let (r2, _) = ws1(r2)?;
         let (r2, parent_name) = qualified_ident(r2)?;
-        parents.push(parent_name);
-        let (r2, _) = ws(r2)?;
-        r = r2;
+        // A lowercase `is` name (`export`, `rw`, `repr('...')`, a custom trait)
+        // is a trait, NOT a parent grammar — only an uppercase/indirect name is
+        // a superclass. Without this, `grammar Foo is export { }` would try to
+        // inherit from a nonexistent `export`. Mirrors the class-decl loop.
+        if parent_name.starts_with(|c: char| c.is_ascii_uppercase())
+            || parent_name.starts_with("::")
+        {
+            let (r2, bracket_suffix) =
+                crate::parser::stmt::class::parse_optional_bracket_suffix(r2)?;
+            parents.push(format!("{}{}", parent_name, bracket_suffix));
+            let (r2, _) = ws(r2)?;
+            r = r2;
+        } else {
+            let r2 = crate::parser::helpers::skip_balanced_parens(r2);
+            let (r2, _) = ws(r2)?;
+            r = r2;
+        }
     }
     let mut does_parents = Vec::new();
     while let Some(r2) = keyword("does", r) {

--- a/t/bracket-metaop-assign-indexed.t
+++ b/t/bracket-metaop-assign-indexed.t
@@ -1,0 +1,57 @@
+use v6;
+use Test;
+
+# A bracket meta-op compound assignment (`[op]=`) must work on an indexed /
+# subscripted lvalue, not just a bare variable: `%h<k> [R//]= $v`, `@a[$i] [+]= 1`.
+# Previously the precedence loop grabbed `[op]` as a bracket *infix* operator and
+# choked on the trailing `=` ("expression after bracket ... operator"). Regression
+# surfaced by PostCocoon::Url (`$result<port> [R//]= ~.<port>`).
+
+plan 10;
+
+# reduce meta (`[+]=` behaves like `+=`) on a hash angle-subscript
+my %h;
+%h<n> = 5;
+%h<n> [+]= 10;
+is %h<n>, 15, "[+]= on hash angle-subscript";
+
+# `[*]=` on an array positional-subscript
+my @a = 2, 3, 4;
+@a[1] [*]= 10;
+is @a[1], 30, "[*]= on array subscript";
+
+# reversed defined-or meta `[R//]=` : `\$x = \$rhs // \$x` -> assigns to the LHS
+# only when the RHS is defined (R reverses the operands of //)
+my %r;
+%r<x> [R//]= "y";
+is %r<x>, "y", "[R//]= assigns when LHS undefined";
+
+my %r2;
+%r2<x> = "keep";
+%r2<x> [R//]= "new";
+is %r2<x>, "new", "[R//]= with R reversal takes the right operand when defined";
+
+# `[//]=` (plain defined-or) leaves a defined LHS untouched
+my %d;
+%d<k> = "orig";
+%d<k> [//]= "fallback";
+is %d<k>, "orig", "[//]= keeps a defined value";
+
+my %d2;
+%d2<k> [//]= "fallback";
+is %d2<k>, "fallback", "[//]= fills an undefined value";
+
+# named reduction op `[max]=` on a subscript
+my @m = 3, 1;
+@m[0] [max]= 10;
+is @m[0], 10, "[max]= on array subscript";
+@m[0] [max]= 2;
+is @m[0], 10, "[max]= keeps the larger value";
+
+# bare-variable form still works (unchanged path)
+my $s = 1;
+$s [+]= 4;
+is $s, 5, "[+]= on a bare scalar still works";
+
+# prefix reduction `[+] @list` is unaffected by the guard
+is ([+] 1, 2, 3, 4), 10, "prefix reduction [+] still parses";

--- a/t/grammar-is-export.t
+++ b/t/grammar-is-export.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+# `grammar Foo is export { ... }` must treat `export` as a trait, not as a parent
+# grammar. Previously the grammar declarator grabbed every `is X` as a superclass,
+# so `is export` tried to inherit from a nonexistent `export`. Class and role
+# declarators already handled this; grammars did not. Surfaced by PostCocoon::Url.
+
+plan 4;
+
+grammar Digits is export {
+    token TOP { \d+ }
+}
+ok Digits.parse("12345"), "grammar with `is export` parses input";
+nok Digits.parse("abc"), "grammar with `is export` rejects non-matching input";
+
+# A real parent grammar (uppercase name) is still honored as inheritance.
+grammar Base {
+    token num { \d+ }
+}
+grammar Sub is Base {
+    token TOP { <num> }
+}
+ok Sub.parse("42"), "grammar `is Base` still inherits tokens";
+
+# `is export` combined with a real parent, in either order.
+grammar Both is Base is export {
+    token TOP { <num> }
+}
+ok Both.parse("7"), "grammar `is Base is export` inherits and exports";


### PR DESCRIPTION
Two independent parser fixes, both surfaced by **PostCocoon::Url** (which now loads):

## 1. Bracket meta-op compound assignment on an indexed lvalue

`%h<k> [R//]= \$v` and `@a[\$i] [+]= 1` failed to parse — the precedence loops grabbed `[op]` as a bracket *infix* operator and choked on the trailing `=` ("expression after bracket ... operator"). A bare-variable LHS already worked via the statement-level path.

- Guard the bracket-infix branches (the list-infix loop and the additive/multiplicative `try_bracket_op_at_level`) to bail when `parse_bracket_meta_assign_op` matches, so `[op]=` is left for the assignment handler.
- Handle `[op]=` on an **indexed** lvalue in `assign_not_expr_mode` via the existing `build_meta_assign_expr` (which already covers `Index`/`MultiDimIndex`). Bare-variable LHS keeps its dedicated statement-level / call-argument path (restricting the new branch to indexed lvalues preserves the call-arg comma-boundary logic).

Surfaced by `$result<port> [R//]= ~.<port>` in PostCocoon::Url.

## 2. `grammar Foo is export { ... }`

The grammar declarator grabbed every `is X` as a superclass, so `is export` tried to inherit from a nonexistent `export`. Class and role declarators already distinguish an uppercase/indirect name (a parent) from a lowercase trait (`export`, `rw`, `repr(...)`). Mirror that logic in the grammar `is` loop.

## Verification

- New pins `t/bracket-metaop-assign-indexed.t` (10 subtests) and `t/grammar-is-export.t` (4 subtests) — identical output under `raku` and `mutsu`.
- `make test`: PASS (19704 tests); `roast/S03-metaops/reverse.t` still green.
- PostCocoon::Url now loads (remaining URL-parse mismatch is a separate grammar-engine issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)