### PR TITLE
fix: Channel/scheduler/Supplier reprs — three more PLAN §8.15 items

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1393,19 +1393,11 @@ item also showed `[:a].raku` renders `[:a]` where raku spells `[:a(Bool::True)]`
 - [ ] **A one-element array holding an Iterable renders without the trailing comma:**
       `[HyperSeq].raku` → mutsu `[HyperSeq]`, raku `[HyperSeq,]` (disambiguates from
       flattening). Applies to Iterable type objects and likely itemized list elements.
-- [ ] **`Channel.new.raku`/`.gist` render as the bare type name `Channel`** (raku:
-      `Channel.new`). The Channel value has no repr arm and its `to_string_value` looks
-      like a type object.
-- [ ] **`Supplier.new.raku` misses its attribute**: raku renders
-      `Supplier.new(taplist => Supplier::TapList.new)`.
 - [ ] **`Proc.new.gist` is `-1`** — Proc's gist/Str delegate to its `.Numeric` (exitcode
       -1 when not run) instead of the default instance form; raku renders
       `Proc.new(in => IO::Pipe, out => IO::Pipe, err => IO::Pipe, os-error => Str,
       exitcode => Nil, signal => Any, pid => Nil, command => [])`. `Proc.new.raku` is
       likewise attribute-less (`Proc.new`).
-- [ ] **`ThreadPoolScheduler.new` / `CurrentThreadScheduler.new` reprs miss
-      `uncaught_handler => Callable`** (their only raku-visible attribute; the Promise
-      repr fixed in #5217 hardcodes the same text and could then compose it).
 - [ ] **`IO::Spec::Unix.new.raku` renders the type-object form `IO::Spec::Unix`** and its
       gist is `(Unix)`; raku renders `IO::Spec::Unix.new` for both.
 - [ ] **`Supply.new` should die** ("Cannot directly create a Supply. You might want: ...");

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,18 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-22: Channel, the schedulers, and Supplier get their Rakudo reprs (PLAN §8.15 slice)
+
+Three more §8.15 repr items closed: `Channel.new.raku`/`.gist` rendered the bare type name
+`Channel` (the Channel value had no repr arm anywhere, so every path fell to its
+type-object-looking string value) — now `Channel.new` across all four paths (bare/nested ×
+raku/gist). `ThreadPoolScheduler.new` / `CurrentThreadScheduler.new` now show their one
+raku-visible attribute (`uncaught_handler => Callable` when unset) via a shared
+`scheduler_raku_repr` that the Promise repr composes, and `Supplier.new` shows
+`taplist => Supplier::TapList.new` — both as native-instance special arms next to the
+existing `X::AdHoc` arm, since these classes have no registered attribute metadata for the
+generic walk. Pin: `t/object-type-reprs.t` (verified green under the reference `raku`).
+
 ## 2026-07-22: `[ident]` is an array literal unless `ident` is an infix operator
 
 The reduction-metaop parser accepted ANY lowercase-initial bareword as a custom reduction

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -38,6 +38,9 @@ fn leaf_gist(v: &Value) -> String {
         // Promise has no custom gist; its element gist is the `.raku` form.
         return promise_raku_repr(&p.status());
     }
+    if let ValueView::Channel(_) = v.view() {
+        return "Channel.new".to_string();
+    }
     if let ValueView::Version { .. } = v.view() {
         // A Version element keeps its `v` prefix (`[v1.2.3]`), which its
         // bare string value drops.
@@ -836,6 +839,8 @@ pub(super) fn dispatch(
         ValueView::LazyList(_) => None, // fall through to runtime to force
         // Promise has no custom gist, so `.gist` is the default `.raku` form.
         ValueView::Promise(p) => Some(Ok(Value::str(promise_raku_repr(&p.status())))),
+        // Channel likewise; its bare string value reads as a type object.
+        ValueView::Channel(_) => Some(Ok(Value::str_from("Channel.new"))),
         _ => Some(Ok(Value::str(target.to_string_value()))),
     })
 }

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -203,13 +203,21 @@ pub(crate) fn needs_raku_dispatch(v: &Value) -> bool {
     }
 }
 
+/// The `.raku` (and default `.gist`) text of a scheduler: its only
+/// raku-visible attribute is `uncaught_handler`, `Callable` when unset —
+/// mutsu's schedulers never carry a handler.
+pub(crate) fn scheduler_raku_repr(class: &str) -> String {
+    format!("{}.new(uncaught_handler => Callable)", class)
+}
+
 /// The `.raku` (and default `.gist`) text of a Promise. Rakudo renders the
 /// two public attributes: the scheduler (whose own `.raku` only shows its
 /// `uncaught_handler`, `Callable` when unset — mutsu promises always run on
 /// the global pool with no handler) and the `PromiseStatus` enum constant.
 pub(crate) fn promise_raku_repr(status: &str) -> String {
     format!(
-        "Promise.new(scheduler => ThreadPoolScheduler.new(uncaught_handler => Callable), status => PromiseStatus::{})",
+        "Promise.new(scheduler => {}, status => PromiseStatus::{})",
+        scheduler_raku_repr("ThreadPoolScheduler"),
         status
     )
 }
