### PR TITLE
fix: method-form .sprintf spreads a single positional container argument

### DIFF
--- a/news/2026-07/sprintf-method-form-flatten.md
+++ b/news/2026-07/sprintf-method-form-flatten.md
@@ -1,0 +1,28 @@
+# Method-form `.sprintf` spreads a single positional container argument
+
+The method form `$format.sprintf(*@args)` has a slurpy signature, so a single
+positional container argument now spreads across the directives exactly like the
+sub form `sprintf($format, @args)`, matching Rakudo. Previously mutsu's native
+1-arg `.sprintf` fast path passed the whole array as one value:
+
+```
+"%d".sprintf([42])       # was 0,     now 42
+"%s-%s".sprintf([1, 2])  # was "1 2-", now "1-2"
+```
+
+## Implementation
+
+`dispatch_1arg.rs`'s native `"sprintf"` arm passed its single argument straight
+to `format_sprintf`, which treats it as one value. It already deferred a bare
+type-object argument to the slow-path `sprintf` arm (which routes through
+`builtin_sprintf`, the source of truth for the sub form's flattening); that defer
+now also covers a list-like argument (`arg.as_list_items().is_some()`), so the
+slurpy spread and the directive/argument-count check match the sub form. A single
+non-container argument keeps the native fast path.
+
+## Not covered (pre-existing, both forms)
+
+`sprintf("%d %d", 1..2)` does not flatten a `Range` into its elements — it is
+counted as one argument in *both* the sub and method forms (mutsu reports an
+argument-count mismatch where rakudo prints `1 2`). That is a separate gap in
+`builtin_sprintf`'s argument flattening, orthogonal to this fix.

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -1029,10 +1029,13 @@ pub(crate) fn native_method_1arg(
         }
         "sprintf" => {
             // Method form: '%f'.sprintf(value) — target is the format string.
-            // A bare type object arg needs the interpreter-aware warning path
-            // (`%s` warns and stringifies to ""), so defer to the slow-path
-            // `sprintf` arm which routes through `builtin_sprintf`.
-            if matches!(arg.view(), ValueView::Package(_)) {
+            // The `*@args` slurpy spreads a single positional container across the
+            // directives (`"%s-%s".sprintf([1,2])` is `1-2`, not `1 2-`), so a
+            // list-like arg must defer to the slow-path `sprintf` arm, which routes
+            // through `builtin_sprintf` (the same flattening the sub form gets). A
+            // bare type object likewise needs the interpreter-aware warning path
+            // (`%s` warns and stringifies to "").
+            if matches!(arg.view(), ValueView::Package(_)) || arg.as_list_items().is_some() {
                 return None;
             }
             let fmt = target.to_string_value();

--- a/t/sprintf-method-form-flatten.t
+++ b/t/sprintf-method-form-flatten.t
@@ -1,0 +1,52 @@
+use v6;
+use Test;
+
+# The method form `$format.sprintf(*@args)` has a slurpy signature, so a single
+# positional container argument spreads across the directives exactly like the
+# sub form `sprintf($format, @args)`. Previously mutsu's native 1-arg `.sprintf`
+# fast path passed the whole array as ONE value, so `"%d".sprintf([42])` gave 0
+# and `"%s-%s".sprintf([1,2])` gave "1 2-".
+
+plan 14;
+
+is "%d".sprintf([42]),        '42',      '"%d".sprintf([42]) spreads the array';
+is "%s-%s".sprintf([1, 2]),   '1-2',     '"%s-%s".sprintf([1,2]) spreads to two args';
+is "%d-%d-%d".sprintf([1,2,3]), '1-2-3', 'three-element array spreads to three args';
+is "%s and %s".sprintf(["a", "b"]), 'a and b', 'string elements spread';
+
+# A list literal spreads the same way.
+is "%s-%s".sprintf((1, 2)),   '1-2',     'a List argument spreads';
+
+# The method form agrees with the sub form.
+is "%s-%s".sprintf([1, 2]), sprintf("%s-%s", [1, 2]),
+    'method form matches the sub form';
+
+# A single non-container argument still works (unchanged fast path).
+is "%d".sprintf(42),      '42',   'single Int arg';
+is "%s".sprintf("hi"),    'hi',   'single Str arg';
+is "%05.2f".sprintf(3.14159), '03.14', 'formatting flags on a single arg';
+
+# An array bound to a variable spreads too.
+{
+    my @a = 7, 8;
+    is "%d/%d".sprintf(@a), '7/8', 'an @-var argument spreads';
+}
+
+# Argument-count mismatch is still detected after spreading.
+{
+    dies-ok { "%d".sprintf([1, 2, 3]) },
+        'too many spread args dies (directive/arg count mismatch)';
+    dies-ok { "no directives".sprintf([1, 2]) },
+        'extra args with no directives dies';
+}
+
+# A bare type object element still gets the string-context warning (from #5336).
+{
+    my $r;
+    { $r = quietly "%s".sprintf(Int); }
+    is $r, '', 'a bare type object stringifies to "" (with a warning)';
+}
+
+# A single %s consuming a multi-element array is an arg-count mismatch (each
+# element is a separate arg after spreading), matching the sub form.
+dies-ok { "%s".sprintf([1, 2, 3]) }, '"%s".sprintf([1,2,3]) is an arg-count mismatch';


### PR DESCRIPTION
## Summary

The method form `\$format.sprintf(*@args)` has a slurpy signature, so a single positional container argument now spreads across the directives exactly like the sub form `sprintf(\$format, @args)`, matching Rakudo. Previously mutsu's native 1-arg `.sprintf` fast path passed the whole array as one value:

```
"%d".sprintf([42])       # was 0,     now 42
"%s-%s".sprintf([1, 2])  # was "1 2-", now "1-2"
```

## Change

`dispatch_1arg.rs`'s native `"sprintf"` arm already deferred a bare type-object argument to the slow-path `sprintf` arm (which routes through `builtin_sprintf`, the source of truth for the sub form's flattening). That defer now also covers a list-like argument (`arg.as_list_items().is_some()`), so the slurpy spread and the directive/argument-count check match the sub form. A single non-container argument keeps the native fast path.

## Not covered (pre-existing, both forms)

`sprintf("%d %d", 1..2)` does not flatten a `Range` into its elements — it is counted as one argument in *both* the sub and method forms. That is a separate gap in `builtin_sprintf`'s argument flattening, orthogonal to this fix.

## Tests

- New pin `t/sprintf-method-form-flatten.t` (14 subtests).
- `make test` green (2386 files / 22724 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)