### PR TITLE
fix: unpassed optional params seed their type object (Any/Mu), not Nil (PLAN 8.5)

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -68,6 +68,11 @@ pub(crate) struct ParamDef {
     pub(crate) is_invocant: bool,
     /// Shape constraint for array parameters, e.g. `@a[3]`, `@a[4,4]`, `@a[*]`, `@a[$n]`.
     pub(crate) shape_constraints: Option<Vec<Expr>>,
+    /// True when this parameter belongs to a block (pointy/bare), whose
+    /// implicit nominal type is Mu, not Any. An unpassed untyped optional
+    /// seeds Mu for blocks and Any for routines.
+    #[serde(default)]
+    pub(crate) block_param: bool,
 }
 
 impl ParamDef {
@@ -84,6 +89,25 @@ impl ParamDef {
             && self.literal_value.is_none()
             && self.slurpy
             && self.sigilless
+    }
+
+    /// Mark this param (and every nested sub-signature param) as belonging to
+    /// a block, so an unpassed untyped optional seeds Mu instead of Any.
+    pub(crate) fn mark_block_param(&mut self) {
+        self.block_param = true;
+        for nested in [&mut self.sub_signature, &mut self.outer_sub_signature]
+            .into_iter()
+            .flatten()
+        {
+            for pd in nested.iter_mut() {
+                pd.mark_block_param();
+            }
+        }
+        if let Some((code_defs, _)) = &mut self.code_signature {
+            for pd in code_defs.iter_mut() {
+                pd.mark_block_param();
+            }
+        }
     }
 }
 
@@ -2336,6 +2360,7 @@ pub(crate) fn make_anon_sub(stmts: Vec<Stmt>) -> Expr {
                         code_signature: None,
                         is_invocant: false,
                         shape_constraints: None,
+                        block_param: false,
                     }
                 })
                 .collect(),

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -182,6 +182,22 @@ impl Compiler {
         let is_pointy = body
             .first()
             .is_some_and(|s| matches!(s, crate::ast::Stmt::SetLine(_)));
+        // Block params have Mu (not Any) as their implicit nominal type;
+        // mark them here so an unpassed untyped optional seeds Mu.
+        let marked_defs: Vec<crate::ast::ParamDef>;
+        let param_defs: &[crate::ast::ParamDef] = if is_pointy {
+            marked_defs = param_defs
+                .iter()
+                .map(|pd| {
+                    let mut pd = pd.clone();
+                    pd.mark_block_param();
+                    pd
+                })
+                .collect();
+            &marked_defs
+        } else {
+            param_defs
+        };
         // Pointy blocks are NOT routine boundaries for `return`.
         let mut compiled = if is_pointy {
             self.compile_closure_body(params, param_defs, body)
@@ -273,6 +289,7 @@ impl Compiler {
                 code_signature: None,
                 is_invocant: false,
                 shape_constraints: None,
+                block_param: false,
             }]
         } else {
             Vec::new()

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1096,14 +1096,47 @@ impl Compiler {
                     bind_stmts.push(bind_stmt(sub.name.clone(), capture_expr));
                     // No need to increment positional_index; capture consumes all remaining
                 } else {
-                    bind_stmts.push(bind_stmt(
-                        sub.name.clone(),
-                        Expr::Index {
-                            target: Box::new(Expr::Var(target_name.clone())),
-                            index: Box::new(Expr::Literal(Value::int(positional_index as i64))),
-                            is_positional: false,
-                        },
-                    ));
+                    let element_expr = Expr::Index {
+                        target: Box::new(Expr::Var(target_name.clone())),
+                        index: Box::new(Expr::Literal(Value::int(positional_index as i64))),
+                        is_positional: false,
+                    };
+                    // An optional destructure param (`-> ($a, $b?)`) seeds its
+                    // type object (Mu for untyped — this is a block) when the
+                    // source has no element at this slot; a default binds the
+                    // default expression instead.
+                    let value_expr = if sub.default.is_some() || sub.optional_marker {
+                        let fallback = match &sub.default {
+                            Some(default_expr) => default_expr.clone(),
+                            None => {
+                                let mut marked = sub.clone();
+                                marked.mark_block_param();
+                                Expr::Literal(
+                                    crate::runtime::Interpreter::missing_optional_param_value(
+                                        &marked,
+                                    ),
+                                )
+                            }
+                        };
+                        Expr::Ternary {
+                            cond: Box::new(Expr::Binary {
+                                left: Box::new(Expr::MethodCall {
+                                    target: Box::new(Expr::Var(target_name.clone())),
+                                    name: Symbol::intern("elems"),
+                                    args: Vec::new(),
+                                    modifier: None,
+                                    quoted: false,
+                                }),
+                                op: crate::token_kind::TokenKind::Gt,
+                                right: Box::new(Expr::Literal(Value::int(positional_index as i64))),
+                            }),
+                            then_expr: Box::new(element_expr),
+                            else_expr: Box::new(fallback),
+                        }
+                    } else {
+                        element_expr
+                    };
+                    bind_stmts.push(bind_stmt(sub.name.clone(), value_expr));
                     positional_index += 1;
                 }
             }
