### PR TITLE
feat: make the Pages site mutsu's home page, not a WASM demo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,6 +46,18 @@ jobs:
           wasm-pack build --target web --no-default-features --features wasm
           mv pkg wasm-demo/pkg
 
+      - name: Record compatibility stats
+        # The landing page headlines "N% of the official spec files pass". Count
+        # it here rather than hand-writing it into the copy, so the figure cannot
+        # drift away from the suite (the README's did). The site falls back to a
+        # baked-in number when this file is absent, i.e. in a local checkout.
+        run: |
+          pass=$(grep -c . roast-whitelist.txt)
+          total=$(find roast -name '*.t' -type f | wc -l)
+          printf '{"roastPass":%d,"roastTotal":%d}\n' "$pass" "$total" \
+            > wasm-demo/content/stats.json
+          cat wasm-demo/content/stats.json
+
       - name: Render bench-trend dashboard
         # Pull the perf history from the bench-data branch and render it into the
         # deployed site as bench-trend.html, so the trend is viewable at

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ target-local/
 # e2e suite) from the bench-data branch's history.
 /wasm-demo/bench-trend.html
 /wasm-demo/.bench-history.e2e.tsv
+# Compatibility numbers counted at deploy time by pages.yml (the landing page
+# falls back to a baked-in figure when it is absent).
+/wasm-demo/content/stats.json
 /node_modules/
 /package.json
 /package-lock.json

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ A Raku (Perl 6) interpreter written in Rust, using a bytecode VM architecture.
 
 mutsu parses Raku source into an AST, compiles it to bytecode, and executes it on a custom VM. It is under active development and improving rapidly, but is **not yet suitable for production use**.
 
