### PR TITLE
fix: Supply.new throws X::Supply::New (cannot directly create a Supply)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1400,8 +1400,6 @@ item also showed `[:a].raku` renders `[:a]` where raku spells `[:a(Bool::True)]`
       likewise attribute-less (`Proc.new`).
 - [ ] **`IO::Spec::Unix.new.raku` renders the type-object form `IO::Spec::Unix`** and its
       gist is `(Unix)`; raku renders `IO::Spec::Unix.new` for both.
-- [ ] **`Supply.new` should die** ("Cannot directly create a Supply. You might want: ...");
-      mutsu constructs a bare `Supply.new` silently. Behavior divergence beyond repr.
 
 ---
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,17 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-22: `Supply.new` throws X::Supply::New (PLAN §8.15 slice)
+
+Rakudo forbids constructing a Supply directly — live supplies come from a Supplier,
+on-demand ones from `Supply.on-demand` / `supply { }` blocks. mutsu silently built a bare
+instance. The `.new` dispatch arm now throws the typed `X::Supply::New` with Rakudo's
+message; internal builders (`1.Supply`, `Supplier.Supply`, Proc streams, ...) assemble
+their instances directly and are unaffected (the now-unreachable `make_supply_instance`
+helper was removed). `t/concurrency-basic.t`'s live-supply section was itself non-raku
+(`Supply.new` + `Supply.emit`) and is rewritten onto `Supplier.new` + `.Supply` +
+`Supplier.emit`. Pin: `t/supply-new-dies.t` (verified green under the reference `raku`).
+
 ## 2026-07-22: Channel, the schedulers, and Supplier get their Rakudo reprs (PLAN §8.15 slice)
 
 Three more §8.15 repr items closed: `Channel.new.raku`/`.gist` rendered the bare type name

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -692,7 +692,12 @@ impl Interpreter {
                         HashMap::new(),
                     ));
                 }
-                "Supply" => return Ok(self.make_supply_instance()),
+                // A Supply cannot be constructed directly (Rakudo throws
+                // X::Supply::New); live supplies come from a Supplier, on-demand
+                // ones from `Supply.on-demand` / `supply { }`. Internal builders
+                // (1.Supply, Supplier.Supply, Proc streams, ...) assemble their
+                // Supply instances directly.
+                "Supply" => return Err(RuntimeError::supply_new()),
                 "Supplier" | "Supplier::Preserving" => {
                     // Shared with the VM's native fast path
                     // (`try_native_builtin_construct`).

--- a/src/runtime/resolution_call_sub.rs
+++ b/src/runtime/resolution_call_sub.rs
@@ -62,15 +62,6 @@ impl Interpreter {
         Value::make_instance(Symbol::intern("Promise"), attrs)
     }
 
-    pub(super) fn make_supply_instance(&self) -> Value {
-        let sid = super::native_methods::next_supply_id();
-        let mut attrs = HashMap::new();
-        attrs.insert("values".to_string(), Value::array(Vec::new()));
-        attrs.insert("taps".to_string(), Value::array(Vec::new()));
-        attrs.insert("supply_id".to_string(), Value::int(sid as i64));
-        Value::make_instance(Symbol::intern("Supply"), attrs)
-    }
-
     pub(crate) fn call_sub_value(
         &mut self,
         func: Value,

--- a/src/value/error_typed.rs
+++ b/src/value/error_typed.rs
@@ -155,6 +155,17 @@ impl RuntimeError {
         Self::typed("X::Immutable", attrs)
     }
 
+    /// X::Supply::New - Supply cannot be constructed directly
+    pub(crate) fn supply_new() -> Self {
+        let msg = "Cannot directly create a Supply. You might want:\n \
+                   - To use a Supplier in order to get a live supply\n \
+                   - To use Supply.on-demand to create an on-demand supply\n \
+                   - To create a Supply using a supply block";
+        let mut attrs = HashMap::new();
+        attrs.insert("message".to_string(), Value::str(msg.to_string()));
+        Self::typed("X::Supply::New", attrs)
+    }
+
     /// X::Cannot::Lazy - Cannot .elems a lazy list
     pub(crate) fn cannot_lazy(action: &str) -> Self {
         let msg = format!("Cannot .{} a lazy list", action);

--- a/t/concurrency-basic.t
+++ b/t/concurrency-basic.t
@@ -19,9 +19,10 @@ is $c.receive, 2, 'channel receive second';
 $c.close;
 ok $c.closed, 'channel closed';
 
-my $s = Supply.new();
+my $sup = Supplier.new;
+my $s = $sup.Supply;
 my $sum = 0;
 $s.tap(-> $x { $sum += $x });
-$s.emit(2);
-$s.emit(3);
+$sup.emit(2);
+$sup.emit(3);
 is $sum, 5, 'supply tap receives emitted values';

--- a/t/supply-new-dies.t
+++ b/t/supply-new-dies.t
@@ -1,0 +1,27 @@
+use v6;
+use Test;
+
+plan 5;
+
+# A Supply cannot be constructed directly (PLAN.md §8.15): Rakudo throws
+# X::Supply::New pointing at Supplier / Supply.on-demand / supply blocks.
+
+throws-like { Supply.new }, X::Supply::New,
+    message => /'Cannot directly create a Supply'/,
+    'Supply.new throws X::Supply::New';
+
+# The supported construction paths still work.
+my $sup = Supplier.new;
+isa-ok $sup.Supply, Supply, 'Supplier.Supply gives a live supply';
+isa-ok 1.Supply, Supply, '.Supply coercion works';
+
+my $sum = 0;
+my $s = $sup.Supply;
+$s.tap(-> $x { $sum += $x });
+$sup.emit(2);
+$sup.emit(3);
+is $sum, 5, 'live supply taps still receive values';
+
+my @got;
+(supply { emit 7; emit 8 }).tap(-> $x { @got.push($x) });
+is-deeply @got, [7, 8], 'supply blocks still work';


### PR DESCRIPTION
Closes the `Supply.new` item of PLAN.md §8.15 (repr oracle sweep).

Rakudo forbids constructing a Supply directly:

```
$ raku -e 'Supply.new'
Cannot directly create a Supply. You might want:
 - To use a Supplier in order to get a live supply
 - To use Supply.on-demand to create an on-demand supply
 - To create a Supply using a supply block
```

mutsu silently built a bare instance. The `.new` dispatch arm now throws the typed `X::Supply::New` with Rakudo's message. Internal builders (`1.Supply`, `Supplier.Supply`, Proc streams, ...) assemble their Supply instances directly and are unaffected; the now-unreachable `make_supply_instance` helper is removed.

`t/concurrency-basic.t`'s live-supply section was itself non-raku (`Supply.new` + `Supply.emit`) and is rewritten onto `Supplier.new` + `.Supply` + `Supplier.emit`.

Pin: `t/supply-new-dies.t` (throws-like X::Supply::New + all supported construction paths still work; verified green under the reference `raku`). Local `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)