### PR TITLE
fix: qualified call `self.Builtin::method` reaches a native ancestor method

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -641,7 +641,7 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 - dists (each its own root cause; triage individually before claiming, confirm the
   raku `-I lib` baseline first): ~~Attribute::Predicate~~ (FIXED — see Done),
   File::Ignore (PARTIAL — module now loads via Regex.ACCEPTS fix; see Done),
-  IO::Path::AutoDecompress, ~~Math::Angle~~ (FIXED — see Done),
+  ~~IO::Path::AutoDecompress~~ (FIXED — see Done), ~~Math::Angle~~ (FIXED — see Done),
   ~~Math::PascalTriangle~~ (FIXED — see Done),
   ~~Statistics::LinearRegression~~ (FIXED — see Done), String::Rotate,
   Text::CodeProcessing, Trait::IO, WriteOnceHash, `are`, ~~`sortuk`~~ (FIXED — see Done),
@@ -666,6 +666,25 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 _(move tickets here with `[claim: <branch>]` when you start)_
 
 ## Done
+
+- **T-057 (IO::Path::AutoDecompress)** (PR `fix-qualified-native-ancestor-method`)
+  — test_die → t/01-basic.rakutest 8/8. Root cause: a qualified method call
+  `self.Builtin::method` where the qualifier is a **native builtin ancestor** was
+  not routed to the native method. The module's `Proccer` role does
+  `self.IO::Path::slurp(|c)` / `self.IO::Path::lines(|c)` to reach the parent's
+  native readers. mutsu's qualified dispatch only resolved a *user*-defined
+  ancestor method, so `resolve_method_with_owner("IO::Path","slurp")` returned
+  None: the instance path fell through to "No such method 'IO::Path::slurp'", and
+  the run-time-mixin path fell through to `dispatch_qualified_non_instance_method`,
+  which split at the FIRST `::` (`IO` / `Path::slurp`) → "Cannot dispatch to a
+  method on IO". Fix: after user-method lookup fails, both the instance and mixin
+  qualified-dispatch paths route to the native handler for the qualifier
+  (`try_qualified_native_ancestor_method` → `call_native_instance_method`) — which
+  bypasses any derived override, so an overriding `method slurp` calling
+  `self.IO::Path::slurp` gets the parent's native version instead of recursing.
+  A qualifier not in the MRO still dies; user-class ancestor qualified calls are
+  unchanged. Pin: `t/qualified-native-ancestor-method.t`.
+  File: `src/runtime/methods_qualified.rs`.
 
 - **T-057 (Math::PascalTriangle)** (PR `fix-where-named-param-sibling-ref`) —
   test_die → t/02-triangle.t 13/13 (release). Root cause: a `where` constraint on

--- a/news/2026-07/qualified-native-ancestor-method.md
+++ b/news/2026-07/qualified-native-ancestor-method.md
@@ -1,0 +1,25 @@
+# A qualified call `self.Builtin::method` reaches a native ancestor method
+
+A qualified method call whose qualifier is a *native* builtin ancestor — e.g.
+`self.IO::Path::slurp` from a class that `is IO::Path` — did not work. mutsu's
+qualified-dispatch paths only resolved a **user**-defined ancestor method, so a
+native (Rust-implemented) method of the qualifier type was never found:
+
+- on a plain subclass instance the call fell through to
+  `No such method 'IO::Path::slurp'`;
+- on a run-time mixin (`self but SomeRole`) it fell through to the non-instance
+  path, which split the name at the *first* `::` (`IO` / `Path::slurp`) and died
+  with `Cannot dispatch to a method on IO`.
+
+Now, after user-method lookup fails, both the instance and mixin qualified-dispatch
+paths route to the native handler for the qualifier
+(`call_native_instance_method`), provided the qualifier is in the receiver's MRO.
+Dispatching to the qualifier — not the receiver's most-derived class — means an
+overriding `method slurp` that calls `self.IO::Path::slurp` gets the parent's
+native version rather than recursing into itself. A qualifier that is not in the
+MRO still dies with `X::Method::InvalidQualifier`, and qualified calls to a
+user-defined ancestor method are unchanged.
+
+This fixes the `IO::Path::AutoDecompress` distribution (T-057), whose `Proccer`
+role delegates to `self.IO::Path::slurp` / `self.IO::Path::lines`;
+`t/01-basic.rakutest` now passes 8/8. Pin: `t/qualified-native-ancestor-method.t`.

