### PR TITLE
fix: Nil.Str / Nil.Stringy warn "Use of Nil in string context"

### DIFF
--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -1423,11 +1423,21 @@ impl Interpreter {
                             self.stack.push(Value::real_array(arr));
                             return Ok(());
                         }
-                        "defined" | "Bool" | "so" | "not" | "gist" | "Str" | "raku" | "perl"
-                        | "WHAT" | "WHICH" | "WHERE" | "HOW" | "WHY" | "VAR" | "DEFINITE"
-                        | "isa" | "does" | "can" | "^name" | "^mro" | "^pun" | "new" | "bless"
+                        "defined" | "Bool" | "so" | "not" | "gist" | "raku" | "perl" | "WHAT"
+                        | "WHICH" | "WHERE" | "HOW" | "WHY" | "VAR" | "DEFINITE" | "isa"
+                        | "does" | "can" | "^name" | "^mro" | "^pun" | "new" | "bless"
                         | "clone" | "item" | "self" | "sink" | "pending" => {
                             // Fall through to normal dispatch
+                        }
+                        // String coercion on Nil warns ("Use of Nil in string
+                        // context") and resumes with the empty string. (`.gist`
+                        // and `.raku`, above, stay in the fall-through list — they
+                        // render "Nil" and do NOT warn.)
+                        "Str" | "Stringy" if args.is_empty() => {
+                            return Err(RuntimeError::warn_signal_with_resume(
+                                "Use of Nil in string context".to_string(),
+                                Value::str(String::new()),
+                            ));
                         }
                         // List/iteration methods inherited from Any: Nil behaves
                         // like a single undefined item (e.g. `Nil.grep(*.defined)`

--- a/t/nil-str-context-warning.t
+++ b/t/nil-str-context-warning.t
@@ -1,0 +1,38 @@
+use Test;
+
+# String coercion of Nil via `.Str` / `.Stringy` warns "Use of Nil in string
+# context" and resumes with the empty string (like raku). `.gist` / `.raku`
+# render "Nil" and do NOT warn.
+#
+# Regression: mutsu returned "" from `Nil.Str` with no warning at all.
+
+plan 8;
+
+# `quietly { ... }` swallows the "Use of Nil in string context" warning; assert
+# the resumed value is the empty string.
+is (quietly { Nil.Str }),     '', 'Nil.Str is the empty string';
+is (quietly { Nil.Stringy }), '', 'Nil.Stringy is the empty string';
+ok (quietly { Nil.Str }).defined, 'Nil.Str is a defined empty string (not a type object)';
+is (quietly { Nil.Str }).chars, 0, 'Nil.Str has zero characters';
+
+# `.gist` / `.raku` render "Nil" and must NOT be diverted to the empty string.
+is Nil.gist, 'Nil', 'Nil.gist is "Nil" (unaffected)';
+is Nil.raku, 'Nil', 'Nil.raku is "Nil" (unaffected)';
+
+# The warning actually fires: capture it via a CONTROL handler.
+{
+    my $warned = False;
+    {
+        Nil.Str;
+        CONTROL { when CX::Warn { $warned = True; .resume } }
+    }
+    ok $warned, 'Nil.Str emits a warning';
+}
+{
+    my $warned = False;
+    {
+        Nil.gist;
+        CONTROL { when CX::Warn { $warned = True; .resume } }
+    }
+    nok $warned, 'Nil.gist emits no warning';
+}


### PR DESCRIPTION
## Problem

String coercion of `Nil` via the `.Str` / `.Stringy` methods warns "Use of Nil in string context" and resumes with the empty string in raku. mutsu returned `""` with **no warning**, because `Str` sat in the Nil fall-through list that routes to normal dispatch.

```raku
Nil.Str;   # mutsu: (silent)  |  raku: warns "Use of Nil in string context"
```

## Fix

Move `Str` out of the Nil fall-through list into a warning arm (alongside a new `Stringy`) in `vm_call_method_ops.rs` that resumes with the empty string. `.gist` / `.raku` stay in the fall-through list — they render `"Nil"` and must **not** warn.

Follows #5307 (which fixed `Nil`'s *numeric* coercions to resume with `0` instead of the type object); this is the string-context sibling.

## Scope note

The `~` prefix-stringify operator (`~Nil`) still does not warn (raku does) — that is a separate operator code path, not the `.Str` method, and is left as a follow-up.

## Testing

- New pin: `t/nil-str-context-warning.t` (8 subtests incl. `CX::Warn` capture, matches raku).
- `make test`: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)