### PR TITLE
fix: role public and private same-name methods no longer collide

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -331,8 +331,21 @@ _51 open tickets._
 ### T-051 — test_fail: test basic stuff after initialization  [impact: 1 dist]
 - dists: Hash::Agnostic
 - e.g. `Hash::Agnostic`: base=2 pass=0 fail=2 die=0 | t/01-basic.rakutest: test basic stuff after initialization
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
+- repro: `class MyHash does Hash::Agnostic {...}; my %h is MyHash = @pairs; say %h.^name` — raku: `MyHash`, mutsu: `Hash`
+- NOTE: a "tied hash" feature (`my %h is CustomAssociativeClass`). Decomposes into three
+  independent gaps, each fixable on its own:
+  1. **tied-hash backing** — `my %h is Foo` (Foo `does Associative`) must back the variable
+     with a blessed instance so `.^name`, subscripting (AT-KEY/ASSIGN-KEY), iteration and
+     coercion dispatch to the class. (WIP on branch `tied-hash-associative`: ApplyVarTrait
+     branch in `src/vm/vm_var_trait_ops.rs`; `:=`-bound instances already work.)
+  2. **public/private same-name role methods** — Hash::Agnostic's `method STORE {...self!STORE(...)}`
+     + `method !STORE` collided (private overwrote public in role composition; two-role
+     public+private also mis-flagged X::Role::Composition::Conflict). **Fixed** — see the
+     `fix-public-private-method-name-collision` PR.
+  3. **`:U:`/`:D:` proto+multi role methods** — `.Str`/`.raku` use `multi method Str(::?ROLE:U:)`
+     / `(::?ROLE:D:)`; mutsu renders both signatures identically and reports an ambiguous call.
+- file: `src/vm/vm_var_trait_ops.rs` (backing), `src/runtime/registration_role.rs` +
+  `src/runtime/class.rs` (public/private methods, gap 2), multi-dispatch (gap 3)
 
 ## Claimed
 