@@ -1171,15 +1204,25 @@ impl Compiler {
                 index: Box::new(Expr::Literal(Value::int(i as i64))),
                 is_positional: false,
             };
-            let value_expr = match params_def.get(i).and_then(|d| d.default.as_ref()) {
-                Some(default_expr) => Expr::Ternary {
+            // An optional param without a default (`-> $a, $b? {}`) seeds its
+            // type object (Mu for untyped block params) when the chunk is
+            // short, like an unpassed optional in a routine call.
+            let missing_expr = match params_def.get(i) {
+                Some(d) if d.default.is_some() => Some(d.default.clone().unwrap()),
+                Some(d) if d.optional_marker => Some(Expr::Literal(
+                    crate::runtime::Interpreter::missing_optional_param_value(d),
+                )),
+                _ => None,
+            };
+            let value_expr = match missing_expr {
+                Some(fallback) => Expr::Ternary {
                     cond: Box::new(Expr::Binary {
                         left: Box::new(chunk_elems()),
                         op: crate::token_kind::TokenKind::Gt,
                         right: Box::new(Expr::Literal(Value::int(i as i64))),
                     }),
                     then_expr: Box::new(element_expr),
-                    else_expr: Box::new(default_expr.clone()),
+                    else_expr: Box::new(fallback),
                 },
                 None => element_expr,
             };

--- a/src/parser/expr/whatever_wrap.rs
+++ b/src/parser/expr/whatever_wrap.rs
@@ -141,6 +141,7 @@ fn make_wc_param(name: String) -> crate::ast::ParamDef {
         code_signature: None,
         is_invocant: false,
         shape_constraints: None,
+        block_param: false,
     }
 }
 
@@ -254,6 +255,7 @@ pub(crate) fn wrap_whatevercode(expr: &Expr) -> Expr {
                 code_signature: None,
                 is_invocant: false,
                 shape_constraints: None,
+                block_param: false,
             }],
             return_type: None,
             body: vec![Stmt::Expr(body_expr)],
@@ -290,6 +292,7 @@ pub(crate) fn wrap_whatevercode(expr: &Expr) -> Expr {
                     code_signature: None,
                     is_invocant: false,
                     shape_constraints: None,
+                    block_param: false,
                 })
                 .collect(),
             return_type: None,

--- a/src/parser/primary/ident/anon_sub.rs
+++ b/src/parser/primary/ident/anon_sub.rs
@@ -24,6 +24,7 @@ pub(crate) fn invocant_param_def() -> crate::ast::ParamDef {
         code_signature: None,
         is_invocant: true,
         shape_constraints: None,
+        block_param: false,
     }
 }
 

