### PR TITLE
fix: multi-dispatch with a where-constrained optional param; exact exp(Int,Int)

### DIFF
--- a/src/builtins/functions/dispatch_2arg.rs
+++ b/src/builtins/functions/dispatch_2arg.rs
@@ -291,14 +291,16 @@ pub(crate) fn native_function_2arg(
             }
         }
         "exp" => {
-            // exp($x, $base) = $base ** $x
-            // Fast path for real args
+            // exp($x, $base) = $base ** $x — delegate to the `**` operator so
+            // integer bases/exponents stay exact (raku: `exp(72, 10)` is the Int
+            // 10**72, not the Num 1e72), while non-integer args still yield a Num.
             if !matches!(arg1.view(), ValueView::Complex(..))
                 && !matches!(arg2.view(), ValueView::Complex(..))
             {
-                let x = runtime::to_float_value(arg1).unwrap_or(f64::NAN);
-                let base = runtime::to_float_value(arg2).unwrap_or(f64::NAN);
-                return Some(Ok(Value::num(base.powf(x))));
+                return Some(Ok(crate::builtins::arith::arith_pow(
+                    arg2.clone(),
+                    arg1.clone(),
+                )));
             }
             let (base_r, base_i) = match arg2.view() {
                 ValueView::Int(i) => (i as f64, 0.0),

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -192,6 +192,12 @@ impl Interpreter {
                 } else {
                     args.get(i).cloned().map(unwrap_varref_value)
                 };
+                // Whether an actual argument was passed for this param (vs. an
+                // unsupplied optional filled with its type object below). An
+                // unsupplied optional's `where` must NOT reject the candidate
+                // during dispatch — raku checks it at bind time against the
+                // default value, not the bare type object.
+                let arg_was_supplied = arg_for_checks.is_some();
                 if arg_for_checks.is_none()
                     && !pd.required
                     && !pd.name.is_empty()
@@ -400,7 +406,9 @@ impl Interpreter {
                         return false;
                     }
                 }
-                if let Some(where_expr) = &pd.where_constraint {
+                if let Some(where_expr) = &pd.where_constraint
+                    && (arg_was_supplied || !(pd.default.is_some() || pd.optional_marker))
+                {
                     let Some(arg) = arg_for_checks.as_ref() else {
                         return false;
                     };

--- a/t/exp-two-arg-integer-exact.t
+++ b/t/exp-two-arg-integer-exact.t
@@ -1,0 +1,22 @@
+use v6;
+use Test;
+
+plan 8;
+
+# The 2-argument `exp($power, $base)` is `$base ** $power`. With integer args it
+# must stay EXACT (an arbitrary-precision Int), like raku's `**` — mutsu used to
+# compute it as an f64 `powf` and return a lossy Num (`exp(72, 10)` was `1e72`,
+# not `10 ** 72`). Regression driver: Math::Root's `exp(4 * $n, 10)`.
+
+is exp(72, 10).^name, 'Int', 'exp(Int, Int) returns an Int';
+is exp(72, 10), 10 ** 72, 'exp(72, 10) == 10 ** 72 exactly';
+is exp(3, 2), 8, 'exp(3, 2) == 8';
+is exp(0, 10), 1, 'exp(0, base) == 1';
+
+# Non-integer arguments still yield a Num.
+is exp(2.5, 10).^name, 'Num', 'exp(Rat, Int) is a Num';
+ok (exp(2, 2.0) - 4).abs < 1e-9, 'exp(Int, Num) numeric value is correct';
+
+# 1-argument exp is unchanged (e ** $x).
+ok (exp(0) - 1).abs < 1e-12, 'exp(0) == 1';
+ok (exp(1) - 2.718281828459045).abs < 1e-12, 'exp(1) == e';

--- a/t/multi-where-optional-param.t
+++ b/t/multi-where-optional-param.t
@@ -1,0 +1,42 @@
+use v6;
+use Test;
+
+plan 9;
+
+# A multi candidate with a `where` constraint on an OPTIONAL (defaulted) param
+# must still match a call that omits that argument: the omitted param defaults,
+# and the `where` is checked at bind time against the default — not against the
+# bare type object during dispatch. mutsu used to reject the candidate with
+# "No matching candidates for proto sub" (regression driver: Math::Root's
+# `multi iroot(Int() $i where * < 1e12, Int $n where * >= 2 = 2)`).
+
+{
+    multi f(Int $a, Int $b where * >= 2 = 2) { "$a,$b" }
+    is f(1),    '1,2', 'defaulted where-param: candidate matches with arg omitted';
+    is f(1, 5), '1,5', 'defaulted where-param: supplied value that satisfies where';
+}
+
+# When the argument IS supplied and fails the `where`, the candidate is still
+# rejected (dispatch falls through to a fallback candidate).
+{
+    multi g(Int $a, Int $b where * >= 2 = 2) { "constrained:$a,$b" }
+    multi g(Int $a, Int $b)                  { "fallback:$a,$b" }
+    is g(1),    'constrained:1,2', 'omitted arg → constrained candidate (default 2 satisfies where)';
+    is g(1, 5), 'constrained:1,5', 'supplied 5 satisfies where → constrained';
+    is g(1, 1), 'fallback:1,1',    'supplied 1 fails where → fallback candidate';
+}
+
+# The same, with a coercion type on the leading param (the exact Math::Root shape).
+{
+    multi h(Int() $a where * < 100, Int $n where * >= 2 = 2) { "small:$a,$n" }
+    multi h(Int() $a where * >= 100, Int $n where * >= 2 = 2) { "big:$a,$n" }
+    is h(5),   'small:5,2',  'coercion + where-optional: small branch, arg omitted';
+    is h(500), 'big:500,2',  'coercion + where-optional: big branch, arg omitted';
+    is h(5, 3), 'small:5,3', 'coercion + where-optional: small branch, arg supplied';
+}
+
+# A non-multi sub already worked; keep it covered.
+{
+    sub s(Int $a, Int $b where * >= 2 = 2) { "$a,$b" }
+    is s(1), '1,2', 'non-multi sub with where-optional param';
+}


### PR DESCRIPTION
Two independent, general fixes surfaced by **Math::Root** (dist-compat T-025).

## 1. Multi-dispatch: `where` on an optional param

```raku
multi f(Int $a, Int $b where * >= 2 = 2) { "\$a,\$b" }
f(1)   # was: "No matching candidates for proto sub: f"  /  now & raku: "1,2"
```

When a param is unsupplied, the dispatch filler substitutes the bare **type object** (not the default value), and the `where` was then evaluated against it (`Int >= 2` → false), spuriously rejecting the candidate. A `where` on an unsupplied optional param is now **skipped during dispatch matching** — raku checks it at bind time against the default. A *supplied* argument that fails the `where` still rejects the candidate (verified against a fallback candidate). (`runtime/types/args_matching.rs`)

## 2. Exact `exp(Int, Int)`

`exp(\$power, \$base)` is `\$base ** \$power`, but mutsu always computed an f64 `powf`:

```raku
exp(72, 10)   # was Num 1e72  /  now & raku: Int 10 ** 72 (exact)
```

Now delegates to the `**` operator (`arith_pow`) so integer args stay exact while non-integer args still yield a `Num`. (`builtins/functions/dispatch_2arg.rs`)

## Tests

- Pins: `t/multi-where-optional-param.t` (9), `t/exp-two-arg-integer-exact.t` (8) — both raku-matched.
- `make test` green (20980 tests); `roast/S06-multi/*` all pass; `cargo clippy -D warnings` clean.

Math::Root is **not yet fully passing** — it further needs `min`/`max` over a lazy `Seq` and the `…` sequence operator with block endpoints (tracked in T-025).