### PR TITLE
fix: inline grammar-action make values persist on subrule Match nodes

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1350,39 +1350,6 @@ and `[Z]`-reduction-returns-a-Seq landed 2026-07-22 (pin `t/repr-residues-2.t`);
       bare class name, so an earlier arm intercepts. Needs a dispatch trace before fixing;
       cosmetic, low value.
 
-### 8.16 Inline grammar-action `make` values do not persist on subrule Match nodes (found 2026-07-22 by the seed-555 dist sweep; Time::Duration::Parser)
-
-An **inline** grammar action (`token duration { s { make 1 } }`, i.e. a `{ make … }`
-code block inside the rule rather than a separate `.parse(:actions)` class) sets the
-rule's `.made` (AST) value, but that value is **not attached to the subrule's Match
-node** in the parse tree. So a parent action that reads `$<subrule>.made` — or, for a
-quantified subrule, `$<subrule>».made` — sees `Any`/`Nil` instead of the produced value.
-
-Minimal repro (raku: `TOP.made` = 60; mutsu = 0):
-```raku
-grammar G {
-    rule TOP  { <time>+ % <sep> { make [+] $<time>».made } }
-    rule time { <number> { make +$<number> * 10 } }
-    token number { \d+ }
-    token sep { <.ws> }
-}
-my $r = G.parse("1 2 3");
-say $r<time>».made;   # raku: [10 20 30]   mutsu: [(Any) (Any) (Any)]
-say $r.made;          # raku: 60           mutsu: 0
-```
-Only the **top** Match gets its `ast` attribute set (from env `"made"` after the top
-code block, in `seq_helpers/smart_match.rs` ~line 761). Each subrule's inline-`make`
-value must instead be committed to its own `RegexCaptures` node during the match and
-carried into the sub-Match built by `make_match_object_full_q`
-(`src/value/value_methods_c.rs`) so `$<x>.made` / `$<x>».made` resolve in parent actions
-and post-parse. This is orthogonal to the action-class walk in
-`methods_grammar.rs::invoke_grammar_actions` (which handles `.parse(:actions)`), and to
-the reduce-time `.made`-in-`<?{…}>` hook (`regex/regex_eval.rs`), both of which already
-work. Blocks **Time::Duration::Parser** (0/42 — every case chains `$<time>».made`) and any
-grammar that reduces child AST values in a parent inline action. Moderate blast radius
-(regex capture struct + Match builder + the match commit path); a dedicated session.
-
----
 
 ## Metrics
 

--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -615,16 +615,6 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   (mutsu processes `use` at runtime); poor ROI.
 - file: builtin-vs-imported-sub dispatch priority (deep)
 
-### T-055 — test_fail: 1 s -> 1 second [Time::Duration::Parser]  [impact: 1 dist]  — DEFERRED (PLAN §8.16)
-- dists: Time::Duration::Parser (0/42)
-- Root cause: **inline grammar-action `make` values do not persist on subrule Match
-  nodes**, so the grammar's `[+] $<time>».made` reduces `[(Any) (Any) …]` → 0. Its
-  `duration`/`time`/`timespec` tokens each `{ make … }` inline and the parent reads
-  `$<subrule>.made` / `».made`. Only the TOP match gets its `ast` set today. Recorded
-  as PLAN.md §8.16 (moderate blast radius: regex capture struct + Match builder). Repro
-  and fix sketch are in §8.16.
-- file: `src/value/value_methods_c.rs` (Match builder), regex capture-commit path
-
 ### T-056 — test_fail: Codepoint [P5quotemeta]  [impact: 1 dist]  — ONE ROOT CAUSE FIXED (PR `fix-subst-replacement-double-backslash`); one deferred
 - dists: P5quotemeta (5756 tests: raku 5756/5756)
 - The module is `S:g/ ( <[ …\x[…] ]> ) /\\$0/` — escape each matched char with a
@@ -662,6 +652,16 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 _(move tickets here with `[claim: <branch>]` when you start)_
 
 ## Done
