### PR TITLE
fix: Attribute.required reports the is-required trait state

### DIFF
--- a/src/runtime/methods_classhow_attribute.rs
+++ b/src/runtime/methods_classhow_attribute.rs
@@ -108,6 +108,17 @@ impl Interpreter {
             .collect()
     }
 
+    /// Map an attribute's `is required` state to the value `.required` reports:
+    /// `Mu` (not required), `1` (bare `is required`), or the reason string
+    /// (`is required("reason")`).
+    fn required_meta_value(is_required: &Option<Option<String>>) -> Value {
+        match is_required {
+            None => Value::package(Symbol::intern("Mu")),
+            Some(None) => Value::int(1),
+            Some(Some(reason)) => Value::str(reason.clone()),
+        }
+    }
+
     /// Build an Attribute introspection object for a modelled built-in type
     /// attribute (private `$!name`, no accessor, read-only).
     fn make_builtin_attribute_object(attr_name: &str, type_name: &str, owner: &str) -> Value {
@@ -131,11 +142,12 @@ impl Interpreter {
             Value::package(Symbol::intern(type_name)),
         );
         meta.insert("has_accessor".to_string(), Value::truth(has_accessor));
+        meta.insert("required".to_string(), Value::package(Symbol::intern("Mu")));
         Value::make_instance(Symbol::intern("Attribute"), meta)
     }
 
     fn make_attribute_object(&self, attr: &super::ClassAttributeDef, owner: &str) -> Value {
-        let (ref attr_name, is_public, ref default, is_rw, _, sigil, _) = *attr;
+        let (ref attr_name, is_public, ref default, is_rw, ref is_required, sigil, _) = *attr;
         // A custom trait_mod:<is> was applied to this attribute at class
         // registration: serve the SAME meta-object it mutated (role mixins,
         // values like JSON::Name's `$.json-name`), topped up below with the
@@ -206,6 +218,13 @@ impl Interpreter {
             .and_then(|cd| cd.attribute_built.get(attr_name).copied())
             .unwrap_or(is_public);
         meta.insert("is_built".to_string(), Value::truth(is_built));
+        // `is required` introspection: `.required` returns the type object `Mu`
+        // when not required, `1` for a bare `is required`, and the reason string
+        // for `is required("reason")` (rakudo).
+        meta.insert(
+            "required".to_string(),
+            Self::required_meta_value(is_required),
+        );
         if let Some(default_expr) = default {
             meta.insert("__mutsu_has_build".to_string(), Value::TRUE);
             if let crate::ast::Expr::Literal(v) = default_expr {
@@ -301,6 +320,7 @@ impl Interpreter {
         meta.insert("is_public".to_string(), Value::truth(is_public));
         meta.insert("has_accessor".to_string(), Value::truth(is_public));
         meta.insert("is_built".to_string(), Value::truth(is_public));
+        meta.insert("required".to_string(), Value::package(Symbol::intern("Mu")));
         meta.insert("sigil".to_string(), Value::str(sigil.to_string()));
         meta.insert(
             "type".to_string(),

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -337,6 +337,13 @@ impl Interpreter {
                             .unwrap_or(false);
                         return Ok(Value::truth(!is_rw));
                     }
+                    "required" => {
+                        // `Mu` (not required), `1` (bare `is required`), or the
+                        // reason string (`is required("reason")`).
+                        return Ok(attributes.as_map().get("required").cloned().unwrap_or_else(
+                            || Value::package(crate::symbol::Symbol::intern("Mu")),
+                        ));
+                    }
                     "build" => {
                         if let Some(build_val) = attributes.as_map().get("build") {
                             return Ok(build_val.clone());

--- a/t/attribute-required.t
+++ b/t/attribute-required.t
@@ -1,0 +1,40 @@
+use v6;
+use Test;
+
+plan 10;
+
+# `.required` on an Attribute introspection object reports the `is required`
+# trait state: Mu (not required), 1 (bare `is required`), or the reason string.
+
+# Bare `is required` -> 1 (an Int)
+class Bare { has $.x is required }
+my $bare = Bare.^attributes[0].required;
+is $bare, 1, 'bare is required returns 1';
+ok $bare.Bool, 'bare is required is truthy';
+isa-ok $bare, Int, 'bare is required is an Int';
+
+# Not required -> the type object Mu
+class Plain { has $.x }
+my $plain = Plain.^attributes[0].required;
+nok $plain.defined, 'plain attribute .required is undefined (Mu)';
+nok $plain.Bool, 'plain attribute .required is falsy';
+
+# `is required("reason")` -> the reason string
+class WithReason { has $.x is required("need an x") }
+is WithReason.^attributes[0].required, 'need an x',
+    'is required(reason) returns the reason string';
+
+# A typed required attribute still reports required-ness
+class Typed { has Int $.n is required }
+is Typed.^attributes[0].required, 1, 'typed is required returns 1';
+
+# Required carried through a role
+role R { has $.r is required }
+class Consumer does R {}
+is Consumer.^attributes[0].required, 1, 'role attribute is required survives composition';
+
+# Multiple attributes each report independently
+class Mixed { has $.a is required; has $.b }
+my @req = Mixed.^attributes.map({ .required.defined });
+is @req[0], True, 'first attribute is required';
+is @req[1], False, 'second attribute is not required';


### PR DESCRIPTION
## Summary

`.required` on an `Attribute` introspection object (from `.^attributes`) previously threw `No such method 'required'`. It now matches rakudo:

- not required → the type object `Mu` (undefined, falsy)
- bare `is required` → `1` (an `Int`, truthy)
- `is required("reason")` → the reason string

## Details

The `is required` state (`Option<Option<String>>`) was already carried on each attribute tuple but ignored when `make_attribute_object` built the `Attribute` meta object. This wires it into the meta map (defaulting to `Mu` for built-in and trait-time attribute objects) and adds a `required` arm to the Attribute method dispatch.

Resolves a `Type/Attribute` doc-diff divergence.

## Test

`t/attribute-required.t` — bare / reason / not-required, typed attributes, role composition, and multiple attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)