### PR TITLE
feat: expression-form sub NAME keeps its name and installs lexically (PLAN §8.13)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1292,26 +1292,21 @@ Both items landed (pins `t/produce-last.t`, `t/reduce-destructuring-signature.t`
 `news/2026-07.md`). Kept note: `rotor(3, 'a'..'h')` as a *function* is `v6.e.PREVIEW`-only; the
 reference `raku` (6.d) also `SORRY`s on it, so it is not a divergence — do not chase.
 
-### 8.13 A `sub NAME { }` used as an *expression* loses its `.name` (deferred — found 2026-07-22 by the variables.rakudoc doc-diff sweep)
+### 8.13 A `sub NAME { }` used as an *expression* loses its `.name` — mostly done 2026-07-23
 
-- [ ] **A named sub in expression/rvalue position drops its name.**
-      `my $s = sub foo { 1 }; say $s.name` is `foo` in raku but empty in mutsu; likewise
-      `(sub baz {1}).name`, `my &g = sub bar {1}; &g.name`, and `anon sub square($x){…}` (its
-      `.name` should stay `square` even though `anon` keeps it out of the symbol table). A
-      *statement-form* `sub foo {…}` is fine — `&foo.name` is `foo` — because the installer records
-      the name; only the expression form loses it.
-- **Root cause: the AST has nowhere to put the name.** A `sub NAME {…}` expression parses to
-      `Expr::AnonSub { body, is_rw, is_block }` / `Expr::AnonSubParams { … }` (`src/ast.rs:311`), both
-      of which have **no `name` field** — the parser consumes and discards the name
-      (`src/parser/primary/ident/anon_sub.rs`). So the created `Sub` value is built nameless.
-- **Why it is deferred (blast radius).** Adding `name: Option<String>` to `AnonSub`/`AnonSubParams`
-      touches ~66 construction sites of `Expr::AnonSub {` across parser + AST helpers + VM, plus the
-      closure-creation path that stamps the `Sub` value's name. It is a mechanical but wide change;
-      do it as its own PR. Also render it in `.gist` (`&foo`) and set `.name`. Pin candidate:
-      `t/sub-expression-name.t`.
-- Entry: `git checkout -b feat-named-sub-expression origin/main`. Files: `src/ast.rs` (the two
-      variants), `src/parser/primary/ident/anon_sub.rs` (+ wherever `sub NAME` in expr position is
-      parsed), the compiler/VM closure builder that creates the `Sub` value.
+The main behaviors landed WITHOUT the feared ~66-site `Expr::AnonSub` field addition: the
+expression-form named sub now parses through the statement sub-decl parser and wraps in
+`Expr::DoStmt(Stmt::SubDecl)` — the compiler's existing do-expr `SubDecl` arm (added for
+`my sub foo {...}`) registers the routine and loads `&NAME` as the value. That gives
+`.name` == "foo" AND the raku-correct lexical install (`&foo` / `foo()` work after
+`my $s = sub foo {...}`, which the old AnonSub lowering also lacked). Pin:
+`t/sub-expression-name.t`.
+
+- [ ] **Leftovers (small):** `anon sub NAME {...}` still drops the name (it must NOT
+      install, so it keeps the AnonSub lowering — needs a name-carrying mechanism or a
+      register-then-remove trick); and a *named* Sub's `.gist` should render `&foo`
+      (mutsu renders the long `sub foo () { ... }` form; anonymous subs gist `sub { }`
+      in raku and that part matches).
 
 ### 8.14 `state` variables in feed-lowered `map` blocks collide across blocks — ✅ DONE 2026-07-23
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -20,6 +20,19 @@ and `\\\\` (was one backslash instead of two). Pin:
 **P5quotemeta** (5756 → 2879 failing; the remaining `# using $_` failures need
 `CALLER::LEXICAL::<$_>` topic access — a separate deep gap, recorded in TODO_dist T-056).
 
