### PR TITLE
fix: grammar instance .parse and negated Unicode property minus enum class (vCard::Parser T-033)

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -255,9 +255,30 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 
 ### T-033 — test_die [vCard::Parser]  [impact: 1 dist]
 - dists: vCard::Parser
-- e.g. `vCard::Parser`: base=2 pass=1 fail=0 die=1 | t/02-grammar.rakutest: 
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
+- e.g. `vCard::Parser`: base=2 pass=1 fail=0 die=1 | t/02-grammar.rakutest:
+- **TWO ROOT CAUSES FIXED (PR `fix-grammar-instance-parse-and-negated-prop-subtract`).**
+  The test builds `my $g = vCard::Parser::Grammar.new` and calls `$g.parse(...)`.
+  1. **Grammar *instance* `.parse`/`.subparse`/`.parsefile` was not dispatched.**
+     mutsu resolved these only on the grammar *type object* (`ValueView::Package`); an
+     instance (`ValueView::Instance`) fell through to "No such method 'parse'", so
+     02-grammar died before any test ran (`ran 0`). Fix: route a grammar instance
+     (`class_is_grammar` — MRO contains `Grammar`) to the same `dispatch_package_parse`
+     as the type object (`methods_dispatch_match.rs`, `runtime_class_query.rs`). Pin:
+     `t/grammar-instance-parse.t`.
+  2. **`<-:C-[:;,"]>` dropped the enumerated subtraction.** A negated Unicode property
+     (`-:C`) joined by a top-level `-[...]` set operator was parsed as a bare negated
+     property, silently discarding the `-[:;,"]` term — so `safe-char` matched the
+     excluded `:`/`;`/`,`/`"`, over-consuming and failing `content-line`. Fix: the
+     `-:`/`:!` assertion branch now routes to `parse_combined_class` when
+     `has_top_level_combine_op` is present (`regex_parse_core.rs`). Pin:
+     `t/regex-negated-property-minus-enum.t`.
+- **Status:** 02-grammar 0 → 19/23 (was `ran 0`). **Remaining (separate, deeper — not
+  this ticket):** (a) `<property-value>+ % <[;]>` with **empty-matching** elements
+  (`N:;Gump;Forrest;;Mr.;` → 6 values incl. 3 empty) fails the whole `content-line`
+  match — an empty-element `+ % sep` quantifier-separator bug; (b) `parsefile` of a
+  full multi-vcard file (test-card1/2) fails while test-card4 passes.
+- file: DONE — src/runtime/methods_dispatch_match.rs, runtime_class_query.rs,
+  regex_parse_core.rs; remaining — empty-element `+ % sep`, multi-vcard parsefile.
 
 ### T-036 — test_die: plan expects Int (plan * fixed; deeper cardinal bugs remain)  [impact: 1 dist]
 - dists: Lingua::EN::Numbers

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -198,10 +198,19 @@ impl Interpreter {
             "enums" => self.dispatch_enums(&target),
             "invert" => self.dispatch_invert_enum(&target),
             "subparse" | "parse" | "parsefile" => {
-                if let ValueView::Package(package_name) = target.view() {
-                    Some(self.dispatch_package_parse(&package_name.resolve(), method, &args))
-                } else {
-                    None
+                match target.view() {
+                    ValueView::Package(package_name) => {
+                        Some(self.dispatch_package_parse(&package_name.resolve(), method, &args))
+                    }
+                    // A grammar *instance* (`G.new`) dispatches `.parse` just like
+                    // the type object; grammars are stateless so the instance name
+                    // is its grammar package name.
+                    ValueView::Instance { class_name, .. }
+                        if self.class_is_grammar(&class_name.resolve()) =>
+                    {
+                        Some(self.dispatch_package_parse(&class_name.resolve(), method, &args))
+                    }
+                    _ => None,
                 }
             }
             "match" => Some(self.dispatch_match_method(target, &args)),

--- a/src/runtime/regex_parse.rs
+++ b/src/runtime/regex_parse.rs
@@ -1131,6 +1131,37 @@ pub(super) fn has_top_level_combine_op(s: &str) -> bool {
     false
 }
 
+/// Whether a combined-class body has at least one top-level set operator and
+/// ALL of them are subtractions (`-`), no top-level `+` union. Used to decide
+/// whether a leading negated property (`<-:C-[:;,"]>`) can fold safely into a
+/// single negated char class: with only subtractions the combined-class parser
+/// leaves the positive-item set empty and returns the correct "full set minus
+/// everything" class. A top-level `+` would introduce a positive item whose
+/// semantics diverge from Raku's full-set base, so those are excluded.
+pub(super) fn top_level_combine_is_subtractive(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    let mut depth = 0i32;
+    let mut saw_subtraction = false;
+    for i in 0..bytes.len() {
+        match bytes[i] {
+            b'(' | b'<' => depth += 1,
+            b')' | b'>' => depth -= 1,
+            b'+' if depth == 0 => return false,
+            b'-' if depth == 0 => {
+                let prev_word =
+                    i > 0 && (bytes[i - 1].is_ascii_alphanumeric() || bytes[i - 1] == b'_');
+                let next_word = i + 1 < bytes.len()
+                    && (bytes[i + 1].is_ascii_alphanumeric() || bytes[i + 1] == b'_');
+                if !(prev_word && next_word) {
+                    saw_subtraction = true;
+                }
+            }
+            _ => {}
+        }
+    }
+    saw_subtraction
+}
+
 /// Skip `<[...]>` character class content where quotes are literal.
 pub(super) fn skip_char_class_content(
     chars: &mut std::iter::Peekable<std::str::Chars>,

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -2106,11 +2106,32 @@ impl Interpreter {
                                 } else if trimmed.starts_with(":!") || trimmed.starts_with("-:") {
                                     // <:!PropName> or <-:PropName> — negated Unicode property
                                     let prop_name = &trimmed[2..];
-                                    let (pname, pargs) = split_prop_args(prop_name);
-                                    RegexAtom::UnicodeProp {
-                                        name: pname.to_string(),
-                                        negated: true,
-                                        args: pargs.map(|s| s.to_string()),
+                                    if top_level_combine_is_subtractive(prop_name) {
+                                        // `<-:C-[:;,"]>` — a negated property followed by a
+                                        // top-level `-[...]`/`-name` set *subtraction*. The
+                                        // whole class starts from the full character set
+                                        // (leading `-`), so route it to the combined-class
+                                        // parser as a leading *negative* item (`-:C-[:;,"]`);
+                                        // its purely-subtractive terms fold into a single
+                                        // negated char class. Both `:!P` and `-:P` normalise
+                                        // to the `-:P` form. (A tail containing a top-level
+                                        // `+` union is left to the plain-property path: the
+                                        // combined-class parser's positive-item semantics do
+                                        // not match Raku's full-set base there.)
+                                        if let Some(atom) = self
+                                            .parse_combined_class(&format!("-:{prop_name}"), mode)
+                                        {
+                                            atom
+                                        } else {
+                                            continue;
+                                        }
+                                    } else {
+                                        let (pname, pargs) = split_prop_args(prop_name);
+                                        RegexAtom::UnicodeProp {
+                                            name: pname.to_string(),
+                                            negated: true,
+                                            args: pargs.map(|s| s.to_string()),
+                                        }
                                     }
                                 } else if let Some(prop_name) = trimmed.strip_prefix(':') {
                                     // `<:Ll+:N>` / `<:Ll-:Lu>` — a compact combined

--- a/src/runtime/runtime_class_query.rs
+++ b/src/runtime/runtime_class_query.rs
@@ -103,6 +103,37 @@ impl Interpreter {
         false
     }
 
+    /// Whether a user-declared class `name` is (or inherits from) a `Grammar`.
+    /// A `grammar G { ... }` declaration lowers to a class whose parent chain
+    /// contains `Grammar`, so a grammar *instance* (`G.new`) can be recognised
+    /// and routed to the grammar `.parse`/`.subparse`/`.parsefile` dispatch just
+    /// like the type object. Walks the registry parent chain with a shared borrow.
+    pub(crate) fn class_is_grammar(&self, name: &str) -> bool {
+        if name == "Grammar" {
+            return true;
+        }
+        let parents = {
+            let reg = self.registry();
+            reg.classes
+                .get(name)
+                .or_else(|| {
+                    reg.classes
+                        .iter()
+                        .find(|(k, _)| k.rsplit_once("::").is_some_and(|(_, short)| short == name))
+                        .map(|(_, v)| v)
+                })
+                .map(|cd| cd.parents.clone())
+        };
+        if let Some(parents) = parents {
+            for parent in &parents {
+                if parent == "Grammar" || self.class_is_grammar(parent) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     /// Check if a class inherits from an immutable Setty type (Set, Bag, Mix).
     /// Whether a user-declared class `name` inherits (transitively) from the base
     /// `Exception` type (or a built-in `X::`/`CX::` exception). Walks the registry

--- a/t/grammar-instance-parse.t
+++ b/t/grammar-instance-parse.t
@@ -1,0 +1,33 @@
+use Test;
+
+plan 8;
+
+# A grammar *instance* (`G.new`) dispatches `.parse`/`.subparse`/`.parsefile`
+# exactly like the grammar type object. (Regression: mutsu resolved these only
+# on the type object, so `G.new.parse(...)` died "No such method 'parse'".)
+
+grammar G {
+    token TOP  { <word>+ % \s+ }
+    token word { \w+ }
+}
+
+my $g = G.new;
+
+ok $g.parse('hello world'), 'instance .parse matches';
+is $g.parse('hello world').Str, 'hello world', 'instance .parse returns the full Match';
+ok $g.subparse('hello world trailing! rest'), 'instance .subparse matches a prefix';
+is $g.parse('hi', :rule<word>).Str, 'hi', 'instance .parse with :rule';
+nok $g.parse('!!!'), 'instance .parse fails on non-matching input';
+
+# subrule access on an instance-parsed Match
+my $m = $g.parse('foo bar');
+is $m<word>».Str.join(','), 'foo,bar', 'instance-parsed Match exposes subcaptures';
+
+# The type-object form still works identically.
+is G.parse('a b c').Str, 'a b c', 'type-object .parse still works';
+
+# parsefile on an instance
+my $tmp = $*TMPDIR.add("grammar-instance-{$*PID}.txt");
+$tmp.spurt("alpha beta");
+is $g.parsefile($tmp.Str).Str, 'alpha beta', 'instance .parsefile matches';
+$tmp.unlink;

--- a/t/regex-negated-property-minus-enum.t
+++ b/t/regex-negated-property-minus-enum.t
@@ -1,0 +1,24 @@
+use Test;
+
+plan 6;
+
+# `<-:C-[:;,"]>` — a negated Unicode property (`:C` control) combined with a
+# top-level `-[...]` enumerated subtraction. mutsu previously dropped the
+# `-[...]` term, so the class matched the excluded characters (`: ; , "`).
+
+grammar T {
+    token safe  { <-:C-[:;,"]>+ }
+    token a     { <-:C-[:;,]>+ }
+}
+
+# The enumerated exclusion is honoured: matching stops at the excluded char.
+is T.subparse('5:Bubba', :rule<safe>).Str, '5', 'excludes ":" after a property term';
+is T.subparse('work;x', :rule<safe>).Str, 'work', 'excludes ";" after a property term';
+is T.subparse('a,b', :rule<safe>).Str, 'a', 'excludes "," after a property term';
+is T.subparse('x"y', :rule<safe>).Str, 'x', 'excludes quote after a property term';
+
+# A full anchored parse: the whole string is safe (no excluded chars, no control).
+ok T.parse('HelloWorld', :rule<safe>), 'plain word matches the negated combined class';
+
+# The quoteless variant behaves identically.
+is T.subparse('5:Bubba', :rule<a>).Str, '5', 'property + enum subtraction (no quote in set)';


### PR DESCRIPTION
Two general grammar/regex fixes, both required by the **vCard::Parser** dist (T-033), whose tests build `my $g = Grammar.new` and call `$g.parse(...)`.

## 1. Grammar instance `.parse`/`.subparse`/`.parsefile`

mutsu resolved these only on the grammar *type object* (`ValueView::Package`); a grammar **instance** (`ValueView::Instance`, from `G.new`) fell through to `No such method 'parse'`, so vCard's `02-grammar` died before any test ran. A grammar is a class whose parent chain contains `Grammar`, so `class_is_grammar` recognises the instance and routes it to the same `dispatch_package_parse` as the type object (grammars are stateless).

```raku
grammar G { token TOP { \w+ } }
G.new.parse("hello")   # was: No such method 'parse'; now: 「hello」
```

## 2. `<-:C-[:;,"]>` dropped the enumerated subtraction

A negated Unicode property (`-:C`) followed by a top-level `-[...]` set subtraction was parsed as a single negated property, silently discarding the `-[:;,"]` term — so the excluded `: ; , "` were matched anyway, over-consuming and failing vCard's `safe-char`/`content-line`. When the tail is purely subtractive it now folds into a single negated char class via `parse_combined_class` (`top_level_combine_is_subtractive`). A tail with a top-level `+` union is left to the plain-property path (a separate, pre-existing niche gap — the combined-class parser's positive-item semantics don't match Raku's full-set base there).

```raku
grammar T { token safe { <-:C-[:;,"]>+ } }
T.subparse('5:Bubba', :rule<safe>).Str   # was '5:Bubba'; now '5' (stops at ':')
```

## Impact

vCard::Parser `02-grammar` goes from `ran 0` (died) → **19/23**. The remaining four failures are separate deeper issues (empty-matching `+ % sep` elements; multi-vcard `parsefile`), recorded in the T-033 ticket.

Pins: `t/grammar-instance-parse.t`, `t/regex-negated-property-minus-enum.t`

🤖 Generated with [Claude Code](https://claude.com/claude-code)