### PR TITLE
fix: don't constant-fold literal operators when a module override may be imported

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -207,11 +207,28 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 - repro: _(fill in a minimal repro + raku baseline before fixing)_
 - file: _(suspected parser/runtime file)_
 
-### T-041 — test_fail: Int  [impact: 1 dist]
+### T-041 — test_fail: Int  [impact: 1 dist]  — FIXED (PR `fix-module-infix-const-fold`)
 - dists: Rat::Power
 - e.g. `Rat::Power`: base=1 pass=0 fail=1 die=0 | t/01-basic.rakutest: Int
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
+- repro: `use Rat::Power; say (64 ** ⅓)` — raku/fix: `4` (Int, via the module's
+  `multi infix:<**>(Int:D, ExpRat:D) is export`); mutsu was: `3.999...` (Num).
+- **Root cause: compile-time constant folding vs a runtime-imported operator
+  override (ADR-0006 known gap).** `64 ** ⅓` is two numeric literals, so the
+  compiler folded it against the *core* `**` at emit time. Rakudo imports the
+  module's `infix:<**>` at *compile* time and never folds a user multi, so it
+  dispatches to the override; mutsu loads modules at *runtime*, so at compile
+  time of the consuming unit the override is not yet registered
+  (`user_declared_infix_ops` / `USER_INFIX_DECLS` still empty).
+- **Fix:** compiling a real module `use` now calls `fold_ctx.note_operator_decl()`
+  (`src/compiler/stmt.rs`), so if the unit folded any literal operator
+  expression it is recompiled with folding off — the same mechanism inline
+  `sub infix:<...>` declarations already use. Only units that BOTH import a
+  module AND fold a literal operator pay this (the `folded` flag is set solely
+  by operator literal folds), so ordinary constant inlining is unaffected;
+  pragmas (`v6`, `strict`, `nqp`, ...) are matched by earlier arms and never
+  reach the generic `use` arm, so they keep folding. Pin:
+  `t/module-exported-infix-no-constant-fold.t` (+ `t/lib/RatPowerFixture.rakumod`).
+- file: `src/compiler/stmt.rs` (generic `Stmt::Use` arm), `src/compiler/const_fold.rs` (mechanism)
 
 ### T-042 — test_fail: We defined G, FWIW  [impact: 1 dist]
 - dists: Math::Arrow

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -3089,6 +3089,22 @@ impl Compiler {
                 condition,
                 arg,
             } => {
+                // A module `use`d here may export operators
+                // (`multi infix:<...> is export`). Because mutsu loads modules
+                // at *runtime*, the compiler cannot see those exports while
+                // compiling the consuming unit, so a literal-only expression
+                // like `64 ** ⅓` after `use Rat::Power` would otherwise be
+                // folded against the *core* operator before the module's
+                // override is installed (ADR-0006 known gap). Treat a real
+                // module import like an inline operator declaration: if the
+                // unit folded any literal operator expression, the unit-level
+                // compile recompiles it with folding off. Only units that both
+                // import a module and fold a literal operator pay this (the
+                // `folded` flag is set solely by operator literal folds), so
+                // constant inlining in the common case is unaffected. Pragmas
+                // (`v6`, `strict`, `nqp`, ...) are matched by earlier arms and
+                // never reach here, so they keep folding.
+                self.fold_ctx.note_operator_decl();
                 let name_idx = self.code.add_constant(Value::str(module.clone()));
                 // The native JSON modules read their import list at run time to
                 // select per-scope defaults (`use JSON::Fast <immutable !pretty>`).

--- a/t/lib/RatPowerFixture.rakumod
+++ b/t/lib/RatPowerFixture.rakumod
@@ -1,0 +1,11 @@
+unit class RatPowerFixture;
+
+# A module-exported `multi infix:<**>` that supersedes the core operator for
+# an `Int` base and a Rat exponent. The consuming unit must NOT constant-fold
+# `64 ** ⅓` against the core `**` before this override is imported.
+subset ExpRat of Rat where * == (½, ⅓, ⅔, ¼, ¾).any;
+
+multi infix:<**>(Int:D $base, ExpRat:D $exp) is export {
+    my $real = $base ** $exp.Num;
+    if $real.round =~= $real { $real.round } else { $real }
+}

--- a/t/module-exported-infix-no-constant-fold.t
+++ b/t/module-exported-infix-no-constant-fold.t
@@ -1,0 +1,28 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+# Regression: a `multi infix:<**> is export`ed from a module supersedes the
+# core operator, so a literal-only expression like `64 ** ⅓` must dispatch to
+# the module's override at runtime rather than being constant-folded against
+# the core `**` at compile time. mutsu loads modules at runtime, so the
+# compiler must treat a module `use` conservatively and disable literal
+# operator folding for the unit (ADR-0006 known gap, fixed for module imports).
+
+use RatPowerFixture;
+
+plan 4;
+
+# The headline case: both operands are literals, so the compile-time folder
+# would evaluate this eagerly if it did not know about the imported override.
+my $r = 64 ** ⅓;
+isa-ok $r, Int, '64 ** ⅓ dispatches to module override -> Int (not folded Num)';
+is $r, 4, '64 ** ⅓ == 4 via the module override';
+
+# A non-ExpRat exponent falls through to the core operator (Num result).
+my $s = 60 ** ⅓;
+isa-ok $s, Num, '60 ** ⅓ uses the core operator (Num)';
+
+# Ordinary (non-operator) constant folding is unaffected by the import.
+constant SECONDS = 60 * 60;
+is SECONDS, 3600, 'plain constant folding still works alongside the import';


### PR DESCRIPTION
## Problem

A `multi infix:<op> is export`ed from a module supersedes the core operator, but mutsu loads modules at **runtime**, so when the compiler compiles the consuming unit the override is not yet registered. A literal-only expression such as `64 ** ⅓` after `use Rat::Power` was constant-folded against the **core** `**` at emit time, yielding `3.999...` (Num) instead of dispatching to the module's `infix:<**>(Int:D, ExpRat:D)` override (which returns `4`, Int).

This is the ADR-0006 documented **known gap**: an operator override imported from a module is registered after the consuming unit has been compiled. Rakudo processes `use` at compile time and never folds a user multi, so it dispatches correctly.

```raku
use Rat::Power;
say (64 ** ⅓);   # raku: 4 (Int) ; mutsu was: 3.9999999999999996 (Num)
```

## Fix

Compiling a real module `use` now calls `fold_ctx.note_operator_decl()`, reusing the existing unit-level refold-off mechanism that inline `sub infix:<...>` declarations already trigger. If the unit folded any literal operator expression it is recompiled with folding off.

Only units that **both** import a module **and** fold a literal operator expression pay the cost — the `folded` flag is set solely by operator literal folds, so ordinary constant inlining (`constant SECONDS = 60 * 60`) is unaffected. Pragmas (`v6`, `strict`, `nqp`, ...) are matched by earlier `use` arms and never reach the generic arm, so they keep folding.

## Test

Pin: `t/module-exported-infix-no-constant-fold.t` (+ `t/lib/RatPowerFixture.rakumod`), verified against raku (4/4). `make test` clean (only `t/proc-async.t` flaked under parallel load, passes 3/3 on retry, unrelated). clippy clean.

Fixes TODO_dist **T-041** (Rat::Power).

🤖 Generated with [Claude Code](https://claude.com/claude-code)