### PR TITLE
fix: undeclared @/%-sigil variable defaults to an empty Array/Hash

### DIFF
--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -603,12 +603,11 @@ impl Interpreter {
                         }
                     })
                     .unwrap_or_else(|| {
-                        // Anonymous @-sigil variables default to empty Array
-                        if name.contains("__ANON_ARRAY_") || name == "@__ANON_ARRAY__" {
-                            Value::real_array(vec![])
-                        } else {
-                            Value::NIL
-                        }
+                        // An undeclared `@`-sigil variable defaults to an empty
+                        // Array (raku auto-declares it as Array under `no strict`):
+                        // `@x[2]` is `(Any)`, `@x.end` is `-1`, `@x.raku` is `[]`.
+                        // Anonymous `@`-sigil variables share this default.
+                        Value::real_array(vec![])
                     });
                 // A whole-container `:=` bind (`my @b := @a`) stores a shared
                 // `ContainerRef` cell in the slot so both aliases observe
@@ -710,13 +709,12 @@ impl Interpreter {
                         if name == "%ENV" {
                             return Err(RuntimeError::undeclared("name", "%ENV"));
                         }
-                        // Anonymous %-sigil variables default to empty Hash
-                        if name == "%__ANON_HASH__" {
-                            self.stack
-                                .push(Value::hash(std::collections::HashMap::new()));
-                        } else {
-                            self.stack.push(Value::NIL);
-                        }
+                        // An undeclared `%`-sigil variable defaults to an empty
+                        // Hash (raku auto-declares it as Hash under `no strict`):
+                        // `%h<k>` is `(Any)`, `%h.raku` is `{}`. Anonymous
+                        // `%`-sigil variables share this default.
+                        self.stack
+                            .push(Value::hash(std::collections::HashMap::new()));
                     }
                 }
                 *ip += 1;

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -2093,9 +2093,17 @@ impl Interpreter {
             }
             _ => return None,
         };
-        let actual_end = if excl_end { end } else { end + 1 };
         let start = start.max(0) as usize;
-        let actual_end = (actual_end.max(0) as usize).min(items.len());
+        // An unbounded end (`@a[3..*]`) clamps to the array length; a bounded
+        // end reads out-of-bounds indices as the typed default (Any), mirroring
+        // the standalone `@a[8..11]` slice path (so `@a[6, 8..11]` on a short or
+        // empty array yields Anys, not a truncated empty sublist).
+        let actual_end = if Self::range_end_is_unbounded(end) {
+            items.len()
+        } else {
+            let e = if excl_end { end } else { end.saturating_add(1) };
+            e.max(0) as usize
+        };
         let default = vm.typed_container_default(&Value::array_with_kind(
             crate::value::Value::array_arc(items.clone().to_vec()),
             kind,

--- a/t/undeclared-array-hash-default.t
+++ b/t/undeclared-array-hash-default.t
@@ -1,0 +1,42 @@
+use Test;
+
+# Under `no strict`, an undeclared @-sigil variable auto-declares as an empty
+# Array and a %-sigil variable as an empty Hash (raku semantics), so element
+# access yields (Any), .end is -1, and .raku renders as [] / {}.
+# Regression pins for Language/perl-nutshell.rakudoc doc-diff findings.
+
+plan 14;
+
+{
+    no strict;
+    is @months[2].gist, '(Any)', 'undeclared @var element access is (Any)';
+    is @months.end, -1, 'undeclared @var .end is -1';
+    is @months.raku, '[]', 'undeclared @var .raku is []';
+    is @months.^name, 'Array', 'undeclared @var is an Array';
+    is @array_of_hashes.raku, '[]', 'undeclared @var .raku (second name) is []';
+}
+
+{
+    no strict;
+    is %calories{"apple"}.gist, '(Any)', 'undeclared %var key access is (Any)';
+    is %calories<apple>.gist, '(Any)', 'undeclared %var angle-bracket access is (Any)';
+    is %calories.raku, '{}', 'undeclared %var .raku is {}';
+    is %calories.^name, 'Hash', 'undeclared %var is a Hash';
+    is (join ',', %calories{'pear', 'plum'}), ',', 'undeclared %var 2-key slice joins to one comma';
+    is (join ',', %calories<pear plum>), ',', 'undeclared %var angle slice joins to one comma';
+}
+
+# A bounded range inside a multi-element subscript reads out-of-bounds indices
+# as the typed default, even on an empty/short array (mirrors the standalone
+# `@a[8..11]` slice). Previously the range sublist was truncated to empty.
+{
+    my @a;
+    is @a[6, 8..11].raku, '(Any, (Any, Any, Any, Any))', 'bounded range in multi-slice on empty array yields Anys';
+    is (join ',', @a[6, 8..11]), ',,,,', 'bounded range in multi-slice on empty array joins to four commas';
+}
+
+# An unbounded range in a multi-element subscript must not panic (regression).
+{
+    my @a = 1, 2, 3, 4, 5;
+    is @a[1, 3..*].raku, '(2, (4, 5))', 'unbounded range in multi-slice does not panic and slices the tail';
+}


### PR DESCRIPTION
## Summary

Under `no strict`, referencing an undeclared `@`-sigil variable auto-declares it
as an empty **Array** and a `%`-sigil variable as an empty **Hash** (raku
semantics). mutsu returned `Nil` for both, diverging from raku:

| expression | raku | mutsu (before) |
|---|---|---|
| `@months[2]` | `(Any)` | `Nil` |
| `@x.end` | `-1` | `0` |
| `@x.raku` | `[]` | `Nil` |
| `%h<apple>` | `(Any)` | `Nil` |
| `%h.raku` | `{}` | `Nil` |

The `GetArrayVar`/`GetHashVar` undeclared-fallback now returns the sigil-typed
empty container (the anonymous `@`/`%` variables already used this default).

## Secondary fix: bounded range in a multi-element subscript

A bounded range inside a multi-element subscript on a short/empty array was
clamped to the array length, so `@a[6, 8..11]` on an empty array produced a
truncated empty sublist instead of the typed defaults (Anys) that the
standalone `@a[8..11]` slice yields. `resolve_range_index_slice` now mirrors the
standalone path — out-of-bounds indices read the typed default, and an
unbounded end (`@a[3..*]`) clamps to the length. That also fixes an `end + 1`
overflow **panic** on `@a[1, 3..*]`.

```
# before                        # after (matches raku)
@a[6, 8..11]  → (Any, ())        (Any, (Any, Any, Any, Any))
@a[1, 3..*]   → panic            (2, (4, 5))   (populated)
```

## Impact

Resolves all **7 output-mismatch findings** in the
`Language/perl-nutshell.rakudoc` doc-diff sweep (match 14 → 21, mismatch 7 → 0).

## Testing

- New pin `t/undeclared-array-hash-default.t` (14 assertions).
- `make test` green; slice/subscript roast tests (`S09-subscript/slice.t`,
  `S09-subscript/multidim-assignment.t`, `S09-autovivification/autovivification.t`,
  `S02-literals/subscript.t`, `S09-multidim/indexing.t`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)