### PR TITLE
fix: Date.new Whatever day and Date.new-from-daycount

### DIFF
--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -250,6 +250,30 @@ impl Interpreter {
                 }
                 None
             }
+            "new-from-daycount" if args.len() == 1 => {
+                if let ValueView::Package(class_name) = target.view() {
+                    let cn = class_name.resolve();
+                    let is_date_like =
+                        cn == "Date" || self.class_mro(&cn).iter().any(|name| name == "Date");
+                    if is_date_like {
+                        use crate::builtins::methods_0arg::temporal;
+                        // `.daycount` is the Modified Julian Day (epoch_days + 40587);
+                        // invert it to civil y/m/d.
+                        let daycount = crate::runtime::to_int(&args[0]);
+                        let (y, m, d) = temporal::epoch_days_to_civil(daycount - 40587);
+                        if cn == "Date" {
+                            return Some(Ok(temporal::make_date(y, m, d)));
+                        }
+                        let date_args = vec![
+                            Value::pair("year".to_string(), Value::int(y)),
+                            Value::pair("month".to_string(), Value::int(m)),
+                            Value::pair("day".to_string(), Value::int(d)),
+                        ];
+                        return Some(self.dispatch_new(target.clone(), date_args));
+                    }
+                }
+                None
+            }
             "Numeric" if args.is_empty() => {
                 if let ValueView::Seq(items) = target.view() {
                     // Check for PredictiveIterator-backed Seq (stored by Seq.new)

--- a/src/runtime/methods_object_native_ctors_temporal.rs
+++ b/src/runtime/methods_object_native_ctors_temporal.rs
@@ -99,7 +99,13 @@ impl Interpreter {
                         month = to_int(v2);
                     }
                     if let Some(v3) = positional.get(2) {
-                        day = to_int(v3);
+                        // A `*` (Whatever) day means the last day of the month:
+                        // `Date.new(2044, 2, *)` -> 2044-02-29.
+                        day = if matches!(v3.view(), ValueView::Whatever) {
+                            temporal::days_in_month(year, month)
+                        } else {
+                            to_int(v3)
+                        };
                     }
                 }
             }

--- a/t/date-whatever-and-daycount.t
+++ b/t/date-whatever-and-daycount.t
@@ -1,0 +1,13 @@
+use Test;
+
+plan 6;
+
+# `Date.new(year, month, *)` — a Whatever day means the last day of that month.
+is Date.new(2042, 2, *).Str, '2042-02-28', 'Whatever day -> last day (non-leap Feb)';
+is Date.new(2044, 2, *).Str, '2044-02-29', 'Whatever day -> last day (leap Feb)';
+is Date.new(2043, 4, *).Str, '2043-04-30', 'Whatever day -> last day (April)';
+is Date.new(2044, 2, 15).Str, '2044-02-15', 'an explicit day is unaffected';
+
+# `Date.new-from-daycount(N)` — inverse of `.daycount` (Modified Julian Day).
+is Date.new-from-daycount(49987).Str, '1995-09-27', 'new-from-daycount reconstructs the date';
+is Date.new(1995, 9, 27).daycount, 49987, 'daycount round-trips';


### PR DESCRIPTION
Two `Type/Date.rakudoc` doc-diff crashes:

- `Date.new(year, month, *)` with a Whatever day now means the last day of that month (`Date.new(2044, 2, *)` → `2044-02-29`) instead of dying with 'Day out of range. Is: 0'.
- `Date.new-from-daycount(N)` is implemented as the inverse of `.daycount` (Modified Julian Day = epoch_days + 40587): `new-from-daycount(49987)` → `1995-09-27`.

Pin: `t/date-whatever-and-daycount.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)