--- a/src/parser/stmt/class/role_decl.rs
+++ b/src/parser/stmt/class/role_decl.rs
@@ -201,6 +201,7 @@ pub(crate) fn parse_optional_role_type_params(
                     code_signature: None,
                     is_invocant: false,
                     shape_constraints: None,
+                    block_param: false,
                 });
                 continue;
             }
@@ -235,6 +236,7 @@ pub(crate) fn parse_optional_role_type_params(
                         code_signature: None,
                         is_invocant: false,
                         shape_constraints: None,
+                        block_param: false,
                     });
                     continue;
                 }

--- a/src/parser/stmt/control/for_params.rs
+++ b/src/parser/stmt/control/for_params.rs
@@ -71,6 +71,7 @@ pub(crate) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
                 code_signature: None,
                 is_invocant: false,
                 shape_constraints: None,
+                block_param: true,
             };
             return Ok((
                 r,
@@ -116,6 +117,7 @@ pub(crate) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
                 code_signature: None,
                 is_invocant: false,
                 shape_constraints: None,
+                block_param: true,
             };
             return Ok((
                 r,
@@ -171,6 +173,7 @@ pub(crate) fn parse_for_params(input: &str) -> PResult<'_, ForParams> {
                 code_signature: None,
                 is_invocant: false,
                 shape_constraints: None,
+                block_param: true,
             };
             return Ok((
                 r,
@@ -311,6 +314,7 @@ fn parse_for_pointy_param(input: &str) -> PResult<'_, ParamDef> {
                 code_signature: None,
                 is_invocant: false,
                 shape_constraints: None,
+                block_param: true,
             },
         ));
     }
@@ -397,6 +401,7 @@ fn parse_for_pointy_param(input: &str) -> PResult<'_, ParamDef> {
             code_signature: None,
             is_invocant: false,
             shape_constraints,
+            block_param: true,
         },
     ))
 }

--- a/src/parser/stmt/control/pointy_param.rs
+++ b/src/parser/stmt/control/pointy_param.rs
@@ -68,6 +68,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
                     optional_marker: false,
                     is_invocant: false,
                     shape_constraints: None,
+                    block_param: true,
                 },
             ));
         } else {
@@ -103,6 +104,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
                 optional_marker: false,
                 is_invocant: false,
                 shape_constraints: None,
+                block_param: true,
             },
         ));
     }
@@ -162,6 +164,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
                     optional_marker: false,
                     is_invocant: false,
                     shape_constraints: None,
+                    block_param: true,
                 },
             ));
         }
@@ -192,6 +195,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
                     optional_marker: false,
                     is_invocant: false,
                     shape_constraints: None,
+                    block_param: true,
                 },
             ));
         }
@@ -221,6 +225,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
                 optional_marker: false,
                 is_invocant: false,
                 shape_constraints: None,
+                block_param: true,
             },
         ));
     }
@@ -282,6 +287,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
                 optional_marker,
                 is_invocant: false,
                 shape_constraints: None,
+                block_param: true,
             },
         ));
     }
@@ -321,6 +327,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
                 optional_marker: false,
                 is_invocant: false,
                 shape_constraints: None,
+                block_param: true,
             },
         ));
     }
@@ -361,6 +368,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
                     optional_marker: false,
                     is_invocant: false,
                     shape_constraints: None,
+                    block_param: true,
                 },
             ));
         }
@@ -508,6 +516,7 @@ pub(crate) fn parse_pointy_param(input: &str) -> PResult<'_, ParamDef> {
             optional_marker,
             is_invocant: false,
             shape_constraints,
+            block_param: true,
         },
     ))
 }

--- a/src/parser/stmt/sub_param/helpers.rs
+++ b/src/parser/stmt/sub_param/helpers.rs
@@ -26,6 +26,7 @@ pub(crate) fn make_param(name: String) -> ParamDef {
         code_signature: None,
         is_invocant: false,
         shape_constraints: None,
+        block_param: false,
     }
 }
 

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -325,6 +325,7 @@ fn positional_param(name: &str) -> ParamDef {
         code_signature: None,
         is_invocant: false,
         shape_constraints: None,
+        block_param: false,
     }
 }
 