+## 2026-07-23: an expression-form `sub NAME {...}` keeps its name and installs lexically (PLAN §8.13)
+
+`my $s = sub foo { 1 }` gave a nameless Sub (`.name` empty) and — unlike Raku — did NOT
+install `&foo` lexically: the expression parser consumed the name and lowered to the
+nameless `Expr::AnonSub`. §8.13 had deferred this fearing a ~66-site `AnonSub` field
+addition, but no AST change was needed: the expression form now parses through the
+statement sub-decl parser and wraps in `Expr::DoStmt(Stmt::SubDecl)`, and the compiler's
+existing do-expr `SubDecl` arm (added for `my sub foo {...}`) registers the routine and
+loads `&NAME` as the expression value. `.name` is "foo", `&foo`/`foo()` work afterwards,
+and `(sub baz {2}).name` / `my &g = sub bar {3}` all match raku. Leftovers recorded in
+§8.13: `anon sub NAME` (must not install; still nameless) and the named-Sub `&foo` gist
+form. Pin: `t/sub-expression-name.t`.
+
 ## 2026-07-23: produce with `last`/`next`, and reduce with a destructuring signature (closes PLAN §8.12)
 
 Both §8.12 items, raku-verified. **`.produce` with `last`** no longer throws

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -777,47 +777,16 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                     },
                 ));
             }
