### PR TITLE
feat: concurrency runs in the browser — a cooperative scheduler for the WASM build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,12 @@ jobs:
         with:
           node-version: '22'
 
+      # Concurrency runs on a cooperative scheduler in the browser (no threads
+      # there), so it needs its own checks. No browser required — this drives
+      # pkg/ straight from Node.
+      - name: Run WASM concurrency tests
+        run: node wasm-demo/concurrency.test.mjs
+
       - name: Install Playwright
         run: |
           npm install playwright

--- a/PLAN.md
+++ b/PLAN.md
@@ -912,6 +912,22 @@ unification / the malloc clusters from `Value` clone/drop and attribute material
 
       Worth doing before the worker-pool ADR above: a silent wrong answer outranks a
       perf/footprint change, and the fix retires name-keyed mechanisms rather than building on them.
+- [ ] **★A joined `start` block writes its stale captured env back over a variable declared after
+      it** (found 2026-07-23 while testing WASM concurrency; reproduces on `main`, so it is not a
+      WASM artefact):
+
+      ```raku
+      my $p = Promise.allof(start { 1 }, start { 2 }); await $p; say $p.WHAT;   # Nil (raku: (Promise))
+      my @p = (start { 1 }, start { 2 }); my $q = Promise.anyof(@p); await $q;  # $q survives
+      ```
+
+      Two or more `start` blocks written **inline as arguments** each capture the enclosing env at a
+      point where `$p` does not exist yet (so it reads as `Nil`); joining them writes that snapshot
+      back wholesale and clobbers the now-assigned `$p`. One inline `start` does not trip it, and
+      binding the promises to a variable first avoids it — i.e. it is the blanket env writeback, the
+      same mechanism as the `named-sub free-var shadow` / dual-store family, not a `Promise` bug.
+      The fix belongs with the cell-based capture work above (write back only what the thread
+      actually mutated), not with a special case at the `allof`/`anyof` call sites.
 - [ ] Eliminate raw-pointer aliased writes: the old `arc_contents_mut` is dead code now, and the
       production path moved to `gc::gc_contents_mut` / `Gc::{get,make}_mut` (the unsoundness was
       moved, not resolved — ANALYSIS rev8 §2.1). With Track B T4–T6 done (news/2026-07.md), start
@@ -1429,31 +1445,6 @@ value-carried callable path.
 - Repro kept at `wasm-demo/content/highlights.txt` (`why/multi` uses the direct-call form as a
   workaround); `scripts/check-site-snippets.mjs` cross-checks against `raku` and would catch a
   regression the moment the snippet is switched back to `&fizz`.
-
-### 8.18 The WebAssembly build traps on `start` / `Channel` instead of degrading (found 2026-07-23 building the tutorial site)
-
-`start { ... }` reaches `spawn_callable_promise` → `spawn_user_thread` → `std::thread::spawn`
-(`src/runtime/builtins_system.rs:13`), which on `wasm32-unknown-unknown` has no
-implementation and traps. In the browser that surfaces as `RuntimeError: unreachable`,
-which also poisons the whole wasm instance — every later evaluation in that session is
-garbage until the page rebuilds the interpreter.
-
-- Affected: `start`, `Promise` combinators that spawn, `Channel` producers, `Proc::Async`.
-  `react`/`whenever` over a `Supply.from-list` already works (no spawn), as does
-  `gather`/`take`.
-- **Likely correct fix:** on wasm, run a `start` block *synchronously* and return an
-  already-kept (or broken) `Promise`, and give `Channel` the same treatment — a
-  single-threaded scheduler is the honest semantics for a platform with one thread, and it
-  is what a reader of the concurrency chapter would expect to see work. The mechanism is one
-  `#[cfg(target_arch = "wasm32")]` arm in `spawn_callable_promise` plus the equivalent for
-  the channel/supply pumps, but the *semantics* need thought: a `start` that blocks until it
-  finishes changes the observable ordering of any program that relies on interleaving, and
-  `await` on a never-kept promise would deadlock rather than trap.
-- **Not attempted here.** The tutorial marks those two lessons `no-browser` in
-  `wasm-demo/content/lessons.txt`, so the site explains the limitation and shows the
-  recorded native output rather than a trap. Removing those flags is the acceptance test
-  for this item; `wasm-demo/e2e.test.mjs` sweeps every non-flagged lesson in a real browser.
-
 
 ## Metrics
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4,6 +4,60 @@
 
 July carried forward the momentum from late June, advancing the dispatch cluster (wrap/dispatching) and the remaining S17 concurrency-infrastructure work in one push. For detailed remaining items and in-progress analysis, see [TODO_roast/BLOCKERS.md](../TODO_roast/BLOCKERS.md).
 
+## 2026-07-23: concurrency works in the browser — a cooperative scheduler for the WASM build (closes PLAN §8.18, issue #5310)
+
+`start { ... }` in the playground used to end the session: `spawn_callable_promise` reaches
+`std::thread::spawn`, which on `wasm32-unknown-unknown` traps as `RuntimeError: unreachable` and
+poisons the whole wasm instance. The same applied to `await`, `Thread.start`, `Promise.in`,
+`Supply.interval` and `sleep`. Real threads are not an option for the deployed site either:
+shared-memory wasm needs `SharedArrayBuffer`, which needs COOP/COEP headers GitHub Pages cannot
+serve.
+
+So the wasm build now provides **concurrency without parallelism**, in
+[src/runtime/wasm_sched.rs](../src/runtime/wasm_sched.rs): a would-be thread becomes a task on a
+run queue, and every point that would block on another thread pumps that queue instead. `pump()`
+runs a ready task, or — when none is ready — jumps a virtual clock to the earliest timer deadline
+and fires it. Tasks are *deferred*, not run eagerly at spawn, which is what makes
+`my $p = start { $c.receive }; $c.send(1); await $p` work.
+
+- **One façade, not `cfg` sprinkled over 20 spawn sites**:
+  [src/runtime/thread_compat.rs](../src/runtime/thread_compat.rs) supplies `JoinHandle`, `sleep`,
+  `mono_now` and a drop-in `Instant`, so the concurrency primitives stay written against real
+  threads. `builtins_system::spawn_user_thread` / `spawn_gc_helper_thread` now return that handle.
+- **Blocking waits go through one chokepoint.** `gc::stw_aware_wait` gained a sibling
+  `gc::wait_until(&Mutex, &Condvar, ready)` that takes the lock itself, so the wasm arm can drop it
+  between rounds and pump. Its four call sites are promise `await`, `Channel.receive` and the two
+  lock/semaphore waits. When the pump runs dry nothing can ever satisfy the waiter, so it reports a
+  deadlock instead of freezing the tab — the one case where the browser genuinely cannot match
+  native (a task that blocks midway on a value sent only after it began).
+- **`Instant::now()` panics on wasm32** and was quietly load-bearing in the `react` drive loop's
+  30s bound, the supply throttle/stable windows and the GC's stop-the-world timeout; those now use
+  the compat `Instant`. The timer heap keys on `f64` seconds and, with no driver thread to spawn,
+  is driven by the pump.
+- **`ReactWaker::wait_activity`** parked on a condvar (also unsupported on wasm32): it pumps now,
+  letting the requested timeout elapse on the virtual clock when nothing is left to produce.
+- **Stop-the-world is trivially achieved on wasm** — one thread means the world is already
+  stopped, and the rendezvous would otherwise wait for a quiescence count that queued,
+  never-started tasks keep artificially high.
+- **Time is real now**: `Date.now()` backs `now`/`time`/`DateTime.now`, which previously read 0
+  (`DateTime.now.year` was 1970). `sleep` advances the virtual clock rather than blocking, so
+  `my $t = now; sleep 1; say now - $t` still says 1.
+- **Output from `Thread.start` no longer vanishes**: its immediate-stdout path bypassed the buffer
+  the page actually reads.
+
+The two tutorial lessons marked `no-browser` (`concurrency/promises`, `concurrency/channels`) run
+in the browser now and lost the flag — PLAN §8.18's stated acceptance test. New:
+`wasm-demo/concurrency.test.mjs`, 28 cases driven straight from Node against `pkg/`, wired into
+the `wasm-e2e` CI job; every expectation was cross-checked against native mutsu *and* `raku`
+except the two that are wasm-specific by construction (deterministic drain of an unawaited
+`start` at program end; deadlock reporting).
+
+Found while testing this, recorded in PLAN §6 rather than fixed here: two or more `start` blocks
+written **inline as arguments** (`Promise.allof(start {1}, start {2})`) write their stale captured
+env back over a variable declared after them, so `my $p = Promise.allof(start {1}, start {2});
+await $p; say $p.WHAT` says `Nil`. It reproduces on `main` and belongs to the env-writeback family,
+not to `Promise`.
+
 ## 2026-07-23: `wasm-demo/` became a Raku introduction site — landing page, bilingual tutorial, playground
 
 The WebAssembly page was a playground and nothing else. It is now a site whose subject is

--- a/src/gc/collect.rs
+++ b/src/gc/collect.rs
@@ -38,10 +38,10 @@
 //! mutates; `scan_black` restores it for every survivor, so the heap's refcounts
 //! are pristine afterward (only genuine garbage is disturbed).
 
+use crate::runtime::thread_compat::Instant;
 use std::collections::{HashMap, HashSet};
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Instant;
 
 use super::gc_ptr::{
     CollectGuard, Color, ErasedGc, drain_candidates, erased_id, gc_drop_edges, gc_finalize,

--- a/src/gc/mod.rs
+++ b/src/gc/mod.rs
@@ -40,8 +40,8 @@ pub(crate) use safepoint::{
     startup_collect_if_requested,
 };
 pub(crate) use stw::{
-    block_quiescent, mark_thread_registered, park_at_safepoint as gc_park_point,
-    preregister_worker_quiescent, stw_aware_wait, worker_started,
+    DEADLOCK_MESSAGE, block_quiescent, mark_thread_registered, park_at_safepoint as gc_park_point,
+    preregister_worker_quiescent, wait_until, worker_started,
 };
 
 /// Test-only serialization for every unit test that touches the process-global

--- a/src/gc/stw.rs
+++ b/src/gc/stw.rs
@@ -40,9 +40,10 @@
 //! quiescent nor unregistered, so the collector keeps waiting until those
 //! drops are done.
 
+use crate::runtime::thread_compat::Instant;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Condvar, Mutex, MutexGuard, OnceLock};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 /// A collect has requested the world to stop. Mutators park at their next
 /// safepoint; quiescent waits refuse to complete while this is set.
