### PR TITLE
fix: Iterator push-*/sink-all work on temporary receivers; push-exactly/push-at-least return the count

### DIFF
--- a/src/runtime/iterator_protocol.rs
+++ b/src/runtime/iterator_protocol.rs
@@ -1,0 +1,154 @@
+//! Shared stepping logic for the index-advancing `Iterator` protocol methods
+//! (`pull-one`, `push-exactly`, `push-at-least`, `push-all`, `push-until-lazy`,
+//! `sink-all`, `skip-one`, `skip-at-least`, `skip-at-least-pull-one`) over a
+//! built-in `Iterator` instance's materialized `items` prefix.
+//!
+//! Two dispatch paths consume this single implementation: the mutating path
+//! (`methods_mut_dispatch.rs`, variable receiver — writes the advanced `index`
+//! back into the instance) and the read-only path (`methods_call_dispatch.rs`,
+//! temporary receiver — the cursor is discarded, but the `push-*` family still
+//! mutates its array argument by identity).
+//!
+//! Spec: https://docs.raku.org/type/Iterator
+
+use crate::value::{Value, ValueView};
+
+pub(crate) struct IterProtoStep {
+    /// The method's return value.
+    pub ret: Value,
+    /// The advanced cursor position.
+    pub new_index: usize,
+    /// Range of `items` the `push-*` family appends to the first array argument.
+    pub append: Option<std::ops::Range<usize>>,
+}
+
+/// Compute the state transition for one Iterator-protocol method call.
+/// Returns `None` for methods outside this family (caller falls through to
+/// its generic dispatch).
+pub(crate) fn step(
+    method: &str,
+    items: &[Value],
+    index: usize,
+    args: &[Value],
+) -> Option<IterProtoStep> {
+    let len = items.len();
+    let end = || Value::str_from("IterationEnd");
+    let arg_int = |v: Option<&Value>, default: i64| -> usize {
+        v.map(crate::runtime::to_int).unwrap_or(default).max(0) as usize
+    };
+    let step = match method {
+        "pull-one" => {
+            if index < len {
+                IterProtoStep {
+                    ret: items[index].clone(),
+                    new_index: index + 1,
+                    append: None,
+                }
+            } else {
+                IterProtoStep {
+                    ret: end(),
+                    new_index: index,
+                    append: None,
+                }
+            }
+        }
+        // push-exactly(@target, n) / push-at-least(@target, n): append up to n
+        // elements; return the count delivered, or IterationEnd when the
+        // source ran dry before reaching n.
+        "push-exactly" | "push-at-least" => {
+            let want = arg_int(args.get(1), 1);
+            let take = len.saturating_sub(index).min(want);
+            IterProtoStep {
+                ret: if take < want {
+                    end()
+                } else {
+                    Value::int(take as i64)
+                },
+                new_index: index + take,
+                append: (take > 0).then(|| index..index + take),
+            }
+        }
+        "push-all" | "push-until-lazy" => IterProtoStep {
+            ret: end(),
+            new_index: len.max(index),
+            append: (index < len).then_some(index..len),
+        },
+        "sink-all" => IterProtoStep {
+            ret: end(),
+            new_index: len.max(index),
+            append: None,
+        },
+        "skip-one" => {
+            if index < len {
+                IterProtoStep {
+                    ret: Value::int(1),
+                    new_index: index + 1,
+                    append: None,
+                }
+            } else {
+                IterProtoStep {
+                    ret: Value::int(0),
+                    new_index: index,
+                    append: None,
+                }
+            }
+        }
+        "skip-at-least" => {
+            let want = arg_int(args.first(), 0);
+            let available = len.saturating_sub(index);
+            if available >= want {
+                IterProtoStep {
+                    ret: Value::int(1),
+                    new_index: index + want,
+                    append: None,
+                }
+            } else {
+                IterProtoStep {
+                    ret: Value::int(0),
+                    new_index: len,
+                    append: None,
+                }
+            }
+        }
+        "skip-at-least-pull-one" => {
+            let want = arg_int(args.first(), 0);
+            let available = len.saturating_sub(index);
+            if available >= want && index + want < len {
+                IterProtoStep {
+                    ret: items[index + want].clone(),
+                    new_index: index + want + 1,
+                    append: None,
+                }
+            } else {
+                IterProtoStep {
+                    ret: end(),
+                    new_index: len,
+                    append: None,
+                }
+            }
+        }
+        _ => return None,
+    };
+    Some(step)
+}
+
+impl crate::Interpreter {
+    /// Append `vals` to the array passed as the `push-*` family's first
+    /// argument, updating every binding that shares the array's identity.
+    pub(crate) fn iterator_append_to_array_arg(&mut self, args: &[Value], vals: &[Value]) {
+        if vals.is_empty() {
+            return;
+        }
+        if let Some(av) = args.first()
+            && let ValueView::Array(existing, arr_kind) = av.view()
+        {
+            let mut next = existing.to_vec();
+            next.extend(vals.iter().cloned());
+            let updated_array = Value::array_with_kind(
+                crate::gc::Gc::new(crate::value::ArrayData::new(next)),
+                arr_kind,
+            );
+            self.overwrite_array_bindings_by_identity(&existing, updated_array);
+        }
+    }
+}

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -969,24 +969,27 @@ impl Interpreter {
                         return Ok(Value::array(vec![Value::str(method_name)]));
                     }
                 }
