### PR TITLE
fix: Iterator.skip-one/skip-at-least return Int; add Match.target

### DIFF
--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1771,7 +1771,9 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                     .is_some_and(|v| v.truthy());
                 return Some(Ok(Value::truth(ok)));
             }
-            "orig" => {
+            "orig" | "target" => {
+                // `.target` is the original string the match ran against; for an
+                // ordinary Match it is identical to `.orig`.
                 return Some(Ok(attributes
                     .as_map()
                     .get("orig")

--- a/src/runtime/did_you_mean.rs
+++ b/src/runtime/did_you_mean.rs
@@ -339,6 +339,7 @@ pub(crate) fn known_methods_for_type(type_name: &str) -> &'static [&'static str]
             "prematch",
             "raku",
             "Str",
+            "target",
             "to",
             "values",
             "WHAT",

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -2157,9 +2157,10 @@ impl Interpreter {
                         }
                         "skip-one" => {
                             let next = pull_one_squish(self)?;
-                            Value::truth(
+                            // Iterator.skip-one returns 1 (Int) on a skip, 0 at end.
+                            Value::int(i64::from(
                                 !matches!(next.view(), ValueView::Str(s) if s.as_str() == "IterationEnd"),
-                            )
+                            ))
                         }
                         "skip-at-least" => {
                             let want = args.first().map(super::to_int).unwrap_or(0).max(0) as usize;
@@ -2172,7 +2173,7 @@ impl Interpreter {
                                     break;
                                 }
                             }
-                            Value::truth(ok)
+                            Value::int(i64::from(ok))
                         }
                         "skip-at-least-pull-one" => {
                             let want = args.first().map(super::to_int).unwrap_or(0).max(0) as usize;
@@ -2351,9 +2352,9 @@ impl Interpreter {
                     "skip-one" => {
                         if index < len {
                             index += 1;
-                            Value::TRUE
+                            Value::int(1)
                         } else {
-                            Value::FALSE
+                            Value::int(0)
                         }
                     }
                     "skip-at-least" => {
@@ -2361,10 +2362,10 @@ impl Interpreter {
                         let available = len.saturating_sub(index);
                         if available >= want {
                             index += want;
-                            Value::TRUE
+                            Value::int(1)
                         } else {
                             index = len;
-                            Value::FALSE
+                            Value::int(0)
                         }
                     }
                     "skip-at-least-pull-one" => {

--- a/src/vm/vm_call_method_compiled_coerce.rs
+++ b/src/vm/vm_call_method_compiled_coerce.rs
@@ -273,19 +273,19 @@ impl Interpreter {
             "skip-one" => {
                 if index < len {
                     index += 1;
-                    Value::TRUE
+                    Value::int(1)
                 } else {
-                    Value::FALSE
+                    Value::int(0)
                 }
             }
             "skip-at-least" => {
                 let want = args.first().map(crate::runtime::to_int).unwrap_or(0).max(0) as usize;
                 if len.saturating_sub(index) >= want {
                     index += want;
-                    Value::TRUE
+                    Value::int(1)
                 } else {
                     index = len;
-                    Value::FALSE
+                    Value::int(0)
                 }
             }
             "skip-at-least-pull-one" => {

--- a/t/iterator-skip-target.t
+++ b/t/iterator-skip-target.t
@@ -1,0 +1,31 @@
+use Test;
+
+# Iterator.skip-one / skip-at-least return an Int count (1 on success, 0 at end),
+# not a Bool. Match.target returns the original string the match ran against.
+
+plan 9;
+
+# skip-one returns Int 1/0 (raku-oracle verified)
+{
+    my $i = <a b>.iterator;
+    my $r = $i.skip-one;
+    is $r, 1, 'skip-one returns 1 on a successful skip';
+    is $r.^name, 'Int', 'skip-one result is an Int';
+    is $i.pull-one, 'b', 'pull-one after skip-one yields the next element';
+    is $i.skip-one, 0, 'skip-one at the end returns 0';
+}
+
+# skip-at-least returns Int 1/0
+{
+    my $i = <a b c>.iterator;
+    is $i.skip-at-least(2), 1, 'skip-at-least(2) returns 1 when enough remain';
+    is $i.pull-one, 'c', 'pull-one after skip-at-least yields the next element';
+    is $i.skip-at-least(20), 0, 'skip-at-least past the end returns 0';
+}
+
+# Match.target is the original matched-against string (alias of .orig)
+{
+    my $m = "abc" ~~ /b/;
+    is $m.target, 'abc', 'Match.target returns the original string';
+    is $m.target, $m.orig, 'Match.target equals Match.orig';
+}


### PR DESCRIPTION
Two doc-diff findings from the QA harness (Type/Iterator.rakudoc, Type/Match.rakudoc).

## Iterator.skip-one / skip-at-least return an Int
raku's `Iterator.skip-one` / `.skip-at-least` return an **Int** — `1` on a
successful skip, `0` at the end — not a `Bool`. mutsu returned `True`/`False`.

```
my $i = <a b>.iterator;
say $i.skip-one;   # was True, now 1
say $i.pull-one;   # b
say $i.skip-one;   # was False, now 0
```

Fixed in all three dispatch sites (array-backed + squish paths in
`methods_mut_dispatch.rs`, and the compiled-coerce fast path in
`vm_call_method_compiled_coerce.rs`). Truthiness is unchanged (`int(0)` is
falsy, `int(1)` truthy), so the internal `tail_rotate` consumer that checks
`.truthy()` is unaffected.

## Match.target
`.target` (the original string a match ran against, an alias of `.orig`) threw
`No such method 'target' for invocant of type 'Match'`. Now answered by the
`orig` arm; added to the did-you-mean suggestion list.

Pin `t/iterator-skip-target.t` (raku-oracle verified). Roast
`S32-list/tail.t`, `S07-iterators/range-iterator.t`,
`S07-iterationbuffer/iterationbuffer.t` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)