### PR TITLE
fix: can-ok / value_can_method resolves methods on a type object

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -210,8 +210,21 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 ### T-039 — test_fail: An object of type 'X' can do the method X  [impact: 1 dist]
 - dists: Chemistry::Elements
 - e.g. `Chemistry::Elements`: base=7 pass=2 fail=5 die=0 | t/005.languages.rakutest: An object of type 'Chemistry::Elements' can do the method 'lang_str_to_column'
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
+- repro: `class W { method m {} }; can-ok W, 'm'` — raku: passes; mutsu was:
+  fails (even though `W.^can('m')` returned True).
+- **PARTIAL (PR `fix-can-ok-type-object`).** The named `can-ok` symptom is fixed:
+  `value_can_method` (behind `can-ok` / `.can`) only resolved class methods for
+  `ValueView::Instance`, so a **type object** (`ValueView::Package`, e.g.
+  `Chemistry::Elements`) fell through to the universal-method whitelist and
+  reported it could not do its own class methods — despite `.^can` (a separate
+  metamodel path) returning True. Added a `Package` arm that walks the class
+  MRO via `class_has_method`. Pin: `t/can-ok-type-object.t`.
+- **REMAINING (separate, deeper — element-lookup bugs, not `can-ok`):** other
+  test files still fail with wrong data (`t/020.get_name_by_symbol` "Br is 35"
+  got 39; `t/010.get_name_by_Z`; `t/005.min-max-Z`) — a distinct root cause in
+  the element table lookup, unrelated to `.can`. The dist stays test_fail until
+  those are chased.
+- file: `src/runtime/accessors_stack.rs` (`value_can_method` type-object arm)
 
 ### T-040 — test_fail: Can't encode A  [impact: 1 dist]  — FIXED (PR `fix-bitwise-failure-operand`)
 - dists: Gray::Code::RBC

--- a/src/runtime/accessors_stack.rs
+++ b/src/runtime/accessors_stack.rs
@@ -125,6 +125,14 @@ impl Interpreter {
         {
             return true;
         }
+        // For type objects (`Chemistry::Elements.^can(...)` / `can-ok $type,
+        // ...`), resolve methods against the named class's MRO too — a type
+        // object can do any of its class's methods, not just the universal set.
+        if let ValueView::Package(class_name) = value.view()
+            && self.class_has_method(&class_name.resolve(), method)
+        {
+            return true;
+        }
         // Universal methods available on all values
         matches!(
             method,

--- a/t/can-ok-type-object.t
+++ b/t/can-ok-type-object.t
@@ -1,0 +1,26 @@
+use v6;
+use Test;
+
+# Regression: `can-ok $type-object, 'method'` (and the `value_can_method`
+# helper behind it) must resolve methods against a *type object*'s class MRO,
+# not only against instances. Surfaced by Chemistry::Elements (TODO_dist T-039):
+# `can-ok Chemistry::Elements, 'lang_str_to_column'` failed even though
+# `.^can('lang_str_to_column')` returned True and the method worked.
+
+plan 5;
+
+class Widget {
+    method frobnicate (Str:D $x --> Int:D) { 42 }
+    method !secret { 1 }
+}
+
+can-ok Widget, 'frobnicate', 'can-ok on a type object finds a public method';
+can-ok Widget.new, 'frobnicate', 'can-ok on an instance still works';
+
+# Consistency with the metamodel `.^can`.
+ok Widget.^can('frobnicate'), '.^can agrees (type object)';
+nok Widget.^can('nonexistent'), '.^can false for a missing method';
+
+# A missing method must still fail can-ok (guard against over-broad matching).
+my $missing = Widget.^can('nonexistent').Bool;
+is $missing, False, 'type object cannot do an undefined method';


### PR DESCRIPTION
## Problem

`value_can_method` (behind `can-ok` and the `.can` test helper) only resolved class methods for `ValueView::Instance`. A **type object** (`ValueView::Package`, e.g. `Chemistry::Elements` or any `MyClass` bareword) fell through to the universal-method whitelist, so `can-ok MyClass, 'a_real_method'` failed even though the metamodel path `MyClass.^can('a_real_method')` returned True.

```raku
class W { method m {} }
can-ok W, 'm';      # raku: ok ; mutsu was: not ok
say W.^can('m');    # (m)  — the metamodel path already worked
```

## Fix

Added a `Package` arm to `value_can_method` that walks the named class's MRO via `class_has_method`, matching `.^can`.

## Test

Pin: `t/can-ok-type-object.t` (5 subtests, verified against raku). `make test` clean (only `t/proc-async.t` flaked under parallel load, passes on retry, unrelated). clippy clean.

Surfaced by Chemistry::Elements (TODO_dist **T-039**). The dist has further, unrelated element-table-lookup failures tracked in the ticket; this PR fixes the named `can-ok` symptom, a general type-object bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)