### PR TITLE
fix: qqx and backtick command quoting interpolate { EXPR } closure blocks

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -299,11 +299,16 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 - repro: _(fill in a minimal repro + raku baseline before fixing)_
 - file: _(suspected parser/runtime file)_
 
-### T-038 — test_fail: .text  [impact: 1 dist]
-- dists: PDF::Extract
-- e.g. `PDF::Extract`: base=1 pass=0 fail=1 die=0 | t/01-san.rakutest: .text
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
+### T-038 — test_fail: .text  [impact: 1 dist]  — FIXED (PR `fix-qqx-closure-interpolation`)
+- dists: PDF::Extract (t/01-san.rakutest 0/1 → 1/1)
+- Root cause: **`qqx` / backtick command quoting did not interpolate `{ EXPR }`
+  closure blocks**, only `$var`. PDF::Extract's `.text` builds its command line as
+  ``qqx`pdftotext -f {$!first} -l {$!last} '{$.file}' -` `` — mutsu left the braces
+  literal (`-f {1} -l {0} '{...}' -`), so pdftotext got no file arg and printed its
+  usage. `qx_string`/`backtick_qx_string` used `interpolate_string_content`
+  (closures off); now they pass closures on (unless the qqx delimiter is a brace,
+  where `{`/`}` are the delimiters). Pin: `t/qqx-closure-interpolation.t`.
+- file: `src/parser/primary/string/qx.rs`
 
 ### T-039 — test_fail: An object of type 'X' can do the method X  [impact: 1 dist]
 - dists: Chemistry::Elements

--- a/src/parser/primary/string/qx.rs
+++ b/src/parser/primary/string/qx.rs
@@ -35,7 +35,11 @@ pub(crate) fn qx_string(input: &str) -> PResult<'_, Expr> {
     };
 
     let command_expr = if is_qq {
-        interpolate_string_content(content)
+        // qqx does full qq interpolation, including `{ EXPR }` closure blocks.
+        // Closures are disabled only when the quote delimiter is itself a brace
+        // (`qqx{ ... }`), where `{`/`}` are the delimiters, not interpolation.
+        let closures = unicode_bracket_close(delim) != Some('}');
+        interpolate_string_content_with_modes(content, true, closures)
     } else {
         // qx uses q-style backslash (only \\ → \)
         let s = content.replace("\\\\", "\\");
@@ -65,7 +69,9 @@ pub(crate) fn backtick_qx_string(input: &str) -> PResult<'_, Expr> {
         .ok_or_else(|| PError::expected("closing '`'"))?;
     let content = &body[..end];
     let rest = &body[end + 1..];
-    let command_expr = interpolate_string_content(content);
+    // Backtick command quoting is qqx-equivalent: full interpolation, including
+    // `{ EXPR }` closure blocks (the delimiter is a backtick, never a brace).
+    let command_expr = interpolate_string_content_with_modes(content, true, true);
     Ok((
         rest,
         Expr::Call {

--- a/t/qqx-closure-interpolation.t
+++ b/t/qqx-closure-interpolation.t
@@ -1,0 +1,29 @@
+use Test;
+
+plan 6;
+
+# qqx (and backtick command quoting) must do full qq interpolation, including
+# `{ EXPR }` closure blocks — not just `$var`. (PDF::Extract's `.text` builds its
+# pdftotext command line with `qqx\`... {$!first} ... '{$.file}' ...\``.)
+
+my $x = 5;
+
+is qqx/echo {$x + 1}/.chomp, '6', 'qqx: closure block interpolates';
+is qqx/echo $x/.chomp, '5', 'qqx: scalar interpolation still works';
+is (qqx`echo {$x * 2}`).chomp, '10', 'backtick: closure block interpolates';
+
+# Attribute accessors inside a `{ }` block (the PDF::Extract shape).
+class C {
+    has $.file = "myfile.txt";
+    has $.first is rw = 1;
+    has $.last  is rw = 0;
+    method cmd {
+        (qqx`echo -f {$!first} -l {$!last} '{$.file}' -`).chomp
+    }
+}
+is C.new.cmd, "-f 1 -l 0 myfile.txt -", 'qqx interpolates attribute accessors in { } blocks';
+
+# Bracketed delimiters interpolate closures; a brace delimiter keeps inner
+# braces literal (they are the quote delimiters).
+is qqx[echo {$x + 1}].chomp, '6', 'qqx[...] interpolates closures';
+is qqx{echo hi}.chomp, 'hi', 'qqx{...} runs (brace delimiter)';


### PR DESCRIPTION
## Summary

`qqx` and backtick command quoting only interpolated `$var`, **not `{ EXPR }`
closure blocks** — the surrounding braces were left literal (dist-compat ticket
**T-038**, surfaced by **PDF::Extract**).

PDF::Extract's `.text` builds its command line as:

```raku
qqx`pdftotext -f {$!first} -l {$!last} '{$.file}' -`
```

mutsu produced `pdftotext -f {1} -l {0} '{myfile.pdf}' -`, so `pdftotext` got no
usable file argument and printed its usage message instead of the extracted text.

## Fix

`qx_string` and `backtick_qx_string` used `interpolate_string_content`, which
disables closure interpolation. They now enable it — **unless the qqx delimiter
is itself a brace** (`qqx{ ... }`, where `{`/`}` are the delimiters, matching the
qq rule). `qx` (single-q semantics) is unchanged and still does not interpolate.

## Testing

- New pin `t/qqx-closure-interpolation.t` (verified identical on raku)
- PDF::Extract `t/01-san.rakutest` now passes 1/1
- Whitelisted `roast/S02-literals/{quoting,string-interpolation,misc-interpolation,adverbs,heredocs,array-interpolation}.t` pass
- `make test`: PASS (21654 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)