### PR TITLE
fix: [ident] is an array literal unless ident is an infix operator

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1385,13 +1385,11 @@ radix strings, `zip`/`roundrobin` listop parsing, `.invert` on a scalar-held Lis
 A repr-focused oracle sweep (`.raku`/`.gist` of built-in object constructors, bare and
 nested — recipe in the sweep memory; script was `tmp/repr-sweep.sh`) surfaced this batch.
 The nested-leaf residues it also found (enum qualification, Uni constructor form, Version
-gist `v` prefix) were fixed in the same PR that recorded this entry.
+gist `v` prefix) were fixed in the same PR that recorded this entry, and the `[ident]`
+mis-parse (any identifier taken as a reduction metaop, so `say [red].raku` printed `Nil`)
+was fixed right after (`t/bareword-array-not-reduction.t`). Probing the trailing-comma
+item also showed `[:a].raku` renders `[:a]` where raku spells `[:a(Bool::True)]`.
 
-- [ ] **`[red]` / `[RaceSeq]` parse as a reduction metaop for ANY identifier.** mutsu's
-      parser turns `[ident]` into `Reduction { op: "ident" }` even when `ident` is not an
-      infix operator (raku: only infix ops reduce; `[red]` is a one-element array). At
-      runtime the unknown-op reduction yields `Nil`, so `say [red].raku` prints `Nil`.
-      Fix in the parser: only take the reduction path for known/declared infix operators.
 - [ ] **A one-element array holding an Iterable renders without the trailing comma:**
       `[HyperSeq].raku` → mutsu `[HyperSeq]`, raku `[HyperSeq,]` (disambiguates from
       flattening). Applies to Iterable type objects and likely itemized list elements.

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,21 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-22: `[ident]` is an array literal unless `ident` is an infix operator
+
+The reduction-metaop parser accepted ANY lowercase-initial bareword as a custom reduction
+op, so `[red]` (an enum value, not an infix) parsed as `Reduction { op: "red" }` and
+evaluated to `Nil`. Worse, the greedy `R`/`Z`/`X` meta-prefix strip ran before any validity
+check, so `[RaceSeq]` became meta `R` + custom op `"aceSeq"` — defeating the existing
+uppercase-initial guard that was supposed to keep `[Type]` an array literal.
+
+A bareword now reduces only when it is a `REDUCTION_OPS` word infix (`min`/`max`/`lcm`/...)
+or a user-declared infix, and declared infixes are matched as a whole BEFORE meta-prefix
+stripping (`infix:<Xyz>` is not mangled into meta `X` + `yz`; `[Rfoo]` still resolves meta
+`R` over a declared `foo` post-strip). Found by the §8.15 repr sweep.
+
+Pin: `t/bareword-array-not-reduction.t` (verified green under the reference `raku`).
+
 ## 2026-07-22: repr oracle sweep — three nested-leaf residues fixed, seven object-type repr gaps recorded (PLAN §8.15)
 
 A repr-focused run of the oracle diff sweep (`.raku`/`.gist` of ~50 built-in object

--- a/src/parser/primary/misc/reduction.rs
+++ b/src/parser/primary/misc/reduction.rs
@@ -147,6 +147,14 @@ fn flatten_bracket_op(s: &str) -> String {
 /// Check if the given op (after flattening) is a valid reduction operator.
 /// Handles R/Z/X meta-prefix chains by stripping them to find the base op.
 fn is_valid_reduction_op(op: &str) -> bool {
+    // A user-declared infix matches as a whole BEFORE meta-prefix stripping —
+    // the greedy R/Z/X strip below would mangle a declared op that happens to
+    // start with a meta letter (`infix:<Xyz>` must not become meta X + "yz").
+    if let Some((_, len)) = crate::parser::stmt::simple::match_user_declared_infix_symbol_op(op)
+        && len == op.len()
+    {
+        return true;
+    }
     let mut s = op;
     // Strip meta prefixes while keeping bare operators like `X` intact.
     while s.len() > 1 {
@@ -244,23 +252,13 @@ fn is_custom_reduction_op(op: &str) -> bool {
         // Also accept the symbol as a prefix of op (shouldn't happen for reduction, but be safe)
         let _ = symbol;
     }
-    // A bareword that is not a declared infix operator: accept it as a custom
-    // reduction op ONLY if it looks like an operator name (lowercase/`_`-initial).
-    // An uppercase-initial identifier is a type name or class (`[Any]`, `[Int]`,
-    // `[Exception]`), so `[Type]` must parse as an array literal, not a reduction
-    // (`[Any].raku` is `[Any]` array literal's `.raku`, NOT a reduction with op
-    // "Any"). User-declared uppercase infixes are already matched above by
-    // `match_user_declared_infix_symbol_op`.
-    if !op
-        .chars()
-        .next()
-        .is_some_and(|c| c.is_lowercase() || c == '_')
-    {
-        return false;
-    }
-    if let Ok((rest, _)) = parse_ident_with_hyphens(op) {
-        return rest.is_empty();
-    }
+    // A bareword that is NOT a declared infix operator is not a reduction op:
+    // `[red]` / `[Any]` are one-element array literals (raku only reduces with
+    // infix operators). Accepting any identifier here turned `say [red].raku`
+    // into a reduction over the unknown op "red", which evaluated to Nil.
+    // Word-form built-in infixes (`min`, `max`, `lcm`, ...) are listed in
+    // `REDUCTION_OPS`; user-declared infixes (word or symbol, any case) are
+    // matched by `match_user_declared_infix_symbol_op` above.
     false
 }
 

--- a/t/bareword-array-not-reduction.t
+++ b/t/bareword-array-not-reduction.t
@@ -1,0 +1,28 @@
+use v6;
+use Test;
+
+plan 10;
+
+# `[ident]` is a one-element array literal unless `ident` is an infix
+# operator: raku only reduces with infixes. mutsu accepted ANY identifier
+# as a reduction op, so `[red]` became a reduction over the unknown op
+# "red" and evaluated to Nil.
+
+enum Color <red green>;
+is [red].elems, 1, '[enum-value] is a one-element array';
+ok [red][0] === red, 'the element is the enum value itself';
+is [RaceSeq].elems, 1, '[Type] with a meta-letter initial is an array, not R+"aceSeq"';
+is [green, red].elems, 2, 'enum list literal unaffected';
+
+# Real reductions keep working.
+is ([+] 1, 2, 3), 6, 'symbolic reduction';
+is ([min] 3, 1, 2), 1, 'word-infix reduction (min)';
+is ([lcm] 4, 6), 12, 'word-infix reduction (lcm)';
+is ([Z] (1, 2), (3, 4)).gist, '((1 3) (2 4))', 'meta Z reduction';
+
+# A user-declared infix reduces — including via the whole-op match that must
+# win before meta-prefix stripping.
+sub infix:<foo>($a, $b) { $a + $b }
+is ([foo] 1, 2, 3), 6, 'user-declared word infix reduces';
+sub infix:<Xyz>($a, $b) { $a * $b }
+is ([Xyz] 2, 3, 4), 24, 'declared infix starting with a meta letter reduces whole';


### PR DESCRIPTION
Closes the parser item of PLAN.md §8.15 (found by the repr oracle sweep).

## Before

```raku
enum Color <red green>;
say [red].raku;      # Nil        — parsed as Reduction { op: "red" }
say [RaceSeq].raku;  # Nil        — parsed as meta R + custom op "aceSeq"
```

The reduction-metaop parser accepted ANY lowercase-initial bareword as a custom reduction op, and its greedy `R`/`Z`/`X` meta-prefix strip ran before any validity check, defeating the existing uppercase-initial guard for `[Type]`.

## After

A bareword reduces only when it is a `REDUCTION_OPS` word infix (`min`/`max`/`lcm`/...) or a **user-declared infix**. Declared infixes are matched as a whole BEFORE meta-prefix stripping, so a declared `infix:<Xyz>` reduces correctly instead of being mangled into meta `X` + `yz`, and `[Rfoo]` still resolves meta `R` over a declared `foo` via the post-strip check.

```raku
say [red].raku;              # [Color::red]  (one-element array, as raku)
say [RaceSeq].elems;         # 1
sub infix:<foo>($a,$b){$a+$b};  say [foo] 1,2,3;   # 6
sub infix:<Xyz>($a,$b){$a*$b};  say [Xyz] 2,3,4;   # 24
```

Pin: `t/bareword-array-not-reduction.t` (10 assertions, verified green under the reference `raku`). Local `make test` (2283 files) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)