### PR TITLE
fix: numeric comparison of a bare numeric type object throws X::Numeric::Uninitialized

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1430,6 +1430,39 @@ garbage until the page rebuilds the interpreter.
   for this item; `wasm-demo/e2e.test.mjs` sweeps every non-flagged lesson in a real browser.
 
 
+### 8.20 Bare numeric type object in an infix *arithmetic* op should throw X::Numeric::Uninitialized (found 2026-07-24 by the numeric-context doc-diff)
+
+The comparison ops (`== != < > <= >= <=>`) now throw `X::Numeric::Uninitialized`
+for a bare concrete-numeric type object operand (`Int == 0`, `Int < 5`), matching
+Rakudo (news `2026-07/numeric-uninitialized-infix.md`). The **arithmetic** ops
+(`+ - * / % **`) should throw the same way (`Int + 1` → `X::Numeric::Uninitialized`
+in rakudo) but were left unchanged, because the fix is entangled with the
+assignment metaops:
+
+- mutsu desugars `$a += 0.1` to `GetLocal; LoadConst; Add; SetLocal` — the **same**
+  `Add` opcode as bare `$a + 0.1`. Adding the type-object check to the shared arith
+  chokepoint (`coerce_numeric_bridge_pair_strict`, `src/vm/vm_dispatch_helpers.rs`)
+  makes `my Rat $a; $a += 0.1` throw, which is wrong (roast `S32-num/rat.t` test
+  ~803, "can do += on variable initialized by type object").
+- Rakudo's `METAOP_ASSIGN` special-cases an undefined container: it uses the
+  operator's **identity element** — `0` for `+`/`-`, `1` for `*`/`**`, and a hard
+  "No zero-argument meaning for: infix:</>" for `/`/`%` — instead of calling
+  `infix:<+>(Rat:U, ...)`. mutsu currently only *accidentally* gets `+=`/`-=` right
+  (it coerces the type object to 0); `*=` already diverges (`my Int $a; $a *= 5`
+  gives 0, should give 5).
+- **Correct fix (one PR):** give the compound-assignment path its own emission that,
+  when the LHS reads as a type object, substitutes the base op's identity (and
+  errors for `/`/`%`), so the bare-infix arith ops are then free to throw
+  `X::Numeric::Uninitialized` via the same predicate the comparison ops use
+  (`check_type_object_in_numeric_context`, `src/vm/vm_comparison_ops.rs`, already
+  `pub(crate)`). This also fixes the pre-existing `*=`/`**=` identity divergence.
+- Related follow-up: prefix `+`/`-` on a type object (`+Int`) should emit the
+  resumable `CX::Warn` numeric-context warning and resume with the type's zero
+  (`+Num` → `0e0`, `+Rat` → `0.0`, ...); mutsu currently coerces to `0` silently
+  for non-`Any` type objects (`src/vm/vm_misc_coerce.rs::exec_num_coerce_op` only
+  handles `Any`). This is the numeric twin of the string-context warning campaign.
+
+
 ## Metrics
 
 | Metric | Current | Target |

