### PR TITLE
fix: don't gobble a block after an uppercase hyphenated type name

### DIFF
--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1567,7 +1567,10 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
         // after such a type, so `$x ~~ PB-Lottery::Ticket { ... }` keeps its
         // `{ ... }` as the enclosing `if`/`unless` body. Forward-ref subs
         // (`do-thing`, `strip-comment`) are lowercase and still gobble their args.
-        let short_name = name.rsplit_once("::").map(|(_, t)| t).unwrap_or(name.as_str());
+        let short_name = name
+            .rsplit_once("::")
+            .map(|(_, t)| t)
+            .unwrap_or(name.as_str());
         let short_name_is_type = short_name.starts_with(|c: char| c.is_ascii_uppercase());
         let hyphen_forward_call =
             !is_user_sub && !name_is_declared_type && !short_name_is_type && name.contains('-');

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1560,7 +1560,17 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
             || name
                 .rsplit_once("::")
                 .is_some_and(|(_, tail)| crate::parser::stmt::simple::is_user_declared_type(tail));
-        let hyphen_forward_call = !is_user_sub && !name_is_declared_type && name.contains('-');
+        // A hyphenated bareword whose short name starts with an uppercase letter
+        // is a *type* reference (`PB-Lottery::Ticket`, `Sub-Test`), not a
+        // forward-referenced sub — even when the type is not declared here (e.g.
+        // it comes from a not-yet-loaded dependency). raku never gobbles a block
+        // after such a type, so `$x ~~ PB-Lottery::Ticket { ... }` keeps its
+        // `{ ... }` as the enclosing `if`/`unless` body. Forward-ref subs
+        // (`do-thing`, `strip-comment`) are lowercase and still gobble their args.
+        let short_name = name.rsplit_once("::").map(|(_, t)| t).unwrap_or(name.as_str());
+        let short_name_is_type = short_name.starts_with(|c: char| c.is_ascii_uppercase());
+        let hyphen_forward_call =
+            !is_user_sub && !name_is_declared_type && !short_name_is_type && name.contains('-');
         if is_user_prefix_sub {
             if let Ok((r2, arg)) = expression_no_sequence(r) {
                 return Ok((r2, make_call_expr(call_name.clone(), input, vec![arg])));

--- a/t/hyphenated-imported-type-block-no-gobble.t
+++ b/t/hyphenated-imported-type-block-no-gobble.t
@@ -1,0 +1,46 @@
+use v6;
+use lib 't/lib';
+use Test;
+use Hy-Phen::Thing;
+
+# A hyphenated *qualified* type name imported from another module
+# (`Hy-Phen::Thing`) must not gobble a following `{ ... }` block as a call
+# argument. At parse time the imported type is not yet known to the parser's
+# user-type table, so the old heuristic treated any hyphenated unknown name as a
+# forward-referenced sub and consumed the block — breaking
+# `$x ~~ Hy-Phen::Thing { ... }` (the `{ ... }` is the if/unless/when body).
+# The short name starts with an uppercase letter, so it is a type, not a sub.
+# Regression seen in PB-Lottery (`$ticket ~~ PB-Lottery::Ticket { ... }`).
+
+plan 5;
+
+my $t = Hy-Phen::Thing.new(:v(3));
+
+# smartmatch against the imported hyphenated type; block is the if-body
+if $t ~~ Hy-Phen::Thing {
+    pass "if-block belongs to the if, not gobbled by Hy-Phen::Thing";
+} else {
+    flunk "instance should smartmatch its own type";
+}
+
+# unless variant
+unless 5 ~~ Hy-Phen::Thing {
+    pass "unless-block belongs to the unless, not gobbled";
+}
+
+# given/when
+my $branch = 'none';
+given $t {
+    when Hy-Phen::Thing { $branch = 'matched' }
+    default             { $branch = 'default' }
+}
+is $branch, 'matched', "when Hy-Phen::Thing block is the when-body";
+
+# the accessor works (proves the type really loaded and constructed)
+is $t.v, 3, "imported hyphenated type constructs and accesses attributes";
+
+# A lowercase hyphenated forward-referenced sub still gobbles its block arg.
+my $ran = 0;
+run-it { $ran = 1 };
+is $ran, 1, "lowercase hyphenated forward-ref sub still gobbles its block";
+sub run-it(&b) { b() }

--- a/t/lib/Hy-Phen/Thing.rakumod
+++ b/t/lib/Hy-Phen/Thing.rakumod
@@ -1,0 +1,2 @@
+unit class Hy-Phen::Thing;
+has $.v = 0;


### PR DESCRIPTION
`$x ~~ PB-Lottery::Ticket { ... }` failed to parse ("Confused. expected '{'"): the block-grab heuristic treated any hyphenated bareword that is not a locally-declared type as a forward-referenced sub and consumed the following `{ ... }` as a call argument. A type imported from another module (via `use`) is not in the parser's user-type table at parse time, so `PB-Lottery::Ticket` was mis-treated as a sub and stole the `unless`/`if`/`when` body.

## Change
A hyphenated bareword whose short name (final `::` component) starts with an uppercase letter is a *type* reference by Raku convention, never a forward-referenced sub. Exclude such names from `hyphen_forward_call` so the following block stays with the enclosing construct — regardless of whether the type is declared in this compilation unit. Lowercase hyphenated forward-ref subs (`do-thing`, `strip-comment`) still gobble their arguments as before.

## Impact
Unblocks parsing of **PB-Lottery** (which now reaches its missing `Text::Utils` dep, same as raku). Extends the existing `t/hyphenated-type-block-no-gobble.t` (declared types) to the imported-type case. Pinned by `t/hyphenated-imported-type-block-no-gobble.t` via `t/lib/Hy-Phen/Thing.rakumod`, output verified against raku.

🤖 Generated with [Claude Code](https://claude.com/claude-code)