### PR TITLE
fix: expose positional captures in $/ after s/// substitution

### DIFF
--- a/src/vm/vm_subst_apply.rs
+++ b/src/vm/vm_subst_apply.rs
@@ -2,15 +2,22 @@ use super::vm_string_regex_ops::*;
 use super::*;
 
 impl Interpreter {
-    /// Create a Match object for a substitution match.
-    pub(super) fn make_subst_match(text: &str, start: usize, end: usize) -> Value {
+    /// Create a Match object for a substitution match, including any
+    /// positional captures (`$0`, `$1`, ...) so the post-`s///` `$/` exposes
+    /// them like a plain `m//` match does.
+    pub(super) fn make_subst_match(
+        text: &str,
+        start: usize,
+        end: usize,
+        positional: &[String],
+    ) -> Value {
         let chars: Vec<char> = text.chars().collect();
         let matched: String = chars[start..end].iter().collect();
         Value::make_match_object_full(
             matched,
             start as i64,
             end as i64,
-            &[],
+            positional,
             &std::collections::HashMap::new(),
             &std::collections::HashMap::new(),
             &[],

--- a/src/vm/vm_subst_exec.rs
+++ b/src/vm/vm_subst_exec.rs
@@ -53,7 +53,7 @@ impl Interpreter {
                     let result = Value::str(out);
                     self.write_subst_topic_checked(code, result)?;
                     // Create Match object and set $/
-                    let match_obj = Self::make_subst_match(&text, start, end);
+                    let match_obj = Self::make_subst_match(&text, start, end, &[]);
                     self.env_mut().insert("/".to_string(), match_obj.clone());
                     self.substitution_in_smartmatch = self.in_smartmatch_rhs;
                     self.stack.push(match_obj);
@@ -95,7 +95,7 @@ impl Interpreter {
                     let result = Value::str(out);
                     self.write_subst_topic_checked(code, result)?;
                     // Create Match object and set $/
-                    let match_obj = Self::make_subst_match(&text, start, end);
+                    let match_obj = Self::make_subst_match(&text, start, end, &captures);
                     self.env_mut().insert("/".to_string(), match_obj.clone());
                     self.substitution_in_smartmatch = self.in_smartmatch_rhs;
                     self.stack.push(match_obj);
@@ -220,7 +220,11 @@ impl Interpreter {
         if result_is_list {
             let matches: Vec<Value> = ranges
                 .iter()
-                .map(|(s, e)| Self::make_subst_match(&text, *s, *e))
+                .enumerate()
+                .map(|(i, (s, e))| {
+                    let caps = per_match_captures.get(i).map_or(&[][..], |c| c.as_slice());
+                    Self::make_subst_match(&text, *s, *e, caps)
+                })
                 .collect();
             let list = Value::array(matches);
             self.env_mut().insert("/".to_string(), list.clone());
@@ -230,7 +234,8 @@ impl Interpreter {
         }
         // Create Match object from first match range and set $/
         let (first_start, first_end) = ranges[0];
-        let match_obj = Self::make_subst_match(&text, first_start, first_end);
+        let first_caps = per_match_captures.first().map_or(&[][..], |c| c.as_slice());
+        let match_obj = Self::make_subst_match(&text, first_start, first_end, first_caps);
         self.env_mut().insert("/".to_string(), match_obj.clone());
         self.substitution_in_smartmatch = self.in_smartmatch_rhs;
         self.stack.push(match_obj);
@@ -329,7 +334,7 @@ impl Interpreter {
                         samespace,
                     );
                     // S/// sets $/ to the match (without mutating $_).
-                    let match_obj = Self::make_subst_match(&text, start, end);
+                    let match_obj = Self::make_subst_match(&text, start, end, &[]);
                     self.env_mut().insert("/".to_string(), match_obj);
                     self.stack.push(Value::str(out));
                 } else {
@@ -365,7 +370,7 @@ impl Interpreter {
                             samespace,
                         )
                     };
-                    let match_obj = Self::make_subst_match(&text, start, end);
+                    let match_obj = Self::make_subst_match(&text, start, end, &captures);
                     self.env_mut().insert("/".to_string(), match_obj);
                     self.stack.push(Value::str(out));
                 } else {
@@ -472,13 +477,18 @@ impl Interpreter {
         if result_is_list {
             let matches: Vec<Value> = ranges
                 .iter()
-                .map(|(s, e)| Self::make_subst_match(&text, *s, *e))
+                .enumerate()
+                .map(|(i, (s, e))| {
+                    let caps = per_match_captures.get(i).map_or(&[][..], |c| c.as_slice());
+                    Self::make_subst_match(&text, *s, *e, caps)
+                })
                 .collect();
             self.env_mut()
                 .insert("/".to_string(), Value::array(matches));
         } else {
             let (s, e) = ranges[0];
-            let match_obj = Self::make_subst_match(&text, s, e);
+            let first_caps = per_match_captures.first().map_or(&[][..], |c| c.as_slice());
+            let match_obj = Self::make_subst_match(&text, s, e, first_caps);
             self.env_mut().insert("/".to_string(), match_obj);
         }
         self.stack.push(Value::str(out));

--- a/t/subst-match-positional-captures.t
+++ b/t/subst-match-positional-captures.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+# After an `s///`, `$/` must expose the positional captures ($0, $1, ...)
+# just like a plain `m//` match does. Regression: mutsu built the post-`s///`
+# `$/` from the match range only, dropping captures, so `$0`/`$1`/`$/[0]`
+# came back empty. (Language/regexes.rakudoc)
+
+plan 8;
+
+{
+    $_ = '2016-01-23 18:09:00';
+    s/ (\d+)\-(\d+)\-(\d+) /today/;
+    is $_, 'today 18:09:00', 's/// replaced the date';
+    is "$0", '2016', '$0 holds the first capture after s///';
+    is "$1", '01', '$1 holds the second capture after s///';
+    is "$2", '23', '$2 holds the third capture after s///';
+    is "$/[0]", '2016', '$/[0] indexes the capture after s///';
+    is "$1-$2-$0", '01-23-2016', 'captures interpolate in a later string';
+}
+
+# :g leaves a list of Match objects in $/, each carrying its own captures.
+{
+    $_ = 'a1b2c3';
+    s:g/(\w)(\d)/X/;
+    is $_, 'XXX', ':g substitution replaced all three pairs';
+    is $/.map({ .[0] ~ '=' ~ .[1] }).join(','), 'a=1,b=2,c=3',
+        'each :g match keeps its own positional captures';
+}


### PR DESCRIPTION
## Summary

After a substitution, Raku sets `$/` to a `Match` object that carries the same positional captures (`$0`, `$1`, …) as the corresponding `m//` match. mutsu built the post-`s///` `$/` from the match range only, so the captures came back empty even though `$/` itself gisted the matched text:

```raku
$_ = '2016-01-23 18:09:00';
s/ (\d+)\-(\d+)\-(\d+) /today/;
"$1-$2-$0".say;    # raku: 01-23-2016   mutsu (before): --
```

A plain `m//` was already correct — only the substitution path discarded captures it had already computed.

## Fix

`make_subst_match` now takes the positional captures and forwards them into the `Match` object. The captures already collected by `regex_find_first_from_with_captures` (and `per_match_captures` for the `:g`/`:x`/`:nth` paths) are threaded into every `s///`/`S///` call site. The Perl-5 path has no captures available and keeps passing an empty slice.

From the `Language/regexes.rakudoc` doc-diff backlog (finding [20]).

## Testing

- New pin `t/subst-match-positional-captures.t` (single + `:g`).
- No regression in the local `t/subst-*` suite or roast `S05-substitution/*`, `S05-metasyntax/repeat.t`, `S05-mass/{recursive,stdrules}.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)