### PR TITLE
fix: a separated quantifier keeps a leading empty element (vCard::Parser 02-grammar 23/23)

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -272,13 +272,25 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
      `-:`/`:!` assertion branch now routes to `parse_combined_class` when
      `has_top_level_combine_op` is present (`regex_parse_core.rs`). Pin:
      `t/regex-negated-property-minus-enum.t`.
-- **Status:** 02-grammar 0 → 19/23 (was `ran 0`). **Remaining (separate, deeper — not
-  this ticket):** (a) `<property-value>+ % <[;]>` with **empty-matching** elements
-  (`N:;Gump;Forrest;;Mr.;` → 6 values incl. 3 empty) fails the whole `content-line`
-  match — an empty-element `+ % sep` quantifier-separator bug; (b) `parsefile` of a
-  full multi-vcard file (test-card1/2) fails while test-card4 passes.
+- **THIRD ROOT CAUSE FIXED (PR `fix-separator-leading-empty-element`).** A separated
+  quantifier `<atom>+ % sep` whose atom can match empty (vCard's
+  `<property-value>+ % <[;]>`, `<property-simple-value>` = `[…]*`) dropped a **leading
+  empty element**: `N:;Gump;Forrest;;Mr.;` failed to match at all because the first
+  property-value (between `:` and the first `;`) is empty. The zero-progress guard
+  rejected a zero-width FIRST atom in BOTH the ratcheted (`token`/`rule`) and the
+  backtracking (`regex`) separator matchers; interior/trailing empties already worked.
+  Fix: accept a zero-width first atom (bounded by the extension loop's `atom_end <= cur`
+  no-progress guard) in `regex_match_sep.rs`. Pin: `t/regex-separator-leading-empty.t`.
+- **Status:** 02-grammar 0 → **23/23**; 01-basic 1/1. **Remaining (separate, deeper —
+  not this ticket):** (a) **03-actions** dies on `%parameter<value>[0]` where
+  `%parameter<value>` is `Any` — a postcircumfix `[idx]` on a runtime-`Any` value is
+  mis-dispatched as type parameterization ("Any cannot be parameterized") instead of
+  returning `Any` (repro: `my %h; %h<k>[0]`; `vm/vm_var_index_ops.rs` ~1868 handles the
+  non-positional Any subscript but not the positional one); (b) `parsefile` of a full
+  multi-vcard file (test-card1/2) fails while test-card4 passes.
 - file: DONE — src/runtime/methods_dispatch_match.rs, runtime_class_query.rs,
-  regex_parse_core.rs; remaining — empty-element `+ % sep`, multi-vcard parsefile.
+  regex_parse_core.rs, regex/regex_match_sep.rs; remaining — positional Any postcircumfix
+  index (vm_var_index_ops.rs), multi-vcard parsefile.
 
 ### T-036 — test_die: plan expects Int (plan * fixed; deeper cardinal bugs remain)  [impact: 1 dist]
 - dists: Lingua::EN::Numbers

