### PR TITLE
fix: for-slice inside `do given` no longer corrupts the topic array

### DIFF
--- a/src/vm/vm_given_when_ops.rs
+++ b/src/vm/vm_given_when_ops.rs
@@ -188,6 +188,27 @@ impl Interpreter {
 
         let saved_topic = self.env().get("_").cloned();
         let saved_when = self.when_matched();
+        // Consume the topic's `TagContainerRef` signal (emitted right before this
+        // op by `do given @c`). It must NOT survive into the body: a nested
+        // `for @c[$slice] { }` — whose slice iterable emits no source tag of its
+        // own — would otherwise pick up this stale `container_ref_var` and write
+        // its loop values back into `@c` at the wrong (0-based) indices, shifting
+        // the array (`do given @l { for @l[1..2] -> $e {} }` corrupted `@l`).
+        // Whole-container topic writeback is not done by the expression form
+        // (in-place `$_[0]=…`/`.push` propagate through the shared container), so
+        // dropping the signal is sufficient; it only scopes topic-source tags to
+        // the body and is restored afterwards.
+        let saved_container_ref = self.container_ref_var.take();
+        let saved_topic_source = self.topic_source_var.take();
+        let saved_container_source = self.topic_container_source.take();
+        if let Some((src, _)) = &saved_container_ref
+            && self.element_source.is_none()
+        {
+            self.topic_source_var = Some(src.clone());
+            if src.starts_with('@') || src.starts_with('%') {
+                self.topic_container_source = Some(src.clone());
+            }
+        }
         self.env_mut().insert("_".to_string(), topic);
         loan_env!(self, set_when_matched(false));
 
@@ -218,6 +239,8 @@ impl Interpreter {
                 } else {
                     self.env_mut().remove("_");
                 }
+                self.topic_source_var = saved_topic_source;
+                self.topic_container_source = saved_container_source;
                 return Err(e);
             }
         }
@@ -228,6 +251,8 @@ impl Interpreter {
         } else {
             self.env_mut().remove("_");
         }
+        self.topic_source_var = saved_topic_source;
+        self.topic_container_source = saved_container_source;
         self.stack.push(last);
         *ip = end;
         Ok(())

--- a/t/do-given-for-slice-no-writeback.t
+++ b/t/do-given-for-slice-no-writeback.t
@@ -1,0 +1,58 @@
+use v6;
+use Test;
+
+plan 8;
+
+# A `for @c[$slice]` loop inside a `do given @c { ... }` expression must NOT
+# write its (read-only) loop values back into @c. Regression: the `do given`
+# topic's container tag leaked into the nested for-loop, which — having no
+# source tag of its own — used it as a writeback target and shifted @c by the
+# slice offset ([A,B,C,D] -> [B,C,C,D]). Root cause of CLDR::List's list
+# formatter producing "B, B, C, D" instead of "A, B, C, D".
+
+sub slice-range(*@list) { do given @list { for @list[1..2] -> $e { }; @list[0] } }
+is slice-range('A'..'D'), 'A', 'do-given + for @list[range] leaves @list[0] intact';
+
+sub slice-comma(*@list) { do given @list { for @list[1,2] -> $e { }; @list.join(',') } }
+is slice-comma(<A B C D>), 'A,B,C,D', 'do-given + for @list[1,2] does not shift @list';
+
+sub slice-whatever(*@list) { do given @list { for @list[1..*-3] -> $e { }; @list.join(',') } }
+is slice-whatever(<A B C D>), 'A,B,C,D', 'do-given + for @list[1..*-3] does not shift @list';
+
+sub nested-when(*@list) {
+    do given @list {
+        when * {
+            for @list[1..*-3] -> $e { }
+            @list[0];
+        }
+    }
+}
+is nested-when('A'..'D'), 'A', 'do-given/when + for-slice keeps @list[0]';
+
+# The full CLDR::List-style list join must produce the right first element.
+my @placeholders = <{0} {1}>;
+sub format(*@list) {
+    do given @list {
+        when * {
+            my $format = @list[*-2] ~ ', ' ~ @list[*-1];
+            for @list[1..*-3] -> $element { $format = $element ~ ', ' ~ $format }
+            @list[0] ~ ', ' ~ $format;
+        }
+    }
+}
+is format('A'..'D'), 'A, B, C, D', 'CLDR-style 4-element list formats correctly';
+
+# A two-iteration middle loop (5 elements) must not corrupt the source array.
+sub keeps-array(*@list) {
+    do given @list { for @list[1..*-3] -> $e { } }
+    @list.join(',');
+}
+is keeps-array('A'..'E'), 'A,B,C,D,E', 'two-iteration for-slice does not corrupt @list';
+
+# In-place topic mutation inside `do given` must still propagate to the source
+# (this was not affected by the fix, but guard against regressing it).
+sub elem-assign(@l) { do given @l { $_[0] = 'Z' }; @l.join(',') }
+is elem-assign(['A','B','C']), 'Z,B,C', 'do-given $_[0] = X still propagates';
+
+sub topic-push(@l) { do given @l { .push('X') }; @l.join(',') }
+is topic-push(['A','B','C']), 'A,B,C,X', 'do-given .push still propagates';


### PR DESCRIPTION
## Summary

A `for @c[$slice] { ... }` loop nested inside a `do given @c { ... }` **expression** shifted `@c` by the slice offset:

```raku
my @l = <A B C D>;
do given @l { for @l[1..2] -> $e { } }
say @l;    # was ["B", "C", "C", "D"]  -> now ["A", "B", "C", "D"]
```

## Root cause

`do given @c` compiles to a `TagContainerRef` for the topic followed by `DoGivenExpr`. The statement form (`exec_given_op`) `take()`s that `container_ref_var` signal at entry, but the expression form (`exec_do_given_expr_op`) never did — it just ran the body. The stale signal leaked into the nested for-loop, whose slice iterable `@l[1..2]` emits **no source tag of its own** (`for_iterable_source_name` returns `None` for an `Index`). The loop's read-only named-param writeback (`for @m -> $row { … }` aliases the source element) then treated `@l` as its writeback target and wrote the loop values back at **0-based** indices, shifting the array.

## Fix

`exec_do_given_expr_op` now consumes the container tag at entry — scoping the topic-source tags (`topic_source_var` / `topic_container_source`) to the body and restoring them afterwards — exactly as the statement `given` already does. In-place topic mutation (`$_[0] = X`, `.push`) still propagates, because that goes through the shared container value, not this signal.

## Context

Root cause of **CLDR::List**'s list formatter emitting `"B, B, C, D"` instead of `"A, B, C, D"` (dist ticket **T-050**). Its `t/format.rakutest` now passes **16/16**. The module's `format` does exactly `do given @list { … for @list[1..*-3] -> $element { … } … @list[0] … }`.

## Tests

New `t/do-given-for-slice-no-writeback.t` (8 assertions): range/comma/whatever slices, `when`-nested, CLDR-style formatting, two-iteration loop integrity, plus guards that in-place `$_[0]=X` / `.push` topic mutation still propagate. No regressions in the given/when/for/topic/loop suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)