### PR TITLE
fix: Proc.new.gist is no longer -1 — drop the native Str/gist exitcode arm

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1393,11 +1393,13 @@ item also showed `[:a].raku` renders `[:a]` where raku spells `[:a(Bool::True)]`
 - [ ] **A one-element array holding an Iterable renders without the trailing comma:**
       `[HyperSeq].raku` → mutsu `[HyperSeq]`, raku `[HyperSeq,]` (disambiguates from
       flattening). Applies to Iterable type objects and likely itemized list elements.
-- [ ] **`Proc.new.gist` is `-1`** — Proc's gist/Str delegate to its `.Numeric` (exitcode
-      -1 when not run) instead of the default instance form; raku renders
-      `Proc.new(in => IO::Pipe, out => IO::Pipe, err => IO::Pipe, os-error => Str,
-      exitcode => Nil, signal => Any, pid => Nil, command => [])`. `Proc.new.raku` is
-      likewise attribute-less (`Proc.new`).
+- [ ] **`Proc.raku`/`.gist` render no attributes** (`Proc.new`); raku renders the full
+      form `Proc.new(in => IO::Pipe, out => IO::Pipe, err => IO::Pipe, os-error => Str,
+      exitcode => Nil, signal => Any, pid => Nil, command => [])` — for a *run* proc even
+      with a cyclic `(my \Proc_... = ...)` backref through its IO::Pipe. Needs Proc's
+      public attributes registered (its ClassDef has none) with type-object defaults.
+      (The worse half — gist/Str delegating to `.Numeric`, so `Proc.new.gist` was `-1` —
+      was fixed with `t/proc-gist-not-exitcode.t`.)
 - [ ] **`IO::Spec::Unix.new.raku` renders the type-object form `IO::Spec::Unix`** and its
       gist is `(Unix)`; raku renders `IO::Spec::Unix.new` for both.
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,16 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-22: `Proc.new.gist` is no longer `-1` (PLAN §8.15 slice)
+
+Proc's registered native `Str`/`gist` rendered the exitcode number (`-1` for a fresh
+Proc) — Rakudo's Proc has no stringifier of its own, so the default instance repr
+applies. The native `Str`/`gist` arms are removed and Proc now gists/rakus as `Proc.new`
+(the numeric `.Numeric`/`.Int`/`.Bool` coercions are untouched). Rendering the full
+Rakudo attribute form (`in => IO::Pipe, ..., command => []`, with the run-proc cyclic
+backref) stays recorded in §8.15 — it needs Proc's public attributes registered.
+Pin: `t/proc-gist-not-exitcode.t` (verified green under the reference `raku`).
+
 ## 2026-07-22: `Supply.new` throws X::Supply::New (PLAN §8.15 slice)
 
 Rakudo forbids constructing a Supply directly — live supplies come from a Supplier,

--- a/src/runtime/native_methods/proc.rs
+++ b/src/runtime/native_methods/proc.rs
@@ -327,13 +327,6 @@ impl Interpreter {
                 };
                 Value::truth(exitcode == 0)
             }
-            "Str" | "gist" => {
-                let exitcode = match attributes.get("exitcode").map(Value::view) {
-                    Some(ValueView::Int(c)) => c,
-                    _ => -1,
-                };
-                Value::str(exitcode.to_string())
-            }
             _ => Value::NIL,
         }
     }

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -397,9 +397,12 @@ impl Interpreter {
                 parents: Vec::new(),
                 attributes: Vec::new(),
                 methods: HashMap::new(),
+                // `Str`/`gist` are NOT native: Rakudo's Proc has no stringifier
+                // of its own, so the default instance repr applies (`Proc.new`),
+                // not the exitcode number the old native arm rendered.
                 native_methods: [
                     "exitcode", "signal", "command", "pid", "err", "out", "in", "Numeric", "Int",
-                    "Bool", "Str", "gist", "spawn", "shell", "run",
+                    "Bool", "spawn", "shell", "run",
                 ]
                 .iter()
                 .map(|s| s.to_string())

--- a/t/proc-gist-not-exitcode.t
+++ b/t/proc-gist-not-exitcode.t
@@ -1,0 +1,18 @@
+use v6;
+use Test;
+
+plan 5;
+
+# Proc has no stringifier of its own in Rakudo, so its gist is the default
+# instance repr — NOT the exitcode number the old native Str/gist arm
+# rendered (`Proc.new.gist` was `-1`).
+
+like Proc.new.gist, /^ 'Proc.new'/, 'fresh Proc gist is the instance form';
+like Proc.new.raku, /^ 'Proc.new'/, 'fresh Proc raku likewise';
+
+my $p = run $*EXECUTABLE, '-e', '', :out;
+# (Rakudo renders a run Proc with a cyclic backref binding, `(my \Proc_... =
+# Proc.new(...))`; mutsu renders the plain instance form for now.)
+like $p.gist, /^ [ 'Proc.new' | '(my \Proc_' ]/, 'a run Proc gists as an instance, not a number';
+is $p.exitcode, 0, 'exitcode accessor unaffected';
+is (run $*EXECUTABLE, '-e', 'exit 3', :out).exitcode, 3, 'nonzero exitcode unaffected';


### PR DESCRIPTION
Closes the worse half of the Proc item of PLAN.md §8.15 (repr oracle sweep).

## Before / after

```raku
say Proc.new.gist;   # was: -1        now: Proc.new
say Proc.new.raku;   # Proc.new (unchanged)
say (run 'true');    # was: 0         now: Proc.new
```

Proc's registered native `Str`/`gist` rendered the exitcode number (`-1` for a fresh Proc). Rakudo's Proc has no stringifier of its own, so the default instance repr applies. The native `Str`/`gist` arms are removed; the numeric `.Numeric`/`.Int`/`.Bool` coercions are untouched.

Rendering the full Rakudo attribute form (`Proc.new(in => IO::Pipe, ..., command => [])`, with the run-proc cyclic backref through its IO::Pipe) stays recorded in §8.15 — it needs Proc's public attributes registered (its ClassDef currently has none).

Pin: `t/proc-gist-not-exitcode.t` (5 assertions, verified green under the reference `raku`). Local `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)