### PR TITLE
fix: .Setty/.Baggy/.Mixy coerce the quant-hash instead of returning the type object

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -88,6 +88,13 @@ doc) are version skew, not mutsu bugs — lowest priority.
   `$!.^name` mismatch (`Any` vs `Nil`) because the *cleared* `$!` is `Value::NIL`,
   which reports `Any` — that is the deferred Nil-vs-Any identity knot below, not this
   fix.
+- `Type/QuantHash.rakudoc` [1]/[2]/[3] — `.Setty`/`.Baggy`/`.Mixy` on a
+  `Set`/`Bag`/`Mix` (or `*Hash`) returned the bare mapped type object (`(Set)`,
+  `(Bag)`, `(Mix)`) instead of coercing the receiver. `dispatch_setty_baggy_mixy`
+  now delegates to the existing `.Set`/`.Bag`/`.Mix` (and `*Hash`) coercion
+  helpers, preserving hashiness via the container's mutable flag. Also fixed
+  `Mix.Set`/`Mix.Setty` dropping non-positive weights (`to_set` `Mix` arm kept
+  every key) — **#5228**. Pin: `t/setty-baggy-mixy-coerce.t`.
 - `hashmap.rakudoc` [1] — a Junction used as a hash-initializer key
   (`%( "a"|"b" => 1 )`) was stored under its stringification (`any(a, b)`) as a
   single literal key instead of threading. Per Rakudo a Junction key stores the

--- a/src/builtins/quanthash_coerce.rs
+++ b/src/builtins/quanthash_coerce.rs
@@ -131,8 +131,13 @@ pub(crate) fn to_set(target: Value, what: &str) -> Result<Value, RuntimeError> {
             }
         }
         ValueView::Mix(m, _) => {
-            for k in m.keys() {
-                elems.insert(k.clone());
+            // A Mix coerces to a Set keeping only keys with a positive weight
+            // (`(a=>2,b=>-1,c=>0).Mix.Set` == `Set(a)`); Raku's Setty drops
+            // zero and negative weights.
+            for (k, w) in m.iter() {
+                if *w > 0.0 {
+                    elems.insert(k.clone());
+                }
             }
         }
         ValueView::Pair(k, v) => {

--- a/src/runtime/methods_type_coerce.rs
+++ b/src/runtime/methods_type_coerce.rs
@@ -161,9 +161,11 @@ impl Interpreter {
         // preserving hash flavor for *Hash type objects.
         let source_type = match target.view() {
             ValueView::Package(name) => Some(name.resolve()),
-            ValueView::Set(..) => Some("Set".to_string()),
-            ValueView::Bag(..) => Some("Bag".to_string()),
-            ValueView::Mix(..) => Some("Mix".to_string()),
+            // The mutable flag distinguishes the `*Hash` flavor from its
+            // immutable sibling, so `.Setty` preserves hashiness.
+            ValueView::Set(_, is_mut) => Some(if is_mut { "SetHash" } else { "Set" }.to_string()),
+            ValueView::Bag(_, is_mut) => Some(if is_mut { "BagHash" } else { "Bag" }.to_string()),
+            ValueView::Mix(_, is_mut) => Some(if is_mut { "MixHash" } else { "Mix" }.to_string()),
             _ => None,
         };
         if let Some(source_type) = source_type
@@ -196,7 +198,31 @@ impl Interpreter {
                     }
                 }
             };
-            return Some(Ok(Value::package(Symbol::intern(mapped))));
+            // On a type object, `.Setty`/`.Baggy`/`.Mixy` yield the mapped type
+            // object; on a concrete quant-hash they coerce to the mapped flavor
+            // (dropping non-positive weights for a Mix source, per Raku).
+            if matches!(target.view(), ValueView::Package(_)) {
+                return Some(Ok(Value::package(Symbol::intern(mapped))));
+            }
+            let coerced = match mapped {
+                "Set" => self.dispatch_to_set_with_what(target.clone(), "Set"),
+                "SetHash" => self
+                    .dispatch_to_set_with_what(target.clone(), "SetHash")
+                    .map(|mut r| {
+                        r.with_set_mut(|_, is_mut| *is_mut = true);
+                        r
+                    }),
+                "Bag" => self.dispatch_to_bag_with_what(target.clone(), "Bag"),
+                "BagHash" => self
+                    .dispatch_to_bag_with_what(target.clone(), "BagHash")
+                    .map(|mut r| {
+                        r.with_bag_mut(|_, is_mut| *is_mut = true);
+                        r
+                    }),
+                "Mix" => self.dispatch_to_mix_with_what(target.clone(), "Mix"),
+                _ => crate::builtins::quanthash_coerce::to_mixhash(target.clone()),
+            };
+            return Some(coerced);
         }
         None
     }

