### PR TITLE
fix: tied-hash STORE routes for env/captured lexicals + register X::Hash::Store::OddNumber

### DIFF
--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1660,6 +1660,10 @@ impl Interpreter {
         // X::Assignment::RO
         register_x("X::Assignment::RO", "Exception");
 
+        // X::Hash::Store::OddNumber — odd number of elements assigned to a hash.
+        // Constructible from user code with :found / :last accessors.
+        register_x("X::Hash::Store::OddNumber", "Exception");
+
         // X::Str::Numeric
         register_x("X::Str::Numeric", "Exception");
 

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -867,6 +867,22 @@ impl Interpreter {
                         }
                     }
                 }
+                // A `%h = ...` / `@a = ...` where the env slot holds a *tied*
+                // instance (`my %h is Foo` closed over into a block, so the store
+                // reaches SetGlobal instead of a local slot) must route through the
+                // class's STORE, exactly like the local-slot path. Statement context
+                // — `maybe_tied_store_reassign_named` leaves the bound instance on
+                // the stack, so discard it after routing.
+                if !raw_mode
+                    && !is_bind_ctx
+                    && !is_rebind
+                    && (name.starts_with('%') || name.starts_with('@'))
+                    && self.maybe_tied_store_reassign_named(&name)?.is_some()
+                {
+                    self.stack.pop();
+                    *ip += 1;
+                    return Ok(());
+                }
                 // Reject private attribute twigil (!) assignment when no self is available
                 {
                     let bare = name.trim_start_matches(['$', '@', '%', '&']);

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -34,6 +34,13 @@ impl Interpreter {
                 return Err(RuntimeError::assignment_ro(None));
             }
         }
