### PR TITLE
fix: importable `class ... is export` + multi-method sigil narrowness (T-057 Statistics::LinearRegression)

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -641,9 +641,9 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 - dists (each its own root cause; triage individually before claiming, confirm the
   raku `-I lib` baseline first): Attribute::Predicate, File::Ignore,
   IO::Path::AutoDecompress, Math::Angle, Math::PascalTriangle,
-  Statistics::LinearRegression, String::Rotate, Text::CodeProcessing, Trait::IO,
-  WriteOnceHash, `are`, `sortuk`, Tree::Binary::PrettyTree (required role method
-  not seen as implemented).
+  ~~Statistics::LinearRegression~~ (FIXED — see Done), String::Rotate,
+  Text::CodeProcessing, Trait::IO, WriteOnceHash, `are`, `sortuk`,
+  Tree::Binary::PrettyTree (required role method not seen as implemented).
 - These `test_die` on the current binary but were not individually reproduced.
   Split off a dedicated ticket when you pick one up.
 
@@ -652,6 +652,30 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 _(move tickets here with `[claim: <branch>]` when you start)_
 
 ## Done
+
+- **T-057 (Statistics::LinearRegression)** (#PENDING) — 6/9 → 9/9. Two general
+  bugs, both on the path to `my LR $model .= new: @x, @y`:
+  1. **`class ... is export` was silently dropped.** A `class Foo is export` /
+     `is export(:TAG)` inside a module never became importable — the class-decl
+     `is`-trait loop skipped `export` without recording it (and `is export(:ALL)`
+     left its `(:ALL)` unconsumed, mis-parsing the body → "Unknown function:
+     export"). The `LR` class (`class LR is export`) was therefore undeclared
+     under `use Statistics::LinearRegression :ALL`. Fix: the class parser now
+     captures `is export`/`is export(:tags)` (a bare `is export` == DEFAULT, also
+     under `:ALL`, matching Rakudo) and emits a `__MUTSU_EXPORT_TYPE__` runtime
+     call that records the export via `register_exported_var(current_package,
+     name, tags)` — mirroring the sub `is export` path. Pin:
+     `t/class-is-export-tag.t` (+ `t/lib/ExportedTypeFixture.rakumod`).
+  2. **`multi method` sigil narrowness was not a tie-break.** `multi method
+     new(@x, @y)` vs `new($a, $b)` reported X::Multi::Ambiguous for two array
+     args: the method dispatch's narrowness tie-break only counted `where`/subset
+     constraints, ignoring the implicit Positional/Associative/Callable constraint
+     an `@`/`%`/`&` sigil imposes (the multi *sub* path already counted these via
+     `typed_param_count`). Fix: `resolution_method.rs` narrowness now returns
+     `(where+subset, sigil-typed)` so `(@x, @y)` beats `($a, $b)`. Pin:
+     `t/multi-method-sigil-narrowness.t`.
+  - file: `src/parser/stmt/class/class_decl.rs`, `src/runtime/builtins.rs`
+    (`__MUTSU_EXPORT_TYPE__`), `src/runtime/resolution_method.rs`.
 
 - **T-055** (#PENDING) — Time::Duration::Parser 0/42 → 42/42. Inline grammar-action
   `{ make … }` values were bubbled to the top node and run with a shared `$/`, so a

--- a/src/parser/stmt/class/class_decl.rs
+++ b/src/parser/stmt/class/class_decl.rs
@@ -479,9 +479,14 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
             stmts.push(meta_setter_stmt(&name, &trait_name, trait_value));
         }
     }
-    if is_export {
+    if is_export && !is_lexical {
         // Register the export AFTER the class is declared so its type object is
         // in scope when `import`/`use` copies it into the caller's namespace.
+        // Only for a package-scoped class: a `my class ... is export` is lexical
+        // and would be trapped inside this synthetic `Stmt::Block` scope (breaking
+        // its visibility to the rest of the module). A bare-file module's
+        // top-level `my class` is already importable by its bare name through the
+        // global registry, so it keeps the pre-existing path here.
         stmts.push(class_stmt);
         stmts.push(export_type_stmt(&name, &export_tags));
         return Ok((rest, Stmt::Block(stmts)));

--- a/src/parser/stmt/class/class_decl.rs
+++ b/src/parser/stmt/class/class_decl.rs
@@ -63,6 +63,38 @@ pub(crate) fn parse_optional_bracket_suffix(input: &str) -> PResult<'_, String> 
     Ok((&input[end..], input[..end].to_string()))
 }
 
+/// Extract the tag names from an `is export(...)` argument list, e.g.
+/// `":ALL, :FOO"` -> `["ALL", "FOO"]`. Each colonpair `:NAME` contributes its
+/// name; bare words are also accepted (`export(FOO)`).
+fn extract_export_tag_names(inner: &str) -> Vec<String> {
+    let mut tags = Vec::new();
+    for part in inner.split(',') {
+        let t = part.trim().trim_start_matches(':').trim();
+        // Take the leading identifier (drop any `<...>`/value tail).
+        let name: String = t
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_' || *c == '-')
+            .collect();
+        if !name.is_empty() {
+            tags.push(name);
+        }
+    }
+    tags
+}
+
+/// Emit a runtime call that records a `is export`-ed type (class/grammar) so a
+/// later `use`/`import` of the enclosing module can import it by its bare name.
+pub(crate) fn export_type_stmt(type_name: &str, tags: &[String]) -> Stmt {
+    let mut args = vec![Expr::Literal(Value::str(type_name.to_string()))];
+    for tag in tags {
+        args.push(Expr::Literal(Value::str(tag.clone())));
+    }
+    Stmt::Expr(Expr::Call {
+        name: Symbol::intern("__MUTSU_EXPORT_TYPE__"),
+        args,
+    })
+}
+
 pub(crate) fn meta_setter_stmt(type_name: &str, key: &str, value: Value) -> Stmt {
     Stmt::Expr(Expr::Call {
         name: Symbol::intern("__MUTSU_SET_META__"),
@@ -230,6 +262,8 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
     let mut does_parents = Vec::new();
     let mut is_repr: Option<String> = None;
     let mut custom_traits: Vec<(String, Option<Expr>)> = Vec::new();
+    let mut is_export = false;
+    let mut export_tags: Vec<String> = Vec::new();
     let mut r = rest;
     loop {
         if let Some(r2) = keyword("is", r) {
@@ -261,6 +295,26 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
                 continue;
             } else if parent == "DEPRECATED" {
                 // `is DEPRECATED` on a class — skip optional parenthesized arg
+                let r2 = skip_balanced_parens(r2);
+                let (r2, _) = ws(r2)?;
+                r = r2;
+                continue;
+            } else if parent == "export" {
+                // `class Foo is export` / `is export(:TAG, :TAG2)` — mark the
+                // class as importable. A bare `is export` uses the DEFAULT tag
+                // (also imported under `:ALL`); tagged forms capture each `:TAG`.
+                is_export = true;
+                if let Some(inner) = r2.strip_prefix('(') {
+                    let end = inner.find(')').unwrap_or(inner.len());
+                    for tag in extract_export_tag_names(&inner[..end]) {
+                        if !export_tags.contains(&tag) {
+                            export_tags.push(tag);
+                        }
+                    }
+                }
+                if export_tags.is_empty() && !export_tags.iter().any(|t| t == "DEFAULT") {
+                    export_tags.push("DEFAULT".to_string());
+                }
                 let r2 = skip_balanced_parens(r2);
                 let (r2, _) = ws(r2)?;
                 r = r2;
@@ -424,6 +478,13 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
         if trait_name == "ver" || trait_name == "auth" || trait_name == "api" {
             stmts.push(meta_setter_stmt(&name, &trait_name, trait_value));
         }
+    }
+    if is_export {
+        // Register the export AFTER the class is declared so its type object is
+        // in scope when `import`/`use` copies it into the caller's namespace.
+        stmts.push(class_stmt);
+        stmts.push(export_type_stmt(&name, &export_tags));
+        return Ok((rest, Stmt::Block(stmts)));
     }
     if stmts.is_empty() {
         return Ok((rest, class_stmt));

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -532,6 +532,24 @@ impl Interpreter {
                     .insert(key, value);
                 Ok(Value::NIL)
             }
+            "__MUTSU_EXPORT_TYPE__" => {
+                // Record a `is export`-ed type (class/grammar) so a later
+                // `use`/`import` of the enclosing module imports it by its bare
+                // name. Mirrors the sub `is export` path: the export package is
+                // the current package at declaration time. Suppressed exports
+                // (e.g. inside an inner block) are skipped, like other exports.
+                if self.suppress_exports {
+                    return Ok(Value::NIL);
+                }
+                let Some(name) = args.first() else {
+                    return Ok(Value::NIL);
+                };
+                let name = name.to_string_value();
+                let tags: Vec<String> = args[1..].iter().map(|a| a.to_string_value()).collect();
+                let pkg = self.current_package().to_string();
+                self.register_exported_var(pkg, name, tags);
+                Ok(Value::NIL)
+            }
             "__mutsu_set_newline" => {
                 let pair = args.first().cloned().unwrap_or(Value::NIL);
                 let ValueView::Pair(name, value) = pair.view() else {

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -239,11 +239,17 @@ impl Interpreter {
             .collect();
         if tied.len() > 1 {
             // "Narrowness" tie-break: among equally-typed candidates, prefer the
-            // one whose params carry more narrowing constraints — a `where` clause
-            // OR a subset type (a subset is narrower than its base, and its
-            // nominal distance was resolved to the base above, so the two tie).
-            let narrowness = |def: &MethodDef| -> usize {
-                def.param_defs
+            // one whose params carry more narrowing constraints. Ranked as a tuple
+            // (higher wins lexicographically):
+            //   .0 = `where` clauses OR subset types (a subset is narrower than its
+            //        base, whose nominal distance was resolved to the base above);
+            //   .1 = sigilled params (`@`/`%`/`&`) — the sigil imposes an implicit
+            //        Positional/Associative/Callable constraint, so `(@x, @y)` is
+            //        narrower than `($a, $b)` for two array args (matching the sub
+            //        dispatch's `typed_param_count`, which also counts sigils).
+            let narrowness = |def: &MethodDef| -> (usize, usize) {
+                let where_subset = def
+                    .param_defs
                     .iter()
                     .filter(|p| {
                         p.where_constraint.is_some()
@@ -253,13 +259,26 @@ impl Interpreter {
                                     .contains_key(Self::constraint_base_for_distance(tc))
                             })
                     })
-                    .count()
+                    .count();
+                let sigil_typed = def
+                    .param_defs
+                    .iter()
+                    .filter(|p| {
+                        !p.is_invocant
+                            && !p.slurpy
+                            && !p.double_slurpy
+                            && (p.name.starts_with('@')
+                                || p.name.starts_with('%')
+                                || p.name.starts_with('&'))
+                    })
+                    .count();
+                (where_subset, sigil_typed)
             };
             let best_where = tied
                 .iter()
                 .map(|&i| narrowness(&all_matches[i].1))
                 .max()
-                .unwrap_or(0);
+                .unwrap_or((0, 0));
             let mut narrowed: Vec<usize> = tied
                 .iter()
                 .copied()

--- a/t/class-is-export-tag.t
+++ b/t/class-is-export-tag.t
@@ -1,0 +1,54 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+# Regression (TODO_dist T-057, Statistics::LinearRegression): a class declared
+# `is export` inside a module must be importable by its bare name. A bare
+# `is export` == DEFAULT (also under :ALL); `is export(:ALL)` is :ALL-only.
+#
+# NOTE on ordering: mutsu shares one global namespace across EVALs in a single
+# process, so once an :ALL import brings a name in it stays visible. The
+# negative check (an :ALL-only name is hidden under a plain `use`) must run
+# BEFORE any :ALL import, so it comes first.
+
+plan 4;
+
+{
+    # An :ALL-only class must NOT be visible under a plain `use`.
+    my $died = False;
+    try {
+        EVAL q:to/CODE/;
+            use ExportedTypeFixture;
+            AllOnlyCls.new.who
+        CODE
+        CATCH { default { $died = True } }
+    }
+    ok $died, ':ALL-only class is not imported by a plain use';
+}
+
+{
+    # Plain `use` imports the DEFAULT-tagged class.
+    my $out = EVAL q:to/CODE/;
+        use ExportedTypeFixture;
+        DefaultCls.new.who
+    CODE
+    is $out, "DefaultCls", 'plain use imports the DEFAULT-tagged class';
+}
+
+{
+    # Import everything under :ALL — both the DEFAULT and :ALL-only classes.
+    my $out = EVAL q:to/CODE/;
+        use ExportedTypeFixture :ALL;
+        DefaultCls.new.who ~ "," ~ AllOnlyCls.new.who
+    CODE
+    is $out, "DefaultCls,AllOnlyCls", ':ALL imports both DEFAULT and :ALL-only classes';
+}
+
+{
+    # multi method new: `(@x, @y)` beats `($a, $b)` for two array args.
+    use ExportedTypeFixture :ALL;
+    my @x = 1, 2, 3;
+    my @y = 4, 5, 6;
+    is Model.new(@x, @y).tag, 'arrays',
+        'multi method new picks the sigil-narrower (@x, @y) candidate';
+}

--- a/t/lib/ExportedTypeFixture.rakumod
+++ b/t/lib/ExportedTypeFixture.rakumod
@@ -1,0 +1,21 @@
+unit class ExportedTypeFixture;
+
+# A class exported under the DEFAULT tag (bare `is export`); also visible
+# under `:ALL`, matching Rakudo's `is export` == `is export(:DEFAULT, :ALL)`.
+class DefaultCls is export {
+    method who { "DefaultCls" }
+}
+
+# A class exported ONLY under the :ALL tag — must NOT leak into a plain `use`.
+class AllOnlyCls is export(:ALL) {
+    method who { "AllOnlyCls" }
+}
+
+# Two `multi method new` candidates distinguished only by param sigil:
+# `(@x, @y)` must win over `($a, $b)` for two array arguments (the sigil
+# imposes an implicit Positional constraint, narrower than a bare Any).
+class Model is export(:ALL) {
+    has $.tag;
+    multi method new(@x, @y) { self.bless(:tag<arrays>) }
+    multi method new($a, $b) { self.bless(:tag<scalars>) }
+}

--- a/t/multi-method-sigil-narrowness.t
+++ b/t/multi-method-sigil-narrowness.t
@@ -1,0 +1,29 @@
+use v6;
+use Test;
+
+# Regression (TODO_dist T-057, Statistics::LinearRegression's `my LR $m .= new: @x, @y`):
+# a `multi method` whose candidates differ only by parameter sigil must resolve
+# by sigil narrowness, NOT report X::Multi::Ambiguous. An `@`/`%`/`&` sigil
+# imposes an implicit Positional/Associative/Callable constraint, so `(@x, @y)`
+# is narrower than `($a, $b)` for two array arguments. (multi *sub* dispatch
+# already did this; the *method* path did not.)
+
+plan 4;
+
+class C {
+    multi method new(@x, @y) { self.bless }
+    multi method new($a, $b) { self.bless }
+    multi method pick2(@x, @y) { "arrays" }
+    multi method pick2($a, $b) { "scalars" }
+    multi method pick1(%h)     { "hash" }
+    multi method pick1($x)     { "scalar" }
+}
+
+my @a = 1, 2, 3;
+my @b = 4, 5, 6;
+my %m = a => 1;
+
+lives-ok { C.new(@a, @b) }, 'multi method new(@x,@y) vs new($a,$b) is not ambiguous for arrays';
+is C.pick2(@a, @b), 'arrays', '(@x, @y) wins over ($a, $b) for two array args';
+is C.pick2(1, 2),   'scalars', '($a, $b) still wins for two scalar args';
+is C.pick1(%m),     'hash', '(%h) wins over ($x) for a hash arg';


### PR DESCRIPTION
## Summary

Fixes **T-057 Statistics::LinearRegression** (6/9 → 9/9). Two general bugs, both on the path through the dist's `my LR \$model .= new: @x, @y`:

### 1. `class ... is export` was silently dropped
A `class Foo is export` / `is export(:TAG)` inside a module never became importable. The class-decl `is`-trait loop skipped `export` without recording it, and `is export(:ALL)` left its `(:ALL)` unconsumed → mis-parsed the body ("Unknown function: export"). So `class LR is export` was undeclared under `use Statistics::LinearRegression :ALL`.

The class parser now captures `is export`/`is export(:tags)` (a bare `is export` == DEFAULT, also under `:ALL`, matching Rakudo) and emits a `__MUTSU_EXPORT_TYPE__` runtime call that records the export via `register_exported_var(current_package, name, tags)` — mirroring the sub `is export` path.

### 2. `multi method` sigil narrowness was not a tie-break
`multi method new(@x, @y)` vs `new($a, $b)` reported `X::Multi::Ambiguous` for two array args. The method dispatch's narrowness tie-break counted only `where`/subset constraints, ignoring the implicit Positional/Associative/Callable constraint an `@`/`%`/`&` sigil imposes (the multi *sub* path already counted these via `typed_param_count`). `resolution_method.rs` narrowness now returns `(where+subset, sigil-typed)`, so `(@x, @y)` beats `($a, $b)`.

## Tests
- `t/class-is-export-tag.t` (+ `t/lib/ExportedTypeFixture.rakumod`)
- `t/multi-method-sigil-narrowness.t`
- `make test` green; spot-checked whitelisted roast (S10/S11 export/import, S12 multi, MRO) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)