### PR TITLE
fix: pass :INITIALIZE to a tied hash's STORE on declaration assignment

### DIFF
--- a/src/vm/vm_var_trait_ops.rs
+++ b/src/vm/vm_var_trait_ops.rs
@@ -421,11 +421,17 @@ impl Interpreter {
                 // Pass the initializer as a single positional list (not as
                 // separate Pair args, which STORE's signature would bind as
                 // *named* arguments); STORE's slurpy `*@values` flattens it.
+                // Raku passes `:INITIALIZE` on the *declaration* assignment
+                // (`my %h is Foo = ...`) but NOT on a later `%h = ...`
+                // reassignment, so a write-once tie can distinguish the initial
+                // population from a forbidden overwrite (WriteOnceHash's STORE
+                // gates on `:$INITIALIZE`). A STORE that ignores it absorbs the
+                // extra named arg through its implicit `*%_`.
                 let list_arg = Value::array(init_values);
                 let stored = self.try_compiled_method_or_interpret(
                     instance.clone(),
                     "STORE",
-                    vec![list_arg],
+                    vec![list_arg, Value::pair("INITIALIZE".to_string(), Value::TRUE)],
                 )?;
                 let bound = if matches!(stored.view(), ValueView::Instance { .. }) {
                     stored

--- a/t/tied-hash-store-initialize.t
+++ b/t/tied-hash-store-initialize.t
@@ -1,0 +1,31 @@
+use Test;
+
+# Raku passes the `:INITIALIZE` named argument to a tied hash's `STORE` on the
+# *declaration* assignment (`my %h is Foo = ...`) but NOT on a later `%h = ...`
+# reassignment. A write-once tie relies on this to tell the initial population
+# apart from a forbidden overwrite (the WriteOnceHash dist pattern).
+
+plan 5;
+
+my @seen;
+
+my class Tied does Associative {
+    has %.store;
+    method STORE(\values, :$INITIALIZE) {
+        @seen.push($INITIALIZE ?? 'init' !! 'reassign');
+        %!store = ();
+        for values.list -> $p { %!store{$p.key} = $p.value }
+        self
+    }
+    method AT-KEY($k) { %!store{$k} }
+    method keys { %!store.keys }
+}
+
+my %h is Tied = a => 1, b => 2;
+is %h<a>, 1, 'declaration initializer stored (a)';
+is %h<b>, 2, 'declaration initializer stored (b)';
+is-deeply @seen, ['init'], 'declaration assignment passed :INITIALIZE';
+
+%h = c => 3;
+is %h<c>, 3, 'reassignment stored';
+is-deeply @seen, ['init', 'reassign'], 'reassignment did NOT pass :INITIALIZE';


### PR DESCRIPTION
Raku passes the `:INITIALIZE` named argument to a tied container's `STORE` on
the **declaration** assignment (`my %h is Foo = ...`) but **not** on a later
`%h = ...` reassignment, so a write-once tie can tell the initial population
apart from a forbidden overwrite. This is the WriteOnceHash dist pattern:

```raku
method STORE(\iterable, :$INITIALIZE) {
    $INITIALIZE ?? self!STORE-FROM-ITERABLE(iterable)
                !! X::Hash::WriteOnce.new.throw
}
```

mutsu never passed `:INITIALIZE`, so such a STORE always took the "already
populated" branch and threw on the very first assignment. The tied-variable
declaration-init path (`ApplyVarTrait`, `vm_var_trait_ops.rs`) now appends
`:INITIALIZE` to the STORE call; the reassignment path
(`maybe_tied_store_reassign`) deliberately does not, matching Rakudo. A STORE
that ignores the flag absorbs it through its implicit `*%_`.

Improves the `does Associative` tied-hash family generally (found while
triaging the T-057 WriteOnceHash dist, whose remaining blockers — the
`class X is Hash` subclass BIND-KEY/EXISTS-KEY protocol and its lossy `.^name`
representation — are deeper and tracked separately).

Pin: `t/tied-hash-store-initialize.t` (verified against raku). No regressions in
the T-051 tied-hash pins; `make test` PASS (21979 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)