### PR TITLE
feat: implement .^shortname; .^ver/.^auth/.^api answer for builtins and undeclared types

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1187,6 +1187,18 @@ the backlog.
       returns the type's `Stash` (was a plain `Hash`, so `(@a>>.WHO).WHAT` was `(Hash)`), and
       `Stash.raku` renders the symbols hash literal (`{:Bar(Foo::Bar)}`, `{}`) instead of
       `Stash.new`. Pin: `t/who-stash.t`.
+- The metamodel-accessor half landed 2026-07-23: `.^shortname` implemented
+      (`Foo::Bar` → `Bar`, qualifier-stripping inside type args too, `R[M2::N]` → `R[N]`);
+      `.^ver` answers `"6.c"` (a Str, as Rakudo) for builtin types/values and `Mu` for
+      unversioned modules/roles/enums instead of throwing; `.^auth`/`.^api` answer `""` for
+      any undeclared type/value (bare `package` still throws — PackageHOW has no
+      ver/auth/api); `.^isa` returns the nqp-boolean Int 1/0 like Rakudo, not Bool.
+      Pin: `t/metamodel-shortname-ver-auth.t`.
+- [ ] **Leftover (doable, small):** anonymous class display name — mutsu names anon classes
+      `__ANON_CLASS_0__` where raku shows `<anon|1>` (visible via `.^name`, `.^shortname`,
+      `say (class :: {})`). The internal name is also the registry key, so the fix is a
+      display-layer mapping (`user_facing_type_name` returns `&str` today and would need to
+      allocate) or renaming the generated key — check `is_internal_anon_type_name` callers.
 - [ ] **Leftover (Rakudo-metamodel-internal, cosmetic):** the *content* of a builtin type's
       stash — raku's `Array.WHO` lists implementation subclasses
       `{:Element(Array::Element), :Shaped(Array::Shaped), ...}` that do not exist in mutsu —

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -1,6 +1,30 @@
 use super::*;
 use crate::symbol::Symbol;
 
+/// `Metamodel::Naming.shortname`: the type name with every `Foo::` package
+/// qualifier dropped, including inside `[...]` type args -- `Foo::Bar` ->
+/// `Bar`, `R[M2::N]` -> `R[N]`. Non-identifier suffixes (`<anon|1>`,
+/// `Int:D`, `+{Role}`) pass through unchanged.
+fn shorten_type_name(name: &str) -> String {
+    let is_ident = |c: char| c.is_alphanumeric() || c == '_' || c == '-' || c == '\'';
+    let chars: Vec<char> = name.chars().collect();
+    let mut out = String::new();
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] == ':' && i + 2 < chars.len() && chars[i + 1] == ':' && is_ident(chars[i + 2]) {
+            // Drop the qualifier segment just emitted along with the `::`.
+            while out.chars().next_back().is_some_and(is_ident) {
+                out.pop();
+            }
+            i += 2;
+            continue;
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    out
+}
+
 impl Interpreter {
     /// Resolve a nominalizable type name to its nominal base type
     /// (`^nominalize`): strip `:D`/`:U`/`:_` definiteness, unwrap a coercion
@@ -125,39 +149,65 @@ impl Interpreter {
                 }
                 _ => value_type_name(&args[0]).to_string(),
             })),