--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -189,6 +189,7 @@ impl Interpreter {
             outer_sub_signature: None,
             code_signature: None,
             shape_constraints: None,
+            block_param: false,
         }
     }
 

--- a/src/runtime/methods_classhow_method_obj.rs
+++ b/src/runtime/methods_classhow_method_obj.rs
@@ -267,6 +267,7 @@ impl Interpreter {
                         outer_sub_signature: None,
                         code_signature: None,
                         shape_constraints: None,
+                        block_param: false,
                     }];
                     param_defs.extend(
                         def.param_defs

--- a/src/runtime/methods_format.rs
+++ b/src/runtime/methods_format.rs
@@ -35,6 +35,7 @@ fn positional_param(name: &str) -> ParamDef {
         code_signature: None,
         is_invocant: false,
         shape_constraints: None,
+        block_param: false,
     }
 }
 

--- a/src/runtime/methods_signature_candidates.rs
+++ b/src/runtime/methods_signature_candidates.rs
@@ -179,6 +179,7 @@ impl Interpreter {
                                 code_signature: None,
                                 is_invocant: false,
                                 shape_constraints: None,
+                                block_param: false,
                             })
                             .collect()
                     } else {
@@ -216,6 +217,7 @@ impl Interpreter {
                                 code_signature: None,
                                 is_invocant: false,
                                 shape_constraints: None,
+                                block_param: true,
                             });
                         }
                         if use_positional {
@@ -239,6 +241,7 @@ impl Interpreter {
                                 code_signature: None,
                                 is_invocant: false,
                                 shape_constraints: None,
+                                block_param: false,
                             });
                         }
                         if use_named {
@@ -262,6 +265,7 @@ impl Interpreter {
                                 code_signature: None,
                                 is_invocant: false,
                                 shape_constraints: None,
+                                block_param: false,
                             });
                         }
                         defs

--- a/src/runtime/methods_string_substr.rs
+++ b/src/runtime/methods_string_substr.rs
@@ -200,6 +200,7 @@ impl Interpreter {
             code_signature: None,
             is_invocant: false,
             shape_constraints: None,
+            block_param: false,
         };
 
         // Create FETCH sub: reads substr from the variable

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -145,6 +145,7 @@ impl Interpreter {
                             code_signature: None,
                             is_invocant: false,
                             shape_constraints: None,
+                            block_param: false,
                         })
                         .collect()
                 };
@@ -210,6 +211,7 @@ impl Interpreter {
                             code_signature: None,
                             is_invocant: false,
                             shape_constraints: None,
+                            block_param: false,
                         })
                         .collect()
                 };
@@ -320,6 +322,7 @@ impl Interpreter {
                         code_signature: None,
                         is_invocant: false,
                         shape_constraints: None,
+                        block_param: false,
                     })
                     .collect()
             };

--- a/src/runtime/methods_walk.rs
+++ b/src/runtime/methods_walk.rs
@@ -675,6 +675,7 @@ fn walk_param(name: &str, slurpy: bool) -> crate::ast::ParamDef {
         code_signature: None,
         is_invocant: false,
         shape_constraints: None,
+        block_param: false,
     }
 }
 

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -53,6 +53,7 @@ impl Interpreter {
             code_signature: None,
             is_invocant: false,
             shape_constraints: None,
+            block_param: false,
         }
     }
 

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -122,6 +122,7 @@ fn delegation_slurpy_param() -> ParamDef {
         code_signature: None,
         is_invocant: false,
         shape_constraints: None,
+        block_param: false,
     }
 }
 
