### PR TITLE
feat: turn wasm-demo into a Raku introduction site (landing + bilingual tutorial + playground)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,14 @@ jobs:
       - name: TAP tests (prove t/)
         run: prove -e 'timeout 30 target/debug/mutsu' t/
 
+      - name: Site snippets still produce their documented output
+        # Every code sample shipped on the wasm-demo site (landing highlights +
+        # tutorial lessons) runs under mutsu here and must match the output
+        # recorded next to it. `raku` is not installed on the runner, so the
+        # raku cross-check is skipped and this is a pure regression gate; the
+        # cross-check runs locally when the expectations are regenerated.
+        run: node scripts/check-site-snippets.mjs
+
       - name: Build (release, for roast)
         # The repo sets `[profile.release] debug = true` for local perf
         # profiling. CI never profiles, and full debug info bloats the binary

--- a/PLAN.md
+++ b/PLAN.md
@@ -1401,6 +1401,74 @@ and `[Z]`-reduction-returns-a-Seq landed 2026-07-22 (pin `t/repr-residues-2.t`);
       arguably more useful, and no roast test exercises them. Matching Rakudo here is risky and
       low value; **deferred as an intentional divergence** unless a dist-compat consumer needs it.
 
+### 8.17 `&name` for a proto-less `multi` collapses to one candidate (found 2026-07-23 while writing the tutorial site)
+
+Taking a code reference to a `multi` that has **no explicit `proto`** and then invoking it as a
+value — the ordinary `.map(&f)` / `.grep(&f)` / `.sort(&f)` shape — does not multi-dispatch. It
+either calls one fixed candidate or nothing at all:
+
+```raku
+multi k(Int $n) { "int $n" }
+multi k(Str $s) { "str $s" }
+say (1, "a").map(&k).join(" ");   # raku: "int 1 str a"   mutsu: "1 a"
+
+multi f(Int $n where $n %% 3) { "Fizz" }
+multi f(Int $n)               { ~$n }
+say (1..5).map(&f).join(" ");     # raku: "1 2 Fizz 4 5"  mutsu: "1 2 3 4 5"
+```
+
+Adding `proto k($) {*}` fixes it, and every *direct* call form is already correct
+(`f(3)`, `(&f)(3)`, `my &g = &f; g(3)`, `&f(3)`) — so this is specifically the
+value-carried callable path.
+
+- Route: `Interpreter::resolve_code_var` (`src/runtime/accessors_resolve.rs:302-383`). With a
+  proto it returns a by-name `Value::routine_parts`, which re-dispatches by name and is correct.
+  Without one it takes either the `def.is_some()` arm (a plain-signature candidate is reachable
+  under the unsuffixed `GLOBAL::<name>` key, so `sub_value_from_function_def` hands back that
+  ONE candidate — the `f` case) or, when no unsuffixed key exists, the `is_multi` arm that builds
+  an empty-body dispatcher Sub carrying `__mutsu_multi_dispatch_candidates` (the `k` case, which
+  then produces no output at all). `call_sub_value`
+  (`src/runtime/resolution_call_sub.rs:234-276`) does understand that dispatcher env, so the
+  fault is upstream of it: the value handed out is wrong, and its fallback ladder
+  (`bind_function_args_values` → slurpy → `candidates.first()`) ignores `where` constraints and
+  specificity ordering anyway.
+- **Likely correct fix:** make `resolve_code_var` return the by-name routine value for *any*
+  name with multi candidates (the proto path), rather than materializing a candidate or a
+  synthetic dispatcher. The captured-Sub dispatcher then only needs to survive the
+  out-of-scope case, and should reuse the real specificity-sorted dispatch
+  (`sort_candidates_by_specificity` / `push_multi_dispatch_frame`) instead of its own ladder.
+- **Why it is not a one-liner:** the `is_multi` dispatcher exists precisely so a `&multi-sub`
+  outlives its defining scope, so the by-name value must keep working after the scope exits;
+  and `resolve_code_var` is on the hot path for every `&foo`. Needs a test matrix over
+  proto/no-proto × in-scope/out-of-scope × where-constrained/type-only.
+- Repro kept at `wasm-demo/content/highlights.txt` (`why/multi` uses the direct-call form as a
+  workaround); `scripts/check-site-snippets.mjs` cross-checks against `raku` and would catch a
+  regression the moment the snippet is switched back to `&fizz`.
+
+### 8.18 The WebAssembly build traps on `start` / `Channel` instead of degrading (found 2026-07-23 building the tutorial site)
+
+`start { ... }` reaches `spawn_callable_promise` → `spawn_user_thread` → `std::thread::spawn`
+(`src/runtime/builtins_system.rs:13`), which on `wasm32-unknown-unknown` has no
+implementation and traps. In the browser that surfaces as `RuntimeError: unreachable`,
+which also poisons the whole wasm instance — every later evaluation in that session is
+garbage until the page rebuilds the interpreter.
+
+- Affected: `start`, `Promise` combinators that spawn, `Channel` producers, `Proc::Async`.
+  `react`/`whenever` over a `Supply.from-list` already works (no spawn), as does
+  `gather`/`take`.
+- **Likely correct fix:** on wasm, run a `start` block *synchronously* and return an
+  already-kept (or broken) `Promise`, and give `Channel` the same treatment — a
+  single-threaded scheduler is the honest semantics for a platform with one thread, and it
+  is what a reader of the concurrency chapter would expect to see work. The mechanism is one
+  `#[cfg(target_arch = "wasm32")]` arm in `spawn_callable_promise` plus the equivalent for
+  the channel/supply pumps, but the *semantics* need thought: a `start` that blocks until it
+  finishes changes the observable ordering of any program that relies on interleaving, and
+  `await` on a never-kept promise would deadlock rather than trap.
+- **Not attempted here.** The tutorial marks those two lessons `no-browser` in
+  `wasm-demo/content/lessons.txt`, so the site explains the limitation and shows the
+  recorded native output rather than a trap. Removing those flags is the acceptance test
+  for this item; `wasm-demo/e2e.test.mjs` sweeps every non-flagged lesson in a real browser.
+
 
 ## Metrics
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ A Raku (Perl 6) interpreter written in Rust, using a bytecode VM architecture.
 
 mutsu parses Raku source into an AST, compiles it to bytecode, and executes it on a custom VM. It is under active development and improving rapidly, but is **not yet suitable for production use**.
 
