### PR TITLE
feat: tied Associative subscript protocol — `:=` BIND-KEY and `{*}` whatever slice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -274,8 +274,10 @@ _40 open tickets._
      (pin `t/tied-hash-associative.t`). Re-assignment `%h = @pairs` now routes through
      `.STORE` (#5103), tied iteration `for %h` through the class's iterator (#5107), and the
      `:delete`/`:exists` adverbs + `:=` BIND-KEY through DELETE-KEY/EXISTS-KEY/BIND-KEY
-     (pin `t/tied-hash-bind.t`). **Remaining for a full pass:** value/whatever slices
-     (`%h{@keys}` / `%h{*}`) are not yet routed to the class's methods.
+     (pin `t/tied-hash-bind.t`). Value/list slices (`%h<a b>` / `%h{'a','c'}`) route
+     through the existing `(Instance, Array)` read arm, and the `{*}` whatever slice
+     enumerates the class's `keys` + AT-KEY. **All gap-1 sub-items now landed; a full
+     dist run is the remaining confirmation.**
   2. **public/private same-name role methods** — Hash::Agnostic's `method STORE {...self!STORE(...)}`
      + `method !STORE` collided (private overwrote public in role composition; two-role
      public+private also mis-flagged X::Role::Composition::Conflict). **Fixed** — see the

--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -271,11 +271,11 @@ _40 open tickets._
      `src/vm/vm_var_trait_ops.rs` + `class_does_role` + the `is raw` container-accessor lvalue
      chain in `runtime/methods_mut_method_lvalue.rs`): `my %h is Foo`/`= @pairs` backs the var,
      `.^name`, element read/write, and the initializer's `STORE` all dispatch to the class now
