### PR TITLE
fix: qualified method call on a type object dispatches to the qualifier class

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -642,6 +642,57 @@ impl Interpreter {
         {
             return None;
         }
+        // A qualified call on a *type object* (`Foo.Bar::baz`) dispatches to the
+        // method defined in the qualifier class `Bar` — NOT the most-derived
+        // override on `Foo` — provided `Bar` is `Foo` or an ancestor/role of it.
+        // `value_type_name` on a type object reports "Package" (its meta-type),
+        // which fails the inheritance check below; resolve against the package's
+        // own name instead and run the qualifier-class method on the type object.
+        if let ValueView::Package(pkg) = target.view() {
+            let pkg_name = pkg.resolve().to_string();
+            // Mirror the instance path: the qualifier must be reachable through the
+            // type's MRO (or a composed role), using the same `class_mro` lookup
+            // rather than `type_inherits` (which does not resolve the hierarchy the
+            // same way for a bare type object).
+            let mro = self.class_mro(&pkg_name);
+            let in_mro = qualifier == pkg_name || mro.iter().any(|c| c.as_str() == qualifier);
+            let in_composed_roles = !in_mro
+                && mro.iter().any(|c| {
+                    self.registry()
+                        .class_composed_roles
+                        .get(c.as_str())
+                        .is_some_and(|roles| {
+                            roles.iter().any(|r| {
+                                r == qualifier
+                                    || r.starts_with(qualifier)
+                                        && r[qualifier.len()..].starts_with('[')
+                            })
+                        })
+                });
+            if !in_mro && !in_composed_roles {
+                return Some(Err(RuntimeError::new(format!(
+                    "X::Method::InvalidQualifier: Cannot dispatch to method {} on {} because it is not inherited or done by {}",
+                    actual_method, qualifier, pkg_name
+                ))));
+            }
+            if let Some((_owner, def)) =
+                self.resolve_method_with_owner(qualifier, actual_method, &args)
+            {
+                let res = self.run_resolved_method_compiled_or_treewalk(
+                    &pkg_name,
+                    qualifier,
+                    actual_method,
+                    def,
+                    AttrMap::new(),
+                    args,
+                    Some(target.clone()),
+                );
+                return Some(res.map(|(result, _updated)| result));
+            }
+            // No user method in the qualifier class (e.g. a builtin like
+            // `Int::abs`): fall back to ordinary unqualified dispatch.
+            return Some(self.call_method_with_values(target.clone(), actual_method, args));
+        }
         let type_name = super::utils::value_type_name(target);
         let type_matches = qualifier == type_name || Self::type_inherits(type_name, qualifier);
         if type_matches {

--- a/t/qualified-parent-method-on-type-object.t
+++ b/t/qualified-parent-method-on-type-object.t
@@ -1,0 +1,35 @@
+use v6;
+use Test;
+
+# A qualified method call on a *type object* (`Foo.Bar::baz`) dispatches to the
+# method defined in the qualifier class, not the most-derived override.
+# Regression: mutsu reported X::Method::InvalidQualifier because a type object
+# reports its meta-type ("Package") for the inheritance check.
+
+plan 8;
+
+class Bar { method baz { 42 } }
+class Foo is Bar { method baz { "nope" } }
+
+is Foo.Bar::baz, 42,     'type object: qualifier picks the parent method';
+is Foo.Foo::baz, "nope", 'type object: own qualifier picks the override';
+is Foo.new.Bar::baz, 42, 'instance: qualifier picks the parent method';
+
+class Empty is Bar { }
+is Empty.Bar::baz, 42, 'inherited (non-overridden) parent method via type object';
+
+is (-42).Int::abs, 42, 'builtin qualified method still works';
+
+role R { method greet { "hi" } }
+class C does R { }
+is C.R::greet, "hi", 'role-qualified method on a type object';
+
+# A qualifier that is neither the type nor an ancestor/role is an error.
+throws-like 'class A {}; class B {}; B.A::foo', X::Method::InvalidQualifier,
+    'unrelated qualifier throws X::Method::InvalidQualifier';
+
+# Deeper hierarchy.
+class Grand { method g { "grand" } }
+class Mid is Grand { method g { "mid" } }
+class Leaf is Mid { method g { "leaf" } }
+is Leaf.Grand::g, "grand", 'qualifier reaches a grandparent method';


### PR DESCRIPTION
## Summary

Found via the doc-diff harness on `Language/operators.rakudoc` (finding [17]).

`Foo.Bar::baz` (where `Foo is Bar` and both define `baz`) died with:

```
X::Method::InvalidQualifier: Cannot dispatch to a method on Bar because it is not inherited or done by Package
```

## Root cause

Two problems in `dispatch_qualified_non_instance_method`:

1. `value_type_name` on a **type object** reports its meta-type (`"Package"`),
   so the inheritance check compared `Bar` against `Package` and always failed.
2. The non-instance path called the method **unqualified**
   (`call_method_with_values`), which resolves the most-derived override — it
   would have returned `Foo`'s `baz`, not `Bar`'s.

## Fix

Add a `Package` (type-object) branch mirroring the instance path: verify the
qualifier is reachable through the type's `class_mro` (or a composed role),
resolve the method in the qualifier class via `resolve_method_with_owner`, and
run it with the type object as invocant. Falls back to unqualified dispatch when
the qualifier class defines no user method (builtins like `Int::abs`). The
`InvalidQualifier` message now matches Rakudo's wording.

## Verification

```
$ mutsu -e 'class Bar { method baz {42} }; class Foo is Bar { method baz {"nope"} }; say Foo.Bar::baz'
42
```

Matches reference raku, including roles (`C.R::greet`), grandparent methods,
and the unrelated-qualifier error. New test
`t/qualified-parent-method-on-type-object.t` (8 cases); existing
dispatch/mro/qualified tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)