### PR TITLE
fix: &multi of a proto-less multi dispatches in map/grep/first (PLAN 8.17)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1258,52 +1258,14 @@ also fixes the parens ambiguity — `return (1 and 2)` (a complete term = 2) vs
   `Pair.new('a', $v)`** — a method-arg-binding container case, not List construction; defer with the
   rest of container-repr (§8.5-adjacent), NOT this precedence bug.
 
-### 8.16 List container aliasing — WIP deep campaign (branch `fix-list-container-aliasing`, draft PR #5290)
+### 8.16 List container aliasing — residue (main campaign MERGED 2026-07-23, PR #5290)
 
-- [ ] **A List `($a, $b)` must hold the *container* of each scalar-var element** (raku), so a later
-      mutation is visible when the List is read: `my $l=($a,$a); $a=99; say $l` → `(99 99)`;
-      `say join ",", ($a, ++$a)` → `3,3`; the fibonacci `@arr.push: ($x,$y)` trap
-      (traps.rakudoc "list-element container aliasing", cases [5]/[6]/[9]). mutsu previously
-      `Itemize`d scalar-var List elements *by value* (a snapshot), so later mutations never tracked.
-- **Approach (in progress).** Tag each scalar-var List element with `WrapVarRef` at compile time and,
-      in `exec_make_array_op` (List path), box the named local into a shared `ContainerRef` cell via
-      `capture_var_cell_inner(box_type_objects=true)` — the same primitive Captures use. The load-bearing
-      design principle: **a `ContainerRef` cell must be transparent like the old `Itemize`-Scalar** —
-      every List *consumer* that needs a value derefs the cell; every consumer that compares *identity*
-      (`=:=`) uses the cell. The deep work is making all consumers cell-aware.
-- **Done so far** (committed on branch): headline aliasing (stored/pushed/nested, `+$a` value-forcing,
-      by-value fn args, array-assign decont, bracket-array non-alias) — pin `t/list-container-aliasing.t`
-      13/13, verified vs raku. Plus the for-loop self-cycle fix (`for $a -> $v is rw` wraps its iterable
-      in `ArrayLiteral([$a])`; the loop's own `TagContainerRef`+writeback drives rw, so aliasing there
-      wrote the cell back into `$a` = self-referential cycle = infinite loop; new compiler flag
-      `suppress_list_var_alias` keeps Itemize while compiling the for-iterable — `t/for-param.t` fixed).
-- **The 3 consumers are now cell-aware ✅ (2026-07-23).** All three CI failures fixed on branch:
-  1. `t/list-dot-equals-method.t` — `($x,$y).=reverse` / `($p,$q) = ($q,$p)` swap. Root cause was
-     broader than `.=`: **every** list assignment held the RHS as live cells and read them lazily during
-     the write loop, so an earlier write corrupted a later aliased read (even a plain `($p,$q)=($q,$p)`
-     gave `35 35`). Fix: list assignment now snapshots the decontainerized RHS *prefix* into a `snap`
-     buffer up front (new `OpCode::DecontListElems` + `list_assign_prefix_count`); the greedy `@`/`%`
-     slurpy still reads the raw lazy tail from `tmp`, so `($a,$b) = 1..Inf` stays lazy. Matches raku
-     `($a,$b) = ($x,++$x)` → `4,4`.
-  2. `t/hash-itemization-flag.t` test 8 — `my %c = ($hi,)` (hash-holding scalar) inside a closure. The
-     captured `$hi` is not a frame local, so `capture_var_cell_inner` could not box it into a cell and
-     returned the bare (de-itemized) `Hash`, which `build_hash_from_items` then flattened. Fix: the
-     non-local List path (`box_type_objects`) now itemizes the value, restoring the old `Itemize`
-     non-flatten semantics for captured `$`-scalars.
-  3. `t/list-infix-comma-precedence.t` tests 24/25 — `$a,$b X!=:= $c,$d`. The cross/zip operand lists
-     now hold `ContainerRef` cells (not `VarRef`s), so the `=:=` branch in
-     `eval_reduction_operator_values` was falling through to `values_identical` (deref → both `Any` →
-     wrongly equal). Fix: added a cell-identity branch (`Gc::ptr_eq`, cell-vs-value → distinct) mirroring
-     `capture_elem_identical`. Also `capture_var_cell_inner` now resolves the `:=` alias root so
-     `$c := $b` boxes into `$b`'s cell (both lists share one cell → exactly one `=:=` pair True).
-  Pins: `t/list-dot-equals-method.t`, `t/hash-itemization-flag.t`, `t/list-infix-comma-precedence.t`
-  (plus the existing `t/list-container-aliasing.t` 13/13, `t/for-param.t`).
-- **Still open beyond the CI failures:** [7] `Pair.new('a', $v)` — `Pair.new`'s method-arg binding
-      decontainerizes, so a later `$v` mutation is not reflected (raku `a => 9`, mutsu `a => 1`). Separate
-      method-arg-binding container case; defer with the rest.
-- **State/entry.** Full campaign detail in memory `project_list_container_aliasing_campaign`. Coordinate
-      with §8.5 and [ADR-0001] container-repr — this is the first-class-scalar-container direction, do NOT
-      merge #5290 until all three consumers are cell-aware and CI is green.
+The List-holds-scalar-containers campaign landed (#5290; see [news/2026-07.md](news/2026-07.md)
+and memory `project_list_container_aliasing_campaign`). One case remains open:
+
+- [ ] **[7] `Pair.new('a', $v)`** — `Pair.new`'s method-arg binding decontainerizes, so a later
+      `$v` mutation is not reflected (raku `a => 9`, mutsu `a => 1`). Separate
+      method-arg-binding container case; coordinate with §8.5 and [ADR-0001] container-repr.
 
 ### 8.10 Object hashes are string-keyed, not `.WHICH`-keyed (deferred deep item — found 2026-07-22 by the numerics/hashmap doc-diff sweeps)
 
