### PR TITLE
feat: anon sub NAME keeps its .name; Sub gist/Str/raku match Rakudo forms

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1278,22 +1278,6 @@ Both items landed (pins `t/produce-last.t`, `t/reduce-destructuring-signature.t`
 `news/2026-07.md`). Kept note: `rotor(3, 'a'..'h')` as a *function* is `v6.e.PREVIEW`-only; the
 reference `raku` (6.d) also `SORRY`s on it, so it is not a divergence — do not chase.
 
-### 8.13 A `sub NAME { }` used as an *expression* loses its `.name` — mostly done 2026-07-23
-
-The main behaviors landed WITHOUT the feared ~66-site `Expr::AnonSub` field addition: the
-expression-form named sub now parses through the statement sub-decl parser and wraps in
-`Expr::DoStmt(Stmt::SubDecl)` — the compiler's existing do-expr `SubDecl` arm (added for
-`my sub foo {...}`) registers the routine and loads `&NAME` as the value. That gives
-`.name` == "foo" AND the raku-correct lexical install (`&foo` / `foo()` work after
-`my $s = sub foo {...}`, which the old AnonSub lowering also lacked). Pin:
-`t/sub-expression-name.t`.
-
-- [ ] **Leftovers (small):** `anon sub NAME {...}` still drops the name (it must NOT
-      install, so it keeps the AnonSub lowering — needs a name-carrying mechanism or a
-      register-then-remove trick); and a *named* Sub's `.gist` should render `&foo`
-      (mutsu renders the long `sub foo () { ... }` form; anonymous subs gist `sub { }`
-      in raku and that part matches).
-
 ### 8.14 `state` variables in feed-lowered `map` blocks collide across blocks — ✅ DONE 2026-07-23
 
 Fixed exactly along the mapped route: `load_state_locals`/`sync_state_locals`(`_in_range`)

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -98,6 +98,22 @@ and `(sub baz {2}).name` / `my &g = sub bar {3}` all match raku. Leftovers recor
 §8.13: `anon sub NAME` (must not install; still nameless) and the named-Sub `&foo` gist
 form. Pin: `t/sub-expression-name.t`.
 
+## 2026-07-23: `anon sub NAME` keeps its name, and Sub gist/Str/raku match Rakudo (closes PLAN §8.13)
+
+The two §8.13 leftovers, raku-verified. **`anon sub NAME {...}`** now parses through
+the statement sub-decl parser (like the plain expression form) with an `__anon_decl`
+custom-trait marker; the compiler's do-expr arm sees the marker and compiles the body
+straight to `MakeAnonSubParams` — pooling the original `Stmt::SubDecl`, whose `name`
+the VM now stamps into `SubData` — WITHOUT registering/installing `&NAME`. So
+`.name` is "foo", the value stays callable, and an enclosing same-named sub is not
+clobbered. (Self-reference by name inside the body errors — same as raku 2022.12.)
+**Sub rendering** (`methods_sub.rs`) now decides Block-vs-Sub by `is_bare_block`
+instead of name-emptiness, and matches Rakudo's forms: named Sub gists `&name`
+(previously the long `sub name () {...}` form), anonymous subs gist `sub { }`
+(previously the pointy `-> () {...}` Block form), `.Str` is the bare name, and
+`.raku` omits an empty signature (`sub foo { #`(Sub|N) ... }`). Pointy/bare blocks
+keep the `-> sig { #`(Block|N) ... }` form. Pin: `t/anon-sub-name-gist.t`.
+
 ## 2026-07-23: produce with `last`/`next`, and reduce with a destructuring signature (closes PLAN §8.12)
 
 Both §8.12 items, raku-verified. **`.produce` with `last`** no longer throws

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -616,6 +616,14 @@ impl Compiler {
                     self.compile_expr(&Expr::Var(name.clone()));
                 }
             }
