### PR TITLE
fix: .sum coerces string elements via the full Raku numeric grammar

### DIFF
--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -911,32 +911,30 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     );
                     return Some(result);
                 }
-                // Check for non-numeric strings first
+                // Check for non-numeric strings first. Use the full Raku numeric
+                // grammar (via `.Numeric`), NOT a base-10 `parse::<f64>`, so radix
+                // literals and allomorphs a string can hold — `"0xff"` (255),
+                // `"0b1111"` (15), `"1/2"` — sum correctly instead of erroring.
                 for item in items.iter() {
-                    if let ValueView::Str(s) = item.view() {
-                        let trimmed = s.trim();
-                        if trimmed.parse::<f64>().is_err() {
-                            let reason =
-                                "base-10 number must begin with valid digits or '.'".to_string();
-                            let msg =
-                                format!("Cannot convert string '{}' to number: {}", *s, reason);
-                            let mut attrs = std::collections::HashMap::new();
-                            attrs.insert("source".to_string(), Value::str(s.to_string()));
-                            attrs.insert("reason".to_string(), Value::str(reason));
-                            attrs.insert("pos".to_string(), Value::int(0));
-                            attrs.insert(
-                                "target-name".to_string(),
-                                Value::str("Numeric".to_string()),
-                            );
-                            attrs.insert("message".to_string(), Value::str(msg.clone()));
-                            let ex = Value::make_instance(
-                                crate::symbol::Symbol::intern("X::Str::Numeric"),
-                                attrs,
-                            );
-                            let mut err = RuntimeError::new(&msg);
-                            err.exception = Some(Box::new(ex));
-                            return Some(Err(err));
-                        }
+                    if let ValueView::Str(s) = item.view()
+                        && crate::runtime::str_numeric::parse_raku_str_to_numeric(&s).is_none()
+                    {
+                        let reason =
+                            "base-10 number must begin with valid digits or '.'".to_string();
+                        let msg = format!("Cannot convert string '{}' to number: {}", *s, reason);
+                        let mut attrs = std::collections::HashMap::new();
+                        attrs.insert("source".to_string(), Value::str(s.to_string()));
+                        attrs.insert("reason".to_string(), Value::str(reason));
+                        attrs.insert("pos".to_string(), Value::int(0));
+                        attrs.insert("target-name".to_string(), Value::str("Numeric".to_string()));
+                        attrs.insert("message".to_string(), Value::str(msg.clone()));
+                        let ex = Value::make_instance(
+                            crate::symbol::Symbol::intern("X::Str::Numeric"),
+                            attrs,
+                        );
+                        let mut err = RuntimeError::new(&msg);
+                        err.exception = Some(Box::new(ex));
+                        return Some(Err(err));
                     }
                 }
                 // Fold with `+` so the result type promotes like Raku's reduction

--- a/t/sum-radix-string.t
+++ b/t/sum-radix-string.t
@@ -1,0 +1,19 @@
+use Test;
+
+# .sum / sum() coerce string elements through the full Raku numeric grammar
+# (like .Numeric), so a string holding a radix literal or an allomorph sums
+# correctly instead of erroring on a base-10-only parse.
+
+plan 9;
+
+is (1, "0xff").sum, 256, 'a hex-string element sums via its numeric value';
+is ("0b1111", "0o17").sum, 30, 'binary + octal string elements sum';
+is (1, "1/2").sum, 1.5, 'a rational-string element sums';
+is sum(0b1111, 5), 20, 'sum() of a binary literal and an Int';
+is ("10", "20").sum, 30, 'plain decimal strings still sum';
+is (1, 2, 3).sum, 6, 'plain Int list still sums';
+is (1, 3, pi).sum, 1 + 3 + pi, 'Num element still promotes';
+is (1.5, 2.5).sum, 4.0, 'Rat elements still sum';
+
+# a genuinely non-numeric string still throws X::Str::Numeric
+dies-ok { (1, "x").sum }, 'a non-numeric string still throws';


### PR DESCRIPTION
`Type/List.rakudoc` doc-diff finding: `(1, "0xff").sum` threw `X::Str::Numeric` instead of yielding `256`.

`.sum`'s non-numeric-string guard validated each string element with a base-10 `parse::<f64>`, which rejects the radix literals and allomorphs a string can legally hold — even though `.Numeric` on the same string already parses them.

Validate with `parse_raku_str_to_numeric` (the `.Numeric` grammar) instead, so `"0xff"` (255), `"0b1111"` (15), `"0o17"` (15), and `"1/2"` sum correctly. A genuinely non-numeric string (`"x"`) still throws `X::Str::Numeric`.

Pin: `t/sum-radix-string.t` (9 tests, green under raku too). Bug fix → default patch bump, no label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)