-                // pull-one on a temporary iterator (no variable): read from items at current index.
-                // Since the iterator is a temporary, index is always 0 or whatever is in attrs.
-                "pull-one" if args.is_empty() => {
-                    let items = match attributes.as_map().get("items").map(|v| v.view()) {
-                        Some(ValueView::Array(values, ..)) => values.to_vec(),
-                        _ => Vec::new(),
-                    };
-                    let index = match attributes.as_map().get("index").map(|v| v.view()) {
-                        Some(ValueView::Int(i)) if i >= 0 => i as usize,
-                        _ => 0,
-                    };
-                    if index < items.len() {
-                        return Ok(items[index].clone());
-                    } else {
-                        return Ok(Value::str_from("IterationEnd"));
-                    }
-                }
                 _ => {}
+            }
+            // Index-advancing protocol methods on a temporary iterator (no
+            // variable receiver): the advanced cursor is discarded with the
+            // temporary, but the `push-*` family still appends to its array
+            // argument. Shares the single stepping implementation with the
+            // mutating (variable receiver) path.
+            let items = match attributes.as_map().get("items").map(|v| v.view()) {
+                Some(ValueView::Array(values, ..)) => values.to_vec(),
+                _ => Vec::new(),
+            };
+            let index = match attributes.as_map().get("index").map(|v| v.view()) {
+                Some(ValueView::Int(i)) if i >= 0 => i as usize,
+                _ => 0,
+            };
+            if let Some(step) = super::iterator_protocol::step(method, &items, index, &args) {
+                if let Some(range) = step.append {
+                    let vals = items[range].to_vec();
+                    self.iterator_append_to_array_arg(&args, &vals);
+                }
+                return Ok(step.ret);
             }
         }
         // DateTime/Date formatter rendering

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -2305,7 +2305,7 @@ impl Interpreter {
                     Some(ValueView::Array(values, ..)) => values.to_vec(),
                     _ => Vec::new(),
                 };
