### PR TITLE
fix: produce with last/next; reduce with a destructuring signature (PLAN §8.12)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1276,31 +1276,11 @@ the backlog.
       (`HashData`), `src/value/value_collections.rs`, `src/value/value_methods_a.rs`
       (`hash_insert_through`), `src/runtime/methods_quanthash_ctor.rs`, the `∈`/`(elem)` set-op path.
 
-### 8.12 `.produce` with `last`, and `.reduce` with a destructuring signature (deferred — found 2026-07-22 by the List.rakudoc doc-diff sweep)
+### 8.12 `.produce` with `last`, and `.reduce` with a destructuring signature — ✅ DONE 2026-07-23
 
-Two leftover `Type/List.rakudoc` reduce/produce findings after the batch of fixes on 2026-07-22
-(`.reduce` on a type object → Nil / empty-list identity, `last`/`next` in a `.reduce` block, `.sum`
-radix strings, `zip`/`roundrobin` listop parsing, `.invert` on a scalar-held List — all landed):
-
-- [ ] **`.produce` with `last` has murky drop semantics.**
-      `(2,3,4,5).produce: { last if $^a > 7; $^a + $^b }` is `(2 5)` in raku, not `(2 5 9)` — the
-      accumulator reaches 9 (call `(5,4)→9`) yet 9 is *not* in the output, so `last` drops **more
-      than** the aborted step (traced: calls are `(2,3)`, `(5,4)`, `(9,5)`; output stops at `5`).
-      mutsu currently throws `X::ControlFlow` (the `.reduce` control-flow fix in the same session did
-      NOT touch `eval_produce_over_items`). Nail the exact raku rule (how many trailing produced
-      values `last` discards) before implementing — do not guess. File: `src/runtime/builtins_reduce.rs`
-      (`eval_produce_over_items`). Pin candidate: `t/produce-last.t`.
-- [ ] **`.reduce` with a destructuring reducer signature.**
-      `reduce &count-and-sum-evens, (0, 0), |numbers` where
-      `sub count-and-sum-evens( (Int \count, Int \sum), Int \x ) {...}` should give `(2 6)`; mutsu
-      throws "Too few positionals passed; expected 2 arguments but got 2" — the destructuring first
-      param `(count, sum)` is not bound from the accumulator tuple. This is the reduce-callable-arity
-      / sub-signature-destructuring interaction, not the reduce loop itself. File:
-      `src/runtime/builtins_reduce.rs` (`reduce_callable_arity`) + the destructuring bind path
-      (`types/binding_signature.rs`). Pin candidate: `t/reduce-destructuring-signature.t`.
-- **Not a bug (do not chase):** `rotor(3, 'a'..'h')` as a *function* is `v6.e.PREVIEW`-only; the
-      reference `raku` (6.d) also `SORRY`s on it, so it is not a divergence. `.rotor` the *method*
-      works.
+Both items landed (pins `t/produce-last.t`, `t/reduce-destructuring-signature.t`; details in
+`news/2026-07.md`). Kept note: `rotor(3, 'a'..'h')` as a *function* is `v6.e.PREVIEW`-only; the
+reference `raku` (6.d) also `SORRY`s on it, so it is not a divergence — do not chase.
 
 ### 8.13 A `sub NAME { }` used as an *expression* loses its `.name` (deferred — found 2026-07-22 by the variables.rakudoc doc-diff sweep)
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,29 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-23: produce with `last`/`next`, and reduce with a destructuring signature (closes PLAN §8.12)
+
+Both §8.12 items, raku-verified. **`.produce` with `last`** no longer throws
+`X::ControlFlow`: Rakudo's produce emits each accumulator value only after the NEXT
+reducer call completes, so `last` on call N truncates to the initial element plus calls
+1..N-2 (`(2,3,4,5).produce({ last if $^a > 7; $^a + $^b })` is `(2 5)`; a first-call
+`last` yields `()`), and `next` skips that step's emit while keeping the accumulator —
+implemented with that one-behind order in `eval_produce_over_items` (both
+associativities). **`reduce &f, (0, 0), |@nums` with a destructuring first param**
+(`sub f( (Int \count, Int \sum), Int \x )`) works now; it took four connected fixes:
+(1) a plain destructuring parameter `($a, $b)` — recorded under the synthetic
+`__subsig__` name like the `|(...)` capture — now consumes exactly ONE positional
+argument (the capture form is distinguished by slurpy+sigilless, set at its parse site;
+`is_capture_subsignature` no longer keys on the name), with a new one-arg bind branch
+in `bind_signature` (when only Pairs remain, the first Pair IS the destructure target —
+the `.map`-over-Hash shape); (2) `args_matching` classifies only real captures as
+variadic, so a destructure-then-plain signature arity-counts correctly; (3)
+`builtin_reduce` follows the one-arg rule — several arguments each stay one item, so
+the seed tuple `(0, 0)` survives; (4) sigilless params declared INSIDE a sub-signature
+are now registered as parse-time term symbols, so `sum + x` in the body reads the
+`\sum` param instead of parsing as the `sum(+x)` listop. Pins: `t/produce-last.t`,
+`t/reduce-destructuring-signature.t`.
+
 ## 2026-07-22: a big `FatRat` keeps its identity, distinct from a big `Rat` (#5238, closes PLAN §8.8)
 
 A rational whose numerator or denominator overflowed i64 was stored in a single

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -72,15 +72,18 @@ pub(crate) struct ParamDef {
 
 impl ParamDef {
     /// True when this parameter is a capture that carries a subsignature, i.e.
-    /// `|c(...)` (a named, sigilless slurpy capture) or `|(...)` (an anonymous
-    /// capture recorded under the synthetic `__subsig__` name).  Such a
+    /// `|c(...)` or the anonymous `|(...)` — both sigilless slurpies.  Such a
     /// parameter consumes all remaining arguments and delegates dispatch to its
     /// subsignature, so for arity counting it behaves like a slurpy capture.
+    /// A plain destructuring parameter `($a, $b)` — also recorded under the
+    /// synthetic `__subsig__` name but NOT slurpy — consumes exactly one
+    /// positional argument and is deliberately excluded.
     pub(crate) fn is_capture_subsignature(&self) -> bool {
         self.sub_signature.is_some()
             && self.type_constraint.is_none()
             && self.literal_value.is_none()
-            && ((self.slurpy && self.sigilless) || self.name == "__subsig__")
+            && self.slurpy
+            && self.sigilless
     }
 }
 

--- a/src/parser/stmt/sub/sub_decl.rs
+++ b/src/parser/stmt/sub/sub_decl.rs
@@ -347,16 +347,29 @@ pub(crate) fn sub_decl_body(
         }
         return Err(PError::expected("sub body '{ ... }'"));
     }
