### PR TITLE
feat: Nil and Any are distinct — remove the types_eqv crutch (PLAN 8.5 complete)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1113,21 +1113,21 @@ the backlog.
       per-file repros in [docs/doc-diff-backlog.md](docs/doc-diff-backlog.md) / [docs/doc-diff-sweep/](docs/doc-diff-sweep/).
       What dominates these files is analysed in the "Campaign status" bullet below (deep buckets, not
       one-liners).
-- [ ] **Leftover from the first backlog batch (re-verified 2026-07-22):** the sequence/lazy
+- **Leftover from the first backlog batch — closed 2026-07-23:** the sequence/lazy
       argument truncation (`@foo.prepend: 1,3...11`, `600.polymod(lazy …)`), `.Slip` hole
       rendering, empty-`Array` `pop` → `X::Cannot::Empty`, and lazy `.elems` → `X::Cannot::Lazy`
-      all match raku now. The one remaining divergence: **autoviv-hole `.List` renders `(Any)`
-      where raku gives `Nil`** (`my @a; @a[2]=5; @a.List` → raku `(Nil Nil 5)`; `@a.head` → raku
-      `Nil`). Needs per-element hole tracking through the List view — same territory as §8.5 /
-      [`array-hole-tracking-embedded`]; do not chase as a display-only patch.
+      all match raku, and the last divergence (autoviv-hole `.List` rendering `(Any)` where raku
+      gives `Nil`) was fixed by Nil-vs-Any campaign step 1 (#5256; `@a.cache` returning a List
+      instead of the Array itself fell in the step-4 slice).
 - **Campaign status (paused 2026-07-22).** After many slice sessions the *shallow,
       interp-shaped* wins (missing method aliases, single-behaviour mismatches) are largely
       **exhausted**. A fresh full-corpus re-sweep on the current `main` is the first step to resume —
       note the older `tmp/sweep` report can go stale after a merge, so always re-sweep before trusting
       a survey row. The **remaining findings cluster into deep buckets**, not one-liners:
-  - **Nil-vs-Any identity knot** (§8.5 / §8.44) — drives most of `perl-nutshell.rakudoc`'s
-    `no strict` autoviv examples (`@undeclared.end` → -1, `%h{missing}` → `(Any)`). Do NOT retry
-    as a small slice; see the mapped campaign.
+  - **Nil-vs-Any identity knot — RESOLVED 2026-07-23** (campaign steps 1-4, see
+    [news/2026-07.md](news/2026-07.md)): `Nil.^name`/`Nil.WHAT`/`Nil === Any`/`Nil eqv Any`
+    now match raku and the `types_eqv` crutch is gone. The `perl-nutshell.rakudoc` `no strict`
+    autoviv examples it drove should be re-swept.
   - **Object-hash `WHICH` keys** — `my %h{Any}; %h<42>:exists` must be `False` (allomorph
     `IntStr` key ≠ `Int` key); mutsu returns `True`. QuantHash/object-hash WHICH-keyed storage
     rework. Recurs in `numerics.rakudoc` and `hashmap.rakudoc`.
@@ -1173,77 +1173,13 @@ the backlog.
       fails. Corpus = `Type/X*.rakudoc` + `throws-like`-style assertions. Good QA is "fails
       correctly", not only "works".
 
-### 8.5 Nil-vs-Any identity knot (deferred deep item — fully mapped 2026-07-20)
+### 8.5 Nil-vs-Any identity knot — RESOLVED 2026-07-23
 
