### PR TITLE
fix: StrDistance numifies to its edit distance

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -651,6 +651,14 @@ pub(super) fn dispatch(
                         Value::int(0)
                     }
                 }
+                // A StrDistance's `.Int` is the edit distance between its
+                // before/after strings, matching `+$str-dist` / `.Numeric`.
+                ValueView::Instance { class_name, .. } if class_name == "StrDistance" => {
+                    Value::int(
+                        super::dispatch_core_math::cool_instance_numeric(target).unwrap_or(0.0)
+                            as i64,
+                    )
+                }
                 _ => return Some(None),
             };
             Some(Some(Ok(result)))
@@ -975,6 +983,16 @@ pub(super) fn dispatch(
                         _ => 0,
                     };
                     Value::int(count)
+                }
+                // A StrDistance (`$str ~~ tr/a/b/`) numifies to the edit distance
+                // between its before/after strings, so `+($str ~~ tr/old/new/)`
+                // is the number of changes, not 0.
+                ValueView::Instance { class_name, .. } if class_name == "StrDistance" => {
+                    match super::dispatch_core_math::cool_instance_numeric(target) {
+                        Some(n) if n.fract() == 0.0 && n.is_finite() => Value::int(n as i64),
+                        Some(n) => Value::num(n),
+                        None => Value::int(0),
+                    }
                 }
                 _ => return Some(None),
             };

--- a/src/builtins/methods_0arg/dispatch_core_math.rs
+++ b/src/builtins/methods_0arg/dispatch_core_math.rs
@@ -114,7 +114,7 @@ fn levenshtein(a: &str, b: &str) -> usize {
 /// coercers: an `IO::Path` numifies via its path string, a `Match` via its
 /// matched substring, and a `StrDistance` via the edit distance between its
 /// `before`/`after` strings.
-fn cool_instance_numeric(target: &Value) -> Option<f64> {
+pub(super) fn cool_instance_numeric(target: &Value) -> Option<f64> {
     let ValueView::Instance {
         class_name,
         attributes,

--- a/t/strdistance-numeric.t
+++ b/t/strdistance-numeric.t
@@ -1,0 +1,20 @@
+use v6;
+use Test;
+
+plan 6;
+
+# A StrDistance (`$str ~~ tr/a/b/`) stringifies to the after-string and numifies
+# to the edit distance between before and after. `+$sd` / `.Numeric` / `.Int`
+# were returning 0 instead of the number of changes.
+my $str = "fold";
+my $sd = ($str ~~ tr/old/new/);
+is $sd.^name, 'StrDistance', 'tr/// in smartmatch yields a StrDistance';
+is ~$sd, 'fnew', 'StrDistance stringifies to the after-string';
+is +$sd, 3, 'prefix + gives the edit distance';
+is $sd.Numeric, 3, '.Numeric gives the edit distance';
+is $sd.Int, 3, '.Int gives the edit distance';
+
+# No changes -> distance 0
+my $s2 = "abc";
+my $sd2 = ($s2 ~~ tr/xyz/pqr/);
+is +$sd2, 0, 'no matching chars -> distance 0';


### PR DESCRIPTION
## Summary

doc-diff backlog finding (working from the end of `docs/doc-diff-backlog.md`): `Type/StrDistance.rakudoc`.

```raku
my $str = "fold";
my $str-dist = ($str ~~ tr/old/new/);
say ~$str-dist;  # fnew   (already correct)
say +$str-dist;  # raku: 3   mutsu (before): 0
```

`StrDistance.Numeric` / `.Int` were not implemented, so the `.Numeric`/`.Int` dispatchers fell through to "no such method" and prefix `+` numified to 0.

## Change

`cool_instance_numeric` already computes the before/after edit distance (used by the `.Rat` path). Expose it `pub(super)` and route `.Numeric` and `.Int` through it for `StrDistance` instances.

Now `+$sd`, `$sd.Numeric`, and `$sd.Int` all return the number of changes (3 for `"fold"` → `"fnew"`), matching raku.

## Verification

- New test `t/strdistance-numeric.t` (6 subtests).
- The doc-diff harness on `Type/StrDistance.rakudoc` drops from 1/4 to 0/4.
- `cargo test --lib` (576) and all whitelisted `S05-transliteration/*` roast files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)