### PR TITLE
fix: a nested instance renders as Foo.new(...) for .raku, not Foo()

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1293,35 +1293,18 @@ the backlog.
       (`HashData`), `src/value/value_collections.rs`, `src/value/value_methods_a.rs`
       (`hash_insert_through`), `src/runtime/methods_quanthash_ctor.rs`, the `∈`/`(elem)` set-op path.
 
-### 8.11 A user instance *nested inside a container* renders as `Foo()` for `.raku` (found 2026-07-22 by the nodality sweep re-run)
+### 8.11 Two small `.raku` residues left by the nested-instance fix (found 2026-07-22)
 
-- [ ] **`[Foo.new].raku` is `[Foo()]`; raku gives `[Foo.new(x => 1)]`.** The instance's *own*
-      `.raku` is correct (`Foo.new(x => 1)`) — only the nested case is wrong, and it is wrong for
-      every container (`(…)`, `[…]`, `%…`, Seq, Pair value, …) and for built-in instance types too
-      (`(1.Supply, 2.Supply).raku` → mutsu `(Supply(), Supply())`, raku `(Supply.new, Supply.new)`).
-- **Root.** Container `.raku` recurses through the *pure* helper
-      `builtins::methods_0arg::raku_repr::raku_value`, which has no interpreter and therefore cannot
-      reach the class registry / `collect_public_raku_attrs`; its `_ =>` arm falls back to
-      `to_string_value()`, i.e. the gist-ish `Foo()`. The correct instance rendering lives in
-      `runtime::methods_instance_ops` (`format!("{}.new({})", …)`) and needs `&mut self`.
-      `builtin_dd` already works around exactly this by special-casing a top-level `Instance` and
-      dispatching the method (`src/runtime/builtins_eval_misc.rs:330`, comment: "would render `F()`").
-- **Fix shape — mirror `.gist`, which already solves exactly this.**
-      `src/runtime/methods_call_dispatch.rs` (~2202, `if method == "gist" && args.is_empty()`) has
-      an interpreter-side recursive renderer `gist_item(interp, value)`, gated by a
-      `collection_contains_instance(value)` predicate so any subtree with no dispatch-needing
-      element still takes the pure fast path (`runtime::gist_value`). It walks
-      Array/Seq/Slip/HyperSeq/RaceSeq/Hash/Pair/ValuePair preserving each container's bracket
-      style and dispatches `.gist` on the instance leaves — which is why `[Foo.new].gist` is
-      already correct while `.raku` is not. Do the same for `.raku` rather than the
-      thread-local-hook idea: same gating, same walk, `.raku` on the leaves. `builtin_dd`'s
-      hand-rolled top-level workaround should then collapse into it.
-- **Verify** all containers (`[Foo.new]`, `(Foo.new,)`, `%(a => Foo.new)`, `(a => Foo.new)`) and
-      the built-in instance types (`(1.Supply, 2.Supply).raku`). Medium blast radius (every
-      `.raku` of a container holding an instance changes output), so it wants its own PR with a
-      full `make roast`. Pin candidate: `t/nested-instance-raku.t`.
-- Entry: `git checkout -b fix-nested-instance-raku origin/main`. Queued for the next session
-      (agreed with the user 2026-07-22).
+Both are *bare* (not nested) reprs, so the §8.11 leaf-dispatch walk renders whatever these
+produce — fixing them fixes the nested case for free. Small, independent, unclaimed:
+
+- [ ] **`Promise.new.raku` is `Promise(Planned)`**; raku gives
+      `Promise.new(scheduler => ThreadPoolScheduler.new(uncaught_handler => Callable), status =>
+      PromiseStatus::Planned)`. The Promise repr never got a `.raku` form distinct from its gist.
+- [ ] **`$/.WHICH` names the wrong object.** `"abc" ~~ /b/; say $/.WHICH.raku` → mutsu
+      `ValueObjAt.new("Str|b")`, raku `ObjAt.new("Match|…")`: `.WHICH` on a Match takes the
+      *matched string*'s identity instead of the Match object's, so it is also a `ValueObjAt`
+      (value identity) where raku has an `ObjAt` (object identity).
 
 ---
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,46 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-22: a nested instance renders as `Foo.new(...)` for `.raku`, not `Foo()`
+
+`.raku` of a container holding a user instance (or a built-in object type) rendered the
+gist-ish fallback:
+
+```
+class Foo { has $.x }
+[Foo.new(x => 1)].raku       # was: [Foo()]          now: [Foo.new(x => 1)]
+(1.Supply, 2.Supply).raku    # was: (Supply(), ...)  now: (Supply.new, Supply.new)
+[Date.new(2020,1,1)].raku    # was: [2020-01-01]     now: [Date.new(2020,1,1)]
+```
+
+The instance's *own* `.raku` was already right — only the nested case was wrong, because
+container `.raku` recurses through the **pure** renderer
+`builtins::methods_0arg::raku_repr::raku_value`, which has no interpreter and so cannot reach
+the class registry; its `_ =>` arm fell back to `to_string_value()`.
+
+`.gist` solves the same problem with an interpreter-side recursive walk, but duplicating that
+walk for `.raku` would mean re-deriving every container rule the pure renderer owns (bracket
+style, `$`-itemization of hash values, single-element trailing commas, adverbial pair keys,
+cycle detection). So the fix keeps **one** renderer and rewrites only the *leaves*
+(`src/runtime/methods_raku_dispatch.rs`): each dispatch-needing element gets its `.raku`
+called through the interpreter, and the text is spliced back into a copy of the tree as a
+`raku_raw` marker pair that `raku_value` emits verbatim. Containers are rebuilt preserving
+kind/itemization/metadata; a subtree with no dispatch-needing element is shared as-is, and the
+native fast path is only bypassed when `container_needs_raku_dispatch` says so
+(`vm/vm_native_dispatch.rs`, mirroring the existing collection-gist bypass). Array, List, Seq,
+Slip, Hash, Pair, Capture, Set/Bag/Mix (via their typed-key store), itemized containers and
+typed `Array[Foo]` are all covered.
+
+Two adjacent gaps fell out of the same verification sweep:
+
+- `Version` had no `raku_value` arm, so a nested `v1.2` rendered as `1.2`.
+- A `$`-sigil attribute is a `Scalar` container, so an aggregate it holds is itemized:
+  `Foo.new(x => $[1, 2])`, not `Foo.new(x => [1, 2])`. The hash-value itemization rule is now
+  shared as `raku_repr::itemize_scalar_repr` and applied to `$` attributes.
+
+Pin: `t/nested-instance-raku.t` (22 assertions, all verified green under the reference `raku`
+as well). Closes PLAN.md §8.11.
+
 ## 2026-07-22: bound-element immutability — a literal-bound hash/array element is read-only
 
 A hash or array element bound to an immutable literal is now read-only, matching raku:

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -164,6 +164,45 @@ fn is_self_array_ref_marker(v: &Value) -> bool {
     matches!(v.view(), ValueView::Pair(name, _) if name == "__mutsu_self_array_ref")
 }
 
