### PR TITLE
fix: a bare HyperWhatever (`**`) matches any value under `~~`

### DIFF
--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -92,8 +92,9 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
     }
 
     match (left.view(), right.view()) {
-        // Whatever on RHS always matches
-        (_, ValueView::Whatever) => Some(true),
+        // Whatever / HyperWhatever on RHS always matches (`$x ~~ (**)` is True for
+        // any value — a bare `**` pattern matches everything, like `*`).
+        (_, ValueView::Whatever | ValueView::HyperWhatever) => Some(true),
 
         // Junction ~~ Junction/Mu type: a Junction IS a Junction, don't autothread
         (ValueView::Junction { .. }, ValueView::Package(name))

--- a/t/smartmatch-hyperwhatever.t
+++ b/t/smartmatch-hyperwhatever.t
@@ -1,0 +1,22 @@
+use v6;
+use Test;
+
+plan 11;
+
+# A bare HyperWhatever pattern (`**`) on the RHS of `~~` matches ANY value,
+# like `*` (Whatever). Regression: `$x ~~ (**)` returned False.
+ok (1, 2, 4, 5, 6) ~~ (**), 'a non-empty list matches bare **';
+ok ()              ~~ (**), 'the empty list matches bare **';
+ok 5               ~~ (**), 'a scalar matches bare **';
+ok "x"             ~~ (**), 'a string matches bare **';
+ok Any             ~~ (**), 'a type object matches bare **';
+
+# `**` inside a list pattern still constrains (this already worked — guard it).
+ok (1, 3)          ~~ (1, **, 3), '** spans zero-or-more middle elements';
+ok (1, 2, 4, 5, 3) ~~ (1, **, 3), '** spans several middle elements';
+nok (1, 2, 4, 5, 6) ~~ (1, **, 5), 'trailing element must still match after **';
+ok (1, 2, 3)       ~~ (**, 3), 'leading ** with a fixed tail';
+nok (1, 2, 3)      ~~ (**, 5), 'leading ** but wrong tail fails';
+
+# The full List.rakudoc example bundled as one check.
+is-deeply [(1,2,3) ~~ (1,*,3), (1,2,3) ~~ (9,*,5), (1,3) ~~ (1,**,3), (1,2,4,5,6) ~~ (**)], [True, False, True, True], 'List.rakudoc smartmatch examples';


### PR DESCRIPTION
## Problem

```raku
say (1, 2, 4, 5, 6) ~~ (**);   # raku: True   mutsu: False
say ()              ~~ (**);   # raku: True   mutsu: False
```

`(**)` is a bare `HyperWhatever` (its `.WHAT` is `HyperWhatever`). Smartmatching
any value against it should be `True` — it matches everything, like `*`.
`pure_smart_match` had a `(_, ValueView::Whatever) => Some(true)` arm but none
for `HyperWhatever`, so `**` fell through to an ordinary type/value comparison
and returned `False`.

## Fix

Extend the Whatever arm to also match `HyperWhatever`. A `**` *inside* a list
pattern (`(1, **, 3)`) is a separate span matcher that already worked and is
unaffected — only the bare-`**` RHS changes.

## Tests

- `t/smartmatch-hyperwhatever.t` — bare `**` against list/scalar/string/type/empty,
  plus the list-pattern `**` cases as guards, and the full List.rakudoc example.
- `t/smart*.t`, `t/whatever*.t`, `t/hyperwhatever*.t` suites still green.

Found via the raku-doc/doc/Type/List.rakudoc doc-diff sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)