### PR TITLE
fix: a class may compose a CORE role of its own name (`class Iterator does Iterator`)

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -977,10 +977,27 @@ _(move tickets here with `[claim: <branch>]` when you start)_
   requirement is satisfied by name when it is a universal object method
   (`runtime/registration.rs`, mirrors `value_can_method`); a non-universal required
   method still errors. Pin: `t/role-required-universal-method.t`.
-  **Residual (deferred, separate deep bug):** Tree::Binary defines
+- **T-057 (Tree::Binary — `class Iterator does Iterator`)** (PR
+  `fix-class-does-self-named-role`) — the self-named-`does`-role blocker recorded
+  as the residual below is now FIXED. `class Iterator does Iterator` (top level)
+  gave "cannot inherit from itself"; inside `package Tree::Binary` it gave a false
+  "C3 MRO cycle detected at Tree::Binary::Iterator". Root cause: a `does`-role
+  whose (short) name equals the class's own name resolved to the class being
+  declared (the package-sibling qualification produced the self FQN), so the role
+  entered the class's own inheritance parents. Fix: in `register_class_decl`, a
+  `does`-parent whose short name matches the class and which names a registered
+  role is composed as that role (the CORE `Iterator`) and excluded from the C3
+  inheritance parents — it is neither self-inheritance nor a self-cycle. `is`
+  self-inheritance and a non-role `does <self>` still error. Pin:
+  `t/class-does-self-named-role.t`.
+  01-basic.rakutest passes; iterator.rakutest / simple-int-trees.rakutest now
+  progress to the **next, separate blocker**: a parametric role
+  `role BinaryTree[...] does HasNodes { method nodes {...} }` — the `method nodes`
+  implementation on the parametric role is not recognized as satisfying the
+  `HasNodes` requirement when `BinaryTree[Int]` is composed, so a consuming class
+  gets "Method 'nodes' must be implemented by IntTree ... required by roles
+  BinaryTree, HasNodes." Parametric-role requirement-satisfaction is a distinct,
+  deeper root cause (deferred).
+  **Residual (FIXED above):** Tree::Binary defines
   `class Iterator does Iterator` inside `package Tree::Binary`, where the second
-  `Iterator` is the **core Raku `Iterator` role**. mutsu resolves the `does`
-  target to the class being defined (same short name in the same package),
-  producing a false "C3 MRO cycle detected at Tree::Binary::Iterator". The `does`
-  role-name lookup must exclude the class under composition and fall back to the
-  outer/core role.
+  `Iterator` is the **core Raku `Iterator` role**.

--- a/news/2026-07/class-does-self-named-role.md
+++ b/news/2026-07/class-does-self-named-role.md
@@ -1,0 +1,30 @@
+# A class may compose a CORE role of its own name (`class Iterator does Iterator`)
+
+A class whose name collides with the name of a CORE role it composes — most
+notably `class Iterator does Iterator`, a common idiom for a bespoke iterator —
+was rejected. At the top level it raised
+`X::Inheritance::SelfInherit: class 'Iterator' cannot inherit from itself`, and
+inside a package (`unit package Tree::Binary; class Iterator does Iterator`) it
+produced a false `C3 MRO cycle detected at Tree::Binary::Iterator`. Rakudo
+accepts both: a class cannot compose *itself*, so `does Iterator` resolves to the
+like-named CORE `Iterator` role.
+
+The root cause was name resolution treating the `does`-role parent as the class
+under declaration. Inside a package, the bare parent `Iterator` was
+package-qualified to the class's own fully-qualified name
+(`Tree::Binary::Iterator`) as a "sibling" class, so the role landed in the
+class's own C3 inheritance-parent list and the class became its own ancestor. At
+the top level the bare `Iterator` simply equalled the class name and tripped the
+self-inheritance guard.
+
+`register_class_decl` now recognizes a `does`-parent whose *short* name equals the
+class's own short name and which names a registered role: it is composed as that
+role (the CORE `Iterator`) and excluded from the C3 inheritance parents, so it is
+neither self-inheritance nor a self-cycle. Genuine self-inheritance via `is`
+(`class A is A`) and a `does` on a same-named non-role (`class B does B`, no such
+role) still error, matching Rakudo.
+
+This unblocks the `Tree::Binary` distribution's module load
+(`01-basic.rakutest` passes); its iterator tests progress to a separate,
+deeper blocker in parametric-role requirement satisfaction. Pin:
+`t/class-does-self-named-role.t`.

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -498,6 +498,19 @@ impl Interpreter {
             "Metamodel::GrammarHOW",
             "Perl6::Metamodel::GrammarHOW",
         ];
