### PR TITLE
fix: bare type objects warn in string context (~, eq, interpolation, print)

### DIFF
--- a/news/2026-07/type-object-string-context-warning.md
+++ b/news/2026-07/type-object-string-context-warning.md
@@ -1,0 +1,49 @@
+# Bare type objects warn in string context
+
+Using a bare type object (an undefined value such as `Int`, `Str`, or an
+uninitialized `my Int $x`) in a string context now emits Rakudo's
+
+```
+Use of uninitialized value of type Int in string context.
+Methods .^name, .raku, .gist, or .say can be used to stringify it to something meaningful.
+```
+
+warning and resumes with the empty string, matching raku. Previously mutsu
+silently resumed with `""` from most string-context entry points, warning only
+from `print` and the `.Str` method.
+
+The warning is now emitted from every string-context entry point a type object
+can reach:
+
+- prefix `~` (`~Int`) — `src/vm/vm_misc_coerce.rs`
+- infix `~` and the string comparators `eq`/`lt`/… (`"a" ~ Int`, `Int eq "x"`)
+  — `src/vm/vm_coerce_concat_ops.rs::coerce_stringy_operand`
+- string interpolation (`"$x"` with an uninitialized typed `$x`, `"{Int}"`) —
+  `src/vm/vm_var_assign_typed.rs::exec_string_concat_op`
+- `print` — `src/runtime/io_env.rs::render_str_value`
+
+A shared helper `warn_type_object_string_context` (`src/runtime/io_env.rs`)
+formats the message and reconciles any captured-outer writeback from the
+resumable-warning handler.
+
+A class that defines a user `.Str`/`.Stringy` still dispatches it even on the
+bare type object (`class A { method Str {"foo"} }` then `~A` / `"{A}"` /
+`print A` all render `"foo"`), matching raku — the warning fires only for type
+objects with no user stringifier. This also fixed a pre-existing `print` bug
+where a type object with a custom `.Str` warned instead of dispatching it.
+
+`Mu` keeps its existing behavior: prefix `~Mu` is the hard error
+`Cannot resolve caller prefix:<~>(Mu:U)`, while infix `~`/interpolation/`print`
+warn like any other type object.
+
+Two known minor divergences from raku remain and are not addressed here:
+
+- Block interpolation `"{Int}"` emits the `...value element of type...` wording
+  (the same as variable interpolation) rather than raku's `...value of type...`.
+  Distinguishing the two forms would require the compiler to tag each
+  interpolation part as a variable vs an expression at the `StringConcat` op;
+  the common `$var`/`$(...)` form matches raku exactly.
+- `Mu eq "x"` warns and returns `False` instead of raku's
+  `Cannot resolve caller infix:<eq>(Mu:U, Str:D)` hard error.
+
+Pinned by `t/type-object-str-context-warning.t`.

--- a/src/runtime/io_env.rs
+++ b/src/runtime/io_env.rs
@@ -184,22 +184,57 @@ impl Interpreter {
         }
     }
 
