### PR TITLE
fix: .^parents excludes composed roles and stops at Cool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "mutsu"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/src/runtime/methods_classhow_parents.rs
+++ b/src/runtime/methods_classhow_parents.rs
@@ -32,23 +32,47 @@ impl Interpreter {
             });
         }
         let mro = self.classhow_mro_names(&args[0]);
-        let parents_iter = mro.into_iter().skip(1);
         let parents: Vec<Value> = if local {
-            self.registry()
+            // `:local` returns the immediately-declared parent class(es), with
+            // composed roles excluded. A user class carries its explicit parents
+            // in the registry (handles multiple inheritance); a class with no
+            // explicit superclass — or a built-in type — falls back to the first
+            // non-role entry of the MRO (`Any` for a bare class, `Cool` for Int).
+            let registered: Vec<String> = self
+                .registry()
                 .classes
                 .get(&class_name)
                 .map(|cd| cd.parents.clone())
                 .unwrap_or_default()
-                .iter()
-                .map(|p| Value::package(Symbol::intern(p)))
+                .into_iter()
+                .filter(|p| !self.parent_is_role(p))
+                .collect();
+            let locals = if registered.is_empty() {
+                mro.iter()
+                    .skip(1)
+                    .find(|p| *p != &class_name && !self.parent_is_role(p))
+                    .cloned()
+                    .into_iter()
+                    .collect()
+            } else {
+                registered
+            };
+            locals
+                .into_iter()
+                .map(|p| Value::package(Symbol::intern(&p)))
                 .collect()
         } else if all {
-            parents_iter
+            // `:all` walks the full MRO but still excludes composed roles.
+            mro.into_iter()
+                .skip(1)
+                .filter(|p| !self.parent_is_role(p))
                 .map(|p| Value::package(Symbol::intern(&p)))
                 .collect()
         } else {
-            parents_iter
-                .filter(|p| p != "Any" && p != "Mu")
+            // The default form stops at Cool/Any/Mu and drops composed roles.
+            mro.into_iter()
+                .skip(1)
+                .filter(|p| p != "Any" && p != "Mu" && p != "Cool" && !self.parent_is_role(p))
                 .map(|p| Value::package(Symbol::intern(&p)))
                 .collect()
         };
@@ -57,16 +81,28 @@ impl Interpreter {
         Ok(Value::array(parents))
     }
 
+    /// Whether `name` names a role (parameterization stripped), so it should be
+    /// excluded from a class's parent list — `.^parents` reports parent classes
+    /// only, never composed roles.
+    fn parent_is_role(&self, name: &str) -> bool {
+        let base = name.split_once('[').map(|(b, _)| b).unwrap_or(name);
+        self.is_role(base)
+    }
+
     /// The direct parents used to build a `:tree`, filling in the implicit
     /// `Any`/`Mu` chain. A base class (no explicit parent) inherits `Any`;
-    /// `Any` inherits `Mu`; `Mu` is the root (no parents).
+    /// `Any` inherits `Mu`; `Mu` is the root (no parents). Composed roles are
+    /// excluded — only parent classes participate in the tree.
     fn tree_effective_parents(&self, class_name: &str) -> Vec<String> {
-        let registered = self
+        let registered: Vec<String> = self
             .registry()
             .classes
             .get(class_name)
             .map(|cd| cd.parents.clone())
-            .unwrap_or_default();
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|p| !self.parent_is_role(p))
+            .collect();
         if !registered.is_empty() {
             return registered;
         }

