### PR TITLE
fix: re-importing a bare-file module with a new tag restores its tag-only exports

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -261,11 +261,30 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   `t/module-exported-infix-no-constant-fold.t` (+ `t/lib/RatPowerFixture.rakumod`).
 - file: `src/compiler/stmt.rs` (generic `Stmt::Use` arm), `src/compiler/const_fold.rs` (mechanism)
 
-### T-042 — test_fail: We defined G, FWIW  [impact: 1 dist]
+### T-042 — test_fail: We defined G, FWIW  [impact: 1 dist]  — FIXED (PR `fix-reimport-tagged-export`)
 - dists: Math::Arrow
 - e.g. `Math::Arrow`: base=1 pass=0 fail=1 die=0 | t/arrow.rakutest: We defined G, FWIW
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
+- repro: `use Math::Arrow; use Math::Arrow :constants; say &term:<G>.defined`
+  — raku: True; mutsu was: False.
+- **Root cause: re-importing a bare-file module with a new tag lost its
+  tag-only exports.** Math::Arrow does `use Math::Arrow;` (plain) then, later,
+  `use Math::Arrow :constants;`. It is a bare-file module (no `unit module`), so
+  its exports register only under `GLOBAL::`. The plain `use` HID the tag-only
+  `sub term:<G> is export(:constants)` by **deleting** `GLOBAL::term:<G>` — so
+  the second `use ... :constants` (which routes through the already-loaded
+  `import_module` path) had nothing to restore. (`import_module` also only
+  consulted `exported_subs[module]`, which is empty for a bare-file module.)
+- **Fix (two parts):** (1) the tag-filter that hides non-requested exports now
+  RENAMES `GLOBAL::name` -> `MOD::name` instead of deleting it, preserving the
+  definition (`runtime/runtime_module.rs`); (2) `import_module` now also consults
+  `module_owned_exports[module]` (populated for bare-file modules) so a later
+  tagged `use` finds and re-aliases them (`runtime/runtime_module_exports.rs`).
+  Math::Arrow passes 6/6. Pin: `t/reimport-tagged-export-after-plain-use.t`
+  (+ `t/lib/TaggedExportFixture.rakumod`).
+- NOTE: using an imported `term:<G>` as a bare term (`say G`) still needs
+  parse-time custom-term registration (a separate slang concern); the dist only
+  checks `&term:<G>.defined`, which now works.
+- file: `src/runtime/runtime_module.rs`, `src/runtime/runtime_module_exports.rs`
 
 ### T-043 — test_fail: bad pod string  [impact: 1 dist]
 - dists: RakupodObject

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -365,12 +365,27 @@ impl Interpreter {
             for (name, symbol_tags) in &owned_exports {
                 let is_mandatory = symbol_tags.contains("MANDATORY");
                 if !want_all && !is_mandatory && symbol_tags.is_disjoint(&requested_tags) {
-                    // This export should NOT be imported — remove from GLOBAL
+                    // This export should NOT be imported under the current tags —
+                    // hide it from GLOBAL. Rather than DELETE it (which would lose
+                    // the definition and make a later `use MOD :tag` unable to
+                    // restore it — a bare-file module registers exports only under
+                    // GLOBAL::), RENAME it to a module-qualified `MOD::name` key.
+                    // That keeps it out of the unqualified namespace while leaving
+                    // `import_module` able to re-alias it on a subsequent tagged
+                    // `use` (its source lookup is `MOD::name`). See T-042
+                    // (Math::Arrow `use ... :constants` after a plain `use`).
                     let global_key = Symbol::intern(&format!("GLOBAL::{}", name));
                     if !func_keys_before.contains(&global_key) {
-                        self.registry_mut().functions.remove(&global_key);
+                        let removed = self.registry_mut().functions.remove(&global_key);
+                        if let Some(def) = removed {
+                            let qualified = Symbol::intern(&format!("{}::{}", module, name));
+                            self.registry_mut()
+                                .functions
+                                .entry(qualified)
+                                .or_insert(def);
+                        }
                     }
-                    // Also remove multi-dispatch variants
+                    // Also rename multi-dispatch variants (`GLOBAL::name/sig`).
                     let prefix = format!("GLOBAL::{}/", name);
                     let multi_keys: Vec<Symbol> = self
                         .registry()
@@ -383,7 +398,15 @@ impl Interpreter {
                         .copied()
                         .collect();
                     for mk in multi_keys {
-                        self.registry_mut().functions.remove(&mk);
+                        let removed = self.registry_mut().functions.remove(&mk);
+                        if let Some(def) = removed {
+                            let suffix = mk.resolve().strip_prefix("GLOBAL::").unwrap().to_string();
+                            let qualified = Symbol::intern(&format!("{}::{}", module, suffix));
+                            self.registry_mut()
+                                .functions
+                                .entry(qualified)
+                                .or_insert(def);
+                        }
                     }
                 }
             }

--- a/src/runtime/runtime_module_exports.rs
+++ b/src/runtime/runtime_module_exports.rs
@@ -179,7 +179,21 @@ impl Interpreter {
             .get(module)
             .cloned()
             .unwrap_or_default();
-        if subs.is_empty() && vars.is_empty() && unit_global_subs.is_empty() {
+        // A bare-file module (no `unit module`/package block) registers its
+        // exports only under GLOBAL, so `exported_subs[module]` is empty; its
+        // owned exports (name -> tags) live in `module_owned_exports`. Consult
+        // that too, so a later `use MOD :tag` (after a plain `use MOD` hid the
+        // tagged exports by renaming them to `MOD::name`) can re-import them.
+        let owned_subs: HashMap<String, HashSet<String>> = self
+            .module_owned_exports
+            .get(module)
+            .cloned()
+            .unwrap_or_default();
+        if subs.is_empty()
+            && vars.is_empty()
+            && unit_global_subs.is_empty()
+            && owned_subs.is_empty()
+        {
             return Err(RuntimeError::new(format!(
                 "No exports found for module: {}",
                 module
@@ -204,6 +218,11 @@ impl Interpreter {
                 }
             }
             for symbol_tags in unit_global_subs.values() {
+                for tag in symbol_tags {
+                    known_tags.insert(tag.clone());
+                }
+            }
+            for symbol_tags in owned_subs.values() {
                 for tag in symbol_tags {
                     known_tags.insert(tag.clone());
                 }
@@ -246,6 +265,16 @@ impl Interpreter {
         // actually re-installed, not just tag-validated.
         let mut merged_subs = subs;
         for (name, tags) in unit_global_subs.iter() {
+            merged_subs
+                .entry(name.clone())
+                .or_default()
+                .extend(tags.iter().cloned());
+        }
+        // Bare-file module exports (see `owned_subs` above). Their source
+        // functions live under `MOD::name` (a plain `use` renamed the hidden
+        // tagged ones there; DEFAULT ones stay `GLOBAL::name` and are already
+        // imported, so the re-alias below is a harmless no-op for them).
+        for (name, tags) in owned_subs.iter() {
             merged_subs
                 .entry(name.clone())
                 .or_default()

--- a/t/lib/TaggedExportFixture.rakumod
+++ b/t/lib/TaggedExportFixture.rakumod
@@ -1,0 +1,6 @@
+# A bare-file module (no `unit module`/package block): its exports register
+# only under GLOBAL. Used to test that a `use Mod :tag` AFTER a plain `use Mod`
+# can still import the tag-only exports (which the plain `use` hid).
+sub always-here is export { "always" }
+sub only-extra is export(:extra) { "extra" }
+sub term:<TAGTERM> is export(:extra) { 99 }

--- a/t/reimport-tagged-export-after-plain-use.t
+++ b/t/reimport-tagged-export-after-plain-use.t
@@ -1,0 +1,23 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+# Regression (TODO_dist T-042, Math::Arrow): a `use Mod :tag` that follows a
+# plain `use Mod` must still import the tag-only exports. A bare-file module
+# registers its exports only under GLOBAL; the plain `use` hid the tag-only
+# ones, and a later tagged `use` could not restore them (they were deleted
+# rather than kept module-qualified). Math::Arrow does exactly this:
+#   use Math::Arrow;            # plain
+#   use Math::Arrow :constants; # then tag-only -> `&term:<G>` must be defined
+
+use TaggedExportFixture;            # plain use: DEFAULT exports only
+
+plan 4;
+
+ok &always-here.defined, 'DEFAULT export imported by the plain use';
+
+use TaggedExportFixture :extra;     # tagged use of the already-loaded module
+
+ok &only-extra.defined, ':extra sub imported by the later tagged use';
+is only-extra(), 'extra', 'the re-imported :extra sub is callable';
+ok &term:<TAGTERM>.defined, ':extra term:<> sub imported by the later tagged use';


### PR DESCRIPTION
## Problem

`use Mod :tag` that follows a plain `use Mod` must import the tag-only exports. A **bare-file module** (no `unit module`/package block) registers its exports only under GLOBAL, and the plain `use` HID the tag-only ones by *deleting* their `GLOBAL::name` function entries — so a later `use Mod :tag` (which routes through the already-loaded `import_module` path) had nothing to restore. `import_module` also only consulted `exported_subs[module]`, which is empty for a bare-file module (its owned exports live in `module_owned_exports`).

```raku
use Math::Arrow;             # plain
use Math::Arrow :constants;  # tag-only, after load
say &term:<G>.defined;       # raku: True ; mutsu was: False
```

This broke **Math::Arrow** (TODO_dist T-042).

## Fix (two parts)

1. The tag-filter that hides non-requested exports now **renames** `GLOBAL::name` → `MOD::name` (and its multi variants) instead of deleting it, preserving the definition so it can be re-aliased later.
2. `import_module` now also merges `module_owned_exports[module]` (populated for bare-file modules) into the exports it re-installs, so a later tagged `use` finds and re-aliases them under `GLOBAL::name`.

## Test

Math::Arrow passes 6/6. Pin: `t/reimport-tagged-export-after-plain-use.t` (+ `t/lib/TaggedExportFixture.rakumod`), verified against raku. `make test` clean (only `t/proc-async.t` flaked under parallel load, passes on retry, unrelated); roast `S11-modules/{import,export,lexical}.t` still pass. clippy clean.

Fixes TODO_dist **T-042** (Math::Arrow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)