+    /// Emit rakudo's "Use of uninitialized value[ element] of type X in string
+    /// context." warning for a bare type object used in string context, and
+    /// resume with the empty string. `element` selects the interpolation
+    /// wording (`... value element of type ...`) that Rakudo uses inside `"$x"`;
+    /// prefix/infix `~` and the string comparators use the non-`element` form.
+    ///
+    /// Callers must first rule out a user-defined `.Str`/`.Stringy` (a type
+    /// object whose class defines one dispatches it and is NOT warned) and any
+    /// operator-specific hard error (e.g. `prefix:<~>(Mu:U)`). The warning
+    /// handler can run user code that mutates a captured-outer caller lexical,
+    /// so its writeback is reconciled here (Slice 1b render pattern).
+    pub(crate) fn warn_type_object_string_context(
+        &mut self,
+        type_name: &str,
+        element: bool,
+    ) -> Result<Value, RuntimeError> {
+        let msg = format!(
+            "Use of uninitialized value{} of type {} in string context.\nMethods .^name, .raku, .gist, or .say can be used to stringify it to something meaningful.",
+            if element { " element" } else { "" },
+            type_name,
+        );
+        let caller_code = self.current_code;
+        let resumed = self.raise_resumable_warning(&msg, Value::str(String::new()))?;
+        self.reconcile_caller_after_internal_dispatch(caller_code);
+        Ok(resumed)
+    }
+
     /// Stringify a value by calling .Str method (used by put/print).
     /// Falls back to to_string_value() if .Str method dispatch fails.
     pub(crate) fn render_str_value(&mut self, value: &Value) -> String {
         // Printing a type object stringifies to "" with rakudo's
-        // uninitialized-value warning suggesting .^name/.raku/.gist/.say.
+        // uninitialized-value warning suggesting .^name/.raku/.gist/.say —
+        // unless its class defines a user `.Stringy`/`.Str`, which dispatches
+        // instead (`class A { method Str {"foo"} }` then `print A` renders
+        // "foo", matching Rakudo).
         if let ValueView::Package(name) = value.view() {
-            let n = name.resolve();
-            let msg = format!(
-                "Use of uninitialized value of type {} in string context.\nMethods .^name, .raku, .gist, or .say can be used to stringify it to something meaningful.",
-                n
-            );
-            let resumed = self
-                .raise_resumable_warning(&msg, Value::str(String::new()))
+            let n = name.resolve().to_string();
+            if self.has_user_method(&n, "Stringy")
+                && let Ok(r) = self.call_method_with_values(value.clone(), "Stringy", vec![])
+            {
+                return r.to_string_value();
+            }
+            if self.has_user_method(&n, "Str")
+                && let Ok(r) = self.call_method_with_values(value.clone(), "Str", vec![])
+            {
+                return r.to_string_value();
+            }
+            return self
+                .warn_type_object_string_context(&n, false)
                 .map(|v| v.to_string_value())
                 .unwrap_or_default();
-            return resumed;
         }
         self.call_method_with_values(value.clone(), "Str", vec![])
             .map(|result| result.to_string_value())

--- a/src/vm/vm_coerce_concat_ops.rs
+++ b/src/vm/vm_coerce_concat_ops.rs
@@ -193,9 +193,9 @@ impl Interpreter {
                 Value::str(String::new()),
             );
         }
-        let cn = match v.view() {
-            ValueView::Instance { class_name, .. } => class_name.resolve().to_string(),
-            ValueView::Package(name) => name.resolve().to_string(),
+        let (cn, is_type_object) = match v.view() {
+            ValueView::Instance { class_name, .. } => (class_name.resolve().to_string(), false),
+            ValueView::Package(name) => (name.resolve().to_string(), true),
             _ => return Ok(v),
         };
         if self.has_user_method(&cn, "Stringy") {
@@ -205,6 +205,12 @@ impl Interpreter {
         if self.has_user_method(&cn, "Str") {
             let r = self.try_compiled_method_or_interpret(v, "Str", Vec::new())?;
             return Ok(Value::str(r.to_string_value()));
+        }
+        // A bare type object without a user stringifier warns and resumes with
+        // the empty string, matching Rakudo (`"a" ~ Int`, `Int eq "x"`). An
+        // Instance without one passes through to the pure stringifier unchanged.
+        if is_type_object {
+            return self.warn_type_object_string_context(&cn, false);
         }
         Ok(v)
     }

--- a/src/vm/vm_misc_coerce.rs
+++ b/src/vm/vm_misc_coerce.rs
@@ -132,20 +132,6 @@ impl Interpreter {
                 name.resolve()
             )));
         }
-        // Any and other Cool-descended type objects stringify to the empty
-        // string with a warning (Rakudo emits `Use of uninitialized value
-        // of type Any in string context.`).
-        if let ValueView::Package(name) = val.view()
-            && name.resolve() == "Any"
-        {
-            let msg = format!(
-                "Use of uninitialized value of type {} in string context.\nMethods .^name, .raku, .gist, or .say can be used to stringify it to something meaningful.",
-                name.resolve()
-            );
-            let resumed = self.raise_resumable_warning(&msg, Value::str(String::new()))?;
-            self.stack.push(resumed);
-            return Ok(());
-        }
         // `~Nil` warns ("Use of Nil in string context") and resumes with the
         // empty string, matching Rakudo. This mirrors the `Nil.Str`/`.Stringy`
         // method path; the prefix:<~> operator reaches this coercion opcode
@@ -197,6 +183,31 @@ impl Interpreter {
                 self.stack.push(result);
                 return Ok(());
             }
