### PR TITLE
fix: skip compile-time default type-check for coercion-typed params (T-022)

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -10,7 +10,7 @@ add a `[claim: <branch>]` marker on its heading and push before you start.
 Move a ticket to **Done** when its PR merges. Rebase on `main` before
 editing this file; keep edits small (one ticket) to avoid conflicts.
 
-_37 open tickets._
+_36 open tickets._
 
 ## Open
 
@@ -63,12 +63,6 @@ _37 open tickets._
 ### T-018 — runtime_error: Cannot call private method X permission  [impact: 1 dist]
 - dists: Cookie::Jar
 - e.g. `Cookie::Jar`: Cookie::Jar: Cannot call private method without permission
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
-
-### T-022 — runtime_error: Runtime error: Failed to parse module 'X': X::Parameter::Default::TypeCheck: Default value type 'X' does not satisfy 'X'  [impact: 1 dist]
-- dists: Devel::ExecRunnerGenerator
-- e.g. `Devel::ExecRunnerGenerator`: Devel::ExecRunnerGenerator: Runtime error: Failed to parse module 'Devel::ExecRunnerGenerator': X::Parameter::Default::TypeCheck: Default value type 'Str' does 
 - repro: _(fill in a minimal repro + raku baseline before fixing)_
 - file: _(suspected parser/runtime file)_
 
@@ -290,6 +284,15 @@ _(move tickets here with `[claim: <branch>]` when you start)_
 
 ## Done
 
+- **T-022** (#5114) — a coercion-typed parameter default
+  (`IO::Path(Str) $p = "x"`, `IO::Path(Str) :$out-path = "."`) wrongly raised the
+  compile-time `X::Parameter::Default::TypeCheck`: `default_type_matches_constraint`
+  cut the constraint at `(` to `IO::Path`, saw the `::`, and returned `Some(false)`.
+  raku performs *no* compile-time default check for coercion types (`raku -c`
+  reports "Syntax OK" even for a default that will never bind — it defers to the
+  runtime binding check), so mutsu now skips the compile-time check for any
+  coercion constraint. Plain (non-coercion) `::`-qualified bad defaults are still
+  rejected. **Devel::ExecRunnerGenerator fully loads**, matching raku.
 - **T-007** (#5108) — `S:g /.../ ` — the non-destructive substitution `S///`
   with whitespace between its adverbs and the delimiter — was mis-parsed as a
   call to an undeclared routine `S:g`; the uppercase-`S` parser never skipped

--- a/src/parser/stmt/sub/param_validate.rs
+++ b/src/parser/stmt/sub/param_validate.rs
@@ -154,6 +154,15 @@ pub(crate) fn default_type_matches_constraint(
     default_value: Option<&Value>,
 ) -> Option<bool> {
     let base = constraint_base_type(constraint);
+    // Coercion type `Target(From)`: raku performs no compile-time default check
+    // for coercion-typed parameters (`IO::Path(Str) $p = 42` compiles fine and
+    // only fails at runtime binding), because the default is coerced through the
+    // `From` type dynamically. So never raise the compile-time
+    // X::Parameter::Default::TypeCheck for a coercion constraint -- defer to the
+    // runtime binding check like raku does.
+    if base.len() < constraint.len() && constraint.as_bytes()[base.len()] == b'(' {
+        return Some(true);
+    }
     if matches!(base, "Any" | "Mu" | "Cool") {
         return Some(true);
     }

--- a/t/coercion-type-param-default.t
+++ b/t/coercion-type-param-default.t
@@ -1,0 +1,52 @@
+use v6;
+use Test;
+
+# A coercion-typed parameter `Target(From) $p = <default>` must NOT raise the
+# compile-time X::Parameter::Default::TypeCheck: raku defers coercion-default
+# checking to runtime binding (`raku -c` reports "Syntax OK" even for a default
+# that will never bind). Regression: mutsu rejected every coercion default whose
+# target contained `::` (e.g. `IO::Path(Str) $p = "x"`) at parse time.
+# T-022 (Devel::ExecRunnerGenerator).
+
+plan 7;
+
+# Positional coercion default whose value matches the `From` type.
+lives-ok {
+    sub f(IO::Path(Str) $p = "default.txt") { $p }
+    f();
+}, 'IO::Path(Str) $p = "default.txt" parses and runs';
+
+# Named coercion default (the exact shape used by the dist).
+lives-ok {
+    sub f(IO::Path(Str) :$out-path = ".") { $out-path }
+    f();
+}, 'IO::Path(Str) :$out-path = "." parses and runs';
+
+# From type is Cool; an Int default conforms to Cool.
+lives-ok {
+    sub f(IO::Path(Cool) $p = 42) { $p }
+    f();
+}, 'IO::Path(Cool) $p = 42 parses and runs';
+
+# Target itself matches the default directly.
+{
+    sub f(Int(Str) $p = 42) { $p }
+    is f().^name, 'Int', 'Int(Str) $p = 42 coerces target to Int';
+}
+
+# Version coercion.
+lives-ok {
+    sub f(Version(Str) $p = "1.2") { $p }
+    f();
+}, 'Version(Str) $p = "1.2" parses and runs';
+
+# A plain (non-coercion) bad default is STILL rejected at compile time.
+dies-ok {
+    EVAL 'sub f(Int $p = "x") { }';
+}, 'plain Int $p = "x" is still a compile-time error';
+
+# A plain (non-coercion) `::`-qualified type with a mismatched default is
+# still rejected -- the coercion carve-out must not leak to plain types.
+dies-ok {
+    EVAL 'sub f(X::AdHoc $p = "x") { }';
+}, 'plain X::AdHoc $p = "x" (non-coercion) is still rejected';


### PR DESCRIPTION
## Summary

A coercion-typed parameter default such as `IO::Path(Str) $p = "default.txt"`
(or the named `IO::Path(Str) :$out-path = "."` used by the dist) was wrongly
rejected at **parse time** with:

```
X::Parameter::Default::TypeCheck: Default value type 'Str' does not satisfy 'IO::Path(Str)'
```

`default_type_matches_constraint` derives the base type by cutting the
constraint at `(`, so `IO::Path(Str)` became `IO::Path`, which contains `::`
and fell into the blanket `return Some(false)` branch.

## Why this is correct

raku performs **no compile-time default check** for coercion types — the
default is coerced through the `From` type dynamically:

```
$ raku -c -e 'sub f(IO::Path(Str) $p = 42) { }'
Syntax OK                         # even a default that never binds compiles
$ raku -c -e 'sub f(Int $p = "x") { }'
===SORRY!=== Default value 'x' will never bind to a parameter of type Int
```

So the fix returns `Some(true)` (skip the compile-time check) whenever the
constraint is a coercion type `Target(From)`. Plain, non-coercion
`::`-qualified types with a mismatched default (`X::AdHoc $p = "x"`) are still
rejected at compile time, exactly as before.

## Result

**Devel::ExecRunnerGenerator (T-022) now fully loads**, matching raku.

## Test

Pin: `t/coercion-type-param-default.t` (7 subtests, output matches raku),
covering valid coercion defaults (positional/named/`From`=Cool/target-match/
`Version`) and that plain non-coercion bad defaults are still compile errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)