### PR TITLE
fix: parse the `:ver:<...>` use-selector form (colon before the angle value)

### DIFF
--- a/src/parser/stmt/decl/use_decl.rs
+++ b/src/parser/stmt/decl/use_decl.rs
@@ -99,7 +99,13 @@ pub(in crate::parser::stmt) fn use_stmt(input: &str) -> PResult<'_, Stmt> {
                 // treating the name as an import tag (which produced `no such tag
                 // 'ver'` / `'auth'`).
                 let is_dist_selector = matches!(tag_name.as_str(), "ver" | "auth" | "api");
-                if is_dist_selector && r.starts_with('<') {
+                if is_dist_selector && (r.starts_with('<') || r.starts_with(":<")) {
+                    // Accept both the plain `:ver<0.0.5>` form and the
+                    // colon-separated `:ver:<0.0.5>` form (used by some lizmat
+                    // dists, e.g. `use Acme::Cow:ver:<0.0.5>:auth<zef:lizmat>`);
+                    // the `:` between the selector key and its angle value is
+                    // optional. Normalize both to the plain `:key<value>` form.
+                    let r = r.strip_prefix(':').unwrap_or(r);
                     let (value, after) = match r[1..].find('>') {
                         Some(end) => (&r[1..end + 1], &r[end + 2..]),
                         None => return Err(PError::expected("closing '>' in version adverb")),

--- a/t/use-colon-ver-selector.t
+++ b/t/use-colon-ver-selector.t
@@ -1,0 +1,33 @@
+use Test;
+
+plan 4;
+
+# `use Foo:ver:<0.0.5>` — the version/auth/api selector may be written with a
+# colon before its angle value (`:ver:<...>`), not just `:ver<...>`. Some lizmat
+# dists (e.g. Acme::Cow) use this form. Both must parse; the `:<...>` colon is
+# optional. We assert by round-tripping through EVAL: a genuine parse error would
+# throw, a successful parse of a `use` on a missing module throws a *load* error
+# (X::CompUnit / "Could not find"), never a parse error.
+
+sub parse-ok(Str $code) {
+    my $err = '';
+    try {
+        EVAL $code;
+        CATCH { default { $err = .Str } }
+    }
+    # A parse failure surfaces as X::Syntax / "Undeclared routine"; a load
+    # failure ("Could not find") means the `use` parsed fine.
+    $err eq '' || $err.contains('Could not find') || $err.contains('CompUnit');
+}
+
+ok parse-ok('use NoSuchModule::ForTest:ver:<0.0.5>:auth<zef:lizmat>;'),
+    'use Foo:ver:<0.0.5>:auth<...> parses (colon before angle value)';
+
+ok parse-ok('use NoSuchModule::ForTest:ver<0.0.5>:auth<zef:lizmat>;'),
+    'use Foo:ver<0.0.5>:auth<...> still parses (plain form)';
+
+ok parse-ok('use NoSuchModule::ForTest:auth:<zef:lizmat>;'),
+    'use Foo:auth:<...> parses (colon before angle value)';
+
+ok parse-ok('use NoSuchModule::ForTest:ver:<0.0.5>;'),
+    'use Foo:ver:<0.0.5> parses (single selector)';


### PR DESCRIPTION
`use Foo:ver:<0.0.5>:auth<zef:lizmat>` — where the version/auth/api selector is
written with a colon before its angle value (`:ver:<...>` rather than the plain
`:ver<...>`) — failed to parse: the `use` adverb loop only recognized the plain
`:key<value>` form, so `ver` was taken as an import tag and the trailing
`:<0.0.5>...` was mis-read as an expression, yielding
`X::Undeclared::Symbols: Undeclared routine: Foo:ver`.

Accept an optional `:` between the selector key and its `<...>` value and
normalize both forms to the canonical `:key<value>`. Raku parses the colon form
in use-name position; several lizmat dists use it.

Unblocks Acme::Cow / Acme::Cow::Example (ticket T-007), which do
`use Acme::Cow:ver:<0.0.5>:auth<zef:lizmat>`; both modules load now.

Pin: `t/use-colon-ver-selector.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)