### PR TITLE
fix: .enums works on enum values and Bool

### DIFF
--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -675,6 +675,10 @@ impl Interpreter {
         let type_name_owned = match target.view() {
             ValueView::Package(name) => Some(name.resolve()),
             ValueView::Str(name) => Some(name.to_string()),
+            // An enum value (e.g. `red` of `enum Color`) carries its enum type.
+            ValueView::Enum { enum_type, .. } => Some(enum_type.resolve()),
+            // A Bool value (True/False) is a member of the built-in Bool enum.
+            ValueView::Bool(_) => Some("Bool".to_string()),
             _ => None,
         };
         let type_name = type_name_owned.as_deref();

--- a/t/enum-enums-method.t
+++ b/t/enum-enums-method.t
@@ -1,0 +1,21 @@
+use v6;
+use Test;
+
+plan 8;
+
+# .enums on an enum type object
+enum Color <red green blue>;
+is Color.enums.sort.gist, '(blue => 2 green => 1 red => 0)', 'Color.enums (type object)';
+
+# .enums on an enum value (was: "No such method 'enums' for invocant of type 'Int'")
+is red.enums.sort.gist, '(blue => 2 green => 1 red => 0)', 'red.enums (enum value)';
+is green.enums.sort.gist, '(blue => 2 green => 1 red => 0)', 'green.enums (enum value)';
+
+# .enums on the built-in Bool enum
+is Bool.enums.sort.gist, '(False => 0 True => 1)', 'Bool.enums (type object)';
+is True.enums.sort.gist, '(False => 0 True => 1)', 'True.enums (Bool value)';
+is False.enums.sort.gist, '(False => 0 True => 1)', 'False.enums (Bool value)';
+
+# The result is a Map
+isa-ok Color.enums, Map, 'Color.enums returns a Map';
+isa-ok red.enums, Map, 'red.enums returns a Map';


### PR DESCRIPTION
## Summary

doc-diff backlog finding (working from the end of `docs/doc-diff-backlog.md`): `Type/Bool.rakudoc`.

`.enums` previously only accepted a Package (type object) or Str invocant. So:
- `red.enums` (an enum *value*) failed with `No such method 'enums' for invocant of type 'Int'`
- `Bool.enums` / `True.enums` / `False.enums` did not resolve

`dispatch_enums` now also handles:
- `ValueView::Enum` — resolves its `enum_type` and looks it up in the enum registry
- `ValueView::Bool` — the built-in Bool enum

This matches raku, where `red.enums`, `True.enums`, and `False.enums` all return the full enum `Map`.

## Verification

- New test `t/enum-enums-method.t` (8 subtests, all pass).
- Re-ran the doc-diff harness on `Type/Bool.rakudoc`: now 0/5 high-signal divergences (was 1/5).
- Output matches `raku` exactly for `Color`, `Bool`, and string-backed enums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)