### PR TITLE
fix: Test isa-ok/can-ok/does-ok default messages and todo `is` diagnostics

### DIFF
--- a/src/runtime/call_helpers.rs
+++ b/src/runtime/call_helpers.rs
@@ -64,6 +64,21 @@ impl Interpreter {
         desc: &str,
         todo: bool,
     ) -> Result<(), RuntimeError> {
+        self.test_ok_with_diag(success, desc, todo, &[])
+    }
+
+    /// Like [`test_ok`](Self::test_ok) but appends extra `#`-prefixed diagnostic
+    /// lines (e.g. `# expected: '4'` / `#      got: '3'`) to the failure block so
+    /// they are routed the same way as `# Failed test` — to stdout for a TODO
+    /// test (a TAP comment) and to stderr otherwise. Callers pass each line
+    /// already `#`-prefixed and without a trailing newline.
+    pub(crate) fn test_ok_with_diag(
+        &mut self,
+        success: bool,
+        desc: &str,
+        todo: bool,
+        detail: &[String],
+    ) -> Result<(), RuntimeError> {
         let mut line = String::new();
         let (record_failure, effective_todo) = {
             let state = self.tap.ensure_state();
@@ -119,7 +134,7 @@ impl Interpreter {
         self.emit_output(&line);
         if record_failure {
             let to_stderr = !effective_todo && self.tap.subtest_depth() == 0;
-            self.emit_test_failure_diag(desc, to_stderr);
+            self.emit_test_failure_diag(desc, to_stderr, detail);
             if !effective_todo
                 && self.tap.subtest_depth() == 0
                 && self.raku_test_die_on_fail_enabled()
@@ -154,7 +169,7 @@ impl Interpreter {
         ));
     }
 
-    fn emit_test_failure_diag(&mut self, desc: &str, to_stderr: bool) {
+    fn emit_test_failure_diag(&mut self, desc: &str, to_stderr: bool, detail: &[String]) {
         let line_no = self.current_test_failure_line();
         let at_line = if let Some(path) = &self.program_path {
             format!("at {} line {}", path, line_no)
@@ -174,6 +189,9 @@ impl Interpreter {
         } else {
             emit(format!("# Failed test '{}'\n", desc));
             emit(format!("# {}\n", at_line));
+        }
+        for line in detail {
+            emit(format!("{}\n", line));
         }
     }
 

--- a/src/runtime/test_functions/basic.rs
+++ b/src/runtime/test_functions/basic.rs
@@ -84,8 +84,9 @@ impl Interpreter {
             }
             _ => false,
         };
-        self.test_ok(ok, &desc, todo)?;
-        if !ok {
+        let detail = if ok {
+            Vec::new()
+        } else {
             let got = left
                 .as_ref()
                 .map(|v| self.value_for_diag(v))
@@ -94,10 +95,14 @@ impl Interpreter {
                 .as_ref()
                 .map(|v| self.value_for_diag(v))
                 .unwrap_or_default();
-            self.output_sink_mut()
-                .stderr_output
-                .push_str(&format!("expected: {}\n     got: {}\n", expected, got));
-        }
+            // Match raku's diagnostic: `#`-prefixed and single-quoted, routed
+            // with the `# Failed test` block (stdout for a TODO test, else stderr).
+            vec![
+                format!("# expected: '{}'", expected),
+                format!("#      got: '{}'", got),
+            ]
+        };
+        self.test_ok_with_diag(ok, &desc, todo, &detail)?;
         Ok(Value::truth(ok))
     }
 

--- a/src/runtime/test_functions/eval_exception.rs
+++ b/src/runtime/test_functions/eval_exception.rs
@@ -192,11 +192,18 @@ impl Interpreter {
             },
             None => String::new(),
         };
+        // The default description renders the expected type via its `.raku`: a
+        // type object is its bare name (`Int`), but a Str type-name is quoted
+        // (`isa-ok $x, 'Womble'` => «is-a '"Womble"'»), matching raku.
+        let type_display = match positionals.get(1).map(|v| v.view()) {
+            Some(ValueView::Str(s)) => format!("\"{}\"", s.as_str()),
+            _ => type_name.clone(),
+        };
         let desc = positionals
             .get(2)
             .map(|v| v.to_string_value())
             .filter(|s| !s.is_empty())
-            .unwrap_or_else(|| format!("The object is-a '{}'", type_name));
+            .unwrap_or_else(|| format!("The object is-a '{}'", type_display));
         (value, type_name, desc)
     }
 
@@ -519,7 +526,7 @@ impl Interpreter {
         let desc = {
             let explicit = Self::positional_string(args, 2);
             if explicit.is_empty() {
-                format!("The object does '{}'", role_name)
+                format!("The object does role '{}'", role_name)
             } else {
                 explicit
             }
@@ -538,7 +545,11 @@ impl Interpreter {
         let desc = {
             let explicit = Self::positional_string(args, 2);
             if explicit.is_empty() {
-                format!("The object can '{}'", method_name)
+                let obj_type = crate::value::types::what_type_name(&value);
+                format!(
+                    "An object of type '{}' can do the method '{}'",
+                    obj_type, method_name
+                )
             } else {
                 explicit
             }

--- a/t/test-default-descriptions.t
+++ b/t/test-default-descriptions.t
@@ -12,8 +12,8 @@ plan 6;
 
 {
     my %r = get_out('use Test; plan 2; does-ok 42, Int; can-ok 42, "Str";');
-    ok %r<out>.contains("ok 1 - The object does 'Int'"), 'does-ok default description is emitted';
-    ok %r<out>.contains("ok 2 - The object can 'Str'"), 'can-ok default description is emitted';
+    ok %r<out>.contains("ok 1 - The object does role 'Int'"), 'does-ok default description is emitted';
+    ok %r<out>.contains("ok 2 - An object of type 'Int' can do the method 'Str'"), 'can-ok default description is emitted';
 }
 
 {

--- a/t/test-isa-can-does-messages.t
+++ b/t/test-isa-can-does-messages.t
@@ -1,0 +1,46 @@
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test;
+use Test::Util;
+
+plan 8;
+
+# isa-ok default description renders the expected type via its .raku: a type
+# object is its bare name, but a Str type-name is quoted.
+{
+    my %r = get_out('use Test; plan 2; isa-ok 42, Int; isa-ok 42, "Int";');
+    ok %r<out>.contains("ok 1 - The object is-a 'Int'"),
+        'isa-ok with a type object uses the bare name';
+    ok %r<out>.contains(qq{ok 2 - The object is-a '"Int"'}),
+        'isa-ok with a Str type-name quotes it';
+}
+
+# can-ok default description names the object type and the method.
+{
+    my %r = get_out('use Test; plan 1; class Womble { method m {...} }; can-ok Womble.new, "m";');
+    ok %r<out>.contains("ok 1 - An object of type 'Womble' can do the method 'm'"),
+        'can-ok default description';
+}
+
+# does-ok default description says "does role".
+{
+    my %r = get_out('use Test; plan 1; role R {}; class C does R {}; does-ok C.new, R;');
+    ok %r<out>.contains("ok 1 - The object does role 'R'"),
+        'does-ok default description';
+}
+
+# A failing `is` under `todo` emits the expected/got diagnostic as `#`-prefixed
+# TAP comments on stdout (routed with the `# Failed test` block), matching raku.
+{
+    my %r = get_out('use Test; plan 1; todo "later"; is 3, 4, "cmp";');
+    ok %r<out>.contains("not ok 1 - cmp # TODO later"), 'todo failure TAP line';
+    ok %r<out>.contains("# expected: '4'"), 'todo failure emits # expected on stdout';
+    ok %r<out>.contains("#      got: '3'"), 'todo failure emits # got on stdout';
+}
+
+# A non-todo `is` failure keeps its diagnostic off stdout (it goes to stderr).
+{
+    my %r = get_out('use Test; plan 1; is 3, 4, "cmp";');
+    nok %r<out>.contains("# expected:"), 'non-todo failure diagnostic is not on stdout';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

From the doc-diff `Type/Test.rakudoc` sweep. Aligns four Test-module output details with reference raku:

- **`isa-ok $x, T`** default description renders the expected type via its `.raku`: a type object stays its bare name (`is-a 'Int'`), but a **Str** type-name is quoted — `isa-ok $x, 'Womble'` → «is-a `'"Womble"'`».
- **`can-ok`** default description → «An object of type 'Womble' can do the method 'collect-rubbish'» (names the object's type and the method), was «The object can '…'».
- **`does-ok`** default description → «The object does role 'Invent'», was «The object does '…'».
- **A failing `is` under `todo`** now emits its `# expected:`/`#      got:` diagnostic as `#`-prefixed, single-quoted TAP comments routed **with** the `# Failed test` block — to stdout for a TODO test, to stderr otherwise — matching raku. Previously the expected/got line went to stderr unconditionally without a `#` prefix or quotes, so a TODO failure's diagnostic never reached stdout. Added `test_ok_with_diag` (`test_ok` now delegates to it) so the detail lines share the failure-diagnostic routing.

Remaining `Test.rakudoc` divergences are deeper: `.isa(role)` should be False (role-vs-class MRO distinction, allomorph-sensitive), `throws-like`'s `message => /re/` adverb subtest, and a combined negated char class `<.-:letter-:digit>` regex bug.

## Tests

Updated `t/test-default-descriptions.t` to the raku-compliant messages (per the "roast is authoritative" rule — the old assertions encoded mutsu's non-compliant wording). Pin `t/test-isa-can-does-messages.t`. Full local `t/` suite (2131 files) and roast S24-testing (`1-basic`, `2-force_todo`, `12-subtest-todo`, `13-cmp-ok`, `line-numbers`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)