### PR TITLE
fix: a one-element Slip renders as slip(3,) (closes PLAN.md §8.6)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1306,12 +1306,22 @@ the backlog.
       `runtime::methods_instance_ops` (`format!("{}.new({})", …)`) and needs `&mut self`.
       `builtin_dd` already works around exactly this by special-casing a top-level `Instance` and
       dispatching the method (`src/runtime/builtins_eval_misc.rs:330`, comment: "would render `F()`").
-- **Fix shape.** Give `raku_value` a way to call back into the interpreter for `Instance` elements
-      — a scoped hook (thread-local set for the duration of a `.raku` dispatch) is the least
-      invasive; the alternative is to make container `.raku` an interpreter-side recursive walk.
-      Medium blast radius (every `.raku` of a container holding an instance changes output), so it
-      wants its own PR with a `make roast` pass. Pin candidate: `t/nested-instance-raku.t`.
-- Entry: `git checkout -b fix-nested-instance-raku origin/main`.
+- **Fix shape — mirror `.gist`, which already solves exactly this.**
+      `src/runtime/methods_call_dispatch.rs` (~2202, `if method == "gist" && args.is_empty()`) has
+      an interpreter-side recursive renderer `gist_item(interp, value)`, gated by a
+      `collection_contains_instance(value)` predicate so any subtree with no dispatch-needing
+      element still takes the pure fast path (`runtime::gist_value`). It walks
+      Array/Seq/Slip/HyperSeq/RaceSeq/Hash/Pair/ValuePair preserving each container's bracket
+      style and dispatches `.gist` on the instance leaves — which is why `[Foo.new].gist` is
+      already correct while `.raku` is not. Do the same for `.raku` rather than the
+      thread-local-hook idea: same gating, same walk, `.raku` on the leaves. `builtin_dd`'s
+      hand-rolled top-level workaround should then collapse into it.
+- **Verify** all containers (`[Foo.new]`, `(Foo.new,)`, `%(a => Foo.new)`, `(a => Foo.new)`) and
+      the built-in instance types (`(1.Supply, 2.Supply).raku`). Medium blast radius (every
+      `.raku` of a container holding an instance changes output), so it wants its own PR with a
+      full `make roast`. Pin candidate: `t/nested-instance-raku.t`.
+- Entry: `git checkout -b fix-nested-instance-raku origin/main`. Queued for the next session
+      (agreed with the user 2026-07-22).
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1185,8 +1185,18 @@ the backlog.
       is `$((1, 2).Seq)` and `.tree(n)` itemizes exactly the `n` levels it treed — which is what
       makes `.tree(*)` identical to `.tree` (roast `S02-lists/tree.t` test 12, previously passing
       only because *both* sides were un-itemized). Pin: `t/tree-itemization.t`.
-- [ ] Last leftover: `Supply`/`Slip`/`QuantHash` `.raku` rendering differs cosmetically
-      (`Supply()` vs `Supply.new`, `slip(3)` vs `slip(3,)`).
+- **§8.6 is closed** (2026-07-22). The last rendering leftover was the one-element Slip
+      (`slip(3)` → `slip(3,)`, pin `t/slip-raku-repr.t`). A full re-run of the sweep over every
+      name in `is_nodal_list_method` (both the flat and the nested shape) now shows **no
+      remaining nodality divergence**; what it still prints is (a) the inherently random
+      `pick`/`roll`, (b) QuantHash key *ordering* (unordered by definition), (c) rows where
+      both sides error with different wording, and (d) two independent findings now tracked
+      separately: §8.10 (nested-instance `.raku`) and `.WHO`/`.HOW` *content* (mutsu renders a
+      Stash as a plain `Hash` and its `ClassHOW` without the mixin roles — a metamodel-fidelity
+      gap, unrelated to hypers).
+- The sweep script is worth keeping: `tmp/nodal-sweep.sh` (uncommitted, regenerate from the
+      recipe — enumerate the names in `is_nodal_list_method`, run each through a flat and a
+      nested shape under both `mutsu -e` and `raku -e`, print only differing rows).
 
 ### 8.7 Bound-element immutability (mostly LANDED 2026-07-22; only `.kv` remains)
 
@@ -1320,6 +1330,26 @@ the backlog.
 - Entry: `git checkout -b feat-which-keyed-quanthash origin/main`. Files: `src/value/mod.rs`
       (`HashData`), `src/value/value_collections.rs`, `src/value/value_methods_a.rs`
       (`hash_insert_through`), `src/runtime/methods_quanthash_ctor.rs`, the `∈`/`(elem)` set-op path.
