### PR TITLE
fix: do not set dispatch_ambiguous in an invocant-less method resolution

### DIFF
--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -334,7 +334,18 @@ impl Interpreter {
             // (same type distance, same number of `where` constraints, and the
             // same most-derived owner class) and none is marked `is default`.
             // Raku raises X::Multi::Ambiguous here.
-            if !default_winner && mro_narrowed.len() > 1 && !all_named {
+            // Only a resolution that HAS the invocant can legitimately declare an
+            // ambiguity: without it, `method_args_match_for_invocant` skips every
+            // invocant type/definedness constraint, so a `:U:`/`:D:` multi pair
+            // (or any invocant-narrowed candidates) all "match" and tie spuriously.
+            // Such invocant-less resolutions come from introspection/speculative
+            // callers (`has_user_method`, `Bool`/`Str` existence probes) that never
+            // consume `dispatch_ambiguous`; leaving the flag set here instead leaks
+            // a false ambiguity into the NEXT real dispatch (a defined-instance
+            // `.gist`/`.Str` call poisoning a following `self.pairs`). The real
+            // dispatch always re-resolves WITH the invocant, so deferring the
+            // decision to it loses nothing.
+            if !default_winner && mro_narrowed.len() > 1 && !all_named && invocant.is_some() {
                 self.dispatch_ambiguous = true;
             }
         }

--- a/t/multi-udismiley-ambiguity-leak.t
+++ b/t/multi-udismiley-ambiguity-leak.t
@@ -1,0 +1,45 @@
+use Test;
+
+# A `:U:`/`:D:` multi-method pair must not leak a spurious "ambiguous dispatch"
+# state onto a LATER, unrelated method call.
+#
+# Root cause: an invocant-less method resolution (from an introspection /
+# existence probe such as the `.Str` identity check) skips every invocant
+# type/definedness constraint in `method_args_match_for_invocant`, so BOTH the
+# `:U:` and `:D:` candidates "match" and tie — setting the internal
+# `dispatch_ambiguous` flag even though the real, invocant-aware dispatch resolves
+# cleanly. The flag then poisoned the NEXT real dispatch: a defined-instance
+# `.gist`/`.Str` call (a U/D multi) left the flag set, so a following `self.pairs`
+# was wrongly reported as "Ambiguous call to 'pairs(...)'".
+
+plan 6;
+
+role R does Associative does Iterable {
+    method AT-KEY($)  { die 'stub AT-KEY' }
+    method keys()     { die 'stub keys' }
+    method pairs(::?ROLE:D:) { self.keys.map: { Pair.new($_, self.AT-KEY($_)) } }
+    proto method gist(|) {*}
+    multi method gist(::?ROLE:U:) { self.Mu::gist }
+    multi method gist(::?ROLE:D:) { '{' ~ self.pairs.sort(*.key).map(*.gist).join(", ") ~ '}' }
+    proto method Str(|) {*}
+    multi method Str(::?ROLE:U:) { self.Mu::Str }
+    multi method Str(::?ROLE:D:) { self.pairs.sort(*.key).join(" ") }
+}
+class C does R {
+    has %!h;
+    method AT-KEY($k) is raw { %!h.AT-KEY($k) }
+    method keys()            { %!h.keys }
+    submethod BUILD()        { %!h = (a => 1, b => 2) }
+}
+
+my $o = C.new;
+
+# Both coercions call self.pairs; calling one must not poison the next.
+is $o.gist, '{a => 1, b => 2}', '.gist (a :D: multi that calls self.pairs) works';
+is $o.Str,  "a\t1 b\t2",          '.Str after .gist does not report pairs as ambiguous';
+is $o.gist, '{a => 1, b => 2}', '.gist again still works';
+is $o.Str,  "a\t1 b\t2",          '.Str again still works';
+
+# The type-object variants still dispatch to the :U: multi.
+is C.gist, '(C)', 'type-object .gist hits the :U: variant';
+is C.Str,  '',    'type-object .Str hits the :U: variant';


### PR DESCRIPTION
A method multi-dispatch that runs **without** the invocant (introspection / existence probes: the `.Str` identity check, `has_user_method`, `Bool` probes, …) cannot evaluate any invocant type/definedness constraint — `method_args_match_for_invocant` skips the whole invocant check when `invocant` is `None`. So a `:U:`/`:D:` multi pair (or any invocant-narrowed candidates) all "match" and tie, and the code set the internal `dispatch_ambiguous` flag **even though the real, invocant-aware dispatch resolves cleanly**.

Those invocant-less callers never consume `dispatch_ambiguous`, so the flag was left set and **leaked into the next real dispatch**. Concretely: a defined-instance `.gist`/`.Str` call (a `:U:`/`:D:` multi) poisoned a following `self.pairs`, which was then wrongly reported as:

```
Ambiguous call to 'pairs(C: )'; these signatures all match:
  (C: Any *%_, *%_)
```

This broke `Hash::Agnostic`-style roles (whose `.Str`/`.gist` call `self.pairs`) once `.gist` had run — the classic order-dependent "works alone, fails after another coercion" symptom.

## Fix

Gate the flag on `invocant.is_some()`: only a resolution that actually has the invocant can legitimately declare an ambiguity. The real dispatch always re-resolves *with* the invocant, so deferring the decision to it loses nothing.

## Testing

- New pin `t/multi-udismiley-ambiguity-leak.t` (6 cases, raku-verified): `.gist` then `.Str` (both `:U:`/`:D:` multis calling `self.pairs`) no longer poison each other; type-object variants still hit `:U:`.
- `make test`: PASS (20703 tests).
- Whitelisted multi-dispatch roast (`S12-methods/multi.t`, `accessors.t`, `parallel-dispatch.t`, `S14-roles/parameterized-mixin.t`): no real (non-`# TODO`) regressions.

Fixes T-051 gap 3 (Hash::Agnostic `:U:`/`:D:` ambiguous-call); `.Str`/`.gist` on a tied hash now work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)