### PR TITLE
feat: Mu.rakuseen($id, &code) cyclic-structure guard for .raku/.gist

### DIFF
--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -12,6 +12,23 @@ use crate::value::ValueView;
 use crate::value::signature::extract_sig_info;
 
 impl Interpreter {
+    /// A `.raku`-legal identifier derived from a `rakuseen` id, used for the
+    /// `(my \NAME = ...)` cycle backreference. Non-identifier characters (`::`,
+    /// `|`, spaces, …) are folded to `_` so the emitted binding parses.
+    fn rakuseen_backref_name(id: &str) -> String {
+        let sanitized: String = id
+            .chars()
+            .map(|c| {
+                if c.is_alphanumeric() || c == '_' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect();
+        format!("{}_backref", sanitized)
+    }
+
     pub(crate) fn call_method_with_values(
         &mut self,
         target: Value,
@@ -130,6 +147,35 @@ impl Interpreter {
         {
             let deconted = Value::array_with_kind(items.clone(), kind.decontainerize());
             return self.call_method_with_values(deconted, method, args);
+        }
+        // `self.rakuseen($id, &code)`: Mu's cyclic-structure guard for
+        // `.raku`/`.gist`. A user `.raku` wraps its body in
+        // `self.rakuseen(self.^name, { ... })`; on the first sight of an id we run
+        // `&code` and return its rendering, but a REPEAT of the same id means a
+        // reference cycle — return a backreference name instead of re-running
+        // `&code` (which would recurse forever), and have the outer occurrence bind
+        // it as `(my \NAME = ...)`.
+        if method == "rakuseen" && args.len() >= 2 {
+            let id = args[0].to_string_value();
+            let code = args[1].clone();
+            if self.rakuseen_active.iter().any(|x| x == &id) {
+                self.rakuseen_cycle_hit.insert(id.clone());
+                return Ok(Value::str(Self::rakuseen_backref_name(&id)));
+            }
+            self.rakuseen_active.push(id.clone());
+            let result = self.call_sub_value(code, vec![], true);
+            if let Some(pos) = self.rakuseen_active.iter().rposition(|x| x == &id) {
+                self.rakuseen_active.remove(pos);
+            }
+            let rendered = result?;
+            if self.rakuseen_cycle_hit.remove(&id) {
+                return Ok(Value::str(format!(
+                    "(my \\{} = {})",
+                    Self::rakuseen_backref_name(&id),
+                    rendered.to_string_value()
+                )));
+            }
+            return Ok(rendered);
         }
         // `List.from-iterator($it)` / `Slip`/`Array`/`Seq`: build the named
         // container by draining a Raku Iterator. Used by custom `does Iterable`

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1202,6 +1202,16 @@ pub struct Interpreter {
     /// specific (an ambiguous dispatch). Consumed by the caller to raise an
     /// `X::Multi::Ambiguous` error instead of silently picking one.
     pub(crate) dispatch_ambiguous: bool,
+    /// Ids currently being rendered by `Mu.rakuseen($id, &code)` — the
+    /// cyclic-structure guard for `.raku`/`.gist`. A repeated id means a cycle:
+    /// `rakuseen` returns a backreference name instead of re-running `&code`
+    /// (which would recurse forever), and the first (outer) occurrence wraps its
+    /// result in `(my \NAME = ...)`.
+    pub(crate) rakuseen_active: Vec<String>,
+    /// Ids for which a cycle backreference was emitted during the current render;
+    /// the outer `rakuseen` for that id consumes the flag to add the `(my \NAME =
+    /// ...)` binding wrapper.
+    pub(crate) rakuseen_cycle_hit: std::collections::HashSet<String>,
     /// Pending Proxy subclass attribute reference for writeback on mutating methods.
     /// Set when reading a Proxy subclass attribute; consumed by subsequent .push/.pop etc.
     pub(crate) pending_proxy_subclass_attr: Option<(crate::value::ProxySubclassAttrs, String)>,

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2117,6 +2117,8 @@ impl Interpreter {
             encoding_registry: Self::builtin_encodings(),
             skip_pseudo_method_native: None,
             dispatch_ambiguous: false,
+            rakuseen_active: Vec::new(),
+            rakuseen_cycle_hit: std::collections::HashSet::new(),
             pending_proxy_subclass_attr: None,
             multi_dispatch_stack: Vec::new(),
             method_dispatch_stack: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -311,6 +311,8 @@ impl Interpreter {
             encoding_registry: self.encoding_registry.clone(),
             skip_pseudo_method_native: None,
             dispatch_ambiguous: false,
+            rakuseen_active: Vec::new(),
+            rakuseen_cycle_hit: std::collections::HashSet::new(),
             pending_proxy_subclass_attr: None,
             multi_dispatch_stack: Vec::new(),
             method_dispatch_stack: Vec::new(),

--- a/t/rakuseen.t
+++ b/t/rakuseen.t
@@ -1,0 +1,38 @@
+use Test;
+
+# `Mu.rakuseen($id, &code)` is the cyclic-structure guard used by `.raku`/`.gist`.
+# First sight of an id runs `&code` and returns its rendering; a repeat of the
+# same id (a reference cycle) returns a backreference name instead of recursing
+# forever, and the outer occurrence binds it as `(my \NAME = ...)`.
+
+plan 6;
+
+# Non-cyclic: just runs the block and returns its value.
+is 42.rakuseen("id1", { "BODY" }), 'BODY', 'rakuseen runs &code and returns it';
+is "x".rakuseen("id2", { 1 + 2 }), 3, 'rakuseen returns the block value (non-Str)';
+
+# Distinct ids do not interfere.
+is-deeply
+    (7.rakuseen("a", { "A" }), 7.rakuseen("b", { "B" })),
+    ("A", "B"),
+    'distinct ids each run their block';
+
+# The same id used sequentially (not nested) is not a cycle.
+is 1.rakuseen("seq", { "one" }) ~ 1.rakuseen("seq", { "two" }), 'onetwo',
+    'the same id used sequentially is not treated as a cycle';
+
+# A self-referential structure terminates (no infinite recursion) and produces a
+# `(my \NAME = ...)` backreference binding rather than hanging.
+class Node {
+    has $.next is rw;
+    method raku {
+        self.rakuseen("Node" ~ self.WHICH, {
+            "Node(" ~ ($.next ?? $.next.raku !! "Nil") ~ ")"
+        })
+    }
+}
+my $n = Node.new;
+$n.next = $n;                          # cycle
+my $r = $n.raku;
+ok $r.contains('my \\'), 'a cyclic .raku emits a (my \NAME = ...) backreference';
+ok $r.contains('Node('), 'the cyclic .raku still renders the outer node body';


### PR DESCRIPTION
Implement the Raku core method `rakuseen`, which guards `.raku`/`.gist` rendering against reference cycles. A user `.raku` wraps its body in `self.rakuseen(self.^name, { ... })` (as `Hash::Agnostic` does):

- First sight of an id → run `&code`, return its rendering.
- A **repeat** of the same id (a reference cycle) → return a backreference name instead of re-running `&code` (which would recurse forever); the outer occurrence binds it as `(my \NAME = ...)`.

Tracked with two interpreter fields: `rakuseen_active` (ids currently rendering) and `rakuseen_cycle_hit` (ids for which a backref was emitted, so the outer call adds the binding wrapper).

## Testing

- New pin `t/rakuseen.t` — 6 cases including a self-referential structure that must **terminate** (produce a `(my \NAME = ...)` backreference, not hang), all raku-verified.
- `make test`: PASS (20768 tests).
- `.raku`/`.gist`/`.perl` roast: no real regressions.

Advances T-051 — `Hash::Agnostic` `.raku` now renders `MyHash.new(:a(42),...)` instead of dying on the missing `rakuseen`. (The subtest still needs `Hash.new(<Associative>)` to populate from the object's pairs — a separate follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)