### PR TITLE
fix: cyclic instance .raku renders Rakudo's backref binding; mutual cycle no longer overflows the stack

### DIFF
--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -27,6 +27,28 @@ The two `.raku` residues the nested-instance sweep left behind (PLAN.md §8.11):
 Pins: `t/promise-raku-repr.t`, `t/match-which.t` (both verified green under the reference
 `raku`). Closes PLAN.md §8.11 (the residues item).
 
+## 2026-07-22: a cyclic instance renders Rakudo's backref binding — and a mutual cycle no longer overflows the stack
+
+`my $a = Bug.new; $a.myself[0] = $a; $a.raku` printed the terminating-but-wrong
+`Bug.new(myself => [Bug()])`; raku prints `(my \Bug_2355566733120 =
+Bug.new(myself => [Bug_2355566733120]))`. Worse, a *direct* instance→instance cycle
+(`$x.next = $y; $y.next = $x`, a plain `$` attribute) crashed with a stack overflow for both
+`.raku` and `.gist`: the `raku_leaf_active` guard the nested-instance fix added only lived in
+the container-leaf walker, and `collect_public_raku_attrs` dispatches an instance-valued
+attribute's `.raku` directly, bypassing it.
+
+Both recursive paths now funnel through one cycle-guarded dispatch
+(`dispatch_raku_leaf`, `src/runtime/methods_raku_dispatch.rs`): a re-entered instance renders
+as its backreference name (`Bug_48` — class display name + the stable instance id, where
+Rakudo uses the `.WHERE` address) and flags the id; the frame that first entered the instance
+(the native renderer in `methods_instance_ops.rs`) consumes the flag and wraps its rendering
+in `(my \Bug_48 = ...)`. A mutual cycle binds only the outer re-entered instance
+(`(my \P_25 = P.new(next => P.new(next => P_25)))`), and the default gist matches, both as in
+Rakudo. The user-facing `Mu.rakuseen` guard (for user-written `.raku` methods) is unchanged.
+
+Pin: `t/cyclic-instance-raku-backref.t` (10 assertions, verified green under the reference
+`raku`).
+
 ## 2026-07-22: a nested instance renders as `Foo.new(...)` for `.raku`, not `Foo()`
 
 `.raku` of a container holding a user instance (or a built-in object type) rendered the

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -989,10 +989,11 @@ impl Interpreter {
                     )));
                 }
                 // Collect public attributes for .raku representation. Mark this
