### PR TITLE
fix: accept `plan *` (a Whatever plan) instead of dying

### DIFF
--- a/src/runtime/test_functions/basic.rs
+++ b/src/runtime/test_functions/basic.rs
@@ -191,6 +191,15 @@ impl Interpreter {
             self.halted = true;
         } else {
             let count = Self::positional_value_required(args, 0, "plan expects count")?;
+            // `plan *` (a Whatever): the test count is unknown up front, so emit
+            // no `1..N` header. Leave the plan unset (like never calling `plan`) —
+            // the file's trailing `done-testing` emits `1..ran`, and without it no
+            // header is emitted, matching Rakudo. Used by files that compute their
+            // assertion count only as they run.
+            if matches!(count.view(), ValueView::Whatever) {
+                self.tap.ensure_state();
+                return Ok(Value::NIL);
+            }
             let planned = match count.view() {
                 ValueView::Int(i) if i >= 0 => i as usize,
                 ValueView::BigInt(i) => {

--- a/t/plan-whatever.t
+++ b/t/plan-whatever.t
@@ -1,0 +1,14 @@
+use Test;
+
+# `plan *` (a Whatever plan) means the test count is unknown up front: no
+# `1..N` header is emitted, and the run must not die with "plan expects Int".
+# The trailing count comes from `done-testing` (exercised here), matching raku.
+
+plan *;
+
+ok 1, 'first assertion after plan *';
+ok 2 == 2, 'second assertion';
+is 3, 3, 'is works under plan *';
+nok False, 'nok works under plan *';
+
+done-testing;


### PR DESCRIPTION
## Problem

```raku
use Test;
plan *;        # was: "plan expects Int" → the whole file aborts, ran 0
ok 1;
done-testing;
```

`plan *` declares a test file whose assertion count is unknown up front (it is
computed as the file runs). mutsu rejected the `Whatever` argument with
`plan expects Int`, so the file died before any assertion executed.

## Fix

Accept a `Whatever` argument to `plan` as a no-op: emit no `1..N` header and
leave the plan unset. The file's trailing `done-testing` then emits `1..ran`
(and, without a `done-testing`, no header is emitted) — matching Rakudo exactly.

## Impact

Surfaced by **Lingua::EN::Numbers** (T-036), whose `t/00-cardinal.t` opens with
`plan *;`. The file now runs (the dist still has further, unrelated
cardinal-word bugs, so it does not fully pass).

## Test

`t/plan-whatever.t` — `plan *` followed by `ok`/`is`/`nok` and `done-testing`;
output matches raku.

🤖 Generated with [Claude Code](https://claude.com/claude-code)