### PR TITLE
fix: role requirement satisfied by an inherited Mu/Any method (e.g. `new`)

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -644,7 +644,8 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   IO::Path::AutoDecompress, ~~Math::Angle~~ (FIXED — see Done), Math::PascalTriangle,
   ~~Statistics::LinearRegression~~ (FIXED — see Done), String::Rotate,
   Text::CodeProcessing, Trait::IO, WriteOnceHash, `are`, ~~`sortuk`~~ (FIXED — see Done),
-  Tree::Binary::PrettyTree (required role method not seen as implemented).
+  Tree::Binary::PrettyTree (role-`new` requirement FIXED; now blocked on a
+  separate `class Iterator does Iterator` name-resolution issue — see Done).
 - These `test_die` on the current binary but were not individually reproduced.
   Split off a dedicated ticket when you pick one up.
 - Triaged 2026-07-23 (deferred, each deep — own root cause):
@@ -966,3 +967,20 @@ _(move tickets here with `[claim: <branch>]` when you start)_
   to an `@` param into a fresh real Array (`runtime/types/binding_signature.rs`).
   SortUk's sort loop does `(@data[$w1],@data[$w2]).=reverse` on `@data is copy`.
   Pin: `t/array-is-copy-list-arg.t`.
+
+- **T-057 (Tree::Binary::PrettyTree)** (PR `fix-role-required-universal-method`) —
+  test_die → role-`new` requirement FIXED (still blocked on a separate issue). One
+  general bug: a role requiring a method that every object inherits from `Mu`/`Any`
+  (`method new {...}`, `gist`, `clone`, ...) was reported "Method 'new' must be
+  implemented by C because it is required by roles: R." — the composition check
+  only counted class/parent-defined methods, not the universal defaults. Now the
+  requirement is satisfied by name when it is a universal object method
+  (`runtime/registration.rs`, mirrors `value_can_method`); a non-universal required
+  method still errors. Pin: `t/role-required-universal-method.t`.
+  **Residual (deferred, separate deep bug):** Tree::Binary defines
+  `class Iterator does Iterator` inside `package Tree::Binary`, where the second
+  `Iterator` is the **core Raku `Iterator` role**. mutsu resolves the `does`
+  target to the class being defined (same short name in the same package),
+  producing a false "C3 MRO cycle detected at Tree::Binary::Iterator". The `does`
+  role-name lookup must exclude the class under composition and fall back to the
+  outer/core role.

--- a/src/runtime/registration.rs
+++ b/src/runtime/registration.rs
@@ -85,6 +85,44 @@ impl Interpreter {
         Self::is_stub_routine_body(&def.body)
     }
 
+    /// Methods every object inherits from `Mu`/`Any` and therefore always
+    /// responds to, so a role requirement of this name is satisfied even when
+    /// the composing class does not define it (rakudo satisfies a `method new
+    /// {...}` role stub with the inherited `Mu.new`). Mirrors the universal-set
+    /// in `value_can_method`; kept to the object-protocol / coercion defaults
+    /// that a bare class genuinely provides.
+    fn is_universal_object_method(method_name: &str) -> bool {
+        matches!(
+            method_name,
+            "new"
+                | "bless"
+                | "CREATE"
+                | "clone"
+                | "defined"
+                | "Bool"
+                | "so"
+                | "not"
+                | "gist"
+                | "raku"
+                | "perl"
+                | "Str"
+                | "item"
+                | "self"
+                | "sink"
+                | "WHAT"
+                | "WHICH"
+                | "WHERE"
+                | "HOW"
+                | "WHY"
+                | "VAR"
+                | "DEFINITE"
+                | "isa"
+                | "does"
+                | "can"
+                | "ACCEPTS"
+        )
+    }
+
     /// Remove duplicate method candidates that are the *same* underlying
     /// definition reaching a class through multiple composition paths (a role
     /// diamond). Identity is the method body's `Arc` pointer plus its positional
@@ -256,6 +294,18 @@ impl Interpreter {
                             required,
                         ));
                         let total = inherited_matches + accessor_match;
