### PR TITLE
fix: parse bareword traits on unit role/module declarations (is export)

### DIFF
--- a/src/parser/stmt/class/package_decl.rs
+++ b/src/parser/stmt/class/package_decl.rs
@@ -242,24 +242,91 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
         ));
     }
     // unit role Name;  — declare a role at the file scope.
+    // unit role Name is export does OtherRole;  — traits and composition too.
     if let Some(r) = keyword("role", rest) {
         let (r, _) = ws1(r)?;
         let (r, name) = qualified_ident(r)?;
         check_pseudo_package_in_decl(&name)?;
-        let (r, _) = ws(r)?;
+        let (mut r, (type_params, type_param_defs)) =
+            super::role_decl::parse_optional_role_type_params(r)?;
+        // Optional type adverbs (:ver<...>, :auth<...>, :api<...>).
+        let (r2, _adverbs) = parse_declarator_traits(r)?;
+        let (r2, _) = ws(r2)?;
+        r = r2;
+        // Optional parent/trait clauses in any order (mirrors block-form roles).
+        let mut parent_roles: Vec<String> = Vec::new();
+        let mut is_export = false;
+        let mut export_tags: Vec<String> = Vec::new();
+        let mut role_is_rw = false;
+        let mut custom_traits: Vec<(String, Option<crate::ast::Expr>)> = Vec::new();
+        loop {
+            if let Some(r2) = keyword("does", r) {
+                let (r2, _) = ws1(r2)?;
+                let (r2, role_name) = qualified_ident(r2)?;
+                let (r2, _) = ws(r2)?;
+                let (r2, bracket_suffix) = parse_optional_bracket_suffix(r2)?;
+                let (r2, _) = ws(r2)?;
+                parent_roles.push(format!("{}{}", role_name, bracket_suffix));
+                r = r2;
+                continue;
+            }
+            if let Some(r2) = keyword("is", r) {
+                let (r2, _) = ws1(r2)?;
+                let (r2, trait_name) = crate::parser::stmt::ident(r2)?;
+                if trait_name == "rw" {
+                    role_is_rw = true;
+                    let r2 = skip_balanced_parens(r2);
+                    let (r2, _) = ws(r2)?;
+                    r = r2;
+                } else if trait_name == "export" {
+                    is_export = true;
+                    if !export_tags.iter().any(|t| t == "DEFAULT") {
+                        export_tags.push("DEFAULT".to_string());
+                    }
+                    let r2 = skip_balanced_parens(r2);
+                    let (r2, _) = ws(r2)?;
+                    r = r2;
+                } else {
+                    // Unknown lowercase trait: skip any parenthesized argument.
+                    // An uppercase bare name would be a parent role, but a
+                    // `unit role` with parents almost always spells them with
+                    // `does`, so treat everything else as a skipped trait_mod.
+                    let has_parens = r2.starts_with('(');
+                    let r2 = skip_balanced_parens(r2);
+                    if !has_parens && trait_name.starts_with(|c: char| c.is_ascii_uppercase()) {
+                        parent_roles.push(trait_name);
+                    } else {
+                        custom_traits.push((trait_name, None));
+                    }
+                    let (r2, _) = ws(r2)?;
+                    r = r2;
+                }
+                continue;
+            }
+            break;
+        }
         let (r, _) = opt_char(r, ';');
+        let mut body: Vec<Stmt> = Vec::new();
+        for role_name in parent_roles.into_iter().rev() {
+            body.insert(
+                0,
+                Stmt::DoesDecl {
+                    name: Symbol::intern(&role_name),
+                },
+            );
+        }
         return Ok((
             r,
             Stmt::RoleDecl {
                 name: Symbol::intern(&name),
-                type_params: Vec::new(),
-                type_param_defs: Vec::new(),
-                is_export: false,
-                export_tags: Vec::new(),
-                body: Vec::new(),
-                is_rw: false,
+                type_params,
+                type_param_defs,
+                is_export,
+                export_tags,
+                body,
+                is_rw: role_is_rw,
                 language_version: super::super::simple::current_language_version(),
-                custom_traits: Vec::new(),
+                custom_traits,
             },
         ));
     }
@@ -344,6 +411,17 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
     // unit package name, e.g. `unit module Foo:ver<0.0.12>:auth<zef:bar>;`.
     let (rest, _traits) = parse_declarator_traits(rest)?;
     let (rest, _) = ws(rest)?;