--- a/src/runtime/class.rs
+++ b/src/runtime/class.rs
@@ -177,38 +177,47 @@ impl Interpreter {
             if defs.iter().all(|d| d.is_submethod) {
                 continue;
             }
-            // Check non-multi methods
-            let non_multi: Vec<&MethodDef> = defs
-                .iter()
-                .filter(|d| !d.is_multi && !Self::is_stub_routine_body(&d.body))
-                .collect();
-            let class_defined_non_multi = non_multi.iter().any(|d| d.role_origin.is_none());
-            if !class_defined_non_multi {
-                let mut conflicting_roles = Vec::new();
-                let mut seen_origins = Vec::new();
-                for def in &non_multi {
-                    let Some(role_name) = &def.role_origin else {
-                        continue;
-                    };
-                    // Use original_role for diamond detection: if two methods
-                    // trace back to the same original role, they are not in conflict.
-                    let origin = def.original_role.as_ref().unwrap_or(role_name);
-                    if seen_origins.contains(origin) {
-                        continue;
+            // Check non-multi methods. Public and private methods that share a
+            // base name live in separate namespaces (dispatch filters on privacy),
+            // so a public `foo` from one role and a private `!foo` from another do
+            // NOT conflict — check each privacy class independently.
+            for is_private in [false, true] {
+                let non_multi: Vec<&MethodDef> = defs
+                    .iter()
+                    .filter(|d| {
+                        !d.is_multi
+                            && d.is_private == is_private
+                            && !Self::is_stub_routine_body(&d.body)
+                    })
+                    .collect();
+                let class_defined_non_multi = non_multi.iter().any(|d| d.role_origin.is_none());
+                if !class_defined_non_multi {
+                    let mut conflicting_roles = Vec::new();
+                    let mut seen_origins = Vec::new();
+                    for def in &non_multi {
+                        let Some(role_name) = &def.role_origin else {
+                            continue;
+                        };
+                        // Use original_role for diamond detection: if two methods
+                        // trace back to the same original role, they are not in conflict.
+                        let origin = def.original_role.as_ref().unwrap_or(role_name);
+                        if seen_origins.contains(origin) {
+                            continue;
+                        }
+                        seen_origins.push(origin.clone());
+                        if !conflicting_roles.contains(role_name) {
+                            conflicting_roles.push(role_name.clone());
+                        }
                     }
-                    seen_origins.push(origin.clone());
-                    if !conflicting_roles.contains(role_name) {
-                        conflicting_roles.push(role_name.clone());
+                    if conflicting_roles.len() > 1 {
+                        conflicting_roles.reverse();
+                        return Err(RuntimeError::new(format!(
+                            "X::Role::Composition::Conflict: Method '{}' must be resolved by class {} because it exists in multiple roles ({})",
+                            method_name,
+                            class_name,
+                            conflicting_roles.join(", "),
+                        )));
                     }
-                }
-                if conflicting_roles.len() > 1 {
-                    conflicting_roles.reverse();
-                    return Err(RuntimeError::new(format!(
-                        "X::Role::Composition::Conflict: Method '{}' must be resolved by class {} because it exists in multiple roles ({})",
-                        method_name,
-                        class_name,
-                        conflicting_roles.join(", "),
-                    )));
                 }
             }
 

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -938,9 +938,18 @@ impl Interpreter {
                                 .or_default()
                                 .push(def);
                         } else {
-                            role_def
+                            // A public `method STORE` and a private `method !STORE`
+                            // share the base name but are distinct methods (dispatch
+                            // filters by is_private). Preserve any existing entry of
+                            // the opposite privacy instead of overwriting it; only a
+                            // genuine same-privacy redeclaration replaces the prior
+                            // non-multi def.
+                            let entry = role_def
                                 .methods
-                                .insert(resolved_method_name.clone(), vec![def]);
+                                .entry(resolved_method_name.clone())
+                                .or_default();
+                            entry.retain(|d| d.is_private != def.is_private || d.is_multi);
+                            entry.push(def);
                         }
                     }
                     // `handles` on a role method: synthesize forwarder methods.

--- a/t/role-public-private-same-name-method.t
+++ b/t/role-public-private-same-name-method.t
@@ -1,0 +1,65 @@
+use v6;
+use Test;
+
+plan 7;
+
+# A role may declare a public method and a private method that share the same
+# base name (e.g. `method STORE` + `method !STORE`). They live in separate
+# namespaces (dispatch filters on privacy), so composing the role must keep
+# both — the private one must not overwrite the public one (or vice versa).
+# Regression: Hash::Agnostic's `method STORE { ...; self!STORE(...) }` pattern.
+{
+    role R {
+        method STORE(*@v) { self!STORE(@v) }
+        method !STORE(@v) { "priv:" ~ @v.elems }
+    }
+    class C does R { }
+
+    is C.^methods.map(*.name).sort.join(","), "STORE",
+        'public STORE survives composition alongside private !STORE';
+    is C.new.STORE(1, 2, 3), "priv:3",
+        'public STORE dispatches and can call the private !STORE';
+}
+
+# The same for `append` / `!append` (Hash::Agnostic's other pair).
+{
+    role R2 {
+        method append(+@v) { self!append(@v) }
+        method !append(@v) { "app:" ~ @v.elems }
+    }
+    class C2 does R2 { }
+    is C2.new.append(1, 2), "app:2",
+        'public append dispatches to private !append from a role';
+}
+
+# Two roles, one contributing the public and the other the private, both under
+# the same base name.
+{
+    role Pub { method foo() { self!foo() ~ "-pub" } }
+    role Priv { method !foo() { "priv" } }
+    class D does Pub does Priv { }
+    is D.new.foo, "priv-pub", 'public and private same-name from two roles coexist';
+}
+
+# A plain (non-role) class still supports the same pattern.
+{
+    class E {
+        method bar(*@v) { self!bar(@v) }
+        method !bar(@v) { "ebar:" ~ @v.elems }
+    }
+    is E.new.bar(9, 9, 9, 9), "ebar:4",
+        'public and private same-name in a plain class coexist';
+}
+
+# A genuine same-privacy redeclaration inside a class is still an error.
+{
+    dies-ok { EVAL 'class F { method g() {1}; method g() {2} }' },
+        'redeclaring a public non-multi method is still rejected';
+}
+
+# A role method that is only public still composes normally (no regression).
+{
+    role G { method only() { "only" } }
+    class H does G { }
+    is H.new.only, "only", 'a role with only a public method still composes';
+}


### PR DESCRIPTION
## Summary

A role that declares both a public `method foo` and a private `method !foo` (same base name) previously lost one of them.

```raku
role R {
    method STORE(*@v)  { self!STORE(@v) }
    method !STORE(@v)  { "priv:" ~ @v.elems }
}
class C does R { }
say C.^methods.map(*.name);   # was ()  -> now (STORE)
say C.new.STORE(1, 2, 3);     # was "No such method 'STORE'"  -> now "priv:3"
```

Root cause: role composition keyed both methods by the **base name** and the private def overwrote the public one via a plain `insert`, so the public method vanished (`.^methods` dropped it, calls failed with *No such method*). Separately, two roles contributing a public `foo` and a private `!foo` were wrongly rejected as `X::Role::Composition::Conflict` (raku: no conflict — they are distinct methods).

## Fix

Public and private methods live in separate namespaces (dispatch already filters on `is_private`), so:

- **`src/runtime/registration_role.rs`** — non-multi role method registration now preserves an existing entry of the *opposite* privacy instead of overwriting it (only a same-privacy redeclaration replaces). This matches the class-declaration path, which already did exactly this.
- **`src/runtime/class.rs`** — the role-composition conflict check now runs once per privacy class, so a public and a private same-base-name method from different roles no longer collide.

## Context

This is the `method STORE { …; self!STORE(…) }` + `method !STORE` pattern from **Hash::Agnostic** (and its `append`/`!append` twin) — gap 2 of dist ticket T-051 (see `TODO_dist/TICKETS.md`). The class-declaration path already handled this; only role composition was affected.

## Tests

New `t/role-public-private-same-name-method.t` (7 assertions): public survives alongside private, dispatch to private from public, two-role split, plain-class parity, genuine redeclaration still errors, public-only role still composes. No regressions across the role/method/composition/private test suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)