### PR TITLE
fix: consume a trailing `::` on a qualified name (package Stash)

### DIFF
--- a/src/parser/primary/ident/term_literals.rs
+++ b/src/parser/primary/ident/term_literals.rs
@@ -182,6 +182,14 @@ pub(crate) fn class_literal(input: &str) -> PResult<'_, Expr> {
     if let Some(dyn_expr) = dynamic_expr {
         return Ok((r, Expr::IndirectTypeLookup(Box::new(dyn_expr))));
     }
+    // A trailing `::` on a qualified name denotes the package Stash
+    // (`::EXPORT::DEFAULT::`). The loop above stops at a `::` not followed by a
+    // name segment or `::(...)`, leaving a stray `::` that breaks the enclosing
+    // expression (e.g. `(|::EXPORT::DEFAULT::, ...)` inside parens). Consume it so
+    // the name parses as a single term.
+    if let Some(after) = r.strip_prefix("::") {
+        r = after;
+    }
     // Type smileys: ::Foo:U, ::Foo:D, ::Foo:_
     if (r.starts_with(":D") || r.starts_with(":U") || r.starts_with(":_"))
         && !r[2..].starts_with('<')

--- a/t/qualified-name-trailing-coloncolon.t
+++ b/t/qualified-name-trailing-coloncolon.t
@@ -1,0 +1,30 @@
+use Test;
+
+# A qualified name with a trailing `::` denotes the package Stash
+# (`::EXPORT::DEFAULT::`). The class-literal parser stopped at the trailing `::`,
+# leaving a stray `::` that broke the enclosing expression when the name appeared
+# inside parentheses / a list — e.g. Test::Class's
+#   sub EXPORT { (|::EXPORT::DEFAULT::, |Test::EXPORT::DEFAULT::).Map }
+# failed to parse. The trailing `::` is now consumed so the name is a single term.
+
+plan 5;
+
+# The exact Test::Class re-export idiom must parse.
+lives-ok { EVAL 'sub EXPORT { (|::EXPORT::DEFAULT::, |Test::EXPORT::DEFAULT::).Map }' },
+    'trailing-:: package names in a parenthesized slip list parse';
+
+# A single trailing-:: package inside parens.
+lives-ok { EVAL 'my $x = (::EXPORT::DEFAULT::)' },
+    'a single trailing-:: package parses inside parens';
+
+# Followed by a postfix method call.
+lives-ok { EVAL 'my $x = (::EXPORT::DEFAULT::).Map' },
+    'trailing-:: package followed by a method call parses';
+
+# No regression: a qualified name without a trailing `::` still parses.
+lives-ok { EVAL 'my $x = (Test::EXPORT::DEFAULT)' },
+    'a qualified name without a trailing :: still parses';
+
+# No regression: an indirect lookup still parses.
+lives-ok { EVAL 'my $name = "Int"; my $x = (::($name))' },
+    'an indirect name lookup still parses inside parens';


### PR DESCRIPTION
## Summary

A qualified name written with a trailing `::` denotes the package Stash
(`::EXPORT::DEFAULT::`). The class-literal parser scanned `::`-separated name
segments but stopped at a trailing `::` not followed by another segment or a
`::(...)` dynamic part, leaving a stray `::` unconsumed.

At statement level mutsu's separator leniency hid this, but inside
parentheses / a list the stray `::` broke the enclosing expression, so
Test::Class's re-export idiom

    sub EXPORT { (|::EXPORT::DEFAULT::, |Test::EXPORT::DEFAULT::).Map }

failed to parse ("expected right-hand expression after '='").

## Fix

Consume the trailing `::` after the qualified-name loop so the name is a single
term in every context (parens, lists, method calls).

## Impact

Unblocks `Test::Class` — it now parses and **loads**, matching raku.

Pin: `t/qualified-name-trailing-coloncolon.t` (5 subtests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)