+        }
+        // A bare type object stringifies to the empty string with Rakudo's
+        // "uninitialized value of type X in string context" warning — unless its
+        // class defines a user `.Stringy`/`.Str` (`class A { method Str {...} }`
+        // then `~A` dispatches it, matching Rakudo). Mu is already handled above
+        // as a hard error, so it never reaches here.
+        if let ValueView::Package(name) = val.view() {
+            let cn = name.resolve().to_string();
+            if self.has_user_method(&cn, "Stringy") {
+                let caller_code = self.current_code;
+                let r = self.try_compiled_method_or_interpret(val.clone(), "Stringy", vec![]);
+                self.reconcile_caller_after_internal_dispatch(caller_code);
+                self.stack.push(r?);
+                return Ok(());
+            }
+            if self.has_user_method(&cn, "Str") {
+                let caller_code = self.current_code;
+                let r = self.try_compiled_method_or_interpret(val.clone(), "Str", vec![]);
+                self.reconcile_caller_after_internal_dispatch(caller_code);
+                self.stack.push(r?);
+                return Ok(());
+            }
+            let resumed = self.warn_type_object_string_context(&cn, false)?;
+            self.stack.push(resumed);
+            return Ok(());
         }
         // Force LazyList before stringification
         if let ValueView::LazyList(_) = val.view() {

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -670,6 +670,17 @@ impl Interpreter {
                     result.push_str(&r.to_string_value());
                     continue;
                 }
+                // A bare type object interpolated into a string warns and
+                // resumes with "" (Rakudo: `Use of uninitialized value element
+                // of type X in string context.` — note the "element" wording
+                // specific to interpolation). The loop reconciles the caller
+                // writeback once after it finishes (same as the Nil arm above).
+                let msg = format!(
+                    "Use of uninitialized value element of type {cn} in string context.\nMethods .^name, .raku, .gist, or .say can be used to stringify it to something meaningful."
+                );
+                let resumed = self.raise_resumable_warning(&msg, Value::str(String::new()))?;
+                result.push_str(&resumed.to_string_value());
+                continue;
             }
             result.push_str(&crate::runtime::utils::coerce_to_str(&v));
         }

--- a/t/type-object-str-context-warning.t
+++ b/t/type-object-str-context-warning.t
@@ -1,0 +1,106 @@
+use Test;
+
+# Using a bare type object in a string context warns
+# "Use of uninitialized value of type X in string context." (or, inside string
+# interpolation, "...value element of type X...") and resumes with the empty
+# string, matching raku. This covers every string-context entry point that a
+# type object can reach: the prefix:<~> and infix:<~> operators, `eq`/`lt`/...
+# string comparisons, `print`, and interpolation.
+#
+# A class that defines a user `.Str`/`.Stringy` dispatches it instead of warning,
+# even when the invocant is the bare type object.
+#
+# `.gist` / `.raku` (and `say`, which uses `.gist`) render the type name and do
+# NOT warn — they are unaffected.
+#
+# Regression: mutsu resumed with "" from prefix/infix `~`, `eq`, and
+# interpolation with no warning at all (only `print` and the `.Str` method
+# warned).
+
+plan 20;
+
+# --- prefix:<~> operator ---
+is (quietly ~Int), '', '~Int is the empty string';
+{
+    my $warned = False;
+    { my $x = ~Int; CONTROL { when CX::Warn { $warned = True; .resume } } }
+    ok $warned, '~Int emits a warning';
+}
+{
+    my $msg;
+    { my $x = ~Int; CONTROL { when CX::Warn { $msg = .message; .resume } } }
+    is $msg,
+        "Use of uninitialized value of type Int in string context.\n" ~
+        "Methods .^name, .raku, .gist, or .say can be used to stringify it to something meaningful.",
+        '~Int warning has raku wording';
+}
+
+# --- infix:<~> concatenation ---
+is (quietly ('a' ~ Int)), 'a', '"a" ~ Int drops the type-object operand';
+is (quietly (Str ~ Num)), '', 'both type-object operands drop to empty';
+{
+    my $count = 0;
+    { my $x = Str ~ Num; CONTROL { when CX::Warn { $count++; .resume } } }
+    is $count, 2, 'Str ~ Num warns once per type-object operand';
+}
+
+# --- string comparison ---
+ok (quietly (Int eq '')), 'Int eq "" is true (Int stringifies to empty)';
+nok (quietly (Int eq 'x')), 'Int eq "x" is false';
+{
+    my $warned = False;
+    { my $b = Int eq 'x'; CONTROL { when CX::Warn { $warned = True; .resume } } }
+    ok $warned, 'Int eq "x" emits a warning';
+}
+
+# --- print ---
+{
+    my $warned = False;
+    { print Int; CONTROL { when CX::Warn { $warned = True; .resume } } }
+    ok $warned, 'print Int emits a warning';
+}
+
+# --- interpolation ---
+is (quietly "a{Int}b"), 'ab', 'interpolating a type object yields the empty string';
+{
+    my Int $y;
+    is (quietly "y=$y"), 'y=', 'interpolating an uninitialized typed var yields empty';
+}
+{
+    # The common `$var` form uses raku's "element" wording exactly.
+    my Int $y;
+    my $msg;
+    { my $s = "y=$y"; CONTROL { when CX::Warn { $msg = .message; .resume } } }
+    is $msg,
+        "Use of uninitialized value element of type Int in string context.\n" ~
+        "Methods .^name, .raku, .gist, or .say can be used to stringify it to something meaningful.",
+        'variable interpolation uses raku\'s "element" wording';
+}
+{
+    # Block `{...}` interpolation of a type object still warns and resumes with
+    # "" (mutsu emits the "element" wording here too; raku uses "of type" for
+    # the block form, a cosmetic difference not asserted).
+    my $warned = False;
+    { my $s = "a{Int}b"; CONTROL { when CX::Warn { $warned = True; .resume } } }
+    ok $warned, 'block interpolation of a type object emits a warning';
+}
+
+# --- a user .Str / .Stringy dispatches even on the bare type object ---
+{
+    class WithStr { method Str { 'STR' } }
+    is (~WithStr), 'STR', '~TypeObject dispatches a user .Str';
+    is ("<" ~ WithStr ~ ">"), '<STR>', 'infix ~ dispatches a user .Str';
+    is ("[{WithStr}]"), '[STR]', 'interpolation dispatches a user .Str';
+}
+{
+    class WithStringy { method Stringy { 'STRINGY' } }
+    is (~WithStringy), 'STRINGY', '~TypeObject dispatches a user .Stringy';
+}
+
+# --- .gist / .raku are unaffected (no warning, render the type name) ---
+is Int.gist, '(Int)', 'Int.gist is "(Int)" (unaffected)';
+{
+    my $warned = False;
+    { my $g = Int.gist; CONTROL { when CX::Warn { $warned = True; .resume } } }
+    nok $warned, 'Int.gist emits no warning';
+}


