### PR TITLE
fix: the benchmark dashboard now wears the site's nav, footer and palette

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           git fetch --depth 1 origin bench-data 2>/dev/null || true
           if git show FETCH_HEAD:bench-history.tsv > /tmp/bench-history.tsv 2>/dev/null; then
-            python3 scripts/bench-visualize.py --standalone \
+            python3 scripts/bench-visualize.py --standalone --site-chrome \
               /tmp/bench-history.tsv -o wasm-demo/bench-trend.html
           else
             echo "no bench-history.tsv on bench-data yet; skipping bench-trend"

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ target-local/
 # wasm-pack output + the Playwright install that drives wasm-demo/e2e.test.mjs
 /pkg/
 /wasm-demo/pkg/
+# Rendered at deploy time by scripts/bench-visualize.py (and transiently by the
+# e2e suite) from the bench-data branch's history.
+/wasm-demo/bench-trend.html
+/wasm-demo/.bench-history.e2e.tsv
 /node_modules/
 /package.json
 /package-lock.json

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -40,6 +40,17 @@ cannot reach the deployed site unnoticed.
 The site stays build-step free (plain HTML + ES modules + CSS); `wasm-demo/README.md` documents
 the layout and how to add a lesson.
 
+**Follow-up the same day:** `bench-trend.html` was the odd one out — a generated page with its
+own neutral light/dark palette, its own sticky header and no site navigation, so landing on it
+was a dead end that looked like a different product. `scripts/bench-visualize.py` gained
+`--site-chrome` (passed by `pages.yml`), which loads `assets/site.css` and `assets/i18n.js` and
+renders the *same* nav, language switch and footer as every other page — the shared chrome keeps
+exactly one definition rather than being duplicated into the Python template. Its palette now
+matches the site, and its `.card`/`header` selectors were namespaced to `.bench-card`/
+`.bench-head` so the two stylesheets can coexist. Without the flag the script still emits a fully
+self-contained file for offline use. The e2e suite renders the dashboard from a synthetic history
+and asserts its chrome, so the generated page cannot drift away from the hand-written ones again.
+
 ## 2026-07-23: `IO::Path::Parts.raku`/`.gist` render the positional parts (PLAN §8.15)
 
 `IO::Path::Parts.new('C:', '/some/dir', 'foo.txt').raku` (and `.gist`) rendered the bare

--- a/scripts/bench-visualize.py
+++ b/scripts/bench-visualize.py
@@ -18,6 +18,11 @@ The output is a single HTML file with no external requests (charts are drawn as
 inline SVG by a small vanilla-JS runtime), so it opens offline. Omit
 `--standalone` when the HTML will be wrapped by something that supplies its own
 document skeleton (e.g. published as an Artifact).
