### PR TITLE
fix: quoted MOP pseudo-method dispatch and anonymous enum .^name

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -51,6 +51,12 @@ doc) are version skew, not mutsu bugs — lowest priority.
   never matched — **#4994**.
 - `regexes.rakudoc` [28] — `m:pos(N)` / `m:continue(N)` discarded the `(N)` argument
   and matched from the start — **#4996**.
+- `typesystem.rakudoc` [1] — a quoted MOP pseudo-method call (`$obj."WHAT"()`) invoked
+  the reflection macro instead of a user-defined `method WHAT`. `dispatch_method_by_name_1`
+  intercepted `WHAT`/`HOW`/`WHO`/`WHY` before user-method resolution; now the quoted-call
+  flag (`skip_pseudo_method_native`) makes those arms fall through to the user method.
+- `typesystem.rakudoc` [10] — an anonymous enum value's `.^name` returned the internal
+  marker `__ANON_ENUM__` instead of raku's empty string.
 
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2552,9 +2552,11 @@ impl Interpreter {
             .skip_pseudo_method_native
             .as_ref()
             .is_some_and(|m| m == method);
-        if skip_pseudo {
-            self.skip_pseudo_method_native = None;
-        }
+        // NOTE: do NOT clear the flag here. A quoted `."WHAT"()` etc. is
+        // intercepted by the MOP-macro arms in `dispatch_method_by_name_1`
+        // *before* user-method resolution; that dispatch consults the flag to
+        // fall through to the user method and clears it there (see the
+        // `skip_pseudo_method_native` read at the top of that function).
         let is_pseudo_method = matches!(
             method,
             "DEFINITE" | "WHAT" | "WHO" | "HOW" | "WHY" | "WHICH" | "WHERE" | "VAR"

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -17,6 +17,18 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Option<Result<Value, RuntimeError>> {
+        // A quoted MOP pseudo-method call (`$obj."WHAT"()`) must dispatch a
+        // user-defined method of that name instead of the reflection macro. The
+        // CallMethod opcode records the quoted pseudo name in
+        // `skip_pseudo_method_native`; consume it here (once per dispatch) so the
+        // WHAT/HOW/WHO/WHY macro arms below fall through to user resolution.
+        let quoted_pseudo = self
+            .skip_pseudo_method_native
+            .as_deref()
+            .is_some_and(|m| m == method);
+        if quoted_pseudo {
+            self.skip_pseudo_method_native = None;
+        }
         match method {
             "are" => Some(self.dispatch_are(target, &args)),
             "classify" | "categorize" if matches!(target.view(), ValueView::Package(name) if name == "Supply") =>
@@ -177,10 +189,10 @@ impl Interpreter {
             "broken" => self.dispatch_promise_broken(&target, &args),
             "allof" => self.dispatch_promise_allof(&target, &args),
             "anyof" => self.dispatch_promise_anyof(&target, &args),
-            "WHAT" if args.is_empty() => Some(self.dispatch_what(&target, args)),
-            "HOW" => Some(self.dispatch_how(&target, &args)),
-            "WHO" if args.is_empty() => Some(self.dispatch_who(&target)),
-            "WHY" if args.is_empty() => Some(self.dispatch_why(&target)),
+            "WHAT" if args.is_empty() && !quoted_pseudo => Some(self.dispatch_what(&target, args)),
+            "HOW" if !quoted_pseudo => Some(self.dispatch_how(&target, &args)),
+            "WHO" if args.is_empty() && !quoted_pseudo => Some(self.dispatch_who(&target)),
+            "WHY" if args.is_empty() && !quoted_pseudo => Some(self.dispatch_why(&target)),
             "^name" if args.is_empty() => Some(self.dispatch_caret_name(&target)),
             "^enum_value_list" | "enum_value_list" => self.dispatch_enum_value_list(&target),
             "enums" => self.dispatch_enums(&target),

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -580,7 +580,15 @@ impl Interpreter {
             // An enum VALUE names its enum type (`Bob.^name` is `Names`), not the
             // underlying storage type — `value_type_name` reports "Int" for the
             // int-backed representation, which is only the `.WHICH`/`.Int` view.
-            ValueView::Enum { enum_type, .. } => enum_type.resolve(),
+            // An anonymous enum (`enum <one two>`) has no name: raku reports "".
+            ValueView::Enum { enum_type, .. } => {
+                let n = enum_type.resolve();
+                if n == "__ANON_ENUM__" {
+                    String::new()
+                } else {
+                    n
+                }
+            }
             ValueView::Mixin(inner, _) => match inner.as_ref().view() {
                 ValueView::Instance { class_name, .. } => {
                     crate::value::user_facing_type_name(&class_name.resolve()).to_string()

--- a/t/quoted-pseudo-method-and-anon-enum-name.t
+++ b/t/quoted-pseudo-method-and-anon-enum-name.t
@@ -1,0 +1,48 @@
+use v6;
+use Test;
+
+# A quoted MOP pseudo-method call (`$obj."WHAT"()`) dispatches a user-defined
+# method of that name, while the bare `.WHAT` term stays the reflection macro.
+# (raku-doc Language/typesystem.rakudoc)
+{
+    class A {
+        method WHAT { "ain't gonna happen" }
+    }
+    is A.new.WHAT.raku, 'A', 'bare .WHAT is the type-object macro';
+    is A.new."WHAT"(), "ain't gonna happen", 'quoted ."WHAT"() calls the user method';
+}
+
+# The same holds for the other reflection macros.
+{
+    class B {
+        method HOW { "user-HOW" }
+        method WHO { "user-WHO" }
+        method WHY { "user-WHY" }
+        method WHICH { "user-WHICH" }
+        method WHERE { "user-WHERE" }
+        method DEFINITE { "user-DEFINITE" }
+    }
+    is B.new."HOW"(), "user-HOW", 'quoted ."HOW"() calls the user method';
+    is B.new."WHO"(), "user-WHO", 'quoted ."WHO"() calls the user method';
+    is B.new."WHY"(), "user-WHY", 'quoted ."WHY"() calls the user method';
+    is B.new."WHICH"(), "user-WHICH", 'quoted ."WHICH"() calls the user method';
+    is B.new."WHERE"(), "user-WHERE", 'quoted ."WHERE"() calls the user method';
+    is B.new."DEFINITE"(), "user-DEFINITE", 'quoted ."DEFINITE"() calls the user method';
+}
+
+# Bare macros keep working when no user method shadows them.
+{
+    class C {}
+    is C.new.WHAT.raku, 'C', 'bare .WHAT still the macro when unshadowed';
+    is C.new.HOW.^name, 'Perl6::Metamodel::ClassHOW', 'bare .HOW still the macro';
+    is C.new.WHO.Str, 'C', 'bare .WHO still the macro';
+}
+
+# An anonymous enum value has no type name: raku reports "".
+{
+    my $e = enum <one two three>;
+    is one.^name, '', 'anonymous enum value .^name is the empty string';
+    is $e.^name, 'Map', 'the anon enum itself is a Map';
+}
+
+done-testing;


### PR DESCRIPTION
Two divergences from raku-doc `Language/typesystem.rakudoc`, found by the doc-diff harness (doc-diff campaign, PLAN §8).

## [1] Quoted MOP pseudo-method call dispatches the user method

`$obj."WHAT"()` (quoted method name) must call a user-defined `method WHAT`, while the bare `.WHAT` term stays the reflection macro:

```raku
class A { method WHAT { "ain't gonna happen" } }
say A.new.WHAT;      # (A)                  — bare term = macro
say A.new."WHAT"();  # ain't gonna happen   — quoted = user method
```

`dispatch_method_by_name_1` intercepted `WHAT`/`HOW`/`WHO`/`WHY` before user-method resolution regardless of quoting (unlike `WHICH`/`WHERE`/`DEFINITE`, which are not in its macro arms and already dispatched the user method). The `CallMethod` opcode already records a quoted pseudo call in `skip_pseudo_method_native`; that flag is now consumed at the top of `dispatch_method_by_name_1` so the four macro arms fall through to the user method for a quoted call. The flag is no longer cleared prematurely in `call_method_with_values` (it is only read there for the native-fastpath bypass).

## [10] Anonymous enum value `.^name`

```raku
my $e = enum <one two three>;
say one.^name;   # was "__ANON_ENUM__", now "" (raku)
```

The internal marker `__ANON_ENUM__` is kept as the lookup key in `enum_types` but rendered as the empty string by `dispatch_caret_name`.

## Tests
- Pin: `t/quoted-pseudo-method-and-anon-enum-name.t`
- `make test` PASS (2139 files); roast `S12-introspection/*` + `S12-enums/*` green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)