### PR TITLE
feat: implement nqp::gethostname for Sys::Hostname (T-030)

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -10,7 +10,7 @@ add a `[claim: <branch>]` marker on its heading and push before you start.
 Move a ticket to **Done** when its PR merges. Rebase on `main` before
 editing this file; keep edits small (one ticket) to avoid conflicts.
 
-_35 open tickets._
+_34 open tickets._
 
 ## Open
 
@@ -105,12 +105,6 @@ _35 open tickets._
 ### T-029 — test_die [POFile]  [impact: 1 dist]
 - dists: POFile
 - e.g. `POFile`: base=4 pass=1 fail=1 die=2 | t/02-deletion.rakutest: 
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
-
-### T-030 — test_die [Sys::Hostname]  [impact: 1 dist]
-- dists: Sys::Hostname
-- e.g. `Sys::Hostname`: base=1 pass=0 fail=0 die=1 | t/01-basic.t: 
 - repro: _(fill in a minimal repro + raku baseline before fixing)_
 - file: _(suspected parser/runtime file)_
 
@@ -278,7 +272,13 @@ _(move tickets here with `[claim: <branch>]` when you start)_
 
 ## Done
 
-- **T-035** (#PENDING) — Text::Diff::Sift4 died on `nqp::ordat` and hit two more
+- **T-030** (#PENDING) — Sys::Hostname's `hostname` sub is
+  `nqp::gethostname.subst(...)`, but mutsu had no `nqp::gethostname` op, so it
+  died with "Could not find symbol '&gethostname' in 'nqp'". Added the op (via the
+  existing `Interpreter::hostname()` helper) and routed the no-paren 0-arg
+  `nqp::gethostname` term through the builtin nqp dispatch. **Sys::Hostname passes
+  3/3**, matching raku. Pin: t/nqp-gethostname.t.
+- **T-035** (#5121) — Text::Diff::Sift4 died on `nqp::ordat` and hit two more
   gaps once it was added. Three general fixes: (1) implemented `nqp::ordat($s,
   $pos)` (codepoint at a position, -1 past end); (2) a typed scalar `:=`-bound to
   an array element (`my Offset $o := @a[$i]`) type-checked the `ContainerRef`

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -639,6 +639,9 @@ impl Interpreter {
                     .unwrap_or(-1);
                 Ok(Value::int(cp))
             }
+            // nqp::gethostname(): the system hostname as a native str. Used by
+            // Sys::Hostname's `hostname` sub (`nqp::gethostname.subst(...)`).
+            "nqp::gethostname" => Ok(Value::str(Self::hostname())),
             // nqp::bindattr($obj, Type, '$!attr', value): write an attribute
             // cell directly, bypassing accessors (roast's Test::Compile uses it
             // to install a precomp repository into a CUR::FileSystem instance).

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -281,6 +281,11 @@ impl Interpreter {
         } else if name.starts_with("Metamodel::") {
             // Meta-object protocol type objects
             Value::package(Symbol::intern(name))
+        } else if name == "nqp::gethostname" {
+            // A no-paren 0-arg `nqp::`-op term dispatches through the builtin nqp
+            // compat layer, not the qualified symbol lookup below (which would
+            // raise "Could not find symbol '&gethostname' in 'nqp'").
+            self.call_function(name, Vec::new())?
         } else if name.contains("::") {
             // Check if this is an access to a non-existent enum variant
             if let Some((pkg, sym)) = name.rsplit_once("::")

--- a/t/nqp-gethostname.t
+++ b/t/nqp-gethostname.t
@@ -1,0 +1,18 @@
+use v6;
+use Test;
+use nqp;
+
+# `nqp::gethostname` (a 0-arg nqp op used with no parens) was unimplemented, so
+# Sys::Hostname's `hostname` sub died with "Could not find symbol '&gethostname'
+# in 'nqp'". T-030 (Sys::Hostname).
+
+plan 4;
+
+my $h = nqp::gethostname;
+isa-ok $h, Str, 'nqp::gethostname returns a Str';
+ok $h.chars, 'nqp::gethostname is non-empty';
+
+# The exact expression Sys::Hostname uses: strip whitespace and NULs.
+my $clean = nqp::gethostname.subst(/ \s | \0 /, '', :g);
+isa-ok $clean, Str, 'method-chained on the nqp::gethostname result works';
+ok $clean.chars, 'cleaned hostname still has characters';


### PR DESCRIPTION
## Summary

Sys::Hostname's `hostname` sub is `nqp::gethostname.subst(...)`, but mutsu had no
`nqp::gethostname` op, so the module died with `Could not find symbol
'&gethostname' in 'nqp'` the first time it was called.

- Added the op (returning the system hostname via the existing
  `Interpreter::hostname()` helper).
- Routed the no-paren 0-arg `nqp::gethostname` term through the builtin nqp
  compat dispatch instead of the qualified symbol-lookup path that raised the
  error.

## Result

Sys::Hostname's test suite passes **3/3**, matching raku.

## Test

Pin: `t/nqp-gethostname.t` (4 subtests, output matches raku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)