### PR TITLE
fix: sprintf `%s` coerces a bare type object to "" with a string-context warning

### DIFF
--- a/news/2026-07/sprintf-type-object-string-context-warning.md
+++ b/news/2026-07/sprintf-type-object-string-context-warning.md
@@ -1,0 +1,37 @@
+# `sprintf`'s `%s` coerces a bare type object to "" with a string-context warning
+
+A bare type object rendered by a `%s` directive now stringifies to the empty
+string with rakudo's `Use of uninitialized value of type X in string context.`
+warning, instead of the mutsu-specific `(Int)` gist. This matches how `~Int` and
+`Int.Str` already behave, and how raku renders `sprintf("%s", Int)` (empty
+string plus the warning). Numeric directives are unchanged — they already coerce
+a type object to `0`.
+
+Both call shapes agree now:
+
+```raku
+sprintf("%s", Int)        # "" + "Use of uninitialized value of type Int ..."
+"%s".sprintf(Int)         # "" + same warning
+sprintf("%s|%s", Int, 5)  # "|5"
+```
+
+## Implementation
+
+The pure native formatter (`format_sprintf_impl`) has no interpreter context and
+cannot emit warnings, so the type-object case is routed through the
+interpreter-aware `Interpreter::builtin_sprintf`:
+
+- `native_sprintf` (the VM fast path) now bails to `None` — falling back to
+  `builtin_sprintf` — when any argument is a bare type object (`Package`), the
+  same way it already defers `Instance`/`Junction` args.
+- `builtin_sprintf` already maps each argument to its directive via
+  `sprintf_arg_specs`; its per-argument loop now, for a bare type object with no
+  user coercion method and a `%s` directive, emits
+  `warn_type_object_string_context` and substitutes the empty string.
+- The method form (`$fmt.sprintf(...)`) is unified onto the same path: the native
+  1-arg `.sprintf` fast path defers a `Package` argument, and the slow-path
+  `sprintf` method arm now delegates to `builtin_sprintf` (the single source of
+  truth) rather than calling the pure formatter directly. A user-defined `.Str`
+  on the type object still dispatches without warning.
+
+Pin: `t/sprintf-type-object-str-context.t`.

--- a/src/builtins/functions/sprintf_fmt.rs
+++ b/src/builtins/functions/sprintf_fmt.rs
@@ -37,6 +37,17 @@ pub(crate) fn native_sprintf(args: &[Value], z_mode: bool) -> Option<Result<Valu
     } else {
         rest
     };
