### PR TITLE
fix: propagate tied hash AT-KEY throw and match user exception messages

### DIFF
--- a/src/runtime/test_functions/throws_like.rs
+++ b/src/runtime/test_functions/throws_like.rs
@@ -390,17 +390,38 @@ impl Interpreter {
             // Fall back to err.message for the "message" and "gist" matchers:
             // neither is stored as an attribute, and an X:: exception's `.gist`
             // renders its message (plus suggestions), so the message text is the
-            // substring the `gist => /.../` matchers look for.
-            let actual_str = actual_val
-                .as_ref()
-                .map(|v| v.to_string_value())
-                .unwrap_or_else(|| {
-                    if attr_name == "message" || attr_name == "gist" {
-                        err_message.clone()
-                    } else {
-                        String::new()
-                    }
-                });
+            // substring the `gist => /.../` matchers look for. When the thrown
+            // exception is a *user-defined* type that overrides `message`/`gist`
+            // (e.g. a module's own X:: class), invoke that method so the matcher
+            // sees the computed text. Built-in X:: carriers already render their
+            // text into `err_message`, so prefer that for them — a built-in's
+            // native `.message` can differ from the carrier string and would
+            // otherwise regress (e.g. X::Phaser::PrePost).
+            let actual_str = if let Some(v) = actual_val.as_ref() {
+                v.to_string_value()
+            } else if attr_name == "message" || attr_name == "gist" {
+                let user_method = exception_val
+                    .as_ref()
+                    .and_then(|ex| match ex.view() {
+                        ValueView::Instance { class_name, .. } => Some(class_name.resolve()),
+                        _ => None,
+                    })
+                    .is_some_and(|cn| self.has_user_method(&cn, attr_name));
+                if user_method {
+                    exception_val
+                        .as_ref()
+                        .and_then(|ex| {
+                            self.call_method_with_values(ex.clone(), attr_name, vec![])
+                                .ok()
+                        })
+                        .map(|v| v.to_string_value())
+                        .unwrap_or_else(|| err_message.clone())
+                } else {
+                    err_message.clone()
+                }
+            } else {
+                String::new()
+            };
             let matched = self.matcher_accepts(expected_val, &actual_str, actual_val.as_ref());
             let expected_display = match expected_val.view() {
                 ValueView::Regex(pattern) => format!("/{}/", *pattern),

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1041,15 +1041,23 @@ impl Interpreter {
                 self.stack.push(idx_clone);
                 return self.exec_index_op_with_positional(is_positional);
             }
-            (ValueView::Instance { .. }, ValueView::Str(key)) => {
+            (ValueView::Instance { class_name, .. }, ValueView::Str(key)) => {
+                let cn = class_name.resolve();
                 let default = self.typed_container_default(&target);
-                let result = self
-                    .try_compiled_method_or_interpret(
-                        target.clone(),
-                        "AT-KEY",
-                        vec![Value::str_arc(key.clone())],
-                    )
-                    .unwrap_or(Value::NIL);
+                let result = match self.try_compiled_method_or_interpret(
+                    target.clone(),
+                    "AT-KEY",
+                    vec![Value::str_arc(key.clone())],
+                ) {
+                    Ok(v) => v,
+                    // If the class actually has an AT-KEY method, an error it
+                    // raises (e.g. Hash::Agnostic's stub that throws
+                    // X::Hash::NoImplementation) must propagate. Only swallow the
+                    // error for a non-Associative instance that has no AT-KEY,
+                    // where `$obj<foo>` yields Nil.
+                    Err(e) if self.has_user_method(&cn, "AT-KEY") => return Err(e),
+                    Err(_) => Value::NIL,
+                };
                 if result.is_nil() { default } else { result }
             }
             (ValueView::Instance { .. }, ValueView::Int(i)) => {

--- a/t/tied-hash-atkey-throw.t
+++ b/t/tied-hash-atkey-throw.t
@@ -1,0 +1,53 @@
+use v6;
+use Test;
+
+plan 6;
+
+# A tied hash whose AT-KEY throws must propagate the exception on read,
+# not swallow it and return Nil (Hash::Agnostic's NYI stubs rely on this).
+{
+    role R does Associative {
+        method AT-KEY($k) { die "stub NYI" }
+        method keys() { () }
+    }
+    class C does R {}
+    my %h is C;
+    dies-ok { my $x = %h<foo> }, 'tied AT-KEY throw propagates on read';
+}
+
+# A non-Associative instance with no AT-KEY: `<foo>` subscript stays Nil
+# (the error is only propagated when the class actually has an AT-KEY).
+{
+    class Plain { has $.x }
+    my $obj = Plain.new(x => 5);
+    lives-ok { my $y = $obj<foo> }, 'plain instance subscript does not die';
+}
+
+# A real tied hash whose AT-KEY returns Nil for a missing key stays Nil,
+# does not error.
+{
+    role Backed does Associative {
+        has %!h;
+        method AT-KEY($k) { %!h.AT-KEY($k) }
+        method keys() { %!h.keys }
+        submethod BUILD() { %!h = (a => 1, b => 2) }
+    }
+    class MyHash does Backed {}
+    my %m is MyHash;
+    is %m<a>, 1, 'tied read of present key';
+    is %m<z>.defined, False, 'tied read of missing key is undefined, not an error';
+}
+
+# throws-like matches a user exception's computed `.message` method, not just
+# stored attributes.
+{
+    my class X::MyErr is Exception {
+        has $.what;
+        method message() { "No implementation of $.what method found." }
+    }
+    throws-like { X::MyErr.new(:what<AT-KEY>).throw },
+        X::MyErr,
+        :what<AT-KEY>,
+        :message(/ "AT-KEY" /);
+    pass 'throws-like message matcher reached';
+}


### PR DESCRIPTION
## Summary

Fixes Hash::Agnostic (dist ticket T-051) subtests 17-20 (`throws-like X::Hash::NoImplementation`), taking the dist from 12/22 to 16/22 passing subtests.

Two focused fixes:

1. **Tied `AT-KEY` throw was swallowed on read.** A `%h<key>` read on a tied Associative instance went through the `(Instance, Str)` index arm which used `.unwrap_or(Value::NIL)`, turning an exception raised by `AT-KEY` (e.g. Hash::Agnostic's NYI stub raising `X::Hash::NoImplementation`) into a silent `Nil`. Now the error propagates when the class actually has a user `AT-KEY` method; the `Nil` fallback is kept for a non-Associative instance with no `AT-KEY` (`$obj<foo>` stays `Nil`).

2. **`throws-like` `:message(/.../)` / `:gist(/.../)` ignored a user-defined `.message`.** The matcher compared against the raw error carrier string, which for a user-defined exception is the class gist (`X::Hash::NoImplementation()`) rather than its computed `.message` ("No implementation of AT-KEY method found for ..."). Now the exception's `message`/`gist` method is invoked when the class overrides it; built-in `X::` carriers keep using the carrier string so their native rendering (e.g. `X::Phaser::PrePost`) is unaffected.

## Testing

- Pin: `t/tied-hash-atkey-throw.t` (throw propagation, non-Associative Nil fallback, present/missing-key reads, user-exception message matcher).
- `make test` PASS (2218 files, 20851 tests).
- Verified no regression on `roast/S32-exceptions/misc.t`, `misc2.t`, `roast/S04-phasers/pre-post.t`, and the built-in `X::TypeCheck` / `X::Phaser::PrePost` message matchers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)