### PR TITLE
fix: `push my @arr, ...` writes into the inline-declared array

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -641,12 +641,23 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 - dists (each its own root cause; triage individually before claiming, confirm the
   raku `-I lib` baseline first): ~~Attribute::Predicate~~ (FIXED — see Done),
   File::Ignore,
-  IO::Path::AutoDecompress, Math::Angle, Math::PascalTriangle,
+  IO::Path::AutoDecompress, ~~Math::Angle~~ (FIXED — see Done), Math::PascalTriangle,
   ~~Statistics::LinearRegression~~ (FIXED — see Done), String::Rotate,
   Text::CodeProcessing, Trait::IO, WriteOnceHash, `are`, `sortuk`,
   Tree::Binary::PrettyTree (required role method not seen as implemented).
 - These `test_die` on the current binary but were not individually reproduced.
   Split off a dedicated ticket when you pick one up.
+- Triaged 2026-07-23 (deferred, each deep — own root cause):
+  - **String::Rotate**: an imported `sub rotate` must override the builtin `rotate`
+    listop (mutsu's builtin shadows it in all call forms) — same class as T-054
+    (P5push) builtin-vs-imported-sub dispatch. DEFER.
+  - **WriteOnceHash**: `self.BIND-KEY`/`self.ASSIGN-KEY`/`self.DELETE-KEY` don't
+    dispatch on a fresh `class ... is Hash` instance (Array-subclass `self.push`
+    is the same no-op) — deep container-subclass-instance self-mutation gap. DEFER
+    (memory `project_container_subclass_instance_self_mutation`).
+  - **`are`**: pure-nqp module (`nqp::if`/`eqaddr`/`until`/`getattr`/`istype`). DEFER.
+  - **Trait::IO**: `my $fh does auto-close` variable trait with a scope-exit phaser
+    that calls `.close`. DEFER.
 
 ## Claimed
 
@@ -919,3 +930,15 @@ _(move tickets here with `[claim: <branch>]` when you start)_
      attribute-trait parser now consumes a `<...>` word-quote as the trait
      argument (single word → Str, multiple → list) (`has_decl.rs`).
   - Pin: `t/attribute-trait-adds-method.t`.
+
+- **T-057 (Math::Angle)** (PR `fix-push-inline-array-decl`) — test_die → 77/77.
+  One general compiler bug: `push my @arr, VALUE` (an inline `my @arr` declaration
+  as the first argument of the `push`/`unshift`/`append`/`prepend` listop) fell
+  through to the generic function-call path, which pushed into a throwaway copy of
+  the freshly declared array and never wrote back — `@arr` stayed empty and a later
+  `@arr[0]` read returned `Any`. The listop→method rewrite only handled a plain
+  `ArrayVar`/`Var`/`Index` first argument; added an `Expr::DoStmt(VarDecl @…)`
+  branch that declares the array in the current scope (`compile_stmt`, initializer
+  preserved) then dispatches `@arr.push(…)` (`compiler/expr_call.rs`). Math::Angle's
+  `sub sexagesimal` does `push my @units, $!angle × rad2deg`. Pin:
+  `t/push-inline-array-decl.t`.

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -854,6 +854,36 @@ impl Compiler {
                 self.compile_expr(&call);
             }
         }
+        // Rewrite push(my @arr, val...)/unshift/append/prepend on an INLINE array
+        // declaration -> declare `@arr` in the current scope, then dispatch the
+        // method on it. Without this the listop falls through to the generic call,
+        // which pushes into a throwaway copy of the fresh array and never writes
+        // back, leaving `@arr` empty (`push my @u, 10; say @u` gave `[]`).
+        else if args.len() >= 2
+            && matches!(
+                name.resolve().as_str(),
+                "push" | "unshift" | "append" | "prepend"
+            )
+            && matches!(&args[0], Expr::DoStmt(s)
+                if matches!(s.as_ref(), Stmt::VarDecl { name: vn, .. } if vn.starts_with('@')))
+        {
+            if let Expr::DoStmt(stmt) = &args[0]
+                && let Stmt::VarDecl { name: vn, .. } = stmt.as_ref()
+            {
+                // Declare `@arr` in the current scope (runs any initializer too),
+                // then behave exactly like `push(@arr, val...)`.
+                self.compile_stmt(stmt);
+                let target = Expr::ArrayVar(vn.trim_start_matches('@').to_string());
+                let method_call = Expr::MethodCall {
+                    target: Box::new(target),
+                    name: *name,
+                    args: args[1..].to_vec(),
+                    modifier: None,
+                    quoted: false,
+                };
+                self.compile_expr(&method_call);
+            }
+        }
         // Rewrite push(@arr, val...)/unshift(@arr, val...)/append/prepend/splice -> @arr.method(val...)
         // splice needs only 1 arg (the array); others need at least 2
         else if !args.is_empty()

