### PR TITLE
fix: an imported-function call left-operand of an expression is not truncated

### DIFF
--- a/src/parser/stmt/simple/control_stmts.rs
+++ b/src/parser/stmt/simple/control_stmts.rs
@@ -489,9 +489,14 @@ pub(crate) fn known_call_stmt(input: &str) -> PResult<'_, Stmt> {
     // Test assertion calls (e.g. `is [1], [1], 'desc'`) can start with bracketed
     // arguments and be mistaken for an expression prefix. Keep them as calls.
     if !is_test_assertion_callable(&name)
-        && KNOWN_CALLS.contains(&name.as_str())
+        && (KNOWN_CALLS.contains(&name.as_str()) || is_imported_function(&name))
         && known_call_is_expression_prefix(input, rest)
     {
+        // A known/imported call that is the left operand of a larger expression
+        // (`has-interp($s) ?? A !! B`, `foo($x) ~~ Bool`, `bar() && baz`) must be
+        // parsed by the expression-statement parser, not truncated to a bare
+        // statement call here. Imported functions were previously excluded, so a
+        // trailing ternary/`~~`/`&&` after an imported call was dropped.
         return Err(PError::expected("known function call"));
     }
     if is_test_assertion_callable(&name) {

--- a/t/imported-call-expression-prefix.t
+++ b/t/imported-call-expression-prefix.t
@@ -1,0 +1,34 @@
+use lib 't/lib';
+use Test;
+use ImportedPredicate;
+
+plan 6;
+
+# An imported-function call that is the LEFT operand of a larger expression at
+# statement-expression position was truncated: the statement-level parser
+# treated `has-interp($s)` as a bare `Stmt::Call` and dropped the trailing
+# `?? A !! B` / `~~` / `&&`, because the "is this actually an expression prefix?"
+# check only applied to the hardcoded KNOWN_CALLS list, not to imported
+# functions. (Template::HAML::Tag: `has-interp($s) ?? InterpString.new(...) !!
+# $s`.) These now parse and evaluate.
+
+sub maybe-interp($s) {
+    has-interp($s) ?? 'interp' !! 'plain';
+}
+is maybe-interp('#{x}'), 'interp', 'imported call ?? then-branch (true)';
+is maybe-interp('plain'), 'plain', 'imported call ?? else-branch (false)';
+
+sub is-bool($s) { has-interp($s) ~~ Bool }
+is is-bool('x'), True, 'imported call as left operand of ~~';
+
+sub anded($s) { has-interp($s) && 'both' }
+is anded('#{x}'), 'both', 'imported call as left operand of &&';
+
+# Multi-line ternary (the exact Template::HAML::Tag shape).
+sub multi($s) {
+    has-interp($s)
+      ?? 'yes'
+      !! 'no';
+}
+is multi('#{x}'), 'yes', 'imported call multi-line ternary (true)';
+is multi('z'), 'no', 'imported call multi-line ternary (false)';

--- a/t/lib/ImportedPredicate.rakumod
+++ b/t/lib/ImportedPredicate.rakumod
@@ -1,0 +1,6 @@
+unit module ImportedPredicate;
+
+# An exported predicate sub, used to exercise the statement-level parse of an
+# imported-function call that is the left operand of a larger expression
+# (`has-interp($s) ?? A !! B`), as in Template::HAML::Tag.
+sub has-interp(Str $text --> Bool) is export { $text.contains('#{') }


### PR DESCRIPTION
At statement-expression position, `has-interp($s) ?? A !! B` (where `has-interp`
is an *imported* sub) was truncated to a bare `Stmt::Call`, dropping the trailing
`?? A !! B`. The "is this call actually the prefix of a larger expression?" guard
(`known_call_is_expression_prefix`) only ran for the hardcoded `KNOWN_CALLS`
list, not for imported functions, so an imported call followed by a ternary /
`~~` / `&&` at statement level lost its tail. (User-declared subs already went
through the expression path and worked.)

Broaden the guard to imported functions too (test-assertion callables stay
excluded, as before). Now an imported call that is the left operand of a larger
expression bails to the expression-statement parser.

Unblocks Template::HAML (ticket T-014): its `Tag` module does
`has-interp($s) ?? Interpolation::InterpString.new(...) !! $s`, which only failed
once `Template::HAML::Interpolation` was loaded (making `has-interp` a known
import). The whole dist now loads, matching raku.

Pin: `t/imported-call-expression-prefix.t` (+ `t/lib/ImportedPredicate.rakumod`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)