### PR TITLE
fix: reify a deferred Seq (Seq.new / *.from-iterator over a user Iterator) universally

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -228,8 +228,21 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 
 ### T-051 — test_fail: test basic stuff after initialization  [impact: 1 dist]
 - dists: Hash::Agnostic
-- e.g. `Hash::Agnostic`: base=2 pass=0 fail=2 die=0 | t/01-basic.rakutest: test basic stuff after initialization
+- e.g. `Hash::Agnostic`: base=2 | **t/01-basic.rakutest now PASSES 22/22** (deferred-Seq
+  reification, see below) | t/02-minimal.rakutest still test_die
 - repro: `class MyHash does Hash::Agnostic {...}; my %h is MyHash = @pairs; say %h.^name` — raku: `MyHash`, mutsu: `Hash`
+- **2026-07-22 UPDATE — subtest 13 `.kv` gap LANDED (deferred-Seq reification, PR `feat-deferred-seq-reify`).**
+  `Seq.new($user-Iterator)` / `List|Slip|Array.from-iterator($it)` are lazy but the consumers
+  (`.List`/`.elems`/`.sort`/`for`/`@a=$seq`/mut-path methods) never drove `pull-one` — reification
+  is now universal via a shared `seq_deferred_method_keeps_lazy` exemption (introspection +
+  laziness-preserving methods stay lazy; everything else reifies). Also fixed: a bare `given`/`when`
+  block whose final statement is an assignment/bind yielded Nil instead of the assigned value (the
+  two-phase `pull-one { with $!k {...} else { $!k := ... } }` KV shape). Pins:
+  `t/seq-new-user-iterator.t`, `t/given-when-tail-assign-value.t`. **`t/01-basic.rakutest` now exits 0.**
+- **REMAINING (02-minimal):** `my %h is MinimalHash = @pairs` where MinimalHash has a
+  `submethod TWEAK` and a minimal STORE (only AT-KEY/keys, no BIND-KEY) dies with
+  "Too many positionals passed; expected 0 arguments but got 1 in sub new" — a tied-hash
+  default-STORE + TWEAK constructor-dispatch blocker, unrelated to the `.kv`/Seq work.
 - NOTE: a "tied hash" feature (`my %h is CustomAssociativeClass`). Decomposes into three
   independent gaps, each fixable on its own:
   1. **tied-hash backing** — `my %h is Foo` (Foo `does Associative`) must back the variable

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -332,6 +332,10 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 crate::value::seq_mark_cached(&items);
                 Some(Ok(Value::array(items.to_vec())))
             }
+            // `.List` on a Slip flattens its elements into a List (`slip(1,2,3).List`
+            // is `(1 2 3)`, not `((1 2 3))`) — without this arm a Slip falls through
+            // to the scalar catch-all and is wrapped as a single element.
+            ValueView::Slip(items) => Some(Ok(Value::array(items.to_vec()))),
             // A shaped array falls through to the slow path, which flattens all
             // dimensions and replaces Nil slots with the type-default.
             ValueView::Array(..) if crate::runtime::utils::is_shaped_array(target) => None,

--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -47,6 +47,18 @@ impl Compiler {
                 }
                 true
             }