+
+### 8.11 A user instance *nested inside a container* renders as `Foo()` for `.raku` (found 2026-07-22 by the nodality sweep re-run)
+
+- [ ] **`[Foo.new].raku` is `[Foo()]`; raku gives `[Foo.new(x => 1)]`.** The instance's *own*
+      `.raku` is correct (`Foo.new(x => 1)`) — only the nested case is wrong, and it is wrong for
+      every container (`(…)`, `[…]`, `%…`, Seq, Pair value, …) and for built-in instance types too
+      (`(1.Supply, 2.Supply).raku` → mutsu `(Supply(), Supply())`, raku `(Supply.new, Supply.new)`).
+- **Root.** Container `.raku` recurses through the *pure* helper
+      `builtins::methods_0arg::raku_repr::raku_value`, which has no interpreter and therefore cannot
+      reach the class registry / `collect_public_raku_attrs`; its `_ =>` arm falls back to
+      `to_string_value()`, i.e. the gist-ish `Foo()`. The correct instance rendering lives in
+      `runtime::methods_instance_ops` (`format!("{}.new({})", …)`) and needs `&mut self`.
+      `builtin_dd` already works around exactly this by special-casing a top-level `Instance` and
+      dispatching the method (`src/runtime/builtins_eval_misc.rs:330`, comment: "would render `F()`").
+- **Fix shape.** Give `raku_value` a way to call back into the interpreter for `Instance` elements
+      — a scoped hook (thread-local set for the duration of a `.raku` dispatch) is the least
+      invasive; the alternative is to make container `.raku` an interpreter-side recursive walk.
+      Medium blast radius (every `.raku` of a container holding an instance changes output), so it
+      wants its own PR with a `make roast` pass. Pin candidate: `t/nested-instance-raku.t`.
+- Entry: `git checkout -b fix-nested-instance-raku origin/main`.
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1166,55 +1166,17 @@ the backlog.
       rendering. Reasonable to keep deferring vs the §1/§6 frontier. Related: §6 (dual-store / lexical
       slot), [`array-hole-tracking-embedded`], [ADR-0001] container-repr.
 
-### 8.6 `>>.` sweep leftovers
+### 8.6 `.WHO`/`.HOW` render without their metamodel detail
 
