### PR TITLE
fix: builtin routine handles type as Sub/Method, never "Routine"; gist/Str match Rakudo

### DIFF
--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -51,6 +51,22 @@ matches the site, and its `.card`/`header` selectors were namespaced to `.bench-
 self-contained file for offline use. The e2e suite renders the dashboard from a synthetic history
 and asserts its chrome, so the generated page cannot drift away from the hand-written ones again.
 
+## 2026-07-23: builtin routine handles are `Sub`/`Method`, never "Routine"; gist/Str match Rakudo
+
+`&say.^name` said "Routine" where Rakudo says "Sub" (a `Routine` is never a concrete
+value's type). `value_type_name`'s (and the `.WHAT` arm's) `ValueView::Routine` case now
+discriminates by the handle's package: `GLOBAL`/empty → `Sub` (`&say`, `&infix:<+>`,
+Test's `&ok`), an owning-type package → `Method` (a builtin-method lookup handle like
+`"abc".^lookup("uc")`, which Rakudo also types as Method). Smartmatch is unaffected
+(`~~ Routine`/`~~ Sub`/`~~ Callable` all still hold, pinned). Rendering now matches
+Rakudo too: a Sub handle gists `&say` (Method handles gist the bare name), and
+stringification (`.Str`, interpolation) is the bare name — previously the qualified
+`GLOBAL::say` / the long `sub say () { #`(Sub|0) ... }` form. `.raku` keeps the long
+candidate-signature form for now (Rakudo renders the proto — mutsu has no real protos
+for builtins; TODO noted in `methods_sub.rs`). Pin: `t/builtin-routine-type-identity.t`
+(passes under raku too). This closes the "CORE::<&say>.^name is Routine" divergence
+spotted 2026-07-23.
+
 ## 2026-07-23: `IO::Path::Parts.raku`/`.gist` render the positional parts (PLAN §8.15)
 
 `IO::Path::Parts.new('C:', '/some/dir', 'foo.txt').raku` (and `.gist`) rendered the bare

--- a/src/runtime/io_doc.rs
+++ b/src/runtime/io_doc.rs
@@ -1220,13 +1220,11 @@ impl Interpreter {
                     if dc.wherefore_name.starts_with("block:") {
                         Value::package(crate::symbol::Symbol::intern("Block"))
                     } else {
-                        // Use callable_type_override if set (Method, Submethod)
-                        let is_standalone_sub =
-                            dc.wherefore_name.starts_with('&') || !dc.wherefore_name.contains("::");
+                        // Use callable_type_override if set (Method, Submethod).
+                        // A proto handle's .^name is "Sub" too (Rakudo; "Routine"
+                        // is never a concrete value's type), so no proto case.
                         let base_type = if let Some(ref ct) = dc.callable_type_override {
                             ct.as_str()
-                        } else if dc.is_proto && is_standalone_sub {
-                            "Routine"
                         } else {
                             "Sub"
                         };

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -2446,7 +2446,7 @@ impl Interpreter {
 ///   and backslash-escape any `<` or `>` in the symbol.
 /// - Otherwise, if the symbol contains `<` or `>`, use `\u{ab}\u{bb}` delimiters.
 /// - Otherwise, use `<>` delimiters as-is.
-fn format_operator_name(name: &str) -> String {
+pub(super) fn format_operator_name(name: &str) -> String {
     // Check if this is a categorical name like "infix:<...>", "prefix:<...>", etc.
     let Some(colon_pos) = name.find(":<") else {
         return name.to_string();

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -93,6 +93,13 @@ impl Interpreter {
                 return Ok(Value::package(Symbol::intern(visible)));
             }
             ValueView::Routine { is_regex: true, .. } => "Regex",
+            // Keep in sync with `value_type_name`: a builtin-method lookup
+            // handle (package = owning type) is a Method, otherwise a Sub.
+            ValueView::Routine { package, .. }
+                if !package.with_str(|p| p == "GLOBAL" || p.is_empty()) =>
+            {
+                "Method"
+            }
             ValueView::Routine { .. } => "Sub",
             // Keep in sync with `runtime::utils::value_type_name`: a bare/pointy
             // block (`{...}`, `-> {...}`) is a `Block`, not a `Sub`. `.WHAT`/`.^name`

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -168,7 +168,21 @@ impl Interpreter {
             }
             return Some(Ok(Value::junction(JunctionKind::Any, signatures)));
         }
-        if matches!(method, "raku" | "perl" | "gist" | "Str") && args.is_empty() {
+        if matches!(method, "gist" | "Str") && args.is_empty() {
+            // Rakudo: a Sub handle gists as `&name` and a builtin-method
+            // lookup handle (package = owning type) as the bare name; `.Str`
+            // is the bare name for both (Rakudo warns on the coercion too).
+            let display = super::methods_instance_ops::format_operator_name(name);
+            let is_method = !(package == "GLOBAL" || package.is_empty());
+            if method == "gist" && !is_method {
+                return Some(Ok(Value::str(format!("&{}", display))));
+            }
+            return Some(Ok(Value::str(display)));
+        }
+        if matches!(method, "raku" | "perl") && args.is_empty() {
+            // TODO: Rakudo renders a builtin routine's .raku as its proto
+            // (`proto sub say (|) {*}`); mutsu has no real protos for
+            // builtins, so the long candidate-signature form remains.
             // For Routine handles, render using the first candidate's signature
             let candidates = self.routine_candidate_subs(package, name);
             let sig_gist = if !candidates.is_empty() {

--- a/src/runtime/utils/type_misc.rs
+++ b/src/runtime/utils/type_misc.rs
@@ -71,11 +71,19 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
             }
         },
         ValueView::WeakSub(_) => "Sub",
-        ValueView::Routine { is_regex, .. } => {
+        // A builtin routine handle is a `Sub` (Rakudo: `&say.^name` is "Sub"),
+        // except a builtin-method lookup handle (`"abc".^lookup("uc")`), whose
+        // package is the owning type, which is a `Method`. "Routine" itself is
+        // never a concrete value's type in Rakudo.
+        ValueView::Routine {
+            is_regex, package, ..
+        } => {
             if is_regex {
                 "Regex"
+            } else if package.with_str(|p| p == "GLOBAL" || p.is_empty()) {
+                "Sub"
             } else {
-                "Routine"
+                "Method"
             }
         }
         ValueView::Package(_) => "Package",

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -605,7 +605,9 @@ impl Value {
                 let args: Vec<String> = type_args.iter().map(|a| a.to_string_value()).collect();
                 format!("({}[{}])", base_name, args.join(","))
             }
-            ValueView::Routine { package, name, .. } => format!("{}::{}", package, name),
+            // Rakudo: Code stringifies to its bare name (`~&say` is "say",
+            // with a coercion warning mutsu does not emit).
+            ValueView::Routine { name, .. } => name.resolve(),
             ValueView::Sub(data) => data.name.resolve(),
             ValueView::WeakSub(weak) => match weak.upgrade() {
                 Some(data) => data.name.resolve(),

--- a/t/builtin-routine-type-identity.t
+++ b/t/builtin-routine-type-identity.t
@@ -1,0 +1,25 @@
+use v6;
+use Test;
+
+plan 13;
+
+# Builtin routine handles are Subs in Rakudo (never "Routine"), and a
+# builtin-method lookup handle is a Method; gist/Str render like Rakudo.
+
+is &say.^name, 'Sub', '&say.^name is Sub';
+is CORE::<&say>.^name, 'Sub', 'CORE::<&say>.^name is Sub';
+is &print.^name, 'Sub', '&print.^name is Sub';
+is &say.WHAT.gist, '(Sub)', '&say.WHAT is (Sub)';
+ok &say ~~ Sub, '&say ~~ Sub';
+ok &say ~~ Routine, '&say ~~ Routine (Sub isa Routine)';
+ok &say ~~ Callable, '&say ~~ Callable';
+
+is 'abc'.^lookup('uc').^name, 'Method', 'builtin method lookup is a Method';
+is 'abc'.^lookup('uc').gist, 'uc', 'Method gists as the bare name';
+
+is &say.gist, '&say', 'Sub handle gists as &name';
+is &infix:<+>.gist, '&infix:<+>', 'operator handle gists with the operator name';
+is &say.Str, 'say', 'Sub handle .Str is the bare name';
+is "x{&say}y", 'xsayy', 'interpolation stringifies to the bare name';
+
+done-testing;

--- a/t/declarator-trailing-wherefore.t
+++ b/t/declarator-trailing-wherefore.t
@@ -23,7 +23,7 @@ is $=pod[1].WHEREFORE.^name, 'Submethod', 'submethod trailing #= -> Submethod WH
 
 proto sub foo() { }
 #={solo}
-is $=pod[2].WHEREFORE.^name, 'Routine', 'proto sub trailing #= -> Routine WHEREFORE';
+is $=pod[2].WHEREFORE.^name, 'Sub', 'proto sub trailing #= -> Sub WHEREFORE (raku: a proto handle is a Sub)';
 
 my $anon-sub = anon Str sub {};
 #={Anonymous}


### PR DESCRIPTION
## Summary

Closes the "`CORE::<&say>.^name` is `Routine` in mutsu, `Sub` in raku" divergence (spotted 2026-07-23 during the §8 burn-down).

`Routine` is never a concrete value's type in Rakudo. `value_type_name`'s (and the `.WHAT` arm's) `ValueView::Routine` case now discriminates by the handle's package:

- `GLOBAL`/empty → **Sub** — `&say`, `&print`, `&infix:<+>`, Test's `&ok`
- an owning-type package → **Method** — a builtin-method lookup handle like `"abc".^lookup("uc")` (Rakudo also types these as Method)

Smartmatch is unaffected: `~~ Routine` / `~~ Sub` / `~~ Callable` all still hold (pinned).

Rendering now matches Rakudo too:

| expr | before | after (= raku) |
|---|---|---|
| `&say.^name` | `Routine` | `Sub` |
| `"abc".^lookup("uc").^name` | `Routine` | `Method` |
| `&say.gist` | `sub say () { #`(Sub\|0) ... }` | `&say` |
| `"abc".^lookup("uc").gist` | long form | `uc` |
| `&say.Str` / `"{&say}"` | `GLOBAL::say` | `say` |

`.raku` keeps the long candidate-signature form for now — Rakudo renders the proto (`proto sub say (|) {*}`) and mutsu has no real protos for builtins; TODO noted in `methods_sub.rs`.

## Testing

- New pin `t/builtin-routine-type-identity.t` (13 tests) — passes under mutsu **and** raku
- `make test`: all 22302 tests pass
- Whitelisted `roast/S06-other/introspection.t`, `S06-advanced/dispatching.t`, `S06-multi/proto.t`, `S02-magicals/subname.t`, `S12-introspection/methods.t` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)