### PR TITLE
fix: a mutated dynamic var in a start block honours its live dynamic binding

### DIFF
--- a/src/vm/vm_closure_dispatch.rs
+++ b/src/vm/vm_closure_dispatch.rs
@@ -231,7 +231,22 @@ impl Interpreter {
         // don't-overwrite default would otherwise hide this closure's own cell.
         for (k, v) in data.env.iter() {
             if matches!(v.view(), ValueView::ContainerRef(_)) {
-                self.env_mut().insert_sym(*k, v.clone());
+                // A captured `ContainerRef` cell normally OVERWRITES the caller's
+                // stale value (it is the single source of truth for that lexical).
+                // But a *dynamic* variable (`$*x`) is dynamic-scope: its live value
+                // is whatever the current dynamic frame set (e.g. `indir` binds
+                // `$*CWD` for its block), NOT the cell the escaping closure captured
+                // from its creator. Overwriting here clobbers that dynamic binding
+                // (indir.t: `start indir :!d, $p, { ...; $*CWD = 42 }` read the
+                // creator's `my $*CWD` instead of the indir-set path). Dynamics are
+                // already excluded from `authoritative_free_vars` below for the same
+                // reason; do the same for the box-on-capture cell — don't overwrite,
+                // so the live dynamic binding stands.
+                if k.with_str(|s| s.trim_start_matches(['$', '@', '%', '&']).starts_with('*')) {
+                    self.env_mut().entry_or_insert_sym(*k, v.clone());
+                } else {
+                    self.env_mut().insert_sym(*k, v.clone());
+                }
             } else {
                 self.env_mut().entry_or_insert_sym(*k, v.clone());
             }

--- a/t/start-dynamic-var-indir.t
+++ b/t/start-dynamic-var-indir.t
@@ -1,0 +1,60 @@
+use Test;
+
+# A `start` block escapes its creating frame, so lexicals it captures AND
+# mutates are boxed into shared ContainerRef cells. A *dynamic* variable
+# (`$*x`) must NOT be treated that way: it is dynamic-scope, so its live value
+# inside the thread is whatever the current dynamic frame set (e.g. `indir`
+# binds `$*CWD` for its block), not the cell captured from the creator.
+#
+# Regression: `start indir $dir, { my $r = $*CWD.basename ne $want; $*CWD = 42; $r }`
+# read the creator's outer `my $*CWD` instead of the indir-set path, because
+# the captured ContainerRef cell overwrote the indir binding when the closure
+# entered (roast S32-io/indir.t test 75, "failures due to race conditions").
+# Only manifested when the block *assigned* to `$*CWD`.
+
+plan 3;
+
+# Core repro without any filesystem dependency: a dynamic override set inside
+# the thread must be read live, even when the block also assigns to the var.
+{
+    my $inner = 'expected';
+    my int $failures;
+    $failures += [+] await flat ^200 .map: {
+        my $*VAR = $_;
+        my $prom = start {
+            my $*VAR = $inner;          # dynamic override for this frame
+            my $res = $*VAR ne $inner;  # should be False: read the override
+            $*VAR = 'clobber';          # the assignment that used to break the read
+            $res
+        }
+        $failures++ unless $*VAR eq $_;
+        $prom
+    }
+    is $failures, 0, 'dynamic override in a mutating start block is read live';
+}
+
+# indir specifically. Use a directory that actually exists so `indir` succeeds
+# regardless of CWD, then confirm the thread reads the indir-bound $*CWD (not
+# the outer `my $*CWD`) even though the block assigns to $*CWD.
+{
+    my $dir = $*TMPDIR.absolute;
+    my $want = $*TMPDIR.basename;
+    my $*CWD = 'sentinel-outer';
+    my int $failures;
+    $failures += [+] await flat ^200 .map: {
+        start indir $dir, {
+            my $res = $*CWD.basename ne $want;   # False: read the indir path
+            $*CWD = 'clobber';
+            $res
+        }
+    }
+    is $failures, 0, 'start+indir reads the indir-bound $*CWD despite the assignment';
+}
+
+# The outer dynamic var is unaffected after the thread completes.
+{
+    my $dir = $*TMPDIR.absolute;
+    my $*CWD = 'sentinel-outer';
+    await start indir $dir, { $*CWD = 'clobber' };
+    is $*CWD, 'sentinel-outer', 'the outer $*CWD is unchanged by the thread';
+}


### PR DESCRIPTION
## Summary

A `start` block escapes its creating frame, so a lexical it captures **and
mutates** is boxed into a shared `ContainerRef` cell that OVERWRITES the
caller's value when the closure enters (the cell is the single source of truth
for that lexical). A **dynamic** variable (`$*x`) must be exempt: it is
dynamic-scope, so its live value inside the thread is whatever the current
dynamic frame set — e.g. `indir` binds `$*CWD` for the duration of its block —
not the cell the closure captured from its creator.

Concretely:

```raku
my $*CWD = 7;
await start indir :!d, 'foo'.IO, {
    my $r = $*CWD !~~ 'foo'.IO;   # was True (read the outer 7), should be False
    $*CWD = 42;                    # <-- this assignment is what promoted $*CWD to a cell
    $r
}
```

The read compiles to a by-name dynamic `GetGlobal`; without the `$*CWD = 42`
assignment it already resolved correctly. The assignment promotes `$*CWD` to a
captured cell, and that cell clobbered `indir`'s dynamic binding on closure
entry.

Dynamics are already excluded from `authoritative_free_vars` for exactly this
reason; this extends the same exemption to the box-on-capture `ContainerRef`
merge in `install_closure_captured_env` — a captured cell keyed by a
dynamic-twigil name uses the don't-overwrite (`entry_or_insert`) path so the
live dynamic binding stands.

## Impact

Fixes the intermittent failure of **roast `S32-io/indir.t` test 75** ("failures
due to race conditions"), which is deterministic once the escaping `start`
closure promotes `$*CWD` to a cell (100% reproducible locally; intermittent in
CI depending on thread scheduling — it took down an unrelated docs PR's CI).

## Test
- New `t/start-dynamic-var-indir.t` (3 assertions, stable across runs): the
  roast test-75 shape, the `indir` case, and outer-var-unchanged.
- `make test` — all 20351 tests pass.
- Closure-capture canary `roast/S12-construction/roles-6e.t` still passes.
- `roast/S32-io/indir.t` release build: 5/5 PASS (was 5/5 FAIL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)