+
+Pass `--site-chrome` when the output is deployed into `wasm-demo/`: it adds the
+site's shared nav and footer by loading `assets/site.css` and `assets/i18n.js`
+from the same directory, so the dashboard is a page of the site rather than an
+orphan. That trades away self-containedness, which is why it is opt-in.
 """
 
 import argparse
@@ -92,71 +97,66 @@ def build_model(rows):
     return {"commits": commit_meta, "benches": out}
 
 
-TEMPLATE = r"""<title>mutsu bench trend</title>
+TEMPLATE = r"""<title>Benchmark trend &mdash; mutsu</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
+__CHROME_HEAD__
 <style>
+/* Palette shared with the rest of the site (wasm-demo/assets/site.css), so the
+   dashboard reads as the same product whether it is deployed alongside the
+   site or opened as a standalone file. */
 :root {
-  --surface: #fcfcfb; --card: #ffffff; --ink: #1a1c1f; --muted: #6b7280;
-  --hair: #e7e7ea; --grid: #eeeef1; --edge: #e2e2e6;
-  --base: #2563eb; --jit: #d97706; --good: #15803d; --bad: #b91c1c;
-  --shadow: 0 1px 2px rgba(20,22,26,.05), 0 1px 3px rgba(20,22,26,.06);
-}
-@media (prefers-color-scheme: dark) {
-  :root {
-    --surface: #14161a; --card: #1b1e23; --ink: #e8eaed; --muted: #969ca5;
-    --hair: #2a2e35; --grid: #24272d; --edge: #2c3037;
-    --base: #3b82f6; --jit: #d97706; --good: #34d399; --bad: #f87171;
-    --shadow: 0 1px 2px rgba(0,0,0,.3), 0 1px 3px rgba(0,0,0,.35);
-  }
-}
-:root[data-theme="light"] {
-  --surface: #fcfcfb; --card: #ffffff; --ink: #1a1c1f; --muted: #6b7280;
-  --hair: #e7e7ea; --grid: #eeeef1; --edge: #e2e2e6;
-  --base: #2563eb; --jit: #d97706; --good: #15803d; --bad: #b91c1c;
-  --shadow: 0 1px 2px rgba(20,22,26,.05), 0 1px 3px rgba(20,22,26,.06);
-}
-:root[data-theme="dark"] {
-  --surface: #14161a; --card: #1b1e23; --ink: #e8eaed; --muted: #969ca5;
-  --hair: #2a2e35; --grid: #24272d; --edge: #2c3037;
-  --base: #3b82f6; --jit: #d97706; --good: #34d399; --bad: #f87171;
+  --surface: #1a0a20; --card: #2a1235; --ink: #f0e6f6; --muted: #9a7fa8;
+  --hair: #3a1c46; --grid: #33163f; --edge: #4a2555;
+  --base: #9fd6ff; --jit: #ffc48a; --good: #7deba0; --bad: #ff6b8a;
+  --accent: #E91E8C;
   --shadow: 0 1px 2px rgba(0,0,0,.3), 0 1px 3px rgba(0,0,0,.35);
 }
 * { box-sizing: border-box; }
 body {
-  margin: 0; background: var(--surface); color: var(--ink);
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  margin: 0; color: var(--ink);
+  background: linear-gradient(135deg, var(--surface) 0%, #2d1040 50%, #1a0a30 100%);
+  background-attachment: fixed;
+  font-family: system-ui, -apple-system, 'Hiragino Sans', 'Noto Sans JP', sans-serif;
   font-size: 14px; line-height: 1.5; -webkit-font-smoothing: antialiased;
+  min-height: 100vh; display: flex; flex-direction: column;
 }
-.mono { font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+.mono { font-family: 'Fira Code', 'JetBrains Mono', ui-monospace, Menlo, monospace;
   font-variant-numeric: tabular-nums; }
-header {
-  position: sticky; top: 0; z-index: 5; background: color-mix(in srgb, var(--surface) 88%, transparent);
+.bench-head {
+  position: sticky; top: 0; z-index: 5; background: rgba(13, 5, 20, .75);
   backdrop-filter: blur(8px); border-bottom: 1px solid var(--edge);
   padding: 18px clamp(16px, 4vw, 40px) 14px;
 }
+/* Deployed alongside the site, the site's own nav already owns the top of the
+   viewport, so the controls scroll away with the content instead of fighting
+   it for the sticky slot. */
+.site-nav ~ .bench-head { position: static; }
 .title { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
 h1 { font-size: 19px; font-weight: 650; margin: 0; letter-spacing: -.01em; }
-.sub { color: var(--muted); font-size: 12.5px; }
+.bench-head .sub { color: var(--muted); font-size: 12.5px; }
 .controls { display: flex; gap: 18px; flex-wrap: wrap; align-items: center; margin-top: 14px; }
 .seg { display: inline-flex; border: 1px solid var(--edge); border-radius: 8px; overflow: hidden; }
 .seg button {
   appearance: none; border: 0; background: transparent; color: var(--muted);
   font: inherit; font-size: 12.5px; padding: 6px 12px; cursor: pointer;
 }
-.seg button[aria-pressed="true"] { background: var(--ink); color: var(--surface); }
+.seg button[aria-pressed="true"] { background: var(--accent); color: #fff; }
+.seg button:hover { color: var(--ink); }
 .seg button:focus-visible { outline: 2px solid var(--base); outline-offset: -2px; }
 .ctl-label { font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); margin-right: 2px; }
 .legend { display: flex; gap: 16px; align-items: center; margin-left: auto; font-size: 12.5px; }
 .legend span { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); }
 .swatch { width: 14px; height: 3px; border-radius: 2px; display: inline-block; }
-main { padding: clamp(16px, 3vw, 28px) clamp(16px, 4vw, 40px) 60px; }
+main { padding: clamp(16px, 3vw, 28px) clamp(16px, 4vw, 40px) 60px; flex: 1; }
 .grid { display: grid; gap: 14px; grid-template-columns: repeat(auto-fill, minmax(310px, 1fr)); }
-.card {
+/* Namespaced: site.css also defines `.card`, and this file is loaded next to
+   it on the deployed site. */
+.bench-card {
   background: var(--card); border: 1px solid var(--edge); border-radius: 12px;
   padding: 13px 14px 8px; box-shadow: var(--shadow); position: relative;
 }
-.card h2 { font-size: 13.5px; font-weight: 600; margin: 0; letter-spacing: -.005em; }
-.card .head { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
+.bench-card h2 { font-size: 13.5px; font-weight: 600; margin: 0; letter-spacing: -.005em; }
+.bench-card .head { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
 .readout { display: flex; align-items: baseline; gap: 8px; margin: 2px 0 4px; }
 .now { font-size: 16px; font-weight: 600; }
 .now .unit { font-size: 11px; color: var(--muted); font-weight: 400; margin-left: 1px; }
@@ -184,16 +184,16 @@ svg { display: block; width: 100%; height: auto; overflow: visible; touch-action
 table { border-collapse: collapse; width: 100%; font-size: 12.5px; }
 th, td { text-align: right; padding: 6px 10px; border-bottom: 1px solid var(--hair); }
 th:first-child, td:first-child { text-align: left; }
-thead th { position: sticky; top: 0; background: var(--surface); color: var(--muted);
+thead th { position: sticky; top: 0; background: var(--card); color: var(--muted);
   font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: .05em; cursor: pointer; }
-tbody tr:hover { background: color-mix(in srgb, var(--ink) 4%, transparent); }
+tbody tr:hover { background: color-mix(in srgb, var(--ink) 8%, transparent); }
 .hidden { display: none; }
 .foot { color: var(--muted); font-size: 11.5px; margin-top: 22px; }
 </style>
-
-<header>
+__CHROME_NAV__
+<div class="bench-head">
   <div class="title">
-    <h1>mutsu bench trend</h1>
+    <h1>Benchmark trend</h1>
     <span class="sub" id="meta"></span>
   </div>
   <div class="controls">
@@ -218,12 +218,13 @@ tbody tr:hover { background: color-mix(in srgb, var(--ink) 4%, transparent); }
       <span><i class="swatch" style="background:var(--jit)"></i>+jit</span>
     </div>
   </div>
-</header>
+</div>
 <main>
   <div class="grid" id="grid"></div>
   <div id="tableWrap" class="hidden"></div>
   <p class="foot" id="foot"></p>
 </main>
+__CHROME_FOOTER__
 
 <script id="data" type="application/json">__DATA__</script>
 <script>
@@ -300,7 +301,7 @@ function cardHTML(b) {
     chip = `<span class="chip ${cls}">${sign}${d.pct.toFixed(1)}%${cls==='flat'?'':arrow}</span>`;
     now = `<span class="now mono">${fmt(d.now)}<span class="unit">${unit()}${nowLane==='jit'?' (+jit)':''}</span></span>`;
   }
-  return `<div class="card" data-name="${b.name}">
+  return `<div class="bench-card" data-name="${b.name}">
     <div class="head"><h2>${b.name}</h2></div>
     <div class="readout">${now}${chip}</div>
     ${c.svg}
@@ -404,6 +405,20 @@ render();
 """
 
 
