### PR TITLE
fix: EXPORT-installed operator sub is a first-class Sub, not a dangling ref

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -443,17 +443,36 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   would need to register enum value names as term symbols — risky, deferred.
 - file: parser term resolution (enum value vs sub)
 
-### T-049 — test_fail: not ok N -  [impact: 1 dist]
+### T-049 — test_fail: not ok N -  [impact: 1 dist]  — PARTIAL (PR `fix-export-infix-operator-closure`)
 - dists: Understitch
 - e.g. `Understitch`: base=4 pass=2 fail=2 die=0 | t/10-basics.t: not ok 1 -
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
+- **FIXED (operator-closure stack overflow, PR `fix-export-infix-operator-closure`).**
+  Understitch installs its `_` operator via a custom `sub EXPORT` returning
+  `Map.new: '&infix:<_>' => &infix:<_>`. Calling the imported operator overflowed
+  the stack: `resolve_code_var` always returned a by-name GLOBAL routine ref for
+  operator names, so the exported value was a dangling ref (the EXPORT sub's nested
+  `infix:<_>` is dropped after EXPORT runs) that `call_infix_routine` re-dispatched
+  by name forever. Now a user operator with a single concrete def resolves to a
+  first-class Sub (via `sub_value_from_function_def`), surviving its scope.
+  `t/09-non-interference.t` and `t/20-combinations.t` pass; pin
+  `t/export-sub-infix-operator-closure.t`.
+- **REMAINING (deferred):**
+  1. `t/10-basics.t` — `use Understitch;` **inside a `subtest { ... }` block** then
+     uses `_`: the parser rejects `_` because `use` is processed at runtime, not at
+     BEGIN/compile time, so the operator symbol is unknown while parsing the block.
+     Parse-time operator import (slang) — a large, separate feature.
+  2. `t/07-properties.t` — `&infix:<_>.precedence` / `.associative` introspection on
+     an operator sub is unimplemented (separate feature).
+- file: `src/runtime/accessors_resolve.rs` (done); remaining — parser slang import,
+  operator-trait introspection
 
-### T-050 — test_fail: root: N Str elements  [impact: 1 dist]
+### T-050 — test_fail: root: N Str elements  [impact: 1 dist]  — STALE (passes on current binary)
 - dists: CLDR::List
-- e.g. `CLDR::List`: base=2 pass=1 fail=1 die=0 | t/format.rakutest: root: 4 Str elements
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
+- Both `t/01-load.rakutest` and `t/format.rakutest` PASS 16/16 on the current
+  binary (a later fix resolved it). Run with `MUTSULIB=$PWD/lib` (or `-I lib`) — a
+  bare `prove -e mutsu` without the lib path fails at `use CLDR::List`, which is a
+  test-harness artifact, not a mutsu bug. Safe to move to Done.
+- file: n/a (resolved)
 
 ### T-051 — test_fail: test basic stuff after initialization  [impact: 1 dist]
 - dists: Hash::Agnostic

--- a/src/runtime/accessors_resolve.rs
+++ b/src/runtime/accessors_resolve.rs
@@ -211,7 +211,9 @@ impl Interpreter {
             // Proto/multi operators keep the routine ref so multi-dispatch runs.
             if !self.has_proto(&normalized_name)
                 && !self.has_multi_candidates(&normalized_name)
-                && let Some(def) = self.resolve_function(&normalized_name).map(|a| (*a).clone())
+                && let Some(def) = self
+                    .resolve_function(&normalized_name)
+                    .map(|a| (*a).clone())
             {
                 return self.sub_value_from_function_def(def);
             }

--- a/src/runtime/accessors_resolve.rs
+++ b/src/runtime/accessors_resolve.rs
@@ -141,6 +141,43 @@ impl Interpreter {
         }
     }
 
