### PR TITLE
feat: anonymous class/grammar/role display as <anon|N> like Rakudo

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1194,11 +1194,10 @@ the backlog.
       any undeclared type/value (bare `package` still throws — PackageHOW has no
       ver/auth/api); `.^isa` returns the nqp-boolean Int 1/0 like Rakudo, not Bool.
       Pin: `t/metamodel-shortname-ver-auth.t`.
-- [ ] **Leftover (doable, small):** anonymous class display name — mutsu names anon classes
-      `__ANON_CLASS_0__` where raku shows `<anon|1>` (visible via `.^name`, `.^shortname`,
-      `say (class :: {})`). The internal name is also the registry key, so the fix is a
-      display-layer mapping (`user_facing_type_name` returns `&str` today and would need to
-      allocate) or renaming the generated key — check `is_internal_anon_type_name` callers.
+- [x] **Anonymous class display name** — done 2026-07-23: `__ANON_{CLASS,GRAMMAR,ROLE}_N__`
+      now display as Rakudo's `<anon|N+1>` via `user_facing_type_name` (returns `Cow` now),
+      covering `.^name`/`.^shortname`/gist/raku/say/`.WHICH`/X::Method::NotFound; anonymous
+      enums keep the empty display name. Pin: `t/anon-class-display-name.t`.
 - [ ] **Leftover (Rakudo-metamodel-internal, cosmetic):** the *content* of a builtin type's
       stash — raku's `Array.WHO` lists implementation subclasses
       `{:Element(Array::Element), :Shaped(Array::Shaped), ...}` that do not exist in mutsu —

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -114,6 +114,20 @@ instead of name-emptiness, and matches Rakudo's forms: named Sub gists `&name`
 `.raku` omits an empty signature (`sub foo { #`(Sub|N) ... }`). Pointy/bare blocks
 keep the `-> sig { #`(Block|N) ... }` form. Pin: `t/anon-sub-name-gist.t`.
 
+## 2026-07-23: anonymous class/grammar/role display as `<anon|N>` (PLAN §8.6 leftover)
+
+Anonymous types were shown by their internal registry name (`__ANON_CLASS_0__`) where
+Rakudo shows `<anon|1>`. The internal name doubles as the registry key, so the fix is a
+pure display-layer mapping: `user_facing_type_name` (already the central display hook,
+now returning `Cow<'_, str>`) maps `__ANON_{CLASS,GRAMMAR,ROLE}_N__` → `<anon|N+1>`
+(the number is arbitrary in Rakudo too — only distinctness matters). That one change
+covered `.^name`, `.^shortname`, gist/raku/say for type objects and instances, and
+`dd`; `.WHICH` (Instance/Package/CustomType arms) and the `X::Method::NotFound`
+message/typename needed the same mapping applied at their format sites (registry
+lookups keep the raw name). Anonymous *enums* deliberately keep the empty display name
+(raku shows `()`), so the mapping matches only the three type kinds. Pin:
+`t/anon-class-display-name.t` (passes under raku too).
+
 ## 2026-07-23: produce with `last`/`next`, and reduce with a destructuring signature (closes PLAN §8.12)
 
 Both §8.12 items, raku-verified. **`.produce` with `last`** no longer throws

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -362,9 +362,17 @@ pub(super) fn dispatch(
                     | ValueView::GenericRange { .. }
             );
             let which_str = match target.view() {
-                ValueView::Package(name) => format!("{}|U{}", name.resolve(), name.id()),
+                ValueView::Package(name) => format!(
+                    "{}|U{}",
+                    crate::value::user_facing_type_name(&name.resolve()),
+                    name.id()
+                ),
                 ValueView::CustomType(c) => {
-                    format!("{}|U{}", c.name.resolve(), c.id)
+                    format!(
+                        "{}|U{}",
+                        crate::value::user_facing_type_name(&c.name.resolve()),
+                        c.id
+                    )
                 }
                 ValueView::Int(n) => format!("Int|{}", n),
                 ValueView::BigInt(n) => format!("Int|{}", *n),
@@ -437,7 +445,13 @@ pub(super) fn dispatch(
                     format!("Regex|{:p}", Arc::as_ptr(&a.pattern))
                 }
                 ValueView::Instance { class_name, id, .. } => {
-                    format!("{}|{}", class_name.resolve(), id)
+                    // Anonymous classes display as `<anon|N>` (the instance id
+                    // keeps the identity unique).
+                    format!(
+                        "{}|{}",
+                        crate::value::user_facing_type_name(&class_name.resolve()),
+                        id
+                    )
                 }
                 ValueView::Junction { kind, values } => {
                     use std::hash::{Hash, Hasher};

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -429,7 +429,7 @@ pub(super) fn dispatch(
             let resolved = name.resolve();
             let full = crate::value::user_facing_type_name(&resolved);
             if method == "gist" {
-                let short = full.rsplit("::").next().unwrap_or(full);
+                let short = full.rsplit("::").next().unwrap_or(&full);
                 Some(Ok(Value::str(format!("({})", short))))
             } else {
                 // .raku returns the full type name

--- a/src/runtime/methods_signature_errors.rs
+++ b/src/runtime/methods_signature_errors.rs
@@ -57,15 +57,18 @@ pub(super) fn make_method_not_found_error(
 ) -> RuntimeError {
     use super::did_you_mean::{known_methods_for_type, suggest_method};
 
+    // Display the user-facing type name (`<anon|N>` for anonymous
+    // class/grammar/role); registry lookups below keep the raw name.
+    let display_type = crate::value::user_facing_type_name(type_name);
     let mut msg = if private {
         format!(
             "No such private method '{}' for invocant of type '{}'",
-            method_name, type_name
+            method_name, display_type
         )
     } else {
         format!(
             "No such method '{}' for invocant of type '{}'",
-            method_name, type_name
+            method_name, display_type
         )
     };
 
@@ -79,7 +82,7 @@ pub(super) fn make_method_not_found_error(
 
     let mut attrs = std::collections::HashMap::new();
     attrs.insert("method".to_string(), Value::str(method_name.to_string()));
-    attrs.insert("typename".to_string(), Value::str(type_name.to_string()));
+    attrs.insert("typename".to_string(), Value::str(display_type.to_string()));
     attrs.insert("private".to_string(), Value::truth(private));
     attrs.insert("message".to_string(), Value::str(msg.clone()));
     let ex = Value::make_instance(Symbol::intern("X::Method::NotFound"), attrs);

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -6,17 +6,36 @@ pub(crate) fn is_internal_anon_type_name(name: &str) -> bool {
     name.starts_with("__ANON_") && name.ends_with("__")
 }
 
+/// An anonymous `class`/`grammar`/`role` is registered under an internal
+/// `__ANON_<KIND>_<N>__` name; Rakudo displays these as `<anon|N>` (the
+/// number is arbitrary, only distinct within a run). Returns the display
+/// form for those three kinds; anonymous enums (whose type displays as the
+/// empty name) and internal non-type `__ANON_*` markers return None.
+fn anon_type_display_name(name: &str) -> Option<String> {
+    let inner = name.strip_suffix("__")?;
+    let n = ["__ANON_CLASS_", "__ANON_GRAMMAR_", "__ANON_ROLE_"]
+        .iter()
+        .find_map(|prefix| inner.strip_prefix(prefix))?;
+    let n: u64 = n.parse().ok()?;
+    Some(format!("<anon|{}>", n + 1))
+}
+
 /// A lexically-scoped `my class`/`my role` whose bare name collides with an
 /// earlier same-named lexical declaration is stored in the registry under a
 /// mangled internal name `Foo\u{0}<site-id>` so its instances keep their own
 /// identity (see `exec_register_class_op`). The `\u{0}` separator can never
 /// appear in a source identifier, so the user-facing name is just everything
-/// before it. This is a pure function so `display.rs` (which has no interpreter
-/// context) can strip the suffix for `.gist`/`.raku`/`say`.
-pub(crate) fn user_facing_type_name(name: &str) -> &str {
-    match name.split_once('\u{0}') {
+/// before it. Anonymous class/grammar/role internal names display as
+/// Rakudo's `<anon|N>`. This is a pure function so `display.rs` (which has
+/// no interpreter context) can map the name for `.gist`/`.raku`/`say`.
+pub(crate) fn user_facing_type_name(name: &str) -> std::borrow::Cow<'_, str> {
+    let base = match name.split_once('\u{0}') {
         Some((short, _)) => short,
         None => name,
+    };
+    match anon_type_display_name(base) {
+        Some(display) => std::borrow::Cow::Owned(display),
+        None => std::borrow::Cow::Borrowed(base),
     }
 }
 

--- a/t/anon-class-display-name.t
+++ b/t/anon-class-display-name.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+plan 12;
+
+# PLAN §8.6 leftover: anonymous class/grammar/role display as Rakudo's
+# `<anon|N>` (N is arbitrary — only distinctness matters), not the internal
+# `__ANON_CLASS_0__` registry name.
+
+my $c = class :: {};
+like $c.^name, /^ '<anon|' \d+ '>' $/, 'anon class .^name is <anon|N>';
+like $c.^shortname, /^ '<anon|' \d+ '>' $/, 'anon class .^shortname is <anon|N>';
+like $c.gist, /^ '(<anon|' \d+ '>)' $/, 'anon class type object gists as (<anon|N>)';
+like $c.raku, /^ '<anon|' \d+ '>' $/, 'anon class .raku is <anon|N>';
+
+my $d = class :: {};
+isnt $d.^name, $c.^name, 'two anon classes get distinct display names';
+
+my $i = $c.new;
+like $i.^name, /^ '<anon|' \d+ '>' $/, 'anon class instance .^name is <anon|N>';
+like $i.gist, /^ '<anon|' \d+ '>.new' $/, 'anon class instance gists as <anon|N>.new';
+like $i.WHICH.gist, /^ '<anon|' \d+ '>|' /, 'instance .WHICH uses the display name';
+like $c.WHICH.gist, /^ '<anon|' \d+ '>|U' /, 'type object .WHICH uses the display name';
+
+throws-like { $i.nosuchmethod }, X::Method::NotFound,
+    message => /"No such method 'nosuchmethod' for invocant of type '<anon|" \d+ ">'"/,
+    'method-not-found names the anon class as <anon|N>';
+
+like (grammar {}).^name, /^ '<anon|' \d+ '>' $/, 'anon grammar .^name is <anon|N>';
+like (role {}).^name, /^ '<anon|' \d+ '>' $/, 'anon role .^name is <anon|N>';
+
+done-testing;


### PR DESCRIPTION
## Summary

Closes the PLAN §8.6 "anonymous class display name" leftover (user-directed).

Anonymous types were shown by their internal registry name (`__ANON_CLASS_0__`) where Rakudo shows `<anon|1>`. The internal name doubles as the registry key, so this is a pure **display-layer** mapping — no registry/lookup changes:

- `user_facing_type_name` (the central display hook) now returns `Cow<'_, str>` and maps `__ANON_{CLASS,GRAMMAR,ROLE}_N__` → `<anon|N+1>`. The number is arbitrary in Rakudo too; only distinctness matters, and the pin test does not pin exact numbers.
- That one change covers `.^name`, `.^shortname`, gist/raku/say for type objects and instances, and `dd`.
- The `.WHICH` arms (Instance/Package/CustomType) and the `X::Method::NotFound` message/`typename` attribute apply the same mapping at their format sites; `known_methods_for_type` and other registry lookups keep the raw name.
- Anonymous **enums** deliberately keep the empty display name (raku shows `()`), so the mapping matches only the three type kinds.

```raku
my $c = class :: {};
say $c.^name;      # <anon|1>   (was __ANON_CLASS_0__)
say $c.new;        # <anon|1>.new
say $c.new.WHICH;  # <anon|1>|25
$c.new.nosuch;     # No such method 'nosuch' for invocant of type '<anon|1>'
```

## Testing

- New pin `t/anon-class-display-name.t` (12 tests) — passes under mutsu **and** raku
- `make test`: all 22279 tests pass
- Whitelisted `roast/S12-class/anonymous.t`, `roast/S12-class/basic.t`, `roast/S14-roles/basic.t` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)