### PR TITLE
fix: numeric allomorphs compare by base in ==/!= and smartmatch

### DIFF
--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -122,6 +122,18 @@ pub(super) fn range_cmp(left: &Value, right: &Value) -> std::cmp::Ordering {
     r_excl_end.cmp(&l_excl_end)
 }
 
+/// Unwrap an allomorph / runtime mixin (`<5.0>` RatStr, `42 but Role`) to its
+/// underlying numeric base for `==`/`!=`. Without this, comparing two mixins of
+/// the same variant falls to structural `l == r`, which also compares the string
+/// halves — so `<5.0> == <5>` was `False` instead of `5.0 == 5` (`True`). The
+/// other comparison ops already unwrap via `cmp_values`.
+fn deref_allomorph_numeric(v: Value) -> Value {
+    match v.view() {
+        ValueView::Mixin(inner, _) => deref_allomorph_numeric(inner.as_ref().clone()),
+        _ => v,
+    }
+}
+
 /// Recursively apply cmp semantics to two values (for use in list element comparison).
 pub(super) fn cmp_values(left: &Value, right: &Value) -> std::cmp::Ordering {
     // Handle NaN
@@ -254,6 +266,7 @@ impl Interpreter {
         let left = self.stack.pop().unwrap();
         let result = self.eval_binary_with_junctions(left, right, |vm, l, r| {
             let (l, r) = vm.coerce_numeric_bridge_pair(l, r)?;
+            let (l, r) = (deref_allomorph_numeric(l), deref_allomorph_numeric(r));
             // NaN is unordered: NaN == anything is always False
             if is_nan_value(&l) || is_nan_value(&r) {
                 return Ok(Value::FALSE);
@@ -297,6 +310,7 @@ impl Interpreter {
         // then negates the boolean-collapsed result, always returning Bool.
         let eq_result = self.eval_binary_with_junctions(left, right, |vm, l, r| {
             let (l, r) = vm.coerce_numeric_bridge_pair(l, r)?;
+            let (l, r) = (deref_allomorph_numeric(l), deref_allomorph_numeric(r));
             // NaN is unordered: NaN == anything is always False
             if is_nan_value(&l) || is_nan_value(&r) {
                 return Ok(Value::FALSE);

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -55,7 +55,42 @@ fn needs_interpreter_lhs(v: &Value) -> bool {
 /// interpreter.  Returns `Some(bool)` for type pairs that can be resolved purely
 /// from the values themselves, or `None` when the interpreter is required (regex
 /// matching, callable invocation, type-object checks with class registries, etc.).
+/// True when `v` is a numeric matcher for smart-match purposes — a bare numeric
+/// type or a numeric allomorph/mixin (`<5>`, `<5.0>`, `42 but Role`). Used to
+/// decide whether an allomorph LHS should compare by its numeric base.
+fn is_numericish_matcher(v: &Value) -> bool {
+    match v.view() {
+        ValueView::Int(_)
+        | ValueView::BigInt(_)
+        | ValueView::Num(_)
+        | ValueView::Rat(_, _)
+        | ValueView::FatRat(_, _)
+        | ValueView::BigRat(_, _)
+        | ValueView::Complex(_, _) => true,
+        ValueView::Mixin(inner, _) => is_numericish_matcher(inner.as_ref()),
+        _ => false,
+    }
+}
+
 pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
+    // An allomorph / numeric mixin (`<5.0>` RatStr) on the LHS compares by its
+    // numeric base when the matcher is numeric: `<5.0> ~~ 5` and `<5.0> ~~ <5>`
+    // are True. Guard on a numeric RHS so a Str matcher keeps the allomorph's
+    // string half (`<5.0> ~~ "5"` stays False, `~~ "5.0"` stays True).
+    if let ValueView::Mixin(inner, _) = left.view()
+        && is_numericish_matcher(right)
+    {
+        return pure_smart_match(&inner.as_ref().clone(), right);
+    }
+    // Symmetrically, a numeric LHS against an allomorph RHS matcher compares by
+    // the RHS's numeric base (`5.0 ~~ <5>` is True). A Str LHS is excluded, so
+    // `"5.0" ~~ <5>` keeps the RHS allomorph's string-matcher semantics (False).
+    if let ValueView::Mixin(inner, _) = right.view()
+        && is_numericish_matcher(left)
+    {
+        return pure_smart_match(left, &inner.as_ref().clone());
+    }
+
     match (left.view(), right.view()) {
         // Whatever on RHS always matches
         (_, ValueView::Whatever) => Some(true),

--- a/t/allomorph-numeric-compare.t
+++ b/t/allomorph-numeric-compare.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+plan 14;
+
+# `==` / `!=` between two numeric allomorphs must compare their numeric bases,
+# not the whole mixin (which also holds the string half). `<5.0> == <5>` was
+# False because it fell to structural equality of the two mixins.
+ok  <5.0> == <5>,  '<5.0> == <5> (RatStr vs IntStr)';
+nok <5.0> != <5>,  '<5.0> != <5> is False';
+ok  <5> == <5.0>,  '<5> == <5.0>';
+ok  <1/2> == <0.5>, '<1/2> == <0.5>';
+ok  <5.0> == 5,    '<5.0> == 5 (allomorph vs Int)';
+
+# Smart-match against a numeric matcher compares by the allomorph's numeric base
+# on either side.
+ok  <5.0> ~~ <5>,  '<5.0> ~~ <5>';
+ok  <5>   ~~ <5.0>,'<5> ~~ <5.0>';
+ok  <5.0> ~~ 5,    '<5.0> ~~ 5';
+ok  5.0   ~~ <5>,  '5.0 ~~ <5>';
+
+# A Str LHS/matcher keeps string semantics — the allomorph's string half is used.
+nok "5.0" ~~ <5>,  '"5.0" ~~ <5> is False (string mismatch)';
+ok  <5.0> ~~ "5.0",'<5.0> ~~ "5.0" is True (string match)';
+nok <5.0> ~~ "5",  '<5.0> ~~ "5" is False (string mismatch)';
+ok  <5>   ~~ "5",  '<5> ~~ "5" is True';
+
+# eqv still distinguishes the types (RatStr is not IntStr)
+nok <5.0> eqv <5>, '<5.0> eqv <5> is False (different allomorph types)';


### PR DESCRIPTION
## Summary

doc-diff backlog finding (working from the end of `docs/doc-diff-backlog.md`): `Type/Allomorph.rakudoc`.

```raku
say "5.0" ~~ <5>; # False
say 5.0   ~~ <5>; # True
say <5.0> ~~ <5>; # raku: True   mutsu (before): False
```

`<5.0> == <5>` (RatStr vs IntStr) also wrongly returned False. Both `==` and smartmatch fell through to **structural mixin equality**, which compares the allomorph's string half (`"5.0"` vs `"5"`) instead of the numeric bases `5.0` and `5`.

## Change

- `exec_num_eq_op` / `exec_num_ne_op`: unwrap `Mixin` allomorphs to their numeric base after coercion, before the same-variant `l == r` fallback.
- `pure_smart_match`: when the matcher is numeric, compare an allomorph operand (either side) by its numeric base. A `Str` LHS/matcher is **excluded**, so the allomorph's string half still governs there — `"5.0" ~~ <5>` stays False and `<5.0> ~~ "5"` stays False, matching raku.

`eqv` still distinguishes the allomorph types (RatStr is not IntStr), unchanged.

## Verification

Full 10-case matrix now matches raku byte-for-byte (`<5.0>~~<5>`, `<5>~~<5.0>`, `<5.0>~~5`, `5.0~~<5>`, `"5.0"~~<5>`, `<5.0>~~"5.0"`, `<5.0>~~"5"`, `<5>~~"5"`, `==`, `!=`).

- New test `t/allomorph-numeric-compare.t` (14 subtests).
- `cargo test --lib`: 576 pass.
- roast: all 22 `S03-smartmatch/*` whitelisted files, plus `S02-literals/allomorphic.t`, `S02-literals/numeric.t`, and the `S03-operators`/`S02-types` numeric/comparison whitelist (1648 tests) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)