### PR TITLE
fix: Str.contains accepts a Regex needle

### DIFF
--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -319,6 +319,11 @@ pub(crate) fn native_method_1arg(
                     type_name,
                 ))));
             }
+            // A Regex needle needs the regex engine (&mut self); fall through to
+            // the slow path (dispatch_contains) instead of matching its gist.
+            if let ValueView::Regex(..) = arg.view() {
+                return None;
+            }
             let s = target.to_string_value();
             Some(Ok(contains_value_recursive(&s, arg)))
         }

--- a/src/builtins/methods_narg/fmt_contains.rs
+++ b/src/builtins/methods_narg/fmt_contains.rs
@@ -104,6 +104,11 @@ pub(crate) fn native_contains_with_options(
     if let ValueView::Package(_) = needle.view() {
         return None;
     }
+    // A Regex needle needs the regex engine (&mut self); let the interpreter's
+    // dispatch_contains own it rather than searching for the regex's gist.
+    if let ValueView::Regex(..) = needle.view() {
+        return None;
+    }
     let start = match positional.get(1).copied().map(Value::view) {
         Some(ValueView::Int(i)) => i,
         Some(ValueView::Num(f)) => f as i64,

--- a/src/runtime/methods_string_search.rs
+++ b/src/runtime/methods_string_search.rs
@@ -2,7 +2,7 @@ use super::*;
 
 impl Interpreter {
     pub(super) fn dispatch_contains(
-        &self,
+        &mut self,
         target: Value,
         args: &[Value],
     ) -> Result<Value, RuntimeError> {
@@ -51,6 +51,12 @@ impl Interpreter {
             ));
         }
         let hay: String = text.chars().skip(start as usize).collect();
+        // A Regex needle means "does the pattern match anywhere from `start`?"
+        // (`"abc".contains(/b/)`), not a literal search for the regex's gist.
+        if let ValueView::Regex(pattern) = needle.view() {
+            let found = self.regex_find_first(&pattern, &hay).is_some();
+            return Ok(Value::truth(found));
+        }
         Ok(Self::contains_value(&hay, &needle, ignore_case))
     }
 

--- a/t/contains-regex.t
+++ b/t/contains-regex.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+# `Str.contains($needle)` accepts a Regex needle: it asks whether the pattern
+# matches anywhere (from an optional start position), not whether the string
+# literally contains the regex's gist.
+
+plan 11;
+
+is "Hello, World".contains(/o/), True, "regex needle matches";
+is "Hello, World".contains(/z/), False, "regex needle that never matches";
+
+# With a start position, the search begins at that character index.
+is "Hello, World".contains(/o/, 5), True, "regex needle from a start position";
+is "abcabc".contains(/b/, 3), True, "regex needle finds a later occurrence";
+is "abcabc".contains(/a/, 4), False, "regex needle: nothing after the start pos";
+
+# Zero-width lookahead assertions work (doc example).
+is 'Hello, World'.contains(/\w <?before ','>/), True, "lookahead assertion matches";
+is 'Hello, World'.contains(/\w <?before ','>/, 5), False, "lookahead assertion from pos 5";
+
+# A plain string needle still works.
+is "abc".contains("b"), True, "string needle still works";
+is "abc".contains("z"), False, "string needle absent";
+
+# A regex with a quantifier / char class.
+is "a1b2c3".contains(/\d\d/), False, "no two consecutive digits";
+is "a12b".contains(/\d\d/), True, "two consecutive digits present";
+
+done-testing;


### PR DESCRIPTION
## What

`"Hello, World".contains(/o/)` returned **False**. All three code paths for
`.contains` stringified the `Regex` needle and did a literal search for its
gist, never running the regex:

- `native_method_1arg`'s `contains` arm (`.contains($needle)`)
- `native_contains_with_options` (`.contains($needle, $pos)` / `:i` forms)
- `dispatch_contains` (the slow path)

## Fix

- Both native fast paths now return `None` for a `Regex` needle, so the
  interpreter owns the semantics.
- `dispatch_contains` (now `&mut self`) runs the regex via `regex_find_first`
  from the optional start position, returning whether the pattern matches
  anywhere in the remaining string.

Now matches raku:

```
"Hello, World".contains(/o/)                  # True
"Hello, World".contains(/o/, 5)               # True
'Hello, World'.contains(/\w <?before ','>/)   # True
'Hello, World'.contains(/\w <?before ','>/,5) # False
```

Surfaced by the doc-diff harness (PLAN §8.1) on `Type/Str.rakudoc`.

## Test

Pin `t/contains-regex.t` (11 cases). `make test` green (2118 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)