### PR TITLE
fix: parse bareword `list`/`cache` with no argument as a zero-arg call

### DIFF
--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -972,17 +972,28 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
         "list" | "cache" if !rest.starts_with('(') => {
             let (r, _) = ws(rest)?;
             // list/cache take a comma expression as a single argument
-            // e.g. `list 1,2,4...16` → `list((1,2,4)...16)`
-            let (r, expr) = crate::parser::stmt::assign::parse_comma_or_expr(r)?;
-            let args = match expr {
-                Expr::ArrayLiteral(items) => items,
-                other => vec![other],
-            };
+            // e.g. `list 1,2,4...16` → `list((1,2,4)...16)`.
+            // With no argument (`list;`, or `list` at statement end), they are a
+            // zero-arg call yielding the empty list; without this fallback the
+            // mandatory comma-expression parse aborted the whole statement.
+            if let Ok((r, expr)) = crate::parser::stmt::assign::parse_comma_or_expr(r) {
+                let args = match expr {
+                    Expr::ArrayLiteral(items) => items,
+                    other => vec![other],
+                };
+                return Ok((
+                    r,
+                    Expr::Call {
+                        name: Symbol::intern(&name),
+                        args,
+                    },
+                ));
+            }
             return Ok((
                 r,
                 Expr::Call {
                     name: Symbol::intern(&name),
-                    args,
+                    args: vec![],
                 },
             ));
         }

--- a/t/list-cache-no-args.t
+++ b/t/list-cache-no-args.t
@@ -1,0 +1,48 @@
+use v6;
+use Test;
+
+# `list` and `cache` used as bare listops with NO argument must parse as a
+# zero-arg call yielding the empty list, matching raku. Regression: mutsu's
+# `list`/`cache` special case unconditionally parsed a mandatory comma
+# expression as the argument, so `list;` (or `list` at statement end) aborted
+# the whole statement with "Confused. expected ... '.' or digits or ...".
+# Found in the wild in REPL (lizmat): a bare `list;` call to a `my sub list`.
+
+plan 6;
+
+# Bare builtin `list` with no argument is the empty list.
+{
+    my @a = list;
+    is @a.elems, 0, 'bare `list` with no argument is the empty list';
+}
+
+# `list` still takes a comma expression as its argument.
+{
+    is (list 1, 2, 3).raku, '(1, 2, 3)', '`list 1, 2, 3` still collects its args';
+}
+
+# `list;` as a statement calls a user-declared `sub list` (name is not stolen).
+{
+    my $ran = 0;
+    my sub list() { $ran = 42 }
+    list;
+    is $ran, 42, '`list;` dispatches to a user-declared sub list';
+}
+
+# `list` at end of a block body (no trailing semicolon) parses too.
+{
+    my $r = do { list };
+    is $r.elems, 0, '`list` as the last statement of a block parses';
+}
+
+# `cache` with no argument parses (zero-arg call).
+{
+    my $c = cache;
+    ok $c.defined || !$c.defined, '`cache` with no argument parses';
+}
+
+# `list` followed by a statement modifier is a zero-arg call, not an error.
+{
+    my @a = (list if True);
+    is @a.elems, 0, '`list if COND` parses as a zero-arg call under the modifier';
+}


### PR DESCRIPTION
`list;` (or `list` at statement end) failed to parse with "Confused. expected ... '.' or digits or ...": the `list`/`cache` special case in `identifier_call` unconditionally parsed a mandatory comma expression as the argument, so a bare `list` with nothing following aborted the whole statement. raku treats a bare `list` as a zero-arg call yielding the empty list.

## Change
Fall back to a zero-argument `Call` when no comma expression follows, keeping the existing `list 1, 2, 3` argument-collection path intact.

## Impact
Found in the wild in **REPL** (lizmat), which calls a `my sub list` as a bare `list;` statement. Pinned by `t/list-cache-no-args.t` (6 cases, output verified identical to raku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)