### PR TITLE
fix: sigilless-parameter scoping — destructured params shadow term constants; single for-param no longer leaks its local slot

### DIFF
--- a/docs/doc-diff-backlog.md
+++ b/docs/doc-diff-backlog.md
@@ -221,26 +221,36 @@ intentionally deferred; see PLAN.md §8.5 and the ADRs:
 
 - **Sigilless-parameter scoping (`py-nutshell.rakudoc`)** — a sigilless binding
   shadowing the `i` term constant is fixed for `my \i` reads and single
-  `-> \i { }` pointy params (#5113), but three sub-cases remain, each on a
-  distinct binding path:
-  - `-> (\i, \j) { i + j }` — the **destructuring** sub-signature path
-    (`__subsig__` + nested `sub_signature` param defs) does not emit the
-    `MarkSigillessReadonly` marker, so `i` still resolves to the imaginary
-    unit. Symmetric fix = inject the marker for each `pd.sigilless` sub-param
-    when compiling the destructuring body.
-  - `for 1,2,3 -> \x { }; say x` — the for-loop sigilless **param leaks** to the
-    outer `\x` binding (gives `3`, not the outer `10`): the single-param
-    save/restore in `vm_for_loop_body.rs` does not restore a sigilless outer
-    binding of the same bare name.
-  - `for ^5 -> \x { block-capturing x }` — a for-loop sigilless param is **not
-    visible** in a nested closure (`Cannot convert string to number '⏏x'`); the
-    nested block does not capture the sigilless loop param.
-  - Also (`py-nutshell` [5] line 1): `{ $_[0] + $_[1] }` over `X`-crossed list
-    topics returns blank — `$_[N]` indexing a list topic is a separate bug.
-  - Minor pre-existing parser-scope leak surfaced while pinning: a source-level
-    `my \i` registers `i` as a user term symbol whose registration leaks past
-    its block, so a later bare `i` in the same unit mis-parses (`-> \i` does not
-    leak; only the `my \i` VarDecl form).
+  `-> \i { }` pointy params (#5113). **Mostly resolved** as of 2026-07-23; pin
+  `t/sigilless-param-scoping.t`:
+  - **Fixed** — `-> (\i, \j) { i + j }` (destructuring): `compile_closure_body`
+    now allocates the `sub_signature` sigilless sub-params as sigilless locals
+    and prepends a `MarkSigillessReadonly` prologue per sigilless sub-param, so a
+    bare-word read resolves the binding, not the imaginary unit. Routine
+    destructure (`sub f((\i,\j))`) is covered by the same
+    `alloc_sub_signature_locals` sigilless registration.
+  - **Fixed** — `for 1,2,3 -> \x { }; say x` (single for-param leak): this was
+    NOT sigilless-specific — a sigiled `for ... -> $x` reusing an outer `my $x`
+    leaked too. The single-param restore only touched env, not the compile-time
+    local *slot* that the loop overwrote each iteration. The
+    `for_param_restore_stack` entry now carries the colliding local slot
+    (`spec.param_local`), and `RestoreForParam` writes the saved value back
+    through it (both the array-source and int-range loop paths). LAST/post
+    phasers still see the final value (restore stays deferred).
+  - **Already worked** — `for ^5 -> \x { block-capturing x }` (nested-closure
+    capture) and `py-nutshell` [5] `{ $_[0] + $_[1] }` over an `X`-crossed list
+    topic both pass on current `main`; no change needed.
+  - **Still deferred (1 niche case, compiler local-scope leak)** —
+    `{ my \i = 5 }; say i` should revert `i` to the imaginary unit after the
+    block, but a bare-block `my \i` leaks its `local_map`/`sigilless_locals`
+    registration past the block, so the outer `say i` compiles to `GetLocal`
+    (the now-Nil block slot) instead of `GetBareWord` (which would reach the
+    imaginary-unit fallback). This is the general compiler bare-block
+    local-scope leak — for a *sigiled* `{ my $x }; say $x` it surfaces only as a
+    runtime "not declared" (vs raku's compile-time), and `i` is the sole name
+    whose term fallback the leak observably suppresses. Fixing it means scoping
+    the compiler's `local_map`/`sigilless_locals` per bare block (broad blast
+    radius), so it is left for a dedicated pass.
 - **List-infix (`Z`/`X`/meta/infix-func) comma precedence** — `operators.rakudoc`
   [24] (`say 100, 200 Z+ 42, 23` → raku `(142 223)`; `1, 2 Z 3, 4` → `((1 3) (2 4))`).
   `Z`/`X` are **looser than comma** in Raku, so the comma list on each side is the

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -8,11 +8,42 @@ impl Compiler {
         for sp in sub_params {
             if !sp.name.is_empty() {
                 compiler.declare_param(&sp.name);
+                // A sigilless destructured sub-param (`-> (\i, \j) { i + j }`) IS the
+                // bare word within the body, so it must shadow a same-named term
+                // constant (e.g. the imaginary unit `i`). Register it like the
+                // single-pointy-param path does, so BareWord resolves to GetLocal.
+                if sp.sigilless {
+                    compiler.sigilless_locals.insert(sp.name.clone());
+                }
             }
             if let Some(nested) = &sp.sub_signature {
                 Self::alloc_sub_signature_locals(compiler, nested);
             }
         }
+    }
+
+    /// Collect `MarkSigillessReadonly` prologue statements for every sigilless
+    /// destructured sub-param (`-> (\i, \j)`), so a bare-word read of the name
+    /// inside the body resolves the binding rather than a same-named term
+    /// constant. Recurses into nested sub-signatures.
+    fn collect_sigilless_subsig_markers(param_defs: &[crate::ast::ParamDef]) -> Vec<Stmt> {
+        fn walk(sub_params: &[crate::ast::ParamDef], out: &mut Vec<Stmt>) {
+            for sp in sub_params {
+                if sp.sigilless && !sp.name.is_empty() {
+                    out.push(Stmt::MarkSigillessReadonly(sp.name.clone()));
+                }
+                if let Some(nested) = &sp.sub_signature {
+                    walk(nested, out);
+                }
+            }
+        }
+        let mut out = Vec::new();
+        for pd in param_defs {
+            if let Some(sub_params) = &pd.sub_signature {
+                walk(sub_params, &mut out);
+            }
+        }
+        out
     }
 
     /// Convert `Stmt::Call`'s `Vec<CallArg>` to `Vec<Expr>` for expression-level
@@ -678,7 +709,31 @@ impl Compiler {
                     sub_compiler.sigilless_locals.insert(pd.name.clone());
                 }
             }
+            // A destructured sub-signature param (`-> (\i, \j) { i + j }`) carries
+            // its real bindings in `sub_signature`. A sigilless sub-param IS the
+            // bare word in the body and must shadow a same-named term constant
+            // (e.g. the imaginary unit `i`); register those names so BareWord
+            // resolves to the binding, not the constant.
+            if let Some(sub_params) = &pd.sub_signature {
+                Self::alloc_sub_signature_locals(&mut sub_compiler, sub_params);
+            }
         }
