### PR TITLE
fix: sub-form pop/shift on empty array throws X::Cannot::Empty in sink context

### DIFF
--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2166,7 +2166,11 @@ impl Compiler {
                         quoted: false,
                     };
                     self.compile_expr(&method_call);
-                    self.code.emit(OpCode::Pop);
+                    // Sink context: a method-call statement (`foo($obj:);`,
+                    // i.e. `$obj.foo();`) sinks its value, and sinking an
+                    // unhandled Failure throws. `true` = the value is a fresh
+                    // rvalue that may run a user-defined `sink` method.
+                    self.code.emit(OpCode::SinkPop(true));
                     return;
                 }
 
@@ -2191,7 +2195,13 @@ impl Compiler {
                         args: expr_args,
                     };
                     self.compile_expr(&call_expr);
-                    self.code.emit(OpCode::Pop);
+                    // Sink context: a bare call statement sinks its value, so a
+                    // returned unhandled Failure throws (e.g. `pop @a;` /
+                    // `shift @a;` on an empty array — Raku's X::Cannot::Empty).
+                    // `false` = a function-call return is not auto-`sink`ed
+                    // (Raku keeps it container-wrapped); only Failure/lazy
+                    // handling applies. Matches the method form `@a.pop;`.
+                    self.code.emit(OpCode::SinkPop(false));
                     return;
                 }
 

--- a/t/pop-shift-sub-empty-failure.t
+++ b/t/pop-shift-sub-empty-failure.t
@@ -1,0 +1,45 @@
+use Test;
+
+# A bare `pop @a;` / `shift @a;` statement (the listop/sub form) on an empty
+# array sinks its return value in sink context. Sinking the resulting Failure
+# throws X::Cannot::Empty — matching the method form `@a.pop;` / `@a.shift;`.
+# Regression: the sub form compiled to a plain `Pop` (silent discard) instead
+# of `SinkPop`, so the Failure vanished. (Trailing `True` keeps the mutating
+# call in non-tail / sink position.)
+
+plan 9;
+
+# --- sub form throws in sink context ---
+throws-like { my @a; pop @a; True },   X::Cannot::Empty, 'pop @a; on empty throws in sink context';
+throws-like { my @a; shift @a; True }, X::Cannot::Empty, 'shift @a; on empty throws in sink context';
+
+# --- method form still throws (unchanged) ---
+throws-like { my @a; @a.pop; True },   X::Cannot::Empty, '@a.pop; on empty throws (method form, unchanged)';
+
+# --- assigning the Failure does not throw; it is a Failure value ---
+{
+    my @a;
+    my $x = pop @a;
+    is $x.WHAT.^name, 'Failure', 'assigned pop-of-empty is a Failure (not thrown when captured)';
+    nok $x.defined, 'the captured Failure is undefined';
+}
+
+# --- non-empty sub-form pop/shift still work and mutate ---
+{
+    my @a = 1, 2, 3;
+    pop @a;
+    is @a, [1, 2], 'pop @a; on non-empty mutates in place';
+    shift @a;
+    is @a, [2], 'shift @a; on non-empty mutates in place';
+}
+
+# --- push/unshift sub form still work (never Failure) ---
+{
+    my @a;
+    push @a, 10, 20;
+    unshift @a, 5;
+    is @a, [5, 10, 20], 'push/unshift @a; still work as statements';
+}
+
+# --- a non-tail non-empty pop does not throw (Failure only on empty) ---
+lives-ok { my @a = 1, 2; pop @a; True }, 'non-empty pop in sink position does not throw';


### PR DESCRIPTION
## Problem

A bare `pop @a;` / `shift @a;` statement (the listop/sub form) on an empty array silently discarded its result, while the method form `@a.pop;` correctly threw `X::Cannot::Empty` (per `Type/Array.rakudoc`).

```raku
my @a; pop @a; put "after";   # mutsu: prints "after"  |  raku: dies X::Cannot::Empty
my @a; @a.pop; put "after";   # both: dies X::Cannot::Empty
```

## Root cause

Both forms return a `Failure`. The difference was purely in statement compilation:

- `@a.pop;` is a `Stmt::Expr(MethodCall)` → emits `OpCode::SinkPop`, which sinks the value and **throws an unhandled Failure** (Raku sink-context semantics).
- `pop @a;` is a `Stmt::Call` routed through the normalized-stmt-call path → emitted a plain `OpCode::Pop`, which just **discards** the value with no Failure check.

## Fix

Emit `SinkPop` (not `Pop`) for statement-level normalized calls (`pop`/`shift`/`push`/`unshift`/… and imported functions) in `src/compiler/stmt.rs`:

- `SinkPop(false)` for the function-call path — a plain return is not auto-`sink`ed (Raku keeps it container-wrapped), only Failure/lazy handling applies.
- `SinkPop(true)` for the invocant-colon method form (`foo($obj:);`), consistent with `$obj.foo();`.

Non-Failure returns are still discarded; only sunk Failures throw. `push`/`unshift` (never return a Failure) are unaffected.

## Testing

- New pin: `t/pop-shift-sub-empty-failure.t` (9 subtests, matches raku).
- `make test`: PASS.
- Whitelisted array-mutation roast (`pop/push/shift/unshift/splice/create/elems/end.t`, 633 tests): PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)