### PR TITLE
fix: unbox Bool to native int for array elements and parameter binding

### DIFF
--- a/src/runtime/native_types.rs
+++ b/src/runtime/native_types.rs
@@ -30,6 +30,19 @@ pub(crate) fn is_native_array_element_type(name: &str) -> bool {
     is_native_int_type(name) || matches!(name, "num" | "num32" | "num64" | "str")
 }
 
+/// Bool `does Int`, so it unboxes to its integer value (True=1, False=0) when
+/// stored in or bound to a native integer slot -- matching raku (`my int $x =
+/// 3 >= 2` -> 1, `sub f(int $x); f(True)` -> 1). Any non-Bool value passes
+/// through unchanged, so this is a safe prelude for every native-int store/bind
+/// path (scalar assign, array element, parameter binding).
+pub(crate) fn unbox_bool_to_native_int(val: crate::value::Value) -> crate::value::Value {
+    if let crate::value::ValueView::Bool(b) = val.view() {
+        crate::value::Value::int(i64::from(b))
+    } else {
+        val
+    }
+}
+
 /// Map a native type to the generic family name Rakudo uses in messages such as
 /// "Cannot bind to a native <family> array" (e.g. `int8`/`int64` -> `int`,
 /// `uint16` -> `uint`, `num32` -> `num`).

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -54,6 +54,9 @@ pub(in crate::runtime) fn wrap_native_int_for_binding(
     if !native_types::is_native_int_type(base) {
         return Ok(val);
     }
+    // Bool `does Int`: unbox it to 1/0 before native-int wrapping, so
+    // `sub f(int $x); f(True)` binds 1 like raku.
+    let val = native_types::unbox_bool_to_native_int(val);
     // Type objects cannot be unboxed to native types
     if let ValueView::Package(pkg_name) = val.view() {
         return Err(crate::value::RuntimeError::new(format!(

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -592,11 +592,7 @@ impl Interpreter {
         }
         // Bool `does Int`: unbox it to its integer value (True=1, False=0) when
         // stored in a native int slot, matching raku (`my int $x = 3 >= 2` → 1).
-        let val = if let ValueView::Bool(b) = val.view() {
-            Value::int(i64::from(b))
-        } else {
-            val
-        };
+        let val = native_types::unbox_bool_to_native_int(val);
         // Full-width signed native types don't wrap — they should throw on overflow.
         if matches!(base, "int" | "int64") {
             if let ValueView::BigInt(n) = val.view() {

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1095,16 +1095,15 @@ impl Interpreter {
             // aliases the array element). The type constraint applies to the
             // *contained* value, so deref the cell before matching -- otherwise the
             // check inspects the container itself and reports the bogus "got Any".
-            let check_val = if is_bind {
-                val.deref_container()
-            } else {
-                val.clone()
-            };
-            if !check_val.is_nil() && !self.type_matches_value(&constraint, &check_val) {
+            // Only the (rare) bind path derefs; the common assignment path borrows
+            // `val` directly with no clone.
+            let bind_derefed = is_bind.then(|| val.deref_container());
+            let check_val = bind_derefed.as_ref().unwrap_or(&val);
+            if !check_val.is_nil() && !self.type_matches_value(&constraint, check_val) {
                 return Err(runtime::utils::type_check_assignment_typed_error(
                     name,
                     &constraint,
-                    &check_val,
+                    check_val,
                 ));
             }
             if !val.is_nil() {

--- a/t/bool-native-int-unbox.t
+++ b/t/bool-native-int-unbox.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+# Bool `does Int`, so it unboxes to its integer value (True=1, False=0) wherever
+# a native integer slot is stored to or bound. A prior fix only handled scalar
+# assignment; this generalizes the unbox to native-int *array* elements and to
+# *parameter binding* (code-review follow-up to the T-035 scalar fix).
+
+plan 9;
+
+# Scalar assignment (the original fix).
+{
+    my int $x = (3 >= 2);
+    is $x, 1, 'True to native int scalar -> 1';
+    is $x.^name, 'Int', 'native int scalar holds an Int';
+    $x = (1 >= 2);
+    is $x, 0, 'False to native int scalar -> 0';
+}
+
+# Sized native int scalar.
+{
+    my int8 $y = True;
+    is $y, 1, 'True to native int8 -> 1';
+}
+
+# Native int array elements.
+{
+    my int @a = (3 >= 2), (1 >= 2);
+    is @a, [1, 0], 'Bool elements in a native int array -> 1/0';
+    is @a[0].^name, 'Int', 'native int array element is an Int';
+}
+
+# Parameter binding.
+{
+    sub f(int $x) { $x }
+    is f(True), 1, 'True bound to a native int parameter -> 1';
+    is f(False), 0, 'False bound to a native int parameter -> 0';
+    is f(True).^name, 'Int', 'bound native int parameter is an Int';
+}


### PR DESCRIPTION
## Summary

Follow-up to a code-review finding on the T-035 fix (#5121). That change unboxed
a Bool assigned to a native `int` **scalar** (`my int $x = 3 >= 2` → 1), but the
type-match broadening (accept Bool for native-int types) applied to *all* callers
while the unbox itself was scalar-only. The result was an inconsistency:

| case | before this PR | raku |
|------|----------------|------|
| `my int $x = 3 >= 2` | `1` ✅ | `1` |
| `my int @a = True, False` | `[1 0]` ✅ (already coerced) | `[1 0]` |
| `sub f(int $x); f(True)` | **`True`** ❌ | `1` |

## Fix

- Add a shared `native_types::unbox_bool_to_native_int` helper (Bool → 1/0, every
  other value passes through unchanged).
- Apply it in `wrap_native_int_for_binding` (parameter binding) as well as the
  scalar `wrap_native_int_by_constraint`, so scalar / array / parameter all match
  raku.
- Drop an unnecessary `val.clone()` on the hot (non-bind) typed-assignment path in
  `exec_set_local_op_inner`: only the rare `:=` bind derefs the container cell;
  the common assignment now borrows `val` directly.

## Known minor gap (out of scope)

A native-int parameter with a **Bool default literal** (`sub g(int $x = True)`)
still binds the raw Bool — the default flows through the compiled binding path,
a larger surface. Supplied arguments and all assignment forms are correct.

## Test

Pin: `t/bool-native-int-unbox.t` (9 subtests, output matches raku).

🤖 Generated with [Claude Code](https://claude.com/claude-code)