@@ -169,6 +170,7 @@ fn delegation_double_slurpy_param() -> ParamDef {
         code_signature: None,
         is_invocant: false,
         shape_constraints: None,
+        block_param: false,
     }
 }
 

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -201,6 +201,7 @@ impl Interpreter {
                                     code_signature: None,
                                     is_invocant: false,
                                     shape_constraints: None,
+                                    block_param: false,
                                 },
                             );
                         }

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -101,6 +101,7 @@ impl Interpreter {
                 code_signature: None,
                 is_invocant: false,
                 shape_constraints: None,
+                block_param: false,
             });
             method_param_defs
         };
@@ -1709,6 +1710,7 @@ impl Interpreter {
                                     code_signature: None,
                                     is_invocant: false,
                                     shape_constraints: None,
+                                    block_param: false,
                                 },
                             );
                         }
@@ -1963,6 +1965,7 @@ impl Interpreter {
                                 code_signature: None,
                                 is_invocant: false,
                                 shape_constraints: None,
+                                block_param: false,
                             };
                             let mut our_param_defs = vec![self_param];
                             our_param_defs.extend(
@@ -2039,6 +2042,7 @@ impl Interpreter {
                                 code_signature: None,
                                 is_invocant: false,
                                 shape_constraints: None,
+                                block_param: false,
                             };
                             let mut my_param_defs = vec![self_param];
                             my_param_defs.extend(

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -608,6 +608,7 @@ impl Interpreter {
                     code_signature: None,
                     is_invocant: false,
                     shape_constraints: None,
+                    block_param: false,
                 });
             }
             if use_named {
@@ -631,6 +632,7 @@ impl Interpreter {
                     code_signature: None,
                     is_invocant: false,
                     shape_constraints: None,
+                    block_param: false,
                 });
             }
             // If neither @_ nor %_ is used, this is a true empty signature
@@ -1192,6 +1194,7 @@ impl Interpreter {
                     code_signature: None,
                     is_invocant: false,
                     shape_constraints: None,
+                    block_param: false,
                 });
             }
             if use_named {
@@ -1215,6 +1218,7 @@ impl Interpreter {
                     code_signature: None,
                     is_invocant: false,
                     shape_constraints: None,
+                    block_param: false,
                 });
             }
             let is_empty = defs.is_empty();

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -485,7 +485,7 @@ impl Interpreter {
         constraint[..end].to_string()
     }
 
-    pub(in crate::runtime) fn missing_optional_param_value(pd: &ParamDef) -> Value {
+    pub(crate) fn missing_optional_param_value(pd: &ParamDef) -> Value {
         if pd.name.starts_with('@') {
             return Value::real_array(Vec::new());
         }
@@ -495,7 +495,9 @@ impl Interpreter {
         if let Some(constraint) = &pd.type_constraint {
             return Value::package(Symbol::intern(&Self::optional_type_object_name(constraint)));
         }
-        Value::NIL
+        // An unpassed untyped optional binds the parameter's implicit nominal
+        // type object: Any for routines, Mu for pointy/bare blocks.
+        Value::package(Symbol::intern(if pd.block_param { "Mu" } else { "Any" }))
     }
 
     pub(crate) fn nominal_type_object_name_for_constraint(&self, constraint: &str) -> String {

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -667,16 +667,11 @@ pub(in crate::runtime) fn bind_sub_signature_from_value(
                     "Too few positional arguments in sub-signature binding".to_string(),
                 ));
             }
-            // Explicitly bind optional params to their type object (Any)
-            // so that values from an outer scope don't leak into recursive calls.
+            // Explicitly bind optional params to their type object (Any/Mu,
+            // or the constrained type) so that values from an outer scope
+            // don't leak into recursive calls.
             if !sub_pd.name.is_empty() {
-                let default_val = if sub_pd.name.starts_with('@') {
-                    Value::array(vec![])
-                } else if sub_pd.name.starts_with('%') {
-                    Value::hash(std::collections::HashMap::new())
-                } else {
-                    Value::NIL
-                };
+                let default_val = Interpreter::missing_optional_param_value(sub_pd);
                 interpreter
                     .env
                     .insert(sub_pd.name.clone(), default_val.clone());
@@ -879,6 +874,7 @@ pub(in crate::runtime) fn callable_signature_info(
                         code_signature: None,
                         is_invocant: false,
                         shape_constraints: None,
+                        block_param: false,
                     })
                     .collect::<Vec<_>>()
             };
