### PR TITLE
feat: loop/while/until expressions are lazy Seqs pulled on demand

### DIFF
--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -613,8 +613,14 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                 }
                 // A genuinely-lazy list stays lazy through `.Array`/`.list`:
                 // tag it with the target context so `.WHAT` reports `Array`/`List`
-                // without materializing the (possibly infinite) generator.
-                ValueView::LazyList(ll) if ll.is_genuinely_lazy() => {
+                // without materializing the (possibly infinite) generator. A
+                // live (not-yet-pulled) gather coroutine is equally deferred —
+                // `(loop { ... }).list[2]` must pull three iterations, not
+                // force the (possibly infinite) loop here.
+                ValueView::LazyList(ll)
+                    if ll.is_genuinely_lazy()
+                        || (ll.coroutine.is_some() && ll.cache.lock().unwrap().is_none()) =>
+                {
                     if want_array {
                         Some(Ok(Value::lazy_list(crate::gc::Gc::new(
                             ll.with_array_context(),

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -312,22 +312,7 @@ impl Compiler {
         use crate::ast::{Expr as AExpr, Stmt as AStmt};
         // Build `take <last_expr>` body: replace the last expression with `take <expr>`
         // and wrap the body in a for loop inside a gather block.
-        let take_body: Vec<AStmt> = {
-            let mut stmts = body.to_vec();
-            // Replace last expression statement with `take(expr)`
-            let last_idx = stmts.iter().rposition(|s| !matches!(s, AStmt::SetLine(_)));
-            if let Some(idx) = last_idx {
-                if let AStmt::Expr(expr) = stmts[idx].clone() {
-                    stmts[idx] = AStmt::Take(expr, false);
-                } else {
-                    // Wrap non-expr last stmt in Take(Nil) since we need a take
-                    stmts.push(AStmt::Take(AExpr::Literal(crate::value::Value::NIL), false));
-                }
-            } else {
-                stmts.push(AStmt::Take(AExpr::Literal(crate::value::Value::NIL), false));
-            }
-            stmts
-        };
+        let take_body = Self::wrap_loop_body_last_in_take(body);
         // Build inner for loop with the take body
         let inner_for = AStmt::For {
             iterable: iterable.clone(),
@@ -359,34 +344,58 @@ impl Compiler {
         self.compile_expr(&lazy_expr);
     }
 
-    /// Compile `do while` / `do until` expression: collect each iteration value.
+    /// Rewrite a loop body so its per-iteration value is `take`n: the last
+    /// expression statement becomes `take <expr>`; a value-bearing `if`/`given`
+    /// last statement is taken through `do` (so a false `if`-modifier yields
+    /// `Empty`, which `take` slips away); any other shape appends `take Nil`.
+    /// The loop's KEEP/UNDO result capture sees through the trailing `Take`
+    /// (see `expand_loop_phasers`). Shared by the `lazy for` lowering and the
+    /// `while`/`loop` expression forms.
+    fn wrap_loop_body_last_in_take(body: &[Stmt]) -> Vec<Stmt> {
+        use crate::ast::{Expr as AExpr, Stmt as AStmt};
+        let mut stmts = body.to_vec();
+        let last_idx = stmts.iter().rposition(|s| !matches!(s, AStmt::SetLine(_)));
+        if let Some(idx) = last_idx {
+            match stmts[idx].clone() {
+                AStmt::Expr(expr) => stmts[idx] = AStmt::Take(expr, false),
+                s @ (AStmt::If { .. } | AStmt::Given { .. }) => {
+                    stmts[idx] = AStmt::Take(AExpr::DoStmt(Box::new(s)), false);
+                }
+                _ => {
+                    stmts.push(AStmt::Take(AExpr::Literal(crate::value::Value::NIL), false));
+                }
+            }
+        } else {
+            stmts.push(AStmt::Take(AExpr::Literal(crate::value::Value::NIL), false));
+        }
+        stmts
+    }
+
+    /// Compile `do while` / `do until` (and parenthesized `(while ...)`)
+    /// expression: lower to `gather { while COND { take do { body } } }` so
+    /// the result is a lazy Seq pulled on demand, matching raku —
+    /// `(while $++ < 2 { 42.say; 43 }).map: *.say` interleaves 42/43, and
+    /// the whole loop only runs to completion when the Seq is reified.
     pub(super) fn compile_do_while_expr(
         &mut self,
         cond: &Expr,
         body: &[Stmt],
         label: &Option<String>,
     ) {
-        let (pre_stmts, loop_body, post_stmts) = self.expand_loop_phasers(body, label.as_deref());
-        for stmt in &pre_stmts {
-            self.compile_stmt(stmt);
-        }
-        let loop_idx = self.code.emit(OpCode::WhileLoop {
-            cond_end: 0,
-            body_end: 0,
+        use crate::ast::{Expr as AExpr, Stmt as AStmt};
+        let inner = AStmt::While {
+            cond: cond.clone(),
+            body: Self::wrap_loop_body_last_in_take(body),
             label: label.clone(),
-            collect: true,
-            isolate_topic: Self::body_mutates_topic(&loop_body),
-        });
-        self.compile_expr(cond);
-        self.code.patch_while_cond_end(loop_idx);
-        self.compile_collected_loop_body(&loop_body);
-        self.code.patch_loop_end(loop_idx);
-        for stmt in &post_stmts {
-            self.compile_stmt(stmt);
-        }
+        };
+        let gather_expr = AExpr::Gather(vec![inner]);
+        self.compile_expr(&gather_expr);
     }
 
-    /// Compile `do loop (...) { ... }` expression: collect each iteration value.
+    /// Compile `do loop (...) { ... }` / `(loop { ... })` expression: lower to
+    /// `gather { loop (...) { take do { body } } }` — a lazy Seq, so an
+    /// infinite `(loop { 42.say })[2]` pulls exactly three iterations.
+    /// The C-style init runs inside the gather, deferred until first pull.
     pub(super) fn compile_do_loop_expr(
         &mut self,
         init: &Option<Box<Stmt>>,
@@ -395,36 +404,17 @@ impl Compiler {
         body: &[Stmt],
         label: &Option<String>,
     ) {
-        let (pre_stmts, loop_body, post_stmts) = self.expand_loop_phasers(body, label.as_deref());
-        if let Some(init_stmt) = init {
-            self.compile_stmt(init_stmt);
-        }
-        for stmt in &pre_stmts {
-            self.compile_stmt(stmt);
-        }
-        let loop_idx = self.code.emit(OpCode::CStyleLoop {
-            cond_end: 0,
-            step_start: 0,
-            body_end: 0,
+        use crate::ast::{Expr as AExpr, Stmt as AStmt};
+        let inner = AStmt::Loop {
+            init: init.clone(),
+            cond: cond.clone(),
+            step: step.clone(),
+            body: Self::wrap_loop_body_last_in_take(body),
+            repeat: false,
             label: label.clone(),
-            collect: true,
-        });
-        if let Some(cond_expr) = cond {
-            self.compile_expr(cond_expr);
-        } else {
-            self.code.emit(OpCode::LoadTrue);
-        }
-        self.code.patch_cstyle_cond_end(loop_idx);
-        self.compile_collected_loop_body(&loop_body);
-        self.code.patch_cstyle_step_start(loop_idx);
-        if let Some(step_expr) = step {
-            self.compile_expr(step_expr);
-            self.code.emit(OpCode::Pop);
-        }
-        self.code.patch_loop_end(loop_idx);
-        for stmt in &post_stmts {
-            self.compile_stmt(stmt);
-        }
+        };
+        let gather_expr = AExpr::Gather(vec![inner]);
+        self.compile_expr(&gather_expr);
     }
 
     pub(super) fn do_if_branch_supported(stmts: &[Stmt]) -> bool {

--- a/src/compiler/helpers_phasers.rs
+++ b/src/compiler/helpers_phasers.rs
@@ -434,6 +434,10 @@ impl Compiler {
         // When we have both result_var (KEEP/UNDO) and post_topic_var (POST),
         // we need to capture the body's last expression into both.
         let capture_var = result_var.clone().or(post_topic_var.clone());
+        let body_taken = matches!(
+            body_main.last(),
+            Some(Stmt::Take(_, false)) if capture_var.is_some()
+        );
         if let Some(cap_var) = capture_var.clone() {
             if let Some((last, prefix)) = body_main.split_last() {
                 loop_body.extend(prefix.iter().cloned());
@@ -443,6 +447,18 @@ impl Compiler {
                         expr: expr.clone(),
                         op: AssignOp::Assign,
                     }),
+                    // A trailing `take <expr>` (the gather-lowered loop
+                    // expression form) carries the iteration value: capture it
+                    // for KEEP/UNDO/POST, then take the captured value so the
+                    // gather still collects it.
+                    Stmt::Take(expr, false) => {
+                        loop_body.push(Stmt::Assign {
+                            name: cap_var.clone(),
+                            expr: expr.clone(),
+                            op: AssignOp::Assign,
+                        });
+                        loop_body.push(Stmt::Take(Expr::Var(cap_var.clone()), false));
+                    }
                     other => {
                         loop_body.push(other.clone());
                         loop_body.push(Stmt::Assign {
@@ -501,8 +517,13 @@ impl Compiler {
                     binding_var: None,
                 });
             }
-            // Preserve loop-body value for expression contexts that collect iteration results.
-            loop_body.push(Stmt::Expr(Expr::Var(result_var)));
+            // Preserve loop-body value for expression contexts that collect
+            // iteration results. Not needed (and harmful — sinking a taken
+            // Failure would throw) when the body's value was already `take`n
+            // into the enclosing gather.
+            if !body_taken {
+                loop_body.push(Stmt::Expr(Expr::Var(result_var)));
+            }
         }
         // NEXT runs after KEEP/UNDO, before the next iteration begins.
         // next_ph was already reversed above for LIFO order.

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -183,6 +183,30 @@ impl Interpreter {
             self.finish()?;
             return Err(err);
         }
+        // Raku also DRAINS the sunk tail when it is a side-effecting lazy Seq:
+        // `(while $++ < 2 { 42.say; 43 }).map: *.say` as the program's final
+        // statement must run its pipeline (non-tail statements drain via the
+        // SinkPop/Pop LazyList arms). Restricted to safely-finite sources — a
+        // finite-bottomed map/grep pipe or a plain (non-`lazy`) gather
+        // coroutine; a `.cache` view or a genuinely-lazy list stays undrained.
+        if Self::tail_stmt_sinks_fresh_rvalue(&body_main) {
+            let drain = last_value.as_ref().and_then(|v| match v.view() {
+                crate::value::ValueView::LazyList(ll)
+                    if !ll.is_cached_no_sink()
+                        && ((ll.lazy_pipe.is_some() && ll.pipe_bottoms_out_finite())
+                            || (ll.coroutine.is_some() && !ll.is_genuinely_lazy())) =>
+                {
+                    Some(ll.clone())
+                }
+                _ => None,
+            });
+            if let Some(ll) = drain
+                && let Err(e) = self.force_lazy_list_vm(&ll)
+            {
+                self.finish()?;
+                return Err(e);
+            }
+        }
         // Only store last_value if _ was actually set during this execution
         // (not inherited from a previous REPL line)
         self.last_value = last_value;
@@ -230,6 +254,10 @@ impl Interpreter {
             // Bare `EVAL "..."` parses as a `Stmt::Call`; other bare sub calls
             // are excluded (see the doc comment).
             Stmt::Call { name, .. } => matches!(name.resolve().as_str(), "EVAL" | "EVALFILE"),
+            // A `(while ...)` / `(loop ...)` expression tail is a fresh lazy
+            // Seq (never a Failure), included so the tail-sink drain above
+            // runs its side effects.
+            Stmt::While { .. } | Stmt::Loop { .. } => true,
             Stmt::Expr(e) => Self::expr_is_fresh_rvalue(e),
             // A bare block's value is its own last statement's value.
             Stmt::Block(body) | Stmt::SyntheticBlock(body) => {

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -955,7 +955,7 @@ impl Interpreter {
         let target = if let ValueView::LazyList(ll) = target.view()
             && ll.needs_vm_lazy_dispatch()
             && Self::lazy_list_needs_forcing(method)
-            && !(ll.coroutine.is_some() && matches!(method, "List" | "values"))
+            && !(ll.coroutine.is_some() && matches!(method, "List" | "list" | "values"))
             // A `.map`/`.grep` on a lazy pipeline, an infinite sequence/closure
             // spec, OR a gather coroutine appends another lazy stage (interpreter
             // dispatch via `is_lazy_pipe_source`) — it must not force the source

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -627,7 +627,42 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
 impl Interpreter {
     /// Perform a smart match, trying pure value matching first, falling back to
     /// the interpreter for complex cases (regex, callable, type checks, etc.).
+    /// Reify a *safely finite* lazy list (a plain gather / a pipe bottoming
+    /// out in a finite source) to a `Seq` so it participates in list
+    /// smartmatch by value — `(gather { take 1; take 2 }) ~~ (1, 2)` must
+    /// compare elements, not an unforced placeholder. Returns `None` for
+    /// anything genuinely lazy (never forces an infinite source).
+    fn reify_finite_lazy_for_match(&mut self, v: &Value) -> Option<Value> {
+        let ValueView::LazyList(ll) = v.view() else {
+            return None;
+        };
+        let finite = if ll.lazy_pipe.is_some() {
+            ll.pipe_bottoms_out_finite()
+        } else {
+            !ll.is_genuinely_lazy()
+                && (ll.coroutine.is_some() || !ll.body.is_empty() || ll.compiled_code.is_some())
+        };
+        if !finite {
+            return None;
+        }
+        match self.force_lazy_list_vm(&ll) {
+            Ok(items) => Some(Value::seq(items)),
+            Err(e) => {
+                self.set_pending_dispatch_error(e);
+                None
+            }
+        }
+    }
+
     pub(super) fn vm_smart_match(&mut self, left: &Value, right: &Value) -> bool {
+        // Force finite lazy operands first so list matching sees their
+        // elements (see reify_finite_lazy_for_match).
+        if let Some(forced) = self.reify_finite_lazy_for_match(left) {
+            return self.vm_smart_match(&forced, right);
+        }
+        if let Some(forced) = self.reify_finite_lazy_for_match(right) {
+            return self.vm_smart_match(left, &forced);
+        }
         // `$x ~~ $obj` where $obj's class defines a user `ACCEPTS` dispatches
         // `$obj.ACCEPTS($x)` — the core smartmatch protocol. Check this BEFORE
         // `pure_smart_match`, whose generic Instance~~Instance arm would otherwise

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -477,11 +477,17 @@ impl Interpreter {
             // variants above stay inline for speed; everything else expands via
             // the shared `value_to_list` range walker.
             ValueView::GenericRange { .. } => crate::runtime::utils::value_to_list(val),
-            // Bounded pull so an infinite source (`@a[0,1,2] = (loop { 42 })`)
-            // supplies the slice without hanging; a finite list reifies fully
-            // below the cap.
+            // A live gather coroutine may be infinite (`@a[0,1,2] =
+            // (loop { 42 })`): bounded pull so the slice fills without
+            // hanging (a finite gather completes below the cap). Every other
+            // lazy kind keeps the strict force (a lazy pipe's own bounded
+            // machinery handles it).
             ValueView::LazyList(list) => {
-                self.force_lazy_list_vm_n(&list, Self::MAX_ASSIGN_SLICE_EXPAND as usize)?
+                if list.coroutine.is_some() && list.cache.lock().unwrap().is_none() {
+                    self.force_lazy_list_vm_n(&list, Self::MAX_ASSIGN_SLICE_EXPAND as usize)?
+                } else {
+                    self.force_lazy_list_vm(&list)?
+                }
             }
             _ => vec![val.clone()],
         })

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -477,7 +477,12 @@ impl Interpreter {
             // variants above stay inline for speed; everything else expands via
             // the shared `value_to_list` range walker.
             ValueView::GenericRange { .. } => crate::runtime::utils::value_to_list(val),
-            ValueView::LazyList(list) => self.force_lazy_list_vm(&list)?,
+            // Bounded pull so an infinite source (`@a[0,1,2] = (loop { 42 })`)
+            // supplies the slice without hanging; a finite list reifies fully
+            // below the cap.
+            ValueView::LazyList(list) => {
+                self.force_lazy_list_vm_n(&list, Self::MAX_ASSIGN_SLICE_EXPAND as usize)?
+            }
             _ => vec![val.clone()],
         })
     }

--- a/t/loop-while-as-lazy-seq.t
+++ b/t/loop-while-as-lazy-seq.t
@@ -1,0 +1,57 @@
+use v6;
+use Test;
+
+# `(loop { ... })` / `(while ...)` / `(until ...)` expressions are lazy Seqs
+# pulled on demand (lowered to a gather-wrapped loop), so an infinite loop
+# body only runs as many iterations as are consumed.
+# Found by the doc-diff sweep (Language/list.rakudoc [4]/[6]/[9]/[12]).
+
+plan 10;
+
+# --- (loop { ... })[N] pulls exactly N+1 iterations ---
+{
+    my $runs = 0;
+    my $v = (loop { $runs++; 42 })[2];
+    is $v, 42, 'infinite loop expression indexes on demand';
+    is $runs, 3, 'exactly three iterations ran for [2]';
+}
+
+# --- .list keeps the pull lazy, with caching across indexes ---
+{
+    my $runs = 0;
+    my @s := (loop { $runs++; 42 }).list;
+    @s[2];
+    is $runs, 3, '@s[2] pulled three iterations';
+    @s[1];
+    is $runs, 3, '@s[1] answered from cache (no extra pulls)';
+    @s[4];
+    is $runs, 5, '@s[4] pulled two more';
+}
+
+# --- interleaving: map pulls one iteration at a time ---
+{
+    my @order;
+    my $c = 0;
+    (while $c++ < 2 { @order.push("body"); 43 }).map: { @order.push("map") };
+    is @order.join(","), 'body,map,body,map',
+        'while-expression Seq interleaves with its consumer';
+}
+
+# --- slice assignment pulls what the LHS needs ---
+{
+    my @a;
+    @a[0, 1, 2] = (loop { 42 });
+    is-deeply @a, [42, 42, 42], 'slice assignment from an infinite loop';
+}
+
+# --- do while / do loop still collect eagerly with correct values ---
+{
+    my $i = 0;
+    my @r = do while $i < 3 { $i++; $i * 10 };
+    is-deeply @r, [10, 20, 30], 'do while collects iteration values';
+    is $i, 3, 'do while side effects applied on array assignment';
+    my @c = do loop (my $j = 0; $j < 3; $j++) { $j * 2 };
+    is-deeply @c, [0, 2, 4], 'do loop collects iteration values';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary
`(loop { ... })` / `(while ...)` / `(until ...)` / `do while` / `do loop (...)` expressions now lower to a gather-wrapped loop (the same shape as the existing `lazy for` lowering) and produce a lazy Seq pulled on demand — previously they collected eagerly, so an infinite `(loop { 42.say })[2]` ran forever. All raku-verified:

- `(loop { 42.say })[2]` → three iterations, terminates
- `my @s := (loop { 42.say }).list; @s[2]; @s[1]; @s[4]` → pulls 3 / cached / 2 more (`.list` now defers a live gather coroutine)
- `(while $++ < 2 { 42.say; 43 }).map: *.say` → interleaved `42 43 42 43`
- `@a[0,1,2] = (loop { 42 })` → `[42 42 42]` (slice-assign RHS pulls a bounded prefix)
- Eager consumers (`my @r = do while ...`, `[while ...]`) unchanged via plain-gather eager materialization

Supporting fixes the lowering surfaced (details in the commit message): KEEP/UNDO result capture sees through the trailing `take`; the program's sunk tail statement drains a finite side-effecting lazy Seq (raku sink semantics); `vm_smart_match` reifies safely-finite lazy operands (`(gather { take 1; take 2 }) ~~ (1, 2)` is now True).

This closes the "loop/while-as-lazy-list" deep item of the doc-diff lazy-list cluster (`Language/list.rakudoc` [4]/[6]/[9]/[12]).

## Test plan
- New pin: `t/loop-while-as-lazy-seq.t` (10 assertions, raku-verified)
- `make test`: 2341 files, all pass (incl. `t/loop-expression-values.t` UNDO semantics)
- Roast: `S04-statements/{while,until,do,loop,repeat,gather,lazy}.t`, `S04-phasers/{keep-undo,enter-leave,first,next}.t`, `S03-smartmatch/any-any.t` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)