### PR TITLE
fix: support bracketed embedded comments in the regex slang

### DIFF
--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -439,7 +439,7 @@ fn skip_embedded_comment(input: &str) -> Option<&str> {
 }
 
 /// Return the matching closing bracket for an opening bracket.
-fn matching_bracket(c: char) -> Option<char> {
+pub(crate) fn matching_bracket(c: char) -> Option<char> {
     match c {
         '(' => Some(')'),
         '[' => Some(']'),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,5 +1,5 @@
 mod expr;
-mod helpers;
+pub(crate) mod helpers;
 mod memo;
 mod outer_redecl;
 mod parse_result;

--- a/src/parser/primary/regex/scan.rs
+++ b/src/parser/primary/regex/scan.rs
@@ -94,13 +94,10 @@ fn scan_to_delim_inner(
             if let Some((_, '`')) = chars.clone().next() {
                 chars.next(); // skip `
                 if let Some((_, bracket)) = chars.next() {
-                    let close = match bracket {
-                        '[' => ']',
-                        '(' => ')',
-                        '{' => '}',
-                        '<' => '>',
-                        _ => bracket,
-                    };
+                    // `#`«...»`, `#`[...]`, etc. — any bracket pair Raku accepts.
+                    // Falls back to the same char for a non-bracket delimiter.
+                    let close =
+                        crate::parser::helpers::matching_bracket(bracket).unwrap_or(bracket);
                     let mut embed_depth = 1u32;
                     for (_, ch) in chars.by_ref() {
                         if ch == bracket && bracket != close {

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -468,8 +468,29 @@ impl Interpreter {
                 }
                 continue;
             }
-            // '#' starts a comment until end of line in Raku regex
+            // '#' starts a comment in Raku regex. `#`«...»` / `#`[...]` is a
+            // bracket-delimited embedded comment (may sit mid-line with pattern
+            // after it); a plain `#` is a line comment (until end of line).
             if c == '#' {
+                if chars.peek() == Some(&'`') {
+                    chars.next(); // consume `
+                    if let Some(bracket) = chars.next() {
+                        let close =
+                            crate::parser::helpers::matching_bracket(bracket).unwrap_or(bracket);
+                        let mut embed_depth = 1u32;
+                        for ch in chars.by_ref() {
+                            if ch == bracket && bracket != close {
+                                embed_depth += 1;
+                            } else if ch == close {
+                                embed_depth -= 1;
+                                if embed_depth == 0 {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    continue;
+                }
                 for ch in chars.by_ref() {
                     if ch == '\n' {
                         break;

--- a/src/runtime/regex_parse_modifier.rs
+++ b/src/runtime/regex_parse_modifier.rs
@@ -141,13 +141,8 @@ impl Interpreter {
                     i += 1;
                     if i < chars.len() {
                         let bracket = chars[i];
-                        let close = match bracket {
-                            '[' => ']',
-                            '(' => ')',
-                            '{' => '}',
-                            '<' => '>',
-                            _ => bracket,
-                        };
+                        let close =
+                            crate::parser::helpers::matching_bracket(bracket).unwrap_or(bracket);
                         out.push(bracket);
                         i += 1;
                         let mut embed_depth = 1u32;

--- a/t/regex-embedded-comment-brackets.t
+++ b/t/regex-embedded-comment-brackets.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+# `#`«...»` (and other bracket pairs) is a bracket-delimited *embedded* comment
+# inside the regex/token slang: it ends at the matching close bracket and the
+# pattern may continue on the same line. mutsu previously only mapped the ASCII
+# bracket openers (`[ ( { <`), so a guillemet `#`«...»` never found its close
+# and ate the rest of the line (including the token's `}`), desyncing the parse.
+# Regression surfaced by Gzz::Text::Utils (grammar tokens with `#`« ... »` docs).
+
+plan 9;
+
+grammar G1 { token TOP { 'a' #`« a guillemet comment » 'b' } }
+ok  G1.parse('ab'),  "guillemet embedded comment, pattern continues after it";
+nok G1.parse('a'),   "the 'b' after the comment is still required";
+
+grammar G2 { token TOP { 'x' #`[ square ] 'y' } }
+ok G2.parse('xy'), "square-bracket embedded comment";
+
+grammar G3 { token TOP { 'p' #`( round ) 'q' } }
+ok G3.parse('pq'), "round-bracket embedded comment";
+
+grammar G4 { token TOP { 'm' #`«« doubled »» 'n' } }
+ok G4.parse('mn'), "doubled-guillemet embedded comment";
+
+# Line comment (plain `#`) still runs to end of line.
+grammar G5 {
+    token TOP {
+        'a' # a line comment to EOL
+        'b'
+    }
+}
+ok G5.parse('ab'), "plain # line comment still works";
+
+# Embedded comment in an m// match, mid-pattern.
+ok 'ab' ~~ / a #`{ brace comment } b /, "embedded comment in m// regex";
+
+# A guillemet comment followed by more grammar declarations must not leak.
+grammar G6 {
+    token one { 'A' #`« doc » }
+    token TOP { <one> 'Z' }
+}
+ok G6.parse('AZ'), "comment before a token's closing brace does not leak into the next token";
+
+# Nested brackets inside the embedded comment are balanced (depth-counted).
+grammar G7 { token TOP { 'a' #`[ outer [ inner ] still comment ] 'b' } }
+ok G7.parse('ab'), "nested brackets inside an embedded comment are balanced";


### PR DESCRIPTION
## Problem

`#`«...»` is a bracket-delimited **embedded** comment inside the regex/token slang: it ends at the matching close bracket and the pattern may continue on the same line. Three sites only mapped the ASCII bracket openers (`[ ( { <`), so a guillemet (or any other Unicode bracket-pair) opener never found its close and ate the rest of the line — including the enclosing token's `}` — desyncing the grammar parse far downstream (a misreported `expected '}'` many lines later).

Surfaced by **Gzz::Text::Utils**, whose grammar tokens document each alternative with `#`« ... »` mid-line:

```raku
token fmt-esc { [    '%' #`« a literal % »
                  || 'N' #`« a nl i.e. \n char ... »
                  ... ] }
```

## Fix

- Reuse the existing comprehensive `matching_bracket` helper (already covers `«»`, `‹›`, CJK brackets, …) in the regex-extent scanner (`scan.rs`) and the interpolation walker (`regex_parse_modifier.rs`).
- The runtime regex tokenizer (`regex_parse_core.rs`) had **no** embedded-comment handling at all (it treated `#`«...»` as a line comment to EOL, dropping any pattern after it on the same line); add bracket-delimited embedded-comment parsing there too.
- Make `parser::helpers` `pub(crate)` so the runtime modules can share the helper.

## Verification

- New pin `t/regex-embedded-comment-brackets.t` (9 subtests) — identical output under `raku` and `mutsu`.
- `make test`: PASS (19727 tests); whitelisted `roast/S05-metasyntax/{charset,litvar}.t` still green.
- `Gzz::Text::Utils` now parses; `use` fails only on its missing `Terminal::ANSI::OO` dependency, matching raku.

🤖 Generated with [Claude Code](https://claude.com/claude-code)