### PR TITLE
fix: polymod decomposes Rat divisors exactly (no float noise)

### DIFF
--- a/src/runtime/methods_collection_ops/first_polymod_tree.rs
+++ b/src/runtime/methods_collection_ops/first_polymod_tree.rs
@@ -224,6 +224,15 @@ impl Interpreter {
                 _ => divisors.push(arg.clone()),
             }
         }
+        // Exact path: when the invocant and every divisor are non-negative
+        // Int/Rat and the list is finite, do the decomposition in exact rational
+        // arithmetic so results like `5.Rat.polymod(.3, .2)` stay `(0.2 0 80)`
+        // instead of accreting float noise. Any operand outside that domain (Num,
+        // BigRat, negatives, a zero divisor, an infinite source, or an i128
+        // overflow) falls through to the float loop below unchanged.
+        if !has_infinite && let Some(exact) = polymod_exact(target, &divisors) {
+            return Ok(Value::seq(exact));
+        }
         let mut result = Vec::new();
         let mut stopped = false;
         for d in &divisors {
@@ -349,4 +358,74 @@ impl Interpreter {
             Ok(Value::array(processed))
         }
     }
+}
+
+/// A non-negative Int/Rat as an exact rational `(num, den)` with `den > 0`.
+/// Returns `None` for any other value (Num, BigInt/BigRat, negatives), which
+/// signals `polymod_exact` to bail to the float path.
+fn polymod_rat(v: &Value) -> Option<(i128, i128)> {
+    match v.view() {
+        ValueView::Int(n) if n >= 0 => Some((n as i128, 1)),
+        ValueView::Rat(n, d) if n >= 0 && d > 0 => Some((n as i128, d as i128)),
+        ValueView::Bool(b) => Some((if b { 1 } else { 0 }, 1)),
+        _ => None,
+    }
+}
+
+/// Build an exact `Value` from a rational, reducing to lowest terms and
+/// preferring `Int` when the denominator is 1. Returns `None` if the reduced
+/// numerator/denominator do not fit `i64` (mutsu's `Rat` payload width), so the
+/// caller can fall back to the float path rather than truncating.
+fn polymod_rat_value(num: i128, den: i128) -> Option<Value> {
+    debug_assert!(den > 0);
+    let g = gcd_i128(num.abs(), den);
+    let g = if g == 0 { 1 } else { g };
+    let n = num / g;
+    let d = den / g;
+    if d == 1 {
+        i64::try_from(n).ok().map(Value::int)
+    } else {
+        let n = i64::try_from(n).ok()?;
+        let d = i64::try_from(d).ok()?;
+        Some(crate::value::make_rat(n, d))
+    }
+}
+
+fn gcd_i128(mut a: i128, mut b: i128) -> i128 {
+    while b != 0 {
+        (a, b) = (b, a % b);
+    }
+    a.abs()
+}
+
+/// Exact rational `polymod`: `n.polymod(d1, d2, ...)` yields
+/// `(n mod d1, (n div d1) mod d2, ..., final quotient)`, all computed without
+/// floating point. Returns `None` (bail to float) when any operand is out of
+/// the non-negative Int/Rat domain, a divisor is zero, or an intermediate
+/// value overflows `i128` / does not fit back into a `Rat`.
+fn polymod_exact(target: &Value, divisors: &[Value]) -> Option<Vec<Value>> {
+    let (mut nn, mut nd) = polymod_rat(target)?;
+    let mut result = Vec::with_capacity(divisors.len() + 1);
+    for d in divisors {
+        let (dn, dd) = polymod_rat(d)?;
+        if dn == 0 {
+            return None; // zero divisor: leave to the float path's own handling
+        }
+        // q = floor( (nn/nd) / (dn/dd) ) = floor( (nn*dd) / (nd*dn) ); all terms
+        // are non-negative here, so truncating division already floors.
+        let p = nn.checked_mul(dd)?;
+        let qden = nd.checked_mul(dn)?;
+        let q = p / qden;
+        // r = n - q*d = (nn*dd - q*dn*nd) / (nd*dd)
+        let r_num = nn
+            .checked_mul(dd)?
+            .checked_sub(q.checked_mul(dn)?.checked_mul(nd)?)?;
+        let r_den = nd.checked_mul(dd)?;
+        result.push(polymod_rat_value(r_num, r_den)?);
+        // The carried quotient is always an integer.
+        nn = q;
+        nd = 1;
+    }
+    result.push(polymod_rat_value(nn, nd)?);
+    Some(result)
 }

--- a/t/polymod-rat-exact.t
+++ b/t/polymod-rat-exact.t
@@ -1,0 +1,22 @@
+use v6;
+use Test;
+
+plan 9;
+
+# Rat divisors must be decomposed in exact rational arithmetic, not float —
+# otherwise the results accrete noise like (0.20000000000000018 ...).
+is 5.Rat.polymod(.3, .2).gist, '(0.2 0 80)', 'Rat divisors stay exact';
+is (2/3).polymod(1/3).gist,    '(0 2)',      'fractional invocant and divisor';
+is (⅔).polymod(⅓).gist,        '(0 2)',      'unicode fraction literals';
+
+# The results are genuine Rats / Ints, not Nums with float tails
+is 5.Rat.polymod(.3, .2)[0], 0.2, 'first remainder equals 1/5 exactly';
+ok 5.Rat.polymod(.3, .2)[0] == 1/5, 'remainder compares equal to 1/5';
+is 5.Rat.polymod(.3, .2)[2].WHAT.gist, '(Int)', 'final quotient is an Int';
+
+# Integer polymod is unchanged (still exact, matches the docs)
+is 120.polymod(10).gist,    '(0 12)',  '120.polymod(10)';
+is 120.polymod(10,10).gist, '(0 2 1)', '120.polymod(10,10)';
+
+# Rat invocant with mixed Rat/Int divisors
+is (7/2).polymod(1/2, 2).gist, '(0 1 3)', 'Rat invocant, mixed Rat/Int divisors';


### PR DESCRIPTION
## Summary

doc-diff backlog finding (working from the end of `docs/doc-diff-backlog.md`): `Type/Real.rakudoc`.

```raku
say 5.Rat.polymod(.3, .2);   # raku: (0.2 0 80)
                             # mutsu (before): (0.20000000000000018 0.19999999999999912 79)
```

`method_polymod` did the entire decomposition in `f64`, so `Rat` divisors accreted floating-point noise.

## Change

Add an exact-rational fast path taken when the invocant and every divisor are non-negative `Int`/`Rat` and the divisor list is finite. Each step's remainder and carried quotient are computed as `i128` rationals and reduced back to `Int`/`Rat`.

Anything outside that domain — `Num`, `BigRat`, negatives, a zero divisor, an infinite lazy source, or an `i128`/`i64` overflow — falls through to the existing float loop unchanged, so:
- integer `polymod` results are byte-identical to before (float is already exact for integers < 2^53),
- the lazy/infinite-list paths are untouched.

## Verification

- New test `t/polymod-rat-exact.t` (9 subtests).
- `t/polymod-seq.t`, `t/polymod-lazy-seq.t`, roast `S32-num/polymod.t`: all pass.
- Cross-checked several Rat/mixed cases against `raku` (`(7/2).polymod(1/2, 2)` → `(0 1 3)`, etc.).

Note: `120.polymod(1, ...)` returning `(120)` in raku v6.d (early-stop on a `1` divisor) is a separate, pre-existing mutsu-vs-raku difference — and raku there contradicts its own `Int.polymod` doc — so it is intentionally out of scope for this precision fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)