+# Site chrome (nav + footer), added by --site-chrome. The markup is empty on
+# purpose: the real navigation, language switch and credit footer are rendered
+# into it by the site's own `assets/i18n.js`, so this page can never drift from
+# the other pages' chrome. Without the flag the file stays self-contained (no
+# external requests) and simply has no chrome.
+CHROME_HEAD = '<link rel="stylesheet" href="assets/site.css">'
+CHROME_NAV = '<nav class="site-nav"></nav>'
+CHROME_FOOTER = """<footer class="site-footer"></footer>
+<script type="module">
+  import { renderChrome } from './assets/i18n.js';
+  renderChrome('bench');
+</script>"""
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("input", nargs="?", help="bench-history.tsv (default: stdin)")
@@ -413,6 +428,13 @@ def main():
         action="store_true",
         help="prepend a DOCTYPE so the file renders in standards mode when opened "
         "directly in a browser (omit when publishing as an Artifact, which adds its own)",
+    )
+    ap.add_argument(
+        "--site-chrome",
+        action="store_true",
+        help="add the mutsu site's shared nav and footer (pulls in assets/site.css and "
+        "assets/i18n.js from the same directory). Use when the output is deployed into "
+        "wasm-demo/; omit to keep the file self-contained for offline use.",
     )
     args = ap.parse_args()
 
