### PR TITLE
fix: loose word-logicals (and/or/andthen/...) are looser than =, +=, comma, return/die (PLAN 8.9)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1194,42 +1194,35 @@ the backlog.
       Faking either means hardcoding Rakudo internals; only worth doing if a real program is
       ever found to introspect them.
 
-### 8.9 The word-logical operators `and`/`or`/`andthen`/`orelse`/`xor` bind too tightly (deferred deep item — found 2026-07-22 by the traps.rakudoc doc-diff sweep)
+### 8.9 The word-logical operators `and`/`or`/`andthen`/`orelse`/`xor` bind too tightly — ✅ DONE 2026-07-23
 
-- [ ] **`and`/`or` (and the other loose word-logicals) must be the *loosest* operators —
-      looser than `=` (assignment), `,` (comma), and the `return`/statement level.** mutsu
-      parses them *tighter* than `=`/`return`, so their result is wrong:
-  - `my $a = 2; say join ",", ($a, ++$a)` → raku `3,3`, mutsu `2,3` (list-element aliasing
-    aside, the sweep case is the precedence family).
-  - `sub f { return True and False }; say f` → raku **`True`** (`(return True) and False` —
-    `return` fires first, `and False` is dead), mutsu **`False`** (parses `return (True and False)`).
-  - `sub g { return 1 and die "no" }; say g` → raku `1`, mutsu **dies** (runs the `die`).
-  - `my $x = 1 and 2; say $x` → raku `1` (`(my $x = 1) and 2`, with a "useless use" warning),
-    mutsu `2` (parses `my $x = (1 and 2)`).
-- **Root.** `and`/`or` are handled *inside* `expression()`'s `ternary` precedence chain
-  (`src/parser/expr/precedence/logic.rs`), which is tighter than the statement-level assignment
-  parser (`src/parser/stmt/assign.rs`) and `return`-argument parsing. So when the assignment/return
-  parser calls `expression()` for its RHS, that call greedily consumes the trailing `... and ...`.
-  Raku's grammar puts `and`/`or`/`andthen`/`orelse`/`notandthen`/`xor` **below** `=` and `,`
-  (see `raku-doc/doc/Language/operators.rakudoc` precedence table: "loose and" / "loose or" are the
-  last two rows). mutsu already treats them as loose vs *listop args* (the comments in
-  `src/parser/expr/operators.rs` around `parse_word_logical_op`), but not vs `=`/`return`/`,`.
-- **Fix shape (structural, high blast radius).** The RHS of an assignment and the argument of
-  `return`/`take`/etc. must be parsed *without* the word-logicals, and a **statement-level**
-  word-logical layer must wrap the whole statement (`(my $x = 1) and 2`). Because `and`/`or` also
-  compose inside expressions (`say (1 and 2)` is correct today), the clean model is a dedicated
-  top-of-precedence `word_logical` layer *above* the current `expression()` entry, with assignment
-  and `return` parsing their operand at the sub-`word_logical` level. This changes how a large
-  fraction of statements parse, so it needs a full `make test` + `make roast` pass and will likely
-  flip several local `t/` tests that currently encode the wrong (tight) precedence — those must be
-  corrected to the Raku semantics, not worked around.
-- **Verified 2026-07-22** against reference `raku` (all four cases above). Pin candidate on landing:
-  `t/word-logical-loosest-precedence.t`.
-- Entry: `git checkout -b fix-word-logical-precedence origin/main`. Files: `src/parser/expr/mod.rs`
-  (`expression`), `src/parser/expr/precedence/logic.rs`, `src/parser/stmt/assign.rs`, and the
-  `return`/`take` statement parsers. Cross-ref: the related `traps.rakudoc` list-element **container
-  aliasing** cases ([5]/[6]/[7]/[9]: `($a, ++$a)` / `@arr.push: ($a,$b)` / `Pair.new('a',$v)` reflect
-  later mutations) are a *separate* deferred item (container-repr, §8.5-adjacent), NOT this precedence bug.
+The loose word-logicals are now the *loosest* operators — looser than item assignment
+(`=`), compound assignment (`+=`, `div=`, …), the comma, and `return`/`die`/`fail`. So
+`my $x = 1 and 2` is `(my $x = 1) and 2`, `$x += 5 or die` is `($x += 5) or die`, and
+`return True and False` fires the `return` with `True` (the tail is dead). Details in
+`news/2026-07.md`; pin `t/word-logical-loosest-precedence.t` (+ `t/compound-assign-precedence.t`
+which continues to pass).
+
+Implementation: rather than a whole new top-of-precedence layer, the hand-rolled
+statement-level RHS/argument parsers now parse *no-word-logical* (new
+`expression_no_word_logical` / `parse_comma_or_expr_no_word_logical` /
+`parse_assign_expr_or_comma_no_word_logical`, entering at the `list_infix_top` tier just
+below the word-logicals) and re-attach a trailing `... and ...` via a scopeless
+`SyntheticBlock` whose second statement re-reads the assigned variable and applies the
+word-logical tail (`word_logical_tail` in `expr/precedence/logic.rs`,
+`wrap_trailing_word_logical` in `stmt/word_logical_split.rs`). `return`/`die`/`fail` parse
+their argument the same way and discard the (unreachable) tail. Parsing no-word-logical
+also fixes the parens ambiguity — `return (1 and 2)` (a complete term = 2) vs
+`return 1 and 2` (`(return 1) and 2`) — which a post-parse tree rewrite could not.
+
+- [ ] **Leftover (niche): `take X and Y`.** `take` is value-producing, so `(take X) and Y`
+      must run `Y` with `take`'s *returned* value driving the short-circuit — the re-read-seed
+      trick used for assignment does not apply (there is no variable to re-read, and re-evaluating
+      `X` would double any side effect). Needs a taken-value capture. Currently `take X and Y`
+      still parses as `take (X and Y)`. Very rare; deferred.
+- Cross-ref: the related `traps.rakudoc` list-element **container aliasing** cases
+  ([5]/[6]/[7]/[9]: `($a, ++$a)` / `@arr.push: ($a,$b)` / `Pair.new('a',$v)` reflect later
+  mutations) are a *separate* deferred item (container-repr, §8.5-adjacent), NOT this precedence bug.
 
 ### 8.10 Object hashes are string-keyed, not `.WHICH`-keyed (deferred deep item — found 2026-07-22 by the numerics/hashmap doc-diff sweeps)
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -16,6 +16,59 @@ attributes would have produced the wrong `volume => ...` named form, so instead 
 positional string for `.raku`/`.perl`/`.gist`. `.Str` still legitimately diverges (the
 object-address form `IO::Path::Parts<addr>`, low value). Pin: `t/io-path-parts-repr.t`.
 
