### PR TITLE
feat: nqp::ordat, typed-scalar bind-to-element, Bool→native-int coercion (T-035)

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -10,7 +10,7 @@ add a `[claim: <branch>]` marker on its heading and push before you start.
 Move a ticket to **Done** when its PR merges. Rebase on `main` before
 editing this file; keep edits small (one ticket) to avoid conflicts.
 
-_36 open tickets._
+_35 open tickets._
 
 ## Open
 
@@ -135,12 +135,6 @@ _36 open tickets._
 ### T-034 — test_die: No such private method X for invocant of type 'X'  [impact: 1 dist]
 - dists: IdClass
 - e.g. `IdClass`: base=6 pass=0 fail=0 die=6 | t/01-basic.rakutest: No such private method 'gen-rest' for invocant of type 'UserId'
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
-
-### T-035 — test_die: Unknown function: ordat  [impact: 1 dist]
-- dists: Text::Diff::Sift4
-- e.g. `Text::Diff::Sift4`: base=1 pass=0 fail=0 die=1 | t/01-sift4.t: Unknown function: ordat
 - repro: _(fill in a minimal repro + raku baseline before fixing)_
 - file: _(suspected parser/runtime file)_
 
@@ -284,6 +278,14 @@ _(move tickets here with `[claim: <branch>]` when you start)_
 
 ## Done
 
