### PR TITLE
fix: .slice expands a Range index argument

### DIFF
--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -154,15 +154,26 @@ impl Interpreter {
                 } else {
                     let mut result = Vec::with_capacity(args.len());
                     for arg in &args {
-                        let idx = match arg.view() {
-                            ValueView::Int(i) => Some(i as usize),
-                            ValueView::Num(n) => Some(n as usize),
-                            _ => None,
+                        // Expand each argument to zero or more 0-based indices, in
+                        // order: a plain number is a single index, while a Range
+                        // (`3..6`) contributes every index it spans, so
+                        // `.slice(0, 3..6, 8)` gathers indices 0,3,4,5,6,8.
+                        let indices: Vec<usize> = match arg.view() {
+                            ValueView::Int(i) if i >= 0 => vec![i as usize],
+                            ValueView::Num(n) if n >= 0.0 => vec![n as usize],
+                            _ if arg.is_range() => crate::runtime::utils::value_to_list(arg)
+                                .iter()
+                                .filter_map(|v| match v.view() {
+                                    ValueView::Int(i) if i >= 0 => Some(i as usize),
+                                    _ => None,
+                                })
+                                .collect(),
+                            _ => Vec::new(),
                         };
-                        if let Some(i) = idx
-                            && i < items.len()
-                        {
-                            result.push(items[i].clone());
+                        for i in indices {
+                            if i < items.len() {
+                                result.push(items[i].clone());
+                            }
                         }
                     }
                     Some(Ok(Value::seq_arc(std::sync::Arc::new(result))))

--- a/t/slice-range-args.t
+++ b/t/slice-range-args.t
@@ -1,0 +1,19 @@
+use v6;
+use Test;
+
+# `.slice` selects elements at the given (increasing) index arguments. A Range
+# argument (`3..6`) expands to every index it spans, so `.slice(0, 3..6, 8)`
+# gathers indices 0,3,4,5,6,8. Previously Range arguments were silently
+# ignored. The result is a Seq. (The gists below were verified against `raku`.)
+
+plan 7;
+
+is (1..10).slice(0, 3..6, 8).raku, '(1, 4, 5, 6, 7, 9).Seq', 'mixed int and range indices';
+is (1..10).slice(2, 4).raku,       '(3, 5).Seq',             'plain int indices';
+is <a b c d e>.slice(1, 3..4).raku, '("b", "d", "e").Seq',   'range on a word list';
+is (10, 20, 30, 40).slice(0..2).raku, '(10, 20, 30).Seq',    'a single range argument';
+is ('x'..'z').slice(0, 2).raku,    '("x", "z").Seq',         'slice over a Range receiver';
+is (1..10).slice().raku,           '().Seq',                 'no arguments is empty';
+
+# Range indices past the end of the list are skipped.
+is (1..3).slice(0, 2..5).raku,     '(1, 3).Seq',             'range indices past the end are skipped';


### PR DESCRIPTION
## Summary

`.slice` selects the elements at its index arguments, and a Range argument expands to every index it spans, so `(1..10).slice(0, 3..6, 8)` gathers indices 0,3,4,5,6,8 → `(1 4 5 6 7 9)`. mutsu matched only `Int`/`Num` arguments and dropped a Range to `None`, so `(1..10).slice(0, 3..6, 8)` returned just `(1 9)`.

## Fix

Expand each argument to zero or more 0-based indices, in order: a plain number is one index, a Range contributes every (non-negative) index it spans; out-of-range indices are skipped as before.

## Verification

- New pin `t/slice-range-args.t` (7 assertions, gists verified against reference `raku`).
- `roast/S03-feeds/basic.t` and `S32-list/seq.t` (whitelisted) unchanged; full `make test` green.

raku additionally requires strictly increasing indices and errors on a backward jump; mutsu stays permissive there, which is out of scope for this fix.

From the Type/Any.rakudoc doc-diff sweep (finding [22]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)