### PR TITLE
fix: a positional index on a runtime Any value returns Any

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -283,16 +283,23 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   backtracking (`regex`) separator matchers; interior/trailing empties already worked.
   Fix: accept a zero-width first atom (bounded by the extension loop's `atom_end <= cur`
   no-progress guard) in `regex_match_sep.rs`. Pin: `t/regex-separator-leading-empty.t`.
-- **Status:** 02-grammar 0 → **23/23**; 01-basic 1/1. **Remaining (separate, deeper —
-  not this ticket):** (a) **03-actions** dies on `%parameter<value>[0]` where
-  `%parameter<value>` is `Any` — a postcircumfix `[idx]` on a runtime-`Any` value is
-  mis-dispatched as type parameterization ("Any cannot be parameterized") instead of
-  returning `Any` (repro: `my %h; %h<k>[0]`; `vm/vm_var_index_ops.rs` ~1868 handles the
-  non-positional Any subscript but not the positional one); (b) `parsefile` of a full
-  multi-vcard file (test-card1/2) fails while test-card4 passes.
+- **FOURTH ROOT CAUSE FIXED (PR `fix-positional-index-on-any`).** 03-actions dies on
+  `%parameter<value>[0]` where `%parameter<value>` is `Any`: a postcircumfix POSITIONAL
+  `[idx]` on a runtime-`Any` value was mis-dispatched as a type parameterization
+  ("Any cannot be parameterized") instead of returning `Any` (repro: `my %h; %h<k>[0]`).
+  `vm/vm_var_index_ops.rs` already returned Any for the non-positional Any subscript;
+  now the positional case does too, intercepted before the non-parametric-type check
+  when the index is a plain value (a type-object index — `Any[Int]` — still throws).
+  A slice `$any[0,1]` yields a matching-length list of Any. Pin:
+  `t/positional-index-on-any.t`. (03-actions now runs its content-line `.made` action
+  path; tests 3–4 pass.)
+- **Status:** 02-grammar **23/23**; 01-basic 1/1; 03-actions 4/9. **Remaining (separate,
+  deeper — not this ticket):** `parsefile` of a full multi-vcard file (test-card1/2,
+  and 03-actions test 5, 04-from-vCard) fails while test-card4 passes — a multi-`<vcard>`
+  `parsefile` / `.made` action-tree bug, unrelated to the four fixed root causes.
 - file: DONE — src/runtime/methods_dispatch_match.rs, runtime_class_query.rs,
-  regex_parse_core.rs, regex/regex_match_sep.rs; remaining — positional Any postcircumfix
-  index (vm_var_index_ops.rs), multi-vcard parsefile.
+  regex_parse_core.rs, regex/regex_match_sep.rs, vm/vm_var_index_ops.rs; remaining —
+  multi-vcard parsefile.
 
 ### T-036 — test_die: plan expects Int (plan * fixed; deeper cardinal bugs remain)  [impact: 1 dist]
 - dists: Lingua::EN::Numbers

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -161,6 +161,24 @@ impl Interpreter {
         items.iter().map(Self::index_to_usize).collect()
     }
 
+    /// Whether a `[...]` subscript on a type object is a type *parameterization*
+    /// (`Any[Int]`, `Any[Int, Str]`) rather than a positional *index*
+    /// (`$any[0]`). A single type object, or a list whose every element is a
+    /// type object, is a parameterization; any plain value (or a list
+    /// containing one) is an index.
+    fn index_is_type_parameterization(idx: &ValueView) -> bool {
+        match idx {
+            ValueView::Package(_) => true,
+            ValueView::Array(items, ..) => {
+                !items.is_empty()
+                    && items
+                        .iter()
+                        .all(|v| matches!(v.view(), ValueView::Package(_)))
+            }
+            _ => false,
+        }
+    }
+
     /// Lazy variant of IndexAutovivify: returns a HashEntryRef without creating
     /// the hash entry if it doesn't exist. Used for `:=` bind expressions
     /// so that `my $b := %h<a><b>` doesn't autovivify until assignment.
