### PR TITLE
fix: min()/max() over a single iterable folds it (Seq, numeric arrays)

### DIFF
--- a/src/builtins/functions/dispatch_1arg.rs
+++ b/src/builtins/functions/dispatch_1arg.rs
@@ -829,38 +829,12 @@ pub(crate) fn native_function_1arg(name: &str, arg: &Value) -> Option<Result<Val
             ValueView::Array(items, ..) => items.first().cloned().unwrap_or(Value::NIL),
             _ => arg.clone(),
         })),
-        "min" => Some(Ok(match arg.view() {
-            ValueView::Hash(items) => items
-                .iter()
-                .min_by(|(ak, _), (bk, _)| ak.cmp(bk))
-                .map(|(k, v)| items.typed_pair(k, v.clone()))
-                .unwrap_or(Value::NIL),
-            ValueView::Array(items, ..) => items
-                .iter()
-                .cloned()
-                .min_by(|a, b| match (a.view(), b.view()) {
-                    (ValueView::Int(x), ValueView::Int(y)) => x.cmp(&y),
-                    _ => a.to_string_value().cmp(&b.to_string_value()),
-                })
-                .unwrap_or(Value::NIL),
-            _ => arg.clone(),
-        })),
-        "max" => Some(Ok(match arg.view() {
-            ValueView::Hash(items) => items
-                .iter()
-                .max_by(|(ak, _), (bk, _)| ak.cmp(bk))
-                .map(|(k, v)| items.typed_pair(k, v.clone()))
-                .unwrap_or(Value::NIL),
-            ValueView::Array(items, ..) => items
-                .iter()
-                .cloned()
-                .max_by(|a, b| match (a.view(), b.view()) {
-                    (ValueView::Int(x), ValueView::Int(y)) => x.cmp(&y),
-                    _ => a.to_string_value().cmp(&b.to_string_value()),
-                })
-                .unwrap_or(Value::NIL),
-            _ => arg.clone(),
-        })),
+        // `min`/`max` on a single argument are intentionally NOT handled here:
+        // the naive Hash/Array-only arm returned a lone Seq/List/Range unfolded
+        // (`min((5,3,8).Seq)` == the Seq) and mis-ordered non-Int arrays via a
+        // stringwise compare (`min([2.0, 10])` == 10). Return `None` so the sub
+        // form falls through to the authoritative `builtin_min`/`builtin_max`,
+        // which flatten a single iterable and fold with `compare_values`.
         "ords" => {
             let s = arg.to_string_value();
             let codes: Vec<Value> = s.chars().map(|ch| Value::int(ch as u32 as i64)).collect();

--- a/t/min-max-over-seq.t
+++ b/t/min-max-over-seq.t
@@ -1,0 +1,45 @@
+use Test;
+
+# min()/max() sub form must fold a single iterable argument. A lone Seq was
+# previously returned unfolded (`min((5,3,8).Seq)` == the Seq itself) because
+# the single-arg native fast path only special-cased Hash/Array.
+
+plan 20;
+
+# --- single lazy Seq (the reported bug) ---
+is min((5, 3, 8).Seq), 3, 'min over a single Seq folds';
+is max((5, 3, 8).Seq), 8, 'max over a single Seq folds';
+is min((3, 1, 2).Seq), 1, 'min over another Seq';
+
+# --- other single-collection shapes ---
+is min((5, 3, 8)),        3, 'min over a List';
+is max((5, 3, 8)),        8, 'max over a List';
+is min((5, 3, 8).Slip),   3, 'min over a Slip';
+is min([5, 3, 8]),        3, 'min over an Array';
+is max([5, 3, 8]),        8, 'max over an Array';
+is min(3, 1, 2),          1, 'min over separate positional args';
+
+# --- non-Int arrays must order numerically, not stringwise ---
+is min([2.0, 10]), 2, 'min([2.0, 10]) orders numerically (not "10" < "2.0")';
+is max([2.0, 10]), 10, 'max([2.0, 10]) orders numerically';
+is min([10, 9, 3]), 3, 'min([10, 9, 3]) is numeric, not stringwise';
+
+# --- strings ---
+is min("b", "a", "c"), 'a', 'min over string args';
+is min(<b a c>),       'a', 'min over a word list';
+
+# --- ranges ---
+is min(1..5), 1, 'min over a Range';
+is max(1..5), 5, 'max over a Range';
+
+# --- hashes: ordered by key ---
+is min({ a => 3, b => 1 }).key, 'a', 'min over a Hash picks the lowest key';
+is max({ a => 3, b => 1 }).key, 'b', 'max over a Hash picks the highest key';
+
+# --- single scalar ---
+is min(5), 5, 'min of a lone scalar is itself';
+
+# --- method form still works ---
+is (5, 3, 8).Seq.min, 3, 'the .min method form is unaffected';
+
+done-testing;


### PR DESCRIPTION
## Problem

The `min`/`max` **sub** forms over a single iterable argument were broken:

```raku
say min((5,3,8).Seq);   # was: (5 3 8)   should be: 3
say min([2.0, 10]);     # was: 10        should be: 2
```

`min((5,3,8))` (a List literal) folds correctly only because the caller
flattens the List into three positional args; a `Seq` stays a single argument.

## Root cause

`native_function_1arg` (`src/builtins/functions/dispatch_1arg.rs`) intercepted
the single-arg `min`/`max` sub call and only special-cased `Hash` and `Array`,
returning every other single argument unchanged via `_ => arg.clone()`. Because
this native fast path returns `Some(...)`, the authoritative `builtin_min` /
`builtin_max` were never reached for a lone Seq/List/Range.

The `Array` arm was additionally wrong: it ordered non-`Int` elements with a
stringwise `to_string_value()` compare, so `min([2.0, 10])` came out as `10`
(`"10" < "2.0"` stringwise).

## Fix

Remove the `min`/`max` arms from `native_function_1arg` so the single-arg sub
form falls through to `builtin_min` / `builtin_max`, which flatten a single
iterable and fold with `compare_values` (numerically correct, Range/Hash/Seq
aware).

## Test

`t/min-max-over-seq.t` (20 subtests) — Seq / List / Slip / Array / Range / Hash
/ scalar, numeric-vs-stringwise ordering, and the `.min` method form. All match
raku.

This resolves remaining bug #1 of **T-025 (Math::Root)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)