### PR TITLE
fix: nested-leaf reprs for enum/Uni/Version; record the repr-sweep batch (PLAN §8.15)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1380,6 +1380,39 @@ radix strings, `zip`/`roundrobin` listop parsing, `.invert` on a scalar-held Lis
       (`scoped_state_key` / `load_state_locals` / `sync_state_locals`). Pin candidate:
       `t/state-var-per-block-in-feed-map.t`.
 
+### 8.15 Built-in object types with missing/wrong reprs, and `[ident]` mis-parsed as reduction (found 2026-07-22 by the repr oracle sweep)
+
+A repr-focused oracle sweep (`.raku`/`.gist` of built-in object constructors, bare and
+nested — recipe in the sweep memory; script was `tmp/repr-sweep.sh`) surfaced this batch.
+The nested-leaf residues it also found (enum qualification, Uni constructor form, Version
+gist `v` prefix) were fixed in the same PR that recorded this entry.
+
+- [ ] **`[red]` / `[RaceSeq]` parse as a reduction metaop for ANY identifier.** mutsu's
+      parser turns `[ident]` into `Reduction { op: "ident" }` even when `ident` is not an
+      infix operator (raku: only infix ops reduce; `[red]` is a one-element array). At
+      runtime the unknown-op reduction yields `Nil`, so `say [red].raku` prints `Nil`.
+      Fix in the parser: only take the reduction path for known/declared infix operators.
+- [ ] **A one-element array holding an Iterable renders without the trailing comma:**
+      `[HyperSeq].raku` → mutsu `[HyperSeq]`, raku `[HyperSeq,]` (disambiguates from
+      flattening). Applies to Iterable type objects and likely itemized list elements.
+- [ ] **`Channel.new.raku`/`.gist` render as the bare type name `Channel`** (raku:
+      `Channel.new`). The Channel value has no repr arm and its `to_string_value` looks
+      like a type object.
+- [ ] **`Supplier.new.raku` misses its attribute**: raku renders
+      `Supplier.new(taplist => Supplier::TapList.new)`.
+- [ ] **`Proc.new.gist` is `-1`** — Proc's gist/Str delegate to its `.Numeric` (exitcode
+      -1 when not run) instead of the default instance form; raku renders
+      `Proc.new(in => IO::Pipe, out => IO::Pipe, err => IO::Pipe, os-error => Str,
+      exitcode => Nil, signal => Any, pid => Nil, command => [])`. `Proc.new.raku` is
+      likewise attribute-less (`Proc.new`).
+- [ ] **`ThreadPoolScheduler.new` / `CurrentThreadScheduler.new` reprs miss
+      `uncaught_handler => Callable`** (their only raku-visible attribute; the Promise
+      repr fixed in #5217 hardcodes the same text and could then compose it).
+- [ ] **`IO::Spec::Unix.new.raku` renders the type-object form `IO::Spec::Unix`** and its
+      gist is `(Unix)`; raku renders `IO::Spec::Unix.new` for both.
+- [ ] **`Supply.new` should die** ("Cannot directly create a Supply. You might want: ...");
+      mutsu constructs a bare `Supply.new` silently. Behavior divergence beyond repr.
+
 ---
 
 ## Metrics

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,28 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-22: repr oracle sweep — three nested-leaf residues fixed, seven object-type repr gaps recorded (PLAN §8.15)
+
+A repr-focused run of the oracle diff sweep (`.raku`/`.gist` of ~50 built-in object
+constructor expressions, bare and nested `[X]` shapes, mutsu vs the reference `raku`)
+surfaced 35 divergent rows collapsing to ~10 root causes. Fixed immediately (the pure
+container renderer lacked leaf arms, so these were right bare but wrong nested):
+
+- **Enums lost their qualification inside containers**: `[red].raku` → `[Less]`-style bare
+  keys; now `[Color::red, Color::green]` via a shared `enum_raku_repr` (also deduplicates
+  the slow-path enum dispatch).
+- **A nested Uni decayed to its text**: `["a".NFC].raku` → `[a]`; now
+  `[Uni.new(0x0061).NFC]` via a shared `uni_raku_repr`.
+- **A nested Version's gist dropped the `v`**: `[v1.2.3].gist` → `[1.2.3]`; now `[v1.2.3]`.
+
+Recorded for follow-up in PLAN.md §8.15: `[ident]` parses as a reduction metaop for ANY
+identifier (`say [red].raku` → `Nil`; raku only reduces infix ops), the missing
+one-element-Iterable trailing comma (`[HyperSeq,]`), Channel/Supplier/Proc/
+ThreadPoolScheduler/IO::Spec::Unix repr gaps (`Proc.new.gist` is `-1` — it delegates to
+`.Numeric`), and `Supply.new` not dying.
+
+Pin: `t/nested-leaf-repr-residues.t` (verified green under the reference `raku`).
+
 ## 2026-07-22: Promise gets its Rakudo repr; `Match.WHICH` (and every instance `.WHICH`) names its class
 
 The two `.raku` residues the nested-instance sweep left behind (PLAN.md §8.11):

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -38,6 +38,11 @@ fn leaf_gist(v: &Value) -> String {
         // Promise has no custom gist; its element gist is the `.raku` form.
         return promise_raku_repr(&p.status());
     }
+    if let ValueView::Version { .. } = v.view() {
+        // A Version element keeps its `v` prefix (`[v1.2.3]`), which its
+        // bare string value drops.
+        return format!("v{}", v.to_string_value());
+    }
     v.to_string_value()
 }
 

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -638,21 +638,7 @@ pub(crate) fn native_method_0arg(
                 return Some(Ok(Value::int(text.chars().count() as i64)));
             }
             "raku" | "perl" => {
-                let codepoints: Vec<String> = text
-                    .chars()
-                    .map(|c| format!("0x{:04X}", c as u32))
-                    .collect();
-                // A normalization form appends the form, e.g. Uni.new(...).NFKC
-                let suffix = if u.form.is_empty() {
-                    String::new()
-                } else {
-                    format!(".{}", u.form)
-                };
-                return Some(Ok(Value::str(format!(
-                    "Uni.new({}){}",
-                    codepoints.join(", "),
-                    suffix
-                ))));
+                return Some(Ok(Value::str(raku_repr::uni_raku_repr(text, &u.form))));
             }
             "gist" => {
                 let codepoints: Vec<String> =

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -214,6 +214,38 @@ pub(crate) fn promise_raku_repr(status: &str) -> String {
     )
 }
 
