### PR TITLE
fix: a module-local class shadows a same-named built-in namespace as a parent

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -12,15 +12,6 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 
 ## Open
 
-### T-052 — runtime_error: 'X' cannot inherit from 'X' because it is unknown.  [impact: 1 dist]
-- dists: Node::Ethereum::RLP
-- e.g. `Node::Ethereum::RLP`: Node::Ethereum::RLP: 'X::Decode' cannot inherit from 'X' because it is unknown.
-- repro: `class X is Exception {}; class X::Decode is X {}` — a user class named `X`
-  collides with the built-in `X::` exception namespace, so `is X` cannot resolve the
-  user `X`. (Split out of T-001 #5064, which fixed only the `also is X::Qualified`
-  truncation for Config::TOML/Crane.)
-- file: _(needs namespace-resolution work: user `X` vs built-in `X::` exception ns)_
-
 ### T-003 — runtime_error: No such method X for invocant of type 'X'  [impact: 2 dists]
 - dists: Injector, hyperize
 - e.g. `Injector`: Injector: No such method 'loaded' for invocant of type 'CompUnit::Repository::FileSystem'
@@ -133,12 +124,6 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 ### T-033 — test_die [vCard::Parser]  [impact: 1 dist]
 - dists: vCard::Parser
 - e.g. `vCard::Parser`: base=2 pass=1 fail=0 die=1 | t/02-grammar.rakutest: 
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
-
-### T-034 — test_die: No such private method X for invocant of type 'X'  [impact: 1 dist]
-- dists: IdClass
-- e.g. `IdClass`: base=6 pass=0 fail=0 die=6 | t/01-basic.rakutest: No such private method 'gen-rest' for invocant of type 'UserId'
 - repro: _(fill in a minimal repro + raku baseline before fixing)_
 - file: _(suspected parser/runtime file)_
 
@@ -295,7 +280,27 @@ _(move tickets here with `[claim: <branch>]` when you start)_
 
 ## Done
 
