### PR TITLE
fix: accept optional/default on a named attributive callable param (:&!writer?)

### DIFF
--- a/src/parser/stmt/sub_param/param_inner.rs
+++ b/src/parser/stmt/sub_param/param_inner.rs
@@ -956,7 +956,17 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
         return Ok((r, p));
     }
 
-    // Bare & (anonymous callable parameter)
+    // Bare & (anonymous callable parameter). The `?`/`!` after `&` mark an
+    // anonymous callable as optional/required ONLY when nothing (or a
+    // terminator) follows — `&?`, `&!`. When an identifier follows, the `?`/`!`
+    // is a *twigil* and this is a named/attributive callable param (`&?ROUTINE`,
+    // `:&!writer`), which must fall through to twigil+name parsing below.
+    let bare_amp_marker_terminates = |after: &[u8]| {
+        after
+            .first()
+            .copied()
+            .is_none_or(|c| !((c as char).is_ascii_alphanumeric() || c == b'_'))
+    };
     if rest.starts_with('&')
         && (rest.len() == 1
             || rest.as_bytes()[1] == b','
@@ -964,8 +974,8 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
             || rest.as_bytes()[1] == b' '
             || rest.as_bytes()[1] == b'\t'
             || rest.as_bytes()[1] == b'\n'
-            || rest.as_bytes()[1] == b'?'
-            || rest.as_bytes()[1] == b'!')
+            || ((rest.as_bytes()[1] == b'?' || rest.as_bytes()[1] == b'!')
+                && bare_amp_marker_terminates(rest.as_bytes().get(2..).unwrap_or(&[]))))
     {
         let rest = &rest[1..];
         let (rest, required, opt_marker) = super::helpers::parse_required_suffix(rest);

--- a/t/attributive-callable-param-twigil.t
+++ b/t/attributive-callable-param-twigil.t
@@ -1,0 +1,56 @@
+use v6;
+use Test;
+
+# A named attributive callable parameter with a twigil (`:&!writer`, `:&.hook`)
+# must accept an optional `?` marker and/or a default value. The bare-anonymous
+# `&?` / `&!` shorthand ate the `&`, mis-reading the twigil `!`/`?` as the
+# required/optional marker of an anonymous callable and stranding the name.
+# Regression surfaced by Chart::Gnuplot (`:&!writer? = -> $msg { ... }`).
+
+plan 8;
+
+# A `:&!writer` param binds a named argument straight into a private callable
+# attribute. Exercise it as the sole positional-less BUILD parameter (the
+# Chart::Gnuplot shape) and combined with other named params.
+
+class C {
+    has &!writer;
+    has $.log = '';
+    submethod BUILD(:&!writer? = -> $m { "default:$m" }) {
+        $!log = &!writer('hi');
+    }
+    method run { $!log }
+}
+is C.new.run, 'default:hi', "attributive callable named-twigil param uses its pointy default";
+is C.new(writer => -> $m { "custom:$m" }).run, 'custom:hi',
+    "a passed callable overrides the default";
+
+# optional marker alone (no default)
+class D {
+    has &!cb;
+    method has-cb { defined &!cb }
+    submethod BUILD(:&!cb?) { }
+}
+nok D.new.has-cb, "optional named-twigil callable may be omitted";
+ok  D.new(cb => -> {}).has-cb, "optional named-twigil callable binds when supplied";
+
+# A `:&!writer` param alongside other params, matching Chart::Gnuplot's BUILD.
+class E {
+    has &!writer;
+    has $.persist;
+    has $.out = '';
+    submethod BUILD(:$terminal!, :$!persist = True, :&!writer? = -> $m { "d:$m" }) {
+        $!out = &!writer($terminal);
+    }
+    method run { $!out }
+}
+is E.new(terminal => 'png').run, 'd:png',
+    "attributive callable default coexists with other named params";
+is E.new(terminal => 'x', writer => -> $m { "w:$m" }).run, 'w:x',
+    "attributive callable override coexists with a required named param";
+
+# The bare anonymous `&?` / `&!` shorthand still works (no name follows).
+sub opt(&?)  { 'opt-ok' }
+sub req(&!)  { 'req-ok' }
+is opt(),        'opt-ok', "bare anonymous &? (optional) still parses";
+is req(-> {}),   'req-ok', "bare anonymous &! (required) still parses";


### PR DESCRIPTION
## Problem

A named attributive callable parameter with a twigil — `:&!writer`, `:&?ROUTINE` — was mis-parsed when an optional `?` (or a default) followed it:

```raku
submethod BUILD(..., :&!writer? = -> $msg { self.command: $msg }, ...) { ... }
```

The bare-anonymous-callable shorthand (`&?` / `&!` — an anonymous callable marked optional/required) matched purely on the second byte being `?`/`!`, so `&!writer` took that branch: it consumed the `&`, read the twigil `!` as the required marker, produced an anonymous `&` param, and stranded `writer?` as a bogus next parameter — a parse error (`expected ')'`).

## Fix

Only treat `&?` / `&!` as the bare-anonymous form when **no identifier follows** the marker; when one does, it is a twigil and the param falls through to the existing twigil+name parsing (which already handles the optional marker and default value).

## Verification

- New pin `t/attributive-callable-param-twigil.t` (8 subtests) — identical output under `raku` and `mutsu`; covers the default, the override, the optional-only form, coexistence with other named params, and the still-valid bare `&?` / `&!` anonymous shorthands.
- `make test`: PASS (19741 tests); whitelisted `roast/S06-signature/{code,optional,named-parameters}.t` still green.
- `Chart::Gnuplot` now parses and `use`s cleanly (matching raku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)