### PR TITLE
fix: s/// replacement \\ before a capture var keeps its backslash

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -625,11 +625,27 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   and fix sketch are in §8.16.
 - file: `src/value/value_methods_c.rs` (Match builder), regex capture-commit path
 
-### T-056 — test_fail: Codepoint [P5quotemeta]  [impact: 1 dist]
-- dists: P5quotemeta
-- e.g. base=1 pass=0 fail=1 die=0 | t/01-basic.rakutest: Codepoint 0 [0]
-- repro: _(fill in — quotemeta over codepoints; check baseline first)_
-- file: _(suspected parser/runtime file)_
+### T-056 — test_fail: Codepoint [P5quotemeta]  [impact: 1 dist]  — ONE ROOT CAUSE FIXED (PR `fix-subst-replacement-double-backslash`); one deferred
+- dists: P5quotemeta (5756 tests: raku 5756/5756)
+- The module is `S:g/ ( <[ …\x[…] ]> ) /\\$0/` — escape each matched char with a
+  backslash. TWO root causes; the test alternates a direct-arg and a `# using $_` form.
+- **ROOT CAUSE 1 — FIXED: `\\$0` replacement dropped the backslash.** `S:g/(x)/\\$0/`
+  yielded `x`, not `\x`. The replacement was double-unescaped: `normalize_subst_replacement`
+  collapsed `\\`→`\`, then `interpolate_subst_replacement_with_closures` read the resulting
+  `\$` as an escaped `$` and dropped the backslash. Fix: normalize keeps `\\` intact and
+  lets the single interpolation pass do the `\\`→`\` collapse (also fixes `\\n`, `\\\\`,
+  and any `\\`-before-sigil). This halves the failures (5756 → 2879) — the direct-arg
+  cases now pass. Pin: `t/subst-replacement-escaped-backslash.t`.
+  File: `src/vm/vm_string_regex_ops.rs::normalize_subst_replacement`.
+- **ROOT CAUSE 2 — DEFERRED (deep, optimizer-dependent, poor ROI): `CALLER::LEXICAL::<$_>`
+  topic access.** The no-arg `multi sub quotemeta(--> Str:D) { quotemeta CALLER::LEXICAL::<$_> }`
+  reads the caller's topic; mutsu returns `Nil`/empty, so every `# using $_` subtest fails.
+  mutsu has no `CALLER::LEXICAL::<…>` resolution (returns Nil for any name). This is fragile
+  even in raku: a same-file/`-I lib` repro returns `Rakudo::Internals::LoweredAwayLexical`
+  (raku lowers the caller `$_` away); only the *precompiled/installed* module boundary keeps
+  it live, which is what makes the real test pass. Implementing a general
+  `CALLER::LEXICAL::<$var>` that walks the dynamic caller frame is a distinct, deep feature.
+- file: DONE (root cause 1) — src/vm/vm_string_regex_ops.rs; remaining — `CALLER::LEXICAL::<>`.
 
 ### T-057 — test_die batch (seed-555, un-triaged)  [impact: several dists]
 - dists (each its own root cause; triage individually before claiming, confirm the

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,22 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-23: an `s///` replacement `\\` before a capture var keeps its backslash (P5quotemeta)
+
+A substitution replacement `\\` (an escaped backslash — one literal backslash) followed
+by a capture variable dropped the backslash: `S:g/(x)/\\$0/` yielded `x` instead of `\x`.
+The replacement was **double-unescaped**. The pipeline runs `normalize_subst_replacement`
+(cooks `\n`, `\x[…]`, `\\`, …) and then `interpolate_subst_replacement_with_closures`
+(interpolates `$var`/`{code}` and *also* cooks `\\`, `\$`, `\n`, …). Normalize collapsed
+`\\`→`\`, and interpolation then read the resulting `\$` as an escaped `$`, dropping the
+backslash entirely. The fix makes `normalize_subst_replacement` keep `\\` intact (emit
+both backslashes) and lets the single downstream interpolation pass perform the one
+`\\`→`\` collapse. This also fixes `\\n` (was becoming a newline instead of backslash+n)
+and `\\\\` (was one backslash instead of two). Pin:
+`t/subst-replacement-escaped-backslash.t`. Unblocks the direct-argument half of
+**P5quotemeta** (5756 → 2879 failing; the remaining `# using $_` failures need
+`CALLER::LEXICAL::<$_>` topic access — a separate deep gap, recorded in TODO_dist T-056).
+
 ## 2026-07-23: produce with `last`/`next`, and reduce with a destructuring signature (closes PLAN §8.12)
 
 Both §8.12 items, raku-verified. **`.produce` with `last`** no longer throws

