### PR TITLE
fix: list-infix Z/X/meta-op is looser than comma in no-paren user-sub call args

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -199,16 +199,22 @@ intentionally deferred; see PLAN.md §8.5 and the ADRs:
     its block, so a later bare `i` in the same unit mis-parses (`-> \i` does not
     leak; only the `my \i` VarDecl form).
 - **List-infix (`Z`/`X`/meta/infix-func) comma precedence** — `operators.rakudoc`
-  [24] (`say 100, 200 Z+ 42, 23` → mutsu `100(242)`, raku `(142 223)`; `1, 2 Z 3, 4`
-  → `((1 3) (2 4))`). `Z`/`X` are **looser than comma** in Raku, so the comma list
-  on each side is the operand (`(100,200) Z+ (42,23)`); mutsu binds them tighter
-  than comma. The parenthesized form already builds the right AST
-  (`MetaOp { meta:"Z", op:"+", left: ArrayLiteral, right: ArrayLiteral }`), so the
-  fix is a precedence-layer change: make the listop-arg / comma-expression parser
-  absorb the whole comma level into a top-level `Z`/`X`/meta-op, analogous to the
-  sequence-operator comma-absorption (`try_parse_sequence_arg_list`). Deferred:
-  it is a core precedence-layer change across many operator forms, not a shallow
-  slice.
+  [24] (`say 100, 200 Z+ 42, 23` → raku `(142 223)`; `1, 2 Z 3, 4` → `((1 3) (2 4))`).
+  `Z`/`X` are **looser than comma** in Raku, so the comma list on each side is the
+  operand (`(100,200) Z+ (42,23)`). **Fixed for the statement/argument listop paths:**
+  `say`/`print`/`put`/`note` and `is`/`ok`/`is-deeply` (#5268), and the no-paren
+  **user-sub / imported-sub / hyphen-forward** call path (#5271) — each applies a
+  per-argument `extend_listop_arg_list_infix` + whole-level
+  `lift_list_infix_in_arg_list` (the paren form already lifted post-parse). **Still
+  deferred (two sub-cases):**
+  - **Builtin listop path** (`join`/`grep`/`map` in `identifier_call.rs` ~1490-1529):
+    subtler raku semantics — `join "-", 1, 2 Z 3, 4` returns `""` in raku, not a
+    clean `(1,2) Z (3,4)` cross — and a distinct code path, so it is NOT the same
+    shallow lift.
+  - **Comparison-operand precedence** (`1 == 1 Z 2 == 2` → raku `(True True)`, mutsu
+    `False`): mutsu's list-infix operand is `range_expr`, tighter than comparison,
+    inverting raku where the `Z` operand is the comparison level. A core
+    precedence-layer redesign (do NOT bolt on) — see the pin memo.
 - **Forward-declaration stub upgrade** — `operators.rakudoc` [6]
   (`sub a() { ... }; say a; sub a() { 42 }` → raku 42, mutsu X::Redeclaration). A
   `{ ... }` yada stub is a forward declaration a later real definition upgrades.

--- a/src/parser/primary/ident/listop.rs
+++ b/src/parser/primary/ident/listop.rs
@@ -306,6 +306,10 @@ pub(crate) fn make_call_expr_from_listop_args<'a>(
         remaining_len: err.remaining_len.or(Some(rest.len())),
         exception: err.exception,
     })?;
+    // A list-infix operator (Z/X/meta/infix func) binds tighter than the comma
+    // separating listop arguments, so it is absorbed into the argument here
+    // (`f @a Z @b` is `f(@a Z @b)`); the whole comma level is then lifted below.
+    let (r, first) = extend_listop_arg_list_infix(r, input, first)?;
     let (r, invocant_colon_call) = try_parse_no_paren_invocant_colon_call(&name, first.clone(), r)?;
     if let Some(method_call) = invocant_colon_call {
         return Ok((r, method_call));
@@ -346,8 +350,15 @@ pub(crate) fn make_call_expr_from_listop_args<'a>(
             remaining_len: err.remaining_len.or(Some(r2.len())),
             exception: err.exception,
         })?;
+        let (r2, arg) = extend_listop_arg_list_infix(r2, input, arg)?;
         args.push(arg);
         r = r2;
     }
