### PR TITLE
chore(dist-tickets): drop the per-PR "N open tickets" count line

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -10,8 +10,6 @@ add a `[claim: <branch>]` marker on its heading and push before you start.
 Move a ticket to **Done** when its PR merges. Rebase on `main` before
 editing this file; keep edits small (one ticket) to avoid conflicts.
 
-_34 open tickets._
-
 ## Open
 
 ### T-052 — runtime_error: 'X' cannot inherit from 'X' because it is unknown.  [impact: 1 dist]

--- a/scripts/dist-compat-tickets.py
+++ b/scripts/dist-compat-tickets.py
@@ -99,7 +99,8 @@ def render(tickets):
         "Move a ticket to **Done** when its PR merges. Rebase on `main` before\n"
         "editing this file; keep edits small (one ticket) to avoid conflicts.\n"
     )
-    out.append(f"\n_{len(tickets)} open tickets._\n")
+    # NOTE: deliberately no "_N open tickets._" line -- a per-PR count is a
+    # constant merge-conflict source when several ticket PRs land in parallel.
     out.append("\n## Open\n")
     for i, t in enumerate(tickets, 1):
         out.append(f"\n### T-{i:03d} — {t['sig']}  [impact: {t['n']} dist{'s' if t['n'] != 1 else ''}]\n")


### PR DESCRIPTION
## Summary

The `_N open tickets._` header in `TODO_dist/TICKETS.md` changed on every ticket
PR (each moves a ticket Open → Done), so it was a constant **merge-conflict
source** whenever several ticket PRs landed in parallel — the exact situation the
two-ended queue is designed to avoid. This session alone hit that conflict three
times.

- Remove the line from `TODO_dist/TICKETS.md`.
- Stop the generator (`scripts/dist-compat-tickets.py`) from re-emitting it, so a
  future regeneration doesn't bring it back.

The live count is trivially derivable when needed: `grep -c '^### T-' TODO_dist/TICKETS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)