### PR TITLE
fix: Iterable-type-object trailing comma in .raku; [Z] reduction returns a Seq

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1370,12 +1370,11 @@ nested — recipe in the sweep memory; script was `tmp/repr-sweep.sh`) surfaced 
 The nested-leaf residues it also found (enum qualification, Uni constructor form, Version
 gist `v` prefix) were fixed in the same PR that recorded this entry, and the `[ident]`
 mis-parse (any identifier taken as a reduction metaop, so `say [red].raku` printed `Nil`)
-was fixed right after (`t/bareword-array-not-reduction.t`). Probing the trailing-comma
-item also showed `[:a].raku` renders `[:a]` where raku spells `[:a(Bool::True)]`.
+was fixed right after (`t/bareword-array-not-reduction.t`). The one-element-Iterable
+trailing comma (incl. type objects — `[HyperSeq,]`, `[List,]`; QuantHashes excluded)
+and `[Z]`-reduction-returns-a-Seq landed 2026-07-22 (pin `t/repr-residues-2.t`); the
+`[:a].raku` note was stale — current raku also renders `[:a]`, no divergence.
 
-- [ ] **A one-element array holding an Iterable renders without the trailing comma:**
-      `[HyperSeq].raku` → mutsu `[HyperSeq]`, raku `[HyperSeq,]` (disambiguates from
-      flattening). Applies to Iterable type objects and likely itemized list elements.
 - [ ] **`Proc.raku`/`.gist` render no attributes** (`Proc.new`); raku renders the full
       form `Proc.new(in => IO::Pipe, out => IO::Pipe, err => IO::Pipe, os-error => Str,
       exitcode => Nil, signal => Any, pid => Nil, command => [])` — for a *run* proc even
@@ -1384,7 +1383,13 @@ item also showed `[:a].raku` renders `[:a]` where raku spells `[:a(Bool::True)]`
       (The worse half — gist/Str delegating to `.Numeric`, so `Proc.new.gist` was `-1` —
       was fixed with `t/proc-gist-not-exitcode.t`.)
 - [ ] **`IO::Spec::Unix.new.raku` renders the type-object form `IO::Spec::Unix`** and its
-      gist is `(Unix)`; raku renders `IO::Spec::Unix.new` for both.
+      gist is `(Unix)`; raku renders `IO::Spec::Unix.new` for both. Traced 2026-07-22 as
+      far as: the instance never reaches the generic attribute walk in
+      `methods_instance_ops` (which would render `IO::Spec::Unix.new` correctly) — its
+      gist/raku land in `dispatch_instance_and_fallback`'s tail fallback arms
+      (`_ => to_string_value`), and `.Str` of the instance is empty while `.raku` is the
+      bare class name, so an earlier arm intercepts. Needs a dispatch trace before fixing;
+      cosmetic, low value.
 
 ---
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -47,6 +47,20 @@ ClassHOW anon-mixin rendering) is recorded in PLAN.md as cosmetic/not-planned. A
 re-verified the §8.1 first-batch findings: only the autoviv-hole `.List` → `Nil` rendering
 remains open (folded into the §8.5/hole-tracking territory).
 
