### PR TITLE
fix: balance nested `<...>` in an angle-bracket subscript key

### DIFF
--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -1463,13 +1463,37 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
         // subscript, never the `<=`/`<=>` infix (those need surrounding space).
         if rest.starts_with('<') && !rest.starts_with("<<") {
             let r = &rest[1..];
-            let Some(end) = r.find('>') else {
+            // Find the balanced closing `>`, allowing nested `<...>` inside the
+            // key: Rakudo balances angle brackets in an angle-word subscript, so
+            // `%h<a<b>>` has the key `a<b>` and `%EXPORT<&trait_mod:<is>>` the key
+            // `&trait_mod:<is>`. A plain `<foo>` closes at the first `>` as before.
+            let mut depth = 1i32;
+            let mut balanced_end = None;
+            for (i, b) in r.bytes().enumerate() {
+                match b {
+                    b'<' => depth += 1,
+                    b'>' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            balanced_end = Some(i);
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            let Some(end) = balanced_end else {
                 return Err(PError::expected_at("closing '>'", r));
             };
             let content = &r[..end];
+            // A key with a nested (balanced) `<` is a single literal key: it is
+            // not word-split and its characters are not validated as simple key
+            // chars (angle brackets are not otherwise valid key chars).
+            let nested_angle = content.contains('<');
             let keys = split_angle_words(content);
             let is_zen_angle = keys.is_empty();
-            if !is_zen_angle
+            if !nested_angle
+                && !is_zen_angle
                 && keys
                     .iter()
                     .any(|key| key.is_empty() || !key.chars().all(is_angle_key_char))
@@ -1477,7 +1501,9 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                 return Err(PError::expected_at("angle index key", r));
             }
             let r = &r[end + 1..];
-            let index_expr = if keys.len() == 1 {
+            let index_expr = if nested_angle {
+                Expr::Literal(Value::str(content.to_string()))
+            } else if keys.len() == 1 {
                 Expr::Literal(Value::str(keys[0].to_string()))
             } else {
                 Expr::ArrayLiteral(

--- a/t/nested-angle-subscript-key.t
+++ b/t/nested-angle-subscript-key.t
@@ -1,0 +1,45 @@
+use Test;
+
+# An angle-bracket subscript key balances nested `<...>`, so the key is the whole
+# balanced content: `%h<a<b>>` has the key `a<b>` and
+# `%EXPORT<&trait_mod:<is>>` the key `&trait_mod:<is>`. The subscript parser
+# stopped at the first `>`, leaving a stray `>` that broke the expression
+# (Trait::Env: `%EXPORT<&trait_mod:<is>> = &trait_mod:<is>;`).
+
+plan 8;
+
+{
+    my %h;
+    %h<a<b>> = 5;
+    is %h.keys.sort.join(','), 'a<b>', 'a nested-angle key is a single literal key';
+    is %h<a<b>>, 5, 'reading back the nested-angle key works';
+}
+
+{
+    my %EXPORT;
+    %EXPORT<&trait_mod:<is>> = 42;
+    is %EXPORT.keys.sort.join(','), '&trait_mod:<is>',
+        'the Trait::Env key `&trait_mod:<is>` is one key';
+    is %EXPORT<&trait_mod:<is>>, 42, 'reading it back works';
+}
+
+# No regressions on the ordinary subscript-key forms.
+{
+    my %h;
+    %h<foo> = 1;
+    is %h<foo>, 1, 'a plain key still works';
+}
+{
+    my %h;
+    %h<=> = 2;
+    is %h.keys.sort.join(','), '=', 'the `=` key still works';
+}
+{
+    my %h = a => 1, b => 2;
+    is ~%h<a b>, '1 2', 'a multi-word angle slice key still works';
+}
+{
+    my %h;
+    %h<(default)> = 9;
+    is %h.keys.sort.join(','), '(default)', 'a parenthesized key still works';
+}


### PR DESCRIPTION
## Summary

An angle-bracket subscript (`%h<key>`) found its closing `>` with `find('>')`,
which stops at the *first* `>`. A key containing a nested balanced `<...>` — such
as `%h<a<b>>` (key `a<b>`) or `%EXPORT<&trait_mod:<is>>` (key `&trait_mod:<is>`) —
therefore closed early, leaving a stray `>` that broke the enclosing expression
with "angle index key" / "expected '>'".

## Fix

Scan for the balanced closing `>` (counting nested `<`/`>`), and treat a key that
contains a nested `<` as a single literal key (not word-split, and its characters
are not validated as simple key chars, since angle brackets are not otherwise
valid key chars). Plain `<foo>` keys close at the first `>` exactly as before.

## Impact

Unblocks `Trait::Env` parse — `%EXPORT<&trait_mod:<is>> = &trait_mod:<is>;` — which
now reaches the same missing-dependency state (JSON::Tiny) as raku.

Pin: `t/nested-angle-subscript-key.t` (8 subtests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)