### PR TITLE
fix: statement-form say/put/print/note as a tail returns True, not Nil

### DIFF
--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -287,6 +287,15 @@ impl Compiler {
                         self.pop_dynamic_scope_lexical(saved);
                         return;
                     }
+                    Stmt::Say(_) | Stmt::Put(_) | Stmt::Print(_) | Stmt::Note(_) => {
+                        // A statement-form I/O builtin (`say`/`put`/`print`/`note`)
+                        // in block-final position prints and returns True, so leave
+                        // True as the block's value (e.g. `do { say 1 }` is a Bool).
+                        self.compile_stmt(stmt);
+                        self.compile_expr(&Expr::Literal(Value::TRUE));
+                        self.pop_dynamic_scope_lexical(saved);
+                        return;
+                    }
                     _ => {}
                 }
             }

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -546,6 +546,14 @@ impl Compiler {
                         }
                         continue;
                     }
+                    Stmt::Say(_) | Stmt::Put(_) | Stmt::Print(_) | Stmt::Note(_) => {
+                        // A statement-form I/O builtin tail (`say`/`put`/`print`/
+                        // `note`) prints and returns True, so leave True on the
+                        // stack as the routine's implicit return.
+                        sub_compiler.compile_stmt(stmt);
+                        sub_compiler.compile_expr(&Expr::Literal(Value::TRUE));
+                        continue;
+                    }
                     _ => {}
                 }
             }
@@ -792,6 +800,18 @@ impl Compiler {
                         continue;
                     }
                 }
+                if is_value
+                    && matches!(
+                        stmt,
+                        Stmt::Say(_) | Stmt::Put(_) | Stmt::Print(_) | Stmt::Note(_)
+                    )
+                {
+                    // A statement-form I/O builtin tail (`say`/`put`/`print`/`note`)
+                    // prints and returns True — leave True as the implicit return.
+                    sub_compiler.compile_stmt(stmt);
+                    sub_compiler.compile_expr(&Expr::Literal(Value::TRUE));
+                    continue;
+                }
                 sub_compiler.compile_stmt(stmt);
             }
             if last_is_enter {
@@ -918,6 +938,14 @@ impl Compiler {
                                 ));
                                 sub_compiler.code.emit(OpCode::GetGlobal(idx));
                             }
+                            continue;
+                        }
+                        Stmt::Say(_) | Stmt::Put(_) | Stmt::Print(_) | Stmt::Note(_) => {
+                            // A statement-form I/O builtin tail (`say`/`put`/
+                            // `print`/`note`) prints and returns True, so leave True
+                            // on the stack as the closure's implicit return.
+                            sub_compiler.compile_stmt(stmt);
+                            sub_compiler.compile_expr(&Expr::Literal(Value::TRUE));
                             continue;
                         }
                         _ => {}

--- a/t/tail-io-builtin-return.t
+++ b/t/tail-io-builtin-return.t
@@ -1,0 +1,49 @@
+use Test;
+
+# A statement-form I/O builtin (`say`/`put`/`print`/`note`) as the *tail*
+# statement of a sub/method/block body is the routine's implicit return value.
+# These builtins return True, so the routine returns True — previously the value
+# was dropped in sink context and the routine returned Nil/Any.
+
+plan 12;
+
+# Plain sub.
+sub s-say  { say "" }
+sub s-put  { put "" }
+sub s-note { note "" }
+ok s-say()  === True, 'sub with `say` tail returns True';
+ok s-put()  === True, 'sub with `put` tail returns True';
+ok s-note() === True, 'sub with `note` tail returns True';
+
+# Bare block.
+my $b = { say "" };
+ok $b() === True, 'block with `say` tail returns True';
+
+# Method on both an instance and a type object.
+class A { method f { say "" } }
+ok A.f     === True, 'method with `say` tail returns True (type object)';
+ok A.new.f === True, 'method with `say` tail returns True (instance)';
+
+# multi method.
+class B { multi method g { say "" } }
+ok B.new.g === True, 'multi method with `say` tail returns True';
+
+# The tail value is usable, e.g. as the condition of the caller.
+sub emit-ok { say "emitted" }
+ok (emit-ok() ?? "yes" !! "no") eq "yes", 'tail True flows into the caller';
+
+# `say` that is NOT the tail does not become the return value.
+sub mixed { say "side"; 42 }
+is mixed(), 42, 'a non-tail `say` leaves the real tail value intact';
+
+# A method whose tail is a normal call still returns that call's value.
+sub val { 7 }
+class C { method h { val() } }
+is C.h, 7, 'a non-IO tail call is unaffected';
+
+# print (no newline) also returns True as a tail.
+sub s-print { print "" }
+ok s-print() === True, 'sub with `print` tail returns True';
+
+# Nested: the block value propagates out through an outer expression.
+is (do { say "" }).WHAT.^name, 'Bool', '`do { say }` yields a Bool';


### PR DESCRIPTION
## Summary

A `say` / `put` / `print` / `note` used as the **tail** statement of a sub, method, or block body was compiled in sink context, so the routine returned `Nil`/`Any` instead of the `True` these builtins yield:

```raku
say "hi";                        # True  (on its own)
sub f { say "hi" }; f()          # was Nil, now True
class A { method g { say "hi" } }; A.g   # was Nil, now True
do { say "hi" }                  # was Any, now Bool (True)
```

Surfaced while investigating finding [14] from the `Language/operators.rakudoc` doc-diff campaign — `C.+foo` over `multi method foo { say … }` returned `(Nil Nil Nil)` where raku gives `(True True True)`.

## Root cause

The tail-value compile paths special-cased `Stmt::Expr` and `Stmt::Call` (leaving their value on the stack) but let the `Stmt::Say` / `Put` / `Print` / `Note` statement variants fall through to a plain sink compile, which pushes no value — so the implicit return was `Nil`.

## Changes

Add a `Say | Put | Print | Note` tail arm (compile the statement, then push `True`) to the three tail-value sites that lacked it:

- `compile_routine_body_stmts` — plain sub bodies
- the closure-body path — methods and blocks
- `compile_block_inline` — `do { ... }` and bare blocks in expression position

Control-flow tails (`for`/`while`/`if`) and non-tail `say` are unaffected.

## Tests

New pin `t/tail-io-builtin-return.t` (12 cases across sub/method/type-object/instance/multi/block/`do`). The full `t/` suite (2208 files, 20757 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)