@@ -912,6 +908,7 @@ pub(in crate::runtime) fn callable_signature_info(
                         code_signature: None,
                         is_invocant: false,
                         shape_constraints: None,
+                        block_param: false,
                     })
                     .collect::<Vec<_>>()
             };

--- a/src/vm/vm_call_light_typed.rs
+++ b/src/vm/vm_call_light_typed.rs
@@ -223,8 +223,13 @@ impl Interpreter {
                         break 'bind;
                     } else {
                         // Missing optional positional: shadow like the named
-                        // case below.
-                        bind_value!(ppb.slot, true, Value::NIL);
+                        // case below, seeding the param's type object (Any/Mu
+                        // for untyped) like the slow path does.
+                        bind_value!(
+                            ppb.slot,
+                            true,
+                            Self::missing_optional_param_value(&cf.param_defs[i])
+                        );
                     }
                     continue;
                 }
@@ -258,28 +263,22 @@ impl Interpreter {
                     ));
                     break 'bind;
                 }
-                // Missing optional named param: bind `Nil` into the overlay
-                // env so the param SHADOWS a same-named caller lexical (the
-                // locals seed below reads through to the caller otherwise)
-                // and so GetLocal's Nil-slot "declared?" probe finds it.
-                match cf.param_name_syms.get(i) {
-                    Some(sym) => {
-                        self.env_mut().insert_sym(*sym, Value::NIL);
-                    }
-                    None => {
-                        self.env_mut()
-                            .insert(cf.param_defs[i].name.clone(), Value::NIL);
-                    }
-                }
+                // Missing optional named param: bind the param's type object
+                // (Any/Mu for untyped, like the slow path) into the slot and
+                // the overlay env so the param SHADOWS a same-named caller
+                // lexical (the locals seed below reads through to the caller
+                // otherwise).
+                let seed = Self::missing_optional_param_value(&cf.param_defs[i]);
                 // A `:color(:$colour)` alias chain also declares its inner
                 // variable(s); when the param is unsupplied they must still be
                 // in scope (undefined), else the body's `$colour` read throws.
                 for (alias_name, alias_slot) in &npb.alias_binds {
                     if let Some(slot) = alias_slot {
-                        self.locals[*slot] = Value::NIL;
+                        self.locals[*slot] = seed.clone();
                     }
-                    self.env_mut().insert(alias_name.clone(), Value::NIL);
+                    self.env_mut().insert(alias_name.clone(), seed.clone());
                 }
+                bind_value!(npb.slot, true, seed);
                 continue;
             };
             let v = v.clone();

--- a/src/vm/vm_method_dispatch.rs
+++ b/src/vm/vm_method_dispatch.rs
@@ -1144,8 +1144,8 @@ impl Interpreter {
                 }
                 param_values.push((param_name, val));
                 arg_idx += 1;
-            } else if pd.map(|pd| pd.optional_marker).unwrap_or(false) {
-                param_values.push((param_name, Value::NIL));
+            } else if let Some(pd) = pd.filter(|pd| pd.optional_marker) {
+                param_values.push((param_name, Self::missing_optional_param_value(pd)));
             }
         }
 