@@ -1406,49 +1368,30 @@ and `[Z]`-reduction-returns-a-Seq landed 2026-07-22 (pin `t/repr-residues-2.t`);
       arguably more useful, and no roast test exercises them. Matching Rakudo here is risky and
       low value; **deferred as an intentional divergence** unless a dist-compat consumer needs it.
 
-### 8.17 `&name` for a proto-less `multi` collapses to one candidate (found 2026-07-23 while writing the tutorial site)
+### 8.18 The WebAssembly build traps on `start` / `Channel` instead of degrading (found 2026-07-23 building the tutorial site)
 
-Taking a code reference to a `multi` that has **no explicit `proto`** and then invoking it as a
-value — the ordinary `.map(&f)` / `.grep(&f)` / `.sort(&f)` shape — does not multi-dispatch. It
-either calls one fixed candidate or nothing at all:
+`start { ... }` reaches `spawn_callable_promise` → `spawn_user_thread` → `std::thread::spawn`
+(`src/runtime/builtins_system.rs:13`), which on `wasm32-unknown-unknown` has no
+implementation and traps. In the browser that surfaces as `RuntimeError: unreachable`,
+which also poisons the whole wasm instance — every later evaluation in that session is
+garbage until the page rebuilds the interpreter.
 
-```raku
-multi k(Int $n) { "int $n" }
-multi k(Str $s) { "str $s" }
-say (1, "a").map(&k).join(" ");   # raku: "int 1 str a"   mutsu: "1 a"
+- Affected: `start`, `Promise` combinators that spawn, `Channel` producers, `Proc::Async`.
+  `react`/`whenever` over a `Supply.from-list` already works (no spawn), as does
+  `gather`/`take`.
+- **Likely correct fix:** on wasm, run a `start` block *synchronously* and return an
+  already-kept (or broken) `Promise`, and give `Channel` the same treatment — a
+  single-threaded scheduler is the honest semantics for a platform with one thread, and it
+  is what a reader of the concurrency chapter would expect to see work. The mechanism is one
+  `#[cfg(target_arch = "wasm32")]` arm in `spawn_callable_promise` plus the equivalent for
+  the channel/supply pumps, but the *semantics* need thought: a `start` that blocks until it
+  finishes changes the observable ordering of any program that relies on interleaving, and
+  `await` on a never-kept promise would deadlock rather than trap.
+- **Not attempted here.** The tutorial marks those two lessons `no-browser` in
+  `wasm-demo/content/lessons.txt`, so the site explains the limitation and shows the
+  recorded native output rather than a trap. Removing those flags is the acceptance test
+  for this item; `wasm-demo/e2e.test.mjs` sweeps every non-flagged lesson in a real browser.
 