-- Both halves of the original item are **done** (2026-07-22): the *nodality* fix (the coercers
-      `Str`, `gist`, `raku`, `perl`, `so`, `Bool`, `Numeric`, `Int`, `Rat`, `Real`, `defined`,
-      `item`, `sink`, `cache`, `lazy` were removed from `is_nodal_list_method`, so they descend to
-      the leaves and preserve the `Array` container), and the *metaobject introspectors*
-      (`.WHAT`/`.WHO`/`.HOW`/`.DEFINITE`/`.WHERE` are no longer hyper-dispatched at all — they
-      apply to the target, like Rakudo's special forms). Pin: `t/hyper-nodality.t` (24 tests).
-      See `news/2026-07.md`.
-- The `.reverse`/`.rotate` leftovers are also **done** (2026-07-22): `Any.reverse` is
-      `self.list.reverse`, so a non-Iterable reverses to a one-element Seq (`"abc".reverse` is
-      `("abc",).Seq`, not the `.flip`ped `"cba"` mutsu used to return, and `42.reverse` no longer
-      errors), while `.rotate` — which Rakudo does *not* define on `Any` — throws
-      `X::Method::NotFound` instead of returning a silent `Nil`. (`.batch` was already correct.)
-      Pin: `t/any-reverse-rotate.t`.
-- `.tree` is **done** (2026-07-22): it itemizes every node it descends into, so `(1, 2).tree`
-      is `$((1, 2).Seq)` and `.tree(n)` itemizes exactly the `n` levels it treed — which is what
-      makes `.tree(*)` identical to `.tree` (roast `S02-lists/tree.t` test 12, previously passing
-      only because *both* sides were un-itemized). Pin: `t/tree-itemization.t`.
-- **§8.6 is closed** (2026-07-22). The last rendering leftover was the one-element Slip
-      (`slip(3)` → `slip(3,)`, pin `t/slip-raku-repr.t`). A full re-run of the sweep over every
-      name in `is_nodal_list_method` (both the flat and the nested shape) now shows **no
-      remaining nodality divergence**; what it still prints is (a) the inherently random
-      `pick`/`roll`, (b) QuantHash key *ordering* (unordered by definition), (c) rows where
-      both sides error with different wording, and (d) two independent findings now tracked
-      separately: §8.10 (nested-instance `.raku`) and `.WHO`/`.HOW` *content* (mutsu renders a
-      Stash as a plain `Hash` and its `ClassHOW` without the mixin roles — a metamodel-fidelity
-      gap, unrelated to hypers).
-- The sweep script is worth keeping: `tmp/nodal-sweep.sh` (uncommitted, regenerate from the
-      recipe — enumerate the names in `is_nodal_list_method`, run each through a flat and a
-      nested shape under both `mutsu -e` and `raku -e`, print only differing rows).
+- [ ] **A Stash renders as a plain `Hash`, and a `ClassHOW` without its mixin roles.**
+      `(@a>>.WHO).WHAT` is `(Hash)` where raku gives `(Stash)`, `Array.WHO` is `{}` where raku
+      lists `{:Element(Array::Element), :Shaped(Array::Shaped), ...}`, and `Array.HOW.raku` is
+      `Perl6::Metamodel::ClassHOW.new` where raku has `ClassHOW+{<anon>}+{<anon>}.new`. A
+      metamodel-fidelity gap, not a dispatch bug — surfaced by the `>>.` sweep only because the
+      introspectors happened to be in it. Low user impact; sized as its own slice.
 
-### 8.7 Bound-element immutability (mostly LANDED 2026-07-22; only `.kv` remains)
+### 8.7 `.kv` on a Hash::Agnostic role returns `()`
 
-- [x] **A hash/array element bound to an immutable value is now read-only.**
-      `%h<i> := 137; %h<i> = 666` throws (`X::AdHoc` "Cannot assign to an immutable value" for a
-      plain hash/array; `X::Assignment::RO` "Cannot modify an immutable Int (137)" for a tied
-      hash) and leaves the value `137`. Implemented via **option (b): a per-variable
-      `__mutsu_ro_index::{var}` side set** (parallel to `__mutsu_bound_index`,
-      `src/vm/vm_var_index_tracking.rs`; gated by `elem_index_meta_possible()`). A `:=` bind to an
-      immutable scalar literal (Int/BigInt/Num/Str/Bool/Rat/Complex, no named source) marks the
-      element; the element-assign chokepoints consult it and throw. Covers the plain path
-      (`exec_index_assign_expr_named_op_inner` + the `try_fast_hash_element_assign` fast path) and
-      the tied path (the instance-dispatch that routes through `ASSIGN-KEY`/`BIND-KEY`, plus the
-      tied delegation where the literal-ness is otherwise lost). Whole-container reassign and
-      `:delete` clear the markers so the element becomes writable again. Also fixed: tied
-      multi-element slice `:delete` (`%h<d e f>:delete`) now deletes each key instead of passing
-      the whole slice array as one key. Pins: `t/bound-element-readonly.t`,
-      `t/tied-hash-bound-element.t`. Clears Hash::Agnostic dist subtests 4/5/6 (dist now 21/22).
 - [ ] **`.kv` on a Hash::Agnostic role returns `()`** (raku yields the flattened k/v list) — the
       last Hash::Agnostic dist gap (subtest 13). Separate pre-existing issue: the role's
       `method kv { Seq.new(KV.new(:backend(self), :iterator(self.keys.iterator))) }` uses a custom

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -32,6 +32,29 @@ This clears subtests 4/5/6 of the `Hash::Agnostic` distribution's `t/01-basic.ra
 (T-051; dist now 21/22, only `.kv` remains). Pins: `t/bound-element-readonly.t`,
 `t/tied-hash-bound-element.t`. See PLAN.md §8.7.
 
+## 2026-07-22: `slip(3,)` — and with it PLAN.md §8.6 is closed
+
+`.raku` on a one-element Slip keeps the trailing comma a one-element list gets: Rakudo emits
+`slip(3,)`, mutsu emitted `slip(3)`. Both Slip rendering sites are fixed (the pure
+`raku_repr::raku_value` used for nested elements, and the `.raku`/`.perl` 0-arg method
+dispatch), and `raku_value` also picked up the `Empty` rendering for an empty Slip that the
+method path already had. Pin: `t/slip-raku-repr.t` (8 tests, green under `raku` too).
+
+That was the last item in §8.6. A full re-run of the sweep that started the section — every
+name in `is_nodal_list_method`, through a flat and a nested shape, mutsu vs `raku`, printing
+only differing rows — now shows **no remaining nodality divergence**. What it still prints is
+the inherently random `pick`/`roll`, QuantHash key *ordering* (unordered by definition), rows
+where both sides error with different wording, and two findings that are not about hypers at
+all and are now tracked on their own:
+
+- **a user instance nested in a container renders as `Foo()`** — `[Foo.new].raku` is `[Foo()]`
+  where raku gives `[Foo.new(x => 1)]`, and likewise `(1.Supply, 2.Supply).raku` →
+  `(Supply(), Supply())`. The instance's *own* `.raku` is correct; only the recursion through
+  the pure `raku_value` helper (which cannot reach the class registry) is wrong. New PLAN.md
+  §8.10, with the root cause and fix shape written up.
+- **`.WHO`/`.HOW` content** — mutsu renders a Stash as a plain `Hash` and its `ClassHOW`
+  without the mixin roles. A metamodel-fidelity gap.
+
 ## 2026-07-22: `.tree` itemizes every node it descends into
 
 The last structural §8.6 leftover. `.tree` on an Iterable is `$(self.map(*.tree).Seq)` — each

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -40,12 +40,29 @@ This clears subtests 4/5/6 of the `Hash::Agnostic` distribution's `t/01-basic.ra
 dispatch), and `raku_value` also picked up the `Empty` rendering for an empty Slip that the
 method path already had. Pin: `t/slip-raku-repr.t` (8 tests, green under `raku` too).
 
