### PR TITLE
feat: call `sub EXPORT` with use-args and install its returned Map

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -365,6 +365,7 @@ impl Compiler {
         self.code.emit(OpCode::UseModule {
             name_idx: test_name_idx,
             tags_idx: None,
+            arg_count: 0,
         });
         if let Some(plan_arg) = Self::extract_test_more_plan_arg(arg) {
             self.compile_expr(plan_arg);
@@ -3029,6 +3030,7 @@ impl Compiler {
                 self.code.emit(OpCode::UseModule {
                     name_idx,
                     tags_idx: None,
+                    arg_count: 0,
                 });
             }
             Stmt::Use { module, arg, .. } if module == "Test::More" => {
@@ -3042,7 +3044,11 @@ impl Compiler {
                     let entries = tags.iter().cloned().map(Value::str).collect::<Vec<Value>>();
                     Some(self.code.add_constant(Value::array(entries)))
                 };
-                self.code.emit(OpCode::UseModule { name_idx, tags_idx });
+                self.code.emit(OpCode::UseModule {
+                    name_idx,
+                    tags_idx,
+                    arg_count: 0,
+                });
             }
             // `use if;` — the bare `if` pragma module itself is a no-op; it only
             // provides the `:if(...)` adverb handled below.
@@ -3083,16 +3089,40 @@ impl Compiler {
                 } else {
                     Some(self.code.add_constant(Value::array(entries)))
                 };
+                // `use`-arguments (`use Foo "a", "b"` / `use Foo <a b c>`) are
+                // evaluated here and pushed on the stack for the module's
+                // `sub EXPORT`. A `<a b c>` word list flattens into positional
+                // args, matching `sub EXPORT(*@args) { ... }` seeing three items.
+                let arg_exprs: Vec<&Expr> = match arg {
+                    Some(Expr::ArrayLiteral(items)) => items.iter().collect(),
+                    Some(other) => vec![other],
+                    None => vec![],
+                };
+                let arg_count = arg_exprs.len() as u16;
                 // `use Foo:if(EXPR)` (the `if` pragma): load the module only when
                 // EXPR is true at runtime, evaluated here so platform-conditional
                 // imports (`use Foo:if($*DISTRO.is-win)`) pick the right branch.
                 if let Some(cond) = condition {
                     self.compile_expr(cond);
                     let skip = self.code.emit(OpCode::JumpIfFalse(0));
-                    self.code.emit(OpCode::UseModule { name_idx, tags_idx });
+                    for e in &arg_exprs {
+                        self.compile_expr(e);
+                    }
+                    self.code.emit(OpCode::UseModule {
+                        name_idx,
+                        tags_idx,
+                        arg_count,
+                    });
                     self.code.patch_jump(skip);
                 } else {
-                    self.code.emit(OpCode::UseModule { name_idx, tags_idx });
+                    for e in &arg_exprs {
+                        self.compile_expr(e);
+                    }
+                    self.code.emit(OpCode::UseModule {
+                        name_idx,
+                        tags_idx,
+                        arg_count,
+                    });
                 }
             }
             Stmt::Import { module, tags } => {

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1371,6 +1371,10 @@ pub(crate) enum OpCode {
     UseModule {
         name_idx: u32,
         tags_idx: Option<u32>,
+        /// Number of `use`-argument values pushed on the stack immediately
+        /// before this op (`use Foo "a", "b"` / `use Foo <a b c>`). Popped by
+        /// the VM and handed to the module's `sub EXPORT`, if any.
+        arg_count: u16,
     },
     ImportModule {
         name_idx: u32,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -325,6 +325,7 @@ mod runtime_container;
 mod runtime_encoding;
 mod runtime_init;
 mod runtime_module;
+mod runtime_module_export_sub;
 mod runtime_module_exports;
 mod runtime_output;
 mod runtime_shared_vars;
@@ -869,6 +870,12 @@ pub struct Interpreter {
     /// provide the same short name. Saved/restored around each load so a
     /// transitive `use` resolves with its own (usually absent) selectors.
     pending_dist_selectors: Vec<(String, String)>,
+    /// Arguments passed to the `use` currently being loaded (`use Foo "a", "b"`
+    /// / `use Foo <a b c>`), evaluated by the caller and pushed for the
+    /// `UseModule` op. Consumed once by `load_module`, which snapshots them into
+    /// a local before running the module body (so a transitive `use` inside the
+    /// body cannot see them) and hands them to the module's `sub EXPORT`.
+    pub(crate) pending_use_export_args: Option<Vec<Value>>,
     end_phasers: Vec<(Vec<Stmt>, Env)>,
     /// Tracks END phaser site_ids to ensure each is registered only once.
     end_phaser_sites: HashSet<u64>,

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -487,6 +487,10 @@ impl Interpreter {
     }
 
     pub(super) fn load_module(&mut self, module: &str) -> Result<(), RuntimeError> {
+        // Snapshot the `use` args (set by `exec_use_module_op`) before running
+        // the module body: a transitive `use` inside the body would otherwise
+        // overwrite the field. Handed to the module's `sub EXPORT`, if any.
+        let export_args = self.pending_use_export_args.take();
         let (source_path, inst_dist_json) = self
             .resolve_module_path(module)
             .ok_or_else(|| RuntimeError::unsatisfied_dependency(module))?;
@@ -609,6 +613,9 @@ impl Interpreter {
                 &before_function_keys,
                 main_exported,
             );
+            // If the module defined `sub EXPORT`, call it with the `use` args and
+            // install the symbols it returns into the caller's scope.
+            self.apply_module_export(export_args.unwrap_or_default())?;
         }
         // Record the module's distribution for every class/role it just declared,
         // so an OTF compile of one of their methods resolves `$?DISTRIBUTION`.

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2042,6 +2042,7 @@ impl Interpreter {
             proto_method_skip: None,
             pending_dispatch_error: None,
             pending_dist_selectors: Vec::new(),
+            pending_use_export_args: None,
             end_phasers: Vec::new(),
             end_phaser_sites: HashSet::new(),
             chroot_root: None,

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -100,6 +100,10 @@ impl Interpreter {
         let saved = std::mem::replace(&mut self.pending_dist_selectors, dist_selectors);
         let result = self.use_module_with_tags_inner(module, tags);
         self.pending_dist_selectors = saved;
+        // `load_module` consumes `pending_use_export_args`; clear any residue
+        // here so a native/pragma/already-loaded path (which never reaches
+        // `load_module`) cannot leak this `use`'s args into a later one.
+        self.pending_use_export_args = None;
         result
     }
 

--- a/src/runtime/runtime_module_export_sub.rs
+++ b/src/runtime/runtime_module_export_sub.rs
@@ -1,0 +1,113 @@
+//! Custom module export via `sub EXPORT`.
+//!
+//! A module may define `sub EXPORT(...)` which Raku calls with the `use`
+//! arguments and whose return `Map` (or list of `Map`s) names the symbols to
+//! install into the importing scope. mutsu calls it at module-load time (see
+//! `load_module`), after the module body has run and its subs are registered.
+use super::*;
+use crate::value::ValueView;
+
+impl Interpreter {
+    /// If the just-loaded module defined `sub EXPORT`, call it with the `use`
+    /// arguments and install the symbols from its returned `Map`(s) into the
+    /// caller's scope. `EXPORT` itself is special (never an export), so it is
+    /// removed from the registry afterwards to avoid leaking as a callable.
+    pub(super) fn apply_module_export(
+        &mut self,
+        export_args: Vec<Value>,
+    ) -> Result<(), RuntimeError> {
+        // The module body runs under GLOBAL, so `sub EXPORT` registers as
+        // `GLOBAL::EXPORT`. Only participate when it is actually present.
+        let Some(def) = self.resolve_function("EXPORT") else {
+            return Ok(());
+        };
+        // Run EXPORT through the compiled call path (not the tree-walk
+        // `call_function` slow path): its params become real local slots, so a
+        // sub the EXPORT returns can capture a use-argument (`sub EXPORT($x)
+        // { Map.new: '&f' => sub { ...$x... } }`).
+        //
+        // Snapshot env across the call and restore it afterwards: the call's
+        // scalar return-merge writes EXPORT's own params/locals (`$x`, a `my $y`)
+        // back into this (the caller's) env as their post-return values. A sub
+        // EXPORT returns that closes over such a lexical carries the correct
+        // captured value, but a later bareword call of it merges the caller env
+        // with `merge_all` (keep-existing) semantics — so the leaked stale entry
+        // would shadow the capture. Dropping EXPORT's env writes keeps the
+        // caller env clean; EXPORT's real effects are its return value and
+        // control flow (die/note/exit), not caller-env mutation.
+        let empty_fns = crate::opcode::CompiledFns::default();
+        let saved_env = self.env.clone();
+        let result = self.compile_and_call_function_def(&def, export_args, &empty_fns)?;
+        self.env = saved_env;
+        // `EXPORT` must not itself become a callable in (or leak from) the
+        // module; drop every registered `EXPORT` routine now that it has run.
+        self.remove_export_routine();
+        self.install_export_map(&result);
+        Ok(())
+    }
+
+    /// Remove any `EXPORT` routine registered by the module body (it runs under
+    /// GLOBAL, so the key is `GLOBAL::EXPORT`; be liberal in case a package
+    /// prefix was used) so it does not leak into the caller as `EXPORT()`.
+    fn remove_export_routine(&mut self) {
+        self.registry_mut().functions.retain(|key, _| {
+            let ks = key.resolve();
+            ks != "EXPORT" && !ks.ends_with("::EXPORT")
+        });
+    }
+
+    /// Install the symbols named by an `EXPORT` return value. Accepts a single
+    /// `Map`/`Hash` (`'&name' => sub {...}`, `'$name' => value`) or a list of
+    /// them (recursing), matching `sub EXPORT { Map.new: ... }` and the
+    /// multi-tag `%(...)` form.
+    fn install_export_map(&mut self, val: &Value) {
+        match val.view() {
+            ValueView::Hash(gc) => {
+                let pairs: Vec<(String, Value)> =
+                    gc.map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                for (key, value) in pairs {
+                    self.install_export_symbol(key, value);
+                }
+            }
+            ValueView::Array(items, ..) => {
+                let items: Vec<Value> = items.iter().cloned().collect();
+                for item in items {
+                    self.install_export_map(&item);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Install one exported symbol under its sigilled name (`&greet`, `$foo`,
+    /// `@bar`, `%baz`) into the current (caller's) scope. An exported operator
+    /// sub is also registered with the parser so runtime-parsed code (EVAL)
+    /// recognizes the new operator symbol.
+    fn install_export_symbol(&mut self, key: String, value: Value) {
+        let sigil = key.chars().next();
+        if let Some('&') = sigil {
+            let op = &key[1..];
+            if matches!(
+                op.split_once(":<").map(|(c, _)| c),
+                Some("prefix" | "postfix" | "infix" | "circumfix" | "postcircumfix")
+            ) {
+                self.imported_operator_names.insert(op.to_string());
+            }
+            if op.starts_with("infix:<") {
+                self.user_declared_infix_ops.insert(op.to_string());
+                crate::vm::vm_jit::note_user_infix_decl();
+            }
+        }
+        // Install into env under the key the reader looks up. A `$scalar` read
+        // compiles to a bare (sigil-stripped) `GetGlobal` — the same key an
+        // `our $x` module global lands under — so the sigil must be dropped for
+        // scalars. Arrays/hashes/subs are read under their sigilled name.
+        self.unsuppress_name(&key);
+        let env_key = match sigil {
+            Some('$') => key[1..].to_string(),
+            _ => key,
+        };
+        self.env.insert(env_key, value);
+        self.fn_resolve_gen += 1;
+    }
+}

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -218,6 +218,7 @@ impl Interpreter {
             proto_method_skip: None,
             pending_dispatch_error: None,
             pending_dist_selectors: Vec::new(),
+            pending_use_export_args: None,
             end_phasers: Vec::new(),
             end_phaser_sites: HashSet::new(),
             chroot_root: self.chroot_root.clone(),

--- a/src/vm/vm_call_dispatch.rs
+++ b/src/vm/vm_call_dispatch.rs
@@ -180,7 +180,7 @@ impl Interpreter {
         cf
     }
 
-    pub(super) fn compile_and_call_function_def(
+    pub(crate) fn compile_and_call_function_def(
         &mut self,
         def: &crate::ast::FunctionDef,
         args: Vec<Value>,

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4242,9 +4242,13 @@ impl Interpreter {
                 self.exec_register_proto_token_op(code, *idx)?;
                 *ip += 1;
             }
-            OpCode::UseModule { name_idx, tags_idx } => {
+            OpCode::UseModule {
+                name_idx,
+                tags_idx,
+                arg_count,
+            } => {
                 self.sync_source_line(code, *ip);
-                self.exec_use_module_op(code, *name_idx, *tags_idx)?;
+                self.exec_use_module_op(code, *name_idx, *tags_idx, *arg_count)?;
                 *ip += 1;
             }
             OpCode::ImportModule { name_idx, tags_idx } => {

--- a/src/vm/vm_module_ops.rs
+++ b/src/vm/vm_module_ops.rs
@@ -8,8 +8,21 @@ impl Interpreter {
         code: &CompiledCode,
         name_idx: u32,
         tags_idx: Option<u32>,
+        arg_count: u16,
     ) -> Result<(), RuntimeError> {
         let module = Self::const_str(code, name_idx);
+        // Pop the `use`-argument values pushed by the compiler (in source
+        // order) and stash them for the module's `sub EXPORT`. Cleared by
+        // `use_module_with_tags` even when the load takes a native/early-return
+        // path, so they can never leak into a later `use`.
+        if arg_count > 0 {
+            let n = arg_count as usize;
+            let split = self.stack.len().saturating_sub(n);
+            let args: Vec<Value> = self.stack.split_off(split);
+            self.pending_use_export_args = Some(args);
+        } else {
+            self.pending_use_export_args = None;
+        }
         let tags: Vec<String> = tags_idx
             .and_then(|idx| code.constants.get(idx as usize))
             .and_then(|v| match v.view() {

--- a/t/sub-export.t
+++ b/t/sub-export.t
@@ -1,0 +1,123 @@
+use v6;
+use Test;
+
+# `sub EXPORT` custom module export: a module may define `sub EXPORT(...)` which
+# is called at load time with the `use` arguments; the Map(s) it returns name
+# the symbols installed into the importing scope. This coexists with `is export`.
+# (Exported sub names avoid Raku builtins like `val` so a bareword call resolves
+# to the export, not the builtin.)
+
+plan 14;
+
+# A scratch lib directory for the generated modules.
+my $lib = $*TMPDIR.add("mutsu-sub-export-{$*PID}");
+$lib.mkdir;
+LEAVE { try { .unlink for $lib.dir; $lib.rmdir } }
+
+sub write-mod($name, $body) {
+    $lib.add("$name.rakumod").spurt($body);
+}
+
+sub run-out($code) {
+    run($*EXECUTABLE, '-I', $lib.Str, '-e', $code, :out).out.slurp;
+}
+
+# 1) No-arg EXPORT returning a sub.
+write-mod 'ENoArg', q:to/END/;
+    sub EXPORT() { Map.new: '&greet' => sub { "hi" } }
+    END
+is run-out('use ENoArg; print greet()'), 'hi',
+    'no-arg EXPORT installs an exported sub';
+
+# 2) EXPORT receiving a single `use` argument, used in the returned closure.
+write-mod 'EArg', q:to/END/;
+    sub EXPORT($x) { Map.new: '&expanded' => sub { "got:$x" } }
+    END
+is run-out('use EArg "hello"; print expanded()'), 'got:hello',
+    'EXPORT arg is captured by a returned closure';
+
+# 3) A `<a b c>` word list flattens into positional EXPORT args.
+write-mod 'EWords', q:to/END/;
+    sub EXPORT(*@a) { Map.new: '&joined' => sub { @a.join(",") } }
+    END
+is run-out('use EWords <a b c>; print joined()'), 'a,b,c',
+    'a word list flattens into positional EXPORT args';
+
+# 4) EXPORT can export scalars, arrays, hashes and subs together.
+write-mod 'EMix', q:to/END/;
+    sub EXPORT() {
+        Map.new: '$S' => 7, '@A' => [1, 2], '%H' => { a => 1 }, '&f' => sub { "f" }
+    }
+    END
+is run-out('use EMix; print "$S|@A[]|%H<a>|{f()}"'), '7|1 2|1|f',
+    'EXPORT installs scalar/array/hash/sub symbols';
+
+# 5) A local defined in EXPORT is captured by a returned closure.
+write-mod 'ELocal', q:to/END/;
+    sub EXPORT() { my $y = "localval"; Map.new: '&peek' => sub { "got:$y" } }
+    END
+is run-out('use ELocal; print peek()'), 'got:localval',
+    'a closure the EXPORT returns captures an EXPORT local';
+
+# 6) `sub EXPORT` and `is export` coexist.
+write-mod 'EBoth', q:to/END/;
+    sub EXPORT() { Map.new: '&fromexport' => sub { "E" } }
+    sub fromtrait is export { "T" }
+    END
+is run-out('use EBoth; print fromexport() ~ fromtrait()'), 'ET',
+    '`sub EXPORT` and `is export` coexist';
+
+# 7) EXPORT itself is not leaked as a callable.
+{
+    my $proc = run($*EXECUTABLE, '-I', $lib.Str, '-e',
+        'use ENoArg; EXPORT()', :out, :err);
+    $proc.out.slurp;
+    $proc.err.slurp;
+    isnt $proc.exitcode, 0, 'EXPORT is not importable as a callable';
+}
+
+# 8) EXPORT side effects (note/die) run at use time.
+write-mod 'EDie', q:to/END/;
+    sub EXPORT($v) { die "prereq failed: $v" if $v eq 'bad'; Map.new }
+    END
+{
+    my $proc = run($*EXECUTABLE, '-I', $lib.Str, '-e',
+        'use EDie "bad"; say "unreached"', :out, :err);
+    my $out = $proc.out.slurp;
+    my $err = $proc.err.slurp;
+    isnt $proc.exitcode, 0, 'EXPORT that dies aborts the load';
+    unlike $out, /unreached/, 'code after a dying use does not run';
+    like $err, /'prereq failed: bad'/, 'EXPORT die message is reported';
+}
+
+# 9) A no-EXPORT module is unaffected (regression guard).
+write-mod 'EPlain', q:to/END/;
+    sub plainsub is export { "plain" }
+    END
+is run-out('use EPlain; print plainsub()'), 'plain',
+    'a module without EXPORT still imports normally';
+
+# 10) EXPORT args can be dynamic expressions, not just literals.
+write-mod 'EDyn', q:to/END/;
+    sub EXPORT($x) { Map.new: '&echo' => sub { $x } }
+    END
+is run-out('my $v = "runtime-" ~ (3 + 4); use EDyn $v; print echo()'),
+    'runtime-7', 'EXPORT receives a runtime-evaluated argument';
+
+# 11) EXPORT selecting among existing module subs by argument.
+write-mod 'ESelect', q:to/END/;
+    sub greet-en { "hello" }
+    sub greet-fr { "bonjour" }
+    sub EXPORT($lang) {
+        Map.new: '&hail' => ($lang eq 'fr' ?? &greet-fr !! &greet-en)
+    }
+    END
+is run-out('use ESelect "fr"; print hail()'), 'bonjour',
+    'EXPORT selects among existing module subs by argument';
+
+# 12) EXPORT locals do not leak into the caller's lexical scope.
+write-mod 'ENoLeak', q:to/END/;
+    sub EXPORT() { my $secret = "hidden"; Map.new: '&ok' => sub { "ok" } }
+    END
+is run-out('use ENoLeak; print ok(); print "|"; print ($secret // "clean")'),
+    'ok|clean', 'EXPORT locals do not leak into the caller scope';


### PR DESCRIPTION
## Summary

Implements Raku's `sub EXPORT` custom module export. A module may define
`sub EXPORT(...)`, which is called at load time with the `use` arguments; the
`Map` (or list of `Map`s) it returns names the symbols installed into the
importing scope. mutsu previously ignored `EXPORT` entirely — neither the
no-arg `sub EXPORT()` form nor the `sub EXPORT($args)` form was ever called.

This is high-impact for real distributions: ~10% of cached dists use
`sub EXPORT`, most with a signature (e.g. `RakudoPrereq`, type-alias exports
like roast's `RT125715`).

## What it does

- **Compiler**: `use Foo "a", "b"` / `use Foo <a b c>` now evaluate their
  arguments and push them for the `UseModule` op (a `<...>` word list flattens
  into positional args). An `arg_count` field is added to the `UseModule` opcode.
- **VM**: `exec_use_module_op` stashes the popped args in a new
  `pending_use_export_args` field; `use_module_with_tags` clears it defensively
  so a native/pragma/already-loaded load (which never reaches `load_module`)
  can't leak args into a later `use`.
- **`load_module`** snapshots the args before running the module body (so a
  transitive `use` inside the body can't see them), then calls
  `apply_module_export` after the body runs.
- **`apply_module_export`** runs `EXPORT` through the **compiled** call path
  (`compile_and_call_function_def`) so a sub it returns can capture a
  use-argument; restores env around the call so `EXPORT`'s own lexicals don't
  leak into the caller (matching Raku's compile-time scope); drops the `EXPORT`
  routine so it isn't itself importable; and installs the returned symbols —
  `$scalar` under its bare (sigil-stripped) key that a `GetGlobal` read
  resolves, `@`/`%`/`&` under their sigilled key, and operator subs into the
  parser's import tables.

Coexists with `is export`.

## Not covered (follow-ups)

- Full `RakudoPrereq` pass still needs `$*RAKU.compiler.version` to report a
  realistic version (separate gap).
- `Understitch` additionally needs parse-time registration of an operator that
  `EXPORT` returns (`&infix:<_>`) — a separate slang concern.

## Tests

- New pin test `t/sub-export.t` (14 subtests): no-arg export, scalar/word-list/
  dynamic args, scalar/array/hash/sub symbols, arg captured by a returned
  closure, coexistence with `is export`, `EXPORT` not leaking as a callable,
  `die`/`note` side effects at use time, and EXPORT locals not leaking into the
  caller.
- `make test` passes (20425 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)