-                // instance as being rendered so a self-referencing attribute
-                // (`$obj.myself[0] = $obj`) stops at the pure `Bug()` fallback
-                // instead of recursing through the nested-leaf walker
-                // (`runtime::methods_raku_dispatch`).
+                // instance as being rendered so a reference cycle back to it
+                // (`$obj.myself[0] = $obj`) renders as a backreference name
+                // instead of recursing (see `dispatch_raku_leaf` in
+                // `runtime::methods_raku_dispatch`); when that happened, wrap
+                // the result in Rakudo's `(my \Bug_48 = Bug.new(...))` binding.
                 let class_key = class_name.resolve();
                 let display_name = crate::value::user_facing_type_name(&class_key);
                 let instance_id = match target.view() {
@@ -1004,19 +1005,26 @@ impl Interpreter {
                 }
                 let public_attrs =
                     self.collect_public_raku_attrs(&class_key, &(attributes).as_map());
-                if let Some(id) = instance_id
-                    && let Some(pos) = self.raku_leaf_active.iter().rposition(|x| *x == id)
-                {
-                    self.raku_leaf_active.remove(pos);
+                let mut cycle_hit = false;
+                if let Some(id) = instance_id {
+                    if let Some(pos) = self.raku_leaf_active.iter().rposition(|x| *x == id) {
+                        self.raku_leaf_active.remove(pos);
+                    }
+                    cycle_hit = self.raku_leaf_cycle_hit.remove(&id);
                 }
-                if public_attrs.is_empty() {
-                    return Ok(Value::str(format!("{}.new", display_name)));
+                let body = if public_attrs.is_empty() {
+                    format!("{}.new", display_name)
+                } else {
+                    format!("{}.new({})", display_name, public_attrs.join(", "))
+                };
+                if cycle_hit && let Some(id) = instance_id {
+                    return Ok(Value::str(format!(
+                        "(my \\{} = {})",
+                        Self::raku_leaf_backref_name(&class_key, id),
+                        body
+                    )));
                 }
-                return Ok(Value::str(format!(
-                    "{}.new({})",
-                    display_name,
-                    public_attrs.join(", ")
-                )));
+                return Ok(Value::str(body));
             }
             if method == "name" && args.is_empty() {
                 return Ok(attributes
@@ -2316,8 +2324,11 @@ impl Interpreter {
                 continue;
             }
             if let Some(val) = attributes.get(attr_name) {
+                // The cycle-guarded dispatch renders a direct instance-valued
+                // attribute that refers back up the chain (`$x.next = $y;
+                // $y.next = $x`) as a backreference instead of recursing.
                 let rendered = self
-                    .call_method_with_values(val.clone(), "raku", vec![])
+                    .dispatch_raku_leaf(val)
                     .map(|v| v.to_string_value())
                     .unwrap_or_else(|_| val.to_string_value());
                 // A `$`-sigil attribute is a Scalar container, so an aggregate

--- a/src/runtime/methods_raku_dispatch.rs
+++ b/src/runtime/methods_raku_dispatch.rs
@@ -16,7 +16,7 @@
 
 use super::Interpreter;
 use crate::builtins::methods_0arg::raku_repr::{needs_raku_dispatch, raku_raw};
-use crate::value::{ArrayData, HashData, Value, ValueView};
+use crate::value::{ArrayData, HashData, RuntimeError, Value, ValueView};
 
 /// Depth cap for the walk. Cycles are caught by container identity (below);
 /// this only keeps a pathologically deep structure from blowing the stack.
@@ -165,26 +165,7 @@ impl Interpreter {
 
     fn expand_container(&mut self, value: &Value, active: &mut Vec<usize>, depth: usize) -> Value {
         if needs_raku_dispatch(value) {
-            // A self-referencing object reaches itself through its own
-            // attributes; dispatching again would recurse forever, so a
-            // re-entered instance falls back to the pure repr.
-            let id = match value.view() {
-                ValueView::Instance { id, .. } => Some(id),
-                _ => None,
-            };
-            if let Some(id) = id {
-                if self.raku_leaf_active.contains(&id) {
-                    return value.clone();
-                }
-                self.raku_leaf_active.push(id);
-            }
-            let rendered = self.call_method_with_values(value.clone(), "raku", vec![]);
-            if let Some(id) = id
-                && let Some(pos) = self.raku_leaf_active.iter().rposition(|x| *x == id)
-            {
-                self.raku_leaf_active.remove(pos);
-            }
-            return match rendered {
+            return match self.dispatch_raku_leaf(value) {
                 Ok(rendered) => raku_raw(rendered.to_string_value()),
                 Err(_) => value.clone(),
             };
@@ -311,6 +292,52 @@ impl Interpreter {
             .iter()
             .map(|item| self.expand_raku_leaves(item, active, depth + 1))
             .collect()
+    }
+
+    /// The Rakudo-style backreference name for a cyclic instance:
+    /// `Bug_48` (class display name + instance id; Rakudo uses the `.WHERE`
+    /// address as the suffix, mutsu the stable instance id).
+    pub(crate) fn raku_leaf_backref_name(class_name: &str, id: u64) -> String {
+        format!("{}_{}", crate::value::user_facing_type_name(class_name), id)
+    }
+
+    /// Dispatch `.raku` on a leaf with the reference-cycle guard. A re-entered
+    /// instance (already being rendered further up this call chain) returns its
+    /// backreference name (`Bug_48`) and flags the id; the frame that first
+    /// entered the instance consumes the flag and wraps its rendering in
+    /// Rakudo's binding form `(my \Bug_48 = Bug.new(...))`.
+    ///
+    /// Every recursive `.raku` path into an instance funnels through here (the
+    /// nested-leaf walker and `collect_public_raku_attrs`), so a cycle is cut
+    /// exactly one hop before it would re-render. The top-level render itself
+    /// registers in `raku_leaf_active` inside the native instance renderer
+    /// (`methods_instance_ops`), which performs the same wrap on exit.
+    pub(crate) fn dispatch_raku_leaf(&mut self, value: &Value) -> Result<Value, RuntimeError> {
+        let ValueView::Instance { class_name, id, .. } = value.view() else {
+            return self.call_method_with_values(value.clone(), "raku", vec![]);
+        };
+        if self.raku_leaf_active.contains(&id) {
+            self.raku_leaf_cycle_hit.insert(id);
+            return Ok(Value::str(Self::raku_leaf_backref_name(
+                &class_name.resolve(),
+                id,
+            )));
+        }
+        self.raku_leaf_active.push(id);
+        let result = self.call_method_with_values(value.clone(), "raku", vec![]);
+        if let Some(pos) = self.raku_leaf_active.iter().rposition(|x| *x == id) {
+            self.raku_leaf_active.remove(pos);
+        }
+        let hit = self.raku_leaf_cycle_hit.remove(&id);
+        let rendered = result?;
+        if hit {
+            return Ok(Value::str(format!(
+                "(my \\{} = {})",
+                Self::raku_leaf_backref_name(&class_name.resolve(), id),
+                rendered.to_string_value()
+            )));
+        }
+        Ok(rendered)
     }
 
     /// The `.raku`/`.perl` text of a container holding a dispatch-needing leaf,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1217,9 +1217,14 @@ pub struct Interpreter {
     /// Instance ids whose `.raku` is currently being rendered by the nested-leaf
     /// walker (`methods_raku_dispatch`). A self-referencing object
     /// (`$obj.myself[0] = $obj`) would otherwise recurse forever: instance →
-    /// attribute container → the same instance. A repeated id renders through
-    /// the pure fallback (`Bug()`) instead of dispatching again.
+    /// attribute container → the same instance. A repeated id renders as a
+    /// Rakudo-style backreference name (`Bug_48`) instead of dispatching again.
     pub(crate) raku_leaf_active: Vec<u64>,
+    /// Instance ids for which a cycle backreference was emitted during the
+    /// current native `.raku` render; the frame that pushed the id onto
+    /// [`raku_leaf_active`] consumes the flag to wrap its rendering in the
+    /// `(my \NAME = ...)` binding (mirroring the user-facing `rakuseen`).
+    pub(crate) raku_leaf_cycle_hit: std::collections::HashSet<u64>,
     /// Pending Proxy subclass attribute reference for writeback on mutating methods.
     /// Set when reading a Proxy subclass attribute; consumed by subsequent .push/.pop etc.
     pub(crate) pending_proxy_subclass_attr: Option<(crate::value::ProxySubclassAttrs, String)>,

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2124,6 +2124,7 @@ impl Interpreter {
             rakuseen_active: Vec::new(),
             rakuseen_cycle_hit: std::collections::HashSet::new(),
             raku_leaf_active: Vec::new(),
+            raku_leaf_cycle_hit: std::collections::HashSet::new(),
             pending_proxy_subclass_attr: None,
             multi_dispatch_stack: Vec::new(),
             method_dispatch_stack: Vec::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -314,6 +314,7 @@ impl Interpreter {
             rakuseen_active: Vec::new(),
             rakuseen_cycle_hit: std::collections::HashSet::new(),
             raku_leaf_active: Vec::new(),
+            raku_leaf_cycle_hit: std::collections::HashSet::new(),
             pending_proxy_subclass_attr: None,
             multi_dispatch_stack: Vec::new(),
             method_dispatch_stack: Vec::new(),

--- a/t/cyclic-instance-raku-backref.t
+++ b/t/cyclic-instance-raku-backref.t
@@ -1,0 +1,45 @@
+use v6;
+use Test;
+
+plan 10;
+
+# A reference cycle through an instance renders in Rakudo's backreference
+# binding form `(my \Bug_<id> = Bug.new(myself => [Bug_<id>]))` instead of
+# the terminating-but-wrong `Bug.new(myself => [Bug()])` (and instead of a
+# stack overflow for a direct instance->instance cycle).
+
+class Bug { has @.myself }
+my $a = Bug.new;
+$a.myself[0] = $a;
+
+like $a.raku, /^ '(my \Bug_' (\d+) ' = Bug.new(myself => [Bug_' $0 ']))' $/,
+    'self-cycle through an array attribute uses the backref binding';
+is $a.gist, $a.raku, 'default gist matches the .raku form';
+like [$a].raku, /^ '[(my \Bug_' (\d+) ' = Bug.new(myself => [Bug_' $0 ']))]' $/,
+    'cyclic instance nested in an array';
+my %h = b => $a;
+like %h.raku, /^ '{:b((my \Bug_' (\d+) ' = Bug.new(myself => [Bug_' $0 '])))}' $/,
+    'cyclic instance nested in a hash';
+
+# A mutual cycle through plain `$` attributes previously overflowed the
+# stack; only the outer re-entered instance gets the binding.
+class P { has $.next is rw }
+my $x = P.new;
+my $y = P.new;
+$x.next = $y;
+$y.next = $x;
+like $x.raku, /^ '(my \P_' (\d+) ' = P.new(next => P.new(next => P_' $0 ')))' $/,
+    'mutual cycle binds only the outer instance';
+like $y.raku, /^ '(my \P_' (\d+) ' = P.new(next => P.new(next => P_' $0 ')))' $/,
+    'the same cycle rendered from the other side';
+
+# Distinct renders of the same object agree (ids are stable).
+is $a.raku, $a.raku, 'repeated renders are identical';
+
+# Non-cyclic structures are untouched by the guard.
+class Foo { has $.x }
+is Foo.new(x => 1).raku, 'Foo.new(x => 1)', 'plain instance unchanged';
+is [Foo.new(x => 1)].raku, '[Foo.new(x => 1)]', 'nested plain instance unchanged';
+class B2 { has $.o }
+is B2.new(o => Foo.new(x => 3)).raku, 'B2.new(o => Foo.new(x => 3))',
+    'instance-valued attribute unchanged';


### PR DESCRIPTION
Closes the queued follow-up from the nested-instance `.raku` fix (#5209).

## Before

```raku
class Bug { has @.myself }; my $a = Bug.new; $a.myself[0] = $a;
$a.raku    # Bug.new(myself => [Bug()])   — terminating but wrong

class P { has $.next is rw }; my $x = P.new; my $y = P.new;
$x.next = $y; $y.next = $x;
$x.raku    # stack overflow (abort) — for .gist too
```

The `raku_leaf_active` guard #5209 added only lived in the container-leaf walker; `collect_public_raku_attrs` dispatches an instance-valued attribute's `.raku` directly, bypassing it — so a direct instance→instance cycle recursed unboundedly.

## After

Both recursive paths funnel through one cycle-guarded dispatch (`dispatch_raku_leaf` in `src/runtime/methods_raku_dispatch.rs`): a re-entered instance renders as its backreference name (`Bug_48` — class display name + the stable instance id, where Rakudo uses the `.WHERE` address) and flags the id; the frame that first entered the instance (the native renderer in `methods_instance_ops.rs`) consumes the flag and wraps its rendering in Rakudo's binding form:

```raku
$a.raku    # (my \Bug_25 = Bug.new(myself => [Bug_25]))
$x.raku    # (my \P_25 = P.new(next => P.new(next => P_25)))   — only the outer instance binds
```

Nested occurrences (`[$a].raku`, `%h.raku`) splice the same form in place, and the default gist matches — all as in Rakudo. The user-facing `Mu.rakuseen` guard (for user-written `.raku` methods) is unchanged.

Pin: `t/cyclic-instance-raku-backref.t` (10 assertions, verified green under the reference `raku`). Local `make test` (2276 files incl. the new pin and the #5209 pins) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)