### PR TITLE
fix: interpolate twigilled attribute arrays/hashes in strings

### DIFF
--- a/src/parser/primary/string/interp_var.rs
+++ b/src/parser/primary/string/interp_var.rs
@@ -38,6 +38,33 @@ pub(crate) fn split_top_level_commas(content: &str) -> Vec<&str> {
     parts
 }
 
+/// After an `@`/`%` sigil, split off the variable name, allowing an optional
+/// attribute twigil (`!` or `.`) which is kept as a name prefix — matching the
+/// non-interpolated parse where `@!attr`/`@.attr` become `ArrayVar("!attr")` /
+/// `ArrayVar(".attr")`. Returns `(twigil_prefixed_name, rest_after_name)`, or
+/// `None` when what follows the sigil is not a (possibly twigilled) identifier.
+///
+/// Without this, `"@!pre.join(".")"` failed to interpolate the private-attribute
+/// array (and, with a nested `"..."` method argument, the un-recognized
+/// interpolation let the inner quote close the outer string, crashing the parse).
+fn split_interp_var_name(var_rest: &str) -> Option<(&str, &str)> {
+    let twigil_len = if matches!(var_rest.as_bytes().first(), Some(b'!') | Some(b'.'))
+        && var_rest[1..].starts_with(|c: char| c.is_alphabetic() || c == '_')
+    {
+        1
+    } else if var_rest.starts_with(|c: char| c.is_alphabetic() || c == '_') {
+        0
+    } else {
+        return None;
+    };
+    let body = &var_rest[twigil_len..];
+    let end = body
+        .find(|c: char| !c.is_alphanumeric() && c != '_' && c != '-')
+        .unwrap_or(body.len());
+    let total = twigil_len + end;
+    Some((&var_rest[..total], &var_rest[total..]))
+}
+
 /// Try to interpolate a `$var` or `@var` at the current position.
 /// Returns `Some(remaining_input)` if interpolation was performed, `None` otherwise.
 pub(crate) fn try_interpolate_var<'a>(
@@ -420,14 +447,8 @@ pub(crate) fn try_interpolate_var<'a>(
                 after_brace
             });
         }
-        if next.is_alphabetic() || next == '_' {
-            let var_rest = &rest[1..];
-            let end = var_rest
-                .find(|c: char| !c.is_alphanumeric() && c != '_' && c != '-')
-                .unwrap_or(var_rest.len());
-            let name = &var_rest[..end];
+        if let Some((name, after_name)) = split_interp_var_name(&rest[1..]) {
             let expr = Expr::ArrayVar(name.to_string());
-            let after_name = &var_rest[end..];
             let mut remainder = after_name;
             // Zen-slice interpolation: "@arr[]" and "@arr.[]" should interpolate the array value
             let mut consumed = false;
@@ -461,14 +482,8 @@ pub(crate) fn try_interpolate_var<'a>(
         {
             return Some(result);
         }
-        if next.is_alphabetic() || next == '_' {
-            let var_rest = &rest[1..];
-            let end = var_rest
-                .find(|c: char| !c.is_alphanumeric() && c != '_' && c != '-')
-                .unwrap_or(var_rest.len());
-            let name = &var_rest[..end];
+        if let Some((name, tail)) = split_interp_var_name(&rest[1..]) {
             let expr = Expr::HashVar(name.to_string());
-            let tail = &var_rest[end..];
             // Zen-slice: %hash{} should stringify the whole hash
             if let Some(r) = tail.strip_prefix("{}") {
                 if !current.is_empty() {

--- a/t/interp-attribute-array-hash-method.t
+++ b/t/interp-attribute-array-hash-method.t
@@ -1,0 +1,43 @@
+use Test;
+
+# A private/accessor attribute array or hash with a method call must
+# interpolate inside a double-quoted string, exactly like a lexical `@var` /
+# `%hash`. Previously `"@!attr.method(...)"` was not recognized as an
+# interpolation: the twigilled sigil (`@!`, `@.`, `%!`, `%.`) fell through the
+# interpolation scanner, so the value was left literal — and when the method
+# had a nested double-quoted argument (`.join(".")`), the inner quote closed the
+# outer string and crashed the parse. (Version::Semver.Str builds its output
+# with `"@!pre-release.join(".")"`.)
+
+plan 8;
+
+class V {
+    has @.pre = <a b>;
+    has @.build = <x y>;
+    has %.opts = (k => 1);
+
+    method with-double-quote(V:D:)  { "-@!pre.join(".")" }
+    method with-single-quote(V:D:)  { "-@!pre.join('.')" }
+    method no-nested-quote(V:D:)    { "n=@!pre.elems()" }
+    method accessor-twigil(V:D:)    { "-@.build.join("-")" }
+    method hash-private(V:D:)       { "k=%!opts.keys.join(",")" }
+    method combined(V:D:) {
+        "@!pre.join(".")" ~ ("+@!build.join(".")" if @!build)
+    }
+}
+
+my $v = V.new;
+is $v.with-double-quote, "-a.b", 'private array attr, nested double quotes';
+is $v.with-single-quote, "-a.b", 'private array attr, nested single quotes';
+is $v.no-nested-quote,   "n=2", 'private array attr method, no nested quote';
+is $v.accessor-twigil,   "-x-y", 'accessor-twigil array attr interpolates';
+is $v.hash-private,      "k=k", 'private hash attr interpolates';
+is $v.combined,          "a.b+x.y", 'concat with paren-modified attr interp';
+
+# Lexical arrays/hashes still interpolate as before (no regression).
+{
+    my @a = <p q>;
+    is "@a.join("/")", "p/q", 'lexical array method interp still works';
+    my %h = (z => 9);
+    is "%h.keys.join(",")", "z", 'lexical hash method interp still works';
+}


### PR DESCRIPTION
A private/accessor attribute array or hash (`@!attr`, `@.attr`, `%!attr`, `%.attr`) was not recognized as an interpolation in a qq-string: the `@`/`%` interpolation scanner only accepted a name starting with an alphabetic/`_` char, so a twigil (`!`/`.`) right after the sigil fell through and the value stayed literal. Worse, when the interpolated method had a nested double-quoted argument — `"@!pre.join(".")"` — the un-recognized interpolation let the inner `"` close the outer string, crashing the parse.

Add `split_interp_var_name`, which accepts an optional leading `!`/`.` twigil and keeps it as a name prefix — matching the non-interpolated parse where `@!attr` becomes `ArrayVar("!attr")`. Route both the `@` and `%` interpolation branches through it. Scalars (`$!attr`) already worked.

Unblocks Version::Semver (its `.Str` builds `"@!pre-release.join(".")"`); the module now parses and loads, matching raku. Ticket T-013.

Pin: `t/interp-attribute-array-hash-method.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)