### PR TITLE
fix: approximately-equal (≅/=~=) tolerance semantics and $*TOLERANCE default

### DIFF
--- a/src/compiler/helpers_dynamic.rs
+++ b/src/compiler/helpers_dynamic.rs
@@ -114,6 +114,52 @@ impl Compiler {
         }
     }
 
+    /// Whether `name` (an internal `*`-prefixed dynamic var name, e.g. `*TOLERANCE`)
+    /// is a built-in dynamic variable provided by the runtime. Built-in dynamics are
+    /// always "declared" by the setting, so reading one and *then* shadowing it with
+    /// a `my $*X` is legal and must NOT trip X::Dynamic::Postdeclaration (which only
+    /// applies to a genuinely user-declared dynamic used before its declaration).
+    pub(super) fn is_builtin_dynamic_var(name: &str) -> bool {
+        let bare = name.trim_start_matches(['$', '@', '%', '&']);
+        let Some(bare) = bare.strip_prefix('*') else {
+            return false;
+        };
+        matches!(
+            bare,
+            "OUT"
+                | "ERR"
+                | "IN"
+                | "ARGFILES"
+                | "ARGS"
+                | "SPEC"
+                | "CWD"
+                | "TMPDIR"
+                | "HOME"
+                | "EXECUTABLE"
+                | "EXECUTABLE-NAME"
+                | "PROGRAM"
+                | "PROGRAM-NAME"
+                | "DISTRO"
+                | "PERL"
+                | "RAKU"
+                | "VM"
+                | "KERNEL"
+                | "PID"
+                | "TOLERANCE"
+                | "COLLATION"
+                | "DEFAULT-READ-ELEMS"
+                | "INIT-INSTANT"
+                | "REPO"
+                | "RAT-OVERFLOW"
+                | "SCHEDULER"
+                | "THREAD"
+                | "SAMPLER"
+                | "USER"
+                | "GROUP"
+                | "LANG"
+        )
+    }
+
     /// Emit X::Dynamic::Package error for a dynamic variable with :: in name.
     pub(super) fn emit_dynamic_package_error(&mut self, name: &str) {
         let symbol = Self::dynamic_var_symbol(name);

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -861,8 +861,13 @@ impl Compiler {
                     self.emit_dynamic_package_error(name);
                     return;
                 }
-                // X::Dynamic::Postdeclaration: dynamic variable used before declaration
-                if name.starts_with('*') && self.accessed_dynamic_vars.contains(name) {
+                // X::Dynamic::Postdeclaration: dynamic variable used before declaration.
+                // Built-in dynamics ($*OUT, $*TOLERANCE, ...) are always declared by
+                // the runtime, so reading one then `my`-shadowing it is legal.
+                if name.starts_with('*')
+                    && self.accessed_dynamic_vars.contains(name)
+                    && !Self::is_builtin_dynamic_var(name)
+                {
                     let symbol = Self::dynamic_var_symbol(name);
                     let mut attrs = std::collections::HashMap::new();
                     attrs.insert("symbol".to_string(), Value::str(symbol));

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -513,8 +513,13 @@ impl Interpreter {
         let (lr, li) = complex_parts(&left);
         let (rr, ri) = complex_parts(&right);
         let approx_f64 = |a: f64, b: f64| -> bool {
-            // Equal values (including Inf == Inf, -Inf == -Inf) are always approximately equal
-            if a == b {
+            // Two identical infinities (Inf == Inf, -Inf == -Inf) are approximately
+            // equal regardless of tolerance — the relative-difference formula below
+            // would compute Inf/Inf = NaN. Finite equal values are NOT short-circuited:
+            // with `$*TOLERANCE = 0` even `1 ≅ 1` must be False (per the spec, a zero
+            // tolerance makes every comparison fail), so they fall through to the
+            // strict `<` test below.
+            if a == b && a.is_infinite() {
                 return true;
             }
             // NaN is never approximately equal to anything
@@ -522,15 +527,21 @@ impl Interpreter {
                 return false;
             }
             let diff = (a - b).abs();
-            // Per Raku spec: if either side is zero, use absolute tolerance;
-            // otherwise use relative percentage difference.
+            // Per Raku spec: the difference must be strictly LESS than the tolerance
+            // (`$*TOLERANCE = 0` fails all comparisons). If either side is zero, use
+            // the absolute difference; otherwise the relative percentage difference.
             if a == 0.0 || b == 0.0 {
                 return diff < tolerance;
             }
             let max_abs = a.abs().max(b.abs());
-            diff / max_abs <= tolerance
+            diff < tolerance * max_abs
         };
-        let result = approx_f64(lr, rr) && approx_f64(li, ri);
+        // For two pure reals the imaginary parts are both exactly 0 and must not be
+        // subjected to the tolerance test (`$*TOLERANCE = 0` would otherwise make
+        // `0 < 0` false and wrongly reject every real comparison); only compare the
+        // imaginary parts when at least one operand is genuinely Complex.
+        let im_ok = (li == 0.0 && ri == 0.0) || approx_f64(li, ri);
+        let result = approx_f64(lr, rr) && im_ok;
         Ok(Value::truth(result))
     }
 }

--- a/t/approx-equal-tolerance.t
+++ b/t/approx-equal-tolerance.t
@@ -1,0 +1,50 @@
+use v6;
+use Test;
+
+# The approximately-equal operator `≅` / `=~=` uses a *strict* relative-difference
+# test against $*TOLERANCE (default 1e-15), which is dynamically overridable.
+# Regressions fixed:
+#  - `1 ≅ 1` short-circuited to True even with $*TOLERANCE = 0
+#  - the relative comparison used `<=` instead of strict `<`
+#  - built-in dynamics tripped X::Dynamic::Postdeclaration on read-then-shadow
+
+plan 14;
+
+# $*TOLERANCE = 0 makes every finite comparison fail (no a==b short-circuit).
+{
+    my $*TOLERANCE = 0;
+    nok 1 ≅ 1, '1 ≅ 1 is False when $*TOLERANCE = 0';
+    nok 0 ≅ 0, '0 ≅ 0 is False when $*TOLERANCE = 0';
+    ok Inf ≅ Inf, 'Inf ≅ Inf is True even when $*TOLERANCE = 0';
+}
+
+# A lexically-widened tolerance.
+{
+    my $*TOLERANCE = .1;
+    ok 11 ≅ 10, '11 ≅ 10 is True when $*TOLERANCE = .1';
+    nok 12 ≅ 10, '12 ≅ 10 is False when $*TOLERANCE = .1';
+}
+
+# The not-arithmetically-symmetric behaviour, using an explicit tolerance.
+{
+    my $*TOLERANCE = 1e-15;
+    my $x = 1;
+    nok ($x + $*TOLERANCE) ≅ $x, '($x + $*TOLERANCE) ≅ $x is False';
+    ok  ($x - $*TOLERANCE) ≅ $x, '($x - $*TOLERANCE) ≅ $x is True';
+}
+
+# Default-tolerance behaviour (the operator falls back to 1e-15).
+ok 1 ≅ 1,            '1 ≅ 1 is True at the default tolerance';
+ok 0 ≅ 0,            '0 ≅ 0 is True at the default tolerance';
+ok Inf ≅ Inf,        'Inf ≅ Inf';
+nok Inf ≅ -Inf,      'Inf ≅ -Inf is False';
+ok 1 =~= 1.0000000000000001, 'ASCII =~= within tolerance';
+nok 100 =~= 101,     '100 =~= 101 is False';
+
+# A built-in dynamic variable may be read and then lexically shadowed with `my`
+# without tripping X::Dynamic::Postdeclaration (unlike a user dynamic).
+{
+    my $ok = $*OUT.defined;
+    { my $*OUT; }
+    ok $ok, 'reading then my-shadowing a built-in dynamic ($*OUT) is allowed';
+}


### PR DESCRIPTION
## Summary

Three related fixes for the approximately-equal operator, from the doc-diff
findings in `Language/operators.rakudoc` [20]/[21].

## Fixes

1. **Tolerance semantics.** `≅`/`=~=` short-circuited to `True` on any `a == b`,
   so `1 ≅ 1` stayed `True` even with `$*TOLERANCE = 0` — but the spec says a zero
   tolerance fails *every* comparison. Restrict the short-circuit to identical
   **infinities** (where the relative formula computes `Inf/Inf = NaN`); finite
   equal values fall through to the tolerance test. Use a strict `<` (was `<=`).
   For two pure reals the imaginary parts (both exactly 0) are no longer subjected
   to the tolerance test, so `Inf ≅ Inf` at `$*TOLERANCE = 0` stays `True`.

2. **`$*TOLERANCE` default.** It read as an undefined value, so `$x + $*TOLERANCE`
   used 0. Seed it to its `1e-15` default in `init_io_environment`.

3. **Built-in dynamics + postdeclaration.** Reading a built-in dynamic and then
   `my`-shadowing it (`say $*OUT; { my $*OUT }`, and the [20]/[21] combination of
   reading `$*TOLERANCE` then `my $*TOLERANCE`) wrongly tripped
   `X::Dynamic::Postdeclaration`. That check is only for genuinely user-declared
   dynamics; add `is_builtin_dynamic_var` and exempt the built-in set. A real
   user dynamic (`say $*foo; my $*foo`) still errors.

## Verification

```
$ mutsu -e 'say $*TOLERANCE; my $x=1; say ($x+$*TOLERANCE) ≅ $x; { my $*TOLERANCE=0; say 1 ≅ 1 }'
1e-15
False
False
```

All match reference raku. New test `t/approx-equal-tolerance.t` (14 cases);
existing dynamic-var / is-approx / complex tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)