### PR TITLE
fix: parse space-separated sigil-shorthand colonpairs in parens

### DIFF
--- a/src/parser/primary/container/paren.rs
+++ b/src/parser/primary/container/paren.rs
@@ -211,20 +211,6 @@ fn paren_expr_inner(input: &str) -> PResult<'_, Expr> {
     if let Some(seq) = try_parse_sequence_in_paren(input, std::slice::from_ref(&first)) {
         return seq;
     }
-    // Chained colonpairs in parens: (:a(2) :b(3) :c(4)) → list of pairs.
-    // In Raku, space-separated colonpairs inside parentheses form a list without commas.
-    if is_colonpair_expr(&first) && looks_like_colonpair_start(input) {
-        let mut items = vec![first];
-        let mut rest = input;
-        while looks_like_colonpair_start(rest) {
-            let (r, pair) = crate::parser::primary::misc::colonpair_expr(rest)?;
-            items.push(pair);
-            let (r, _) = ws(r)?;
-            rest = r;
-        }
-        let (rest, _) = parse_char(rest, ')')?;
-        return Ok((rest, finalize_paren_list(items)));
-    }
     let before_close = input;
     if let Ok((input, _)) = parse_char(input, ')') {
         // Parenthesized pair: (:a(3)) — mark as positional so it's not treated
@@ -329,15 +315,7 @@ fn paren_expr_inner(input: &str) -> PResult<'_, Expr> {
     }
     // Comma-separated list with sequence operator detection
     // Use expression_no_sequence so that `...` is not consumed as part of an item
-    let sep = if input.starts_with(',') {
-        ','
-    } else if input.starts_with(';') && !input.starts_with(";;") {
-        ';'
-    } else {
-        return Err(PError::expected("',' or ';' in parenthesized list"));
-    };
-    let (input, _) = parse_char(input, sep)?;
-    let (input, _) = ws(input)?;
+    //
     // A top-level `;` inside `(...)` separates the list into "sections", one per
     // semicolon-group: `(1,2;3,4)` is `((1,2),(3,4))`, not the flat `(1,2,3,4)`.
     // `items` accumulates the CURRENT section; completed sections move into
@@ -345,29 +323,18 @@ fn paren_expr_inner(input: &str) -> PResult<'_, Expr> {
     let mut sections: Vec<Vec<Expr>> = Vec::new();
     let mut items = vec![first];
     let mut saw_semicolon = false;
