### PR TITLE
fix: zip/roundrobin parse unparenthesized <...> args; roundrobin :slip

### DIFF
--- a/src/parser/primary/ident/predicates.rs
+++ b/src/parser/primary/ident/predicates.rs
@@ -248,6 +248,8 @@ pub(crate) fn is_expr_listop(name: &str) -> bool {
             | "shell"
             | "indir"
             | "cross"
+            | "zip"
+            | "roundrobin"
             | "await"
             | "sleep"
             | "sleep-timer"

--- a/src/runtime/builtins_collection_deepmap.rs
+++ b/src/runtime/builtins_collection_deepmap.rs
@@ -68,7 +68,20 @@ impl Interpreter {
         }
     }
 
-    pub(super) fn builtin_roundrobin(&self, args: &[Value]) -> Result<Value, RuntimeError> {
+    pub(super) fn builtin_roundrobin(&self, raw_args: &[Value]) -> Result<Value, RuntimeError> {
+        // Split off the `:slip` adverb (a `slip => Bool` named arg); the rest are
+        // the lists-of-lists streams. With `:slip`, the tuples are concatenated
+        // into one flat Seq instead of a Seq of tuples.
+        let mut slip = false;
+        let mut positional: Vec<Value> = Vec::with_capacity(raw_args.len());
+        for a in raw_args {
+            match a.view() {
+                ValueView::Pair(k, v) if k == "slip" => slip = v.truthy(),
+                ValueView::ValuePair(k, v) if k.to_string_value() == "slip" => slip = v.truthy(),
+                _ => positional.push(a.clone()),
+            }
+        }
+        let args = &positional[..];
         if args.is_empty() {
             return Ok(Value::seq(Vec::new()));
         }
@@ -126,6 +139,16 @@ impl Interpreter {
             rounds.push(Value::array(tuple));
         }
 
+        if slip {
+            let flat: Vec<Value> = rounds
+                .iter()
+                .flat_map(|r| match r.view() {
+                    ValueView::Array(items, _) => items.iter().cloned().collect::<Vec<_>>(),
+                    _ => vec![r.clone()],
+                })
+                .collect();
+            return Ok(Value::seq(flat));
+        }
         Ok(Value::seq(rounds))
     }
 

--- a/t/zip-roundrobin-listop-angle.t
+++ b/t/zip-roundrobin-listop-angle.t
@@ -1,0 +1,34 @@
+use Test;
+
+# `zip` and `roundrobin` are list-prefix routines, so an unparenthesized
+# `<...>` word list after them is a quote-word argument, not a `<` comparison.
+# `roundrobin`'s `:slip` adverb flattens the tuples into one Seq.
+
+plan 8;
+
+is (zip <a b c>, <d e f>, <g h i>).map(*.join(",")).join("|"), "a,d,g|b,e,h|c,f,i",
+    'zip with unparenthesized <...> word-list args';
+
+is (zip <1 2 3>, [1, 2, 3], (1, 2, 3), :with(&infix:<*>)).join("|"), "1|8|27",
+    'zip with :with and mixed unparenthesized args';
+
+is-deeply (roundrobin <a b c>, <d e f>, <g h i>).List,
+    (("a", "d", "g"), ("b", "e", "h"), ("c", "f", "i")),
+    'roundrobin with unparenthesized <...> word-list args';
+
+is-deeply (roundrobin <a b c>, <d e f m n o p>, <g h i j>).List,
+    (("a","d","g"), ("b","e","h"), ("c","f","i"), ("m","j"), ("n",), ("o",), ("p",)),
+    'roundrobin with ragged streams';
+
+is-deeply (roundrobin <a b c>, <d e f m n o p>, <g h i j>, :slip).List,
+    ("a","d","g","b","e","h","c","f","i","m","j","n","o","p"),
+    'roundrobin :slip flattens the tuples';
+
+# parenthesized forms still work
+is-deeply zip(<a b>, <c d>).List, (("a","c"), ("b","d")), 'zip(...) parenthesized still works';
+is-deeply roundrobin(<a b>, <c d>).List, (("a","c"), ("b","d")), 'roundrobin(...) parenthesized still works';
+
+# `zip` still usable inside `for`
+my @out;
+@out.push(.join(",")) for zip <a b c>, <d e f>;
+is @out.join("|"), "a,d|b,e|c,f", 'zip in a for loop';


### PR DESCRIPTION
`Type/List.rakudoc` doc-diff findings (5 parse crashes / one mismatch): the documented `zip <a b c>, <d e f>` and `roundrobin <a b c>, <d e f>, <g h i>` died with "Confused" because `zip`/`roundrobin` were not registered as list-prefix routines, so the `<...>` after the name parsed as a `<` comparison instead of a quote-word argument.

- Add `zip` and `roundrobin` to `is_expr_listop`, so an unparenthesized word list (and other comma-separated list args) after them parses as arguments. Both are documented `sub` routines (List.rakudoc). Fixes the `for zip …`, `say roundrobin …`, and `zip …, :with(&infix:<*>)` examples.
- Implement `roundrobin`'s `:slip` adverb: it was consumed as a positional `slip => True` stream (`(a d g slip => True) …`); it is now split off as a named arg and flattens the tuples into one Seq (`(a d g b e h c f i m j n o p)`).

Pin: `t/zip-roundrobin-listop-angle.t` (8 tests, green under raku too). Bug fix → default patch bump, no label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)