### PR TITLE
fix: IO::Path::Parts.raku/.gist render the positional parts (PLAN 8.15)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1392,18 +1392,15 @@ and `[Z]`-reduction-returns-a-Seq landed 2026-07-22 (pin `t/repr-residues-2.t`);
       (`_ => to_string_value`), and `.Str` of the instance is empty while `.raku` is the
       bare class name, so an earlier arm intercepts. Needs a dispatch trace before fixing;
       cosmetic, low value.
-- [ ] **`IO::Path::Parts.raku`/`.gist` drop the constructor arguments** — found 2026-07-23.
-      `IO::Path::Parts.new('C:', '/some/dir', 'foo.txt').gist` renders `IO::Path::Parts.new`
-      (mutsu) vs `IO::Path::Parts.new("C:","/some/dir","foo.txt")` (raku) — the three attrs
-      (`volume`/`dirname`/`basename`) are not walked into the repr. Same class of bug as the
-      just-fixed Proc one (§8.15 above): register the attributes so the generic attribute walk
-      renders the full `.new(...)` form. `.Str` also diverges (mutsu `IO::Path::Parts()` vs raku
-      `IO::Path::Parts<addr>`) but that is the object-address form and low value. **The rest of
-      IO::Path::Parts already matches raku exactly** — the documented spec surface (`.new`,
-      `.volume`/`.dirname`/`.basename`, Associative `$parts<k>`, Positional `$parts[0]` → Pair,
-      Iterable `for $parts[]`/`.map` → 3 pairs, `.hash`/`.Hash`, `.^name`, type-matching against
-      Positional/Associative/Iterable, and construction via `IO::Path.parts` / `IO::Spec.split`)
-      is fully implemented and verified. Pin target: `t/io-path-parts-repr.t`.
+- [x] **`IO::Path::Parts.raku`/`.gist` drop the constructor arguments** — fixed 2026-07-23.
+      Unlike Proc, IO::Path::Parts is a Positional in Rakudo, so its `.raku`/`.gist` render the
+      three parts *positionally* (`IO::Path::Parts.new("C:","/some/dir","foo.txt")`, each via its
+      own `.raku`, joined by `,` with no spaces) — the generic named-attribute walk would have
+      emitted `volume => ...` pairs, so registering attributes was the wrong tool. Added a native
+      arm in `methods_instance_ops.rs` (alongside the Scheduler/Supplier/Stash native reprs) that
+      builds the positional form for `.raku`/`.perl`/`.gist`. `.Str` still diverges (mutsu
+      `IO::Path::Parts()` vs raku `IO::Path::Parts<addr>`) — the object-address form, intentionally
+      not matched (low value, non-deterministic). Pin: `t/io-path-parts-repr.t`.
 - [ ] **Undocumented single-item fallback methods diverge from Rakudo (low value, no roast
       coverage)** — `.elems` (mutsu 3 / raku 1), `.list`/`.List` (mutsu 3 pairs / raku `(self,)`),
       `.keys` (mutsu `(volume dirname basename)` / raku `(0)`), `.values` (mutsu 3 parts / raku

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,18 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-23: `IO::Path::Parts.raku`/`.gist` render the positional parts (PLAN §8.15)
+
+`IO::Path::Parts.new('C:', '/some/dir', 'foo.txt').raku` (and `.gist`) rendered the bare
+`IO::Path::Parts.new`, dropping the constructor arguments. Unlike Proc (which registered its
+public attributes so the generic named-attribute walk could render them), IO::Path::Parts is a
+Positional in Rakudo, so its repr is *positional*: `IO::Path::Parts.new("C:","/some/dir","foo.txt")`
+— each of the three parts via its own `.raku`, joined by `,` with no spaces. Registering
+attributes would have produced the wrong `volume => ...` named form, so instead a native arm in
+`methods_instance_ops.rs` (alongside the Scheduler/Supplier/Stash native reprs) builds the
+positional string for `.raku`/`.perl`/`.gist`. `.Str` still legitimately diverges (the
+object-address form `IO::Path::Parts<addr>`, low value). Pin: `t/io-path-parts-repr.t`.
+
 ## 2026-07-23: an `s///` replacement `\\` before a capture var keeps its backslash (P5quotemeta)
 
 A substitution replacement `\\` (an escaped backslash — one literal backslash) followed

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1005,6 +1005,31 @@ impl Interpreter {
                             "Supplier.new(taplist => Supplier::TapList.new)".to_string(),
                         ));
                     }
