### PR TITLE
fix: list-valued sort keys compare element-wise (multi-key .sort)

### DIFF
--- a/src/runtime/utils/compare.rs
+++ b/src/runtime/utils/compare.rs
@@ -148,6 +148,21 @@ pub(crate) fn compare_values(a: &Value, b: &Value) -> i32 {
         };
         return compare_values(&normalize(a), &normalize(b));
     }
+    // List-like values (Array/Seq/Slip/List) compare element-wise, like Raku's
+    // `cmp`/`<=>` on lists: the first differing element decides, and if one list
+    // is a prefix of the other the shorter sorts Less. This drives multi-key
+    // `.sort` where a 1-arity block returns a list of keys
+    // (`.sort({ .Int, .comb.sum, .Str })`) — without it the list keys fall to the
+    // string-gist fallback below and mis-order.
+    if let (Some(al), Some(bl)) = (a.as_list_items(), b.as_list_items()) {
+        for (ax, bx) in al.iter().zip(bl.iter()) {
+            let c = compare_values(ax, bx);
+            if c != 0 {
+                return c;
+            }
+        }
+        return al.len().cmp(&bl.len()) as i32;
+    }
     match (a.view(), b.view()) {
         (
             ValueView::Version {

--- a/t/sort-list-key.t
+++ b/t/sort-list-key.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+plan 9;
+
+# A 1-arity .sort block that returns a *list* of keys is a multi-key
+# Schwartzian sort: keys compare element-wise (Raku list cmp), the first
+# differing element decides, shorter-as-prefix sorts Less.
+is <01 11 111 2 20 02>.sort( { .Int, .comb.sum, .Str } ).join(" "),
+   "01 02 2 11 20 111",
+   "multi-key sort by (.Int, .comb.sum, .Str)";
+
+# List cmp / <=> semantics that the same code path relies on.
+is (1, 2, 3) cmp (1, 2, 4), Less, "list cmp: first difference decides";
+is (1, 2)    cmp (1, 2, 3), Less, "list cmp: prefix sorts Less";
+is (1, 2, 3) cmp (1, 2),    More, "list cmp: longer sorts More";
+is ("a", "b") cmp ("a", "c"), Less, "list cmp: string elements";
+is (2,) cmp (10,), Less, "list cmp: numeric, not stringwise";
+is (1, 2, 3) cmp (1, 2, 3), Same, "list cmp: equal lists are Same";
+
+# Multi-key sort over pairs (.key primary, .value secondary).
+my @data = (3 => 'c'), (1 => 'a'), (3 => 'a'), (1 => 'b');
+is @data.sort({ .key, .value }).gist,
+   "(1 => a 1 => b 3 => a 3 => c)",
+   "multi-key sort of pairs by (.key, .value)";
+
+# Numeric keys must compare numerically inside the list, not stringwise.
+is (2, 10, 1, 20).map({ ($_,) }).sort.map(*.[0]).join(" "),
+   "1 2 10 20",
+   "singleton-list keys still sort numerically";


### PR DESCRIPTION
## Problem

A 1-arity `.sort` block that returns a *list* of keys is a multi-key
Schwartzian sort in Raku — the keys compare element-wise. mutsu got this
wrong:

```raku
say <01 11 111 2 20 02>.sort( { .Int, .comb.sum, .Str } );
# raku:  (01 02 2 11 20 111)
# mutsu: (01 11 111 02 2 20)   # sorted by the joined gist string
```

Root cause: `compare_values` (`src/runtime/utils/compare.rs`) had no arm for
list-like operands, so two list keys fell through to the string-gist fallback
`a.to_string_value().cmp(b.to_string_value())`.

## Fix

Add an early element-wise comparison when **both** operands are list-like
(Array/Seq/Slip), matching Raku's `cmp`/`<=>` on lists: the first differing
element decides, and a list that is a prefix of the other sorts `Less`. Only
both-list-like pairs change behaviour; mixed comparisons still fall through, so
the blast radius stays minimal.

This also fixes bare list `cmp`/`<=>`:

```raku
say (1,2) cmp (1,2,3);  # Less
say (2,)  cmp (10,);    # Less  (numeric, not stringwise)
```

Found via the `raku-doc/doc/Type/List.rakudoc` doc-diff sweep.

## Tests

- `t/sort-list-key.t` — new regression (multi-key sort, list cmp semantics, pairs).
- `make test` green (2236 files / 21055 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)