### PR TITLE
feat: List/Slip/Array/Seq.from-iterator($iterator)

### DIFF
--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -131,6 +131,57 @@ impl Interpreter {
             let deconted = Value::array_with_kind(items.clone(), kind.decontainerize());
             return self.call_method_with_values(deconted, method, args);
         }
+        // `List.from-iterator($it)` / `Slip`/`Array`/`Seq`: build the named
+        // container by draining a Raku Iterator. Used by custom `does Iterable`
+        // types (Hash::Agnostic's `method List { List.from-iterator(self.iterator) }`).
+        //
+        // mutsu's `.iterator` yields a materialized `Iterator` instance whose
+        // `items`/`index` attributes hold the remaining elements; `pull-one`
+        // advances by writing the bumped index back to the ITERATOR'S VARIABLE, so
+        // driving `pull-one` on this temporary (unnamed) value would never advance
+        // and would loop forever. Read the elements straight out of the instance
+        // instead; fall back to the generic list coercion for any other shape.
+        if method == "from-iterator"
+            && args.len() == 1
+            && let ValueView::Package(name) = target.view()
+            && matches!(name.resolve().as_str(), "List" | "Slip" | "Array" | "Seq")
+        {
+            let container = name.resolve();
+            let iterator = args.into_iter().next().unwrap();
+            let items: Vec<Value> = if let ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } = iterator.view()
+                && class_name == "Iterator"
+            {
+                let map = attributes.as_map();
+                let all = match map.get("items").map(|v| v.view()) {
+                    Some(ValueView::Array(values, ..)) => values.to_vec(),
+                    _ => Vec::new(),
+                };
+                let index = match map.get("index").map(|v| v.view()) {
+                    Some(ValueView::Int(i)) if i >= 0 => (i as usize).min(all.len()),
+                    _ => 0,
+                };
+                all[index..].to_vec()
+            } else {
+                crate::runtime::utils::value_to_list(&iterator)
+            };
+            return Ok(match container.as_str() {
+                "Slip" => Value::slip_arc(std::sync::Arc::new(items)),
+                "Seq" => Value::seq_arc(std::sync::Arc::new(items)),
+                "Array" => Value::array_with_kind(
+                    crate::gc::Gc::new(crate::value::ArrayData::new(items)),
+                    crate::value::ArrayKind::Array,
+                ),
+                // "List" and any fallthrough
+                _ => Value::array_with_kind(
+                    crate::gc::Gc::new(crate::value::ArrayData::new(items)),
+                    crate::value::ArrayKind::List,
+                ),
+            });
+        }
         // `Rakudo::Internals::JSON.from-json` / `.to-json`: a core Rakudo class
         // routed to the native JSON implementation (used by OpenSSL, JSON::JWT).
         if let Some(result) = self.try_rakudo_internals_json_method(&target, method, &args) {

--- a/t/from-iterator.t
+++ b/t/from-iterator.t
@@ -1,0 +1,32 @@
+use Test;
+
+# `List`/`Slip`/`Array`/`Seq`.from-iterator($iterator) builds the named container
+# by consuming a Raku Iterator. Used by custom `does Iterable` types
+# (e.g. Hash::Agnostic's `method List { List.from-iterator(self.iterator) }`).
+
+plan 12;
+
+is List.from-iterator((1, 2, 3).iterator).raku, '(1, 2, 3)', 'List.from-iterator';
+is Array.from-iterator((1, 2, 3).iterator).raku, '[1, 2, 3]', 'Array.from-iterator';
+is Slip.from-iterator((1, 2, 3).iterator).^name, 'Slip', 'Slip.from-iterator is a Slip';
+is Seq.from-iterator((1, 2, 3).iterator).^name,  'Seq',  'Seq.from-iterator is a Seq';
+
+is List.from-iterator((1, 2, 3).iterator).elems, 3, 'List.from-iterator has all elems';
+is-deeply Array.from-iterator((<a b c>).iterator), ['a', 'b', 'c'], 'Array.from-iterator elements';
+
+# Empty iterator.
+is List.from-iterator(().iterator).elems, 0, 'List.from-iterator of empty';
+
+# Pairs survive (the Hash::Agnostic use case).
+my @pairs = (:a(1), :b(2));
+ok List.from-iterator(@pairs.iterator).are(Pair),  'List.from-iterator keeps Pairs';
+ok Slip.from-iterator(@pairs.iterator).are(Pair),  'Slip.from-iterator keeps Pairs';
+ok Array.from-iterator(@pairs.iterator).are(Pair), 'Array.from-iterator keeps Pairs';
+
+# A partially-consumed iterator continues from its current position.
+my $it = (10, 20, 30).iterator;
+$it.pull-one;
+is-deeply List.from-iterator($it), (20, 30), 'from-iterator resumes after pull-one';
+
+# Slip flattens when interpolated into a list.
+is (0, |Slip.from-iterator((1, 2).iterator), 3).elems, 4, 'Slip.from-iterator flattens in a list';


### PR DESCRIPTION
Implement the Raku core method `.from-iterator` on the `List`/`Slip`/`Array`/`Seq` type objects: it builds the named container by consuming a Raku `Iterator`.

Custom `does Iterable` types rely on it — e.g. `Hash::Agnostic` defines `method List { List.from-iterator(self.iterator) }` (likewise `.list`/`.Slip`/`.Array`), which previously died with:

```
No such method 'from-iterator' for invocant of type 'List'
```

## Note on the implementation

mutsu's `.iterator` yields a materialized `Iterator` instance whose `items`/`index` attributes hold the remaining elements, and its `pull-one` advances by writing the bumped index **back to the iterator variable**. Driving `pull-one` on the temporary (unnamed) iterator value passed to `from-iterator` would therefore never advance and would loop forever. So the elements are read straight out of the instance (`items[index..]`); any other iterator shape falls back to the generic `value_to_list` coercion.

## Testing

- New pin `t/from-iterator.t` — 12 cases (List/Slip/Array/Seq, empty, Pairs preserved, resume-after-`pull-one`, Slip flattening), all raku-verified.
- `make test`: PASS (20748 tests).
- S07-iterators roast: no real regressions.

Advances T-051 (Hash::Agnostic `.list`/`.List`/`.Slip`/`.Array` coercions now work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)