### PR TITLE
fix: a Junction hash-initializer key threads over its members

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -88,6 +88,14 @@ doc) are version skew, not mutsu bugs — lowest priority.
   `$!.^name` mismatch (`Any` vs `Nil`) because the *cleared* `$!` is `Value::NIL`,
   which reports `Any` — that is the deferred Nil-vs-Any identity knot below, not this
   fix.
+- `hashmap.rakudoc` [1] — a Junction used as a hash-initializer key
+  (`%( "a"|"b" => 1 )`) was stored under its stringification (`any(a, b)`) as a
+  single literal key instead of threading. Per Rakudo a Junction key stores the
+  value under each of its members (`%h<a> == %h<b> == 1`). Added `hash_pair_keys`
+  (expands a Junction key to its members, else the key itself) and routed every
+  hash-initializer `ValuePair` arm through it (`build_hash_from_items`,
+  `coerce_to_hash`, `MakeHashFromPairs`), covering `%( )`, plain list assignment,
+  and single-pair assignment. Pin: `t/hash-junction-key.t`.
 
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are

--- a/src/runtime/utils/coerce_containers.rs
+++ b/src/runtime/utils/coerce_containers.rs
@@ -1,5 +1,16 @@
 use super::*;
 
+/// The concrete key(s) a hash-initializer pair stores its value under. A Junction
+/// key threads over its members (`"a"|"b" => 1` stores 1 under both `a` and `b`,
+/// per Rakudo); every other key is itself.
+pub(crate) fn hash_pair_keys(key: &Value) -> Vec<Value> {
+    if let ValueView::Junction { values, .. } = key.view() {
+        values.iter().cloned().collect()
+    } else {
+        vec![key.clone()]
+    }
+}
+
 pub(crate) fn coerce_to_hash(value: Value) -> Value {
     let mix_weight_value = crate::value::mix_weight_to_value;
     let value = value.into_descalarized();
@@ -32,11 +43,14 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
                     map.insert(k.clone(), v.deref_container());
                     i += 1;
                 } else if let ValueView::ValuePair(k, v) = flat[i].view() {
-                    let str_key = k.to_string_value();
-                    if !matches!(k.view(), ValueView::Str(_)) {
-                        original_keys.insert(str_key.clone(), k.clone());
+                    let dv = v.deref_container();
+                    for kk in hash_pair_keys(k) {
+                        let str_key = kk.to_string_value();
+                        if !matches!(kk.view(), ValueView::Str(_)) {
+                            original_keys.insert(str_key.clone(), kk.clone());
+                        }
+                        map.insert(str_key, dv.clone());
                     }
-                    map.insert(str_key, v.deref_container());
                     i += 1;
                 } else {
                     let key_val = &flat[i];
@@ -66,7 +80,10 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
                     map.insert(k.clone(), v.deref_container());
                     i += 1;
                 } else if let ValueView::ValuePair(k, v) = items[i].view() {
-                    map.insert(k.to_string_value(), v.deref_container());
+                    let dv = v.deref_container();
+                    for kk in hash_pair_keys(k) {
+                        map.insert(kk.to_string_value(), dv.clone());
+                    }
                     i += 1;
                 } else {
                     let key = items[i].to_string_value();
@@ -88,7 +105,10 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
         }
         ValueView::ValuePair(k, v) => {
             let mut map = HashMap::new();
-            map.insert(k.to_string_value(), v.deref_container());
+            let dv = v.deref_container();
+            for kk in hash_pair_keys(k) {
+                map.insert(kk.to_string_value(), dv.clone());
+            }
             Value::hash(map)
         }
         ValueView::Set(items, _) => {
@@ -230,12 +250,17 @@ pub(crate) fn build_hash_from_items(items: Vec<Value>) -> Result<Value, RuntimeE
                     map.insert(k.clone(), v.clone());
                 }
             }
