### PR TITLE
fix: balance nested brackets in an `&[op]` operator reference

### DIFF
--- a/src/parser/primary/var/sigil_vars.rs
+++ b/src/parser/primary/var/sigil_vars.rs
@@ -18,6 +18,29 @@ use super::scalar::scalar_var;
 
 static ANON_ARRAY_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// Find the `]` that closes the outer `[` of an `&[op]` operator reference,
+/// balancing nested brackets. `input` starts just past the outer `[`. This lets
+/// a metaop whose operand is itself bracketed parse correctly: `&[R[~~]]` has
+/// the operator `R[~~]` (reverse of the reduce `[~~]`), not `R[~~` cut at the
+/// first `]`. Returns the byte offset of the matching `]`, or `None` if
+/// unbalanced.
+fn matching_op_bracket_end(input: &str) -> Option<usize> {
+    let mut depth = 0usize;
+    for (idx, ch) in input.char_indices() {
+        match ch {
+            '[' => depth += 1,
+            ']' => {
+                if depth == 0 {
+                    return Some(idx);
+                }
+                depth -= 1;
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 /// Parse a leading-`::` qualified variable name after a sigil, i.e. the
 /// `::Pkg::name` / `::Pkg::('name')` form (`input` starts at the first `::`).
 ///
@@ -416,7 +439,7 @@ pub(crate) fn code_var(input: &str) -> PResult<'_, Expr> {
     }
     // Handle &[op] — short form for &infix:<op>
     if let Some(after_bracket) = input.strip_prefix('[')
-        && let Some(end_pos) = after_bracket.find(']')
+        && let Some(end_pos) = matching_op_bracket_end(after_bracket)
     {
         let op_name = &after_bracket[..end_pos];
         let rest = &after_bracket[end_pos + 1..];

--- a/t/amp-bracket-nested-metaop.t
+++ b/t/amp-bracket-nested-metaop.t
@@ -1,0 +1,22 @@
+use Test;
+
+plan 6;
+
+# `&[op]` is the code-reference form of an infix operator. When the operator is
+# a metaop whose operand is itself bracketed (`R[~~]` — the reverse of the reduce
+# `[~~]`), the closing `]` must be matched with bracket balancing. mutsu found the
+# FIRST `]`, so `&[R[~~]]` was cut to `R[~~` + a stray `]` and failed to parse.
+# (Test::Run uses `&[R[~~]]`.)
+
+my $rr = &[R[~~]];
+ok $rr ~~ Callable, '&[R[~~]] parses to a callable (nested-bracket metaop)';
+
+# The plain and single-metaop forms still work.
+is (&[+])(2, 3), 5, '&[+] still works';
+is (&[*])(4, 5), 20, '&[*] still works';
+ok &[~~] ~~ Callable, '&[~~] still a callable';
+ok &[R~~] ~~ Callable, '&[R~~] (single metaop, no inner bracket) still works';
+
+# An unknown bare word inside &[...] is still a compile error.
+ok (try { EVAL 'my $x = &[doesntexist]' } === Nil) && $! ~~ Exception,
+    '&[doesntexist] still errors ("Missing infix inside []")';


### PR DESCRIPTION
`&[R[~~]]` — a code reference to a metaop whose operand is itself bracketed
(`R[~~]`, the reverse of the reduce `[~~]`) — failed to parse. The `&[op]` parser
found the FIRST `]`, cutting the operator to `R[~~` and stranding a `]`, which
broke the surrounding statement.

Match the closing `]` with bracket balancing (`matching_op_bracket_end`) so the
whole `R[~~]` operator is captured.

Unblocks Test::Run (ticket T-017): its `runs_ok` does
`$op_std = &[R[~~]] if ...`. The whole dist now loads, matching raku.

Pin: `t/amp-bracket-nested-metaop.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)