@@ -276,6 +277,49 @@ pub(crate) fn block_quiescent<R>(f: impl FnOnce() -> R) -> R {
 /// the global rendezvous — a collector achieving a fresh stop in that window
 /// scans without needing this mutex to make progress on *this* thread (it may
 /// briefly block tracing this one node, bounded by the 10ms re-check).
+/// [`stw_aware_wait`] against a mutex this takes itself, so the wasm build can
+/// release it between rounds.
+///
+/// Natively this is `stw_aware_wait` with the lock taken for you, and the
+/// result is always `Some`. On wasm nobody else can ever set the condition
+/// while this thread waits — there is no other thread — so instead of parking
+/// on the condvar it runs the cooperative scheduler ([`crate::runtime::wasm_sched::pump`])
+/// between checks, dropping the guard each round so the task that resolves the
+/// wait can take the same lock. `None` means the pump ran dry: the waiter is
+/// blocked on something that can never happen, and the caller should raise a
+/// deadlock error rather than spin forever.
+pub(crate) fn wait_until<'a, T>(
+    mutex: &'a Mutex<T>,
+    cvar: &Condvar,
+    ready: impl FnMut(&T) -> bool,
+) -> Option<MutexGuard<'a, T>> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let guard = mutex.lock().unwrap();
+        Some(stw_aware_wait(cvar, guard, ready))
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = cvar;
+        let mut ready = ready;
+        loop {
+            let guard = mutex.lock().unwrap();
+            if ready(&guard) {
+                return Some(guard);
+            }
+            drop(guard);
+            if !crate::runtime::wasm_sched::pump() {
+                return None;
+            }
+        }
+    }
+}
+
+/// What a `None` from [`wait_until`] means, phrased for the user who hit it.
+pub(crate) const DEADLOCK_MESSAGE: &str = "deadlock: nothing left to run while waiting. The WASM build runs on a single \
+     thread, so a `start` block that blocks on a value sent only after it began \
+     can never be woken";
+
 pub(crate) fn stw_aware_wait<'a, T>(
     cvar: &Condvar,
     mut guard: MutexGuard<'a, T>,