+        // Short (unqualified) name of the class being declared, for detecting a
+        // `does`-role that shares the class's own name (see below).
+        fn short_of(s: &str) -> &str {
+            s.rsplit("::").next().unwrap_or(s)
+        }
+        let self_short = short_of(name);
+        // Parents that must NOT enter the C3 inheritance MRO because they are a
+        // `does`-role whose (short) name collides with the class's own name — e.g.
+        // `class Iterator does Iterator` (Rakudo composes the CORE `Iterator` role,
+        // not the class itself). Such a parent is still composed as a role by the
+        // role-composition loop below; keeping it in the inheritance parent list
+        // would make the class its own C3 ancestor (self-cycle / self-inherit).
+        let mut self_named_does_roles: HashSet<String> = HashSet::new();
         let mut deferred_custom_traits: Vec<String> = Vec::new();
         for parent in parents {
             let resolved_parent_name = self.resolve_declared_type_name(parent);
@@ -509,6 +522,16 @@ impl Interpreter {
             };
             // Strip leading `::` for comparison (e.g., `is ::F` refers to `F`)
             let resolved_parent = base_parent.strip_prefix("::").unwrap_or(base_parent);
+            // A `does`-role of the class's own short name resolves to the like-named
+            // CORE/existing role (a class cannot compose itself), so it is neither a
+            // self-inheritance error nor a real inheritance parent.
+            let is_self_named_does_role = does_parents.contains(parent)
+                && short_of(resolved_parent) == self_short
+                && self.registry().roles.contains_key(resolved_parent);
+            if is_self_named_does_role {
+                self_named_does_roles.insert(parent.clone());
+                continue;
+            }
             if resolved_parent == name {
                 return Err(RuntimeError::new(format!(
                     "X::Inheritance::SelfInherit: class '{}' cannot inherit from itself",
@@ -672,8 +695,20 @@ impl Interpreter {
                 return Err(err);
             }
         }
+        // Drop any `does`-role that shares the class's own name from the C3
+        // inheritance parents (it is composed as a role below; leaving it here
+        // would make the class its own ancestor — see `self_named_does_roles`).
+        let inheritance_parents: Vec<String> = if self_named_does_roles.is_empty() {
+            parents.to_vec()
+        } else {
+            parents
+                .iter()
+                .filter(|p| !self_named_does_roles.contains(*p))
+                .cloned()
+                .collect()
+        };
         let mut class_def = ClassDef {
-            parents: parents.to_vec(),
+            parents: inheritance_parents,
             attributes: Vec::new(),
             attribute_types: HashMap::new(),
             attribute_smileys: HashMap::new(),

--- a/t/class-does-self-named-role.t
+++ b/t/class-does-self-named-role.t
@@ -1,0 +1,49 @@
+use Test;
+
+# A class whose own name collides with the name of a CORE role it composes.
+# `class Iterator does Iterator` must compose the CORE `Iterator` role (a class
+# cannot compose itself), NOT be treated as self-inheritance or a C3 self-cycle.
+# Regression: mutsu resolved the `does Iterator` parent to the class being
+# declared, giving "cannot inherit from itself" at top level and a "C3 MRO cycle"
+# inside a package.
+
+plan 6;
+
+# --- top level: does the CORE Iterator role, same name as the class ---
+{
+    class Iterator does Iterator {
+        has @.items;
+        method pull-one {
+            return IterationEnd unless @!items.elems;
+            return @!items.shift;
+        }
+    }
+    my $it = Iterator.new(items => [1, 2, 3]);
+    is $it.^name, 'Iterator', 'self-named class keeps its own name';
+    ok $it ~~ Iterator, 'instance is-a the (self-named) class';
+    is $it.pull-one, 1, 'composed CORE Iterator role: pull-one works (1)';
+    is $it.pull-one, 2, 'composed CORE Iterator role: pull-one works (2)';
+}
+
+# --- inside a package: same collision, previously a "C3 MRO cycle" ---
+{
+    my $ok = EVAL q:to/CODE/;
+        package My::Pkg {
+            class Iterator does Iterator {
+                has @.items;
+                method pull-one {
+                    return IterationEnd unless @!items.elems;
+                    return @!items.shift;
+                }
+            }
+        }
+        My::Pkg::Iterator.new(items => [7]).pull-one;
+        CODE
+    is $ok, 7, 'packaged self-named `does Iterator` composes the role (no C3 cycle)';
+}
+
+# --- genuine self-inheritance via `is` must still be rejected ---
+{
+    try { EVAL 'class SelfIs is SelfIs {}' }
+    ok $!, 'real self-inheritance (`is`) is still an error';
+}


### PR DESCRIPTION
## Problem

`class Iterator does Iterator` — a common idiom for a bespoke iterator — was rejected:

- At the top level: `X::Inheritance::SelfInherit: class 'Iterator' cannot inherit from itself`
- Inside a package (`unit package Tree::Binary; class Iterator does Iterator`): a false `C3 MRO cycle detected at Tree::Binary::Iterator`

Rakudo accepts both. A class cannot compose *itself*, so `does Iterator` resolves to the like-named CORE `Iterator` role.

## Root cause

The `does`-role parent resolved to the class under declaration. Inside a package, the bare parent `Iterator` was package-qualified to the class's own fully-qualified name (`Tree::Binary::Iterator`) as a "sibling" class, so the role landed in the class's own C3 inheritance-parent list and the class became its own ancestor. At the top level the bare `Iterator` simply equalled the class name and tripped the self-inheritance guard.

## Fix

`register_class_decl` now recognizes a `does`-parent whose *short* name equals the class's own short name and which names a registered role: it is composed as that role (the CORE `Iterator`) and excluded from the C3 inheritance parents — so it is neither self-inheritance nor a self-cycle. Genuine self-inheritance via `is` (`class A is A`) and a `does` on a same-named non-role (`class B does B`, no such role) still error, matching Rakudo.

## Impact

Unblocks the `Tree::Binary` distribution's module load (T-057): `01-basic.rakutest` passes. Its iterator tests now progress to a separate, deeper blocker in parametric-role requirement satisfaction (`role BinaryTree[...] does HasNodes { method nodes {...} }`), recorded in TICKETS.md.

## Verification

- `make test`: Result: PASS (2369 files, 22489 tests)
- All local role/class/inheritance tests pass; no clippy warnings
- Pin: `t/class-does-self-named-role.t` (6 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)