### PR TITLE
fix: lazy gather .elems/.Int/.Numeric throw X::Cannot::Lazy

### DIFF
--- a/src/builtins/methods_0arg/dispatch_core_numeric.rs
+++ b/src/builtins/methods_0arg/dispatch_core_numeric.rs
@@ -74,12 +74,22 @@ pub(super) fn dispatch(
     match method {
         "elems" => {
             if let ValueView::LazyList(list) = target.view() {
-                if matches!(
+                let from_gather = matches!(
                     list.env
                         .get("__mutsu_lazylist_from_gather")
                         .map(Value::view),
                     Some(ValueView::Bool(true))
-                ) {
+                );
+                // A plain `gather {...}` Seq is not lazy (raku: `.is-lazy` is
+                // False), so `.elems` reifies and counts. A `lazy gather` (or
+                // `gather.lazy`) is `lazy`-forced -- it carries the preserve-lazy
+                // marker -- and `.elems` must throw X::Cannot::Lazy like any
+                // other lazy list, rather than eagerly reifying.
+                let forced_lazy = list
+                    .env
+                    .get("__mutsu_preserve_lazy_on_array_assign")
+                    .is_some();
+                if from_gather && !forced_lazy {
                     return Some(None);
                 }
                 let mut ex_attrs = std::collections::HashMap::new();

--- a/src/value/value_lazy.rs
+++ b/src/value/value_lazy.rs
@@ -213,7 +213,7 @@ impl LazyList {
 
     /// Whether this list carries the `lazy` prefix marker (set by the `lazy`
     /// statement prefix / `.lazy` method).
-    fn is_lazy_marked(&self) -> bool {
+    pub(crate) fn is_lazy_marked(&self) -> bool {
         matches!(
             self.env
                 .get("__mutsu_preserve_lazy_on_array_assign")

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -603,10 +603,13 @@ impl Interpreter {
                 && (ll.lazy_pipe.is_some() || ll.is_infinite_spec() || ll.is_from_gather() || ll.cat_pull.is_some()))
             && !((ll.lazy_pipe.is_some() || ll.is_infinite_spec())
                 && Self::lazy_pipe_preserving_coercion(&method))
-            // On an infinite sequence/closure spec the count/numeric coercions
-            // produce a *soft* X::Cannot::Lazy Failure (recoverable with `//`),
-            // emitted by the 0-arg native dispatch — they must not be hard-forced.
-            && !(ll.is_infinite_spec() && matches!(method.as_str(), "elems" | "Int" | "Numeric"))
+            // On an infinite sequence/closure spec — OR an explicitly `lazy`-marked
+            // (`lazy gather {…}`) list — the count/numeric coercions produce a
+            // *soft* X::Cannot::Lazy Failure (recoverable with `//`), emitted by
+            // the 0-arg native dispatch — they must not be hard-forced/reified.
+            // A plain (non-`lazy`) finite gather stays forceable and reifies.
+            && !((ll.is_infinite_spec() || ll.is_lazy_marked())
+                && matches!(method.as_str(), "elems" | "Int" | "Numeric"))
         {
             let saved_env = self.env().clone();
             // `.head(n)` only needs the first `n` elements: pull them lazily so

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -973,10 +973,13 @@ impl Interpreter {
             && !((ll.lazy_pipe.is_some() || ll.is_infinite_spec())
                 && Self::lazy_pipe_preserving_coercion(method)
                 && !ll.pipe_bottoms_out_finite())
-            // On an infinite sequence/closure spec the count/numeric coercions
-            // produce a *soft* X::Cannot::Lazy Failure (recoverable with `//`),
-            // emitted by the 0-arg native dispatch — they must not be hard-forced.
-            && !(ll.is_infinite_spec() && matches!(method, "elems" | "Int" | "Numeric"))
+            // On an infinite sequence/closure spec — OR an explicitly `lazy`-marked
+            // (`lazy gather {…}`) list — the count/numeric coercions produce a
+            // *soft* X::Cannot::Lazy Failure (recoverable with `//`), emitted by
+            // the 0-arg native dispatch — they must not be hard-forced/reified.
+            // A plain (non-`lazy`) finite gather stays forceable and reifies.
+            && !((ll.is_infinite_spec() || ll.is_lazy_marked())
+                && matches!(method, "elems" | "Int" | "Numeric"))
         {
             let saved_env = self.env().clone();
             // `.head(n)` only needs the first `n` elements: pull them lazily so

--- a/t/lazy-gather-elems-cannot-lazy.t
+++ b/t/lazy-gather-elems-cannot-lazy.t
@@ -1,0 +1,54 @@
+use Test;
+
+# A `lazy gather {...}` Seq (or `gather {...}.lazy`) is lazy: count/numeric
+# coercions (`.elems`, `.Int`, `.Numeric`) throw X::Cannot::Lazy (a soft
+# Failure, recoverable with `//`). A plain `gather {...}` Seq is NOT lazy:
+# `.elems` reifies and counts.
+#
+# Regression: mutsu exempted every gather-backed Seq from the X::Cannot::Lazy
+# check via the `__mutsu_lazylist_from_gather` marker, so `lazy gather.elems`
+# eagerly reified and returned a count instead of throwing. The `lazy` prefix
+# (`gather.lazy`) is now distinguished by the preserve-lazy marker, and the VM
+# force-reify path skips it for count/numeric coercions.
+
+plan 10;
+
+# --- plain gather: elems reifies and counts ---
+is (gather { take 1; take 2 }).elems, 2, 'plain gather .elems reifies and counts';
+is (gather { take $_ for 1..3 }).elems, 3, 'plain gather over a loop counts';
+
+# --- lazy gather: elems/Int/Numeric throw X::Cannot::Lazy ---
+{
+    my $l = lazy gather { take 1; take 2 };
+    is ((try $l.elems) // $!.^name), 'X::Cannot::Lazy', 'lazy gather .elems throws X::Cannot::Lazy (soft)';
+}
+{
+    my $l = lazy gather { take 1; take 2 };
+    is ((try $l.Int) // $!.^name), 'X::Cannot::Lazy', 'lazy gather .Int throws X::Cannot::Lazy (soft)';
+}
+{
+    my $l = lazy gather { take 1; take 2 };
+    is ((try $l.Numeric) // $!.^name), 'X::Cannot::Lazy', 'lazy gather .Numeric throws X::Cannot::Lazy (soft)';
+}
+
+# --- gather.lazy method form is the same ---
+{
+    my $l = (gather { take 1 }).lazy;
+    is ((try $l.elems) // $!.^name), 'X::Cannot::Lazy', 'gather.lazy .elems throws X::Cannot::Lazy';
+}
+
+# --- a lazy gather assigned directly to @ stays lazy: .elems throws ---
+{
+    my @a = lazy gather { take 1; take 2 };
+    is ((try @a.elems) // $!.^name), 'X::Cannot::Lazy', 'lazy gather assigned to @ keeps .elems lazy';
+}
+
+# --- other lazy-marked lists unaffected ---
+is (lazy 3, 4, 5).is-lazy, True, 'lazy list literal is-lazy True';
+is ((try (lazy 3, 4, 5).elems) // $!.^name), 'X::Cannot::Lazy', 'lazy list literal .elems throws';
+
+# --- reification of a plain gather still works when assigned ---
+{
+    my @r = gather { take 1; take 2; take 3 };
+    is @r, [1, 2, 3], 'plain gather assigned to @ reifies to the right elements';
+}


### PR DESCRIPTION
## Problem

A `lazy gather {...}` Seq (equivalently `gather {...}.lazy`) is lazy in raku: count/numeric coercions throw `X::Cannot::Lazy` (a soft, `//`-recoverable Failure). mutsu instead eagerly reified it and returned a count.

```raku
my $l = lazy gather { take 1; take 2 };
say (try $l.elems) // $!.^name;   # mutsu: 2  |  raku: X::Cannot::Lazy
```

## Root cause

Every gather-backed `LazyList` carries a `__mutsu_lazylist_from_gather` marker, and that marker **unconditionally** exempted the list from the `X::Cannot::Lazy` check in the native 0-arg `.elems` dispatch — so both a plain `gather` (correct: reifies + counts) and a `lazy gather` (wrong: should throw) were reified.

## Fix

A `lazy gather` compiles to `gather.lazy`, and `.lazy` sets the `__mutsu_preserve_lazy_on_array_assign` marker (a plain `gather {...}` has none). Use it to distinguish the two:

- **Native dispatch** (`dispatch_core_numeric.rs`): a from-gather `LazyList` is exempted from the `X::Cannot::Lazy` check only when it is *not* `lazy`-forced.
- **VM method dispatch** (`vm_call_method_ops.rs` / `vm_call_method_mut_ops.rs`): the force-reify guard for `elems`/`Int`/`Numeric` now also skips a `is_lazy_marked()` list, so a `lazy gather` reaches native dispatch (and its soft `X::Cannot::Lazy`) instead of being hard-reified first. Without this the native fix never fires — the VM reifies the Seq before native dispatch runs.

A plain `gather {...}` stays forceable and `.elems` reifies + counts as before. `is_lazy_marked` is promoted to `pub(crate)` for the VM guard.

## Scope note

This fixes the `.elems`/`.Int`/`.Numeric` **throw** behavior (the documented `X::Cannot::Lazy` semantics). A *separate, pre-existing* modeling gap remains and is intentionally left out: `(gather {...}).is-lazy` and `(gather {...}).map(...).is-lazy` wrongly report `True` (raku: `False`) because `is_value_lazy` treats every `LazyList` as lazy and mutsu's `lazy_pipe` does not track whether its source was lazy. A precise `.is-lazy` fix needs source-laziness propagation through the pipe and is deferred.

## Testing

- New pin: `t/lazy-gather-elems-cannot-lazy.t` (10 subtests, matches raku).
- `make test`: PASS (two clean full-`t/` runs; the lazy `.is-lazy` tests are the pre-existing flaky ones described above, verified unrelated to this deterministic change).
- Whitelisted gather/lazy roast (`S02-types/lazy-lists`, `S04-statements/gather`+`lazy`, `integration/gather-*`): PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)