### PR TITLE
fix: accept any sigil in orwith pointy-block parameter (-> &edit)

### DIFF
--- a/src/parser/stmt/control/conditionals.rs
+++ b/src/parser/stmt/control/conditionals.rs
@@ -246,16 +246,25 @@ pub(crate) fn parse_elsif_chain(
             let (r, orwith_cond_expr) = condition_expr(r)?;
             let (r, _) = ws(r)?;
             // Check for optional pointy block: orwith EXPR -> $param { ... }
+            // The bound variable may use any sigil (e.g. `-> &edit { ... }`),
+            // not just `$`. VarDecl names strip a leading `$` but keep `&`/`@`/`%`.
             let (r, orwith_param_name) = if let Some(r2) = r.strip_prefix("->") {
                 let (r2, _) = ws(r2)?;
-                if let Some(r_after_sigil) = r2.strip_prefix('$') {
+                let sigil = r2.chars().next();
+                if let Some(sig) = sigil.filter(|&c| c == '$' || c == '&' || c == '@' || c == '%') {
+                    let r_after_sigil = &r2[sig.len_utf8()..];
                     let end = r_after_sigil
                         .find(|c: char| !c.is_alphanumeric() && c != '_' && c != '-')
                         .unwrap_or(r_after_sigil.len());
                     let name = &r_after_sigil[..end];
                     let r2 = &r_after_sigil[end..];
                     let (r2, _) = ws(r2)?;
-                    (r2, Some(name.to_string()))
+                    let decl_name = if sig == '$' {
+                        name.to_string()
+                    } else {
+                        format!("{sig}{name}")
+                    };
+                    (r2, Some(decl_name))
                 } else {
                     (r, None)
                 }

--- a/src/parser/stmt/control/with_stmt.rs
+++ b/src/parser/stmt/control/with_stmt.rs
@@ -307,16 +307,25 @@ pub(crate) fn with_stmt(input: &str) -> PResult<'_, Stmt> {
         let (r, _) = ws(r)?;
 
         // Check for optional pointy block on orwith: orwith EXPR -> $param { ... }
+        // The bound variable may use any sigil (e.g. `-> &edit { ... }`), not
+        // just `$`. VarDecl names strip a leading `$` but keep `&`/`@`/`%`.
         let (r, orwith_param_name) = if let Some(r2) = r.strip_prefix("->") {
             let (r2, _) = ws(r2)?;
-            if let Some(r_after_sigil) = r2.strip_prefix('$') {
+            let sigil = r2.chars().next();
+            if let Some(sig) = sigil.filter(|&c| c == '$' || c == '&' || c == '@' || c == '%') {
+                let r_after_sigil = &r2[sig.len_utf8()..];
                 let end = r_after_sigil
                     .find(|c: char| !c.is_alphanumeric() && c != '_' && c != '-')
                     .unwrap_or(r_after_sigil.len());
                 let name = &r_after_sigil[..end];
                 let r2 = &r_after_sigil[end..];
                 let (r2, _) = ws(r2)?;
-                (r2, Some(name.to_string()))
+                let decl_name = if sig == '$' {
+                    name.to_string()
+                } else {
+                    format!("{sig}{name}")
+                };
+                (r2, Some(decl_name))
             } else if let Some(r_after_backslash) = r2.strip_prefix('\\') {
                 let end = r_after_backslash
                     .find(|c: char| !c.is_alphanumeric() && c != '_' && c != '-')

--- a/t/orwith-pointy-sigil.t
+++ b/t/orwith-pointy-sigil.t
@@ -1,0 +1,53 @@
+use Test;
+
+# `orwith EXPR -> PARAM { ... }` must accept a pointy parameter with any sigil,
+# not just `$`. Regression: `orwith ... -> &edit { ... }` failed to parse
+# ("Unexpected block in infix position") because the orwith pointy-block parser
+# only recognized `$`-sigil parameters. (Edit::Files dist binds `-> &edit`.)
+
+plan 5;
+
+# with ... orwith chain, &-sigil pointy bound to a Callable
+{
+    my &f = { 42 };
+    my $out;
+    with Any { $out = 'with' }
+    orwith &f -> &edit { $out = edit() }
+    is $out, 42, "with/orwith with &-sigil pointy (callable)";
+}
+
+# if ... orwith ... else chain (the shape Edit::Files uses)
+{
+    my &f = { 7 };
+    my $out;
+    if False { $out = 'if' }
+    orwith &f -> &edit { $out = edit() }
+    else { $out = 'else' }
+    is $out, 7, "if/orwith/else with &-sigil pointy";
+}
+
+# @-sigil pointy binds the topic as an array
+{
+    my @vals = 1, 2, 3;
+    my $out;
+    with Nil { }
+    orwith @vals -> @a { $out = @a.sum }
+    is $out, 6, "orwith with @-sigil pointy";
+}
+
+# %-sigil pointy binds the topic as a hash
+{
+    my %h = a => 1, b => 2;
+    my $out;
+    with Nil { }
+    orwith %h -> %m { $out = %m<a> + %m<b> }
+    is $out, 3, "orwith with %-sigil pointy";
+}
+
+# $-sigil pointy still works (no regression)
+{
+    my $out;
+    with Nil { }
+    orwith 99 -> $v { $out = $v }
+    is $out, 99, "orwith with \$-sigil pointy still works";
+}


### PR DESCRIPTION
`orwith EXPR -> &edit { ... }` failed to parse ("Unexpected block in infix position"): the orwith pointy-block parser only recognized a `$`-sigil parameter. Raku allows binding the topic to a parameter of any sigil.

Generalize the hand-rolled parameter scanner in both orwith paths — the `if`/`elsif` chain (`conditionals.rs`) and the `with`/`without` chain (`with_stmt.rs`) — to accept `$`/`&`/`@`/`%` sigils, keeping the VarDecl-name convention (strip a leading `$`, keep the others).

Fixes loading the **Edit::Files** dist, which binds `orwith ::('&' ~ $editor) -> &edit`. Pinned by `t/orwith-pointy-sigil.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)