### PR TITLE
fix: tied-hash backing for qualified/plain classes (`my %h is Foo::Bar`)

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -215,8 +215,34 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 ### T-044 — test_fail: can we access existing key (N)  [impact: 1 dist]
 - dists: Hash::str
 - e.g. `Hash::str`: base=1 pass=0 fail=1 die=0 | t/01-basic.rakutest: can we access existing key (1)
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
+- repro: `my %h is Hash::str = fortytwo => "foo"; say %h<fortytwo>` (raku: `foo`,
+  mutsu was: `(Any)`).
+- **PARTIAL (PR `fix-tied-hash-qualified-plain`).** Two general tied-hash bugs
+  found and fixed:
+  1. **`::`-qualified variable trait truncated** — `my %h is Hash::str` parsed
+     the trait name with plain `ident`, yielding `Hash` (the `::str` was
+     dropped), so tied-hash backing never matched the class. Fixed by using the
+     `::`-aware `qualified_ident` in `src/parser/stmt/decl/my_decl.rs`.
+  2. **tied backing required `does Associative`** — `vm_var_trait_ops.rs` only
+     tied a `%` variable when the class composed `Associative`. Raku ties ANY
+     class named by `is` on a `%` variable (the sigil supplies the associative
+     semantics). Relaxed to also tie when the class defines the associative
+     protocol (STORE / AT-KEY). Pin: `t/tied-hash-qualified-plain.t`.
+- **REMAINING (deferred): full nqp op surface.** Hash::str's actual STORE /
+  AT-KEY / push are written directly in nqp ops (`use nqp`): `nqp::create`,
+  `nqp::hash`, `nqp::p6bindattrinvres`, `nqp::bindkey`, `nqp::existskey`,
+  `nqp::deletekey`, `nqp::hllbool`, `nqp::hllize`, `nqp::eqaddr`,
+  `nqp::istype`, `nqp::getattr`, `nqp::decont`, `nqp::isnull`, `nqp::null`,
+  `nqp::elems`, and the **control-flow ops** `nqp::until` / `nqp::if` /
+  `nqp::stmts` (currently mis-parsed as calls to a bare `if`/`until`). mutsu
+  implements only ~5 nqp ops today; the control-flow ops need special
+  compiler forms (thunked, re-evaluated args), which is a large, separate
+  feature (ADR-worthy). The tied-hash *plumbing* is now correct — verified
+  with a pure-Raku tied class in the pin — so once the nqp surface lands,
+  Hash::str should pass.
+- file: `src/parser/stmt/decl/my_decl.rs` (qualified trait name, done),
+  `src/vm/vm_var_trait_ops.rs` (Associative-optional tie, done); remaining —
+  nqp op layer (compiler + runtime)
 
 ### T-045 — test_fail: did we chomp one  [impact: 1 dist]
 - dists: P5chomp

--- a/src/parser/stmt/decl/my_decl.rs
+++ b/src/parser/stmt/decl/my_decl.rs
@@ -1,6 +1,7 @@
 use super::super::super::expr::expression;
 use super::super::super::helpers::{ws, ws1};
 use super::super::super::parse_result::{PError, PResult};
