### PR TITLE
fix: lines/Str.lines accept :count and a leading named arg

### DIFF
--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -554,6 +554,18 @@ pub(crate) fn native_method_1arg(
                             .collect();
                     return Some(Ok(Value::seq(lines)));
                 }
+                // `.lines(:count)` returns the number of lines instead of the list.
+                if key == "count" {
+                    if value.truthy() {
+                        let n = crate::builtins::split_lines_chomped(&s).len();
+                        return Some(Ok(Value::int(n as i64)));
+                    }
+                    let lines: Vec<Value> = crate::builtins::split_lines_chomped(&s)
+                        .into_iter()
+                        .map(Value::str)
+                        .collect();
+                    return Some(Ok(Value::seq(lines)));
+                }
                 return None;
             }
 

--- a/src/runtime/builtins_io_stream.rs
+++ b/src/runtime/builtins_io_stream.rs
@@ -134,17 +134,26 @@ impl Interpreter {
     }
 
     pub(super) fn builtin_lines(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
-        if let Some(first) = args.first()
+        // Named args (`:chomp`, `:count`) may appear before or after the string
+        // argument (`lines(:!chomp, "a\nb")`), so partition them out first and
+        // treat the first *positional* argument as the string/handle.
+        let mut chomp = true;
+        let mut count_only = false;
+        let mut positional: Vec<&Value> = Vec::new();
+        for arg in args {
+            match arg.view() {
+                ValueView::Pair(key, value) if key == "chomp" => chomp = value.truthy(),
+                ValueView::Pair(key, value) if key == "count" => count_only = value.truthy(),
+                _ => positional.push(arg),
+            }
+        }
+        if let Some(first) = positional.first()
             && Self::handle_id_from_value(first).is_none()
         {
             let text = first.to_string_value();
             let mut limit: Option<usize> = None;
-            let mut chomp = true;
-            for arg in &args[1..] {
+            for arg in &positional[1..] {
                 match arg.view() {
-                    ValueView::Pair(key, value) if key == "chomp" => {
-                        chomp = value.truthy();
-                    }
                     ValueView::Int(i) => {
                         limit = Some(i.max(0) as usize);
                     }
@@ -167,6 +176,10 @@ impl Interpreter {
             let mut lines = crate::builtins::split_lines_with_chomp(&text, chomp);
             if let Some(n) = limit {
                 lines.truncate(n);
+            }
+            // `lines(:count)` returns the number of lines instead of the list.
+            if count_only {
+                return Ok(Value::int(lines.len() as i64));
             }
             let values: Vec<Value> = lines.into_iter().map(Value::str).collect();
             // `lines` returns a Seq (so `.^name` is Seq), matching Rakudo and

--- a/t/lines-named-args.t
+++ b/t/lines-named-args.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+# `lines` / `Str.lines` accept the `:chomp` and `:count` named args, and the
+# sub form accepts a named arg before the string positional.
+
+plan 9;
+
+# `:count` (method form) returns the number of lines instead of the list.
+is "a\nb\nc".lines(:count), 3, ".lines(:count) returns the line count";
+is "".lines(:count), 0, ".lines(:count) on an empty string is 0";
+is "one line".lines(:count), 1, ".lines(:count) with no newline is 1";
+
+# `:count` (sub form).
+is lines("a\nb\nc", :count), 3, "lines(str, :count) returns the count";
+
+# A named arg may precede the string in the sub form.
+is lines(:!chomp, "a\nb").raku, ("a\n", "b").Seq.raku,
+    "lines(:!chomp, str) keeps line endings";
+is lines("a\nb").raku, ("a", "b").Seq.raku, "lines(str) chomps by default";
+
+# `:chomp` (method form) still works.
+is "a\nb".lines(:!chomp).raku, ("a\n", "b").Seq.raku, ".lines(:!chomp) keeps endings";
+is "a\n".lines(:!chomp).elems, 1, ".lines(:!chomp) on a trailing newline";
+
+# `.lines` with no args is unaffected.
+is "a\nb".lines.elems, 2, "plain .lines still splits";
+
+done-testing;


### PR DESCRIPTION
## What

Two doc-diff findings (PLAN §8.1) on `Type/Str.rakudoc`:

**1. `:count`.** `.lines(:count)` threw *No such method 'lines'* and
`lines($str, :count)` discarded the arg. The 1-arg method path only recognized
`:chomp`. Add a `:count` case returning the line count as an `Int` (`:!count`
returns the plain Seq).

```
"a\nb\nc".lines(:count)        # 3
lines("a\nb\nc", :count)       # 3
```

**2. A leading named arg in the sub form.** `lines(:!chomp, "a\nb")` treated
the leading `:!chomp` Pair as the string argument (stringifying it to
`chomp\tFalse`). The sub now partitions named args (`:chomp`/`:count`) from
positionals first, so a named arg may precede the string.

```
lines(:!chomp, "a\nb").raku    # ("a\n", "b").Seq
```

## Test

Pin `t/lines-named-args.t` (9 cases). `make test` green (2118 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)