### PR TITLE
docs: record BigFatRat completion (PLAN §8.8) and pause the doc-diff campaign

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1108,6 +1108,21 @@ the backlog.
       several doc examples. Other confirmed findings: autoviv-hole `.List`/`.Slip` renders `(Any)`
       instead of `Nil`; empty-`Array` `pop` does not throw `X::Cannot::Empty`; lazy `.elems` does not
       throw `X::Cannot::Lazy`.
+- **Campaign status (paused 2026-07-22).** After many slice sessions the *shallow,
+      interp-shaped* wins (missing method aliases, single-behaviour mismatches) are largely
+      **exhausted**. A fresh full-corpus re-sweep on the current `main` is the first step to resume —
+      note the older `tmp/sweep` report can go stale after a merge, so always re-sweep before trusting
+      a survey row. The **remaining findings cluster into deep buckets**, not one-liners:
+  - **Nil-vs-Any identity knot** (§8.5 / §8.44) — drives most of `perl-nutshell.rakudoc`'s
+    `no strict` autoviv examples (`@undeclared.end` → -1, `%h{missing}` → `(Any)`). Do NOT retry
+    as a small slice; see the mapped campaign.
+  - **Object-hash `WHICH` keys** — `my %h{Any}; %h<42>:exists` must be `False` (allomorph
+    `IntStr` key ≠ `Int` key); mutsu returns `True`. QuantHash/object-hash WHICH-keyed storage
+    rework. Recurs in `numerics.rakudoc` and `hashmap.rakudoc`.
+  - **Loose word-logical precedence** (§8.9) — `and`/`or`/`andthen`/… bind too tightly.
+  - Niche/parser one-offs (lower priority): extended identifiers in variable names
+    (`my $foo:bar<baz>`), Win32 `IO::Path` backslash semantics, `Thread.run`/`Thread.start`,
+    declarator-pod `.WHY` on a `&sub`, `X::AdHoc+{X::Promise::Broken}` role-mixin in `.^name`.
 
 ### 8.2 Documented-surface coverage (doc examples + method matrix)
 
