### PR TITLE
fix: a routine's $_ is a fresh Any, not the caller's given/for/with topic

### DIFF
--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1730,6 +1730,13 @@ pub(crate) struct CompiledCode {
     /// only at routine boundaries, allowing pointy-block returns to propagate
     /// up to the enclosing routine.
     pub(crate) is_routine: bool,
+    /// Whether the body references the topic `$_` (its constant pool contains
+    /// the name `"_"`, emitted by any read/write of `$_`). A routine gets a
+    /// fresh `$_` (Any), so a positional-light call must shadow the caller's
+    /// topic with Any before running such a body — but only when it is actually
+    /// read, so a topic-free hot loop (`fib`) skips the shadowing write and
+    /// keeps the frame-reuse fast path. Computed once in `compute_needs_env_sync`.
+    pub(crate) reads_topic: bool,
     /// Source line number (1-based) where this closure/block was defined.
     pub(crate) source_line: Option<i64>,
     /// Whether this compiled code represents a pointy block (`-> { }` / `<-> { }`).
@@ -2109,6 +2116,7 @@ impl CompiledCode {
             named_arg_specs: Vec::new(),
             closure_escapes: Vec::new(),
             is_routine: false,
+            reads_topic: false,
             has_once: false,
             source_line: None,
             is_pointy_block: false,
@@ -2328,6 +2336,16 @@ impl CompiledCode {
         // compile-time scaffolding (ADR-0006 §2.4). A constant added afterwards
         // (a runtime-built chunk being patched) simply takes a fresh slot.
         self.const_index = rustc_hash::FxHashMap::default();
+        // Does the body touch the topic `$_`? Any read/write of `$_` interns the
+        // name `"_"` into the constant pool (GetGlobal/SetGlobal name), so a
+        // pool scan is a sound (never-miss) over-approximation — a stray string
+        // literal `"_"` only costs a harmless extra topic-shadow write on that
+        // routine's calls. A topic-free routine (e.g. `fib`) has no `"_"`
+        // constant, so its hot-loop calls skip the shadow write entirely.
+        self.reads_topic = self
+            .constants
+            .iter()
+            .any(|c| matches!(c.view(), crate::value::ValueView::Str(s) if s.as_str() == "_"));
         self.compute_locals_sym();
         self.compute_free_vars();
         // Collect env-only `my` declarations so the method-dispatch return merge

--- a/src/vm/vm_call_light.rs
+++ b/src/vm/vm_call_light.rs
@@ -194,6 +194,25 @@ impl Interpreter {
         // coherent; any later reassignment in the body writes through to env via
         // the SetLocal path (`flush_local_to_env`).
 
+        // Raku: a routine gets its own `$_` initialized to `(Any)` — it does NOT
+        // inherit the caller's topic. This positional-light path reads `$_`
+        // through the scoped overlay, which would otherwise fall through to the
+        // caller's topic (`given 'x' { f(1) }` where `sub f($n){ ... $_ ... }`
+        // saw `'x'`, not `Any`). Shadow it with `Any` here — gated on
+        // `reads_topic` so a topic-free hot loop (`fib`) never pays this env
+        // write and keeps the frame-reuse fast path. An explicit `$_` parameter
+        // (bound above) owns `$_`, so skip when one is present.
+        if cf.code.reads_topic
+            && cf.code.is_routine
+            && !cf.param_defs.iter().any(|pd| pd.name == "_")
+        {
+            let any_val = Value::package(crate::symbol::Symbol::intern("Any"));
+            if let Some(slot) = cf.code.locals.iter().position(|n| n == "_") {
+                self.locals[slot] = any_val.clone();
+            }
+            self.env_mut().insert("_".to_string(), any_val);
+        }
+
         let saved_stack_depth = self.stack.len();
         let let_mark = self.let_saves_len();
         // This path skips push_caller_env, so roll back the line the callee

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -353,6 +353,19 @@ impl Interpreter {
         if cf.code.is_routine && !self.no_readonly_vars() {
             self.unmark_readonly("_");
         }
+        // Raku: a routine gets its own `$_` = `(Any)`, not the caller's topic.
+        // Shadow the caller's topic with Any before the body reads it (gated on
+        // `reads_topic` so a topic-free routine pays nothing). See vm_call_light.
+        if cf.code.reads_topic
+            && cf.code.is_routine
+            && !cf.param_defs.iter().any(|pd| pd.name == "_")
+        {
+            let any_val = Value::package(crate::symbol::Symbol::intern("Any"));
+            if let Some(slot) = cf.code.locals.iter().position(|n| n == "_") {
+                self.locals[slot] = any_val.clone();
+            }
+            self.env_mut().insert("_".to_string(), any_val);
+        }
         for (i, pd) in cf.param_defs.iter().enumerate() {
             if !pd.name.is_empty()
                 && !pd.sigilless

--- a/t/routine-topic-is-fresh-any-not-caller.t
+++ b/t/routine-topic-is-fresh-any-not-caller.t
@@ -1,0 +1,68 @@
+use Test;
+
+# Raku: a routine (sub/method) gets its own `$_` initialized to `(Any)` — it
+# does NOT inherit the caller's topic. Regression: the positional/named "light"
+# call paths read `$_` through the scoped env overlay, which fell through to the
+# caller's `given`/`for`/`with` topic, so a param-taking sub that reads `$_` saw
+# the caller's topic value instead of a fresh `Any`. (The no-param path and the
+# method path already installed a fresh `$_`.) Fixed by shadowing `$_` with Any
+# at the routine boundary, gated on the body actually referencing `$_`
+# (`reads_topic`) so a topic-free hot loop keeps its fast path.
+
+plan 13;
+
+sub noparam()          { $_.^name }
+sub oneparam($x)       { $_.^name }
+sub typedparam(Int $x) { $_.^name }
+sub twoparam($x, $y)   { $_.^name }
+sub namedparam($x, :$opt) { $_.^name }
+class C { method m($x) { $_.^name } }
+my $c = C.new;
+
+# Baseline at top level: $_ is Any.
+is noparam(),  'Any', 'no-param sub: $_ is Any at top level';
+is oneparam(1), 'Any', 'one-param sub: $_ is Any at top level';
+
+# Inside a `given` with a Str topic, the routine's own $_ is still Any.
+given 'ctx' {
+    is noparam(),        'Any', 'no-param sub: fresh $_ inside given';
+    is oneparam(1),      'Any', 'one-param sub: fresh $_ inside given';
+    is typedparam(1),    'Any', 'typed-param sub: fresh $_ inside given';
+    is twoparam(1, 2),   'Any', 'two-param sub: fresh $_ inside given';
+    is namedparam(1, opt => 2), 'Any', 'named-param sub: fresh $_ inside given';
+    is $c.m(1),          'Any', 'method: fresh $_ inside given';
+}
+
+# Inside a `for` loop (element topic).
+my @names;
+for 'a', 'b' {
+    @names.push(oneparam(1));
+}
+is @names.join(','), 'Any,Any', 'one-param sub: fresh $_ inside for loop';
+
+# Inside `with`.
+with 'w' {
+    is oneparam(1), 'Any', 'one-param sub: fresh $_ inside with';
+}
+
+# A routine that WRITES its $_ then reads it back sees the written value, not
+# the caller topic.
+sub setread($x) { $_ = $x * 2; $_ }
+given 'ctx' {
+    is setread(5), 10, 'routine that assigns $_ reads back its own value';
+}
+
+# An explicit `$_` parameter binds the topic to the argument (not Any, not the
+# caller topic).
+sub explicit($_) { "got:$_" }
+given 'ctx' {
+    is explicit('arg'), 'got:arg', 'explicit $_ param binds the argument';
+}
+
+# The caller's topic is unchanged after the call.
+my $after = '';
+given 'ctx' {
+    oneparam(1);
+    $after = $_;
+}
+is $after, 'ctx', "caller's topic intact after a fresh-\$_ routine call";


### PR DESCRIPTION
## Problem

Raku initializes a routine's `$_` to `(Any)` — a sub/method does **not** inherit the caller's topic. mutsu's no-param and method call paths already installed a fresh `$_`, but the positional/named "light" call paths (used for **param-taking subs**) read `$_` through the scoped env overlay, which fell through to the caller's topic. So a param-taking sub that read `$_` while called from inside a `given`/`for`/`with` saw the caller's topic **value** instead of a fresh Any:

```raku
sub f($x) { $_.^name }
given 'ctx' { say f(1) }   # was "Str", now "Any" (matches raku)
```

(The no-param path — `vm_call_named_inner` — and the method path already set `$_ = Any`. Only the light param paths leaked.)

## Fix

Shadow `$_` with Any at the light-call routine boundary (env + the `_` local slot if one exists), for a routine with no explicit `$_` parameter. Applied to `vm_call_light` (positional-light) and `vm_call_light_typed` (named-light).

Gated on a new compile-time `reads_topic` flag — the body's constant pool contains the name `"_"`, a sound never-miss over-approximation (a stray string literal `"_"` only costs a harmless extra shadow write). So a **topic-free hot loop** like `fib`, whose constants have no `"_"`, skips the shadowing env write entirely and keeps the frame-reuse fast path untouched. `reads_topic` is computed once per chunk in `compute_needs_env_sync`.

## Correctness preserved

- An explicit `$_` parameter still binds the argument (not Any).
- A routine that assigns `$_` reads back its own written value.
- The caller's topic is intact after the call.

## Perf

`fib(30)` unchanged (~0.5s; the gate short-circuits on the `reads_topic` bool, and fib has no `"_"` constant so the `param_defs` scan is never reached).

## Discovery

Third fix from the vCard::Parser `t/03-actions` investigation (siblings: #5261 when_matched leak, #5265 readonly-mark leak). vCard's actions are methods (already had fresh `$_`), so this specifically covers param-taking **subs**.

## Tests

- New pin: `t/routine-topic-is-fresh-any-not-caller.t` (13 assertions, all matching raku; no-param/one-param/typed/multi/named/method inside given/for/with, explicit `$_` param, assign-then-read, caller topic intact)
- Full `t/` suite: 2321 files / 21919 tests PASS

## Known limitation

`reads_topic` only sees `$_` referenced **directly** in the routine body, not `$_` read from a nested closure whose own body references it (`sub f($x){ { $_ }() }`). That rare case keeps the pre-existing behavior (no regression, just an incomplete fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)