### PR TITLE
fix: .flat respects itemization depth — Array elements stay single and itemized

### DIFF
--- a/src/builtins/functions/flat.rs
+++ b/src/builtins/functions/flat.rs
@@ -67,23 +67,49 @@ pub(crate) fn deitemize_flat_operand(v: &Value) -> Value {
 
 pub(crate) fn flat_val(v: &Value, out: &mut Vec<Value>, flatten_arrays: bool) {
     match v.view() {
-        // Lists, Seqs, and Slips are always flattened; their children
-        // inherit flatten_arrays=true since Lists don't itemize.
-        ValueView::Array(items, ArrayKind::List) => {
+        // Slips always flatten — slipping is their whole purpose.
+        ValueView::Slip(items) => {
             for item in items.iter() {
                 flat_val(item, out, true);
             }
         }
-        ValueView::Seq(items) | ValueView::Slip(items) => {
-            for item in items.iter() {
-                flat_val(item, out, true);
+        // Lists and Seqs flatten in list context; as the element of an
+        // itemizing container (a `[...]` Array element lives in a Scalar
+        // container) they stay single and itemized: `(1, @a, 5).flat` with
+        // `my @a = 2, (3, 4)` yields `(1 2 (3 4) 5)`, and
+        // `[(1, 2), $(3, 4)].flat.raku` is `($(1, 2), $(3, 4)).Seq`.
+        ValueView::Array(items, ArrayKind::List) => {
+            if flatten_arrays {
+                for item in items.iter() {
+                    flat_val(item, out, true);
+                }
+            } else {
+                out.push(Value::array_with_kind(items.clone(), ArrayKind::ItemList));
+            }
+        }
+        ValueView::Seq(items) => {
+            if flatten_arrays {
+                for item in items.iter() {
+                    flat_val(item, out, true);
+                }
+            } else {
+                out.push(Value::array_with_kind(
+                    crate::gc::Gc::new(crate::value::ArrayData::new(items.to_vec())),
+                    ArrayKind::ItemList,
+                ));
             }
         }
         // Real Arrays ([...]): flatten if flag is set. Children get
-        // flatten_arrays=false because [...] itemizes its elements.
-        ValueView::Array(items, ArrayKind::Array) if flatten_arrays => {
-            for item in items.iter() {
-                flat_val(item, out, false);
+        // flatten_arrays=false because [...] itemizes its elements. As an
+        // element of an itemizing container the array itself stays single,
+        // itemized (`[1, [2, 3]].flat.raku` is `(1, $[2, 3]).Seq`).
+        ValueView::Array(items, ArrayKind::Array) => {
+            if flatten_arrays {
+                for item in items.iter() {
+                    flat_val(item, out, false);
+                }
+            } else {
+                out.push(Value::array_with_kind(items.clone(), ArrayKind::ItemArray));
             }
         }
         // A shaped (native) array (`array[int].new(:shape(10), …)`) flattens its

--- a/t/flat-itemization-depth.t
+++ b/t/flat-itemization-depth.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+# `.flat` itemization depth: an Array's elements live in Scalar containers,
+# so flat does not descend into them — a List/Array element of an Array
+# stays single (and itemized in .raku). List elements of a List flatten.
+# Found by the doc-diff sweep (Language/list.rakudoc [8]/[10]/[11]).
+
+plan 10;
+
+{
+    my @l := 2, (3, 4);
+    is-deeply (1, @l, 5).flat.List, (1, 2, 3, 4, 5),
+        'bound List flattens fully';
+    my @a = 2, (3, 4);
+    is (1, @a, 5).flat.elems, 4,
+        'Array element List stays single under flat';
+    is (1, @a, 5).flat[2].gist, '(3 4)',
+        'the un-flattened element is the inner list';
+    is @a.flat.raku, '(2, $(3, 4)).Seq', 'Array.flat itemizes List elements';
+}
+
+is ((1, 2), $(3, 4)).flat.raku, '(1, 2, $(3, 4)).Seq',
+    'List flattens, itemized element stays (doc example)';
+is [(1, 2), $(3, 4)].flat.raku, '($(1, 2), $(3, 4)).Seq',
+    'Array.flat keeps both elements itemized (doc example)';
+is (0, [(1, 2), $(3, 4)], 5).flat.raku, '(0, $(1, 2), $(3, 4), 5).Seq',
+    'Array inside a List spills itemized elements (doc example)';
+
+is [[1, 2], [3, 4]].flat.raku, '($[1, 2], $[3, 4]).Seq',
+    'Array elements of an Array stay itemized arrays';
+is (1, ((2, 3), 4)).flat.List, (1, 2, 3, 4),
+    'nested Lists in List context flatten fully';
+is join(",", [1, (2, 3)]), '1,2 3',
+    'join respects the itemization depth';
+
+done-testing;

--- a/t/vm-basic.t
+++ b/t/vm-basic.t
@@ -1,5 +1,5 @@
 use Test;
-plan 328;
+plan 329;
 
 # Literal compilation
 is 42, 42, 'integer literal';
@@ -607,9 +607,12 @@ is $block_val, 30, 'block with multiple stmts returns last value';
 
 # === Additional native methods ===
 
-# .flat
+# .flat — an Array's elements are itemized (Scalar containers), so flat
+# does not descend into them (raku: 3); a bound List flattens fully.
 my @nested = (1, (2, 3), (4, 5));
-is @nested.flat.elems, 5, 'native .flat flattens array';
+is @nested.flat.elems, 3, 'native .flat keeps itemized array elements';
+my @nested-list := 1, (2, 3), (4, 5);
+is @nested-list.flat.elems, 5, 'native .flat flattens a bound List';
 
 # .reverse
 my @rev = (1, 2, 3);


### PR DESCRIPTION
## Summary
An Array's elements live in Scalar containers, so `flat` must not descend into them. The List/Seq arms of `flat_val` now honor the `flatten_arrays` context flag (they previously always descended); as elements of an itemizing container they stay single and are pushed as ItemList/ItemArray so `.raku` renders them itemized. All raku-verified:

- `my @a = 2, (3, 4); (1, @a, 5).flat` → `(1 2 (3 4) 5)` (was fully flattened)
- `[(1, 2), $(3, 4)].flat.raku` → `($(1, 2), $(3, 4)).Seq`
- `(0, [(1, 2), $(3, 4)], 5).flat.raku` → `(0, $(1, 2), $(3, 4), 5).Seq`
- `[1, [2, 3]].flat.raku` → `(1, $[2, 3]).Seq`
- `join(",", [1, (2, 3)])` → `1,2 3` (join shares `flat_val`)
- Bound Lists (`my @l := 2, (3, 4)`) and nested Lists in List context still flatten fully; Slips always flatten.

`t/vm-basic.t` pinned the old over-flattening (expected 5 where raku says 3) and was updated to the raku semantics.

Found by the doc-diff sweep (`Language/list.rakudoc` [8]/[10]/[11], `docs/doc-diff-backlog.md` lazy-list cluster).

## Test plan
- New pin: `t/flat-itemization-depth.t` (10 assertions, raku-verified)
- `make test`: 2341 files, all pass
- Roast: `S32-list/{flat,join,map}.t`, `S02-literals/array-interpolation.t`, `S06-signature/slurpy-params.t`, `S09-subscript/slice.t` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)