### PR TITLE
docs: batteries adoption policy + first slot records (TLS foundation, HTTP client)

### DIFF
--- a/BATTERIES.md
+++ b/BATTERIES.md
@@ -1,0 +1,213 @@
+# Batteries — mutsu's bundled standard library
+
+mutsu aims to be a **batteries-included Raku implementation**: install the single
+binary and you can write practical programs immediately — JSON, HTTP, templating,
+a database layer, file utilities — with **no `zef install` step and no network
+access** required. This document is the **policy** for what we bundle and how we
+decide. Each bundled library additionally has its own **selection record** under
+[`docs/batteries/`](docs/batteries/) capturing why it was chosen, what the
+alternatives were, and its license.
+
+Related: [`PLAN.md` §1 (Batteries)](PLAN.md) is the task ledger; this file is the
+standing policy those tasks implement.
+
+## 1. Adoption policy — community-first, adopt-as-is
+
+The ordering below is strict. Do not skip to a lower rung because a higher one
+looks like more work up front — the whole point is to stay aligned with the real
+Raku ecosystem rather than accreting a private dialect.
+
+1. **Adopt a community library verbatim.** The first choice for any battery is an
+   existing, actively-usable Raku module, **vendored unchanged**. We adapt mutsu
+   to the module, never the module to mutsu — exactly as we already do for the
+   bundled Zef (`vendor/zef/`, our compatibility north star).
+
+2. **If it does not run on mutsu, grow mutsu's core — not the library.** When a
+   chosen community module hits a gap (a missing builtin, an incomplete NativeCall
+   feature, a parser edge case), the fix goes into the **interpreter**, as a
+   general improvement that also helps every other real dist. We do **not** patch
+   the vendored source, and we do **not** reimplement the module to route around
+   the gap. Running the genuine upstream module *is* the compatibility win.
+
+3. **Self-implement and dual-live only as a genuine last resort.** If no community
+   library is viable even after reasonable core work — or none exists — we may
+   ship a homegrown module ("dual-lived": usable on mutsu today, and ideally
+   publishable to the ecosystem later). This rung is the exception, and every use
+   of it must be justified in the library's selection record.
+
+4. **When mutsu has influence, push improvements upstream.** The clean long-term
+   shape is not a pile of private forks. Once mutsu carries weight in the
+   ecosystem, prefer contributing enabling work back upstream over maintaining
+   mutsu-only divergences.
+
+### Consequence: prefer "make the real module run" over "make a shim"
+
+A shim that reimplements a slice of a library is tempting because it is quick, but
+it (a) diverges from the ecosystem, (b) has to be maintained forever, and (c)
+earns us none of the compatibility signal that running the real module does. When
+weighing "grow the core (rung 2)" vs. "write a shim (rung 3)", the core work is
+the **gain** even when it is larger; the shim is the **risk** (a private dialect,
+a maintenance tail). See the "gain vs. risk" framing in `CLAUDE.md`.
+
+## 2. Selection criteria
+
+When choosing among community candidates for a battery slot, weigh, in roughly
+this order:
+
+- **License compatibility** (see §4) — a hard gate. If it is not
+  redistributable under a permissive/compatible license, it cannot be bundled.
+- **Dependency weight** — prefer few or zero dependencies. A single-file,
+  zero-dependency module is dramatically easier to vendor, cache, and keep
+  working than one that drags in a large tree.
+- **Proven behaviour on mutsu** — does it load and run today, or how far is it?
+  A candidate that already `use`s cleanly beats a "better" one that needs a
+  multi-session core campaign just to load.
+- **API fit and idiom** — a clean, Raku-idiomatic public API that downstream
+  code (and other batteries) can build on.
+- **Use-case coverage** — the guiding yardstick is **"a small web blog can be
+  written with the bundle alone."** A battery earns its slot by moving that goal
+  forward.
+
+Record how these applied in the library's selection record; the alternatives you
+rejected, and *why*, are as important as the winner.
+
+## 3. Vendoring and resolution
+
+- **Vendor unchanged, with attribution.** Copy the upstream `lib/` (plus
+  `LICENSE`, `META6.json`, and `README` for attribution) verbatim, following the
+  `vendor/zef/` precedent. Exclude upstream test suites, CI config, and precomp
+  artifacts. Do not hand-edit vendored sources.
+- **Zero-config `use`.** An installed mutsu must resolve bundled modules with no
+  environment setup. The mechanism is a **built-in default module search path**
+  (a `modules/` tree shipped alongside the binary, registered in the interpreter
+  the same way `add_default_site_repo()` registers the default site repo).
+- **The bundle is the *floor*, not a ceiling — it must be the LOWEST-priority
+  source.** Explicit `-I` / `MUTSULIB` / project-local paths, **and the user's
+  `mzef`-managed site repo**, all take priority over the bundled `modules/` tree.
+  This ordering is deliberate: it is the [independent-update
+  mechanism](#6-security-updates-and-independent-updatability) — a newer
+  (e.g. security-patched) version installed with `mzef` shadows the bundled copy.
+  Bundled modules therefore keep their versioned `META6.json` so version selection
+  can prefer a newer installed candidate.
+- **Provenance.** Record the upstream URL, version, commit, and license for each
+  vendored tree (as `vendor/README.md` does for Zef).
+
+### Updating a vendored module (must be documented per library)
+
+Because a bundled module may need a **security or bug-fix update independently of
+the mutsu binary** (see [§6](#6-security-updates-and-independent-updatability)),
+**every battery's record must spell out its exact re-vendoring recipe** — a future
+maintainer must be able to bump it without reverse-engineering how it was
+imported. The recipe, kept in the library's `docs/batteries/<lib>.md`, states:
+
+1. **Upstream + pin** — the source URL and the current version/commit.
+2. **The vendor command** — the concrete copy step (an `rsync` recipe like
+   `vendor/README.md`'s for Zef), with the exact excludes (upstream `t/`, `xt/`,
+   `.github/`, precomp artifacts) and the includes to preserve (`lib/`,
+   `resources/`, `LICENSE`, `META6.json`, `README`).
+3. **Provenance bump** — update the version/commit/date in the record and the
+   [bundle index](#7-bundle-index).
+4. **Verification** — the smoke test to re-run after the bump (`use` the module +
+   a representative call), so a bad bump is caught.
+
+Vendored sources are **never hand-edited**; an update is always a clean re-vendor
+of a new upstream release. If mutsu needs a change to run the module, that change
+goes in the interpreter (rung 2), not in the vendored copy.
+
+## 4. License policy
+
+Bundling redistributes the library's source inside mutsu's distribution, so
+license compliance is mandatory, not optional.
+
+- **Only permissive / redistribution-friendly licenses may be bundled.** Artistic
+  2.0, MIT, BSD, Apache-2.0 and equivalents are fine (most of the Raku ecosystem
+  is Artistic 2.0). A copyleft or non-redistributable license disqualifies a
+  candidate from bundling — pick a differently-licensed alternative instead.
+- **Preserve the upstream license text and attribution.** Keep the upstream
+  `LICENSE` and author/`auth` metadata in the vendored tree, unmodified.
+- **Record the license** in the library's selection record and in the bundle
+  index below.
+- **mutsu's own license** must remain compatible with everything it bundles.
+
+## 5. Documentation requirement
+
+"Well-documented" is an explicit project goal, so **documentation is mandatory
+when adding a battery**. Each bundled library needs, under `docs/batteries/`:
+
+- an **overview** (what it is; that no install is needed);
+- a **selection record** — this is a hard requirement, and its rationale must be
+  **clear and self-contained**: *why this library was chosen*, **the alternatives
+  considered and the specific reason each lost**, and the license. A future reader
+  must be able to reconstruct the decision without re-doing the investigation. The
+  alternatives-and-why are as load-bearing as the winner.
+- **provenance and an update procedure** (see [§3](#3-vendoring-and-resolution)):
+  upstream URL, version, commit, and the exact re-vendoring recipe;
+- an **API reference** and **example code**.
+
+Use [`docs/batteries/http-client.md`](docs/batteries/http-client.md) as the
+template for new records.
+
+### Publish the bundle on the Pages site
+
+The bundled-library set is a headline feature ("batteries included"), so it must
+be **visible on the project's Pages site** (`wasm-demo/`, deployed by
+`.github/workflows/pages.yml`), not only in the repo:
+
+- A **Batteries page** (`wasm-demo/batteries.html`) lists every bundled library
+  with a one-line description, its license, and its status.
+- It is reachable from the site navigation — add an entry to the `NAV` array in
+  [`wasm-demo/assets/i18n.js`](wasm-demo/assets/i18n.js) (with an `i18n` label key)
+  and give it an active-page state, exactly like the existing pages.
+- **Each entry links to its `docs/batteries/<lib>.md` record** so the full
+  documentation is reachable from the site. `docs/batteries/*.md` stays the single
+  source of truth (linked as GitHub-rendered markdown); do not fork the prose into
+  the HTML page — the page carries only the list + summaries + links.
+- Note the deploy trigger: `pages.yml` only republishes on `wasm-demo/**` changes
+  (or manual `workflow_dispatch`). A `docs/batteries/` edit alone will not
+  redeploy the site, and that is fine because the page links out to GitHub rather
+  than embedding the docs. Publish real rows only when the battery actually works
+  — do not advertise a not-yet-functional library on the public site.
+
+## 6. Security updates and independent updatability
+
+A bundled library **must be updatable independently of the mutsu binary** when a
+security patch lands — users must not have to wait for a new mutsu release to get
+a fixed dependency. This is a hard requirement (it is why the bundle is the
+lowest-priority source, above). Updates come at two layers:
+
+- **Native system libraries ride the OS.** For batteries that bind a system
+  library via NativeCall (e.g. `OpenSSL` → system `libssl`/`libcrypto`), the
+  security-critical native code is **not shipped by us** — mutsu `dlopen`s the
+  host's library, so its CVEs are patched by the OS package manager
+  (`apt upgrade libssl3`, etc.) on its own cadence, independent of mutsu. This is
+  a deliberate advantage of binding the system library over statically linking a
+  vendored implementation (which would pin the code to our binary and force a
+  mutsu re-release for every upstream CVE).
+- **Bundled Raku modules are overridable via `mzef`.** The vendored `modules/`
+  tree is only the *floor*. A patched module version installed with
+  `mzef install <Module>` lands in the higher-priority site repo and **shadows the
+  bundled copy** by version selection — no mutsu release required. Re-vendoring the
+  patched version into the tree (for the next release, so fresh installs get it too)
+  is a separate, isolated operation per the [vendoring policy](#3-vendoring-and-resolution):
+  update one module + its provenance record, never the interpreter core.
+
+Document, in each battery's record, which layer(s) its updates come through.
+
+## 7. Bundle index
+
+Legend: **Adopted** = community module vendored as-is · **Dual-lived** = homegrown
+(last resort) · **Native** = provided by the interpreter core.
+
+Build order is **bottom-up**: the TLS foundation is the active first target, then
+the HTTP client on top of it.
+
+| Battery | Provider | Kind | License | Status | Record |
+| --- | --- | --- | --- | --- | --- |
+| TLS / HTTPS socket (foundation) | `OpenSSL` + `IO::Socket::SSL` | Adopted | MIT / MIT | **Active first target** — NativeCall campaign (`%?RESOURCES`, `is native(&lib)`, CStruct, buffer round-trips) | [tls-openssl.md](docs/batteries/tls-openssl.md) |
+| HTTP client | `HTTP::UserAgent` (`zef:sergot`), leaning; `HTTP::Tiny` alt. | Adopted | MIT / Artistic-2.0 | Planned — sequenced after the TLS foundation | [http-client.md](docs/batteries/http-client.md) |
+| JSON | native `to-json` / `from-json` | Native | — | Working | — |
+
+Other modules with a proven working record (Template::Mustache, File::Temp,
+File::Directory::Tree, HTTP::Parser, MIME::Base64, HTTP::Server::Tiny,
+NativeCall MVP, the Zef CLI) are tracked in `PLAN.md` §1 and are folded into this
+index as their bundling + documentation is finalized.

--- a/docs/batteries/http-client.md
+++ b/docs/batteries/http-client.md
@@ -1,0 +1,117 @@
+# Battery: HTTP client
+
+**Slot:** HTTP client · **Chosen (leaning):** `HTTP::UserAgent`
+(`auth<zef:sergot>`, v1.2.0, MIT) · **Kind:** Adopted (community module, vendored
+as-is) · **Sequenced after** the [TLS / HTTPS foundation](tls-openssl.md) ·
+**Alternatives:** `HTTP::Tiny`, `Cro::HTTP::Client`, homegrown curl client
+
+This record is the **template** for battery selection records (rationale +
+alternatives + license). The client slot's decision is coupled to the TLS
+decision, so read [tls-openssl.md](tls-openssl.md) alongside it.
+
+## Decision and sequencing
+
+The guiding yardstick is **"a small web blog can be written with the bundle
+alone."** For that, the client needs real HTTPS, which every pure-Raku client
+delegates to `IO::Socket::SSL` → `OpenSSL`. So the client slot is **built bottom-up**:
+
+1. **TLS foundation first** — bundle `OpenSSL` + `IO::Socket::SSL` and grow mutsu's
+   NativeCall to run them ([tls-openssl.md](tls-openssl.md)). This is the active
+   first target.
+2. **Then the client** — adopt the mature **`HTTP::UserAgent`**.
+
+**Why `HTTP::UserAgent` over the lighter `HTTP::Tiny`:** the usual argument for
+`HTTP::Tiny` is its zero dependencies. But **once we commit to bundling the TLS
+stack, dependency-weight stops being the deciding axis** — `HTTP::UserAgent`'s
+extra dependencies are all pure-Raku (`HTTP::Status`, `URI`, `Encode`,
+`DateTime::Parse`, plus already-working `File::Temp` / `MIME::Base64`), i.e. the
+"grow-the-core" surface we want to exercise anyway. In exchange we get the
+**classic, full-featured de-facto client** (cookies, sessions, the `HTTP::Message`
+object family) that makes the blog use-case ergonomic. (User decision, 2026-07-24.)
+
+**`HTTP::Tiny` is kept as a documented alternative / possible early win** — it is
+zero-dep, verified to load on mutsu today, and lazily `require`s TLS, so it *could*
+land an `http://`-only battery before the TLS foundation is ready if we want an
+earlier milestone. It is not the primary choice.
+
+## Candidates
+
+The Raku ecosystem has **no single crowned HTTP client** (unlike Python's
+`requests`); the field splits three ways, plus a homegrown option.
+
+### ✅ `HTTP::UserAgent` (`zef:sergot`, v1.2.0, MIT) — chosen
+
+- **What it is:** the long-standing, mature general-purpose blocking client,
+  loosely modeled on Perl's `LWP::UserAgent`. Rich feature set (cookies, sessions,
+  redirects, the `HTTP::Message` family).
+- **Dependencies:** `HTTP::Status`, `DateTime::Parse`, `Encode`, `URI`,
+  `File::Temp`, `MIME::Base64`, and `IO::Socket::SSL` (→ `OpenSSL`). All
+  permissive; the non-TLS ones are pure Raku.
+- **Load timing caveat:** it declares `IO::Socket::SSL` as a hard dependency, so —
+  unlike `HTTP::Tiny`'s lazy `require` — the first client battery is effectively
+  **gated on the TLS foundation landing** (verify whether its `http://` path can
+  run with `IO::Socket::SSL` merely installed-but-unused). This is the accepted
+  cost of choosing it; it is why TLS is sequenced first.
+- **License:** MIT.
+
+### `HTTP::Tiny` (`zef:jjatria`, v0.2.6, Artistic-2.0) — alternative / early win
+
+- **What it is:** "a small, simple, correct HTTP/1.1 client," a Raku port of Perl's
+  `HTTP::Tiny`. Response is a hash: `<success>/<status>/<reason>/<content>/<headers>`.
+- **Strengths:** `"depends": []` (**zero** deps, single file `lib/HTTP/Tiny.rakumod`),
+  and it **loads + constructs on mutsu today** (`use HTTP::Tiny; HTTP::Tiny.new`
+  works; `.^name` resolves). HTTPS is a lazy `try require ::('IO::Socket::SSL')`, so
+  `http://` works without the TLS stack present.
+- **Why not primary:** its one advantage (zero deps) is neutralized once we bundle
+  the TLS stack for `HTTP::UserAgent` anyway, and it is more minimal (no cookie jar,
+  no `HTTP::Message` family). Retained as the fallback / earlier-milestone option.
+- **Known mutsu gap (if used):** a real request currently fails with
+  `Unknown function: split-url` (surfaced as HTTP status 599). `split-url` is a
+  lexical `sub` in the `HTTP::Tiny` class body (`lib/HTTP/Tiny.rakumod:380`) called
+  from private `method !request`. Reduced repros (class-body lexical sub via
+  `proto`/`multi`/private method, inside `CATCH`, from a forward-declared nested
+  class, through a redispatch chain) **all pass individually**, so it is an
+  interaction bug specific to the full module needing dedicated isolation — a
+  general lexical-scope/dispatch fix, not an `HTTP::Tiny` hack.
+- **License:** Artistic-2.0.
+
+### `Cro::HTTP::Client` (`zef:cro`) — rejected
+
+Part of **Cro**, the prominent modern Raku stack for reactive/async network
+services (HTTP client + server, WebSockets, TLS, routing) on the
+`supply`/`react`/`whenever` model. Rejected as a first battery: async-first, pulls
+in the whole Cro stack, and its TLS relies on `IO::Socket::Async::SSL` (async +
+OpenSSL) which mutsu has no foundation for. Overkill for "make one request."
+
+### Homegrown curl-shellout client — rejected
+
+A mutsu-specific client driving system `curl` via `Proc::Async` (the pattern the
+bundled Zef uses to fetch). Rejected: it is a **rung-3 last resort** (private
+reimplementation) the policy avoids when a community option is viable, and it is an
+**architectural mismatch** — `HTTP::UserAgent` / `HTTP::Tiny` speak HTTP/1.1
+themselves over a *socket* abstraction, whereas `curl` speaks the whole protocol,
+so `curl` cannot be slotted in as the socket/TLS backend those clients drive.
+
+## TLS / HTTPS
+
+Delegated to the shared foundation — see **[tls-openssl.md](tls-openssl.md)** for
+the full analysis: why `IO::Socket::SSL` → `OpenSSL` is the common layer, the
+concrete NativeCall gaps mutsu must grow to run it, the packaging impact
+(`libssl3` in the Docker runtime stage), and the security-update story
+(TLS CVEs ride the OS).
+
+## Security updates
+
+Per [BATTERIES.md §6](../../BATTERIES.md#6-security-updates-and-independent-updatability):
+the bundled client is the lowest-priority source, so a patched version installed
+with `mzef install HTTP::UserAgent` shadows the bundled copy without a mutsu
+release. Its TLS security rides the system `libssl` (see tls-openssl.md).
+
+## License
+
+- **`HTTP::UserAgent`** — MIT. Upstream: <https://github.com/raku-community-modules/HTTP-UserAgent>.
+- **`HTTP::Tiny`** (alternative) — Artistic-2.0. Upstream:
+  <https://gitlab.com/jjatria/http-tiny>, author José Joaquín Atria.
+- Whichever is bundled is vendored verbatim with its `LICENSE` / `META6.json` /
+  `README` preserved for attribution; source unmodified (per
+  [BATTERIES.md §4](../../BATTERIES.md#4-license-policy)).

--- a/docs/batteries/tls-openssl.md
+++ b/docs/batteries/tls-openssl.md
@@ -1,0 +1,146 @@
+# Battery: TLS / HTTPS socket — `OpenSSL` + `IO::Socket::SSL`
+
+**Slot:** TLS / HTTPS socket (foundation) · **Providers:** `OpenSSL`
+(`auth<zef:raku-community-modules>`, v0.2.7) + `IO::Socket::SSL`
+(`auth<raku-community-modules>`, v0.0.4) · **Kind:** Adopted (community modules,
+vendored as-is) · **License:** MIT / MIT
+
+This is the **first active battery target** and, by design, a **NativeCall
+campaign** rather than a quick win. It is the foundation the whole pure-Raku HTTP
+stack stands on, so it is sequenced first.
+
+## Why this is first
+
+The chosen HTTP client direction is the mature **`HTTP::UserAgent`** (see
+[http-client.md](http-client.md)), which **hard-depends** on `IO::Socket::SSL`.
+And every pure-Raku HTTP client (`HTTP::UserAgent` and `HTTP::Tiny` alike)
+delegates HTTPS to `IO::Socket::SSL` → the `OpenSSL` binding. So `OpenSSL` is the
+critical-path foundation: nothing above it (HTTPS for any client, plus the OpenSSL
+digest/crypto modules) works until it runs on mutsu. We build up from the bottom.
+
+Growing mutsu's NativeCall to run the genuine `OpenSSL` binding is **aligned
+investment we want regardless** — NativeCall is a first-class subsystem we intend
+to build out, not a subsystem we are reluctantly touching for TLS. (User decision,
+2026-07-24.)
+
+## Dependency + license facts
+
+```
+IO::Socket::SSL v0.0.4  (MIT)
+└─ OpenSSL v0.2.7        (MIT, zero Raku deps; native dep on system libssl/libcrypto)
+```
+
+Both MIT — clears the [license gate](../../BATTERIES.md#4-license-policy). `OpenSSL`
+provides 19 modules (`OpenSSL::SSL`, `::Ctx`, `::Bio`, `::X509`, `::EVP`, digests,
+RSA, …); the HTTPS path needs the SSL/Ctx/Bio/Method/Err/X509 subset.
+
+## What mutsu must grow to run the real `OpenSSL` binding
+
+Measured against the vendored `OpenSSL` 0.2.7 source. This is the concrete gap
+list — the campaign's work items, roughly in load order:
+
+1. **`%?RESOURCES` + resource JSON (first blocker).** `use OpenSSL::SSL` fails at
+   `CHECK` today: `OpenSSL::NativeLib` does
+   `BEGIN Rakudo::Internals::JSON.from-json: %?RESOURCES<libraries.json>.slurp` to
+   learn the platform library names. Needs `%?RESOURCES<...>` resolving a dist
+   resource, `Rakudo::Internals::JSON.from-json`, and `$*VM.platform-library-name`
+   (which turns `ssl`/`crypto` into `libssl.so.3` / `libcrypto.so.3` on Linux).
+2. **`is native(&lib)`** — the native library name is supplied dynamically by
+   *calling a Raku sub at bind time* (`is native(&ssl-lib)`), not a string
+   literal. mutsu's `is native` must accept a code-block argument.
+3. **`is repr('CStruct')` structs — 14 of them** (SSL, SSL_CTX, BIO, X509, EVP,
+   Cipher, Session, Stack, Method, …). Simple integer-field CStructs already
+   construct on mutsu; the remaining work is the nested / pointer-carrying structs
+   that get passed to and returned from native calls (PLAN.md §1 B4 ② NativeCall
+   remainder).
+4. **CArray / buffer round-trips** for `SSL_read` / `SSL_write` (read into a
+   caller-provided byte buffer; write a `Blob`), including a *returned* pointer
+   reified back to a Raku buffer.
+5. **Handshake control flow** — `SSL_new` / `SSL_set_fd` / `SSL_connect` /
+   `SSL_get_error` retry loop over a connected `IO::Socket::INET` fd, then
+   `IO::Socket::SSL`'s Raku layer on top.
+
+Callbacks (verify callbacks) are **not** required for a basic TLS client, so the
+NativeCall callback gap (B4 ③) is out of scope for the first HTTPS milestone.
+
+## Packaging impact (must land with this track)
+
+`OpenSSL` `dlopen`s the **system** OpenSSL at runtime (it resolves
+`libssl.so.3` / `libcrypto.so.3` via `$*VM.platform-library-name`), so bundling it
+adds a runtime packaging requirement that must land **in the same PR as this
+track**:
+
+- **`Dockerfile`**: add `libssl3` to the runtime-stage `apt-get install`
+  (`ca-certificates` is already present). Builder stage unchanged.
+- **Release tarball**: document "system libssl required for HTTPS" (present by
+  default on Linux/macOS).
+
+## Security updates
+
+This slot is the strongest case for the batteries
+[independent-update policy](../../BATTERIES.md#6-security-updates-and-independent-updatability),
+and it retroactively justifies binding the system OpenSSL over statically linking
+a vendored TLS implementation:
+
+- **The TLS crypto itself (`libssl`/`libcrypto`) rides the OS.** mutsu `dlopen`s
+  the host library, so TLS CVEs are patched by the OS package manager
+  (`apt upgrade libssl3`) **without any mutsu release**. A statically-linked TLS
+  stack would have forced a full mutsu rebuild + redistribution for every OpenSSL
+  CVE — unacceptable for the most security-critical dependency.
+- **The Raku bindings (`OpenSSL`, `IO::Socket::SSL`) override via `mzef`.** A
+  patched binding version installed with `mzef install` shadows the bundled copy
+  (the bundle is the lowest-priority source), so users are never blocked on our
+  release cadence for a binding-level fix either.
+
+## First implementation slice
+
+A bounded first PR that de-risks the campaign:
+
+1. Vendor `OpenSSL` (+ its `resources/`, `LICENSE`, `META6.json`) into the bundled
+   `modules/` tree per the [vendoring policy](../../BATTERIES.md#3-vendoring-and-resolution).
+2. Get `use OpenSSL::SSL` **past `CHECK`** — close gap (1) (`%?RESOURCES` +
+   `$*VM.platform-library-name` + `Rakudo::Internals::JSON`). Success criterion:
+   the module loads and `ssl-lib()` returns `libssl.so.3` without error.
+3. Land `t/` pins for whatever general fixes fall out (resource resolution,
+   `$*VM.platform-library-name`), then continue with gaps (2)→(5) in subsequent
+   slices, ending in an end-to-end `IO::Socket::SSL` connect + a real `https://`
+   smoke test.
+
+## Provenance and update procedure
+
+Per [BATTERIES.md §3](../../BATTERIES.md#updating-a-vendored-module-must-be-documented-per-library).
+To bump either module to a new upstream release (e.g. a security fix), re-vendor —
+do **not** hand-edit the vendored tree:
+
+| Module | Upstream | Pinned version |
+| --- | --- | --- |
+| `OpenSSL` | <https://github.com/raku-community-modules/OpenSSL> | v0.2.7 |
+| `IO::Socket::SSL` | <https://github.com/raku-community-modules/IO-Socket-SSL> | v0.0.4 |
+
+```sh
+# 1. Get the new upstream release into a checkout, then rsync it into modules/.
+#    Keep runtime files + attribution; drop upstream tests/CI/precomp.
+rsync -a --delete \
+  --exclude='.git' --exclude='.github' --exclude='t/' --exclude='xt/' \
+  --exclude='*.precomp' --exclude='.precomp/' \
+  <openssl-checkout>/ modules/OpenSSL/
+# (same for IO-Socket-SSL -> modules/IO-Socket-SSL/)
+```
+
+2. Bump the version/commit in the table above and in the
+   [bundle index](../../BATTERIES.md#7-bundle-index).
+3. **Verify:** `use OpenSSL::SSL` loads, and the `https://` smoke test
+   (`t/`) still passes.
+
+Note: a *deployed* mutsu can also take a patched binding without a re-vendor —
+`mzef install OpenSSL` / `mzef install IO::Socket::SSL` shadows the bundled copy
+(see [Security updates](#security-updates)). Re-vendoring is for the next release,
+so fresh installs ship the fix too.
+
+## License
+
+- `OpenSSL` — MIT. Upstream: <https://github.com/raku-community-modules/OpenSSL>.
+- `IO::Socket::SSL` — MIT. Upstream:
+  <https://github.com/raku-community-modules/IO-Socket-SSL>.
+- Vendored verbatim with `LICENSE` / `META6.json` / `README` preserved; sources
+  unmodified (per [BATTERIES.md §4](../../BATTERIES.md#4-license-policy)).


### PR DESCRIPTION
Establishes the standing **batteries** policy (mutsu's bundled standard library, PLAN.md §1) and the first per-library **selection records**, so library selection is deliberate, its rationale is preserved, and independent/security updates are possible. **Docs only** — no code changes.

## What this adds

- **`BATTERIES.md`** — policy + bundle index:
  - **Adoption policy** (strict order): community-first, adopt vendored modules **as-is**; when one does not run on mutsu, **grow the interpreter core** (e.g. NativeCall) to run the *real* module rather than patch/reimplement; self-implement/dual-live only as a last resort; contribute upstream long-term.
  - **Selection criteria** (license gate → dependency weight → proven-on-mutsu → API fit → the "a small blog with the bundle alone" yardstick).
  - **Vendoring + zero-config resolution**, with the bundle as the **lowest-priority** source so an `mzef`-installed newer version shadows it.
  - **Documented per-library update / re-vendor procedure** (required in every record).
  - **License policy** (permissive-only gate; preserve upstream LICENSE/attribution).
  - **Documentation requirement**: a clear, self-contained selection record per library, and **publication of the bundle list on the Pages site** (`wasm-demo/`) with each entry linking to its `docs/batteries/` record.
  - **Security / independent-update policy** (two layers): native system libs (`libssl`) ride the OS package manager; bundled Raku modules override via `mzef` — neither needs a mutsu release.

- **`docs/batteries/tls-openssl.md`** — the **first active target**: bundle `OpenSSL` + `IO::Socket::SSL` as-is and grow NativeCall to run them (the TLS foundation the HTTP client sits on). Records the concrete NativeCall gap list, packaging impact (`libssl3` in the Docker runtime stage), the security-update story, a first implementation slice, and the re-vendor recipe.

- **`docs/batteries/http-client.md`** — the HTTP client slot (sequenced after TLS), leaning **`HTTP::UserAgent`** (mature de-facto; dependency weight stops mattering once the TLS stack is bundled), with **`HTTP::Tiny`** as the verified alternative / possible early `http://` win, and Cro / homegrown-curl analyzed and rejected. Doubles as the record template.

## Sequencing captured

Bottom-up: **OpenSSL (TLS foundation) → IO::Socket::SSL → HTTP client**. Implementation follows in later PRs (the `modules/` vendoring mechanism + zero-config resolution, then the NativeCall campaign to get `OpenSSL` running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)