+use super::super::idents::qualified_ident;
 use super::super::{ident, keyword, var_name};
 use super::destructure::parse_destructuring_decl;
 use super::helpers::{
@@ -438,7 +439,10 @@ fn parse_variable_traits<'a>(
         let mut r = input;
         while let Some(after_is) = keyword("is", r) {
             let (r2, _) = ws1(after_is)?;
-            let (r2, trait_name) = ident(r2)?;
+            // Use a `::`-aware parser so a qualified class trait like
+            // `my %h is Hash::str` keeps its full name (plain `ident` would
+            // truncate it to `Hash`, breaking tied-hash backing).
+            let (r2, trait_name) = qualified_ident(r2)?;
             if trait_name == "readonly" {
                 return Err(PError::fatal(
                     "X::Comp::Trait::Unknown: Unknown variable trait 'is readonly'".to_string(),

--- a/src/vm/vm_var_trait_ops.rs
+++ b/src/vm/vm_var_trait_ops.rs
@@ -377,9 +377,18 @@ impl Interpreter {
         // methods (.Str/.raku/.List/.Slip/.gist/...) all dispatch to the class's
         // (possibly role-provided) methods — a "tied hash". The instance keeps
         // its identity across `%h = ...` (STORE) reassignments.
+        // Raku ties a `%` variable to ANY class named by `is` — the `%` sigil
+        // supplies the associative semantics, so the class need not declare
+        // `does Associative` (e.g. `Hash::str`, which only defines AT-KEY/STORE
+        // via nqp ops). We tie when the class either composes `Associative` or
+        // defines the associative protocol (STORE / AT-KEY), which covers both
+        // the role-composed (`Hash::Agnostic`) and the plain-class (`Hash::str`)
+        // styles without grabbing unrelated `is <Type>` container traits.
         if name.starts_with('%')
             && self.registry().classes.contains_key(&trait_name)
-            && self.class_does_role(&trait_name, "Associative")
+            && (self.class_does_role(&trait_name, "Associative")
+                || self.registry_mut().class_has_method(&trait_name, "STORE")
+                || self.registry_mut().class_has_method(&trait_name, "AT-KEY"))
         {
             if has_arg {
                 self.stack.pop();

--- a/t/tied-hash-qualified-plain.t
+++ b/t/tied-hash-qualified-plain.t
@@ -1,0 +1,55 @@
+use v6;
+use Test;
+
+# Two independent fixes exercised here:
+#
+# 1. `my %h is Some::Qualified::Class` — the variable-trait name parser must
+#    keep the FULL `::`-qualified class name (a plain `ident` parser truncated
+#    `Foo::Bar` to `Foo`, so tied-hash backing never found the class).
+#
+# 2. A class that supplies the associative protocol (STORE / AT-KEY) but does
+#    NOT declare `does Associative` must still back a `%` variable as a tied
+#    hash. Raku ties ANY class named by `is` on a `%` variable — the sigil
+#    provides the associative semantics.
+
+plan 8;
+
+# A plain (non-role, no `does Associative`) tied-hash class with a qualified
+# name. Backing store is an ordinary Hash so we avoid nqp ops.
+class My::Tied::Hash {
+    has %!store;
+    method new() { self.bless }
+    method STORE(::?CLASS:D: \pairs, :$INITIALIZE) {
+        %!store = ();
+        for pairs.list -> $p {
+            %!store{$p.key} = $p.value;
+        }
+        self
+    }
+    method AT-KEY(::?CLASS:D: $key) is raw { %!store{$key} }
+    method ASSIGN-KEY(::?CLASS:D: $key, \value) { %!store{$key} = value }
+    method EXISTS-KEY(::?CLASS:D: $key) { %!store{$key}:exists }
+    method keys(::?CLASS:D:) { %!store.keys }
+}
+
+my %h is My::Tied::Hash = a => 1, b => 2;
+
+is %h.^name, 'My::Tied::Hash', 'qualified class name kept (not truncated to "My")';
+is %h<a>, 1, 'tied AT-KEY reads initializer value (1)';
+is %h<b>, 2, 'tied AT-KEY reads initializer value (2)';
+is-deeply (%h<a>:exists), True, 'tied EXISTS-KEY for existing key';
+is-deeply (%h<z>:exists), False, 'tied EXISTS-KEY for missing key';
+
+%h<c> = 3;
+is %h<c>, 3, 'tied ASSIGN-KEY stores a new key';
+
+# A single-segment plain class with the protocol but no `does Associative`.
+class Plainish {
+    has %!s;
+    method new() { self.bless }
+    method STORE(\pairs) { for pairs.list -> $p { %!s{$p.key} = $p.value }; self }
+    method AT-KEY($k) is raw { %!s{$k} }
+}
+my %p is Plainish = x => 10;
+is %p.^name, 'Plainish', 'plain class (no Associative) still backs the variable';
+is %p<x>, 10, 'plain tied class reads value';


### PR DESCRIPTION
Two independent, general tied-hash bugs, surfaced by the Hash::str dist (TODO_dist T-044) but affecting any tied-hash class.

## 1. `::`-qualified variable trait names were truncated
`my %h is Hash::str` parsed the trait name with the single-segment `ident` parser, yielding `Hash` (the `::str` was dropped), so tied-hash backing never matched the class and `.^name` stayed `Hash`. Now parsed with the `::`-aware `qualified_ident` (`src/parser/stmt/decl/my_decl.rs`).

## 2. Tied backing required `does Associative`
`vm_var_trait_ops.rs` only tied a `%` variable when the class composed `Associative`. Raku ties **any** class named by `is` on a `%` variable — the sigil supplies the associative semantics; the class need not declare `does Associative` (e.g. `Hash::str`, which only defines AT-KEY/STORE). Relaxed to also tie when the class defines the associative protocol (STORE / AT-KEY), covering both role-composed (`Hash::Agnostic`) and plain-class (`Hash::str`) styles.

## Test
Pin: `t/tied-hash-qualified-plain.t` (8 subtests, verified against raku).
`make test` PASS (21268 tests), clippy clean.

## Remaining (out of scope)
Hash::str's STORE/AT-KEY/push are written directly in raw nqp ops (`nqp::create`, `nqp::hash`, `nqp::until`/`nqp::if`/`nqp::stmts`, …), most of which mutsu does not implement. The tied-hash *plumbing* is now correct (verified with a pure-Raku tied class); the nqp op surface is a large, separate feature recorded in the T-044 ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)