### PR TITLE
fix: object hashes key by .WHICH — key objects survive (PLAN 8.10)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1274,41 +1274,28 @@ and memory `project_list_container_aliasing_campaign`). One case remains open:
       `$v` mutation is not reflected (raku `a => 9`, mutsu `a => 1`). Separate
       method-arg-binding container case; coordinate with §8.5 and [ADR-0001] container-repr.
 
-### 8.10 Object hashes are string-keyed, not `.WHICH`-keyed (deferred deep item — found 2026-07-22 by the numerics/hashmap doc-diff sweeps)
+### 8.10 Object hashes are string-keyed, not `.WHICH`-keyed (object-hash half ✅ DONE 2026-07-24; Set/Bag/Mix element identity still open)
 
-- [ ] **An object hash (`:{ ... }` / a `%h{Any}`-typed hash) must key by the actual key
-      *object* indexed by its `.WHICH` identity, not by the key's stringification.** mutsu stores
-      *every* hash in `HashData.map: HashMap<String, Value>` (`src/value/mod.rs:940`), so an object
-      hash loses its key objects and conflates any keys that share a `.Str`. The user-visible
-      divergences:
-  - `my %h{Any} = 42 => "foo"; say %h.keys.map(*.^name)` → raku `(Int)`, mutsu `(Str)` (the key
-    object type is lost — the key was reduced to the string `"42"`).
-  - `%h<42>:exists` (look up with the allomorph `IntStr <42>`) → raku **`False`** (an `IntStr`'s
-    `.WHICH` differs from the `Int 42` key), mutsu **`True`** (both stringify to `"42"`).
-    `%h{42}:exists` is `True` in both (same `Int` key). *(numerics.rakudoc:458, hashmap.rakudoc:292.)*
-  - `:{ 0 => 42 }<0>` (Int key, IntStr lookup) → raku `(Any)`, mutsu `42`; likewise `:{ '0' => 42 }<0>`
-    (Str key, IntStr lookup) → raku `(Any)`, mutsu `42`. Only `:{ <0> => 42 }<0>` (matching IntStr
-    key/lookup) is `42` in both. *(hashmap.rakudoc:292.)*
-- **Same root, wider blast radius.** This is the QuantHash-identity issue already flagged for
-      `Set`/`Bag`/`Mix` in the PR #4788 note (`(1, "1", 1.0).Set.elems` is 1 in mutsu vs 3 in raku;
-      `∈` over a *Set* stays loose) and the `traps.rakudoc` [8] object-hash-enum-key finding
-      (`:{ Dog => 42 }{ Dog }` should be `(Any)` — a `Dog` *enum value* key is `.WHICH`-distinct from
-      the bareword). All four surfaces (object Hash, Set, Bag, Mix) share the string-key backing store.
-- **Where it bites.** Purely the doc-diff QA campaign so far (numerics [4], hashmap [1], traps [8]);
-      no roast whitelist test depends on it. Object hashes and `∈`-over-Set allomorph identity are
-      niche, so the payoff is modest — this is recorded to stop the recurring re-discovery, not as an
-      urgent item.
-- **Fix shape (representation rework — ADR-worthy).** Give the QuantHash/object-hash family a key
-      store that preserves the key `Value` and indexes by a canonical `.WHICH` string (or a `Value`
-      newtype keyed on `WHICH`), while ordinary `Str`-keyed hashes keep the fast `HashMap<String, _>`
-      path. High blast radius: `HashData` is threaded through ~everything that reads/writes hash
-      entries, plus the Set/Bag/Mix constructors (`src/runtime/methods_quanthash_ctor.rs`) and the
-      `∈`/`(elem)` membership path (already partly `.WHICH`-correct for *list* RHS via
-      `values_identical`, but not for a materialized `Set`). Coordinate with [ADR-0001] container-repr
-      and §8.5; do **not** attempt as a small slice.
-- Entry: `git checkout -b feat-which-keyed-quanthash origin/main`. Files: `src/value/mod.rs`
-      (`HashData`), `src/value/value_collections.rs`, `src/value/value_methods_a.rs`
-      (`hash_insert_through`), `src/runtime/methods_quanthash_ctor.rs`, the `∈`/`(elem)` set-op path.
+**Done (2026-07-24):** object hashes (`my %h{Any}`, `:{...}`, `Hash[K,V].new`) now key by the
+key object's `.WHICH` with the key objects preserved in `HashData.original_keys`. The invariant
+is enforced at the `tag_container_metadata` chokepoint (`ensure_object_hash_which_keys`);
+`:{...}` parses to an `__object_hash()` call (a `Mu`-keyed object hash, matching raku's
+`Hash[Mu,Mu]`); angle-word subscripts (`%h<42>`) are val()-allomorphic like standalone `<...>`
+words; classify/categorize return the `Hash[Mu,Mu]` shape per raku. All the doc-diff findings
+(numerics [4], hashmap [1], traps [8]) now match raku. Pin: `t/object-hash-which-keys.t`;
+details in `news/2026-07.md`.
+
+- [ ] **Remaining: Set/Bag/Mix element identity.** The QuantHash backing store is still
+      string-keyed: `(1, "1", 1.0).Set.elems` is 1 in mutsu vs 3 in raku, and `∈` over a
+      *materialized* Set compares stringifications (`<1> ∈ (1,).Set` is True in mutsu, False in
+      raku; the *list*-RHS branch is already `.WHICH`-correct via `values_identical`). Fix shape:
+      key `SetData.elements` / `BagData.counts` / `MixData.weights` by `value_which_key` with
+      `original_keys` covering every element (the object-hash pattern), then update the
+      membership/union/intersection paths and every direct consumer of the element strings
+      (`.keys`, `.pick`/`.roll`, printing via `typed_key`). Entry:
+      `src/builtins/quanthash_coerce.rs`, `src/runtime/methods_quanthash_ctor.rs`,
+      `src/vm/vm_set_ops.rs`, `src/runtime/ops_set.rs`. Coordinate with [ADR-0001]
+      container-repr; the read-side `typed_key` reconstruction already exists.
 
 ### 8.12 `.produce` with `last`, and `.reduce` with a destructuring signature — ✅ DONE 2026-07-23
 

--- a/news/2026-07.md
+++ b/news/2026-07.md
@@ -4804,6 +4804,39 @@ composed callables, not `.assuming` wrappers. Out-of-scope `where`-constraint di
 verified already correct (candidates are specificity-sorted at capture time by
 `resolve_all_multi_candidates`). Pin: `t/multi-ref-dispatch.t` (14 tests, raku-verified).
 
+## 2026-07-24: object hashes key by `.WHICH` — key objects survive (PLAN §8.10, object-hash half)
+
+Object hashes (`my %h{Any}`, `:{...}`, `Hash[K,V].new`) stored every key as its
+stringification, conflating any keys sharing a `.Str` (`my %h{Any} = 42 => "foo"` reported
+`(Str)` keys; `%h<42>:exists` — an IntStr allomorph — wrongly hit the `Int 42` key;
+`:{ 0 => 42 }<0>` returned 42 instead of `(Any)`; `:{ Dog => 42 }{Dog}` hit the autoquoted
+Str key). Now every entry is stored under the canonical `.WHICH` string of its key *object*
+(`value_which_key`), with the objects preserved in `HashData.original_keys`.
+
+Design: the keying invariant is enforced at the `tag_container_metadata` chokepoint
+(`ensure_object_hash_which_keys` — idempotent, losslessly re-keys a stringified hash from the
+key objects the key-type-blind builders record in `original_keys`). Key changes riding on it:
+
+- `:{...}` (including empty) parses to an `__object_hash()` call building a `Mu`-keyed object
+  hash — raku's `Hash[Mu,Mu]` shape; missing-key reads yield `Any`, `.raku` prints
+  `(my Mu %{Mu} = ...)`.
+- Angle-word subscripts (`%h<42>`) are val()-allomorphic like standalone `<...>` words, so an
+  IntStr lookup is `.WHICH`-distinct from both `Int 42` and `Str "42"`.
+- Bulk assignment, `Hash[Int,Int].new(1 => 2)`, `.push`, `AT-KEY`/`EXISTS-KEY`/`ASSIGN-KEY`/
+  `DELETE-KEY`, `:exists`/`:delete`, slices, `.keys`/`.kv`/`.pairs`/`.pick`, `say`/`.gist`/
+  `.raku`, `∈` membership, Set/Bag/Mix coercions, `|%h` interpolation and hash-to-hash
+  flattening all preserve or correctly stringify the key objects (an object hash assigned to a
+  plain `%` var stringifies, to an object-hash var keeps the objects — matching raku).
+- classify/categorize return raku's `Hash[Mu,Mu]` shape at every nesting level, and `:into`
+  targets keep their object-hash identity.
+- Expression-position container declarations register their type constraint BEFORE the
+  initializer runs, fixing a stale-constraint leak between `%__ANON_HASH__` EVALs.
+- `my %h{Int} = "42" => 1` now fails the key type check like raku (the recorded key object is
+  checked, not a lossy string reconstruction).
+
+Pin: `t/object-hash-which-keys.t` (30 tests, raku-verified). Remaining in PLAN §8.10: the
+Set/Bag/Mix element stores are still string-keyed (`(1,"1",1.0).Set.elems` is 1 vs raku 3).
+
 ## References
 
 - The whitelist stands at **1338** as of this writing (2026-07-01, at `4c311c71`).

--- a/src/builtins/map_hash_coerce.rs
+++ b/src/builtins/map_hash_coerce.rs
@@ -208,6 +208,10 @@ pub(crate) fn to_map(target: Value) -> Result<Value, RuntimeError> {
                 return Ok(target.clone());
             }
             // Decontainerize values (Map values are not wrapped in Scalar).
+            // An object hash stores `.WHICH` keys — a plain `.Map` is
+            // Str-keyed, so stringify each original key object (raku:
+            // `my %h{Any} = 1 => "a"; %h.Map.keys` is `("1",)`).
+            let typed = map.has_typed_keys();
             let deconted: HashMap<String, Value> = map
                 .iter()
                 .map(|(k, v)| {
@@ -215,7 +219,12 @@ pub(crate) fn to_map(target: Value) -> Result<Value, RuntimeError> {
                         ValueView::Scalar(inner) => inner.clone(),
                         _ => v.clone(),
                     };
-                    (k.clone(), deconted)
+                    let key = if typed {
+                        map.typed_key(k).to_string_value()
+                    } else {
+                        k.clone()
+                    };
+                    (key, deconted)
                 })
                 .collect();
             break 'hash Value::hash(deconted);

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -935,11 +935,20 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
             }
             Ok(Value::capture(vec![], named))
         }
-        // Hash.Capture → named args from hash entries
+        // Hash.Capture → named args from hash entries. An object hash stores
+        // `.WHICH` keys — the named-arg name is the original key's
+        // stringification (raku: `("42" => 70, :42a).Capture` on an object
+        // hash is `\(:42(70), :a(42))`).
         ValueView::Hash(map) => {
+            let typed = map.has_typed_keys();
             let mut named = HashMap::new();
             for (k, v) in map.iter() {
-                named.insert(k.clone(), v.clone());
+                let name = if typed {
+                    map.typed_key(k).to_string_value()
+                } else {
+                    k.clone()
+                };
+                named.insert(name, v.clone());
             }
             Ok(Value::capture(vec![], named))
         }

--- a/src/builtins/methods_0arg/dispatch_core_range.rs
+++ b/src/builtins/methods_0arg/dispatch_core_range.rs
@@ -5,7 +5,6 @@ use crate::runtime;
 use crate::symbol::Symbol;
 use crate::value::{RuntimeError, Value, ValueView};
 
-use super::raku_repr::hash_pick_item;
 use super::{is_infinite_range, sample_weighted_bag_key, sample_weighted_mix_key};
 
 /// Efficiently sample one random element from a Range without enumerating all elements.
@@ -184,7 +183,10 @@ pub(super) fn dispatch(
                         idx = items.len() - 1;
                     }
                     let (key, value) = items.iter().nth(idx).expect("index in range");