-            if let Ok((r_named, _name)) = crate::parser::stmt::parse_sub_name_pub(r) {
-                let (r_named, _) = ws(r_named)?;
-                if r_named.starts_with("is ")
-                    || r_named.starts_with("returns ")
-                    || r_named.starts_with("of ")
-                {
-                    let (r_named, traits) = crate::parser::stmt::parse_sub_traits_pub(r_named)?;
-                    let (r_named, body) = parse_block_body(r_named)?;
-                    let mut expr = Expr::AnonSub {
-                        body,
-                        is_rw: traits.is_rw,
-                        is_block: false,
-                    };
-                    if traits.is_rw {
-                        expr = set_anon_sub_rw(expr, true);
-                    }
-                    return Ok((r_named, expr));
-                }
-                if r_named.starts_with('{') {
-                    let (r_named, body) = parse_block_body(r_named)?;
-                    return Ok((
-                        r_named,
-                        Expr::AnonSub {
-                            body,
-                            is_rw: false,
-                            is_block: false,
-                        },
-                    ));
-                }
-                if r_named.starts_with('(') {
-                    let (r_named, params_body) =
-                        parse_anon_sub_with_params(r_named).map_err(|err| PError {
-                            messages: merge_expected_messages(
-                                "expected anonymous sub parameter list/body",
-                                &err.messages,
-                            ),
-                            remaining_len: err.remaining_len.or(Some(r_named.len())),
-                            exception: None,
-                        })?;
-                    return Ok((r_named, params_body));
-                }
+            // A NAMED sub in expression position (`my $s = sub foo {...}`)
+            // is a full declaration in Raku: it installs `&foo` lexically AND
+            // evaluates to the routine object (whose `.name` is "foo").
+            // Delegate to the statement sub-decl parser and wrap in `DoStmt` —
+            // the compiler's do-expr `SubDecl` arm registers the routine and
+            // loads `&NAME` as the expression value.
+            if crate::parser::stmt::parse_sub_name_pub(r).is_ok()
+                && let Ok((r_decl, stmt)) = crate::parser::stmt::sub_decl_body_pub(r)
+            {
+                return Ok((r_decl, Expr::DoStmt(Box::new(stmt))));
             }
             if r.starts_with("is ") || r.starts_with("returns ") || r.starts_with("of ") {
                 let (r, traits) = crate::parser::stmt::parse_sub_traits_pub(r)?;

--- a/src/parser/primary/mod.rs
+++ b/src/parser/primary/mod.rs
@@ -319,6 +319,7 @@ pub(super) fn primary(input: &str) -> PResult<'_, Expr> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ast::Stmt;
     use crate::value::ValueView;
 
     #[test]
@@ -962,7 +963,10 @@ mod tests {
     fn primary_parses_named_sub_literal_in_expression_context() {
         let (rest, expr) = primary("sub f { 42 }").unwrap();
         assert_eq!(rest, "");
-        assert!(matches!(expr, Expr::AnonSub { .. }));
+        assert!(matches!(
+            expr,
+            Expr::DoStmt(ref stmt) if matches!(**stmt, Stmt::SubDecl { ref name, .. } if name == "f")
+        ));
     }
 
     #[test]

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -55,8 +55,8 @@ pub(super) use pub_shims::{
     constant_decl_pub, for_stmt_pub, given_stmt_pub, ident_pub, if_stmt_pub, labeled_loop_stmt_pub,
     lazy_for_stmt_pub, let_stmt_pub, loop_stmt_pub, my_decl_expr_pub, parse_param_list_pub,
     parse_param_list_with_return_pub, parse_pointy_param_pub, parse_return_type_annotation_pub,
-    parse_sub_name_pub, parse_sub_traits_pub, statement_pub, sub_decl_with_semicolon_mode_pub,
-    temp_stmt_pub, until_stmt_pub, while_stmt_pub, with_stmt_pub,
+    parse_sub_name_pub, parse_sub_traits_pub, statement_pub, sub_decl_body_pub,
+    sub_decl_with_semicolon_mode_pub, temp_stmt_pub, until_stmt_pub, while_stmt_pub, with_stmt_pub,
 };
 
 thread_local! {

--- a/src/parser/stmt/pub_shims.rs
+++ b/src/parser/stmt/pub_shims.rs
@@ -60,6 +60,13 @@ pub(crate) fn sub_decl_with_semicolon_mode_pub(
     sub::sub_decl_with_semicolon_mode(input, allow_main_semicolon_decl)
 }
 
+/// Public accessor for sub_decl_body (used by primary/ident for the
+/// expression-form named sub `my $s = sub foo {...}` — input is positioned at
+/// the sub NAME, after the `sub` keyword).
+pub(crate) fn sub_decl_body_pub(input: &str) -> PResult<'_, Stmt> {
+    sub::sub_decl_body(input, false, false, false)
+}
+
 /// Public accessor for constant declaration parser (used by primary.rs in expression context).
 pub(crate) fn constant_decl_pub(input: &str) -> PResult<'_, Stmt> {
     decl::constant_decl(input)

--- a/t/sub-expression-name.t
+++ b/t/sub-expression-name.t
@@ -1,0 +1,24 @@
+use v6;
+use Test;
+
+plan 8;
+
+# PLAN §8.13: a named sub in expression position keeps its name and — like any
+# sub declaration in Raku — installs itself lexically.
+
+my $s = sub foo { 1 };
+is $s.name, 'foo', 'expression-form named sub keeps its .name';
+is $s(), 1, 'the stored value is callable';
+is &foo.name, 'foo', 'the name is installed lexically too';
+is foo(), 1, 'the installed sub is callable by name';
+
+is (sub baz { 2 }).name, 'baz', 'parenthesized expression form keeps the name';
+my &g = sub bar { 3 };
+is &g.name, 'bar', 'bound to a &-var the name survives';
+is g(), 3, 'and it is callable through the binding';
+
+# The statement form still works as before.
+sub plain { 4 }
+is &plain.name, 'plain', 'statement-form name is unchanged';
+
+done-testing;


### PR DESCRIPTION
## Summary

PLAN.md §8.13 (the concrete-bug burn-down): `my $s = sub foo { 1 }` gave a nameless Sub (`.name` empty) and — unlike Raku — did **not** install `&foo` lexically, because the expression parser consumed the name and lowered to the nameless `Expr::AnonSub`.

No AST change was needed (§8.13 had deferred this fearing a ~66-site `AnonSub` field addition): the expression form now parses through the statement sub-decl parser (new `sub_decl_body_pub` shim) and wraps in `Expr::DoStmt(Stmt::SubDecl)` — the compiler's existing do-expr `SubDecl` arm (added for `my sub foo {...}`) registers the routine and loads `&NAME` as the expression value. Both raku behaviors come out right: `.name` is `foo`, and `&foo` / `foo()` work after the declaration; `(sub baz {2}).name` and `my &g = sub bar {3}; &g.name` match raku too.

Leftovers recorded in PLAN §8.13 (small): `anon sub NAME` (must not install, still nameless) and the named-Sub `&foo` gist form.

## Testing

- New pin `t/sub-expression-name.t` (8 assertions) — green under both mutsu and the reference `raku`.
- Full `t/` prove: 2310 files / 21776 tests, all pass.
- `cargo clippy -- -D warnings` and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)