### PR TITLE
fix: sprintf numeric directives warn for a bare type object in numeric context

### DIFF
--- a/news/2026-07/sprintf-type-object-numeric-context-warning.md
+++ b/news/2026-07/sprintf-type-object-numeric-context-warning.md
@@ -1,0 +1,28 @@
+# `sprintf`'s numeric directives warn for a bare type object in numeric context
+
+A bare type object rendered by a numeric directive (`%d %i %u %b %o %x %X %c
+%e %f %g`) now emits rakudo's `Use of uninitialized value of type X in numeric
+context` warning, matching `+Int`. The rendered value is unchanged — the type
+object still coerces to `0` (`"0"`, `"0.000000"`, etc.) — this only adds the
+missing warning, completing the sprintf type-object story alongside the earlier
+`%s` string-context fix.
+
+```raku
+sprintf("%d", Int)   # "0" + numeric-context warning (was: "0" silently)
+sprintf("%f", Int)   # "0.000000" + warning
+```
+
+## Implementation
+
+A new `Interpreter::warn_type_object_numeric_context` helper mirrors the
+string-context sibling: it raises the resumable numeric warning (no
+`Methods .^name...` suffix — that is string-context only) and resumes with
+integer `0`, reconciling any captured-outer writeback from the warning handler.
+
+`builtin_sprintf`'s per-directive loop already isolated the bare-type-object /
+no-user-method case for `%s`; its numeric branch now calls the new helper. The
+pure formatter already coerces a type object to the correct numeric `0`, so the
+numeric arm only emits the warning without substituting the value. A
+user-defined `.Int` / `.Numeric` still dispatches without warning.
+
+Pin: `t/sprintf-type-object-numeric-context.t`.

--- a/src/runtime/builtins_string.rs
+++ b/src/runtime/builtins_string.rs
@@ -61,14 +61,20 @@ impl Interpreter {
                 _ => continue,
             };
             if !self.has_user_method(&cn, method) {
-                // A bare type object rendered with `%s` stringifies to "" with
-                // rakudo's "uninitialized value of type X in string context"
-                // warning (matching `~Int` / `Int.Str`), rather than the `(Int)`
-                // gist. Numeric directives already coerce a type object to 0 in
-                // the pure formatter, so only `%s` warns/coerces here.
-                if is_type_object && method == "Str" {
-                    let coerced = self.warn_type_object_string_context(&cn, false)?;
-                    actual_args[idx] = Value::str(coerced.to_string_value());
+                // A bare type object stringifies (`%s`) to "" with rakudo's
+                // "uninitialized value of type X in string context" warning
+                // (matching `~Int` / `Int.Str`), rather than the `(Int)` gist; a
+                // numeric directive coerces it to 0 with the "... in numeric
+                // context" warning (matching `+Int`). The pure formatter already
+                // renders the numeric 0, so the numeric arm only emits the
+                // warning.
+                if is_type_object {
+                    if method == "Str" {
+                        let coerced = self.warn_type_object_string_context(&cn, false)?;
+                        actual_args[idx] = Value::str(coerced.to_string_value());
+                    } else {
+                        self.warn_type_object_numeric_context(&cn)?;
+                    }
                 }
                 continue;
             }

--- a/src/runtime/io_env.rs
+++ b/src/runtime/io_env.rs
@@ -211,6 +211,23 @@ impl Interpreter {
         Ok(resumed)
     }
 
+    /// Emit rakudo's "Use of uninitialized value of type X in numeric context"
+    /// warning for a bare type object used in numeric context, and resume with
+    /// integer `0` (Rakudo's `Mu.Numeric` coercion). The numeric wording has no
+    /// `Methods .^name...` suffix (that is string-context only). Like its string
+    /// sibling, the warning handler can run user code that mutates a
+    /// captured-outer caller lexical, so its writeback is reconciled here.
+    pub(crate) fn warn_type_object_numeric_context(
+        &mut self,
+        type_name: &str,
+    ) -> Result<Value, RuntimeError> {
+        let msg = format!("Use of uninitialized value of type {type_name} in numeric context");
+        let caller_code = self.current_code;
+        let resumed = self.raise_resumable_warning(&msg, Value::int(0))?;
+        self.reconcile_caller_after_internal_dispatch(caller_code);
+        Ok(resumed)
+    }
+
     /// Coerce a value used as a plain (`Str`-keyed) hash subscript key into its
     /// string key, matching Rakudo. A bare type object stringifies to the empty
     /// string with the "uninitialized value of type X in string context"

--- a/t/sprintf-type-object-numeric-context.t
+++ b/t/sprintf-type-object-numeric-context.t
@@ -1,0 +1,38 @@
+use v6;
+use Test;
+
+# A bare type object rendered by a numeric directive (%d %i %u %b %o %x %X %c
+# %e %f %g) coerces to 0 with rakudo's "Use of uninitialized value of type X in
+# numeric context" warning (matching `+Int`), rather than the mutsu `(Int)`
+# gist. The `%s` string-context warning is covered by
+# t/sprintf-type-object-str-context.t.
+
+plan 10;
+
+# Value coercion (warnings quieted; the warning itself is checked below).
+is quietly(sprintf("%d", Int)),      "0",        '%d on Int -> 0';
+is quietly(sprintf("%f", Int)),      "0.000000", '%f on Int -> 0.000000';
+is quietly(sprintf("%x", Str)),      "0",        '%x on Str -> 0';
+is quietly(sprintf("%e", Int)),      "0.000000e+00", '%e on Int -> exponent form';
+is quietly(sprintf("%d|%d", Int, 5)),"0|5",      'mixed type-object / value';
+
+# Concrete values are unaffected (and do NOT warn).
+is sprintf("%d", 42),   "42", 'concrete Int still renders';
+
+# A user `.Int` dispatches even for the type object (no warning).
+class C { method Int { 7 } }
+is sprintf("%d", C),  "7", 'user .Int on a type object dispatches (no warning)';
+
+# The numeric-context warning is actually emitted, with the right wording
+# (no "Methods .^name..." suffix — that is string-context only).
+{
+    my @warnings;
+    my $r;
+    {
+        CONTROL { when CX::Warn { @warnings.push(.message); .resume } }
+        $r = sprintf("%d", Int);
+    }
+    is $r, "0", 'resumes with 0';
+    ok @warnings.grep(*.contains("numeric context")), 'numeric-context warning emitted';
+    nok @warnings.grep(*.contains("Methods .^name")), 'no string-context Methods suffix';
+}


### PR DESCRIPTION
## Summary

A bare type object rendered by a numeric directive (`%d %i %u %b %o %x %X %c %e %f %g`) coerced to `0` *silently*, where raku emits the `Use of uninitialized value of type X in numeric context` warning (matching `+Int`). The rendered value is unchanged — the type object still coerces to `0` (`"0"`, `"0.000000"`, …) — this only adds the missing warning, completing the sprintf type-object story alongside the earlier `%s` string-context fix (#5336).

```raku
sprintf("%d", Int)   # "0" + numeric-context warning   (was: "0" silently)
sprintf("%f", Int)   # "0.000000" + warning
```

## Implementation

A new `Interpreter::warn_type_object_numeric_context` helper mirrors the string-context sibling: it raises the resumable numeric warning (no `Methods .^name...` suffix — that is string-context only) and resumes with integer `0`, reconciling any captured-outer writeback from the warning handler.

`builtin_sprintf`'s per-directive loop already isolated the bare-type-object / no-user-method case for `%s`; its numeric branch now calls the new helper. The pure formatter already coerces the type object to the correct numeric `0`, so the numeric arm only emits the warning without substituting the value. A user-defined `.Int` / `.Numeric` still dispatches without warning.

## Tests

- New pin: `t/sprintf-type-object-numeric-context.t` (10 subtests).
- `make test` passes; existing `t/sprintf-type-object-str-context.t`, `t/native-sprintf.t`, `t/sprintf-numeric-coerce.t`, `t/sprintf-user-str-dispatch.t` pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)