### PR TITLE
fix: assignment binds through a ternary lvalue (compound and conditional)

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -105,12 +105,6 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 - file: DONE — runtime/registration_role.rs, runtime/undeclared_routines.rs;
   remaining — nqp op support (large, separate)
 
-### T-028 — test_die [P5reset]  [impact: 1 dist]
-- dists: P5reset
-- e.g. `P5reset`: base=1 pass=0 fail=0 die=1 | t/01-basic.rakutest: 
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
-
 ### T-029 — test_die [POFile]  [impact: 1 dist]
 - dists: POFile
 - e.g. `POFile`: base=4 pass=1 fail=1 die=2 | t/02-deletion.rakutest: 
@@ -287,6 +281,24 @@ _(move tickets here with `[claim: <branch>]` when you start)_
 
 ## Done
 
+- **T-028** (#PENDING) — P5reset's `reset()` died with "Cannot modify an
+  immutable value" on its comb-loop ternary. A ternary `?? !!` is an lvalue and
+  assignment binds LOOSER than the conditional, so `cond ?? A !! B op= rhs`
+  parses as `(cond ?? A !! B) op= rhs` — the compound (or simple) assignment
+  applies to whichever branch is selected. mutsu handled only the parenthesized
+  simple `=` case and rejected compound-assign-through-a-ternary-lvalue outright.
+  Fixes: the compound-assign builders (`build_compound_assign_expr`,
+  `build_compound_assign_target_expr`, `assign_to_target_expr`) now desugar a
+  `Ternary` target to `cond ?? (A op= rhs) !! (B op= rhs)`; a non-lvalue branch
+  recurses to the RO-error form (raises only if selected); the compiler's
+  `__mutsu_assign_callable_lvalue(Ternary)` path tolerates a non-lvalue branch;
+  and `(EXPR if COND) op= rhs` pushes the compound assignment into the
+  conditional's then-branch (a silent no-op when the modifier does not fire).
+  The comb-loop now runs identically to raku. Pin:
+  t/ternary-lvalue-compound-assign.t. **Remaining P5reset blocker (deferred, not
+  this ticket):** `for CALLER::OUR::.kv -> \key, \value { value = ... }` writable
+  iteration + sigilless `\value` writeback — the actual variable reset still no-ops
+  (the module loads and reset() executes without error).
 - **T-024** (#5149) — Adverb::Eject died before test 1 on `@a[1]:eject` /
   `%h<a>:eject`: a subscript carrying a user-defined (non built-in) adverb was
   not routed to a user `postcircumfix:<[ ]>`/`<{ }>` candidate. Three general

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -182,13 +182,16 @@ impl Compiler {
                 then_expr,
                 else_expr,
             } = &args[0]
-            && let Some(then_assign) = Self::assign_expr_for_lvalue(then_expr, &args[2])
-            && let Some(else_assign) = Self::assign_expr_for_lvalue(else_expr, &args[2])
         {
             // `(cond ?? $a !! $b) = rhs`: the ternary yields whichever branch is
             // the selected lvalue, then the assignment writes through to it.
             // Desugar to `cond ?? ($a = rhs) !! ($b = rhs)` so only the taken
-            // branch is assigned (and rhs is evaluated once, in that branch).
+            // branch is assigned (and rhs is evaluated once, in that branch). A
+            // non-lvalue branch (`cond ?? 9 !! $x = rhs`) desugars to an RO-error
+            // form via `ternary_branch_assign`, raising only if that branch is
+            // selected -- raku accepts the assignment when the lvalue branch wins.
+            let then_assign = Self::ternary_branch_assign(then_expr, &args[2]);
+            let else_assign = Self::ternary_branch_assign(else_expr, &args[2]);
             let desugared = Expr::Ternary {
                 cond: cond.clone(),
                 then_expr: Box::new(then_assign),

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -119,6 +119,26 @@ impl Compiler {
         }
     }
 
+    /// Like `assign_expr_for_lvalue` but never fails: a non-lvalue branch target
+    /// (e.g. the literal `9` in `cond ?? 9 !! $x`) becomes an expression that
+    /// raises the read-only error when evaluated -- which only happens if that
+    /// branch is the one selected, matching raku's runtime "Cannot modify an
+    /// immutable value". Used to desugar a ternary lvalue on the LHS of `=` where
+    /// one branch may not be assignable.
+    pub(super) fn ternary_branch_assign(target: &Expr, value: &Expr) -> Expr {
+        Self::assign_expr_for_lvalue(target, value).unwrap_or_else(|| Expr::DoBlock {
+            body: vec![
+                Stmt::Expr(target.clone()),
+                Stmt::Expr(value.clone()),
+                Stmt::Expr(Expr::Call {
+                    name: crate::symbol::Symbol::intern("__mutsu_assignment_ro"),
+                    args: Vec::new(),
+                }),
+            ],
+            label: None,
+        })
+    }
+
     pub(super) fn postfix_index_name(target: &Expr) -> Option<String> {
         match target {
             Expr::HashVar(name) => Some(format!("%{}", name)),

--- a/src/parser/expr/precedence/assign.rs
+++ b/src/parser/expr/precedence/assign.rs
@@ -117,6 +117,19 @@ pub(crate) fn assign_to_target_expr(target: Expr, value: Expr) -> Expr {
             name: Symbol::intern("__mutsu_assign_callable_lvalue"),
             args: vec![*target, Expr::ArrayLiteral(args), value],
         },
+        // `(cond ?? $a !! $b) = rhs`: the ternary selects an lvalue branch; the
+        // assignment writes through to whichever branch is taken. Desugar to
+        // `cond ?? ($a = rhs) !! ($b = rhs)`. A non-lvalue branch recurses to the
+        // RO-error `other` arm, which raises only when that branch is selected.
+        Expr::Ternary {
+            cond,
+            then_expr,
+            else_expr,
+        } => Expr::Ternary {
+            cond,
+            then_expr: Box::new(assign_to_target_expr(*then_expr, value.clone())),
+            else_expr: Box::new(assign_to_target_expr(*else_expr, value)),
+        },
         Expr::SymbolicDeref { sigil, expr } => Expr::SymbolicDerefAssign {
             sigil,
             expr,
@@ -282,6 +295,24 @@ pub(crate) fn build_compound_assign_target_expr(target: Expr, op_name: &str, val
                 value,
             )
         }
+        // `(cond ?? A !! B) op= rhs`: apply the compound assignment through the
+        // ternary lvalue to whichever branch is selected. See the matching arm in
+        // `build_compound_assign_expr` (compound_expr.rs) for the rationale.
+        Expr::Ternary {
+            cond,
+            then_expr,
+            else_expr,
+        } => Expr::Ternary {
+            cond,
+            then_expr: Box::new(build_compound_assign_target_expr(
+                *then_expr,
+                op_name,
+                value.clone(),
+            )),
+            else_expr: Box::new(build_compound_assign_target_expr(
+                *else_expr, op_name, value,
+            )),
+        },
         other => assignment_ro_expr(other, value),
     }
 }

--- a/src/parser/stmt/assign/compound_expr.rs
+++ b/src/parser/stmt/assign/compound_expr.rs
@@ -180,6 +180,63 @@ pub(crate) fn build_compound_assign_expr(
             op: op.token_kind(),
             right: Box::new(rhs),
         },
+        // `(EXPR if COND) op= rhs`: a statement-modifier conditional whose body is
+        // an lvalue (`($s = $x.chop if $s) ~= $y`, from P5reset). Push the compound
+        // assignment into the then-branch so it runs only when the condition holds;
+        // an unrun modifier yields Empty in raku, which the metaop-assign ignores
+        // (`($s = "a" if 0) ~= "y"` is a silent no-op). Only a single-expression
+        // then-branch with an empty else is a well-defined lvalue.
+        Expr::DoStmt(stmt)
+            if matches!(
+                stmt.as_ref(),
+                Stmt::If { then_branch, else_branch, binding_var: None, .. }
+                    if then_branch.len() == 1
+                        && else_branch.is_empty()
+                        && matches!(then_branch[0], Stmt::Expr(_))
+            ) =>
+        {
+            let Stmt::If {
+                cond,
+                then_branch,
+                else_branch,
+                binding_var,
+            } = *stmt
+            else {
+                unreachable!("guarded by the match arm")
+            };
+            let mut then_branch = then_branch;
+            let inner = match then_branch.pop() {
+                Some(Stmt::Expr(e)) => e,
+                _ => unreachable!("guarded by the match arm"),
+            };
+            let inner_assign = build_compound_assign_expr(inner, op, rhs)?;
+            Expr::DoStmt(Box::new(Stmt::If {
+                cond,
+                then_branch: vec![Stmt::Expr(inner_assign)],
+                else_branch,
+                binding_var,
+            }))
+        }
+        // `(cond ?? A !! B) op= rhs`: the ternary is an lvalue selecting one
+        // branch, so the compound assignment writes through to whichever branch
+        // is taken. Desugar to `cond ?? (A op= rhs) !! (B op= rhs)` so only the
+        // selected branch is mutated and `rhs` is evaluated once, in that branch.
+        // A non-lvalue branch (a literal like `9` in `True ?? 9 !! $l ~= "x"`)
+        // recurses to the RO-error `other` arm below, which raises only if that
+        // branch is taken -- matching raku ("Cannot modify an immutable Int (9)").
+        Expr::Ternary {
+            cond,
+            then_expr,
+            else_expr,
+        } => {
+            let then_assign = build_compound_assign_expr(*then_expr, op, rhs.clone())?;
+            let else_assign = build_compound_assign_expr(*else_expr, op, rhs)?;
+            Expr::Ternary {
+                cond,
+                then_expr: Box::new(then_assign),
+                else_expr: Box::new(else_assign),
+            }
+        }
         // `(state $best) max= $score` / `(my $n) += 1`: the declaration *is* the lvalue.
         // Unlike plain `=`, the new value has to read the variable back, so this cannot
         // become a `VarDecl` with an initializer — a `state` initializer runs once, but the

--- a/src/parser/stmt/simple_expr_stmt/core.rs
+++ b/src/parser/stmt/simple_expr_stmt/core.rs
@@ -8,8 +8,9 @@ use crate::parser::parse_result::{
 };
 use crate::parser::primary::parse_call_arg_list;
 use crate::parser::stmt::assign::{
-    CompoundAssignOp, compound_assigned_value_expr, parse_assign_expr_or_comma,
-    parse_comma_or_expr, parse_compound_assign_op, parse_set_compound_assign_op,
+    CompoundAssignOp, build_compound_assign_expr, compound_assigned_value_expr,
+    parse_assign_expr_or_comma, parse_comma_or_expr, parse_compound_assign_op,
+    parse_set_compound_assign_op,
 };
 use crate::parser::stmt::modifier::{is_stmt_modifier_keyword, parse_statement_modifier};
 use crate::parser::stmt::simple::{
@@ -1418,6 +1419,16 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
                 ],
             });
             return parse_statement_modifier(r, stmt);
+        }
+        // `(cond ?? $a !! $b) op= rhs` (unparenthesized): the ternary is an
+        // lvalue selecting one branch, so route through `build_compound_assign_expr`
+        // which desugars to `cond ?? ($a op= rhs) !! ($b op= rhs)` -- only the
+        // taken branch is mutated. The generic RO fallback below would instead
+        // reject it as immutable.
+        if matches!(expr, Expr::Ternary { .. })
+            && let Ok(ternary_assign) = build_compound_assign_expr(expr.clone(), op, rhs.clone())
+        {
+            return parse_statement_modifier(r, Stmt::Expr(ternary_assign));
         }
         let stmt =
             if matches!(expr, Expr::BracketArray(..)) && matches!(op, CompoundAssignOp::Comma) {

--- a/t/ternary-lvalue-compound-assign.t
+++ b/t/ternary-lvalue-compound-assign.t
@@ -1,0 +1,84 @@
+use v6;
+use Test;
+
+# A ternary `?? !!` is an lvalue: an assignment (simple or compound) binds
+# LOOSER than the conditional, so it applies to whichever branch is selected.
+# `cond ?? A !! B op= rhs` parses as `(cond ?? A !! B) op= rhs`. Regression pin
+# for the P5reset dist, whose reset() loop uses this shape.
+
+# --- compound assignment through a ternary lvalue (unparenthesized) ---
+{
+    my $l;
+    False ?? 9 !! $l ~= "x";
+    is $l, "x", 'False ?? 9 !! $l ~= "x" appends to the selected else branch';
+}
+{
+    my $a = "p";
+    my $b = "q";
+    False ?? $a !! $b ~= "x";
+    is "$a|$b", "p|qx", 'compound assign hits the else branch when cond is false';
+}
+{
+    my $a = "p";
+    my $b = "q";
+    True ?? $a !! $b ~= "x";
+    is "$a|$b", "px|q", 'compound assign hits the then branch when cond is true';
+}
+{
+    my $a = 1;
+    my $b = 2;
+    False ?? $a !! $b += 5;
+    is "$a|$b", "1|7", 'numeric compound assign through a ternary lvalue';
+}
+
+# --- explicit-paren form ---
+{
+    my $a = "p";
+    my $b = "q";
+    (False ?? $a !! $b) ~= "x";
+    is "$a|$b", "p|qx", 'parenthesized ternary lvalue compound assign';
+}
+
+# --- simple assignment through a ternary lvalue with a non-lvalue branch ---
+{
+    my $l;
+    False ?? 9 !! $l = "x";
+    is $l, "x", 'simple assign works when the taken branch is an lvalue (other branch a literal)';
+}
+
+# --- a non-lvalue branch, when SELECTED, is a runtime error ---
+{
+    my $l;
+    dies-ok { True ?? 9 !! $l ~= "x" },
+        'assigning through a literal branch when it is selected dies';
+}
+
+# --- statement-modifier conditional as a compound-assign lvalue ---
+# `(EXPR if COND) op= rhs`: applies only when COND holds; a no-op otherwise.
+{
+    my $s = "p";
+    ($s = "a" if 1) ~= "y";
+    is $s, "ay", 'compound assign through a taken (if 1) conditional-assignment lvalue';
+}
+{
+    my $s = "p";
+    ($s = "a" if 0) ~= "y";
+    is $s, "p", 'unrun (if 0) conditional-assignment lvalue is a silent no-op';
+}
+
+# --- the P5reset comb-loop shape end to end ---
+{
+    my $start;
+    sub start-from() { my $value = $start; $start = Nil; $value }
+    my $letters;
+    for "xyz".comb -> $letter {
+        $letter eq '-'
+          ?? ($start = $letters.chop if $letters)
+          !! $letters ~= $start
+            ?? (start-from() .. $letter).join
+            !! $letter;
+    }
+    is $letters, "xyz", 'P5reset comb-loop nested ternary-lvalue compound assign';
+}
+
+done-testing;


### PR DESCRIPTION
A ternary `?? !!` is an lvalue, and an assignment binds **looser** than the conditional, so `cond ?? A !! B op= rhs` parses as `(cond ?? A !! B) op= rhs` — the assignment applies to whichever branch is selected. This matches raku, whose AST wraps the whole ternary in `METAOP_ASSIGN`. mutsu previously supported only the parenthesized simple `=` case and rejected a compound assignment through a ternary lvalue with `Cannot modify an immutable value`.

## Fixes
- `build_compound_assign_expr` / `build_compound_assign_target_expr` / `assign_to_target_expr` now desugar a `Ternary` target to `cond ?? (A op= rhs) !! (B op= rhs)` — only the taken branch is mutated, `rhs` evaluated once.
- A non-lvalue branch (e.g. the literal `9`) recurses to the read-only-error form, which raises **only if that branch is selected** (`True ?? 9 !! $l ~= "x"` dies, like raku).
- The compiler's `__mutsu_assign_callable_lvalue(Ternary)` path no longer requires **both** branches to be lvalues (new `ternary_branch_assign` helper), fixing `False ?? 9 !! $l = "x"`.
- The statement-level compound-assign handler routes a `Ternary` lhs through the builder instead of the generic RO fallback.
- `(EXPR if COND) op= rhs` pushes the compound assignment into the conditional's then-branch, so it runs only when the modifier fires and is a silent no-op otherwise (raku: an unrun modifier yields `Empty`, which metaop-assign ignores).

## Impact
Unblocks the **P5reset** dist: its `reset()` comb-loop nested ternary now runs identically to raku, and `reset()` executes without error (was a hard crash / parse error). The remaining P5reset gap — `for CALLER::OUR::.kv -> \key, \value { value = ... }` writable iteration with sigilless writeback — is deferred (the module loads and runs; the actual variable reset still no-ops).

Pin: `t/ternary-lvalue-compound-assign.t` (10 subtests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)