### PR TITLE
feat: iterate a tied Iterable instance (`for %h is Foo`) via its own iterator

### DIFF
--- a/src/vm/vm_for_loop_dispatch.rs
+++ b/src/vm/vm_for_loop_dispatch.rs
@@ -252,6 +252,8 @@ impl Interpreter {
             // `HashEntryRef` so an in-loop `%h{$p.key} = X` is observable through
             // a later `$p.value` read (raku's live hash-iteration pairs).
             Self::hash_live_pairs(&gc, iterable.hash_is_itemized())
+        } else if let Some(items) = self.try_iterable_instance_items(&iterable)? {
+            items
         } else {
             runtime::value_to_list(&iterable)
         };
@@ -362,5 +364,66 @@ impl Interpreter {
         }
         *ip = loop_end;
         Ok(())
+    }
+
+    /// `for $obj` where `$obj` is an instance of a class that `does Iterable`
+    /// with its own `iterator` method (a "tied" hash/list like Hash::Agnostic):
+    /// iterate via that method's `Iterator` (`pull-one` until `IterationEnd`)
+    /// rather than treating the instance as a single opaque value. Returns
+    /// `None` for any other value so the caller falls through to `value_to_list`.
+    /// An `is Array` subclass (backed by `__mutsu_array_storage`) is left to that
+    /// path — its elements are the storage, not a user iterator.
+    fn try_iterable_instance_items(
+        &mut self,
+        iterable: &Value,
+    ) -> Result<Option<Vec<Value>>, RuntimeError> {
+        let ValueView::Instance {
+            class_name,
+            attributes,
+            ..
+        } = iterable.view()
+        else {
+            return Ok(None);
+        };
+        if attributes.contains_key("__mutsu_array_storage") {
+            return Ok(None);
+        }
+        let cn = class_name.as_str().to_string();
+        if !(self.class_does_role(&cn, "Iterable") && self.has_user_method(&cn, "iterator")) {
+            return Ok(None);
+        }
+        let iterator =
+            self.try_compiled_method_or_interpret(iterable.clone(), "iterator", vec![])?;
+        // Drive `pull-one` through a temp *variable*, not a bare value: a user
+        // `Iterator` instance keeps its cursor in its own attributes, and an
+        // Instance value clone deep-copies those, so calling `pull-one` on a
+        // fresh clone each step would restart from the first element forever.
+        // The by-name mut path writes the advanced iterator back to the temp
+        // slot so the next `pull-one` sees the moved cursor.
+        let tmp = "$__mutsu_for_iterable_iter";
+        let saved = self.get_env_with_main_alias(tmp);
+        self.set_env_with_main_alias(tmp, iterator);
+        let mut items = Vec::new();
+        let result = loop {
+            let cur = self.get_env_with_main_alias(tmp).unwrap_or(Value::NIL);
+            let val = match self.call_method_mut_with_values(tmp, cur, "pull-one", vec![]) {
+                Ok(v) => v,
+                Err(e) => break Err(e),
+            };
+            if matches!(val.view(), ValueView::Str(s) if s.as_str() == "IterationEnd")
+                || matches!(val.view(), ValueView::Package(n) if n == crate::symbol::Symbol::intern("IterationEnd"))
+            {
+                break Ok(());
+            }
+            items.push(val);
+        };
+        match saved {
+            Some(v) => self.set_env_with_main_alias(tmp, v),
+            None => {
+                self.env_mut().remove(tmp);
+            }
+        }
+        result?;
+        Ok(Some(items))
     }
 }

--- a/t/tied-hash-iterate.t
+++ b/t/tied-hash-iterate.t
@@ -1,0 +1,37 @@
+use Test;
+
+plan 4;
+
+# `for %h` / `.map` over a tied container (`my %h is Foo`, Foo `does Iterable`
+# with its own `iterator` method) must iterate via that method, not treat the
+# instance as a single opaque value.
+
+role TinyAssoc does Associative does Iterable {
+    has %!store;
+    method AT-KEY($k)         is raw { %!store.AT-KEY($k) }
+    method ASSIGN-KEY($k, \v) is raw { %!store.ASSIGN-KEY($k, v) }
+    method keys()                    { %!store.keys }
+    method STORE(*@pairs) { for @pairs -> $p { self.ASSIGN-KEY($p.key, $p.value) }; self }
+    method pairs()    { self.keys.map({ Pair.new($_, self.AT-KEY($_)) }) }
+    method iterator() { self.pairs.iterator }
+}
+class TiedHash does TinyAssoc { }
+
+my %h is TiedHash = (a => 1, b => 2, c => 3);
+
+# for-loop yields the class's Pairs
+my @seen;
+for %h -> $p {
+    isa-ok $p, Pair, 'for %h yields a Pair' if @seen == 0;
+    @seen.push: "{$p.key}={$p.value}";
+}
+is @seen.sort.join(','), 'a=1,b=2,c=3', 'for %h iterates all pairs via .iterator';
+
+# the tied instance is Iterable
+ok %h ~~ Iterable, 'a tied hash does Iterable';
+
+# a plain hash still iterates the ordinary way (no regression)
+my %plain = (x => 1, y => 2);
+my @pk;
+for %plain -> $p { @pk.push: $p.key }
+is @pk.sort.join(','), 'x,y', 'a plain hash still iterates normally';


### PR DESCRIPTION
## Summary

`for %h` where `%h` is `my %h is Foo` (Foo `does Iterable` with its own `iterator` method, e.g. Hash::Agnostic) treated the backing instance as a single opaque value. It now iterates via the class's `.iterator` (`pull-one` until `IterationEnd`), yielding the class's elements (Pairs for a hash), matching Raku.

The iterator's cursor lives in its own instance attributes and an Instance clone deep-copies them, so `pull-one` is driven through a temp *variable* (the by-name mut path writes the advanced iterator back) rather than a bare cloned value, which would restart from the first element forever.

An `is Array` subclass (backed by `__mutsu_array_storage`) is left to the ordinary `value_to_list` path.

## Tests

- New pin: `t/tied-hash-iterate.t` (4 assertions).
- `make test` passes (0 real failures).
- Hash::Agnostic's "checking iterator" subtest now passes (`TODO_dist` T-051).

## Follow-ups

Remaining T-051 gaps: `:delete`/`:exists`/`:=` BIND-KEY, value/whatever slices, and the `.pairs.Map`/`.antipairs`/`.List`/`.Slip`/`.Array` comparison methods in the first subtest.