-- [ ] **Separate the `Nil` value from the `Any` type object.** Surfaced repeatedly by the §8.1 doc-diff
-      campaign (phasers `END say my $x` → mutsu `Nil` / raku `(Any)`; statement-prefixes `sink for`;
-      objects `.new` uninit attr). The user-visible divergences (all masked today by one crutch):
-      `Nil.^name` = `Any` (want `Nil`); `Nil === Any` / `Any === Nil` = True (want False);
-      uninitialized untyped `my $x` — `$x === Nil` = True and `$x.raku` = `Nil` (want `$x === Any`,
-      `.raku` = `Any`, `say $x` gist `(Any)`).
-- **Investigated + fully reverted 2026-07-20 — there is NO clean safe subset.** The sole reason
-      `Nil === Any` is True is one explicit arm in `src/value/types_eqv.rs`
-      (`(Nil, Package("Any")) => true`), which **masks dozens of "mutsu stored `Nil` where `Any` was
-      meant"** sites (attribute defaults, container/`.List` holes, `$_` topic, some special-var defaults).
-      Removing it cascades to **5 t/ files**; making an uninitialized `my $x` hold `Any` cascades to **6
-      t/ files + an index-underflow panic** (both the store-reset and the parser-`BareWord("Any")`
-      approaches), because **`my $x`-defaults-to-`Nil` is load-bearing across the compiler** (shadow-slot
-      capture, block-inline, do-expr value, redeclaration no-op — 6+ `Expr::Literal(nil)` special-cases)
-      **and the VM closure-cell machinery**. The three couplings are proven; `Nil.^name`="Nil" alone even
-      regresses uninit `.^name`. This is genuinely a dedicated multi-session campaign (same hard territory
-      as the §6 lexical-slot / dual-store work; #4822 was closed twice on it).
-- **The full cascade map, the dependency-ordered campaign steps, and the guardrails** (esp.
-      `roast/S02-types/nil.t` — 67 tests, whitelisted, the authoritative spec; **always run it with
-      `MUTSU_FUDGE=1`** or its `#?rakudo todo` tests false-fail) are recorded in the memory note
-      `project-nil-any-identity-knot`. Read it before any re-attempt; do **not** re-attempt as a small slice.
-- **Campaign step 1 landed 2026-07-23** (#5256): `.List` materializes array holes as literal
-      `Nil` (via the new canonical `ArrayData::hole_at` predicate; `is default` does not change
-      `.List` — only `.Slip`), argless `.head` reads the store raw (hole → `Nil`), and `=:=`
-      treats only a compile-time *literal* `Nil` operand as the Nil singleton (two reads that both
-      yield Nil stay non-identical — S03-operators/identity.t 34/37). This decouples
-      `roast/S32-array/delete.t` subtest 33 from the eqv crutch. Pin: `t/nil-list-holes.t`.
-- **Campaign step 2 landed 2026-07-23** (branch `nil-any-step2`) — every "stored Nil should be
-      Any" site found by disabling the eqv crutch locally and sweeping the full `t/` suite:
-      explicit `my $x = Nil` resets to Any (statement and expression position; the synthesized
-      no-init default keeps Nil — still load-bearing), `$_` unset-topic reads as Any (an explicitly
-      Nil-topicalized `$_` stays Nil), `$/`/`$!` `.VAR.default` report Nil, absent-key/index
-      `:delete` returns the hole type object (Any / element type) on all paths, and an unset
-      untyped scalar attribute seeds the Any type object in both constructors (post-BUILD required
-      checks treat that seed as unset). Four local tests that encoded the wrong (crutch-masked)
-      semantics were corrected against reference raku: `t/array-slice-oob.t` (Array OOB slices pad
-      Any; List/Seq pad Nil), `t/multidim-indexing.t` 6 (shaped OOB delete throws — the old
-      expectation fails under real raku), `t/vm-basic.t` 188 (`try`'s Nil resets the container to
-      Any). **Key data point: the full `t/` suite (2312 files) passes with the crutch disabled.**
-- **Campaign step 3 landed 2026-07-23** (branch `nil-any-step3`) — uninit `my $x` now seeds the
-      **Any type object**. The winning approach was neither of the two that failed in the 2026-07-20
-      investigation (parser-BareWord / store-reset): the AST keeps the synthesized `Literal(Nil)`
-      (so all 6+ compiler default-init recognition sites — redeclaration no-op, shadow-slot,
-      block-inline, do-expr — stay intact) and the **compiler substitutes the Any type object only
-      at RHS-emission time**, in the three emit sites (`compiler/stmt.rs`, `expr_block.rs`,
-      `helpers_block_inline.rs`; shared predicate `uninit_untyped_scalar_defaults_to_any`).
-      `$/`/`$!` stay Nil; `is default(...)`/`:=`-bind/explicit-init decls keep their paths. VM
-      knock-ons fixed in the same slice: (a) `=:=` — the Package-singleton shortcuts must not
-      treat two Any-holding container reads as identical (`ContainerEqNamed` excludes "Any";
-      `is_value_non_reference` includes the Any type object); (b) closure-capture boxing
-      (`box_captured_lexicals` / `box_decl_local_cell`) boxes the Any seed into a shared cell
-      exactly like the old Nil seed (cross-thread reassignment visibility); (c) the `CallFunc`
-      interpreter-carrier branch gained the same carrier writeback `ExecCall` already had (an
-      `EVAL` under `try` writes caller lexicals by name; the Nil-slot env fallback used to mask
-      the missing writeback); (d) `(my $x) does Int` stays `X::Does::TypeObject` (Any/Mu are
-      type objects even though they sit in the class registry); (e) `.Hash` on the Any type
-      object is `{}` like the old Nil arm. Pin: `t/uninit-scalar-any.t` (18 tests, raku-verified).
-      **Full `t/` (2321 files, 21932 tests) passes with the crutch disabled.**
-- **Remaining steps:** 4 (remove the eqv crutch LAST; also lets `Nil.^name`/`Nil === Any`
-      divergences close — nil.t/identity.t/delete.t and full `t/` already pass crutch-off as of
-      step 3), then re-check `.cache` on a holey Array (returns a List today, raku returns the
-      Array itself — noticed during step 1, unrelated).
-- **Step-4 prerequisite found 2026-07-23:** an **unpassed optional parameter** (`sub w($p?)`)
-      still seeds Nil — visible as `$p.raku` = `Nil` (raku: `Any`; pointy blocks: `Mu`). `===`/
-      `.^name` are crutch-masked today, so step 4 would surface it. Param binding is spread
-      across the light/typed/named/method dispatch paths, so it is its own slice.
-- **Cost/benefit** (for the remaining step 4): payoff is closing the `Nil.^name`/`Nil === Any`
-      divergences and deleting the last band-aid. Related: §6 (dual-store / lexical slot),
-      [`array-hole-tracking-embedded`], [ADR-0001] container-repr.
+- The four-step campaign landed in full (#5256 → #5264 → #5273/#5280 → step 4); the
+  `types_eqv` `(Nil, Package("Any"))` crutch is deleted and `Nil.^name`/`Nil.WHAT`/
+  `Nil === Any`/`Nil eqv Any`/`Nil.gist` all match raku. Full history, mechanisms, and
+  the per-step knock-on lists are recorded in [news/2026-07.md](news/2026-07.md)
+  (2026-07-23 entry) and the memory note `project-nil-any-identity-knot`.
 
 ### 8.6 `.WHO`/`.HOW` render without their metamodel detail — mostly done; internals leftover
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4448,6 +4448,49 @@ archive of what was removed from the document body.
   (real programs — see the 2026-07-14 PLAN/BLOCKERS re-audit #4498). Releases v0.3.0 /
   v0.3.1 shipped; bench CI now records history on every main push (#4456).
 
+## 2026-07-23: Nil-vs-Any identity knot resolved — the PLAN 8.5 campaign lands in full
+
+The four-step campaign (mapped 2026-07-20 after two failed direct attempts) is complete;
+the `types_eqv` `(Nil, Package("Any"))` crutch is deleted. `Nil.^name` = `Nil`,
+`Nil.WHAT === Nil` (the `.WHAT` returns the Nil value itself, not a Package wrapper),
+`Nil === Any` / `Nil eqv Any` = `False`, and `Nil.gist` = `"Nil"` — all raku-verified.
+
+- **Step 1** (#5256): `.List` materializes array holes as literal `Nil`
+  (`ArrayData::hole_at`), argless `.head` reads the store raw, `=:=` treats only a
+  literal `Nil` operand as the singleton. Pin: `t/nil-list-holes.t`.
+- **Step 2** (#5264): every crutch-masked storage site stores `Any` — explicit
+  `my $x = Nil` resets to Any, `$_` unset-topic, `:delete` hole type objects, unset
+  untyped attribute seeds. Found by fault-injection: disable the crutch, sweep full `t/`.
+- **Step 3** (#5273): uninit untyped `my $x` holds the **Any type object**. The AST keeps
+  the synthesized `Literal(Nil)` (compiler default-init recognition intact); the compiler
+  substitutes Any at RHS-emission time only. Five VM knock-ons fixed at mechanism level
+  (`=:=` Package-singleton arms, closure-cell boxing of the Any seed, CallFunc carrier
+  writeback, `does` on type objects, `.Hash` on Any). Pin: `t/uninit-scalar-any.t`.
+- **Step 3.5** (#5280): unpassed optional params seed their type object — Any for
+  routines, Mu for pointy/bare blocks (incl. destructure and short for-loop chunks),
+  the constraint's object for typed optionals. `ParamDef.block_param` +
+  `missing_optional_param_value` as the single seed authority; the light-typed,
+  method-dispatch and sub-signature paths each hardcoded Nil before. Pin:
+  `t/optional-param-seed.t`.
+- **Step 4** (this entry): the crutch arm is removed; `value_type_name`/`.WHAT`/HOW
+  report `Nil` for the Nil value; `values_identical` (=== ) follows eqv. Knock-ons fixed
+  at mechanism level: the anonymous `$` scalar reads as Any like `my $x`
+  (S03-operators/context.t), a user subclass of Array/Hash defaults missing elements to
+  Any via a cheap parent-chain query, made lazy on the instance index path (net faster
+  than before), `Nil.gist` no longer masquerades as `(Any)` (the array-store hole
+  rendering keeps its own translation), `::('Nil') === Nil` is True (a `Package("Nil")`
+  denotes the same singleton), and `@a.cache` returns the Array itself instead of a List
+  view. Pin: `t/nil-any-identity.t` (16 tests).
+
+Full `t/` (2332 files, 22048 tests) passes at every step; the only local roast sweep
+failures are the known debug-build-slow files (`S04-declarations/state.t`,
+`S12-methods/private.t` — equally slow on main, release CI unaffected).
+
+Also landed the same day, discovered by the campaign's raku-diff probing: `(` is never a
+quote/regex delimiter without preceding whitespace (#5281) — `multi mm($x)`, `sub qq`,
+`sub tr` etc. were uncallable with paren call syntax because `mm(9)` mis-parsed as an
+m:sigspace regex, `qq(5)` as a quote, `tr(5)` as a transliteration.
+
 ## References
 
 - The whitelist stands at **1338** as of this writing (2026-07-01, at `4c311c71`).

--- a/src/builtins/methods_0arg/collection.rs
+++ b/src/builtins/methods_0arg/collection.rs
@@ -1180,6 +1180,11 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     ll.with_cached_no_sink(),
                 ))));
             }
+            // An already-reified Positional caches as itself: `@a.cache` is
+            // `@a` (an Array, not a List view of it).
+            if matches!(target.view(), ValueView::Array(_, kind) if kind.is_real_array()) {
+                return Some(Ok(target.clone()));
+            }
             let items = target
                 .as_list_items()
                 .map(|items| items.to_vec())

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -118,17 +118,10 @@ pub(super) fn dispatch(
                 )))
             }
         }
-        ValueView::Nil => {
-            if method == "raku" || method == "perl" {
-                Some(Ok(Value::str_from("Nil")))
-            } else {
-                // gist returns "(Any)" because mutsu uses the Nil
-                // value for uninitialized variables (which are actually Any).
-                // The literal `Nil.gist` case is handled by compile-time
-                // folding in the compiler (see compiler/expr.rs).
-                Some(Ok(Value::str_from("(Any)")))
-            }
-        }
+        // raku/perl and gist of the Nil value are all "Nil". (Uninitialized
+        // variables hold the Any type object since PLAN 8.5, so a runtime
+        // Nil here is a genuine Nil, not an uninit placeholder.)
+        ValueView::Nil => Some(Ok(Value::str_from("Nil"))),
         ValueView::FatRat(n, d) => {
             if d == 0 && (method == "gist" || method == "Str") {
                 Some(Err(RuntimeError::numeric_divide_by_zero_with(Some(

--- a/src/runtime/builtins_multidim_ops.rs
+++ b/src/runtime/builtins_multidim_ops.rs
@@ -274,8 +274,8 @@ impl Interpreter {
         let value = multidim_index(target, &indices);
         // An unassigned shaped cell holds its unset seed — Nil or the Any
         // type object — and does not exist yet.
-        let raw_exists = !value.is_nil()
-            && !(crate::runtime::utils::is_shaped_array(target) && value.is_any_type_object());
+        let raw_exists = !(value.is_nil()
+            || crate::runtime::utils::is_shaped_array(target) && value.is_any_type_object());
         let exists = if negated { !raw_exists } else { raw_exists };
         let key = make_key_tuple(&indices);
 

--- a/src/runtime/builtins_multidim_ops.rs
+++ b/src/runtime/builtins_multidim_ops.rs
@@ -272,7 +272,10 @@ impl Interpreter {
         }
 
         let value = multidim_index(target, &indices);
-        let raw_exists = !value.is_nil();
+        // An unassigned shaped cell holds its unset seed — Nil or the Any
+        // type object — and does not exist yet.
+        let raw_exists = !value.is_nil()
+            && !(crate::runtime::utils::is_shaped_array(target) && value.is_any_type_object());
         let exists = if negated { !raw_exists } else { raw_exists };
         let key = make_key_tuple(&indices);
 

--- a/src/runtime/methods.rs
+++ b/src/runtime/methods.rs
@@ -25,8 +25,9 @@ fn make_nonneg_failure() -> Value {
     Value::make_instance(Symbol::intern("Failure"), failure_attrs)
 }
 
-/// Recursively fetch @target[indices...]; returns Failure for any negative index,
-/// or Nil if the chain runs out of elements.
+/// Recursively fetch @target[indices...]; returns Failure for any negative index.
+/// A missing slot of a real Array reads as its element default (`Any`), like a
+/// single-dim out-of-range read; a List miss (or a non-list link) reads as Nil.
 pub(crate) fn multidim_at_pos(target: &Value, indices: &[Value]) -> Value {
     let mut cur = target.clone();
     for idx in indices {
@@ -35,10 +36,18 @@ pub(crate) fn multidim_at_pos(target: &Value, indices: &[Value]) -> Value {
         let Some(i) = pos_index(idx) else {
             return make_nonneg_failure();
         };
+        let is_real_array =
+            matches!(cur.view(), crate::value::ValueView::Array(_, kind) if kind.is_real_array());
         let Some(items) = cur.as_list_items() else {
             return Value::NIL;
         };
-        cur = items.get(i).cloned().unwrap_or(Value::NIL);
+        cur = items.get(i).cloned().unwrap_or_else(|| {
+            if is_real_array {
+                Value::package(Symbol::intern("Any"))
+            } else {
+                Value::NIL
+            }
+        });
     }
     cur.into_descalarized()
 }

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2270,11 +2270,23 @@ impl Interpreter {
                 match value.view() {
                     ValueView::Nil => "Nil".to_string(),
                     ValueView::Array(items, kind) => {
+                        // Shaped arrays join their rows with a newline, like
+                        // the pure fast path (`say my @a[2,2]` is one row per
+                        // line even when cells are type objects).
+                        let sep = if kind == ArrayKind::Shaped
+                            && items
+                                .iter()
+                                .any(|v| matches!(v.view(), ValueView::Array(..)))
+                        {
+                            "\n "
+                        } else {
+                            " "
+                        };
                         let inner = items
                             .iter()
                             .map(|item| gist_item(interp, item))
                             .collect::<Vec<_>>()
-                            .join(" ");
+                            .join(sep);
                         match kind {
                             ArrayKind::List | ArrayKind::ItemList => format!("({inner})"),
                             _ => format!("[{inner}]"),

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -80,7 +80,9 @@ impl Interpreter {
                 };
                 return Ok(Value::package(Symbol::intern(visible)));
             }
-            ValueView::Nil => "Any",
+            // `Nil.WHAT` IS the Nil type object — the same object the `Nil`
+            // term denotes (`Nil.WHAT === Nil` is True), not a Package wrapper.
+            ValueView::Nil => return Ok(Value::NIL),
             ValueView::Package(name) => {
                 let resolved = name.resolve();
                 let visible = if crate::value::is_internal_anon_type_name(&resolved) {
@@ -283,7 +285,7 @@ impl Interpreter {
                     ValueView::Hash(_) => "Hash",
                     ValueView::Array(_, kind) if kind.is_real_array() => "Array",
                     ValueView::Array(_, _) => "List",
-                    ValueView::Nil => "Any",
+                    ValueView::Nil => "Nil",
                     _ => "Mu",
                 };
                 tn.to_string()

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -663,10 +663,29 @@ impl Interpreter {
                 }
                 _ => "Array".to_string(),
             };
+            // Storing Nil into a fresh array element resets it to the element
+            // default: Any for untyped, the element type object for typed
+            // (`my Int @a; @a.push(Nil)` stores `Int`).
+            let nil_to_elem_default = |slf: &mut Self, vals: Vec<Value>| -> Vec<Value> {
+                if !vals.iter().any(Value::is_nil) {
+                    return vals;
+                }
+                let default = match slf.var_type_constraint(&key) {
+                    Some(c) => {
+                        let nominal = slf.nominal_type_object_name_for_constraint(&c);
+                        Value::package(crate::symbol::Symbol::intern(&nominal))
+                    }
+                    None => Value::package(crate::symbol::Symbol::intern("Any")),
+                };
+                vals.into_iter()
+                    .map(|v| if v.is_nil() { default.clone() } else { v })
+                    .collect()
+            };
             match method {
                 "push" => {
                     let normalized_args = Self::normalize_push_unshift_args(args);
                     self.check_container_element_types(&key, &target, &normalized_args)?;
+                    let normalized_args = nil_to_elem_default(self, normalized_args);
                     let result = self.push_to_shared_var(&key, normalized_args, &target);
                     self.reattach_array_type_metadata(&key, &saved_meta);
                     return Ok(result);
@@ -678,6 +697,7 @@ impl Interpreter {
                     // as-is (no recursive flattening).
                     let flat_values = flatten_append_args(args);
                     self.check_container_element_types(&key, &target, &flat_values)?;
+                    let flat_values = nil_to_elem_default(self, flat_values);
                     let result = if let Some(slot) = self.env.get_mut(&key)
                         && let Some(r) = slot.with_array_mut(|arc_items, kind| {
                             let kind = *kind;
@@ -703,6 +723,7 @@ impl Interpreter {
                 "unshift" => {
                     let normalized_args = Self::normalize_push_unshift_args(args);
                     self.check_container_element_types(&key, &target, &normalized_args)?;
+                    let normalized_args = nil_to_elem_default(self, normalized_args);
                     let result = if let Some(slot) = self.env.get_mut(&key)
                         && let Some(r) = slot.with_array_mut(|arc_items, kind| {
                             let kind = *kind;

--- a/src/runtime/methods_signature_shaped.rs
+++ b/src/runtime/methods_signature_shaped.rs
@@ -98,7 +98,12 @@ impl Interpreter {
         let len = dims[0];
         if dims.len() == 1 {
             let mut items = Vec::new();
-            Self::autoviv_resize(&mut items, len, Value::NIL)?;
+            // Unused shaped cells hold the Any type object (the untyped
+            // element default), like a statement-form shaped declaration —
+            // `(my @b[42])` must be eqv to `my @a[42]`. A typed shaped decl
+            // (`my Int @a[3]`) re-seeds these cells with its element type via
+            // coerce_typed_array_elements (the unset-seed arm).
+            Self::autoviv_resize(&mut items, len, Value::package(Symbol::intern("Any")))?;
             let value = Value::shaped_array(items);
             crate::runtime::utils::mark_shaped_array(&value, Some(dims));
             return Ok(value);

--- a/src/runtime/runtime_class_query.rs
+++ b/src/runtime/runtime_class_query.rs
@@ -196,6 +196,28 @@ impl Interpreter {
         false
     }
 
+    /// Whether a user-declared class inherits (transitively) from Array or
+    /// Hash. Exact-name registry lookups only — this runs on the
+    /// missing-element read path, so it must stay cheap for non-container
+    /// classes (one map miss).
+    pub(crate) fn class_inherits_array_or_hash(&self, name: &str) -> bool {
+        if name == "Array" || name == "Hash" {
+            return true;
+        }
+        let parents = {
+            let reg = self.registry();
+            reg.classes.get(name).map(|cd| cd.parents.clone())
+        };
+        if let Some(parents) = parents {
+            for parent in &parents {
+                if self.class_inherits_array_or_hash(parent) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
     /// Check if a class has scoped subs declared in its body.
     /// True if `class_name` has recorded class-body `my` lexicals (statics)
     /// stored in `package_lexicals` by `register_class_decl`. A method reading

--- a/src/runtime/runtime_container.rs
+++ b/src/runtime/runtime_container.rs
@@ -415,6 +415,45 @@ impl Interpreter {
                     _ => out.push(v.clone()),
                 }
             }
+            // A shaped array's unset cell seed (the Any type object) re-seeds
+            // as the element type object, like the variable path's typed
+            // coercion (`has Int @.g[2;2]` cells read as `Int`).
+            fn reseed_shaped_cells(v: &Value, elem: &Value) -> Value {
+                let ValueView::Array(items, kind) = v.view() else {
+                    return v.clone();
+                };
+                if !items
+                    .iter()
+                    .any(|it| it.is_any_type_object() || matches!(it.view(), ValueView::Array(..)))
+                {
+                    return v.clone();
+                }
+                let rebuilt: Vec<Value> = items
+                    .iter()
+                    .map(|it| {
+                        if it.is_any_type_object() {
+                            elem.clone()
+                        } else if matches!(it.view(), ValueView::Array(..)) {
+                            reseed_shaped_cells(it, elem)
+                        } else {
+                            it.clone()
+                        }
+                    })
+                    .collect();
+                Value::array_with_kind(
+                    crate::gc::Gc::new(crate::value::ArrayData::new(rebuilt)),
+                    kind,
+                )
+            }
+            let value = if matches!(value.view(), ValueView::Array(_, ArrayKind::Shaped)) {
+                let elem = Value::package(crate::symbol::Symbol::intern(elem_type));
+                let shape = crate::runtime::utils::shaped_array_shape(&value);
+                let reseeded = reseed_shaped_cells(&value, &elem);
+                crate::runtime::utils::mark_shaped_array(&reseeded, shape.as_deref());
+                reseeded
+            } else {
+                value
+            };
             let mut elems: Vec<Value> = Vec::new();
             match value.view() {
                 ValueView::Array(items, ArrayKind::Shaped) => {
@@ -427,12 +466,22 @@ impl Interpreter {
                 _ => {}
             }
             for it in &elems {
-                if !it.is_nil() && !self.type_matches_value(elem_type, it) {
+                if !it.is_nil()
+                    && !self.type_matches_value(elem_type, it)
+                    // The freshly re-seeded element type object is type-legal.
+                    && !(matches!(it.view(), ValueView::Package(p) if p.resolve() == elem_type))
+                {
                     return Err(crate::runtime::utils::type_check_element_typed_error(
                         &display, elem_type, it,
                     ));
                 }
             }
+            let info = ContainerTypeInfo {
+                value_type: elem_type.to_string(),
+                key_type: key_type.map(|k| k.to_string()),
+                declared_type: None,
+            };
+            return Ok(self.tag_container_metadata(value, info));
         }
         let info = ContainerTypeInfo {
             value_type: elem_type.to_string(),

--- a/src/runtime/utils/coerce_containers.rs
+++ b/src/runtime/utils/coerce_containers.rs
@@ -295,6 +295,25 @@ pub(crate) fn build_hash_from_items(items: Vec<Value>) -> Result<Value, RuntimeE
 /// TODO: Properly implement lazy arrays that reify elements on demand.
 const MAX_ARRAY_EXPAND: i64 = 100_000;
 
+/// Replace Nil elements with the Any type object when materializing values
+/// into a fresh untyped real Array: assigning Nil to an element container
+/// resets it to its default (`my @a = (..., Nil, ...)` stores Any).
+pub(crate) fn nil_elems_to_any(items: Vec<Value>) -> Vec<Value> {
+    if !items.iter().any(Value::is_nil) {
+        return items;
+    }
+    items
+        .into_iter()
+        .map(|v| {
+            if v.is_nil() {
+                Value::package(crate::symbol::Symbol::intern("Any"))
+            } else {
+                v
+            }
+        })
+        .collect()
+}
+
 pub(crate) fn coerce_to_array(value: Value) -> Value {
     fn metadata_shape_for_items(
         items: &crate::gc::Gc<crate::value::ArrayData>,
@@ -309,7 +328,10 @@ pub(crate) fn coerce_to_array(value: Value) -> Value {
             // `ContainerRef` cell (Phase 2); decontainerize it on copy so a
             // later write through the bound source does not leak into the copy.
             // Only rebuild when a cell is actually present (common path keeps
-            // sharing the Arc, so there is no per-assignment cost).
+            // sharing the Arc, so there is no per-assignment cost). Nil
+            // elements are left alone here — this coercion is type-blind, and
+            // the assignment sites convert them to the element default (Any,
+            // or the typed default via coerce_typed_array_elements).
             let items = if items
                 .iter()
                 .any(|v| matches!(v.view(), ValueView::ContainerRef(_)))
@@ -430,7 +452,8 @@ pub(crate) fn coerce_to_array(value: Value) -> Value {
             // element VALUES, so decontainerize any shared `ContainerRef` cells the
             // Seq carries (e.g. `my @g = @a.grep(...)`, whose Seq references @a's
             // rw slots) so a later write through the copy does not leak into the
-            // source. Only rebuild when a cell is actually present.
+            // source. Only rebuild when a cell is actually present. (Nil
+            // elements are handled by the assignment sites, not here.)
             let arc = if items
                 .iter()
                 .any(|v| matches!(v.view(), ValueView::ContainerRef(_)))

--- a/src/runtime/utils/gist.rs
+++ b/src/runtime/utils/gist.rs
@@ -140,6 +140,17 @@ pub(crate) fn gist_value(value: &Value) -> String {
             // Nested real arrays recurse through this same arm, so their cells
             // are handled too; a List/Seq keeps a genuine Nil (its own arm).
             let is_real = kind.is_real_array();
+            // Shaped arrays join their rows with a newline (`say my @a[2,2]`
+            // prints one row per line), matching the fast-path gist.
+            let sep = if kind == crate::value::ArrayKind::Shaped
+                && items
+                    .iter()
+                    .any(|v| matches!(v.view(), ValueView::Array(..)))
+            {
+                "\n "
+            } else {
+                " "
+            };
             let inner = items
                 .iter()
                 .map(|v| {
@@ -150,7 +161,7 @@ pub(crate) fn gist_value(value: &Value) -> String {
                     }
                 })
                 .collect::<Vec<_>>()
-                .join(" ");
+                .join(sep);
             SEEN_PTRS.with(|seen| pop_ptr(seen, ptr));
             match kind {
                 crate::value::ArrayKind::Array

--- a/src/runtime/utils/type_misc.rs
+++ b/src/runtime/utils/type_misc.rs
@@ -56,7 +56,7 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
                 "Mix"
             }
         }
-        ValueView::Nil => "Any",
+        ValueView::Nil => "Nil",
         ValueView::Sub(data) => match data.env.get("__mutsu_callable_type").map(Value::view) {
             Some(ValueView::Str(kind)) if kind.as_str() == "Method" => "Method",
             Some(ValueView::Str(kind)) if kind.as_str() == "Submethod" => "Submethod",

--- a/src/value/types_eqv.rs
+++ b/src/value/types_eqv.rs
@@ -300,11 +300,11 @@ impl Value {
             }
             // Other Instance types: use identity comparison
             (ValueView::Instance { .. }, ValueView::Instance { .. }) => self == other,
-            // Nil and Package("Any") are eqv: both represent the undefined type object Any.
-            // This matters for containerized contexts (e.g. hash values).
+            // The Nil value IS the Nil type object: a `Package("Nil")` obtained
+            // via type lookup (`::('Nil')`) denotes the same singleton.
             (ValueView::Nil, ValueView::Package(name))
             | (ValueView::Package(name), ValueView::Nil)
-                if name == "Any" =>
+                if name == "Nil" =>
             {
                 true
             }

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -2120,9 +2120,12 @@ impl Interpreter {
                             // `@a.push` compiles to `ArrayPush` only for single-arg pushes on
                             // a *local* array; the captured-closure and multi-arg forms reach
                             // here as `CallMethodMut`. Mirror the `ArrayPush` opcode's env-bound
-                            // branch (`normalize_push_unshift_args` then extend).
-                            let norm = crate::runtime::Interpreter::normalize_push_unshift_args(
-                                args.to_vec(),
+                            // branch (`normalize_push_unshift_args` then extend). This path is
+                            // gated to untyped arrays, so a Nil element stores Any.
+                            let norm = crate::runtime::utils::nil_elems_to_any(
+                                crate::runtime::Interpreter::normalize_push_unshift_args(
+                                    args.to_vec(),
+                                ),
                             );
                             items.extend(norm);
                             Value::array_with_kind(
@@ -2131,7 +2134,9 @@ impl Interpreter {
                             )
                         }
                         "append" | "prepend" => {
-                            let flat = crate::runtime::flatten_append_args(args.to_vec());
+                            let flat = crate::runtime::utils::nil_elems_to_any(
+                                crate::runtime::flatten_append_args(args.to_vec()),
+                            );
                             if method == "append" {
                                 items.extend(flat);
                             } else {
@@ -2145,8 +2150,10 @@ impl Interpreter {
                             )
                         }
                         "unshift" => {
-                            let norm = crate::runtime::Interpreter::normalize_push_unshift_args(
-                                args.to_vec(),
+                            let norm = crate::runtime::utils::nil_elems_to_any(
+                                crate::runtime::Interpreter::normalize_push_unshift_args(
+                                    args.to_vec(),
+                                ),
                             );
                             for (i, v) in norm.into_iter().enumerate() {
                                 items.insert(i, v);

--- a/src/vm/vm_data_push_ops.rs
+++ b/src/vm/vm_data_push_ops.rs
@@ -3,6 +3,44 @@ use super::*;
 use crate::value::RuntimeError;
 
 impl Interpreter {
+    /// Storing Nil into a fresh array element resets it to the element
+    /// default: Any for untyped arrays, the element type object for typed
+    /// (`my Int @a; @a.push(Nil)` stores `Int`). Slips convert per element.
+    fn push_nil_to_elem_default(&mut self, target_name: &str, val: Value) -> Value {
+        let has_nil = match val.view() {
+            ValueView::Slip(items) => items.iter().any(Value::is_nil),
+            _ => val.is_nil(),
+        };
+        if !has_nil {
+            return val;
+        }
+        let default = match self
+            .var_type_constraint_fast(target_name)
+            .map(|s| s.to_string())
+        {
+            Some(c) => {
+                let nominal = loan_env!(self, nominal_type_object_name_for_constraint(&c));
+                Value::package(crate::symbol::Symbol::intern(&nominal))
+            }
+            None => Value::package(crate::symbol::Symbol::intern("Any")),
+        };
+        match val.view() {
+            ValueView::Slip(items) => Value::slip(
+                items
+                    .iter()
+                    .map(|v| {
+                        if v.is_nil() {
+                            default.clone()
+                        } else {
+                            v.clone()
+                        }
+                    })
+                    .collect(),
+            ),
+            _ => default,
+        }
+    }
+
     /// Fast path for @arr.push(val) — directly appends to the array Arc.
     pub(super) fn exec_array_push_op(
         &mut self,
@@ -28,6 +66,7 @@ impl Interpreter {
         // interpreter fallback.
         if self.shared_vars_active {
             let val = self.stack.pop().unwrap_or(Value::NIL);
+            let val = self.push_nil_to_elem_default(target_name, val);
             let target = self.env().get(target_name).cloned().unwrap_or(Value::NIL);
             // Track B/Track C: a `state @a` under an active thread context is a
             // shared `ContainerRef` cell. Push INTO the cell under its lock
@@ -88,7 +127,10 @@ impl Interpreter {
             self.stack.push(result);
             return Ok(());
         }
-        let mut val = self.stack.pop().unwrap_or(Value::NIL);
+        let mut val = {
+            let popped = self.stack.pop().unwrap_or(Value::NIL);
+            self.push_nil_to_elem_default(target_name, popped)
+        };
 
         // Reference push (`@a.push(@b)` / `@a.push(%h)`): Raku's non-flattening
         // `**@` slurpy stores the container itself, so later mutations of the

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -503,6 +503,11 @@ impl Interpreter {
                             // a topic explicitly set to Nil (e.g. `Xorelse`
                             // topicalizing a Nil operand) must stay Nil.
                             Ok(Value::package(Symbol::intern("Any")))
+                        } else if name.starts_with("__ANON_STATE_") {
+                            // An anonymous scalar (`$`) is a declared but
+                            // uninitialized scalar: it reads as the Any type
+                            // object, like `my $x` (S03-operators/context.t).
+                            Ok(Value::package(Symbol::intern("Any")))
                         } else {
                             Ok(Value::NIL)
                         }

--- a/src/vm/vm_helpers_lazy.rs
+++ b/src/vm/vm_helpers_lazy.rs
@@ -182,6 +182,12 @@ impl Interpreter {
         let r = self.force_lazy_list_vm_inner(list);
         self.restore_readonly_state(saved_readonly);
         self.reconcile_caller_after_lazy_force(caller_code);
+        // An array-context lazy list IS the array's element store: a Nil the
+        // pipe produced resets its fresh element container to Any, like any
+        // other store into an untyped array element.
+        if list.in_array_context() {
+            return r.map(crate::runtime::utils::nil_elems_to_any);
+        }
         r
     }
 
@@ -427,6 +433,10 @@ impl Interpreter {
         let r = self.force_lazy_list_vm_n_inner(list, needed);
         self.restore_readonly_state(saved_readonly);
         self.reconcile_caller_after_lazy_force(caller_code);
+        // See force_lazy_list_vm: array-context elements store Any, not Nil.
+        if list.in_array_context() {
+            return r.map(crate::runtime::utils::nil_elems_to_any);
+        }
         r
     }
 

--- a/src/vm/vm_misc_typed_range.rs
+++ b/src/vm/vm_misc_typed_range.rs
@@ -16,17 +16,23 @@ impl Interpreter {
             "Array" | "Hash" | "List" | "Seq" | "Positional" | "Associative"
         );
         match value.view() {
-            ValueView::Array(items, ..) => {
+            ValueView::Array(items, kind) => {
+                // A shaped array's unset cell seed (the Any type object from
+                // `Array.new(:shape(...))`) is acceptable like a Nil cell: the
+                // typed coercion re-seeds it with the element type object.
+                let shaped = kind == crate::value::ArrayKind::Shaped;
                 if is_container_constraint {
                     // Each element is checked as a whole against the constraint
-                    items
-                        .iter()
-                        .all(|item| self.type_matches_value(constraint, item))
+                    items.iter().all(|item| {
+                        (shaped && item.is_any_type_object())
+                            || self.type_matches_value(constraint, item)
+                    })
                 } else {
                     // Recurse into sub-arrays for simple element types
-                    items
-                        .iter()
-                        .all(|item| self.array_elements_match_constraint(constraint, item))
+                    items.iter().all(|item| {
+                        (shaped && item.is_any_type_object())
+                            || self.array_elements_match_constraint(constraint, item)
+                    })
                 }
             }
             ValueView::Seq(items) => {

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -573,16 +573,18 @@ impl Interpreter {
             }
             _ => (raw_val, false, Vec::new()),
         };
-        // For typed container elements, explicit `is default(...)` wins over
-        // the nominal type-object fallback when Nil is assigned.
-        let val = if val.is_nil() {
+        // Assigning Nil to a container element resets it to its default:
+        // explicit `is default(...)` wins, then the typed nominal type object,
+        // then Any for an untyped element (raku: `@a[0] = Nil; @a[0]` is Any).
+        // A `:=` bind replaces the container, so Nil stays Nil there.
+        let val = if val.is_nil() && !bind_mode {
             if let Some(default) = self.var_default(&var_name) {
                 default.clone()
             } else if let Some(constraint) = loan_env!(self, var_type_constraint(&var_name)) {
                 let nominal = loan_env!(self, nominal_type_object_name_for_constraint(&constraint));
                 Value::package(Symbol::intern(&nominal))
             } else {
-                val
+                Value::package(Symbol::intern("Any"))
             }
         } else {
             val

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -574,12 +574,20 @@ impl Interpreter {
             _ => (raw_val, false, Vec::new()),
         };
         // Assigning Nil to a container element resets it to its default:
-        // explicit `is default(...)` wins, then the typed nominal type object,
-        // then Any for an untyped element (raku: `@a[0] = Nil; @a[0]` is Any).
-        // A `:=` bind replaces the container, so Nil stays Nil there.
+        // explicit `is default(...)` wins — name-keyed, or attached to the
+        // container itself (a `%h is raw` param loses the name metadata) —
+        // then the typed nominal type object, then Any for an untyped element
+        // (raku: `@a[0] = Nil; @a[0]` is Any). An `is default(Nil)` container
+        // genuinely stores Nil. A `:=` bind replaces the container, so Nil
+        // stays Nil there.
         let val = if val.is_nil() && !bind_mode {
             if let Some(default) = self.var_default(&var_name) {
                 default.clone()
+            } else if let Some(default) = self
+                .get_env_with_main_alias(&var_name)
+                .and_then(|t| self.container_default(&t))
+            {
+                default
             } else if let Some(constraint) = loan_env!(self, var_type_constraint(&var_name)) {
                 let nominal = loan_env!(self, nominal_type_object_name_for_constraint(&constraint));
                 Value::package(Symbol::intern(&nominal))

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -146,11 +146,28 @@ impl Interpreter {
                     .map(Value::view)
                 {
                     Some(ValueView::Bool(true)) => Value::lazy_list(list.clone()),
-                    _ => Value::real_array(self.force_lazy_list_vm(&list)?),
+                    _ => Value::real_array(crate::runtime::utils::nil_elems_to_any(
+                        self.force_lazy_list_vm(&list)?,
+                    )),
                 }
             } else {
                 runtime::coerce_to_array(raw_val)
             };
+            // An untyped `@` assignment resets Nil elements to Any (their
+            // fresh containers' default); typed arrays keep Nil for the typed
+            // element coercion downstream.
+            if loan_env!(self, var_type_constraint(name)).is_none()
+                && let ValueView::Array(items, kind) = assigned.view()
+                && kind.is_real_array()
+                && items.iter().any(Value::is_nil)
+            {
+                assigned = Value::array_with_kind(
+                    crate::gc::Gc::new(crate::value::ArrayData::new(
+                        crate::runtime::utils::nil_elems_to_any(items.to_vec()),
+                    )),
+                    kind,
+                );
+            }
             let class_name = match self.locals[idx].view() {
                 ValueView::Instance { class_name, .. } => Some(class_name),
                 ValueView::Package(class_name) => Some(class_name),

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -161,12 +161,12 @@ impl Interpreter {
                 && kind.is_real_array()
                 && items.iter().any(Value::is_nil)
             {
-                assigned = Value::array_with_kind(
-                    crate::gc::Gc::new(crate::value::ArrayData::new(
-                        crate::runtime::utils::nil_elems_to_any(items.to_vec()),
-                    )),
-                    kind,
-                );
+                // Clone the ArrayData so shape/default/type metadata survive;
+                // only the items are rewritten.
+                let mut data = (**items).clone();
+                data.items =
+                    crate::runtime::utils::nil_elems_to_any(std::mem::take(&mut data.items));
+                assigned = Value::array_with_kind(crate::gc::Gc::new(data), kind);
             }
             let class_name = match self.locals[idx].view() {
                 ValueView::Instance { class_name, .. } => Some(class_name),

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -901,7 +901,9 @@ impl Interpreter {
                             Some(ValueView::Bool(true)) => {
                                 Value::lazy_list(crate::gc::Gc::new(list.with_array_context()))
                             }
-                            _ => Value::real_array(self.force_lazy_list_vm(&list)?),
+                            _ => Value::real_array(crate::runtime::utils::nil_elems_to_any(
+                                self.force_lazy_list_vm(&list)?,
+                            )),
                         }
                     }
                     ValueView::LazyIoLines { .. } => {
@@ -924,6 +926,24 @@ impl Interpreter {
                     }
                 }
             };
+            // An untyped `@` assignment resets Nil elements to Any (their
+            // fresh containers' default; `my @a = (1,2)[1,2]` is `[2, Any]`).
+            // Typed arrays keep Nil here — the typed element coercion below
+            // converts it to the element type object instead. Binds keep the
+            // source values untouched.
+            if !is_bind
+                && loan_env!(self, var_type_constraint(name)).is_none()
+                && let ValueView::Array(items, kind) = assigned.view()
+                && kind.is_real_array()
+                && items.iter().any(Value::is_nil)
+            {
+                assigned = Value::array_with_kind(
+                    crate::gc::Gc::new(crate::value::ArrayData::new(
+                        crate::runtime::utils::nil_elems_to_any(items.to_vec()),
+                    )),
+                    kind,
+                );
+            }
             // Mark a genuine bound array SLICE (`@slice := @array[1,2]`, §4
             // BLOCKERS.md test 15): its OWN elements are shared `ContainerRef`
             // cells from the bind-time slice promotion (`vm_var_index_ops.rs`).

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -937,12 +937,12 @@ impl Interpreter {
                 && kind.is_real_array()
                 && items.iter().any(Value::is_nil)
             {
-                assigned = Value::array_with_kind(
-                    crate::gc::Gc::new(crate::value::ArrayData::new(
-                        crate::runtime::utils::nil_elems_to_any(items.to_vec()),
-                    )),
-                    kind,
-                );
+                // Clone the ArrayData so shape/default/type metadata survive;
+                // only the items are rewritten.
+                let mut data = (**items).clone();
+                data.items =
+                    crate::runtime::utils::nil_elems_to_any(std::mem::take(&mut data.items));
+                assigned = Value::array_with_kind(crate::gc::Gc::new(data), kind);
             }
             // Mark a genuine bound array SLICE (`@slice := @array[1,2]`, §4
             // BLOCKERS.md test 15): its OWN elements are shared `ContainerRef`

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -367,6 +367,18 @@ impl Interpreter {
                 coerced_items.push(Self::native_fill_for_constraint(Some(constraint)));
                 continue;
             }
+            // A shaped declaration's unset cell seed (the Any type object from
+            // `Array.new(:shape(...))`) re-seeds as the element type object,
+            // exactly like a Nil cell. Only the no-initializer shaped form —
+            // a user-supplied `Any` element must still fail the type check.
+            if kind == crate::value::ArrayKind::Shaped
+                && !explicit_initializer
+                && item.is_any_type_object()
+            {
+                let base = crate::runtime::types::strip_type_smiley(constraint).0;
+                coerced_items.push(Value::package(crate::symbol::Symbol::intern(base)));
+                continue;
+            }
             if item.is_nil() {
                 if let Some(default) = self.var_default(var_name) {
                     coerced_items.push(default.clone());

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -716,10 +716,12 @@ impl Interpreter {
         if let ValueView::Package(type_name) = container.view()
             && (type_name == "Hash" || type_name == "Hash:U")
         {
-            let missing = Value::package(crate::symbol::Symbol::intern(hole_type));
+            // `:delete` on the Hash TYPE OBJECT (`Hash<z>:delete`) yields Nil
+            // (raku: S32-hash/delete.t) — there is no container whose hole
+            // default could apply, unlike an absent key of a real hash.
             return Ok(match idx.view() {
-                ValueView::Array(keys, ..) => Value::array(vec![missing; keys.len()]),
-                _ => missing,
+                ValueView::Array(keys, ..) => Value::array(vec![Value::NIL; keys.len()]),
+                _ => Value::NIL,
             });
         }
         if matches!(container.view(), ValueView::Array(..)) {

--- a/src/vm/vm_var_exists_ops.rs
+++ b/src/vm/vm_var_exists_ops.rs
@@ -468,10 +468,12 @@ impl Interpreter {
             let idxs = match idx.view() {
                 ValueView::Int(i) => vec![i],
                 ValueView::Array(items, ..) if crate::runtime::utils::is_shaped_array(&target) => {
-                    // Shaped array: multi-dimensional exists (e.g. @arr[0;0]:exists)
+                    // Shaped array: multi-dimensional exists (e.g. @arr[0;0]:exists).
+                    // An unassigned cell holds its unset seed — Nil or the Any
+                    // type object — and does not exist yet.
                     let exists = Self::index_array_multidim(&target, items.as_ref(), false)
                         .ok()
-                        .is_some_and(|v| !v.is_nil());
+                        .is_some_and(|v| !v.is_nil() && !v.is_any_type_object());
                     let result = Value::truth(exists ^ effective_negated);
                     self.stack.push(result);
                     return Ok(());

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1086,7 +1086,6 @@ impl Interpreter {
             }
             (ValueView::Instance { class_name, .. }, ValueView::Str(key)) => {
                 let cn = class_name.resolve();
-                let default = self.typed_container_default(&target);
                 let result = match self.try_compiled_method_or_interpret(
                     target.clone(),
                     "AT-KEY",
@@ -1101,10 +1100,13 @@ impl Interpreter {
                     Err(e) if self.has_user_method(&cn, "AT-KEY") => return Err(e),
                     Err(_) => Value::NIL,
                 };
-                if result.is_nil() { default } else { result }
+                if result.is_nil() {
+                    self.typed_container_default(&target)
+                } else {
+                    result
+                }
             }
             (ValueView::Instance { .. }, ValueView::Int(i)) => {
-                let default = self.typed_container_default(&target);
                 let fallback = target.clone();
                 let result = self
                     .try_compiled_method_or_interpret(target.clone(), "AT-POS", vec![Value::int(i)])
@@ -1116,7 +1118,11 @@ impl Interpreter {
                         )
                     })
                     .unwrap_or(Value::NIL);
-                if result.is_nil() { default } else { result }
+                if result.is_nil() {
+                    self.typed_container_default(&target)
+                } else {
+                    result
+                }
             }
             // Whatever slice on a tied Associative instance (`%h is Foo; %h{*}`):
             // enumerate the class's own keys (via its `keys` method) and read each

--- a/src/vm/vm_var_multidim_helpers.rs
+++ b/src/vm/vm_var_multidim_helpers.rs
@@ -108,12 +108,18 @@ impl Interpreter {
         let Some(i) = Self::index_to_usize(head) else {
             return Ok(Value::NIL);
         };
-        let ValueView::Array(items, ..) = target.view() else {
+        let ValueView::Array(items, kind) = target.view() else {
             return Ok(Value::NIL);
         };
         if i >= items.len() {
             if strict_oob {
                 return Err(RuntimeError::new("Index out of bounds"));
+            }
+            // A missing slot of a real Array reads as its element default
+            // (`Any`), like a single-dim out-of-range read; a List miss
+            // stays Nil (S32-array/multislice-6e.t).
+            if kind.is_real_array() {
+                return Ok(Value::package(Symbol::intern("Any")));
             }
             return Ok(Value::NIL);
         }

--- a/src/vm/vm_var_multidim_ops.rs
+++ b/src/vm/vm_var_multidim_ops.rs
@@ -515,8 +515,8 @@ impl Interpreter {
             }
             ValueView::Array(indices, ..) => {
                 // Multiple indices at this dimension level
-                let items = match target.view() {
-                    ValueView::Array(items, ..) => items,
+                let (items, target_is_real_array) = match target.view() {
+                    ValueView::Array(items, kind) => (items, kind.is_real_array()),
                     _ => return Ok(Value::NIL),
                 };
                 let has_more_multi = rest.iter().any(|v| {
@@ -534,6 +534,11 @@ impl Interpreter {
                     let result = if let Some(i) = Self::index_to_usize(idx) {
                         if i < items.len() {
                             self.multi_dim_index_read(&items[i], rest)?
+                        } else if target_is_real_array {
+                            // A missing slot of a real Array reads as its
+                            // element default, Any (indexing further into the
+                            // Any type object stays Any, matching raku).
+                            Value::package(Symbol::intern("Any"))
                         } else {
                             self.multi_dim_index_read(&Value::NIL, rest)?
                         }
@@ -569,12 +574,16 @@ impl Interpreter {
                 }
                 let idx = resolved.as_ref().unwrap_or(dim);
                 if let Some(i) = Self::index_to_usize(idx) {
-                    let items = match target.view() {
-                        ValueView::Array(items, ..) => items,
+                    let (items, is_real) = match target.view() {
+                        ValueView::Array(items, kind) => (items, kind.is_real_array()),
                         _ => return Ok(Value::NIL),
                     };
                     if i < items.len() {
                         self.multi_dim_index_read(&items[i], rest)
+                    } else if is_real {
+                        // Out of bounds on a real Array: the element default
+                        // (Any), like a single-dim OOB read; a List stays Nil.
+                        Ok(Value::package(Symbol::intern("Any")))
                     } else {
                         // Out of bounds — return Nil for scalar index
                         Ok(Value::NIL)
@@ -583,12 +592,14 @@ impl Interpreter {
                     // Non-numeric index (e.g., string "0")
                     let i = idx.to_string_value().parse::<usize>().ok();
                     if let Some(i) = i {
-                        let items = match target.view() {
-                            ValueView::Array(items, ..) => items,
+                        let (items, is_real) = match target.view() {
+                            ValueView::Array(items, kind) => (items, kind.is_real_array()),
                             _ => return Ok(Value::NIL),
                         };
                         if i < items.len() {
                             self.multi_dim_index_read(&items[i], rest)
+                        } else if is_real {
+                            Ok(Value::package(Symbol::intern("Any")))
                         } else {
                             Ok(Value::NIL)
                         }

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -330,6 +330,15 @@ impl Interpreter {
             // (`(1,2,3)[11]`, `()[0]`) is out-of-range → `Nil`, so only a real
             // `Array` (`[...]`/`my @a`) gets the `Any` default.
             Value::package(Symbol::intern("Any"))
+        } else if let ValueView::Instance { class_name, .. } = target.view() {
+            // A user subclass of Array/Hash (`class A is Array {}`) defaults
+            // its missing elements to `Any` like its base container does
+            // (S12-introspection/WHAT.t: `A.new[0].WHAT === Any`).
+            if self.class_inherits_array_or_hash(&class_name.resolve()) {
+                Value::package(Symbol::intern("Any"))
+            } else {
+                Value::NIL
+            }
         } else {
             Value::NIL
         }

--- a/t/nil-any-identity.t
+++ b/t/nil-any-identity.t
@@ -1,0 +1,38 @@
+use v6;
+use Test;
+
+plan 16;
+
+# PLAN 8.5 step 4: the Nil value and the Any type object are distinct.
+# The types_eqv "Nil eqv Package(Any)" crutch is gone; these pin the
+# real semantics (all raku-verified).
+
+is Nil.^name, 'Nil', 'Nil.^name is Nil';
+ok Nil.WHAT === Nil, 'Nil.WHAT is the Nil type object';
+is Nil.WHAT.raku, 'Nil', 'Nil.WHAT.raku is Nil';
+
+nok Nil === Any, 'Nil === Any is False';
+nok Any === Nil, 'Any === Nil is False';
+ok Nil === Nil, 'Nil === Nil is True';
+
+nok Nil eqv Any, 'Nil eqv Any is False';
+nok Any eqv Nil, 'Any eqv Nil is False';
+ok Nil eqv Nil, 'Nil eqv Nil is True';
+
+ok Nil ~~ Any, 'Nil ~~ Any is True (Nil isa Any)';
+ok Nil ~~ Mu, 'Nil ~~ Mu is True';
+nok Any ~~ Nil, 'Any ~~ Nil is False';
+
+# An uninitialized scalar still holds Any (not Nil) — the step-3 seed.
+my $x;
+ok $x === Any, 'uninit my $x holds the Any type object';
+
+# The anonymous scalar `$` is a declared uninitialized scalar: Any.
+is ($).WHAT.gist, '(Any)', 'anonymous $ variable reads as Any';
+
+# A user subclass of Array/Hash defaults missing elements to Any,
+# like its base container (S12-introspection/WHAT.t).
+my class NA is Array {};
+my class NH is Hash {};
+ok NA.new[0].WHAT === Any, 'Array-subclass missing element is Any';
+ok NH.new<k>.WHAT === Any, 'Hash-subclass missing value is Any';


### PR DESCRIPTION
## Summary

The final step of the Nil-vs-Any campaign (PLAN 8.5): the `(Nil, Package("Any")) => true` crutch arm in `types_eqv` is **deleted**. It masked every place mutsu stored `Nil` where `Any` was meant; with steps 1–3.5 landed (#5256, #5264, #5273, #5280), the full `t/` suite already passed crutch-off, so this slice removes the arm and fixes the surfaced semantics at their mechanisms (all raku-verified):

| expression | before | after (= raku) |
|---|---|---|
| `Nil.^name` | `Any` | `Nil` |
| `Nil.WHAT === Nil` | `False` | `True` |
| `Nil === Any` / `Nil eqv Any` | `True` | `False` |
| `Nil.gist` (runtime value) | `(Any)` | `Nil` |
| `($).WHAT` | `(Nil)` | `(Any)` |
| `(class A is Array {}).new[0]` | `Nil` | `Any` |
| `@a.cache.^name` | `List` | `Array` |

## Implementation

- `value_type_name` / `.WHAT` / HOW type-name paths report `Nil` for the Nil value; `.WHAT` returns the Nil value itself, and a `Package("Nil")` from type lookup (`::('Nil')`) is eqv/=== to it (a genuine single-object identity, unlike the removed Nil/Any conflation). `===` follows eqv via `values_identical`.
- The anonymous `$` scalar reads as the Any type object like `my $x` (S03-operators/context.t 31).
- A user subclass of Array/Hash defaults missing elements to `Any` like its base container (S12-introspection/WHAT.t 34/37) via a cheap exact-match parent-chain query (`class_inherits_array_or_hash`), evaluated **lazily** on the instance index path — measured net faster than the previous eager default computation (private.t debug: 17s main → 15s).
- `Nil.gist` no longer masquerades as `(Any)`; the array-store hole rendering keeps its own `(Any)` translation (real-array cells can't hold Nil).
- `@a.cache` returns the Array itself instead of a List copy (leftover noted during step 1).
- PLAN.md §8.5 closed out; campaign history recorded in news/2026-07.md.

## Testing

- New pin: `t/nil-any-identity.t` (16 tests, verified against raku).
- Full `t/`: 2332 files / 22048 tests PASS.
- Roast sweeps (S02-types, S02-names, S02-lists, S03-operators, S04-declarations, S06-signature, S12-*, S32-scalar/str via the official runner): pass except the two known debug-slow files (`S04-declarations/state.t` 45s on main too, `S12-methods/private.t`) that exceed the 30s per-file budget only in local debug `-j` runs — release CI is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)