--- a/src/vm/vm_string_regex_ops.rs
+++ b/src/vm/vm_string_regex_ops.rs
@@ -462,6 +462,13 @@ pub(super) fn normalize_subst_replacement(template: &str) -> String {
         };
         match next {
             '\\' => {
+                // Keep the escaped backslash INTACT (both chars). The downstream
+                // interpolation pass (`interpolate_subst_replacement_with_closures`,
+                // run once per match) performs the single `\\` → `\` collapse.
+                // Collapsing it here as well double-unescaped it: `\\$0` became
+                // `\$0`, and interpolation then read the `\$` as an escaped `$` and
+                // dropped the backslash entirely (`S:g/(x)/\\$0/` lost its `\`).
+                out.push('\\');
                 out.push('\\');
                 chars.next();
             }

--- a/t/subst-replacement-escaped-backslash.t
+++ b/t/subst-replacement-escaped-backslash.t
@@ -1,0 +1,41 @@
+use Test;
+
+# A replacement `\\` (escaped backslash → one literal backslash) followed by a
+# capture var must keep the backslash: `S/(x)/\\$0/` yields `\x`, not `x`. The
+# replacement was double-unescaped — `normalize_subst_replacement` collapsed
+# `\\`→`\`, then the interpolation pass read the resulting `\$` as an escaped `$`
+# and dropped the backslash entirely. (P5quotemeta `S:g/(<[...]>)/\\$0/`.)
+
+plan 12;
+
+# S/// (non-destructive) with $0 after \\
+is (S/ (a) /\\$0/ given "a"), "\\a", 'S/// : \\ before $0 keeps the backslash';
+is (S:g/ (<[ab]>) /\\$0/ given "ab"), "\\a\\b", 'S:g/// : \\ before $0, each match';
+
+# s/// (destructive)
+my $d = "a"; $d ~~ s/ (a) /\\$0/;
+is $d, "\\a", 's/// : \\ before $0 keeps the backslash';
+
+# .subst with a closure replacement (per-match $0).
+is "ab".subst(/(<[ab]>)/, {"\\$0"}, :g), "\\a\\b", '.subst closure replacement \\$0';
+
+# \\ before a hex codepoint char class (the P5quotemeta shape)
+is (S:g/ ( <[ \x[3164] ]> ) /\\$0/ given "\x[3164]"), "\\\x[3164]",
+    'S:g/// : \\ before $0 with a hex codepoint class';
+
+# A lone literal backslash in the replacement (no capture after) still works.
+is (S/ a /\\/ given "a"), "\\", 'lone \\ replacement is one backslash';
+is (S/ a /\\X/ given "a"), "\\X", '\\ before a literal char';
+is (S/ (a) /$0\\/ given "a"), "a\\", '\\ after $0';
+
+# Two escaped backslashes → two literal backslashes.
+is (S/ (a) /\\\\$0/ given "a"), "\\\\a", 'double \\\\ before $0 = two backslashes';
+
+# \\ before n is a literal backslash + n, NOT a newline.
+is (S/ a /\\n/ given "a"), "\\n", '\\ before n is literal backslash + n';
+
+# A bare \n escape (single backslash) still becomes a newline.
+is (S/ a /\n/ given "a"), "\n", 'bare \n is a newline';
+
+# $0 interpolation without a backslash is unaffected.
+is (S/ (a) /X$0X/ given "a"), "XaX", 'plain $0 interpolation still works';


### PR DESCRIPTION
## Summary

A substitution replacement `\\` (an escaped backslash — one literal backslash) followed by a capture variable dropped the backslash:

```raku
S:g/ (x) /\\$0/ given "x"   # raku: "\x"   mutsu (before): "x"
```

## Root cause

The replacement was **double-unescaped**. The pipeline runs `normalize_subst_replacement` (cooks `\n`, `\x[…]`, `\\`, …) and then `interpolate_subst_replacement_with_closures` (interpolates `$var`/`{code}` and *also* cooks `\\`, `\$`, `\n`, …). `normalize` collapsed `\\`→`\`, and interpolation then read the resulting `\$` as an escaped `$`, dropping the backslash entirely.

## Fix

Make `normalize_subst_replacement` keep `\\` intact (emit both backslashes) and let the single downstream interpolation pass perform the one `\\`→`\` collapse. This also fixes:
- `\\n` — was becoming a newline instead of a literal backslash + `n`.
- `\\\\` — was one backslash instead of two.

## Impact

Unblocks the direct-argument half of **P5quotemeta** (`S:g/(<[…]>)/\\$0/`): failures drop from 5756 → 2879. The remaining `# using $_` failures need `CALLER::LEXICAL::<$_>` topic access — a separate, deep, optimizer-dependent gap recorded in `TODO_dist/TICKETS.md` (T-056).

## Testing

- New pin: `t/subst-replacement-escaped-backslash.t` (12 assertions, all matching raku).
- `make test` PASS (2309 files, 21772 tests).
- All 104 `t/subst-*` / `t/regex-*` / `t/trans*` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)