### PR TITLE
fix: Promise renders its Rakudo .raku repr; instance .WHICH names its class

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1293,19 +1293,6 @@ the backlog.
       (`HashData`), `src/value/value_collections.rs`, `src/value/value_methods_a.rs`
       (`hash_insert_through`), `src/runtime/methods_quanthash_ctor.rs`, the `∈`/`(elem)` set-op path.
 
-### 8.11 Two small `.raku` residues left by the nested-instance fix (found 2026-07-22)
-
-Both are *bare* (not nested) reprs, so the §8.11 leaf-dispatch walk renders whatever these
-produce — fixing them fixes the nested case for free. Small, independent, unclaimed:
-
-- [ ] **`Promise.new.raku` is `Promise(Planned)`**; raku gives
-      `Promise.new(scheduler => ThreadPoolScheduler.new(uncaught_handler => Callable), status =>
-      PromiseStatus::Planned)`. The Promise repr never got a `.raku` form distinct from its gist.
-- [ ] **`$/.WHICH` names the wrong object.** `"abc" ~~ /b/; say $/.WHICH.raku` → mutsu
-      `ValueObjAt.new("Str|b")`, raku `ObjAt.new("Match|…")`: `.WHICH` on a Match takes the
-      *matched string*'s identity instead of the Match object's, so it is also a `ValueObjAt`
-      (value identity) where raku has an `ObjAt` (object identity).
-
 ### 8.12 `.produce` with `last`, and `.reduce` with a destructuring signature (deferred — found 2026-07-22 by the List.rakudoc doc-diff sweep)
 
 Two leftover `Type/List.rakudoc` reduce/produce findings after the batch of fixes on 2026-07-22

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,29 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-22: Promise gets its Rakudo repr; `Match.WHICH` (and every instance `.WHICH`) names its class
+
+The two `.raku` residues the nested-instance sweep left behind (PLAN.md §8.11):
+
+- **`Promise.new.raku` was `Promise(Planned)`** — the gist leaked through because Promise fell
+  to the `to_string_value()` catch-alls in every repr path. It now renders the Rakudo attribute
+  form `Promise.new(scheduler => ThreadPoolScheduler.new(uncaught_handler => Callable), status
+  => PromiseStatus::Planned)` (the scheduler part is faithful: a promise runs on the global
+  pool, and `ThreadPoolScheduler.raku` only ever shows its unset `uncaught_handler`). The form
+  is a pure function of the status, so one helper (`raku_repr::promise_raku_repr`) feeds the
+  pure renderer (nested `[$p].raku`), the native gist/raku fast path, the collection-gist
+  helpers, and the slow-path dispatch — `.gist` matches raku too, since Promise has no custom
+  gist. `.Str` stays `Promise(Status)` (raku's is a nondeterministic `Promise<addr>`).
+- **`$/.WHICH` was `ValueObjAt.new("Str|b")`** — the Match method table's `_` fallback
+  delegates unknown methods to the matched string, so `.WHICH` took the *string's value
+  identity*. It now falls through to the generic instance arm and yields object identity,
+  `ObjAt.new("Match|<id>")`. The same arm had a second bug: it labeled every instance `Any|<id>`
+  (via the `'static`-str `value_type_name`), so `A.new.WHICH` said `Any|25` where raku says
+  `A|…`; it now uses the instance's class name.
+
+Pins: `t/promise-raku-repr.t`, `t/match-which.t` (both verified green under the reference
+`raku`). Closes PLAN.md §8.11 (the residues item).
+
 ## 2026-07-22: a nested instance renders as `Foo.new(...)` for `.raku`, not `Foo()`
 
 `.raku` of a container holding a user instance (or a built-in object type) rendered the

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -417,8 +417,8 @@ pub(super) fn dispatch(
                 ValueView::RegexWithAdverbs(a) => {
                     format!("Regex|{:p}", Arc::as_ptr(&a.pattern))
                 }
-                ValueView::Instance { id, .. } => {
-                    format!("{}|{}", runtime::utils::value_type_name(target), id)
+                ValueView::Instance { class_name, id, .. } => {
+                    format!("{}|{}", class_name.resolve(), id)
                 }
                 ValueView::Junction { kind, values } => {
                     use std::hash::{Hash, Hasher};

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -2,7 +2,7 @@
 use crate::runtime;
 use crate::value::{RuntimeError, Value, ValueView};
 
-use super::raku_repr::raku_value;
+use super::raku_repr::{promise_raku_repr, raku_value};
 use super::{format_temporal_num, gist_array_wrap, range_gist_string};
 
 /// Rakudo caps an aggregate's `.gist` at the first 100 elements, then appends
@@ -33,6 +33,10 @@ fn leaf_gist(v: &Value) -> String {
         )
     {
         return "WhateverCode.new".to_string();
+    }
+    if let ValueView::Promise(p) = v.view() {
+        // Promise has no custom gist; its element gist is the `.raku` form.
+        return promise_raku_repr(&p.status());
     }
     v.to_string_value()
 }
@@ -825,6 +829,8 @@ pub(super) fn dispatch(
             ))))
         }
         ValueView::LazyList(_) => None, // fall through to runtime to force
