### PR TITLE
feat: <?wb> / <!wb> word-boundary zero-width regex assertions

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1000,6 +1000,12 @@ enum RegexAtom {
     LeftWordBoundary,
     /// `>>` or `»` — right word boundary assertion (zero-width)
     RightWordBoundary,
+    /// `<?wb>` (word boundary) / `<!wb>` (not a word boundary) — zero-width
+    /// assertion at a transition between a word char and a non-word char (either
+    /// direction), i.e. `<<` or `>>`.
+    WordBoundary {
+        negated: bool,
+    },
     /// `^^` — start of line assertion (zero-width)
     StartOfLine,
     /// `$$` — end of line assertion (zero-width)

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -243,6 +243,18 @@ impl Interpreter {
                     None
                 };
             }
+            RegexAtom::WordBoundary { negated } => {
+                // `<?wb>` / `<!wb>`: a boundary is a transition between a word char
+                // and a non-word char (either direction) — i.e. `<<` or `>>`.
+                let before_is_word = pos > 0 && is_word_char(chars[pos - 1]);
+                let at_is_word = pos < chars.len() && is_word_char(chars[pos]);
+                let is_boundary = before_is_word != at_is_word;
+                return if is_boundary != *negated {
+                    Some(pos)
+                } else {
+                    None
+                };
+            }
             RegexAtom::StartOfLine => {
                 // The char immediately before `pos`. At slice-position 0 this is
                 // not necessarily the start of the original parse text: a subrule
@@ -682,6 +694,7 @@ impl Interpreter {
             | RegexAtom::ClosureInterpolation { .. }
             | RegexAtom::LeftWordBoundary
             | RegexAtom::RightWordBoundary
+            | RegexAtom::WordBoundary { .. }
             | RegexAtom::StartOfLine
             | RegexAtom::TildeMarker
             | RegexAtom::EndOfLine

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -157,6 +157,7 @@ impl Interpreter {
             | RegexAtom::UnicodePropAssert { .. }
             | RegexAtom::LeftWordBoundary
             | RegexAtom::RightWordBoundary
+            | RegexAtom::WordBoundary { .. }
             | RegexAtom::StartOfLine
             | RegexAtom::EndOfLine
             | RegexAtom::WsRule

--- a/src/runtime/regex_parse_charclass.rs
+++ b/src/runtime/regex_parse_charclass.rs
@@ -612,6 +612,7 @@ impl Interpreter {
             | RegexAtom::EndOfLine
             | RegexAtom::LeftWordBoundary
             | RegexAtom::RightWordBoundary
+            | RegexAtom::WordBoundary { .. }
             | RegexAtom::UnicodeProp { .. }
             | RegexAtom::UnicodePropAssert { .. }
             | RegexAtom::SameAssertion { .. }

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -1892,6 +1892,9 @@ impl Interpreter {
                                     } else if negated_name == "same" || negated_name == ".same" {
                                         // <!same> — zero-width assertion: next two chars are different
                                         RegexAtom::SameAssertion { negated: true }
+                                    } else if negated_name == "wb" || negated_name == ".wb" {
+                                        // <!wb> — zero-width assertion: NOT at a word boundary
+                                        RegexAtom::WordBoundary { negated: true }
                                     } else {
                                         // <!alpha>, <!digit>, etc. — zero-width negative assertion for named class
                                         let clean_name =
@@ -2157,6 +2160,9 @@ impl Interpreter {
                                 } else if trimmed == "?same" || trimmed == "?.same" {
                                     // <?same> — zero-width assertion: next two chars are the same
                                     RegexAtom::SameAssertion { negated: false }
+                                } else if trimmed == "?wb" || trimmed == "?.wb" {
+                                    // <?wb> — zero-width assertion: at a word boundary
+                                    RegexAtom::WordBoundary { negated: false }
                                 } else if trimmed.starts_with("at(") && trimmed.ends_with(')') {
                                     // <at(N)> — zero-width assertion: match at position N
                                     let inner = &trimmed[3..trimmed.len() - 1];

--- a/t/regex-wb-assertion.t
+++ b/t/regex-wb-assertion.t
@@ -1,0 +1,24 @@
+use Test;
+
+# `<?wb>` is a zero-width assertion at a word boundary (a transition between a
+# word char and a non-word char, either direction — i.e. `<<` or `>>`), and
+# `<!wb>` asserts NOT at a boundary. (Language/regexes.rakudoc.)
+
+plan 10;
+
+ok "two-words" ~~ / two<?wb>\-<?wb>words /, '<?wb> around a hyphen';
+ok "twowords"  ~~ / two<!wb><!wb>words /,    '<!wb> inside a word';
+nok "two words" ~~ / two<!wb>\s words /,     '<!wb> fails at a real boundary';
+
+# string edges are boundaries
+ok "cat" ~~ /<?wb>cat<?wb>/,  '<?wb> at both string edges';
+ok "cat" ~~ /cat<?wb>/,       '<?wb> at end of string';
+ok "cat" ~~ /<?wb>cat/,       '<?wb> at start of string';
+
+# <!wb> inside a word matches, at a boundary fails
+ok  "abcd"  ~~ /ab<!wb>cd/,   '<!wb> between two word chars';
+nok "ab cd" ~~ /ab<!wb> cd/,  '<!wb> before a space fails';
+
+# substitution inserts at every boundary
+is "stuff here!!!".subst(:g, /<?wb>/, "|"), "|stuff| |here|!!!", '<?wb> subst marks all boundaries';
+is "a-b".subst(:g, /<?wb>/, "|"),           "|a|-|b|",           '<?wb> subst around punctuation';


### PR DESCRIPTION
## Summary

`<?wb>` asserts a **word boundary** — a transition between a word char and a
non-word char in either direction (i.e. `<<` or `>>`) — and `<!wb>` asserts **not**
at a boundary. mutsu had `<<`/`>>` but not the combined `wb` assertion, so:

```raku
say "two-words" ~~ / two<?wb>\-<?wb>words /;      # was Nil, now ｢two-words｣
say "stuff here!!!".subst(:g, /<?wb>/, "|");      # was unchanged, now |stuff| |here|!!!
```

## Implementation

New `RegexAtom::WordBoundary { negated }`:
- **Parse** `<?wb>` / `<?.wb>` and `<!wb>` / `<!.wb>` (regex_parse_core).
- **Match** as `before_is_word != at_is_word`, XORed with `negated`
  (regex_match_atom_simple).
- **Zero-width dispatch** (regex_match_capture) so it can fire at string edges —
  `cat<?wb>` at end-of-string matches, like `cat>>` already does. Added to the
  zero-width atom classifier.

## Discovery

doc-diff sweep on `Language/regexes.rakudoc` (findings [13]/[14]) — see
`docs/doc-diff-backlog.md`.

## Test

Pin: `t/regex-wb-assertion.t` (10 cases incl. string edges, `<!wb>` inside a word,
and `:g` substitution). Whitelisted `roast/S05-metasyntax/regex.t` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)