### PR TITLE
fix: a module's own code can call its un-imported tagged export

### DIFF
--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -55,17 +55,72 @@ impl Interpreter {
             }
             return None;
         }
-        let local = format!("{}::{}", self.current_package(), name);
-        self.registry()
+        let cur_pkg = self.current_package();
+        let local = format!("{}::{}", cur_pkg, name);
+        if let Some(def) = self.registry().functions.get(&Symbol::intern(&local)).cloned() {
+            return Some(def);
+        }
+        if let Some(def) = self
+            .registry()
             .functions
-            .get(&Symbol::intern(&local))
+            .get(&Symbol::intern(&format!("GLOBAL::{}", name)))
             .cloned()
-            .or_else(|| {
-                self.registry()
+        {
+            return Some(def);
+        }
+        // A module's tagged export (`sub foo is export(:tag)`) that the importing
+        // program did not request is hidden by renaming `GLOBAL::foo` to
+        // `MOD::foo` (see the hide step in `runtime_module.rs`). But MOD's own
+        // routines — a grammar action method running under `MOD::Grammar`, or an
+        // ordinary method of `MOD::SomeClass` — still refer to `foo` by its bare
+        // name and relied on the now-removed GLOBAL entry. Restore visibility by
+        // walking up the enclosing namespace of the code that is running: the
+        // current package (set to the grammar's package during action dispatch)
+        // and the invocant's class (ordinary method bodies run under GLOBAL, so
+        // `self`'s class is the only module signal available). For each ancestor
+        // namespace that is a loaded module owning an export of this name,
+        // resolve `MOD::foo`. This fires only for genuinely-hidden owned exports,
+        // so an unrelated `Foo::bar` in a sibling package block is never
+        // spuriously resolved.
+        if !self.module_owned_exports.is_empty() {
+            if let Some(def) = self.resolve_hidden_owned_export(&cur_pkg, name) {
+                return Some(def);
+            }
+            if let Some(ValueView::Instance { class_name, .. }) =
+                self.env.get("self").map(Value::view)
+            {
+                let cn = class_name.resolve();
+                if let Some(def) = self.resolve_hidden_owned_export(&cn, name) {
+                    return Some(def);
+                }
+            }
+        }
+        None
+    }
+
+    /// Walk up the namespace segments of `context` looking for a loaded module
+    /// that owns an export named `name`, and return the hidden `MOD::name`
+    /// routine if one is registered. See `resolve_function`.
+    fn resolve_hidden_owned_export(&self, context: &str, name: &str) -> Option<Arc<FunctionDef>> {
+        let mut probe = context;
+        loop {
+            if self
+                .module_owned_exports
+                .get(probe)
+                .is_some_and(|owned| owned.contains_key(name))
+                && let Some(def) = self
+                    .registry()
                     .functions
-                    .get(&Symbol::intern(&format!("GLOBAL::{}", name)))
+                    .get(&Symbol::intern(&format!("{}::{}", probe, name)))
                     .cloned()
-            })
+            {
+                return Some(def);
+            }
+            match probe.rsplit_once("::") {
+                Some((outer, _)) => probe = outer,
+                None => return None,
+            }
+        }
     }
 
     pub(super) fn insert_token_def(&mut self, name: &str, def: FunctionDef, multi: bool) {

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -57,7 +57,12 @@ impl Interpreter {
         }
         let cur_pkg = self.current_package();
         let local = format!("{}::{}", cur_pkg, name);
-        if let Some(def) = self.registry().functions.get(&Symbol::intern(&local)).cloned() {
+        if let Some(def) = self
+            .registry()
+            .functions
+            .get(&Symbol::intern(&local))
+            .cloned()
+        {
             return Some(def);
         }
         if let Some(def) = self

--- a/t/lib/TaggedExportUser.rakumod
+++ b/t/lib/TaggedExportUser.rakumod
@@ -1,0 +1,28 @@
+# A module that references its OWN tagged-export subs (`is export(:tag)`) from
+# a grammar action method and from an ordinary method. A `use TaggedExportUser`
+# without the `:tag` does not import those subs, so the importing program must
+# not see them (they are hidden by renaming `GLOBAL::name` -> `MOD::name`). But
+# the module's own code still refers to them by bare name and must resolve them.
+# Regression pin for T-029 (POFile: grammar action / method could not see a
+# module-lexical tagged export).
+
+grammar TaggedExportUser::Parser {
+    token TOP { \w+ }
+}
+
+class TaggedExportUser::Actions {
+    method TOP($/) { make decorate(~$/) }   # tagged export from a grammar action
+}
+
+class TaggedExportUser::Widget {
+    has $.name;
+    method rendered() { decorate($!name) } # tagged export from an ordinary method
+}
+
+class TaggedExportUser {
+    method parse(Str $input) {
+        TaggedExportUser::Parser.parse($input, actions => TaggedExportUser::Actions).made
+    }
+}
+
+sub decorate(Str $s) is export(:helpers) { "<{$s}>" }

--- a/t/module-tagged-export-internal-visibility.t
+++ b/t/module-tagged-export-internal-visibility.t
@@ -1,0 +1,31 @@
+use lib 't/lib';
+use Test;
+use TaggedExportUser;
+
+# A module's own routines must be able to call its tagged-export subs
+# (`sub foo is export(:tag)`) by bare name, even though a plain `use MODULE`
+# (without `:tag`) does not import those subs into the caller. mutsu hides the
+# un-imported tagged export by renaming `GLOBAL::foo` to `MODULE::foo`; before
+# T-029 that also hid it from the module's own grammar-action methods and
+# ordinary methods, which dispatched via bare-name resolution and died with
+# "Unknown function". (POFile's `PO::Actions.TOP` -> `po-unquote`, and
+# `POFile::Entry.Str` -> `po-quote`.)
+
+plan 4;
+
+# The tagged export is NOT imported into this program (no :helpers tag).
+ok !MY::<&decorate>.defined, 'tagged export is not imported without its tag';
+
+# A grammar action method of the module can call the tagged export.
+is TaggedExportUser.parse('hello'), '<hello>',
+    'grammar action resolves module tagged export';
+
+# An ordinary method of the module can call the tagged export.
+is TaggedExportUser::Widget.new(name => 'x').rendered, '<x>',
+    'ordinary method resolves module tagged export';
+
+# Importing WITH the tag makes the sub available to the caller too.
+{
+    use TaggedExportUser :helpers;
+    is decorate('y'), '<y>', 'explicit :tag import brings the sub into scope';
+}


### PR DESCRIPTION
## Summary

A `sub foo is export(:tag)` that the importing program does not request is hidden by renaming `GLOBAL::foo` to `MOD::foo`, so a plain `use MOD` never leaks it into the caller. But the module's **own** routines still refer to `foo` by its bare name:

- a **grammar action method** (dispatched under the grammar's package), and
- an **ordinary method** (whose body runs under GLOBAL)

both resolved `foo` via bare-name lookup and died with `Unknown function` once the GLOBAL entry was renamed away.

## Fix

In `resolve_function`'s miss path, walk up the enclosing namespace of the running code — the current package (set to the grammar's package during action dispatch) and the invocant `self`'s class (ordinary method bodies run under GLOBAL, so `self`'s class is the only module signal) — and, for any ancestor namespace that is a **loaded module owning an export of this name** (`module_owned_exports`), resolve `MOD::foo`. This fires only for genuinely-hidden owned exports, so an unrelated `Foo::bar` in a sibling package block is never spuriously resolved.

## Impact

Root-causes **T-029 (POFile)**: `PO::Actions.TOP` → `po-unquote` and `POFile::Entry.Str` → `po-quote` are both tagged `is export(:quoting)`. POFile `01-basic` goes from **2/44 → 33/44** passing. The remaining failures are a separate grammar bug (`:sym<...>` word-quote whitespace), tracked as a follow-up.

## Test

`t/module-tagged-export-internal-visibility.t` (+ `t/lib/TaggedExportUser.rakumod`): a module referencing its own tagged export from a grammar action and an ordinary method, plus checks that the sub is not leaked without its tag and is available with an explicit `:tag` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)