### PR TITLE
fix: X/Z meta-assignment operators write back and accumulate in place

### DIFF
--- a/src/compiler/expr_ops.rs
+++ b/src/compiler/expr_ops.rs
@@ -500,6 +500,26 @@ impl Compiler {
                 return;
             }
         }
+        // X/Z meta-assignment: `@a X[+=] @b`, `@a Z[+=] @b`. The inner op is an
+        // in-place assignment operator, so each cross/zip pair mutates the
+        // corresponding left cell and the mutated left container is written back
+        // to the lvalue. The expression value is the Seq of per-op assignment
+        // results (which, for `X`, differs from the mutated container). Only a
+        // simple lvalue (`@a`, `$a`) is written back; any other left operand
+        // falls through to the general path.
+        if (meta == "X" || meta == "Z")
+            && let Some(target) = Self::meta_assign_writeback_target(op, left)
+        {
+            self.compile_expr(left);
+            self.compile_expr(right);
+            let meta_idx = self.code.add_constant(Value::str(meta.to_string()));
+            let op_idx = self.code.add_constant(Value::str(op.to_string()));
+            self.code.emit(OpCode::MetaOpAssign { meta_idx, op_idx });
+            // The MetaOpAssign pushes [result_seq, mutated_left]; store the
+            // mutated container (top) back into the lvalue, leaving the Seq.
+            self.emit_set_named_var(&target);
+            return;
+        }
         // List-associative chaining for X/Z: `a X b X c` is a single n-ary
         // cross/zip producing flat n-tuples, not left-nested pairs. Collect a
         // chain of identical (meta, op) MetaOps into one flat operand list and
@@ -527,6 +547,32 @@ impl Compiler {
         let meta_idx = self.code.add_constant(Value::str(meta.to_string()));
         let op_idx = self.code.add_constant(Value::str(op.to_string()));
         self.code.emit(OpCode::MetaOp { meta_idx, op_idx });
+    }
+
+    /// If `op` is an in-place assignment operator (`+=`, `~=`, `**=`, `min=`, …)
+    /// and `left` is a simple lvalue variable, return the name to write the
+    /// mutated container back to (`@a`, `$a`). Comparison operators that merely
+    /// end in `=` (`==`, `<=`, `=~=`, …) are not assignments. Returns `None`
+    /// when the op is not an assignment or the left operand is not a plain
+    /// variable lvalue.
+    fn meta_assign_writeback_target(op: &str, left: &Expr) -> Option<String> {
+        let is_assign_op = op.ends_with('=')
+            && op.len() > 1
+            && !matches!(
+                op,
+                "==" | "!=" | "<=" | ">=" | "===" | "!==" | "<=>" | "=~=" | "=:="
+            );
+        if !is_assign_op {
+            return None;
+        }
+        match left {
+            Expr::ArrayVar(name) => Some(format!("@{name}")),
+            Expr::Var(name) => Some(name.clone()),
+            // TODO: compile to bytecode a slice writeback for an `Index` left
+            // (`@a[0,1] X[+=] 10`), mirroring the hyper-op `IndexAssignExprNamed`
+            // path; for now such targets fall through and are not mutated.
+            _ => None,
+        }
     }
 
     /// Flatten a left-nested chain of identical (meta, op) MetaOps into a flat

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1264,6 +1264,18 @@ pub(crate) enum OpCode {
         op_idx: u32,
     },
 
+    // -- X/Z meta-assignment (`@a X[+=] @b`, `@a Z[+=] @b`) --
+    // The inner op is an in-place assignment operator. Each cross (X) or zip
+    // (Z) pair mutates the corresponding left cell with the base op, in place.
+    // Pops right and left, then pushes TWO values: the result Seq (the per-op
+    // assignment values, bottom) and the mutated left container (top). The
+    // compiler always pairs this with a store of the mutated container back
+    // into the left lvalue, leaving the result Seq as the expression value.
+    MetaOpAssign {
+        meta_idx: u32,
+        op_idx: u32,
+    },
+
     // -- List-associative n-ary MetaOp (X/Z chained: `a X b X c`) --
     // Pops `count` operands off the stack and combines them in a single
     // n-ary cross (X) or zip (Z) so the result is flat n-tuples rather than

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3983,6 +3983,12 @@ impl Interpreter {
                 *ip += 1;
             }
 
