### PR TITLE
fix: single-element reduce returns the coerced element, not identity op elem

### DIFF
--- a/src/runtime/builtins_reduce.rs
+++ b/src/runtime/builtins_reduce.rs
@@ -139,13 +139,18 @@ impl Interpreter {
             return Ok(Value::NIL);
         }
         if items.len() == 1 {
-            // For numeric infix operators (e.g. `reduce &infix:<+>, "2"`), apply
-            // the identity element + the single element so that coercions happen.
+            // A single-element reduce returns the element's *value* coerced to the
+            // operator's natural type — NOT `identity op elem` (that would negate
+            // for `-`, invert for `/`, etc.). Raku: `[+] "2"` is `2` (Int), `[-] 10`
+            // is `10`, `[~] 5` is `"5"` (Str). Numeric operators coerce the element
+            // to Numeric; `~` (and other string ops) coerce to Str; everything else
+            // (e.g. `[,]`, `[max]`, chaining ops) returns the element unchanged.
             let op_name = match callable.view() {
                 ValueView::Sub(data) => Some(data.name.resolve()),
                 ValueView::Routine { name, .. } => Some(name.resolve()),
                 _ => None,
             };
+            let elem = items.into_iter().next().unwrap();
             if let Some(ref op) = op_name {
                 // Strip infix:<...> wrapper if present
                 let bare_op = op
@@ -156,8 +161,7 @@ impl Interpreter {
                     bare_op,
                     "+" | "-" | "*" | "/" | "%" | "**" | "+|" | "+&" | "+^"
                 ) {
-                    let elem = items.into_iter().next().unwrap();
-                    // Validate non-numeric strings
+                    // Validate non-numeric strings (raku throws on `[+] "x"`).
                     if let ValueView::Str(s) = elem.view()
                         && crate::runtime::str_numeric::parse_raku_str_to_numeric(&s).is_none()
                     {
@@ -166,11 +170,13 @@ impl Interpreter {
                             "base-10 number must begin with valid digits or '.'",
                         ));
                     }
-                    let identity = crate::runtime::reduction_identity(bare_op);
-                    return self.call_sub_value(callable, vec![identity, elem], false);
+                    return Ok(crate::runtime::utils::coerce_to_numeric(elem));
+                }
+                if matches!(bare_op, "~" | "x") {
+                    return Ok(Value::str(elem.to_str_context()));
                 }
             }
-            return Ok(items.into_iter().next().unwrap());
+            return Ok(elem);
         }
 
         let arity = self.reduce_callable_arity(&callable);

--- a/t/reduce-single-element.t
+++ b/t/reduce-single-element.t
@@ -1,0 +1,25 @@
+use v6;
+use Test;
+
+plan 12;
+
+# A single-element reduce returns the element's *value* coerced to the
+# operator's natural type — NOT `identity op elem`. Regression: `[-] 10`
+# used to fold `0 - 10 = -10`.
+
+is reduce(&infix:<->, (10,)), 10, 'reduce &infix:<-> over one element is the element';
+is reduce(&infix:</>, (10,)), 10, 'reduce &infix:</> over one element is the element';
+is reduce(&infix:<**>, (2,)), 2, 'reduce &infix:<**> over one element is the element';
+is reduce(&infix:<%>, (7,)), 7, 'reduce &infix:<%> over one element is the element';
+is reduce(&infix:<+>, (5,)), 5, 'reduce &infix:<+> over one element is the element';
+is reduce(&infix:<*>, (3,)), 3, 'reduce &infix:<*> over one element is the element';
+
+# The single element is coerced to the operator's natural type.
+is reduce(&infix:<+>, ("2",)).WHAT, Int, 'numeric reduce coerces Str to Int';
+is reduce(&infix:<->, ("10",)), 10, 'numeric reduce coerces "10" to 10';
+is reduce(&infix:<~>, (5,)), "5", 'string reduce &infix:<~> coerces to Str';
+is reduce(&infix:<~>, (5,)).WHAT, Str, '&infix:<~> single element is Str';
+
+# Metaop reduce forms.
+is ([-] 10), 10, 'metaop [-] over one element';
+is ([-] 10, 3, 2), 5, 'metaop [-] still folds multiple elements left-assoc';


### PR DESCRIPTION
## Problem

```raku
say reduce &infix:<->, (10,);   # raku: 10   mutsu: -10
```

The one-element `reduce`/`[op]` path folded the operator's identity element with
the single value (`0 - 10 = -10`). That only gives the right answer for `+` and
`*` (their identities are true identities); for `-`, `/`, `**`, `%` and the
bitwise ops it was wrong.

## Fix

Raku returns the element's **value** coerced to the operator's natural type, not
`identity op elem`:

```raku
[-] 10      # 10   (Int)
[+] "2"     # 2    (Int, coerced)
[~] 5       # "5"  (Str, coerced)
```

So: for numeric operators coerce the element to Numeric (`coerce_to_numeric`);
for `~`/`x` coerce to Str; otherwise (`[,]`, `[max]`, chaining ops) return it
unchanged. The existing non-numeric-string validation for numeric operators is
kept (`[+] "x"` still throws).

## Tests

- `t/reduce-single-element.t` — every numeric op over one element, Str→Int / Str
  coercion, and that multi-element left-assoc folding is unaffected.
- Metaop / reduce suites (`t/*metaop*.t`, `reduce-*`, `supply-reduce`) still green.

Found via the raku-doc/doc/Type/List.rakudoc doc-diff sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)