### PR TITLE
fix: Range.AT-POS/EXISTS-POS/in-range + Range.WHICH notation

### DIFF
--- a/src/builtins/arith.rs
+++ b/src/builtins/arith.rs
@@ -8,7 +8,7 @@
 mod add_sub;
 mod mul_div_mod;
 mod pow_negate;
-mod range;
+pub(crate) mod range;
 mod rat;
 mod temporal;
 

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -3,7 +3,7 @@ mod dispatch_1arg;
 mod dispatch_2arg;
 mod dispatch_3arg;
 mod dispatch_variadic;
-mod flat;
+pub(crate) mod flat;
 mod junction;
 mod math;
 mod sprintf_fmt;

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -349,6 +349,11 @@ pub(super) fn dispatch(
                     | ValueView::Junction { .. }
                     | ValueView::Nil
                     | ValueView::Enum { .. }
+                    | ValueView::Range(..)
+                    | ValueView::RangeExcl(..)
+                    | ValueView::RangeExclStart(..)
+                    | ValueView::RangeExclBoth(..)
+                    | ValueView::GenericRange { .. }
             );
             let which_str = match target.view() {
                 ValueView::Package(name) => format!("{}|U{}", name.resolve(), name.id()),
@@ -453,6 +458,16 @@ pub(super) fn dispatch(
                 }
                 ValueView::Channel(c) => {
                     format!("Channel|{:p}", c.arc_ptr())
+                }
+                ValueView::Range(..)
+                | ValueView::RangeExcl(..)
+                | ValueView::RangeExclStart(..)
+                | ValueView::RangeExclBoth(..)
+                | ValueView::GenericRange { .. } => {
+                    // A Range is a value type: its identity is its notation
+                    // (`Range|1..2`, `Range|1^..^5`, `Range|"a".."z"`), which is
+                    // exactly the range's `.raku` representation.
+                    format!("Range|{}", super::raku_repr::raku_value(target))
                 }
                 ValueView::Whatever => {
                     use std::sync::atomic::{AtomicU64, Ordering};

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -469,6 +469,11 @@ pub(crate) fn native_method_1arg(
                 ValueView::Num(f) if f >= 0.0 => f as usize,
                 _ => return Some(Ok(Value::NIL)),
             };
+            // A Range is not array-backed; index its (possibly lazy) element
+            // sequence directly.
+            if crate::builtins::arith::range::range_bounds(target).is_some() {
+                return Some(Ok(range_at_pos(target, idx)));
+            }
             if let Some(items) = target.as_list_items() {
                 Some(Ok(items.get(idx).cloned().unwrap_or(Value::NIL)))
             } else {
@@ -520,6 +525,62 @@ pub(crate) fn native_method_1arg(
                     _ => None,
                 }
             }
+        }
+        "EXISTS-POS" => {
+            let idx = match arg.view() {
+                ValueView::Int(i) => i,
+                ValueView::Num(f) => f as i64,
+                _ => return Some(Ok(Value::FALSE)),
+            };
+            if idx < 0 {
+                return Some(Ok(Value::FALSE));
+            }
+            // On a Range, an index exists when it is below the element count.
+            // A lazy (infinite) range cannot report `.elems`, so — like raku —
+            // `.EXISTS-POS` on it throws X::Cannot::Lazy.
+            if crate::builtins::arith::range::range_bounds(target).is_some() {
+                match range_elem_count(target) {
+                    None => {
+                        let mut attrs = std::collections::HashMap::new();
+                        attrs.insert(
+                            "message".to_string(),
+                            Value::str("Cannot .elems a lazy list".to_string()),
+                        );
+                        let ex = Value::make_instance(Symbol::intern("X::Cannot::Lazy"), attrs);
+                        let mut err = RuntimeError::new("Cannot .elems a lazy list");
+                        err.exception = Some(Box::new(ex));
+                        return Some(Err(err));
+                    }
+                    Some(n) => return Some(Ok(Value::truth((idx as usize) < n))),
+                }
+            }
+            if let Some(items) = target.as_list_items() {
+                return Some(Ok(Value::truth((idx as usize) < items.len())));
+            }
+            None
+        }
+        "in-range" => {
+            // Range.in-range(x): True when x lies within the range, otherwise
+            // it throws X::OutOfRange (it never returns False).
+            if crate::builtins::arith::range::range_bounds(target).is_some() {
+                if range_contains_value(target, arg) {
+                    return Some(Ok(Value::TRUE));
+                }
+                use crate::builtins::methods_0arg::raku_repr::raku_value;
+                let msg = format!(
+                    "Value out of range. Is: {}, should be in {}",
+                    raku_value(arg),
+                    raku_value(target)
+                );
+                let mut attrs = std::collections::HashMap::new();
+                attrs.insert("message".to_string(), Value::str(msg.clone()));
+                attrs.insert("got".to_string(), arg.clone());
+                let ex = Value::make_instance(Symbol::intern("X::OutOfRange"), attrs);
+                let mut err = RuntimeError::new(msg);
+                err.exception = Some(Box::new(ex));
+                return Some(Err(err));
+            }
+            None
         }
         "split" => {
             if let ValueView::Instance { class_name, .. } = target.view()
@@ -2026,4 +2087,65 @@ pub(crate) fn native_method_1arg(
         }
         _ => None,
     }
+}
+
+/// The 0-based `n`th element of a Range, or Nil when `idx` is past the end.
+/// An infinite integer range (`a..*`) is indexed arithmetically; every other
+/// range materializes its (finite) element list.
+fn range_at_pos(range: &Value, idx: usize) -> Value {
+    if crate::builtins::functions::flat::is_infinite_range(range) {
+        if let Some((start, _end, excl_start, _)) =
+            crate::builtins::arith::range::range_bounds(range)
+            && let ValueView::Int(a) = start.view()
+        {
+            let first = if excl_start { a + 1 } else { a };
+            return Value::int(first + idx as i64);
+        }
+        return Value::NIL;
+    }
+    crate::runtime::value_to_list(range)
+        .get(idx)
+        .cloned()
+        .unwrap_or(Value::NIL)
+}
+
+/// Number of elements in a Range, or None when the range is infinite.
+fn range_elem_count(range: &Value) -> Option<usize> {
+    if crate::builtins::functions::flat::is_infinite_range(range) {
+        return None;
+    }
+    Some(crate::runtime::value_to_list(range).len())
+}
+
+/// Whether `val` lies within `range`, honoring the range's exclusivity and
+/// Whatever endpoints. Mirrors `Interpreter::value_in_range` for the numeric
+/// and string-endpoint cases used by `.in-range`.
+fn range_contains_value(range: &Value, val: &Value) -> bool {
+    let Some((start, end, excl_start, excl_end)) =
+        crate::builtins::arith::range::range_bounds(range)
+    else {
+        return false;
+    };
+    let start_whatever = matches!(start.view(), ValueView::Whatever | ValueView::HyperWhatever);
+    let end_whatever = matches!(end.view(), ValueView::Whatever | ValueView::HyperWhatever);
+    let string_range =
+        matches!(start.view(), ValueView::Str(_)) || matches!(end.view(), ValueView::Str(_));
+    if string_range {
+        let v = val.to_string_value();
+        let smin = start.to_string_value();
+        let smax = end.to_string_value();
+        let min_ok = start_whatever || if excl_start { v > smin } else { v >= smin };
+        let max_ok = end_whatever || if excl_end { v < smax } else { v <= smax };
+        return min_ok && max_ok;
+    }
+    let v = val.to_f64();
+    let min_ok = start_whatever || {
+        let vmin = start.to_f64();
+        if excl_start { v > vmin } else { v >= vmin }
+    };
+    let max_ok = end_whatever || {
+        let vmax = end.to_f64();
+        if excl_end { v < vmax } else { v <= vmax }
+    };
+    min_ok && max_ok
 }

