### PR TITLE
fix: accept apostrophes in private method call names (self!foo'bar)

### DIFF
--- a/src/parser/expr/postfix/call_method.rs
+++ b/src/parser/expr/postfix/call_method.rs
@@ -1,6 +1,6 @@
 use crate::ast::Expr;
 use crate::parser::helpers::ws;
-use crate::parser::parse_result::{PResult, parse_char, take_while1};
+use crate::parser::parse_result::{PResult, parse_char};
 use crate::symbol::Symbol;
 
 pub(crate) fn auto_invoke_bareword_method_target(expr: Expr) -> Expr {
@@ -276,8 +276,11 @@ pub(crate) fn parse_private_method_name(input: &str) -> Option<(&str, String)> {
     let mut name = String::new();
     let mut first = true;
     loop {
-        let (r, part) =
-            take_while1(rest, |c: char| c.is_alphanumeric() || c == '_' || c == '-').ok()?;
+        // Private method names follow standard Raku identifier rules, which
+        // allow hyphens and apostrophes between word segments (e.g.
+        // `rotate-left'right`). Use the canonical identifier parser rather than
+        // a crude char class so those separators are handled correctly.
+        let (r, part) = crate::parser::stmt::parse_raku_ident(rest).ok()?;
         if !first {
             name.push_str("::");
         }

--- a/t/private-method-apostrophe-name.t
+++ b/t/private-method-apostrophe-name.t
@@ -1,0 +1,34 @@
+use Test;
+
+# A private method call `self!name` must accept apostrophes inside the
+# identifier, matching Raku's identifier rules (hyphens and apostrophes are
+# allowed between word segments). Regression: `self!rotate-left'right` used to
+# fail to parse because the private-method-name scanner only allowed hyphens.
+# (AVL-Tree dist uses `rotate-left'right` / `rotate-right'left`.)
+
+plan 4;
+
+class C {
+    method !foo-x'y($n) { $n * 2 }
+    method call-colon() { self!foo-x'y: 5 }
+    method call-paren() { self!foo-x'y(7) }
+}
+
+is C.new.call-colon, 10, "private call with apostrophe name (colon args)";
+is C.new.call-paren, 14, "private call with apostrophe name (paren args)";
+
+# Apostrophe only counts when followed by a letter; a trailing quote still ends
+# the name. `self!foo` followed by a quoted string arg must not be swallowed.
+class D {
+    method !foo($n) { $n }
+    method go() { self!foo('ok') }
+}
+is D.new.go, 'ok', "apostrophe not followed by letter ends the method name";
+
+# Mixed hyphen + apostrophe segments.
+class E {
+    method !rotate-left'right($x) { "L$x" }
+    method !rotate-right'left($x) { "R$x" }
+    method both() { self!rotate-left'right(1) ~ self!rotate-right'left(2) }
+}
+is E.new.both, "L1R2", "multiple apostrophe/hyphen private method names";


### PR DESCRIPTION
`self!rotate-left'right` failed to parse: the private-method-name scanner used a crude character class (alphanumeric, `_`, `-`) that omitted the apostrophe, even though the matching `method !rotate-left'right` definition parsed fine. Raku identifiers allow both hyphens and apostrophes between word segments.

Reuse the canonical `parse_raku_ident` for each `::`-separated segment so private method names follow the same identifier rules as everywhere else.

Fixes loading the **AVL-Tree** dist (uses `rotate-left'right` / `rotate-right'left`). Pinned by `t/private-method-apostrophe-name.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)