### PR TITLE
fix: Nil numeric coercion resumes with 0, not the type object

### DIFF
--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -1439,14 +1439,22 @@ impl Interpreter {
                             // Fall through to normal dispatch
                         }
                         // Numeric coercion on Nil (an undefined value) warns and
-                        // yields the corresponding numeric type object, e.g.
-                        // `Nil.Rat` is `(Rat)` which numifies to 0.
-                        "Rat" | "FatRat" | "Int" | "Num" | "Complex" if args.is_empty() => {
+                        // resumes with the corresponding numeric *zero* — raku's
+                        // `Nil.Int` is `0` (defined), `Nil.Num` is `0e0`,
+                        // `Nil.Rat` is `0.0`, etc. — NOT the type object.
+                        "Rat" | "FatRat" | "Int" | "Num" | "Complex" | "Numeric"
+                            if args.is_empty() =>
+                        {
+                            let zero = match method {
+                                "Int" | "Numeric" => Value::int(0),
+                                "Num" => Value::num(0.0),
+                                "Rat" => crate::value::make_rat(0, 1),
+                                "FatRat" => crate::value::make_big_fat_rat(0.into(), 1.into()),
+                                "Complex" => Value::complex(0.0, 0.0),
+                                _ => unreachable!(),
+                            };
                             let msg = "Use of Nil in numeric context".to_string();
-                            return Err(RuntimeError::warn_signal_with_resume(
-                                msg,
-                                Value::package(method_sym),
-                            ));
+                            return Err(RuntimeError::warn_signal_with_resume(msg, zero));
                         }
                         // `Nil.ords` warns ("Use of Nil in string context") and
                         // resumes to an empty Seq; `Nil.chrs` warns and resumes

--- a/t/nil-numeric-coercion-zero.t
+++ b/t/nil-numeric-coercion-zero.t
@@ -1,0 +1,36 @@
+use Test;
+
+# Numeric coercion of Nil (an undefined value) warns "Use of Nil in numeric
+# context" and resumes with the corresponding numeric ZERO — raku's `Nil.Int`
+# is `0` (a defined Int), `Nil.Num` is `0e0`, `Nil.Rat` is `0.0`, etc. — NOT
+# the type object.
+#
+# Regression: mutsu resumed with the numeric type object (`(Int)`), so
+# `say Nil.Int` printed `(Int)` and `Nil.Int.defined` was False.
+
+plan 14;
+
+# `quietly { ... }` swallows the "Use of Nil in numeric context" warning; we
+# assert the resumed value.
+
+# --- values ---
+is (quietly { Nil.Int }),     0,      'Nil.Int is 0';
+is (quietly { Nil.Numeric }), 0,      'Nil.Numeric is 0';
+is (quietly { Nil.Num }),     0e0,    'Nil.Num is 0e0';
+is (quietly { Nil.Rat }),     0.0,    'Nil.Rat is 0.0';
+is (quietly { Nil.Complex }), <0+0i>, 'Nil.Complex is 0+0i';
+
+# --- types ---
+is (quietly { Nil.Int }).WHAT.^name,     'Int',     'Nil.Int is an Int';
+is (quietly { Nil.Num }).WHAT.^name,     'Num',     'Nil.Num is a Num';
+is (quietly { Nil.Rat }).WHAT.^name,     'Rat',     'Nil.Rat is a Rat';
+is (quietly { Nil.FatRat }).WHAT.^name,  'FatRat',  'Nil.FatRat is a FatRat';
+is (quietly { Nil.Complex }).WHAT.^name, 'Complex', 'Nil.Complex is a Complex';
+
+# --- the resumed zero is a defined, usable value ---
+ok (quietly { Nil.Int }).defined, 'Nil.Int is defined (a real 0, not a type object)';
+is (quietly { Nil.Int + 5 }), 5, 'Nil.Int participates in arithmetic as 0';
+is (quietly { Nil.FatRat }), 0, 'Nil.FatRat numifies to 0';
+
+# --- a failed match numifies through Nil the same way ---
+is (quietly { ("one-two" ~~ /234/).Int }), 0, 'failed-match Nil coerces to 0 via .Int';


### PR DESCRIPTION
## Problem

Numeric coercion of `Nil` warns "Use of Nil in numeric context" and resumes with the corresponding numeric **zero** in raku — but mutsu resumed with the numeric *type object*:

```raku
say Nil.Int;          # mutsu: (Int)   |  raku: 0
say Nil.Int.defined;  # mutsu: False   |  raku: True
say Nil.Numeric;      # mutsu: Nil (no warning)  |  raku: 0
```

## Fix

In the `Nil` method-dispatch fast path (`vm_call_method_ops.rs`), resume each numeric coercion with its zero value instead of `Value::package(method_sym)`:

| method | resume value |
|---|---|
| `Int` / `Numeric` | `0` |
| `Num` | `0e0` |
| `Rat` | `0.0` |
| `FatRat` | `FatRat.new(0,1)` |
| `Complex` | `0+0i` |

`Numeric` is also added to the match (it previously fell through to the Nil-absorbing default and returned `Nil` with no warning). The warning itself is unchanged.

## Testing

- New pin: `t/nil-numeric-coercion-zero.t` (14 subtests, verified identical output under raku).
- `roast/S02-types/nil.t` (whitelisted, 67 tests): PASS.
- `make test`: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)