### PR TITLE
fix: given/with rebinds $_ over a local-slot $_ (sub param or my $_)

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -293,13 +293,22 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   A slice `$any[0,1]` yields a matching-length list of Any. Pin:
   `t/positional-index-on-any.t`. (03-actions now runs its content-line `.made` action
   path; tests 3–4 pass.)
-- **Status:** 02-grammar **23/23**; 01-basic 1/1; 03-actions 4/9. **Remaining (separate,
-  deeper — not this ticket):** `parsefile` of a full multi-vcard file (test-card1/2,
-  and 03-actions test 5, 04-from-vCard) fails while test-card4 passes — a multi-`<vcard>`
-  `parsefile` / `.made` action-tree bug, unrelated to the four fixed root causes.
+- **FIFTH ROOT CAUSE FIXED (PR `fix-given-with-topic-shadows-local`).** `from-vCard`
+  (04-from-vCard) died at `with $vcard { return $_.made }` with "No such method 'made'
+  for invocant of type 'Str'": inside a `sub from-vCard ($_) {...}`, `$_` occupies a
+  local slot (the parameter), and `given`/`with` wrote the topic only to the env mirror
+  — the body read the stale outer `$_` (the input Str, slot-authoritative under the (B)
+  env-write gate). Fix: `exec_given_op` mirrors the topic into the `_` local slot on
+  entry and restores it on exit (`vm/vm_given_when_ops.rs`). Pin:
+  `t/given-with-topic-shadows-local.t`. **04-from-vCard now passes 1/1.**
+- **Status:** 01-basic 1/1; 02-grammar **23/23**; 04-from-vCard **1/1**; 03-actions 4/9.
+  **Remaining (separate, deeper — not this ticket):** 03-actions test 5
+  (`is-deeply parsefile(...).made, from-json(test-card3.jcard)`) — the `.made` action
+  tree of a full multi-`<vcard>` parse is produced correctly, so the failure is in the
+  `is-deeply`/`from-json` reference comparison, a separate deeper issue.
 - file: DONE — src/runtime/methods_dispatch_match.rs, runtime_class_query.rs,
-  regex_parse_core.rs, regex/regex_match_sep.rs, vm/vm_var_index_ops.rs; remaining —
-  multi-vcard parsefile.
+  regex_parse_core.rs, regex/regex_match_sep.rs, vm/vm_var_index_ops.rs,
+  vm/vm_given_when_ops.rs; remaining — 03-actions test 5 is-deeply/from-json comparison.
 
 ### T-036 — test_die: plan expects Int (plan * fixed; deeper cardinal bugs remain)  [impact: 1 dist]
 - dists: Lingua::EN::Numbers

--- a/src/vm/vm_given_when_ops.rs
+++ b/src/vm/vm_given_when_ops.rs
@@ -63,6 +63,18 @@ impl Interpreter {
         } else {
             None
         };
+        // When `$_` already occupies a local slot (a `sub f ($_) {...}` parameter
+        // or a `my $_`), the body reads and writes that slot — it is the
+        // authoritative half under the (B) per-store env-write gate, and the env
+        // mirror alone is not seen. Mirror the topic into the slot on entry (and
+        // restore it on exit) so `with $x { $_ }` inside such a sub reads the
+        // topic, not the stale outer `$_`. `code.locals` positions never move
+        // within a frame, so the slot index stays valid across the body.
+        let topic_local_slot = self.find_local_slot(code, "_");
+        let saved_local_topic = topic_local_slot.map(|s| self.locals[s].clone());
+        if let Some(slot) = topic_local_slot {
+            self.locals[slot] = topic.clone();
+        }
         self.env_mut().insert("_".to_string(), topic);
         loan_env!(self, set_when_matched(false));
         // A read-only topic (`given @a` / `given 42` / `given expr()`) forbids
@@ -114,6 +126,11 @@ impl Interpreter {
                 this.env_mut().insert("_".to_string(), v);
             } else {
                 this.env_mut().remove("_");
+            }
+            // Restore the outer `$_` local slot (the sub `$_` param / `my $_`
+            // shadowed by this given/with) to its entry value.
+            if let Some(slot) = topic_local_slot {
+                this.locals[slot] = saved_local_topic.clone().unwrap_or(Value::NIL);
             }
             // A pointy parameter (`-> @p`) is block-scoped in Raku, but mutsu
             // desugars it to a global `@p := $_` whose alias/bound markers would

