### PR TITLE
fix: Str.trans replacement cycling, Seq keys, and :squash overflow

### DIFF
--- a/src/runtime/methods_trans.rs
+++ b/src/runtime/methods_trans.rs
@@ -6,6 +6,10 @@ enum TransRule {
     CharMap {
         from_chars: Vec<char>,
         to_chars: Vec<char>,
+        /// When the replacement is shorter than the key: `true` cycles the
+        /// replacement (the Str=>Str first-multi form, `'123' => 'þð'` gives
+        /// `þðþ`), `false` repeats the last replacement char (the list form).
+        cycle: bool,
     },
     /// Multi-character token mapping (from array pairs).
     TokenMap {
@@ -36,6 +40,19 @@ enum TransRule {
 enum TokenReplacement {
     Static(String),
     Closure(Value),
+}
+
+/// A Seq/Slip key or value in a `.trans` pair is list-like; materialize it to
+/// an Array so the list-form dispatch recognizes it (`"abc".comb => 1..2`).
+/// Any other value is returned unchanged (Arc-cheap clone).
+fn normalize_trans_operand(v: &Value) -> Value {
+    match v.view() {
+        ValueView::Seq(items)
+        | ValueView::HyperSeq(items)
+        | ValueView::RaceSeq(items)
+        | ValueView::Slip(items) => Value::array(items.to_vec()),
+        _ => v.clone(),
+    }
 }
 
 /// Expand a tr-style spec string: `a..z` becomes all chars from 'a' to 'z'.
@@ -216,6 +233,13 @@ impl Interpreter {
                     rules.push(self.parse_trans_pair(key, value));
                 }
             } else if let ValueView::ValuePair(key, value) = arg.view() {
+                // A Seq/Slip key or value (e.g. from `"abc".comb`) is list-like;
+                // materialize it to an Array so the list-form dispatch below
+                // recognizes it instead of stringifying the whole sequence.
+                let key_norm = normalize_trans_operand(key);
+                let value_norm = normalize_trans_operand(value);
+                let key = &key_norm;
+                let value = &value_norm;
                 // For ValuePair, the key preserves its original type
                 if let ValueView::Regex(pattern) = key.view() {
                     if is_closure(value) {
@@ -308,6 +332,7 @@ impl Interpreter {
                                         rules.push(TransRule::CharMap {
                                             from_chars,
                                             to_chars,
+                                            cycle: false,
                                         });
                                     }
                                 }
@@ -332,6 +357,7 @@ impl Interpreter {
                             rules.push(TransRule::CharMap {
                                 from_chars,
                                 to_chars,
+                                cycle: false,
                             });
                         }
                     }
@@ -433,9 +459,14 @@ impl Interpreter {
         } else {
             let from_chars: Vec<char> = from_list.iter().filter_map(|s| s.chars().next()).collect();
             let to_chars: Vec<char> = to_list.iter().filter_map(|s| s.chars().next()).collect();
+            // The Str=>Str first-multi form cycles a short replacement to the
+            // key length (`'123' => 'þð'` gives `þðþ`); a Str=>list/range target
+            // is dispatched to the list form, which repeats the last char.
+            let cycle = matches!(value.view(), ValueView::Str(_));
             TransRule::CharMap {
                 from_chars,
                 to_chars,
+                cycle,
             }
         }
     }
@@ -469,6 +500,7 @@ impl Interpreter {
                     TransRule::CharMap {
                         from_chars,
                         to_chars,
+                        cycle,
                     } => {
                         if let Some(pos) = from_chars.iter().position(|&fc| fc == chars[i])
                             && 1 >= best_len
@@ -476,12 +508,19 @@ impl Interpreter {
                             best_len = 1;
                             best_replacement = if pos < to_chars.len() {
                                 to_chars[pos].to_string()
-                            } else if delete {
+                            } else if delete || to_chars.is_empty() {
                                 String::new()
-                            } else if !to_chars.is_empty() {
-                                to_chars.last().unwrap().to_string()
+                            } else if *cycle && !squash {
+                                // Str=>Str form: cycle the replacement to the key
+                                // length. Under `:squash` the form falls back to
+                                // repeat-last so the squash collapse below reduces
+                                // the run (`'123' => 'þð', :squash` => `þð`),
+                                // matching `:delete`.
+                                to_chars[pos % to_chars.len()].to_string()
                             } else {
-                                String::new()
+                                // List form (or squashed Str=>Str): repeat the
+                                // last replacement char.
+                                to_chars.last().unwrap().to_string()
                             };
                             best_closure = None;
                             found = true;

--- a/t/trans-replacement-cycle.t
+++ b/t/trans-replacement-cycle.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+# `.trans` has two forms with different short-replacement semantics:
+#   * Str => Str (the first multi): the replacement is CYCLED to the key length.
+#   * list/range key or value (the second multi): the last replacement char is
+#     repeated, and `:delete` drops the unmatched trailing chars.
+
+plan 12;
+
+# Str => Str cycles a short replacement (doc example).
+is "a123b123c".trans('123' => 'þð'), "aþðþbþðþc", "Str=>Str cycles the replacement";
+is "12345".trans('12345' => 'AB'), "ABABA", "Str=>Str cycle over a longer key";
+is "1234567".trans('1234567' => 'ABC'), "ABCABCA", "Str=>Str cycle with a 3-char replacement";
+
+# A Str key with a list/range target is dispatched to the list form: repeat-last.
+is "12345".trans('12345' => (1, 2)), "12222", "Str key + list value repeats the last char";
+is "12345".trans('12345' => 1..2), "12222", "Str key + range value repeats the last char";
+
+# A Seq key (e.g. from `.comb`) is list-like, not a stringified sequence.
+is "abc".trans("abc".comb => 1..2, :delete), "12", ".comb key + :delete drops the unmatched tail";
+is "abc".trans("abc".comb => ("1", "2")), "122", ".comb key repeats the last replacement";
+
+# List key with an integer/range value works the same as a string list value.
+is "abc".trans(<a b c> => (1, 2), :delete), "12", "list key + int list value + :delete";
+
+# `:squash` and `:delete` make the Str=>Str form a strict substitution (doc).
+is "a123b123c".trans('123' => 'þð', :squash), "aþðbþðc", ":squash strict-substitutes like :delete";
+is "a123b123c".trans('123' => 'þð', :delete), "aþðbþðc", ":delete strict-substitutes";
+
+# Equal-length Str=>Str is unaffected.
+is "a123b123c".trans('23' => '4'), "a144b144c", "equal-length map is a plain substitution";
+
+# Range key => range value (list form) with :squash still works (doc example).
+is "aaa1123bb123c".trans('a'..'z' => 'A'..'Z', :squash), "A1123B123C", "range=>range :squash";
+
+done-testing;


### PR DESCRIPTION
## What

Three related `.trans` divergences surfaced by the doc-diff harness (PLAN §8.1)
on `Type/Str.rakudoc`:

**1. Str=>Str replacement cycling.** The `trans(Pair)` first-multi form (both
origin and target are `Str`) cycles a short replacement to the key length:

```
"a123b123c".trans('123' => 'þð')   # aþðþbþðþc  (mutsu gave aþððbþððc)
"12345".trans('12345' => 'AB')     # ABABA      (mutsu gave ABBBB)
```

A `Str` key with a **list/range** target is dispatched to the second multi,
which repeats the last char (`'12345' => (1,2)` → `12222`). Added a `cycle`
flag to `CharMap`, set only when both key and value are plain strings.

**2. Seq keys.** A `Seq`/`Slip` key or value (e.g. from `"abc".comb`) was
stringified whole instead of treated as a list:

```
"abc".trans("abc".comb => 1..2, :delete)   # 12  (mutsu gave 1)
```

Normalize a `Seq`/`HyperSeq`/`RaceSeq`/`Slip` operand to an `Array` up front so
the list-form dispatch recognizes it.

**3. `:squash` overflow.** Per the doc, `:squash` and `:delete` make the
Str=>Str form a strict substitution, so an overflow char is dropped rather than
cycled (`'123' => 'þð', :squash` == `aþðbþðc`).

## Test

Pin `t/trans-replacement-cycle.t` (12 cases). `make test` green (2118 files);
the harness on Str.rakudoc drops from 9 to 7 output-mismatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)