### PR TITLE
fix: parse a named `anon sub` in expression context

### DIFF
--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -685,6 +685,37 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                         })?;
                     return Ok((r, params_body));
                 }
+                // `anon sub NAME(...) { ... }` / `anon sub NAME { ... }` — a named
+                // anonymous sub in expression context (e.g. `(&f = anon sub g($x)
+                // {...})($y)`). The name allows self-reference; `anon` means it is
+                // not installed in the enclosing namespace. Mirrors the named-sub
+                // handling in the plain `"sub"` case below.
+                if let Ok((r_named, _name)) = crate::parser::stmt::parse_sub_name_pub(r_sub) {
+                    let (r_named, _) = ws(r_named)?;
+                    if r_named.starts_with('(') {
+                        let (r, params_body) =
+                            parse_anon_sub_with_params(r_named).map_err(|err| PError {
+                                messages: merge_expected_messages(
+                                    "expected anonymous sub parameter list/body",
+                                    &err.messages,
+                                ),
+                                remaining_len: err.remaining_len.or(Some(r_named.len())),
+                                exception: None,
+                            })?;
+                        return Ok((r, params_body));
+                    }
+                    if r_named.starts_with('{') {
+                        let (r, body) = parse_block_body(r_named)?;
+                        return Ok((
+                            r,
+                            Expr::AnonSub {
+                                body,
+                                is_rw: false,
+                                is_block: false,
+                            },
+                        ));
+                    }
+                }
             } else if let Ok((r_type, type_name)) =
                 crate::parser::parse_result::take_while1(r_ws, |c: char| {
                     c.is_alphanumeric() || c == ':' || c == '_'

--- a/t/anon-named-sub-in-expression.t
+++ b/t/anon-named-sub-in-expression.t
@@ -1,0 +1,35 @@
+use Test;
+
+# A *named* `anon sub` in expression context (notably inside parentheses) used
+# to fail to parse: `(anon sub jp($p) { ... })` gave a SORRY, while the same
+# without parentheses (`my $x = anon sub jp($p) {...}`) or without a name
+# (`(anon sub ($p) {...})`) parsed fine. The `anon sub` handler only recognized
+# `anon sub {...}` and `anon sub (...)`, never `anon sub NAME ...`.
+# (Needle::Compile self-installs a JSON::Path stub this way.)
+
+plan 4;
+
+# Parenthesized named anon sub, assigned then called.
+{
+    my $x = (anon sub jp($p) { $p ~ "!" });
+    is $x("hi"), "hi!", "parenthesized named anon sub, scalar binding";
+}
+
+# Directly called named anon sub in parens (no assignment).
+{
+    my $out;
+    (anon sub greet($n) { $out = "hello $n" })("world");
+    is $out, "hello world", "directly-called named anon sub in parens";
+}
+
+# Named anon sub with a typed parameter.
+{
+    my $x = (anon sub jp(Str $p) { "got: $p" });
+    is $x("yo"), "got: yo", "named anon sub with typed param";
+}
+
+# Named anon sub with a block body only (no signature).
+{
+    my $y = anon sub named2 { 42 };
+    is $y(), 42, "named anon sub with block body only";
+}


### PR DESCRIPTION
## Problem

A *named* `anon sub` in expression context — notably inside parentheses — failed to parse:

```raku
(anon sub jp($p) { $p ~ "!" })      # SORRY (before)
my $x = anon sub jp($p) {...}       # OK  (no parens)
(anon sub ($p) {...})               # OK  (no name)
```

The `anon sub` handler in `identifier_call.rs` only recognized `anon sub {...}` and `anon sub (...)`, never a named form. So for `anon sub jp(...)`, `anon` was parsed as a bare word and `sub jp(...)` was left dangling.

## Fix

Add named-sub handling to the `anon sub` branch, mirroring the plain `"sub"` case: after the `sub` keyword, parse an optional name and then `(params)` / `{body}`. The name allows self-reference; `anon` means the sub is not installed in the enclosing namespace.

## Impact

Unblocks the `Needle::Compile` parse — it self-installs a JSON::Path stub via `(&jp = anon sub jp(str $pattern) {...})($pattern)`. The module now parses through to its genuine missing-dependency point (`has-word`), matching raku.

Split out as dist-compat ticket T-002b. (Verified against raku for the parenthesized, directly-called, typed-param, and block-body forms.)

Pin: `t/anon-named-sub-in-expression.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)