### PR TITLE
fix: user/list `skip` no longer loses to Test's `skip` after `plan`

### DIFF
--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -816,9 +816,7 @@ impl Interpreter {
                 // List skip signature: (Int $n, @list)
                 // Key distinction: Test::skip's first arg is always a Str.
                 if self.test_mode_active() {
-                    let is_list_skip = args.len() >= 2
-                        && matches!(args[0].view(), ValueView::Int(..) | ValueView::Num(..));
-                    if is_list_skip {
+                    if Self::skip_call_is_list_skip(&args) {
                         self.builtin_skip(&args)
                     } else {
                         self.test_fn_skip(&args)
@@ -1054,6 +1052,40 @@ impl Interpreter {
 
     /// Builtin `skip(N, list)` function — skips N elements from the list.
     /// This is only called when the args look like a list-skip (not Test::skip).
+    /// Disambiguate the `skip` name between Test's `skip($reason?, $count = 1)`
+    /// (a TAP skip directive) and the core list routine `skip(Int $n, *@list)`.
+    /// Test's skip takes a Str reason (or nothing) first and never a list
+    /// operand, so a non-Str count first arg and/or a positional list operand
+    /// means the list routine was intended — e.g. `skip(4, @a)`, `skip(*-4, @a)`
+    /// (head-skip-tail, which exports its own `&skip`). Shared by the three
+    /// `skip` dispatch sites (builtins.rs, test_functions/mod.rs,
+    /// vm_native_test.rs) so they agree.
+    pub(crate) fn skip_call_is_list_skip(args: &[Value]) -> bool {
+        if args.len() < 2 {
+            return false;
+        }
+        let numeric_or_whatever_first =
+            matches!(args[0].view(), ValueView::Int(..) | ValueView::Num(..))
+                || Self::is_whatever_code_value(&args[0]);
+        let list_operand = args[1..].iter().any(|a| {
+            matches!(
+                a.view(),
+                ValueView::Array(..)
+                    | ValueView::Seq(..)
+                    | ValueView::HyperSeq(..)
+                    | ValueView::RaceSeq(..)
+                    | ValueView::Slip(..)
+                    | ValueView::LazyList(..)
+                    | ValueView::Range(..)
+                    | ValueView::RangeExcl(..)
+                    | ValueView::RangeExclStart(..)
+                    | ValueView::RangeExclBoth(..)
+                    | ValueView::GenericRange { .. }
+            )
+        });
+        numeric_or_whatever_first || list_operand
+    }
+
     pub(crate) fn builtin_skip(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         if args.len() < 2 {
             return Err(RuntimeError::new("Too few positionals passed to 'skip'"));

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -62,7 +62,7 @@ impl Interpreter {
     /// variant (`:nth(1..3)`).
     /// Is `value` a `WhateverCode` (e.g. `*-1`)? Those carry a
     /// `__mutsu_callable_type` marker in their captured environment.
-    fn is_whatever_code_value(value: &Value) -> bool {
+    pub(crate) fn is_whatever_code_value(value: &Value) -> bool {
         matches!(
             value.view(),
             ValueView::Sub(data)

--- a/src/runtime/test_functions/mod.rs
+++ b/src/runtime/test_functions/mod.rs
@@ -219,6 +219,14 @@ impl Interpreter {
             "isnt" => self.test_fn_isnt(args).map(Some),
             "plan" => self.test_fn_plan(args).map(Some),
             "done-testing" => self.test_fn_done_testing().map(Some),
+            // `skip` collides with the core list routine `skip(Int $n, *@list)`.
+            // When the call looks like list-skip (see `skip_call_is_list_skip`),
+            // dispatch the list-skip builtin instead of the TAP skip directive.
+            // This path (interpreter `exec_call`) runs before user-sub resolution,
+            // so it must apply the same disambiguation the other skip sites do —
+            // otherwise a module exporting its own `&skip` (head-skip-tail) is
+            // shadowed by Test's skip once `plan` activates test mode.
+            "skip" if Self::skip_call_is_list_skip(args) => self.builtin_skip(args).map(Some),
             "skip" => self.test_fn_skip(args).map(Some),
             "skip-rest" => self.test_fn_skip_rest(args).map(Some),
             "bail-out" => self.test_fn_bail_out(args).map(Some),

--- a/src/vm/vm_native_test.rs
+++ b/src/vm/vm_native_test.rs
@@ -54,19 +54,11 @@ impl Interpreter {
         // diagnostics report the right source line.
         let (clean_args, callsite_line) = self.sanitize_call_args(args);
         // `skip` collides with the core list routine `skip(Int $n, *@list)`.
-        // Test's `skip($reason?, $count = 1)` always takes a Str (or no) first
-        // arg, so a numeric first arg followed by a list operand means the core
-        // routine was intended (a file may selectively import Test without
-        // `&skip`). Decline here and let the normal `call_function` path apply
-        // the same disambiguation (builtins.rs `"skip"` arm) and dispatch the
-        // list-skip builtin.
-        if name == "skip"
-            && clean_args.len() >= 2
-            && matches!(
-                clean_args[0].view(),
-                ValueView::Int(..) | ValueView::Num(..)
-            )
-        {
+        // When the call looks like list-skip (see `skip_call_is_list_skip`),
+        // decline here and let the normal `call_function` path dispatch the
+        // list-skip builtin (a file may selectively import Test without `&skip`,
+        // or a module may export its own `&skip`).
+        if name == "skip" && Self::skip_call_is_list_skip(&clean_args) {
             return None;
         }
         loan_env!(self, set_pending_callsite_line(callsite_line));

--- a/t/skip-user-multi-shadows-test.t
+++ b/t/skip-user-multi-shadows-test.t
@@ -1,0 +1,36 @@
+use v6;
+use Test;
+
+# A user-imported list `skip` (e.g. from the head-skip-tail dist, which defines
+# `my proto sub skip(Mu, |) {*}` + `my multi sub skip($n, +values)`) must win
+# over Test's TAP `skip` directive once `plan` activates test mode. The
+# interpreter's `exec_call` runs `call_test_function` before user-sub
+# resolution, so the skip name needs the same list-vs-Test disambiguation there
+# that the other dispatch sites already apply. Regression: the multi user `skip`
+# was shadowed by Test's `skip`, which emitted "# SKIP N" and returned Nil.
+
+my proto sub skip(Mu, |) {*}
+my multi sub skip($skip, +values) { values.skip($skip) }
+
+plan 5;
+
+my @a = ^10;
+
+# Numeric first arg.
+is-deeply skip(4, @a), (4, 5, 6, 7, 8, 9), 'skip(Int, @list) uses the list routine, not Test::skip';
+
+# WhateverCode first arg (`*-4`).
+is-deeply skip(*-4, @a), (6, 7, 8, 9), 'skip(WhateverCode, @list) uses the list routine';
+
+# A Range operand (list-like second arg) is also list-skip.
+is-deeply skip(2, 1..5), (3, 4, 5), 'skip(Int, Range) uses the list routine';
+
+# Test's own skip directive (Str reason) is unaffected — it still emits a TAP
+# SKIP for the given count.
+subtest 'Test::skip directive still works' => {
+    plan 3;
+    ok 1, 'a real test';
+    skip 'deliberately skipped', 2;
+}
+
+pass 'reached the end without the skip routine consuming tests';


### PR DESCRIPTION
## Summary

`skip` is both Test's TAP directive (`skip($reason?, $count = 1)`) and the core list routine (`skip(Int $n, *@list)`). Once `plan` activated test mode, `skip(4, @a)` / `skip(*-4, @a)` routed to **Test's** skip — emitting `# SKIP N` and returning `Nil` — even when a module exported its own list `skip`:

```raku
my proto sub skip(Mu, |) {*}
my multi sub skip($skip, +values) { values.skip($skip) }
plan 1;
my @a = ^10;
is-deeply skip(4, @a), (4,5,6,7,8,9), 'skip';   # was "ok 1 - # SKIP 4" then Nil
```

## Root cause

The interpreter's `exec_call` runs `call_test_function` **before** user-sub resolution, and its `skip` arm handled the name unconditionally — unlike `builtins.rs` and `vm_native_test.rs`, which already disambiguate list-skip from Test-skip. A plain `sub skip` was unaffected (resolved + OTF-compiled before `exec_call`); only proto/multi shadows fell through to the Test path.

## Fix

Factor the list-vs-Test heuristic into `skip_call_is_list_skip` and apply it at all three dispatch sites. The shared heuristic also now recognizes a `WhateverCode` count (`*-4`) and a positional list operand (Array/Seq/Range/…), so `skip(*-4, @a)` and `skip(2, 1..5)` disambiguate too. Test's `skip("reason", $count)` (Str first arg, no list operand) is unchanged and still emits TAP `# SKIP` directives.

## Context

Dist ticket **T-047** (head-skip-tail — "provide sub versions of .head|skip|tail"). Its `t/01-basic.rakutest` now passes **6/6**.

## Tests

New `t/skip-user-multi-shadows-test.t` (5 assertions): Int/WhateverCode/Range list-skip forms win over Test, and Test's own skip directive still works. No regressions across the skip/test/subtest suites or the roast S24 skip tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)