--- a/t/push-inline-array-decl.t
+++ b/t/push-inline-array-decl.t
@@ -1,0 +1,70 @@
+use v6;
+use Test;
+
+# `push my @arr, VALUE` declares @arr in the current scope AS the first
+# argument of the push listop. The array must actually receive the pushed
+# elements (it used to fall through to the generic call and push into a
+# throwaway copy, leaving @arr empty). Regression pin for Math::Angle.
+
+plan 12;
+
+{
+    push my @u, 10;
+    is-deeply @u, [10], 'push my @u, single value';
+}
+
+{
+    push my @u, 10, 20, 30;
+    is-deeply @u, [10, 20, 30], 'push my @u, multiple values';
+}
+
+{
+    push (my @u), 5;
+    is-deeply @u, [5], 'push (my @u), value';
+}
+
+{
+    unshift my @u, 1, 2;
+    is-deeply @u, [1, 2], 'unshift my @u';
+}
+
+{
+    push my @u = (1, 2), 3;
+    is-deeply @u, [(1, 2), 3], 'push my @u = (...), value keeps initializer';
+}
+
+{
+    # The elements are readable/usable right after the inline-decl push.
+    push my @u, 5 * 2;
+    is @u[0].abs, 10, 'pushed element is a real value, not Any';
+    is @u.elems, 1, 'elems reflects the push';
+}
+
+{
+    # Plain (separately declared) form still works.
+    my @u;
+    push @u, 9;
+    is-deeply @u, [9], 'separately declared push still works';
+}
+
+{
+    # Inline decl inside a method body (the Math::Angle shape): the pushed
+    # value comes from an attribute read.
+    class C {
+        has $!angle is built;
+        method units() {
+            push my @u, $!angle * 2;
+            @u[0].abs
+        }
+    }
+    is C.new(angle => 10).units, 20, 'push my @u of attribute inside method';
+    is C.new(angle => -7).units, 14, 'push my @u of negative attribute';
+}
+
+{
+    # Two independent inline-decl pushes in the same scope do not interfere.
+    push my @a, 1;
+    push my @b, 2;
+    is-deeply @a, [1], 'first inline-decl array';
+    is-deeply @b, [2], 'second inline-decl array';
+}


### PR DESCRIPTION
## Summary

`push my @u, VALUE` — with an inline `my @u` declaration as the **first argument**
of the `push` (or `unshift`/`append`/`prepend`) listop — used to fall through to
the generic function-call path, which pushed into a throwaway copy of the freshly
declared array and never wrote back. The declared `@u` stayed empty:

```raku
push my @u, 10; say @u;          # was [], now [10]
push my @u, 5*2; say @u[0].abs;  # was "No such method 'abs' for invocant of type 'Any'", now 10
```

The listop→method rewrite only fired when the first argument was a plain
`ArrayVar`/`Var`/`Index`; an inline `Expr::DoStmt(VarDecl)` was uncovered. Added a
branch that declares the array in the current scope (via `compile_stmt`, so any
initializer like `push my @u = (1,2), 3` is preserved) and then dispatches
`@arr.push(...)` on it — mirroring the existing inline-declaration handling in
list assignment (`compiler/expr_call.rs`).

Note: `splice my @u, ...` and `append`/`prepend` as bare listops are separate,
pre-existing parser/registration gaps (the former parses `splice` as a bareword;
the latter are not registered as sub-form listops) and are out of scope here.

## Impact

Fixes the **Math::Angle** distribution (T-057 batch): `sub sexagesimal` does
`push my @units, $!angle × rad2deg`. All three test files now pass (77/77).

## Testing

- New pin `t/push-inline-array-decl.t` (12 tests), all pass under mutsu **and** raku.
- Math::Angle `t/*.rakutest`: 77/77 PASS.
- Full `make test`: 22405 tests, Result: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)