### PR TITLE
fix: multi-dispatch on invocant definedness (:D:/:U: markers)

### DIFF
--- a/src/parser/stmt/sub/param_list.rs
+++ b/src/parser/stmt/sub/param_list.rs
@@ -12,6 +12,18 @@ pub(crate) fn invalid_param_smiley_error(smiley: &str) -> PError {
     PError::fatal_with_exception(msg, Box::new(ex))
 }
 
+/// Build an anonymous invocant `ParamDef` for a definedness-smiley invocant
+/// marker (`Foo:D:` / `Foo:U:`). The param is named `self` (the implicit
+/// invocant name) and carries the full type constraint including the smiley so
+/// multi-dispatch can select on the invocant's definedness.
+pub(crate) fn make_smiley_invocant_param(invocant_type: String) -> ParamDef {
+    let mut p = crate::parser::stmt::sub_param::make_param("self".to_string());
+    p.type_constraint = Some(invocant_type);
+    p.is_invocant = true;
+    p.traits.push("invocant".to_string());
+    p
+}
+
 /// Strip sigil prefix from a parameter name, returning the bare name.
 pub(crate) fn strip_param_sigil(name: &str) -> &str {
     name.strip_prefix('@')

--- a/src/parser/stmt/sub/return_type.rs
+++ b/src/parser/stmt/sub/return_type.rs
@@ -181,9 +181,19 @@ pub(crate) fn parse_param_list_with_return_inner(
         }
         rest = r;
     }
