### PR TITLE
fix: nested named-alias names must not leak as body variables (T-048)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -196,11 +196,11 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 - repro: _(fill in a minimal repro + raku baseline before fixing)_
 - file: _(suspected parser/runtime file)_
 
-### T-048 — test_fail: millis unit to nanos  [impact: 1 dist]
+### T-048 — test_fail: millis unit to nanos  [impact: 1 dist]  [claim: fix-nested-alias-name-leak]
 - dists: TimeUnit
 - e.g. `TimeUnit`: base=1 pass=0 fail=1 die=0 | t/01-usage.rakutest: millis unit to nanos
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
+- repro: `sub g(:mil(:milli(:$millis))=0){ milli }` where `my constant milli=1000000` — mutsu binds the alias name `milli` as a body variable and shadows the outer constant. raku: only innermost `:$millis` is a body variable; alias names are caller-side only.
+- file: signature binding (runtime/param binding)
 
 ### T-049 — test_fail: not ok N -  [impact: 1 dist]
 - dists: Understitch

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -4310,9 +4310,18 @@ impl CompiledFunction {
                                 .to_string(),
                         );
                     }
-                    // On a match (by any key), every sub-signature name is
-                    // bound to the value — e.g. `:color(:$colour)` binds both.
-                    alias_binds.push((sub_pd.name.clone(), slot_of(&sub_pd.name)));
+                    // Only a LEAF of the rename chain names a body variable.
+                    // In `:mil(:milli(:$millis))` the caller may pass `mil`,
+                    // `milli` or `millis` (all become alias_keys above), but
+                    // inside the body only `$millis` exists — the intermediate
+                    // alias names (`mil`, `milli`, which themselves carry a
+                    // sub-signature) must NOT be bound as body variables, else
+                    // they shadow a same-named outer constant/lexical. A leaf
+                    // with no further sub-signature is the real variable
+                    // (`$millis`, or the `$a`/`$b` of a destructuring sig).
+                    if sub_pd.sub_signature.is_none() {
+                        alias_binds.push((sub_pd.name.clone(), slot_of(&sub_pd.name)));
+                    }
                     if let Some(ref nested) = sub_pd.sub_signature {
                         worklist.extend(nested.iter());
                     }

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -41,11 +41,32 @@ impl Interpreter {
     /// bound value (already stored in `env` under `pd.name`). The constraint is
     /// checked whether the value was supplied, defaulted, or fell back to the
     /// type object for an unsupplied optional named param.
+    /// The name the parameter's value is actually stored under. For a plain
+    /// named param that is `pd.name`; for a rename param (`:min(:$minutes)`,
+    /// `:version($)`) the value lives under the innermost leaf variable
+    /// (`minutes`, `__ANON_STATE__`) because the alias/param names are
+    /// caller-facing keys only and are never bound as body variables.
+    fn rename_leaf_value_name(pd: &ParamDef) -> Option<String> {
+        let mut sub = pd.sub_signature.as_ref()?;
+        loop {
+            let child = sub.first()?;
+            match &child.sub_signature {
+                Some(next) => sub = next,
+                None => return Some(child.name.clone()),
+            }
+        }
+    }
+
     fn check_named_param_where_constraint(&mut self, pd: &ParamDef) -> Result<(), RuntimeError> {
         let Some(where_expr) = &pd.where_constraint else {
             return Ok(());
         };
-        let bound_val = self.env.get(&pd.name).cloned().unwrap_or(Value::NIL);
+        // Read the value from the leaf variable for a rename param; fall back to
+        // the param's own name for a plain named param.
+        let bound_val = Self::rename_leaf_value_name(pd)
+            .and_then(|n| self.env.get(&n).cloned())
+            .or_else(|| self.env.get(&pd.name).cloned())
+            .unwrap_or(Value::NIL);
         let saved_topic = self.env.get("_").cloned();
         self.env.insert("_".to_string(), bound_val.clone());
         // env_dirty substrate (docs/captured-outer-cell-sharing.md §10):
@@ -993,10 +1014,18 @@ impl Interpreter {
                             ));
                             rw_bindings.push((pd.name.clone(), source_name));
                         }
-                        self.bind_param_value(&pd.name, bound_value);
-                        self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
+                        // A rename param `:min(:$minutes)` names a caller key
+                        // only; its OWN name (`min`) is NOT a body variable
+                        // (raku: `min` in the body resolves to the outer
+                        // routine/constant, not the argument). Only bind the
+                        // param's own name when it has no sub-signature; the
+                        // leaf variable is bound via the rename recursion below.
+                        // Mirrors `bind_sub_signature_from_value`'s line-778 rule.
                         if let Some(sub_params) = &pd.sub_signature {
                             bind_named_rename_sub_signature(self, sub_params, val)?;
+                        } else {
+                            self.bind_param_value(&pd.name, bound_value);
+                            self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
                         }
                         found = true;
                         break;
