### PR TITLE
fix: .WHO on builtin values returns the type's Stash; Stash.raku is the symbols hash

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1102,12 +1102,13 @@ the backlog.
       134 raku-drift.** The ranked, tracked backlog is [docs/doc-diff-backlog.md](docs/doc-diff-backlog.md)
       (the QA analogue of BLOCKERS.md; re-sweep to refresh). Still TODO: a real-module corpus, and growing
       the non-determinism / error-example skip heuristics as new noise shows up.
-- [ ] **First backlog item from the run: sequence/lazy argument truncation** — `1, 3 ... 11` (and lazy
-      `gather`/`Seq`) passed as a routine/method argument is materialised to only its first two
-      elements (`@foo.prepend: 1,3...11` → `[1 3 …]`; `600.polymod(lazy …)` → `(600)`). One root cause,
-      several doc examples. Other confirmed findings: autoviv-hole `.List`/`.Slip` renders `(Any)`
-      instead of `Nil`; empty-`Array` `pop` does not throw `X::Cannot::Empty`; lazy `.elems` does not
-      throw `X::Cannot::Lazy`.
+- [ ] **Leftover from the first backlog batch (re-verified 2026-07-22):** the sequence/lazy
+      argument truncation (`@foo.prepend: 1,3...11`, `600.polymod(lazy …)`), `.Slip` hole
+      rendering, empty-`Array` `pop` → `X::Cannot::Empty`, and lazy `.elems` → `X::Cannot::Lazy`
+      all match raku now. The one remaining divergence: **autoviv-hole `.List` renders `(Any)`
+      where raku gives `Nil`** (`my @a; @a[2]=5; @a.List` → raku `(Nil Nil 5)`; `@a.head` → raku
+      `Nil`). Needs per-element hole tracking through the List view — same territory as §8.5 /
+      [`array-hole-tracking-embedded`]; do not chase as a display-only patch.
 - **Campaign status (paused 2026-07-22).** After many slice sessions the *shallow,
       interp-shaped* wins (missing method aliases, single-behaviour mismatches) are largely
       **exhausted**. A fresh full-corpus re-sweep on the current `main` is the first step to resume —
@@ -1181,14 +1182,18 @@ the backlog.
       rendering. Reasonable to keep deferring vs the §1/§6 frontier. Related: §6 (dual-store / lexical
       slot), [`array-hole-tracking-embedded`], [ADR-0001] container-repr.
 
-### 8.6 `.WHO`/`.HOW` render without their metamodel detail
+### 8.6 `.WHO`/`.HOW` render without their metamodel detail — mostly done; internals leftover
 
-- [ ] **A Stash renders as a plain `Hash`, and a `ClassHOW` without its mixin roles.**
-      `(@a>>.WHO).WHAT` is `(Hash)` where raku gives `(Stash)`, `Array.WHO` is `{}` where raku
-      lists `{:Element(Array::Element), :Shaped(Array::Shaped), ...}`, and `Array.HOW.raku` is
-      `Perl6::Metamodel::ClassHOW.new` where raku has `ClassHOW+{<anon>}+{<anon>}.new`. A
-      metamodel-fidelity gap, not a dispatch bug — surfaced by the `>>.` sweep only because the
-      introspectors happened to be in it. Low user impact; sized as its own slice.
+- The dispatch half landed 2026-07-22: `.WHO` on a *builtin value* (`42.WHO`, `@a.WHO`) now
+      returns the type's `Stash` (was a plain `Hash`, so `(@a>>.WHO).WHAT` was `(Hash)`), and
+      `Stash.raku` renders the symbols hash literal (`{:Bar(Foo::Bar)}`, `{}`) instead of
+      `Stash.new`. Pin: `t/who-stash.t`.
+- [ ] **Leftover (Rakudo-metamodel-internal, cosmetic):** the *content* of a builtin type's
+      stash — raku's `Array.WHO` lists implementation subclasses
+      `{:Element(Array::Element), :Shaped(Array::Shaped), ...}` that do not exist in mutsu —
+      and `Array.HOW.raku`'s anonymous-mixin rendering (`ClassHOW+{<anon>}+{<anon>}.new`).
+      Faking either means hardcoding Rakudo internals; only worth doing if a real program is
+      ever found to introspect them.
 
 ### 8.7 `.kv` on a Hash::Agnostic role returns `()`
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -33,6 +33,20 @@ Driven as a dedicated deep slice per the "autostart dedicated sessions" policy. 
 resolved several `numerics.rakudoc` doc-diff lines for free (big-FatRat division
 contagion, `RatStr.FatRat`, `(42 + FatRat.new(1,2))/huge`).
 
