### PR TITLE
fix: type-object hash keys coerce to "" with a string-context warning

### DIFF
--- a/news/2026-07/hash-key-type-object-string-context.md
+++ b/news/2026-07/hash-key-type-object-string-context.md
@@ -1,0 +1,50 @@
+# Type-object hash keys coerce to "" with a string-context warning
+
+A bare type object used as a plain (`Str`-keyed) hash subscript key now coerces
+to the empty string with Rakudo's "Use of uninitialized value of type X in
+string context" warning, instead of keying by its `(Int)`-style gist.
+
+```raku
+my %h;
+%h{Int} = 1;        # warns; keys under ""
+say %h.keys.raku;   # ("",).Seq   (was ("(Int)",).Seq)
+say %h{""};         # 1           — the same entry
+```
+
+Because every distinct type object stringifies to the same `""`, they collapse
+onto one key (`%h{Int} = 1; %h{Str} = 2` leaves a single entry holding `2`),
+matching Rakudo. The coercion is applied uniformly across the whole subscript
+family — store, read, `:exists` and `:delete` — so all four agree on the `""`
+key (previously a store keyed `(Int)` while a fresh read would have keyed the
+same, but the fix keeps them consistent under the new `""` key). A type object
+whose class defines a user `.Str`/`.Stringy` dispatches it instead (no warning),
+and an object hash (`my %h{Any}`) keeps the type object as a genuine `.WHICH`
+key.
+
+## Implementation
+
+The coercion lives in one VM helper, `Interpreter::coerce_type_object_hash_key`
+(`src/runtime/io_env.rs`), mirroring the existing prefix-`~` string-context
+logic: rule out a user `.Str`/`.Stringy` (dispatch it if present), otherwise emit
+the warning via `warn_type_object_string_context` and resume with `""`. Each
+subscript site calls it when the key is a `ValueView::Package` (type object):
+
+- store — `exec_index_assign_expr_named_op_inner` (`vm_var_assign_index_named.rs`),
+  with the simple-hash fast path (`try_fast_hash_element_assign`) rejecting
+  type-object keys so they reach the slow path;
+- read — the plain-`Hash` arm of `exec_index_op_with_positional`
+  (`vm_var_index_ops.rs`);
+- `:exists` — both `Hash` arms of `exec_exists_index_adv_op`
+  (`vm_var_exists_ops.rs`);
+- `:delete` — `exec_delete_index_named_op_inner` (`vm_var_delete_ops.rs`), again
+  with the fast delete path rejecting type-object keys.
+
+Pin: `t/hash-key-type-object.t`.
+
+## Deferred
+
+List-to-hash construction (`my %h = (Int, 1, Str, 2)`) still keys the type
+objects by their gist rather than collapsing them onto `""`. That path runs
+through `exec_make_hash_op`, a non-`Result` hash-literal builder shared by `%(…)`
+literals, so warning-emitting key coercion there is a wider change left for a
+follow-up.

--- a/src/runtime/io_env.rs
+++ b/src/runtime/io_env.rs
@@ -211,6 +211,37 @@ impl Interpreter {
         Ok(resumed)
     }
 
