### PR TITLE
docs: record the BigFatRat representation gap (Math::Root 02/03)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1219,6 +1219,43 @@ the backlog.
 - Entry: `git checkout -b feat-bound-element-ro origin/main`. Related: §3 (substrate),
       [ADR-0001] container-repr, [ADR-0013] element cell provenance.
 
+### 8.8 A big FatRat has no distinct representation (deferred deep item — found 2026-07-22 by the Math::Root dist)
+
+- [ ] **A `FatRat` whose numerator or denominator overflows i64 collapses to the shared
+      `BigRat` value variant, losing its FatRat identity.** So `FatRat.new(10**40+5, 10**33).WHAT`
+      is `Rat` (via `types.rs`: `BigRat => "Rat"`) instead of `FatRat`, and a routine typed
+      `--> FatRat` that returns such a value fails its return type-check
+      (`Type check failed for return value; expected FatRat but got Rat`).
+- **Where it bites (Math::Root, thundergnat).** `t/01-integer.t` (75) now passes fully after
+      the min-fold fix (#5165) and the exact big-integer `round($scale)` fix (#5168). But
+      `t/02-rational.t` (67) and `t/03-triangular.t` (21) both die at their first `root(...)` call:
+      `root` is `sub root(...) --> FatRat` and its body is `FatRat.new(newton(...).round(10), 10**k)`
+      — the constructed value is a big rational that mutsu stores as `BigRat`, typed `Rat`, so the
+      `--> FatRat` check throws before any test runs. raku passes both files.
+- **Second, entangled facet — big-rational `.Str` digit budget.** A `BigRat` also can't pick the
+      right Rakudo `Rational.Str` digit budget, precisely *because* it can't tell a big Rat from a
+      big FatRat (they differ: `Rat.Str` = `chars(denom)+1` digits and **degrades the intermediate
+      to Num** when `fract*10^digits` overflows u64 — so `Rat.new(10**400, 9**999).Str` is `'0'`;
+      `FatRat.Str` = `chars(denom)+chars(whole)+5` digits and stays exact). The current
+      `display.rs` `BigRat` arm degrades any >20-digit-denominator BigRat to an f64 gist, which is
+      wrong for a moderate terminating FatRat like `FatRat.new(10**40+5, 10**33)` (prints `1e7`
+      instead of `10000000.000…005`). A naïve "render exactly / use the FatRat budget" fix
+      regresses the whitelisted `roast/S32-num/rat.t` test 856 (`Rat.new(10**400, 9**999).Str eq
+      '0'`), because that `'0'` is a *Rat*-specific consequence of the Num degradation. So the
+      display cannot be made correct for both without the type distinction either.
+- **Fix (ADR-worthy — a dedicated big-FatRat representation).** Add a `BigFatRat` value variant
+      (parallel to `BigRat`) threaded through the nanbox `Kind`, `encode`/`decode`/`peek`, the
+      `ValueView` enum, `types.rs` (→ `"FatRat"`), arithmetic (FatRat ops stay exact, never
+      degrade), and `display.rs` (FatRat budget, exact). This is high blast radius: ~150
+      `ValueView::BigRat` match sites plus the nanbox encoding. The existing
+      `format_rat_str_bigint(_, _, is_fatrat)` already implements both Rakudo budgets in BigInt
+      arithmetic, so display becomes a routing decision once the variant carries the FatRat bit.
+- **Landed this session (independent, general):** `#5165` (min/max fold a single iterable) and
+      `#5168` (`round($scale)` exact for big integers). Together they fix Math::Root `01-integer.t`.
+- Entry: `git checkout -b feat-bigfatrat-repr origin/main`. Related: §3 (substrate),
+      [ADR-0001] Value representation; `src/value/nanbox/`, `src/value/display.rs`,
+      `src/runtime/methods_object_native_ctors_buf_num.rs` (`build_native_fatrat_value`).
+
 ---
 
 ## Metrics

--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -64,24 +64,29 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 - repro: _(fill in a minimal repro + raku baseline before fixing)_
 - file: _(suspected parser/runtime file)_
 
-### T-025 — test_die [Math::Root] (partial: 2 of ≥4 fixed)  [impact: 1 dist]
+### T-025 — test_die [Math::Root] (01-integer.t DONE; 02/03 blocked on BigFatRat)  [impact: 1 dist]
 - dists: Math::Root
 - e.g. `Math::Root`: base=3 pass=0 fail=0 die=3 | t/01-integer.t
 - FIXED (#5160): (a) multi-dispatch with a `where` on an optional param —
   `multi iroot(Int() $i where * < 1e12, Int $n where * >= 2 = 2)` failed to match
   `iroot(5)` (the `where` was checked against the type object for the unsupplied
   `$n`); (b) `exp(Int, Int)` now exact (`exp(72,10)` = `10**72` Int, not `1e72` Num).
-  Tests 1-18 of t/01-integer.t now pass.
-- REMAINING (≥2 more bugs, dies at test 19 = `iroot(5**18)` → the `newton` path):
-  1. `min`/`max` over a single **lazy Seq** returns the Seq instead of reducing
-     (`min((5,3,8).Seq)` → `(5 3 8)`; a `Slip`/`List`/`Array` reduces fine, so
-     `extrema_from_values_generic`'s `as_list_items()` flatten misses a lazy Seq —
-     `.tail(2)` produces one). raku: 3.
-  2. The `…` sequence operator with **block endpoints**
-     (`{ ... } … { ... }`, the generator/limit-block form) in `newton`.
-  Repro for (1): `say min((5,3,8).Seq)` — raku 3, mutsu `(5 3 8)`.
-- file: runtime/builtins_collection_extrema.rs (min/max lazy-Seq flatten);
-  sequence-operator with block endpoints
+- FIXED (#5165): `min`/`max` over a single argument now folds it. The **real** root
+  cause was NOT `extrema_from_values_generic` but the single-arg native fast path
+  `native_function_1arg` (`min`/`max` arms), which only special-cased Hash/Array and
+  returned any other lone arg (a Seq) unchanged; it also mis-ordered non-Int arrays
+  with a stringwise compare. Removed both arms → falls through to `builtin_min`/`max`.
+- FIXED (#5168): `(17**1500).round(10)` returned `Inf` — the exact scaled-round helper
+  was i128-only and overflowed to an f64 round (BigInt → Inf). Added a BigInt fallback
+  (`exact_round_scaled_bigint`). This was the actual "bug #2" (NOT the `…` sequence
+  operator, which already works with block endpoints — verified newton standalone).
+- **`t/01-integer.t` (75) now passes fully** with #5160 + #5165 + #5168.
+- REMAINING (`t/02-rational.t` 67 + `t/03-triangular.t` 21): **blocked on a dedicated
+  `BigFatRat` representation** — `root(...)` is typed `--> FatRat` and returns a big
+  rational that mutsu stores as `BigRat` (typed `Rat`), so the return type-check throws.
+  See PLAN.md §8.8 for the full analysis and fix plan (high blast radius; ADR-worthy).
+- file: DONE parts — builtins/functions/dispatch_1arg.rs, builtins/arith/rat.rs;
+  remaining — value/nanbox + value/display.rs (BigFatRat variant, PLAN.md §8.8)
 
 ### T-027 — test_die [ObjectCache]  [impact: 1 dist]
 - dists: ObjectCache


### PR DESCRIPTION
## Summary

Records a hard, high-blast-radius finding surfaced by the **Math::Root** dist (T-025).

`t/01-integer.t` (75 tests) now passes fully after two independent fixes that landed this session:
- #5165 — `min()`/`max()` over a single iterable folds it (Seq / numeric arrays).
- #5168 — `.round($scale)` stays exact for large integers (BigInt path).

`t/02-rational.t` (67) and `t/03-triangular.t` (21) remain blocked: `root(...)` is
`sub root(...) --> FatRat`, and a `FatRat` whose components overflow i64 collapses to
mutsu's shared `BigRat` value variant (which types as `Rat`), so the `--> FatRat`
return type-check throws before any test runs.

## What this PR does

Docs-only. Adds **PLAN.md §8.8** with the full analysis:
- the type-identity gap (`BigRat` → `"Rat"`),
- the entangled `.Str` digit-budget facet (why a naïve display fix regresses the
  whitelisted `roast/S32-num/rat.t` test 856 — raku's `Rat.new(10**400,9**999).Str eq '0'`
  is a Rat-specific Num-degradation quirk), and
- the fix plan: a dedicated `BigFatRat` variant threaded through the nanbox `Kind`,
  `ValueView`, `types.rs`, arithmetic, and `display.rs` (ADR-worthy; ~150 match sites).

Also updates the **T-025** ticket to reflect the DONE parts and the remaining blocker.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)