+    // A top-level list-infix meta-op (`Z`/`X`) or `minmax` is LOOSER than the
+    // comma separating listop arguments, so it owns the whole comma level:
+    // `f 1, 2 X 3, 4` is `f((1,2) X (3,4))`. The per-argument parse above left
+    // the meta-op bound only to its neighbouring element; lift it across the
+    // full argument list, mirroring `parse_expr_listop_args`.
+    let args = crate::parser::primary::lift_list_infix_in_arg_list(args);
     Ok((r, make_call_expr(name, input, args)))
 }

--- a/t/list-infix-comma-precedence.t
+++ b/t/list-infix-comma-precedence.t
@@ -7,7 +7,7 @@ use Test;
 # the whole comma list on each side is one operand: `say((a, b) Zop (c, d))`.
 # mutsu previously bound the meta-op tighter than comma, giving `say(a, (b Zop c), d)`.
 
-plan 13;
+plan 17;
 
 # Capture what a `say`/`print` statement actually emits, so we test the
 # unparenthesized listop statement path (not the parenthesized-list path).
@@ -59,3 +59,16 @@ is-deeply @a, [(1, 3), (2, 4)],
 # whole Z becomes a WhateverCode (regression guard for repeat.t test 34).
 my @b = flat <a b c> Z (1 xx *);
 is @b.join('|'), 'a|1|b|1|c|1', 'Z with an `xx *` extender operand does not curry';
+
+# A no-paren user-sub call gobbles a whole comma level as its argument list, and
+# the list-infix operator is LOOSER than that comma, so it owns both operands:
+# `f 1, 2 X 3, 4` is `f((1,2) X (3,4))`, one cross-product argument.
+sub collect(*@a) { @a.join('|') }
+is (collect 1, 2 X 3, 4), '1|3|1|4|2|3|2|4',
+    'user-sub no-paren: (1,2) X (3,4) is one argument';
+is (collect 100, 200 Z+ 42, 23), '142|223',
+    'user-sub no-paren: (100,200) Z+ (42,23)';
+is (collect 1, 2 Z 3, 4), '1|3|2|4',
+    'user-sub no-paren: (1,2) Z (3,4)';
+is (collect 1, 2, 3), '1|2|3',
+    'user-sub no-paren: a plain comma list is unaffected';


### PR DESCRIPTION
## Summary

The list-infix level (`Z`, `X`, the `Z+`/`X*` meta-ops, `minmax`) is **looser** than the comma that separates a no-paren listop's arguments, so it owns the whole comma level on each side:

- `f 1, 2 X 3, 4` is `f((1,2) X (3,4))` — one cross-product argument — **not** `(f 1, 2) X (3, 4)`.

`parse_expr_listop_args` (the `say`/`print`/`is`/`ok` path, #5268) already applied the per-argument `extend_listop_arg_list_infix` + whole-level `lift_list_infix_in_arg_list` fix, but `make_call_expr_from_listop_args` — the no-paren **user-sub / imported-sub / hyphen-forward-call** path — parsed each argument with the bare list-prefix `parse_listop_arg` and never lifted, so the meta-op stayed bound to its neighbour element and was applied by the outer expression parser *outside* the call.

This mirrors the working path: extend each argument with the list-infix loop, then lift the meta-op/`minmax` across the full argument list. Feeds (`==>`/`<==`) stay outside the call as before (the loop is the no-feed variant).

### Before / after

```
sub f(*@a){ say @a.raku }; f 1, 2 X 3, 4
# raku:  [1, 3, 1, 4, 2, 3, 2, 4]
# mutsu: [1, 2]           (before)  ->  [1, 3, 1, 4, 2, 3, 2, 4]  (after)
```

## Scope

The builtin listop path (`join`/`grep`/`map`) has subtler raku semantics (e.g. `join "-", 1, 2 Z 3, 4` returns `""` in raku) and a different code path; it is left deferred, as is the comparison-operand precedence case (`1 == 1 Z 2 == 2`), which needs a core precedence-layer redesign.

## Tests

Pin: `t/list-infix-comma-precedence.t` (+4 user-sub cases). Roast canaries `S03-metaops/{zip,cross,hyper}.t`, `S03-sequence/basic.t`, `S03-operators/repeat.t` all pass. `make test` PASS (21944 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)