### PR TITLE
fix: allow `my enum` in a role and a role type param after :ver/:auth adverbs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -793,6 +793,10 @@ pub(crate) enum Stmt {
         name: Symbol,
         variants: Vec<(String, Option<Expr>)>,
         is_export: bool,
+        /// Whether declared with an explicit `my` scope (lexical). A `my enum`
+        /// is private to its enclosing scope and, unlike a default our-scoped
+        /// enum, is allowed inside a role body.
+        is_my: bool,
         /// Base type constraint (e.g., `my Str enum ...` has base_type = Some("Str"))
         base_type: Option<String>,
         /// Language version active when this enum was declared (e.g., "6.c", "6.d", "6.e")

--- a/src/parser/stmt/class/package_decl.rs
+++ b/src/parser/stmt/class/package_decl.rs
@@ -247,12 +247,21 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
         let (r, _) = ws1(r)?;
         let (r, name) = qualified_ident(r)?;
         check_pseudo_package_in_decl(&name)?;
-        let (mut r, (type_params, type_param_defs)) =
+        let (mut r, (mut type_params, mut type_param_defs)) =
             super::role_decl::parse_optional_role_type_params(r)?;
         // Optional type adverbs (:ver<...>, :auth<...>, :api<...>).
         let (r2, _adverbs) = parse_declarator_traits(r)?;
         let (r2, _) = ws(r2)?;
         r = r2;
+        // The signature may also FOLLOW the adverbs — the order Raku itself uses:
+        // `unit role Algorithm::Treap:ver<0.10.3>:auth<zef:titsuki>[::KeyT];`.
+        if type_params.is_empty() && r.starts_with('[') {
+            let (r2, (tp, tpd)) = super::role_decl::parse_optional_role_type_params(r)?;
+            let (r2, _) = ws(r2)?;
+            type_params = tp;
+            type_param_defs = tpd;
+            r = r2;
+        }
         // Optional parent/trait clauses in any order (mirrors block-form roles).
         let mut parent_roles: Vec<String> = Vec::new();
         let mut is_export = false;

--- a/src/parser/stmt/decl/enum_decl.rs
+++ b/src/parser/stmt/decl/enum_decl.rs
@@ -31,7 +31,7 @@ pub(crate) fn enum_decl(input: &str) -> PResult<'_, Stmt> {
             return parse_anon_enum_body(r);
         }
     }
-    parse_enum_decl_body(rest)
+    parse_enum_decl_body(rest, false)
 }
 
 /// Parse anonymous enum body (after `enum` keyword with no name).
@@ -93,6 +93,7 @@ fn parse_anon_enum_body(input: &str) -> PResult<'_, Stmt> {
             name: Symbol::intern(""),
             variants,
             is_export: false,
+            is_my: false,
             base_type: None,
             language_version: super::super::simple::current_language_version(),
         },
@@ -254,13 +255,14 @@ fn parse_enum_variant_entry(input: &str) -> PResult<'_, (String, Option<Expr>)> 
     }
 }
 
-pub(in crate::parser::stmt) fn parse_enum_decl_body(input: &str) -> PResult<'_, Stmt> {
-    parse_enum_decl_body_with_type(input, None)
+pub(in crate::parser::stmt) fn parse_enum_decl_body(input: &str, is_my: bool) -> PResult<'_, Stmt> {
+    parse_enum_decl_body_with_type(input, None, is_my)
 }
 
 pub(super) fn parse_enum_decl_body_with_type(
     input: &str,
     base_type: Option<String>,
+    is_my: bool,
 ) -> PResult<'_, Stmt> {
     let (rest, name_str) = qualified_ident(input)?;
     let name = Symbol::intern(&name_str);
@@ -344,6 +346,7 @@ pub(super) fn parse_enum_decl_body_with_type(
                         name,
                         variants: vec![("__DYNAMIC__".to_string(), Some(combined))],
                         is_export,
+                        is_my,
                         base_type: base_type.clone(),
                         language_version: super::super::simple::current_language_version(),
                     },
@@ -358,6 +361,7 @@ pub(super) fn parse_enum_decl_body_with_type(
                     name,
                     variants: vec![("__DYNAMIC__".to_string(), Some(expr))],
                     is_export,
+                    is_my,
                     base_type: base_type.clone(),
                     language_version: super::super::simple::current_language_version(),
                 },