+        // Promise has no custom gist, so `.gist` is the default `.raku` form.
+        ValueView::Promise(p) => Some(Ok(Value::str(promise_raku_repr(&p.status())))),
         _ => Some(Ok(Value::str(target.to_string_value()))),
     })
 }

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1944,6 +1944,11 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 // `Str.clone` falling through to the slow path.)
                 return Some(Ok(target.clone()));
             }
+            // A Match has reference identity (`ObjAt.new("Match|<id>")`), not
+            // the value identity of its matched string — the Str delegation
+            // below would land on `ValueObjAt.new("Str|...")`. Fall through to
+            // the generic Instance arm in `dispatch_core_coerce`.
+            "WHICH" => {}
             _ => {
                 let str_val = Value::str(target.to_string_value());
                 return native_method_0arg(&str_val, Symbol::intern(method));

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -203,6 +203,17 @@ pub(crate) fn needs_raku_dispatch(v: &Value) -> bool {
     }
 }
 
+/// The `.raku` (and default `.gist`) text of a Promise. Rakudo renders the
+/// two public attributes: the scheduler (whose own `.raku` only shows its
+/// `uncaught_handler`, `Callable` when unset — mutsu promises always run on
+/// the global pool with no handler) and the `PromiseStatus` enum constant.
+pub(crate) fn promise_raku_repr(status: &str) -> String {
+    format!(
+        "Promise.new(scheduler => ThreadPoolScheduler.new(uncaught_handler => Callable), status => PromiseStatus::{})",
+        status
+    )
+}
+
 /// Whether a string key may be rendered in the adverbial pair form
 /// `:key(value)`. Mirrors Raku's `<.ident>`: the key must start with a letter
 /// or `_`, continue with word chars, and may contain `-`/`'` only when each is
@@ -540,6 +551,7 @@ pub fn raku_value(v: &Value) -> String {
         }
         ValueView::Str(s) => escape_raku_str(&s),
         ValueView::Int(i) => i.to_string(),
