### PR TITLE
fix: accept a string-literal parameter in a pointy-block signature

### DIFF
--- a/src/parser/primary/string.rs
+++ b/src/parser/primary/string.rs
@@ -25,9 +25,12 @@ pub(super) use helpers::{
 pub(super) use interp_content::finalize_interpolation;
 pub(super) use interp_var::try_interpolate_var;
 pub(super) use q_string::{big_q_string, q_string};
-pub(super) use quoted::{
-    corner_bracket_string, double_quoted_string, parse_backslash_c_bracket, single_quoted_string,
-    smart_double_quoted_string, smart_single_quoted_string,
+pub(super) use quoted::{corner_bracket_string, parse_backslash_c_bracket};
+// Reachable from other `crate::parser` submodules (e.g. pointy-block literal
+// parameters in `stmt::control::pointy_param`), so widen past `pub(super)`.
+pub(in crate::parser) use quoted::{
+    double_quoted_string, single_quoted_string, smart_double_quoted_string,
+    smart_single_quoted_string,
 };
 pub(super) use quotewords::parse_quotewords_quoted_atom;
 pub(super) use qx::backtick_qx_string;

--- a/src/parser/stmt/control/pointy_param.rs
+++ b/src/parser/stmt/control/pointy_param.rs
@@ -325,6 +325,47 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
         ));
     }
 
+    // String literal value parameter: `-> 'home.html' { ... }` / `-> "x" { }`.
+    // Cro routes literal path segments this way (`get -> 'home.html' { ... }`);
+    // the argument is matched against the literal string, exactly like the
+    // numeric `-> 42 { }` form above. Only a plain (non-interpolating) string
+    // literal is a literal parameter; an interpolating `"$foo"` is not.
+    if rest.starts_with('\'') || rest.starts_with('"') {
+        let parsed = if rest.starts_with('\'') {
+            crate::parser::primary::string::single_quoted_string(rest)
+        } else {
+            crate::parser::primary::string::double_quoted_string(rest)
+        };
+        if let Ok((r, Expr::Literal(val))) = parsed
+            && matches!(val.view(), crate::value::ValueView::Str(_))
+        {
+            return Ok((
+                r,
+                ParamDef {
+                    name: "__literal__".to_string(),
+                    default: None,
+                    multi_invocant: true,
+                    required: false,
+                    named: false,
+                    slurpy,
+                    double_slurpy,
+                    onearg: false,
+                    sigilless: false,
+                    type_constraint,
+                    literal_value: Some(val),
+                    sub_signature: None,
+                    outer_sub_signature: None,
+                    code_signature: None,
+                    where_constraint: None,
+                    traits: Vec::new(),
+                    optional_marker: false,
+                    is_invocant: false,
+                    shape_constraints: None,
+                },
+            ));
+        }
+    }
+
     // Named parameter prefix: :$x, :@l, :%h
     let mut named = false;
     if rest.starts_with(':')

--- a/t/pointy-string-literal-param.t
+++ b/t/pointy-string-literal-param.t
@@ -1,0 +1,31 @@
+use Test;
+
+plan 6;
+
+# A pointy block may take a string-literal parameter, matching the argument
+# against that literal — the same way the numeric form `-> 42 { }` works. Cro
+# routes literal path segments this way: `get -> 'home.html' { ... }`. mutsu
+# handled numeric literals but not string literals, so `-> 'x' { }` failed to
+# parse ("Confused ... right-hand expression").
+
+# Parses (a genuine parse error would throw at compile time).
+my $single = -> 'home.html' { 'ok-single' };
+ok $single ~~ Callable, "-> 'literal' { } parses (single-quoted)";
+
+my $double = -> "home.html" { 'ok-double' };
+ok $double ~~ Callable, '-> "literal" { } parses (double-quoted)';
+
+# The literal parameter matches an equal argument.
+is $single('home.html'), 'ok-single', 'string-literal param matches the equal argument';
+
+# A literal followed by a normal positional (`-> 'x', $y { }`).
+my $mixed = -> 'get', $path { "got-$path" };
+is $mixed('get', '/x'), 'got-/x', 'literal + positional pointy params';
+
+# Multi-candidate dispatch by literal (the numeric form still works too).
+my $num = -> 42 { 'forty-two' };
+is $num(42), 'forty-two', 'numeric literal pointy param still works';
+
+# A pointy block with no parameter is unaffected.
+my $none = -> { 'no-param' };
+is $none(), 'no-param', '-> { } (no param) unaffected';


### PR DESCRIPTION
`-> 'home.html' { ... }` failed to parse ("Confused ... right-hand expression
after '='"). The pointy-parameter parser handled a numeric literal parameter
(`-> 42 { }`) but not a string literal, even though Raku accepts both — the
argument is matched against the literal value. Cro routes literal path segments
this way (`get -> 'home.html' { ... }`).

Add a string-literal branch alongside the numeric one: a plain (non-
interpolating) single- or double-quoted string becomes a `__literal__`
parameter with a `Str` `literal_value`. An interpolating `"$foo"` is not a
literal and falls through to the normal paths. Widen the `single_quoted_string`
/ `double_quoted_string` re-exports from `pub(super)` to `pub(in crate::parser)`
so the pointy-parameter parser can reach them.

This advances App::IRC::Log's parse (ticket T-012) past its `get -> 'x' { }`
routes; the dist still needs Cro / Array::Sorted::Util to fully load, which raku
lacks here too.

Pin: `t/pointy-string-literal-param.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)