### PR TITLE
fix: list-constructed hash type-object keys coerce to "" with a string-context warning

### DIFF
--- a/news/2026-07/list-constructed-hash-type-object-key.md
+++ b/news/2026-07/list-constructed-hash-type-object-key.md
@@ -1,0 +1,44 @@
+# List-constructed hash type-object keys coerce to "" with a warning
+
+A bare type object used as a hash key in *list* construction now stringifies to
+the empty string with Rakudo's "Use of uninitialized value of type X in string
+context" warning, matching the subscript-store behavior shipped earlier
+(`%h{Int} = 1`). Previously mutsu kept the type object's gist as the key:
+
+```raku
+my %h = (Int, 1);      # was: keys ((Int));  now: keys ("",)  + warning
+say %(Int, 1).keys;    # was: ((Int));       now: ()          + warning
+(Int, 1).hash;         # was: {(Int) => 1};  now: {"" => 1}    + warning
+```
+
+This holds across every list-to-hash path: the `my %h = (...)` assignment, the
+`%(...)` literal, the `.hash`/`.Hash` methods, and the `hash(...)`/`Hash(...)`
+coercers. A class defining a user `.Str`/`.Stringy` dispatches it instead of
+warning (`(Foo, 1).hash` keys by `Foo.Str`), and ordinary string/numeric keys
+are unaffected.
+
+## Implementation
+
+The pairing logic in `build_hash_from_items` was factored into
+`build_hash_from_items_with_key_coercion`, which takes a per-key encoder hook.
+The interpreter-aware `Interpreter::build_hash_from_items_warning` uses it to
+coerce a bare type-object key via the existing `coerce_type_object_hash_key`
+helper (warn + optional user `.Str` dispatch), while the plain
+`build_hash_from_items` keeps the original gist encoding and `original_keys`
+recording.
+
+The empty-string coercion is a *plain* (`Str`-keyed) hash semantic only. An
+object hash (`%h{Any}`, `%h{Int}`, ...) keeps its keys distinct — collapsing
+them to `""` would drop the key entirely — so `coerce_hash_var_value` gates the
+warning variant behind `is_str_keyed_hash_var` and routes object hashes through
+the unchanged `build_hash_from_items`, which preserves the type-object key for
+the object-hash re-tag and for `.antipairs`/`.invert`.
+
+The `.hash`/`.Hash` methods (and the `%(...)` literal, which compiles to
+`MakeArray(...).hash`) are dispatched natively without an interpreter, so a
+list invocant is intercepted in the VM `CallMethod` path (and in
+`call_method_with_values` for re-entrant dispatch) and routed to the
+interpreter-aware builder. `exec_make_hash_op` now coerces its type-object keys
+too.
+
+Pinned by `t/hash-key-type-object-list.t`.

--- a/src/runtime/builtins_coerce.rs
+++ b/src/runtime/builtins_coerce.rs
@@ -27,7 +27,7 @@ impl Interpreter {
         Ok(match name {
             "Array" => Value::real_array(items),
             "List" => Value::array(items),
-            "Hash" => crate::runtime::utils::build_hash_from_items(items)?,
+            "Hash" => self.build_hash_from_items_warning(items)?,
             _ => Value::real_array(items),
         })
     }

--- a/src/runtime/builtins_collection.rs
+++ b/src/runtime/builtins_collection.rs
@@ -352,12 +352,12 @@ impl Interpreter {
         Some(r)
     }
 