-    if let Some((r, _invocant_type)) = parse_implicit_invocant_marker(rest) {
+    if let Some((r, invocant_type)) = parse_implicit_invocant_marker(rest) {
         let (r, _) = ws(r)?;
         rest = r;
+        // A definedness smiley (`Foo:D:` / `Foo:U:`) on an anonymous invocant
+        // constrains dispatch and must survive as an invocant param so that
+        // `multi method g(Foo:U:)` and `multi method g(Foo:D:)` are distinct
+        // candidates rather than collapsing into an ambiguous pair. Other
+        // anonymous typed markers (`Foo:`) are still discarded as before.
+        if invocant_type.ends_with(":D") || invocant_type.ends_with(":U") {
+            let mut inv = super::param_list::make_smiley_invocant_param(invocant_type);
+            inv.multi_invocant = multi_invocant;
+            params.push(inv);
+        }
         if rest.starts_with(')') {
             return Ok((rest, (params, return_type)));
         }

--- a/src/parser/stmt/tests_3.rs
+++ b/src/parser/stmt/tests_3.rs
@@ -114,12 +114,18 @@ fn parse_method_decl_with_match_var_param() {
 
 #[test]
 fn parse_method_decl_with_typed_invocant_marker() {
+    // A definedness-smiley invocant marker (`A:D:`) is preserved as an anonymous
+    // invocant param carrying the `A:D` constraint, so multi-dispatch can select
+    // on invocant definedness. The following `$key` is the sole positional.
     let (rest, stmts) = program("class A { method AT-KEY(A:D: $key) { 1 } }").unwrap();
     assert_eq!(rest, "");
     if let Stmt::ClassDecl { body, .. } = &stmts[0] {
         if let Stmt::MethodDecl { param_defs, .. } = &body[0] {
-            assert_eq!(param_defs.len(), 1);
-            assert_eq!(param_defs[0].name, "key");
+            assert_eq!(param_defs.len(), 2);
+            assert_eq!(param_defs[0].name, "self");
+            assert!(param_defs[0].is_invocant);
+            assert_eq!(param_defs[0].type_constraint.as_deref(), Some("A:D"));
+            assert_eq!(param_defs[1].name, "key");
         } else {
             panic!("expected MethodDecl");
         }
@@ -141,8 +147,19 @@ fn parse_method_decl_with_operator_name() {
 }
 
 #[test]
-fn parse_sub_decl_with_typed_invocant_marker() {
-    let (rest, stmts) = program("sub f(A:D: $key) { $key }").unwrap();
+fn parse_sub_decl_with_smiley_invocant_marker_is_rejected() {
+    // A definedness-smiley invocant marker (`A:D:`) in a *sub* signature is an
+    // invocant, which subs do not allow — raku rejects `sub f(A:D: $key)` at
+    // compile time, and so does mutsu now that the smiley invocant is preserved
+    // rather than silently discarded.
+    assert!(program("sub f(A:D: $key) { $key }").is_err());
+}
+
+#[test]
+fn parse_sub_decl_with_plain_typed_marker_discarded() {
+    // A plain (non-smiley) anonymous typed marker carries no dispatch-relevant
+    // constraint and is still discarded, leaving only the real params.
+    let (rest, stmts) = program("sub f(A: $key) { $key }").unwrap();
     assert_eq!(rest, "");
     if let Stmt::SubDecl { param_defs, .. } = &stmts[0] {
         assert_eq!(param_defs.len(), 1);

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -81,6 +81,11 @@ impl Interpreter {
     pub(super) fn method_positional_signature(def: &MethodDef) -> Vec<String> {
         def.param_defs
             .iter()
+            // The invocant is implicit and not part of the positional signature
+            // for role/stub conformance: a method whose only difference from a
+            // stub is a typed invocant marker (`method !foo(A:D:)` vs the stub
+            // `method !foo`) still satisfies it.
+            .filter(|pd| !(pd.is_invocant || pd.traits.iter().any(|t| t == "invocant")))
             .filter(|pd| !(pd.named || (pd.slurpy && pd.name.starts_with('%'))))
             .map(|pd| {
                 if pd.slurpy {

--- a/t/multi-method-invocant-definedness.t
+++ b/t/multi-method-invocant-definedness.t
@@ -1,0 +1,48 @@
+use v6;
+use Test;
+
+plan 10;
+
+# multi-dispatch on the invocant's definedness via anonymous :D:/:U: markers
+class Cook {
+    has @.utensils is rw;
+    multi method gist(Cook:U:) { 'U:' ~ self.^name }
+    multi method gist(Cook:D:) { 'D:' ~ @.utensils.join(',') }
+}
+is Cook.gist,                        'U:Cook',  'Cook:U: candidate on a type object';
+is Cook.new(utensils => <a b>).gist, 'D:a,b',   'Cook:D: candidate on an instance';
+
+# The same, with a named invocant carrying the smiley
+class C {
+    multi method g(C:U $s:) { 'u' }
+    multi method g(C:D $s:) { 'd' }
+}
+is C.g,     'u', 'named :U invocant on type object';
+is C.new.g, 'd', 'named :D invocant on instance';
+
+# A single (non-multi) :D: method still binds self and enforces the constraint
+class D {
+    method who(D:D:) { self.^name }
+}
+is D.new.who, 'D', 'single :D: method binds self';
+dies-ok { D.who }, ':D: method rejects a type-object invocant';
+
+# :D: method with a following positional param
+class E {
+    method f(E:D: $x) { $x * 2 }
+}
+is E.new.f(21), 42, ':D: invocant plus a positional param';
+
+# :U:/:D: combined with a return type
+class F {
+    multi method label(F:U: --> Str) { 'type' }
+    multi method label(F:D: --> Str) { 'instance' }
+}
+is F.label,     'type',     ':U: candidate with return type';
+is F.new.label, 'instance', ':D: candidate with return type';
+
+# A plain (no-smiley) anonymous invocant marker is still fine
+class G {
+    method h(G:) { 'ok' }
+}
+is G.new.h, 'ok', 'plain anonymous typed invocant marker still works';


### PR DESCRIPTION
## Summary

doc-diff backlog finding (working from the end of `docs/doc-diff-backlog.md`): `Language/classtut.rakudoc`.

```raku
class C {
    multi method g(C:U:) { "undef" }
    multi method g(C:D:) { "def" }
}
say C.g;      # raku: undef   mutsu (before): Ambiguous call to 'g(C: )'
say C.new.g;  # raku: def     mutsu (before): Ambiguous call to 'g(C: )'
```

The method-signature parser discarded an **anonymous typed invocant marker**
(`Foo:D:` / `Foo:U:`) entirely, dropping the definedness constraint that makes the
two candidates distinct — so both collapsed to `(C: ...)` and every call was ambiguous.

## Change

Preserve a definedness-smiley invocant marker as a synthesized anonymous invocant
param (named `self`, `type_constraint = "Foo:D"`) in the method / signature-literal
parse path (`parse_param_list_with_return_inner`). This flows through the existing
method-registration logic, which already keeps the invocant param's `type_constraint`
(including the smiley) and uses it for candidate selection.

Plain markers without a smiley (`Foo:`) are still discarded, so behavior is unchanged
except where the smiley is load-bearing.

Side effects (both match raku):
- `sub f(Foo:D: $x)` is now correctly rejected — invocants aren't allowed in subs.
- A single non-multi `method m(Foo:D:)` now enforces the definedness constraint on its invocant (calling it on a type object errors, as in raku).

## Verification

- New test `t/multi-method-invocant-definedness.t` (10 subtests) — anonymous & named smiley invocants, single `:D:` methods, `:D:`+positional, `:U:`/`:D:` with return types, plain marker.
- Updated the two parser unit tests that encoded the old discard-the-marker behavior.
- `cargo test --lib`: 577 pass.
- roast `S12-methods/multi.t`, `S12-subset/subtypes.t`: pass.
- Full classtut example (`⚗Cook⚗` / `⚗ Cooks with ...`) now matches raku byte-for-byte; the harness finding dropped from 2/10 to 1/10 (the remaining one is unrelated — `.^methods(:local)` POPULATE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)