### PR TITLE
feat: uninitialized untyped `my $x` holds the Any type object (PLAN 8.5 step 3)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1214,14 +1214,36 @@ the backlog.
       Any; List/Seq pad Nil), `t/multidim-indexing.t` 6 (shaped OOB delete throws — the old
       expectation fails under real raku), `t/vm-basic.t` 188 (`try`'s Nil resets the container to
       Any). **Key data point: the full `t/` suite (2312 files) passes with the crutch disabled.**
-- **Remaining steps:** 3 (uninit `my $x` = Any — the compiler/closure-cell knot; the ONLY
-      remaining crutch dependency is the uninit-scalar read: `my $x; $x === Any` must stay True,
-      so the crutch cannot be removed before step 3), 4 (remove the eqv crutch LAST; also lets
-      `Nil.^name`/`Nil === Any` divergences close), then re-check `.cache` on a holey Array
-      (returns a List today, raku returns the Array itself — noticed during step 1, unrelated).
-- **Cost/benefit** (for the remaining steps 3-4): step 3 is the proven-hard compiler knot; the
-      payoff is uninit-value rendering + dropping the crutch. Related: §6 (dual-store / lexical
-      slot), [`array-hole-tracking-embedded`], [ADR-0001] container-repr.
+- **Campaign step 3 landed 2026-07-23** (branch `nil-any-step3`) — uninit `my $x` now seeds the
+      **Any type object**. The winning approach was neither of the two that failed in the 2026-07-20
+      investigation (parser-BareWord / store-reset): the AST keeps the synthesized `Literal(Nil)`
+      (so all 6+ compiler default-init recognition sites — redeclaration no-op, shadow-slot,
+      block-inline, do-expr — stay intact) and the **compiler substitutes the Any type object only
+      at RHS-emission time**, in the three emit sites (`compiler/stmt.rs`, `expr_block.rs`,
+      `helpers_block_inline.rs`; shared predicate `uninit_untyped_scalar_defaults_to_any`).
+      `$/`/`$!` stay Nil; `is default(...)`/`:=`-bind/explicit-init decls keep their paths. VM
+      knock-ons fixed in the same slice: (a) `=:=` — the Package-singleton shortcuts must not
+      treat two Any-holding container reads as identical (`ContainerEqNamed` excludes "Any";
+      `is_value_non_reference` includes the Any type object); (b) closure-capture boxing
+      (`box_captured_lexicals` / `box_decl_local_cell`) boxes the Any seed into a shared cell
+      exactly like the old Nil seed (cross-thread reassignment visibility); (c) the `CallFunc`
+      interpreter-carrier branch gained the same carrier writeback `ExecCall` already had (an
+      `EVAL` under `try` writes caller lexicals by name; the Nil-slot env fallback used to mask
+      the missing writeback); (d) `(my $x) does Int` stays `X::Does::TypeObject` (Any/Mu are
+      type objects even though they sit in the class registry); (e) `.Hash` on the Any type
+      object is `{}` like the old Nil arm. Pin: `t/uninit-scalar-any.t` (18 tests, raku-verified).
+      **Full `t/` (2321 files, 21932 tests) passes with the crutch disabled.**
+- **Remaining steps:** 4 (remove the eqv crutch LAST; also lets `Nil.^name`/`Nil === Any`
+      divergences close — nil.t/identity.t/delete.t and full `t/` already pass crutch-off as of
+      step 3), then re-check `.cache` on a holey Array (returns a List today, raku returns the
+      Array itself — noticed during step 1, unrelated).
+- **Step-4 prerequisite found 2026-07-23:** an **unpassed optional parameter** (`sub w($p?)`)
+      still seeds Nil — visible as `$p.raku` = `Nil` (raku: `Any`; pointy blocks: `Mu`). `===`/
+      `.^name` are crutch-masked today, so step 4 would surface it. Param binding is spread
+      across the light/typed/named/method dispatch paths, so it is its own slice.
+- **Cost/benefit** (for the remaining step 4): payoff is closing the `Nil.^name`/`Nil === Any`
+      divergences and deleting the last band-aid. Related: §6 (dual-store / lexical slot),
+      [`array-hole-tracking-embedded`], [ADR-0001] container-repr.
 
 ### 8.6 `.WHO`/`.HOW` render without their metamodel detail — mostly done; internals leftover
 

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -214,6 +214,16 @@ impl Compiler {
                         // An uninitialized `&`-sigil var (`(my &)` / `(my &foo)`)
                         // defaults to the Callable type object, not Any/Nil.
                         self.compile_expr(&Expr::BareWord("Callable".to_string()));
+                    } else if Self::uninit_untyped_scalar_defaults_to_any(
+                        name,
+                        expr,
+                        type_constraint.as_deref(),
+                        custom_traits,
+                    ) {
+                        // Expression-position uninitialized untyped scalar
+                        // (`(my $x)`, `(my $)`, do-block value): seed and yield
+                        // the Any type object (PLAN 8.5 step 3).
+                        self.compile_expr(&Self::any_type_object_expr());
                     } else {
                         self.compile_expr(expr);
                     }

