### PR TITLE
fix: `.Str` / `.Stringy` on a bare type object warns in string context

### DIFF
--- a/news/2026-07/type-object-str-method-string-context-warning.md
+++ b/news/2026-07/type-object-str-method-string-context-warning.md
@@ -1,0 +1,29 @@
+# `.Str` / `.Stringy` on a bare type object warns in string context
+
+An explicit `Int.Str` / `Str.Stringy` call on a bare type object stringified to
+the empty string *silently*, where raku emits the `Use of uninitialized value of
+type X in string context.` warning. Prefix `~`, interpolation, `print`, and hash
+keys already warned; the explicit method form was the remaining silent path.
+
+```raku
+Int.Str       # "" + warning (was: "" silently)
+Str.Stringy   # "" + warning
+role R { }; R.Str   # "" + warning
+```
+
+## Implementation
+
+The bare type-object arm of the slow-path `Str`/`Stringy` handler
+(`methods_instance_ops.rs`) returned `Value::str("")` directly. It now routes
+through `Interpreter::warn_type_object_string_context`, the shared helper that
+raises the warning and resumes with `""`.
+
+`.Stringy`'s default implementation is `self.Str`, so a type object whose class
+defines a user `.Str` (but no `.Stringy`) stringifies through it — the handler
+delegates `.Stringy` to the user `.Str` before warning. `.Str` never falls back
+to `.Stringy`, matching raku. A user `.Str`/`.Stringy` is dispatched before
+reaching this fallback, so it never triggers the warning.
+
+`.gist` / `.raku` are unchanged (they render `(Int)` / `Int` without warning).
+
+Pin: `t/type-object-str-method-warning.t`.

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1853,7 +1853,21 @@ impl Interpreter {
                 }
             }
             "Str" | "Stringy" if args.is_empty() => match target.view() {
-                ValueView::Package(_) => Ok(Value::str(String::new())),
+                ValueView::Package(name) => {
+                    // A bare type object stringifies to "" with rakudo's
+                    // "uninitialized value of type X in string context" warning
+                    // (matching `~Int`); a user `.Str`/`.Stringy` dispatched
+                    // before reaching here. `.Stringy`'s default implementation
+                    // is `self.Str`, so `.Stringy` on a type object with only a
+                    // user `.Str` delegates to it; `.Str` never falls back to
+                    // `.Stringy`.
+                    let n = name.resolve();
+                    if method == "Stringy" && self.has_user_method(&n, "Str") {
+                        self.call_method_with_values(target.clone(), "Str", vec![])
+                    } else {
+                        self.warn_type_object_string_context(&n, false)
+                    }
+                }
                 ValueView::Instance { class_name, .. } => {
                     // When Stringy is requested but only Str is user-defined (or
                     // vice versa), delegate to the available user method so that

--- a/t/type-object-str-method-warning.t
+++ b/t/type-object-str-method-warning.t
@@ -1,0 +1,46 @@
+use v6;
+use Test;
+
+# An explicit `.Str` / `.Stringy` call on a bare type object stringifies to the
+# empty string with rakudo's "Use of uninitialized value of type X in string
+# context" warning, matching prefix `~` / interpolation (which already warn).
+# `.Stringy`'s default implementation is `self.Str`, so a type object with only a
+# user `.Str` stringifies through it; `.Str` never falls back to `.Stringy`.
+
+plan 14;
+
+# Value coercion (warnings quieted; the warning itself is checked below).
+is quietly(Int.Str),       "", 'Int.Str -> ""';
+is quietly(Str.Str),       "", 'Str.Str -> ""';
+is quietly(Numeric.Str),   "", 'Numeric.Str -> ""';
+is quietly(Int.Stringy),   "", 'Int.Stringy -> ""';
+is quietly(Str.Stringy),   "", 'Str.Stringy -> ""';
+
+role R { }
+is quietly(R.Str),         "", 'role type object .Str -> ""';
+subset S of Int;
+is quietly(S.Str),         "", 'subset type object .Str -> ""';
+
+# `.gist` / `.raku` do NOT warn and keep their representation.
+is Int.gist,   "(Int)", '.gist on a type object is unchanged (no warning)';
+is Int.raku,   "Int",   '.raku on a type object is unchanged (no warning)';
+
+# A user `.Str` / `.Stringy` dispatches (no warning).
+class A { method Str { "AA" } }
+is A.Str,      "AA", 'user .Str on a type object dispatches';
+is A.Stringy,  "AA", 'user-.Str type object stringifies through default .Stringy';
+
+# A defined value is unaffected.
+is "hi".Str,   "hi", 'defined Str value .Str is unaffected';
+is 42.Str,     "42", 'defined Int value .Str is unaffected';
+
+# The warning is actually emitted.
+{
+    my $warned = False;
+    my $r;
+    {
+        CONTROL { when CX::Warn { $warned = True; .resume } }
+        $r = Int.Str;
+    }
+    ok $warned && $r eq "", 'Int.Str emits the string-context warning';
+}


### PR DESCRIPTION
## Summary

An explicit `.Str` / `.Stringy` call on a bare type object stringified to `""` *silently*, where raku emits the `Use of uninitialized value of type X in string context.` warning. Prefix `~`, interpolation, `print`, and hash keys already warned (via earlier fixes); the explicit method form was the last silent path.

```raku
Int.Str              # "" + warning   (was: "" silently)
Str.Stringy          # "" + warning
role R { }; R.Str    # "" + warning
```

## Implementation

The bare type-object arm of the slow-path `Str`/`Stringy` handler (`methods_instance_ops.rs`) returned `Value::str("")` directly. It now routes through `Interpreter::warn_type_object_string_context` — the shared helper (already used by `~`, interpolation, `print`, hash keys) that raises the warning and resumes with `""`.

`.Stringy`'s default implementation is `self.Str`, so a type object whose class defines a user `.Str` (but no `.Stringy`) stringifies through it — the handler delegates `.Stringy` to the user `.Str` before warning. `.Str` never falls back to `.Stringy`, matching raku. A user `.Str`/`.Stringy` is dispatched before reaching this fallback, so it never triggers the warning. `.gist` / `.raku` are unchanged (they render `(Int)` / `Int` without warning).

## Tests

- New pin: `t/type-object-str-method-warning.t` (14 subtests).
- `make test` passes; existing `t/nil-str-context-warning.t`, `t/type-object-str-context-warning.t`, `t/sprintf-user-str-dispatch.t` pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)