### PR TITLE
fix: accept a type smiley on a type-capture parameter (::T:U)

### DIFF
--- a/src/parser/stmt/sub_param/param_inner.rs
+++ b/src/parser/stmt/sub_param/param_inner.rs
@@ -266,8 +266,20 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
         && let Ok((r, capture_name)) = super::super::ident(after_capture)
     {
         type_constraint = Some(format!("::{}", capture_name));
-        let (r, _) = ws(r)?;
-        rest = r;
+        // A type smiley may follow the capture: `::T:U`, `::T:D`, `::T:_`
+        // constrains the argument to a type object / instance while still binding
+        // the capture. Consume it before the `:`-named-marker check below, which
+        // would otherwise misread `:U` as a named-parameter marker. (YAMLish uses
+        // `::GrammarType:U :$schema`.)
+        if r.starts_with(":D") || r.starts_with(":U") || r.starts_with(":_") {
+            let smiley = &r[..2];
+            type_constraint = Some(format!("::{}{}", capture_name, smiley));
+            let (r, _) = ws(&r[2..])?;
+            rest = r;
+        } else {
+            let (r, _) = ws(r)?;
+            rest = r;
+        }
         if rest.starts_with('=') && !rest.starts_with("==") {
             let r = &rest[1..];
             let (r, _) = ws(r)?;

--- a/t/type-capture-smiley-param.t
+++ b/t/type-capture-smiley-param.t
@@ -1,0 +1,32 @@
+use Test;
+
+# A type-capture parameter may carry a type smiley: `::T:U $x`, `::T:D :$x`.
+# Regression: mutsu misread the `:U` after `::T` as a named-parameter marker and
+# failed to parse ("Confused"). raku accepts the signature. (YAMLish declares
+# `sub load-yaml(Str $input, ::GrammarType:U :$schema = ::Schema::Core, :%tags)`.)
+#
+# Note: with the smiley, raku does not make the capture name usable in the body,
+# so these tests exercise the parameter itself, not the captured type name.
+
+plan 5;
+
+# Positional with :U smiley
+sub pos-u(::T:U $x) { $x.^name }
+is pos-u(Int), 'Int', "::T:U positional parses and binds the argument";
+
+# Positional with :D smiley
+sub pos-d(::T:D $x) { $x }
+is pos-d(42), 42, "::T:D positional parses and binds the argument";
+
+# Named with :U smiley and a default
+sub named-u(::T:U :$schema = Str) { $schema.^name }
+is named-u(), 'Str', "::T:U named param with default";
+is named-u(schema => Int), 'Int', "::T:U named param passed explicitly";
+
+# The exact shape YAMLish uses: leading typed positional, smiley'd type-capture
+# named param with default, plus a slurpy-ish named hash.
+sub yamlish-shape(Str $input, ::GrammarType:U :$schema = Int, :%tags) {
+    "$input/$schema.^name()/{%tags.elems}"
+}
+is yamlish-shape("doc", schema => Str, tags => {a => 1}),
+    "doc/Str/1", "YAMLish-shaped signature parses and binds";


### PR DESCRIPTION
`::T:U $x` / `::T:D :$x` failed to parse ("Confused"): after the `::T` capture, the parser read the `:U` type smiley as a named-parameter `:` marker. Consume a `:D`/`:U`/`:_` smiley immediately following the capture and fold it into the type-constraint string, before the named-marker check.

Advances parsing the **YAMLish** dist, whose exported `load-yaml`/`load-yamls` declare `::GrammarType:U :$schema = ::Schema::Core` (the module's parse error is cleared; a separate runtime `.map` issue remains before it loads fully). Pinned by `t/type-capture-smiley-param.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)