### PR TITLE
fix: Code.yada reports whether the body is a yada stub

### DIFF
--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1894,6 +1894,20 @@ impl Interpreter {
                 self.metamodel_primitives_dispatch(method, args)
             }
             _ => {
+                // `.yada` on a Code is True when the routine body is nothing but a
+                // yada stub (`...`/`!!!`/`???`), which parses to a lone
+                // `__mutsu_stub_die`/`__mutsu_stub_warn` call. Handle it before the
+                // callable-compose fallback so it isn't turned into a method-chain.
+                if method == "yada" && args.is_empty() {
+                    let body = match target.view() {
+                        ValueView::Sub(data) => Some(data.body.clone()),
+                        ValueView::WeakSub(weak) => weak.upgrade().map(|d| d.body.clone()),
+                        _ => None,
+                    };
+                    if let Some(body) = body {
+                        return Ok(Value::truth(Self::sub_body_is_yada_stub(&body)));
+                    }
+                }
                 // Method calls on callables compose by applying the method to the
                 // callable's return value, e.g. `(*-*).abs`.
                 if matches!(target.view(), ValueView::Sub(_) | ValueView::WeakSub(_)) {
@@ -2343,6 +2357,21 @@ impl Interpreter {
             }
         }
         parts
+    }
+
+    /// Whether a routine body is exactly a yada stub (`...`/`!!!`/`???`), which
+    /// parses to a single `__mutsu_stub_die`/`__mutsu_stub_warn` call. `SetLine`
+    /// annotations don't count; anything beyond the lone stub makes it non-yada
+    /// (`sub f { ...; 2 }` is not a stub).
+    fn sub_body_is_yada_stub(body: &[crate::ast::Stmt]) -> bool {
+        use crate::ast::{Expr, Stmt};
+        let meaningful: Vec<&Stmt> = body
+            .iter()
+            .filter(|s| !matches!(s, Stmt::SetLine(_)))
+            .collect();
+        meaningful.len() == 1
+            && matches!(meaningful[0], Stmt::Expr(Expr::Call { name, .. })
+                if *name == "__mutsu_stub_die" || *name == "__mutsu_stub_warn")
     }
 }
 

--- a/t/routine-yada.t
+++ b/t/routine-yada.t
@@ -1,0 +1,20 @@
+use v6;
+use Test;
+
+# Code.yada is True only when the routine body is exactly a yada stub
+# (`...`, `!!!`, or `???`). See Type/Routine.rakudoc.
+
+plan 8;
+
+ok  (sub a() { ... }).yada,     '... stub is yada';
+ok  (sub b() { !!! }).yada,     '!!! stub is yada';
+ok  (sub c() { ??? }).yada,     '??? stub is yada';
+nok (sub d() { 1 }).yada,       'real body is not yada';
+nok (sub e() { ...; 2 }).yada,  'stub plus more is not yada';
+nok (sub f() { }).yada,         'empty body is not yada';
+
+# Blocks/pointy blocks are Code too.
+ok  ({ ... }).yada,             'bare block stub is yada';
+nok ({ 42 }).yada,              'bare block with body is not yada';
+
+done-testing;


### PR DESCRIPTION
## Summary

`(sub f() { ... }).yada` returned a `<composed-method:yada>` placeholder Sub:
a method call on a callable was unconditionally turned into a method-chain
composition (the `(*.abs)` currying mechanism), swallowing real `Code`
introspection methods like `.yada`.

`.yada` is now handled *before* that fallback. It is `True` exactly when the
routine body is a lone yada stub (`...`/`!!!`/`???`, which parses to a single
`__mutsu_stub_die`/`__mutsu_stub_warn` call), and `False` otherwise — a real
body, an empty body, or a stub followed by more statements (`sub f { ...; 2 }`).
It works for named subs, anonymous subs, and bare blocks.

```
say (sub f() { ... }).yada;   # was <composed-method:yada> → now True
say (sub g() { 1 }).yada;     # was <composed-method:yada> → now False
```

## Testing

- New pin `t/routine-yada.t` (8 cases).
- Surfaced by the doc-diff harness on `Type/Routine.rakudoc` (one mismatch resolved).
- Whatever-currying compose path (`t/whatevercode-compose.t`, `t/whatever-xz-currying.t`, …) and the `t/` sub/routine suite stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)