### PR TITLE
feat: Cool.Version + Version.raku ctor-form rule; §8.2 method-coverage harness

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1131,10 +1131,17 @@ the backlog.
       ` # OUTPUT: «…»` annotation that is a built-in oracle — and run them through 8.1. This is the
       structured, objective form of "read the docs to find gaps"; do **not** do the read-and-guess
       form. Complements the one-shot `raku-doc` audits already recorded in §4.
-- [ ] **Per-type method-coverage matrix**: for each `Type/*.rakudoc`, enumerate the documented methods
-      and check which mutsu implements (call each / introspect), producing an "N of M implemented"
-      table per type. This surfaces the **never-called holes** a diff over existing examples cannot: a
-      method with no doc example is invisible to the bullet above.
+- [ ] **Per-type method-coverage matrix** — **harness landed** (`scripts/method-coverage.raku`,
+      2026-07-22): extracts every `=head2 method/routine` from `Type/*.rakudoc` and probes both
+      interpreters with a dynamic call across several argument shapes; a hole = mutsu answers
+      "No such method" on every shape where raku dispatches (`^can` is unusable on both sides —
+      raku over-answers via Any/Cool inheritance, mutsu under/over-answers). Crashing probes are
+      isolated by a PROBE/RES retry protocol and reported as `crash` (§8.3 findings for free).
+      Output: `tmp/method-coverage.tsv` + `tmp/method-coverage-summary.md`. First findings:
+      `Cool.Version` (fixed with the harness PR), `.subst-mutate` unreachable via a *dynamic*
+      method call (any CallMethodMut-opcode-only method — the dynamic path never routes to the
+      mut-op table), `Mu.return`/`Mu.emit` probe crashes. TODO: run the full-corpus triage and
+      fold the per-type hole list into `docs/doc-diff-backlog.md`.
 
 ### 8.3 Robustness — zero panics / crashes
 
@@ -1194,14 +1201,6 @@ the backlog.
       and `Array.HOW.raku`'s anonymous-mixin rendering (`ClassHOW+{<anon>}+{<anon>}.new`).
       Faking either means hardcoding Rakudo internals; only worth doing if a real program is
       ever found to introspect them.
