### PR TITLE
fix: enum value lookup matches rational and cross-type numeric values

### DIFF
--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -240,32 +240,47 @@ impl Interpreter {
                         .and_then(|(idx, _)| by_index(idx)),
                 )
             }
+            // A numeric value matches by numeric equality: an exact `Int` variant,
+            // or (for a rational-valued enum like `enum Mass (g => 1/1, ...)`) a
+            // `Generic` variant whose value equals it numerically (`Mass(1)` -> g).
             ValueView::Int(int_value) => Some(
                 variants
                     .iter()
                     .enumerate()
-                    .find(|(_, (_, v))| *v == EnumValue::Int(int_value))
+                    .find(|(_, (_, v))| {
+                        *v == EnumValue::Int(int_value)
+                            || crate::runtime::to_float_value(&v.to_value())
+                                == Some(int_value as f64)
+                    })
                     .and_then(|(idx, _)| by_index(idx)),
             ),
-            ValueView::Num(num_value) => {
-                if num_value.fract() == 0.0 {
-                    let int_value = num_value as i64;
-                    Some(
-                        variants
-                            .iter()
-                            .enumerate()
-                            .find(|(_, (_, v))| *v == EnumValue::Int(int_value))
-                            .and_then(|(idx, _)| by_index(idx)),
-                    )
-                } else {
-                    Some(None)
-                }
-            }
+            ValueView::Num(num_value) => Some(
+                variants
+                    .iter()
+                    .enumerate()
+                    .find(|(_, (_, v))| {
+                        crate::runtime::to_float_value(&v.to_value()) == Some(num_value)
+                    })
+                    .and_then(|(idx, _)| by_index(idx)),
+            ),
             ValueView::Str(name) => Some(
                 variants
                     .iter()
                     .enumerate()
                     .find(|(_, (key, _))| key.as_str() == name.as_str())
+                    .and_then(|(idx, _)| by_index(idx)),
+            ),
+            // A rational/complex value (e.g. `Mass(1/1000)` for `enum Mass (mg =>
+            // 1/1000, ...)`) is stored as an `EnumValue::Generic`; match it by
+            // value equality against each variant's value.
+            ValueView::Rat(..)
+            | ValueView::BigRat(..)
+            | ValueView::FatRat(..)
+            | ValueView::Complex(..) => Some(
+                variants
+                    .iter()
+                    .enumerate()
+                    .find(|(_, (_, v))| v.to_value() == value)
                     .and_then(|(idx, _)| by_index(idx)),
             ),
             _ => None,

--- a/t/enum-rational-value-lookup.t
+++ b/t/enum-rational-value-lookup.t
@@ -1,0 +1,19 @@
+use Test;
+
+plan 6;
+
+# Calling an enum type as a coercer looks up the member by value. For a
+# rational-valued enum the value is stored generically, and mutsu could not
+# match a Rat (or an Int that equals it numerically) — `Mass(1/1000)` died with
+# "No value '0.001' found in enum Mass". Look up by numeric/value equality.
+enum Mass ( mg => 1/1000, g => 1/1, kg => 1000/1 );
+
+is Mass(1/1000).key, 'mg', 'lookup by exact Rat value';
+is Mass(1).key,      'g',  'Int matches a rational variant numerically';
+is Mass(1000).key,   'kg', 'Int matches a larger rational variant';
+is Mass(0.001).key,  'mg', 'Num matches a rational variant';
+
+# Integer-valued enums are unaffected.
+enum Color <red green blue>;
+is Color(0).key, 'red',  'integer enum lookup by 0';
+is Color(2).key, 'blue', 'integer enum lookup by 2';


### PR DESCRIPTION
Calling an enum type as a coercer (`Mass(1/1000)`) looks up the member by value. A rational-valued enum (`enum Mass (mg => 1/1000, g => 1/1, ...)`) stores its values as `EnumValue::Generic`, and `coerce_to_enum_variant` had no arm for a Rat/Complex input, so `Mass(1/1000)` died with 'No value 0.001 found in enum Mass'. It also matched Int only against exact Int variants, so `Mass(1)` missed the `g => 1/1` member.

Match numeric inputs (Int/Num/Rat/BigRat/FatRat/Complex) against each variant's value by numeric/value equality. Integer-valued enums are unchanged.

From the `Type/Enumeration.rakudoc` doc-diff example. Pin: `t/enum-rational-value-lookup.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)