### PR TITLE
fix: Nil in string context warns (.Str/.Stringy, prefix/infix ~, print, interpolation)

### DIFF
--- a/src/vm/vm_coerce_concat_ops.rs
+++ b/src/vm/vm_coerce_concat_ops.rs
@@ -184,6 +184,15 @@ impl Interpreter {
     /// `concat_values` / `to_str_context` handle those, including built-in
     /// `.gist`/`.Str`). Shared by infix `~` and the string-comparison ops.
     pub(super) fn coerce_stringy_operand(&mut self, v: Value) -> Result<Value, RuntimeError> {
+        // A Nil operand in a string context (infix `~`, `eq`/`lt`/… string
+        // comparisons) warns and resumes with the empty string, matching
+        // Rakudo — once per Nil operand (so `Nil ~ Nil` warns twice).
+        if v.is_nil() {
+            return self.raise_resumable_warning(
+                "Use of Nil in string context",
+                Value::str(String::new()),
+            );
+        }
         let cn = match v.view() {
             ValueView::Instance { class_name, .. } => class_name.resolve().to_string(),
             ValueView::Package(name) => name.resolve().to_string(),

--- a/src/vm/vm_data_io_ops.rs
+++ b/src/vm/vm_data_io_ops.rs
@@ -268,6 +268,16 @@ impl Interpreter {
     /// Recursively collect .Str output from a value, threading through Junctions.
     fn collect_str_threaded(&mut self, v: &Value, out: &mut String) -> Result<(), RuntimeError> {
         match v.view() {
+            ValueView::Nil => {
+                // `print Nil` stringifies via `.Str`, which warns ("Use of Nil
+                // in string context") and resumes with the empty string. (`say`
+                // uses `.gist` and renders "Nil" without a warning.)
+                let resumed = self.raise_resumable_warning(
+                    "Use of Nil in string context",
+                    Value::str(String::new()),
+                )?;
+                out.push_str(&resumed.to_string_value());
+            }
             ValueView::Junction { values, .. } => {
                 for elem in values.iter() {
                     self.collect_str_threaded(elem, out)?;

--- a/src/vm/vm_misc_coerce.rs
+++ b/src/vm/vm_misc_coerce.rs
@@ -146,6 +146,22 @@ impl Interpreter {
             self.stack.push(resumed);
             return Ok(());
         }
+        // `~Nil` warns ("Use of Nil in string context") and resumes with the
+        // empty string, matching Rakudo. This mirrors the `Nil.Str`/`.Stringy`
+        // method path; the prefix:<~> operator reaches this coercion opcode
+        // instead, so it needs its own arm here. An inline resume_safe CONTROL
+        // handler can mutate a captured-outer caller lexical while running, so
+        // reconcile its writeback (same pattern as the concat/interp paths).
+        if val.is_nil() {
+            let caller_code = self.current_code;
+            let resumed = self.raise_resumable_warning(
+                "Use of Nil in string context",
+                Value::str(String::new()),
+            )?;
+            self.reconcile_caller_after_internal_dispatch(caller_code);
+            self.stack.push(resumed);
+            return Ok(());
+        }
         // Stringifying an unhandled Failure throws
         if let Some(err) = self.failure_to_runtime_error_if_unhandled(&val) {
             return Err(err);

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -611,6 +611,17 @@ impl Interpreter {
             if let Some(err) = self.failure_to_runtime_error_if_unhandled(&v) {
                 return Err(err);
             }
+            // Interpolating Nil (`"{Nil}"`, `"$x"` with $x holding Nil) stringifies
+            // via `.Str`: warns ("Use of Nil in string context") and resumes with
+            // the empty string, matching Rakudo.
+            if v.is_nil() {
+                let resumed = self.raise_resumable_warning(
+                    "Use of Nil in string context",
+                    Value::str(String::new()),
+                )?;
+                result.push_str(&resumed.to_string_value());
+                continue;
+            }
             // Buf/Blob instances with "bytes" attribute: call .Str which throws X::Buf::AsStr
             // Blob type objects (no "bytes" attr, e.g. $*DISTRO.signature) stringify to ""
             if let ValueView::Instance { attributes, .. } = v.view()

--- a/t/nil-str-context-warning.t
+++ b/t/nil-str-context-warning.t
@@ -1,13 +1,16 @@
 use Test;
 
-# String coercion of Nil via `.Str` / `.Stringy` warns "Use of Nil in string
-# context" and resumes with the empty string (like raku). `.gist` / `.raku`
-# render "Nil" and do NOT warn.
+# Coercing Nil into a string context warns "Use of Nil in string context" and
+# resumes with the empty string (like raku). This covers every string-context
+# entry point: the `.Str`/`.Stringy` methods, the prefix:<~> and infix:<~>
+# operators, `eq`/`lt`/... string comparisons, `print`, and interpolation.
+# `.gist` / `.raku` (and `say`, which uses `.gist`) render "Nil" and do NOT warn.
 #
-# Regression: mutsu returned "" from `Nil.Str` with no warning at all.
+# Regression: mutsu returned "" from these paths with no warning at all.
 
-plan 8;
+plan 16;
 
+# --- .Str / .Stringy methods ---
 # `quietly { ... }` swallows the "Use of Nil in string context" warning; assert
 # the resumed value is the empty string.
 is (quietly { Nil.Str }),     '', 'Nil.Str is the empty string';
@@ -35,4 +38,38 @@ is Nil.raku, 'Nil', 'Nil.raku is "Nil" (unaffected)';
         CONTROL { when CX::Warn { $warned = True; .resume } }
     }
     nok $warned, 'Nil.gist emits no warning';
+}
+
+# --- prefix:<~> operator ---
+is (quietly ~Nil), '', '~Nil is the empty string';
+{
+    my $warned = False;
+    { my $x = ~Nil; CONTROL { when CX::Warn { $warned = True; .resume } } }
+    ok $warned, '~Nil emits a warning';
+}
+
+# --- infix:<~> concatenation ---
+is (quietly ('abc' ~ Nil)), 'abc', '"abc" ~ Nil drops the Nil operand';
+{
+    my $count = 0;
+    { my $x = Nil ~ Nil; CONTROL { when CX::Warn { $count++; .resume } } }
+    is $count, 2, 'Nil ~ Nil warns once per Nil operand';
+}
+
+# --- string comparison ---
+ok (quietly (Nil eq '')), 'Nil eq "" is true (Nil stringifies to empty)';
+
+# --- print ---
+{
+    my $warned = False;
+    { print Nil; CONTROL { when CX::Warn { $warned = True; .resume } } }
+    ok $warned, 'print Nil emits a warning';
+}
+
+# --- interpolation ---
+is (quietly "a{Nil}b"), 'ab', 'interpolating Nil yields the empty string';
+{
+    my $warned = False;
+    { my $s = "a{Nil}b"; CONTROL { when CX::Warn { $warned = True; .resume } } }
+    ok $warned, 'interpolating Nil emits a warning';
 }


### PR DESCRIPTION
## Summary

Coercing `Nil` into a **string context** now warns `Use of Nil in string context` and resumes with the empty string, matching Rakudo. Previously mutsu produced the empty string silently at most of these sites.

This PR covers every string-coercion entry point:

| Site | Path | Example |
|------|------|---------|
| `.Str` / `.Stringy` methods | `vm_call_method_ops` | `Nil.Str` |
| prefix `~` | `StrCoerce` opcode | `~Nil` |
| infix `~`, `eq`/`lt`/… | `coerce_stringy_operand` | `"a" ~ Nil`, `Nil eq ""` |
| `print` | `collect_str_threaded` | `print Nil` |
| string interpolation | `StringConcat` opcode | `"a{Nil}b"` |

(The `.Str`/`.Stringy` method arm landed in the first commit; the second commit extends the same warning to the operators, `print`, and interpolation.)

## Behavior

- Warns **once per Nil coerced**, so `Nil ~ Nil` warns twice (like raku).
- Resumes with the empty string, so `"a" ~ Nil` is `"a"` and `"a{Nil}b"` is `"ab"`.
- `quietly` suppresses the warning; an inline `resume_safe` `CONTROL { when CX::Warn {...} }` handler captures it (the `StrCoerce` arm reconciles captured-outer writeback like the concat/interp paths already did).
- `say` / `.gist` / `.raku` render `"Nil"` and do **not** warn (they use `.gist`).

## Not covered (separate)

- The `Useless use of "~" ... in sink context` warnings raku additionally emits are an unrelated sink-context-useless-use feature, not part of this change.

## Test

- `t/nil-str-context-warning.t` — extended to 16 subtests covering all five sites, `quietly` suppression, and `CONTROL` capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)