### PR TITLE
fix: accept parametrized type in returns/of sub traits (returns Array[Int])

### DIFF
--- a/src/parser/stmt/sub/traits.rs
+++ b/src/parser/stmt/sub/traits.rs
@@ -5,8 +5,36 @@ use super::*;
 /// stopped at the `(` and the trailing `()` was left to be parsed as a sub body.
 fn parse_trait_type_name(input: &str) -> PResult<'_, String> {
     let (rest, base) = take_while1(input, |c: char| c.is_alphanumeric() || c == '_' || c == ':')?;
+    let mut base = base.to_string();
+    let mut rest = rest;
+    // Parametrization: `returns Array[Int]`, `of Maybe[Array]`. Scan a balanced
+    // `[...]` (nested brackets allowed) and fold it into the type-name string,
+    // matching how the `-->` return-type annotation records `"Array[Int]"`.
+    if rest.starts_with('[') {
+        let bytes = rest.as_bytes();
+        let mut depth = 0i32;
+        let mut end = None;
+        for (i, &b) in bytes.iter().enumerate() {
+            match b {
+                b'[' => depth += 1,
+                b']' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = Some(i);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let Some(close) = end else {
+            return Err(PError::expected("closing ']' of a parametrized type"));
+        };
+        base.push_str(&rest[..=close]);
+        rest = &rest[close + 1..];
+    }
     let Some(inner) = rest.strip_prefix('(') else {
-        return Ok((rest, base.to_string()));
+        return Ok((rest, base));
     };
     let mut depth = 1usize;
     for (idx, ch) in inner.char_indices() {

--- a/t/returns-parametrized-type.t
+++ b/t/returns-parametrized-type.t
@@ -1,0 +1,27 @@
+use Test;
+
+# The `returns` / `of` sub traits must accept a parametrized type name such as
+# `Array[Int]` or `Maybe[Array]`. Regression: the trait-type-name parser only
+# handled a bare name plus an optional `(...)` coercion source, so it stopped at
+# the `[` and left `[Int] { ... }` behind, failing to parse. The `-->` form
+# already handled parametrization. (Clu::Command dist uses `returns Maybe[Array]`.)
+
+plan 5;
+
+sub r-plain() returns Array[Int] { my Int @a = 1, 2; @a }
+is r-plain(), [1, 2], "returns Array[Int]";
+
+sub o-plain() of Array[Int] { my Int @a = 3, 4; @a }
+is o-plain(), [3, 4], "of Array[Int]";
+
+# Nested parametrization
+sub nested() returns Hash[Str] { my Str %h = a => 'x'; %h }
+is nested()<a>, 'x', "returns Hash[Str] (nested type param)";
+
+# `of` chaining onto a preceding role type still works (no regression)
+sub chained(--> Positional) { }
+ok chained.defined.not, "of-chaining path unaffected";
+
+# `returns Str()` coercion source still works (no regression)
+sub coerce() returns Str() { 42 }
+is coerce().^name, 'Str', "returns Str() coercion still works";


### PR DESCRIPTION
`sub f() returns Array[Int] { ... }` failed to parse: the `returns`/`of` trait-type-name parser only handled a bare type name plus an optional `(...)` coercion source, so it stopped at the `[` in a parametrized type (`Array[Int]`, `Maybe[Array]`) and left `[Int] { }` to be misparsed as a sub body. The `-->` return-type form already handled parametrization.

Scan a balanced `[...]` (nested brackets allowed) after the base name and fold it into the type-name string, matching how `-->` records `"Array[Int]"`.

Advances loading the **Clu::Command** dist (declares `returns Maybe[Array]`; now reaches its missing-dep boundary, same as raku). Pinned by `t/returns-parametrized-type.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)