### PR TITLE
fix: preserve is_positional for a parenthesized indexed assign/bind

### DIFF
--- a/src/parser/stmt/assign/try_assign.rs
+++ b/src/parser/stmt/assign/try_assign.rs
@@ -32,7 +32,13 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
 
     // Handle subscripted lvalues: @a[1] = ..., %h{key} = ..., %h<key> = ...
     if r.starts_with('[') || r.starts_with('{') || r.starts_with('<') {
-        let (r_after, index_expr) = if let Some(inner) = r.strip_prefix('<') {
+        // `[...]` is a positional subscript; `{...}`/`<...>` are associative.
+        // The resulting IndexAssign MUST carry the right flag so the VM routes a
+        // user Associative/Positional object to BIND-KEY/ASSIGN-KEY vs
+        // BIND-POS/ASSIGN-POS (a wrong `is_positional` sent a `%h<k> := v` to the
+        // non-existent BIND-POS, dropping to the generic path that replaced the
+        // whole tied container).
+        let (r_after, index_expr, is_positional) = if let Some(inner) = r.strip_prefix('<') {
             // `<...>` is word-quoting (a literal string key), NOT an expression.
             // Parsing the inside as an expression mis-reads `%h<b> := 5` — `b>`
             // is taken as a `b > ...` comparison, so the chained bind never
@@ -61,9 +67,10 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
                 )
             };
             let (r_after, _) = ws(&inner[end + 1..])?;
-            (r_after, index_expr)
+            (r_after, index_expr, false)
         } else {
             let closing = if r.as_bytes()[0] == b'[' { ']' } else { '}' };
+            let is_positional = closing == ']';
             let (r_idx, _) = parse_char(r, r.as_bytes()[0] as char)?;
             let (r_idx, _) = ws(r_idx)?;
             // Parse comma-separated index expressions inside brackets
@@ -89,7 +96,7 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
             };
             let (r_idx, _) = parse_char(r_idx, closing)?;
             let (r_after, _) = ws(r_idx)?;
-            (r_after, index_expr)
+            (r_after, index_expr, is_positional)
         };
         // Check for binding assignment (:= or ::=)
         if let Some(stripped) = r_after
@@ -125,7 +132,7 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
                     target: Box::new(target),
                     index: Box::new(index_expr),
                     value: Box::new(bind_value),
-                    is_positional: true,
+                    is_positional,
                 },
             ));
         }
@@ -154,7 +161,7 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
                     target: Box::new(target),
                     index: Box::new(index_expr),
                     value: Box::new(rhs),
-                    is_positional: true,
+                    is_positional,
                 },
             ));
         }

--- a/t/paren-index-bind-positional.t
+++ b/t/paren-index-bind-positional.t
@@ -1,0 +1,40 @@
+use Test;
+
+# A parenthesized (expression-context) indexed assignment/bind must carry the
+# SAME `is_positional` flag as its bare-statement form. The expression-context
+# parser (`try_parse_assign_expr`, used for `(...)` groups) used to hardcode
+# `is_positional: true` for every subscript shape, so a `(%h<k> := v)` /
+# `(%h<k> = v)` was compiled as a POSITIONAL element assign. For a user
+# Associative object that routed to the non-existent BIND-POS/ASSIGN-POS, which
+# fell through to the generic path and REPLACED the whole tied container.
+# Regression pin for the Hash::Agnostic dist (`%h<i> := 137` in `t/01-basic`).
+
+plan 12;
+
+# --- plain hash: associative subscript stays associative through parens -------
+my %h = (a => 1, b => 2, c => 3);
+(%h<d> := 4);
+is %h.elems, 4, 'paren <> bind adds one key (not a whole-hash replace)';
+is %h<d>, 4, 'paren <> bind stored the value';
+is %h.keys.sort.join(","), 'a,b,c,d', 'paren <> bind kept the other keys';
+
+(%h<e> = 5);
+is %h.elems, 5, 'paren <> assign adds one key';
+is %h<e>, 5, 'paren <> assign stored the value';
+
+%h{'f'} := 6;   # brace subscript, bare
+is %h.elems, 6, 'brace bind adds one key';
+is %h<f>, 6, 'brace bind stored the value';
+
+(%h{'g'} = 7);  # brace subscript, parenthesized
+is %h.elems, 7, 'paren brace assign adds one key';
+
+# --- plain array: positional subscript stays positional through parens --------
+my @a = 10, 20, 30;
+(@a[5] := 99);
+is @a[5], 99, 'paren [] bind stored the value at the index';
+is @a.elems, 6, 'paren [] bind extended the array';
+
+(@a[1] = 21);
+is @a[1], 21, 'paren [] assign updated the element';
+is @a.elems, 6, 'paren [] assign did not change elems';


### PR DESCRIPTION
The expression-context assignment parser (`try_parse_assign_expr`, used for `(...)` groups) hardcoded `is_positional: true` when lowering a subscripted lvalue to `IndexAssign`, **regardless of the subscript shape**. So a parenthesized `(%h<k> := v)` / `(%h<k> = v)` compiled as a **positional** element assignment, while the bare-statement form correctly carried `is_positional: false`.

## Impact

For a user `Associative` object (`class MyHash does Hash::Agnostic`) this routed the bind to the non-existent `BIND-POS`/`ASSIGN-POS`; with no such method the VM fell through to the generic plain-`Hash` path, which **replaced the whole tied container** with a fresh `Hash` holding just the one pair:

```raku
my %h is MyHash = (a=>1, b=>2, c=>3);
(%h<i> := 137);
say %h.elems;   # was 1, raku: 4
```

The `Hash::Agnostic` dist test binds via the paren form (`is (%h<i> := 137), 137, ...`), so this wiped the backing hash and cascaded into every later subtest.

## Fix

Derive `is_positional` from the bracket the parser already matched (`[` → positional, `<`/`{` → associative) and thread it into both the `:=` and `=` `IndexAssign` nodes.

## Testing

- New pin `t/paren-index-bind-positional.t` — 12 cases (hash `<>`/`{}` + array `[]`, bind & assign, bare & parenthesized), all raku-verified.
- Plain hash/array behavior unchanged; `make test` PASS (20628 tests).
- Cuts the `Hash::Agnostic` dist (T-051) failures from 11 to 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)