### PR TITLE
fix: multi-dispatch named-slurpy ranking + cross-module proto invocant clobber

### DIFF
--- a/news/2026-07/multi-dispatch-named-slurpy-ranking.md
+++ b/news/2026-07/multi-dispatch-named-slurpy-ranking.md
@@ -1,0 +1,23 @@
+# Multi dispatch: a named-hash slurpy no longer loses to a bare zero-arg candidate
+
+A `multi method` that declares a named parameter plus a named-hash slurpy is
+narrower than a bare zero-arg candidate and must win dispatch. In Raku a zero-arg
+method is really `(*%_)`, so `(Bool :$b, *%a)` out-narrows it. mutsu ranked the
+bare `()` candidate as *more* specific: `method_candidate_type_distance` charged a
+flat `+2000` distance penalty to any named-hash slurpy (`*%a`), while the bare
+candidate's implicit `*%_` is not in its `param_defs` and paid nothing. So `()`
+won on raw distance and the explicit-named tie-break never ran.
+
+The concrete fallout was `HTTP::Request.new(GET => $url)` dispatching to the wrong
+`new`: the pair-collecting `multi method new(Bool :$bin, *%args)` lost to a bare
+`multi method new()`, so the URL was silently dropped and the client connected to
+`localhost`.
+
+The fix stops penalizing a *named-hash* slurpy in the type-distance sum (a
+*positional* slurpy `*@x` is still penalized, so `(@x)` keeps beating `(*@x)`). A
+named slurpy competes only over named arguments, and the existing narrowness
+tie-break already ranks it correctly: a candidate that declares an explicit named
+parameter (`(IO::Path :$file!)`) still beats a bare `(*%items)`, and `()` vs
+`(*%a)` now correctly *ties* (ambiguous), matching rakudo.
+
+Pinned by `t/multi-named-slurpy-ranking.t`.

--- a/news/2026-07/proto-cross-module-invocant-writeback.md
+++ b/news/2026-07/proto-cross-module-invocant-writeback.md
@@ -1,0 +1,36 @@
+# A cross-module proto-method call no longer clobbers the enclosing invocant
+
+A plain method that delegates to an attribute whose class declares a `proto
+method` in another compilation unit corrupted the *enclosing* invocant, turning it
+into `Any`. The minimal shape:
+
+```raku
+# module A
+class Inner { proto method field(|) {*}; multi method field($f) { ... } }
+# module B
+class Outer { has Inner $.inner; method poke($f) { $.inner.field($f) } }
+# script
+my $o = Outer.new;
+$o.poke("X");        # $o is now Any!
+```
+
+`HTTP::Message.field` delegating to `HTTP::Header.field` (a cross-module `proto
+method`) hit exactly this, so an `HTTP::UserAgent` request corrupted its own
+request object.
+
+The cause was in the slow proto-dispatch interception (`try_proto_method_body`).
+After running the proto body it diffed the env for changed scalars to propagate
+genuine caller-lexical mutations — but it treated every env key that was *new or
+newly a writeback-safe scalar* as changed (`unwrap_or(true)`). The proto run leaks
+bareword type objects (`Any`, `POuter`), magic vars, `__mutsu_*` keys, and even
+the caller's own instance variable reset to a type object into env; recording
+those as caller-var writebacks committed `Any` straight back onto the caller.
+
+The fix requires a real *pre-existing* writeback-safe scalar whose value the proto
+dispatch changed (`unwrap_or(false)`), which is the only genuine caller-lexical
+mutation, and additionally excludes the invocant (`self`) and internal `__mutsu_*`
+names. The enclosing `self` is also saved and restored across the proto dispatch.
+
+Pinned by `t/proto-cross-module-invocant.t` (needs the separate
+`t/lib/ProtoInvocant{Inner,Outer}.rakumod` units — a same-file proto compiles to
+bytecode and never takes this path).

