### PR TITLE
fix: .tree itemizes every node it descends into

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1181,9 +1181,12 @@ the backlog.
       errors), while `.rotate` — which Rakudo does *not* define on `Any` — throws
       `X::Method::NotFound` instead of returning a silent `Nil`. (`.batch` was already correct.)
       Pin: `t/any-reverse-rotate.t`.
-- [ ] Remaining leftovers, each small and independent: `.tree` does not itemize its per-node
-      result (`$((1,2).Seq)` in raku, mutsu `(1, 2)`), and `Supply`/`Slip`/`QuantHash` `.raku`
-      rendering differs cosmetically (`Supply()` vs `Supply.new`, `slip(3)` vs `slip(3,)`).
+- `.tree` is **done** (2026-07-22): it itemizes every node it descends into, so `(1, 2).tree`
+      is `$((1, 2).Seq)` and `.tree(n)` itemizes exactly the `n` levels it treed — which is what
+      makes `.tree(*)` identical to `.tree` (roast `S02-lists/tree.t` test 12, previously passing
+      only because *both* sides were un-itemized). Pin: `t/tree-itemization.t`.
+- [ ] Last leftover: `Supply`/`Slip`/`QuantHash` `.raku` rendering differs cosmetically
+      (`Supply()` vs `Supply.new`, `slip(3)` vs `slip(3,)`).
 
 ### 8.7 Bound-element immutability (mostly LANDED 2026-07-22; only `.kv` remains)
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -32,6 +32,30 @@ This clears subtests 4/5/6 of the `Hash::Agnostic` distribution's `t/01-basic.ra
 (T-051; dist now 21/22, only `.kv` remains). Pins: `t/bound-element-readonly.t`,
 `t/tied-hash-bound-element.t`. See PLAN.md §8.7.
 
+## 2026-07-22: `.tree` itemizes every node it descends into
+
+The last structural §8.6 leftover. `.tree` on an Iterable is `$(self.map(*.tree).Seq)` — each
+node is an *itemized* Seq — and mutsu returned a plain, un-itemized Array:
+
+```
+(1, 2).tree.raku          # was (1, 2)          , now $((1, 2).Seq)
+(1, (2, 3)).tree.raku     # was (1, (2, 3))     , now $((1, $((2, 3).Seq)).Seq)
+(1..3).tree.raku          # was 1..3            , now $((1, 2, 3).Seq)
+%(:a(1)).tree.raku        # was {:a(1)}         , now $((:a(1),).Seq)
+"ab".tree                 # "ab" , unchanged: a non-Iterable is its own tree
+```
+
+The `.tree(n)` depth forms itemize exactly the `n` levels they tree, which is what makes
+`.tree(*)` identical to `.tree` — `roast/S02-lists/tree.t` test 12 asserts precisely that and
+was passing only because *both* sides were un-itemized; fixing the 0-arg form alone broke it.
+Both paths now share one `tree_to_depth(&Value, depth)` helper in
+`src/builtins/methods_0arg/dispatch_core_math.rs`, replacing the duplicated `tree_recursive` /
+`Interpreter::tree_depth` pair (the latter is deleted), and it also covers Seq/Slip/Hash/Range
+targets that the old Array-only version passed through untouched.
+
+Pin: `t/tree-itemization.t` (15 tests, green under `raku` too). `make test` 2249 files /
+21218 tests pass, as do the whitelisted `S02-lists/tree.t` and `S03-metaops/hyper.t`.
+
 ## 2026-07-22: `"abc".reverse` is `("abc",).Seq` — `Any.reverse` is `self.list.reverse`, and `.rotate` is list-only
 
 Two more §8.6 leftovers from the `>>.` mutsu-vs-raku sweep.

--- a/src/builtins/methods_0arg/dispatch_core_math.rs
+++ b/src/builtins/methods_0arg/dispatch_core_math.rs
@@ -82,14 +82,33 @@ fn str_to_rat(s: &str) -> Value {
 }
 
 /// Recursively apply `.tree` to nested arrays.