--- a/t/given-with-topic-shadows-local.t
+++ b/t/given-with-topic-shadows-local.t
@@ -1,0 +1,58 @@
+use Test;
+
+plan 8;
+
+# `given`/`with` must rebind `$_` to the topic inside the block, shadowing an
+# outer `$_` that already occupies a local slot (a `sub f ($_)` parameter or a
+# `my $_`). Regression: the topic was written only to the env mirror, so the
+# body read the stale outer `$_` (its slot is authoritative under the (B)
+# per-store env-write gate).
+
+sub with_param ($_) { with 42 { return $_ } }
+is with_param("outer"), 42, 'with rebinds $_ over a sub $_ parameter';
+
+sub given_param ($_) { given 7 { return $_ } }
+is given_param("outer"), 7, 'given rebinds $_ over a sub $_ parameter';
+
+# The rebound topic keeps its real type (not the outer Str).
+sub topic_type ($_) {
+    my $m = "hello" ~~ /(\w+)/;
+    with $m { return $_.WHAT.^name }
+}
+is topic_type("INPUT"), 'Match', 'rebound topic keeps its Match type';
+
+# `.made` on a rebound Match topic (the vCard::Parser `from-vCard` shape).
+grammar G { token TOP { \w+ }; }
+class A { method TOP ($/) { make "MADE:$/" } }
+sub parse_it ($_) {
+    my $r = G.parse($_, actions => A.new);
+    with $r { return $_.made }
+}
+is parse_it("wibble"), 'MADE:wibble', 'with-rebound Match topic supports .made';
+
+# The outer $_ is restored after the block.
+sub restored ($_) {
+    with 99 { }
+    return $_;
+}
+is restored("KEEP"), 'KEEP', 'outer $_ parameter restored after the block';
+
+# Nested given/with over a sub $_ parameter.
+sub nested ($_) {
+    given 'a' {
+        with 'b' { return "$_" }
+    }
+}
+is nested("x"), 'b', 'nested with over given rebinds correctly';
+
+# The topic is available for smartmatching / method calls, then the outer $_
+# parameter is seen again after the block.
+sub after ($_) {
+    my $seen = do with "abc" { .chars };
+    return "$seen:$_";
+}
+is after("Z"), '3:Z', 'topic method call works, outer $_ seen after';
+
+# No outer $_ (the common case) is unaffected.
+sub plain { with 3 { return $_ } }
+is plain(), 3, 'with with no outer $_ still works';


### PR DESCRIPTION
Inside a `sub f ($_) { ... with $x { $_ } }`, the `$_` parameter occupies a local slot. `given`/`with` wrote the topic only to the env `_` mirror, but the body reads/writes the local slot — the authoritative half under the (B) per-store env-write gate — so `$_` inside the block was the **stale outer value** (the sub's argument), not the topic.

```raku
sub f ($_) { with 42 { return $_ } }
f("outer")    # was: "outer";  now: 42
```

vCard::Parser's `from-vCard` — `sub from-vCard ($_) { ... with $vcard { return $_.made } }`, whose `$_` is the input Str parameter — therefore died `"No such method 'made' for invocant of type 'Str'"`.

**Fix:** `exec_given_op` mirrors the topic into the `_` local slot on entry and restores the slot's entry value on exit. The source-writeback path is untouched (it still reads env `_`), so an `if EXPR -> $_` pointy nested in a `given %h<k>` element topic does not flush a leftover value back to the container (verified by `t/if-pointy-topic-under-given.t`).

## Impact

vCard::Parser's **04-from-vCard now passes 1/1** (combined with the earlier grammar/charclass/separator/Any-index fixes, #5237/#5240/#5245). 02-grammar stays 23/23.

Verified against `raku`. Pin: `t/given-with-topic-shadows-local.t`

🤖 Generated with [Claude Code](https://claude.com/claude-code)