### PR TITLE
fix: interpolate quoted words in postcircumfix «»/<<>> hash subscripts

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -71,6 +71,14 @@ doc) are version skew, not mutsu bugs — lowest priority.
   (`'FF.DD'.parse-base(16)` → `255.86328125`); it now rounds to Rakudo's digit budget
   (`255.863281`) — **#5063**. Big Rats/FatRats are left on the old exact-expansion path
   pending a `BigFatRat` variant (see "FatRat-vs-Rat repr tag" under Deferred).
+- `hashmap.rakudoc` [2] — the postcircumfix guillemet/double-angle subscript
+  (`%h«oranges "$fruit"»`, `%h<<oranges "$fruit">>`) did not interpolate: it kept
+  `"$fruit"` (quotes and all) as a literal key. The subscript path used a naive
+  whitespace splitter (`angle_words_index_expr`, bare-`$name`-only) instead of the
+  qqww word-splitter that a standalone `«...»` term uses; it now shares
+  `split_quotish_words` via `angle_words_subscript_index_expr`, so quoted words and
+  full sigil interpolation work and the single-word-scalar / multi-word-slice
+  distinction is preserved. Pin: `t/angle-subscript-interpolation.t`.
 
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -496,31 +496,6 @@ fn postfix_expr_inner(input: &str, allow_ws_dot: bool) -> PResult<'_, Expr> {
     postfix_expr_loop(rest, expr, allow_ws_dot)
 }
 
