### PR TITLE
fix: scan an s/// replacement as a qq-string, not a regex

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -31,8 +31,24 @@ _51 open tickets._
 - dists: Needle::Compile, Test::Selector
 - e.g. `Needle::Compile`: Needle::Compile: expected statement: expected expected statement: expected use statement or import statement or no statement or need statement or unit statement
 - e.g. `Test::Selector`: Test::Selector: expected statement: expected expected statement: expected use statement or import statement or no statement or need statement or unit statement 
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
+- repro: `my $s='a'; $s ~~ s:g/ (.) /<[/; say $s` — raku: `<[`, mutsu (before): parse error
+- file: `src/parser/primary/regex/scan.rs` (replacement half scanned as a regex, so `<[` read as a `<[...]>` char class)
+- NOTE: two distinct root causes clustered under one message.
+  - **Test::Selector** (fixed by fix-subst-replacement-literal-angle): the `s///`
+    *replacement* half is a qq-like string, not a regex — `<[`/`]>`/`#`/`'` are
+    literal. `scan_to_delim` (regex mode) mis-scanned them; added
+    `scan_to_delim_replacement`.
+  - **Needle::Compile** is a **separate** case: `anon sub <name>(...)` inside a
+    parenthesized expression (`(&jp = anon sub jp(...) {...})($x)`) fails to parse,
+    while the same without parens / without a name parses. Still open — split out
+    below as T-002b.
+
+### T-002b — parse_error: named `anon sub` inside a parenthesized expression  [impact: 1 dist]
+- dists: Needle::Compile
+- repro: `(anon sub jp($p) { say $p })("hi")` — raku: `Syntax OK`, mutsu: SORRY.
+  `my $x = anon sub jp($p) {...}` (no parens) and `(anon sub ($p) {...})(...)`
+  (no name) both parse; only a *named* `anon sub` in expression context fails.
+- file: _(suspected: `anon sub` term parsing in expression/primary context)_
 
 ### T-003 — runtime_error: No such method X for invocant of type 'X'  [impact: 2 dists]
 - dists: Injector, hyperize

