### PR TITLE
fix: a qualified private-method call resolves a nested owner class name

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -74,12 +74,6 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   lacks in the sweep environment, so this is parse-advance only.
 - file: `src/parser/stmt/control/pointy_param.rs` (string-literal pointy param, done)
 
-### T-018 — runtime_error: Cannot call private method X permission  [impact: 1 dist]
-- dists: Cookie::Jar
-- e.g. `Cookie::Jar`: Cookie::Jar: Cannot call private method without permission
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
-
 ### T-025 — test_die [Math::Root] (01-integer.t DONE; 02/03 blocked on BigFatRat)  [impact: 1 dist]
 - dists: Math::Root
 - e.g. `Math::Root`: base=3 pass=0 fail=0 die=3 | t/01-integer.t
@@ -402,6 +396,21 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 _(move tickets here with `[claim: <branch>]` when you start)_
 
 ## Done
+
+- **T-018** (#PENDING) — Cookie::Jar died with "Cannot call private method without
+  permission". It calls a private method whose OWNER class has a *nested* name:
+  `$cookie!Cookie::Jar::Cookie::match` (owner `Cookie::Jar::Cookie`, method `match`)
+  across a `trusts Cookie::Jar` boundary. Four dispatch/validation sites split the
+  qualified name at the FIRST `::` (`split_once`), so the owner was mis-read as
+  `Cookie::Jar` and the method as `Cookie::match` → permission/no-such-method error.
+  Changed them to `rsplit_once` (owner = everything before the last `::`):
+  registration.rs (compile-time private-access validation — the one the dist hit),
+  methods_instance_ops.rs (two instance sites), methods_qualified.rs (non-instance).
+  Cookie::Jar now LOADS. Pin: t/qualified-private-method-nested-owner.t. Note:
+  the dist's tests still need `IDNA::Punycode` (missing dep, raku lacks it too), so
+  they cannot run — but the module load, the ticket's blocker, is fixed. A separate
+  pre-existing gap remains: `self!Nested::Owner::method` (self-qualified, nested
+  owner) goes through a different self-private path and is still rejected.
 
 - **T-047** (#PENDING) — head-skip-tail failed to load (not merely the "skip(4)"
   test): its `EXPORT` sub calls `CORE::.EXISTS-KEY('&head')` to detect a symbol

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -82,9 +82,12 @@ impl Interpreter {
                 // X::Method::Private::Unqualified rather than the Permission
                 // error used for a qualified-but-untrusted call.
                 let was_qualified = private_rest.contains("::");
-                // Resolve: owner-qualified (!Owner::method) or unqualified (!method)
+                // Resolve: owner-qualified (!Owner::method) or unqualified (!method).
+                // Split at the LAST `::` — the owner class may itself be a nested
+                // name (`$c!Jar::Cookie::secret` is owner `Jar::Cookie`, method
+                // `secret`, NOT owner `Jar`, method `Cookie::secret`).
                 let (pm_name, resolved) =
-                    if let Some((owner_class, pm_name)) = private_rest.split_once("::") {
+                    if let Some((owner_class, pm_name)) = private_rest.rsplit_once("::") {
                         let caller_allowed = caller_class.as_deref() == Some(owner_class)
                             || self.registry().class_trusts.get(owner_class).is_some_and(
                                 |trusted| {
@@ -1388,8 +1391,11 @@ impl Interpreter {
                     .last()
                     .cloned()
                     .or_else(|| Some(self.current_package().to_string()));
+                // Split at the LAST `::` so a nested owner class name
+                // (`$c!Jar::Cookie::secret` → owner `Jar::Cookie`, method `secret`)
+                // resolves correctly.
                 let (pm_name, resolved) = if let Some((owner_class, pm_name)) =
-                    private_rest.split_once("::")
+                    private_rest.rsplit_once("::")
                 {
                     let caller_allowed =
                         caller_class.as_deref() == Some(owner_class)

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -18,8 +18,9 @@ impl Interpreter {
         ) {
             return None;
         }
-        // Owner-qualified: !Owner::method
-        if let Some((owner_class, private_name)) = private_rest.split_once("::") {
+        // Owner-qualified: !Owner::method. Split at the LAST `::` so a nested owner
+        // class name (`$x!Jar::Cookie::secret`) keeps its full qualifier.
+        if let Some((owner_class, private_name)) = private_rest.rsplit_once("::") {
             let caller_class = self
                 .method_class_stack
                 .last()

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -450,7 +450,10 @@ impl Interpreter {
                     self.validate_private_access_in_expr(caller_class, arg)?;
                 }
                 if *modifier == Some('!')
-                    && let Some((owner_class, _)) = name.resolve().split_once("::")
+                    // Split at the LAST `::`: the owner class of a qualified private
+                    // call may itself be a nested name (`$c!Cookie::Jar::Cookie::match`
+                    // is owner `Cookie::Jar::Cookie`, not `Cookie::Jar`).
+                    && let Some((owner_class, _)) = name.resolve().rsplit_once("::")
                     && owner_class != caller_class
                     && !self
                         .registry()

--- a/t/qualified-private-method-nested-owner.t
+++ b/t/qualified-private-method-nested-owner.t
@@ -1,0 +1,67 @@
+use v6;
+use Test;
+
+# A qualified private-method call `$obj!Owner::method` where the OWNER class is
+# itself a nested name (`Jar::Cookie`) must resolve the owner as everything up to
+# the LAST `::`, not the first. Regression pin for the Cookie::Jar dist, which
+# calls `$cookie!Cookie::Jar::Cookie::match` (owner `Cookie::Jar::Cookie`, method
+# `match`) across a `trusts` boundary — previously "Cannot call private method
+# without permission" / "No such private method 'Cookie::match'".
+
+# --- instance call across a trust boundary, nested owner name ---
+{
+    class Jar { ... }
+    my class Jar::Cookie {
+        trusts Jar;
+        has $.x;
+        method !secret { "s-" ~ $!x }
+    }
+    class Jar:ver<0.1> {
+        method peek($c) { $c!Jar::Cookie::secret }
+    }
+    is Jar.new.peek(Jar::Cookie.new(x => 7)), 's-7',
+        'instance !Nested::Owner::method resolves the full nested owner';
+}
+
+# --- the exact Cookie::Jar shape: caller class is itself nested + versioned ---
+{
+    class Cookie::Jar { ... }
+    my class Cookie::Jar::Cookie {
+        trusts Cookie::Jar;
+        has $.x;
+        method !match { "m-" ~ $!x }
+    }
+    class Cookie::Jar:ver<1.0> {
+        method peek($c) { $c!Cookie::Jar::Cookie::match }
+    }
+    is Cookie::Jar.new.peek(Cookie::Jar::Cookie.new(x => 3)), 'm-3',
+        'nested caller class calling a deeper nested owner private method';
+}
+
+# --- type-object qualified private call with a nested owner (Cookie::Jar `!new`) ---
+{
+    class Box { ... }
+    my class Box::Item {
+        trusts Box;
+        has $.v;
+        method !make($v) { self.bless(:$v) }
+    }
+    class Box:ver<2.0> {
+        method build { (Box::Item!Box::Item::make(9)).v }
+    }
+    is Box.new.build, 9,
+        'type-object !Nested::Owner::new resolves the full nested owner';
+}
+
+# --- a simple single-level owner still works (no regression) ---
+{
+    class Simple {
+        has $.n;
+        method !get { $!n }
+        method use2($o) { $o!Simple::get }
+    }
+    is Simple.new(n => 4).use2(Simple.new(n => 5)), 5,
+        'single-level !Owner::method still resolves';
+}
+
+done-testing;


### PR DESCRIPTION
`$obj!Owner::method` where the OWNER class is itself a nested name (`$cookie!Cookie::Jar::Cookie::match` — owner `Cookie::Jar::Cookie`, method `match`) was mis-parsed: four dispatch/validation sites split the qualified name at the FIRST `::` (`split_once`), reading owner `Cookie::Jar` and method `Cookie::match`, and rejecting the (trusted) call with `Cannot call private method without permission` / `No such private method 'Cookie::match'`.

## Fix
Split at the LAST `::` instead (`rsplit_once`) — a private method name never contains `::`, so the owner is everything before the final component. Fixed:
- `registration.rs` — the compile-time private-access validation (the site the dist actually hit)
- `methods_instance_ops.rs` — the two instance private-dispatch sites
- `methods_qualified.rs` — the non-instance site

## Impact
Unblocks the **load** of the Cookie::Jar dist, which calls `$cookie!Cookie::Jar::Cookie::match`/`::touch` and `Cookie::Jar::Cookie!Cookie::Jar::Cookie::new` across a `trusts` boundary. (Its tests still need the missing `IDNA::Punycode` dep, which raku also lacks, so they can't run — but the module now loads.)

Pin: `t/qualified-private-method-nested-owner.t`. A separate pre-existing gap remains: `self!Nested::Owner::method` (self-qualified) uses a different self-private path and is still rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)