### PR TITLE
fix: parse constant term:<NAME> operator-name declarations

### DIFF
--- a/src/parser/stmt/decl/constant_subset.rs
+++ b/src/parser/stmt/decl/constant_subset.rs
@@ -38,6 +38,19 @@ pub(in crate::parser::stmt) fn constant_decl(input: &str) -> PResult<'_, Stmt> {
         let name = format!("{prefix}{n}");
         register_term_symbol_from_decl_name(&name);
         (r, name)
+    } else if rest.starts_with("term:<") || rest.starts_with("term:\u{ab}") {
+        // `constant term:<♥> = "♥"` defines a term named `♥`, resolvable as a
+        // bareword. Parse the operator name (`term:<♥>`) and use its inner
+        // symbol (`♥`) as the constant's name, exactly as `constant ♥ = ...`
+        // would if `♥` were a legal identifier.
+        let (r, full) = parse_sigilless_decl_name(rest)?;
+        let inner = full
+            .strip_prefix("term:<")
+            .and_then(|s| s.strip_suffix('>'))
+            .unwrap_or(&full)
+            .to_string();
+        register_term_symbol_from_decl_name(&inner);
+        (r, inner)
     } else {
         let (r, n) = ident(rest)?;
         register_term_symbol_from_decl_name(&n);

--- a/t/constant-term-operator-name.t
+++ b/t/constant-term-operator-name.t
@@ -1,0 +1,22 @@
+use Test;
+
+plan 4;
+
+# `constant term:<NAME> = value` defines a term named NAME, resolvable as a
+# bareword — exactly as `constant NAME = value` would if NAME were a legal
+# identifier. Previously mutsu parsed only the `term` head and failed to find
+# the initializer ("Missing initializer on constant declaration").
+
+constant term:<X> = 'heart';
+is X, 'heart', 'constant term:<X> defines a bareword term';
+
+constant term:<♥> = '♥';
+is ♥, '♥', 'constant term:<...> works with a non-ASCII symbol';
+
+# Guillemet delimiters are equivalent to angle brackets.
+constant term:«Y» = 42;
+is Y, 42, 'constant term:«Y» (guillemets) defines a term';
+
+# The value keeps its type.
+constant term:<PI> = 3.14;
+is PI.WHAT.^name, 'Rat', 'constant term keeps the value type';


### PR DESCRIPTION
`constant term:<NAME> = value` defines a term named NAME, resolvable as a bareword. mutsu parsed only the `term` head with `ident()` and left `:<NAME>` unconsumed, so it never found the `=` initializer and died with 'Missing initializer on constant declaration'.

Route the operator-category form through the sub-name parser and use the inner symbol as the constant's name (registering it as a term). Handles angle-bracket and guillemet delimiters and non-ASCII symbols.

```
constant term:<♥> = '♥';
say ♥;   # ♥  (was: Missing initializer on constant declaration)
```

From the `Language/optut.rakudoc` doc-diff example. Pin: `t/constant-term-operator-name.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)