-Try it in your browser: **https://tokuhirom.github.io/mutsu/** — an introduction to
-Raku (English / 日本語) with a [hands-on tutorial](https://tokuhirom.github.io/mutsu/tutorial.html)
-and a [playground](https://tokuhirom.github.io/mutsu/playground.html), all running
-locally as WebAssembly.
+**https://tokuhirom.github.io/mutsu/** (English / 日本語) introduces the project and
+the language, with a [hands-on Raku tutorial](https://tokuhirom.github.io/mutsu/tutorial.html)
+and a [playground](https://tokuhirom.github.io/mutsu/playground.html). Everything on
+it runs locally as WebAssembly — the site is running mutsu itself.
 
 ## Install
 
@@ -29,8 +29,8 @@ mzef --version                            # the bundled Zef package manager
 The release archive is self-contained: `bin/mutsu`, `bin/mzef`, and the
 vendored Zef tree at `share/mutsu/zef`. `mzef` is a thin shim that runs the
 bundled Zef under `mutsu`, so `mzef install <dist>` works out of the box with no
-extra setup. Linux (x64/arm64) binaries are published each release; macOS builds
-are best-effort while an upstream toolchain issue is resolved.
+extra setup. Every release publishes all four targets: Linux x64/arm64 and macOS
+x64/arm64.
 
 ### With Docker
 
@@ -94,7 +94,7 @@ For interactive use:
 
 ## Status
 
-mutsu passes **1,145 out of ~1,460** official [Roast](https://github.com/Raku/roast) test files. Compatibility is improving daily.
+mutsu passes **1,433 out of 1,464** official [Roast](https://github.com/Raku/roast) test files in full. Compatibility is improving daily; the [site](https://tokuhirom.github.io/mutsu/) shows the figure counted at its last deploy.
 
 ## What Works
 
@@ -254,7 +254,7 @@ Usage:
 - **Single-threaded execution.** `start`/`await` work but run on a single thread.
 - **Incomplete container semantics.** Some binding and container behaviors differ from Rakudo.
 - **Limited exception types.** Not all `X::` exception classes are implemented.
-- **No package manager integration.** There is no zef/ecosystem support; `use` works for local modules only.
+- **The package manager is young.** Zef ships bundled as `mzef` and runs on mutsu, but installing arbitrary ecosystem distributions is not yet dependable.
 - **Some advanced features are missing or incomplete.** Certain meta-programming, NativeCall, and supply/react patterns are not yet supported.
 
 ## Building

--- a/wasm-demo/README.md
+++ b/wasm-demo/README.md
@@ -1,10 +1,12 @@
 # wasm-demo — the mutsu site
 
 The static site deployed to <https://tokuhirom.github.io/mutsu/> by
-`.github/workflows/pages.yml`. It is an introduction to **Raku**, not just a demo of
-mutsu: a landing page arguing why the language is interesting, a hands-on tutorial,
-and the playground. Every code sample runs locally in the visitor's browser through
-mutsu compiled to WebAssembly — nothing is sent to a server.
+`.github/workflows/pages.yml`. It is **mutsu's home page**, not a WebAssembly demo:
+the landing page introduces the implementation (what it is, how to install it, what is
+inside), and then argues why the language it implements is worth a look. A hands-on
+Raku tutorial and the playground follow. Every code sample runs locally in the
+visitor's browser through mutsu compiled to WebAssembly — nothing is sent to a server,
+which makes the site both the pitch and the proof.
 
 The site is deliberately **build-step free**: plain HTML, ES modules and CSS, served
 as-is. The only generated input is `pkg/`, the `wasm-pack` output.
@@ -12,7 +14,8 @@ as-is. The only generated input is `pkg/`, the `wasm-pack` output.
 ## Layout
 
 ```
-index.html          landing page — "why Raku", with runnable highlights
+index.html          landing page — what mutsu is, install, what is inside,
+                    then "why Raku" with runnable highlights
 tutorial.html       the tutorial: chapter/lesson navigation + one runnable lesson
 playground.html     editor + persistent REPL (this used to be index.html)
 assets/
@@ -26,13 +29,25 @@ assets/
 content/
   lessons.txt       tutorial code and expected output (the corpus)
   highlights.txt    landing-page code and expected output
+  install.js        the install recipes (shell code, shared between languages)
   tutorial.en.js    tutorial titles and prose (English)
   tutorial.ja.js    tutorial titles and prose (Japanese)
   landing.en.js     landing-page copy (English)
   landing.ja.js     landing-page copy (Japanese)
+  stats.json        compatibility numbers — generated, git-ignored (see below)
 bench-trend.html    benchmark dashboard — generated, git-ignored (see below)
 pkg/                wasm-pack output — generated, git-ignored
 ```
+
+## The compatibility headline
+
+The landing page leads with "N% of the official spec files pass in full". That
+number is **counted at deploy time**, not written into the copy: `pages.yml` divides
+`roast-whitelist.txt` by the number of `.t` files under `roast/` and writes
+`content/stats.json`. A local checkout has no such file, so the page falls back to
+the figure baked into `index.html` — keep that fallback roughly current, but the
+deployed site never depends on it. (The README's hand-written count is exactly what
+this avoids: it sat ~290 files stale.)
 
 `bench-trend.html` is rendered into the site at deploy time by
 `scripts/bench-visualize.py` from the `bench-data` branch's `bench-history.tsv`.

--- a/wasm-demo/assets/site.css
+++ b/wasm-demo/assets/site.css
@@ -281,7 +281,95 @@ footer.site-footer a:hover { text-decoration: underline; }
 }
 .card h3 { font-size: 1.12rem; margin-bottom: 0.35rem; }
 .card .card-body { color: var(--dim); font-size: 0.92rem; margin-bottom: 0.8rem; }
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(19rem, 1fr));
+  gap: 1.1rem;
+  align-items: start;
+}
+.card-grid .card { margin-bottom: 0; }
+.card-grid .card .card-body { margin-bottom: 0; }
+.card a { color: var(--pink); }
+
+/* Headline numbers */
+
+.stat-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 1rem;
+}
+.stat {
+  background: rgba(42, 18, 53, 0.55);
+  border: 1px solid var(--border);
+  border-radius: 0.7rem;
+  padding: 1rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.stat-value {
+  font-size: 1.75rem;
+  line-height: 1.2;
+  font-weight: 700;
+  background: linear-gradient(90deg, var(--purple), var(--pink));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.stat-label { color: var(--text); font-size: 0.92rem; }
+.stat-note { color: var(--dim); font-size: 0.8rem; }
+
+/* Install recipes */
+
+.tabs { display: flex; gap: 0.35rem; flex-wrap: wrap; margin-bottom: 0.7rem; }
+.tabs button {
+  background: var(--panel-bg);
+  border: 1px solid var(--border);
+  color: var(--dim);
+  padding: 0.3rem 0.85rem;
+  border-radius: 1rem;
+  font: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.tabs button:hover, .tabs button:focus-visible { color: var(--text); border-color: var(--pink); outline: none; }
+.tabs button[aria-selected="true"] { border-color: var(--pink); color: var(--text); background: #3a1a48; }
+
+.shell {
+  position: relative;
+  background: var(--console-bg);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+}
+.shell pre {
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  line-height: 1.6;
+  padding: 0.9rem 1rem;
+  padding-right: 5.5rem;
+  overflow-x: auto;
+  color: var(--text);
+}
+.copy-btn {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  background: var(--panel-bg);
+  border: 1px solid var(--border);
+  color: var(--dim);
+  font: inherit;
+  font-size: 0.75rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 0.3rem;
+  cursor: pointer;
+}
+.copy-btn:hover { color: var(--text); border-color: var(--pink); }
+.install-note { color: var(--dim); font-size: 0.85rem; margin-top: 0.7rem; }
+
 .card .card-body code,
+.stat-note code,
+.install-note code,
 .lesson-body code {
   font-family: var(--mono);
   font-size: 0.88em;

--- a/wasm-demo/content/install.js
+++ b/wasm-demo/content/install.js
@@ -1,0 +1,43 @@
+/**
+ * The install recipes shown on the landing page.
+ *
+ * Like the snippet corpora, the *code* lives here once and is shared between
+ * languages; only the prose in content/landing.<lang>.js is translated.  `id`
+ * keys the note in `install.notes` of those modules.
+ */
+
+export default [
+  {
+    id: 'mise',
+    label: 'mise',
+    code: [
+      '# latest release (or pin: @0.7.0)',
+      'mise use -g github:tokuhirom/mutsu',
+      '',
+      "mutsu -e 'say \"Hello, World!\"'",
+      'mzef --version',
+    ].join('\n'),
+  },
+  {
+    id: 'docker',
+    label: 'Docker',
+    code: [
+      '# REPL',
+      'docker run --rm -it ghcr.io/tokuhirom/mutsu',
+      '',
+      '# one-liner',
+      "docker run --rm ghcr.io/tokuhirom/mutsu mutsu -e 'say (^10).sum'",
+    ].join('\n'),
+  },
+  {
+    id: 'source',
+    label: 'From source',
+    code: [
+      'git clone https://github.com/tokuhirom/mutsu',
+      'cd mutsu',
+      'cargo build --release',
+      '',
+      "./target/release/mutsu -e 'say \"Hello, World!\"'",
+    ].join('\n'),
+  },
+];

--- a/wasm-demo/content/landing.en.js
+++ b/wasm-demo/content/landing.en.js
@@ -5,14 +5,86 @@
 
 export default {
   hero: {
-    title: 'Raku, running in this tab',
-    tagline: 'A language built for expressiveness — gradual types, real grammars, ' +
-      'lazy lists and multiple dispatch — with an interpreter small enough to ship ' +
-      'to your browser.',
-    sub: 'mutsu is a Raku implementation written in Rust. Everything on this site ' +
-      'runs locally as WebAssembly: no server, no round trip.',
-    startTutorial: 'Start the tutorial',
-    openPlayground: 'Open the playground',
+    title: 'mutsu — Raku, implemented in Rust',
+    tagline: 'A Raku interpreter with a bytecode VM, a baseline JIT and a cycle-collecting ' +
+      'GC — shipped as a single binary with a package manager in the box.',
+    sub: 'It also compiles to WebAssembly, which is what is running this page: every ' +
+      'example below executes locally in your browser, with no server behind it.',
+    install: 'Install it',
+    openPlayground: 'Try it in the browser',
+    repo: 'GitHub',
+  },
+
+  stats: {
+    roastLabel: 'Roast spec files passing in full',
+    roastNote: '{pass} of {total} files in the official Raku test suite',
+    binaryValue: 'Single binary',
+    binaryLabel: 'No runtime to install',
+    binaryNote: '<code>mutsu</code> plus the bundled <code>mzef</code> package manager',
+    wasmValue: 'WebAssembly',
+    wasmLabel: 'The same interpreter, in a tab',
+    wasmNote: 'this page is running it — nothing is sent to a server',
+  },
+
+  install: {
+    heading: 'Install',
+    lede: 'Prebuilt binaries for Linux and macOS are published on every release.',
+    copy: 'Copy',
+    copied: 'Copied',
+    notes: {
+      mise: 'The release archive is self-contained — <code>bin/mutsu</code>, ' +
+        '<code>bin/mzef</code> and the vendored Zef tree — so ' +
+        '<code>mzef install &lt;dist&gt;</code> works with no further setup.',
+      docker: 'The image carries both binaries. Mount a named volume at ' +
+        '<code>$HOME</code> to keep modules installed by <code>mzef</code> across runs.',
+      source: 'Needs Rust 1.92+ and a C compiler. <code>make test</code> runs the local ' +
+        'suite, <code>make roast</code> the official spec tests.',
+    },
+  },
+
+  features: {
+    heading: 'What is inside',
+    lede: 'mutsu is not a subset interpreter with a fixed feature list — it is built ' +
+      'against the official spec suite and tries to be the whole language.',
+    cards: [
+      {
+        title: 'A bytecode VM, not a tree walker',
+        body: 'Source is parsed to an AST, compiled to bytecode and executed by a VM ' +
+          'with around 340 instructions. There is no separate interpreter to fall back ' +
+          'to — the VM is the only execution engine.',
+      },
+      {
+        title: 'Baseline JIT',
+        body: 'Once a chunk of bytecode is hot it is compiled to native machine code ' +
+          'through Cranelift. It is on by default, and the interpreter-only path stays ' +
+          'benchmarked next to it on every commit.',
+      },
+      {
+        title: 'A real garbage collector',
+        body: 'Reference counting alone leaks cycles, so mutsu adds a cycle collector. ' +
+          'Only container-shaped values take part in it, which keeps numeric and string ' +
+          'code out of the collector entirely.',
+      },
+      {
+        title: 'mzef, the package manager, is bundled',
+        body: 'Upstream <a href="https://github.com/ugexe/zef">Zef</a> ships with mutsu ' +
+          'and runs on it. A distribution from the ecosystem downloads, installs into ' +
+          'the site repository and is then <code>use</code>-able — with no second Raku ' +
+          'installation involved.',
+      },
+      {
+        title: 'NativeCall',
+        body: 'Call into C libraries from Raku: native types, <code>CArray[T]</code> ' +
+          'buffers, and pointers including <code>is rw</code> out-parameters — enough ' +
+          'to drive SQLite through its C API. Structs and callbacks are still to come.',
+      },
+      {
+        title: 'Driven by the official test suite',
+        body: 'Roast is the specification, and progress is measured in whole files ' +
+          'passing — never by special-casing a test. Anything that regresses a passing ' +
+          'file is a bug, not a tradeoff.',
+      },
+    ],
   },
 
   why: {

--- a/wasm-demo/content/landing.ja.js
+++ b/wasm-demo/content/landing.ja.js
@@ -5,13 +5,82 @@
 
 export default {
   hero: {
-    title: 'Raku を、このタブの中で',
-    tagline: '漸進的型付け、本物の Grammar、遅延リスト、マルチディスパッチ——' +
-      '表現力のために設計された言語を、ブラウザに配れるほど小さなインタプリタで。',
-    sub: 'mutsu は Rust で書かれた Raku 実装です。このサイトの実行はすべて ' +
-      'WebAssembly としてローカルで行われます。サーバとの往復はありません。',
-    startTutorial: 'チュートリアルを始める',
-    openPlayground: 'プレイグラウンドを開く',
+    title: 'mutsu — Rust で書かれた Raku 実装',
+    tagline: 'バイトコード VM、ベースライン JIT、循環参照を回収する GC を備えた Raku ' +
+      'インタプリタ。パッケージマネージャ同梱の単一バイナリとして配布しています。',
+    sub: 'WebAssembly にもビルドでき、このページを動かしているのがそれです。' +
+      '以下の例はすべてブラウザ内でローカルに実行されます。サーバはありません。',
+    install: 'インストール',
+    openPlayground: 'ブラウザで試す',
+    repo: 'GitHub',
+  },
+
+  stats: {
+    roastLabel: '完全にパスする Roast 仕様テストファイル',
+    roastNote: '公式 Raku テストスイート {total} ファイル中 {pass} ファイル',
+    binaryValue: '単一バイナリ',
+    binaryLabel: '別途ランタイム不要',
+    binaryNote: '<code>mutsu</code> と、同梱のパッケージマネージャ <code>mzef</code>',
+    wasmValue: 'WebAssembly',
+    wasmLabel: '同じインタプリタがタブの中で',
+    wasmNote: 'このページがそれです。サーバには何も送っていません',
+  },
+
+  install: {
+    heading: 'インストール',
+    lede: 'Linux と macOS 向けのビルド済みバイナリをリリースごとに公開しています。',
+    copy: 'コピー',
+    copied: 'コピーしました',
+    notes: {
+      mise: 'リリースアーカイブは <code>bin/mutsu</code>、<code>bin/mzef</code>、' +
+        '同梱の Zef ツリーで完結しているので、<code>mzef install &lt;dist&gt;</code> が' +
+        '追加設定なしで動きます。',
+      docker: 'イメージには両方のバイナリが入っています。<code>mzef</code> で入れた' +
+        'モジュールを残したい場合は <code>$HOME</code> に名前付きボリュームをマウントしてください。',
+      source: 'Rust 1.92 以降と C コンパイラが必要です。<code>make test</code> でローカルの' +
+        'テスト、<code>make roast</code> で公式仕様テストが走ります。',
+    },
+  },
+
+  features: {
+    heading: '中身',
+    lede: '機能を絞ったサブセット実装ではありません。公式仕様スイートを基準に開発し、' +
+      '言語全体の実装を目指しています。',
+    cards: [
+      {
+        title: '木を辿るのではなくバイトコード VM',
+        body: 'ソースを AST に解析し、バイトコードにコンパイルして、約 340 命令の VM で' +
+          '実行します。フォールバック先の別インタプリタは存在せず、実行エンジンは VM だけです。',
+      },
+      {
+        title: 'ベースライン JIT',
+        body: 'バイトコードがホットになると Cranelift でネイティブコードにコンパイルします。' +
+          '既定で有効で、インタプリタのみの経路もコミットごとに並べて計測し続けています。',
+      },
+      {
+        title: '本物のガベージコレクタ',
+        body: '参照カウントだけでは循環参照が漏れるため、循環回収器を備えています。' +
+          '対象はコンテナ系の値だけなので、数値や文字列の処理は GC のコストを一切払いません。',
+      },
+      {
+        title: 'パッケージマネージャ mzef を同梱',
+        body: '本家の <a href="https://github.com/ugexe/zef">Zef</a> を同梱し、mutsu 上で' +
+          '動かしています。エコシステムの配布物をダウンロードしてサイトリポジトリに' +
+          'インストールし、<code>use</code> で解決できます。別途 Raku を入れる必要はありません。',
+      },
+      {
+        title: 'NativeCall',
+        body: 'Raku から C ライブラリを呼べます。ネイティブ型、<code>CArray[T]</code> ' +
+          'バッファ、<code>is rw</code> の出力引数を含むポインタに対応しており、' +
+          'SQLite の C API を叩ける程度には揃っています。構造体とコールバックは今後の課題です。',
+      },
+      {
+        title: '公式テストスイート駆動',
+        body: '仕様は Roast であり、進捗はファイル単位の完全パス数で測ります。' +
+          'テストを個別に特別扱いすることはしません。パスしていたファイルが落ちたら' +
+          'それはトレードオフではなくバグです。',
+      },
+    ],
   },
 
   why: {

--- a/wasm-demo/e2e.test.mjs
+++ b/wasm-demo/e2e.test.mjs
@@ -16,6 +16,8 @@ import { spawn, spawnSync } from 'child_process';
 import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs';
 
 import { parseCorpus } from './assets/corpus.js';
+import landingEn from './content/landing.en.js';
+import INSTALL from './content/install.js';
 
 const PORT = 18765;
 const BASE = `http://localhost:${PORT}`;
@@ -124,9 +126,27 @@ try {
   assert((await page.textContent('#hero-title')).length > 0, 'the hero has a title');
   assert(await page.locator('#why-cards .card').count() === highlights.length,
          `every highlight snippet has a card (${highlights.length})`);
+  assert(await page.locator('#feature-cards .card').count() === landingEn.features.cards.length,
+         `every feature has a card (${landingEn.features.cards.length})`);
+  assert(await page.locator('#stat-row .stat').count() === 3,
+         'the headline numbers are shown');
+  assert(/^\d+(\.\d+)?%$/.test((await page.textContent('#stat-row .stat-value')).trim()),
+         'the roast figure renders as a percentage');
   assert(await page.locator('.site-nav .nav-links a').count() >= 4, 'the nav lists the pages');
   assert((await page.textContent('.site-footer')).includes('Raku/doc'),
          'the footer credits the official Raku documentation');
+
+  console.log('Test: install recipes');
+  assert(await page.locator('#install-tabs button').count() === INSTALL.length,
+         `every install recipe has a tab (${INSTALL.length})`);
+  const firstRecipe = (await page.textContent('#install-panels pre')).trim();
+  assert(firstRecipe === INSTALL[0].code.trim(),
+         `the ${INSTALL[0].id} recipe is shown first`);
+  await page.click(`#install-tabs button:nth-child(${INSTALL.length})`);
+  assert((await page.textContent('#install-panels pre')).trim()
+           === INSTALL[INSTALL.length - 1].code.trim(),
+         'picking another tab swaps in its recipe');
+  await page.click('#install-tabs button:nth-child(1)');
 
   console.log('Test: landing page language switch');
   const enTitle = await page.textContent('#hero-title');

--- a/wasm-demo/index.html
+++ b/wasm-demo/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>mutsu — Raku in the browser</title>
-<meta name="description" content="An introduction to the Raku programming language, with every example runnable in the browser. Powered by mutsu, a Raku interpreter written in Rust and compiled to WebAssembly.">
+<title>mutsu — a Raku implementation written in Rust</title>
+<meta name="description" content="mutsu is a Raku interpreter written in Rust: a bytecode VM with a baseline JIT and a cycle-collecting GC, shipped as a single binary with the Zef package manager bundled. It also compiles to WebAssembly, so every example on this page runs in your browser.">
 <link rel="stylesheet" href="assets/site.css">
 </head>
 <body>
@@ -12,9 +12,10 @@
 <nav class="site-nav"></nav>
 
 <noscript>
-  <p class="section">This site runs a Raku interpreter in your browser, so it needs
-  JavaScript and WebAssembly enabled. The language itself is documented at
-  <a href="https://docs.raku.org/">docs.raku.org</a>.</p>
+  <p class="section">This page runs the mutsu interpreter in your browser, so it needs
+  JavaScript and WebAssembly enabled. mutsu itself is a native binary — see
+  <a href="https://github.com/tokuhirom/mutsu">github.com/tokuhirom/mutsu</a> for
+  install instructions.</p>
 </noscript>
 
 <header class="hero">
@@ -22,12 +23,30 @@
   <p class="tagline" id="hero-tagline"></p>
   <p class="sub" id="hero-sub"></p>
   <p class="cta">
-    <a class="btn" id="cta-tutorial" href="tutorial.html"></a>
+    <a class="btn" id="cta-install" href="#install-section"></a>
     <a class="btn-ghost" id="cta-playground" href="playground.html"></a>
+    <a class="btn-ghost" id="cta-repo" href="https://github.com/tokuhirom/mutsu" rel="noopener"></a>
   </p>
 </header>
 
 <main>
+  <section class="section" id="stats-section">
+    <div class="stat-row" id="stat-row"></div>
+  </section>
+
+  <section class="section" id="install-section">
+    <h2 id="install-heading"></h2>
+    <p class="lede" id="install-lede"></p>
+    <div class="tabs" id="install-tabs" role="tablist"></div>
+    <div id="install-panels"></div>
+  </section>
+
+  <section class="section" id="features-section">
+    <h2 id="features-heading"></h2>
+    <p class="lede" id="features-lede"></p>
+    <div class="card-grid" id="feature-cards"></div>
+  </section>
+
   <section class="section" id="why-section">
     <h2 id="why-heading"></h2>
     <p class="lede" id="why-lede"></p>
@@ -50,8 +69,17 @@ import { createSnippet } from './assets/snippet.js';
 
 import landingEn from './content/landing.en.js';
 import landingJa from './content/landing.ja.js';
+import INSTALL from './content/install.js';
 
 const LANDING = { en: landingEn, ja: landingJa };
+
+/* Compatibility numbers.  pages.yml writes content/stats.json at deploy time by
+   counting roast-whitelist.txt against roast/, so the figure on the site cannot
+   drift away from the suite the way a hand-written one does.  These values are
+   the fallback for a local checkout, where that file does not exist. */
+let STATS = { roastPass: 1433, roastTotal: 1464 };
+
+const nf = () => new Intl.NumberFormat(currentLang() === 'ja' ? 'ja' : 'en');
 
 /* ---- static text ------------------------------------------------- */
 
@@ -60,16 +88,125 @@ function paintText() {
   document.getElementById('hero-title').textContent = L.hero.title;
   document.getElementById('hero-tagline').textContent = L.hero.tagline;
   document.getElementById('hero-sub').textContent = L.hero.sub;
-  const tut = document.getElementById('cta-tutorial');
+  const install = document.getElementById('cta-install');
   const play = document.getElementById('cta-playground');
-  tut.textContent = L.hero.startTutorial;
-  tut.href = langHref('tutorial.html');
+  install.textContent = L.hero.install;
   play.textContent = L.hero.openPlayground;
   play.href = langHref('playground.html');
+  document.getElementById('cta-repo').textContent = L.hero.repo;
+  document.getElementById('install-heading').textContent = L.install.heading;
+  document.getElementById('install-lede').textContent = L.install.lede;
+  document.getElementById('features-heading').textContent = L.features.heading;
+  document.getElementById('features-lede').textContent = L.features.lede;
   document.getElementById('why-heading').textContent = L.why.heading;
   document.getElementById('why-lede').textContent = L.why.lede;
   document.getElementById('next-heading').textContent = L.next.heading;
   document.getElementById('next-lede').textContent = L.next.lede;
+}
+
+/* ---- headline numbers -------------------------------------------- */
+
+const statRow = document.getElementById('stat-row');
+
+function paintStats() {
+  const L = LANDING[currentLang()].stats;
+  const fmt = nf();
+  const pct = (100 * STATS.roastPass / STATS.roastTotal).toFixed(1);
+  const tiles = [
+    {
+      value: `${pct}%`,
+      label: L.roastLabel,
+      note: L.roastNote.replace('{pass}', fmt.format(STATS.roastPass))
+        .replace('{total}', fmt.format(STATS.roastTotal)),
+    },
+    { value: L.binaryValue, label: L.binaryLabel, note: L.binaryNote },
+    { value: L.wasmValue, label: L.wasmLabel, note: L.wasmNote },
+  ];
+
+  statRow.textContent = '';
+  for (const tile of tiles) {
+    const el = document.createElement('div');
+    el.className = 'stat';
+    const v = document.createElement('strong');
+    v.className = 'stat-value';
+    v.textContent = tile.value;
+    const l = document.createElement('span');
+    l.className = 'stat-label';
+    l.textContent = tile.label;
+    const n = document.createElement('span');
+    n.className = 'stat-note';
+    // Prose is a literal from the content modules, never user input.
+    n.innerHTML = tile.note;
+    el.append(v, l, n);
+    statRow.appendChild(el);
+  }
+}
+
+/* ---- install recipes --------------------------------------------- */
+
+const tabsEl = document.getElementById('install-tabs');
+const panelsEl = document.getElementById('install-panels');
+let installTab = INSTALL[0].id;
+
+function paintInstall() {
+  const L = LANDING[currentLang()].install;
+
+  tabsEl.textContent = '';
+  for (const recipe of INSTALL) {
+    const b = document.createElement('button');
+    b.type = 'button';
+    b.role = 'tab';
+    b.textContent = recipe.label;
+    b.setAttribute('aria-selected', String(recipe.id === installTab));
+    b.addEventListener('click', () => { installTab = recipe.id; paintInstall(); });
+    tabsEl.appendChild(b);
+  }
+
+  const recipe = INSTALL.find(r => r.id === installTab);
+  panelsEl.textContent = '';
+
+  const shell = document.createElement('div');
+  shell.className = 'shell';
+  const pre = document.createElement('pre');
+  pre.textContent = recipe.code;
+  const copy = document.createElement('button');
+  copy.type = 'button';
+  copy.className = 'copy-btn';
+  copy.textContent = L.copy;
+  copy.addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(recipe.code);
+      copy.textContent = L.copied;
+      setTimeout(() => { copy.textContent = L.copy; }, 1500);
+    } catch { /* clipboard blocked (insecure context, denied permission) */ }
+  });
+  shell.append(copy, pre);
+
+  const note = document.createElement('p');
+  note.className = 'install-note';
+  note.innerHTML = L.notes[recipe.id];
+
+  panelsEl.append(shell, note);
+}
+
+/* ---- feature cards ----------------------------------------------- */
+
+const featuresEl = document.getElementById('feature-cards');
+
+function paintFeatures() {
+  const L = LANDING[currentLang()].features;
+  featuresEl.textContent = '';
+  for (const card of L.cards) {
+    const el = document.createElement('section');
+    el.className = 'card';
+    const h = document.createElement('h3');
+    h.textContent = card.title;
+    const p = document.createElement('p');
+    p.className = 'card-body';
+    p.innerHTML = card.body;
+    el.append(h, p);
+    featuresEl.appendChild(el);
+  }
 }
 
 /* ---- highlight cards --------------------------------------------- */
@@ -138,14 +275,27 @@ function paintNext() {
 
 function paintAll() {
   paintText();
+  paintStats();
+  paintInstall();
+  paintFeatures();
   paintCards();
   paintNext();
 }
 
 /* ---- boot -------------------------------------------------------- */
 
+async function loadStats() {
+  try {
+    const res = await fetch('content/stats.json');
+    if (!res.ok) return;                       // not deployed: keep the fallback
+    const s = await res.json();
+    if (s.roastPass > 0 && s.roastTotal > 0) STATS = s;
+  } catch { /* absent or unparsable: keep the fallback */ }
+}
+
 async function main() {
   renderChrome('home');
+  await loadStats();
   buildCards(parseCorpus(await (await fetch('content/highlights.txt')).text()));
   window.addEventListener('langchange', paintAll);
   paintAll();


### PR DESCRIPTION
## Why

The deployed site opened on *"Raku, running in this tab"* and went straight into eight language highlights. That is a good Raku introduction, but it never said what mutsu is, how to install it, or why the implementation itself is interesting — a visitor who arrived looking for the project found a demo of it instead.

## What changed

`index.html` now leads with the implementation and keeps the language pitch below it, unchanged:

- **Hero** — names mutsu and what it is (bytecode VM, baseline JIT, cycle-collecting GC, single binary with a package manager bundled). CTAs: Install / Try it in the browser / GitHub.
- **Headline numbers** — spec-suite pass rate, single binary, WebAssembly.
- **Install** — copyable mise / Docker / from-source recipes behind tabs.
- **What is inside** — six cards: the VM, the JIT, the GC, mzef, NativeCall, roast-driven development.
- **Why Raku** and **Where to go next** — as before.

### The compatibility figure is counted, not written

`pages.yml` divides `roast-whitelist.txt` by the `.t` files under `roast/` into `content/stats.json` at deploy time; the page falls back to a baked-in number in a local checkout. The README's hand-written count is exactly what this avoids — it had drifted 288 files stale (`1,145 of ~1,460` → `1,433 of 1,464`), and is corrected here.

### Claims are checked against the tree

- NativeCall says structs and callbacks are **still to come** — `src/runtime/nativecall.rs:14` says so.
- mzef claims an install that ends in a `use`-able dist, not a green test phase — `docs/mzef-install-pipeline.md` phase 6 is amber (13/16 suites fail).
- The README's "no package manager integration" limitation and its stale "macOS builds are best-effort" note are both corrected (all four release targets are required now).

Install recipe code lives in `content/install.js`, shared between languages — the same split the snippet corpora already use: code once, prose per language.

## Test

`node wasm-demo/e2e.test.mjs` — 72 assertions pass, 0 page errors. New coverage: feature-card count, the three stat tiles, the percentage format, and install-tab switching. Checked at 1280px and 390px in both languages; no horizontal overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)