### PR TITLE
fix: IO::Path .raku SPEC, '.'.parent, and unlink list/soft-fail semantics

### DIFF
--- a/src/parser/primary/ident/predicates.rs
+++ b/src/parser/primary/ident/predicates.rs
@@ -224,6 +224,7 @@ pub(crate) fn is_listop(name: &str) -> bool {
             | "gmtime"
             | "times"
             | "undefine"
+            | "unlink"
     ) || is_expr_listop(name)
 }
 

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -346,25 +346,32 @@ impl Interpreter {
     }
 
     pub(super) fn builtin_unlink(&self, args: &[Value]) -> Result<Value, RuntimeError> {
-        // Raku's unlink() returns a list of filenames that were requested to be
-        // removed (always truthy). Errors other than NotFound still throw.
+        // Raku's `unlink` sub returns an Array of the paths it successfully
+        // removed. A path that did not exist is deemed a success (included); a
+        // path whose removal failed for another reason (e.g. it is a directory)
+        // is silently dropped from the result, and the sub never throws. (The
+        // `.unlink` method form fails softly instead — handled separately.)
         let mut names = Vec::new();
-        for arg in args {
+        // `unlink <a b c>` passes a single list argument; flatten so each path
+        // is removed individually rather than stringifying the whole list.
+        let paths: Vec<Value> = args
+            .iter()
+            .flat_map(crate::runtime::utils::value_to_list)
+            .collect();
+        for arg in &paths {
             let path = arg.to_string_value();
             let resolved = self.resolve_path(&path);
             match fs::remove_file(&resolved) {
-                Ok(()) => {}
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-                Err(err) => {
-                    return Err(RuntimeError::new(format!(
-                        "Failed to unlink '{}': {}",
-                        path, err
-                    )));
+                Ok(()) => names.push(Value::str_arc(path.into())),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    names.push(Value::str_arc(path.into()))
                 }
+                Err(_) => {}
             }
-            names.push(Value::str_arc(path.into()));
         }
-        Ok(Value::array(names))
+        // `unlink` returns an `Array` (not a List), so `say unlink <...>` gists
+        // as `[...]` and `.WHAT` is `Array`.
+        Ok(Value::real_array(names))
     }
 
     pub(super) fn builtin_open(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {

--- a/src/runtime/native_io/io_path_lexical.rs
+++ b/src/runtime/native_io/io_path_lexical.rs
@@ -131,7 +131,10 @@ impl Interpreter {
                     p.clone()
                 };
                 for _ in 0..levels {
-                    if path == "." {
+                    // A bare current-directory path — with or without a trailing
+                    // separator (`.`, `./`, `.\`) — has `..` as its parent, like
+                    // raku (`'./'.IO.parent` is `".."`).
+                    if path == "." || path == "./" || path == ".\\" {
                         path = "..".to_string();
                         continue;
                     }

--- a/src/runtime/native_io/io_path_mutate.rs
+++ b/src/runtime/native_io/io_path_mutate.rs
@@ -160,13 +160,38 @@ impl Interpreter {
                     ))
                 }
             },
+            // Per raku, `.unlink` returns True on success, False when the file did
+            // not exist, and fails softly (a Failure carrying X::IO::Unlink) for
+            // any other error (e.g. the path is a directory) so `without`/`try`
+            // can handle it rather than the method throwing.
             "unlink" => match fs::remove_file(&path_buf) {
                 Ok(()) => Ok(Value::TRUE),
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Value::FALSE),
-                Err(err) => Err(RuntimeError::new(format!(
-                    "Failed to unlink '{}': {}",
-                    p, err
-                ))),
+                Err(err) => {
+                    // Rakudo reports libuv's wording for a directory target
+                    // ("illegal operation on a directory"); use it for the
+                    // EISDIR case and fall back to the OS message otherwise.
+                    let reason = if err.raw_os_error() == Some(21) {
+                        "illegal operation on a directory".to_string()
+                    } else {
+                        err.to_string()
+                    };
+                    let msg = format!(
+                        "Failed to remove the file '{}': Failed to delete file: {}",
+                        Self::stringify_path(&path_buf),
+                        reason
+                    );
+                    let mut ex_attrs = HashMap::new();
+                    ex_attrs.insert("message".to_string(), Value::str_from(&msg));
+                    ex_attrs.insert("path".to_string(), Value::str_from(&p));
+                    let ex = Value::make_instance(Symbol::intern("X::IO::Unlink"), ex_attrs);
+                    let mut failure_attrs = HashMap::new();
+                    failure_attrs.insert("exception".to_string(), ex);
+                    Ok(Value::make_instance(
+                        Symbol::intern("Failure"),
+                        failure_attrs,
+                    ))
+                }
             },
             "chmod" => {
                 let mode_value = args

--- a/src/runtime/native_io/native_io_path.rs
+++ b/src/runtime/native_io/native_io_path.rs
@@ -113,10 +113,20 @@ impl Interpreter {
                 // (class_name is part of Instance equality). An explicitly
                 // subclassed instance (`IO::Path::Win32.new(...)`) already has
                 // that name as its `class_name`, so this is a no-op for it.
+                // A plain `IO::Path` renders its `:SPEC` explicitly
+                // (`IO::Spec::Unix` on POSIX); a SPEC-variant subclass
+                // (`IO::Path::Win32`) omits it — the subclass already implies
+                // its spec, matching Rakudo's `.raku`.
+                let spec = if class_name == "IO::Path" {
+                    ":SPEC(IO::Spec::Unix), "
+                } else {
+                    ""
+                };
                 Ok(Value::str(format!(
-                    "{}.new(\"{}\", :CWD(\"{}\"))",
+                    "{}.new(\"{}\", {}:CWD(\"{}\"))",
                     class_name,
                     escape(&p),
+                    spec,
                     escape(&cwd)
                 )))
             }

--- a/t/io-path-raku-parent-unlink.t
+++ b/t/io-path-raku-parent-unlink.t
@@ -1,0 +1,43 @@
+use v6;
+use Test;
+
+# IO::Path.raku renders its SPEC explicitly for a plain IO::Path.
+like "foo/bar".IO.raku,
+    /^ 'IO::Path.new("foo/bar", :SPEC(IO::Spec::Unix), :CWD(' /,
+    'IO::Path.raku includes :SPEC(IO::Spec::Unix)';
+
+# A bare current-directory path has `..` as its parent, with or without a
+# trailing separator.
+is "./".IO.parent.Str,  "..", "'./'.IO.parent is '..'";
+is ".".IO.parent.Str,   "..", "'.'.IO.parent is '..'";
+is "foo".IO.parent.Str, ".",  "'foo'.IO.parent is '.'";
+is "/etc/foo".IO.parent.Str, "/etc", "'/etc/foo'.IO.parent is '/etc'";
+is "/".IO.parent.Str,   "/",   "'/'.IO.parent is '/'";
+
+# `unlink` as a no-paren listop accepts a word-quote argument, returns an Array
+# of the paths it removed (a non-existent path counts as removed), and silently
+# drops a path it could not remove (e.g. a directory).
+my $dir = $*TMPDIR.add("mutsu-unlink-test-{$*PID}");
+$dir.mkdir;
+my $f = $dir.add("f.txt");
+$f.spurt("x");
+my $sub = $dir.add("subdir");
+$sub.mkdir;
+
+my @removed = unlink $f.Str, $sub.Str, $dir.add("nope.txt").Str;
+is @removed.WHAT.^name, 'Array', 'unlink returns an Array';
+is @removed.elems, 2, 'unlink drops the directory, keeps file + non-existent';
+ok $f.Str (elem) @removed.Set, 'removed file is listed';
+nok $f.e, 'the file was actually removed';
+
+# The `.unlink` method fails softly (Failure) on a directory rather than throwing.
+my $result = $sub.unlink;
+ok $result ~~ Failure, '.unlink on a directory returns a Failure';
+like $result.exception.message,
+    /'Failed to remove the file' .* 'illegal operation on a directory'/,
+    '.unlink failure message matches raku wording';
+
+$sub.rmdir;
+$dir.rmdir;
+
+done-testing;


### PR DESCRIPTION
## Summary

From the doc-diff `Type/IO/Path.rakudoc` sweep. Fixes several divergences from reference raku:

- **`IO::Path.raku`** renders `:SPEC(IO::Spec::Unix)` explicitly for a plain `IO::Path`. A SPEC-variant subclass (`IO::Path::Win32`) omits it, matching Rakudo.
  - `"foo/bar".IO.raku` → `IO::Path.new("foo/bar", :SPEC(IO::Spec::Unix), :CWD("..."))`
- **`'./'.IO.parent`** (and `.`/`.\` current-directory forms with a trailing separator) yields `..`, like raku, not `.`.
- **`unlink` is now a no-paren listop**, so `unlink <a b c>` parses (word-quote argument) instead of reading `<` as a chained comparison.
- **`unlink` sub** flattens list arguments, returns an `Array` (`say unlink <...>` → `[...]`, `.WHAT` is `Array`), counts a non-existent path as removed, and silently drops a path it could not remove (e.g. a directory) without throwing.
- **`.unlink` method** fails softly (Failure carrying `X::IO::Unlink`) on a non-NotFound error instead of throwing, with the Rakudo message wording (`Failed to remove the file '...': Failed to delete file: illegal operation on a directory`), so `without`/`try` handle it.

Remaining `IO/Path.rakudoc` divergences are Win32-specific path handling (`IO::Path::Win32` basename/parts/normalization) or environment/filesystem-dependent (`~~ :rw`, directory-listing examples) — left as a separate niche cluster.

## Tests

Pin `t/io-path-raku-parent-unlink.t`. Verified no regressions across the local IO suite and whitelisted IO::Path/unlink roast tests (`io-path.t`, `io-path-unix.t`, `io-path-subclasses.t`, `io-path-win.t`, `io-path-cygwin.t`, `S16-filehandles/unlink.t`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)