--- a/t/setty-baggy-mixy-coerce.t
+++ b/t/setty-baggy-mixy-coerce.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+# .Setty / .Baggy / .Mixy coerce a Set/Bag/Mix (and their *Hash flavors) to the
+# corresponding quant-hash flavor, rather than returning the bare type object.
+# See Type/QuantHash.rakudoc.
+
+plan 20;
+
+my %b is Bag = one => 1, two => 2;
+is %b.Setty.gist, 'Set(one two)',          'Bag.Setty drops weights to a Set';
+is %b.Baggy.gist, 'Bag(one two(2))',       'Bag.Baggy keeps weights';
+is %b.Mixy.gist,  'Mix(one two(2))',       'Bag.Mixy keeps weights as a Mix';
+
+my %s is Set = <one two>;
+is %s.Setty.gist, 'Set(one two)',          'Set.Setty is a Set';
+is %s.Baggy.gist, 'Bag(one two)',          'Set.Baggy weight-1 Bag';
+is %s.Mixy.gist,  'Mix(one two)',          'Set.Mixy weight-1 Mix';
+
+my %m is Mix = one => 1, minus => -1, zero => 0;
+is %m.Setty.gist, 'Set(one)',              'Mix.Setty keeps only positive weights';
+is %m.Baggy.gist, 'Bag(one)',              'Mix.Baggy keeps only positive weights';
+is %m.Mixy.gist,  'Mix(minus(-1) one)',    'Mix.Mixy keeps non-zero weights';
+
+# .Set on a Mix must also drop non-positive weights (regression).
+is %m.Set.gist,   'Set(one)',              'Mix.Set drops non-positive weights';
+
+# Hash flavors preserve hashiness.
+my %sh is SetHash = <a b>;
+is %sh.Setty.^name, 'SetHash',             'SetHash.Setty stays a SetHash';
+is %sh.Baggy.^name, 'BagHash',             'SetHash.Baggy is a BagHash';
+is %sh.Mixy.^name,  'MixHash',             'SetHash.Mixy is a MixHash';
+
+my %bh is BagHash = a => 2;
+is %bh.Setty.^name, 'SetHash',             'BagHash.Setty is a SetHash';
+is %bh.Baggy.^name, 'BagHash',             'BagHash.Baggy stays a BagHash';
+
+my %mh is MixHash = a => 2, b => -1;
+is %mh.Setty.gist, 'SetHash(a)',           'MixHash.Setty drops non-positive';
+is %mh.Baggy.gist, 'BagHash(a(2))',        'MixHash.Baggy drops non-positive';
+is %mh.Mixy.^name, 'MixHash',              'MixHash.Mixy stays a MixHash';
+
+# Type objects map to the mapped type object.
+is Bag.Setty.^name, 'Set',                 'Bag type object .Setty is the Set type';
+is Mix.Baggy.^name, 'Bag',                 'Mix type object .Baggy is the Bag type';
+
+done-testing;


### PR DESCRIPTION
## Summary

`.Setty` / `.Baggy` / `.Mixy` on a `Set`/`Bag`/`Mix` (and their `*Hash`
flavors) returned the bare *mapped type object* (`(Set)`, `(Bag)`, `(Mix)`)
instead of coercing the receiver. `dispatch_setty_baggy_mixy` computed the
right target flavor but then returned `Value::package(mapped)` rather than the
coerced value.

It now delegates to the existing `.Set`/`.Bag`/`.Mix` (and `*Hash`) coercion
helpers, so `%b.Setty` == `%b.Set`, preserving hashiness for a `*Hash` source
(detected via the container's mutable flag) and yielding the mapped type object
only when the receiver is itself a type object.

Also fixes `Mix.Set` / `Mix.Setty`: the `to_set` `Mix` arm kept every key
regardless of weight, so `(a => 1, b => -1, c => 0).Mix.Set` wrongly included
`b`. It now drops non-positive weights, matching Rakudo's Setty rule.

```
my %b is Bag = one => 1, two => 2;
say %b.Setty;   # was (Set) → now Set(one two)
my %m is Mix = one => 1, minus => -1;
say %m.Setty;   # was (Set) → now Set(one)
```

## Testing

- New pin `t/setty-baggy-mixy-coerce.t` (20 cases across Set/Bag/Mix, their
  `*Hash` flavors, and type objects).
- Surfaced by the doc-diff harness on `Type/QuantHash.rakudoc` (3 mismatches → 0).
- Whitelisted roast `set.t`/`bag.t`/`mix.t`/`baggy.t`/`sethash.t`/`baghash.t`/`mixhash.t`
  all pass; `t/` quant-hash suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)