### PR TITLE
fix: state variables no longer collide across feed/function-form map blocks (PLAN §8.14)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1313,45 +1313,14 @@ reference `raku` (6.d) also `SORRY`s on it, so it is not a divergence — do not
       variants), `src/parser/primary/ident/anon_sub.rs` (+ wherever `sub NAME` in expr position is
       parsed), the compiler/VM closure builder that creates the `Sub` value.
 
-### 8.14 `state` variables in feed-lowered `map` blocks collide across blocks (deferred deep item — found 2026-07-22 by the Chemistry::Elements dist)
+### 8.14 `state` variables in feed-lowered `map` blocks collide across blocks — ✅ DONE 2026-07-23
 
-- [ ] **Two distinct blocks that each declare `state $n`, invoked via the feed-lowered
-      `map(BLOCK, list)` function form, share the same `state` storage.** After the first
-      block runs, the second block's `state $n = 0` does NOT re-initialize — it continues
-      from the first block's final value:
-      ```raku
-      my @a = <a b c d e>;
-      @a ==> map({ state $n = -1; $n++; $_ => $n.clone }) ==> my %first;   # ends $n = 4
-      my @b = <H He Li B>;
-      @b ==> map({ state $n = 0;  $n++; $_ => $n.clone }) ==> my %second;  # raku: H=>1
-      say %second<H>;   # raku: 1 ; mutsu: 5  (continued from %first's 4)
-      ```
-      The `.map` *method* form is correct (raku-equal); only the **feed / function** form
-      (`@a ==> map(...)`, `map(BLOCK, @a)`) collides.
-- **Root cause.** The inline map path (`eval_map_over_items`, `src/runtime/resolution_map_grep.rs`)
-      RE-compiles the block body fresh with `Compiler::new()` (ip restarts at 0), so the
-      compile-time `$var@<ip>` state key is *identical* for two distinct blocks. At runtime,
-      `state_scope_id` is `None` on this path (the method path preserves the block's original
-      `compiled_code`, whose ips differ), so both `$n` resolve to the bare key `$n@<ip>` and
-      share `self.state_vars`.
-- **Why the obvious fix fails.** Setting `vm.state_scope_id = Some(data.id)` in the inline
-      loop (so the key becomes `$n@<ip>#c{id}`) fixes the *cross-block* collision but BREAKS
-      *within-map* persistence (every iteration re-initializes → all `1`s). The state-key
-      plumbing is inconsistent: `StateVarInit` uses `scoped_state_key`, but
-      `load_state_locals`/`sync_state_locals` (`vm_run_loop.rs`) use the RAW key. They only
-      agree when `state_scope_id` is `None`. So a correct fix must thread the scoped key
-      through the inline map path's load/sync/init together — a change to the `state`-variable
-      subsystem, higher blast radius than one map site.
-- **Where it bites (Chemistry::Elements, raku-community-modules).** The module builds two hashes
-      with `... ==> map({ state $n ...}) ==> my %...` back-to-back at load time. The second
-      (`%symbol_to_name`, atomic numbers) starts its counter off by the first map's length (+4),
-      so `get_Z_by_symbol("Br")` returns 39 instead of 35 (and `get_name_by_symbol` → Nil).
-      The `can-ok`-on-a-type-object symptom of the same dist was fixed separately (#5206);
-      this counter bug is the remaining `t/010`/`t/020` failure.
-- Entry: `git checkout -b fix-state-scope-feed-map origin/main`. Files:
-      `src/runtime/resolution_map_grep.rs` (inline loop), `src/vm/vm_run_loop.rs`
-      (`scoped_state_key` / `load_state_locals` / `sync_state_locals`). Pin candidate:
-      `t/state-var-per-block-in-feed-map.t`.
+Fixed exactly along the mapped route: `load_state_locals`/`sync_state_locals`(`_in_range`)
+now resolve through `scoped_state_key` like `StateVarInit`/`Guard`/`reset` (a no-op where
+`state_scope_id` is None), and every inline fresh-recompile loop (map, rw-map, grep, first —
+including the `try_native_array_map`-fed rw path) sets `state_scope_id = Some(data.id)`.
+Pin: `t/state-var-per-block-in-feed-map.t`; details in `news/2026-07.md`. This was the
+remaining Chemistry::Elements `t/010`/`t/020` blocker.
 
 ### 8.15 Built-in object types with missing/wrong reprs, and `[ident]` mis-parsed as reduction (found 2026-07-22 by the repr oracle sweep)
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -27,6 +27,24 @@ are now registered as parse-time term symbols, so `sum + x` in the body reads th
 `\sum` param instead of parsing as the `sum(+x)` listop. Pins: `t/produce-last.t`,
 `t/reduce-destructuring-signature.t`.
 
+## 2026-07-23: `state` variables no longer collide across feed/function-form map blocks (closes PLAN §8.14)
+
+Two distinct blocks each declaring `state $n`, invoked via the feed / function form
+(`@a ==> map({ state $n ... })`, `map(BLOCK, @a)`), shared one state slot — the inline
+map path re-compiles the block fresh, so the compile-time `$var@<ip>` key is identical
+for different blocks (the Chemistry::Elements two-hash counter bug). The fix threads the
+scoped key through the whole state subsystem, exactly as §8.14's map prescribed:
+`load_state_locals` / `sync_state_locals` / `sync_state_locals_in_range` now resolve
+through `scoped_state_key` — matching `StateVarInit`/`StateVarInitGuard`/
+`reset_state_locals_in_range`, and a no-op on every pre-existing path (scope id None) —
+and each inline fresh-recompile loop (map, rw-map, grep-with-mutated, first) sets
+`state_scope_id = Some(block id)`. Investigation note: the variable-source feed
+(`@a ==> map(...)`) reaches a THIRD map loop — `eval_map_over_items_rw` via
+`builtin_map`'s named-array-source writeback branch — distinct from both the inline
+`eval_map_over_items` and the compiled-closure path, which is why fixing the first two
+alone left the original repro failing. Pin: `t/state-var-per-block-in-feed-map.t`
+(feed, function, within-map persistence, grep, first — all raku-verified).
+
 ## 2026-07-22: a big `FatRat` keeps its identity, distinct from a big `Rat` (#5238, closes PLAN §8.8)
 
 A rational whose numerator or denominator overflowed i64 was stored in a single

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -404,6 +404,14 @@ impl Interpreter {
                 .map(|cc| frame_authoritative_set(cc, &data.authoritative_captures))
                 .unwrap_or_default();
             let loop_result: Result<Value, RuntimeError> = self.with_nested_registers(|vm| {
+                // Scope this block's `state` variables to the closure instance
+                // (`$n@<ip>#c{id}`): the body was re-compiled fresh above, so
+                // the compile-time `$var@<ip>` key alone is IDENTICAL for two
+                // distinct blocks (ip restarts at 0) and their state would
+                // collide (`@a ==> map({ state $n ... })` twice — PLAN §8.14).
+                // load/sync/init all resolve through `scoped_state_key`, so
+                // within-map persistence across items is unaffected.
+                vm.state_scope_id = Some(data.id);
                 let mut i = 0usize;
                 while i < list_items.len() {
                     if arity > 1 && i + arity > list_items.len() {
@@ -640,6 +648,9 @@ impl Interpreter {
 
         let mut found: Option<(usize, Value)> = None;
         let loop_result: Result<(), RuntimeError> = self.with_nested_registers(|vm| {
+            // Scope `state` variables to the closure instance (see
+            // `eval_map_over_items`).
+            vm.state_scope_id = Some(data.id);
             vm.set_topic_source_var(None);
             let len = list_items.len();
             for scan in 0..len {

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -159,6 +159,10 @@ impl Interpreter {
                 })
                 .unwrap_or_default();
             let loop_result: Result<Value, RuntimeError> = self.with_nested_registers(|vm| {
+                // Scope `state` variables to the closure instance — the body was
+                // re-compiled fresh, so two distinct blocks share compile-time
+                // state keys (see the same line in `eval_map_over_items`).
+                vm.state_scope_id = Some(data.id);
                 let mut i = 0usize;
                 while i < list_items.len() {
                     if arity > 1 && i + arity > list_items.len() {
@@ -385,6 +389,9 @@ impl Interpreter {
                 })
                 .unwrap_or_default();
             let loop_result: Result<(), RuntimeError> = self.with_nested_registers(|vm| {
+                // Scope `state` variables to the closure instance (see
+                // `eval_map_over_items`).
+                vm.state_scope_id = Some(data.id);
                 let mut i = 0usize;
                 let mut stop = false;
                 while i < list_items.len() {

--- a/src/vm/vm_run_loop.rs
+++ b/src/vm/vm_run_loop.rs
@@ -447,9 +447,15 @@ impl Interpreter {
         }
     }
 
+    // Both loaders/syncers resolve the key through `scoped_state_key`, matching
+    // `StateVarInit`/`StateVarInitGuard`/`reset_state_locals_in_range` — the
+    // store must be read and written under ONE key shape or a scope-id'd init
+    // and a raw sync silently diverge (a no-op when `state_scope_id` is None,
+    // which is every path that existed before the inline-map scoping).
     fn load_state_locals(&mut self, code: &CompiledCode) {
         for (slot, key) in &code.state_locals {
-            if let Some(val) = self.get_state_var(key) {
+            let scoped_key = self.scoped_state_key(key);
+            if let Some(val) = self.get_state_var(&scoped_key) {
                 self.locals[*slot] = val.clone();
             }
         }
@@ -463,7 +469,8 @@ impl Interpreter {
                 .get(local_name)
                 .cloned()
                 .unwrap_or_else(|| self.locals[*slot].clone());
-            self.set_state_var(key.clone(), val);
+            let scoped_key = self.scoped_state_key(key);
+            self.set_state_var(scoped_key, val);
         }
     }
 
@@ -512,7 +519,8 @@ impl Interpreter {
                 .get(local_name)
                 .cloned()
                 .unwrap_or_else(|| self.locals[*slot].clone());
-            self.set_state_var(key.clone(), val);
+            let scoped_key = self.scoped_state_key(key);
+            self.set_state_var(scoped_key, val);
         }
     }
 

--- a/t/state-var-per-block-in-feed-map.t
+++ b/t/state-var-per-block-in-feed-map.t
@@ -1,0 +1,36 @@
+use v6;
+use Test;
+
+plan 8;
+
+# PLAN §8.14: two distinct blocks that each declare `state $n`, invoked via the
+# feed / function form of map, must NOT share state storage (the inline map
+# path re-compiles the block, so the compile-time state key alone collides).
+
+my @a = <a b c d e>;
+@a ==> map({ state $n = -1; $n++; $_ => $n.clone }) ==> my %first;
+my @b = <H He Li B>;
+@b ==> map({ state $n = 0; $n++; $_ => $n.clone }) ==> my %second;
+is %second<H>, 1, 'the second feed-map block re-runs its own state initializer';
+is %first<a>, 0, 'first block starts from its own initializer';
+is %first<e>, 4, 'first block counts its own items';
+is %second<B>, 4, 'second block counts its own items';
+
+# The function form with distinct blocks is likewise independent.
+my %f1 = map({ state $n = -1; $n++; $_ => $n.clone }, <a b>);
+my %f2 = map({ state $n = 0; $n++; $_ => $n.clone }, <x y>);
+is %f2<x>, 1, 'function-form map keeps per-block state';
+
+# State still persists across items WITHIN one map.
+my @counts = map({ state $n = 0; $n++; $n }, <p q r>);
+is-deeply @counts, [1, 2, 3], 'state persists across the items of one map';
+
+# grep and first blocks with state are scoped per block too.
+my @g1 = grep({ state $n = 0; $n++; $n > 1 }, <a b c>);
+my @g2 = grep({ state $n = 0; $n++; $n > 1 }, <x y z>);
+is-deeply @g2, [<y z>], 'a second grep block re-runs its own state initializer';
+my $h1 = first({ state $n = 0; $n++; $n == 2 }, <a b c>);
+my $h2 = first({ state $n = 0; $n++; $n == 2 }, <x y z>);
+is $h2, 'y', 'a second first block re-runs its own state initializer';
+
+done-testing;


### PR DESCRIPTION
## Summary

Closes PLAN.md §8.14 (the concrete-bug burn-down). Two distinct blocks each declaring `state $n`, invoked via the feed / function form (`@a ==> map({ state $n ... })`, `map(BLOCK, @a)`), shared one state slot — the inline map path re-compiles the block fresh, so the compile-time `$var@<ip>` state key is identical for different blocks. This was the remaining Chemistry::Elements `t/010`/`t/020` blocker (`get_Z_by_symbol("Br")` → 39 instead of 35).

The fix follows exactly the route §8.14's investigation mapped (thread the scoped key through load/sync/init together, instead of the known-broken point fix):

- `load_state_locals` / `sync_state_locals` / `sync_state_locals_in_range` now resolve through `scoped_state_key`, matching `StateVarInit` / `StateVarInitGuard` / `reset_state_locals_in_range`. This is a no-op on every pre-existing path (where `state_scope_id` is None, scoped == raw).
- Every inline fresh-recompile loop (map, rw-map, grep-with-mutated, first) sets `state_scope_id = Some(block id)`: distinct blocks get distinct keys, items within one loop share theirs.

Investigation note (recorded in news): the variable-source feed reaches a **third** map loop — `eval_map_over_items_rw` via `builtin_map`'s named-array-source writeback branch — distinct from both the inline `eval_map_over_items` and the compiled-closure path, which is why fixing the first two alone left the original repro failing.

## Testing

- New pin `t/state-var-per-block-in-feed-map.t` (8 assertions: feed form, function form, within-map persistence, grep, first) — green under both mutsu and the reference `raku`.
- Full `t/` prove: 2301 files / 21689 tests, all pass.
- Whitelisted `S04-declarations/state` roast files pass.
- `cargo clippy -- -D warnings` and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)