### PR TITLE
fix: anonymous enum value .WHAT is the empty type object

### DIFF
--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -69,7 +69,15 @@ impl Interpreter {
             ValueView::Mix(_, true) => "MixHash",
             ValueView::Pair(_, _) | ValueView::ValuePair(_, _) => "Pair",
             ValueView::Enum { enum_type, .. } => {
-                return Ok(Value::package(Symbol::intern(&enum_type.resolve())));
+                let resolved = enum_type.resolve();
+                // An anonymous enum (`enum <one two>`) has no type name: raku's
+                // `.WHAT` is the empty type object `()`.
+                let visible = if crate::value::is_internal_anon_type_name(&resolved) {
+                    ""
+                } else {
+                    &resolved
+                };
+                return Ok(Value::package(Symbol::intern(visible)));
             }
             ValueView::Nil => "Any",
             ValueView::Package(name) => {
@@ -583,7 +591,7 @@ impl Interpreter {
             // An anonymous enum (`enum <one two>`) has no name: raku reports "".
             ValueView::Enum { enum_type, .. } => {
                 let n = enum_type.resolve();
-                if n == "__ANON_ENUM__" {
+                if crate::value::is_internal_anon_type_name(&n) {
                     String::new()
                 } else {
                     n

--- a/t/quoted-pseudo-method-and-anon-enum-name.t
+++ b/t/quoted-pseudo-method-and-anon-enum-name.t
@@ -38,11 +38,21 @@ use Test;
     is C.new.WHO.Str, 'C', 'bare .WHO still the macro';
 }
 
-# An anonymous enum value has no type name: raku reports "".
+# An anonymous enum value has no type name: raku reports "" and its `.WHAT`
+# is the empty type object `()`.
 {
     my $e = enum <one two three>;
     is one.^name, '', 'anonymous enum value .^name is the empty string';
+    is one.WHAT.gist, '()', 'anonymous enum value .WHAT is the empty type object';
+    is one.WHAT.^name, '', 'anonymous enum value .WHAT.^name is the empty string';
     is $e.^name, 'Map', 'the anon enum itself is a Map';
+}
+
+# A named enum value keeps its type name through both .^name and .WHAT.
+{
+    enum E2 <a b>;
+    is a.^name, 'E2', 'named enum value .^name is the enum type';
+    is a.WHAT.gist, '(E2)', 'named enum value .WHAT is the enum type object';
 }
 
 done-testing;


### PR DESCRIPTION
Follow-up to #5045. That PR fixed an anonymous enum value's `.^name` (via `dispatch_caret_name`) but left the sibling `.WHAT` path (`dispatch_what`) still rendering the internal `__ANON_ENUM__` marker:

```raku
my $e = enum <one two>;
say one.WHAT;      # was (__ANON_ENUM__), now () (raku)
say one.WHAT.^name; # was "__ANON_ENUM__", now "" (raku)
```

The `ValueView::Enum` arm of `dispatch_what` now strips an internal anonymous type name to `""` via the shared `is_internal_anon_type_name` helper, and the `.^name` arm from #5045 is switched from a literal `"__ANON_ENUM__"` comparison to the same helper for consistency. A named enum keeps its type name through both paths.

## Tests
- Pin extended: `t/quoted-pseudo-method-and-anon-enum-name.t`
- `make test` PASS (2143 files); roast `S12-enums/*` green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)