@@ -1182,43 +1197,6 @@ the backlog.
       `method kv { Seq.new(KV.new(:backend(self), :iterator(self.keys.iterator))) }` uses a custom
       `KV` iterator instance, and mutsu's `Seq.new(<custom Iterator instance>)` does not pull from
       it (same family as the `from-iterator` gap fixed in #5132). Investigate independently.
-
-### 8.8 A big FatRat has no distinct representation (deferred deep item — found 2026-07-22 by the Math::Root dist)
-
-- [ ] **A `FatRat` whose numerator or denominator overflows i64 collapses to the shared
-      `BigRat` value variant, losing its FatRat identity.** So `FatRat.new(10**40+5, 10**33).WHAT`
-      is `Rat` (via `types.rs`: `BigRat => "Rat"`) instead of `FatRat`, and a routine typed
-      `--> FatRat` that returns such a value fails its return type-check
-      (`Type check failed for return value; expected FatRat but got Rat`).
-- **Where it bites (Math::Root, thundergnat).** `t/01-integer.t` (75) now passes fully after
-      the min-fold fix (#5165) and the exact big-integer `round($scale)` fix (#5168). But
-      `t/02-rational.t` (67) and `t/03-triangular.t` (21) both die at their first `root(...)` call:
-      `root` is `sub root(...) --> FatRat` and its body is `FatRat.new(newton(...).round(10), 10**k)`
-      — the constructed value is a big rational that mutsu stores as `BigRat`, typed `Rat`, so the
-      `--> FatRat` check throws before any test runs. raku passes both files.
-- **Second, entangled facet — big-rational `.Str` digit budget.** A `BigRat` also can't pick the
-      right Rakudo `Rational.Str` digit budget, precisely *because* it can't tell a big Rat from a
-      big FatRat (they differ: `Rat.Str` = `chars(denom)+1` digits and **degrades the intermediate
-      to Num** when `fract*10^digits` overflows u64 — so `Rat.new(10**400, 9**999).Str` is `'0'`;
-      `FatRat.Str` = `chars(denom)+chars(whole)+5` digits and stays exact). The current
-      `display.rs` `BigRat` arm degrades any >20-digit-denominator BigRat to an f64 gist, which is
-      wrong for a moderate terminating FatRat like `FatRat.new(10**40+5, 10**33)` (prints `1e7`
-      instead of `10000000.000…005`). A naïve "render exactly / use the FatRat budget" fix
-      regresses the whitelisted `roast/S32-num/rat.t` test 856 (`Rat.new(10**400, 9**999).Str eq
-      '0'`), because that `'0'` is a *Rat*-specific consequence of the Num degradation. So the
-      display cannot be made correct for both without the type distinction either.
-- **Fix (ADR-worthy — a dedicated big-FatRat representation).** Add a `BigFatRat` value variant
-      (parallel to `BigRat`) threaded through the nanbox `Kind`, `encode`/`decode`/`peek`, the
-      `ValueView` enum, `types.rs` (→ `"FatRat"`), arithmetic (FatRat ops stay exact, never
-      degrade), and `display.rs` (FatRat budget, exact). This is high blast radius: ~150
-      `ValueView::BigRat` match sites plus the nanbox encoding. The existing
-      `format_rat_str_bigint(_, _, is_fatrat)` already implements both Rakudo budgets in BigInt
-      arithmetic, so display becomes a routing decision once the variant carries the FatRat bit.
-- **Landed this session (independent, general):** `#5165` (min/max fold a single iterable) and
-      `#5168` (`round($scale)` exact for big integers). Together they fix Math::Root `01-integer.t`.
-- Entry: `git checkout -b feat-bigfatrat-repr origin/main`. Related: §3 (substrate),
-      [ADR-0001] Value representation; `src/value/nanbox/`, `src/value/display.rs`,
-      `src/runtime/methods_object_native_ctors_buf_num.rs` (`build_native_fatrat_value`).
 
 ### 8.9 The word-logical operators `and`/`or`/`andthen`/`orelse`/`xor` bind too tightly (deferred deep item — found 2026-07-22 by the traps.rakudoc doc-diff sweep)
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,35 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-22: a big `FatRat` keeps its identity, distinct from a big `Rat` (#5238, closes PLAN §8.8)
+
+A rational whose numerator or denominator overflowed i64 was stored in a single
+`BigRat` value variant with no way to tell a (raku) `Rat` from a (raku) `FatRat`:
+`(4.5.FatRat)**60` and `(4.5)**60` were indistinguishable, so mutsu reported `Rat`
+for the FatRat (`.^name` / `.WHAT` / `~~ FatRat`), gave it the rounded `Rat.Str`
+digit budget, and printed `n/d` for `.raku`. A routine typed `--> FatRat` returning
+such a value failed its return type-check.
+
+The fix adds a FatRat flag to `ValueRepr::BigRat` (threaded through the nanbox
+`BigRatBox`, encode/decode/peek, and serde), read via the new `Value::is_bigfatrat()`.
+The `ValueView::BigRat` borrow stays two fields, so the ~150 arithmetic/coercion sites
+that must treat both flavours identically (value equality, `+`/`-`/`*`/`/`, numeric
+coercion) are untouched; only the ~8 sites where the flavour is observable consult the
+flag: the three type-name functions (`value_type_name`, `what_type_name`,
+`dispatch_what`/`dispatch_caret_name` — `.^name` uses the last one), the isa table,
+`.Str` (big FatRat keeps full precision; big Rat rounds to the `Rational.Str` budget,
+keeping the astronomically-small-denominator `0` case via the Num fallback), `.raku`
+(`FatRat.new(n, d)` vs the exact decimal), the three `.WHICH` builders, `eqv` (a big
+Rat is never eqv to a big FatRat of equal value), and the `.Rat`/`.FatRat` coercions.
+`make_big_fat_rat` now preserves the flavour even when the result reduces back into
+i64 range. This also closes the `t/rat-complex-stringify-regressions.t` test-8 gap
+#5063 left open (a big Rat `.Str` now rounds like raku). Pin: `t/bigfatrat-variant.t`
+(24 assertions, all matching raku); `roast/S32-num/rat.t` (869) stays green.
+
+Driven as a dedicated deep slice per the "autostart dedicated sessions" policy. It also
+resolved several `numerics.rakudoc` doc-diff lines for free (big-FatRat division
+contagion, `RatStr.FatRat`, `(42 + FatRat.new(1,2))/huge`).
+
 ## 2026-07-22: `Proc.new.gist` is no longer `-1` (PLAN §8.15 slice)
 
 Proc's registered native `Str`/`gist` rendered the exitcode number (`-1` for a fresh


### PR DESCRIPTION
Docs-only follow-up to #5238 (BigFatRat representation split).

- Moves the now-resolved **PLAN §8.8** (a big `FatRat` has no distinct representation) out of PLAN.md and into `news/2026-07.md`, with the design summary of how #5238 fixed it (FatRat flag on `ValueRepr::BigRat`, read via `Value::is_bigfatrat()`, `ValueView` kept 2-field so ~150 arithmetic sites stay untouched).
- Adds a **campaign-status note** to PLAN §8.1: the shallow interp-shaped doc-diff wins are largely exhausted; the remaining findings cluster into deep buckets (Nil-vs-Any knot, object-hash `WHICH` keys, loose word-logical precedence) plus niche parser one-offs. A fresh full-corpus re-sweep on current `main` is the first step to resume — older `tmp/sweep` reports go stale after a merge.

Default patch bump (docs-only, no label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)