--- a/src/runtime/did_you_mean.rs
+++ b/src/runtime/did_you_mean.rs
@@ -278,6 +278,8 @@ pub(crate) fn known_methods_for_type(type_name: &str) -> &'static [&'static str]
             "succ", "pred", "pick", "roll", "WHAT", "WHICH",
         ],
         "Range" => &[
+            "AT-POS",
+            "EXISTS-POS",
             "bounds",
             "elems",
             "excludes-max",
@@ -288,6 +290,7 @@ pub(crate) fn known_methods_for_type(type_name: &str) -> &'static [&'static str]
             "gist",
             "grep",
             "head",
+            "in-range",
             "infinite",
             "int-bounds",
             "is-int",

--- a/t/range-pos-which.t
+++ b/t/range-pos-which.t
@@ -1,0 +1,36 @@
+use Test;
+
+# Range positional protocol (AT-POS / EXISTS-POS / in-range) and .WHICH.
+# All expected values verified against the reference raku implementation.
+
+plan 20;
+
+# .WHICH is the range's notation, not just its minimum
+is (1..2).WHICH.Str, 'Range|1..2', '.WHICH of an inclusive range';
+is (1^..^5).WHICH.Str, 'Range|1^..^5', '.WHICH of an exclusive-both range';
+is (1..^3).WHICH.Str, 'Range|1..^3', '.WHICH of an exclusive-end range';
+is ('a'..'z').WHICH.Str, 'Range|"a".."z"', '.WHICH of a string range quotes endpoints';
+ok (1..2).WHICH eqv (1..2).WHICH, 'equal ranges have equal .WHICH';
+
+# AT-POS: 0-based element access
+is (1..4).AT-POS(0), 1, 'AT-POS(0) is the first element';
+is (1..4).AT-POS(2), 3, 'AT-POS(2)';
+is (1..4).AT-POS(3), 4, 'AT-POS(last)';
+is (1..4).AT-POS(4), Nil, 'AT-POS past the end is Nil';
+is (2^..8).AT-POS(0), 3, 'AT-POS on an exclusive-start range';
+is ('a'..'e').AT-POS(2), 'c', 'AT-POS on a string range';
+is (1..*).AT-POS(5), 6, 'AT-POS on an infinite range is arithmetic';
+
+# EXISTS-POS: index existence
+ok (6..10).EXISTS-POS(2), 'EXISTS-POS in bounds';
+ok (6..10).EXISTS-POS(4), 'EXISTS-POS at the last index';
+nok (6..10).EXISTS-POS(5), 'EXISTS-POS past the end';
+nok (6..10).EXISTS-POS(-1), 'EXISTS-POS with a negative index';
+
+# in-range: containment or throw
+ok (1..10).in-range(5), 'in-range for an interior value';
+ok ('a'..'z').in-range('c'), 'in-range on a string range';
+throws-like { (1..10).in-range(50) }, X::OutOfRange,
+    'in-range throws X::OutOfRange outside the range';
+throws-like { (1^..10).in-range(1) }, X::OutOfRange,
+    'in-range respects an excluded start';


