### PR TITLE
fix: multi-dispatch counts a positional Pair toward positional arity

### DIFF
--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -87,12 +87,18 @@ impl Interpreter {
         let result = (|| {
             let positional_params: Vec<&ParamDef> =
                 param_defs.iter().filter(|p| !p.named).collect();
+            // A `Pair` (interned String key) is a *named* argument (`a => 1`,
+            // `:a(1)`); a `ValuePair` (general key) is a *positional* argument
+            // produced by the parser's `PositionalPair` (a computed/quoted-key
+            // pair or a space-parenthesized `f (a => 1)`), so it counts toward the
+            // positional arity here. Without this, `multi q($x)` fails to match
+            // `q("a" => 1)` / `q (a => 1)` (0 positional args counted).
             let positional_arg_count = args
                 .iter()
                 .filter(|arg| {
                     !matches!(
                         unwrap_varref_value((*arg).clone()).view(),
-                        ValueView::Pair(..) | ValueView::ValuePair(..)
+                        ValueView::Pair(..)
                     )
                 })
                 .count();

--- a/t/multi-dispatch-positional-pair.t
+++ b/t/multi-dispatch-positional-pair.t
@@ -1,0 +1,45 @@
+use Test;
+
+# A Pair argument is *named* only when its key is a bareword literal
+# (`a => 1`, `:a(1)`). A pair with a computed key (`$k => 1`), a quoted key
+# (`"a" => 1`), or one wrapped by a space-parenthesized argument (`f (a => 1)`)
+# is a *positional* argument. Multi-dispatch candidate selection must count these
+# positional pairs toward the positional arity, so `multi route($x)` matches them.
+
+plan 9;
+
+multi route(:$a!) { 'named' }
+multi route($x)   { 'pos' }
+
+# Bareword-literal key => named.
+is route(a => 1), 'named', 'bareword-key pair is a named arg';
+
+# Quoted key => positional.
+is route("a" => 1), 'pos', 'quoted-key pair is a positional arg';
+
+# Computed key => positional.
+my $k = 'a';
+is route($k => 1), 'pos', 'computed-key pair is a positional arg';
+
+# Space-parenthesized argument => positional (the doc-example shape). Bind to a
+# variable first so the outer `is(...)` listop does not swallow the trailing args.
+my $sp = route (a => 1);
+is $sp, 'pos', 'space-parenthesized pair is a positional arg';
+
+# Mixed positional-pair + named still binds correctly.
+multi f($x, :$v) { "x={$x.raku} v=$v" }
+is f(("x" => 1), :v(9)), 'x=:x(1) v=9', 'positional pair + named arg';
+
+# A slurpy positional collects positional pairs.
+sub g(*@a) { @a.raku }
+is g("a" => 1, "b" => 2), '[:a(1), :b(2)]', 'slurpy positional collects pairs';
+
+# Named-only pair still routes to the named candidate.
+multi h(:$n!) { "named $n" }
+multi h($p)   { "pos {$p.raku}" }
+is h(n => 5),   'named 5',  'bareword named routes to the named candidate';
+is h("n" => 5), 'pos :n(5)', 'quoted-key pair routes to the positional candidate';
+
+# A single Pair-valued variable is a positional argument.
+my $p = ('z' => 1);
+is route($p), 'pos', 'a Pair-valued variable is positional';


### PR DESCRIPTION
## Summary

A pair argument whose key is not a bareword literal is a **positional** argument in Raku:

```raku
multi q(:$a!) { 'named' }
multi q($x)   { 'pos' }
q(a => 1)       # named    (bareword key)
q("a" => 1)     # pos      (quoted key)     -- was "No matching candidates"
q($k => 1)      # pos      (computed key)   -- was "No matching candidates"
q (a => 1)      # pos      (space-paren)    -- was "No matching candidates"
```

The parser already marks these `PositionalPair` (lowered to a `ValuePair` via `ContainerizePair`), and single-dispatch bound them correctly — but multi-dispatch **candidate selection** counted 0 positional args, so `multi q($x)` never matched.

Finding [12] of the `Language/operators.rakudoc` doc-diff campaign.

## Root cause & fix

`args_match_param_types` excluded both `Pair` (named) **and** `ValuePair` (positional) from its positional-argument count. A named argument always reaches dispatch as an interned-String-key `Pair` (a bareword `a => 1` / `:a(1)` compiles without `ContainerizePair`); a `ValuePair` is always a positional pair. So the fix is to exclude only `Pair` from the positional count.

## Tests

New pin `t/multi-dispatch-positional-pair.t` (9 cases: bareword-named vs quoted/computed/space-paren-positional, mixed named+positional, slurpy, Pair-valued variable). The full `t/` suite (2214 files, 20817 tests) and `roast/S06-signature/named-parameters.t` / `roast/S06-multi/type-based.t` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)