### PR TITLE
fix: last/next inside a .reduce block are loop-control, not X::ControlFlow

### DIFF
--- a/src/runtime/builtins_reduce.rs
+++ b/src/runtime/builtins_reduce.rs
@@ -195,17 +195,37 @@ impl Interpreter {
             OpAssoc::Right => {
                 let mut acc = items.last().cloned().unwrap();
                 let mut right_edge = items.len().saturating_sub(1);
+                let mut out = Ok(());
                 while right_edge >= step {
                     let start = right_edge - step;
                     let mut call_args = items[start..right_edge].to_vec();
-                    call_args.push(acc);
-                    acc = self.call_sub_value(callable.clone(), call_args, true)?;
-                    if is_thunky {
-                        acc = Self::dethunk(self, acc)?;
-                    }
+                    call_args.push(acc.clone());
                     right_edge = start;
+                    // `last` inside the reduce block stops and keeps the current
+                    // accumulator; `next` skips this step, also keeping the accumulator.
+                    match self.call_sub_value(callable.clone(), call_args, true) {
+                        Ok(v) => {
+                            acc = if is_thunky {
+                                match Self::dethunk(self, v) {
+                                    Ok(d) => d,
+                                    Err(e) => {
+                                        out = Err(e);
+                                        break;
+                                    }
+                                }
+                            } else {
+                                v
+                            };
+                        }
+                        Err(e) if e.is_last() => break,
+                        Err(e) if e.is_next() => continue,
+                        Err(e) => {
+                            out = Err(e);
+                            break;
+                        }
+                    }
                 }
-                Ok(acc)
+                out.map(|()| acc)
             }
             OpAssoc::Chain => {
                 let mut result = true;
@@ -225,16 +245,36 @@ impl Interpreter {
             OpAssoc::Left => {
                 let mut acc = items[0].clone();
                 let mut idx = 1usize;
+                let mut out = Ok(());
                 while idx + step <= items.len() {
-                    let mut call_args = vec![acc];
+                    let mut call_args = vec![acc.clone()];
                     call_args.extend(items[idx..idx + step].iter().cloned());
-                    acc = self.call_sub_value(callable.clone(), call_args, true)?;
-                    if is_thunky {
-                        acc = Self::dethunk(self, acc)?;
-                    }
                     idx += step;
+                    // `last` inside the reduce block stops and keeps the current
+                    // accumulator; `next` skips this step, also keeping the accumulator.
+                    match self.call_sub_value(callable.clone(), call_args, true) {
+                        Ok(v) => {
+                            acc = if is_thunky {
+                                match Self::dethunk(self, v) {
+                                    Ok(d) => d,
+                                    Err(e) => {
+                                        out = Err(e);
+                                        break;
+                                    }
+                                }
+                            } else {
+                                v
+                            };
+                        }
+                        Err(e) if e.is_last() => break,
+                        Err(e) if e.is_next() => continue,
+                        Err(e) => {
+                            out = Err(e);
+                            break;
+                        }
+                    }
                 }
-                Ok(acc)
+                out.map(|()| acc)
             }
         };
 

--- a/t/reduce-last-next.t
+++ b/t/reduce-last-next.t
@@ -1,0 +1,21 @@
+use Test;
+
+# `last` / `next` inside a .reduce block are loop-control signals: `last` stops
+# the reduction and returns the current accumulator; `next` skips the current
+# step, keeping the accumulator. They must not escape as an X::ControlFlow error.
+
+plan 5;
+
+sub last-after-seven { last if $^a > 7; $^a + $^b }
+is (2, 3, 4, 5).reduce(&last-after-seven), 9,
+    'last in a reduce block returns the accumulator so far';
+
+is (2, 3, 4, 5).reduce(-> $a, $b { last if $a > 7; $a + $b }), 9,
+    'last in a pointy reduce block';
+
+is (2, 3, 4, 5).reduce(-> $a, $b { next if $b == 4; $a + $b }), 10,
+    'next in a reduce block skips the step, keeping the accumulator';
+
+# plain reductions still work (no control flow)
+is (1..5).reduce(&infix:<+>), 15, 'plain reduce still works';
+is (2, 3, 4, 5).reduce({ $^a + $^b }), 14, 'plain block reduce still works';


### PR DESCRIPTION
`Type/List.rakudoc` doc-diff finding: `(2, 3, 4, 5).reduce: &last-after-seven` (whose block does `last if $^a > 7; $^a + $^b`) died with `X::ControlFlow` instead of yielding `9`. The reduce loop propagated the `last`/`next` control signal as an error via `?`.

The left- and right-associative reduce loops now catch the control signal: `last` stops the reduction and returns the accumulator reached so far, and `next` skips the current step while keeping the accumulator (`reduce -> $a, $b { next if $b == 4; $a + $b }` over `2,3,4,5` is `10`). Both branches also restore the `hash_autovivify` flag on any error now (they no longer `?`-return past the restore).

`.produce` with `last` (finding [8]) has murkier semantics (raku drops more than the aborted step) and is deferred separately.

Pin: `t/reduce-last-next.t` (5 tests, green under raku too). Bug fix → default patch bump, no label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)