### PR DESCRIPTION
Type/Range.rakudoc doc-diff findings from the QA harness.

## `.WHICH`
Returned only the minimum (`Range|1`); now the full notation, which is the
range's `.raku` form, and a Range is a value type so equal ranges share
identity:

```
(1..2).WHICH      # Range|1..2
(1^..^5).WHICH    # Range|1^..^5
('a'..'z').WHICH  # Range|"a".."z"
(1..2).WHICH eqv (1..2).WHICH   # True
```

## Positional protocol
```
(1..4).AT-POS(2)       # 3
(1..*).AT-POS(5)       # 6   (arithmetic on an infinite range)
(6..10).EXISTS-POS(2)  # True
(6..10).EXISTS-POS(5)  # False
(1..*).EXISTS-POS(9)   # throws X::Cannot::Lazy (matches raku)
(1..10).in-range(5)    # True
(1..10).in-range(50)   # throws X::OutOfRange
```

`.in-range` honors exclusivity and Whatever endpoints and works over string
ranges; it never returns False (raku throws instead).

`mod arith::range` and `mod functions::flat` are now `pub(crate)` so the pure
1-arg method dispatch can reach `range_bounds` / `is_infinite_range`.

Pin `t/range-pos-which.t` (raku-oracle verified). Roast `S02-types/range.t`
and `S03-operators/range.t` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)