### PR TITLE
fix: interpolate $var.method() inside a double-quoted regex literal

### DIFF
--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -1013,6 +1013,46 @@ pub(super) fn is_inside_single_quoted_regex_literal(chars: &[char], pos: usize) 
     open.is_some()
 }
 
+/// Whether byte position `pos` sits inside a double-quoted regex literal
+/// (`"..."`). Tracks both quote families so a `"` inside a `'...'` region (or
+/// vice versa) is not mistaken for an opener. Used to decide when a
+/// `$var.method(...)` chain is a qq-string interpolation rather than a bare
+/// scalar followed by a match-any `.`.
+pub(super) fn is_inside_double_quoted_regex_literal(chars: &[char], pos: usize) -> bool {
+    let mut open: Option<char> = None;
+    let mut escaped = false;
+    for &ch in chars.iter().take(pos) {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        match open {
+            Some(o) => {
+                let closes = if matches!(o, '"' | '\u{201C}' | '\u{201E}') {
+                    matches!(ch, '"' | '\u{201D}')
+                } else {
+                    regex_single_quote_closes(o, ch)
+                };
+                if closes {
+                    open = None;
+                }
+            }
+            None => {
+                if matches!(ch, '\'' | '\u{2018}' | '\u{201A}' | '\u{FF62}')
+                    || matches!(ch, '"' | '\u{201C}' | '\u{201E}')
+                {
+                    open = Some(ch);
+                }
+            }
+        }
+    }
+    matches!(open, Some('"' | '\u{201C}' | '\u{201E}'))
+}
+
 pub(super) fn regex_single_quote_atom(literal: String, ignore_case: bool) -> RegexAtom {
     let lit_chars: Vec<char> = literal.chars().collect();
     if lit_chars.is_empty() {

--- a/src/runtime/regex_parse_modifier.rs
+++ b/src/runtime/regex_parse_modifier.rs
@@ -354,6 +354,21 @@ impl Interpreter {
                         i += 1;
                         continue;
                     }
+                    // Inside a double-quoted regex literal, a `$var.method(...)`
+                    // chain is a qq-string method-call interpolation (Raku
+                    // interpolates `"$x.uc()"`), not a scalar followed by a
+                    // match-any `.`. A bare `/ $x.foo() /` is a Raku syntax
+                    // error, so this only applies within `"..."`. Evaluate the
+                    // whole chain and match its result literally.
+                    if let Some(chain_end) = scan_interp_method_chain(&chars, j)
+                        && is_inside_double_quoted_regex_literal(&chars, i)
+                    {
+                        let expr_str: String = chars[i..chain_end].iter().collect();
+                        let val = self.eval_string_as_source(&expr_str);
+                        out.push_str(&Self::escape_regex_scalar_literal(&val.to_string_value()));
+                        i = chain_end;
+                        continue;
+                    }
                     let name: String = chars[name_start..j].iter().collect();
                     // Reduce-time dyn-var overlay: a `$*` var written by a grammar
                     // action mid-parse takes precedence over `self.env` so the next
@@ -783,4 +798,47 @@ impl Interpreter {
         err.exception = Some(Box::new(ex));
         err
     }
+}
+
+/// Starting at `start` (just past a scanned `$var` name), scan a chain of
+/// `.method(...)` calls (`.flip()`, `.flip().uc()`, `.substr(0,3)`), respecting
+/// nested parens in the argument lists. Returns the end index of the chain when
+/// it contains at least one parenthesized method call, else `None` (a bare
+/// `.method` without parens does not interpolate). Used to interpolate a
+/// `$var.method(...)` term inside a double-quoted regex literal.
+fn scan_interp_method_chain(chars: &[char], start: usize) -> Option<usize> {
+    let mut i = start;
+    let mut saw_call = false;
+    while i < chars.len() && chars[i] == '.' {
+        let mut k = i + 1;
+        let id_start = k;
+        while k < chars.len() && (chars[k].is_alphanumeric() || chars[k] == '_' || chars[k] == '-')
+        {
+            k += 1;
+        }
+        if k == id_start || k >= chars.len() || chars[k] != '(' {
+            break;
+        }
+        let mut depth = 0usize;
+        while k < chars.len() {
+            match chars[k] {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        k += 1;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+            k += 1;
+        }
+        if depth != 0 {
+            break;
+        }
+        i = k;
+        saw_call = true;
+    }
+    saw_call.then_some(i)
 }

--- a/t/regex-interp-method-call.t
+++ b/t/regex-interp-method-call.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+# Inside a double-quoted regex literal, a `$var.method(...)` chain is a
+# qq-string method-call interpolation (Raku interpolates `"$x.uc()"`), not a
+# scalar followed by a match-any `.`. Regression: mutsu interpolated only the
+# bare `$var` and left `.method()` as literal regex, so nothing matched.
+# (raku-doc Language/regexes.rakudoc, "Regexes / Regex interpolation")
+
+plan 6;
+
+my $p = 'gnirts';
+
+is ('a string here' ~~ / "$p.flip()" /).Str, 'string',
+    '$p.flip() interpolates as a method call inside "..."';
+
+is ('a STRING x' ~~ / "$p.flip().uc()" /).Str, 'STRING',
+    'chained .flip().uc() interpolates';
+
+# A method call with arguments (nested parens handled).
+my $word = 'hello';
+is ('xhelx' ~~ / "$word.substr(0,3)" /).Str, 'hel',
+    'method call with arguments interpolates';
+
+# A bare `.method` WITHOUT parens is NOT an interpolation: the literal text
+# (var value + ".method") is matched.
+is ('gnirts.foo' ~~ / "$p.foo" /).Str, 'gnirts.foo',
+    'a paren-less .foo stays literal inside "..."';
+
+# Plain interpolation with no method still works.
+is ('zgnirtsz' ~~ / "$p" /).Str, 'gnirts',
+    'plain $p interpolation inside "..." unaffected';
+
+# The documented example.
+my $string = 'Is this a regex or a string: 123';
+is ($string.match(/ "$p.flip()" /)).Str, 'string',
+    'documented $pattern.flip() example';


### PR DESCRIPTION
## Problem

Inside a `"..."` in a regex, a `$var.method(...)` chain is a qq-string method-call interpolation — Raku interpolates `/ "$pattern.flip()" /` and matches the flipped string. mutsu interpolated only the bare `$var` and left `.method()` as literal regex:

```raku
my $p = 'gnirts';
say 'a string here'.match: / "$p.flip()" /;   # raku: ｢string｣  mutsu (before): Nil
```

## Root cause

`interpolate_regex_scalars` (`src/runtime/regex_parse_modifier.rs`) scanned the variable name and stopped at the `.`, so `$p` interpolated to `gnirts` and the orphaned `.flip()` was matched literally.

## Fix

After scanning a `$var`, detect a `.ident(...)` method-call chain (nested parens in arguments handled). Only when we are **inside a double-quoted literal** — a bare `/ $x.foo() /` is a Raku syntax error ("Null regex not allowed"), so the method-call reading applies solely within `"..."` — evaluate the whole chain via `eval_string_as_source` and emit its result as an escaped literal. A paren-less `.method` stays literal (matching Raku).

New helper `is_inside_double_quoted_regex_literal` tracks both quote families so a `"` inside a `'...'` region is not mistaken for an opener.

Pin: `t/regex-interp-method-call.t`. From the doc-diff QA harness (raku-doc `Language/regexes.rakudoc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)