### PR TITLE
fix: Any.reverse is self.list.reverse; .rotate is list-only

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1175,10 +1175,15 @@ the backlog.
       (`.WHAT`/`.WHO`/`.HOW`/`.DEFINITE`/`.WHERE` are no longer hyper-dispatched at all — they
       apply to the target, like Rakudo's special forms). Pin: `t/hyper-nodality.t` (24 tests).
       See `news/2026-07.md`.
-- [ ] Unrelated leftovers the same sweep surfaced, each small and independent: `Int.reverse` /
-      `Int.rotate` / `Int.batch` are missing (raku has them on `Any`), `.tree` does not itemize its
-      per-node result (`($((1,2).Seq),)` in raku), and `Supply`/`Slip`/`QuantHash` `.raku` rendering
-      differs cosmetically (`Supply()` vs `Supply.new`, `slip(3)` vs `slip(3,)`).
+- The `.reverse`/`.rotate` leftovers are also **done** (2026-07-22): `Any.reverse` is
+      `self.list.reverse`, so a non-Iterable reverses to a one-element Seq (`"abc".reverse` is
+      `("abc",).Seq`, not the `.flip`ped `"cba"` mutsu used to return, and `42.reverse` no longer
+      errors), while `.rotate` — which Rakudo does *not* define on `Any` — throws
+      `X::Method::NotFound` instead of returning a silent `Nil`. (`.batch` was already correct.)
+      Pin: `t/any-reverse-rotate.t`.
+- [ ] Remaining leftovers, each small and independent: `.tree` does not itemize its per-node
+      result (`$((1,2).Seq)` in raku, mutsu `(1, 2)`), and `Supply`/`Slip`/`QuantHash` `.raku`
+      rendering differs cosmetically (`Supply()` vs `Supply.new`, `slip(3)` vs `slip(3,)`).
 
 ### 8.7 Bound-element immutability (mostly LANDED 2026-07-22; only `.kv` remains)
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -32,6 +32,32 @@ This clears subtests 4/5/6 of the `Hash::Agnostic` distribution's `t/01-basic.ra
 (T-051; dist now 21/22, only `.kv` remains). Pins: `t/bound-element-readonly.t`,
 `t/tied-hash-bound-element.t`. See PLAN.md §8.7.
 
+## 2026-07-22: `"abc".reverse` is `("abc",).Seq` — `Any.reverse` is `self.list.reverse`, and `.rotate` is list-only
+
+Two more §8.6 leftovers from the `>>.` mutsu-vs-raku sweep.
+
+`.reverse` on a non-Iterable is `Any.reverse` == `self.list.reverse`, so it yields a
+one-element Seq. mutsu's *method* form flipped a Str's characters (that is `.flip`) and had
+no `.reverse` at all for the other scalars — even though the `reverse(...)` *function* form
+already did the right thing, comment and all:
+
+```
+"abc".reverse      # was "cba"      , now ("abc",).Seq , same as raku
+42.reverse         # was an error   , now (42,).Seq
+(a => 1).reverse   # was an error   , now (:a(1),).Seq
+"abc".flip         # "cba" , unchanged; this is the character reversal
+```
+
+`.rotate` is the opposite case: Rakudo does **not** define it on `Any`, so a non-Iterable
+invocant must throw `X::Method::NotFound` — mutsu returned a silent `Nil` (`42.rotate` →
+`Nil`), which quietly swallowed a typo. (`.batch`, the third name PLAN.md listed here, turned
+out to be correct already.)
+
+`t/vm-basic.t` asserted the old `"abc".reverse eq "cba"`; it now pins raku's behaviour plus a
+`.flip` companion. New pin: `t/any-reverse-rotate.t` (17 tests, green under `raku` too). The
+25 whitelisted roast files that touch `.reverse`/`.rotate` (`S32-list/reverse.t`,
+`S32-array/rotate.t`, `S02-types/array.t`, `S17-supply/*`, …) all still pass.
+
 ## 2026-07-22: `@a>>.WHAT` is the Array, not a list of `Int`s — the metaobject introspectors are not hypered
 
 Closes the other half of PLAN.md §8.6, the last divergence the `>>.` sweep found.

--- a/src/builtins/methods_0arg/dispatch_core_list.rs
+++ b/src/builtins/methods_0arg/dispatch_core_list.rs
@@ -138,7 +138,21 @@ pub(super) fn dispatch(
                     Some(Ok(Value::seq(reversed)))
                 }
             }
