### PR TITLE
fix: DateTime.new accepts a date-only string

### DIFF
--- a/src/builtins/methods_0arg/temporal.rs
+++ b/src/builtins/methods_0arg/temporal.rs
@@ -395,8 +395,15 @@ pub fn parse_datetime_string(s: &str) -> Result<DateTimeParts, RuntimeError> {
         )
     };
 
-    // Split on T/t
-    let t_pos = s.find(['T', 't']).ok_or_else(make_err)?;
+    // Split on T/t. A date-only string (`2023-03-04`) is valid: the time
+    // defaults to midnight UTC (`DateTime.new("2023-03-04")` -> ...T00:00:00Z).
+    let Some(t_pos) = s.find(['T', 't']) else {
+        // Keep the DateTime-flavored error for a malformed date-only string
+        // rather than the `Date`-flavored one `parse_date_string` would raise.
+        let (year, month, day) = parse_date_string(s).map_err(|_| make_err())?;
+        validate_datetime(year, month, day, 0, 0, 0.0, 0)?;
+        return Ok((year, month, day, 0, 0, 0.0, 0));
+    };
     let (date_part, time_tz_with_t) = s.split_at(t_pos);
     let time_tz = &time_tz_with_t[1..];
 

--- a/t/datetime-date-only-string.t
+++ b/t/datetime-date-only-string.t
@@ -1,0 +1,23 @@
+use Test;
+
+plan 5;
+
+# `DateTime.new(Str)` accepts a date-only string (no time part): the time
+# defaults to midnight UTC. Previously mutsu required a `T` separator and died
+# with "Invalid DateTime string".
+is DateTime.new("2023-03-04").Str, '2023-03-04T00:00:00Z',
+    'a date-only string defaults to midnight UTC';
+
+is DateTime.new("2012-04-01").Str, '2012-04-01T00:00:00Z',
+    'another date-only string';
+
+# A full datetime string still parses.
+is DateTime.new("2023-03-04T05:06:07Z").Str, '2023-03-04T05:06:07Z',
+    'a full datetime string still parses';
+
+# A malformed string still raises the DateTime-flavored error.
+throws-like 'DateTime.new("2012/04")', X::Temporal::InvalidFormat,
+    target => 'DateTime';
+
+throws-like 'DateTime.new("garbage")', X::Temporal::InvalidFormat,
+    target => 'DateTime';


### PR DESCRIPTION
`DateTime.new(Str)` required a `T` separator, so a date-only string (`DateTime.new("2023-03-04")`) died with 'Invalid DateTime string'. Rakudo accepts it and defaults the time to midnight UTC.

Parse a T-less string as a date with a zero time, keeping the DateTime-flavored `X::Temporal::InvalidFormat` for a malformed one.

From the `Type/DateTime.rakudoc` doc-diff example. Pin: `t/datetime-date-only-string.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)