### PR TITLE
fix: frugal quantifiers match minimally under `:g`

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -644,7 +644,8 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   ~~IO::Path::AutoDecompress~~ (FIXED — see Done), ~~Math::Angle~~ (FIXED — see Done),
   ~~Math::PascalTriangle~~ (FIXED — see Done),
   ~~Statistics::LinearRegression~~ (FIXED — see Done), String::Rotate,
-  Text::CodeProcessing (PARTIAL — `.match`/`.subst` `&Named` arg fixed; see Done),
+  Text::CodeProcessing (PARTIAL — extraction 05/07 pass via `&Named` + frugal-`:g`
+  fixes; code-eval 02/03/04/06 deferred; see Done),
   Trait::IO, WriteOnceHash, `are`, ~~`sortuk`~~ (FIXED — see Done),
   Tree::Binary::PrettyTree (role-`new` requirement FIXED; now blocked on a
   separate `class Iterator does Iterator` name-resolution issue — see Done).
@@ -681,13 +682,18 @@ _(move tickets here with `[claim: <branch>]` when you start)_
   (`methods_string.rs`) now extract the named regex's source via
   `extract_token_regex_pattern` (the same path `$str ~~ &Named` uses) and match
   with THAT, so the returned Match carries the named regex's own captures at top
-  level. Pin: `t/match-subst-named-regex-arg.t`. **Remaining blocker (separate
-  regex-engine bug, not `&Named`-specific — reproduces with an inline `/ /` too):**
-  a frugal `.*?` followed by a `<?after \v>` look-behind and a `$<fence>`
-  back-reference (the `MarkdownSearch` code-fence body) does not match minimally
-  under `:g` — mutsu spans one match across several fences (1 match where Rakudo
-  finds 2+), so the markdown/org/pod extraction is still wrong. Needs dedicated
-  regex-engine work (frugal-quantifier + capture-back-reference interaction).
+  level. Pin: `t/match-subst-named-regex-arg.t`. **Second general bug — FIXED**
+  (PR `fix-frugal-quantifier-global-match`): a top-level frugal `.*?` (the
+  `MarkdownSearch` code-fence body) did not match minimally under `:g` — the
+  global-match path kept the *longest* end per start, forcing the frugal
+  quantifier to its greedy length, so one match spanned several fences. Fixed by a
+  canonical-per-start global match (see that PR / news). With both fixes the
+  **code-extraction** tests pass: `t/05-string-code-extraction.rakutest` 3/3 and
+  `t/07-file-code-extraction.rakutest` 3/3 (were 0). **Remaining (deferred, deep):
+  code *evaluation*** — `t/02`/`03`/`04` (markdown/org/pod processing) and `t/06`
+  (file evaluation) drive `StringCodeChunksEvaluation`, which runs each chunk in a
+  `Text::CodeProcessing::REPLSandbox` and injects the results; that REPL-eval
+  pipeline is a separate, larger feature. (`t/08` header-parameters is 2/4.)
 
 - **T-057 (IO::Path::AutoDecompress)** (PR `fix-qualified-native-ancestor-method`)
   — test_die → t/01-basic.rakutest 8/8. Root cause: a qualified method call

--- a/news/2026-07/frugal-quantifier-global-match.md
+++ b/news/2026-07/frugal-quantifier-global-match.md
@@ -1,0 +1,28 @@
+# Frugal quantifiers match minimally under `:g`
+
+A top-level frugal (lazy) quantifier — `.*?`, `.+?`, `** N..*?` — now matches
+minimally under global matching (`.match(..., :g)`), as it always did for a
+single match:
+
+```raku
+"aXbXcX".match(/ .*? 'X' /, :g).map(*.Str);   # («aX» «bX» «cX») — was one match «aXbXcX»
+"aXbXcX".match(/ $<c>=(.*?) 'X' /, :g)».<c>;   # (a b c)          — was (aXbXc)
+```
+
+mutsu's global-match path collected *every* possible match end at each start
+position and then kept the longest per start (via `select_non_overlapping_matches`),
+which is right for a greedy quantifier but forced a frugal top-level quantifier to
+its greedy length. Single (non-`:g`) matches were already correct because the
+single-match engine returns match ends in DFS-completion order, highest-priority
+(canonical greedy/frugal) first, and takes the first.
+
+The plain `:g` path now uses the same canonical choice: a new
+`regex_match_canonical_per_start` keeps only the highest-priority end at each
+start (the one the single-match engine would pick), which
+`select_non_overlapping_matches` then tiles into non-overlapping matches. The
+`:overlap` and `:exhaustive` paths still enumerate every end, and `s:g///` was
+already correct, so only plain `.match(..., :g)` changed.
+
+This unblocks the `Text::CodeProcessing` distribution's markdown/org/pod code-chunk
+extraction (T-057), whose search regex uses a frugal `.*?` code body between the
+opening and closing fences under `:g`. Pin: `t/frugal-quantifier-global-match.t`.