+            // `anon sub NAME ... {...}` (marked `__anon_decl` by the parser):
+            // build the routine value carrying its declared name WITHOUT
+            // registering `&NAME` in the enclosing scope.
+            Stmt::SubDecl { custom_traits, .. }
+                if custom_traits.iter().any(|(t, _)| t == "__anon_decl") =>
+            {
+                self.compile_anon_named_sub_decl(stmt);
+            }
             Stmt::SubDecl {
                 name,
                 name_expr: None,

--- a/src/compiler/expr_closure.rs
+++ b/src/compiler/expr_closure.rs
@@ -114,6 +114,41 @@ impl Compiler {
         }
     }
 
+    /// Compile `anon sub NAME ... { ... }` (a `Stmt::SubDecl` marked
+    /// `__anon_decl` by the parser): compile the routine body and emit
+    /// `MakeAnonSubParams` with the original decl (which carries the name)
+    /// so the built `SubData` keeps `.name` — without registering or
+    /// installing `&NAME` in the enclosing scope.
+    pub(super) fn compile_anon_named_sub_decl(&mut self, stmt: &Stmt) {
+        let Stmt::SubDecl {
+            params,
+            param_defs,
+            body,
+            ..
+        } = stmt
+        else {
+            return;
+        };
+        if let Some(err_val) = self.check_placeholder_conflicts(params, body, None) {
+            let idx = self.code.add_constant(err_val);
+            self.code.emit(OpCode::LoadConst(idx));
+            self.code.emit(OpCode::Die);
+            return;
+        }
+        if let Some(err_val) = Self::check_native_readonly_param_assignment(param_defs, body) {
+            let idx = self.code.add_constant(err_val);
+            self.code.emit(OpCode::LoadConst(idx));
+            self.code.emit(OpCode::Die);
+            return;
+        }
+        let compiled = self.compile_routine_closure_body(params, param_defs, body);
+        let esc = self.escaping_position;
+        let cc_idx = self.add_closure_code_baked(compiled, esc);
+        let idx = self.code.add_stmt(stmt.clone());
+        self.code
+            .emit(OpCode::MakeAnonSubParams(idx, Some(cc_idx), false));
+    }
+
     /// Compile AnonSubParams expression.
     pub(super) fn compile_expr_anon_sub_params(
         &mut self,

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -687,34 +687,18 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                 }
                 // `anon sub NAME(...) { ... }` / `anon sub NAME { ... }` — a named
                 // anonymous sub in expression context (e.g. `(&f = anon sub g($x)
