### PR TITLE
fix: prefix ++/-- accepts a postfix `.=` mutator as its lvalue

### DIFF
--- a/src/compiler/expr_unary.rs
+++ b/src/compiler/expr_unary.rs
@@ -72,6 +72,19 @@ impl Compiler {
                     let slot = self.local_map.get(&var_name).copied();
                     let name_idx = self.code.add_constant(Value::str(var_name));
                     self.code.emit(OpCode::PreIncrement(name_idx, slot));
+                } else if let Expr::AssignExpr { name, .. } = expr
+                    && !name.starts_with('@')
+                    && !name.starts_with('%')
+                {
+                    // `++($x .= method)`: the `.=` mutator assigns back into `$x`
+                    // and yields it as an lvalue, so the prefix `++` increments the
+                    // live variable. Emit the assignment (leaving its value on the
+                    // stack), drop it, then pre-increment the scalar.
+                    self.compile_expr(expr);
+                    self.code.emit(OpCode::Pop);
+                    let slot = self.local_map.get(name).copied();
+                    let name_idx = self.code.add_constant(Value::str(name.clone()));
+                    self.code.emit(OpCode::PreIncrement(name_idx, slot));
                 } else if let Expr::Index { target, index, .. } = expr {
                     if let Some(name) = Self::postfix_index_name(target) {
                         self.compile_expr(index);
@@ -118,6 +131,17 @@ impl Compiler {
                     self.code.emit(OpCode::Pop);
                     let slot = self.local_map.get(&var_name).copied();
                     let name_idx = self.code.add_constant(Value::str(var_name));
+                    self.code.emit(OpCode::PreDecrement(name_idx, slot));
+                } else if let Expr::AssignExpr { name, .. } = expr
+                    && !name.starts_with('@')
+                    && !name.starts_with('%')
+                {
+                    // `--($x .= method)`: see the `++` case above — the `.=`
+                    // mutator yields `$x` as an lvalue for the pre-decrement.
+                    self.compile_expr(expr);
+                    self.code.emit(OpCode::Pop);
+                    let slot = self.local_map.get(name).copied();
+                    let name_idx = self.code.add_constant(Value::str(name.clone()));
                     self.code.emit(OpCode::PreDecrement(name_idx, slot));
                 } else if let Expr::Index { target, index, .. } = expr {
                     if let Some(name) = Self::postfix_index_name(target) {

--- a/t/prefix-incr-dot-assign.t
+++ b/t/prefix-incr-dot-assign.t
@@ -1,0 +1,38 @@
+use v6;
+use Test;
+
+# A postfix `.=` mutator yields its variable as an lvalue, so a prefix `++`/`--`
+# can operate on it: `++$a.=abs` is `++($a.=abs)`.
+# Regression: mutsu rejected this with "prefix:<++> requires mutable arguments".
+
+plan 8;
+
+{
+    my $a = -5;
+    is (++$a.=abs), 6, '++$a.=abs returns 6';
+    is $a, 6, '  ... and $a is now 6';
+}
+
+{
+    my $b = 3.5;
+    is (--$b.=floor), 2, '--$b.=floor returns 2';
+    is $b, 2, '  ... and $b is now 2';
+}
+
+{
+    my $c = "5";
+    is (++$c.=Int), 6, '++$c.=Int coerces then increments';
+    is $c, 6, '  ... and $c is now 6';
+}
+
+{
+    # Plain `.=` chain still increments the same variable.
+    my $d = -10;
+    ++$d.=abs;
+    is $d, 11, 'statement form mutates the variable';
+}
+
+{
+    my $e = -1;
+    is (--$e.=abs), 0, '--$e.=abs returns 0';
+}


### PR DESCRIPTION
## Summary

Found via the doc-diff harness on `Language/operators.rakudoc` (finding [1]).

`++$a.=abs` — i.e. `++($a.=abs)` — died with:

```
Cannot resolve caller prefix:<++>(...); the parameter requires mutable arguments
```

## Root cause

The prefix `++`/`--` compiler (`compiler/expr_unary.rs`) recognized `Var`, a
bareword, a var-decl and an index as lvalues, but not an `AssignExpr` — the AST
shape a `.=` mutator produces. So `++($a.=abs)` fell through to the
`__mutsu_incdec_nomatch` error path.

## Fix

A `.=` mutator assigns back into its scalar and yields that variable as an
lvalue. Add an `AssignExpr` branch to both prefix `++` and `--`: emit the
assignment (leaving its value on the stack), drop it, then pre-increment /
pre-decrement the scalar — mirroring the existing var-decl branch. Restricted to
scalar names (not `@`/`%`).

## Verification

```
$ mutsu -e 'my $a = -5; say ++$a.=abs; say $a'
6
6
```

Matches reference raku. New regression test `t/prefix-incr-dot-assign.t`
(8 cases); existing dot-assign / inc-dec tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)