@@ -425,6 +447,11 @@ def main():
     # Guard against a stray </script> in the data breaking the inline block.
     payload = payload.replace("</", "<\\/")
     doc = TEMPLATE.replace("__DATA__", payload)
+    doc = (
+        doc.replace("__CHROME_HEAD__", CHROME_HEAD if args.site_chrome else "")
+        .replace("__CHROME_NAV__", CHROME_NAV if args.site_chrome else "")
+        .replace("__CHROME_FOOTER__", CHROME_FOOTER if args.site_chrome else "")
+    )
     if args.standalone:
         doc = '<!DOCTYPE html>\n<meta charset="utf-8">\n' + doc
 

--- a/wasm-demo/README.md
+++ b/wasm-demo/README.md
@@ -30,7 +30,20 @@ content/
   tutorial.ja.js    tutorial titles and prose (Japanese)
   landing.en.js     landing-page copy (English)
   landing.ja.js     landing-page copy (Japanese)
+bench-trend.html    benchmark dashboard — generated, git-ignored (see below)
 pkg/                wasm-pack output — generated, git-ignored
+```
+
+`bench-trend.html` is rendered into the site at deploy time by
+`scripts/bench-visualize.py` from the `bench-data` branch's `bench-history.tsv`.
+Passing `--site-chrome` makes it load `assets/site.css` and `assets/i18n.js` and
+render the same nav, language switch and footer as every other page, so the shared
+chrome has exactly one definition. Without the flag the script keeps producing a
+fully self-contained file for offline use:
+
+```sh
+git show origin/bench-data:bench-history.tsv \
+  | python3 scripts/bench-visualize.py --standalone --site-chrome -o wasm-demo/bench-trend.html
 ```
 
 ## Languages
@@ -115,7 +128,8 @@ SKIP_LESSON_SWEEP=1 node wasm-demo/e2e.test.mjs   # skip the per-lesson sweep
 
 The e2e suite runs **every** tutorial lesson in the browser and compares against the
 recorded expectation, so a WASM-only regression cannot reach the deployed site
-unnoticed.
+unnoticed. It also renders `bench-trend.html` from a synthetic history and checks its
+chrome, so the generated page cannot silently drift away from the hand-written ones.
 
 ## Credit
 

--- a/wasm-demo/e2e.test.mjs
+++ b/wasm-demo/e2e.test.mjs
@@ -12,8 +12,8 @@
 // SKIP_LESSON_SWEEP=1 to skip it while iterating locally.
 
 import { chromium } from 'playwright';
-import { spawn } from 'child_process';
-import { existsSync, readFileSync } from 'fs';
+import { spawn, spawnSync } from 'child_process';
+import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs';
 
 import { parseCorpus } from './assets/corpus.js';
 
@@ -74,6 +74,32 @@ if (!existsSync('wasm-demo/pkg/mutsu.js')) {
 const lessons = parseCorpus(readFileSync('wasm-demo/content/lessons.txt', 'utf8'));
 const highlights = parseCorpus(readFileSync('wasm-demo/content/highlights.txt', 'utf8'));
 
+// The bench dashboard is generated at deploy time from the bench-data branch.
+// Render one here from a synthetic history so its site chrome is covered by the
+// same suite as the hand-written pages — it is a page of the site, and it is
+// easy to forget when the shared chrome changes.
+const BENCH_HTML = 'wasm-demo/bench-trend.html';
+const BENCH_TSV = 'wasm-demo/.bench-history.e2e.tsv';
+const benchRows = [
+  'date\tcommit\tbenchmark\tmutsu_median_s\tmutsu_min_s\traku_median_s\tratio_mutsu_over_raku\truns\trunner\trakudo',
+];
+for (let i = 0; i < 6; i++) {
+  const sha = `${i}`.repeat(40);
+  for (const [name, base] of [['bench-fib', 0.2], ['bench-hash', 0.04]]) {
+    const t = (base * (1 + i / 50)).toFixed(4);
+    benchRows.push(`2026-07-${10 + i}T00:00:00Z\t${sha}\t${name}\t${t}\t${t}\t0.3000\t0.80\t7\tci\tRakudo`);
+    benchRows.push(`2026-07-${10 + i}T00:00:00Z\t${sha}\t${name}+jit\t${t}\t${t}\t0.3000\t0.70\t7\tci\tRakudo`);
+  }
+}
+writeFileSync(BENCH_TSV, benchRows.join('\n') + '\n');
+const rendered = spawnSync('python3', ['scripts/bench-visualize.py', '--standalone',
+                                       '--site-chrome', BENCH_TSV, '-o', BENCH_HTML],
+                           { encoding: 'utf8' });
+if (rendered.status !== 0) {
+  console.error('Error: could not render the bench dashboard:', rendered.stderr);
+  process.exit(1);
+}
+
 // Start HTTP server
 server = spawn('python3', ['-m', 'http.server', String(PORT), '-d', 'wasm-demo'], {
   stdio: ['ignore', 'pipe', 'pipe'],
@@ -121,6 +147,34 @@ try {
          `the "${firstHighlight.key}" card produces its expected output`);
   assert(await page.locator(`#card-${firstHighlight.id} .verdict.ok`).count() === 1,
          'a matching run is marked as matching');