+## 2026-07-22: Iterable-type-object trailing comma and `[Z]` returns a Seq (PLAN §8.15 slice)
+
+Two more §8.15 residues, both raku-verified. A one-element array whose sole element is
+an *Iterable type object* now renders with the disambiguating trailing comma
+(`[HyperSeq,]`, `[List,]`, `[Map,]`, `[Stash,]`) — Rakudo's List.raku rule is
+`istype(elem, Iterable)`, which was implemented for instance elements but not Package
+values; note Set/Bag/Mix are NOT Iterable in Rakudo, so `[Set]` stays comma-less. And a
+`[Z]` reduction now yields a `Seq` like the plain `Z` infix (`([Z] ...).WHAT` is
+`(Seq)`, `.raku` gets the `.Seq` suffix) — the n-ary zip fold in
+`eval_reduction_operator_values` wrapped its result in a List. The `[:a].raku` item
+recorded from the sweep memory was stale (current raku also renders `[:a]`). Pin:
+`t/repr-residues-2.t`. The IO::Spec::Unix repr item stays deferred with a dispatch-trace
+finding recorded in §8.15.
+
 ## 2026-07-22: `Proc.new.gist` is no longer `-1` (PLAN §8.15 slice)
 
 Proc's registered native `Str`/`gist` rendered the exitcode number (`-1` for a fresh

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -283,10 +283,11 @@ pub(crate) fn is_adverbial_pair_key(s: &str) -> bool {
 
 /// Whether a single element warrants a trailing comma when it is the sole
 /// element of a real (`@`-sigil) array's `.raku`: `[1..5,]`, `[(1, 2),]`,
-/// `[{:x(1)},]`. Raku adds the comma when the element is itself an Iterable
-/// whose bare `.raku` literal would otherwise flatten/merge into the array
-/// (Range, List/Array, Seq, Hash/Map). Pair, Set/Bag/Mix (rendered as
-/// constructor calls), scalars, and type objects do NOT get a comma.
+/// `[{:x(1)},]`, `[HyperSeq,]`. Raku's rule (List.raku) is `istype(elem,
+/// Iterable)` — an Iterable's bare `.raku` literal would otherwise
+/// flatten/merge into the array. This includes Iterable *type objects*
+/// (`[List,]`, `[Map,]`) but not Set/Bag/Mix (QuantHashes are not Iterable
+/// in Rakudo), Pair, Buf, Junction, or scalars.
 fn element_needs_trailing_comma(v: &Value) -> bool {
     match v.view() {
         ValueView::ContainerRef(cell) => {
@@ -302,6 +303,20 @@ fn element_needs_trailing_comma(v: &Value) -> bool {
         | ValueView::Array(..)
         | ValueView::Seq(..)
         | ValueView::Hash(_) => true,
+        ValueView::Package(name) => matches!(
+            name.resolve().as_str(),
+            "Iterable"
+                | "List"
+                | "Array"
+                | "Slip"
+                | "Seq"
+                | "HyperSeq"
+                | "RaceSeq"
+                | "Range"
+                | "Map"
+                | "Hash"
+                | "Stash"
+        ),
         _ => false,
     }
 }

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -77,7 +77,9 @@ impl Interpreter {
                 tuple.push(right_list[i].clone());
                 results.push(Value::array(tuple));
             }
-            return Ok(Value::array(results));
+            // Like the plain `Z` infix, the reduction yields a Seq (raku:
+            // `([Z] ...).WHAT` is `(Seq)`, `.raku` shows the `.Seq` suffix).
+            return Ok(Value::seq_arc(std::sync::Arc::new(results)));
         }
         // Z-prefixed meta-operator: zip two lists element-wise with the inner op.
         if let Some(inner_op) = op.strip_prefix('Z')

--- a/t/repr-residues-2.t
+++ b/t/repr-residues-2.t
@@ -1,0 +1,24 @@
+use v6;
+use Test;
+
+plan 10;
+
+# --- one-element Iterable trailing comma (PLAN §8.15) ------------------------
+# Rakudo's List.raku rule: a sole element that istype Iterable gets a trailing
+# comma so the round-trip does not flatten — including Iterable TYPE OBJECTS.
+is [HyperSeq].raku, '[HyperSeq,]', 'Iterable type object gets the trailing comma';
+is [List].raku, '[List,]', 'List type object gets the trailing comma';
+is [Map].raku, '[Map,]', 'Map type object gets the trailing comma';
+is [Hash,].raku, '[Hash,]', 'Hash type object keeps the trailing comma';
+# QuantHashes are NOT Iterable in Rakudo; scalars never get the comma.
+is [Set].raku, '[Set]', 'Set type object gets no comma';
+is [Int].raku, '[Int]', 'non-Iterable type object gets no comma';
+is [(1, 2),].raku, '[(1, 2),]', 'instance Iterable element keeps its comma';
+
+# --- [Z] reduction returns a Seq (PLAN §8.15) --------------------------------
+isa-ok ([Z] ((1, 2), (3, 4))), Seq, '[Z] reduction is a Seq';
+is ([Z] ((1, 2), (3, 4), (5, 6))).raku, '((1, 3, 5), (2, 4, 6)).Seq',
+    '[Z] over three lists zips n-ary and rakus with the .Seq suffix';
+is-deeply ([Z] ((1, 2), (3, 4))).List, ((1, 3), (2, 4)), '[Z] values are the zipped tuples';
+
+done-testing;


### PR DESCRIPTION
## Summary

Two PLAN.md §8.15 residues (the concrete-bug burn-down), both verified against the reference `raku`:

- **Iterable-type-object trailing comma**: `[HyperSeq].raku` now renders `[HyperSeq,]` (likewise `[List,]`, `[Map,]`, `[Stash,]`). Rakudo's `List.raku` rule is `istype(elem, Iterable)`; `element_needs_trailing_comma` implemented it for instance elements (`[(1, 2),]`) but not Package values. Set/Bag/Mix are **not** Iterable in Rakudo (verified), so `[Set]` correctly stays comma-less.
- **`[Z]` reduction returns a Seq**: `([Z] ((1,2),(3,4))).WHAT` is now `(Seq)` and `.raku` gets the `.Seq` suffix, matching the plain `Z` infix — the n-ary zip fold in `eval_reduction_operator_values` wrapped its result in a List.

Bookkeeping: the `[:a].raku` sweep note was stale (current raku also renders `[:a]` — no divergence), and the IO::Spec::Unix repr item stays deferred with the dispatch-trace findings recorded in §8.15.

## Testing

- New pin `t/repr-residues-2.t` (10 assertions) — green under both mutsu and the reference `raku`.
- Full `t/` prove: 2301 files / 21691 tests, all pass.
- All 9 whitelisted `S03-metaops` roast files pass (6365 tests).
- `cargo clippy -- -D warnings` and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)