### PR TITLE
fix: .match honours the ordinal adverb shortcuts (:1st/:2nd/:Nth)

### DIFF
--- a/src/runtime/methods_match_dispatch.rs
+++ b/src/runtime/methods_match_dispatch.rs
@@ -36,7 +36,10 @@ impl Interpreter {
                         return Err(Self::str_match_x_error("match", value));
                     }
                     repeat_bounds = Self::parse_match_repeat_bounds(value);
-                } else if key == "nth" {
+                } else if key == "nth" || key == "st" || key == "nd" || key == "rd" || key == "th" {
+                    // `:nth(N)` and its ordinal shortcuts `:1st`/`:2nd`/`:3rd`/`:Nth`
+                    // (which parse as `st => 1`, `nd => 2`, `rd => 3`, `th => N`) all
+                    // select the 1-based Nth match.
                     nth_arg = Some(value.clone());
                 }
                 continue;

--- a/t/match-nth-ordinal.t
+++ b/t/match-nth-ordinal.t
@@ -1,0 +1,26 @@
+use Test;
+
+# `.match` accepts the ordinal adverb shortcuts :1st/:2nd/:3rd/:Nth, which
+# parse as `st => 1`, `nd => 2`, `rd => 3`, `th => N` and are equivalent to
+# :nth(N) (see Type/Str.rakudoc match examples).
+
+plan 8;
+
+is "foo[bar][baz]".match(/../, :1st), 'fo', ':1st selects the first match';
+is "foo[bar][baz]".match(/../, :2nd), 'o[', ':2nd selects the second match';
+is "foo[bar][baz]".match(/../, :3rd), 'ba', ':3rd selects the third match';
+is "foo[bar][baz]".match(/../, :4th), 'r]', ':4th selects the fourth match';
+
+# Two-digit ordinal via :th(N)
+is "aaaaaaaaaaaa".match(/a/, :12th), 'a', ':12th selects the twelfth match';
+
+# Equivalence with :nth(N)
+is "foo[bar][baz]".match(/../, :2nd),
+   "foo[bar][baz]".match(/../, :nth(2)),
+   ':2nd matches :nth(2)';
+
+# Out-of-range ordinal yields no match
+is "ab".match(/./, :5th), Nil, 'out-of-range ordinal returns Nil';
+
+# Ordinal shortcut still cooperates with a preceding literal-count position
+is "aXaXaX".match(/a/, :3rd), 'a', ':3rd across separated matches';


### PR DESCRIPTION
## Summary

`.match(/../, :1st)` and its siblings `:2nd`/`:3rd`/`:4th`/`:Nth` parse as the
colonpairs `st => 1`, `nd => 2`, `rd => 3`, `th => N` — the ordinal-adverb sugar
for `:nth(N)`. The match dispatcher only recognised the `nth` key, so every
ordinal shortcut was silently dropped and `.match` returned the first match
regardless of which ordinal was requested.

This mirrors the substitution path (`methods_string.rs`) which already treated
`st`/`nd`/`rd`/`th` as `:nth` aliases.

Found by the doc-diff sweep (`Type/Str.rakudoc:398`).

### Before
```
$ mutsu -e 'say "foo[bar][baz]".match(/../, :2nd); say "foo[bar][baz]".match(/../, :3rd);'
｢fo｣
｢fo｣
```

### After (matches raku)
```
｢o[｣
｢ba｣
```

## Test
- New `t/match-nth-ordinal.t` (8 assertions): each ordinal, a two-digit `:12th`,
  equivalence with `:nth(2)`, out-of-range → Nil, and separated matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)