+    // A bare type object argument needs interpreter-aware coercion: a `%s`
+    // directive stringifies it to "" with rakudo's "uninitialized value of type
+    // X in string context" warning (matching `~Int` / `Int.Str`) instead of
+    // rendering the `(Int)` gist. Fall back to `builtin_sprintf`, which can emit
+    // the warning. (Instance args already bail in `try_native_function`.)
+    if actual_args
+        .iter()
+        .any(|a| matches!(a.view(), ValueView::Package(_)))
+    {
+        return None;
+    }
     if let Err(e) = runtime::sprintf::validate_sprintf_directives(&fmt, actual_args.len()) {
         return Some(Err(e));
     }

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -1028,7 +1028,13 @@ pub(crate) fn native_method_1arg(
             }
         }
         "sprintf" => {
-            // Method form: '%f'.sprintf(value) — target is the format string
+            // Method form: '%f'.sprintf(value) — target is the format string.
+            // A bare type object arg needs the interpreter-aware warning path
+            // (`%s` warns and stringifies to ""), so defer to the slow-path
+            // `sprintf` arm which routes through `builtin_sprintf`.
+            if matches!(arg.view(), ValueView::Package(_)) {
+                return None;
+            }
             let fmt = target.to_string_value();
             let rendered = runtime::format_sprintf(&fmt, Some(arg));
             Some(Ok(Value::str(rendered)))

--- a/src/runtime/builtins_string.rs
+++ b/src/runtime/builtins_string.rs
@@ -46,10 +46,12 @@ impl Interpreter {
             let Some(arg) = actual_args.get(idx) else {
                 continue;
             };
-            let class_name = match arg.view() {
-                ValueView::Instance { class_name, .. } => Some(class_name.resolve().to_string()),
-                ValueView::Package(name) => Some(name.resolve().to_string()),
-                _ => None,
+            let (class_name, is_type_object) = match arg.view() {
+                ValueView::Instance { class_name, .. } => {
+                    (Some(class_name.resolve().to_string()), false)
+                }
+                ValueView::Package(name) => (Some(name.resolve().to_string()), true),
+                _ => (None, false),
             };
             let Some(cn) = class_name else { continue };
             let method = match spec.to_ascii_lowercase() {
@@ -59,6 +61,15 @@ impl Interpreter {
                 _ => continue,
             };
             if !self.has_user_method(&cn, method) {
+                // A bare type object rendered with `%s` stringifies to "" with
+                // rakudo's "uninitialized value of type X in string context"
+                // warning (matching `~Int` / `Int.Str`), rather than the `(Int)`
+                // gist. Numeric directives already coerce a type object to 0 in
+                // the pure formatter, so only `%s` warns/coerces here.
+                if is_type_object && method == "Str" {
+                    let coerced = self.warn_type_object_string_context(&cn, false)?;
+                    actual_args[idx] = Value::str(coerced.to_string_value());
+                }
                 continue;
             }
             let arg_clone = actual_args[idx].clone();

--- a/src/runtime/methods_dispatch_match.rs
+++ b/src/runtime/methods_dispatch_match.rs
@@ -105,19 +105,16 @@ impl Interpreter {
             }
             "sprintf" if args.is_empty() => Some(self.dispatch_sprintf(&target)),
             "sprintf" => {
-                // Method form `$format.sprintf(*@args)` == `sprintf($format, @args)`
-                // for two or more args (the 1-arg form is a native fast-path
-                // method; the 0-arg arm above is a no-directive passthrough).
-                let fmt = target.to_string_value();
-                Some(
-                    crate::runtime::sprintf::validate_sprintf_directives(&fmt, args.len())
-                        .and_then(|_| {
-                            crate::runtime::sprintf::validate_sprintf_arg_types(&fmt, &args)
-                        })
-                        .map(|_| {
-                            Value::str(crate::runtime::sprintf::format_sprintf_args(&fmt, &args))
-                        }),
-                )
+                // Method form `$format.sprintf(*@args)` == `sprintf($format, @args)`.
+                // Delegate to `builtin_sprintf` (the single source of truth) so a
+                // bare type object arg gets the same string-context warning and
+                // "" coercion as the sub form. Reached for 2+ args, and for the
+                // 1-arg type-object case the native fast-path defers here (the
+                // 0-arg arm above is a no-directive passthrough).
+                let mut full = Vec::with_capacity(args.len() + 1);
+                full.push(target.clone());
+                full.extend(args.iter().cloned());
+                Some(self.builtin_sprintf(&full, false))
             }
             "shape" if args.is_empty() => self.dispatch_shape(&target),
             "default" if args.is_empty() => Self::dispatch_default(&target),

--- a/t/sprintf-type-object-str-context.t
+++ b/t/sprintf-type-object-str-context.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+# A bare type object rendered by `%s` (string context) stringifies to the empty
+# string with rakudo's "Use of uninitialized value of type X in string context"
+# warning, instead of the `(Int)` gist. Numeric directives keep coercing a type
+# object to 0. Both the sub form `sprintf(...)` and the method form
+# `$fmt.sprintf(...)` must agree.
+
+plan 12;
+
+# --- value coercion (warnings are quieted; checked separately below) ---
+is quietly(sprintf("%s", Int)),        "",     'sub form: %s on Int -> ""';
+is quietly(sprintf("%s", Str)),        "",     'sub form: %s on Str -> ""';
+is quietly(sprintf("%s|%s", Int, 5)),  "|5",   'sub form: mixed type-object / value';
+is quietly("%s".sprintf(Int)),         "",     'method form: %s on Int -> ""';
+is quietly("%s %s".sprintf(Int, 5)),   " 5",   'method form: mixed';
+is quietly(sprintf("%-5s|", Int)),     "     |", 'width padding applies to the "" coercion';
+is quietly(sprintf("%.2s", Str)),      "",     'precision truncation of ""';
+
+# Concrete values are unaffected.
+is sprintf("%s", 42),   "42", 'concrete value still renders';
+is "%d".sprintf(42),    "42", 'method form concrete value still renders';
+
+# A class defining `.Str` dispatches even for the type object (no warning).
+class HasStr { method Str { "custom" } }
+is sprintf("%s", HasStr),  "custom", 'user .Str on a type object dispatches (sub form)';
+is "%s".sprintf(HasStr),   "custom", 'user .Str on a type object dispatches (method form)';
+
+# The string-context warning is actually emitted.
+{
+    my $warned = False;
+    my $r;
+    {
+        CONTROL { when CX::Warn { $warned = True; .resume } }
+        $r = sprintf("%s", Int);
+    }
+    ok $warned && $r eq "", 'warning is emitted for %s on a type object';
+}


### PR DESCRIPTION
## Summary

A bare type object rendered by a `%s` directive stringified to the mutsu-specific `(Int)` gist instead of raku's empty string plus the `Use of uninitialized value of type X in string context.` warning — the same behaviour `~Int` and `Int.Str` already produce.

```raku
sprintf("%s", Int)        # now: "" + warning   (was: "(Int)")
"%s".sprintf(Int)         # now: "" + warning   (was: "(Int)")
sprintf("%s|%s", Int, 5)  # now: "|5"           (was: "(Int)|5")
```

## Implementation

The pure native formatter (`format_sprintf_impl`) has no interpreter context and cannot emit warnings, so type-object args are routed through the interpreter-aware `Interpreter::builtin_sprintf`:

- `native_sprintf` (VM fast path) bails to `None` — falling back to `builtin_sprintf` — when any argument is a bare type object (`Package`), the same way it already defers `Instance`/`Junction` args.
- `builtin_sprintf`'s per-directive loop (already mapping args to directives via `sprintf_arg_specs`) now emits `warn_type_object_string_context` and substitutes `""` for a bare type object under `%s` with no user coercion method.
- The method form `$fmt.sprintf(...)` is unified onto the same path: the native 1-arg `.sprintf` fast path defers a `Package` arg, and the slow-path `sprintf` method arm delegates to `builtin_sprintf` (single source of truth).

Numeric directives (`%d` etc.) are unchanged — they already coerce a type object to `0`. A user-defined `.Str` on the type object still dispatches without warning (both call shapes).

## Tests

- New pin: `t/sprintf-type-object-str-context.t` (12 subtests).
- `make test` + existing `t/*sprintf*` / `t/*fmt*` tests pass; whitelisted `roast/6.d/S32-str/sprintf.t` and the lettered `sprintf-*` roast tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)