### PR TITLE
feat: model the CallFrame setting frame and for-block frames

### DIFF
--- a/docs/callframe-introspection-plan.md
+++ b/docs/callframe-introspection-plan.md
@@ -1,8 +1,29 @@
 # CallFrame introspection — implementation plan
 
-Status: **Planned** (investigated 2026-07-21, not yet started). Target: the four
-`Type/CallFrame.rakudoc` doc-diff findings, plus the related `.annotations`/`.code`
-accessors. This is a **medium feature** (frame modeling), not a quick accessor fix —
+Status: **Mostly implemented** (2026-07-21). Landed:
+
+- **G4** `.annotations` returns a `Map` (and a `Map` is no longer `~~ Hash`) — PR #5095.
+- **G2** the synthetic "setting" frame: `callframe(1)` at the top level is now
+  line 1 / code `Mu`, one level above the mainline. Deeper levels yield `Mu`.
+- **G1/G3** the `for`-block frame: a `for` body is a distinct Raku call frame, so
+  `callframe(0)` inside a `for` body is a `Block` and the enclosing routine is one
+  level up. This makes the documented `calling-frame` walk reach `(GLOBAL)`. The
+  block nesting is counted at compile time (`Compiler::callframe_block_depth`) and
+  passed as the hidden `__callframe_blocks` arg, so there is **zero runtime cost** —
+  no per-iteration frame push. Only `for` blocks are counted; `while`/`loop`/`if`
+  bodies are elided frames in Rakudo (optimizer-dependent, not a clean syntactic
+  property) and are deliberately not modeled. Pins: `t/callframe-for-block-frame.t`,
+  `t/callframe-setting-frame.t`, `t/callframe-annotations-map.t`.
+
+**Deferred (1 finding):** the statement-form `FIRST` phaser example
+(`FIRST $frame = callframe; ... say $frame.code()` → `Code.new`). Rakudo models a
+*statement-form* phaser as a `Code` frame but a *block-form* phaser (`FIRST { }`) as
+a `Block` frame; mutsu's AST desugars both to `Phaser { body }` and does not
+preserve the distinction, and there is no roast coverage. The `.my<$the-answer>`
+example is raku-drift (`LoweredAwayLexical`), not a mutsu bug.
+
+Original investigation (target: the four `Type/CallFrame.rakudoc` doc-diff findings)
+follows. This was a **medium feature** (frame modeling), not a quick accessor fix —
 see "Why it is not a clean slice" below.
 
 Source of truth for expected behavior is reference `raku` (Rakudo v2026.06). Every

--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -116,13 +116,17 @@ intentionally deferred; see PLAN.md §8.5 and the ADRs:
   (NB: `regexes.rakudoc` [3] `<same>` is a *separate* missing builtin subrule, not this root.)
 - **WHICH-keyed QuantHash storage** — `QuantHash.rakudoc`, `Baggy`, `setbagmix` (Set/Bag key by stringification).
 - **Custom `does Iterable`/`does Iterator` protocol** — `iterating.rakudoc`, `Iterator.rakudoc`.
-- **CallFrame frame modeling** — `CallFrame.rakudoc` (4 findings). The accessors
-  (`.line`/`.file`/`.annotations`) already work; the gaps are frame *modeling*:
-  `.code` is `Nil` for block/phaser/mainline frames (raku: `Block`/`Code`/`Mu`),
-  there is no bootstrap "setting" frame so `callframe(1)` at top level is `Nil`
-  (raku: line 1, code `Mu`), and `.annotations` returns `Hash` not `Map`. Medium
-  feature, not a shallow accessor fix — full investigation and a sequenced plan (G1–G4,
-  with G4 `.annotations→Map` a small standalone win) are in
+- **CallFrame frame modeling** — `CallFrame.rakudoc`. Mostly landed: G4
+  `.annotations→Map` (#5095), G2 the synthetic "setting" frame (`callframe(1)` at
+  top level is now line 1 / code `Mu`), and G1/G3 the `for`-block frame (a `for`
+  body is a distinct call frame, so the documented `calling-frame` walk reaches
+  `(GLOBAL)`). The `for`-block level is a compile-time count (`callframe_block_depth`)
+  passed as the hidden `__callframe_blocks` arg — zero runtime cost. **Remaining (1
+  finding, deferred):** the statement-form `FIRST` phaser example (`$frame.code()`
+  → `Code.new`) — Rakudo models a statement-form phaser as a `Code` frame and a
+  block-form phaser as a `Block` frame, a distinction mutsu's AST does not preserve
+  (both desugar to `Phaser { body }`), and there is no roast coverage. The
+  remaining `.my<$the-answer>` example is raku-drift (`LoweredAwayLexical`). See
   [docs/callframe-introspection-plan.md](callframe-introspection-plan.md).
 
 ### Untriaged