-                // {...})($y)`). The name allows self-reference; `anon` means it is
-                // not installed in the enclosing namespace. Mirrors the named-sub
-                // handling in the plain `"sub"` case below.
-                if let Ok((r_named, _name)) = crate::parser::stmt::parse_sub_name_pub(r_sub) {
-                    let (r_named, _) = ws(r_named)?;
-                    if r_named.starts_with('(') {
-                        let (r, params_body) =
-                            parse_anon_sub_with_params(r_named).map_err(|err| PError {
-                                messages: merge_expected_messages(
-                                    "expected anonymous sub parameter list/body",
-                                    &err.messages,
-                                ),
-                                remaining_len: err.remaining_len.or(Some(r_named.len())),
-                                exception: None,
-                            })?;
-                        return Ok((r, params_body));
+                // {...})($y)`). The name is kept on the routine (`.name`, gist
+                // `&NAME`) but `anon` means it is NOT installed in the enclosing
+                // namespace. Parse the full declaration like the plain named-sub
+                // expression form below, and mark it `__anon_decl` so the
+                // compiler builds the value without registering it.
+                if crate::parser::stmt::parse_sub_name_pub(r_sub).is_ok()
+                    && let Ok((r_decl, mut stmt)) = crate::parser::stmt::sub_decl_body_pub(r_sub)
+                {
+                    if let Stmt::SubDecl { custom_traits, .. } = &mut stmt {
+                        custom_traits.push(("__anon_decl".to_string(), None));
                     }
-                    if r_named.starts_with('{') {
-                        let (r, body) = parse_block_body(r_named)?;
-                        return Ok((
-                            r,
-                            Expr::AnonSub {
-                                body,
-                                is_rw: false,
-                                is_block: false,
-                            },
-                        ));
-                    }
+                    return Ok((r_decl, Expr::DoStmt(Box::new(stmt))));
                 }
             } else if let Ok((r_type, type_name)) =
                 crate::parser::parse_result::take_while1(r_ws, |c: char| {

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -676,28 +676,45 @@ impl Interpreter {
             };
             let name = data.name.resolve();
             let id = data.id;
-            if method == "gist" || method == "Str" {
-                if name.is_empty() || name == "<anon>" {
-                    return Some(Ok(Value::str(format!(
-                        "-> {} {{ #`(Block|{}) ... }}",
-                        sig_gist, id
-                    ))));
-                }
-                return Some(Ok(Value::str(format!(
-                    "sub {} {} {{ #`(Sub|{}) ... }}",
-                    name, sig_gist, id
-                ))));
-            }
-            // .raku / .perl
-            if name.is_empty() || name == "<anon>" {
+            let is_anon = name.is_empty() || name == "<anon>";
+            // Bare/pointy blocks are `Block`s: `-> sig { #`(Block|id) ... }`
+            // for gist/Str/raku alike (an anon *sub* is a `Sub` even without
+            // a name, so blockness is decided by is_bare_block, not the name).
+            if data.is_bare_block {
                 return Some(Ok(Value::str(format!(
                     "-> {} {{ #`(Block|{}) ... }}",
                     sig_gist, id
                 ))));
             }
+            if method == "gist" {
+                // Rakudo: a named Sub gists as `&name`; an anonymous sub as
+                // `sub { }` (the signature is not shown).
+                if is_anon {
+                    return Some(Ok(Value::str_from("sub { }")));
+                }
+                return Some(Ok(Value::str(format!("&{}", name))));
+            }
+            if method == "Str" {
+                // Rakudo: Code.Str is the routine's name (with a coercion
+                // warning, which mutsu does not emit).
+                return Some(Ok(Value::str(name.to_string())));
+            }
+            // .raku / .perl — an empty signature is omitted entirely:
+            // `sub foo { ... }`, `sub ($x) { ... }`, `sub { ... }`.
+            let sig_part = if sig_gist == "()" {
+                String::new()
+            } else {
+                format!("{} ", sig_gist)
+            };
+            if is_anon {
+                return Some(Ok(Value::str(format!(
+                    "sub {}{{ #`(Sub|{}) ... }}",
+                    sig_part, id
+                ))));
+            }
             return Some(Ok(Value::str(format!(
-                "sub {} {} {{ #`(Sub|{}) ... }}",
-                name, sig_gist, id
+                "sub {} {}{{ #`(Sub|{}) ... }}",
+                name, sig_part, id
             ))));
         }
         if method == "line" && args.is_empty() {

--- a/src/vm/vm_register_ops.rs
+++ b/src/vm/vm_register_ops.rs
@@ -182,6 +182,7 @@ impl Interpreter {
     ) -> Result<(), RuntimeError> {
         let stmt = &code.stmt_pool[idx as usize];
         if let Stmt::SubDecl {
+            name,
             params,
             param_defs,
             return_type,
@@ -221,7 +222,9 @@ impl Interpreter {
                 .or_else(|| self.current_source_line());
             let val = Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
                 package: Symbol::intern(&self.current_package()),
-                name: Symbol::intern(""),
+                // Anonymous closures pool a SubDecl with an empty name; a
+                // named `anon sub NAME` decl carries its name through here.
+                name: *name,
                 params: params.clone(),
                 param_defs: param_defs.clone(),
                 body: body.clone(),

--- a/t/anon-sub-name-gist.t
+++ b/t/anon-sub-name-gist.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+plan 14;
+
+# PLAN §8.13 leftovers: `anon sub NAME {...}` keeps its .name without
+# installing `&NAME`, and Sub gist/Str/raku render the Rakudo forms.
+
+my $s = anon sub foo { 42 };
+is $s.name, 'foo', 'anon sub NAME keeps its .name';
+is $s.(), 42, 'anon sub is callable';
+is $s.gist, '&foo', 'named Sub gists as &name';
+like $s.raku, /^ 'sub foo { #`(Sub|' \d+ ') ... }' $/, 'named Sub .raku form';
+
+my $t = anon sub add($x, $y) { $x + $y };
+is $t.name, 'add', 'anon sub with params keeps its .name';
+is $t.(2, 3), 5, 'anon sub with params is callable';
+
+# `anon` must NOT install the name in the enclosing scope.
+eval-dies-ok 'my $a = anon sub nowhere-installed { 1 }; nowhere-installed()',
+    'anon sub name is not installed';
+sub outer { 'outer' }
+my $shadow = anon sub outer { 'anon' };
+is outer(), 'outer', 'anon sub does not clobber an existing same-named sub';
+is $shadow.(), 'anon', 'the anon value itself stays callable';
+
+# Sub rendering forms (Rakudo-compatible).
+sub named-here { }
+is &named-here.gist, '&named-here', 'a declared sub gists as &name';
+is &named-here.Str, 'named-here', 'Sub.Str is the bare name';
+is (sub { }).gist, 'sub { }', 'anonymous sub gists as sub { }';
+like (sub ($x) { }).raku, /^ 'sub ($x) { #`(Sub|' \d+ ') ... }' $/,
+    'anonymous sub .raku keeps its signature';
+like (sub { }).raku, /^ 'sub { #`(Sub|' \d+ ') ... }' $/,
+    'anonymous sub .raku omits an empty signature';
+
+done-testing;


### PR DESCRIPTION
## Summary

Closes PLAN §8.13's two leftovers (raku-verified):

**1. `anon sub NAME {...}` keeps its `.name` without installing `&NAME`.**
The parser now routes the named-anon form through the statement sub-decl parser (like the plain `sub NAME` expression form, #5254) and marks the `Stmt::SubDecl` with an `__anon_decl` custom trait. The compiler's do-expr arm sees the marker and compiles the body straight to `MakeAnonSubParams`, pooling the original decl — whose `name` the VM now stamps into `SubData` — without any registration/installation. So:

- `(anon sub foo { 42 }).name` is `"foo"`, the value is callable
- `foo()` afterwards stays an unknown-routine error (raku: compile-time error)
- an enclosing `sub foo` is not clobbered
- self-reference by name inside the body errors, same as raku 2022.12

This avoids the feared `Expr::AnonSub` name-field addition entirely (no AST change).

**2. Sub `gist`/`Str`/`raku` now match Rakudo's forms.** `methods_sub.rs` decides Block-vs-Sub by `is_bare_block` instead of name-emptiness:

| expr | before | after (= raku) |
|---|---|---|
| `&foo.gist` | `sub foo () { #`(Sub\|N) ... }` | `&foo` |
| `(sub {}).gist` | `-> () { #`(Block\|N) ... }` | `sub { }` |
| `&foo.Str` | long form | `foo` |
| `&foo.raku` | `sub foo () { … }` | `sub foo { #`(Sub\|N) ... }` (empty sig omitted) |
| `(-> $x {}).gist` | `-> ($x) { #`(Block\|N) ... }` | unchanged |

## Testing

- New pin `t/anon-sub-name-gist.t` (14 tests) — passes under mutsu **and** raku
- `make test`: all 2349 files / 22252 tests pass
- All 92 whitelisted `roast/S06-*` files pass, plus the whitelisted `anon sub` users (`integration/advent2012-day02.t`, `S02-lexical-conventions/pod-in-multi-line-exprs.t`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)