### PR TITLE
fix: Pair.new value argument aliases the source scalar's container (PLAN 8.16 [7])

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1261,18 +1261,12 @@ also fixes the parens ambiguity — `return (1 and 2)` (a complete term = 2) vs
 - Cross-ref: the related `traps.rakudoc` list-element **container aliasing** cases. The **List**
   cases ([5]/[6]/[9]: `($a, ++$a)` / `@arr.push: ($a,$b)` reflect later mutations) were fixed
   2026-07-23 in #5290 (a List `(...)` boxes each scalar-var element into a shared `ContainerRef`;
-  the three list/hash/metaop consumers are cell-aware — see §8.16). Still open: **[7]
-  `Pair.new('a', $v)`** — a method-arg-binding container case, not List construction; defer with the
-  rest of container-repr (§8.5-adjacent), NOT this precedence bug.
-
-### 8.16 List container aliasing — residue (main campaign MERGED 2026-07-23, PR #5290)
-
-The List-holds-scalar-containers campaign landed (#5290; see [news/2026-07.md](news/2026-07.md)
-and memory `project_list_container_aliasing_campaign`). One case remains open:
-
-- [ ] **[7] `Pair.new('a', $v)`** — `Pair.new`'s method-arg binding decontainerizes, so a later
-      `$v` mutation is not reflected (raku `a => 9`, mutsu `a => 1`). Separate
-      method-arg-binding container case; coordinate with §8.5 and [ADR-0001] container-repr.
+  the three list/hash/metaop consumers are cell-aware). The last case, **[7]
+  `Pair.new('a', $v)`**, was fixed 2026-07-24 (the value argument is `WrapVarRef`-tagged and the
+  CallMethodMut exec boxes the source local into a shared cell — the fat-arrow `MakePair`
+  mechanism; pin `t/pair-new-container-alias.t`, details in `news/2026-07/`). Known shared
+  residue: a *captured outer* variable still snapshots (no local slot to box) for both `=> $var`
+  and `Pair.new` — container-repr territory ([ADR-0001]).
 
 ### 8.10 Object hashes are string-keyed, not `.WHICH`-keyed (object-hash half ✅ DONE 2026-07-24; Set/Bag/Mix element identity still open)
 

--- a/news/2026-07/pair-new-value-container-alias.md
+++ b/news/2026-07/pair-new-value-container-alias.md
@@ -1,0 +1,29 @@
+# `Pair.new($k, $v)` value aliases the source scalar's container (PLAN 8.16 [7])
+
+The last open `traps.rakudoc` container-aliasing case landed: raku's `Pair.new`
+binds its positional value parameter raw, so the built Pair's value is the
+caller's Scalar container itself — a later `$v = 9` shows through the Pair, and
+`$p.value = 7` writes through to `$v`. mutsu's method-argument compile path
+decontainerizes scalar-variable arguments, so the Pair got a snapshot
+(raku `a => 9`, mutsu `a => 1`).
+
+The fix reuses the fat-arrow `key => $var` capture mechanism end to end. The
+compiler (`compile_expr_method_on_var`) tags the value argument with
+`WrapVarRef` when the call is literally `Pair.new(<expr>, $var)` — bareword
+`Pair` receiver, method `new`, exactly two positional args, plain scalar-var
+value. The `CallMethodMut` exec then checks the *runtime* receiver: if it is
+the native `Pair` type object (and `new` is not user-overridden), the source
+local is boxed into a shared `ContainerRef` cell via `capture_var_cell` — the
+same call `MakePair` performs; any other receiver (a shadowing user class, a
+rebound name) unwraps the tag to the plain value, byte-identical to an
+untagged compile.
+
+Scope matches raku exactly: only the 2-positional form aliases. The named form
+(`Pair.new(key => "a", value => $x)`), the key argument, and `.freeze` all
+decontainerize, and `.value.VAR.^name` reports `Scalar`. Pin:
+`t/pair-new-container-alias.t` (verified 8/8 under the reference raku too).
+
+Known shared residue (pre-existing, fat-arrow behaves identically): a
+*captured outer* variable read through a closure env has no local slot to box,
+so `sub f() { Pair.new("a", $o) }` still snapshots where raku aliases. That is
+container-repr territory (ADR-0001), tracked with the §8.13 cross-ref note.

