### PR TITLE
fix: store Any (not Nil) at every crutch-masked storage site (PLAN 8.5 step 2)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1196,18 +1196,32 @@ the backlog.
       `roast/S02-types/nil.t` — 67 tests, whitelisted, the authoritative spec; **always run it with
       `MUTSU_FUDGE=1`** or its `#?rakudo todo` tests false-fail) are recorded in the memory note
       `project-nil-any-identity-knot`. Read it before any re-attempt; do **not** re-attempt as a small slice.
-- **Campaign step 1 landed 2026-07-23** (branch `nil-any-campaign`): `.List` materializes array
-      holes as literal `Nil` (via the new canonical `ArrayData::hole_at` predicate; `is default` does
-      not change `.List` — only `.Slip`), argless `.head` reads the store raw (hole → `Nil`), and
-      `Nil` was dropped from the `=:=` fresh-container short-circuit so a List element holding
-      literal `Nil` satisfies `=:= Nil`. This decouples `roast/S32-array/delete.t` subtest 33 from
-      the eqv crutch (it now passes on real Nils). Pin: `t/nil-list-holes.t` (16 assertions,
-      raku-verified). Remaining steps: 2 (store `Any` at every "stored Nil should be Any" site),
-      3 (uninit `my $x` = Any — the compiler/closure-cell knot), 4 (remove the eqv crutch LAST),
-      5 (`(my $x = Nil)` yields the container value Any).
-- **Cost/benefit: LOW-value, HIGH-cost** (for the remaining steps 2-5). The doc-diff payoff is only
-      niche uninitialized-value rendering. Related: §6 (dual-store / lexical slot),
-      [`array-hole-tracking-embedded`], [ADR-0001] container-repr.
+- **Campaign step 1 landed 2026-07-23** (#5256): `.List` materializes array holes as literal
+      `Nil` (via the new canonical `ArrayData::hole_at` predicate; `is default` does not change
+      `.List` — only `.Slip`), argless `.head` reads the store raw (hole → `Nil`), and `=:=`
+      treats only a compile-time *literal* `Nil` operand as the Nil singleton (two reads that both
+      yield Nil stay non-identical — S03-operators/identity.t 34/37). This decouples
+      `roast/S32-array/delete.t` subtest 33 from the eqv crutch. Pin: `t/nil-list-holes.t`.
+- **Campaign step 2 landed 2026-07-23** (branch `nil-any-step2`) — every "stored Nil should be
+      Any" site found by disabling the eqv crutch locally and sweeping the full `t/` suite:
+      explicit `my $x = Nil` resets to Any (statement and expression position; the synthesized
+      no-init default keeps Nil — still load-bearing), `$_` unset-topic reads as Any (an explicitly
+      Nil-topicalized `$_` stays Nil), `$/`/`$!` `.VAR.default` report Nil, absent-key/index
+      `:delete` returns the hole type object (Any / element type) on all paths, and an unset
+      untyped scalar attribute seeds the Any type object in both constructors (post-BUILD required
+      checks treat that seed as unset). Four local tests that encoded the wrong (crutch-masked)
+      semantics were corrected against reference raku: `t/array-slice-oob.t` (Array OOB slices pad
+      Any; List/Seq pad Nil), `t/multidim-indexing.t` 6 (shaped OOB delete throws — the old
+      expectation fails under real raku), `t/vm-basic.t` 188 (`try`'s Nil resets the container to
+      Any). **Key data point: the full `t/` suite (2312 files) passes with the crutch disabled.**
+- **Remaining steps:** 3 (uninit `my $x` = Any — the compiler/closure-cell knot; the ONLY
+      remaining crutch dependency is the uninit-scalar read: `my $x; $x === Any` must stay True,
+      so the crutch cannot be removed before step 3), 4 (remove the eqv crutch LAST; also lets
+      `Nil.^name`/`Nil === Any` divergences close), then re-check `.cache` on a holey Array
+      (returns a List today, raku returns the Array itself — noticed during step 1, unrelated).
+- **Cost/benefit** (for the remaining steps 3-4): step 3 is the proven-hard compiler knot; the
+      payoff is uninit-value rendering + dropping the crutch. Related: §6 (dual-store / lexical
+      slot), [`array-hole-tracking-embedded`], [ADR-0001] container-repr.
 
 ### 8.6 `.WHO`/`.HOW` render without their metamodel detail — mostly done; internals leftover
 

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -275,6 +275,30 @@ impl Compiler {
                                 });
                                 self.emit_set_named_var(name);
                                 self.emit_get_named_var(name);
