### PR TITLE
fix: list-infix Z/X/meta-op is looser than comma in no-paren builtin-listop call args

### DIFF
--- a/src/compiler/expr_ops.rs
+++ b/src/compiler/expr_ops.rs
@@ -525,12 +525,21 @@ impl Compiler {
         // chain of identical (meta, op) MetaOps into one flat operand list and
         // emit a single n-ary op. Only the plain general op reaches here; the
         // special short-circuit ops above return early, so they never chain.
+        // `=:=`/`!=:=` compare container identity, so an operand list of scalar
+        // variables (`($a,$b) X=:= ($c,$d)`) must preserve each element's
+        // container (raku Lists retain element containers). Compile such
+        // operands ref-preserving so the runtime sees `ContainerRef`s.
+        let is_identity_op = op == "=:=" || op == "!=:=";
         if meta == "X" || meta == "Z" {
             let mut operands: Vec<&Expr> = Vec::new();
             Self::collect_meta_chain(meta, op, left, right, &mut operands);
             if operands.len() > 2 {
                 for operand in &operands {
-                    self.compile_expr(operand);
+                    if is_identity_op {
+                        self.compile_meta_identity_operand(operand);
+                    } else {
+                        self.compile_expr(operand);
+                    }
                 }
                 let meta_idx = self.code.add_constant(Value::str(meta.to_string()));
                 let op_idx = self.code.add_constant(Value::str(op.to_string()));
@@ -542,11 +551,49 @@ impl Compiler {
                 return;
             }
         }
-        self.compile_expr(left);
-        self.compile_expr(right);
+        if is_identity_op && (meta == "X" || meta == "Z") {
+            self.compile_meta_identity_operand(left);
+            self.compile_meta_identity_operand(right);
+        } else {
+            self.compile_expr(left);
+            self.compile_expr(right);
+        }
         let meta_idx = self.code.add_constant(Value::str(meta.to_string()));
         let op_idx = self.code.add_constant(Value::str(op.to_string()));
         self.code.emit(OpCode::MetaOp { meta_idx, op_idx });
+    }
+
+    /// Compile a cross/zip meta-op operand for a container-identity op
+    /// (`=:=`/`!=:=`), preserving each scalar-var element's container so the
+    /// runtime compares container identity rather than value. A list literal
+    /// (`($a,$b)`) tags each scalar-var element with `WrapVarRef` (instead of
+    /// `Itemize`, which would decontainerize it); a bare scalar var operand is
+    /// wrapped directly. Everything else compiles normally.
+    fn compile_meta_identity_operand(&mut self, operand: &Expr) {
+        match operand {
+            Expr::ArrayLiteral(elems) => {
+                self.with_escape(true, |c| {
+                    for elem in elems {
+                        c.compile_expr(elem);
+                        if let Expr::Var(name) = elem
+                            && !name.contains("::")
+                        {
+                            let name_idx = c.code.add_constant(Value::str(name.clone()));
+                            c.code.emit(OpCode::WrapVarRef(name_idx));
+                        } else if Self::expr_is_scalar_var(elem) {
+                            c.code.emit(OpCode::Itemize);
+                        }
+                    }
+                });
+                self.code.emit(OpCode::MakeArray(elems.len() as u32));
+            }
+            Expr::Var(name) if !name.contains("::") => {
+                self.compile_expr(operand);
+                let name_idx = self.code.add_constant(Value::str(name.clone()));
+                self.code.emit(OpCode::WrapVarRef(name_idx));
+            }
+            _ => self.compile_expr(operand),
+        }
     }
 
     /// If `op` is an in-place assignment operator (`+=`, `~=`, `**=`, `min=`, …)

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1501,6 +1501,12 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                 remaining_len: err.remaining_len.or(Some(r.len())),
                 exception: None,
             })?;
+            // A list-infix operator (Z/X/meta/infix func) binds tighter than the
+            // comma separating listop arguments, so it is absorbed into the
+            // argument here (`reverse @a Z @b` is `reverse(@a Z @b)`); the whole
+            // comma level is then lifted below. (Same as the user-sub path in
+            // `make_call_expr_from_listop_args`.)
+            let (r2, arg) = crate::parser::expr::extend_listop_arg_list_infix(r2, input, arg)?;
             let (r2, invocant_colon_call) =
                 try_parse_no_paren_invocant_colon_call(&name, arg.clone(), r2)?;
             if let Some(method_call) = invocant_colon_call {
@@ -1523,9 +1529,18 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                     break;
                 }
                 let (r3, rest_arg) = parse_arg(r3)?;
