### PR TITLE
fix: a handled exception no longer lingers in $! after the try

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -79,6 +79,15 @@ doc) are version skew, not mutsu bugs — lowest priority.
   `split_quotish_words` via `angle_words_subscript_index_expr`, so quoted words and
   full sigil interpolation work and the single-word-scalar / multi-word-slice
   distinction is preserved. Pin: `t/angle-subscript-interpolation.t`.
+- `perl-var.rakudoc` [2] (partial) — a CATCH that *handled* an exception (matching
+  `when`/`default`, or `.resume`) wrongly left the handled exception in `$!` outside
+  the `try`. Per Raku, `$!` is only updated when the exception propagates out
+  unhandled; a handled `try` keeps `$!`'s pre-`try` value. Fixed in the try/catch VM
+  op (restore the prior `$!` on the handled paths). Pin:
+  `t/dollar-bang-handled-exception.t`. NB: the doc line still shows a residual
+  `$!.^name` mismatch (`Any` vs `Nil`) because the *cleared* `$!` is `Value::NIL`,
+  which reports `Any` — that is the deferred Nil-vs-Any identity knot below, not this
+  fix.
 
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are

--- a/src/vm/vm_try_catch_ops.rs
+++ b/src/vm/vm_try_catch_ops.rs
@@ -357,6 +357,13 @@ impl Interpreter {
                     Value::make_instance(Symbol::intern("X::AdHoc"), exc_attrs)
                 };
                 let saved_topic = self.env().get("_").cloned();
+                // Per Raku semantics `$!` is only *updated* to the exception when it
+                // propagates out of the `try` unhandled (swallowed by the implicit
+                // trap). A CATCH that handles the exception (a matching
+                // `when`/`default`, or `.resume`) leaves `$!` at whatever it held
+                // before the `try`. Remember that prior value so the handled paths
+                // below can restore it.
+                let prior_bang = self.env().get("!").cloned();
                 self.env_mut().insert("!".to_string(), err_val.clone());
                 self.env_mut().insert("_".to_string(), err_val);
                 let saved_when = self.when_matched();
@@ -382,6 +389,11 @@ impl Interpreter {
                             } else {
                                 self.env_mut().remove("_");
                             }
+                            // A resumed exception is handled: restore `$!` to its
+                            // pre-`try` value so the resumed body and the code after
+                            // the `try` see the prior `$!`, not the handled exception.
+                            self.env_mut()
+                                .insert("!".to_string(), prior_bang.unwrap_or(Value::NIL));
                             // Resume from the instruction after die
                             if let Some(resume_point) = self.take_resume_ip_for(code) {
                                 // Run from the resume point to the end of the try body
@@ -404,6 +416,14 @@ impl Interpreter {
                     self.env_mut().insert("_".to_string(), v);
                 } else {
                     self.env_mut().remove("_");
+                }
+                // A handled exception (a matching `when`/`default`) leaves `$!` at
+                // its pre-`try` value. When nothing matched, `$!` keeps the
+                // exception: an explicit CATCH re-throws (below), and an implicit
+                // `try` trap swallows it with the exception left in `$!`.
+                if when_handled {
+                    self.env_mut()
+                        .insert("!".to_string(), prior_bang.unwrap_or(Value::NIL));
                 }
                 // If there's an explicit CATCH block but no `when`/`default`
                 // matched, re-throw the exception (Raku semantics).

--- a/t/dollar-bang-handled-exception.t
+++ b/t/dollar-bang-handled-exception.t
@@ -1,0 +1,38 @@
+use v6;
+use Test;
+
+# `$!` is only *updated* to an exception when it propagates out of a `try`
+# unhandled (swallowed by the implicit trap). When a CATCH block handles the
+# exception — a matching `when`/`default`, or `.resume` — `$!` keeps whatever it
+# held before the `try`. Regression: mutsu used to leave the handled exception in
+# `$!` (doc-diff perl-var.rakudoc [2]).
+
+plan 7;
+
+# Handled by a matching `default` leaves the prior $! untouched.
+try { die "PRIOR" };
+is $!.message, 'PRIOR', 'unhandled exception is stored in $!';
+try { die "H"; CATCH { default { } } };
+is $!.message, 'PRIOR', 'a handled (default) exception keeps the prior $!';
+
+# An unhandled exception swallowed by a later try overwrites $!.
+try { die "NEXT" };
+is $!.message, 'NEXT', 'a later unhandled exception overwrites $!';
+
+# `.resume` handles the exception: prior $! is kept.
+$! = Nil;
+try { die "SEED" };
+is $!.message, 'SEED', 'seed $! with an unhandled exception';
+try { fail "R"; CATCH { default { .resume } } };
+is $!.message, 'SEED', 'a resumed exception keeps the prior $!';
+
+# Handling clears the *definedness* view: after a handled try starting from a
+# cleared $!, $! is undefined again.
+$! = Nil;
+try { die "X"; CATCH { default { } } };
+nok $!.defined, 'handled from a cleared $! leaves $! undefined';
+
+# Successful try resets $! (does not preserve a prior exception).
+try { die "OLD" };
+try { my $ok = 1 };
+nok $!.defined, 'a successful try resets $!';


### PR DESCRIPTION
## Summary

Per Raku semantics, `$!` is only *updated* to an exception when it propagates out of a `try` **unhandled** (swallowed by the implicit trap). When a CATCH block **handles** the exception — a matching `when`/`default`, or `.resume` — `$!` keeps whatever value it held before the `try`. mutsu instead left the handled exception in `$!`:

```raku
try { die "PRIOR" };                    # $! = X::AdHoc(PRIOR)
try { die "H"; CATCH { default { } } }; # handled
say $!.message;                         # raku: PRIOR ; mutsu before: H
```

## Fix

The try/catch VM op (`vm_try_catch_ops.rs`) set `$!` to the thrown exception before running the CATCH block and never restored it on the handled paths. Remember the pre-`try` `$!` and restore it when the exception is handled (a matching `when`/`default`, or a `.resume`). The unhandled-but-swallowed path (an implicit `try` with no matching CATCH) still leaves the exception in `$!`, and a re-throwing explicit CATCH still propagates.

Verified against reference `raku` with a full truth table (unhandled-from-nil / set-prior / handled-keeps-prior / unhandled-overwrites / resume-keeps-prior).

## Context

This is the substance of doc-diff `perl-var.rakudoc` [2]. The doc line still shows a residual `$!.^name` `Any`-vs-`Nil` mismatch on the *cleared* `$!` (`Value::NIL` reports `Any`) — that is the separate, deferred Nil-vs-Any identity knot, not this fix.

## Tests

- New: `t/dollar-bang-handled-exception.t` (green against reference `raku` too).
- `make test` passes; all `t/*catch*`, `t/*exception*`, and whitelisted `S04-exceptions` roast tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)