--- a/src/runtime/regex/regex_match_sep.rs
+++ b/src/runtime/regex/regex_match_sep.rs
@@ -149,9 +149,14 @@ impl Interpreter {
         // singular matcher's Named-atom path spawns a scratch sub-interpreter
         // (plus a tail-text copy) per candidate per call, which is ~300x
         // slower on nested grammar rules like `rule arraylist { <value> * %
-        // [\,] }` over `[[1,2,3],[4,5,6],[7,8,9]]`. A zero-width first atom
-        // means zero iterations (same zero-progress guard as the general
-        // path).
+        // [\,] }` over `[[1,2,3],[4,5,6],[7,8,9]]`.
+        //
+        // A zero-width FIRST atom is a genuine empty element (Rakudo:
+        // `<-[;]>* % ';'` on ";b" is `("", "b")`, not zero iterations), so it
+        // is accepted here. The infinite-loop risk lives only in the extension
+        // loop below, which is bounded by its own `atom_end <= cur`
+        // no-progress guard: after a zero-width atom, the separator must
+        // advance `cur` or the loop breaks.
         if can_extend(0)
             && let Some((end, caps)) = self
                 .regex_match_atom_all_with_capture_in_pkg(
@@ -163,7 +168,6 @@ impl Interpreter {
                     pattern.ignore_case,
                 )
                 .pop()
-            && end > start
         {
             atom_caps.push(caps);
             cur = end;
@@ -268,10 +272,15 @@ impl Interpreter {
         // `regex_match_atom_all_with_capture_in_pkg` returns lowest-priority
         // first; iterate highest-priority first so the chains come out in
         // highest-priority order for the engine.
+        //
+        // A zero-width first atom (`end == start`) is a genuine empty leading
+        // element (Rakudo: `<-[;]>* % ';'` on ";b" is `("", "b")`). It is the
+        // LOWEST-priority first match, so `.rev()` places it last — the greedy
+        // longest chain is still found first, and the empty-first chains are
+        // only lower-priority backtracking options. The recursion is bounded by
+        // `extend_separated_chain`'s `atom_end <= cur` no-progress guard (and
+        // the 20_000 chain cap), so a zero-width atom cannot loop forever.
         for (end, caps) in first_matches.into_iter().rev() {
-            if end == start {
-                continue;
-            }
             let mut atom_caps = vec![caps];
             let mut sep_caps: Vec<RegexCaptures> = Vec::new();
             self.extend_separated_chain(

--- a/t/regex-separator-leading-empty.t
+++ b/t/regex-separator-leading-empty.t
@@ -1,0 +1,53 @@
+use Test;
+
+plan 14;
+
+# A separated quantifier `<atom>+ % sep` whose atom can match the empty string
+# must treat a LEADING empty element as a genuine element, matching Rakudo.
+# (Regression: the separator matcher's zero-progress guard rejected a
+# zero-width first atom, so `;b;c` failed to match while `a;;c`/`a;b;` worked.
+# Both the ratcheted `token`/`rule` path and the backtracking `regex` path.)
+
+grammar T {
+    token plus   { <val>+ % ';' }
+    token star   { <val>* % ';' }
+    regex rgxpl  { <val>+ % ';' }
+    token val    { <-[;]>* }
+}
+
+sub vals($rule, $s) {
+    my $m = T.subparse($s, :rule($rule));
+    $m.defined ?? $m<val>».Str.join('|') !! 'NOMATCH';
+}
+
+# Leading empty element (the regressed case).
+is vals('plus', ';b;c'), '|b|c',   'leading empty element (+)';
+is vals('plus', ';;'),   '||',     'all-empty elements (+)';
+is vals('star', ';a'),   '|a',     'leading empty element (*)';
+
+# Interior / trailing empties (already worked) still work.
+is vals('plus', 'a;;c'), 'a||c',   'interior empty element';
+is vals('plus', 'a;b;'), 'a|b|',   'trailing empty element';
+is vals('plus', 'a;b;c'), 'a|b|c', 'no empty elements';
+
+# Single empty element / empty input.
+is vals('plus', ''),  '',   'empty input yields one empty element (+)';
+is vals('star', ''),  '',   'empty input yields one empty element (*)';
+is vals('plus', ';'), '|',  'one separator yields two empty elements';
+
+# The end position advances past the whole run.
+is T.subparse(';b;c', :rule<plus>).to, 4, 'match consumes the full leading-empty run';
+
+# The non-ratcheted `regex` path behaves identically.
+is vals('rgxpl', ';b;c'), '|b|c', 'leading empty element (regex, non-ratchet)';
+is vals('rgxpl', ';;'),   '||',   'all-empty elements (regex, non-ratchet)';
+
+# An atom that CANNOT match empty still yields zero elements on a leading sep.
+grammar U {
+    token list { <d>+ % ',' }
+    token d    { \d+ }
+}
+nok U.subparse(',5', :rule<list>).defined && U.subparse(',5', :rule<list>).from == 0
+    && U.subparse(',5', :rule<list>).to > 0,
+    'non-empty-matching atom does not fabricate a leading empty element';
+is U.subparse('5,6', :rule<list>)<d>».Str.join('|'), '5|6', 'non-empty atom list still works';


### PR DESCRIPTION
A separated quantifier `<atom>+ % sep` whose atom can match the empty string dropped a **leading empty element**:

```raku
grammar T { token list { <val>+ % ';' }; token val { <-[;]>* } }
T.subparse(';b;c', :rule<list>)<val>».Str   # was ("",) / NOMATCH; now ("", "b", "c")
```

Interior and trailing empties (`a;;c`, `a;b;`) already worked — only a zero-width **first** atom was rejected, by the zero-progress guard in *both* separator matchers:

- the ratcheted (`token`/`rule`) path bailed on `end > start`;
- the backtracking (`regex`) path skipped the first match on `end == start`.

A zero-width first atom is a genuine empty element (Rakudo semantics), so it is now accepted. The infinite-loop risk lives only in the extension step, bounded by its own `atom_end <= cur` no-progress guard (plus the 20 000 chain cap): after a zero-width atom, the separator must advance or the loop breaks.

## Impact

This is the shape at the heart of **vCard::Parser**'s `property-value` list (`N:;Gump;Forrest;;Mr.;` — a leading empty value). With the earlier grammar-instance + charclass fixes (#5237), its `02-grammar` suite now passes **23/23** (was `ran 0`).

Verified against `raku` across leading/interior/trailing/all-empty cases and both the ratchet and non-ratchet paths.

Pin: `t/regex-separator-leading-empty.t`

🤖 Generated with [Claude Code](https://claude.com/claude-code)