### PR TITLE
fix: a named param's `where` constraint can reference its sibling named params

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -641,7 +641,8 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 - dists (each its own root cause; triage individually before claiming, confirm the
   raku `-I lib` baseline first): ~~Attribute::Predicate~~ (FIXED — see Done),
   File::Ignore (PARTIAL — module now loads via Regex.ACCEPTS fix; see Done),
-  IO::Path::AutoDecompress, ~~Math::Angle~~ (FIXED — see Done), Math::PascalTriangle,
+  IO::Path::AutoDecompress, ~~Math::Angle~~ (FIXED — see Done),
+  ~~Math::PascalTriangle~~ (FIXED — see Done),
   ~~Statistics::LinearRegression~~ (FIXED — see Done), String::Rotate,
   Text::CodeProcessing, Trait::IO, WriteOnceHash, `are`, ~~`sortuk`~~ (FIXED — see Done),
   Tree::Binary::PrettyTree (role-`new` requirement FIXED; now blocked on a
@@ -666,8 +667,24 @@ _(move tickets here with `[claim: <branch>]` when you start)_
 
 ## Done
 
-- **T-057 (Statistics::LinearRegression)** (#PENDING) — 6/9 → 9/9. Two general
-  bugs, both on the path to `my LR $model .= new: @x, @y`:
+- **T-057 (Math::PascalTriangle)** (PR `fix-where-named-param-sibling-ref`) —
+  test_die → t/02-triangle.t 13/13 (release). Root cause: a `where` constraint on
+  a **named** parameter could not reference the *other* named parameters of the
+  same signature. The module's dispatch is
+  `multi method get(:$line!, :$col! where $line == *)` /
+  `where $line > *` — the `where` on `:$col!` references the sibling `:$line!`.
+  Positional params were bound into the env before later params' where-checks, but
+  named params were not, so any candidate whose `where` referenced a sibling named
+  param never matched and dispatch failed with "Cannot resolve caller". Fix:
+  `types/args_matching.rs` binds every supplied sibling named param into the env
+  before evaluating a named param's where-constraint (mirroring the positional
+  path). Pin: `t/where-named-param-sibling-ref.t`. (t/01-meta.t needs Test::META,
+  which fails to load under raku here too — out of scope.) Note: the recursive
+  `C(99,49)` case is memoized but slow (~7.5s release) because where-constrained
+  multi dispatch clones the env per candidate — a separate, pre-existing perf item,
+  not a blocker (well within the roast timeout budget).
+
+
   1. **`class ... is export` was silently dropped.** A `class Foo is export` /
      `is export(:TAG)` inside a module never became importable — the class-decl
      `is`-trait loop skipped `export` without recording it (and `is export(:ALL)`

--- a/news/2026-07/where-named-param-sibling-ref.md
+++ b/news/2026-07/where-named-param-sibling-ref.md
@@ -1,0 +1,26 @@
+# A named param's `where` constraint can reference its sibling named params
+
+A `where` constraint on a *named* parameter could not see the other named
+parameters of the same signature. Given
+
+```raku
+multi method get(:$line!, :$col! where $line == *) { 1 }
+multi method get(:$line!, :$col! where $line >  *) { ... }
+```
+
+the `where` on `:$col!` references the sibling `:$line!`. mutsu never bound the
+sibling named params into scope before evaluating the constraint, so `$line` was
+undefined during dispatch, the candidate never matched, and the call failed with
+`Cannot resolve caller ...; none of these signatures matches`.
+
+Positional parameters already worked: each is bound into the environment as
+matching proceeds, so a later param's `where` clause sees the earlier ones. Named
+parameters took a different path that bound only `$_` and the param under test.
+Now, before evaluating a named param's `where` constraint, every supplied sibling
+named param is bound into the environment too, mirroring the positional path.
+Whatever-currying on either side (`$line == *`, `* == $line`) and explicit block
+forms (`where { $col <= $line }`) all work.
+
+This fixes the `Math::PascalTriangle` distribution: its `get(:$line!, :$col!)`
+dispatch is built entirely on sibling-referencing `where` constraints, and
+`t/02-triangle.t` now passes 13/13. Pin: `t/where-named-param-sibling-ref.t`.

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -611,6 +611,20 @@ impl Interpreter {
                         }
                     };
                     let saved = self.env.clone();
+                    // Bind every sibling named parameter supplied in this call so a
+                    // `where` constraint on this param can reference the others, e.g.
+                    // `:$line!, :$col! where $line == *`. Positional params get this
+                    // for free (each is bound into env before later where-checks);
+                    // named params are only reached here, so bind them explicitly.
+                    for sib in param_defs.iter().filter(|s| s.named && !s.name.is_empty()) {
+                        let sib_bare = sib
+                            .name
+                            .trim_start_matches(|c: char| "$@%&".contains(c))
+                            .trim_start_matches(['!', '.']);
+                        if let Some((_, v)) = named_args.iter().find(|(k, _)| k == sib_bare) {
+                            self.env.insert(sib.name.clone(), v.clone());
+                        }
+                    }
                     self.env.insert("_".to_string(), val.clone());
                     // Bind the parameter name so `where {$param ...}` can reference
                     // it during dispatch matching (mirrors the positional path).

--- a/t/where-named-param-sibling-ref.t
+++ b/t/where-named-param-sibling-ref.t
@@ -1,0 +1,46 @@
+use Test;
+
+# A `where` constraint on a named parameter must be able to reference the OTHER
+# named parameters of the same signature, e.g. `:$line!, :$col! where $line == *`.
+# Positional params already saw each other; named params did not, so a candidate
+# whose `where` referenced a sibling named param never matched and multi dispatch
+# failed with "Cannot resolve caller" / "No matching candidates".
+
+plan 8;
+
+# --- Whatever on the right, referencing a sibling named param ---
+{
+    multi f(:$line!, :$col! where $line == *) { 'eq' }
+    multi f(:$line!, :$col! where $line >  *) { 'gt' }
+    is f(:line(2), :col(2)), 'eq', 'where $line == * (sibling ref, Whatever right)';
+    is f(:line(2), :col(1)), 'gt', 'where $line >  * (sibling ref, Whatever right)';
+}
+
+# --- Whatever on the left, referencing a sibling named param ---
+{
+    multi g(:$line!, :$col! where * == $line) { 'eq' }
+    multi g(:$line!, :$col! where * <  $line) { 'lt' }
+    is g(:line(5), :col(5)), 'eq', 'where * == $line (sibling ref, Whatever left)';
+    is g(:line(5), :col(3)), 'lt', 'where * <  $line (sibling ref, Whatever left)';
+}
+
+# --- explicit block form referencing both params ---
+{
+    multi h(:$line!, :$col! where { $col <= $line }) { 'ok' }
+    is h(:line(4), :col(2)), 'ok', 'where { $col <= $line } (explicit block, sibling ref)';
+}
+
+# --- full three-way dispatch as used by Math::PascalTriangle ---
+{
+    class Tri {
+        proto method get(UInt:D() :$line!, UInt:D() :$col!) {*}
+        multi method get(:$line!, :$col! where * == 0)     { 1 }
+        multi method get(:$line!, :$col! where $line == *) { 1 }
+        multi method get(:$line!, :$col! where $line > *)  {
+            self.get(:line($line - 1), :$col) + self.get(:line($line - 1), :col($col - 1))
+        }
+    }
+    is Tri.get(:line(2), :col(1)), 2,   'binomial C(2,1) via sibling-ref where dispatch';
+    is Tri.get(:line(4), :col(2)), 6,   'binomial C(4,2)';
+    is Tri.get(:line(9), :col(4)), 126, 'binomial C(9,4)';
+}


### PR DESCRIPTION
## Problem

A `where` constraint on a **named** parameter could not see the other named parameters of the same signature. Given

```raku
multi method get(:$line!, :$col! where $line == *) { 1 }
multi method get(:$line!, :$col! where $line >  *) { ... }
```

the `where` on `:$col!` references the sibling `:$line!`. mutsu never bound the sibling named params into scope before evaluating the constraint, so `$line` was undefined during dispatch, the candidate never matched, and the call failed with `Cannot resolve caller ...; none of these signatures matches`.

## Root cause

Positional parameters already worked: each is bound into the environment as matching proceeds, so a later param's `where` clause sees the earlier ones. Named parameters took a different path (`types/args_matching.rs`) that bound only `$_` and the single param under test.

## Fix

Before evaluating a named param's `where` constraint, every supplied sibling named param is bound into the environment too, mirroring the positional path. Whatever-currying on either side (`$line == *`, `* == $line`) and explicit block forms (`where { $col <= $line }`) all work.

## Impact

Fixes the `Math::PascalTriangle` distribution (T-057): its `get(:$line!, :$col!)` dispatch is built entirely on sibling-referencing `where` constraints. `t/02-triangle.t` now passes **13/13** (release). (`t/01-meta.t` needs `Test::META`, which fails to load under raku here too — out of scope.)

## Verification

- `make test`: Result: PASS (2369 files, 22491 tests)
- Pin: `t/where-named-param-sibling-ref.t` (8 tests; verified identical output under raku)
- All local where/multi/signature tests pass; no clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)