### PR TITLE
docs: record proto-token LTM literal-vs-charclass tie-break bug (File::Ignore globstar)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1429,6 +1429,51 @@ garbage until the page rebuilds the interpreter.
   recorded native output rather than a trap. Removing those flags is the acceptance test
   for this item; `wasm-demo/e2e.test.mjs` sweeps every non-flagged lesson in a real browser.
 
+### 8.20 Proto-token LTM ignores literal-vs-charclass specificity on an equal-length tie (found 2026-07-24, File::Ignore)
+
+When a `proto token` has two `:sym<>` candidates that match the SAME length at a
+position, Rakudo's Longest-Token-Matching breaks the tie by declaration order /
+specificity (a literal `<sym>` candidate outranks a character-class one). mutsu
+picks the wrong candidate, so a globstar `**` in a `.gitignore`-style grammar is
+dispatched to the fall-through `matcher` candidate instead of the dedicated `**`
+candidate.
+
+- **Minimal repro** (both candidates match `**`, 2 chars):
+  ```raku
+  grammar G {
+      token TOP { <pp>+ % '/' }
+      proto token pp {*}
+      token pp:sym<**> { <sym> }        # literal, declared first
+      token pp:sym<m>  { <-[/]>+ }      # char-class fall-through
+  }
+  class Act {
+      method TOP($/) { make $<pp>.map(*.ast).join('|') }
+      method pp:sym<**>($/) { make 'GLOBSTAR' }
+      method pp:sym<m>($/)  { make "M:$/" }
+  }
+  say G.parse('d/**', :actions(Act)).ast;
+  # raku:  M:d|GLOBSTAR      mutsu: M:d|M:**   (dispatched to the wrong sym)
+  ```
+- **Confirmed:** a SOLE `pp:sym<**>` candidate matches `**` fine (so `<sym>`
+  literal escaping is correct); the bug is purely the multi-candidate tie-break.
+  raku's tie-break is declaration order — swapping the two `token` lines makes
+  raku pick `m` too; mutsu picks `m` regardless of order.
+- **Code paths ruled out during triage:** the tie-break is NOT in
+  `regex_match_public.rs` `parse_anchored_single_subrule` LTM loop (never entered
+  for a `<pp>` inside `<pp>+ % '/'`) nor the `regex_match_capture.rs:453`
+  "keep-longest inner_end / first-on-tie" subrule loop (a `MUTSU_DBG_LTM` probe in
+  both produced zero output for this grammar). The live path is a third
+  proto-token dispatch — likely via `regex_match_ends_from_caps_in_pkg` /
+  `regex_token_method.rs` (or wherever `parsed_subrule_candidates` for a proto is
+  actually consumed). Find that path first; the fix is to break an equal-length
+  tie by candidate declaration order (and/or literal-over-charclass specificity),
+  matching Rakudo. Validate against the whole `S05-grammar/` roast set — this is
+  load-bearing for every proto-token grammar.
+- **Impact:** unblocks the `File::Ignore` distribution's `**` globstar patterns
+  (T-057): `wildcard.rakutest` 36/44 → (expected) full, plus `negated`/`range`
+  partials that also stem from globstar. `path`/`charclass`/`literal` already pass.
+  Also a general grammar-correctness fix.
+
 
 ## Metrics
 

--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -1019,7 +1019,17 @@ _(move tickets here with `[claim: <branch>]` when you start)_
   Residual File::Ignore failures are separate gitignore-pattern-semantics bugs
   (negated-rule precedence, directory-only `dir*/`, globstar `a/**/b`, charclass
   ranges in negated.t/range.t/wildcard.t, and `walk`) — each its own root cause,
-  deferred.
+  deferred. **Triaged 2026-07-24 — most residuals share ONE root cause:** the
+  globstar `**` (and the `dir*/`-ignores-a-file / `a/**/b` failures) is a
+  **proto-token LTM tie-break bug** — mutsu dispatches `**` to the fall-through
+  `path-part:sym<matcher>` (char-class) instead of the dedicated
+  `path-part:sym<**>` when both match the same length. Minimal repro, ruled-out
+  code paths, and the fix direction are in **PLAN.md §8.20** (a general grammar
+  bug, load-bearing for every proto-token grammar — validate against all of
+  `S05-grammar/`). `directory-only` logic itself is correct in isolation; it only
+  looks wrong because `d/**` mis-dispatches and matches `dir21`. Separate: a
+  `<sym>` auto-capture is not recorded on a multi-candidate proto match (the
+  action doesn't read it, so it doesn't affect File::Ignore).
 
 - **T-057 (SortUk)** (PR `fix-array-is-copy-list-arg`) — test_die → t/01-basic.t
   4/4 (00-meta.t needs the uninstalled `Test::META` dep, same as raku). One general


### PR DESCRIPTION
## What

Records a precisely root-caused grammar bug found while triaging the `File::Ignore` distribution (T-057). Docs-only (PLAN.md §8.20 + TICKETS.md), no code change — default patch bump, no label.

## The bug

When a `proto token` has two `:sym<>` candidates that match the **same length** at a position, Rakudo breaks the tie by declaration order / specificity (a literal `<sym>` candidate outranks a char-class one). mutsu picks the wrong one:

```raku
grammar G {
    token TOP { <pp>+ % '/' }
    proto token pp {*}
    token pp:sym<**> { <sym> }      # literal, declared first
    token pp:sym<m>  { <-[/]>+ }    # char-class fall-through
}
# G.parse('d/**', :actions(Act)).ast
#   raku:  M:d|GLOBSTAR     mutsu: M:d|M:**   (dispatched to the wrong sym)
```

So a gitignore globstar `**` is dispatched to the fall-through `matcher` candidate instead of the dedicated `**` candidate.

## Why record instead of fix now

This is a grammar-engine LTM change that is load-bearing for every proto-token grammar (must be validated against the whole `S05-grammar/` roast set). During triage I ruled out two candidate dispatch paths (`regex_match_public.rs` single-anchored-subrule LTM and `regex_match_capture.rs:453` — a `MUTSU_DBG_LTM` probe produced zero output in both), so the live path is a third proto-token dispatch. §8.20 captures the minimal repro, the ruled-out paths, and the fix direction so a future focused session can implement it safely.

## Impact when fixed

Unblocks `File::Ignore` globstar patterns (T-057) — `wildcard.rakutest` 36/44 plus `negated`/`range` partials that stem from the same `**` mis-dispatch. A general grammar-correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)