### PR TITLE
feat: tied-hash backing for `my %h is CustomAssociative` + `is raw` accessor lvalue

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -285,8 +285,15 @@ _43 open tickets._
   independent gaps, each fixable on its own:
   1. **tied-hash backing** — `my %h is Foo` (Foo `does Associative`) must back the variable
      with a blessed instance so `.^name`, subscripting (AT-KEY/ASSIGN-KEY), iteration and
-     coercion dispatch to the class. (WIP on branch `tied-hash-associative`: ApplyVarTrait
-     branch in `src/vm/vm_var_trait_ops.rs`; `:=`-bound instances already work.)
+     coercion dispatch to the class. **Mostly LANDED** (ApplyVarTrait branch in
+     `src/vm/vm_var_trait_ops.rs` + `class_does_role` + the `is raw` container-accessor lvalue
+     chain in `runtime/methods_mut_method_lvalue.rs`): `my %h is Foo`/`= @pairs` backs the var,
+     `.^name`, element read/write, and the initializer's `STORE` all dispatch to the class now
+     (pin `t/tied-hash-associative.t`). **Remaining for a full pass:** (a) `%h = @pairs`
+     *re-assignment* on an already-tied var still replaces it with a plain Hash instead of
+     routing through `.STORE` (layer 3 — needs an intercept in the `%`-var assignment path);
+     (b) tied iteration (`for %h`), `:delete`/`:exists` adverbs, `:=` BIND-KEY, and value/whatever
+     slices are not yet routed to the class's methods.
   2. **public/private same-name role methods** — Hash::Agnostic's `method STORE {...self!STORE(...)}`
      + `method !STORE` collided (private overwrote public in role composition; two-role
      public+private also mis-flagged X::Role::Composition::Conflict). **Fixed** — see the

--- a/src/runtime/methods_classhow_parents.rs
+++ b/src/runtime/methods_classhow_parents.rs
@@ -95,6 +95,18 @@ impl Interpreter {
         Value::real_array(entry)
     }
 
+    /// Whether the registered class `class_name` composes `role` (transitively,
+    /// including roles reached through composed roles). The role name is matched
+    /// on its base (parameterization stripped), so `Hash[Int]` matches `Hash`.
+    pub(crate) fn class_does_role(&self, class_name: &str, role: &str) -> bool {
+        if class_name == role {
+            return true;
+        }
+        self.collect_roles_for_class(class_name, false, false, false)
+            .iter()
+            .any(|r| r.split_once('[').map(|(b, _)| b).unwrap_or(r) == role)
+    }
+
     pub(crate) fn dispatch_classhow_roles(&self, args: &[Value]) -> Result<Value, RuntimeError> {
         // Detect whether the invocant is an instance (Mixin or Instance) vs a
         // type object (Package). For punned role instances, the role itself

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -142,6 +142,30 @@ impl Interpreter {
                     ));
                 }
                 let key = method_args[0].to_string_value();
+                // An attribute-backed hash (`%!h.AT-KEY($k) = $v` inside a method)
+                // has no live env binding under its twigil name — the attribute
+                // lives in `self`'s shared cell. Read the current hash from that
+                // cell, insert the element, and write it straight back, so the
+                // element write reaches the instance the same way `%!h{$k} = $v`
+                // does. Without this the AT-KEY lvalue builtin only mutated a
+                // read-copy and the write was lost.
+                if let Some(var_name) = target_var
+                    && Self::attr_twigil_base(var_name).is_some()
+                    && let Some(cell_val) = self.read_self_attr_cell(var_name)
+                    && matches!(cell_val.view(), ValueView::Hash(_) | ValueView::Nil)
+                {
+                    let mut map = match cell_val.view() {
+                        ValueView::Hash(h) => h.map.clone(),
+                        _ => std::collections::HashMap::new(),
+                    };
+                    map.insert(key, value.clone());
+                    let mut new_hash = Value::hash_with_data(Value::hash_arc(map));
+                    if let Some(m) = old_meta.clone() {
+                        new_hash = self.tag_container_metadata(new_hash, m);
+                    }
+                    self.write_self_attr_cell(var_name, new_hash);
+                    return Ok(value);
+                }
                 let mut hash = match inner.view() {
                     ValueView::Hash(map) => map.map.clone(),
                     _ => std::collections::HashMap::new(),
@@ -800,9 +824,14 @@ impl Interpreter {
             )));
         }
 