+/// The `.raku` text of an enum value: `Order::Less`, or the quoted form
+/// `Color::<r-g>` when the key is not a plain identifier.
+pub(crate) fn enum_raku_repr(enum_type: &str, key: &str) -> String {
+    let is_ident = key
+        .chars()
+        .next()
+        .is_some_and(|c| c == '_' || (c.is_alphabetic() && !c.is_numeric()))
+        && key
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '\'');
+    if is_ident {
+        format!("{}::{}", enum_type, key)
+    } else {
+        format!("{}::<{}>", enum_type, key)
+    }
+}
+
+/// The `.raku` text of a Uni / normalization form: `Uni.new(0x0061)`, with the
+/// form appended when set (`Uni.new(0x0061).NFC`).
+pub(crate) fn uni_raku_repr(text: &str, form: &str) -> String {
+    let codepoints: Vec<String> = text
+        .chars()
+        .map(|c| format!("0x{:04X}", c as u32))
+        .collect();
+    let suffix = if form.is_empty() {
+        String::new()
+    } else {
+        format!(".{}", form)
+    };
+    format!("Uni.new({}){}", codepoints.join(", "), suffix)
+}
+
 /// Whether a string key may be rendered in the adverbial pair form
 /// `:key(value)`. Mirrors Raku's `<.ident>`: the key must start with a letter
 /// or `_`, continue with word chars, and may contain `-`/`'` only when each is
