### PR TITLE
fix: register comb as a builtin sub

### DIFF
--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -107,6 +107,7 @@ pub(crate) const BUILTIN_FUNCTION_NAMES: &[&str] = &[
     "substr",
     "substr-rw",
     "words",
+    "comb",
     "rand",
     "sprintf",
     "zprintf",

--- a/t/comb-sub-form.t
+++ b/t/comb-sub-form.t
@@ -1,0 +1,23 @@
+use v6;
+use Test;
+
+# `comb` has a sub form: `comb($matcher, $input, $limit?)` == `$input.comb($matcher, $limit)`.
+# Previously a bare `comb(...)` call aborted at compile time with
+# "Undeclared routine: comb".
+
+plan 8;
+
+is comb(/\w/, "a;b;c").raku, ("a", "b", "c").Seq.raku, "comb(regex, str)";
+is comb(/\N/, "a;b;c").raku, ("a", ";", "b", ";", "c").Seq.raku, "comb(regex, str) non-word";
+is comb(/\w/, "a;b;c", 2).raku, ("a", "b").Seq.raku, "comb(regex, str, limit)";
+is comb("a", "banana").raku, ("a", "a", "a").Seq.raku, "comb(str, str)";
+is comb(2, "abcdefg").raku, ("ab", "cd", "ef", "g").Seq.raku, "comb(size, str)";
+is comb(3, "abcdefghijk").raku, ("abc", "def", "ghi", "jk").Seq.raku, "comb(size, str) uneven";
+
+# The sub form returns a Seq, like the method.
+is comb(/\w/, "a;b;c").^name, "Seq", "comb sub returns a Seq";
+
+# Limit of 0 yields an empty Seq.
+is comb(/\w/, "a;b;c", 0).elems, 0, "comb with a 0 limit is empty";
+
+done-testing;


### PR DESCRIPTION
## What

`comb(/\w/, "a;b;c")` aborted at compile time with *Undeclared routine: comb*.

The sub-form delegation (`comb($matcher, $input, $limit?)` →
`$input.comb($matcher, $limit)`) already existed in the runtime fallback, but
`comb` was missing from `BUILTIN_FUNCTION_NAMES`, so the CHECK-time
undeclared-routine walker rejected the call before it could run.

## Fix

Add `comb` to `BUILTIN_FUNCTION_NAMES`. Now the sub form runs and returns a Seq,
matching the method:

```
comb(/\w/, "a;b;c")        # ("a", "b", "c").Seq
comb(/\w/, "a;b;c", 2)     # ("a", "b").Seq
comb("a", "banana")        # ("a", "a", "a").Seq
comb(2, "abcdefg")         # ("ab", "cd", "ef", "g").Seq
```

Surfaced by the doc-diff harness (PLAN §8.1) on `Type/Str.rakudoc`.

> Note: `comb(/.<(.)>/, ...)` still returns the full match rather than the
> `<( )>` capture region — a pre-existing bug shared with the `.comb` method
> (both use `regex_find_all`'s full-match spans), tracked separately.

## Test

Pin `t/comb-sub-form.t` (8 cases). `make test` green (2124 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)