### PR TITLE
fix: Mix construction accumulates repeated-key weights with exact arithmetic

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -155,6 +155,20 @@ doc) are version skew, not mutsu bugs — lowest priority.
   `is_builtin_dynamic_var` — **#5128**. Pin: `t/approx-equal-tolerance.t`.
   **Still open:** a bare `say $*TOLERANCE` reads undefined (not 1e-15); seeding it
   is blocked by the block-scope-dynamic desync below.
+- `Mix.rakudoc` [1]/[2], `Baggy.rakudoc` [1] — Mix **construction** folded
+  repeated-key weights with lossy f64 addition, so
+  `(sugar => 0.1, sugar => 0.02).Mix<sugar>` was `0.12000000000000001` instead of
+  `0.12` (and `Mix.new-from-pairs` the same). `MixData.weights` is still a
+  `HashMap<String,f64>` store, but the two coercion ctors (`to_mix` in
+  `quanthash_coerce.rs`, `dispatch_new_from_pairs`) now accumulate weights as
+  exact `Value`s (`arith_add` keeps `Rat + Rat` exact via `mix_pair_weight_value`
+  + `mix_accum`) and lower to the stored f64 only at the boundary, so the nearest
+  double to `0.12` (which formats as `0.12`) is stored. Pin:
+  `t/mix-weight-exact-accumulation.t`. **Still deferred:** Mix *arithmetic*
+  operators (`$a (+) $b`) still add the already-f64 stored weights, so
+  `(a=>0.1).Mix (+) (a=>0.02).Mix` remains `0.12000000000000001` — that needs the
+  full exact-weight storage rework (the "FatRat-vs-Rat repr tag" class below), not
+  a construction fix.
 
 ### Deferred / deep (tracked elsewhere — do not re-open as a shallow slice)
 These root causes account for a large share of the survey's `mism`/`crash` and are

--- a/src/builtins/quanthash_coerce.rs
+++ b/src/builtins/quanthash_coerce.rs
@@ -545,32 +545,73 @@ pub(crate) fn mix_pair_weight(v: &Value) -> Result<f64, RuntimeError> {
     }
 }
 