--- a/t/classhow-parents-exclude-roles.t
+++ b/t/classhow-parents-exclude-roles.t
@@ -1,0 +1,62 @@
+use v6;
+use Test;
+
+# `.^parents` reports parent classes only — composed roles are excluded, and
+# the default form also stops at Cool/Any/Mu (matching Rakudo's ClassHOW).
+# The gist strings below were verified against reference `raku`.
+
+plan 19;
+
+# A class that only composes a role has no class parents.
+role R {}
+class C does R {}
+is C.^parents.gist,          '()',           'C.^parents excludes composed role R';
+is C.^parents(:all).gist,    '((Any) (Mu))', ':all excludes roles, keeps Any/Mu';
+is C.^parents(:local).gist,  '((Any))',      ':local of a role-only class is Any';
+is C.^parents(:tree).gist,   '[(Any) [(Mu)]]', 'role-only class tree is just Any/Mu';
+
+# A role that `is` a class flattens that class into the consumer as a parent.
+role A is Exception {}
+class X::Ouch does A {}
+is X::Ouch.^parents.gist, '((Exception))',
+    'role composed from a class contributes the class as a parent, not the role';
+
+# Multiple composed roles: still no class parents.
+role S {}
+class M does R does S {}
+is M.^parents.gist,         '()',      'multiple roles all excluded';
+is M.^parents(:local).gist, '((Any))', 'multi-role :local is Any';
+
+# Class inheritance is preserved (roles do not disturb it).
+class Base {}
+class Derived is Base {}
+is Derived.^parents.gist,        '((Base))', 'inherited class kept';
+is Derived.^parents(:local).gist,'((Base))', ':local kept';
+
+# Multiple inheritance.
+class P1 {}
+class P2 {}
+class MI is P1 is P2 {}
+is MI.^parents.gist,         '((P1) (P2))', 'multiple inheritance parents';
+is MI.^parents(:local).gist, '((P1) (P2))', 'multiple inheritance :local';
+
+# Role composition + class inheritance together.
+role Q {}
+class QC does Q is Base {}
+is QC.^parents.gist, '((Base))', 'role dropped, class kept';
+
+# The default form stops at Cool/Any/Mu for built-in types.
+is Int.^parents.gist,   '()',       'Int.^parents is empty (Cool excluded)';
+is Str.^parents.gist,   '()',       'Str.^parents is empty (Cool excluded)';
+is Array.^parents.gist, '((List))', 'Array.^parents keeps List, drops Cool';
+
+# :local keeps the immediate built-in parent (Cool for Int, List for Array).
+is Int.^parents(:local).gist,   '((Cool))', 'Int :local is Cool';
+is Array.^parents(:local).gist, '((List))', 'Array :local is List';
+
+# :all keeps Cool/Any/Mu but still drops roles.
+is Int.^parents(:all).gist, '((Cool) (Any) (Mu))', 'Int :all chain';
+
+# A user class subclassing a built-in.
+class MyInt is Int {}
+is MyInt.^parents.gist, '((Int))', 'MyInt default is Int';


### PR DESCRIPTION
## Summary

Rakudo's `ClassHOW.parents` reports parent **classes** only — a composed role never appears — and the default form (no adverb) stops at `Cool`, `Any` and `Mu`. mutsu diverged on three counts:

- **every form leaked composed roles**: `role R {}; class C does R {}; C.^parents` gave `((R))` instead of `()`;
- **the default form dropped only Any/Mu**, so built-ins leaked `Cool`: `Int.^parents` was `((Cool))`, raku `()`;
- **`:local` on a built-in returned `()`** instead of the immediate parent: `Int.^parents(:local)` should be `((Cool))`.

## Fix

In `dispatch_classhow_parents`:
- **default** form filters `Cool`/`Any`/`Mu` and composed roles;
- **`:all`** keeps `Cool`/`Any`/`Mu` but still drops roles;
- **`:local`** uses the registered parents (multiple inheritance) filtered of roles, falling back to the first non-role MRO entry for a bare class (`Any`) or a built-in (`Cool`);
- **`:tree`** (via `tree_effective_parents`) drops roles too.

A role that `is` a class still contributes that class as a parent (`role A is Exception {}; class X::Ouch does A {}` → `((Exception))`), since the class is flattened into the consumer.

The internal MRO still lists composed roles (used for method dispatch); only the `.^parents` presentation layer is corrected. `.^mro` still including composed roles is a separate, deeper issue left untouched here.

## Verification

- New pin `t/classhow-parents-exclude-roles.t` (19 assertions, gists verified against reference `raku`).
- `objects.rakudoc` doc-diff sweep: this finding is resolved (mismatch 5 → 4).
- No regressions: `roast/S12-introspection/{parents,roles,walk,meta-class,methods}.t`, `roast/S12-class/inheritance.t`, and the related local `t/` MRO/parents tests all pass; full `make test` green.

From the doc-diff QA campaign (PLAN.md §8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)