+            // `$x = expr` / `$x := expr` at the tail of a `given`/`when` block is
+            // the block's value (`given 3 { $y = 5 }` yields 5), mirroring the
+            // block-final assignment handling in `compile_block_inline`. Without
+            // this the fallback compiles the assignment as a sink and the block
+            // yields Nil (surfaced by a two-phase `pull-one { with $!k {...} else
+            // { $!k := ... } }` iterator whose `else` value was dropped).
+            Stmt::Assign { name, expr, .. } => {
+                self.compile_expr(expr);
+                self.code.emit(OpCode::Dup);
+                self.emit_set_named_var(name);
+                true
+            }
             _ => false,
         }
     }

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -194,6 +194,8 @@ impl Interpreter {
         {
             let container = name.resolve();
             let iterator = args.into_iter().next().unwrap();
+            let user_iterator = matches!(iterator.view(), ValueView::Instance { class_name, .. }
+                if class_name != "Iterator" && self.class_does_role(&class_name.resolve(), "Iterator"));
             let items: Vec<Value> = if let ValueView::Instance {
                 class_name,
                 attributes,
@@ -211,6 +213,23 @@ impl Interpreter {
                     _ => 0,
                 };
                 all[index..].to_vec()
+            } else if user_iterator {
+                // A user-defined `does Iterator` instance: drive its `pull-one`
+                // until IterationEnd. Unlike the built-in `Iterator` (whose index
+                // write-back needs a named variable), a user iterator persists its
+                // own attribute mutations across `pull-one` calls, so driving the
+                // temporary directly reifies the elements the class produces.
+                let mut pulled = Vec::new();
+                loop {
+                    let val = self.call_method_with_values(iterator.clone(), "pull-one", vec![])?;
+                    if matches!(val.view(), ValueView::Str(s) if s.as_str() == "IterationEnd")
+                        || matches!(val.view(), ValueView::Package(n) if n == Symbol::intern("IterationEnd"))
+                    {
+                        break;
+                    }
+                    pulled.push(val);
+                }
+                pulled
             } else {
                 crate::runtime::utils::value_to_list(&iterator)
             };

--- a/src/runtime/methods_object_native_ctors_misc.rs
+++ b/src/runtime/methods_object_native_ctors_misc.rs
@@ -158,10 +158,10 @@ impl Interpreter {
     /// VM-native construction for `Seq.new($iterator?)`. Construction reads and
     /// writes only VM-owned state: a `PredictiveIterator` argument is stashed in
     /// the `predictive_seq_iters` carrier table (plus an `__mutsu_*` env side
-    /// table so the association survives sub/block returns), a materialized
-    /// `items`/`stuff` instance is copied eagerly, any other iterator is
-    /// registered as a deferred (lazy) iterator keyed off the new Seq's own Arc,
-    /// and the no-arg form yields a pre-consumed Seq. No FS / process / user
+    /// table so the association survives sub/block returns), any other iterator
+    /// (built-in or user-defined `does Iterator`) is registered as a deferred
+    /// (lazy) iterator keyed off the new Seq's own Arc — pulled only when the Seq
+    /// is consumed — and the no-arg form yields a pre-consumed Seq. No FS / process / user
     /// code — pulling from the iterator happens later, on consumption. The
     /// interpreter's `dispatch_new` arm delegates here, so the native VM fast
     /// path is byte-identical (one struct, one `self`).
@@ -184,7 +184,20 @@ impl Interpreter {
                 }
                 return seq;
             }
-            if let ValueView::Instance { attributes, .. } = iterator.view() {
+            // mutsu's OWN built-in `Iterator` (from `.iterator`) is an eager
+            // representation: its `items` attribute already holds the full
+            // materialized contents, so return them directly. This shortcut is
+            // keyed strictly on the built-in `Iterator` class — a user
+            // `does Iterator` class must NOT hit it (its `pull-one` is the source
+            // of truth and may transform/generate elements the way raku expects),
+            // so those fall through to the deferred-pull path below.
+            if let ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } = iterator.view()
+                && class_name == "Iterator"
+            {
                 let map = attributes.as_map();
                 if let Some(ValueView::Array(items, ..)) = map
                     .get("items")

--- a/src/runtime/test_functions/comparison.rs
+++ b/src/runtime/test_functions/comparison.rs
@@ -317,6 +317,13 @@ impl Interpreter {
 
     fn seq_to_list(&mut self, v: &Value) -> Value {
         match v.view() {
+            // A `Seq.new($iterator)` stores its iterator deferred (empty backing
+            // vec). Pull every element before comparing, else it compares as the
+            // empty list (`is-deeply Seq.new($user-iter), (...)`).
+            ValueView::Seq(items) if crate::value::seq_has_deferred_iter(&items) => {
+                let pulled = self.materialize_deferred_seq(&items);
+                Value::array_with_kind(crate::value::Value::array_arc(pulled), ArrayKind::List)
+            }
             ValueView::Seq(items) => Value::array_with_kind(
                 crate::value::Value::array_arc(items.clone().to_vec()),
                 ArrayKind::List,

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -100,6 +100,37 @@ pub(crate) fn seq_has_deferred_iter(arc_ptr: &Arc<Vec<Value>>) -> bool {
     map.contains_key(&key)
 }
 
+/// Whether a method call on a `Seq.new($iterator)` (deferred-iterator) Seq must
+/// pull every element from the iterator FIRST (reify), or leave the Seq lazy.
+///
+/// The listed methods are non-consuming: introspection and laziness-preserving
+/// coercions that have a correct native impl reading no elements. `sink` is
+/// excluded because the interpreter's `call_method_with_values` has a dedicated
+/// deferred-`sink` handler (pull for an uncached Seq, no pull for a cached one)
+/// that the blanket reify would bypass. Everything else (`.List`/`.elems`/`.sort`
+/// /`.map`/`for`/...) reads the elements and so must reify first. This is the
+/// shared exemption used by the VM fast-path reify guards (native/mut/interpret).
+pub(crate) fn seq_deferred_method_keeps_lazy(method: &str) -> bool {
+    matches!(
+        method,
+        "cache"
+            | "raku"
+            | "perl"
+            | "is-lazy"
+            | "iterator"
+            | "sink"
+            | "lazy"
+            | "WHAT"
+            | "WHICH"
+            | "WHERE"
+            | "HOW"
+            | "WHY"
+            | "VAR"
+            | "DEFINITE"
+            | "defined"
+    )
+}
+
 /// Mark a LazyList (from gather) as consumed.
 pub(crate) fn lazylist_consume(gc_ptr: &crate::gc::Gc<LazyList>) -> bool {
     let mut list = consumed_lazylists().lock().unwrap();

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -41,6 +41,21 @@ impl Interpreter {
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
         let method: &str = method_sym.as_str();
+        // A `Seq.new($iterator)` stores its iterator deferred (empty backing vec).
+        // Several native interceptors below (`try_native_sort`, `.Seq`/`.Map`
+        // coercions, ...) read the target's items directly and would yield nothing
+        // for such a Seq — reaching them before the `call_method_with_values`
+        // fallthrough that pulls the iterator. Reify here first so every native
+        // path sees the pulled elements. `cache`/`raku`/`perl` keep the Seq lazy.
+        let target = if let ValueView::Seq(arc) = target.view()
+            && crate::value::seq_has_deferred_iter(&arc)
+            && !crate::value::seq_deferred_method_keeps_lazy(method)
+        {
+            let pulled = self.materialize_deferred_seq(&arc);
+            Value::seq_arc(std::sync::Arc::new(pulled))
+        } else {
+            target
+        };
         // Native default construction: `Foo.new(...)` for a simple user-defined
         // class is pure data assembly (named args + attribute defaults), so the
         // Interpreter builds the instance directly instead of routing through the

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -447,6 +447,20 @@ impl Interpreter {
         } else {
             target
         };
+        // A `Seq.new($iterator)` stores its iterator deferred (empty backing vec).
+        // Mut-path list methods (`.sort`, comparator `.map`/`.grep`, ...) read that
+        // empty vec directly, so pull every element from the iterator first. The
+        // non-mut path reifies via `try_native_method`'s deferred-Seq bail; this is
+        // the mut-path twin. `cache`/`raku`/`perl` keep the Seq lazy.
+        let target = if let ValueView::Seq(arc) = target.view()
+            && crate::value::seq_has_deferred_iter(&arc)
+            && !crate::value::seq_deferred_method_keeps_lazy(method.as_str())
+        {
+            let pulled = self.materialize_deferred_seq(&arc);
+            Value::seq_arc(std::sync::Arc::new(pulled))
+        } else {
+            target
+        };
         // Mutating a lazy `@`-array (infinite source). raku rejects operations
         // that touch the (non-existent) end — push/pop/append — with
         // `X::Cannot::Lazy`, but allows front operations (unshift/prepend/shift/

--- a/src/vm/vm_coerce_concat_ops.rs
+++ b/src/vm/vm_coerce_concat_ops.rs
@@ -20,7 +20,7 @@ impl Interpreter {
     /// `Seq.new($iterator)`), driving the iterator's `pull-one` until
     /// `IterationEnd`. Works for both built-in and user-defined `Iterator`
     /// classes. The deferred iterator is removed and the Seq is marked consumed.
-    pub(super) fn materialize_deferred_seq(&mut self, items_arc: &Arc<Vec<Value>>) -> Vec<Value> {
+    pub(crate) fn materialize_deferred_seq(&mut self, items_arc: &Arc<Vec<Value>>) -> Vec<Value> {
         let Some(iterator) = crate::value::seq_take_deferred_iter(items_arc) else {
             return (**items_arc).clone();
         };

--- a/src/vm/vm_for_loop_dispatch.rs
+++ b/src/vm/vm_for_loop_dispatch.rs
@@ -133,7 +133,7 @@ impl Interpreter {
             self.reset_state_locals_in_range(code, *ip + 1, spec.body_end as usize);
         }
 
-        let iterable = self.stack.pop().unwrap();
+        let mut iterable = self.stack.pop().unwrap();
 
         // Handle lazy IO lines: iterate by pulling one line at a time
         // so that $fh.tell reflects the current read position.
@@ -214,6 +214,16 @@ impl Interpreter {
         // re-iterable, so a `for @$s` loop must NOT consume it — otherwise a
         // second `for @$s` would spuriously throw (surfaced by Zef::Pluggable
         // iterating `@$backend` across two calls).
+        // A `Seq.new($iterator)` (including user-defined `Iterator` classes) stores
+        // its iterator deferred (empty backing vec). Pull every element from the
+        // iterator before the loop reads the items, else `for Seq.new($iter)`
+        // iterates nothing. Mirrors the slip/`.eager` reification path.
+        if let ValueView::Seq(arc) = iterable.view()
+            && crate::value::seq_has_deferred_iter(&arc)
+        {
+            let pulled = self.materialize_deferred_seq(&arc);
+            iterable = Value::seq_arc(std::sync::Arc::new(pulled));
+        }
         if let ValueView::Seq(arc) = iterable.view()
             && !crate::value::seq_is_cached(&arc)
         {

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -35,6 +35,19 @@ impl Interpreter {
             }
         }
         let method_name = method_sym.resolve();
+        // A `Seq.new($iterator)` stores its iterator deferred (empty backing vec).
+        // The native impls below read that empty vec directly and would yield
+        // nothing (`.List`/`.elems`/`.Array`/...). Defer such a Seq to the
+        // interpreter, whose `call_method_with_values` pulls every element from
+        // the iterator (`materialize_deferred_seq`) before dispatching. `cache`/
+        // `raku`/`perl` intentionally keep the Seq lazy (they must NOT pull), so
+        // they proceed with the native path.
+        if let ValueView::Seq(items) = target.view()
+            && crate::value::seq_has_deferred_iter(&items)
+            && !crate::value::seq_deferred_method_keeps_lazy(method_name.as_str())
+        {
+            return None;
+        }
         // `.Capture` that must call user methods / drain a live source (Channel/
         // Supply, or a non-Str Pair key needing `.Str`) is interpreter-aware; other
         // targets fall through to the pure native `value_to_capture` below.

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -328,6 +328,24 @@ impl Interpreter {
         self.explicit_initializer_context = false;
         self.vardecl_context = false;
         self.shaped_decl_context = false;
+        // A `Seq.new($iterator)` stores its iterator deferred (empty backing vec).
+        // Assigning it to an `@`/`%` container reifies the Seq (raku list
+        // semantics), so pull every element from the iterator first — the array/
+        // hash coercion below (`value_to_list`/`build_hash_from_items`) reads the
+        // items directly and would otherwise store nothing. A `$` scalar target
+        // keeps the Seq lazy, and a `:=` bind must not consume it, so both are
+        // excluded.
+        if !is_bind
+            && !is_rebind
+            && let ValueView::Seq(arc) = raw_popped.view()
+            && crate::value::seq_has_deferred_iter(&arc)
+        {
+            let name = &code.locals[idx];
+            if name.starts_with('@') || name.starts_with('%') {
+                let pulled = self.materialize_deferred_seq(&arc);
+                raw_popped = Value::seq_arc(std::sync::Arc::new(pulled));
+            }
+        }
         // Slice 2a/2b: `$scalar = @arr` / `$scalar = %hash` / chained `$r = $q`
         // promotes the source container to a shared `ContainerRef` cell (raku
         // reference semantics). Handled before the decont marker and fast/slow

--- a/t/given-when-tail-assign-value.t
+++ b/t/given-when-tail-assign-value.t
@@ -1,0 +1,46 @@
+use Test;
+
+# The value of a `given`/`when` block whose final statement is an assignment
+# (`$x = ...`) or bind (`$x := ...`) is that assigned value, not Nil. A bare
+# `given`/`when` in tail position (e.g. as a sub/method return, or the `else`
+# branch of a `with`, which desugars to a `given`) used to drop the assignment's
+# value and yield Nil. Surfaced by a two-phase `pull-one { with $!k {...} else
+# { $!k := ... } }` iterator whose `else` value was lost.
+
+plan 8;
+
+# given tail, plain assign
+sub g-assign { my $y; given 3 { $y = 5 } }
+is g-assign(), 5, 'given tail plain assign is the block value';
+
+# given tail, bind
+sub g-bind { my $y; given 3 { $y := 5 } }
+is g-bind(), 5, 'given tail bind is the block value';
+
+# when tail, assign
+sub w-assign { my $y; given 3 { when 3 { $y = 5 } } }
+is w-assign(), 5, 'when tail assign is the block value';
+
+# with/else (desugars to given), assign in else
+sub with-else-assign { my $y; with Any { 1 } else { $y = 9 } }
+is with-else-assign(), 9, 'with/else tail assign is the block value';
+
+# with/else, bind on a private attribute (the KV-iterator shape)
+class C {
+    has $!k;
+    method f {
+        with $!k { my $v = $!k; $!k := Mu; "val$v" }
+        else     { $!k := 7 }
+    }
+}
+my $c = C.new;
+is $c.f, 7,      'with/else tail bind on private attr returns the bound value';
+is $c.f, 'val7', 'the bind persisted (next call sees it via with)';
+
+# do given still works (regression guard)
+my $z;
+is (do given 4 { $z = 8 }), 8, 'do given tail assign yields the value';
+
+# a plain literal tail still yields the literal (regression guard)
+sub g-lit { given 3 { 42 } }
+is g-lit(), 42, 'given tail literal still yields the literal';

--- a/t/seq-new-user-iterator.t
+++ b/t/seq-new-user-iterator.t
@@ -1,0 +1,81 @@
+use Test;
+
+# A stateful user-defined `Iterator` whose `pull-one` transforms/generates
+# elements. `Seq.new($it)` / `*.from-iterator($it)` must actually drive
+# `pull-one` (deferred reification), not read an empty backing vec or wrap the
+# iterator as a single element.
+
+plan 16;
+
+class Counter does Iterator {
+    has $.n = 0;
+    method pull-one() {
+        return IterationEnd if $.n >= 3;
+        $!n = $.n + 1;
+        $.n;
+    }
+}
+
+is Seq.new(Counter.new).List,  (1, 2, 3),  'Seq.new(user iter).List pulls';
+is Seq.new(Counter.new).elems, 3,          'Seq.new(user iter).elems pulls';
+is Seq.new(Counter.new).Array, [1, 2, 3],  'Seq.new(user iter).Array pulls';
+is Seq.new(Counter.new).eager, (1, 2, 3),  'Seq.new(user iter).eager pulls';
+
+my $c = 0;
+for Seq.new(Counter.new) { $c++ }
+is $c, 3, 'for Seq.new(user iter) iterates';
+
+my @a = Seq.new(Counter.new);
+is @a, [1, 2, 3], '@a = Seq.new(user iter) reifies';
+
+is (|Seq.new(Counter.new)).elems, 3, 'slip Seq.new(user iter) expands';
+
+is List.from-iterator(Counter.new),  (1, 2, 3), 'List.from-iterator(user iter)';
+is Array.from-iterator(Counter.new), [1, 2, 3], 'Array.from-iterator(user iter)';
+is Slip.from-iterator(Counter.new).List, (1, 2, 3), 'Slip.from-iterator(user iter)';
+
+# A pull-one that transforms elements — the seq is NOT the raw attribute.
+class Doubler does Iterator {
+    has @.src;
+    has $.i = 0;
+    method pull-one() {
+        return IterationEnd if $.i >= @.src.elems;
+        my $v = @.src[$.i] * 2;
+        $!i = $.i + 1;
+        $v;
+    }
+}
+is Seq.new(Doubler.new(src => (1, 2, 3))).List, (2, 4, 6),
+    'Seq.new transforms via pull-one, not raw items';
+
+# The built-in `.iterator` still reifies correctly (no infinite pull loop).
+is Seq.new((1, 2, 3).iterator).List, (1, 2, 3), 'Seq.new(built-in iterator).List';
+
+# `.sort`/`.reverse` (comparator-capable methods) also reify: chained (a rvalue
+# receiver -> CallMethod) and via a variable (an lvalue receiver -> CallMethodMut).
+is Seq.new(Counter.new).sort,        (1, 2, 3), 'chained .sort reifies';
+is Seq.new(Counter.new).reverse,     (3, 2, 1), 'chained .reverse reifies';
+my $s = Seq.new(Counter.new);
+is $s.sort, (1, 2, 3), 'variable-target .sort reifies';
+
+# A two-phase `pull-one { with $!k {...} else { $!k := $it.pull-one } }` iterator
+# (the Hash::Agnostic `.kv` shape): the `else` branch's trailing `:=` bind must be
+# the block's value, so the pulled key is returned; the next call emits its value.
+class KV does Iterator {
+    has $.backend;
+    has $.iterator;
+    has $!key;
+    method pull-one() is raw {
+        with $!key {
+            my $key = $!key;
+            $!key  := Mu;
+            $!backend{$key};
+        }
+        else {
+            $!key := $!iterator.pull-one;
+        }
+    }
+}
+my %b = a => 1, b => 2;
+is Seq.new(KV.new(:backend(%b), :iterator(<a b>.iterator))).List, ("a", 1, "b", 2),
+    'two-phase KV iterator (trailing := in with/else is the block value)';


### PR DESCRIPTION
## Problem

`Seq.new(\$iterator)` and `List`/`Slip`/`Array.from-iterator(\$iterator)` store their iterator **deferred**, matching raku's laziness. But most Seq consumers read the empty backing vec and **never drive the iterator's `pull-one`**, so a user-defined `does Iterator` yielded nothing:

```raku
class Probe does Iterator { has $.n = 0; method pull-one { return IterationEnd if $.n >= 3; $!n = $.n + 1; $.n } }
Seq.new(Probe.new).List    # raku (1 2 3) ; mutsu ()   <- BUG
Seq.new(Probe.new).elems   # raku 3       ; mutsu 0     <- BUG
for Seq.new(Probe.new) {}  # raku 3 iters ; mutsu 0     <- BUG
my @a = Seq.new(Probe.new) # raku [1 2 3] ; mutsu []    <- BUG
Seq.new(Probe.new).sort    # raku (1 2 3) ; mutsu ()    <- BUG
```

Only `.eager` / slip worked (they already called `materialize_deferred_seq`).

## Fix

Reification is now **universal**. Every VM fast-path dispatch entry (native / mut / interpret) plus the for-loop and array/hash-assign paths pull every element from the iterator before reading it. They share one `seq_deferred_method_keeps_lazy` exemption so introspection and laziness-preserving methods (`.is-lazy` / `.iterator` / `.cache` / `.sink` / `.WHAT` / ...) leave the Seq lazy.

- `*.from-iterator` now drives a **user** iterator's `pull-one` (the built-in `Iterator` keeps its eager `items` shortcut — driving `pull-one` on the temporary would never advance its index).
- The `Seq.new` `items`/`stuff` shortcut is scoped strictly to the built-in `Iterator` class, so a real iterator's `pull-one` is no longer bypassed (previously `Seq.new(<iter with @.items>)` returned the raw attribute instead of the pulled/transformed values).

Also fixes a related **compiler** bug uncovered by the Hash::Agnostic `.kv` iterator: a bare `given`/`when` block whose final statement is an assignment (`\$x = ...`) or bind (`\$x := ...`) yielded `Nil` instead of the assigned value (so the two-phase `pull-one { with \$!k {...} else { \$!k := ... } }` KV shape lost its `else` value). And `.List` on a `Slip` no longer wraps the slip as a single element.

## Impact

Clears the last gap of the **Hash::Agnostic** dist `t/01-basic.rakutest` (subtest 13 `.kv`) — now **22/22, exit 0**. (`t/02-minimal.rakutest` still fails on an unrelated tied-STORE + `submethod TWEAK` constructor blocker, tracked in TODO_dist/TICKETS.md T-051.)

## Tests

- `t/seq-new-user-iterator.t` (16) — List/elems/Array/eager/for/`@a=`/slip/`.sort`/`.reverse`/`*.from-iterator`/transforming-`pull-one`/two-phase-KV/built-in-iterator.
- `t/given-when-tail-assign-value.t` (8) — given/when/with-else tail assign & bind is the block value.

`make test` green; targeted roast (`S32-list/seq.t`, `sort.t`, `reverse.t`, `S04-statements/{given,when,with}.t`) green.