### PR TITLE
fix: a nested-sub `with $cc<key>` element topic reads the local container (URI 13/14)

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -221,14 +221,24 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   Array/Hash/ContainerRef container (`vm/vm_given_when_ops.rs`, `vm/vm_loop_writeback.rs`).
   `given %h<k>`/`given @a[i]` reassignment still writes back. Pin:
   `t/given-element-topic-readonly-writeback.t`.
-- **remaining (deeper, separate)**: (1) the *positional* form `with $cc[0]` still
-  corrupts `$cc` via a different path (NOT the writeback — it survives even with the
-  writeback guarded; a dual-store locals/env clobber when the block does not reference
-  `$cc`). (2) URI now advances past the `<scheme>` corruption but dies at
-  `URI::Authority` / `URI::Path` construction ("Default constructor ... only takes named
-  arguments") — a positional `Match:D` subcapture argument still arrives as a type object
-  and no user `multi method new(...:U: Match:D $x)` candidate matches. Both are the
-  positional-Match variant of the same dual-store issue.
+- **REAL ROOT CAUSE + FULL FIX (PR pending, `fix-nested-element-topic-local-read`)**:
+  the actual bug was the element-source **read**, not the writeback. `with $cc<key>` /
+  `with $cc[i]` lowers to a `TagElementSource` opcode that reads the container by *name*
+  via `get_env_with_main_alias`. Under the (B) per-store env-write gate (#4942, default
+  ON), a plain lexical in a **nested sub** is authoritative in its **local slot** with
+  its env mirror suppressed — so that env-name read missed `$cc`, returned Nil, and
+  indexing Nil bound `$_`/the pointy `-> $auth` to `Any`. Fix: read the live local slot
+  first (`gate_local_slot_value`) in the `TagElementSource` handler
+  (`vm/vm_exec_dispatch.rs`). This fixes BOTH the associative and the positional forms
+  (they were the same bug) and unblocks the whole URI parser. Pin:
+  `t/given-element-topic-nested-local.t`. (The earlier `fix-given-element-match-writeback`
+  guard is complementary and still correct — it stops a spurious no-op writeback from
+  corrupting a read-only Match — but the *nested Any* was this read fix.)
+- **URI now passes 13/14 test files** (01/authority/directory/escape/issue-43/
+  missing-components/mutate/november-urlencoded/path/query/rel2abs/require/
+  rfc-3986-examples all green; was 0). **Remaining: `utf8-c8.rakutest` only** — needs
+  the `utf8-c8` synthetic-codepoint encoding (`.slurp(:enc('utf8-c8'))` /
+  `uri-unescape(:enc('utf8-c8'))`), a separate niche encoding feature, NOT a T-031 bug.
 
 ### T-032 — test_die [ValueTypeCache] (same nqp cluster as T-027)  [impact: 1 dist]
 - dists: ValueTypeCache

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3288,8 +3288,16 @@ impl Interpreter {
                 // Read the element value `container[index]` and push it as the
                 // topic, reusing the standard index op so all container shapes
                 // (Array/Hash/ContainerRef/typed) are handled uniformly.
+                //
+                // Under the (B) per-store env-write gate, a plain lexical in a
+                // nested sub is authoritative in its local slot and its env
+                // mirror is suppressed, so `get_env_with_main_alias` misses it
+                // (returns Nil → indexing Nil yields `Any`). This broke
+                // `with $cc<key>` on a grammar Match subcapture held in a nested
+                // sub's `my $cc` (the URI dist). Read the live local slot first.
                 let cval = self
-                    .get_env_with_main_alias(&container)
+                    .gate_local_slot_value(code, &container)
+                    .or_else(|| self.get_env_with_main_alias(&container))
                     .unwrap_or(Value::NIL);
                 self.stack.push(cval);
                 self.stack.push(index.clone());

--- a/t/given-element-topic-nested-local.t
+++ b/t/given-element-topic-nested-local.t
@@ -1,0 +1,86 @@
+use v6;
+use Test;
+
+# A `given`/`with` topic that is a container element (`with $cc<key>` /
+# `with $cc[i]`) reads the element from the container variable named in the
+# topic. Under the per-store env-write gate, a plain lexical in a *nested* sub
+# is authoritative in its local slot and its env mirror is suppressed — so the
+# element-source read (`TagElementSource`), which looked the container up by
+# name in the env, missed it and bound `$_` to `Any` (indexing a Nil container).
+# This broke `with $cc<key>` on a grammar Match subcapture held in a nested
+# sub's `my $cc` — the shape at the heart of the URI dist's URI.new parser.
+
+plan 8;
+
+grammar G {
+    token TOP  { <uri> }
+    token uri  { <auth> '/' <rest> }
+    token auth { \w+ }
+    token rest { \w+ }
+}
+
+# Associative element topic on a Match subcapture, inside a nested sub.
+sub read-assoc($s) {
+    my $cc = G.parse($s)<uri>;
+    my $got;
+    with $cc<auth> { $got = $_.Str }
+    $got;
+}
+is read-assoc('foo/bar'), 'foo', 'nested with $cc<key> binds $_ to the subcapture';
+
+# Pointy form (the exact URI shape: `with $x<k> -> $auth { ... }`) — the bound
+# parameter must be a defined Match, not Any.
+sub read-pointy($s) {
+    my $cc = G.parse($s)<uri>;
+    my $type = 'none';
+    my $ok = False;
+    with $cc<auth> -> $auth {
+        $ok   = $auth.defined;
+        $type = $auth.Str;
+    }
+    ($ok, $type);
+}
+{
+    my ($ok, $type) = read-pointy('foo/bar');
+    ok $ok, 'nested with $cc<key> -> $auth binds a *defined* Match';
+    is $type, 'foo', 'the bound parameter carries the matched text';
+}
+
+# The bound Match must satisfy a `Match:D` parameter (URI passes it to
+# `Authority.new(Match:D $auth)`).
+sub recv(Match:D $c) { $c.Str }
+sub feed($s) {
+    my $cc = G.parse($s)<uri>;
+    my $r;
+    with $cc<auth> -> $auth { $r = recv($auth) }
+    $r;
+}
+is feed('foo/bar'), 'foo', 'nested with-bound Match satisfies a Match:D sub param';
+
+# Positional element topic on a Match subcapture, inside a nested sub.
+grammar GP { token TOP { (\w+) '/' (\w+) } }
+sub read-pos($s) {
+    my $m = GP.parse($s);
+    my $got;
+    with $m[0] { $got = $_.Str }
+    ($got, $m[1].Str);   # $m must still be usable afterwards
+}
+{
+    my ($got, $rest) = read-pos('foo/bar');
+    is $got, 'foo', 'nested with $m[i] binds $_ to the positional subcapture';
+    is $rest, 'bar', 'the sibling positional subcapture is still usable';
+}
+
+# Regression: hash-var / array-var element writeback still works (env-backed,
+# not gated locals), and a nested my-hash element reads correctly too.
+sub hash-nested() {
+    my %h = a => 1;
+    my $seen;
+    with %h<a> { $seen = $_ }
+    ($seen, %h<a>);
+}
+{
+    my ($seen, $v) = hash-nested();
+    is $seen, 1, 'nested with %h<k> reads the element';
+    is $v, 1, 'read-only nested with %h<k> leaves the element unchanged';
+}


### PR DESCRIPTION
## Summary

A `given`/`with` topic that is a container element (`with $cc<key>` / `with $cc[i]`) lowers to a `TagElementSource` opcode that reads the container by **name** via `get_env_with_main_alias`. Under the per-store env-write gate (#4942, default ON), a plain lexical in a **nested sub** is authoritative in its **local slot** with its env mirror suppressed — so that env-name read missed `$cc`, returned Nil, and indexing Nil bound `$_` (and the pointy `-> $auth` parameter) to `Any`.

This is why `with $cc<scheme>` on a grammar `Match` subcapture held in a nested sub's `my $cc` produced an undefined topic — the exact shape at the heart of the URI dist's `URI.new` parser (`with $comp_container<authority> -> $auth { Authority.new($auth) }`).

## Fix

Read the live local slot first (`gate_local_slot_value`) in the `TagElementSource` handler (`vm/vm_exec_dispatch.rs`), falling back to the env read. One change fixes **both** the associative (`$cc<key>`) and positional (`$cc[i]`) element-topic forms — they were the same bug.

## Impact

Root-causes and closes **T-031 (URI)**. URI now passes **13/14 test files** (01, authority, directory, escape, issue-43, missing-components, mutate, november-urlencoded, path, query, rel2abs, require, rfc-3986-examples — all green; was **0**). The one remaining file, `utf8-c8.rakutest`, needs the unrelated `utf8-c8` synthetic-codepoint encoding.

Complements #5226 (the writeback guard), which is still correct.

## Test

Pin: `t/given-element-topic-nested-local.t` (8 cases: associative + positional subcaptures, pointy `-> $auth` binding, `Match:D` sub-param, hash-var regression — raku-clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)