+- **T-035** (#PENDING) — Text::Diff::Sift4 died on `nqp::ordat` and hit two more
+  gaps once it was added. Three general fixes: (1) implemented `nqp::ordat($s,
+  $pos)` (codepoint at a position, -1 past end); (2) a typed scalar `:=`-bound to
+  an array element (`my Offset $o := @a[$i]`) type-checked the `ContainerRef`
+  cell instead of its contents ("expected Offset but got Any") — deref before the
+  bind-time constraint check; (3) a Bool assigned to a native `int` (`my int $x =
+  3 >= 2`) is now accepted and unboxed to 1/0 (Bool `does Int`). **Sift4's suite
+  passes 32/32**, matching raku. Pin: t/nqp-ordat-and-native-int-coerce.t.
 - **T-022** (#5114) — a coercion-typed parameter default
   (`IO::Path(Str) $p = "x"`, `IO::Path(Str) :$out-path = "."`) wrongly raised the
   compile-time `X::Parameter::Default::TypeCheck`: `default_type_matches_constraint`

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -616,6 +616,29 @@ impl Interpreter {
                     _ => Ok(Value::NIL),
                 }
             }
+            // nqp::ordat($str, $pos): the Unicode codepoint of the character at
+            // position `$pos` in `$str` (equivalent to `$str.substr($pos, 1).ord`).
+            // Returns -1 when the position is past the end, matching nqp. Used by
+            // Text::Diff::Sift4's inner char-comparison loop.
+            "nqp::ordat" => {
+                let s = args
+                    .first()
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_default();
+                let pos = args
+                    .get(1)
+                    .and_then(|v| match v.view() {
+                        ValueView::Int(i) => Some(i),
+                        _ => v.to_string_value().parse::<i64>().ok(),
+                    })
+                    .unwrap_or(0);
+                let cp = usize::try_from(pos)
+                    .ok()
+                    .and_then(|p| s.chars().nth(p))
+                    .map(|c| c as i64)
+                    .unwrap_or(-1);
+                Ok(Value::int(cp))
+            }
             // nqp::bindattr($obj, Type, '$!attr', value): write an attribute
             // cell directly, bypassing accessors (roast's Test::Compile uses it
             // to install a precomp repository into a CUR::FileSystem instance).

--- a/src/runtime/types/type_matching_static.rs
+++ b/src/runtime/types/type_matching_static.rs
@@ -83,8 +83,11 @@ impl Interpreter {
         {
             return true;
         }
-        // Native integer types match Int values
-        if crate::runtime::native_types::is_native_int_type(constraint) && value_type == "Int" {
+        // Native integer types match Int values -- and Bool, which `does Int`
+        // (`enum Bool does Int`), so `my int $x = 3 >= 2` stores 1 like raku.
+        if crate::runtime::native_types::is_native_int_type(constraint)
+            && matches!(value_type, "Int" | "Bool")
+        {
             return true;
         }
         // Native float types (num32, num64) are subtypes of Num

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -590,6 +590,13 @@ impl Interpreter {
         if !native_types::is_native_int_type(base) {
             return Ok(val);
         }
+        // Bool `does Int`: unbox it to its integer value (True=1, False=0) when
+        // stored in a native int slot, matching raku (`my int $x = 3 >= 2` → 1).
+        let val = if let ValueView::Bool(b) = val.view() {
+            Value::int(i64::from(b))
+        } else {
+            val
+        };
         // Full-width signed native types don't wrap — they should throw on overflow.
         if matches!(base, "int" | "int64") {
             if let ValueView::BigInt(n) = val.view() {

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1091,11 +1091,20 @@ impl Interpreter {
                     )));
                 }
             }
-            if !val.is_nil() && !self.type_matches_value(&constraint, &val) {
+            // A `:=` bind stores a `ContainerRef` cell (e.g. `my Offset $o := @a[$i]`
+            // aliases the array element). The type constraint applies to the
+            // *contained* value, so deref the cell before matching -- otherwise the
+            // check inspects the container itself and reports the bogus "got Any".
+            let check_val = if is_bind {
+                val.deref_container()
+            } else {
+                val.clone()
+            };
+            if !check_val.is_nil() && !self.type_matches_value(&constraint, &check_val) {
                 return Err(runtime::utils::type_check_assignment_typed_error(
                     name,
                     &constraint,
-                    &val,
+                    &check_val,
                 ));
             }
             if !val.is_nil() {

--- a/t/nqp-ordat-and-native-int-coerce.t
+++ b/t/nqp-ordat-and-native-int-coerce.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+use nqp;
+
+# Three gaps that blocked Text::Diff::Sift4 (T-035):
+#  1. `nqp::ordat($str, $pos)` was unimplemented ("Unknown function: ordat").
+#  2. A typed scalar `:=`-bound to an array element (`my Offset $o := @a[$i]`)
+#     type-checked the ContainerRef itself and reported the bogus "got Any".
+#  3. A Bool assigned to a native `int` was rejected instead of coercing (Bool
+#     `does Int`, so True=1 / False=0).
+
+plan 11;
+
+# --- 1. nqp::ordat -------------------------------------------------------
+is nqp::ordat("abc", 0), 97,  'nqp::ordat first char';
+is nqp::ordat("abc", 2), 99,  'nqp::ordat later char';
+is nqp::ordat("h\c[LATIN SMALL LETTER E WITH ACUTE]llo", 1), 233,
+    'nqp::ordat non-ASCII codepoint';
+is nqp::ordat("abc", 5), -1,  'nqp::ordat past end returns -1';
+
+# --- 2. typed scalar := bound to an array element ------------------------
+{
+    class Offset {
+        has int $.c1 is built(:bind);
+        has int $.c2 is built(:bind);
+    }
+    my @offset_arr;
+    @offset_arr.push(Offset.new(c1 => 3, c2 => 5));
+    my int $i = 0;
+    my Offset $ofs;
+    $ofs := @offset_arr[$i];
+    is $ofs.c1, 3, 'typed scalar bind to array element reads .c1';
+    is $ofs.c2, 5, 'typed scalar bind to array element reads .c2';
+    is $ofs.^name, 'Offset', 'bound typed scalar has the element type';
+}
+
+# --- 3. Bool coerces to a native int ------------------------------------
+{
+    my int $x;
+    $x = (3 >= 2);
+    is $x, 1, 'True assigned to native int stores 1';
+    is $x.^name, 'Int', 'native int holds an Int, not a Bool';
+    $x = (1 >= 2);
+    is $x, 0, 'False assigned to native int stores 0';
+    my int $y = True;
+    is $y, 1, 'native int declared with a Bool default is 1';
+}


### PR DESCRIPTION
## Summary

Three independent gaps that together blocked **Text::Diff::Sift4** (T-035):

1. **`nqp::ordat($str, $pos)`** was unimplemented ("Unknown function: ordat").
   Added it beside the other nqp compat ops — the Unicode codepoint of the
   character at `$pos` (equivalent to `$str.substr($pos, 1).ord`), returning `-1`
   past the end, matching nqp.

2. **Typed scalar `:=`-bound to an array element** (`my Offset $o := @a[$i]`)
   was rejected with the bogus `Type check failed in assignment to $o; expected
   Offset but got Any`. The SetLocal-time constraint check inspected the
   `ContainerRef` cell the bind stores instead of the contained value; now derefs
   the cell before matching in bind mode.

3. **Bool assigned to a native `int`** (`my int $x = 3 >= 2`) was rejected. Bool
   `does Int` (`enum Bool does Int`), so a native-int slot accepts it: allowed in
   the static type match and unboxed to `1`/`0` in
   `wrap_native_int_by_constraint`, matching raku.

## Result

Text::Diff::Sift4's test suite now passes **32/32**, matching raku.

## Test

Pin: `t/nqp-ordat-and-native-int-coerce.t` (11 subtests, output matches raku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)