### PR TITLE
fix: parse a compact combined char class <:Ll+:N>

### DIFF
--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -1061,6 +1061,36 @@ pub(super) fn split_prop_args(s: &str) -> (&str, Option<&str>) {
     (s, None)
 }
 
+/// Whether a compact combined-class body (the text after the leading `:` in
+/// `<:Ll+:N>`) contains a top-level `+`/`-` set operator joining another atom,
+/// rather than being a single property. Operators inside a property's argument
+/// parens (`<:Nv(0+1)>`) and kebab-case hyphens (`Grapheme_Base` style names)
+/// are ignored.
+pub(super) fn has_top_level_combine_op(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    let mut depth = 0i32;
+    for i in 0..bytes.len() {
+        match bytes[i] {
+            b'(' | b'<' => depth += 1,
+            b')' | b'>' => depth -= 1,
+            b'+' if depth == 0 => return true,
+            b'-' if depth == 0 => {
+                // A hyphen between word chars is a kebab name separator, not a
+                // set-difference operator.
+                let prev_word =
+                    i > 0 && (bytes[i - 1].is_ascii_alphanumeric() || bytes[i - 1] == b'_');
+                let next_word = i + 1 < bytes.len()
+                    && (bytes[i + 1].is_ascii_alphanumeric() || bytes[i + 1] == b'_');
+                if !(prev_word && next_word) {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
 /// Skip `<[...]>` character class content where quotes are literal.
 pub(super) fn skip_char_class_content(
     chars: &mut std::iter::Peekable<std::str::Chars>,

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -2109,12 +2109,28 @@ impl Interpreter {
                                         args: pargs.map(|s| s.to_string()),
                                     }
                                 } else if let Some(prop_name) = trimmed.strip_prefix(':') {
-                                    // <:PropName> — Unicode property assertion
-                                    let (pname, pargs) = split_prop_args(prop_name);
-                                    RegexAtom::UnicodeProp {
-                                        name: pname.to_string(),
-                                        negated: false,
-                                        args: pargs.map(|s| s.to_string()),
+                                    // `<:Ll+:N>` / `<:Ll-:Lu>` — a compact combined
+                                    // class joins property (and named-class) atoms
+                                    // with top-level `+`/`-` set operators. Route it
+                                    // to the combined-class parser (which also handles
+                                    // the spaced `<+:Ll +:N>` form) by treating the
+                                    // leading atom as an implicit positive item.
+                                    if has_top_level_combine_op(prop_name) {
+                                        if let Some(atom) =
+                                            self.parse_combined_class(&format!("+{trimmed}"), mode)
+                                        {
+                                            atom
+                                        } else {
+                                            continue;
+                                        }
+                                    } else {
+                                        // <:PropName> — single Unicode property assertion
+                                        let (pname, pargs) = split_prop_args(prop_name);
+                                        RegexAtom::UnicodeProp {
+                                            name: pname.to_string(),
+                                            negated: false,
+                                            args: pargs.map(|s| s.to_string()),
+                                        }
                                     }
                                 } else if trimmed.starts_with('+') || trimmed.starts_with('-') {
                                     // Combined character class: <+ xdigit - lower>

--- a/t/regex-compact-combined-property-class.t
+++ b/t/regex-compact-combined-property-class.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+# A compact combined character class `<:Ll+:N>` joins Unicode-property (and
+# named-class) atoms with top-level `+`/`-` set operators, without the spaced
+# `<+:Ll +:N>` form. Regression: mutsu treated the whole `Ll+:N` as one bogus
+# property name and never matched. (raku-doc Language/regexes.rakudoc)
+
+plan 9;
+
+ok  ("9" ~~ /<:Ll+:N>/),          '<:Ll+:N> matches a number';
+ok  ("a" ~~ /<:Ll+:N>/),          '<:Ll+:N> matches a lowercase letter';
+nok ("A" ~~ /<:Ll+:N>/),          '<:Ll+:N> rejects an uppercase letter';
+ok  ("9" ~~ /<:N+:Ll>/),          'operand order does not matter';
+ok  ("9" ~~ /<:Ll+:Nd>/),         'combined with a two-letter property (:Nd)';
+
+# Set difference: lowercase minus uppercase (uppercase can never be Ll anyway,
+# but the `-` operator must parse).
+ok  ("x" ~~ /<:Ll-:Lu>/),         '<:Ll-:Lu> set difference parses and matches';
+
+# A plain single property still works (no combine operator).
+ok  ("9" ~~ /<:N>/),              'single <:N> still matches';
+
+# The spaced form is unchanged.
+ok  ("9" ~~ /<+:Ll +:N>/),        'spaced <+:Ll +:N> still matches';
+
+# The documented example: capture a combined class.
+"raku9" ~~ /\w+(<:Ll+:N>)/;
+is ~$0, "9",                      'captured <:Ll+:N> from the doc example';


### PR DESCRIPTION
## Problem

A combined character class can join Unicode-property (and named-class) atoms with top-level `+`/`-` set operators compactly — `<:Ll+:N>` — without the spaced `<+:Ll +:N>` form:

```raku
say "9" ~~ /<:Ll+:N>/;                    # raku: ｢9｣   mutsu (before): Nil
say $0 if "raku9" ~~ /\w+(<:Ll+:N>)/;     # raku: ｢9｣   mutsu (before): (nothing)
```

## Root cause

In `src/runtime/regex_parse_core.rs`, the `<:PropName>` branch took the whole body after `:` (`Ll+:N`) as a single property name via `split_prop_args`, which resolves to no property, so the class never matched. The spaced `<+:Ll +:N>` form already worked (it hits `parse_combined_class`).

## Fix

Detect a top-level combining operator in the property body — new helper `has_top_level_combine_op`, which ignores operators inside argument parens (`:Nv(0+1)`) and kebab-case hyphens (`Grapheme_Base`) — and route such a class to the existing `parse_combined_class`, treating the leading atom as an implicit positive item. Single `<:PropName>` and the spaced `<+:Ll +:N>` form are unchanged.

Pin: `t/regex-compact-combined-property-class.t`. From the doc-diff QA harness (raku-doc `Language/regexes.rakudoc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)