### PR TITLE
fix: the metaobject introspectors are not hyper-dispatched (PLAN.md §8.6)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1166,19 +1166,16 @@ the backlog.
       rendering. Reasonable to keep deferring vs the §1/§6 frontier. Related: §6 (dual-store / lexical
       slot), [`array-hole-tracking-embedded`], [ADR-0001] container-repr.
 
-### 8.6 `.WHAT`/`.WHO`/`.HOW`/`.DEFINITE` are hyper-dispatched, but Rakudo never hypers them
+### 8.6 `>>.` sweep leftovers
 
-- [ ] **Stop hypering the metaobject introspectors.** In Rakudo `@a>>.WHAT` is not a hyper at all:
-      the introspector applies to the *target*, so `my @a = (1,2),(3,); (@a>>.WHAT).raku` is plain
-      `Array`, `(@a>>.WHO).WHAT` is `(Stash)`, `(@a>>.HOW)` is the Array's `ClassHOW`, and
-      `(@a>>.DEFINITE).WHAT` is `(Bool)`. mutsu maps them element-wise instead and yields a list of
-      per-element results. Affects `src/vm/vm_hyper_method_ops.rs`. Low user impact (nobody hypers
-      `.HOW` in anger), but it is a real divergence and the last one left in the `>>.` sweep.
-- The *nodality* half of this item is **done** (2026-07-22): the coercers (`Str`, `gist`, `raku`,
-      `perl`, `so`, `Bool`, `Numeric`, `Int`, `Rat`, `Real`, `defined`, `item`, `sink`, `cache`,
-      `lazy`) were removed from `is_nodal_list_method`, so they descend to the leaves and preserve
-      the `Array` container like raku. Pin: `t/hyper-nodality.t`. See `news/2026-07.md`.
-- Unrelated leftovers the same sweep surfaced, each small and independent: `Int.reverse` /
+- Both halves of the original item are **done** (2026-07-22): the *nodality* fix (the coercers
+      `Str`, `gist`, `raku`, `perl`, `so`, `Bool`, `Numeric`, `Int`, `Rat`, `Real`, `defined`,
+      `item`, `sink`, `cache`, `lazy` were removed from `is_nodal_list_method`, so they descend to
+      the leaves and preserve the `Array` container), and the *metaobject introspectors*
+      (`.WHAT`/`.WHO`/`.HOW`/`.DEFINITE`/`.WHERE` are no longer hyper-dispatched at all — they
+      apply to the target, like Rakudo's special forms). Pin: `t/hyper-nodality.t` (24 tests).
+      See `news/2026-07.md`.
+- [ ] Unrelated leftovers the same sweep surfaced, each small and independent: `Int.reverse` /
       `Int.rotate` / `Int.batch` are missing (raku has them on `Any`), `.tree` does not itemize its
       per-node result (`($((1,2).Seq),)` in raku), and `Supply`/`Slip`/`QuantHash` `.raku` rendering
       differs cosmetically (`Supply()` vs `Supply.new`, `slip(3)` vs `slip(3,)`).

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -32,6 +32,34 @@ This clears subtests 4/5/6 of the `Hash::Agnostic` distribution's `t/01-basic.ra
 (T-051; dist now 21/22, only `.kv` remains). Pins: `t/bound-element-readonly.t`,
 `t/tied-hash-bound-element.t`. See PLAN.md §8.7.
 
+## 2026-07-22: `@a>>.WHAT` is the Array, not a list of `Int`s — the metaobject introspectors are not hypered
+
+Closes the other half of PLAN.md §8.6, the last divergence the `>>.` sweep found.
+
+Rakudo compiles `.WHAT`/`.WHO`/`.HOW`/`.DEFINITE`/`.WHERE` as special forms rather than
+method calls, so a hyper never reaches the elements — the introspector applies to the
+*target*:
+
+```
+my @a = (1, 2), (3,);
+(@a>>.WHAT).raku       # was [(Int, Int), (Int,)]   , now Array , same as raku
+(@a>>.DEFINITE).raku   # was (Bool::True, Bool::True) , now Bool::True
+(@a>>.WHO)             # now the Array's own package stash
+say (Int>>.DEFINITE)   # False
+```
+
+A `Seq` target is no longer consumed by `$s>>.WHAT` either. Two cases deliberately keep
+hypering, because they are ordinary methods in Rakudo and were already correct:
+`.WHICH`/`.WHY`/`.VAR`, and a *quoted* name (`@a>>."WHAT"()` → `[Int, Int]`), which is a
+genuine dynamic method call. Implemented as an early bail in `exec_hyper_method_call_op`
+(`src/vm/vm_hyper_method_ops.rs`); `WHO`/`HOW`/`DEFINITE` were dropped from
+`is_nodal_list_method`, which no longer needs to approximate them at the node level.
+
+Pin: `t/hyper-nodality.t` (now 24 tests, green under `raku` too). `make test` 2236 files /
+21070 tests pass. Remaining §8.6 leftovers are unrelated and independent: `Int.reverse` /
+`Int.rotate` / `Int.batch` are missing, `.tree` does not itemize, and `Supply`/`Slip`
+`.raku` rendering differs cosmetically.
+
 ## 2026-07-22: `@a>>.Str` descends again — the hyper nodality set no longer includes the coercers
 
 Follow-up to the playground sweep below, which found this and deferred it because it touches

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -45,10 +45,9 @@ fn hyper_subscript_index_is_slice(v: &Value) -> bool {
 /// list-shaped routines `is nodal`. They used to be listed here, which is why
 /// `@a>>.Str` returned a `List` where raku returns an `Array`.
 ///
-/// Still-known gap: `.WHO`/`.HOW`/`.DEFINITE` are not hyper-dispatched at all
-/// in Rakudo (they apply to the target itself, so `@a>>.WHO` is the Array's
-/// Stash). mutsu maps them per element; they stay listed here so at least the
-/// node level is used. See PLAN.md §8.6.
+/// The metaobject introspectors (`.WHAT`/`.WHO`/`.HOW`/`.DEFINITE`/`.WHERE`)
+/// are not nodal either — they are not hyper-dispatched *at all*; see
+/// [`Interpreter::is_target_level_introspector`].
 fn is_nodal_list_method(name: &str) -> bool {
     matches!(
         name,
@@ -80,8 +79,6 @@ fn is_nodal_list_method(name: &str) -> bool {
             | "BagHash"
             | "Mix"
             | "MixHash"
-            | "WHO"
-            | "HOW"
             | "hash"
             | "Hash"
             | "kv"
@@ -103,7 +100,6 @@ fn is_nodal_list_method(name: &str) -> bool {
             | "rotor"
             | "repeated"
             | "snip"
-            | "DEFINITE"
             | "list"
             | "AT-POS"
             | "AT-KEY"
@@ -168,6 +164,19 @@ impl Interpreter {
         }
         self.set_env_with_main_alias(var, new_val.clone());
         self.locals_set_by_name(code, var, new_val);
+    }
+
+    /// Whether a name is a metaobject introspector that Rakudo compiles as a
+    /// special form rather than a method call, so a hyper never applies to the
+    /// elements: `my @a = (1,2),(3,); (@a>>.WHAT).raku` is plain `Array`,
+    /// `(@a>>.WHO)` is the Array's Stash, `(@a>>.HOW)` its ClassHOW,
+    /// `(@a>>.DEFINITE)` a single Bool, and `@a>>.WHERE` == `@a.WHERE`.
+    ///
+    /// `.WHICH`, `.WHY` and `.VAR` are ordinary methods in Rakudo and *do*
+    /// hyper, so they are not listed. A *quoted* name (`@a>>."WHAT"()`) is a
+    /// genuine dynamic method call and hypers too — the caller checks that.
+    fn is_target_level_introspector(name: &str) -> bool {
+        matches!(name, "WHAT" | "WHO" | "HOW" | "DEFINITE" | "WHERE")
     }
 
     /// `$b>>++` / `$b>>--` on a Bag/Mix/Set: apply the postfix op to each weight,
@@ -270,6 +279,17 @@ impl Interpreter {
         let target = self.stack.pop().ok_or_else(|| {
             RuntimeError::new("Interpreter stack underflow in HyperMethodCall target")
         })?;
+        // The metaobject introspectors are *not* hyper-dispatched in Rakudo:
+        // they are compiled as special forms, so `@a>>.WHAT` applies to the
+        // Array itself (`Array`, not a per-element list of `Int`s), and a Seq
+        // target is not consumed. `.WHICH`/`.WHY`/`.VAR` *are* ordinary methods
+        // and do hyper, so they are deliberately absent here.
+        if arity == 0 && !quoted && Self::is_target_level_introspector(method_raw) {
+            let (result, _) =
+                self.call_method_mut_with_temp_target(&target, method_raw, vec![], 0)?;
+            self.stack.push(result);
+            return Ok(());
+        }
         // Mark Seq as consumed (single-use semantics).
         if let ValueView::Seq(arc) = target.view() {
             crate::value::seq_consume(&arc)?;

--- a/t/hyper-nodality.t
+++ b/t/hyper-nodality.t
@@ -6,7 +6,7 @@ use Test;
 # introspectors* nodal, so `@a>>.Str` stopped at the node and yielded a List
 # where Rakudo descends to the leaves and yields an Array.
 
-plan 16;
+plan 24;
 
 my @flat = 1, 2, 3;
 my @nested = (1, 2), (3,);
@@ -41,5 +41,24 @@ is @flat>>.elems.raku, '(1, 1, 1)', '.elems at the node level over scalar elemen
 # --- the hyper still writes back / composes ---------------------------------
 
 is (@flat >>+>> 10).raku, '[11, 12, 13]', 'a hyper operator over an Array still yields an Array';
+
+# --- the metaobject introspectors are not hyper-dispatched at all ------------
+# Rakudo compiles .WHAT/.WHO/.HOW/.DEFINITE as special forms, so `>>` never
+# reaches the elements: they apply to the target itself.
+
+is (@nested>>.WHAT).raku, 'Array', '>>.WHAT applies to the target, not the elements';
+is (@nested>>.DEFINITE).raku, 'Bool::True', '>>.DEFINITE applies to the target';
+# (mutsu renders a Stash as a plain Hash -- compare against the target's own
+# .WHO instead of pinning the type name.)
+is (@nested>>.WHO).raku, @nested.WHO.raku, '>>.WHO is the target package stash';
+is ((1, 2)>>.WHAT).raku, 'List', '>>.WHAT over a List is the List type object';
+is (%(:a(1))>>.WHAT).raku, 'Hash', '>>.WHAT over a Hash is the Hash type object';
+is (Int>>.DEFINITE).raku, 'Bool::False', '>>.DEFINITE over a type object is False';
+
+# A *quoted* method name is a genuine dynamic method call and does hyper.
+is (@flat>>."WHAT"()).raku, '[Int, Int, Int]', 'a quoted >>."WHAT"() still hypers';
+
+# .WHICH is an ordinary method in Rakudo, so it keeps hypering.
+is (@flat>>.WHICH).elems, 3, '>>.WHICH still hypers';
 
 done-testing;


### PR DESCRIPTION
Closes the remaining half of PLAN.md §8.6 — the last divergence found by the `>>.` mutsu-vs-raku sweep.

Rakudo compiles `.WHAT`/`.WHO`/`.HOW`/`.DEFINITE`/`.WHERE` as special forms rather than method calls, so a hyper never reaches the elements: the introspector applies to the **target**. mutsu mapped them element-wise instead.

```
my @a = (1, 2), (3,);
(@a>>.WHAT).raku       # was [(Int, Int), (Int,)]     , now Array
(@a>>.DEFINITE).raku   # was (Bool::True, Bool::True) , now Bool::True
(@a>>.WHO)             # now the Array's own package stash
say (Int>>.DEFINITE)   # False
```

A `Seq` target is no longer consumed by `$s>>.WHAT` either.

Two cases deliberately keep hypering, because they are ordinary methods in Rakudo and were already correct:

- `.WHICH` / `.WHY` / `.VAR`
- a *quoted* name — `@a>>."WHAT"()` is a genuine dynamic method call and yields `[Int, Int]` in raku too.

Implemented as an early bail in `exec_hyper_method_call_op` (`src/vm/vm_hyper_method_ops.rs`); `WHO`/`HOW`/`DEFINITE` were dropped from `is_nodal_list_method`, which no longer needs to approximate them at the node level.

Pin: `t/hyper-nodality.t`, 16 -> 24 tests, **green under `raku` too** (all 24 verified against the reference implementation). `make test` passes: 2236 files / 21070 tests.

Remaining §8.6 leftovers are unrelated and independent (`Int.reverse`/`rotate`/`batch` missing, `.tree` itemization, `Supply`/`Slip` `.raku` rendering); PLAN.md updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)