### PR TITLE
fix: bare when/default in a routine no longer leaks when_matched to an enclosing given/with

### DIFF
--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -194,6 +194,19 @@ impl Interpreter {
         // package). Restored after the env merge below.
         let saved_package = self.enter_routine_package(cf);
 
+        // A routine (sub/method) body is its own topicalizer for a bare
+        // `when`/`default`: a matching `when` sets the global `when_matched`
+        // flag (and returns via the succeed signal, caught by the
+        // `return_value.is_some()` arm below). That flag must not leak to the
+        // caller — otherwise a routine with a bare `when`, called from inside an
+        // enclosing `given`/`with` body, would leave `when_matched` true and the
+        // enclosing block would break early, skipping the rest of its statements
+        // (e.g. `given $x { $r = f(); say $r }` never runs the `say`). Reset it
+        // for the routine body and restore the caller's value on exit.
+        let saved_when_matched = self.when_matched();
+        if cf.code.is_routine {
+            self.set_when_matched(false);
+        }
         let mut ip = 0;
         let mut result = Ok(());
         let mut explicit_return: Option<Value> = None;
@@ -249,6 +262,12 @@ impl Interpreter {
             if self.is_halted() {
                 break;
             }
+        }
+
+        // Restore the caller's `when_matched` — a bare `when` inside this
+        // routine body must not leak its match state to an enclosing given/with.
+        if cf.code.is_routine {
+            self.set_when_matched(saved_when_matched);
         }
 
         // Natural fall-through completion (no explicit return / fail / error

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -409,6 +409,14 @@ impl Interpreter {
         // required-param early returns above). Restored after the env merge below.
         let saved_package = self.enter_routine_package(cf);
 
+        // A routine body is its own topicalizer for a bare `when`/`default`: a
+        // matching `when` sets the global `when_matched` flag, which must not
+        // leak to an enclosing `given`/`with` body (see vm_call_light.rs for the
+        // full rationale). Reset for the body; restore the caller's value below.
+        let saved_when_matched = self.when_matched();
+        if cf.code.is_routine {
+            self.set_when_matched(false);
+        }
         // Execute the function body
         let mut ip = 0;
         let mut result = Ok(());
@@ -456,6 +464,12 @@ impl Interpreter {
             if self.is_halted() {
                 break;
             }
+        }
+
+        // Restore the caller's `when_matched` — a bare `when` inside this
+        // routine body must not leak its match state to an enclosing given/with.
+        if cf.code.is_routine {
+            self.set_when_matched(saved_when_matched);
         }
 
         // Natural fall-through completion (no explicit return / fail / error

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -221,6 +221,14 @@ impl Interpreter {
         }
 
         let let_mark = self.let_saves_len();
+        // A routine body is its own topicalizer for a bare `when`/`default`: a
+        // matching `when` sets the global `when_matched` flag, which must not
+        // leak to an enclosing `given`/`with` body (see vm_call_light.rs for the
+        // full rationale). Reset for the body; restore the caller's value below.
+        let saved_when_matched = self.when_matched();
+        if cf.code.is_routine {
+            self.set_when_matched(false);
+        }
         // Body-internal env_dirty (from nested calls) concerns the callee env,
         // which the return merge reconciles; reset so the post-merge value
         // reflects only what was actually written back to the caller.
@@ -304,6 +312,12 @@ impl Interpreter {
             if self.is_halted() {
                 break;
             }
+        }
+
+        // Restore the caller's `when_matched` — a bare `when` inside this
+        // routine body must not leak its match state to an enclosing given/with.
+        if cf.code.is_routine {
+            self.set_when_matched(saved_when_matched);
         }
 
         // Natural fall-through completion (no explicit return / fail / error

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -548,6 +548,12 @@ impl Interpreter {
 
         // Execute bytecode
         let let_mark = self.let_saves_len();
+        // A method body is its own topicalizer for a bare `when`/`default`: a
+        // matching `when` sets the global `when_matched` flag, which must not
+        // leak to an enclosing `given`/`with` body (see vm_call_light.rs for the
+        // full rationale). Reset for the body; restore the caller's value below.
+        let saved_when_matched = self.when_matched();
+        self.set_when_matched(false);
         let mut ip = 0;
         let mut result = Ok(());
         let mut explicit_return: Option<Value> = None;
@@ -627,6 +633,10 @@ impl Interpreter {
                 break;
             }
         }
+
+        // Restore the caller's `when_matched` — a bare `when` inside this method
+        // body must not leak its match state to an enclosing given/with.
+        self.set_when_matched(saved_when_matched);
 
         let ret_val = if result.is_ok() {
             if self.stack.len() > saved_stack_depth {
@@ -1317,6 +1327,11 @@ impl Interpreter {
 
         // Execute bytecode (same as slow path)
         let let_mark = self.let_saves_len();
+        // A method body is its own topicalizer for a bare `when`/`default`; its
+        // `when_matched` must not leak to an enclosing given/with (see the slow
+        // path above / vm_call_light.rs for the full rationale).
+        let saved_when_matched = self.when_matched();
+        self.set_when_matched(false);
         let mut ip = 0;
         let mut result = Ok(());
         let mut explicit_return: Option<Value> = None;
@@ -1393,6 +1408,9 @@ impl Interpreter {
                 break;
             }
         }
+
+        // Restore the caller's `when_matched` — see the slow path above.
+        self.set_when_matched(saved_when_matched);
 
         let ret_val = if result.is_ok() {
             if self.stack.len() > saved_stack_depth {

--- a/t/when-in-routine-does-not-leak-to-given.t
+++ b/t/when-in-routine-does-not-leak-to-given.t
@@ -1,0 +1,111 @@
+use Test;
+
+# A bare `when`/`default` in a sub/method body topicalizes on the routine: a
+# matching `when` must return from the routine WITHOUT leaking its match state
+# to an enclosing `given`/`with`. Regression: the global `when_matched` flag set
+# inside the routine leaked out, so the enclosing given/with broke early and
+# skipped the rest of its statements (e.g. `given $x { $r = f(); say $r }` never
+# ran the say). Fixed by save/reset/restore of `when_matched` at the routine
+# call boundary. Discovered via vCard::Parser t/03-actions (its content-line
+# action calls `made-value`, a method with bare when/default, from inside a
+# `with $topic { ... }` block).
+
+plan 12;
+
+sub classify($_) {
+    when * > 10 { "big" }
+    default { "small" }
+}
+
+# Routine value is still correct at top level (no enclosing topicalizer).
+is classify(50), 'big',   'sub bare-when match value at top level';
+is classify(3),  'small', 'sub bare-when default value at top level';
+
+# Inside `given`, statements after the routine call must still run.
+my $out = '';
+given 'ctx' {
+    $out = classify(20);
+    $out ~= '-after';
+}
+is $out, 'big-after', 'sub bare-when in given does not skip the rest of the block';
+
+# Inside `with`, likewise.
+class C {
+    method kind($_) {
+        when Int { "int" }
+        default { "other" }
+    }
+}
+my $r = '';
+with 'topic' {
+    $r = C.new.kind(5);
+    $r ~= '!';
+}
+is $r, 'int!', 'method bare-when in with does not skip the rest of the block';
+
+# The topic assignment itself must complete (the earlier bug skipped it, so the
+# var kept its pre-call value).
+my $assigned = 'none';
+given 'topic' {
+    $assigned = classify(99);
+}
+is $assigned, 'big', 'assignment from a when-routine call inside given completes';
+
+# Multiple when-routine calls in one given: every effect is visible.
+sub tag($_) {
+    when * %% 2 { 'even' }
+    default { 'odd' }
+}
+my @res;
+given 'x' {
+    @res.push(tag(4));
+    @res.push(tag(7));
+    @res.push('end');
+}
+is @res.join(','), 'even,odd,end', 'multiple when-routines in one given all run';
+
+# A `given` nested INSIDE a routine still works (the routine reset must not
+# disturb the routine's own inner given).
+sub describe($x) {
+    my $s = 'none';
+    given $x {
+        when 1 { $s = 'one' }
+        when 2 { $s = 'two' }
+        default { $s = 'many' }
+    }
+    return $s;
+}
+is describe(1), 'one',  'given inside routine: first when';
+is describe(2), 'two',  'given inside routine: second when';
+is describe(9), 'many', 'given inside routine: default';
+
+# `for` is also a topicalizer that inspects when_matched between iterations —
+# a when-routine call in the loop body must not truncate the loop.
+sub score($_) {
+    when * >= 5 { 'hi' }
+    default { 'lo' }
+}
+my @scores;
+for 3, 7, 1 {
+    @scores.push(score($_));
+}
+is @scores.join(','), 'lo,hi,lo', 'when-routine call inside for loop does not truncate iteration';
+
+# Directly returning the caller's when state: an outer given whose own when
+# matched, then calls a when-routine, must keep behaving correctly afterwards.
+my $trace = '';
+given 5 {
+    when * > 0 {
+        $trace ~= 'outer-';
+        $trace ~= classify(1);   # inner routine: 'small'
+        $trace ~= '-end';
+    }
+}
+is $trace, 'outer-small-end', 'inner when-routine does not abort the outer when block';
+
+# Nested routine calls: a when-routine that itself calls another when-routine.
+sub outer($_) {
+    when * > 0 { 'pos:' ~ classify($_ * 100) }
+    default { 'nonpos' }
+}
+is outer(1), 'pos:big', 'nested when-routine calls compose correctly';


### PR DESCRIPTION
## Problem

A bare `when`/`default` in a sub or method body topicalizes on the routine itself. When such a routine was called from **inside** an enclosing `given`/`with`/`for` body, the matching `when` set the global `when_matched` flag and that flag **leaked past the routine's call boundary**.

The enclosing block's body loop checks `when_matched` after every opcode (to decide when to stop), so it broke early — skipping every statement after the call:

```raku
sub classify($_) {
    when * > 10 { "big" }
    default { "small" }
}
my $out = '';
given 'ctx' {
    $out = classify(20);   # returns "big", but sets when_matched=true
    $out ~= '-after';      # SKIPPED — given broke after the call
}
say $out;                  # was '' (SetLocal also skipped); now 'big-after'
```

The routine value itself was always correct (the `when`'s succeed signal is caught by the `return_value.is_some()` arm and returned normally); only the stray global flag leaked. `given`/`for`/`try` already save/reset/restore `when_matched` at their boundaries — routine calls did not.

## Fix

Save/reset/restore `when_matched` around the routine body in all five routine-body execution loops:
- `vm/vm_call_light.rs`
- `vm/vm_call_light_typed.rs`
- `vm/vm_call_named_inner.rs`
- `vm/vm_method_dispatch.rs` (`call_compiled_method` slow + `call_compiled_method_fast`)

Gated on `is_routine` so non-routine closures (bare/pointy blocks) still propagate their `when` to the lexically enclosing given/routine (correct Raku semantics).

## Discovery

Found via `vCard::Parser` `t/03-actions`, whose content-line grammar action calls `made-value` (a method with bare when/default) from inside a `with $topic { ... }` block. The fix takes that test from 4 to 7 passing.

## Tests

- New pin: `t/when-in-routine-does-not-leak-to-given.t` (12 assertions, all matching raku)
- Full `t/` suite: 2315 files / 21840 tests PASS
- `given.t` / `when.t` / `for.t` roast: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)