+                            } else if type_constraint.is_none()
+                                && is_nil_literal
+                                && custom_traits.iter().any(|(t, _)| t == "__has_initializer")
+                                && !custom_traits
+                                    .iter()
+                                    .any(|(t, _)| t == "__scalar_bind" || t == "default")
+                                && !name.starts_with('@')
+                                && !name.starts_with('%')
+                                && !name.starts_with('&')
+                                && name != "__ANON_STATE__"
+                            {
+                                // Untyped `(my $x = Nil)` with an EXPLICIT Nil
+                                // initializer: assignment of Nil resets a fresh
+                                // untyped scalar to Any (S02-types/nil.t 21) —
+                                // store and yield Any directly (the plain
+                                // SetLocal emitted here has no vardecl reset
+                                // path). Uninitialized `(my $x)` keeps its
+                                // synthesized-Nil path, `:=` binds keep Nil, and
+                                // an `is default(...)` decl is re-read after the
+                                // trait applies (below).
+                                self.code.emit(OpCode::Pop);
+                                self.compile_expr(&Expr::BareWord("Any".to_string()));
+                                self.code.emit(OpCode::Dup);
+                                self.emit_set_named_var(name);
                             } else {
                                 // Enforce a scalar type constraint in expression
                                 // position too (e.g. a bare `my Str $x := 3` whose

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1259,7 +1259,15 @@ impl Compiler {
                     if is_constant || self.sigilless_locals.contains(name.as_str()) {
                         self.code.emit(OpCode::MarkConstantContext);
                     }
-                    if has_explicit_initializer {
+                    // A default-trait decl suppresses the explicit-initializer
+                    // mark: its `is default(...)` is applied AFTER the store, so
+                    // SetLocal's untyped-Nil-to-Any reset would fire before the
+                    // default is registered and clobber a runtime-Nil value
+                    // (`my $foo is default(Nil) = do without ... { $_ }` must
+                    // keep Nil — S04-statements/with.t 49/56). The store keeps
+                    // Nil verbatim and the ApplyVarTrait that follows replaces a
+                    // still-Nil scalar with its default.
+                    if has_explicit_initializer && !has_default_trait {
                         self.code.emit(OpCode::MarkExplicitInitializerContext);
                     }
                     // Mark this SetLocal as coming from a VarDecl so the VM

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -174,6 +174,10 @@ fn statement(input: &str) -> PResult<'_, Stmt> {
     }
     if (input.starts_with("qx") || input.starts_with("qqx"))
         && let Ok((rest, expr)) = crate::parser::primary::string::qx_string(input)
+        // A postfix chain on the qx result (`qx`pwd`.chomp.IO`) must parse as
+        // one expression statement — without this guard the shortcut consumed
+        // only the qx call and `.chomp` became a separate $_-method statement.
+        && !rest.starts_with('.')
     {
         let result = parse_statement_modifier(rest, Stmt::Expr(expr));
         STMT_MEMO.store(input, &result);

--- a/src/parser/stmt/simple_expr_stmt/core.rs
+++ b/src/parser/stmt/simple_expr_stmt/core.rs
@@ -109,7 +109,12 @@ pub(crate) fn expr_stmt(input: &str) -> PResult<'_, Stmt> {
         return parse_statement_modifier(rest, stmt);
     }
 
-    if let Ok((rest, expr)) = crate::parser::primary::string::qx_string(input) {
+    if let Ok((rest, expr)) = crate::parser::primary::string::qx_string(input)
+        // A postfix chain on the qx result (`qx`pwd`.chomp.IO`) must parse as
+        // one expression — without this guard the shortcut consumed only the
+        // qx call and `.chomp` became a separate $_-method statement.
+        && !rest.starts_with('.')
+    {
         return parse_statement_modifier(rest, Stmt::Expr(expr));
     }
 

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -326,6 +326,9 @@ impl Interpreter {
                 // Native types have zero/empty defaults instead of Nil.
                 // The plan's type_constraints carry the same MRO-wide map
                 // `get_attr_type_constraint` would walk per attribute.
+                // A non-native attribute with no default seeds its nominal
+                // type object (`has $!z` reads as Any, `has Int $!x` as Int),
+                // matching raku — not Nil.
                 match plan.type_constraints.get(attr_name).map(String::as_str) {
                     Some(
                         "int" | "int8" | "int16" | "int32" | "int64" | "uint" | "uint8" | "uint16"
@@ -333,7 +336,11 @@ impl Interpreter {
                     ) => Value::int(0),
                     Some("num" | "num32" | "num64") => Value::num(0.0),
                     Some("str") => Value::str("".to_string()),
-                    _ => Value::NIL,
+                    Some(tc) => {
+                        let nominal = self.nominal_type_object_name_for_constraint(tc);
+                        Value::package(crate::symbol::Symbol::intern(&nominal))
+                    }
+                    None => Value::package(crate::symbol::Symbol::intern("Any")),
                 }
             };
             attributes.insert(attr_sym, val);
@@ -881,8 +888,9 @@ impl Interpreter {
 
     /// Build the attribute map for a freshly `CREATE`d instance: every declared
     /// attribute keyed by its bare name with a type-default empty value (native
-    /// numerics → 0, `str` → "", everything else → `Nil`). Unlike `bless`, this
-    /// does not evaluate `has $.x = EXPR` default expressions.
+    /// numerics → 0, `str` → "", everything else → its nominal type object —
+    /// `Any` when untyped). Unlike `bless`, this does not evaluate
+    /// `has $.x = EXPR` default expressions.
     fn create_default_attr_slots(&mut self, class_name: &str) -> AttrMap {
         let mut attributes = AttrMap::new();
         if self.registry().classes.contains_key(class_name) {
@@ -897,7 +905,11 @@ impl Interpreter {
                     ) => Value::int(0),
                     Some("num" | "num32" | "num64") => Value::num(0.0),
                     Some("str") => Value::str("".to_string()),
-                    _ => Value::NIL,
+                    Some(tc) => {
+                        let nominal = self.nominal_type_object_name_for_constraint(tc);
+                        Value::package(crate::symbol::Symbol::intern(&nominal))
+                    }
+                    None => Value::package(crate::symbol::Symbol::intern("Any")),
                 };
                 attributes.insert(attr_name, val);
             }

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -231,6 +231,10 @@ impl Interpreter {
                 def.clone()
             } else if let Some(tc) = self.var_type_constraint(target_var) {
                 Value::package(Symbol::intern(&tc))
+            } else if matches!(target_var, "$/" | "$!" | "/" | "!") {
+                // The match/error special vars default to Nil, not Any
+                // (S02-types/nil.t: `$/.VAR.default === Nil`).
+                Value::NIL
             } else {
                 Value::package(Symbol::intern("Any"))
             };

--- a/src/runtime/methods_object_default_ctor.rs
+++ b/src/runtime/methods_object_default_ctor.rs
@@ -263,15 +263,17 @@ impl Interpreter {
                 None => {
                     // Uninitialized: `@` -> empty Array, `%` -> empty Hash. For
                     // `$`: a native-typed scalar gets its native zero (`int` -> 0,
-                    // `num` -> 0e0, `str` -> ""); an untyped `$` gets Nil. A
-                    // class-typed `$` cannot reach here — it fell through above.
+                    // `num` -> 0e0, `str` -> ""); an untyped `$` gets the Any
+                    // type object (`has $!z` reads as Any, matching raku — NOT
+                    // Nil). A typed `$` keeps Nil: the accessor synthesizes the
+                    // declared type object from the stored Nil at read time.
                     let empty = match sigil {
                         '@' => Value::real_array(Vec::new()),
                         '%' => Value::hash(HashMap::new()),
-                        _ => type_constraints
-                            .get(attr_name)
-                            .and_then(|c| Self::native_scalar_default(c))
-                            .unwrap_or(Value::NIL),
+                        _ => match type_constraints.get(attr_name) {
+                            Some(c) => Self::native_scalar_default(c).unwrap_or(Value::NIL),
+                            None => Value::package(crate::symbol::Symbol::intern("Any")),
+                        },
                     };
                     attrs.insert(attr_sym, empty);
                 }
@@ -423,9 +425,14 @@ impl Interpreter {
             // `X::Attribute::Required` with the same message and reason.
             for (attr_name, _, _, _, is_required, _, _) in class_attrs.iter() {
                 if let Some(reason) = is_required {
+                    // The pre-BUILD seed for an unset untyped attribute is
+                    // the Any type object (not Nil), so treat it as unset too.
                     let is_set = !matches!(
                         attrs.get(attr_name).map(Value::view),
                         Some(ValueView::Nil) | None
+                    ) && !matches!(
+                        attrs.get(attr_name).map(Value::view),
+                        Some(ValueView::Package(n)) if n == "Any"
                     );
                     if !is_set {
                         let attr_full_name = format!("$!{}", attr_name);

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -1839,7 +1839,27 @@ impl Interpreter {
                                     }
                                 }
                             }
-                            _ => Value::NIL,
+                            _ => {
+                                // A scalar attribute with no default seeds its
+                                // nominal type object (`has $!z` reads as Any,
+                                // `has Int $!x` as Int) — not Nil — matching
+                                // raku. Native types keep zero/empty defaults.
+                                match attr_type_constraints.get(&attr_name).map(String::as_str) {
+                                    Some(
+                                        "int" | "int8" | "int16" | "int32" | "int64" | "uint"
+                                        | "uint8" | "uint16" | "uint32" | "uint64" | "byte"
+                                        | "atomicint",
+                                    ) => Value::int(0),
+                                    Some("num" | "num32" | "num64") => Value::num(0.0),
+                                    Some("str") => Value::str("".to_string()),
+                                    Some(tc) => {
+                                        let nominal =
+                                            self.nominal_type_object_name_for_constraint(tc);
+                                        Value::package(crate::symbol::Symbol::intern(&nominal))
+                                    }
+                                    None => Value::package(crate::symbol::Symbol::intern("Any")),
+                                }
+                            }
                         }
                     };
                     // A coercion-typed attribute (`has Int() $.x = "42"`) coerces
@@ -1920,8 +1940,14 @@ impl Interpreter {
                     {
                         if let Some(reason) = is_required {
                             let attr_val = attrs.get(attr_name.as_str());
+                            // The pre-BUILD seed for an unset untyped
+                            // attribute is the Any type object, not Nil.
                             let is_set =
-                                !matches!(attr_val.map(Value::view), Some(ValueView::Nil) | None);
+                                !matches!(attr_val.map(Value::view), Some(ValueView::Nil) | None)
+                                    && !matches!(
+                                        attr_val.map(Value::view),
+                                        Some(ValueView::Package(n)) if n == "Any"
+                                    );
                             if !is_set {
                                 let attr_full_name = format!("$!{}", attr_name);
                                 return Err(RuntimeError::attribute_required(

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -496,6 +496,13 @@ impl Interpreter {
                                     &name[1..]
                                 )))
                             }
+                        } else if name == "_" {
+                            // An UNSET topic (no `$_` entry in any scope) reads
+                            // as Any, not Nil (`$_ === Any` at the top level,
+                            // S02-types/nil.t 39). Only the not-found fallback:
+                            // a topic explicitly set to Nil (e.g. `Xorelse`
+                            // topicalizing a Nil operand) must stay Nil.
+                            Ok(Value::package(Symbol::intern("Any")))
                         } else {
                             Ok(Value::NIL)
                         }

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1139,11 +1139,14 @@ impl Interpreter {
             }
             // Wrap native integer values on assignment (overflow wrapping)
             val = Self::wrap_native_int_by_constraint(&constraint, val)?;
-        } else if !is_bind && !is_vardecl {
-            // Untyped scalar: *reassigning* Nil resets it to the default type
-            // object Any (`$x = Nil` leaves `$x =:= Any`). Declarations keep their
-            // existing Nil path. The reset guard is a no-op for `@`/`%` containers
-            // and internal temps.
+        } else if !is_bind && (!is_vardecl || has_explicit_initializer) {
+            // Untyped scalar: assigning Nil resets it to the default type
+            // object Any (`$x = Nil` / `my $x = Nil` leave `$x === Any`,
+            // S02-types/nil.t 21). Only a declaration WITHOUT an explicit
+            // initializer keeps the synthesized-Nil path — that default is
+            // load-bearing across the compiler's shadow-slot/closure-cell
+            // machinery (PLAN 8.5 step 3). The reset guard is a no-op for
+            // `@`/`%` containers and internal temps.
             val = self.reset_nil_untyped_scalar(name, val);
         }
         // Only enforce sigilless-readonly when this is NOT a new variable

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -143,7 +143,11 @@ impl Interpreter {
                         v.with_hash_mut(|hash| crate::value::gc_data_mut(hash).remove(&key))
                     })
                     .flatten();
-                let removed = removed.or(container_default).unwrap_or(Value::NIL);
+                // An absent key deletes to Any (typed hashes never take this
+                // fast path, so the hole type is always Any here).
+                let removed = removed
+                    .or(container_default)
+                    .unwrap_or_else(|| Value::package(crate::symbol::Symbol::intern("Any")));
                 if let Some(slot) = local_slot
                     && let Some(env_val) = self.env().get(var_name).cloned()
                 {
@@ -613,7 +617,9 @@ impl Interpreter {
                 for i in indices {
                     let r =
                         Self::delete_array_multidim(container, std::slice::from_ref(&i), hole_type)
-                            .unwrap_or(Value::NIL);
+                            .unwrap_or_else(|_| {
+                                Value::package(crate::symbol::Symbol::intern(hole_type))
+                            });
                     results.push(r);
                 }
                 Ok(Value::array(results))
@@ -624,7 +630,9 @@ impl Interpreter {
                 for i in indices_vec {
                     let r =
                         Self::delete_array_multidim(container, std::slice::from_ref(&i), hole_type)
-                            .unwrap_or(Value::NIL);
+                            .unwrap_or_else(|_| {
+                                Value::package(crate::symbol::Symbol::intern(hole_type))
+                            });
                     results.push(r);
                 }
                 Ok(Value::array(results))
@@ -639,7 +647,9 @@ impl Interpreter {
                 for i in expanded {
                     let r =
                         Self::delete_array_multidim(container, std::slice::from_ref(&i), hole_type)
-                            .unwrap_or(Value::NIL);
+                            .unwrap_or_else(|_| {
+                                Value::package(crate::symbol::Symbol::intern(hole_type))
+                            });
                     results.push(r);
                 }
                 Ok(Value::array(results))
@@ -653,9 +663,13 @@ impl Interpreter {
     }
 
     fn delete_from_missing_container(idx: Value) -> Value {
+        // Deleting from a container that was never vivified: every addressed
+        // slot is absent, so each deletes to the Any hole (matching raku's
+        // `my %j; (%j<x>:delete).raku` → `Any`), not Nil.
+        let missing = Value::package(crate::symbol::Symbol::intern("Any"));
         match idx.view() {
-            ValueView::Array(keys, ..) => Value::array(vec![Value::NIL; keys.len()]),
-            _ => Value::NIL,
+            ValueView::Array(keys, ..) => Value::array(vec![missing; keys.len()]),
+            _ => missing,
         }
     }
 
@@ -683,22 +697,29 @@ impl Interpreter {
                 let h = crate::value::gc_data_mut(hash);
                 let removed = keys
                     .iter()
-                    .map(|key| h.remove(&key.to_string_value()).unwrap_or(Value::NIL))
+                    .map(|key| {
+                        // An absent key deletes to the hole type object
+                        // (`Any`, or the value type of a typed hash), not Nil.
+                        h.remove(&key.to_string_value()).unwrap_or_else(|| {
+                            Value::package(crate::symbol::Symbol::intern(hole_type))
+                        })
+                    })
                     .collect();
                 Value::array(removed)
             }
             _ => crate::value::gc_data_mut(hash)
                 .remove(&idx.to_string_value())
-                .unwrap_or(Value::NIL),
+                .unwrap_or_else(|| Value::package(crate::symbol::Symbol::intern(hole_type))),
         }) {
             return Ok(removed);
         }
         if let ValueView::Package(type_name) = container.view()
             && (type_name == "Hash" || type_name == "Hash:U")
         {
+            let missing = Value::package(crate::symbol::Symbol::intern(hole_type));
             return Ok(match idx.view() {
-                ValueView::Array(keys, ..) => Value::array(vec![Value::NIL; keys.len()]),
-                _ => Value::NIL,
+                ValueView::Array(keys, ..) => Value::array(vec![missing; keys.len()]),
+                _ => missing,
             });
         }
         if matches!(container.view(), ValueView::Array(..)) {

--- a/t/array-slice-oob.t
+++ b/t/array-slice-oob.t
@@ -1,22 +1,24 @@
 use Test;
-plan 13;
+plan 14;
 
-# Array slicing beyond bounds should pad with Nil
+# An out-of-bounds ARRAY slice pads with Any (the vivifiable-container
+# default raku reports), while a List/Seq slice pads with Nil
+# (List.AT-POS returns Nil beyond the end). Verified against raku.
 {
     my @a = 1, 2, 3;
-    is-deeply @a[^5], (1, 2, 3, Nil, Nil),
-        'exclusive range slice pads with Nil';
-    is-deeply @a[0..6], (1, 2, 3, Nil, Nil, Nil, Nil),
-        'inclusive range slice pads with Nil';
+    is-deeply @a[^5], (1, 2, 3, Any, Any),
+        'exclusive range slice pads with Any';
+    is-deeply @a[0..6], (1, 2, 3, Any, Any, Any, Any),
+        'inclusive range slice pads with Any';
 }
 
 # Empty array slicing
 {
     my @a;
-    is-deeply @a[^3], (Nil, Nil, Nil),
-        'exclusive range slice on empty array pads with Nil';
-    is-deeply @a[0..2], (Nil, Nil, Nil),
-        'inclusive range slice on empty array pads with Nil';
+    is-deeply @a[^3], (Any, Any, Any),
+        'exclusive range slice on empty array pads with Any';
+    is-deeply @a[0..2], (Any, Any, Any),
+        'inclusive range slice on empty array pads with Any';
 }
 
 # Lazy slicing should clip at array boundary
@@ -29,8 +31,14 @@ plan 13;
 # Slicing with individual array indices
 {
     my @a = 1, 2, 3;
-    is-deeply @a[0, 1, 2, 3, 4], (1, 2, 3, Nil, Nil),
-        'array index slice pads with Nil';
+    is-deeply @a[0, 1, 2, 3, 4], (1, 2, 3, Any, Any),
+        'array index slice pads with Any';
+}
+
+# A LIST slice beyond the end pads with Nil, not Any
+{
+    is-deeply (1, 2, 3)[^5], (1, 2, 3, Nil, Nil),
+        'list slice pads with Nil';
 }
 
 # Open-ended slices should clip at array boundary

--- a/t/multidim-indexing.t
+++ b/t/multidim-indexing.t
@@ -13,7 +13,11 @@ ok @arr[0;0]:exists, 'cell exists after assignment';
 throws-like { @arr[0] = 'y' }, X::NotEnoughDimensions,
     operation => 'assign to', got-dimensions => 1, needed-dimensions => 2;
 
-is-deeply (try @arr[2;0]:delete), @arr.default, 'out-of-bounds delete returns default';
+# raku throws X::OutOfRange here (verified 2026-07-23); the old expectation
+# (`is-deeply (try ...), @arr.default`) compared try's Nil against Any and
+# only passed through the Nil-eqv-Any crutch.
+throws-like { @arr[2;0]:delete }, Exception, message => /'out of range'/,
+    'out-of-bounds delete on a shaped array throws';
 
 @arr[1;1] := 42;
 dies-ok { @arr[1;1] = 99 }, 'bound multidim cell is read-only';

--- a/t/vm-basic.t
+++ b/t/vm-basic.t
@@ -582,8 +582,11 @@ is vm_shout("hello"), "HELLO", 'compiled function with method call';
 # === Try/Catch ===
 
 # Basic try/catch
+# raku: assigning try's Nil into $try_result resets the container to Any
+# (verified 2026-07-23; the old `is ..., Nil` only passed via the
+# Nil-eqv-Any crutch).
 my $try_result = try { die "oops"; CATCH { default { "caught" } } };
-is $try_result, Nil, 'try/catch catches error';
+ok $try_result === Any, 'try/catch catches error';
 
 # try without error
 my $try_ok = try { 42 };


### PR DESCRIPTION
## Summary

Step 2 of the **Nil-vs-Any identity campaign** (PLAN 8.5), following #5256 (step 1).

**Method:** disable the `Nil === Any` eqv crutch locally (fault injection, not committed), sweep the full `t/` suite plus the nil.t/delete.t/identity.t guardrails, and fix every underlying storage site the crutch was masking:

- **Explicit `my $x = Nil` resets the fresh container to Any** — in statement position (SetLocal applies the untyped-Nil reset when the vardecl carries an explicit initializer) and in expression position (`(my $x = Nil) === Any`, nil.t 21). The synthesized no-init default still stores Nil — that path stays load-bearing for the shadow-slot/closure-cell machinery until step 3.
- **An unset topic reads as Any** (`$_ === Any` at top level, nil.t 39) via the GetGlobal not-found fallback only — a topic explicitly set to Nil (`Xorelse` topicalizing a Nil operand) still reads Nil.
- **`$/.VAR.default` / `$!.VAR.default` report Nil** (nil.t 40).
- **`:delete` of an absent key/index returns the hole type object** (Any, or the element type of a typed container) instead of Nil, on all four paths: hash slow path, hash fast path, array slice loops, never-vivified container.
- **An unset untyped scalar attribute (`has $!z`) seeds the Any type object** in both the native and interpreter constructors; the post-BUILD required checks treat that seed as still-unset.

Three local tests encoded the wrong (crutch-masked) semantics and were corrected against reference raku:
- `t/array-slice-oob.t` — Array OOB slices pad with **Any**; List/Seq slices pad with **Nil** (both raku-verified; a new List-slice assertion pins the distinction)
- `t/multidim-indexing.t` test 6 — shaped OOB delete **throws** in raku (the old `is-deeply (try ...), @arr.default` expectation fails under real raku too)
- `t/vm-basic.t` test 188 — `try`'s Nil resets the assigned container to Any

## Key data point

With the crutch disabled, `roast/S02-types/nil.t` (67 tests) and the **full t/ suite (2312 files, 21822 tests) pass**. The only remaining crutch dependency is the uninitialized-scalar read (`my $x; $x === Any` — step 3, the compiler/closure-cell knot). The crutch itself is unchanged in this PR and comes out at step 4.

## Verification

- Guardrails green (crutch on AND off): nil.t (MUTSU_FUDGE=1), S32-array/delete.t, S32-hash/delete.t, S03-operators/identity.t, t/nil-list-holes.t
- Full `make test` passes in both configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)