### PR TITLE
feat: NativeCall CArray[T] arguments (contiguous C buffers and char**)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -304,9 +304,13 @@ sessions).
       [`docs/ecosystem-guts-dependency-survey.md`](../docs/ecosystem-guts-dependency-survey.md)
       and the highest-leverage way to widen the batteries base. Workflow per bug:
       minimal repro → general fix → `t/` pin → PR → re-check with `--only <Dist>`.
-- [ ] **NativeCall remainder**: ① `CArray[uint8]`, `CArray[Str]` ② `is repr('CStruct')` structs
-      ③ callbacks (generic C callbacks). Everything from the MVP up to real SQLite CRUD is done
-      (news/2026-06.md archive section).
+- [ ] **NativeCall remainder**: ~~① `CArray[uint8]`, `CArray[Str]`~~ (done — CArray[T] is a
+      constructible/indexable native-backed buffer, marshalled to a `T*` / `char**` argument with
+      out-array writeback; `t/nativecall-carray.t`) ② `is repr('CStruct')` structs ③ callbacks
+      (generic C callbacks). Not yet: a *returned* `CArray[T]` is surfaced as the raw `Pointer` it
+      carries (no length to reify a Raku array), and `.^name` reads `CArray[uint8]` rather than
+      raku's `NativeCall::Types::CArray[uint8]`. Everything from the MVP up to real SQLite CRUD is
+      done (news/2026-06.md archive section).
 - [ ] **Remaining 2 blockers for full Humming-Bird serving** (LOAD + LISTEN + accept + decode works;
       #3549): **B1** = leakage of `var_type_constraint` from typed parameters to same-named caller
       lexicals (the proper fix scopes the global name-keyed HashMap at call boundaries;

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -67,6 +67,30 @@ for builtins; TODO noted in `methods_sub.rs`). Pin: `t/builtin-routine-type-iden
 (passes under raku too). This closes the "CORE::<&say>.^name is Routine" divergence
 spotted 2026-07-23.
 
+## 2026-07-23: NativeCall `CArray[T]` arguments — contiguous C buffers and `char**` (PLAN §1 NativeCall remainder ①)
+
+`CArray[T]` is now a real NativeCall aggregate type. It is registered as a built-in parametric
+type (`is_builtin_type` / `is_known_type_constraint`), so `CArray[uint8]` resolves to a type
+object and `.new(...)` routes through the shared native-array construction path — the value is a
+mutable, element-assignable native-backed `Array` that reports `.^name` `CArray[uint8]` and
+smartmatches its parametric type (`$a ~~ CArray[uint8]`).
+
+At call time the marshaller (`runtime/nativecall.rs`) turns a `CArray[T]` argument into a
+contiguous C buffer passed as a `T*` — one `ArgOwner::CArrayNum` holds the heap byte buffer whose
+address stays stable across the move into the owners vector (the same keep-alive discipline as the
+existing `CStr`/`OutPtr` owners). `CArray[Str]` marshals to a NULL-terminated `char**`
+(`ArgOwner::CArrayStr`). Because a Raku `CArray` is backed by C memory, any bytes the callee writes
+into a numeric buffer are copied back element-by-element into the caller's array through the shared
+GC node (`with_array_inplace`), so an out-array fill (`memcpy($dst, $src, $n)`) is visible at the
+call site. Verified end-to-end against libc: `strlen`/`memcmp`/`memcpy` over `CArray[uint8]`,
+`memcmp` over `CArray[int32]`/`CArray[num64]`, and `strsep` exercising the `CArray[Str]` `char**`
+path. Pin: `t/nativecall-carray.t` (21 tests).
+
+Not yet: a *returned* `CArray[T]` is surfaced as the raw `Pointer` it carries (a returned pointer
+has no length to reify a Raku array), and `.^name` reads `CArray[uint8]` rather than raku's fully
+qualified `NativeCall::Types::CArray[uint8]`. `is repr('CStruct')` structs (②) and callbacks (③)
+remain.
+
 ## 2026-07-23: `IO::Path::Parts.raku`/`.gist` render the positional parts (PLAN §8.15)
 
 `IO::Path::Parts.new('C:', '/some/dir', 'foo.txt').raku` (and `.gist`) rendered the bare

--- a/src/runtime/methods_aggregate_ctor.rs
+++ b/src/runtime/methods_aggregate_ctor.rs
@@ -238,7 +238,9 @@ impl Interpreter {
                 }
             }
         }
-        let mut result = if matches!(base_class_name, "Array" | "array") {
+        let mut result = if matches!(base_class_name, "Array" | "array" | "CArray") {
+            // A CArray is a mutable, element-assignable buffer like a native
+            // `array`, so build a real (mutable) Array, not an immutable List.
             Value::real_array(items)
         } else {
             Value::array(items)
@@ -408,7 +410,7 @@ impl Interpreter {
             (cn_resolved.as_str(), None)
         };
         match base {
-            "Array" | "List" | "Positional" | "array" => {
+            "Array" | "List" | "Positional" | "array" | "CArray" => {
                 Some(self.try_native_array_construct(class_name, base, &type_args, args))
             }
             "Hash" | "Map" => Some(self.try_native_hash_construct(class_name, &type_args, args)),

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -572,7 +572,7 @@ impl Interpreter {
                     // Shared with the VM's native fast path.
                     return Ok(Self::build_native_iterationbuffer_value(*class_name, &args));
                 }
-                "Array" | "List" | "Positional" | "array" => {
+                "Array" | "List" | "Positional" | "array" | "CArray" => {
                     // Shared single implementation with the VM's native fast path.
                     return self.try_native_array_construct(
                         *class_name,

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -6,10 +6,12 @@
 //! types, marshal the Raku argument `Value`s into C values, perform the call,
 //! and marshal the C return value back into a `Value`.
 //!
-//! This is the MVP: scalar C types (signed/unsigned 8/16/32/64-bit integers,
-//! 32/64-bit floats), `Str` passed as a NUL-terminated `char*`, and an opaque
-//! `Pointer`. Aggregates (`CStruct`/`CArray`/`CUnion`), callbacks, and typed
-//! pointers are follow-up work.
+//! Supported so far: scalar C types (signed/unsigned 8/16/32/64-bit integers,
+//! 32/64-bit floats), `Str` passed as a NUL-terminated `char*`, an opaque
+//! `Pointer`, and `CArray[T]` (a contiguous C buffer / `char**` for
+//! `CArray[Str]`) as a call argument, with the C-side data copied back into the
+//! Raku array after the call so an out-array (`memcpy`-style fill) is visible.
+//! `CStruct`/`CUnion` structs and callbacks remain follow-up work.
 
 use crate::value::{RuntimeError, Value, ValueView};
 
@@ -31,6 +33,10 @@ pub enum CType {
     Str,
     /// Opaque `Pointer` / `Pointer[T]` — carried as an integer address.
     Pointer,
+    /// `CArray[T]` — a contiguous C buffer whose element C type is carried in
+    /// the [`ParamSpec::elem`] field (a scalar numeric type, or `Str` for a
+    /// `char**`). Passed as a pointer to the first element.
+    CArray,
 }
 
 impl CType {
@@ -64,6 +70,8 @@ impl CType {
 pub struct ParamSpec {
     pub ct: CType,
     pub is_rw: bool,
+    /// Element C type when `ct == CType::CArray` (`None` otherwise).
+    pub elem: Option<CType>,
 }
 
 /// The resolved descriptor for one `is native` sub: which library/symbol to
@@ -200,6 +208,9 @@ pub fn call_native(spec: &NativeCallSpec, args: &[Value]) -> Result<Value, Runti
     // Arg indices whose `is rw Pointer` out-slot must be written back into the
     // caller's Pointer object after the call.
     let mut writebacks: Vec<usize> = Vec::new();
+    // Arg indices holding a numeric `CArray` whose C buffer must be copied back
+    // into the caller's Raku array after the call (an out-array fill).
+    let mut carray_writebacks: Vec<usize> = Vec::new();
 
     for (i, (ps, v)) in spec.params.iter().zip(args.iter()).enumerate() {
         let (ty, owner) = if ps.is_rw && ps.ct == CType::Pointer {
@@ -209,13 +220,19 @@ pub fn call_native(spec: &NativeCallSpec, args: &[Value]) -> Result<Value, Runti
             writebacks.push(i);
             (Type::pointer(), ArgOwner::new_out_ptr(slot))
         } else {
-            marshal_arg(ps.ct, v).map_err(|msg| {
+            let (ty, owner) = marshal_arg(ps, v).map_err(|msg| {
                 RuntimeError::new(format!(
                     "NativeCall: argument {} to '{}': {msg}",
                     i + 1,
                     spec.symbol
                 ))
-            })?
+            })?;
+            // A numeric CArray is backed by C memory in Raku, so any write the
+            // callee performs must be reflected back into the caller's array.
+            if matches!(owner, ArgOwner::CArrayNum { .. }) {
+                carray_writebacks.push(i);
+            }
+            (ty, owner)
         };
         arg_types.push(ty);
         owners.push(owner);
@@ -246,7 +263,12 @@ pub fn call_native(spec: &NativeCallSpec, args: &[Value]) -> Result<Value, Runti
             CType::U64 => Value::int(cif.call::<u64>(code, &ffi_args) as i64),
             CType::F32 => Value::num(cif.call::<f32>(code, &ffi_args) as f64),
             CType::F64 => Value::num(cif.call::<f64>(code, &ffi_args)),
-            CType::Pointer => make_pointer_value(cif.call::<usize>(code, &ffi_args)),
+            // A CArray return is mapped to `CType::Pointer` at registration
+            // (a returned `CArray[T]` has no length to reify), so this arm is
+            // unreachable in practice — treat it as an opaque pointer.
+            CType::Pointer | CType::CArray => {
+                make_pointer_value(cif.call::<usize>(code, &ffi_args))
+            }
             CType::Str => {
                 let ptr = cif.call::<*const std::ffi::c_char>(code, &ffi_args);
                 if ptr.is_null() {
@@ -265,6 +287,25 @@ pub fn call_native(spec: &NativeCallSpec, args: &[Value]) -> Result<Value, Runti
     for idx in writebacks {
         if let ArgOwner::OutPtr { slot, .. } = &owners[idx] {
             write_pointer_address(&args[idx], **slot);
+        }
+    }
+
+    // Copy each numeric CArray's (possibly callee-modified) C buffer back into
+    // the caller's Raku array, element by element, through the shared backing
+    // node so the mutation is visible at the call site.
+    for idx in carray_writebacks {
+        if let ArgOwner::CArrayNum { buf, elem, .. } = &owners[idx]
+            && let Some(arr) = resolve_array_value(&args[idx])
+        {
+            let sz = carray_elem_size(*elem);
+            arr.with_array_inplace(|data, _kind| {
+                for (i, cell) in data.items.iter_mut().enumerate() {
+                    let off = i * sz;
+                    if off + sz <= buf.len() {
+                        *cell = decode_carray_elem(*elem, &buf[off..off + sz]);
+                    }
+                }
+            });
         }
     }
 
@@ -355,6 +396,24 @@ enum ArgOwner {
         slot: Box<usize>,
         slot_ptr: *mut std::ffi::c_void,
     },
+    /// A numeric `CArray[T]`: `buf` is the contiguous element buffer (heap, so
+    /// its address is stable across the move into `owners`); `data_ptr` is the
+    /// `T*` handed to libffi. `elem` is the element C type (for writeback).
+    CArrayNum {
+        buf: Vec<u8>,
+        data_ptr: *const std::ffi::c_void,
+        elem: CType,
+    },
+    /// A `CArray[Str]` (`char**`): `strings` keeps the NUL-terminated buffers
+    /// alive, `ptrs` is the NULL-terminated `char*` array, `data_ptr` is the
+    /// `char**` handed to libffi (the address of the first `char*`).
+    CArrayStr {
+        #[allow(dead_code)]
+        strings: Vec<std::ffi::CString>,
+        #[allow(dead_code)]
+        ptrs: Vec<*const std::ffi::c_char>,
+        data_ptr: *const std::ffi::c_void,
+    },
 }
 
 #[cfg(feature = "libffi")]
@@ -383,6 +442,8 @@ impl ArgOwner {
             ArgOwner::Ptr(p) => arg(p),
             ArgOwner::CStr(_, p) => arg(p),
             ArgOwner::OutPtr { slot_ptr, .. } => arg(slot_ptr),
+            ArgOwner::CArrayNum { data_ptr, .. } => arg(data_ptr),
+            ArgOwner::CArrayStr { data_ptr, .. } => arg(data_ptr),
         }
     }
 }
@@ -402,9 +463,86 @@ fn resolve_arg(v: &Value) -> Value {
     }
 }
 
+/// Unwrap a native-call argument to the underlying `Array` value (sharing the
+/// same GC backing node), unwrapping a `Scalar` / `ContainerRef` / `VarRef`
+/// container first. Used to write a numeric CArray's buffer back into the
+/// caller's array in place.
 #[cfg(feature = "libffi")]
-fn marshal_arg(ct: CType, raw: &Value) -> Result<(libffi::middle::Type, ArgOwner), String> {
+fn resolve_array_value(v: &Value) -> Option<Value> {
+    match v.view() {
+        ValueView::Array(..) => Some(v.clone()),
+        ValueView::Scalar(inner) => resolve_array_value(inner),
+        ValueView::ContainerRef(cell) => cell.lock().ok().and_then(|g| resolve_array_value(&g)),
+        ValueView::VarRef { value, .. } => resolve_array_value(value),
+        _ => None,
+    }
+}
+
+/// The size in bytes of one `CArray[T]` element for a scalar C element type.
+#[cfg(feature = "libffi")]
+fn carray_elem_size(elem: CType) -> usize {
+    match elem {
+        CType::I8 | CType::U8 => 1,
+        CType::I16 | CType::U16 => 2,
+        CType::I32 | CType::U32 | CType::F32 => 4,
+        CType::I64 | CType::U64 | CType::F64 => 8,
+        // A pointer-sized element (`Pointer`); Str is handled separately.
+        CType::Pointer | CType::Str | CType::CArray | CType::Void => std::mem::size_of::<usize>(),
+    }
+}
+
+/// Encode one Raku value into `dst` (exactly `carray_elem_size(elem)` bytes) as
+/// a native-endian C scalar of the given element type.
+#[cfg(feature = "libffi")]
+fn encode_carray_elem(elem: CType, v: &Value, dst: &mut [u8]) {
+    let int = crate::runtime::to_int(v);
+    let num = crate::runtime::utils::to_float_value(v).unwrap_or(0.0);
+    match elem {
+        CType::I8 | CType::U8 => dst.copy_from_slice(&(int as u8).to_ne_bytes()),
+        CType::I16 | CType::U16 => dst.copy_from_slice(&(int as u16).to_ne_bytes()),
+        CType::I32 | CType::U32 => dst.copy_from_slice(&(int as u32).to_ne_bytes()),
+        CType::I64 | CType::U64 => dst.copy_from_slice(&(int as u64).to_ne_bytes()),
+        CType::F32 => dst.copy_from_slice(&(num as f32).to_ne_bytes()),
+        CType::F64 => dst.copy_from_slice(&num.to_ne_bytes()),
+        CType::Pointer | CType::Str | CType::CArray | CType::Void => {
+            dst.copy_from_slice(&(int as usize).to_ne_bytes())
+        }
+    }
+}
+
+/// Decode one C scalar element (native-endian bytes in `src`) back into a Raku
+/// value. Integer elements become `Int`, float elements become `Num`.
+#[cfg(feature = "libffi")]
+fn decode_carray_elem(elem: CType, src: &[u8]) -> Value {
+    fn arr<const N: usize>(src: &[u8]) -> [u8; N] {
+        let mut a = [0u8; N];
+        a.copy_from_slice(&src[..N]);
+        a
+    }
+    match elem {
+        CType::I8 => Value::int(i8::from_ne_bytes(arr(src)) as i64),
+        CType::U8 => Value::int(u8::from_ne_bytes(arr(src)) as i64),
+        CType::I16 => Value::int(i16::from_ne_bytes(arr(src)) as i64),
+        CType::U16 => Value::int(u16::from_ne_bytes(arr(src)) as i64),
+        CType::I32 => Value::int(i32::from_ne_bytes(arr(src)) as i64),
+        CType::U32 => Value::int(u32::from_ne_bytes(arr(src)) as i64),
+        CType::I64 => Value::int(i64::from_ne_bytes(arr(src))),
+        CType::U64 => Value::int(u64::from_ne_bytes(arr::<8>(src)) as i64),
+        CType::F32 => Value::num(f32::from_ne_bytes(arr(src)) as f64),
+        CType::F64 => Value::num(f64::from_ne_bytes(arr(src))),
+        CType::Pointer | CType::Str | CType::CArray | CType::Void => {
+            Value::int(usize::from_ne_bytes(arr(src)) as i64)
+        }
+    }
+}
+
+#[cfg(feature = "libffi")]
+fn marshal_arg(ps: &ParamSpec, raw: &Value) -> Result<(libffi::middle::Type, ArgOwner), String> {
     use libffi::middle::Type;
+    if ps.ct == CType::CArray {
+        return marshal_carray_arg(ps, raw);
+    }
+    let ct = ps.ct;
     let resolved = resolve_arg(raw);
     let v = &resolved;
     let int = || crate::runtime::to_int(v);
@@ -433,7 +571,68 @@ fn marshal_arg(ct: CType, raw: &Value) -> Result<(libffi::middle::Type, ArgOwner
             (Type::pointer(), ArgOwner::CStr(cstr, ptr))
         }
         CType::Void => return Err("a parameter cannot have type void".to_string()),
+        // Routed to `marshal_carray_arg` above; unreachable here.
+        CType::CArray => return marshal_carray_arg(ps, raw),
     })
+}
+
+/// Marshal a `CArray[T]` argument: a Raku array of elements becomes a
+/// contiguous C buffer (`T*`), or a `char**` (NULL-terminated) for
+/// `CArray[Str]`. A null/Any argument becomes a null pointer.
+#[cfg(feature = "libffi")]
+fn marshal_carray_arg(
+    ps: &ParamSpec,
+    raw: &Value,
+) -> Result<(libffi::middle::Type, ArgOwner), String> {
+    use libffi::middle::Type;
+    let elem = ps
+        .elem
+        .ok_or_else(|| "CArray parameter is missing its element type".to_string())?;
+    let list = match resolve_array_value(raw) {
+        Some(arr) => arr
+            .with_array_inplace(|data, _| data.items.clone())
+            .unwrap_or_default(),
+        // A bare type object / Any becomes a null pointer.
+        None => Vec::new(),
+    };
+
+    if elem == CType::Str {
+        let mut strings = Vec::with_capacity(list.len());
+        let mut ptrs: Vec<*const std::ffi::c_char> = Vec::with_capacity(list.len() + 1);
+        for item in &list {
+            let s = item.to_string_value();
+            let cstr = std::ffi::CString::new(s)
+                .map_err(|_| "CArray[Str] element contains an embedded NUL byte".to_string())?;
+            ptrs.push(cstr.as_ptr());
+            strings.push(cstr);
+        }
+        // C `char**` arrays are conventionally NULL-terminated.
+        ptrs.push(std::ptr::null());
+        let data_ptr = ptrs.as_ptr() as *const std::ffi::c_void;
+        return Ok((
+            Type::pointer(),
+            ArgOwner::CArrayStr {
+                strings,
+                ptrs,
+                data_ptr,
+            },
+        ));
+    }
+
+    let sz = carray_elem_size(elem);
+    let mut buf = vec![0u8; list.len() * sz];
+    for (i, item) in list.iter().enumerate() {
+        encode_carray_elem(elem, item, &mut buf[i * sz..(i + 1) * sz]);
+    }
+    let data_ptr = buf.as_ptr() as *const std::ffi::c_void;
+    Ok((
+        Type::pointer(),
+        ArgOwner::CArrayNum {
+            buf,
+            data_ptr,
+            elem,
+        },
+    ))
 }
 
 #[cfg(feature = "libffi")]
@@ -451,7 +650,7 @@ fn ret_ffi_type(ct: CType) -> libffi::middle::Type {
         CType::U64 => Type::u64(),
         CType::F32 => Type::f32(),
         CType::F64 => Type::f64(),
-        CType::Str | CType::Pointer => Type::pointer(),
+        CType::Str | CType::Pointer | CType::CArray => Type::pointer(),
     }
 }
 

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -453,6 +453,23 @@ impl Interpreter {
                     }
                     return false;
                 }
+                // NativeCall `CArray[T]`: a C buffer backed by a native Array
+                // carrying a `CArray[...]` declared type and `T` value type.
+                "CArray" => {
+                    if let ValueView::Array(..) = value.view()
+                        && let Some(metadata) = self.container_type_metadata(value)
+                        && metadata
+                            .declared_type
+                            .as_deref()
+                            .is_some_and(|declared| declared.starts_with("CArray["))
+                    {
+                        return self.type_matches_value(
+                            inner,
+                            &Value::package(Symbol::intern(&metadata.value_type)),
+                        );
+                    }
+                    return false;
+                }
                 "Array" | "List" | "Positional" => {
                     if let ValueView::Array(items, ..) = value.view() {
                         // Prefer the container's declared element type when known

--- a/src/runtime/utils/type_constraints.rs
+++ b/src/runtime/utils/type_constraints.rs
@@ -113,6 +113,8 @@ pub(crate) fn is_known_type_constraint(constraint: &str) -> bool {
             // Array-like
             | "array"
             | "Hashray"
+            // NativeCall aggregate type (a contiguous C array)
+            | "CArray"
             // Numeric subtypes
             | "byte"
             | "uint"

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -340,15 +340,36 @@ impl Interpreter {
             let Some(tc) = pd.type_constraint.as_deref() else {
                 return Ok(());
             };
+            let is_rw = pd.traits.iter().any(|t| t == "rw");
+            // `CArray[T]` — a contiguous C buffer whose element type T is
+            // marshalled per-element. Unrecognized element types skip native
+            // registration (so the failure surfaces clearly).
+            if let Some(inner) = tc.strip_prefix("CArray[").and_then(|s| s.strip_suffix(']')) {
+                let Some(elem) = CType::from_type_name(inner) else {
+                    return Ok(());
+                };
+                params.push(ParamSpec {
+                    ct: CType::CArray,
+                    is_rw,
+                    elem: Some(elem),
+                });
+                continue;
+            }
             let Some(ct) = CType::from_type_name(tc) else {
                 return Ok(());
             };
-            let is_rw = pd.traits.iter().any(|t| t == "rw");
-            params.push(ParamSpec { ct, is_rw });
+            params.push(ParamSpec {
+                ct,
+                is_rw,
+                elem: None,
+            });
         }
 
         let ret = match return_type {
             None => CType::Void,
+            // A returned `CArray[T]` has no length to reify into a Raku array,
+            // so it is surfaced as the raw `Pointer` it carries.
+            Some(rt) if rt.starts_with("CArray[") => CType::Pointer,
             Some(rt) => match CType::from_type_name(rt) {
                 Some(ct) => ct,
                 None => return Ok(()),

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -449,6 +449,8 @@ impl Interpreter {
                 | "Supply"
                 | "Supplier"
                 | "Promise"
+                // NativeCall aggregate type (a contiguous C array).
+                | "CArray"
         ) || {
             // Handle parameterized types like Buf[uint8], Array[Int], etc.
             if let Some(open) = name.find('[')

--- a/t/nativecall-carray.t
+++ b/t/nativecall-carray.t
@@ -1,0 +1,79 @@
+use Test;
+
+# NativeCall CArray[T] support: a `CArray[T]` is a contiguous C buffer that can
+# be constructed, indexed, and passed to a native function as a `T*` (or a
+# `char**` for CArray[Str]). Data the callee writes into the buffer is copied
+# back into the Raku array (out-array semantics).
+
+use NativeCall;
+
+plan 21;
+
+# --- Raku-side construction / indexing (numeric) ---
+my $u = CArray[uint8].new(104, 105, 0);
+isa-ok $u, CArray[uint8],            'CArray[uint8].new returns a CArray[uint8]';
+is $u.elems, 3,                      'CArray[uint8] has the constructed elems';
+is $u[0], 104,                       'CArray[uint8] positional read';
+is $u[1], 105,                       'CArray[uint8] positional read (2)';
+
+my $i = CArray[int32].new;
+$i[0] = 1000;
+$i[1] = 2000;
+is $i.elems, 2,                      'empty CArray[int32].new grows on element assign';
+is $i[1], 2000,                      'CArray[int32] element assign/read';
+
+# --- Raku-side construction / indexing (Str) ---
+my $s = CArray[Str].new('alpha', 'beta', 'gamma');
+is $s.elems, 3,                      'CArray[Str] has the constructed elems';
+is $s[2], 'gamma',                   'CArray[Str] positional read';
+$s[1] = 'BETA';
+is $s[1], 'BETA',                    'CArray[Str] element assign/read';
+
+# --- strlen over a CArray[uint8] used as a NUL-terminated char* ---
+sub c_strlen(CArray[uint8] $p) returns int64 is native('c') is symbol('strlen') { * }
+is c_strlen(CArray[uint8].new(104, 105, 0)), 2, 'strlen(CArray[uint8]) counts to NUL';
+
+# --- memcmp over two numeric CArrays (read-only, two buffers) ---
+sub c_memcmp(CArray[uint8] $a, CArray[uint8] $b, size_t $n) returns int32
+    is native('c') is symbol('memcmp') { * }
+my $a = CArray[uint8].new(1, 2, 3);
+my $b = CArray[uint8].new(1, 2, 3);
+my $c = CArray[uint8].new(1, 2, 4);
+is c_memcmp($a, $b, 3), 0,           'memcmp of equal uint8 buffers is 0';
+ok c_memcmp($a, $c, 3) < 0,          'memcmp orders unequal uint8 buffers';
+
+# --- int32 element type (memcmp over 2 int32 = 8 bytes) ---
+sub c_memcmp32(CArray[int32] $a, CArray[int32] $b, size_t $n) returns int32
+    is native('c') is symbol('memcmp') { * }
+my $x = CArray[int32].new(1000, 2000);
+my $y = CArray[int32].new(1000, 2000);
+my $z = CArray[int32].new(1000, 2001);
+is c_memcmp32($x, $y, 8), 0,         'memcmp of equal int32 buffers is 0';
+ok c_memcmp32($x, $z, 8) != 0,       'memcmp of unequal int32 buffers is non-zero';
+
+# --- memcpy fills the destination CArray (writeback / out-array) ---
+sub c_memcpy(CArray[uint8] $dst, CArray[uint8] $src, size_t $n) returns Pointer
+    is native('c') is symbol('memcpy') { * }
+my $dst = CArray[uint8].new(0, 0, 0, 0);
+my $src = CArray[uint8].new(9, 8, 7, 6);
+c_memcpy($dst, $src, 4);
+is $dst[0], 9,                       'memcpy wrote back element 0';
+is $dst[3], 6,                       'memcpy wrote back element 3';
+is-deeply (^4).map({ $dst[$_] }).List, (9, 8, 7, 6), 'memcpy filled the whole dst buffer';
+
+# --- char** end-to-end: strsep(char **stringp, char *delim) returns the first
+#     token as char*, exercising the CArray[Str] -> char** marshalling ---
+sub c_strsep(CArray[Str] $sp, Str $delim) returns Str is native('c') is symbol('strsep') { * }
+is c_strsep(CArray[Str].new('one,two,three'), ','), 'one',
+    'strsep over a CArray[Str] char** returns the first token';
+
+# --- num64 element type round-trips through a byte-wise memcmp ---
+sub c_memcmp64(CArray[num64] $a, CArray[num64] $b, size_t $n) returns int32
+    is native('c') is symbol('memcmp') { * }
+my $p = CArray[num64].new(1.5e0, 2.5e0);
+my $q = CArray[num64].new(1.5e0, 2.5e0);
+is c_memcmp64($p, $q, 16), 0,        'memcmp of equal num64 buffers is 0';
+
+# --- smartmatch against the parametric type ---
+ok CArray[int32].new(1, 2) ~~ CArray[int32], 'CArray value smartmatches its parametric type';
+nok CArray[int32].new(1, 2) ~~ CArray[num64], 'CArray value does not match a different element type';


### PR DESCRIPTION
## Summary

Implements part ① of the **NativeCall remainder** (PLAN.md §1): `CArray[uint8]` / `CArray[Str]` (and any scalar element type) as call arguments.

`CArray[T]` is now a real NativeCall aggregate type instead of an undeclared bareword. It is registered as a built-in parametric type, so `CArray[uint8]` resolves to a type object and `.new(...)` routes through the shared native-array construction path — the value is a mutable, element-assignable native-backed `Array` that reports `.^name` `CArray[uint8]` and smartmatches its parametric type (`$a ~~ CArray[uint8]`).

At call time the marshaller (`runtime/nativecall.rs`) turns a `CArray[T]` argument into:
- a contiguous C buffer passed as `T*` (`ArgOwner::CArrayNum`), for numeric element types;
- a NULL-terminated `char**` for `CArray[Str]` (`ArgOwner::CArrayStr`).

Both follow the existing owner keep-alive discipline (heap address stable across the move into the owners vector, same as the `CStr`/`OutPtr` owners). Because a Raku `CArray` is backed by C memory, bytes the callee writes into a numeric buffer are copied back element-by-element into the caller's array through the shared GC node (`with_array_inplace`), so an **out-array fill** (`memcpy($dst, $src, $n)`) is visible at the call site.

## Testing

Verified end-to-end against libc in `t/nativecall-carray.t` (21 tests):
- `strlen` / `memcmp` / `memcpy` (writeback) over `CArray[uint8]`
- `memcmp` over `CArray[int32]` and `CArray[num64]`
- `strsep` exercising the `CArray[Str]` → `char**` path
- Raku-side construction, indexing, element assignment, and parametric smartmatch

`make test` passes (22291 tests). `cargo fmt` / `cargo clippy -D warnings` clean.

## Not covered (follow-up)

- A *returned* `CArray[T]` is surfaced as the raw `Pointer` it carries (a returned pointer has no length to reify a Raku array).
- `.^name` reads `CArray[uint8]` rather than raku's fully qualified `NativeCall::Types::CArray[uint8]`.
- `is repr('CStruct')` structs (②) and callbacks (③) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)