### PR TITLE
fix: parse chained bind through an indexed lvalue ($c := %h<k> := v)

### DIFF
--- a/src/parser/stmt/assign/assign_stmt.rs
+++ b/src/parser/stmt/assign/assign_stmt.rs
@@ -565,7 +565,12 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
     // Binding (:= or ::=)
     if let Some(stripped) = rest.strip_prefix("::=").or_else(|| rest.strip_prefix(":=")) {
         let (rest, _) = ws(stripped)?;
-        let (rest, expr) = parse_comma_or_expr(rest).map_err(|err| PError {
+        // Use the assign-aware RHS parser (like every other branch here) so a
+        // chained bind whose next lvalue is indexed — `$c := %h<k> := 5` — parses:
+        // `try_parse_assign_expr` recognizes the trailing `%h<k> := 5` indexed
+        // bind, which a plain expression parser would leave behind. (Fasta binds
+        // `$current := %labels{.substr(1)} := my str @`.)
+        let (rest, expr) = parse_assign_expr_or_comma(rest).map_err(|err| PError {
             messages: merge_expected_messages(
                 "expected right-hand expression after ':='",
                 &err.messages,

--- a/src/parser/stmt/simple_expr_stmt/core.rs
+++ b/src/parser/stmt/simple_expr_stmt/core.rs
@@ -595,7 +595,10 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
         }
         let rest = &rest[2..];
         let (rest, _) = ws(rest)?;
-        let (rest, value) = parse_comma_or_expr(rest).map_err(|err| PError {
+        // Assign-aware RHS parser so a chained bind whose next lvalue is also
+        // indexed — `%h<a> := %h<b> := 7` — parses (the trailing `%h<b> := 7`
+        // indexed bind is recognized instead of being left behind).
+        let (rest, value) = parse_assign_expr_or_comma(rest).map_err(|err| PError {
             messages: merge_expected_messages(
                 "expected assigned expression after index bind",
                 &err.messages,

--- a/t/chained-bind-indexed-lvalue.t
+++ b/t/chained-bind-indexed-lvalue.t
@@ -1,0 +1,45 @@
+use Test;
+
+# A chained binding `$a := $b := VALUE` must work even when a middle term is an
+# indexed lvalue (`%h<k>`, `%h{"k"}`). Regression: the scalar `:=` statement
+# parsed its RHS with a plain expression parser that stopped at the second `:=`,
+# so `$c := %h<k> := 5` failed ("Confused"). The other assignment branches all
+# use the assign-aware RHS parser; the bind branch now does too.
+# (Fasta binds `$current := %labels{.substr(1)} := my str @`.)
+
+plan 6;
+
+{
+    my %h; my $c;
+    $c := %h<k> := 5;
+    is %h<k>, 5, "chained bind, middle angle-key lvalue: hash updated";
+    is $c, 5, "chained bind, middle angle-key lvalue: scalar bound";
+}
+
+{
+    my %h; my $c;
+    $c := %h{"j"} := 9;
+    is %h{"j"}, 9, "chained bind, middle brace-key lvalue";
+}
+
+{
+    # Both terms indexed.
+    my %h;
+    %h<a> := %h<b> := 7;
+    is (%h<a>, %h<b>).join(","), "7,7", "chained bind, both terms indexed";
+}
+
+{
+    # Fasta shape: bind a scalar to a hash element bound to a fresh native array.
+    my %labels; my $current;
+    $current := %labels<lbl> := my str @;
+    $current.push("x");
+    is %labels<lbl>, ["x"], "chained bind to a fresh anonymous native array (Fasta)";
+}
+
+{
+    # Plain scalar chain still works (no regression).
+    my $a; my $b;
+    $a := $b := 42;
+    is "$a $b", "42 42", "plain chained scalar bind still works";
+}


### PR DESCRIPTION
A chained binding whose next lvalue is indexed failed to parse ("Confused"): both the scalar-bind (`$c := ...`) and the indexed-bind (`%h<a> := ...`) statement handlers parsed their RHS with a plain expression parser that stopped at the second `:=`, leaving `%h<k> := v` behind. Every other assignment branch already uses the assign-aware `parse_assign_expr_or_comma` (which `try_parse_assign_expr` recurses through for a trailing indexed bind); route the two bind branches through it too.

Makes the **Fasta** dist load (it binds `$current := %labels{.substr(1)} := my str @`). Pinned by `t/chained-bind-indexed-lvalue.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)