### PR TITLE
fix: a bare `if` block binds its scalar placeholder to the condition value

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1908,19 +1908,15 @@ fn collect_ph_stmt_shallow(stmt: &Stmt, out: &mut Vec<String>) {
                 collect_ph_expr_shallow(e, out);
             }
         }
-        Stmt::If {
-            cond,
-            then_branch,
-            else_branch,
-            ..
-        } => {
+        Stmt::If { cond, .. } => {
+            // The `if` condition is evaluated in THIS block's scope, so a
+            // placeholder there (`if $^a { ... }`) is this block's parameter. The
+            // then/else branches are their OWN `{}` block scopes, so a placeholder
+            // inside them (`if 42 { $^a }`) belongs to the if-block and binds the
+            // condition value — it is NOT this block's parameter (matches Raku;
+            // see the If placeholder handling in compile_if_value). So we do NOT
+            // descend into the branches here.
             collect_ph_expr_shallow(cond, out);
-            for s in then_branch {
-                collect_ph_stmt_shallow(s, out);
-            }
-            for s in else_branch {
-                collect_ph_stmt_shallow(s, out);
-            }
         }
         Stmt::While { cond, body, .. } => {
             collect_ph_expr_shallow(cond, out);

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -129,6 +129,18 @@ impl Compiler {
             return;
         }
         let needs_at_underscore = Self::body_uses_legacy_args(then_branch);
+        // A bare `if EXPR { ... $^a ... }` whose block has a scalar placeholder
+        // receives the condition value as that placeholder (like `-> $a`), so
+        // `if 42 { $^a.say }` prints 42. Bind the first scalar placeholder
+        // (`$^a` → env key `^a`); a valid block takes only the one condition value.
+        let cond_placeholder: Option<String> = if binding_var.is_none() {
+            crate::ast::collect_placeholders_shallow(then_branch)
+                .into_iter()
+                .find(|n| n.starts_with('^'))
+        } else {
+            None
+        };
+        let needs_cond_value = needs_at_underscore || cond_placeholder.is_some();
         // A topic-binding `if EXPR -> $v { ... }` (or a pointy `elsif`): bind the
         // condition value to `$v` and test the bound variable, mirroring the
         // statement-form desugar (`{ my $v = EXPR; if $v { ... } }`) that
@@ -165,8 +177,9 @@ impl Compiler {
         } else {
             self.compile_expr(cond);
         }
-        if needs_at_underscore {
-            // Duplicate condition for @_ (bare if blocks receive condition as @_).
+        if needs_cond_value {
+            // Duplicate condition for @_ / the placeholder (bare if blocks
+            // receive the condition value).
             self.code.emit(OpCode::Dup);
         }
         let jump_else = self.code.emit(OpCode::JumpIfFalse(0));
@@ -174,11 +187,14 @@ impl Compiler {
             // Flatten the duplicated condition into @_.
             self.code.emit(OpCode::FlattenSlurpy);
             self.emit_set_named_var("@_");
+        } else if let Some(ph) = &cond_placeholder {
+            // Bind the scalar placeholder to the (unflattened) condition value.
+            self.emit_set_named_var(ph);
         }
         self.compile_stmts_value(then_branch);
         let jump_end = self.code.emit(OpCode::Jump(0));
         self.code.patch_jump(jump_else);
-        if needs_at_underscore {
+        if needs_cond_value {
             // Pop leftover duplicated condition on the false branch.
             self.code.emit(OpCode::Pop);
         }

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -117,6 +117,18 @@ impl Compiler {
         if pointy_topic_scope {
             self.code.emit(OpCode::EnterPointyTopic);
         }
+        // A bare `do if EXPR { ... $^a ... }` / `(if EXPR { ... })` block receives
+        // the condition value as `@_` and as a scalar placeholder (like `-> $a`),
+        // so `do if 9 { $^a + 1 }` is 10. Mirrors `compile_if_value`.
+        let needs_at_underscore = binding_var.is_none() && Self::body_uses_legacy_args(then_branch);
+        let cond_placeholder: Option<String> = if binding_var.is_none() {
+            crate::ast::collect_placeholders_shallow(then_branch)
+                .into_iter()
+                .find(|n| n.starts_with('^'))
+        } else {
+            None
+        };
+        let needs_cond_value = needs_at_underscore || cond_placeholder.is_some();
         if let Some(var_name) = binding_var {
             let bare_name = var_name.trim_start_matches('$').to_string();
             let var_decl = Stmt::VarDecl {
@@ -136,10 +148,22 @@ impl Compiler {
         } else {
             self.compile_expr(cond);
         }
+        if needs_cond_value {
+            self.code.emit(OpCode::Dup);
+        }
         let jump_else = self.code.emit(OpCode::JumpIfFalse(0));
+        if needs_at_underscore {
+            self.code.emit(OpCode::FlattenSlurpy);
+            self.emit_set_named_var("@_");
+        } else if let Some(ph) = &cond_placeholder {
+            self.emit_set_named_var(ph);
+        }
         self.compile_block_inline(then_branch);
         let jump_end = self.code.emit(OpCode::Jump(0));
         self.code.patch_jump(jump_else);
+        if needs_cond_value {
+            self.code.emit(OpCode::Pop);
+        }
 
         if else_branch.is_empty() {
             let empty_idx = self.code.add_constant(Value::slip(vec![]));

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1601,6 +1601,19 @@ impl Compiler {
                 // the condition value as @_ in Raku).
                 let needs_at_underscore =
                     binding_var.is_none() && Self::body_uses_legacy_args(then_branch);
+                // A bare `if EXPR { ... $^a ... }` whose block has a scalar
+                // placeholder receives the condition value as that placeholder
+                // (like `if EXPR -> $a { ... }`), so `if 42 { $^a.say }` prints 42.
+                // Bind the first scalar placeholder (`$^a` → env key `^a`); a valid
+                // block can take only the one condition value.
+                let cond_placeholder: Option<String> = if binding_var.is_none() {
+                    crate::ast::collect_placeholders_shallow(then_branch)
+                        .into_iter()
+                        .find(|n| n.starts_with('^'))
+                } else {
+                    None
+                };
+                let needs_cond_value = needs_at_underscore || cond_placeholder.is_some();
                 // A condition that is a compile-time constant resolves the branch
                 // here (ADR-0006 §2.2): `constant DEBUG = False; if DEBUG { note
                 // ... }` emits nothing at all. The unreachable branch is only
@@ -1608,7 +1621,7 @@ impl Compiler {
                 // even in a never-taken branch) — otherwise the runtime branch is
                 // compiled as usual.
                 if binding_var.is_none()
-                    && !needs_at_underscore
+                    && !needs_cond_value
                     && let Some(taken) = self.const_condition(cond)
                 {
                     let (live, dead) = if taken {
@@ -1654,9 +1667,9 @@ impl Compiler {
                     self.compile_condition_expr(&desugared_cond);
                 } else {
                     self.compile_condition_expr(cond);
-                    if needs_at_underscore {
+                    if needs_cond_value {
                         // Duplicate condition value: one for JumpIfFalse truthiness
-                        // test, one for setting @_ in the then_branch.
+                        // test, one for setting @_ / the placeholder in the then_branch.
                         self.code.emit(OpCode::Dup);
                     }
                 }
@@ -1665,6 +1678,9 @@ impl Compiler {
                     // Flatten the duplicated condition into @_ (like *@ slurpy).
                     self.code.emit(OpCode::FlattenSlurpy);
                     self.emit_set_named_var("@_");
+                } else if let Some(ph) = &cond_placeholder {
+                    // Bind the scalar placeholder to the (unflattened) condition value.
+                    self.emit_set_named_var(ph);
                 }
                 if Self::body_mutates_topic(then_branch) {
                     self.synthetic_block_body = true;
@@ -1676,7 +1692,7 @@ impl Compiler {
                 }
                 if else_branch.is_empty() {
                     self.code.patch_jump(jump_else);
-                    if needs_at_underscore {
+                    if needs_cond_value {
                         // Pop the leftover duplicated condition value on the
                         // false branch (JumpIfFalse consumed only one copy).
                         self.code.emit(OpCode::Pop);
@@ -1684,7 +1700,7 @@ impl Compiler {
                 } else {
                     let jump_end = self.code.emit(OpCode::Jump(0));
                     self.code.patch_jump(jump_else);
-                    if needs_at_underscore {
+                    if needs_cond_value {
                         self.code.emit(OpCode::Pop);
                     }
                     if else_branch.len() == 1 && matches!(else_branch[0], Stmt::If { .. }) {

--- a/t/if-block-placeholder.t
+++ b/t/if-block-placeholder.t
@@ -1,0 +1,54 @@
+use v6;
+use Test;
+
+plan 10;
+
+# A bare `if EXPR { ... $^a ... }` block receives the condition value as its
+# scalar placeholder, like `if EXPR -> $a { ... }`. Regression: `$^a` used to
+# read the boolified condition (True) instead of the value. The bug bit hardest
+# for a compile-time-constant condition (`if 42 { ... }`), which was resolved at
+# compile time and inlined without binding the placeholder.
+
+# Statement form (non-last statement, so it takes the const-folding path).
+my @out1;
+$_ = 1;
+if 42 { @out1.push($_); @out1.push($^a) }
+is @out1, [1, 42], 'bare if block: $_ stays outer, $^a is the condition value';
+
+# do if / value forms.
+is (do if 5 { $^a * 2 }), 10, 'do if: $^a binds the condition (arithmetic)';
+is (do if 9 { $^a + 1 }), 10, 'do if: $^a in a value expression';
+
+# Parenthesised value-if.
+my $r = (if 7 { $^a - 2 });
+is $r, 5, 'parenthesised (if ...) binds $^a';
+
+# elsif branch binds its own $^a to the elsif condition.
+my $ev;
+if 0 { $ev = 'no' } elsif 3 { $ev = $^a }
+is $ev, 3, 'elsif block binds its own $^a to the elsif condition';
+
+# Not-taken then-branch: placeholder binding must not fire, else runs.
+is (if 0 { $^a } else { 'else' }), 'else', 'untaken then-branch: else value returned';
+
+# The condition value flows unflattened (a list condition stays whole).
+my $lst;
+if (1, 2, 3) { $lst = $^a }
+is $lst.elems, 3, 'a list condition binds whole to $^a';
+
+# `$_` inside the block is NOT the condition (stays the outer topic).
+$_ = 99;
+my $topic;
+if 42 { $topic = $_ }
+is $topic, 99, 'bare if does not set $_ to the condition';
+
+# A non-constant condition takes the runtime branch and still binds.
+my $rc;
+my $cond = 8;
+if $cond { $rc = $^a }
+is $rc, 8, 'runtime (non-constant) condition binds $^a';
+
+# Nested if: the inner $^a binds the inner condition, not the outer.
+my $inner;
+if 2 { if 5 { $inner = $^a } }
+is $inner, 5, 'nested if: inner $^a binds the inner condition';


### PR DESCRIPTION
## Problem

```raku
$_ = 1; if 42 { $_.say; $^a.say }   # raku: 1 then 42   mutsu: 1 then True
```

In Raku a bare `if EXPR { ... }` block whose body uses a placeholder receives
the condition value as that placeholder — exactly like `if EXPR -> $a { ... }` —
and the placeholder belongs to the if-block, not the enclosing scope
(`sub f { if 42 { say $^a } }; f()` prints 42; `f` takes no argument).

mutsu bound `$^a` to the *boolified* condition (`True`), and for a
compile-time-constant condition (`if 42 { ... }`) it dropped the binding
entirely.

## Fix

Three changes, all required:

1. **Bind the placeholder in all three `if` compilers** — statement form
   (`compile_stmt`), value form (`compile_if_value`), and `do if` / `(if ...)`
   (`compile_do_if_expr_bound`). Each now duplicates the condition and binds the
   first scalar placeholder (`$^a` → env key `^a`), mirroring the existing `@_`
   handling.
2. **Exclude the constant-condition fast path** (ADR-0006 §2.2) when a
   placeholder must be bound. `if 42 { $^a }` is compile-time-true, so it was
   inlined without ever binding `$^a` — the dominant failure.
3. **Scope placeholders correctly** — `collect_placeholders_shallow` no longer
   descends into `if` then/else branches. Those are their own placeholder
   scopes, so `{ if 42 { $^a } }` stays arity-0 and the `$^a` binds the
   condition, matching Raku.

## Tests

- `t/if-block-placeholder.t` — statement / `do if` / value / parenthesised /
  elsif / nested / non-constant-condition / list-condition forms, and that `$_`
  is *not* set to the condition.
- All `t/placeholder*.t`, `t/if-*.t`, `t/given-when*.t`, `t/topic*.t` suites
  still green.

Known adjacent gap left alone: `if 7 { @_[0] }` (bare `@_` indexing in an if
block) is still `(Any)` — a pre-existing limitation of the Debug-string
`body_uses_legacy_args` heuristic, unrelated to placeholder binding.

Found via the raku-doc/doc/Language/control.rakudoc doc-diff sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)