+## 2026-07-23: the loose word-logicals `and`/`or`/`andthen`/`orelse`/`notandthen` are now the loosest operators (closes PLAN §8.9)
+
+Raku's `and`/`or` (and `andthen`/`orelse`/`notandthen`) are the *loosest* infix
+operators — looser than item assignment (`=`), compound assignment (`+=`, `div=`, …),
+the comma, and `return`/`die`/`fail`. mutsu parsed them *tighter* than `=`/`return`, so
+their results were wrong:
+
+- `my $x = 1 and 2; say $x` → now `1` (was `2`): `(my $x = 1) and 2`.
+- `$t = 2 and 3; say $t` → now `2` (was `3`): `($t = 2) and 3`.
+- `my @a = 1, 2 and 3; say @a` → now `[1 2]` (was `[1 3]`): `(my @a = 1, 2) and 3`.
+- `$x += 5 or die; say $x` → now `($x += 5) or die` (was `$x += (5 or die)`).
+- `sub f { return True and False }; say f` → now `True` (was `False`): the `return`
+  fires with `True`; `and False` is dead code.
+- `sub g { return 1 and die }; say g` → now `1` (was: ran the `die`).
+- `die "boom" and say "x"` → now dies with `"boom"` (was: ran `say`, then died).
+
+The core expression precedence chain already parsed these correctly (the word-logical
+layer sits above item assignment in `expr/precedence/logic.rs`); only the *hand-rolled*
+statement-level assignment / declaration / `return` parsers were wrong, because they
+parsed their RHS/argument with `expression()`, which greedily folds a trailing
+`... and ...` into the RHS.
+
+**Fix.** Those parsers now parse the RHS/argument *no-word-logical* — new
+`expression_no_word_logical`, `parse_comma_or_expr_no_word_logical`, and
+`parse_assign_expr_or_comma_no_word_logical`, all entering at the `list_infix_top`
+precedence tier just below the word-logicals — and re-attach a trailing `... and ...` at
+the correct (looser) precedence:
+
+- **Assignment / declaration** (`my $x = …`, `$x = …`, `@a = …`, `$x += …`, `$x div= …`):
+  the value-producing statement is wrapped in a scopeless `Stmt::SyntheticBlock` whose
+  second statement re-reads the just-assigned variable and applies the word-logical tail
+  (`word_logical_tail` continues the `or`/`and` chain from a seed;
+  `wrap_trailing_word_logical` builds the block). Re-reading the variable is exact for
+  `=` assignment — it holds precisely the assigned value, so the boolean/definedness
+  short-circuit and the `andthen`/`orelse` value pass-through all match.
+- **`return` / `die` / `fail`**: control transfers before the tail would run, so they
+  parse the argument no-word-logical and *discard* the (unreachable) tail.
+
+Parsing no-word-logical (rather than rewriting the parsed tree afterwards) is what makes
+the parenthesis distinction work: `return (1 and 2)` is a complete term (`2`) consumed by
+the RHS parser, while `return 1 and 2` leaves `and 2` in the stream for the tail — both
+collapse to the same `Binary` in the AST, so a post-parse rewrite could not tell them
+apart. `xor` is handled the same way (it is left in the stream by the no-word-logical
+parse, which still consumes the *tight* `^^`).
+
+New helpers live in `src/parser/stmt/word_logical_split.rs`,
+`src/parser/expr/precedence/logic.rs` (`word_logical_tail`), and `src/parser/expr/mod.rs`
+(`expression_no_word_logical`, `starts_with_loose_word_logical`). Pins:
+`t/word-logical-loosest-precedence.t` (18 cases), and `t/compound-assign-precedence.t`
+continues to pass. Leftover (deferred, niche): `take X and Y` — `take` is value-producing,
+so it needs a taken-value capture rather than a variable re-read; it still parses as
+`take (X and Y)`.
+
 ## 2026-07-23: an `s///` replacement `\\` before a capture var keeps its backslash (P5quotemeta)
 
 A substitution replacement `\\` (an escaped backslash — one literal backslash) followed

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -202,6 +202,71 @@ pub(in crate::parser) fn expression_no_assign(input: &str) -> PResult<'_, Expr> 
     Ok((rest, expr))
 }
 
+/// Like [`expression`], but stops before the loosest word-logical operators
+/// (`and`/`or`/`xor`/`andthen`/`orelse`/`notandthen`). Used by the hand-rolled
+/// statement-level assignment, declaration and `return` RHS parsers so those
+/// operators bind *looser* than item assignment (`=`), the comma, and
+/// `return` — matching Raku's precedence table (`operators.rakudoc`: "loose and"
+/// / "loose or" are the last two rows). A parenthesized word-logical
+/// (`return (1 and 2)`) is a complete term consumed here; an unparenthesized one
+/// (`return 1 and 2`) is left in the stream for the caller's word-logical tail.
+///
+/// Applies the same fat-arrow (`=>`) and WhateverCode wrapping as [`expression`].
+/// The parse entry is the list-infix layer ([`list_infix_top`]), which is the
+/// precedence tier just below the word-logicals.
+pub(in crate::parser) fn expression_no_word_logical(input: &str) -> PResult<'_, Expr> {
+    let (rest, mut expr) = precedence::list_infix_top(input, operators::ExprMode::Full)?;
+    let (r, _) = ws(rest)?;
+    if r.starts_with("=>") && !r.starts_with("==>") {
+        let r = &r[2..];
+        let (r, _) = ws(r)?;
+        let (r, value) = parse_fat_arrow_value(r)?;
+        let consumed = &input[..input.len() - rest.len()];
+        let leading_colons = consumed.trim_start().starts_with("::");
+        let is_bareword =
+            !leading_colons && matches!(&expr, Expr::BareWord(name) if !name.contains("::"));
+        let left = match expr {
+            Expr::BareWord(ref name)
+                if !consumed.trim_start().starts_with('(')
+                    && !leading_colons
+                    && !name.contains("::") =>
+            {
+                Expr::Literal(Value::str(name.clone()))
+            }
+            _ => expr,
+        };
+        let pair = Expr::Binary {
+            left: Box::new(left),
+            op: TokenKind::FatArrow,
+            right: Box::new(value),
+        };
+        let result = if is_bareword {
+            pair
+        } else {
+            Expr::PositionalPair(Box::new(pair))
+        };
+        return Ok((r, result));
+    }
+    expr = wrap_composition_operands(expr);
+    if should_wrap_whatevercode(&expr) {
+        expr = match expr {
+            Expr::CallOn { target, args }
+                if should_wrap_whatevercode(&target) && !args.iter().any(contains_whatever) =>
+            {
+                Expr::CallOn {
+                    target: Box::new(wrap_whatevercode(&target)),
+                    args,
+                }
+            }
+            ref e if try_wrap_whatevercode_call_chain(e).is_some() => {
+                try_wrap_whatevercode_call_chain(&expr).unwrap()
+            }
+            other => wrap_whatevercode(&other),
+        };
+    }
+    Ok((rest, expr))
+}
+
 pub(in crate::parser) fn expression_no_sequence(input: &str) -> PResult<'_, Expr> {
     // Same as expression but skip memo and don't include sequence
     let (rest, mut expr) = precedence::ternary_mode(input, operators::ExprMode::NoSequence)?;