--- a/t/optional-param-seed.t
+++ b/t/optional-param-seed.t
@@ -1,0 +1,50 @@
+use v6;
+use Test;
+
+plan 16;
+
+# An unpassed untyped optional parameter of a routine holds the Any type
+# object (not Nil); a pointy block's holds Mu (PLAN 8.5, Nil-vs-Any).
+
+sub opt-pos($p?) { $p }
+is opt-pos().raku, 'Any', 'unpassed optional positional of a sub is Any';
+is opt-pos().^name, 'Any', 'unpassed optional positional .^name is Any';
+nok opt-pos().defined, 'unpassed optional positional is undefined';
+is opt-pos(42), 42, 'passed optional positional binds the argument';
+
+sub opt-named(:$k) { $k }
+is opt-named().raku, 'Any', 'unpassed optional named of a sub is Any';
+is opt-named(:k(7)), 7, 'passed optional named binds the argument';
+
+sub opt-typed(Int $p?) { $p }
+is opt-typed().raku, 'Int', 'unpassed typed optional seeds its type object';
+
+sub opt-typed-named(Int :$k) { $k }
+is opt-typed-named().raku, 'Int', 'unpassed typed optional named seeds its type object';
+
+my &blk-pos = -> $p? { $p };
+is blk-pos().raku, 'Mu', 'unpassed optional positional of a pointy block is Mu';
+
+my &blk-named = -> :$k { $k };
+is blk-named().raku, 'Mu', 'unpassed optional named of a pointy block is Mu';
+
+my &blk-typed = -> Int $p? { $p };
+is blk-typed().raku, 'Int', 'typed optional of a pointy block seeds its type object';
+
+my class OptC {
+    method m($p?) { $p }
+    method mn(:$k) { $k }
+}
+is OptC.m().raku, 'Any', 'unpassed optional positional of a method is Any';
+is OptC.mn().raku, 'Any', 'unpassed optional named of a method is Any';
+
+sub opt-destructure($a, ($b, $c?)) { $c }
+is opt-destructure(1, (2,)).raku, 'Any', 'unpassed optional in a sub-signature destructure is Any';
+
+my @seen;
+for 1, 2, 3 -> $a, $b? { @seen.push($b.raku) }
+is @seen.join(';'), '2;Mu', 'short final chunk of a multi-param for loop seeds Mu';
+
+my @typed-seen;
+for 1, 2, 3 -> $a, Int $b? { @typed-seen.push($b.raku) }
+is @typed-seen.join(';'), '2;Int', 'typed short final chunk seeds the type object';


### PR DESCRIPTION
## Summary

An unpassed optional parameter with no default used to bind **Nil**. Raku seeds the parameter's implicit nominal type object instead: **Any** for routine (sub/method) params, **Mu** for pointy/bare block params, and the constraint's type object for typed optionals.

```raku
sub w($p?) { $p.raku };        say w();   # was Nil → now Any
my &b = -> $p? { $p.raku };    say b();   # was Nil → now Mu
for 1,2,3 -> $a, $b? { }                  # short final chunk: $b was Nil → now Mu
my &d = -> ($a, $b?) { };      # destructure: $b was Nil → now Mu (raku-verified)
```

This is the prerequisite slice for PLAN 8.5 step 4 (removing the `types_eqv` Nil/Any crutch): `$p.raku` / `.^name` / `.WHAT` on an unpassed optional now agree with raku without the crutch masking them.

## Implementation

- `ParamDef` gains `block_param` (serde-defaulted), set by the pointy/for param parsers and recursively by the compiler when a closure compiles as a pointy block (`mark_block_param` covers nested sub-signature/code-signature defs).
- `missing_optional_param_value` returns the Any/Mu type object for untyped optionals and is now the single seed authority: the light-typed call path, the method-dispatch fast path, and the sub-signature destructure bind (each hardcoded `Value::NIL`) route through it.
- Multi-param `for` loops and positional destructure params compile an elems-guarded ternary that seeds the type object; destructure defaults (`-> ($a, $b = 9)`) now bind too.

## Testing

- New pin: `t/optional-param-seed.t` (16 tests, output verified against raku).
- Full `t/` suite: 2329 files / 22009 tests PASS (debug build).
- Roast sweep (whitelisted S06-signature, S06-multi, S06-currying, S06-advanced, S04 for/given/when, destructure): 66 files / 1972 tests PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)