-multi f(Int $n where $n %% 3) { "Fizz" }
-multi f(Int $n)               { ~$n }
-say (1..5).map(&f).join(" ");     # raku: "1 2 Fizz 4 5"  mutsu: "1 2 3 4 5"
-```
-
-Adding `proto k($) {*}` fixes it, and every *direct* call form is already correct
-(`f(3)`, `(&f)(3)`, `my &g = &f; g(3)`, `&f(3)`) — so this is specifically the
-value-carried callable path.
-
-- Route: `Interpreter::resolve_code_var` (`src/runtime/accessors_resolve.rs:302-383`). With a
-  proto it returns a by-name `Value::routine_parts`, which re-dispatches by name and is correct.
-  Without one it takes either the `def.is_some()` arm (a plain-signature candidate is reachable
-  under the unsuffixed `GLOBAL::<name>` key, so `sub_value_from_function_def` hands back that
-  ONE candidate — the `f` case) or, when no unsuffixed key exists, the `is_multi` arm that builds
-  an empty-body dispatcher Sub carrying `__mutsu_multi_dispatch_candidates` (the `k` case, which
-  then produces no output at all). `call_sub_value`
-  (`src/runtime/resolution_call_sub.rs:234-276`) does understand that dispatcher env, so the
-  fault is upstream of it: the value handed out is wrong, and its fallback ladder
-  (`bind_function_args_values` → slurpy → `candidates.first()`) ignores `where` constraints and
-  specificity ordering anyway.
-- **Likely correct fix:** make `resolve_code_var` return the by-name routine value for *any*
-  name with multi candidates (the proto path), rather than materializing a candidate or a
-  synthetic dispatcher. The captured-Sub dispatcher then only needs to survive the
-  out-of-scope case, and should reuse the real specificity-sorted dispatch
-  (`sort_candidates_by_specificity` / `push_multi_dispatch_frame`) instead of its own ladder.
-- **Why it is not a one-liner:** the `is_multi` dispatcher exists precisely so a `&multi-sub`
-  outlives its defining scope, so the by-name value must keep working after the scope exits;
-  and `resolve_code_var` is on the hot path for every `&foo`. Needs a test matrix over
-  proto/no-proto × in-scope/out-of-scope × where-constrained/type-only.
-- Repro kept at `wasm-demo/content/highlights.txt` (`why/multi` uses the direct-call form as a
-  workaround); `scripts/check-site-snippets.mjs` cross-checks against `raku` and would catch a
-  regression the moment the snippet is switched back to `&fizz`.
 
 ## Metrics
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4754,6 +4754,56 @@ quote/regex delimiter without preceding whitespace (#5281) — `multi mm($x)`, `
 `sub tr` etc. were uncallable with paren call syntax because `mm(9)` mis-parsed as an
 m:sigspace regex, `qq(5)` as a quote, `tr(5)` as a transliteration.
 
