### PR TITLE
fix: .hash/.Hash on an undefined invocant is the empty hash

### DIFF
--- a/src/builtins/map_hash_coerce.rs
+++ b/src/builtins/map_hash_coerce.rs
@@ -125,7 +125,24 @@ where
 /// flat list receivers. Mirrors the interpreter's `dispatch_to_hash_impl`.
 pub(crate) fn to_hash(target: Value, check_odd: bool) -> Result<Value, RuntimeError> {
     match target.view() {
-        ValueView::Hash(_) => Ok(target.clone()),
+        ValueView::Hash(map) => {
+            // A Map (a Hash carrying the `Map` declared-type) coerces to a fresh
+            // *mutable* Hash, dropping its immutability; a plain Hash is returned
+            // by identity (raku's `%h.Hash =:= %h`).
+            let is_map = Interpreter::hashdata_type_info(&map)
+                .and_then(|info| info.declared_type)
+                .is_some_and(|dt| dt == "Map");
+            if is_map {
+                let mut result = target.clone();
+                result.with_hash_mut(|arc| {
+                    let data = crate::gc::Gc::make_mut(arc);
+                    data.declared_type = None;
+                });
+                Ok(result)
+            } else {
+                Ok(target.clone())
+            }
+        }
         ValueView::Array(items, ..) => items_to_hash(items.as_ref(), check_odd),
         ValueView::Seq(items) | ValueView::Slip(items) => items_to_hash(items.as_ref(), check_odd),
         ValueView::Set(s, _) => Ok(quanthash_to_hash(

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -366,6 +366,11 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 "Hash" => Some(Ok(target.clone())),
                 _ => Some(Ok(Value::hash(std::collections::HashMap::new()))),
             },
+            // An undefined invocant (`my $d`; a bare `Nil`) has no contents, so
+            // `.hash` is the empty hash — like the type-object arm above. Without
+            // this, `Nil` falls to the list path below and is treated as a
+            // one-element initializer → spurious "Odd number of elements".
+            ValueView::Nil => Some(Ok(Value::hash(std::collections::HashMap::new()))),
             // `.hash` on a hash (`%$h`) IS that hash in Associative context:
             // return it de-itemized (a `$`-held itemized hash contextualized as
             // `%$h` spills to the hash, not an opaque single element), preserving

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -126,6 +126,12 @@ impl Interpreter {
                 if method == "Map" {
                     return Some(crate::builtins::map_hash_coerce::to_map(target));
                 }
+                // `.Hash` on an undefined invocant (`my $d`; a bare `Nil`) is the
+                // empty hash, like the `.hash` method. (`.Map` still throws on
+                // an undefined invocant, matching raku, so this is Hash-only.)
+                if target.is_nil() {
+                    return Some(Ok(Value::hash(std::collections::HashMap::new())));
+                }
                 Some(crate::builtins::map_hash_coerce::to_hash(target, true))
             }
             "hash" if args.is_empty() && !matches!(target.view(), ValueView::Instance { .. }) => {

--- a/t/hash-on-undefined.t
+++ b/t/hash-on-undefined.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+# `.hash` on an undefined invocant is the empty hash (it has no contents), and
+# `.Hash` coerces a Map to a fresh mutable Hash while returning a plain Hash by
+# identity. Previously `my $d; $d.hash` threw "Odd number of elements".
+
+plan 13;
+
+# `.hash` on an undefined scalar / type object is `{}`.
+my $d;
+is $d.hash.gist, '{}',       'undefined scalar .hash is empty';
+is $d.hash.^name, 'Hash',    '.hash returns a Hash';
+ok $d.hash.defined,          'the empty hash is defined';
+my Int $x;
+is $x.hash.gist, '{}',       'typed undefined .hash is empty';
+is Any.hash.gist, '{}',      'Any type object .hash is empty';
+
+# `.hash` on a Map returns a Map (immutable, keeps its type).
+my %m is Map = a => 42, b => 666;
+is %m.hash.^name, 'Map',                 'Map.hash stays a Map';
+is %m.hash.raku, 'Map.new((:a(42),:b(666)))'.subst(/\s/, '', :g),
+    'Map.hash renders as Map.new(...)';
+
+# `.Hash` on a Map is a fresh mutable Hash (drops the Map-ness).
+is %m.Hash.^name, 'Hash',     'Map.Hash is a plain Hash';
+is %m.Hash.gist, '{a => 42, b => 666}', 'Map.Hash renders as a hash';
+
+# `.Hash` on a plain Hash is the same hash (identity).
+my %h = a => 1, b => 2;
+is %h.Hash.^name, 'Hash',     'Hash.Hash is a Hash';
+ok %h.Hash =:= %h,            'Hash.Hash is identity';
+
+# A defined non-Associative scalar still throws on odd hash coercion.
+throws-like { my $y = 42; $y.hash }, X::Hash::Store::OddNumber,
+    'defined scalar .hash is an odd-count error';
+
+# `.Hash` on an undefined scalar is also empty.
+is $d.Hash.gist, '{}',        'undefined scalar .Hash is empty';


### PR DESCRIPTION
## Summary

`.hash` and `.Hash` on an undefined invocant have no contents, so they are the empty hash `{}`. mutsu instead listified the value to a one-element list and threw "Odd number of elements found where hash initializer expected":

```raku
my $d; say $d.hash;   # was: Odd number of elements ...; now: {}
```

Also `%m.Hash` on a `Map` returned the Map unchanged; raku's `.Hash` coercion drops the Map-ness and yields a fresh **mutable** Hash (a plain Hash is still returned by identity, `%h.Hash =:= %h`).

## Fix

- **`.hash` (method):** add a `Nil` arm to the collection dispatch returning an empty hash, next to the type-object arm.
- **`.Hash` (coercion):** return an empty hash for a `Nil` invocant in the Map/Hash dispatch. `.Map` still throws on an undefined invocant, matching raku, so this is Hash-only.
- **`.Hash`/`.Map` on a Map:** `to_hash` now strips the `Map` declared-type so the result is a mutable Hash.

The bare-word literal `Nil.hash` still routes through a separate Nil-literal dispatch and is left as a pre-existing quirk; a variable holding Nil (the doc's `my $d`) is fixed.

## Verification

- New pin `t/hash-on-undefined.t` (13 assertions, gists verified against reference `raku`).
- `roast/S02-types/{hash,nil}.t` and `S32-hash/keys_values.t` (whitelisted) unchanged; local hash/Map coercion tests all pass; full `make test` green.

From the Type/Any.rakudoc doc-diff sweep (finding [2]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)