### PR TITLE
fix: a return-type coercion to Array/List reifies a lazy gather

### DIFF
--- a/src/runtime/accessors.rs
+++ b/src/runtime/accessors.rs
@@ -495,6 +495,21 @@ impl Interpreter {
             return Ok(value);
         }
 
+        // A lazy value (a `gather`/`take` coroutine, a lazy map/grep pipeline)
+        // must be reified before an *eager-container* coercion reads its elements:
+        // `sub f(--> Array(Seq)) { gather { take 2; take 3 } }` returns `[2, 3]`,
+        // not `[]`. Force it into an eager Seq (still `.WHAT` Seq, so an already-
+        // passed `(Seq)` source constraint stays satisfied). Only for Array/List
+        // targets — a `Seq(...)`/plain `--> Seq` coercion keeps its laziness (the
+        // no-paren case returns early above and never reaches here).
+        let value = if matches!(base_target, "Array" | "List")
+            && let ValueView::LazyList(list) = value.view()
+        {
+            Value::seq(self.force_lazy_list_bridge(&list)?)
+        } else {
+            value
+        };
+
         // Try to coerce the value
         let coerced = self.try_coerce_value_for_return(base_target, value.clone())?;
 

--- a/t/return-coercion-lazy-gather.t
+++ b/t/return-coercion-lazy-gather.t
@@ -1,0 +1,36 @@
+use Test;
+
+# A return-type coercion to an eager container (`--> Array(Seq)` / `--> Array()`
+# / `--> List(...)`) must reify a lazy value (a gather/take coroutine) before
+# reading its elements, so the coercion yields the produced items — not an empty
+# container. A plain `--> Seq` (no coercion) keeps its laziness.
+
+plan 7;
+
+sub g-array(--> Array(Seq)) { gather { take 2; take 3 } }
+is-deeply g-array().List, (2, 3), 'gather through --> Array(Seq) reifies to its items';
+
+sub g-array-empty-src(--> Array()) { gather { take 5; take 6 } }
+is-deeply g-array-empty-src().List, (5, 6), 'gather through --> Array() reifies';
+
+# eager Seq return still coerces fine (no regression)
+sub eager-seq(--> Array(Seq)) { (7, 8, 9).Seq }
+is-deeply eager-seq().List, (7, 8, 9), 'eager Seq through --> Array(Seq) still works';
+
+# the categorize doc example: a multi-key mapper returning Array(Seq). Use Int
+# keys (not `<...>` allomorphs) so the bucket keys are plain Int, decoupled from
+# the separate object-hash key-identity item (PLAN.md §8.10).
+sub divisible-by(Int $n --> Array(Seq)) {
+    gather { for 2, 3, 5, 7 { take $_ if $n %% $_ } }
+}
+my %cat = (3..13).categorize(&divisible-by);
+is-deeply %cat{2}.List, (4, 6, 8, 10, 12), 'categorize gather mapper: bucket 2';
+is-deeply %cat{3}.List, (3, 6, 9, 12),     'categorize gather mapper: bucket 3';
+
+# a plain --> Seq keeps a lazy gather lazy (laziness is NOT forced)
+sub lazy-seq(--> Seq) { lazy gather { take 1; take 2 } }
+ok lazy-seq().is-lazy, 'a plain --> Seq return keeps a lazy gather lazy';
+
+# non-lazy value through Array(Seq) coercion is unaffected
+sub already-array(--> Array(Seq)) { my @a = 1, 2, 3; @a.Seq }
+is-deeply already-array().List, (1, 2, 3), 'a reified array through --> Array(Seq) works';


### PR DESCRIPTION
`Type/Any.rakudoc` doc-diff finding (`.categorize` with an `Array(Seq)` mapper).

## The bug

`sub f(--> Array(Seq)) { gather { take 2; take 3 } }` returned `[]` instead of `[2, 3]`. A `gather`/`take` coroutine is a lazy `LazyList`; the return-type coercion read its (still-empty) backing before the coroutine ran, so the coerced Array came out empty.

## The fix

`enforce_coercion_return` now forces a lazy value into an eager `Seq` before an *eager-container* coercion (`Array(...)` / `List(...)` / the empty-source `Array()` forms) reads its elements. The reified value stays a `Seq` (`.WHAT` Seq), so an already-satisfied `(Seq)` source constraint still holds.

Laziness is preserved where it should be:
- a plain `--> Seq` (no parens) returns early and never reaches the coercion, so `sub (--> Seq) { lazy gather {...} }` stays lazy;
- a `Seq(...)` target is not an eager container and is left untouched.

This unblocks the doc's `.categorize(&divisible-by)` example, whose mapper returns `Array(Seq)`.

Pin: `t/return-coercion-lazy-gather.t` (7 tests, green under raku too). Bug fix → default patch bump, no label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)