+
+- **T-055** (#PENDING) — Time::Duration::Parser 0/42 → 42/42. Inline grammar-action
+  `{ make … }` values were bubbled to the top node and run with a shared `$/`, so a
+  subrule's `.made` never reached its own Match node and the parent's
+  `[+] $<time>».made` reduced `[(Any) …]` → 0. Fixed by reduce-time bottom-up inline
+  execution (`reduce_regex_captures_made`): named-subrule blocks stay on their node, run
+  once children-first with `$<name>` bound to the reduced child Matches, and commit the
+  value to `RegexCaptures::ast` (carried into the Match by `make_match_object_full_q`).
+  Mid-rule `$/` matched-so-far preserved. See PLAN §8.16 (now closed) / news 2026-07-23.
+  Pin: `t/grammar-inline-make-subrule-made.t`.
 
 - **T-018** (#PENDING) — Cookie::Jar died with "Cannot call private method without
   permission". It calls a private method whose OWNER class has a *nested* name:

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -61,6 +61,33 @@ and each inline fresh-recompile loop (map, rw-map, grep-with-mutated, first) set
 alone left the original repro failing. Pin: `t/state-var-per-block-in-feed-map.t`
 (feed, function, within-map persistence, grep, first — all raku-verified).
 
+## 2026-07-23: inline grammar-action `make` values now persist on subrule Match nodes (closes PLAN §8.16; Time::Duration::Parser 0/42 → 42/42)
+
+An **inline** grammar action — a `{ make … }` code block inside a rule rather than a
+separate `.parse(:actions)` action class — set the rule's own `.made` (AST) value, but
+that value was never attached to the **subrule's** Match node. So a parent action
+reading `$<sub>.made` (or `$<sub>».made` for a quantified subrule) saw `Any`/`Nil`
+instead of the produced value: `rule TOP { <time>+ % <sep> { make [+] $<time>».made } }`
+gave `0`, not `60`.
+
+The root cause was the flat code-block model: every subrule's inline block was *bubbled*
+into the top node's `code_blocks` list and run at the top level with a single shared
+`$/`, so per-node `.made` was lost. The fix moves inline-block execution to a
+**reduce-time bottom-up walk** (`reduce_regex_captures_made`, in
+`regex/regex_eval_repeat.rs`): named-subrule blocks now stay on their own
+`RegexCaptures` node (they no longer bubble — `build_named_candidates_from_inner`), and
+the walk runs each node's blocks exactly once, children first, binding `$<name>` to the
+already-reduced child Matches so `$<sub>.made` / `$<sub>».made` resolve. The produced
+value is committed to a new `RegexCaptures::ast` field, which `make_match_object_full_q`
+carries into the Match so it also survives post-parse (`$m<sub>.made`). A mid-rule
+`{ … $/ … }` still sees its matched-so-far prefix (the block's `$/` comes from its own
+context; only `$<name>.made` reads the reduced value), so
+`t/regex-code-block-slash-var.t` stays green. All winning-path call sites (grammar
+`.parse`, `~~`, `.match`, `.comb`) route through the reduce; the failure-path eager
+buffer stays flat. Pin: `t/grammar-inline-make-subrule-made.t` (10 assertions). This is
+orthogonal to the `.parse(:actions)` action-class walk and the `.made`-in-`<?{…}>` hook,
+both already working.
+
 ## 2026-07-22: a big `FatRat` keeps its identity, distinct from a big `Rat` (#5238, closes PLAN §8.8)
 
 A rational whose numerator or denominator overflowed i64 was stored in a single

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -339,14 +339,16 @@ impl Interpreter {
                 let has_code = self.has_code_block_in_prefix(&pat);
                 if has_code {
                     self.enable_eager_code_blocks();
-                    let matches = self.regex_find_all_with_caps(&pat, &text);
+                    let mut matches = self.regex_find_all_with_caps(&pat, &text);
                     let eager_blocks = self.drain_eager_code_blocks();
                     if !eager_blocks.is_empty() {
                         self.execute_regex_code_blocks(&eager_blocks);
                     } else {
-                        for (_, _, caps) in &matches {
-                            if !caps.code_blocks.is_empty() {
-                                self.execute_regex_code_blocks(&caps.code_blocks);
+                        for (_, _, caps) in &mut matches {
+                            if !caps.code_blocks.is_empty()
+                                || caps.named_subcaps.values().any(|v| !v.is_empty())
+                            {
+                                self.reduce_regex_captures_made(caps, Some(&text));
                             }
                         }
                     }

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -397,7 +397,7 @@ impl Interpreter {
                 // A failed `.subparse` yields a failed Match, not a Failure.
                 return Ok(self.make_failed_match_value(&text, start_pos.unwrap_or(0)));
             };
-            self.execute_regex_code_blocks(&captures.code_blocks);
+            self.reduce_regex_captures_made(&mut captures, Some(&text));
             // A subparse must begin at the requested offset (0, or `:pos(N)`);
             // `:c(N)` allows any start >= N, so it is exempt from the check.
             let required_from = start_pos.or(if continue_pos.is_some() {

--- a/src/runtime/methods_match_dispatch.rs
+++ b/src/runtime/methods_match_dispatch.rs
@@ -176,12 +176,12 @@ impl Interpreter {
         } else {
             self.regex_match_with_captures(&pat, &text)
         };
-        if let Some(captures) = captures {
+        if let Some(mut captures) = captures {
             let matched = captures.matched.clone();
             let from = captures.from as i64;
             let to = captures.to as i64;
-            // Execute code blocks from regex for side effects
-            self.execute_regex_code_blocks(&captures.code_blocks);
+            // Reduce-time inline actions (children first) commit per-node `.made`.
+            self.reduce_regex_captures_made(&mut captures, Some(&text));
             let match_obj = Value::make_match_object_full(
                 matched,
                 from,

--- a/src/runtime/regex/regex_eval_repeat.rs
+++ b/src/runtime/regex/regex_eval_repeat.rs
@@ -233,94 +233,199 @@ impl Interpreter {
             let Ok((stmts, _)) = crate::parse_dispatch::parse_source(&ctx.code) else {
                 continue;
             };
-            // Set up $/ as a match object for the matched-so-far text
-            let match_obj = Value::make_match_object_with_captures(
-                ctx.matched_so_far.clone(),
+            self.setup_regex_code_block_env(ctx);
+            self.eval_regex_code_block_body(&stmts);
+        }
+    }
+
+    /// Install `$/` (matched-so-far), `$¢`, `$0…` and `$<name>` in the env from a
+    /// single code-block context, i.e. the capture state as it stood at the block's
+    /// textual position during matching (so a mid-rule `{ … $/ … }` sees the
+    /// prefix matched so far, not the whole rule).
+    fn setup_regex_code_block_env(&mut self, ctx: &CodeBlockContext) {
+        // Set up $/ as a match object for the matched-so-far text
+        let match_obj = Value::make_match_object_with_captures(
+            ctx.matched_so_far.clone(),
+            0,
+            ctx.matched_so_far.chars().count() as i64,
+            &[],
+            &HashMap::new(),
+        );
+        self.env.insert("/".to_string(), match_obj.clone());
+        // Set up $¢ (current match cursor) — same as $/ for in-progress match
+        self.env.insert("\u{00A2}".to_string(), match_obj);
+        // Set up positional captures ($0, $1, ...)
+        for (i, val) in ctx.positional.iter().enumerate() {
+            let pos_match = Value::make_match_object_with_captures(
+                val.clone(),
                 0,
-                ctx.matched_so_far.chars().count() as i64,
+                val.chars().count() as i64,
                 &[],
                 &HashMap::new(),
             );
-            self.env.insert("/".to_string(), match_obj.clone());
-            // Set up $¢ (current match cursor) — same as $/ for in-progress match
-            self.env.insert("\u{00A2}".to_string(), match_obj);
-            // Set up positional captures ($0, $1, ...)
-            for (i, val) in ctx.positional.iter().enumerate() {
-                let pos_match = Value::make_match_object_with_captures(
-                    val.clone(),
+            self.env.insert(i.to_string(), pos_match);
+        }
+        // Set up named captures as $<name> variables
+        let ast_hint = self.env.get("made").cloned().unwrap_or(Value::NIL);
+        for (k, v) in &ctx.named {
+            let to_match_with_ast = |text: &str, ast: &Value| -> Value {
+                let match_obj = Value::make_match_object_with_captures(
+                    text.to_string(),
                     0,
-                    val.chars().count() as i64,
+                    text.chars().count() as i64,
                     &[],
                     &HashMap::new(),
                 );
-                self.env.insert(i.to_string(), pos_match);
-            }
-            // Set up named captures as $<name> variables
-            let ast_hint = self.env.get("made").cloned().unwrap_or(Value::NIL);
-            for (k, v) in &ctx.named {
-                let to_match_with_ast = |text: &str, ast: &Value| -> Value {
-                    let match_obj = Value::make_match_object_with_captures(
-                        text.to_string(),
-                        0,
-                        text.chars().count() as i64,
-                        &[],
-                        &HashMap::new(),
-                    );
-                    if let ValueView::Instance {
-                        class_name,
-                        attributes,
-                        ..
-                    } = match_obj.view()
-                    {
-                        let attrs = attributes.as_ref().clone();
-                        attrs.insert("ast".to_string(), ast.clone());
-                        Value::make_instance(class_name, (attrs).to_map())
-                    } else {
-                        match_obj
-                    }
-                };
-                let value = if v.len() == 1 {
-                    to_match_with_ast(&v[0], &ast_hint)
+                if let ValueView::Instance {
+                    class_name,
+                    attributes,
+                    ..
+                } = match_obj.view()
+                {
+                    let attrs = attributes.as_ref().clone();
+                    attrs.insert("ast".to_string(), ast.clone());
+                    Value::make_instance(class_name, (attrs).to_map())
                 } else {
-                    Value::array(
-                        v.iter()
-                            .map(|s| to_match_with_ast(s, &ast_hint))
-                            .collect::<Vec<_>>(),
-                    )
-                };
-                self.env.insert(format!("<{}>", k), value);
+                    match_obj
+                }
+            };
+            let value = if v.len() == 1 {
+                to_match_with_ast(&v[0], &ast_hint)
+            } else {
+                Value::array(
+                    v.iter()
+                        .map(|s| to_match_with_ast(s, &ast_hint))
+                        .collect::<Vec<_>>(),
+                )
+            };
+            self.env.insert(format!("<{}>", k), value);
+        }
+    }
+
+    /// Evaluate one already-parsed regex `{ … }` code block body, snapshotting
+    /// the env before and recording any changed variable as a pending local
+    /// update for the outer VM. Assumes the block's `$/`, `$<name>`, `$0…` etc.
+    /// have already been installed in `self.env` by the caller.
+    pub(in crate::runtime) fn eval_regex_code_block_body(&mut self, stmts: &[crate::ast::Stmt]) {
+        // Snapshot env keys and values before execution
+        let snapshot: HashMap<Symbol, String> = self
+            .env
+            .iter()
+            .map(|(k, v)| (*k, format!("{:?}", v)))
+            .collect();
+        let saved_in_block = self.in_regex_code_block;
+        self.in_regex_code_block = true;
+        let _ = self.eval_block_value(stmts);
+        self.in_regex_code_block = saved_in_block;
+        // Record changed env variables as pending local updates for the outer VM
+        for (k, v) in &self.env {
+            let old_repr = snapshot.get(k).map(|s| s.as_str()).unwrap_or("");
+            let new_repr = format!("{:?}", v);
+            if old_repr != new_repr {
+                let name = k.resolve();
+                // Slice C' (docs/vm-single-store.md, open-question #2): an
+                // embedded regex `{ ... }` / `:my`/`:let` block writes a caller
+                // lexical *directly* into `env`, bypassing
+                // `set_env_with_main_alias`. If a carrier is active (the regex
+                // ran inside an EVAL / interpreter fallback), log the name into
+                // the carrier write set too, so the carrier-return writeback
+                // reconciles it precisely and the blanket `env_dirty` net can be
+                // dropped for non-EVAL carriers as well. Logging a superset is
+                // safe — the writeback filters by the caller's compiled slots.
+                if let Some(set) = self.carrier_writes.as_mut() {
+                    set.insert(name.clone());
+                }
+                self.pending_local_updates.push((name, v.clone()));
             }
-            // Snapshot env keys and values before execution
-            let snapshot: HashMap<Symbol, String> = self
-                .env
-                .iter()
-                .map(|(k, v)| (*k, format!("{:?}", v)))
-                .collect();
-            let saved_in_block = self.in_regex_code_block;
-            self.in_regex_code_block = true;
-            let _ = self.eval_block_value(&stmts);
-            self.in_regex_code_block = saved_in_block;
-            // Record changed env variables as pending local updates for the outer VM
-            for (k, v) in &self.env {
-                let old_repr = snapshot.get(k).map(|s| s.as_str()).unwrap_or("");
-                let new_repr = format!("{:?}", v);
-                if old_repr != new_repr {
-                    let name = k.resolve();
-                    // Slice C' (docs/vm-single-store.md, open-question #2): an
-                    // embedded regex `{ ... }` / `:my`/`:let` block writes a caller
-                    // lexical *directly* into `env`, bypassing
-                    // `set_env_with_main_alias`. If a carrier is active (the regex
-                    // ran inside an EVAL / interpreter fallback), log the name into
-                    // the carrier write set too, so the carrier-return writeback
-                    // reconciles it precisely and the blanket `env_dirty` net can be
-                    // dropped for non-EVAL carriers as well. Logging a superset is
-                    // safe — the writeback filters by the caller's compiled slots.
-                    if let Some(set) = self.carrier_writes.as_mut() {
-                        set.insert(name.clone());
-                    }
-                    self.pending_local_updates.push((name, v.clone()));
+        }
+    }
+
+    /// Reduce-time bottom-up walk over the winning capture tree that runs each
+    /// node's inline `{ … }` code blocks exactly once — children first — and
+    /// commits the produced `make` value to that node's `ast`. Binding `$<child>`
+    /// to the already-reduced child Matches (so `$<child>.made` / `$<child>».made`
+    /// resolve to the children's produced values) is what makes an inline grammar
+    /// action's `make [+] $<time>».made` work. The block's `$/` still comes from
+    /// its own matched-so-far context, so a mid-rule `{ … $/ … }` is unaffected.
+    /// Leaves the top node's `make` in `env["made"]` for the call site to read as
+    /// the whole-parse `.made`.
+    ///
+    /// Subrule code blocks are NOT bubbled into the parent (see
+    /// `build_named_candidates_from_inner`), so each `caps.code_blocks` list holds
+    /// only that node's own blocks and every block runs once here.
+    pub(in crate::runtime) fn reduce_regex_captures_made(
+        &mut self,
+        caps: &mut RegexCaptures,
+        orig: Option<&str>,
+    ) {
+        // Children first so a parent block reading a child's `.made` sees it.
+        for scs in caps.named_subcaps.values_mut() {
+            for sc in scs.iter_mut() {
+                self.reduce_regex_captures_made(Arc::make_mut(sc), orig);
+            }
+        }
+        for sc in caps.positional_subcaps.iter_mut().flatten() {
+            self.reduce_regex_captures_made(Arc::make_mut(sc), orig);
+        }
+        for pq in caps.positional_quantified.iter_mut().flatten() {
+            for entry in pq.iter_mut() {
+                if let Some(sc) = entry.3.as_mut() {
+                    self.reduce_regex_captures_made(Arc::make_mut(sc), orig);
                 }
             }
+        }
+        if caps.code_blocks.is_empty() {
+            return;
+        }
+        // Build this node's Match so `$<name>` can carry the children's asts. The
+        // block's `$/` still comes from its own matched-so-far context (below), so
+        // a mid-rule `{ … $/ … }` sees the prefix — only the child `.made` values
+        // read via `$<name>` / `$<name>».made` come from here.
+        let node_match = Value::make_match_object_full_q(
+            caps.matched.clone(),
+            caps.from as i64,
+            caps.to as i64,
+            &caps.positional,
+            &caps.named,
+            &caps.named_subcaps,
+            &caps.positional_subcaps,
+            &caps.positional_quantified,
+            &caps.positional_nil,
+            orig,
+            &caps.named_quantified,
+        );
+        // Named captures carrying a child `.made` (from the recursion above).
+        let ast_named: Vec<(String, Value)> =
+            if let ValueView::Instance { attributes, .. } = node_match.view() {
+                match attributes.as_map().get("named").map(Value::view) {
+                    Some(ValueView::Hash(named_hash)) => named_hash
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect(),
+                    _ => Vec::new(),
+                }
+            } else {
+                Vec::new()
+            };
+        let blocks = std::mem::take(&mut caps.code_blocks);
+        let saved_match = self.env.get("/").cloned();
+        // Fresh `make` slot for this node (do not inherit a sibling's value).
+        self.env.remove("made");
+        for ctx in &blocks {
+            let Ok((stmts, _)) = crate::parse_dispatch::parse_source(&ctx.code) else {
+                continue;
+            };
+            self.setup_regex_code_block_env(ctx);
+            // Override `$<name>` with the reduced (ast-carrying) child Matches so
+            // `$<sub>.made` / `$<sub>».made` resolve to the produced values.
+            for (k, v) in &ast_named {
+                self.env.insert(format!("<{}>", k), v.clone());
+            }
+            self.eval_regex_code_block_body(&stmts);
+        }
+        caps.ast = self.env.get("made").cloned();
+        if let Some(m) = saved_match {
+            self.env.insert("/".to_string(), m);
         }
     }
 }

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -752,7 +752,13 @@ impl Interpreter {
                 if subcap.sym.is_none() && sym_key.is_some() {
                     subcap.sym = sym_key.cloned();
                 }
-                new_caps.code_blocks.extend(subcap.code_blocks.clone());
+                // The subrule's own inline `{ … }` code blocks stay ON the subcap
+                // (a queryable Match node) rather than bubbling into the parent, so
+                // the reduce-time walk (`reduce_regex_captures_made`) can run them
+                // once at this node — with `$/` bound to this subrule's Match — and
+                // commit the produced `make` value to `subcap.ast`. Bubbling them up
+                // (the old behaviour) ran them at the top level with the wrong `$/`
+                // and dropped the per-node `.made`.
                 // A non-suppressing alias `<name=subrule>` (NOT `<name=.subrule>` /
                 // `<name=&subrule>`) installs the capture under BOTH the alias name
                 // AND the subrule's own name, matching Rakudo (e.g. `<x=num>` yields
@@ -822,7 +828,8 @@ impl Interpreter {
                     subcap.sym = sym_key.cloned();
                 }
                 subcap.action_name = Some(spec.lookup_name.clone());
-                new_caps.code_blocks.extend(subcap.code_blocks.clone());
+                // Keep the silent subrule's inline blocks on its own (marker) node
+                // for the reduce-time walk to run once — see the non-silent branch.
                 let marker = format!(
                     "{}{}",
                     crate::runtime::SILENT_ACTION_MARKER_PREFIX,

--- a/src/runtime/regex_types.rs
+++ b/src/runtime/regex_types.rs
@@ -100,6 +100,12 @@ pub(crate) struct RegexCaptures {
     pub(crate) action_name: Option<String>,
     /// Hash captures from `%<name>=(...)` aliasing in regex.
     pub(crate) hash_captures: HashMap<String, Vec<(String, Option<String>)>>,
+    /// The AST value produced by this node's inline `{ make … }` code block(s),
+    /// computed at reduce time (`reduce_regex_captures_made`). Carried into the
+    /// Match object built by `make_match_object_full_q` so `$<sub>.made` /
+    /// `$<sub>».made` resolve in a parent inline action and post-parse. `None`
+    /// when the rule ran no `make`.
+    pub(crate) ast: Option<Value>,
 }
 
 #[derive(Clone)]

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -239,13 +239,13 @@ impl Interpreter {
                         is_block: false,
                         def_file: None,
                     });
-                    if let Some(captures) = self.regex_match_with_captures(&pat, &text) {
+                    if let Some(mut captures) = self.regex_match_with_captures(&pat, &text) {
                         // Set positional captures before executing code blocks
                         for (i, v) in captures.positional.iter().enumerate() {
                             self.env.insert(i.to_string(), Value::str(v.clone()));
                         }
-                        // Execute code blocks from regex for side effects
-                        self.execute_regex_code_blocks(&captures.code_blocks);
+                        // Reduce-time inline actions (children first).
+                        self.reduce_regex_captures_made(&mut captures, Some(&text));
                         let match_obj = Value::make_match_object_with_captures(
                             captures.matched.clone(),
                             captures.from as i64,
@@ -534,10 +534,13 @@ impl Interpreter {
                 } else {
                     non_overlapping
                 };
-                // Execute code blocks from each match for side effects
-                for cap in &selected {
-                    if !cap.code_blocks.is_empty() {
-                        self.execute_regex_code_blocks(&cap.code_blocks);
+                // Reduce-time inline actions from each match (children first).
+                let mut selected = selected;
+                for cap in &mut selected {
+                    if !cap.code_blocks.is_empty()
+                        || cap.named_subcaps.values().any(|v| !v.is_empty())
+                    {
+                        self.reduce_regex_captures_made(cap, Some(&text));
                     }
                 }
                 self.apply_multi_regex_captures(&selected, &text);
@@ -686,7 +689,7 @@ impl Interpreter {
                 } else {
                     self.env.remove("_");
                 }
-                if let Some(captures) = match_result {
+                if let Some(mut captures) = match_result {
                     // Reset stale numeric capture vars from any previous match.
                     let stale_numeric: Vec<Symbol> = self
                         .env
@@ -705,8 +708,9 @@ impl Interpreter {
                     }
                     // Clear any previous `made` value before executing code blocks
                     self.env.remove("made");
-                    // Execute code blocks from regex for side effects
-                    self.execute_regex_code_blocks(&captures.code_blocks);
+                    // Reduce-time inline actions: run each subrule's `{ make … }`
+                    // once (children first) and commit per-node `.made`.
+                    self.reduce_regex_captures_made(&mut captures, Some(&text));
                     // Merge hash captures into named for Match object
                     let mut named_with_hash = captures.named.clone();
                     for hash_name in captures.hash_captures.keys() {

--- a/src/value/value_methods_c.rs
+++ b/src/value/value_methods_c.rs
@@ -183,6 +183,10 @@ impl Value {
             if let Some(ref action_name) = caps.action_name {
                 attrs.insert("action_name".to_string(), Value::str(action_name.clone()));
             }
+            // Inline `{ make … }` value produced by this subrule at reduce time.
+            if let Some(ref ast) = caps.ast {
+                attrs.insert("ast".to_string(), ast.clone());
+            }
             if !caps.capture_alias_map.is_empty() {
                 let alias_hash: HashMap<String, Value> = caps
                     .capture_alias_map

--- a/t/grammar-inline-make-subrule-made.t
+++ b/t/grammar-inline-make-subrule-made.t
@@ -1,0 +1,44 @@
+use Test;
+
+# An inline grammar action (`{ make … }` inside a rule, not a separate
+# `.parse(:actions)` action class) sets that rule's `.made`. That value must be
+# attached to the SUBRULE's Match node so a parent inline action reading
+# `$<sub>.made` / `$<sub>».made` — and any post-parse `$m<sub>.made` — sees the
+# produced value rather than `Any`. (PLAN §8.16; Time::Duration::Parser.)
+
+plan 10;
+
+grammar G {
+    rule TOP  { <time>+ % <sep> { make [+] $<time>».made } }
+    rule time { <number> { make +$<number> * 10 } }
+    token number { \d+ }
+    token sep { <.ws> }
+}
+
+my $r = G.parse("1 2 3");
+is $r.made, 60, 'parent inline action reduces child .made values';
+is $r<time>».made.join(','), '10,20,30', 'each subrule Match carries its own .made';
+is $r<time>[0].made, 10, 'first subrule .made';
+is $r<time>[2].made, 30, 'last subrule .made';
+
+# Single (non-quantified) subrule: `$<sub>.made` (scalar) resolves too.
+grammar H {
+    rule TOP { <word> { make $<word>.made ~ '!' } }
+    token word { \w+ { make $/.Str.uc } }
+}
+my $h = H.parse("hello");
+is $h.made, 'HELLO!', 'scalar subrule .made available to parent inline action';
+is $h<word>.made, 'HELLO', 'scalar subrule Match carries .made';
+
+# Two levels of nesting: grandchild .made propagates up through the child.
+grammar J {
+    rule  TOP  { <pair> { make $<pair>.made } }
+    rule  pair { <a> <b> { make $<a>.made + $<b>.made } }
+    token a    { \d+ { make +$/ * 2 } }
+    token b    { \d+ { make +$/ * 3 } }
+}
+my $j = J.parse("5 7");
+is $j.made, 31, 'two-level nesting: (5*2) + (7*3) = 31';
+is $j<pair>.made, 31, 'intermediate node carries reduced .made';
+is $j<pair><a>.made, 10, 'grandchild a .made';
+is $j<pair><b>.made, 21, 'grandchild b .made';


### PR DESCRIPTION
## Summary

An **inline** grammar action — a `{ make … }` code block inside a rule rather than a separate `.parse(:actions)` action class — set the rule's own `.made` value but never attached it to the **subrule's** Match node. A parent action reading `$<sub>.made` / `$<sub>».made` therefore saw `Any`/`Nil`:

```raku
grammar G {
    rule TOP  { <time>+ % <sep> { make [+] $<time>».made } }
    rule time { <number> { make +$<number> * 10 } }
    token number { \d+ }
    token sep { <.ws> }
}
G.parse("1 2 3").made   # raku: 60   mutsu (before): 0
```

## Root cause

The flat code-block model *bubbled* every subrule's inline block into the top node's `code_blocks` list and ran them all at the top level with a single shared `$/`, so per-node `.made` was lost.

## Fix

Replace the flat top-level execution with a **reduce-time bottom-up walk** (`reduce_regex_captures_made`, in `regex/regex_eval_repeat.rs`):

- Named-subrule blocks now stay on their own `RegexCaptures` node (they no longer bubble — `build_named_candidates_from_inner`).
- The walk runs each node's blocks exactly once, **children first**, binding `$<name>` to the already-reduced child Matches so `$<sub>.made` / `$<sub>».made` resolve.
- The produced value is committed to a new `RegexCaptures::ast` field, which `make_match_object_full_q` carries into the Match so it also survives post-parse (`$m<sub>.made`).
- A mid-rule `{ … $/ … }` still sees its matched-so-far prefix — the block's `$/` comes from its own context; only `$<name>.made` reads the reduced value (keeps `t/regex-code-block-slash-var.t` green).

All winning-path call sites (grammar `.parse`, `~~`, `.match`, `.comb`) route through the reduce; the failure-path eager buffer stays flat. Orthogonal to the `.parse(:actions)` action-class walk and the `.made`-in-`<?{…}>` hook, both already working.

Closes PLAN §8.16; unblocks **Time::Duration::Parser** (0/42 → 42/42).

## Testing

- New pin: `t/grammar-inline-make-subrule-made.t` (10 assertions).
- `make test` PASS (2306 files, 21743 tests).
- All whitelisted `roast/S05-*` grammar/capture/metasyntax tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)