--- a/src/compiler/expr_method.rs
+++ b/src/compiler/expr_method.rs
@@ -131,8 +131,29 @@ impl Compiler {
         let arity = args.len() as u32;
         let arg_sources_idx = self.add_arg_sources_constant(args);
         let esc = Self::method_escapes_closure_args(&name.resolve());
-        for arg in args {
+        // `Pair.new($k, $v)` binds its value parameter raw, so the built Pair's
+        // value aliases `$v`'s container (write-through, traps.rakudoc; only the
+        // 2-positional form — the named form and the key decontainerize). Tag the
+        // value argument with `WrapVarRef` — the same capture the fat-arrow
+        // `key => $var` path uses — and let the CallMethodMut exec box the source
+        // local into a shared cell when the receiver really is the native Pair
+        // type (any other receiver unwraps to the plain value).
+        let pair_value_capture = matches!(target, Expr::BareWord(_))
+            && target_name == "Pair"
+            && name.resolve() == "new"
+            && modifier.is_none()
+            && !quoted
+            && args.len() == 2
+            && matches!(&args[1], Expr::Var(n) if !n.contains("::"));
+        for (i, arg) in args.iter().enumerate() {
             self.compile_method_arg_with_escape(arg, esc);
+            if pair_value_capture
+                && i == 1
+                && let Expr::Var(n) = arg
+            {
+                let src_idx = self.code.add_constant(Value::str(n.clone()));
+                self.code.emit(OpCode::WrapVarRef(src_idx));
+            }
         }
         let name_idx = self.code.add_constant(Value::str(name.resolve()));
         let modifier_idx = modifier.map(|m| self.code.add_constant(Value::str(m.to_string())));

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -430,10 +430,16 @@ impl Interpreter {
         }
         let start = self.stack.len() - arity;
         let raw_args: Vec<Value> = self.stack.drain(start..).collect();
-        let args = if raw_args
-            .iter()
-            .any(|a| matches!(a.view(), ValueView::Slip(_)))
-        {
+        let mut has_slip = false;
+        let mut has_varref = false;
+        for a in &raw_args {
+            match a.view() {
+                ValueView::Slip(_) => has_slip = true,
+                ValueView::VarRef { .. } => has_varref = true,
+                _ => {}
+            }
+        }
+        let args = if has_slip {
             let preserve_empty_slip = Self::preserve_empty_slip_arg(&method);
             let mut args = Vec::new();
             for arg in raw_args {
@@ -446,6 +452,33 @@ impl Interpreter {
         let target = self.stack.pop().ok_or_else(|| {
             RuntimeError::new("Interpreter stack underflow in CallMethodMut target".to_string())
         })?;
+        // `Pair.new($k, $v)` compiles its value argument tagged with `WrapVarRef`
+        // (see `compile_expr_method_on_var`): when the receiver is the native
+        // Pair type, box the source local into a shared `ContainerRef` cell so
+        // the built Pair's value aliases `$v` (write-through, the same capture
+        // the fat-arrow `MakePair` path performs). Any other receiver (a
+        // shadowing user class, a rebound name) unwraps to the plain value —
+        // identical to an untagged compile.
+        let args = if has_varref {
+            let native_pair_new = method == "new"
+                && matches!(target.view(), ValueView::Package(cn) if cn == "Pair")
+                && !self.has_user_method("Pair", "new");
+            args.into_iter()
+                .map(|a| match a.view() {
+                    ValueView::VarRef { name, value, .. } => {
+                        let inner = value.clone();
+                        if native_pair_new {
+                            self.capture_var_cell(code, &name.resolve(), inner)
+                        } else {
+                            inner
+                        }
+                    }
+                    _ => a,
+                })
+                .collect()
+        } else {
+            args
+        };
         // `X::Foo.throw`/`.fail`/... on an Exception type object (compiled here
         // because the bareword target routes through CallMethodMut) requires a
         // concrete invocant: X::Parameter::InvalidConcreteness.

--- a/t/pair-new-container-alias.t
+++ b/t/pair-new-container-alias.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+plan 8;
+
+# traps.rakudoc: Pair.new binds its positional value parameter raw, so the
+# built Pair's value aliases the source scalar's container (write-through).
+# Only the 2-positional form aliases; the named form, the key, and a frozen
+# Pair decontainerize.
+
+my $v = 1;
+my $p = Pair.new("a", $v);
+$v = 9;
+is $p.value, 9, 'Pair.new positional value reflects later mutation of the source scalar';
+
+my $w = 1;
+my $q = Pair.new("a", $w);
+$q.value = 7;
+is $w, 7, 'assigning to .value writes through to the source scalar';
+
+my $m = 2;
+is Pair.new("b", $m).value.VAR.^name, 'Scalar', '.value is a Scalar container';
+
+my $x = 1;
+my $r = Pair.new(key => "a", value => $x);
+$x = 9;
+is $r.value, 1, 'named-form value does not alias';
+
+my $k = "x";
+my $s = Pair.new($k, 1);
+$k = "y";
+is $s.key, "x", 'key does not alias';
+
+my $u = 1;
+my $t = Pair.new("a", $u).freeze;
+$u = 9;
+is $t, 1, 'freeze decontainerizes the value';
+
+# fat-arrow parity: the same capture mechanism backs `key => $var`
+my $f = 1;
+my $fp = (a => $f);
+$f = 4;
+is $fp.value, 4, 'fat-arrow pair value aliases (parity check)';
+
+# a Pair built in a fresh block scope each iteration stays independent
+my @ps = (1..3).map({ my $n = $_; Pair.new("k", $n) });
+is-deeply @ps.map(*.value).list, (1, 2, 3), 'per-iteration Pairs keep distinct values';


### PR DESCRIPTION
## Summary

The last open `traps.rakudoc` container-aliasing case (PLAN §8.16 [7]): raku's `Pair.new` binds its positional value parameter raw, so the built Pair's value **is** the caller's Scalar container — a later `$v = 9` shows through the Pair, and `$p.value = 7` writes through to `$v`. mutsu's method-argument compile path decontainerized the argument, so the Pair got a snapshot (raku `a => 9`, mutsu `a => 1`).

## Fix

Reuses the fat-arrow `key => $var` capture mechanism end to end:

- **Compiler** (`compile_expr_method_on_var`): tag the value argument with `WrapVarRef` when the call is literally `Pair.new(<expr>, $var)` — bareword `Pair` receiver, method `new`, no modifier/quoting, exactly two positional args, plain scalar-var value.
- **VM** (`exec_call_method_mut_op_impl`): when the *runtime* receiver is the native `Pair` type object (and `new` is not user-overridden), box the source local into a shared `ContainerRef` cell via `capture_var_cell` — the same call `MakePair` performs. Any other receiver (a shadowing user class, a rebound name) unwraps the tag to the plain value, byte-identical to an untagged compile. The existing Slip scan over the drained args was extended to detect VarRef in the same single pass.

Scope matches raku exactly (verified against the reference `raku`): only the 2-positional form aliases — the named form (`Pair.new(key => "a", value => $x)`), the key argument, and `.freeze` all decontainerize, and `.value.VAR.^name` reports `Scalar`.

Known shared residue (pre-existing; fat-arrow behaves identically): a captured *outer* variable has no local slot to box, so a Pair built in a closure still snapshots where raku aliases — container-repr territory (ADR-0001), noted in the PLAN.md cross-ref.

## Testing

- New pin `t/pair-new-container-alias.t` (8 assertions; passes 8/8 under the reference raku too)
- `make test`: PASS (2380 files, 22641 tests)
- Pair-related roast files (`S02-types/pair.t`, `S02-literals/pairs.t`, `nested_pairs.t`, `pairs-as-lvalues.t`, `autopairs.t`, `pair-boolean.t`): all PASS
- `cargo fmt` / `cargo clippy -- -D warnings`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)