### PR TITLE
fix: an empty Blob/Buf instance gists as `Blob:0x<>`, not `Blob()`

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -297,9 +297,11 @@ pub(super) fn dispatch(
                         elems.join(",")
                     ))))
                 } else {
-                    // gist — show at most 100 elements, append "..." if truncated
+                    // gist — show at most 100 elements, append "..." if truncated.
+                    // An empty Blob/Buf instance gists as `Blob:0x<>` (empty hex
+                    // body), not `Blob()` — the latter is the type-object spelling.
                     if bytes.is_empty() {
-                        Some(Ok(Value::str(format!("{}()", class_name))))
+                        Some(Ok(Value::str(format!("{}:0x<>", class_name))))
                     } else {
                         let cn = class_name.resolve();
                         let hex_width = if cn.contains("64") {

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -749,7 +749,11 @@ impl Value {
                     attributes.as_map().get("bytes").map(Value::view)
                 {
                     if bytes.is_empty() {
-                        format!("{}()", class_name)
+                        // An empty Blob/Buf *instance* gists as `Blob:0x<>` (the
+                        // hex body is just empty), not `Blob()` — that spelling
+                        // is reserved for the type object, which gists as
+                        // `(Blob)` via a separate path.
+                        format!("{}:0x<>", class_name)
                     } else {
                         // Determine hex width from element size in the class name
                         let cn = class_name.resolve();

--- a/t/blob-empty-gist.t
+++ b/t/blob-empty-gist.t
@@ -1,0 +1,39 @@
+use Test;
+
+# An empty Blob/Buf *instance* gists as `Blob:0x<>` (an empty hex body), not
+# `Blob()`. The `Blob()` / `(Blob)` spellings belong to the *type object*.
+# https://docs.raku.org/language/traps (`[~] @chunks` of an empty Blob array).
+
+plan 13;
+
+# --- empty instances gist with an empty hex body -----------------------------
+is Blob.new.gist,  'Blob:0x<>',        'empty Blob.new gists as Blob:0x<>';
+is Buf.new.gist,   'Buf:0x<>',         'empty Buf.new gists as Buf:0x<>';
+is buf8.new.gist,  'Buf[uint8]:0x<>',  'empty buf8.new gists with its element type';
+is buf16.new.gist, 'Buf[uint16]:0x<>', 'empty buf16.new gists with its element type';
+
+# --- non-empty instances are unaffected --------------------------------------
+is Blob.new(1, 2, 3).gist, 'Blob:0x<01 02 03>', 'a populated Blob still shows its bytes';
+is buf16.new(0x1234).gist, 'Buf[uint16]:0x<1234>', 'a populated typed Buf keeps its width';
+
+# --- the type object keeps the `(Blob)` spelling -----------------------------
+is Blob.gist, '(Blob)', 'the Blob type object gists as (Blob)';
+is Buf.gist,  '(Buf)',  'the Buf type object gists as (Buf)';
+
+# --- `.raku` of an empty instance is unaffected ------------------------------
+is Blob.new.raku,  'Blob.new()',        'empty Blob.raku is Blob.new()';
+is buf8.new.raku,  'Buf[uint8].new()',  'empty buf8.raku keeps its type';
+
+# --- the doc trap: reducing a single empty Blob with [~] returns it ----------
+{
+    my @chunks = Blob.new;
+    is ([~] @chunks).gist, 'Blob:0x<>', '[~] over a lone empty Blob yields Blob:0x<>';
+}
+{
+    my @chunks;
+    is ([~] @chunks || Blob.new).gist, 'Blob:0x<>',
+        '[~] of an empty list falls back to Blob:0x<>';
+}
+
+# --- empty Blob is still boolean-false and zero-length -----------------------
+is Blob.new.elems, 0, 'empty Blob has no elements';


### PR DESCRIPTION
## Summary

`say Blob.new` printed `Blob()`, but Rakudo gists an empty Blob/Buf **instance** as `Blob:0x<>` — an empty hex body, the same shape as a populated one (`Blob:0x<01 02>`):

```raku
say Blob.new;    # was: Blob()   now: Blob:0x<>
say Buf.new;     # was: Buf()    now: Buf:0x<>
say buf8.new;    # was: Buf[uint8]()  now: Buf[uint8]:0x<>
```

The `Blob()` / `(Blob)` spellings belong to the **type object**, which reaches a different code path and already gists as `(Blob)`.

## Implementation

Both Blob/Buf gist paths short-circuited an empty `bytes` array to `format!("{}()", class_name)`:
- `Value`'s `Display` impl (`src/value/display.rs`) — used by `say` and string coercion;
- the `.gist` / `.Str` method dispatcher (`src/builtins/methods_0arg/dispatch_core_repr.rs`).

Emit `{}:0x<>` for the empty instance in both, leaving the type-object path (`(Blob)`) untouched.

This also fixes the documented `traps` example `say [~] @chunks` where `@chunks` is a lone/empty Blob — the `[~]` identity returns the Blob, whose gist was wrong.

Verified against `raku`: empty/populated `Blob`/`Buf`/`buf8`/`buf16`, the `Blob`/`Buf` type objects (`(Blob)`), and `.raku` (`Blob.new()`).

Findings [17]/[18] of the `Language/traps.rakudoc` doc-diff campaign.

Pin: `t/blob-empty-gist.t` (13 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)