### PR TITLE
feat: HyperSeq/RaceSeq expose .configuration (.batch/.degree)

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -12,12 +12,25 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 
 ## Open
 
-### T-003 — runtime_error: No such method X for invocant of type 'X'  [impact: 2 dists]
-- dists: Injector, hyperize
-- e.g. `Injector`: Injector: No such method 'loaded' for invocant of type 'CompUnit::Repository::FileSystem'
-- e.g. `hyperize`: hyperize: No such method 'configuration' for invocant of type 'List'
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
+### T-003 — runtime_error: No such method X for invocant of type 'X'  [impact: 1 dist remaining]
+- dists: ~~hyperize~~ (FIXED, PR pending), Injector (remaining)
+- hyperize — **FIXED**: died at `Iterable.hyper.configuration` ("No such method
+  'configuration' for invocant of type 'List'" — the HyperSeq delegated the unknown
+  method to its inner List). Added `HyperSeq`/`RaceSeq` `.configuration`, returning a
+  `HyperConfiguration` whose `.batch`/`.degree` report the `:batch`/`:degree` the
+  sequence was hyperized with. The batch/degree are recorded in a side registry
+  (`hyper_config_set`/`_get` in value/mod.rs, keyed by the inner element `Arc`) since
+  the HyperSeq value itself does not carry the config. **Trap:** there are FOUR
+  `.hyper`/`.race` creation sites (`vm_call_method_ops`, TWO in
+  `vm_call_method_mut_ops`, `methods_call_dispatch`, plus a 0-arg native path); a
+  `.hyper(:named)` with only named args routes through the *second*
+  `vm_call_method_mut_ops` block (line ~1157), so config_set must be added there.
+  hyperize passes 8/8. Pin: t/hyper-seq-configuration.t.
+- Injector (remaining) — `CompUnit::Repository::FileSystem.loaded` (module-repository
+  introspection: list the compunits loaded from a path-based repo). Separate, deeper
+  root cause; not addressed by the hyperize fix.
+- file: DONE — value/mod.rs, runtime/methods_call_dispatch.rs, vm/vm_call_method_ops.rs,
+  vm/vm_call_method_mut_ops.rs; remaining — CompUnit::Repository introspection (Injector)
 
 ### T-004 — runtime_error: Runtime error: An exception occurred while evaluating a CHECK  [impact: 2 dists]
 - dists: ML::TriesWithFrequencies, Rakudo::Version

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -29,12 +29,42 @@ impl Interpreter {
         format!("{}_backref", sanitized)
     }
 
+    /// Build a `HyperConfiguration` instance carrying `.batch`/`.degree`. A
+    /// `None` reports the core default (batch 64; degree = available CPU cores).
+    pub(crate) fn make_hyper_configuration(batch: Option<i64>, degree: Option<i64>) -> Value {
+        let default_degree = std::thread::available_parallelism()
+            .map(|n| n.get() as i64)
+            .unwrap_or(4);
+        let mut attrs = std::collections::HashMap::new();
+        attrs.insert("batch".to_string(), Value::int(batch.unwrap_or(64)));
+        attrs.insert(
+            "degree".to_string(),
+            Value::int(degree.unwrap_or(default_degree)),
+        );
+        Value::make_instance(crate::symbol::Symbol::intern("HyperConfiguration"), attrs)
+    }
+
     pub(crate) fn call_method_with_values(
         &mut self,
         target: Value,
         method: &str,
         args: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
+        // `HyperConfiguration.batch`/`.degree` — read the stored attribute. The
+        // instance is minted by `HyperSeq.configuration` (used by the `hyperize`
+        // dist); it has no user-defined accessors, so answer them directly.
+        if matches!(method, "batch" | "degree")
+            && args.is_empty()
+            && let ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } = target.view()
+            && class_name == "HyperConfiguration"
+            && let Some(v) = attributes.as_map().get(method)
+        {
+            return Ok(v.clone());
+        }
         // .emit on any value: push to the supply emit buffer if inside a
         // supply block, otherwise raise CX::Emit like the `emit` sub.
         if method == "emit"
@@ -3205,6 +3235,9 @@ impl Interpreter {
             }
             let items = value_to_list(&target);
             let arc = std::sync::Arc::new(items);
