### PR TITLE
fix: package/module .HOW reports PackageHOW/ModuleHOW, not ClassHOW

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2605,10 +2605,18 @@ impl Compiler {
                     // Register the package name so it's accessible as a value
                     let name_idx = self.code.add_constant(Value::str(qualified_name.clone()));
                     self.code.emit(OpCode::RegisterPackage { name_idx });
+                    self.code.emit(OpCode::SetPackageKind {
+                        name_idx,
+                        kind: *kind,
+                    });
                 } else if is_stub_body {
                     // Stub package — register name but don't execute the body
                     let name_idx = self.code.add_constant(Value::str(qualified_name.clone()));
                     self.code.emit(OpCode::RegisterPackage { name_idx });
+                    self.code.emit(OpCode::SetPackageKind {
+                        name_idx,
+                        kind: *kind,
+                    });
                     self.code.emit(OpCode::RegisterPackageStub { name_idx });
                 } else {
                     let name_idx = self.code.add_constant(Value::str(qualified_name.clone()));
@@ -2618,6 +2626,10 @@ impl Compiler {
                     } else {
                         self.code.emit(OpCode::RegisterPackage { name_idx });
                     }
+                    self.code.emit(OpCode::SetPackageKind {
+                        name_idx,
+                        kind: *kind,
+                    });
                     // Clear any previous stub status for this package
                     self.code.emit(OpCode::ClearPackageStub { name_idx });
                     let pkg_idx = self.code.emit(OpCode::PackageScope {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1184,6 +1184,12 @@ pub(crate) enum OpCode {
     RegisterPackage {
         name_idx: u32,
     },
+    /// Record the declarator keyword (`package`/`module`/`grammar`) of a bare
+    /// `Stmt::Package` so `.HOW` reports the matching metaclass.
+    SetPackageKind {
+        name_idx: u32,
+        kind: crate::ast::PackageKind,
+    },
     /// Register a lexically-scoped (`my`) package type object.
     /// Same as RegisterPackage but marks the name as block-declared
     /// so it is cleaned up when the enclosing block scope exits.

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -281,7 +281,15 @@ impl Interpreter {
             }
         };
         // Use appropriate HOW metaclass for each type kind
-        let how_name = if self.registry().roles.contains_key(&type_name) && !type_name.contains('[')
+        let how_name = if let Some(kind) = self.registry().package_kinds.get(&type_name) {
+            // A bare `package`/`module`/`grammar` reports its own metaclass
+            // rather than the default `ClassHOW`.
+            match kind {
+                crate::ast::PackageKind::Package => "Perl6::Metamodel::PackageHOW",
+                crate::ast::PackageKind::Module => "Perl6::Metamodel::ModuleHOW",
+                crate::ast::PackageKind::Grammar => "Perl6::Metamodel::GrammarHOW",
+            }
+        } else if self.registry().roles.contains_key(&type_name) && !type_name.contains('[')
             || matches!(
                 type_name.as_str(),
                 "Numeric"
@@ -298,7 +306,8 @@ impl Interpreter {
                     | "Iterable"
                     | "Iterator"
                     | "PositionalBindFailover"
-            ) {
+            )
+        {
             "Perl6::Metamodel::ParametricRoleGroupHOW"
         } else if self.registry().enum_types.contains_key(&type_name) {
             "Perl6::Metamodel::EnumHOW"

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -6,6 +6,8 @@ impl Interpreter {
     pub(super) fn is_metamodel_how(class_name: &Symbol) -> bool {
         let cn = class_name.resolve();
         cn == "Perl6::Metamodel::ClassHOW"
+            || cn == "Perl6::Metamodel::ModuleHOW"
+            || cn == "Perl6::Metamodel::PackageHOW"
             || cn == "Perl6::Metamodel::SubsetHOW"
             || cn == "Perl6::Metamodel::EnumHOW"
             || cn == "Perl6::Metamodel::CurriedRoleHOW"

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -68,6 +68,12 @@ pub(crate) struct Registry {
     pub(crate) class_stubs: HashSet<String>,
     /// Forward-declared package stubs.
     pub(crate) package_stubs: HashSet<String>,
+    /// Declarator keyword used for a bare `package`/`module`/`grammar` (a
+    /// `Stmt::Package`), so `.HOW` reports the matching metaclass
+    /// (`PackageHOW`/`ModuleHOW`/`GrammarHOW`) instead of the default
+    /// `ClassHOW`. Classes and roles are absent (they default to `ClassHOW` /
+    /// the role HOW).
+    pub(crate) package_kinds: HashMap<String, crate::ast::PackageKind>,
     /// `is hidden` parents deferred until the parent is fully declared.
     pub(crate) hidden_defer_parents: HashMap<String, HashSet<String>>,
     /// `trusts` relationships: class -> set of trusted classes.

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3849,6 +3849,11 @@ impl Interpreter {
                 self.update_local_if_exists(code, &name, &pkg_val);
                 *ip += 1;
             }
+            OpCode::SetPackageKind { name_idx, kind } => {
+                let name = Self::const_str(code, *name_idx).to_string();
+                self.registry_mut().package_kinds.insert(name, *kind);
+                *ip += 1;
+            }
             OpCode::RegisterPackageMy { name_idx } => {
                 let name = Self::const_str(code, *name_idx).to_string();
                 self.shadow_suppressed_type_with_package(&name);

--- a/t/package-module-how.t
+++ b/t/package-module-how.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+plan 9;
+
+# A bare `package`/`module` reports its own metaclass, not the default ClassHOW.
+package P { }
+is P.HOW.^name, 'Perl6::Metamodel::PackageHOW', 'package uses PackageHOW';
+
+module M { }
+is M.HOW.^name, 'Perl6::Metamodel::ModuleHOW', 'module uses ModuleHOW';
+
+class C { }
+is C.HOW.^name, 'Perl6::Metamodel::ClassHOW', 'class still uses ClassHOW';
+
+# .gist of the metaobject (what `say P.HOW` prints).
+is P.HOW.gist, 'Perl6::Metamodel::PackageHOW.new', 'PackageHOW gist';
+is M.HOW.gist, 'Perl6::Metamodel::ModuleHOW.new', 'ModuleHOW gist';
+
+# A versioned module exposes .^ver / .^auth / .^name.
+my module Mv:ver<1.2.3>:auth<me> { }
+is Mv.^name, 'Mv',        'module .^name';
+is-deeply Mv.^ver, v1.2.3, 'module .^ver';
+is Mv.^auth, 'me',         'module .^auth';
+
+# A package has no version metamethods (absent by design).
+my package Pv:ver<1.2.3> { }
+dies-ok { Pv.^ver }, 'package .^ver is absent';
+
+done-testing;


### PR DESCRIPTION
## Summary

Closes the `Type/Metamodel/PackageHOW.rakudoc` doc-diff divergence:

```raku
package P {}
say P.HOW;   # was Perl6::Metamodel::ClassHOW.new → now Perl6::Metamodel::PackageHOW.new
```

A bare `package`/`module` (a `Stmt::Package`) now reports its own metaclass — `PackageHOW` / `ModuleHOW` — instead of the default `ClassHOW`. The declarator keyword is threaded from the compiler to the registry via a new `SetPackageKind` opcode (name → `PackageKind`), and `dispatch_how` consults `registry.package_kinds` before the role/enum/subset/class selection.

`ModuleHOW`/`PackageHOW` are added to `is_metamodel_how` so metamethods still dispatch: a versioned module answers `.^ver`/`.^auth`/`.^name`, while a package's `.^ver`/`.^auth` stay absent by design (the existing not-in-`classes` path throws `X::Method::NotFound`) and `.^name` works.

## Test

- New `t/package-module-how.t` (9 assertions): metaclass name + gist for package/module/class, versioned-module metamethods, and package `.^ver` absence.
- All 9 `roast/S12-introspection/*.t` files pass (including `meta-class.t`, whose "metamethods on a module" subtest exercises `M.^ver`/`.^auth` through the new `ModuleHOW`).
- `opcode_size_guard` passes (the new opcode stays within the 48-byte budget).
- `Type/Metamodel/PackageHOW.rakudoc` doc-diff: 1 → 0 high-signal divergences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)