### PR TITLE
fix: =begin pod is a Pod::Block::Named; :key<> pod config is a fatal error

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -359,11 +359,23 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   checks `&term:<G>.defined`, which now works.
 - file: `src/runtime/runtime_module.rs`, `src/runtime/runtime_module_exports.rs`
 
-### T-043 — test_fail: bad pod string  [impact: 1 dist]
-- dists: RakupodObject
-- e.g. `RakupodObject`: base=1 pass=0 fail=1 die=0 | t/1-critical.t: bad pod string
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
+### T-043 — test_fail: bad pod string  [impact: 1 dist]  — FIXED (PR `fix-pod-block-named-empty-config`)
+- dists: RakupodObject (t/1-critical.t: 6/10 → 10/10)
+- Two general bugs behind the RakupodObject failures:
+  1. **`=begin pod ... =end pod` produced a bare `Pod::Block`** instead of a
+     `Pod::Block::Named` named `"pod"` (raku: `$=pod[0].^name eq 'Pod::Block::Named'`,
+     `.name eq 'pod'`). `isa-ok $good, Pod::Block::Named` failed. Fixed in
+     `io_pod_entries.rs` / `io_pod_blocks.rs`: the `target == "pod"` arm now calls
+     `make_pod_named_with_config("pod", contents, config)` (config parsed from the
+     directive tail), so `=begin pod :attr<x>` carries config too.
+  2. **`:key<>` (empty angle brackets) in Pod config was silently accepted** as an
+     empty string; raku treats it as a fatal compile error
+     ("Invalid key (K) / colonpair (:K<>) combo in pod config string"), so
+     `dies-ok { extract-rakupod-object $bad-pod }` failed. `parse_pod_config`
+     (`io_pod_config.rs`) now records the offending colonpair in a thread-local;
+     `collect_pod_blocks` returns `Result` and surfaces it — `run.rs` propagates it
+     (top-level SORRY) and `system_eval_string.rs` short-circuits EVAL. `:key< >`
+     (a space) stays valid. Pin: `t/pod-block-named-and-empty-config.t`.
 
 ### T-044 — test_fail: can we access existing key (N)  [impact: 1 dist]
 - dists: Hash::str