--- a/src/parser/primary/regex/lit.rs
+++ b/src/parser/primary/regex/lit.rs
@@ -24,7 +24,9 @@ use super::adverbs::{
 use super::call_args::{
     has_unescaped_statement_boundary, parse_call_arg_list, parse_colon_method_arg,
 };
-use super::scan::{scan_to_delim, scan_to_delim_p5, scan_to_delim_subst_pattern};
+use super::scan::{
+    scan_to_delim, scan_to_delim_p5, scan_to_delim_replacement, scan_to_delim_subst_pattern,
+};
 use super::subst::{
     build_non_destructive_subst_expr, build_topic_subst_compound_expr, build_topic_subst_expr,
     parse_subst_replacement_expr, try_strip_subst_compound_assign,
@@ -308,8 +310,12 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
                     };
                     let replacement_scan = if is_paired && !r2.starts_with(open_ch) {
                         None
+                    } else if adverbs.perl5 {
+                        // A Perl5 replacement string treats `{`/`<` etc. as literal;
+                        // only `\` escapes and the close delimiter are significant.
+                        scan_to_delim_p5(r2, open_ch, close_ch, is_paired)
                     } else {
-                        scan_to_delim(r2, open_ch, close_ch, is_paired)
+                        scan_to_delim_replacement(r2, open_ch, close_ch, is_paired)
                     };
                     if let Some((replacement, rest)) = replacement_scan {
                         let pattern = if adverbs.perl5 {
@@ -423,8 +429,12 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
                     };
                     let replacement_scan = if is_paired && !r2.starts_with(open_ch) {
                         None
+                    } else if adverbs.perl5 {
+                        // A Perl5 replacement string treats `{`/`<` etc. as literal;
+                        // only `\` escapes and the close delimiter are significant.
+                        scan_to_delim_p5(r2, open_ch, close_ch, is_paired)
                     } else {
-                        scan_to_delim(r2, open_ch, close_ch, is_paired)
+                        scan_to_delim_replacement(r2, open_ch, close_ch, is_paired)
                     };
                     if let Some((replacement, rest)) = replacement_scan {
                         if !is_paired
@@ -612,8 +622,12 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
                     };
                     let replacement_scan = if is_paired && !r2.starts_with(open_ch) {
                         None
+                    } else if adverbs.perl5 {
+                        // A Perl5 replacement string treats `{`/`<` etc. as literal;
+                        // only `\` escapes and the close delimiter are significant.
+                        scan_to_delim_p5(r2, open_ch, close_ch, is_paired)
                     } else {
-                        scan_to_delim(r2, open_ch, close_ch, is_paired)
+                        scan_to_delim_replacement(r2, open_ch, close_ch, is_paired)
                     };
                     if let Some((replacement, rest)) = replacement_scan {
                         if !is_paired

--- a/src/parser/primary/regex/scan.rs
+++ b/src/parser/primary/regex/scan.rs
@@ -36,6 +36,112 @@ pub(in crate::parser) fn scan_to_delim(
     scan_to_delim_inner(input, open_ch, close_ch, is_paired, false, false)
 }
 
+/// Scan the *replacement* half of a substitution (`s/pat/REPL/`).
+///
+/// The replacement is a qq-like string, NOT a regex, so the regex-specific
+/// constructs that `scan_to_delim` recognizes — character classes `<[...]>`,
+/// `<...>` assertions, `<<`/`>>` word boundaries, `#` comments, and bare
+/// single/double-quoted atoms — are all literal text here. Only these affect
+/// where the closing delimiter is found:
+/// - `\` escapes the next char,
+/// - `{...}` interpolated closures skip a balanced (string-aware) brace block,
+/// - `$(...)`/`@(...)` interpolation skips a balanced paren block,
+/// - for paired delimiters, a nested open delimiter raises the depth.
+///
+/// Without this, `s:g/ '[' /<[/` (replacement is the literal text `<[`) would
+/// have `scan_to_delim` treat `<[` as the start of a `<[...]>` character class
+/// and scan past the closing `/`, breaking the whole expression.
+pub(in crate::parser) fn scan_to_delim_replacement(
+    input: &str,
+    open_ch: char,
+    close_ch: char,
+    is_paired: bool,
+) -> Option<(&str, &str)> {
+    let mut depth = 1u32;
+    let mut chars = input.char_indices();
+    while let Some((i, c)) = chars.next() {
+        if c == close_ch {
+            // Skip '.' when it's part of '..' (range operator).
+            if close_ch == '.' && input[i + 1..].starts_with('.') {
+                chars.next();
+                continue;
+            }
+            depth -= 1;
+            if depth == 0 {
+                return Some((&input[..i], &input[i + c.len_utf8()..]));
+            }
+        } else if is_paired && c == open_ch {
+            depth += 1;
+        } else if c == '{' {
+            // Interpolated closure `{ ... }`: skip a balanced brace block so a
+            // delimiter char inside it (including inside a nested string) does
+            // not end the replacement early (e.g. `s/x/{ "a/b" }/`). Only
+            // reached when '{' is not itself the paired delimiter (that case is
+            // handled by the depth bump above).
+            skip_interp_block(&mut chars)?;
+        } else if (c == '$' || c == '@') && input[i + c.len_utf8()..].starts_with('(') {
+            // `$(...)` / `@(...)` interpolation: skip the balanced paren block.
+            chars.next(); // consume '('
+            let mut paren_depth = 1u32;
+            loop {
+                match chars.next() {
+                    Some((_, '(')) => paren_depth += 1,
+                    Some((_, ')')) => {
+                        paren_depth -= 1;
+                        if paren_depth == 0 {
+                            break;
+                        }
+                    }
+                    Some((_, '\\')) => {
+                        chars.next();
+                    }
+                    Some(_) => {}
+                    None => return None,
+                }
+            }
+        } else if c == '\\' {
+            chars.next();
+        }
+    }
+    None
+}
+
+/// Skip a balanced `{ ... }` block, having already consumed the opening `{`.
+/// String literals inside are skipped whole so a `}` within a string does not
+/// close the block early. Returns None if the braces never balance.
+fn skip_interp_block(chars: &mut std::str::CharIndices<'_>) -> Option<()> {
+    let mut brace_depth = 1u32;
+    while let Some((_, ch)) = chars.next() {
+        match ch {
+            '{' => brace_depth += 1,
+            '}' => {
+                brace_depth -= 1;
+                if brace_depth == 0 {
+                    return Some(());
+                }
+            }
+            '\\' => {
+                chars.next();
+            }
+            '\'' | '"' => {
+                let quote = ch;
+                loop {
+                    match chars.next() {
+                        Some((_, '\\')) => {
+                            chars.next();
+                        }
+                        Some((_, c2)) if c2 == quote => break,
+                        Some(_) => {}
+                        None => return None,
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 /// Like `scan_to_delim` but for the *pattern* half of a substitution
 /// (`s/pattern/replacement/`). There the closing delimiter is a mandatory
 /// separator, so a trailing `$` is always the end-of-string anchor — never the

--- a/src/parser/primary/regex/scan.rs
+++ b/src/parser/primary/regex/scan.rs
@@ -99,6 +99,20 @@ pub(in crate::parser) fn scan_to_delim_replacement(
                     None => return None,
                 }
             }
+        } else if c == '$' && !is_paired && input[i + 1..].starts_with(close_ch) {
+            // `$/` — the match variable — followed by the close delimiter. When
+            // it is immediately followed by a postfix `.`/`[`/`<` the delimiter
+            // is part of `$/` (e.g. `$/.chars()`, `$/[0]`, `$/<k>`), not the end
+            // of the replacement, so skip it. Mirrors the same disambiguation in
+            // `scan_to_delim`.
+            let after = &input[i + 1..];
+            let after_delim = &after[close_ch.len_utf8()..];
+            if after_delim.starts_with('[')
+                || after_delim.starts_with('.')
+                || after_delim.starts_with('<')
+            {
+                chars.next(); // skip the delimiter char (it is part of $/)
+            }
         } else if c == '\\' {
             chars.next();
         }

--- a/t/subst-replacement-literal-angle.t
+++ b/t/subst-replacement-literal-angle.t
@@ -1,0 +1,71 @@
+use Test;
+
+# The replacement half of a substitution is a qq-like string, not a regex,
+# so text like `<[`, `]>`, `<`, `#`, and `'` in the replacement is literal —
+# it must NOT be interpreted as a regex character class / assertion / comment.
+# Regression: `s:g/ '[' /<[/` used to fail parsing because the replacement `<[`
+# was scanned as the start of a `<[...]>` character class, consuming past the
+# closing `/`. (Test::Selector builds its glob->regex this way.)
+
+plan 9;
+
+{
+    my $s = 'a';
+    $s ~~ s:g/ (.) /<[/;
+    is $s, '<[', 'replacement `<[` is literal (global)';
+}
+
+{
+    my $s = 'a';
+    $s ~~ s:g/ (.) /]>/;
+    is $s, ']>', 'replacement `]>` is literal (global)';
+}
+
+{
+    my $s = 'a';
+    $s ~~ s/ (.) /<[/;
+    is $s, '<[', 'replacement `<[` is literal (single)';
+}
+
+{
+    my $s = 'a';
+    $s ~~ s/ (.) /</;
+    is $s, '<', 'replacement `<` is literal';
+}
+
+{
+    my $s = 'a';
+    $s ~~ s/ (.) /a#b/;
+    is $s, 'a#b', 'replacement with `#` is literal, not a comment';
+}
+
+{
+    my $s = 'x';
+    $s ~~ s/x/'a'/;
+    is $s, "'a'", 'single quotes in replacement are literal';
+}
+
+# The `{...}` closure form still protects its contents (including a nested
+# string that contains the delimiter), so this must keep working.
+{
+    my $s = 'x';
+    $s ~~ s/x/{ "a/b" }/;
+    is $s, 'a/b', 'closure replacement with delimiter inside a string';
+}
+
+# The exact glob->regex build sequence used by Test::Selector.
+{
+    my $want = 'a*b?c[d]';
+    $want ~~ s:g/ '?' /./;
+    $want ~~ s:g/ '*' /.*?/;
+    $want ~~ s:g/ '[' /<[/;
+    $want ~~ s:g/ ']' /]>/;
+    is $want, 'a.*?b.c<[d]>', 'Test::Selector glob->regex build';
+}
+
+# Non-destructive S/// replacement is likewise a string.
+{
+    my $s = 'a';
+    my $r = S/ (.) /<[/ given $s;
+    is $r, '<[', 'S/// replacement `<[` is literal';
+}


### PR DESCRIPTION
## Problem

The replacement half of a substitution (`s/pat/REPL/`) is a qq-like string, **not** a regex, so text like `<[`, `]>`, `<`, `#`, and `'` in it is literal. The scanner used for both halves (`scan_to_delim`) applied regex-specific handling to the replacement — it treated a leading `<[` as the start of a `<[...]>` character class and scanned past the closing delimiter, breaking the whole expression.

Concretely, `s:g/ '[' /<[/` failed to parse. This is how `Test::Selector` builds its glob→regex matcher, so the module failed to load.

```raku
my $s = 'a'; $s ~~ s:g/ (.) /<[/; say $s;   # raku: <[   mutsu (before): parse error
```

## Fix

Add `scan_to_delim_replacement`, which recognizes only what a qq-string needs to find its closing delimiter:
- `\` escapes,
- `{...}` interpolated closures (balanced, string-aware, so a delimiter char inside a nested string is protected — `s/x/{ "a/b" }/` keeps working),
- `$(...)`/`@(...)` interpolation,
- nested paired delimiters.

The three replacement-scan sites in `lit.rs` route through it; Perl5 replacements keep the plain `scan_to_delim_p5` string scan. Pattern/match scans are untouched.

Verified against raku for `<[`, `]>`, `<`, `#`, `'a'`, the `{...}` closure form, and the full `Test::Selector` glob-build sequence.

Fixes the `Test::Selector` half of dist-compat ticket T-002. (`Needle::Compile`, the other dist clustered under the same generic error message, is a **separate** root cause — named `anon sub` inside a parenthesized expression — split out as T-002b.)

Pin: `t/subst-replacement-literal-angle.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)