-            ValueView::Str(s) => Some(Ok(Value::str(s.chars().rev().collect()))),
+            // `Any.reverse` is `self.list.reverse`, so a non-Iterable is a
+            // one-element list and reverses to itself: `"abc".reverse` is
+            // `("abc",).Seq`, NOT `"cba"` (that is `.flip`). The `reverse(...)`
+            // *function* form already did this; the method form did not.
+            ValueView::Str(_)
+            | ValueView::Int(_)
+            | ValueView::BigInt(_)
+            | ValueView::Num(_)
+            | ValueView::Bool(_)
+            | ValueView::Rat(..)
+            | ValueView::FatRat(..)
+            | ValueView::BigRat(..)
+            | ValueView::Complex(..)
+            | ValueView::Pair(..)
+            | ValueView::ValuePair(..) => Some(Ok(Value::seq(vec![target.clone()]))),
             ValueView::Seq(items) | ValueView::Slip(items) => {
                 // A non-lazy Seq/Slip reverses its materialized elements. (Lazy
                 // Seqs are deferred-materialized by the slow path before reaching

--- a/src/runtime/methods_collection_ops/tail_rotate.rs
+++ b/src/runtime/methods_collection_ops/tail_rotate.rs
@@ -243,7 +243,15 @@ impl Interpreter {
             match target.view() {
                 ValueView::Capture { positional, .. } => positional.clone(),
                 ValueView::LazyList(ll) => ll.cache.lock().unwrap().clone().unwrap_or_default(),
-                _ => return Ok(Value::NIL),
+                // Unlike `.reverse`, `.rotate` is NOT defined on `Any` in Rakudo
+                // (only on List/Array/Buf), so a non-Iterable invocant is a
+                // method-not-found error, not a silent `Nil`.
+                _ => {
+                    return Err(RuntimeError::method_not_found(
+                        "rotate",
+                        &crate::value::types::what_type_name(&target),
+                    ));
+                }
             }
         };
         if items.is_empty() {

--- a/t/any-reverse-rotate.t
+++ b/t/any-reverse-rotate.t
@@ -1,0 +1,35 @@
+use Test;
+
+# `Any.reverse` is `self.list.reverse`, so a non-Iterable invocant is a
+# one-element list and reverses to itself. mutsu used to flip a Str instead
+# (that is `.flip`) and to have no `.reverse` at all on the other scalars.
+# `.rotate`, by contrast, is NOT defined on `Any` in Rakudo, so a non-Iterable
+# invocant is a method-not-found error rather than a silent `Nil`.
+
+plan 17;
+
+is "abc".reverse.raku, '("abc",).Seq', '.reverse on a Str is a 1-element Seq';
+is "abc".flip, 'cba', '.flip is what reverses the characters';
+is 42.reverse.raku, '(42,).Seq', '.reverse on an Int';
+is (1/2).reverse.raku, '(0.5,).Seq', '.reverse on a Rat';
+is 1.5e0.reverse.raku, '(1.5e0,).Seq', '.reverse on a Num';
+is True.reverse.raku, '(Bool::True,).Seq', '.reverse on a Bool';
+is (1+2i).reverse.raku, '(<1+2i>,).Seq', '.reverse on a Complex';
+is (a => 1).reverse.raku, '(:a(1),).Seq', '.reverse on a Pair';
+is 100000000000000000000.reverse.elems, 1, '.reverse on a big Int is 1 element';
+
+# The list cases are unchanged.
+is [1, 2, 3].reverse.raku, '(3, 2, 1).Seq', '.reverse on an Array still reverses';
+is (1..3).reverse.raku, '(3, 2, 1).Seq', '.reverse on a Range still reverses';
+is (1, 2).Seq.reverse.raku, '(2, 1).Seq', '.reverse on a Seq still reverses';
+
+# The `reverse(...)` function form already agreed with raku; pin it.
+is reverse("abc").raku, '("abc",).Seq', 'reverse() on a Str is a 1-element Seq';
+is reverse(1, 2).raku, '(2, 1).Seq', 'reverse() on a list still reverses';
+
+# .rotate is list-only.
+is [1, 2, 3].rotate.raku, '(2, 3, 1).Seq', '.rotate on an Array still rotates';
+throws-like { 42.rotate }, X::Method::NotFound, '.rotate on an Int is a method-not-found';
+throws-like { "ab".rotate }, X::Method::NotFound, '.rotate on a Str is a method-not-found';
+
+done-testing;

--- a/t/vm-basic.t
+++ b/t/vm-basic.t
@@ -1,5 +1,5 @@
 use Test;
-plan 327;
+plan 328;
 
 # Literal compilation
 is 42, 42, 'integer literal';
@@ -611,7 +611,10 @@ is @nested.flat.elems, 5, 'native .flat flattens array';
 # .reverse
 my @rev = (1, 2, 3);
 is @rev.reverse.join(","), "3,2,1", 'native .reverse on array';
-is "abc".reverse, "cba", 'native .reverse on string';
+# A Str is a single element for `Any.reverse`, so it reverses to itself.
+# (Reversing the characters is `.flip`.)
+is "abc".reverse.raku, '("abc",).Seq', 'native .reverse on string is a 1-element Seq';
+is "abc".flip, "cba", '.flip reverses the characters';
 
 # .unique
 my @dup = (1, 2, 2, 3, 1);


### PR DESCRIPTION
Two more PLAN.md §8.6 leftovers from the `>>.` mutsu-vs-raku sweep.

### `.reverse`

`.reverse` on a non-Iterable is `Any.reverse` == `self.list.reverse`, so it yields a **one-element Seq**. mutsu's *method* form flipped a Str's characters (that is `.flip`) and had no `.reverse` at all for the other scalars — even though the `reverse(...)` **function** form already did the right thing, comment and all (`dispatch_1arg.rs`: "reverse() on a string returns a single-element Seq (not a flip)").

```
"abc".reverse      # was "cba"       , now ("abc",).Seq  , same as raku
42.reverse         # was an error    , now (42,).Seq
(a => 1).reverse   # was an error    , now (:a(1),).Seq
"abc".flip         # "cba" , unchanged -- this is the character reversal
[1,2,3].reverse    # (3, 2, 1).Seq , unchanged
```

### `.rotate`

The opposite case: Rakudo does **not** define `.rotate` on `Any`, so a non-Iterable invocant must throw `X::Method::NotFound`. mutsu returned a silent `Nil` (`42.rotate` → `Nil`), which quietly swallowed a typo.

(`.batch`, the third name PLAN.md listed alongside these, turned out to be correct already.)

### Tests

- New pin `t/any-reverse-rotate.t` — 17 tests, **green under `raku` too**.
- `t/vm-basic.t` asserted the old `"abc".reverse eq "cba"`; per the "roast/raku is authoritative, update the local test" rule it now pins raku's behaviour and gained a `.flip` companion assertion.
- `make test` passes, and the 25 whitelisted roast files that touch `.reverse`/`.rotate` (`S32-list/reverse.t`, `S32-array/rotate.t`, `S02-types/array.t`, `S17-supply/{reverse,rotate,map,grab}.t`, `S32-container/buf.t`, …) all still pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)