### PR TITLE
fix: accept self as a ternary then-branch

### DIFF
--- a/src/parser/expr/precedence/ternary.rs
+++ b/src/parser/expr/precedence/ternary.rs
@@ -181,6 +181,7 @@ pub(crate) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
         };
         if mode == ExprMode::Full
             && let Expr::BareWord(name) = &then_expr
+            && name != "self"
             && !name.contains("::")
             && !crate::runtime::utils::is_known_type_constraint(name)
             && !crate::runtime::utils::is_builtin_enum_value(name)

--- a/t/ternary-self-then-branch.t
+++ b/t/ternary-self-then-branch.t
@@ -1,0 +1,24 @@
+use v6;
+use Test;
+
+# `self` as the then-branch of a ternary must be accepted. The then-branch
+# guard treats a bare identifier as the (incomplete) head of a listop call and
+# errors, but `self` is a complete nullary term, like a type object. Regression
+# surfaced by Pray::Geometry::Vector3D (`... ?? self.scale(...) !! $in ?? self !! self.clone`).
+
+plan 5;
+
+class V {
+    has $.n = 1;
+    method clone-ish { V.new(n => $!n) }
+    method pick-self($cond)  { $cond ?? self !! V.new(n => 99) }
+    method pick-other($cond) { $cond ?? V.new(n => 99) !! self }
+    method chained($a, $b)   { $a ?? self !! ($b ?? self !! self.clone-ish) }
+}
+
+my $v = V.new(n => 5);
+is $v.pick-self(True).n,  5,  "self as then-branch returns the invocant";
+is $v.pick-self(False).n, 99, "false then-branch takes the else";
+is $v.pick-other(True).n, 99, "self as else-branch still works";
+is $v.chained(True, False).n, 5, "self in a nested-ternary then-branch";
+is $v.chained(False, False).n, 5, "self.method reached through the else chain";


### PR DESCRIPTION
## Problem

`COND ?? self !! ...` failed to parse:

```raku
method normalize(...) {
    ... ?? self.scale(...) !! $in ?? self !! self.clone
}
```

The ternary then-branch guard rejects a bare identifier there, assuming it is the (not-yet-complete) head of a listop call whose comma args and the `!!` were gobbled (e.g. `1 ?? is-deeply $x, $y !! ...`). But `self` is a complete nullary term — like a type object or a sigilless value term, both already excluded from that guard.

Surfaced by **Pray::Geometry::Vector3D**.

## Fix

Add `self` to the then-branch guard's exclusions in `ternary.rs`, so it is accepted as a complete then-expression.

## Verification

- New pin `t/ternary-self-then-branch.t` (5 subtests) — identical output under `raku` and `mutsu`.
- `make test`: PASS (19709 tests); `roast/S03-operators/ternary.t` still green (no regression to the `!!`-without-`??` "Confused" case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)