### PR TITLE
fix: .match coerces a defined non-Regex/non-Str matcher to a literal string

### DIFF
--- a/src/runtime/methods_match_dispatch.rs
+++ b/src/runtime/methods_match_dispatch.rs
@@ -63,14 +63,19 @@ impl Interpreter {
             }
             // An *undefined* matcher (Nil, or a bare type object like `Any`)
             // resolves to no `.match` candidate — Rakudo throws X::Multi::NoMatch
-            // rather than hanging (roast .../multi-no-match.t). A *defined*
-            // non-Regex/non-Str matcher (an Int, a list) still silently yields Nil.
+            // rather than hanging (roast .../multi-no-match.t).
             ValueView::Nil | ValueView::Package(_) => {
                 return Err(super::methods_signature_errors::make_multi_no_match_error(
                     "match",
                 ));
             }
-            _ => return Ok(Value::NIL),
+            // Any other *defined* matcher (an Int, a list, ...) is coerced to its
+            // string form and matched literally: `"1 2 3".match([1,2,3])` matches
+            // `[1,2,3].Str` (= "1 2 3"), and `"x123y".match(123)` matches "123".
+            _ => {
+                let escaped = pattern.to_string_value().replace('\'', "\\'");
+                format!("'{}'", escaped)
+            }
         };
         if global || overlap || exhaustive || repeat_bounds.is_some() || nth_arg.is_some() {
             let all = self.regex_match_all_with_captures(&pat, &text);

--- a/t/match-nonregex-matcher.t
+++ b/t/match-nonregex-matcher.t
@@ -1,0 +1,27 @@
+use Test;
+
+# A defined non-Regex/non-Str matcher passed to `.match` is coerced to its
+# string form and matched literally (see Type/Str.rakudoc):
+#   "1 2 3".match([1,2,3])  matches [1,2,3].Str  == "1 2 3"
+#   "x123y".match(123)      matches "123"
+# An *undefined* matcher (Nil / a bare type object) still throws X::Multi::NoMatch.
+
+plan 8;
+
+is "1 2 3".match([1,2,3]), '1 2 3', 'a list matcher is stringified (space-joined)';
+is "x123y".match(123), '123', 'an Int matcher matches its decimal string';
+is "5".match(5), '5', 'a single-digit Int matcher';
+is "abc".match(97), Nil, 'an Int whose string is absent yields Nil';
+
+# A list is joined with spaces, so a run without the spaces does not match.
+is "123".match([1,2,3]), Nil, 'list matcher keeps the space separators';
+
+# A Rat matcher stringifies too.
+is "pi=3.5!".match(3.5), '3.5', 'a Rat matcher matches its string form';
+
+# The matcher sets $/ like any other match.
+"x123y".match(123);
+is ~$/, '123', 'a coerced literal match still populates $/';
+
+# Undefined matchers remain a multi-dispatch failure.
+dies-ok { "abc".match(Any) }, 'a bare type object matcher dies (X::Multi::NoMatch)';


### PR DESCRIPTION
## Summary

Raku coerces any *defined* matcher that is not a `Regex` or `Str` to its string
form and matches it literally:

```raku
"1 2 3".match([1,2,3])   # ｢1 2 3｣   — matches [1,2,3].Str == "1 2 3"
"x123y".match(123)       # ｢123｣
"5".match(5)             # ｢5｣
```

mutsu's `.match` dispatcher fell through to `Ok(Nil)` for every such matcher, so
all of these returned `Nil`.

This coerces the matcher via `to_string_value()` and matches it as a literal
(reusing the Str arm's quote-escaping). `Nil` and bare type objects (`Any`) still
raise `X::Multi::NoMatch` — only *defined* non-Regex/non-Str values are coerced.

Found by the doc-diff sweep (`Type/Str.rakudoc:398`).

## Test
- New `t/match-nonregex-matcher.t` (8 assertions): list/Int/Rat matchers, the
  space-separator semantics of a list, `$/` population, absent-substring → Nil,
  and that a bare type object still dies.
- `t/multi-no-match-builtins.t` and `t/match-caps.t` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)