### PR TITLE
fix: accept the explicit greedy marker `**!` on range quantifiers

### DIFF
--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -2947,12 +2947,19 @@ impl Interpreter {
                         if chars.peek() == Some(&'*') {
                             // `**` quantifier: parse count or range
                             chars.next();
-                            // Handle frugal modifier: **? means non-greedy
-                            starstar_frugal = if chars.peek() == Some(&'?') {
-                                chars.next();
-                                true
-                            } else {
-                                false
+                            // Handle the greediness modifier: `**?` is frugal
+                            // (non-greedy); `**!` is the explicit greedy marker
+                            // (the same as a bare `**`, but written out).
+                            starstar_frugal = match chars.peek() {
+                                Some(&'?') => {
+                                    chars.next();
+                                    true
+                                }
+                                Some(&'!') => {
+                                    chars.next();
+                                    false
+                                }
+                                _ => false,
                             };
                             // Skip whitespace after ** or **?
                             while chars.peek().is_some_and(|ch| ch.is_whitespace()) {

--- a/t/regex-starstar-greedy-marker.t
+++ b/t/regex-starstar-greedy-marker.t
@@ -1,0 +1,22 @@
+use v6;
+use Test;
+
+# The `**` range quantifier accepts an explicit greediness marker:
+# `**?` is frugal (non-greedy) and `**!` is the explicit greedy marker
+# (identical to a bare `**`, just written out). Regression: mutsu only
+# recognized `**?` and choked on `**!` with "Unrecognized regex
+# metacharacter !". (Language/regexes.rakudoc)
+
+plan 6;
+
+# Frugal vs explicit-greedy on a bracketed range quantifier.
+is ~('/foo/o/bar/' ~~ /\/.**?{1..10}\//), '/foo/', '**?{1..10} is frugal (minimal)';
+is ~('/foo/o/bar/' ~~ /\/.**!{1..10}\//), '/foo/o/bar/', '**!{1..10} is greedy (maximal)';
+
+# `**!` matches the same as a bare `**` (both greedy).
+is ~('aaaa' ~~ /a**!{1..3}/), 'aaa', '**!{1..3} greedily takes 3';
+is ~('aaaa' ~~ /a**{1..3}/),  'aaa', 'bare **{1..3} also greedy (baseline)';
+
+# The marker also works on a plain count and a non-brace range.
+is ~('aaaa' ~~ /a**!2/),      'aa',  '**!N works on an exact count';
+is ~('aaaaa' ~~ /a**!2..4/),  'aaaa', '**!N..M works on a bare range';


### PR DESCRIPTION
## Summary

The `**` range quantifier takes an optional greediness marker: `**?` is frugal (non-greedy) and `**!` is the **explicit greedy marker** — identical to a bare `**`, just spelled out. mutsu only consumed the `**?` frugal form; a `**!` hit the generic metachar scanner and died:

```raku
say '/foo/o/bar/' ~~ /\/.**!{1..10}\//;   # raku: ｢/foo/o/bar/｣
                                          # mutsu (before): Runtime error: Unrecognized regex metacharacter !
```

## Fix

Extend the post-`**` marker check to also consume `!`, treating it as explicit-greedy (`frugal = false`, the default). Covers the bracketed range (`**!{1..10}`), an exact count (`**!2`), and a bare range (`**!2..4`).

From the `Language/regexes.rakudoc` doc-diff backlog (finding [10]).

## Testing

- New pin `t/regex-starstar-greedy-marker.t`.
- All 72 `t/regex-*.t` pass; roast `S05-metasyntax/repeat.t`, `S05-mass/{stdrules,recursive}.t` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)