-That was the last item in §8.6. A full re-run of the sweep that started the section — every
-name in `is_nodal_list_method`, through a flat and a nested shape, mutsu vs `raku`, printing
-only differing rows — now shows **no remaining nodality divergence**. What it still prints is
-the inherently random `pick`/`roll`, QuantHash key *ordering* (unordered by definition), rows
-where both sides error with different wording, and two findings that are not about hypers at
-all and are now tracked on their own:
+### §8.6 is closed — what the four fixes were, and what the sweep says now
+
+The section is removed from PLAN.md; the four fixes it tracked, in order, were:
+
+| fix | before → after |
+|---|---|
+| nodality: coercers are not `is nodal` | `@a>>.Str` on `[(1,2),(3,)]`: `("1 2", "3")` → `[("1", "2"), ("3",)]` |
+| the metaobject introspectors are not hypered | `(@a>>.WHAT).raku`: `[(Int, Int), (Int,)]` → `Array` |
+| `Any.reverse` / list-only `.rotate` | `"abc".reverse`: `"cba"` → `("abc",).Seq`; `42.rotate`: `Nil` → `X::Method::NotFound` |
+| one-element Slip rendering | `slip(3).raku`: `slip(3)` → `slip(3,)` |
+
+plus `.tree` itemization, which the same sweep surfaced (its own entry below).
+
+A full re-run of the sweep that started the section — every name in `is_nodal_list_method`,
+through a flat and a nested shape, mutsu vs `raku`, printing only differing rows — now shows
+**no remaining nodality divergence**. (The recipe is worth re-deriving rather than looking for:
+enumerate the candidate names from the source, run each through two shapes under both
+`./target/debug/mutsu -e` and `raku -e`, print only differing rows, then filter the noise. The
+script lived in `tmp/nodal-sweep.sh` and is not committed.)
+
+What it still prints is the inherently random `pick`/`roll`, QuantHash key *ordering*
+(unordered by definition), rows where both sides error with different wording, and two findings
+that are not about hypers at all and are now tracked on their own:
 
 - **a user instance nested in a container renders as `Foo()`** — `[Foo.new].raku` is `[Foo()]`
   where raku gives `[Foo.new(x => 1)]`, and likewise `(1.Supply, 2.Supply).raku` →
@@ -53,7 +70,7 @@ all and are now tracked on their own:
   the pure `raku_value` helper (which cannot reach the class registry) is wrong. New PLAN.md
   §8.10, with the root cause and fix shape written up.
 - **`.WHO`/`.HOW` content** — mutsu renders a Stash as a plain `Hash` and its `ClassHOW`
-  without the mixin roles. A metamodel-fidelity gap.
+  without the mixin roles. A metamodel-fidelity gap; it inherits the now-vacant PLAN.md §8.6.
 
 ## 2026-07-22: `.tree` itemizes every node it descends into
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -68,7 +68,7 @@ that are not about hypers at all and are now tracked on their own:
   where raku gives `[Foo.new(x => 1)]`, and likewise `(1.Supply, 2.Supply).raku` →
   `(Supply(), Supply())`. The instance's *own* `.raku` is correct; only the recursion through
   the pure `raku_value` helper (which cannot reach the class registry) is wrong. New PLAN.md