@@ -1867,6 +1885,28 @@ impl Interpreter {
             // from Any so that `%h<missing><b> === Any` holds.
             (ValueView::Package(name), _) if !is_positional && name.resolve() == "Any" => {
                 Value::package(Symbol::intern("Any"))
+            }
+            // Postcircumfix POSITIONAL index (`[idx]`) on the bare Any type object —
+            // a runtime Any value (e.g. from a missing hash key: `my %h; %h<k>[0]`)
+            // indexed positionally — returns Any per Raku, rather than being
+            // mis-read as a type parameterization. A type-object index (`Any[Int]`,
+            // a genuine parameterization attempt) still falls through to
+            // X::NotParametric below, so only a plain value index is intercepted.
+            // A slice (`$any[0, 1]`) yields a matching-length list of Any.
+            (ValueView::Package(name), idx)
+                if is_positional
+                    && name.resolve() == "Any"
+                    && !Self::index_is_type_parameterization(&idx) =>
+            {
+                match idx {
+                    ValueView::Array(items, ..) => Value::array(
+                        items
+                            .iter()
+                            .map(|_| Value::package(Symbol::intern("Any")))
+                            .collect(),
+                    ),
+                    _ => Value::package(Symbol::intern("Any")),
+                }
             }
             // Parameterizing a user-declared class / package / module that is NOT
             // parametric throws X::NotParametric. Roles (handled above), built-in

--- a/t/positional-index-on-any.t
+++ b/t/positional-index-on-any.t
@@ -1,0 +1,32 @@
+use Test;
+
+plan 10;
+
+# A POSITIONAL postcircumfix index (`[idx]`) on a runtime `Any` value returns
+# Any (Rakudo S09), rather than being mis-read as a type parameterization.
+# (Regression: `my %h; %h<k>[0]` threw "Any cannot be parameterized".)
+
+my %h;
+is-deeply %h<missing>[0], Any, 'positional [0] on a missing hash value is Any';
+is-deeply %h<missing>[5], Any, 'positional [5] on a missing hash value is Any';
+is-deeply %h<a><b>[0],   Any, 'chained missing-key then [0] is Any';
+
+my @a;
+is-deeply @a[99][0], Any, 'nested [i][0] on a missing array slot is Any';
+
+my $any = Any;
+is-deeply $any[0], Any, 'positional [0] on a bare Any scalar is Any';
+
+# A slice yields a matching-length list of Any.
+is-deeply %h<missing>[0, 1].list, (Any, Any).list, 'slice on Any is a list of Any';
+is %h<missing>[0, 1, 2].elems, 3, 'slice length is preserved';
+
+# Non-positional subscript on Any still returns Any (unchanged).
+is-deeply %h<missing><b>, Any, 'associative subscript on Any is Any';
+
+# A genuine type parameterization on a non-parametric type still throws.
+dies-ok { my $x = Any.WHAT[Int]; }, 'Any[Int] (type parameterization) still dies';
+
+# Real containers still index normally (no accidental capture).
+my @real = 10, 20, 30;
+is @real[1], 20, 'a real array still indexes normally';


### PR DESCRIPTION
A POSITIONAL postcircumfix index (`[idx]`) on a bare `Any` value — e.g. the result of a missing hash key — threw `"Any cannot be parameterized"` instead of returning `Any` (Rakudo S09):

```raku
my %h;
%h<k>[0]      # was: "Any cannot be parameterized"; now: Any
%h<a><b>[0]   # Any
$any[0, 1]    # (Any, Any)  — slice yields a matching-length list of Any
```

The VM already returned Any for the *non-positional* Any subscript (`%h<k><b>`), but the positional case fell through to the non-parametric-type check and was mis-read as a type parameterization.

**Fix:** intercept a positional index on the Any type object when the index is a plain value, returning Any. A genuine type-object index (`Any[Int]`) is still a parameterization attempt and continues to throw `X::NotParametric`.

## Impact

This is the **vCard::Parser** `03-actions` blocker: its `content-line` action reads `%parameter<value>[0]` where `value` is often absent (Any). With this fix the action path runs and 03-actions advances past it (tests 3–4 pass; the remaining failures are a separate multi-vcard `parsefile` bug).

Verified against `raku`. Pin: `t/positional-index-on-any.t`

🤖 Generated with [Claude Code](https://claude.com/claude-code)