### PR TITLE
fix: parse ::?CLASS / ::?ROLE as a method return type

### DIFF
--- a/src/parser/stmt/sub/traits.rs
+++ b/src/parser/stmt/sub/traits.rs
@@ -4,6 +4,21 @@ use super::*;
 /// parenthesized source: `Str`, `Str()`, `Int(Str)`. Without this, `returns Str()`
 /// stopped at the `(` and the trailing `()` was left to be parsed as a sub body.
 fn parse_trait_type_name(input: &str) -> PResult<'_, String> {
+    // `::?CLASS` / `::?ROLE` pseudo-types (the current class/role) may appear as a
+    // return type (`method m() of ::?CLASS`). The generic identifier scan below
+    // stops at `?`, leaving a stray `?CLASS`, so handle them up front. An optional
+    // definedness smiley (`::?CLASS:D`) is folded in.
+    for pseudo in ["::?CLASS", "::?ROLE"] {
+        if let Some(after) = input.strip_prefix(pseudo) {
+            let (rest, name) =
+                if after.starts_with(":D") || after.starts_with(":U") || after.starts_with(":_") {
+                    (&after[2..], format!("{}{}", pseudo, &after[..2]))
+                } else {
+                    (after, pseudo.to_string())
+                };
+            return Ok((rest, name));
+        }
+    }
     let (rest, base) = take_while1(input, |c: char| c.is_alphanumeric() || c == '_' || c == ':')?;
     let mut base = base.to_string();
     let mut rest = rest;

--- a/t/method-return-type-pseudo-class.t
+++ b/t/method-return-type-pseudo-class.t
@@ -1,0 +1,33 @@
+use Test;
+
+# A method return type declared with `of ::?CLASS` / `of ::?ROLE` / `returns
+# ::?CLASS` must parse — the pseudo-type names the current class/role. The trait
+# type-name scanner previously stopped at the `?`, leaving a stray `?CLASS`, so:
+#   * a slurpy param before it (`method m(*%a) of ::?CLASS { }`) failed with
+#     "expected '{'", and
+#   * a non-slurpy one silently mis-parsed `of ::?CLASS { ... }` as a bogus
+#     `of` method.
+# (WebDriver.rakumod regression: `multi method timeouts(*%args ...) of ::?CLASS`.)
+
+plan 7;
+
+lives-ok { EVAL 'class C1 { method m(*%a) of ::?CLASS { self } }' },
+    'slurpy param then `of ::?CLASS` parses';
+
+lives-ok { EVAL 'class C2 { method m($x) of ::?CLASS { self } }' },
+    'non-slurpy param then `of ::?CLASS` parses (no bogus `of` method)';
+
+lives-ok { EVAL 'class C3 { method m(*%a) returns ::?CLASS { self } }' },
+    'slurpy param then `returns ::?CLASS` parses';
+
+lives-ok { EVAL 'role R4 { method m() of ::?ROLE { self } }' },
+    '`of ::?ROLE` parses in a role';
+
+lives-ok { EVAL 'class C5 { method m(*%a) of ::?CLASS:D { self } }' },
+    '`of ::?CLASS:D` (with definedness smiley) parses';
+
+# The pseudo-type resolves to the concrete class at runtime.
+class C6 { method make-me(*%a) of ::?CLASS { self } }
+my $o = C6.new;
+ok $o.make-me ~~ C6, '::?CLASS return type resolves to the current class';
+is $o.make-me.^name, 'C6', 'the returned value is a C6 instance';


### PR DESCRIPTION
## Summary

\`parse_trait_type_name\` scanned the type after \`of\` / \`returns\` / \`-->\` with
an identifier predicate that allowed \`:\` but not \`?\`, so \`::?CLASS\` / \`::?ROLE\`
(the current-class / current-role pseudo-types) stopped at the \`?\`, leaving a
stray \`?CLASS\`. As a result:

- a **slurpy** parameter before the return type,
  \`method m(*%args) of ::?CLASS { ... }\`, failed to parse (\`expected '{'\`), and
- a **non-slurpy** one silently mis-parsed \`of ::?CLASS { ... }\` as a bogus
  method named \`of\`.

## Fix

Recognise the \`::?CLASS\` / \`::?ROLE\` pseudo-types (with an optional
\`:D\`/\`:U\`/\`:_\` definedness smiley) up front in \`parse_trait_type_name\`, before
the generic identifier scan. Both the slurpy and non-slurpy forms now record the
return type correctly.

## Impact

Unblocks \`WebDriver.rakumod\` parse — \`multi method timeouts(*%args where ?%args)
of ::?CLASS\` — which now parses cleanly, matching \`raku -c\`'s "Syntax OK".

Pin: \`t/method-return-type-pseudo-class.t\` (7 subtests).

Note: two orthogonal, **pre-existing** runtime gaps remain (reproducible via the
already-parsing \`-->\` form, so out of scope here): a \`::?ROLE\` return type in a
composed role and a \`::?CLASS:D\` return type are not fully honored at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)