### PR TITLE
fix: inline `my` declarations in a parenthesized list-assignment target

### DIFF
--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -207,7 +207,7 @@ impl Compiler {
                         | Expr::HashVar(_)
                         | Expr::Whatever
                         | Expr::Index { .. }
-                )
+                ) || matches!(t, Expr::DoStmt(s) if matches!(s.as_ref(), Stmt::VarDecl { .. }))
             })
         {
             // ($a, $b, ...) = expr -- list assignment to existing variables
@@ -232,6 +232,27 @@ impl Compiler {
             let mut seen_slurpy = false;
             let mut offset: usize = 0;
             for target in targets.iter() {
+                // An inline `my $x` / `my @a` declaration in the LHS list
+                // (`(my $x, my $y) = 1, 2`) declares the variable first, then
+                // behaves exactly like a plain Var/ArrayVar/HashVar target. The
+                // VarDecl carries the sigil for aggregates (`@a`/`%h`) but not
+                // for scalars (`x`).
+                let declared_target;
+                let target: &Expr = if let Expr::DoStmt(stmt) = target
+                    && let Stmt::VarDecl { name: vn, .. } = stmt.as_ref()
+                {
+                    self.compile_stmt(stmt);
+                    declared_target = if let Some(rest) = vn.strip_prefix('@') {
+                        Expr::ArrayVar(rest.to_string())
+                    } else if let Some(rest) = vn.strip_prefix('%') {
+                        Expr::HashVar(rest.to_string())
+                    } else {
+                        Expr::Var(vn.clone())
+                    };
+                    &declared_target
+                } else {
+                    target
+                };
                 match target {
                     Expr::Var(var_name) => {
                         if seen_slurpy {
@@ -339,10 +360,27 @@ impl Compiler {
             // its `.elems` is the number of targets. A `*` (Whatever) target is a
             // discard slot and contributes nothing; `@`/`%` slurpy targets
             // contribute their (flattened) contents.
+            // An inline `my $x` target was already declared+assigned in the loop
+            // above; read it back as its plain Var/ArrayVar/HashVar so this does
+            // NOT re-run the declaration (which would re-initialize it to Nil).
             let result_targets: Vec<Expr> = targets
                 .iter()
                 .filter(|t| !matches!(t, Expr::Whatever))
-                .cloned()
+                .map(|t| {
+                    if let Expr::DoStmt(stmt) = t
+                        && let Stmt::VarDecl { name: vn, .. } = stmt.as_ref()
+                    {
+                        if let Some(rest) = vn.strip_prefix('@') {
+                            Expr::ArrayVar(rest.to_string())
+                        } else if let Some(rest) = vn.strip_prefix('%') {
+                            Expr::HashVar(rest.to_string())
+                        } else {
+                            Expr::Var(vn.clone())
+                        }
+                    } else {
+                        t.clone()
+                    }
+                })
                 .collect();
             self.compile_expr(&Expr::ArrayLiteral(result_targets));
             return;

--- a/t/inline-my-in-list-assign.t
+++ b/t/inline-my-in-list-assign.t
@@ -1,0 +1,59 @@
+use v6;
+use Test;
+
+plan 13;
+
+# An inline `my` declaration inside a parenthesized list-assignment target
+# (`(my $x, my $y) = 1, 2`) declares the variables and assigns to them, exactly
+# like the more common `my ($x, $y) = 1, 2`. mutsu used to route the paren list
+# through the callable-lvalue path and throw "Cannot modify an immutable value".
+# (Regression driver: Math::Trig's `(my $x, my $y, $z) = cylindrical-to-cartesian(...)`.)
+
+{
+    (my $x, my $y) = 1, 2;
+    is $x, 1, 'inline my: first scalar';
+    is $y, 2, 'inline my: second scalar';
+}
+
+# Mixed: inline `my` declarations alongside a pre-declared variable.
+{
+    my $z;
+    (my $x, my $y, $z) = 10, 20, 30;
+    is $x, 10, 'mixed: inline first';
+    is $y, 20, 'mixed: inline second';
+    is $z, 30, 'mixed: pre-declared third';
+}
+
+# A single inline my in parens.
+{
+    (my $only) = 42;
+    is $only, 42, 'single inline my in parens';
+}
+
+# Inline my for an aggregate target: the first `@` is greedy and slurps the
+# remaining RHS values (`(my @a, my $x) = (1,2), 3` → @a = [(1,2), 3], $x = Any).
+{
+    (my @a, my $x) = (1, 2), 3;
+    is @a.raku, '[(1, 2), 3]', 'inline my @a slurps the remaining RHS';
+    ok !$x.defined, 'trailing scalar after a slurpy @ is undefined';
+}
+
+# Inline my for a hash target.
+{
+    (my $first, my %rest) = 'k', a => 1, b => 2;
+    is $first, 'k', 'scalar before slurpy hash';
+    is %rest.keys.sort.join(' '), 'a b', 'inline my %h slurps remaining pairs';
+}
+
+# The result of the list assignment (in list context) is the assigned targets.
+{
+    my @r = ((my $a, my $b) = 5, 6);
+    is @r.elems, 2, 'list-assign result has one item per target';
+    is @r.join(' '), '5 6', 'list-assign result values';
+}
+
+# Re-running the same declaration form does not leak the previous values.
+{
+    (my $p, my $q) = 7, 8;
+    is "$p $q", '7 8', 'inline my values are the assigned ones, not Nil';
+}


### PR DESCRIPTION
## Summary

`(my \$x, my \$y) = 1, 2` — an inline `my` declaration inside a parenthesized list-assignment target — now declares the variables and assigns to them, exactly like the more common `my (\$x, \$y) = 1, 2`.

mutsu previously threw **"Cannot modify an immutable value (cannot assign through non-callable value)"**: the list-destructure lowering only accepted `Var`/`ArrayVar`/`HashVar`/`Whatever`/`Index` targets, so a `my \$x` (which parses to a `DoStmt(VarDecl)` element) fell through to the callable-lvalue path and tried to assign through the array of `Nil`s the declarations evaluate to.

## Fix (`compiler/expr_call.rs`)

- Accept a `DoStmt(VarDecl)` list-assignment target in the allowlist.
- In the destructure loop, compile the declaration first, then treat it as its sigil's plain `Var`/`ArrayVar`/`HashVar` target (the VarDecl carries the sigil for aggregates `@a`/`%h` but not for scalars).
- The result read-back (list assignment yields its LHS targets) maps each declared target to its plain Var too, so it reads the **assigned** value rather than re-running the declaration — which would re-initialize the variable to `Nil`.

Greedy `@`/`%` slurpy semantics and the trailing-scalar-is-undefined behavior are inherited from the existing loop, so `(my @a, my \$x) = (1,2), 3` gives `@a = [(1,2), 3]`, `\$x = Any` as in raku.

## Driver

`Math::Trig` (dist-compat **T-026**) dies at `(my \$x, my \$y, \$z) = cylindrical-to-cartesian(...)`. With this fix the dist passes all 6 test files.

## Tests

- Pin: `t/inline-my-in-list-assign.t` (13 subtests, output matched against raku).
- `make test` green (20923 tests); `roast/S03-operators/assign.t`, `roast/S04-declarations/{multiple,state}.t`, `roast/S02-types/array.t`, `roast/S32-array/perl.t` all pass; `cargo clippy -D warnings` clean.