### PR TITLE
fix: reject `(` as a quote/regex delimiter without preceding whitespace

### DIFF
--- a/src/parser/primary/quote_adverbs.rs
+++ b/src/parser/primary/quote_adverbs.rs
@@ -150,9 +150,12 @@ impl QuoteFlags {
 /// Example: ":s:b:c" → flags.scalar=true, flags.backslash=true, flags.closure=true
 pub(super) fn parse_colon_adverbs<'a>(mut input: &'a str, flags: &mut QuoteFlags) -> &'a str {
     loop {
-        // Allow whitespace before each colon (e.g. "q :heredoc :c \"EOF\"")
-        input = input.trim_start_matches(' ');
-        let Some(r) = input.strip_prefix(':') else {
+        // Allow whitespace before each colon (e.g. "q :heredoc :c \"EOF\"").
+        // Only commit the trim when a `:` adverb actually follows — otherwise
+        // the caller must still see the whitespace, which decides whether a
+        // following `(` is a delimiter (`q (...)`) or call syntax (`q(...)`).
+        let trimmed = input.trim_start_matches(' ');
+        let Some(r) = trimmed.strip_prefix(':') else {
             break;
         };
         // Handle negated adverbs (:!a, :!c, etc.)

--- a/src/parser/primary/regex/lit.rs
+++ b/src/parser/primary/regex/lit.rs
@@ -115,6 +115,7 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
             return Err(PError::expected("regex delimiter"));
         }
         let (spec, adverbs) = parse_match_adverbs(rest)?;
+        let pre_ws_len = spec.len();
         if adverbs.global
             || adverbs.exhaustive
             || adverbs.overlap
@@ -130,6 +131,7 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
             ));
         }
         let (spec, _) = ws(spec)?;
+        let had_ws = spec.len() != pre_ws_len;
         // rx allows any non-word character as its delimiter (e.g. `rx|...|`,
         // `rx!...!`), matching the general rule used by `m//` and `s///` — not
         // just the bracket pairs. Brackets nest; every other delimiter uses the
@@ -138,10 +140,12 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
             return Err(PError::expected("regex delimiter"));
         };
         // `:` is never a delimiter — it starts an adverb (`rx :foo:` is an error).
+        // `(` is only a delimiter after whitespace (`rx:i(a)` is call-like syntax).
         let is_delim = !open_ch.is_alphanumeric()
             && open_ch != '_'
             && open_ch != ':'
-            && !open_ch.is_whitespace();
+            && !open_ch.is_whitespace()
+            && (open_ch != '(' || had_ws);
         // Don't treat `rx.method` as a regex with a `.` delimiter when the `.`
         // is followed by an identifier (a method call on a bare `rx`).
         let looks_like_method = open_ch == '.'
