### PR TITLE
fix: CallFrame.annotations returns a Map, and a Map is not a Hash

### DIFF
--- a/src/runtime/system_introspect.rs
+++ b/src/runtime/system_introspect.rs
@@ -128,7 +128,10 @@ impl Interpreter {
         if let Some(line) = attrs.get("line") {
             map.insert("line".to_string(), line.clone());
         }
-        Value::hash(map)
+        // raku's CallFrame.annotations is an immutable Map, not a mutable Hash.
+        let mut data = crate::value::HashData::new(map);
+        data.declared_type = Some("Map".to_string());
+        Value::hash_with_data(crate::gc::Gc::new(data))
     }
 
     pub(super) fn seconds_from_value(val: Option<Value>) -> Option<f64> {

--- a/src/runtime/utils/type_misc.rs
+++ b/src/runtime/utils/type_misc.rs
@@ -17,6 +17,7 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
         // (`lazy for`, arithmetic/closure sequences) present as `Array`/`List`.
         ValueView::LazyList(ll) if ll.is_from_gather() => "Seq",
         ValueView::LazyList(_) => "Array",
+        ValueView::Hash(ref h) if h.declared_type.as_deref() == Some("Map") => "Map",
         ValueView::Hash(_) => "Hash",
         ValueView::Range(_, _)
         | ValueView::RangeExcl(_, _)

--- a/src/value/types_isa.rs
+++ b/src/value/types_isa.rs
@@ -30,6 +30,7 @@ impl Value {
             ValueView::Seq(_) => "Seq",
             ValueView::HyperSeq(_) => "HyperSeq",
             ValueView::RaceSeq(_) => "RaceSeq",
+            ValueView::Hash(ref h) if h.declared_type.as_deref() == Some("Map") => "Map",
             ValueView::Hash(..) => "Hash",
             ValueView::Set(_, is_mutable) => {
                 if is_mutable {

--- a/t/callframe-annotations-map.t
+++ b/t/callframe-annotations-map.t
@@ -1,0 +1,14 @@
+use v6;
+use Test;
+
+plan 5;
+
+# CallFrame.annotations is an immutable Map, not a mutable Hash.
+my $ann = callframe.annotations;
+is $ann.^name, 'Map', 'annotations returns a Map';
+ok $ann ~~ Map, 'annotations does Map';
+nok $ann ~~ Hash, 'annotations is not a (mutable) Hash';
+
+# The <file>/<line> lookups still resolve.
+is $ann<file>, callframe.file, 'annotations<file> matches .file';
+ok $ann<line>.defined, 'annotations<line> is defined';


### PR DESCRIPTION
## Summary

Two related type-correctness fixes surfaced while working the CallFrame
introspection plan (`docs/callframe-introspection-plan.md`, finding **G4**):

1. **`CallFrame.annotations` now returns a `Map`, not a `Hash`.** Rakudo's
   `.annotations` is an immutable `Map`; mutsu built a mutable `Hash`, so
   `callframe.annotations.^name` reported `Hash`. `build_annotations` now
   builds a `HashData` with `declared_type = "Map"`.

2. **A `Map` is no longer reported as a `Hash` in type/smartmatch checks.**
   Verifying (1) exposed that `%h.Map ~~ Hash` wrongly returned `True`:
   `isa_check` and `value_type_name` reported every Map-typed hash as `Hash`.
   Since `Map` is the *parent* of `Hash`, `Map ~~ Hash` must be `False` while
   `Hash ~~ Map` and `Map ~~ Associative` stay `True`. Both paths now report a
   declared-Map hash as `Map`.

Verified against reference `raku`:

```
my $m = %(a=>1).Map;
say $m ~~ Hash;         # False
say $m ~~ Map;          # True
say %(a=>1) ~~ Map;     # True
say $m ~~ Associative;  # True
say callframe.annotations.^name;  # Map
```

## Test

New pin `t/callframe-annotations-map.t`. `t/` Map/Hash suites and
`roast/S02-types/hash.t` / `roast/S32-hash/map.t` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)