+        ValueView::Promise(p) => promise_raku_repr(&p.status()),
         ValueView::Rat(n, d) => {
             if d == 0 {
                 if n == 0 {

--- a/src/runtime/methods_promise.rs
+++ b/src/runtime/methods_promise.rs
@@ -273,11 +273,10 @@ impl Interpreter {
                 Ok(Value::make_instance(Symbol::intern("Promise::Vow"), attrs))
             }
             "WHAT" => Ok(Value::package(shared.class_name())),
-            "raku" | "perl" => Ok(Value::str(format!(
-                "Promise.new(status => {})",
-                shared.status()
-            ))),
-            "Str" | "gist" => Ok(Value::str(format!("Promise({})", shared.status()))),
+            "raku" | "perl" | "gist" => Ok(Value::str(
+                crate::builtins::methods_0arg::raku_repr::promise_raku_repr(&shared.status()),
+            )),
+            "Str" => Ok(Value::str(format!("Promise({})", shared.status()))),
             "isa" => {
                 let arg = args.first().cloned().unwrap_or(Value::NIL);
                 let target_name = match arg.view() {

--- a/src/runtime/utils/gist.rs
+++ b/src/runtime/utils/gist.rs
@@ -102,6 +102,10 @@ pub(crate) fn gist_value(value: &Value) -> String {
         // A `:=`-bound element holds a `ContainerRef` cell; render the held
         // value so a bound element gists like a plain one (Phase 5 leak).
         ValueView::ContainerRef(cell) => gist_value(&cell.lock().unwrap()),
+        // Promise has no custom gist, so it gists in the default `.raku` form.
+        ValueView::Promise(p) => {
+            crate::builtins::methods_0arg::raku_repr::promise_raku_repr(&p.status())
+        }
         ValueView::Rat(_, _) | ValueView::FatRat(_, _) | ValueView::BigRat(_, _) => {
             // Rat.gist is identical to Rat.Str in Raku
             value.to_string_value()

--- a/t/match-which.t
+++ b/t/match-which.t
@@ -1,0 +1,23 @@
+use v6;
+use Test;
+
+plan 8;
+
+# Match.WHICH is reference identity (ObjAt), not the matched string's value
+# identity (which delegated to Str and produced ValueObjAt.new("Str|...")).
+"abc" ~~ /b/;
+is $/.WHICH.^name, 'ObjAt', 'Match.WHICH is an ObjAt';
+like $/.WHICH.raku, /^ 'ObjAt.new("Match|'/, 'Match.WHICH identity names Match';
+ok $/.WHICH eqv $/.WHICH, 'same Match has a stable WHICH';
+
+# A user-class instance likewise carries its class name, not `Any`.
+class A { }
+my $a = A.new;
+is $a.WHICH.^name, 'ObjAt', 'instance WHICH is an ObjAt';
+like $a.WHICH.raku, /^ 'ObjAt.new("A|'/, 'instance WHICH names its class';
+ok $a.WHICH eqv $a.WHICH, 'same instance has a stable WHICH';
+nok A.new.WHICH eqv A.new.WHICH, 'distinct instances have distinct WHICHes';
+
+my $other = A.new;
+"xy" ~~ /y/;
+nok $/.WHICH eqv $other.WHICH, 'Match and unrelated instance differ';

--- a/t/promise-raku-repr.t
+++ b/t/promise-raku-repr.t
@@ -1,0 +1,25 @@
+use v6;
+use Test;
+
+plan 7;
+
+# Promise.raku renders the Rakudo attribute form, not a bare `Promise(Status)`.
+my $planned = 'Promise.new(scheduler => ThreadPoolScheduler.new(uncaught_handler => Callable), status => PromiseStatus::Planned)';
+my $kept    = 'Promise.new(scheduler => ThreadPoolScheduler.new(uncaught_handler => Callable), status => PromiseStatus::Kept)';
+my $broken  = 'Promise.new(scheduler => ThreadPoolScheduler.new(uncaught_handler => Callable), status => PromiseStatus::Broken)';
+
+my $p = Promise.new;
+is $p.raku, $planned, 'planned Promise.raku';
+is $p.gist, $planned, 'Promise has no custom gist, so .gist is the .raku form';
+
+$p.keep(42);
+is $p.raku, $kept, 'kept Promise.raku';
+
+my $b = Promise.new;
+$b.break('nope');
+is $b.raku, $broken, 'broken Promise.raku';
+
+# Nested inside containers, the same form is used.
+is [$p].raku, "[$kept]", 'Promise nested in an array .raku';
+is [$p].gist, "[$kept]", 'Promise nested in an array .gist';
+is (:p($b),).hash.raku, "\{:p($broken)}", 'Promise nested in a hash .raku';


### PR DESCRIPTION
Closes the two `.raku` residues left by the nested-instance fix (PLAN.md §8.11):

## Promise repr

`Promise.new.raku` (and `.gist`, which Promise does not customize) rendered the mutsu-only gist `Promise(Planned)`. It now renders Rakudo's attribute form:

```
Promise.new(scheduler => ThreadPoolScheduler.new(uncaught_handler => Callable), status => PromiseStatus::Planned)
```

The scheduler part is faithful: mutsu promises always run on the global pool, and Rakudo's `ThreadPoolScheduler.raku` only ever shows its (unset) `uncaught_handler`. The form is a pure function of the status, so a single helper (`raku_repr::promise_raku_repr`) feeds all four repr paths: the pure renderer (nested `[$p].raku`), the native gist/raku fast path, the collection-gist helpers, and the slow-path Promise dispatch. `.Str` stays `Promise(Status)` — raku's is a nondeterministic `Promise<addr>`.

## Match / instance `.WHICH`

`"abc" ~~ /b/; $/.WHICH.raku` gave `ValueObjAt.new("Str|b")`: the Match method table's `_` fallback delegated `.WHICH` to the matched string, taking the string's *value* identity. It now falls through to the generic instance arm for object identity. That arm had a second bug — it labeled every instance `Any|<id>` (via the `'static`-str `value_type_name`), so `class A {}; A.new.WHICH` said `Any|25` where raku says `A|…`. It now uses the instance's class name:

```
$/.WHICH.raku      # ObjAt.new("Match|48")
A.new.WHICH.raku   # ObjAt.new("A|50")
```

Pins: `t/promise-raku-repr.t`, `t/match-which.t` — both verified green under the reference `raku`. Local `make test` (2276 files) passes; S17-promise and S02-types WHICH roast spot-checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)