+/// The exact numeric weight of a Mix pair value, preserving its `Rat`/`Int`
+/// representation so repeated keys accumulate with exact rational arithmetic
+/// (`0.1 + 0.02` must sum to `0.12`, not the lossy f64 `0.12000000000000001`).
+/// Delegates to [`mix_pair_weight`] for the Inf/NaN/Complex/bad-Str validation
+/// errors, then returns the exact `Value` rather than that validated f64.
+pub(crate) fn mix_pair_weight_value(v: &Value) -> Result<Value, RuntimeError> {
+    let f = mix_pair_weight(v)?;
+    match v.view() {
+        ValueView::Int(_)
+        | ValueView::BigInt(_)
+        | ValueView::Num(_)
+        | ValueView::Rat(..)
+        | ValueView::BigRat(..)
+        | ValueView::FatRat(..) => Ok(v.clone()),
+        ValueView::Bool(b) => Ok(Value::int(i64::from(b))),
+        // Str / other coercible types fall back to the validated f64 — none of
+        // these carry exactly-representable rationals through this path.
+        _ => Ok(Value::num(f)),
+    }
+}
+
+/// Accumulate `w` into `weights[key]` using exact `Value` arithmetic
+/// (`arith_add` keeps `Rat + Rat` exact). Mix weights are folded as `Value`s
+/// during construction and only lowered to `f64` at the coercion boundary.
+fn mix_accum(
+    weights: &mut HashMap<String, Value>,
+    key: String,
+    w: Value,
+) -> Result<(), RuntimeError> {
+    use std::collections::hash_map::Entry;
+    match weights.entry(key) {
+        Entry::Occupied(mut e) => {
+            let sum = crate::builtins::arith::arith_add(e.get().clone(), w)?;
+            *e.get_mut() = sum;
+        }
+        Entry::Vacant(e) => {
+            e.insert(w);
+        }
+    }
+    Ok(())
+}
+
 fn mix_add_item_with_keys(
-    weights: &mut HashMap<String, f64>,
+    weights: &mut HashMap<String, Value>,
     mut original_keys: Option<&mut HashMap<String, Value>>,
     item: &Value,
     flatten: bool,
 ) -> Result<(), RuntimeError> {
     match item.view() {
         ValueView::Pair(k, v) => {
-            let w = mix_pair_weight(v)?;
-            *weights.entry(k.clone()).or_insert(0.0) += w;
+            mix_accum(weights, k.clone(), mix_pair_weight_value(v)?)?;
         }
         ValueView::ValuePair(k, v) => {
-            let w = mix_pair_weight(v)?;
+            let w = mix_pair_weight_value(v)?;
             let str_key = k.to_string_value();
             if let Some(ref mut orig) = original_keys
                 && k.as_str().is_none()
             {
                 orig.entry(str_key.clone()).or_insert_with(|| k.clone());
             }
-            *weights.entry(str_key).or_insert(0.0) += w;
+            mix_accum(weights, str_key, w)?;
         }
         ValueView::Hash(h) if flatten => {
             for (k, v) in h.iter() {
-                let w = mix_pair_weight(v)?;
-                if w != 0.0 {
-                    *weights.entry(k.clone()).or_insert(0.0) += w;
+                let w = mix_pair_weight_value(v)?;
+                if w.to_f64() != 0.0 {
+                    mix_accum(weights, k.clone(), w)?;
                 }
             }
         }
@@ -595,7 +636,7 @@ fn mix_add_item_with_keys(
                 {
                     orig.entry(k.clone()).or_insert(typed);
                 }
-                *weights.entry(k.clone()).or_insert(0.0) += 1.0;
+                mix_accum(weights, k.clone(), Value::int(1))?;
             }
         }
         ValueView::Bag(b, _) if flatten => {
@@ -606,8 +647,7 @@ fn mix_add_item_with_keys(
                 {
                     orig.entry(k.clone()).or_insert(typed);
                 }
-                *weights.entry(k.clone()).or_insert(0.0) +=
-                    crate::runtime::utils::bigint_to_f64_sat(v);
+                mix_accum(weights, k.clone(), Value::bigint(v.clone()))?;
             }
         }
         ValueView::Mix(m, _) if flatten => {
@@ -618,7 +658,9 @@ fn mix_add_item_with_keys(
                 {
                     orig.entry(k.clone()).or_insert(typed);
                 }
-                *weights.entry(k.clone()).or_insert(0.0) += v;
+                // A Mix already stores f64 weights, so this fold is inherently
+                // f64-precision (there is no exact source to recover here).
+                mix_accum(weights, k.clone(), Value::num(*v))?;
             }
         }
         _ => {
@@ -628,7 +670,7 @@ fn mix_add_item_with_keys(
             {
                 orig.entry(str_key.clone()).or_insert_with(|| item.clone());
             }
-            *weights.entry(str_key).or_insert(0.0) += 1.0;
+            mix_accum(weights, str_key, Value::int(1))?;
         }
     }
     Ok(())
@@ -648,7 +690,9 @@ pub(crate) fn to_mix(target: Value, what: &str) -> Result<Value, RuntimeError> {
         )));
         return Err(err);
     }
-    let mut weights: HashMap<String, f64> = HashMap::new();
+    // Weights are folded as exact `Value`s (so `0.1 + 0.02` stays `0.12`) and
+    // lowered to the stored `f64` representation only at the return boundary.
+    let mut weights: HashMap<String, Value> = HashMap::new();
     let mut original_keys: HashMap<String, Value> = HashMap::new();
     match target.view() {
         // Always return the immutable variant; the caller flips it for `.MixHash`.
@@ -683,7 +727,7 @@ pub(crate) fn to_mix(target: Value, what: &str) -> Result<Value, RuntimeError> {
         }
         _ if target.is_range() => {
             for item in value_to_list(&target) {
-                *weights.entry(item.to_string_value()).or_insert(0.0) += 1.0;
+                mix_accum(&mut weights, item.to_string_value(), Value::int(1))?;
             }
         }
         _ => {
@@ -693,9 +737,11 @@ pub(crate) fn to_mix(target: Value, what: &str) -> Result<Value, RuntimeError> {
                     .entry(str_key.clone())
                     .or_insert_with(|| target.clone());
             }
-            weights.insert(str_key, 1.0);
+            mix_accum(&mut weights, str_key, Value::int(1))?;
         }
     }
