### PR TITLE
fix: route self.Mu::/self.Any:: qualified coercion to the built-in default

### DIFF
--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -1950,6 +1950,14 @@ impl Interpreter {
             return result;
         }
 
+        // Qualified coercion to a universal base (self.Mu::Str, self.Any::gist):
+        // route to the built-in default, bypassing the receiver's own override.
+        // Must precede the instance/non-instance qualified dispatchers, which would
+        // otherwise recurse (type object) or reject it as "not inherited" (instance).
+        if let Some(result) = self.dispatch_universal_base_coercion(&target, method, &args) {
+            return result;
+        }
+
         // Qualified method: Class::method on Instance
         if let Some(result) = self.dispatch_qualified_instance_method(&target, method, args.clone())
         {

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -2282,7 +2282,11 @@ impl Interpreter {
 
     /// Collect public attribute representations for `.raku` output.
     /// Returns a list of `"name => value.raku"` strings for public attributes.
-    fn collect_public_raku_attrs(&mut self, class_name: &str, attributes: &AttrMap) -> Vec<String> {
+    pub(crate) fn collect_public_raku_attrs(
+        &mut self,
+        class_name: &str,
+        attributes: &AttrMap,
+    ) -> Vec<String> {
         let class_attrs = self.collect_class_attributes(class_name);
         let mut parts = Vec::new();
         for (attr_name, is_public, _default, _is_rw, _is_required, _sigil, _where) in &class_attrs {

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -51,6 +51,91 @@ impl Interpreter {
         Some(Err(make_private_unqualified_error(private_rest)))
     }
 
+    /// `Mu`/`Any`/`Cool` are the implicit roots of every type's MRO but carry no
+    /// user-defined methods of their own, so a qualified coercion call to one of
+    /// them (`self.Mu::Str`, `self.Any::gist`) must reach the BUILT-IN default
+    /// coercion, bypassing any user/role override on the receiver. Hash::Agnostic
+    /// and friends rely on this: `multi method Str(::?ROLE:U:) { self.Mu::Str }`.
+    ///
+    /// Without this, the type-object path re-dispatches the receiver's own
+    /// overriding `.Str`/`.gist` (via `dispatch_qualified_non_instance_method`,
+    /// which loses the class name and re-enters unqualified dispatch) and recurses
+    /// until the stack overflows; the instance path is wrongly rejected as
+    /// "not inherited".
+    ///
+    /// The qualifier must actually sit in the receiver's MRO (so `self.Cool::Str`
+    /// on a non-Cool class still errors, matching Rakudo), and only the base
+    /// coercion/introspection methods that Mu/Any/Cool provide as defaults are
+    /// intercepted — anything else falls through to normal dispatch.
+    pub(super) fn dispatch_universal_base_coercion(
+        &mut self,
+        target: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Option<Result<Value, RuntimeError>> {
+        if method.starts_with('!') || !args.is_empty() {
+            return None;
+        }
+        let (qualifier, actual_method) = method.rsplit_once("::")?;
+        if !matches!(qualifier, "Mu" | "Any" | "Cool") {
+            return None;
+        }
+        let cn = match target.view() {
+            ValueView::Package(name) => name.resolve(),
+            ValueView::Instance { class_name, .. } => class_name.resolve(),
+            _ => return None,
+        };
+        // `Mu` and `Any` are the implicit roots of every type, so a qualified
+        // coercion to them is always valid — and `class_mro` does not always
+        // materialize them (a role-only class `C does R` linearizes to `[C, R]`).
+        // `Cool` is only reachable from Cool-derived types, so it must actually
+        // appear in the MRO (matching Rakudo's "not inherited" rejection otherwise).
+        if qualifier == "Cool" && !self.class_mro(&cn).iter().any(|c| c.as_str() == "Cool") {
+            return None;
+        }
+        match target.view() {
+            // Type object (`C.Mu::Str`): the built-in coercion of an undefined value.
+            ValueView::Package(name) => {
+                let n = name.resolve();
+                let v = match actual_method {
+                    // A type object stringifies to the empty string (Rakudo also
+                    // emits an "uninitialized value in string context" warning; the
+                    // existing bare-class `.Str` fallback is silent, so match it).
+                    "Str" | "Stringy" => Value::str(String::new()),
+                    "gist" => {
+                        if crate::value::is_internal_anon_type_name(&n) {
+                            Value::str_from("()")
+                        } else {
+                            let short = n.rsplit("::").next().unwrap_or(&n);
+                            Value::str(format!("({})", short))
+                        }
+                    }
+                    "raku" | "perl" => Value::str(n),
+                    "Bool" | "defined" => Value::truth(false),
+                    _ => return None,
+                };
+                Some(Ok(v))
+            }
+            // Defined instance (`$o.Mu::gist`): the generic `Class.new(attrs)` repr,
+            // ignoring the receiver's own `gist`/`raku` override.
+            ValueView::Instance { attributes, .. } => match actual_method {
+                "gist" | "raku" | "perl" => {
+                    let display_name = crate::value::user_facing_type_name(&cn);
+                    let public_attrs = self.collect_public_raku_attrs(&cn, &attributes.to_map());
+                    let rendered = if public_attrs.is_empty() {
+                        format!("{}.new", display_name)
+                    } else {
+                        format!("{}.new({})", display_name, public_attrs.join(", "))
+                    };
+                    Some(Ok(Value::str(rendered)))
+                }
+                "Bool" | "defined" => Some(Ok(Value::truth(true))),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
     /// Handle qualified method names: Class::method (e.g., $o.Parent::x).
     /// Returns Some(result) if handled, None to continue.
     pub(super) fn dispatch_qualified_instance_method(

--- a/t/qualified-mu-coercion.t
+++ b/t/qualified-mu-coercion.t
@@ -1,0 +1,47 @@
+use Test;
+
+# A qualified coercion to a universal base type (`self.Mu::Str`, `self.Any::gist`)
+# must reach the BUILT-IN default coercion, bypassing the receiver's own override.
+# Regression: a role/class that overrides `.Str`/`.gist` and delegates to
+# `self.Mu::Str` used to recurse forever (type object -> stack overflow) or be
+# rejected as "not inherited" (defined instance). Hash::Agnostic relies on this.
+
+plan 16;
+
+# --- Type object (`:U:` multi delegating to self.Mu::...) --------------------
+role R {
+    proto method Str(|)  {*}
+    multi method Str(::?ROLE:U:)  { self.Mu::Str  }
+    multi method Str(::?ROLE:D:)  { "defined-str" }
+    proto method gist(|) {*}
+    multi method gist(::?ROLE:U:) { self.Mu::gist }
+    multi method gist(::?ROLE:D:) { "defined-gist" }
+}
+class C does R { has $.x }
+
+is C.Str,  '',     'type-object self.Mu::Str is the empty string (no infinite recursion)';
+is C.gist, '(C)',  'type-object self.Mu::gist is the paren type name';
+
+# Direct qualified coercions on a bare type object.
+is C.Mu::Str,      '',    'C.Mu::Str is the empty string';
+is C.Mu::gist,     '(C)', 'C.Mu::gist is (C)';
+is C.Mu::raku,     'C',   'C.Mu::raku is the bare type name';
+is C.Any::gist,    '(C)', 'C.Any::gist is (C)';
+is C.Mu::Bool,     False, 'C.Mu::Bool is False';
+is C.Mu::defined,  False, 'C.Mu::defined is False';
+
+# A role-only class (`does R`, no `is`) still resolves Mu/Any in its MRO.
+ok C.new(x => 1).defined, 'a defined instance is defined';
+
+# --- Defined instance -------------------------------------------------------
+is C.new(x => 5).Mu::gist,  'C.new(x => 5)', 'instance self.Mu::gist is the generic .new repr';
+is C.new(x => 5).Any::gist, 'C.new(x => 5)', 'instance self.Any::gist is the generic .new repr';
+is C.new(x => 5).Mu::raku,  'C.new(x => 5)', 'instance self.Mu::raku is the generic .new repr';
+is C.new(x => 5).Mu::Bool,  True,            'instance self.Mu::Bool is True';
+
+# The overriding `:D:` multi still wins for an unqualified call.
+is C.new(x => 5).Str,  'defined-str',  'unqualified .Str still hits the user :D: multi';
+is C.new(x => 5).gist, 'defined-gist', 'unqualified .gist still hits the user :D: multi';
+
+# --- Cool is NOT a universal base: a non-Cool class must reject Cool:: -------
+dies-ok { C.Cool::Str }, 'Cool:: on a non-Cool class still dies (Cool is not in the MRO)';


### PR DESCRIPTION
A qualified coercion to a universal base type (`self.Mu::Str`, `self.Any::gist`) must reach the **built-in default** coercion, bypassing any user/role override on the receiver. `Hash::Agnostic` and friends rely on this idiom:

```raku
proto method Str(|) {*}
multi method Str(::?ROLE:U:) { self.Mu::Str }
```

## The bug

- **Type object** (`C.Str` where `C` is undefined, hitting the `:U:` multi): the qualified `self.Mu::Str` fell through to `dispatch_qualified_non_instance_method`, which loses the class name (`value_type_name(Package(C))` is `"Package"`) and re-dispatches `.Str` **unqualified**, re-entering the receiver's own overriding `Str` → infinite recursion → **stack overflow**.
- **Defined instance** (`$o.Mu::gist`): rejected as `Cannot dispatch to method gist on Mu because it is not inherited or done by C`, because a role-only class (`class C does R`) linearizes to `[C, R]` in `class_mro` without the implicit `Any`/`Mu`.

## The fix

Add `dispatch_universal_base_coercion`, called **before** the qualified instance/non-instance dispatchers. It computes the built-in default for:

- `Mu`/`Any` — always valid roots of every type (so it does not rely on `class_mro` materializing them for role-only classes),
- `Cool` — only when actually present in the MRO, so a non-Cool class still errors as in Rakudo.

Covers `Str`/`Stringy`/`gist`/`raku`/`perl`/`Bool`/`defined` for type objects and `gist`/`raku`/`perl`/`Bool`/`defined` for defined instances.

## Testing

- New pin `t/qualified-mu-coercion.t` — 16 cases, all verified identical under `raku`.
- `make test`: PASS (20632 tests).
- Relevant roast (`S12-methods/qualified.t`, `S14-roles/basic.t`, `S12-class/basic.t`, …): no regressions.

Unblocks the `Hash::Agnostic` dist type-object coercion tests (its `test_die` was exactly this crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)