### PR TITLE
fix: `.match` / `.subst` accept a named regex passed as a value (`&Named`)

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -644,7 +644,8 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   ~~IO::Path::AutoDecompress~~ (FIXED — see Done), ~~Math::Angle~~ (FIXED — see Done),
   ~~Math::PascalTriangle~~ (FIXED — see Done),
   ~~Statistics::LinearRegression~~ (FIXED — see Done), String::Rotate,
-  Text::CodeProcessing, Trait::IO, WriteOnceHash, `are`, ~~`sortuk`~~ (FIXED — see Done),
+  Text::CodeProcessing (PARTIAL — `.match`/`.subst` `&Named` arg fixed; see Done),
+  Trait::IO, WriteOnceHash, `are`, ~~`sortuk`~~ (FIXED — see Done),
   Tree::Binary::PrettyTree (role-`new` requirement FIXED; now blocked on a
   separate `class Iterator does Iterator` name-resolution issue — see Done).
 - These `test_die` on the current binary but were not individually reproduced.
@@ -666,6 +667,27 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 _(move tickets here with `[claim: <branch>]` when you start)_
 
 ## Done
+
+- **T-057 (Text::CodeProcessing)** (PR `fix-match-subst-named-regex-arg`) —
+  PARTIAL. General bug fixed: a **named regex/token passed as a value**
+  (`&Named`, or a hash slot holding it — the module keeps
+  `%fileTypeToSearchSub{$docType} = &MarkdownSearch` and calls
+  `$input.match(that, :g)` / `$input.subst(that, ...)`) did not work as a
+  `.match` / `.subst` pattern. mutsu represents `&Named` as a `Routine`
+  (`is_regex`), and both dispatchers only accepted a `Regex` value or a `Str`, so
+  the Routine fell through to literal-string matching of its stringified
+  `sub Named (...) {...}` form → never matched (returned `Nil` / left the string
+  unchanged). Fix: `.match` (`methods_match_dispatch.rs`) and `.subst`
+  (`methods_string.rs`) now extract the named regex's source via
+  `extract_token_regex_pattern` (the same path `$str ~~ &Named` uses) and match
+  with THAT, so the returned Match carries the named regex's own captures at top
+  level. Pin: `t/match-subst-named-regex-arg.t`. **Remaining blocker (separate
+  regex-engine bug, not `&Named`-specific — reproduces with an inline `/ /` too):**
+  a frugal `.*?` followed by a `<?after \v>` look-behind and a `$<fence>`
+  back-reference (the `MarkdownSearch` code-fence body) does not match minimally
+  under `:g` — mutsu spans one match across several fences (1 match where Rakudo
+  finds 2+), so the markdown/org/pod extraction is still wrong. Needs dedicated
+  regex-engine work (frugal-quantifier + capture-back-reference interaction).
 
 - **T-057 (IO::Path::AutoDecompress)** (PR `fix-qualified-native-ancestor-method`)
   — test_die → t/01-basic.rakutest 8/8. Root cause: a qualified method call

--- a/news/2026-07/match-subst-named-regex-arg.md
+++ b/news/2026-07/match-subst-named-regex-arg.md
@@ -1,0 +1,32 @@
+# `.match` / `.subst` accept a named regex passed as a value (`&Named`)
+
+A named regex or token passed as a *value* — `&Named`, or a hash/array slot
+holding one — now works as the pattern argument of `.match` and `.subst`:
+
+```raku
+my regex Word { \w+ }
+"foo bar baz".match(&Word, :g).elems;      # 3
+"foo bar baz".subst(&Word, 'X', :g);       # "X X X"
+
+my %search = word => &Word;
+"ab cd".match(%search<word>, :g);          # matches "ab", "cd"
+```
+
+mutsu represents `&Named` as a `Routine` value (flagged `is_regex`), and both
+`.match` and `.subst` previously accepted only a `Regex` value (`rx/.../`) or a
+`Str`. A `Routine` fell through to the literal-string branch and matched its
+stringified `sub Named (...) {...}` form, so it never matched — `.match` returned
+`Nil` and `.subst` left the string unchanged. (Smart-match, `$str ~~ &Named`,
+already worked.)
+
+Both dispatchers now detect a regex `Routine` and extract its source via
+`extract_token_regex_pattern` — the same path smart-match uses — then match with
+that source, so the returned `Match` carries the named regex's own captures at
+top level (`$m<k>`, not `$m<Named><k>`).
+
+This is a step toward the `Text::CodeProcessing` distribution (T-057), which
+stores its per-format search regex as `&MarkdownSearch` in a hash and drives
+`.match(:g)` / `.subst` with it. A separate regex-engine bug remains for that
+distribution (a frugal `.*?` combined with a `<?after>` look-behind and a
+capture back-reference does not match minimally under `:g`), tracked in the
+dist-ticket ledger. Pin: `t/match-subst-named-regex-arg.t`.

