### PR TITLE
fix: .reduce on a type object is Nil; empty list returns operator identity

### DIFF
--- a/src/runtime/builtins_reduce.rs
+++ b/src/runtime/builtins_reduce.rs
@@ -136,7 +136,27 @@ impl Interpreter {
         items: Vec<Value>,
     ) -> Result<Value, RuntimeError> {
         if items.is_empty() {
-            return Ok(Value::NIL);
+            // An empty reduce returns the operator's identity element (`0` for
+            // `+`, `""` for `~`, `1` for `*`, `True` for chaining comparisons, …),
+            // matching raku (`[+] ()` is `0`; `().reduce(&infix:<+>)` is `0`;
+            // `reduce &infix:<*>, ()` is `1`). An operator with no known identity
+            // (a bare block) yields Nil. An *undefined* invocant is caught earlier
+            // by `dispatch_reduce_method` and returns Nil regardless of operator.
+            let op_name = match callable.view() {
+                ValueView::Sub(data) => Some(data.name.resolve()),
+                ValueView::Routine { name, .. } => Some(name.resolve()),
+                _ => None,
+            };
+            return Ok(match op_name {
+                Some(op) => {
+                    let bare_op = op
+                        .strip_prefix("infix:<")
+                        .and_then(|s| s.strip_suffix('>'))
+                        .unwrap_or(op.as_str());
+                    crate::runtime::reduction_identity(bare_op)
+                }
+                None => Value::NIL,
+            });
         }
         if items.len() == 1 {
             // A single-element reduce returns the element's *value* coerced to the

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -384,6 +384,13 @@ impl Interpreter {
             let attrs_clone = attributes.to_map();
             return self.dispatch_supply_reduce(target, &attrs_clone, callable);
         }
+        // `.reduce` on an *undefined* invocant — a bare type object (`Range`,
+        // `Str`, `Any`) or `Nil` — is `Nil`, because `Any.reduce` is guarded on a
+        // defined invocant. (A type object passed as a list *element*, e.g.
+        // `(Range,).reduce(&+)`, is a different thing and reduces normally.)
+        if !crate::runtime::types::value_is_defined(&target) {
+            return Ok(Value::NIL);
+        }
         let items = Self::value_to_list(&target);
         self.reduce_items(callable, items)
     }

--- a/t/reduce-empty-and-typeobject.t
+++ b/t/reduce-empty-and-typeobject.t
@@ -1,0 +1,31 @@
+use Test;
+
+# .reduce on an *undefined* invocant (a bare type object or Nil) is Nil, because
+# Any.reduce is guarded on a defined invocant. .reduce on an empty concrete list
+# returns the operator's identity element (0 for +, "" for ~, 1 for *, …), like
+# the [op] reduce metaop and matching raku.
+
+plan 14;
+
+# --- undefined invocant => Nil --------------------------------------------
+is Range.reduce(&infix:<+>), Nil, 'Range.reduce (type object) is Nil';
+is Str.reduce(&infix:<~>),   Nil, 'Str.reduce (type object) is Nil';
+is Array.reduce(&infix:<+>), Nil, 'Array.reduce (type object) is Nil';
+is Int.reduce(&infix:<+>),   Nil, 'Int.reduce (type object) is Nil';
+is Any.reduce(&infix:<+>),   Nil, 'Any.reduce (type object) is Nil';
+
+# --- empty concrete list => operator identity -----------------------------
+is [].reduce(&infix:<+>), 0,  'empty list .reduce(&+) is 0';
+is [].reduce(&infix:<~>), '', 'empty list .reduce(&~) is ""';
+is [].reduce(&infix:<*>), 1,  'empty list .reduce(&*) is 1';
+my @e;
+is @e.reduce(&infix:<+>), 0, 'empty @array .reduce(&+) is 0';
+is (reduce &infix:<+>, ()), 0, 'reduce &+, () (function form) is 0';
+
+# --- a type object as a list *element* reduces normally (not the guard) ----
+is (Range,).reduce(&infix:<+>), 0, 'a type object element coerces (0), not Nil';
+
+# --- non-empty still reduces ----------------------------------------------
+is [1, 2, 3].reduce(&infix:<+>), 6, 'non-empty .reduce still works';
+is (1..5).reduce(&infix:<+>), 15, 'Range .reduce still works';
+is [5].reduce(&infix:<+>), 5, 'single-element .reduce returns the element';


### PR DESCRIPTION
`Type/Any.rakudoc` doc-diff finding: `Range.reduce(&infix:<+>)` and `Str.reduce(&infix:<~>)` are `Nil` in raku, but mutsu had the behavior backwards on both ends.

## Undefined invocant → `Nil`

`.reduce` on an undefined invocant — a bare type object (`Range`, `Str`, `Array`, `Int`, `Any`) or `Nil` — is `Nil`, because `Any.reduce` is guarded on a defined invocant. mutsu treated the type object as a single element and coerced it (`0`). `dispatch_reduce_method` now guards on `value_is_defined`.

A type object passed as a list *element* (`(Range,).reduce(&+)`) is unaffected and still coerces (`0`, matching raku).

## Empty concrete list → operator identity

`.reduce` on an empty concrete list returns the operator's identity element (`0` for `+`, `""` for `~`, `1` for `*`, …), matching raku and the existing `[op] ()` reduce metaop path — mutsu returned `Nil`. `reduce_items` now looks up `reduction_identity` (Nil only for an op with no known identity, e.g. a bare block). Fixes both the method form (`().reduce(&infix:<+>)`) and the function form (`reduce &infix:<+>, ()`).

Pin: `t/reduce-empty-and-typeobject.t` (14 tests, green under raku too). Bug fix → default patch bump, no label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)