--- a/news/2026-07/numeric-uninitialized-infix.md
+++ b/news/2026-07/numeric-uninitialized-infix.md
@@ -1,0 +1,41 @@
+# Numeric comparison of a bare numeric type object throws X::Numeric::Uninitialized
+
+A bare concrete-numeric type object (`Int`, `Num`, `Rat`, `FatRat`, `Real`,
+`Bool`) used as an operand of a numeric comparison operator
+(`== != < > <= >= <=>`) now throws `X::Numeric::Uninitialized`, matching Rakudo.
+
+Previously the equality/three-way ops (`==`, `!=`, `<=>`) silently coerced the
+type object to `0`, so `Int == 0` wrongly returned `True`; and the relational
+ops (`< <= > >=`) threw a bare `X::AdHoc` carrying the right message but the
+wrong exception type.
+
+The error is fatal — it is **not** suppressed by `quietly` — and carries the
+standard message (`Use of uninitialized value of type Int in numeric context`)
+plus a `.type` attribute holding the offending type object.
+
+## Implementation
+
+- `RuntimeError::numeric_uninitialized(type_name)` (`src/value/error_construct.rs`)
+  builds the typed `X::Numeric::Uninitialized` exception with `message` and
+  `type` attributes.
+- `check_type_object_in_numeric_context` (`src/vm/vm_comparison_ops.rs`) — the
+  predicate the relational ops already used — now throws this typed exception
+  instead of a bare `X::AdHoc`, and its type set was corrected to the concrete
+  numeric types that Rakudo hard-errors on (`Int Num Rat FatRat Real Bool`).
+  `Complex` and native `int`/`num` were removed: Rakudo warns-and-coerces for
+  those rather than throwing.
+- The equality ops (`==`, `!=`), the native `!=`, and the three-way `<=>` gained
+  the check at their call sites. Generic `cmp`/`before`/`after` deliberately do
+  not throw (they compare the type object as-is, matching Rakudo).
+
+## Not covered (deferred — see PLAN.md)
+
+The arithmetic operators (`+ - * / % **`) should also throw
+`X::Numeric::Uninitialized` on a bare numeric type object (`Int + 1`), but they
+were left unchanged: mutsu desugars the assignment metaop `$a += 0.1` to the
+same `Add` opcode as bare infix, and that form must keep working. Rakudo's
+`METAOP_ASSIGN` uses the operator's identity element (0 for `+`, 1 for `*`) when
+the container holds a type object, so `my Rat $a; $a += 0.1` yields `0.1`
+without throwing (roast `S32-num/rat.t`). Making the bare-infix arithmetic case
+throw requires a compiler-level distinction between the two forms plus
+`METAOP_ASSIGN` identity semantics.

--- a/src/value/error_construct.rs
+++ b/src/value/error_construct.rs
@@ -76,6 +76,28 @@ impl RuntimeError {
         err
     }
 