+/// Key of the pre-rendered-`.raku` marker pair.
+///
+/// A value whose correct `.raku` is only reachable through method dispatch (a
+/// user instance, a built-in object type such as `Supply`/`Date`/`IO::Path`)
+/// cannot be rendered by this pure module: it has no interpreter, so its `_ =>`
+/// arm falls back to `to_string_value()` (`Foo()`). The interpreter-side
+/// `.raku` entry point therefore dispatches those *leaves* itself and splices
+/// the resulting text back into the tree as this marker, then hands the tree to
+/// `raku_value` — so every container keeps its exact bracket / itemization /
+/// trailing-comma rules instead of a duplicated walk having to re-derive them.
+pub(crate) const RAKU_RAW_KEY: &str = "__mutsu_raku_raw";
+
+/// Wrap an already-rendered `.raku` fragment so `raku_value` emits it verbatim.
+pub(crate) fn raku_raw(rendered: String) -> Value {
+    Value::pair(RAKU_RAW_KEY.to_string(), Value::str(rendered))
+}
+
+fn raku_raw_repr(v: &Value) -> Option<String> {
+    match v.view() {
+        ValueView::Pair(name, inner) if name == RAKU_RAW_KEY => Some(inner.to_string_value()),
+        _ => None,
+    }
+}
+
+/// Whether this value's `.raku` needs interpreter method dispatch to be
+/// correct — i.e. `raku_value` would fall through to `to_string_value()`.
+///
+/// `Match`/`ObjAt`/`ValueObjAt` instances are excluded: this module renders
+/// them exactly (and better than dispatch would for a nested Match).
+pub(crate) fn needs_raku_dispatch(v: &Value) -> bool {
+    match v.view() {
+        ValueView::Instance { class_name, .. } => {
+            !(class_name == "Match" || class_name == "ObjAt" || class_name == "ValueObjAt")
+        }
+        ValueView::CustomType(_) | ValueView::CustomTypeInstance(_) => true,
+        _ => false,
+    }
+}
+
 /// Whether a string key may be rendered in the adverbial pair form
 /// `:key(value)`. Mirrors Raku's `<.ident>`: the key must start with a letter
 /// or `_`, continue with word chars, and may contain `-`/`'` only when each is
