### PR TITLE
fix: role `::?ROLE:U:`/`:D:` multi methods dispatch by invocant definedness

### DIFF
--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -30,17 +30,29 @@ impl Interpreter {
                 continue;
             }
             if let Some(constraint) = pd.type_constraint.as_deref() {
-                if let Some(captured_name) = constraint.strip_prefix("::") {
+                // `::?CLASS` / `::?ROLE` are pseudo-types (the current class), NOT
+                // type captures — `constraint.strip_prefix("::")` would otherwise
+                // read them as a capture named `?CLASS`/`?ROLE:U` and both bind a
+                // bogus capture and skip the invocant check, so a role's
+                // `multi method m(::?ROLE:U:)` / `(::?ROLE:D:)` pair became an
+                // ambiguous call once composed into a class. Only a genuine
+                // `::T` capture (not starting with `?`) binds here.
+                if let Some(captured_name) = constraint.strip_prefix("::")
+                    && !captured_name.starts_with('?')
+                {
                     self.bind_type_capture(
                         captured_name,
                         &Value::package(Symbol::intern(class_name)),
                     );
                 }
                 // Check type constraint on the invocant (including :U/:D smileys).
-                // Resolve ::?CLASS to the actual class name for matching.
-                // Pure type captures (e.g. ::T) don't constrain the invocant.
+                // Resolve the `::?CLASS`/`::?ROLE` pseudo-types to the actual
+                // class name for matching. Pure type captures (e.g. ::T) don't
+                // constrain the invocant.
                 if let Some(inv) = invocant {
-                    let resolved = constraint.replace("::?CLASS", class_name);
+                    let resolved = constraint
+                        .replace("::?CLASS", class_name)
+                        .replace("::?ROLE", class_name);
                     let is_type_capture = resolved.starts_with("::");
                     if !is_type_capture && !self.type_matches_value(&resolved, inv) {
                         self.env = saved_env;

--- a/t/role-ud-multi-dispatch.t
+++ b/t/role-ud-multi-dispatch.t
@@ -1,0 +1,52 @@
+use Test;
+
+plan 8;
+
+# A role's `multi method m(::?ROLE:U:)` / `(::?ROLE:D:)` pair must resolve by the
+# invocant's definedness once composed into a class — the `:U`/`:D` smiley on the
+# `::?ROLE` pseudo-type was previously read as a bogus type capture, skipping the
+# invocant check and making the call ambiguous.
+
+role R {
+    proto method describe(|) {*}
+    multi method describe(::?ROLE:U:) { 'type object' }
+    multi method describe(::?ROLE:D:) { 'instance' }
+}
+class C does R { }
+
+is C.describe,     'type object', '::?ROLE:U: selected on a type object';
+is C.new.describe, 'instance',    '::?ROLE:D: selected on an instance';
+
+# `::?CLASS:U:` / `:D:` on a plain class keeps working.
+class D {
+    proto method kind(|) {*}
+    multi method kind(::?CLASS:U:) { 'undef' }
+    multi method kind(::?CLASS:D:) { 'def' }
+}
+is D.kind,     'undef', '::?CLASS:U: on a type object';
+is D.new.kind, 'def',   '::?CLASS:D: on an instance';
+
+# A concrete-type invocant smiley (`C:U:` / `C:D:`) still dispatches too.
+class E {
+    proto method q(|) {*}
+    multi method q(E:U:) { 'u' }
+    multi method q(E:D:) { 'd' }
+}
+is E.q,     'u', 'E:U: on a type object';
+is E.new.q, 'd', 'E:D: on an instance';
+
+# A genuine `::T` type capture on the invocant is unaffected.
+role Cap {
+    method whoami(::T:) { T.^name }
+}
+class F does Cap { }
+is F.whoami, 'F', '::T invocant capture binds the class';
+
+# `.gist`-style role multi (the Hash::Agnostic shape) picks the right candidate.
+role G {
+    proto method gist(|) {*}
+    multi method gist(::?ROLE:U:) { '(' ~ self.^name ~ ')' }
+    multi method gist(::?ROLE:D:) { 'live' }
+}
+class H does G { }
+is (H.gist, H.new.gist).join(','), '(H),live', 'U/D gist multi resolves both ways';


### PR DESCRIPTION
## Summary

A role's `multi method m(::?ROLE:U:)` / `(::?ROLE:D:)` pair became an **"Ambiguous call"** once composed into a class. The invocant match read `::?ROLE:U` via `strip_prefix("::")` as a type capture named `?ROLE:U`, which both bound a bogus capture and set `is_type_capture = true`, so the `:U`/`:D` definedness constraint on the invocant was never checked — both candidates matched every invocant.

`::?CLASS`/`::?ROLE` are pseudo-types, not captures:

- Skip the capture bind when the stripped name starts with `?`.
- Resolve `::?ROLE` (like `::?CLASS`) to the concrete class name before the invocant type-check, so the smiley is honored.

`::?CLASS` on a class worked already (it is substituted to the class name at composition); `::?ROLE` is not substituted, so the dispatch-time resolution is what fixes the role case. This is the `.gist`/`.Str`/`.raku` shape used by Hash::Agnostic (`TODO_dist` T-051 gap 3).

## Tests

- New pin: `t/role-ud-multi-dispatch.t` (8 assertions: `::?ROLE:U/:D`, `::?CLASS:U/:D`, concrete `C:U/:D`, a genuine `::T` capture, and a `.gist` shape).
- `make test` passes.