### PR TITLE
fix: a leading-`::` pair key (`::V => 42`) evaluates to the constant's value

### DIFF
--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -82,10 +82,21 @@ pub(super) fn expression(input: &str) -> PResult<'_, Expr> {
             // A qualified name (`Bool::True`, `Foo::Bar`) is NOT autoquoted — it is
             // evaluated to its value, so `Bool::True => "a"` has the Bool *value*
             // as its (positional) key, matching raku.
-            let is_bareword = matches!(&expr, Expr::BareWord(name) if !name.contains("::"));
+            //
+            // A leading-`::` pseudo-package form (`::V`) is the same: it is a symbol
+            // lookup that must be evaluated to its value (`my constant V = 'x';
+            // ::V => 42` keys on 'x', not "V"). The `::` prefix is stripped during
+            // term parsing, so `::V` reaches here as `BareWord("V")` — the AST alone
+            // cannot distinguish it from a plain `V`. Detect it from the raw LHS
+            // source text instead.
+            let leading_colons = consumed.trim_start().starts_with("::");
+            let is_bareword =
+                !leading_colons && matches!(&expr, Expr::BareWord(name) if !name.contains("::"));
             let left = match expr {
                 Expr::BareWord(ref name)
-                    if !consumed.trim_start().starts_with('(') && !name.contains("::") =>
+                    if !consumed.trim_start().starts_with('(')
+                        && !leading_colons
+                        && !name.contains("::") =>
                 {
                     Expr::Literal(Value::str(name.clone()))
                 }
@@ -144,10 +155,16 @@ pub(in crate::parser) fn expression_no_assign(input: &str) -> PResult<'_, Expr> 
         let (r, _) = ws(r)?;
         let (r, value) = parse_fat_arrow_value(r)?;
         let consumed = &input[..input.len() - rest.len()];
-        let is_bareword = matches!(&expr, Expr::BareWord(name) if !name.contains("::"));
+        // A leading-`::` pseudo-package form (`::V`) is a symbol lookup evaluated to
+        // its value, not autoquoted (see the note in `expression`).
+        let leading_colons = consumed.trim_start().starts_with("::");
+        let is_bareword =
+            !leading_colons && matches!(&expr, Expr::BareWord(name) if !name.contains("::"));
         let left = match expr {
             Expr::BareWord(ref name)
-                if !consumed.trim_start().starts_with('(') && !name.contains("::") =>
+                if !consumed.trim_start().starts_with('(')
+                    && !leading_colons
+                    && !name.contains("::") =>
             {
                 Expr::Literal(Value::str(name.clone()))
             }
@@ -194,10 +211,16 @@ pub(in crate::parser) fn expression_no_sequence(input: &str) -> PResult<'_, Expr
         let (r, _) = ws(r)?;
         let (r, value) = parse_fat_arrow_value(r)?;
         let consumed = &input[..input.len() - rest.len()];
-        let is_bareword = matches!(&expr, Expr::BareWord(name) if !name.contains("::"));
+        // A leading-`::` pseudo-package form (`::V`) is a symbol lookup evaluated to
+        // its value, not autoquoted (see the note in `expression`).
+        let leading_colons = consumed.trim_start().starts_with("::");
+        let is_bareword =
+            !leading_colons && matches!(&expr, Expr::BareWord(name) if !name.contains("::"));
         let left = match expr {
             Expr::BareWord(ref name)
-                if !consumed.trim_start().starts_with('(') && !name.contains("::") =>
+                if !consumed.trim_start().starts_with('(')
+                    && !leading_colons
+                    && !name.contains("::") =>
             {
                 Expr::Literal(Value::str(name.clone()))
             }
@@ -248,10 +271,16 @@ pub(in crate::parser) fn listop_arg_expr(input: &str) -> PResult<'_, Expr> {
         let (r, _) = ws(r)?;
         let (r, value) = parse_fat_arrow_value(r)?;
         let consumed = &input[..input.len() - rest.len()];
-        let is_bareword = matches!(&expr, Expr::BareWord(name) if !name.contains("::"));
+        // A leading-`::` pseudo-package form (`::V`) is a symbol lookup evaluated to
+        // its value, not autoquoted (see the note in `expression`).
+        let leading_colons = consumed.trim_start().starts_with("::");
+        let is_bareword =
+            !leading_colons && matches!(&expr, Expr::BareWord(name) if !name.contains("::"));
         let left = match expr {
             Expr::BareWord(ref name)
-                if !consumed.trim_start().starts_with('(') && !name.contains("::") =>
+                if !consumed.trim_start().starts_with('(')
+                    && !leading_colons
+                    && !name.contains("::") =>
             {
                 Expr::Literal(Value::str(name.clone()))
             }
@@ -310,10 +339,16 @@ pub(in crate::parser) fn call_arg_expr(input: &str) -> PResult<'_, Expr> {
         let (r, _) = ws(r)?;
         let (r, value) = parse_fat_arrow_value(r)?;
         let consumed = &input[..input.len() - rest.len()];
-        let is_bareword = matches!(&expr, Expr::BareWord(name) if !name.contains("::"));
+        // A leading-`::` pseudo-package form (`::V`) is a symbol lookup evaluated to
+        // its value, not autoquoted (see the note in `expression`).
+        let leading_colons = consumed.trim_start().starts_with("::");
+        let is_bareword =
+            !leading_colons && matches!(&expr, Expr::BareWord(name) if !name.contains("::"));
         let left = match expr {
             Expr::BareWord(ref name)
-                if !consumed.trim_start().starts_with('(') && !name.contains("::") =>
+                if !consumed.trim_start().starts_with('(')
+                    && !leading_colons
+                    && !name.contains("::") =>
             {
                 Expr::Literal(Value::str(name.clone()))
             }

--- a/t/colon-const-fatarrow-key.t
+++ b/t/colon-const-fatarrow-key.t
@@ -1,0 +1,49 @@
+use v6;
+use Test;
+
+plan 6;
+
+# A leading-`::` pseudo-package form on the LHS of `=>` is a symbol lookup that
+# is evaluated to its value, NOT autoquoted like a plain bareword. So
+# `::V => 42` keys on V's value ('x'), while `V => 42` keys on the string "V".
+
+my constant V = "x";
+
+{
+    my %h = V => "oi", ::V => 42;
+    is %h.raku, '{:V("oi"), :x(42)}',
+        '::V => uses the constant value as key; V => autoquotes';
+}
+
+{
+    # ::V alone (positional pair) evaluates the constant value.
+    my %h = ::V => 42;
+    is %h.raku, '{:x(42)}', 'bare ::V => value keys on the constant value';
+}
+
+{
+    # A numeric constant value stringifies as the hash key.
+    my constant K = 7;
+    my %h = ::K => "v";
+    is %h.raku, '{"7" => "v"}', 'numeric constant value becomes the key';
+}
+
+# Plain bareword keys are still autoquoted (named-argument semantics).
+{
+    my %h = a => 1, b => 2;
+    is %h.raku, '{:a(1), :b(2)}', 'plain bareword keys autoquote';
+}
+
+# Qualified names (Bool::True) still evaluate to their value.
+{
+    my %h = Bool::True => 5;
+    is %h.raku, '{:True(5)}', 'qualified name key evaluates to its value';
+}
+
+# `::V => x` produces a *positional* pair (value key), so it lands in the
+# slurpy positional list, not the slurpy named hash.
+{
+    sub f(*@a, *%h) { "@a.raku()|%h.raku()" }
+    is f(::V => 42), '[:x(42)]|{}',
+        '::V => makes a positional pair, not a named argument';
+}


### PR DESCRIPTION
## Summary

A leading-`::` pseudo-package form on the LHS of `=>` is a symbol lookup that
must be evaluated to its value, not autoquoted like a plain bareword.

```raku
my constant V = 'x';
my %h = V => 'oi', ::V => 42;
say %h.raku;
# raku:  {:V("oi"), :x(42)}
# mutsu (before): {:V(42)}   # ::V wrongly autoquoted to "V", colliding with V => "oi"
# mutsu (after):  {:V("oi"), :x(42)}
```

This mirrors the existing qualified-name behavior (`Bool::True => 5` keys on
the Bool value), and `::V => 42` correctly produces a *positional* pair (value
key), landing in a slurpy `*@a` rather than `*%h`.

## Root cause

The `::` prefix is stripped during term parsing, so `::V` reaches the fat-arrow
parser as `BareWord("V")` — indistinguishable in the AST from a plain `V`
(which *should* autoquote). The fat-arrow parser already inspects the raw
consumed LHS source text (to reject `(...)` forms), so the leading `::` is
detected there: when present, autoquoting is skipped and a positional pair is
emitted, exactly like `Foo::Bar`.

## Test

Pin `t/colon-const-fatarrow-key.t` (6 assertions: value key, positional-pair
placement, numeric constant key, plus autoquote/qualified-name non-regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)