### PR TITLE
fix: a bare block binds to a role's &callable type parameter

### DIFF
--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -37,7 +37,23 @@ impl Interpreter {
                 values.push(Value::package(Symbol::intern(trimmed)));
                 continue;
             }
-            match crate::parse_dispatch::parse_source(expr)
+            // A bare block-literal argument (`R[{ .<id> // die }]`) must bind to a
+            // `&callable` param as the Block itself. Evaluated as a *statement*, a
+            // bare `{ ... }` is a block that mutsu immediately *executes* (yielding
+            // its body's value, or dying), so `role R[&f]; class A does R[{ 1 }]`
+            // saw an `Int`, not a `Callable`, and matched no candidate. Wrap it in
+            // parens to force expression context, where `{ ... }` is a Block term.
+            let expr_owned;
+            let eval_expr = {
+                let t = expr.trim();
+                if t.starts_with('{') && t.ends_with('}') {
+                    expr_owned = format!("({t})");
+                    expr_owned.as_str()
+                } else {
+                    expr.as_str()
+                }
+            };
+            match crate::parse_dispatch::parse_source(eval_expr)
                 .and_then(|(stmts, _)| self.eval_block_value(&stmts))
             {
                 Ok(value) => values.push(value),
@@ -208,8 +224,22 @@ impl Interpreter {
                 &arg_values,
             );
             let mut resolved = Vec::with_capacity(selected.type_params.len());
-            for param_name in &selected.type_params {
-                let value = self.env.get(param_name).cloned().unwrap_or(Value::NIL);
+            for (i, param_name) in selected.type_params.iter().enumerate() {
+                // `type_params` are sigil-less (`f`), but `bind_function_args_values`
+                // stores a callable param under its full name (`&f`) — only `$`/`@`/`%`
+                // sigils are stripped. Fall back to the ParamDef's own name so a
+                // `role R[&f]` param resolves to its bound Callable, not `Nil`.
+                let value = self
+                    .env
+                    .get(param_name)
+                    .or_else(|| {
+                        selected
+                            .type_param_defs
+                            .get(i)
+                            .and_then(|pd| self.env.get(&pd.name))
+                    })
+                    .cloned()
+                    .unwrap_or(Value::NIL);
                 resolved.push(value);
             }
             self.env = saved_env;

--- a/src/runtime/undeclared_routines.rs
+++ b/src/runtime/undeclared_routines.rs
@@ -273,8 +273,18 @@ fn walk_stmt(stmt: &Stmt, scan: &mut Scan) {
             scan.declare(&name.resolve());
             walk_stmts(body, scan);
         }
-        Stmt::RoleDecl { name, body, .. } => {
+        Stmt::RoleDecl {
+            name,
+            type_params,
+            type_param_defs,
+            body,
+            ..
+        } => {
             scan.declare(&name.resolve());
+            // A callable role type parameter (`role R[&f]`) is in scope in the
+            // body as the bare routine `f`, so seed it before scanning the body
+            // (otherwise `method m { f() }` is flagged as an undeclared routine).
+            walk_params(type_params, type_param_defs, scan);
             walk_stmts(body, scan);
         }
         Stmt::SubsetDecl {

--- a/t/role-block-callable-arg.t
+++ b/t/role-block-callable-arg.t
@@ -1,0 +1,32 @@
+use Test;
+
+# A bare block literal passed as a parametric-role argument must bind to a
+# `&callable` type parameter as the Block itself. Evaluated as a statement a
+# bare `{ ... }` is a block that executes immediately, so
+# `role R[&f]; class A does R[{ 1 }]` used to see an Int (or die) and match no
+# role candidate.
+
+plan 6;
+
+role RCall[&f] { method apply(|c) { f(|c) } }
+
+class A1 does RCall[{ 42 }] { }
+is A1.new.apply, 42, 'bare block binds to &f and is callable from the role';
+
+class A2 does RCall[{ $^n * 2 }] { }
+is A2.new.apply(21), 42, 'block with a placeholder param works as &f';
+
+class A3 does RCall[{ .<id> // die "no id" }] { }
+is A3.new.apply({ id => 7 }), 7, 'block reading its argument (a hash) works as &f';
+dies-ok { A3.new.apply({}) }, 'the block still dies when its own logic dies';
+
+# Non-block callable arguments keep working (regression guard).
+sub named-sub { 99 }
+class A4 does RCall[&named-sub] { }
+is A4.new.apply, 99, '&sub-ref still binds to &f';
+
+my &blk = { 100 };
+class A5 does RCall[&blk] { }
+is A5.new.apply, 100, 'a &-sigil variable still binds to &f';
+
+done-testing;


### PR DESCRIPTION
## Problem

A parametric role with a `&callable` type parameter could not be given a bare
block literal:

```raku
role R[&f] { method apply(|c) { f(|c) } }
class A does R[{ 42 }] { }
say A.new.apply;   # was an error; now 42
```

Three distinct bugs stacked up:

1. **Argument evaluated as a statement.** The role argument string `{ 1 }` was
   parsed and evaluated as a *statement*, where a bare `{ ... }` is a block that
   mutsu **executes immediately** (yielding its body value, or dying). So the
   role saw an `Int`, not a `Callable`, and matched no candidate. Fixed by
   evaluating a block-literal argument in expression context (`({ ... })`).

2. **`Undeclared routine: f` in the body.** The undeclared-routine scan seeded a
   sub's/method's signature params but not a `RoleDecl`'s type parameters, so
   `method m { f() }` was rejected at compile time. Fixed by seeding them.

3. **`&f` resolved to `Nil` at runtime.** `bind_function_args_values` stores a
   callable param under its full name (`&f` — only `$`/`@`/`%` are stripped),
   but the role-concretization loop looked it up by the sigil-less `f`. Fixed by
   falling back to the ParamDef's own name.

## Result

`f(...)` is now callable inside the role body, and a bare block, a `&`-sigil
variable, and a `&sub` reference all bind. (Reading `&f` as a bare *value* —
rather than calling it — remains a separate, pre-existing gap, untouched here.)

Surfaced by the **ObjectCache** dist (T-027), which uses
`class Article does ObjectCache[{ .<id> // die }]`. ObjectCache itself still does
not fully load — its role body is written in `nqp::` ops (`nqp::hash`,
`nqp::atkey`, …) that mutsu does not implement — so this is a general fix, not a
full unblock of that dist.

## Test

`t/role-block-callable-arg.t` (6 subtests) — bare block / placeholder block /
topic-hash block / a block that dies / `&sub` ref / `&`-variable. All match raku.

🤖 Generated with [Claude Code](https://claude.com/claude-code)