+## 2026-07-23: List container aliasing lands — a List holds the *container* of each scalar-var element (PLAN §8.16, #5290)
+
+A List `($a, $b)` now holds the container of each scalar-variable element (raku semantics),
+so a later mutation is visible when the List is read: `my $l=($a,$a); $a=99; say $l` →
+`(99 99)`; `say join ",", ($a, ++$a)` → `3,3`; the fibonacci `@arr.push: ($x,$y)` trap
+(traps.rakudoc "list-element container aliasing"). mutsu previously `Itemize`d scalar-var
+List elements *by value* (a snapshot), so later mutations never tracked.
+
+Mechanism: each scalar-var List element is tagged `WrapVarRef` at compile time and
+`exec_make_array_op` (List path) boxes the named local into a shared `ContainerRef` cell via
+`capture_var_cell_inner(box_type_objects=true)` — the same primitive Captures use. The
+design principle: a `ContainerRef` cell must be transparent like the old `Itemize`-Scalar —
+every List consumer that needs a value derefs the cell; every consumer that compares
+identity (`=:=`) uses the cell. Notable consumer fixes on the way in:
+
+- **List assignment** snapshots the decontainerized RHS *prefix* up front (new
+  `OpCode::DecontListElems` + `list_assign_prefix_count`), so `($p,$q) = ($q,$p)` swaps
+  correctly while `($a,$b) = 1..Inf` stays lazy. Matches raku `($a,$b) = ($x,++$x)` → `4,4`.
+- **Captured (non-frame-local) `$`-scalars** in the List path itemize the value, keeping the
+  old non-flatten semantics for `my %c = ($hi,)` inside a closure.
+- **`=:=` over cross/zip operand lists** got a cell-identity branch (`Gc::ptr_eq`), and
+  `capture_var_cell_inner` resolves the `:=` alias root so `$c := $b` boxes into `$b`'s cell.
+- **For-loop self-cycle**: `for $a -> $v is rw` compiles its iterable with
+  `suppress_list_var_alias` (keeps Itemize) — the loop's own `TagContainerRef`+writeback
+  drives rw, and aliasing there created a self-referential cycle (infinite loop).
+
+Pins: `t/list-container-aliasing.t` (13), `t/list-dot-equals-method.t`,
+`t/hash-itemization-flag.t`, `t/list-infix-comma-precedence.t`, `t/for-param.t`.
+Residue: `Pair.new('a', $v)` method-arg binding decontainerizes (stays in PLAN §8.16).
+
+## 2026-07-23: `&name` of a proto-less `multi` now multi-dispatches in map/grep/first (PLAN §8.17)
+
+`(1,"a").map(&k)` / `(1..5).grep(&even)` / `.first(&even)` returned the *original elements*
+(identity) when `&k` referred to a proto-less `multi`. Root cause was NOT in
+`resolve_code_var` as PLAN §8.17 hypothesized: the dispatcher Sub it builds (empty body +
+`__mutsu_multi_dispatch_candidates` env) is handled correctly by `call_sub_value` — in scope
+it re-dispatches by name (full specificity + `where` semantics), out of scope it walks the
+specificity-sorted captured candidates. The real fault: the inline fast paths in
+`eval_map_over_items` / `eval_grep_over_items_with_mutated` / `try_first_match_batched` /
+`try_native_array_map` compile `data.body` directly, and the dispatcher's empty body
+evaluates to the topic `$_` — hence identity.
+
+Fix: a shared `sub_is_call_carrier()` predicate (resolution_map_grep.rs) recognizes all
+three carrier-Sub markers (`__mutsu_routine_name`, `__mutsu_compose_left/right`,
+`__mutsu_multi_dispatch_candidates`) and every inline fast path defers such Subs to
+`call_sub_value`. This also closed a latent hole: `.first` batched-path only excluded
+composed callables, not `.assuming` wrappers. Out-of-scope `where`-constraint dispatch was
+verified already correct (candidates are specificity-sorted at capture time by
+`resolve_all_multi_candidates`). Pin: `t/multi-ref-dispatch.t` (14 tests, raku-verified).
+
 ## References
 
 - The whitelist stands at **1338** as of this writing (2026-07-01, at `4c311c71`).

