### PR TITLE
fix: a Pair answers <key>:exists for its own key

### DIFF
--- a/src/vm/vm_var_exists_ops.rs
+++ b/src/vm/vm_var_exists_ops.rs
@@ -92,6 +92,16 @@ impl Interpreter {
             }
             if let Some(map) = match target.view() {
                 ValueView::Hash(map) => Some(map.clone()),
+                // A Pair answers `<key>:exists` for its own key: treat it as a
+                // single-entry map (`(a => 5)<a>:exists` is True, `<b>` False).
+                ValueView::Pair(key, value) => {
+                    let mut m = std::collections::HashMap::new();
+                    m.insert((*key).clone(), (*value).clone());
+                    match Value::hash(m).view() {
+                        ValueView::Hash(map) => Some(map.clone()),
+                        _ => None,
+                    }
+                }
                 ValueView::Instance {
                     class_name,
                     attributes,

--- a/t/pair-subscript-exists.t
+++ b/t/pair-subscript-exists.t
@@ -1,0 +1,15 @@
+use Test;
+
+plan 5;
+
+# A Pair answers a `<key>:exists` subscript for its own key, mirroring a
+# single-entry Map. Previously mutsu returned False even for the pair's own key.
+my $p = a => 5;
+
+is $p<a>, 5, 'a Pair subscript returns the value for its key';
+is-deeply ($p<a>:exists), True, ':exists is True for the pair key';
+is-deeply ($p<b>:exists), False, ':exists is False for a different key';
+is-deeply ($p<a>:!exists), False, ':!exists negates';
+
+# Value access for a non-matching key is Nil.
+is-deeply $p<no-such-key>, Nil, 'a non-matching key subscript is Nil';


### PR DESCRIPTION
`(a => 5)<a>:exists` returned False because the `:exists` subscript handler only recognized Hash/Stash targets. Treat a Pair as a single-entry map so `<key>:exists` answers for the pair's own key, matching raku.

From the `Type/Pair.rakudoc` doc-diff example. Pin: `t/pair-subscript-exists.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)