### PR TITLE
fix: fold :ignoremark (and other inline modifiers) into rx// literals

### DIFF
--- a/src/parser/primary/regex/lit.rs
+++ b/src/parser/primary/regex/lit.rs
@@ -173,7 +173,14 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
                     Expr::Literal(build_regex_with_adverbs(pattern, &adverbs)),
                 ));
             }
-            return Ok((rest, Expr::Literal(Value::regex(pattern.to_string()))));
+            // Plain-Regex path: still fold in the compile-time inline modifiers
+            // (`:i`/`:m`/`:s`/`:ratchet`) as a `:m …`-style prefix. Without this,
+            // an adverb that is NOT in `adverbs_need_value` — notably
+            // `:ignoremark`/`:m` on `rx//` — was silently dropped, so
+            // `rx:ignoremark /ä/` compiled to a bare `ä` and lost its mark
+            // insensitivity (the `m:ignoremark` form already prepends `:m`).
+            let pattern = apply_inline_match_adverbs(pattern.to_string(), &adverbs);
+            return Ok((rest, Expr::Literal(Value::regex(pattern))));
         }
         return Err(PError::expected("regex closing delimiter"));
     }

--- a/t/rx-ignoremark-adverb.t
+++ b/t/rx-ignoremark-adverb.t
@@ -1,0 +1,21 @@
+use v6;
+use Test;
+
+# `rx:ignoremark` / `rx:m` must fold the mark-insensitivity into the compiled
+# Regex, exactly like the `m:ignoremark` form does. Regression: `:ignoremark`
+# was not in the set of adverbs that force inline-modifier folding, so the
+# `rx//` plain-Regex path dropped it and matched mark-sensitively.
+# (Language/regexes.rakudoc)
+
+plan 8;
+
+nok (so 'a' ~~ rx/ä/),               'baseline: rx/ä/ does not match "a"';
+ok  (so 'a' ~~ rx:ignoremark /ä/),   'rx:ignoremark /ä/ matches "a" (mark stripped from pattern)';
+ok  (so 'ä' ~~ rx:ignoremark /a/),   'rx:ignoremark /a/ matches "ä" (mark stripped from text)';
+ok  (so 'ỡ' ~~ rx:ignoremark /o/),   'rx:ignoremark strips a decomposed grapheme';
+ok  (so 'a' ~~ rx:m /ä/),            'the :m short form works the same';
+
+# The other compile-time inline adverbs on rx// still work (unaffected).
+ok  (so 'ABC' ~~ rx:i /abc/),        'rx:i is case-insensitive';
+ok  (so 'a b' ~~ rx:s /a b/),        'rx:s honors significant space';
+nok (so 'A' ~~ rx/abc/),             'a plain rx// with no adverb is literal';


### PR DESCRIPTION
## Summary

`rx:ignoremark /ä/` compiled to a bare `ä` and matched **mark-sensitively**, while the equivalent `m:ignoremark /ä/` works:

```raku
say so 'a' ~~ rx:ignoremark /ä/;    # raku: True    mutsu (before): False
say so 'ỡ' ~~ rx:ignoremark /o/;    # raku: True    mutsu (before): False
```

Root: the `rx//` builder only folded inline modifiers into the pattern when `adverbs_need_value` was true, and `ignore_mark` is **not** in that set (only `ignore_case`/`sigspace` are). So a `:ignoremark`-only `rx//` fell to the plain-Regex branch that dropped the flag. (`m:ignoremark` already prepends a `:m ` inline modifier, hence it worked.)

## Fix

Apply `apply_inline_match_adverbs` on the plain-Regex branch too, so any compile-time inline modifier (`:i`/`:m`/`:s`/`:ratchet`) is folded in as a `:m …`-style prefix regardless of `adverbs_need_value` — matching the `m//` behavior. `:i`/`:s` already took the value path and are unchanged.

From the `Language/regexes.rakudoc` doc-diff backlog (finding [8]).

## Testing

- New pin `t/rx-ignoremark-adverb.t`.
- All 72 `t/regex-*.t` pass; roast `S05-modifier/{ignoremark,ignorecase-and-ignoremark,ignorecase,sigspace,pos,continue}.t` + `S05-metasyntax/{regex,changed}.t` + `S05-mass/charsets.t` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)