### PR TITLE
fix: an optional :D named param does not match a call that omits it

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1386,6 +1386,38 @@ item also showed `[:a].raku` renders `[:a]` where raku spells `[:a(Bool::True)]`
 - [ ] **`IO::Spec::Unix.new.raku` renders the type-object form `IO::Spec::Unix`** and its
       gist is `(Unix)`; raku renders `IO::Spec::Unix.new` for both.
 
+### 8.16 Inline grammar-action `make` values do not persist on subrule Match nodes (found 2026-07-22 by the seed-555 dist sweep; Time::Duration::Parser)
+
+An **inline** grammar action (`token duration { s { make 1 } }`, i.e. a `{ make … }`
+code block inside the rule rather than a separate `.parse(:actions)` class) sets the
+rule's `.made` (AST) value, but that value is **not attached to the subrule's Match
+node** in the parse tree. So a parent action that reads `$<subrule>.made` — or, for a
+quantified subrule, `$<subrule>».made` — sees `Any`/`Nil` instead of the produced value.
+
+Minimal repro (raku: `TOP.made` = 60; mutsu = 0):
+```raku
+grammar G {
+    rule TOP  { <time>+ % <sep> { make [+] $<time>».made } }
+    rule time { <number> { make +$<number> * 10 } }
+    token number { \d+ }
+    token sep { <.ws> }
+}
+my $r = G.parse("1 2 3");
+say $r<time>».made;   # raku: [10 20 30]   mutsu: [(Any) (Any) (Any)]
+say $r.made;          # raku: 60           mutsu: 0
+```
+Only the **top** Match gets its `ast` attribute set (from env `"made"` after the top
+code block, in `seq_helpers/smart_match.rs` ~line 761). Each subrule's inline-`make`
+value must instead be committed to its own `RegexCaptures` node during the match and
+carried into the sub-Match built by `make_match_object_full_q`
+(`src/value/value_methods_c.rs`) so `$<x>.made` / `$<x>».made` resolve in parent actions
+and post-parse. This is orthogonal to the action-class walk in
+`methods_grammar.rs::invoke_grammar_actions` (which handles `.parse(:actions)`), and to
+the reduce-time `.made`-in-`<?{…}>` hook (`regex/regex_eval.rs`), both of which already
+work. Blocks **Time::Duration::Parser** (0/42 — every case chains `$<time>».made`) and any
+grammar that reduces child AST values in a parent inline action. Moderate blast radius
+(regex capture struct + Match builder + the match commit path); a dedicated session.
+
 ---
 
 ## Metrics

--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -584,6 +584,50 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 - file: `src/vm/vm_var_trait_ops.rs` (backing), `src/runtime/registration_role.rs` +
   `src/runtime/class.rs` (public/private methods, gap 2), multi-dispatch (gap 3)
 
+<!-- New actionable tickets from the seed-555 fresh sweep (2026-07-22). Known
+     already-blocked root causes (ObjectCache/ValueTypeCache = nqp cluster, XML,
+     Crane compile, P5reset = Slice-F) are NOT re-added. -->
+
+### T-053 — test_fail: BIT add/get [Algorithm::BinaryIndexedTree]  [impact: 1 dist]  — FIXED (PR `fix-multi-optional-named-definite`)
+- dists: Algorithm::BinaryIndexedTree (t/01-basic.t 1/5 → 5/5)
+- No-arg `.new` picked `multi submethod BUILD(Int:D :$!size)` with `$!size`
+  undefined instead of `multi submethod BUILD()`. Root cause: an omitted optional
+  `:D` named param must not match, and `:$!size`'s external key is `size` (twigil
+  stripped). Fixed in `src/runtime/types/args_matching.rs`. Pin:
+  `t/multi-optional-named-definite.t`.
+
+### T-054 — test_fail: builtin push/pop return value [P5push]  [impact: 1 dist]
+- dists: P5push
+- `P5push` exports `proto sub push`/`multi sub push(@a,*@v --> Int:D){...}` and
+  `pop`. mutsu's builtin `push`/`pop` shadow the imported subs in EVERY call form
+  (`push @a,x`, `push(@a,x)`, `&push(@a,x)`), so `push @a, 42` returns the array,
+  not the new elem count. **DEFER**: an imported `sub push` overriding the builtin
+  listop is the same compile-time-import problem as Understitch's `_` operator
+  (mutsu processes `use` at runtime); poor ROI.
+- file: builtin-vs-imported-sub dispatch priority (deep)
+
+### T-055 — test_fail: 1 s -> 1 second [Time::Duration::Parser]  [impact: 1 dist]
+- dists: Time::Duration::Parser
+- e.g. base=1 pass=0 fail=1 die=0 | t/00-basic.rakutest: 1 s -> 1 second
+- repro: _(fill in — duration string parsing; check `raku -I lib` baseline first)_
+- file: _(suspected parser/runtime file)_
+
+### T-056 — test_fail: Codepoint [P5quotemeta]  [impact: 1 dist]
+- dists: P5quotemeta
+- e.g. base=1 pass=0 fail=1 die=0 | t/01-basic.rakutest: Codepoint 0 [0]
+- repro: _(fill in — quotemeta over codepoints; check baseline first)_
+- file: _(suspected parser/runtime file)_
+
+### T-057 — test_die batch (seed-555, un-triaged)  [impact: several dists]
+- dists (each its own root cause; triage individually before claiming, confirm the
+  raku `-I lib` baseline first): Attribute::Predicate, File::Ignore,
+  IO::Path::AutoDecompress, Math::Angle, Math::PascalTriangle,
+  Statistics::LinearRegression, String::Rotate, Text::CodeProcessing, Trait::IO,
+  WriteOnceHash, `are`, `sortuk`, Tree::Binary::PrettyTree (required role method
+  not seen as implemented).
+- These `test_die` on the current binary but were not individually reproduced.
+  Split off a dedicated ticket when you pick one up.
+
 ## Claimed
 
 _(move tickets here with `[claim: <branch>]` when you start)_

