### PR TITLE
fix: typed-array .push reports "for an element of @a" on a type error

### DIFF
--- a/src/vm/vm_data_push_ops.rs
+++ b/src/vm/vm_data_push_ops.rs
@@ -200,10 +200,13 @@ impl Interpreter {
             };
             for item in items_to_check {
                 if !self.type_matches_value(&type_name, item) {
-                    return Err(RuntimeError::typecheck_assignment(
+                    // A rejected element push reports "for an element of @a"
+                    // (matching rakudo and the interpreter's other array-mutator
+                    // paths), not the scalar "in assignment to @a" wording.
+                    return Err(crate::runtime::utils::type_check_element_typed_error(
+                        target_name,
                         &type_name,
                         item,
-                        Some(target_name),
                     ));
                 }
             }

--- a/t/typed-array-push-typecheck.t
+++ b/t/typed-array-push-typecheck.t
@@ -1,0 +1,45 @@
+use v6;
+use Test;
+
+plan 9;
+
+# Pushing an element that violates a typed array's element type reports
+# "for an element of @a" (like rakudo and the other array mutators), NOT the
+# scalar "in assignment to @a" wording.
+
+# .push
+{
+    my Int @a;
+    my $ex;
+    { @a.push("x"); CATCH { default { $ex = $_ } } }
+    isa-ok $ex, X::TypeCheck::Assignment, 'push type error is X::TypeCheck::Assignment';
+    is $ex.message, 'Type check failed for an element of @a; expected Int but got Str ("x")',
+        'push message names the element and the offending value';
+    is $ex.got, "x", '.got is the offending value';
+}
+
+# A valid push still works
+{
+    my Int @a;
+    @a.push(5);
+    @a.push(6);
+    is @a, [5, 6], 'valid pushes succeed';
+}
+
+# push matches append/unshift wording (all element mutators agree)
+for <push append unshift prepend> -> $meth {
+    my Int @a;
+    my $ex;
+    { @a."$meth"("x"); CATCH { default { $ex = $_ } } }
+    is $ex.message, 'Type check failed for an element of @a; expected Int but got Str ("x")',
+        "$meth reports the element-of wording";
+}
+
+# A Slip-flattened push type-checks each element
+{
+    my Int @a;
+    my $ex;
+    { @a.push(|(1, "x")); CATCH { default { $ex = $_ } } }
+    is $ex.message, 'Type check failed for an element of @a; expected Int but got Str ("x")',
+        'Slip element push type-checks each element';
+}


### PR DESCRIPTION
## Summary

`my Int @a; @a.push("x")` previously raised the scalar assignment wording:

```
Type check failed in assignment to @a; expected Int, got Str
```

rakudo — and the interpreter's own `append`/`unshift`/`prepend` and typed-hash paths — report:

```
Type check failed for an element of @a; expected Int but got Str ("x")
```

and expose the offending value via `.got`.

## Cause

`.push` on a plain typed array is compiled to the VM-native push op (`vm_data_push_ops.rs`), whose element type-check called the generic `typecheck_assignment` helper (scalar wording). The other array mutators go through `check_container_element_types` / `type_check_element_typed_error`, which already produce the correct element wording.

## Fix

Route the VM push type-check through `type_check_element_typed_error` so the message, exception attributes, and `.got` match rakudo and the other mutator paths. Slip-flattened pushes (`@a.push(|(1, "x"))`) type-check each element the same way.

## Test

`t/typed-array-push-typecheck.t` — message/exception-type/`.got`, valid pushes, agreement across push/append/unshift/prepend, and Slip-element pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)