### PR TITLE
fix: QuantHash slice assignment applies membership/count/weight semantics

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -113,6 +113,18 @@ doc) are version skew, not mutsu bugs — lowest priority.
   hash-initializer `ValuePair` arm through it (`build_hash_from_items`,
   `coerce_to_hash`, `MakeHashFromPairs`), covering `%( )`, plain list assignment,
   and single-pair assignment. Pin: `t/hash-junction-key.t`.
+- `SetHash.rakudoc` [1]/[2] — a QuantHash (SetHash/BagHash/MixHash) **slice**
+  assignment (`$sh<a b> = False, True`) wrongly replaced the container with a
+  fresh plain Hash of the raw rvalues, dropping every untouched member and the
+  membership/count/weight semantics (mutsu gave `(apple kiwi)` for
+  `<peach apple orange>.SetHash; $_<apple kiwi> = False, True` instead of
+  `(kiwi orange peach)`). The named-slice-assign path only handled Array/Hash
+  containers; added a mutable-Set/Bag/Mix arm that mirrors the single-key store
+  (per-key membership/count/weight, Nil-pads a short rvalue rather than cycling,
+  early-returns the per-key result list — Set → Bool, Bag → count, Mix → weight)
+  and throws RO for an immutable Set/Bag/Mix. This also fixed the doc's
+  `$fruits<apple banana kiwi>»++` hyper-increment over a SetHash slice. Pin:
+  `t/quanthash-slice-assign.t`.
 - `operators.rakudoc` [25]/[26] — the left-exclusive sequence operators
   (`^...` / `^...^`) failed to parse as an unparenthesized listop argument
   (`say 1 ^... 4`). `build_sequence_from_seeds` recognized `...`/`...^`/`…`/`…^`

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -1207,6 +1207,119 @@ impl Interpreter {
                 if vals.is_empty() {
                     vals.push(Value::NIL);
                 }
+                // A mutable QuantHash (SetHash/BagHash/MixHash) slice assignment
+                // applies membership/count/weight semantics per key
+                // (`$sh<a b> = False, True` removes `a`, adds `b`), NOT a plain
+                // hash-slice store — which would replace the container with a
+                // fresh Hash of the raw rvalues and drop every untouched member.
+                // Mirror the single-key store arms, distributing `vals` across
+                // `keys`, then early-return the per-key result list (Set → Bool,
+                // Bag/Mix → the assigned value).
+                {
+                    let (is_set, is_bag, is_mix, is_mut) =
+                        match self.env().get(&var_name).map(Value::view) {
+                            Some(ValueView::Set(_, m)) => (true, false, false, m),
+                            Some(ValueView::Bag(_, m)) => (false, true, false, m),
+                            Some(ValueView::Mix(_, m)) => (false, false, true, m),
+                            _ => (false, false, false, false),
+                        };
+                    if is_set || is_bag || is_mix {
+                        let what = if is_set {
+                            "Set"
+                        } else if is_bag {
+                            "Bag"
+                        } else {
+                            "Mix"
+                        };
+                        if !is_mut {
+                            return Err(RuntimeError::assignment_ro(Some(what)));
+                        }
+                        // Raku pads a short rvalue with Nil (`$sh<a b c> = True`
+                        // sets only `a`), it does NOT cycle the value list. A
+                        // Set slot's expression value is its Bool membership; a
+                        // Bag/Mix slot's is its assigned count/weight (Nil → 0,
+                        // with a "Use of Nil in numeric context" warning in raku).
+                        let mut results: Vec<Value> = Vec::with_capacity(keys.len());
+                        for (i, key_val) in keys.iter().enumerate() {
+                            let v = vals.get(i).cloned().unwrap_or(Value::NIL);
+                            let str_key = key_val.to_string_value();
+                            if is_bag {
+                                let count = Self::bag_assignment_count(&v)?;
+                                if let Some(container) = self.env_mut().get_mut(&var_name) {
+                                    container.with_bag_mut(|bag, _| {
+                                        let b = crate::value::gc_data_mut(bag);
+                                        if count == num_bigint::BigInt::from(0) {
+                                            b.remove(&str_key);
+                                            Self::forget_quanthash_object_key(
+                                                &mut b.original_keys,
+                                                &str_key,
+                                            );
+                                        } else {
+                                            b.insert(str_key.clone(), count.clone());
+                                            Self::record_quanthash_object_key(
+                                                &mut b.original_keys,
+                                                &str_key,
+                                                key_val,
+                                            );
+                                        }
+                                    });
+                                }
+                                results.push(Value::bigint(count));
+                            } else if is_mix {
+                                let weight = Self::mix_assignment_weight(&v)?;
+                                if let Some(container) = self.env_mut().get_mut(&var_name) {
+                                    container.with_mix_mut(|mix, _| {
+                                        let m = crate::value::gc_data_mut(mix);
+                                        if weight == 0.0 {
+                                            m.remove(&str_key);
+                                            Self::forget_quanthash_object_key(
+                                                &mut m.original_keys,
+                                                &str_key,
+                                            );
+                                        } else {
+                                            m.insert(str_key.clone(), weight);
+                                            Self::record_quanthash_object_key(
+                                                &mut m.original_keys,
+                                                &str_key,
+                                                key_val,
+                                            );
+                                        }
+                                    });
+                                }
+                                results.push(crate::value::mix_weight_to_value(weight));
+                            } else {
+                                let present = v.truthy();
+                                if let Some(container) = self.env_mut().get_mut(&var_name) {
+                                    container.with_set_mut(|set, _| {
+                                        let s = crate::value::gc_data_mut(set);
+                                        if present {
+                                            s.insert(str_key.clone());
+                                            Self::record_quanthash_object_key(
+                                                &mut s.original_keys,
+                                                &str_key,
+                                                key_val,
+                                            );
+                                        } else {
+                                            s.remove(&str_key);
+                                            Self::forget_quanthash_object_key(
+                                                &mut s.original_keys,
+                                                &str_key,
+                                            );
+                                        }
+                                    });
+                                }
+                                results.push(Value::truth(present));
+                            }
+                        }
+                        if let Some(slot) = self.resolve_local_slot(code, eff_slot, &var_name)
+                            && let Some(updated) = self.env().get(&var_name).cloned()
+                        {
+                            self.locals[slot] = updated;
+                        }
+                        self.stack.push(Value::array(results));
+                        return Ok(());
+                    }
+                }
                 // Check value type constraint for hash slice assignment
                 if let Some(constraint) = loan_env!(self, var_type_constraint(&var_name))
                     && !self.is_container_subclass(&constraint)

--- a/t/quanthash-slice-assign.t
+++ b/t/quanthash-slice-assign.t
@@ -1,0 +1,76 @@
+use v6;
+use Test;
+
+plan 20;
+
+# SetHash slice assignment applies membership (Bool) semantics per key, keeps
+# untouched members, and does NOT replace the container with a plain Hash.
+{
+    my $fruits = <peach apple orange>.SetHash;
+    my @r = ($fruits<apple kiwi> = False, True);
+    is @r.raku, '[Bool::False, Bool::True]', 'SetHash slice assign returns per-key Bool';
+    is $fruits.keys.sort.raku, '("kiwi", "orange", "peach").Seq',
+        'SetHash slice assign removes False keys, adds True keys, keeps the rest';
+}
+
+# Short rvalue pads with Nil (no cycling): only the first key is set True.
+{
+    my $s = SetHash.new;
+    my @r = ($s<a b c> = True);
+    is @r.raku, '[Bool::True, Bool::False, Bool::False]', 'SetHash slice pads with Nil (Bool::False)';
+    is $s.keys.sort.raku, '("a",).Seq', 'SetHash slice: only first key set';
+}
+
+# BagHash slice assignment applies count semantics per key.
+{
+    my $b = BagHash.new;
+    my @r = ($b<a x> = 3, 2);
+    is @r.raku, '[3, 2]', 'BagHash slice assign returns per-key counts';
+    is $b<a>, 3, 'BagHash slice: a => 3';
+    is $b<x>, 2, 'BagHash slice: x => 2';
+}
+{
+    my $b = <a b c>.BagHash;
+    my @r = ($b<a x> = 0, 2);
+    is @r.raku, '[0, 2]', 'BagHash slice with 0 removes, keeps expr value 0';
+    is $b.keys.sort.raku, '("b", "c", "x").Seq', 'BagHash slice: a removed (0), x added';
+}
+{
+    my $b = BagHash.new;
+    my @r = ($b<x y z> = 5);
+    is @r.raku, '[5, 0, 0]', 'BagHash slice pads short rvalue with 0';
+    is $b.keys.sort.raku, '("x",).Seq', 'BagHash slice: only x set (padded 0 => absent)';
+}
+
+# MixHash slice assignment applies weight semantics per key.
+{
+    my $m = MixHash.new;
+    my @r = ($m<a x> = 0.5, 2);
+    is @r.raku, '[0.5, 2]', 'MixHash slice assign returns per-key weights';
+    is $m<a>, 0.5, 'MixHash slice: a => 0.5';
+    is $m<x>, 2, 'MixHash slice: x => 2';
+}
+{
+    my $m = MixHash.new;
+    my @r = ($m<a b> = 1.5, -2);
+    is @r.raku, '[1.5, -2]', 'MixHash slice keeps negative weights';
+    is $m<b>, -2, 'MixHash slice: negative weight stored';
+}
+
+# Hyper-increment/decrement over a QuantHash slice.
+{
+    my SetHash $fruits .= new;
+    $fruits<apple banana kiwi>»++;
+    $fruits<banana kiwi>»--;
+    is $fruits.keys.sort.raku, '("apple",).Seq', 'SetHash hyper ++/-- over a slice';
+}
+
+# Immutable Set/Bag/Mix slice assignment throws (RO), not a silent replace.
+{
+    my $s = <a b>.Set;
+    dies-ok { $s<a c> = True, True }, 'immutable Set slice assign dies';
+    my $b = <a b>.Bag;
+    dies-ok { $b<a c> = 1, 1 }, 'immutable Bag slice assign dies';
+    my $m = <a b>.Mix;
+    dies-ok { $m<a c> = 1, 1 }, 'immutable Mix slice assign dies';
+}


### PR DESCRIPTION
## Summary

A named slice assignment to a mutable QuantHash — `$sh<a b> = False, True` on a
`SetHash` (and the `BagHash`/`MixHash` equivalents) — fell through the
Array/Hash-only slice-assign path and was handled as a plain hash-slice store:
the container was **replaced with a fresh Hash** of the raw rvalues, dropping
every untouched member and the Set/Bag/Mix element semantics.

```raku
my $fruits = <peach apple orange>.SetHash;
$fruits<apple kiwi> = False, True;
say $fruits.keys.sort;   # was (apple kiwi), now (kiwi orange peach)
```

## Fix

Add a mutable-Set/Bag/Mix arm to the named-slice-assign handler
(`exec_index_assign_expr_named_op_inner`) that mirrors the existing single-key
store arms:

- **Set** — truthiness controls membership; per-key result is a `Bool`.
- **Bag** — `bag_assignment_count`; `0` removes; per-key result is the count.
- **Mix** — `mix_assignment_weight`; `0` removes; per-key result is the weight.

A short rvalue is **Nil-padded** (raku does not cycle a value list across a
slice), and an **immutable** `Set`/`Bag`/`Mix` throws `X::Assignment::RO`
instead of silently replacing itself. This also fixes
`$fruits<apple banana kiwi>»++` (SetHash hyper-increment over a slice), which
previously died with a spurious `Type check failed … expected SetHash but got
Int`.

Resolves the `SetHash.rakudoc` [1]/[2] doc-diff-backlog findings.

## Testing

- New pin: `t/quanthash-slice-assign.t` (20 subtests: Set/Bag/Mix slice assign,
  Nil-padding, expr result, hyper ++/--, immutable RO).
- `make test` — all 22145 tests pass.
- Verified no regressions in the QuantHash/set/slice roast + local suites
  (`roast/S02-types/{set,sethash,bag,baghash,mix,mixhash}.t`,
  `roast/S09-subscript/slice.t`, `roast/S32-hash/{slice,adverbs}.t`, and the
  `t/quanthash-*`/`t/*slice*`/`t/hyper-*` local tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)