--- a/src/runtime/io_pod_blocks.rs
+++ b/src/runtime/io_pod_blocks.rs
@@ -1,7 +1,8 @@
 use super::*;
 
 impl Interpreter {
-    pub(super) fn collect_pod_blocks(&mut self, input: &str) {
+    pub(super) fn collect_pod_blocks(&mut self, input: &str) -> Result<(), RuntimeError> {
+        Self::clear_pod_config_error();
         let lines: Vec<&str> = input.lines().collect();
         let mut entries = Vec::new();
         let mut idx = 0usize;
@@ -234,7 +235,9 @@ impl Interpreter {
                     let (contents, next_idx) =
                         Self::collect_pod_entries(&lines, idx + 1, Some(target));
                     if target == "pod" {
-                        entries.push(Self::make_pod_block(contents));
+                        let after_target = rest.strip_prefix(target).unwrap_or("");
+                        let (config, _) = Self::parse_pod_config(after_target);
+                        entries.push(Self::make_pod_named_with_config("pod", contents, config));
                     } else if let Some(level) = Self::parse_heading_level(target) {
                         entries.push(Self::make_pod_heading(level, contents));
                     } else {
@@ -287,5 +290,9 @@ impl Interpreter {
             idx += 1;
         }
         self.env.insert("=pod".to_string(), Value::array(entries));
+        if let Some(err) = Self::take_pod_config_error() {
+            return Err(err);
+        }
+        Ok(())
     }
 }

--- a/src/runtime/io_pod_config.rs
+++ b/src/runtime/io_pod_config.rs
@@ -1,6 +1,24 @@
 use super::*;
+use std::cell::RefCell;
+
+thread_local! {
+    /// Records the first invalid Pod config colonpair (e.g. `:key<>`) seen while
+    /// parsing a Pod document. `collect_pod_blocks` clears this before parsing and
+    /// surfaces it as a fatal error afterwards, matching Rakudo's compile-time SORRY.
+    static POD_CONFIG_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
+}
 
 impl Interpreter {
+    /// Clear any pending Pod config error before parsing a fresh document.
+    pub(crate) fn clear_pod_config_error() {
+        POD_CONFIG_ERROR.with(|e| *e.borrow_mut() = None);
+    }
+
+    /// Take the pending Pod config error, if any (e.g. from a `:key<>` colonpair).
+    pub(crate) fn take_pod_config_error() -> Option<RuntimeError> {
+        POD_CONFIG_ERROR.with(|e| e.borrow_mut().take().map(RuntimeError::new))
+    }
+
     /// Parse Pod config adverbs from a directive tail.
     /// Supports all Raku Pod config value forms including `:key<str>`, `:key(val)`,
     /// `:key[val]`, `:key{k=>v}`, `:!key`, `:NNNkey`, lists, hashes, typed scalars.
@@ -52,6 +70,18 @@ impl Interpreter {
             let (value, after_val) = if let Some(after_open) = after_name.strip_prefix('<') {
                 // :key<value> -- angle bracket form (always Str)
                 if let Some(close_idx) = after_open.find('>') {
+                    // `:key<>` (empty angle brackets) is a fatal Pod config error
+                    // in Raku ("Invalid key / colonpair combo in pod config string").
+                    if close_idx == 0 {
+                        POD_CONFIG_ERROR.with(|e| {
+                            let mut slot = e.borrow_mut();
+                            if slot.is_none() {
+                                *slot = Some(format!(
+                                    "Invalid key ({name}) / colonpair (:{name}<>) combo in pod config string"
+                                ));
+                            }
+                        });
+                    }
                     let raw = &after_open[..close_idx];
                     (Value::str(raw.to_string()), &after_open[close_idx + 1..])
                 } else {

--- a/src/runtime/io_pod_entries.rs
+++ b/src/runtime/io_pod_entries.rs
@@ -502,7 +502,9 @@ impl Interpreter {
                     let (contents, next_idx) =
                         Self::collect_pod_entries(lines, idx + 1, Some(target));
                     if target == "pod" {
-                        entries.push(Self::make_pod_block(contents));
+                        let after_target = rest.strip_prefix(target).unwrap_or("");
+                        let (config, _) = Self::parse_pod_config(after_target);
+                        entries.push(Self::make_pod_named_with_config("pod", contents, config));
                     } else if let Some(level) = Self::parse_heading_level(target) {
                         entries.push(Self::make_pod_heading(level, contents));
                     } else {

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -50,7 +50,9 @@ impl Interpreter {
                 .insert("*PROGRAM".to_string(), Value::str(String::new()));
         }
         self.collect_doc_comments(&preprocessed);
-        self.collect_pod_blocks(&preprocessed);
+        // A `:key<>` colonpair (empty angle brackets) in Pod config is a fatal
+        // compile error in Raku; surface it before running the program.
+        self.collect_pod_blocks(&preprocessed)?;
         self.add_declarator_pod_entries();
         let file_name = self
             .program_path

--- a/src/runtime/system_eval_string.rs
+++ b/src/runtime/system_eval_string.rs
@@ -290,7 +290,10 @@ impl Interpreter {
                 .filter(|k| k.starts_with('&')),
         );
         self.env.insert("__mutsu_in_eval".to_string(), Value::TRUE);
-        self.collect_pod_blocks(trimmed);
+        // A `:key<>` colonpair (empty angle brackets) in the EVAL'd source's Pod
+        // is a fatal compile error in Raku; short-circuit before evaluating.
+        let pod_err = self.collect_pod_blocks(trimmed).err();
+        let pod_failed = pod_err.is_some();
         // Collect operator sub names so the parser recognizes them in EVAL context
         let op_names = self.collect_operator_sub_names();
         let op_assoc = self.collect_operator_assoc_map();
@@ -298,7 +301,9 @@ impl Interpreter {
         let bracketed_stmt_inner = unwrap_bracketed_statements(trimmed)
             .filter(|inner| looks_like_bracketed_statement_list(inner));
         // General case: parse and evaluate as Raku code
-        let mut result = if let Some(inner) = bracketed_stmt_inner {
+        let mut result = if let Some(err) = pod_err {
+            Err(err)
+        } else if let Some(inner) = bracketed_stmt_inner {
             // EVAL q[[ ... ]] can yield one wrapper [] around statement lists.
             self.parse_and_eval_with_operators(inner, &op_names, &op_assoc, &imported_names)
                 .or_else(|_| {
@@ -317,7 +322,8 @@ impl Interpreter {
         }
         // Fallback: parser still rejects forms like `~< foo bar >`.
         // Rewrite to an equivalent parenthesized form and try again.
-        if result.is_err()
+        if !pod_failed
+            && result.is_err()
             && let Some(rewritten) = rewrite_prefixed_angle_list(trimmed)
         {
             result = self.parse_and_eval_with_operators(
@@ -328,14 +334,16 @@ impl Interpreter {
             );
         }
         // Accept parenthesized statement lists like `(6;)` in EVAL.
-        if result.is_err()
+        if !pod_failed
+            && result.is_err()
             && let Some(inner) = unwrap_parenthesized_statements(trimmed)
         {
             result =
                 self.parse_and_eval_with_operators(inner, &op_names, &op_assoc, &imported_names);
         }
         // EVAL q[[ ... ]] sometimes carries one outer statement-list bracket pair.
-        if result.is_err()
+        if !pod_failed
+            && result.is_err()
             && bracketed_stmt_inner.is_none()
             && let Some(inner) = unwrap_bracketed_statements(trimmed)
         {
@@ -344,7 +352,8 @@ impl Interpreter {
         }
         // EVAL should accept routine declarations in snippet context.
         // If unit-scope parsing rejects a declaration, retry inside an implicit block.
-        if result.is_err()
+        if !pod_failed
+            && result.is_err()
             && trimmed.contains("sub ")
             && let Some(err) = result.as_ref().err()
             && err.message.contains("X::UnitScope::Invalid")

--- a/t/pod-block-named-and-empty-config.t
+++ b/t/pod-block-named-and-empty-config.t
@@ -1,0 +1,65 @@
+use Test;
+
+plan 8;
+
+# `=begin pod ... =end pod` yields a Pod::Block::Named named "pod", not a bare
+# Pod::Block (RakupodObject T-043).
+{
+    my $doc = q:to/POD/;
+    =begin pod
+    Hello
+    =end pod
+    POD
+    use MONKEY-SEE-NO-EVAL;
+    my $pod;
+    EVAL($doc ~ "\n\$pod = \$=pod[0]");
+    isa-ok $pod, Pod::Block::Named, 'pod block is Pod::Block::Named';
+    ok $pod ~~ Pod::Block, 'pod block is-a Pod::Block';
+    is $pod.name, 'pod', 'named block name is "pod"';
+}
+
+# `=begin pod :attr<x>` carries config through to the named block.
+{
+    my $doc = q:to/POD/;
+    =begin pod :status<draft>
+    Hi
+    =end pod
+    POD
+    use MONKEY-SEE-NO-EVAL;
+    my $pod;
+    EVAL($doc ~ "\n\$pod = \$=pod[0]");
+    is $pod.config<status>, 'draft', 'pod block config is captured';
+}
+
+# `:key<>` (empty angle brackets) is a fatal Pod config error in Raku.
+{
+    use MONKEY-SEE-NO-EVAL;
+    dies-ok {
+        EVAL("=begin pod\n=begin code :lang<>\nx\n=end code\n=end pod\n\$=pod[0]");
+    }, 'empty <> colonpair in pod config dies';
+
+    dies-ok {
+        EVAL("=begin pod :foo<>\nx\n=end pod\n\$=pod[0]");
+    }, 'empty <> colonpair on the pod directive dies';
+}
+
+# A space inside the angle brackets is a valid (non-empty) value, not an error.
+{
+    use MONKEY-SEE-NO-EVAL;
+    lives-ok {
+        EVAL("=begin pod\n=begin code :lang< >\nx\n=end code\n=end pod\n\$=pod[0]");
+    }, ':key< > (space) is a valid value, not empty';
+}
+
+# Named blocks other than "pod" keep their own name.
+{
+    my $doc = q:to/POD/;
+    =begin foo
+    Bar
+    =end foo
+    POD
+    use MONKEY-SEE-NO-EVAL;
+    my $pod;
+    EVAL($doc ~ "\n\$pod = \$=pod[0]");
+    is $pod.name, 'foo', 'other named blocks keep their name';
+}


### PR DESCRIPTION
## Summary

Fixes two general Pod bugs surfaced by the **RakupodObject** distribution
(dist-compat ticket **T-043**). `t/1-critical.t` goes from **6/10 → 10/10**,
matching raku.

### 1. `=begin pod` now produces a `Pod::Block::Named`

Raku exposes `$=pod[0]` for a `=begin pod ... =end pod` block as a
`Pod::Block::Named` with `.name eq 'pod'`; mutsu built a bare `Pod::Block`, so
`isa-ok $good, Pod::Block::Named` failed. The `target == "pod"` arm in both
`io_pod_entries.rs` and `io_pod_blocks.rs` now builds the block via
`make_pod_named_with_config("pod", contents, config)`, parsing config from the
directive tail so `=begin pod :attr<x>` carries it through.

### 2. `:key<>` in Pod config is now a fatal error

`:key<>` (empty angle brackets) in a Pod config directive is a **fatal compile
error** in raku:

```
Invalid key (lang) / colonpair (:lang<>) combo in pod config string
```

mutsu silently accepted it as an empty string, so `dies-ok { extract-rakupod-object $bad-pod }`
failed. `parse_pod_config` now records the offending colonpair in a thread-local;
`collect_pod_blocks` returns `Result` and surfaces it. `run.rs` propagates it
(top-level SORRY equivalent) and `system_eval_string.rs` short-circuits EVAL.
A space inside the brackets (`:key< >`) stays a valid, non-empty value.

## Testing

- `t/pod-block-named-and-empty-config.t` (new pin, verified identical output on raku)
- All whitelisted `roast/S26-documentation/*` tests pass
- `make test`: PASS (21583 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)