### PR TITLE
fix: .List materializes array holes as literal Nil; Nil =:= Nil holds through fresh-container reads (PLAN 8.5 step 1)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1196,9 +1196,18 @@ the backlog.
       `roast/S02-types/nil.t` — 67 tests, whitelisted, the authoritative spec; **always run it with
       `MUTSU_FUDGE=1`** or its `#?rakudo todo` tests false-fail) are recorded in the memory note
       `project-nil-any-identity-knot`. Read it before any re-attempt; do **not** re-attempt as a small slice.
-- **Cost/benefit: LOW-value, HIGH-cost.** The doc-diff payoff is only niche uninitialized-value
-      rendering. Reasonable to keep deferring vs the §1/§6 frontier. Related: §6 (dual-store / lexical
-      slot), [`array-hole-tracking-embedded`], [ADR-0001] container-repr.
+- **Campaign step 1 landed 2026-07-23** (branch `nil-any-campaign`): `.List` materializes array
+      holes as literal `Nil` (via the new canonical `ArrayData::hole_at` predicate; `is default` does
+      not change `.List` — only `.Slip`), argless `.head` reads the store raw (hole → `Nil`), and
+      `Nil` was dropped from the `=:=` fresh-container short-circuit so a List element holding
+      literal `Nil` satisfies `=:= Nil`. This decouples `roast/S32-array/delete.t` subtest 33 from
+      the eqv crutch (it now passes on real Nils). Pin: `t/nil-list-holes.t` (16 assertions,
+      raku-verified). Remaining steps: 2 (store `Any` at every "stored Nil should be Any" site),
+      3 (uninit `my $x` = Any — the compiler/closure-cell knot), 4 (remove the eqv crutch LAST),
+      5 (`(my $x = Nil)` yields the container value Any).
+- **Cost/benefit: LOW-value, HIGH-cost** (for the remaining steps 2-5). The doc-diff payoff is only
+      niche uninitialized-value rendering. Related: §6 (dual-store / lexical slot),
+      [`array-hole-tracking-embedded`], [ADR-0001] container-repr.
 
 ### 8.6 `.WHO`/`.HOW` render without their metamodel detail — mostly done; internals leftover
 

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -250,13 +250,25 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 let vec: Vec<Value> = if let Some(def) = items.default.as_deref() {
                     items
                         .iter()
-                        .map(|v| match v.view() {
-                            ValueView::Package(n) if n == "Any" => def.clone(),
-                            _ => v.clone(),
+                        .enumerate()
+                        .map(|(i, v)| {
+                            if items.hole_at(i) {
+                                def.clone()
+                            } else {
+                                v.clone()
+                            }
                         })
                         .collect()
                 } else {
-                    items.to_vec()
+                    // No custom default: holes read as `Any`. A deleted slot
+                    // stores literal `Nil`, which must still surface as `Any`.
+                    items
+                        .iter()
+                        .map(|v| match v.view() {
+                            ValueView::Nil => Value::package(crate::symbol::Symbol::intern("Any")),
+                            _ => v.clone(),
+                        })
+                        .collect()
                 };
                 Some(Ok(Value::slip_arc(std::sync::Arc::new(vec))))
             }
@@ -339,7 +351,23 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
             // A shaped array falls through to the slow path, which flattens all
             // dimensions and replaces Nil slots with the type-default.
             ValueView::Array(..) if crate::runtime::utils::is_shaped_array(target) => None,
-            ValueView::Array(items, _) => Some(Ok(Value::array(items.to_vec()))),
+            ValueView::Array(items, _) => {
+                // `.List` materializes array holes as literal `Nil` — even when
+                // the array has an `is default(...)` value (Rakudo semantics:
+                // only `.Slip` substitutes the default).
+                let vec: Vec<Value> = items
+                    .iter()
+                    .enumerate()
+                    .map(|(i, v)| {
+                        if items.hole_at(i) {
+                            Value::NIL
+                        } else {
+                            v.clone()
+                        }
+                    })
+                    .collect();
+                Some(Ok(Value::array(vec)))
+            }
             ValueView::GenericRange {
                 start,
                 end,

--- a/src/builtins/methods_0arg/dispatch_core_range.rs
+++ b/src/builtins/methods_0arg/dispatch_core_range.rs
@@ -86,7 +86,14 @@ pub(super) fn dispatch(
             // method — defer to runtime dispatch so the user accessor wins
             // over the list-like fallback.
             ValueView::Instance { .. } => return None,
-            ValueView::Array(items, ..) => Some(Ok(items.first().cloned().unwrap_or(Value::NIL))),
+            // Argless `.head` reads the backing store raw (Rakudo's Array.head
+            // candidate): a hole at index 0 yields `Nil`, not the vivified
+            // `Any` that iteration (`for @a`, `.head(n)`) would produce.
+            ValueView::Array(items, ..) => Some(Ok(if items.hole_at(0) {
+                Value::NIL
+            } else {
+                items.first().cloned().unwrap_or(Value::NIL)
+            })),
             ValueView::Range(start, end) => {
                 if start > end {
                     Some(Ok(Value::NIL))

--- a/src/compiler/expr_binary.rs
+++ b/src/compiler/expr_binary.rs
@@ -496,6 +496,20 @@ impl Compiler {
 
         // Special-case: =:= (container identity)
         if matches!(op, TokenKind::Ident(name) if name == "=:=") {
+            // A literal `Nil` operand (`$x =:= Nil`, `@list[$i] =:= Nil`):
+            // Nil is a singleton, never a container, so this is a pure value
+            // identity check — a read that yields literal Nil (e.g. a `.List`
+            // hole element) IS Nil. Emit with no fresh-container flags so the
+            // VM falls through to `values_identical`. Two *reads* that both
+            // happen to yield Nil stay non-identical via the fresh flags below.
+            let left_lit_nil = matches!(left, Expr::Literal(lit) if lit.is_nil());
+            let right_lit_nil = matches!(right, Expr::Literal(lit) if lit.is_nil());
+            if left_lit_nil || right_lit_nil {
+                self.compile_expr(left);
+                self.compile_expr(right);
+                self.code.emit(OpCode::ContainerEq(0));
+                return;
+            }
             // Resolve variable names from both sides, including through
             // list-indexing patterns like ($foo, "x")[0] which preserves
             // the container of $foo.

--- a/src/value/value_collections.rs
+++ b/src/value/value_collections.rs
@@ -164,6 +164,25 @@ impl ArrayData {
     pub fn has_type_meta(&self) -> bool {
         self.value_type.is_some() || self.key_type.is_some() || self.declared_type.is_some()
     }
+
+    /// Whether index `i` is a hole (a deleted slot or an autovivification
+    /// gap), as opposed to an explicitly-assigned element. The canonical
+    /// predicate mirrored by `:exists`/`:k`/`:p`: a literal `Nil` slot is a
+    /// deleted hole; a type-object slot (`Any`, or the element type of a
+    /// typed array) is a gap unless the embedded `initialized` set records
+    /// an explicit assignment (`None` means bulk-constructed — no gaps).
+    pub fn hole_at(&self, i: usize) -> bool {
+        match self.items.get(i).map(Value::view) {
+            None => true,
+            Some(crate::value::ValueView::Nil) => true,
+            Some(crate::value::ValueView::Package(name)) => {
+                let is_gap_marker =
+                    name == "Any" || self.value_type.as_deref().is_some_and(|t| name == t);
+                is_gap_marker && self.initialized.as_ref().is_some_and(|s| !s.contains(&i))
+            }
+            Some(_) => false,
+        }
+    }
 }
 
 impl std::ops::Deref for ArrayData {

--- a/src/vm/vm_comparison_container_ops.rs
+++ b/src/vm/vm_comparison_container_ops.rs
@@ -29,14 +29,15 @@ impl Interpreter {
 
     /// Returns `true` when **both** values are simple, non-reference
     /// types where stack copies can never carry container identity
-    /// (Int, Str, Bool, Rat, …).
+    /// (Int, Str, Bool, Nil, Rat, …).
     ///
     /// Note: `Package` is NOT included because type objects are singletons —
     /// two variables holding the same Package should be considered `=:=`.
-    /// `Nil` is NOT included either: Nil is a singleton that no container
-    /// ever holds (assignment resets to the default), so an expression
-    /// yielding Nil — e.g. a `.List` hole element — IS the Nil singleton
-    /// and `=:= Nil` must be True even through a "fresh container" read.
+    /// `Nil` IS included: two *variable/element reads* both yielding Nil are
+    /// distinct containers (uninitialized scalars store Nil pre-PLAN-8.5-step-3),
+    /// so they must not compare identical. The `X =:= Nil` literal form is
+    /// compiled with `flags == 0` instead (see `compile_binary`'s `=:=` arm),
+    /// which routes to `values_identical` where Nil == Nil holds.
     fn is_value_non_reference(left: &Value, right: &Value) -> bool {
         fn is_non_ref(v: &Value) -> bool {
             matches!(
@@ -46,6 +47,7 @@ impl Interpreter {
                     | ValueView::Num(_)
                     | ValueView::Str(_)
                     | ValueView::Bool(_)
+                    | ValueView::Nil
                     | ValueView::Rat(..)
                     | ValueView::FatRat(..)
                     | ValueView::BigRat(..)

--- a/src/vm/vm_comparison_container_ops.rs
+++ b/src/vm/vm_comparison_container_ops.rs
@@ -29,10 +29,14 @@ impl Interpreter {
 
     /// Returns `true` when **both** values are simple, non-reference
     /// types where stack copies can never carry container identity
-    /// (Int, Str, Bool, Nil, Rat, …).
+    /// (Int, Str, Bool, Rat, …).
     ///
     /// Note: `Package` is NOT included because type objects are singletons —
     /// two variables holding the same Package should be considered `=:=`.
+    /// `Nil` is NOT included either: Nil is a singleton that no container
+    /// ever holds (assignment resets to the default), so an expression
+    /// yielding Nil — e.g. a `.List` hole element — IS the Nil singleton
+    /// and `=:= Nil` must be True even through a "fresh container" read.
     fn is_value_non_reference(left: &Value, right: &Value) -> bool {
         fn is_non_ref(v: &Value) -> bool {
             matches!(
@@ -42,7 +46,6 @@ impl Interpreter {
                     | ValueView::Num(_)
                     | ValueView::Str(_)
                     | ValueView::Bool(_)
-                    | ValueView::Nil
                     | ValueView::Rat(..)
                     | ValueView::FatRat(..)
                     | ValueView::BigRat(..)

--- a/t/nil-list-holes.t
+++ b/t/nil-list-holes.t
@@ -1,0 +1,48 @@
+use v6;
+use Test;
+
+# PLAN 8.5 step 1: .List materializes array holes as literal Nil
+# (Rakudo semantics; .Slip keeps Any / the `is default` value instead),
+# argless .head reads the store raw (hole -> Nil), and a List element
+# holding literal Nil satisfies `=:= Nil`.
+
+plan 16;
+
+# --- .List on an autovivification-gap array ---
+my @a;
+@a[2] = 5;
+is @a.List.raku, '(Nil, Nil, 5)', '.List materializes autoviv holes as Nil';
+is @a.List[0].raku, 'Nil', 'a .List hole element reads back as literal Nil';
+ok @a.List[0] =:= Nil, 'a .List hole element is =:= Nil';
+is @a.head.raku, 'Nil', 'argless .head on a hole gives Nil, not Any';
+is @a[0].raku, 'Any', 'a direct element read still vivifies to Any';
+is @a.Slip.raku, 'slip(Any, Any, 5)', '.Slip keeps holes as Any';
+
+# --- deleted slots are holes too ---
+my @b = 1, 2, 3;
+@b[1]:delete;
+is @b.List.raku, '(1, Nil, 3)', '.List materializes a deleted slot as Nil';
+ok @b.List[1] =:= Nil, 'a deleted slot reads as Nil through .List';
+
+# --- `is default(...)` does not change .List (only .Slip) ---
+my @c is default(42) = 1, 2, 3;
+@c[1]:delete;
+is @c.List.raku, '(1, Nil, 3)', '.List keeps holes Nil even with is default';
+is @c.Slip[1], 42, '.Slip substitutes the is default value for holes';
+
+# --- typed arrays: holes still materialize as Nil ---
+my Int @d;
+@d[2] = 5;
+is @d.List.raku, '(Nil, Nil, 5)', '.List on a typed array materializes holes as Nil';
+is @d.head.raku, 'Nil', '.head on a typed-array hole gives Nil';
+
+# --- literal Nil in a List preserves identity ---
+my $l = (Nil, 1);
+is $l[0].raku, 'Nil', 'a literal Nil List element reads back as Nil';
+ok $l[0] =:= Nil, 'a literal Nil List element is =:= Nil';
+ok (Nil, 1)[0] =:= Nil, 'an anonymous List Nil element is =:= Nil';
+
+# --- .head(n) iterates, so holes vivify to Any (unlike argless .head) ---
+my @e = 1, 2, 3;
+@e[1]:delete;
+is @e.head(3).raku, '(1, Any, 3).Seq', '.head(n) iteration keeps holes as Any';


### PR DESCRIPTION
## Summary

First step of the **Nil-vs-Any identity campaign** (PLAN 8.5), following the dependency order from the 2026-07-20 cascade map: decouple hole reads from the `Nil === Any` eqv crutch **before** touching storage sites.

- **New canonical hole predicate `ArrayData::hole_at(i)`** — a literal `Nil` slot (deleted) or a type-object slot (`Any`, or the element type of a typed array) not recorded in the embedded `initialized` set. Mirrors the `:exists`/`:k`/`:p` predicate.
- **`.List` on an Array materializes holes as literal `Nil`** (Rakudo semantics; `is default(...)` does NOT change `.List` — only `.Slip` substitutes the default). Typed-array holes also become `Nil`.
- **`.Slip` now uses `hole_at`** for its default substitution — a genuinely assigned `Any` element is no longer clobbered by the default — and surfaces literal-`Nil` slots as `Any` when there is no custom default.
- **Argless `.head` reads the backing store raw** (Rakudo's `Array.head` candidate): a hole at index 0 yields `Nil`, while iteration (`.head(n)`, `for`) still vivifies holes to `Any`.
- **`=:=` no longer short-circuits `Nil` through the fresh-container flag**: Nil is a singleton no container ever holds, so an index read yielding Nil IS Nil (`(Nil,1)[0] =:= Nil` is now True, matching raku).

`roast/S32-array/delete.t` subtest 33 now passes on real Nils instead of riding the eqv crutch.

## Verification

- Pin: `t/nil-list-holes.t` (16 assertions, verified against reference raku)
- Guardrails green: `nil.t` (MUTSU_FUDGE=1), `S32-array/delete.t`, `S32-hash/delete.t`, `S09-typed-arrays/arrays.t`
- Full `make test` (2311 files, 21805 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)