### PR TITLE
fix: Signature ~~ Signature honours built-in parametric roles

### DIFF
--- a/src/value/signature.rs
+++ b/src/value/signature.rs
@@ -951,7 +951,57 @@ fn is_supertype_of(t1: &str, t2: &str) -> bool {
     if t1 == "Stringy" {
         return t2 == "Str";
     }
-    false
+    // Built-in parametric roles: `t1` is a role that the built-in type `t2`
+    // composes (`Pair ~~ Associative`, `Array ~~ Positional`, ...). The
+    // signature layer has no registry handle, so the standard-library role
+    // memberships are enumerated here (user roles are matched by the runtime's
+    // `isa_check`/`does_check`, not this pure-value helper). Verified against
+    // reference raku.
+    match t1 {
+        "Associative" => matches!(
+            t2,
+            "Hash"
+                | "Map"
+                | "Pair"
+                | "Stash"
+                | "QuantHash"
+                | "Set"
+                | "Bag"
+                | "Mix"
+                | "SetHash"
+                | "BagHash"
+                | "MixHash"
+        ),
+        "Positional" => matches!(t2, "Array" | "List" | "Range" | "Buf" | "Blob" | "Slip"),
+        "Iterable" => matches!(
+            t2,
+            "List"
+                | "Array"
+                | "Seq"
+                | "Range"
+                | "Hash"
+                | "Map"
+                | "Slip"
+                | "Set"
+                | "Bag"
+                | "Mix"
+                | "SetHash"
+                | "BagHash"
+                | "MixHash"
+        ),
+        "Callable" => matches!(
+            t2,
+            "Sub"
+                | "Block"
+                | "Method"
+                | "Submethod"
+                | "Routine"
+                | "WhateverCode"
+                | "Code"
+                | "Macro"
+        ),
+        _ => false,
+    }
 }
 
 /// Convert a where-constraint expression to a runtime Value.

--- a/t/signature-role-subtype-smartmatch.t
+++ b/t/signature-role-subtype-smartmatch.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+# Signature ~~ Signature must honour the built-in parametric role hierarchy:
+# `:(Pair)` is narrower than `:(Associative)` because a Pair does Associative.
+# (raku-doc Language/functions.rakudoc)
+ok :( Pair ) ~~ :( Associative ), 'Pair signature matches Associative signature';
+nok :( Pair ) ~~ :( Hash ),       'Pair signature does not match Hash signature';
+
+ok  :( Array ) ~~ :( Positional ), 'Array does Positional';
+ok  :( List )  ~~ :( Positional ), 'List does Positional';
+nok :( Seq )   ~~ :( Positional ), 'Seq does NOT do Positional';
+ok  :( Seq )   ~~ :( Iterable ),   'Seq does Iterable';
+ok  :( Range ) ~~ :( Iterable ),   'Range does Iterable';
+ok  :( Hash )  ~~ :( Associative ),'Hash does Associative';
+ok  :( Set )   ~~ :( Associative ),'Set does Associative';
+
+ok  :( Sub )    ~~ :( Callable ), 'Sub does Callable';
+ok  :( Method ) ~~ :( Callable ), 'Method does Callable';
+
+# The pre-existing class hierarchy still holds.
+ok  :( Int ) ~~ :( Cool ),    'Int is a Cool';
+ok  :( Int ) ~~ :( Numeric ), 'Int is Numeric';
+nok :( Int ) ~~ :( Str ),     'Int is not a Str';
+
+# Unrelated roles must NOT match.
+nok :( Pair )  ~~ :( Positional ), 'Pair is not Positional';
+nok :( Array ) ~~ :( Associative ),'Array is not Associative';
+
+done-testing;


### PR DESCRIPTION
From the doc-diff campaign (PLAN §8), raku-doc `Language/functions.rakudoc`:

```raku
say :( Pair ) ~~ :( Associative ); # True  (Pair does Associative)
say :( Pair ) ~~ :( Hash );        # False
```

mutsu returned `False` for the first line. The signature-subtype check (`type_accepts` → `is_supertype_of` in `src/value/signature.rs`) only knew the built-in **class** hierarchy (Cool/Numeric/Real/Stringy), so `:(Int) ~~ :(Cool)` already worked but any **role**-based relationship (`Pair`/`Associative`, `Array`/`Positional`, `Sub`/`Callable`, …) returned `False`.

The signature layer is a pure-value module with no registry handle, so the standard-library role memberships are enumerated in `is_supertype_of`, verified against reference raku:

- `Associative` ← Hash, Map, Pair, Stash, QuantHash, {Set,Bag,Mix}{,Hash}
- `Positional` ← Array, List, Range, Buf, Blob, Slip (**not** Seq)
- `Iterable` ← List, Array, Seq, Range, Hash, Map, Slip, {Set,Bag,Mix}{,Hash} (**not** Pair)
- `Callable` ← Sub, Block, Method, Submethod, Routine, WhateverCode, Code, Macro

User-defined roles are still matched by the runtime's isa/does checks, not this helper. The change also improves callable-typed parameter matching (`code_signature_matches_value` shares the same subtype helper).

## Tests
- Pin: `t/signature-role-subtype-smartmatch.t`
- `make test` PASS (2139 files); roast `S06-signature/*` + `S12-subset/*` green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)