--- a/src/compiler/helpers_ast_utils.rs
+++ b/src/compiler/helpers_ast_utils.rs
@@ -5,6 +5,41 @@ impl Compiler {
         matches!(expr, Expr::DoStmt(s) if matches!(s.as_ref(), Stmt::VarDecl { .. }))
     }
 
+    /// An uninitialized untyped `$` scalar declaration (`my $x;`) seeds the
+    /// Any type object, not Nil (PLAN 8.5 step 3). The substitution happens
+    /// only at RHS-emission time: the AST keeps the synthesized
+    /// `Literal(Nil)` so every default-init recognition site (redeclaration
+    /// no-op, shadow-slot capture, block-inline, do-expr value) still
+    /// matches. `$/`/`$!` stay Nil per S02-types/nil.t; `is default(...)`
+    /// decls keep the Nil seed so the trailing ApplyVarTrait replaces it
+    /// with the default; `:=` binds and explicit `= Nil` initializers keep
+    /// their own paths.
+    pub(super) fn uninit_untyped_scalar_defaults_to_any(
+        name: &str,
+        expr: &Expr,
+        type_constraint: Option<&str>,
+        custom_traits: &[(String, Option<Expr>)],
+    ) -> bool {
+        !name.starts_with('@')
+            && !name.starts_with('%')
+            && !name.starts_with('&')
+            && name != "/"
+            && name != "!"
+            && name != "$/"
+            && name != "$!"
+            && type_constraint.is_none()
+            && matches!(expr, Expr::Literal(lit) if lit.is_nil())
+            && !custom_traits
+                .iter()
+                .any(|(t, _)| t == "__has_initializer" || t == "__scalar_bind" || t == "default")
+    }
+
+    /// The `Any` type-object literal seeded by
+    /// `uninit_untyped_scalar_defaults_to_any` sites.
+    pub(super) fn any_type_object_expr() -> Expr {
+        Expr::Literal(Value::package(crate::symbol::Symbol::intern("Any")))
+    }
+
     /// Check if a method call is a known mutating method on an indexed target
     /// (e.g., `%hash<key>.push(4)` or `@array[0].push(5)`).
     pub(super) fn is_mutating_method_on_index(

--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -236,7 +236,19 @@ impl Compiler {
                             let slot = self.declare_local(name);
                             self.code.emit(OpCode::SetLocal(slot));
                         } else {
-                            self.compile_expr(expr);
+                            if Self::uninit_untyped_scalar_defaults_to_any(
+                                name,
+                                expr,
+                                type_constraint.as_deref(),
+                                custom_traits,
+                            ) {
+                                // Block-final uninitialized untyped scalar:
+                                // seed and yield the Any type object
+                                // (PLAN 8.5 step 3).
+                                self.compile_expr(&Self::any_type_object_expr());
+                            } else {
+                                self.compile_expr(expr);
+                            }
                             // Enforce a scalar type constraint here too, so a
                             // block-final `my Str $x := 3` raises
                             // X::TypeCheck::Binding instead of silently storing

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1130,6 +1130,10 @@ impl Compiler {
                     // An uninitialized `&`-sigil variable (`my &foo;` / `my &;`)
                     // defaults to the `Callable` type object, not Any/Nil.
                     let callable_default = Expr::BareWord("Callable".to_string());
+                    // An uninitialized untyped `$` scalar (`my $x;`) holds the
+                    // Any type object, not Nil (PLAN 8.5 step 3) — see
+                    // `uninit_untyped_scalar_defaults_to_any`.
+                    let any_default = Self::any_type_object_expr();
                     let rhs_expr = if has_default_trait
                         && !name.starts_with('@')
                         && !name.starts_with('%')
@@ -1146,6 +1150,13 @@ impl Compiler {
                         // would trip the value type-check. Only default to Callable
                         // for the unconstrained `my &a` / `my &`.
                         &callable_default
+                    } else if Self::uninit_untyped_scalar_defaults_to_any(
+                        name,
+                        expr,
+                        type_constraint.as_deref(),
+                        custom_traits,
+                    ) {
+                        &any_default
                     } else {
                         expr
                     };

--- a/src/runtime/methods_dispatch_match2.rs
+++ b/src/runtime/methods_dispatch_match2.rs
@@ -116,6 +116,12 @@ impl Interpreter {
                 self.dispatch_setty_baggy_mixy(&target, method)
             }
             "Map" | "Hash" if args.is_empty() => {
+                // `.Hash` on the Any type object — notably an uninitialized
+                // `my $d` (PLAN 8.5 step 3 seeds Any) — is the empty hash,
+                // exactly like the Nil arm below.
+                if method == "Hash" && target.is_any_type_object() {
+                    return Some(Ok(Value::hash(std::collections::HashMap::new())));
+                }
                 if matches!(target.view(), ValueView::Package(_)) {
                     return Some(Ok(Value::package(Symbol::intern(method))));
                 }

--- a/src/value/view.rs
+++ b/src/value/view.rs
@@ -530,6 +530,15 @@ impl Value {
         self.0.is_nil()
     }
 
+    /// Whether this is the `Any` type object (`Package("Any")`) — notably the
+    /// value an uninitialized untyped scalar declaration seeds (PLAN 8.5
+    /// step 3), which container-identity heuristics must treat like the old
+    /// Nil seed (two distinct uninitialized scalars are not `=:=`).
+    #[inline]
+    pub fn is_any_type_object(&self) -> bool {
+        matches!(self.view(), ValueView::Package(sym) if sym.as_str() == "Any")
+    }
+
     // ---- consuming extractors (move the payload out) ----
 
     /// The backing store and kind if this is exactly an `Array`, consuming

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1345,7 +1345,19 @@ impl Interpreter {
                         crate::vm::vm_stats::record_function_fallback(name);
                     }
                     self.set_pending_call_arg_sources(arg_sources);
+                    // Carrier writeback (mirrors `exec_exec_call_op`): an
+                    // interpreter carrier like `EVAL` writes caller lexicals
+                    // into env BY NAME; drain those writes into this frame's
+                    // slots so a subsequent slot read sees them. Previously
+                    // masked by the Nil-slot env fallback: an uninitialized
+                    // caller scalar's slot stayed Nil, so reads fell back to
+                    // env. With the Any seed (PLAN 8.5 step 3) the slot holds
+                    // a real value, so the writeback must be explicit
+                    // (t/require-expression.t `BEGIN try EVAL`).
+                    let carrier_saved = self.begin_carrier();
                     let result = self.vm_call_function(name, args);
+                    let written = self.end_carrier(carrier_saved);
+                    self.writeback_carrier_writes(code, &written);
                     self.set_pending_call_arg_sources(None);
                     // Interpreter function calls (e.g. `require`) may register
                     // new subs — invalidate function resolution caches.

--- a/src/vm/vm_comparison_container_ops.rs
+++ b/src/vm/vm_comparison_container_ops.rs
@@ -33,6 +33,10 @@ impl Interpreter {
     ///
     /// Note: `Package` is NOT included because type objects are singletons —
     /// two variables holding the same Package should be considered `=:=`.
+    /// The sole exception is the `Any` type object: it is the seed of every
+    /// uninitialized untyped scalar (PLAN 8.5 step 3), so a fresh container
+    /// holding it must not compare identical to another Any-holding read —
+    /// exactly how the old Nil seed behaved on this path.
     /// `Nil` IS included: two *variable/element reads* both yielding Nil are
     /// distinct containers (uninitialized scalars store Nil pre-PLAN-8.5-step-3),
     /// so they must not compare identical. The `X =:= Nil` literal form is
@@ -40,6 +44,9 @@ impl Interpreter {
     /// which routes to `values_identical` where Nil == Nil holds.
     fn is_value_non_reference(left: &Value, right: &Value) -> bool {
         fn is_non_ref(v: &Value) -> bool {
+            if v.is_any_type_object() {
+                return true;
+            }
             matches!(
                 v.view(),
                 ValueView::Int(_)
@@ -94,7 +101,14 @@ impl Interpreter {
             // Instance values (user objects) are NOT singletons: assignment
             // copies the reference but creates a new container, so =:= is False.
             match (left.view(), right.view()) {
-                (ValueView::Package(a), ValueView::Package(b)) => a == b,
+                // The Any type object is excluded from the Package-singleton
+                // shortcut: it is the seed of every uninitialized untyped
+                // scalar (PLAN 8.5 step 3), so two distinct uninitialized
+                // containers would otherwise wrongly compare identical
+                // (S03-operators/identity.t "basic sanity"). The cost — a
+                // rare `my $a := Any; my $b := Any` pair no longer comparing
+                // True — mirrors how the old Nil seed behaved here.
+                (ValueView::Package(a), ValueView::Package(b)) => a == b && a.as_str() != "Any",
                 (ValueView::Sub(a), ValueView::Sub(b)) => crate::gc::Gc::ptr_eq(&a, &b),
                 (ValueView::WeakSub(a), ValueView::WeakSub(b)) => crate::gc::WeakGc::ptr_eq(&a, &b),
                 _ => false,

--- a/src/vm/vm_comparison_container_ops.rs
+++ b/src/vm/vm_comparison_container_ops.rs
@@ -215,6 +215,12 @@ impl Interpreter {
         let b_ref = Self::extract_hash_ref(b);
         if let (Some((a_arc, a_key)), Some((b_arc, b_key))) = (a_ref, b_ref) {
             crate::gc::Gc::ptr_eq(&a_arc, &b_arc) && a_key == b_key
+        } else if a.is_any_type_object() && b.is_any_type_object() {
+            // Two raw container reads that both hold the Any type object (the
+            // uninitialized-scalar seed, PLAN 8.5 step 3) are distinct
+            // containers — `[$foo][0] =:= $foo` with an uninit `$foo` is
+            // False (S02-types/array_ref.t 45), matching the old Nil seed.
+            false
         } else {
             // Both are the same value identity (for non-hash-ref cases)
             crate::runtime::values_identical(a, b)

--- a/src/vm/vm_mixin_does_ops.rs
+++ b/src/vm/vm_mixin_does_ops.rs
@@ -191,7 +191,12 @@ impl Interpreter {
             ValueView::Nil => Some("Any".to_string()),
             ValueView::Package(name) => {
                 let n = name.resolve();
-                if self.has_class(&n) {
+                // `Any`/`Mu` sit in the class registry but are the
+                // undefined-scalar type objects — an uninitialized `my $x`
+                // holds the Any type object (PLAN 8.5 step 3), and
+                // `(my $x) does Int` must stay X::Does::TypeObject exactly
+                // like the old Nil seed did via the arm above.
+                if n != "Any" && n != "Mu" && self.has_class(&n) {
                     None
                 } else {
                     Some(n.to_string())

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -666,15 +666,21 @@ impl Interpreter {
             }
             // Only box plain scalar containers. Reference types share already;
             // type objects / proxies must not be hidden behind a ContainerRef.
-            if matches!(
-                cur.view(),
-                ValueView::Package(_)
-                    | ValueView::Array(..)
-                    | ValueView::Hash(..)
-                    | ValueView::Sub(..)
-                    | ValueView::Instance { .. }
-                    | ValueView::Proxy { .. }
-            ) {
+            // EXCEPTION: the Any type object is the uninitialized-scalar seed
+            // (PLAN 8.5 step 3) — box it exactly like the old Nil seed, so a
+            // captured-then-reassigned lexical stays a shared cell
+            // (t/then-captured-lexical-cross-thread.t).
+            if !cur.is_any_type_object()
+                && matches!(
+                    cur.view(),
+                    ValueView::Package(_)
+                        | ValueView::Array(..)
+                        | ValueView::Hash(..)
+                        | ValueView::Sub(..)
+                        | ValueView::Instance { .. }
+                        | ValueView::Proxy { .. }
+                )
+            {
                 continue;
             }
             let container = cur.clone().into_container_ref();

--- a/src/vm/vm_set_ops.rs
+++ b/src/vm/vm_set_ops.rs
@@ -273,6 +273,14 @@ impl Interpreter {
                 }
             }
             _ => {
+                // The Any type object is the uninitialized-scalar seed
+                // (PLAN 8.5 step 3): like the old Nil seed (whose empty
+                // stringification skipped insertion), it contributes no
+                // element — `my $s; $s ∪= 0` unions from the empty set
+                // (S04-phasers/enter-leave.t 32).
+                if value.is_any_type_object() {
+                    return;
+                }
                 let sv = value.to_string_value();
                 if !sv.is_empty() {
                     elems.insert(sv);
@@ -320,9 +328,13 @@ impl Interpreter {
             }
             _ => {
                 let mut elems = HashSet::new();
-                let sv = value.to_string_value();
-                if !sv.is_empty() {
-                    elems.insert(sv);
+                // Any type object = uninitialized-scalar seed → empty set,
+                // like the old Nil seed (see union_insert_set_elem).
+                if !value.is_any_type_object() {
+                    let sv = value.to_string_value();
+                    if !sv.is_empty() {
+                        elems.insert(sv);
+                    }
                 }
                 Ok(elems)
             }

--- a/src/vm/vm_var_assign_local_get.rs
+++ b/src/vm/vm_var_assign_local_get.rs
@@ -282,15 +282,20 @@ impl Interpreter {
         if self.locals[idx].is_container_ref() {
             return;
         }
-        if matches!(
-            self.locals[idx].view(),
-            ValueView::Package(_)
-                | ValueView::Array(..)
-                | ValueView::Hash(..)
-                | ValueView::Sub(..)
-                | ValueView::Instance { .. }
-                | ValueView::Proxy { .. }
-        ) {
+        // The Any type object (uninitialized-scalar seed, PLAN 8.5 step 3) is
+        // boxed like the old Nil seed; other reference/identity-bearing values
+        // are skipped (mirrors `box_captured_lexicals`).
+        if !self.locals[idx].is_any_type_object()
+            && matches!(
+                self.locals[idx].view(),
+                ValueView::Package(_)
+                    | ValueView::Array(..)
+                    | ValueView::Hash(..)
+                    | ValueView::Sub(..)
+                    | ValueView::Instance { .. }
+                    | ValueView::Proxy { .. }
+            )
+        {
             return;
         }
         if loan_env!(self, var_type_constraint(name)).is_some()

--- a/t/uninit-scalar-any.t
+++ b/t/uninit-scalar-any.t
@@ -1,0 +1,57 @@
+use Test;
+
+# PLAN 8.5 step 3: an uninitialized untyped `my $x` holds the Any type
+# object (not Nil), matching Rakudo. The AST keeps the synthesized
+# Literal(Nil) marker; the compiler substitutes the Any type object at
+# RHS-emission time only (statement, expression, and block-final
+# positions), so `$/`/`$!` and `:=` binds keep their Nil semantics.
+
+plan 18;
+
+my $x;
+is $x.raku, 'Any', 'uninit my $x .raku is Any';
+is $x.^name, 'Any', 'uninit my $x .^name is Any';
+is $x.gist, '(Any)', 'uninit my $x gist is (Any)';
+ok $x === Any, 'uninit my $x === Any';
+nok $x.defined, 'uninit my $x is undefined';
+
+is (my $y).raku, 'Any', 'expression-position (my $y) yields Any';
+is (do { my $z }).raku, 'Any', 'do-block value of bare decl is Any';
+sub f { my $v }
+is f().raku, 'Any', 'block-final bare decl returns Any';
+
+my ($a, $b);
+is $a.raku, 'Any', 'comma-chained decl seeds Any';
+nok $a =:= $b, 'two distinct uninit scalars are not =:=';
+
+state $s;
+is $s.raku, 'Any', 'uninit state scalar is Any';
+
+my $bound := Nil;
+ok $bound === Nil, ':= Nil bind keeps Nil';
+
+my Int $t;
+is $t.raku, 'Int', 'typed uninit scalar keeps its type object';
+
+my &c;
+is &c.raku, 'Callable', 'uninit &-sigil var keeps Callable';
+
+my $d is default(42);
+is $d, 42, 'is default(...) decl gets its default, not Any';
+
+# Closure capture of an uninitialized lexical stays a live view: a later
+# parent reassignment is observed (shared-cell semantics).
+my $gate;
+my $c2 = -> { $gate.defined ?? 'def' !! 'undef' };
+$gate = 1;
+is $c2(), 'def', 'closure over uninit lexical sees later assignment';
+
+# Assigning Nil to an initialized var resets the container to Any again.
+my $r = 5;
+$r = Nil;
+is $r.raku, 'Any', 'assigning Nil resets to Any';
+
+# for-loop body redeclaration stays fresh each iteration.
+my @seen;
+for 1..2 { my $i; @seen.push($i.raku); $i = 9 }
+is @seen.join(','), 'Any,Any', 'loop-body bare decl reseeds Any per iteration';


### PR DESCRIPTION
## Summary

PLAN 8.5 (Nil-vs-Any identity knot) **step 3** — the proven-hard compiler knot. An uninitialized untyped scalar declaration (`my $x;`) now seeds the **Any type object** instead of Nil, matching Rakudo:

| expr | before | after (= raku) |
|---|---|---|
| `my $x; $x.raku` | `Nil` | `Any` |
| `say $x` | `Nil` | `(Any)` |
| `(my $y).raku` / `do { my $z }` / block-final `my $v` | `Nil` | `Any` |
| `state $s; $s.raku` | `Nil` | `Any` |

## Approach (third way — not the two that failed on 2026-07-20)

The AST **keeps the synthesized `Literal(Nil)`** default, so all 6+ compiler default-init recognition sites (redeclaration no-op, shadow-slot capture, block-inline, do-expr value, `&`-sigil Callable substitution) stay intact. The compiler substitutes the Any type object **only at RHS-emission time**, in the three emit sites (`compiler/stmt.rs`, `compiler/expr_block.rs`, `compiler/helpers_block_inline.rs`) via the shared predicate `uninit_untyped_scalar_defaults_to_any`. `$/`/`$!` stay Nil (S02-types/nil.t); `is default(...)`, `:=` binds, and explicit initializers keep their existing paths.

- parser-BareWord (rejected 2026-07-20): rewrote the AST → broke the recognition sites.
- store-reset (rejected 2026-07-20): reset cells at runtime → disrupted closure capture + index panic.

## VM knock-ons fixed in the same slice

- **`=:=`**: the Package-singleton shortcuts must not treat two Any-holding container reads as identical (identity.t "basic sanity" / subparam rebinding). `ContainerEqNamed` excludes the Any type object from its Package arm; `is_value_non_reference` includes it — both mirroring the old Nil-seed behavior exactly.
- **Closure-capture boxing** (`box_captured_lexicals` / `box_decl_local_cell`): the Any seed is boxed into a shared `ContainerRef` cell like the old Nil seed, so a captured-then-reassigned lexical stays live across threads (`t/then-captured-lexical-cross-thread.t`).
- **`CallFunc` carrier writeback**: an `EVAL` under `try` writes caller lexicals into env by name; the old Nil-slot env fallback masked the missing slot writeback that `ExecCall` already performed (`t/require-expression.t` `BEGIN try EVAL`).
- **`does`**: `(my $x) does Int` stays `X::Does::TypeObject` — Any/Mu sit in the class registry but are type objects for does-invocant purposes.
- **`.Hash`** on the Any type object is `{}`, like the old Nil arm.

## Validation

- Pin: `t/uninit-scalar-any.t` (18 tests, verified against reference raku first).
- **Fault injection: the full `t/` suite (2321 files, 21932 tests) passes with the `types_eqv` Nil==Any crutch disabled**, and the roast guardrails (`S02-types/nil.t`, `S03-operators/identity.t`, `S32-array/delete.t`, MUTSU_FUDGE=1) pass crutch-off too. The crutch is left in place for this PR; removing it is step 4.
- `make test` green with the crutch restored.

## Remaining 8.5 work (recorded in PLAN.md)

- Step 4: remove the eqv crutch (also closes `Nil.^name` / `Nil === Any`).
- New prerequisite found: an unpassed optional parameter (`sub w($p?)`) still seeds Nil (`$p.raku` = `Nil`; raku `Any`, pointy blocks `Mu`) — its own slice across the param-binding paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)