@@ -265,7 +304,15 @@ fn raku_array_wrap(inner: &str, kind: ArrayKind) -> String {
 /// are rendered as-is. Values whose own repr already carries the `$` sigil
 /// (e.g. an explicitly itemized `$[1, 2]`) are not double-itemized.
 fn raku_hash_value(v: &Value) -> String {
-    let base = raku_value(v);
+    itemize_scalar_repr(v, raku_value(v))
+}
+
+/// Apply the `Scalar`-container itemization rule to an already-rendered repr.
+///
+/// Every value held in a `$`-container — a hash value, a `$`-sigil attribute —
+/// renders itemized when it is an aggregate: `{:a($[1, 2])}`,
+/// `Foo.new(x => $[1, 2])`, `Foo.new(x => $(1, 2))`. Scalars are unchanged.
+pub(crate) fn itemize_scalar_repr(v: &Value, base: String) -> String {
     // Don't double-itemize a value whose repr already carries a sigil: an
     // explicitly itemized `$[...]`, or a cycle-reference placeholder for a
     // recursive structure (`%hash_<ptr>` / `@Array_<ptr>`).
@@ -416,6 +463,10 @@ pub fn raku_value(v: &Value) -> String {
     thread_local! {
         static SEEN_PTRS: std::cell::RefCell<Vec<(usize, String)>> = const { std::cell::RefCell::new(Vec::new()) };
         static ARRAY_CYCLE_FOUND: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    }
+    // A leaf the interpreter already rendered for us (see `RAKU_RAW_KEY`).
+    if let Some(rendered) = raku_raw_repr(v) {
+        return rendered;
     }
     match v.view() {
         // A `:=`-bound element holds a `ContainerRef` cell; render the held
@@ -602,17 +653,23 @@ pub fn raku_value(v: &Value) -> String {
                     };
                 }
             }
-            let key_repr = match key.view() {
-                // Non-string keys that would be ambiguous as barewords need parens.
-                // A Bool key is NOT wrapped: `Bool::True` already renders
-                // unambiguously (raku prints `Bool::True => "a"`, not `(...)`).
-                ValueView::Pair(_, _)
-                | ValueView::ValuePair(_, _)
-                | ValueView::Package(_)
-                | ValueView::Nil => {
-                    format!("({})", raku_value(key))
+            let key_repr = if raku_raw_repr(key).is_some() {
+                // A pre-rendered leaf (an instance key) is already a complete
+                // term: `Foo.new(x => 1) => 1`, no disambiguating parens.
+                raku_value(key)
+            } else {
+                match key.view() {
+                    // Non-string keys that would be ambiguous as barewords need parens.
+                    // A Bool key is NOT wrapped: `Bool::True` already renders
+                    // unambiguously (raku prints `Bool::True => "a"`, not `(...)`).
+                    ValueView::Pair(_, _)
+                    | ValueView::ValuePair(_, _)
+                    | ValueView::Package(_)
+                    | ValueView::Nil => {
+                        format!("({})", raku_value(key))
+                    }
+                    _ => raku_value(key),
                 }
-                _ => raku_value(key),
             };
             format!("{} => {}", key_repr, raku_value(value))
         }
@@ -750,6 +807,9 @@ pub fn raku_value(v: &Value) -> String {
             }
         }
         ValueView::Nil => "Nil".to_string(),
+        // A Version renders as its `v`-prefixed literal (`v1.2`, `v1.2+`) —
+        // `.Str` drops the `v`, `.raku` keeps it.
+        ValueView::Version { .. } => format!("v{}", v.to_string_value()),
         ValueView::Package(name) => name.resolve().to_string(),
         // A parameterized role type object renders as `Cup[EggNog]`.
         ValueView::ParametricRole {
@@ -824,6 +884,8 @@ pub fn raku_value(v: &Value) -> String {
                 // with quoted key syntax ("key" => value) to distinguish them
                 // from named arguments which use colonpair syntax (:key(value)).
                 match v.view() {
+                    // A pre-rendered leaf is not a Pair, it only wears one.
+                    _ if raku_raw_repr(v).is_some() => parts.push(raku_value(v)),
                     ValueView::Pair(k, val) => {
                         parts.push(format!(
                             "{} => {}",

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -158,6 +158,11 @@ impl Interpreter {
                 return Ok(Value::package(Symbol::intern("Scalar")));
             }
             if method == "raku" || method == "perl" {
+                // An itemized aggregate can still hold a value whose repr needs
+                // method dispatch (`$[Foo.new].raku`).
+                if let Some(rendered) = self.raku_repr_with_dispatch(&target) {
+                    return Ok(Value::str(rendered));
+                }
                 return Ok(Value::str(
                     crate::builtins::methods_0arg::raku_repr::raku_value(&target),
                 ));
@@ -2839,15 +2844,25 @@ impl Interpreter {
             && info.value_type != "Mu"
             && let ValueView::Array(items, _) = target.view()
         {
+            let items = items.to_vec();
             let inner = items
                 .iter()
-                .map(crate::builtins::methods_0arg::raku_repr::raku_value)
+                .map(|item| self.raku_element_repr(item))
                 .collect::<Vec<_>>()
                 .join(", ");
             let type_name = info
                 .declared_type
                 .unwrap_or_else(|| format!("Array[{}]", info.value_type));
             return Ok(Value::str(format!("{type_name}.new({inner})")));
+        }
+        // .raku/.perl on a container holding a value whose repr is only
+        // reachable through method dispatch (a user instance, a built-in object
+        // type). See `methods_raku_dispatch`.
+        if matches!(method, "raku" | "perl")
+            && args.is_empty()
+            && let Some(rendered) = self.raku_repr_with_dispatch(&target)
+        {
+            return Ok(Value::str(rendered));
         }
 
         // ACCEPTS for allomorphic types with Instance arguments

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -985,11 +985,27 @@ impl Interpreter {
                         "X::AdHoc.new(payload => {payload_raku})"
                     )));
                 }
-                // Collect public attributes for .raku representation
+                // Collect public attributes for .raku representation. Mark this
+                // instance as being rendered so a self-referencing attribute
+                // (`$obj.myself[0] = $obj`) stops at the pure `Bug()` fallback
+                // instead of recursing through the nested-leaf walker
+                // (`runtime::methods_raku_dispatch`).
                 let class_key = class_name.resolve();
                 let display_name = crate::value::user_facing_type_name(&class_key);
+                let instance_id = match target.view() {
+                    ValueView::Instance { id, .. } => Some(id),
+                    _ => None,
+                };
+                if let Some(id) = instance_id {
+                    self.raku_leaf_active.push(id);
+                }
                 let public_attrs =
                     self.collect_public_raku_attrs(&class_key, &(attributes).as_map());
+                if let Some(id) = instance_id
+                    && let Some(pos) = self.raku_leaf_active.iter().rposition(|x| *x == id)
+                {
+                    self.raku_leaf_active.remove(pos);
+                }
                 if public_attrs.is_empty() {
                     return Ok(Value::str(format!("{}.new", display_name)));
                 }
@@ -2289,7 +2305,7 @@ impl Interpreter {
     ) -> Vec<String> {
         let class_attrs = self.collect_class_attributes(class_name);
         let mut parts = Vec::new();
-        for (attr_name, is_public, _default, _is_rw, _is_required, _sigil, _where) in &class_attrs {
+        for (attr_name, is_public, _default, _is_rw, _is_required, sigil, _where) in &class_attrs {
             if !is_public {
                 continue;
             }
@@ -2298,6 +2314,14 @@ impl Interpreter {
                     .call_method_with_values(val.clone(), "raku", vec![])
                     .map(|v| v.to_string_value())
                     .unwrap_or_else(|_| val.to_string_value());
+                // A `$`-sigil attribute is a Scalar container, so an aggregate
+                // it holds renders itemized: `Foo.new(x => $[1, 2])`. `@`/`%`
+                // attributes are the aggregate itself and stay bare.
+                let rendered = if *sigil == '$' {
+                    crate::builtins::methods_0arg::raku_repr::itemize_scalar_repr(val, rendered)
+                } else {
+                    rendered
+                };
                 parts.push(format!("{} => {}", attr_name, rendered));
             }
         }

--- a/src/runtime/methods_raku_dispatch.rs
+++ b/src/runtime/methods_raku_dispatch.rs
@@ -1,0 +1,334 @@
+//! `.raku`/`.perl` on a container that holds a value whose repr is only
+//! reachable through method dispatch.
+//!
+//! The pure renderer `builtins::methods_0arg::raku_repr::raku_value` owns every
+//! container rule (bracket style, itemization, trailing commas, adverbial pair
+//! keys, cycle detection). It has no interpreter, though, so an `Instance` leaf
+//! falls through to `to_string_value()` — `[Foo.new(x => 1)].raku` rendered as
+//! `[Foo()]`, and a built-in object type likewise (`(1.Supply,).raku` →
+//! `(Supply(),)`).
+//!
+//! Rather than duplicate the container rules in an interpreter-side walk (the
+//! shape `.gist` uses), this module keeps the single renderer and only rewrites
+//! the *leaves*: each dispatch-needing element gets its `.raku` called through
+//! the interpreter, and the resulting text is spliced back into a copy of the
+//! tree as a `raku_raw` marker that `raku_value` emits verbatim.
+
+use super::Interpreter;
+use crate::builtins::methods_0arg::raku_repr::{needs_raku_dispatch, raku_raw};
+use crate::value::{ArrayData, HashData, Value, ValueView};
+
+/// Depth cap for the walk. Cycles are caught by container identity (below);
+/// this only keeps a pathologically deep structure from blowing the stack.
+const MAX_DEPTH: usize = 256;
+
+/// Container identity, for the visited set. Only the `Gc`-backed containers can
+/// participate in a cycle, so the others have no identity to track.
+fn container_id(value: &Value) -> Option<usize> {
+    match value.view() {
+        ValueView::Array(data, _) => Some(crate::gc::Gc::as_ptr(&data) as usize),
+        ValueView::Hash(data) => Some(crate::gc::Gc::as_ptr(&data) as usize),
+        _ => None,
+    }
+}
+
+fn typed_keys_contain(
+    original_keys: &Option<std::collections::HashMap<String, Value>>,
+    seen: &mut std::collections::HashSet<usize>,
+    depth: usize,
+) -> bool {
+    original_keys.as_ref().is_some_and(|keys| {
+        keys.values()
+            .any(|k| contains_dispatch_leaf_seen(k, seen, depth + 1))
+    })
+}
+
+/// Whether any leaf inside `value` needs method dispatch to render.
+fn contains_dispatch_leaf(value: &Value) -> bool {
+    let mut seen = std::collections::HashSet::new();
+    contains_dispatch_leaf_seen(value, &mut seen, 0)
+}
+
+/// `seen` holds every container already walked — not just the ancestors. A
+/// circular structure (`@a = 42, @a`) would otherwise be re-walked once per
+/// path reaching it, which is exponential for a graph with two cyclic edges
+/// (`%h = :b(%h), :c(@b); @b = %h, @b, 42` — `roast/S32-array/perl.t`).
+fn contains_dispatch_leaf_seen(
+    value: &Value,
+    seen: &mut std::collections::HashSet<usize>,
+    depth: usize,
+) -> bool {
+    if depth > MAX_DEPTH {
+        return false;
+    }
+    if needs_raku_dispatch(value) {
+        return true;
+    }
+    if let Some(id) = container_id(value)
+        && !seen.insert(id)
+    {
+        return false;
+    }
+    match value.view() {
+        ValueView::Scalar(inner) => contains_dispatch_leaf_seen(inner, seen, depth + 1),
+        ValueView::ContainerRef(cell) => {
+            let inner = cell.lock().unwrap().clone();
+            contains_dispatch_leaf_seen(&inner, seen, depth + 1)
+        }
+        ValueView::Hash(map) => {
+            let values: Vec<Value> = map.map.values().cloned().collect();
+            values
+                .iter()
+                .any(|v| contains_dispatch_leaf_seen(v, seen, depth + 1))
+        }
+        // A Set/Bag/Mix keeps its element *objects* in `original_keys`; those
+        // are what `.raku` renders (the string keys are the internal index).
+        ValueView::Set(data, _) => typed_keys_contain(&data.original_keys, seen, depth),
+        ValueView::Bag(data, _) => typed_keys_contain(&data.original_keys, seen, depth),
+        ValueView::Mix(data, _) => typed_keys_contain(&data.original_keys, seen, depth),
+        ValueView::Capture { positional, named } => {
+            positional
+                .iter()
+                .any(|v| contains_dispatch_leaf_seen(v, seen, depth + 1))
+                || named
+                    .values()
+                    .any(|v| contains_dispatch_leaf_seen(v, seen, depth + 1))
+        }
+        ValueView::Pair(_, v) => contains_dispatch_leaf_seen(v, seen, depth + 1),
+        ValueView::ValuePair(k, v) => {
+            contains_dispatch_leaf_seen(k, seen, depth + 1)
+                || contains_dispatch_leaf_seen(v, seen, depth + 1)
+        }
+        _ => match value.as_list_items() {
+            Some(items) => {
+                let items = items.to_vec();
+                items
+                    .iter()
+                    .any(|v| contains_dispatch_leaf_seen(v, seen, depth + 1))
+            }
+            None => false,
+        },
+    }
+}
+
+/// Whether `value` is a *container* holding a leaf whose `.raku` needs method
+/// dispatch — i.e. whether the pure native fast path must be bypassed so
+/// [`Interpreter::raku_repr_with_dispatch`] can render it. A bare leaf is
+/// excluded: it dispatches normally (routing it here would recurse).
+pub(crate) fn container_needs_raku_dispatch(value: &Value) -> bool {
+    matches!(
+        value.view(),
+        ValueView::Array(..)
+            | ValueView::Seq(..)
+            | ValueView::HyperSeq(..)
+            | ValueView::RaceSeq(..)
+            | ValueView::Slip(..)
+            | ValueView::Hash(..)
+            | ValueView::Pair(..)
+            | ValueView::ValuePair(..)
+            | ValueView::Scalar(..)
+            | ValueView::Set(..)
+            | ValueView::Bag(..)
+            | ValueView::Mix(..)
+            | ValueView::Capture { .. }
+    ) && contains_dispatch_leaf(value)
+}
+
+impl Interpreter {
+    /// Rebuild `value` with every dispatch-needing leaf replaced by its
+    /// interpreter-rendered `.raku` text. Containers are rebuilt in place with
+    /// their kind/metadata preserved so the pure renderer still sees the same
+    /// shape.
+    fn expand_raku_leaves(
+        &mut self,
+        value: &Value,
+        active: &mut Vec<usize>,
+        depth: usize,
+    ) -> Value {
+        // A subtree with nothing to dispatch is shared as-is.
+        if depth > MAX_DEPTH || !contains_dispatch_leaf(value) {
+            return value.clone();
+        }
+        // A container that is its own ancestor is left for `raku_value`'s cycle
+        // placeholder; rebuilding it would recurse forever.
+        if let Some(id) = container_id(value) {
+            if active.contains(&id) {
+                return value.clone();
+            }
+            active.push(id);
+            let rebuilt = self.expand_container(value, active, depth);
+            active.pop();
+            return rebuilt;
+        }
+        self.expand_container(value, active, depth)
+    }
+
+    fn expand_container(&mut self, value: &Value, active: &mut Vec<usize>, depth: usize) -> Value {
+        if needs_raku_dispatch(value) {
+            // A self-referencing object reaches itself through its own
+            // attributes; dispatching again would recurse forever, so a
+            // re-entered instance falls back to the pure repr.
+            let id = match value.view() {
+                ValueView::Instance { id, .. } => Some(id),
+                _ => None,
+            };
+            if let Some(id) = id {
+                if self.raku_leaf_active.contains(&id) {
+                    return value.clone();
+                }
+                self.raku_leaf_active.push(id);
+            }
+            let rendered = self.call_method_with_values(value.clone(), "raku", vec![]);
+            if let Some(id) = id
+                && let Some(pos) = self.raku_leaf_active.iter().rposition(|x| *x == id)
+            {
+                self.raku_leaf_active.remove(pos);
+            }
+            return match rendered {
+                Ok(rendered) => raku_raw(rendered.to_string_value()),
+                Err(_) => value.clone(),
+            };
+        }
+        match value.view() {
+            ValueView::Array(data, kind) => {
+                let mut rebuilt = ArrayData::clone(&data);
+                let items = std::mem::take(&mut rebuilt.items);
+                rebuilt.items = items
+                    .iter()
+                    .map(|item| self.expand_raku_leaves(item, active, depth + 1))
+                    .collect();
+                Value::array_with_kind(crate::gc::Gc::new(rebuilt), kind)
+            }
+            ValueView::Hash(map) => {
+                let entries: Vec<(String, Value)> = map
+                    .map
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+                let mut rebuilt = HashData::clone(&map);
+                for (k, v) in entries {
+                    let expanded = self.expand_raku_leaves(&v, active, depth + 1);
+                    rebuilt.map.insert(k, expanded);
+                }
+                let itemized = value.hash_is_itemized();
+                Value::hash(rebuilt).with_hash_itemized(itemized)
+            }
+            ValueView::Pair(key, v) => {
+                let key = key.clone();
+                let v = v.clone();
+                Value::pair(key, self.expand_raku_leaves(&v, active, depth + 1))
+            }
+            ValueView::ValuePair(k, v) => {
+                let (k, v) = (k.clone(), v.clone());
+                let k = self.expand_raku_leaves(&k, active, depth + 1);
+                let v = self.expand_raku_leaves(&v, active, depth + 1);
+                Value::value_pair(k, v)
+            }
+            ValueView::Scalar(inner) => {
+                let inner = inner.clone();
+                Value::scalar(self.expand_raku_leaves(&inner, active, depth + 1))
+            }
+            ValueView::ContainerRef(cell) => {
+                let inner = cell.lock().unwrap().clone();
+                self.expand_raku_leaves(&inner, active, depth + 1)
+            }
+            ValueView::Seq(_) | ValueView::HyperSeq(_) | ValueView::RaceSeq(_) => {
+                let items = self.expand_list_items(value, active, depth);
+                match value.view() {
+                    ValueView::HyperSeq(_) => Value::hyper_seq_arc(std::sync::Arc::new(items)),
+                    ValueView::RaceSeq(_) => Value::race_seq_arc(std::sync::Arc::new(items)),
+                    _ => Value::seq_arc(std::sync::Arc::new(items)),
+                }
+            }
+            ValueView::Capture { positional, named } => {
+                let (positional, named) = (positional.clone(), named.clone());
+                let positional: Vec<Value> = positional
+                    .iter()
+                    .map(|v| self.expand_raku_leaves(v, active, depth + 1))
+                    .collect();
+                let named = named
+                    .into_iter()
+                    .map(|(k, v)| {
+                        let expanded = self.expand_raku_leaves(&v, active, depth + 1);
+                        (k, expanded)
+                    })
+                    .collect();
+                Value::capture(positional, named)
+            }
+            ValueView::Set(data, is_mut) => {
+                let mut rebuilt = crate::value::SetData::clone(&data);
+                rebuilt.original_keys =
+                    self.expand_typed_keys(rebuilt.original_keys, active, depth);
+                Value::set_parts(crate::gc::Gc::new(rebuilt), is_mut)
+            }
+            ValueView::Bag(data, is_mut) => {
+                let mut rebuilt = crate::value::BagData::clone(&data);
+                rebuilt.original_keys =
+                    self.expand_typed_keys(rebuilt.original_keys, active, depth);
+                Value::bag_parts(crate::gc::Gc::new(rebuilt), is_mut)
+            }
+            ValueView::Mix(data, is_mut) => {
+                let mut rebuilt = crate::value::MixData::clone(&data);
+                rebuilt.original_keys =
+                    self.expand_typed_keys(rebuilt.original_keys, active, depth);
+                Value::mix_parts(crate::gc::Gc::new(rebuilt), is_mut)
+            }
+            ValueView::Slip(_) => {
+                let items = self.expand_list_items(value, active, depth);
+                Value::slip_arc(std::sync::Arc::new(items))
+            }
+            _ => value.clone(),
+        }
+    }
+
+    fn expand_typed_keys(
+        &mut self,
+        original_keys: Option<std::collections::HashMap<String, Value>>,
+        active: &mut Vec<usize>,
+        depth: usize,
+    ) -> Option<std::collections::HashMap<String, Value>> {
+        original_keys.map(|keys| {
+            keys.into_iter()
+                .map(|(k, v)| {
+                    let expanded = self.expand_raku_leaves(&v, active, depth + 1);
+                    (k, expanded)
+                })
+                .collect()
+        })
+    }
+
+    fn expand_list_items(
+        &mut self,
+        value: &Value,
+        active: &mut Vec<usize>,
+        depth: usize,
+    ) -> Vec<Value> {
+        let items: Vec<Value> = value
+            .as_list_items()
+            .map(|items| items.to_vec())
+            .unwrap_or_default();
+        items
+            .iter()
+            .map(|item| self.expand_raku_leaves(item, active, depth + 1))
+            .collect()
+    }
+
+    /// The `.raku`/`.perl` text of a container holding a dispatch-needing leaf,
+    /// or `None` when the pure renderer already handles the value on its own.
+    pub(crate) fn raku_repr_with_dispatch(&mut self, target: &Value) -> Option<String> {
+        if !container_needs_raku_dispatch(target) {
+            return None;
+        }
+        let expanded = self.expand_raku_leaves(target, &mut Vec::new(), 0);
+        Some(crate::builtins::methods_0arg::raku_repr::raku_value(
+            &expanded,
+        ))
+    }
+
+    /// Render one element for `.raku` with leaf dispatch applied (used by the
+    /// typed-container `.raku` paths, which build their own outer text).
+    pub(crate) fn raku_element_repr(&mut self, value: &Value) -> String {
+        let expanded = self.expand_raku_leaves(value, &mut Vec::new(), 0);
+        crate::builtins::methods_0arg::raku_repr::raku_value(&expanded)
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -254,6 +254,7 @@ mod methods_promise;
 mod methods_promise_class;
 mod methods_qualified;
 mod methods_quanthash_ctor;
+mod methods_raku_dispatch;
 mod methods_seq_dispatch;
 pub(crate) mod methods_signature;
 mod methods_signature_candidates;
@@ -369,6 +370,7 @@ pub(crate) use utils::*;
 
 // Re-export thread utility functions for VM access
 pub(crate) use methods_collection_ops::{current_mutsu_thread_id, is_initial_thread};
+pub(crate) use methods_raku_dispatch::container_needs_raku_dispatch;
 
 use self::unicode::{check_unicode_property, check_unicode_property_with_args};
 
@@ -1212,6 +1214,12 @@ pub struct Interpreter {
     /// the outer `rakuseen` for that id consumes the flag to add the `(my \NAME =
     /// ...)` binding wrapper.
     pub(crate) rakuseen_cycle_hit: std::collections::HashSet<String>,
+    /// Instance ids whose `.raku` is currently being rendered by the nested-leaf
+    /// walker (`methods_raku_dispatch`). A self-referencing object
+    /// (`$obj.myself[0] = $obj`) would otherwise recurse forever: instance →
+    /// attribute container → the same instance. A repeated id renders through
+    /// the pure fallback (`Bug()`) instead of dispatching again.
+    pub(crate) raku_leaf_active: Vec<u64>,
     /// Pending Proxy subclass attribute reference for writeback on mutating methods.
     /// Set when reading a Proxy subclass attribute; consumed by subsequent .push/.pop etc.
     pub(crate) pending_proxy_subclass_attr: Option<(crate::value::ProxySubclassAttrs, String)>,

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2123,6 +2123,7 @@ impl Interpreter {
             dispatch_ambiguous: false,
             rakuseen_active: Vec::new(),
             rakuseen_cycle_hit: std::collections::HashSet::new(),
+            raku_leaf_active: Vec::new(),
             pending_proxy_subclass_attr: None,
             multi_dispatch_stack: Vec::new(),
             method_dispatch_stack: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -313,6 +313,7 @@ impl Interpreter {
             dispatch_ambiguous: false,
             rakuseen_active: Vec::new(),
             rakuseen_cycle_hit: std::collections::HashSet::new(),
+            raku_leaf_active: Vec::new(),
             pending_proxy_subclass_attr: None,
             multi_dispatch_stack: Vec::new(),
             method_dispatch_stack: Vec::new(),

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -207,6 +207,16 @@ impl Interpreter {
         if method_sym == "gist" && args.is_empty() && collection_contains_instance(target) {
             return None;
         }
+        // Collection .raku/.perl bypass: an element whose `.raku` is only
+        // reachable through method dispatch (a user instance, a built-in object
+        // type) must be rendered by the interpreter — the pure renderer would
+        // fall back to `Foo()` (see `runtime::methods_raku_dispatch`).
+        if matches!(method_name.as_str(), "raku" | "perl")
+            && args.is_empty()
+            && crate::runtime::container_needs_raku_dispatch(target)
+        {
+            return None;
+        }
         // Pick/roll on Package/Str
         if (method_sym == "pick" || method_sym == "roll")
             && args.len() <= 1

--- a/t/nested-instance-raku.t
+++ b/t/nested-instance-raku.t
@@ -1,0 +1,61 @@
+use Test;
+
+plan 25;
+
+class Foo { has $.x }
+class Bar { method raku { "CUSTOM" } }
+
+my $f = Foo.new(x => 1);
+
+# The instance's own .raku was already right; the nested cases rendered `Foo()`
+# because the pure renderer cannot dispatch a method.
+is $f.raku, 'Foo.new(x => 1)', 'a bare instance';
+is [$f].raku, '[Foo.new(x => 1)]', 'an instance in an Array';
+is ($f,).raku, '(Foo.new(x => 1),)', 'an instance in a List';
+is %(a => $f).raku, '{:a(Foo.new(x => 1))}', 'an instance as a Hash value';
+is (a => $f).raku, ':a(Foo.new(x => 1))', 'an instance as a Pair value';
+is ($f => 1).raku, 'Foo.new(x => 1) => 1', 'an instance as a Pair key';
+is [[$f],].raku, '[[Foo.new(x => 1)],]', 'a nested Array';
+is $[$f].raku, '$[Foo.new(x => 1)]', 'an itemized Array';
+is [$f].Seq.raku, '(Foo.new(x => 1),).Seq', 'an instance in a Seq';
+is ($f,).Set.raku, 'Set.new(Foo.new(x => 1))', 'an instance in a Set';
+is ($f => 2,).Mix.raku, '(Foo.new(x => 1)=>2).Mix', 'an instance in a Mix';
+is \($f, x => $f).raku, '\(Foo.new(x => 1), :x(Foo.new(x => 1)))', 'an instance in a Capture';
+is {a => $f}.Map.raku, 'Map.new((:a(Foo.new(x => 1))))', 'an instance in a Map';
+
+my Foo @typed = $f, Foo.new(x => 2);
+is @typed.raku, 'Array[Foo].new(Foo.new(x => 1), Foo.new(x => 2))', 'a typed Array of instances';
+
+# A user `method raku` wins, nested as well as bare.
+is Bar.new.raku, 'CUSTOM', 'a user method raku';
+is [Bar.new].raku, '[CUSTOM]', 'a user method raku, nested';
+
+# Built-in object types have the same problem and the same fix.
+is (1.Supply, 2.Supply).raku, '(Supply.new, Supply.new)', 'Supply instances in a List';
+is [Date.new(2020, 1, 1)].raku, '[Date.new(2020,1,1)]', 'a Date in an Array';
+is [Version.new('1.2')].raku, '[v1.2]', 'a Version in an Array';
+
+# A collection with nothing to dispatch keeps the pure renderer's output.
+is (1, 2).raku, '(1, 2)', 'a plain List is untouched';
+is (Foo,).raku, '(Foo,)', 'a type object is not an instance';
+
+# A `$`-sigil attribute is a Scalar container, so its aggregate is itemized.
+is Foo.new(x => [1, 2]).raku, 'Foo.new(x => $[1, 2])', 'an aggregate in a $-attribute';
+
+# Cyclic structures must terminate: an object reached through its own attribute
+# is not dispatched again, and a container that is its own ancestor is left to
+# the renderer's cycle placeholder.
+class Cyc { has @.myself }
+my $c = Cyc.new;
+$c.myself[0] = $c;
+ok $c.raku.chars, 'a self-referencing object survives .raku';
+
+my @circ;
+@circ = 42, @circ;
+ok @circ.raku.chars, 'a circular array survives .raku';
+
+my %ch;
+my @cb;
+%ch = :b(%ch), :c(@cb);
+@cb = %ch, @cb, 42;
+ok @cb.raku.chars, 'a circular array within a circular hash survives .raku';


### PR DESCRIPTION
Closes PLAN.md §8.11.

## Problem

`.raku` of a container holding a user instance (or a built-in object type) rendered the gist-ish fallback:

```
class Foo { has $.x }
[Foo.new(x => 1)].raku       # was: [Foo()]           now: [Foo.new(x => 1)]
(1.Supply, 2.Supply).raku    # was: (Supply(), ...)   now: (Supply.new, Supply.new)
[Date.new(2020,1,1)].raku    # was: [2020-01-01]      now: [Date.new(2020,1,1)]
```

The instance's *own* `.raku` was already right — only the nested case was wrong, because container `.raku` recurses through the **pure** renderer `builtins::methods_0arg::raku_repr::raku_value`, which has no interpreter and so cannot reach the class registry; its `_ =>` arm fell back to `to_string_value()`.

## Approach

`.gist` solves the same problem with an interpreter-side recursive walk, but duplicating that walk for `.raku` would mean re-deriving every container rule the pure renderer owns (bracket style, `$`-itemization of hash values, single-element trailing commas, adverbial pair keys, cycle detection).

So this keeps **one** renderer and rewrites only the *leaves* (`src/runtime/methods_raku_dispatch.rs`): each dispatch-needing element gets its `.raku` called through the interpreter, and the text is spliced back into a copy of the tree as a `raku_raw` marker pair that `raku_value` emits verbatim. Containers are rebuilt preserving kind / itemization / metadata; a subtree with no dispatch-needing element is shared as-is, and the native fast path is only bypassed when `container_needs_raku_dispatch` says so (`vm/vm_native_dispatch.rs`, mirroring the existing collection-gist bypass).

Covered: Array, List, Seq, Slip, HyperSeq/RaceSeq, Hash, Pair/ValuePair (key *and* value), Capture, Set/Bag/Mix (via their typed-key store), itemized containers (`$[Foo.new]`), and typed `Array[Foo]`.

Cycles are handled on both axes:

- an instance reached through its own attribute is not dispatched again (`raku_leaf_active`), so a self-referencing object terminates with the same output as before this PR;
- the containment walk keeps a visited set of container identities, so a doubly-circular structure (`%h = :b(%h), :c(@b); @b = %h, @b, 42` — `roast/S32-array/perl.t`) stays linear instead of exponential.

## Two adjacent gaps fixed by the same sweep

- `Version` had no `raku_value` arm, so a nested `v1.2` rendered as `1.2`.
- A `$`-sigil attribute is a `Scalar` container, so an aggregate it holds is itemized: `Foo.new(x => $[1, 2])`, not `Foo.new(x => [1, 2])`. The hash-value itemization rule is now shared as `raku_repr::itemize_scalar_repr` and applied to `$` attributes.

## Verification

- Pin: `t/nested-instance-raku.t` — 25 assertions, all green under the reference `raku` as well.
- `make test` PASS (2261 files / 21344 tests).
- All 358 whitelisted roast files that mention `.raku`/`.perl`: PASS (this caught both cycle bugs above before pushing).

## Follow-ups recorded (new PLAN.md §8.11)

- `Promise.new.raku` is `Promise(Planned)`; raku gives the full `Promise.new(scheduler => ..., status => PromiseStatus::Planned)`.
- `$/.WHICH` takes the matched *string*'s identity, so it is a `ValueObjAt` where raku has `ObjAt.new("Match|…")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)