-fn tree_recursive(items: &[Value]) -> Vec<Value> {
-    items
+/// `.tree` on an Iterable is `$(self.map(*.tree).Seq)`: every node it descends
+/// into becomes an *itemized* Seq, so `(1, (2, 3)).tree.raku` is
+/// `$((1, $((2, 3).Seq)).Seq)`. A non-Iterable is its own tree.
+///
+/// `depth` is how many levels still get treed — `.tree(1)` itemizes only the
+/// top node and leaves its children as they are, `.tree(0)` is the identity,
+/// and `.tree` / `.tree(*)` are `usize::MAX`. Shared with the `.tree(...)`
+/// argument forms in `runtime::…::dispatch_tree`.
+pub(crate) fn tree_to_depth(v: &Value, depth: usize) -> Value {
+    if depth == 0 {
+        return v.clone();
+    }
+    let children = match v.view() {
+        ValueView::Array(inner, ..) => inner.to_vec(),
+        ValueView::Seq(inner) | ValueView::Slip(inner) => inner.to_vec(),
+        ValueView::Hash(_)
+        | ValueView::Range(..)
+        | ValueView::RangeExcl(..)
+        | ValueView::RangeExclStart(..)
+        | ValueView::RangeExclBoth(..) => crate::runtime::utils::value_to_list(v),
+        _ => return v.clone(),
+    };
+    let treed = children
         .iter()
-        .map(|v| match v.view() {
-            ValueView::Array(inner, ..) => Value::array(tree_recursive(&inner)),
-            _ => v.clone(),
-        })
-        .collect()
+        .map(|c| tree_to_depth(c, depth - 1))
+        .collect();
+    Value::scalar(Value::seq(treed))
 }
 
 /// Levenshtein edit distance between two strings (by Unicode scalar), used for
@@ -576,10 +595,7 @@ pub(super) fn dispatch(
                 }
             }
         }),
