### PR TITLE
fix: attribute `is` trait that adds a method via .^add_method (T-057 Attribute::Predicate)

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -639,7 +639,8 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 
 ### T-057 — test_die batch (seed-555, un-triaged)  [impact: several dists]
 - dists (each its own root cause; triage individually before claiming, confirm the
-  raku `-I lib` baseline first): Attribute::Predicate, File::Ignore,
+  raku `-I lib` baseline first): ~~Attribute::Predicate~~ (FIXED — see Done),
+  File::Ignore,
   IO::Path::AutoDecompress, Math::Angle, Math::PascalTriangle,
   ~~Statistics::LinearRegression~~ (FIXED — see Done), String::Rotate,
   Text::CodeProcessing, Trait::IO, WriteOnceHash, `are`, `sortuk`,
@@ -886,3 +887,35 @@ _(move tickets here with `[claim: <branch>]` when you start)_
   angle key. Trait::Env now parses; a follow-up cross-module private-sub
   false-redeclaration (`sub apply-trait` in two modules) and a missing JSON::Tiny
   dep still block full load — see `bug-cross-module-private-sub-redeclaration`.
+- **T-057 (Attribute::Predicate)** (#PENDING) — 0/4 → 4/4. The dist's `is
+  predicate` attribute trait (`multi sub trait_mod:<is>(Attribute:D \attr,
+  :$predicate!)`) builds `method { attr.get_value(self).defined }` and installs
+  it with `.^add_method`. Four general bugs on that path:
+  1. **A trait-added method was clobbered by class composition.** During class
+     registration the attribute trait's `.^add_method` writes straight into the
+     registry entry, but the local `class_def` (re-inserted at the end of body
+     processing) overwrote it. Merge registry methods not present locally after
+     `apply_attribute_traits`, mirroring the class_def re-sync already done after
+     `run_block_raw` (`registration_class_decl.rs`).
+  2. **An escaping closure did not capture sigilless bindings.** `\attr` /
+     `my \x` read from a nested closure compiled to a plain `GetBareWord` — fine
+     while the creating frame was live, but once it returned the bare name
+     degraded to the literal string (`{ thing }` returned `"thing"`). The
+     compiler now hands enclosing sigilless names down to nested closures
+     (`enclosing_sigilless`) and emits a by-name `GetGlobal` (recorded as a free
+     variable and captured) for them (`compiler/mod.rs`, `compiler/expr.rs`).
+  3. **The interpret dispatch path lost the signature's sigilless context.** The
+     multi/user-sub fallback compiles a body with a *fresh* `Compiler`, so a
+     nested closure there never saw `\attr` as a lexical. Seed the fresh
+     compiler's `enclosing_sigilless` from the routine's sigilless params via a
+     `pending_eval_sigilless` interpreter field (`builtins_operators_fallback.rs`,
+     `resolution_eval.rs`). `MethodDef` gained a `captured_env` carrying the
+     closure literal's frozen scope so a `.^add_method` method resolves its
+     captures at dispatch (`decl_types.rs`, `vm_method_dispatch.rs`,
+     `methods_classhow_dispatch.rs`).
+  4. **An angle-bracket trait argument was dropped.** `is predicate<bazzy>`
+     parsed as bare `is predicate` (Bool True) with `<bazzy>` leaking out as a
+     separate statement; the trait sub therefore never got the name. The
+     attribute-trait parser now consumes a `<...>` word-quote as the trait
+     argument (single word → Str, multiple → list) (`has_decl.rs`).
+  - Pin: `t/attribute-trait-adds-method.t`.

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -187,6 +187,19 @@ impl Compiler {
                         let name_idx = self.code.add_constant(Value::str(name.clone()));
                         self.code.emit(OpCode::GetBareWord(name_idx));
                     }
+                } else if self.enclosing_sigilless.contains(name.as_str())
+                    && !crate::runtime::Interpreter::is_builtin_type(name)
+                {
+                    // A sigilless binding (`\thing`, `my \x`) from an ENCLOSING
+                    // scope, read here from a nested — possibly escaping — closure.
+                    // It IS the variable, so emit a by-name global read: GetGlobal
+                    // is in `op_name_const_idx`, so `compute_free_vars` records it
+                    // as a free variable and the closure captures the enclosing
+                    // frame's slot value. A plain GetBareWord would not be captured
+                    // and would degrade to the literal string once the creating
+                    // frame returns (escaping closure / `.^add_method` method body).
+                    let name_idx = self.code.add_constant(Value::str(name.clone()));
+                    self.code.emit(OpCode::GetGlobal(name_idx));
                 } else {
                     let name_idx = self.code.add_constant(Value::str(name.clone()));
                     self.code.emit(OpCode::GetBareWord(name_idx));

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -217,6 +217,14 @@ pub(crate) struct Compiler {
     /// or as a sigilless parameter).  BareWord resolution only uses GetLocal
     /// for names in this set; `$`-sigiled variables must not shadow type names.
     sigilless_locals: std::collections::HashSet<String>,
+    /// Sigilless-binding names declared in an ENCLOSING compilation (the parent
+    /// sub/block's `sigilless_locals`, transitively). A BareWord naming one of
+    /// these — but not a local of the current frame — is a genuine lexical
+    /// capture, so it is compiled as a by-name global read (recorded as a free
+    /// variable and captured) rather than a plain `GetBareWord` that would
+    /// degrade to the literal name string once the creating frame is gone
+    /// (escaping closure / `.^add_method`).
+    enclosing_sigilless: std::collections::HashSet<String>,
     /// Set true immediately before compiling a *synthesized* `Stmt::Block`
     /// (an if/while/loop/control branch body the compiler wraps at compile time,
     /// not a genuine source `{ ... }`). The `Stmt::Block` arm consumes it to
@@ -320,6 +328,7 @@ impl Compiler {
             class_names_current_scope: std::collections::HashSet::new(),
             outer_constant_names: std::collections::HashSet::new(),
             sigilless_locals: std::collections::HashSet::new(),
+            enclosing_sigilless: std::collections::HashSet::new(),
             last_source_line: None,
             pending_index_rw_writebacks: Vec::new(),
             current_distribution: None,
@@ -505,8 +514,25 @@ impl Compiler {
 
     /// Hand a nested body's compiler the chain it is being compiled inside, so a
     /// symbolic deref in that body still sees the enclosing scopes.
+    /// Seed the enclosing-sigilless set from an interpret-path caller (the multi
+    /// / user-sub fallback), which compiles a routine body with a fresh compiler
+    /// that has no signature context. Without this, a nested closure in the body
+    /// would compile a bare reference to a `\thing` parameter as a bareword and
+    /// lose the capture. Public so `Interpreter::compile_block_value_opts` can
+    /// call it. No-op for the common empty case.
+    pub(crate) fn seed_enclosing_sigilless(&mut self, names: &[String]) {
+        self.enclosing_sigilless.extend(names.iter().cloned());
+    }
+
     fn inherit_enclosing_scopes(&self, sub: &mut Compiler) {
         sub.enclosing_scopes = self.full_scope_chain();
+        // Hand down every sigilless binding visible here (this frame's own plus
+        // the ones it inherited) so a nested closure recognizes a bare reference
+        // to an enclosing `\thing` / `my \x` as a lexical capture, not a bareword.
+        sub.enclosing_sigilless
+            .extend(self.sigilless_locals.iter().cloned());
+        sub.enclosing_sigilless
+            .extend(self.enclosing_sigilless.iter().cloned());
     }
 
     /// Bake the scope chain visible right here into the code chunk, and return

--- a/src/parser/stmt/decl/has_decl.rs
+++ b/src/parser/stmt/decl/has_decl.rs
@@ -575,6 +575,31 @@ pub(in crate::parser::stmt) fn has_decl(input: &str) -> PResult<'_, Stmt> {
                     rest = r2;
                     continue;
                 }
+                // `is predicate<bazzy>` — an angle-bracket word-quote argument
+                // (`:predicate<bazzy>` == `:predicate("bazzy")`). A single word
+                // becomes a Str; multiple words become a list of Str. Without
+                // this the `<bazzy>` leaked out as a separate statement and the
+                // trait sub saw only the bare `:predicate` (Bool True).
+                if let Some(stripped) = r_ws.strip_prefix('<')
+                    && let Some(close) = stripped.find('>')
+                {
+                    let inner = stripped[..close].trim();
+                    let words: Vec<&str> = inner.split_whitespace().collect();
+                    let trait_arg = match words.as_slice() {
+                        [] => None,
+                        [one] => Some(Expr::Literal(Value::str_from(one))),
+                        many => Some(Expr::ArrayLiteral(
+                            many.iter()
+                                .map(|w| Expr::Literal(Value::str_from(w)))
+                                .collect(),
+                        )),
+                    };
+                    unknown_traits.push(("is".to_string(), trait_name.to_string(), trait_arg));
+                    rest = &stripped[close + 1..];
+                    let (r2, _) = ws(rest)?;
+                    rest = r2;
+                    continue;
+                }
                 unknown_traits.push(("is".to_string(), trait_name.to_string(), None));
             }
             let (r, _) = ws(r)?;

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -517,7 +517,20 @@ impl Interpreter {
                 self.set_current_package(fn_pkg);
             }
             self.prepare_definite_return_slot(return_spec.as_deref());
+            // Tell the fresh-compiler body path which parameters are sigilless
+            // (`\attr`) so a nested closure captures them by name instead of
+            // compiling a bare reference as a bareword (lost capture). Restored
+            // after the eval; a nested call sets and restores its own.
+            let saved_eval_sigilless = std::mem::replace(
+                &mut self.pending_eval_sigilless,
+                def.param_defs
+                    .iter()
+                    .filter(|pd| pd.sigilless && !pd.name.is_empty())
+                    .map(|pd| pd.name.clone())
+                    .collect(),
+            );
             let result = self.eval_block_value_with_pre_post(&def.body);
+            self.pending_eval_sigilless = saved_eval_sigilless;
             self.set_current_package(saved_package);
             self.routine_stack.pop();
             self.block_stack.pop();

--- a/src/runtime/decl_types.rs
+++ b/src/runtime/decl_types.rs
@@ -114,6 +114,16 @@ pub(crate) struct MethodDef {
     pub(crate) deprecated_message: Option<String>,
     /// Whether this is a submethod (not inherited by subclasses).
     pub(crate) is_submethod: bool,
+    /// Frozen closure environment for a method installed via `.^add_method`
+    /// with a closure literal (`method { $captured }`). A method AST normally
+    /// carries no captured lexicals, but a meta-programmed method can close over
+    /// its creating scope (e.g. Attribute::Predicate's `is predicate` builds
+    /// `method { attr.get_value(self).defined }`, capturing `attr`). Those
+    /// captures live only in the source `Sub`'s env, which the plain
+    /// body+compiled_code MethodDef would drop. When set, the method dispatch
+    /// merges these names into the body env (params/self take precedence) so a
+    /// by-name read resolves the capture. `None` for ordinary declared methods.
+    pub(crate) captured_env: Option<crate::env::Env>,
 }
 
 /// Invocant context for an active `proto method` `{*}` dispatch.

--- a/src/runtime/dispatch_proto.rs
+++ b/src/runtime/dispatch_proto.rs
@@ -264,6 +264,7 @@ impl Interpreter {
             is_default: false,
             deprecated_message: None,
             is_submethod: false,
+            captured_env: None,
         };
         let attributes = match invocant.view() {
             ValueView::Instance { attributes, .. } => attributes.as_map().clone(),

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -551,6 +551,15 @@ impl Interpreter {
                     is_default: false,
                     deprecated_message: None,
                     is_submethod: false,
+                    // Preserve the closure literal's captured scope so a method
+                    // like `method { attr.get_value(self) }` (Attribute::Predicate's
+                    // `is predicate`) can still resolve `attr` after its creating
+                    // sub returns. Only carried when the env actually holds captures.
+                    captured_env: if sub_data.env.is_empty() {
+                        None
+                    } else {
+                        Some(sub_data.env.clone())
+                    },
                 };
                 // If the class doesn't exist yet (e.g. built-in types like Rat, Int, Str),
                 // create a stub ClassDef so methods can be added dynamically.
@@ -616,6 +625,11 @@ impl Interpreter {
                     is_default: false,
                     deprecated_message: None,
                     is_submethod: false,
+                    captured_env: if sub_data.env.is_empty() {
+                        None
+                    } else {
+                        Some(sub_data.env.clone())
+                    },
                 };
                 let inserted =
                     if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -904,6 +904,15 @@ pub struct Interpreter {
     /// Used to propagate package declarations when a module is re-used.
     module_packages: HashMap<String, HashSet<String>>,
     closure_env_overrides: HashMap<u64, Env>,
+    /// Sigilless parameter names (`\attr`, `my \x`) of the routine whose body is
+    /// about to be compiled by the interpret path (`compile_block_value_opts`).
+    /// The multi/user-sub fallback runs a body via a *fresh* `Compiler`, which
+    /// otherwise would not know these bare names are lexical variables — so a
+    /// nested closure would compile them as barewords and lose the capture
+    /// (e.g. Attribute::Predicate's `is predicate` builds `method {
+    /// attr.get_value(self) }`). Seeded right before the eval and consumed by the
+    /// fresh compiler's `enclosing_sigilless`. Empty except across that call.
+    pending_eval_sigilless: Vec<String>,
     /// PredictiveIterator backing a `Seq.new(iterator)`, keyed by the Seq's
     /// Arc pointer (`seq_id`). Kept off the scoped `env` so the association
     /// survives sub/block returns between Seq creation and `.tail`/`.Numeric`

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -144,6 +144,7 @@ pub(super) fn make_delegation_method(attr_var_name: &str, target_method: &str) -
         is_default: false,
         deprecated_message: None,
         is_submethod: false,
+        captured_env: None,
     }
 }
 
