### PR TITLE
fix: allow the $/ match variable inside a slash-regex code block

### DIFF
--- a/src/parser/primary/regex/scan.rs
+++ b/src/parser/primary/regex/scan.rs
@@ -243,6 +243,13 @@ fn scan_to_delim_inner(
         } else if !p5_mode && c == '>' && input[i + 1..].starts_with('>') {
             // >> is a right word boundary assertion — skip both chars
             chars.next(); // consume second >
+        } else if !p5_mode && c == '{' {
+            // A bare `{ ... }` embedded code block is Main-slang code, not regex:
+            // skip the whole balanced (string-aware) brace block so a delimiter
+            // inside it — most commonly the `/` of the `$/` match variable
+            // (`/ (\d) { say $/ } \d+ /`) — does not end the regex early. In P5
+            // mode `{n,m}` is a quantifier, not code, so this is Raku-only.
+            skip_interp_block(&mut chars)?;
         } else if !p5_mode
             && c == '<'
             && (input[i + 1..].starts_with('[')

--- a/t/regex-code-block-slash-var.t
+++ b/t/regex-code-block-slash-var.t
@@ -1,0 +1,29 @@
+use Test;
+
+# A `{ ... }` embedded code block in a slash-delimited regex is Main-slang code:
+# a `/` inside it (most often the `$/` match variable) must not terminate the
+# regex. Regression: `/ (\d) { say $/ } \d+ /` used to fail to parse ("Confused.
+# unparsed input" at the `}`) because the closing-delimiter scanner saw the `/`
+# of `$/` inside the block.
+
+plan 6;
+
+lives-ok {
+    'ab' ~~ / a { my $z = $/; } b /;
+}, 'a $/ reference inside a regex code block parses';
+
+{
+    my $seen;
+    '123' ~~ / (\d) { $seen = $/.Str } \d+ /;
+    is $seen, '1', 'the code block observed $/ at the capture point';
+    is ~$/, '123', 'the whole regex still matched to the end';
+}
+
+# A literal slash inside a string inside the block is also safe.
+lives-ok {
+    'x' ~~ / x { my $p = "a/b"; } /;
+}, 'a slash in a string in a code block does not close the regex';
+
+# Existing constructs still parse correctly.
+ok 'aa' ~~ / a ** {2} /, 'a {n} quantifier still works';
+ok 'abc' ~~ /abc$/, 'a trailing $ anchor still works';


### PR DESCRIPTION
Type/Match.rakudoc doc-diff finding.

`/ (\d) { say $/ } \d+ /` failed to parse:

```
Confused. unparsed input, column 35: "} \d+ /;"
```

The delimiter scanner walked a bare `{ ... }` embedded code block character by
character, so the `/` of the `$/` match variable inside the block was mistaken
for the regex's closing `/` — ending the regex early and leaving `; }` as stray
input. (`{ say $0 }` happened to work only because it contains no `/`.)

A bare `{ ... }` in a Raku regex is Main-slang code, not pattern text, so
`scan_to_delim_inner` now skips the whole balanced (string-aware) brace block
via the existing `skip_interp_block` helper. Guarded to `!p5_mode`, since in a
P5 regex `{n,m}` is a quantifier, not code. `<?{...}>` / `<!{...}>` / `<{...}>`
assertions are unaffected (matched by the `<` branch first).

```raku
'ab' ~~ / a { my $z = $/ } b /;      # parses
'x'  ~~ / x { my $p = "a/b" } /;     # slash-in-string in a block is safe too
```

Pin `t/regex-code-block-slash-var.t` (raku-oracle verified). Roast
`S05-metasyntax/{regex,repeat,charset,assertions}.t` and
`S05-substitution/subst.t` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)