### PR TITLE
fix: subscript a numbered capture ($0[0]) in string interpolation

### DIFF
--- a/src/parser/primary/string/interp_var.rs
+++ b/src/parser/primary/string/interp_var.rs
@@ -241,7 +241,11 @@ pub(crate) fn try_interpolate_var<'a>(
                 index: Box::new(Expr::Literal(Value::int(index_val))),
                 is_positional: true,
             };
-            let (expr, var_rest) = try_parse_interp_method_call(&var_rest[end..], expr);
+            // A numbered capture is a Match, so a trailing subscript accesses its
+            // nested captures: `$0[0]` (positional sub-capture) / `$0<name>` /
+            // `$0{...}`. Without this the `[0]` was left as a literal fragment.
+            let (expr, var_rest) = parse_postcircumfix_index(&var_rest[end..], expr);
+            let (expr, var_rest) = try_parse_interp_method_call(var_rest, expr);
             parts.push(expr);
             return Some(var_rest);
         }

--- a/t/interp-numbered-capture-subscript.t
+++ b/t/interp-numbered-capture-subscript.t
@@ -1,0 +1,25 @@
+use v6;
+use Test;
+
+# A numbered capture ($0, $1, ...) is a Match, so a subscript in string
+# interpolation accesses its nested captures. Regression: mutsu left the
+# `[0]` as a literal fragment, printing "abc[0]" instead of the sub-capture.
+# (raku-doc Language/regexes.rakudoc)
+
+plan 6;
+
+if 'abc' ~~ / ( a (.) (.) ) / {
+    is "$0", "abc",               'plain $0 still interpolates the whole capture';
+    is "$0[0]", "b",              '$0[0] interpolates the first nested capture';
+    is "$0[1]", "c",              '$0[1] interpolates the second nested capture';
+    is "Inner: $0[0] and $0[1]", "Inner: b and c",
+                                  'both nested subscripts interpolate in one string';
+}
+
+if 'abc' ~~ / ( a $<x>=(.) . ) / {
+    is "$0<x>", "b",              '$0<name> interpolates a named sub-capture';
+}
+
+if 'abc' ~~ / (.) (.) (.) / {
+    is "$0.uc()", "A",            'method call on a numbered capture still works';
+}


### PR DESCRIPTION
## Problem

A numbered capture (`$0`, `$1`, ...) is a `Match`, so a trailing subscript in string interpolation should access its nested captures. mutsu left the `[0]` as a literal fragment:

```raku
if 'abc' ~~ / ( a (.) (.) ) / {
    say "Inner: $0[0] and $0[1]";   # raku: «Inner: b and c»
}                                    # mutsu (before): «Inner: abc[0] and abc[1]»
```

## Root cause

In `src/parser/primary/string/interp_var.rs`, the numbered-capture branch built the base `Expr::Index` for `$0` (indexing into `$/`) but then only chained `try_parse_interp_method_call` — it never called `parse_postcircumfix_index`, unlike the `$/` branch right above it. So the `[0]` / `<name>` / `{...}` after `$0` was never consumed.

## Fix

Call `parse_postcircumfix_index` in the numbered-capture branch before the method-call chain, matching the `$/` branch. This enables `$0[0]` (positional sub-capture), `$0<name>` (named sub-capture), and `$0{...}`.

Pin: `t/interp-numbered-capture-subscript.t`.

From the doc-diff QA harness (raku-doc `Language/regexes.rakudoc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)