-     (pin `t/tied-hash-associative.t`). **Remaining for a full pass:** (a) `%h = @pairs`
-     *re-assignment* on an already-tied var still replaces it with a plain Hash instead of
-     routing through `.STORE` (layer 3 — needs an intercept in the `%`-var assignment path);
-     (b) tied iteration (`for %h`), `:delete`/`:exists` adverbs, `:=` BIND-KEY, and value/whatever
-     slices are not yet routed to the class's methods.
+     (pin `t/tied-hash-associative.t`). Re-assignment `%h = @pairs` now routes through
+     `.STORE` (#5103), tied iteration `for %h` through the class's iterator (#5107), and the
+     `:delete`/`:exists` adverbs + `:=` BIND-KEY through DELETE-KEY/EXISTS-KEY/BIND-KEY
+     (pin `t/tied-hash-bind.t`). **Remaining for a full pass:** value/whatever slices
+     (`%h{@keys}` / `%h{*}`) are not yet routed to the class's methods.
   2. **public/private same-name role methods** — Hash::Agnostic's `method STORE {...self!STORE(...)}`
      + `method !STORE` collided (private overwrote public in role composition; two-role
      public+private also mis-flagged X::Role::Composition::Conflict). **Fixed** — see the

--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -276,8 +276,24 @@ _40 open tickets._
      `:delete`/`:exists` adverbs + `:=` BIND-KEY through DELETE-KEY/EXISTS-KEY/BIND-KEY
      (pin `t/tied-hash-bind.t`). Value/list slices (`%h<a b>` / `%h{'a','c'}`) route
      through the existing `(Instance, Array)` read arm, and the `{*}` whatever slice
-     enumerates the class's `keys` + AT-KEY. **All gap-1 sub-items now landed; a full
-     dist run is the remaining confirmation.**
+     enumerates the class's `keys` + AT-KEY. **The tied-variable subscript protocol is
+     now complete.** A full `Hash::Agnostic` dist run (2026-07-22, `t/01-basic.rakutest`)
+     still `test_die`s on TWO remaining, unrelated-to-subscript blockers:
+     - **(1) `self.Mu::Str` / `self.Mu::gist` stack overflow** — Hash::Agnostic's
+       type-object coercions are `multi method Str(::?ROLE:U:) { self.Mu::Str }`
+       (likewise gist). A qualified call to a *universal base* (`Mu`/`Any`/`Cool`) is
+       not routed to the built-in default coercion: `Mu` is absent from the instance
+       MRO, so the qualified dispatch falls back to re-dispatching the receiver's own
+       role multi, which calls `self.Mu::Str` again → infinite recursion / stack
+       overflow (repro: `role R { multi method Str(::?ROLE:U:) { self.Mu::Str } }; class C does R {}; C.Str`).
+       Fix needs `self.{Mu,Any,Cool}::<coercion>` to reach the interpreter's *default*
+       Str/gist/raku (bypassing the user/role override). `native_method_0arg` alone is
+       insufficient — a generic instance's gist/raku need interpreter-level attribute
+       rendering (`gist_needs_method_dispatch`). Type-object defaults are already
+       correct (`C.Str`=="", `C.gist`=="(C)", `C.raku`=="C").
+     - **(2) `.Slip` coercion** — `%h.Slip.are(Pair)` fails while `.list`/`.List` pass;
+       Hash::Agnostic's `method Slip { Slip.from-iterator(self.iterator) }` — `Slip.from-iterator`
+       does not yield the Pairs the role's iterator produces.
   2. **public/private same-name role methods** — Hash::Agnostic's `method STORE {...self!STORE(...)}`
      + `method !STORE` collided (private overwrote public in role composition; two-role
      public+private also mis-flagged X::Role::Composition::Conflict). **Fixed** — see the

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -341,13 +341,37 @@ impl Interpreter {
         if let Some(target) = self.env().get(&var_name).cloned()
             && let ValueView::Instance { class_name, .. } = target.view()
         {
-            let method = if is_positional {
+            let cls = class_name.resolve();
+            // A `:=` element bind (`%h<c> := $x`) arrives with the RHS wrapped in
+            // a `__mutsu_bind_index_value` marker; route it to the class's
+            // BIND-KEY/BIND-POS when declared, so the class controls the bind
+            // instead of the marker being stored verbatim via ASSIGN.
+            let is_bind = matches!(
+                self.stack.last().map(Value::view),
+                Some(ValueView::Pair(n, _)) if n == "__mutsu_bind_index_value"
+            );
+            let bind_method = if is_positional {
+                "BIND-POS"
+            } else {
+                "BIND-KEY"
+            };
+            let assign_method = if is_positional {
                 "ASSIGN-POS"
             } else {
                 "ASSIGN-KEY"
             };
-            if self.has_user_method(&class_name.resolve(), method) {
-                let val = self.stack.pop().unwrap_or(Value::NIL);
+            let method = if is_bind && self.has_user_method(&cls, bind_method) {
+                Some(bind_method)
+            } else if self.has_user_method(&cls, assign_method) {
+                Some(assign_method)
+            } else {
+                None
+            };
+            if let Some(method) = method {
+                let raw_val = self.stack.pop().unwrap_or(Value::NIL);
+                // Unwrap the bind marker so neither BIND-KEY nor the ASSIGN
+                // fallback stores the internal wrapper pair as the value.
+                let (val, _bind_source) = Self::unwrap_bind_index_value(raw_val);
                 // Unwrap a single-element subscript list (`<baz>` parses as a
                 // one-element list) to the bare key/index.
                 let idx_arg = match idx.view() {

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1067,6 +1067,26 @@ impl Interpreter {
                     .unwrap_or(Value::NIL);
                 if result.is_nil() { default } else { result }
             }
+            // Whatever slice on a tied Associative instance (`%h is Foo; %h{*}`):
+            // enumerate the class's own keys (via its `keys` method) and read each
+            // through AT-KEY, mirroring the plain-Hash `(Hash, Whatever)` arm above.
+            // Guarded on a user `keys` method so non-Associative instances keep the
+            // Nil fallback below.
+            (ValueView::Instance { class_name, .. }, ValueView::Whatever)
+                if self.has_user_method(&class_name.resolve(), "keys") =>
+            {
+                let keys = self
+                    .try_compiled_method_or_interpret(target.clone(), "keys", vec![])
+                    .unwrap_or(Value::NIL);
+                let results = crate::runtime::utils::value_to_list(&keys)
+                    .into_iter()
+                    .map(|k| {
+                        self.try_compiled_method_or_interpret(target.clone(), "AT-KEY", vec![k])
+                            .unwrap_or(Value::NIL)
+                    })
+                    .collect::<Vec<_>>();
+                Value::array(results)
+            }
             // Buf/Blob slice by a Range: `$buf[0..7]` / `$buf[2..^5]`. The bytes
             // live in the instance's `bytes` array; a single-Int index is served
             // by `AT-POS` above, but a Range index has no AT-POS arm and would

--- a/t/tied-hash-bind.t
+++ b/t/tied-hash-bind.t
@@ -1,10 +1,11 @@
 use Test;
 
-plan 9;
+plan 11;
 
-# A `my %h is CustomClass` (Associative) routes the `:=` element bind and the
-# `:exists` / `:delete` adverbs through the class's BIND-KEY / EXISTS-KEY /
-# DELETE-KEY methods rather than treating the variable as a plain Hash.
+# A `my %h is CustomClass` (Associative) routes the `:=` element bind, the
+# `:exists` / `:delete` adverbs, and a `{*}` whatever slice through the class's
+# BIND-KEY / EXISTS-KEY / DELETE-KEY / keys+AT-KEY methods rather than treating
+# the variable as a plain Hash.
 
 my @log;
 
@@ -39,3 +40,9 @@ is %h<c>, 99, ':= bind stores the bound value (not the internal marker)';
 ok @log.grep('BIND c'), ':= dispatched to BIND-KEY, not ASSIGN-KEY';
 
 is %h.keys.sort.join(','), 'a,c', 'the tied hash reflects the bound key';
+
+# --- {*} whatever slice enumerates the class's keys via AT-KEY ----------------
+my %v is MyHash;
+%v<p> = 10; %v<q> = 20; %v<r> = 30;
+is (%v{*}).sort.join(','), '10,20,30', '{*} whatever slice reads all values via keys+AT-KEY';
+is (%v<p r>).join(','), '10,30', 'value slice reads the named values';

--- a/t/tied-hash-bind.t
+++ b/t/tied-hash-bind.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 9;
+
+# A `my %h is CustomClass` (Associative) routes the `:=` element bind and the
+# `:exists` / `:delete` adverbs through the class's BIND-KEY / EXISTS-KEY /
+# DELETE-KEY methods rather than treating the variable as a plain Hash.
+
+my @log;
+
+class MyHash does Associative {
+    has %.store;
+    method AT-KEY($k)          is raw { %!store.AT-KEY($k) }
+    method ASSIGN-KEY($k, \v)  is raw { %!store.ASSIGN-KEY($k, v) }
+    method EXISTS-KEY($k)  { @log.push("EXISTS $k"); %!store.EXISTS-KEY($k) }
+    method DELETE-KEY($k)  { @log.push("DELETE $k"); %!store.DELETE-KEY($k) }
+    method BIND-KEY($k, \v) { @log.push("BIND $k"); %!store.BIND-KEY($k, v) }
+    method keys()          { %!store.keys }
+}
+
+my %h is MyHash;
+%h<a> = 1;
+%h<b> = 2;
+
+# --- :exists routes through EXISTS-KEY ----------------------------------------
+is %h<a>:exists, True,  ':exists is True for a present key';
+is %h<z>:exists, False, ':exists is False for a missing key';
+ok @log.grep('EXISTS a'), ':exists dispatched to EXISTS-KEY';
+
+# --- :delete routes through DELETE-KEY ----------------------------------------
+is %h<b>:delete, 2, ':delete returns the removed value';
+is %h.keys.sort.join(','), 'a', ':delete removed the key from the class';
+ok @log.grep('DELETE b'), ':delete dispatched to DELETE-KEY';
+
+# --- := element bind routes through BIND-KEY ----------------------------------
+my $x = 99;
+%h<c> := $x;
+is %h<c>, 99, ':= bind stores the bound value (not the internal marker)';
+ok @log.grep('BIND c'), ':= dispatched to BIND-KEY, not ASSIGN-KEY';
+
+is %h.keys.sort.join(','), 'a,c', 'the tied hash reflects the bound key';


### PR DESCRIPTION
## Summary

Two remaining slices of the tied-hash subscript protocol on a `my %h is CustomAssociative` variable (dist ticket **T-051**, Hash::Agnostic):

### 1. `:=` element bind → BIND-KEY
`%h<c> := $x` arrived with the RHS wrapped in the internal `__mutsu_bind_index_value` marker, and the tied-hash `Instance` dispatch only recognized `ASSIGN-KEY`/`ASSIGN-POS` — so the bind fell through to `ASSIGN-KEY` and stored the wrapper pair verbatim:

```
%h<c> := $x;
say %h<c>;   # before: __mutsu_bind_index_value => (99 ...)   after: 99
```

Now the marker is detected and, when the class declares `BIND-KEY`/`BIND-POS`, unwrapped and dispatched to the bind method. Without a bind method, the marker is still unwrapped before the `ASSIGN` fallback so the raw value (never the wrapper) is stored. `:exists` / `:delete` already routed to `EXISTS-KEY` / `DELETE-KEY`.

### 2. `{*}` whatever slice → keys + AT-KEY
`%h{*}` read back `(Nil,)` — the index-read path had no `(Instance, Whatever)` arm. Added one that enumerates the class's own `keys` and reads each through `AT-KEY`, mirroring the plain-Hash `(Hash, Whatever)` arm. Value/list slices (`%h<a b>` / `%h{'a','c'}`) already worked via the existing `(Instance, Array)` arm.

With these, all gap-1 sub-items of T-051 have landed (backing, `.^name`, element read/write, STORE initializer + re-assignment, iteration, adverbs, bind, and slices); a full dist run is the remaining confirmation.

## Test

New `t/tied-hash-bind.t` exercises `:exists`, `:delete`, `:=`, the `{*}` whatever slice, and a value slice on a tied `Associative` class, asserting each dispatches to the corresponding class method. Existing `t/tied-hash-associative.t` / `t/tied-hash-reassign.t` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)