### PR TITLE
fix: a grammar's .^mro threads Grammar -> Match -> Capture -> Cool

### DIFF
--- a/src/runtime/methods_classhow_mro.rs
+++ b/src/runtime/methods_classhow_mro.rs
@@ -26,7 +26,16 @@ impl Interpreter {
                 builtin.iter().map(|s| s.to_string()).collect()
             }
         };
-        if self.package_looks_like_grammar(&class_name) {
+        // A grammar's MRO threads through Grammar -> Match -> Capture -> Cool.
+        // Trigger this whenever the type is (or inherits from) Grammar: the
+        // `token`/`rule` heuristic (`package_looks_like_grammar`) misses an empty
+        // grammar (`grammar G {}`), a token-less subclass (`grammar S is B {}`),
+        // and the `Grammar` type object itself, all of which nonetheless carry
+        // `Grammar` in the MRO computed above.
+        if self.package_looks_like_grammar(&class_name)
+            || class_name == "Grammar"
+            || mro.iter().any(|name| name == "Grammar")
+        {
             for parent in ["Grammar", "Match", "Capture", "Cool", "Any", "Mu"] {
                 if !mro.iter().any(|name| name == parent) {
                     mro.push(parent.to_string());

--- a/t/grammar-mro-match.t
+++ b/t/grammar-mro-match.t
@@ -1,0 +1,28 @@
+use Test;
+
+# A grammar's method resolution order threads through Grammar -> Match ->
+# Capture -> Cool before Any/Mu (a Grammar is-a Match). mutsu detected
+# grammar-ness by the presence of `token`/`rule` definitions, so an empty
+# grammar, a token-less subclass, and the `Grammar` type object all dropped
+# Match/Capture/Cool from `.^mro`.
+# https://docs.raku.org/language/traps (`grammar G {}; G.^mro`).
+
+plan 4;
+
+sub mro-names($t) { $t.^mro.map(*.^name).join(' ') }
+
+grammar Empty {}
+is mro-names(Empty), 'Empty Grammar Match Capture Cool Any Mu',
+    'an empty grammar threads Match/Capture/Cool';
+
+grammar WithToken { token TOP { . } }
+is mro-names(WithToken), 'WithToken Grammar Match Capture Cool Any Mu',
+    'a grammar with a token keeps the full chain';
+
+grammar Base {}
+grammar Sub is Base {}
+is mro-names(Sub), 'Sub Base Grammar Match Capture Cool Any Mu',
+    'a token-less grammar subclass still threads Match/Capture/Cool';
+
+is mro-names(Grammar), 'Grammar Match Capture Cool Any Mu',
+    'the Grammar type object itself has the full chain';


### PR DESCRIPTION
## Summary

`grammar G {}; G.^mro` returned `((G) (Grammar) (Any) (Mu))`, dropping the `Match`/`Capture`/`Cool` links a grammar inherits (a Grammar *is-a* Match):

```raku
grammar G {}; say G.^mro;
# was: ((G) (Grammar) (Any) (Mu))
# now: ((G) (Grammar) (Match) (Capture) (Cool) (Any) (Mu))
say Grammar.^mro;               # was missing Match/Capture/Cool too
grammar Sub is Base {}; ...     # token-less subclass was also affected
```

## Root cause

`classhow_mro_names` detected grammar-ness via `package_looks_like_grammar`, which only checks for `G::`-prefixed `token`/`rule` definitions. So an **empty grammar**, a **token-less subclass**, and the **`Grammar` type object** itself — none of which register tokens — all fell through to the generic `+ Any + Mu` tail.

## Fix

Trigger the grammar-MRO branch whenever the computed MRO already contains `Grammar` (the type *is*, or inherits from, Grammar), in addition to the existing token heuristic and the `Grammar` type object by name. The branch already appends only the missing `[Grammar, Match, Capture, Cool, Any, Mu]` links, so it composes with any user parent chain.

Verified against `raku`: empty grammar, grammar with a token, token-less subclass, and the `Grammar` type object all now match; `Match`/`Capture`/`Cool`/normal-class MROs are unaffected.

Scope: this corrects `.^mro` only. The `Grammar ~~ Cool` / `~~ Match` type-check gap is a **separate, pre-existing** issue in the isa machinery (a token-carrying grammar smartmatches `Cool` as `False` today too) and is left for a follow-up.

Finding [20] of the `Language/traps.rakudoc` doc-diff campaign.

Pin: `t/grammar-mro-match.t` (4 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)