+    // Lower the exact-`Value` weights to the stored `f64` representation.
+    let weights: HashMap<String, f64> = weights.into_iter().map(|(k, v)| (k, v.to_f64())).collect();
     if original_keys.is_empty() {
         Ok(Value::mix(weights))
     } else {

--- a/src/runtime/methods_dispatch_new.rs
+++ b/src/runtime/methods_dispatch_new.rs
@@ -160,21 +160,31 @@ impl Interpreter {
         };
         match type_name.as_str() {
             "Mix" | "MixHash" => {
-                let mut weights: HashMap<String, f64> = HashMap::new();
+                // Fold weights as exact `Value`s so repeated keys accumulate with
+                // exact rational arithmetic (`0.1 + 0.02` → `0.12`, not the lossy
+                // f64 `0.12000000000000001`); lower to f64 only at the boundary.
+                use crate::builtins::quanthash_coerce::mix_pair_weight_value;
+                let mut weights: HashMap<String, Value> = HashMap::new();
                 for item in &items {
                     let (key, weight) = match item.view() {
-                        ValueView::Pair(k, v) => (
-                            k.clone(),
-                            crate::builtins::quanthash_coerce::mix_pair_weight(v)?,
-                        ),
-                        ValueView::ValuePair(k, v) => (
-                            k.to_string_value(),
-                            crate::builtins::quanthash_coerce::mix_pair_weight(v)?,
-                        ),
-                        _ => (item.to_string_value(), 1.0),
+                        ValueView::Pair(k, v) => (k.clone(), mix_pair_weight_value(v)?),
+                        ValueView::ValuePair(k, v) => {
+                            (k.to_string_value(), mix_pair_weight_value(v)?)
+                        }
+                        _ => (item.to_string_value(), Value::int(1)),
                     };
-                    *weights.entry(key).or_insert(0.0) += weight;
+                    match weights.entry(key) {
+                        std::collections::hash_map::Entry::Occupied(mut e) => {
+                            let sum = crate::builtins::arith::arith_add(e.get().clone(), weight)?;
+                            *e.get_mut() = sum;
+                        }
+                        std::collections::hash_map::Entry::Vacant(e) => {
+                            e.insert(weight);
+                        }
+                    }
                 }
+                let weights: HashMap<String, f64> =
+                    weights.into_iter().map(|(k, v)| (k, v.to_f64())).collect();
                 Ok(if type_name == "MixHash" {
                     Value::mix_hash(weights)
                 } else {

--- a/t/mix-weight-exact-accumulation.t
+++ b/t/mix-weight-exact-accumulation.t
@@ -1,0 +1,58 @@
+use v6;
+use Test;
+
+plan 12;
+
+# Mix construction accumulates repeated-key weights with EXACT rational
+# arithmetic, so `0.1 + 0.02` sums to `0.12`, not the lossy f64
+# `0.12000000000000001`. (Regression: mutsu stored/accumulated weights as f64.)
+
+# .Mix coercion on a list of pairs (doc: Type/Mix.rakudoc, Type/Baggy.rakudoc)
+{
+    my $recipe = (butter => 0.22, sugar => 0.1, flour => 0.275, sugar => 0.02).Mix;
+    is $recipe<sugar>, 0.12, '.Mix accumulates 0.1 + 0.02 exactly to 0.12';
+    is $recipe<sugar>.raku, '0.12', '.Mix sugar weight raku is 0.12 (not f64 noise)';
+    is $recipe.pairs.sort.gist,
+        '(butter => 0.22 flour => 0.275 sugar => 0.12)',
+        '.Mix pairs render exact weights';
+    is $recipe.total, 0.615, '.Mix total is exact';
+}
+
+# Mix.new-from-pairs (doc: Type/Baggy.rakudoc [1])
+{
+    my $m = Mix.new-from-pairs: 'butter' => 0.22, 'sugar' => 0.1, 'sugar' => 0.02;
+    is $m.gist, 'Mix(butter(0.22) sugar(0.12))',
+        'Mix.new-from-pairs accumulates exactly';
+    is $m<sugar>, 0.12, 'new-from-pairs sugar weight is 0.12';
+}
+
+# MixHash coercion preserves the same exactness.
+{
+    my $mh = (a => 0.1, a => 0.02).MixHash;
+    is $mh<a>, 0.12, '.MixHash accumulates 0.1 + 0.02 exactly';
+}
+
+# Replicated pairs accumulate exactly (0.1 * 3 == 0.3, not 0.30000000000000004).
+{
+    my $m = ((a => 0.1) xx 3).Mix;
+    is $m<a>, 0.3, '.Mix of 3x 0.1 is exactly 0.3';
+}
+
+# Integer and mixed weights still work.
+{
+    my $m = (a => 2, a => 3, b => 1).Mix;
+    is $m<a>, 5, 'integer weights accumulate';
+    is $m<b>, 1, 'single integer weight';
+}
+
+# A single non-accumulated fractional weight is unchanged.
+{
+    my $m = (x => 0.333).Mix;
+    is $m<x>, 0.333, 'single fractional weight preserved';
+}
+
+# Negative weights survive accumulation.
+{
+    my $m = (a => 0.5, a => -0.2).Mix;
+    is $m<a>, 0.3, 'accumulation with a negative weight is exact';
+}


### PR DESCRIPTION
## Summary

Mix coercion folded repeated-key weights with **lossy f64 addition**, so a Mix
built from decimal Rat weights that share a key was off by float noise:

```raku
my $recipe = (butter => 0.22, sugar => 0.1, flour => 0.275, sugar => 0.02).Mix;
say $recipe<sugar>;   # was 0.12000000000000001, now 0.12
say Mix.new-from-pairs: 'sugar' => 0.1, 'sugar' => 0.02;   # same
```

The Rat literals `0.1`/`0.02` were reduced to f64 *before* being summed, and
`0.1_f64 + 0.02_f64` is a different double than the nearest double to `0.12`
(whose string form is the clean `0.12`).

## Fix

`MixData.weights` stays a `HashMap<String,f64>` store, but the two construction
paths now accumulate weights as **exact `Value`s** and lower to f64 only at the
coercion boundary:

- `mix_pair_weight_value` returns the exact `Rat`/`Int`/`Num` weight (delegating
  to `mix_pair_weight` for the Inf/NaN/Complex/bad-Str validation errors).
- `mix_accum` folds via `arith_add`, keeping `Rat + Rat` exact
  (`1/10 + 1/50 = 3/25`); `(3/25).to_f64()` is the nearest double to `0.12`,
  which formats as `0.12`.

Applied in `to_mix`/`to_mixhash` (`quanthash_coerce.rs`) and
`dispatch_new_from_pairs` (`methods_dispatch_new.rs`). Integer, replicated
(`xx`), and negative weights accumulate exactly too.

Resolves the `Mix.rakudoc` [1]/[2] and `Baggy.rakudoc` [1] doc-diff-backlog
findings.

## Not covered (stays deferred)

Mix **arithmetic operators** (`$a (+) $b`) still add the already-f64 stored
weights, so `(a=>0.1).Mix (+) (a=>0.02).Mix` remains
`0.12000000000000001`. Fixing that needs the full exact-weight *storage* rework
(the "FatRat-vs-Rat repr tag" deferred class), not a construction fix — recorded
in `docs/doc-diff-backlog.md`.

## Testing

- New pin: `t/mix-weight-exact-accumulation.t` (12 subtests).
- `make test` — all 22191 tests pass.
- No regressions in `roast/S02-types/{mix,mixhash,bag,baghash,set}.t` or the
  `t/*mix*` / `t/setbagmix-*` / `t/*quanthash*` local suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)