+    // Consume bareword traits such as `is export` / `is rw` / custom
+    // `is Foo(...)` before the terminating semicolon, e.g.
+    // `unit module App::Racoco::ConfigFile is export;`.
+    let mut rest = rest;
+    while let Some(r) = keyword("is", rest) {
+        let (r, _) = ws1(r)?;
+        let (r, _trait_name) = crate::parser::stmt::ident(r)?;
+        let r = skip_balanced_parens(r);
+        let (r, _) = ws(r)?;
+        rest = r;
+    }
     let (rest, _) = opt_char(rest, ';');
     Ok((
         rest,

--- a/src/parser/stmt/stmtlist.rs
+++ b/src/parser/stmt/stmtlist.rs
@@ -301,7 +301,15 @@ pub(crate) fn stmt_list_with_mode(
                     }
                     *body = tail_stmts;
                 }
-                Stmt::RoleDecl { body, .. } => *body = tail_stmts,
+                Stmt::RoleDecl { body, .. } => {
+                    // The declarator may have already recorded `does Role`
+                    // composition as leading `DoesDecl` statements in `body`
+                    // (e.g. `unit role R does Base;`). Keep those and append the
+                    // absorbed compilation-unit statements after them, rather
+                    // than replacing the body wholesale and dropping the
+                    // parent-role composition.
+                    body.append(&mut tail_stmts);
+                }
                 _ => {}
             }
             stmts.push(decl);

--- a/t/unit-role-module-is-export.t
+++ b/t/unit-role-module-is-export.t
@@ -1,0 +1,49 @@
+use v6;
+use Test;
+
+# `unit role Foo is export;` and `unit module Foo is export;` — lowercase
+# bareword traits (`is export`, `is rw`, custom `is Foo(...)`) and `does Role`
+# composition on a unit-scoped role/module declaration must be parsed, NOT left
+# dangling to trigger "Confused. expected statement". Regression: mutsu's
+# `unit role`/`unit module` branches consumed only `:adverb<...>` colon-traits,
+# so `is export` after the name was an unparsed leftover that aborted the whole
+# compilation unit.
+#
+# EVAL of a `unit ...;` compilation unit returns the declared type object.
+
+plan 6;
+
+# `is export` on a unit role parses; the result is the role type object.
+{
+    my $r = EVAL 'unit role UR0 is export; method who() { "UR0" }';
+    is $r.^name, 'UR0', 'unit role is export parses and yields the role type';
+}
+
+# `is rw` on a unit role stays a trait, not a parent.
+{
+    my $r = EVAL 'unit role UR1 is rw; method tag() { "rw-role" }';
+    is $r.^name, 'UR1', 'unit role is rw stays a trait';
+}
+
+# `does OtherRole` composition on a unit role parses and actually composes:
+# the composing role inherits the parent role's method.
+{
+    role Base2 { method base() { "base" } }
+    my $r = EVAL 'unit role UR2 does Base2; method own() { "own" }';
+    my $o = Mu.new but $r;
+    is $o.base, 'base', 'unit role does Role composes the parent role';
+    is $o.own,  'own',  'unit role does Role keeps its own methods';
+}
+
+# `is export` on a unit module parses (no dangling-statement error). The
+# regression was a parse failure, so `lives-ok` on EVAL is the pin.
+{
+    lives-ok { EVAL 'unit module UM0 is export; our sub answer() { 42 }' },
+        'unit module is export parses without a dangling-statement error';
+}
+
+# A custom parenthesized trait on a unit module is consumed too.
+{
+    lives-ok { EVAL 'unit module UM1 is export(:MANDATORY); my $x = 7' },
+        'unit module is export(:tag) consumes the parenthesized argument';
+}


### PR DESCRIPTION
`unit role Foo is export;` and `unit module Foo is export;` failed to parse with "Confused. expected statement": the `unit role`/`unit module` branches consumed only `:adverb<...>` colon-traits, so a bareword trait such as `is export` (or `is rw`, or a custom `is Foo(...)`) after the name was left unparsed and aborted the whole compilation unit. `unit class` already handled these; roles and modules did not.

## Changes
- **`unit role`**: parse an optional trait/parent loop (mirroring block-form roles) handling `is export`, `is rw`, custom `is Foo(...)`, and `does Role` composition, recording parent roles as leading `DoesDecl` statements.
- **`unit module`/`unit package`**: consume bareword `is ...` traits before the terminating semicolon (skipped, as `Stmt::Package` has no trait fields).
- **stmtlist**: when a `unit role` absorbs the rest of the compilation unit into its body, append the tail *after* the declarator's `DoesDecl` composition instead of replacing the body wholesale (which dropped the parent-role composition).

## Impact
Unblocks parsing of **App::Racoco** (`unit module ... is export;` in `ConfigFile`, `unit role ... is export;` in `Report::Reporter`). Matches raku behavior.

Pinned by `t/unit-role-module-is-export.t` (6 cases, output verified identical to raku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)