### PR TITLE
fix: nodemap sub form + nodemap on a Hash acts on values

### DIFF
--- a/src/parser/primary/ident/predicates.rs
+++ b/src/parser/primary/ident/predicates.rs
@@ -256,6 +256,7 @@ pub(crate) fn is_expr_listop(name: &str) -> bool {
             | "dir"
             | "first"
             | "deepmap"
+            | "nodemap"
             | "duckmap"
             | "make"
             | "take"

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -718,6 +718,7 @@ impl Interpreter {
             "flat" => self.builtin_flat(&args),
             "duckmap" => self.builtin_duckmap(&args),
             "deepmap" => self.builtin_deepmap(&args),
+            "nodemap" => self.builtin_nodemap(&args),
             "slip" | "Slip" => self.builtin_slip(&args),
             "take" => {
                 let value = if args.len() <= 1 {

--- a/src/runtime/builtins_collection_deepmap.rs
+++ b/src/runtime/builtins_collection_deepmap.rs
@@ -150,6 +150,15 @@ impl Interpreter {
         self.deepmap_iterate(&block, &obj)
     }
 
+    pub(super) fn builtin_nodemap(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
+        if args.len() < 2 {
+            return Err(RuntimeError::new("nodemap requires a block and an object"));
+        }
+        let block = args[0].clone();
+        let obj = args[1].clone();
+        self.nodemap_iterate(&block, &obj)
+    }
+
     /// Iterate over the elements of a value, applying duckmap to each.
     /// This is the entry point for both the method and function forms.
     pub(crate) fn duckmap_iterate(
@@ -420,6 +429,21 @@ impl Interpreter {
                     }
                 }
                 Ok(Value::array(result))
+            }
+            // On an Associative, nodemap acts on the values, keeping the keys
+            // (raku: "it will act on the values"), and returns a Hash.
+            ValueView::Hash(map) => {
+                let mut result = std::collections::HashMap::new();
+                for (k, v) in map.iter() {
+                    match self.call_sub_value(block.clone(), vec![v.clone()], false) {
+                        Ok(mapped) => {
+                            result.insert(k.clone(), mapped);
+                        }
+                        Err(e) if e.is_next() => continue,
+                        Err(e) => return Err(e),
+                    }
+                }
+                Ok(Value::hash_with_data(Value::hash_arc(result)))
             }
             // Single value: apply the block directly
             _ => self.call_sub_value(block.clone(), vec![target.clone()], false),

--- a/src/runtime/system_eval_names.rs
+++ b/src/runtime/system_eval_names.rs
@@ -155,6 +155,7 @@ pub(crate) const EVAL_KNOWN_ROUTINE_NAMES: &[&str] = &[
     "nextcallee",
     "nextsame",
     "nextwith",
+    "nodemap",
     "not",
     "now",
     "open",

--- a/t/nodemap-sub.t
+++ b/t/nodemap-sub.t
@@ -1,0 +1,33 @@
+use v6;
+use Test;
+
+# `nodemap` has a sub form (`nodemap &op, \obj`) as well as the method form.
+# It applies its callable to each top-level element without descending into
+# sublists, and on an Associative it acts on the values. Previously the sub
+# form failed to parse ("Two terms in a row"/numify error) and the Hash case
+# of the method form mapped the whole hash as one value.
+
+plan 8;
+
+# Sub form over nested lists (no recursion into sublists).
+is (nodemap *+1, [[1,2,3], [[4,5],6,7], 7]).raku, '(4, 4, 8)',
+    'nodemap sub over nested lists counts sublist elems + 1';
+is (nodemap *+1, (10, 20, 30)).raku, '(11, 21, 31)', 'nodemap sub over a flat list';
+
+# Hyper method form.
+is ([[2, 3], [4, [5, 6]]]».nodemap(*+1)).raku, '((3, 4), (5, 3))',
+    'hyper nodemap over a list of lists';
+
+# On an Associative, nodemap acts on the values and returns a Hash.
+is (nodemap *.flip, { what => "is", this => "thing" }).raku,
+    '{:this("gniht"), :what("si")}', 'nodemap sub on a hash maps the values';
+my %h = a => "xy", b => "pq";
+is %h.nodemap(*.flip).raku, '{:a("yx"), :b("qp")}', 'nodemap method on a hash maps the values';
+
+# nodemap does not flatten Slips (unlike map).
+is [[2,3], [[4,5],6,7], 7].nodemap({.elems == 1 ?? $_ !! slip}).gist, '(() () 7)',
+    'nodemap keeps empty Slips as empty lists';
+
+# Method form returns a List even from an Array.
+is [2, 3].nodemap(*+1).^name, 'List', 'nodemap returns a List';
+is <a b c>.nodemap(*.uc).raku, '("A", "B", "C")', 'nodemap over a word list';


### PR DESCRIPTION
## Summary

`nodemap` is documented with both a method (`obj.nodemap(&block)`) and a sub (`nodemap &op, \obj`). mutsu had only the method, so the sub form failed to parse — the bare word `nodemap` was numified:

```raku
say nodemap *+1, [[1,2,3], [[4,5],6,7], 7];   # was: Cannot convert string to number ... '⏏nodemap'
# now: (4 4 8)
```

And `nodemap_iterate` had no `Hash` arm, so `%h.nodemap(&op)` mapped the **whole** stringified hash as one value instead of acting on the values.

## Fix

- Add the `nodemap` sub, mirroring `deepmap`: register it in `is_expr_listop` (parser), `system_eval_names`, and the builtin dispatch, with a new `builtin_nodemap` delegating to `nodemap_iterate`.
- Add a `Hash` arm to `nodemap_iterate` that applies the callable to each value, keeps the keys, and returns a Hash (raku: "it will act on the values").

## Verification

- New pin `t/nodemap-sub.t` (8 assertions, verified against reference `raku`).
- `roast/S32-list/deepmap.t` and `S03-metaops/hyper.t` (whitelisted) unchanged; local deepmap/nodemap/duckmap tests all pass; full `make test` green.

From the Type/Any.rakudoc doc-diff sweep (findings [8]/[9]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)