+    /// Coerce a value used as a plain (`Str`-keyed) hash subscript key into its
+    /// string key, matching Rakudo. A bare type object stringifies to the empty
+    /// string with the "uninitialized value of type X in string context"
+    /// warning — unless its class defines a user `.Str`/`.Stringy`, which
+    /// dispatches (`%h{Foo}` where `Foo` defines `method Str` keys as its
+    /// result, no warning). All other values use the ordinary
+    /// `to_string_value` encoding. Object hashes (typed keys) do NOT reach here
+    /// — they key by `.WHICH` and keep the type object.
+    pub(crate) fn coerce_type_object_hash_key(
+        &mut self,
+        val: &Value,
+    ) -> Result<String, RuntimeError> {
+        if let ValueView::Package(name) = val.view() {
+            let cn = name.resolve().to_string();
+            if self.has_user_method(&cn, "Stringy")
+                && let Ok(r) = self.call_method_with_values(val.clone(), "Stringy", vec![])
+            {
+                return Ok(r.to_string_value());
+            }
+            if self.has_user_method(&cn, "Str")
+                && let Ok(r) = self.call_method_with_values(val.clone(), "Str", vec![])
+            {
+                return Ok(r.to_string_value());
+            }
+            return Ok(self
+                .warn_type_object_string_context(&cn, false)?
+                .to_string_value());
+        }
+        Ok(val.to_string_value())
+    }
+
     /// Stringify a value by calling .Str method (used by put/print).
     /// Falls back to to_string_value() if .Str method dispatch fails.
     pub(crate) fn render_str_value(&mut self, value: &Value) -> String {

--- a/src/vm/vm_var_assign_element.rs
+++ b/src/vm/vm_var_assign_element.rs
@@ -215,6 +215,9 @@ impl Interpreter {
                 | ValueView::Nil
                 | ValueView::Seq(..)
                 | ValueView::Slip(..)
+                // A bare type object key coerces to "" with a string-context
+                // warning (or dispatches a user .Str) — handled on the slow path.
+                | ValueView::Package(..)
         ) {
             return None;
         }

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -1501,6 +1501,12 @@ impl Interpreter {
                     };
                 let key = if use_which {
                     runtime::utils::value_which_key(&idx)
+                } else if !is_object_hash && matches!(idx.view(), ValueView::Package(_)) {
+                    // A bare type object keyed into a plain (Str-keyed) hash
+                    // coerces to the empty string with Rakudo's "uninitialized
+                    // value of type X in string context" warning (a user
+                    // `.Str`/`.Stringy` dispatches instead).
+                    self.coerce_type_object_hash_key(&idx)?
                 } else {
                     idx.to_string_value()
                 };

--- a/src/vm/vm_var_delete_ops.rs
+++ b/src/vm/vm_var_delete_ops.rs
@@ -93,7 +93,12 @@ impl Interpreter {
         // Reject complex index types
         if matches!(
             idx.view(),
-            ValueView::Array(..) | ValueView::Whatever | ValueView::GenericRange { .. }
+            ValueView::Array(..)
+                | ValueView::Whatever
+                | ValueView::GenericRange { .. }
+                // A bare type object key coerces to "" (warning / user .Str) —
+                // handled on the slow path.
+                | ValueView::Package(..)
         ) {
             return None;
         }
@@ -433,6 +438,10 @@ impl Interpreter {
                 })
                 .collect();
             Value::array(converted)
+        } else if matches!(idx.view(), ValueView::Package(_)) {
+            // A bare type object key coerces to "" (warning / user .Str) before
+            // the delete, matching the store/read/exists paths.
+            Value::str(self.coerce_type_object_hash_key(&idx)?)
         } else {
             idx
         };

--- a/src/vm/vm_var_exists_ops.rs
+++ b/src/vm/vm_var_exists_ops.rs
@@ -371,6 +371,10 @@ impl Interpreter {
                             } else {
                                 Value::hash_key_encode(&idx)
                             }
+                        } else if matches!(idx.view(), ValueView::Package(_)) {
+                            // A bare type object key coerces to "" (warning /
+                            // user .Str), matching the store/read paths.
+                            self.coerce_type_object_hash_key(&idx)?
                         } else {
                             idx.to_string_value()
                         };
