### PR TITLE
fix: a leading-dot topic method call accepts a quoted method name

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -53,10 +53,19 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 
 ### T-005 — runtime_error: Runtime error: Failed to parse module 'X': Unexpected block in infix position (missing statement control word before the  [impact: 2 dists]
 - dists: REPL, mv2d
-- e.g. `mv2d`: App::MoarVM::Debug: Runtime error: Failed to parse module 'App::MoarVM::Debug': Unexpected block in infix position (missing statement control word before the ex
-- e.g. `REPL`: REPL: Runtime error: Failed to parse module 'REPL': Unexpected block in infix position (missing statement control word before the expression?)
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
+- **PARSE BUG FIXED (PR pending)**: root cause was a leading-dot topic method call
+  with a *quoted* method name — `."$method"()` / `.'method'()` (i.e. `$_."$method"()`).
+  mutsu only handled the explicit-invocant form (`$obj."$m"()`); the topic form left
+  the `.` unconsumed, and the later `{` block was flagged "Unexpected block in infix
+  position". `topic_method_call` (parser/primary/regex/lit.rs) now reuses
+  `parse_quoted_method_name` (Static → `MethodCall{quoted:true}`, Dynamic →
+  `DynamicMethodCall`), matching the explicit-invocant path. Both REPL.rakumod and the
+  mv2d modules parse cleanly now. Pin: t/topic-quoted-method-call.t.
+  (REPL used it as `note ."$method"()` inside a CATCH block, line 693.)
+- remaining (NOT this ticket, deeper): both dists now hit missing *dependencies* —
+  REPL needs `CodeUnit` (raku itself also fails this dep here), mv2d needs
+  `Data::MessagePack`. These are dependency-resolution/install issues, not parse bugs.
+- file: DONE (parse) — parser/primary/regex/lit.rs; remaining — external deps
 
 ### T-009 — parse_error: Runtime error: Failed to parse module 'X': X::Syntax::Confused: Strange text after block (missing semicolon or comma?)  [impact: 1 dist]
 - dists: XML::Canonical

--- a/src/parser/primary/regex/lit.rs
+++ b/src/parser/primary/regex/lit.rs
@@ -1215,6 +1215,45 @@ pub(in crate::parser::primary) fn topic_method_call(input: &str) -> PResult<'_, 
             },
         ));
     }
+    // Quoted method name on the topic: ."$method"() / .'method'() — equivalent to
+    // $_."$method"(). Mirrors the explicit-invocant path; quoted method names
+    // require parenthesized arguments.
+    if (r.starts_with('"') || r.starts_with('\''))
+        && let Some((r, qname)) = crate::parser::expr::parse_quoted_method_name(r)
+    {
+        if !r.starts_with('(') {
+            return Err(PError::expected_at(
+                "parenthesized arguments after quoted method name",
+                r,
+            ));
+        }
+        let (r, _) = parse_char(r, '(')?;
+        let (r, _) = ws(r)?;
+        let (r, args) = parse_call_arg_list(r)?;
+        let (r, _) = ws(r)?;
+        let (r, _) = parse_char(r, ')')?;
+        let topic = Box::new(Expr::Var("_".to_string()));
+        return Ok((
+            r,
+            match qname {
+                crate::parser::expr::QuotedMethodName::Static(name) => Expr::MethodCall {
+                    target: topic,
+                    name: Symbol::intern(&name),
+                    args,
+                    modifier: None,
+                    quoted: true,
+                },
+                crate::parser::expr::QuotedMethodName::Dynamic(name_expr) => {
+                    Expr::DynamicMethodCall {
+                        target: topic,
+                        name_expr: Box::new(name_expr),
+                        args,
+                        modifier: None,
+                    }
+                }
+            },
+        ));
+    }
     let (r, modifier) = if let Some(stripped) = r.strip_prefix('^') {
         (stripped, Some('^'))
     } else if let Some(stripped) = r.strip_prefix('?') {

--- a/t/topic-quoted-method-call.t
+++ b/t/topic-quoted-method-call.t
@@ -1,0 +1,74 @@
+use v6;
+use Test;
+
+# A leading-dot topic method call with a *quoted* method name — `."$m"()` and
+# `.'m'()` — is `$_."$m"()`. mutsu used to reject the topic form (only the
+# explicit-invocant `$obj."$m"()` worked), leaving the `.` unconsumed and
+# failing with "Unexpected block in infix position".
+
+plan 8;
+
+# Interpolated (dynamic) method name on the topic.
+{
+    my $m = "uc";
+    my $got;
+    given "hi" { $got = ."$m"() }
+    is $got, "HI", 'topic ."$m"() dynamic method name';
+}
+
+# Double-quoted static method name on the topic.
+{
+    my $got;
+    given "hi" { $got = ."uc"() }
+    is $got, "HI", 'topic ."uc"() static double-quoted name';
+}
+
+# Single-quoted static method name on the topic.
+{
+    my $got;
+    given "hi" { $got = .'uc'() }
+    is $got, "HI", "topic .'uc'() static single-quoted name";
+}
+
+# Inside a map block (the topic is the current element).
+{
+    my @a = <a b c>;
+    is-deeply @a.map({ ."uc"() }).List, ("A", "B", "C").List,
+        'topic quoted method call inside map block';
+}
+
+# Dynamic name inside map block.
+{
+    my $m = "uc";
+    my @a = <x y>;
+    is-deeply @a.map({ ."$m"() }).List, ("X", "Y").List,
+        'topic dynamic method call inside map block';
+}
+
+# With arguments.
+{
+    my $m = "substr";
+    my $got;
+    given "hello" { $got = ."$m"(1, 3) }
+    is $got, "ell", 'topic dynamic method call with arguments';
+}
+
+# The explicit-invocant form still works (regression guard).
+{
+    my $m = "uc";
+    is "hi"."$m"(), "HI", 'explicit-invocant quoted method call still works';
+}
+
+# Inside a CATCH block, calling a quoted method on the exception topic.
+{
+    my $method = "message";
+    my $seen;
+    for 1 {
+        CATCH {
+            $seen = ."$method"();
+            .resume;
+        }
+        die "boom";
+    }
+    is $seen, "boom", 'topic quoted method call inside CATCH block';
+}


### PR DESCRIPTION
## Summary

A leading-dot topic method call with a **quoted** method name — `."$method"()` or `.'method'()` — is the topic (`$_`) form of `$_."$method"()`. mutsu only parsed the explicit-invocant form (`$obj."$m"()`); the topic form left the leading `.` unconsumed, so the following `{` block was rejected with **"Unexpected block in infix position"**.

`topic_method_call` (`parser/primary/regex/lit.rs`) now reuses `parse_quoted_method_name` before the identifier fallback, exactly as the explicit-invocant path does:
- a static name → `MethodCall { quoted: true }`
- an interpolated name → `DynamicMethodCall`

## Impact

Unblocks the parse phase of the T-005 dist-compat tickets (**REPL**, **mv2d**), whose modules use `note ."$method"()` inside a `CATCH` block. Both now parse cleanly (they subsequently hit missing external dependencies, a separate concern).

## Test

Pin: `t/topic-quoted-method-call.t` (8 cases: dynamic/static/single-quoted names, inside map blocks, with arguments, inside CATCH, plus an explicit-invocant regression guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)