+                        if total == 0 && Self::is_universal_object_method(&method_name) {
+                            // A role requirement is satisfied by NAME, and every
+                            // object inherits a set of methods from `Mu`/`Any`
+                            // (`new`, `bless`, `clone`, `gist`, `defined`, ...).
+                            // rakudo composes fine when a role stub `method new
+                            // {...}` is "implemented" only by the inherited
+                            // `Mu.new`; the class need not redefine it. (Real
+                            // dist: Tree::Binary::PrettyTree provides only
+                            // `submethod BUILD`, relying on `Mu.new` to satisfy
+                            // `Renderer`'s `method new {...}` requirement.)
+                            continue;
+                        }
                         if total == 0 {
                             // rakudo: "Method 'o' must be implemented by A
                             // because it is required by roles: C1, R1." — an

--- a/t/role-required-universal-method.t
+++ b/t/role-required-universal-method.t
@@ -1,0 +1,66 @@
+use v6;
+use Test;
+
+# A role requirement is satisfied by NAME, and every object inherits a set of
+# methods from Mu/Any (`new`, `bless`, `clone`, `gist`, `defined`, ...). A role
+# stub `method new {...}` is therefore satisfied by the inherited `Mu.new` even
+# when the composing class does not redefine it — mutsu used to reject this with
+# "Method 'new' must be implemented by C because it is required by roles: R.".
+# Regression pin for Tree::Binary::PrettyTree (only defines `submethod BUILD`).
+
+plan 6;
+
+{
+    role R {
+        method new(:$x) {...}
+        method go() {...}
+    }
+    class C does R {
+        method go() { 'hi' }
+    }
+    lives-ok { C.new }, 'class composing a role that requires `new` builds';
+    is C.new.go, 'hi', 'the class works after composition';
+}
+
+{
+    # `gist` required by a role is satisfied by the universal Mu.gist.
+    role Showable {
+        method gist() {...}
+        method label() {...}
+    }
+    class Widget does Showable {
+        method label() { 'widget' }
+    }
+    lives-ok { Widget.new }, 'role requiring `gist` is satisfied by Mu.gist';
+    is Widget.new.label, 'widget', 'Widget.label works';
+}
+
+{
+    # A genuinely-unimplemented (non-universal) required method still errors.
+    my $err;
+    {
+        role Needs {
+            method frobnicate() {...}
+        }
+        # Compose at runtime via EVAL so the composition error is catchable.
+        $err = (try EVAL 'role N2 { method frobnicate() {...} }; class Bad does N2 { }; Bad') // $!;
+    }
+    ok $err.defined && "$err".contains('frobnicate'),
+        'a non-universal required method is still enforced';
+}
+
+{
+    # The BUILD-only shape from Tree::Binary::PrettyTree: role requires `new`,
+    # class provides only `submethod BUILD`.
+    role Renderer {
+        method new(:$tree) {...}
+        method render() {...}
+    }
+    class Pretty does Renderer {
+        has $.tree;
+        submethod BUILD(:$!tree = 0) {}
+        method render() { "tree=$!tree" }
+    }
+    is Pretty.new(tree => 5).render, 'tree=5',
+        'BUILD-only class composes a role requiring `new`';
+}


### PR DESCRIPTION
## Summary

A role requirement is satisfied by **name**, and every object inherits a set of
methods from `Mu`/`Any` (`new`, `bless`, `clone`, `gist`, `defined`, ...). A role
stub `method new {...}` is therefore satisfied by the inherited `Mu.new` even
when the composing class does not redefine it.

mutsu rejected this at composition:

```raku
role R { method new(:$x) {...}; method go() {...} }
class C does R { method go() { 'hi' } }
C.new;   # was: "Method 'new' must be implemented by C because it is
         #       required by roles: R."; now: works (Mu.new)
```

The requirement check only counted methods defined on the class or its explicit
parents. Before erroring, the requirement is now accepted when the method name is
one of the universal object-protocol / coercion defaults every class provides via
Mu/Any (mirrors the universal set in `value_can_method`). A genuinely-unimplemented
non-universal required method still errors.

## Impact

Unblocks the `method new {...}` role stub used by **Tree::Binary::PrettyTree**,
which provides only `submethod BUILD` and relies on `Mu.new`. (Tree::Binary then
hits a separate `class Iterator does Iterator` name-resolution issue, recorded as
a deferred follow-up in the ticket.)

## Testing

- New pin `t/role-required-universal-method.t` (6 tests), passes under mutsu **and** raku.
- Full `make test`: 22473 tests, Result: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)