### PR DESCRIPTION
## Summary

Using a bare type object (an undefined value such as `Int`, or an uninitialized `my Int $x`) in a string context now emits Rakudo's warning and resumes with the empty string, matching raku:

```
Use of uninitialized value of type Int in string context.
Methods .^name, .raku, .gist, or .say can be used to stringify it to something meaningful.
```

Previously mutsu silently resumed with `""` from prefix/infix `~`, `eq`/`lt`, and interpolation — it warned only from `print` and the `.Str` method.

## What changed

The warning is now emitted from every string-context entry point a type object can reach, via a shared `warn_type_object_string_context` helper (`src/runtime/io_env.rs`):

- prefix `~` (`~Int`) — `src/vm/vm_misc_coerce.rs`
- infix `~` and the string comparators `eq`/`lt`/… (`"a" ~ Int`, `Int eq "x"`) — `src/vm/vm_coerce_concat_ops.rs`
- string interpolation (`"$x"` with an uninitialized typed `$x`, `"{Int}"`) — `src/vm/vm_var_assign_typed.rs`
- `print` — `src/runtime/io_env.rs`

A class that defines a user `.Str`/`.Stringy` still dispatches it even on the bare type object (`class A { method Str {"foo"} }` → `~A` / `"{A}"` / `print A` render `"foo"`), matching raku — the warning fires only for type objects with no user stringifier. This also fixed a pre-existing `print` bug where a type object with a custom `.Str` warned instead of dispatching it.

`Mu` keeps its existing behavior: prefix `~Mu` is the hard error `Cannot resolve caller prefix:<~>(Mu:U)`, while infix `~`/interpolation/`print` warn like any other type object.

## Known minor divergences (documented, not addressed here)

- Block interpolation `"{Int}"` emits the `...value element of type...` wording (same as variable interpolation) rather than raku's `...value of type...`. Distinguishing the two forms would require the compiler to tag each interpolation part; the common `$var`/`$(...)` form matches raku exactly.
- `Mu eq "x"` warns and returns `False` instead of raku's `infix:<eq>(Mu:U, Str:D)` hard error.

## Testing

- New pin `t/type-object-str-context-warning.t` (20 subtests) — green on both raku and mutsu.
- `make test` PASS (22498 tests). Existing `t/nil-str-context-warning.t` and `roast/S32-basics/warn.t` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)