### PR TITLE
fix: implement IO::Path::Parts as a Positional/Associative/Iterable container

### DIFF
--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1633,21 +1633,61 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         }
     }
 
-    // IO::Path::Parts — .hash returns attributes as a Hash
+    // IO::Path::Parts does Associative, Positional and Iterable: `.hash`/`.Hash`
+    // give the parts as a Map, while `.list`/`.List`/`.flat`/`.pairs`/`.kv`/
+    // iteration expose them as an ordered list of `key => part` Pairs; `.keys`/
+    // `.values`/`.elems` follow the same fixed volume/dirname/basename order.
     if let ValueView::Instance {
         class_name,
         attributes,
         ..
     } = target.view()
         && class_name.resolve() == "IO::Path::Parts"
-        && (method == "hash" || method == "Hash")
     {
-        let map: HashMap<String, Value> = attributes
-            .as_map()
-            .iter()
-            .map(|(k, v)| (k.resolve(), v.clone()))
-            .collect();
-        return Some(Ok(Value::hash(map)));
+        let attrs = attributes.as_map();
+        let keys = crate::runtime::io_path_parts_keys();
+        let part = |key: &str| attrs.get(key).cloned().unwrap_or(Value::NIL);
+        let make_list = |items: Vec<Value>| {
+            Value::array_with_kind(
+                crate::gc::Gc::new(crate::value::ArrayData::new(items)),
+                crate::value::ArrayKind::List,
+            )
+        };
+        let pairs = || -> Vec<Value> {
+            keys.iter()
+                .map(|k| Value::pair((*k).to_string(), part(k)))
+                .collect()
+        };
+        match method {
+            "hash" | "Hash" | "Map" => {
+                let map: HashMap<String, Value> =
+                    keys.iter().map(|k| (k.to_string(), part(k))).collect();
+                return Some(Ok(Value::hash(map)));
+            }
+            "list" | "List" | "flat" | "pairs" | "Slip" | "cache" | "eager" | "Array" => {
+                return Some(Ok(make_list(pairs())));
+            }
+            "keys" => {
+                return Some(Ok(make_list(
+                    keys.iter().map(|k| Value::str_from(k)).collect(),
+                )));
+            }
+            "values" => {
+                return Some(Ok(make_list(keys.iter().map(|k| part(k)).collect())));
+            }
+            "kv" => {
+                let mut kv = Vec::with_capacity(keys.len() * 2);
+                for k in keys {
+                    kv.push(Value::str_from(k));
+                    kv.push(part(k));
+                }
+                return Some(Ok(make_list(kv)));
+            }
+            "elems" => {
+                return Some(Ok(Value::int(keys.len() as i64)));
+            }
+            _ => {}
+        }
     }
 
     // Match object methods

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -486,6 +486,22 @@ pub(crate) fn native_method_1arg(
                         }
                         Some(Ok(Value::int(0)))
                     }
+                    // IO::Path::Parts does Positional: `$parts[0]` is `volume => C:`,
+                    // `[1]` the dirname pair, `[2]` the basename pair (fixed order).
+                    ValueView::Instance {
+                        class_name,
+                        attributes,
+                        ..
+                    } if class_name == "IO::Path::Parts" => {
+                        Some(Ok(crate::runtime::io_path_parts_keys()
+                            .get(idx)
+                            .map(|key| {
+                                let v =
+                                    attributes.as_map().get(*key).cloned().unwrap_or(Value::NIL);
+                                Value::pair((*key).to_string(), v)
+                            })
+                            .unwrap_or(Value::NIL)))
+                    }
                     _ => None,
                 }
             }