-  §8.10, with the root cause and fix shape written up.
+  §8.11, with the root cause and fix shape written up.
 - **`.WHO`/`.HOW` content** — mutsu renders a Stash as a plain `Hash` and its `ClassHOW`
   without the mixin roles. A metamodel-fidelity gap; it inherits the now-vacant PLAN.md §8.6.
 

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -700,7 +700,12 @@ pub(super) fn dispatch(
                 Some(Ok(Value::str_from("Empty")))
             } else {
                 let inner = items.iter().map(raku_value).collect::<Vec<_>>().join(", ");
-                Some(Ok(Value::str(format!("slip({})", inner))))
+                // A one-element slip keeps the list's trailing comma: `slip(3,)`.
+                if items.len() == 1 {
+                    Some(Ok(Value::str(format!("slip({},)", inner))))
+                } else {
+                    Some(Ok(Value::str(format!("slip({})", inner))))
+                }
             }
         }
         ValueView::Junction { .. } if method == "raku" || method == "perl" => None,

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -476,8 +476,16 @@ pub fn raku_value(v: &Value) -> String {
             }
         }
         ValueView::Slip(items) => {
+            if items.is_empty() {
+                return "Empty".to_string();
+            }
             let inner = items.iter().map(raku_value).collect::<Vec<_>>().join(", ");
-            format!("slip({})", inner)
+            // A one-element slip keeps the list's trailing comma: `slip(3,)`.
+            if items.len() == 1 {
+                format!("slip({},)", inner)
+            } else {
+                format!("slip({})", inner)
+            }
         }
         ValueView::Str(s) => escape_raku_str(&s),
         ValueView::Int(i) => i.to_string(),

--- a/t/slip-raku-repr.t
+++ b/t/slip-raku-repr.t
@@ -1,0 +1,22 @@
+use Test;
+
+# A one-element Slip renders like a one-element list -- with the trailing
+# comma that keeps it round-trippable: `slip(3,)`, not `slip(3)` (which would
+# EVAL back to the same thing here, but is not what Rakudo emits and reads as
+# a call with no comma). An empty Slip is `Empty`.
+
+plan 8;
+
+is slip(3).raku, 'slip(3,)', 'a one-element slip keeps the trailing comma';
+is slip("a").raku, 'slip("a",)', 'a one-element Str slip';
+is Slip.new(3).raku, 'slip(3,)', 'Slip.new with one element';
+is (3,).Slip.raku, 'slip(3,)', '.Slip on a one-element list';
+is slip(1, 2).raku, 'slip(1, 2)', 'a multi-element slip has no trailing comma';
+is slip().raku, 'Empty', 'an empty slip is Empty';
+
+# A slipped element still flattens into its container, so the container's own
+# rendering is unaffected.
+is (slip(3),).raku, '(3,)', 'a slip flattens into a list';
+is [slip(3)].raku, '[3]', 'a slip flattens into an array';
+
+done-testing;


### PR DESCRIPTION
The last item in PLAN.md §8.6.

`.raku` on a one-element Slip keeps the trailing comma a one-element list gets: Rakudo emits `slip(3,)`, mutsu emitted `slip(3)`.

```
slip(3).raku      # was "slip(3)"    , now "slip(3,)"
slip("a").raku    # was "slip(\"a\")" , now "slip(\"a\",)"
slip(1, 2).raku   # "slip(1, 2)" , unchanged
slip().raku       # "Empty"      , unchanged
```

Both Slip rendering sites are fixed — the pure `raku_repr::raku_value` (used when a Slip is an element of something being rendered) and the `.raku`/`.perl` 0-arg method dispatch — and `raku_value` also picked up the `Empty` rendering for an empty Slip that the method path already had.

### §8.6 is now closed

I re-ran the sweep that produced the section (every name in `is_nodal_list_method`, through a flat and a nested shape, mutsu vs `raku`, printing only differing rows). **No nodality divergence remains.** What it still prints is the inherently random `pick`/`roll`, QuantHash key *ordering* (unordered by definition), rows where both sides error with different wording, and two findings that are not about hypers at all, now tracked separately:

- **a user instance nested in a container renders as `Foo()`** — `[Foo.new].raku` is `[Foo()]` where raku gives `[Foo.new(x => 1)]`; same for `(1.Supply, 2.Supply).raku` → `(Supply(), Supply())`. The instance's own `.raku` is correct; only the recursion through the pure `raku_value` helper (no interpreter → no class registry) is wrong, which `builtin_dd` already works around by hand. Written up as **PLAN.md §8.10** with root cause and fix shape.
- **`.WHO`/`.HOW` content** — mutsu renders a Stash as a plain `Hash` and its `ClassHOW` without the mixin roles (metamodel fidelity).

### Tests

- New pin `t/slip-raku-repr.t` — 8 tests, **green under `raku` too**.
- `make test` passes (2250 files / 21233 tests); the whitelisted roast files that mention `slip(` (`S07-slip/slip.t`, `S32-list/map.t`, `S04-statement-modifiers/if.t`, `S07-hyperrace/stress.t`) all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)