+                let (r3, rest_arg) =
+                    crate::parser::expr::extend_listop_arg_list_infix(r3, input, rest_arg)?;
                 args.push(rest_arg);
                 rest_after = r3;
             }
+            // A top-level list-infix meta-op (`Z`/`X`) or `minmax` is LOOSER than
+            // the comma separating listop arguments, so it owns the whole comma
+            // level: `reverse 1, 2 Z 3, 4` is `reverse((1,2) Z (3,4))`. The
+            // per-argument parse above left the meta-op bound only to its
+            // neighbouring element; lift it across the full argument list,
+            // mirroring `make_call_expr_from_listop_args`.
+            let args = crate::parser::primary::lift_list_infix_in_arg_list(args);
             return Ok((rest_after, make_call_expr(name, input, args)));
         }
     }

--- a/src/runtime/ops_reduction.rs
+++ b/src/runtime/ops_reduction.rs
@@ -657,6 +657,10 @@ impl Interpreter {
                 Ok(Value::truth(left == right))
             }
             "eqv" => Ok(Value::truth(left.eqv(right))),
+            // Plain-value container identity (`1 =:= 1`, `Nil =:= Nil`). Named
+            // scalar-variable operands (`($a,$b) X=:= ($c,$d)`) are intercepted
+            // by `eval_reduction_operator_values` before reaching here so their
+            // binding roots decide identity; only non-variable values fall here.
             "=:=" => Ok(Value::truth(super::values_identical(left, right))),
             "!=:=" => Ok(Value::truth(!super::values_identical(left, right))),
             "===" => Ok(Value::truth(super::values_identical(left, right))),

