### PR TITLE
fix: add Any.serial (identity for ordinary values)

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -185,6 +185,13 @@ pub(super) fn dispatch(
             }
             Some(Some(Ok(target.clone())))
         }
+        "serial" => {
+            // Any ordinary value is already its own serial (non-parallel) form,
+            // so `.serial` returns the invocant unchanged (like `.self`). Only a
+            // hyper/race pipeline has a distinct serial form, which mutsu's hyper
+            // method dispatch handles before reaching here.
+            Some(Some(Ok(target.clone())))
+        }
         "clone" => {
             match target.view() {
                 ValueView::Package(_) | ValueView::Nil => Some(Some(Ok(target.clone()))),

--- a/t/any-serial.t
+++ b/t/any-serial.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+# `.serial` returns the invocant's serial (non-parallel) form. For any
+# ordinary value that is simply itself, so `.serial` is the identity — it
+# previously threw "No such method 'serial'".
+
+plan 11;
+
+# The undefined default (Any) returns itself.
+my $b;
+is $b.serial.^name, 'Any', 'Any.serial is Any';
+ok $b.serial === $b,       'undefined invocant returns itself';
+
+# A defined scalar returns its value.
+my $breakfast = 'food';
+is $breakfast.serial, 'food', 'Str.serial is the string';
+
+# Type object.
+is Any.serial.^name, 'Any', 'Any type object serial';
+is Int.serial.^name, 'Int', 'Int type object serial';
+
+# Numbers and strings.
+is 42.serial, 42,        'Int.serial';
+is "str".serial, 'str',  'literal Str.serial';
+
+# Containers keep their type and contents.
+is (1, 2, 3).serial.raku, '(1, 2, 3)',   'List.serial';
+is [1, 2, 3].serial.raku, '[1, 2, 3]',   'Array.serial';
+is (1..5).serial.raku,    '1..5',        'Range.serial';
+my %h = a => 1;
+is %h.serial.raku, '{:a(1)}', 'Hash.serial';


### PR DESCRIPTION
## Summary

`.serial` returns the invocant's serial (non-parallel) form. For any ordinary value that is simply itself, so `.serial` is the identity — but mutsu had no handler and threw `No such method 'serial'`:

```raku
my $b; say $b.serial.^name;   # was: No such method 'serial' for Any; now: Any
'food'.serial.say;            # now: food
```

## Fix

Add a `serial` arm to the 0-arg method dispatch (next to `self`) that returns the invocant unchanged. A hyper/race pipeline has a distinct serial form, which mutsu's hyper method dispatch already resolves upstream (the value is collapsed before reaching this handler), so only the ordinary-value identity is added.

## Verification

- New pin `t/any-serial.t` (11 assertions, verified against reference `raku`).
- No existing test uses `.serial`; full `make test` green.

From the Type/Any.rakudoc doc-diff sweep (finding [1]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)