### PR TITLE
fix: user `infix:<->` must not swallow the `-` of a pointy arrow

### DIFF
--- a/src/parser/stmt/simple/user_ops.rs
+++ b/src/parser/stmt/simple/user_ops.rs
@@ -179,6 +179,33 @@ pub(crate) fn match_user_declared_infix_symbol_op(input: &str) -> Option<(String
                     continue;
                 }
                 let consumed = op.len();
+                // A single-character symbol op must not be matched when it is
+                // actually the prefix of a longer *reserved* token: the pointy /
+                // return arrow (`->`, `-->`), auto-increment/decrement (`++`,
+                // `--`), or a compound assignment (`-=`, `+=`, ...). The core
+                // operator parsers (e.g. `parse_additive_op`) apply the same
+                // guards; without them here a user `infix:<->` would make the `-`
+                // in a `for @a -> $x { }` pointy block parse as subtraction and
+                // then choke on the stray `>`.
+                if op.len() == 1 {
+                    let after = &input[consumed..];
+                    let c0 = op.as_bytes()[0];
+                    // pointy / return arrow: `->` / `-->`
+                    if c0 == b'-' && after.starts_with('>') {
+                        continue;
+                    }
+                    // doubled auto-increment / decrement: `++` / `--`
+                    if (c0 == b'+' || c0 == b'-') && after.as_bytes().first() == Some(&c0) {
+                        continue;
+                    }
+                    // compound assignment `op=` (but not `op==` / `op=>`)
+                    if after.starts_with('=')
+                        && !after.starts_with("==")
+                        && !after.starts_with("=>")
+                    {
+                        continue;
+                    }
+                }
                 // For word-like operators, require identifier boundary.
                 if op
                     .as_bytes()

--- a/t/user-infix-minus-vs-pointy-arrow.t
+++ b/t/user-infix-minus-vs-pointy-arrow.t
@@ -1,0 +1,52 @@
+use Test;
+
+plan 8;
+
+# A user-declared `infix:<->` (which registers `-` as a user infix symbol) must
+# NOT make the parser treat the `-` in a `->` pointy-block arrow as subtraction.
+# Regression: `multi infix:<->(...)` earlier broke a later `for @a -> $x { }` in
+# the same lexical scope with "expected expression after infix operator".
+{
+    multi infix:<->(Str:D $a, Str:D $b) is export { $a ~ $b }
+
+    # The custom infix still works...
+    is ("ab" - "cd"), 'abcd', 'user infix:<-> applies to declared types';
+    # ...and the built-in Int subtraction is unaffected.
+    is (10 - 3), 7, 'built-in Int subtraction still works alongside a user infix:<->';
+
+    # A pointy block after the user infix:<-> parses as a lambda, not `- >`.
+    my @out;
+    for 1, 2, 3 -> $x { @out.push: $x * 2 }
+    is @out, [2, 4, 6], 'for ... -> $x block parses after a user infix:<->';
+
+    my $sq = -> $n { $n * $n };
+    is $sq(5), 25, 'bare pointy lambda parses after a user infix:<->';
+
+    # Return arrow `-->` still works too.
+    my sub twice($n --> Int) { $n * 2 }
+    is twice(6), 12, 'return arrow --> parses after a user infix:<->';
+}
+
+# Auto-decrement / compound-assign are not swallowed by a user infix:<->.
+{
+    multi infix:<->(Str:D $a, Str:D $b) is export { $a ~ $b }
+    my $i = 5;
+    $i--;
+    is $i, 4, 'post-decrement -- parses after a user infix:<->';
+    my $j = 10;
+    $j -= 3;
+    is $j, 7, 'compound assignment -= parses after a user infix:<->';
+}
+
+# A method body with a pointy loop after operator overloads (the IP::Addr shape).
+{
+    my class C {
+        multi infix:<->(C:D $a, Int:D $b) is export { $a }
+        method items(--> List) {
+            my @list;
+            for 1, 2, 3 -> $ip { @list.push: $ip }
+            @list;
+        }
+    }
+    is C.items, [1, 2, 3], 'class method pointy loop parses after infix:<-> overload';
+}


### PR DESCRIPTION
A user-declared `multi infix:<->(...)` registers `-` as a user infix symbol. `match_user_declared_infix_symbol_op` then matched that `-` against the `-` of a `->` pointy-block arrow (`for @a -> $x { }`, `-> $n {...}`, `--> Ret`), consuming the `-` and choking on the stray `>` with *"expected expression after infix operator"*.

The core operator parsers (`parse_additive_op`) already guard `-` against `->`/`--`/`-=`; the user-infix matcher did not.

Add the same guards to the symbol-op matcher: a single-character symbol op is not matched when it is actually the prefix of a longer reserved token — the pointy/return arrow (`->`, `-->`), a doubled increment/decrement (`++`, `--`), or a compound assignment (`op=`, excluding `op==`/`op=>`). The custom infix still applies to real operator uses (`"a" - "b"` → the overload), and built-in subtraction is unaffected.

## Repro

```raku
multi infix:<->(Str:D $a, Str:D $b) is export { $a ~ $b }
for 1, 2, 3 -> $x { say $x }   # before: SORRY, "expected expression after infix operator"
```

Unblocks the IP::Addr parse (ticket T-015): its class defines `multi infix:<->` and later iterates with `for self.each -> $ip { ... }`. (IP::Addr has a further, unrelated runtime blocker — a cross-role private-method call — so it does not fully load yet.)

Pin: `t/user-infix-minus-vs-pointy-arrow.t` (8 tests). roast S06-operator-overloading + S04 pointy blocks green (254 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)