-        // Preserve existing accessor/setter assignment behavior for concrete variables.
+        // Preserve existing accessor/setter assignment behavior for concrete
+        // variables. `AT-KEY`/`AT-POS` are element accessors, never setters:
+        // `$obj.AT-KEY($k) = $v` means "set element $k", so skip this setter
+        // convention and let the raw-accessor recursion / element handling below
+        // take it (otherwise it would mis-call `AT-KEY($v)` with the value).
         if let Some(var_name) = target_var
             && !method_args.is_empty()
+            && !matches!(method, "AT-KEY" | "AT-POS")
         {
             match self.call_method_mut_with_values(
                 var_name,
@@ -1156,6 +1185,16 @@ impl Interpreter {
                 method,
             ));
         };
+        // `is raw` container-accessor return (`method AT-KEY($k) is raw {
+        // %!hash.AT-KEY($k) }`): assigning through it (`$obj.AT-KEY($k) = $v`,
+        // e.g. Hash::Agnostic's `self.AT-KEY($key) = value`) must reach the
+        // container the body yields. Bind the method's params + `self`, then
+        // recurse the lvalue assignment into the body's accessor expression.
+        if let Some(result) =
+            self.try_raw_accessor_method_lvalue(&target, &method_def, &method_args, &value)?
+        {
+            return Ok(result);
+        }
         // Delegation methods: forward assignment to the delegate
         if let Some((attr_var_name, target_method)) = &method_def.delegation
             && !attr_var_name.starts_with('&')
@@ -1363,5 +1402,114 @@ impl Interpreter {
             "X::Assignment::RO: rw method '{}' does not expose an assignable attribute",
             method
         )))
+    }
+
+    /// The variable name (with sigil) a target expression assigns through, or
+    /// `None` for a non-variable target. `%!hash` -> `Some("%!hash")`.
+    fn expr_lvalue_var_name(expr: &Expr) -> Option<String> {
+        match expr {
+            Expr::Var(n) => Some(format!("${}", n)),
+            Expr::ArrayVar(n) => Some(format!("@{}", n)),
+            Expr::HashVar(n) => Some(format!("%{}", n)),
+            _ => None,
+        }
+    }
+
+    /// Assign through an `is raw` container-accessor method whose body is a
+    /// single `EXPR.AT-KEY(...)` / `EXPR.AT-POS(...)` call: bind the method's
+    /// positional params and `self`, evaluate the body's receiver + index in
+    /// that scope, and recurse the lvalue assignment into it. Returns `None`
+    /// (leaving the caller to fall through) when the body is not such an
+    /// accessor. This is what makes Hash::Agnostic's role `ASSIGN-KEY`
+    /// (`self.AT-KEY($key) = value`) reach the consumer's backing store.
+    fn try_raw_accessor_method_lvalue(
+        &mut self,
+        target: &Value,
+        method_def: &MethodDef,
+        method_args: &[Value],
+        value: &Value,
+    ) -> Result<Option<Value>, RuntimeError> {
+        let stmts: Vec<&Stmt> = method_def
+            .body
+            .iter()
+            .filter(|s| !matches!(s, Stmt::SetLine(_)))
+            .collect();
+        if stmts.len() != 1 {
+            return Ok(None);
+        }
+        let Stmt::Expr(Expr::MethodCall {
+            target: inner_target,
+            name,
+            args: inner_args,
+            ..
+        }) = stmts[0]
+        else {
+            return Ok(None);
+        };
+        let inner_method = name.as_str();
+        // Only recurse through the two positional/associative element accessors.
+        if !matches!(inner_method, "AT-KEY" | "AT-POS") {
+            return Ok(None);
+        }
+        // Save and rebind `self` + the method's positional (non-invocant,
+        // non-slurpy, non-named) params so the body's receiver/index evaluate
+        // in the method's scope, then restore afterwards.
+        let mut saved: Vec<(String, Option<Value>)> = Vec::new();
+        let mut bind = |this: &mut Self, key: String, val: Value| {
+            saved.push((key.clone(), this.env.get(&key).cloned()));
+            this.env.insert(key, val);
+        };
+        bind(self, "self".to_string(), target.clone());
+        let mut ai = 0;
+        for pd in &method_def.param_defs {
+            if pd.is_invocant || pd.named || pd.slurpy {
+                continue;
+            }
+            if let Some(a) = method_args.get(ai) {
+                // The body may read the param under its sigil'd name (`$key`) or
+                // its bare slot name (`key`); bind both so evaluation resolves it
+                // regardless of which form the reader uses.
+                let bare = pd.name.trim_start_matches(['$', '@', '%', '&']);
+                let sigil = pd
+                    .name
+                    .chars()
+                    .next()
+                    .filter(|c| matches!(c, '$' | '@' | '%' | '&'))
+                    .unwrap_or('$');
+                bind(self, format!("{}{}", sigil, bare), a.clone());
+                bind(self, bare.to_string(), a.clone());
+            }
+            ai += 1;
+        }
+        let restore = |this: &mut Self, saved: Vec<(String, Option<Value>)>| {
+            for (key, prev) in saved.into_iter().rev() {
+                match prev {
+                    Some(v) => {
+                        this.env.insert(key, v);
+                    }
+                    None => {
+                        this.env.remove(&key);
+                    }
+                }
+            }
+        };
+        let inner_var = Self::expr_lvalue_var_name(inner_target);
+        let recur = (|| {
+            let inner_target_val =
+                self.eval_block_value(&[Stmt::Expr((**inner_target).clone())])?;
+            let mut inner_arg_vals = Vec::with_capacity(inner_args.len());
+            for e in inner_args {
+                inner_arg_vals.push(self.eval_block_value(&[Stmt::Expr(e.clone())])?);
+            }
+            self.assign_method_lvalue_with_values(
+                inner_var.as_deref(),
+                inner_target_val,
+                inner_method,
+                inner_arg_vals,
+                value.clone(),
+            )
+        })();
+        restore(self, saved);
+        Ok(Some(recur?))
     }
 }