@@ -406,4 +471,19 @@ pub(in crate::parser) fn parse_fat_arrow_value(input: &str) -> PResult<'_, Expr>
 
 pub(in crate::parser) fn term_expr(input: &str) -> PResult<'_, Expr> {
     postfix::prefix_expr(input)
+}
+
+/// Returns true when `input` begins with a loose word-logical operator
+/// (`and`/`or`/`xor`/`andthen`/`orelse`/`notandthen`), not immediately followed
+/// by `=` (a compound assignment). Used by the statement-level word-logical tail
+/// wrapper to decide whether to attach a trailing `... and ...`.
+pub(in crate::parser) fn starts_with_loose_word_logical(input: &str) -> bool {
+    operators::parse_word_logical_op(input).is_some()
+}
+
+/// Continue parsing a statement-level word-logical chain from an already-parsed
+/// leftmost operand (`seed`), with `input` positioned at the first word-logical
+/// operator. Thin public wrapper over [`precedence::word_logical_tail`].
+pub(in crate::parser) fn word_logical_tail_pub(input: &str, seed: Expr) -> PResult<'_, Expr> {
+    precedence::word_logical_tail(input, seed)
 }

--- a/src/parser/expr/precedence.rs
+++ b/src/parser/expr/precedence.rs
@@ -72,7 +72,9 @@ pub(crate) use list_infix_loop::{
     parse_list_infix_loop, parse_list_infix_loop_no_feed, parse_list_infix_loop_with_operand,
 };
 pub(crate) use list_infix_top::{item_expr, list_infix_top};
-pub(crate) use logic::{assign_not_expr_mode, or_expr_mode, or_expr_no_assign_mode};
+pub(crate) use logic::{
+    assign_not_expr_mode, or_expr_mode, or_expr_no_assign_mode, word_logical_tail,
+};
 pub(crate) use logic2::{junctive_expr_mode, not_expr_mode, or_or_expr_mode};
 pub(crate) use ternary::{comparison_nonassoc_key, structural_comparison_expr_mode};
 

--- a/src/parser/expr/precedence/logic.rs
+++ b/src/parser/expr/precedence/logic.rs
@@ -72,6 +72,82 @@ pub(crate) fn assign_or_and_expr(input: &str, mode: ExprMode) -> PResult<'_, Exp
     and_expr_mode(input, mode)
 }
 