+        // `%h = ...` where `%h` is a tied container held in env (a global, or a
+        // captured lexical reached through this env-named path rather than a
+        // local slot) must route through the class's STORE, exactly like the
+        // local-slot `maybe_tied_store_reassign` does.
+        if self.maybe_tied_store_reassign_named(&name)?.is_some() {
+            return Ok(());
+        }
         let raw_val = self.stack.pop().unwrap_or(Value::NIL);
         let (raw_val, bind_source) = match raw_val.view() {
             ValueView::VarRef { name, value, .. } => (value.clone(), Some(name.resolve())),

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -695,34 +695,83 @@ impl Interpreter {
         if !(name.starts_with('%') || name.starts_with('@')) {
             return Ok(None);
         }
-        let ValueView::Instance { class_name, .. } = self.locals[idx].view() else {
-            return Ok(None);
+        let name = name.to_string();
+        // The tied instance normally lives in the local slot, but when this store
+        // runs inside a block invoked by another sub (`runit({ %h = "a" })`, or a
+        // `throws-like { %h = ... }` block) the hash is a captured lexical held in
+        // `env`, not `self.locals[idx]`. Resolve the instance from either place and
+        // remember where it came from so the bound result is written back there.
+        let (instance, from_local) = match self.locals[idx].view() {
+            ValueView::Instance { .. } => (self.locals[idx].clone(), true),
+            _ => match self.get_env_with_main_alias(&name) {
+                Some(v) if matches!(v.view(), ValueView::Instance { .. }) => (v, false),
+                _ => return Ok(None),
+            },
         };
-        let cn = class_name.as_str().to_string();
-        let is_tied = self.has_user_method(&cn, "STORE")
-            && (self.class_does_role(&cn, "Associative")
-                || self.class_does_role(&cn, "Positional"));
-        if !is_tied {
+        if !self.instance_is_tied(&instance) {
             return Ok(None);
         }
+        let bound = self.tied_store_dispatch(instance)?;
+        if from_local {
+            self.locals[idx] = bound.clone();
+        }
+        self.set_env_with_main_alias(&name, bound.clone());
+        self.stack.push(bound);
+        Ok(Some(()))
+    }
+
+    /// The `env`-named twin of `maybe_tied_store_reassign`: `%h = ...` where the
+    /// tied instance lives only in `env` (a global or captured lexical, reached
+    /// via `AssignExpr(name_idx)` rather than a local-slot store). Routes through
+    /// the class's `STORE` and leaves the bound instance on the stack.
+    pub(super) fn maybe_tied_store_reassign_named(
+        &mut self,
+        name: &str,
+    ) -> Result<Option<()>, RuntimeError> {
+        if !(name.starts_with('%') || name.starts_with('@')) {
+            return Ok(None);
+        }
+        let Some(instance) = self.get_env_with_main_alias(name) else {
+            return Ok(None);
+        };
+        if !matches!(instance.view(), ValueView::Instance { .. })
+            || !self.instance_is_tied(&instance)
+        {
+            return Ok(None);
+        }
+        let bound = self.tied_store_dispatch(instance)?;
+        self.set_env_with_main_alias(name, bound.clone());
+        self.stack.push(bound);
+        Ok(Some(()))
+    }
+
+    /// True when `instance` is a tied container: a user `STORE` method plus a
+    /// composed `Associative`/`Positional` role.
+    fn instance_is_tied(&mut self, instance: &Value) -> bool {
+        let ValueView::Instance { class_name, .. } = instance.view() else {
+            return false;
+        };
+        let cn = class_name.as_str();
+        self.has_user_method(cn, "STORE")
+            && (self.class_does_role(cn, "Associative") || self.class_does_role(cn, "Positional"))
+    }
+
+    /// Pop the RHS and route it through the tied instance's `STORE`, returning
+    /// the bound instance (the STORE result if it is itself an instance, else the
+    /// original instance).
+    fn tied_store_dispatch(&mut self, instance: Value) -> Result<Value, RuntimeError> {
         let rhs = self.stack.pop().unwrap_or(Value::NIL);
         let store_values = Self::associative_store_values(&rhs);
-        let instance = self.locals[idx].clone();
-        let name = name.to_string();
         // Pass the flattened values as a single positional list; STORE's slurpy
         // `*@values` flattens it (separate args would bind Pairs as *named*).
         let list_arg = Value::array(store_values);
         let stored =
             self.try_compiled_method_or_interpret(instance.clone(), "STORE", vec![list_arg])?;
-        let bound = if matches!(stored.view(), ValueView::Instance { .. }) {
+        Ok(if matches!(stored.view(), ValueView::Instance { .. }) {
             stored
         } else {
             instance
-        };
-        self.locals[idx] = bound.clone();
-        self.set_env_with_main_alias(&name, bound.clone());
-        self.stack.push(bound);
-        Ok(Some(()))
+        })
     }
 
     /// Flatten an RHS value into the list `STORE` expects: a Hash becomes its

--- a/t/tied-hash-store-oddnumber.t
+++ b/t/tied-hash-store-oddnumber.t
@@ -1,0 +1,59 @@
+use Test;
+
+plan 8;
+
+# Gap A: X::Hash::Store::OddNumber is constructible from user code with its
+# :found / :last accessors (it was known internally but not in the user-visible
+# exception registry, so `.new` failed with X::Method::NotFound).
+{
+    my $e = X::Hash::Store::OddNumber.new(:found(0), :last<a>);
+    is $e.found, 0,   'X::Hash::Store::OddNumber.new exposes .found';
+    is $e.last,  'a', 'X::Hash::Store::OddNumber.new exposes .last';
+    is $e.^name, 'X::Hash::Store::OddNumber', 'right exception type';
+    isa-ok $e, Exception, 'is an Exception';
+}
+
+# A tied hash whose STORE throws X::Hash::Store::OddNumber on an odd assignment.
+role OddThrower does Associative {
+    method STORE(*@v) {
+        X::Hash::Store::OddNumber.new(:found(@v.elems), :last(@v.tail)).throw
+            if @v.elems % 2;
+    }
+    method AT-KEY($) { Nil }
+    method keys()    { () }
+}
+class OT does OddThrower {}
+
+# Gap B: a `%h = <odd>` on the tied hash must route through STORE even when the
+# hash is a lexical captured across a call boundary — exactly the shape of a
+# `throws-like { %h = ... }` block, which invokes the block from another sub.
+{
+    my %h is OT;
+    throws-like { %h = "a" }, X::Hash::Store::OddNumber, :found(1), :last<a>,
+        'captured tied odd-assign routes through STORE and throws';
+}
+
+# The same store at top level (not captured in a block) also routes through STORE.
+{
+    my %h is OT;
+    my $threw = False;
+    { %h = "solo"; CATCH { when X::Hash::Store::OddNumber { $threw = True } } }
+    ok $threw, 'top-level tied odd-assign routes through STORE and throws';
+}
+
+# A tied hash with a real backing store: `%h = key/value list` populates it via
+# STORE, both top-level and captured in a sub.
+role Backed does Associative {
+    has %!h;
+    method STORE(*@pairs) { %!h = @pairs.map({ .key => .value }).Hash }
+    method AT-KEY($k)     { %!h.AT-KEY($k) }
+    method keys()         { %!h.keys }
+}
+class B does Backed {}
+{
+    my %h is B;
+    sub runit(&code) { code() }
+    runit({ %h = (x => 1, y => 2) });
+    is %h<x>, 1, 'captured store populates backing (x)';
+    is %h<y>, 2, 'captured store populates backing (y)';
+}


### PR DESCRIPTION
## Summary

Fixes two independent gaps blocking Hash::Agnostic dist subtests 7 (`a Failure as a value will be thrown`) and 8 (`X::Hash::Store::OddNumber`). Locally the dist test `t/01-basic.rakutest` goes from **6 failures → 4** (the remaining 4 are the deferred bound-element-immutability cluster 4/5/6 and a separate pre-existing `.kv` custom-iterator gap).

### Gap A — `X::Hash::Store::OddNumber` not constructible from user code

mutsu builds this exception internally (odd number of elements assigned to a hash) but it was absent from the user-visible exception registry, so `X::Hash::Store::OddNumber.new(:found(0), :last<a>)` from Raku failed with `X::Method::NotFound: Unknown method new`. Registered it as an `Exception` so it constructs with its `.found` / `.last` accessors.

### Gap B — tied `%h = ...` bypassed STORE for captured/global lexicals

A `%h = ...` on a tied hash (`my %h is Foo`, `Foo does Associative` with a user `STORE`) only routed through STORE when the tied instance lived in the **local slot**. When `%h` is a lexical captured across a call boundary — a block invoked by another sub, exactly the shape of a `throws-like { %h = ... }` block — the instance lives in `env`, so the store fell through to mutsu's built-in plain-hash coerce and STORE never fired (the module's `!STORE` throws `X::Hash::Store::OddNumber` on odd input and re-throws a stored `Failure`, so subtests 7 & 8 saw the wrong exception / no throw).

Fix:
- `maybe_tied_store_reassign` now resolves the tied instance from `env` as well as the local slot, writing the bound result back to whichever holds it.
- New env-named twin `maybe_tied_store_reassign_named`, wired into the `AssignExpr` (`exec_assign_expr_op_inner`) and `SetGlobal` paths so a captured/global tied hash routes through STORE too.
- Shared the STORE-dispatch core (`tied_store_dispatch`) and the tied-check (`instance_is_tied`) between both entry points.

## Test

Pin `t/tied-hash-store-oddnumber.t` — verifies both gaps, cross-checked against `raku` (identical output). `make test` green (the sole failure, `t/supply-live-grep-map-react-order.t` test 5, is a known S17 supply-ordering flake, unrelated; 5/5 pass on re-run).

Bug fix; default patch bump (no label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)