### PR TITLE
fix: Complex.round(Rat scale) is exact (no float noise)

### DIFF
--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -1156,11 +1156,22 @@ pub(crate) fn native_method_1arg(
             fn raku_round(v: f64) -> f64 {
                 (v + 0.5).floor()
             }
-            fn round_real(x: f64, scale: f64) -> f64 {
+            fn round_real(x: f64, scale: f64, scale_val: &Value) -> f64 {
                 if scale == 0.0 {
                     raku_round(x)
                 } else {
-                    raku_round(x / scale) * scale
+                    let k = raku_round(x / scale);
+                    // Multiply back by the scale, but when the scale is an exact
+                    // rational do the final step as `k * num / den` so a scale
+                    // like 0.1 (== 1/10) yields `k / 10` (the exact nearest
+                    // double) instead of `k * 0.1`, which carries float noise
+                    // (e.g. -39 * 0.1 == -3.9000000000000004).
+                    match scale_val.view() {
+                        ValueView::Rat(n, d) | ValueView::FatRat(n, d) if d != 0 => {
+                            k * n as f64 / d as f64
+                        }
+                        _ => k * scale,
+                    }
                 }
             }
             // Unwrap target allomorphic types too
@@ -1171,8 +1182,8 @@ pub(crate) fn native_method_1arg(
             };
             // Handle Complex target separately — always returns Complex
             if let ValueView::Complex(re, im) = unwrapped_target.view() {
-                let rr = round_real(re, scale);
-                let ri = round_real(im, scale);
+                let rr = round_real(re, scale, unwrapped_arg);
+                let ri = round_real(im, scale, unwrapped_arg);
                 return Some(Ok(Value::complex(rr, ri)));
             }
             let x = match unwrapped_target.view() {
@@ -1183,7 +1194,7 @@ pub(crate) fn native_method_1arg(
                 ValueView::FatRat(n, d) if d != 0 => n as f64 / d as f64,
                 _ => return None,
             };
-            let result = round_real(x, scale);
+            let result = round_real(x, scale, unwrapped_arg);
             // Return type depends on the scale type
             match scale_type {
                 RoundResult::Int => {

--- a/t/complex-round-scale.t
+++ b/t/complex-round-scale.t
@@ -1,0 +1,19 @@
+use v6;
+use Test;
+
+plan 6;
+
+# Complex.round($scale) with a Rat scale must not accrete float noise:
+# the imaginary part was -3.9000000000000004 instead of -3.9.
+is (1.256-3.875i).round(0.1).gist, '1.3-3.9i', 'Complex.round(0.1) is exact';
+is (1.2-3.8i).round.gist,          '1-4i',     'Complex.round (no scale)';
+is (1.44+2.66i).round(0.1).gist,   '1.4+2.7i', 'Complex.round(0.1) positive parts';
+is (12.34+56.78i).round(0.01).gist, '12.34+56.78i', 'Complex.round(0.01)';
+
+# A Num (not Rat) scale keeps raku's float behavior — 0.1e0 is a Num, so
+# `k * 0.1` noise is expected and matches raku (the exact path is Rat-only).
+is (1.256-3.875i).round(0.1e0).gist, '1.3-3.9000000000000004i',
+    'Complex.round with a Num scale matches raku (float)';
+
+# Real (non-Complex) rounding with a Rat scale stays exact too
+is 2.35e0.round(0.1), 2.4, 'Num.round(0.1) stays clean';


### PR DESCRIPTION
## Summary

doc-diff backlog finding (working from the end of `docs/doc-diff-backlog.md`): `Type/Complex.rakudoc`.

```raku
say (1.256-3.875i).round(0.1);   # raku: 1.3-3.9i
                                 # mutsu (before): 1.3-3.9000000000000004i
```

`round_real` finished with `raku_round(x/scale) * scale`, and `-39 * 0.1` carries float error.

## Change

When the scale is an exact rational (`Rat`/`FatRat`), do the final multiply-back as `k * num / den` so a scale like `0.1` (== 1/10) yields `k / 10` — the exact nearest double — instead of `k * 0.1`. A `Num` scale keeps raku's float behavior (raku *also* returns `1.3-3.9000000000000004i` for a `Num` scale), so the exact path is Rat-scale-only.

Both the `Complex`-target and general `Num`/`Rat`-target branches route through `round_real`, so the fix is consistent (the `Int`/`Rat`-target exact fast path via `exact_round_scaled` is unchanged).

## Verification

- New test `t/complex-round-scale.t` (6 subtests), including the Num-scale case pinned to raku's float result.
- `t/round-exact-scale.t` and other `.round` tests pass; a spread of `.round(scale)` values cross-checked against `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)