+            OpCode::MetaOpAssign { meta_idx, op_idx } => {
+                self.sync_source_line(code, *ip);
+                self.exec_meta_op_assign(code, *meta_idx, *op_idx)?;
+                *ip += 1;
+            }
+
             OpCode::MetaOpNary {
                 meta_idx,
                 op_idx,

--- a/src/vm/vm_meta_ops.rs
+++ b/src/vm/vm_meta_ops.rs
@@ -185,6 +185,79 @@ impl Interpreter {
         Ok(())
     }
 
+    /// X/Z meta-assignment: `@a X[+=] @b`, `@a Z[+=] @b`. The inner op is an
+    /// in-place assignment operator (`+=`, `~=`, `**=`, `min=`, …). Each cross
+    /// (`X`, left index slowest) or zip (`Z`) pair mutates the corresponding
+    /// left cell with the base op, in place. Pushes two values: the Seq of the
+    /// per-op assignment results (bottom) and the mutated left container (top).
+    /// The compiler stores the mutated container back into the lvalue, leaving
+    /// the Seq as the expression value.
+    pub(super) fn exec_meta_op_assign(
+        &mut self,
+        code: &CompiledCode,
+        meta_idx: u32,
+        op_idx: u32,
+    ) -> Result<(), RuntimeError> {
+        let right = self.stack.pop().unwrap_or(Value::NIL);
+        let left = self.stack.pop().unwrap_or(Value::NIL);
+        let meta = Self::const_str(code, meta_idx).to_string();
+        let op = Self::const_str(code, op_idx).to_string();
+        // Strip the trailing `=` to get the base op (`+=` -> `+`, `min=` -> `min`).
+        let base_op = &op[..op.len() - 1];
+
+        // A scalar left operand (`$a X[+=] @b`) folds into a single cell; a
+        // list-like left (`@a`) keeps its per-element cells.
+        let left_is_listy = matches!(
+            left.view(),
+            ValueView::Array(..)
+                | ValueView::Seq(_)
+                | ValueView::Slip(_)
+                | ValueView::Range(..)
+                | ValueView::RangeExcl(..)
+                | ValueView::RangeExclStart(..)
+                | ValueView::RangeExclBoth(..)
+                | ValueView::GenericRange { .. }
+                | ValueView::LazyList(_)
+        );
+        let mut left_cells = runtime::value_to_list(&left);
+        let right_list = runtime::value_to_list(&right);
+
+        // Per-op assignment results, in evaluation order.
+        let mut results: Vec<Value> = Vec::new();
+        if meta == "X" {
+            // Cross: left index slowest, so all right values accumulate into the
+            // first left cell before advancing to the next.
+            for cell in left_cells.iter_mut() {
+                for r in &right_list {
+                    let v = self.eval_reduction_operator_values(base_op, cell, r)?;
+                    *cell = v.clone();
+                    results.push(v);
+                }
+            }
+        } else {
+            // Zip: element-wise up to the shorter length.
+            let n = left_cells.len().min(right_list.len());
+            for i in 0..n {
+                let v =
+                    self.eval_reduction_operator_values(base_op, &left_cells[i], &right_list[i])?;
+                left_cells[i] = v.clone();
+                results.push(v);
+            }
+        }
+
+        let result_seq = Value::seq_arc(std::sync::Arc::new(results));
+        let mutated_left = if left_is_listy {
+            Value::real_array(left_cells)
+        } else {
+            left_cells.into_iter().next().unwrap_or(Value::NIL)
+        };
+        // Bottom: the Seq (expression value). Top: the mutated container, which
+        // the compiler stores back into the lvalue.
+        self.stack.push(result_seq);
+        self.stack.push(mutated_left);
+        Ok(())
+    }
+
     /// List-associative n-ary cross (`X`) / zip (`Z`). `a X b X c` combines all
     /// operands at once so each result is a flat n-tuple (or an n-way reduction
     /// when an operator is attached), matching Raku's list associativity.

--- a/t/meta-cross-zip-assign.t
+++ b/t/meta-cross-zip-assign.t
@@ -1,0 +1,108 @@
+use Test;
+
+# X/Z meta-assignment operators (`@a X[+=] @b`, `@a Z[+=] @b`). The inner op is
+# an in-place assignment operator, so each cross (X, left index slowest) or zip
+# (Z) pair mutates the corresponding left cell. The left container is written
+# back, and the expression value is the Seq of the per-op assignment results.
+
+plan 16;
+
+# --- Cross meta-assignment: @a[i] accumulates every @b element. ---
+{
+    my @a = 1, 2, 3;
+    my @b = 10, 20, 30;
+    @a X[+=] @b;
+    is-deeply @a, [61, 62, 63], 'X[+=] mutates each left cell by the whole right';
+}
+{
+    my @a = 100, 200;
+    my @b = 1, 2, 3;
+    @a X[-=] @b;
+    is-deeply @a, [94, 194], 'X[-=] subtracts every right element';
+}
+{
+    # The expression value is the Seq of per-op results, distinct from @a for X.
+    my @a = 1, 2, 3;
+    my @b = 10, 20, 30;
+    my @r = @a X[+=] @b;
+    is-deeply @r, [11, 31, 61, 12, 32, 62, 13, 33, 63], 'X[+=] value is the per-op result Seq';
+    is-deeply @a, [61, 62, 63], 'X[+=] still mutates @a when the value is captured';
+}
+
+# --- Zip meta-assignment: element-wise. ---
+{
+    my @a = 1, 2, 3;
+    my @b = 10, 20, 30;
+    @a Z[+=] @b;
+    is-deeply @a, [11, 22, 33], 'Z[+=] adds element-wise';
+}
+{
+    my @a = 2, 3, 4;
+    my @b = 10, 10, 10;
+    @a Z[*=] @b;
+    is-deeply @a, [20, 30, 40], 'Z[*=] multiplies element-wise';
+}
+{
+    my @a = 2, 3;
+    my @b = 3, 2;
+    @a Z[**=] @b;
+    is-deeply @a, [8, 9], 'Z[**=] exponentiates element-wise';
+}
+{
+    my @a = 5, 5;
+    my @b = 3, 9;
+    @a Z[min=] @b;
+    is-deeply @a, [3, 5], 'Z[min=] takes the element-wise minimum';
+}
+{
+    my @a = 1, 2, 3;
+    my @b = 10, 20, 30;
+    my @r = @a Z[+=] @b;
+    is-deeply @r, [11, 22, 33], 'Z[+=] value equals the mutated cells';
+    is-deeply @a, [11, 22, 33], 'Z[+=] mutates @a';
+}
+
+# --- String and Unicode inner ops. ---
+{
+    my @a = "a", "b";
+    my @b = "x", "y";
+    @a Z[~=] @b;
+    is-deeply @a, ["ax", "by"], 'Z[~=] concatenates strings element-wise';
+}
+{
+    my @a = 2, 3;
+    my @b = 10;
+    @a Z[×=] @b;
+    is-deeply @a, [20, 3], 'Z[×=] accepts the Unicode multiply alias';
+}
+
+# --- Uneven zip leaves the extra left cells untouched. ---
+{
+    my @a = 1, 2, 3, 4;
+    my @b = 10, 20;
+    @a Z[+=] @b;
+    is-deeply @a, [11, 22, 3, 4], 'Z stops at the shorter operand';
+}
+
+# --- A Range as the right operand. ---
+{
+    my @a = 0, 0;
+    @a X[+=] (1..3);
+    is-deeply @a, [6, 6], 'X[+=] iterates a Range right operand';
+}
+
+# --- Scalar left operand folds into a single cell. ---
+{
+    my $a = 5;
+    my @b = 1, 2, 3;
+    $a X[+=] @b;
+    is $a, 11, 'scalar X[+=] folds every right element into the scalar';
+}
+
+# --- Plain (non-assign) X still produces the flat cross list. ---
+{
+    my @a = 1, 2, 3;
+    my @b = 10, 20;
+    is-deeply (@a X[+] @b).List, (11, 21, 12, 22, 13, 23).List,
+        'plain X[+] is unaffected';
+}


### PR DESCRIPTION
## Summary

`@a X[+=] @b` and `@a Z[+=] @b` are the cross / zip meta-operators applied to an **in-place assignment operator**. Each cross (`X`, left index slowest) or zip (`Z`) pair must mutate the corresponding left cell with the base op, in place, and write the left container back. mutsu computed a value with the base op stripped of its `=` and then discarded it, leaving `@a` untouched:

```raku
my @a = 1, 2, 3; my @b = 10, 20, 30;
@a X[+=] @b; say @a;   # was: [1 2 3]   now: [61 62 63]
@a Z[+=] @b; say @a;   # was: [1 2 3]   now: [11 22 33]
```

## Implementation

- Compile an X/Z meta-assignment (op ends in `=`, not a comparison, left is a simple `@a`/`$a` lvalue) to a new `MetaOpAssign` opcode.
- The VM folds each cross/zip pair through the base op into the left cells **in place**, then pushes two values: the `Seq` of the per-op assignment results (the expression value — which for `X` differs from the mutated container) and the mutated left container. The compiler stores the latter back into the lvalue, leaving the `Seq` as the expression value.
- Cross accumulates every right element into a left cell before advancing, so `@a X[+=] @b` for `@a = 1,2,3` / `@b = 10,20,30` yields the value `Seq` `(11 31 61 12 32 62 13 33 63)` and mutates `@a` to `[61 62 63]`, matching Rakudo.
- A scalar left (`$a X[+=] @b`) folds into a single cell. An `Index` left (`@a[0,1] X[+=] 10`) still falls through unmutated — slice writeback is a follow-up (marked `TODO`).

All outputs verified against `raku` (base ops `+= -= *= **= min= ~= ×=`, Range right operands, uneven zip, scalar left).

Finding [11] of the `Language/operators.rakudoc` doc-diff campaign.

Pin: `t/meta-cross-zip-assign.t` (16 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)