### PR TITLE
fix: .invert on a scalar-held List inverts its pairs, not the whole list

### DIFF
--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -129,6 +129,24 @@ fn extend_inverted_pairs(out: &mut Vec<Value>, key: Value, value: &Value) {
     }
 }
 
+/// Invert one list element for `.invert`: a `Pair`/`ValuePair` contributes its
+/// `value => key` entries (a list value expands to one entry per member).
+/// Returns `false` for a non-pair element so the caller can reject the whole
+/// list (raku throws `X::TypeCheck` for `(1, 2).invert`).
+fn extend_inverted_pairs_from_element(out: &mut Vec<Value>, item: &Value) -> bool {
+    match item.view() {
+        ValueView::Pair(key, value) => {
+            extend_inverted_pairs(out, Value::str(key.clone()), &value.clone());
+            true
+        }
+        ValueView::ValuePair(key, value) => {
+            extend_inverted_pairs(out, key.clone(), &value.clone());
+            true
+        }
+        _ => false,
+    }
+}
+
 fn invert_value(target: &Value) -> Option<Value> {
     let mut result = Vec::new();
     match target.view() {
@@ -172,20 +190,23 @@ fn invert_value(target: &Value) -> Option<Value> {
         ValueView::ValuePair(key, value) => {
             extend_inverted_pairs(&mut result, key.clone(), value);
         }
-        ValueView::Array(_, _) | ValueView::Seq(_) | ValueView::Slip(_) => {
+        ValueView::Array(items, _) => {
+            // Iterate the array's own elements directly, NOT via `value_to_list`:
+            // a List held in a `$` scalar (`my $l = List.new(...)`; the documented
+            // `.invert` example) is an *itemized* Array, and `value_to_list` treats
+            // an itemized array as a single element — which made `$l.invert` see one
+            // `Array`, not its `Pair`s, and throw `X::TypeCheck`. Its elements are
+            // still the pairs regardless of the itemization flag.
+            for item in items.iter() {
+                if !extend_inverted_pairs_from_element(&mut result, item) {
+                    return None;
+                }
+            }
+        }
+        ValueView::Seq(_) | ValueView::Slip(_) => {
             for item in crate::runtime::utils::value_to_list(target) {
-                match item.view() {
-                    ValueView::Pair(key, value) => {
-                        let key = key.clone();
-                        let value = value.clone();
-                        extend_inverted_pairs(&mut result, Value::str(key), &value);
-                    }
-                    ValueView::ValuePair(key, value) => {
-                        let key = key.clone();
-                        let value = value.clone();
-                        extend_inverted_pairs(&mut result, key, &value);
-                    }
-                    _ => return None,
+                if !extend_inverted_pairs_from_element(&mut result, &item) {
+                    return None;
                 }
             }
         }
@@ -803,7 +824,15 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     target.view(),
                     ValueView::Array(..) | ValueView::Seq(..) | ValueView::Slip(..)
                 ) {
-                    let got_val = crate::runtime::utils::value_to_list(target)
+                    // Report the first non-pair element's type. Iterate an Array's
+                    // own elements (an itemized `$`-held list would otherwise report
+                    // the whole `Array` here instead of the offending `Int`).
+                    let elements = if let ValueView::Array(items, _) = target.view() {
+                        items.iter().cloned().collect::<Vec<_>>()
+                    } else {
+                        crate::runtime::utils::value_to_list(target)
+                    };
+                    let got_val = elements
                         .into_iter()
                         .find(|item| {
                             !matches!(item.view(), ValueView::Pair(..) | ValueView::ValuePair(..))

--- a/t/invert-scalar-held-list.t
+++ b/t/invert-scalar-held-list.t
@@ -1,0 +1,34 @@
+use Test;
+
+# .invert on a List held in a `$` scalar must invert the list's own Pair
+# elements, not treat the (itemized) list as a single element. Previously
+# `my $l = List.new(...); $l.invert` threw X::TypeCheck "got Array".
+
+plan 7;
+
+my $l = List.new('a' => (2, 3), 'b' => 17);
+is-deeply $l.invert.List, (2 => 'a', 3 => 'a', 17 => 'b'),
+    'invert on a $-held List with a list-valued pair';
+
+my $p = (a => 1, b => 2);
+is-deeply $p.invert.List, (1 => 'a', 2 => 'b'),
+    'invert on a $-held list of scalar pairs';
+
+# inline (non-itemized) list still works
+is-deeply ('a' => (2, 3), 'b' => 17).invert.List, (2 => 'a', 3 => 'a', 17 => 'b'),
+    'invert on an inline list of pairs';
+
+my $single = ('x' => (2, 3),);
+is-deeply $single.invert.List, (2 => 'x', 3 => 'x'),
+    'invert on a $-held single list-valued pair';
+
+# a Hash still inverts
+my %h = a => 1, b => 2;
+is-deeply %h.invert.sort.List, (1 => 'a', 2 => 'b'),
+    'invert on a Hash';
+
+# a non-pair element still throws X::TypeCheck with the right "got" type
+dies-ok { (1, 2).invert }, 'a plain (non-pair) list still throws on invert';
+my $bad = (1, 2);
+throws-like { $bad.invert }, X::TypeCheck,
+    'a $-held plain list throws X::TypeCheck on invert';


### PR DESCRIPTION
`Type/List.rakudoc` doc-diff finding: the documented `my $l = List.new('a' => (2, 3), 'b' => 17); $l.invert` threw `X::TypeCheck` ("expected Pair but got Array") instead of yielding `(2 => a 3 => a 17 => b)`.

A List held in a `$` scalar is an *itemized* Array, and `invert_value` iterated it via `value_to_list`, which treats an itemized array as a single element — so `.invert` saw one `Array`, not its `Pair`s. Iterate the array's own elements directly instead (the elements are the pairs regardless of the itemization flag). The inline non-itemized form already worked; both paths now share `extend_inverted_pairs_from_element`.

The type-check error path is fixed the same way, so `my $l = (1, 2); $l.invert` reports "got Int" (not "Array"), matching raku.

Pin: `t/invert-scalar-held-list.t` (7 tests, green under raku too). Bug fix → default patch bump, no label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)