+/// Continue parsing a statement-level word-logical chain, given an
+/// already-parsed leftmost operand (`seed`) and the input positioned *at* the
+/// first word-logical operator.
+///
+/// Used by the hand-rolled statement-level assignment / declaration / `return`
+/// parsers: after the RHS is parsed with `expression_no_word_logical` (which
+/// stops before the loose word-logicals), the trailing `... and ...` is parsed
+/// here with `seed` (typically a re-read of the just-assigned variable) as the
+/// left operand. The precedence mirrors `or_expr_mode` wrapping `and_expr_mode`
+/// (`or`/`xor`/`orelse` looser than `and`/`andthen`/`notandthen`), but — because
+/// this runs at *statement* level, where the comma is looser than `=` yet the
+/// word-logicals are looser still — each operand absorbs a full comma list
+/// (`X = 1, 2 and 3, 4` → `(X = 1, 2) and (3, 4)`).
+pub(crate) fn word_logical_tail(input: &str, seed: Expr) -> PResult<'_, Expr> {
+    let (rest, left) = and_chain_seeded(input, seed)?;
+    or_chain_continue(rest, left)
+}
+
+/// Word-logical operand at statement level: a comma list whose elements stop
+/// before the word-logicals.
+fn wl_operand(input: &str) -> PResult<'_, Expr> {
+    crate::parser::stmt::assign::parse_comma_or_expr_no_word_logical(input)
+}
+
+/// Consume a chain of `and`/`andthen`/`notandthen` starting from `seed`.
+fn and_chain_seeded(input: &str, seed: Expr) -> PResult<'_, Expr> {
+    let mut rest = input;
+    let mut left = seed;
+    loop {
+        let (r, _) = ws(rest)?;
+        if let Some((op @ (LogicalOp::And | LogicalOp::AndThen | LogicalOp::NotAndThen), len)) =
+            parse_word_logical_op(r)
+        {
+            let r = &r[len..];
+            let (r, _) = ws(r)?;
+            let (r, right) = wl_operand(r)?;
+            left = Expr::Binary {
+                left: Box::new(left),
+                op: op.token_kind(),
+                right: Box::new(right),
+            };
+            rest = r;
+            continue;
+        }
+        break;
+    }
+    Ok((rest, left))
+}
+
+/// Continue a chain of `or`/`xor`/`orelse` from an already-parsed `and`-level
+/// left operand. Each `or`-operand is itself a full `and` chain.
+fn or_chain_continue(input: &str, left0: Expr) -> PResult<'_, Expr> {
+    let mut rest = input;
+    let mut left = left0;
+    loop {
+        let (r, _) = ws(rest)?;
+        if let Some((op @ (LogicalOp::Or | LogicalOp::XorXor | LogicalOp::OrElse), len)) =
+            parse_word_logical_op(r)
+        {
+            let r = &r[len..];
+            let (r, _) = ws(r)?;
+            let (r, first) = wl_operand(r)?;
+            let (r, right) = and_chain_seeded(r, first)?;
+            left = Expr::Binary {
+                left: Box::new(left),
+                op: op.token_kind(),
+                right: Box::new(right),
+            };
+            rest = r;
+            continue;
+        }
+        break;
+    }
+    Ok((rest, left))
+}
+
 /// Low-precedence: and / andthen / notandthen
 pub(crate) fn and_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
     // The list-infix operators (`Z`/`X`/meta/`...`/feed/`minmax`) sit just below

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -1,7 +1,8 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::super::expr::{
-    QuotedMethodName, expression, expression_no_sequence, parse_quoted_method_name,
+    QuotedMethodName, expression, expression_no_sequence, expression_no_word_logical,
+    parse_quoted_method_name,
 };
 use super::super::helpers::ws;
 use super::super::parse_result::{
@@ -76,7 +77,8 @@ mod try_assign;
 // ---- Re-exports preserving each public function's original visibility ----
 pub(in crate::parser) use assign_stmt::assign_stmt;
 pub(in crate::parser) use comma::{
-    normalize_comma_list_items, parse_comma_or_expr, parse_comma_or_expr_item,
+    normalize_comma_list_items, parse_comma_or_expr, parse_comma_or_expr_item_no_word_logical,
+    parse_comma_or_expr_no_word_logical,
 };
 pub(in crate::parser) use try_assign::try_parse_assign_expr;
 
@@ -94,7 +96,7 @@ pub(crate) use op::{
 };
 pub(crate) use paren::{looks_like_parenthesized_assignment, parenthesized_assign_expr};
 pub(crate) use sink::{
-    parse_assign_expr_or_comma, rewrite_scalar_assignment_rhs_as_sink,
-    rewrite_scalar_assignment_stmt_as_sink,
+    parse_assign_expr_or_comma, parse_assign_expr_or_comma_no_word_logical,
+    rewrite_scalar_assignment_rhs_as_sink, rewrite_scalar_assignment_stmt_as_sink,
 };
 pub(crate) use try_assign::parse_colon_method_arg;

--- a/src/parser/stmt/assign/assign_stmt.rs
+++ b/src/parser/stmt/assign/assign_stmt.rs
@@ -223,35 +223,45 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
 
     if let Some((stripped, op)) = parse_compound_assign_op(rest) {
         let (rest, _) = ws(stripped)?;
-        let (rest, rhs) = parse_assign_expr_or_comma(rest).map_err(|err| PError {
-            messages: merge_expected_messages(
-                "expected right-hand expression after compound assignment",
-                &err.messages,
-            ),
-            remaining_len: err.remaining_len.or(Some(rest.len())),
-            exception: None,
-        })?;
+        // The loose word-logicals bind looser than the compound assignment:
+        // `$x += 5 and 6` is `($x += 5) and 6`. Parse the RHS no-word-logical and
+        // re-attach a trailing tail below.
+        let (rest, rhs) =
+            parse_assign_expr_or_comma_no_word_logical(rest).map_err(|err| PError {
+                messages: merge_expected_messages(
+                    "expected right-hand expression after compound assignment",
+                    &err.messages,
+                ),
+                remaining_len: err.remaining_len.or(Some(rest.len())),
+                exception: None,
+            })?;
         // Use the sigil-appropriate lvalue expression so `%h ,= %g` / `@a ,= 3`
         // read the current container as a Hash/Array (not a scalar `Var("%h")`),
         // giving the comma operator the two containers to merge/append.
         let expr = compound_assigned_value_expr(var_expr, op, rhs);
         let stmt = Stmt::Assign {
-            name,
+            name: name.clone(),
             expr,
             op: AssignOp::Assign,
         };
+        let (rest, stmt) = crate::parser::stmt::word_logical_split::wrap_trailing_word_logical(
+            rest,
+            stmt,
+            crate::parser::stmt::word_logical_split::seed_read_expr(&name),
+        )?;
         return parse_statement_modifier(rest, stmt);
     }
     if let Some((stripped, op_name)) = parse_custom_compound_assign_op(rest) {
         let (rest, _) = ws(stripped)?;
-        let (rest, rhs) = parse_assign_expr_or_comma(rest).map_err(|err| PError {
-            messages: merge_expected_messages(
-                "expected right-hand expression after compound assignment",
-                &err.messages,
-            ),
-            remaining_len: err.remaining_len.or(Some(rest.len())),
-            exception: None,
-        })?;
+        let (rest, rhs) =
+            parse_assign_expr_or_comma_no_word_logical(rest).map_err(|err| PError {
+                messages: merge_expected_messages(
+                    "expected right-hand expression after compound assignment",
+                    &err.messages,
+                ),
+                remaining_len: err.remaining_len.or(Some(rest.len())),
+                exception: None,
+            })?;
         let stmt = Stmt::Assign {
             name: name.clone(),
             expr: Expr::InfixFunc {
@@ -262,6 +272,11 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
             },
             op: AssignOp::Assign,
         };
+        let (rest, stmt) = crate::parser::stmt::word_logical_split::wrap_trailing_word_logical(
+            rest,
+            stmt,
+            crate::parser::stmt::word_logical_split::seed_read_expr(&name),
+        )?;
         return parse_statement_modifier(rest, stmt);
     }
 
@@ -495,7 +510,11 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
         // `@x = 1, 2, 3` assigns the whole list. Atomic `⚛=` is always a scalar
         // store and is handled below.
         if sigil == b'$' && !is_atomic {
-            let (after_rhs, rhs) = expression(rest).map_err(|err| PError {
+            // Parse the RHS at a precedence that stops before the loose
+            // word-logicals: `$x = 1 and 2` is `($x = 1) and 2` (they are looser
+            // than item assignment). Any trailing `... and ...` is re-attached by
+            // `wrap_trailing_word_logical` below.
+            let (after_rhs, rhs) = expression_no_word_logical(rest).map_err(|err| PError {
                 messages: merge_expected_messages(
                     "expected right-hand expression after '='",
                     &err.messages,
@@ -507,7 +526,7 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
             if after_ws.starts_with(',') && !after_ws.starts_with(",,") {
                 // `($x = rhs), <rest...>` — assign the first element, sink the rest.
                 let assign_expr = Expr::AssignExpr {
-                    name,
+                    name: name.clone(),
                     expr: Box::new(rhs),
                     is_bind: false,
                 };
@@ -524,30 +543,43 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
                         r = r2;
                         break;
                     }
-                    let (r2, next) = expression(r2)?;
+                    let (r2, next) = expression_no_word_logical(r2)?;
                     items.push(next);
                     let (r2, _) = ws(r2)?;
                     r = r2;
                 }
                 let stmt = Stmt::Expr(Expr::ArrayLiteral(items));
+                let (r, stmt) =
+                    crate::parser::stmt::word_logical_split::wrap_trailing_word_logical(
+                        r,
+                        stmt,
+                        Expr::Var(name),
+                    )?;
                 return parse_statement_modifier(r, stmt);
             }
             let stmt = Stmt::Assign {
-                name,
+                name: name.clone(),
                 expr: rhs,
                 op: AssignOp::Assign,
             };
+            let (after_rhs, stmt) =
+                crate::parser::stmt::word_logical_split::wrap_trailing_word_logical(
+                    after_rhs,
+                    stmt,
+                    Expr::Var(name),
+                )?;
             return parse_statement_modifier(after_rhs, stmt);
         }
 
-        let (rest, expr) = parse_assign_expr_or_comma(rest).map_err(|err| PError {
-            messages: merge_expected_messages(
-                "expected right-hand expression after '='",
-                &err.messages,
-            ),
-            remaining_len: err.remaining_len.or(Some(rest.len())),
-            exception: None,
-        })?;
+        let (rest, expr) =
+            parse_assign_expr_or_comma_no_word_logical(rest).map_err(|err| PError {
+                messages: merge_expected_messages(
+                    "expected right-hand expression after '='",
+                    &err.messages,
+                ),
+                remaining_len: err.remaining_len.or(Some(rest.len())),
+                exception: None,
+            })?;
         if is_atomic {
             let stmt = Stmt::Expr(Expr::Call {
                 name: Symbol::intern("__mutsu_atomic_store_var"),
@@ -556,10 +588,15 @@ pub(in crate::parser) fn assign_stmt(input: &str) -> PResult<'_, Stmt> {
             return parse_statement_modifier(rest, stmt);
         }
         let stmt = Stmt::Assign {
-            name,
+            name: name.clone(),
             expr,
             op: AssignOp::Assign,
         };
+        let (rest, stmt) = crate::parser::stmt::word_logical_split::wrap_trailing_word_logical(
+            rest,
+            stmt,
+            crate::parser::stmt::word_logical_split::seed_read_expr(&name),
+        )?;
         return parse_statement_modifier(rest, stmt);
     }
     // Binding (:= or ::=)

--- a/src/parser/stmt/assign/comma.rs
+++ b/src/parser/stmt/assign/comma.rs
@@ -5,16 +5,6 @@ pub(in crate::parser) fn parse_comma_or_expr(input: &str) -> PResult<'_, Expr> {
     parse_comma_or_expr_impl(input, false)
 }
 
-/// Like [`parse_comma_or_expr`], but in *item* context: a bare single element
-/// with a trailing comma (`return 5,`) yields the scalar element, not a
-/// 1-element list. Rakudo distinguishes bare `5,` (scalar) from the
-/// parenthesized `(5,)` (a 1-element List, parsed by the circumfix parser and so
-/// unaffected). Used by `return` (and `fail`), where `return sprintf(...),`
-/// must yield the scalar so a `--> Str` routine does not see a `List`.
-pub(in crate::parser) fn parse_comma_or_expr_item(input: &str) -> PResult<'_, Expr> {
-    parse_comma_or_expr_impl(input, true)
-}
-
 fn parse_comma_or_expr_impl(input: &str, item_context: bool) -> PResult<'_, Expr> {
     let (rest, first) = expression(input)?;
     let (r, _) = ws(rest)?;
@@ -46,6 +36,60 @@ fn parse_comma_or_expr_impl(input: &str, item_context: bool) -> PResult<'_, Expr
                 return Ok((r2, finalize_list(items)));
             }
             let (r2, next) = expression(r2)?;
+            items.push(next);
+            r = r2;
+        }
+    }
+    Ok((rest, first))
+}
+
+/// Like [`parse_comma_or_expr`], but each element is parsed with
+/// [`expression_no_word_logical`] so the loose word-logicals bind looser than
+/// the comma. Parsing therefore stops at a top-level `... and ...`, leaving it
+/// for the statement-level word-logical tail. Used by the assignment /
+/// declaration / `return` RHS parsers.
+pub(in crate::parser) fn parse_comma_or_expr_no_word_logical(input: &str) -> PResult<'_, Expr> {
+    parse_comma_or_expr_no_wl_impl(input, false)
+}
+
+/// Item-context variant of [`parse_comma_or_expr_no_word_logical`]: a bare
+/// single element with a trailing comma (`return 5,`) yields the scalar element,
+/// not a 1-element list. Rakudo distinguishes bare `5,` (scalar) from the
+/// parenthesized `(5,)` (a 1-element List). Used by `return` (and `fail`).
+pub(in crate::parser) fn parse_comma_or_expr_item_no_word_logical(
+    input: &str,
+) -> PResult<'_, Expr> {
+    parse_comma_or_expr_no_wl_impl(input, true)
+}
+
+fn parse_comma_or_expr_no_wl_impl(input: &str, item_context: bool) -> PResult<'_, Expr> {
+    let (rest, first) = expression_no_word_logical(input)?;
+    let (r, _) = ws(rest)?;
+    if r.starts_with(',') && !r.starts_with(",,") {
+        let (r, _) = parse_char(r, ',')?;
+        let (r, _) = ws(r)?;
+        if r.starts_with(';') || r.is_empty() || r.starts_with('}') || r.starts_with(')') {
+            if item_context {
+                return Ok((r, first));
+            }
+            return Ok((r, Expr::ArrayLiteral(vec![first])));
+        }
+        let mut items = vec![first];
+        let (mut r, second) = expression_no_word_logical(r)?;
+        items.push(second);
+        loop {
+            let (r2, _) = ws(r)?;
+            if !r2.starts_with(',') {
+                let items = normalize_comma_list_items(items);
+                return Ok((r2, finalize_list(items)));
+            }
+            let (r2, _) = parse_char(r2, ',')?;
+            let (r2, _) = ws(r2)?;
+            if r2.starts_with(';') || r2.is_empty() || r2.starts_with('}') || r2.starts_with(')') {
+                let items = normalize_comma_list_items(items);
+                return Ok((r2, finalize_list(items)));
+            }
+            let (r2, next) = expression_no_word_logical(r2)?;
             items.push(next);
             r = r2;
         }

--- a/src/parser/stmt/assign/sink.rs
+++ b/src/parser/stmt/assign/sink.rs
@@ -86,6 +86,89 @@ pub(crate) fn parse_assign_expr_or_comma(input: &str) -> PResult<'_, Expr> {
     parse_comma_or_expr(input)
 }
 
