### PR TITLE
fix: handle an indexed-element bind (`%h<k> := v`) in expression context

### DIFF
--- a/src/parser/expr/precedence/logic.rs
+++ b/src/parser/expr/precedence/logic.rs
@@ -196,21 +196,94 @@ pub(crate) fn assign_not_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
         let after = &r[2..];
         let (after, _) = ws(after)?;
         if let Ok((r2, rhs)) = ternary_mode(after, mode) {
-            let bind_name = match unwrap_grouped_lvalue(expr.clone()) {
-                Expr::Var(name) => Some(name),
-                Expr::ArrayVar(name) => Some(format!("@{name}")),
-                Expr::HashVar(name) => Some(format!("%{name}")),
-                _ => None,
-            };
-            if let Some(name) = bind_name {
-                return Ok((
-                    r2,
-                    Expr::AssignExpr {
-                        name,
-                        expr: Box::new(rhs),
-                        is_bind: true,
-                    },
-                ));
+            match unwrap_grouped_lvalue(expr.clone()) {
+                Expr::Var(name) => {
+                    return Ok((
+                        r2,
+                        Expr::AssignExpr {
+                            name,
+                            expr: Box::new(rhs),
+                            is_bind: true,
+                        },
+                    ));
+                }
+                Expr::ArrayVar(name) => {
+                    return Ok((
+                        r2,
+                        Expr::AssignExpr {
+                            name: format!("@{name}"),
+                            expr: Box::new(rhs),
+                            is_bind: true,
+                        },
+                    ));
+                }
+                Expr::HashVar(name) => {
+                    return Ok((
+                        r2,
+                        Expr::AssignExpr {
+                            name: format!("%{name}"),
+                            expr: Box::new(rhs),
+                            is_bind: true,
+                        },
+                    ));
+                }
+                // Indexed element bind: `%h<k> := v`, `@a[i] := v`. Desugar to an
+                // IndexAssign whose value carries the `__mutsu_bind_index_value`
+                // marker so the VM takes *bind* (not assign) semantics — matching
+                // the statement-level handler. This lets an indexed bind parse in
+                // expression context (`my $c = %h<k> := v`, `$c = %h<k> := X.new: ...`,
+                // `return @a[i] := v`); previously only simple sigil variables bound
+                // here and indexed lvalues were left to the statement-level handler,
+                // which is absent in expression context.
+                //
+                // Only a single-element bind on a plain sigil-variable target is
+                // handled here. Slice binds (`@a[0,1] := 4,5`), Whatever-index binds
+                // (`@a[*-1] := 42`, illegal → X::Bind::Slice), and binds into a
+                // non-variable target (`(1,2)[0] := 3`, `10[0] := 1`, → X::Bind) must
+                // keep falling through to the statement-level handler, which
+                // distributes/validates them. Guard on those so this fast path does
+                // not shadow that handling.
+                Expr::Index {
+                    target,
+                    index,
+                    is_positional,
+                } if matches!(
+                    target.as_ref(),
+                    Expr::ArrayVar(_) | Expr::HashVar(_) | Expr::Var(_)
+                ) && !matches!(
+                    index.as_ref(),
+                    Expr::ArrayLiteral(_)
+                        | Expr::Whatever
+                        | Expr::Lambda {
+                            is_whatever_code: true,
+                            ..
+                        }
+                        | Expr::AnonSubParams {
+                            is_whatever_code: true,
+                            ..
+                        }
+                ) =>
+                {
+                    let bind_value = Expr::Call {
+                        name: crate::symbol::Symbol::intern("__mutsu_bind_index_value"),
+                        args: vec![
+                            rhs.clone(),
+                            crate::parser::stmt::simple_expr_stmt::lvalue::bind_source_metadata_expr(
+                                &rhs,
+                            ),
+                        ],
+                    };
+                    return Ok((
+                        r2,
+                        Expr::IndexAssign {
+                            target,
+                            index,
+                            value: Box::new(bind_value),
+                            is_positional,
+                        },
+                    ));
+                }
+                _ => {}
             }
         }
     }

--- a/t/indexed-bind-in-expression.t
+++ b/t/indexed-bind-in-expression.t
@@ -1,0 +1,64 @@
+use Test;
+
+# An indexed-element bind (`%h<k> := v`, `@a[i] := v`) must work in expression
+# context, not only as a statement. Previously the expression-level `:=` handler
+# only bound simple sigil variables (`$x := v`), leaving indexed lvalues to the
+# statement-level handler — which is absent when the bind is the RHS of a
+# declaration/assignment. So
+#   my $commit = %!commits{$sha1} := Git::Commit.new: ...;   # Git::Blame::File
+# failed to parse. The bind is now handled in expression context too.
+
+plan 11;
+
+{
+    my %c;
+    my $c = %c<k> := 5;
+    is $c, 5, 'my $x = %h<k> := v returns the bound value';
+    is %c<k>, 5, 'and the hash element is bound';
+}
+
+{
+    my @a;
+    my $c = @a[0] := 7;
+    is $c, 7, 'my $x = @a[i] := v returns the bound value';
+    is @a[0], 7, 'and the array element is bound';
+}
+
+{
+    # Chained bind on an indexed lvalue with a method-call RHS (the exact
+    # Git::Blame::File shape).
+    my class G { has $.n }
+    my %commits;
+    my $key = 'sha1';
+    my $commit = %commits{$key} := G.new(n => 42);
+    is $commit.n, 42, 'my $x = %h<k> := Class.new(...) binds and returns';
+    is %commits{$key}.n, 42, 'the hash element holds the same object';
+}
+
+{
+    # Plain-variable bind in expression context still works (no regression).
+    my $a;
+    my $c = $a := 9;
+    is $c, 9, 'plain-variable bind in expression context still works';
+}
+
+{
+    # Statement-level indexed bind still works (no regression).
+    my %c;
+    %c<k> := 3;
+    is %c<k>, 3, 'statement-level indexed bind still works';
+}
+
+# The expression-context fast path must NOT shadow the statement-level handler's
+# special handling of slice binds, Whatever-index binds, and non-variable targets.
+{
+    my @a = 1, 2, 3;
+    @a[0, 1] := 4, 5;
+    is ~@a, '4 5 3', 'a slice bind (@a[0,1] := ...) still distributes';
+}
+
+throws-like { my @a = 1, 2, 3; @a[*-1] := 42 }, X::Bind::Slice,
+    'a Whatever-index bind is still X::Bind::Slice';
+
+throws-like '(1,2)[0] := 3', X::Bind,
+    'a bind into a non-variable target is still X::Bind';


### PR DESCRIPTION
## Summary

The expression-level `:=` handler only bound simple sigil-variable lvalues
(`$x`, `@a`, `%h`), leaving indexed lvalues (`%h<k> := v`, `@a[i] := v`) to the
statement-level bind handler. But that handler is absent when the bind is the
RHS of a declaration or assignment, so

    my $commit = %!commits{$sha1} := Git::Commit.new: :$sha1, |%fields;

(Git::Blame::File) failed to parse — `expression()` parsed `%!commits{$sha1}` and
stopped, leaving `:= ...` unconsumed.

## Fix

Desugar an indexed `Expr::Index := rhs` to an `IndexAssign` whose value carries
the `__mutsu_bind_index_value` marker (bind, not assign semantics), matching the
statement-level and `try_parse_assign_expr` handlers. Simple sigil-variable binds
are unchanged.

## Impact

Unblocks `Git::Blame::File` parse — it now **loads**, matching raku.

Pin: `t/indexed-bind-in-expression.t` (8 subtests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)