### PR TITLE
fix: .pairup is Pair-aware and handles type objects

### DIFF
--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -634,31 +634,36 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             }
         }
         "pairup" => match target.view() {
-            ValueView::Package(name) if name == "Any" => Some(Ok(Value::seq(Vec::new()))),
+            // A bare type object listifies to nothing, so `Range.pairup` is `()`.
+            ValueView::Package(_) => Some(Ok(Value::seq(Vec::new()))),
             _ => {
                 let items = crate::runtime::utils::value_to_list(target);
-                if !items.len().is_multiple_of(2) {
-                    let mut attrs = std::collections::HashMap::new();
-                    attrs.insert("got".to_string(), Value::int(items.len() as i64));
-                    attrs.insert(
-                        "message".to_string(),
-                        Value::str(format!(
-                            "Cannot pair up odd number of elements ({})",
-                            items.len()
-                        )),
-                    );
-                    let ex = Value::make_instance(Symbol::intern("X::Pairup::OddNumber"), attrs);
-                    let mut err = RuntimeError::new(format!(
-                        "X::Pairup::OddNumber: Cannot pair up odd number of elements ({})",
-                        items.len()
-                    ));
-                    err.exception = Some(Box::new(ex));
-                    return Some(Err(err));
+                let mut pairs: Vec<Value> = Vec::new();
+                let mut i = 0;
+                while i < items.len() {
+                    // A Pair in the source list is emitted unchanged (consuming
+                    // one element); any other value takes the following element
+                    // as its value (`key => value`, consuming two).
+                    if matches!(
+                        items[i].view(),
+                        ValueView::Pair(..) | ValueView::ValuePair(..)
+                    ) {
+                        pairs.push(items[i].clone());
+                        i += 1;
+                    } else if i + 1 < items.len() {
+                        pairs.push(Value::value_pair(items[i].clone(), items[i + 1].clone()));
+                        i += 2;
+                    } else {
+                        let msg = "Odd number of elements found for .pairup()";
+                        let mut attrs = std::collections::HashMap::new();
+                        attrs.insert("message".to_string(), Value::str(msg.to_string()));
+                        let ex =
+                            Value::make_instance(Symbol::intern("X::Pairup::OddNumber"), attrs);
+                        let mut err = RuntimeError::new(format!("X::Pairup::OddNumber: {msg}"));
+                        err.exception = Some(Box::new(ex));
+                        return Some(Err(err));
+                    }
                 }
-                let pairs: Vec<Value> = items
-                    .chunks_exact(2)
-                    .map(|chunk| Value::value_pair(chunk[0].clone(), chunk[1].clone()))
-                    .collect();
                 Some(Ok(Value::seq(pairs)))
             }
         },

--- a/t/pairup-pair-aware.t
+++ b/t/pairup-pair-aware.t
@@ -1,0 +1,34 @@
+use v6;
+use Test;
+
+# `.pairup` walks its source list: a Pair element passes through unchanged
+# (consuming one element), any other value takes the following element as its
+# value (`key => value`, consuming two). A bare type object listifies to
+# nothing, and a trailing lone non-Pair element is an error.
+
+plan 12;
+
+# A Pair in the list is emitted as-is; the rest pairs up two at a time.
+is (a => 1, 'b', 'c').pairup.raku, '(:a(1), :b("c")).Seq', 'leading Pair then key/value';
+is (a => 1, b => 2).pairup.raku,   '(:a(1), :b(2)).Seq',   'all Pairs pass through';
+is ('k', 'v', c => 3).pairup.raku, '(:k("v"), :c(3)).Seq', 'key/value then trailing Pair';
+
+# Plain values pair up two at a time.
+is (1, 2, 3, 4).pairup.raku, '(1 => 2, 3 => 4).Seq', 'plain values chunk into pairs';
+is ('x', 'y').pairup.raku,   '(:x("y"),).Seq',       'single key/value pair';
+is ().pairup.raku,           '().Seq',               'empty list is empty';
+
+# A bare type object listifies to nothing.
+is Range.pairup.raku, '().Seq', 'Range type object is empty';
+is Int.pairup.raku,   '().Seq', 'Int type object is empty';
+is Any.pairup.raku,   '().Seq', 'Any type object is empty';
+
+# A trailing lone non-Pair element is an odd-count error.
+throws-like { (1, 2, 3).pairup.eager }, X::Pairup::OddNumber,
+    'odd plain count throws', message => /'Odd number of elements found for .pairup()'/;
+throws-like { (a => 1, 'b').pairup.eager }, X::Pairup::OddNumber,
+    'Pair then lone value throws';
+
+# A Pair does not consume a following value, so this stays even.
+is (a => 1, 'b', 'c', d => 4).pairup.raku, '(:a(1), :b("c"), :d(4)).Seq',
+    'Pairs interspersed with key/value pairs';


### PR DESCRIPTION
## Summary

Rakudo's `.pairup` walks its source list: a `Pair` element is emitted unchanged (consuming one element), while any other value takes the following element as its value (`key => value`, consuming two). A bare type object listifies to nothing.

mutsu instead chunked the list into fixed pairs of two, so it:

- **mispaired Pair elements** — `(a => 1, b => 2).pairup` gave `((:a(1)) => :b(2),)` instead of `(:a(1), :b(2))`;
- **rejected an even-after-Pairs list as odd** — `('k', 'v', c => 3).pairup` threw instead of yielding `(:k("v"), :c(3))`;
- **threw `X::Pairup::OddNumber` on a type object** instead of returning `()` (`Range.pairup`).

```raku
say (a => 1, 'b', 'c').pairup.raku;   # now (:a(1), :b("c")).Seq  (was: threw)
say Range.pairup.raku;                # now ().Seq                (was: threw)
```

## Fix

Rewrite the loop in the `pairup` handler to advance by one on a `Pair` and by two otherwise, treat any `Package` (type object) invocant as empty, and match Rakudo's odd-count message (`Odd number of elements found for .pairup()`).

## Verification

- New pin `t/pairup-pair-aware.t` (12 assertions, including `throws-like` on the odd cases).
- `roast/S32-basics/pairup.t` (whitelisted) and local `t/pairup.t` still pass 6/6.
- No regressions; full `make test` green.

From the Type/Any.rakudoc doc-diff sweep (findings [10]/[11]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)