-                let mut index = match updated.get("index").map(Value::view) {
+                let index = match updated.get("index").map(Value::view) {
                     Some(ValueView::Int(i)) if i >= 0 => i as usize,
                     _ => 0,
                 };
@@ -2315,22 +2315,20 @@ impl Interpreter {
                 // on a stored iterator report the true (possibly infinite) count.
                 let known_count = updated.get("known_count").cloned();
 
-                let mut append_to_first_array_arg = |vals: &[Value]| {
-                    if vals.is_empty() {
-                        return;
+                // The index-advancing protocol family shares one stepping
+                // implementation with the read-only (temporary receiver) path.
+                if let Some(step) = super::iterator_protocol::step(method, &items, index, &args) {
+                    if let Some(range) = step.append {
+                        let vals = items[range].to_vec();
+                        self.iterator_append_to_array_arg(&args, &vals);
                     }
-                    if let Some(av) = args.first()
-                        && let ValueView::Array(existing, arr_kind) = av.view()
-                    {
-                        let mut next = existing.to_vec();
-                        next.extend(vals.iter().cloned());
-                        let updated_array = Value::array_with_kind(
-                            crate::gc::Gc::new(crate::value::ArrayData::new(next)),
-                            arr_kind,
-                        );
-                        self.overwrite_array_bindings_by_identity(&existing, updated_array);
-                    }
-                };
+                    updated.insert("index".to_string(), Value::int(step.new_index as i64));
+                    self.env.insert(
+                        target_var.to_string(),
+                        Value::write_back_sharing(&attributes, class_name, updated, target_id),
+                    );
+                    return Ok(step.ret);
+                }
 
                 let ret = match method {
                     "count-only" => known_count
@@ -2340,76 +2338,6 @@ impl Interpreter {
                         Some(c) => Value::truth(c.to_f64() > 0.0),
                         None => Value::truth(index < len),
                     },
-                    "pull-one" => {
-                        if index < len {
-                            let out = items[index].clone();
-                            index += 1;
-                            out
-                        } else {
-                            Value::str_from("IterationEnd")
-                        }
-                    }
-                    "push-exactly" | "push-at-least" => {
-                        let want = args.get(1).map(super::to_int).unwrap_or(1).max(0) as usize;
-                        let available = len.saturating_sub(index);
-                        let take = available.min(want);
-                        if take > 0 {
-                            append_to_first_array_arg(&items[index..index + take]);
-                            index += take;
-                        }
-                        if index >= len {
-                            Value::str_from("IterationEnd")
-                        } else {
-                            Value::NIL
-                        }
-                    }
-                    "push-all" | "push-until-lazy" => {
-                        if index < len {
-                            append_to_first_array_arg(&items[index..]);
-                            index = len;
-                        }
-                        Value::str_from("IterationEnd")
-                    }
-                    "sink-all" => {
-                        index = len;
-                        Value::str_from("IterationEnd")
-                    }
-                    "skip-one" => {
-                        if index < len {
-                            index += 1;
-                            Value::int(1)
-                        } else {
-                            Value::int(0)
-                        }
-                    }
-                    "skip-at-least" => {
-                        let want = args.first().map(super::to_int).unwrap_or(0).max(0) as usize;
-                        let available = len.saturating_sub(index);
-                        if available >= want {
-                            index += want;
-                            Value::int(1)
-                        } else {
-                            index = len;
-                            Value::int(0)
-                        }
-                    }
-                    "skip-at-least-pull-one" => {
-                        let want = args.first().map(super::to_int).unwrap_or(0).max(0) as usize;
-                        let available = len.saturating_sub(index);
-                        if available >= want {
-                            index += want;
-                            if index < len {
-                                let out = items[index].clone();
-                                index += 1;
-                                out
-                            } else {
-                                Value::str_from("IterationEnd")
-                            }
-                        } else {
-                            index = len;
-                            Value::str_from("IterationEnd")
-                        }
-                    }
                     "can" => {
                         let method_name = args
                             .first()

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -199,6 +199,7 @@ mod io_pod_config;
 mod io_pod_entries;
 mod io_pod_table;
 mod io_sysinfo;
+mod iterator_protocol;
 pub(crate) mod json;
 mod lock_reentry;
 mod main_args;

--- a/t/iterator-push-methods.t
+++ b/t/iterator-push-methods.t
@@ -1,0 +1,69 @@
+use v6;
+use Test;
+
+# Iterator protocol: push-exactly / push-at-least / push-all / sink-all
+# must work on a chained (temporary) receiver, and the push-* family
+# returns the delivered count (IterationEnd when the source ran dry first).
+# Spec: raku-doc/doc/Type/Iterator.rakudoc
+
+plan 16;
+
+# --- chained temporary receivers (doc examples) ---
+{
+    my @array;
+    is (1 .. Inf).iterator.push-exactly(@array, 3), 3,
+        'push-exactly on a temporary iterator returns the count';
+    is-deeply @array, [1, 2, 3], 'push-exactly appended the elements';
+}
+
+{
+    my @array;
+    is (1 .. Inf).iterator.push-at-least(@array, 10), 10,
+        'push-at-least on a temporary iterator returns the count';
+    is @array.elems, 10, 'push-at-least appended at least n elements';
+}
+
+{
+    my @array;
+    is (1 .. 1000).iterator.push-all(@array).gist, 'IterationEnd',
+        'push-all on a temporary iterator returns IterationEnd';
+    is @array.elems, 1000, 'push-all appended every element';
+}
+
+is (1 .. 1000).iterator.sink-all.gist, 'IterationEnd',
+    'sink-all on a temporary iterator returns IterationEnd';
+
+# --- variable receivers: return values and cursor advancement ---
+{
+    my @a;
+    my $it = (1 .. 10).iterator;
+    is $it.push-exactly(@a, 3), 3, 'push-exactly returns the count, not Nil';
+    is $it.push-at-least(@a, 4), 4, 'push-at-least returns the count';
+    is-deeply @a, [1, 2, 3, 4, 5, 6, 7], 'cursor advances across push calls';
+}
+
+{
+    my @a;
+    my $it = (1 .. 2).iterator;
+    is $it.push-exactly(@a, 5).gist, 'IterationEnd',
+        'push-exactly returns IterationEnd when the source runs dry first';
+    is-deeply @a, [1, 2], 'the available elements were still appended';
+}
+
+{
+    my @a;
+    my $it = (1 .. 3).iterator;
+    is $it.push-exactly(@a, 3), 3,
+        'push-exactly returns the count when it drains the source exactly';
+}
+
+# --- regression: the rest of the index-advancing family ---
+{
+    my $it = (1 .. 3).iterator;
+    is $it.pull-one, 1, 'pull-one first';
+    $it.pull-one;
+    is $it.pull-one, 3, 'pull-one third';
+    is $it.pull-one.gist, 'IterationEnd', 'pull-one exhausted';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary
- The index-advancing Iterator protocol methods (`push-exactly`, `push-at-least`, `push-all`, `push-until-lazy`, `sink-all`, `skip-*`) were only reachable via the mutating (variable receiver) dispatch path, so a chained call like `(1..Inf).iterator.push-exactly(@array, 3)` died with *No such method*. They now also work on temporary receivers.
- `push-exactly` / `push-at-least` returned `Nil` (or `IterationEnd` on an exact drain) where Rakudo returns the delivered count. They now return the count, with `IterationEnd` only when the source runs dry before reaching n (verified against reference raku).
- The stepping logic is extracted into a single shared implementation (`src/runtime/iterator_protocol.rs`) used by both paths (1 operation = 1 implementation); the old temporary-receiver `pull-one` special case is subsumed by it.

Found by the doc-diff sweep (`Type/Iterator.rakudoc` findings [6]-[9], `docs/doc-diff-backlog.md` lazy-list cluster).

## Test plan
- New pin: `t/iterator-push-methods.t` (16 assertions, all raku-verified)
- `make test` locally: 2341 files, all pass
- Whitelisted iterator roast files (`S02-types/*-iterator.t`, `S07-iterators/range-iterator.t`, `S32-hash/iterator.t`, `S32-list/iterator.t`): pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)