+            // Remember the requested batch/degree so `.configuration` can report
+            // them (the HyperSeq/RaceSeq value itself does not carry the config).
+            crate::value::hyper_config_set(&arc, batch_val, degree_val);
             return Ok(if method == "hyper" {
                 Value::hyper_seq_arc(arc)
             } else {
@@ -3225,6 +3258,14 @@ impl Interpreter {
             match method {
                 "hyper" => return Ok(Value::hyper_seq_arc(items)),
                 "race" => return Ok(Value::race_seq_arc(items)),
+                "configuration" if args.is_empty() => {
+                    // `HyperSeq.configuration` — a HyperConfiguration exposing the
+                    // `.batch`/`.degree` the sequence was hyperized with (or the
+                    // core defaults when unspecified). Used by the `hyperize` dist.
+                    let (batch, degree) =
+                        crate::value::hyper_config_get(&items).unwrap_or((None, None));
+                    return Ok(Self::make_hyper_configuration(batch, degree));
+                }
                 "is-lazy" => return Ok(Value::FALSE),
                 "iterator" if args.is_empty() => {
                     // A HyperSeq/RaceSeq allows only a single iterator (rakudo #4413):

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -21,6 +21,43 @@ fn consumed_seqs() -> &'static Mutex<Vec<Weak<Vec<Value>>>> {
     CONSUMED_SEQS.get_or_init(|| Mutex::new(Vec::new()))
 }
 
+/// Records the `:batch`/`:degree` a `HyperSeq`/`RaceSeq` was created with, keyed
+/// by its inner element `Arc` (Weak, so entries expire with the sequence). Read
+/// back by `.configuration` (`HyperSeq.configuration.batch`/`.degree`). `None`
+/// means the value was not specified, so `.configuration` reports the default.
+#[allow(clippy::type_complexity)]
+static HYPER_CONFIGS: OnceLock<Mutex<Vec<(Weak<Vec<Value>>, Option<i64>, Option<i64>)>>> =
+    OnceLock::new();
+
+#[allow(clippy::type_complexity)]
+fn hyper_configs() -> &'static Mutex<Vec<(Weak<Vec<Value>>, Option<i64>, Option<i64>)>> {
+    HYPER_CONFIGS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Associate a `:batch`/`:degree` configuration with a hyper/race sequence's
+/// element `Arc`, so a later `.configuration` can report it.
+pub(crate) fn hyper_config_set(arc_ptr: &Arc<Vec<Value>>, batch: Option<i64>, degree: Option<i64>) {
+    let mut list = hyper_configs().lock().unwrap();
+    list.retain(|(w, ..)| w.strong_count() > 0);
+    list.push((Arc::downgrade(arc_ptr), batch, degree));
+}
+
+/// Look up the recorded `:batch`/`:degree` for a hyper/race sequence's element
+/// `Arc`. Returns `None` when no configuration was recorded (e.g. a default
+/// `Iterable.hyper` or a `.map`-derived sequence).
+pub(crate) fn hyper_config_get(arc_ptr: &Arc<Vec<Value>>) -> Option<(Option<i64>, Option<i64>)> {
+    let list = hyper_configs().lock().unwrap();
+    let target_ptr = Arc::as_ptr(arc_ptr);
+    for (w, batch, degree) in list.iter() {
+        if let Some(existing) = w.upgrade()
+            && Arc::as_ptr(&existing) == target_ptr
+        {
+            return Some((*batch, *degree));
+        }
+    }
+    None
+}
+
 /// Global set tracking "cached" Seq instances (have called .cache).
 static CACHED_SEQS: OnceLock<Mutex<Vec<Weak<Vec<Value>>>>> = OnceLock::new();
 

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -150,6 +150,9 @@ impl Interpreter {
                 // Create HyperSeq/RaceSeq
                 let items = crate::runtime::value_to_list(&target);
                 let arc = std::sync::Arc::new(items);
+                // Remember the requested batch/degree so `.configuration` can
+                // report them (the HyperSeq/RaceSeq does not carry the config).
+                crate::value::hyper_config_set(&arc, batch, degree);
                 let result = if method == "hyper" {
                     Value::hyper_seq_arc(arc)
                 } else {
@@ -179,6 +182,16 @@ impl Interpreter {
                     }
                     "is-lazy" => {
                         self.stack.push(Value::FALSE);
+                        return Ok(());
+                    }
+                    "configuration" if args.is_empty() => {
+                        // `HyperSeq.configuration` — expose the `.batch`/`.degree`
+                        // the sequence was hyperized with (defaults otherwise).
+                        // Used by the `hyperize` dist.
+                        let (batch, degree) =
+                            crate::value::hyper_config_get(&items_arc).unwrap_or((None, None));
+                        self.stack
+                            .push(Interpreter::make_hyper_configuration(batch, degree));
                         return Ok(());
                     }
                     "^name" => {
@@ -1142,6 +1155,9 @@ impl Interpreter {
             }
             let items = crate::runtime::value_to_list(&target);
             let arc = std::sync::Arc::new(items);
+            // Remember the requested batch/degree so `.configuration` can report
+            // them (the HyperSeq/RaceSeq does not carry the config).
+            crate::value::hyper_config_set(&arc, batch, degree);
             let result = if method == "hyper" {
                 Value::hyper_seq_arc(arc)
             } else {

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -1056,6 +1056,9 @@ impl Interpreter {
             // Materialize and wrap
             let items = crate::runtime::value_to_list(&target);
             let arc = std::sync::Arc::new(items);
+            // Remember the requested batch/degree so `.configuration` can report
+            // them (the HyperSeq/RaceSeq does not carry the config).
+            crate::value::hyper_config_set(&arc, batch, degree);
             let result = if method == "hyper" {
                 Value::hyper_seq_arc(arc)
             } else {
@@ -1092,6 +1095,21 @@ impl Interpreter {
                 "is-lazy" => {
                     self.stack.push(Value::FALSE);
                     // Pure reflection (no env write): no env_dirty mark needed.
+                    return Ok(());
+                }
+                "configuration" if args.is_empty() => {
+                    // `HyperSeq.configuration` — expose the `.batch`/`.degree` the
+                    // sequence was hyperized with (defaults otherwise). Used by the
+                    // `hyperize` dist.
+                    let items_arc = match target.view() {
+                        ValueView::HyperSeq(items) | ValueView::RaceSeq(items) => items.clone(),
+                        _ => unreachable!(),
+                    };
+                    let (batch, degree) =
+                        crate::value::hyper_config_get(&items_arc).unwrap_or((None, None));
+                    self.stack
+                        .push(Interpreter::make_hyper_configuration(batch, degree));
+                    // Pure value (no env write): no env_dirty mark needed.
                     return Ok(());
                 }
                 "^name" => {

--- a/t/hyper-seq-configuration.t
+++ b/t/hyper-seq-configuration.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+# `HyperSeq`/`RaceSeq` expose `.configuration`, whose `.batch`/`.degree` report
+# the values the sequence was hyperized with. Regression pin for the `hyperize`
+# dist (whose subs default `:batch`/`:degree` off `Iterable.hyper.configuration`).
+
+my @a = ^10;
+
+# Explicit batch/degree round-trip through .configuration.
+{
+    my $c := @a.hyper(:batch(12), :degree(16)).configuration;
+    is $c.batch,  12, 'hyper .configuration.batch reports the requested batch';
+    is $c.degree, 16, 'hyper .configuration.degree reports the requested degree';
+}
+
+# Only batch supplied — degree falls back to a positive default.
+{
+    my $c := @a.hyper(:batch(42)).configuration;
+    is $c.batch, 42, 'hyper .configuration.batch with only :batch supplied';
+    ok $c.degree > 0, 'hyper .configuration.degree defaults to a positive value';
+}
+
+# .race carries its configuration the same way.
+{
+    my $c := @a.race(:batch(7), :degree(3)).configuration;
+    is $c.batch,  7, 'race .configuration.batch reports the requested batch';
+    is $c.degree, 3, 'race .configuration.degree reports the requested degree';
+}
+
+# The default configuration off the Iterable type object has positive values,
+# so the `hyperize` INIT block (`Iterable.hyper.configuration`) can read them.
+{
+    my $c := Iterable.hyper.configuration;
+    ok $c.batch  > 0, 'Iterable.hyper.configuration.batch has a positive default';
+    ok $c.degree > 0, 'Iterable.hyper.configuration.degree has a positive default';
+}
+
+done-testing;


### PR DESCRIPTION
`Iterable.hyper.configuration` and `@a.hyper(:batch(N), :degree(M)).configuration` died with `No such method 'configuration' for invocant of type 'List'` — a `HyperSeq`/`RaceSeq` delegated the unknown method to its inner `List`.

## Fix
Added a `.configuration` method on `HyperSeq`/`RaceSeq` returning a `HyperConfiguration` whose `.batch`/`.degree` report the values the sequence was hyperized with (or the core defaults: batch 64, degree = available CPU cores).

The `HyperSeq`/`RaceSeq` value does not carry its config, so `:batch`/`:degree` are recorded in a side registry keyed by the inner element `Arc` (`hyper_config_set`/`hyper_config_get`, Weak refs so entries expire with the sequence) and read back by `.configuration`.

Config is registered at **every** `.hyper`/`.race` creation site — there are several (the non-mut and two mut VM paths, plus the slow path); a `.hyper(:named)` with only named args routes through the *second* `vm_call_method_mut_ops` block.

## Impact
Unblocks the **hyperize** dist (8/8), whose subs derive their `:batch`/`:degree` defaults from `Iterable.hyper.configuration`. (The other T-003 dist, Injector, is a separate `CompUnit::Repository` introspection gap, not addressed here.)

Pin: `t/hyper-seq-configuration.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)