-
-### 8.7 `.kv` on a Hash::Agnostic role returns `()`
-
-- [ ] **`.kv` on a Hash::Agnostic role returns `()`** (raku yields the flattened k/v list) — the
-      last Hash::Agnostic dist gap (subtest 13). Separate pre-existing issue: the role's
-      `method kv { Seq.new(KV.new(:backend(self), :iterator(self.keys.iterator))) }` uses a custom
-      `KV` iterator instance, and mutsu's `Seq.new(<custom Iterator instance>)` does not pull from
-      it (same family as the `from-iterator` gap fixed in #5132). Investigate independently.
 
 ### 8.9 The word-logical operators `and`/`or`/`andthen`/`orelse`/`xor` bind too tightly (deferred deep item — found 2026-07-22 by the traps.rakudoc doc-diff sweep)
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -33,6 +33,30 @@ Driven as a dedicated deep slice per the "autostart dedicated sessions" policy. 
 resolved several `numerics.rakudoc` doc-diff lines for free (big-FatRat division
 contagion, `RatStr.FatRat`, `(42 + FatRat.new(1,2))/huge`).
 
+## 2026-07-22: `Cool.Version`, the `Version.raku` ctor-form rule, and the §8.2 method-coverage harness
+
+The first §8.2 deliverable landed: `scripts/method-coverage.raku` extracts every documented
+`=head2 method/routine` from `Type/*.rakudoc` and probes both interpreters with dynamic
+calls across several argument shapes (a hole = "No such method" on every shape where raku
+dispatches; `^can` is unusable as the oracle on either side, and mutsu's arity-keyed
+dispatch reports an arity miss as "No such method", which single-shape probing would
+misread as ~everything missing). Crashing probes are isolated via a PROBE/RES line
+protocol and double as §8.3 robustness findings (first catch: `Mu.return` / `Mu.emit`
+abort the process).
+
+Its first verified hole is fixed in the same PR: **`Cool.Version` was missing** — now
+`"6.c".Version`, `42.Version` etc. build the Version from `self.Str`. That surfaced the
+**`Version.raku` ctor-form rule**: Rakudo renders the `v` literal form only when the
+canonical string starts with an ASCII digit (`v6.c`, `v6.*`, `v1.2+`) and otherwise the
+constructor form (`Version.new('True')`, `Version.new('*.6')`, bare `Version.new` when
+empty); mutsu unconditionally printed `v...`. Both the native repr and the container-leaf
+`.raku` path now share `version_raku_repr`. Pin: `t/cool-version.t` (16 assertions,
+verified green under the reference `raku`).
+
+Also verified fixed & de-listed from PLAN §8.7 (landed earlier via the deferred-Seq
+reification + double-slurpy fixes): the Hash::Agnostic dist now passes `t/01-basic.rakutest`
+22/22 and `t/02-minimal.rakutest` 11/11.
+
 ## 2026-07-22: `.WHO` on builtin values is a Stash; `Stash.raku` is the symbols hash (PLAN §8.6)
 
 `.WHO` on a *builtin value* (`42.WHO`, `@a.WHO`, `"x".WHO`) fell through `dispatch_who` to

--- a/scripts/method-coverage.raku
+++ b/scripts/method-coverage.raku
@@ -1,0 +1,252 @@
+#!/usr/bin/env raku
+# method-coverage.raku — per-type method-coverage matrix (PLAN.md §8.2).
+#
+# For each raku-doc Type/*.rakudoc file it extracts the documented method /
+# routine names and probes BOTH the reference `raku` and `mutsu` with a
+# zero-argument dynamic call on a sample value of the type. Only a
+# "No such method" outcome counts as a hole — any other error (arity, type
+# check, undefined invocant, ...) proves dispatch *found* the method. This
+# surfaces the never-called holes that a diff over existing doc examples
+# cannot see (a documented method with no example is invisible to §8.1).
+#
+# raku is the oracle: a (type, method) row is a reportable hole only when
+# mutsu lacks it AND raku finds it, so doc drift never floods the report.
+#
+# A method whose probe crashes/hangs the interpreter mid-batch is retried
+# with the crasher excluded (PROBE/RES line protocol), and reported with
+# status `crash` — those rows double as §8.3 robustness findings.
+#
+# Usage:
+#   raku scripts/method-coverage.raku [--mutsu=PATH] [--timeout=N]
+#                                     [--report=FILE] [--summary=FILE]
+#                                     [FILES-OR-DIRS ...]
+# Defaults: mutsu=target/debug/mutsu, timeout=30s/type, corpus=raku-doc/doc/Type.
+
+# Methods never worth probing: process-fatal, filesystem-mutating, or
+# stdout-noisy calls. Reported as `skipped`.
+my constant %DENY = <
+    exit run shell spurt unlink rmdir mkdir rename move copy symlink link
+    chdir chmod kill print put say note prompt sleep sleep-until bail-out
+    done-testing plan diag flunk exec QuitProcess restore
+>.map(* => True).Hash;
+
+# Sample invocants: a defined instance where one is cheap to make (instance
+# methods dispatch more faithfully than on a type object), else the type
+# object via ::('Name').
+my constant %SAMPLE =
+    'Str'      => '""',
+    'Int'      => '0',
+    'Num'      => '0e0',
+    'Rat'      => '0.5',
+    'FatRat'   => 'FatRat.new(1, 2)',
+    'Complex'  => '1i',
+    'Bool'     => 'True',
+    'Array'    => '[1]',
+    'List'     => '(1,)',
+    'Hash'     => '%(:a(1))',
+    'Map'      => 'Map.new((:a(1)))',
+    'Set'      => 'set(1)',
+    'SetHash'  => 'SetHash.new(1)',
+    'Bag'      => 'bag(1)',
+    'BagHash'  => 'BagHash.new(1)',
+    'Mix'      => 'mix(1)',
+    'MixHash'  => 'MixHash.new(1)',
+    'Range'    => '(1..2)',
+    'Pair'     => '(:a(1))',
+    'Seq'      => '(1, 2).Seq',
+    'Slip'     => '(1, 2).Slip',
+    'Date'     => 'Date.new(2000, 1, 1)',
+    'DateTime' => 'DateTime.new(year => 2000)',
+    'Duration' => 'Duration.new(1)',
+    'Instant'  => 'now',
+    'Version'  => 'v1.2',
+    'IO::Path' => '"/tmp".IO',
+    'Regex'    => 'rx/a/',
+    'Match'    => '("a" ~~ rx/a/)',
+    'Junction' => 'any(1, 2)',
+;
+
+sub MAIN(
+    *@paths,
+    Str  :$mutsu   = 'target/debug/mutsu',
+    Int  :$timeout = 30,
+    Str  :$report  = 'tmp/method-coverage.tsv',
+    Str  :$summary = 'tmp/method-coverage-summary.md',
+) {
+    my @files = collect-files(@paths);
+    note "Scanning { +@files } Type .rakudoc files ...";
+
+    mkdir 'tmp/mcov' unless 'tmp/mcov'.IO.d;
+    my $prog-path = "tmp/mcov/probe-{$*PID}.raku";
+
+    my @rows;                     # [type, method, mutsu-status, raku-status]
+    for @files.sort -> $file {
+        my $type = type-name($file);
+        my @methods = extract-methods($file);
+        next unless @methods;
+        my (%mutsu-res, %raku-res);
+        %mutsu-res = probe($mutsu, $type, @methods, $prog-path, $timeout);
+        %raku-res  = probe('raku', $type, @methods, $prog-path, $timeout);
+        for @methods -> $m {
+            @rows.push: [$type, $m, %mutsu-res{$m} // 'crash', %raku-res{$m} // 'crash'];
+        }
+        my $holes = @methods.grep({ hole(%mutsu-res{$_} // 'crash', %raku-res{$_} // 'crash') });
+        note "  $type: { +@methods } documented, { +$holes } holes";
+    }
+
+    spurt $report, @rows.map(*.join("\t")).join("\n") ~ "\n";
+    write-summary($summary, @rows);
+    note "Report: $report";
+    note "Summary: $summary";
+}
+
+sub hole($mutsu-status, $raku-status) {
+    $mutsu-status eq 'nomethod' | 'crash' and $raku-status eq 'ok' | 'err';
+}
+
+sub collect-files(@paths) {
+    my @roots = @paths ?? @paths !! ('raku-doc/doc/Type',);
+    my @files;
+    for @roots -> $p {
+        if $p.IO.d {
+            @files.append: walk($p.IO);
+        }
+        elsif $p.IO.f {
+            @files.push: $p.IO;
+        }
+    }
+    @files
+}
+
+sub walk(IO::Path $dir) {
+    my @out;
+    for $dir.dir.sort -> $e {
+        if $e.d { @out.append: walk($e) }
+        elsif $e.extension eq 'rakudoc' { @out.push: $e }
+    }
+    @out
+}
+
+sub type-name(IO::Path $file) {
+    my $rel = $file.Str;
+    $rel ~~ s/ .* '/Type/' //;
+    $rel ~~ s/ '.rakudoc' $ //;
+    $rel.subst('/', '::', :g)
+}
+
+sub extract-methods(IO::Path $file) {
+    my %seen;
+    my @methods;
+    for $file.lines -> $line {
+        next unless $line ~~ /^ '=head2' \s+ [ 'multi' \s+ ]? [ 'method' | 'routine' ] \s+ (\S+) \s* $/;
+        my $name = ~$0;
+        # Only plain method identifiers: no markup, no operator forms.
+        next unless $name ~~ /^ <[a..z A..Z]> <[a..z A..Z 0..9 _ \-]>* <[! ?]>? $/;
+        next if %seen{$name}++;
+        @methods.push: $name;
+    }
+    @methods
+}
+
+# Run one interpreter over a type's method list; returns method => status.
+# status: ok | err | nomethod | skipped | crash | notype
+sub probe(Str $bin, Str $type, @methods, Str $prog-path, Int $timeout) {
+    my %res;
+    for @methods.grep({ %DENY{$_} }) -> $m { %res{$m} = 'skipped' }
+    my @todo = @methods.grep({ !%DENY{$_} });
+    my %skip;
+    # Retry loop: a crash mid-batch marks the dangling PROBE method as crashed
+    # and reruns the remainder without it.
+    for ^(1 + @todo.elems) {
+        my @batch = @todo.grep({ !%skip{$_} && !(%res{$_}:exists) });
+        last unless @batch;
+        my $src = probe-program($type, @batch);
+        spurt $prog-path, $src;
+        my $proc = run 'timeout', $timeout.Str, |$bin.words, $prog-path,
+                   :out, :err, :in;
+        # `.close` on a Proc pipe returns the Proc; in sink context that sunk
+        # Proc throws X::Proc::Unsuccessful on a nonzero exit — bind it away.
+        my $ = $proc.in.close;
+        my $out = $proc.out.slurp(:close);
+        my $ = $proc.err.slurp(:close);
+        my $ = $proc.exitcode;
+        my $pending = '';
+        for $out.lines {
+            when /^ 'PROBE ' (\S+) $/ { $pending = ~$0 }
+            when /^ 'RES ' (\S+) ' ' (\S+) $/ { %res{~$0} = ~$1; $pending = '' }
+            when /^ 'NOTYPE' $/ {
+                %res{$_} = 'notype' for @batch;
+                return %res;
+            }
+        }
+        if $pending {
+            %res{$pending} = 'crash';
+            %skip{$pending} = True;
+        }
+        else {
+            last;   # completed (or produced nothing parseable — avoid looping)
+        }
+    }
+    %res
+}
+
+sub probe-program(Str $type, @methods) {
+    my $sample = %SAMPLE{$type} // "::('$type')";
+    my $names = @methods.map({ "'$_'" }).join(', ');
+    q:to/END/.subst('%SAMPLE%', $sample).subst('%TYPE%', $type).subst('%NAMES%', $names);
+    my $sample;
+    {
+        $sample = %SAMPLE%;
+        CATCH { default { say "NOTYPE"; exit 0 } }
+    }
+    # mutsu's arity-keyed dispatch reports an arity miss as "No such method",
+    # so a zero-arg probe alone would flag every 1+-arg method as a hole.
+    # Retry across several argument shapes; the method is a hole only when
+    # EVERY shape answers "no such method".
+    my @shapes = \(), \(0), \('a'), \(0, 0), \('a', 'b'), \(Any);
+    for (%NAMES%) -> $m {
+        say "PROBE $m";
+        my $status = 'nomethod';
+        for @shapes -> $c {
+            my $s = 'ok';
+            {
+                my $ = $sample."$m"(|$c);
+                CATCH { default {
+                    $s = .message ~~ /:i 'no such method'/ ?? 'nomethod' !! 'err';
+                } }
+            }
+            if $s ne 'nomethod' {
+                $status = $s;
+                last;
+            }
+        }
+        say "RES $m $status";
+    }
+    END
+}
+
+sub write-summary(Str $path, @rows) {
+    my %by-type;
+    for @rows -> [$type, $m, $ms, $rs] {
+        %by-type{$type}.push: [$m, $ms, $rs];
+    }
+    my @lines = '# Per-type method-coverage matrix (PLAN.md §8.2)', '',
+        'Documented = `=head2 method/routine` entries in the type\'s rakudoc.',
+        'A hole = mutsu answers "No such method" (or crashes) where raku dispatches.',
+        '', '| Type | Documented | Implemented | Holes |', '|---|---|---|---|';
+    my @hole-lines;
+    for %by-type.keys.sort -> $type {
+        my @ms = %by-type{$type}.list;
+        my $doc = +@ms;
+        my @holes = @ms.grep({ hole(.[1], .[2]) });
+        my $impl = +@ms.grep({ .[1] eq 'ok' | 'err' });
+        @lines.push: "| $type | $doc | $impl | { +@holes } |";
+        if @holes {
+            @hole-lines.push: "- **$type**: " ~ @holes.map({
+                .[1] eq 'crash' ?? "{.[0]} (CRASH)" !! .[0]
+            }).join(', ');
+        }
+    }
+    @lines.append: '', '## Holes by type', '', |@hole-lines, '';
+    spurt $path, @lines.join("\n");
+}

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -773,6 +773,28 @@ pub(super) fn dispatch(
                 Some(None)
             }
         }
+        "Version" => match target.view() {
+            // Cool.Version: Version.new(self.Str). A Version invocant is
+            // already its own version.
+            ValueView::Version { .. } => Some(Some(Ok(target.clone()))),
+            ValueView::Str(_)
+            | ValueView::Int(_)
+            | ValueView::BigInt(_)
+            | ValueView::Num(_)
+            | ValueView::Rat(_, _)
+            | ValueView::BigRat(_, _)
+            | ValueView::FatRat(_, _)
+            | ValueView::Bool(_) => {
+                let s = target.to_string_value();
+                if s.is_empty() {
+                    Some(Some(Ok(Value::version(Vec::new(), false, false))))
+                } else {
+                    let (parts, plus, minus) = Value::parse_version_string(&s);
+                    Some(Some(Ok(Value::version(parts, plus, minus))))
+                }
+            }
+            _ => None,
+        },
         "Num" => {
             let result = match target.view() {
                 ValueView::Int(i) => Value::num(i as f64),

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -465,7 +465,14 @@ pub(super) fn dispatch(
             } else {
                 ""
             };
-            Some(Ok(Value::str(format!("v{}{}", s, suffix))))
+            let full = format!("{}{}", s, suffix);
+            // .gist always keeps the `v` prefix (`vTrue`); only .raku/.perl
+            // switch to the constructor form for a non-literal version.
+            if method == "gist" {
+                Some(Ok(Value::str(format!("v{}", full))))
+            } else {
+                Some(Ok(Value::str(super::raku_repr::version_raku_repr(&full))))
+            }
         }
         ValueView::Str(s) => {
             if method == "raku" || method == "perl" {

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -254,6 +254,23 @@ pub(crate) fn uni_raku_repr(text: &str, form: &str) -> String {
     format!("Uni.new({}){}", codepoints.join(", "), suffix)
 }
 
+/// The `.raku` text of a Version: the `v` literal form when the canonical
+/// string round-trips as a version literal (it starts with an ASCII digit —
+/// Rakudo: `v6.c`, `v6.*`, `v1.2+`), else the constructor form
+/// (`Version.new('True')`, `Version.new('*.6')`, bare `Version.new` when empty).
+pub(crate) fn version_raku_repr(full: &str) -> String {
+    if full.is_empty() {
+        "Version.new".to_string()
+    } else if full.starts_with(|c: char| c.is_ascii_digit()) {
+        format!("v{full}")
+    } else {
+        format!(
+            "Version.new('{}')",
+            full.replace('\\', "\\\\").replace('\'', "\\'")
+        )
+    }
+}
+
 /// Whether a string key may be rendered in the adverbial pair form
 /// `:key(value)`. Mirrors Raku's `<.ident>`: the key must start with a letter
 /// or `_`, continue with word chars, and may contain `-`/`'` only when each is
@@ -864,7 +881,7 @@ pub fn raku_value(v: &Value) -> String {
         ValueView::Nil => "Nil".to_string(),
         // A Version renders as its `v`-prefixed literal (`v1.2`, `v1.2+`) —
         // `.Str` drops the `v`, `.raku` keeps it.
-        ValueView::Version { .. } => format!("v{}", v.to_string_value()),
+        ValueView::Version { .. } => version_raku_repr(&v.to_string_value()),
         // An enum value renders qualified (`Order::Less`); without this arm a
         // nested enum fell through to its bare string value (`Less`).
         ValueView::Enum { enum_type, key, .. } => {

--- a/t/cool-version.t
+++ b/t/cool-version.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+plan 16;
+
+# Cool.Version — Version.new(self.Str) on any Cool value.
+is "6.c".Version.raku, 'v6.c', 'Str.Version';
+is 42.Version.raku, 'v42', 'Int.Version';
+is (0.5).Version.raku, 'v0.5', 'Rat.Version';
+is 4e0.Version.raku, 'v4', 'Num.Version';
+is (v1.2).Version.raku, 'v1.2', 'Version.Version is identity';
+isa-ok "1.2.3".Version, Version, 'Str.Version returns a Version';
+is "1.2.3".Version.parts.elems, 3, 'parts split on the dots';
+
+# Version.raku renders the v literal form only when the canonical string
+# starts with a digit; anything else uses the constructor form.
+is True.Version.raku, "Version.new('True')", 'non-literal version rakus as Version.new';
+is "".Version.raku, 'Version.new', 'empty version rakus as bare Version.new';
+is Version.new("*").raku, "Version.new('*')", 'leading whatever-part uses the ctor form';
+is Version.new("6.*").raku, 'v6.*', 'digit-leading whatever version keeps the v form';
+is Version.new("6c").raku, 'v6.c', 'alnum run splits into literal parts';
+is (v1.2+).raku, 'v1.2+', 'the + suffix stays in the v form';
+
+# gist / Str are unaffected by the ctor-form rule.
+is True.Version.gist, 'vTrue', 'gist always keeps the v prefix';
+is (v1.2).Str, '1.2', 'Str has no v prefix';
+is [v1.2, "True".Version].raku, "[v1.2, Version.new('True')]", 'container leaf uses the same rule';
+
+done-testing;


### PR DESCRIPTION
## Summary

Working PLAN.md §8 in order — this lands the first §8.2 deliverable plus the hole it immediately found:

- **`scripts/method-coverage.raku`** (§8.2 per-type method-coverage matrix): extracts every documented `=head2 method/routine` from `Type/*.rakudoc` and probes **both** interpreters with a dynamic zero-to-two-arg call sweep; a hole = mutsu answers "No such method" on *every* argument shape where raku dispatches. `^can` is unusable as the oracle on either side (raku over-answers via Any/Cool inheritance; mutsu's arity-keyed dispatch reports an arity miss as "No such method", which single-shape probing would misread as ~everything missing). Crashing probes are isolated via a PROBE/RES line protocol and double as §8.3 robustness findings (first catch: `Mu.return` / `Mu.emit` abort the process; `subst-mutate` is unreachable via a dynamic method call — CallMethodMut-opcode-only).
- **`Cool.Version` was missing** — the harness's first verified hole. Now `"6.c".Version`, `42.Version`, `True.Version` etc. build the Version from `self.Str`.
- **`Version.raku` ctor-form rule**: Rakudo renders the `v` literal form only when the canonical string starts with an ASCII digit (`v6.c`, `v6.*`, `v1.2+`) and otherwise the constructor form (`Version.new('True')`, `Version.new('*.6')`, bare `Version.new` when empty); mutsu unconditionally printed `v...`. Both the native repr and the container-leaf `.raku` path now share `version_raku_repr`; `.gist` keeps the `v` prefix unconditionally (matches raku).
- **PLAN.md §8.7 removed** — verified fixed on main (Hash::Agnostic dist `t/01-basic.rakutest` 22/22, `t/02-minimal.rakutest` 11/11, landed via the deferred-Seq reification + double-slurpy fixes).

## Testing

- New pin `t/cool-version.t` (16 assertions) — green under both mutsu and the reference `raku`.
- Version-related roast files all pass: `S02-types/version.t`, `S02-types/version-stress.t`, `S02-literals/version.t`, `6.d/S02-literals/version.t`, `S11-modules/versioning.t`, `S14-roles/versioning.t` (2161 tests).
- Full `t/` prove (debug, -j4): green except two failures unrelated to this diff — `t/concurrent-compound-assign.t` (load flake under heavy parallel load; passes 3/3 standalone) and `t/export-sub-infix-operator-closure.t`, which is a **pre-existing debug-only deterministic stack overflow from #5239** (release passes 3/3, JIT on or off; debug aborts 5/5 even with a 64 MB stack — an infinite by-name infix re-dispatch cycle the release build somehow avoids). I'm taking that up as the next slice.
- `cargo clippy -- -D warnings` and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)