### PR TITLE
fix: a Bool numifies (False->0, True->1) in ordered comparison

### DIFF
--- a/src/runtime/utils/compare.rs
+++ b/src/runtime/utils/compare.rs
@@ -134,6 +134,20 @@ pub(crate) fn compare_values(a: &Value, b: &Value) -> i32 {
     {
         return compare_values(&a.deref_container(), &b.deref_container());
     }
+    // A Bool numifies (False → 0, True → 1) when compared against a number or
+    // another Bool, so `0 cmp False` / `0 <=> False` is Same, matching Rakudo.
+    // Without this, a Bool falls through to the string-comparison fallback below
+    // ("0".cmp("False")), which mis-orders it and breaks `min`/`max` tie-breaking
+    // (`min False, 0` must keep the first argument). Normalize a Bool operand to
+    // its Int value; recursion terminates because neither operand is a Bool after
+    // normalization.
+    if matches!(a.view(), ValueView::Bool(_)) || matches!(b.view(), ValueView::Bool(_)) {
+        let normalize = |v: &Value| match v.view() {
+            ValueView::Bool(flag) => Value::int(if flag { 1 } else { 0 }),
+            _ => v.clone(),
+        };
+        return compare_values(&normalize(a), &normalize(b));
+    }
     match (a.view(), b.view()) {
         (
             ValueView::Version {

--- a/src/vm/vm_comparison_order_ops.rs
+++ b/src/vm/vm_comparison_order_ops.rs
@@ -145,6 +145,20 @@ impl Interpreter {
             ValueView::Mixin(inner, _) => inner.as_ref(),
             _ => right,
         };
+        // A Bool numifies (False → 0, True → 1) in ordered comparison, so
+        // `0 cmp False` / `0 <=> False` / `False before 0` all treat it as its
+        // Int value, matching Rakudo. Without this it hits the string-comparison
+        // fallback below ("0" vs "False") and mis-orders.
+        let normalize_bool = |v: &Value| -> Option<Value> {
+            match v.view() {
+                ValueView::Bool(flag) => Some(Value::int(if flag { 1 } else { 0 })),
+                _ => None,
+            }
+        };
+        let left_norm = normalize_bool(left);
+        let right_norm = normalize_bool(right);
+        let left = left_norm.as_ref().unwrap_or(left);
+        let right = right_norm.as_ref().unwrap_or(right);
         match (left.view(), right.view()) {
             (ValueView::Int(a), ValueView::Int(b)) => a.cmp(&b),
             (_, _)

--- a/t/bool-numeric-compare.t
+++ b/t/bool-numeric-compare.t
@@ -1,0 +1,41 @@
+use v6;
+use Test;
+
+# A Bool numifies (False -> 0, True -> 1) in ordered comparison (cmp / <=> /
+# before / after / min / max / sort), so `0 cmp False` is Same, matching Rakudo.
+# Regression: mutsu fell back to string comparison ("0" vs "False"), mis-ordering
+# a Bool against a number and breaking min/max tie-breaking.
+
+plan 21;
+
+# cmp / <=> are Same for equal numeric-vs-Bool values.
+is (0 cmp False), Same, '0 cmp False is Same';
+is (False cmp 0), Same, 'False cmp 0 is Same';
+is (0 <=> False), Same, '0 <=> False is Same';
+is (1 cmp True),  Same, '1 cmp True is Same';
+is (True cmp False), More, 'True cmp False is More';
+is (False cmp True), Less, 'False cmp True is Less';
+is (True <=> False), More, 'True <=> False is More';
+
+# before / after.
+ok !(False before 0), 'False before 0 is False (equal)';
+ok !(0 after False),  '0 after False is False (equal)';
+ok (False before True), 'False before True';
+ok (True after False),  'True after False';
+
+# min / max keep the FIRST argument on a numeric tie (0 == False).
+is (min 0, False), 0,     'min 0, False keeps first (0)';
+is (min False, 0), False, 'min False, 0 keeps first (False)';
+is (max 0, False), 0,     'max 0, False keeps first (0)';
+is (max False, 0), False, 'max False, 0 keeps first (False)';
+is (0 min False), 0,      'infix 0 min False';
+is (False min 0), False,  'infix False min 0';
+
+# .min / .max methods over a list.
+is (0, False).min, 0,      '(0, False).min';
+is (False, 0).min, False,  '(False, 0).min';
+
+# sort orders Bools by their numeric value, interleaved with numbers.
+is-deeply (3, True, 2, False).sort.List, (False, True, 2, 3),
+    'sort interleaves Bool by numeric value';
+is-deeply (True, False).min, False, '(True, False).min';


### PR DESCRIPTION
## Summary

Found via the doc-diff harness on `Language/operators.rakudoc` (findings
[22]/[23], the `min`/`max` tie-breaking examples).

`0 cmp False`, `0 <=> False`, `False before 0`, and — crucially — `min`/`max`
tie-breaking treated a `Bool` as a **string** (`"0"` vs `"False"`) instead of
its numeric value. So `min False, 0` returned `0` instead of keeping the first
argument, and `0 cmp False` reported `Less`/`More` instead of `Same`.

## Root cause

Two comparators reimplement ordering and neither numified `Bool`:

- `compare_values` (`utils/compare.rs`) — used by `.min`/`.max`, the `min`/`max`
  listops (via `minmax_two`) and `.sort` with the default comparator — fell
  through to its string-comparison fallback for a `Bool` operand.
- `spaceship_ordering` (VM) — the core of `cmp`/`<=>`/`before`/`after` — had no
  `Bool` arm and hit the same string fallback. `numeric_spaceship_ordering`
  delegates its non-string cases here, so `<=>` is covered too.

## Fix

Normalize a `Bool` operand to its `Int` value (`False → 0`, `True → 1`) at the
top of both comparators. Every ordered comparison and the min/max
first-on-tie rule now match Rakudo. Arithmetic (`True + 1`) already coerced
`Bool` on its own path and is unaffected.

## Verification

```
$ mutsu -e 'say min False, 0; say 0 cmp False; say (3, True, 2, False).sort'
False
Same
(False True 2 3)
```

All match reference raku. New regression test `t/bool-numeric-compare.t`
(21 cases). Existing min/max/sort/cmp tests (`sort-spaceship-numeric-coerce`,
`spaceship-edge-cases`, `range-minmax-adverbs`, `unicmp`, ...) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)