### PR TITLE
fix: `Regex.ACCEPTS($str)` returns the Match instead of throwing

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -640,7 +640,7 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 ### T-057 — test_die batch (seed-555, un-triaged)  [impact: several dists]
 - dists (each its own root cause; triage individually before claiming, confirm the
   raku `-I lib` baseline first): ~~Attribute::Predicate~~ (FIXED — see Done),
-  File::Ignore,
+  File::Ignore (PARTIAL — module now loads via Regex.ACCEPTS fix; see Done),
   IO::Path::AutoDecompress, ~~Math::Angle~~ (FIXED — see Done), Math::PascalTriangle,
   ~~Statistics::LinearRegression~~ (FIXED — see Done), String::Rotate,
   Text::CodeProcessing, Trait::IO, WriteOnceHash, `are`, `sortuk`,
@@ -942,3 +942,16 @@ _(move tickets here with `[claim: <branch>]` when you start)_
   preserved) then dispatches `@arr.push(…)` (`compiler/expr_call.rs`). Math::Angle's
   `sub sexagesimal` does `push my @units, $!angle × rad2deg`. Pin:
   `t/push-inline-array-decl.t`.
+
+- **T-057 (File::Ignore)** (PR `feat-regex-accepts`) — test_die → PARTIAL (0 ran →
+  charclass/literal/path fully pass). One general bug: `$regex.ACCEPTS($str)` threw
+  "No such method 'ACCEPTS' for invocant of type 'Regex'". `.ACCEPTS` on a Regex
+  matches the regex against its argument and returns the **Match** (like
+  `$str ~~ $rx`), not a Bool; File::Ignore's `ignore-file` does
+  `$pattern.ACCEPTS($path)`. Added a Regex/RegexWithAdverbs arm in
+  `call_method_with_values` that reuses the string `.match` path
+  (`runtime/methods_call_dispatch.rs`). Pin: `t/regex-accepts-method.t`.
+  Residual File::Ignore failures are separate gitignore-pattern-semantics bugs
+  (negated-rule precedence, directory-only `dir*/`, globstar `a/**/b`, charclass
+  ranges in negated.t/range.t/wildcard.t, and `walk`) — each its own root cause,
+  deferred.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -80,6 +80,20 @@ impl Interpreter {
             }
             return Err(RuntimeError::emit_signal(target));
         }
+        // `Regex.ACCEPTS($str)` matches the regex (the invocant) against the
+        // argument and returns the Match (like `$str ~~ $rx`), NOT a Bool. Reuse
+        // the string `.match` path (`$str.match($rx)`), which drives the regex
+        // engine and builds the Match object. Needs the interpreter, so it lives
+        // here rather than on the pure native fast path.
+        if method == "ACCEPTS"
+            && args.len() == 1
+            && matches!(
+                target.view(),
+                ValueView::Regex(_) | ValueView::RegexWithAdverbs(_)
+            )
+        {
+            return self.dispatch_match_method(args[0].clone(), std::slice::from_ref(&target));
+        }
         // `Mu.ACCEPTS`: every value can be smart-matched against, and `$x.ACCEPTS($y)` is
         // just `$y ~~ $x`. The builtins carry their own ACCEPTS for the container types
         // (Range, Set, Bag, Pair, ...) and a user class may define one, so this only backs

--- a/t/regex-accepts-method.t
+++ b/t/regex-accepts-method.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+# `$regex.ACCEPTS($str)` matches the regex against the string and returns the
+# Match (like `$str ~~ $rx`), NOT a Bool. It used to throw
+# "No such method 'ACCEPTS' for invocant of type 'Regex'". Regression pin for
+# File::Ignore, whose ignore-file does `$pattern.ACCEPTS($path)`.
+
+plan 10;
+
+# A successful match returns a truthy Match stringifying to the matched text.
+is /foo/.ACCEPTS('foobar').Str, 'foo', 'ACCEPTS returns the Match on success';
+ok /foo/.ACCEPTS('foobar'),           'the returned Match is truthy';
+is /foo/.ACCEPTS('xfoox').Str, 'foo', 'ACCEPTS matches anywhere in the string';
+
+# A failed match is falsy (Nil).
+nok /foo/.ACCEPTS('bar'),             'ACCEPTS is falsy on no match';
+ok  /foo/.ACCEPTS('bar') ~~ Nil,      'ACCEPTS returns Nil on no match';
+
+# Works through a variable-bound regex.
+my $rx = rx/\d+/;
+ok  $rx.ACCEPTS('a5b'),               'ACCEPTS on a bound regex, match';
+nok $rx.ACCEPTS('abc'),               'ACCEPTS on a bound regex, no match';
+
+# Captures are accessible on the returned Match.
+is /(\d+)/.ACCEPTS('ab12cd')[0].Str, '12', 'ACCEPTS Match exposes captures';
+
+# `so` coerces the Match to Bool, matching smartmatch.
+is (so /foo/.ACCEPTS('foobar')), True,  'so ACCEPTS == True on match';
+is (so /foo/.ACCEPTS('bar')),    False, 'so ACCEPTS == False on no match';


### PR DESCRIPTION
## Summary

`$regex.ACCEPTS($str)` threw `No such method 'ACCEPTS' for invocant of type 'Regex'`.

`.ACCEPTS` on a Regex matches the regex (the invocant) against its argument and
returns the resulting **Match** — the same value as `$str ~~ $rx` — not a Bool.
It is the smartmatch primitive, so a module that stores compiled regexes and
applies them via `$pattern.ACCEPTS($path)` could not run at all.

```raku
/foo/.ACCEPTS('foobar')      # was: throw;  now: ｢foo｣  (a Match)
/foo/.ACCEPTS('bar')         # was: throw;  now: Nil
/(\d+)/.ACCEPTS('ab12cd')[0] # was: throw;  now: ｢12｣ (captures work)
so /foo/.ACCEPTS('bar')      # was: throw;  now: False
```

Added a `Regex`/`RegexWithAdverbs` arm to `call_method_with_values` that reuses
the string `.match` path (`$str.match($rx)`), which drives the regex engine and
builds the Match (captures, `.Str`, truthiness all work); a failed match returns
`Nil`, matching Rakudo. It sits next to the existing `Mu.ACCEPTS` fallback (both
need the interpreter's regex engine).

## Impact

Unblocks the **File::Ignore** distribution (T-057 batch), whose `ignore-file`
does `$pattern.ACCEPTS($path)`. The module now loads and its
`charclass`/`literal`/`path` test files pass fully (0 tests ran → those pass).
The remaining File::Ignore failures are separate gitignore-pattern-semantics
bugs (negated-rule precedence, directory-only `dir*/`, globstar `a/**/b`,
charclass ranges) — each its own root cause, recorded in the ticket as deferred.

## Testing

- New pin `t/regex-accepts-method.t` (10 tests), passes under mutsu **and** raku.
- Full `make test`: 22421 tests, Result: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)