### PR TITLE
fix: .round($scale) stays exact for large integers (BigInt path)

### DIFF
--- a/src/builtins/arith/rat.rs
+++ b/src/builtins/arith/rat.rs
@@ -246,6 +246,17 @@ fn value_from_i128(n: i128) -> Value {
 /// inexact (Num/Complex), the scale is zero, or i128 overflow would occur — the
 /// caller then falls back to the f64 path.
 pub(crate) fn exact_round_scaled(target: &Value, scale: &Value) -> Option<Value> {
+    // Fast path: exact i128 arithmetic. On any i128 overflow (large Ints, e.g.
+    // `(17**1500).round(10)`), this yields `None` via the `checked_*` ops, and we
+    // retry with the BigInt path below rather than degrading to a lossy f64
+    // round (a huge BigInt numifies to `Inf`, so the scaled round returned `Inf`).
+    if let Some(v) = exact_round_scaled_i128(target, scale) {
+        return Some(v);
+    }
+    exact_round_scaled_bigint(target, scale)
+}
+
+fn exact_round_scaled_i128(target: &Value, scale: &Value) -> Option<Value> {
     let (tn, td) = exact_rat_parts_i128(&target.view())?;
     let (sn, sd) = exact_rat_parts_i128(&scale.view())?;
     if sn == 0 {
@@ -271,5 +282,35 @@ pub(crate) fn exact_round_scaled(target: &Value, scale: &Value) -> Option<Value>
         Some(value_from_i128(rn.checked_div(sd)?))
     } else {
         Some(rat_from_i128_or_num(rn, sd))
+    }
+}
+
+/// BigInt-precision `round($scale)` for rational targets/scales that overflow
+/// the i128 fast path. Mirrors `exact_round_scaled_i128` exactly, using
+/// arbitrary-precision arithmetic so `(17**1500).round(10)` stays exact.
+fn exact_round_scaled_bigint(target: &Value, scale: &Value) -> Option<Value> {
+    use num_integer::Integer;
+    let (tn, td) = to_big_rat_parts(target)?;
+    let (sn, sd) = to_big_rat_parts(scale)?;
+    if sn.is_zero() {
+        return None;
+    }
+    let two = NumBigInt::from(2);
+    // r = self/scale + 1/2 = (2*tn*sd + td*sn) / (2*td*sn)
+    let mut num = &two * &tn * &sd + &td * &sn;
+    let mut den = &td * &sn * &two;
+    if den.is_negative() {
+        num = -num;
+        den = -den;
+    }
+    // floor(num/den) with den > 0
+    let floor_q = num.div_floor(&den);
+    // result = floor_q * scale = floor_q * sn / sd
+    let rn = floor_q * &sn;
+    if is_integer_scale(&scale.view()) {
+        // sd == 1 for an integer scale, so the result is an exact integer.
+        Some(Value::from_bigint(rn / &sd))
+    } else {
+        Some(crate::value::make_big_rat_arith(rn, sd))
     }
 }

--- a/t/round-scale-bigint.t
+++ b/t/round-scale-bigint.t
@@ -1,0 +1,36 @@
+use Test;
+
+# .round($scale) on a very large integer must stay exact. The i128 fast path
+# overflows for such values and previously fell through to an f64 round, where
+# the BigInt numifies to Inf — so `(17**1500).round(10)` returned `Inf` (and,
+# coerced to Int, saturated to i64::MAX). A BigInt path now keeps it exact.
+
+plan 12;
+
+# --- large BigInt targets, integer scale ---
+is (17 ** 1500).round(10),
+   (17 ** 1500).round(10).Str.Int,   # sanity: it is a real integer, not Inf
+   'round(10) of a huge BigInt is an integer, not Inf';
+
+# raku's round is floor(x/scale + 1/2) * scale.
+my $x = 10 ** 40 + 7;               # ...0007
+is $x.round(10),  10 ** 40 + 10,    'round(10) rounds ..07 up to the next ten';
+is (10 ** 40 + 3).round(10), 10 ** 40, 'round(10) rounds ..03 down';
+
+is (10 ** 30).round(10), 10 ** 30, 'round(10) of an exact power of ten is itself';
+is (10 ** 30).round(1),  10 ** 30, 'round(1) of a big int is itself';
+
+# --- negative big ints round half-up (toward +Inf on the .5 tie) ---
+is (-(10 ** 40) - 7).round(10), -(10 ** 40) - 10, 'negative big round(10), 7 below rounds away';
+is (-(10 ** 40) - 3).round(10), -(10 ** 40),      'negative big round(10), 3 below rounds toward zero';
+
+# --- small ints still work (i128 fast path) ---
+is (1234567).round(100),  1234600, 'small int round(100)';
+is (-1234567).round(100), -1234600, 'small negative int round(100)';
+is (7).round(10), 10, 'round(10) of 7';
+is (4).round(10), 0,  'round(10) of 4';
+
+# --- round() with no scale still works on a big int ---
+is (17 ** 1500).round, 17 ** 1500, 'round() with no scale on a big int is identity';
+
+done-testing;


### PR DESCRIPTION
## Problem

`Real.round($scale)` returned `Inf` for a large integer:

```raku
say (17**1500).round(10);   # was: Inf   should be: 4713918...289788023301...0
```

## Root cause

The exact scaled-round helper `exact_round_scaled` (`src/builtins/arith/rat.rs`)
did all its arithmetic in `i128`. For a target that overflows `i128` — such as
`17**1500` — every `checked_*` op returned `None`, so `round` fell through to
the f64 path. There the BigInt numifies to `Inf`, so `(17**1500).round(10)`
came out `Inf` (and, coerced back to `Int` via the callee's `--> Int`,
saturated to `i64::MAX`).

## Fix

Split `exact_round_scaled` into:
- `exact_round_scaled_i128` — the existing i128 fast path, unchanged; and
- `exact_round_scaled_bigint` — a BigInt fallback that mirrors the same
  `floor(self/scale + 1/2) * scale` arithmetic with `num_bigint`, tried when the
  i128 path overflows.

Both rational targets and rational scales are supported; the result normalizes
to `Int` when it fits, else `BigInt` / a reduced big `Rat`.

## Impact

This is the remaining blocker for **Math::Root**'s `newton` path:
`iroot(17**1500)` and the full `t/01-integer.t` now compute correctly instead
of returning a saturated value.

## Test

`t/round-scale-bigint.t` (12 subtests) — large positive/negative BigInt
targets, exact powers of ten, small ints (i128 fast path), and no-scale
`round()`. All match raku.

🤖 Generated with [Claude Code](https://claude.com/claude-code)