### PR TITLE
fix: a read-only `with $match<key>` topic no longer corrupts the Match

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -189,6 +189,25 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   handling of a captured Match variable (Slice-F territory). Suspects:
   `src/parser/stmt/modifier.rs` (with-modifier topic binding) and the VM topic/`$_`
   scope handling; the grammar-subcapture storage may reify differently from a regex Match.
+- **PARTIAL FIX (PR pending, `fix-given-element-match-writeback`)**: the *associative*
+  form `with $cc<scheme>` no longer corrupts `$cc`. Root cause was the `given`/`with`
+  element-source rw-writeback (`write_back_element_source`): `given $x<k>`/`given @a[i]`
+  aliases the element read-write and re-stores `$_` into it on block exit — but it did
+  so **unconditionally**, even when the body never changed `$_`. For a read-only
+  aggregate (a `Match` subcapture, where `$cc` is a `ValueView::Instance`, not a
+  Hash/Array) that spurious re-store clobbered the whole `$cc`. Fix: skip the writeback
+  when `$_` is unchanged from its entry value, and only write back to a genuine mutable
+  Array/Hash/ContainerRef container (`vm/vm_given_when_ops.rs`, `vm/vm_loop_writeback.rs`).
+  `given %h<k>`/`given @a[i]` reassignment still writes back. Pin:
+  `t/given-element-topic-readonly-writeback.t`.
+- **remaining (deeper, separate)**: (1) the *positional* form `with $cc[0]` still
+  corrupts `$cc` via a different path (NOT the writeback — it survives even with the
+  writeback guarded; a dual-store locals/env clobber when the block does not reference
+  `$cc`). (2) URI now advances past the `<scheme>` corruption but dies at
+  `URI::Authority` / `URI::Path` construction ("Default constructor ... only takes named
+  arguments") — a positional `Match:D` subcapture argument still arrives as a type object
+  and no user `multi method new(...:U: Match:D $x)` candidate matches. Both are the
+  positional-Match variant of the same dual-store issue.
 
 ### T-032 — test_die [ValueTypeCache] (same nqp cluster as T-027)  [impact: 1 dist]
 - dists: ValueTypeCache

--- a/src/vm/vm_given_when_ops.rs
+++ b/src/vm/vm_given_when_ops.rs
@@ -52,6 +52,17 @@ impl Interpreter {
         {
             self.topic_container_source = Some(src.clone());
         }
+        // The value the topic was bound to on entry. For an element-source topic
+        // (`given $x<k>` / `given @a[i]`), the writeback below re-stores `$_` into
+        // that element; if the body never changed `$_`, that writeback is a no-op
+        // that must be skipped — re-storing into a *read-only* aggregate (a grammar
+        // Match subcapture, `given $cc<scheme>`) would otherwise autovivify and
+        // clobber the whole `$cc`. Keep the entry value to detect "unchanged".
+        let element_orig = if element_source.is_some() {
+            Some(topic.clone())
+        } else {
+            None
+        };
         self.env_mut().insert("_".to_string(), topic);
         loan_env!(self, set_when_matched(false));
         // A read-only topic (`given @a` / `given 42` / `given expr()`) forbids
@@ -88,7 +99,7 @@ impl Interpreter {
             }
             if write_back {
                 if let Some(src) = &element_source {
-                    this.write_back_element_source(code, src, &pointy_param);
+                    this.write_back_element_source(code, src, &pointy_param, element_orig.as_ref());
                 } else {
                     this.write_back_given_topic(
                         code,

--- a/src/vm/vm_loop_writeback.rs
+++ b/src/vm/vm_loop_writeback.rs
@@ -55,6 +55,7 @@ impl Interpreter {
         code: &CompiledCode,
         src: &(String, Value, bool),
         pointy_param: &Option<String>,
+        orig: Option<&Value>,
     ) {
         let (container, index, _positional) = src;
         // For a pointy block, write back the bound parameter's final value;
@@ -66,6 +67,17 @@ impl Interpreter {
         let Some(current) = current else {
             return;
         };
+        // If the body never changed the topic from the value bound on entry, the
+        // writeback is a no-op. Skip it: assigning the same value back into a
+        // read-only aggregate element (a grammar Match subcapture — `given
+        // $cc<scheme>`, whose `$cc` is a `Match`, not a mutable Hash) would
+        // autovivify a fresh Hash and destroy the whole `$cc`. `given %h<k>`
+        // still writes back whenever `$_` was actually reassigned.
+        if let Some(orig) = orig
+            && Self::loop_var_unchanged(&current, orig)
+        {
+            return;
+        }
         let key = match index.view() {
             ValueView::Int(i) => i.to_string(),
             ValueView::Str(s) => s.as_ref().clone(),
@@ -74,12 +86,38 @@ impl Interpreter {
         let Some(mut cval) = self.get_env_with_main_alias(container) else {
             return;
         };
+        // Only a genuine mutable Array/Hash (or a cell wrapping one) is a
+        // writable element target here. A read-only aggregate — a grammar Match
+        // subcapture, `given $cc<scheme>` / `given $cc[0]` where `$cc` is a
+        // `Match` (a `ValueView::Instance`, not an Array/Hash) — is NOT: the
+        // no-op `assign_into_nested_container` leaves `cval` untouched, but the
+        // unconditional `set_env` re-store below still clobbered `$cc` (via the
+        // element/topic scope bookkeeping). Skip the whole writeback for such a
+        // container; its elements were never assignable in the first place.
+        if !Self::is_writable_element_container(&cval) {
+            return;
+        }
         // The element index here is an already-resolved existing slot (loop
         // aliasing), so the autoviv reservation cannot realistically fail; this
         // writeback teardown has no error channel, so discard the Result.
         let _ = Self::assign_into_nested_container(&mut cval, &key, current);
         self.set_env_with_main_alias(container, cval.clone());
         self.update_local_if_exists(code, container, &cval);
+    }
+
+    /// Whether `v` is a container whose element can be assigned through the
+    /// `given $x<k>` / `given @a[i]` element-source writeback: a plain mutable
+    /// Array or Hash, or a `ContainerRef` cell wrapping one. A Match subcapture,
+    /// a type object, or any other `Instance` is read-only here.
+    fn is_writable_element_container(v: &Value) -> bool {
+        match v.view() {
+            ValueView::Array(..) | ValueView::Hash(..) => true,
+            ValueView::ContainerRef(cell) => {
+                let inner = cell.lock().unwrap().clone();
+                Self::is_writable_element_container(&inner)
+            }
+            _ => false,
+        }
     }
 
     /// Whether the loop variable still holds the same binding as the source

--- a/t/given-element-topic-readonly-writeback.t
+++ b/t/given-element-topic-readonly-writeback.t
@@ -1,0 +1,72 @@
+use v6;
+use Test;
+
+# A `given`/`with` topic that is a *container element* (`given %h<k>` /
+# `given @a[i]`) aliases that element read-write: reassigning `$_` in the body
+# propagates back. But if the body never changes `$_`, the writeback must be a
+# no-op. mutsu unconditionally re-stored `$_` into the element on block exit;
+# when the container was a read-only aggregate (a grammar Match subcapture,
+# `with $cc<scheme>` where `$cc` is a `Match`), that spurious write clobbered the
+# whole `$cc`, so every other subcapture (`$cc<hier-part>`) turned into `Any`.
+# This is the shape that broke URI's `parse` method.
+
+plan 9;
+
+# Read-only associative element topic on a Match subcapture must NOT corrupt it.
+{
+    grammar G {
+        token TOP  { <uri> }
+        token uri  { <scheme> '://' <rest> }
+        token scheme { \w+ }
+        token rest   { \S+ }
+    }
+    my $cc = G.parse('http://example.com/a')<uri>;
+    my $scheme = '';
+    $scheme = .lc with $cc<scheme>;
+    is $scheme, 'http', 'with $cc<scheme> reads the subcapture';
+    is $cc<scheme>.Str, 'http', '$cc<scheme> is still usable afterwards';
+    is $cc<rest>.Str,   'example.com/a', 'the *other* subcapture is preserved';
+    ok $cc.defined, '$cc itself is still a defined Match';
+}
+
+# The same, but inside a nested sub scope (the shape that actually broke): a
+# grammar-parse subcapture passed on to a typed sub after a `with` on a sibling.
+{
+    grammar G2 {
+        token TOP { <scheme> '://' <host> }
+        token scheme { \w+ }
+        token host   { \S+ }
+    }
+    sub recv(Match:D $c) { $c.Str }
+    sub parse($str) {
+        my $cc = G2.parse($str);
+        my $s = '';
+        $s = .lc with $cc<scheme>;
+        return recv($cc<host>);
+    }
+    is parse('http://example.com'), 'example.com',
+        'nested with $cc<k> leaves the sibling subcapture a valid Match:D';
+}
+
+# Writeback still happens when the body *does* reassign the topic (hash var).
+{
+    my %h = a => 1;
+    given %h<a> { $_ = 5 }
+    is %h<a>, 5, 'given %h<k> writes back a reassigned topic';
+}
+
+# Read-only body is a no-op for a hash element, and still binds $_.
+{
+    my %h = a => 1;
+    my $seen;
+    given %h<a> { $seen = $_ }
+    is %h<a>, 1, 'read-only given %h<k> leaves the element unchanged';
+    is $seen, 1, 'read-only given %h<k> still binds $_ to the element';
+}
+
+# Array element writeback still works.
+{
+    my @a = 1, 2, 3;
+    given @a[1] { $_ = 9 }
+    is-deeply @a, [1, 9, 3], 'given @a[i] writes back a reassigned topic';
+}


### PR DESCRIPTION
## Summary

A `given`/`with` topic that is a container element (`given %h<k>` / `given @a[i]`) aliases that element read-write and re-stores `$_` into it on block exit. That writeback ran **unconditionally** — even when the body never changed `$_`.

For a read-only aggregate — a grammar `Match` subcapture, e.g. `with $cc<scheme>` where `$cc` is a `Match` (a `ValueView::Instance`, not a mutable Hash/Array) — the spurious re-store clobbered the whole `$cc`, so every *other* subcapture (`$cc<hier-part>`) turned into `Any`. Minimal repro:

```raku
sub parse($str) {
    my $cc = G.parse($str)<uri>;
    my $s = '';
    $s = .lc with $cc<scheme>;   # <- corrupts $cc
    recv($cc<hier-part>);        # $cc<hier-part> is now Any
}
```

## Fix

Two guards on `write_back_element_source`:
- skip the writeback when the final `$_` is unchanged from the value it was bound to on entry (the no-op case), and
- only write back to a genuine mutable Array/Hash (or a `ContainerRef` wrapping one); a `Match` / type object / `Instance` element was never an assignable lvalue.

`given %h<k>` / `given @a[i]` reassignment still writes back.

## Scope

This is the `with $var<key>` corruption behind the **URI** dist (T-031). It fixes the *associative* form; the positional `with $var[i]` variant and URI's deeper `URI::Authority` construction remain separate dual-store issues (recorded in the ticket).

## Test

Pin: `t/given-element-topic-readonly-writeback.t` (9 cases, raku-clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)