### PR TITLE
feat: positive named-class / Unicode-property regex assertions (<?alpha>)

### DIFF
--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -2154,6 +2154,110 @@ impl Interpreter {
                                     }
                                     try_collapse_alternation_to_charclass(&alt_patterns)
                                         .unwrap_or(RegexAtom::Alternation(alt_patterns))
+                                } else if let Some(prop_name) = trimmed.strip_prefix("?:") {
+                                    // <?:PropName> — zero-width positive Unicode property assertion
+                                    // (the positive twin of `<!:PropName>` above).
+                                    RegexAtom::UnicodePropAssert {
+                                        name: prop_name.to_string(),
+                                        negated: false,
+                                    }
+                                } else if trimmed
+                                    .strip_prefix('?')
+                                    .map(|n| n.strip_prefix('.').unwrap_or(n))
+                                    .is_some_and(|n| {
+                                        matches!(
+                                            n,
+                                            "alpha"
+                                                | "upper"
+                                                | "lower"
+                                                | "digit"
+                                                | "xdigit"
+                                                | "space"
+                                                | "alnum"
+                                                | "blank"
+                                                | "cntrl"
+                                                | "punct"
+                                                | "graph"
+                                                | "print"
+                                                | "ws"
+                                                | "ident"
+                                        )
+                                    })
+                                {
+                                    // <?alpha>, <?digit>, <?alnum>, ... — zero-width positive
+                                    // assertion for a named class (the positive twin of `<!alpha>`).
+                                    let pos_name = trimmed.strip_prefix('?').unwrap();
+                                    let clean_name = pos_name.strip_prefix('.').unwrap_or(pos_name);
+                                    let inner_atom = if clean_name == "ident" {
+                                        RegexAtom::Group(RegexPattern {
+                                            tokens: vec![
+                                                RegexToken {
+                                                    atom: RegexAtom::CharClass(CharClass {
+                                                        items: vec![ClassItem::NamedBuiltin(
+                                                            "alpha".to_string(),
+                                                        )],
+                                                        negated: false,
+                                                    }),
+                                                    quant: RegexQuant::One,
+                                                    named_capture: None,
+                                                    hash_capture: None,
+                                                    secondary_named_capture: None,
+                                                    force_list_capture: false,
+                                                    ratchet: false,
+                                                    frugal: false,
+                                                    separator: None,
+                                                },
+                                                RegexToken {
+                                                    atom: RegexAtom::CharClass(CharClass {
+                                                        items: vec![ClassItem::NamedBuiltin(
+                                                            "alnum".to_string(),
+                                                        )],
+                                                        negated: false,
+                                                    }),
+                                                    quant: RegexQuant::ZeroOrMore,
+                                                    named_capture: None,
+                                                    hash_capture: None,
+                                                    secondary_named_capture: None,
+                                                    force_list_capture: false,
+                                                    ratchet: false,
+                                                    frugal: false,
+                                                    separator: None,
+                                                },
+                                            ],
+                                            anchor_start: false,
+                                            anchor_end: false,
+                                            ignore_case,
+                                            ignore_mark,
+                                        })
+                                    } else {
+                                        RegexAtom::CharClass(CharClass {
+                                            items: vec![ClassItem::NamedBuiltin(
+                                                clean_name.to_string(),
+                                            )],
+                                            negated: false,
+                                        })
+                                    };
+                                    RegexAtom::Lookaround {
+                                        pattern: RegexPattern {
+                                            tokens: vec![RegexToken {
+                                                atom: inner_atom,
+                                                quant: RegexQuant::One,
+                                                named_capture: None,
+                                                hash_capture: None,
+                                                secondary_named_capture: None,
+                                                force_list_capture: false,
+                                                ratchet: false,
+                                                frugal: false,
+                                                separator: None,
+                                            }],
+                                            anchor_start: false,
+                                            anchor_end: false,
+                                            ignore_case,
+                                            ignore_mark,
+                                        },
+                                        negated: false,
+                                        is_behind: false,
+                                    }
                                 } else if trimmed == "?same" || trimmed == "?.same" {
                                     // <?same> — zero-width assertion: next two chars are the same
                                     RegexAtom::SameAssertion { negated: false }

--- a/t/regex-positive-named-class-assert.t
+++ b/t/regex-positive-named-class-assert.t
@@ -1,0 +1,26 @@
+use Test;
+
+# `<?alpha>`, `<?digit>`, ... and `<?:PropName>` are zero-width POSITIVE
+# assertions for a named char class / Unicode property (the positive twins of
+# `<!alpha>` / `<!:PropName>`, which already worked). mutsu treated the positive
+# form as a subrule call and failed to match. (Language/regexes.rakudoc [2].)
+
+plan 9;
+
+ok  '333' ~~ m/^^ <?alnum> \d+ /,   '<?alnum> positive named-class assertion';
+ok  '333' ~~ m/^^ <?:Nd> \d+ /,     '<?:Nd> positive Unicode-property assertion';
+ok  'abc' ~~ m/ <?alpha> \w+ /,     '<?alpha> before a letter';
+ok  'a1'  ~~ m/ <?ident> \w+ /,     '<?ident> before an identifier';
+nok 'abc' ~~ m/ <?digit> \w+ /,     '<?digit> fails before a letter';
+
+# negatives must still work (regression guard)
+ok  '333' ~~ m/^^ <!alpha> \d+ /,   '<!alpha> still works';
+ok  '333' ~~ m/^^ <!:L> \d+ /,      '<!:L> still works';
+
+# a real positive lookahead is unaffected
+ok  'abc' ~~ /<?before a> abc/,     '<?before ...> lookahead unaffected';
+
+# zero-width: the assertion consumes nothing
+if 'x9' ~~ m/ <?alnum> (.) / {
+    is ~$0, 'x', '<?alnum> is zero-width (capture starts at the same pos)';
+}


### PR DESCRIPTION
## Summary

`<?alpha>`, `<?digit>`, `<?alnum>`, ... and `<?:PropName>` are zero-width **positive**
assertions for a named char class / Unicode property — the positive twins of the
already-working `<!alpha>` / `<!:PropName>`. mutsu had no positive branch, so the
positive form fell through to the subrule-call path and failed to match:

```raku
say '333' ~~ m/^^ <?alnum> \d+ /;   # was False, now ｢333｣
say '333' ~~ m/^^ <?:Nd> \d+ /;     # was False, now ｢333｣
```

## Implementation

A positive branch mirroring the negative one in `regex_parse_core`:
- `<?:Prop>` → `UnicodePropAssert { negated: false }`
- `<?NAME>` for a known builtin class → `Lookaround { negated: false }` over that
  class (`<?ident>` = `alpha alnum*`, matching the negative form).

Guarded to the known builtin class names, so a positive lookahead subrule
(`<?before ...>`, `<?foo>`) is unaffected. Negatives (`<!alpha>`, `<!:L>`) still work.

## Discovery

doc-diff sweep on `Language/regexes.rakudoc` (finding [2]) — see `docs/doc-diff-backlog.md`.

## Test

Pin: `t/regex-positive-named-class-assert.t` (9 cases incl. negative-form and
lookahead regression guards). Whitelisted `roast/S05-metasyntax/regex.t` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)