--- a/src/runtime/resolution_map_grep.rs
+++ b/src/runtime/resolution_map_grep.rs
@@ -39,6 +39,20 @@ pub(crate) fn whatever_code_keeps_outer_topic(data: &SubData) -> bool {
     ) && !data.params.iter().any(|p| p == "_")
 }
 
+/// A carrier Sub delegates its behaviour through env markers instead of its
+/// own body: an `.assuming` routine wrapper (`__mutsu_routine_name`), a
+/// composed callable (`__mutsu_compose_left`/`right`), or the multi-candidate
+/// dispatcher built by `resolve_code_var` for a proto-less `&some-multi`
+/// (`__mutsu_multi_dispatch_candidates`). Its `data.body` is empty, so any
+/// fast path that compiles the body inline would silently evaluate to the
+/// topic; such Subs must always go through `call_sub_value`, which resolves
+/// the markers.
+pub(crate) fn sub_is_call_carrier(data: &SubData) -> bool {
+    data.env.contains_key("__mutsu_routine_name")
+        || data.env.contains_key("__mutsu_compose_left")
+        || data.env.contains_key("__mutsu_multi_dispatch_candidates")
+}
+
 /// Bind `$_`/`_` for one iteration of a batched map/grep/first loop.
 ///
 /// For a `$_`-referencing WhateverCode the topic is held at `outer_topic` for
@@ -272,34 +286,9 @@ impl Interpreter {
             } else {
                 1
             };
