### PR TITLE
fix: reify a lazy Seq before coercing it to a Hash (gather/map assignment)

### DIFF
--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -89,6 +89,16 @@ impl Interpreter {
         {
             return crate::runtime::utils::coerce_to_hash(listed);
         }
+        // A lazy sequence (e.g. `%h = gather { take ... }` or `%h = ....map(...)`)
+        // must be reified before it can be split into key/value pairs. Without
+        // forcing, `coerce_to_hash` falls to its `_` arm and stringifies the whole
+        // unreified LazyList into a single bogus key. Force it into an eager Seq
+        // first, matching Raku (assignment to a `%` container is eager).
+        if let ValueView::LazyList(ll) = value.view()
+            && let Ok(items) = self.force_lazy_list(&ll)
+        {
+            return crate::runtime::utils::coerce_to_hash(Value::seq(items));
+        }
         crate::runtime::utils::coerce_to_hash(value)
     }
 

--- a/t/hash-assign-lazy-seq.t
+++ b/t/hash-assign-lazy-seq.t
@@ -1,0 +1,31 @@
+use v6;
+use Test;
+
+plan 8;
+
+# Assigning a lazy sequence (gather / map) to a % container must reify it
+# before splitting into key/value pairs. Previously the unreified LazyList
+# stringified into a single bogus key ({ => Nil}).
+
+my %h = gather { take 'foo' => 1; take 'bar' => 2 };
+is %h<foo>, 1, 'gather of pairs into a Hash: foo';
+is %h<bar>, 2, 'gather of pairs into a Hash: bar';
+
+my %kv = gather { take 'a'; take 1; take 'b'; take 2 };
+is %kv<a>, 1, 'gather of alternating key/value into a Hash: a';
+is %kv<b>, 2, 'gather of alternating key/value into a Hash: b';
+
+my %m = (1..3).map({ $_ => $_ * $_ });
+is %m{3}, 9, 'map producing pairs into a Hash';
+
+my $seq = gather { take 'x' => 10; take 'y' => 20 };
+my %s = $seq;
+is %s<y>, 20, 'lazy Seq bound to a scalar then assigned to a Hash';
+
+# The lazy seq must not lose elements.
+my %big = gather { take $_ => $_ for 1..10 };
+is %big.elems, 10, 'all gathered pairs survive the assignment';
+
+# An empty gather yields an empty hash.
+my %e = gather { };
+is %e.elems, 0, 'empty gather is the empty hash';


### PR DESCRIPTION
## Problem

```raku
my %h = gather { take "foo" => 1; take "bar" => 2 };
say %h;   # raku: {bar => 2, foo => 1}   mutsu: { => Nil}
```

`gather { ... }` returns an unreified `LazyList`. `coerce_to_hash` has arms for
`Hash`/`Array`/`Seq`/`Pair`/… but not `LazyList`, so the lazy value fell to the
`_` catch-all which stringifies the whole object into a single key
(`value.to_string_value() => Nil`).

## Fix

In `coerce_object_to_hash`, force a `LazyList` into an eager `Seq` (via
`force_lazy_list`) before delegating to `coerce_to_hash`. Assignment to a `%`
container is eager in Raku, so this is the correct point to reify. The same bug
affected any lazy producer assigned to a hash, e.g. `%h = (1..3).map({ $_ => $_ })`.

## Tests

- `t/hash-assign-lazy-seq.t` — gather-of-pairs, alternating key/value, map→hash,
  lazy-Seq-via-scalar, element preservation, empty gather.
- Related suites (`gather-lazy`, `gather-returns-seq`, `finite-gather-pipe-reify`,
  `concurrent-hash-assign`) still green.

Found via the raku-doc/doc/Language/control.rakudoc doc-diff sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)