-- **T-028** (#PENDING) — P5reset's `reset()` died with "Cannot modify an
+- **T-052** (#PENDING) — Node::Ethereum::RLP failed to load: its
+  `Exception.rakumod` declares `module M { class X is Exception {}; class
+  X::Decode is X {}; class X::Decode::Length is X::Decode {} }`, and `is X`
+  resolved to the built-in `X::` exception namespace (registered as a class)
+  instead of the module-local `M::X`, throwing "'X::Decode' cannot inherit from
+  'X' because it is unknown." Fix: when registering a class inside a module, a
+  bare inheritance-parent name is now qualified to `{current_package}::{parent}`
+  when that names a registered class/role (`qualify_sibling_parent_name`, called
+  from `vm_typedecl_ops` where `current_package` is the enclosing module) — the
+  module-local sibling lexically shadows the same-named built-in. The RLP dist
+  now loads and both test files pass (8/8, 9/9). **Note (separate, pre-existing,
+  not this ticket):** a class written `X::Decode` inside a module is still
+  registered under the bare `X::Decode` rather than `M::X::Decode`, and a bare
+  `X` *term* inside the module still resolves to the built-in namespace — neither
+  affects the dist (the inheritance chain is correct at the object level). Pin:
+  t/module-local-class-shadows-builtin-ns.t.
+- **T-034** (stale) — IdClass ("No such private method 'gen-rest'"): re-verified
+  against the current binary, all 6 test files pass (6/6). The sweep TSV was a
+  stale snapshot; an earlier fix already resolved it. Removed from Open with no
+  new PR (nothing to change).
+- **T-028** (#5180) — P5reset's `reset()` died with "Cannot modify an
   immutable value" on its comb-loop ternary. A ternary `?? !!` is an lvalue and
   assignment binds LOOSER than the conditional, so `cond ?? A !! B op= rhs`
   parses as `(cond ?? A !! B) op= rhs` — the compound (or simple) assignment

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -421,6 +421,40 @@ impl Interpreter {
         names
     }
 
+    /// Qualify a bare inheritance-parent name with the current package when a
+    /// same-named sibling class/role is declared there. Inside
+    /// `module M { class X is Exception {}; class X::Decode is X {} }`, the parent
+    /// `X` collides with the built-in `X::` exception namespace; without this the
+    /// MRO links `X::Decode` to the built-in namespace (an unknown parent, so it
+    /// falls back to `Any`) instead of the module-local `M::X`.
+    ///
+    /// Only rewrites a bare name (no `::`, no type args) when
+    /// `{current_package}::{name}` names a registered class/role. A module-local
+    /// class lexically shadows any same-named outer or built-in type, so the
+    /// package-qualified sibling is preferred even when a bare built-in of that
+    /// name also exists (e.g. `X`, which is registered as the built-in `X::`
+    /// exception namespace class); genuine built-in and cross-package parents,
+    /// which have no current-package-qualified sibling, are left untouched.
+    pub(crate) fn qualify_sibling_parent_name(&self, parent: &str) -> String {
+        if parent.contains("::") || parent.contains('[') {
+            return parent.to_string();
+        }
+        let pkg = self.current_package();
+        if pkg.is_empty() || pkg == "GLOBAL" {
+            return parent.to_string();
+        }
+        let qualified = format!("{}::{}", pkg, parent);
+        let registered = {
+            let reg = self.registry();
+            reg.classes.contains_key(&qualified) || reg.roles.contains_key(&qualified)
+        };
+        if registered {
+            qualified
+        } else {
+            parent.to_string()
+        }
+    }
+
     pub(crate) fn resolve_declared_type_name(&self, name: &str) -> String {
         let (base, suffix) = if let Some(bracket) = name.find('[') {
             (&name[..bracket], &name[bracket..])

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -140,6 +140,13 @@ impl Interpreter {
             let mapped_parents: Vec<String> = parents
                 .iter()
                 .map(|p| self.lexical_env_remap_name(p))
+                // Qualify a bare parent that names a sibling class in the current
+                // package but collides with a built-in namespace (`class X::Decode
+                // is X` inside `module M`, where `X` is both `M::X` and the built-in
+                // `X::` exception namespace). Must run here, where `current_package`
+                // is the enclosing module — the child class name reaches
+                // `register_class_decl` without its module prefix.
+                .map(|p| self.qualify_sibling_parent_name(&p))
                 .collect();
             let mapped_hidden_parents: Vec<String> = hidden_parents
                 .iter()

--- a/t/module-local-class-shadows-builtin-ns.t
+++ b/t/module-local-class-shadows-builtin-ns.t
@@ -1,0 +1,69 @@
+use v6;
+use Test;
+
+# A class declared inside a module shadows a built-in namespace of the same
+# name when resolving an inheritance parent. Regression pin for the
+# Node::Ethereum::RLP dist, whose Exception.rakumod does:
+#
+#   module Node::Ethereum::RLP::Exception {
+#       class X is Exception { ... }
+#       class X::Decode is X {};
+#       class X::Decode::Length is X::Decode {};
+#   }
+#
+# `X` collides with the built-in `X::` exception namespace, so `is X` used to
+# resolve to the built-in namespace (an unknown inheritance parent that fell
+# back to `Any`) instead of the module-local `X`, throwing
+# "'X::Decode' cannot inherit from 'X' because it is unknown."
+
+lives-ok {
+    module M {
+        class X is Exception {}
+        class X::Decode is X {}
+    }
+}, 'class X::Decode is X resolves the module-local X inside a module';
+
+lives-ok {
+    module M2 {
+        class X is Exception {}
+        class X::Decode is X {}
+        class X::Decode::Length is X::Decode {}
+    }
+}, 'a deeper X::Decode::Length is X::Decode chain also resolves';
+
+# The inheritance chain is wired to the module-local X (not the built-in `X`,
+# whose MRO is just `X Any Mu`). Assert on the MRO name list, which does not
+# depend on how a bare `X` term resolves.
+module M3 {
+    class X is Exception {
+        has Str $.payload is default('boom');
+        method message { "X: $!payload" }
+    }
+    class X::Decode is X {}
+    class X::Decode::Length is X::Decode {}
+
+    my @decode-mro = X::Decode.^mro.map(*.^name);
+    ok @decode-mro.grep(* eq 'Exception'),
+        'X::Decode MRO reaches Exception (parent linked, not Any)';
+    ok @decode-mro.grep(*.ends-with('::X')),
+        'X::Decode inherits the module-local X, not the built-in X';
+
+    ok X::Decode::Length.^mro.map(*.^name).grep(* eq 'Exception'),
+        'X::Decode::Length MRO reaches Exception through the chain';
+}
+
+# A non-colliding sibling name (Y) was never affected — keep it as a control.
+module M4 {
+    class Y is Exception {}
+    class Y::Decode is Y {}
+    ok Y::Decode.^mro.map(*.^name).grep(* eq 'Exception'),
+        'a non-colliding sibling name still links (control)';
+}
+
+# Top-level (no enclosing module) was already correct.
+lives-ok {
+    class TX is Exception {}
+    class TX::Decode is TX {}
+}, 'top-level class-name-as-namespace inheritance still works';
+
+done-testing;


### PR DESCRIPTION
Inside `module M { class X is Exception {}; class X::Decode is X {} }`, the parent `X` resolved to the built-in `X::` exception namespace (which is itself a registered class) instead of the module-local `M::X`, throwing `'X::Decode' cannot inherit from 'X' because it is unknown.` A module-local class lexically shadows any same-named outer or built-in type, so the parent must bind to `M::X`.

## Fix
When a class is registered inside a module, a bare inheritance-parent name is now qualified to `{current_package}::{parent}` whenever that names a registered class/role (`qualify_sibling_parent_name`). It runs in `vm_typedecl_ops`, where `current_package` is the enclosing module — the child class name reaches `register_class_decl` without its module prefix, so the qualification can't be derived from the child name alone.

## Impact
Unblocks **Node::Ethereum::RLP**, whose `Exception.rakumod` uses exactly this pattern (`class X is Exception; class X::Decode is X; class X::Decode::Length is X::Decode`). The dist now loads and both test files pass (8/8, 9/9).

**Note (separate, pre-existing, out of scope):** a class written `X::Decode` inside a module is still registered under the bare `X::Decode` rather than `M::X::Decode`, and a bare `X` *term* inside the module still resolves to the built-in namespace. Neither affects the dist — the inheritance chain is correct at the object level.

Also retires the stale **T-034** (IdClass) ticket: re-verified 6/6 passing on the current binary (its sweep TSV was a stale snapshot).

Pin: `t/module-local-class-shadows-builtin-ns.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)