+
+  /* =============================================================== *
+   * Benchmark dashboard — a generated page, but still a page of the site
+   * =============================================================== */
+
+  console.log('Test: benchmark dashboard wears the site chrome');
+  await page.goto(`${BASE}/bench-trend.html?lang=en`, { waitUntil: 'networkidle' });
+  await page.waitForFunction(() => document.querySelector('.site-nav a') !== null,
+                             { timeout: 15000 });
+  assert(await page.locator('.site-nav .nav-links a').count() >= 4,
+         'it has the shared navigation');
+  assert(await page.textContent('.site-nav a[aria-current="page"]') === 'Benchmarks',
+         'with itself marked as the current page');
+  assert((await page.textContent('.site-footer')).includes('Raku/doc'),
+         'and the shared footer credit');
+  assert(await page.locator('.lang-switch button').count() === 2,
+         'and the language switch');
+  assert(await page.locator('.bench-card svg').count() === 2,
+         'the charts still render (one per benchmark)');
+  await page.click('#view button[data-v="table"]');
+  assert(await page.locator('#tableWrap tbody tr').count() === 2,
+         'and the table view still works');
+  assert(await page.evaluate(() =>
+    getComputedStyle(document.body).backgroundImage.includes('gradient')),
+    'it uses the site background rather than its own');
+  assert(await page.evaluate(() =>
+    document.documentElement.scrollWidth <= document.documentElement.clientWidth),
+    'and does not scroll sideways');
 
   /* =============================================================== *
    * Tutorial
@@ -360,6 +414,8 @@ try {
   failed++;
 } finally {
   server.kill();
+  rmSync(BENCH_TSV, { force: true });
+  rmSync(BENCH_HTML, { force: true });
 }
 
 console.log(`\nResults: ${passed} passed, ${failed} failed`);


### PR DESCRIPTION
Follow-up to #5306.

`bench-trend.html` was the odd page out: generated, with its own neutral light/dark palette, its own sticky header and **no site navigation at all** — landing on it was a dead end that looked like a different product.

## What changed

`scripts/bench-visualize.py` gains **`--site-chrome`** (passed by `pages.yml`), which loads `assets/site.css` and `assets/i18n.js` and renders the *same* nav, language switch and footer as every other page. The shared chrome keeps exactly one definition rather than being duplicated into the Python template — change `i18n.js` and this page follows.

Without the flag the script still emits a fully self-contained file (no external requests), which is what the offline and Artifact uses need, so the trade-off stays opt-in.

Also:

- the dashboard's palette now matches the site (purple, single dark theme) instead of its own neutral light/dark scheme;
- selectors that collided with `site.css` are namespaced — `.card` → `.bench-card`, the `header` element selector → `.bench-head`;
- the controls give up the sticky slot when the site nav is present, since the nav already owns the top of the viewport;
- `/wasm-demo/bench-trend.html` is git-ignored (it has always been generated at deploy time).

## Testing

`node wasm-demo/e2e.test.mjs` — **71 passed, 0 failed**.

The suite now renders the dashboard from a synthetic history and asserts its chrome, so the generated page cannot silently drift away from the hand-written ones again:

```
Test: benchmark dashboard wears the site chrome
  PASS: it has the shared navigation
  PASS: with itself marked as the current page
  PASS: and the shared footer credit
  PASS: and the language switch
  PASS: the charts still render (one per benchmark)
  PASS: and the table view still works
  PASS: it uses the site background rather than its own
  PASS: and does not scroll sideways
```

Both output modes were also checked against the real 769-commit history: `--site-chrome` emits the link/nav/footer/module script, plain `--standalone` emits none of them and stays self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)