-Try it in your browser: **https://tokuhirom.github.io/mutsu/** (WebAssembly demo)
+Try it in your browser: **https://tokuhirom.github.io/mutsu/** — an introduction to
+Raku (English / 日本語) with a [hands-on tutorial](https://tokuhirom.github.io/mutsu/tutorial.html)
+and a [playground](https://tokuhirom.github.io/mutsu/playground.html), all running
+locally as WebAssembly.
 
 ## Install
 
@@ -284,4 +287,4 @@ See [CLAUDE.md](CLAUDE.md) for development conventions, architecture details, an
 
 - [Raku documentation](https://docs.raku.org/)
 - [Roast (official Raku test suite)](https://github.com/Raku/roast)
-- [WebAssembly demo](https://tokuhirom.github.io/mutsu/)
+- [The mutsu site](https://tokuhirom.github.io/mutsu/) — Raku introduction, tutorial and playground (source in `wasm-demo/`)

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,42 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-23: `wasm-demo/` became a Raku introduction site — landing page, bilingual tutorial, playground
+
+The WebAssembly page was a playground and nothing else. It is now a site whose subject is
+**Raku**, with mutsu as the thing that makes it interactive:
+
+- `index.html` — a landing page arguing why Raku is interesting, with eight runnable
+  highlights (exact rationals, junctions, lazy infinite lists, multiple dispatch, grammars,
+  metaoperators, concurrency, Unicode).
+- `tutorial.html` — a Go-Tour-style tutorial: 9 chapters, 36 lessons, each an editable program
+  that runs in a fresh interpreter. Deep-linkable (`#chapter/lesson`), with per-lesson progress
+  in `localStorage` and the recorded output available as "Expected output".
+- `playground.html` — the previous page, unchanged in behaviour. Old `index.html#code=...`
+  permalinks redirect here and keep working.
+
+Everything is **English and Japanese**, switchable in place (`?lang=`, remembered in
+`localStorage`). Code is shared between the two languages and prose is not: the snippets live
+once in `content/lessons.txt` / `content/highlights.txt` keyed `<chapter>/<lesson>`, and the
+per-language modules supply titles and explanations for the same keys, so a sample can never
+drift between translations.
+
+The tutorial follows the official Raku documentation (Raku/doc, vendored here as `raku-doc/`,
+Artistic License 2.0); the site footer credits it on every page.
+
+The expected-output blocks in the corpora are **generated and cross-checked, not hand-written**:
+`scripts/check-site-snippets.mjs --update` runs every snippet under both `mutsu` and `raku` and
+records an expectation only where the two agree — so the site can only teach behaviour real Raku
+has, and it caught a genuine mutsu bug while the content was being written (recorded as PLAN
+§8.17: `&name` for a proto-less `multi` collapses to one candidate, so `.map(&f)` does not
+multi-dispatch). Without `--update` the script is a regression gate and now runs in CI, which
+also checks that every snippet has prose in both languages. The Playwright suite additionally
+runs *every* lesson in a real browser against its recorded output, so a WASM-only regression
+cannot reach the deployed site unnoticed.
+
+The site stays build-step free (plain HTML + ES modules + CSS); `wasm-demo/README.md` documents
+the layout and how to add a lesson.
+
 ## 2026-07-23: `IO::Path::Parts.raku`/`.gist` render the positional parts (PLAN §8.15)
 
 `IO::Path::Parts.new('C:', '/some/dir', 'foo.txt').raku` (and `.gist`) rendered the bare

--- a/scripts/check-site-snippets.mjs
+++ b/scripts/check-site-snippets.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+//
+// Verifies every code snippet shipped on the static site (wasm-demo/).
+//
+//   node scripts/check-site-snippets.mjs             # check, exit 1 on drift
+//   node scripts/check-site-snippets.mjs --update    # (re)write the expectations
+//
+// Each snippet is run under mutsu.  When `raku` is on PATH it is run there too
+// and the two outputs must agree -- the tutorial is only allowed to teach
+// behaviour that real Raku actually has.  In --update mode an expectation is
+// written only for snippets where both agree (or where raku is unavailable).
+//
+// MUTSU_BIN selects the interpreter (default: target/debug/mutsu).
+
+import { spawnSync } from 'child_process';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+import { parseCorpus, renderCorpus } from '../wasm-demo/assets/corpus.js';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const MUTSU = process.env.MUTSU_BIN || join(ROOT, 'target/debug/mutsu');
+const UPDATE = process.argv.includes('--update');
+const TIMEOUT = 60_000;
+
+const CORPORA = ['wasm-demo/content/lessons.txt', 'wasm-demo/content/highlights.txt'];
+
+const scratch = mkdtempSync(join(tmpdir(), 'mutsu-site-'));
+
+function run(bin, file) {
+  const res = spawnSync(bin, [file], { encoding: 'utf8', timeout: TIMEOUT });
+  if (res.error) return { ok: false, text: `${bin}: ${res.error.message}` };
+  const text = (res.stdout || '') + (res.stderr || '');
+  return { ok: res.status === 0, text: text.replace(/\s+$/, '') };
+}
+
+function haveRaku() {
+  const res = spawnSync('raku', ['--version'], { encoding: 'utf8', timeout: TIMEOUT });
+  return !res.error && res.status === 0;
+}
+
+const RAKU = haveRaku();
+if (!RAKU) console.warn('warning: `raku` not found on PATH -- skipping the cross-check');
+
+let failed = 0;
+let checked = 0;
+
+for (const rel of CORPORA) {
+  const path = join(ROOT, rel);
+  const text = readFileSync(path, 'utf8');
+  const entries = parseCorpus(text);
+  const header = text.slice(0, text.search(/^#== /m));
+  const expectations = new Map();
+
+  console.log(`\n=== ${rel} (${entries.length} snippets)`);
+
+  for (const e of entries) {
+    checked++;
+    const file = join(scratch, `${e.key.replace(/\//g, '-')}.raku`);
+    writeFileSync(file, e.code + '\n');
+
+    const got = run(MUTSU, file);
+    const ref = RAKU ? run('raku', file) : null;
+
+    const problems = [];
+    if (!got.ok) problems.push(`mutsu exited non-zero:\n${indent(got.text)}`);
+    if (ref && !ref.ok) problems.push(`raku exited non-zero:\n${indent(ref.text)}`);
+    if (ref && ref.ok && got.ok && ref.text !== got.text) {
+      problems.push(`mutsu and raku disagree:\n--- raku\n${indent(ref.text)}\n--- mutsu\n${indent(got.text)}`);
+    }
+    if (!problems.length && !UPDATE && e.expect !== got.text) {
+      problems.push(`output drifted from the recorded expectation:\n--- expected\n${indent(e.expect)}\n--- got\n${indent(got.text)}`);
+    }
+
+    if (problems.length) {
+      failed++;
+      console.log(`FAIL ${e.key}`);
+      for (const p of problems) console.log(indent(p, '     '));
+    } else {
+      console.log(`ok   ${e.key}`);
+      expectations.set(e.key, got.text);
+    }
+  }
+
+  if (UPDATE) {
+    writeFileSync(path, renderCorpus(header, entries, expectations));
+    console.log(`updated ${rel}`);
+  }
+}
+
+function indent(text, pad = '       ') {
+  return text.split('\n').map(l => pad + l).join('\n');
+}
+
+rmSync(scratch, { recursive: true, force: true });
+
+/* ------------------------------------------------------------------ *
+ * Every snippet must have prose in every language, and no prose may be
+ * left behind pointing at a snippet that no longer exists.
+ * ------------------------------------------------------------------ */
+
+console.log('\n=== translations');
+
+const LANGS = ['en', 'ja'];
+const tutorial = {};
+const landing = {};
+for (const lang of LANGS) {
+  tutorial[lang] = (await import(`../wasm-demo/content/tutorial.${lang}.js`)).default;
+  landing[lang] = (await import(`../wasm-demo/content/landing.${lang}.js`)).default;
+}
+
+const lessons = parseCorpus(readFileSync(join(ROOT, 'wasm-demo/content/lessons.txt'), 'utf8'));
+const highlights = parseCorpus(readFileSync(join(ROOT, 'wasm-demo/content/highlights.txt'), 'utf8'));
+
+let missing = 0;
+function want(cond, what) {
+  if (!cond) { console.log(`FAIL ${what}`); missing++; }
+}
+
+for (const lang of LANGS) {
+  for (const lesson of lessons) {
+    want(tutorial[lang].lessons[lesson.key], `tutorial.${lang}: no prose for ${lesson.key}`);
+    want(tutorial[lang].chapters[lesson.group], `tutorial.${lang}: no title for chapter ${lesson.group}`);
+  }
+  for (const key of Object.keys(tutorial[lang].lessons)) {
+    want(lessons.some(l => l.key === key), `tutorial.${lang}: prose for unknown lesson ${key}`);
+  }
+  for (const h of highlights) {
+    want(landing[lang].snippets[h.key], `landing.${lang}: no prose for ${h.key}`);
+  }
+  for (const key of Object.keys(landing[lang].snippets)) {
+    want(highlights.some(h => h.key === key), `landing.${lang}: prose for unknown snippet ${key}`);
+  }
+}
+console.log(missing
+  ? `${missing} missing/orphaned translations`
+  : `ok   ${lessons.length} lessons + ${highlights.length} highlights, prose present in ${LANGS.join('/')}`);
+
+console.log(`\n${checked - failed}/${checked} snippets ok`);
+// Snippet drift is what --update exists to fix, so it is not an error there.
+// A missing translation is never regenerable, so it fails either way.
+process.exit(missing || (failed && !UPDATE) ? 1 : 0);

--- a/wasm-demo/README.md
+++ b/wasm-demo/README.md
@@ -1,0 +1,125 @@
+# wasm-demo — the mutsu site
+
+The static site deployed to <https://tokuhirom.github.io/mutsu/> by
+`.github/workflows/pages.yml`. It is an introduction to **Raku**, not just a demo of
+mutsu: a landing page arguing why the language is interesting, a hands-on tutorial,
+and the playground. Every code sample runs locally in the visitor's browser through
+mutsu compiled to WebAssembly — nothing is sent to a server.
+
+The site is deliberately **build-step free**: plain HTML, ES modules and CSS, served
+as-is. The only generated input is `pkg/`, the `wasm-pack` output.
+
+## Layout
+
+```
+index.html          landing page — "why Raku", with runnable highlights
+tutorial.html       the tutorial: chapter/lesson navigation + one runnable lesson
+playground.html     editor + persistent REPL (this used to be index.html)
+assets/
+  site.css          all styling
+  i18n.js           language selection, UI strings, shared nav + footer
+  corpus.js         parser for the .txt snippet corpora (shared with Node)
+  highlight.js      the small Raku syntax highlighter
+  editor.js         textarea + highlight overlay widget
+  runner.js         WASM lifecycle: isolated runs and long-lived REPL sessions
+  snippet.js        editor + Run + output + expected-output widget
+content/
+  lessons.txt       tutorial code and expected output (the corpus)
+  highlights.txt    landing-page code and expected output
+  tutorial.en.js    tutorial titles and prose (English)
+  tutorial.ja.js    tutorial titles and prose (Japanese)
+  landing.en.js     landing-page copy (English)
+  landing.ja.js     landing-page copy (Japanese)
+pkg/                wasm-pack output — generated, git-ignored
+```
+
+## Languages
+
+The site is bilingual (English / Japanese). The picked language lives in
+`localStorage` and in the `?lang=` query parameter, so a shared link keeps the
+language it was read in. Switching re-renders in place; nothing reloads.
+
+**Code is shared between languages, prose is not.** The corpus files hold one copy of
+each snippet, keyed `<chapter>/<lesson>`; the per-language modules supply titles and
+explanations for those same keys. That way a snippet can never drift between the two
+translations, and adding a language means adding prose only.
+
+## The snippet corpora
+
+`content/lessons.txt` and `content/highlights.txt` use one format:
+
+```
+#== basics/hello
+say "Hello, World!";
+#-- expect
+Hello, World!
+```
+
+The `#-- expect` blocks are **generated, not hand-written**:
+
+```sh
+cargo build
+node scripts/check-site-snippets.mjs --update
+```
+
+That runs every snippet under `target/debug/mutsu` *and* under `raku`, and records an
+expectation only when the two agree — so the tutorial can only teach behaviour real
+Raku actually has, and a snippet that mutsu gets wrong is caught while it is being
+written rather than by a reader. Without `--update` the script checks instead of
+writing and exits non-zero on drift; CI runs it that way (`raku` is not on the
+runner, so there it is a pure regression gate).
+
+The tutorial shows the recorded output under "Expected output", compares a run
+against it, and marks the lesson done in the table of contents when they match.
+
+A snippet may carry flags after its key:
+
+```
+#== concurrency/promises no-browser
+```
+
+`no-browser` means "runs natively, but not in the WebAssembly build" — `start` needs
+real OS threads and `wasm32-unknown-unknown` has none, so `std::thread::spawn` traps.
+Those lessons are still checked natively by `check-site-snippets.mjs`; the site
+disables their Run button, explains why, and shows the recorded native output instead
+of a WASM trap. (See PLAN.md §8.18 for the underlying gap.)
+
+## Adding a lesson
+
+1. Add a `#== <chapter>/<id>` block to `content/lessons.txt` at the position it should
+   appear (chapter order follows first appearance).
+2. Add a title and prose under the same key to **both** `content/tutorial.en.js` and
+   `content/tutorial.ja.js`.
+3. `node scripts/check-site-snippets.mjs --update` to record the output.
+4. `node wasm-demo/e2e.test.mjs` to check it in the browser.
+
+Nothing else needs touching: the table of contents, the counters, prev/next, and the
+e2e lesson sweep are all derived from the corpus.
+
+## Running locally
+
+```sh
+wasm-pack build --target web --no-default-features --features wasm
+mv pkg wasm-demo/pkg
+python3 -m http.server 8000 -d wasm-demo    # then open http://localhost:8000/
+```
+
+## Tests
+
+```sh
+node scripts/check-site-snippets.mjs   # every snippet, under mutsu (+ raku if present)
+npm install playwright && npx playwright install chromium
+node wasm-demo/e2e.test.mjs            # the site itself, in a real browser
+SKIP_LESSON_SWEEP=1 node wasm-demo/e2e.test.mjs   # skip the per-lesson sweep
+```
+
+The e2e suite runs **every** tutorial lesson in the browser and compares against the
+recorded expectation, so a WASM-only regression cannot reach the deployed site
+unnoticed.
+
+## Credit
+
+The tutorial and its examples follow the official Raku documentation
+([Raku/doc](https://github.com/Raku/doc)), vendored in this repository as `raku-doc/`
+and used under the Artistic License 2.0. The credit is shown in the site footer on
+every page.

--- a/wasm-demo/assets/corpus.js
+++ b/wasm-demo/assets/corpus.js
@@ -1,0 +1,99 @@
+/**
+ * Parser for the plain-text snippet corpora (content/lessons.txt,
+ * content/highlights.txt).  Shared by the site and by
+ * scripts/check-site-snippets.mjs, so the browser and the verifier can never
+ * disagree about what a snippet is.
+ *
+ * Format:
+ *
+ *     #== <group>/<id> [flag ...]
+ *     <code lines>
+ *     #-- expect
+ *     <expected output lines>
+ *
+ * Anything before the first "#==" is a file comment and is ignored.
+ *
+ * The only flag so far is `no-browser`: the snippet runs natively but not in
+ * the WebAssembly build (`start` needs real threads, which wasm32 has none of),
+ * so the site shows its recorded output instead of offering to run it.
+ */
+
+const START = /^#== +(\S+)((?: +[\w-]+)*)\s*$/;
+const EXPECT = /^#-- expect\s*$/;
+
+/** Drop leading/trailing blank lines, keeping interior ones. */
+function trimBlank(lines) {
+  let a = 0;
+  let b = lines.length;
+  while (a < b && lines[a].trim() === '') a++;
+  while (b > a && lines[b - 1].trim() === '') b--;
+  return lines.slice(a, b);
+}
+
+/**
+ * @returns {Array<{group: string, id: string, key: string, flags: string[],
+ *                  code: string, expect: string}>}
+ */
+export function parseCorpus(text) {
+  const entries = [];
+  let current = null;
+  let target = null;   // 'code' | 'expect'
+
+  for (const line of text.split('\n')) {
+    const start = START.exec(line);
+    if (start) {
+      const key = start[1];
+      const slash = key.indexOf('/');
+      current = {
+        group: slash < 0 ? key : key.slice(0, slash),
+        id: slash < 0 ? key : key.slice(slash + 1),
+        key,
+        flags: start[2].split(/\s+/).filter(Boolean),
+        code: [],
+        expect: [],
+      };
+      entries.push(current);
+      target = 'code';
+      continue;
+    }
+    if (!current) continue;             // file header
+    if (EXPECT.test(line)) { target = 'expect'; continue; }
+    current[target].push(line);
+  }
+
+  return entries.map(e => ({
+    group: e.group,
+    id: e.id,
+    key: e.key,
+    flags: e.flags,
+    code: trimBlank(e.code).join('\n'),
+    expect: trimBlank(e.expect).join('\n'),
+  }));
+}
+
+/** Group parsed entries in file order: [{group, items: [...]}, ...]. */
+export function groupCorpus(entries) {
+  const groups = [];
+  for (const e of entries) {
+    let g = groups.find(g => g.group === e.group);
+    if (!g) groups.push(g = { group: e.group, items: [] });
+    g.items.push(e);
+  }
+  return groups;
+}
+
+/** Re-emit a corpus, replacing every expectation.  Used by --update. */
+export function renderCorpus(header, entries, expectations) {
+  const out = [header.replace(/\n+$/, ''), ''];
+  for (const e of entries) {
+    out.push(`#== ${[e.key, ...(e.flags || [])].join(' ')}`);
+    out.push(e.code);
+    const expect = expectations.get(e.key);
+    if (expect !== undefined && expect !== '') {
+      out.push('#-- expect');
+      out.push(expect);
+    }
+    out.push('');
+  }
+  return out.join('\n');
+}

--- a/wasm-demo/assets/editor.js
+++ b/wasm-demo/assets/editor.js
@@ -1,0 +1,60 @@
+/**
+ * The editable code widget: a transparent <textarea> stacked on a highlighted
+ * <pre>.  Used by the playground, the tutorial, and the landing-page snippets.
+ */
+
+import { highlight } from './highlight.js';
+
+/**
+ * Turn an existing `.editor-wrap` (or a fresh one) into an editor.
+ *
+ * @param {HTMLElement} wrap   element to fill; gets the `editor-wrap` class
+ * @param {object} opts        {code, minHeight, onRun, label}
+ * @returns {{getCode: () => string, setCode: (s: string) => void,
+ *            textarea: HTMLTextAreaElement}}
+ */
+export function createEditor(wrap, opts = {}) {
+  wrap.classList.add('editor-wrap');
+  wrap.textContent = '';
+
+  const pre = document.createElement('pre');
+  pre.setAttribute('aria-hidden', 'true');
+
+  const textarea = document.createElement('textarea');
+  textarea.spellcheck = false;
+  textarea.autocapitalize = 'off';
+  textarea.autocomplete = 'off';
+  textarea.setAttribute('autocorrect', 'off');
+  if (opts.label) textarea.setAttribute('aria-label', opts.label);
+  textarea.style.minHeight = opts.minHeight || '9rem';
+
+  wrap.appendChild(pre);
+  wrap.appendChild(textarea);
+
+  function sync() {
+    // A trailing newline needs a filler so the <pre> keeps the textarea height.
+    pre.innerHTML = highlight(textarea.value) + '\n';
+    pre.scrollTop = textarea.scrollTop;
+    pre.scrollLeft = textarea.scrollLeft;
+  }
+
+  textarea.addEventListener('input', sync);
+  textarea.addEventListener('scroll', () => {
+    pre.scrollTop = textarea.scrollTop;
+    pre.scrollLeft = textarea.scrollLeft;
+  });
+  textarea.addEventListener('keydown', (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && opts.onRun) {
+      e.preventDefault();
+      opts.onRun();
+    }
+  });
+
+  const api = {
+    textarea,
+    getCode: () => textarea.value,
+    setCode: (text) => { textarea.value = text; sync(); },
+  };
+  api.setCode(opts.code || '');
+  return api;
+}

--- a/wasm-demo/assets/highlight.js
+++ b/wasm-demo/assets/highlight.js
@@ -1,0 +1,57 @@
+/**
+ * A deliberately small Raku-flavoured tokenizer: it is a highlighter, not a
+ * parser, so it aims to be right on ordinary code and never to throw.
+ */
+
+const KEYWORDS = new Set([
+  'my', 'our', 'has', 'state', 'let', 'temp', 'constant', 'sub', 'method', 'multi', 'only', 'proto',
+  'submethod', 'class', 'role', 'grammar', 'token', 'rule', 'regex', 'module', 'package', 'enum',
+  'subset', 'unit', 'if', 'elsif', 'else', 'unless', 'with', 'without', 'while', 'until', 'for', 'loop',
+  'repeat', 'given', 'when', 'default', 'return', 'return-rw', 'last', 'next', 'redo', 'do', 'try',
+  'CATCH', 'CONTROL', 'BEGIN', 'END', 'INIT', 'ENTER', 'LEAVE', 'FIRST', 'LAST', 'use', 'need', 'require',
+  'import', 'is', 'does', 'where', 'returns', 'of', 'handles', 'start', 'await', 'react', 'whenever',
+  'supply', 'gather', 'take', 'say', 'print', 'put', 'note', 'die', 'fail', 'so', 'not', 'and', 'or',
+  'andthen', 'orelse', 'xor', 'eq', 'ne', 'lt', 'gt', 'le', 'ge', 'cmp', 'leg', 'x', 'xx', 'div', 'mod',
+  'gcd', 'lcm', 'elem', 'cont', 'self', 'sort', 'map', 'grep', 'first', 'reduce', 'new',
+]);
+
+const TOKEN_RE = new RegExp([
+  /(?<comment>#.*)/,
+  /(?<pod>^=\w+[\s\S]*?^=end\s+\w+$|^=\w+.*$)/,
+  /(?<qstring>\b(?:q|qq|qw|rx|m|s|tr)\s*(?:\:\w+\s*)*[/{|(<[][\s\S]*?[/}|)>\]])/,
+  /(?<string>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|<(?:[^<>\n])*>)/,
+  /(?<number>\b\d[\d_]*(?:\.\d+)?(?:e[-+]?\d+)?\b|\bpi\b|\bInf\b|\bNaN\b)/,
+  /(?<variable>[$@%&][.!^*?:=~]?[\w'-]+|\$[/!_0-9]|\$\^\w+)/,
+  /(?<word>[A-Za-z_][\w-]*)/,
+  /(?<op>[-+*/~%^?!<>=|&.,;:\\()[\]{}]+)/,
+].map(r => r.source).join('|'), 'gm');
+
+export function escapeHtml(s) {
+  return s.replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
+}
+
+export function highlight(src) {
+  let out = '';
+  let last = 0;
+  TOKEN_RE.lastIndex = 0;
+  let m;
+  while ((m = TOKEN_RE.exec(src)) !== null) {
+    if (m.index > last) out += escapeHtml(src.slice(last, m.index));
+    const g = m.groups;
+    const text = escapeHtml(m[0]);
+    if (g.comment || g.pod) out += `<span class="tok-comment">${text}</span>`;
+    else if (g.qstring || g.string) out += `<span class="tok-string">${text}</span>`;
+    else if (g.number) out += `<span class="tok-number">${text}</span>`;
+    else if (g.variable) out += `<span class="tok-var">${text}</span>`;
+    else if (g.word) {
+      if (KEYWORDS.has(m[0])) out += `<span class="tok-keyword">${text}</span>`;
+      else if (/^[A-Z]/.test(m[0])) out += `<span class="tok-type">${text}</span>`;
+      else out += text;
+    } else if (g.op) out += `<span class="tok-op">${text}</span>`;
+    else out += text;
+    last = m.index + m[0].length;
+    if (m[0].length === 0) TOKEN_RE.lastIndex++;   // never loop forever
+  }
+  out += escapeHtml(src.slice(last));
+  return out;
+}

--- a/wasm-demo/assets/i18n.js
+++ b/wasm-demo/assets/i18n.js
@@ -1,0 +1,225 @@
+/**
+ * Language selection and the shared page chrome (nav + footer).
+ *
+ * The picked language lives in localStorage and in the `?lang=` query
+ * parameter, so a shared URL keeps the language it was read in.  Pages listen
+ * for the `langchange` event and re-render; nothing reloads.
+ */
+
+export const LANGS = ['en', 'ja'];
+
+const STRINGS = {
+  en: {
+    'nav.home': 'Home',
+    'nav.tutorial': 'Tutorial',
+    'nav.playground': 'Playground',
+    'nav.bench': 'Benchmarks',
+    'nav.github': 'GitHub',
+
+    'footer.tagline': 'mutsu — a Raku interpreter written in Rust, running here as WebAssembly.',
+    'footer.credit': 'The tutorial and its examples follow the official Raku documentation ' +
+      '(Raku/doc), which this repository vendors as <code>raku-doc/</code> and uses under the ' +
+      'Artistic License 2.0.',
+    'footer.docs': 'Official Raku docs',
+    'footer.doc-repo': 'Raku/doc repository',
+    'footer.repo': 'mutsu on GitHub',
+
+    'run': 'Run ▶',
+    'run.running': 'Running…',
+    'run.loading': 'Loading the interpreter…',
+    'run.hint': 'Ctrl+Enter',
+    'reset': 'Reset code',
+    'output': 'Output',
+    'output.empty': 'Press Run to execute this snippet.',
+    'output.none': '(no output)',
+    'expected.summary': 'Expected output',
+    'verdict.ok': '✓ matches the expected output',
+    'verdict.differs': '≠ differs from the expected output — that is fine while you experiment',
+    'no-browser.note': 'This example needs real OS threads, which the WebAssembly build ' +
+      'does not have — so it cannot run here. The output below is what it prints when ' +
+      'you run it with mutsu (or Rakudo) on your machine.',
+    'no-browser.output': 'Output (recorded from a native run)',
+
+    'lesson.editor': 'Editor',
+    'lesson.prev': '← Previous',
+    'lesson.next': 'Next →',
+    'lesson.of': 'Lesson {n} of {total}',
+
+    'toc.title': 'Contents',
+    'toc.reset-progress': 'Clear progress',
+  },
+  ja: {
+    'nav.home': 'ホーム',
+    'nav.tutorial': 'チュートリアル',
+    'nav.playground': 'プレイグラウンド',
+    'nav.bench': 'ベンチマーク',
+    'nav.github': 'GitHub',
+
+    'footer.tagline': 'mutsu — Rust で書かれた Raku インタプリタ。このページでは WebAssembly として動いています。',
+    'footer.credit': 'チュートリアルと例文は公式 Raku ドキュメント（Raku/doc）を参考にしています。' +
+      '本リポジトリは <code>raku-doc/</code> としてそれを同梱し、Artistic License 2.0 のもとで利用しています。',
+    'footer.docs': '公式 Raku ドキュメント',
+    'footer.doc-repo': 'Raku/doc リポジトリ',
+    'footer.repo': 'mutsu (GitHub)',
+
+    'run': '実行 ▶',
+    'run.running': '実行中…',
+    'run.loading': 'インタプリタを読み込み中…',
+    'run.hint': 'Ctrl+Enter',
+    'reset': 'コードを戻す',
+    'output': '出力',
+    'output.empty': '「実行」を押すとこのコードが動きます。',
+    'output.none': '（出力なし）',
+    'expected.summary': '期待される出力',
+    'verdict.ok': '✓ 期待どおりの出力です',
+    'verdict.differs': '≠ 期待される出力とは違います（自由に書き換えて試している場合はこれで OK）',
+    'no-browser.note': 'この例は本物の OS スレッドを必要とし、WebAssembly 版にはそれがないため、' +
+      'ここでは実行できません。下の出力は、手元の環境で mutsu（または Rakudo）で実行したときのものです。',
+    'no-browser.output': '出力（ネイティブ実行の記録）',
+
+    'lesson.editor': 'エディタ',
+    'lesson.prev': '← 前へ',
+    'lesson.next': '次へ →',
+    'lesson.of': 'レッスン {n} / {total}',
+
+    'toc.title': '目次',
+    'toc.reset-progress': '進捗を消す',
+  },
+};
+
+const STORAGE_KEY = 'mutsu-site-lang';
+
+function detect() {
+  const fromUrl = new URLSearchParams(location.search).get('lang');
+  if (LANGS.includes(fromUrl)) return fromUrl;
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (LANGS.includes(saved)) return saved;
+  } catch { /* private mode */ }
+  return (navigator.language || 'en').toLowerCase().startsWith('ja') ? 'ja' : 'en';
+}
+
+let lang = detect();
+
+export function currentLang() {
+  return lang;
+}
+
+export function setLang(next) {
+  if (!LANGS.includes(next) || next === lang) return;
+  lang = next;
+  try { localStorage.setItem(STORAGE_KEY, next); } catch { /* private mode */ }
+  const url = new URL(location.href);
+  url.searchParams.set('lang', next);
+  history.replaceState(null, '', url);
+  document.documentElement.lang = next;
+  window.dispatchEvent(new CustomEvent('langchange', { detail: next }));
+}
+
+/** Look up a UI string, with `{name}` placeholders. */
+export function t(key, vars) {
+  let s = (STRINGS[lang] && STRINGS[lang][key]) ?? STRINGS.en[key] ?? key;
+  if (vars) for (const [k, v] of Object.entries(vars)) s = s.replaceAll(`{${k}}`, v);
+  return s;
+}
+
+/** Keep in-page links on the current language. */
+export function langHref(path) {
+  return `${path}?lang=${lang}`;
+}
+
+const NAV = [
+  { key: 'nav.home', href: 'index.html', page: 'home' },
+  { key: 'nav.tutorial', href: 'tutorial.html', page: 'tutorial' },
+  { key: 'nav.playground', href: 'playground.html', page: 'playground' },
+  { key: 'nav.bench', href: 'bench-trend.html', page: 'bench' },
+];
+
+/**
+ * Render the shared header and footer into `<nav class="site-nav">` and
+ * `<footer class="site-footer">`, and keep them in sync with the language.
+ */
+export function renderChrome(activePage) {
+  const nav = document.querySelector('.site-nav');
+  const footer = document.querySelector('.site-footer');
+
+  function paint() {
+    document.documentElement.lang = lang;
+    if (nav) {
+      nav.innerHTML = '';
+      const brand = document.createElement('a');
+      brand.className = 'brand';
+      brand.href = langHref('index.html');
+      brand.textContent = 'mutsu';
+      nav.appendChild(brand);
+
+      const links = document.createElement('div');
+      links.className = 'nav-links';
+      for (const item of NAV) {
+        const a = document.createElement('a');
+        a.href = item.page === 'bench' ? item.href : langHref(item.href);
+        a.textContent = t(item.key);
+        if (item.page === activePage) a.setAttribute('aria-current', 'page');
+        links.appendChild(a);
+      }
+      const gh = document.createElement('a');
+      gh.href = 'https://github.com/tokuhirom/mutsu';
+      gh.textContent = t('nav.github');
+      gh.rel = 'noopener';
+      links.appendChild(gh);
+      nav.appendChild(links);
+
+      const spacer = document.createElement('span');
+      spacer.className = 'spacer';
+      nav.appendChild(spacer);
+
+      const sw = document.createElement('div');
+      sw.className = 'lang-switch';
+      sw.setAttribute('role', 'group');
+      sw.setAttribute('aria-label', 'Language');
+      for (const l of LANGS) {
+        const b = document.createElement('button');
+        b.type = 'button';
+        b.dataset.lang = l;
+        b.textContent = l === 'ja' ? '日本語' : 'English';
+        b.setAttribute('aria-pressed', String(l === lang));
+        b.addEventListener('click', () => setLang(l));
+        sw.appendChild(b);
+      }
+      nav.appendChild(sw);
+    }
+
+    if (footer) {
+      footer.innerHTML = '';
+      const tagline = document.createElement('p');
+      tagline.textContent = t('footer.tagline');
+      footer.appendChild(tagline);
+
+      // The credit carries a <code> element, so it is the one string built
+      // from markup rather than textContent.  It is a literal from STRINGS,
+      // never user input.
+      const credit = document.createElement('p');
+      credit.innerHTML = t('footer.credit');
+      footer.appendChild(credit);
+
+      const links = document.createElement('p');
+      const parts = [
+        ['https://docs.raku.org/', t('footer.docs')],
+        ['https://github.com/Raku/doc', t('footer.doc-repo')],
+        ['https://github.com/tokuhirom/mutsu', t('footer.repo')],
+      ];
+      parts.forEach(([href, text], i) => {
+        if (i) links.appendChild(document.createTextNode(' · '));
+        const a = document.createElement('a');
+        a.href = href;
+        a.textContent = text;
+        a.rel = 'noopener';
+        links.appendChild(a);
+      });
+      footer.appendChild(links);
+    }
+  }
+
+  paint();
+  window.addEventListener('langchange', paint);
+}

--- a/wasm-demo/assets/runner.js
+++ b/wasm-demo/assets/runner.js
@@ -1,0 +1,72 @@
+/**
+ * WASM lifecycle for the whole site.
+ *
+ * The module is a few megabytes, so it is loaded once per page and shared by
+ * every snippet on it.  `runIsolated` gives each snippet a clean interpreter
+ * (the tutorial's lessons must not leak declarations into each other), while
+ * `createSession` hands out the long-lived REPL the playground needs.
+ */
+
+import init, { Repl } from '../pkg/mutsu.js';
+
+let bootPromise = null;
+let scratchRepl = null;
+
+/** Start loading the WASM module.  Safe to call repeatedly. */
+export function boot() {
+  if (!bootPromise) {
+    bootPromise = init().then(() => {
+      document.body.dataset.wasmReady = '1';
+    });
+    // boot() is also kicked off speculatively, with nobody awaiting it yet, so
+    // a failure (an offline visitor, or a navigation that aborts the fetch)
+    // would otherwise surface as an unhandled promise rejection. Callers that
+    // do await it still see the rejection.
+    bootPromise.catch(() => {});
+  }
+  return bootPromise;
+}
+
+export function isReady() {
+  return document.body.dataset.wasmReady === '1';
+}
+
+/** A fresh REPL session (playground). */
+export async function createSession() {
+  await boot();
+  return new Repl();
+}
+
+/**
+ * Run a snippet with no state carried over from previous runs.
+ *
+ * A Rust panic poisons the wasm instance, so a failed run throws away the
+ * scratch interpreter rather than reusing a corrupt one.
+ *
+ * @returns {Promise<{output: string, crashed: boolean}>}
+ */
+export async function runIsolated(code) {
+  try {
+    await boot();
+  } catch (e) {
+    return { output: `Failed to load the interpreter: ${e.message}`, crashed: true };
+  }
+  if (!scratchRepl) scratchRepl = new Repl();
+  try {
+    scratchRepl.reset();
+  } catch {
+    scratchRepl = new Repl();
+  }
+  try {
+    const res = JSON.parse(scratchRepl.evalBlock(code));
+    return { output: (res.output || '').replace(/\n+$/, ''), crashed: false };
+  } catch (e) {
+    scratchRepl = null;
+    return { output: `WASM error: ${e.message}`, crashed: true };
+  }
+}
+
+/** True when the interpreter reported an error rather than a value. */
+export function looksLikeError(output) {
+  return /(^|\n)(Error|Runtime error|Parse error):/.test(output);
+}

--- a/wasm-demo/assets/site.css
+++ b/wasm-demo/assets/site.css
@@ -1,0 +1,527 @@
+/* Shared styling for the mutsu site (landing, tutorial, playground). */
+
+:root {
+  --purple: #7B2D8B;
+  --pink: #E91E8C;
+  --dark-bg: #1a0a20;
+  --panel-bg: #2a1235;
+  --panel-bg-2: #33163f;
+  --console-bg: #0d0514;
+  --border: #4a2555;
+  --text: #f0e6f6;
+  --dim: #9a7fa8;
+  --green: #7deba0;
+  --red: #ff6b8a;
+  --mono: 'Fira Code', 'Cascadia Code', 'JetBrains Mono', ui-monospace, monospace;
+  --sans: system-ui, -apple-system, 'Hiragino Sans', 'Noto Sans JP', sans-serif;
+
+  /* syntax colors */
+  --syn-comment: #7a5f88;
+  --syn-string: #ffc48a;
+  --syn-number: #9fd6ff;
+  --syn-var: #7deba0;
+  --syn-keyword: #ff86c8;
+  --syn-type: #e6a3ff;
+  --syn-op: #c8b0d4;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: var(--sans);
+  background: linear-gradient(135deg, var(--dark-bg) 0%, #2d1040 50%, #1a0a30 100%);
+  background-attachment: fixed;
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  line-height: 1.6;
+}
+
+a { color: #e6a3ff; }
+
+/* ------------------------------------------------------------------ *
+ * Site chrome
+ * ------------------------------------------------------------------ */
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.7rem 1.2rem;
+  border-bottom: 1px solid var(--border);
+  background: rgba(13, 5, 20, 0.6);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(8px);
+  flex-wrap: wrap;
+}
+.site-nav .brand {
+  font-weight: 700;
+  font-size: 1.05rem;
+  text-decoration: none;
+  background: linear-gradient(90deg, var(--purple), var(--pink));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.site-nav .nav-links { display: flex; gap: 0.4rem; flex-wrap: wrap; }
+.site-nav .nav-links a {
+  color: var(--dim);
+  text-decoration: none;
+  font-size: 0.9rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 0.35rem;
+}
+.site-nav .nav-links a:hover { color: var(--text); background: var(--panel-bg); }
+.site-nav .nav-links a[aria-current="page"] { color: var(--text); background: var(--panel-bg-2); }
+.site-nav .spacer { flex: 1; }
+
+.lang-switch { display: flex; border: 1px solid var(--border); border-radius: 0.4rem; overflow: hidden; }
+.lang-switch button {
+  background: transparent;
+  border: 0;
+  color: var(--dim);
+  font: inherit;
+  font-size: 0.82rem;
+  padding: 0.25rem 0.65rem;
+  cursor: pointer;
+}
+.lang-switch button[aria-pressed="true"] { background: var(--panel-bg-2); color: var(--text); }
+.lang-switch button:hover { color: var(--text); }
+
+footer.site-footer {
+  border-top: 1px solid var(--border);
+  padding: 1.4rem 1.2rem 2rem;
+  color: var(--dim);
+  font-size: 0.82rem;
+  text-align: center;
+  margin-top: auto;
+}
+footer.site-footer p + p { margin-top: 0.4rem; }
+footer.site-footer a { color: var(--pink); text-decoration: none; }
+footer.site-footer a:hover { text-decoration: underline; }
+
+/* ------------------------------------------------------------------ *
+ * Buttons
+ * ------------------------------------------------------------------ */
+
+.btn {
+  background: linear-gradient(135deg, var(--purple), var(--pink));
+  border: none;
+  color: white;
+  padding: 0.5rem 1.3rem;
+  border-radius: 0.4rem;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+  transition: opacity 0.15s;
+}
+.btn:hover { opacity: 0.9; }
+.btn:disabled { opacity: 0.5; cursor: wait; }
+.btn-ghost {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--dim);
+  padding: 0.45rem 0.9rem;
+  border-radius: 0.4rem;
+  font: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+  transition: all 0.15s;
+}
+.btn-ghost:hover { border-color: var(--pink); color: var(--text); }
+
+/* ------------------------------------------------------------------ *
+ * Editor widget (textarea + highlight overlay, pixel-aligned)
+ * ------------------------------------------------------------------ */
+
+.editor-wrap {
+  position: relative;
+  background: var(--panel-bg);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+.editor-wrap:focus-within {
+  border-color: var(--pink);
+  box-shadow: 0 0 0 2px rgba(233, 30, 140, 0.15);
+}
+/* The overlay and the textarea must render text identically and overlap
+   pixel-for-pixel: same font, size, padding, line-height, borders. */
+.editor-wrap textarea,
+.editor-wrap pre {
+  font-family: var(--mono);
+  font-size: 0.88rem;
+  line-height: 1.55;
+  padding: 0.9rem;
+  margin: 0;
+  border: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  tab-size: 4;
+}
+.editor-wrap pre {
+  position: absolute;
+  inset: 0;
+  overflow: auto;
+  pointer-events: none;
+  color: var(--text);
+}
+.editor-wrap textarea {
+  position: relative;
+  display: block;
+  width: 100%;
+  background: transparent;
+  color: transparent;
+  caret-color: var(--pink);
+  resize: vertical;
+  outline: none;
+  overflow: auto;
+}
+.editor-wrap textarea::selection { background: rgba(233, 30, 140, 0.35); }
+
+.tok-comment { color: var(--syn-comment); font-style: italic; }
+.tok-string  { color: var(--syn-string); }
+.tok-number  { color: var(--syn-number); }
+.tok-var     { color: var(--syn-var); }
+.tok-keyword { color: var(--syn-keyword); font-weight: 600; }
+.tok-type    { color: var(--syn-type); }
+.tok-op      { color: var(--syn-op); }
+
+/* ------------------------------------------------------------------ *
+ * Output pane
+ * ------------------------------------------------------------------ */
+
+.output {
+  background: var(--console-bg);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  line-height: 1.5;
+  padding: 0.7rem 0.9rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+  color: var(--green);
+  min-height: 2.6rem;
+}
+.output.error { color: var(--red); }
+.output.muted { color: var(--dim); font-style: italic; font-family: var(--sans); }
+
+.run-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  margin: 0.6rem 0;
+}
+.hint { color: var(--dim); font-size: 0.78rem; }
+.grow { flex: 1; }
+.snippet-note {
+  color: var(--syn-string);
+  background: rgba(255, 196, 138, 0.08);
+  border-left: 2px solid var(--syn-string);
+  font-size: 0.82rem;
+  padding: 0.5rem 0.7rem;
+  border-radius: 0 0.3rem 0.3rem 0;
+  margin-bottom: 0.6rem;
+}
+.verdict { font-size: 0.82rem; font-weight: 600; }
+.verdict.ok { color: var(--green); }
+.verdict.differs { color: var(--syn-string); }
+
+/* ------------------------------------------------------------------ *
+ * Landing page
+ * ------------------------------------------------------------------ */
+
+.hero {
+  text-align: center;
+  padding: 3rem 1.2rem 2rem;
+  max-width: 52rem;
+  margin: 0 auto;
+}
+.hero h1 {
+  font-size: clamp(2.2rem, 6vw, 3.4rem);
+  line-height: 1.15;
+  background: linear-gradient(90deg, var(--purple), var(--pink));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.hero .tagline { color: var(--text); font-size: 1.15rem; margin-top: 0.9rem; }
+.hero .sub { color: var(--dim); margin-top: 0.7rem; font-size: 0.95rem; }
+.hero .cta { margin-top: 1.6rem; display: flex; gap: 0.7rem; justify-content: center; flex-wrap: wrap; }
+
+.section {
+  max-width: 60rem;
+  margin: 0 auto;
+  padding: 1.5rem 1.2rem;
+  width: 100%;
+}
+.section > h2 {
+  font-size: 1.5rem;
+  margin-bottom: 0.4rem;
+}
+.section > .lede { color: var(--dim); margin-bottom: 1.4rem; }
+
+.card {
+  background: rgba(42, 18, 53, 0.55);
+  border: 1px solid var(--border);
+  border-radius: 0.7rem;
+  padding: 1.1rem 1.2rem;
+  margin-bottom: 1.1rem;
+}
+.card h3 { font-size: 1.12rem; margin-bottom: 0.35rem; }
+.card .card-body { color: var(--dim); font-size: 0.92rem; margin-bottom: 0.8rem; }
+.card .card-body code,
+.lesson-body code {
+  font-family: var(--mono);
+  font-size: 0.88em;
+  background: rgba(13, 5, 20, 0.6);
+  padding: 0.08em 0.35em;
+  border-radius: 0.25rem;
+  color: var(--syn-type);
+}
+
+/* ------------------------------------------------------------------ *
+ * Tutorial page
+ * ------------------------------------------------------------------ */
+
+.tutorial-layout {
+  display: grid;
+  grid-template-columns: 17rem 1fr;
+  gap: 1.4rem;
+  max-width: 78rem;
+  width: 100%;
+  margin: 0 auto;
+  padding: 1.2rem;
+  align-items: start;
+  flex: 1;
+}
+
+.toc {
+  position: sticky;
+  top: 4.2rem;
+  max-height: calc(100vh - 5.5rem);
+  overflow-y: auto;
+  background: rgba(42, 18, 53, 0.45);
+  border: 1px solid var(--border);
+  border-radius: 0.6rem;
+  padding: 0.8rem;
+}
+.toc h2 { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--dim); margin-bottom: 0.6rem; }
+.toc .toc-intro { font-size: 0.82rem; color: var(--dim); margin-bottom: 0.9rem; }
+.toc .toc-source {
+  font-size: 0.72rem;
+  color: var(--dim);
+  margin-top: 0.9rem;
+  padding-top: 0.7rem;
+  border-top: 1px solid var(--border);
+}
+.toc ol { list-style: none; }
+.toc .chapter { margin-bottom: 0.7rem; }
+.toc .chapter > .chapter-title {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 0.25rem;
+  display: flex;
+  gap: 0.4rem;
+}
+.toc .chapter > .chapter-title .num { color: var(--pink); }
+.toc .lesson-link {
+  display: block;
+  padding: 0.22rem 0.5rem;
+  font-size: 0.85rem;
+  color: var(--dim);
+  text-decoration: none;
+  border-left: 2px solid transparent;
+  border-radius: 0 0.25rem 0.25rem 0;
+}
+.toc .lesson-link:hover { color: var(--text); background: var(--panel-bg); }
+.toc .lesson-link[aria-current="true"] {
+  color: var(--text);
+  background: var(--panel-bg-2);
+  border-left-color: var(--pink);
+}
+.toc .lesson-link.done::after { content: " ✓"; color: var(--green); }
+
+.lesson { min-width: 0; }
+.lesson .crumb { color: var(--dim); font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.07em; }
+.lesson h1 { font-size: 1.7rem; margin: 0.25rem 0 0.9rem; }
+.lesson-body { margin-bottom: 1.1rem; }
+.lesson-body p + p,
+.lesson-body p + ul,
+.lesson-body ul + p { margin-top: 0.7rem; }
+.lesson-body ul { padding-left: 1.2rem; }
+.lesson-body li { margin-top: 0.25rem; }
+.lesson-body strong { color: var(--text); }
+
+.pane-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--dim);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.35rem;
+}
+.pane-title::after { content: ""; flex: 1; height: 1px; background: var(--border); }
+
+.lesson-nav {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+  margin-top: 1.6rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+}
+.lesson-nav button:disabled { opacity: 0.4; cursor: default; }
+
+.toc-actions { margin-top: 0.8rem; }
+
+details.expected { margin-top: 0.7rem; }
+details.expected summary {
+  cursor: pointer;
+  color: var(--dim);
+  font-size: 0.82rem;
+}
+details.expected pre {
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  white-space: pre-wrap;
+  color: var(--dim);
+  background: var(--console-bg);
+  border: 1px solid var(--border);
+  border-radius: 0.4rem;
+  padding: 0.6rem 0.8rem;
+  margin-top: 0.4rem;
+  overflow-x: auto;
+}
+
+/* ------------------------------------------------------------------ *
+ * Playground
+ * ------------------------------------------------------------------ */
+
+.container {
+  max-width: 62rem;
+  width: 100%;
+  margin: 0 auto;
+  padding: 1rem 1.2rem 1.5rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.examples { display: flex; flex-direction: column; gap: 0.4rem; }
+.example-group { display: flex; flex-wrap: wrap; gap: 0.35rem; align-items: center; }
+.example-group .group-label {
+  color: var(--dim);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  min-width: 5.5rem;
+}
+.examples button {
+  background: var(--panel-bg);
+  border: 1px solid var(--border);
+  color: var(--dim);
+  padding: 0.25rem 0.65rem;
+  border-radius: 1rem;
+  font: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.examples button:hover, .examples button:focus-visible {
+  border-color: var(--pink);
+  color: var(--text);
+  outline: none;
+}
+.examples button.active { border-color: var(--pink); color: var(--text); background: #3a1a48; }
+#example-desc { color: var(--dim); font-size: 0.82rem; min-height: 1.2em; padding-left: 0.2rem; }
+
+.repl {
+  background: var(--console-bg);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  font-family: var(--mono);
+  font-size: 0.86rem;
+  line-height: 1.5;
+  display: flex;
+  flex-direction: column;
+  min-height: 220px;
+  max-height: 460px;
+}
+.repl:focus-within { border-color: var(--pink); }
+#repl-log {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.8rem 0.8rem 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+#repl-log .echo { color: var(--text); }
+#repl-log .echo .prompt { color: var(--pink); user-select: none; }
+#repl-log .out { color: var(--green); }
+#repl-log .out.error { color: var(--red); }
+#repl-log .note { color: var(--dim); font-style: italic; }
+.repl-input-line { display: flex; align-items: baseline; gap: 0.4rem; padding: 0.4rem 0.8rem 0.8rem; }
+#repl-prompt { color: var(--pink); user-select: none; }
+#repl-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text);
+  font-family: inherit;
+  font-size: inherit;
+}
+#repl-input:disabled { opacity: 0.5; }
+
+#toast {
+  position: fixed;
+  left: 50%;
+  bottom: 1.5rem;
+  transform: translateX(-50%) translateY(1rem);
+  background: var(--panel-bg);
+  border: 1px solid var(--pink);
+  color: var(--text);
+  padding: 0.5rem 1rem;
+  border-radius: 0.4rem;
+  font-size: 0.85rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s, transform 0.2s;
+  z-index: 40;
+}
+#toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+
+/* ------------------------------------------------------------------ *
+ * Responsive
+ * ------------------------------------------------------------------ */
+
+@media (max-width: 860px) {
+  .tutorial-layout { grid-template-columns: 1fr; }
+  /* Stacked above the lesson, 36 links would be a long scroll before the
+     reader reaches any content, so cap it and let it scroll internally. */
+  .toc { position: static; max-height: 45vh; }
+}
+@media (max-width: 640px) {
+  .example-group .group-label { min-width: 100%; }
+  .hero { padding-top: 2rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; }
+}

--- a/wasm-demo/assets/snippet.js
+++ b/wasm-demo/assets/snippet.js
@@ -1,0 +1,195 @@
+/**
+ * A runnable snippet: editor + Run button + output pane, optionally with the
+ * expected output recorded in the corpus.  Shared by the landing page and the
+ * tutorial so both behave identically.
+ */
+
+import { createEditor } from './editor.js';
+import { runIsolated, looksLikeError, isReady, boot } from './runner.js';
+import { t } from './i18n.js';
+
+/**
+ * @param {HTMLElement} host   container to fill
+ * @param {object} opts        {code, expect, minHeight, showExpected}
+ */
+export function createSnippet(host, opts = {}) {
+  host.textContent = '';
+
+  const editorHost = document.createElement('div');
+  host.appendChild(editorHost);
+
+  const row = document.createElement('div');
+  row.className = 'run-row';
+
+  const runBtn = document.createElement('button');
+  runBtn.type = 'button';
+  runBtn.className = 'btn run-btn';
+
+  const hint = document.createElement('span');
+  hint.className = 'hint';
+
+  const resetBtn = document.createElement('button');
+  resetBtn.type = 'button';
+  resetBtn.className = 'btn-ghost reset-btn';
+
+  const grow = document.createElement('span');
+  grow.className = 'grow';
+
+  const verdict = document.createElement('span');
+  verdict.className = 'verdict';
+
+  row.append(runBtn, hint, grow, verdict, resetBtn);
+  host.appendChild(row);
+
+  // Shown instead of a run for snippets the WebAssembly build cannot execute.
+  const note = document.createElement('p');
+  note.className = 'snippet-note';
+  note.hidden = true;
+  host.appendChild(note);
+
+  const out = document.createElement('div');
+  out.className = 'output muted';
+  host.appendChild(out);
+
+  let expected = opts.expect || '';
+  let noBrowser = !!opts.noBrowser;
+  let details = null;
+  let summary = null;
+  let expectedPre = null;
+  if (opts.showExpected) {
+    // Built up front and hidden when empty: the widget is reused across
+    // lessons, so it must exist before the first setCode() supplies text.
+    details = document.createElement('details');
+    details.className = 'expected';
+    summary = document.createElement('summary');
+    expectedPre = document.createElement('pre');
+    expectedPre.textContent = expected;
+    details.append(summary, expectedPre);
+    details.hidden = !expected;
+    host.appendChild(details);
+  }
+
+  const editor = createEditor(editorHost, {
+    code: opts.code || '',
+    minHeight: opts.minHeight,
+    onRun: run,
+  });
+
+  let original = opts.code || '';
+  let busy = false;
+
+  async function run() {
+    if (busy || noBrowser) return;
+    busy = true;
+    runBtn.disabled = true;
+    runBtn.textContent = isReady() ? t('run.running') : t('run.loading');
+    verdict.textContent = '';
+    verdict.className = 'verdict';
+    // Let the button repaint before the VM blocks this thread.
+    await new Promise(r => setTimeout(r, 0));
+
+    const res = await runIsolated(editor.getCode());
+    const text = res.output;
+    out.classList.remove('muted', 'error');
+    if (!text) {
+      out.textContent = t('output.none');
+      out.classList.add('muted');
+    } else {
+      out.textContent = text;
+      if (res.crashed || looksLikeError(text)) out.classList.add('error');
+    }
+    if (expected) {
+      const ok = text.trim() === expected.trim();
+      verdict.textContent = ok ? t('verdict.ok') : t('verdict.differs');
+      verdict.classList.add(ok ? 'ok' : 'differs');
+    }
+    busy = false;
+    runBtn.disabled = false;
+    runBtn.textContent = t('run');
+    host.dispatchEvent(new CustomEvent('snippetrun', { bubbles: true, detail: { ok: !!expected && text.trim() === expected.trim() } }));
+  }
+
+  /**
+   * Put the widget into its "cannot run here" state: the recorded native
+   * output IS the output, so it is shown as such rather than hidden behind an
+   * "Expected output" toggle the reader would have to guess at.
+   */
+  function paintNoBrowser() {
+    runBtn.disabled = true;
+    runBtn.textContent = t('run');
+    hint.textContent = t('no-browser.output');
+    note.hidden = false;
+    note.textContent = t('no-browser.note');
+    verdict.textContent = '';
+    verdict.className = 'verdict';
+    if (details) details.hidden = true;
+    out.className = 'output';
+    out.textContent = expected || t('output.none');
+  }
+
+  function relabel() {
+    if (noBrowser) { paintNoBrowser(); return; }
+    if (!busy) runBtn.textContent = t('run');
+    hint.textContent = t('run.hint');
+    note.hidden = true;
+    resetBtn.textContent = t('reset');
+    if (summary) summary.textContent = t('expected.summary');
+    if (out.classList.contains('muted') && !out.dataset.ran) out.textContent = t('output.empty');
+  }
+
+  runBtn.addEventListener('click', run);
+  resetBtn.addEventListener('click', () => {
+    editor.setCode(original);
+    out.className = 'output muted';
+    delete out.dataset.ran;
+    out.textContent = t('output.empty');
+    verdict.textContent = '';
+  });
+  host.addEventListener('snippetrun', () => { out.dataset.ran = '1'; });
+  window.addEventListener('langchange', relabel);
+
+  relabel();
+  out.textContent = t('output.empty');
+
+  // The interpreter is a multi-megabyte download. A page that exists to run
+  // code (the tutorial) fetches it up front; a page a visitor may only read
+  // (the landing page) waits until they show interest in a snippet, so nobody
+  // pays for a runtime they never use.
+  if (opts.eagerBoot) {
+    boot();
+  } else {
+    const kick = () => {
+      boot();
+      editor.textarea.removeEventListener('focusin', kick);
+      runBtn.removeEventListener('pointerenter', kick);
+    };
+    editor.textarea.addEventListener('focusin', kick);
+    runBtn.addEventListener('pointerenter', kick);
+  }
+
+  return {
+    run,
+    relabel,
+    getCode: editor.getCode,
+    setCode(code, expectText, cannotRunHere = false) {
+      original = code;
+      editor.setCode(code);
+      expected = expectText || '';
+      noBrowser = cannotRunHere;
+      if (expectedPre) expectedPre.textContent = expected;
+      if (details) details.hidden = !expected;
+      delete out.dataset.ran;
+      verdict.textContent = '';
+      verdict.className = 'verdict';
+      if (noBrowser) {
+        paintNoBrowser();
+        return;
+      }
+      runBtn.disabled = false;
+      note.hidden = true;
+      hint.textContent = t('run.hint');
+      out.className = 'output muted';
+      out.textContent = t('output.empty');
+    },
+  };
+}

--- a/wasm-demo/content/highlights.txt
+++ b/wasm-demo/content/highlights.txt
@@ -1,0 +1,89 @@
+#  Landing-page highlight snippets.  Same format as lessons.txt:
+#  "#== <group>/<id>" then code, then "#-- expect" then the expected output.
+#  Regenerate the expectations with:
+#      node scripts/check-site-snippets.mjs --update
+#  Titles and prose live in content/landing.<lang>.js, keyed by "<group>/<id>".
+
+#== why/rationals
+# 0.1 + 0.2 is exactly 0.3, because Raku divides into rationals.
+say 0.1 + 0.2 == 0.3;
+say (1/3 + 1/6).nude;
+say 2 ** 100;
+#-- expect
+True
+(1 2)
+1267650600228229401496703205376
+
+#== why/junctions
+# One value that is several values at once.
+my $x = 7;
+say so $x == 3 | 7 | 9;
+say so all(2, 4, 6) %% 2;
+say (1..20).grep(* == any(3, 7, 11));
+#-- expect
+True
+True
+(3 7 11)
+
+#== why/lazy
+# Infinite sequences, computed only as far as you look.
+my @fib = 1, 1, * + * ... *;
+say @fib.head(10);
+say (1..Inf).grep(*.is-prime).head(5);
+#-- expect
+(1 1 2 3 5 8 13 21 34 55)
+(2 3 5 7 11)
+
+#== why/multi
+# Dispatch on types, arity, and arbitrary constraints.
+multi fizz(Int $n where $n %% 15) { "FizzBuzz" }
+multi fizz(Int $n where $n %%  3) { "Fizz"     }
+multi fizz(Int $n where $n %%  5) { "Buzz"     }
+multi fizz(Int $n)                { ~$n        }
+say (1..15).map({ fizz($_) }).join(" ");
+#-- expect
+1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz 11 Fizz 13 14 FizzBuzz
+
+#== why/grammars
+# Grammars are first-class: a parser is just a class of named regexes.
+grammar Ini {
+    token TOP     { <pair>+ % \n }
+    token pair    { <key> \s* "=" \s* <value> }
+    token key     { \w+ }
+    token value   { \N+ }
+}
+my $m = Ini.parse("name = mutsu\nlang = Raku");
+say $m<pair>.map({ "{.<key>} -> {.<value>}" });
+#-- expect
+(name -> mutsu lang -> Raku)
+
+#== why/operators
+# Metaoperators build new operators out of the ones you already know.
+say [+] 1..100;
+say (1, 2, 3) >>*>> 10;
+say (-4, 5, -6)>>.abs;
+say <a b c> Z <1 2 3>;
+#-- expect
+5050
+(10 20 30)
+(4 5 6)
+((a 1) (b 2) (c 3))
+
+#== why/concurrency
+# Promises and reactive streams are in the core language.
+my @results = (1..4).map: -> $n { start { $n * $n } };
+say await @results;
+#-- expect
+(1 4 9 16)
+
+#== why/unicode
+# Raku speaks Unicode: in source, in strings, and as operators.
+say "π ≈ {pi.fmt('%.5f')}";
+say 1 ≤ 2 ≤ 3;                     # ≤ is an alias for <=
+say (set(<a b>) ∪ set(<b c>)).keys.sort;
+say "Ω".uniname;
+#-- expect
+π ≈ 3.14159
+True
+(a b c)
+GREEK CAPITAL LETTER OMEGA

--- a/wasm-demo/content/landing.en.js
+++ b/wasm-demo/content/landing.en.js
@@ -1,0 +1,100 @@
+/**
+ * English prose for the landing page.  Snippet code lives in
+ * content/highlights.txt; keys must match its "<group>/<id>" ids.
+ */
+
+export default {
+  hero: {
+    title: 'Raku, running in this tab',
+    tagline: 'A language built for expressiveness — gradual types, real grammars, ' +
+      'lazy lists and multiple dispatch — with an interpreter small enough to ship ' +
+      'to your browser.',
+    sub: 'mutsu is a Raku implementation written in Rust. Everything on this site ' +
+      'runs locally as WebAssembly: no server, no round trip.',
+    startTutorial: 'Start the tutorial',
+    openPlayground: 'Open the playground',
+  },
+
+  why: {
+    heading: 'Why Raku',
+    lede: 'Eight things that are ordinary in Raku and awkward almost everywhere else. ' +
+      'Every one of them runs right here — edit it and see.',
+  },
+
+  next: {
+    heading: 'Where to go next',
+    lede: 'Pick a path.',
+    cards: [
+      {
+        title: 'Take the tour',
+        body: 'Nine chapters, from <code>say "hello"</code> to grammars and ' +
+          'concurrency. Every lesson is an editable, runnable program.',
+        href: 'tutorial.html',
+        cta: 'Start the tutorial →',
+      },
+      {
+        title: 'Just try things',
+        body: 'A playground with a REPL that keeps its state between runs, ' +
+          'plus a shareable permalink for whatever you write.',
+        href: 'playground.html',
+        cta: 'Open the playground →',
+      },
+      {
+        title: 'Read the real docs',
+        body: 'The official Raku documentation is the authority on the language, ' +
+          'and it is excellent. This site is an introduction, not a replacement.',
+        href: 'https://docs.raku.org/',
+        cta: 'docs.raku.org →',
+      },
+    ],
+  },
+
+  snippets: {
+    'why/rationals': {
+      title: 'Arithmetic that means it',
+      body: 'Dividing two integers gives an exact rational, not a float, so ' +
+        '<code>0.1 + 0.2 == 0.3</code> is simply true. Integers are arbitrary ' +
+        'precision, so nothing silently overflows.',
+    },
+    'why/junctions': {
+      title: 'Junctions',
+      body: 'One value that is several values at once. Comparisons thread over ' +
+        'every member and collapse to a single answer, so a chain of ' +
+        '<code>||</code> becomes <code>3 | 7 | 9</code>.',
+    },
+    'why/lazy': {
+      title: 'Infinite lists, finite work',
+      body: 'Sequences are lazy, so "all the primes" is an ordinary value you can ' +
+        'pass to <code>.grep</code> and <code>.head</code>. Only the elements you ' +
+        'look at are ever computed.',
+    },
+    'why/multi': {
+      title: 'Multiple dispatch',
+      body: 'Candidates share a name and the narrowest one wins — dispatching on ' +
+        'types, on arity, and on arbitrary <code>where</code> constraints. ' +
+        'FizzBuzz becomes four declarations and no conditionals.',
+    },
+    'why/grammars': {
+      title: 'Grammars in the language',
+      body: 'A parser is a class whose methods are named patterns, callable from ' +
+        'each other. Parsing is a first-class feature, not a library you bolt on.',
+    },
+    'why/operators': {
+      title: 'Operators you can build',
+      body: 'Metaoperators turn any operator into a reduction (<code>[+]</code>), ' +
+        'an element-wise version (<code>&gt;&gt;*&gt;&gt;</code>), or a zip — ' +
+        'including operators you define yourself.',
+    },
+    'why/concurrency': {
+      title: 'Concurrency in the core',
+      body: '<code>start</code> returns a promise, <code>await</code> collects ' +
+        'results, and supplies give you reactive streams — all in the language ' +
+        'proper rather than in a framework.',
+    },
+    'why/unicode': {
+      title: 'Unicode all the way down',
+      body: 'Source, identifiers, strings and operators are Unicode. Strings are ' +
+        'sequences of graphemes, so what you count is what a reader sees.',
+    },
+  },
+};

--- a/wasm-demo/content/landing.ja.js
+++ b/wasm-demo/content/landing.ja.js
@@ -1,0 +1,95 @@
+/**
+ * Japanese prose for the landing page.  Snippet code lives in
+ * content/highlights.txt; keys must match its "<group>/<id>" ids.
+ */
+
+export default {
+  hero: {
+    title: 'Raku を、このタブの中で',
+    tagline: '漸進的型付け、本物の Grammar、遅延リスト、マルチディスパッチ——' +
+      '表現力のために設計された言語を、ブラウザに配れるほど小さなインタプリタで。',
+    sub: 'mutsu は Rust で書かれた Raku 実装です。このサイトの実行はすべて ' +
+      'WebAssembly としてローカルで行われます。サーバとの往復はありません。',
+    startTutorial: 'チュートリアルを始める',
+    openPlayground: 'プレイグラウンドを開く',
+  },
+
+  why: {
+    heading: 'Raku の何が面白いのか',
+    lede: 'Raku では当たり前で、他の多くの言語では面倒なこと 8 つ。' +
+      'どれもこの場で動きます。書き換えて確かめてください。',
+  },
+
+  next: {
+    heading: '次に読むもの',
+    lede: '進み方を選んでください。',
+    cards: [
+      {
+        title: 'ツアーに出る',
+        body: '<code>say "hello"</code> から Grammar と並行処理まで全 9 章。' +
+          'どのレッスンも編集して実行できるプログラムです。',
+        href: 'tutorial.html',
+        cta: 'チュートリアルへ →',
+      },
+      {
+        title: 'とにかく触る',
+        body: '実行のあいだ状態が保たれる REPL 付きのプレイグラウンド。' +
+          '書いたコードは共有用のパーマリンクにできます。',
+        href: 'playground.html',
+        cta: 'プレイグラウンドへ →',
+      },
+      {
+        title: '本家のドキュメントを読む',
+        body: '言語について最終的な権威は公式 Raku ドキュメントで、内容も非常に充実しています。' +
+          'このサイトは入り口であって、その代わりではありません。',
+        href: 'https://docs.raku.org/',
+        cta: 'docs.raku.org →',
+      },
+    ],
+  },
+
+  snippets: {
+    'why/rationals': {
+      title: '意味どおりに動く算術',
+      body: '整数どうしの除算は浮動小数点ではなく正確な有理数になるので、' +
+        '<code>0.1 + 0.2 == 0.3</code> はそのまま真です。整数は多倍長なので、' +
+        '黙ってオーバーフローすることもありません。',
+    },
+    'why/junctions': {
+      title: 'ジャンクション',
+      body: '「複数の値であると同時に 1 つの値」。比較は全要素に分配され、' +
+        '1 つの答えにまとまります。<code>||</code> の連鎖が <code>3 | 7 | 9</code> になります。',
+    },
+    'why/lazy': {
+      title: '無限のリスト、有限の計算',
+      body: '数列は遅延評価なので「すべての素数」も普通の値として <code>.grep</code> や ' +
+        '<code>.head</code> に渡せます。実際に見た要素だけが計算されます。',
+    },
+    'why/multi': {
+      title: 'マルチディスパッチ',
+      body: '同名の候補のうち最も狭いものが選ばれます。型でも引数の個数でも、' +
+        '任意の <code>where</code> 制約でも分岐できます。FizzBuzz は条件分岐なしの 4 つの宣言になります。',
+    },
+    'why/grammars': {
+      title: '言語に組み込まれた Grammar',
+      body: 'パーサは「メソッドが名前付きパターンであるクラス」で、互いに呼び出せます。' +
+        '構文解析は後付けのライブラリではなく第一級の機能です。',
+    },
+    'why/operators': {
+      title: '組み立てられる演算子',
+      body: 'メタ演算子は任意の演算子を畳み込み（<code>[+]</code>）、' +
+        '要素ごとの適用（<code>&gt;&gt;*&gt;&gt;</code>）、zip などに変えます。' +
+        '自分で定義した演算子にも同じことができます。',
+    },
+    'why/concurrency': {
+      title: 'コアにある並行処理',
+      body: '<code>start</code> は Promise を返し、<code>await</code> が結果を集め、' +
+        'Supply がリアクティブなストリームを与えます。フレームワークではなく言語そのものの機能です。',
+    },
+    'why/unicode': {
+      title: '隅々まで Unicode',
+      body: 'ソース、識別子、文字列、演算子のすべてが Unicode です。文字列は書記素の列なので、' +
+        '数えた結果が読み手の見え方と一致します。',
+    },
+  },
+};

--- a/wasm-demo/content/lessons.txt
+++ b/wasm-demo/content/lessons.txt
@@ -1,0 +1,595 @@
+#  Tutorial code corpus.
+#
+#  Format:  "#== <chapter-id>/<lesson-id> [flags]" starts a lesson, the lines
+#  after it are the starter code, and "#-- expect" starts the expected output
+#  block.  The order of the lessons here is the order of the tutorial; chapters
+#  are ordered by first appearance.
+#
+#  Flag `no-browser`: the snippet runs natively but not in the WebAssembly
+#  build (`start` needs OS threads, which wasm32 has none of).  The site shows
+#  the recorded native output instead of offering to run it.
+#
+#  The expected-output blocks are GENERATED and verified: run
+#      node scripts/check-site-snippets.mjs --update
+#  which runs every snippet under both `raku` and `mutsu` and only writes an
+#  expectation when the two agree.  Titles and prose live in
+#  content/tutorial.<lang>.js, keyed by "<chapter-id>/<lesson-id>".
+
+#== basics/hello
+# Every Raku program is a list of statements.  `say` prints its argument
+# followed by a newline.  Edit anything below and press Run.
+say "Hello, World!";
+say "Hello".uc;
+say 6 * 7;
+#-- expect
+Hello, World!
+HELLO
+42
+
+#== basics/variables
+my $answer = 42;          # $ - a single item
+my @langs  = <Raku Perl Rust>;   # @ - a positional list
+my %ages   = Raku => 10, Perl => 37;   # % - an associative map
+
+say $answer;
+say @langs.elems;
+say @langs[0];
+say %ages<Raku>;
+#-- expect
+42
+3
+Raku
+10
+
+#== basics/types
+say 42.^name;
+say "hi".^name;
+say (1/3).^name;
+say (1..5).^name;
+say 42 ~~ Int;
+say 42 ~~ Cool;
+say Int.^mro;
+#-- expect
+Int
+Str
+Rat
+Range
+True
+True
+((Int) (Cool) (Any) (Mu))
+
+#== basics/interpolation
+my $who  = "world";
+my @xs   = 1, 2, 3;
+
+say "Hello, $who!";
+say "The sum is { @xs.sum }";   # any expression in { }
+say "The list is @xs[]";
+say 'single quotes take no $who';
+#-- expect
+Hello, world!
+The sum is 6
+The list is 1 2 3
+single quotes take no $who
+
+#== operators/numbers
+say 0.1 + 0.2 == 0.3;     # True: Raku divides into exact Rats
+say (1/3).nude;           # numerator and denominator
+say 7 / 2;
+say 7 div 2;              # integer division
+say 7 % 3;
+say 10 %% 5;              # "is divisible by"
+say 2 ** 100;             # arbitrary precision
+#-- expect
+True
+(1 3)
+3.5
+3
+1
+True
+1267650600228229401496703205376
+
+#== operators/strings
+say "ab" ~ "cd";          # ~ concatenates
+say "-" x 10;             # x repeats
+say "apple" lt "banana";  # string comparison
+say "b" cmp "a";
+say 3 <=> 10;
+say "Raku".flip;
+say "raku".tc;
+#-- expect
+abcd
+----------
+True
+More
+Less
+ukaR
+Raku
+
+#== operators/ranges
+say (1..5).list;
+say (1..^5).list;         # ^ excludes the endpoint
+say ("a".."e").join(",");
+say (2, 4, 8 ... 64);     # ... infers the rule
+say (1, 1, * + * ... *)[^10];
+#-- expect
+(1 2 3 4 5)
+(1 2 3 4)
+a,b,c,d,e
+(2 4 8 16 32 64)
+(1 1 2 3 5 8 13 21 34 55)
+
+#== operators/meta
+say [+] 1..10;            # reduce with +
+say [*] 1..5;
+say [~] <a b c>;
+my @a = 1, 2, 3;
+say @a >>+>> 10;          # hyper: apply element-wise
+say (-3, 4, -5)>>.abs;
+say (1, 2) Z (3, 4);      # zip
+say (1, 2) X <a b>;       # cross
+#-- expect
+55
+120
+abc
+[11 12 13]
+(3 4 5)
+((1 3) (2 4))
+((1 a) (1 b) (2 a) (2 b))
+
+#== operators/junctions
+my $n = 7;
+say so $n == 3 | 7 | 9;   # any-junction
+say so all(1, 2, 3) < 5;
+say so none(<a b c>) eq "d";
+say (1..10).grep(* == any(2, 4, 8));
+#-- expect
+True
+True
+True
+(2 4 8)
+
+#== control/conditionals
+my $n = 7;
+if    $n > 10 { say "big"    }
+elsif $n > 5  { say "medium" }
+else          { say "small"  }
+
+unless $n %% 2 { say "$n is odd" }
+
+my $maybe;
+with $maybe { say "defined" } else { say "undefined" }
+
+say $n > 5 ?? "yes" !! "no";
+#-- expect
+medium
+7 is odd
+undefined
+yes
+
+#== control/loops
+for 1..3 -> $i { say "i = $i" }
+
+for <a b c>.kv -> $i, $v { say "$i: $v" }
+
+my $sum = 0;
+$sum += $_ for 1..10;     # statement modifier
+say $sum;
+
+my $k = 0;
+while $k < 3 { $k++ }
+say "k = $k";
+#-- expect
+i = 1
+i = 2
+i = 3
+0: a
+1: b
+2: c
+55
+k = 3
+
+#== control/given-when
+sub describe($x) {
+    given $x {
+        when Int     { "an Int"       }
+        when Str     { "a Str"        }
+        when 1.5     { "exactly 1.5"  }
+        when * > 100 { "a big number" }
+        default      { "something else" }
+    }
+}
+say describe($_) for 42, "hi", 1.5, 200e0, pi;
+#-- expect
+an Int
+a Str
+exactly 1.5
+a big number
+something else
+
+#== control/loop-control
+for 1..10 {
+    next if $_ %% 2;      # skip the evens
+    last if $_ > 7;       # stop past 7
+    say $_;
+}
+say "done";
+#-- expect
+1
+3
+5
+7
+done
+
+#== lists/arrays
+my @a = 10, 20, 30, 40, 50;
+say @a[0];
+say @a[*-1];              # * - 1 counts from the end
+say @a[1..3];             # a slice
+say @a[0, 2, 4];
+@a.push(60);
+say @a.elems;
+say @a.reverse;
+#-- expect
+10
+50
+(20 30 40)
+(10 30 50)
+6
+(60 50 40 30 20 10)
+
+#== lists/map-grep-sort
+my @n = 5, 3, 9, 1, 7;
+say @n.sort;
+say @n.sort({ $^b <=> $^a });   # descending
+say @n.grep(* > 4);
+say @n.map(* ** 2);
+say @n.sum, " ", @n.min, " ", @n.max;
+say <banana apple cherry>.sort(*.chars);
+#-- expect
+(1 3 5 7 9)
+(9 7 5 3 1)
+(5 9 7)
+(25 9 81 1 49)
+25 1 9
+(apple banana cherry)
+
+#== lists/hashes
+my %h = apple => 3, banana => 5, cherry => 2;
+say %h<apple>;
+%h<durian> = 7;
+say %h.elems;
+say %h.keys.sort;
+say %h<grape>:exists;
+say %h.sort(*.key).map({ "{.key}={.value}" }).join(", ");
+#-- expect
+3
+4
+(apple banana cherry durian)
+False
+apple=3, banana=5, cherry=2, durian=7
+
+#== lists/lazy
+my @fib = 1, 1, * + * ... *;    # infinite, computed on demand
+say @fib.head(10);
+say (1..Inf).grep(*.is-prime).head(5);
+say (1..*).map(* ** 2).head(5);
+
+my @collatz = gather {
+    my $x = 27;
+    while $x > 1 { take $x; $x = $x %% 2 ?? $x div 2 !! 3 * $x + 1 }
+    take 1;
+}
+say @collatz.elems;
+#-- expect
+(1 1 2 3 5 8 13 21 34 55)
+(2 3 5 7 11)
+(1 4 9 16 25)
+112
+
+#== subs/basics
+sub greet($name) { "Hello, $name!" }
+say greet("Raku");
+
+sub area($w, $h = $w) { $w * $h }     # default value
+say area(3, 4);
+say area(5);
+
+sub stats(*@nums) { min => @nums.min, max => @nums.max }   # slurpy
+say stats(3, 9, 1);
+#-- expect
+Hello, Raku!
+12
+25
+(min => 1 max => 9)
+
+#== subs/signatures
+sub connect(Str :$host = "localhost", Int :$port = 80 --> Str) {
+    "$host:$port"
+}
+say connect;
+say connect(:port(8080));
+say connect(host => "example.com", port => 443);
+
+sub first-and-rest($first, *@rest) { "$first + {@rest.elems} more" }
+say first-and-rest(1, 2, 3, 4);
+#-- expect
+localhost:80
+localhost:8080
+example.com:443
+1 + 3 more
+
+#== subs/multi
+multi fact(0)                  { 1 }
+multi fact(Int $n where * > 0) { $n * fact($n - 1) }
+say fact(10);
+
+multi show(Int $x) { "Int $x" }
+multi show(Str $x) { "Str $x" }
+multi show(@x)     { "a list of {@x.elems}" }
+say show($_) for 1, "a", [1, 2, 3];
+#-- expect
+3628800
+Int 1
+Str a
+a list of 3
+
+#== subs/closures
+my $add = -> $a, $b { $a + $b };
+say $add(2, 3);
+
+sub counter() { my $n = 0; return sub { ++$n } }
+my $tick = counter();
+say $tick(), $tick(), $tick();
+
+say (1..5).map({ $_ * 2 });
+say (1..5).map(* * 2);          # the same, with the Whatever star
+#-- expect
+5
+123
+(2 4 6 8 10)
+(2 4 6 8 10)
+
+#== objects/classes
+class Point {
+    has $.x = 0;                # public accessor
+    has $.y = 0;
+    method length { sqrt($.x ** 2 + $.y ** 2) }
+    method Str    { "($.x, $.y)" }
+}
+
+my $p = Point.new(x => 3, y => 4);
+say ~$p;                        # our Str method
+say $p.length;
+say $p.x;
+#-- expect
+(3, 4)
+5
+3
+
+#== objects/inheritance
+class Animal {
+    has Str $.name;
+    method speak { "..." }
+    method intro { "{$.name} says {self.speak}" }
+}
+class Dog is Animal { method speak { "Woof" } }
+class Cat is Animal { method speak { "Meow" } }
+
+.say for Dog.new(name => "Rex").intro, Cat.new(name => "Tom").intro;
+say Dog.new(name => "Rex") ~~ Animal;
+#-- expect
+Rex says Woof
+Tom says Meow
+True
+
+#== objects/roles
+role Comparable {
+    method compare($other) { self.value <=> $other.value }
+}
+class Card does Comparable {
+    has $.value;
+}
+say Card.new(value => 3).compare(Card.new(value => 9));
+say Card ~~ Comparable;
+say Card.^roles.map(*.^name);
+#-- expect
+Less
+True
+(Comparable)
+
+#== objects/subsets
+subset Even of Int where * %% 2;
+sub half(Even $n) { $n div 2 }
+say half(10);
+say (try half(7)) // "7 is not Even";
+
+enum Color <Red Green Blue>;
+say Green;
+say Green.Int;
+say Blue > Red;
+#-- expect
+5
+7 is not Even
+Green
+1
+True
+
+#== regex/matching
+my $s = "The year 2026 rocks";
+if $s ~~ / \d ** 4 / { say "matched: $/" }
+say so "foobar" ~~ /^ foo /;
+say "a1b2c3".comb(/\d/).join(",");
+say $s.words.grep(/^ <[A..Z]> /);
+#-- expect
+matched: 2026
+True
+1,2,3
+(The)
+
+#== regex/captures
+if "2026-07-23" ~~ / (\d ** 4) "-" (\d ** 2) "-" (\d ** 2) / {
+    say "y=$0 m=$1 d=$2";
+}
+
+if "key = value" ~~ / $<k>=[\w+] \s* "=" \s* $<v>=[\w+] / {
+    say "{$<k>} => {$<v>}";
+}
+
+my regex ident { <[a..zA..Z_]> \w* }
+say so "hello_world" ~~ / ^ <ident> $ /;
+#-- expect
+y=2026 m=07 d=23
+key => value
+True
+
+#== regex/substitution
+my $t = "the quick brown fox";
+say $t.subst("quick", "slow");
+say $t.subst(/\w+/, *.tc, :g);        # :g is global
+say $t.trans("aeiou" => "AEIOU");
+
+my $u = $t;
+$u ~~ s/quick/lazy/;
+say $u;
+#-- expect
+the slow brown fox
+The Quick Brown Fox
+thE qUIck brOwn fOx
+the lazy brown fox
+
+#== regex/grammars
+grammar Greeting {
+    rule  TOP   { <greet> <name> }
+    token greet { "Hello" | "Hi" }
+    token name  { \w+ }
+}
+
+my $m = Greeting.parse("Hello Camelia");
+say $m<greet>;
+say $m<name>;
+say Greeting.parse("Goodbye Camelia").defined;
+#-- expect
+｢Hello｣
+｢Camelia｣
+False
+
+#== concurrency/promises no-browser
+my @squares = (1..5).map: -> $n { start { $n * $n } };
+say await @squares;
+
+my $p = Promise.new;
+$p.keep("kept");
+say $p.result;
+say $p.status;
+#-- expect
+(1 4 9 16 25)
+kept
+Kept
+
+#== concurrency/channels no-browser
+my $c = Channel.new;
+start {
+    $c.send($_) for 1..3;
+    $c.close;
+}
+say $c.list;
+#-- expect
+(1 2 3)
+
+#== concurrency/supplies
+my $supply = Supply.from-list(1..5);
+react {
+    whenever $supply -> $v {
+        say "got $v";
+    }
+}
+say "stream finished";
+#-- expect
+got 1
+got 2
+got 3
+got 4
+got 5
+stream finished
+
+#== wrapping-up/exceptions
+sub risky($n) {
+    die "negative input" if $n < 0;
+    sqrt($n);
+}
+say risky(9);
+
+my $r = try risky(-1);
+say "caught: {$!.message}" with $!;
+
+class MyError is Exception {
+    method message { "something specific went wrong" }
+}
+try {
+    MyError.new.throw;
+    CATCH { when MyError { say "caught: {.message}" } }
+}
+#-- expect
+3
+caught: negative input
+caught: something specific went wrong
+
+#== wrapping-up/phasers
+sub work {
+    ENTER { say "entering" }
+    LEAVE { say "leaving"  }
+    say "working";
+}
+work();
+
+for 1..3 {
+    FIRST { say "first"  }
+    LAST  { say "last"   }
+    say "  item $_";
+}
+#-- expect
+entering
+working
+leaving
+first
+  item 1
+  item 2
+  item 3
+last
+
+#== wrapping-up/introspection
+class Foo {
+    has $.bar;
+    method baz { }
+}
+say Foo.^name;
+say Foo.^attributes.map(*.name);
+say Foo.^mro;
+say Foo.new(bar => 1).^can("baz").elems;
+say Foo.new(bar => 1).^can("nope").elems;
+#-- expect
+Foo
+($!bar)
+((Foo) (Any) (Mu))
+1
+0
+
+#== wrapping-up/putting-it-together
+my $text = "the quick brown fox jumps over the lazy dog the end";
+
+my %freq;
+%freq{$_}++ for $text.words;
+
+for %freq.sort({ -.value, .key }).head(3) -> $pair {
+    say "{$pair.key}: {$pair.value}";
+}
+
+say "distinct words: {%freq.elems}";
+say "longest: {$text.words.sort(-*.chars).head}";
+#-- expect
+the: 3
+brown: 1
+dog: 1
+distinct words: 9
+longest: quick

--- a/wasm-demo/content/tutorial.en.js
+++ b/wasm-demo/content/tutorial.en.js
@@ -1,0 +1,466 @@
+/**
+ * English prose for the tutorial.  Code and expected output live in
+ * content/lessons.txt; the keys here must match its "<chapter>/<lesson>" ids.
+ *
+ * The explanations follow the official Raku documentation (Raku/doc), vendored
+ * in this repository under raku-doc/ and used under the Artistic License 2.0.
+ */
+
+export default {
+  title: 'A tour of Raku',
+  intro: 'Every lesson is a real program. Edit it, press Run, and the ' +
+    'interpreter in your browser executes it — nothing is sent to a server.',
+  source: 'Written against the official Raku documentation (Raku/doc).',
+
+  chapters: {
+    basics: 'Getting started',
+    operators: 'Operators',
+    control: 'Control flow',
+    lists: 'Lists and hashes',
+    subs: 'Subs and signatures',
+    objects: 'Objects',
+    regex: 'Regexes and grammars',
+    concurrency: 'Concurrency',
+    'wrapping-up': 'Wrapping up',
+  },
+
+  lessons: {
+    'basics/hello': {
+      title: 'Hello, World',
+      body: `
+        <p>A Raku program is a sequence of statements, each ended by a semicolon.
+        <code>say</code> prints its argument followed by a newline.</p>
+        <p>Almost everything in Raku is an object with methods, including
+        literals: <code>"Hello".uc</code> calls the <code>uc</code> (uppercase)
+        method on a string literal.</p>
+        <p>Comments start with <code>#</code> and run to the end of the line.</p>`,
+    },
+    'basics/variables': {
+      title: 'Variables and sigils',
+      body: `
+        <p><code>my</code> declares a lexical variable — one visible from its
+        declaration to the end of the enclosing block.</p>
+        <p>The leading punctuation is called a <strong>sigil</strong>, and it tells
+        you the shape of what is inside:</p>
+        <ul>
+          <li><code>$</code> — a single item (any object at all, including a list
+              treated as one thing)</li>
+          <li><code>@</code> — a positional container, indexed by number</li>
+          <li><code>%</code> — an associative container, indexed by key</li>
+          <li><code>&amp;</code> — a piece of code</li>
+        </ul>
+        <p><code>&lt;Raku Perl Rust&gt;</code> is the quote-word list: a whitespace
+        separated list of strings, without quotes or commas.</p>`,
+    },
+    'basics/types': {
+      title: 'Types',
+      body: `
+        <p>Raku is gradually typed: you can leave types off, and they are still
+        there at run time. <code>.^name</code> asks an object's metaobject for its
+        type name — the <code>.^</code> operator is a method call on the
+        <em>metaclass</em> rather than on the object.</p>
+        <p><code>~~</code> is the smartmatch operator. Against a type it answers
+        "does this value conform to that type?". Types form a tree, so an
+        <code>Int</code> is also a <code>Cool</code> (the "convenient object
+        language" types that helpfully convert between numbers and strings), an
+        <code>Any</code>, and a <code>Mu</code>.</p>`,
+    },
+    'basics/interpolation': {
+      title: 'String interpolation',
+      body: `
+        <p>Double-quoted strings interpolate variables. They also interpolate
+        <strong>arbitrary code</strong> in curly braces, which is how most
+        formatting gets done — there is no separate template mini-language.</p>
+        <p>An array interpolates its elements when it is followed by a subscript,
+        so <code>"@xs[]"</code> means "all of <code>@xs</code>, space separated".
+        A bare <code>@xs</code> inside a string stays literal, so email addresses
+        do not surprise you.</p>
+        <p>Single-quoted strings interpolate nothing at all.</p>`,
+    },
+
+    'operators/numbers': {
+      title: 'Numbers that behave',
+      body: `
+        <p>Division of two integers produces a <code>Rat</code> — an exact
+        rational, stored as a numerator and a denominator. That is why
+        <code>0.1 + 0.2 == 0.3</code> is <code>True</code> in Raku while it is
+        false in most languages: no binary floating point was involved.</p>
+        <p><code>div</code> is integer division, <code>%</code> is modulus, and
+        <code>%%</code> asks "is divisible by" directly, so you never write
+        <code>x % n == 0</code> again.</p>
+        <p><code>Int</code> is arbitrary precision — <code>2 ** 100</code> is
+        exact, not an overflow.</p>`,
+    },
+    'operators/strings': {
+      title: 'Strings and comparison',
+      body: `
+        <p>Raku keeps numeric and string operators separate, so an operator's
+        meaning never depends on its operands: <code>~</code> concatenates,
+        <code>+</code> adds, <code>x</code> repeats a string, and <code>eq lt
+        gt</code> compare as strings while <code>== &lt; &gt;</code> compare as
+        numbers.</p>
+        <p>The three-way comparators return an enum rather than a number:
+        <code>&lt;=&gt;</code> compares numerically and <code>cmp</code> compares
+        by type-appropriate order, both yielding <code>Less</code>,
+        <code>Same</code>, or <code>More</code>.</p>`,
+    },
+    'operators/ranges': {
+      title: 'Ranges and sequences',
+      body: `
+        <p><code>..</code> builds a <code>Range</code>. A caret on either side
+        excludes that endpoint: <code>1..^5</code> is 1 through 4. Ranges work on
+        strings too, incrementing them the way an odometer would.</p>
+        <p><code>...</code> is the sequence operator. Give it the first few
+        elements and it infers the rule — arithmetic, geometric, or a closure you
+        supply. <code>* + *</code> is a closure taking two arguments, so
+        <code>1, 1, * + * ... *</code> is the Fibonacci sequence, generated
+        lazily and forever.</p>`,
+    },
+    'operators/meta': {
+      title: 'Metaoperators',
+      body: `
+        <p>Metaoperators build new operators out of existing ones, so you learn
+        one rule instead of a hundred function names.</p>
+        <ul>
+          <li><code>[op]</code> — reduce a list with <code>op</code>:
+              <code>[+]</code> sums, <code>[*]</code> multiplies,
+              <code>[~]</code> concatenates.</li>
+          <li><code>&gt;&gt;op&lt;&lt;</code> — apply <code>op</code> element-wise
+              ("hyper"), and <code>&gt;&gt;.method</code> calls a method on every
+              element.</li>
+          <li><code>Z</code> zips two lists together; <code>X</code> takes their
+              cross product.</li>
+        </ul>
+        <p>These compose with any operator, including ones you define yourself.</p>`,
+    },
+    'operators/junctions': {
+      title: 'Junctions',
+      body: `
+        <p>A junction is a single value that is several values at once. Comparing
+        against it threads the comparison over every member and collapses the
+        result according to the junction's kind: <code>any</code>,
+        <code>all</code>, <code>one</code>, or <code>none</code>.</p>
+        <p><code>|</code> is shorthand for <code>any</code>. Junctions collapse to
+        a plain <code>Bool</code> in boolean context, and <code>so</code> forces
+        that collapse so you can print it.</p>`,
+    },
+
+    'control/conditionals': {
+      title: 'Conditionals',
+      body: `
+        <p><code>if</code>/<code>elsif</code>/<code>else</code> work as you expect,
+        and need no parentheses around the condition. <code>unless</code> is the
+        negated form.</p>
+        <p><code>with</code> is <code>if</code>'s definedness twin: it runs its
+        block when the value is <em>defined</em> (not merely true), and binds it
+        to the topic variable <code>$_</code>. <code>without</code> is its negation.</p>
+        <p>The ternary is spelled <code>?? !!</code>, keeping <code>?</code> and
+        <code>:</code> free for other jobs.</p>`,
+    },
+    'control/loops': {
+      title: 'Loops',
+      body: `
+        <p><code>for</code> iterates a list. The pointy block
+        <code>-&gt; $i { ... }</code> names the current element; without one, the
+        element lands in the topic variable <code>$_</code>.</p>
+        <p>A pointy block can take several parameters, and <code>for</code> will
+        pull that many elements per iteration — which is what makes
+        <code>.kv</code> (index, value pairs) read so naturally.</p>
+        <p>Any statement can take a trailing <code>for</code>, <code>if</code>,
+        <code>while</code> or <code>unless</code> modifier when a full block would
+        be noise.</p>`,
+    },
+    'control/given-when': {
+      title: 'given / when',
+      body: `
+        <p><code>given</code> sets the topic <code>$_</code>, and each
+        <code>when</code> smartmatches against it. Because smartmatch is
+        polymorphic, one <code>given</code> block can dispatch on a type, an exact
+        value, a regex, or a predicate — <code>when * &gt; 100</code> matches a
+        closure.</p>
+        <p>A matching <code>when</code> exits the block with its value, so no
+        <code>break</code> is needed. <code>default</code> catches the rest.</p>`,
+    },
+    'control/loop-control': {
+      title: 'Loop control',
+      body: `
+        <p><code>next</code> skips to the next iteration, <code>last</code> leaves
+        the loop, and <code>redo</code> repeats the current iteration without
+        re-evaluating the list.</p>
+        <p>Loops are expressions too: a <code>for</code> loop in a value context
+        returns the list of its iterations' values, so gathering results rarely
+        needs an accumulator variable.</p>`,
+    },
+
+    'lists/arrays': {
+      title: 'Arrays and slices',
+      body: `
+        <p><code>@a[$i]</code> indexes; a <em>list</em> of indices returns a slice,
+        and a <code>Range</code> is just such a list.</p>
+        <p>Inside a subscript, <code>*</code> stands for the number of elements, so
+        <code>@a[*-1]</code> is the last element and <code>@a[*-2]</code> the one
+        before it.</p>
+        <p>Arrays are objects: <code>.push</code>, <code>.elems</code>,
+        <code>.reverse</code>, <code>.rotate</code>, <code>.pick</code> and the
+        rest are methods on them.</p>`,
+    },
+    'lists/map-grep-sort': {
+      title: 'map, grep, sort',
+      body: `
+        <p><code>.map</code> transforms every element, <code>.grep</code> keeps the
+        ones matching a test, and <code>.sort</code> orders them.</p>
+        <p>Blocks can be written three ways, all equivalent:
+        <code>{ $_ * 2 }</code> using the topic, <code>{ $^a &lt;=&gt; $^b }</code>
+        using self-declared placeholder parameters (they sort into alphabetical
+        order), or <code>* ** 2</code> using the Whatever star, which turns an
+        expression into a closure.</p>
+        <p><code>.sort</code> given a one-argument block sorts by that key rather
+        than by the element itself, so <code>.sort(*.chars)</code> is
+        "shortest first".</p>`,
+    },
+    'lists/hashes': {
+      title: 'Hashes',
+      body: `
+        <p>A hash maps keys to values. <code>%h&lt;key&gt;</code> is the
+        literal-key subscript (no quotes needed) and <code>%h{$k}</code> takes an
+        expression.</p>
+        <p>Iterating a hash yields <code>Pair</code> objects with
+        <code>.key</code> and <code>.value</code>. Hash order is deliberately
+        randomized, so sort by whatever you actually mean before printing.</p>
+        <p>Subscript adverbs ask structural questions:
+        <code>:exists</code>, <code>:delete</code>, <code>:k</code> (keys),
+        <code>:v</code> (values), <code>:p</code> (pairs).</p>`,
+    },
+    'lists/lazy': {
+      title: 'Laziness',
+      body: `
+        <p>Sequences are lazy: elements are produced only when something asks for
+        them. That makes an infinite list an ordinary value you can pass around —
+        <code>(1..Inf).grep(*.is-prime)</code> is every prime, and
+        <code>.head(5)</code> computes exactly five of them.</p>
+        <p><code>gather</code>/<code>take</code> builds a lazy list from arbitrary
+        control flow: run the block, and every <code>take</code> contributes an
+        element. It is a coroutine in the shape of a loop.</p>`,
+    },
+
+    'subs/basics': {
+      title: 'Subroutines',
+      body: `
+        <p><code>sub</code> declares a subroutine. The last expression evaluated is
+        the return value, so an explicit <code>return</code> is optional.</p>
+        <p>Parameters may have defaults, and a default may refer to an earlier
+        parameter (<code>$h = $w</code> makes <code>area(5)</code> a square).</p>
+        <p>A <code>*@rest</code> parameter is <em>slurpy</em>: it soaks up every
+        remaining positional argument.</p>`,
+    },
+    'subs/signatures': {
+      title: 'Signatures',
+      body: `
+        <p>A signature can constrain types (<code>Str $host</code>), name
+        parameters (<code>:$port</code>, passed as <code>:port(8080)</code> or
+        <code>port =&gt; 8080</code>), and declare a return type after
+        <code>--&gt;</code>.</p>
+        <p>Named parameters are order-independent and optional by default;
+        positional ones are required by default. Adding <code>!</code> or
+        <code>?</code> flips that.</p>
+        <p>Signatures are not only for subs: blocks, <code>for</code> loops,
+        <code>catch</code> handlers and destructuring assignments all use the same
+        syntax.</p>`,
+    },
+    'subs/multi': {
+      title: 'Multiple dispatch',
+      body: `
+        <p><code>multi</code> declares one of several candidates sharing a name.
+        At each call Raku picks the <em>narrowest</em> candidate that accepts the
+        arguments — dispatching on arity, on types, on exact literal values, and
+        on <code>where</code> constraints.</p>
+        <p>That turns recursion base cases into declarations
+        (<code>multi fact(0) { 1 }</code>) and replaces long chains of type
+        checks with separate, individually readable definitions.</p>`,
+    },
+    'subs/closures': {
+      title: 'Blocks and closures',
+      body: `
+        <p>Blocks are first-class values. <code>-&gt; $a, $b { ... }</code> is a
+        block with a signature; <code>{ ... }</code> is one that takes
+        <code>$_</code>.</p>
+        <p>Every block closes over the lexical variables it can see, so the
+        <code>counter</code> sub below hands back a function with its own private
+        <code>$n</code> that survives the call.</p>
+        <p>The Whatever star builds a closure out of an expression:
+        <code>* * 2</code> means <code>{ $_ * 2 }</code>. Use it when the
+        expression is short enough that naming the parameter would only add
+        noise.</p>`,
+    },
+
+    'objects/classes': {
+      title: 'Classes',
+      body: `
+        <p><code>class</code> declares a type. <code>has $.x</code> declares an
+        attribute <em>with</em> a public read accessor; <code>has $!x</code>
+        declares a private one. Inside the class both are reachable as
+        <code>$!x</code>.</p>
+        <p>Every class gets a <code>.new</code> that takes named arguments for its
+        public attributes. Attributes can have defaults, and
+        <code>is required</code> makes one mandatory.</p>
+        <p>Defining a <code>Str</code> method is how <code>~$p</code> and string
+        interpolation learn to render your object.</p>`,
+    },
+    'objects/inheritance': {
+      title: 'Inheritance',
+      body: `
+        <p><code>is</code> sets a superclass. Methods are looked up along the
+        method resolution order, so a subclass's <code>speak</code> wins, and the
+        inherited <code>intro</code> still calls the <em>right</em> one — that is
+        dynamic dispatch.</p>
+        <p><code>self</code> is the invocant. <code>$.name</code> is shorthand for
+        <code>self.name</code>, meaning it goes through the accessor method and
+        respects overriding.</p>`,
+    },
+    'objects/roles': {
+      title: 'Roles',
+      body: `
+        <p>A role is a bundle of behaviour that gets <em>composed</em> into a class
+        with <code>does</code>. Composition is flat: the role's methods become the
+        class's own methods, and a conflict is a compile-time error rather than a
+        silently chosen winner.</p>
+        <p>Prefer roles when you want shared behaviour without claiming an
+        is-a relationship. A class still <code>~~</code>-matches every role it
+        does, so roles work as interfaces too.</p>`,
+    },
+    'objects/subsets': {
+      title: 'Subsets and enums',
+      body: `
+        <p><code>subset</code> names a type plus a predicate. It is a real type:
+        usable in signatures, in <code>where</code> clauses, and in smartmatches,
+        and it is checked when a value is bound.</p>
+        <p><code>enum</code> declares a set of named constants that are also
+        values of a new type, ordered by their numeric value.</p>
+        <p><code>try</code> runs a block and returns <code>Nil</code> instead of
+        dying when it fails, so <code>//</code> (defined-or) can supply a
+        fallback.</p>`,
+    },
+
+    'regex/matching': {
+      title: 'Matching',
+      body: `
+        <p>Raku regexes are their own sub-language, redesigned rather than
+        inherited. Whitespace inside a pattern is insignificant, so you can space
+        a pattern out for readability. Literal text goes in quotes.</p>
+        <p><code>**</code> is the repetition quantifier — <code>\\d ** 4</code> is
+        exactly four digits — and character classes are written
+        <code>&lt;[a..z]&gt;</code>.</p>
+        <p>A successful match sets <code>$/</code>, the match object, which
+        stringifies to the matched text.</p>`,
+    },
+    'regex/captures': {
+      title: 'Captures',
+      body: `
+        <p>Parentheses capture positionally into <code>$0</code>,
+        <code>$1</code>, … (numbered from zero). <code>$&lt;name&gt;=[...]</code>
+        captures by name into <code>$&lt;name&gt;</code>.</p>
+        <p>Named regexes are declared with <code>my regex name { ... }</code> and
+        called from inside another pattern as <code>&lt;name&gt;</code>. That is
+        the whole idea behind grammars: patterns that call other patterns.</p>`,
+    },
+    'regex/substitution': {
+      title: 'Substitution',
+      body: `
+        <p><code>.subst</code> returns a new string. Its replacement can be a
+        closure, which receives the match — <code>*.tc</code> title-cases each
+        one. The <code>:g</code> adverb replaces every occurrence instead of the
+        first.</p>
+        <p><code>s///</code> modifies a variable in place, and <code>.trans</code>
+        does character-by-character translation.</p>`,
+    },
+    'regex/grammars': {
+      title: 'Grammars',
+      body: `
+        <p>A grammar is a class whose methods are named patterns. Parsing starts at
+        <code>TOP</code>, and each pattern may call others by name.</p>
+        <p><code>token</code> is a pattern with backtracking disabled — the right
+        default for lexical pieces — and <code>rule</code> is a token that also
+        treats whitespace in the pattern as "allow whitespace here".</p>
+        <p><code>.parse</code> returns a match object indexed by the sub-patterns
+        that matched, or <code>Nil</code> when the whole input does not parse.</p>`,
+    },
+
+    'concurrency/promises': {
+      title: 'Promises',
+      body: `
+        <p><code>start</code> runs a block on the thread pool and immediately
+        returns a <code>Promise</code>. <code>await</code> waits for one, or for a
+        list of them, and gives back the results in order.</p>
+        <p>A <code>Promise</code> can also be created and kept (or broken) by hand,
+        which is how you bridge callback-shaped APIs into this model.</p>`,
+    },
+    'concurrency/channels': {
+      title: 'Channels',
+      body: `
+        <p>A <code>Channel</code> is a thread-safe queue: producers
+        <code>.send</code>, consumers <code>.receive</code>, and
+        <code>.close</code> signals that no more values are coming.</p>
+        <p><code>.list</code> reads the channel until it closes, which makes a
+        producer/consumer pipeline read like ordinary list processing.</p>`,
+    },
+    'concurrency/supplies': {
+      title: 'Supplies',
+      body: `
+        <p>A <code>Supply</code> is an asynchronous stream of values. Where a
+        <code>Channel</code> is pull-based, a supply pushes to whoever is tapping
+        it.</p>
+        <p><code>react</code> sets up a block that stays alive while its
+        <code>whenever</code> handlers are still expecting values, and finishes
+        when the streams are done. Supplies can be mapped, grepped and merged just
+        like lists.</p>`,
+    },
+
+    'wrapping-up/exceptions': {
+      title: 'Exceptions',
+      body: `
+        <p><code>die</code> throws. A <code>try</code> block returns
+        <code>Nil</code> on failure and puts the exception in <code>$!</code>.</p>
+        <p>A <code>CATCH</code> block inside any block handles exceptions thrown in
+        it, using <code>when</code> to match by exception type. Handled means
+        handled: control resumes after the enclosing block.</p>
+        <p>Your own exception types come from subclassing <code>Exception</code>
+        and providing a <code>message</code> method.</p>`,
+    },
+    'wrapping-up/phasers': {
+      title: 'Phasers',
+      body: `
+        <p>Phasers are blocks that run at a defined moment rather than where they
+        are written, so setup and teardown can live next to the code they belong
+        to.</p>
+        <p><code>ENTER</code>/<code>LEAVE</code> fire on entering and leaving a
+        block — <code>LEAVE</code> even when an exception unwinds it.
+        <code>FIRST</code>/<code>LAST</code> fire on the first and last iteration
+        of a loop. <code>BEGIN</code> runs at compile time.</p>`,
+    },
+    'wrapping-up/introspection': {
+      title: 'Introspection',
+      body: `
+        <p>The <code>.^</code> operator calls a method on an object's
+        <em>metaobject</em> — the object describing its type. That is the whole
+        metaobject protocol, and it is available at run time.</p>
+        <p><code>.^name</code>, <code>.^attributes</code>, <code>.^methods</code>,
+        <code>.^mro</code> (the method resolution order) and <code>.^can</code>
+        let a program inspect types
+        it was not written against, which is how serializers and test frameworks
+        are built.</p>`,
+    },
+    'wrapping-up/putting-it-together': {
+      title: 'Putting it together',
+      body: `
+        <p>A word-frequency count, using pieces from every chapter: a
+        <code>for</code> modifier, auto-vivifying hash elements, sorting by a
+        computed key (negated to sort descending, then by key to break ties), and
+        interpolated method calls.</p>
+        <p>That is the tour. From here, the
+        <a href="https://docs.raku.org/" rel="noopener">official documentation</a>
+        goes deeper on every topic here, and the
+        <a href="playground.html">playground</a> gives you a REPL that keeps its
+        state between runs.</p>`,
+    },
+  },
+};

--- a/wasm-demo/content/tutorial.ja.js
+++ b/wasm-demo/content/tutorial.ja.js
@@ -1,0 +1,415 @@
+/**
+ * Japanese prose for the tutorial.  Code and expected output live in
+ * content/lessons.txt; the keys here must match its "<chapter>/<lesson>" ids.
+ *
+ * The explanations follow the official Raku documentation (Raku/doc), vendored
+ * in this repository under raku-doc/ and used under the Artistic License 2.0.
+ */
+
+export default {
+  title: 'Raku の歩き方',
+  intro: 'どのレッスンも実際に動くプログラムです。書き換えて「実行」を押すと、' +
+    'ブラウザの中のインタプリタがその場で実行します（サーバには何も送りません）。',
+  source: '公式 Raku ドキュメント（Raku/doc）に基づいて書かれています。',
+
+  chapters: {
+    basics: 'はじめの一歩',
+    operators: '演算子',
+    control: '制御構造',
+    lists: 'リストとハッシュ',
+    subs: 'サブルーチンとシグネチャ',
+    objects: 'オブジェクト',
+    regex: '正規表現と Grammar',
+    concurrency: '並行処理',
+    'wrapping-up': 'まとめ',
+  },
+
+  lessons: {
+    'basics/hello': {
+      title: 'Hello, World',
+      body: `
+        <p>Raku のプログラムは文の並びで、各文はセミコロンで終わります。
+        <code>say</code> は引数を出力して改行します。</p>
+        <p>Raku ではほとんどすべてがメソッドを持つオブジェクトです。リテラルも例外ではなく、
+        <code>"Hello".uc</code> は文字列リテラルに対して <code>uc</code>（大文字化）
+        メソッドを呼んでいます。</p>
+        <p>コメントは <code>#</code> から行末までです。</p>`,
+    },
+    'basics/variables': {
+      title: '変数とシジル',
+      body: `
+        <p><code>my</code> はレキシカル変数を宣言します。宣言した位置から、それを囲むブロックの
+        終わりまでが有効範囲です。</p>
+        <p>先頭の記号は<strong>シジル</strong>と呼ばれ、中身の「かたち」を表します。</p>
+        <ul>
+          <li><code>$</code> — 単一の値（リストを 1 個のものとして扱う場合も含め、任意のオブジェクト）</li>
+          <li><code>@</code> — 位置で引くコンテナ（配列）</li>
+          <li><code>%</code> — キーで引くコンテナ（ハッシュ）</li>
+          <li><code>&amp;</code> — コード</li>
+        </ul>
+        <p><code>&lt;Raku Perl Rust&gt;</code> は quote-word リストで、
+        クォートもカンマも書かずに空白区切りの文字列リストを作ります。</p>`,
+    },
+    'basics/types': {
+      title: '型',
+      body: `
+        <p>Raku は漸進的型付けです。型注釈は省略できますが、実行時には型が存在します。
+        <code>.^name</code> はオブジェクトのメタオブジェクトに型名を尋ねます。
+        <code>.^</code> はオブジェクトそのものではなく<em>メタクラス</em>へのメソッド呼び出しです。</p>
+        <p><code>~~</code> はスマートマッチ演算子で、型に対しては「この値はその型に適合するか」を
+        答えます。型は木構造になっているので、<code>Int</code> は同時に <code>Cool</code>
+        （数値と文字列をよしなに変換してくれる型群）でもあり、<code>Any</code> でも
+        <code>Mu</code> でもあります。</p>`,
+    },
+    'basics/interpolation': {
+      title: '文字列の補間',
+      body: `
+        <p>ダブルクォート文字列は変数を補間します。さらに波括弧の中には<strong>任意の式</strong>
+        を書けます。整形処理の多くはこれで済むので、テンプレート専用の記法は要りません。</p>
+        <p>配列は添字を続けたときに要素が展開されるので、<code>"@xs[]"</code> は
+        「<code>@xs</code> の全要素を空白区切りで」という意味になります。裸の <code>@xs</code>
+        は文字列中ではそのままなので、メールアドレスを書いても事故になりません。</p>
+        <p>シングルクォート文字列は何も補間しません。</p>`,
+    },
+
+    'operators/numbers': {
+      title: '数値の扱い',
+      body: `
+        <p>整数どうしの除算は <code>Rat</code>（分子と分母を持つ正確な有理数）になります。
+        だから Raku では <code>0.1 + 0.2 == 0.3</code> が <code>True</code> です。
+        多くの言語で偽になるのは二進浮動小数点を経由するからで、ここではそれが起きません。</p>
+        <p><code>div</code> は整数除算、<code>%</code> は剰余、そして <code>%%</code> は
+        「割り切れるか」を直接尋ねる演算子です。<code>x % n == 0</code> と書く必要はもうありません。</p>
+        <p><code>Int</code> は多倍長なので、<code>2 ** 100</code> はオーバーフローせず正確です。</p>`,
+    },
+    'operators/strings': {
+      title: '文字列と比較',
+      body: `
+        <p>Raku は数値用と文字列用の演算子を分けているので、演算子の意味がオペランドによって
+        変わることがありません。<code>~</code> は連結、<code>+</code> は加算、
+        <code>x</code> は文字列の繰り返し、<code>eq lt gt</code> は文字列比較、
+        <code>== &lt; &gt;</code> は数値比較です。</p>
+        <p>三方比較は数値ではなく列挙値を返します。<code>&lt;=&gt;</code> は数値順、
+        <code>cmp</code> は型に応じた順序で比較し、どちらも <code>Less</code> /
+        <code>Same</code> / <code>More</code> のいずれかになります。</p>`,
+    },
+    'operators/ranges': {
+      title: '範囲と数列',
+      body: `
+        <p><code>..</code> は <code>Range</code> を作ります。どちらかの側に <code>^</code>
+        を付けるとその端点を除外するので、<code>1..^5</code> は 1 から 4 です。
+        文字列にも使え、桁上がりのように増加します。</p>
+        <p><code>...</code> は数列演算子です。最初の数項を書けば規則（等差・等比、あるいは
+        自分で書いたクロージャ）を推論します。<code>* + *</code> は 2 引数のクロージャなので、
+        <code>1, 1, * + * ... *</code> は遅延評価で無限に続くフィボナッチ数列になります。</p>`,
+    },
+    'operators/meta': {
+      title: 'メタ演算子',
+      body: `
+        <p>メタ演算子は既存の演算子から新しい演算子を組み立てます。関数名を 100 個覚える代わりに、
+        規則を 1 つ覚えれば済みます。</p>
+        <ul>
+          <li><code>[op]</code> — リストを <code>op</code> で畳み込みます。
+              <code>[+]</code> は合計、<code>[*]</code> は総乗、<code>[~]</code> は連結です。</li>
+          <li><code>&gt;&gt;op&lt;&lt;</code> — 要素ごとに <code>op</code> を適用します（ハイパー演算子）。
+              <code>&gt;&gt;.method</code> は全要素にメソッドを呼びます。</li>
+          <li><code>Z</code> は 2 つのリストを綴じ合わせ、<code>X</code> は直積を取ります。</li>
+        </ul>
+        <p>これらは自分で定義した演算子も含め、どんな演算子とも組み合わせられます。</p>`,
+    },
+    'operators/junctions': {
+      title: 'ジャンクション',
+      body: `
+        <p>ジャンクションは「複数の値であると同時に 1 つの値」です。比較するとすべての要素に対して
+        比較が分配され、ジャンクションの種類（<code>any</code> / <code>all</code> /
+        <code>one</code> / <code>none</code>）に従って結果がまとめられます。</p>
+        <p><code>|</code> は <code>any</code> の略記です。ジャンクションは真偽値文脈で普通の
+        <code>Bool</code> に潰れます。<code>so</code> はその変換を明示的に行うので、
+        そのまま出力できます。</p>`,
+    },
+
+    'control/conditionals': {
+      title: '条件分岐',
+      body: `
+        <p><code>if</code> / <code>elsif</code> / <code>else</code> は見た目どおりに動き、
+        条件を括弧で囲む必要はありません。<code>unless</code> はその否定形です。</p>
+        <p><code>with</code> は「定義されているか」を見る <code>if</code> の兄弟です。値が
+        <em>定義済み</em>（単に真であるかではなく）ならブロックを実行し、その値をトピック変数
+        <code>$_</code> に束縛します。否定形は <code>without</code> です。</p>
+        <p>三項演算子は <code>?? !!</code> と書きます。<code>?</code> と <code>:</code>
+        は他の用途のために空けてあります。</p>`,
+    },
+    'control/loops': {
+      title: 'ループ',
+      body: `
+        <p><code>for</code> はリストを反復します。ポインティブロック
+        <code>-&gt; $i { ... }</code> は現在の要素に名前を付けます。書かなければ要素はトピック変数
+        <code>$_</code> に入ります。</p>
+        <p>ポインティブロックは複数の引数を取れて、<code>for</code> はその個数ずつ要素を取り出します。
+        <code>.kv</code>（添字と値の組）が自然に読めるのはこのためです。</p>
+        <p>どの文にも <code>for</code> / <code>if</code> / <code>while</code> /
+        <code>unless</code> を後置修飾子として付けられます。ブロックを書くほどでもないときに便利です。</p>`,
+    },
+    'control/given-when': {
+      title: 'given / when',
+      body: `
+        <p><code>given</code> はトピック <code>$_</code> を設定し、各 <code>when</code>
+        がそれとスマートマッチします。スマートマッチは多相なので、1 つの <code>given</code>
+        ブロックで型・厳密な値・正規表現・述語のどれに対しても分岐できます
+        （<code>when * &gt; 100</code> はクロージャとのマッチです）。</p>
+        <p>マッチした <code>when</code> はその値を持ってブロックを抜けるので、
+        <code>break</code> は不要です。残りは <code>default</code> が受けます。</p>`,
+    },
+    'control/loop-control': {
+      title: 'ループ制御',
+      body: `
+        <p><code>next</code> は次の反復へ進み、<code>last</code> はループを抜け、
+        <code>redo</code> はリストを再評価せずに現在の反復をやり直します。</p>
+        <p>ループも式です。値が必要な文脈に置かれた <code>for</code> ループは各反復の値の
+        リストを返すので、結果を集めるために変数を用意する必要はあまりありません。</p>`,
+    },
+
+    'lists/arrays': {
+      title: '配列とスライス',
+      body: `
+        <p><code>@a[$i]</code> は添字アクセスです。添字に<em>リスト</em>を渡すとスライスになり、
+        <code>Range</code> もそのようなリストの一種です。</p>
+        <p>添字の中の <code>*</code> は要素数を表すので、<code>@a[*-1]</code> は最後の要素、
+        <code>@a[*-2]</code> はその 1 つ前です。</p>
+        <p>配列はオブジェクトです。<code>.push</code>、<code>.elems</code>、
+        <code>.reverse</code>、<code>.rotate</code>、<code>.pick</code> などはすべてメソッドです。</p>`,
+    },
+    'lists/map-grep-sort': {
+      title: 'map・grep・sort',
+      body: `
+        <p><code>.map</code> は全要素を変換し、<code>.grep</code> は条件に合う要素だけを残し、
+        <code>.sort</code> は並べ替えます。</p>
+        <p>ブロックの書き方は 3 通りあり、どれも等価です。トピックを使う
+        <code>{ $_ * 2 }</code>、自己宣言プレースホルダ引数を使う
+        <code>{ $^a &lt;=&gt; $^b }</code>（アルファベット順に引数へ割り当てられます）、
+        そして式をクロージャに変える Whatever スター <code>* ** 2</code> です。</p>
+        <p><code>.sort</code> に 1 引数のブロックを渡すと、要素そのものではなくその値をキーとして
+        並べ替えます。<code>.sort(*.chars)</code> は「短い順」という意味です。</p>`,
+    },
+    'lists/hashes': {
+      title: 'ハッシュ',
+      body: `
+        <p>ハッシュはキーと値の対応です。<code>%h&lt;key&gt;</code> はリテラルキー用の添字
+        （クォート不要）で、<code>%h{$k}</code> は式を取ります。</p>
+        <p>ハッシュを反復すると <code>.key</code> と <code>.value</code> を持つ
+        <code>Pair</code> が得られます。ハッシュの順序は意図的にランダム化されているので、
+        出力するときは意味のある順に明示的に並べ替えてください。</p>
+        <p>添字の副詞は構造についての問い合わせです。<code>:exists</code>、
+        <code>:delete</code>、<code>:k</code>（キー）、<code>:v</code>（値）、
+        <code>:p</code>（ペア）。</p>`,
+    },
+    'lists/lazy': {
+      title: '遅延評価',
+      body: `
+        <p>数列は遅延評価されます。要素は誰かが要求したときにだけ作られるので、無限リストも
+        普通の値として持ち回せます。<code>(1..Inf).grep(*.is-prime)</code> は「すべての素数」で、
+        <code>.head(5)</code> はそのうち 5 個だけを計算します。</p>
+        <p><code>gather</code> / <code>take</code> は任意の制御構造から遅延リストを作ります。
+        ブロックを実行し、<code>take</code> のたびに要素が 1 つ足されます。ループの形をした
+        コルーチンだと思ってください。</p>`,
+    },
+
+    'subs/basics': {
+      title: 'サブルーチン',
+      body: `
+        <p><code>sub</code> はサブルーチンを宣言します。最後に評価した式が戻り値になるので、
+        明示的な <code>return</code> は省略できます。</p>
+        <p>引数にはデフォルト値を与えられ、デフォルト値から前の引数を参照できます
+        （<code>$h = $w</code> なので <code>area(5)</code> は正方形になります）。</p>
+        <p><code>*@rest</code> は<em>スラーピー</em>引数で、残りの位置引数をすべて受け取ります。</p>`,
+    },
+    'subs/signatures': {
+      title: 'シグネチャ',
+      body: `
+        <p>シグネチャでは型を制約でき（<code>Str $host</code>）、名前付き引数を宣言でき
+        （<code>:$port</code>、呼び出し側は <code>:port(8080)</code> または
+        <code>port =&gt; 8080</code>）、<code>--&gt;</code> の後ろに戻り値型を書けます。</p>
+        <p>名前付き引数は順序が自由で既定では省略可能、位置引数は既定では必須です。
+        <code>!</code> や <code>?</code> を付けるとこれを反転できます。</p>
+        <p>シグネチャはサブルーチン専用ではありません。ブロック、<code>for</code> ループ、
+        例外ハンドラ、分配代入でも同じ記法を使います。</p>`,
+    },
+    'subs/multi': {
+      title: 'マルチディスパッチ',
+      body: `
+        <p><code>multi</code> は同じ名前を共有する候補の 1 つを宣言します。呼び出しのたびに
+        Raku は引数を受け付ける候補のうち<em>最も狭い</em>ものを選びます。判定材料は引数の個数、
+        型、厳密なリテラル値、そして <code>where</code> 制約です。</p>
+        <p>おかげで再帰の基底条件は宣言そのものになり
+        （<code>multi fact(0) { 1 }</code>）、長い型チェックの連鎖は独立して読める複数の定義に
+        置き換わります。</p>`,
+    },
+    'subs/closures': {
+      title: 'ブロックとクロージャ',
+      body: `
+        <p>ブロックは第一級の値です。<code>-&gt; $a, $b { ... }</code> はシグネチャ付きの
+        ブロック、<code>{ ... }</code> は <code>$_</code> を受け取るブロックです。</p>
+        <p>すべてのブロックは見えているレキシカル変数を捕捉します。下の <code>counter</code>
+        は、呼び出しが終わっても生き続ける自分専用の <code>$n</code> を持った関数を返します。</p>
+        <p>Whatever スターは式からクロージャを作ります。<code>* * 2</code> は
+        <code>{ $_ * 2 }</code> の意味です。引数に名前を付けるほうがかえって邪魔なくらい
+        短い式のときに使ってください。</p>`,
+    },
+
+    'objects/classes': {
+      title: 'クラス',
+      body: `
+        <p><code>class</code> は型を宣言します。<code>has $.x</code> は公開読み取りアクセサ
+        <em>付き</em>の属性、<code>has $!x</code> は非公開の属性です。クラスの内側からは
+        どちらも <code>$!x</code> で参照します。</p>
+        <p>すべてのクラスには公開属性を名前付き引数で受け取る <code>.new</code> が備わります。
+        属性にはデフォルト値を書け、<code>is required</code> を付けると必須になります。</p>
+        <p><code>Str</code> メソッドを定義すると、<code>~$p</code> や文字列補間が
+        そのオブジェクトの表示方法を知るようになります。</p>`,
+    },
+    'objects/inheritance': {
+      title: '継承',
+      body: `
+        <p><code>is</code> は親クラスを指定します。メソッドはメソッド解決順序に沿って探索されるので、
+        サブクラスの <code>speak</code> が優先され、継承した <code>intro</code> からも
+        <em>正しい方</em>が呼ばれます。これが動的ディスパッチです。</p>
+        <p><code>self</code> は起動対象（invocant）です。<code>$.name</code> は
+        <code>self.name</code> の略記なので、アクセサメソッドを経由し、オーバーライドを尊重します。</p>`,
+    },
+    'objects/roles': {
+      title: 'ロール',
+      body: `
+        <p>ロールは振る舞いのまとまりで、<code>does</code> によってクラスに<em>合成</em>されます。
+        合成は平坦です。ロールのメソッドはクラス自身のメソッドになり、衝突は暗黙に勝者が決まるのではなく
+        コンパイル時エラーになります。</p>
+        <p>is-a 関係を主張せずに振る舞いだけを共有したいときはロールを選びましょう。クラスは
+        自分が does しているすべてのロールに <code>~~</code> でマッチするので、
+        インタフェースとしても機能します。</p>`,
+    },
+    'objects/subsets': {
+      title: 'サブセットと列挙型',
+      body: `
+        <p><code>subset</code> は「型 + 述語」に名前を付けます。これは本物の型で、
+        シグネチャでも <code>where</code> 節でもスマートマッチでも使え、値が束縛される
+        タイミングで検査されます。</p>
+        <p><code>enum</code> は名前付き定数の集合を宣言します。それらは新しい型の値でもあり、
+        数値によって順序付けられます。</p>
+        <p><code>try</code> はブロックを実行し、失敗したら例外を投げる代わりに <code>Nil</code>
+        を返すので、<code>//</code>（定義済みor）で代替値を用意できます。</p>`,
+    },
+
+    'regex/matching': {
+      title: 'マッチング',
+      body: `
+        <p>Raku の正規表現は継承ではなく再設計された独自のサブ言語です。パターン中の空白は
+        意味を持たないので、読みやすく空けて書けます。リテラルの文字列はクォートで囲みます。</p>
+        <p><code>**</code> は繰り返し量指定子で、<code>\\d ** 4</code> はちょうど 4 桁を意味します。
+        文字クラスは <code>&lt;[a..z]&gt;</code> と書きます。</p>
+        <p>マッチが成功すると <code>$/</code>（マッチオブジェクト）が設定されます。これは
+        文字列化するとマッチした部分になります。</p>`,
+    },
+    'regex/captures': {
+      title: 'キャプチャ',
+      body: `
+        <p>丸括弧は位置キャプチャで、<code>$0</code>、<code>$1</code>… に入ります
+        （0 始まりです）。<code>$&lt;name&gt;=[...]</code> は名前付きキャプチャで、
+        <code>$&lt;name&gt;</code> で取り出せます。</p>
+        <p>名前付き正規表現は <code>my regex name { ... }</code> で宣言し、別のパターンの中から
+        <code>&lt;name&gt;</code> として呼び出します。「パターンが他のパターンを呼ぶ」——
+        これが Grammar の考え方そのものです。</p>`,
+    },
+    'regex/substitution': {
+      title: '置換',
+      body: `
+        <p><code>.subst</code> は新しい文字列を返します。置換先にはクロージャを書け、マッチが
+        渡されます（<code>*.tc</code> は各マッチを先頭大文字にします）。<code>:g</code>
+        副詞を付けると最初の 1 個ではなく全部を置換します。</p>
+        <p><code>s///</code> は変数をその場で書き換え、<code>.trans</code> は文字単位の
+        変換を行います。</p>`,
+    },
+    'regex/grammars': {
+      title: 'Grammar',
+      body: `
+        <p>Grammar は「メソッドが名前付きパターンであるクラス」です。解析は <code>TOP</code>
+        から始まり、各パターンは他のパターンを名前で呼び出せます。</p>
+        <p><code>token</code> はバックトラックを無効にしたパターンで、字句的な部品にはこれが
+        適切な既定です。<code>rule</code> はそれに加えて、パターン中の空白を
+        「ここに空白が入ってよい」の意味として扱います。</p>
+        <p><code>.parse</code> はマッチしたサブパターンで引けるマッチオブジェクトを返し、
+        入力全体が解析できなければ <code>Nil</code> を返します。</p>`,
+    },
+
+    'concurrency/promises': {
+      title: 'Promise',
+      body: `
+        <p><code>start</code> はブロックをスレッドプール上で実行し、ただちに
+        <code>Promise</code> を返します。<code>await</code> は 1 つ、またはリストの完了を待ち、
+        結果を順番どおりに返します。</p>
+        <p><code>Promise</code> は手動で作って keep（成功）や break（失敗）させることもできます。
+        コールバック形式の API をこのモデルに橋渡しするときに使います。</p>`,
+    },
+    'concurrency/channels': {
+      title: 'Channel',
+      body: `
+        <p><code>Channel</code> はスレッド安全なキューです。生産側が <code>.send</code>、
+        消費側が <code>.receive</code> し、<code>.close</code> でこれ以上値が来ないことを
+        伝えます。</p>
+        <p><code>.list</code> はチャネルが閉じるまで読み続けるので、生産者・消費者のパイプラインが
+        普通のリスト処理のように書けます。</p>`,
+    },
+    'concurrency/supplies': {
+      title: 'Supply',
+      body: `
+        <p><code>Supply</code> は値の非同期ストリームです。<code>Channel</code> が pull 型なのに対し、
+        Supply は購読している側へ push します。</p>
+        <p><code>react</code> は、<code>whenever</code> ハンドラが値を待っているあいだ生き続け、
+        ストリームが終わると終了するブロックを作ります。Supply はリストと同じように
+        map・grep・merge できます。</p>`,
+    },
+
+    'wrapping-up/exceptions': {
+      title: '例外',
+      body: `
+        <p><code>die</code> は例外を投げます。<code>try</code> ブロックは失敗時に
+        <code>Nil</code> を返し、例外を <code>$!</code> に入れます。</p>
+        <p>任意のブロックの中に置いた <code>CATCH</code> ブロックは、そのブロックで投げられた
+        例外を処理します。型による振り分けには <code>when</code> を使います。処理された例外は
+        本当に処理済みで、制御は囲みブロックの後ろから続きます。</p>
+        <p>独自の例外型は <code>Exception</code> を継承し、<code>message</code> メソッドを
+        用意すれば作れます。</p>`,
+    },
+    'wrapping-up/phasers': {
+      title: 'フェイザ',
+      body: `
+        <p>フェイザは「書かれた場所」ではなく「決められたタイミング」で実行されるブロックです。
+        おかげで前処理・後処理を、関係するコードのすぐ隣に書けます。</p>
+        <p><code>ENTER</code> / <code>LEAVE</code> はブロックの出入りで発火します
+        （<code>LEAVE</code> は例外で巻き戻る場合にも実行されます）。
+        <code>FIRST</code> / <code>LAST</code> はループの最初と最後の反復で、
+        <code>BEGIN</code> はコンパイル時に実行されます。</p>`,
+    },
+    'wrapping-up/introspection': {
+      title: 'イントロスペクション',
+      body: `
+        <p><code>.^</code> はオブジェクトの<em>メタオブジェクト</em>——その型を記述している
+        オブジェクト——に対してメソッドを呼びます。これがメタオブジェクトプロトコルであり、
+        実行時に利用できます。</p>
+        <p><code>.^name</code>、<code>.^attributes</code>、<code>.^methods</code>、
+        <code>.^mro</code>（メソッド解決順序）、<code>.^can</code>
+        を使うと、想定していなかった型もプログラムから
+        調べられます。シリアライザやテストフレームワークはこの仕組みの上に作られています。</p>`,
+    },
+    'wrapping-up/putting-it-together': {
+      title: '総仕上げ',
+      body: `
+        <p>各章の道具を使った単語頻度の集計です。後置 <code>for</code> 修飾子、
+        自動生成されるハッシュ要素、計算したキーによる並べ替え（降順にするための符号反転と、
+        同点を解決するためのキー比較）、そして補間の中のメソッド呼び出しを使っています。</p>
+        <p>ツアーはこれで終わりです。ここから先は
+        <a href="https://docs.raku.org/" rel="noopener">公式ドキュメント</a>
+        が各トピックをさらに詳しく解説しています。
+        <a href="playground.html">プレイグラウンド</a>では、
+        実行のあいだ状態が保たれる REPL を試せます。</p>`,
+    },
+  },
+};

--- a/wasm-demo/e2e.test.mjs
+++ b/wasm-demo/e2e.test.mjs
@@ -1,16 +1,24 @@
-// E2E tests for the WASM playground using Playwright
+// E2E tests for the static site (landing page, tutorial, playground) using Playwright.
 // Run: node wasm-demo/e2e.test.mjs
 //
 // Requires: npm install playwright
 // Also requires wasm-demo/pkg/ to be built:
 //   wasm-pack build --target web --no-default-features --features wasm
 //   mv pkg wasm-demo/pkg
+//
+// The tutorial sweep runs EVERY lesson in the browser and compares against the
+// expectation recorded in content/lessons.txt (which scripts/check-site-snippets.mjs
+// generated from a native mutsu run cross-checked against raku). Set
+// SKIP_LESSON_SWEEP=1 to skip it while iterating locally.
 
 import { chromium } from 'playwright';
 import { spawn } from 'child_process';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
+
+import { parseCorpus } from './assets/corpus.js';
 
 const PORT = 18765;
+const BASE = `http://localhost:${PORT}`;
 let server;
 let browser;
 let passed = 0;
@@ -47,11 +55,24 @@ async function runEditor(page, code) {
   return (await page.locator('#repl-log > div').last().textContent()).trim();
 }
 
+/** Press a snippet's Run button and return its output text. */
+async function runSnippet(page, scope = '') {
+  const btn = `${scope} .run-btn`.trim();
+  await page.click(btn);
+  await page.waitForFunction(
+    (sel) => { const b = document.querySelector(sel); return b && !b.disabled; },
+    btn, { timeout: 60000 });
+  return (await page.locator(`${scope} .output`.trim()).first().textContent()).trim();
+}
+
 // Check pkg exists
 if (!existsSync('wasm-demo/pkg/mutsu.js')) {
   console.error('Error: wasm-demo/pkg/ not found. Build WASM first.');
   process.exit(1);
 }
+
+const lessons = parseCorpus(readFileSync('wasm-demo/content/lessons.txt', 'utf8'));
+const highlights = parseCorpus(readFileSync('wasm-demo/content/highlights.txt', 'utf8'));
 
 // Start HTTP server
 server = spawn('python3', ['-m', 'http.server', String(PORT), '-d', 'wasm-demo'], {
@@ -66,9 +87,151 @@ try {
   const errors = [];
   page.on('pageerror', err => errors.push(err.message));
 
-  // --- Test: Page loads and WASM initializes ---
-  console.log('Test: WASM initialization');
-  await page.goto(`http://localhost:${PORT}/`, { waitUntil: 'networkidle' });
+  /* =============================================================== *
+   * Landing page
+   * =============================================================== */
+
+  console.log('Test: landing page');
+  await page.goto(`${BASE}/index.html?lang=en`, { waitUntil: 'networkidle' });
+  await page.waitForFunction(() => document.body.dataset.ready === '1', { timeout: 30000 });
+
+  assert((await page.textContent('#hero-title')).length > 0, 'the hero has a title');
+  assert(await page.locator('#why-cards .card').count() === highlights.length,
+         `every highlight snippet has a card (${highlights.length})`);
+  assert(await page.locator('.site-nav .nav-links a').count() >= 4, 'the nav lists the pages');
+  assert((await page.textContent('.site-footer')).includes('Raku/doc'),
+         'the footer credits the official Raku documentation');
+
+  console.log('Test: landing page language switch');
+  const enTitle = await page.textContent('#hero-title');
+  await page.click('.lang-switch button[data-lang="ja"]');
+  const jaTitle = await page.textContent('#hero-title');
+  assert(enTitle !== jaTitle, 'switching to Japanese re-renders the hero');
+  assert((await page.textContent('.site-footer')).includes('Artistic License 2.0'),
+         'the Japanese footer keeps the licence credit');
+  assert(new URL(page.url()).searchParams.get('lang') === 'ja',
+         'the language lands in the URL so links stay shareable');
+  await page.click('.lang-switch button[data-lang="en"]');
+  assert(await page.textContent('#hero-title') === enTitle, 'switching back restores English');
+
+  console.log('Test: landing page snippet runs');
+  const firstHighlight = highlights[0];
+  const cardOut = await runSnippet(page, `#card-${firstHighlight.id}`);
+  assert(cardOut === firstHighlight.expect,
+         `the "${firstHighlight.key}" card produces its expected output`);
+  assert(await page.locator(`#card-${firstHighlight.id} .verdict.ok`).count() === 1,
+         'a matching run is marked as matching');
+
+  /* =============================================================== *
+   * Tutorial
+   * =============================================================== */
+
+  console.log('Test: tutorial page');
+  await page.goto(`${BASE}/tutorial.html?lang=en`, { waitUntil: 'networkidle' });
+  await page.waitForFunction(() => document.body.dataset.ready === '1', { timeout: 30000 });
+
+  assert(await page.locator('.toc .lesson-link').count() === lessons.length,
+         `the table of contents lists every lesson (${lessons.length})`);
+  assert(await page.locator('.toc .chapter').count() ===
+         new Set(lessons.map(l => l.group)).size, 'chapters are grouped');
+  assert(await page.textContent('#lesson-title') !== '', 'the first lesson renders');
+  assert(await page.locator('#prev-btn').isDisabled(), 'Previous is disabled on lesson 1');
+
+  console.log('Test: tutorial navigation');
+  await page.click('#next-btn');
+  assert(new URL(page.url()).hash === `#${lessons[1].key}`,
+         'Next moves to the second lesson and records it in the URL');
+  const secondTitle = await page.textContent('#lesson-title');
+  await page.click('#prev-btn');
+  assert(await page.textContent('#lesson-title') !== secondTitle, 'Previous goes back');
+
+  console.log('Test: tutorial deep link');
+  const deep = lessons.find(l => l.group === 'regex');
+  await page.goto(`${BASE}/tutorial.html?lang=en#${deep.key}`, { waitUntil: 'networkidle' });
+  await page.waitForFunction(() => document.body.dataset.ready === '1', { timeout: 30000 });
+  assert((await page.inputValue('.editor-wrap textarea')).trim() === deep.code.trim(),
+         'a deep link opens that lesson with its code loaded');
+  assert(await page.locator('details.expected').count() === 1,
+         'the lesson shows its expected output');
+
+  console.log('Test: tutorial language switch keeps your edits');
+  await page.fill('.editor-wrap textarea', 'say "mine";');
+  const titleBefore = await page.textContent('#lesson-title');
+  await page.click('.lang-switch button[data-lang="ja"]');
+  assert(await page.textContent('#lesson-title') !== titleBefore,
+         'the lesson title switches to Japanese');
+  assert(await page.inputValue('.editor-wrap textarea') === 'say "mine";',
+         'switching language does not discard what you typed');
+  await page.click('.lang-switch button[data-lang="en"]');
+  await page.click('.reset-btn');
+
+  console.log('Test: tutorial marks a lesson done when its output matches');
+  await runSnippet(page);
+  assert(await page.locator('.toc .lesson-link.done').count() >= 1,
+         'a matching run marks the lesson done in the table of contents');
+  await page.click('#clear-progress');
+  assert(await page.locator('.toc .lesson-link.done').count() === 0, 'progress can be cleared');
+
+  console.log('Test: a lesson the WASM build cannot run says so');
+  const blocked = lessons.find(l => l.flags.includes('no-browser'));
+  if (blocked) {
+    await page.evaluate(k => { location.hash = k; }, blocked.key);
+    await page.waitForFunction(() => !document.querySelector('.snippet-note').hidden,
+                               { timeout: 10000 }).catch(() => {});
+    assert(!(await page.locator('.snippet-note').isHidden()),
+           `${blocked.key} explains why it cannot run in the browser`);
+    assert(await page.locator('.run-btn').isDisabled(), 'and its Run button is disabled');
+    assert((await page.textContent('.output')).trim() === blocked.expect,
+           'and it shows the output recorded from a native run');
+    await page.evaluate(k => { location.hash = k; }, deep.key);
+    await page.waitForFunction(() => document.querySelector('.snippet-note').hidden,
+                               { timeout: 10000 });
+    assert(!(await page.locator('.run-btn').isDisabled()),
+           'moving to a runnable lesson re-enables Run');
+  }
+
+  console.log('Test: tutorial edits are runnable');
+  await page.fill('.editor-wrap textarea', 'say "edited";');
+  const editedOut = await runSnippet(page);
+  assert(editedOut === 'edited', `an edited lesson runs (got: ${JSON.stringify(editedOut)})`);
+  assert(await page.locator('.verdict.differs').count() === 1,
+         'output that differs from the expectation says so');
+  await page.click('.reset-btn');
+  assert((await page.inputValue('.editor-wrap textarea')).trim() === deep.code.trim(),
+         'Reset restores the lesson code');
+
+  /* =============================================================== *
+   * Every lesson actually runs in the browser
+   * =============================================================== */
+
+  if (!process.env.SKIP_LESSON_SWEEP) {
+    const runnable = lessons.filter(l => !l.flags.includes('no-browser'));
+    console.log(`Test: all ${runnable.length} browser-runnable lessons produce their expected output`);
+    let sweepFailures = 0;
+    for (const lesson of runnable) {
+      // Navigate by hash rather than reloading: one page load means one WASM
+      // instance for the whole sweep instead of ~20 MB recompiled per lesson.
+      await page.evaluate(k => { location.hash = k; }, lesson.key);
+      await page.waitForFunction(
+        (code) => document.querySelector('.editor-wrap textarea').value.trim() === code,
+        lesson.code.trim(), { timeout: 10000 });
+      const out = await runSnippet(page);
+      if (out !== lesson.expect) {
+        sweepFailures++;
+        console.error(`  ${lesson.key}\n    expected: ${JSON.stringify(lesson.expect)}` +
+                      `\n    got:      ${JSON.stringify(out)}`);
+      }
+    }
+    assert(sweepFailures === 0,
+           `every lesson matches its recorded output (${sweepFailures} mismatched)`);
+  }
+
+  /* =============================================================== *
+   * Playground
+   * =============================================================== */
+
+  console.log('Test: playground WASM initialization');
+  await page.goto(`${BASE}/playground.html`, { waitUntil: 'networkidle' });
   await page.waitForFunction(() => document.body.dataset.ready === '1', { timeout: 30000 });
   assert(!(await page.isDisabled('#repl-input')), 'REPL input is enabled once WASM is ready');
 
@@ -171,13 +334,21 @@ try {
     };
     return enc(document.getElementById('code').value);
   });
-  await page.goto(`http://localhost:${PORT}/#code=${hash}`, { waitUntil: 'networkidle' });
+  await page.goto(`${BASE}/playground.html#code=${hash}`, { waitUntil: 'networkidle' });
   await page.waitForFunction(() => document.body.dataset.ready === '1', { timeout: 30000 });
   assert(await page.inputValue('#code') === shared,
          'a permalink restores the code, non-ASCII included');
   const sharedOut = await runEditor(page, await page.inputValue('#code'));
   assert(sharedOut === 'unicode: こんにちは',
          `the restored code runs (got: ${JSON.stringify(sharedOut)})`);
+
+  // --- Test: old index.html permalinks still work ---
+  console.log('Test: legacy permalink redirect');
+  await page.goto(`${BASE}/index.html#code=${hash}`, { waitUntil: 'networkidle' });
+  await page.waitForFunction(() => document.body.dataset.ready === '1', { timeout: 30000 });
+  assert(new URL(page.url()).pathname.endsWith('/playground.html'),
+         'an old index.html permalink redirects to the playground');
+  assert(await page.inputValue('#code') === shared, 'and still carries its code');
 
   // --- Test: No page errors (unreachable traps) ---
   console.log('Test: No WASM crashes');

--- a/wasm-demo/index.html
+++ b/wasm-demo/index.html
@@ -3,828 +3,163 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>mutsu playground - Raku in the Browser</title>
-<style>
-  :root {
-    --purple: #7B2D8B;
-    --pink: #E91E8C;
-    --dark-bg: #1a0a20;
-    --panel-bg: #2a1235;
-    --console-bg: #0d0514;
-    --border: #4a2555;
-    --text: #f0e6f6;
-    --dim: #9a7fa8;
-    --green: #7deba0;
-    --red: #ff6b8a;
-    --mono: 'Fira Code', 'Cascadia Code', 'JetBrains Mono', ui-monospace, monospace;
-    /* syntax colors */
-    --syn-comment: #7a5f88;
-    --syn-string: #ffc48a;
-    --syn-number: #9fd6ff;
-    --syn-var: #7deba0;
-    --syn-keyword: #ff86c8;
-    --syn-type: #e6a3ff;
-    --syn-op: #c8b0d4;
-  }
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body {
-    font-family: system-ui, -apple-system, sans-serif;
-    background: linear-gradient(135deg, var(--dark-bg) 0%, #2d1040 50%, #1a0a30 100%);
-    background-attachment: fixed;
-    color: var(--text);
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-  }
-  header {
-    text-align: center;
-    padding: 1.6rem 1rem 0.8rem;
-  }
-  header h1 {
-    font-size: 2.2rem;
-    background: linear-gradient(90deg, var(--purple), var(--pink));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-  }
-  header p {
-    color: var(--dim);
-    margin-top: 0.3rem;
-    font-size: 0.95rem;
-  }
-  header .links { margin-top: 0.5rem; font-size: 0.85rem; }
-  header .links a {
-    color: #e6a3ff;
-    text-decoration: none;
-    border-bottom: 1px solid rgba(230, 163, 255, .4);
-    margin: 0 0.5rem;
-  }
-  .container {
-    max-width: 1000px;
-    width: 100%;
-    margin: 0 auto;
-    padding: 0 1rem 1rem;
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 0.8rem;
-  }
-
-  /* ---- examples ---- */
-  .examples { display: flex; flex-direction: column; gap: 0.4rem; }
-  .example-group {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.35rem;
-    align-items: center;
-  }
-  .example-group .group-label {
-    color: var(--dim);
-    font-size: 0.72rem;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    min-width: 5.5rem;
-  }
-  .examples button {
-    background: var(--panel-bg);
-    border: 1px solid var(--border);
-    color: var(--dim);
-    padding: 0.25rem 0.65rem;
-    border-radius: 1rem;
-    font-size: 0.8rem;
-    cursor: pointer;
-    transition: all 0.15s;
-  }
-  .examples button:hover, .examples button:focus-visible {
-    border-color: var(--pink);
-    color: var(--text);
-    outline: none;
-  }
-  .examples button.active {
-    border-color: var(--pink);
-    color: var(--text);
-    background: #3a1a48;
-  }
-  #example-desc {
-    color: var(--dim);
-    font-size: 0.82rem;
-    min-height: 1.2em;
-    padding-left: 0.2rem;
-  }
-
-  /* ---- editor ---- */
-  .pane-title {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    color: var(--dim);
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-  }
-  .pane-title::after {
-    content: "";
-    flex: 1;
-    height: 1px;
-    background: var(--border);
-  }
-  .editor-wrap {
-    position: relative;
-    background: var(--panel-bg);
-    border: 1px solid var(--border);
-    border-radius: 0.5rem;
-    overflow: hidden;
-  }
-  .editor-wrap:focus-within {
-    border-color: var(--pink);
-    box-shadow: 0 0 0 2px rgba(233, 30, 140, 0.15);
-  }
-  /* The highlight layer and the textarea must render text identically and
-     overlap pixel-for-pixel: same font, size, padding, line-height, borders. */
-  #code, #highlight {
-    font-family: var(--mono);
-    font-size: 0.92rem;
-    line-height: 1.55;
-    padding: 0.9rem;
-    margin: 0;
-    border: 0;
-    white-space: pre-wrap;
-    word-break: break-word;
-    overflow-wrap: break-word;
-    tab-size: 4;
-  }
-  #highlight {
-    position: absolute;
-    inset: 0;
-    overflow: auto;
-    pointer-events: none;
-    color: var(--text);
-  }
-  #code {
-    position: relative;
-    display: block;
-    width: 100%;
-    min-height: 190px;
-    background: transparent;
-    color: transparent;
-    caret-color: var(--pink);
-    resize: vertical;
-    outline: none;
-    overflow: auto;
-  }
-  #code::selection { background: rgba(233, 30, 140, 0.35); }
-  .tok-comment { color: var(--syn-comment); font-style: italic; }
-  .tok-string  { color: var(--syn-string); }
-  .tok-number  { color: var(--syn-number); }
-  .tok-var     { color: var(--syn-var); }
-  .tok-keyword { color: var(--syn-keyword); font-weight: 600; }
-  .tok-type    { color: var(--syn-type); }
-  .tok-op      { color: var(--syn-op); }
-
-  .toolbar {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-    flex-wrap: wrap;
-  }
-  #run-btn {
-    background: linear-gradient(135deg, var(--purple), var(--pink));
-    border: none;
-    color: white;
-    padding: 0.5rem 1.4rem;
-    border-radius: 0.4rem;
-    font-size: 0.95rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: opacity 0.15s;
-  }
-  #run-btn:hover { opacity: 0.9; }
-  #run-btn:disabled { opacity: 0.5; cursor: wait; }
-  .ghost-btn {
-    background: transparent;
-    border: 1px solid var(--border);
-    color: var(--dim);
-    padding: 0.45rem 0.9rem;
-    border-radius: 0.4rem;
-    font-size: 0.85rem;
-    cursor: pointer;
-    transition: all 0.15s;
-  }
-  .ghost-btn:hover { border-color: var(--pink); color: var(--text); }
-  .hint { color: var(--dim); font-size: 0.78rem; }
-  .grow { flex: 1; }
-
-  /* ---- REPL ---- */
-  .repl {
-    background: var(--console-bg);
-    border: 1px solid var(--border);
-    border-radius: 0.5rem;
-    font-family: var(--mono);
-    font-size: 0.88rem;
-    line-height: 1.5;
-    display: flex;
-    flex-direction: column;
-    min-height: 220px;
-    max-height: 460px;
-  }
-  .repl:focus-within { border-color: var(--pink); }
-  #repl-log {
-    flex: 1;
-    overflow-y: auto;
-    padding: 0.8rem 0.8rem 0;
-    white-space: pre-wrap;
-    word-break: break-word;
-  }
-  #repl-log .echo { color: var(--text); }
-  #repl-log .echo .prompt { color: var(--pink); user-select: none; }
-  #repl-log .out { color: var(--green); }
-  #repl-log .out.error { color: var(--red); }
-  #repl-log .note { color: var(--dim); font-style: italic; }
-  .repl-input-line {
-    display: flex;
-    align-items: baseline;
-    gap: 0.4rem;
-    padding: 0.4rem 0.8rem 0.8rem;
-  }
-  #repl-prompt { color: var(--pink); user-select: none; }
-  #repl-input {
-    flex: 1;
-    background: transparent;
-    border: none;
-    outline: none;
-    color: var(--text);
-    font-family: inherit;
-    font-size: inherit;
-  }
-  #repl-input:disabled { opacity: 0.5; }
-
-  footer {
-    text-align: center;
-    padding: 1.2rem;
-    color: var(--dim);
-    font-size: 0.8rem;
-  }
-  footer a { color: var(--pink); text-decoration: none; }
-  footer a:hover { text-decoration: underline; }
-
-  #toast {
-    position: fixed;
-    left: 50%;
-    bottom: 1.5rem;
-    transform: translateX(-50%) translateY(1rem);
-    background: var(--panel-bg);
-    border: 1px solid var(--pink);
-    color: var(--text);
-    padding: 0.5rem 1rem;
-    border-radius: 0.4rem;
-    font-size: 0.85rem;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.2s, transform 0.2s;
-  }
-  #toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
-
-  @media (max-width: 640px) {
-    .example-group .group-label { min-width: 100%; }
-  }
-</style>
+<title>mutsu — Raku in the browser</title>
+<meta name="description" content="An introduction to the Raku programming language, with every example runnable in the browser. Powered by mutsu, a Raku interpreter written in Rust and compiled to WebAssembly.">
+<link rel="stylesheet" href="assets/site.css">
 </head>
 <body>
 
-<header>
-  <h1>mutsu playground</h1>
-  <p>A Raku interpreter in the browser, powered by Rust + WebAssembly</p>
-  <p class="links">
-    <a href="https://github.com/tokuhirom/mutsu">GitHub</a>
-    <a href="bench-trend.html">📈 Benchmark trend</a>
+<nav class="site-nav"></nav>
+
+<noscript>
+  <p class="section">This site runs a Raku interpreter in your browser, so it needs
+  JavaScript and WebAssembly enabled. The language itself is documented at
+  <a href="https://docs.raku.org/">docs.raku.org</a>.</p>
+</noscript>
+
+<header class="hero">
+  <h1 id="hero-title"></h1>
+  <p class="tagline" id="hero-tagline"></p>
+  <p class="sub" id="hero-sub"></p>
+  <p class="cta">
+    <a class="btn" id="cta-tutorial" href="tutorial.html"></a>
+    <a class="btn-ghost" id="cta-playground" href="playground.html"></a>
   </p>
 </header>
 
-<div class="container">
-  <div class="examples" id="examples"></div>
-  <div id="example-desc">Pick an example, edit it, then poke at the result from the REPL below.</div>
+<main>
+  <section class="section" id="why-section">
+    <h2 id="why-heading"></h2>
+    <p class="lede" id="why-lede"></p>
+    <div id="why-cards"></div>
+  </section>
 
-  <div>
-    <div class="pane-title">Editor</div>
-    <div class="editor-wrap">
-      <pre id="highlight" aria-hidden="true"></pre>
-      <textarea id="code" spellcheck="false" autocapitalize="off" autocorrect="off"
-                placeholder="Write your Raku code here...">say "Hello from mutsu!";</textarea>
-    </div>
-  </div>
+  <section class="section" id="next-section">
+    <h2 id="next-heading"></h2>
+    <p class="lede" id="next-lede"></p>
+    <div id="next-cards"></div>
+  </section>
+</main>
 
-  <div class="toolbar">
-    <button id="run-btn">Run &#9654;</button>
-    <span class="hint">Ctrl+Enter</span>
-    <span class="grow"></span>
-    <button id="share-btn" class="ghost-btn">Share link</button>
-    <button id="reset-btn" class="ghost-btn">Reset session</button>
-  </div>
-
-  <div>
-    <div class="pane-title">REPL &mdash; shares the editor's interpreter state</div>
-    <div class="repl">
-      <div id="repl-log"></div>
-      <div class="repl-input-line">
-        <span id="repl-prompt">&gt;</span>
-        <input id="repl-input" type="text" spellcheck="false" autocapitalize="off"
-               autocorrect="off" autocomplete="off" disabled
-               placeholder="loading...">
-      </div>
-    </div>
-  </div>
-</div>
-
-<footer>
-  <a href="https://github.com/tokuhirom/mutsu">mutsu</a> &mdash; a Raku interpreter written in Rust
-</footer>
-
-<div id="toast"></div>
+<footer class="site-footer"></footer>
 
 <script type="module">
-import init, { Repl } from './pkg/mutsu.js';
+import { renderChrome, currentLang, langHref } from './assets/i18n.js';
+import { parseCorpus } from './assets/corpus.js';
+import { createSnippet } from './assets/snippet.js';
 
-const codeEl = document.getElementById('code');
-const highlightEl = document.getElementById('highlight');
-const runBtn = document.getElementById('run-btn');
-const shareBtn = document.getElementById('share-btn');
-const resetBtn = document.getElementById('reset-btn');
-const logEl = document.getElementById('repl-log');
-const inputEl = document.getElementById('repl-input');
-const promptEl = document.getElementById('repl-prompt');
-const descEl = document.getElementById('example-desc');
-const examplesEl = document.getElementById('examples');
-const toastEl = document.getElementById('toast');
+import landingEn from './content/landing.en.js';
+import landingJa from './content/landing.ja.js';
 
-/* ------------------------------------------------------------------ *
- * Examples
- * ------------------------------------------------------------------ */
+const LANDING = { en: landingEn, ja: landingJa };
 
-const EXAMPLES = [
-  { group: 'Basics', name: 'Hello', desc: 'The obligatory greeting.',
-    code: `say "Hello, World!";` },
-  { group: 'Basics', name: 'FizzBuzz', desc: '%% is the "divisible by" operator - no modulo-equals-zero dance.',
-    code: `for 1..20 -> $n {
-    if    $n %% 15 { say "FizzBuzz" }
-    elsif $n %% 3  { say "Fizz" }
-    elsif $n %% 5  { say "Buzz" }
-    else           { say $n }
-}` },
-  { group: 'Basics', name: 'Rationals', desc: 'Raku divides into exact Rats, so 0.1 + 0.2 == 0.3 really is True.',
-    code: `say 0.1 + 0.2 == 0.3;      # True - not a Num!
-my $third = 1 / 3;
-say $third;                # 0.333333
-say $third.nude;           # (1 3) - numerator and denominator
-say $third * 3 == 1;       # True
-say 2 ** 100;              # arbitrary precision Int` },
-  { group: 'Basics', name: 'Ranges', desc: 'Ranges are first-class and work on strings too.',
-    code: `say (1..10).sum;
-say ('a'..'e').join('-');
-say (1..*).head(5);        # infinite range, lazily taken
-say (1..10).grep(*.is-prime);` },
+/* ---- static text ------------------------------------------------- */
 
-  { group: 'Functional', name: 'Map & Grep', desc: '* builds a lambda: * ** 2 is "square it".',
-    code: `my @nums = 1..10;
-my @evens = @nums.grep(* %% 2);
-my @squares = @evens.map(* ** 2);
-say "Evens:   @evens[]";
-say "Squares: @squares[]";` },
-  { group: 'Functional', name: 'Sequences', desc: 'The ... operator infers the rule and produces a lazy sequence.',
-    code: `my @fib = 0, 1, * + * ... *;
-say @fib[^10];
-
-say (1, 2, 4 ... 64);      # geometric, inferred
-say ('a' ... 'j').join;` },
-  { group: 'Functional', name: 'Reduce & Hyper', desc: '[+] reduces with +; >>.<< applies a method element-wise.',
-    code: `say [+] 1..10;             # 55
-say [*] 1..5;              # 120
-say [~] <hello world>;
-say [max] 3, 9, 2;
-
-my @a = 1, 2, 3;
-say @a >>*>> 10;           # hyper: (10 20 30)
-say (-5, 3, -1)>>.abs;` },
-  { group: 'Functional', name: 'gather/take', desc: 'gather/take is a coroutine-ish lazy list producer.',
-    code: `my @collatz = gather {
-    my $n = 27;
-    while $n > 1 {
-        take $n;
-        $n = $n %% 2 ?? $n div 2 !! 3 * $n + 1;
-    }
-    take 1;
+function paintText() {
+  const L = LANDING[currentLang()];
+  document.getElementById('hero-title').textContent = L.hero.title;
+  document.getElementById('hero-tagline').textContent = L.hero.tagline;
+  document.getElementById('hero-sub').textContent = L.hero.sub;
+  const tut = document.getElementById('cta-tutorial');
+  const play = document.getElementById('cta-playground');
+  tut.textContent = L.hero.startTutorial;
+  tut.href = langHref('tutorial.html');
+  play.textContent = L.hero.openPlayground;
+  play.href = langHref('playground.html');
+  document.getElementById('why-heading').textContent = L.why.heading;
+  document.getElementById('why-lede').textContent = L.why.lede;
+  document.getElementById('next-heading').textContent = L.next.heading;
+  document.getElementById('next-lede').textContent = L.next.lede;
 }
-say @collatz.elems;
-say @collatz.head(10);
-say @collatz.max;` },
-  { group: 'Functional', name: 'Junctions', desc: 'One value that is several values at once - comparisons thread over it.',
-    code: `my $x = 5;
-say "in the set"   if $x == any(3, 5, 9);
-say "all positive" if all(1, 2, $x) > 0;
-say "none is even" if none(1, 3, $x) %% 2;
-say so 5 == 3 | 5 | 9;     # | is the any-junction operator` },
-  { group: 'Functional', name: 'Sets & Bags', desc: 'Set operators use real math symbols (ASCII alternatives exist).',
-    code: `my $a = set <apple banana cherry>;
-my $b = set <banana cherry durian>;
-say $a (&) $b;             # intersection
-say $a (|) $b;             # union
-say $a (-) $b;             # difference
-say 'apple' (elem) $a;
 
-my $bag = bag <a b a c a b>;
-say $bag<a>;               # 3
-say $bag.sort(-*.value).head(2).map(*.key);` },
+/* ---- highlight cards --------------------------------------------- */
 
-  { group: 'Objects', name: 'Classes', desc: 'has $.x gives a public accessor; has $!x stays private.',
-    code: `class Point {
-    has $.x is required;
-    has $.y is required;
-    method distance { sqrt($.x ** 2 + $.y ** 2) }
-    method Str { "($.x, $.y)" }
-}
-my $p = Point.new(x => 3, y => 4);
-say $p;                    # .gist - the default rendering
-say ~$p;                   # our Str method
-say $p.distance;` },
-  { group: 'Objects', name: 'Roles', desc: 'Roles compose behaviour into classes - flat, not inherited.',
-    code: `role Greet {
-    method greet { "Hi, I am { self.name }" }
-}
-class Dog does Greet {
-    has $.name;
-    method speak { "Woof!" }
-}
-my $d = Dog.new(name => 'Rex');
-say $d.greet;
-say $d.speak;
-say $d ~~ Greet;` },
-  { group: 'Objects', name: 'Multi dispatch', desc: 'Dispatch on type, arity, and even on a where-constraint.',
-    code: `multi fact(0) { 1 }
-multi fact(Int $n where * > 0) { $n * fact($n - 1) }
-say fact(10);
+const cardsEl = document.getElementById('why-cards');
+const cards = [];
 
-multi describe(Int $n) { "an Int: $n" }
-multi describe(Str $s) { "a Str: $s" }
-multi describe(@a)     { "a list of {@a.elems}" }
-say describe($_) for 42, "hi", [1,2,3];` },
-  { group: 'Objects', name: 'Subsets', desc: 'A named type plus a predicate - checked at binding time.',
-    code: `subset Even of Int where * %% 2;
-sub halve(Even $n) { $n div 2 }
-say halve(10);
+function buildCards(corpus) {
+  for (const entry of corpus) {
+    const card = document.createElement('section');
+    card.className = 'card';
+    card.id = `card-${entry.id}`;
 
-my $err = try { halve(7) };
-say $!.^name if $!;` },
+    const h = document.createElement('h3');
+    const body = document.createElement('p');
+    body.className = 'card-body';
+    const snippetHost = document.createElement('div');
 
-  { group: 'Text', name: 'Regex', desc: 'Raku regexes: whitespace is free, <[...]> is a character class.',
-    code: `my $str = "Hello World 2026";
-if $str ~~ / (<[A..Z]>\\w+) \\s (\\w+) \\s (\\d ** 4) / {
-    say "matched: $/";
-    say "first:   $0";
-    say "year:    $2";
-}
-say "a1b2c3".comb(/\\d/).join(',');
-say "2026-07-22".split('-').map(+*);` },
-  { group: 'Text', name: 'Named rules', desc: 'Regexes can be named and nested, which is how grammars are built.',
-    code: `my regex ident { <[a..zA..Z_]> \\w* }
-my regex num   { \\d+ }
-if "count = 42" ~~ / <ident> \\s* '=' \\s* <num> / {
-    say "name  = ", ~$<ident>;
-    say "value = ", +$<num>;
-}` },
-  { group: 'Text', name: 'Substitution', desc: 'S/// returns a new string; :g goes global.',
-    code: `my $s = "the quick brown fox";
-say $s.subst('quick', 'slow');
-say $s.subst(/\\w+/, *.tc, :g);
-say $s.trans('aeiou' => 'AEIOU');
-say $s.words.map(*.tc).join(' ');` },
-  { group: 'Text', name: 'Strings', desc: 'Interpolation runs arbitrary code inside { }.',
-    code: `my @xs = 1..5;
-say "sum of @xs[] is { @xs.sum }";
-say "unicode: \\c[SNOWMAN] { "snow" x 3 }";
-say "raku".flip, " ", "abc".uc, " ", "Hello".chars;
-say "%.3f".sprintf(pi);` },
-];
+    card.append(h, body, snippetHost);
+    cardsEl.appendChild(card);
 
-let activeExample = null;
-
-function renderExamples() {
-  const groups = [];
-  for (const ex of EXAMPLES) {
-    let g = groups.find(g => g.name === ex.group);
-    if (!g) groups.push(g = { name: ex.group, items: [] });
-    g.items.push(ex);
-  }
-  for (const g of groups) {
-    const row = document.createElement('div');
-    row.className = 'example-group';
-    const label = document.createElement('span');
-    label.className = 'group-label';
-    label.textContent = g.name;
-    row.appendChild(label);
-    for (const ex of g.items) {
-      const btn = document.createElement('button');
-      btn.textContent = ex.name;
-      btn.title = ex.desc;
-      btn.addEventListener('click', () => loadExample(ex, btn));
-      row.appendChild(btn);
-    }
-    examplesEl.appendChild(row);
+    const snippet = createSnippet(snippetHost, {
+      code: entry.code,
+      expect: entry.expect,
+      minHeight: '6.5rem',
+      noBrowser: entry.flags.includes('no-browser'),
+    });
+    cards.push({ key: entry.key, h, body, snippet });
   }
 }
 
-function loadExample(ex, btn) {
-  setCode(ex.code);
-  descEl.textContent = ex.desc;
-  if (activeExample) activeExample.classList.remove('active');
-  activeExample = btn || null;
-  if (btn) btn.classList.add('active');
-  codeEl.focus();
-}
-
-/* ------------------------------------------------------------------ *
- * Syntax highlighting
- *
- * A deliberately small Raku-flavoured tokenizer: it is a highlighter, not
- * a parser, so it aims to be right on ordinary code and never to throw.
- * ------------------------------------------------------------------ */
-
-const KEYWORDS = new Set([
-  'my','our','has','state','let','temp','constant','sub','method','multi','only','proto',
-  'submethod','class','role','grammar','token','rule','regex','module','package','enum',
-  'subset','unit','if','elsif','else','unless','with','without','while','until','for','loop',
-  'repeat','given','when','default','return','return-rw','last','next','redo','do','try',
-  'CATCH','CONTROL','BEGIN','END','INIT','ENTER','LEAVE','FIRST','use','need','require',
-  'import','is','does','where','returns','of','handles','start','await','react','whenever',
-  'supply','gather','take','say','print','put','note','die','fail','so','not','and','or',
-  'andthen','orelse','xor','eq','ne','lt','gt','le','ge','cmp','leg','x','xx','div','mod',
-  'gcd','lcm','elem','cont','self','sort','map','grep','first','reduce','new',
-]);
-
-const TOKEN_RE = new RegExp([
-  /(?<comment>#.*)/,
-  /(?<pod>^=\w+[\s\S]*?^=end\s+\w+$|^=\w+.*$)/,
-  /(?<qstring>\b(?:q|qq|qw|rx|m|s|tr)\s*(?:\:\w+\s*)*[\/{|(<\[][\s\S]*?[\/}|)>\]])/,
-  /(?<string>"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|<(?:[^<>\n])*>)/,
-  /(?<number>\b\d[\d_]*(?:\.\d+)?(?:e[-+]?\d+)?\b|\bpi\b|\be\b|\bInf\b|\bNaN\b)/,
-  /(?<variable>[$@%&][.!^*?:=~]?[\w'-]+|\$[\/!_0-9]|\$\^\w+)/,
-  /(?<word>[A-Za-z_][\w-]*)/,
-  /(?<op>[-+*\/~%^?!<>=|&.,;:\\()\[\]{}]+)/,
-].map(r => r.source).join('|'), 'gm');
-
-function escapeHtml(s) {
-  return s.replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
-}
-
-function highlight(src) {
-  let out = '';
-  let last = 0;
-  TOKEN_RE.lastIndex = 0;
-  let m;
-  while ((m = TOKEN_RE.exec(src)) !== null) {
-    if (m.index > last) out += escapeHtml(src.slice(last, m.index));
-    const g = m.groups;
-    const text = escapeHtml(m[0]);
-    if (g.comment || g.pod) out += `<span class="tok-comment">${text}</span>`;
-    else if (g.qstring || g.string) out += `<span class="tok-string">${text}</span>`;
-    else if (g.number) out += `<span class="tok-number">${text}</span>`;
-    else if (g.variable) out += `<span class="tok-var">${text}</span>`;
-    else if (g.word) {
-      if (KEYWORDS.has(m[0])) out += `<span class="tok-keyword">${text}</span>`;
-      else if (/^[A-Z]/.test(m[0])) out += `<span class="tok-type">${text}</span>`;
-      else out += text;
-    }
-    else if (g.op) out += `<span class="tok-op">${text}</span>`;
-    else out += text;
-    last = m.index + m[0].length;
-    if (m[0].length === 0) TOKEN_RE.lastIndex++;   // never loop forever
-  }
-  out += escapeHtml(src.slice(last));
-  return out;
-}
-
-function syncHighlight() {
-  // Trailing newline needs a filler so the <pre> keeps the textarea's height.
-  highlightEl.innerHTML = highlight(codeEl.value) + '\n';
-  highlightEl.scrollTop = codeEl.scrollTop;
-  highlightEl.scrollLeft = codeEl.scrollLeft;
-}
-
-function setCode(text) {
-  codeEl.value = text;
-  syncHighlight();
-}
-
-codeEl.addEventListener('input', syncHighlight);
-codeEl.addEventListener('scroll', () => {
-  highlightEl.scrollTop = codeEl.scrollTop;
-  highlightEl.scrollLeft = codeEl.scrollLeft;
-});
-
-/* ------------------------------------------------------------------ *
- * REPL log
- * ------------------------------------------------------------------ */
-
-function appendLog(text, cls) {
-  if (!text) return;
-  const div = document.createElement('div');
-  div.className = cls;
-  div.textContent = text.replace(/\n$/, '');
-  logEl.appendChild(div);
-  logEl.scrollTop = logEl.scrollHeight;
-  return div;
-}
-
-function appendEcho(prompt, text) {
-  const div = document.createElement('div');
-  div.className = 'echo';
-  const p = document.createElement('span');
-  p.className = 'prompt';
-  p.textContent = prompt + ' ';
-  div.appendChild(p);
-  div.appendChild(document.createTextNode(text));
-  logEl.appendChild(div);
-  logEl.scrollTop = logEl.scrollHeight;
-}
-
-function appendOutput(text) {
-  if (!text) return;
-  const isError = /(^|\n)Error:/.test(text);
-  appendLog(text, 'out' + (isError ? ' error' : ''));
-}
-
-function toast(msg) {
-  toastEl.textContent = msg;
-  toastEl.classList.add('show');
-  setTimeout(() => toastEl.classList.remove('show'), 1600);
-}
-
-/* ------------------------------------------------------------------ *
- * WASM session
- * ------------------------------------------------------------------ */
-
-let repl = null;
-
-async function initWasm() {
-  appendLog('Loading mutsu WASM module...', 'note');
-  try {
-    await init();
-    repl = new Repl();
-    logEl.innerHTML = '';
-    appendLog('mutsu - a Raku interpreter in Rust + WebAssembly.', 'note');
-    appendLog('Type an expression and hit Enter. The editor above shares this session.', 'note');
-    inputEl.disabled = false;
-    inputEl.placeholder = '';
-    document.body.dataset.ready = '1';
-    inputEl.focus();
-  } catch (e) {
-    appendLog('Failed to load WASM module: ' + e.message, 'out error');
+function paintCards() {
+  const L = LANDING[currentLang()];
+  for (const c of cards) {
+    const text = L.snippets[c.key] || { title: c.key, body: '' };
+    c.h.textContent = text.title;
+    // Prose is a literal from the content modules, never user input.
+    c.body.innerHTML = text.body;
   }
 }
 
-/** Rust panics abort the wasm instance; everything after is garbage. */
-function fatal(e) {
-  appendLog('WASM error: ' + e.message, 'out error');
-  appendLog('The session is unusable - press "Reset session" to start a fresh one.', 'note');
-}
+/* ---- "where to go next" cards ------------------------------------ */
 
-function runEditor() {
-  if (!repl) return;
-  const code = codeEl.value;
-  if (!code.trim()) return;
-  runBtn.disabled = true;
-  // Let the disabled state paint before we block the thread on the VM.
-  setTimeout(() => {
-    appendEcho('#', 'run editor buffer');
-    try {
-      const res = JSON.parse(repl.evalBlock(code));
-      appendOutput(res.output || '(no output)');
-    } catch (e) {
-      fatal(e);
-    }
-    runBtn.disabled = false;
-    updatePrompt();
-  }, 10);
-}
+const nextEl = document.getElementById('next-cards');
 
-function updatePrompt() {
-  promptEl.textContent = repl && repl.isPending() ? '*' : '>';
-}
-
-/* history: newest last, index === length means "editing a fresh line" */
-const history = [];
-let historyIndex = 0;
-let draft = '';
-
-function submitLine() {
-  if (!repl) return;
-  const line = inputEl.value;
-  appendEcho(promptEl.textContent, line);
-  inputEl.value = '';
-  if (line.trim() !== '' && history[history.length - 1] !== line) history.push(line);
-  historyIndex = history.length;
-  draft = '';
-  try {
-    const res = JSON.parse(repl.evalLine(line));
-    appendOutput(res.output);
-  } catch (e) {
-    fatal(e);
-  }
-  updatePrompt();
-}
-
-inputEl.addEventListener('keydown', (e) => {
-  if (e.key === 'Enter') {
-    e.preventDefault();
-    submitLine();
-  } else if (e.key === 'ArrowUp') {
-    if (historyIndex > 0) {
-      if (historyIndex === history.length) draft = inputEl.value;
-      historyIndex--;
-      inputEl.value = history[historyIndex];
-      e.preventDefault();
-    }
-  } else if (e.key === 'ArrowDown') {
-    if (historyIndex < history.length) {
-      historyIndex++;
-      inputEl.value = historyIndex === history.length ? draft : history[historyIndex];
-      e.preventDefault();
-    }
-  } else if (e.key === 'l' && e.ctrlKey) {
-    logEl.innerHTML = '';
-    e.preventDefault();
-  }
-});
-
-codeEl.addEventListener('keydown', (e) => {
-  if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-    e.preventDefault();
-    runEditor();
-  }
-});
-
-runBtn.addEventListener('click', runEditor);
-
-resetBtn.addEventListener('click', () => {
-  if (!repl) return;
-  try {
-    repl.reset();
-  } catch (e) {
-    // A panicked instance cannot reset itself; build a brand new one.
-    repl = new Repl();
-  }
-  logEl.innerHTML = '';
-  appendLog('Session reset - all variables and declarations are gone.', 'note');
-  updatePrompt();
-  inputEl.focus();
-});
-
-/* ------------------------------------------------------------------ *
- * Permalinks: #code=<base64url of UTF-8>
- * ------------------------------------------------------------------ */
-
-function encodeCode(text) {
-  const bytes = new TextEncoder().encode(text);
-  let bin = '';
-  for (const b of bytes) bin += String.fromCharCode(b);
-  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
-function decodeCode(enc) {
-  const b64 = enc.replace(/-/g, '+').replace(/_/g, '/');
-  const bin = atob(b64);
-  const bytes = Uint8Array.from(bin, c => c.charCodeAt(0));
-  return new TextDecoder().decode(bytes);
-}
-
-shareBtn.addEventListener('click', async () => {
-  const url = location.origin + location.pathname + '#code=' + encodeCode(codeEl.value);
-  try {
-    await navigator.clipboard.writeText(url);
-    toast('Link copied to clipboard');
-  } catch {
-    location.hash = 'code=' + encodeCode(codeEl.value);
-    toast('Link is in the address bar');
-  }
-});
-
-function loadFromHash() {
-  const m = /^#code=(.+)$/.exec(location.hash);
-  if (!m) return false;
-  try {
-    setCode(decodeCode(m[1]));
-    descEl.textContent = 'Loaded from a shared link.';
-    return true;
-  } catch {
-    return false;
+function paintNext() {
+  const L = LANDING[currentLang()];
+  nextEl.textContent = '';
+  for (const card of L.next.cards) {
+    const el = document.createElement('section');
+    el.className = 'card';
+    const h = document.createElement('h3');
+    h.textContent = card.title;
+    const p = document.createElement('p');
+    p.className = 'card-body';
+    p.innerHTML = card.body;
+    const a = document.createElement('a');
+    a.className = 'btn-ghost';
+    a.href = card.href.startsWith('http') ? card.href : langHref(card.href);
+    if (card.href.startsWith('http')) a.rel = 'noopener';
+    a.textContent = card.cta;
+    el.append(h, p, a);
+    nextEl.appendChild(el);
   }
 }
 
-/* ------------------------------------------------------------------ *
- * Boot
- * ------------------------------------------------------------------ */
+function paintAll() {
+  paintText();
+  paintCards();
+  paintNext();
+}
 
-renderExamples();
-if (!loadFromHash()) syncHighlight();
-initWasm();
+/* ---- boot -------------------------------------------------------- */
+
+async function main() {
+  renderChrome('home');
+  buildCards(parseCorpus(await (await fetch('content/highlights.txt')).text()));
+  window.addEventListener('langchange', paintAll);
+  paintAll();
+  document.body.dataset.ready = '1';
+}
+
+// A permalink from the old single-page playground still points at index.html.
+// Redirect *instead of* running main(), so the pending navigation cannot abort
+// a fetch we started (an aborted fetch is an unhandled rejection).
+if (/^#code=/.test(location.hash)) {
+  location.replace('playground.html' + location.search + location.hash);
+} else {
+  main();
+}
 </script>
 
 </body>

--- a/wasm-demo/package.json
+++ b/wasm-demo/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "mutsu-site",
+  "private": true,
+  "type": "module",
+  "description": "Marks the static site's content modules as ESM so Node can import them directly (scripts/check-site-snippets.mjs)."
+}

--- a/wasm-demo/playground.html
+++ b/wasm-demo/playground.html
@@ -1,0 +1,472 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>mutsu playground — Raku in the browser</title>
+<meta name="description" content="An in-browser Raku playground and REPL, powered by mutsu — a Raku interpreter written in Rust and compiled to WebAssembly.">
+<link rel="stylesheet" href="assets/site.css">
+</head>
+<body>
+
+<nav class="site-nav"></nav>
+
+<noscript>
+  <p class="section">The playground runs a Raku interpreter in your browser, so it needs
+  JavaScript and WebAssembly enabled. The language itself is documented at
+  <a href="https://docs.raku.org/">docs.raku.org</a>.</p>
+</noscript>
+
+<div class="container">
+  <div class="examples" id="examples"></div>
+  <div id="example-desc">Pick an example, edit it, then poke at the result from the REPL below.</div>
+
+  <div>
+    <div class="pane-title">Editor</div>
+    <div id="editor-host"></div>
+  </div>
+
+  <div class="run-row">
+    <button id="run-btn" class="btn">Run &#9654;</button>
+    <span class="hint">Ctrl+Enter</span>
+    <span class="grow"></span>
+    <button id="share-btn" class="btn-ghost">Share link</button>
+    <button id="reset-btn" class="btn-ghost">Reset session</button>
+  </div>
+
+  <div>
+    <div class="pane-title">REPL &mdash; shares the editor's interpreter state</div>
+    <div class="repl">
+      <div id="repl-log"></div>
+      <div class="repl-input-line">
+        <span id="repl-prompt">&gt;</span>
+        <input id="repl-input" type="text" spellcheck="false" autocapitalize="off"
+               autocorrect="off" autocomplete="off" disabled aria-label="REPL input"
+               placeholder="loading...">
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer class="site-footer"></footer>
+
+<div id="toast"></div>
+
+<script type="module">
+import { renderChrome } from './assets/i18n.js';
+import { createEditor } from './assets/editor.js';
+import { createSession } from './assets/runner.js';
+
+renderChrome('playground');
+
+const runBtn = document.getElementById('run-btn');
+const shareBtn = document.getElementById('share-btn');
+const resetBtn = document.getElementById('reset-btn');
+const logEl = document.getElementById('repl-log');
+const inputEl = document.getElementById('repl-input');
+const promptEl = document.getElementById('repl-prompt');
+const descEl = document.getElementById('example-desc');
+const examplesEl = document.getElementById('examples');
+const toastEl = document.getElementById('toast');
+
+/* ------------------------------------------------------------------ *
+ * Examples
+ * ------------------------------------------------------------------ */
+
+const EXAMPLES = [
+  { group: 'Basics', name: 'Hello', desc: 'The obligatory greeting.',
+    code: `say "Hello, World!";` },
+  { group: 'Basics', name: 'FizzBuzz', desc: '%% is the "divisible by" operator - no modulo-equals-zero dance.',
+    code: `for 1..20 -> $n {
+    if    $n %% 15 { say "FizzBuzz" }
+    elsif $n %% 3  { say "Fizz" }
+    elsif $n %% 5  { say "Buzz" }
+    else           { say $n }
+}` },
+  { group: 'Basics', name: 'Rationals', desc: 'Raku divides into exact Rats, so 0.1 + 0.2 == 0.3 really is True.',
+    code: `say 0.1 + 0.2 == 0.3;      # True - not a Num!
+my $third = 1 / 3;
+say $third;                # 0.333333
+say $third.nude;           # (1 3) - numerator and denominator
+say $third * 3 == 1;       # True
+say 2 ** 100;              # arbitrary precision Int` },
+  { group: 'Basics', name: 'Ranges', desc: 'Ranges are first-class and work on strings too.',
+    code: `say (1..10).sum;
+say ('a'..'e').join('-');
+say (1..*).head(5);        # infinite range, lazily taken
+say (1..10).grep(*.is-prime);` },
+
+  { group: 'Functional', name: 'Map & Grep', desc: '* builds a lambda: * ** 2 is "square it".',
+    code: `my @nums = 1..10;
+my @evens = @nums.grep(* %% 2);
+my @squares = @evens.map(* ** 2);
+say "Evens:   @evens[]";
+say "Squares: @squares[]";` },
+  { group: 'Functional', name: 'Sequences', desc: 'The ... operator infers the rule and produces a lazy sequence.',
+    code: `my @fib = 0, 1, * + * ... *;
+say @fib[^10];
+
+say (1, 2, 4 ... 64);      # geometric, inferred
+say ('a' ... 'j').join;` },
+  { group: 'Functional', name: 'Reduce & Hyper', desc: '[+] reduces with +; >>.<< applies a method element-wise.',
+    code: `say [+] 1..10;             # 55
+say [*] 1..5;              # 120
+say [~] <hello world>;
+say [max] 3, 9, 2;
+
+my @a = 1, 2, 3;
+say @a >>*>> 10;           # hyper: (10 20 30)
+say (-5, 3, -1)>>.abs;` },
+  { group: 'Functional', name: 'gather/take', desc: 'gather/take is a coroutine-ish lazy list producer.',
+    code: `my @collatz = gather {
+    my $n = 27;
+    while $n > 1 {
+        take $n;
+        $n = $n %% 2 ?? $n div 2 !! 3 * $n + 1;
+    }
+    take 1;
+}
+say @collatz.elems;
+say @collatz.head(10);
+say @collatz.max;` },
+  { group: 'Functional', name: 'Junctions', desc: 'One value that is several values at once - comparisons thread over it.',
+    code: `my $x = 5;
+say "in the set"   if $x == any(3, 5, 9);
+say "all positive" if all(1, 2, $x) > 0;
+say "none is even" if none(1, 3, $x) %% 2;
+say so 5 == 3 | 5 | 9;     # | is the any-junction operator` },
+  { group: 'Functional', name: 'Sets & Bags', desc: 'Set operators use real math symbols (ASCII alternatives exist).',
+    code: `my $a = set <apple banana cherry>;
+my $b = set <banana cherry durian>;
+say $a (&) $b;             # intersection
+say $a (|) $b;             # union
+say $a (-) $b;             # difference
+say 'apple' (elem) $a;
+
+my $bag = bag <a b a c a b>;
+say $bag<a>;               # 3
+say $bag.sort(-*.value).head(2).map(*.key);` },
+
+  { group: 'Objects', name: 'Classes', desc: 'has $.x gives a public accessor; has $!x stays private.',
+    code: `class Point {
+    has $.x is required;
+    has $.y is required;
+    method distance { sqrt($.x ** 2 + $.y ** 2) }
+    method Str { "($.x, $.y)" }
+}
+my $p = Point.new(x => 3, y => 4);
+say $p;                    # .gist - the default rendering
+say ~$p;                   # our Str method
+say $p.distance;` },
+  { group: 'Objects', name: 'Roles', desc: 'Roles compose behaviour into classes - flat, not inherited.',
+    code: `role Greet {
+    method greet { "Hi, I am { self.name }" }
+}
+class Dog does Greet {
+    has $.name;
+    method speak { "Woof!" }
+}
+my $d = Dog.new(name => 'Rex');
+say $d.greet;
+say $d.speak;
+say $d ~~ Greet;` },
+  { group: 'Objects', name: 'Multi dispatch', desc: 'Dispatch on type, arity, and even on a where-constraint.',
+    code: `multi fact(0) { 1 }
+multi fact(Int $n where * > 0) { $n * fact($n - 1) }
+say fact(10);
+
+multi describe(Int $n) { "an Int: $n" }
+multi describe(Str $s) { "a Str: $s" }
+multi describe(@a)     { "a list of {@a.elems}" }
+say describe($_) for 42, "hi", [1,2,3];` },
+  { group: 'Objects', name: 'Subsets', desc: 'A named type plus a predicate - checked at binding time.',
+    code: `subset Even of Int where * %% 2;
+sub halve(Even $n) { $n div 2 }
+say halve(10);
+
+my $err = try { halve(7) };
+say $!.^name if $!;` },
+
+  { group: 'Text', name: 'Regex', desc: 'Raku regexes: whitespace is free, <[...]> is a character class.',
+    code: `my $str = "Hello World 2026";
+if $str ~~ / (<[A..Z]>\\w+) \\s (\\w+) \\s (\\d ** 4) / {
+    say "matched: $/";
+    say "first:   $0";
+    say "year:    $2";
+}
+say "a1b2c3".comb(/\\d/).join(',');
+say "2026-07-22".split('-').map(+*);` },
+  { group: 'Text', name: 'Named rules', desc: 'Regexes can be named and nested, which is how grammars are built.',
+    code: `my regex ident { <[a..zA..Z_]> \\w* }
+my regex num   { \\d+ }
+if "count = 42" ~~ / <ident> \\s* '=' \\s* <num> / {
+    say "name  = ", ~$<ident>;
+    say "value = ", +$<num>;
+}` },
+  { group: 'Text', name: 'Substitution', desc: 'S/// returns a new string; :g goes global.',
+    code: `my $s = "the quick brown fox";
+say $s.subst('quick', 'slow');
+say $s.subst(/\\w+/, *.tc, :g);
+say $s.trans('aeiou' => 'AEIOU');
+say $s.words.map(*.tc).join(' ');` },
+  { group: 'Text', name: 'Strings', desc: 'Interpolation runs arbitrary code inside { }.',
+    code: `my @xs = 1..5;
+say "sum of @xs[] is { @xs.sum }";
+say "unicode: \\c[SNOWMAN] { "snow" x 3 }";
+say "raku".flip, " ", "abc".uc, " ", "Hello".chars;
+say "%.3f".sprintf(pi);` },
+];
+
+let activeExample = null;
+
+function renderExamples() {
+  const groups = [];
+  for (const ex of EXAMPLES) {
+    let g = groups.find(g => g.name === ex.group);
+    if (!g) groups.push(g = { name: ex.group, items: [] });
+    g.items.push(ex);
+  }
+  for (const g of groups) {
+    const row = document.createElement('div');
+    row.className = 'example-group';
+    const label = document.createElement('span');
+    label.className = 'group-label';
+    label.textContent = g.name;
+    row.appendChild(label);
+    for (const ex of g.items) {
+      const btn = document.createElement('button');
+      btn.textContent = ex.name;
+      btn.title = ex.desc;
+      btn.addEventListener('click', () => loadExample(ex, btn));
+      row.appendChild(btn);
+    }
+    examplesEl.appendChild(row);
+  }
+}
+
+function loadExample(ex, btn) {
+  editor.setCode(ex.code);
+  descEl.textContent = ex.desc;
+  if (activeExample) activeExample.classList.remove('active');
+  activeExample = btn || null;
+  if (btn) btn.classList.add('active');
+  editor.textarea.focus();
+}
+
+/* ------------------------------------------------------------------ *
+ * Editor
+ * ------------------------------------------------------------------ */
+
+const editor = createEditor(document.getElementById('editor-host'), {
+  code: 'say "Hello from mutsu!";',
+  minHeight: '190px',
+  label: 'Raku code',
+  onRun: () => runEditor(),
+});
+// Stable ids for the e2e suite and for anything linking into the page.
+editor.textarea.id = 'code';
+editor.textarea.placeholder = 'Write your Raku code here...';
+document.querySelector('#editor-host pre').id = 'highlight';
+
+/* ------------------------------------------------------------------ *
+ * REPL log
+ * ------------------------------------------------------------------ */
+
+function appendLog(text, cls) {
+  if (!text) return;
+  const div = document.createElement('div');
+  div.className = cls;
+  div.textContent = text.replace(/\n$/, '');
+  logEl.appendChild(div);
+  logEl.scrollTop = logEl.scrollHeight;
+  return div;
+}
+
+function appendEcho(prompt, text) {
+  const div = document.createElement('div');
+  div.className = 'echo';
+  const p = document.createElement('span');
+  p.className = 'prompt';
+  p.textContent = prompt + ' ';
+  div.appendChild(p);
+  div.appendChild(document.createTextNode(text));
+  logEl.appendChild(div);
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+function appendOutput(text) {
+  if (!text) return;
+  const isError = /(^|\n)Error:/.test(text);
+  appendLog(text, 'out' + (isError ? ' error' : ''));
+}
+
+function toast(msg) {
+  toastEl.textContent = msg;
+  toastEl.classList.add('show');
+  setTimeout(() => toastEl.classList.remove('show'), 1600);
+}
+
+/* ------------------------------------------------------------------ *
+ * WASM session
+ * ------------------------------------------------------------------ */
+
+let repl = null;
+
+async function initWasm() {
+  appendLog('Loading mutsu WASM module...', 'note');
+  try {
+    repl = await createSession();
+    logEl.innerHTML = '';
+    appendLog('mutsu - a Raku interpreter in Rust + WebAssembly.', 'note');
+    appendLog('Type an expression and hit Enter. The editor above shares this session.', 'note');
+    inputEl.disabled = false;
+    inputEl.placeholder = '';
+    document.body.dataset.ready = '1';
+    inputEl.focus();
+  } catch (e) {
+    appendLog('Failed to load WASM module: ' + e.message, 'out error');
+  }
+}
+
+/** Rust panics abort the wasm instance; everything after is garbage. */
+function fatal(e) {
+  appendLog('WASM error: ' + e.message, 'out error');
+  appendLog('The session is unusable - press "Reset session" to start a fresh one.', 'note');
+}
+
+function runEditor() {
+  if (!repl) return;
+  const code = editor.getCode();
+  if (!code.trim()) return;
+  runBtn.disabled = true;
+  // Let the disabled state paint before we block the thread on the VM.
+  setTimeout(() => {
+    appendEcho('#', 'run editor buffer');
+    try {
+      const res = JSON.parse(repl.evalBlock(code));
+      appendOutput(res.output || '(no output)');
+    } catch (e) {
+      fatal(e);
+    }
+    runBtn.disabled = false;
+    updatePrompt();
+  }, 10);
+}
+
+function updatePrompt() {
+  promptEl.textContent = repl && repl.isPending() ? '*' : '>';
+}
+
+/* history: newest last, index === length means "editing a fresh line" */
+const history = [];
+let historyIndex = 0;
+let draft = '';
+
+function submitLine() {
+  if (!repl) return;
+  const line = inputEl.value;
+  appendEcho(promptEl.textContent, line);
+  inputEl.value = '';
+  if (line.trim() !== '' && history[history.length - 1] !== line) history.push(line);
+  historyIndex = history.length;
+  draft = '';
+  try {
+    const res = JSON.parse(repl.evalLine(line));
+    appendOutput(res.output);
+  } catch (e) {
+    fatal(e);
+  }
+  updatePrompt();
+}
+
+inputEl.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    submitLine();
+  } else if (e.key === 'ArrowUp') {
+    if (historyIndex > 0) {
+      if (historyIndex === history.length) draft = inputEl.value;
+      historyIndex--;
+      inputEl.value = history[historyIndex];
+      e.preventDefault();
+    }
+  } else if (e.key === 'ArrowDown') {
+    if (historyIndex < history.length) {
+      historyIndex++;
+      inputEl.value = historyIndex === history.length ? draft : history[historyIndex];
+      e.preventDefault();
+    }
+  } else if (e.key === 'l' && e.ctrlKey) {
+    logEl.innerHTML = '';
+    e.preventDefault();
+  }
+});
+
+runBtn.addEventListener('click', runEditor);
+
+resetBtn.addEventListener('click', async () => {
+  if (!repl) return;
+  try {
+    repl.reset();
+  } catch (e) {
+    // A panicked instance cannot reset itself; build a brand new one.
+    repl = await createSession();
+  }
+  logEl.innerHTML = '';
+  appendLog('Session reset - all variables and declarations are gone.', 'note');
+  updatePrompt();
+  inputEl.focus();
+});
+
+/* ------------------------------------------------------------------ *
+ * Permalinks: #code=<base64url of UTF-8>
+ * ------------------------------------------------------------------ */
+
+function encodeCode(text) {
+  const bytes = new TextEncoder().encode(text);
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function decodeCode(enc) {
+  const b64 = enc.replace(/-/g, '+').replace(/_/g, '/');
+  const bin = atob(b64);
+  const bytes = Uint8Array.from(bin, c => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+shareBtn.addEventListener('click', async () => {
+  const url = location.origin + location.pathname + '#code=' + encodeCode(editor.getCode());
+  try {
+    await navigator.clipboard.writeText(url);
+    toast('Link copied to clipboard');
+  } catch {
+    location.hash = 'code=' + encodeCode(editor.getCode());
+    toast('Link is in the address bar');
+  }
+});
+
+function loadFromHash() {
+  const m = /^#code=(.+)$/.exec(location.hash);
+  if (!m) return false;
+  try {
+    editor.setCode(decodeCode(m[1]));
+    descEl.textContent = 'Loaded from a shared link.';
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * Boot
+ * ------------------------------------------------------------------ */
+
+renderExamples();
+loadFromHash();
+initWasm();
+</script>
+
+</body>
+</html>

--- a/wasm-demo/tutorial.html
+++ b/wasm-demo/tutorial.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Raku tutorial — mutsu</title>
+<meta name="description" content="A hands-on tour of the Raku programming language: nine chapters of editable, runnable examples, in English and Japanese.">
+<link rel="stylesheet" href="assets/site.css">
+</head>
+<body>
+
+<nav class="site-nav"></nav>
+
+<noscript>
+  <p class="section">The tutorial runs a Raku interpreter in your browser, so it needs
+  JavaScript and WebAssembly enabled. The language itself is documented at
+  <a href="https://docs.raku.org/">docs.raku.org</a>.</p>
+</noscript>
+
+<div class="tutorial-layout">
+  <aside class="toc">
+    <p class="toc-intro" id="toc-intro"></p>
+    <h2 id="toc-title"></h2>
+    <div id="toc-body"></div>
+    <p class="toc-actions">
+      <button type="button" class="btn-ghost" id="clear-progress"></button>
+    </p>
+    <p class="toc-source" id="toc-source"></p>
+  </aside>
+
+  <main class="lesson">
+    <p class="crumb" id="lesson-crumb"></p>
+    <h1 id="lesson-title"></h1>
+    <div class="lesson-body" id="lesson-body"></div>
+
+    <div class="pane-title" id="editor-label"></div>
+    <div id="snippet-host"></div>
+
+    <nav class="lesson-nav">
+      <button type="button" class="btn-ghost" id="prev-btn"></button>
+      <span class="grow"></span>
+      <span class="hint" id="lesson-counter"></span>
+      <span class="grow"></span>
+      <button type="button" class="btn" id="next-btn"></button>
+    </nav>
+  </main>
+</div>
+
+<footer class="site-footer"></footer>
+
+<script type="module">
+import { renderChrome, currentLang, t } from './assets/i18n.js';
+import { parseCorpus, groupCorpus } from './assets/corpus.js';
+import { createSnippet } from './assets/snippet.js';
+
+import tutorialEn from './content/tutorial.en.js';
+import tutorialJa from './content/tutorial.ja.js';
+
+const TEXT = { en: tutorialEn, ja: tutorialJa };
+const PROGRESS_KEY = 'mutsu-tutorial-done';
+
+renderChrome('tutorial');
+
+const lessons = parseCorpus(await (await fetch('content/lessons.txt')).text());
+const chapters = groupCorpus(lessons);
+
+/* ---- progress ---------------------------------------------------- */
+
+function loadProgress() {
+  try {
+    return new Set(JSON.parse(localStorage.getItem(PROGRESS_KEY) || '[]'));
+  } catch {
+    return new Set();
+  }
+}
+function saveProgress(set) {
+  try {
+    localStorage.setItem(PROGRESS_KEY, JSON.stringify([...set]));
+  } catch { /* private mode */ }
+}
+let done = loadProgress();
+
+/* ---- routing ----------------------------------------------------- */
+
+function keyFromHash() {
+  const key = decodeURIComponent(location.hash.replace(/^#/, ''));
+  return lessons.some(l => l.key === key) ? key : lessons[0].key;
+}
+
+let currentKey = keyFromHash();
+
+function go(key) {
+  if (key === currentKey && location.hash) return;
+  currentKey = key;
+  location.hash = key;
+  render();
+  document.querySelector('.lesson h1').scrollIntoView({ block: 'nearest' });
+}
+
+/* ---- the one snippet widget, reused across lessons --------------- */
+
+const snippet = createSnippet(document.getElementById('snippet-host'), {
+  code: '',
+  expect: '',
+  minHeight: '11rem',
+  showExpected: true,
+  eagerBoot: true,
+});
+
+document.addEventListener('snippetrun', (e) => {
+  if (e.detail && e.detail.ok) {
+    done.add(currentKey);
+    saveProgress(done);
+    paintToc();
+  }
+});
+
+/* ---- rendering --------------------------------------------------- */
+
+const tocBody = document.getElementById('toc-body');
+
+function paintToc() {
+  const T = TEXT[currentLang()];
+  tocBody.textContent = '';
+  chapters.forEach((chapter, ci) => {
+    const box = document.createElement('div');
+    box.className = 'chapter';
+
+    const title = document.createElement('div');
+    title.className = 'chapter-title';
+    const num = document.createElement('span');
+    num.className = 'num';
+    num.textContent = String(ci + 1);
+    const label = document.createElement('span');
+    label.textContent = T.chapters[chapter.group] || chapter.group;
+    title.append(num, label);
+    box.appendChild(title);
+
+    for (const lesson of chapter.items) {
+      const a = document.createElement('a');
+      a.className = 'lesson-link';
+      a.href = `#${lesson.key}`;
+      a.textContent = (T.lessons[lesson.key] || {}).title || lesson.id;
+      if (lesson.key === currentKey) a.setAttribute('aria-current', 'true');
+      if (done.has(lesson.key)) a.classList.add('done');
+      a.addEventListener('click', (e) => { e.preventDefault(); go(lesson.key); });
+      box.appendChild(a);
+    }
+    tocBody.appendChild(box);
+  });
+}
+
+/**
+ * @param {boolean} loadCode  replace the editor contents with the lesson's
+ *   code.  False when only the language changed: the reader's edits are theirs,
+ *   and the code is language-independent anyway.
+ */
+function render(loadCode = true) {
+  const T = TEXT[currentLang()];
+  const idx = lessons.findIndex(l => l.key === currentKey);
+  const lesson = lessons[idx];
+  const text = T.lessons[lesson.key] || { title: lesson.id, body: '' };
+
+  document.title = `${text.title} — ${T.title}`;
+  document.getElementById('toc-intro').textContent = T.intro;
+  document.getElementById('toc-source').textContent = T.source;
+  document.getElementById('toc-title').textContent = t('toc.title');
+  document.getElementById('clear-progress').textContent = t('toc.reset-progress');
+  document.getElementById('lesson-crumb').textContent =
+    T.chapters[lesson.group] || lesson.group;
+  document.getElementById('lesson-title').textContent = text.title;
+  // Prose comes from the content modules in this repository, never user input.
+  document.getElementById('lesson-body').innerHTML = text.body;
+  document.getElementById('editor-label').textContent = t('lesson.editor');
+  document.getElementById('lesson-counter').textContent =
+    t('lesson.of', { n: idx + 1, total: lessons.length });
+
+  const prev = document.getElementById('prev-btn');
+  const next = document.getElementById('next-btn');
+  prev.textContent = t('lesson.prev');
+  next.textContent = t('lesson.next');
+  prev.disabled = idx === 0;
+  next.disabled = idx === lessons.length - 1;
+  prev.onclick = () => go(lessons[idx - 1].key);
+  next.onclick = () => go(lessons[idx + 1].key);
+
+  if (loadCode) {
+    snippet.setCode(lesson.code, lesson.expect, lesson.flags.includes('no-browser'));
+  }
+  paintToc();
+}
+
+document.getElementById('clear-progress').addEventListener('click', () => {
+  done = new Set();
+  saveProgress(done);
+  paintToc();
+});
+
+window.addEventListener('hashchange', () => {
+  const key = keyFromHash();
+  if (key !== currentKey) { currentKey = key; render(); }
+});
+window.addEventListener('langchange', () => render(false));
+
+render();
+document.body.dataset.ready = '1';
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## What

`wasm-demo/` was a playground and nothing else. This makes its subject **Raku**, with mutsu as the thing that makes it interactive.

| page | what it is |
|---|---|
| `index.html` | landing page — *why Raku*, with eight runnable highlights (exact rationals, junctions, lazy infinite lists, multiple dispatch, grammars, metaoperators, concurrency, Unicode) |
| `tutorial.html` | a Go-Tour-style tutorial: **9 chapters, 36 lessons**, each an editable program that runs in a fresh interpreter. Deep-linkable (`#chapter/lesson`), per-lesson progress in `localStorage`, recorded output available as "Expected output" |
| `playground.html` | the previous page, behaviour unchanged. Old `index.html#code=...` permalinks redirect here and keep working |

Everything is **English and Japanese**, switchable in place (`?lang=`, remembered in `localStorage`).

## How the content is kept honest

Code is shared between the languages, prose is not: snippets live once in `content/lessons.txt` / `content/highlights.txt` keyed `<chapter>/<lesson>`, and the per-language modules supply titles and explanations for the same keys — so a sample cannot drift between translations.

The expected-output blocks are **generated and cross-checked, not hand-written**:

```sh
node scripts/check-site-snippets.mjs --update   # runs each snippet under mutsu AND raku
```

An expectation is recorded only where the two agree, so the site can only teach behaviour real Raku actually has. Without `--update` the script is a regression gate — now a CI step — that also checks every snippet has prose in both languages. The Playwright suite additionally runs **every browser-runnable lesson in a real browser** against its recorded output, so a WASM-only regression cannot reach the deployed site unnoticed.

That cross-check earned its keep immediately: it caught a genuine mutsu bug while the content was being written.

## Two findings recorded in PLAN.md (not fixed here)

- **§8.17 — `&name` for a proto-less `multi` collapses to one candidate.** `.map(&f)` does not multi-dispatch (`(1,"a").map(&k)` → `1 a`, raku → `int 1 str a`). Every direct call form is already correct, and an explicit `proto` fixes it; the fault is in `resolve_code_var`. Root cause and the likely fix are written up in the entry.
- **§8.18 — the WASM build traps on `start` / `Channel`.** `std::thread::spawn` is unimplemented on `wasm32-unknown-unknown`, so the trap also poisons the instance. Those two lessons carry a `no-browser` flag: the site disables Run, explains why, and shows the output recorded from a native run instead of a trap. Removing the flags is the acceptance test for that item.

## Credit

The tutorial and its examples follow the official Raku documentation ([Raku/doc](https://github.com/Raku/doc)), vendored here as `raku-doc/` under the Artistic License 2.0. The credit is in the site footer on every page and in the tutorial sidebar.

## Testing

- `node scripts/check-site-snippets.mjs` — 44/44 snippets agree between mutsu and raku; prose present in en/ja
- `node wasm-demo/e2e.test.mjs` — **63 passed, 0 failed** (includes the 34-lesson browser sweep)

The site stays build-step free (plain HTML + ES modules + CSS); `wasm-demo/README.md` documents the layout and how to add a lesson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)