### PR TITLE
fix: stop double-negating a negated char-class lookahead <![...]>

### DIFF
--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -1544,9 +1544,13 @@ impl Interpreter {
                                 } else {
                                     (false, cc_trimmed)
                                 };
-                            let class_negated = if negated { !cc_negated } else { cc_negated };
-                            if let Some(class) = self.parse_raku_char_class(cc_inner, class_negated)
-                            {
+                            // The outer `?`/`!` negation is carried by the
+                            // Lookaround's `negated` flag below; the char class
+                            // itself only reflects an inner `-[...]`. Folding
+                            // `negated` into the class here too (`!cc_negated`)
+                            // double-negated `<![...]>`, inverting it into a
+                            // positive lookahead.
+                            if let Some(class) = self.parse_raku_char_class(cc_inner, cc_negated) {
                                 // Build a lookahead with the char class as the inner pattern
                                 let inner_pattern = RegexPattern {
                                     tokens: vec![RegexToken {

--- a/t/regex-negated-charclass-lookahead.t
+++ b/t/regex-negated-charclass-lookahead.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+# A negated character-class lookahead `<![...]>` must be a single negation.
+# Regression: mutsu double-negated it (folding the `!` both into the class and
+# into the Lookaround), inverting `<![...]>` into a positive lookahead.
+# (raku-doc Language/regexes.rakudoc)
+
+plan 10;
+
+# <?[...]>  positive lookahead of the class
+is ("3x" ~~ /<?[0..9]>\w/).Str, "3",   '<?[0..9]> matches before a digit';
+nok ("ax" ~~ /<?[0..9]>\w/),           '<?[0..9]> fails before a non-digit';
+
+# <![...]>  negative lookahead of the class (the fixed case)
+is ("3x" ~~ /<![0..9]>\w/).Str, "x",   '<![0..9]> skips the digit, matches the letter';
+is ("ax" ~~ /<![0..9]>\w/).Str, "a",   '<![0..9]> matches before a non-digit';
+
+# <?-[...]>  positive lookahead of the *negated* class
+is ("3x" ~~ /<?-[0..9]>\w/).Str, "x",  '<?-[0..9]> matches before a non-digit';
+is ("ax" ~~ /<?-[0..9]>\w/).Str, "a",  '<?-[0..9]> matches before a non-digit (a)';
+
+# <!-[...]>  negative lookahead of the negated class
+is ("3x" ~~ /<!-[0..9]>\w/).Str, "3",  '<!-[0..9]> matches before a digit';
+nok ("ax" ~~ /<!-[0..9]>\w/),          '<!-[0..9]> fails before a non-digit';
+
+# The documented example that surfaced the bug.
+my regex key {^^ <![#-]> \d+ }
+is ("333" ~~ &key).Str, "333",         '<![#-]> after ^^ inside a named regex';
+nok ("#333" ~~ &key),                  '<![#-]> rejects a leading # at line start';


### PR DESCRIPTION
## Problem

A negative character-class lookahead `<![...]>` was inverted into a *positive* lookahead:

```raku
"ax" ~~ /<![0..9]>\w/   # raku: ｢a｣   mutsu (before): Nil
"3x" ~~ /<![0..9]>\w/   # raku: ｢x｣   mutsu (before): ｢3｣
```

The documented example failed outright:

```raku
my regex key {^^ <![#-]> \d+ }
say "333" ~~ &key;      # raku: ｢333｣  mutsu (before): Nil
```

## Root cause

In `src/runtime/regex_parse_core.rs`, the `<?[...]>` / `<![...]>` handler applied the outer `!` **twice**: it folded it into the char class (`class_negated = if negated { !cc_negated }`) *and* set the `Lookaround { negated }` flag. The two negations cancelled, so `<![...]>` matched exactly where a positive lookahead would.

## Fix

The char class should reflect only an inner `-[...]`; the outer `?`/`!` is carried by the `Lookaround`. Pass `cc_negated` instead of `class_negated`.

Verified against reference `raku` across all four forms — `<?[...]>`, `<![...]>`, `<?-[...]>`, `<!-[...]>` — all now match.

Pin: `t/regex-negated-charclass-lookahead.t`. From the doc-diff QA harness (raku-doc `Language/regexes.rakudoc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)