### PR TITLE
fix: accept a qualified parent name in `also is <parent>`

### DIFF
--- a/src/parser/stmt/class/class_decl.rs
+++ b/src/parser/stmt/class/class_decl.rs
@@ -9,7 +9,7 @@ use crate::parser::expr::expression;
 use crate::parser::helpers::{skip_balanced_parens, ws, ws1};
 use crate::parser::parse_result::{PError, PResult, opt_char, take_while1};
 use crate::parser::stmt::sub::parse_indirect_decl_name;
-use crate::parser::stmt::{block, ident, keyword, qualified_ident};
+use crate::parser::stmt::{block, keyword, qualified_ident};
 
 pub(crate) fn parse_declarator_traits(input: &str) -> PResult<'_, Vec<(String, Value)>> {
     let mut traits = Vec::new();
@@ -454,7 +454,11 @@ pub(crate) fn also_trait_stmt(input: &str) -> PResult<'_, Stmt> {
     }
     let rest = keyword("is", rest).ok_or_else(|| PError::expected("is or does after also"))?;
     let (rest, _) = ws1(rest)?;
-    let (rest, trait_name) = ident(rest)?;
+    // The parent may be a qualified name (`also is X::Config::TOML::DuplicateKeys`),
+    // so read a full `::`-qualified identifier — a bare `ident` would stop at the
+    // first `::`, taking only the first segment as the parent and leaving the rest
+    // as a stray term (Config::TOML / Crane / Node::Ethereum::RLP exception trees).
+    let (rest, trait_name) = qualified_ident(rest)?;
     let (rest, _) = ws(rest)?;
     let (rest, _) = opt_char(rest, ';');
     Ok((

--- a/t/also-is-qualified-parent.t
+++ b/t/also-is-qualified-parent.t
@@ -1,0 +1,42 @@
+use Test;
+
+# `also is <parent>` inside a class body must accept a *qualified* parent name.
+# The `also is` parser read a bare identifier, so it stopped at the first `::` —
+# `also is X::Config::TOML::DuplicateKeys` took just `X` as the parent and left
+# `::…` as a stray term, giving "cannot inherit from 'X' because it is unknown"
+# (Config::TOML, Crane, and other exception hierarchies).
+
+plan 5;
+
+{
+    class X::Base { }
+    class X::Derived { also is X::Base; }
+    ok X::Derived.new ~~ X::Base, 'also is a qualified X::-rooted parent inherits';
+}
+
+{
+    class Foo::Bar::Base { }
+    class Foo::Bar::Deep { also is Foo::Bar::Base; }
+    ok Foo::Bar::Deep.new ~~ Foo::Bar::Base, 'also is a deep qualified parent inherits';
+}
+
+# No regression: a simple (unqualified) parent still works.
+{
+    class Plain { }
+    class Sub { also is Plain; }
+    ok Sub.new ~~ Plain, 'also is an unqualified parent still works';
+}
+
+# No regression: `also is rw` is a class trait, not a parent.
+{
+    class C { has $.x is rw; also is rw; has $.y }
+    my $o = C.new;
+    lives-ok { $o.x = 1; $o.y = 2 }, 'also is rw still applies the rw class trait';
+}
+
+# The inheritance is real: methods are inherited through the qualified parent.
+{
+    class X::WithMethod { method greet { 'hi' } }
+    class X::Child { also is X::WithMethod; }
+    is X::Child.new.greet, 'hi', 'a method is inherited through the qualified parent';
+}


### PR DESCRIPTION
## Summary

`also is <parent>` inside a class body read the parent with a bare `ident`, which
stops at the first `::`. So `also is X::Config::TOML::DuplicateKeys` took only `X`
as the parent and left the rest as a stray term, giving **"cannot inherit from
'X' because it is unknown"** — hitting exception hierarchies that build their tree
with `also is` (Config::TOML, Crane, …).

## Fix

Read a full `::`-qualified identifier for the parent, the same as the inline
`class Foo is Bar::Baz` path already does. `also is rw` and unqualified parents
are unaffected.

## How it was found

First ticket off the new dist-compat test-suite sweep (`--run-tests`): the
"cannot inherit from 'X'" signature clustered 3 dists; this is the shared root
cause for the `also is`-based ones.

Pin: `t/also-is-qualified-parent.t` (5 subtests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)