### PR TITLE
fix: a role's my $.x composes as a class-level attribute (type-object accessor)

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -32,12 +32,24 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 - file: DONE — value/mod.rs, runtime/methods_call_dispatch.rs, vm/vm_call_method_ops.rs,
   vm/vm_call_method_mut_ops.rs; remaining — CompUnit::Repository introspection (Injector)
 
-### T-004 — runtime_error: Runtime error: An exception occurred while evaluating a CHECK  [impact: 2 dists]
-- dists: ML::TriesWithFrequencies, Rakudo::Version
-- e.g. `Rakudo::Version`: rakudo: Runtime error: An exception occurred while evaluating a CHECK
-- e.g. `ML::TriesWithFrequencies`: ML::TriesWithFrequencies: Runtime error: An exception occurred while evaluating a CHECK
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
+### T-004 — runtime_error: An exception occurred while evaluating a CHECK  [impact: ~0 real remaining]
+- dists: ML::TriesWithFrequencies (LOAD fixed, PR pending), Rakudo::Version (rakudo-only)
+- ML::TriesWithFrequencies — **LOAD FIXED**: the `Trieish` role declares
+  `my Str $.trieRootLabel = 'TRIEROOT'` (a *class-level* attribute), and a CHECK-time
+  constant reads it via the composed class's TYPE object
+  (`constant $TrieRoot = ...::Trie.trieRootLabel`). mutsu composed the role's `my $.x`
+  as a *per-instance* attribute, so the type-object accessor was missing → "No such
+  method 'trieRootLabel'". Now a role `my $.x`/`our $.x` composes onto the class's
+  `class_level_attrs` (not per-instance), and the role type object exposes it too
+  (`R.x`). The dist LOADS now; remaining per-test failures (e.g. trie-merge
+  equivalence) are separate, deeper trie-logic bugs. Pin:
+  t/role-my-class-level-attr-accessor.t.
+- Rakudo::Version — **rakudo-only, not a mutsu bug**: its `BEGIN` block does
+  `die "... supposed to run on Rakudo ..." if $*RAKU.compiler.name ne 'rakudo'`, so it
+  intentionally refuses any non-rakudo compiler (raku itself fails it too, at EXPORT).
+  mutsu reports compiler name 'mutsu' → the BEGIN die is correct behavior.
+- file: DONE — runtime/registry.rs, registration_role.rs, registration_class_decl.rs,
+  methods_call_dispatch.rs (role `my $.x` → class-level attr)
 
 ### T-005 — runtime_error: Runtime error: Failed to parse module 'X': Unexpected block in infix position (missing statement control word before the  [impact: 2 dists]
 - dists: REPL, mv2d

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2655,6 +2655,23 @@ impl Interpreter {
         // Role type-object method punning
         if method != "new" {
             if let ValueView::Package(role_name) = target.view() {
+                // A class-level (`my $.x`) role attribute is readable on the role
+                // type object directly (`R.x`), returning its recorded default —
+                // no instance punning (there is no per-instance storage for it).
+                let class_level_default = if args.is_empty() {
+                    self.registry()
+                        .role_class_level_attrs
+                        .get(&(role_name.resolve(), method.to_string()))
+                        .cloned()
+                } else {
+                    None
+                };
+                if let Some(default) = class_level_default {
+                    return match default {
+                        Some(expr) => self.eval_block_value(&[Stmt::Expr(expr)]),
+                        None => Ok(Value::NIL),
+                    };
+                }
                 // Decide under the guard, then drop it before re-entering.
                 let should_dispatch = self
                     .registry()

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -764,6 +764,25 @@ impl Interpreter {
                         class_def.attributes.push(attr.clone());
                     }
                 }
+                // Carry each composed-role class-level attribute (`my $.x`/`our $.x`)
+                // onto the consuming class as a class-level attribute, so the accessor
+                // works on the class type object (`C.x`), matching raku. The default
+                // expr is evaluated now (role param bindings, if any, are in scope).
+                let role_class_level: Vec<(String, Option<crate::ast::Expr>)> = self
+                    .registry()
+                    .role_class_level_attrs
+                    .iter()
+                    .filter(|((r, _), _)| r == base_role_name)
+                    .map(|((_, attr), expr)| (attr.clone(), expr.clone()))
+                    .collect();
+                for (attr, default) in role_class_level {
+                    let value = if let Some(expr) = default {
+                        self.eval_block_value(&[Stmt::Expr(expr)])?
+                    } else {
+                        Value::NIL
+                    };
+                    class_def.class_level_attrs.insert(attr, value);
+                }
                 // Carry each composed-role attribute's deferred `is default(...)`
                 // expression onto the consuming class so it can be evaluated at
                 // construction with this class's type-param bindings in scope.

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -473,8 +473,8 @@ impl Interpreter {
                     sigil,
                     where_constraint,
                     is_alias: _,
-                    is_our: _,
-                    is_my: _,
+                    is_our,
+                    is_my,
                     is_default,
                     is_type,
                     deprecated_message: _,
@@ -482,6 +482,18 @@ impl Interpreter {
                     unknown_traits: _,
                 } => {
                     let attr_name_str = attr_name.resolve();
+                    // A class-level (`my $.x` / `our $.x`) role attribute is NOT a
+                    // per-instance attribute: it becomes a class-level attribute on the
+                    // consuming class (accessor on the type object, `C.x`) — exactly
+                    // like `class C { my $.x }`. Record its default expr keyed by
+                    // (role, attr) and skip the per-instance attribute registration, so
+                    // no per-instance accessor shadows the class-level fallback.
+                    if *is_my || *is_our {
+                        self.registry_mut()
+                            .role_class_level_attrs
+                            .insert((name.to_string(), attr_name_str.clone()), default.clone());
+                        continue;
+                    }
                     role_def.own_attribute_names.insert(attr_name_str.clone());
                     // Carry an `is Type` container trait (`has @.a is G::A`) so it
                     // can be transferred to the consuming class at composition and

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -124,6 +124,11 @@ pub(crate) struct Registry {
     /// are bound: (role-base, attr) -> expr. Evaluated at instance construction
     /// (with role param bindings in scope) to tag `@`/`%` containers.
     pub(crate) role_attribute_default_exprs: HashMap<(String, String), crate::ast::Expr>,
+    /// Class-level (`my $.x` / `our $.x`) role attributes: (role-base, attr) ->
+    /// optional default expr. These generate an accessor on the *type object*
+    /// (not per-instance), so at composition they are copied into the consuming
+    /// class's `class_level_attrs` rather than its per-instance attributes.
+    pub(crate) role_class_level_attrs: HashMap<(String, String), Option<crate::ast::Expr>>,
     /// Per-attribute deferred `is default(...)` expression carried from a composed
     /// parametric role onto a consuming class: (class, attr) -> expr. Evaluated at
     /// construction with the class's role type-param bindings in scope.

--- a/t/role-my-class-level-attr-accessor.t
+++ b/t/role-my-class-level-attr-accessor.t
@@ -1,0 +1,45 @@
+use v6;
+use Test;
+
+# A `my $.x` (class-level) attribute declared in a role composes onto the
+# consuming class as a class-level attribute: its accessor works on the class
+# *type object* (`C.x`), not only on instances. Regression pin for the
+# ML::TriesWithFrequencies dist, whose `Trieish` role declares
+# `my Str $.trieRootLabel = 'TRIEROOT'` and a CHECK-time constant reads it via
+# `ML::TriesWithFrequencies::Trie.trieRootLabel` (the type object).
+
+role R {
+    my Str $.label = 'ROOT';
+}
+class C does R {}
+
+is C.label, 'ROOT', 'my $.x role attr accessor works on the composed class type object';
+is C.new.label, 'ROOT', 'and also on an instance of the composed class';
+
+# The role type object itself already exposes it.
+is R.label, 'ROOT', 'the role type object exposes its own class-level accessor';
+
+# A class that declares `my $.x` directly keeps working (unchanged path).
+class D {
+    my Str $.tag = 'D-TAG';
+}
+is D.tag, 'D-TAG', 'my $.x declared directly on a class still works on the type object';
+
+# A CHECK-time constant reading a composed class-level role attr (the dist shape).
+role Trieish {
+    my Str $.trieRootLabel = 'TRIEROOT';
+}
+class Trie does Trieish {}
+constant $ROOT = Trie.trieRootLabel;
+is $ROOT, 'TRIEROOT', 'a constant can read a composed class-level role attr at compile time';
+
+# A plain per-instance `has $.x` in a role must NOT become class-level: calling
+# its accessor on the type object still fails (it needs an instance).
+role HR {
+    has Str $.inst = 'I';
+}
+class HC does HR {}
+is HC.new.inst, 'I', 'has $.x role attr works on an instance';
+dies-ok { HC.inst }, 'has $.x role attr does NOT leak onto the type object';
+
+done-testing;


### PR DESCRIPTION
A `my $.x` (or `our $.x`) attribute declared in a role is a **class-level** attribute: its accessor works on the class *type object* (`C.x`), not only on instances. mutsu composed it as a *per-instance* attribute, so the type-object accessor was missing — `role R { my Str $.x = 'v' }; class C does R {}; C.x` threw `No such method 'x' for invocant of type 'C'`.

## Fix
A role `my $.x`/`our $.x` attribute is recorded in a side registry (`role_class_level_attrs`, keyed by `(role, attr)` with its default expr) and skipped from per-instance composition. At class composition it is evaluated into the consuming class's `class_level_attrs` (so `C.x` and `C.new.x` both work, as for a directly-declared `class C { my $.x }`), and the role type object exposes it directly (`R.x`). A plain per-instance `has $.x` is unaffected and still does **not** leak onto the type object.

## Impact
Unblocks the **load** of the ML::TriesWithFrequencies dist, whose `Trieish` role declares `my Str $.trieRootLabel = 'TRIEROOT'` and reads it at CHECK time via the composed class's type object; the dist previously died with "An exception occurred while evaluating a CHECK". (The other T-004 dist, Rakudo::Version, is a rakudo-only module that intentionally dies on any non-rakudo compiler — not a mutsu bug.)

Pin: `t/role-my-class-level-attr-accessor.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)