-        "tree" => Some(match target.view() {
-            ValueView::Array(items, ..) => Some(Ok(Value::array(tree_recursive(&items)))),
-            _ => Some(Ok(target.clone())),
-        }),
+        "tree" => Some(Some(Ok(tree_to_depth(target, usize::MAX)))),
         "encode" => {
             let s = target.to_string_value();
             let bytes: Vec<Value> = s.as_bytes().iter().map(|&b| Value::int(b as i64)).collect();

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod collection;
 pub(crate) mod complex_math;
 mod dispatch_core_coerce;
 mod dispatch_core_list;
-mod dispatch_core_math;
+pub(crate) mod dispatch_core_math;
 mod dispatch_core_numeric;
 pub(crate) mod dispatch_core_range;
 mod dispatch_core_repr;

--- a/src/runtime/methods_collection_ops/first_polymod_tree.rs
+++ b/src/runtime/methods_collection_ops/first_polymod_tree.rs
@@ -281,12 +281,24 @@ impl Interpreter {
             // .tree(0) — identity
             ValueView::Int(0) => Ok(target),
             // .tree(n) — tree to n levels
-            ValueView::Int(n) if n > 0 => Ok(Value::array(self.tree_depth(&items, n as usize)?)),
+            ValueView::Int(n) if n > 0 => Ok(
+                crate::builtins::methods_0arg::dispatch_core_math::tree_to_depth(
+                    &target, n as usize,
+                ),
+            ),
             // .tree(*) or .tree(Inf) — full depth (same as .tree())
-            ValueView::Whatever => Ok(Value::array(self.tree_depth(&items, usize::MAX)?)),
-            ValueView::Num(f) if f.is_infinite() && f.is_sign_positive() => {
-                Ok(Value::array(self.tree_depth(&items, usize::MAX)?))
-            }
+            ValueView::Whatever => Ok(
+                crate::builtins::methods_0arg::dispatch_core_math::tree_to_depth(
+                    &target,
+                    usize::MAX,
+                ),
+            ),
+            ValueView::Num(f) if f.is_infinite() && f.is_sign_positive() => Ok(
+                crate::builtins::methods_0arg::dispatch_core_math::tree_to_depth(
+                    &target,
+                    usize::MAX,
+                ),
+            ),
             // .tree([&first, *@rest]) — array of closures form
             ValueView::Array(closure_list, ..) => {
                 if closure_list.is_empty() {
@@ -302,23 +314,6 @@ impl Interpreter {
             }
             _ => Ok(target),
         }
-    }
-
-    pub(in crate::runtime) fn tree_depth(
-        &mut self,
-        items: &[Value],
-        depth: usize,
-    ) -> Result<Vec<Value>, RuntimeError> {
-        let mut result = Vec::new();
-        for item in items {
-            match item.view() {
-                ValueView::Array(inner, ..) if depth > 0 => {
-                    result.push(Value::array(self.tree_depth(&inner, depth - 1)?));
-                }
-                _ => result.push(item.clone()),
-            }
-        }
-        Ok(result)
     }
 
     pub(in crate::runtime) fn tree_with_closures(

--- a/t/tree-itemization.t
+++ b/t/tree-itemization.t
@@ -1,0 +1,33 @@
+use Test;
+
+# `.tree` itemizes every node it descends into: an Iterable becomes
+# `$(self.map(*.tree).Seq)`. mutsu used to return a plain, non-itemized Array,
+# so `(1, 2).tree.raku` was `(1, 2)` instead of `$((1, 2).Seq)`. The `.tree(n)`
+# depth forms itemize the same way, which is what makes `.tree(*)` and `.tree`
+# identical (roast S02-lists/tree.t test 12).
+
+plan 15;
+
+is (1, 2).tree.raku, '$((1, 2).Seq)', '.tree itemizes the top node';
+is (1, (2, 3)).tree.raku, '$((1, $((2, 3).Seq)).Seq)', '.tree itemizes every level';
+is ((1, 2), (3,)).tree.raku, '$(($((1, 2).Seq), $((3,).Seq)).Seq)', '.tree over a list of lists';
+is ().tree.raku, '$(().Seq)', '.tree on an empty list';
+is [1, 2].tree.raku, '$((1, 2).Seq)', '.tree on an Array yields a Seq';
+is (1..3).tree.raku, '$((1, 2, 3).Seq)', '.tree expands a Range';
+is %(:a(1)).tree.raku, '$((:a(1),).Seq)', '.tree on a Hash trees its pairs';
+is (1, 2).tree.WHAT.gist, '(Seq)', '.tree yields a Seq, not a List';
+
+# A non-Iterable is its own tree.
+is "ab".tree.raku, '"ab"', '.tree on a Str is the Str';
+is 42.tree.raku, '42', '.tree on an Int is the Int';
+
+# The depth forms itemize exactly as far as they descend.
+is (1, 2).tree(0).raku, '(1, 2)', '.tree(0) is the identity';
+is (1, (2, (3, 4))).tree(1).raku, '$((1, (2, (3, 4))).Seq)', '.tree(1) itemizes one level';
+is (1, (2, (3, 4))).tree(2).raku, '$((1, $((2, (3, 4)).Seq)).Seq)', '.tree(2) itemizes two levels';
+is (1, (2, 3)).tree(*).raku, (1, (2, 3)).tree.raku, '.tree(*) is .tree';
+
+# The closure forms are unchanged.
+is ((1, 2), (3, 4)).tree(*.join(' '), *.join('|')), '1|2 3|4', '.tree with Whatever-closures';
+
+done-testing;


### PR DESCRIPTION
The last structural PLAN.md §8.6 leftover from the `>>.` mutsu-vs-raku sweep.

`.tree` on an Iterable is `$(self.map(*.tree).Seq)` — every node it descends into is an **itemized** Seq. mutsu returned a plain, un-itemized Array:

```
(1, 2).tree.raku          # was (1, 2)      , now $((1, 2).Seq)
(1, (2, 3)).tree.raku     # was (1, (2, 3)) , now $((1, $((2, 3).Seq)).Seq)
(1..3).tree.raku          # was 1..3        , now $((1, 2, 3).Seq)
%(:a(1)).tree.raku        # was {:a(1)}     , now $((:a(1),).Seq)
"ab".tree                 # "ab" , unchanged -- a non-Iterable is its own tree
```

### The `.tree(n)` forms had to move together

`roast/S02-lists/tree.t` test 12 asserts `.tree(*)` returns `self.tree`. It was passing only because *both* sides were un-itemized — fixing the 0-arg form alone made it fail. So the depth forms now itemize exactly the `n` levels they tree:

```
(1, (2, (3, 4))).tree(1)   # $((1, (2, (3, 4))).Seq)
(1, (2, (3, 4))).tree(2)   # $((1, $((2, (3, 4)).Seq)).Seq)
(1, 2).tree(0)             # (1, 2)  -- still the identity
```

Both paths now share one `tree_to_depth(&Value, depth)` helper in `src/builtins/methods_0arg/dispatch_core_math.rs`, replacing the duplicated `tree_recursive` / `Interpreter::tree_depth` pair (the latter is deleted). It also covers Seq/Slip/Hash/Range targets that the old Array-only version passed through untouched.

### Tests

- New pin `t/tree-itemization.t` — 15 tests, **green under `raku` too**.
- `make test` passes (2249 files / 21218 tests); the whitelisted `roast/S02-lists/tree.t` and `roast/S03-metaops/hyper.t` (`».tree` is nodal) both still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)