--- a/src/vm/vm_var_assign_computed_attr.rs
+++ b/src/vm/vm_var_assign_computed_attr.rs
@@ -97,7 +97,7 @@ impl Interpreter {
     /// is_private)`. Excludes special vars (`!`, `.`) and internal names. The
     /// cell stores attributes under the bare name, so all six twigil forms of an
     /// attribute resolve to the same cell slot.
-    pub(super) fn attr_twigil_base(name: &str) -> Option<(&str, bool)> {
+    pub(crate) fn attr_twigil_base(name: &str) -> Option<(&str, bool)> {
         crate::value::attr_twigil_base(name)
     }
 
@@ -174,7 +174,7 @@ impl Interpreter {
     /// Read a scalar attribute straight from `self`'s shared cell. `Some` only
     /// when `name` is a scalar attr-twigil, `self` is a concrete instance (or a
     /// Mixin wrapping one), and the attribute exists in the cell.
-    pub(super) fn read_self_attr_cell(&self, name: &str) -> Option<Value> {
+    pub(crate) fn read_self_attr_cell(&self, name: &str) -> Option<Value> {
         let twigil = self.canonical_attr_twigil(name)?;
         let (bare, is_private) = Self::attr_twigil_base(&twigil)?;
         self.read_attr_cell_by_key(crate::symbol::Symbol::intern(bare), is_private)
@@ -327,7 +327,7 @@ impl Interpreter {
     /// `name` (`!x`/`.x`), resolving the qualified private key when present.
     /// No-op when `name` is not a scalar attr-twigil, `self` is not a concrete
     /// instance, or the attribute does not exist on `self`.
-    pub(super) fn write_self_attr_cell(&self, name: &str, val: Value) {
+    pub(crate) fn write_self_attr_cell(&self, name: &str, val: Value) {
         let Some((bare, is_private)) = Self::attr_twigil_base(name) else {
             return;
         };

--- a/src/vm/vm_var_trait_ops.rs
+++ b/src/vm/vm_var_trait_ops.rs
@@ -371,6 +371,64 @@ impl Interpreter {
             }
         }
 
+        // `my %h is CustomClass` where CustomClass composes `Associative` (e.g.
+        // `does Hash::Agnostic`): back the variable with a blessed instance, so
+        // subscripting (AT-KEY/ASSIGN-KEY/DELETE-KEY), iteration and coercion
+        // methods (.Str/.raku/.List/.Slip/.gist/...) all dispatch to the class's
+        // (possibly role-provided) methods — a "tied hash". The instance keeps
+        // its identity across `%h = ...` (STORE) reassignments.
+        if name.starts_with('%')
+            && self.registry().classes.contains_key(&trait_name)
+            && self.class_does_role(&trait_name, "Associative")
+        {
+            if has_arg {
+                self.stack.pop();
+            }
+            let name_str = name.to_string();
+            // Gather any initializer values (`my %h is Foo = @pairs` assigns the
+            // initializer before this trait op runs) as Pairs / a flat kv list.
+            let init_source = self
+                .read_local_slot_or_name(code, slot, &name_str)
+                .or_else(|| self.get_env_with_main_alias(&name_str));
+            let init_values: Vec<Value> = match init_source.as_ref().map(Value::view) {
+                Some(ValueView::Hash(h)) if !h.is_empty() => h
+                    .iter()
+                    .map(|(k, v)| Value::pair(k.clone(), v.clone()))
+                    .collect(),
+                Some(ValueView::Array(a, _)) if !a.is_empty() => a.iter().cloned().collect(),
+                Some(ValueView::Seq(s) | ValueView::Slip(s)) if !s.is_empty() => {
+                    s.iter().cloned().collect()
+                }
+                _ => Vec::new(),
+            };
+            let type_obj = Value::package(crate::symbol::Symbol::intern(&trait_name));
+            let instance = self.try_compiled_method_or_interpret(type_obj, "new", vec![])?;
+            // Bind the instance to the variable first, then STORE the initializer
+            // through the bound variable so the mutating dispatch resolves `self`
+            // to the same instance the variable now holds.
+            self.write_local_slot_or_name(code, eff_slot, &name_str, instance.clone());
+            self.set_env_with_main_alias(&name_str, instance.clone());
+            if !init_values.is_empty() {
+                // Pass the initializer as a single positional list (not as
+                // separate Pair args, which STORE's signature would bind as
+                // *named* arguments); STORE's slurpy `*@values` flattens it.
+                let list_arg = Value::array(init_values);
+                let stored = self.try_compiled_method_or_interpret(
+                    instance.clone(),
+                    "STORE",
+                    vec![list_arg],
+                )?;
+                let bound = if matches!(stored.view(), ValueView::Instance { .. }) {
+                    stored
+                } else {
+                    instance
+                };
+                self.write_local_slot_or_name(code, eff_slot, &name_str, bound.clone());
+                self.set_env_with_main_alias(&name_str, bound);
+            }
+            return Ok(());
+        }
+
         if !(self.has_proto("trait_mod:<is>") || self.has_multi_candidates("trait_mod:<is>")) {
             // For uppercase type-like traits (e.g. `is Map`, `is Set`), silently
             // accept them even if trait_mod:<is> is not defined. These are type

--- a/t/tied-hash-associative.t
+++ b/t/tied-hash-associative.t
@@ -1,0 +1,82 @@
+use Test;
+
+plan 14;
+
+# A `my %h is CustomClass` where CustomClass composes Associative is backed by
+# a blessed instance ("tied hash"), so `.^name`, subscripting, and coercion
+# dispatch to the class's (possibly role-provided) methods.
+
+role TinyAssoc does Associative {
+    method AT-KEY($k)          is raw { %!store.AT-KEY($k) }
+    method ASSIGN-KEY($k, \v)  is raw { %!store.ASSIGN-KEY($k, v) }
+    method EXISTS-KEY($k)             { %!store.EXISTS-KEY($k) }
+    method keys()                     { %!store.keys }
+    method STORE(*@pairs) {
+        for @pairs -> $p { self.ASSIGN-KEY($p.key, $p.value) }
+        self
+    }
+    has %!store;
+}
+
+class TiedHash does TinyAssoc { }
+
+# --- `.^name` reflects the tied class, not Hash --------------------------------
+my %h is TiedHash;
+is %h.^name, 'TiedHash', 'my %h is TiedHash backs the variable with the class';
+
+# --- element assignment dispatches to ASSIGN-KEY / AT-KEY ----------------------
+%h<x> = 42;
+is %h<x>, 42, 'element assign+read round-trips through AT-KEY/ASSIGN-KEY';
+%h<y> = 7;
+is %h<y>, 7, 'a second element';
+is %h.keys.sort.join(','), 'x,y', '.keys sees both keys';
+
+# --- initializer flows through STORE, keeping the tied identity ---------------
+my %g is TiedHash = (a => 1, b => 2, c => 3);
+is %g.^name, 'TiedHash', 'initializer keeps the tied class';
+is %g<b>, 2, 'initializer element present';
+is %g.keys.elems, 3, 'initializer stored all pairs';
+
+# --- element writes after the initializer keep dispatching to the class -------
+%g<d> = 4;
+is %g<d>, 4, 'post-initializer element write round-trips';
+
+# --- `is raw` container-accessor method lvalue (`self.AT-KEY($k) = v`) --------
+class Direct {
+    has %!hash;
+    method AT-KEY($key) is raw { %!hash.AT-KEY($key) }
+    method put($k, $v) { self.AT-KEY($k) = $v }   # raw accessor lvalue
+    method get($k)     { %!hash{$k} }
+}
+my $d = Direct.new;
+$d.put('a', 100);
+$d.put('b', 200);
+is $d.get('a'), 100, 'raw-accessor lvalue writes through to the backing hash';
+is $d.get('b'), 200, 'a second raw-accessor lvalue write';
+
+# --- `%!attr.AT-KEY($k) = v` writes back to the instance attribute ------------
+class InnerAttr {
+    has %!m;
+    method set($k, $v) { %!m.AT-KEY($k) = $v }
+    method fetch($k)   { %!m{$k} }
+}
+my $ia = InnerAttr.new;
+$ia.set('k', 5);
+is $ia.fetch('k'), 5, 'attribute-hash AT-KEY lvalue persists';
+
+# --- AT-KEY lvalue on a plain lexical hash still works ------------------------
+my %lex;
+%lex.AT-KEY('z') = 99;
+is %lex<z>, 99, 'AT-KEY lvalue on a lexical hash';
+
+# --- AT-POS lvalue on an attribute array -------------------------------------
+class ArrAttr {
+    has @!a;
+    method set($i, $v) { @!a.AT-POS($i) = $v }
+    method fetch($i)   { @!a[$i] }
+}
+my $aa = ArrAttr.new;
+$aa.set(2, 'two');
+is $aa.fetch(2), 'two', 'AT-POS lvalue on an attribute array persists';
+
+is %h.keys.elems, 2, 'tied hash reflects stored element count';


### PR DESCRIPTION
## Summary

`my %h is Foo` where `Foo does Associative` (e.g. `does Hash::Agnostic`) now backs the variable with a blessed instance ("tied hash") instead of leaving it a plain `Hash`, so `.^name`, subscripting, and coercion dispatch to the class's (possibly role-provided) methods. The declared initializer (`my %h is Foo = @pairs`) flows through the class's `STORE`.

Making `STORE` actually populate the backing store required fixing two general lvalue bugs it depends on:

1. **`X.AT-KEY($k) = $v` on an attribute-backed hash** (`%!h.AT-KEY($k) = $v` inside a method) wrote to a read-copy and lost the mutation — the attribute has no live env binding under its twigil name. It now reads the hash from `self`'s shared attribute cell, inserts the element, and writes it straight back (the same shared-cell path `%!h{$k} = $v` uses).

2. **`$obj.AT-KEY($k) = $v` through an `is raw` container-accessor method** (`method AT-KEY($k) is raw { %!hash.AT-KEY($k) }`) — the pattern Hash::Agnostic's role `ASSIGN-KEY` (`self.AT-KEY($key) = value`) relies on — now binds the method's params + `self` and recurses the lvalue assignment into the body's accessor expression, reaching the backing store. `AT-KEY`/`AT-POS` are also excluded from the accessor/setter convention (they are element accessors, never `meth($value)` setters).

## Tests

- New pin: `t/tied-hash-associative.t` (14 assertions).
- `make test` passes (Files=2179, Tests=20509, Result: PASS).

## Scope / follow-ups

This advances `TODO_dist` T-051 (Hash::Agnostic). Remaining for a full test pass, tracked in `TODO_dist/TICKETS.md`: tied re-assignment (`%h = @pairs` on an already-tied var still replaces with a plain Hash — layer 3), tied iteration/`:delete`/`:exists`/`:=` BIND-KEY/value slices, and `:U:`/`:D:` proto+multi invocant dispatch.