### PR TITLE
fix: strip the backslash from an escaped `\%` in an s/// replacement

### DIFF
--- a/src/vm/vm_subst_apply.rs
+++ b/src/vm/vm_subst_apply.rs
@@ -358,6 +358,12 @@ impl Interpreter {
                         out.push('@');
                         i += 2;
                     }
+                    b'%' => {
+                        // `%` is a sigil (a bare `%(...)` would interpolate a
+                        // hash), so `\%` is an escaped literal percent.
+                        out.push('%');
+                        i += 2;
+                    }
                     b'{' => {
                         out.push('{');
                         i += 2;

--- a/t/subst-replacement-escape-percent.t
+++ b/t/subst-replacement-escape-percent.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+# In an `s///` replacement, `%` is a sigil (a bare `%(...)` would interpolate
+# a hash), so `\%` is an escaped literal percent — the backslash is stripped,
+# like `\$` and `\@`. Regression: mutsu handled `\$`/`\@` but left `\%`
+# literal ("\%"). (Language/regexes.rakudoc)
+
+plan 4;
+
+{
+    $_ = 'foo';
+    s/foo/\%(/;
+    is $_, '%(', '\% in a replacement becomes a literal %';
+}
+{
+    $_ = 'x';
+    s/x/\$/;
+    is $_, '$', '\$ still works (baseline)';
+}
+{
+    $_ = 'y';
+    s/y/\@/;
+    is $_, '@', '\@ still works (baseline)';
+}
+{
+    $_ = 'z';
+    s/z/100\%/;
+    is $_, '100%', '\% works mid-string too';
+}


### PR DESCRIPTION
## Summary

`%` is a sigil in an `s///` replacement (a bare `%(...)` interpolates a hash), so `\%` is an escaped literal percent whose backslash should be stripped — exactly like `\$` and `\@`:

```raku
$_ = 'foo';
s/foo/\%(/;
.say;    # raku: %(    mutsu (before): \%(
```

mutsu's replacement interpolator handled `\$`/`\@`/`\{` but had no `\%` arm.

## Fix

Add the `b'%'` escape arm to `interpolate_subst_replacement_with_closures`.

From the `Language/regexes.rakudoc` doc-diff backlog (finding [19]).

## Testing

- New pin `t/subst-replacement-escape-percent.t`.
- All `t/subst-*.t` + `t/ss-substitution.t` pass; roast `S05-substitution/{subst,match}.t` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)