### PR TITLE
fix: accept a bare trailing colon on a return value (return $x:)

### DIFF
--- a/src/parser/stmt/simple/control_stmts.rs
+++ b/src/parser/stmt/simple/control_stmts.rs
@@ -23,6 +23,24 @@ pub(crate) fn return_stmt(input: &str) -> PResult<'_, Stmt> {
         remaining_len: err.remaining_len.or(Some(rest.len())),
         exception: None,
     })?;
+    // `return $x:` is the indirect-method-call spelling `$x.return`, which
+    // returns `$x` from the enclosing routine — identical to `return $x`. Accept
+    // a bare trailing colon (no colon-args), i.e. a `:` immediately followed by a
+    // statement terminator, and consume it. A `:` that starts an adverb/pair
+    // (`:foo`, `:$x`) is left alone. (Geo::Ellipsoid::Utils writes `return $x:`.)
+    let rest = {
+        let (after_ws, _) = ws(rest)?;
+        if let Some(after_colon) = after_ws.strip_prefix(':').filter(|r| !r.starts_with(':')) {
+            let (probe, _) = ws(after_colon)?;
+            if probe.is_empty() || probe.starts_with(';') || probe.starts_with('}') {
+                after_colon
+            } else {
+                rest
+            }
+        } else {
+            rest
+        }
+    };
     let stmt = Stmt::Return(expr);
     parse_statement_modifier(rest, stmt)
 }

--- a/t/return-trailing-colon.t
+++ b/t/return-trailing-colon.t
@@ -1,0 +1,30 @@
+use Test;
+
+# `return $x:` is the indirect-method-call spelling `$x.return`, which returns
+# `$x` from the enclosing routine — identical to `return $x`. Regression: mutsu
+# choked on the bare trailing colon ("Confused"). raku accepts it (though a bare
+# `$x:` statement is rejected by both). (Geo::Ellipsoid::Utils writes `return $x:`.)
+
+plan 5;
+
+sub same_line() { my $x = 42; return $x: }
+is same_line(), 42, "return \$x: on the same line as the closing brace";
+
+sub newline() {
+    my $x = 7;
+    return $x:
+}
+is newline(), 7, "return \$x: followed by newline then closing brace";
+
+sub with_expr() {
+    my @v = 1, 2, 3;
+    return @v.sum:
+}
+is with_expr(), 6, "return EXPR: where EXPR is a method call";
+
+# A `:` starting an adverb/pair is NOT consumed as a bare trailing colon.
+sub literal_ret() { return 5 }
+is literal_ret(), 5, "plain return still works (no regression)";
+
+sub bare_ret() { return }
+ok bare_ret() === Nil, "bare return still works (no regression)";


### PR DESCRIPTION
`return $x:` is the indirect-method-call spelling `$x.return`, which returns `$x` from the enclosing routine — identical to `return $x`. mutsu choked on the trailing colon ("Confused") because the return-statement parser handed the leftover `:` to the statement-modifier parser.

Consume a bare trailing colon (a `:` immediately followed by a statement terminator: `;`, `}`, or EOF) after the return value. A `:` that starts an adverb or pair (`:foo`, `:$x`) is left untouched.

Makes the **Geo::Ellipsoid** dist load fully (no external deps; its `Utils` module writes `return $degrees:`). Pinned by `t/return-trailing-colon.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)