--- a/src/vm/vm_comparison_container_ops.rs
+++ b/src/vm/vm_comparison_container_ops.rs
@@ -105,7 +105,7 @@ impl Interpreter {
 
     /// Walk the `__mutsu_sigilless_alias::` chain to find the ultimate
     /// binding root for a variable name.
-    fn resolve_alias_root(&self, name: &str) -> String {
+    pub(crate) fn resolve_alias_root(&self, name: &str) -> String {
         let mut current = name.to_string();
         let mut seen = std::collections::HashSet::new();
         while seen.insert(current.clone()) {

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -155,6 +155,21 @@ impl Interpreter {
         if normalized_op == "=~=" || normalized_op == "\u{2245}" {
             return self.approx_eq_values(left.clone(), right.clone());
         }
+        // Container identity (`=:=`/`!=:=`) between scalar-variable operands
+        // needs `self` to resolve binding roots: `($a,$b) X=:= ($c,$d)` compiles
+        // its operand lists ref-preserving (`WrapVarRef`), so the elements are
+        // `VarRef`s carrying the source variable name. Two variables are the same
+        // container only when they share a binding root (`$c := $b`); distinct
+        // `my` scalars are distinct containers. Non-variable operands fall through
+        // to the static value-identity path below.
+        if (normalized_op == "=:=" || normalized_op == "!=:=")
+            && let (Some((ln, _, _)), Some((rn, _, _))) = (left.as_varref(), right.as_varref())
+        {
+            let same =
+                self.resolve_alias_root(&ln.resolve()) == self.resolve_alias_root(&rn.resolve());
+            let result = if normalized_op == "=:=" { same } else { !same };
+            return Ok(Value::truth(result));
+        }
         match Interpreter::apply_reduction_op(normalized_op, left, right) {
             Ok(v) => Ok(v),
             Err(err) if err.message.starts_with("Unsupported reduction operator:") => {

--- a/t/list-infix-comma-precedence.t
+++ b/t/list-infix-comma-precedence.t
@@ -7,7 +7,7 @@ use Test;
 # the whole comma list on each side is one operand: `say((a, b) Zop (c, d))`.
 # mutsu previously bound the meta-op tighter than comma, giving `say(a, (b Zop c), d)`.
 
-plan 17;
+plan 25;
 
 # Capture what a `say`/`print` statement actually emits, so we test the
 # unparenthesized listop statement path (not the parenthesized-list path).
@@ -72,3 +72,33 @@ is (collect 1, 2 Z 3, 4), '1|3|2|4',
     'user-sub no-paren: (1,2) Z (3,4)';
 is (collect 1, 2, 3), '1|2|3',
     'user-sub no-paren: a plain comma list is unaffected';
+
+# A no-paren BUILTIN listop (join/reverse/sort/min/sum/...) gobbles the whole
+# comma level, and the list-infix operator is LOOSER than that comma, so it owns
+# both operands: `reverse 1, 2 Z 3, 4` is `reverse((1,2) Z (3,4))`. The whole
+# argument list (separator included) becomes the meta-op's left operand.
+is-deeply (reverse 1, 2 Z 3, 4), ((2, 4), (1, 3)),
+    'builtin reverse: ((1,2) Z (3,4)) is one argument, then reversed';
+is-deeply (sort 3, 1 Z 2, 4), ((1, 4), (3, 2)),
+    'builtin sort: sorts the cross ((3,1) Z (2,4))';
+is (min 1, 2 Z 3, 4), (1, 3),
+    'builtin min: over ((1,2) Z (3,4))';
+is (sum 1, 2 Z 3, 4), 4,
+    'builtin sum: over ((1,2) Z (3,4))';
+
+# Junction constructors (all/any/one/none) are list-prefix, so they too absorb
+# the whole comma level into a single cross/zip meta-op operand.
+ok (? all 1, 2 X<= 2, 3, 4), 'junction all: all((1,2) X<= (2,3,4))';
+ok (? one 1, 2 X== 2, 3, 4), 'junction one: one((1,2) X== (2,3,4))';
+
+# `=:=`/`!=:=` compare CONTAINER identity, so a cross/zip operand list of scalar
+# variables keeps each element's container (raku Lists retain element
+# containers). Four distinct `my` scalars are four distinct containers.
+{
+    my ($a, $b, $c, $d);
+    ok (? all $a, $b X!=:= $c, $d),
+        'X!=:= : distinct my-scalars are distinct containers (all True)';
+    $c := $b;
+    ok (? one $a, $b X=:= $c, $d),
+        'X=:= : exactly one pair shares a binding root after `$c := $b`';
+}


### PR DESCRIPTION
## Summary

A list-infix operator (`Z`, `X`, their `Z+`/`X*` meta-ops) is **looser** than the comma that separates listop arguments, so it owns the whole comma level as its two operands (operators.rakudoc precedence: "Comma operator" is tighter than "List infix"). This already worked for `say`/`print`/`put`/`note` (#5268) and no-paren user/imported-sub calls (#5271); this PR extends it to the **plain-comma-list builtin listop path** (`join`/`reverse`/`sort`/`min`/`max`/`sum`, and the junction constructors `all`/`any`/`one`/`none`).

```raku
reverse 1, 2 Z 3, 4    # now: reverse((1,2) Z (3,4))  → ((2 4) (1 3))   [raku ✓]
                       # was: reverse(1, (2 Z 3), 4)  → ((2 3) (1 4))
```

The fix applies the same extend+lift as #5271 to the inline builtin-listop argument loop in `identifier_call.rs`: `extend_listop_arg_list_infix` per argument, then `lift_list_infix_in_arg_list` across the whole list. The block-first `map {..}, list` / `grep {..}, list` form is unaffected (different code path — raku errors on `map {..}, 1 Z 2` anyway).

## Container-identity fix (exposed by the parse change)

The correct parse routed `all $a, $b X!=:= $c, $d` through the cross-meta value path, exposing a pre-existing gap: `=:=`/`!=:=` compare **container** identity, but a cross/zip operand list of scalar variables was materialized to decontainerized values, so distinct undefined `my` scalars compared equal (wrong). This regressed roast `S03-metaops/cross.t` (tests 21-22, 24).

Fixed properly by preserving element container identity for identity-op operands:
- **Compiler** (`expr_ops.rs`): a cross/zip operand list for `=:=`/`!=:=` tags its scalar-var elements with `WrapVarRef` — a raku List retains element containers, unlike an Array.
- **VM** (`vm_dispatch_helpers.rs`): `eval_reduction_operator_values` resolves the two operands' binding roots (`resolve_alias_root`) when both are `VarRef`s. Distinct `my` scalars are distinct containers; `$c := $b` makes exactly that pair identical.

```raku
my ($a,$b,$c,$d);
say ($a,$b) X!=:= ($c,$d);   # (True True True True)   — all distinct containers
$c := $b;
say ($a,$b) X=:=  ($c,$d);   # (False False True False) — only $b/$c share a root
```

Array-var operands (`@a X=:= @b`) are untouched (a separate, deeper array-element-container question).

## Tests

- Pin: `t/list-infix-comma-precedence.t` (+8 cases, now 25 tests).
- roast `S03-metaops/cross.t` stays green (was regressing on the parse fix alone).
- `make test` (2326 files, 21977 tests) PASS; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)