@@ -284,6 +285,7 @@ pub(super) fn substitute_type_params_in_method(
         is_default: method.is_default,
         deprecated_message: method.deprecated_message.clone(),
         is_submethod: method.is_submethod,
+        captured_env: None,
     }
 }
 

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -225,6 +225,7 @@ impl Interpreter {
                         is_default: *is_default_candidate,
                         deprecated_message: None,
                         is_submethod: *is_submethod,
+                        captured_env: None,
                     };
                     if let Some(class_def) = self.registry_mut().classes.get_mut(name) {
                         if *multi {

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -1446,19 +1446,38 @@ impl Interpreter {
                     // to it with an Attribute introspection object; otherwise raise
                     // X::Comp::Trait::Unknown. Kept in a separate method so its
                     // locals don't inflate this already-large function's frame.
-                    if !unknown_traits.is_empty()
-                        && let Err(err) = self.apply_attribute_traits(
+                    if !unknown_traits.is_empty() {
+                        if let Err(err) = self.apply_attribute_traits(
                             unknown_traits,
                             &attr_name_str,
                             *sigil,
                             *is_public,
                             name,
                             type_constraint.as_deref(),
-                        )
-                    {
-                        self.set_current_package(saved_package);
-                        self.env = saved_env;
-                        return Err(err);
+                        ) {
+                            self.set_current_package(saved_package);
+                            self.env = saved_env;
+                            return Err(err);
+                        }
+                        // A user-defined `trait_mod:<is>` may have called
+                        // `.^add_method` on the class currently being composed
+                        // (e.g. Attribute::Predicate's `is predicate` adds a
+                        // `has-foo` accessor). Those methods land directly in the
+                        // registry entry, but the local `class_def` — re-inserted
+                        // at the end of body processing — would clobber them.
+                        // Merge any registry methods not already present locally,
+                        // mirroring the class_def re-sync done after run_block_raw.
+                        if let Some(reg_cd) = self.registry().classes.get(name) {
+                            let added: Vec<(String, Vec<MethodDef>)> = reg_cd
+                                .methods
+                                .iter()
+                                .filter(|(mname, _)| !class_def.methods.contains_key(*mname))
+                                .map(|(mname, mdefs)| (mname.clone(), mdefs.clone()))
+                                .collect();
+                            for (mname, mdefs) in added {
+                                class_def.methods.insert(mname, mdefs);
+                            }
+                        }
                     }
 
                     // Handle class-level attributes (our $.x / my $.x)
@@ -1737,6 +1756,7 @@ impl Interpreter {
                         is_default: *is_default_candidate,
                         deprecated_message: deprecated_message.clone(),
                         is_submethod: *is_submethod,
+                        captured_env: None,
                     };
                     // `my method` and `our method` are NOT part of the class
                     // method table — they are only callable as functions.

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -987,6 +987,7 @@ impl Interpreter {
                         is_default: *is_default_candidate,
                         deprecated_message: None,
                         is_submethod: *is_submethod,
+                        captured_env: None,
                     };
                     // `my method` in roles are role-private, skip method table.
                     // Submethods (is_submethod) DO get composed even though

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -107,6 +107,10 @@ impl Interpreter {
         }
         compiler.is_routine = !self.routine_stack.is_empty();
         compiler.lexically_in_routine = !self.routine_stack.is_empty();
+        // Let a nested closure in this body recognize the enclosing routine's
+        // sigilless parameters (`\attr`) as lexical captures rather than
+        // barewords. The fresh compiler otherwise has no signature context.
+        compiler.seed_enclosing_sigilless(&self.pending_eval_sigilless);
         let scope = if let Some(frame) = self.routine_stack.last() {
             // Set enclosing_package to the clean package name so that
             // $?PACKAGE resolves to the package, not the mangled routine

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1963,6 +1963,7 @@ impl Interpreter {
                             is_default: false,
                             deprecated_message: None,
                             is_submethod: false,
+                            captured_env: None,
                         };
                         let mut methods = HashMap::new();
                         // Rakudo's CompUnit::Repository role requires exactly
@@ -2016,6 +2017,7 @@ impl Interpreter {
                             is_default: false,
                             deprecated_message: None,
                             is_submethod: false,
+                            captured_env: None,
                         };
                         let mut methods = HashMap::new();
                         for name in ["meta", "content"] {
@@ -2060,6 +2062,7 @@ impl Interpreter {
             chain_declared_packages: HashSet::new(),
             module_packages: HashMap::new(),
             closure_env_overrides: HashMap::new(),
+            pending_eval_sigilless: Vec::new(),
             predictive_seq_iters: HashMap::new(),
             protect_block_cache: HashMap::new(),
             subset_predicate_cache: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -229,6 +229,7 @@ impl Interpreter {
             chain_declared_packages: self.chain_declared_packages.clone(),
             module_packages: self.module_packages.clone(),
             closure_env_overrides: self.closure_env_overrides.clone(),
+            pending_eval_sigilless: Vec::new(),
             predictive_seq_iters: self.predictive_seq_iters.clone(),
             protect_block_cache: HashMap::new(),
             subset_predicate_cache: HashMap::new(),

--- a/src/runtime/system.rs
+++ b/src/runtime/system.rs
@@ -245,6 +245,7 @@ impl Interpreter {
                     is_default: *is_default_candidate,
                     deprecated_message: deprecated_message.clone(),
                     is_submethod: false,
+                    captured_env: None,
                 };
                 if let Some(class_def) = self.registry_mut().classes.get_mut(&class_name) {
                     if *multi {

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1237,6 +1237,20 @@ impl Interpreter {
         // owner class declared statics.
         self.inject_class_body_statics(owner_class);
 
+        // A method installed via `.^add_method` with a closure literal
+        // (`method { $captured }`) carries the frozen creating-scope env so its
+        // captures still resolve after that scope is gone. Merge those names in
+        // (params/self/attrs inserted above win) so the locals-population loop
+        // below picks them up via its by-name `self.env().get(name)` fallback.
+        if let Some(captured) = &method_def.captured_env {
+            let env = self.env_mut();
+            for (sym, val) in captured.iter() {
+                if !env.contains_key_sym(*sym) {
+                    env.insert_sym(*sym, val.clone());
+                }
+            }
+        }
+
         // Raku: routine parameters are read-only by default (`method m($x) { $x = 5 }`
         // dies). The slow path does this in `bind_function_args_values`; the fast
         // path binds params directly, so mark `$` scalar params read-only here.

--- a/t/attribute-trait-adds-method.t
+++ b/t/attribute-trait-adds-method.t
@@ -1,0 +1,53 @@
+use Test;
+
+# A user-defined `trait_mod:<is>` on an attribute may call `.^add_method` with a
+# closure that captures the trait sub's lexicals (e.g. the Attribute meta-object
+# and the sigilless `\attr` parameter). Three things must hold for this to work,
+# exercised together here (the Attribute::Predicate dist pattern):
+#   1. The method the trait added must survive class composition (the local
+#      class_def re-insert must not clobber the registry method).
+#   2. A closure that escapes its creating sub must capture sigilless variables
+#      (`\attr`) by value, not degrade the bare reference into a string.
+#   3. An angle-bracket trait argument (`is predicate<bazzy>`) must reach the
+#      trait sub as the named argument's value, not leak out as a statement.
+
+plan 8;
+
+multi sub trait_mod:<is>(Attribute:D \attr, :$predicate!) {
+    my $name := $predicate ~~ Bool
+      ?? "has-{attr.name.substr(2)}"
+      !! $predicate.Str;
+    my $method := method { attr.get_value(self).defined }
+    $method.set_name($name);
+    attr.package.^add_method($name, $method);
+}
+
+class A {
+    has $.a is predicate;
+    has $.b is predicate<bazzy>;
+}
+
+my $x = A.new(a => 42);
+ok  $x.has-a,  'bare `is predicate` adds has-<name>, true when set';
+nok $x.bazzy,  'named `is predicate<bazzy>` adds `bazzy`, false when unset';
+
+my $y = A.new(b => 666);
+nok $y.has-a,  'has-a false when a unset';
+ok  $y.bazzy,  'bazzy true when b set';
+
+# --- Isolated: escaping closure captures a sigilless binding ---
+sub make-getter(\thing) { return { thing } }
+is make-getter(42)(),  42, 'escaping closure captures sigilless \thing (int)';
+is make-getter('hi')(), 'hi', 'escaping closure captures sigilless \thing (str)';
+
+# --- Isolated: add_method with a closure capturing a sub-local ---
+class B { }
+sub install($cls, $val) { $cls.^add_method('grab', method { $val }) }
+install(B, 'captured');
+is B.new.grab, 'captured', '.^add_method closure keeps its captured lexical';
+
+# --- Isolated: multi-word angle-bracket trait arg ---
+my @seen;
+multi sub trait_mod:<is>(Attribute:D \attr, :$tag!) { @seen = $tag.list }
+class C { has $.c is tag<x y z>; }
+is-deeply @seen, ['x', 'y', 'z'], 'multi-word `is tag<x y z>` passes a list';


### PR DESCRIPTION
Attribute::Predicate's `is predicate` attribute trait
(`multi sub trait_mod:<is>(Attribute:D \attr, :$predicate!)`) builds
`method { attr.get_value(self).defined }` and installs it with `.^add_method`.
Four general bugs on that path, taking the dist from **0/4 to 4/4**:

1. **A trait-added method was clobbered by class composition.** The attribute
   trait's `.^add_method` writes into the registry entry, but the local
   `class_def` re-inserted at the end of body processing overwrote it. Merge
   registry methods not present locally after `apply_attribute_traits`,
   mirroring the class_def re-sync already done after `run_block_raw`.

2. **An escaping closure did not capture sigilless bindings.** `\attr` /
   `my \x` read from a nested closure compiled to a plain `GetBareWord`, which
   degraded to the literal name string once the creating frame returned
   (`{ thing }` returned `"thing"`). The compiler now hands enclosing sigilless
   names down to nested closures (`enclosing_sigilless`) and emits a by-name
   `GetGlobal` (recorded as a free variable and captured) for them.

3. **The interpret dispatch path lost the signature's sigilless context.** The
   multi/user-sub fallback compiles a body with a fresh `Compiler`, so a nested
   closure there never saw `\attr` as a lexical. Seed the fresh compiler's
   `enclosing_sigilless` from the routine's sigilless params via a
   `pending_eval_sigilless` interpreter field. `MethodDef` gained a
   `captured_env` carrying the closure literal's frozen scope so a `.^add_method`
   method resolves its captures at dispatch.

4. **An angle-bracket trait argument was dropped.** `is predicate<bazzy>` parsed
   as bare `is predicate` (Bool True) with `<bazzy>` leaking out as a separate
   statement. The attribute-trait parser now consumes a `<...>` word-quote as
   the trait argument (single word → Str, multiple → list).

Pin: `t/attribute-trait-adds-method.t` (8 subtests, verified against raku).
`make test` PASS (21982 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)