### PR TITLE
fix: a package Stash supports .EXISTS-KEY

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -200,12 +200,6 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 - repro: _(fill in a minimal repro + raku baseline before fixing)_
 - file: _(suspected parser/runtime file)_
 
-### T-047 — test_fail: does skip(N) work  [impact: 1 dist]
-- dists: head-skip-tail
-- e.g. `head-skip-tail`: base=1 pass=0 fail=1 die=0 | t/01-basic.rakutest: does skip(4) work
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
-
 ### T-048 — test_fail: TimeUnit (nested-alias FIXED #5146; blocked on enum-vs-sub)  [impact: 1 dist]
 - dists: TimeUnit
 - e.g. `TimeUnit`: base=1 pass=0 fail=1 die=0 | t/01-usage.rakutest
@@ -293,6 +287,14 @@ _(move tickets here with `[claim: <branch>]` when you start)_
 
 ## Done
 
+- **T-047** (#PENDING) — head-skip-tail failed to load (not merely the "skip(4)"
+  test): its `EXPORT` sub calls `CORE::.EXISTS-KEY('&head')` to detect a symbol
+  clash, and mutsu's `Stash` (the type behind `CORE::`/`Foo::`) had no `EXISTS-KEY`
+  method ("No such method 'EXISTS-KEY' for invocant of type 'Stash'"). Added
+  `EXISTS-KEY` for `Stash` (exact-key membership over the package `symbols` map;
+  unlike `AT-KEY`, no sigil-fallback — matching raku, where
+  `Foo::.EXISTS-KEY('baz')` is False even when `$baz` exists). The dist now loads
+  and passes 6/6. Pin: t/stash-exists-key.t.
 - **T-052** (#PENDING) — Node::Ethereum::RLP failed to load: its
   `Exception.rakumod` declares `module M { class X is Exception {}; class
   X::Decode is X {}; class X::Decode::Length is X::Decode {} }`, and `is X`

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -822,8 +822,10 @@ impl Interpreter {
         }
     }
 
-    /// Dispatch "EXISTS-KEY" on a Match: does the match have the named capture?
-    /// Returns None for non-Match targets so they fall through to other handlers.
+    /// Dispatch "EXISTS-KEY" on a Match (does the match have the named capture?)
+    /// or a Stash (does the package have the named symbol?). `CORE::.EXISTS-KEY`
+    /// is used by dists (e.g. head-skip-tail) to detect a symbol clash before
+    /// exporting. Returns None for other targets so they fall through.
     fn dispatch_match_exists_key(
         &self,
         target: &Value,
@@ -834,14 +836,27 @@ impl Interpreter {
             attributes,
             ..
         } = target.view()
-            && class_name == "Match"
         {
-            let key = args[0].to_string_value();
-            let exists = matches!(
-                attributes.as_map().get("named").map(Value::view),
-                Some(ValueView::Hash(named)) if named.contains_key(key.as_str())
-            );
-            return Some(Ok(Value::truth(exists)));
+            if class_name == "Match" {
+                let key = args[0].to_string_value();
+                let exists = matches!(
+                    attributes.as_map().get("named").map(Value::view),
+                    Some(ValueView::Hash(named)) if named.contains_key(key.as_str())
+                );
+                return Some(Ok(Value::truth(exists)));
+            }
+            if class_name == "Stash" {
+                // Exact-key membership only — unlike the Stash `AT-KEY` arm, raku's
+                // `EXISTS-KEY` does NOT sigil-fallback (`Foo::.EXISTS-KEY('baz')` is
+                // False even when `$baz` exists). Dists query the full sigil'd name
+                // (`CORE::.EXISTS-KEY('&head')`).
+                let exists = matches!(
+                    attributes.as_map().get("symbols").map(Value::view),
+                    Some(ValueView::Hash(symbols))
+                        if symbols.contains_key(args[0].to_string_value().as_str())
+                );
+                return Some(Ok(Value::truth(exists)));
+            }
         }
         None
     }

--- a/t/stash-exists-key.t
+++ b/t/stash-exists-key.t
@@ -1,0 +1,26 @@
+use v6;
+use Test;
+
+# A package Stash supports `.EXISTS-KEY` (the Associative membership method).
+# Regression pin for the head-skip-tail dist, whose EXPORT sub does
+# `CORE::.EXISTS-KEY('&head')` to detect a symbol clash before exporting —
+# previously died with "No such method 'EXISTS-KEY' for invocant of type 'Stash'".
+
+module Foo {
+    our sub bar() { 42 }
+    our $baz = 5;
+}
+
+ok Foo::.EXISTS-KEY('&bar'), 'EXISTS-KEY finds an our-scoped sub symbol';
+ok Foo::.EXISTS-KEY('$baz'), 'EXISTS-KEY finds an our-scoped scalar symbol';
+nok Foo::.EXISTS-KEY('&nope'), 'EXISTS-KEY is False for a missing symbol';
+
+# Unlike AT-KEY, EXISTS-KEY does NOT sigil-fallback: the bare name is a distinct
+# (absent) key from the scalar-sigil symbol.
+nok Foo::.EXISTS-KEY('baz'), 'EXISTS-KEY does not sigil-fallback (bare name absent)';
+
+# The CORE pseudo-stash answers EXISTS-KEY for a symbol it does not have.
+nok CORE::.EXISTS-KEY('&this_symbol_does_not_exist_xyz'),
+    'CORE::.EXISTS-KEY is False for an unknown symbol';
+
+done-testing;


### PR DESCRIPTION
`CORE::.EXISTS-KEY('&head')` (and `Foo::.EXISTS-KEY(...)`) died with `No such method 'EXISTS-KEY' for invocant of type 'Stash'`. A `Stash` is `Associative`, so it must answer `EXISTS-KEY`.

## Fix
Added an `EXISTS-KEY` arm for `Stash`: exact-key membership over the package `symbols` map. Unlike the Stash `AT-KEY` arm it does **not** sigil-fallback — `Foo::.EXISTS-KEY('baz')` is `False` even when `$baz` exists, matching raku.

## Impact
Unblocks the **head-skip-tail** dist, whose `EXPORT` sub uses `CORE::.EXISTS-KEY('&head')` to detect a symbol clash before exporting. The dist now loads and passes 6/6.

Pin: `t/stash-exists-key.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)