### PR TITLE
fix: grammar .subparse yields a failed Match and honors :pos(N)

### DIFF
--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1686,7 +1686,14 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     .cloned()
                     .unwrap_or(Value::str(String::new()))));
             }
-            "Bool" => return Some(Ok(Value::TRUE)),
+            "Bool" => {
+                // A failed `.subparse` Match is falsy; every other Match is truthy.
+                let ok = !attributes
+                    .as_map()
+                    .get("__failed_match__")
+                    .is_some_and(|v| v.truthy());
+                return Some(Ok(Value::truth(ok)));
+            }
             "orig" => {
                 return Some(Ok(attributes
                     .as_map()

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -107,6 +107,18 @@ impl Interpreter {
         name: &str,
         arg_values: &[Value],
     ) -> Result<Option<String>, RuntimeError> {
+        self.eval_token_call_values_at(name, arg_values, 0)
+    }
+
+    /// Like [`eval_token_call_values`], but the LTM candidate filter measures each
+    /// candidate's declarative prefix starting at character offset `start_pos`
+    /// (for a `:pos(N)`/`:c(N)` subparse) rather than at the start of the subject.
+    pub(super) fn eval_token_call_values_at(
+        &mut self,
+        name: &str,
+        arg_values: &[Value],
+        start_pos: usize,
+    ) -> Result<Option<String>, RuntimeError> {
         let defs = match self.resolve_token_defs(name) {
             Some(defs) => defs,
             None => return Ok(None),
@@ -114,7 +126,17 @@ impl Interpreter {
         let subject = match self.env.get("_").map(Value::view) {
             Some(ValueView::Str(s)) => Some(s.to_string()),
             _ => None,
-        };
+        }
+        .map(|s| {
+            // Measure the candidate from the requested start position: a
+            // `:pos(N)` subparse anchors there, so a candidate that only matches
+            // later in the subject must still be considered.
+            if start_pos == 0 {
+                s
+            } else {
+                s.chars().skip(start_pos).collect::<String>()
+            }
+        });
         // Collect all matching candidates with their declarative prefix match
         // lengths. `declarative_prefix_match_len` is the ONLY trial match here:
         // it stops at the candidate's first code block/assertion and never

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -191,10 +191,18 @@ impl Interpreter {
         let mut start_rule = "TOP".to_string();
         let mut rule_args: Vec<Value> = Vec::new();
         let mut actions_obj: Option<Value> = None;
+        // `:pos(N)` anchors the (sub)parse to start exactly at position N;
+        // `:c(N)`/`:continue(N)` starts searching from N. Both default to 0.
+        let mut start_pos: Option<usize> = None;
+        let mut continue_pos: Option<usize> = None;
         for arg in args {
             if let ValueView::Pair(key, value) = arg.view() {
                 if key == "rule" || key == "token" {
                     start_rule = value.to_string_value();
+                } else if key == "pos" {
+                    start_pos = value.as_int().and_then(|n| usize::try_from(n).ok());
+                } else if key == "c" || key == "continue" {
+                    continue_pos = value.as_int().and_then(|n| usize::try_from(n).ok());
                 } else if key == "args" {
                     // :args(\(42)) passes a Capture; :args(42,) passes an Array
                     match value.view() {
@@ -278,27 +286,35 @@ impl Interpreter {
         // Establish any `:my $*/%*/@*… = …;` dynamic variables the grammar's rules
         // declare, so action methods run during the match share them (`%*PLAYED`).
         let saved_grammar_dynvars = self.establish_grammar_dynamic_vars(package_name);
+        let candidate_from = start_pos.or(continue_pos).unwrap_or(0);
         let result = (|| -> Result<Value, RuntimeError> {
-            let pattern = match self.eval_token_call_values(&start_rule, &rule_args) {
-                Ok(Some(pattern)) => pattern,
-                Ok(None) => {
-                    // Check for pending regex error (e.g., <sym> used outside proto regex)
-                    if let Some(err) = Self::take_pending_regex_error() {
-                        return Err(err);
+            let pattern =
+                match self.eval_token_call_values_at(&start_rule, &rule_args, candidate_from) {
+                    Ok(Some(pattern)) => pattern,
+                    Ok(None) => {
+                        // Check for pending regex error (e.g., <sym> used outside proto regex)
+                        if let Some(err) = Self::take_pending_regex_error() {
+                            return Err(err);
+                        }
+                        self.env.insert("/".to_string(), Value::NIL);
+                        if is_full_parse {
+                            return Ok(self.parse_failure_for_pattern(&text, None));
+                        }
+                        return Ok(self.make_failed_match_value(&text, start_pos.unwrap_or(0)));
                     }
-                    self.env.insert("/".to_string(), Value::NIL);
-                    return Ok(self.parse_failure_for_pattern(&text, None));
-                }
-                Err(err)
-                    if err
-                        .message
-                        .contains("No matching candidates for proto token") =>
-                {
-                    self.env.insert("/".to_string(), Value::NIL);
-                    return Ok(self.parse_failure_for_pattern(&text, None));
-                }
-                Err(err) => return Err(err),
-            };
+                    Err(err)
+                        if err
+                            .message
+                            .contains("No matching candidates for proto token") =>
+                    {
+                        self.env.insert("/".to_string(), Value::NIL);
+                        if is_full_parse {
+                            return Ok(self.parse_failure_for_pattern(&text, None));
+                        }
+                        return Ok(self.make_failed_match_value(&text, start_pos.unwrap_or(0)));
+                    }
+                    Err(err) => return Err(err),
+                };
 
             // Bind rule args to the env so code assertions { ... } can access them
             if !rule_args.is_empty()
@@ -327,6 +343,12 @@ impl Interpreter {
             }
             let captures = if method == "parse" || method == "parsefile" {
                 self.regex_match_with_captures_full_from_start(&pattern, &text)
+            } else if let Some(pos) = start_pos {
+                // `:pos(N)` — subparse anchored to begin exactly at N.
+                self.regex_match_with_captures_at(&pattern, &text, pos)
+            } else if let Some(cpos) = continue_pos {
+                // `:c(N)`/`:continue(N)` — search for a match from N onwards.
+                self.regex_match_with_captures_from(&pattern, &text, cpos)
             } else {
                 self.regex_match_with_captures(&pattern, &text)
             };
@@ -369,12 +391,28 @@ impl Interpreter {
                     return Ok(self.make_goal_failure_value(&goal, pos));
                 }
                 self.env.insert("/".to_string(), Value::NIL);
-                return Ok(self.parse_failure_for_pattern(&text, Some(&pattern)));
+                if is_full_parse {
+                    return Ok(self.parse_failure_for_pattern(&text, Some(&pattern)));
+                }
+                // A failed `.subparse` yields a failed Match, not a Failure.
+                return Ok(self.make_failed_match_value(&text, start_pos.unwrap_or(0)));
             };
             self.execute_regex_code_blocks(&captures.code_blocks);
-            if captures.from != 0 {
+            // A subparse must begin at the requested offset (0, or `:pos(N)`);
+            // `:c(N)` allows any start >= N, so it is exempt from the check.
+            let required_from = start_pos.or(if continue_pos.is_some() {
+                None
+            } else {
+                Some(0)
+            });
+            if let Some(want) = required_from
+                && captures.from != want
+            {
                 self.env.insert("/".to_string(), Value::NIL);
-                return Ok(self.parse_failure_for_pattern(&text, Some(&pattern)));
+                if is_full_parse {
+                    return Ok(self.parse_failure_for_pattern(&text, Some(&pattern)));
+                }
+                return Ok(self.make_failed_match_value(&text, start_pos.unwrap_or(0)));
             }
             if (method == "parse" || method == "parsefile") && captures.to != text.chars().count() {
                 self.env.insert("/".to_string(), Value::NIL);
@@ -863,6 +901,23 @@ impl Interpreter {
             .map(|(end, _)| end)
             .max()
             .unwrap_or(0)
+    }
+
+    /// A failed `.subparse` yields a *failed* `Match` (gists as `#<failed match>`,
+    /// `.Bool` is `False` but `.defined` is `True`), NOT the `Failure` that a
+    /// full `.parse` returns. The `__failed_match__` marker drives both the gist
+    /// (see `match_gist`) and truthiness.
+    pub(super) fn make_failed_match_value(&self, text: &str, from: usize) -> Value {
+        let mut attrs = HashMap::new();
+        attrs.insert("str".to_string(), Value::str_from(""));
+        attrs.insert("from".to_string(), Value::int(from as i64));
+        attrs.insert("to".to_string(), Value::int(-1));
+        attrs.insert("pos".to_string(), Value::int(-1));
+        attrs.insert("orig".to_string(), Value::str(text.to_string()));
+        attrs.insert("list".to_string(), Value::array(Vec::new()));
+        attrs.insert("named".to_string(), Value::hash(HashMap::new()));
+        attrs.insert("__failed_match__".to_string(), Value::TRUE);
+        Value::make_instance(Symbol::intern("Match"), attrs)
     }
 
     pub(super) fn make_parse_failure_value(&self, text: &str, best_end: usize) -> Value {

--- a/src/runtime/utils/gist.rs
+++ b/src/runtime/utils/gist.rs
@@ -279,6 +279,13 @@ pub(crate) fn gist_value(value: &Value) -> String {
 /// A quantified capture (`(\w)+`) is a list of Match values, each emitted under
 /// the same index. `depth` controls indentation (one leading space per level).
 pub(crate) fn match_gist(attributes: &AttrMap, depth: usize) -> String {
+    // A failed `.subparse` Match renders as `#<failed match>` (Rakudo).
+    if attributes
+        .get("__failed_match__")
+        .is_some_and(|v| v.truthy())
+    {
+        return "#<failed match>".to_string();
+    }
     let matched = attributes
         .get("str")
         .map(|s| s.to_string_value())

--- a/src/value/types_truthy.rs
+++ b/src/value/types_truthy.rs
@@ -84,6 +84,15 @@ impl Value {
                 if class_name == "Failure" {
                     return false;
                 }
+                // A failed `.subparse` Match is falsy (but still defined).
+                if class_name == "Match"
+                    && attributes
+                        .as_map()
+                        .get("__failed_match__")
+                        .is_some_and(|v| v.truthy())
+                {
+                    return false;
+                }
                 // Buf/Blob: truthy when non-empty
                 let cn = class_name.resolve();
                 if cn == "Buf"

--- a/t/grammar-subparse-pos-failed.t
+++ b/t/grammar-subparse-pos-failed.t
@@ -1,0 +1,48 @@
+use v6;
+use Test;
+
+plan 14;
+
+grammar RepeatChar {
+    token start($character) { $character+ }
+}
+
+# A successful subparse (the token matches a prefix from position 0).
+is ~RepeatChar.subparse('bbbabb', :rule('start'), :args(\('b'))), 'bbb',
+    'subparse matches the leading run';
+
+# A full .parse that does not consume the whole input fails (returns Nil-ish).
+nok RepeatChar.parse('bbbabb', :rule('start'), :args(\('b'))).defined,
+    'parse requires full consumption';
+
+# A failed .subparse yields a *failed* Match, not a Failure.
+my $failed = RepeatChar.subparse('bbbabb', :rule('start'), :args(\('a')));
+is $failed.gist, '#<failed match>', 'failed subparse gists as #<failed match>';
+is $failed.^name, 'Match', 'failed subparse is a Match';
+ok $failed.defined, 'failed subparse is defined';
+nok $failed.Bool, 'failed subparse is false';
+nok ?$failed, 'failed subparse is falsy in boolean context';
+is $failed.from, 0, 'failed subparse .from is 0';
+
+# `:pos(N)` anchors the subparse to begin exactly at position N.
+is ~RepeatChar.subparse('bbbabb', :rule('start'), :args(\('a')), :pos(3)), 'a',
+    ':pos(3) matches the "a" at offset 3';
+
+grammar Word {
+    token TOP { \w+ }
+}
+is ~Word.subparse('abcdef', :pos(2)), 'cdef', ':pos anchors a plain token';
+is Word.subparse('abcdef', :pos(2)).from, 2, ':pos match reports its .from';
+
+# A total no-match subparse also yields a failed Match.
+grammar Digits {
+    token TOP { \d+ }
+}
+my $nd = Digits.subparse('abc');
+is $nd.gist, '#<failed match>', 'no-match subparse is a failed Match';
+nok $nd, 'no-match subparse is falsy';
+
+# A .parse failure is still a Failure/undefined (unchanged behavior).
+nok Digits.parse('abc').defined, 'parse still fails on no digits';
+
+done-testing;

--- a/t/grammar-subparse.t
+++ b/t/grammar-subparse.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 5;
+plan 6;
 
 grammar LTM {
     proto token TOP {*}
@@ -12,4 +12,8 @@ is ~LTM.subparse('aaaaaaaa'), 'aaaa', 'subparse uses proto token LTM';
 is ~LTM.subparse('acacaca'), 'aca', 'subparse handles separator quantifier';
 ok LTM.parse('aaaa').defined, 'parse succeeds on full match';
 ok !LTM.parse('aaaab').defined, 'parse requires full input consumption';
-ok !LTM.subparse('bbbb').defined, 'subparse returns Nil on no match';
+# A failed .subparse yields a *failed* Match: it is defined but false, and
+# gists as `#<failed match>` (unlike .parse, which returns a Failure/Nil).
+my $failed = LTM.subparse('bbbb');
+ok !$failed, 'subparse yields a false (failed) Match on no match';
+is $failed.gist, '#<failed match>', 'failed subparse gists as #<failed match>';


### PR DESCRIPTION
## Summary

Closes the `Type/Grammar.rakudoc` `subparse` doc-diff divergence and adds `:pos(N)` support.

**Failed subparse → a failed Match, not a Failure.** A `.subparse` that does not match now returns a *failed* `Match` — it gists as `#<failed match>`, `.Bool` is `False`, but `.defined` is `True` (Rakudo) — instead of the `X::Syntax::Confused` `Failure` that a full `.parse` returns. A `__failed_match__` marker drives the gist (`match_gist`), truthiness (`truthy` + the Match `.Bool` method), and the three subparse failure paths in `dispatch_package_parse` now branch on `is_full_parse`.

**`:pos(N)` / `:c(N)`.** Previously parsed and silently ignored. `:pos(N)` anchors the subparse to begin exactly at N; `:c(N)` searches from N. The offset is threaded into the match (`regex_match_with_captures_at`/`_from`), the required-start check, and the LTM candidate filter (new `eval_token_call_values_at`, which measures each candidate's declarative prefix from the requested offset so a token that only matches later in the subject is still considered).

### Before / after

```raku
grammar RepeatChar { token start($c) { $c+ } }
say RepeatChar.subparse('bbbabb', :rule('start'), :args(\('a')));            # was X::Syntax::Confused() → now #<failed match>
say RepeatChar.subparse('bbbabb', :rule('start'), :args(\('a')), :pos(3));   # was X::Syntax::Confused() → now ｢a｣
```

## Test

- New `t/grammar-subparse-pos-failed.t` (14 assertions): failed-match gist/Bool/defined/from, `:pos(N)` anchoring, no-match subparse, and unchanged `.parse` failure.
- Updated `t/grammar-subparse.t` — its "subparse returns Nil on no match" case encoded the old (wrong) behavior; a failed subparse is a defined-but-false Match per raku.
- All `t/*grammar*`, `t/*match*`, `roast/S05-grammar/*` tests pass.
- `Type/Grammar.rakudoc` doc-diff: 1 → 0 high-signal divergences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)