@@ -376,6 +380,7 @@ pub(super) fn parse_enum_decl_body_with_type(
             name,
             variants,
             is_export,
+            is_my,
             base_type,
             language_version: super::super::simple::current_language_version(),
         },

--- a/src/parser/stmt/decl/my_decl.rs
+++ b/src/parser/stmt/decl/my_decl.rs
@@ -107,7 +107,7 @@ pub(super) fn my_decl_inner(input: &str, apply_modifier: bool) -> PResult<'_, St
     // my Array enum Foo <...>  (typed enum — base type is accepted but currently ignored)
     if let Some(r) = keyword("enum", rest) {
         let (r, _) = ws1(r)?;
-        return super::enum_decl::parse_enum_decl_body(r);
+        return super::enum_decl::parse_enum_decl_body(r, !is_our);
     }
     // Check for `my <Type> enum <Name> ...` (e.g., `my Array enum PageSizes «...»`)
     {
@@ -117,7 +117,7 @@ pub(super) fn my_decl_inner(input: &str, apply_modifier: bool) -> PResult<'_, St
             && let Some(r) = keyword("enum", after_ws)
             && let Ok((r, _)) = ws1(r)
         {
-            return super::enum_decl::parse_enum_decl_body_with_type(r, Some(_type_name));
+            return super::enum_decl::parse_enum_decl_body_with_type(r, Some(_type_name), !is_our);
         }
         rest = saved;
     }

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -257,6 +257,10 @@ impl Interpreter {
                 // implicitly our-scoped `subset` is forbidden.
                 Stmt::SubsetDecl { is_my: true, .. } => None,
                 Stmt::SubsetDecl { .. } => Some("subset"),
+                // A `my enum` is lexically scoped and private to the role body,
+                // which is allowed (like `my class`/`my subset`/`my role`); only
+                // an implicitly our-scoped `enum` is forbidden.
+                Stmt::EnumDecl { is_my: true, .. } => None,
                 Stmt::EnumDecl { .. } => Some("enum"),
                 // A `my role` is lexically scoped and private to the role body, which
                 // is allowed (like `my class`); only an implicitly our-scoped `role` is
@@ -394,6 +398,12 @@ impl Interpreter {
         // site regardless).
         let mut role_own_attrs: HashSet<String> = HashSet::new();
         let mut body_used_modules: HashSet<String> = HashSet::new();
+        // Types declared inside the role body itself (`my enum`, `my subset`,
+        // `my class`, ...) are not yet in the registry while the role's method
+        // signatures are validated, so collect their names to accept them as
+        // parameter/attribute constraints. The real registration happens when the
+        // role body runs.
+        let mut body_declared_types: HashSet<String> = HashSet::new();
         for stmt in &flattened_body {
             match stmt {
                 Stmt::HasDecl {
@@ -403,6 +413,12 @@ impl Interpreter {
                 }
                 Stmt::Use { module, .. } | Stmt::Need { module } | Stmt::Import { module, .. } => {
                     body_used_modules.insert(module.clone());
+                }
+                Stmt::EnumDecl { name, .. }
+                | Stmt::SubsetDecl { name, .. }
+                | Stmt::ClassDecl { name, .. }
+                | Stmt::RoleDecl { name, .. } => {
+                    body_declared_types.insert(name.resolve());
                 }
                 _ => {}
             }
@@ -818,6 +834,10 @@ impl Interpreter {
                             let self_short = name.rsplit_once("::").map(|(_, s)| s).unwrap_or(name);
                             let resolvable = tc_base == name
                                 || tc_base == self_short
+                                // A type declared in this role's own body (`my enum`,
+                                // `my subset`, ...) is not registered until the body
+                                // runs; accept its name here.
+                                || body_declared_types.contains(tc_base)
                                 || self.is_resolvable_type(tc)
                                 || (!tc.contains("::")
                                     && enclosing_prefixes.iter().any(|pfx| {

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -13,6 +13,7 @@ impl Interpreter {
             name,
             variants,
             is_export,
+            is_my: _,
             base_type,
             language_version,
         } = stmt

--- a/t/my-enum-and-type-params-in-role.t
+++ b/t/my-enum-and-type-params-in-role.t
@@ -1,0 +1,74 @@
+use v6;
+use Test;
+
+# A `my enum` (lexically scoped) is private to the role body and, unlike a
+# default our-scoped enum, is allowed inside a role. An `our`/bare enum inside a
+# role must still be rejected. Also covers: a type declared in the role body
+# used as a parameter constraint, and a role type parameter (`[::KeyT]`)
+# supplied AFTER the `:ver`/`:auth` adverbs.
+
+plan 6;
+
+# 1. `my enum` inside a role is accepted.
+{
+    role R1 {
+        my enum TOrder is export <DESC ASC>;
+        method first-order { TOrder::DESC }
+    }
+    class C1 does R1 { }
+    is C1.new.first-order.key, 'DESC', 'my enum inside a role works';
+}
+
+# 2. A bare (default our-scoped) enum inside a role is rejected.
+{
+    my $err = '';
+    try {
+        EVAL 'role RBad { enum EBad <A B>; }';
+        CATCH { default { $err = .message } }
+    }
+    like $err, /'our-scoped enum'/, 'bare enum inside a role is rejected';
+}
+
+# 3. An `our`-scoped enum inside a role is rejected.
+{
+    my $err = '';
+    try {
+        EVAL 'role ROur { our enum EOur <A B>; }';
+        CATCH { default { $err = .message } }
+    }
+    like $err, /'our-scoped enum'/, 'our enum inside a role is rejected';
+}
+
+# 4. A body-declared enum type used as a parameter constraint is accepted (the
+#    role used to fail to register with "Invalid typename 'Color'"). The enum is
+#    private to the role, so feed the value from inside a sibling method.
+{
+    role R4 {
+        my enum Color is export <Red Green>;
+        method paint(Color $c) { $c.key }
+        method paint-green { self.paint(Green) }
+    }
+    class C4 does R4 { }
+    is C4.new.paint-green, 'Green', 'body-declared enum usable as param type';
+}
+
+# 5. A role type parameter declared with `[::KeyT]` (no adverbs) constrains
+#    method params.
+{
+    role R5[::KeyT] {
+        method wrap(KeyT $k) { $k }
+    }
+    class C5 does R5[Int] { }
+    is C5.new.wrap(42), 42, 'plain role type param constrains method param';
+}
+
+# 6. A role type parameter supplied AFTER :ver/:auth adverbs is still captured,
+#    so the param constraint resolves (this used to error "Invalid typename").
+{
+    my $ok = 0;
+    try {
+        EVAL 'role R6:ver<1.0>:auth<zef:me>[::KeyT] { method wrap(KeyT $k) { $k } }; my $r = 1;';
+        $ok = 1;
+    }
+    ok $ok, 'role type param after :ver/:auth adverbs is captured';
+}


### PR DESCRIPTION
Fixes TICKETS **T-019** (Algorithm::Treap). The dist failed to load with three
related role-declaration gaps; with all three fixed it **fully loads, matching raku**.

1. **`my enum` inside a role** was rejected with *"Cannot declare our-scoped enum
   inside of a role"* — the check treated every `EnumDecl` as our-scoped. Added an
   `is_my` field to `EnumDecl` (threaded through the parser via the existing
   `is_our` flag) so only default/`our`-scoped enums are forbidden, like
   `my class`/`my subset`/`my role` already are. Bare/`our` enums are still rejected.

2. **A body-declared type used as a param constraint** (`my enum Color; method paint(Color $c)`)
   raised a false *"Invalid typename"*: the role's signature validation runs before
   the body registers those types. The role body is now pre-scanned for declared
   type names, mirroring the existing body-`use` allow-list.

3. **A role type parameter after `:ver`/`:auth` adverbs**
   (`unit role Foo:ver<..>:auth<..>[::KeyT]`) was dropped, so `KeyT` in a method
   signature became an unknown type. The unit-role parser only parsed `[...]`
   *before* the adverbs; added the same after-adverbs fallback the block-form role
   parser already has.

Pin: `t/my-enum-and-type-params-in-role.t` (6 subtests, output matches raku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)