+## 2026-07-22: `.WHO` on builtin values is a Stash; `Stash.raku` is the symbols hash (PLAN §8.6)
+
+`.WHO` on a *builtin value* (`42.WHO`, `@a.WHO`, `"x".WHO`) fell through `dispatch_who` to
+a plain empty `Hash`, so `(@a>>.WHO).WHAT` was `(Hash)` where raku gives `(Stash)` (type
+objects, user-class instances, and custom types were already correct). The fallback now
+resolves the value's type name and returns the same `package_stash_value` stash. And
+`Stash.raku` rendered the generic `Stash.new`; Rakudo's Stash is a Hash subclass whose
+`.raku` is the symbols hash literal — mutsu now renders `{:Bar(Foo::Bar)}` / `{}` from the
+stash's symbols. Verified against the reference `raku`; pin: `t/who-stash.t`. The §8.6
+leftover (the Rakudo-internal *content* of builtin stashes like `Array::Element`, and
+ClassHOW anon-mixin rendering) is recorded in PLAN.md as cosmetic/not-planned. Also
+re-verified the §8.1 first-batch findings: only the autoviv-hole `.List` → `Nil` rendering
+remains open (folded into the §8.5/hole-tracking territory).
+
 ## 2026-07-22: `Proc.new.gist` is no longer `-1` (PLAN §8.15 slice)
 
 Proc's registered native `Str`/`gist` rendered the exitcode number (`-1` for a fresh
@@ -1004,7 +1018,7 @@ the missing piece: each iteration runs user VM code, so a timer entry would
 have to spawn a fresh 256 MiB-stack worker per tick. raku wins here because its
 timer hands off to a thread pool, which mutsu does not have — tracked in PLAN
 §6 as a worker-pool slice, not a timer one.
-||||||| parent of f308123c (fix: regex LR seed loop no longer re-evaluates every subrule (2^depth) — 99problems-41-to-50 P47)
+
 ## 2026-07-17: integration/99problems-41-to-50.t whitelisted — regex LR seed loop no longer 2^depth (P47)
 
 `integration/99problems-41-to-50.t` aborted at 2/9: P47's precedence-climbing

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1005,6 +1005,20 @@ impl Interpreter {
                             "Supplier.new(taplist => Supplier::TapList.new)".to_string(),
                         ));
                     }
+                    // A Stash is a Hash subclass in Rakudo: its .raku is the
+                    // symbols hash literal (`{:Bar(Foo::Bar)}`), not `Stash.new`.
+                    // (.gist/.Str — the package name — are handled on the fast
+                    // path in dispatch_core_repr.)
+                    "Stash" if method == "raku" || method == "perl" => {
+                        let symbols = attributes
+                            .as_map()
+                            .get("symbols")
+                            .cloned()
+                            .unwrap_or_else(|| Value::hash(HashMap::new()));
+                        return Ok(Value::str(
+                            crate::builtins::methods_0arg::raku_repr::raku_value(&symbols),
+                        ));
+                    }
                     _ => {}
                 }
                 // Collect public attributes for .raku representation. Mark this

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -347,7 +347,9 @@ impl Interpreter {
         if let ValueView::CustomType(c) = target.view() {
             return Ok(self.package_stash_value(&c.name.resolve()));
         }
-        Ok(Value::hash_with_data(Value::hash_arc(HashMap::new())))
+        // Builtin values (Int, Str, Array, ...) also answer .WHO with their
+        // type's Stash, same as the type object (raku: 42.WHO.^name is Stash).
+        Ok(self.package_stash_value(value_type_name(target)))
     }
 
     /// Dispatch .WHY method — returns a Pod::Block::Declarator instance