@@ -167,7 +171,7 @@ re-verify each block against `raku` before writing a fix.
 | Language/functions.rakudoc | 3 | 2 | 0 |
 | Language/nativecall.rakudoc | 1 | 4 | 0 |
 | Language/experimental.rakudoc | 0 | 5 | 0 |
-| Type/CallFrame.rakudoc | 4 | 0 | 1 |
+| Type/CallFrame.rakudoc | 1 | 0 | 1 |
 | Language/unicode.rakudoc | 4 | 0 | 1 |
 | Language/hashmap.rakudoc | 4 | 0 | 1 |
 | Type/Routine.rakudoc | 3 | 1 | 1 |

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -32,7 +32,37 @@ impl Compiler {
         }
     }
 
+    /// True when `expr` is a `key => value` named argument whose key is the
+    /// literal string `key`.
+    fn is_named_arg_key(expr: &Expr, key: &str) -> bool {
+        matches!(expr, Expr::Binary { left, op, .. }
+            if *op == crate::token_kind::TokenKind::FatArrow
+                && matches!(left.as_ref(), Expr::Literal(l)
+                    if matches!(l.view(), crate::value::ValueView::Str(s) if s.as_str() == key)))
+    }
+
     pub(super) fn compile_expr_call(&mut self, name: &Symbol, args: &[Expr]) {
+        // `callframe`/`caller` inside N enclosing `for` blocks must report the
+        // frames those blocks introduce. The block nesting is a compile-time
+        // property of the call site, so capture it as a hidden `__callframe_blocks`
+        // named arg for the runtime to offset the requested level (see
+        // `Compiler::callframe_block_depth`). Guarded against re-injection so the
+        // recursive re-dispatch terminates.
+        if self.callframe_block_depth > 0
+            && name == "callframe"
+            && !args
+                .iter()
+                .any(|a| Self::is_named_arg_key(a, "__callframe_blocks"))
+        {
+            let mut new_args = args.to_vec();
+            new_args.push(Expr::Binary {
+                left: Box::new(Expr::Literal(Value::str("__callframe_blocks".to_string()))),
+                op: crate::token_kind::TokenKind::FatArrow,
+                right: Box::new(Expr::Literal(Value::int(self.callframe_block_depth as i64))),
+            });
+            self.compile_expr_call(name, &new_args);
+            return;
+        }
         // Parser-rewritten atomic-op forms (`⚛$x`, `$x ⚛= v`, `$x⚛++`) arrive
         // here already lowered to `__mutsu_atomic_*_var(<var-name-literal>, …)`
         // (the explicit `atomic-fetch($x)` / `cas($x, …)` named forms are handled

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -258,7 +258,10 @@ impl Compiler {
                 body_declares_routines: Self::stmts_declare_routines(&loop_body),
             })));
         self.hoist_sub_decls(&loop_body, true);
+        // A `for` body is its own Raku call frame (see `callframe_block_depth`).
+        self.callframe_block_depth += 1;
         self.compile_collected_loop_body(&loop_body);
