### PR TITLE
fix: Capture .keys/.values/.kv/.pairs interleave positional and named parts

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -510,7 +510,16 @@ pub(super) fn dispatch(
                         }
                     }
                     ValueView::Pair(k, v) => format!("{} => {}", k, gist_item(v)),
-                    ValueView::ValuePair(k, v) => format!("{} => {}", gist_item(k), gist_item(v)),
+                    ValueView::ValuePair(k, v) => {
+                        // Parenthesize a Pair-valued key: `(red => 2) => apples`.
+                        let key = match k.view() {
+                            ValueView::Pair(..) | ValueView::ValuePair(..) => {
+                                format!("({})", gist_item(k))
+                            }
+                            _ => gist_item(k),
+                        };
+                        format!("{} => {}", key, gist_item(v))
+                    }
                     ValueView::Junction { kind, values } => {
                         let kind_str = match kind {
                             crate::value::JunctionKind::Any => "any",
@@ -627,7 +636,16 @@ pub(super) fn dispatch(
                         }
                     }
                     ValueView::Pair(k, v) => format!("{} => {}", k, gist_item(v)),
-                    ValueView::ValuePair(k, v) => format!("{} => {}", gist_item(k), gist_item(v)),
+                    ValueView::ValuePair(k, v) => {
+                        // Parenthesize a Pair-valued key: `(red => 2) => apples`.
+                        let key = match k.view() {
+                            ValueView::Pair(..) | ValueView::ValuePair(..) => {
+                                format!("({})", gist_item(k))
+                            }
+                            _ => gist_item(k),
+                        };
+                        format!("{} => {}", key, gist_item(v))
+                    }
                     ValueView::Junction { kind, values } => {
                         let kind_str = match kind {
                             crate::value::JunctionKind::Any => "any",
@@ -713,10 +731,18 @@ pub(super) fn dispatch(
             if method == "raku" || method == "perl" {
                 Some(Ok(Value::str(raku_value(target))))
             } else {
-                // gist: use " => " separator
+                // gist: use " => " separator. A Pair-valued key is parenthesized
+                // so the outer arrow is unambiguous (`(red => 2) => apples`),
+                // matching raku's gist and the `gist_value` fast path.
+                let key_gist = match k.view() {
+                    ValueView::Pair(..) | ValueView::ValuePair(..) => {
+                        format!("({})", runtime::gist_value(k))
+                    }
+                    _ => runtime::gist_value(k),
+                };
                 Some(Ok(Value::str(format!(
                     "{} => {}",
-                    runtime::gist_value(k),
+                    key_gist,
                     runtime::gist_value(v)
                 ))))
             }

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -727,17 +727,54 @@ fn dispatch_capture(
         }
         "list" => Some(Ok(Value::array(positional.to_vec()))),
         "elems" => Some(Ok(Value::int(positional.len() as i64))),
+        "Numeric" | "Int" => Some(Ok(Value::int(positional.len() as i64))),
         "is-lazy" => Some(Ok(Value::FALSE)),
-        "keys" => Some(Ok(Value::array(
-            named.keys().map(|k| Value::str(k.clone())).collect(),
-        ))),
-        "values" => Some(Ok(Value::array(named.values().cloned().collect()))),
-        "pairs" => Some(Ok(Value::array(
-            named
+        // Capture `.keys`/`.values`/`.kv`/`.pairs` interleave the positional
+        // part (indexed 0..n) with the named part (raku Capture semantics).
+        "keys" => {
+            let mut keys: Vec<Value> = (0..positional.len() as i64).map(Value::int).collect();
+            keys.extend(named.keys().map(|k| Value::str(k.clone())));
+            Some(Ok(Value::seq(keys)))
+        }
+        "values" => {
+            let mut vals = positional.to_vec();
+            vals.extend(named.values().cloned());
+            Some(Ok(Value::seq(vals)))
+        }
+        "kv" => {
+            let mut kv = Vec::with_capacity(positional.len() * 2 + named.len() * 2);
+            for (idx, v) in positional.iter().enumerate() {
+                kv.push(Value::int(idx as i64));
+                kv.push(v.clone());
+            }
+            for (k, v) in named.iter() {
+                kv.push(Value::str(k.clone()));
+                kv.push(v.clone());
+            }
+            Some(Ok(Value::seq(kv)))
+        }
+        "pairs" => {
+            let mut pairs: Vec<Value> = positional
                 .iter()
-                .map(|(k, v)| Value::pair(k.clone(), v.clone()))
-                .collect(),
-        ))),
+                .enumerate()
+                .map(|(idx, v)| Value::value_pair(Value::int(idx as i64), v.clone()))
+                .collect();
+            pairs.extend(named.iter().map(|(k, v)| Value::pair(k.clone(), v.clone())));
+            Some(Ok(Value::seq(pairs)))
+        }
+        "antipairs" => {
+            let mut pairs: Vec<Value> = positional
+                .iter()
+                .enumerate()
+                .map(|(idx, v)| Value::value_pair(v.clone(), Value::int(idx as i64)))
+                .collect();
+            pairs.extend(
+                named
+                    .iter()
+                    .map(|(k, v)| Value::value_pair(v.clone(), Value::str(k.clone()))),
+            );
+            Some(Ok(Value::seq(pairs)))
+        }
         "raku" | "perl" => {
             let mut parts = Vec::new();
             for v in positional {

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -49,6 +49,22 @@ fn starts_hyper_prefix_op(s: &str) -> bool {
     rest.starts_with('\u{00AB}') || rest.starts_with("<<")
 }
 
+/// A slip prefix (`|`) directly followed by a term-starting sigil/paren is an
+/// unambiguous argument start, so `unique |$x` / `min |@a` parse as a call with
+/// a flattened argument rather than reading `|` as the infix any-junction. The
+/// no-space requirement between `|` and the term disambiguates it from a spaced
+/// junction infix (`$a | $b`).
+fn starts_slip_prefix_arg(s: &str) -> bool {
+    let Some(rest) = s.strip_prefix('|') else {
+        return false;
+    };
+    // `||` is the short-circuit-or infix, never a slip.
+    matches!(
+        rest.as_bytes().first(),
+        Some(b'$') | Some(b'@') | Some(b'%') | Some(b'&') | Some(b'(')
+    ) || rest.starts_with("\\(")
+}
+
 /// When `do STMT` parses its inner statement via the full statement parser, a
 /// statement modifier (`do $_ for @list`) or assignment consumes the trailing
 /// `;`. In expression context the `;` belongs to the *outer* statement, so if it
@@ -1621,6 +1637,7 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
             // (A bare `+`/`-` is left out on purpose: `pi - 1` must stay a
             // subtraction, which needs term-vs-listop knowledge we lack here.)
             || starts_hyper_prefix_op(r)
+            || starts_slip_prefix_arg(r)
             || starts_with_term_keyword(r)
             // A quote construct (`q:to/END/`, `qw<>`, `Q/…/`, …) starts a term,
             // so `undeclared-sub q:to/END/` is a no-paren listop call.

--- a/src/runtime/utils/gist.rs
+++ b/src/runtime/utils/gist.rs
@@ -186,7 +186,17 @@ pub(crate) fn gist_value(value: &Value) -> String {
             setbagmix_gist(value).unwrap_or_else(|| value.to_string_value())
         }
         ValueView::Pair(k, v) => format!("{} => {}", k, gist_value(v)),
-        ValueView::ValuePair(k, v) => format!("{} => {}", gist_value(k), gist_value(v)),
+        ValueView::ValuePair(k, v) => {
+            // A Pair-valued key is parenthesized so the outer arrow is
+            // unambiguous: `(red => 2) => apples`, matching raku's gist.
+            let key_gist = match k.view() {
+                ValueView::Pair(..) | ValueView::ValuePair(..) => {
+                    format!("({})", gist_value(k))
+                }
+                _ => gist_value(k),
+            };
+            format!("{} => {}", key_gist, gist_value(v))
+        }
         ValueView::Seq(items)
         | ValueView::HyperSeq(items)
         | ValueView::RaceSeq(items)

--- a/t/capture-keys-values-pairs.t
+++ b/t/capture-keys-values-pairs.t
@@ -1,0 +1,35 @@
+use v6;
+use Test;
+
+# A Capture's introspection methods interleave the positional part (indexed
+# 0..n) with the named part (raku Capture semantics), rather than exposing only
+# the named arguments.
+
+my $c = \(2, 3, 5, apples => (red => 2));
+
+is $c.keys.raku,   '(0, 1, 2, "apples").Seq', '.keys = positional indices then named keys';
+is $c.values.raku, '(2, 3, 5, :red(2)).Seq',  '.values = positional then named values';
+is $c.kv.gist,     '(0 2 1 3 2 5 apples red => 2)', '.kv interleaves positional and named';
+is $c.pairs.gist,  '(0 => 2 1 => 3 2 => 5 apples => red => 2)', '.pairs = index/named pairs';
+is $c.antipairs.gist, '(2 => 0 3 => 1 5 => 2 (red => 2) => apples)',
+    '.antipairs swaps and parenthesizes a Pair-valued key';
+
+is \(1, 2, 3, apples => 2).Numeric, 3, '.Numeric = number of positional elements';
+is \(1, 2, 3, apples => 2).elems,   3, '.elems = number of positional elements';
+
+# A Pair-valued key is parenthesized in the gist so the outer arrow is clear.
+is ((red => 2) => "apples").gist, '(red => 2) => apples', 'Pair-as-key gist is parenthesized';
+is ("a" => 1).gist, 'a => 1', 'plain Str key is not parenthesized';
+
+# `|$capture` flattens the capture as a no-paren listop argument, even when a
+# trailing named argument follows.
+my $x = \(4, 2, 3, -2);
+is (unique |$x, as => {.abs}).gist, '(4 2 3)', 'unique |capture with trailing named arg';
+my $y = \(1, 7, 3, by => {1/$_});
+is (min |$y), 7, 'min |capture with named arg';
+is (max |$y), 1, 'max |capture with named arg';
+
+# A spaced `|` between two terms remains the any-junction infix.
+is (1 | 2).WHAT.^name, 'Junction', 'spaced | stays a junction infix';
+
+done-testing;


### PR DESCRIPTION
## Summary

A Capture's introspection methods (`.keys`, `.values`, `.kv`, `.pairs`, `.antipairs`) exposed only the **named** arguments, dropping the positional part. Raku interleaves the positional part (indexed `0..n`) with the named part.

Before / after (`\(2, 3, 5, apples => (red => 2))`):

| method | mutsu (before) | raku / mutsu (after) |
|---|---|---|
| `.keys` | `(apples)` | `(0 1 2 apples)` |
| `.values` | `(red => 2)` | `(2 3 5 red => 2)` |
| `.kv` | garbage | `(0 2 1 3 2 5 apples red => 2)` |
| `.pairs` | `(apples => red => 2)` | `(0 => 2 1 => 3 2 => 5 apples => red => 2)` |
| `.Numeric` | X::Method::NotFound | `3` |

## Changes

- `dispatch_capture` (methods_0arg/mod.rs) yields positional indices then named keys/values, adds `.kv`, `.antipairs`, `.Numeric`/`.Int` (positional count).
- A **Pair-valued key** now renders parenthesized in every gist path (`gist_value`, the `.gist` method, and the two collection `gist_item` closures): `(red => 2) => apples`, matching raku.
- The no-paren listop-arg gate recognizes a slip prefix `|\$x`/`|@a`/`|(...)` as an unambiguous term start (`starts_slip_prefix_arg`), so `unique |\$x, as => {.abs}` parses as a call; a spaced `|` stays the any-junction infix.

## Tests

Pin `t/capture-keys-values-pairs.t`. From the doc-diff `Type/Capture.rakudoc` sweep — all 14 raku-clean examples now match reference raku (was 7/14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)