### PR TITLE
fix: distinguish big FatRat from big Rat with a representation flag

### DIFF
--- a/src/builtins/arith/mul_div_mod.rs
+++ b/src/builtins/arith/mul_div_mod.rs
@@ -307,14 +307,9 @@ pub(crate) fn arith_mod(left: Value, right: Value) -> Result<Value, RuntimeError
         let den = &ad * &bd;
         let has_fat_rat = is_fat_rat_like(&l) || is_fat_rat_like(&r);
         return Ok(if has_fat_rat {
-            // FatRat % ... stays a FatRat. make_big_fat_rat normalizes small
-            // results down to Rat, so re-tag those as FatRat.
-            let tmp = crate::value::make_big_fat_rat(num, den);
-            if let ValueView::Rat(n, d) = tmp.view() {
-                Value::fat_rat_raw(n, d)
-            } else {
-                tmp
-            }
+            // FatRat % ... stays a FatRat; make_big_fat_rat preserves the flavour
+            // whether the result reduces into i64 range or needs big integers.
+            crate::value::make_big_fat_rat(num, den)
         } else {
             crate::value::make_big_rat_arith(num, den)
         });

--- a/src/builtins/arith/pow_negate.rs
+++ b/src/builtins/arith/pow_negate.rs
@@ -191,12 +191,7 @@ pub(crate) fn arith_pow(left: Value, right: Value) -> Value {
                 } else {
                     let nn = NumBigInt::from(n).pow(p);
                     let dd = NumBigInt::from(d).pow(p);
-                    let tmp = make_big_fat_rat(nn, dd);
-                    if let ValueView::Rat(nn, dd) = tmp.view() {
-                        Value::fat_rat_raw(nn, dd)
-                    } else {
-                        tmp
-                    }
+                    make_big_fat_rat(nn, dd)
                 }
             }
             (ValueView::FatRat(n, d), ValueView::Int(b)) => {
@@ -209,12 +204,7 @@ pub(crate) fn arith_pow(left: Value, right: Value) -> Value {
                 } else {
                     let nn = NumBigInt::from(d).pow(p);
                     let dd = NumBigInt::from(n).pow(p);
-                    let tmp = make_big_fat_rat(nn, dd);
-                    if let ValueView::Rat(nn, dd) = tmp.view() {
-                        Value::fat_rat_raw(nn, dd)
-                    } else {
-                        tmp
-                    }
+                    make_big_fat_rat(nn, dd)
                 }
             }
             (ValueView::BigRat(n, d), ValueView::Int(b)) if b >= 0 => {

--- a/src/builtins/arith/rat.rs
+++ b/src/builtins/arith/rat.rs
@@ -95,7 +95,10 @@ pub(crate) fn needs_bigrat_path(l: &Value, r: &Value) -> bool {
 pub(crate) fn is_fat_rat_like(v: &Value) -> bool {
     match v.view() {
         ValueView::FatRat(_, _) => true,
-        ValueView::BigRat(_, d) => d.to_u64().is_none(),
+        // The FatRat flag is authoritative; the big-denominator check is a
+        // safety fallback (a plain Rat degrades to Num past u64, so any
+        // big-denominator rational must be a FatRat).
+        ValueView::BigRat(_, d) => v.is_bigfatrat() || d.to_u64().is_none(),
         _ => false,
     }
 }

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -367,6 +367,14 @@ pub(super) fn dispatch(
                 ValueView::Bool(b) => format!("Bool|{}", if b { 1 } else { 0 }),
                 ValueView::Rat(n, d) => format!("Rat|{}/{}", n, d),
                 ValueView::FatRat(n, d) => format!("FatRat|{}/{}", n, d),
+                ValueView::BigRat(n, d) => {
+                    let flavour = if target.is_bigfatrat() {
+                        "FatRat"
+                    } else {
+                        "Rat"
+                    };
+                    format!("{}|{}/{}", flavour, n, d)
+                }
                 ValueView::Complex(r, i) => format!("Complex|{}+{}i", r, i),
                 // An enum value's identity is `{EnumType}|{ordinal}` (raku:
                 // `Bob.WHICH` is `Names|0`, using the position in the enum, not

--- a/src/builtins/methods_0arg/dispatch_core_math.rs
+++ b/src/builtins/methods_0arg/dispatch_core_math.rs
@@ -3,7 +3,7 @@
 /// NFC/NFD/NFKC/NFKD
 use crate::runtime;
 use crate::symbol::Symbol;
-use crate::value::{RuntimeError, Value, ValueView, make_big_rat, make_rat};
+use crate::value::{RuntimeError, Value, ValueView, make_big_fat_rat, make_rat};
 use num_traits::ToPrimitive;
 
 use super::complex_math::complex_trig;
@@ -378,6 +378,10 @@ pub(super) fn dispatch(
         }
         "Rat" => Some(match target.view() {
             ValueView::Rat(_, _) => Some(Ok(target.clone())),
+            // A big FatRat coerces to a big Rat: drop the FatRat flag.
+            ValueView::BigRat(n, d) if target.is_bigfatrat() => {
+                Some(Ok(Value::bigrat(n.clone(), d.clone())))
+            }
             ValueView::BigRat(_, _) => Some(Ok(target.clone())),
             ValueView::Int(i) => Some(Ok(make_rat(i, 1))),
             ValueView::Num(f) => {
@@ -477,11 +481,14 @@ pub(super) fn dispatch(
         "FatRat" => Some(match target.view() {
             ValueView::FatRat(_, _) => Some(Ok(target.clone())),
             ValueView::Rat(n, d) => Some(Ok(Value::fat_rat_raw(n, d))),
-            ValueView::BigRat(_, _) => Some(Ok(target.clone())),
+            // A big FatRat stays as-is; a big Rat gains the FatRat flag.
+            ValueView::BigRat(_, _) if target.is_bigfatrat() => Some(Ok(target.clone())),
+            ValueView::BigRat(n, d) => Some(Ok(Value::bigfatrat(n.clone(), d.clone()))),
             ValueView::Int(i) => Some(Ok(Value::fat_rat_raw(i, 1))),
-            ValueView::BigInt(i) => {
-                Some(Ok(make_big_rat((**i).clone(), num_bigint::BigInt::from(1))))
-            }
+            ValueView::BigInt(i) => Some(Ok(make_big_fat_rat(
+                (**i).clone(),
+                num_bigint::BigInt::from(1),
+            ))),
             ValueView::Num(f) => {
                 if f.is_nan() {
                     Some(Ok(Value::fat_rat_raw(0, 0)))

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -145,6 +145,8 @@ pub(super) fn dispatch(
                 ))))
             } else if method == "gist" {
                 Some(Ok(Value::str(target.to_string_value())))
+            } else if target.is_bigfatrat() {
+                Some(Ok(Value::str(format!("FatRat.new({}, {})", n, d))))
             } else {
                 Some(Ok(Value::str(raku_value(target))))
             }

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -498,6 +498,14 @@ pub(crate) fn native_method_0arg(
                 ValueView::Num(n) => format!("Num|{}", n),
                 ValueView::Rat(n, d) => format!("Rat|{}/{}", n, d),
                 ValueView::FatRat(n, d) => format!("FatRat|{}/{}", n, d),
+                ValueView::BigRat(n, d) => {
+                    let flavour = if inner.as_ref().is_bigfatrat() {
+                        "FatRat"
+                    } else {
+                        "Rat"
+                    };
+                    format!("{}|{}/{}", flavour, n, d)
+                }
                 ValueView::Complex(r, i) => format!("Complex|{}+{}i", r, i),
                 _ => format!("{:?}", inner),
             };

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -59,6 +59,7 @@ impl Interpreter {
             ValueView::Hash(_) => "Hash",
             ValueView::Rat(_, _) => "Rat",
             ValueView::FatRat(_, _) => "FatRat",
+            ValueView::BigRat(_, _) if target.is_bigfatrat() => "FatRat",
             ValueView::BigRat(_, _) => "Rat",
             ValueView::Complex(_, _) => "Complex",
             ValueView::Set(_, false) => "Set",

--- a/src/runtime/utils/errors.rs
+++ b/src/runtime/utils/errors.rs
@@ -30,6 +30,7 @@ pub(crate) fn value_short_repr(val: &Value) -> String {
         ValueView::Num(n) => format!("({})", n),
         ValueView::Bool(b) => format!("({})", if b { "True" } else { "False" }),
         ValueView::Rat(n, d) => format!("({}/{})", n, d),
+        ValueView::BigRat(n, d) if val.is_bigfatrat() => format!("(FatRat.new({}, {}))", n, d),
         ValueView::BigRat(n, d) => format!("({}/{})", n, d),
         ValueView::FatRat(n, d) => format!("(FatRat.new({}, {}))", n, d),
         ValueView::Nil => "(Nil)".to_string(),
@@ -199,7 +200,14 @@ pub(crate) fn value_which_key(value: &Value) -> String {
         ValueView::Bool(b) => format!("Bool|{}", if b { 1 } else { 0 }),
         ValueView::Rat(n, d) => format!("Rat|{}/{}", n, d),
         ValueView::FatRat(n, d) => format!("FatRat|{}/{}", n, d),
-        ValueView::BigRat(n, d) => format!("Rat|{}/{}", n, d),
+        ValueView::BigRat(n, d) => {
+            let flavour = if value.is_bigfatrat() {
+                "FatRat"
+            } else {
+                "Rat"
+            };
+            format!("{}|{}/{}", flavour, n, d)
+        }
         ValueView::Complex(r, i) => format!("Complex|{}+{}i", r, i),
         ValueView::Nil => format!("Nil|U{}", Symbol::intern("Nil").id()),
         ValueView::Package(name) => format!("{}|U{}", name.resolve(), name.id()),

--- a/src/runtime/utils/type_misc.rs
+++ b/src/runtime/utils/type_misc.rs
@@ -27,7 +27,13 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
         ValueView::Pair(_, _) | ValueView::ValuePair(_, _) => "Pair",
         ValueView::Rat(_, _) => "Rat",
         ValueView::FatRat(_, _) => "FatRat",
-        ValueView::BigRat(_, _) => "Rat",
+        ValueView::BigRat(_, _) => {
+            if value.is_bigfatrat() {
+                "FatRat"
+            } else {
+                "Rat"
+            }
+        }
         ValueView::Complex(_, _) => "Complex",
         ValueView::Set(_, is_mutable) => {
             if is_mutable {

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -1,6 +1,6 @@
 use super::*;
 use num_bigint::BigInt as NumBigInt;
-use num_traits::{Signed, ToPrimitive, Zero};
+use num_traits::{Signed, Zero};
 
 pub(crate) fn is_internal_anon_type_name(name: &str) -> bool {
     name.starts_with("__ANON_") && name.ends_with("__")
@@ -256,102 +256,6 @@ fn format_rat_str_bigint(numer: &NumBigInt, denom: &NumBigInt, is_fatrat: bool) 
     }
 }
 
-// BigRat stringification helpers. mutsu stores a Rat or FatRat whose numerator
-// or denominator overflows i64 as a single `BigRat` variant, so it cannot tell a
-// (raku) Rat from a (raku) FatRat once either component is big. The two use
-// different Str digit budgets in Rakudo, so we keep the historical
-// exact-expansion behaviour for BigRat rather than guess wrong; the faithful
-// `format_rat_str_bigint` above is used only for the i64-backed Rat/FatRat
-// variants. Distinguishing big Rats from big FatRats needs a dedicated
-// `BigFatRat` representation (TODO).
-fn format_ratio_bigint_decimal(
-    numer: &NumBigInt,
-    denom: &NumBigInt,
-    append_dot_zero_for_integer: bool,
-    max_fraction_digits: Option<usize>,
-) -> String {
-    if denom.is_zero() {
-        if numer.is_zero() {
-            return "NaN".to_string();
-        }
-        return if numer.is_positive() {
-            "Inf".to_string()
-        } else {
-            "-Inf".to_string()
-        };
-    }
-
-    let sign = numer.is_negative() ^ denom.is_negative();
-    let n = numer.abs();
-    let d = denom.abs();
-    let int_part = &n / &d;
-    let mut rem = n % &d;
-
-    if rem.is_zero() {
-        if append_dot_zero_for_integer {
-            return format!("{}{}.0", if sign { "-" } else { "" }, int_part);
-        }
-        return format!("{}{}", if sign { "-" } else { "" }, int_part);
-    }
-
-    let mut frac = String::new();
-    while !rem.is_zero() {
-        if max_fraction_digits.is_some_and(|limit| frac.len() >= limit) {
-            break;
-        }
-        rem *= 10u8;
-        let digit = &rem / &d;
-        rem %= &d;
-        let ch = digit.to_u8().unwrap_or(0);
-        frac.push(char::from(b'0' + ch));
-    }
-
-    format!("{}{}.{}", if sign { "-" } else { "" }, int_part, frac)
-}
-
-/// Compute digits for BigInt denominator (non-terminating): max(6, chars).
-fn rat_nonterminating_digits_bigint(denom: &NumBigInt) -> usize {
-    if denom.is_zero() {
-        return 6;
-    }
-    let digits = denom.abs().to_string().len();
-    digits.max(6)
-}
-
-/// Format a non-terminating BigRat as decimal with proper digit count and trailing zero stripping.
-fn format_nonterminating_ratio_bigint(numer: &NumBigInt, denom: &NumBigInt) -> String {
-    let digits = rat_nonterminating_digits_bigint(denom);
-    format_ratio_bigint_decimal(numer, denom, false, Some(digits))
-}
-
-/// Strip trailing zeros from a decimal string (but keep at least one digit after the decimal point).
-fn strip_trailing_zeros(s: &str) -> String {
-    if s.contains('.') {
-        let trimmed = s.trim_end_matches('0');
-        if let Some(stripped) = trimmed.strip_suffix('.') {
-            stripped.to_string()
-        } else {
-            trimmed.to_string()
-        }
-    } else {
-        s.to_string()
-    }
-}
-
-fn has_terminating_decimal_bigint(denom: &NumBigInt) -> bool {
-    if denom.is_zero() {
-        return false;
-    }
-    let mut dd = denom.abs();
-    while (&dd % 2u8).is_zero() {
-        dd /= 2u8;
-    }
-    while (&dd % 5u8).is_zero() {
-        dd /= 5u8;
-    }
-    dd == NumBigInt::from(1u8)
-}
-
 impl Value {
     pub(crate) fn to_string_value(&self) -> String {
         match self.view() {
@@ -592,17 +496,26 @@ impl Value {
                     }
                 } else if (n % d).is_zero() {
                     format!("{}", n / d)
+                } else if self.is_bigfatrat() {
+                    // A FatRat has unlimited precision: apply the FatRat digit
+                    // budget over the full big-integer expansion (`format_rat_str_bigint`
+                    // computes the decimal directly, so a huge denominator never
+                    // produces `Inf`, unlike an f64 fallback).
+                    format_rat_str_bigint(n, d, true)
                 } else if d.abs().to_string().len() > 20 {
-                    // For BigRats with very large denominators (beyond uint64 range),
-                    // fall back to Num-based formatting like Raku does for standard Rats.
+                    // A plain Rat with an astronomically large denominator (beyond
+                    // ~u64 range) is a degenerate Rat: raku stringifies it via its
+                    // Num value, so a vanishingly small ratio prints as `0` rather
+                    // than a thousand-digit fraction. A denominator that merely
+                    // overflows i64 but stays around u64 range still uses the exact
+                    // budget below (e.g. `<1/99999999999999999999>`).
                     let val = crate::value::bigrat_to_f64(n, d);
-                    // Use the Num Str formatting
                     Value::Num(val).to_string_value()
-                } else if has_terminating_decimal_bigint(d) {
-                    format_ratio_bigint_decimal(n, d, false, None)
                 } else {
-                    let s = format_nonterminating_ratio_bigint(n, d);
-                    strip_trailing_zeros(&s)
+                    // A big Rat with an in-range denominator follows raku's fixed
+                    // digit-budget rounding (`Rational.Str`): `|denom| < 100_000 ?
+                    // 6 : chars(|denom|) + 1`. Mirrors the i64 Rat arm above.
+                    format_rat_str_bigint(n, d, false)
                 }
             }
             ValueView::Complex(r, i) => format_complex(r, i),

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -902,9 +902,11 @@ pub fn make_big_fat_rat(num: NumBigInt, den: NumBigInt) -> Value {
         d = -d;
     }
     if let (Some(n_i64), Some(d_i64)) = (n.to_i64(), d.to_i64()) {
-        Value::Rat(n_i64, d_i64)
+        // A FatRat that reduces into i64 range stays a FatRat (its identity is
+        // not lost just because the current value is small).
+        Value::FatRat(n_i64, d_i64)
     } else {
-        Value::bigrat(n, d)
+        Value::bigfatrat(n, d)
     }
 }
 
@@ -1161,7 +1163,15 @@ pub(in crate::value) enum ValueRepr {
     Hash(Gc<HashData>, bool),
     Rat(i64, i64),
     FatRat(i64, i64),
-    BigRat(Box<NumBigInt>, Box<NumBigInt>),
+    /// A rational whose numerator or denominator overflows i64, stored as
+    /// big integers. The `bool` is the FatRat flag: `true` when this is a
+    /// (raku) `FatRat` (unlimited precision, full `.Str` expansion,
+    /// `FatRat.new(..)` `.raku`), `false` for a plain big `Rat` (rounded
+    /// `.Str` digit budget). Both flavours share this one variant because
+    /// they must behave identically for arithmetic and value equality — only
+    /// display, `.^name`, `.raku`, `.WHICH`, and eqv consult the flag. Read
+    /// it via `Value::is_bigfatrat()`.
+    BigRat(Box<NumBigInt>, Box<NumBigInt>, bool),
     Complex(f64, f64),
     /// Set (immutable) or SetHash (mutable). The bool is `true` for mutable (SetHash).
     Set(crate::gc::Gc<SetData>, bool),
@@ -1448,8 +1458,8 @@ impl Value {
         Value::from_repr(ValueRepr::FatRat(n, d))
     }
     #[inline]
-    pub(in crate::value) fn BigRat(n: Box<NumBigInt>, d: Box<NumBigInt>) -> Value {
-        Value::from_repr(ValueRepr::BigRat(n, d))
+    pub(in crate::value) fn BigRat(n: Box<NumBigInt>, d: Box<NumBigInt>, is_fat: bool) -> Value {
+        Value::from_repr(ValueRepr::BigRat(n, d, is_fat))
     }
     #[inline]
     pub(in crate::value) fn Complex(re: f64, im: f64) -> Value {

--- a/src/value/nanbox/boxes.rs
+++ b/src/value/nanbox/boxes.rs
@@ -25,6 +25,8 @@ pub(in crate::value) struct F64Pair(pub(in crate::value) f64, pub(in crate::valu
 pub(in crate::value) struct BigRatBox(
     pub(in crate::value) NumBigInt,
     pub(in crate::value) NumBigInt,
+    /// FatRat flag: `true` for a big `FatRat`, `false` for a big `Rat`.
+    pub(in crate::value) bool,
 );
 
 #[derive(Debug, Clone)]

--- a/src/value/nanbox/decode.rs
+++ b/src/value/nanbox/decode.rs
@@ -93,7 +93,7 @@ unsafe fn decode_kind(kind: Kind, bits: u64) -> ValueRepr {
         }
         Kind::BigRat => {
             let b = Arc::unwrap_or_clone(unsafe { take_arc::<BigRatBox>(bits) });
-            ValueRepr::BigRat(Box::new(b.0), Box::new(b.1))
+            ValueRepr::BigRat(Box::new(b.0), Box::new(b.1), b.2)
         }
         Kind::Complex => {
             let p = Arc::unwrap_or_clone(unsafe { take_arc::<F64Pair>(bits) });

--- a/src/value/nanbox/encode.rs
+++ b/src/value/nanbox/encode.rs
@@ -37,7 +37,9 @@ impl NanBox {
             }
             ValueRepr::Rat(n, d) => pack_arc(Kind::Rat, Arc::new(I64Pair(n, d))),
             ValueRepr::FatRat(n, d) => pack_arc(Kind::FatRat, Arc::new(I64Pair(n, d))),
-            ValueRepr::BigRat(n, d) => pack_arc(Kind::BigRat, Arc::new(BigRatBox(*n, *d))),
+            ValueRepr::BigRat(n, d, is_fat) => {
+                pack_arc(Kind::BigRat, Arc::new(BigRatBox(*n, *d, is_fat)))
+            }
             ValueRepr::Complex(re, im) => pack_arc(Kind::Complex, Arc::new(F64Pair(re, im))),
             ValueRepr::GenericRange {
                 start,

--- a/src/value/nanbox/peek.rs
+++ b/src/value/nanbox/peek.rs
@@ -59,6 +59,18 @@ impl NanBox {
         }
     }
 
+    /// True iff this is a big-integer-backed rational tagged as a FatRat.
+    #[inline]
+    pub(in crate::value) fn is_bigfatrat(&self) -> bool {
+        let bits = self.0.get();
+        if let Classified::Kind(Kind::BigRat) = classify(bits) {
+            // SAFETY: BigRat words carry an Arc<BigRatBox>.
+            unsafe { peek_arc::<BigRatBox>(bits) }.2
+        } else {
+            false
+        }
+    }
+
     /// The payload if this is an `Int` (inline or boxed). No coercion.
     #[inline]
     pub(in crate::value) fn as_int(&self) -> Option<i64> {

--- a/src/value/nanbox/tests.rs
+++ b/src/value/nanbox/tests.rs
@@ -363,6 +363,12 @@ fn every_variant_roundtrips_losslessly() {
         ValueRepr::BigRat(
             Box::new(NumBigInt::from(10).pow(25)),
             Box::new(NumBigInt::from(3)),
+            false,
+        ),
+        ValueRepr::BigRat(
+            Box::new(NumBigInt::from(10).pow(25)),
+            Box::new(NumBigInt::from(7)),
+            true,
         ),
         ValueRepr::Complex(1.5, -2.5),
         ValueRepr::Set(

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -34,7 +34,7 @@ enum SerValue {
     Hash(HashMap<String, SerValue>),
     Rat(i64, i64),
     FatRat(i64, i64),
-    BigRat(NumBigInt, NumBigInt),
+    BigRat(NumBigInt, NumBigInt, bool),
     Complex(f64, f64),
     Set(HashSet<String>),
     Bag(HashMap<String, NumBigInt>),
@@ -159,7 +159,7 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
         }
         ValueView::Rat(n, d) => Ok(SerValue::Rat(n, d)),
         ValueView::FatRat(n, d) => Ok(SerValue::FatRat(n, d)),
-        ValueView::BigRat(n, d) => Ok(SerValue::BigRat(n.clone(), d.clone())),
+        ValueView::BigRat(n, d) => Ok(SerValue::BigRat(n.clone(), d.clone(), v.is_bigfatrat())),
         ValueView::Complex(r, i) => Ok(SerValue::Complex(r, i)),
         ValueView::Set(s, _) => Ok(SerValue::Set(s.elements.clone())),
         ValueView::Bag(b, _) => Ok(SerValue::Bag(b.counts.clone())),
@@ -342,7 +342,13 @@ fn ser_to_value(sv: SerValue) -> Value {
         ),
         SerValue::Rat(n, d) => Value::Rat(n, d),
         SerValue::FatRat(n, d) => Value::FatRat(n, d),
-        SerValue::BigRat(n, d) => Value::bigrat(n, d),
+        SerValue::BigRat(n, d, is_fat) => {
+            if is_fat {
+                Value::bigfatrat(n, d)
+            } else {
+                Value::bigrat(n, d)
+            }
+        }
         SerValue::Complex(r, i) => Value::Complex(r, i),
         SerValue::Set(s) => Value::set(s),
         SerValue::Bag(b) => Value::bag_big(b),

--- a/src/value/types.rs
+++ b/src/value/types.rs
@@ -7,6 +7,7 @@ pub(crate) fn what_type_name(val: &Value) -> String {
         ValueView::Num(_) => "Num".to_string(),
         ValueView::Str(_) => "Str".to_string(),
         ValueView::Bool(_) => "Bool".to_string(),
+        ValueView::BigRat(_, _) if val.is_bigfatrat() => "FatRat".to_string(),
         ValueView::Rat(_, _) | ValueView::BigRat(_, _) => "Rat".to_string(),
         ValueView::FatRat(_, _) => "FatRat".to_string(),
         ValueView::Complex(_, _) => "Complex".to_string(),

--- a/src/value/types_eqv.rs
+++ b/src/value/types_eqv.rs
@@ -161,10 +161,14 @@ impl Value {
             // comparison is delegated to PartialEq, which ignores the flag.
             (ValueView::Bag(a, a_mut), ValueView::Bag(b, b_mut)) => a_mut == b_mut && *a == *b,
             (ValueView::Mix(a, a_mut), ValueView::Mix(b, b_mut)) => a_mut == b_mut && *a == *b,
+            // Two big rationals are eqv only when they share the FatRat flag
+            // (a big Rat is never eqv to a big FatRat, even with equal value).
+            (ValueView::BigRat(_, _), ValueView::BigRat(_, _)) => {
+                self.is_bigfatrat() == other.is_bigfatrat() && self == other
+            }
             (ValueView::Int(_), ValueView::Int(_))
             | (ValueView::Str(_), ValueView::Str(_))
             | (ValueView::Bool(_), ValueView::Bool(_))
-            | (ValueView::BigRat(_, _), ValueView::BigRat(_, _))
             | (ValueView::Enum { .. }, ValueView::Enum { .. })
             | (ValueView::Regex(_), ValueView::Regex(_))
             | (ValueView::RegexWithAdverbs { .. }, ValueView::RegexWithAdverbs { .. })

--- a/src/value/types_isa.rs
+++ b/src/value/types_isa.rs
@@ -24,7 +24,13 @@ impl Value {
             ValueView::Bool(_) => "Bool",
             ValueView::Rat(_, _) => "Rat",
             ValueView::FatRat(_, _) => "FatRat",
-            ValueView::BigRat(_, _) => "Rat",
+            ValueView::BigRat(_, _) => {
+                if self.is_bigfatrat() {
+                    "FatRat"
+                } else {
+                    "Rat"
+                }
+            }
             ValueView::Complex(_, _) => "Complex",
             ValueView::Array(..) | ValueView::LazyList(_) => "Array",
             ValueView::Seq(_) => "Seq",
@@ -253,10 +259,10 @@ impl Value {
                 self.view(),
                 ValueView::Instance { class_name, .. } if class_name == "Date" || class_name == "DateTime"
             ),
-            "FatRat" => matches!(
-                self.view(),
-                ValueView::FatRat(_, _) | ValueView::BigRat(_, _)
-            ),
+            "FatRat" => {
+                matches!(self.view(), ValueView::FatRat(_, _))
+                    || (matches!(self.view(), ValueView::BigRat(_, _)) && self.is_bigfatrat())
+            }
             "Int" => matches!(self.view(), ValueView::Bool(_)),
             "Stringy" => matches!(self.view(), ValueView::Str(_)),
             "Block" | "Routine" | "Code" | "Callable" => {

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -83,10 +83,21 @@ impl Value {
             _ => self,
         }
     }
-    /// Create a BigRat value. The numerator/denominator are boxed (the variant
-    /// stores them behind `Box` to keep `Value` small).
+    /// Create a big `Rat` value. The numerator/denominator are boxed (the
+    /// variant stores them behind `Box` to keep `Value` small).
     pub fn bigrat(num: NumBigInt, den: NumBigInt) -> Self {
-        Value::BigRat(Box::new(num), Box::new(den))
+        Value::BigRat(Box::new(num), Box::new(den), false)
+    }
+    /// Create a big `FatRat` value (unlimited precision). Differs from
+    /// [`Value::bigrat`] only in the FatRat flag, which drives display,
+    /// `.^name`, `.raku`, `.WHICH`, and eqv.
+    pub fn bigfatrat(num: NumBigInt, den: NumBigInt) -> Self {
+        Value::BigRat(Box::new(num), Box::new(den), true)
+    }
+    /// True iff this is a big-integer-backed rational carrying the FatRat flag.
+    #[inline]
+    pub fn is_bigfatrat(&self) -> bool {
+        self.0.is_bigfatrat()
     }
     /// The HOW (meta-object) of a `CustomType` or `CustomTypeInstance`, if this
     /// is one. Centralizes access now that both are boxed payloads.

--- a/t/bigfatrat-variant.t
+++ b/t/bigfatrat-variant.t
@@ -1,0 +1,53 @@
+use Test;
+
+# A rational whose numerator or denominator overflows i64 is stored as a big
+# integer pair. mutsu must still distinguish a (raku) Rat from a (raku) FatRat
+# for that case: type name, .WHAT, .Str digit budget, .raku form, ~~, .WHICH,
+# eqv, and the .Rat / .FatRat coercions all consult the FatRat flag.
+
+plan 24;
+
+my $bf = (4.5.FatRat) ** 60;   # big FatRat
+my $br = 4.5 ** 60;            # big Rat, same numeric value
+
+# --- type identity ---
+is $bf.^name, 'FatRat', 'big FatRat reports FatRat';
+is $br.^name, 'Rat', 'big Rat reports Rat';
+is $bf.WHAT.gist, '(FatRat)', 'big FatRat .WHAT is (FatRat)';
+is $br.WHAT.gist, '(Rat)', 'big Rat .WHAT is (Rat)';
+
+# --- smartmatch against the two types ---
+ok $bf ~~ FatRat, 'big FatRat ~~ FatRat';
+nok $bf ~~ Rat, 'big FatRat is not a Rat';
+ok $br ~~ Rat, 'big Rat ~~ Rat';
+nok $br ~~ FatRat, 'big Rat is not a FatRat';
+ok $bf ~~ Rational, 'big FatRat ~~ Rational';
+ok $br ~~ Rational, 'big Rat ~~ Rational';
+
+# --- .Str digit budget: Rat rounds, FatRat keeps full precision ---
+my $full = '1558657976916843360832062017400788597510.058834953945635510598466400011830046423710882663726806640625';
+my $rounded = '1558657976916843360832062017400788597510.0588349539456355106';
+is ~$bf, $full, 'big FatRat .Str keeps full expansion';
+is ~$br, $rounded, 'big Rat .Str rounds to the digit budget';
+
+# --- .raku form ---
+ok $bf.raku.starts-with('FatRat.new('), 'big FatRat .raku is FatRat.new(..)';
+is $br.raku, $full, 'big Rat .raku is the exact terminating decimal';
+
+# --- coercions flip the flavour ---
+is $bf.Rat.^name, 'Rat', '.Rat on a big FatRat drops the FatRat flag';
+is $br.FatRat.^name, 'FatRat', '.FatRat on a big Rat sets the FatRat flag';
+is ~$bf.Rat, $rounded, '.Rat on a big FatRat then rounds like a Rat';
+is ~$br.FatRat, $full, '.FatRat on a big Rat then keeps full precision';
+
+# --- WHICH carries the flavour ---
+ok $bf.WHICH.Str.starts-with('FatRat|'), 'big FatRat WHICH starts with FatRat|';
+ok $br.WHICH.Str.starts-with('Rat|'), 'big Rat WHICH starts with Rat|';
+
+# --- eqv distinguishes the flavour even at equal value ---
+nok ($bf eqv $br), 'big FatRat is not eqv to a big Rat of equal value';
+ok ($br eqv (4.5 ** 60)), 'two equal big Rats are eqv';
+ok ($bf eqv ((4.5.FatRat) ** 60)), 'two equal big FatRats are eqv';
+
+# --- numeric equality still ignores the flavour ---
+ok ($bf == $br), 'big FatRat == big Rat of equal value';

--- a/t/rat-complex-stringify-regressions.t
+++ b/t/rat-complex-stringify-regressions.t
@@ -19,8 +19,12 @@ is ~$huge, '111111111111111111111111111111111111111111111', 'exact BigInt divisi
 is ~$huge.FatRat, '111111111111111111111111111111111111111111111', 'BigInt .FatRat keeps full string';
 
 my $pow-rat = 4.5 ** 60;
-my $pow-rat-str = '1558657976916843360832062017400788597510.058834953945635510598466400011830046423710882663726806640625';
-is ~$pow-rat, $pow-rat-str, 'Rat ** Int keeps arbitrary precision stringification';
-is $pow-rat.raku, $pow-rat-str, 'Rat ** Int .raku keeps terminating decimal precision';
-is ~$pow-rat.FatRat, $pow-rat-str, 'Rat ** Int .FatRat keeps arbitrary precision stringification';
-is $pow-rat.FatRat.Str, $pow-rat-str, 'Rat ** Int .FatRat.Str keeps arbitrary precision stringification';
+# A big Rat's .Str follows Rakudo's fixed digit-budget rounding (Rational.Str),
+# while .raku keeps the full exact terminating expansion. A big FatRat keeps the
+# full expansion for both (unlimited precision).
+my $pow-rat-full = '1558657976916843360832062017400788597510.058834953945635510598466400011830046423710882663726806640625';
+my $pow-rat-str  = '1558657976916843360832062017400788597510.0588349539456355106';
+is ~$pow-rat, $pow-rat-str, 'big Rat .Str rounds to the Rational.Str digit budget';
+is $pow-rat.raku, $pow-rat-full, 'big Rat .raku keeps the full terminating decimal';
+is ~$pow-rat.FatRat, $pow-rat-full, 'big FatRat .Str keeps arbitrary precision stringification';
+is $pow-rat.FatRat.Str, $pow-rat-full, 'big FatRat .Str keeps arbitrary precision stringification';


### PR DESCRIPTION
## Summary

A rational whose numerator or denominator overflows i64 was stored as a single `BigRat` variant with no way to tell a (raku) `Rat` from a (raku) `FatRat`. Both `(4.5.FatRat)**60` and `(4.5)**60` collapsed to the same `BigRat`, so mutsu:

- reported `Rat` for the FatRat (`.^name` / `.WHAT` / `~~ FatRat`),
- gave the FatRat the rounded `Rat.Str` digit budget instead of full precision,
- printed `n/d` for `.raku` instead of `FatRat.new(n, d)`.

This adds a **FatRat flag** to `ValueRepr::BigRat`, threaded through the nanbox `BigRatBox` (encode/decode/peek) and serde, and read via the new `Value::is_bigfatrat()`.

## Design

`ValueView::BigRat` stays a **2-field borrow**, so the ~150 arithmetic/coercion sites that must treat both flavours identically (value equality, `+`/`-`/`*`/`/`, numeric coercion) are untouched. Only the handful of sites where the flavour is *observable* consult the flag:

- `.^name` / `.WHAT` / `~~ FatRat` / `~~ Rat` — the three type-name paths (`value_type_name`, `what_type_name`, `dispatch_what`/`dispatch_caret_name`) plus the isa table
- `.Str` — big FatRat keeps full precision; big Rat rounds to the `Rational.Str` digit budget (and keeps the astronomically-small-denominator `0` case via the Num fallback)
- `.raku` — `FatRat.new(n, d)` vs the exact decimal
- `.WHICH` (three builders) and `eqv` — a big Rat is never eqv to a big FatRat of equal value
- `.Rat` drops the flag, `.FatRat` sets it; `make_big_fat_rat` now preserves the flavour even when the result reduces back into i64 range

Verified against `raku` for name/WHAT/Str/raku/isa/WHICH/eqv/coercion and arithmetic contagion (FatRat stays FatRat through big intermediate values; a big Rat with an oversized denominator still degrades to Num).

## Tests

- New `t/bigfatrat-variant.t` (24 assertions, all matching `raku`).
- Fixes the `t/rat-complex-stringify-regressions.t` test-8 gap #5063 left open: a big Rat `.Str` now rounds like raku (that test previously pinned the old buggy full-expansion behaviour, which could not be fixed without splitting the representation).
- `roast/S32-num/rat.t` (869) and `roast/S02-types/{fatrat,num}.t` pass; `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)