### PR TITLE
fix: `@`-sigil `is copy` param is a mutable Array copy of a List arg

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -643,7 +643,7 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   File::Ignore (PARTIAL — module now loads via Regex.ACCEPTS fix; see Done),
   IO::Path::AutoDecompress, ~~Math::Angle~~ (FIXED — see Done), Math::PascalTriangle,
   ~~Statistics::LinearRegression~~ (FIXED — see Done), String::Rotate,
-  Text::CodeProcessing, Trait::IO, WriteOnceHash, `are`, `sortuk`,
+  Text::CodeProcessing, Trait::IO, WriteOnceHash, `are`, ~~`sortuk`~~ (FIXED — see Done),
   Tree::Binary::PrettyTree (required role method not seen as implemented).
 - These `test_die` on the current binary but were not individually reproduced.
   Split off a dedicated ticket when you pick one up.
@@ -955,3 +955,14 @@ _(move tickets here with `[claim: <branch>]` when you start)_
   (negated-rule precedence, directory-only `dir*/`, globstar `a/**/b`, charclass
   ranges in negated.t/range.t/wildcard.t, and `walk`) — each its own root cause,
   deferred.
+
+- **T-057 (SortUk)** (PR `fix-array-is-copy-list-arg`) — test_die → t/01-basic.t
+  4/4 (00-meta.t needs the uninstalled `Test::META` dep, same as raku). One general
+  bug: an `@`-sigil `is copy` param bound to an (immutable) List argument
+  (`f(<x y>)`, `f((1,2))`) kept the List kind, so `@d[0] = …` / `.push` /
+  `(@d[0],@d[1]).=reverse` inside the sub threw "Cannot modify an immutable List"
+  (a real-Array argument already worked). `detach_shared_container` preserves the
+  array kind, so `is copy` now reifies an `ArrayKind::List`/`ItemList` value bound
+  to an `@` param into a fresh real Array (`runtime/types/binding_signature.rs`).
+  SortUk's sort loop does `(@data[$w1],@data[$w2]).=reverse` on `@data is copy`.
+  Pin: `t/array-is-copy-list-arg.t`.

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -1331,6 +1331,23 @@ impl Interpreter {
                     // caller's `@a`.
                     if is_copy {
                         value = value.detach_shared_container();
+                        // A `@`-sigil `is copy` param is a *mutable Array* copy of
+                        // its argument, even when the argument is an (immutable)
+                        // List (`f(<x y>)`, `f((1,2))`): `@d[0] = …`, `.push`, and
+                        // `.=reverse` must work. `detach_shared_container` preserves
+                        // the `List` kind, so element assignment was still rejected
+                        // as "Cannot modify an immutable List". Reify any list-kind
+                        // value into a fresh real Array (keeping its element data /
+                        // type metadata). A real-Array argument already detached above.
+                        if pd.name.starts_with('@')
+                            && let ValueView::Array(gc, ArrayKind::List | ArrayKind::ItemList) =
+                                value.view()
+                        {
+                            value = Value::array_with_kind(
+                                crate::gc::Gc::new((**gc).clone()),
+                                ArrayKind::Array,
+                            );
+                        }
                     }
                     if pd.sigilless {
                         let alias_key = sigilless_alias_key(&pd.name);

--- a/t/array-is-copy-list-arg.t
+++ b/t/array-is-copy-list-arg.t
@@ -1,0 +1,65 @@
+use v6;
+use Test;
+
+# An `@`-sigil `is copy` parameter is a *mutable Array* copy of its argument,
+# even when the argument is an (immutable) List (`<x y>`, `(1,2)`). Element
+# assignment, `.push`, and `(@a[i],@a[j]).=reverse` must all work inside the
+# sub; without the fix they threw "Cannot modify an immutable List". The copy
+# is distinct, so the caller's data is never mutated. Regression pin for SortUk.
+
+plan 10;
+
+{
+    sub f(@d is copy) { @d[0] = 99; @d }
+    is-deeply f(<x y>), [99, 'y'], 'element assign on is-copy of a <> List';
+    is-deeply f((1, 2)), [99, 2],  'element assign on is-copy of a () List';
+}
+
+{
+    sub f(@d is copy) { @d.push(9); @d }
+    is-deeply f(<x y>), ['x', 'y', 9], 'push on is-copy of a List (result is an Array)';
+}
+
+{
+    # The gitignore-swap shape used by SortUk's sort loop.
+    sub swap(@d is copy) { (@d[0], @d[1]).=reverse; @d }
+    is-deeply swap(<a b>), ['b', 'a'], '(@d[0],@d[1]).=reverse swaps elements';
+}
+
+{
+    # A real-Array argument is copied, not aliased: the caller is untouched.
+    sub f(@d is copy) { @d[0] = 99; @d }
+    my @a = 1, 2;
+    is-deeply f(@a), [99, 2], 'is-copy of an Array mutates the copy';
+    is-deeply @a, [1, 2],     'the caller Array is unchanged (distinct copy)';
+}
+
+{
+    # A List argument is likewise copied; mutating the param keeps its size.
+    sub f(@d is copy) { @d[0] = 'Z'; @d.elems }
+    is f(<a b c>), 3, 'is-copy List keeps its elements';
+}
+
+{
+    # Repeated push (statement-modifier `for`) on the copy accumulates.
+    sub build(@d is copy) {
+        @d.push($_) for 10, 20, 30;
+        @d
+    }
+    is-deeply build(<s t>), ['s', 't', 10, 20, 30], 'repeated push on is-copy List';
+}
+
+{
+    # Nested: an inner element read after a swap sees the swapped value.
+    sub f(@d is copy) {
+        (@d[0], @d[2]).=reverse;
+        @d[0]
+    }
+    is f(<p q r>), 'r', 'read after in-place element swap on is-copy List';
+}
+
+{
+    # `is copy` of an empty List still yields a mutable Array.
+    sub f(@d is copy) { @d.push(1); @d }
+    is-deeply f(()), [1], 'push onto is-copy of an empty List';
+}


### PR DESCRIPTION
## Summary

An `@`-sigil `is copy` parameter bound to an (immutable) **List** argument
(`f(<x y>)`, `f((1,2))`) kept the `List` kind, so element assignment / `.push` /
`(@d[0],@d[1]).=reverse` inside the sub threw **"Cannot modify an immutable
List"**. A real-`Array` argument already worked (it was detached into a mutable
copy); only the list-kind case was wrong.

```raku
sub f(@d is copy) { @d[0] = 99; @d }
f(<x y>);   # was: throw;  now: [99 y]
f((1, 2));  # was: throw;  now: [99 2]

sub swap(@d is copy) { (@d[0], @d[1]).=reverse; @d }
swap(<a b>); # was: throw;  now: [b a]
```

`detach_shared_container` (invoked for `is copy`) preserves the array kind, so an
`ArrayKind::List`/`ItemList` value stayed immutable. Now an `@`-sigil `is copy`
param reifies a list-kind value into a fresh real `Array` (cloning its element
data / type metadata). The copy is distinct, so the caller's data is still never
mutated (verified in the pin).

## Impact

Fixes the **SortUk** distribution (T-057 batch): its sort loop does
`(@data[$w1],@data[$w2]).=reverse` on a `@data is copy` parameter. `t/01-basic.t`
now passes 4/4 (`t/00-meta.t` needs the uninstalled `Test::META` dependency, same
as raku).

## Testing

- New pin `t/array-is-copy-list-arg.t` (10 tests), passes under mutsu **and** raku.
- Full `make test`: 22433 tests, Result: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)