### PR TITLE
fix: generic .WHERE — every value answers with a per-identity-stable Int

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1155,6 +1155,12 @@ the backlog.
   - Niche/parser one-offs (lower priority): extended identifiers in variable names
     (`my $foo:bar<baz>`), Win32 `IO::Path` backslash semantics, `Thread.run`/`Thread.start`,
     declarator-pod `.WHY` on a `&sub`, `X::AdHoc+{X::Promise::Broken}` role-mixin in `.^name`.
+  - **`&f` re-materializes a fresh Sub per mention** (found 2026-07-23 by the generic-WHERE
+    slice): `sub f() {1}; &f.WHICH` differs across two mentions (`Sub|27` then `Sub|29`;
+    raku: stable) because `sub_value_from_function_def` builds a new `SubData` (fresh id +
+    fresh env snapshot) on every `resolve_code_var`. `&f === &f` masks it via fingerprint
+    comparison, and `&f.WHERE` inherits the instability. A stable per-`FunctionDef` identity
+    interacts with wrap-chain ids (`wrap_chains` is keyed by `data.id`) — not a small slice.
 
 ### 8.2 Documented-surface coverage (doc examples + method matrix)
 

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -528,6 +528,29 @@ pub(super) fn dispatch(
                 attrs,
             ))))
         }
+        "WHERE" => {
+            // Rakudo: `.WHERE` is the object's memory address as an Int.
+            // mutsu's scalar values are unboxed (no stable address to report),
+            // so derive a per-identity-stable Int from the WHICH identity
+            // string instead: reference types embed their allocation address /
+            // object id in it, value types their value. This preserves the
+            // observable contract (same object => same WHERE, distinct
+            // objects => distinct) without pinnable addresses.
+            let which_str = match dispatch(target, "WHICH") {
+                Some(Some(Ok(objat))) => match objat.view() {
+                    ValueView::Instance { attributes, .. } => attributes
+                        .as_map()
+                        .get("WHICH")
+                        .map(|v| v.to_string_value()),
+                    _ => None,
+                },
+                _ => None,
+            }?;
+            use std::hash::{Hash, Hasher};
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            which_str.hash(&mut hasher);
+            Some(Some(Ok(Value::int((hasher.finish() >> 1) as i64))))
+        }
         "Bool" => {
             if matches!(target.view(), ValueView::Instance { .. })
                 && (target.does_check("Real") || target.does_check("Numeric"))

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1736,27 +1736,6 @@ impl Interpreter {
                 }
                 _ => Ok(Value::str(target.to_string_value())),
             },
