### PR TITLE
fix: a zen slice :k/:kv/:p adverb maps to keys/kv/pairs

### DIFF
--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -1517,16 +1517,33 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                     is_positional: false,
                 }
             };
-            if is_zen_angle && r.starts_with(":v") && !is_ident_char(r.as_bytes().get(2).copied()) {
-                let r = &r[2..];
+            // Zen-slice `:k`/`:v`/`:kv`/`:p` adverbs map to the keys/values/kv/pairs
+            // method (`%h<>:k` is `%h.keys`, `%h<>:v` is `%h.values`). Probe the
+            // two-letter `:kv` before the one-letter `:k`/`:v` so `:kv` is not read
+            // as `:k` + a stray `v`.
+            let zen_adverb = is_zen_angle
+                .then(|| {
+                    [
+                        (":kv", "kv"),
+                        (":k", "keys"),
+                        (":v", "values"),
+                        (":p", "pairs"),
+                    ]
+                    .into_iter()
+                    .find(|(adv, _)| {
+                        r.starts_with(adv) && !is_ident_char(r.as_bytes().get(adv.len()).copied())
+                    })
+                })
+                .flatten();
+            if let Some((adv, method)) = zen_adverb {
                 expr = Expr::MethodCall {
                     target: Box::new(indexed_expr),
-                    name: Symbol::intern("values"),
+                    name: Symbol::intern(method),
                     args: Vec::new(),
                     modifier: None,
                     quoted: false,
                 };
-                rest = r;
+                rest = &r[adv.len()..];
                 continue;
             }
             // Check for :exists / :!exists / :delete adverbs

--- a/t/zen-slice-kv-adverbs.t
+++ b/t/zen-slice-kv-adverbs.t
@@ -1,0 +1,25 @@
+use Test;
+
+# A zen slice with a `:k`/`:v`/`:kv`/`:p` adverb maps to the keys/values/kv/pairs
+# method: `%h<>:k` is `%h.keys`. Previously only `:v` was handled; `:k` (and
+# `:kv`/`:p`) left the adverb stranded as a separate `:k` term.
+
+plan 9;
+
+my %h1 = a => 1;
+is-deeply %h1<>:k.List, ("a",), '%h<>:k on a one-key hash';
+is-deeply %h1<>:v.List, (1,),   '%h<>:v on a one-key hash';
+
+my %h2 = a => 1, b => 2;
+is-deeply %h2<>:k.sort.List, ("a", "b"), '%h<>:k on a two-key hash';
+is-deeply %h2<>:v.sort.List, (1, 2),     '%h<>:v on a two-key hash';
+is-deeply %h2<>:kv.sort.List, (1, 2, "a", "b"), '%h<>:kv yields keys and values';
+is-deeply %h2<>:p.sort.List, (:a(1), :b(2)), '%h<>:p yields pairs';
+
+# the bare zen slice still returns the hash
+is-deeply %h1<>, %h1, '%h<> (no adverb) returns the hash';
+
+# array zen slice adverbs
+my @a = 1, 2, 3;
+is-deeply @a[]:k.List, (0, 1, 2), '@a[]:k yields the indices';
+is-deeply @a[]:v.List, (1, 2, 3), '@a[]:v yields the values';


### PR DESCRIPTION
`Type/Hash.rakudoc` doc-diff finding: `say %h<>:k` died with "No such method 'say' for invocant of type 'Hash'". Only the `<>:v` (→ `.values`) zen-slice adverb was handled; `:k`, `:kv`, and `:p` fell through, leaving the adverb stranded as a separate `:k` term so `say` reattached as a method call on the hash.

Generalize the zen-slice adverb handling to map `:k`→`keys`, `:v`→`values`, `:kv`→`kv`, `:p`→`pairs` (probing the two-letter `:kv` before the one-letter `:k`). Works for both hash (`%h<>:k`) and array (`@a[]:k`) zen slices.

Pin: `t/zen-slice-kv-adverbs.t` (9 tests, green under raku too). Bug fix → default patch bump, no label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)