@@ -1888,6 +1904,19 @@ pub(crate) fn native_method_1arg(
                 let key = arg.to_string_value();
                 let weight = data.weights.get(&key).copied().unwrap_or(0.0);
                 Some(Ok(crate::value::mix_weight_to_value(weight)))
+            }
+            // IO::Path::Parts does Associative: `$parts<volume>` returns the part.
+            ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } if class_name == "IO::Path::Parts" => {
+                let key = arg.to_string_value();
+                Some(Ok(attributes
+                    .as_map()
+                    .get(&key)
+                    .cloned()
+                    .unwrap_or(Value::NIL)))
             }
             ValueView::Nil => Some(Ok(Value::package(Symbol::intern("Any")))),
             ValueView::Package(name) if matches!(name.resolve().as_str(), "Any" | "Mu") => {

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -425,6 +425,13 @@ impl Interpreter {
             } else {
                 (cn_resolved.as_str(), None)
             };
+            // `IO::Path::Parts` is a parts container, not an `IO::Path` subclass —
+            // build it directly before the `IO::Path::`-prefix rule below would
+            // register it with an `IO::Path` parent and route `.new` through path
+            // assembly (which mis-derives volume/dirname/basename).
+            if cn_resolved == "IO::Path::Parts" {
+                return Ok(Self::build_io_path_parts_instance(&args));
+            }
             if cn_resolved.starts_with("IO::Path::")
                 && !self.registry().classes.contains_key(&cn_resolved)
             {

--- a/src/runtime/methods_object_native_ctors_io.rs
+++ b/src/runtime/methods_object_native_ctors_io.rs
@@ -178,6 +178,38 @@ impl Interpreter {
         Ok(Value::make_instance(class_name, attrs))
     }
 
+    /// `IO::Path::Parts.new(\volume, \dirname, \basename)` — a small container for
+    /// the three parts of a path (also produced by `IO::Path.parts`). It is NOT an
+    /// `IO::Path` (unlike the auto-registered `IO::Path::*` spec subclasses), so it
+    /// must be constructed before `dispatch_new`'s `IO::Path::`-prefix rule routes
+    /// it into `build_io_path_instance`. The three parts are accepted positionally
+    /// (as the doc's signature) or by `:volume`/`:dirname`/`:basename` name.
+    pub(crate) fn build_io_path_parts_instance(args: &[Value]) -> Value {
+        let mut positional: Vec<Value> = Vec::new();
+        let (mut volume, mut dirname, mut basename) = (None, None, None);
+        for arg in args {
+            match arg.view() {
+                ValueView::Pair(key, value) if key == "volume" => volume = Some(value.clone()),
+                ValueView::Pair(key, value) if key == "dirname" => dirname = Some(value.clone()),
+                ValueView::Pair(key, value) if key == "basename" => basename = Some(value.clone()),
+                ValueView::Pair(_, _) => {}
+                _ => positional.push(arg.clone()),
+            }
+        }
+        let mut take = positional.into_iter();
+        let pick = |slot: Option<Value>, next: Option<Value>| {
+            slot.or(next).unwrap_or_else(|| Value::str_from(""))
+        };
+        let volume = pick(volume, take.next());
+        let dirname = pick(dirname, take.next());
+        let basename = pick(basename, take.next());
+        let mut attrs = HashMap::new();
+        attrs.insert("volume".to_string(), volume);
+        attrs.insert("dirname".to_string(), dirname);
+        attrs.insert("basename".to_string(), basename);
+        Value::make_instance(Symbol::intern("IO::Path::Parts"), attrs)
+    }
+
     /// VM-native construction for a built-in type whose `.new(...)` is pure data
     /// assembly (no env / registry / user code): `Buf`/`Blob` (byte overlay),
     /// `utf8`/`utf16` (code units), `Uni` (codepoints), `Version`, `Duration`

--- a/src/runtime/native_io/io_path_lexical.rs
+++ b/src/runtime/native_io/io_path_lexical.rs
@@ -106,7 +106,10 @@ impl Interpreter {
                 parts.insert("volume".to_string(), Value::str(volume));
                 parts.insert("dirname".to_string(), Value::str(dirname));
                 parts.insert("basename".to_string(), Value::str(basename));
-                Ok(Value::hash(parts))
+                Ok(Value::make_instance(
+                    Symbol::intern("IO::Path::Parts"),
+                    parts,
+                ))
             }
             "parent" => {
                 let mut levels = 1i64;

--- a/src/runtime/types/type_matching_static.rs
+++ b/src/runtime/types/type_matching_static.rs
@@ -226,10 +226,15 @@ impl Interpreter {
                     | "Blob"
                     | "Capture"
                     | "array"
+                    | "IO::Path::Parts"
             )
         {
             // The bare native `array` type (and its parameterized form
             // `array[int]`, whose base name is `array`) does Positional.
+            return true;
+        }
+        // IO::Path::Parts does Positional, Associative and Iterable.
+        if constraint == "Iterable" && value_type == "IO::Path::Parts" {
             return true;
         }
         // Array is-a List in Raku type hierarchy (and Slip is-a List)
@@ -244,7 +249,15 @@ impl Interpreter {
         if constraint == "Associative"
             && matches!(
                 value_type,
-                "Hash" | "Map" | "Pair" | "Bag" | "Set" | "Mix" | "QuantHash" | "Capture"
+                "Hash"
+                    | "Map"
+                    | "Pair"
+                    | "Bag"
+                    | "Set"
+                    | "Mix"
+                    | "QuantHash"
+                    | "Capture"
+                    | "IO::Path::Parts"
             )
         {
             return true;

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -290,6 +290,12 @@ pub(crate) fn make_order(ord: std::cmp::Ordering) -> Value {
     }
 }
 
+/// The three parts of an `IO::Path::Parts`, in the fixed order they are exposed
+/// positionally (`$parts[0]`/`[1]`/`[2]`) and by iteration (`.list`/`$parts[]`).
+pub(crate) fn io_path_parts_keys() -> &'static [&'static str] {
+    &["volume", "dirname", "basename"]
+}
+
 pub(crate) fn version_cmp_parts(
     a_parts: &[crate::value::VersionPart],
     b_parts: &[crate::value::VersionPart],

--- a/src/runtime/utils/list.rs
+++ b/src/runtime/utils/list.rs
@@ -502,6 +502,20 @@ pub(crate) fn value_to_list(val: &Value) -> Vec<Value> {
             {
                 return value_to_list(frames);
             }
+            // IO::Path::Parts is Iterable: list context yields its parts as an
+            // ordered list of `volume`/`dirname`/`basename` Pairs.
+            if class_name.resolve() == "IO::Path::Parts" {
+                let attrs = attributes.as_map();
+                return crate::runtime::io_path_parts_keys()
+                    .iter()
+                    .map(|k| {
+                        Value::pair(
+                            (*k).to_string(),
+                            attrs.get(*k).cloned().unwrap_or(Value::NIL),
+                        )
+                    })
+                    .collect();
+            }
             if let Some(ValueView::Array(items, ..)) =
                 attributes.as_map().get("__array_items").map(Value::view)
             {

--- a/t/io-path-parts.t
+++ b/t/io-path-parts.t
@@ -1,0 +1,51 @@
+use v6;
+use Test;
+
+plan 24;
+
+# IO::Path::Parts.new(\volume, \dirname, \basename) — direct construction.
+my $p = IO::Path::Parts.new('C:', '/some/dir', 'foo.txt');
+is $p.^name, 'IO::Path::Parts', '.^name is IO::Path::Parts';
+is $p.volume, 'C:', '.volume accessor';
+is $p.dirname, '/some/dir', '.dirname accessor';
+is $p.basename, 'foo.txt', '.basename accessor';
+
+# It does Associative, Positional and Iterable.
+ok $p ~~ Associative, 'does Associative';
+ok $p ~~ Positional, 'does Positional';
+ok $p ~~ Iterable, 'does Iterable';
+
+# Associative: <key> yields the part.
+is $p<volume>, 'C:', '<volume> associative';
+is $p<dirname>, '/some/dir', '<dirname> associative';
+is $p<basename>, 'foo.txt', '<basename> associative';
+
+# Positional: [i] yields the i-th part as an ordered Pair.
+is $p[0].^name, 'Pair', '[0] is a Pair';
+is $p[0].gist, 'volume => C:', '[0] is the volume pair';
+is $p[1].gist, 'dirname => /some/dir', '[1] is the dirname pair';
+is $p[2].gist, 'basename => foo.txt', '[2] is the basename pair';
+
+# Iterable: the zen slice / .list yields the three pairs in order.
+is-deeply $p[].map(*.gist).List, ('volume => C:', 'dirname => /some/dir', 'basename => foo.txt'),
+    'zen slice yields the ordered pairs';
+is $p.elems, 3, '.elems is 3';
+is-deeply $p.keys.List, ('volume', 'dirname', 'basename'), '.keys in order';
+is-deeply $p.values.List, ('C:', '/some/dir', 'foo.txt'), '.values in order';
+
+# .hash round-trips to a Map keyed by part name.
+my %h = $p.hash;
+is %h<basename>, 'foo.txt', '.hash keeps the parts';
+
+# IO::Path.parts returns the same kind of object.
+my $q = 'foo/bar.txt'.IO.parts;
+is $q.^name, 'IO::Path::Parts', 'IO::Path.parts returns IO::Path::Parts';
+is $q<dirname>, 'foo', '.parts dirname';
+is $q<basename>, 'bar.txt', '.parts basename';
+ok $q ~~ Associative, '.parts result does Associative';
+
+# Named construction also works.
+my $r = IO::Path::Parts.new(:volume(''), :dirname('a'), :basename('b'));
+is $r.dirname, 'a', 'named-arg construction';
+
+done-testing;


### PR DESCRIPTION
## Summary

Fixes all 3 `Type/IO/Path/Parts.rakudoc` doc-diff divergences.

`IO::Path::Parts.new('C:', '/some/dir', 'foo.txt')` previously fell into `dispatch_new`'s `IO::Path::`-prefix rule, which auto-registered the class with an `IO::Path` parent and routed `.new` through path-string assembly — so `.dirname`/`.basename` were mis-derived (`/`), and the Positional/Associative/Iterable protocols were entirely absent (`$parts<volume>` → Nil, `$parts[0]` → Nil).

It is now constructed directly as a small parts container (before that prefix rule), and `IO::Path.parts` returns the same object instead of a bare `Hash`. The class does **Positional**, **Associative** and **Iterable** over its three fixed parts (volume, dirname, basename):

- `$parts<key>` (AT-KEY) → the part
- `$parts[0/1/2]` (AT-POS) → the ordered `key => part` Pair
- iteration / `.list` / `.pairs` / `.keys` / `.values` / `.kv` / `.elems` follow the same order
- `.hash` / `.Hash` / `.Map` → a Map
- `~~ Positional` / `Associative` / `Iterable` all report True

### Before / after (`IO::Path::Parts.new('C:', '/some/dir', 'foo.txt')`)

```
.dirname.say;    # was «/» → now «/some/dir»
.basename.say;   # was «/» → now «foo.txt»
$parts<volume>;  # was Nil → now «C:»
$parts[0];       # was Nil → now «volume => C:» (a Pair)
```

## Test

- New `t/io-path-parts.t` (24 assertions) covering construction, accessors, the three container protocols, role smartmatch, and `IO::Path.parts` consistency.
- Existing `t/io-path-methods.t`, `roast/S32-io/io-path.t` pass (the `.parts ~~ Associative` check now sees the real container type).
- `Type/IO/Path/Parts.rakudoc` doc-diff: 3 → 0 high-signal divergences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)