### PR TITLE
fix: sum of a huge i64-endpoint Range no longer overflows

### DIFF
--- a/src/builtins/functions/dispatch_variadic.rs
+++ b/src/builtins/functions/dispatch_variadic.rs
@@ -5,6 +5,37 @@ use crate::runtime;
 use crate::value::{RuntimeError, Value, ValueView};
 use num_bigint::BigInt as NumBigInt;
 
+/// Gauss sum of the inclusive integer range `lo..hi` (empty when `lo > hi`),
+/// computed in i128 so the product never overflows for i64 endpoints — the
+/// sum of `1 .. 10_000_000_000_000` is ~5e25, far past i64.
+fn int_series_sum_i128(lo: i64, hi: i64) -> i128 {
+    if lo > hi {
+        return 0;
+    }
+    let n = (hi as i128) - (lo as i128) + 1;
+    n * ((lo as i128) + (hi as i128)) / 2
+}
+
+/// Fold an i128 arithmetic-series sum into the running `sum` accumulator.
+/// Returns `Some(value)` when the total no longer fits in `i64` and the whole
+/// `sum` must be returned early as a BigInt (mirrors the `GenericRange` arm),
+/// otherwise `None` after updating `total`/`total_f` in place.
+fn fold_series_sum(total: &mut i64, total_f: &mut f64, has_num: bool, s: i128) -> Option<Value> {
+    if has_num {
+        *total_f += s as f64;
+        return None;
+    }
+    if let Ok(v) = i64::try_from(s)
+        && let Some(nt) = total.checked_add(v)
+    {
+        *total = nt;
+        return None;
+    }
+    Some(Value::bigint_arc(std::sync::Arc::new(
+        NumBigInt::from(*total) + NumBigInt::from(s),
+    )))
+}
+
 pub(crate) fn native_function_variadic(
     name: &str,
     args: &[Value],
@@ -200,51 +231,27 @@ pub(crate) fn native_function_variadic(
                         total_f += f;
                     }
                     ValueView::Range(a, b) => {
-                        let n = b - a + 1;
-                        if n > 0 {
-                            let s = n * (a + b) / 2;
-                            if has_num {
-                                total_f += s as f64;
-                            } else {
-                                total += s;
-                            }
+                        let s = int_series_sum_i128(a, b);
+                        if let Some(v) = fold_series_sum(&mut total, &mut total_f, has_num, s) {
+                            return Some(Ok(v));
                         }
                     }
                     ValueView::RangeExcl(a, b) => {
-                        let n = b - a;
-                        if n > 0 {
-                            let b_adj = b - 1;
-                            let s = n * (a + b_adj) / 2;
-                            if has_num {
-                                total_f += s as f64;
-                            } else {
-                                total += s;
-                            }
+                        let s = int_series_sum_i128(a, b - 1);
+                        if let Some(v) = fold_series_sum(&mut total, &mut total_f, has_num, s) {
+                            return Some(Ok(v));
                         }
                     }
                     ValueView::RangeExclStart(a, b) => {
-                        let start = a + 1;
-                        if start <= b {
-                            let n = b - start + 1;
-                            let s = n * (start + b) / 2;
-                            if has_num {
-                                total_f += s as f64;
-                            } else {
-                                total += s;
-                            }
+                        let s = int_series_sum_i128(a + 1, b);
+                        if let Some(v) = fold_series_sum(&mut total, &mut total_f, has_num, s) {
+                            return Some(Ok(v));
                         }
                     }
                     ValueView::RangeExclBoth(a, b) => {
-                        let start = a + 1;
-                        let end = b - 1;
-                        if start <= end {
-                            let n = end - start + 1;
-                            let s = n * (start + end) / 2;
-                            if has_num {
-                                total_f += s as f64;
-                            } else {
-                                total += s;
-                            }
+                        let s = int_series_sum_i128(a + 1, b - 1);
+                        if let Some(v) = fold_series_sum(&mut total, &mut total_f, has_num, s) {
+                            return Some(Ok(v));
                         }
                     }
                     ValueView::GenericRange {

--- a/t/sum-range-bigint-no-overflow.t
+++ b/t/sum-range-bigint-no-overflow.t
@@ -1,0 +1,33 @@
+use v6;
+use Test;
+
+# `sum RANGE` with i64 endpoints must not overflow: the Gauss product is
+# computed in wider precision and promoted to a BigInt past i64 range.
+# (raku-doc Language/structures.rakudoc — this used to panic in mutsu.)
+is sum(1 .. 9_999_999_999_999), 49999999999995000000000000,
+    'sum of a huge inclusive range returns the exact BigInt';
+
+is sum(1 .. 1_000_000_000), 500000000500000000,
+    'sum of a large i64-fitting range is exact';
+
+# Exclusive endpoints stay correct at large scale.
+is sum(1 ..^ 9_999_999_999_999), 49999999999985000000000001,
+    'exclusive-end huge range is exact';
+is sum(1 ^.. 9_999_999_999_999), 49999999999994999999999999,
+    'exclusive-start huge range is exact';
+
+# Small ranges are unchanged (all four boundary flavours).
+is sum(1 .. 100),   5050, 'inclusive small range';
+is sum(1 ..^ 100),  4950, 'exclusive-end small range';
+is sum(1 ^.. 100),  5049, 'exclusive-start small range';
+is sum(1 ^..^ 100), 4949, 'exclusive-both small range';
+
+# Empty / degenerate ranges sum to 0.
+is sum(5 .. 3), 0, 'reversed (empty) range sums to 0';
+is sum(0 .. 0), 0, 'single-zero range sums to 0';
+
+# The result is an Int (BigInt) type, arithmetic keeps working on it.
+ok sum(1 .. 9_999_999_999_999) ~~ Int, 'huge range sum is an Int';
+is sum(1 .. 9_999_999_999_999) + 5, 49999999999995000000000005, 'BigInt sum keeps arithmetic';
+
+done-testing;


### PR DESCRIPTION
From the doc-diff campaign, raku-doc `Language/structures.rakudoc`:

```raku
say sum 1 .. 9_999_999_999_999;  # 49999999999995000000000000
```

mutsu **panicked** with `attempt to multiply with overflow`. The arithmetic-series fast path in `dispatch_variadic.rs` computed the Gauss sum `n * (a + b) / 2` in `i64` for the `ValueView::Range` / `RangeExcl*` arms, but the result (~5e25) far exceeds `i64`. The `GenericRange` arm already handled the overflow via BigInt; the four i64-endpoint arms did not.

The i64-endpoint arms now compute the series sum in `i128` via a shared `int_series_sum_i128(lo, hi)` helper and fold it through `fold_series_sum`, which promotes the running total to a BigInt (mirroring the `GenericRange` arm) when it no longer fits in `i64`. **All i64-fitting results are byte-identical to before** (verified: `1..100`→5050, `1..1_000_000_000`→500000000500000000, and the exclusive-endpoint flavours all match reference raku).

## Tests
- Pin: `t/sum-range-bigint-no-overflow.t`
- `make test` PASS (2144 files); roast `S32-list/reduce.t` green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)