-    pub(super) fn builtin_hash(&self, args: &[Value]) -> Result<Value, RuntimeError> {
+    pub(super) fn builtin_hash(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         let mut flat_values = Vec::new();
         for arg in args {
             flat_values.extend(Self::value_to_list(arg));
         }
-        crate::runtime::utils::build_hash_from_items(flat_values)
+        self.build_hash_from_items_warning(flat_values)
     }
 
     pub(super) fn builtin_junction(

--- a/src/runtime/io_env.rs
+++ b/src/runtime/io_env.rs
@@ -242,6 +242,28 @@ impl Interpreter {
         Ok(val.to_string_value())
     }
 
+    /// Build a `Hash` from a flat item list (`my %h = (...)`, `%(...)`, `Hash(...)`),
+    /// coercing a bare type-object key to `""` with the Rakudo
+    /// "uninitialized value of type X in string context" warning (or dispatching
+    /// a user `.Str`/`.Stringy`). This is the interpreter-aware counterpart of the
+    /// silent `build_hash_from_items`; the warning requires `&mut self`, so the
+    /// no-interpreter `.hash`/`.Hash` list path only coerces silently.
+    pub(crate) fn build_hash_from_items_warning(
+        &mut self,
+        items: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
+        crate::runtime::utils::build_hash_from_items_with_key_coercion(items, |kk| {
+            if matches!(kk.view(), ValueView::Package(_)) {
+                Ok((self.coerce_type_object_hash_key(kk)?, false))
+            } else {
+                Ok((
+                    Value::hash_key_encode(kk),
+                    !matches!(kk.view(), ValueView::Str(_)),
+                ))
+            }
+        })
+    }
+
     /// Stringify a value by calling .Str method (used by put/print).
     /// Falls back to to_string_value() if .Str method dispatch fails.
     pub(crate) fn render_str_value(&mut self, value: &Value) -> String {

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -129,6 +129,28 @@ impl Interpreter {
         {
             return self.call_method_with_values(target, "sum", Vec::new());
         }
+        // `.hash` / `.Hash` on a bare positional list (`(Int, 1).hash`, and the
+        // `%(...)` literal, which compiles to `MakeArray(...).hash`) builds a
+        // plain Hash from the flattened elements. A bare type-object key
+        // stringifies to "" with the Rakudo "uninitialized value in string
+        // context" warning; the native `.hash` fast path cannot warn (no
+        // interpreter), so route list invocants through the interpreter-aware
+        // builder. Set/Bag/Mix/Instance/type-object invocants keep their native
+        // `.hash` semantics.
+        if matches!(method, "hash" | "Hash")
+            && args.is_empty()
+            && matches!(
+                target.view(),
+                ValueView::Array(..) | ValueView::Seq(_) | ValueView::Slip(_)
+            )
+        {
+            let items: Vec<Value> = match target.view() {
+                ValueView::Array(items, _) => items.iter().cloned().collect(),
+                ValueView::Seq(items) | ValueView::Slip(items) => items.iter().cloned().collect(),
+                _ => unreachable!(),
+            };
+            return self.build_hash_from_items_warning(items);
+        }
         // A Backtrace is a List of Backtrace::Frame: list-iteration methods
         // (grep/map/first/...) operate on its frames, not the Backtrace itself.
         if let ValueView::Instance {

--- a/src/runtime/utils/coerce_containers.rs
+++ b/src/runtime/utils/coerce_containers.rs
@@ -218,6 +218,33 @@ pub(crate) fn coerce_to_hash(value: Value) -> Value {
 }
 
 pub(crate) fn build_hash_from_items(items: Vec<Value>) -> Result<Value, RuntimeError> {
+    // Stringify each non-`Str` key and record the original in `original_keys` so
+    // an object-hash re-tag (`%h{Any} = ..., Foo, $o`) and `.antipairs`/`.invert`
+    // can recover the real key. A bare type object stringifies to its gist here;
+    // the empty-string-with-warning coercion is a *plain* (`Str`-keyed) hash
+    // semantic, applied only by the interpreter-aware `build_hash_from_items_warning`.
+    build_hash_from_items_with_key_coercion(items, |kk| {
+        Ok((
+            Value::hash_key_encode(kk),
+            !matches!(kk.view(), ValueView::Str(_)),
+        ))
+    })
+}
+
+/// Build a `Hash` from a flat item list, mapping each *bare* (non-`Pair`) key
+/// value to its string key via `encode_key`. `encode_key` returns
+/// `(string_key, record_original)`: when `record_original` is true the original
+/// key `Value` is remembered in the hash's `original_keys` side table (so
+/// `.keys` can recover a non-`Str` key); a type object coerced to `""` returns
+/// `false`, matching Rakudo's plain-`Str` `""` key. Pair/Hash flattening and
+/// the "Odd number of elements" error are handled here regardless of the hook.
+pub(crate) fn build_hash_from_items_with_key_coercion<F>(
+    items: Vec<Value>,
+    mut encode_key: F,
+) -> Result<Value, RuntimeError>
+where
+    F: FnMut(&Value) -> Result<(String, bool), RuntimeError>,
+{
     let total_items = items.len();
     let last_item = items
         .last()
@@ -255,8 +282,8 @@ pub(crate) fn build_hash_from_items(items: Vec<Value>) -> Result<Value, RuntimeE
             // matching Rakudo. Every other non-Str key stringifies as usual.
             ValueView::ValuePair(key, boxed_val) => {
                 for kk in hash_pair_keys(key) {
-                    let str_key = Value::hash_key_encode(&kk);
-                    if !matches!(kk.view(), ValueView::Str(_)) {
+                    let (str_key, record_original) = encode_key(&kk)?;
+                    if record_original {
                         original_keys.insert(str_key.clone(), kk.clone());
                     }
                     map.insert(str_key, boxed_val.clone());
@@ -280,8 +307,8 @@ pub(crate) fn build_hash_from_items(items: Vec<Value>) -> Result<Value, RuntimeE
                     err.exception = Some(Box::new(ex));
                     return Err(err);
                 };
-                let str_key = Value::hash_key_encode(&item);
-                if !matches!(item.view(), ValueView::Str(_)) {
+                let (str_key, record_original) = encode_key(&item)?;
+                if record_original {
                     original_keys.insert(str_key.clone(), item.clone());
                 }
                 map.insert(str_key, value);

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -474,6 +474,31 @@ impl Interpreter {
         } else {
             target
         };
+        // `.hash` / `.Hash` on a bare positional list (`(Int, 1).hash`, and the
+        // `%(...)` literal, which compiles to `MakeArray(...).hash`) builds a
+        // plain Hash from the flattened elements. A bare type-object key
+        // stringifies to "" with the Rakudo "uninitialized value in string
+        // context" warning; the native `.hash` fast path cannot warn (no
+        // interpreter), so route list invocants through the interpreter-aware
+        // builder here. Set/Bag/Mix/Instance/type-object invocants keep their
+        // native `.hash` semantics.
+        if matches!(method, "hash" | "Hash")
+            && args.is_empty()
+            && modifier.is_none()
+            && matches!(
+                target.view(),
+                ValueView::Array(..) | ValueView::Seq(_) | ValueView::Slip(_)
+            )
+        {
+            let items: Vec<Value> = match target.view() {
+                ValueView::Array(items, _) => items.iter().cloned().collect(),
+                ValueView::Seq(items) | ValueView::Slip(items) => items.iter().cloned().collect(),
+                _ => unreachable!(),
+            };
+            let result = self.build_hash_from_items_warning(items)?;
+            self.stack.push(result);
+            return Ok(());
+        }
         // `Pair.freeze` on a non-variable receiver (e.g. `Pair.new(...).freeze`,
         // or a `.freeze.foo` chain): decontainerize the value, mark it read-only,
         // and return it. There is no variable to rebind here (empty target name).

--- a/src/vm/vm_data_ops.rs
+++ b/src/vm/vm_data_ops.rs
@@ -115,17 +115,25 @@ impl Interpreter {
         self.stack.push(Value::real_array(elems));
     }
 
-    pub(super) fn exec_make_hash_op(&mut self, n: u32) {
+    pub(super) fn exec_make_hash_op(&mut self, n: u32) -> Result<(), RuntimeError> {
         let n = n as usize;
         let start = self.stack.len() - n * 2;
         let items: Vec<Value> = self.stack.drain(start..).collect();
         let mut map = HashMap::new();
         for pair in items.chunks(2) {
-            let key = Value::hash_key_encode(&pair[0]);
+            // A bare type-object key (`%(Int, 1)`) stringifies to "" with the
+            // Rakudo "uninitialized value in string context" warning (or a user
+            // `.Str`/`.Stringy`), matching the `my %h = (Int, 1)` list path.
+            let key = if matches!(pair[0].view(), ValueView::Package(_)) {
+                self.coerce_type_object_hash_key(&pair[0])?
+            } else {
+                Value::hash_key_encode(&pair[0])
+            };
             let val = pair[1].clone();
             map.insert(key, val);
         }
         self.stack.push(Value::hash(map));
+        Ok(())
     }
 
     /// Build a Hash from N Pair values on the stack (from `%(k=>v, ...)` syntax).

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -2853,7 +2853,7 @@ impl Interpreter {
                 *ip += 1;
             }
             OpCode::MakeHash(n) => {
-                self.exec_make_hash_op(*n);
+                self.exec_make_hash_op(*n)?;
                 *ip += 1;
             }
             OpCode::MakeHashFromPairs(n) => {

--- a/src/vm/vm_var_assign_coerce.rs
+++ b/src/vm/vm_var_assign_coerce.rs
@@ -140,6 +140,20 @@ impl Interpreter {
         }
     }
 
+    /// True when a `%` variable stores plain `Str` keys — no object-hash key
+    /// constraint, or an explicit `Str` one. A bare type-object key coerces to
+    /// "" (with the string-context warning) only for these; an object hash
+    /// (`%h{Any}`, `%h{Int}`, ...) keeps its keys distinct.
+    fn is_str_keyed_hash_var(&self, name: &str) -> bool {
+        match self.var_hash_key_constraint(name) {
+            None => true,
+            Some(kc) => {
+                let (base, _) = crate::runtime::types::strip_type_smiley(&kc);
+                base == "Str"
+            }
+        }
+    }
+
     pub(super) fn coerce_hash_var_value(
         &mut self,
         name: &str,
@@ -202,6 +216,19 @@ impl Interpreter {
             }
             return Ok(result);
         }
+        // A bare type-object key stringifies to "" with a warning only for a
+        // plain (`Str`-keyed) hash. An object hash (`%h{Any}`, `%h{Int}`, ...)
+        // keeps its keys distinct (by WHICH / reconstructed type) via
+        // `build_hash_from_items`'s `original_keys` recording, so the coercion
+        // must NOT run there — it would collapse distinct type-object keys to a
+        // single "" and drop the object-hash key entirely.
+        let build_items = |this: &mut Self, items: Vec<Value>| {
+            if this.is_str_keyed_hash_var(name) {
+                this.build_hash_from_items_warning(items)
+            } else {
+                runtime::utils::build_hash_from_items(items)
+            }
+        };
         // For Array/Seq/Slip values, use `build_hash_from_items` which
         // raises "Odd number of elements" when appropriate. Hash values from
         // scalar containers (`$h`) are NOT pre-flattened, so they appear as
@@ -213,10 +240,10 @@ impl Interpreter {
                 // while a hash sourced from a `$` scalar carries
                 // `HashData.itemized` and stays opaque (`%m = ($hashitem,)` →
                 // "Odd number") — matching Raku.
-                runtime::utils::build_hash_from_items(items.iter().cloned().collect())?
+                build_items(self, items.iter().cloned().collect())?
             }
             ValueView::Seq(items) | ValueView::Slip(items) => {
-                runtime::utils::build_hash_from_items(items.iter().cloned().collect())?
+                build_items(self, items.iter().cloned().collect())?
             }
             // A single bare scalar assigned to a hash is a one-element (odd)
             // initializer: `my %h = 1` is X::Hash::Store::OddNumber. Hashes,
@@ -233,7 +260,7 @@ impl Interpreter {
                     | ValueView::BigRat(..)
             ) =>
             {
-                runtime::utils::build_hash_from_items(vec![value])?
+                build_items(self, vec![value])?
             }
             _ => self.coerce_object_to_hash(value),
         };
@@ -335,7 +362,7 @@ impl Interpreter {
             }
             // Non-Associative values: coerce to Map
             ValueView::Array(items, _) => {
-                let hash = runtime::utils::build_hash_from_items(items.iter().cloned().collect())?;
+                let hash = self.build_hash_from_items_warning(items.iter().cloned().collect())?;
                 let info = crate::runtime::ContainerTypeInfo {
                     value_type: String::new(),
                     key_type: None,
@@ -344,7 +371,7 @@ impl Interpreter {
                 Ok(self.tag_container_metadata(hash, info))
             }
             ValueView::Seq(items) | ValueView::Slip(items) => {
-                let hash = runtime::utils::build_hash_from_items(items.iter().cloned().collect())?;
+                let hash = self.build_hash_from_items_warning(items.iter().cloned().collect())?;
                 let info = crate::runtime::ContainerTypeInfo {
                     value_type: String::new(),
                     key_type: None,
@@ -356,7 +383,7 @@ impl Interpreter {
                 // For other types (Int, Str, etc.), coerce to Map via
                 // build_hash_from_items which raises X::Hash::Store::OddNumber
                 // for odd element counts (e.g., `constant %h = 42`).
-                let hash = runtime::utils::build_hash_from_items(vec![value])?;
+                let hash = self.build_hash_from_items_warning(vec![value])?;
                 let info = crate::runtime::ContainerTypeInfo {
                     value_type: String::new(),
                     key_type: None,

--- a/t/hash-key-type-object-list.t
+++ b/t/hash-key-type-object-list.t
@@ -1,0 +1,58 @@
+use v6;
+use Test;
+
+# A bare type object used as a hash key in LIST construction (as opposed to a
+# subscript, covered by t/hash-key-type-object.t) coerces to the empty string
+# with Rakudo's "uninitialized value of type X in string context" warning. This
+# holds across every list-to-hash path: `my %h = (...)`, the `%(...)` literal,
+# `.hash`/`.Hash`, the `hash(...)`/`Hash(...)` coercers, and `constant`. A user
+# .Str/.Stringy dispatches instead (no warning).
+
+plan 14;
+
+# --- my %h = (...) assignment ---
+{
+    my %h;
+    quietly %h = (Int, 1);
+    is %h.keys.raku, '("",).Seq', 'assignment: type object key coerces to ""';
+    is %h{""}, 1, 'assignment: the value is stored under ""';
+}
+{
+    my %h;
+    quietly %h = (Int, 1, Str, 2);
+    is %h.elems, 1, 'assignment: two type object keys collapse to one "" key';
+    is %h{""}, 2, 'assignment: the later write wins';
+}
+
+# --- %(...) literal ---
+{
+    my %h = quietly %(Int, 1);
+    is %h.keys.raku, '("",).Seq', '%() literal: type object key coerces to ""';
+    is %h{""}, 1, '%() literal: value stored under ""';
+}
+
+# --- .hash / .Hash methods ---
+is (quietly (Int, 1).hash.keys.raku), '("",).Seq', '.hash: type object key coerces to ""';
+is (quietly (Int, 1).Hash.keys.raku), '("",).Seq', '.Hash: type object key coerces to ""';
+
+# --- hash(...) / Hash(...) coercers ---
+is (quietly hash(Int, 1).keys.raku), '("",).Seq', 'hash(): type object key coerces to ""';
+is (quietly Hash(Int, 1).keys.raku), '("",).Seq', 'Hash(): type object key coerces to ""';
+
+# --- a user .Str dispatches (no coercion to "") ---
+{
+    my class Foo { method Str { "foo" } }
+    my %h = (Foo, 1);
+    is %h.keys.raku, '("foo",).Seq', 'assignment: user .Str type object keys by its .Str';
+    is (Foo, 1).hash.keys.raku, '("foo",).Seq', '.hash: user .Str type object keys by its .Str';
+}
+
+# --- ordinary (non-type-object) keys are unaffected ---
+{
+    my %h = ("a", 1, "b", 2);
+    is %h.keys.sort.raku, '("a", "b").Seq', 'plain string keys unaffected';
+    my %n = (5, "x");
+    is %n.keys.raku, '("5",).Seq', 'numeric key stringifies to "5" as before';
+}
+
+done-testing;


### PR DESCRIPTION
## Summary

Follow-up to #5330 (subscript type-object keys). A bare type object used as a hash key in **list** construction now stringifies to the empty string with Rakudo's *"Use of uninitialized value of type X in string context"* warning, instead of keeping the type object's gist as the key.

```raku
my %h = (Int, 1);      # was: keys ((Int));  now: keys ("",)  + warning
say %(Int, 1).keys;    # was: ((Int));       now: ()          + warning
(Int, 1).hash;         # was: {(Int) => 1};  now: {"" => 1}    + warning
hash(Int, 1); Hash(Int, 1);   # same coercion
```

Covered across every list-to-hash path: `my %h = (...)` assignment, the `%(...)` literal, `.hash`/`.Hash`, and the `hash(...)`/`Hash(...)` coercers. A user `.Str`/`.Stringy` dispatches instead of warning; ordinary string/numeric keys are unaffected.

## Implementation

- Factored `build_hash_from_items` into `build_hash_from_items_with_key_coercion` (per-key encoder hook). The interpreter-aware `Interpreter::build_hash_from_items_warning` coerces bare type-object keys via the existing `coerce_type_object_hash_key` (warn + user `.Str`); plain `build_hash_from_items` keeps the original gist encoding + `original_keys` recording.
- The `""` coercion is a **plain (Str-keyed)** hash semantic only. Object hashes (`%h{Any}`, `%h{Int}`, ...) keep distinct keys — collapsing them to `""` would drop the key — so `coerce_hash_var_value` gates the warning variant behind `is_str_keyed_hash_var` and routes object hashes through the unchanged builder (preserving keys for the object-hash re-tag and `.antipairs`/`.invert`).
- `.hash`/`.Hash` and `%(...)` (which compiles to `MakeArray(...).hash`) dispatch natively without an interpreter, so list invocants are intercepted in the VM `CallMethod` path and in `call_method_with_values`. `exec_make_hash_op` coerces its type-object keys too.

## Testing

- New pin: `t/hash-key-type-object-list.t` (14 subtests, raku-verified).
- `make test` green; targeted roast (`S02-types/hash.t`, `S09-typed-arrays/hashes.t`, `S09-hashes/objecthash.t`, `S29-conversions/hash.t`, classify/categorize suite) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)