### PR TITLE
fix: Hash.new/Map.new copy the pairs of a blessed Associative argument

### DIFF
--- a/src/runtime/methods_aggregate_ctor.rs
+++ b/src/runtime/methods_aggregate_ctor.rs
@@ -282,7 +282,23 @@ impl Interpreter {
         // keep it (only the QuantHash constructors eat named args).
         let mut flat = Vec::new();
         for arg in args {
-            flat.extend(Self::value_to_list(arg));
+            // A blessed Associative object (`class Foo does Associative`, e.g. a
+            // Hash::Agnostic tied hash) is NOT enumerable by `value_to_list`, which
+            // would keep it as one scalar item and turn it into a bogus
+            // `{"Foo()" => Any}` entry. Enumerate its `.pairs` so
+            // `Hash.new($assoc)` copies its key/value contents, like raku. Detect
+            // it by the Associative protocol (an `AT-KEY` method) rather than
+            // `does Associative`, since a transitively-composed role `does` does
+            // not always propagate to the type check. A plain Hash/Map already
+            // flattens correctly and is left untouched.
+            let assoc_instance = matches!(arg.view(), ValueView::Instance { class_name, .. }
+                if self.has_user_method(&class_name.resolve(), "AT-KEY"));
+            if assoc_instance {
+                let pairs = self.call_method_with_values(arg.clone(), "pairs", vec![])?;
+                flat.extend(Self::value_to_list(&pairs));
+            } else {
+                flat.extend(Self::value_to_list(arg));
+            }
         }
         let mut map = HashMap::new();
         // Track the original (typed) key objects for a non-`Str`-keyed object

--- a/t/hash-new-associative.t
+++ b/t/hash-new-associative.t
@@ -1,0 +1,30 @@
+use Test;
+
+# `Hash.new($assoc)` / `Map.new($assoc)` must copy the key/value contents of a
+# blessed Associative object (a class that implements the AT-KEY/keys protocol,
+# e.g. a Hash::Agnostic tied hash), not treat the object as a single scalar key.
+# Regression: `Hash.new($obj)` produced `{"Obj()" => Any}` because the flattening
+# used `value_to_list`, which cannot enumerate a blessed Associative instance.
+
+plan 6;
+
+class MyHash does Associative {
+    has %.store handles <AT-KEY EXISTS-KEY DELETE-KEY keys values pairs>;
+}
+
+my $obj = MyHash.new(store => {a => 1, b => 2, c => 3});
+
+my %h = Hash.new($obj);
+is %h.elems, 3, 'Hash.new(Associative) copies all pairs';
+is-deeply %h.sort.List, (:a(1), :b(2), :c(3)).sort.List, 'Hash.new(Associative) copies key/value contents';
+
+my %m = Map.new($obj);
+is %m.elems, 3, 'Map.new(Associative) copies all pairs';
+is %m<b>, 2, 'Map.new(Associative) preserves values';
+
+# A plain Hash argument is unaffected (already flattened to its pairs).
+my %plain = (x => 10, y => 20);
+is-deeply Hash.new(%plain).sort.List, (:x(10), :y(20)).sort.List, 'Hash.new(%plain-hash) still works';
+
+# Named args still become data (rakudo issue #3211 behavior kept).
+is Hash.new(:42a, :666b).elems, 2, 'Hash.new(:named) keeps named args as data';


### PR DESCRIPTION
`Hash.new($assoc)` / `Map.new($assoc)` where the argument is a **blessed Associative object** (a class implementing the AT-KEY/keys protocol, e.g. a Hash::Agnostic tied hash) rendered as `{"Obj()" => Any}`: the flattening used `value_to_list`, which cannot enumerate a blessed instance, so the whole object collapsed into a single stringified key.

## Fix

Detect an Associative instance by its `AT-KEY` method — **not** `does Associative`, since a transitively-composed role `does` does not always propagate to the type check (`$obj ~~ Associative` returns `False` for a `class Foo does Bar` where `Bar does Associative`; a separate, more general gap) — and expand it via `.pairs` before flattening. A plain `Hash`/`Map` argument already flattens to its pairs and is left untouched.

## Testing

- New pin `t/hash-new-associative.t` — 6 cases (Hash/Map from an Associative instance, plain-hash arg untouched, named args kept as data), all raku-verified.
- `make test`: PASS (20774 tests).

Advances T-051 — Hash::Agnostic `.Hash` (`Hash.new(self)`) now copies contents, and the dist test's first `test basic stuff after initialization` subtest passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)