### PR TITLE
fix: allow whitespace between S/// adverbs and the delimiter

### DIFF
--- a/src/parser/primary/regex/lit.rs
+++ b/src/parser/primary/regex/lit.rs
@@ -587,7 +587,11 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
     if let Some(after_s) = input.strip_prefix('S')
         && !crate::parser::stmt::simple::is_user_declared_type("S")
     {
+        let had_adverbs = after_s.starts_with(':');
         let (spec, adverbs) = parse_match_adverbs(after_s)?;
+        // Allow whitespace between adverbs and the delimiter (e.g.
+        // `S:g /pattern/replacement/`), mirroring the lowercase `s` parser.
+        let spec = if had_adverbs { ws(spec)?.0 } else { spec };
         if let Some(open_ch) = spec.chars().next() {
             let is_delim = !open_ch.is_alphanumeric() && open_ch != '_' && !open_ch.is_whitespace();
             let looks_like_method = open_ch == '.'

--- a/t/nondestructive-subst-adverb-space.t
+++ b/t/nondestructive-subst-adverb-space.t
@@ -1,0 +1,42 @@
+use v6;
+use Test;
+
+# The non-destructive substitution `S///` accepts whitespace between its adverbs
+# and the opening delimiter (`S:g /pattern/replacement/`), just like the
+# in-place `s///`. mutsu used to reject `S:g /.../` (with a space) as an
+# "Undeclared routine: S:g".
+
+plan 6;
+
+# 1. S:g with a space before the delimiter.
+{
+    my $s = "a1b2c3";
+    is (S:g /\d// given $s), 'abc', 'S:g /.../ (space) removes all digits, non-destructive';
+    is $s, 'a1b2c3', 'original is untouched by S:g';
+}
+
+# 2. S:g with no space still works (regression guard).
+{
+    my $s = "x9y8";
+    is (S:g/\d// given $s), 'xy', 'S:g/.../ (no space) still works';
+}
+
+# 3. S with a single adverb and a replacement string.
+{
+    my $s = "foo bar foo";
+    is (S:g /foo/baz/ given $s), 'baz bar baz', 'S:g /.../.../  with replacement';
+}
+
+# 4. A different adverb (`:i`) with a space before the delimiter.
+{
+    my $s = "Foo FOO foo";
+    is (S:i:g /foo/x/ given $s), 'x x x', 'S:i:g /.../.../  case-insensitive with space';
+}
+
+# 5. The topic form used by the real dist (inside a for/given block).
+{
+    my @out = gather for <a1 b2 c3> {
+        take S:g /<:digit>// ;
+    }
+    is @out.join(','), 'a,b,c', 'S:g on the topic inside a loop';
+}


### PR DESCRIPTION
Fixes **lemmatize** (TICKETS **T-007**, the loadable half). It now **fully loads, matching raku**.

The non-destructive substitution `S///` accepts whitespace between its adverbs
and the opening delimiter (`S:g /pattern/replacement/`), like the in-place
`s///` already does. The uppercase-`S` parser never skipped that whitespace, so
`S:g /.../ ` (used by lemmatize as `S:g /<:punct>//`) was mis-parsed as a call to
an undeclared routine `S:g`. The `S` branch now mirrors the lowercase `s` branch:
after parsing adverbs, it skips whitespace before the delimiter.

(T-007's other dist, Acme::Cow::Example, uses a version+auth-qualified
`use Acme::Cow:<0.0.5>:auth<zef:lizmat>` that raku itself cannot resolve under
`-I lib` in the sweep env, so that half is raku-non-load; mutsu already loads it.)

Pin: `t/nondestructive-subst-adverb-space.t` (6 subtests, output matches raku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)