### PR TITLE
fix: `fail` in TWEAK returns a Failure; user infix:<×>/<÷> keeps builtin parse

### DIFF
--- a/src/parser/expr/operators.rs
+++ b/src/parser/expr/operators.rs
@@ -236,8 +236,10 @@ fn word_infix_at(r: &str, kw: &str) -> bool {
 }
 
 pub(super) fn parse_multiplicative_op(r: &str) -> Option<(MultiplicativeOp, usize)> {
-    // Unicode: multiply (U+00D7) -- skip if user-defined infix exists, and (like
-    // the ASCII `*` below) leave `×=` for the compound-assignment parser.
+    // Unicode: multiply (U+00D7) -- skip if user-defined infix exists (the caller
+    // then parses it as a multiplicative-precedence `infix:<×>` call so the user
+    // candidate dispatches), and (like the ASCII `*` below) leave `×=` for the
+    // compound-assignment parser.
     if r.starts_with('\u{00D7}')
         && !r.starts_with("\u{00D7}=")
         && !super::super::stmt::simple::is_user_defined_infix("\u{00D7}")

--- a/src/parser/expr/precedence_meta_ops/arith.rs
+++ b/src/parser/expr/precedence_meta_ops/arith.rs
@@ -297,6 +297,32 @@ pub(crate) fn multiplicative_expr(input: &str) -> PResult<'_, Expr> {
             rest = r;
             continue;
         }
