### PR TITLE
fix: route :v/:k/:kv/:p slice adverbs through a tied Associative hash

### DIFF
--- a/src/runtime/builtins_multidim_subscript.rs
+++ b/src/runtime/builtins_multidim_subscript.rs
@@ -168,6 +168,32 @@ impl Interpreter {
                 t
             }
         };
+        // A blessed Associative object (`my %h is Foo`, Foo `does Associative`)
+        // has no native Hash storage, so the `:v`/`:k`/`:kv`/`:p` slice adverbs
+        // must dispatch through its subscript protocol. Snapshot its current
+        // contents (keys + AT-KEY) into a plain Hash and run the ordinary Hash
+        // path on that; a companion `:delete` is routed back through DELETE-KEY on
+        // the instance (the snapshot is a copy). `:exists` is handled on the
+        // instance elsewhere and never reaches here.
+        let assoc_instance: Option<Value> = if matches!(target.view(), ValueView::Instance { class_name, .. }
+            if self.has_user_method(&class_name.resolve(), "AT-KEY"))
+        {
+            Some(target.clone())
+        } else {
+            None
+        };
+        let target = if let Some(inst) = assoc_instance.as_ref() {
+            let keys_val = self.call_method_with_values(inst.clone(), "keys", vec![])?;
+            let mut map = std::collections::HashMap::new();
+            for key in crate::runtime::utils::value_to_list(&keys_val) {
+                let value =
+                    self.call_method_with_values(inst.clone(), "AT-KEY", vec![key.clone()])?;
+                map.insert(key.to_string_value(), value);
+            }
+            Value::hash(map)
+        } else {
+            target
+        };
         let index = args[1].clone();
         let mode = args[2].to_string_value();
         let var_name = args
@@ -459,7 +485,13 @@ impl Interpreter {
         }
 
         // Hash `:delete` companion (arrays handled in the positional path above).
-        if delete_after
+        // A blessed Associative instance deletes through its DELETE-KEY protocol
+        // (its storage is not the snapshot Hash built above).
+        if delete_after && let Some(inst) = assoc_instance.as_ref() {
+            for idx in &indices {
+                self.call_method_with_values(inst.clone(), "DELETE-KEY", vec![idx.clone()])?;
+            }
+        } else if delete_after
             && let Some(var_name) = var_name.as_ref()
             && let Some(entry) = self.env.get_mut(var_name)
         {

--- a/t/tied-hash-value-slice.t
+++ b/t/tied-hash-value-slice.t
@@ -1,0 +1,43 @@
+use Test;
+
+# The `:v`/`:k`/`:kv`/`:p` slice adverbs must dispatch through a tied
+# (user Associative) hash's subscript protocol, not silently return Nil.
+# `:exists`/`:delete` were already wired; the value/key/pair adverbs were not.
+
+plan 14;
+
+class MyHash does Associative {
+    has %.store;
+    method AT-KEY($k)     is raw { %!store.AT-KEY($k)     }
+    method EXISTS-KEY($k)        { %!store.EXISTS-KEY($k) }
+    method DELETE-KEY($k)        { %!store.DELETE-KEY($k) }
+    method keys()               { %!store.keys           }
+}
+my $mk = { MyHash.new(store => {a => 1, b => 2, c => 3}) };
+
+my %h := $mk();
+
+# Single key.
+is (%h<a>:v), 1,          ':v on a single key returns the value';
+is (%h<a>:k), 'a',        ':k on a single key returns the key';
+is-deeply (%h<a>:kv), ('a', 1),   ':kv on a single key';
+is-deeply (%h<a>:p), (a => 1),    ':p on a single key';
+
+# Missing key.
+is-deeply (%h<z>:v), (),  ':v on a missing key is empty';
+is-deeply (%h<z>:exists), False, ':exists on a missing key';
+
+# List slice.
+is-deeply (%h<a b>:v), (1, 2),          ':v slice returns the values';
+is-deeply (%h<a b>:k), ('a', 'b'),      ':k slice returns the keys';
+is-deeply (%h<a b>:kv), ('a', 1, 'b', 2), ':kv slice is flat';
+
+# Whatever / zen slices cover every key.
+is-deeply (%h{*}:v).sort, (1, 2, 3),    ':v whatever-slice covers all values';
+is-deeply (%h{}:v).sort,  (1, 2, 3),    ':v zen-slice covers all values';
+is-deeply (%h{*}:k).sort, <a b c>,      ':k whatever-slice covers all keys';
+
+# `:v:delete` reads the value AND removes the key via DELETE-KEY.
+my %d := $mk();
+is (%d<b>:v:delete), 2,   ':v:delete returns the deleted value';
+nok (%d<b>:exists),       ':v:delete actually removed the key';


### PR DESCRIPTION
The `:v`/`:k`/`:kv`/`:p` subscript slice adverbs on a blessed Associative object (`my %h is Foo`, `Foo does Associative`) all returned `(Nil)`: `builtin_subscript_adverb` only handled native `Hash`/`Array` targets, so a tied `Instance` fell through. (`:exists`/`:delete`/`:=` were already wired in earlier T-051 slices.)

## Fix

Snapshot the instance's current contents (its `keys` + `AT-KEY`) into a plain `Hash` and run the ordinary Hash slice path on that; a companion `:delete` is routed back through the instance's `DELETE-KEY` (the snapshot is a copy, so deleting from it would be lost).

## Testing

- New pin `t/tied-hash-value-slice.t` — 14 cases: single key, list slice, whatever/zen slice, missing key, and `:v:delete`, all raku-verified.
- `make test`: PASS (20823 tests).
- S09-subscript / S02-types/hash / S32-hash roast: no real (non-`# TODO`) regressions.

Advances T-051 — Hash::Agnostic value slices now work. (The dist's `can we do value slices` subtest also needs the upstream *bound-value-is-immutable* fix — `%h<i> = 666` after `%h<i> := 137` must throw X::Bind — which cascades into that subtest; tracked separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)