--- a/src/runtime/methods_match_dispatch.rs
+++ b/src/runtime/methods_match_dispatch.rs
@@ -61,6 +61,30 @@ impl Interpreter {
                 let escaped = p.replace('\'', "\\'");
                 format!("'{}'", escaped)
             }
+            // A named regex/token passed as a value — `&Named`, or a hash/array
+            // slot holding it (`%searchSub{$type}`) — is a `Routine` with
+            // `is_regex`. Extract its regex source and match with THAT, so the
+            // returned Match carries the named regex's own captures at top level
+            // (mirroring the smartmatch `$str ~~ &Named` path). Without this the
+            // Routine fell through to the literal-string arm below and matched its
+            // stringified form (`sub Named (...) {...}`) → never matched.
+            ValueView::Routine {
+                is_regex: true,
+                name,
+                package,
+            } => {
+                let qualified = format!("{}::{}", package.resolve(), name.resolve());
+                match self
+                    .extract_token_regex_pattern(&qualified)
+                    .or_else(|| self.extract_token_regex_pattern(&name.resolve()))
+                {
+                    Some(p) => p,
+                    None => {
+                        let escaped = pattern.to_string_value().replace('\'', "\\'");
+                        format!("'{}'", escaped)
+                    }
+                }
+            }
             // An *undefined* matcher (Nil, or a bare type object like `Any`)
             // resolves to no `.match` candidate — Rakudo throws X::Multi::NoMatch
             // rather than hanging (roast .../multi-no-match.t).