+                    // IO::Path::Parts is a Positional in Rakudo, so its .raku
+                    // (and .gist, which equals .raku) renders the three parts
+                    // positionally via each part's own .raku, joined by `,`
+                    // (`IO::Path::Parts.new("C:","/some/dir","foo.txt")`) — NOT
+                    // the generic named-attribute walk, which has no fixed
+                    // ordering and would emit `volume => ...` pairs.
+                    "IO::Path::Parts" => {
+                        let attr_map = attributes.as_map();
+                        let rendered: Vec<String> = ["volume", "dirname", "basename"]
+                            .iter()
+                            .map(|k| {
+                                let v = attr_map
+                                    .get(*k)
+                                    .cloned()
+                                    .unwrap_or_else(|| Value::str_from(""));
+                                self.call_method_with_values(v.clone(), "raku", vec![])
+                                    .map(|r| r.to_string_value())
+                                    .unwrap_or_else(|_| v.to_string_value())
+                            })
+                            .collect();
+                        return Ok(Value::str(format!(
+                            "IO::Path::Parts.new({})",
+                            rendered.join(",")
+                        )));
+                    }
                     // A Stash is a Hash subclass in Rakudo: its .raku is the
                     // symbols hash literal (`{:Bar(Foo::Bar)}`), not `Stash.new`.
                     // (.gist/.Str — the package name — are handled on the fast

--- a/t/io-path-parts-repr.t
+++ b/t/io-path-parts-repr.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+plan 7;
+
+# IO::Path::Parts is a Positional in Rakudo: .raku / .gist render the three
+# parts positionally, each via its own .raku, joined by `,` (no spaces), NOT
+# the generic named-attribute walk. (.Str is the object-address form
+# `IO::Path::Parts<addr>` and is intentionally not matched — see PLAN 8.15.)
+# Pin for PLAN 8.15.
+my $p = IO::Path::Parts.new('C:', '/some/dir', 'foo.txt');
+is $p.raku, 'IO::Path::Parts.new("C:","/some/dir","foo.txt")', '.raku renders the parts positionally';
+is $p.gist, 'IO::Path::Parts.new("C:","/some/dir","foo.txt")', '.gist equals .raku';
+is $p.perl, 'IO::Path::Parts.new("C:","/some/dir","foo.txt")', '.perl equals .raku';
+
+# Empty-ish parts still render each part's .raku (empty string is `""`).
+my $q = IO::Path::Parts.new('', '.', 'x');
+is $q.raku, 'IO::Path::Parts.new("",".","x")', 'empty volume renders as ""';
+
+# IO::Path.parts produces the same object and repr.
+my $r = 'foo/bar.txt'.IO.parts;
+is $r.raku, 'IO::Path::Parts.new("","foo","bar.txt")', '.IO.parts repr';
+
+# Named construction round-trips through the same positional repr.
+my $s = IO::Path::Parts.new(:volume(''), :dirname('a'), :basename('b'));
+is $s.raku, 'IO::Path::Parts.new("","a","b")', 'named-arg construction repr';
+
+# A part with a quote in it is escaped by the inner .raku.
+my $t = IO::Path::Parts.new('a"b', 'd', 'f');
+is $t.raku, 'IO::Path::Parts.new("a\"b","d","f")', 'inner .raku escapes quotes';
+
+done-testing;


### PR DESCRIPTION
## Summary

`IO::Path::Parts.new('C:', '/some/dir', 'foo.txt').raku` (and `.gist`) rendered the bare `IO::Path::Parts.new`, dropping the constructor arguments (PLAN §8.15).

Unlike Proc — whose repr was fixed by registering its public named attributes so the generic attribute walk could render them — **IO::Path::Parts is a Positional in Rakudo**, so its repr is *positional*, not named:

```
IO::Path::Parts.new("C:","/some/dir","foo.txt")
```

— each of the three parts (`volume`/`dirname`/`basename`) via its own `.raku`, joined by `,` with no spaces. Registering attributes would have produced the wrong `volume => ...` named form, so instead a native arm in `methods_instance_ops.rs` (alongside the Scheduler/Supplier/Stash native reprs) builds the positional string for `.raku`/`.perl`/`.gist`.

`.Str` still legitimately diverges (the object-address form `IO::Path::Parts<addr>`, non-deterministic and low value) and is intentionally not matched.

## Verification

- New pin `t/io-path-parts-repr.t` (7 tests) — direct construction, `.IO.parts`, named construction, empty parts, and inner `.raku` quote-escaping all match raku.
- Existing `t/io-path-parts.t` and `roast/S32-io/io-path.t` still pass.
- `make test` PASS (22086 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)