+    /// X::Numeric::Uninitialized — a bare numeric type object (`Int`, `Num`,
+    /// `Rat`, ...) used as an operand of an infix numeric operator (`+ - * / % **`,
+    /// `== != < > <= >= <=>`). Unlike prefix `+`/`-` (a resumable warning that
+    /// coerces to 0), Rakudo's numeric infix multis have no candidate accepting an
+    /// undefined operand of a concrete numeric type, so they throw this fatal
+    /// exception (not suppressed by `quietly`). The `type` attribute holds the
+    /// offending type object; `.message` is the standard "uninitialized value"
+    /// wording.
+    pub(crate) fn numeric_uninitialized(type_name: &str) -> Self {
+        let mut attrs = HashMap::new();
+        let msg = format!("Use of uninitialized value of type {type_name} in numeric context");
+        attrs.insert("message".to_string(), Value::str_from(&msg));
+        attrs.insert(
+            "type".to_string(),
+            Value::package(Symbol::intern(type_name)),
+        );
+        let ex = Value::make_instance(Symbol::intern("X::Numeric::Uninitialized"), attrs);
+        let mut err = Self::new(&msg);
+        err.exception = Some(Box::new(ex));
+        err
+    }
+
     /// Create a Failure value wrapping an X::Numeric::DivideByZero exception
     /// for a method call on a zero-denominator Rational (e.g. `.floor`, `.Int`).
     pub(crate) fn divide_by_zero_failure_for_method(method: &str, type_name: &str) -> Value {

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -1,21 +1,24 @@
 use super::*;
 
-/// Check if a value is a numeric type object (undefined) used in numeric context.
-/// In Raku, numeric type objects (Int, Num, Rat, etc.) throw a hard error when
-/// used in numeric comparison, even inside `quietly`. Non-numeric type objects
-/// (Any, Str, etc.) only produce a suppressible warning and coerce to 0.
-fn check_type_object_in_numeric_context(v: &Value) -> Result<(), RuntimeError> {
+/// Check if a value is a concrete numeric type object (undefined) used as an
+/// operand of an infix numeric operator. In Raku, the numeric infix multis
+/// (`+ - * / % **`, `== != < > <= >= <=>`) have no candidate accepting an
+/// undefined operand of a concrete numeric type, so they throw a fatal
+/// `X::Numeric::Uninitialized` (not suppressed by `quietly`). Non-concrete-numeric
+/// type objects (Any, Str, Cool, Numeric, Complex, ...) instead fall through to a
+/// generic candidate that warns and coerces to 0, so they must NOT be caught here.
+pub(crate) fn check_type_object_in_numeric_context(v: &Value) -> Result<(), RuntimeError> {
     if let ValueView::Package(name) = v.view() {
         let type_name = name.resolve();
+        // Rakudo hard-errors for these concrete numeric type objects. `Complex`
+        // is deliberately excluded — its infix candidates warn+coerce like the
+        // generic path (verified against rakudo).
         let is_numeric_type = matches!(
             type_name.as_ref(),
-            "Int" | "Num" | "Rat" | "FatRat" | "Complex" | "int" | "num"
+            "Int" | "Num" | "Rat" | "FatRat" | "Real" | "Bool"
         );
         if is_numeric_type {
-            return Err(RuntimeError::new(format!(
-                "Use of uninitialized value of type {} in numeric context",
-                type_name
-            )));
+            return Err(RuntimeError::numeric_uninitialized(&type_name));
         }
     }
     Ok(())
@@ -265,6 +268,8 @@ impl Interpreter {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
         let result = self.eval_binary_with_junctions(left, right, |vm, l, r| {
+            check_type_object_in_numeric_context(&l)?;
+            check_type_object_in_numeric_context(&r)?;
             let (l, r) = vm.coerce_numeric_bridge_pair(l, r)?;
             let (l, r) = (deref_allomorph_numeric(l), deref_allomorph_numeric(r));
             // NaN is unordered: NaN == anything is always False
@@ -309,6 +314,8 @@ impl Interpreter {
         // It first evaluates == (which autothreads through junctions),
         // then negates the boolean-collapsed result, always returning Bool.
         let eq_result = self.eval_binary_with_junctions(left, right, |vm, l, r| {
+            check_type_object_in_numeric_context(&l)?;
+            check_type_object_in_numeric_context(&r)?;
             let (l, r) = vm.coerce_numeric_bridge_pair(l, r)?;
             let (l, r) = (deref_allomorph_numeric(l), deref_allomorph_numeric(r));
             // NaN is unordered: NaN == anything is always False
@@ -357,6 +364,8 @@ impl Interpreter {
         }
         // Fall through to standard != logic
         let eq_result = self.eval_binary_with_junctions(left, right, |vm, l, r| {
+            check_type_object_in_numeric_context(&l)?;
+            check_type_object_in_numeric_context(&r)?;
             let (l, r) = vm.coerce_numeric_bridge_pair(l, r)?;
             if is_nan_value(&l) || is_nan_value(&r) {
                 return Ok(Value::FALSE);

--- a/src/vm/vm_comparison_order_ops.rs
+++ b/src/vm/vm_comparison_order_ops.rs
@@ -376,6 +376,10 @@ impl Interpreter {
         let right = self.stack.pop().unwrap();
         let left = self.stack.pop().unwrap();
         let result = self.eval_binary_with_junctions(left, right, |vm, l, r| {
+            // `<=>` is numeric (unlike generic `cmp`): a bare numeric type object
+            // operand throws X::Numeric::Uninitialized, matching rakudo.
+            crate::vm::vm_comparison_ops::check_type_object_in_numeric_context(&l)?;
+            crate::vm::vm_comparison_ops::check_type_object_in_numeric_context(&r)?;
             let (l, r) = vm.coerce_numeric_bridge_pair(l, r)?;
             // NaN <=> anything produces Nil (unordered)
             if is_nan_value(&l) || is_nan_value(&r) {

--- a/src/vm/vm_dispatch_helpers.rs
+++ b/src/vm/vm_dispatch_helpers.rs
@@ -272,6 +272,15 @@ impl Interpreter {
         left: Value,
         right: Value,
     ) -> Result<(Value, Value), RuntimeError> {
+        // NOTE: unlike the comparison ops, the arithmetic ops do NOT throw
+        // X::Numeric::Uninitialized on a bare numeric type object here. `Int + 1`
+        // *should* throw (rakudo), but mutsu desugars the assignment metaop
+        // `$a += 0.1` to the same `Add` opcode as bare infix, and that form must
+        // NOT throw — rakudo's METAOP_ASSIGN uses the operator's identity element
+        // (0 for `+`, 1 for `*`) when the container holds a type object. Adding the
+        // check here breaks `my Rat $a; $a += 0.1` (roast S32-num/rat.t). Fixing
+        // the bare-infix case needs a compiler-level distinction between the two
+        // forms plus METAOP_ASSIGN identity semantics — see PLAN.md.
         crate::runtime::utils::check_str_numeric(&left)?;
         crate::runtime::utils::check_str_numeric(&right)?;
         self.coerce_numeric_bridge_pair(left, right)

--- a/t/array-oob-any.t
+++ b/t/array-oob-any.t
@@ -15,11 +15,13 @@ plan 24;
     is @s[11].^name, 'Str', 'typed Array OOB is the element type';
 }
 
-# A type object coerces to "" (Str context) and 0 (numeric context).
+# A non-concrete-numeric type object coerces to "" (Str context) and 0 (numeric
+# context) with a warning. A concrete-numeric type object (Int) instead throws
+# X::Numeric::Uninitialized in a numeric infix op (fatal, matching rakudo).
 {
     ok Any eq '', 'Any eq ""';
     ok Str eq '', 'Str eq ""';
-    ok Int == 0, 'Int == 0';
+    throws-like { Int == 0 }, X::Numeric::Uninitialized, 'Int == 0 throws (concrete numeric)';
     ok Any == 0, 'Any == 0';
     my @foo;
     ok @foo[0] eq '', 'Array OOB eq ""';

--- a/t/numeric-uninitialized-infix.t
+++ b/t/numeric-uninitialized-infix.t
@@ -1,0 +1,63 @@
+use v6;
+use Test;
+
+# A bare concrete-numeric type object (Int, Num, Rat, FatRat, Real, Bool) used
+# as an operand of a numeric *comparison* operator throws
+# X::Numeric::Uninitialized, matching Rakudo. This is a fatal exception (not a
+# resumable warning, so `quietly` does not suppress it). Previously `==`/`!=`/
+# `<=>` silently coerced the type object to 0 (so `Int == 0` wrongly returned
+# True), and the relational ops threw a bare X::AdHoc instead of the typed error.
+#
+# NOTE: the arithmetic ops (`+ - * / % **`) are deliberately NOT covered here.
+# `Int + 1` should also throw in rakudo, but mutsu desugars the assignment
+# metaop `$a += 0.1` to the same `Add` opcode as bare infix, and that form must
+# keep working (METAOP_ASSIGN identity semantics). See PLAN.md.
+
+plan 24;
+
+# --- Comparison operators throw ---------------------------------------------
+throws-like { my $x = Int < 5 }, X::Numeric::Uninitialized, 'Int < 5 throws';
+throws-like { my $x = Int <= 5 }, X::Numeric::Uninitialized, 'Int <= 5 throws';
+throws-like { my $x = Int > 5 }, X::Numeric::Uninitialized, 'Int > 5 throws';
+throws-like { my $x = Int >= 5 }, X::Numeric::Uninitialized, 'Int >= 5 throws';
+throws-like { my $x = Int == 0 }, X::Numeric::Uninitialized, 'Int == 0 throws';
+throws-like { my $x = Int != 0 }, X::Numeric::Uninitialized, 'Int != 0 throws';
+throws-like { my $x = Int <=> 3 }, X::Numeric::Uninitialized, 'Int <=> 3 throws';
+throws-like { my $x = 5 > Int }, X::Numeric::Uninitialized, 'type object on the right throws';
+
+# --- Other concrete numeric types -------------------------------------------
+throws-like { my $x = Num < 1 }, X::Numeric::Uninitialized, 'Num < 1 throws';
+throws-like { my $x = Rat < 1 }, X::Numeric::Uninitialized, 'Rat < 1 throws';
+throws-like { my $x = FatRat < 1 }, X::Numeric::Uninitialized, 'FatRat < 1 throws';
+throws-like { my $x = Real < 1 }, X::Numeric::Uninitialized, 'Real < 1 throws';
+throws-like { my $x = Bool < 1 }, X::Numeric::Uninitialized, 'Bool < 1 throws';
+
+# --- Exception shape --------------------------------------------------------
+{
+    my $ex;
+    { Int == 0; CATCH { default { $ex = $_ } } }
+    isa-ok $ex, X::Numeric::Uninitialized, 'exception type is correct';
+    is $ex.message, 'Use of uninitialized value of type Int in numeric context',
+        'message matches rakudo';
+    is $ex.type.^name, 'Int', '.type is the offending type object';
+}
+
+# --- Fatal, not a resumable warning: quietly does NOT suppress it -----------
+{
+    my $reached = False;
+    { my $x = quietly (Int < 5); $reached = True; CATCH { default {} } }
+    nok $reached, 'quietly does not turn the fatal error into a resumable warning';
+}
+
+# --- Non-concrete-numeric type objects do NOT throw (warn + coerce to 0) ----
+lives-ok { my $x = quietly (Any < 5) }, 'Any < 5 does not throw';
+lives-ok { my $x = quietly (Str < 5) }, 'Str < 5 does not throw';
+lives-ok { my $x = quietly (Numeric < 5) }, 'Numeric < 5 does not throw';
+lives-ok { my $x = quietly (Complex == 0) }, 'Complex == 0 does not throw';
+
+# --- Generic ordering (cmp/before/after) compares type objects, no throw ----
+lives-ok { my $x = Int cmp 1 }, 'generic cmp does not throw on a type object';
+lives-ok { my $x = Int before 1 }, 'before does not throw on a type object';
+
+# --- Defined numeric values still compare normally --------------------------
+ok 3 < 4, 'ordinary Int comparison is unaffected';


### PR DESCRIPTION
## Summary

A bare concrete-numeric type object (`Int`, `Num`, `Rat`, `FatRat`, `Real`, `Bool`) used as an operand of a numeric **comparison** operator (`== != < > <= >= <=>`) now throws `X::Numeric::Uninitialized`, matching Rakudo.

Previously:
- `==` / `!=` / `<=>` silently coerced the type object to `0`, so `Int == 0` wrongly returned `True`.
- the relational ops (`< <= > >=`) threw a bare `X::AdHoc` carrying the right message but the wrong exception type.

The error is fatal (not suppressed by `quietly`) and carries the standard message plus a `.type` attribute holding the offending type object.

```
$ raku -e '{ Int == 0; CATCH { default { say .^name } } }'
X::Numeric::Uninitialized
```

## Changes

- `RuntimeError::numeric_uninitialized(type_name)` (`src/value/error_construct.rs`) builds the typed exception with `message` + `type` attrs.
- `check_type_object_in_numeric_context` (`src/vm/vm_comparison_ops.rs`) throws the typed exception instead of `X::AdHoc`, and its type set is corrected to what rakudo hard-errors on (`Int Num Rat FatRat Real Bool`). `Complex` and native `int`/`num` were removed — rakudo warns-and-coerces for those.
- The check was added to `==`, `!=`, native `!=`, and `<=>`. Generic `cmp`/`before`/`after` deliberately do **not** throw (they compare the type object as-is, matching rakudo).

## Deferred (PLAN.md §8.20)

The arithmetic ops (`+ - * / % **`) should also throw on a bare numeric type object (`Int + 1`), but were left unchanged: mutsu desugars the assignment metaop `$a += 0.1` to the **same** `Add` opcode as bare infix, and that form must keep working (rakudo's `METAOP_ASSIGN` uses the operator's identity element for an undefined LHS — `my Rat $a; $a += 0.1` yields `0.1`, roast `S32-num/rat.t`). Making the bare-infix arithmetic case throw needs a compiler-level distinction between the two forms plus `METAOP_ASSIGN` identity semantics.

## Tests

- New pin `t/numeric-uninitialized-infix.t` (24 subtests).
- Updated `t/array-oob-any.t` — the stale `ok Int == 0` (old wrong behavior) now expects the throw.
- `make test` green (2379 files / 22627 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)