--- a/src/runtime/methods_string.rs
+++ b/src/runtime/methods_string.rs
@@ -226,6 +226,29 @@ impl Interpreter {
         let pattern = positional
             .first()
             .ok_or_else(|| super::methods_signature_errors::make_multi_no_match_error("subst"))?;
+        // A named regex/token passed as a value (`&Named`, or a hash slot holding
+        // it) is a `Routine` with `is_regex`. Normalize it to a `Regex` value
+        // built from its source so the regex-pattern branch below drives the
+        // substitution (mirrors `.match`); otherwise it fell through to the
+        // literal-string branch and matched its stringified `sub ...` form.
+        let pattern_owned: Value = match pattern.view() {
+            ValueView::Routine {
+                is_regex: true,
+                name,
+                package,
+            } => {
+                let qualified = format!("{}::{}", package.resolve(), name.resolve());
+                match self
+                    .extract_token_regex_pattern(&qualified)
+                    .or_else(|| self.extract_token_regex_pattern(&name.resolve()))
+                {
+                    Some(p) => Value::regex(p),
+                    None => pattern.clone(),
+                }
+            }
+            _ => pattern.clone(),
+        };
+        let pattern = &pattern_owned;
         let replacement_val = positional.get(1).cloned();
         let is_closure = matches!(
             replacement_val.as_ref().map(Value::view),

--- a/t/match-subst-named-regex-arg.t
+++ b/t/match-subst-named-regex-arg.t
@@ -1,0 +1,52 @@
+use Test;
+
+# A named regex/token passed as a *value* — `&Named`, or a hash/array slot
+# holding it — must work as the pattern argument of `.match` and `.subst`.
+# mutsu represents `&Named` as a `Routine` (is_regex); `.match`/`.subst`
+# previously only accepted a `Regex` value (`rx/.../`) or a Str, so `&Named`
+# fell through to literal-string matching of its stringified `sub Named {...}`
+# form and never matched. (`$str ~~ &Named` already worked.)
+
+plan 12;
+
+my regex Word  { \w+ }
+my regex Digits { \d+ }
+my regex KV { $<k>=(\w+) '=' $<v>=(\w+) }
+
+# --- .match with &Named ---
+{
+    my $s = "foo bar baz";
+    is $s.match(&Word).Str, 'foo', '.match(&Named) single match';
+    is $s.match(&Word, :g).elems, 3, '.match(&Named, :g) global count';
+    is $s.match(&Word, :g).map(*.Str).join(','), 'foo,bar,baz', '.match(&Named, :g) values';
+    ok !"...".match(&Word).defined, '.match(&Named) with no match is undefined';
+}
+
+# --- named captures of the named regex are top-level on the Match ---
+{
+    my $m = "a=1 b=2".match(&KV, :g);
+    is $m.elems, 2, '.match(&KV, :g) count';
+    is $m[0]<k>, 'a', 'named capture <k> is top-level (0)';
+    is $m[1]<v>, '2', 'named capture <v> is top-level (1)';
+}
+
+# --- a hash slot holding &Named (the Text::CodeProcessing shape) ---
+{
+    my %search = word => &Word, digits => &Digits;
+    my $s = "ab 12 cd 34";
+    is $s.match(%search<digits>, :g).map(*.Str).join(','), '12,34',
+        '.match(%hash{key}) where the slot holds &Named';
+}
+
+# --- .subst with &Named ---
+{
+    is "foo bar baz".subst(&Word, 'X'), 'X bar baz', '.subst(&Named) first match';
+    is "foo bar baz".subst(&Word, 'X', :g), 'X X X', '.subst(&Named, :g) global';
+    is "a1b2c3".subst(&Digits, '#', :g), 'a#b#c#', '.subst(&Named, :g) digits';
+}
+
+# --- .subst with &Named and a replacement closure using the match ---
+{
+    is "foo bar".subst(&Word, -> $m { $m.Str.uc }, :g), 'FOO BAR',
+        '.subst(&Named, closure, :g)';
+}


### PR DESCRIPTION
## Problem

A named regex/token passed as a **value** — `&Named`, or a hash/array slot holding one — did not work as the pattern argument of `.match` / `.subst`:

```raku
my regex Word { \w+ }
"foo bar baz".match(&Word, :g).elems;   # mutsu: 0   (raku: 3)
"foo bar baz".subst(&Word, 'X', :g);    # mutsu: "foo bar baz"  (raku: "X X X")
```

mutsu represents `&Named` as a `Routine` value (flagged `is_regex`), and both dispatchers only accepted a `Regex` value (`rx/.../`) or a `Str`. A `Routine` fell through to the literal-string branch and matched its **stringified** `sub Named (...) {...}` form, so it never matched — `.match` returned `Nil` and `.subst` left the string unchanged. (Smart-match, `$str ~~ &Named`, already worked.)

## Fix

`.match` (`methods_match_dispatch.rs`) and `.subst` (`methods_string.rs`) now detect a regex `Routine` and extract its source via `extract_token_regex_pattern` — the same path smart-match uses — then match with that source, so the returned `Match` carries the named regex's own captures at top level (`$m<k>`, not `$m<Named><k>`).

## Impact

Step toward the `Text::CodeProcessing` distribution (T-057), which stores its per-format search regex as `&MarkdownSearch` in a hash and drives `.match(:g)` / `.subst` with it.

**A separate regex-engine bug remains** for that distribution (recorded in the dist-ticket ledger): a frugal `.*?` combined with a `<?after>` look-behind and a capture back-reference does not match minimally under `:g` — this reproduces with an inline `/ /` too, so it is independent of this `&Named` fix.

## Verification

- `make test`: Result: PASS (2372 files, 22529 tests)
- Pin: `t/match-subst-named-regex-arg.t` (12 tests; verified identical output under raku)
- All local match/subst/regex/grammar/token tests pass; no clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)