### PR TITLE
fix: WhateverCode pseudo-method currying matches Rakudo's list

### DIFF
--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -91,6 +91,19 @@ has no length to reify a Raku array), and `.^name` reads `CArray[uint8]` rather 
 qualified `NativeCall::Types::CArray[uint8]`. `is repr('CStruct')` structs (②) and callbacks (③)
 remain.
 
+## 2026-07-23: WhateverCode pseudo-method currying matches Rakudo's list
+
+`(* + 1).WHAT` curried into a new WhateverCode where Rakudo evaluates it immediately
+(`(WhateverCode)`). Probing raku 2022.12 fixed the exact non-currying set — it is
+WHAT / WHO / HOW / WHERE / DEFINITE / VAR, evaluated immediately on Whatever AND on an
+already-built WhateverCode — while `.WHICH` and `.WHY` DO curry (`*.WHICH` is a
+WhateverCode; the old mutsu list wrongly exempted both). The parser's pseudo-method
+exemption in `whatever.rs` now uses that list and also fires for
+`is_wrapped_whatevercode` targets, not just bare `*`. The non-curried `.WHERE` then
+exposed that Sub values had no `WHERE` at all — added (the sub's id; Rakudo's memory
+address is not pinnable anyway). Pin: `t/whatevercode-pseudo-method-curry.t` (passes
+under raku, modulo mutsu not emitting coercion warnings).
+
 ## 2026-07-23: `IO::Path::Parts.raku`/`.gist` render the positional parts (PLAN §8.15)
 
 `IO::Path::Parts.new('C:', '/some/dir', 'foo.txt').raku` (and `.gist`) rendered the bare

--- a/src/parser/expr/whatever.rs
+++ b/src/parser/expr/whatever.rs
@@ -192,13 +192,15 @@ pub(crate) fn contains_whatever(expr: &Expr) -> bool {
         Expr::Unary { expr, .. } | Expr::PostfixOp { expr, .. } => {
             contains_whatever(expr) || is_wrapped_whatevercode(expr)
         }
-        // Pseudo-methods (.WHAT, .WHO, .HOW, etc.) are always evaluated immediately
-        // on Whatever, they don't create WhateverCode. e.g. *.WHAT returns (Whatever).
+        // Non-currying pseudo-methods evaluate immediately on Whatever AND on
+        // an already-built WhateverCode: `*.WHAT` is `(Whatever)` and
+        // `(* + 1).WHAT` is `(WhateverCode)`. Rakudo's list is exactly these
+        // six — `.WHICH` and `.WHY` DO curry (`*.WHICH` is a WhateverCode).
         Expr::MethodCall { target, name, .. }
             if matches!(
                 name.resolve().as_str(),
-                "WHAT" | "WHO" | "HOW" | "WHY" | "WHICH" | "WHERE" | "DEFINITE" | "VAR"
-            ) && is_whatever(target) =>
+                "WHAT" | "WHO" | "HOW" | "WHERE" | "DEFINITE" | "VAR"
+            ) && (is_whatever(target) || is_wrapped_whatevercode(target)) =>
         {
             false
         }

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -359,6 +359,11 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Option<Result<Value, RuntimeError>> {
+        if method == "WHERE" && args.is_empty() {
+            // Rakudo: the object's memory address. Any per-object-stable Int
+            // is compatible (addresses are not pinnable); use the sub's id.
+            return Some(Ok(Value::int(data.id as i64)));
+        }
         if method == "nextwith" {
             // Tail-style dispatch: call target with caller frame and return from current frame.
             let saved_env = self.env.clone();

--- a/t/whatevercode-pseudo-method-curry.t
+++ b/t/whatevercode-pseudo-method-curry.t
@@ -1,0 +1,25 @@
+use v6;
+use Test;
+
+plan 10;
+
+# Rakudo's non-currying pseudo-methods on Whatever/WhateverCode are exactly
+# WHAT/WHO/HOW/WHERE/DEFINITE/VAR — `.WHICH` and `.WHY` DO curry.
+
+is (* + 1).WHAT.gist, '(WhateverCode)', '.WHAT on a WhateverCode does not curry';
+is *.WHAT.gist, '(Whatever)', '.WHAT on bare * does not curry';
+ok (* + 1).DEFINITE, '.DEFINITE does not curry';
+is (* + 1).WHERE.^name, 'Int', '.WHERE does not curry and is an Int';
+is (* + 1).VAR.^name, 'WhateverCode', '.VAR does not curry';
+is (* + 1).WHO.^name, 'Stash', '.WHO does not curry';
+
+is (*.WHICH).("a").gist.substr(0, 4), 'Str|', '*.WHICH curries into a WhateverCode';
+my $which = (* + 1).WHICH;
+is $which.^name, 'WhateverCode', '.WHICH on a WhateverCode curries';
+my $why = (* + 1).WHY;
+is $why.^name, 'WhateverCode', '.WHY curries';
+
+my $w = * + 1;
+is $w.WHAT.gist, '(WhateverCode)', '.WHAT on a WhateverCode in a variable';
+
+done-testing;


### PR DESCRIPTION
## Summary

`(* + 1).WHAT` curried into a new WhateverCode where Rakudo evaluates it immediately (`(WhateverCode)`).

Probing raku 2022.12 fixed the exact non-currying set: **WHAT / WHO / HOW / WHERE / DEFINITE / VAR**, evaluated immediately on Whatever **and** on an already-built WhateverCode. `.WHICH` and `.WHY` **do** curry (`*.WHICH` is a WhateverCode) — mutsu's old exemption list wrongly included both, and only fired for bare `*`. The parser's pseudo-method exemption in `whatever.rs` now uses the raku-verified list and also fires for `is_wrapped_whatevercode` targets.

The now-non-curried `.WHERE` exposed that Sub values had no `WHERE` at all — added, returning the sub's id (Rakudo's memory address is not pinnable anyway).

| expr | before | after (= raku) |
|---|---|---|
| `(* + 1).WHAT.gist` | `WhateverCode.new` (curried) | `(WhateverCode)` |
| `(* + 1).DEFINITE` | curried | `True` |
| `(* + 1).WHERE` | curried | an `Int` |
| `*.WHICH` | `Whatever\|U1` (immediate) | curries; `.("a")` gives `Str\|a` |
| `(* + 1).WHY` | immediate | curries |

## Testing

- New pin `t/whatevercode-pseudo-method-curry.t` (10 tests) — passes under mutsu **and** raku
- Full `t/` suite: all 22377 tests pass
- Whitelisted `roast/S02-types/{whatever,WHICH,capture,pair,baggy}.t` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)