--- a/src/runtime/methods_qualified.rs
+++ b/src/runtime/methods_qualified.rs
@@ -442,6 +442,21 @@ impl Interpreter {
             }
         }
 
+        // Last resort: the qualifier is a NATIVE builtin ancestor (verified in the
+        // MRO above) whose method is Rust-implemented rather than a user method —
+        // e.g. `self.IO::Path::slurp` from a class that `is IO::Path`. Dispatch it
+        // to the native handler for the qualifier so an overriding derived method
+        // does not recurse. (`in_mro` guaranteed above, so this cannot reach a
+        // native type outside the receiver's hierarchy.)
+        if let Some(res) = self.try_qualified_native_ancestor_method(
+            qualifier,
+            actual_method,
+            &attributes.to_map(),
+            args,
+        ) {
+            return Some(res);
+        }
+
         None
     }
 
@@ -703,6 +718,24 @@ impl Interpreter {
                 );
                 return Some(res.map(|(result, _updated)| result));
             }
+            // Last resort: qualifier is a native builtin ancestor of the mixin's
+            // inner instance (e.g. `self.IO::Path::slurp` where `self` is a
+            // run-time mixin over an `is IO::Path` instance). Dispatch to the
+            // native handler for the qualifier, reading the inner instance's
+            // attributes. (`in_mro` verified above.)
+            let attrs_map = if let ValueView::Instance { attributes, .. } = inner.as_ref().view() {
+                attributes.to_map()
+            } else {
+                AttrMap::new()
+            };
+            if let Some(res) = self.try_qualified_native_ancestor_method(
+                qualifier,
+                actual_method,
+                &attrs_map,
+                args,
+            ) {
+                return Some(res);
+            }
         }
 
         None
@@ -788,6 +821,28 @@ impl Interpreter {
             "X::Method::InvalidQualifier: Cannot dispatch to a method on {} because it is not inherited or done by {}",
             qualifier, type_name
         ))))
+    }
+
+    /// Route a qualified call `self.Builtin::method` to the native handler for
+    /// `qualifier` when `qualifier` is a builtin type whose `method` is
+    /// Rust-implemented (not a user method). Used as the last resort by the
+    /// instance / mixin qualified-dispatch paths after user-method lookup fails,
+    /// e.g. `self.IO::Path::slurp` from a class that `is IO::Path`. The caller has
+    /// already verified `qualifier` is in the receiver's MRO, so this only reaches
+    /// a native ancestor. Dispatching to the qualifier (not the receiver's most
+    /// derived class) means an overriding `method slurp` calling
+    /// `self.IO::Path::slurp` gets the parent's native version, not itself.
+    pub(super) fn try_qualified_native_ancestor_method(
+        &mut self,
+        qualifier: &str,
+        actual_method: &str,
+        attrs: &AttrMap,
+        args: Vec<Value>,
+    ) -> Option<Result<Value, RuntimeError>> {
+        if !self.is_native_method(qualifier, actual_method) {
+            return None;
+        }
+        Some(self.call_native_instance_method(qualifier, attrs, actual_method, args))
     }
 
     /// Handle method calls on Proxy subclass values (accessing subclass attributes).