-    let (rest, body) = if param_defs.iter().any(|p| p.sigilless) {
-        // When there are sigilless params, we need to register them as term
-        // symbols in the block scope so they shadow keywords (e.g. \return).
-        let (r, _) = parse_char(rest, '{')?;
-        super::super::simple::push_scope();
-        for pd in &param_defs {
+    // Sigilless params anywhere in the signature — including inside a
+    // destructuring sub-signature (`( (Int \count, Int \sum), Int \x )`) —
+    // must be registered as term symbols so they shadow keywords (\return)
+    // and builtin listops (\sum: `sum + x` is the param, not `sum(+x)`).
+    fn any_sigilless(params: &[crate::ast::ParamDef]) -> bool {
+        params
+            .iter()
+            .any(|p| p.sigilless || p.sub_signature.as_deref().is_some_and(any_sigilless))
+    }
+    fn register_sigilless_terms(params: &[crate::ast::ParamDef]) {
+        for pd in params {
             if pd.sigilless {
                 super::super::simple::register_user_term_symbol(&pd.name);
             }
+            if let Some(sub) = &pd.sub_signature {
+                register_sigilless_terms(sub);
+            }
         }
+    }
+    let (rest, body) = if any_sigilless(&param_defs) {
+        let (r, _) = parse_char(rest, '{')?;
+        super::super::simple::push_scope();
+        register_sigilless_terms(&param_defs);
         let result = block_inner(r);
         super::super::simple::pop_scope();
         result?

--- a/src/parser/stmt/sub_param/param_inner.rs
+++ b/src/parser/stmt/sub_param/param_inner.rs
@@ -50,6 +50,12 @@ fn parse_single_param_inner(input: &str) -> PResult<'_, ParamDef> {
             }
             let mut p = super::helpers::make_param("__subsig__".to_string());
             p.sub_signature = Some(sub_params);
+            // An anonymous capture `|(...)` consumes ALL remaining arguments;
+            // mark it slurpy+sigilless (like the named `|c(...)` form) so it is
+            // distinguishable from a plain one-argument destructuring
+            // `(...)` parameter, which is also recorded under `__subsig__`.
+            p.slurpy = true;
+            p.sigilless = true;
             return Ok((r, p));
         }
         let (r, _) = ws(r)?;

--- a/src/runtime/builtins_reduce.rs
+++ b/src/runtime/builtins_reduce.rs
@@ -71,34 +71,55 @@ impl Interpreter {
         let step = arity.saturating_sub(1).max(1);
         let assoc = self.callable_produce_assoc(&callable);
 
+        // `last`/`next` in the producer block follow Rakudo's one-behind emit
+        // order: each accumulator value is emitted only after the NEXT reducer
+        // call completes. So `last` on call N truncates the output to the
+        // initial element plus calls 1..N-2 (the pending value is dropped too:
+        // `(2,3,4,5).produce({ last if $^a > 7; $^a + $^b })` is `(2 5)`, and a
+        // first-call `last` yields `()`), while `next` skips that step's emit
+        // and keeps the accumulator unchanged.
         match assoc {
             OpAssoc::Right => {
                 let mut out = Vec::new();
                 let mut acc = items.last().cloned().unwrap_or(Value::NIL);
-                out.push(acc.clone());
                 let mut right_edge = items.len().saturating_sub(1);
                 while right_edge >= step {
                     let start = right_edge - step;
                     let mut call_args = items[start..right_edge].to_vec();
-                    call_args.push(acc);
-                    acc = self.call_sub_value(callable.clone(), call_args, true)?;
-                    out.push(acc.clone());
+                    call_args.push(acc.clone());
+                    match self.call_sub_value(callable.clone(), call_args, true) {
+                        Ok(new_acc) => {
+                            out.push(acc);
+                            acc = new_acc;
+                        }
+                        Err(e) if e.is_last() => return Ok(out),
+                        Err(e) if e.is_next() => {}
+                        Err(e) => return Err(e),
+                    }
                     right_edge = start;
                 }
+                out.push(acc);
                 Ok(out)
             }
             _ => {
                 let mut out = Vec::new();
                 let mut acc = items[0].clone();
-                out.push(acc.clone());
                 let mut idx = 1usize;
                 while idx + step <= items.len() {
-                    let mut call_args = vec![acc];
+                    let mut call_args = vec![acc.clone()];
                     call_args.extend(items[idx..idx + step].iter().cloned());
-                    acc = self.call_sub_value(callable.clone(), call_args, true)?;
-                    out.push(acc.clone());
+                    match self.call_sub_value(callable.clone(), call_args, true) {
+                        Ok(new_acc) => {
+                            out.push(acc);
+                            acc = new_acc;
+                        }
+                        Err(e) if e.is_last() => return Ok(out),
+                        Err(e) if e.is_next() => {}
+                        Err(e) => return Err(e),
+                    }
                     idx += step;
                 }
+                out.push(acc);
                 Ok(out)
             }
         }
@@ -110,13 +131,20 @@ impl Interpreter {
             .cloned()
             .ok_or_else(|| RuntimeError::new("reduce expects a callable as first argument"))?;
 
+        // `reduce &f, +values` follows the one-arg rule: a SINGLE list argument
+        // supplies the item list (flattened), but with several arguments each
+        // one is its own item — `reduce &f, (0, 0), |@nums` keeps the seed
+        // tuple `(0, 0)` as one value (the reduce-with-destructuring shape).
         let mut items = Vec::new();
-        for arg in args.iter().skip(1) {
+        if args.len() == 2 {
+            let arg = &args[1];
             if matches!(arg.view(), ValueView::Hash(_)) {
                 items.push(arg.clone());
             } else {
                 items.extend(crate::runtime::value_to_list(arg));
             }
+        } else {
+            items.extend(args.iter().skip(1).cloned());
         }
         self.reduce_items(callable, items)
     }

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -107,7 +107,7 @@ impl Interpreter {
             let mut has_variadic_positional = false;
             for pd in &positional_params {
                 let is_capture_param = pd.name == "_capture" || (pd.slurpy && pd.sigilless);
-                let is_subsig_capture = pd.name == "__subsig__" && pd.sub_signature.is_some();
+                let is_subsig_capture = pd.is_capture_subsignature();
                 if pd.slurpy || is_capture_param || is_subsig_capture {
                     has_variadic_positional = true;
                     continue;
@@ -130,7 +130,7 @@ impl Interpreter {
             let mut i = 0usize;
             for pd in positional_params {
                 let is_capture_param = pd.name == "_capture" || (pd.slurpy && pd.sigilless);
-                let is_subsig_capture = pd.name == "__subsig__" && pd.sub_signature.is_some();
+                let is_subsig_capture = pd.is_capture_subsignature();
                 let mut arg_for_checks: Option<Value> = if pd.slurpy || is_capture_param {
                     if is_capture_param {
                         // |c capture params preserve both positional and named parts.

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -1151,7 +1151,7 @@ impl Interpreter {
                 if pd.where_constraint.is_some() {
                     self.check_named_param_where_constraint(pd)?;
                 }
-            } else if pd.name == "__subsig__"
+            } else if pd.is_capture_subsignature()
                 && let Some(sub_params) = &pd.sub_signature
             {
                 // An anonymous capture `|(...)` consumes ALL remaining arguments
@@ -1161,6 +1161,41 @@ impl Interpreter {
                 let capture = sub_signature_target_from_remaining_args(&args[positional_idx..]);
                 bind_sub_signature_from_value(self, sub_params, &capture)?;
                 positional_idx = args.len();
+                continue;
+            } else if pd.name == "__subsig__"
+                && let Some(sub_params) = &pd.sub_signature
+            {
+                // A plain destructuring parameter `($a, $b)` consumes exactly
+                // ONE positional argument and binds that argument's elements
+                // via the subsignature — later parameters keep their own
+                // arguments (`sub f( ($c, $s), $x )`, the reduce-with-
+                // destructuring shape). Pair entries are usually trailing named
+                // args and are skipped — but when ONLY Pairs remain, the first
+                // Pair itself is the destructure target (a `.map` over a Hash
+                // passes each Pair positionally: `-> (:$suffix) { }`).
+                let mut target_idx = positional_idx;
+                while target_idx < args.len()
+                    && matches!(
+                        unwrap_varref_value(args[target_idx].clone()).view(),
+                        ValueView::Pair(..)
+                    )
+                {
+                    target_idx += 1;
+                }
+                if target_idx >= args.len() {
+                    target_idx = positional_idx;
+                }
+                if target_idx < args.len() {
+                    let arg = unwrap_varref_value(args[target_idx].clone());
+                    bind_sub_signature_from_value(self, sub_params, &arg)?;
+                    positional_idx = target_idx + 1;
+                } else if pd.default.is_none() && !pd.optional_marker {
+                    return Err(RuntimeError::new(format!(
+                        "Too few positionals passed; expected {} arguments but got {}",
+                        param_defs.len(),
+                        args.len()
+                    )));
+                }
                 continue;
             } else {
                 // Positional param -- skip over Pair entries (named args)

--- a/t/produce-last.t
+++ b/t/produce-last.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+plan 8;
+
+# Rakudo's produce emits each accumulator value only after the NEXT reducer
+# call completes, so `last` drops the pending value too, and `next` skips
+# that step's emit while keeping the accumulator (PLAN §8.12).
+
+is-deeply ((2,3,4,5).produce: -> $a, $b { last if $a > 7; $a + $b }).List,
+    (2, 5), 'last on the third call keeps only the first two values';
+is-deeply ((2,3,4).produce: -> $a, $b { last; $a + $b }).List,
+    (), 'last on the first call yields the empty Seq';
+is-deeply ((2,).produce: -> $a, $b { last; $a + $b }).List,
+    (2,), 'a single-element list never calls the reducer';
+# (Eagerly reified via assignment: consuming the lazy Seq inside a routine
+# call would let the block's `next` escape into the consumer's loop in Rakudo.)
+my @next-skipped = (2,3,4,5,6).produce: -> $a, $b { next if $b == 4; $a + $b };
+is-deeply @next-skipped.List,
+    (2, 5, 10, 16), 'next skips the step and keeps the accumulator';
+is-deeply ((2,3,4,5).produce: -> $a, $b { $a + $b }).List,
+    (2, 5, 9, 14), 'plain produce is unchanged';
+isa-ok ((2,3,4,5).produce: -> $a, $b { last if $a > 7; $a + $b }), Seq,
+    'produce with last still returns a Seq';
+is-deeply (produce -> $a, $b { last if $a > 7; $a + $b }, (2,3,4,5)).List,
+    (2, 5), 'the function form follows the same rule';
+is-deeply ([\+] (2,3,4,5)).List, (2, 5, 9, 14), 'triangle reduce is unchanged';
+
+done-testing;

--- a/t/reduce-destructuring-signature.t
+++ b/t/reduce-destructuring-signature.t
@@ -1,0 +1,40 @@
+use v6;
+use Test;
+
+plan 9;
+
+# PLAN §8.12: reduce with a destructuring reducer signature. The accumulator
+# tuple binds through the first parameter's sub-signature.
+
+sub count-and-sum-evens( (Int \count, Int \sum), Int \x ) {
+    x %% 2 ?? (count + 1, sum + x) !! (count, sum)
+}
+is-deeply (reduce &count-and-sum-evens, (0, 0), |(1, 2, 3, 4)).List, (2, 6),
+    'reduce with a destructuring first param and a seed tuple';
+
+# A destructuring parameter consumes exactly ONE positional argument.
+sub f( ($c, $s), $x ) { ($c + $x, $s) }
+is-deeply f((0, 1), 5), (5, 1), 'destructure followed by a plain param';
+sub g( (Int \c, Int \s), Int \x ) { (c + x, s) }
+is-deeply g((0, 1), 5), (5, 1), 'sigilless typed destructure followed by a plain param';
+sub sole( ($c, $s) ) { ($c, $s) }
+is-deeply sole((7, 8)), (7, 8), 'sole destructuring param still binds';
+sub tail( $x, ($c, $s) ) { ($x, $c, $s) }
+is-deeply tail(1, (7, 8)), (1, 7, 8), 'destructure in the last position still binds';
+
+# The `|(...)` anonymous capture still consumes all remaining arguments.
+sub cap(| ($a, $b)) { "$a $b" }
+is cap(3, 4), '3 4', 'anonymous capture subsignature still takes all args';
+sub ncap(|c ($a, $b)) { "$a $b" }
+is ncap(5, 6), '5 6', 'named capture subsignature still takes all args';
+
+# A sigilless param declared inside a sub-signature shadows builtin listops
+# in the body (`sum + x` reads the param, not `sum(+x)`).
+sub shadows( (\sum, \x) ) { sum + x }
+is shadows((10, 5)), 15, 'sub-signature sigilless param shadows the sum builtin';
+
+# reduce's one-arg rule: several arguments each stay one item.
+is-deeply (reduce -> $a, $b { $a + $b }, (1, 2, 3)), 6,
+    'a single list argument still flattens into the item list';
+
+done-testing;


### PR DESCRIPTION
## Summary

Closes both PLAN.md §8.12 items (the concrete-bug burn-down), verified against the reference `raku`:

- **`.produce` with `last`/`next`** no longer throws `X::ControlFlow`. Rakudo emits each accumulator value only after the NEXT reducer call completes, so `last` on call N truncates to the initial element plus calls 1..N-2 (`(2,3,4,5).produce({ last if $^a > 7; $^a + $^b })` is `(2 5)`; a first-call `last` yields `()`), and `next` skips that step's emit while keeping the accumulator. Implemented with that one-behind order in `eval_produce_over_items` (both associativities); the semantics were probed on raku first (incl. boundary cases) per the PLAN note "nail the exact rule — do not guess".
- **`reduce &f, (0, 0), |@nums` with a destructuring first param** (`sub f( (Int \count, Int \sum), Int \x )`) now yields `(2 6)`. Four connected fixes:
  1. A plain destructuring parameter `($a, $b)` — recorded under the synthetic `__subsig__` name like the `|(...)` capture — now consumes exactly **one** positional argument. The capture form is distinguished by slurpy+sigilless (set at its parse site); `is_capture_subsignature` no longer keys on the name. New one-arg bind branch in `bind_signature`; when only Pairs remain, the first Pair IS the destructure target (the `.map`-over-Hash shape, pinned by `t/coercion-type-regressions.t`).
  2. `args_matching` classifies only real captures as variadic, so a destructure-then-plain signature (`(($c,$s), $x)`) arity-counts correctly — previously the destructure swallowed all args and the trailing param starved ("Too few positionals ... expected 2 but got 2").
  3. `builtin_reduce` follows the one-arg rule: several arguments each stay one item, so the seed tuple `(0, 0)` survives instead of being flattened.
  4. Sigilless params declared **inside** a sub-signature now register as parse-time term symbols, so `sum + x` in the body reads the `\sum` param instead of parsing as the `sum(+x)` listop.

## Testing

- New pins `t/produce-last.t` (8) and `t/reduce-destructuring-signature.t` (9) — green under both mutsu and the reference `raku`.
- Full `t/` prove: 2302 files / 21698 tests, all pass (including the `.map`-destructure and capture-subsig regressions caught and fixed during development).
- All 46 whitelisted `S06-signature*`/`S06-multi*` roast files pass (1200 tests).
- `cargo clippy -- -D warnings` and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)