--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -606,11 +606,15 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   (mutsu processes `use` at runtime); poor ROI.
 - file: builtin-vs-imported-sub dispatch priority (deep)
 
-### T-055 — test_fail: 1 s -> 1 second [Time::Duration::Parser]  [impact: 1 dist]
-- dists: Time::Duration::Parser
-- e.g. base=1 pass=0 fail=1 die=0 | t/00-basic.rakutest: 1 s -> 1 second
-- repro: _(fill in — duration string parsing; check `raku -I lib` baseline first)_
-- file: _(suspected parser/runtime file)_
+### T-055 — test_fail: 1 s -> 1 second [Time::Duration::Parser]  [impact: 1 dist]  — DEFERRED (PLAN §8.16)
+- dists: Time::Duration::Parser (0/42)
+- Root cause: **inline grammar-action `make` values do not persist on subrule Match
+  nodes**, so the grammar's `[+] $<time>».made` reduces `[(Any) (Any) …]` → 0. Its
+  `duration`/`time`/`timespec` tokens each `{ make … }` inline and the parent reads
+  `$<subrule>.made` / `».made`. Only the TOP match gets its `ast` set today. Recorded
+  as PLAN.md §8.16 (moderate blast radius: regex capture struct + Match builder). Repro
+  and fix sketch are in §8.16.
+- file: `src/value/value_methods_c.rs` (Match builder), regex capture-commit path
 
 ### T-056 — test_fail: Codepoint [P5quotemeta]  [impact: 1 dist]
 - dists: P5quotemeta

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -520,7 +520,13 @@ impl Interpreter {
                 })
                 .collect();
             for pd in param_defs.iter().filter(|pd| pd.named) {
-                let bare_name = pd.name.trim_start_matches(|c: char| "$@%&".contains(c));
+                // Strip the sigil AND any twigil: an attribute-binding named param
+                // `:$!size` / `:$.size` has external named key `size`, so its `!`/`.`
+                // twigil must be dropped to match the call's `size => ...` arg.
+                let bare_name = pd
+                    .name
+                    .trim_start_matches(|c: char| "$@%&".contains(c))
+                    .trim_start_matches(['!', '.']);
                 let arg_val = named_args
                     .iter()
                     .find(|(k, _)| k == bare_name)
@@ -528,6 +534,23 @@ impl Interpreter {
 
                 // Check required named params have corresponding args
                 if pd.required && pd.default.is_none() && arg_val.is_none() {
+                    return false;
+                }
+
+                // An unsupplied optional named param binds its type object, which
+                // is `:U` (undefined). A `:D` (definite) smiley therefore fails to
+                // bind unless a default supplies a defined value — so the candidate
+                // does NOT match a call that omits it. Without this, `f(Int:D
+                // :$size)` wrongly matched `f()` and out-dispatched the narrower
+                // `f()` / `multi submethod BUILD()` candidate.
+                if arg_val.is_none()
+                    && pd.default.is_none()
+                    && let Some(constraint) = &pd.type_constraint
+                    && matches!(
+                        crate::runtime::types::strip_type_smiley(constraint).1,
+                        Some(":D")
+                    )
+                {
                     return false;
                 }
 

--- a/t/multi-optional-named-definite.t
+++ b/t/multi-optional-named-definite.t
@@ -1,0 +1,65 @@
+use Test;
+
+plan 12;
+
+# An OPTIONAL named parameter with a `:D` (definite) smiley and no default binds
+# its type object (`:U`) when omitted, so it must NOT match a call that omits it.
+# Otherwise `f(Int:D :$size)` wrongly out-dispatches the empty `f()`.
+# (Algorithm::BinaryIndexedTree: `multi submethod BUILD(Int:D :$!size)` vs
+# `multi submethod BUILD()` for a no-arg `.new`.)
+
+{
+    multi a() { "empty" }
+    multi a(Int:D :$size) { "sized" }
+    is a(),            "empty", ':D named candidate does not match a no-arg call';
+    is a(size => 3),   "sized", ':D named candidate matches when supplied';
+}
+
+# An untyped or non-:D named param still binds its (undefined) type object when
+# omitted, so it DOES match — and rakudo prefers the explicit-named candidate.
+{
+    multi b() { "empty" }
+    multi b(:$x) { "named" }
+    is b(),        "named", 'untyped optional named still matches (explicit-named wins)';
+
+    multi c() { "empty" }
+    multi c(Int :$size) { "sized" }
+    is c(),        "sized", 'non-:D typed named still matches an omitting call';
+    is c(size=>9), "sized", 'non-:D typed named matches when supplied';
+}
+
+# multi submethod BUILD dispatch: no-arg `.new` picks BUILD(), `.new(:size)`
+# picks BUILD(Int:D :$!size) and the attribute-binding `:$!size` receives it.
+{
+    my class C {
+        has @!tree;
+        has Int $!size;
+        multi submethod BUILD(Int:D :$!size) { for 0..$!size { @!tree.push(0) } }
+        multi submethod BUILD() { $!size = 5; for 0..$!size { @!tree.push(0) } }
+        method size  { $!size }
+        method elems { @!tree.elems }
+    }
+    is C.new.size,             5, 'no-arg new -> BUILD() sets size=5';
+    is C.new.elems,            6, 'no-arg new -> BUILD() built 6 slots';
+    is C.new(size => 3).size,  3, 'new(:size) -> BUILD(:$!size) receives 3';
+    is C.new(size => 3).elems, 4, 'new(:size) -> BUILD(:$!size) built 4 slots';
+}
+
+# `:$!attr` attribute-binding named param binds a matching `attr => ...` call arg
+# (the `!` twigil is not part of the external named key).
+{
+    my class P {
+        has Int $.n;
+        submethod BUILD(Int:D :$!n) { }
+        method get { $!n }
+    }
+    is P.new(n => 42).get, 42, ':$!n attribute-binding named binds n => 42';
+}
+
+# Required named (`:$x!`) is unaffected: it must be supplied.
+{
+    multi r() { "empty" }
+    multi r(Int:D :$x!) { "req" }
+    is r(),       "empty", 'required named candidate does not match an omitting call';
+    is r(x => 1), "req",   'required named candidate matches when supplied';
+}


### PR DESCRIPTION
## Summary

Two related multi-dispatch bugs, surfaced by **Algorithm::BinaryIndexedTree**
(fresh dist-compat sweep). Its constructor is:

```raku
multi submethod BUILD(Int:D :$!size) { for 0..$!size { @!tree.push(0) } }
multi submethod BUILD() { $!size = 1000; for 0..$!size { @!tree.push(0) } }
```

`Algorithm::BinaryIndexedTree.new` (no args) wrongly ran the `Int:D :$!size`
candidate with `$!size` undefined, so the tree was never built and every
operation hit "Use of uninitialized value". `t/01-basic.t` went 1/5 → 5/5.

### Bug 1 — an omitted `:D` optional named should not match

An optional named parameter binds its **type object** (`:U`, undefined) when the
call omits it. A `:D` (definite) smiley therefore fails to bind, so the candidate
must not match. mutsu only checked a named param's type constraint when the arg
was *supplied*, so `f(Int:D :$size)` matched `f()` and out-dispatched the empty
candidate. Now an omitted optional named with a `:D` smiley and no default
rejects the candidate. Untyped / non-`:D` named params still match when omitted
(raku's explicit-named preference then correctly prefers them).

### Bug 2 — `:$!attr` external key drops the twigil

An attribute-binding named param `:$!size` has external named key `size` — the
`!`/`.` twigil is not part of the key. The matcher stripped only the sigil, so it
searched for a `!size` arg and never bound `size => 3`. This made
`.new(size => 3)` miss `BUILD(Int:D :$!size)` (invisible until bug 1 stopped
masking it). The twigil is now stripped too.

Together: `.new` picks `BUILD()`, `.new(size => N)` picks `BUILD(Int:D :$!size)`.

## Testing

- New pin `t/multi-optional-named-definite.t` (12 cases, verified identical on raku)
- Algorithm::BinaryIndexedTree `t/01-basic.t` now passes 5/5
- All whitelisted `roast/S06-multi/*`, `roast/S06-signature/*`,
  `roast/S12-construction/*`, `roast/S12-attributes/*` pass
- `make test`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)