+        self.callframe_block_depth -= 1;
         self.code.patch_loop_end(loop_idx);
         // Balance the ForLoop opcode's deferred param-restore push (see the
         // Stmt::For compile path). Required even though this collected form has

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -114,6 +114,15 @@ pub(crate) struct Compiler {
     dynamic_scope_names: Option<std::collections::HashSet<String>>,
     /// Track dynamic variable accesses (names starting with '*') for postdeclaration check
     accessed_dynamic_vars: std::collections::HashSet<String>,
+    /// Number of enclosing `for`-loop blocks between the code currently being
+    /// compiled and the enclosing routine. A `for` block is a distinct call
+    /// frame in Raku (`callframe(0)` inside a `for` body is the block, the
+    /// routine is one level up), so `callframe`/`caller` call sites capture this
+    /// depth (as the hidden `__callframe_blocks` arg) and the runtime offsets the
+    /// requested level by it. Reset to 0 for each nested routine (nested subs get
+    /// a fresh `Compiler`). Only `for` blocks are counted: `while`/`loop`/`if`
+    /// bodies are elided frames in Rakudo and unreliable to model.
+    pub(crate) callframe_block_depth: u32,
     /// Whether we are compiling inside a routine (sub/method). `return` outside
     /// a routine must throw X::ControlFlow::Return instead of normal return.
     pub(crate) is_routine: bool,
@@ -286,6 +295,7 @@ impl Compiler {
             dynamic_scope_all: false,
             dynamic_scope_names: None,
             accessed_dynamic_vars: std::collections::HashSet::new(),
+            callframe_block_depth: 0,
             is_routine: false,
             lexically_in_routine: false,
             lexically_in_method: false,

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1993,7 +1993,12 @@ impl Compiler {
                     self.compile_stmt(s);
                 }
                 self.hoist_sub_decls(&loop_body, true);
+                // A `for` body is its own Raku call frame; count it so a
+                // `callframe`/`caller` inside sees the enclosing routine one
+                // level further up (see `callframe_block_depth`).
+                self.callframe_block_depth += 1;
                 self.compile_body_with_implicit_try(&loop_body);
+                self.callframe_block_depth -= 1;
                 for n in &newly_registered {
                     self.sigilless_locals.remove(n);
                 }

--- a/src/runtime/builtins_eval_misc.rs
+++ b/src/runtime/builtins_eval_misc.rs
@@ -24,6 +24,7 @@ impl Interpreter {
     ) -> Result<Value, RuntimeError> {
         let mut depth = default_depth;
         let mut callsite_line: Option<i64> = None;
+        let mut nblocks: usize = 0;
         for arg in args {
             match arg.view() {
                 ValueView::Int(i) if i >= 0 => depth = i as usize,
@@ -33,10 +34,15 @@ impl Interpreter {
                         callsite_line = Some(line);
                     }
                 }
+                ValueView::Pair(k, v) if k == "__callframe_blocks" => {
+                    if let ValueView::Int(n) = v.view() {
+                        nblocks = n.max(0) as usize;
+                    }
+                }
                 _ => {}
             }
         }
-        if let Some(frame) = self.callframe_value(depth, callsite_line) {
+        if let Some(frame) = self.callframe_value(depth, callsite_line, nblocks) {
             return Ok(frame);
         }
         Ok(Value::NIL)
@@ -95,7 +101,7 @@ impl Interpreter {
 
         // If no caller found in routine_stack, fall back to callframe
         if caller_start_idx.is_none() && type_filter.is_none() && skip == 0 {
-            if let Some(frame) = self.callframe_value(1, callsite_line) {
+            if let Some(frame) = self.callframe_value(1, callsite_line, 0) {
                 return Ok(frame);
             }
             return Ok(Value::package(Symbol::intern("Mu")));

--- a/src/runtime/system_introspect.rs
+++ b/src/runtime/system_introspect.rs
@@ -8,12 +8,22 @@ impl Interpreter {
         &self,
         depth: usize,
         callsite_line: Option<i64>,
+        nblocks: usize,
     ) -> Option<Value> {
         let file = self
             .env
             .get("?FILE")
             .map(|v| v.to_string_value())
             .unwrap_or_default();
+
+        // Each enclosing `for` block introduces a Raku call frame between the
+        // call site and its routine. The compiler counted them (`nblocks`); the
+        // first `nblocks` levels are those block frames, and the routine/caller
+        // stack begins at `depth - nblocks`.
+        if depth < nblocks {
+            return Some(self.block_frame_value(&file, callsite_line));
+        }
+        let depth = depth - nblocks;
 
         if depth == 0 {
             // Current frame: use current env, current file/line, current code
@@ -35,6 +45,14 @@ impl Interpreter {
         // depth >= 1: walk up the caller env stack
         let stack_len = self.callframe_stack.len();
         if depth > stack_len {
+            // One level past the outermost real frame is the synthetic "setting"
+            // frame: raku always has an outer setting/bootstrap frame above the
+            // unit's mainline. It reports line 1 (where control entered the
+            // compilation unit) and a `Mu` code object. Anything deeper has no
+            // call information and yields Mu (`None` here -> Nil at the caller).
+            if depth == stack_len + 1 {
+                return Some(self.setting_frame_value(&file));
+            }
             return None;
         }
         let entry = &self.callframe_stack[stack_len - depth];
@@ -50,6 +68,42 @@ impl Interpreter {
         attrs.insert("__depth".to_string(), Value::int(depth as i64));
         attrs.insert("annotations".to_string(), self.build_annotations(&attrs));
         Some(Value::make_instance(Symbol::intern("CallFrame"), attrs))
+    }
+
+    /// Build a synthetic CallFrame for an enclosing `for` block. Its `code` is
+    /// the `Block` type object (`.^name` -> `Block`, `~~ Routine` -> False), its
+    /// line is the call site, and its lexicals come from the current env (the
+    /// block body is inlined into the enclosing routine's scope in mutsu).
+    fn block_frame_value(&self, file: &str, callsite_line: Option<i64>) -> Value {
+        let code = Value::package(Symbol::intern("Block"));
+        let my_hash = self.build_lexical_hash(&self.env, None);
+        let mut attrs = HashMap::new();
+        attrs.insert("line".to_string(), Value::int(callsite_line.unwrap_or(0)));
+        attrs.insert("file".to_string(), Value::str(file.to_string()));
+        Self::insert_callframe_code_attrs(&mut attrs, &code);
+        attrs.insert("code".to_string(), code);
+        attrs.insert("my".to_string(), my_hash);
+        attrs.insert("inline".to_string(), Value::FALSE);
+        attrs.insert("__depth".to_string(), Value::int(0));
+        attrs.insert("annotations".to_string(), self.build_annotations(&attrs));
+        Value::make_instance(Symbol::intern("CallFrame"), attrs)
+    }
+
+    /// Build the synthetic "setting" CallFrame that sits above the mainline.
+    /// Its `line` is 1 (the unit entry point), its `code` is the `Mu` type
+    /// object, and its annotations mirror `line`/`file`.
+    fn setting_frame_value(&self, file: &str) -> Value {
+        let code = Value::package(Symbol::intern("Mu"));
+        let mut attrs = HashMap::new();
+        attrs.insert("line".to_string(), Value::int(1));
+        attrs.insert("file".to_string(), Value::str(file.to_string()));
+        Self::insert_callframe_code_attrs(&mut attrs, &code);
+        attrs.insert("code".to_string(), code);
+        attrs.insert("my".to_string(), Value::hash(HashMap::new()));
+        attrs.insert("inline".to_string(), Value::FALSE);
+        attrs.insert("__depth".to_string(), Value::int(1));
+        attrs.insert("annotations".to_string(), self.build_annotations(&attrs));
+        Value::make_instance(Symbol::intern("CallFrame"), attrs)
     }
 
     /// Extract subname, package, subtype, and sub attributes from a code value

--- a/t/callframe-for-block-frame.t
+++ b/t/callframe-for-block-frame.t
@@ -1,0 +1,57 @@
+use v6;
+use Test;
+
+plan 11;
+
+# A `for` block is its own Raku call frame: callframe(0) inside a for body is
+# the block, and the enclosing routine is one level up. (Type/CallFrame.rakudoc
+# "calling-frame" example.)
+
+# --- The documented calling-frame idiom -------------------------------------
+sub calling-frame() {
+    for 1..* -> $level {
+        given callframe($level) -> $frame {
+            when $frame ~~ CallFrame {
+                next unless $frame.code ~~ Routine;
+                return $frame.code.package.gist;
+            }
+            default { return "no calling routine or method found"; }
+        }
+    }
+}
+is calling-frame(), '(GLOBAL)', 'calling-frame walk reaches the enclosing routine';
+
+# --- Frame kinds inside a for body ------------------------------------------
+sub s {
+    for 1 -> $x {
+        is callframe(0).code.^name, 'Block', 'callframe(0) in a for body is a Block';
+        ok callframe(0).code !~~ Routine, 'the for-block frame is not a Routine';
+        is callframe(1).code.^name, 'Sub', 'callframe(1) is the enclosing sub';
+        ok callframe(1).code ~~ Routine, 'the enclosing frame is a Routine';
+        is callframe(1).code.name, 's', 'the enclosing sub is named s';
+    }
+}
+s();
+
+# --- Two nested for blocks --------------------------------------------------
+sub t {
+    for 1 -> $a {
+        for 1 -> $b {
+            is callframe(0).code.^name, 'Block', 'inner for-block is a Block';
+            is callframe(1).code.^name, 'Block', 'outer for-block is a Block';
+            is callframe(2).code.^name, 'Sub',   't is two levels up';
+            is callframe(2).code.name, 't', 'the routine two levels up is t';
+        }
+    }
+}
+t();
+
+# A sub declared inside a for body still resets the block depth: callframe(0)
+# inside it is the sub itself, not a synthetic block frame.
+sub outer {
+    for 1 {
+        sub inner { callframe(0).code.^name }
+        is inner(), 'Sub', 'a sub nested in a for body resets the frame depth';
+    }
+}
+outer();

--- a/t/callframe-setting-frame.t
+++ b/t/callframe-setting-frame.t
@@ -1,0 +1,21 @@
+use v6;
+use Test;
+
+plan 6;
+
+# The synthetic "setting" frame sits one level above the unit mainline. It
+# reports line 1 (where control entered the unit) and a `Mu` code object.
+# (Type/CallFrame.rakudoc method-line example.)
+
+# At the top level, callframe(1) is the setting frame.
+is callframe(1).line, 1, 'callframe(1).line at top level is 1 (setting frame)';
+is callframe(1).annotations<line>, 1, 'the setting frame annotation matches .line';
+is callframe(1).code.^name, 'Mu', 'the setting frame code is Mu';
+ok callframe(1) ~~ CallFrame, 'the setting frame is a CallFrame';
+
+# One deeper is out of call information: callframe(2) at the top level is Mu.
+ok callframe(2) ~~ Mu, 'callframe(2) past the setting frame is Mu';
+
+# From inside a sub, the setting frame is one past the mainline caller.
+sub s { callframe(2) }
+ok s() ~~ CallFrame, 'callframe(2) from a top-level sub is the setting frame';


### PR DESCRIPTION
## Summary

Fixes two of the three actionable `Type/CallFrame.rakudoc` doc-diff findings by
adding the frame modeling mutsu lacked (the third is `raku`-version drift).
Follows #5095 (`.annotations → Map`).

- **Setting frame (G2):** `callframe(1)` at the top level is now the synthetic
  "setting" frame — line 1, code `Mu` — one level above the unit mainline.
  Deeper levels yield `Mu`.
- **`for`-block frame (G1/G3):** a `for` body is a distinct Raku call frame, so
  `callframe(0)` inside a `for` body is a `Block` and the enclosing routine is
  one level up. This makes the documented `calling-frame` walk return
  `(GLOBAL)` instead of `no calling routine or method found`.

## Design — zero runtime cost

The `for`-block nesting is a **compile-time** property of the `callframe` call
site, so the compiler counts enclosing `for` blocks (`callframe_block_depth`,
reset per routine because nested subs get a fresh `Compiler`) and passes the
count as a hidden `__callframe_blocks` arg. The runtime offsets the requested
level by it. There is **no per-iteration frame push** on the hot loop path.

Only `for` blocks are counted. `while`/`loop`/`if` bodies are optimizer-elided
frames in Rakudo (their frame presence is optimizer-dependent, not a clean
syntactic property), so they are deliberately left unmodeled rather than
guessed.

## Deferred

The statement-form `FIRST` phaser example (`FIRST $frame = callframe; …
$frame.code()` → `Code.new`) is deferred: Rakudo models a *statement-form*
phaser as a `Code` frame but a *block-form* phaser (`FIRST { }`) as a `Block`
frame, a distinction mutsu's AST does not preserve (both desugar to
`Phaser { body }`), and there is no roast coverage. Recorded in
`docs/callframe-introspection-plan.md`.

## Tests

New pins `t/callframe-for-block-frame.t` (11) and `t/callframe-setting-frame.t`
(6), both verified against reference `raku`. `roast/S06-advanced/callframe.t`
(whitelisted, 22/22) and the for/while/loop roast suites still pass; full
`make test` green (2182 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)