@@ -259,7 +263,10 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
         && !crate::parser::stmt::simple::is_user_declared_sub("ss")
         && let Some(first_ch) = after_ss.chars().next()
         && (first_ch == ':'
-            || (!first_ch.is_alphanumeric() && first_ch != '_' && !first_ch.is_whitespace())
+            || (!first_ch.is_alphanumeric()
+                && first_ch != '_'
+                && first_ch != '('
+                && !first_ch.is_whitespace())
             || (first_ch.is_whitespace()
                 && after_ss.trim_start().starts_with(['(', '[', '{', '<'])))
     {
@@ -271,13 +278,19 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
         // ss implies :ss (:samespace + :sigspace)
         adverbs.samespace = true;
         adverbs.sigspace = true;
+        let pre_ws_len = spec.len();
         let spec = if first_ch == ':' || first_ch.is_whitespace() {
             ws(spec)?.0
         } else {
             spec
         };
+        let had_ws = spec.len() != pre_ws_len;
         if let Some(open_ch) = spec.chars().next() {
-            let is_delim = !open_ch.is_alphanumeric() && open_ch != '_' && !open_ch.is_whitespace();
+            // `(` is only a delimiter after whitespace (`ss:g(a)` is call-like).
+            let is_delim = !open_ch.is_alphanumeric()
+                && open_ch != '_'
+                && !open_ch.is_whitespace()
+                && (open_ch != '(' || had_ws);
             let looks_like_method = open_ch == '.'
                 && spec.len() > 2
                 && spec[1..].starts_with(|c: char| c.is_alphabetic() || c == '_')
@@ -391,9 +404,15 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
             (after_s, MatchAdverbs::default())
         };
         // Allow whitespace between adverbs and delimiter (e.g. s:Perl5 /pattern/)
+        let pre_ws_len = spec.len();
         let spec = if first_ch == ':' { ws(spec)?.0 } else { spec };
+        let had_ws = spec.len() != pre_ws_len;
         if let Some(open_ch) = spec.chars().next() {
-            let is_delim = !open_ch.is_alphanumeric() && open_ch != '_' && !open_ch.is_whitespace();
+            // `(` is only a delimiter after whitespace (`s(a)` is a call).
+            let is_delim = !open_ch.is_alphanumeric()
+                && open_ch != '_'
+                && !open_ch.is_whitespace()
+                && (open_ch != '(' || had_ws);
             // Don't treat s.identifier as substitution when the identifier is 2+ chars
             // (likely a method call on bare 's'). Single-char like s.a.b. is still valid regex.
             let looks_like_method = open_ch == '.'
@@ -591,9 +610,15 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
         let (spec, adverbs) = parse_match_adverbs(after_s)?;
         // Allow whitespace between adverbs and the delimiter (e.g.
         // `S:g /pattern/replacement/`), mirroring the lowercase `s` parser.
+        let pre_ws_len = spec.len();
         let spec = if had_adverbs { ws(spec)?.0 } else { spec };
+        let had_ws = spec.len() != pre_ws_len;
         if let Some(open_ch) = spec.chars().next() {
-            let is_delim = !open_ch.is_alphanumeric() && open_ch != '_' && !open_ch.is_whitespace();
+            // `(` is only a delimiter after whitespace (`S(a)` is a call).
+            let is_delim = !open_ch.is_alphanumeric()
+                && open_ch != '_'
+                && !open_ch.is_whitespace()
+                && (open_ch != '(' || had_ws);
             let looks_like_method = open_ch == '.'
                 && spec.len() > 2
                 && spec[1..].starts_with(|c: char| c.is_alphabetic() || c == '_')
@@ -874,14 +899,21 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
     {
         let (spec, mut adverbs) = parse_match_adverbs(after_m)?;
         let spec = parse_compact_match_adverbs(spec, &mut adverbs);
+        let pre_ws_len = spec.len();
         let (spec, _) = ws(spec)?;
+        let had_ws = spec.len() != pre_ws_len;
         // After stripping whitespace, check if this is a fat arrow pair (e.g., `m => 1000`).
         // The initial `=>` check above only catches `m=>` without whitespace.
         if spec.starts_with("=>") {
             return Err(PError::expected("regex literal"));
         }
         if let Some(open_ch) = spec.chars().next() {
-            let is_delim = !open_ch.is_alphanumeric() && open_ch != '_' && !open_ch.is_whitespace();
+            // `(` is only a delimiter after whitespace — `m(9)` / `mm(9)` are
+            // calls to user routines named `m` / `mm`, never a regex.
+            let is_delim = !open_ch.is_alphanumeric()
+                && open_ch != '_'
+                && !open_ch.is_whitespace()
+                && (open_ch != '(' || had_ws);
             if is_delim {
                 let (close_ch, is_paired) = match open_ch {
                     '{' => ('}', true),

--- a/src/parser/primary/regex/trans.rs
+++ b/src/parser/primary/regex/trans.rs
@@ -54,7 +54,9 @@ pub(super) fn parse_trans_adverbs(
     }
 
     let open_ch = rest.chars().next()?;
-    if open_ch.is_alphanumeric() || open_ch == '_' || open_ch.is_whitespace() {
+    // `(` directly after `tr`/`TR` (or its adverbs) is call syntax, never a
+    // delimiter — Raku requires whitespace before a paren delimiter.
+    if open_ch.is_alphanumeric() || open_ch == '_' || open_ch.is_whitespace() || open_ch == '(' {
         return None;
     }
     let (close_ch, is_paired) = match open_ch {

--- a/src/parser/primary/string/q_string.rs
+++ b/src/parser/primary/string/q_string.rs
@@ -32,6 +32,12 @@ pub(crate) fn big_q_string(input: &str) -> PResult<'_, Expr> {
         return Err(PError::expected("Q string"));
     }
 
+    // `(` directly after the construct name/adverbs is call syntax, never a
+    // delimiter — Raku requires whitespace before a paren delimiter (`Q (...)`).
+    if rest.starts_with('(') {
+        return Err(PError::expected("Q string"));
+    }
+
     if let Some((open, close)) = quote_delimiters(rest) {
         flags.quote_open = Some(open);
         flags.quote_close = Some(close);
@@ -159,12 +165,6 @@ pub(crate) fn q_string(input: &str) -> PResult<'_, Expr> {
     }
     let mut after_q = &input[1..];
 
-    if let Some(after_paren) = after_q.strip_prefix('(')
-        && !after_paren.starts_with('(')
-    {
-        return Err(PError::expected("q string"));
-    }
-
     // q:nfc, q:nfd, q:nfkc, q:nfkd — Unicode normalization adverbs
     for nf_form in &[":nfkc", ":nfkd", ":nfc", ":nfd"] {
         if let Some(rest_after_nf) = after_q.strip_prefix(nf_form) {
@@ -211,6 +211,13 @@ pub(crate) fn q_string(input: &str) -> PResult<'_, Expr> {
     // interpolate closures alone, so it goes through the flag-driven path instead.
     if flags.heredoc {
         return parse_to_heredoc_with_flags(after_q, &flags, flags.qq_mode);
+    }
+
+    // `(` directly after the construct name/adverbs is call syntax, never a
+    // delimiter — Raku requires whitespace before a paren delimiter (`q (...)`,
+    // `qq (...)`, `qw (...)`). This covers `q(`, `q((`, `qq(`, `qw(`, `q:w(`, ...
+    if after_q.starts_with('(') {
+        return Err(PError::expected("q string"));
     }
 
     // `#` cannot be used as a quoting delimiter (it starts a comment).
@@ -280,6 +287,10 @@ pub(crate) fn q_string(input: &str) -> PResult<'_, Expr> {
 
 /// Parse q:nfc/q:nfd/q:nfkc/q:nfkd forms.
 pub(crate) fn parse_nf_form<'a>(rest_after_nf: &'a str, nf_name: &str) -> PResult<'a, Expr> {
+    // Same rule as the other quote forms: a paren delimiter needs whitespace.
+    if rest_after_nf.starts_with('(') {
+        return Err(PError::expected("q string"));
+    }
     let form_upper = nf_name.to_uppercase();
     let (rest, content) = read_delimited_content(rest_after_nf, false)?;
     use unicode_normalization::UnicodeNormalization;

--- a/src/parser/primary/string/qx.rs
+++ b/src/parser/primary/string/qx.rs
@@ -20,7 +20,8 @@ pub(crate) fn qx_string(input: &str) -> PResult<'_, Expr> {
         .chars()
         .next()
         .ok_or_else(|| PError::expected("qx string delimiter"))?;
-    if delim.is_alphanumeric() || delim.is_whitespace() {
+    // `(` directly after `qx`/`qqx` is call syntax, never a delimiter.
+    if delim.is_alphanumeric() || delim.is_whitespace() || delim == '(' {
         return Err(PError::expected("qx string delimiter"));
     }
 

--- a/t/paren-quote-delimiter.t
+++ b/t/paren-quote-delimiter.t
@@ -1,0 +1,50 @@
+use v6;
+use Test;
+
+plan 14;
+
+# Raku never allows `(` as a quote/regex delimiter directly after the
+# construct name or its adverbs — that is call syntax (`q(...)` calls `q`).
+# A paren delimiter requires intervening whitespace: `q (...)`.
+
+# A user routine whose name collides with a quote construct is callable
+# with call parens. (Each declaration is scoped to its own block, since a
+# declared routine shadows the quote construct for the rest of the scope.)
+{
+    sub qq($x) { $x * 2 }
+    is qq(5), 10, 'qq(5) calls the user sub qq, not a qq() quote';
+}
+{
+    multi mm($x) { 'one' }
+    multi mm($x, $y) { "two:$y" }
+    is mm(9), 'one', 'mm(9) calls the user multi mm, not an m:sigspace regex';
+    is mm(1, 2), 'two:2', 'mm(1, 2) dispatches with both args';
+}
+{
+    sub tr($x) { $x + 1 }
+    is tr(5), 6, 'tr(5) calls the user sub tr, not a transliteration';
+}
+{
+    sub s($x) { $x ~ '!' }
+    is s('hi'), 'hi!', 's("hi") calls the user sub s, not a substitution';
+}
+
+# The paren-without-space forms are compile errors when no such routine
+# exists (never silently a quote).
+ok !try { EVAL 'q(foo)'; True }, 'q(foo) is not a q-quote';
+ok !try { EVAL 'qw(a b)'; True }, 'qw(a b) is not a word quote';
+ok !try { EVAL 'my $x = qq(foo); True' }, 'qq(foo) is not a qq-quote';
+
+# With whitespace the paren IS a valid delimiter.
+is q (foo bar), 'foo bar', 'q (foo bar) — space before paren delimiter';
+my $lang = 'Raku';
+is qq (hello $lang), 'hello Raku', 'qq (...) interpolates';
+is q (($lang)), '$lang', 'q ((...)) — doubled parens after space';
+
+$_ = '9';
+is (m (9)).Str, '9', 'm (9) — space before paren delimiter matches';
+$_ = 'A';
+is (m:i (a)).Str, 'A', 'm:i (a) — space after adverb, paren delimiter';
+
+# Other delimiters right after the name still work, no space needed.
+is q{hi} ~ qq[there], 'hithere', 'brace/bracket delimiters unaffected';

--- a/t/quote-alternate-delimiters.t
+++ b/t/quote-alternate-delimiters.t
@@ -11,8 +11,9 @@ is q{{ {{ } }} }}, ' {{ } }} ',   'q{{ {{ } }} }} — nested doubled braces';
 is q[[$foo $bar]], '$foo $bar',    'q[[$foo $bar]] — doubled brackets';
 is q[[ fo] ]],    ' fo] ',        'q[[ fo] ]] — single ] inside doubled brackets';
 
-# Doubled parentheses
-is q(($foo $bar)), '$foo $bar',    'q(($foo $bar)) — doubled parens';
+# Doubled parentheses (whitespace required before a paren delimiter;
+# `q((...))` without a space is a call to a routine named `q`)
+is q (($foo $bar)), '$foo $bar',   'q (($foo $bar)) — doubled parens';
 
 # Q with doubled brackets
 is Q{{hello}},     'hello',        'Q{{hello}} — doubled braces';

--- a/t/quoting.t
+++ b/t/quoting.t
@@ -23,9 +23,10 @@ my $lang = 'Raku';
 my $qq1 = qq/hello $lang/;
 is $qq1, 'hello Raku', 'qq// interpolates variables';
 
-# qq() with parens
-my $qq2 = qq(hello $lang);
-is $qq2, 'hello Raku', 'qq() interpolates variables';
+# qq () with parens (whitespace required before a paren delimiter;
+# `qq(...)` without a space is a call to a routine named `qq`)
+my $qq2 = qq (hello $lang);
+is $qq2, 'hello Raku', 'qq () interpolates variables';
 
 # qq{} with braces
 my $qq3 = qq{hello $lang};


### PR DESCRIPTION
## Summary

Raku never allows `(` as a quoting delimiter directly after a quote construct's name or adverbs — that is call syntax (`q(...)` calls a routine named `q`). A paren delimiter requires intervening whitespace (`q (...)`). mutsu accepted the no-space form for `m//`, `mm//`, `s///`, `S///`, `ss///`, `tr///`, `TR///`, `rx//`, `q`, `qq`, `Q`, `qw`, `qww`, `qb`, `q:nf*`, `qx`/`qqx`, which silently mis-parsed calls to user routines with colliding names:

```raku
multi mm($x) { "one" }; say mm(9);   # was: an m:sigspace regex match (Nil) → now: "one"
sub qq($x) { $x * 2 };  say qq(5);   # was: the qq-quote "5"              → now: 10
sub tr($x) { $x + 1 };  say tr(5);   # was: a transliteration             → now: 6
```

All rejected forms were verified against raku (`q(foo)`, `q((foo))`, `qq(foo)`, `qw(a b)`, `q:w(a b)`, `m:i(a)`, `s:g(a)`, `ss(a)`, `S(a)`, `TR(abc)`, `qx(echo hi)` are all compile errors in Rakudo); all legal space forms (`q (...)`, `qq (...)`, `m (9)`, `m:i (a)`, `ss (a a)`, doubled `q ((...))`) still parse.

## Implementation

- Regex forms (`m`/`mm`/`s`/`S`/`ss`/`rx` in `regex/lit.rs`) track whether whitespace separated the name+adverbs from the delimiter and exclude `(` otherwise; `tr`/`TR` (`trans.rs`) and `qx`/`qqx` never allow a pre-delimiter space, so `(` is excluded outright.
- `q`/`qq`/`Q` and friends reject a leading `(` after adverb parsing; the old bare-`q(` guard (which wrongly exempted `q((`) is subsumed.
- `parse_colon_adverbs` no longer swallows trailing whitespace when no adverb follows, so callers can still see the space that distinguishes `q (...)` from `q(...)`.
- `t/quoting.t` and `t/quote-alternate-delimiters.t` asserted the illegal no-space forms (raku rejects both `qq(...)` and `q((...))`); updated to the space forms.

## Testing

- New pin: `t/paren-quote-delimiter.t` (14 tests, passes under both raku and mutsu).
- Full `t/` suite: 2331 files / 22030 tests PASS (debug build).
- Roast sweep (whitelisted S02-literals + S05 regex families): 124 files / 6792 tests PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)