@@ -504,12 +508,21 @@ impl Interpreter {
                     (0..len as i64).collect()
                 }
                 _ => {
+                    // A bare type object key coerces to "" (warning / user .Str)
+                    // before lookup, matching the store/read paths.
+                    let pkg_key = if matches!(idx.view(), ValueView::Package(_)) {
+                        Some(self.coerce_type_object_hash_key(&idx)?)
+                    } else {
+                        None
+                    };
                     // For hash access, delegate to single key exists
                     let exists = match (target.view(), idx.view()) {
                         (ValueView::Hash(map), ValueView::Str(key)) => {
                             map.contains_key(key.as_str())
                         }
-                        (ValueView::Hash(map), _) => map.contains_key(&idx.to_string_value()),
+                        (ValueView::Hash(map), _) => map.contains_key(
+                            &pkg_key.clone().unwrap_or_else(|| idx.to_string_value()),
+                        ),
                         (ValueView::Set(set, _), ValueView::Str(key)) => set.contains(key.as_str()),
                         (ValueView::Set(set, _), _) => set.contains(&idx.to_string_value()),
                         (ValueView::Bag(bag, _), ValueView::Str(key)) => {

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1002,7 +1002,15 @@ impl Interpreter {
                 }
             }
             (ValueView::Hash(items), _) => {
-                let key_str = index.to_string_value();
+                // A bare type object used as a plain-hash key coerces to the
+                // empty string with Rakudo's "uninitialized value of type X in
+                // string context" warning (a user `.Str`/`.Stringy` dispatches
+                // instead). Object hashes never reach here — they key by WHICH.
+                let key_str = if matches!(index.view(), ValueView::Package(_)) {
+                    self.coerce_type_object_hash_key(&index)?
+                } else {
+                    index.to_string_value()
+                };
                 let v = self.resolve_hash_entry(&items, &key_str);
                 if v.is_nil() {
                     if self.hash_autovivify {

--- a/t/hash-key-type-object.t
+++ b/t/hash-key-type-object.t
@@ -1,0 +1,71 @@
+use v6;
+use Test;
+
+# A bare type object used as a plain (Str-keyed) hash subscript key coerces to
+# the empty string with Rakudo's "uninitialized value of type X in string
+# context" warning. This holds across store, read, :exists and :delete, so all
+# four agree on the "" key. A user .Str/.Stringy dispatches instead (no warning),
+# and an object hash (typed keys) keeps the type object.
+
+plan 13;
+
+# --- store keys "" ---
+{
+    my %h;
+    quietly %h{Int} = 1;
+    is %h.keys.raku, '("",).Seq', 'type object store keys ""';
+    is %h.elems, 1, 'one entry stored';
+}
+
+# --- read finds the "" key ---
+{
+    my %h;
+    quietly %h{Int} = 1;
+    is (quietly %h{Int}), 1, 'read via type object finds "" entry';
+    is (quietly %h{""}), 1, 'read via literal "" finds the same entry';
+}
+
+# --- distinct type objects collapse to the same "" key ---
+{
+    my %h;
+    quietly %h{Int} = 1;
+    quietly %h{Str} = 2;
+    is %h.elems, 1, 'two distinct type objects collapse to one "" key';
+    is (quietly %h{Int}), 2, 'the later write wins';
+}
+
+# --- :exists agrees with the store ---
+{
+    my %h;
+    quietly %h{Int} = 1;
+    ok (quietly %h{Int}:exists), 'type object :exists is True after store';
+    ok (quietly %h{""}:exists), 'literal "" :exists is True too';
+    my %g;
+    nok (quietly %g{Int}:exists), 'type object :exists is False on an empty hash';
+}
+
+# --- :delete removes the "" key ---
+{
+    my %h;
+    quietly %h{Int} = 1;
+    quietly %h{Int}:delete;
+    is %h.elems, 0, 'type object :delete removes the "" entry';
+}
+
+# --- a user .Str dispatches (no coercion to "") ---
+{
+    my class Foo { method Str { "foo" } }
+    my %h;
+    %h{Foo} = 1;
+    is %h.keys.raku, '("foo",).Seq', 'user .Str type object keys by its .Str';
+    ok %h{Foo}:exists, 'user .Str :exists agrees with the store';
+}
+
+# --- an object hash keeps the type object as a key ---
+{
+    my %h{Any};
+    %h{Int} = 1;
+    is %h.keys.raku, '(Int,).Seq', 'object hash keeps the type object key';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

A bare type object used as a plain (`Str`-keyed) hash subscript key now coerces to the empty string with Rakudo's *"Use of uninitialized value of type X in string context"* warning, instead of keying by its `(Int)`-style gist.

```raku
my %h;
%h{Int} = 1;        # warns; keys under ""
say %h.keys.raku;   # ("",).Seq   (was ("(Int)",).Seq)
say %h{""};         # 1           — the same entry
```

Because every type object stringifies to the same `""`, distinct ones collapse onto one key (`%h{Int} = 1; %h{Str} = 2` leaves a single entry holding `2`), matching Rakudo. A type object whose class defines a user `.Str`/`.Stringy` dispatches it instead (no warning), and an object hash (`my %h{Any}`) keeps the type object as a genuine `.WHICH` key.

This closes a `docs/doc-diff-backlog.md` finding.

## Implementation

The coercion lives in one VM helper, `Interpreter::coerce_type_object_hash_key` (`src/runtime/io_env.rs`), mirroring the existing prefix-`~` string-context logic: rule out a user `.Str`/`.Stringy` (dispatch it if present), otherwise emit the warning via `warn_type_object_string_context` and resume with `""`. It is applied uniformly across the whole subscript family so store, read, `:exists` and `:delete` all agree on the `""` key:

- **store** — `exec_index_assign_expr_named_op_inner`, with the simple-hash fast path (`try_fast_hash_element_assign`) rejecting type-object keys so they reach the slow path;
- **read** — the plain-`Hash` arm of `exec_index_op_with_positional`;
- **`:exists`** — both `Hash` arms of `exec_exists_index_adv_op`;
- **`:delete`** — `exec_delete_index_named_op_inner`, with `try_fast_hash_delete` likewise rejecting type-object keys.

## Deferred

List-to-hash construction (`my %h = (Int, 1, Str, 2)`) still keys the type objects by gist rather than collapsing them onto `""`. That path runs through `exec_make_hash_op`, a non-`Result` hash-literal builder shared by `%(…)` literals, so warning-emitting key coercion there is a wider change left for a follow-up.

## Testing

- New pin `t/hash-key-type-object.t` (13 subtests; passes on both `raku` and `mutsu`).
- `make test` green (Files=2370, Tests=22517, Result: PASS); `cargo clippy -- -D warnings` clean.
- Verified byte-identical output vs `raku` for store/read/exists/delete, warning counts, user-`.Str` dispatch, and object-hash key retention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)