### PR TITLE
fix: .+/.* on a type object walks the full MRO

### DIFF
--- a/src/runtime/methods_signature_shaped.rs
+++ b/src/runtime/methods_signature_shaped.rs
@@ -283,6 +283,54 @@ impl Interpreter {
             }
         }
 
+        // A *type object* of a user-defined class (`C.+foo` / `C.*foo`): walk the
+        // MRO like the Instance path above, running each level's method with the
+        // type object as the (attribute-less) invocant. Without this, a type
+        // object falls through to the single-dispatch builtin path below and only
+        // the most-derived method runs (`C.+foo` yields `(C-only)` not the whole
+        // MRO chain). Built-in type objects have no registry entry and fall
+        // through to the count-based path.
+        if let ValueView::Package(name) = target.view()
+            && !method.starts_with('!')
+        {
+            let class_name = name.resolve();
+            if self.registry().classes.contains_key(class_name.as_str()) {
+                let candidates = self.resolve_methods_per_mro_level(&class_name, method, &args);
+                if !candidates.is_empty() {
+                    let mut out = Vec::with_capacity(candidates.len());
+                    for (resolved_owner, method_def) in candidates {
+                        let (result, _updated) = self.run_resolved_method_compiled_or_treewalk(
+                            &class_name,
+                            resolved_owner.as_str(),
+                            method,
+                            method_def,
+                            crate::value::AttrMap::default(),
+                            args.clone(),
+                            Some(target.clone()),
+                        )?;
+                        out.push(result);
+                    }
+                    return Ok(out);
+                }
+                // Method is defined somewhere in the MRO but no multi candidate
+                // matched: raise a dispatch error, mirroring the Instance path.
+                let method_exists = self.class_mro(&class_name).iter().any(|cn| {
+                    self.registry()
+                        .classes
+                        .get(cn.as_str())
+                        .and_then(|c| c.methods.get(method))
+                        .is_some_and(|ovs| {
+                            let is_ancestor = cn.as_str() != class_name.as_str();
+                            ovs.iter()
+                                .any(|d| !d.is_private && (!d.is_my || !is_ancestor))
+                        })
+                });
+                if method_exists {
+                    return Err(make_multi_no_match_error(method));
+                }
+            }
+        }
+
         // Built-in (non-Instance) target: one native handler, but `.+`/`.*`
         // (and the hyper `».+`/`».*`, which reach this via
         // `call_method_all_with_temp_target`) must yield one result per MRO level

--- a/t/dotplus-type-object.t
+++ b/t/dotplus-type-object.t
@@ -1,0 +1,39 @@
+use Test;
+
+# `.+` / `.*` on a *type object* of a user-defined class must walk the whole MRO
+# and call every level's method, exactly like on an instance. Previously a type
+# object fell through to the single-dispatch path and only the most-derived
+# method ran (`C.+f` yielded `(3)` instead of `(3 2 1)`).
+
+plan 10;
+
+class A { method f { 1 } }
+class B is A { method f { 2 } }
+class C is B { method f { 3 } }
+
+# .+ walks the full MRO on a type object.
+is-deeply C.+f, (3, 2, 1), '.+ on a type object walks the MRO';
+is-deeply B.+f, (2, 1), '.+ on a two-level type object';
+is-deeply A.+f, (1,), '.+ on a single-level type object';
+
+# .* behaves the same for a method that exists.
+is-deeply C.*f, (3, 2, 1), '.* on a type object walks the MRO';
+
+# .* on a missing method yields the empty list (no error).
+is-deeply A.*nonesuch, (), '.* on a missing method is ()';
+
+# .+ on a missing method dies.
+dies-ok { A.+nonesuch }, '.+ on a missing method dies';
+
+# The instance path is unchanged.
+is-deeply C.new.+f, (3, 2, 1), '.+ on an instance still walks the MRO';
+is-deeply B.new.*f, (2, 1), '.* on an instance still walks the MRO';
+
+# Only the levels that define the method contribute.
+class P { method g { 'p' } }
+class Q is P { }              # Q does not define g
+class R is Q { method g { 'r' } }
+is-deeply R.+g, ('r', 'p'), '.+ skips levels that do not define the method';
+
+# The result is a List.
+ok C.+f ~~ List, '.+ returns a List';


### PR DESCRIPTION
## Summary

`.+` / `.*` (call-all-candidates) walked the whole MRO only for an **instance**. On a **type object** of a user-defined class it fell through to the single-dispatch path and ran just the most-derived method:

```
class A { method f { 1 } }
class B is A { method f { 2 } }
class C is B { method f { 3 } }
C.+f    # before: (3)      raku: (3 2 1)
```

This was finding [14]'s root cause from the `Language/operators.rakudoc` doc-diff campaign. (The doc example `C.+foo` also exercises a separate multi-method implicit-return bug — a `multi method` whose body ends in a bare `say` returns `Nil` instead of the statement value — which is orthogonal and left for a follow-up.)

## Changes

- Add a `ValueView::Package` branch to `call_method_all_with_values`, mirroring the `Instance` path: resolve the per-MRO-level candidates via `resolve_methods_per_mro_level` and run each with the type object as the (attribute-less) invocant. Raise the same `X::Multi` no-match error when the method exists in the MRO but no candidate matches. Built-in type objects have no registry entry and still take the existing count-based builtin-MRO path.

## Tests

New pin `t/dotplus-type-object.t` (10 cases: `.+`/`.*` MRO walk, missing-method `()`/dies, MRO gaps, instance-path unchanged, List result). `roast/S03-metaops/hyper.t` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)