### PR TITLE
fix: bind a placeholder variable inside parentheses

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1256,7 +1256,7 @@ fn collect_assign_ph_expr(expr: &Expr, out: &mut Vec<String>) {
             collect_assign_ph_expr(left, out);
             collect_assign_ph_expr(right, out);
         }
-        Expr::Unary { expr, .. } => collect_assign_ph_expr(expr, out),
+        Expr::Unary { expr, .. } | Expr::Grouped(expr) => collect_assign_ph_expr(expr, out),
         Expr::Block(body) | Expr::AnonSub { body, .. } => {
             for s in body {
                 collect_assign_ph_stmt(s, out);
@@ -1363,9 +1363,10 @@ fn collect_unattached_ph_expr(expr: &Expr, out: &mut Vec<String>) {
             collect_unattached_ph_expr(then_expr, out);
             collect_unattached_ph_expr(else_expr, out);
         }
-        Expr::AssignExpr { expr, .. } | Expr::PositionalPair(expr) | Expr::ZenSlice(expr) => {
-            collect_unattached_ph_expr(expr, out)
-        }
+        Expr::AssignExpr { expr, .. }
+        | Expr::PositionalPair(expr)
+        | Expr::ZenSlice(expr)
+        | Expr::Grouped(expr) => collect_unattached_ph_expr(expr, out),
         Expr::ArrayLiteral(es)
         | Expr::BracketArray(es, _)
         | Expr::StringInterpolation(es)
@@ -1842,6 +1843,7 @@ fn collect_ph_expr(expr: &Expr, out: &mut Vec<String>) {
         Expr::Reduction { expr, .. }
         | Expr::Eager(expr)
         | Expr::Itemize(expr)
+        | Expr::Grouped(expr)
         | Expr::DeitemizeForBind(expr) => collect_ph_expr(expr, out),
         Expr::HyperOp { left, right, .. }
         | Expr::HyperFuncOp { left, right, .. }
@@ -2140,6 +2142,7 @@ fn collect_ph_expr_shallow(expr: &Expr, out: &mut Vec<String>) {
         Expr::Reduction { expr, .. }
         | Expr::Eager(expr)
         | Expr::Itemize(expr)
+        | Expr::Grouped(expr)
         | Expr::DeitemizeForBind(expr) => collect_ph_expr_shallow(expr, out),
         Expr::HyperOp { left, right, .. }
         | Expr::HyperFuncOp { left, right, .. }

--- a/t/placeholder-in-parens.t
+++ b/t/placeholder-in-parens.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+# A placeholder variable inside a parenthesised sub-expression must still be
+# collected as a block parameter. `^($^x)` desugars to `0 ..^ Grouped($^x)`,
+# and the placeholder scan skipped the `Grouped` node — so the block took no
+# parameters and `$^x` read as an unbound default.
+# (raku-doc Language/structures.rakudoc)
+{
+    my &a-func = { (^($^þ)).Seq };
+    is a-func(3), (0, 1, 2),         'unicode placeholder in parens under prefix-^ binds';
+    is a-func(7), (0, 1, 2, 3, 4, 5, 6), 'and again with a different argument';
+}
+
+{
+    my &f = { ^($^x) };
+    is f(3).raku, '^3', 'ascii placeholder in parens binds';
+}
+
+# Multiple placeholders inside parens, and nested parens.
+{
+    my &g = { ($^a) + ($^b) };
+    is g(3, 4), 7, 'two parenthesised placeholders bind in order';
+
+    my &h = { (($^x)) };
+    is h(9), 9, 'doubly-parenthesised placeholder binds';
+}
+
+# Unparenthesised placeholders are unaffected.
+{
+    my &p = { $^x + 1 };
+    is p(5), 6, 'bare placeholder still binds';
+    my &q = { ^$^x };
+    is q(3).raku, '^3', 'prefix-^ on a bare placeholder still binds';
+}
+
+done-testing;


### PR DESCRIPTION
From the doc-diff campaign, raku-doc `Language/structures.rakudoc`:

```raku
my &a-func = { (^($^þ)).Seq };
say a-func(3), a-func(7);  # (0 1 2)(0 1 2 3 4 5 6)
```

mutsu produced `(0..^Bool::True)(0..^Bool::True)`: the `$^x`/`$^þ` placeholder inside the parenthesised sub-expression was never collected, so the block took **no parameters** and the placeholder read as an unbound default.

`^($^x)` desugars to `0 ..^ Grouped($^x)`, and the four placeholder-collection walkers (`collect_ph_expr`, `collect_ph_expr_shallow`, `collect_unattached_ph_expr`, `collect_assign_ph_expr`) had no arm for `Expr::Grouped` — it fell through their catch-all, so the inner placeholder was invisible and the block was built as a zero-arg closure. Added the `Grouped` arm to all four, so the walk descends into a parenthesised expression like every other single-expression wrapper (`Eager`/`Itemize`/`Reduction`/…). Not unicode-specific — plain `{ ^($^x) }` had the same bug.

## Tests
- Pin: `t/placeholder-in-parens.t` (unicode + ascii, multiple + nested parens, unparenthesised regressions)
- `make test` PASS (2147 files); all `t/*placeholder*` green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)