### PR TITLE
fix: IO::Spec instances repr as instances; catdir/catfile flatten list args

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1359,14 +1359,16 @@ and `[Z]`-reduction-returns-a-Seq landed 2026-07-22 (pin `t/repr-residues-2.t`);
       `t/proc-gist-not-exitcode.t`. (The *run*-proc full form with the cyclic
       `(my \Proc_... = ...)` backref through IO::Pipe remains a plain instance form — a deep
       IO::Pipe-repr + backref-naming rabbit hole, out of scope.)
-- [ ] **`IO::Spec::Unix.new.raku` renders the type-object form `IO::Spec::Unix`** and its
-      gist is `(Unix)`; raku renders `IO::Spec::Unix.new` for both. Traced 2026-07-22 as
-      far as: the instance never reaches the generic attribute walk in
-      `methods_instance_ops` (which would render `IO::Spec::Unix.new` correctly) — its
-      gist/raku land in `dispatch_instance_and_fallback`'s tail fallback arms
-      (`_ => to_string_value`), and `.Str` of the instance is empty while `.raku` is the
-      bare class name, so an earlier arm intercepts. Needs a dispatch trace before fixing;
-      cosmetic, low value.
+- [x] **`IO::Spec::Unix.new.raku`/`.gist` rendered the type-object form** — fixed 2026-07-23.
+      The interceptor was the IO::Spec instance→Package method delegation in
+      `methods_instance_ops.rs` (path methods are class methods, so every method call on an
+      IO::Spec instance swapped the invocant for the type object — including gist/raku/Str).
+      Repr methods now stay on the instance and reach the generic attribute walk
+      (`IO::Spec::Unix.new`). Bonus found while testing: `catdir`/`catfile` are slurpy in
+      Rakudo, so a passed list flattens (`$*SPEC.catdir(<a b>)` is `a/b`, was `a b`) —
+      now routed through `flatten_into_slurpy`. `.Str` keeps the generic
+      `IO::Spec::Unix()` form (the Rakudo `<addr>` form is a global divergence, out of
+      scope). Pin: `t/io-spec-instance-repr.t`.
 - [x] **`IO::Path::Parts.raku`/`.gist` drop the constructor arguments** — fixed 2026-07-23.
       Unlike Proc, IO::Path::Parts is a Positional in Rakudo, so its `.raku`/`.gist` render the
       three parts *positionally* (`IO::Path::Parts.new("C:","/some/dir","foo.txt")`, each via its

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -98,6 +98,20 @@ and `(sub baz {2}).name` / `my &g = sub bar {3}` all match raku. Leftovers recor
 §8.13: `anon sub NAME` (must not install; still nameless) and the named-Sub `&foo` gist
 form. Pin: `t/sub-expression-name.t`.
 
+## 2026-07-23: IO::Spec instances repr as instances, and catdir/catfile flatten lists (PLAN §8.15 leftover)
+
+`IO::Spec::Unix.new.gist`/`.raku` rendered the *type object* forms (`(Unix)` /
+`IO::Spec::Unix`) because the IO::Spec instance→Package method delegation in
+`methods_instance_ops.rs` (path methods are class methods) swapped the invocant for
+the type object on EVERY method — including the repr methods. gist/raku/perl/Str/
+Stringy now stay on the instance and reach the generic attribute walk, rendering
+`IO::Spec::Unix.new` like Rakudo; instance path methods (`.canonpath` etc.) still
+delegate. Bonus fix found while testing: `catdir`/`catfile` are slurpy in Rakudo, so
+a passed list flattens (`$*SPEC.catdir(<a b>)` is `a/b`, was the stringified `a b`) —
+both now route args through `flatten_into_slurpy`. `.Str` keeps mutsu's generic
+`IO::Spec::Unix()` instance form (Rakudo's `<addr>` form is a global divergence, out
+of scope). Pin: `t/io-spec-instance-repr.t` (passes under raku too).
+
 ## 2026-07-23: `anon sub NAME` keeps its name, and Sub gist/Str/raku match Rakudo (closes PLAN §8.13)
 
 The two §8.13 leftovers, raku-verified. **`anon sub NAME {...}`** now parses through

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -1324,7 +1324,11 @@ impl Interpreter {
                     }
                     "updir" => return Ok(Value::str_from("..")),
                     "catdir" => {
-                        let parts: Vec<String> = args.iter().map(|a| a.to_string_value()).collect();
+                        // catdir/catfile are slurpy (`*@parts`): a passed list
+                        // (`$*SPEC.catdir(<a b>)`) flattens into its elements.
+                        let mut flat = Vec::new();
+                        crate::runtime::types::flatten_into_slurpy(&args, &mut flat);
+                        let parts: Vec<String> = flat.iter().map(|a| a.to_string_value()).collect();
                         if parts.is_empty() {
                             return Ok(Value::str_from(""));
                         }
@@ -1337,7 +1341,9 @@ impl Interpreter {
                         return Ok(Value::str(result));
                     }
                     "catfile" => {
-                        let parts: Vec<String> = args.iter().map(|a| a.to_string_value()).collect();
+                        let mut flat = Vec::new();
+                        crate::runtime::types::flatten_into_slurpy(&args, &mut flat);
+                        let parts: Vec<String> = flat.iter().map(|a| a.to_string_value()).collect();
                         if is_win32 {
                             return Ok(Value::str(Self::win32_catfile(&parts)));
                         }

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -494,8 +494,13 @@ impl Interpreter {
                 return Ok(Value::truth(result));
             }
 
-            // IO::Spec methods — delegate to Package-based handler
-            if class_name == "IO::Spec" || class_name.resolve().starts_with("IO::Spec::") {
+            // IO::Spec methods — delegate to the Package-based handler (the
+            // path methods are class methods). Repr methods stay on the
+            // instance: `IO::Spec::Unix.new.gist` is `IO::Spec::Unix.new`
+            // (the generic instance repr), not the type object's `(Unix)`.
+            if (class_name == "IO::Spec" || class_name.resolve().starts_with("IO::Spec::"))
+                && !matches!(method, "gist" | "raku" | "perl" | "Str" | "Stringy")
+            {
                 let pkg = Value::package(class_name);
                 return self.call_method_with_values(pkg, method, args);
             }

--- a/t/io-spec-instance-repr.t
+++ b/t/io-spec-instance-repr.t
@@ -1,0 +1,21 @@
+use v6;
+use Test;
+
+plan 8;
+
+# PLAN §8.15 leftover: an IO::Spec::* *instance* reprs as the generic
+# instance form, not the type object's; and catdir/catfile are slurpy.
+
+my $s = IO::Spec::Unix.new;
+is $s.gist, 'IO::Spec::Unix.new', 'IO::Spec::Unix instance gists as .new form';
+is $s.raku, 'IO::Spec::Unix.new', 'IO::Spec::Unix instance .raku is the .new form';
+is $s.canonpath('a//b/'), 'a/b', 'instance path methods still work';
+
+is $*SPEC.gist.substr(0, 1), '(', '$*SPEC is a type object and gists as (...)';
+
+is $*SPEC.catdir(<a b>), 'a/b', 'catdir flattens a passed list';
+is $*SPEC.catdir('a', 'b'), 'a/b', 'catdir with separate args';
+is $*SPEC.catfile(<x y>, 'z.txt'), 'x/y/z.txt', 'catfile flattens a passed list';
+is $*SPEC.catdir(), '', 'catdir with no args is empty';
+
+done-testing;


### PR DESCRIPTION
## Summary

Closes the PLAN §8.15 "IO::Spec::Unix.new repr" leftover.

`IO::Spec::Unix.new.gist`/`.raku` rendered the *type object* forms (`(Unix)` / `IO::Spec::Unix`). Root cause: the IO::Spec instance→Package method delegation in `methods_instance_ops.rs` (path methods are class methods) swapped the invocant for the type object on **every** method — including the repr methods. `gist`/`raku`/`perl`/`Str`/`Stringy` now stay on the instance and reach the generic attribute walk, rendering `IO::Spec::Unix.new` like Rakudo; instance path methods (`.canonpath` etc.) still delegate.

Bonus fix found while testing: `catdir`/`catfile` are slurpy in Rakudo, so a passed list flattens — `$*SPEC.catdir(<a b>)` is now `a/b` (was the stringified `a b`); both route args through the existing `flatten_into_slurpy`.

`.Str` keeps mutsu's generic `IO::Spec::Unix()` instance form (Rakudo's `<addr>` form is a global divergence shared by all classes, out of scope).

## Testing

- New pin `t/io-spec-instance-repr.t` (8 tests) — passes under mutsu **and** raku
- `make test`: all 22299 tests pass (run with these changes applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)