+        // The destructure bind statements are prepended to the body at runtime by
+        // by-name assignment (not into the freshly-allocated local slots), so a
+        // sigilless sub-param read still routes through GetBareWord. Emit a
+        // `MarkSigillessReadonly` marker for each sigilless sub-param so that
+        // GetBareWord's `i`/`NaN`-term guard sees a sigilless binding and falls
+        // through to the env value instead of the term constant.
+        let subsig_markers = Self::collect_sigilless_subsig_markers(param_defs);
+        let augmented_body: Vec<Stmt>;
+        let body: &[Stmt] = if subsig_markers.is_empty() {
+            body
+        } else {
+            let mut v = subsig_markers;
+            v.extend_from_slice(body);
+            augmented_body = v;
+            &augmented_body
+        };
         // Bake the positional-param → slot map now, while `local_map` still holds
         // exactly the parameter slots (before the body can shadow them). §1.5.
         sub_compiler.record_param_local_slots(params, param_defs);

--- a/src/runtime/gc_roots.rs
+++ b/src/runtime/gc_roots.rs
@@ -70,7 +70,7 @@ impl Interpreter {
         if let Some((_, v, _)) = &self.element_source {
             visitor.visit_value(v);
         }
-        for (_, v) in &self.for_param_restore_stack {
+        for (_, v, _) in &self.for_param_restore_stack {
             visit_opt(visitor, v);
         }
         for frame in &self.call_frames {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1415,7 +1415,14 @@ pub struct Interpreter {
     pub(crate) topic_container_source: Option<String>,
     pub(crate) element_source: Option<(String, Value, bool)>,
     pub(crate) quanthash_bind_params: Vec<String>,
-    pub(crate) for_param_restore_stack: Vec<(String, Option<Value>)>,
+    /// Deferred restore of a single named for-loop param's prior binding, applied
+    /// by `RestoreForParam` after the loop's LAST/post phasers. Tuple is
+    /// `(name, saved_env_value, colliding_local_slot)`: the slot is `Some` when
+    /// the loop param shares a compile-time local slot with an enclosing binding
+    /// of the same bare name (`my \x = 10; for ... -> \x { }`), so the restore
+    /// must write the saved value back through that slot too — otherwise a later
+    /// `GetLocal` read of the outer name sees the loop's last iteration value.
+    pub(crate) for_param_restore_stack: Vec<(String, Option<Value>, Option<u32>)>,
     pub(crate) call_frames: Vec<crate::vm::VmCallFrame>,
     /// Active CONTROL handlers on the dynamic call stack (one per executing
     /// `CONTROL { }` block). Kept in lock-step with `control_handler_depth` so

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -3539,7 +3539,19 @@ impl Interpreter {
                 // that the loop's LAST/post phasers (which needed the param at
                 // its final value) have run. Paired with the push the ForLoop
                 // opcode performs on normal completion.
-                if let Some((name, saved_val)) = self.for_param_restore_stack.pop() {
+                if let Some((name, saved_val, colliding_slot)) = self.for_param_restore_stack.pop()
+                {
+                    // A loop param that shares a compile-time local slot with an
+                    // enclosing binding of the same bare name overwrote that slot
+                    // each iteration; write the saved value back through it too so
+                    // a later `GetLocal` read of the outer name (`my \x = 10; for
+                    // ... -> \x {}; say x`) sees the restored outer value, not the
+                    // loop's last iteration value.
+                    if let Some(slot) = colliding_slot
+                        && (slot as usize) < self.locals.len()
+                    {
+                        self.locals[slot as usize] = saved_val.clone().unwrap_or(Value::NIL);
+                    }
                     match saved_val {
                         Some(v) => {
                             self.env_mut().insert(name, v);

--- a/src/vm/vm_for_loop_body.rs
+++ b/src/vm/vm_for_loop_body.rs
@@ -169,10 +169,16 @@ impl Interpreter {
         // loop's binding of that name (the env keys these by bare name). Skip
         // `@`/`%` sigils, which bind a shared mutable container the body may
         // legitimately reassign, and skip the rw case (handled via writeback).
-        let saved_param: Option<(String, Option<Value>)> = param_name
+        let saved_param: Option<(String, Option<Value>, Option<u32>)> = param_name
             .as_ref()
             .filter(|n| !n.starts_with('@') && !n.starts_with('%'))
-            .map(|name| (name.clone(), self.env().get(name).cloned()));
+            .map(|name| {
+                (
+                    name.clone(),
+                    self.env().get(name).cloned(),
+                    spec.param_local,
+                )
+            });
         // Track loop-body declarations for per-iteration closure capture
         // (owned_captures). Balanced by pop on every exit.
         self.push_loop_local_scope();

--- a/src/vm/vm_for_loop_intrange.rs
+++ b/src/vm/vm_for_loop_intrange.rs
@@ -38,10 +38,16 @@ impl Interpreter {
         // restored after the loop's LAST/post phasers via the `RestoreForParam`
         // opcode (the compiler emits it for any single non-@/% named param), so
         // the push below must balance that pop on normal completion.
-        let saved_param: Option<(String, Option<Value>)> = param_name
+        let saved_param: Option<(String, Option<Value>, Option<u32>)> = param_name
             .as_ref()
             .filter(|n| !n.starts_with('@') && !n.starts_with('%'))
-            .map(|name| (name.clone(), self.env().get(name).cloned()));
+            .map(|name| {
+                (
+                    name.clone(),
+                    self.env().get(name).cloned(),
+                    spec.param_local,
+                )
+            });
 
         // Track loop-body declarations so closures created in the body capture
         // them per-iteration (owned_captures). Balanced by pop on every exit.

--- a/t/sigilless-param-scoping.t
+++ b/t/sigilless-param-scoping.t
@@ -1,0 +1,81 @@
+use v6;
+use Test;
+
+# Sigilless-parameter scoping (doc-diff backlog: py-nutshell.rakudoc).
+# A sigilless binding must shadow a same-named term constant (e.g. the imaginary
+# unit `i`) within its scope, and a single named for-loop param must not leak its
+# value to an enclosing binding of the same bare name.
+
+plan 14;
+
+# --- Destructuring sub-signature sigilless params shadow the `i` term ---
+# `-> (\i, \j)` binds `i`/`j` as bare-word readonly names; inside the body `i`
+# must be the bound value, not the imaginary unit.
+is (-> (\i, \j) { i + j })((3, 4)), 7, 'pointy destructure sigilless shadows i';
+is (-> (\i, \j) { i + j })((1, 2)), 3, 'pointy destructure sigilless sums bound';
+
+# Nested destructuring.
+is (-> (\a, (\b, \c)) { a + b + c })((1, (2, 3))), 6, 'nested destructure sigilless';
+
+# A source-level `my \i` also shadows the term for the destructured params.
+{
+    my \i = 42;
+    is (-> (\i, \j) { i + j })((1, 2)), 3, 'destructure shadows outer sigilless too';
+}
+
+# Routine (non-pointy) destructuring sigilless params.
+sub add-pair((\i, \j)) { i + j }
+is add-pair((3, 4)), 7, 'routine destructure sigilless shadows i';
+
+# Plain (non-destructured) sigilless routine params still work.
+sub add2(\i, \j) { i + j }
+is add2(3, 4), 7, 'plain sigilless routine params shadow i';
+
+# Sigiled destructuring is unaffected.
+is (-> ($a, $b) { $a + $b })((3, 4)), 7, 'sigiled destructure unchanged';
+
+# --- Single named for-loop param must not leak to an outer binding ---
+{
+    my \x = 10;
+    for 1, 2, 3 -> \x { }
+    is x, 10, 'sigilless for-param does not leak to outer \x';
+}
+
+{
+    my $x = 10;
+    for 1, 2, 3 -> $x { }
+    is $x, 10, 'sigiled for-param does not leak to outer $x';
+}
+
+# Int-range for-loop path (a separate VM loop implementation).
+{
+    my $x = 10;
+    for 1 .. 3 -> $x { }
+    is $x, 10, 'int-range for-param does not leak to outer $x';
+}
+
+# Nested loops reusing the same name restore correctly.
+{
+    my $i = 99;
+    for 1 .. 2 -> $i {
+        for 10, 20 -> $i { }
+    }
+    is $i, 99, 'nested for-loops reusing a name restore the outer';
+}
+
+# A LAST phaser must still observe the param at its final iteration value
+# (the restore is deferred until after the loop's LAST/post phasers).
+{
+    my @seen;
+    for 1, 2 -> $x { LAST { @seen.push($x) } }
+    is-deeply @seen, [2], 'LAST phaser sees the final for-param value';
+}
+
+# The loop param genuinely binds each element inside the body.
+{
+    my @collected;
+    my \x = 10;
+    for 1, 2, 3 -> \x { @collected.push(x) }
+    is-deeply @collected, [1, 2, 3], 'sigilless for-param binds each element';
+    is x, 10, 'outer \x still intact after the collecting loop';
+}


### PR DESCRIPTION
## Summary

doc-diff backlog item **"Sigilless-parameter scoping" (`py-nutshell.rakudoc`)**. Two divergences from reference raku fixed:

### 1. Destructuring sigilless params shadow a term constant
`(-> (\i, \j) { i + j })((3,4))` returned `4+1i` (the `i` bound word resolved to the imaginary unit) instead of `7`. The pointy closure-body compiler never registered the `sub_signature` sub-params as sigilless locals, so a bare-word read fell through to the term constant.

**Fix:** `compile_closure_body` now allocates the sigilless `sub_signature` sub-params as sigilless locals (via `alloc_sub_signature_locals`, which also newly covers the routine `sub f((\i,\j))` path) and prepends a `MarkSigillessReadonly` prologue per sigilless sub-param, so `has_sigilless_binding` reroutes the read to the binding.

### 2. Single named for-loop param no longer leaks its local slot
`my \x = 10; for 1,2,3 -> \x { }; say x` printed `3` (the loop's last value) instead of the outer `10`. This was **not** sigilless-specific — a sigiled `for ... -> $x` reusing an outer `my $x` leaked too. The deferred single-param restore only rewrote the env binding, not the compile-time local *slot* the loop overwrote each iteration; a later `GetLocal` read saw the stale value.

**Fix:** the `for_param_restore_stack` entry now carries the colliding local slot (`spec.param_local`); `RestoreForParam` writes the saved value back through it, on both the array-source and int-range loop paths. LAST/post phasers still observe the final value (restore stays deferred).

## Already-passing / deferred sub-cases
- Nested-closure capture (`for ^5 -> \x { { x } }`) and the `$_[N]` list-topic index (`py-nutshell` [5]) already pass on `main` — no change needed.
- `{ my \i = 5 }; say i` (revert `i` to the imaginary unit after the block) stays deferred: it's a compiler bare-block `local_map`/`sigilless_locals` scope leak (`i` compiles to `GetLocal` of the now-Nil block slot instead of `GetBareWord`), a broad change left for a dedicated pass. Documented in `docs/doc-diff-backlog.md`.

## Testing
- Pin: `t/sigilless-param-scoping.t` (14 assertions)
- `make test` green (22234 tests)
- Targeted roast: `S06-signature/unpack-array.t`, `unpack-object.t`, `S04-statements/for.t`, `S06-signature/positional-placeholders.t`, `S12-construction/roles-6e.t` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)