+        // Unicode `×`/`÷` when the user declared `infix:<×>`/`infix:<÷>`:
+        // `parse_multiplicative_op` deliberately skipped them so the user
+        // candidate can win, but they keep their canonical MULTIPLICATIVE
+        // precedence (Rakudo: `×` is `equiv(&infix:<*>)`). Emit the operator call
+        // here rather than deferring to the generic custom-infix path, which
+        // would give a trait-less declaration the wrong (additive) level and
+        // strand `×` as "two terms in a row".
+        if let Some(sym) = ["\u{00D7}", "\u{00F7}"].into_iter().find(|s| {
+            r.starts_with(*s)
+                && r.as_bytes().get(s.len()) != Some(&b'=')
+                && crate::parser::stmt::simple::is_user_defined_infix(s)
+        }) {
+            let r2 = &r[sym.len()..];
+            let (r2, _) = ws(r2)?;
+            let (r2, right) = prefix_expr_with_ws_dot(r2).map_err(|err| {
+                enrich_expected_error(err, "expected expression after infix operator", r2.len())
+            })?;
+            left = Expr::InfixFunc {
+                name: sym.to_string(),
+                left: Box::new(left),
+                right: vec![right],
+                modifier: None,
+            };
+            rest = r2;
+            continue;
+        }
         // Custom infix ops at multiplicative level (between additive and multiplicative inclusive)
         // (covers is equiv<*>, is tighter<+>, is looser<*>)
         {

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -408,7 +408,11 @@ impl Interpreter {
         // parameter binds -- the args are also pre-folded into `attributes` above
         // for the common no-explicit-BUILD case.
         if plan.has_tweak {
-            self.run_tweak_phase(class_name, &inv, &args)?;
+            match self.run_tweak_phase(class_name, &inv, &args)? {
+                Ok(()) => {}
+                // `fail` inside TWEAK: return the Failure instead of the instance.
+                Err(failure) => return Ok(failure),
+            }
         }
         Ok(inv)
     }
@@ -575,14 +579,15 @@ impl Interpreter {
     /// ordering/dispatch instead of duplicating it (Track A ③ ctor: a class whose
     /// only non-simple feature is TWEAK is native-default constructible, then
     /// runs TWEAK here).
+    #[allow(clippy::type_complexity)]
     pub(crate) fn run_tweak_phase(
         &mut self,
         class_name: Symbol,
         inv: &Value,
         tweak_args: &[Value],
-    ) -> Result<(), RuntimeError> {
+    ) -> Result<Result<(), Value>, RuntimeError> {
         let Some(cell) = Self::self_instance_attrs(inv) else {
-            return Ok(());
+            return Ok(Ok(()));
         };
         let mut probe_attrs = cell.to_map();
         let refresh_probe = probe_attrs
@@ -642,7 +647,7 @@ impl Interpreter {
                 if refresh_probe {
                     probe_attrs = cell.to_map();
                 }
-                let (_v, updated) = self.run_resolved_method_celled(
+                match self.run_resolved_method_celled(
                     &cn,
                     &role_name,
                     "TWEAK",
@@ -650,9 +655,18 @@ impl Interpreter {
                     &probe_attrs,
                     tweak_args.to_vec(),
                     Some(inv.clone()),
-                )?;
-                if let Some(m) = updated {
-                    cell.commit_attrs(m);
+                ) {
+                    Ok((_v, updated)) => {
+                        if let Some(m) = updated {
+                            cell.commit_attrs(m);
+                        }
+                    }
+                    // `fail` inside TWEAK yields a Failure `.new` returns, not an
+                    // error (Raku: the Failure only throws when the object is used).
+                    Err(err) if err.is_fail() => {
+                        return Ok(Err(self.fail_error_to_failure_value(&err)));
+                    }
+                    Err(err) => return Err(err),
                 }
             }
             // Call the class's TWEAK if it has one that wasn't already handled
@@ -672,19 +686,26 @@ impl Interpreter {
                 if refresh_probe {
                     probe_attrs = cell.to_map();
                 }
-                let (_v, updated) = self.run_instance_method_celled(
+                match self.run_instance_method_celled(
                     mro_class,
                     &probe_attrs,
                     "TWEAK",
                     tweak_args.to_vec(),
                     Some(inv.clone()),
-                )?;
-                if let Some(m) = updated {
-                    cell.commit_attrs(m);
+                ) {
+                    Ok((_v, updated)) => {
+                        if let Some(m) = updated {
+                            cell.commit_attrs(m);
+                        }
+                    }
+                    Err(err) if err.is_fail() => {
+                        return Ok(Err(self.fail_error_to_failure_value(&err)));
+                    }
+                    Err(err) => return Err(err),
                 }
             }
         }
-        Ok(())
+        Ok(Ok(()))
     }
 
     /// Run the BUILD phase of construction: invoke every BUILD submethod (own and

--- a/src/runtime/methods_object_default_ctor.rs
+++ b/src/runtime/methods_object_default_ctor.rs
@@ -456,10 +456,15 @@ impl Interpreter {
                 return Some(Err(e));
             }
         }
-        if has_tweak && let Err(e) = self.run_tweak_phase(class_name, &inv, args) {
+        if has_tweak {
             // Pass the original constructor args so `submethod TWEAK(:$y)` binds
-            // them, matching the full `.new` path.
-            return Some(Err(e));
+            // them, matching the full `.new` path. A `fail` inside TWEAK yields a
+            // Failure to return, not an error.
+            match self.run_tweak_phase(class_name, &inv, args) {
+                Ok(Ok(())) => {}
+                Ok(Err(failure)) => return Some(Ok(failure)),
+                Err(e) => return Some(Err(e)),
+            }
         }
         // Re-check `where` after BUILD/TWEAK: the full constructor enforces
         // constraints again post-construction, so a BUILD/TWEAK that mutates an

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -1974,7 +1974,10 @@ impl Interpreter {
                                 .is_empty())
                 });
                 if any_tweak {
-                    self.run_tweak_phase(*class_name, &inv, &args)?;
+                    // `fail` inside TWEAK yields a Failure `.new` returns.
+                    if let Err(failure) = self.run_tweak_phase(*class_name, &inv, &args)? {
+                        return Ok(failure);
+                    }
                     // Re-check `where` after the TWEAK phase (formerly checked
                     // after each TWEAK step; a violation surfaces identically —
                     // rakudo enforces `where` at assignment time, so the

--- a/src/runtime/ops_reduction.rs
+++ b/src/runtime/ops_reduction.rs
@@ -285,8 +285,11 @@ impl Interpreter {
                 crate::builtins::arith_add(left.clone(), right.clone())
             }
             "-" => Ok(crate::builtins::arith_sub(left.clone(), right.clone())),
-            "*" => Ok(crate::builtins::arith_mul(left.clone(), right.clone())),
-            "/" => crate::builtins::arith_div(left.clone(), right.clone()),
+            // `×` (U+00D7) / `÷` (U+00F7) are the Unicode multiply/divide
+            // operators; they fall back to the same arithmetic as `*` / `/` when a
+            // user `infix:<×>`/`infix:<÷>` candidate does not match the operands.
+            "*" | "\u{00D7}" => Ok(crate::builtins::arith_mul(left.clone(), right.clone())),
+            "/" | "\u{00F7}" => crate::builtins::arith_div(left.clone(), right.clone()),
             "div" => {
                 let divisor = to_int(right);
                 if divisor == 0 {

--- a/t/tweak-fail-returns-failure.t
+++ b/t/tweak-fail-returns-failure.t
@@ -1,0 +1,33 @@
+use Test;
+
+# `fail` inside a TWEAK (or BUILD) submethod must make `.new` return a Failure
+# — an unthrown exception that only throws when the object is used — not throw
+# immediately at construction. A constructor that validates its arguments with
+# `fail` relies on this (e.g. Math::Angle's TWEAK fails when zero or multiple
+# angle units are given, and the caller `dies-ok { $obj }`).
+
+plan 6;
+
+class Angle {
+    has $.rad;
+    submethod TWEAK(:$rad, :$deg) {
+        fail 'Specify exactly one of rad or deg'
+            unless ($rad.defined xor $deg.defined);
+        $!rad = $deg.defined ?? $deg / 57.29577951308232 !! $rad;
+    }
+}
+
+my $bad = Angle.new;                 # neither -> fail
+ok $bad ~~ Failure, 'new with no unit returns a Failure, not a throw';
+dies-ok { $bad.rad }, 'using the Failure throws';
+
+my $bad2 = Angle.new(:rad(1), :deg(90));   # both -> fail
+ok $bad2 ~~ Failure, 'new with two units returns a Failure';
+
+my $good = Angle.new(:rad(1));
+ok $good !~~ Failure, 'valid construction is not a Failure';
+is $good.rad, 1, 'valid construction stores its attribute';
+
+# A `fail` in a plain method still returns a Failure (regression guard).
+class M { method risky($bad) { fail 'no' if $bad; 42 } }
+ok M.new.risky(True) ~~ Failure, 'fail in a plain method still returns a Failure';

--- a/t/user-infix-unicode-multiply.t
+++ b/t/user-infix-unicode-multiply.t
@@ -1,0 +1,26 @@
+use Test;
+
+# Declaring a `multi infix:<×>` / `infix:<÷>` candidate must NOT disable the
+# built-in parse of the Unicode multiply/divide operators. Previously the
+# parser skipped `×`/`÷` entirely once a user candidate existed, leaving
+# `2 × 3` stranded as "Two terms in a row". They now behave exactly like the
+# ASCII `*` / `/`: parsed at multiplicative precedence, with the VM dispatching
+# to the user candidate for operands the built-in does not handle.
+
+plan 6;
+
+class Angle { has $.v; method v { $!v } }
+multi infix:<×>(Angle $a, Real $b) { Angle.new(v => $a.v × $b) }
+multi infix:<×>(Real $a, Angle $b) { Angle.new(v => $a × $b.v) }
+multi infix:<÷>(Angle $a, Real $b) { Angle.new(v => $a.v ÷ $b) }
+
+# Built-in numeric × / ÷ still parse and evaluate.
+is 2 × 3, 6, 'builtin × still parses with a user infix:<×> declared';
+is 12 ÷ 4, 3, 'builtin ÷ still parses with a user infix:<÷> declared';
+is 2 × 3 + 1, 7, '× keeps multiplicative precedence (tighter than +)';
+
+# The user candidates dispatch for the mixed operand types.
+my $a = Angle.new(v => 5);
+is ($a × 3).v, 15, 'user infix:<×>(Angle, Real) dispatches';
+is (2 × $a).v, 10, 'user infix:<×>(Real, Angle) dispatches';
+is ($a ÷ 5).v, 1, 'user infix:<÷>(Angle, Real) dispatches';


### PR DESCRIPTION
## Summary

Two general fixes surfaced by the `Math::Angle` dist.

### 1. `fail` inside a TWEAK submethod threw immediately
The BUILD phase already converted a `fail` into a returned Failure (`run_build_phase`), but the TWEAK phase (`run_tweak_phase`) propagated it as a hard error. So a constructor that validates its arguments with `fail` — and a caller doing `dies-ok { $obj }` (the object is only sunk later) — aborted at construction. `run_tweak_phase` now mirrors BUILD: `err.is_fail()` becomes `Ok(Err(failure))`, and `.new` returns the Failure. (`fail` in a plain method already worked; regression-guarded.)

### 2. Declaring `multi infix:<×>` / `infix:<÷>` broke the built-in Unicode multiply/divide
`parse_multiplicative_op` deliberately skips `×`/`÷` once a user infix exists (so the candidate can win), but the generic custom-infix path then gave a trait-less declaration the wrong (additive) precedence and stranded `2 × 3` as *"Two terms in a row"*. Now `multiplicative_expr` parses a user-declared `×`/`÷` as a multiplicative-precedence `InfixFunc` (its canonical level — Rakudo makes `×` `equiv(&infix:<*>)`), and `apply_reduction_op` treats `×`/`÷` as `*`/`/` so the operator falls back to built-in arithmetic when no user candidate matches. `×`/`÷` stay distinct from `*`/`/`, so a user `infix:<×>` body that uses `*` no longer infinitely recurses (guarded by `t/unicode-infix-op.t`).

## Tests
- Pins: `t/tweak-fail-returns-failure.t`, `t/user-infix-unicode-multiply.t`
- `make test` passes (22089 tests, Result: PASS).
- `Math::Angle` 01-basic (20/20) and 03-arithmetic (30/30) now pass; 02-io remains blocked by a separate `push my @a, ...` inline-declaration container-identity bug (recorded for follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)