### PR TITLE
fix: coerce a Rat/Num/allomorph count for Str.chop

### DIFF
--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -221,8 +221,18 @@ pub(crate) fn native_method_1arg(
                     use num_traits::ToPrimitive;
                     bi.to_usize().unwrap_or(usize::MAX)
                 }
-                ValueView::Num(f) => (f as i64).max(0) as usize,
-                _ => arg.to_string_value().parse::<usize>().unwrap_or(1),
+                // A plain string coerces like `.Int` (parse an integer literal).
+                ValueView::Str(_) => arg.to_string_value().parse::<usize>().unwrap_or(1),
+                // Any other numeric (Num/Rat/FatRat/allomorph) coerces like `.Int`,
+                // truncating toward zero: `.chop(3.6)` chops 3.
+                _ => {
+                    let f = arg.to_f64();
+                    if f.is_finite() && f > 0.0 {
+                        f.trunc() as usize
+                    } else {
+                        0
+                    }
+                }
             };
             let char_count = s.chars().count();
             let keep = char_count.saturating_sub(n);

--- a/src/value/value_methods_c.rs
+++ b/src/value/value_methods_c.rs
@@ -423,6 +423,8 @@ impl Value {
                 .get("str")
                 .map(|v| v.to_string_value().trim().parse::<f64>().unwrap_or(0.0))
                 .unwrap_or(0.0),
+            // A numeric allomorph (IntStr/NumStr/RatStr) numifies to its inner value.
+            ValueView::Mixin(inner, _) => inner.to_f64(),
             _ => 0.0,
         }
     }

--- a/t/chop-numeric-arg.t
+++ b/t/chop-numeric-arg.t
@@ -1,0 +1,34 @@
+use v6;
+use Test;
+
+# `.chop($n)` coerces its argument like `.Int` (truncating toward zero),
+# so a Rat/Num/allomorph count works, not only a plain Int.
+
+plan 9;
+
+# Rat argument truncates toward zero: 3.6 chops 3 chars.
+is "Whateverable".chop(3.6), "Whatevera", "chop(Rat) truncates toward zero";
+
+# A string that looks like an integer coerces.
+is "Whateverable".chop("3"), "Whatevera", "chop(Str) parses an integer";
+
+# A numeric allomorph coerces via its inner value.
+is "Whateverable".chop(<3>), "Whatevera", "chop(IntStr) uses the inner value";
+
+# A fractional count below 1 truncates to 0 (chops nothing).
+is "Whateverable".chop(2/3), "Whateverable", "chop(2/3) truncates to 0";
+
+# Explicit 0 and the no-arg default (1) still work.
+is "Whateverable".chop(0), "Whateverable", "chop(0) removes nothing";
+is "Whateverable".chop, "Whateverabl", "chop with no arg removes one char";
+
+# A plain Int still works.
+is "Whateverable".chop(3), "Whatevera", "chop(Int) removes three chars";
+
+# Larger-than-length counts empty the string, never underflow.
+is "abc".chop(10), "", "chop past the end yields the empty string";
+
+# A Num argument truncates toward zero as well (2.9 -> 2).
+is "Whateverable".chop(2.9e0), "Whateverab", "chop(Num) truncates toward zero";
+
+done-testing;


### PR DESCRIPTION
## What

`.chop($n)` coerces its argument like `.Int` (truncating toward zero). mutsu
handled only Int/BigInt/Num/Str, so:

- `.chop(3.6)` fell through to the string-parse fallback (`"3.6".parse::<usize>()`
  failed → defaulted to chopping 1 char).
- `.chop(<3>)` (an `IntStr` allomorph) reached `Value::to_f64`, which had no
  `Mixin` arm and returned `0` → chopped nothing.

## Fix

- `dispatch_1arg.rs` chop: route any non-string numeric argument through
  `to_f64().trunc()` (truncate toward zero, matching `.Int`).
- `value_methods_c.rs`: add the missing `Mixin` arm to `Value::to_f64` so a
  numeric allomorph numifies to its inner value — mirroring `to_bigint`, which
  already did this.

Now matches raku:

```
"Whateverable".chop(3.6)  # Whatevera
"Whateverable".chop("3")  # Whatevera
"Whateverable".chop(<3>)  # Whatevera
"Whateverable".chop(2/3)  # Whateverable  (truncates to 0)
```

Surfaced by the doc-diff harness (PLAN §8.1) on `Type/Str.rakudoc`.

## Test

Pin `t/chop-numeric-arg.t`. `make test` green (2118 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)