### PR TITLE
fix: a literal-bound hash/array element is read-only

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1183,41 +1183,28 @@ the backlog.
       per-node result (`($((1,2).Seq),)` in raku), and `Supply`/`Slip`/`QuantHash` `.raku` rendering
       differs cosmetically (`Supply()` vs `Supply.new`, `slip(3)` vs `slip(3,)`).
 
-### 8.7 Bound-element immutability (READY-TO-IMPLEMENT — de-risked 2026-07-22; found by the Hash::Agnostic dist)
+### 8.7 Bound-element immutability (mostly LANDED 2026-07-22; only `.kv` remains)
 
-- [ ] **A hash/array element bound to an immutable value must become read-only.**
-      `%h<i> := 137; %h<i> = 666` must throw and leave the value `137`; mutsu silently overwrites
-      to `666`. Exact exceptions (confirmed vs raku): plain hash/array element → **`X::AdHoc`
-      "Cannot assign to an immutable value"**; tied hash → **`X::Assignment::RO` "Cannot modify an
-      immutable Int (137)"**. General, NOT tied-specific — a plain `my %h; %h<i> := 137; %h<i> = 666`
-      also fails to die in mutsu. Blocks Hash::Agnostic dist `t/01-basic.rakutest` subtests 4/5/6.
-- **ONE fix clears 4, 5 AND 6.** Verified: value slices already work in isolation (#5141), so 5 & 6
-      fail *only* as a cascade from subtest 4 corrupting `%h<i>` (its `dies-ok { %h<i> = 666 }`
-      silently succeeds → the later `:delete` returns 666 not 137, and elems counts drift).
-- **Mechanism gap.** mutsu's read-only tracking is NAME-based (`mark_readonly`/`is_readonly` over
-      `readonly_vars`); scalar bind-to-literal works via it (`vm_var_assign_set_local.rs:358-369`,
-      allowlist Int/BigInt/Num/Str/Bool/Rat/Complex + `bind_source.is_none()`). A bound *element* has
-      no variable name → no per-element RO. (The `.VAR.^name` cosmetic — mutsu `Scalar` vs raku `Int`
-      — is a SEPARATE deeper value-repr issue; the subtests need only the throw + value-preservation.)
-- **NOT the ADR-scale change first feared — option (b)'s side-set already exists.**
-      `src/vm/vm_var_index_tracking.rs` has `mark_bound_index`/`is_bound_index`/`remove_bound_index`
-      over an env key `__mutsu_bound_index::{var}` (a Hash side-set gated by
-      `env::elem_index_meta_possible()`), and the `:=` element bind already calls `mark_bound_index`
-      (`vm_var_assign_index_named.rs:1081` hash, `:1851` array). Plan: (1) add a parallel
-      `__mutsu_ro_index::{var}` trio (register the prefix in `src/env.rs:233`); (2) at the two bind
-      mark sites ALSO `mark_ro_index` when the bound value matches the immutable-literal allowlist;
-      (3) in the element-ASSIGN path near the `is_bound_index` check (`vm_var_assign_index_named.rs:796`,
-      + the multidim path `vm_var_multidim_ops.rs:792`) throw `X::Assignment::RO` (when the var holds a
-      tied `Instance` — reuse `instance_is_tied`) else `X::AdHoc`; (4) `remove_ro_index` on `:delete` /
-      whole-container reassign / splice, mirroring every `remove_bound_index` call site. Pin plain+tied,
-      hash+array. Element write path is hot — the `elem_index_meta_possible()` gate keeps it zero-cost
-      when no `:=` element bind exists.
-- **Then dist is 21/22; last = `.kv`:** returns `()` (raku yields the flattened k/v list). SEPARATE
-      pre-existing gap — the role's `method kv { Seq.new(KV.new(:backend(self), :iterator(...))) }` uses
-      a custom `KV` iterator instance and mutsu's `Seq.new(<custom Iterator instance>)` does not pull
-      from it (same family as the `from-iterator` gap fixed in #5132). Investigate independently.
-- Entry: `git checkout -b feat-bound-element-ro origin/main`. Related: §3 (substrate),
-      [ADR-0001] container-repr, [ADR-0013] element cell provenance.
+- [x] **A hash/array element bound to an immutable value is now read-only.**
+      `%h<i> := 137; %h<i> = 666` throws (`X::AdHoc` "Cannot assign to an immutable value" for a
+      plain hash/array; `X::Assignment::RO` "Cannot modify an immutable Int (137)" for a tied
+      hash) and leaves the value `137`. Implemented via **option (b): a per-variable
+      `__mutsu_ro_index::{var}` side set** (parallel to `__mutsu_bound_index`,
+      `src/vm/vm_var_index_tracking.rs`; gated by `elem_index_meta_possible()`). A `:=` bind to an
+      immutable scalar literal (Int/BigInt/Num/Str/Bool/Rat/Complex, no named source) marks the
+      element; the element-assign chokepoints consult it and throw. Covers the plain path
+      (`exec_index_assign_expr_named_op_inner` + the `try_fast_hash_element_assign` fast path) and
+      the tied path (the instance-dispatch that routes through `ASSIGN-KEY`/`BIND-KEY`, plus the
+      tied delegation where the literal-ness is otherwise lost). Whole-container reassign and
+      `:delete` clear the markers so the element becomes writable again. Also fixed: tied
+      multi-element slice `:delete` (`%h<d e f>:delete`) now deletes each key instead of passing
+      the whole slice array as one key. Pins: `t/bound-element-readonly.t`,
+      `t/tied-hash-bound-element.t`. Clears Hash::Agnostic dist subtests 4/5/6 (dist now 21/22).
+- [ ] **`.kv` on a Hash::Agnostic role returns `()`** (raku yields the flattened k/v list) — the
+      last Hash::Agnostic dist gap (subtest 13). Separate pre-existing issue: the role's
+      `method kv { Seq.new(KV.new(:backend(self), :iterator(self.keys.iterator))) }` uses a custom
+      `KV` iterator instance, and mutsu's `Seq.new(<custom Iterator instance>)` does not pull from
+      it (same family as the `from-iterator` gap fixed in #5132). Investigate independently.
 
 ---
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,34 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-22: bound-element immutability — a literal-bound hash/array element is read-only
+
+A hash or array element bound to an immutable literal is now read-only, matching raku:
+
+```
+my %h; %h<i> := 137; %h<i> = 666;   # was: silently 666
+                                     # now: throws X::AdHoc, %h<i> stays 137
+```
+
+The mechanism is a per-variable `__mutsu_ro_index::{var}` side set (parallel to
+`__mutsu_bound_index`, in `src/vm/vm_var_index_tracking.rs`, gated by
+`elem_index_meta_possible()` so it is zero-cost until some `:=` element bind of a literal
+happens). A `:=` bind to an immutable scalar literal (Int/BigInt/Num/Str/Bool/Rat/Complex,
+with no named container source — a bind to a mutable variable stays writable-through) marks
+the element; the element-assign chokepoints consult it and throw before mutating. Both the
+plain path (`exec_index_assign_expr_named_op_inner` and the `try_fast_hash_element_assign`
+fast path) and the tied path (a user `Associative` that routes the write through `ASSIGN-KEY`,
+where the literal-ness is otherwise lost across the `BIND-KEY` method delegation) are covered:
+a tied container yields `X::Assignment::RO` "Cannot modify an immutable Int (137)". Whole-
+container reassignment (`%h = (...)`) and `:delete` clear the markers so the element becomes
+writable again. Also fixed a related tied-hash bug: a multi-element slice `:delete`
+(`%h<d e f>:delete`) now deletes each key and returns the list of values, instead of passing
+the whole slice array to `DELETE-KEY` as a single (nonexistent) key.
+
+This clears subtests 4/5/6 of the `Hash::Agnostic` distribution's `t/01-basic.rakutest`
+(T-051; dist now 21/22, only `.kv` remains). Pins: `t/bound-element-readonly.t`,
+`t/tied-hash-bound-element.t`. See PLAN.md §8.7.
+
 ## 2026-07-22: `@a>>.Str` descends again — the hyper nodality set no longer includes the coercers
 
 Follow-up to the playground sweep below, which found this and deferred it because it touches

--- a/src/env.rs
+++ b/src/env.rs
@@ -233,6 +233,7 @@ pub(crate) fn note_env_key(key: &str) {
         } else if key.starts_with("__mutsu_bound_index::")
             || key.starts_with("__mutsu_elem_share::")
             || key.starts_with("__mutsu_deleted_index::")
+            || key.starts_with("__mutsu_ro_index::")
         {
             ELEM_INDEX_META_SEEN.store(true, Ordering::Relaxed);
         }

--- a/src/vm/vm_misc_assign.rs
+++ b/src/vm/vm_misc_assign.rs
@@ -11,6 +11,12 @@ impl Interpreter {
             _ => unreachable!("AssignExpr name must be a string constant"),
         };
         self.check_readonly_for_modify(&name)?;
+        // A whole-container reassignment breaks every `:=`-bound element, so drop
+        // the read-only-element markers (`%h<i> := 137; %h = (...)` makes `%h<i>`
+        // writable again). Covers the tied-STORE path below too.
+        if name.starts_with('%') || name.starts_with('@') {
+            self.clear_all_ro_index(&name);
+        }
         if name.starts_with('%')
             && self
                 .var_type_constraint_fast(&name)

--- a/src/vm/vm_var_assign_element.rs
+++ b/src/vm/vm_var_assign_element.rs
@@ -244,6 +244,14 @@ impl Interpreter {
                 return None;
             }
         }
+        // Reject if this key was `:=`-bound to an immutable literal (`%h<i> := 137`):
+        // the slow path must throw X::AdHoc / X::Assignment::RO, not overwrite it.
+        if crate::env::elem_index_meta_possible() {
+            let ro_key = self.stack[stack_len - 1].to_string_value();
+            if self.is_ro_index(var_name, &ro_key) {
+                return None;
+            }
+        }
         // Check that the variable exists in env as a plain Hash
         // and that it has no container type metadata
         let env = self.env();

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -369,6 +369,25 @@ impl Interpreter {
             };
             if let Some(method) = method {
                 let raw_val = self.stack.pop().unwrap_or(Value::NIL);
+                // A plain assign (`%h<i> = v`) to a tied element that was
+                // `:=`-bound to an immutable literal must throw, even though the
+                // tied container routes the write through ASSIGN-KEY (so it never
+                // reaches the plain-container RO check further below). The bind
+                // recorded a `__mutsu_ro_index` marker against the outer variable.
+                if !is_bind && self.is_ro_index(&var_name, &Self::encode_bound_index(&idx)) {
+                    let key_arg = match idx.view() {
+                        ValueView::Array(items, _) if items.len() == 1 => items[0].clone(),
+                        _ => idx.clone(),
+                    };
+                    let cur = self
+                        .call_method_with_values(target.clone(), "AT-KEY", vec![key_arg])
+                        .unwrap_or(Value::NIL);
+                    let tn = crate::runtime::utils::value_type_name(&cur);
+                    return Err(RuntimeError::assignment_ro_typename(
+                        tn,
+                        &cur.to_string_value(),
+                    ));
+                }
                 // Unwrap the bind marker so neither BIND-KEY nor the ASSIGN
                 // fallback stores the internal wrapper pair as the value.
                 let (val, _bind_source) = Self::unwrap_bind_index_value(raw_val);
@@ -389,6 +408,29 @@ impl Interpreter {
                     _ => val.clone(),
                 };
                 self.call_method_with_values(target, method, vec![idx_arg, val_arg])?;
+                // A `:=` bind of an immutable literal into a tied container
+                // (`%h<i> := 137` where %h does Associative) makes that element
+                // read-only, just like a plain hash element bind. The literal-ness
+                // is known here but lost across the BIND-KEY method delegation, so
+                // record it against the OUTER variable — a later plain `%h<i> = v`
+                // (which has no ASSIGN-KEY and falls through to the check below)
+                // then throws instead of writing through the backing cell.
+                if method == "BIND-KEY"
+                    && _bind_source.is_none()
+                    && matches!(
+                        val.view(),
+                        ValueView::Int(_)
+                            | ValueView::BigInt(_)
+                            | ValueView::Num(_)
+                            | ValueView::Str(_)
+                            | ValueView::Bool(_)
+                            | ValueView::Rat(..)
+                            | ValueView::Complex(..)
+                    )
+                {
+                    let enc = Self::encode_bound_index(&idx);
+                    self.mark_ro_index(&var_name, enc);
+                }
                 self.stack.push(val);
                 return Ok(());
             }
@@ -545,6 +587,25 @@ impl Interpreter {
         } else {
             val
         };
+        // A `:=` element bind to an immutable literal (`%h<i> := 137`,
+        // `@a[0] := 137`) makes that element read-only: a later plain `=`
+        // assignment must throw rather than write through the shared cell. Same
+        // allowlist as the scalar literal-bind RO (vm_var_assign_set_local.rs):
+        // pure immutable scalar kinds, and no named container source (a bind to
+        // a variable stays writable-through). Marked after the store completes;
+        // consulted at the element-assign chokepoint below.
+        let is_literal_ro_bind = bind_mode
+            && bind_sources.iter().all(|s| s.is_none())
+            && matches!(
+                val.view(),
+                ValueView::Int(_)
+                    | ValueView::BigInt(_)
+                    | ValueView::Num(_)
+                    | ValueView::Str(_)
+                    | ValueView::Bool(_)
+                    | ValueView::Rat(..)
+                    | ValueView::Complex(..)
+            );
         // `$vec[1] = x` / `$vec[1]--` on an `is Array` subclass instance held in
         // a scalar: write into the backing `__mutsu_array_storage` element in
         // place, instead of the associative path treating the instance as a hash
@@ -776,6 +837,34 @@ impl Interpreter {
         // container and cannot call `self`; the marker is cleared after the store.
         let elem_is_value_share =
             !bind_mode && self.array_share_active && self.is_element_share(&var_name, &encoded_idx);
+        // A plain `=` assignment to an element that was `:=`-bound to an immutable
+        // literal (`%h<i> := 137; %h<i> = 666`) must throw, not write through the
+        // shared cell. Checked before any container mutation so the bound value is
+        // preserved. A tied container yields X::Assignment::RO ("Cannot modify an
+        // immutable ..."), a plain hash/array yields X::AdHoc ("Cannot assign to an
+        // immutable value") — matching raku.
+        if !bind_mode && self.is_ro_index(&var_name, &encoded_idx) {
+            let is_tied = self
+                .env()
+                .get(&var_name)
+                .cloned()
+                .is_some_and(|c| self.instance_is_tied(&c));
+            if is_tied {
+                let ro_key = idx.to_string_value();
+                let (tn, disp) = match self.env().get(&var_name).map(Value::view) {
+                    Some(ValueView::Hash(hd)) => match hd.map.get(&ro_key) {
+                        Some(v) => (
+                            crate::runtime::utils::value_type_name(v),
+                            v.to_string_value(),
+                        ),
+                        None => ("Int", String::new()),
+                    },
+                    _ => ("Int", String::new()),
+                };
+                return Err(RuntimeError::assignment_ro_typename(tn, &disp));
+            }
+            return Err(RuntimeError::new("Cannot assign to an immutable value"));
+        }
         // Native typed arrays store unboxed scalars and cannot bind containers to
         // their elements: `my num @a; @a[0] := $x` is illegal.
         if bind_mode
@@ -1988,6 +2077,11 @@ impl Interpreter {
                 }
                 for encoded in range_initialized_marks {
                     self.mark_initialized_index(&var_name, encoded);
+                }
+                // A `:=` bind to an immutable literal locks the element read-only
+                // (see `is_literal_ro_bind`); record it so a later plain `=` throws.
+                if is_literal_ro_bind {
+                    self.mark_ro_index(&var_name, encoded_idx.clone());
                 }
                 // Slice 2b: a `=`-shared element just reassigned with a non-share
                 // value has been replaced by a plain value — drop the share

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -9,6 +9,15 @@ impl Interpreter {
         idx: u32,
     ) -> Result<(), RuntimeError> {
         let idx = idx as usize;
+        // A whole `%`/`@` reassignment breaks every `:=`-bound element — drop the
+        // read-only-element markers so a later `%h<k> = v` is writable again.
+        if crate::env::elem_index_meta_possible() {
+            let name = &code.locals[idx];
+            if name.starts_with('%') || name.starts_with('@') {
+                let name = name.clone();
+                self.clear_all_ro_index(&name);
+            }
+        }
         // Slice 2a/2b: `$scalar = @arr` / chained `$r = $q` reassignment (the
         // VarDecl form goes through `exec_set_local_op`). Promote the source
         // container to a shared `ContainerRef` cell so structural mutation through
@@ -747,7 +756,7 @@ impl Interpreter {
 
     /// True when `instance` is a tied container: a user `STORE` method plus a
     /// composed `Associative`/`Positional` role.
-    fn instance_is_tied(&mut self, instance: &Value) -> bool {
+    pub(super) fn instance_is_tied(&mut self, instance: &Value) -> bool {
         let ValueView::Instance { class_name, .. } = instance.view() else {
             return false;
         };

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -278,6 +278,16 @@ impl Interpreter {
         idx: u32,
     ) -> Result<(), RuntimeError> {
         let idx = idx as usize;
+        // A whole `%`/`@` (re)assignment or rebind replaces the container, breaking
+        // every `:=`-bound element — drop the read-only-element markers so a later
+        // `%h<k> = v` is writable again (`%h<i> := 137; %h = (...)`).
+        if crate::env::elem_index_meta_possible() {
+            let name = &code.locals[idx];
+            if name.starts_with('%') || name.starts_with('@') {
+                let name = name.clone();
+                self.clear_all_ro_index(&name);
+            }
+        }
         let raw_popped = self.stack.pop().unwrap_or(Value::NIL);
         // Check if we're trying to write to a private instance attribute (!attr)
         // when self is a type object (not an instance). Raku says this should die.

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -100,6 +100,14 @@ impl Interpreter {
         if self.var_type_constraint_fast(var_name).is_some() || self.is_readonly(var_name) {
             return None;
         }
+        // A `:=`-bound-to-literal key must clear its read-only marker on delete;
+        // route it to the slow path (which calls `unmark_ro_indices`) so a later
+        // re-bind/assign of the same key is not stale.
+        if crate::env::elem_index_meta_possible()
+            && self.is_ro_index(var_name, &idx.to_string_value())
+        {
+            return None;
+        }
         let env = self.env();
         match env.get(var_name).map(Value::view) {
             Some(ValueView::Hash(hash_arc)) => {
@@ -226,6 +234,30 @@ impl Interpreter {
                 None
             };
             if let Some(m) = method {
+                // A multi-element subscript (`%h<e f>:delete` / `$q[1,2]:delete`)
+                // is a SLICE: the protocol method takes ONE key/index, so call it
+                // per element and return the list of deleted values. A one-element
+                // list unwraps to the bare key (a single scalar result).
+                let slice_keys: Option<Vec<Value>> = match idx.view() {
+                    ValueView::Array(items, _) if items.len() != 1 => {
+                        Some(items.iter().cloned().collect())
+                    }
+                    ValueView::Seq(items) | ValueView::Slip(items) if items.len() != 1 => {
+                        Some(items.iter().cloned().collect())
+                    }
+                    _ => None,
+                };
+                if let Some(keys) = slice_keys {
+                    let mut results = Vec::with_capacity(keys.len());
+                    for k in keys {
+                        results.push(self.call_method_with_values(target.clone(), m, vec![k])?);
+                    }
+                    self.stack.push(Value::array_with_kind(
+                        crate::gc::Gc::new(crate::value::ArrayData::new(results)),
+                        crate::value::ArrayKind::List,
+                    ));
+                    return Ok(());
+                }
                 let idx_arg = match idx.view() {
                     ValueView::Array(items, _) if items.len() == 1 => items[0].clone(),
                     ValueView::Seq(items) | ValueView::Slip(items) if items.len() == 1 => {
@@ -428,6 +460,9 @@ impl Interpreter {
         self.mark_deleted_indices(&var_name, &idx_for_unmark);
         // Remove deleted indices from the bound-index tracking set to sever bindings.
         self.unmark_bound_indices(&var_name, &idx_for_unmark);
+        // Deleting a `:=`-bound-to-literal element frees its key: clear the RO
+        // marker so a later re-bind (or re-assign) of the same key is not stale.
+        self.unmark_ro_indices(&var_name, &idx_for_unmark);
         // Trim trailing holes from arrays after deletion.
         // A "hole" is either Nil (deleted) or an uninitialized Package("Any") slot.
         self.trim_trailing_array_holes(&var_name);
@@ -532,6 +567,7 @@ impl Interpreter {
         self.unmark_initialized_indices(var_name, &flat_idx);
         self.mark_deleted_indices(var_name, &flat_idx);
         self.unmark_bound_indices(var_name, &flat_idx);
+        self.unmark_ro_indices(var_name, &flat_idx);
         self.trim_trailing_array_holes(var_name);
         if let Some(container) = self.env().get(var_name).cloned() {
             self.write_local_slot_or_name(code, slot, var_name, container);

--- a/src/vm/vm_var_index_tracking.rs
+++ b/src/vm/vm_var_index_tracking.rs
@@ -93,6 +93,68 @@ impl Interpreter {
         }
     }
 
+    /// Mark element `encoded` of `var_name` as read-only. Set when an element is
+    /// `:=`-bound to an immutable literal (`%h<i> := 137` / `@a[0] := 137`): a
+    /// later plain `=` assignment to that element must throw rather than write
+    /// through the shared cell. Parallel to `mark_bound_index` but a distinct
+    /// side-set (a `:=` bind to a *container source* is writable-through, so only
+    /// the literal-bind subset lands here). See PLAN.md §8.7.
+    pub(super) fn mark_ro_index(&mut self, var_name: &str, encoded: String) {
+        let key = format!("__mutsu_ro_index::{}", var_name);
+        if let Some(entry) = self.env_mut().get_mut(&key)
+            && entry
+                .with_hash_mut(|map| {
+                    crate::gc::Gc::make_mut(map).insert(encoded.clone(), Value::TRUE);
+                })
+                .is_some()
+        {
+            return;
+        }
+        let mut map = std::collections::HashMap::new();
+        map.insert(encoded, Value::TRUE);
+        self.env_mut().insert(key, Value::hash(map));
+    }
+
+    pub(super) fn is_ro_index(&self, var_name: &str, encoded: &str) -> bool {
+        // Runs on every element write; see `is_bound_index` for the gate rationale.
+        if !crate::env::elem_index_meta_possible() {
+            return false;
+        }
+        let key = format!("__mutsu_ro_index::{}", var_name);
+        if let Some(ValueView::Hash(map)) = self.env().get(&key).map(Value::view) {
+            map.contains_key(encoded)
+        } else {
+            false
+        }
+    }
+
+    /// Drop the entire read-only-index side table for `var_name` — used when the
+    /// whole `%`/`@` variable is reassigned (`%h = (...)`), which breaks every
+    /// element binding, so a later `%h<k> = v` must be writable again.
+    pub(super) fn clear_all_ro_index(&mut self, var_name: &str) {
+        if !crate::env::elem_index_meta_possible() {
+            return;
+        }
+        let key = format!("__mutsu_ro_index::{}", var_name);
+        self.env_mut().remove(&key);
+    }
+
+    /// Remove a read-only-index marker for the indices addressed by `idx`
+    /// (scalar / slice / range). Mirror of `unmark_bound_indices`.
+    pub(super) fn unmark_ro_indices(&mut self, var_name: &str, idx: &Value) {
+        if !crate::env::elem_index_meta_possible() {
+            return;
+        }
+        let key = format!("__mutsu_ro_index::{}", var_name);
+        let Some(entry) = self.env_mut().get_mut(&key) else {
+            return;
+        };
+        entry.with_hash_mut(|map| {
+            let m = crate::gc::Gc::make_mut(map);
+            Self::unmark_index_entries(m, idx);
+        });
+    }
+
     /// Remove a bound-index marker (e.g. after splice breaks the binding).
     pub(super) fn remove_bound_index(&mut self, var_name: &str, encoded: &str) {
         if !crate::env::elem_index_meta_possible() {

--- a/t/bound-element-readonly.t
+++ b/t/bound-element-readonly.t
@@ -1,0 +1,78 @@
+use Test;
+
+# A `:=` bind of an element to an immutable literal makes that element
+# read-only: a later plain `=` assignment must throw and preserve the value.
+# See PLAN.md §8.7 / T-051 (Hash::Agnostic tied hash).
+
+plan 20;
+
+# --- plain hash element ---------------------------------------------------
+{
+    my %h;
+    %h<i> := 137;
+    is %h<i>, 137, 'hash element bound to literal reads back the literal';
+    dies-ok { %h<i> = 666 }, 'assign to literal-bound hash element dies';
+    is %h<i>, 137, 'hash element value preserved after failed assign';
+    is %h<i>:delete, 137, 'literal-bound hash element deletes to its value';
+}
+
+# --- plain array element --------------------------------------------------
+{
+    my @a;
+    @a[0] := 137;
+    is @a[0], 137, 'array element bound to literal reads back the literal';
+    dies-ok { @a[0] = 9 }, 'assign to literal-bound array element dies';
+    is @a[0], 137, 'array element value preserved after failed assign';
+}
+
+# --- string literal bind --------------------------------------------------
+{
+    my %s;
+    %s<k> := "hi";
+    dies-ok { %s<k> = "bye" }, 'assign to string-literal-bound element dies';
+    is %s<k>, "hi", 'string-literal-bound element value preserved';
+}
+
+# --- other keys stay writable --------------------------------------------
+{
+    my %h;
+    %h<i> := 137;
+    %h<j> = 5;
+    is %h<j>, 5, 'a different (unbound) key stays writable';
+    lives-ok { %h<j> = 6 }, 'reassigning an unbound key lives';
+    is %h<j>, 6, 'unbound key reassignment takes effect';
+}
+
+# --- whole-container reassignment breaks the binding ---------------------
+{
+    my %h;
+    %h<i> := 137;
+    %h = (i => 5, j => 9);
+    lives-ok { %h<i> = 666 }, 'whole-hash reassign makes the element writable again';
+    is %h<i>, 666, 'element writable after whole-hash reassign';
+}
+{
+    my @a;
+    @a[0] := 137;
+    @a = (1, 2, 3);
+    lives-ok { @a[0] = 9 }, 'whole-array reassign makes the element writable again';
+    is @a[0], 9, 'element writable after whole-array reassign';
+}
+
+# --- delete frees the read-only marker -----------------------------------
+{
+    my %g;
+    %g<x> := 10;
+    %g<x>:delete;
+    lives-ok { %g<x> = 99 }, 'a deleted literal-bound key becomes writable';
+    is %g<x>, 99, 'reassignment after delete takes effect';
+}
+
+# --- binding to a mutable variable stays writable-through ----------------
+{
+    my $v = 5;
+    my %h;
+    %h<k> := $v;
+    lives-ok { %h<k> = 6 }, 'element bound to a mutable variable stays writable';
+    is %h<k>, 6, 'write-through updates the element';
+}

--- a/t/tied-hash-bound-element.t
+++ b/t/tied-hash-bound-element.t
@@ -1,0 +1,35 @@
+use Test;
+
+# Tied (user Associative) hash: a `:=` bind to an immutable literal makes the
+# element read-only even though the write routes through ASSIGN-KEY; and a
+# multi-element `:delete` slice deletes each key. Modeled on the Hash::Agnostic
+# distribution's t/01-basic.rakutest (T-051).
+
+plan 8;
+
+class MyHash does Associative {
+    has %!hash;
+    method AT-KEY($key)          is raw { %!hash.AT-KEY($key)         }
+    method BIND-KEY($key,\value) is raw { %!hash.BIND-KEY($key,value) }
+    method EXISTS-KEY($key)             { %!hash.EXISTS-KEY($key)     }
+    method DELETE-KEY($key)             { %!hash.DELETE-KEY($key)     }
+    method ASSIGN-KEY($key,\value) is raw { self.AT-KEY($key) = value }
+    method keys()                       { %!hash.keys                 }
+}
+
+my %h is MyHash;
+
+# --- bound-element read-only (routes through ASSIGN-KEY) ------------------
+is (%h<i> := 137), 137, 'can bind a literal to a tied element';
+is %h<i>, 137, 'tied bound element reads back the literal';
+dies-ok { %h<i> = 666 }, 'assign to a literal-bound tied element dies';
+is %h<i>, 137, 'tied bound element value preserved after failed assign';
+is %h<i>:delete, 137, 'tied bound element deletes to its value';
+
+# --- multi-element slice delete ------------------------------------------
+%h<d> = 628;
+%h<e> = 271;
+%h<f> = 6;
+is-deeply %h<d e f>:exists, (True, True, True), 'tied slice :exists';
+is-deeply %h<d e f>:delete, (628, 271, 6), 'tied slice :delete returns each value';
+is-deeply %h<d e f>:exists, (False, False, False), 'tied slice deleted';


### PR DESCRIPTION
## Summary

A hash or array element bound to an immutable literal is now read-only, matching raku:

```raku
my %h; %h<i> := 137; %h<i> = 666;   # was: silently 666
                                     # now: throws X::AdHoc, %h<i> stays 137
```

mutsu previously wrote through the shared cell and silently overwrote the bound value.

## Mechanism

Option (b) from PLAN.md §8.7: a per-variable `__mutsu_ro_index::{var}` side set (parallel to `__mutsu_bound_index`, in `vm_var_index_tracking.rs`), gated by `elem_index_meta_possible()` so it stays **zero-cost** until some `:=` element bind of a literal happens. A `:=` bind to an immutable scalar literal (Int/BigInt/Num/Str/Bool/Rat/Complex, with no named container source — a bind to a mutable variable stays writable-through) marks the element; the element-assign chokepoints consult it and throw before mutating.

Covers:
- **Plain path** (`exec_index_assign_expr_named_op_inner` + the `try_fast_hash_element_assign` fast path) → `X::AdHoc` *"Cannot assign to an immutable value"*.
- **Tied path** (a user `Associative` routing writes through `ASSIGN-KEY`, where the literal-ness is otherwise lost across the `BIND-KEY` method delegation) → `X::Assignment::RO` *"Cannot modify an immutable Int (137)"*.

Whole-container reassignment (`%h = (...)`) and `:delete` clear the markers so the element becomes writable again. Also fixes a related tied-hash bug: a multi-element slice `:delete` (`%h<d e f>:delete`) now deletes each key and returns the list of values, instead of passing the whole slice array to `DELETE-KEY` as one (nonexistent) key.

## Impact

Clears subtests 4/5/6 of the `Hash::Agnostic` distribution's `t/01-basic.rakutest` (T-051; dist now 21/22, only `.kv` remains).

## Tests

- `t/bound-element-readonly.t` (20 assertions, plain hash/array, whole-reassign clear, delete clear, mutable-var write-through)
- `t/tied-hash-bound-element.t` (8 assertions, tied bound-RO via ASSIGN-KEY + tied slice delete) — verified byte-identical to `raku`
- `make test` PASS (2239 files, 21095 tests); targeted roast (S02-types/hash, S32-hash/{delete,adverbs,delete-adverb,exists-adverb,hyperslice}, S03-operators/{assign-is-not-binding,subscript-adverbs}, S09-typed-arrays/arrays, S04-declarations/constant) all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)