+/// No-word-logical twin of [`parse_assign_expr_or_comma`]: identical
+/// chained-assignment and comma handling, but every element is parsed with
+/// [`expression_no_word_logical`] so a top-level (unparenthesized) word-logical
+/// is left in the stream for the statement-level word-logical tail. Used by the
+/// assignment / declaration RHS parsers so `@a = 1, 2 and 3` is
+/// `(@a = 1, 2) and 3` while `$x ||= 42, 43` keeps its item-assignment
+/// (comma-tight) `||=`.
+pub(crate) fn parse_assign_expr_or_comma_no_word_logical(input: &str) -> PResult<'_, Expr> {
+    if let Ok((rest, assign_expr)) = try_parse_assign_expr(input) {
+        let (r, _) = ws(rest)?;
+        // Chained *list* assignment to an `@`/`%` container absorbs the comma list
+        // on its right (see [`parse_assign_expr_or_comma`]).
+        if r.starts_with(',')
+            && !r.starts_with(",,")
+            && let Expr::AssignExpr {
+                name,
+                expr,
+                is_bind: false,
+            } = &assign_expr
+            && (name.starts_with('@') || name.starts_with('%'))
+        {
+            let (r2, _) = parse_char(r, ',')?;
+            let (r2, _) = ws(r2)?;
+            if !(r2.starts_with(';') || r2.is_empty() || r2.starts_with('}') || r2.starts_with(')'))
+            {
+                let mut items = vec![(**expr).clone()];
+                let (mut r_iter, second) = expression_no_word_logical(r2)?;
+                items.push(second);
+                loop {
+                    let (r3, _) = ws(r_iter)?;
+                    if !r3.starts_with(',') || r3.starts_with(",,") {
+                        r_iter = r3;
+                        break;
+                    }
+                    let (r3, _) = parse_char(r3, ',')?;
+                    let (r3, _) = ws(r3)?;
+                    if r3.starts_with(';') || r3.is_empty() || r3.starts_with('}') {
+                        r_iter = r3;
+                        break;
+                    }
+                    let (r3, next) = expression_no_word_logical(r3)?;
+                    items.push(next);
+                    r_iter = r3;
+                }
+                return Ok((
+                    r_iter,
+                    Expr::AssignExpr {
+                        name: name.clone(),
+                        expr: Box::new(Expr::ArrayLiteral(items)),
+                        is_bind: false,
+                    },
+                ));
+            }
+        }
+        if r.starts_with(',') && !r.starts_with(",,") {
+            let (r, _) = parse_char(r, ',')?;
+            let (r, _) = ws(r)?;
+            if r.starts_with(';') || r.is_empty() || r.starts_with('}') {
+                return Ok((r, Expr::ArrayLiteral(vec![assign_expr])));
+            }
+            let mut items = vec![assign_expr];
+            let (mut r, second) = expression_no_word_logical(r)?;
+            items.push(second);
+            loop {
+                let (r2, _) = ws(r)?;
+                if !r2.starts_with(',') {
+                    return Ok((r2, Expr::ArrayLiteral(items)));
+                }
+                let (r2, _) = parse_char(r2, ',')?;
+                let (r2, _) = ws(r2)?;
+                if r2.starts_with(';') || r2.is_empty() || r2.starts_with('}') {
+                    return Ok((r2, Expr::ArrayLiteral(items)));
+                }
+                let (r2, next) = expression_no_word_logical(r2)?;
+                items.push(next);
+                r = r2;
+            }
+        }
+        return Ok((rest, assign_expr));
+    }
+    parse_comma_or_expr_no_word_logical(input)
+}
+
 pub(crate) fn rewrite_scalar_assignment_rhs_as_sink(name: String, rhs: Expr) -> Option<Expr> {
     match rhs {
         Expr::MetaOp {

--- a/src/parser/stmt/decl/my_decl_assign.rs
+++ b/src/parser/stmt/decl/my_decl_assign.rs
@@ -1,6 +1,7 @@
-use super::super::super::expr::expression;
+use super::super::super::expr::{expression, expression_no_word_logical};
 use super::super::super::helpers::ws;
 use super::super::super::parse_result::{PError, PResult, merge_expected_messages, parse_char};
+use super::super::assign::parse_assign_expr_or_comma_no_word_logical;
 use super::super::keyword;
 use super::helpers::shaped_array_new_with_data_expr;
 use super::my_decl::MyDeclState;
@@ -344,24 +345,26 @@ fn handle_simple_assign(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
     let is_scalar = !s.is_array && !s.is_hash;
     let var_name_for_leave = s.name.clone();
     // Scalar declarations stop at comma; array/hash consume the full comma list.
+    // The RHS is parsed at a precedence that stops before the loose
+    // word-logicals (`and`/`or`/`andthen`/...): in Raku they are looser than the
+    // declaration's `=`, so `my $x = 1 and 2` is `(my $x = 1) and 2`.
     let (rest, expr) = if s.is_array || s.is_hash {
-        parse_assign_expr_or_comma(rest)?
+        parse_assign_expr_or_comma_no_word_logical(rest)?
     } else {
-        expression(rest)?
+        expression_no_word_logical(rest)?
     };
-    // In Raku, andthen/orelse/notandthen have lower precedence than declaration
-    // assignment. If the expression is `expr andthen { block }`, split it so
-    // the declaration assigns `expr` and the andthen runs as a side effect.
-    let (expr, post_andthen) = match expr {
-        Expr::Binary {
-            left,
-            op:
-                op @ (crate::token_kind::TokenKind::AndThen
-                | crate::token_kind::TokenKind::OrElse
-                | crate::token_kind::TokenKind::NotAndThen),
-            right,
-        } => (*left, Some((op, *right))),
-        other => (other, None),
+    // Capture a trailing word-logical tail, seeded by a re-read of the declared
+    // variable. It is re-attached below as a scopeless `SyntheticBlock` second
+    // statement: `my $x = 1 and 2` runs `my $x = 1`, then `$x and 2`.
+    let (rest, post_andthen) = {
+        let (rws, _) = ws(rest)?;
+        if crate::parser::expr::starts_with_loose_word_logical(rws) {
+            let seed = crate::parser::stmt::word_logical_split::seed_read_expr(&s.name);
+            let (r, tail) = crate::parser::expr::word_logical_tail_pub(rws, seed)?;
+            (r, Some(tail))
+        } else {
+            (rest, None)
+        }
     };
     let expr = match expr {
         Expr::MetaOp {
@@ -399,6 +402,11 @@ fn handle_simple_assign(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
                 consume_scalar_decl_trailing_comma(rest, stmt)?
             } else {
                 (rest, stmt)
+            };
+            let stmt = if let Some(tail) = post_andthen {
+                Stmt::SyntheticBlock(vec![stmt, Stmt::Expr(tail)])
+            } else {
+                stmt
             };
             if s.apply_modifier {
                 return parse_statement_modifier(rest, stmt);
@@ -494,14 +502,8 @@ fn handle_simple_assign(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
         } else {
             (rest, stmt)
         };
-        let stmt = if let Some((op, rhs)) = post_andthen.clone() {
-            let var_ref = Expr::Var(s.name.clone());
-            let andthen_expr = Expr::Binary {
-                left: Box::new(var_ref),
-                op,
-                right: Box::new(rhs),
-            };
-            Stmt::SyntheticBlock(vec![stmt, Stmt::Expr(andthen_expr)])
+        let stmt = if let Some(tail) = post_andthen.clone() {
+            Stmt::SyntheticBlock(vec![stmt, Stmt::Expr(tail)])
         } else {
             stmt
         };
@@ -542,14 +544,8 @@ fn handle_simple_assign(input: &str, s: MyDeclState) -> PResult<'_, Stmt> {
     } else {
         (rest, stmt)
     };
-    let stmt = if let Some((op, rhs)) = post_andthen {
-        let var_ref = Expr::Var(s.name.clone());
-        let andthen_expr = Expr::Binary {
-            left: Box::new(var_ref),
-            op,
-            right: Box::new(rhs),
-        };
-        Stmt::SyntheticBlock(vec![stmt, Stmt::Expr(andthen_expr)])
+    let stmt = if let Some(tail) = post_andthen {
+        Stmt::SyntheticBlock(vec![stmt, Stmt::Expr(tail)])
     } else {
         stmt
     };

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod simple_expr_stmt;
 mod stmtlist;
 mod sub;
 pub(crate) mod sub_param;
+pub(crate) mod word_logical_split;
 
 use super::memo::{MemoEntry, MemoStats, ParseMemo};
 use super::parse_result::{PError, PResult, parse_char, update_best_error};
@@ -28,7 +29,7 @@ use super::helpers::{
 use args::{parse_stmt_call_args, parse_stmt_call_args_no_paren};
 pub(in crate::parser) use assign::assign_stmt;
 use assign::{
-    parse_assign_expr_or_comma, parse_comma_or_expr, parse_comma_or_expr_item,
+    parse_assign_expr_or_comma, parse_comma_or_expr, parse_comma_or_expr_item_no_word_logical,
     try_parse_assign_expr,
 };
 use class::class_decl_body;

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::AtomicUsize;
 use regex::Regex;
 
 use super::super::add_parse_warning;
-use super::super::expr::expression;
+use super::super::expr::{expression, expression_no_word_logical};
 use super::super::helpers::{is_loop_label_name, skip_balanced_parens, ws, ws1};
 use super::super::parse_result::{PError, PResult, merge_expected_messages, opt_char, parse_char};
 
@@ -18,8 +18,9 @@ use crate::value::ValueView;
 pub(super) use super::simple_expr_stmt::{expr_stmt, let_stmt, temp_stmt};
 
 use super::{
-    block, ident, is_stmt_modifier_keyword, keyword, parse_comma_or_expr, parse_comma_or_expr_item,
-    parse_statement_modifier, parse_stmt_call_args, parse_stmt_call_args_no_paren, statement,
+    block, ident, is_stmt_modifier_keyword, keyword, parse_comma_or_expr,
+    parse_comma_or_expr_item_no_word_logical, parse_statement_modifier, parse_stmt_call_args,
+    parse_stmt_call_args_no_paren, statement,
 };
 
 // Themed submodules. This file is the facade: it owns the parser-state statics

--- a/src/parser/stmt/simple/control_stmts.rs
+++ b/src/parser/stmt/simple/control_stmts.rs
@@ -18,11 +18,27 @@ pub(crate) fn return_stmt(input: &str) -> PResult<'_, Stmt> {
         let (rest, _) = opt_char(rest, ';');
         return Ok((rest, Stmt::Return(Expr::Literal(Value::NIL))));
     }
-    let (rest, expr) = parse_comma_or_expr_item(rest).map_err(|err| PError {
+    // Parse the return value at a precedence that stops before the loose
+    // word-logicals (`and`/`or`/`andthen`/...): they are looser than `return`, so
+    // `return True and False` is `(return True) and False`. The `return` fires
+    // with `True`; `and False` is dead code (control has already transferred).
+    let (rest, expr) = parse_comma_or_expr_item_no_word_logical(rest).map_err(|err| PError {
         messages: merge_expected_messages("expected return value expression", &err.messages),
         remaining_len: err.remaining_len.or(Some(rest.len())),
         exception: None,
     })?;
+    // Consume (and discard) any trailing word-logical tail: it is unreachable
+    // because `return` transfers control before it would be evaluated.
+    let rest = {
+        let (r, _) = ws(rest)?;
+        if crate::parser::expr::starts_with_loose_word_logical(r) {
+            let (r, _dead) =
+                crate::parser::expr::word_logical_tail_pub(r, Expr::Literal(Value::NIL))?;
+            r
+        } else {
+            rest
+        }
+    };
     // `return $x:` is the indirect-method-call spelling `$x.return`, which
     // returns `$x` from the enclosing routine — identical to `return $x`. Accept
     // a bare trailing colon (no colon-args), i.e. a `:` immediately followed by a
@@ -122,7 +138,21 @@ pub(crate) fn die_stmt(input: &str) -> PResult<'_, Stmt> {
         };
         return parse_statement_modifier(rest, stmt);
     }
-    let (rest, expr) = expression(rest)?;
+    // Like `return`, `die`/`fail` transfer control before a trailing loose
+    // word-logical would run: `die X and Y` is `(die X) and Y`, so `die` throws
+    // (or `fail` returns a Failure) with `X` and the tail is dead code. Parse the
+    // argument no-word-logical and consume (discard) any trailing tail.
+    let (rest, expr) = expression_no_word_logical(rest)?;
+    let rest = {
+        let (r, _) = ws(rest)?;
+        if crate::parser::expr::starts_with_loose_word_logical(r) {
+            let (r, _dead) =
+                crate::parser::expr::word_logical_tail_pub(r, Expr::Literal(Value::NIL))?;
+            r
+        } else {
+            rest
+        }
+    };
     let stmt = if is_fail {
         Stmt::Fail(expr)
     } else {

--- a/src/parser/stmt/word_logical_split.rs
+++ b/src/parser/stmt/word_logical_split.rs
@@ -1,0 +1,54 @@
+//! Statement-level word-logical tail wrapping.
+//!
+//! In Raku the loose word-logicals `and`/`or`/`xor`/`andthen`/`orelse`/
+//! `notandthen` are the *loosest* infix operators — looser than item assignment
+//! (`=`), the comma operator (`,`), and `return`/statement-level parsing. So
+//! `my $x = 1 and 2` is `(my $x = 1) and 2` and `return True and False` is
+//! `(return True) and False` (the `return` fires; `and False` is dead code).
+//!
+//! The hand-rolled statement-level assignment, declaration and `return` parsers
+//! parse their RHS with [`expression_no_word_logical`], which stops before a
+//! top-level (unparenthesized) word-logical. This module then re-attaches the
+//! trailing `... and ...` at the correct, looser precedence: it wraps the
+//! value-producing statement in a scopeless [`Stmt::SyntheticBlock`] whose second
+//! statement re-reads the assigned variable and applies the word-logical tail.
+//!
+//! Re-reading the assigned variable (`seed`) as the tail's left operand is exact
+//! for `= ` assignment: the variable holds precisely the value the assignment
+//! produced, so the boolean / definedness short-circuit and the `andthen`/
+//! `orelse` value pass-through all match `(<assignment>) <op> ...`.
+
+use crate::ast::{Expr, Stmt};
+use crate::parser::expr::{starts_with_loose_word_logical, word_logical_tail_pub};
+use crate::parser::helpers::ws;
+use crate::parser::parse_result::PResult;
+
+/// The read expression for an assignment target's variable, used to re-read the
+/// just-assigned value as the left operand of the hoisted word-logical.
+/// `$x` is stored as `Var("x")`, `@a` as `ArrayVar("a")`, `%h` as `HashVar("h")`.
+pub(crate) fn seed_read_expr(name: &str) -> Expr {
+    if let Some(n) = name.strip_prefix('@') {
+        Expr::ArrayVar(n.to_string())
+    } else if let Some(n) = name.strip_prefix('%') {
+        Expr::HashVar(n.to_string())
+    } else {
+        Expr::Var(name.trim_start_matches('$').to_string())
+    }
+}
+
+/// If `rest` begins with a loose word-logical operator, parse the word-logical
+/// tail (seeded by `seed`, a re-read of the just-assigned variable) and wrap
+/// `stmt` in a scopeless `SyntheticBlock([stmt, Expr(tail)])`. Otherwise returns
+/// `(rest, stmt)` unchanged.
+pub(crate) fn wrap_trailing_word_logical<'a>(
+    rest: &'a str,
+    stmt: Stmt,
+    seed: Expr,
+) -> PResult<'a, Stmt> {
+    let (r, _) = ws(rest)?;
+    if !starts_with_loose_word_logical(r) {
+        return Ok((rest, stmt));
+    }
+    let (r, tail) = word_logical_tail_pub(r, seed)?;
+    Ok((r, Stmt::SyntheticBlock(vec![stmt, Stmt::Expr(tail)])))
+}

--- a/t/word-logical-loosest-precedence.t
+++ b/t/word-logical-loosest-precedence.t
@@ -1,0 +1,95 @@
+use Test;
+
+# operators.rakudoc precedence table: the loose word-logicals
+# `and`/`or`/`xor`/`andthen`/`orelse`/`notandthen` are the LOOSEST infix
+# operators — looser than item assignment (`=`), the comma operator (`,`), and
+# the `return`/statement level. So `my $x = 1 and 2` is `(my $x = 1) and 2`,
+# and `return True and False` is `(return True) and False` (return fires first).
+#
+# They still compose INSIDE an expression / parentheses, where there is no
+# looser assignment/return to bind first: `say (1 and 2)` is `2`.
+
+plan 18;
+
+# return is tighter than `and`/`or` (return fires, the tail is dead code)
+{
+    sub f { return True and False }
+    is f(), True, 'return True and False -> (return True) and False';
+}
+{
+    sub g { return 1 and die "boom" }
+    is g(), 1, 'return 1 and die -> die never runs';
+}
+{
+    sub h { return 5 or die "boom" }
+    is h(), 5, 'return 5 or die -> die never runs';
+}
+
+# item assignment is tighter than `and`/`or`
+{
+    my $x = 1 and 2;
+    is $x, 1, 'my $x = 1 and 2 -> ($x = 1) and 2';
+}
+{
+    my $y = 5 or die "boom";
+    is $y, 5, 'my $y = 5 or die -> ($y = 5) or die';
+}
+{
+    my $z = 0 orelse 9;
+    is $z, 0, 'my $z = 0 orelse 9 -> ($z = 0) orelse 9';
+}
+{
+    my $t = 1;
+    $t = 2 and 3;
+    is $t, 2, '$t = 2 and 3 -> ($t = 2) and 3';
+}
+
+# comma is tighter than `and`
+{
+    my @a = 1, 2 and 3;
+    is-deeply @a, [1, 2], 'my @a = 1,2 and 3 -> (my @a = 1,2) and 3';
+}
+
+# ...but inside an expression / parens the word-logicals still compose
+is (1 and 2), 2, 'and inside parens still composes';
+is (1 or 2), 1, 'or inside parens still composes';
+is (Nil orelse 7), 7, 'orelse inside parens still composes';
+
+# a bare listop argument is already looser than the word-logicals
+{
+    my $called = 0;
+    sub note-it($v) { $called++; $v }
+    my $r = note-it(1) and note-it(2);
+    is $called, 2, 'listop-arg word-logical composes at expression level';
+}
+
+# compound assignment is also tighter than the word-logicals
+{
+    my $x = 1;
+    $x += 5 and 6;
+    is $x, 6, '$x += 5 and 6 -> ($x += 5) and 6';
+}
+{
+    my $x = 1;
+    $x += 5 or die "boom";
+    is $x, 6, '$x += 5 or die -> die never runs';
+}
+
+# a left-associative word-logical chain: only the first leaf is the RHS
+{
+    my $c = 1 and 2 and 0 or (my $ran = 1);
+    is $c, 1, 'my $c = 1 and 2 and 0 or ... -> $c is 1';
+    is $ran, 1, 'the trailing `or` branch ran ($c chain was falsy)';
+}
+
+# `return` value stops before the word-logical (mixed and/or tail is all dead)
+{
+    sub k { return 3 or die "boom" and die "boom2" }
+    is k(), 3, 'return 3 or die and die -> return 3, whole tail dead';
+}
+
+# array declaration: word-logical wraps the whole (comma) list assignment
+{
+    my @a = 1, 2, 3 and 4;
+    is-deeply @a, [1, 2, 3], 'my @a = 1,2,3 and 4 -> (my @a = 1,2,3) and 4';
+}


### PR DESCRIPTION
## Summary

The loose word-logical operators `and`/`or`/`andthen`/`orelse`/`notandthen` are Raku's **loosest** infix operators — looser than item assignment (`=`), compound assignment (`+=`, `div=`, ...), the comma, and `return`/`die`/`fail`. mutsu parsed them *tighter* than `=`/`return`, so their results were wrong:

| expression | before | after (raku) |
|---|---|---|
| `my $x = 1 and 2; say $x` | `2` | **`1`** — `(my $x = 1) and 2` |
| `$t = 2 and 3; say $t` | `3` | **`2`** — `($t = 2) and 3` |
| `my @a = 1, 2 and 3; say @a` | `[1 3]` | **`[1 2]`** |
| `$x += 5 or die; say $x` | `$x += (5 or die)` | **`($x += 5) or die`** |
| `sub f { return True and False }; say f` | `False` | **`True`** — `(return True) and False` |
| `sub g { return 1 and die }; say g` | dies | **`1`** |
| `die "x" and say "y"` | ran `say`, then died | **dies `"x"`** |

## Root cause

The core expression precedence chain already parsed these correctly (the word-logical layer sits above item assignment in `expr/precedence/logic.rs`). Only the **hand-rolled** statement-level assignment / declaration / `return` / `die` parsers were wrong: they parsed the RHS/argument with `expression()`, which greedily folds a trailing `... and ...` into the RHS.

## Fix

Those parsers now parse the RHS/argument **no-word-logical** — new `expression_no_word_logical`, `parse_comma_or_expr_no_word_logical`, and `parse_assign_expr_or_comma_no_word_logical`, all entering at the `list_infix_top` precedence tier just below the word-logicals — and re-attach a trailing `... and ...` at the correct (looser) precedence:

- **Assignment / declaration** wrap the value-producing statement in a scopeless `Stmt::SyntheticBlock` whose second statement re-reads the just-assigned variable and applies the word-logical tail (`word_logical_tail` continues the `or`/`and` chain from a seed; `wrap_trailing_word_logical` builds the block). Re-reading is exact for `=` assignment — the variable holds precisely the assigned value.
- **`return` / `die` / `fail`** transfer control before the tail would run, so they parse the argument no-word-logical and *discard* the unreachable tail.

Parsing no-word-logical (rather than rewriting the parsed tree afterwards) is what makes the parenthesis distinction work: `return (1 and 2)` is a complete term (`2`) consumed by the RHS parser, while `return 1 and 2` leaves `and 2` in the stream — both collapse to the same `Binary` in the AST, so a post-parse rewrite could not tell them apart.

## Tests

- Pin: `t/word-logical-loosest-precedence.t` (18 cases).
- `t/compound-assign-precedence.t` continues to pass (`||=`/`^^=` stay item-assignment; word forms `or=`/`and=`/`xor=` stay list-assignment).
- Full local `make test` green (2339 files / 22120 tests).

## Deferred (niche)

`take X and Y` — `take` is value-producing, so `(take X) and Y` must run `Y` with `take`'s *returned* value driving the short-circuit; the re-read-seed trick does not apply (no variable to re-read, and re-evaluating `X` would double side effects). Still parses as `take (X and Y)`. Recorded in PLAN §8.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)