@@ -332,42 +376,56 @@ impl Drop for StwGuard {
 /// Only one stop can be in flight; a concurrent second caller fails fast (its
 /// suspects are re-queued and picked up later).
 pub(crate) fn try_stop_the_world(timeout: Duration) -> Option<StwGuard> {
-    // SeqCst: the collector side of the Dekker handshake. This store must be
-    // totally ordered against every mutator's `quiescent_exit_checked`
-    // (QUIESCENT store then STOP load) so a worker leaving quiescence cannot slip
-    // past the stop into `Gc` mutation while this collector counts it quiescent.
-    if STOP_REQUESTED.swap(true, Ordering::SeqCst) {
-        return None;
+    // wasm32 has exactly one thread, so the world is already stopped: whoever
+    // called the collector IS the only mutator, and every "worker" is a task on
+    // `runtime::wasm_sched`'s queue that by definition is not running. Take the
+    // stop unconditionally — the rendezvous below would otherwise wait on a
+    // condvar (which wasm32 std cannot do) for a quiescence count that queued,
+    // never-started tasks keep artificially high.
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = timeout;
+        return Some(StwGuard { _private: () });
     }
-    let deadline = Instant::now() + timeout;
-    let (lock, cvar) = rendezvous();
-    let mut guard = lock.lock().unwrap();
-    let self_counted = usize::from(thread_is_registered());
-    loop {
-        // Re-read the target every iteration: a worker finishing mid-wait
-        // unregisters itself (after its `Value` drops are done), lowering the
-        // number of threads that must park. The collector's own thread, if
-        // registered, is running this very function — exclude it.
-        let needed = super::gc_ptr::mutator_worker_count().saturating_sub(self_counted);
-        // SeqCst load (see the `swap` above): pairs with the mutators' SeqCst
-        // QUIESCENT stores to complete the handshake's total order.
-        if QUIESCENT.load(Ordering::SeqCst) >= needed {
-            drop(guard);
-            return Some(StwGuard { _private: () });
-        }
-        let now = Instant::now();
-        if now >= deadline {
-            drop(guard);
-            STOP_REQUESTED.store(false, Ordering::Release);
-            cvar.notify_all();
-            // Back off: an unwrapped blocking site is holding quiescence up;
-            // retrying at every candidate trigger would stall the mutators
-            // that DO park. Suspects stay queued and dead sweeps continue.
-            STW_RETRY_AT_MS.store(now_ms() + 100, Ordering::Release);
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        // SeqCst: the collector side of the Dekker handshake. This store must be
+        // totally ordered against every mutator's `quiescent_exit_checked`
+        // (QUIESCENT store then STOP load) so a worker leaving quiescence cannot slip
+        // past the stop into `Gc` mutation while this collector counts it quiescent.
+        if STOP_REQUESTED.swap(true, Ordering::SeqCst) {
             return None;
         }
-        let (g, _) = cvar.wait_timeout(guard, deadline - now).unwrap();
-        guard = g;
+        let deadline = Instant::now() + timeout;
+        let (lock, cvar) = rendezvous();
+        let mut guard = lock.lock().unwrap();
+        let self_counted = usize::from(thread_is_registered());
+        loop {
+            // Re-read the target every iteration: a worker finishing mid-wait
+            // unregisters itself (after its `Value` drops are done), lowering the
+            // number of threads that must park. The collector's own thread, if
+            // registered, is running this very function — exclude it.
+            let needed = super::gc_ptr::mutator_worker_count().saturating_sub(self_counted);
+            // SeqCst load (see the `swap` above): pairs with the mutators' SeqCst
+            // QUIESCENT stores to complete the handshake's total order.
+            if QUIESCENT.load(Ordering::SeqCst) >= needed {
+                drop(guard);
+                return Some(StwGuard { _private: () });
+            }
+            let now = Instant::now();
+            if now >= deadline {
+                drop(guard);
+                STOP_REQUESTED.store(false, Ordering::Release);
+                cvar.notify_all();
+                // Back off: an unwrapped blocking site is holding quiescence up;
+                // retrying at every candidate trigger would stall the mutators
+                // that DO park. Suspects stay queued and dead sweeps continue.
+                STW_RETRY_AT_MS.store(now_ms() + 100, Ordering::Release);
+                return None;
+            }
+            let (g, _) = cvar.wait_timeout(guard, deadline - now).unwrap();
+            guard = g;
+        }
     }
 }
 

--- a/src/runtime/builtins_system.rs
+++ b/src/runtime/builtins_system.rs
@@ -10,7 +10,7 @@ pub(crate) const USER_THREAD_STACK_SIZE: usize = 256 * 1024 * 1024;
 
 /// Spawn a worker thread with a large stack for running user code, so deep VM
 /// recursion does not overflow the default thread stack.
-pub(crate) fn spawn_user_thread<F, T>(f: F) -> std::thread::JoinHandle<T>
+pub(crate) fn spawn_user_thread<F, T>(f: F) -> crate::runtime::thread_compat::JoinHandle<T>
 where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
@@ -32,7 +32,7 @@ where
 /// collect). Long blocking waits inside the closure (sleeps, blocking reads)
 /// must be wrapped in `gc::block_quiescent` so the thread does not starve the
 /// stop-the-world rendezvous.
-pub(crate) fn spawn_gc_helper_thread<F, T>(f: F) -> std::thread::JoinHandle<T>
+pub(crate) fn spawn_gc_helper_thread<F, T>(f: F) -> crate::runtime::thread_compat::JoinHandle<T>
 where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
@@ -40,7 +40,10 @@ where
     spawn_registered_thread(None, f)
 }
 
-fn spawn_registered_thread<F, T>(stack_size: Option<usize>, f: F) -> std::thread::JoinHandle<T>
+fn spawn_registered_thread<F, T>(
+    stack_size: Option<usize>,
+    f: F,
+) -> crate::runtime::thread_compat::JoinHandle<T>
 where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
@@ -56,36 +59,30 @@ where
     // without this a spawn burst starves every stop-the-world attempt — see
     // `gc::stw::preregister_worker_quiescent`.
     crate::gc::preregister_worker_quiescent();
-    let mut builder = std::thread::Builder::new();
-    if let Some(size) = stack_size {
-        builder = builder.stack_size(size);
-    }
-    builder
-        .spawn(move || {
-            struct WorkerGuard;
-            impl Drop for WorkerGuard {
-                fn drop(&mut self) {
-                    // Drop this thread's `Gc`-bearing thread-local state (pending
-                    // DESTROY queue, failure registry) BEFORE unregistering. Rust
-                    // runs TLS destructors after the closure returns — i.e. after
-                    // `exit_mutator_worker` below — so without this an unregistered
-                    // thread's TLS teardown would mutate the `Gc` graph while a
-                    // collector, believing this thread gone, runs trial deletion.
-                    // See `value::drop_thread_local_gc_state`.
-                    crate::value::drop_thread_local_gc_state();
-                    crate::gc::mark_thread_registered(false);
-                    crate::gc::exit_mutator_worker();
-                }
+    crate::runtime::thread_compat::spawn_thread(stack_size, move || {
+        struct WorkerGuard;
+        impl Drop for WorkerGuard {
+            fn drop(&mut self) {
+                // Drop this thread's `Gc`-bearing thread-local state (pending
+                // DESTROY queue, failure registry) BEFORE unregistering. Rust
+                // runs TLS destructors after the closure returns — i.e. after
+                // `exit_mutator_worker` below — so without this an unregistered
+                // thread's TLS teardown would mutate the `Gc` graph while a
+                // collector, believing this thread gone, runs trial deletion.
+                // See `value::drop_thread_local_gc_state`.
+                crate::value::drop_thread_local_gc_state();
+                crate::gc::mark_thread_registered(false);
+                crate::gc::exit_mutator_worker();
             }
-            let _guard = WorkerGuard;
-            // Registered-mutator flag + leave the parent-granted quiescent
-            // state (parking first if a scan is in progress): this thread's
-            // quiescence now counts toward (and is required by) the STW
-            // rendezvous (gc::stw).
-            crate::gc::worker_started();
-            f()
-        })
-        .expect("failed to spawn worker thread")
+        }
+        let _guard = WorkerGuard;
+        // Registered-mutator flag + leave the parent-granted quiescent
+        // state (parking first if a scan is in progress): this thread's
+        // quiescence now counts toward (and is required by) the STW
+        // rendezvous (gc::stw).
+        crate::gc::worker_started();
+        f()
+    })
 }
 
 /// State for a live child process (when `:in` is used with `run`).

--- a/src/runtime/builtins_system_async.rs
+++ b/src/runtime/builtins_system_async.rs
@@ -50,7 +50,9 @@ impl Interpreter {
                 // Poll for global exit flag so that `start { exit }` can
                 // wake us up.
                 loop {
-                    crate::gc::block_quiescent(|| thread::sleep(Duration::from_millis(100)));
+                    crate::gc::block_quiescent(|| {
+                        crate::runtime::thread_compat::sleep(Duration::from_millis(100))
+                    });
                     if let Some(code) = super::builtins_control_flow::global_exit_requested() {
                         self.halted = true;
                         self.exit_code = code;
@@ -70,7 +72,7 @@ impl Interpreter {
                         return Ok(Value::NIL);
                     }
                 } else {
-                    crate::gc::block_quiescent(|| thread::sleep(duration));
+                    crate::gc::block_quiescent(|| crate::runtime::thread_compat::sleep(duration));
                 }
                 self.sync_shared_vars_to_env();
                 Ok(Value::NIL)
@@ -80,11 +82,12 @@ impl Interpreter {
 
     /// Sleep for the given duration, but check for global exit every 100ms.
     fn interruptible_sleep(total: Duration) {
-        let start = std::time::Instant::now();
-        while start.elapsed() < total {
-            let remaining = total.saturating_sub(start.elapsed());
-            let chunk = remaining.min(Duration::from_millis(100));
-            crate::gc::block_quiescent(|| thread::sleep(chunk));
+        let start = crate::runtime::thread_compat::mono_now();
+        let total_secs = total.as_secs_f64();
+        while crate::runtime::thread_compat::mono_now() - start < total_secs {
+            let remaining = total_secs - (crate::runtime::thread_compat::mono_now() - start);
+            let chunk = Duration::from_secs_f64(remaining).min(Duration::from_millis(100));
+            crate::gc::block_quiescent(|| crate::runtime::thread_compat::sleep(chunk));
             if super::builtins_control_flow::global_exit_requested().is_some() {
                 return;
             }
@@ -93,13 +96,11 @@ impl Interpreter {
 
     pub(super) fn builtin_sleep_timer(&self, args: &[Value]) -> Result<Value, RuntimeError> {
         let duration = Self::duration_from_seconds(Self::seconds_from_value(args.first().cloned()));
-        let start = Instant::now();
-        crate::gc::block_quiescent(|| thread::sleep(duration));
-        let elapsed = start.elapsed();
-        let remaining = duration.checked_sub(elapsed).unwrap_or_default();
-        Ok(crate::builtins::arith::make_duration_value(
-            remaining.as_secs_f64(),
-        ))
+        let start = crate::runtime::thread_compat::mono_now();
+        crate::gc::block_quiescent(|| crate::runtime::thread_compat::sleep(duration));
+        let elapsed = crate::runtime::thread_compat::mono_now() - start;
+        let remaining = (duration.as_secs_f64() - elapsed).max(0.0);
+        Ok(crate::builtins::arith::make_duration_value(remaining))
     }
 
     pub(super) fn builtin_sleep_till(&self, args: &[Value]) -> Result<Value, RuntimeError> {
@@ -144,7 +145,9 @@ impl Interpreter {
                 return Ok(Value::FALSE);
             }
             let diff_secs = target - now;
-            crate::gc::block_quiescent(|| thread::sleep(Duration::from_secs_f64(diff_secs)));
+            crate::gc::block_quiescent(|| {
+                crate::runtime::thread_compat::sleep(Duration::from_secs_f64(diff_secs))
+            });
             return Ok(Value::TRUE);
         }
         Ok(Value::FALSE)

--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -65,7 +65,10 @@ impl Interpreter {
                 Some(ValueView::Bool(true))
             );
             let deadline = if wait_until_done && live {
-                Some(std::time::Instant::now() + std::time::Duration::from_secs(5))
+                Some(
+                    crate::runtime::thread_compat::Instant::now()
+                        + std::time::Duration::from_secs(5),
+                )
             } else {
                 None
             };
@@ -93,7 +96,7 @@ impl Interpreter {
                 let Some(limit) = deadline else {
                     break Ok(());
                 };
-                let now = std::time::Instant::now();
+                let now = crate::runtime::thread_compat::Instant::now();
                 if now >= limit {
                     break Ok(());
                 }

--- a/src/runtime/methods_collection_ops/mod.rs
+++ b/src/runtime/methods_collection_ops/mod.rs
@@ -89,8 +89,9 @@ impl GrepAdverb {
     }
 }
 
-static THREAD_HANDLES: std::sync::LazyLock<Mutex<HashMap<u64, std::thread::JoinHandle<()>>>> =
-    std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
+static THREAD_HANDLES: std::sync::LazyLock<
+    Mutex<HashMap<u64, crate::runtime::thread_compat::JoinHandle<()>>>,
+> = std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
 
 static NEXT_THREAD_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
 

--- a/src/runtime/methods_collection_ops/socket_thread.rs
+++ b/src/runtime/methods_collection_ops/socket_thread.rs
@@ -414,9 +414,18 @@ impl Interpreter {
             // Flush any remaining buffered output from the thread
             let output = std::mem::take(&mut thread_interp.output_sink_mut().output);
             if !output.is_empty() {
-                use std::io::Write;
-                let _ = std::io::stdout().write_all(output.as_bytes());
-                let _ = std::io::stdout().flush();
+                // wasm has no readable process stdout, so leftovers go to the
+                // shared buffer `Thread.finish` drains (see `OutputSink::emit`).
+                #[cfg(target_arch = "wasm32")]
+                if let Some(shared) = thread_interp.output_sink().shared_thread_output.clone() {
+                    shared.lock().unwrap().push_str(&output);
+                }
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    use std::io::Write;
+                    let _ = std::io::stdout().write_all(output.as_bytes());
+                    let _ = std::io::stdout().flush();
+                }
             }
             let stderr = std::mem::take(&mut thread_interp.output_sink_mut().stderr_output);
             if !stderr.is_empty() {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -12,14 +12,13 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
-use std::thread;
 
 static ROLE_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 pub(crate) fn next_role_id() -> u64 {
     ROLE_ID_COUNTER.fetch_add(1, Ordering::Relaxed)
 }
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::ast::{Expr, FunctionDef, ParamDef, PhaserKind, Stmt};
 use crate::env::Env;
@@ -353,12 +352,16 @@ mod system_eval_vars;
 mod system_introspect;
 mod tap_state;
 mod test_functions;
+pub(crate) mod thread_compat;
 pub(crate) mod types;
 mod undeclared_routines;
 mod unicode;
 pub(crate) mod utf8_c8;
 pub(crate) mod utils;
 pub(crate) mod value_iterator;
+/// Cooperative scheduler standing in for OS threads in the browser.
+#[cfg(target_arch = "wasm32")]
+pub(crate) mod wasm_sched;
 pub(crate) use self::output_sink::OutputSink;
 #[allow(unused_imports)]
 pub(crate) use self::output_sink::{OutputSinkReadGuard, OutputSinkWriteGuard};
@@ -1144,7 +1147,7 @@ pub struct Interpreter {
     /// `find_local_slot`. `None` for a non-local target (by-name fallback).
     let_saves: Vec<(String, Value, bool, Option<u32>)>,
     pub(super) supply_emit_buffer: Vec<Vec<Value>>,
-    pub(super) supply_emit_timed_buffer: Vec<Vec<(Value, std::time::Instant)>>,
+    pub(super) supply_emit_timed_buffer: Vec<Vec<(Value, crate::runtime::thread_compat::Instant)>>,
     /// Active streaming consumers for on-demand `supply { ... }` bodies driven by
     /// `react`. When a stream consumer is registered for an emitter's
     /// `supplier_id`, `emit` delivers the value to the consumer callback

--- a/src/runtime/native_methods/interval_timer.rs
+++ b/src/runtime/native_methods/interval_timer.rs
@@ -12,19 +12,24 @@
 //! the heap lock RELEASED, so an action may itself register new timers.
 //! Actions must stay cheap (a channel send, a promise keep, a thread spawn) —
 //! never run user VM code on the driver thread.
+//!
+//! Deadlines are seconds on [`thread_compat::mono_now`] rather than `Instant`
+//! values: `Instant::now()` panics on wasm32, where the same heap is driven by
+//! the cooperative scheduler's pump instead of by a thread.
 use crate::runtime::native_methods::SupplyEvent;
+use crate::runtime::thread_compat;
 use crate::value::Value;
-use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::sync::{Condvar, Mutex, OnceLock};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 /// Returns `Some(period)` to be rescheduled `period` after this deadline
 /// (fixed-rate, with catch-up skipping), or `None` to be dropped.
 type TimerAction = Box<dyn FnMut() -> Option<Duration> + Send>;
 
 struct TimerEntry {
-    next: Instant,
+    /// Deadline in `thread_compat::mono_now()` seconds.
+    next: f64,
     action: TimerAction,
 }
 
@@ -43,7 +48,8 @@ impl PartialOrd for TimerEntry {
 }
 impl Ord for TimerEntry {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        Reverse(self.next).cmp(&Reverse(other.next))
+        // Reversed so the max-heap's `peek` is the EARLIEST deadline.
+        other.next.total_cmp(&self.next)
     }
 }
 
@@ -54,14 +60,21 @@ fn timer_state() -> &'static TimerState {
     STATE.get_or_init(|| {
         let state: &'static TimerState =
             Box::leak(Box::new((Mutex::new(BinaryHeap::new()), Condvar::new())));
+        // On wasm there is no driver thread to spawn: the heap is driven by
+        // `wasm_fire_next_timer` from the cooperative scheduler's pump, which
+        // jumps the virtual clock to the earliest deadline rather than
+        // sleeping until it.
+        #[cfg(target_arch = "wasm32")]
+        return state;
         // One long-lived driver thread for the whole process. Actions may
         // clone/drop `Gc` values (a kept promise handle), so the driver is a
         // registered GC mutator; it parks quiescent while waiting.
+        #[cfg(not(target_arch = "wasm32"))]
         crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
             let (heap, cvar) = state;
             let mut guard = heap.lock().unwrap();
             loop {
-                let now = Instant::now();
+                let now = thread_compat::mono_now();
                 // Collect every due entry first, then run the actions with
                 // the heap lock released: an action registering a new timer
                 // (or dropping a value whose finalizer does) must not
@@ -78,7 +91,7 @@ fn timer_state() -> &'static TimerState {
                         // heap lock; short chunks avoid holding anything
                         // during the actual wait).
                         None => Duration::from_millis(500),
-                        Some(entry) => entry.next - now,
+                        Some(entry) => Duration::from_secs_f64((entry.next - now).max(0.0)),
                     };
                     let (g, _) =
                         crate::gc::block_quiescent(|| cvar.wait_timeout(guard, wait).unwrap());
@@ -86,19 +99,7 @@ fn timer_state() -> &'static TimerState {
                     continue;
                 }
                 drop(guard);
-                let mut reschedule = Vec::new();
-                for mut entry in due {
-                    if let Some(period) = (entry.action)() {
-                        // Fixed-rate schedule, but never a catch-up burst:
-                        // if we fell behind (loaded host), skip ahead.
-                        entry.next += period;
-                        let now = Instant::now();
-                        if entry.next < now {
-                            entry.next = now + period;
-                        }
-                        reschedule.push(entry);
-                    }
-                }
+                let reschedule = run_due_actions(due);
                 guard = heap.lock().unwrap();
                 for entry in reschedule {
                     guard.push(entry);
@@ -109,11 +110,61 @@ fn timer_state() -> &'static TimerState {
     })
 }
 
+/// Run each due entry's action (with the heap lock RELEASED — see the module
+/// docs) and return the ones that asked to be rescheduled.
+fn run_due_actions(due: Vec<TimerEntry>) -> Vec<TimerEntry> {
+    let mut reschedule = Vec::new();
+    for mut entry in due {
+        if let Some(period) = (entry.action)() {
+            // Fixed-rate schedule, but never a catch-up burst: if we fell
+            // behind (loaded host), skip ahead.
+            entry.next += period.as_secs_f64();
+            let now = thread_compat::mono_now();
+            if entry.next < now {
+                entry.next = now + period.as_secs_f64();
+            }
+            reschedule.push(entry);
+        }
+    }
+    reschedule
+}
+
+/// Fire the earliest pending timer, jumping the virtual clock forward to its
+/// deadline. Returns false when no timer is pending — the cooperative
+/// scheduler's signal that a waiter can never be woken.
+///
+/// This is the wasm stand-in for the driver thread: same heap, same actions,
+/// but driven from [`crate::runtime::wasm_sched::pump`] at the points where a
+/// native build would be blocked waiting.
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn wasm_fire_next_timer() -> bool {
+    let (heap, _) = timer_state();
+    let deadline = match heap.lock().unwrap().peek() {
+        Some(entry) => entry.next,
+        None => return false,
+    };
+    crate::runtime::wasm_sched::advance_clock_to(deadline);
+    let now = thread_compat::mono_now();
+    let mut due = Vec::new();
+    {
+        let mut guard = heap.lock().unwrap();
+        while guard.peek().is_some_and(|e| e.next <= now) {
+            due.push(guard.pop().unwrap());
+        }
+    }
+    let reschedule = run_due_actions(due);
+    let mut guard = heap.lock().unwrap();
+    for entry in reschedule {
+        guard.push(entry);
+    }
+    true
+}
+
 fn register_entry(delay: Duration, action: TimerAction) {
     let (heap, cvar) = timer_state();
     let mut guard = heap.lock().unwrap();
     guard.push(TimerEntry {
-        next: Instant::now() + delay,
+        next: thread_compat::mono_now() + delay.as_secs_f64(),
         action,
     });
     cvar.notify_all();

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -106,7 +106,7 @@ impl Interpreter {
 
     pub(super) fn sleep_for_supply_delay(delay_seconds: f64) {
         if delay_seconds > 0.0 {
-            std::thread::sleep(Duration::from_secs_f64(delay_seconds));
+            crate::runtime::thread_compat::sleep(Duration::from_secs_f64(delay_seconds));
         }
     }
 

--- a/src/runtime/native_methods/scheduler.rs
+++ b/src/runtime/native_methods/scheduler.rs
@@ -119,7 +119,9 @@ impl Interpreter {
         }
         // Quiescent: a registered thread's raw sleep would starve a GC
         // stop-the-world rendezvous.
-        crate::gc::block_quiescent(|| std::thread::sleep(interval_timer::clamp_delay_secs(delay)));
+        crate::gc::block_quiescent(|| {
+            crate::runtime::thread_compat::sleep(interval_timer::clamp_delay_secs(delay))
+        });
         true
     }
 
@@ -440,7 +442,9 @@ impl Interpreter {
             } else if interval > 0.0 && interval.is_finite() {
                 // Quiescent — see `scheduler_sleep`.
                 crate::gc::block_quiescent(|| {
-                    std::thread::sleep(std::time::Duration::from_secs_f64(interval))
+                    crate::runtime::thread_compat::sleep(std::time::Duration::from_secs_f64(
+                        interval,
+                    ))
                 });
             }
         }

--- a/src/runtime/native_methods/state_lock.rs
+++ b/src/runtime/native_methods/state_lock.rs
@@ -86,11 +86,16 @@ pub(crate) fn acquire_lock(
             }
             Some(_) => {
                 // STW-aware: a thread blocked on lock acquisition counts as
-                // quiescent for the GC's cooperative stop-the-world.
-                state = crate::gc::stw_aware_wait(&runtime.lock_cv, state, |s| match s.owner {
-                    None => true,
-                    Some(owner) => owner == me,
-                });
+                // quiescent for the GC's cooperative stop-the-world. On wasm
+                // it pumps the cooperative scheduler instead, so the task
+                // holding the lock gets a chance to release it.
+                drop(state);
+                state =
+                    crate::gc::wait_until(&runtime.state, &runtime.lock_cv, |s| match s.owner {
+                        None => true,
+                        Some(owner) => owner == me,
+                    })
+                    .ok_or_else(|| RuntimeError::new(crate::gc::DEADLOCK_MESSAGE))?;
             }
         }
     }
@@ -244,13 +249,10 @@ pub(crate) fn semaphore_runtime_by_id(id: u64) -> Option<Arc<SemaphoreRuntime>> 
 }
 
 pub(crate) fn semaphore_acquire(rt: &SemaphoreRuntime) -> Result<(), RuntimeError> {
-    let state = rt
-        .state
-        .lock()
-        .map_err(|_| RuntimeError::new("Semaphore state poisoned"))?;
     // STW-aware: blocked acquirers count as quiescent for the GC's
-    // cooperative stop-the-world.
-    let mut state = crate::gc::stw_aware_wait(&rt.cv, state, |s| *s > 0);
+    // cooperative stop-the-world (and pump the scheduler on wasm).
+    let mut state = crate::gc::wait_until(&rt.state, &rt.cv, |s| *s > 0)
+        .ok_or_else(|| RuntimeError::new(crate::gc::DEADLOCK_MESSAGE))?;
     *state -= 1;
     Ok(())
 }

--- a/src/runtime/native_methods/state_supplier.rs
+++ b/src/runtime/native_methods/state_supplier.rs
@@ -9,7 +9,7 @@ struct UniqueFilterState {
     as_fn: Option<Value>,
     with_fn: Option<Value>,
     expires_seconds: Option<f64>,
-    seen: Vec<(Value, std::time::Instant)>,
+    seen: Vec<(Value, crate::runtime::thread_compat::Instant)>,
 }
 
 #[derive(Clone)]
@@ -26,7 +26,7 @@ struct ClassifyState {
 #[derive(Clone)]
 struct ElemsTraceState {
     interval_seconds: f64,
-    last_emit_at: Option<std::time::Instant>,
+    last_emit_at: Option<crate::runtime::thread_compat::Instant>,
     emitted_count: i64,
     last_reported_count: i64,
 }
@@ -899,7 +899,7 @@ pub(in crate::runtime) fn supplier_emit_callbacks(
             } else if let Some(ref mut uf) = tap.unique_filter {
                 // Expire old seen values if :expires is set
                 if let Some(expire_secs) = uf.expires_seconds {
-                    let now = std::time::Instant::now();
+                    let now = crate::runtime::thread_compat::Instant::now();
                     uf.seen
                         .retain(|(_, ts)| now.duration_since(*ts).as_secs_f64() < expire_secs);
                 }
@@ -921,8 +921,10 @@ pub(in crate::runtime) fn supplier_emit_callbacks(
                         .iter()
                         .any(|(s, _)| values_identical(s, emitted_value));
                     if !already_seen {
-                        uf.seen
-                            .push((emitted_value.clone(), std::time::Instant::now()));
+                        uf.seen.push((
+                            emitted_value.clone(),
+                            crate::runtime::thread_compat::Instant::now(),
+                        ));
                         actions.push(SupplierEmitAction::Call(
                             tap.callback.clone(),
                             emitted_value.clone(),
@@ -937,7 +939,7 @@ pub(in crate::runtime) fn supplier_emit_callbacks(
                 });
             } else if let Some(ref mut elems) = tap.elems_trace {
                 elems.emitted_count += 1;
-                let now = std::time::Instant::now();
+                let now = crate::runtime::thread_compat::Instant::now();
                 let should_emit = if elems.interval_seconds <= 0.0 {
                     true
                 } else if let Some(last_emit) = elems.last_emit_at {
@@ -1074,7 +1076,8 @@ pub(in crate::runtime) fn supplier_unique_mark_seen(
         && let Some(tap) = subs.taps.get_mut(tap_index)
         && let Some(ref mut uf) = tap.unique_filter
     {
-        uf.seen.push((key, std::time::Instant::now()));
+        uf.seen
+            .push((key, crate::runtime::thread_compat::Instant::now()));
     }
 }
 

--- a/src/runtime/native_supplier_methods.rs
+++ b/src/runtime/native_supplier_methods.rs
@@ -471,7 +471,7 @@ impl Interpreter {
                     buf.push(value.clone());
                 }
                 if let Some(buf) = self.supply_emit_timed_buffer.last_mut() {
-                    buf.push((value.clone(), std::time::Instant::now()));
+                    buf.push((value.clone(), crate::runtime::thread_compat::Instant::now()));
                 }
                 if let Some(supplier_id) = supplier_id_from_attrs(&attrs) {
                     supplier_emit(supplier_id, value.clone());

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -559,9 +559,10 @@ impl Interpreter {
                         let as_fn = attrs.get("unique_as").cloned();
                         let with_fn = attrs.get("unique_with").cloned();
                         let expires_secs = attrs.get("unique_expires").map(|v| v.to_f64());
-                        let mut seen_keys: Vec<(Value, std::time::Instant)> = Vec::new();
+                        let mut seen_keys: Vec<(Value, crate::runtime::thread_compat::Instant)> =
+                            Vec::new();
                         let mut unique_items: Vec<Value> = Vec::new();
-                        let now = std::time::Instant::now();
+                        let now = crate::runtime::thread_compat::Instant::now();
                         for item in emitted {
                             // Expire old seen values if :expires is set
                             if let Some(expire_secs) = expires_secs {

--- a/src/runtime/output_sink.rs
+++ b/src/runtime/output_sink.rs
@@ -64,7 +64,12 @@ impl OutputSink {
     /// identical to the former `Interpreter::emit_output` body.
     pub(crate) fn emit(&mut self, text: &str, subtest_active: bool) {
         self.output_emitted = true;
-        if !subtest_active && self.immediate_stdout {
+        // On wasm the process stdout goes nowhere the page can read: the
+        // playground shows what this sink buffers and hands back. So the
+        // immediate-flush path (used by `Thread.start` workers, which want
+        // real-time chronological output natively) must not bypass the buffer,
+        // or a thread's `say` would simply vanish.
+        if !subtest_active && self.immediate_stdout && !cfg!(target_arch = "wasm32") {
             use std::io::Write;
             let _ = std::io::stdout().write_all(text.as_bytes());
             let _ = std::io::stdout().flush();
@@ -87,7 +92,8 @@ impl OutputSink {
     /// `write_to_handle_value_trying` (no `output_emitted` flag, no Stdout-style
     /// thread-clone interleaving — stderr buffers per interpreter).
     pub(crate) fn emit_stderr(&mut self, text: &str, subtest_active: bool) {
-        if !subtest_active && self.immediate_stdout {
+        // Buffered on wasm for the same reason as `emit`.
+        if !subtest_active && self.immediate_stdout && !cfg!(target_arch = "wasm32") {
             use std::io::Write;
             let _ = std::io::stderr().write_all(text.as_bytes());
             let _ = std::io::stderr().flush();

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -440,6 +440,12 @@ impl Interpreter {
     }
 
     pub(super) fn finish(&mut self) -> Result<(), RuntimeError> {
+        // On wasm a fire-and-forget `start` block is a task nobody pumped: it is
+        // still sitting on the cooperative scheduler's queue. Run it here, at the
+        // same point a native build would collect a finished thread's output, so
+        // `start { say "hi" }` prints instead of silently evaporating.
+        #[cfg(target_arch = "wasm32")]
+        crate::runtime::wasm_sched::drain_ready();
         // Drain any output produced by fire-and-forget `start` threads that was
         // never collected by an `await` (those drain on join). A `start` block
         // that ran to a `say` and then blocked/exited still left its text in the

--- a/src/runtime/subtest.rs
+++ b/src/runtime/subtest.rs
@@ -85,7 +85,7 @@ pub(crate) enum SupplyDrivePolicy {
     React,
     Promise {
         promise: crate::value::SharedPromise,
-        deadline: std::time::Instant,
+        deadline: crate::runtime::thread_compat::Instant,
         last_value: Value,
     },
 }

--- a/src/runtime/supply_promise.rs
+++ b/src/runtime/supply_promise.rs
@@ -250,7 +250,7 @@ impl Interpreter {
             react_subs,
             crate::runtime::subtest::SupplyDrivePolicy::Promise {
                 promise: promise.clone(),
-                deadline: std::time::Instant::now() + Duration::from_secs(30),
+                deadline: crate::runtime::thread_compat::Instant::now() + Duration::from_secs(30),
                 last_value: seed,
             },
         )

--- a/src/runtime/supply_transform.rs
+++ b/src/runtime/supply_transform.rs
@@ -14,7 +14,7 @@ fn wait_for_control_limit(ctrl_id: u64) -> i64 {
     let waker = crate::value::waker::ReactWaker::new();
     let sink_id = supplier_sink_register(ctrl_id, 0, &waker);
     let mut current_limit: i64 = 0;
-    let start = std::time::Instant::now();
+    let start = crate::runtime::thread_compat::Instant::now();
     while current_limit == 0 && start.elapsed() < std::time::Duration::from_secs(30) {
         for (_, event) in waker.drain() {
             if let crate::value::waker::SinkEvent::Emit(val) = event

--- a/src/runtime/test_functions/tap_ok.rs
+++ b/src/runtime/test_functions/tap_ok.rs
@@ -237,13 +237,14 @@ impl Interpreter {
                                 .collect::<Vec<_>>()
                         } else {
                             let events = if timed_emitted.is_empty() {
-                                let now = std::time::Instant::now();
+                                let now = crate::runtime::thread_compat::Instant::now();
                                 emitted.into_iter().map(|v| (v, now)).collect::<Vec<_>>()
                             } else {
                                 timed_emitted.clone()
                             };
                             let mut total = initial_count;
-                            let mut last_emit_at: Option<std::time::Instant> = None;
+                            let mut last_emit_at: Option<crate::runtime::thread_compat::Instant> =
+                                None;
                             let mut out = Vec::new();
                             for (_, ts) in events {
                                 total += 1;
@@ -267,10 +268,11 @@ impl Interpreter {
                         let with_fn = attributes.as_map().get("unique_with").cloned();
                         let expires_secs =
                             attributes.as_map().get("unique_expires").map(Value::to_f64);
-                        let mut seen: Vec<(Value, std::time::Instant)> = Vec::new();
+                        let mut seen: Vec<(Value, crate::runtime::thread_compat::Instant)> =
+                            Vec::new();
                         let mut unique = Vec::new();
                         let events = if timed_emitted.is_empty() {
-                            let now = std::time::Instant::now();
+                            let now = crate::runtime::thread_compat::Instant::now();
                             emitted.into_iter().map(|v| (v, now)).collect::<Vec<_>>()
                         } else {
                             timed_emitted

--- a/src/runtime/thread_compat.rs
+++ b/src/runtime/thread_compat.rs
@@ -1,0 +1,163 @@
+//! One façade over "run this concurrently", "wait", and "what time is it" —
+//! OS threads and real clocks natively, the cooperative queue and virtual clock
+//! of [`crate::runtime::wasm_sched`] on `wasm32`.
+//!
+//! Every spawn site in the interpreter goes through
+//! [`crate::runtime::builtins_system::spawn_user_thread`] /
+//! `spawn_gc_helper_thread`, which return this module's [`JoinHandle`] rather
+//! than `std::thread::JoinHandle`. That is what keeps the wasm build free of
+//! `cfg` noise at ~20 call sites: the concurrency primitives are written once
+//! against real threads, and only this module knows the browser has none.
+
+use std::time::Duration;
+
+/// Handle on work that runs concurrently: an OS thread natively, a queued task
+/// on wasm.
+pub(crate) struct JoinHandle<T> {
+    #[cfg(not(target_arch = "wasm32"))]
+    inner: std::thread::JoinHandle<T>,
+    #[cfg(target_arch = "wasm32")]
+    inner: super::wasm_sched::PendingTask<T>,
+}
+
+impl<T> JoinHandle<T> {
+    /// Wait for the work to finish and take its result. On wasm this *runs* the
+    /// task (it was only queued by `spawn`), so a `join` is the point at which
+    /// a `start` block actually executes if nothing pumped the queue earlier.
+    pub(crate) fn join(self) -> std::thread::Result<T> {
+        self.inner.join()
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn spawn_thread<F, T>(stack_size: Option<usize>, f: F) -> JoinHandle<T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    let mut builder = std::thread::Builder::new();
+    if let Some(size) = stack_size {
+        builder = builder.stack_size(size);
+    }
+    JoinHandle {
+        inner: builder.spawn(f).expect("failed to spawn worker thread"),
+    }
+}
+
+/// Queue `f` on the single browser thread. The stack size is meaningless here
+/// (there is one stack) and is ignored.
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn spawn_thread<F, T>(_stack_size: Option<usize>, f: F) -> JoinHandle<T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    JoinHandle {
+        inner: super::wasm_sched::spawn(f),
+    }
+}
+
+/// Block the current thread for `duration`.
+///
+/// On wasm there is nothing to block — freezing the only thread would freeze
+/// the page — so a sleep instead runs whatever work is pending and jumps the
+/// virtual clock forward by the requested time. Code that sleeps to let a
+/// `start` block get somewhere therefore still behaves as intended, and elapsed
+/// time still reads back correctly.
+pub(crate) fn sleep(duration: Duration) {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        std::thread::sleep(duration);
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        let deadline = mono_now() + duration.as_secs_f64();
+        while mono_now() < deadline && super::wasm_sched::has_ready_tasks() {
+            super::wasm_sched::pump();
+        }
+        super::wasm_sched::advance_clock_to(deadline);
+    }
+}
+
+/// Seconds on a monotonic clock, from an arbitrary process-local epoch. Used
+/// for deadlines (the timer heap, elapsed-time checks) where `SystemTime` would
+/// be wrong because it can jump.
+pub(crate) fn mono_now() -> f64 {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        use std::sync::OnceLock;
+        use std::time::Instant;
+        static EPOCH: OnceLock<Instant> = OnceLock::new();
+        EPOCH.get_or_init(Instant::now).elapsed().as_secs_f64()
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        // `Instant::now()` panics on wasm32-unknown-unknown, so the monotonic
+        // clock is the host's `Date.now()` plus whatever the virtual clock has
+        // been advanced by. `Date.now()` can step backwards across an NTP
+        // adjustment where a true monotonic clock would not; over the lifetime
+        // of one page that is not worth a second clock.
+        js_epoch_secs() + super::wasm_sched::clock_offset_secs()
+    }
+}
+
+/// A drop-in `std::time::Instant` that also works in a browser.
+///
+/// `std::time::Instant::now()` panics on wasm32-unknown-unknown ("time not
+/// implemented on this platform"), which took down every deadline in the
+/// interpreter — the `react` drive loop's 30s bound, the supply throttle/stable
+/// windows, the GC's stop-the-world timeout. This carries [`mono_now`] seconds
+/// instead and supports the same handful of operations those sites use.
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
+pub(crate) struct Instant(f64);
+
+impl Instant {
+    pub(crate) fn now() -> Self {
+        Instant(mono_now())
+    }
+
+    pub(crate) fn elapsed(&self) -> Duration {
+        Duration::from_secs_f64((mono_now() - self.0).max(0.0))
+    }
+
+    /// Saturating, like `Instant::saturating_duration_since`: a deadline that
+    /// has already passed yields `ZERO`, never a negative (panicking) value.
+    pub(crate) fn duration_since(&self, earlier: Instant) -> Duration {
+        Duration::from_secs_f64((self.0 - earlier.0).max(0.0))
+    }
+}
+
+impl std::ops::Add<Duration> for Instant {
+    type Output = Instant;
+    fn add(self, rhs: Duration) -> Instant {
+        Instant(self.0 + rhs.as_secs_f64())
+    }
+}
+
+impl std::ops::Sub<Instant> for Instant {
+    type Output = Duration;
+    fn sub(self, rhs: Instant) -> Duration {
+        self.duration_since(rhs)
+    }
+}
+
+/// Seconds since the UNIX epoch, from the JS `Date.now()` the host already has.
+/// Without this every wasm build reported time 0 — `DateTime.now.year` was 1970
+/// and `time` was `0`.
+#[cfg(all(target_arch = "wasm32", feature = "wasm"))]
+pub(crate) fn js_epoch_secs() -> f64 {
+    use wasm_bindgen::prelude::*;
+    #[wasm_bindgen]
+    unsafe extern "C" {
+        #[wasm_bindgen(js_namespace = Date)]
+        fn now() -> f64;
+    }
+    now() / 1000.0
+}
+
+/// wasm32 without the `wasm` feature has no JS glue to ask, so time stands
+/// still — as it did everywhere before.
+#[cfg(all(target_arch = "wasm32", not(feature = "wasm")))]
+pub(crate) fn js_epoch_secs() -> f64 {
+    0.0
+}

--- a/src/runtime/wasm_sched.rs
+++ b/src/runtime/wasm_sched.rs
@@ -1,0 +1,198 @@
+//! Cooperative single-threaded scheduler for the `wasm32` build.
+//!
+//! Browsers give a wasm module one thread and no way to create another:
+//! `std::thread::spawn` traps (`RuntimeError: unreachable`), which is why
+//! `start { ... }`, `await`, `Thread.start`, `Promise.in` and `Supply.interval`
+//! all died on the playground while `Channel`, `Supply`, `react` and `Lock` —
+//! none of which need a second thread — already worked.
+//!
+//! Real threads are also out of reach for the deployed site: shared-memory wasm
+//! needs `SharedArrayBuffer`, which needs the COOP/COEP headers that GitHub
+//! Pages cannot serve. So instead of *parallel* execution this module provides
+//! *concurrent* execution: every would-be thread becomes a task on a run queue,
+//! and every point where the interpreter would block on another thread pumps
+//! that queue instead.
+//!
+//! ```text
+//! start { ... }        -> enqueue a task, return a Planned promise
+//! await $p             -> pump() until $p is resolved
+//! $chan.receive        -> pump() until the queue has a value
+//! sleep 1              -> pump(), then advance the virtual clock
+//! ```
+//!
+//! [`pump`] is the whole event loop: run a ready task if there is one, and
+//! otherwise jump the virtual clock to the earliest timer deadline and fire it.
+//! When neither is possible nothing can ever make the waiter ready — that is a
+//! real deadlock, and `pump` returns `false` so the caller can raise an error
+//! instead of hanging the browser tab.
+//!
+//! The one thing this cannot emulate is a task that blocks halfway through on
+//! something only its *waiter* would do later: tasks run to completion, so
+//! `my $p = start { $c.receive }; $c.send(1); await $p` works (the task is not
+//! started until the `await`), but a task that waits on a value sent after it
+//! has already begun deadlocks. Native mutsu runs both.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+type Task = Box<dyn FnOnce() + Send>;
+
+/// Ready-to-run tasks, oldest first. Never held across running a task: a task
+/// may enqueue more tasks, and may itself pump the queue from a nested
+/// `await`.
+fn queue() -> &'static Mutex<VecDeque<(u64, Task)>> {
+    static QUEUE: OnceLock<Mutex<VecDeque<(u64, Task)>>> = OnceLock::new();
+    QUEUE.get_or_init(|| Mutex::new(VecDeque::new()))
+}
+
+fn next_id() -> u64 {
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+    NEXT.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Seconds the virtual clock has been advanced past real time, as `f64` bits.
+///
+/// Nothing in a browser can block the single thread for a second without
+/// freezing the page, so `sleep`/timer waits do not spend real time — they jump
+/// this offset forward instead. Both the wall clock (`now`, `time`,
+/// `DateTime.now`) and the monotonic clock the timer heap runs on include it,
+/// so `my $t = now; sleep 2; say now - $t` still says `2`.
+static CLOCK_OFFSET_SECS: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn clock_offset_secs() -> f64 {
+    f64::from_bits(CLOCK_OFFSET_SECS.load(Ordering::Relaxed))
+}
+
+/// Move the virtual clock forward by `secs` (never backwards).
+pub(crate) fn advance_clock(secs: f64) {
+    if !secs.is_finite() || secs <= 0.0 {
+        return;
+    }
+    let mut cur = CLOCK_OFFSET_SECS.load(Ordering::Relaxed);
+    loop {
+        let next = (f64::from_bits(cur) + secs).to_bits();
+        match CLOCK_OFFSET_SECS.compare_exchange_weak(
+            cur,
+            next,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => return,
+            Err(observed) => cur = observed,
+        }
+    }
+}
+
+/// Advance the virtual clock so that [`crate::runtime::thread_compat::mono_now`]
+/// reaches `deadline` (no-op when it is already there).
+pub(crate) fn advance_clock_to(deadline: f64) {
+    advance_clock(deadline - crate::runtime::thread_compat::mono_now());
+}
+
+/// Queue `f` to run later on the single thread, and hand back the slot its
+/// result lands in. The task does not start here: deferring it is what lets
+/// `my $p = start { $c.receive }; $c.send(1); await $p` work, since by the time
+/// the task runs the main line has already sent.
+pub(crate) fn spawn<F, T>(f: F) -> PendingTask<T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    let id = next_id();
+    let slot: Arc<Mutex<Option<std::thread::Result<T>>>> = Arc::new(Mutex::new(None));
+    let write_to = Arc::clone(&slot);
+    let task: Task = Box::new(move || {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        *write_to.lock().unwrap() = Some(result);
+    });
+    queue().lock().unwrap().push_back((id, task));
+    PendingTask { id, slot }
+}
+
+/// The wasm stand-in for a `JoinHandle`'s thread: an id in the run queue plus
+/// the slot the task's return value lands in.
+pub(crate) struct PendingTask<T> {
+    id: u64,
+    slot: Arc<Mutex<Option<std::thread::Result<T>>>>,
+}
+
+impl<T> PendingTask<T> {
+    fn is_finished(&self) -> bool {
+        self.slot.lock().unwrap().is_some()
+    }
+
+    /// Run this task to completion (if it has not run already) and take its
+    /// result. Fails only when the task cannot run at all — it is already on
+    /// the stack (a task joining itself).
+    pub(crate) fn join(self) -> std::thread::Result<T> {
+        if !self.is_finished() {
+            run_task(self.id);
+        }
+        self.slot.lock().unwrap().take().unwrap_or_else(|| {
+            Err(Box::new(
+                "join on a task that is already running (single-threaded WASM build)".to_string(),
+            ) as Box<dyn std::any::Any + Send>)
+        })
+    }
+}
+
+/// Pull one specific queued task out and run it. Returns false when it is not
+/// in the queue (already run, or currently running further up the stack).
+fn run_task(id: u64) -> bool {
+    let task = {
+        let mut q = queue().lock().unwrap();
+        q.iter().position(|(qid, _)| *qid == id).map(|at| {
+            let (_, task) = q.remove(at).expect("position() just found it");
+            task
+        })
+    };
+    match task {
+        Some(task) => {
+            task();
+            true
+        }
+        None => false,
+    }
+}
+
+/// Run the oldest ready task. Returns false when the queue is empty.
+fn run_one() -> bool {
+    let task = queue().lock().unwrap().pop_front();
+    match task {
+        Some((_, task)) => {
+            task();
+            true
+        }
+        None => false,
+    }
+}
+
+pub(crate) fn has_ready_tasks() -> bool {
+    !queue().lock().unwrap().is_empty()
+}
+
+/// Make one step of progress: run a ready task, or fire the earliest timer
+/// (jumping the virtual clock to its deadline).
+///
+/// Returns `false` when there is nothing left to run — the caller is blocked on
+/// something that can never happen, so it should raise an error rather than
+/// spin.
+pub(crate) fn pump() -> bool {
+    if run_one() {
+        return true;
+    }
+    crate::runtime::native_methods::interval_timer::wasm_fire_next_timer()
+}
+
+/// Run everything that is ready, so `start { say "hi" }` still prints when the
+/// program never awaits it. Bounded: a self-rescheduling timer (an untapped
+/// `Supply.interval`) would otherwise spin forever.
+pub(crate) fn drain_ready() {
+    const MAX_STEPS: usize = 100_000;
+    for _ in 0..MAX_STEPS {
+        if !run_one() {
+            return;
+        }
+    }
+}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -397,7 +397,10 @@ pub(crate) static NIL_VALUE: Value = Value(NanBox::NIL);
 pub(crate) use types::{role_mixin_suffix, what_type_name};
 pub use view::ValueView;
 
-/// Get current time as seconds since UNIX epoch (returns 0.0 on WASM).
+/// Get current time as seconds since UNIX epoch. On WASM the host's
+/// `Date.now()` supplies it, plus whatever the cooperative scheduler's virtual
+/// clock has been advanced by (see `runtime::wasm_sched`), so a `sleep` is
+/// visible to `now` / `time` / `DateTime.now` exactly as it is natively.
 pub(crate) fn current_time_secs_f64() -> f64 {
     #[cfg(not(target_arch = "wasm32"))]
     {
@@ -408,7 +411,8 @@ pub(crate) fn current_time_secs_f64() -> f64 {
     }
     #[cfg(target_arch = "wasm32")]
     {
-        0.0
+        crate::runtime::thread_compat::js_epoch_secs()
+            + crate::runtime::wasm_sched::clock_offset_secs()
     }
 }
 

--- a/src/value/value_async.rs
+++ b/src/value/value_async.rs
@@ -222,11 +222,20 @@ impl SharedPromise {
         // other promises/channels, so it must not hold this mutex).
         crate::gc::gc_safepoint(crate::gc::SafepointKind::Await);
         let (lock, cvar) = &*self.inner;
-        let state = lock.lock().unwrap();
         // STW-aware: the waiting thread counts as quiescent for the GC's
         // cooperative stop-the-world, and never resumes (cloning `Value`s
         // below mutates Gc refcounts) while a cycle scan is in progress.
-        let state = crate::gc::stw_aware_wait(cvar, state, |s| s.status != "Planned");
+        // On wasm this pumps the cooperative scheduler instead of parking —
+        // the `start` block we are waiting for only runs because of it.
+        let state = match crate::gc::wait_until(lock, cvar, |s| s.status != "Planned") {
+            Some(state) => state,
+            None => {
+                // Single-threaded build with nothing left to run: break the
+                // promise so `await` reports a deadlock instead of hanging.
+                let _ = self.try_break(Value::str(crate::gc::DEADLOCK_MESSAGE.to_string()));
+                lock.lock().unwrap()
+            }
+        };
         (
             state.result.clone(),
             state.output.clone(),
@@ -298,13 +307,17 @@ impl SharedChannel {
         // channel lock is taken — see `SharedPromise::wait`.
         crate::gc::gc_safepoint(crate::gc::SafepointKind::Await);
         let (lock, cvar) = &*self.inner;
-        let mut state = lock.lock().unwrap();
         loop {
             // STW-aware: block (quiescent) until there is something to take or
             // the channel is drained-closed; the queue pop / `Value` clones run
-            // only outside a stop-the-world window.
-            state =
-                crate::gc::stw_aware_wait(cvar, state, |s| !s.queue.is_empty() || s.drained_closed);
+            // only outside a stop-the-world window. On wasm the wait pumps the
+            // cooperative scheduler, so a queued `start` block gets to send.
+            let mut state = match crate::gc::wait_until(lock, cvar, |s| {
+                !s.queue.is_empty() || s.drained_closed
+            }) {
+                Some(state) => state,
+                None => return Err(Value::str(crate::gc::DEADLOCK_MESSAGE.to_string())),
+            };
             if let Some(val) = state.queue.pop_front() {
                 Self::finish_if_drained(&mut state);
                 return Ok(val);

--- a/src/value/waker.rs
+++ b/src/value/waker.rs
@@ -81,6 +81,37 @@ impl ReactWaker {
     /// elapses. Counts the thread GC-quiescent for the duration (the wait
     /// touches no `Gc` state). Consumes a pending poke.
     pub(crate) fn wait_activity(&self, timeout: Duration) {
+        #[cfg(target_arch = "wasm32")]
+        {
+            // In a browser the producers are not other threads — they are the
+            // queued tasks and timers of `runtime::wasm_sched`, and a condvar
+            // wait would both park the only thread that could ever run them and
+            // panic (wasm32 std has no condvar). So run them instead, until an
+            // event shows up or the requested timeout elapses on the virtual
+            // clock. Letting the timeout elapse matters: it is what lets the
+            // caller's own deadline (the react drive loop's) expire rather than
+            // spin, when nothing is left that could produce.
+            use crate::runtime::thread_compat::mono_now;
+            let (lock, _) = &*self.inner;
+            let deadline = mono_now() + timeout.as_secs_f64();
+            loop {
+                {
+                    let state = lock.lock().unwrap();
+                    if !state.events.is_empty() || state.poked {
+                        break;
+                    }
+                }
+                if mono_now() >= deadline {
+                    break;
+                }
+                if !crate::runtime::wasm_sched::pump() {
+                    crate::runtime::wasm_sched::advance_clock_to(deadline);
+                    break;
+                }
+            }
+            lock.lock().unwrap().poked = false;
+        }
+        #[cfg(not(target_arch = "wasm32"))]
         crate::gc::block_quiescent(|| {
             let (lock, cvar) = &*self.inner;
             let mut state = lock.lock().unwrap();

--- a/src/vm/vm_hyper_race_parallel.rs
+++ b/src/vm/vm_hyper_race_parallel.rs
@@ -54,7 +54,7 @@ impl Interpreter {
             String,
             String,
         );
-        let mut handles: Vec<std::thread::JoinHandle<ThreadResult>> =
+        let mut handles: Vec<crate::runtime::thread_compat::JoinHandle<ThreadResult>> =
             Vec::with_capacity(num_batches);
         for batch in batches {
             let thread_interp = self.clone_for_thread();

--- a/src/vm/vm_react_subscriptions.rs
+++ b/src/vm/vm_react_subscriptions.rs
@@ -280,7 +280,7 @@ impl Interpreter {
                     return Ok(());
                 }
                 // Bound the wait so a stalled source cannot hang the await.
-                if std::time::Instant::now() >= *deadline {
+                if crate::runtime::thread_compat::Instant::now() >= *deadline {
                     promise.keep(Value::NIL, String::new(), String::new());
                     return Ok(());
                 }
@@ -549,7 +549,7 @@ impl Interpreter {
             if !progressed {
                 let mut cap = REACT_IDLE_WAIT;
                 if let SupplyDrivePolicy::Promise { deadline, .. } = &policy {
-                    let now = std::time::Instant::now();
+                    let now = crate::runtime::thread_compat::Instant::now();
                     cap = if *deadline > now {
                         cap.min(*deadline - now)
                     } else {

--- a/wasm-demo/README.md
+++ b/wasm-demo/README.md
@@ -78,11 +78,20 @@ A snippet may carry flags after its key:
 #== concurrency/promises no-browser
 ```
 
-`no-browser` means "runs natively, but not in the WebAssembly build" — `start` needs
-real OS threads and `wasm32-unknown-unknown` has none, so `std::thread::spawn` traps.
-Those lessons are still checked natively by `check-site-snippets.mjs`; the site
-disables their Run button, explains why, and shows the recorded native output instead
-of a WASM trap. (See PLAN.md §8.18 for the underlying gap.)
+`no-browser` means "runs natively, but not in the WebAssembly build" — the snippet
+needs something a browser cannot provide at all (spawning a real process, say). Those
+lessons are still checked natively by `check-site-snippets.mjs`; the site disables
+their Run button, explains why, and shows the recorded native output instead of a WASM
+trap. No lesson currently carries the flag.
+
+**Concurrency is not one of those cases.** `start`, `await`, `Promise`, `Channel`,
+`Thread`, `Supply.interval` and `sleep` all run in the browser, on the cooperative
+scheduler in `src/runtime/wasm_sched.rs`: a would-be thread becomes a task on a run
+queue, and every point that would block on another thread pumps that queue instead.
+It is concurrency without parallelism — nothing runs at the same time as anything
+else, and a task that blocks midway on something only its waiter would do later
+reports a deadlock rather than hanging the tab. `wasm-demo/concurrency.test.mjs`
+pins the behaviour (run it with Node, no browser needed).
 
 ## Adding a lesson
 
@@ -108,6 +117,7 @@ python3 -m http.server 8000 -d wasm-demo    # then open http://localhost:8000/
 
 ```sh
 node scripts/check-site-snippets.mjs   # every snippet, under mutsu (+ raku if present)
+node wasm-demo/concurrency.test.mjs    # start/await/Channel/timers in the WASM build
 npm install playwright && npx playwright install chromium
 node wasm-demo/e2e.test.mjs            # the site itself, in a real browser
 SKIP_LESSON_SWEEP=1 node wasm-demo/e2e.test.mjs   # skip the per-lesson sweep

--- a/wasm-demo/assets/i18n.js
+++ b/wasm-demo/assets/i18n.js
@@ -35,7 +35,7 @@ const STRINGS = {
     'expected.summary': 'Expected output',
     'verdict.ok': '✓ matches the expected output',
     'verdict.differs': '≠ differs from the expected output — that is fine while you experiment',
-    'no-browser.note': 'This example needs real OS threads, which the WebAssembly build ' +
+    'no-browser.note': 'This example needs something the WebAssembly build ' +
       'does not have — so it cannot run here. The output below is what it prints when ' +
       'you run it with mutsu (or Rakudo) on your machine.',
     'no-browser.output': 'Output (recorded from a native run)',
@@ -73,7 +73,7 @@ const STRINGS = {
     'expected.summary': '期待される出力',
     'verdict.ok': '✓ 期待どおりの出力です',
     'verdict.differs': '≠ 期待される出力とは違います（自由に書き換えて試している場合はこれで OK）',
-    'no-browser.note': 'この例は本物の OS スレッドを必要とし、WebAssembly 版にはそれがないため、' +
+    'no-browser.note': 'この例は WebAssembly 版にない機能を必要とするため、' +
       'ここでは実行できません。下の出力は、手元の環境で mutsu（または Rakudo）で実行したときのものです。',
     'no-browser.output': '出力（ネイティブ実行の記録）',
 

--- a/wasm-demo/concurrency.test.mjs
+++ b/wasm-demo/concurrency.test.mjs
@@ -1,0 +1,102 @@
+// Concurrency tests for the WASM build, run against pkg/ directly (no browser).
+// Run: node wasm-demo/concurrency.test.mjs
+//
+// Requires wasm-demo/pkg/ to be built:
+//   wasm-pack build --target web --no-default-features --features wasm
+//   mv pkg wasm-demo/pkg
+//
+// Browsers give a wasm module one thread, so `start`/`await`/`Thread`/timers run
+// on the cooperative scheduler in src/runtime/wasm_sched.rs rather than on OS
+// threads. These are the cases that used to die with `RuntimeError: unreachable`
+// the moment anything called `std::thread::spawn`; the point of the file is that
+// the queue, the pump and the virtual clock keep producing the SAME answers a
+// native mutsu gives.
+
+import { readFile } from 'node:fs/promises';
+import init, { evaluate } from './pkg/mutsu.js';
+
+const wasm = await readFile(new URL('./pkg/mutsu_bg.wasm', import.meta.url));
+await init({ module_or_path: wasm });
+
+let passed = 0;
+let failed = 0;
+
+/** Run `code` and compare its whole output with `expected`. */
+function is(code, expected, name) {
+  let got;
+  try {
+    got = evaluate(code);
+  } catch (e) {
+    got = `THREW: ${e}`;
+  }
+  if (got.trim() === expected.trim()) {
+    console.log(`  PASS: ${name}`);
+    passed++;
+  } else {
+    console.error(`  FAIL: ${name}\n    code:     ${code}\n    expected: ${JSON.stringify(expected)}\n    got:      ${JSON.stringify(got)}`);
+    failed++;
+  }
+}
+
+console.log('start / await');
+is('my $p = Promise.start({ 40 + 2 }); say $p.result;', '42', 'Promise.start.result');
+is('say await start { 1 + 1 };', '2', 'await a start block');
+is('say await Promise.kept(3);', '3', 'await an already-kept promise');
+is('my $p = start { 7 }; say $p.status; say await $p; say $p.status;',
+   'Planned\n7\nKept', 'a start block stays Planned until awaited');
+is('say (await (start { 1 }, start { 2 }, start { 3 })).join(",");',
+   '1,2,3', 'await a list of promises');
+is('my @p = (1..3).map({ start { $_ * 2 } }); say await @p;', '(2 4 6)', 'await mapped start blocks');
+// Deterministic here, unlike native mutsu/raku where the process may exit
+// before a detached thread gets to print: the queue is drained at program end.
+is('start { say "from the task" }; say "mainline";',
+   'mainline\nfrom the task', 'an unawaited start block still runs at program end');
+
+console.log('promise combinators');
+is('await Promise.allof(start { 1 }, start { 2 }); say "all done";', 'all done', 'Promise.allof');
+is('my @p = (start { 1 }, start { 2 }); my $any = Promise.anyof(@p); await $any; say $any.status;',
+   'Kept', 'Promise.anyof');
+is('say await Promise.kept(2).then({ .result * 21 });', '42', 'then on a kept promise');
+is('my $p = start { 6 }; say await $p.then({ .result * 7 });', '42', 'then on a pending promise');
+is('my $p = start { die "boom" }; try { await $p; CATCH { default { say "caught: " ~ .message } } }',
+   'caught: boom', 'a die inside start surfaces at await');
+
+console.log('channels');
+is('my $c = Channel.new; $c.send(1); $c.send(2); $c.close; say $c.list;', '(1 2)', 'send/close/list');
+is('my $c = Channel.new; my $p = start { $c.send(42); $c.close }; await $p; say $c.receive;',
+   '42', 'receive a value a start block sent');
+is('my $c = Channel.new; start { for 1..3 { $c.send($_) }; $c.close }; say $c.list;',
+   '(1 2 3)', 'a blocking receive pumps the queued producer');
+is('my $c = Channel.new; $c.send("x"); $c.close; react { whenever $c -> $v { say "got $v" } }',
+   'got x', 'react/whenever over a channel');
+
+console.log('threads and locks');
+is('my $t = Thread.start({ say "in thread" }); $t.finish; say "joined";',
+   'in thread\njoined', 'Thread.start/finish');
+is('my $l = Lock.new; my $n = 0; await (^4).map: { start { $l.protect({ $n++ }) } }; say $n;',
+   '4', 'Lock.protect across start blocks');
+is('my atomicint $i = 0; await (^5).map: { start { $i⚛++ } }; say $i;', '5', 'atomicint increments');
+
+console.log('timers and the virtual clock');
+is('await Promise.in(0.01); say "timer fired";', 'timer fired', 'Promise.in');
+is('my $t = now; sleep 1; say (now - $t) >= 1;', 'True', 'sleep advances the clock it reports');
+is('say time > 1700000000;', 'True', 'time comes from the host clock, not 0');
+is('say DateTime.now.year >= 2026;', 'True', 'DateTime.now is a real date');
+is('my $n = 0; react { whenever Supply.interval(0.01) { $n++; done if $n >= 3 } }; say $n;',
+   '3', 'Supply.interval drives a react block');
+is('my $p = start { sleep 0.05; "late" }; say await $p;', 'late', 'a start block that sleeps');
+
+console.log('supplies');
+is('Supply.from-list(1,2,3).tap({ say $_ });', '1\n2\n3', 'Supply.from-list');
+is('my $s = Supplier.new; my @got; my $t = $s.Supply.tap({ @got.push($_) }); $s.emit(1); $s.emit(2); $s.done; say @got;',
+   '[1 2]', 'tap a Supplier');
+
+console.log('deadlock reporting (single-threaded limit)');
+// WASM-ONLY behaviour: native mutsu and raku both block here forever (a second
+// thread could still send). With one thread and an empty run queue nothing ever
+// can, so the pump reports it instead of freezing the tab.
+is('my $c = Channel.new; try { $c.receive; CATCH { default { say "reported" } } }',
+   'reported', 'a receive that can never be satisfied errors instead of hanging');
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/wasm-demo/content/lessons.txt
+++ b/wasm-demo/content/lessons.txt
@@ -6,8 +6,10 @@
 #  are ordered by first appearance.
 #
 #  Flag `no-browser`: the snippet runs natively but not in the WebAssembly
-#  build (`start` needs OS threads, which wasm32 has none of).  The site shows
-#  the recorded native output instead of offering to run it.
+#  build (a feature the browser cannot provide at all, e.g. spawning a real
+#  process).  The site shows the recorded native output instead of offering to
+#  run it.  Concurrency does NOT need this flag: `start`/`await`/`Channel` run
+#  on the cooperative scheduler (src/runtime/wasm_sched.rs).
 #
 #  The expected-output blocks are GENERATED and verified: run
 #      node scripts/check-site-snippets.mjs --update
@@ -474,7 +476,7 @@ say Greeting.parse("Goodbye Camelia").defined;
 ｢Camelia｣
 False
 
-#== concurrency/promises no-browser
+#== concurrency/promises
 my @squares = (1..5).map: -> $n { start { $n * $n } };
 say await @squares;
 
@@ -487,7 +489,7 @@ say $p.status;
 kept
 Kept
 
-#== concurrency/channels no-browser
+#== concurrency/channels
 my $c = Channel.new;
 start {
     $c.send($_) for 1..3;


### PR DESCRIPTION
Fixes #5310, closes PLAN §8.18.

## The problem

`start { ... }` in the playground did not just fail — it ended the session.
`spawn_callable_promise` reaches `std::thread::spawn`, which on
`wasm32-unknown-unknown` traps as `RuntimeError: unreachable` and poisons the whole
wasm instance, so every later evaluation is garbage too. The same held for `await`,
`Thread.start`, `Promise.in`, `Supply.interval` and `sleep`. Everything that needs no
second thread — `Channel`, `Supply`, `react`/`whenever`, `Lock`, `atomicint` — already
worked, so this was specifically "the wasm build cannot spawn", not "concurrency is
impossible in a browser".

Real threads are not available to the deployed site either: shared-memory wasm needs
`SharedArrayBuffer`, which needs the COOP/COEP headers GitHub Pages cannot serve.

## The approach: concurrency without parallelism

`src/runtime/wasm_sched.rs` turns every would-be thread into a task on a run queue, and
every point that would block on another thread pumps that queue instead:

```
start { ... }   -> enqueue a task, return a Planned promise
await $p        -> pump() until $p resolves
$chan.receive   -> pump() until the queue has a value
sleep 1         -> pump(), then advance the virtual clock
```

`pump()` runs a ready task, or — when none is ready — jumps a virtual clock to the
earliest timer deadline and fires it. Tasks are **deferred**, not run eagerly at spawn,
which is what makes `my $p = start { $c.receive }; $c.send(1); await $p` work.

## What that needed

- **`src/runtime/thread_compat.rs`** — one façade (`JoinHandle`, `sleep`, `mono_now`, a
  drop-in `Instant`) so the ~20 spawn sites stay written against real threads and the
  wasm build needs no `cfg` sprinkled through them.
- **One blocking-wait chokepoint.** `gc::stw_aware_wait` gained a sibling
  `gc::wait_until(&Mutex, &Condvar, ready)` that takes the lock itself, so the wasm arm
  can drop it between rounds and pump. Four call sites: promise `await`,
  `Channel.receive`, lock acquisition, semaphore acquire. A dry pump means the waiter can
  never be satisfied → it reports a deadlock rather than freezing the tab. That is the
  one case the browser cannot match natively (a task that blocks midway on a value sent
  only after it began).
- **`Instant::now()` panics on wasm32** and was quietly load-bearing in the `react` drive
  loop's 30s bound, the supply throttle/stable windows and the GC's stop-the-world
  timeout. The timer heap keys on `f64` seconds and, with no driver thread to spawn, is
  driven by the pump.
- **`ReactWaker::wait_activity`** parked on a condvar (unsupported on wasm32 too); it
  pumps now, letting the requested timeout elapse on the virtual clock when nothing is
  left that could produce.
- **Stop-the-world is trivially achieved on wasm** — one thread means the world is
  already stopped, and the rendezvous would otherwise wait on a quiescence count that
  queued, never-started tasks keep artificially high.
- **Time is real now**: `Date.now()` backs `now`/`time`/`DateTime.now`, which read 0
  before (`DateTime.now.year` was 1970). `sleep` advances the virtual clock instead of
  blocking, so `my $t = now; sleep 1; say now - $t` still says `1`.
- **`Thread.start` output no longer vanishes** into a process stdout the page cannot read.

## Verification

- **New `wasm-demo/concurrency.test.mjs`** — 28 cases driven straight from Node against
  `pkg/` (no browser), wired into the `wasm-e2e` CI job. **28/28 pass.** Every expectation
  was cross-checked against native mutsu *and* `raku`, except the two that are
  wasm-specific by construction (deterministic drain of an unawaited `start` at program
  end; deadlock reporting).
- The two tutorial lessons flagged `no-browser` (`concurrency/promises`,
  `concurrency/channels`) now run in the browser and lost the flag — PLAN §8.18's stated
  acceptance test.
- Native: `make test` (2357 files / 22346 tests) PASS; the 100 whitelisted
  `roast/S17-*` + `S32-io/lock.t` files PASS; 155 concurrency-related `t/` files PASS.

## Found on the way, not fixed here

Two or more `start` blocks written **inline as arguments** write their stale captured env
back over a variable declared after them:

```raku
my $p = Promise.allof(start { 1 }, start { 2 }); await $p; say $p.WHAT;  # Nil (raku: (Promise))
```

It reproduces on `main`, so it is not a wasm artefact, and it belongs to the env-writeback
family rather than to `Promise` — recorded in PLAN §6 next to the cell-based capture work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)