### PR TITLE
feat: CORE:: stash resolves core symbols; GLOBAL::/OUR:: exclude CORE; DYNAMIC:: chain lives (pseudo-6c 40→31)

### DIFF
--- a/src/compiler/expr_helpers.rs
+++ b/src/compiler/expr_helpers.rs
@@ -587,8 +587,15 @@ impl Compiler {
             self.emit_outer_var_access(bare_name, depth);
             return;
         }
-        // $DYNAMIC:: variable access
-        if let Some(bare_name) = name.strip_prefix("DYNAMIC::") {
+        // $DYNAMIC:: variable access. Strip every leading DYNAMIC:: layer — a
+        // repeated chain (`$DYNAMIC::DYNAMIC::...::x`) still names the dynamic var
+        // `x`; going too high just yields an undefined value (roast pseudo-6c
+        // "no guts spillage"), never a lookup for the whole chained string.
+        if name.starts_with("DYNAMIC::") {
+            let mut bare_name = name;
+            while let Some(rest) = bare_name.strip_prefix("DYNAMIC::") {
+                bare_name = rest;
+            }
             let name_idx = self.code.add_constant(Value::str(bare_name.to_string()));
             self.code.emit(OpCode::GetDynamicVar(name_idx));
             return;

--- a/src/runtime/accessors_resolve.rs
+++ b/src/runtime/accessors_resolve.rs
@@ -227,6 +227,11 @@ impl Interpreter {
         // resolve the bare function name.
         let bare_name = Self::strip_pseudo_packages(name);
         let has_packages = bare_name != name;
+        // GLOBAL::/OUR:: are package namespaces that do NOT contain CORE symbols,
+        // unlike the lexical/core pseudo-packages (CORE, SETTING, MY, OUTER, ...).
+        // A builtin name qualified through them is undefined (roast pseudo-6c:
+        // `!defined(&GLOBAL::say)`), so suppress the builtin fast-paths below.
+        let core_visible = !has_packages || !Self::innermost_pseudo_is_package_only(name);
         let lookup_name = bare_name.strip_prefix('*').unwrap_or(bare_name);
         if bare_name == "?ROUTINE" {
             // Skip pointy-block entries to find the enclosing routine
@@ -259,7 +264,7 @@ impl Interpreter {
         // user-defined overrides.
         // When pseudo-package qualifiers are present (e.g. SETTING::), resolve
         // to the builtin directly, bypassing user-defined overrides.
-        if has_packages && Self::is_builtin_function(lookup_name) {
+        if has_packages && core_visible && Self::is_builtin_function(lookup_name) {
             return Value::routine_parts(
                 Symbol::intern("GLOBAL"),
                 Symbol::intern(lookup_name),
@@ -376,7 +381,7 @@ impl Interpreter {
             )
         } else if let Some(def) = def {
             self.sub_value_from_function_def(def)
-        } else if Self::is_builtin_function(lookup_name) {
+        } else if core_visible && Self::is_builtin_function(lookup_name) {
             Value::routine_parts(Symbol::intern("GLOBAL"), Symbol::intern(lookup_name), false)
         } else if Self::is_mop_macro_function(lookup_name) {
             // The MOP pseudo-methods `WHAT`/`HOW`/`VAR` are also first-class
@@ -403,6 +408,36 @@ impl Interpreter {
         } else {
             Value::NIL
         }
+    }
+
+    /// True when the innermost (last) stripped pseudo-package prefix is a
+    /// package namespace (GLOBAL/OUR) rather than a lexical/core scope. Such
+    /// namespaces do not contain CORE symbols, so a builtin name qualified
+    /// through them is undefined (roast pseudo-6c: `!defined(&GLOBAL::say)`).
+    /// `GLOBAL::CORE::not` still sees CORE because CORE is the innermost prefix.
+    fn innermost_pseudo_is_package_only(name: &str) -> bool {
+        let pseudo = [
+            "SETTING", "CALLER", "OUTER", "CORE", "GLOBAL", "MY", "OUR", "DYNAMIC", "UNIT",
+        ];
+        let mut rest = name;
+        let mut last: Option<&str> = None;
+        loop {
+            let mut found = false;
+            for pkg in &pseudo {
+                if let Some(after) = rest.strip_prefix(pkg)
+                    && let Some(after) = after.strip_prefix("::")
+                {
+                    rest = after;
+                    last = Some(pkg);
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                break;
+            }
+        }
+        matches!(last, Some("GLOBAL") | Some("OUR"))
     }
 
     /// Strip pseudo-package prefixes (SETTING::, OUTER::, CALLER::, CORE::, etc.)

--- a/src/runtime/methods_dispatch_match3.rs
+++ b/src/runtime/methods_dispatch_match3.rs
@@ -936,6 +936,22 @@ impl Interpreter {
                     if let Some(value) = stash_lookup(&key) {
                         return Some(Ok(value));
                     }
+                    // CORE::/SETTING:: expose the (huge) core symbol table, which
+                    // is not materialized into the stash. Resolve a missing key
+                    // lazily so `CORE::.<&not>` / `::("CORE")::('&not')` find core
+                    // routines. Qualify with the stash name so a user shadow of the
+                    // same name is bypassed (roast: `CORE::.<&not>` when shadowed).
+                    // TODO: extend to non-code core symbols ($ vars, type objects).
+                    if let Some(ValueView::Str(stash_name)) =
+                        attributes.as_map().get("name").map(Value::view)
+                        && (stash_name.as_str() == "CORE" || stash_name.as_str() == "SETTING")
+                        && let Some(bare) = key.strip_prefix('&')
+                    {
+                        let v = self.resolve_code_var(&format!("{}::{bare}", stash_name.as_str()));
+                        if !v.is_nil() {
+                            return Some(Ok(v));
+                        }
+                    }
                 }
                 Some(Ok(Value::NIL))
             }

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4436,7 +4436,10 @@ impl Interpreter {
             }
             OpCode::GetDynamicVar(name_idx) => {
                 let name = Self::const_str(code, *name_idx);
-                let val = loan_env!(self, get_dynamic_var(name))?;
+                // An unfound dynamic via the DYNAMIC:: pseudo-package is undefined,
+                // not an error (roast pseudo-6c: `!defined($DYNAMIC::x82)`, and the
+                // "no guts spillage" deep-chain lookup must eval-live).
+                let val = loan_env!(self, get_dynamic_var(name)).unwrap_or(Value::NIL);
                 self.stack.push(val);
                 *ip += 1;
             }

--- a/t/pseudo-core-stash.t
+++ b/t/pseudo-core-stash.t
@@ -1,0 +1,36 @@
+use v6.c;
+use Test;
+
+plan 12;
+
+# CORE:: pseudo-package exposes the core symbol table lazily. The `&CORE::name`
+# symbolic form already worked; these pin the stash forms that resolve missing
+# keys against the core resolver (roast S02-names pseudo-6c tests 60/61/63/66).
+my $real = &not;
+
+ok &CORE::not === $real,           '&CORE::not works';
+ok CORE::.<&not> === $real,        'CORE::.<&not> stash form works';
+my $core = "CORE";
+ok ::($core)::('&not') === $real,  '::("CORE") indirect stash form works';
+ok CORE::<&not> === $real,         'CORE::<&not> angle form works';
+
+{
+    sub not($x) { $x } #OK
+    # CORE:: must bypass a same-named user shadow.
+    ok CORE::.<&not> === $real,     'CORE::.<&not> ignores a user shadow';
+    ok ::($core)::('&not') === $real, '::("CORE") ignores a user shadow';
+}
+
+# GLOBAL:: / OUR:: are package namespaces and do NOT contain CORE symbols
+# (roast pseudo-6c test 81). A builtin qualified through them is undefined.
+ok !defined(&GLOBAL::say),  'GLOBAL:: does not find CORE symbols';
+ok !defined(&GLOBAL::not),  'GLOBAL:: does not find CORE &not';
+ok !defined(&OUR::say),     'OUR:: does not find CORE symbols';
+
+# DYNAMIC:: with an unfound name yields an undefined value, never an error, even
+# through a deep repeated chain (roast pseudo-6c "no guts spillage").
+ok !defined($DYNAMIC::nonexistent), 'unfound $DYNAMIC:: is undefined';
+lives-ok { EVAL('$' ~ "DYNAMIC::" x 50 ~ 'True') },
+    'deep $DYNAMIC:: chain lives (no guts spillage)';
+is (EVAL('$' ~ "DYNAMIC::" x 50 ~ 'Nonexistent')).defined, False,
+    'deep $DYNAMIC:: chain to unfound name is undefined';


### PR DESCRIPTION
## Summary

Three related pseudo-package fixes for roast `S02-names/pseudo-6c.t` (Failed **40 → 31**), continuing the CORE:: cluster after #5262.

- **CORE::/SETTING:: stash resolves core symbols lazily.** The core symbol table is far too large to materialize into a stash hash, so `CORE::.<&not>`, `CORE::<&not>` and `::("CORE")::('&not')` returned `Nil`. The Stash `AT-KEY` path now falls back to the core resolver on a miss when the stash is `CORE`/`SETTING`, qualifying the key with the stash name so a same-named user shadow is bypassed — matching the already-working `&CORE::not` symbolic form (roast tests 60/61/63/66).

- **GLOBAL::/OUR:: no longer find CORE symbols.** They are package namespaces, not lexical/core scopes, so a builtin qualified through them must be undefined (`!defined(&GLOBAL::say)`, roast test 81). A new `innermost_pseudo_is_package_only` guard suppresses the two builtin fast-paths in `resolve_code_var` when the innermost pseudo prefix is `GLOBAL`/`OUR`. `GLOBAL::CORE::not` still sees CORE (CORE is innermost).

- **`$DYNAMIC::` chain lives (no guts spillage).** `$DYNAMIC::x` now strips *every* leading `DYNAMIC::` layer and yields an undefined value (never a "Cannot find dynamic variable" error) on a miss, so a deep repeated chain `$DYNAMIC::DYNAMIC::…::True` eval-lives (roast test 155 "no guts spillage" subtest).

## Test

Pin: `t/pseudo-core-stash.t` (12 assertions). `make test` + `make roast` green.

Remaining pseudo-6c failures are separate clusters (indirect `::("CALLER"/"UNIT"/"SETTING")` forms, CALLER/CALLERS in inline blocks, CORE:: runtime binding, BEGIN-time constant-routine registration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)