-            "WHERE" if args.is_empty() => {
-                let type_obj_name = match target.view() {
-                    ValueView::Package(name) => Some(name.resolve()),
-                    ValueView::Str(name) => Some(name.to_string()),
-                    _ => None,
-                };
-                if let Some(name) = type_obj_name {
-                    if !self.registry().roles.contains_key(&name) {
-                        return Err(RuntimeError::new(format!(
-                            "X::Method::NotFound: Unknown method value dispatch (fallback disabled): {}",
-                            method
-                        )));
-                    }
-                    Ok(Value::str(format!("{}|type-object", name)))
-                } else {
-                    Err(RuntimeError::new(format!(
-                        "X::Method::NotFound: Unknown method value dispatch (fallback disabled): {}",
-                        method
-                    )))
-                }
-            }
             "raku" | "perl" if args.is_empty() => match target.view() {
                 ValueView::Package(name) => Ok(Value::str(name.resolve())),
                 ValueView::Junction { kind, values } => {

--- a/src/runtime/methods_sub.rs
+++ b/src/runtime/methods_sub.rs
@@ -359,11 +359,6 @@ impl Interpreter {
         method: &str,
         args: Vec<Value>,
     ) -> Option<Result<Value, RuntimeError>> {
-        if method == "WHERE" && args.is_empty() {
-            // Rakudo: the object's memory address. Any per-object-stable Int
-            // is compatible (addresses are not pinnable); use the sub's id.
-            return Some(Ok(Value::int(data.id as i64)));
-        }
         if method == "nextwith" {
             // Tail-style dispatch: call target with caller frame and return from current frame.
             let saved_env = self.env.clone();

--- a/t/generic-where.t
+++ b/t/generic-where.t
@@ -1,0 +1,46 @@
+use v6;
+use Test;
+
+# Generic .WHERE: every value answers .WHERE with an Int that is stable per
+# identity (same object => same WHERE, distinct objects => distinct). mutsu
+# derives it from the WHICH identity string since scalar values are unboxed
+# (Rakudo reports the boxed object's memory address).
+
+plan 20;
+
+ok 42.WHERE ~~ Int, '42.WHERE is an Int';
+ok 42.WHERE == 42.WHERE, 'same Int value, same WHERE';
+nok 42.WHERE == 43.WHERE, 'different Int value, different WHERE';
+ok "abc".WHERE ~~ Int, 'Str.WHERE is an Int';
+ok 1.5.WHERE ~~ Int, 'Num.WHERE is an Int';
+ok (1/3).WHERE ~~ Int, 'Rat.WHERE is an Int';
+ok (2+3i).WHERE ~~ Int, 'Complex.WHERE is an Int';
+ok True.WHERE ~~ Int, 'Bool.WHERE is an Int';
+ok (1..5).WHERE ~~ Int, 'Range.WHERE is an Int';
+
+my @a = 1, 2;
+my @b = 1, 2;
+ok @a.WHERE ~~ Int, 'Array.WHERE is an Int';
+ok @a.WHERE == @a.WHERE, 'same array, same WHERE';
+nok @a.WHERE == @b.WHERE, 'distinct arrays differ even with equal contents';
+
+my %h = a => 1;
+ok %h.WHERE ~~ Int, 'Hash.WHERE is an Int';
+
+ok Int.WHERE ~~ Int, 'type object WHERE is an Int';
+ok Any.WHERE ~~ Int, 'Any.WHERE is an Int';
+
+class C { }
+my $c = C.new;
+my $d = C.new;
+ok $c.WHERE == $c.WHERE, 'same instance, same WHERE';
+nok $c.WHERE == $d.WHERE, 'distinct instances differ';
+
+role R { }
+ok R.WHERE ~~ Int, 'role type object WHERE is an Int';
+
+enum E <A B>;
+ok A.WHERE == A.WHERE, 'enum value WHERE is stable';
+
+sub f() { 1 }
+ok &f.WHERE ~~ Int, 'Sub.WHERE is an Int';


### PR DESCRIPTION
## Summary

`42.WHERE` (and `.WHERE` on Str/Num/Rat/Complex/Bool/Range/Array/Hash/instances/type objects/roles/enums) died with `X::Method::NotFound`; only Sub had a WHERE arm (#5313). Now every value answers `.WHERE` with an Int, matching raku on all probes.

## Implementation

WHERE is implemented once, in the native 0-arg dispatch (`dispatch_core_coerce.rs`), derived by hashing the WHICH identity string: reference types embed their allocation address / object id in it, value types their value. This preserves `.WHERE`'s observable contract — same object ⇒ same WHERE, distinct objects ⇒ distinct (`@a.WHERE != @b.WHERE` even with equal contents) — without pinnable addresses, which mutsu's unboxed scalar representation cannot provide.

The two scattered arms are deleted so WHERE has exactly one implementation:
- `methods_sub.rs` — Sub `WHERE` = `data.id`
- `methods_instance_ops.rs` — role type-object fallback returning a `"R|type-object"` **Str** (wrong type vs raku's Int; nothing depended on it)

## Known residue (recorded in PLAN.md)

`&f` re-materializes a fresh Sub per mention (`sub_value_from_function_def` builds a new SubData + env snapshot each `resolve_code_var`), so `&f.WHERE == &f.WHERE` is False — but this is the pre-existing `&f.WHICH` instability (`Sub|27` then `Sub|29`), which WHERE merely inherits. A stable per-FunctionDef identity interacts with wrap-chain ids (`wrap_chains` keys on `data.id`) and is a separate slice; noted in PLAN §8's campaign list.

## Testing

- New pin: `t/generic-where.t` (20 tests) — passes under both mutsu and raku.
- Broad mutsu-vs-raku probe sweep (23 expressions incl. `>>.WHERE`, enum, Set, Seq, pi, bound scalars): identical output.
- `make test`: all pass (exit 0).
- `cargo fmt` / `cargo clippy`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)