### PR TITLE
fix: preserve a container's is-default across whole-container reassignment

### DIFF
--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1041,6 +1041,24 @@ impl Interpreter {
         if !is_bind && !is_constant && (name.starts_with('@') || name.starts_with('%')) {
             val = self.coerce_typed_container_assignment(name, val, has_explicit_initializer)?;
         }
+        // Raku `@array = ...` / `%hash = ...` assigns INTO the existing container,
+        // so its `is default(...)` element default survives the reassignment
+        // (`my @a is default('N/A'); @a = Nil; @a[4]` still reads 'N/A'). The
+        // freshly-built container carries no default of its own, and the Nil /
+        // hole rebuilds above discard any grafted onto an intermediate value, so
+        // regraft here — after all coercion/rebuilding — from the old container
+        // (or the variable's registered default).
+        if !is_bind
+            && !is_vardecl
+            && !is_constant
+            && (name.starts_with('@') || name.starts_with('%'))
+            && self.container_default(&val).is_none()
+            && let Some(def) = self
+                .container_default(&self.locals[idx])
+                .or_else(|| self.var_default(name).cloned())
+        {
+            val = self.tag_container_default(val, def);
+        }
         if let Some(constraint) = loan_env!(self, var_type_constraint(name))
             && !name.starts_with('%')
             && !name.starts_with('@')

--- a/t/container-default-survives-reassign.t
+++ b/t/container-default-survives-reassign.t
@@ -1,0 +1,35 @@
+use Test;
+
+plan 8;
+
+# A container's `is default(...)` element default is a property of the
+# container bound to the variable. Raku `@array = ...` / `%hash = ...` assigns
+# INTO that container, so the default survives the reassignment — including a
+# `= Nil` reset (which clears the elements but keeps the container). Previously
+# mutsu replaced the container with a fresh one on reassignment and lost the
+# default, so a later out-of-range read returned Any instead of the default.
+
+my @array is default( 'N/A' );
+is @array[22], 'N/A', 'array default before any assignment';
+
+@array = Nil;
+is @array.raku, '["N/A"]', '= Nil resets the array (element takes the default)';
+is @array[4], 'N/A', 'array default survives = Nil';
+
+@array = 1, 2;
+is @array[10], 'N/A', 'array default survives = LIST';
+
+@array = ();
+is @array[10], 'N/A', 'array default survives = ()';
+
+my %hash is default( 'no-value-here' );
+%hash<foo> = 'bar';
+is %hash<wrong-key>, 'no-value-here', 'hash default before reassignment';
+
+%hash = (a => 1);
+is %hash<missing>, 'no-value-here', 'hash default survives = LIST';
+
+# A container with no declared default is unaffected (out-of-range reads Any).
+my @plain = 1, 2, 3;
+@plain = 4, 5;
+is @plain[9].raku, 'Any', 'no default declared -> out-of-range reads Any';


### PR DESCRIPTION
A container's `is default(...)` element default belongs to the container bound to the variable. Raku `@array = ...` / `%hash = ...` assigns INTO that container, so the default survives the reassignment — including a `= Nil` reset that clears the elements but keeps the container.

mutsu built a fresh container for the RHS and installed it, dropping the old default; a `= Nil` reassignment additionally rebuilds the array during Nil-hole replacement, discarding any default grafted onto an intermediate value. Regraft the default (from the old container, or the variable's registered default) after all coercion/rebuilding.

```
my @array is default('N/A');
@array = Nil;
say @array[4];   # was (Any), now N/A (matches raku)
```

Fixes the `Type/Variable.rakudoc` `is default` example (doc-diff backlog). Pin: `t/container-default-survives-reassign.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)