-/// Build the index expression for an interpolating angle subscript (`«...»` / `<<...>>`).
-/// Each whitespace-separated word is interpolated: a bare `$name` reads that variable,
-/// anything else is a literal string key. A single word yields a scalar key; multiple
-/// words yield a slice (matching Rakudo's `%h<<$a b>>` semantics).
-fn angle_words_index_expr(content: &str) -> Expr {
-    fn word_expr(word: &str) -> Expr {
-        if let Some(name) = word.strip_prefix('$')
-            && !name.is_empty()
-            && name
-                .chars()
-                .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
-        {
-            Expr::Var(name.to_string())
-        } else {
-            Expr::Literal(Value::str(word.to_string()))
-        }
-    }
-    let words = split_angle_words(content);
-    if words.len() == 1 {
-        word_expr(words[0])
-    } else {
-        Expr::ArrayLiteral(words.iter().map(|w| word_expr(w)).collect())
-    }
-}
-
 fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PResult<'_, Expr> {
     loop {
         // Allow whitespace before dotty postfix call in expression context:
@@ -1562,7 +1537,9 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                 let r = &r[end + '\u{00BB}'.len_utf8()..];
                 expr = Expr::Index {
                     target: Box::new(expr),
-                    index: Box::new(angle_words_index_expr(content)),
+                    index: Box::new(crate::parser::primary::angle_words_subscript_index_expr(
+                        content,
+                    )),
                     is_positional: false,
                 };
                 rest = r;
@@ -1581,7 +1558,9 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                 let r = &r[end + 2..];
                 expr = Expr::Index {
                     target: Box::new(expr),
-                    index: Box::new(angle_words_index_expr(content)),
+                    index: Box::new(crate::parser::primary::angle_words_subscript_index_expr(
+                        content,
+                    )),
                     is_positional: false,
                 };
                 rest = r;

--- a/src/parser/primary/container.rs
+++ b/src/parser/primary/container.rs
@@ -20,6 +20,7 @@ mod paren;
 mod sigil_context;
 
 // pub(super) re-exports — visible within crate::parser::primary and its submodules
+pub(crate) use angle_words::angle_words_subscript_index_expr;
 pub(super) use angle_words::{
     angle_list, double_angle_list, find_nested_angle_close_pub, french_quote_list,
 };

--- a/src/parser/primary/container/angle_words.rs
+++ b/src/parser/primary/container/angle_words.rs
@@ -206,6 +206,19 @@ fn find_nested_angle_close(input: &str) -> Option<usize> {
     None
 }
 
+/// Build the index expression for an interpolating angle subscript (`%h«...»` /
+/// `%h<<...>>`), reusing the qqww word-splitter so quoted words (`"$x"`, `'lit'`)
+/// and sigil interpolation (`$x`, `@a[]`, `%h{}`) behave exactly as in a standalone
+/// `«...»` term. A single word yields a scalar key; multiple words yield a slice
+/// (matching Rakudo's `%h«a b»` semantics). Falls back to a plain literal key if the
+/// content cannot be tokenised as quote-words.
+pub(crate) fn angle_words_subscript_index_expr(content: &str) -> Expr {
+    match split_quotish_words(content) {
+        Ok(exprs) => crate::parser::primary::string::make_word_result_expr(exprs),
+        Err(_) => Expr::Literal(crate::value::Value::str(content.to_string())),
+    }
+}
+
 fn split_quotish_words(content: &str) -> Result<Vec<Expr>, PError> {
     let mut words = Vec::new();
     let mut rest = content;

--- a/src/parser/primary/mod.rs
+++ b/src/parser/primary/mod.rs
@@ -1,6 +1,7 @@
 mod container;
 // Re-exported so other parser subtrees (e.g. crate::parser::expr postfix
 // parsing) can build the same X::Comp::FailGoal for unterminated brackets.
+pub(crate) use container::angle_words_subscript_index_expr;
 pub(crate) use container::fail_goal_error_at;
 pub(crate) use container::try_parse_sequence_arg_list;
 pub(in crate::parser) mod ident;

--- a/t/angle-subscript-interpolation.t
+++ b/t/angle-subscript-interpolation.t
@@ -1,0 +1,36 @@
+use v6;
+use Test;
+
+# A postcircumfix guillemet / double-angle subscript (`%h«...»`, `%h<<...>>`) is an
+# interpolating quote-word list (qqww semantics). Quoted words and sigil variables
+# inside the subscript must interpolate exactly as in a standalone `«...»` term.
+# Regression: `%h«oranges "$fruit"»` used to keep `"$fruit"` literal (doc-diff
+# hashmap.rakudoc [2]).
+
+plan 10;
+
+my %h = oranges => 'round', bananas => 'bendy', '1' => 'one';
+my $fruit = 'bananas';
+
+# Bare variable interpolation.
+is-deeply %h«oranges $fruit».List, ('round', 'bendy'), 'bare $var in « » subscript';
+is-deeply %h<<oranges $fruit>>.List, ('round', 'bendy'), 'bare $var in << >> subscript';
+
+# Double-quoted interpolating word.
+is-deeply %h«oranges "$fruit"».List, ('round', 'bendy'), 'quoted "$var" in « » subscript';
+is-deeply %h<<oranges "$fruit">>.List, ('round', 'bendy'), 'quoted "$var" in << >> subscript';
+
+# Single-word subscript stays scalar (not a one-element list).
+is %h«oranges», 'round', 'single word « » subscript is scalar';
+is %h<<oranges>>, 'round', 'single word << >> subscript is scalar';
+is %h«$fruit», 'bendy', 'single interpolated word « » subscript is scalar';
+
+# Numeric-looking keys work (allomorphic qqww, stringified for hash lookup).
+is %h«1», 'one', 'numeric word « » subscript';
+
+# Plain non-interpolating literal words still work.
+is-deeply %h«oranges bananas».List, ('round', 'bendy'), 'plain multi-word « » slice';
+
+# Non-interpolating <...> keeps literal $-text (no interpolation).
+my %g = '$fruit' => 'literal';
+is %g<$fruit>, 'literal', 'plain < > subscript does not interpolate';


### PR DESCRIPTION
## Summary

A postcircumfix guillemet/double-angle subscript (`%h«...»`, `%h<<...>>`) is an interpolating quote-word list (qqww semantics), but the parser built its index expression with a naive whitespace splitter (`angle_words_index_expr`) that only interpolated a bare `$name` and kept everything else — including double-quoted words like `"$fruit"` — as a literal key.

So `%h«oranges "$fruit"»` looked up the literal key `"$fruit"` (quotes and all) instead of the interpolated value:

```
my %h = oranges => 'round', bananas => 'bendy';
my $fruit = 'bananas';
say %h«oranges "$fruit"»;   # raku: (round bendy) ; mutsu before: (round (Any))
```

This is doc-diff finding `hashmap.rakudoc` [2].

## Fix

Route the subscript content through the same `split_quotish_words` machinery that a standalone `«...»` term already uses, via a new `angle_words_subscript_index_expr`. Quoted words and full sigil interpolation (`$x`, `@a[]`, `%h{}`) now interpolate, and the single-word-scalar / multi-word-slice distinction is preserved through `make_word_result_expr`. Both the guillemet (`«»`) and ASCII (`<<>>`) forms are covered.

## Tests

- New: `t/angle-subscript-interpolation.t` (verified green against reference `raku` too).
- `make test` passes; existing angle/subscript prove tests unaffected.
- Re-swept `hashmap.rakudoc`: mismatch 4 → 3, match 15 → 16 (the `«...»` interpolation finding is gone; the remaining 3 are the deferred junction-key / allomorph-key items and hash-iteration-order noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)