### PR TITLE
fix: **@values slurpy no longer suppresses the implicit %_ named slurpy

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -243,10 +243,16 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   block whose final statement is an assignment/bind yielded Nil instead of the assigned value (the
   two-phase `pull-one { with $!k {...} else { $!k := ... } }` KV shape). Pins:
   `t/seq-new-user-iterator.t`, `t/given-when-tail-assign-value.t`. **`t/01-basic.rakutest` now exits 0.**
-- **REMAINING (02-minimal):** `my %h is MinimalHash = @pairs` where MinimalHash has a
-  `submethod TWEAK` and a minimal STORE (only AT-KEY/keys, no BIND-KEY) dies with
-  "Too many positionals passed; expected 0 arguments but got 1 in sub new" — a tied-hash
-  default-STORE + TWEAK constructor-dispatch blocker, unrelated to the `.kv`/Seq work.
+- **02-minimal FIXED (PR `fix-double-slurpy-implicit-named`).** The
+  "Too many positionals passed; expected 0 arguments but got 1 in sub new" die was NOT a
+  tied-STORE issue: `has_explicit_named_slurpy` (`src/runtime/registration.rs`) wrongly
+  treated a `**@values` (double-star slurpy POSITIONAL, `@` sigil) as a NAMED slurpy, so the
+  implicit `*%_` every method gets was suppressed and `%_` stayed `Any` instead of `{}`.
+  Hash::Agnostic's `method new(::?CLASS:U: **@values is raw) { self.bless(|%_) }` then splatted
+  a stray `Any` positional into `submethod TWEAK`. Fix = a named slurpy is `%`-sigiled only
+  (dropped the `|| pd.double_slurpy` clause). Pin: `t/double-slurpy-implicit-named.t`.
+  **Both `t/01-basic.rakutest` (22/22) and `t/02-minimal.rakutest` (11/11) now pass — T-051
+  DONE once this PR merges.**
 - NOTE: a "tied hash" feature (`my %h is CustomAssociativeClass`). Decomposes into three
   independent gaps, each fixable on its own:
   1. **tied-hash backing** — `my %h is Foo` (Foo `does Associative`) must back the variable

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -21,9 +21,15 @@ impl Interpreter {
     }
 
     fn has_explicit_named_slurpy(param_defs: &[ParamDef]) -> bool {
+        // A *named* slurpy is always `%`-sigiled (`*%foo` or `**%foo`). A
+        // double-star slurpy on an `@`-sigiled param (`**@values`) is a
+        // slip-preserving slurpy POSITIONAL, not a named one, so it must NOT
+        // suppress the implicit `*%_` every method otherwise gets — else `%_`
+        // stays `Any` and `self.bless(|%_)` splats a stray `Any` positional
+        // into `TWEAK`/`BUILD` (raku: `%_` is always an empty Hash here).
         param_defs
             .iter()
-            .any(|pd| pd.slurpy && (pd.name.starts_with('%') || pd.double_slurpy))
+            .any(|pd| pd.slurpy && pd.name.starts_with('%'))
     }
 
     fn implicit_method_named_slurpy_param() -> ParamDef {

--- a/t/double-slurpy-implicit-named.t
+++ b/t/double-slurpy-implicit-named.t
@@ -1,0 +1,40 @@
+use Test;
+
+# A `**@values` (double-star / slip-preserving) slurpy is a POSITIONAL slurpy,
+# not a named one, so it must NOT suppress the implicit `*%_` that every method
+# otherwise receives. Without it `%_` was `Any` (not an empty Hash), and
+# `self.bless(|%_)` splatted a stray `Any` positional into TWEAK/BUILD, dying
+# with "Too many positionals passed; expected 0 arguments but got 1".
+
+plan 6;
+
+# `%_` inside a method with a `**@values` slurpy is an (empty) Hash.
+class A {
+    method m(**@v) { %_ }
+}
+is-deeply A.new.m, {}, '%_ is an empty Hash under a **@ slurpy';
+isa-ok A.new.m, Hash, '%_ is a Hash, not Any';
+
+# The Hash::Agnostic construction shape: a custom `new` with `**@values is raw`
+# that forwards `|%_` to `bless`, plus a `submethod TWEAK`.
+class B {
+    has $.x;
+    method new(::?CLASS:U: **@values is raw) { self.bless(|%_) }
+    submethod TWEAK { }
+}
+ok B.new.defined, '.new with **@values + TWEAK constructs (no stray Any)';
+is B.new(x => 42).x, 42, 'named args still bind through |%_';
+
+# A genuine named slurpy (`*%opts` / `**%opts`) still consumes the implicit `%_`.
+class C {
+    has %.opts;
+    method new(*%opts) { self.bless(:%opts) }
+}
+is-deeply C.new(a => 1, b => 2).opts, {a => 1, b => 2}, '*%named slurpy captures named args';
+
+# `**@values` collects the positionals (slip-preserving) and `%_` the nameds.
+class D {
+    method split(**@v) { (@v, %_) }
+}
+is-deeply D.new.split(1, 2, :k<v>), ([1, 2], {k => 'v'}),
+    '**@ takes positionals, implicit %_ takes nameds';


### PR DESCRIPTION
## Problem

A method's implicit `*%_` (the named-args `Hash` every method receives) was **dropped** whenever the signature had a `**@values` slurpy:

```raku
class M {
    has $.x;
    method new(::?CLASS:U: **@values is raw) { self.bless(|%_) }
    submethod TWEAK { }
}
M.new;   # dies: "Too many positionals passed; expected 0 arguments but got 1 in sub new"
```

`has_explicit_named_slurpy` (`src/runtime/registration.rs`) treated any `double_slurpy` param as a **named** slurpy, so it suppressed the implicit `*%_`. But `**@values` is a slip-preserving slurpy **positional** (`@` sigil) — only a `%`-sigiled slurpy (`*%foo` / `**%foo`) is named.

With `*%_` suppressed, `%_` read back as `Any` (not an empty `Hash`), so `self.bless(|%_)` splatted a stray `Any` positional into `TWEAK`/`BUILD` → the die.

## Fix

A named slurpy is `%`-sigiled only — dropped the `|| pd.double_slurpy` clause. `%_` is now always the correct (empty) `Hash` under a `**@` slurpy, matching raku.

## Impact

This is exactly the shape of **Hash::Agnostic**'s `method new(::?CLASS:U: **@values is raw) { self.bless(|%_) }` + `submethod TWEAK`. With this fix its dist `t/02-minimal.rakutest` passes **11/11** (and `t/01-basic.rakutest` 22/22 from #5181) — **completing T-051**.

## Tests

`t/double-slurpy-implicit-named.t` (6): `%_` is an empty `Hash` under `**@`; `.new` with `**@values` + `TWEAK` constructs; named args still bind through `|%_`; a genuine `*%named` slurpy still captures nameds; `**@` splits positionals from the implicit `%_` nameds.

`make test` green; the S06-signature roast suite (signature/slurpy/capture/named-parameters/…) green.