--- a/src/runtime/methods_match_dispatch.rs
+++ b/src/runtime/methods_match_dispatch.rs
@@ -102,14 +102,14 @@ impl Interpreter {
             }
         };
         if global || overlap || exhaustive || repeat_bounds.is_some() || nth_arg.is_some() {
-            let all = self.regex_match_all_with_captures(&pat, &text);
             let mut selected = if exhaustive {
                 // :exhaustive keeps every possible match, ordered by start
                 // position ascending and, at each position, longest first.
-                let mut all = all;
+                let mut all = self.regex_match_all_with_captures(&pat, &text);
                 all.sort_by(|a, b| a.from.cmp(&b.from).then(b.to.cmp(&a.to)));
                 all
             } else if overlap {
+                let all = self.regex_match_all_with_captures(&pat, &text);
                 let mut best_by_start: std::collections::BTreeMap<usize, RegexCaptures> =
                     std::collections::BTreeMap::new();
                 for capture in all {
@@ -123,6 +123,10 @@ impl Interpreter {
                 }
                 best_by_start.into_values().collect::<Vec<_>>()
             } else {
+                // Plain `:g` (and `:nth` / `:x`, which index into the ordered
+                // non-overlapping match list): keep the canonical greedy/frugal
+                // match at each start so a top-level `.*?` matches minimally.
+                let all = self.regex_match_canonical_per_start(&pat, &text);
                 self.select_non_overlapping_matches(all)
             };
             // Apply :nth filtering before :x bounds

--- a/src/runtime/regex/regex_match_find.rs
+++ b/src/runtime/regex/regex_match_find.rs
@@ -195,6 +195,32 @@ impl Interpreter {
         pattern: &str,
         text: &str,
     ) -> Vec<RegexCaptures> {
+        self.regex_match_captures_impl(pattern, text, false)
+    }
+
+    /// Like [`regex_match_all_with_captures`], but at each start position keeps
+    /// ONLY the highest-DFS-priority (canonical greedy/frugal) match end — the one
+    /// the single-match engine would pick — instead of every possible end. Used by
+    /// the plain `:g` path: collecting every end and then keeping the longest per
+    /// start (as `select_non_overlapping_matches` does) forces a top-level frugal
+    /// quantifier (`.*?`) to its greedy length, so `"aXbXcX".match(/.*?'X'/, :g)`
+    /// returned one match ("aXbXcX") instead of three ("aX","bX","cX"). The
+    /// `:overlap` / `:exhaustive` paths still need all ends and keep using
+    /// `regex_match_all_with_captures`.
+    pub(in crate::runtime) fn regex_match_canonical_per_start(
+        &mut self,
+        pattern: &str,
+        text: &str,
+    ) -> Vec<RegexCaptures> {
+        self.regex_match_captures_impl(pattern, text, true)
+    }
+
+    fn regex_match_captures_impl(
+        &mut self,
+        pattern: &str,
+        text: &str,
+        canonical_only: bool,
+    ) -> Vec<RegexCaptures> {
         let Some(parsed) = self.parse_regex(pattern) else {
             return Vec::new();
         };
@@ -213,18 +239,22 @@ impl Interpreter {
                 starts.extend(0..=stripped_chars.len());
             }
             for start in starts {
-                for (end, mut caps) in self.regex_match_ends_from_caps_in_pkg(
+                let ends = self.regex_match_ends_from_caps_in_pkg(
                     &stripped_parsed,
                     &stripped_chars,
                     start,
                     &pkg,
-                ) {
+                );
+                for (end, mut caps) in ends {
                     let from = map_pos(caps.capture_start.unwrap_or(start), &pos_map, orig_len);
                     let to = map_pos(caps.capture_end.unwrap_or(end), &pos_map, orig_len);
                     caps.from = from;
                     caps.to = to;
                     caps.matched = orig_chars[from..to].iter().collect();
                     out.push(caps);
+                    if canonical_only {
+                        break;
+                    }
                 }
             }
             out.sort_by_key(|caps| (caps.from, caps.to, caps.positional.len(), caps.named.len()));
@@ -239,13 +269,15 @@ impl Interpreter {
             starts.extend(0..=orig_chars.len());
         }
         for start in starts {
-            for (end, mut caps) in
-                self.regex_match_ends_from_caps_in_pkg(&parsed, &orig_chars, start, &pkg)
-            {
+            let ends = self.regex_match_ends_from_caps_in_pkg(&parsed, &orig_chars, start, &pkg);
+            for (end, mut caps) in ends {
                 caps.from = caps.capture_start.unwrap_or(start);
                 caps.to = caps.capture_end.unwrap_or(end);
                 caps.matched = orig_chars[caps.from..caps.to].iter().collect();
                 out.push(caps);
+                if canonical_only {
+                    break;
+                }
             }
         }
         out.sort_by_key(|caps| (caps.from, caps.to, caps.positional.len(), caps.named.len()));

--- a/t/frugal-quantifier-global-match.t
+++ b/t/frugal-quantifier-global-match.t
@@ -1,0 +1,42 @@
+use Test;
+
+# A top-level frugal (lazy) quantifier — `.*?`, `.+?`, `X ** N..*?` — must match
+# minimally under `:g`. mutsu's global-match path collected every possible match
+# end at each start and then kept the LONGEST, which forced a frugal top-level
+# quantifier to its greedy length: `"aXbXcX".match(/ .*? 'X' /, :g)` returned one
+# match ("aXbXcX") instead of three ("aX","bX","cX"). Single (non-`:g`) matches
+# were already correct, as were `:overlap` / `:exhaustive` and `s:g///`.
+
+plan 10;
+
+# --- .*? under :g ---
+is "aXbXcX".match(/ .*? 'X' /, :g).map(*.Str).join('|'), 'aX|bX|cX',
+    'frugal .*? matches minimally under :g';
+is "aXbXcX".match(/ .*? 'X' /, :g).elems, 3, 'frugal .*? :g count';
+
+# --- capturing frugal group under :g ---
+is "aXbXcX".match(/ $<c>=(.*?) 'X' /, :g).map({ ~$_<c> }).join('|'), 'a|b|c',
+    'captured frugal group is minimal under :g';
+
+# --- .+? under :g ---
+is "aXXbXX".match(/ 'a'? $<c>=(.+?) 'X' /, :g).map({ ~$_<c> }).join('|'), 'X|b',
+    'frugal .+? matches minimally under :g';
+
+# --- greedy .* is unchanged under :g (regression guard) ---
+is "aXbXcX".match(/ .* 'X' /, :g).map(*.Str).join('|'), 'aXbXcX',
+    'greedy .* still maximal under :g';
+
+# --- single (non-:g) frugal was already correct ---
+is ("aXbXcX" ~~ / $<c>=(.*?) 'X' /) && ~$<c>, 'a', 'frugal single match still minimal';
+
+# --- frugal with a following anchor / literal fence body ---
+{
+    my $md = "```\nAAA\n```\n```\nBBB\n```\n";
+    my @m = $md.match(/ '```' \v $<code>=(.*?) <?after \v> '```' /, :g);
+    is @m.elems, 2, 'frugal fence body: two code blocks under :g';
+    is ~@m[0]<code>, "AAA\n", 'first fence body is minimal';
+    is ~@m[1]<code>, "BBB\n", 'second fence body is minimal';
+}
+
+# --- :exhaustive still returns every end (regression guard) ---
+is "aaa".match(/ a+ /, :ex).elems, 6, ':exhaustive still enumerates all ends';


### PR DESCRIPTION
## Problem

A top-level frugal (lazy) quantifier — `.*?`, `.+?`, `** N..*?` — did not match minimally under global matching:

```raku
"aXbXcX".match(/ .*? 'X' /, :g).map(*.Str);   # mutsu: («aXbXcX»)      raku: («aX» «bX» «cX»)
"aXbXcX".match(/ $<c>=(.*?) 'X' /, :g)».<c>;   # mutsu: (aXbXc)         raku: (a b c)
```

Single (non-`:g`) matches, `:overlap` / `:exhaustive`, and `s:g///` were already correct.

## Root cause

The global-match path (`regex_match_all_with_captures`) collected **every** possible match end at each start position, and the plain-`:g` selector (`select_non_overlapping_matches`) kept the **longest** end per start. That is right for a greedy quantifier but forces a frugal top-level quantifier to its greedy length. The single-match engine, by contrast, returns match ends in DFS-completion order — canonical (greedy/frugal) first — and takes the first.

## Fix

The plain `:g` path now uses that same canonical choice via a new `regex_match_canonical_per_start`, which keeps only the highest-priority end at each start; `select_non_overlapping_matches` then tiles them into non-overlapping matches. `:overlap` / `:exhaustive` still enumerate every end, so only plain `.match(..., :g)` changed.

## Impact

Unblocks the **code-extraction** half of the `Text::CodeProcessing` distribution (T-057), whose search regex uses a frugal `.*?` fence body under `:g`: `t/05-string-code-extraction.rakutest` and `t/07-file-code-extraction.rakutest` now pass 3/3 (were 0). (The code-*evaluation* tests need a REPL-sandbox pipeline — deferred, tracked in the ledger.)

## Verification

- `make test`: Result: PASS (2376 files, 22572 tests)
- Pin: `t/frugal-quantifier-global-match.t` (10 tests; verified identical output under raku), including greedy-`:g` and `:exhaustive` regression guards
- All local regex/match/subst/grammar tests pass; no clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)