### PR TITLE
fix: parse an adverbial colonpair after a parenless method call

### DIFF
--- a/src/parser/expr/postfix/helpers.rs
+++ b/src/parser/expr/postfix/helpers.rs
@@ -5,6 +5,36 @@ use crate::symbol::Symbol;
 use crate::token_kind::TokenKind;
 use crate::value::{Value, ValueView};
 
+/// Does the input (which starts at a `:`) begin a bareword/variable colonpair
+/// adverb — as opposed to a block/typed-hash/array/angle listop argument?
+///
+/// A no-space `:` right after a parenless method name is Raku's adverbial
+/// colonpair (`$obj.git:so`, `.grep:Str`, `.foo:bar(3)`, `.m:$x`) and binds as a
+/// named argument. But `.map:{...}` / `.method:[...]` / `.method:<...>` are
+/// colon-listop calls taking a block / array / angle-word argument, so those
+/// must NOT be diverted. This distinguishes the two by the character right after
+/// the colon: an identifier start, `!name`, or a sigil is an adverb; a brace,
+/// bracket, angle, digit, or anything else is left for the listop reading.
+pub(crate) fn colonpair_adverb_follows(input: &str) -> bool {
+    let Some(rest) = input.strip_prefix(':') else {
+        return false;
+    };
+    // `::` is a package separator, never a colonpair here.
+    let mut chars = rest.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => true,
+        // `:!name` — a negated boolean colonpair. Require an identifier char to
+        // follow so a stray `:!` (prefix `!`) is not mistaken for an adverb.
+        Some('!') => chars.next().is_some_and(|c| c.is_alphabetic() || c == '_'),
+        // `:$var` / `:@var` / `:%var` / `:&var` — a variable colonpair. Require a
+        // name char after the sigil so bare sigils are not swallowed.
+        Some('$') | Some('@') | Some('%') | Some('&') => {
+            chars.next().is_some_and(|c| c.is_alphabetic() || c == '_')
+        }
+        _ => false,
+    }
+}
+
 /// Check if an expression is a negative integer literal (e.g., `-(1)` from `-1`).
 /// Returns the negative value string (e.g., "-1") if so.
 pub(crate) fn extract_negative_literal(expr: &Expr) -> Option<String> {

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -13,8 +13,8 @@ use super::call_method::{
 };
 use super::dot_assign::{atomic_var_name, parse_dot_assign};
 use super::helpers::{
-    compose_prefix_into_whatevercode, extract_negative_literal, extract_range_negative_end,
-    is_angle_key_char, make_negative_subscript_error,
+    colonpair_adverb_follows, compose_prefix_into_whatevercode, extract_negative_literal,
+    extract_range_negative_end, is_angle_key_char, make_negative_subscript_error,
 };
 use crate::ast::{ExistsAdverb, Expr, HyperSliceAdverb, Stmt};
 use crate::parser::expr::operators::{
@@ -984,6 +984,18 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                         let (r3, first_arg) = colonpair_expr(r2)?;
                         args.push(first_arg);
                         r3
+                    } else if colonpair_adverb_follows(r2) {
+                        // A bareword/variable colonpair immediately after the
+                        // method name (no space) is an adverbial named argument,
+                        // e.g. `$obj.git:so`, `.grep:Str`, `.foo:bar(3)`, `.m:$x`.
+                        // Raku parses `.method:adverb` as a colonpair, not a
+                        // colon-listop positional. Block/typed-hash/array forms
+                        // (`.map:{...}`, `.method:[...]`, `.method:<...>`) are
+                        // excluded by `colonpair_adverb_follows`, so they keep the
+                        // listop reading below.
+                        let (r_cp, cp) = colonpair_expr(r2)?;
+                        args.push(cp);
+                        r_cp
                     } else {
                         let r3 = &r2[1..];
                         let (r3, _) = ws(r3)?;

--- a/t/method-call-colonpair-adverb.t
+++ b/t/method-call-colonpair-adverb.t
@@ -1,0 +1,47 @@
+use Test;
+
+plan 8;
+
+# A colonpair written with NO space directly after a parenless method name is an
+# adverbial named argument (Raku's `.method:adverb` form), e.g. `$obj.git:so`.
+# mutsu previously failed to parse it: `:so` was read as a colon-listop positional
+# (`so` prefix op) which needs an operand, yielding a "condition expression" /
+# "Confused" parse error. Some dists (e.g. Overwatch) use this on attributes:
+# `$.git-interval = 5 if $.git ~~ Bool && $.git:so;`
+
+# A genuine parse error surfaces as X::Syntax / "Confused"; EVAL of a class
+# definition (never executed) is the cleanest way to assert "parses".
+sub parses(Str $code) {
+    my $err = '';
+    try {
+        EVAL $code;
+        CATCH { default { $err = .Str } }
+    }
+    $err eq '' || !($err.contains('Confused') || $err.contains('expected'));
+}
+
+ok parses('class C { has $.git; method go() { my $x; $x = 5 if $.git ~~ Bool && $.git:so } }'),
+    '$.attr:adverb inside an if-condition parses';
+
+ok parses('my $o; $o.some-method:so;'),
+    '$o.method:so parses (bareword colonpair adverb)';
+
+ok parses('my $o; $o.some-method:foo(3);'),
+    '$o.method:foo(3) parses (colonpair with value)';
+
+ok parses('my $o; $o.some-method:$x;'),
+    '$o.method:$x parses (variable colonpair adverb)';
+
+# The colonpair adverb is absorbed by methods that ignore extra named args,
+# matching Raku (`5.Str:foo` -> "5", `(1,2,3).elems:foo` -> 3).
+is (5.Str:foo), '5', '.Str:adverb absorbs the colonpair (matches Raku)';
+is ((1, 2, 3).elems:foo), 3, '.elems:adverb absorbs the colonpair (matches Raku)';
+
+# `.method:{...}` (no space) is a colon-listop BLOCK argument, NOT a typed-hash
+# colonpair — must not regress.
+my @doubled = (1, 2, 3).map:{ $_ * 2 };
+is-deeply @doubled, [2, 4, 6], '.map:{block} stays a block arg';
+
+# `.method: {block}` WITH a space is a colon-listop positional, unaffected.
+my @kept = <a b c>.grep: { .chars == 1 };
+is-deeply @kept, ['a', 'b', 'c'], '.grep: {block} (space) still positional';


### PR DESCRIPTION
`\$obj.git:so` — a colonpair written with no space directly after a parenless
method name — failed to parse. The no-space colon branch of the postfix
method-call parser read `:so` as a colon-listop *positional* argument (`so` as a
prefix operator needing an operand), producing a "Confused / right-hand
expression after '='" parse error. In Raku `.method:adverb` is an adverbial
colonpair that binds as a named argument (`\$obj.git:so`, `.grep:Str`,
`.foo:bar(3)`, `.m:\$x`).

Divert the no-space `:` case to `colonpair_expr` when the character after the
colon begins a bareword/`!name`/sigil colonpair (`colonpair_adverb_follows`).
Block / typed-hash / array / angle forms (`.map:{...}`, `.method:[...]`,
`.method:<...>`) are excluded, so colon-listop calls taking a block/array
argument keep their existing reading.

Unblocks Overwatch (ticket T-010), whose `overwatch` class does
`\$.git-interval = 5 if \$.git ~~ Bool && \$.git:so;`; it now parses and reaches
its genuine missing dep `Shell::Command`, matching raku.

Pin: `t/method-call-colonpair-adverb.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)