### PR TITLE
fix: lazy sequences survive @-array assignment; gather/start do-statement parse fixes (L2b step 6)

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -195,6 +195,12 @@ pub(super) fn dispatch(
         "clone" => {
             match target.view() {
                 ValueView::Package(_) | ValueView::Nil => Some(Some(Ok(target.clone()))),
+                // A lazy array (`my @a = 1, 2, 4 ... Inf`) clones to an
+                // independent lazy list: separate cache/spec state, same
+                // deterministic generator, so both keep reifying on demand.
+                ValueView::LazyList(ll) => Some(Some(Ok(Value::lazy_list(crate::gc::Gc::new(
+                    (**ll).clone(),
+                ))))),
                 // Clone the whole `ArrayData`, not just its elements, so
                 // per-slot metadata (`initialized` deletion holes, `default`,
                 // `shape`, element type) survives the copy — e.g.

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -66,6 +66,12 @@ pub(crate) fn without_pending_prefix<T>(f: impl FnOnce() -> T) -> T {
 /// parse, leaving the trailing `,4,5` to be misread as siblings by whatever
 /// list the prefix expression itself sits in).
 fn parse_prefix_listop_operand(input: &str) -> PResult<'_, Expr> {
+    // The sequence operators are looser than comma, so `lazy 1, 2 ... 100`
+    // takes the WHOLE sequence as the operand (`lazy ((1, 2) ... 100)`), not
+    // just the comma list of seeds.
+    if let Some(result) = crate::parser::primary::try_parse_sequence_arg_list(input) {
+        return result;
+    }
     let (rest, first) = expression_no_sequence(input)?;
     let (r, _) = ws(rest)?;
     if !r.starts_with(',') || r.starts_with(",,") {

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -932,8 +932,21 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                 return Ok((r, Expr::Gather(body)));
             }
             // gather <statement> (e.g. `gather for ^5 { ... }`)
-            if let Ok((r, stmt)) = crate::parser::stmt::statement_pub(r) {
-                return Ok((r, Expr::Gather(vec![stmt])));
+            if let Ok((r_after, stmt)) = crate::parser::stmt::statement_pub(r) {
+                // The statement parse consumes the terminating `;`, but the
+                // gather expression must stop before it — otherwise the rest
+                // of the line (`my @a = gather do {…}; say "x"`) is misread
+                // as an infix on the gather.
+                let r_after = restore_do_stmt_terminator(r, r_after);
+                // `gather do { ... }` is `gather { ... }`: the do-block is the
+                // whole body, so inline its statements. This also lets the
+                // lazy-gather coroutine suspend at each take (it can only
+                // suspend at the body's top level, not inside a nested
+                // DoBlockExpr frame).
+                if let crate::ast::Stmt::Expr(Expr::DoBlock { body, label: None }) = &stmt {
+                    return Ok((r_after, Expr::Gather(body.clone())));
+                }
+                return Ok((r_after, Expr::Gather(vec![stmt])));
             }
         }
         "die" | "fail" => {
@@ -1026,9 +1039,11 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                 ));
             }
             // start <statement> — wrap the next statement in a block
-            if let Ok((r, stmt)) = crate::parser::stmt::statement_pub(r) {
+            if let Ok((r_after, stmt)) = crate::parser::stmt::statement_pub(r) {
+                // Give back a consumed statement terminator (see the gather arm).
+                let r_after = restore_do_stmt_terminator(r, r_after);
                 return Ok((
-                    r,
+                    r_after,
                     Expr::Call {
                         name: Symbol::intern("start"),
                         args: vec![make_anon_sub(vec![stmt])],

--- a/src/value/value_lazy.rs
+++ b/src/value/value_lazy.rs
@@ -192,6 +192,25 @@ impl LazyList {
             || self.cat_pull.is_some()
     }
 
+    /// Whether `my @a = <this list>` keeps the list as a reify-on-demand lazy
+    /// array (L2b step 6, docs/lazy-arrays.md) instead of eagerly
+    /// materializing. An explicit `lazy` marker always preserves; otherwise
+    /// only a *deterministic* unreifiable source does — an infinite
+    /// arithmetic/geometric sequence spec, or a map/grep pipe over an
+    /// infinite source. A pipe bottoming out in a finite source (a plain
+    /// gather) and a finite cat-pull materialize eagerly, matching raku.
+    ///
+    /// TODO: closure_seq (`1, {rand} ... *`) and scan_spec stay on the old
+    /// capped-Array path: S32-array/create.t "partially-reified" requires
+    /// `@a.clone` to SHARE the reifier (clone and original see the same
+    /// `{rand}` values), which needs a shared element-cell store —
+    /// container-repr territory (ADR-0001 layer 3a), not a per-site fix.
+    pub(crate) fn preserve_lazy_on_array_assign(&self) -> bool {
+        self.is_lazy_marked()
+            || self.sequence_spec.is_some()
+            || (self.lazy_pipe.is_some() && !self.pipe_bottoms_out_finite())
+    }
+
     /// Whether this list carries the `lazy` prefix marker (set by the `lazy`
     /// statement prefix / `.lazy` method).
     fn is_lazy_marked(&self) -> bool {

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -429,7 +429,6 @@ impl Interpreter {
         }
     }
 
-    pub(crate) const LAZY_ASSIGN_PRESERVE_MARKER: &str = "__mutsu_preserve_lazy_on_array_assign";
     pub(crate) const MAX_ASSIGN_SLICE_EXPAND: i64 = 100_000;
 
     pub(crate) fn assignment_rhs_values(

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -140,15 +140,15 @@ impl Interpreter {
             self.coerce_hash_var_value(name, raw_val)?
         } else if name.starts_with('@') {
             let mut assigned = if let ValueView::LazyList(list) = raw_val.view() {
-                match list
-                    .env
-                    .get(Self::LAZY_ASSIGN_PRESERVE_MARKER)
-                    .map(Value::view)
-                {
-                    Some(ValueView::Bool(true)) => Value::lazy_list(list.clone()),
-                    _ => Value::real_array(crate::runtime::utils::nil_elems_to_any(
+                // Mirror the SetLocal `@`-assign arm: an unreifiable lazy list
+                // survives assignment as a reify-on-demand LazyList in array
+                // context (L2b step 6 — docs/lazy-arrays.md).
+                if list.preserve_lazy_on_array_assign() {
+                    Value::lazy_list(crate::gc::Gc::new(list.with_array_context()))
+                } else {
+                    Value::real_array(crate::runtime::utils::nil_elems_to_any(
                         self.force_lazy_list_vm(&list)?,
-                    )),
+                    ))
                 }
             } else {
                 runtime::coerce_to_array(raw_val)

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -891,19 +891,20 @@ impl Interpreter {
             } else {
                 match raw_popped.view() {
                     ValueView::LazyList(list) => {
-                        match list
-                            .env
-                            .get(Self::LAZY_ASSIGN_PRESERVE_MARKER)
-                            .map(Value::view)
-                        {
-                            // Preserved into an `@` array: keep it lazy but tag
-                            // array context so gist/`.WHAT` render `[...]`/`Array`.
-                            Some(ValueView::Bool(true)) => {
-                                Value::lazy_list(crate::gc::Gc::new(list.with_array_context()))
-                            }
-                            _ => Value::real_array(crate::runtime::utils::nil_elems_to_any(
+                        // An unreifiable lazy list (infinite spec / infinite
+                        // pipe / `lazy`-marked) survives `@`-assign as a
+                        // reify-on-demand LazyList tagged with array context
+                        // so gist/`.WHAT` render `[...]`/`Array` (L2b step 6 —
+                        // docs/lazy-arrays.md; mutations reify a prefix via
+                        // `reify_lazy_array_slot`). A plain finite gather (or
+                        // a pipe over one) is `.is-lazy` False and
+                        // materializes eagerly.
+                        if list.preserve_lazy_on_array_assign() {
+                            Value::lazy_list(crate::gc::Gc::new(list.with_array_context()))
+                        } else {
+                            Value::real_array(crate::runtime::utils::nil_elems_to_any(
                                 self.force_lazy_list_vm(&list)?,
-                            )),
+                            ))
                         }
                     }
                     ValueView::LazyIoLines { .. } => {

--- a/t/gather-do-stmt-terminator.t
+++ b/t/gather-do-stmt-terminator.t
@@ -1,0 +1,28 @@
+use v6;
+use Test;
+
+# `gather <statement>` / `start <statement>` parse their operand with the
+# statement parser, which consumes the terminating `;`. The expression must
+# give the terminator back — otherwise the rest of the line was misread as
+# an infix on the gather (`my @a = gather do {…}; say "x"` parsed `say` as
+# an infix function and the take'd values leaked to stdout).
+# Found by the doc-diff sweep (Type/Seq.rakudoc [1]).
+
+plan 6;
+
+my @a = gather do { take "one" }; my $after = "ran";
+is-deeply @a, ["one"], 'gather do {...} collects its take';
+is $after, "ran", 'the statement after the ; runs as its own statement';
+
+my @b = lazy gather do { take 1; take 2 }; my @got;
+@got.push($_) for @b;
+is-deeply @got, [1, 2], 'lazy gather do iterates via for';
+
+my @c = gather for ^3 { take $_ * 2 }; my $tail = "ok";
+is-deeply @c, [0, 2, 4], 'gather for still works';
+is $tail, "ok", 'trailing statement intact after gather for';
+
+my $p = start do { 42 }; my $r = await $p;
+is $r, 42, 'start do {...} keeps the statement after the ;';
+
+done-testing;

--- a/t/lazy-array-assign-preserve.t
+++ b/t/lazy-array-assign-preserve.t
@@ -1,0 +1,55 @@
+use v6;
+use Test;
+
+# L2b step 6 (docs/lazy-arrays.md): a genuinely-lazy list assigned to an
+# `@` array survives as a reify-on-demand lazy array, matching raku.
+# Found by the doc-diff sweep (Language/list.rakudoc [7], [1]).
+
+plan 12;
+
+# Infinite sequence assigned directly.
+{
+    my @a = 1, 2, 4, 8 ... Inf;
+    ok @a.is-lazy, 'infinite ... sequence array is lazy';
+    is @a[3], 8, 'indexing reifies on demand';
+    is-deeply @a[10..12], (1024, 2048, 4096), 'slice past the seed reifies';
+    is @a.gist, '[...]', 'gist renders the lazy placeholder';
+}
+
+# Infinite sequence through a bound scalar.
+{
+    my $l := 1, 2, 4, 8 ... Inf;
+    my @lazy-array = $l;
+    ok @lazy-array.is-lazy, 'sequence via bound scalar stays lazy';
+    is-deeply @lazy-array[10..15], (1024, 2048, 4096, 8192, 16384, 32768),
+        'doc example slice matches';
+}
+
+# The `lazy` prefix takes the whole sequence as its operand (looser than
+# comma), so the marker survives onto the sequence itself.
+{
+    my $s = lazy 1, 11, 121 ... 10**6;
+    ok $s.is-lazy, 'lazy prefix on a ... sequence marks the sequence';
+    my @lazy-array = lazy 1, 11, 121 ... 10**6;
+    ok @lazy-array.is-lazy, 'and it survives array assignment';
+    is @lazy-array[3], 1331, 'elements still reify';
+}
+
+# Mutation semantics: partial reify and X::Cannot::Lazy.
+{
+    my @a = 1, 2, 4 ... Inf;
+    @a[2] = 99;
+    is-deeply @a[^4], (1, 2, 99, 8), 'element assign reifies a prefix, tail stays live';
+}
+{
+    my @a = 1, 2, 4 ... Inf;
+    throws-like { @a.push(9) }, X::Cannot::Lazy, 'push on a lazy array throws';
+}
+
+# A plain finite gather still materializes eagerly (is-lazy False).
+{
+    my @a = gather { take 1; take 2 };
+    nok @a.is-lazy, 'plain gather array is not lazy';
+}
+
+done-testing;

--- a/t/sequence.t
+++ b/t/sequence.t
@@ -42,8 +42,11 @@ is (1, 0 ... *).[^5].join(', '), '1, 0, -1, -2, -3', 'infinite decreasing';
 is (1, 3, 9 ... *).[^5].join(', '), '1, 3, 9, 27, 81', 'infinite geometric';
 is (81, 27, 9 ... *).[^5].join(', '), '81, 27, 9, 3, 1', 'infinite decreasing geometric';
 is (1, { $_ + 2 } ... *).[^5].join(', '), '1, 3, 5, 7, 9', 'infinite closure';
+# An infinite sequence assigned to an @ array now stays lazy (raku
+# semantics), so pushing to a copy of it dies; slice an eager prefix
+# instead to exercise the slurped multi-seed call.
 my @fib = 0, 1, *+* ... *;
-my @fib-seed = @fib;
+my @fib-seed = @fib[^7];
 @fib-seed.push(8);
 is infix:<...>(|@fib-seed).join(', '), '0, 1, 1, 2, 3, 5, 8', 'slurped multi-seed LHS from array';
 


### PR DESCRIPTION
## Summary
Four related fixes to the lazy-list cluster from `docs/doc-diff-backlog.md` (all raku-verified):

1. **`my @a = 1, 2, 4 ... Inf` stays lazy** (L2b step 6, `docs/lazy-arrays.md`): `.is-lazy` is True, gist renders `[...]`, indexing/slicing reifies on demand, element assignment partial-reifies (`@a[2] = 99; @a[^4]` → `(1 2 99 8)`), and `push` throws `X::Cannot::Lazy` — previously the assignment force-capped the sequence into a 100k-element real Array. Scoped to deterministic sources via `LazyList::preserve_lazy_on_array_assign` (sequence_spec, infinite pipes, `lazy`-marked); `closure_seq`/`scan_spec` stay on the capped path because `S32-array/create.t` requires `.clone` to *share* the reifier for `{rand}` sequences, which needs the ADR-0001 container-repr element-cell store (TODO left in `value_lazy.rs`).
2. **`.clone` on a lazy array** returns an independent lazy list (was `No such method 'clone'`).
3. **`lazy` prefix precedence**: `lazy 1, 11, 121 ... 10**100` parsed as `(lazy (1,11,121)) ... 10**100`, losing the lazy marker (`.is-lazy` False, eager materialization with float degradation). The prefix operand parser now detects a top-level sequence operator like the listop-argument paths do.
4. **`gather`/`start` statement-operand terminator**: `my @a = gather do {…}; say "x"` swallowed the `;` (the statement parser consumes it), so `say "x"` was misparsed as an infix on the gather — the take'd values leaked to stdout. Both arms now restore the terminator like the `do <stmt>` arm; `gather do { … }` additionally inlines the do-block as the gather body (same semantics as `gather { … }`) so the lazy coroutine can suspend at each take.

`t/sequence.t`'s "slurped multi-seed LHS" subtest pushed into a copy of the (previously capped) infinite fib array — that now dies exactly as in raku, so it builds its seeds from an eager `@fib[^7]` slice.

## Test plan
- New pins: `t/lazy-array-assign-preserve.t` (12), `t/gather-do-stmt-terminator.t` (6)
- `make test`: 2342 files, all pass
- L2 regression watch-list (docs/lazy-arrays.md): `S32-array/create.t`, `delete-adverb*.t`, `S09-subscript/slice.t`, `S32-list/{flat,grep,map,first,head,tail,join}.t`, `S03-sequence/misc.t`, `S07-iterators/range-iterator.t`, `S06-signature/slurpy-params.t`, `S04-statements/{gather,lazy}.t`, `S03-operators/eqv.t` — 17 files / 1104 tests, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)