### PR TITLE
fix: add missing Dateish methods (DateTime ordered formatters, days-in-year, formatter)

### DIFF
--- a/src/builtins/methods_0arg/temporal_dispatch.rs
+++ b/src/builtins/methods_0arg/temporal_dispatch.rs
@@ -47,6 +47,13 @@ pub fn date_method_0arg(attributes: &AttrMap, method: &str) -> Option<Result<Val
         "day-of-year" => Some(Ok(Value::int(day_of_year(year, month, day)))),
         "is-leap-year" => Some(Ok(Value::truth(is_leap_year(year)))),
         "days-in-month" => Some(Ok(Value::int(days_in_month(year, month)))),
+        "days-in-year" => Some(Ok(Value::int(if is_leap_year(year) { 366 } else { 365 }))),
+        // The stored formatter Callable, or the `Callable` default when none was
+        // supplied (`Date.new(...).formatter.^name` -> `Callable`).
+        "formatter" => Some(Ok(attributes
+            .get("formatter")
+            .cloned()
+            .unwrap_or_else(|| Value::package(Symbol::intern("Callable"))))),
         "daycount" => Some(Ok(Value::int(daycount(year, month, day)))),
         "Str" | "gist" => {
             // If a formatter was applied and rendered, use that
@@ -185,6 +192,14 @@ pub fn datetime_method_0arg(
         "day-of-year" => Some(Ok(Value::int(day_of_year(year, month, day)))),
         "is-leap-year" => Some(Ok(Value::truth(is_leap_year(year)))),
         "days-in-month" => Some(Ok(Value::int(days_in_month(year, month)))),
+        "days-in-year" => Some(Ok(Value::int(if is_leap_year(year) { 366 } else { 365 }))),
+        "formatter" => Some(Ok(attributes
+            .get("formatter")
+            .cloned()
+            .unwrap_or_else(|| Value::package(Symbol::intern("Callable"))))),
+        "yyyy-mm-dd" | "mm-dd-yyyy" | "dd-mm-yyyy" => Some(Ok(Value::str(format_date_ordered(
+            method, year, month, day, "-",
+        )))),
         "daycount" => Some(Ok(Value::int(daycount(year, month, day)))),
         "whole-second" => Some(Ok(Value::int(second.floor() as i64))),
         "hh-mm-ss" => Some(Ok(Value::str(format!(

--- a/src/runtime/methods_temporal.rs
+++ b/src/runtime/methods_temporal.rs
@@ -171,6 +171,16 @@ pub(super) fn dispatch_temporal_method(
                     )
                     .map(|v| rebless_datetime_result(v, class_name, &attributes)),
                 ),
+                // `.yyyy-mm-dd($sep)` etc. with an optional separator (default `-`).
+                "yyyy-mm-dd" | "mm-dd-yyyy" | "dd-mm-yyyy" => {
+                    let sep = args
+                        .first()
+                        .map(|v| v.to_string_value())
+                        .unwrap_or_else(|| "-".to_string());
+                    Some(Ok(Value::str(temporal::format_date_ordered(
+                        method, year, month, day, &sep,
+                    ))))
+                }
                 "clone" => Some(
                     datetime_clone(year, month, day, hour, minute, second, timezone, args)
                         .map(|v| rebless_datetime_result(v, class_name, &attributes)),

--- a/t/dateish-methods.t
+++ b/t/dateish-methods.t
@@ -1,0 +1,28 @@
+use Test;
+
+plan 11;
+
+# Dateish methods that were missing on DateTime (Date already had the ordered
+# formatters) or on both types (days-in-year, formatter).
+
+# Ordered date formatters on DateTime, with the default and a custom separator.
+my $dt = DateTime.new(1470853583);
+is $dt.yyyy-mm-dd,      '2016-08-10', 'DateTime.yyyy-mm-dd';
+is $dt.mm-dd-yyyy,      '08-10-2016', 'DateTime.mm-dd-yyyy';
+is $dt.dd-mm-yyyy,      '10-08-2016', 'DateTime.dd-mm-yyyy';
+is $dt.yyyy-mm-dd('/'), '2016/08/10', 'DateTime.yyyy-mm-dd with a separator';
+
+# Date still works.
+is Date.new('2015-11-15').yyyy-mm-dd,      '2015-11-15', 'Date.yyyy-mm-dd';
+is Date.new('2015-11-15').dd-mm-yyyy('/'), '15/11/2015', 'Date.dd-mm-yyyy with a separator';
+
+# days-in-year on both types.
+is Date.new('2016-01-02').days-in-year, 366, 'Date.days-in-year (leap)';
+is DateTime.new(:year<2100>, :month<2>).days-in-year, 365, 'DateTime.days-in-year (non-leap)';
+
+# .formatter returns the Callable default or the supplied formatter.
+is Date.new('2015-12-31').formatter.^name, 'Callable', 'default formatter is Callable';
+my $us = sub ($self) { sprintf "%02d/%02d/%04d", .month, .day, .year given $self };
+my $d = Date.new('2015-12-31', formatter => $us);
+is $d.formatter.^name, 'Sub', 'a supplied formatter keeps its type';
+is $d.Str, '12/31/2015', 'the formatter renders the date';


### PR DESCRIPTION
`Type/Dateish.rakudoc` examples crashed on several methods:

- `yyyy-mm-dd` / `mm-dd-yyyy` / `dd-mm-yyyy` existed on Date but not DateTime (0-arg and with a separator argument).
- `days-in-year` was missing on both Date and DateTime.
- `.formatter` was missing (returns the supplied formatter Callable, or the `Callable` default).

Type/Dateish now has zero crashes (was 5). Pin: `t/dateish-methods.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)