@@ -584,6 +592,9 @@ pub fn raku_value(v: &Value) -> String {
         ValueView::Str(s) => escape_raku_str(&s),
         ValueView::Int(i) => i.to_string(),
         ValueView::Promise(p) => promise_raku_repr(&p.status()),
+        // A Channel's only repr is the bare constructor (Rakudo shows no
+        // attributes); its string value (`Channel`) reads as a type object.
+        ValueView::Channel(_) => "Channel.new".to_string(),
         ValueView::Rat(n, d) => {
             if d == 0 {
                 if n == 0 {

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -988,6 +988,25 @@ impl Interpreter {
                         "X::AdHoc.new(payload => {payload_raku})"
                     )));
                 }
+                // Schedulers and Supplier are native instances with no
+                // registered class attributes, so the generic attribute walk
+                // below would render a bare `.new`; Rakudo shows their fixed
+                // raku-visible attributes (an unset `uncaught_handler` is the
+                // `Callable` type object, a fresh taplist is an empty
+                // `Supplier::TapList`).
+                match class_name.resolve().as_str() {
+                    cls @ ("ThreadPoolScheduler" | "CurrentThreadScheduler") => {
+                        return Ok(Value::str(
+                            crate::builtins::methods_0arg::raku_repr::scheduler_raku_repr(cls),
+                        ));
+                    }
+                    "Supplier" => {
+                        return Ok(Value::str(
+                            "Supplier.new(taplist => Supplier::TapList.new)".to_string(),
+                        ));
+                    }
+                    _ => {}
+                }
                 // Collect public attributes for .raku representation. Mark this
                 // instance as being rendered so a reference cycle back to it
                 // (`$obj.myself[0] = $obj`) renders as a backreference name

--- a/src/runtime/utils/gist.rs
+++ b/src/runtime/utils/gist.rs
@@ -106,6 +106,8 @@ pub(crate) fn gist_value(value: &Value) -> String {
         ValueView::Promise(p) => {
             crate::builtins::methods_0arg::raku_repr::promise_raku_repr(&p.status())
         }
+        // Channel likewise; its bare string value reads as a type object.
+        ValueView::Channel(_) => "Channel.new".to_string(),
         ValueView::Rat(_, _) | ValueView::FatRat(_, _) | ValueView::BigRat(_, _) => {
             // Rat.gist is identical to Rat.Str in Raku
             value.to_string_value()

--- a/t/object-type-reprs.t
+++ b/t/object-type-reprs.t
@@ -1,0 +1,28 @@
+use v6;
+use Test;
+
+plan 9;
+
+# Object-type reprs from PLAN.md §8.15 (repr oracle sweep): Channel rendered
+# as the bare type name, and the schedulers/Supplier hid their raku-visible
+# attributes.
+
+is Channel.new.raku, 'Channel.new', 'Channel.raku is the constructor form';
+is Channel.new.gist, 'Channel.new', 'Channel.gist matches';
+is [Channel.new].raku, '[Channel.new]', 'Channel nested in an array .raku';
+is [Channel.new].gist, '[Channel.new]', 'Channel nested in an array .gist';
+
+is ThreadPoolScheduler.new.raku,
+    'ThreadPoolScheduler.new(uncaught_handler => Callable)',
+    'ThreadPoolScheduler shows its unset uncaught_handler';
+is CurrentThreadScheduler.new.raku,
+    'CurrentThreadScheduler.new(uncaught_handler => Callable)',
+    'CurrentThreadScheduler likewise';
+is ThreadPoolScheduler.new.gist,
+    'ThreadPoolScheduler.new(uncaught_handler => Callable)',
+    'scheduler gist matches the raku form';
+
+is Supplier.new.raku, 'Supplier.new(taplist => Supplier::TapList.new)',
+    'Supplier shows its taplist';
+is [Supplier.new].raku, '[Supplier.new(taplist => Supplier::TapList.new)]',
+    'Supplier nested in an array';


### PR DESCRIPTION
Three more repr items from PLAN.md §8.15 (repr oracle sweep), all now matching the reference `raku`:

| expression | was | now |
|---|---|---|
| `Channel.new.raku` / `.gist` | `Channel` (bare type name) | `Channel.new` |
| `ThreadPoolScheduler.new.raku` | `ThreadPoolScheduler.new` | `ThreadPoolScheduler.new(uncaught_handler => Callable)` |
| `CurrentThreadScheduler.new.raku` | `CurrentThreadScheduler.new` | `CurrentThreadScheduler.new(uncaught_handler => Callable)` |
| `Supplier.new.raku` | `Supplier.new` | `Supplier.new(taplist => Supplier::TapList.new)` |

The Channel value had no repr arm anywhere, so every path fell to its type-object-looking string value; arms now cover all four paths (bare/nested × raku/gist). The schedulers' one raku-visible attribute is rendered via a shared `scheduler_raku_repr` that the Promise repr (#5217) composes. Schedulers and Supplier are native instances with no registered attribute metadata, so they render as special arms next to the existing `X::AdHoc` arm.

Pin: `t/object-type-reprs.t` (9 assertions, verified green under the reference `raku`). Local `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)