--- a/t/qualified-native-ancestor-method.t
+++ b/t/qualified-native-ancestor-method.t
@@ -1,0 +1,59 @@
+use Test;
+
+# A qualified method call `self.Builtin::method` where the qualifier is a NATIVE
+# builtin ancestor (e.g. `IO::Path`) must dispatch to that type's native method,
+# bypassing any override on the derived class. Previously mutsu could only resolve
+# a qualified call to a *user*-defined ancestor method: `self.IO::Path::slurp`
+# from a class that `is IO::Path` failed with "No such method 'IO::Path::slurp'"
+# (instance) or "Cannot dispatch to a method on IO" (run-time mixin, mis-split at
+# the first `::`).
+
+plan 6;
+
+# A temp file to slurp/lines against.
+my $file = $*TMPDIR.add("qnam-{$*PID}.txt");
+$file.spurt("alpha\nbeta\ngamma\n");
+LEAVE { $file.unlink if $file.e }
+
+# --- subclass of a builtin: qualified call to the builtin ancestor's method ---
+{
+    my class MyPath is IO::Path {
+        method myslurp { self.IO::Path::slurp(:enc<utf8>) }
+        method mylines { self.IO::Path::lines(:enc<utf8>) }
+    }
+    my $p = MyPath.new($file.absolute);
+    is $p.myslurp, "alpha\nbeta\ngamma\n", 'self.IO::Path::slurp on a subclass instance';
+    is-deeply $p.mylines.List, <alpha beta gamma>.List, 'self.IO::Path::lines on a subclass instance';
+}
+
+# --- overriding method calls the ancestor's native version (no recursion) ---
+{
+    my class Loud is IO::Path {
+        method slurp(|c) { "LOUD:" ~ self.IO::Path::slurp(|c) }
+    }
+    my $p = Loud.new($file.absolute);
+    is $p.slurp(:enc<utf8>), "LOUD:alpha\nbeta\ngamma\n",
+        'overriding slurp delegating to self.IO::Path::slurp does not recurse';
+}
+
+# --- run-time mixin over a builtin-subclass instance (the AutoDecompress shape) ---
+{
+    my role Proccer { method fetch { self.IO::Path::slurp(:enc<utf8>) } }
+    my class MyPath2 is IO::Path {}
+    my $p = MyPath2.new($file.absolute) but Proccer;
+    is $p.fetch, "alpha\nbeta\ngamma\n", 'self.IO::Path::slurp through a run-time mixin';
+}
+
+# --- a bad qualifier (not in the MRO) is still rejected ---
+{
+    my class Plain is IO::Path {}
+    my $p = Plain.new($file.absolute);
+    dies-ok { $p.Str::slurp }, 'qualifier not in the MRO still dies';
+}
+
+# --- a user-class ancestor qualified call still works (regression) ---
+{
+    my class Base { method greet { 'base' } }
+    my class Deriv is Base { method greet { 'deriv:' ~ self.Base::greet } }
+    is Deriv.new.greet, 'deriv:base', 'user-class ancestor qualified call still works';
+}


### PR DESCRIPTION
## Problem

A qualified method call whose qualifier is a **native builtin ancestor** — e.g. `self.IO::Path::slurp` from a class that `is IO::Path` — did not work. mutsu's qualified-dispatch paths only resolved a *user*-defined ancestor method, so a native (Rust-implemented) method of the qualifier type was never found:

- on a plain subclass instance: `No such method 'IO::Path::slurp'`
- on a run-time mixin (`self but SomeRole`): it fell through to the non-instance path, which splits the name at the **first** `::` (`IO` / `Path::slurp`) → `Cannot dispatch to a method on IO`

## Fix

After user-method lookup fails, both the instance and mixin qualified-dispatch paths route to the native handler for the qualifier (`try_qualified_native_ancestor_method` → `call_native_instance_method`), provided the qualifier is in the receiver's MRO. Dispatching to the **qualifier** — not the receiver's most-derived class — means an overriding `method slurp` that calls `self.IO::Path::slurp` gets the parent's native version rather than recursing into itself.

A qualifier that is not in the MRO still dies with `X::Method::InvalidQualifier`; qualified calls to a user-defined ancestor method are unchanged.

## Impact

Fixes the `IO::Path::AutoDecompress` distribution (T-057), whose `Proccer` role delegates to `self.IO::Path::slurp` / `self.IO::Path::lines`. `t/01-basic.rakutest` now passes **8/8**.

## Verification

- `make test`: Result: PASS (2372 files, 22523 tests)
- Pin: `t/qualified-native-ancestor-method.t` (6 tests; verified identical output under raku)
- All local qualified-method / private-method / trust / mixin tests pass; no clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)