-                    Some(Ok(hash_pick_item(key, value)))
+                    // typed_pair reconstructs an object hash's real key object
+                    // from its `.WHICH` store key (plain hashes get the plain
+                    // `Pair(str_key, v)` as before).
+                    Some(Ok(items.typed_pair(key, value.clone())))
                 }
             }
             _ => {

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -516,7 +516,16 @@ pub(super) fn dispatch(
                         sorted_keys.sort();
                         let parts: Vec<String> = sorted_keys
                             .iter()
-                            .map(|k| format!("{} => {}", k, gist_item(&map[*k])))
+                            .map(|k| {
+                                // An object hash stores `.WHICH` string keys;
+                                // show the original key (`True`, not `Bool|1`).
+                                let key_disp = if map.has_typed_keys() {
+                                    gist_item(&map.typed_key(k))
+                                } else {
+                                    (*k).clone()
+                                };
+                                format!("{} => {}", key_disp, gist_item(&map[*k]))
+                            })
                             .collect();
                         // A nested immutable Map gists as `Map.new((...))`, not `{...}`.
                         if map.declared_type.as_deref() == Some("Map") {
@@ -642,7 +651,16 @@ pub(super) fn dispatch(
                         sorted_keys.sort();
                         let parts: Vec<String> = sorted_keys
                             .iter()
-                            .map(|k| format!("{} => {}", k, gist_item(&map[*k])))
+                            .map(|k| {
+                                // An object hash stores `.WHICH` string keys;
+                                // show the original key (`True`, not `Bool|1`).
+                                let key_disp = if map.has_typed_keys() {
+                                    gist_item(&map.typed_key(k))
+                                } else {
+                                    (*k).clone()
+                                };
+                                format!("{} => {}", key_disp, gist_item(&map[*k]))
+                            })
                             .collect();
                         // A nested immutable Map gists as `Map.new((...))`, not `{...}`.
                         if map.declared_type.as_deref() == Some("Map") {

--- a/src/builtins/methods_0arg/raku_repr.rs
+++ b/src/builtins/methods_0arg/raku_repr.rs
@@ -874,7 +874,12 @@ pub fn raku_value(v: &Value) -> String {
             // and the itemized wrapper (`$(my Int %)`) stay type-aware without an
             // interpreter round-trip. (`Map` is handled above and returns early.)
             if map.value_type.is_some() || map.key_type.is_some() {
-                let value_type = map.value_type.as_deref().unwrap_or("Any");
+                // An object hash with no element-type constraint is a
+                // `:{...}` literal — rakudo's Hash[Mu,Mu], shown as `my Mu`.
+                let value_type = map
+                    .value_type
+                    .as_deref()
+                    .unwrap_or(if map.key_type.is_some() { "Mu" } else { "Any" });
                 let key_suffix = match map.key_type.as_deref() {
                     Some(kt) => format!("{{{}}}", kt),
                     None => String::new(),
@@ -1122,19 +1127,6 @@ pub(crate) fn setbagmix_raku(v: &Value) -> Option<String> {
             Some(format!("({}).{}", pairs, type_name))
         }
         _ => None,
-    }
-}
-
-pub(super) fn hash_pick_item(key: &str, value: &Value) -> Value {
-    match key {
-        "True" => Value::value_pair(Value::TRUE, value.clone()),
-        "False" => Value::value_pair(Value::FALSE, value.clone()),
-        _ => {
-            if let Ok(n) = key.parse::<f64>() {
-                return Value::value_pair(Value::num(n), value.clone());
-            }
-            Value::pair(key.to_string(), value.clone())
-        }
     }
 }
 

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -1976,8 +1976,16 @@ pub(crate) fn native_method_1arg(
         }
         "AT-KEY" => match target.view() {
             ValueView::Hash(map) => {
-                let key = arg.to_string_value();
-                Some(Ok(map.get(&key).cloned().unwrap_or(Value::NIL)))
+                // An object hash stores `.WHICH` keys (fall back to the plain
+                // string key for the ordinary Str-keyed hash).
+                let v = if map.key_type.is_some() {
+                    let which = crate::runtime::utils::value_which_key(arg);
+                    map.get(&which).cloned()
+                } else {
+                    None
+                };
+                let v = v.or_else(|| map.get(&arg.to_string_value()).cloned());
+                Some(Ok(v.unwrap_or(Value::NIL)))
             }
             ValueView::Set(data, _) => {
                 let key = arg.to_string_value();
@@ -2014,8 +2022,12 @@ pub(crate) fn native_method_1arg(
         },
         "EXISTS-KEY" => match target.view() {
             ValueView::Hash(map) => {
-                let key = arg.to_string_value();
-                Some(Ok(Value::truth(map.contains_key(&key))))
+                // An object hash stores `.WHICH` keys (fall back to the plain
+                // string key for the ordinary Str-keyed hash).
+                let found = (map.key_type.is_some()
+                    && map.contains_key(&crate::runtime::utils::value_which_key(arg)))
+                    || map.contains_key(&arg.to_string_value());
+                Some(Ok(Value::truth(found)))
             }
             ValueView::Set(data, _) => {
                 let key = arg.to_string_value();

--- a/src/builtins/quanthash_coerce.rs
+++ b/src/builtins/quanthash_coerce.rs
@@ -63,9 +63,21 @@ pub(crate) fn to_set(target: Value, what: &str) -> Result<Value, RuntimeError> {
                 }
             }
             ValueView::Hash(h) if flatten => {
+                // An object hash contributes its key OBJECTS (decoded from the
+                // `.WHICH` store keys); a plain hash its string keys.
                 for (k, v) in h.iter() {
                     if v.truthy() {
-                        elems.insert(k.clone());
+                        if h.has_typed_keys() {
+                            let obj = h.typed_key(k);
+                            let str_key = obj.to_string_value();
+                            if !matches!(obj.view(), ValueView::Str(_)) {
+                                *has_non_str = true;
+                                original_keys.entry(str_key.clone()).or_insert(obj);
+                            }
+                            elems.insert(str_key);
+                        } else {
+                            elems.insert(k.clone());
+                        }
                     }
                 }
             }
@@ -119,9 +131,21 @@ pub(crate) fn to_set(target: Value, what: &str) -> Result<Value, RuntimeError> {
             }
         }
         ValueView::Hash(items) => {
+            // An object hash's Set keeps the key OBJECTS (`:{42 => "a"}.Set`
+            // is `Set.new(42)`, an Int element); plain hashes keep Str keys.
             for (k, v) in items.iter() {
                 if v.truthy() {
-                    elems.insert(k.clone());
+                    if items.has_typed_keys() {
+                        let obj = items.typed_key(k);
+                        let str_key = obj.to_string_value();
+                        if !matches!(obj.view(), ValueView::Str(_)) {
+                            has_non_str = true;
+                            original_keys.entry(str_key.clone()).or_insert(obj);
+                        }
+                        elems.insert(str_key);
+                    } else {
+                        elems.insert(k.clone());
+                    }
                 }
             }
         }
@@ -309,7 +333,19 @@ pub(crate) fn to_bag(target: Value, what: &str) -> Result<Value, RuntimeError> {
                 for (k, v) in h.iter() {
                     let weight = pair_weight(v)?;
                     if weight.is_positive() {
-                        *counts.entry(k.clone()).or_default() += weight;
+                        // Object hashes contribute their key OBJECTS.
+                        let key = if h.has_typed_keys() {
+                            let obj = h.typed_key(k);
+                            let str_key = obj.to_string_value();
+                            if !matches!(obj.view(), ValueView::Str(_)) {
+                                *has_non_str_keys = true;
+                                original_keys.entry(str_key.clone()).or_insert(obj);
+                            }
+                            str_key
+                        } else {
+                            k.clone()
+                        };
+                        *counts.entry(key).or_default() += weight;
                     }
                 }
             }
@@ -611,7 +647,20 @@ fn mix_add_item_with_keys(
             for (k, v) in h.iter() {
                 let w = mix_pair_weight_value(v)?;
                 if w.to_f64() != 0.0 {
-                    mix_accum(weights, k.clone(), w)?;
+                    // Object hashes contribute their key OBJECTS.
+                    let key = if h.has_typed_keys() {
+                        let obj = h.typed_key(k);
+                        let str_key = obj.to_string_value();
+                        if let Some(ref mut orig) = original_keys
+                            && !matches!(obj.view(), ValueView::Str(_))
+                        {
+                            orig.entry(str_key.clone()).or_insert(obj);
+                        }
+                        str_key
+                    } else {
+                        k.clone()
+                    };
+                    mix_accum(weights, key, w)?;
                 }
             }
         }

--- a/src/compiler/expr_block.rs
+++ b/src/compiler/expr_block.rs
@@ -1,6 +1,45 @@
 use super::*;
 
 impl Compiler {
+    /// The constraint string an expression-position container declaration
+    /// (`(my Int @c)`, `$(my Int %{Int})`) registers via `SetVarType`, or
+    /// `None` when nothing should be tagged. Boxed element types only —
+    /// native `int`/`num`/`str` change the storage and would panic in the
+    /// auto-vivify. For an *anonymous* object hash (`my Int %{Int}` as an
+    /// rvalue / `$(...)` itemization / EVAL round-trip) this keeps the FULL
+    /// constraint including the `{KeyType}` half, so the container's key type
+    /// survives and `(my Int %{Int})` round-trips through `.raku.EVAL`. A
+    /// *named* object hash (`my Int %j{Cool}`) tags only the VALUE-type half:
+    /// re-applying the key-type half would mark the value `.WHICH`-keyed
+    /// while a raw-binding mutation (`gen my Int %j{Cool}` → `sub gen(\h){
+    /// h{$_}=... }`) can still store plain string keys, so adverbs
+    /// (`%j<b>:k`) would miss.
+    fn expr_decl_settable_constraint(
+        name: &str,
+        type_constraint: &Option<String>,
+    ) -> Option<String> {
+        if !(name.starts_with('@') || name.starts_with('%')) {
+            return None;
+        }
+        let tc = type_constraint.as_ref()?;
+        let is_native_value_type = if name.starts_with('@') {
+            crate::runtime::native_types::is_native_array_element_type(tc)
+        } else {
+            crate::runtime::native_types::is_native_int_type(tc)
+                || matches!(tc.as_str(), "num" | "num32" | "num64" | "str")
+        };
+        if is_native_value_type {
+            return None;
+        }
+        let value_tc = if name.starts_with('%') && !name.contains("__ANON_HASH__") {
+            tc.split('{').next().unwrap_or(tc)
+        } else {
+            tc
+        };
+        // Bare `my %h{KeyType}` (no value type): nothing to tag.
+        (!value_tc.is_empty()).then(|| value_tc.to_string())
+    }
+
     /// Compile DoStmt expression (do { ... }, do if, do for, etc.).
     pub(super) fn compile_expr_do_stmt(&mut self, stmt: &Stmt) {
         match stmt {
@@ -85,6 +124,21 @@ impl Compiler {
                         self.code.emit(OpCode::Pop);
                         Some(j)
                     };
+                    // Register the declared type constraint BEFORE the
+                    // initializer assignment, so the assignment's coercion and
+                    // container tagging see THIS declaration's constraint — not
+                    // a stale one left on the shared name by a previous
+                    // expression-position declaration (`$(my Mu %{Mu} = :k<v>)`
+                    // EVAL'd after `(my Int %{Int} = 1 => 2)` reuses
+                    // `%__ANON_HASH__`, and the stale `Int` constraint would
+                    // reject the new values). The post-assignment `SetVarType`
+                    // below still runs to re-tag the stored value.
+                    if let Some(pre_tc) = Self::expr_decl_settable_constraint(name, type_constraint)
+                    {
+                        let name_idx = self.code.add_constant(Value::str(name.clone()));
+                        let tc_idx = self.code.add_constant(Value::str(pre_tc));
+                        self.code.emit(OpCode::SetVarType { name_idx, tc_idx });
+                    }
                     self.compile_expr(expr);
                     let name_idx = self.code.add_constant(Value::str(name.clone()));
                     // Mark a fresh declaration so SetGlobal creates a NEW container
@@ -141,38 +195,11 @@ impl Compiler {
                     //    `Positional[T]`/`Associative[T]` type-capture binding working;
                     //    that role-matching gap is now fixed in `resolved_type_capture_name`,
                     //    so a genuinely-typed `Hash[Int]`/`Array[Int]` binds correctly.)
-                    let is_native_value_type = type_constraint.as_ref().is_some_and(|tc| {
-                        if name.starts_with('@') {
-                            crate::runtime::native_types::is_native_array_element_type(tc)
-                        } else {
-                            crate::runtime::native_types::is_native_int_type(tc)
-                                || matches!(tc.as_str(), "num" | "num32" | "num64" | "str")
-                        }
-                    });
-                    if (name.starts_with('@') || name.starts_with('%'))
-                        && let Some(tc) = type_constraint
-                        && !is_native_value_type
+                    if let Some(post_tc) =
+                        Self::expr_decl_settable_constraint(name, type_constraint)
                     {
-                        // For an *anonymous* object hash (`my Int %{Int}` as an
-                        // rvalue / `$(...)` itemization / EVAL round-trip), tag the
-                        // FULL constraint including the `{KeyType}` half, so the
-                        // container's key type survives (`(my Int %{Int})` .raku
-                        // round-trips). The anonymous form is never the target of a
-                        // raw-binding mutation (`gen my Int %{Cool}` → `\h` param →
-                        // `h{$_}=...`), so tagging the key type here cannot desync a
-                        // later plain-string-keyed write — the concern that keeps a
-                        // *named* object hash's key type stripped below.
-                        let value_tc = if name.starts_with('%') && !name.contains("__ANON_HASH__") {
-                            tc.split('{').next().unwrap_or(tc)
-                        } else {
-                            tc
-                        };
-                        if value_tc.is_empty() {
-                            // Bare `my %h{KeyType}` (no value type): nothing to tag.
-                        } else {
-                            let tc_idx = self.code.add_constant(Value::str(value_tc.to_string()));
-                            self.code.emit(OpCode::SetVarType { name_idx, tc_idx });
-                        }
+                        let tc_idx = self.code.add_constant(Value::str(post_tc));
+                        self.code.emit(OpCode::SetVarType { name_idx, tc_idx });
                     }
                     // Read back the coerced value (SetGlobal coerces list->hash for %)
                     let name_idx2 = self.code.add_constant(Value::str(name.clone()));

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -700,12 +700,21 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                             .all(|key| !key.is_empty() && key.chars().all(is_angle_key_char))
                     {
                         let r2 = &r2[end + 1..];
+                        // Angle-word subscript keys are val()-allomorphic like
+                        // standalone `<...>` words: `%h<42>` looks up with an
+                        // IntStr, which an object hash keys distinctly from
+                        // both `Int 42` and `Str "42"`. Plain hashes stringify
+                        // the key, so they are unaffected.
                         let index_expr = if keys.len() == 1 {
-                            Expr::Literal(Value::str(keys[0].to_string()))
+                            Expr::Literal(crate::parser::angle_word_value_full_allomorphic(keys[0]))
                         } else {
                             Expr::ArrayLiteral(
                                 keys.into_iter()
-                                    .map(|k| Expr::Literal(Value::str(k.to_string())))
+                                    .map(|k| {
+                                        Expr::Literal(
+                                            crate::parser::angle_word_value_full_allomorphic(k),
+                                        )
+                                    })
                                     .collect(),
                             )
                         };
@@ -1494,14 +1503,17 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                 return Err(PError::expected_at("angle index key", r));
             }
             let r = &r[end + 1..];
+            // Angle-word subscript keys are val()-allomorphic like standalone
+            // `<...>` words (see the `.<...>` postfix above). A nested-angle
+            // key (`%h<a<b>>`) is a single literal Str key as before.
             let index_expr = if nested_angle {
                 Expr::Literal(Value::str(content.to_string()))
             } else if keys.len() == 1 {
-                Expr::Literal(Value::str(keys[0].to_string()))
+                Expr::Literal(crate::parser::angle_word_value_full_allomorphic(keys[0]))
             } else {
                 Expr::ArrayLiteral(
                     keys.into_iter()
-                        .map(|k| Expr::Literal(Value::str(k.to_string())))
+                        .map(|k| Expr::Literal(crate::parser::angle_word_value_full_allomorphic(k)))
                         .collect(),
                 )
             };
@@ -2572,12 +2584,20 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                             .iter()
                             .all(|key| !key.is_empty() && key.chars().all(is_angle_key_char))
                     {
+                        // val()-allomorphic keys, matching the plain `<...>`
+                        // subscript above.
                         let args = if keys.len() == 1 {
-                            vec![Expr::Literal(Value::str(keys[0].to_string()))]
+                            vec![Expr::Literal(
+                                crate::parser::angle_word_value_full_allomorphic(keys[0]),
+                            )]
                         } else {
                             vec![Expr::ArrayLiteral(
                                 keys.into_iter()
-                                    .map(|k| Expr::Literal(Value::str(k.to_string())))
+                                    .map(|k| {
+                                        Expr::Literal(
+                                            crate::parser::angle_word_value_full_allomorphic(k),
+                                        )
+                                    })
                                     .collect(),
                             )]
                         };

--- a/src/parser/primary/misc/colonpair.rs
+++ b/src/parser/primary/misc/colonpair.rs
@@ -86,9 +86,17 @@ pub(crate) fn colonpair_expr(input: &str) -> PResult<'_, Expr> {
     // expression-based parsing rather than the simple hash key heuristic.
     if let Some(after_brace) = r.strip_prefix('{') {
         let (inner, _) = ws_inner(after_brace);
-        // Empty object hash: :{}
+        // Empty object hash: :{} — still a Mu-keyed object hash, so route
+        // through the same `__object_hash()` construction as the non-empty
+        // form (a plain `Expr::Hash` would lose the key-type marking).
         if let Some(rest) = inner.strip_prefix('}') {
-            return Ok((rest, Expr::Hash(Vec::new())));
+            return Ok((
+                rest,
+                Expr::Call {
+                    name: crate::symbol::Symbol::intern("__object_hash"),
+                    args: Vec::new(),
+                },
+            ));
         }
         return parse_object_hash_body(inner);
     }
@@ -770,8 +778,9 @@ fn parse_signature_fragment(input: &str) -> PResult<'_, String> {
 
 /// Parse the body of an object hash `:{ ... }`.
 /// Object hashes allow arbitrary expression keys (e.g., regex), so we parse
-/// each entry using full expression parsing and emit a `hash(...)` call with
-/// Pair arguments, preserving expression-typed keys at runtime.
+/// each entry using full expression parsing and emit an `__object_hash(...)`
+/// call with Pair arguments — the runtime builds a `Mu`-keyed object hash
+/// (`.WHICH`-keyed, key objects preserved), matching raku's `Hash[Mu,Mu]`.
 fn parse_object_hash_body(input: &str) -> PResult<'_, Expr> {
     let mut args = Vec::new();
     let mut rest = input;
@@ -781,7 +790,7 @@ fn parse_object_hash_body(input: &str) -> PResult<'_, Expr> {
             return Ok((
                 rest,
                 Expr::Call {
-                    name: crate::symbol::Symbol::intern("hash"),
+                    name: crate::symbol::Symbol::intern("__object_hash"),
                     args,
                 },
             ));

--- a/src/parser/primary/mod.rs
+++ b/src/parser/primary/mod.rs
@@ -434,16 +434,17 @@ mod tests {
 
     #[test]
     fn parse_typed_hash_literal_with_non_string_keys() {
-        // Object hash `:{ ... }` is now parsed as a `hash(...)` call
-        // to preserve expression-typed keys (e.g., regex keys).
+        // Object hash `:{ ... }` parses as an `__object_hash(...)` call —
+        // the runtime builds a Mu-keyed, `.WHICH`-keyed object hash — with
+        // expression-typed keys (e.g., regex keys) preserved as arguments.
         let (rest, expr) = primary(":{ :42foo, (True) => False, 42e0 => 1 }").unwrap();
         assert_eq!(rest, "");
         match expr {
             Expr::Call { name, args } => {
-                assert_eq!(name, "hash");
+                assert_eq!(name, "__object_hash");
                 assert_eq!(args.len(), 3);
             }
-            _ => panic!("expected hash call, got {:?}", expr),
+            _ => panic!("expected __object_hash call, got {:?}", expr),
         }
     }
 

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -703,6 +703,7 @@ impl Interpreter {
             "bag" => self.builtin_bag(&args),
             "mix" => self.builtin_mix(&args),
             "hash" => self.builtin_hash(&args),
+            "__object_hash" => self.builtin_object_hash(&args),
             "any" | "all" | "one" | "none" => self.builtin_junction(name, args),
             "pair" => self.builtin_pair(&args),
             "keys" => self.builtin_keys(&args),

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -362,10 +362,15 @@ impl Interpreter {
     }
 
     /// `:{ ... }` — a `Mu`-keyed object hash. Builds like `hash(...)` (which
-    /// records the key objects in `original_keys`), then tags the `Mu` key/value
-    /// types and re-keys by `.WHICH`.
+    /// records the key objects in `original_keys`), then tags the `Mu` key type
+    /// and re-keys by `.WHICH`. Uses the warning-free builder: an object hash
+    /// KEEPS a type-object key distinct (no ""-stringification warning).
     pub(super) fn builtin_object_hash(&self, args: &[Value]) -> Result<Value, RuntimeError> {
-        let hash = self.builtin_hash(args)?;
+        let mut flat_values = Vec::new();
+        for arg in args {
+            flat_values.extend(Self::value_to_list(arg));
+        }
+        let hash = crate::runtime::utils::build_hash_from_items(flat_values)?;
         Ok(crate::runtime::utils::into_object_hash(hash, "Mu"))
     }
 

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -347,6 +347,7 @@ impl Interpreter {
             "list" => self.builtin_list(args),
             "slip" | "Slip" => self.builtin_slip(args),
             "hash" => self.builtin_hash(args),
+            "__object_hash" => self.builtin_object_hash(args),
             _ => return None,
         };
         Some(r)
@@ -358,6 +359,14 @@ impl Interpreter {
             flat_values.extend(Self::value_to_list(arg));
         }
         self.build_hash_from_items_warning(flat_values)
+    }
+
+    /// `:{ ... }` — a `Mu`-keyed object hash. Builds like `hash(...)` (which
+    /// records the key objects in `original_keys`), then tags the `Mu` key/value
+    /// types and re-keys by `.WHICH`.
+    pub(super) fn builtin_object_hash(&self, args: &[Value]) -> Result<Value, RuntimeError> {
+        let hash = self.builtin_hash(args)?;
+        Ok(crate::runtime::utils::into_object_hash(hash, "Mu"))
     }
 
     pub(super) fn builtin_junction(

--- a/src/runtime/builtins_collection_classify.rs
+++ b/src/runtime/builtins_collection_classify.rs
@@ -431,7 +431,7 @@ impl Interpreter {
     /// single (non-flattening) array — Raku stores each bucket as `$[...]`, so
     /// `my @a = %c<k>` yields one element and `for %c<k> {}` runs once. Recurses
     /// into nested categorize buckets (multi-level paths become nested hashes).
-    fn itemize_bucket_value(mut v: Value) -> Value {
+    fn itemize_bucket_value(mut v: Value, object_hash: bool) -> Value {
         if matches!(v.view(), ValueView::Array(..)) {
             let (items, kind) = v.into_array().unwrap();
             return Value::array_with_kind(items, kind.itemize());
@@ -442,14 +442,22 @@ impl Interpreter {
                 let keys: Vec<String> = data.map.keys().cloned().collect();
                 for k in keys {
                     if let Some(val) = data.map.remove(&k) {
-                        data.map.insert(k, Self::itemize_bucket_value(val));
+                        data.map
+                            .insert(k, Self::itemize_bucket_value(val, object_hash));
                     }
                 }
-                // A nested multi-level bucket is a `Mu`-keyed object hash in
-                // raku, like the top-level result.
-                data.key_type = Some("Mu".to_string());
+                // When the top-level result is an object hash (standalone
+                // classify/categorize, or `:into` an object hash), the nested
+                // multi-level buckets are `Mu`-keyed object hashes too, like
+                // raku. Classifying into a PLAIN hash keeps plain nested
+                // buckets.
+                if object_hash {
+                    data.key_type = Some("Mu".to_string());
+                }
             }
-            crate::runtime::utils::ensure_object_hash_which_keys(arc);
+            if object_hash {
+                crate::runtime::utils::ensure_object_hash_which_keys(arc);
+            }
         });
         v
     }
@@ -467,7 +475,7 @@ impl Interpreter {
     ) -> Value {
         let buckets: HashMap<String, Value> = buckets
             .into_iter()
-            .map(|(k, v)| (k, Self::itemize_bucket_value(v)))
+            .map(|(k, v)| (k, Self::itemize_bucket_value(v, key_type.is_some())))
             .collect();
         let mut hash = Value::hash(buckets);
         hash.with_hash_mut(|arc| {

--- a/src/runtime/builtins_collection_classify.rs
+++ b/src/runtime/builtins_collection_classify.rs
@@ -94,22 +94,31 @@ impl Interpreter {
                     .or_insert_with(|| Value::hash(HashMap::new()));
                 let is_hash = matches!(entry.view(), ValueView::Hash(_));
                 let is_array = matches!(entry.view(), ValueView::Array(..));
+                // Record the next path component's key object in the nested
+                // hash's `original_keys` so the multi-level result can be
+                // re-keyed by `.WHICH` per level (nested buckets are `Mu`-keyed
+                // object hashes in raku, like the top level).
+                let recurse = |map: &mut crate::gc::Gc<crate::value::HashData>,
+                               item: Value|
+                 -> Result<(), RuntimeError> {
+                    let data = crate::gc::Gc::make_mut(map);
+                    if !matches!(path[1].view(), ValueView::Str(_)) {
+                        data.original_keys
+                            .get_or_insert_with(HashMap::new)
+                            .insert(path[1].to_string_value(), path[1].clone());
+                    }
+                    insert_nested_bucket(&mut data.map, &path[1..], item, name)
+                };
                 if is_hash {
                     entry
-                        .with_hash_mut(|map| {
-                            let map = crate::gc::Gc::make_mut(map);
-                            insert_nested_bucket(map, &path[1..], item, name)
-                        })
+                        .with_hash_mut(|map| recurse(map, item.clone()))
                         .unwrap()
                 } else if is_array {
                     Err(mixed_level_error(name))
                 } else {
                     *entry = Value::hash(HashMap::new());
                     entry
-                        .with_hash_mut(|map| {
-                            let map = crate::gc::Gc::make_mut(map);
-                            insert_nested_bucket(map, &path[1..], item, name)
-                        })
+                        .with_hash_mut(|map| recurse(map, item.clone()))
                         .unwrap_or(Ok(()))
                 }
             }
@@ -212,8 +221,35 @@ impl Interpreter {
             }
         }
 
+        // Object-hash key preservation (§3.3): when the classifier returns a
+        // non-`Str` key (e.g. a Junction from `*.contains: any 'a','f'`), the
+        // bucket key is stored under its stringification but the result must be
+        // an *object hash* so `$result{ any(...) }` is a by-key lookup (not
+        // junction autothreading) and `.keys` yields the real key objects.
+        // Records each first-level non-Str key object under its encoded string.
+        let mut object_keys: HashMap<String, Value> = HashMap::new();
+        // An `:into` object hash stores `.WHICH` keys: seed the (raw-string-
+        // keyed) working buckets from its original key objects, and remember
+        // its key type so the result keeps the object-hash identity.
+        let mut into_key_type: Option<String> = None;
         let mut buckets: HashMap<String, Value> = match into_target.as_ref().map(Value::view) {
-            Some(ValueView::Hash(map)) => map.as_ref().map.clone(),
+            Some(ValueView::Hash(map)) => {
+                into_key_type = map.key_type.clone();
+                if map.has_typed_keys() {
+                    let mut seeded = HashMap::with_capacity(map.len());
+                    for (k, v) in map.iter() {
+                        let obj = map.typed_key(k);
+                        let str_key = obj.to_string_value();
+                        if !matches!(obj.view(), ValueView::Str(_)) {
+                            object_keys.insert(str_key.clone(), obj);
+                        }
+                        seeded.insert(str_key, v.clone());
+                    }
+                    seeded
+                } else {
+                    map.as_ref().map.clone()
+                }
+            }
             _ => HashMap::new(),
         };
         let mut bag_counts: Option<HashMap<String, i64>> = match into_target
@@ -232,14 +268,6 @@ impl Interpreter {
         // Track classification level depth across all items for mixed-level detection
         let mut expected_level: Option<usize> = None;
         let mut expected_multi_level: Option<bool> = None;
-
-        // Object-hash key preservation (§3.3): when the classifier returns a
-        // non-`Str` key (e.g. a Junction from `*.contains: any 'a','f'`), the
-        // bucket key is stored under its stringification but the result must be an
-        // *object hash* so `$result{ any(...) }` is a by-key lookup (not junction
-        // autothreading) and `.keys` yields the real key objects. Records each
-        // first-level non-Str key object under its encoded string.
-        let mut object_keys: HashMap<String, Value> = HashMap::new();
 
         for item in &items {
             let mapped = match mapper.view() {
@@ -362,7 +390,9 @@ impl Interpreter {
                     updated = Some(Self::classify_finish_hash(
                         buckets.clone(),
                         object_keys.clone(),
-                        false,
+                        into_key_type
+                            .clone()
+                            .or_else(|| (!object_keys.is_empty()).then(|| "Any".to_string())),
                     ));
                 }
                 if let Some(new_value) = updated {
@@ -382,14 +412,15 @@ impl Interpreter {
             return Ok(Value::mix(counts));
         }
 
-        // Only the standalone `.classify`/`.categorize` (no `:into` target) mints a
-        // fresh `Hash[Any,Mu]`; `classify-list`/`:into(%h)` classify into an
-        // existing container and keep its type.
-        Ok(Self::classify_finish_hash(
-            buckets,
-            object_keys,
-            into_target.is_none(),
-        ))
+        // The standalone `.classify`/`.categorize` (no `:into` target) mints a
+        // fresh `Hash[Mu,Mu]` (the `:{...}` shape); `classify-list`/`:into(%h)`
+        // classify into an existing container and keep its type.
+        let key_type = if into_target.is_none() {
+            Some("Mu".to_string())
+        } else {
+            into_key_type.or_else(|| (!object_keys.is_empty()).then(|| "Any".to_string()))
+        };
+        Ok(Self::classify_finish_hash(buckets, object_keys, key_type))
     }
 
     /// Wrap classify's bucket map in a `Hash`, marking it an *object hash*
@@ -406,53 +437,50 @@ impl Interpreter {
             return Value::array_with_kind(items, kind.itemize());
         }
         v.with_hash_mut(|arc| {
-            let data = crate::gc::Gc::make_mut(arc);
-            let keys: Vec<String> = data.map.keys().cloned().collect();
-            for k in keys {
-                if let Some(val) = data.map.remove(&k) {
-                    data.map.insert(k, Self::itemize_bucket_value(val));
+            {
+                let data = crate::gc::Gc::make_mut(arc);
+                let keys: Vec<String> = data.map.keys().cloned().collect();
+                for k in keys {
+                    if let Some(val) = data.map.remove(&k) {
+                        data.map.insert(k, Self::itemize_bucket_value(val));
+                    }
                 }
+                // A nested multi-level bucket is a `Mu`-keyed object hash in
+                // raku, like the top-level result.
+                data.key_type = Some("Mu".to_string());
             }
+            crate::runtime::utils::ensure_object_hash_which_keys(arc);
         });
         v
     }
 
+    /// Finish a classify/categorize bucket map: itemize the bucket values,
+    /// then (when `key_type` is `Some`) mark the result an object hash and
+    /// re-key it by `.WHICH` from the recorded key objects. The standalone
+    /// `.classify`/`.categorize` pass `Some("Mu")` — raku returns the same
+    /// `Hash[Mu,Mu]` shape as a `:{...}` literal; the `:into` forms pass the
+    /// target's own key type so the target's identity is preserved.
     fn classify_finish_hash(
         buckets: HashMap<String, Value>,
         object_keys: HashMap<String, Value>,
-        standalone: bool,
+        key_type: Option<String>,
     ) -> Value {
         let buckets: HashMap<String, Value> = buckets
             .into_iter()
             .map(|(k, v)| (k, Self::itemize_bucket_value(v)))
             .collect();
         let mut hash = Value::hash(buckets);
-        // The standalone `.classify`/`.categorize` always return a fresh
-        // `Hash[Any,Mu]` in Raku: the value type is `Any` (each bucket is an
-        // itemized array) and the key type is the most general `Mu` (keys can be
-        // anything the mapper returns). Classifying *into* an existing container
-        // (`classify-list`, `:into(%h)`) instead keeps the invocant's own type
-        // (a plain `Hash`, `BagHash`, ...), so only tag when standalone.
-        if standalone {
-            hash.with_hash_mut(|arc| {
-                let data = crate::gc::Gc::make_mut(arc);
-                data.value_type = Some("Any".to_string());
-                data.key_type = Some("Mu".to_string());
-                if !object_keys.is_empty() {
-                    data.original_keys = Some(object_keys);
-                }
-            });
-            return hash;
-        }
-        // Classifying into an existing plain hash: preserve the object-hash
-        // tagging (typed keys) but not the `Any`/`Mu` type-object constraint.
-        if object_keys.is_empty() {
-            return hash;
-        }
         hash.with_hash_mut(|arc| {
-            let data = crate::gc::Gc::make_mut(arc);
-            data.key_type = Some("Any".to_string());
-            data.original_keys = Some(object_keys);
+            {
+                let data = crate::gc::Gc::make_mut(arc);
+                data.key_type = key_type.clone();
+                if !object_keys.is_empty() {
+                    data.original_keys = Some(object_keys.clone());
+                }
+            }
+            if arc.key_type.is_some() {
+                crate::runtime::utils::ensure_object_hash_which_keys(arc);
+            }
         });
         hash
     }

--- a/src/runtime/builtins_multidim_assign.rs
+++ b/src/runtime/builtins_multidim_assign.rs
@@ -193,7 +193,18 @@ impl Interpreter {
                     // this should fail because {} is not an Int.
                     // (This is handled by type check above for the actual value being assigned.)
                     let mut new_hash = (**h).clone();
-                    new_hash.insert(key, effective_value.clone());
+                    if new_hash.key_type.is_some() {
+                        // An object hash (`has %.a{Str:D}`) stores `.WHICH`
+                        // keys and records the key object.
+                        let which = crate::runtime::utils::value_which_key(&index);
+                        new_hash
+                            .original_keys
+                            .get_or_insert_with(std::collections::HashMap::new)
+                            .insert(which.clone(), index.clone());
+                        new_hash.map.insert(which, effective_value.clone());
+                    } else {
+                        new_hash.insert(key, effective_value.clone());
+                    }
                     Value::hash(new_hash)
                 }
                 ValueView::Array(items, kind) => {
@@ -292,7 +303,12 @@ impl Interpreter {
 
         let (removed, updated) = match current.view() {
             ValueView::Hash(h) => {
-                let key = index.to_string_value();
+                // An object hash (`has %.a{Str:D}`) stores `.WHICH` keys.
+                let key = if h.key_type.is_some() {
+                    crate::runtime::utils::value_which_key(&index)
+                } else {
+                    index.to_string_value()
+                };
                 let mut new_hash = (**h).clone();
                 let removed = new_hash
                     .remove(&key)

--- a/src/runtime/methods_aggregate_ctor.rs
+++ b/src/runtime/methods_aggregate_ctor.rs
@@ -368,25 +368,22 @@ impl Interpreter {
             } else {
                 (String::new(), None)
             };
-            // An object hash with a non-`Str` key type keeps the original typed
-            // keys so they round-trip through `.raku`/`.keys`.
-            let track_typed_keys = key_type.as_deref().is_some_and(|kt| {
-                let (base, _) = crate::runtime::types::strip_type_smiley(kt);
-                base != "Str" && base != "Any" && base != "Mu"
-            });
             let info = crate::runtime::ContainerTypeInfo {
                 value_type,
                 key_type,
                 declared_type: Some(class_name.resolve()),
             };
-            let result = self.tag_container_metadata(result, info);
-            if track_typed_keys && !original_keys.is_empty() {
-                return Ok(crate::runtime::utils::set_hash_original_keys(
-                    result,
-                    original_keys,
-                ));
-            }
-            return Ok(result);
+            // Attach the recorded key objects BEFORE tagging: for an object
+            // hash (`Hash[Int,Int].new(1 => 2)`) `tag_container_metadata`
+            // re-keys the map by each key object's `.WHICH`, so it must see
+            // the real keys (a plain typed hash ignores the speculative map
+            // via the `has_typed_keys` gate).
+            let result = if original_keys.is_empty() {
+                result
+            } else {
+                crate::runtime::utils::set_hash_original_keys(result, original_keys)
+            };
+            return Ok(self.tag_container_metadata(result, info));
         }
         Ok(result)
     }

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -27,7 +27,15 @@ impl Interpreter {
                 }
                 ValueView::Hash(_) => {
                     let name = if let Some(key_type) = info.key_type {
-                        format!("Hash[{},{}]", info.value_type, key_type)
+                        if info.value_type.is_empty() {
+                            // The `:{...}` / classify shape (of = Mu, no
+                            // declared value type): rakudo parameterizes it as
+                            // Hash[Mu,Mu,Any] — the third argument is the
+                            // (Any) default that differs from the Mu of-type.
+                            format!("Hash[Mu,{},Any]", key_type)
+                        } else {
+                            format!("Hash[{},{}]", info.value_type, key_type)
+                        }
                     } else {
                         format!("Hash[{}]", info.value_type)
                     };
@@ -652,6 +660,11 @@ impl Interpreter {
                     match target.view() {
                         ValueView::Hash(_) => {
                             if let Some(ref key_type) = info.key_type {
+                                // See dispatch_what: the `:{...}` shape (no
+                                // declared value type) is Hash[Mu,Mu,Any].
+                                if info.value_type.is_empty() {
+                                    return Ok(Value::str(format!("Hash[Mu,{},Any]", key_type)));
+                                }
                                 return Ok(Value::str(format!(
                                     "Hash[{},{}]",
                                     info.value_type, key_type

--- a/src/runtime/methods_mut.rs
+++ b/src/runtime/methods_mut.rs
@@ -128,12 +128,29 @@ impl Interpreter {
                 // so a whole-hash rw-accessor writeback (`$o.h<k> = v`, which
                 // round-trips the whole hash) does not strip the element default.
                 let existing_default = existing_hash.default.clone();
+                // Likewise carry the object-hash `original_keys` from BOTH
+                // sides of the merge: the store keys are `.WHICH` strings, and
+                // losing the key objects would make the later re-tag treat
+                // them as raw Str keys and double-encode them.
+                let mut merged_orig = existing_hash.original_keys.clone().unwrap_or_default();
+                if let ValueView::Hash(new_hash) = value.descalarize().view()
+                    && let Some(ref new_orig) = new_hash.original_keys
+                {
+                    merged_orig.extend(new_orig.clone());
+                }
                 let mut result =
                     Self::normalize_hash_like_assignment(existing_hash.map.clone(), value);
                 if let Some(def) = existing_default {
                     result.with_hash_mut(|arc| {
                         if arc.default.is_none() {
                             crate::gc::Gc::make_mut(arc).default = Some(def);
+                        }
+                    });
+                }
+                if !merged_orig.is_empty() {
+                    result.with_hash_mut(|arc| {
+                        if arc.original_keys.is_none() {
+                            crate::gc::Gc::make_mut(arc).original_keys = Some(merged_orig);
                         }
                     });
                 }

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -141,7 +141,24 @@ impl Interpreter {
                         &value,
                     ));
                 }
-                let key = method_args[0].to_string_value();
+                // Insert into a clone of the WHOLE HashData (not just the map),
+                // so an object hash keeps its `original_keys`; an object hash
+                // stores the entry under the key's `.WHICH` and records the
+                // key object. Losing `original_keys` would make the re-tag
+                // treat the `.WHICH` store keys as raw Str keys and
+                // double-encode them.
+                let insert_entry =
+                    |data: &mut crate::value::HashData, key_val: &Value, value: Value| {
+                        if data.key_type.is_some() {
+                            let which = crate::runtime::utils::value_which_key(key_val);
+                            data.original_keys
+                                .get_or_insert_with(std::collections::HashMap::new)
+                                .insert(which.clone(), key_val.clone());
+                            data.map.insert(which, value);
+                        } else {
+                            data.map.insert(key_val.to_string_value(), value);
+                        }
+                    };
                 // An attribute-backed hash (`%!h.AT-KEY($k) = $v` inside a method)
                 // has no live env binding under its twigil name — the attribute
                 // lives in `self`'s shared cell. Read the current hash from that
@@ -154,24 +171,24 @@ impl Interpreter {
                     && let Some(cell_val) = self.read_self_attr_cell(var_name)
                     && matches!(cell_val.view(), ValueView::Hash(_) | ValueView::Nil)
                 {
-                    let mut map = match cell_val.view() {
-                        ValueView::Hash(h) => h.map.clone(),
-                        _ => std::collections::HashMap::new(),
+                    let mut data = match cell_val.view() {
+                        ValueView::Hash(h) => (**h).clone(),
+                        _ => crate::value::HashData::default(),
                     };
-                    map.insert(key, value.clone());
-                    let mut new_hash = Value::hash_with_data(Value::hash_arc(map));
+                    insert_entry(&mut data, &method_args[0], value.clone());
+                    let mut new_hash = Value::hash_with_data(crate::gc::Gc::new(data));
                     if let Some(m) = old_meta.clone() {
                         new_hash = self.tag_container_metadata(new_hash, m);
                     }
                     self.write_self_attr_cell(var_name, new_hash);
                     return Ok(value);
                 }
-                let mut hash = match inner.view() {
-                    ValueView::Hash(map) => map.map.clone(),
-                    _ => std::collections::HashMap::new(),
+                let mut data = match inner.view() {
+                    ValueView::Hash(map) => (**map).clone(),
+                    _ => crate::value::HashData::default(),
                 };
-                hash.insert(key, value.clone());
-                let mut new_hash = Value::hash_with_data(Value::hash_arc(hash));
+                insert_entry(&mut data, &method_args[0], value.clone());
+                let mut new_hash = Value::hash_with_data(crate::gc::Gc::new(data));
                 // Propagate container type metadata to avoid stale pointer reuse
                 let meta = old_meta.unwrap_or(ContainerTypeInfo {
                     value_type: "Any".to_string(),

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -313,11 +313,20 @@ impl Interpreter {
         } else {
             String::new()
         };
+        // An object hash with no element-type constraint is a `:{...}`
+        // literal — rakudo's Hash[Mu,Mu], shown as `my Mu`.
+        let value_type = if !info.value_type.is_empty() {
+            info.value_type.as_str()
+        } else if info.key_type.is_some() {
+            "Mu"
+        } else {
+            "Any"
+        };
         let inner = parts.join(", ");
         let result = if inner.is_empty() {
-            format!("(my {} %{})", info.value_type, key_suffix)
+            format!("(my {} %{})", value_type, key_suffix)
         } else {
-            format!("(my {} %{} = {})", info.value_type, key_suffix, inner)
+            format!("(my {} %{} = {})", value_type, key_suffix, inner)
         };
         Ok(Value::str(itemize_wrap(result)))
     }

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -1155,6 +1155,10 @@ impl Interpreter {
                         flat.extend(Self::value_to_list(arg));
                     }
                     let mut map = HashMap::new();
+                    // Record non-Str key objects so a parameterized object hash
+                    // (`Hash[Int,Int].new(1 => 2)`) re-keys by `.WHICH` from the
+                    // real key when `tag_container_metadata` runs below.
+                    let mut original_keys: HashMap<String, Value> = HashMap::new();
                     let mut iter = flat.into_iter();
                     while let Some(item) = iter.next() {
                         match item.view() {
@@ -1162,16 +1166,26 @@ impl Interpreter {
                                 map.insert(k.clone(), v.clone());
                             }
                             ValueView::ValuePair(k, v) => {
-                                map.insert(k.to_string_value(), v.clone());
+                                let str_key = k.to_string_value();
+                                if !matches!(k.view(), ValueView::Str(_)) {
+                                    original_keys.insert(str_key.clone(), k.clone());
+                                }
+                                map.insert(str_key, v.clone());
                             }
                             _ => {
-                                let key = item.to_string_value();
+                                let str_key = item.to_string_value();
+                                if !matches!(item.view(), ValueView::Str(_)) {
+                                    original_keys.insert(str_key.clone(), item.clone());
+                                }
                                 let value = iter.next().unwrap_or(Value::NIL);
-                                map.insert(key, value);
+                                map.insert(str_key, value);
                             }
                         }
                     }
-                    let result = Value::hash(map);
+                    let result = crate::runtime::utils::set_hash_original_keys(
+                        Value::hash(map),
+                        original_keys,
+                    );
                     let value_type = type_args
                         .first()
                         .cloned()

--- a/src/runtime/ops_set.rs
+++ b/src/runtime/ops_set.rs
@@ -32,7 +32,7 @@ impl Interpreter {
                 .iter()
                 .filter_map(|(k, v)| {
                     if v.truthy() || v.is_nil() {
-                        Some(k.clone())
+                        Some(crate::runtime::utils::hash_elem_key(&h, k))
                     } else {
                         None
                     }
@@ -219,7 +219,7 @@ impl Interpreter {
                 .filter_map(|(k, v)| {
                     let c = Self::multiply_pair_i64(v);
                     if c > 0 {
-                        Some((k.clone(), (c, c != 1)))
+                        Some((crate::runtime::utils::hash_elem_key(&h, k), (c, c != 1)))
                     } else {
                         None
                     }
@@ -319,7 +319,11 @@ impl Interpreter {
                             }
                         }
                     };
-                    if w != 0.0 { Some((k.clone(), w)) } else { None }
+                    if w != 0.0 {
+                        Some((crate::runtime::utils::hash_elem_key(&h, k), w))
+                    } else {
+                        None
+                    }
                 })
                 .collect()),
             _ if value.as_list_items().is_some() => {
@@ -441,7 +445,7 @@ impl Interpreter {
                 for (k, v) in map.iter() {
                     let weight = v.to_f64() as i64;
                     if weight != 0 {
-                        result.insert(k.clone(), weight);
+                        result.insert(crate::runtime::utils::hash_elem_key(&map, k), weight);
                     }
                 }
                 Ok(result)
@@ -503,7 +507,7 @@ impl Interpreter {
                 for (k, v) in map.iter() {
                     let weight = v.to_f64();
                     if weight != 0.0 {
-                        result.insert(k.clone(), weight);
+                        result.insert(crate::runtime::utils::hash_elem_key(&map, k), weight);
                     }
                 }
                 Ok(result)

--- a/src/runtime/runtime_container.rs
+++ b/src/runtime/runtime_container.rs
@@ -106,7 +106,21 @@ impl Interpreter {
         {
             return value;
         }
-        if value.with_hash_mut(|arc| embed_type_info!(arc)).is_some() {
+        if value
+            .with_hash_mut(|arc| {
+                embed_type_info!(arc);
+                // An object hash (`my %h{Any}` / `:{...}`) keys by the `.WHICH`
+                // of the key *object*. The list→hash coercion that built the
+                // value is key-type-blind and stringified the keys (recording
+                // the key objects in `original_keys`), so enforce the keying
+                // invariant here — the chokepoint every declared-constraint
+                // assignment and `SetVarType` tagging flows through.
+                if info.key_type.is_some() {
+                    crate::runtime::utils::ensure_object_hash_which_keys(arc);
+                }
+            })
+            .is_some()
+        {
             return value;
         }
         if value

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -243,6 +243,57 @@ pub(crate) fn set_hash_original_keys(
     value
 }
 
+/// Enforce the object-hash keying invariant on a hash that carries (or is
+/// about to carry) a `key_type`: every entry is stored under the canonical
+/// `.WHICH` string of its key *object*, and `original_keys` maps every store
+/// key back to that object. A hash built by a key-type-blind path (hash
+/// literal, list→hash coercion) has stringified keys; this re-keys it
+/// losslessly using the key objects those paths record in `original_keys`
+/// (a key with no recorded object was a genuine `Str` key). Idempotent:
+/// a hash already `.WHICH`-keyed is left untouched (checked first, so a
+/// shared Gc is not cloned).
+pub(crate) fn ensure_object_hash_which_keys(value: &mut crate::gc::Gc<crate::value::HashData>) {
+    let which_keyed = value.map.keys().all(|k| {
+        value
+            .original_keys
+            .as_ref()
+            .and_then(|orig| orig.get(k))
+            .is_some_and(|obj| value_which_key(obj) == *k)
+    });
+    if which_keyed {
+        return;
+    }
+    let data = crate::gc::Gc::make_mut(value);
+    let old_map = std::mem::take(&mut data.map);
+    let old_orig = data.original_keys.take().unwrap_or_default();
+    let mut new_map = HashMap::with_capacity(old_map.len());
+    let mut new_orig = HashMap::with_capacity(old_map.len());
+    for (key, val) in old_map {
+        let key_obj = old_orig
+            .get(&key)
+            .cloned()
+            .unwrap_or_else(|| Value::hash_key_decode(&key));
+        let which = value_which_key(&key_obj);
+        new_orig.insert(which.clone(), key_obj);
+        new_map.insert(which, val);
+    }
+    data.map = new_map;
+    data.original_keys = Some(new_orig);
+}
+
+/// Turn a freshly-built plain hash into an object hash (`:{ ... }` — key type
+/// `Mu`), embedding the key type metadata and enforcing the `.WHICH` keying
+/// invariant. The value type is left unset: like rakudo, a missing-key read
+/// on `:{...}` yields `Any`, not `Mu`. Callers must use the returned value.
+pub(crate) fn into_object_hash(mut value: Value, key_type: &str) -> Value {
+    value.with_hash_mut(|arc| {
+        let data = crate::gc::Gc::make_mut(arc);
+        data.key_type = Some(key_type.to_string());
+        ensure_object_hash_which_keys(arc);
+    });
+    value
+}
+
 /// Snapshot the original keys embedded in an object hash, if any.
 pub(crate) fn hash_original_keys_snapshot(hash: &Value) -> Option<HashMap<String, Value>> {
     if let ValueView::Hash(arc) = hash.view() {

--- a/src/runtime/utils/coerce_containers.rs
+++ b/src/runtime/utils/coerce_containers.rs
@@ -24,8 +24,11 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
             let mut flat: Vec<Value> = Vec::with_capacity(items.len());
             for item in items.iter() {
                 if let ValueView::Hash(h) = item.view() {
+                    // An object hash stores `.WHICH` keys — flatten via the
+                    // original key objects (a plain hash's typed_pair is the
+                    // plain `Pair(str_key, v)` as before).
                     for (k, v) in h.iter() {
-                        flat.push(Value::pair(k.clone(), v.clone()));
+                        flat.push(h.typed_pair(k, v.clone()));
                     }
                 } else {
                     flat.push(item.clone());
@@ -74,6 +77,7 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
         | ValueView::RaceSeq(items)
         | ValueView::Slip(items) => {
             let mut map = HashMap::new();
+            let mut original_keys: HashMap<String, Value> = HashMap::new();
             let mut i = 0;
             while i < items.len() {
                 if let ValueView::Pair(k, v) = items[i].view() {
@@ -82,21 +86,29 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
                 } else if let ValueView::ValuePair(k, v) = items[i].view() {
                     let dv = v.deref_container();
                     for kk in hash_pair_keys(k) {
-                        map.insert(kk.to_string_value(), dv.clone());
+                        let str_key = kk.to_string_value();
+                        if !matches!(kk.view(), ValueView::Str(_)) {
+                            original_keys.insert(str_key.clone(), kk.clone());
+                        }
+                        map.insert(str_key, dv.clone());
                     }
                     i += 1;
                 } else {
-                    let key = items[i].to_string_value();
+                    let key_val = &items[i];
+                    let str_key = key_val.to_string_value();
+                    if !matches!(key_val.view(), ValueView::Str(_)) {
+                        original_keys.insert(str_key.clone(), key_val.clone());
+                    }
                     let val = if i + 1 < items.len() {
                         items[i + 1].clone()
                     } else {
                         Value::NIL
                     };
-                    map.insert(key, val);
+                    map.insert(str_key, val);
                     i += 2;
                 }
             }
-            Value::hash(map)
+            set_hash_original_keys(Value::hash(map), original_keys)
         }
         ValueView::Pair(k, v) => {
             let mut map = HashMap::new();
@@ -105,11 +117,16 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
         }
         ValueView::ValuePair(k, v) => {
             let mut map = HashMap::new();
+            let mut original_keys: HashMap<String, Value> = HashMap::new();
             let dv = v.deref_container();
             for kk in hash_pair_keys(k) {
-                map.insert(kk.to_string_value(), dv.clone());
+                let str_key = kk.to_string_value();
+                if !matches!(kk.view(), ValueView::Str(_)) {
+                    original_keys.insert(str_key.clone(), kk.clone());
+                }
+                map.insert(str_key, dv.clone());
             }
-            Value::hash(map)
+            set_hash_original_keys(Value::hash(map), original_keys)
         }
         ValueView::Set(items, _) => {
             let mut map = HashMap::new();
@@ -269,12 +286,24 @@ where
             // key=>value pairs (`%m = (%h,)` / `%(%h,)`). A hash sourced from a
             // `$` scalar carries the per-holder itemization flag (set by
             // `itemize_value`) and stays an opaque single element — matching
-            // Raku, where `%m = ($hashitem,)` dies "Odd number". Keys are the
-            // source hash's string keys: flattening an object hash into a plain
-            // Hash/Map stringifies them (the target re-tags via its own metadata).
+            // Raku, where `%m = ($hashitem,)` dies "Odd number". An object hash
+            // stores `.WHICH` keys: flatten via the original key objects, so a
+            // plain target sees their stringifications and an object-hash
+            // target (re-keyed by `tag_container_metadata`) keeps the objects.
             ValueView::Hash(h) if !item.hash_is_itemized() => {
-                for (k, v) in h.iter() {
-                    map.insert(k.clone(), v.clone());
+                if h.has_typed_keys() {
+                    for (k, v) in h.iter() {
+                        let key_obj = h.typed_key(k);
+                        let str_key = Value::hash_key_encode(&key_obj);
+                        if !matches!(key_obj.view(), ValueView::Str(_)) {
+                            original_keys.insert(str_key.clone(), key_obj);
+                        }
+                        map.insert(str_key, v.clone());
+                    }
+                } else {
+                    for (k, v) in h.iter() {
+                        map.insert(k.clone(), v.clone());
+                    }
                 }
             }
             // A Junction key (`"a"|"b" => 1`) is not itself a key: it threads,

--- a/src/runtime/utils/gist.rs
+++ b/src/runtime/utils/gist.rs
@@ -184,9 +184,19 @@ pub(crate) fn gist_value(value: &Value) -> String {
             }
             let mut sorted_keys: Vec<&String> = items.keys().collect();
             sorted_keys.sort();
+            // An object hash stores `.WHICH` keys — gist the original key
+            // object (plain hashes gist the string key unchanged).
+            let typed = items.has_typed_keys();
             let parts: Vec<String> = sorted_keys
                 .iter()
-                .map(|k| format!("{} => {}", k, gist_value(&items[*k])))
+                .map(|k| {
+                    let key_gist = if typed {
+                        gist_value(&items.typed_key(k))
+                    } else {
+                        (*k).clone()
+                    };
+                    format!("{} => {}", key_gist, gist_value(&items[*k]))
+                })
                 .collect();
             SEEN_PTRS.with(|seen| pop_ptr(seen, ptr));
             // An immutable Map gists as `Map.new((k => v, ...))`, not `{...}`

--- a/src/runtime/utils/set_coerce.rs
+++ b/src/runtime/utils/set_coerce.rs
@@ -1,5 +1,16 @@
 use super::*;
 
+/// The Set-element key string for a hash entry: an object hash stores
+/// `.WHICH` keys, so decode back to the original key object's
+/// stringification (a plain hash's key is returned unchanged).
+pub(crate) fn hash_elem_key(h: &crate::value::HashData, k: &str) -> String {
+    if h.has_typed_keys() {
+        h.typed_key(k).to_string_value()
+    } else {
+        k.to_string()
+    }
+}
+
 pub(crate) fn coerce_to_set(val: &Value) -> HashSet<String> {
     fn insert_set_elem(elems: &mut HashSet<String>, value: &Value) {
         let pair_selected = |weight: &Value| weight.truthy() || weight.is_nil();
@@ -24,7 +35,7 @@ pub(crate) fn coerce_to_set(val: &Value) -> HashSet<String> {
             ValueView::Hash(items) => {
                 for (k, v) in items.iter() {
                     if v.truthy() || v.is_nil() {
-                        elems.insert(k.clone());
+                        elems.insert(hash_elem_key(&items, k));
                     }
                 }
             }
@@ -69,7 +80,7 @@ pub(crate) fn coerce_to_set(val: &Value) -> HashSet<String> {
             .iter()
             .filter_map(|(k, v)| {
                 if v.truthy() || v.is_nil() {
-                    Some(k.clone())
+                    Some(hash_elem_key(&items, k))
                 } else {
                     None
                 }
@@ -119,7 +130,7 @@ pub(crate) fn coerce_value_to_quanthash(val: &Value) -> Value {
             let mut set = HashSet::new();
             for (k, v) in h.iter() {
                 if v.truthy() {
-                    set.insert(k.clone());
+                    set.insert(hash_elem_key(&h, k));
                 }
             }
             Value::set(set)
@@ -136,7 +147,7 @@ pub(crate) fn coerce_value_to_quanthash(val: &Value) -> Value {
                     ValueView::Hash(h) => {
                         for (k, v) in h.iter() {
                             if v.truthy() {
-                                set.insert(k.clone());
+                                set.insert(hash_elem_key(&h, k));
                             }
                         }
                     }

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1498,13 +1498,24 @@ impl Interpreter {
                 match inner_target.view() {
                     ValueView::Hash(map) => {
                         let old_meta = self.container_type_metadata(inner_target).clone();
-                        let key = args[0].to_string_value();
                         let value = args[1].clone();
                         let source_var = arg_sources
                             .as_ref()
                             .and_then(|s| s.get(1))
                             .and_then(|s| s.clone());
                         let mut new_map = (**map).clone();
+                        // An object hash stores `.WHICH` keys and records the
+                        // key object.
+                        let key = if new_map.key_type.is_some() {
+                            let which = crate::runtime::utils::value_which_key(&args[0]);
+                            new_map
+                                .original_keys
+                                .get_or_insert_with(std::collections::HashMap::new)
+                                .insert(which.clone(), args[0].clone());
+                            which
+                        } else {
+                            args[0].to_string_value()
+                        };
                         // Phase 2 Stage 2: BIND-KEY installs a shared
                         // `ContainerRef` cell (reusing the source variable's
                         // existing cell binding when present) instead of a

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1277,7 +1277,12 @@ impl Interpreter {
                     _ => &target,
                 };
                 if let ValueView::Hash(map) = inner_target.view() {
-                    let key = args[0].to_string_value();
+                    // An object hash stores `.WHICH` keys.
+                    let key = if map.key_type.is_some() {
+                        crate::runtime::utils::value_which_key(&args[0])
+                    } else {
+                        args[0].to_string_value()
+                    };
                     let result = self.resolve_hash_entry(&map, &key);
                     self.stack.push(result);
                     return Ok(());
@@ -1291,14 +1296,23 @@ impl Interpreter {
                     _ => &target,
                 };
                 match inner_target.view() {
-                    ValueView::Hash(_) => {
+                    ValueView::Hash(map) => {
                         let old_meta = self.container_type_metadata(inner_target).clone();
-                        let mut hash = match inner_target.view() {
-                            ValueView::Hash(map) => map.map.clone(),
-                            _ => std::collections::HashMap::new(),
-                        };
-                        hash.insert(key, value.clone());
-                        let new_hash = Value::hash_with_data(Value::hash_arc(hash));
+                        // Clone the whole HashData (not just the map) so the
+                        // object-hash `original_keys` survive; an object hash
+                        // stores the key under its `.WHICH` and records the
+                        // key object.
+                        let mut data = (**map).clone();
+                        if data.key_type.is_some() {
+                            let which = crate::runtime::utils::value_which_key(&args[0]);
+                            data.original_keys
+                                .get_or_insert_with(std::collections::HashMap::new)
+                                .insert(which.clone(), args[0].clone());
+                            data.map.insert(which, value.clone());
+                        } else {
+                            data.map.insert(key, value.clone());
+                        }
+                        let new_hash = Value::hash_with_data(crate::gc::Gc::new(data));
                         let meta = old_meta.unwrap_or(crate::runtime::ContainerTypeInfo {
                             value_type: "Any".to_string(),
                             key_type: None,
@@ -1380,6 +1394,12 @@ impl Interpreter {
                 };
                 match inner_target.view() {
                     ValueView::Hash(map) => {
+                        // An object hash stores `.WHICH` keys.
+                        let key = if map.key_type.is_some() {
+                            crate::runtime::utils::value_which_key(&args[0])
+                        } else {
+                            key
+                        };
                         let old_meta = self.container_type_metadata(inner_target).clone();
                         let old_value = if map.contains_key(&key) {
                             self.resolve_hash_entry(&map, &key)

--- a/src/vm/vm_coerce_concat_ops.rs
+++ b/src/vm/vm_coerce_concat_ops.rs
@@ -97,9 +97,11 @@ impl Interpreter {
                 }
                 items
             }
+            // typed_pair decodes an object hash's `.WHICH` store keys back to
+            // the original key objects (plain hashes get `Pair(str_key, v)`).
             ValueView::Hash(map) => map
                 .iter()
-                .map(|(k, v)| Value::pair(k.clone(), v.clone()))
+                .map(|(k, v)| map.typed_pair(k, v.clone()))
                 .collect(),
             ValueView::LazyList(ll) => {
                 if ll.scan_spec.is_some() {

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1636,11 +1636,9 @@ impl Interpreter {
                     };
                     // Hashes embed metadata in `HashData`; write the tagged value
                     // back (no-op Arc for array/instance side-table containers).
+                    // Tagging an object hash also re-keys it by `.WHICH`
+                    // (see `tag_container_metadata`).
                     let tagged = self.tag_container_metadata(value, info);
-                    // Object hash (`my Int %{Int}`) declared in expression
-                    // position: the list->hash coercion stringified the keys
-                    // before the key type was tagged, so recover the typed keys now.
-                    let tagged = self.populate_object_hash_typed_keys(tagged);
                     self.set_env_with_main_alias(&name, tagged.clone());
                     self.update_local_if_exists(code, &name, &tagged);
                 }

--- a/src/vm/vm_set_ops.rs
+++ b/src/vm/vm_set_ops.rs
@@ -109,23 +109,20 @@ impl Interpreter {
         needle: &Value,
         whole: &Value,
     ) -> bool {
-        if let Some(info) = self.container_type_metadata(whole) {
-            if let Some(key_type) = info.key_type {
-                if (key_type == "Any" || key_type == "Mu")
-                    && matches!(needle.view(), ValueView::Str(s) if s.parse::<i128>().is_ok())
-                {
-                    // Heuristic for typed hashes: numeric-looking string keys should
-                    // not alias numeric keys.
-                    return false;
-                }
-                if key_type != "Any"
-                    && key_type != "Mu"
-                    && !self.type_matches_value(&key_type, needle)
-                {
-                    return false;
-                }
+        if let Some(info) = self.container_type_metadata(whole)
+            && let Some(key_type) = info.key_type
+        {
+            if key_type != "Any" && key_type != "Mu" && !self.type_matches_value(&key_type, needle)
+            {
+                return false;
             }
-        } else if !matches!(needle.view(), ValueView::Str(_)) {
+            // An object hash stores `.WHICH` keys: membership is by key
+            // object identity, so `13 ∈ %objh` finds the Int key while
+            // `"13"` does not.
+            let which = crate::runtime::utils::value_which_key(needle);
+            return hash.get(&which).is_some_and(|v| v.truthy());
+        }
+        if !matches!(needle.view(), ValueView::Str(_)) {
             // Plain Hash keys are Str by default.
             return false;
         }
@@ -248,7 +245,7 @@ impl Interpreter {
             ValueView::Hash(items) => {
                 for (k, v) in items.iter() {
                     if v.truthy() || v.is_nil() {
-                        elems.insert(k.clone());
+                        elems.insert(crate::runtime::utils::hash_elem_key(&items, k));
                     }
                 }
             }
@@ -301,7 +298,7 @@ impl Interpreter {
                 .iter()
                 .filter_map(|(k, v)| {
                     if v.truthy() || v.is_nil() {
-                        Some(k.clone())
+                        Some(crate::runtime::utils::hash_elem_key(&h, k))
                     } else {
                         None
                     }

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -229,6 +229,27 @@ impl Interpreter {
                 runtime::utils::build_hash_from_items(items)
             }
         };
+        // An object hash (`.WHICH`-keyed) assigned to a `%` variable
+        // materializes as fresh entries: a plain target sees the stringified
+        // original keys (raku: `my %p = %o` stringifies), while the key
+        // objects are recorded in `original_keys` so a key-constrained target
+        // re-keys by `.WHICH` when `tag_container_metadata` runs below.
+        let value = match value.view() {
+            ValueView::Hash(h) if h.has_typed_keys() => {
+                let mut map = std::collections::HashMap::with_capacity(h.len());
+                let mut orig = std::collections::HashMap::new();
+                for (k, v) in h.iter() {
+                    let key_obj = h.typed_key(k);
+                    let str_key = Value::hash_key_encode(&key_obj);
+                    if !matches!(key_obj.view(), ValueView::Str(_)) {
+                        orig.insert(str_key.clone(), key_obj);
+                    }
+                    map.insert(str_key, v.clone());
+                }
+                runtime::utils::set_hash_original_keys(Value::hash(map), orig)
+            }
+            _ => value,
+        };
         // For Array/Seq/Slip values, use `build_hash_from_items` which
         // raises "Odd number of elements" when appropriate. Hash values from
         // scalar containers (`$h`) are NOT pre-flattened, so they appear as

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -1484,21 +1484,11 @@ impl Interpreter {
                 } else {
                     idx
                 };
-                // Determine the keying mode for an object hash. A freshly created
-                // or already-`.WHICH`-keyed hash (one carrying `original_keys`) is
-                // keyed by `.WHICH`. A *plain-built* object hash — e.g. one bulk
-                // assigned from a pair list (`my %h{Mu} = :42a, ...`), whose keys
-                // were stringified during hash construction and which carries no
-                // `original_keys` — must keep using plain string keys here so that
-                // a follow-up element assignment (`%h<c> = ...`) overwrites the
-                // existing entry instead of inserting a duplicate under a `.WHICH`
-                // key. (Fully unifying object-hash keying across construction,
-                // flatten, gist and comparison is a larger change.)
-                let use_which = is_object_hash
-                    && match index_target.as_ref().map(Value::view) {
-                        Some(ValueView::Hash(h)) => h.original_keys.is_some() || h.map.is_empty(),
-                        _ => true,
-                    };
+                // An object hash is always `.WHICH`-keyed: every path that
+                // attaches a `key_type` (`tag_container_metadata`) enforces the
+                // keying invariant, so a "plain-built" object hash with
+                // stringified keys can no longer reach this element assignment.
+                let use_which = is_object_hash;
                 let key = if use_which {
                     runtime::utils::value_which_key(&idx)
                 } else if !is_object_hash && matches!(idx.view(), ValueView::Package(_)) {

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -126,33 +126,6 @@ impl Interpreter {
         Value::str(key.to_string())
     }
 
-    /// For an object hash (`my Int %{Int}`) whose key type is a non-`Str` type,
-    /// reconstruct the typed key objects from the stringified store keys and
-    /// record them in `original_keys`, so `.keys`/`.pairs`/`.raku` report the
-    /// real key (`Int(1)`, not `"1"`). No-op for plain / `Str`-keyed hashes and
-    /// for hashes that already carry `original_keys`. Used on the SetVarType
-    /// path, where the list→hash coercion ran before the key type was known.
-    pub(crate) fn populate_object_hash_typed_keys(&self, value: Value) -> Value {
-        let ValueView::Hash(map) = value.view() else {
-            return value;
-        };
-        let Some(key_type) = map.key_type.clone() else {
-            return value;
-        };
-        let (base, _) = crate::runtime::types::strip_type_smiley(&key_type);
-        if base == "Str" || base == "Any" || base == "Mu" || map.has_typed_keys() {
-            return value;
-        }
-        let mut original_keys = std::collections::HashMap::with_capacity(map.len());
-        for key in map.keys() {
-            original_keys.insert(key.clone(), Self::try_reconstruct_typed_key(key, base));
-        }
-        if original_keys.is_empty() {
-            return value;
-        }
-        crate::runtime::utils::set_hash_original_keys(value, original_keys)
-    }
-
     pub(super) fn coerce_typed_container_assignment(
         &mut self,
         var_name: &str,
@@ -252,15 +225,19 @@ impl Interpreter {
                 std::collections::HashMap::new();
             for (key, val) in map.iter() {
                 let coerced_key = if let Some(constraint) = &key_constraint {
-                    // Hash keys are always stored as strings internally, but for
-                    // key-constrained hashes (e.g. %h{Int}), we need to check
-                    // that the key can be interpreted as the constraint type.
-                    // Since hash construction stringifies pair keys (e.g. 1 => 2
-                    // becomes "1" => 2), we try to reconstruct the typed value
-                    // from the string key before checking the constraint.
+                    // The hash was built by a key-type-blind path that
+                    // stringified the keys, recording the key objects in
+                    // `original_keys`. Check the constraint against the real
+                    // key object when recorded (so `my %h{Int} = "42" => 1`
+                    // fails like raku); a key with no recorded object was a
+                    // genuine `Str` key — reconstruct as a last resort.
                     let target_type =
                         coercion_target(constraint).unwrap_or_else(|| constraint.clone());
-                    let key_as_typed_value = Self::try_reconstruct_typed_key(key, &target_type);
+                    let key_as_typed_value = saved_original_keys
+                        .as_ref()
+                        .and_then(|orig| orig.get(key))
+                        .cloned()
+                        .unwrap_or_else(|| Self::try_reconstruct_typed_key(key, &target_type));
                     if !loan_env!(self, type_matches_value(&target_type, &key_as_typed_value)) {
                         return Err(runtime::utils::type_check_element_typed_error(
                             var_name,

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -2022,6 +2022,14 @@ impl Interpreter {
                     "Type Array does not support associative indexing.".to_string(),
                 ));
             }
+            // An allomorph angle-word subscript (`$ref<0>` — an IntStr Mixin)
+            // is still ASSOCIATIVE indexing: an Array target dies, exactly
+            // like the Str-key arm above.
+            (ValueView::Array(..), ValueView::Mixin(..)) if !is_positional => {
+                return Err(RuntimeError::new(
+                    "Type Array does not support associative indexing.".to_string(),
+                ));
+            }
             // Associative indexing on non-hash types returns a Failure
             (_, ValueView::Str(_))
                 if matches!(

--- a/src/vm/vm_var_ops.rs
+++ b/src/vm/vm_var_ops.rs
@@ -321,6 +321,12 @@ impl Interpreter {
             if let Some(def) = native_element_default(&info.value_type) {
                 return def;
             }
+            // Metadata with no element-type constraint (e.g. `:{...}` — an
+            // object hash with only a key type) defaults like an untyped
+            // container: `Any`.
+            if info.value_type.is_empty() {
+                return Value::package(Symbol::intern("Any"));
+            }
             Value::package(Symbol::intern(&info.value_type))
         } else if matches!(target.view(), ValueView::Hash(_))
             || matches!(target.view(), ValueView::Array(_, kind) if kind.is_real_array())

--- a/t/classify-hash-any-mu-raku.t
+++ b/t/classify-hash-any-mu-raku.t
@@ -2,27 +2,29 @@ use Test;
 
 plan 10;
 
-# classify/categorize always return `Hash[Any,Mu]` in Raku, and object-hash
-# `.raku` renders each pair per its key: a Str identifier key becomes a
-# colonpair `:key(value)`, everything else becomes `key => value`.
+# classify/categorize return the `:{...}` shape — rakudo's Hash[Mu,Mu]
+# (parameterized name Hash[Mu,Mu,Any]; the third argument is the Any default).
+# Object-hash `.raku` renders each pair per its key: a Str identifier key
+# becomes a colonpair `:key(value)`, everything else becomes `key => value`.
+# All expectations below are raku-verified.
 
 # --- classify / categorize type object + .raku ---
 
-is (1,2,3,4).classify(* %% 2).WHAT.^name, 'Hash[Any,Mu]',
-    'classify with Bool keys is Hash[Any,Mu]';
+is (1,2,3,4).classify(* %% 2).WHAT.^name, 'Hash[Mu,Mu,Any]',
+    'classify with Bool keys is Hash[Mu,Mu]';
 
-is <apple banana avocado>.classify(*.substr(0,1)).WHAT.^name, 'Hash[Any,Mu]',
-    'classify with Str keys is Hash[Any,Mu]';
+is <apple banana avocado>.classify(*.substr(0,1)).WHAT.^name, 'Hash[Mu,Mu,Any]',
+    'classify with Str keys is Hash[Mu,Mu]';
 
-is (1,2,3,4).categorize(* %% 2).WHAT.^name, 'Hash[Any,Mu]',
-    'categorize is Hash[Any,Mu]';
+is (1,2,3,4).categorize(* %% 2).WHAT.^name, 'Hash[Mu,Mu,Any]',
+    'categorize is Hash[Mu,Mu]';
 
 is (1,2,3,4).classify(* %% 2).raku,
-    '(my Any %{Mu} = Bool::False => $[1, 3], Bool::True => $[2, 4])',
+    '(my Mu %{Mu} = Bool::False => $[1, 3], Bool::True => $[2, 4])',
     'classify Bool-key .raku uses arrow for non-Str keys';
 
 is <apple banana avocado>.classify(*.substr(0,1)).raku,
-    '(my Any %{Mu} = :a($["apple", "avocado"]), :b($["banana"]))',
+    '(my Mu %{Mu} = :a($["apple", "avocado"]), :b($["banana"]))',
     'classify Str-key .raku uses colonpairs';
 
 # lookups still work after the metadata tag

--- a/t/native-array-backed-instance-methods.t
+++ b/t/native-array-backed-instance-methods.t
@@ -48,7 +48,9 @@ is $s.values.join(","), "3,1,2,4", 'values of is-Array';
 is $s.kv.join(","), "0,3,1,1,2,2,3,4", 'kv of is-Array';
 is $s.pairs.map(*.value).join(","), "3,1,2,4", 'pairs of is-Array';
 is $s.antipairs.map(*.key).join(","), "3,1,2,4", 'antipairs of is-Array';
-is $s.classify({ $_ %% 2 })<True>.join(","), "2,4", 'classify over is-Array';
+# classify keys by the Bool OBJECT (.WHICH-keyed object hash), so index with
+# the Bool `True`, not the Str `<True>` — matching raku, where `<True>` misses.
+is $s.classify({ $_ %% 2 }){True}.join(","), "2,4", 'classify over is-Array';
 is $s.rotor(2).map(*.join("")).join(","), "31,24", 'rotor over is-Array';
 is $s.combinations(4).elems, 1, 'combinations over is-Array';
 is $s.permutations.elems, 24, 'permutations over is-Array';

--- a/t/object-hash-which-keys.t
+++ b/t/object-hash-which-keys.t
@@ -1,0 +1,87 @@
+use v6;
+use Test;
+
+plan 30;
+
+# Object hashes key by the .WHICH identity of the key OBJECT, not by its
+# stringification (PLAN 8.10). Covers the numerics/hashmap/traps doc-diff
+# findings: key objects survive bulk assignment, allomorph lookups miss
+# Int/Str keys, and `:{ ... }` builds a Mu-keyed object hash.
+
+# --- declared object hash, bulk assignment ---
+{
+    my %h{Any} = 42 => "foo";
+    is-deeply %h.keys.map(*.^name).list, ("Int",), 'bulk-assigned key keeps its Int type';
+    ok %h{42}:exists, 'Int lookup hits the Int key';
+    nok %h<42>:exists, 'IntStr allomorph lookup misses the Int key';
+    is %h{42}, "foo", 'Int lookup returns the value';
+}
+
+# --- separate declaration and assignment ---
+{
+    my %h{Any};
+    %h = 42 => "foo";
+    is-deeply %h.keys.map(*.^name).list, ("Int",), 're-assigned key keeps its Int type';
+    nok %h<42>:exists, 'allomorph lookup misses after re-assignment';
+    %h{5} = "z";
+    ok %h{5}:exists, 'element assignment stores an Int key';
+    is-deeply %h.keys.map(*.^name).sort.list, ("Int", "Int"), 'both keys are Int';
+}
+
+# --- :{ ... } literal is a Mu-keyed object hash ---
+{
+    is :{ 0 => 42 }<0>.^name, 'Any', 'Int key, IntStr lookup misses (Any)';
+    is :{ "0" => 42 }<0>.^name, 'Any', 'Str key, IntStr lookup misses (Any)';
+    is :{ <0> => 42 }<0>, 42, 'IntStr key, IntStr lookup hits';
+    is :{ 0 => 42 }{0}, 42, 'Int key, Int lookup hits';
+    is :{ "0" => 42 }{"0"}, 42, 'Str key, Str lookup hits';
+    my %h := :{ 0 => 42 };
+    is-deeply %h.keys.map(*.^name).list, ("Int",), ':{ } literal preserves the Int key object';
+}
+
+# --- enum keys (traps.rakudoc [8]) ---
+{
+    enum Dog <Fido Rex>;
+    my %h := :{ Dog => 42 };
+    is %h{Dog}.^name, 'Any', 'Dog type-object key misses the autoquoted "Dog" Str key';
+    is %h{"Dog"}, 42, 'Str lookup hits the autoquoted key';
+    is %h{Fido}.^name, 'Any', 'enum value key misses too';
+    my %e{Any} = Fido => 1;
+    # `Fido => 1` autoquotes: the key is the Str "Fido", not the enum value
+    is-deeply %e.keys.map(*.^name).list, ("Str",), 'fat-arrow autoquotes even for an enum name';
+    ok %e<Fido>:exists, 'Str lookup finds the autoquoted key';
+}
+
+# --- flattening back into hashes ---
+{
+    my %o{Any} = 42 => "a";
+    my %p = %o;
+    is-deeply %p.keys.list, ("42",), 'object hash assigned to a plain hash stringifies keys';
+    my %q{Any} = %o;
+    is-deeply %q.keys.map(*.^name).list, ("Int",), 'object hash assigned to an object hash keeps key objects';
+    my %m = %o, x => 1;
+    is-deeply %m.keys.sort.list, ("42", "x"), 'flattening into a plain-hash list stringifies keys';
+}
+
+# --- mixed-type keys with the same stringification coexist ---
+{
+    my %h{Any};
+    %h{1} = "int";
+    %h{"1"} = "str";
+    is %h.elems, 2, 'Int 1 and Str "1" are distinct keys';
+    is %h{1}, "int", 'Int key reads back';
+    is %h{"1"}, "str", 'Str key reads back';
+    %h{1}:delete;
+    is %h.elems, 1, ':delete removes only the Int key';
+    is %h{"1"}, "str", 'Str key survives the Int delete';
+}
+
+# --- misc reads ---
+{
+    my %h{Any} = 1 => "a", "x" => "b";
+    is-deeply %h.kv.sort.list, (1, "a", "b", "x"), '.kv yields typed keys';
+    is-deeply %h{1, "x"}.list, ("a", "b"), 'mixed-type slice';
+    ok %h.raku.contains('1 => "a"'), '.raku shows the Int key unquoted';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

Object hashes (`my %h{Any}`, `:{...}`, `Hash[K,V].new`) stored every key as its stringification, conflating any keys that share a `.Str`. This PR makes them key by the canonical `.WHICH` string of the key **object** (`value_which_key`), with the key objects preserved in `HashData.original_keys` — the object-hash half of PLAN §8.10 (the numerics [4] / hashmap [1] / traps [8] doc-diff findings).

Before → after (raku-verified):

- `my %h{Any} = 42 => "foo"; %h.keys.map(*.^name)` → was `(Str)`, now `(Int)`
- `%h<42>:exists` (IntStr allomorph) → was `True`, now `False`; `%h{42}:exists` stays `True`
- `:{ 0 => 42 }<0>` → was `42`, now `(Any)`; `:{ <0> => 42 }<0>` stays `42`
- `:{ Dog => 42 }{Dog}` (enum type object) → was `42`, now `(Any)`; `{"Dog"}` stays `42`
- `Int 1` and `Str "1"` coexist as distinct keys; `:delete` removes only the matching identity

## Design

The keying invariant — *an object hash stores `.WHICH` keys and `original_keys` covers every entry* — is enforced at the `tag_container_metadata` chokepoint (`ensure_object_hash_which_keys`, idempotent). Key-type-blind builders (hash literals, list→hash coercion, `Hash[K,V].new`) record the key objects in `original_keys`; attaching a `key_type` re-keys losslessly from those objects. This removes the old `use_which` split (WHICH-keyed vs "plain-built" object hashes) and the lossy string-reconstruction of typed keys.

Riding on the invariant:

- `:{...}` (including empty) parses to an `__object_hash()` call building a Mu-keyed object hash — rakudo's `Hash[Mu,Mu]` shape (`^name` `Hash[Mu,Mu,Any]`, missing-key reads yield `Any`, `.raku` prints `(my Mu %{Mu} = ...)`).
- Angle-word subscripts (`%h<42>`) are val()-allomorphic like standalone `<...>` words (plain hashes are unaffected — they stringify the key).
- All read/write/coercion surfaces updated to preserve or correctly stringify key objects: element + bulk assignment, `AT-KEY`/`EXISTS-KEY`/`ASSIGN-KEY`/`DELETE-KEY`, `:exists`/`:delete`, slices, `.keys`/`.kv`/`.pairs`/`.pick`, `say`/`.gist`/`.raku`, `∈` and the set operators, `.Set`/`.Bag`/`.Mix`/`.Map`, `|%h` interpolation, hash flattening (object→plain stringifies, object→object keeps objects — matching raku).
- classify/categorize return the `Hash[Mu,Mu]` shape at every nesting level; `:into` targets keep their object-hash identity.
- Expression-position container declarations register their type constraint BEFORE the initializer runs, fixing a stale-constraint leak between `%__ANON_HASH__` EVALs (S32-hash/perl.t idempotence tests).
- `my %h{Int} = "42" => 1` now fails the key type check like raku.

Remaining in PLAN §8.10 (updated): the Set/Bag/Mix element stores are still string-keyed (`(1,"1",1.0).Set.elems` is 1 vs raku 3) — a follow-up campaign.

## Test plan

- New pin: `t/object-hash-which-keys.t` (30 tests, passes on both mutsu and raku)
- `t/classify-hash-any-mu-raku.t` re-pinned to the raku-verified `Hash[Mu,Mu,Any]` / `(my Mu %{Mu} = ...)` forms (old pins disagreed with the reference raku and with roast classify.t)
- `t/native-array-backed-instance-methods.t` indexes the classify result with `{True}` since `<True>` now misses (raku-verified)
- `make test` green locally; risk-area whitelisted roast sweep green (S32-hash/*, S09-hashes/objecthash.t, S02-types hash/quanthash files, S32-list classify/categorize/pick/roll, all 8 S03 set-operator files, allomorphic.t, val.t, slurpy tests — 14k+ tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)