+            // A Junction key (`"a"|"b" => 1`) is not itself a key: it threads,
+            // storing the value under each of its members (`%h<a> == %h<b> == 1`),
+            // matching Rakudo. Every other non-Str key stringifies as usual.
             ValueView::ValuePair(key, boxed_val) => {
-                let str_key = Value::hash_key_encode(key);
-                if !matches!(key.view(), ValueView::Str(_)) {
-                    original_keys.insert(str_key.clone(), key.clone());
+                for kk in hash_pair_keys(key) {
+                    let str_key = Value::hash_key_encode(&kk);
+                    if !matches!(kk.view(), ValueView::Str(_)) {
+                        original_keys.insert(str_key.clone(), kk.clone());
+                    }
+                    map.insert(str_key, boxed_val.clone());
                 }
-                map.insert(str_key, boxed_val.clone());
             }
             _ => {
                 let Some(value) = iter.next() else {

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -123,8 +123,13 @@ impl Interpreter {
                 ValueView::Pair(k, v) => {
                     map.insert(k.clone(), v.clone());
                 }
+                // A Junction key (`%( "a"|"b" => 1 )`) threads: it stores the value
+                // under each member key (`%h<a> == %h<b> == 1`), not under the
+                // junction's stringification. Matches Rakudo.
                 ValueView::ValuePair(k, v) => {
-                    map.insert(k.to_string_value(), v.clone());
+                    for kk in crate::runtime::utils::hash_pair_keys(k) {
+                        map.insert(kk.to_string_value(), v.clone());
+                    }
                 }
                 _ => {
                     // Non-pair values: use stringified value as key mapped to True

--- a/t/hash-junction-key.t
+++ b/t/hash-junction-key.t
@@ -1,0 +1,40 @@
+use v6;
+use Test;
+
+# A Junction used as a hash-initializer key threads: the value is stored under
+# each of the junction's members, not under the junction's stringification.
+# `%( "a"|"b" => 1 )` sets both %h<a> and %h<b> to 1 (Rakudo semantics).
+# Regression: mutsu stored the literal key `any(a, b)` (doc-diff hashmap.rakudoc [1]).
+
+plan 12;
+
+# `%( ... )` literal, multiple pairs.
+my %a = %( "a"|"b" => 1, c => 2 );
+is-deeply %a.keys.sort.List, ('a', 'b', 'c'), 'any-junction key expands in %( )';
+is %a<a>, 1, 'first junction member gets the value';
+is %a<b>, 1, 'second junction member gets the value';
+is %a<c>, 2, 'a normal pair is unaffected';
+
+# Plain list assignment, multiple pairs.
+my %m = ("a"|"b" => 1, c => 2);
+is-deeply %m.keys.sort.List, ('a', 'b', 'c'), 'any-junction key expands in list assignment';
+
+# Plain list assignment, a single all-junction pair.
+my %b = ("x"&"y" => 3);
+is-deeply %b.keys.sort.List, ('x', 'y'), 'all-junction key expands (single pair)';
+is %b<x>, 3, 'all-junction member x';
+is %b<y>, 3, 'all-junction member y';
+
+# A three-member junction built with .any.
+my %h = (<p q r>.any => 9);
+is-deeply %h.keys.sort.List, ('p', 'q', 'r'), 'three-member junction key expands';
+is %h<q>, 9, 'middle junction member';
+
+# Normal hashes are unaffected.
+my %n = (a => 1, b => 2);
+is-deeply %n.keys.sort.List, ('a', 'b'), 'a normal hash keeps its keys';
+
+# A non-string, non-junction key still stringifies to a single key.
+my %t;
+%t{3} = 'x';
+is-deeply %t.keys.List, ('3',), 'a numeric key stays a single stringified key';


### PR DESCRIPTION
## Summary

A Junction used as a hash key in a hash initializer (`%( "a"|"b" => 1 )`) was stored under its stringification (`any(a, b)`) as one literal key, so `%h<a>` and `%h<b>` were both undefined. Per Rakudo a Junction key **threads**: the value is stored under each of the junction's members.

```raku
my %hash = %( "a"|"b" => 1, c => 2 );
say %hash{"b"|"c"};    # raku: any(1, 2) ; mutsu before: any((Any), 2)
```

## Fix

Add `hash_pair_keys` (expands a Junction key to its members, otherwise the key itself) and route every hash-initializer `ValuePair` arm through it:

- `build_hash_from_items`
- all three `coerce_to_hash` arms (Array / Seq / single Pair)
- the `MakeHashFromPairs` VM op

so `%( )`, plain list assignment, and single-pair assignment all thread junction keys consistently (`any`, `all`, any arity). Non-junction keys are unchanged.

This is doc-diff `hashmap.rakudoc` [1].

## Tests

- New: `t/hash-junction-key.t` (green against reference `raku` too).
- `make test` passes; all `t/*hash*`, `t/*junction*`, `t/*pair*` tests unaffected.
- Re-swept `hashmap.rakudoc`: mismatch 3 → 2, match 16 → 17 (the junction-key finding is gone; the remaining 2 are the deferred allomorph-key item and hash-iteration-order noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)