--- a/src/runtime/dispatch_proto.rs
+++ b/src/runtime/dispatch_proto.rs
@@ -337,17 +337,53 @@ impl Interpreter {
             .filter(|(_, v)| Self::is_writeback_safe_scalar(v))
             .map(|(k, v)| (*k, v.clone()))
             .collect();
+        // The nested proto dispatch rebinds `env["self"]` to its own invocant and
+        // does not restore the enclosing method's `self` afterward (unlike the
+        // normal method-call path). When a plain method delegates to an attribute
+        // whose class declares a cross-module `proto method` (HTTP::Message.field
+        // -> HTTP::Header.field), the enclosing method's `self` is left holding the
+        // proto's invocant / a stale type object, and the method-return writeback
+        // then commits that back to the caller's variable — turning it into `Any`.
+        // Save and restore the enclosing invocant across the proto dispatch.
+        let saved_self = self.env.get("self").cloned();
         let result =
             self.run_proto_method(target.clone(), &cn, &owner, method, args.to_vec(), proto);
+        match saved_self {
+            Some(v) => {
+                self.env.insert("self".to_string(), v);
+            }
+            None => {
+                self.env.remove("self");
+            }
+        }
         let changed: Vec<String> = self
             .env
             .iter()
             .filter(|(k, v)| {
                 let kn = k.resolve();
+                // `self`/`$_` are the callee's invocant and topic, never a caller
+                // lexical to write back. The nested proto dispatch can leave the
+                // enclosing method's `self` slot holding a type object (a
+                // writeback-safe `Package`); recording it here would clobber the
+                // enclosing invocant on return — a plain method that merely
+                // delegates to an attribute's cross-module `proto method` would
+                // turn its own `self` into `Any` (HTTP::Message.field ->
+                // HTTP::Header.field). Exclude the invocant explicitly.
                 kn != "_"
                     && kn != "$_"
+                    && kn != "self"
+                    && !kn.starts_with("__mutsu_")
                     && Self::is_writeback_safe_scalar(v)
-                    && proto_pre_env.get(*k).map(|p| p != *v).unwrap_or(true)
+                    // Only a name that ALREADY existed as a writeback-safe scalar
+                    // before the proto dispatch and whose value the dispatch
+                    // changed is a genuine caller-lexical mutation to propagate.
+                    // A name that is *new* to env (or was a non-scalar before) is
+                    // internal leakage from the proto run — bareword type objects
+                    // (`Any`/`POuter`), magic vars (`?FILE`), `__mutsu_*` keys, and
+                    // even the caller's own instance var reset to a type object.
+                    // Recording those clobbers the caller (`unwrap_or(true)` turned
+                    // `$o` into `Any`). Require a real pre-existing scalar.
+                    && proto_pre_env.get(*k).map(|p| p != *v).unwrap_or(false)
             })
             .map(|(k, _)| k.resolve())
             .collect();

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -381,17 +381,24 @@ impl Interpreter {
             if pd.is_invocant || pd.name.starts_with("__type_capture__") {
                 continue;
             }
-            // Slurpy parameters (`*@x`, `*%h`, `**@x`) are less specific than a
-            // required positional of the same type. When a single Positional
+            // Positional slurpy parameters (`*@x`, `**@x`) are less specific than
+            // a required positional of the same type. When a single Positional
             // argument matches both `(@x)` and `(*@x)`, the non-slurpy candidate
             // must win rather than being treated as equally specific (ambiguous).
-            // This includes a user-written named-hash slurpy: `(*%items)` must
-            // lose to `(IO::Path :$file!)` for `.load(file => $path)` (META6's
-            // `multi method new` set). The implicit method `*%_` is on every
-            // candidate, so it carries no penalty.
+            //
+            // A named-hash slurpy (`*%h`) is NOT penalized here. It competes with
+            // other candidates only over *named* arguments, and a bare zero-arg
+            // candidate is really `(*%_)` in Raku — equivalent, not narrower — so
+            // a flat distance penalty would wrongly let `()` beat `(Bool :$b, *%h)`
+            // (`HTTP::Request.new(GET => $url)` picking the wrong `new`). Named
+            // slurpies are instead ranked by the explicit-named tie-break below:
+            // `(IO::Path :$file!)` still beats `(*%items)` because it declares an
+            // explicit named param, and `()` vs `(*%h)` correctly ties (ambiguous),
+            // matching rakudo. The implicit method `*%_` carries no penalty either.
             if (pd.slurpy || pd.double_slurpy) && pd.name != "%_" && pd.name != "_" {
-                total += 2000;
                 if !pd.named && !pd.name.starts_with('%') {
+                    // positional slurpy
+                    total += 2000;
                     arg_idx += 1;
                 }
                 continue;

--- a/t/lib/ProtoInvocantInner.rakumod
+++ b/t/lib/ProtoInvocantInner.rakumod
@@ -1,0 +1,18 @@
+unit class ProtoInvocantInner;
+
+# A `proto method` in its OWN compilation unit. Reaching it from another module's
+# method takes the slow proto-dispatch path (same-file protos compile to bytecode
+# and never hit it), which is where the invocant-clobber regression lived.
+has @.fields;
+
+proto method field(|) {*}
+
+multi method field(*%fields) {
+    for %fields.sort(*.key) -> (:key($k), :value($v)) {
+        @.fields.push: ($k => $v);
+    }
+}
+
+multi method field($f) {
+    @.fields.first(*.key eq $f)
+}

--- a/t/lib/ProtoInvocantOuter.rakumod
+++ b/t/lib/ProtoInvocantOuter.rakumod
@@ -1,0 +1,11 @@
+unit class ProtoInvocantOuter;
+
+use ProtoInvocantInner;
+
+has ProtoInvocantInner $.inner = ProtoInvocantInner.new;
+
+# A plain method that merely delegates to the attribute's cross-module proto
+# method. Nothing here mutates the outer invocant.
+method poke($f) { $.inner.field($f) }
+
+method poke-named(*%h) { $.inner.field(|%h) }

--- a/t/multi-named-slurpy-ranking.t
+++ b/t/multi-named-slurpy-ranking.t
@@ -1,0 +1,46 @@
+use Test;
+
+# A multi candidate that declares a named parameter (optional) plus a named-hash
+# slurpy is NARROWER than a bare zero-arg candidate: in Raku a zero-arg method is
+# really `(*%_)`, so `(Bool :$b, *%a)` out-narrows it. Regression: mutsu ranked the
+# bare `()` candidate as more specific (a flat +2000 distance penalty on the named
+# slurpy let `()` win), so `HTTP::Request.new(GET => $url)` dispatched to the wrong
+# `new` and dropped the URL.
+
+plan 6;
+
+class C {
+    multi method g(Bool :$b, *%a) { "slurpy" }
+    multi method g()              { "zero" }
+}
+
+is C.g(b => True), "slurpy", "declared named+slurpy beats bare zero-arg (named that binds)";
+is C.g(x => 1),    "slurpy", "declared named+slurpy beats bare zero-arg (extra named to slurpy)";
+is C.g(),          "slurpy", "declared named+slurpy beats bare zero-arg (no args)";
+
+# The HTTP::Request.new(GET => $url) shape: the slurpy candidate collects the pair.
+class Req {
+    has $.url;
+    proto method new(|) {*}
+    multi method new(Bool :$bin, *%args) {
+        my $url = 'none';
+        for %args.kv -> $k, $v { $url = $v if $k.lc eq 'get' }
+        self.bless(:$url)
+    }
+    multi method new() { self.bless(:url('default')) }
+}
+
+is Req.new(GET => "http://example.com/").url, "http://example.com/",
+    "GET => url reaches the (Bool :\$bin, *%args) candidate";
+# Even with no args, the `(Bool :$bin, *%args)` candidate is narrower than the
+# bare `()` (which is really `(*%_)`), so it wins and `%args` is simply empty —
+# exactly as rakudo dispatches.
+is Req.new.url, "none", "no-arg new still reaches the narrower slurpy candidate (raku parity)";
+
+# A named-hash slurpy still LOSES to a candidate declaring an explicit named param
+# (the tie-break that the removed penalty used to short-circuit).
+class D {
+    multi method f(Int :$file!) { "explicit" }
+    multi method f(*%items)     { "slurpy" }
+}
+is D.f(file => 3), "explicit", "explicit named param beats a named-hash slurpy";

--- a/t/proto-cross-module-invocant.t
+++ b/t/proto-cross-module-invocant.t
@@ -1,0 +1,29 @@
+use lib 't/lib';
+use Test;
+
+# Regression: a plain method that delegates to an attribute whose class declares a
+# *cross-module* `proto method` (e.g. HTTP::Message.field -> HTTP::Header.field)
+# corrupted the ENCLOSING invocant. The slow proto-dispatch interception recorded
+# every changed/new env scalar as a caller-var writeback, including the caller's
+# own instance variable reset to a type object, turning `$o` into `Any`.
+
+use ProtoInvocantOuter;
+
+plan 6;
+
+my $o = ProtoInvocantOuter.new;
+
+$o.poke("X");                          # sink-context delegation through the proto
+ok $o.defined,               "outer invocant survives a delegated proto call (sink)";
+is $o.WHAT.^name, "ProtoInvocantOuter", "outer keeps its type after the proto call";
+
+my $p = ProtoInvocantOuter.new;
+my $r = $p.poke("Y");                  # assignment context too
+ok $p.defined,               "outer invocant survives a delegated proto call (assign)";
+
+# The delegated setter still actually mutates the inner object.
+my $q = ProtoInvocantOuter.new;
+$q.poke-named(A => 1, B => 2);
+ok $q.defined,               "outer survives a *%h delegation to the proto setter";
+is $q.inner.fields.elems, 2, "inner proto setter ran and pushed both fields";
+is $q.inner.field("A").value, 1, "inner proto getter reads back a stored field";


### PR DESCRIPTION
Two independent method-dispatch bugs, both surfaced while getting the genuine
`HTTP::UserAgent` community module to run on mutsu (batteries campaign).

## 1. Named-hash slurpy no longer loses to a bare zero-arg candidate

A `multi method` declaring a named parameter plus a named-hash slurpy
(`(Bool :$b, *%a)`) is narrower than a bare zero-arg candidate and must win — in
Raku a zero-arg method is really `(*%_)`. mutsu ranked the bare `()` as *more*
specific: `method_candidate_type_distance` charged a flat `+2000` penalty to any
named-hash slurpy (`*%a`), while the bare candidate's implicit `*%_` isn't in its
`param_defs` and paid nothing. So `()` won on raw distance and the explicit-named
tie-break never ran.

Fallout: `HTTP::Request.new(GET => $url)` dispatched to a bare `multi method new()`
instead of `multi method new(Bool :$bin, *%args)`, silently dropping the URL and
connecting to `localhost`.

Fix: only penalize a *positional* slurpy (`*@x` still loses to `(@x)`); a
named-hash slurpy is ranked by the existing explicit-named tie-break. So
`(IO::Path :$file!)` still beats `(*%items)`, and `()` vs `(*%a)` now correctly
**ties** (ambiguous), matching rakudo.

## 2. Cross-module proto-method call no longer clobbers the enclosing invocant

A plain method delegating to an attribute whose class declares a `proto method` in
another compilation unit corrupted the *enclosing* invocant to `Any`:

```raku
class Inner { proto method field(|) {*}; multi method field($f) { ... } }   # module A
class Outer { has Inner $.inner; method poke($f) { $.inner.field($f) } }    # module B
my $o = Outer.new; $o.poke("X");   # $o is now Any!
```

`HTTP::Message.field` -> `HTTP::Header.field` (cross-module `proto`) hit exactly
this. The slow proto-dispatch interception (`try_proto_method_body`) diffed env for
changed scalars to propagate genuine caller-lexical mutations, but treated every
*new-or-newly-safe* env key as changed (`unwrap_or(true)`), sweeping up leaked
bareword type objects, magic vars, `__mutsu_*` keys, and the caller's own instance
variable reset to a type object — committing `Any` back onto the caller.

Fix: require a genuine *pre-existing* writeback-safe scalar the proto changed
(`unwrap_or(false)`), exclude `self`/`__mutsu_*`, and save/restore the enclosing
`self` across the proto dispatch.

## Tests
- `t/multi-named-slurpy-ranking.t`
- `t/proto-cross-module-invocant.t` (+ `t/lib/ProtoInvocant{Inner,Outer}.rakumod`)

Both verified raku-identical. Local `make test` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)