### PR TITLE
fix: numeric coercion of an enum member acts on its underlying value

### DIFF
--- a/src/runtime/methods_enum_dispatch.rs
+++ b/src/runtime/methods_enum_dispatch.rs
@@ -5,7 +5,7 @@ impl Interpreter {
     /// Dispatch methods on Enum values.
     /// Returns Some(result) if handled, None if not an enum method.
     pub(super) fn dispatch_enum_method(
-        &self,
+        &mut self,
         target: &Value,
         method: &str,
         args: &[Value],
@@ -22,24 +22,15 @@ impl Interpreter {
 
         match method {
             "key" => Some(Ok(Value::str(key.resolve()))),
-            "value" | "Int" | "Numeric" => match value {
-                EnumValue::Int(i) => Some(Ok(Value::int(*i))),
-                EnumValue::Str(s) => {
-                    if method == "value" {
-                        Some(Ok(Value::str(s.clone())))
-                    } else {
-                        // .Int / .Numeric on a string enum should try to coerce
-                        None // fall through to runtime for proper error
-                    }
-                }
-                EnumValue::Generic(v) => {
-                    if method == "value" {
-                        Some(Ok(v.as_ref().clone()))
-                    } else {
-                        None
-                    }
-                }
-            },
+            "value" => Some(Ok(value.to_value())),
+            // A numeric coercion of an enum member acts on its underlying value:
+            // `cool.Int` for `enum Numbers (cool => '42')` is `'42'.Int` == 42,
+            // and `sqrt-n-one.Real` for a `'i'` value raises the string-numeric
+            // error, exactly as raku does.
+            "Int" | "Numeric" | "Real" | "Num" | "Rat" | "Complex" => {
+                let underlying = value.to_value();
+                Some(self.call_method_with_values(underlying, method, args.to_vec()))
+            }
             "WHAT" => Some(Ok(Value::package(enum_type))),
             "raku" | "perl" => {
                 let k = key.resolve();

--- a/t/enum-string-value-coerce.t
+++ b/t/enum-string-value-coerce.t
@@ -1,0 +1,20 @@
+use Test;
+
+plan 8;
+
+# A numeric coercion of an enum member acts on its underlying value. For a
+# string-valued enum, `cool.Int` is `'42'.Int`. Previously mutsu fell through to
+# a bogus "No such method 'Int' for invocant of type 'Int'" error.
+enum Numbers ( cool => '42', almost-pi => '3.14' );
+
+is cool.Int,       42,   '.Int coerces the string value';
+is almost-pi.Int,  3,    '.Int truncates a fractional string value';
+is cool.Real,      42,   '.Real coerces the string value';
+is almost-pi.Real, 3.14, '.Real keeps the fractional value';
+is cool.value,     '42', '.value returns the raw string';
+
+# Integer-valued enums are unaffected.
+enum Color <red green blue>;
+is blue.Int,     2, 'integer enum .Int';
+is blue.Numeric, 2, 'integer enum .Numeric';
+is blue.value,   2, 'integer enum .value';


### PR DESCRIPTION
`cool.Int` for `enum Numbers (cool => '42')` should be `'42'.Int` == 42, but mutsu returned None for a string/generic-valued enum on `.Int`/`.Numeric` and fell through to a bogus 'No such method Int for invocant of type Int' error.

Route `.Int`/`.Numeric`/`.Real`/`.Num`/`.Rat`/`.Complex` on an enum member through the underlying value's own coercion. Integer-valued enums are unchanged.

From the `Type/Enumeration.rakudoc` doc-diff example. Pin: `t/enum-string-value-coerce.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)