### PR TITLE
fix: IterationEnd in a ternary then-branch is a complete term, not a listop head

### DIFF
--- a/src/parser/expr/precedence/ternary.rs
+++ b/src/parser/expr/precedence/ternary.rs
@@ -185,6 +185,7 @@ pub(crate) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
             && !name.contains("::")
             && !crate::runtime::utils::is_known_type_constraint(name)
             && !crate::runtime::utils::is_builtin_enum_value(name)
+            && !crate::runtime::utils::is_builtin_constant_term(name)
             && !crate::parser::stmt::simple::is_user_declared_type(name)
             && !crate::parser::stmt::simple::is_user_declared_value_term(name)
         {

--- a/src/runtime/utils/type_constraints.rs
+++ b/src/runtime/utils/type_constraints.rs
@@ -192,6 +192,16 @@ pub(crate) fn is_builtin_enum_value(name: &str) -> bool {
     )
 }
 
+/// Well-known nullary value terms that resolve as a bareword — e.g.
+/// `IterationEnd`, the `Mu`-typed iterator sentinel. Unlike a type object or an
+/// enum value, these are neither types nor enums, so they need a separate list.
+/// A parser that must decide whether a bareword is a *complete* nullary term or
+/// the head of a listop call (e.g. the `?? then !!` ternary guard) treats these
+/// as complete terms.
+pub(crate) fn is_builtin_constant_term(name: &str) -> bool {
+    matches!(name, "IterationEnd")
+}
+
 /// Check if a compound (`::`-separated) name is a known Raku standard type.
 pub(crate) fn is_known_compound_type(name: &str) -> bool {
     matches!(

--- a/t/ternary-then-iterationend.t
+++ b/t/ternary-then-iterationend.t
@@ -1,0 +1,27 @@
+use Test;
+
+plan 6;
+
+# A well-known nullary sentinel term (`IterationEnd`) in the then-branch of a
+# `?? ... !!` ternary was rejected as a parse error inside a routine: the ternary
+# guard treats an *unknown* bareword there as a listop head that gobbled the
+# `!!`, but `IterationEnd` is a complete term. P5tie's iterator does:
+#   ($!lastkey := &!FIRSTKEY($!tied)) =:= Nil ?? IterationEnd !! &!mapper(...)
+
+# IterationEnd is a valid then-branch value.
+is (True ?? IterationEnd !! 5), IterationEnd, 'IterationEnd in then-branch (true)';
+is (False ?? IterationEnd !! 5), 5, 'IterationEnd in then-branch (false)';
+
+# Inside a routine (where the parse originally failed).
+sub pick($cond) { $cond ?? IterationEnd !! 'other' }
+is pick(True), IterationEnd, 'IterationEnd then-branch inside a sub (true)';
+is pick(False), 'other', 'IterationEnd then-branch inside a sub (false)';
+
+# Inside a class method with a private code attribute in the else-branch — the
+# exact P5tie shape.
+class C {
+    has &!mapper = -> $x { "mapped-$x" };
+    method choose($cond, $x) { $cond ?? IterationEnd !! &!mapper($x) }
+}
+is C.new.choose(True, 9), IterationEnd, 'method: IterationEnd then-branch (true)';
+is C.new.choose(False, 9), 'mapped-9', 'method: else-branch private code attr (false)';


### PR DESCRIPTION
`\$cond ?? IterationEnd !! &!mapper(\$x)` failed to parse inside a routine. The
`?? then !!` guard treats an *unknown* bareword in the then-branch as a listop
head that gobbled the `!!` (`1 ?? undeclared-sub !! 3` →
`X::Syntax::ConditionalOperator::SecondPartGobbled`), and rejects it. But
`IterationEnd` — the `Mu`-typed iterator sentinel — is a genuine nullary value
term, neither a type object nor an enum value, so it was mis-rejected.

Add `is_builtin_constant_term` for well-known sentinel value terms and exclude
them from the ternary guard (alongside the existing type/enum exclusions).

Unblocks P5tie (ticket T-011), whose tied-hash iterator does
`(\$!lastkey := &!FIRSTKEY(\$!tied)) =:= Nil ?? IterationEnd !! &!mapper(...)`; it
now parses and loads, matching raku.

Pin: `t/ternary-then-iterationend.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)