### PR TITLE
fix: allow a subscript directly on a hyper method call

### DIFF
--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -1705,6 +1705,14 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     | Expr::BareWord(_)
                     | Expr::Index { .. }
                     | Expr::MethodCall { .. }
+                    // A hyper method call may be directly subscripted, just like a
+                    // plain method call: `@a>>.b{$k}` is `(@a>>.b){$k}` (raku applies
+                    // `postcircumfix:<{ }>` to the hyper-dispatch result). Without
+                    // this the `{$k}` was left as a separate block statement, which
+                    // silently truncated the enclosing declaration list (e.g. a role
+                    // body would drop every method after such a call).
+                    | Expr::HyperMethodCall { .. }
+                    | Expr::HyperMethodCallDynamic { .. }
                     | Expr::Call { .. }
                     | Expr::Literal(_)
                     | Expr::DoStmt(_)

--- a/t/hyper-method-call-subscript.t
+++ b/t/hyper-method-call-subscript.t
@@ -1,0 +1,48 @@
+use v6;
+use Test;
+
+# A hyper method call (`>>.name` / `».name`) may be directly subscripted, just
+# like a plain method call: `@a>>.b{$k}` parses as `(@a>>.b){$k}`. Previously the
+# `{...}` was left as a *separate block statement*, which silently truncated the
+# enclosing declaration list — a role body would drop every method declared after
+# such a call, so a later private method vanished from composition.
+
+plan 4;
+
+# 1. Positional subscript on a hyper method call result evaluates correctly.
+{
+    my @a = [1, 2, 3], [4, 5, 6];
+    is (@a>>.reverse)[0].join(','), '3,2,1', 'positional subscript on hyper result';
+}
+
+# 2. The subscript form without explicit grouping parses the same way.
+{
+    my @a = [1, 2, 3], [4, 5, 6];
+    is (@a>>.reverse[0]).join(','), '3,2,1', 'hyper-call subscript without extra parens';
+}
+
+# 3. A `>>.method{subscript}` inside a method-call argument must not swallow the
+#    rest of the enclosing role body. The private `!init` declared AFTER such a
+#    method used to be dropped, so `self!init` failed at composition.
+{
+    role R {
+        has %.opt;
+        method pick($k) { self.wrap(self.opt>>.self{$k}) }
+        method wrap($v) { $v }
+        method !init() { 'inited' }
+        method run() { self!init }
+    }
+    class C does R { }
+    is C.new.run, 'inited', 'private method after >>.m{subscript} survives composition';
+}
+
+# 4. The same construct in a bare parenthesized expression also keeps following
+#    statements intact (a positional subscript, whose runtime semantics are
+#    unambiguous, exercised here).
+{
+    my @a = [10, 20], [30, 40];
+    my $i = 1;
+    my $picked = (@a>>.reverse[$i]);
+    my $after = 'reached';
+    is $after, 'reached', 'statement after paren >>.m[subscript] still runs';
+}


### PR DESCRIPTION
Fixes TICKETS **T-020** (Menu::Simple). With this the dist **fully loads, matching raku**.

`@a>>.b{$k}` — a `{...}` postcircumfix directly after a `>>.name`/`».name` hyper
method call — was not recognized as a subscript: `HyperMethodCall` /
`HyperMethodCallDynamic` were missing from the postfix `{...}` allow-list, so the
`{$k}` was parsed as a **separate block statement**.

Inside a declaration list this silently truncated everything after it: a role
body dropped every method declared *after* such a call, so a later **private
method vanished from composition** and `self!that-method` failed at runtime with
*"No such private method"* (Menu::Simple's `role Option-group` has
`self.get-option(self.options>>.option-menu-number{$menu-number})` before its
private `!counter-init`).

Now `@a>>.b{$k}` parses as `(@a>>.b){$k}`, matching raku's `postcircumfix:<{ }>`
on the hyper-dispatch result — the same treatment `.b{$k}` already gets on a
plain method call.

Pin: `t/hyper-method-call-subscript.t` (4 subtests, output matches raku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)