+    /// Build a first-class `Sub` value from a resolved `FunctionDef`, capturing
+    /// the current env so the callable outlives its defining scope. Shared by the
+    /// operator and ordinary code-var resolution paths.
+    fn sub_value_from_function_def(&self, def: crate::runtime::FunctionDef) -> Value {
+        let mut captured_env = self.env.clone();
+        if let Some(ref return_type) = def.return_type {
+            captured_env.insert(
+                "__mutsu_return_type".to_string(),
+                Value::str(return_type.clone()),
+            );
+        }
+        if def.is_method {
+            captured_env.insert(
+                "__mutsu_callable_type".to_string(),
+                Value::str_from("Method"),
+            );
+        }
+        let empty_sig = def.empty_sig;
+        let mut sub_val = Value::make_sub(
+            def.package,
+            def.name,
+            def.params,
+            def.param_defs,
+            def.body,
+            def.is_rw,
+            captured_env,
+        );
+        // Preserve empty_sig from the FunctionDef so that arity checks
+        // (e.g. sort rejecting 0-arity callables) work correctly.
+        if empty_sig && let ValueView::Sub(data) = sub_val.view() {
+            let mut new_data = (**data).clone();
+            new_data.empty_sig = true;
+            sub_val = Value::sub_value(crate::gc::Gc::new(new_data));
+        }
+        sub_val
+    }
+
     pub(crate) fn resolve_code_var(&self, name: &str) -> Value {
         let normalized_name = Self::normalize_categorical_operator_name(name);
         if (normalized_name.starts_with("infix:<")
@@ -148,6 +185,36 @@ impl Interpreter {
             || normalized_name.starts_with("postfix:<"))
             && normalized_name.ends_with('>')
         {
+            // A concrete operator sub bound in env — a `my &infix:<op>` binding or
+            // one installed by a custom `sub EXPORT` (`Map.new: '&infix:<op>' =>
+            // &infix:<op>`) — must win over the by-name GLOBAL routine ref.
+            let var_key = format!("&{}", normalized_name);
+            if let Some(val) = self.env.get(&var_key) {
+                match val.view() {
+                    ValueView::WeakSub(weak) => {
+                        return match weak.upgrade() {
+                            Some(strong) => Value::sub_value(strong),
+                            None => Value::NIL,
+                        };
+                    }
+                    ValueView::Sub(_) | ValueView::Instance { .. } | ValueView::Mixin(..) => {
+                        return val.clone();
+                    }
+                    _ => {}
+                }
+            }
+            // A user operator sub with a single concrete def must become a
+            // first-class Sub that outlives its defining scope. The by-name GLOBAL
+            // routine ref only resolves through `call_function`, which fails once
+            // the defining scope (e.g. a custom `sub EXPORT`) is gone, and then
+            // re-dispatches the operator by name forever (infinite recursion).
+            // Proto/multi operators keep the routine ref so multi-dispatch runs.
+            if !self.has_proto(&normalized_name)
+                && !self.has_multi_candidates(&normalized_name)
+                && let Some(def) = self.resolve_function(&normalized_name).map(|a| (*a).clone())
+            {
+                return self.sub_value_from_function_def(def);
+            }
             return Value::routine_parts(
                 Symbol::intern("GLOBAL"),
                 Symbol::intern(&normalized_name),
@@ -306,37 +373,7 @@ impl Interpreter {
                 self.resolve_token_defs(lookup_name).is_some() || self.has_proto_token(lookup_name),
             )
         } else if let Some(def) = def {
-            let mut captured_env = self.env.clone();
-            if let Some(ref return_type) = def.return_type {
-                captured_env.insert(
-                    "__mutsu_return_type".to_string(),
-                    Value::str(return_type.clone()),
-                );
-            }
-            if def.is_method {
-                captured_env.insert(
-                    "__mutsu_callable_type".to_string(),
-                    Value::str_from("Method"),
-                );
-            }
-            let empty_sig = def.empty_sig;
-            let mut sub_val = Value::make_sub(
-                def.package,
-                def.name,
-                def.params,
-                def.param_defs,
-                def.body,
-                def.is_rw,
-                captured_env,
-            );
-            // Preserve empty_sig from the FunctionDef so that arity checks
-            // (e.g. sort rejecting 0-arity callables) work correctly.
-            if empty_sig && let ValueView::Sub(data) = sub_val.view() {
-                let mut new_data = (**data).clone();
-                new_data.empty_sig = true;
-                sub_val = Value::sub_value(crate::gc::Gc::new(new_data));
-            }
-            sub_val
+            self.sub_value_from_function_def(def)
         } else if Self::is_builtin_function(lookup_name) {
             Value::routine_parts(Symbol::intern("GLOBAL"), Symbol::intern(lookup_name), false)
         } else if Self::is_mop_macro_function(lookup_name) {

--- a/t/export-sub-infix-operator-closure.t
+++ b/t/export-sub-infix-operator-closure.t
@@ -1,0 +1,28 @@
+use Test;
+
+plan 7;
+
+# A custom `sub EXPORT` that installs an operator sub via a Map — the operator's
+# `&infix:<op>` reference must be captured as a first-class Sub that outlives the
+# EXPORT scope. Previously `resolve_code_var` always returned a by-name GLOBAL
+# routine ref for operators, which dangled once EXPORT returned and re-dispatched
+# the operator by name forever (infinite recursion / stack overflow). (Understitch)
+
+use lib $?FILE.IO.parent.add('lib').Str;
+
+use ExportInfix;   # installs infix:<jn> that joins with "-"
+
+is "a" jn "b", "a-b", 'EXPORT-installed infix operator works';
+is &infix:<jn>("x", "y"), "x-y", 'explicit &infix:<jn> call works';
+is ("p" jn "q" jn "r"), "p-q-r", 'chained EXPORT-installed operator works';
+
+my &op = &infix:<jn>;
+is op("m", "n"), "m-n", 'operator ref bound to a lexical is callable';
+
+# Closure capture: the operator body reads the EXPORT parameter.
+is (1 jn 2), "1-2", 'operator captures the EXPORT separator';
+
+# A plain top-level operator still resolves and stays callable.
+sub infix:<box>($a, $b) { "[$a,$b]" }
+is &infix:<box>(3, 4), "[3,4]", 'top-level operator ref is callable';
+is (5 box 6), "[5,6]", 'top-level operator applies by syntax';

--- a/t/lib/ExportInfix.rakumod
+++ b/t/lib/ExportInfix.rakumod
@@ -1,0 +1,6 @@
+sub EXPORT(\sep = "-") {
+    sub infix:<jn> (Cool $a, Cool $b) is assoc('left') {
+        $a ~ sep ~ $b
+    }
+    Map.new: '&infix:<jn>' => &infix:<jn>,
+}


### PR DESCRIPTION
## Summary

An operator installed by a custom `sub EXPORT` — the idiom

```raku
sub EXPORT(\sep = "-") {
    sub infix:<jn> ($a, $b) { $a ~ sep ~ $b }
    Map.new: '&infix:<jn>' => &infix:<jn>,
}
```

— **overflowed the stack** whenever the imported operator was applied
(surfaced by the **Understitch** distribution, whose `_` operator uses exactly
this pattern; dist-compat ticket **T-049**).

### Root cause

`resolve_code_var` returned a **by-name GLOBAL routine ref** for every operator
name. So `&infix:<jn>` inside EXPORT evaluated to a reference to the nested sub —
which EXPORT drops once it returns. Applying the imported operator then looped:

```
exec_infix_func_op
  -> call_infix_fallback -> call_user_routine_direct
    -> call_sub_value (sees a Routine value)
      -> call_function("infix:<jn>")
        -> call_infix_routine   (env lookup rejects the Routine view,
                                  falls through to re-evaluating `left jn right`)
          -> exec_infix_func_op ...   ∞
```

### Fix

When an operator name has a **single concrete def** (and is not a proto/multi —
those keep the routine ref so multi-dispatch still runs), `resolve_code_var`
now builds a first-class `Sub` via a new `sub_value_from_function_def` helper,
capturing the env so the callable outlives its defining scope — exactly like an
ordinary `&sub` reference. A lexically-bound operator (`my &infix:<op>`, or a
value already installed in env by EXPORT) is preferred over the routine ref too.
The ordinary code-var path is refactored to reuse the same helper.

## Testing

- New pin `t/export-sub-infix-operator-closure.t` (verified identical on raku)
- Understitch `t/09-non-interference.t` and `t/20-combinations.t` now pass
  (remaining Understitch failures — `use` inside a `subtest` block, and
  `.precedence`/`.associative` introspection — are separate features, tracked in
  the T-049 ledger entry)
- All whitelisted `roast/S06-operator-overloading/*` pass
- `make test`: PASS (21617 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)