--- a/t/who-stash.t
+++ b/t/who-stash.t
@@ -1,0 +1,31 @@
+use v6;
+use Test;
+
+plan 12;
+
+# .WHO on builtin values (not just type objects) answers with the type's
+# Stash, same as Rakudo (42.WHO.^name is Stash, not Hash).
+
+is 42.WHO.^name, 'Stash', '.WHO on an Int value is a Stash';
+is "x".WHO.^name, 'Stash', '.WHO on a Str value is a Stash';
+my @a = 1, 2;
+is @a.WHO.^name, 'Stash', '.WHO on an Array instance is a Stash';
+is @a.WHO.gist, 'Array', '.WHO gist of an Array instance is the package name';
+my %h = a => 1;
+is %h.WHO.^name, 'Stash', '.WHO on a Hash instance is a Stash';
+is (@a>>.WHO).WHAT.gist, '(Stash)', '>>.WHO applies to the target and is a Stash';
+
+# Stash.raku renders the symbols hash literal (Stash is a Hash subclass in
+# Rakudo), not the generic `Stash.new`.
+
+is 42.WHO.raku, '{}', '.raku of an empty Stash is {}';
+class Foo { class Bar {} }
+is Foo.WHO.raku, '{:Bar(Foo::Bar)}', 'Stash.raku lists the nested package symbols';
+is Foo.WHO.gist, 'Foo', 'Stash.gist is the package name';
+is Foo.new.WHO.^name, 'Stash', '.WHO on a user-class instance is a Stash';
+is Foo.new.WHO.raku, '{:Bar(Foo::Bar)}', 'instance .WHO.raku matches the type stash';
+
+# The pseudo-package colon form still aliases .WHO.
+ok Foo:: === Foo.WHO, 'Foo:: is the same stash as Foo.WHO';
+
+done-testing;


### PR DESCRIPTION
## Summary

Two PLAN.md §8.6 fixes (the `.WHO`/`.HOW` metamodel-detail item), both verified against the reference `raku`:

- **`.WHO` on a builtin value returns the type's `Stash`.** `dispatch_who`'s fallback returned a plain empty `Hash` for any value that is not a Package/Instance/CustomType, so `42.WHO.^name` was `Hash` and `(@a>>.WHO).WHAT` was `(Hash)` where raku gives `(Stash)`. The fallback now resolves the value's type name (`value_type_name`) and returns the same `package_stash_value` stash the type object answers with.
- **`Stash.raku` renders the symbols hash literal.** Rakudo's Stash is a Hash subclass whose `.raku` is the symbols hash (`{:Bar(Foo::Bar)}`, `{}`), not the generic `Stash.new`. Added a native-instance repr arm next to the existing Scheduler/Supplier arms; `.gist`/`.Str` (the package name) were already correct on the fast path.

## Bookkeeping

- PLAN.md §8.6 slimmed to the leftover (Rakudo-internal builtin stash content like `Array::Element`, ClassHOW `+{<anon>}` mixin rendering — recorded as cosmetic/not-planned), with the landed half moved to `news/2026-07.md`.
- PLAN.md §8.1 first-batch findings re-verified: sequence/lazy argument truncation, empty-Array `pop` → `X::Cannot::Empty`, and lazy `.elems` → `X::Cannot::Lazy` are all fixed already; the only remaining divergence is autoviv-hole `.List` rendering `(Any)` where raku gives `Nil` (folded into the §8.5 / hole-tracking territory).

## Testing

- New pin `t/who-stash.t` (12 tests) — green under both mutsu and the reference `raku`.
- Full `t/` prove suite: 2298 files / 21660 tests, all pass.
- The 5 whitelisted roast files that use `.WHO` (`S02-packages/package-lookup.t`, `S11-modules/require.t`, `S17-promise/basic.t`, `S10-packages/precompilation.t`, `S11-repository/curli-install.t`) all pass.
- `cargo clippy -- -D warnings` and `cargo fmt --check` clean.
- (A `gc_stress::spawn_churn_does_not_starve_stop_the_world` failure during a local `make test` was load-contention from a parallel release build; it passes 3/3 standalone.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)