### PR TITLE
fix: Str.contains honors :ignoremark

### DIFF
--- a/src/builtins/methods_narg/fmt_contains.rs
+++ b/src/builtins/methods_narg/fmt_contains.rs
@@ -85,11 +85,14 @@ pub(crate) fn native_contains_with_options(
     let mut ignore_case = false;
     for arg in args {
         if let ValueView::Pair(key, value) = arg.view() {
-            if matches!(key.as_str(), "i" | "ignorecase" | "m" | "ignoremark") {
-                ignore_case = value.truthy();
-            } else {
+            match key.as_str() {
+                "i" | "ignorecase" => ignore_case = value.truthy(),
+                // `:ignoremark` needs NFD mark-stripping (the interpreter's
+                // strip logic); let dispatch_contains own it.
+                "m" | "ignoremark" if value.truthy() => return None,
+                "m" | "ignoremark" => {}
                 // An unexpected named arg: let the interpreter own the semantics.
-                return None;
+                _ => return None,
             }
         } else {
             positional.push(arg);

--- a/src/runtime/methods_string_search.rs
+++ b/src/runtime/methods_string_search.rs
@@ -1,5 +1,24 @@
 use super::*;
 
+/// Fold a string for `.contains` matching: `:ignoremark` strips combining marks
+/// (NFD, drop combining code points), `:ignorecase` lowercases. Applied to both
+/// the haystack and each needle so the comparison is symmetric.
+fn fold_for_contains(s: &str, ignore_case: bool, ignore_mark: bool) -> String {
+    use unicode_normalization::UnicodeNormalization;
+    let stripped: String = if ignore_mark {
+        s.nfd()
+            .filter(|c| !unicode_normalization::char::is_combining_mark(*c))
+            .collect()
+    } else {
+        s.to_string()
+    };
+    if ignore_case {
+        stripped.to_lowercase()
+    } else {
+        stripped
+    }
+}
+
 impl Interpreter {
     pub(super) fn dispatch_contains(
         &mut self,
@@ -8,10 +27,13 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         let mut positional: Vec<Value> = Vec::new();
         let mut ignore_case = false;
+        let mut ignore_mark = false;
         for arg in args {
             if let ValueView::Pair(key, value) = arg.view() {
-                if matches!(key.as_str(), "i" | "ignorecase" | "m" | "ignoremark") {
-                    ignore_case = value.truthy();
+                match key.as_str() {
+                    "i" | "ignorecase" => ignore_case = value.truthy(),
+                    "m" | "ignoremark" => ignore_mark = value.truthy(),
+                    _ => {}
                 }
             } else {
                 positional.push(arg.clone());
@@ -57,25 +79,29 @@ impl Interpreter {
             let found = self.regex_find_first(&pattern, &hay).is_some();
             return Ok(Value::truth(found));
         }
-        Ok(Self::contains_value(&hay, &needle, ignore_case))
+        // `:ignorecase`/`:ignoremark` fold the haystack once here; each needle is
+        // folded the same way inside contains_value.
+        let folded_hay = fold_for_contains(&hay, ignore_case, ignore_mark);
+        Ok(Self::contains_value(
+            &folded_hay,
+            &needle,
+            ignore_case,
+            ignore_mark,
+        ))
     }
 
-    fn contains_value(hay: &str, needle: &Value, ignore_case: bool) -> Value {
+    fn contains_value(hay: &str, needle: &Value, ignore_case: bool, ignore_mark: bool) -> Value {
         match needle.view() {
             ValueView::Junction { kind, values } => {
                 let mapped = values
                     .iter()
-                    .map(|v| Self::contains_value(hay, v, ignore_case))
+                    .map(|v| Self::contains_value(hay, v, ignore_case, ignore_mark))
                     .collect::<Vec<_>>();
                 Value::junction(kind, mapped)
             }
             _ => {
-                let needle = needle.to_string_value();
-                let ok = if ignore_case {
-                    hay.to_lowercase().contains(&needle.to_lowercase())
-                } else {
-                    hay.contains(&needle)
-                };
+                let needle = fold_for_contains(&needle.to_string_value(), ignore_case, ignore_mark);
+                let ok = hay.contains(&needle);
                 Value::truth(ok)
             }
         }

--- a/t/contains-ignoremark.t
+++ b/t/contains-ignoremark.t
@@ -1,0 +1,22 @@
+use v6;
+use Test;
+
+# `Str.contains($needle, :ignoremark)` compares after stripping combining marks
+# (NFD, dropping combining code points); `:ignorecase` folds case. They combine.
+
+plan 10;
+
+is "abc".contains("ä"), False, "plain contains: a-with-diaeresis absent";
+is "abc".contains("ä", :ignoremark), True, ":ignoremark strips the needle's mark";
+is "äbc".contains("a", :ignoremark), True, ":ignoremark strips the haystack's mark";
+is "café".contains("cafe", :ignoremark), True, ":ignoremark over a full word";
+is "café".contains("cafx", :ignoremark), False, ":ignoremark still needs the rest to match";
+
+is "ABC".contains("b", :ignorecase), True, ":ignorecase folds case";
+is "ÀBC".contains("àb", :ignorecase, :ignoremark), True, ":ignorecase + :ignoremark combine";
+is "ÀBC".contains("àb", :ignoremark), False, ":ignoremark alone keeps case significant";
+
+is "abc".contains("x", :ignoremark), False, "absent needle stays False under :ignoremark";
+is "abc".contains("B", :i), True, ":i shorthand for :ignorecase";
+
+done-testing;


### PR DESCRIPTION
## What

`"abc".contains("ä", :ignoremark)` returned **False**. `.contains` folded `:m` /
`:ignoremark` into the same lowercase comparison as `:ignorecase`, which never
strips combining marks.

## Fix

- `dispatch_contains` now tracks `ignore_case` and `ignore_mark` separately and
  folds both the haystack and each needle through a shared `fold_for_contains`
  helper (NFD + drop combining marks for `:ignoremark`, lowercase for
  `:ignorecase`).
- The native fast path (`native_contains_with_options`) returns `None` for a
  truthy `:ignoremark` so the interpreter — which owns the NFD strip — handles
  it; `:ignorecase` stays native.

Now matches raku:

```
"abc".contains("ä", :ignoremark)                 # True
"café".contains("cafe", :ignoremark)             # True
"ÀBC".contains("àb", :ignorecase, :ignoremark)   # True
```

Surfaced by the doc-diff harness (PLAN §8.1) on `Type/Str.rakudoc`.

## Test

Pin `t/contains-ignoremark.t` (10 cases). `make test` green (2122 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)