### PR TITLE
fix: prompt returns the Any type object at end of input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/runtime/builtins_io_stream.rs
+++ b/src/runtime/builtins_io_stream.rs
@@ -86,12 +86,14 @@ impl Interpreter {
             .get_dynamic_handle("$*IN")
             .or_else(|| self.default_input_handle());
         if let Some(handle) = handle {
-            let line = self
-                .read_line_from_handle_value(&handle)?
-                .unwrap_or_default();
-            return Ok(Value::str(line));
+            // At end of input `prompt` returns the `Any` type object (like
+            // `get`), not an empty string: `prompt(...).defined` is False.
+            return Ok(match self.read_line_from_handle_value(&handle)? {
+                Some(line) => Value::str(line),
+                None => Value::package(crate::symbol::Symbol::intern("Any")),
+            });
         }
-        Ok(Value::str(String::new()))
+        Ok(Value::package(crate::symbol::Symbol::intern("Any")))
     }
 
     pub(super) fn builtin_get(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {

--- a/t/prompt-eof-any.t
+++ b/t/prompt-eof-any.t
@@ -1,0 +1,29 @@
+use Test;
+
+# `prompt` returns the `Any` type object at end of input (like `get`), not an
+# empty string, so `prompt(...).defined` is False. Regression pin for
+# Language/py-nutshell.rakudoc doc-diff finding.
+
+plan 4;
+
+my $exe = $*EXECUTABLE;
+
+# Drive a subprocess with empty stdin so prompt hits EOF immediately.
+spurt "tmp/prompt-eof-prog.raku", 'my $x = prompt("p "); print $x.^name, "|", $x.defined, "|", $x.gist;';
+my $out = qqx{echo -n "" | $exe tmp/prompt-eof-prog.raku};
+
+# The prompt message "p " is written to stdout before the type-object output.
+is $out, "p Any|False|(Any)", 'prompt at EOF returns the Any type object';
+
+# Normal input still yields a Str.
+spurt "tmp/prompt-line-prog.raku", 'my $x = prompt("q "); print $x.^name, "|", $x;';
+my $out2 = qqx{echo "hello" | $exe tmp/prompt-line-prog.raku};
+is $out2, "q Str|hello", 'prompt with input returns the read Str';
+
+# get shares the EOF semantics.
+spurt "tmp/get-eof-prog.raku", 'my $x = get(); print $x.^name, "|", $x.defined;';
+my $out3 = qqx{echo -n "" | $exe tmp/get-eof-prog.raku};
+is $out3, "Any|False", 'get at EOF returns the Any type object';
+
+unlink $_ for <tmp/prompt-eof-prog.raku tmp/prompt-line-prog.raku tmp/get-eof-prog.raku>;
+pass 'cleanup';


### PR DESCRIPTION
## Summary

`prompt` returned an empty string when input reached EOF; raku returns the
`Any` type object (like `get`), so `prompt(...).defined` is `False` and its
gist is `(Any)`:

```
# empty stdin
prompt("Say hi → ")   # mutsu ""  → raku (Any)   .^name Any, .defined False
```

`builtin_prompt` now returns the `Any` type object on a `None` read (matching
`builtin_get`) instead of `.unwrap_or_default()`-ing to `""`. Normal input
still returns the read `Str`.

## Impact

Resolves the prompt-EOF finding in the `Language/py-nutshell.rakudoc` doc-diff
sweep.

## Testing

- New pin `t/prompt-eof-any.t` (drives real subprocesses with empty/non-empty
  stdin).
- `make test` green; `roast/S16-io/prompt.t` and `roast/S16-io/say.t` pass.

(The Cargo.lock line is a `0.13.0 → 0.14.0` version sync picked up from main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)