### PR TITLE
fix: IO::Path.add is slurpy; .relative defaults to $*CWD

### DIFF
--- a/src/runtime/native_io/io_path_lexical.rs
+++ b/src/runtime/native_io/io_path_lexical.rs
@@ -189,18 +189,41 @@ impl Interpreter {
                 if method == "child" && Self::named_bool(args, "secure") {
                     return None;
                 }
-                let child_name = args
-                    .first()
-                    .map(|v| v.to_string_value())
-                    .unwrap_or_default();
-                match Self::io_path_join_child(attributes, &p, &child_name) {
-                    Ok(joined) => {
-                        let mut new_attrs = attributes.clone();
-                        new_attrs.insert("path".to_string(), Value::str(joined));
-                        Ok(Value::make_instance(io_path_class, new_attrs))
+                // `.add` is slurpy (`*@children`): it flattens its positional
+                // arguments and joins each resulting element onto the path as a
+                // separate segment, so `"foo".IO.add(<bar baz>)` is `foo/bar/baz`
+                // (not `foo/bar baz`) and `.add(("a", ("b", "c")))` is `foo/a/b/c`.
+                // `.child`, by contrast, takes a single `Str()` child and keeps it
+                // whole (`.child(<bar baz>)` is `foo/bar baz`).
+                let segments: Vec<String> = if method == "add" {
+                    let mut children = Vec::new();
+                    for v in Self::positional_values(args) {
+                        crate::builtins::flat_val(v, &mut children, true);
                     }
-                    Err(e) => Err(e),
+                    children.iter().map(|c| c.to_string_value()).collect()
+                } else {
+                    vec![
+                        Self::positional_value(args, 0)
+                            .map(|v| v.to_string_value())
+                            .unwrap_or_default(),
+                    ]
+                };
+                let mut current = p.clone();
+                let mut joined_ok = Ok(());
+                for seg in &segments {
+                    match Self::io_path_join_child(attributes, &current, seg) {
+                        Ok(joined) => current = joined,
+                        Err(e) => {
+                            joined_ok = Err(e);
+                            break;
+                        }
+                    }
                 }
+                joined_ok.map(|()| {
+                    let mut new_attrs = attributes.clone();
+                    new_attrs.insert("path".to_string(), Value::str(current));
+                    Value::make_instance(io_path_class, new_attrs)
+                })
             }
             "extension" => (|| -> Result<Value, RuntimeError> {
                 let subst = Self::positional_value(args, 0).map(|v| v.to_string_value());

--- a/src/runtime/native_io/io_path_stat.rs
+++ b/src/runtime/native_io/io_path_stat.rs
@@ -123,12 +123,17 @@ impl Interpreter {
                     // walk up with `..` (raku returns e.g. `../A/x`), and the old
                     // fall-through to the absolute path corrupted zef's extract
                     // paths (it uses `$archive.relative($tmp)` to build `-C`).
+                    // `.relative`'s default base is `$*CWD` (`cwd_path`), NOT the
+                    // receiver's own `.CWD` attribute — unlike `.absolute`, which
+                    // defaults to `$.CWD`. So `.resolve` (which stamps `:CWD("/")`)
+                    // followed by no-arg `.relative` still relativizes against the
+                    // process cwd: `"foo/bar".IO.resolve.relative` is `foo/bar`, and
+                    // `IO::Path.new("b/c", :CWD("/a")).relative` is `../../..a/b/c`
+                    // relative to `$*CWD`, not `b/c`. The receiver's `.CWD` is only
+                    // used to make the *target* path absolute (`path_buf`, above).
                     let base_buf = match args.first().map(|v| v.to_string_value()) {
                         Some(base) => self.resolve_path(&base),
-                        None => instance_cwd
-                            .as_ref()
-                            .map(|c| self.resolve_path(c))
-                            .unwrap_or_else(|| cwd_path.clone()),
+                        None => cwd_path.clone(),
                     };
                     let rel = Self::lexical_abs2rel(&path_buf, &base_buf);
                     Ok(Value::str(rel))

--- a/t/io-path-add-relative.t
+++ b/t/io-path-add-relative.t
@@ -1,0 +1,47 @@
+use Test;
+
+# IO::Path.add is slurpy (*@children): it flattens its positional arguments and
+# joins each element onto the path as a separate segment. IO::Path.relative
+# defaults its base to $*CWD (not the receiver's own .CWD, unlike .absolute).
+
+plan 14;
+
+# --- .add: slurpy / list flattening ---------------------------------------
+is "foo".IO.add(<bar baz>).Str, "foo/bar/baz",
+    '.add(<bar baz>) splits the word list into path segments';
+is "foo".IO.add("a", "b").Str, "foo/a/b",
+    '.add with multiple positional args joins each as a segment';
+is "foo".IO.add(("a", ("b", "c"))).Str, "foo/a/b/c",
+    '.add deep-flattens a nested list';
+is "foo".IO.add("bar baz").Str, "foo/bar baz",
+    '.add with a single Str keeps it whole (no split on space)';
+is "foo".IO.add().Str, "foo",
+    '.add() with no arguments is a no-op';
+
+# --- .child: single Str() child (NOT slurpy) ------------------------------
+is "foo".IO.child(<bar baz>).Str, "foo/bar baz",
+    '.child(<bar baz>) coerces the list to a single Str child';
+is "foo".IO.child("x").Str, "foo/x",
+    '.child adds a single segment';
+
+# --- .relative: default base is $*CWD -------------------------------------
+is "foo/bar".IO.resolve.relative, "foo/bar",
+    '.resolve.relative relativizes against $*CWD, not the stamped :CWD("/")';
+is IO::Path.new("/a/b/c", :CWD("/a")).relative, "/a/b/c".IO.relative,
+    '.relative ignores the receiver .CWD and uses $*CWD';
+
+# a plain relative receiver's .relative round-trips against $*CWD
+is "sub/dir/file".IO.relative, "sub/dir/file",
+    '.relative of a cwd-relative path is itself';
+
+# explicit base still honored (the zef $archive.relative($tmp) path)
+is "/a/b/c".IO.relative("/a"), "b/c",
+    '.relative(base) strips an explicit ancestor base';
+is "/a/x".IO.relative("/a/b"), "../x",
+    '.relative(base) walks up with .. for a sibling base';
+
+# --- .absolute: default base is the receiver .CWD (asymmetric with .relative)
+is IO::Path.new("b/c", :CWD("/a")).absolute, "/a/b/c",
+    '.absolute defaults to the receiver .CWD';
+is "/x/y".IO.absolute, "/x/y",
+    '.absolute of an already-absolute path is itself';


### PR DESCRIPTION
Two `Type/IO/Path.rakudoc` doc-diff findings, both general bugs.

## `.add` is slurpy (`*@children`)

`.add` flattens its positional arguments and joins each element onto the path as its own segment — it is not a single `Str()` coercion.

- `"foo".IO.add(<bar baz>)` → `foo/bar/baz` (was `foo/bar baz`)
- `"foo".IO.add("a", "b")` → `foo/a/b`
- `"foo".IO.add(("a", ("b", "c")))` → `foo/a/b/c` (deep flatten)
- `"foo".IO.add("bar baz")` → `foo/bar baz` (a single Str stays whole)

`.child` keeps its single-`Str()` semantics (`.child(<bar baz>)` is `foo/bar baz`).

## `.relative` defaults to `$*CWD`

`.relative`'s default base is `$*CWD`, **not** the receiver's own `.CWD` attribute — unlike `.absolute`, which defaults to `$.CWD`. Since `.resolve` stamps `:CWD("/")`, `"foo/bar".IO.resolve.relative` was mis-relativized against `/` (`home/tokuhirom/.../foo/bar`); it now relativizes against the process cwd (`foo/bar`), matching raku. The receiver `.CWD` is still used to make the *target* path absolute.

Pin: `t/io-path-add-relative.t` (14 tests, green under raku too). Bug fix → default patch bump, no label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)