### PR TITLE
fix: augment `class X does Role` composition + sigilless binding shadows native type

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -957,6 +957,10 @@ pub(crate) enum Stmt {
     AugmentClass {
         name: Symbol,
         body: Vec<Stmt>,
+        /// Roles composed onto the augmented type via `does Role` on the augment
+        /// declaration itself (`augment class Str does Rotate { }`). Their methods
+        /// are mixed into the existing (builtin or user) class.
+        does_roles: Vec<Symbol>,
         /// True when declared with `augment role ...` (roles are always closed,
         /// so augmenting one is illegal); false for `augment class ...`.
         is_role: bool,

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -168,19 +168,22 @@ impl Compiler {
                 // stripped share the same key in local_map but must NOT shadow type
                 // names, so they go through GetBareWord which checks the type registry.
                 if let Some(&slot) = self.local_map.get(name.as_str()) {
-                    if crate::runtime::Interpreter::is_builtin_type(name) {
-                        let name_idx = self.code.add_constant(Value::str(name.clone()));
-                        self.code.emit(OpCode::GetBareWord(name_idx));
-                    } else if self.sigilless_locals.contains(name.as_str())
+                    if self.sigilless_locals.contains(name.as_str())
                         || self.constant_vars_in_scope.contains(name.as_str())
                         || name == "self"
                         || name == "__ANON_STATE__"
                     {
                         // Sigilless bindings and in-scope constants: the bare word
-                        // IS the variable, so read directly from the local slot.
+                        // IS the variable, so read directly from the local slot —
+                        // even when the name coincides with a native lowercase type
+                        // (`my \str`, an `Int \ch` param): in Raku the lexical
+                        // binding shadows the native type within its scope.
                         // (Out-of-scope constants fall through to GetBareWord, which
                         // resolves them as `our`-scoped package globals.)
                         self.code.emit(OpCode::GetLocal(slot));
+                    } else if crate::runtime::Interpreter::is_builtin_type(name) {
+                        let name_idx = self.code.add_constant(Value::str(name.clone()));
+                        self.code.emit(OpCode::GetBareWord(name_idx));
                     } else {
                         // The local is a `$`-sigiled variable — a bare word with the
                         // same name should resolve as a type/package, not the variable.

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -534,6 +534,18 @@ impl Compiler {
                     return;
                 }
                 let saved_dynamic_scope = self.push_dynamic_scope_lexical();
+                // Snapshot the sigilless bindings that name a native lowercase
+                // type (`str`/`int`/...). A `my \str` declared *inside* this block
+                // is lexically scoped to it, so it must stop shadowing the native
+                // type once the block ends; drop any such name the block newly
+                // registers on exit. Scoped to type names only to keep the
+                // (pre-existing) leak behaviour of ordinary sigilless names.
+                let sigilless_type_names_before: std::collections::HashSet<String> = self
+                    .sigilless_locals
+                    .iter()
+                    .filter(|n| crate::runtime::Interpreter::is_builtin_type(n))
+                    .cloned()
+                    .collect();
                 // A genuine source `{ ... }` is a Raku callframe (it contributes
                 // an anonymous frame to a backtrace captured inside it); a
                 // synthesized if/while/loop body is not. `synthetic_block_body`
@@ -660,6 +672,10 @@ impl Compiler {
                     self.code.patch_block_post_start(idx);
                     self.code.patch_loop_end(idx);
                 }
+                self.sigilless_locals.retain(|n| {
+                    sigilless_type_names_before.contains(n)
+                        || !crate::runtime::Interpreter::is_builtin_type(n)
+                });
                 self.pop_dynamic_scope_lexical(saved_dynamic_scope);
             }
             Stmt::SyntheticBlock(stmts) => {

--- a/src/parser/stmt/class/class_decl.rs
+++ b/src/parser/stmt/class/class_decl.rs
@@ -161,12 +161,41 @@ pub(crate) fn augment_class_decl(input: &str) -> PResult<'_, Stmt> {
         }
     }
     let (rest, _) = ws(rest)?;
+    // Parent/role clauses on the augment itself: `augment class Str does Rotate { }`
+    // (and `is Parent`, which is accepted and ignored — you cannot change a
+    // builtin's parents by augmenting). Only `does Role` is captured, since its
+    // methods must be mixed into the augmented type.
+    let mut does_roles = Vec::new();
+    let mut rest = rest;
+    loop {
+        if let Some(r2) = keyword("does", rest) {
+            let (r2, _) = ws1(r2)?;
+            let (r2, role_name) = qualified_ident(r2)?;
+            let (r2, _) = ws(r2)?;
+            let (r2, bracket_suffix) = parse_optional_bracket_suffix(r2)?;
+            does_roles.push(Symbol::intern(&format!("{}{}", role_name, bracket_suffix)));
+            let (r2, _) = ws(r2)?;
+            rest = r2;
+            continue;
+        }
+        if let Some(r2) = keyword("is", rest) {
+            let (r2, _) = ws1(r2)?;
+            let (r2, _parent) = qualified_ident(r2)?;
+            let (r2, _) = ws(r2)?;
+            let (r2, _) = parse_optional_bracket_suffix(r2)?;
+            let (r2, _) = ws(r2)?;
+            rest = r2;
+            continue;
+        }
+        break;
+    }
     let (rest, body) = block(rest)?;
     Ok((
         rest,
         Stmt::AugmentClass {
             name: Symbol::intern(&name),
             body,
+            does_roles,
             is_role,
         },
     ))

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -3582,6 +3582,25 @@ impl Interpreter {
             return result;
         }
 
+        // A method the user explicitly added to a builtin type via
+        // `augment class Str does Role { }` (or a method body) must win over the
+        // native string/collection/coercion dispatchers below — in Rakudo an
+        // augmented method overrides the built-in. This only diverts when the
+        // value's type actually carries a user-declared method of this name
+        // (builtin types have no `.methods` entries unless augmented), so normal
+        // native dispatch is unaffected. Without it, a name that collides with a
+        // native dispatcher that hard-errors on this type (e.g. `.rotate` on a
+        // Str is method-not-found natively) never reaches the augment fallback.
+        if !matches!(
+            target.view(),
+            ValueView::Instance { .. } | ValueView::Package(_)
+        ) {
+            let type_name = crate::runtime::utils::value_type_name(&target);
+            if self.has_user_method(type_name, method) {
+                return self.dispatch_instance_and_fallback(target, method, args);
+            }
+        }
+
         // Primary method dispatch by name (group 1: string, IO, coercion, misc)
         if let Some(result) = self.dispatch_method_by_name_1(target.clone(), method, args.clone()) {
             return result;

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -52,7 +52,12 @@ impl Interpreter {
 
     /// Augment an existing class by adding methods (and attributes) from the body.
     /// This implements `augment class ClassName { ... }` (monkey-patching).
-    pub(crate) fn augment_class(&mut self, name: &str, body: &[Stmt]) -> Result<(), RuntimeError> {
+    pub(crate) fn augment_class(
+        &mut self,
+        name: &str,
+        body: &[Stmt],
+        does_roles: &[String],
+    ) -> Result<(), RuntimeError> {
         self.clear_private_zeroarg_method_cache();
         // Check if the class exists (user-defined or builtin)
         let is_builtin = !self.registry().classes.contains_key(name);
@@ -319,8 +324,110 @@ impl Interpreter {
             }
         }
 
+        // Mix in roles composed via `does Role` on the augment declaration
+        // (`augment class Str does Rotate { }`): copy each role's methods
+        // (including those of its parent roles) onto the augmented class, and
+        // record the composition so `.^roles`/`does` introspection sees it.
+        for role_name in does_roles {
+            self.compose_role_into_augmented_class(name, role_name);
+        }
+
         self.set_current_package(saved_package);
         Ok(())
+    }
+
+    /// Copy the methods and attributes of `role_name` (and its parent roles)
+    /// onto an already-registered class `name`, marking them as role-origin so
+    /// class-local methods still take priority. Used by `augment class X does R`.
+    fn compose_role_into_augmented_class(&mut self, name: &str, role_name: &str) {
+        self.clear_private_zeroarg_method_cache();
+        // Ensure a parameterized/bare role is available. Strip any `[...]`
+        // type-parameter suffix, then resolve the (possibly short) name to its
+        // registered qualified name — a role imported from a module is stored
+        // under its full `Module::Role` name with the short name as an alias.
+        let stripped = role_name
+            .split_once('[')
+            .map(|(b, _)| b)
+            .unwrap_or(role_name);
+        let resolved = self.resolve_declared_type_name(stripped);
+        let base_role = if self.registry().roles.contains_key(resolved.as_str()) {
+            resolved.as_str()
+        } else {
+            stripped
+        };
+        let role_def = match self.registry().roles.get(base_role) {
+            Some(r) => r.clone(),
+            None => return,
+        };
+        let base_role = base_role.to_string();
+        let base_role = base_role.as_str();
+        // Collect this role's methods plus every parent role's methods.
+        let mut all_methods: HashMap<String, Vec<MethodDef>> = role_def.methods.clone();
+        let mut all_attributes = role_def.attributes.clone();
+        let mut composed = vec![base_role.to_string()];
+        if let Some(parent_names) = self.registry().role_parents.get(base_role).cloned() {
+            let mut stack: Vec<String> = parent_names;
+            while let Some(parent) = stack.pop() {
+                if composed.contains(&parent) {
+                    continue;
+                }
+                composed.push(parent.clone());
+                if let Some(parent_role) = self.registry().roles.get(&parent).cloned() {
+                    for (mname, mdefs) in &parent_role.methods {
+                        all_methods
+                            .entry(mname.clone())
+                            .or_default()
+                            .extend(mdefs.clone());
+                    }
+                    for attr in &parent_role.attributes {
+                        if !all_attributes.iter().any(|a| a.0 == attr.0) {
+                            all_attributes.push(attr.clone());
+                        }
+                    }
+                }
+                if let Some(grandparents) = self.registry().role_parents.get(&parent).cloned() {
+                    for gp in grandparents {
+                        if !composed.contains(&gp) {
+                            stack.push(gp);
+                        }
+                    }
+                }
+            }
+        }
+        if let Some(class_def) = self.registry_mut().classes.get_mut(name) {
+            for (mname, mdefs) in all_methods {
+                // Only add a role method the class does not already define
+                // itself (a class-local method wins over a composed one).
+                let entry = class_def.methods.entry(mname).or_default();
+                let has_local = entry.iter().any(|d| d.role_origin.is_none());
+                if !has_local {
+                    for mut d in mdefs {
+                        if d.role_origin.is_none() {
+                            d.role_origin = Some(base_role.to_string());
+                        }
+                        entry.push(d);
+                    }
+                }
+            }
+            for attr in all_attributes {
+                if !class_def.attributes.iter().any(|a| a.0 == attr.0) {
+                    class_def.attributes.push(attr);
+                }
+            }
+        }
+        // Record the `does` relationship for introspection (`.^roles`, `does`).
+        self.registry_mut()
+            .class_does_only_roles
+            .entry(name.to_string())
+            .or_default()
+            .push(base_role.to_string());
+        self.registry_mut()
+            .class_composed_roles
+            .entry(name.to_string())
+            .or_default()
+            .extend(composed);
+        // Recompile so the fast path sees the newly composed methods.
+        self.compile_class_methods(name);
     }
 
     pub(crate) fn register_subset_decl(

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -356,6 +356,7 @@ impl Interpreter {
         if let Stmt::AugmentClass {
             name,
             body,
+            does_roles,
             is_role,
         } = stmt
         {
@@ -372,7 +373,8 @@ impl Interpreter {
             if *is_role {
                 return Err(self.augment_role_error(&name_str));
             }
-            loan_env!(self, augment_class(&name_str, body))?;
+            let does_role_names: Vec<String> = does_roles.iter().map(|s| s.resolve()).collect();
+            loan_env!(self, augment_class(&name_str, body, &does_role_names))?;
             // Recompile augmented class methods for the fast path
             self.compile_class_methods(&name_str);
             // Augment can add methods/attributes — drop cached construction plans.

--- a/t/augment-does-role.t
+++ b/t/augment-does-role.t
@@ -1,0 +1,34 @@
+use Test;
+
+# `augment class BuiltinType does Role { }` (MONKEY-TYPING) must mix the role's
+# methods into the builtin type, and an augmented method must override the
+# native one (Rakudo semantics). Previously the `does Role` clause on the
+# augment declaration was mis-parsed (`augment` swallowed as a bareword, the
+# rest parsed as a plain `class Str does Role` redeclaration), so the role's
+# methods were never composed onto the type.
+
+plan 5;
+
+role Rotate {
+    method rotate-str (Int $n = 1) {
+        my $shft = abs($n % self.chars);
+        self.substr($shft) ~ self.substr(0, $shft)
+    }
+}
+
+use MONKEY-TYPING;
+augment class Str does Rotate { }
+
+is 'Rakudo'.rotate-str,     'akudoR', 'augmented role method (default arg)';
+is 'Rakudo'.rotate-str(-1), 'oRakud', 'augmented role method (explicit arg)';
+ok 'Rakudo'.^can('rotate-str'), '.^can reports the composed method';
+
+# A method whose name collides with a native list method that hard-errors on a
+# Str (`.rotate` is List-only in Rakudo) must dispatch to the augmented role
+# method, not raise "No such method".
+role Twist {
+    method rotate (Int $n = 1) { "twist:$n" }
+}
+augment class Str does Twist { }
+is 'x'.rotate,   'twist:1', 'augmented method overrides native .rotate';
+is 'x'.rotate(4), 'twist:4', 'augmented method overrides native .rotate (arg)';

--- a/t/sigilless-binding-shadows-native-type.t
+++ b/t/sigilless-binding-shadows-native-type.t
@@ -1,0 +1,39 @@
+use Test;
+
+# A sigilless binding (`my \x`, or a `\x` / typed `Str \x` routine parameter)
+# whose name coincides with a native lowercase type (`str`, `int`, `num`) must
+# shadow that type within its scope: a bare reference to the name reads the
+# binding, not the native type object. Previously the compiler resolved the
+# bare word to the native type (`say str` printed `(str)`), ignoring the
+# lexical binding.
+
+plan 6;
+
+{
+    my \str = "hello";
+    is str, "hello", 'my \str shadows the native str type';
+}
+
+{
+    my \int = 42;
+    is int, 42, 'my \int shadows the native int type';
+}
+
+sub take-str (\str) { str.chars }
+is take-str("Rakudo"), 6, 'sigilless \str param shadows native type in body';
+
+sub rotate-it (Str(Any) \str, Int \ch = 1 --> Str) {
+    my \shft = abs(ch % str.chars);
+    str.substr(shft) ~ str.substr(0, shft)
+}
+is rotate-it('Rakudo', 3), 'udoRak', 'coercion + sigilless params bind correctly';
+is rotate-it('Rakudo'),    'akudoR', 'default sigilless param binds correctly';
+
+# A `my \str` is lexically scoped to its block; outside it, the bare word
+# resolves to the native `str` type again (the compiler must not leak the
+# block-local sigilless binding past the block).
+{
+    my \str = "inner";
+    #= just declares the shadow; nothing to assert here
+}
+is str.^name, 'str', 'block-local \str does not leak past its block';


### PR DESCRIPTION
## Summary

Two general fixes surfaced while investigating the `String::Rotate` dist (`augment class Str does Rotate { }` and `sub rotate (Str(Any) \str, …)`).

### 1. `augment class X does Role { }` was mis-parsed
The `does Role` (and any `is`) trait clause on an augment declaration was never consumed by `augment_class_decl`, so the parser failed and the statement fell back to `augment` (a bareword expression) + a plain `class X does Role {}` redeclaration. Now the augment parses trait clauses, `Stmt::AugmentClass` carries the composed `does_roles`, and `augment_class` mixes each role's methods (and its parent roles') into the existing builtin/user class — resolving an imported role's short name to its registered qualified name.

### 2. An augmented method overrides the native one
`call_method_with_values` now routes a call whose builtin-value type carries a user-declared method of that name to the augment fallback **before** the native string/collection dispatchers, matching Rakudo (an augmented method wins over the built-in). Without it, a name that collides with a native dispatcher that hard-errors on the type (`.rotate` is List-only in Rakudo, so `"x".rotate` was "No such method") never reached the composed method. The guard only diverts when the type actually has a user method (a builtin type has none unless augmented), so normal native dispatch is unaffected. (Fast-path 0-arg native methods like `.flip` are not yet overridden — a separate, perf-sensitive change.)

### 3. A sigilless binding shadows a same-named native lowercase type
`my \str` / a `Str \str` parameter must make a bare `str` in scope read the binding, not the native `str` type object (`say str` was printing `(str)`, so `str.chars` in a sub body was wrong). The compiler now checks `sigilless_locals` before `is_builtin_type` when resolving a bare word, and drops a block-local type-named sigilless binding on block exit so it does not leak past its scope.

## Tests
- Pins: `t/augment-does-role.t`, `t/sigilless-binding-shadows-native-type.t`
- `make test` passes locally (22062 tests, Result: PASS).

Note: `String::Rotate` is not yet fully green — its exported `sub rotate` (a builtin-colliding module sub with a sigilless param) still hits the module-single-sub OTF exclusion + imported-sub-vs-builtin dispatch priority (deep, tracked separately). These fixes make the method form (`augment class Str does Rotate`) and sigilless bodies work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)