@@ -1013,11 +1042,9 @@ impl Interpreter {
                             if let ValueView::Pair(key, inner_val) = arg.view()
                                 && key == inner_key.as_str()
                             {
-                                self.bind_param_value(&pd.name, inner_val.clone());
-                                self.bind_param_type_constraint(
-                                    &pd.name,
-                                    pd.type_constraint.clone(),
-                                );
+                                // Rename param: bind only the leaf variable, not
+                                // the param's own name (see the primary-match
+                                // branch above).
                                 bind_named_rename_sub_signature(self, sub_params, inner_val)?;
                                 found = true;
                                 break 'alias;
@@ -1054,17 +1081,22 @@ impl Interpreter {
                         err.exception = Some(Box::new(exception));
                         return Err(err);
                     }
+                    // A rename param `:min(:$minutes)` binds only its leaf
+                    // variable (below); its own name is a caller key, not a body
+                    // variable — so skip binding `pd.name` when a sub-signature
+                    // is present.
+                    let is_rename = pd.sub_signature.is_some();
                     if let Some(captured_name) = pd
                         .type_constraint
                         .as_deref()
                         .and_then(|constraint| constraint.strip_prefix("::"))
                     {
                         self.bind_type_capture(captured_name, &value);
-                        if !pd.name.is_empty() {
+                        if !pd.name.is_empty() && !is_rename {
                             self.bind_param_value(&pd.name, value.clone());
                             self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
                         }
-                    } else if !pd.name.is_empty() {
+                    } else if !pd.name.is_empty() && !is_rename {
                         self.bind_param_value(&pd.name, value.clone());
                         self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
                     }
@@ -1096,8 +1128,12 @@ impl Interpreter {
                     // bindings live under twigil'd keys (`$!x`/`!x`), not the bare
                     // param name — so binding the default here does not disturb them.
                     let value = Self::missing_optional_param_value(pd);
-                    self.bind_param_value(&pd.name, value.clone());
-                    self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
+                    // A rename param binds only its leaf variable (below); skip
+                    // binding the param's own name when a sub-signature exists.
+                    if pd.sub_signature.is_none() {
+                        self.bind_param_value(&pd.name, value.clone());
+                        self.bind_param_type_constraint(&pd.name, pd.type_constraint.clone());
+                    }
                     // A `:color(:$colour)` alias chain declares its inner
                     // variable(s); bind them to the same unsupplied default so
                     // the body's `$colour` read finds an (undefined) value

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -549,13 +549,18 @@ pub(in crate::runtime) fn bind_named_rename_sub_signature(
                 None,
             ));
         }
-        interpreter.bind_param_value(bind_name, value.clone());
-        interpreter.set_var_type_constraint(bind_name, sub_pd.type_constraint.clone());
         // A named alias can chain: `:type(:class($kind))` nests a further
-        // rename under this alias. The innermost variable (`$kind`) is the one
-        // the body actually reads, so recurse to bind every level down to it.
+        // rename under this alias. Only the LEAF of the chain (`$kind`, the one
+        // with no further sub-signature) names a body variable; the intermediate
+        // alias names (`type`, `class`) are caller-facing keys only and must NOT
+        // be bound as body variables, else they shadow a same-named outer
+        // constant/lexical (e.g. `:mil(:milli(:$millis))` with an outer
+        // `constant milli`). Recurse to reach the leaf.
         if let Some(nested) = &sub_pd.sub_signature {
             bind_named_rename_sub_signature(interpreter, nested, value)?;
+        } else {
+            interpreter.bind_param_value(bind_name, value.clone());
+            interpreter.set_var_type_constraint(bind_name, sub_pd.type_constraint.clone());
         }
     }
     Ok(())

--- a/t/nested-alias-name-no-leak.t
+++ b/t/nested-alias-name-no-leak.t
@@ -1,0 +1,65 @@
+use v6;
+use Test;
+
+plan 12;
+
+# A nested named-alias chain `:mil(:milli(:$millis))` makes every level
+# (`mil`, `milli`, `millis`) a valid caller-side key, but inside the body only
+# the innermost `$millis` is a variable. The alias names (`mil`, `milli`) and
+# the param's own name must NOT be bound as body variables, else they shadow a
+# same-named outer constant/lexical (regression: TimeUnit's `nanos-from` read
+# the alias `milli`/`min` instead of the module constant).
+
+{
+    my constant milli = 1000000;
+    sub g(:mil(:milli(:$millis)) = 0) { "millis=$millis milli=" ~ milli }
+    is g(mil => 2),    'millis=2 milli=1000000', 'outer alias key + constant not shadowed';
+    is g(milli => 3),  'millis=3 milli=1000000', 'middle alias key + constant not shadowed';
+    is g(millis => 4), 'millis=4 milli=1000000', 'innermost key + constant not shadowed';
+}
+
+# The innermost leaf variable is the only body variable; every alias name binds
+# it at the call site.
+{
+    sub h(:d(:day(:$days)) = 0) { $days }
+    is h(d => 7),    7, 'leaf reachable via outer alias';
+    is h(day => 8),  8, 'leaf reachable via middle alias';
+    is h(days => 9), 9, 'leaf reachable via innermost name';
+}
+
+# The param's own name is a caller key only, not a body variable: `min` in the
+# body resolves to the outer constant, not the argument.
+{
+    my constant min = 60;
+    sub to-seconds(:min(:$minutes) = 0) { $minutes * min }
+    is to-seconds(min => 30), 1800, 'top param name resolves to outer constant, not arg';
+}
+
+# A multi sub with rename + where-constraint + default (the TimeUnit shape).
+{
+    my constant sec = 1000;
+    my constant mn  = sec * 60;
+    multi sub nanos-from(
+        :min(:minute(:$minutes)) where { $_ >= 0 } = 0,
+        |c
+    ) { $minutes * mn }
+    multi sub nanos-from(|c) { die "fallback" }
+    is nanos-from(min => 2),    120000, 'multi rename+where: outer alias';
+    is nanos-from(minute => 3), 180000, 'multi rename+where: middle alias';
+}
+
+# A rename to an anonymous `$` with a `where` constraint: the constraint must be
+# checked against the passed value even though no named body variable exists
+# (zef's `multi sub MAIN(Bool :version($) where .so)`).
+{
+    sub want-true(Bool :flag($) where .so) { "matched" }
+    is want-true(flag => True), 'matched', 'where on anonymous rename checks passed value';
+    dies-ok { want-true(flag => False) }, 'where on anonymous rename rejects failing value';
+}
+
+# `:color(:$colour)` single-level rename: caller uses either key, body uses the
+# leaf; the outer name `color` is not a body variable.
+{
+    sub paint(:color(:$colour) = 'none') { $colour }
+    is paint(color => 'red'), 'red', 'single-level rename by outer key';
+}


### PR DESCRIPTION
## Summary

A named-alias chain `:mil(:milli(:\$millis))` makes every level (`mil`, `milli`, `millis`) a valid caller-side key, but inside the routine body **only the innermost `\$millis` is a variable**. mutsu was binding the intermediate alias names *and* the param's own name as body variables, so they shadowed same-named outer constants/lexicals.

This is exactly what broke the **TimeUnit** dist (ticket T-048): its `nanos-from` signature is

```raku
Numeric() :min(:minute(:\$minutes)) where { \$_ >= 0 } = 0,
```

and the body computes `\$minutes * min` where `min` is a module `constant`. mutsu bound the alias name `min`/`milli` to the argument, so `min` in the body was the argument (e.g. `30`) instead of the constant (`60_000_000_000`).

### Minimal repro

```raku
my constant milli = 1000000;
sub g(:mil(:milli(:\$millis)) = 0){ "millis=\$millis milli=" ~ milli }
say g(mil => 2)
# raku:  millis=2 milli=1000000
# before: millis=2 milli=2      (alias name `milli` shadowed the constant)
```

## Fix

The **leaf rule**, applied uniformly across every param-binding path: only the innermost leaf of a rename chain names a body variable; the intermediate alias names and the param's own name are caller-facing keys only. This mirrors the pre-existing rule in `bind_sub_signature_from_value` (`!(named && sub_signature.is_some())`).

- `opcode.rs` (light-path `alias_binds`): bind only the leaf.
- `signature.rs` `bind_named_rename_sub_signature`: bind only the leaf.
- `binding_signature.rs` (slow path): skip binding `pd.name` for a rename param across the primary-match, alias-match, default, and unsupplied-optional branches.
- The `where` constraint now reads its value from the leaf variable (`rename_leaf_value_name`) rather than `pd.name`, so an anonymous rename with a constraint — `Bool :version(\$) where .so`, exactly what zef's `MAIN` uses — still checks the passed value. (This is verified by `tests/mzef_shim.rs`.)

## Tests

- Pin: `t/nested-alias-name-no-leak.t` (12 subtests, output matched against raku).
- `make test` green (20852 tests); all `roast/S06-signature/*.t` pass; `cargo clippy -D warnings` clean.

TimeUnit's tests 1–2 now pass; the remaining failures are an unrelated enum-value-vs-same-named-sub name-resolution bug (tracked separately).