### PR TITLE
fix: role diamond duplicate mis-flagged as required-method conflict (T-023)

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -10,7 +10,7 @@ add a `[claim: <branch>]` marker on its heading and push before you start.
 Move a ticket to **Done** when its PR merges. Rebase on `main` before
 editing this file; keep edits small (one ticket) to avoid conflicts.
 
-_36 open tickets._
+_35 open tickets._
 
 ## Open
 
@@ -63,12 +63,6 @@ _36 open tickets._
 ### T-018 — runtime_error: Cannot call private method X permission  [impact: 1 dist]
 - dists: Cookie::Jar
 - e.g. `Cookie::Jar`: Cookie::Jar: Cannot call private method without permission
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
-
-### T-023 — runtime_error: multiple candidates for required method X  [impact: 1 dist]
-- dists: UpRooted
-- e.g. `UpRooted`: UpRooted::Reader::MySQL: X::Role::Composition::Conflict: multiple candidates for required method 'quote-constant'
 - repro: _(fill in a minimal repro + raku baseline before fixing)_
 - file: _(suspected parser/runtime file)_
 
@@ -284,6 +278,17 @@ _(move tickets here with `[claim: <branch>]` when you start)_
 
 ## Done
 
+- **T-023** (#5117) — a role composition *diamond*: a stubbed (required) role
+  method (`method !quote-constant { !!! }` in `Quoter`, reached via `FQN`) and its
+  concrete implementation (in `DBIConnection`) both flowed through one shared
+  intermediate role (`DBISelect`) into the class, so the same `MethodDef`,
+  re-tagged with each intermediate's `role_origin`, was counted twice and wrongly
+  raised `X::Role::Composition::Conflict: multiple candidates for required method`.
+  `resolve_class_stub_requirements` now deduplicates candidates by their `body`
+  Arc pointer + positional signature, collapsing a diamond duplicate while keeping
+  genuinely-distinct candidates (two `multi method f(Int)`, `::?ROLE:U:` vs `:D:`,
+  a parametric role composed at two type args). **UpRooted::Reader::MySQL /
+  ::PostgreSQL now load**, matching raku. Pin: t/role-diamond-stub-concrete.t.
 - **T-022** (#5114) — a coercion-typed parameter default
   (`IO::Path(Str) $p = "x"`, `IO::Path(Str) :$out-path = "."`) wrongly raised the
   compile-time `X::Parameter::Default::TypeCheck`: `default_type_matches_constraint`

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -78,6 +78,33 @@ impl Interpreter {
         Self::is_stub_routine_body(&def.body)
     }
 
+    /// Remove duplicate method candidates that are the *same* underlying
+    /// definition reaching a class through multiple composition paths (a role
+    /// diamond). Identity is the method's deepest source role (`original_role`,
+    /// falling back to `role_origin`) plus its positional signature; keeping the
+    /// first occurrence. Methods with distinct source roles are preserved, so a
+    /// genuine same-name-different-role conflict is still detected.
+    fn dedup_method_candidates(defs: &mut Vec<MethodDef>) {
+        // A method reaching the class through multiple composition paths (a role
+        // diamond) is the *same* `MethodDef` cloned once per path, so all its
+        // clones share the same `body` Arc allocation. Deduplicate by that
+        // pointer identity, paired with the positional signature: two
+        // genuinely-distinct definitions own separate allocations and survive
+        // (`multi method f(Int)` twice, or `::?ROLE:U:` vs `:D:` differing only by
+        // invocant), and the same parametric role composed at two different type
+        // arguments (`does R[Str] does R[Int]`) shares the body Arc but keeps a
+        // distinct signature, so it survives too -- only a true diamond duplicate
+        // (same body *and* same signature) is collapsed.
+        let mut seen: std::collections::HashSet<(*const Vec<Stmt>, Vec<String>)> =
+            std::collections::HashSet::new();
+        defs.retain(|def| {
+            seen.insert((
+                std::sync::Arc::as_ptr(&def.body),
+                Self::method_positional_signature(def),
+            ))
+        });
+    }
+
     pub(super) fn method_positional_signature(def: &MethodDef) -> Vec<String> {
         def.param_defs
             .iter()
@@ -182,6 +209,17 @@ impl Interpreter {
                     concrete.push(def);
                 }
             }
+            // A method can reach the class through multiple composition paths (a
+            // diamond: `class does Selector` where `Selector does DBIConn`, and
+            // DBIConn's method is also pulled in directly). The *same* underlying
+            // definition then appears several times, each tagged with a different
+            // intermediate `role_origin`. Deduplicate candidates by the method's
+            // deepest source role (`original_role`, falling back to `role_origin`)
+            // plus its positional signature, so a diamond-shared method counts
+            // once -- while genuinely distinct same-named methods from different
+            // roles still collide.
+            Self::dedup_method_candidates(&mut stubs);
+            Self::dedup_method_candidates(&mut concrete);
             if !stubs.is_empty() {
                 for required in &stubs {
                     let matching: Vec<&MethodDef> = concrete

--- a/t/role-diamond-stub-concrete.t
+++ b/t/role-diamond-stub-concrete.t
@@ -1,0 +1,58 @@
+use v6;
+use Test;
+
+# When a stubbed (required) role method and its concrete implementation both
+# reach a class through a *shared intermediate role* (a composition diamond),
+# the concrete satisfies the requirement -- there is no conflict. mutsu wrongly
+# reported "X::Role::Composition::Conflict: multiple candidates for required
+# method" because the same underlying definition, re-tagged with the
+# intermediate role's origin, was counted twice. T-023 (UpRooted).
+
+plan 4;
+
+# The exact diamond shape from UpRooted: a stub in Quoter (via FQN) and a
+# concrete in DBIConn both flow through the single intermediate role Selector.
+{
+    role Quoter { method !qc ( $v, $t ) { !!! } }
+    role FQN does Quoter { }
+    role DBIConn { method !qc ( $v, $t --> Str ) { "quoted" } }
+    role Selector does FQN does DBIConn { }
+    class Reader does Selector { method go { self!qc(1, 2) } }
+    is Reader.new.go, 'quoted', 'diamond stub+concrete via one intermediate role resolves';
+}
+
+# Deeper chain (class does a role that does the Selector).
+{
+    role Quoter2 { method !qc ( $v, $t ) { !!! } }
+    role FQN2 does Quoter2 { }
+    role DBIConn2 { method !qc ( $v, $t --> Str ) { "deep" } }
+    role Selector2 does FQN2 does DBIConn2 { }
+    role Reader2Role does Selector2 { }
+    class Reader2 does Reader2Role { method go { self!qc(1, 2) } }
+    is Reader2.new.go, 'deep', 'diamond resolves through two intermediate roles';
+}
+
+# Class directly composes the stub role and the concrete role (no intermediate).
+{
+    role Q3 { method !qc ( $v, $t ) { !!! } }
+    role C3 { method !qc ( $v, $t ) { "direct" } }
+    class R3 does Q3 does C3 { method go { self!qc(1, 2) } }
+    is R3.new.go, 'direct', 'direct stub+concrete resolves (unchanged)';
+}
+
+# A genuine conflict -- a stub plus TWO different concrete implementations from
+# distinct roles -- must STILL be rejected.
+{
+    my $err;
+    {
+        EVAL q:to/CODE/;
+            role QS { method !qc ( $v, $t ) { !!! } }
+            role CA { method !qc ( $v, $t ) { "A" } }
+            role CB { method !qc ( $v, $t ) { "B" } }
+            class RC does QS does CA does CB { method go { self!qc(1, 2) } }
+            RC.new.go;
+        CODE
+        CATCH { default { $err = .message } }
+    }
+    ok $err.defined, 'stub + two distinct concretes still conflicts';
+}


### PR DESCRIPTION
## Summary

When a stubbed (required) role method and its concrete implementation both reach
a class through a **shared intermediate role** (a composition diamond), the
concrete satisfies the requirement — there is no conflict. mutsu instead raised:

```
X::Role::Composition::Conflict: multiple candidates for required method 'quote-constant'
```

The same `MethodDef`, cloned once per composition path and re-tagged with each
intermediate role's `role_origin`, appeared several times in the class's method
list, so `resolve_class_stub_requirements` counted the single underlying concrete
method as multiple candidates.

## Fix

Deduplicate candidates by their `body` Arc pointer (all clones of one definition
share the allocation) paired with the positional signature. A true diamond
duplicate collapses; genuinely-distinct candidates are preserved:

- two `multi method f(Int)` in one class body (still ambiguous),
- `multi method m(::?ROLE:U:)` vs `(::?ROLE:D:)` (different bodies),
- the same parametric role composed at two type args, `does R[Str] does R[Int]`
  (shared body Arc but distinct signature).

## Result

**UpRooted (T-023)** — `UpRooted::Reader::MySQL` / `::PostgreSQL` load now,
matching raku. (`UpRooted::Writer::*` / `::Schema::*` have a separate,
context-dependent parse gap — a leaked-region bug where the module parses alone
but fails via the `use` chain — tracked separately.)

## Test

Pin: `t/role-diamond-stub-concrete.t` (4 subtests): the diamond resolves through
one and two intermediate roles, the direct case still resolves, and a genuine
`stub + two distinct concretes` conflict is still rejected. Full `make test`
passes (20602 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)