@@ -822,6 +854,14 @@ pub fn raku_value(v: &Value) -> String {
         // A Version renders as its `v`-prefixed literal (`v1.2`, `v1.2+`) —
         // `.Str` drops the `v`, `.raku` keeps it.
         ValueView::Version { .. } => format!("v{}", v.to_string_value()),
+        // An enum value renders qualified (`Order::Less`); without this arm a
+        // nested enum fell through to its bare string value (`Less`).
+        ValueView::Enum { enum_type, key, .. } => {
+            enum_raku_repr(&enum_type.resolve(), &key.resolve())
+        }
+        // A Uni / normalization form nested in a container keeps its
+        // constructor form (`Uni.new(0x0061).NFC`), not its decoded text.
+        ValueView::Uni(u) => uni_raku_repr(&u.text, &u.form),
         ValueView::Package(name) => name.resolve().to_string(),
         // A parameterized role type object renders as `Cup[EggNog]`.
         ValueView::ParametricRole {

--- a/src/runtime/methods_enum_dispatch.rs
+++ b/src/runtime/methods_enum_dispatch.rs
@@ -32,20 +32,12 @@ impl Interpreter {
                 Some(self.call_method_with_values(underlying, method, args.to_vec()))
             }
             "WHAT" => Some(Ok(Value::package(enum_type))),
-            "raku" | "perl" => {
-                let k = key.resolve();
-                let is_ident = k
-                    .chars()
-                    .next()
-                    .is_some_and(|c| c == '_' || (c.is_alphabetic() && !c.is_numeric()))
-                    && k.chars()
-                        .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '\'');
-                if is_ident {
-                    Some(Ok(Value::str(format!("{}::{}", enum_type, k))))
-                } else {
-                    Some(Ok(Value::str(format!("{}::<{}>", enum_type, k))))
-                }
-            }
+            "raku" | "perl" => Some(Ok(Value::str(
+                crate::builtins::methods_0arg::raku_repr::enum_raku_repr(
+                    &enum_type.resolve(),
+                    &key.resolve(),
+                ),
+            ))),
             "gist" => Some(Ok(Value::str(key.resolve()))),
             "Str" => match value {
                 EnumValue::Int(_) => Some(Ok(Value::str(key.resolve()))),

--- a/t/nested-leaf-repr-residues.t
+++ b/t/nested-leaf-repr-residues.t
@@ -1,0 +1,21 @@
+use v6;
+use Test;
+
+plan 8;
+
+# Nested-leaf repr residues found by the 2026-07-22 repr oracle sweep: the
+# pure container renderer lacked arms for these leaves, so they fell through
+# to their bare string values inside containers (the bare reprs were right).
+
+enum Color <red green>;
+is red.raku, 'Color::red', 'bare enum .raku (pinned)';
+my @a = red, green;
+is @a.raku, '[Color::red, Color::green]', 'enums nested in an array stay qualified';
+is (:c(red),).hash.raku, '{:c(Color::red)}', 'enum nested in a hash stays qualified';
+
+is ("a".NFC).raku, 'Uni.new(0x0061).NFC', 'bare Uni .raku (pinned)';
+is ["a".NFC].raku, '[Uni.new(0x0061).NFC]', 'Uni nested in an array keeps its constructor form';
+
+is [v1.2.3].raku, '[v1.2.3]', 'Version nested .raku (pinned)';
+is [v1.2.3].gist, '[v1.2.3]', 'Version nested in an array gist keeps the v prefix';
+is [Order::Less].raku, '[Order::Less]', 'built-in enum nested in an array stays qualified';


### PR DESCRIPTION
A repr-focused run of the oracle diff sweep (`.raku`/`.gist` of ~50 built-in object constructor expressions, bare and nested `[X]` shapes, mutsu vs the reference `raku`) surfaced 35 divergent rows collapsing to ~10 root causes.

## Fixed here — three pure-renderer leaf residues (right bare, wrong nested)

| expression | was | now (= raku) |
|---|---|---|
| `[red, green].raku` | `[Less]`-style bare keys | `[Color::red, Color::green]` |
| `["a".NFC].raku` | `[a]` | `[Uni.new(0x0061).NFC]` |
| `[v1.2.3].gist` | `[1.2.3]` | `[v1.2.3]` |

The enum and Uni reprs are now shared helpers (`enum_raku_repr`, `uni_raku_repr`) used by both the pure renderer (`raku_value`) and the slow-path dispatches, deduplicating the existing bare-repr logic.

## Recorded as PLAN.md §8.15 for follow-up

- `[ident]` parses as a **reduction metaop for ANY identifier** (`say [red].raku` → `Nil`; raku only reduces infix ops) — parser fix.
- One-element-Iterable arrays miss the trailing comma (`[HyperSeq,]`).
- `Channel.new` renders as the bare type name; `Supplier.new` misses `taplist`; **`Proc.new.gist` is `-1`** (delegates to `.Numeric`); ThreadPoolScheduler/CurrentThreadScheduler miss `uncaught_handler`; `IO::Spec::Unix.new` renders as a type object.
- `Supply.new` should die ("Cannot directly create a Supply...") but constructs silently.

Pin: `t/nested-leaf-repr-residues.t` (verified green under the reference `raku`). Local `make test` (2278 files) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)