### PR TITLE
feat: route `%h = ...` on a tied Associative variable through STORE

### DIFF
--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -49,6 +49,14 @@ impl Interpreter {
             return Ok(());
         }
 
+        // A tied `%h`/`@a` (`my %h is Foo` where Foo `does Associative`) routes
+        // `%h = ...` through the class's `STORE`, preserving the tied instance,
+        // instead of replacing it with a plain Hash (Raku semantics for a
+        // custom-typed container variable). Same shape as the Proxy STORE above.
+        if let Some(()) = self.maybe_tied_store_reassign(code, idx)? {
+            return Ok(());
+        }
+
         // A sigilless `\target` bound to a multi-dim slice lvalue distributes a
         // whole-value assignment (`target = values`) element-wise through its
         // leaf cells — the raw analogue of the `@slice := @array[1,2]; @slice =
@@ -665,6 +673,66 @@ impl Interpreter {
                 };
                 self.locals[target_idx] = source_val;
             }
+        }
+    }
+
+    /// `%h = ...` / `@a = ...` where the slot currently holds a *tied* instance
+    /// (`my %h is Foo`, Foo `does Associative`/`Positional` with a user `STORE`):
+    /// route the assignment through the class's `STORE` and keep the same
+    /// instance bound, instead of replacing the slot with a plain Hash/Array.
+    /// Returns `Some(())` when it handled the assignment, `None` to fall through
+    /// to the ordinary store. The RHS assignment result (the tied instance) is
+    /// left on the stack.
+    pub(super) fn maybe_tied_store_reassign(
+        &mut self,
+        code: &CompiledCode,
+        idx: usize,
+    ) -> Result<Option<()>, RuntimeError> {
+        let name = &code.locals[idx];
+        if !(name.starts_with('%') || name.starts_with('@')) {
+            return Ok(None);
+        }
+        let ValueView::Instance { class_name, .. } = self.locals[idx].view() else {
+            return Ok(None);
+        };
+        let cn = class_name.as_str().to_string();
+        let is_tied = self.has_user_method(&cn, "STORE")
+            && (self.class_does_role(&cn, "Associative")
+                || self.class_does_role(&cn, "Positional"));
+        if !is_tied {
+            return Ok(None);
+        }
+        let rhs = self.stack.pop().unwrap_or(Value::NIL);
+        let store_values = Self::associative_store_values(&rhs);
+        let instance = self.locals[idx].clone();
+        let name = name.to_string();
+        // Pass the flattened values as a single positional list; STORE's slurpy
+        // `*@values` flattens it (separate args would bind Pairs as *named*).
+        let list_arg = Value::array(store_values);
+        let stored =
+            self.try_compiled_method_or_interpret(instance.clone(), "STORE", vec![list_arg])?;
+        let bound = if matches!(stored.view(), ValueView::Instance { .. }) {
+            stored
+        } else {
+            instance
+        };
+        self.locals[idx] = bound.clone();
+        self.set_env_with_main_alias(&name, bound.clone());
+        self.stack.push(bound);
+        Ok(Some(()))
+    }
+
+    /// Flatten an RHS value into the list `STORE` expects: a Hash becomes its
+    /// pairs, a list-like aggregate its items, anything else a single element.
+    fn associative_store_values(rhs: &Value) -> Vec<Value> {
+        match rhs.view() {
+            ValueView::Hash(h) => h
+                .iter()
+                .map(|(k, v)| Value::pair(k.clone(), v.clone()))
+                .collect(),
+            ValueView::Array(a, _) => a.iter().cloned().collect(),
+            ValueView::Seq(s) | ValueView::Slip(s) => s.iter().cloned().collect(),
+            _ => vec![rhs.clone()],
         }
     }
 }

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -201,6 +201,16 @@ impl Interpreter {
         code: &CompiledCode,
         idx: u32,
     ) -> Result<(), RuntimeError> {
+        // A re-assignment to a tied container (`my %h is Foo; %h = ...`, Foo
+        // `does Associative`/`Positional`) routes through the class's `STORE`,
+        // preserving the tied instance, instead of overwriting the slot with a
+        // plain Hash/Array. Gated on `!vardecl_context` so a fresh declaration
+        // (`my %h = ...`) is untouched.
+        if !self.vardecl_context
+            && let Some(()) = self.maybe_tied_store_reassign(code, idx as usize)?
+        {
+            return Ok(());
+        }
         // Named-sub declaration boxing decision: a scalar local that a
         // directly-nested *named sub* writes (`needs_cell_named_sub`) becomes a
         // shared `ContainerRef` cell so the named sub's by-name env writes and the

--- a/t/tied-hash-reassign.t
+++ b/t/tied-hash-reassign.t
@@ -1,0 +1,33 @@
+use Test;
+
+plan 6;
+
+# Re-assigning to a tied container (`%h = ...` where `%h` is `my %h is Foo`,
+# Foo `does Associative`) must route through the class's `STORE` and keep the
+# tied instance, not replace it with a plain Hash.
+
+role TinyAssoc does Associative {
+    has %!store;
+    method AT-KEY($k)         is raw { %!store.AT-KEY($k) }
+    method ASSIGN-KEY($k, \v) is raw { %!store.ASSIGN-KEY($k, v) }
+    method DELETE-KEY($k)            { %!store{$k}:delete }
+    method keys()                    { %!store.keys }
+    method CLEAR                     { self.DELETE-KEY($_) for self.keys }
+    method STORE(*@pairs) {
+        self.CLEAR;
+        for @pairs -> $p { self.ASSIGN-KEY($p.key, $p.value) }
+        self
+    }
+}
+class TiedHash does TinyAssoc { }
+
+my %h is TiedHash = (a => 1, b => 2);
+is %h.^name, 'TiedHash', 'starts tied';
+is %h.keys.sort.join(','), 'a,b', 'initializer stored';
+
+# Re-assignment keeps the tied class and replaces the contents via STORE.
+%h = (p => 9, q => 8);
+is %h.^name, 'TiedHash', 're-assignment keeps the tied class (not a plain Hash)';
+is %h.keys.sort.join(','), 'p,q', 're-assignment stored the new keys through STORE';
+is %h<p>, 9, 're-assigned element reads back';
+nok %h<a>:exists, 'STORE.CLEAR dropped the old keys';


### PR DESCRIPTION
## Summary

`my %h is Foo` (Foo `does Associative`, with a user `STORE`) is backed by a tied instance (#5099). A subsequent `%h = @pairs` **re-assignment** was still replacing the slot with a plain `Hash` — losing the tied identity and never running the class's `STORE`/`CLEAR`.

It now routes the assignment through `.STORE(rhs)` and keeps the same instance bound, matching Raku (where `%h = ...` on an Associative-typed variable calls `STORE`, so e.g. Hash::Agnostic's `CLEAR` + `DELETE-KEY` run).

- Intercept added at the `SetLocal` op (the reassignment path, gated on `!vardecl_context` so a fresh `my %h = ...` declaration is untouched) and mirrored at the expression-assign path, next to the existing Proxy-STORE intercept.
- `@a = ...` on a `Positional`-tied variable is handled the same way.
- The RHS is flattened (Hash → pairs, list → items) and passed as one positional list so `STORE`'s slurpy `*@values` flattens it.

## Tests

- New pin: `t/tied-hash-reassign.t` (6 assertions).
- `make test` passes (0 real failures).
- Hash::Agnostic's "can assign from pairs / key-value / a Map" subtests now pass (`TODO_dist` T-051).

## Follow-ups

Remaining T-051 gaps: tied iteration (`for %h`), `:delete`/`:exists`/`:=` BIND-KEY/value slices, and `:U:`/`:D:` `.gist`/`.Str`/`.raku` multi-dispatch (separate PR #5102).