-            // Routine wrapper from .assuming() on a builtin — delegate to call_sub_value
-            // which knows how to resolve __mutsu_routine_name.
-            if data.env.contains_key("__mutsu_routine_name") {
-                let mut result = Vec::new();
-                let mut i = 0usize;
-                while i < list_items.len() {
-                    if arity > 1 && i + arity > list_items.len() {
-                        return Err(RuntimeError::new("Not enough elements for map block arity"));
-                    }
-                    let chunk: Vec<Value> = if arity == 1 {
-                        vec![list_items[i].clone()]
-                    } else {
-                        list_items[i..i + arity].to_vec()
-                    };
-                    let value =
-                        self.call_sub_value(Value::sub_value(data.clone()), chunk, false)?;
-                    let value = self.reify_finite_pipe_value(value)?;
-                    match value.view() {
-                        ValueView::Slip(elems) => result.extend(elems.iter().cloned()),
-                        _ => result.push(value),
-                    }
-                    i += arity;
-                }
-                return Ok(Value::array(result));
-            }
-            if data.env.contains_key("__mutsu_compose_left")
-                && data.env.contains_key("__mutsu_compose_right")
-            {
+            // Carrier Subs (.assuming wrapper, composed callable, multi-candidate
+            // dispatcher) — delegate to call_sub_value which resolves the markers.
+            if sub_is_call_carrier(&data) {
                 let mut result = Vec::new();
                 let mut i = 0usize;
                 while i < list_items.len() {
@@ -595,9 +584,7 @@ impl Interpreter {
         if !data.assumed_positional.is_empty() || !data.assumed_named.is_empty() {
             return None;
         }
-        if data.env.contains_key("__mutsu_compose_left")
-            && data.env.contains_key("__mutsu_compose_right")
-        {
+        if sub_is_call_carrier(&data) {
             return None;
         }
         // A multi-param matcher block would take element tuples; `.first` has

--- a/src/runtime/resolution_map_grep_rw.rs
+++ b/src/runtime/resolution_map_grep_rw.rs
@@ -44,8 +44,7 @@ impl Interpreter {
                 && crate::ast::collect_placeholders_shallow(&data.body).is_empty();
             if requires_full_binding
                 || is_routine_callback
-                || data.env.contains_key("__mutsu_routine_name")
-                || data.env.contains_key("__mutsu_compose_left")
+                || super::resolution_map_grep::sub_is_call_carrier(&data)
             {
                 // Fall through to call_sub_value path for complex cases
                 let mut result = Vec::new();
@@ -295,9 +294,9 @@ impl Interpreter {
             } else {
                 1
             };
-            if data.env.contains_key("__mutsu_compose_left")
-                && data.env.contains_key("__mutsu_compose_right")
-            {
+            // Carrier Subs (.assuming wrapper, composed callable, multi-candidate
+            // dispatcher) — delegate to call_sub_value which resolves the markers.
+            if super::resolution_map_grep::sub_is_call_carrier(&data) {
                 let mut i = 0usize;
                 while i < list_items.len() {
                     if arity > 1 && i + arity > list_items.len() {

--- a/src/vm/vm_native_map.rs
+++ b/src/vm/vm_native_map.rs
@@ -73,10 +73,7 @@ impl Interpreter {
         if !data.assumed_positional.is_empty() || !data.assumed_named.is_empty() {
             return None;
         }
-        if data.env.contains_key("__mutsu_routine_name")
-            || data.env.contains_key("__mutsu_compose_left")
-            || data.env.contains_key("__mutsu_compose_right")
-        {
+        if crate::runtime::resolution_map_grep::sub_is_call_carrier(&data) {
             return None;
         }
         let requires_full_binding = data.param_defs.iter().any(|pd| {

--- a/t/multi-ref-dispatch.t
+++ b/t/multi-ref-dispatch.t
@@ -1,0 +1,54 @@
+use v6;
+use Test;
+
+# &name of a proto-less multi must multi-dispatch when carried as a value
+# into map/grep/first/sort (PLAN §8.17). The dispatcher Sub built by
+# resolve_code_var has an empty body; inline fast paths that compile the
+# body directly must defer to call_sub_value (sub_is_call_carrier).
+
+plan 14;
+
+multi k(Int $n) { "int $n" }
+multi k(Str $s) { "str $s" }
+
+is (1, "a").map(&k).join(" "), "int 1 str a", 'List.map(&multi) dispatches by type';
+
+multi f(Int $n where $n %% 3) { "Fizz" }
+multi f(Int $n)               { ~$n }
+
+is (1..5).map(&f).join(" "), "1 2 Fizz 4 5", 'Range.map(&multi) honours where constraints';
+
+my @a = 1, 2, 3, 4, 5, 6;
+is @a.map(&f).join(" "), "1 2 Fizz 4 5 Fizz", 'Array.map(&multi) dispatches';
+
+multi even(Int $n) { $n %% 2 }
+multi even(Str $s) { False }
+
+is (1, 2, 3, "x", 4).grep(&even).join(","), "2,4", '.grep(&multi) dispatches';
+is @a.grep(&even).join(","), "2,4,6", 'Array.grep(&multi) dispatches';
+is (1..5).first(&even), 2, '.first(&multi) dispatches';
+is (5, 1, 2).first(&even, :end), 2, '.first(&multi, :end) dispatches';
+
+is (map &f, 1..5).join(" "), "1 2 Fizz 4 5", 'map &multi, list (function form)';
+is (grep &even, 1..5).join(","), "2,4", 'grep &multi, list (function form)';
+is (first &even, 1..5), 2, 'first &multi, list (function form)';
+
+multi neg(Int $n) { -$n }
+multi neg(Str $s) { $s }
+is (3, 1, 2).sort(&neg).join(","), "3,2,1", '.sort(&multi) dispatches';
+
+multi parity(Int $n) { $n %% 2 ?? "even" !! "odd" }
+multi parity(Str $s) { "str" }
+is (1..4).classify(&parity).sort(*.key).map({ .key ~ ":" ~ .value.join("|") }).join(" "),
+    "even:2|4 odd:1|3", '.classify(&multi) dispatches';
+
+# The captured dispatcher must keep working after the defining scope exits,
+# including where-constraint candidates (specificity-sorted capture).
+my &saved;
+{
+    multi g(Int $n where $n %% 3) { "Fizz" }
+    multi g(Int $n) { ~$n }
+    &saved = &g;
+}
+is saved(3), "Fizz", 'out-of-scope &multi honours where constraints';
+is (1..5).map(&saved).join(" "), "1 2 Fizz 4 5", 'out-of-scope &multi works in map';

--- a/wasm-demo/content/highlights.txt
+++ b/wasm-demo/content/highlights.txt
@@ -40,7 +40,7 @@ multi fizz(Int $n where $n %% 15) { "FizzBuzz" }
 multi fizz(Int $n where $n %%  3) { "Fizz"     }
 multi fizz(Int $n where $n %%  5) { "Buzz"     }
 multi fizz(Int $n)                { ~$n        }
-say (1..15).map({ fizz($_) }).join(" ");
+say (1..15).map(&fizz).join(" ");
 #-- expect
 1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz 11 Fizz 13 14 FizzBuzz
 


### PR DESCRIPTION
## Summary

`(1,"a").map(&k)` / `(1..5).grep(&even)` / `.first(&even)` with a **proto-less `multi`** returned the original elements unchanged (identity) instead of multi-dispatching:

```raku
multi k(Int $n) { "int $n" }
multi k(Str $s) { "str $s" }
say (1, "a").map(&k).join(" ");   # raku: "int 1 str a"   mutsu (before): "1 a"

multi f(Int $n where $n %% 3) { "Fizz" }
multi f(Int $n)               { ~$n }
say (1..5).map(&f).join(" ");     # raku: "1 2 Fizz 4 5"  mutsu (before): "1 2 3 4 5"
```

## Root cause

Not in `resolve_code_var` as PLAN §8.17 hypothesized — the dispatcher Sub it builds (empty body + `__mutsu_multi_dispatch_candidates` env) is handled correctly by `call_sub_value`: in scope it re-dispatches by name (full specificity + `where` semantics), out of scope it walks the specificity-sorted captured candidates (verified: out-of-scope `where` dispatch already matches raku).

The real fault: the inline fast paths in `eval_map_over_items`, `eval_grep_over_items_with_mutated`, `try_first_match_batched`, and `try_native_array_map` compile `data.body` directly — and the dispatcher's **empty body evaluates to the topic `$_`**, hence identity.

## Fix

A shared `sub_is_call_carrier()` predicate (`resolution_map_grep.rs`) recognizes all three carrier-Sub markers (`__mutsu_routine_name`, `__mutsu_compose_left/right`, `__mutsu_multi_dispatch_candidates`); every inline fast path now defers such Subs to `call_sub_value`. This replaces the scattered per-site marker checks (the two identical loops in `eval_map_over_items` are merged) and closes a latent hole: `.first`'s batched path only excluded composed callables, not `.assuming` wrappers.

Also:
- `wasm-demo/content/highlights.txt` `why/multi` drops its direct-call workaround (`.map(&fizz)` now); `node scripts/check-site-snippets.mjs` = 44/44 ok.
- PLAN.md: §8.17 removed; §8.16 condensed to its residue (#5290 merged). Details moved to `news/2026-07.md`.

## Testing

- New pin: `t/multi-ref-dispatch.t` (14 tests) — map/grep/first/sort/classify × method/function forms × in-scope/out-of-scope × where-constrained; raku-verified.
- `make test`: 2362 files, 22412 tests, all pass.
- Targeted roast: `S32-list/{map,grep,first}.t`, `S06-multi/{type-based,proto}.t` all pass.
- Broader mutsu-vs-raku sweep (classify/categorize/min/max/reduce/mixed-arity): identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)