-    if sep == ';' {
-        saw_semicolon = true;
-        sections.push(std::mem::take(&mut items));
-    }
-    if !saw_semicolon
-        && let Some(result) = try_inline_modifier(input, finalize_paren_list(items.clone()))
-    {
-        let (rest, modified_expr) = result?;
-        let (rest, _) = ws(rest)?;
-        let (rest, _) = parse_char(rest, ')')?;
-        return Ok((rest, modified_expr));
-    }
-    // Handle trailing comma/semicolon before close paren
-    if let Ok((input, _)) = parse_char(input, ')') {
-        return Ok((
-            input,
-            finalize_paren_sections(sections, items, saw_semicolon),
-        ));
-    }
-    let (mut input_rest, second) = expression_no_sequence(input)?;
-    items.push(second);
+    let mut input_rest = input;
     loop {
         let (input, _) = ws(input_rest)?;
+        // Space-separated colonpairs form a list without commas: (:$a :$b),
+        // (:a(1) :b(2) :c(3)). A colonpair immediately followed by another
+        // colonpair (no separating comma) continues the current list.
+        if items.last().is_some_and(is_colonpair_expr) && looks_like_colonpair_start(input) {
+            let (r, pair) = crate::parser::primary::misc::colonpair_expr(input)?;
+            items.push(pair);
+            input_rest = r;
+            continue;
+        }
         if let Ok((input, _)) = parse_char(input, ')') {
             return Ok((
                 input,
@@ -474,6 +441,9 @@ fn looks_like_colonpair_start(input: &str) -> bool {
     if digit_end > 0 && r[digit_end..].starts_with('<') {
         return false;
     }
-    // Must start with identifier char or `!` (negated colonpair)
-    r.starts_with(|c: char| c.is_alphabetic() || c == '_' || c == '!')
+    // Must start with an identifier char, `!` (negated colonpair), or a sigil
+    // (`:$var`/`:@var`/`:%var`/`:&var` shorthand colonpair).
+    r.starts_with(|c: char| {
+        c.is_alphabetic() || c == '_' || c == '!' || c == '$' || c == '@' || c == '%' || c == '&'
+    })
 }

--- a/t/paren-adjacent-colonpairs.t
+++ b/t/paren-adjacent-colonpairs.t
@@ -1,0 +1,43 @@
+use Test;
+
+# Space-separated colonpairs inside parentheses form a list without commas.
+# The `:$var` sigil-shorthand form must be recognized as an adjacent colonpair
+# just like the explicit `:name(...)` form (WebService::Nominatim regression).
+
+plan 9;
+
+my $a = 1;
+my $b = 2;
+my $c = 3;
+
+# Pure adjacency with sigil shorthand.
+is (:$a :$b).raku, '(:a(1), :b(2))', 'adjacent :$a :$b';
+
+# Comma then adjacency.
+is (:$a, :$b :$c).raku, '(:a(1), :b(2), :c(3))', 'comma then adjacent';
+
+# Adjacency then comma.
+is (:$a :$b, :$c).raku, '(:a(1), :b(2), :c(3))', 'adjacent then comma';
+
+# Mixed sigil-shorthand and explicit-paren forms.
+is (:a(1) :$b).raku, '(:a(1), :b(2))', 'paren-form then sigil-shorthand';
+is (:$a :b(2)).raku, '(:a(1), :b(2))', 'sigil-shorthand then paren-form';
+
+# Array / hash / callable sigils.
+my @arr = 1, 2;
+my %hsh;
+is (:@arr :%hsh).raku, '(:arr([1, 2]), :hsh({}))', 'array and hash sigils';
+
+# Assigned into a hash — the WebService::Nominatim %query pattern.
+my %q = (
+    :$a,
+    :$b
+    :$c,
+);
+is %q.keys.sort.join(','), 'a,b,c', 'colonpairs into hash with mixed commas';
+
+# Explicit-paren colonpairs still work (no regression).
+is (:x(1) :y(2)).raku, '(:x(1), :y(2))', 'explicit paren colonpairs';
+
+# Plain comma list is unaffected.
+is (1, 2, 3).raku, '(1, 2, 3)', 'plain comma list unaffected';


### PR DESCRIPTION
## Summary

Space-separated colonpairs inside parentheses form a list without commas
(`(:a(1) :b(2))`), but the sigil-shorthand form `:\$var`/`:@var`/`:%var`/`:&var`
was **not** recognized as an adjacent colonpair. `looks_like_colonpair_start`
only accepted an identifier char or `!` after the `:`, not a sigil, so:

- `(:\$a :\$b)` failed to parse, and
- more importantly a hash literal mixing commas and adjacency
  (`(:\$a, :\$b :\$c)`) failed with `expected right-hand expression after '='`.

## Fix

- Accept `\$`/`@`/`%`/`&` after the `:` in `looks_like_colonpair_start`.
- Unify the parenthesized-list parser so an adjacent colonpair acts as an
  implicit separator **anywhere** in the list, not only immediately after the
  first element. This drops the separate chained-colonpair fast path and
  handles the mixed comma/adjacency cases uniformly.

## Impact

Unblocks `WebService::Nominatim` parse — its `%query` hash literal has a
`:\$format` with no trailing comma before `:\$addressdetails`. mutsu now reaches
the same missing-dependency state (`HTTP::Tiny`) as raku instead of a parse
error.

Pin: `t/paren-adjacent-colonpairs.t` (9 subtests, output matches raku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)