### PR TITLE
fix: a read-only given/with/for topic no longer leaks its readonly mark into a called routine

### DIFF
--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -116,6 +116,17 @@ impl Interpreter {
         }
 
         let saved_readonly = self.enter_readonly_frame();
+        // A routine gets a fresh, writable `$_` — it does NOT inherit the
+        // caller's topic, so a caller `given`/`with`/`for` that marked `_`
+        // readonly (a literal/read-only topic) must not leak that mark into this
+        // routine's `$_` (`given 'x' { f() }` where `sub f { $_ = ... }` must
+        // not hit "Cannot assign to a readonly variable (_)"). Clear it here —
+        // journaled by the readonly frame, so it is restored on return — before
+        // the param loop below, which re-marks `_` if the routine has an
+        // explicit (readonly) `$_` parameter.
+        if cf.code.is_routine && !self.no_readonly_vars() {
+            self.unmark_readonly("_");
+        }
         // Bind params to slots. Also write the param into the overlay when a
         // name-based reader needs it (reflective access anywhere / GetGlobal /
         // closure capture via needs_env_sync), or when it is `Nil` (the GetLocal

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -347,6 +347,12 @@ impl Interpreter {
         // traits, so every param is immutable). Save the existing readonly
         // state to restore after the call.
         let saved_readonly = self.enter_readonly_frame();
+        // A routine gets a fresh, writable `$_` — clear any readonly mark leaked
+        // from the caller's topic (see vm_call_light.rs for the full rationale);
+        // the param loop below re-marks `_` for an explicit `$_` param.
+        if cf.code.is_routine && !self.no_readonly_vars() {
+            self.unmark_readonly("_");
+        }
         for (i, pd) in cf.param_defs.iter().enumerate() {
             if !pd.name.is_empty()
                 && !pd.sigilless

--- a/src/vm/vm_call_named_inner.rs
+++ b/src/vm/vm_call_named_inner.rs
@@ -34,6 +34,12 @@ impl Interpreter {
         loan_env!(self, inject_pending_callsite_line());
         self.push_call_frame();
         let saved_stack_depth = self.call_frames.last().unwrap().saved_stack_depth;
+        // A routine gets a fresh, writable `$_` — clear any readonly mark leaked
+        // from the caller's topic (see vm_call_light.rs for the full rationale);
+        // param binding below re-marks `_` for an explicit `$_` parameter.
+        if cf.code.is_routine && !self.no_readonly_vars() {
+            self.unmark_readonly("_");
+        }
         let return_spec = cf.return_type.clone();
 
         loan_env!(self, push_caller_env());

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -231,6 +231,15 @@ impl Interpreter {
 
         self.push_call_frame();
         let saved_stack_depth = self.call_frames.last().unwrap().saved_stack_depth;
+        // A method gets a fresh, writable `$_` (Any) — it does NOT inherit the
+        // caller's topic, so a caller `given`/`with`/`for` that marked `_`
+        // readonly must not leak that mark into the method (`given 'x' { $o.m }`
+        // where `method m { $_ = ... }`). Clear it here, journaled by the
+        // frame's readonly scope so it is restored on return; an explicit
+        // (readonly) `$_` parameter re-marks it during param binding.
+        if !self.no_readonly_vars() {
+            self.unmark_readonly("_");
+        }
 
         // Scoped-overlay (docs/vm-dual-store.md Slice 6): install an empty
         // born-owned overlay over the caller (gated on no inner closures) so the
@@ -1041,6 +1050,12 @@ impl Interpreter {
 
         self.push_light_call_frame();
         let saved_stack_depth = self.call_frames.last().unwrap().saved_stack_depth;
+        // A method gets a fresh, writable `$_` (Any) — clear any readonly mark
+        // leaked from the caller's topic (see the slow path above). Journaled by
+        // the frame's readonly scope; an explicit `$_` param re-marks it.
+        if !self.no_readonly_vars() {
+            self.unmark_readonly("_");
+        }
         // Scoped-overlay (docs/vm-dual-store.md Slice 6): install an empty
         // born-owned overlay over the caller so the `self`/`?CLASS`/param/attr
         // env writes below land in a fresh map (strong_count 1) instead of

--- a/t/given-readonly-topic-does-not-leak-into-routine.t
+++ b/t/given-readonly-topic-does-not-leak-into-routine.t
@@ -1,0 +1,90 @@
+use Test;
+
+# A routine (sub/method) gets a fresh, writable `$_` — it does NOT inherit the
+# caller's topic. So when a routine is called from inside a `given`/`with`/`for`
+# whose topic is read-only (a literal / read-only value marks `$_` readonly),
+# the routine's own `$_` must remain assignable. Regression: the global readonly
+# mark on `_` leaked past the routine-call boundary, so `$_ = ...` inside the
+# called routine died with "Cannot assign to a readonly variable (_)". Fixed by
+# clearing the `_` readonly mark at the routine boundary (journaled by the
+# readonly frame, restored on return); an explicit `$_` param re-marks it.
+# Discovered alongside the when_matched leak while working vCard::Parser
+# t/03-actions.
+
+plan 13;
+
+sub reassign($x)      { $_ = $x; "sub:$_" }
+sub typed(Int $x)     { $_ = $x; "typed:$_" }
+class C { method m($x) { $_ = $x; "method:$_" } }
+my $c = C.new;
+
+# Baseline: works at top level (no enclosing readonly topic).
+is reassign(1), 'sub:1', 'sub $_= works at top level';
+
+# Inside `given` with a read-only (literal) topic.
+given 'g' {
+    is reassign(2),  'sub:2',    'sub $_= inside given (read-only topic)';
+    is $c.m(3),      'method:3',  'method $_= inside given (read-only topic)';
+    is typed(4),     'typed:4',   'typed-param sub $_= inside given';
+}
+
+# Inside `with`.
+with 'w' {
+    is reassign(5), 'sub:5',    'sub $_= inside with';
+    is $c.m(6),     'method:6',  'method $_= inside with';
+}
+
+# Inside a `for` loop (loop topic is read-only).
+my @out;
+for 7, 8 {
+    @out.push(reassign($_ * 10));
+}
+is @out.join(','), 'sub:70,sub:80', 'sub $_= inside for loop';
+
+# Nested given/with.
+given 'outer' {
+    with 'inner' {
+        is $c.m(9), 'method:9', 'method $_= inside nested given/with';
+    }
+}
+
+# The enclosing topic is restored after the call: the given's own `$_` stays
+# read-only for the given's own body.
+my $restored = '';
+given 'topic' {
+    reassign(99);
+    $restored = $_;          # still the given's topic
+}
+is $restored, 'topic', "caller's topic is intact after the routine call";
+
+# An explicit readonly `$_` param still cannot be assigned (the routine reset
+# must not make explicit readonly params writable).
+sub ro($_) { $_ = 0 }
+my $ro-err = '';
+given 'g' {
+    ro(1);
+    CATCH { default { $ro-err = 'ro-blocked' } }
+}
+is $ro-err, 'ro-blocked', 'explicit readonly $_ param stays read-only';
+
+# `is copy` on a `$_` param is writable.
+sub cp($_ is copy) { $_ = 42; "cp:$_" }
+given 'g' {
+    is cp(1), 'cp:42', '$_ is copy param is writable inside given';
+}
+
+# Deeper nesting: routine called two given-levels down.
+given 'a' {
+    given 'b' {
+        given 'c' {
+            is reassign(3), 'sub:3', 'sub $_= three given-levels deep';
+        }
+    }
+}
+
+# A routine that calls another routine, both assigning $_.
+sub inner2($x) { $_ = $x; "in:$_" }
+sub outer2($x) { $_ = $x; inner2($x + 1) ~ "/out:$_" }
+given 'g' {
+    is outer2(1), 'in:2/out:1', 'nested routine calls each keep their own $_';
+}


### PR DESCRIPTION
## Problem

A routine (sub/method) gets a fresh, writable `$_` — it does not inherit the caller's topic. But mutsu's readonly mark is a **global set keyed by bare name**, and `enter_readonly_frame` only journals a scope sentinel; it does not clear the set. So when a `given`/`with`/`for` with a **read-only topic** (a literal / read-only value marks `$_` readonly) called a routine, the `_` readonly mark leaked past the routine-call boundary and `$_ = ...` inside the routine died:

```raku
given 'ctx' {
    reassign(9);   # sub reassign($x) { $_ = $x }
}
# was: Cannot assign to a readonly variable (_) or a value
# now: works (matches raku)
```

## Fix

At the routine-call boundary (after the frame's readonly scope is open, before param binding), clear the `_` readonly mark for routines. The unmark is journaled by the readonly frame, so the caller's mark is restored on return; an explicit readonly `$_` param re-marks it during the normal param-readonly pass, so `sub ro($_) { $_ = 0 }` still correctly rejects the assignment.

Applied to all routine-call paths:
- `vm_call_light.rs`
- `vm_call_light_typed.rs`
- `vm_call_named_inner.rs`
- `vm_method_dispatch.rs` (both `call_compiled_method` and `call_compiled_method_fast`; methods are always routines)

Gated on `!no_readonly_vars()` so the common no-readonly-context call pays nothing (no `Symbol::intern` on the hot path).

## Discovery

Found alongside the `when_matched`-leak fix (#5261) while working `vCard::Parser` `t/03-actions`.

## Tests

- New pin: `t/given-readonly-topic-does-not-leak-into-routine.t` (13 assertions, all matching raku; covers sub/method/typed/for/nested, explicit readonly `$_` param still blocked, `is copy` writable, caller topic intact after call)
- Full `t/` suite: 2318 files / 21882 tests PASS
- topic/readonly `t/` subset (52 files / 459 tests): PASS

## Note / follow-up

This surfaced a **separate** unfixed bug: in `vm_call_light`, a routine's `$_` inherits the caller's topic *value* (not just the readonly mark) — `sub k($x){ $_.^name }` inside `given 'ctx'` sees `Str`, not the fresh `Any` raku gives. The method path already sets `$_ = Any`. That value-leak is deferred to a separate PR (behavioral change with wider blast radius); vCard's actions are methods, so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)