### PR TITLE
feat: user does Iterable/Iterator drives for-loop and array-assign

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -173,6 +173,14 @@ pub(crate) struct Compiler {
     bind_target_direct: bool,
     /// Variables declared as `constant` (no Scalar container).
     constant_vars: std::collections::HashSet<String>,
+    /// Scalar variables `:=`-bound to a non-itemized value (no Scalar
+    /// container), so `for $x` iterates the bound value's elements rather than
+    /// treating `$x` as a single item. Populated when the bind RHS produces a
+    /// non-itemized value (a list/constructor/method-call/container-var, or
+    /// another already-non-itemized bound scalar). A bind to a plain itemized
+    /// scalar (`my $x := $itemized`) inherits the item container and is NOT
+    /// recorded. See `normalize_for_iterable`.
+    noncontainer_bound_vars: std::collections::HashSet<String>,
     /// Subset of `constant_vars` whose declaring lexical block is still open.
     /// Constants are `our`-scoped (installed in the package), so once their
     /// declaring block has exited, their stale local slot must not be reused —
@@ -305,6 +313,7 @@ impl Compiler {
             bind_terminal: false,
             bind_target_direct: false,
             constant_vars: std::collections::HashSet::new(),
+            noncontainer_bound_vars: std::collections::HashSet::new(),
             constant_vars_in_scope: std::collections::HashSet::new(),
             constant_vars_current_scope: std::collections::HashSet::new(),
             my_vars_current_scope: std::collections::HashSet::new(),
@@ -1342,14 +1351,22 @@ impl Compiler {
     fn normalize_for_iterable(&self, iterable: &Expr) -> Expr {
         match iterable {
             // Scalar variables are item containers in `for` and should not be flattened.
-            // Exception: `constant $x` binds without a Scalar container, so `for $x`
-            // should iterate the elements (like sigilless variables).
-            Expr::Var(name) if !self.constant_vars.contains(name) => {
+            // Exception: `constant $x` and a `:=`-bound-to-non-itemized `$x` bind
+            // without a Scalar container, so `for $x` iterates the elements (like
+            // sigilless variables).
+            Expr::Var(name)
+                if !self.constant_vars.contains(name)
+                    && !self.noncontainer_bound_vars.contains(name) =>
+            {
                 Expr::ArrayLiteral(vec![iterable.clone()])
             }
             // A parenthesized single scalar (`for ($x)`) reaches here as
             // `Grouped(Var)`; iterate it once, exactly like the bare `for $x`.
-            Expr::Grouped(inner) if matches!(inner.as_ref(), Expr::Var(name) if !self.constant_vars.contains(name)) => {
+            Expr::Grouped(inner)
+                if matches!(inner.as_ref(), Expr::Var(name)
+                    if !self.constant_vars.contains(name)
+                        && !self.noncontainer_bound_vars.contains(name)) =>
+            {
                 Expr::ArrayLiteral(vec![(**inner).clone()])
             }
             _ => iterable.clone(),

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1217,6 +1217,25 @@ impl Compiler {
                     if !self.code.scalar_bind_locals.contains(&sym) {
                         self.code.scalar_bind_locals.push(sym);
                     }
+                    // A `:=` bind installs the RHS without a Scalar container, so
+                    // `for $x` iterates the bound value's elements. The one
+                    // exception is a bind to a plain itemized scalar
+                    // (`my $x := $itemized`), which inherits the item container;
+                    // a bind to another already-non-itemized bound scalar stays
+                    // non-itemized. Classify the RHS to distinguish these.
+                    let rhs_is_itemized_scalar = match expr {
+                        Expr::Var(rhs) => !self.noncontainer_bound_vars.contains(rhs),
+                        Expr::Grouped(inner) => match inner.as_ref() {
+                            Expr::Var(rhs) => !self.noncontainer_bound_vars.contains(rhs),
+                            _ => false,
+                        },
+                        _ => false,
+                    };
+                    if !rhs_is_itemized_scalar {
+                        self.noncontainer_bound_vars.insert(name.clone());
+                    } else {
+                        self.noncontainer_bound_vars.remove(name);
+                    }
                 }
                 if *is_state {
                     if let Some((guard_idx, key, key_idx)) = state_guard_idx {

--- a/src/vm/vm_for_loop_dispatch.rs
+++ b/src/vm/vm_for_loop_dispatch.rs
@@ -383,7 +383,7 @@ impl Interpreter {
     /// `None` for any other value so the caller falls through to `value_to_list`.
     /// An `is Array` subclass (backed by `__mutsu_array_storage`) is left to that
     /// path — its elements are the storage, not a user iterator.
-    fn try_iterable_instance_items(
+    pub(crate) fn try_iterable_instance_items(
         &mut self,
         iterable: &Value,
     ) -> Result<Option<Vec<Value>>, RuntimeError> {

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -882,6 +882,12 @@ impl Interpreter {
                 }
             } else if is_bind {
                 self.bind_positional_value(name, &raw_popped)?
+            } else if let Some(items) = self.try_iterable_instance_items(&raw_popped)? {
+                // A user class that `does Iterable` with its own `iterator`
+                // method populates the array via that iterator (raku:
+                // `my @a = $iterable` reifies `.iterator` into the array),
+                // rather than storing the object as a single element.
+                runtime::coerce_to_array(Value::real_array(items))
             } else {
                 match raw_popped.view() {
                     ValueView::LazyList(list) => {

--- a/t/iterable-iterator-protocol.t
+++ b/t/iterable-iterator-protocol.t
@@ -1,0 +1,99 @@
+use v6;
+use Test;
+
+plan 11;
+
+# A user class that `does Iterable` supplies its own `iterator`; `for` calls it
+# and iterates the produced elements (Iterable.rakudoc / iterating.rakudoc).
+{
+    class DNA does Iterable {
+        has $.chain;
+        method iterator(DNA:D:) { $!chain.comb.rotor(3).iterator }
+    }
+    my $a := DNA.new(chain => 'GAATCC');
+    my @got;
+    @got.push($_.join) for $a;
+    is @got.join('|'), 'GAA|TCC', 'for calls .iterator on a := bound Iterable';
+
+    # Bare-expression source iterates the same way.
+    my @bare;
+    @bare.push($_.join) for DNA.new(chain => 'ACGTTT');
+    is @bare.join('|'), 'ACG|TTT', 'for iterates a bare Iterable expression';
+
+    # Array-assignment context reifies the iterator into the array.
+    my @chain = DNA.new(chain => 'ACGTACGTT');
+    is @chain.map(*.join).join('|'), 'ACG|TAC|GTT', 'my @a = Iterable reifies .iterator';
+    is @chain.elems, 3, 'array-assigned Iterable has the iterated element count';
+}
+
+# A class that `does Iterable does Iterator` returning self and driving pull-one.
+{
+    class Count does Iterable does Iterator {
+        has $.n;
+        has Int $!i = 0;
+        method iterator { self }
+        method pull-one(--> Mu) {
+            if $!i < $.n {
+                $!i++;
+                return $!i;
+            }
+            IterationEnd;
+        }
+    }
+    my $c := Count.new(n => 4);
+    my @got;
+    @got.push($_) for $c;
+    is @got.join(','), '1,2,3,4', 'does Iterator: pull-one drives for until IterationEnd';
+
+    my @arr = Count.new(n => 3);
+    is @arr.join(','), '1,2,3', 'does Iterator: array-assign reifies pull-one';
+}
+
+# A separate Iterator object (iterator does NOT return self) with mutable state.
+{
+    class Down does Iterable {
+        has $.from;
+        method iterator {
+            class It does Iterator {
+                has $.cur is rw;
+                method pull-one {
+                    return IterationEnd if $.cur < 1;
+                    my $v = $.cur;
+                    $.cur = $.cur - 1;
+                    $v;
+                }
+            }.new(cur => $.from);
+        }
+    }
+    my $d := Down.new(from => 3);
+    my @got;
+    @got.push($_) for $d;
+    is @got.join(','), '3,2,1', 'separate stateful Iterator object works in for';
+}
+
+# Itemization: `:=` bind iterates, `=` assign keeps a single item.
+{
+    my $bound := (1, 2, 3);
+    my @a;
+    @a.push($_) for $bound;
+    is @a.join(','), '1,2,3', ':= bound list iterates its elements in for';
+
+    my $assigned = (1, 2, 3);
+    my @b;
+    @b.push($_.gist) for $assigned;
+    is @b.elems, 1, '= assigned list is a single item in for';
+
+    # Bind to an already-itemized scalar inherits the item container.
+    my $it = (4, 5, 6);
+    my $rebound := $it;
+    my @c;
+    @c.push($_) for $rebound;
+    is @c.elems, 1, ':= bind to an itemized scalar stays a single item';
+
+    # Bind to an already-non-itemized bound scalar stays non-itemized.
+    my $nc := (7, 8, 9);
+    my $rebound2 := $nc;
+    my @d;
+    @d.push($_) for $rebound2;
+    is @d.join(','), '7,8,9', ':= bind to a non-itemized bound scalar iterates';
+}


### PR DESCRIPTION
## Summary

Makes a user class that `does Iterable` (and optionally `does Iterator`) actually iterate through its own `.iterator` / `pull-one`, matching the `Iterable.rakudoc` and `iterating.rakudoc` examples. Previously mutsu iterated such an object once *as itself*.

### Root cause

A `:=`-bound scalar (and a bare expression) is **not** in a Scalar container, so `for $x` must iterate the value's elements. mutsu unconditionally wrapped every `$`-var for-source in a 1-element list (`normalize_for_iterable`), so the custom `.iterator` was never reached. This was a general itemization bug — `my $b := (1,2,3); .say for $b` also wrongly printed `(1 2 3)` instead of `1␤2␤3`.

### Fix

- Track `:=` binds to non-itemized values in a new `noncontainer_bound_vars` compiler set (mirrors `constant_vars`), classifying the RHS: a bind to a plain itemized scalar (`my $x := $itemized`) inherits the item container and is **not** recorded; a bind to a constructor / method-call / list / container-var, or to another already-non-itemized bound scalar, is.
- Exempt those vars from wrapping in `normalize_for_iterable`, so the Iterable instance reaches `try_iterable_instance_items`, which calls `.iterator` and drives `pull-one` until `IterationEnd`.
- Array assignment (`my @a = $iterable`) reuses the same helper before `coerce_to_array`, reifying the iterator into the array.

### Verified

- Both doc examples (verbatim, including `where`-constrained `new`) pass.
- A separate stateful Iterator object (whose `iterator` does not return `self`) works.
- Itemization edge cases match raku exactly: `:=` iterates, `=` stays a single item, and bind-of-bind inherits correctly.
- New `t/iterable-iterator-protocol.t` (11 tests) — identical output under `raku` and `mutsu`.
- `make test` green (21852 tests); targeted roast `S04-statements/for.t`, `S03-binding/{arrays,scalars}.t`, `S07-iterators/range-iterator.t` all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)