### PR TITLE
fix: a modifier condition ending in a block self-terminates the statement

### DIFF
--- a/src/parser/stmt/modifier.rs
+++ b/src/parser/stmt/modifier.rs
@@ -16,9 +16,19 @@ use super::{keyword, parse_comma_or_expr};
 ///   42 if 23
 ///   is 50; 1
 /// where `is` on the next line is confused with a continuation.
-fn check_two_terms_across_lines(r: &str) -> Result<(), PError> {
+fn check_two_terms_across_lines(cond_input: &str, r: &str) -> Result<(), PError> {
     // Only check if there's content after the condition
     if r.is_empty() || r.starts_with(';') || r.starts_with('}') {
+        return Ok(());
+    }
+    // A condition that ends in a `}` block is self-terminating at end of line,
+    // exactly like any block statement: `say 1 if @a.grep: { ... }` followed by a
+    // statement on the next line is legitimate, not "two terms in a row". Detect
+    // it from the consumed condition text (ends in `}`).
+    if cond_input[..cond_input.len() - r.len()]
+        .trim_end()
+        .ends_with('}')
+    {
         return Ok(());
     }
     // Check if whitespace before remaining contains a newline
@@ -313,6 +323,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
     // Try statement modifiers
     if let Some(r) = keyword("if", rest) {
         let (r, _) = ws1(r)?;
+        let cond_input = r;
         let (r, cond) = expression(r).map_err(|err| PError {
             messages: merge_expected_messages(
                 "expected condition expression after 'if'",
@@ -328,7 +339,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
         if modified_ends_block && block_follows_modifier_condition(r) {
             return Ok(None);
         }
-        check_two_terms_across_lines(r)?;
+        check_two_terms_across_lines(cond_input, r)?;
         let then_stmt = rewrite_placeholder_block_modifier_stmt(stmt, &cond);
         if let Some(split) = try_split_decl_modifier(&then_stmt, &cond) {
             return Ok(Some((r, split)));
@@ -345,6 +356,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
     }
     if let Some(r) = keyword("unless", rest) {
         let (r, _) = ws1(r)?;
+        let cond_input = r;
         let (r, cond) = expression(r).map_err(|err| PError {
             messages: merge_expected_messages(
                 "expected condition expression after 'unless'",
@@ -356,7 +368,7 @@ fn parse_single_modifier(rest: &str, stmt: Stmt) -> Result<Option<(&str, Stmt)>,
         if modified_ends_block && block_follows_modifier_condition(r) {
             return Ok(None);
         }
-        check_two_terms_across_lines(r)?;
+        check_two_terms_across_lines(cond_input, r)?;
         let then_stmt = rewrite_placeholder_block_modifier_stmt(stmt, &cond);
         let neg_cond = Expr::Unary {
             op: TokenKind::Bang,

--- a/t/modifier-cond-ending-in-block.t
+++ b/t/modifier-cond-ending-in-block.t
@@ -1,0 +1,52 @@
+use Test;
+
+# A statement modifier (`if` / `unless`) whose condition ends in a `}` block —
+# e.g. a colon-block method call `@a.grep: { ... }` — is self-terminating at end
+# of line, exactly like any block statement. A statement on the next line is a
+# new statement, not "two terms in a row". (Terminal::UI::Pane regression:
+#   die "..." if @args.grep: { $_ ~~ Str && /\e/ }
+#   my $i = @!lines.elems;
+# )
+
+plan 6;
+
+lives-ok {
+    EVAL q:to/CODE/;
+        my @a = 1, 2, 3;
+        say 1 if @a.grep: { $_ > 1 }
+        my $i = @a.elems;
+        CODE
+}, '`if` condition ending in a colon-block self-terminates before a new statement';
+
+lives-ok {
+    EVAL q:to/CODE/;
+        my @a = 1, 2, 3;
+        say 1 unless @a.map: { $_ }
+        my $i = @a.elems;
+        CODE
+}, '`unless` condition ending in a colon-block self-terminates';
+
+lives-ok {
+    EVAL q:to/CODE/;
+        my @a = 1, 2, 3;
+        my $x = 0;
+        $x = 9 if @a.first: { $_ == 2 }
+        my $y = 1;
+        CODE
+}, 'the modified statement still runs after a block-ending condition';
+
+# The condition is still evaluated correctly.
+my @a = 1, 2, 3;
+my $ran = 0;
+$ran = 1 if @a.grep: { $_ > 2 }
+my $after = 42;
+is $ran, 1, 'the modifier fires when the block condition is truthy';
+is $after, 42, 'the following statement is parsed and run';
+
+# A genuine "two terms in a row" (non-block condition) is still a syntax error.
+throws-like qq:to/CODE/, X::Syntax::Confused,
+    my \@b = 1, 2;
+    say 1 if \@b.elems
+    say 2
+    CODE
+    'a non-block condition followed by a bare statement is still Confused';


### PR DESCRIPTION
## Summary

A postfix `if` / `unless` statement modifier whose condition ends in a `}` block
— e.g. a colon-block method call `@a.grep: { ... }` — is self-terminating at end
of line, exactly like any block statement. `check_two_terms_across_lines` did not
account for this, so

    die "..." if @args.grep: { $_ ~~ Str && /\e/ }
    my $i = @!lines.elems;

was rejected as "two terms in a row across lines" (Terminal::UI::Pane
regression).

## Fix

Pass the pre-condition input to `check_two_terms_across_lines` so it can detect a
condition whose consumed text ends in `}` and skip the check in that case. A
non-block condition is still not self-terminating, so a genuine
`say 1 if @a.elems` followed by a bare statement on the next line stays Confused,
matching raku.

## Impact

Unblocks `Terminal::UI::Pane` parse. (The sibling `Terminal::UI` still has a
separate niche parse gap — a `[&($op)]` bracket-infix-op inside parens — tracked
for a follow-up; the whole dist also needs `Terminal::ANSI`, which raku lacks
here too.)

Pin: `t/modifier-cond-ending-in-block.t` (6 subtests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)