+            "shortname" if !args.is_empty() => {
+                let full = self
+                    .dispatch_classhow_method("name", vec![args[0].clone()])?
+                    .to_string_value();
+                Ok(Value::str(shorten_type_name(&full)))
+            }
             "ver" if args.len() == 1 => {
-                let invocant_name = match args[0].view() {
-                    ValueView::Package(name) => name,
-                    ValueView::Instance { class_name, .. } => class_name,
-                    _ => {
-                        return Err(RuntimeError::new(
-                            "X::Method::NotFound: Unknown method value dispatch (fallback disabled): ver",
-                        ));
-                    }
+                let name = match args[0].view() {
+                    ValueView::Package(name) => name.resolve(),
+                    ValueView::Instance { class_name, .. } => class_name.resolve(),
+                    // A plain value (`42.^ver`): resolve through its type so
+                    // builtins answer below.
+                    _ => value_type_name(&args[0]).to_string(),
                 };
-                let name = invocant_name.resolve();
                 if let Some(meta) = self.type_metadata.get(&name)
                     && let Some(value) = meta.get("ver").cloned()
                 {
                     return Ok(Self::version_from_value(value));
                 }
+                // Core-setting language versions surface as plain Strs
+                // (`Int.^ver.WHAT` is Str in Rakudo); only a declared
+                // `:ver(...)` adverb (the type_metadata path above) is a
+                // real Version object.
                 if let Some(subset) = self.registry().subsets.get(&name) {
-                    return Ok(Self::version_from_value(Value::str(subset.version.clone())));
+                    return Ok(Value::str(subset.version.clone()));
                 }
-                if invocant_name == "Grammar" {
-                    return Ok(Self::version_from_value(Value::str_from("6.e")));
+                if name == "Grammar" {
+                    return Ok(Value::str_from("6.e"));
                 }
-                // A *class* with no declared version: `.^ver` is `Mu` (an undefined
-                // type object), not an error -- matching Rakudo. Reached e.g. when
-                // the `:ver(...)` adverb is an expression mutsu does not evaluate at
-                // registration (`unit class C:ver($?DISTRIBUTION.meta<ver>)`), or a
-                // plain unversioned class. (`has $.V = ::?CLASS.^ver` then sets V to
-                // Mu rather than throwing X::Method::NotFound.)
                 // A bare `package` uses PackageHOW, which has no `.^ver` at all, so
                 // `P.^ver` must still throw X::Method::NotFound ("absent by design").
+                if matches!(
+                    self.registry().package_kinds.get(&name),
+                    Some(crate::ast::PackageKind::Package)
+                ) {
+                    return Err(RuntimeError::new(
+                        "X::Method::NotFound: Unknown method value dispatch (fallback disabled): ver",
+                    ));
+                }
+                // Core setting types report the language version they were
+                // declared in (`Int.^ver` is v6.c). Checked before the class
+                // registry so an add_method stub for a builtin doesn't turn
+                // this into Mu.
+                if Self::is_builtin_type(&name) {
+                    return Ok(Value::str_from("6.c"));
+                }
+                // A class/module/role/enum with no declared version: `.^ver` is
+                // `Mu` (an undefined type object), not an error -- matching
+                // Rakudo. Reached e.g. when the `:ver(...)` adverb is an
+                // expression mutsu does not evaluate at registration
+                // (`unit class C:ver($?DISTRIBUTION.meta<ver>)`), or a plain
+                // unversioned declaration.
                 // TODO: evaluate expression-form `:ver(...)` adverbs at class
                 // registration and store the result in type_metadata.
-                if self.registry().classes.contains_key(&name) {
+                if self.registry().classes.contains_key(&name)
+                    || self.registry().roles.contains_key(&name)
+                    || self.registry().enum_types.contains_key(&name)
+                    || self.registry().package_kinds.contains_key(&name)
+                {
                     return Ok(Value::package(crate::symbol::Symbol::intern("Mu")));
                 }
                 Err(RuntimeError::new(
@@ -165,43 +215,53 @@ impl Interpreter {
                 ))
             }
             "auth" if args.len() == 1 => {
-                let invocant_name = match args[0].view() {
-                    ValueView::Package(name) => name,
-                    ValueView::Instance { class_name, .. } => class_name,
-                    _ => {
-                        return Err(RuntimeError::new(
-                            "X::Method::NotFound: Unknown method value dispatch (fallback disabled): auth",
-                        ));
-                    }
+                let name = match args[0].view() {
+                    ValueView::Package(name) => name.resolve(),
+                    ValueView::Instance { class_name, .. } => class_name.resolve(),
+                    _ => value_type_name(&args[0]).to_string(),
                 };
-                let Some(meta) = self.type_metadata.get(&invocant_name.resolve()) else {
+                // A bare `package` uses PackageHOW, which has no `.^auth`.
+                if matches!(
+                    self.registry().package_kinds.get(&name),
+                    Some(crate::ast::PackageKind::Package)
+                ) {
                     return Err(RuntimeError::new(
                         "X::Method::NotFound: Unknown method value dispatch (fallback disabled): auth",
                     ));
-                };
-                let Some(value) = meta.get("auth").cloned() else {
-                    return Err(RuntimeError::new(
-                        "X::Method::NotFound: Unknown method value dispatch (fallback disabled): auth",
-                    ));
-                };
-                Ok(Value::str(value.to_string_value()))
+                }
+                // A type with no declared `:auth` has an empty-string auth
+                // (`class C {}; C.^auth` eq ""), so default to "" rather than
+                // throwing -- same shape as `.^api` below.
+                if let Some(value) = self
+                    .type_metadata
+                    .get(&name)
+                    .and_then(|meta| meta.get("auth").cloned())
+                {
+                    return Ok(Value::str(value.to_string_value()));
+                }
+                Ok(Value::str(String::new()))
             }
             "api" if args.len() == 1 => {
-                let invocant_name = match args[0].view() {
-                    ValueView::Package(name) => name,
-                    ValueView::Instance { class_name, .. } => class_name,
-                    _ => {
-                        return Err(RuntimeError::new(
-                            "X::Method::NotFound: Unknown method value dispatch (fallback disabled): api",
-                        ));
-                    }
+                let name = match args[0].view() {
+                    ValueView::Package(name) => name.resolve(),
+                    ValueView::Instance { class_name, .. } => class_name.resolve(),
+                    _ => value_type_name(&args[0]).to_string(),
                 };
+                // A bare `package` uses PackageHOW, which has no `.^api`.
+                if matches!(
+                    self.registry().package_kinds.get(&name),
+                    Some(crate::ast::PackageKind::Package)
+                ) {
+                    return Err(RuntimeError::new(
+                        "X::Method::NotFound: Unknown method value dispatch (fallback disabled): api",
+                    ));
+                }
                 // A declared `:api(...)` is stored in type_metadata; a type with no
                 // `:api` has an empty-string api in Rakudo (`class C {}; C.^api` eq
                 // ""), so default to "" rather than throwing.
                 if let Some(value) = self
                     .type_metadata
-                    .get(&invocant_name.resolve())
+                    .get(&name)
                     .and_then(|meta| meta.get("api").cloned())
                 {
                     return Ok(Value::str(value.to_string_value()));
@@ -209,20 +269,22 @@ impl Interpreter {
                 Ok(Value::str(String::new()))
             }
             "isa" if args.len() == 2 => {
+                // `.^isa` answers with an Int 1/0 (Rakudo surfaces the nqp
+                // boolean directly), not a Bool.
                 // Allow calling .^isa on an instance: use the instance's class.
                 let class_name = match args[0].view() {
                     ValueView::Package(name) => name,
                     ValueView::Instance { class_name, .. } => class_name,
-                    _ => return Ok(Value::FALSE),
+                    _ => return Ok(Value::int(0)),
                 };
                 let other_name = match args[1].view() {
                     ValueView::Package(name) => name,
                     ValueView::Instance { class_name, .. } => class_name,
-                    _ => return Ok(Value::FALSE),
+                    _ => return Ok(Value::int(0)),
                 };
                 let is_same = class_name == other_name;
                 if is_same {
-                    return Ok(Value::TRUE);
+                    return Ok(Value::int(1));
                 }
                 let class_resolved = class_name.resolve();
                 let other_resolved = other_name.resolve();
@@ -236,7 +298,7 @@ impl Interpreter {
                 {
                     loop {
                         if base == other_resolved {
-                            return Ok(Value::TRUE);
+                            return Ok(Value::int(1));
                         }
                         let Some(parent_base) =
                             self.registry().subsets.get(&base).map(|s| s.base.clone())
@@ -250,8 +312,8 @@ impl Interpreter {
                     }
                 }
                 let mro = self.class_mro(&class_name.resolve());
-                Ok(Value::truth(
-                    mro.iter().any(|p| p.as_str() == other_resolved),
+                Ok(Value::int(
+                    mro.iter().any(|p| p.as_str() == other_resolved) as i64
                 ))
             }
             "mro" if !args.is_empty() => {

--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -315,6 +315,7 @@ impl Interpreter {
         if matches!(
             method_name,
             "name"
+                | "shortname"
                 | "ver"
                 | "auth"
                 | "api"

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -33,6 +33,7 @@ impl Interpreter {
                 | "archetypes"
                 | "nominalize"
                 | "name"
+                | "shortname"
                 | "set_name"
                 | "ver"
                 | "auth"

--- a/t/metamodel-shortname-ver-auth.t
+++ b/t/metamodel-shortname-ver-auth.t
@@ -1,0 +1,58 @@
+use v6;
+use Test;
+
+# Metamodel accessors that were missing or over-strict (PLAN 8.6 residue):
+# `.^shortname` did not exist at all, and `.^ver`/`.^auth`/`.^api` threw
+# X::Method::NotFound for builtin types, plain values, and undeclared
+# modules/roles/enums where Rakudo answers v6.c / Mu / "".
+
+plan 22;
+
+# --- .^shortname (Metamodel::Naming) ---
+class Foo { class Bar {} }
+is Foo.^shortname, 'Foo', 'shortname of a top-level class is its name';
+is Foo::Bar.^shortname, 'Bar', 'shortname drops the package qualifier';
+is Int.^shortname, 'Int', 'shortname of a builtin type';
+is 42.^shortname, 'Int', 'shortname on a plain value uses its type';
+
+module M2 { class Deep::X {} }
+is M2::Deep::X.^shortname, 'X', 'shortname drops every qualifier level';
+
+role R3[::T] {}
+is R3.^shortname, 'R3', 'shortname of a role';
+is R3[M2::Deep::X].^shortname, 'R3[X]',
+    'shortname shortens qualified names inside type args too';
+is Set[Str].^shortname, 'Set[Str]', 'parameterized builtin keeps its args';
+
+enum ShortE <se-a se-b>;
+is ShortE.^shortname, 'ShortE', 'shortname of an enum';
+subset ShortS of Int;
+is ShortS.^shortname, 'ShortS', 'shortname of a subset';
+
+# --- .^ver ---
+# Core-setting language versions surface as plain Strs in Rakudo
+# (Int.^ver.WHAT is Str); only a declared :ver adverb is a Version.
+is-deeply Int.^ver, '6.c', 'builtin type .^ver is the Str "6.c"';
+is-deeply 42.^ver, '6.c', '.^ver on a plain value is the Str "6.c"';
+module UnverM { }
+ok UnverM.^ver === Mu, 'unversioned module .^ver is Mu';
+role UnverR { }
+ok UnverR.^ver === Mu, 'unversioned role .^ver is Mu';
+enum UnverE <ue-a ue-b>;
+ok UnverE.^ver === Mu, 'unversioned enum .^ver is Mu';
+
+# --- .^auth ---
+class NoAuth { }
+is NoAuth.^auth, '', 'class with no :auth has empty-string auth';
+is 42.^auth, '', '.^auth on a plain value is empty string';
+module NoAuthM { }
+is NoAuthM.^auth, '', 'module with no :auth has empty-string auth';
+class WithAuth:auth<github:me> { }
+is WithAuth.^auth, 'github:me', 'declared :auth is still returned';
+
+# --- .^api on a plain value ---
+is 42.^api, '', '.^api on a plain value is empty string';
+
+# --- .^isa returns the nqp boolean as an Int, matching Rakudo ---
+is-deeply Foo.^isa(Any), 1, '.^isa answers with Int 1';
+is-deeply Foo.^isa(ShortE), 0, '.^isa answers with Int 0';


### PR DESCRIPTION
## Summary

PLAN 8.6 residue sweep — metamodel accessors that were missing or over-strict, found by diffing mutsu against raku on `.WHO`/`.HOW`-adjacent introspection:

- **`.^shortname` (Metamodel::Naming) did not exist at all** (threw "No such method"). Implemented as the type name with every `Foo::` qualifier dropped, including inside `[...]` type args (`Foo::Bar` → `Bar`, `R[M2::N]` → `R[N]`), matching Rakudo. Added to both ClassHOW method whitelists (`is_classhow_method`, `classhow_find_method`).
- **`.^ver` threw for builtin types and plain values** (`Int.^ver`, `42.^ver`); now answers the Str `"6.c"`. Core-setting language versions are **Strs** in Rakudo (`Int.^ver.WHAT` is `Str`), not Version objects — the subset and Grammar paths now also return Strs. Only a declared `:ver(...)` adverb produces a real Version. Unversioned modules/roles/enums answer `Mu` instead of throwing. Bare `package` still throws (PackageHOW has no ver — pinned by `t/package-module-how.t`).
- **`.^auth` threw unless `:auth` was declared**; now answers `""` for any undeclared type/value, same shape as `.^api`. Bare `package` throws, matching PackageHOW.
- **`.^api` on a plain value** (`42.^api`) threw; now answers `""`. Bare `package` now throws (was `""`), matching Rakudo.
- **`.^isa` returned Bool**; Rakudo surfaces the nqp boolean as Int `1`/`0` (`Foo.^isa(Any).WHAT` is `(Int)`).

Remaining 8.6 leftovers (anon-class display name; Rakudo-internal stash contents / HOW mixin rendering) recorded in PLAN.md.

## Test plan

- New pin: `t/metamodel-shortname-ver-auth.t` (22 tests) — **verified to pass under `raku` as well**.
- Related pins green: `t/meta-api.t`, `t/package-module-how.t`, `t/class-version-meta-and-default.t`, `t/grammar-meta-mro.t`, `t/metamodel-classhow.t`, `t/who-stash.t`.
- All whitelisted roast files using `.^ver`/`.^auth`/`.^isa`/`.^api`/`.^shortname` pass: `S02-types/subset-6e.t`, `S04-exception-handlers/catch.t`, `S05-grammar/parse_and_parsefile-6e.t`, `S12-introspection/meta-class.t`, `S14-roles/basic.t`, `S32-num/rat.t`.
- `make test` green locally; full roast delegated to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)