### PR TITLE
fix: sprintf slurps its argument list, flattening Range/List/Seq args

### DIFF
--- a/src/builtins/functions/sprintf_fmt.rs
+++ b/src/builtins/functions/sprintf_fmt.rs
@@ -25,18 +25,14 @@ pub(crate) fn native_sprintf(args: &[Value], z_mode: bool) -> Option<Result<Valu
         _ => String::new(),
     };
     let rest: &[Value] = if args.is_empty() { &[] } else { &args[1..] };
-    // Raku: sprintf("%d", [42]) treats the single array's elements as args.
-    let flattened: Vec<Value>;
-    let actual_args = if rest.len() == 1 {
-        if let ValueView::Array(items, ..) = rest[0].view() {
-            flattened = items.as_ref().clone().items;
-            &flattened[..]
-        } else {
-            rest
-        }
-    } else {
-        rest
-    };
+    // Raku's `sprintf($format, *@args)` slurps its arguments, so every list-like
+    // argument (Array, List/Seq/Slip, Range) flattens into one flat positional
+    // list: `sprintf("%d %d", 1..2)` sees two args. `flatten_into_slurpy` performs
+    // exactly the slurpy flatten, respecting itemization (a scalar-held array
+    // stays one argument), and mirrors `Interpreter::builtin_sprintf`.
+    let mut flattened: Vec<Value> = Vec::with_capacity(rest.len());
+    runtime::types::flatten_into_slurpy(rest, &mut flattened);
+    let actual_args = &flattened[..];
     // A bare type object argument needs interpreter-aware coercion: a `%s`
     // directive stringifies it to "" with rakudo's "uninitialized value of type
     // X in string context" warning (matching `~Int` / `Int.Str`) instead of

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -1030,12 +1030,25 @@ pub(crate) fn native_method_1arg(
         "sprintf" => {
             // Method form: '%f'.sprintf(value) — target is the format string.
             // The `*@args` slurpy spreads a single positional container across the
-            // directives (`"%s-%s".sprintf([1,2])` is `1-2`, not `1 2-`), so a
-            // list-like arg must defer to the slow-path `sprintf` arm, which routes
-            // through `builtin_sprintf` (the same flattening the sub form gets). A
+            // directives (`"%s-%s".sprintf([1,2])` is `1-2`, not `1 2-`; likewise a
+            // Range: `"%d %d".sprintf(1..2)` is `1 2`), so any list-like arg must
+            // defer to the slow-path `sprintf` arm, which routes through
+            // `builtin_sprintf` (the same slurpy flattening the sub form gets). A
             // bare type object likewise needs the interpreter-aware warning path
             // (`%s` warns and stringifies to "").
-            if matches!(arg.view(), ValueView::Package(_)) || arg.as_list_items().is_some() {
+            if matches!(arg.view(), ValueView::Package(_))
+                || arg.as_list_items().is_some()
+                || matches!(
+                    arg.view(),
+                    ValueView::Range(..)
+                        | ValueView::RangeExcl(..)
+                        | ValueView::RangeExclStart(..)
+                        | ValueView::RangeExclBoth(..)
+                        | ValueView::GenericRange { .. }
+                        | ValueView::Seq(..)
+                        | ValueView::Slip(..)
+                )
+            {
                 return None;
             }
             let fmt = target.to_string_value();

--- a/src/runtime/builtins_string.rs
+++ b/src/runtime/builtins_string.rs
@@ -18,19 +18,16 @@ impl Interpreter {
             Some(ValueView::Str(s)) => s.to_string(),
             _ => String::new(),
         };
-        // Flatten array arguments (Raku: sprintf("%d", [42]) treats array elements as args)
+        // Raku's `sprintf($format, *@args)` slurps its arguments, so every
+        // list-like argument (Array, List/Seq/Slip, Range) flattens into a single
+        // flat positional list — `sprintf("%d %d", 1..2)` sees two args, and
+        // `sprintf("%d %d %d", 1, 2..3)` sees three. `flatten_into_slurpy` performs
+        // exactly the slurpy flatten, respecting itemization: a scalar-held array
+        // (`my $x = [1,2,3]`) is itemized and stays a single argument, matching
+        // raku, whereas a bare `[1,2,3]` literal flattens to its elements.
         let rest = &args[1..];
-        let flattened: Vec<Value>;
-        let mut actual_args: Vec<Value> = if rest.len() == 1 {
-            if let ValueView::Array(items, ..) = rest[0].view() {
-                flattened = items.as_ref().clone().items;
-                flattened
-            } else {
-                rest.to_vec()
-            }
-        } else {
-            rest.to_vec()
-        };
+        let mut actual_args: Vec<Value> = Vec::with_capacity(rest.len());
+        crate::runtime::types::flatten_into_slurpy(rest, &mut actual_args);
         super::sprintf::validate_sprintf_directives(&fmt, actual_args.len())?;
         super::sprintf::validate_sprintf_arg_types(&fmt, &actual_args)?;
         // The pure formatter only knows `to_string_value`/`.gist`/numeric unbox,

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -15,12 +15,13 @@ mod type_registry;
 pub(crate) use coercion::{coerce_impossible_error, is_coercion_constraint, parse_coercion_type};
 pub(in crate::runtime) use signature::{
     bind_named_rename_sub_signature, bind_sub_signature_from_value,
-    collect_nested_named_alias_keys, encode_slurpy_rw_param, flatten_into_slurpy,
-    indexed_varref_from_value, sigilless_alias_key, sigilless_readonly_key,
-    sub_signature_matches_value, sub_signature_target_from_remaining_args, varref_from_value,
-    wrap_native_int_for_binding,
+    collect_nested_named_alias_keys, encode_slurpy_rw_param, indexed_varref_from_value,
+    sigilless_alias_key, sigilless_readonly_key, sub_signature_matches_value,
+    sub_signature_target_from_remaining_args, varref_from_value, wrap_native_int_for_binding,
 };
-pub(crate) use signature::{decode_slurpy_rw_param, make_varref_value, unwrap_varref_value};
+pub(crate) use signature::{
+    decode_slurpy_rw_param, flatten_into_slurpy, make_varref_value, unwrap_varref_value,
+};
 // Internal re-exports used by submodules via `use super::*`
 use signature::code_signature_matches_value;
 

--- a/src/runtime/types/signature.rs
+++ b/src/runtime/types/signature.rs
@@ -114,7 +114,7 @@ const MAX_SLURPY_RANGE_EXPAND: i64 = 100_000;
 /// Recursively flatten a list of values for `*@` (flattening slurpy) parameter binding.
 /// Non-itemized Array/List elements are flattened recursively; itemized containers
 /// (`$(...)`, `$[...]`) are preserved as single elements.
-pub(in crate::runtime) fn flatten_into_slurpy(values: &[Value], out: &mut Vec<Value>) {
+pub(crate) fn flatten_into_slurpy(values: &[Value], out: &mut Vec<Value>) {
     for val in values {
         match val.view() {
             ValueView::Array(arr, kind) if !kind.is_itemized() => {

--- a/t/sprintf-slurpy-flatten.t
+++ b/t/sprintf-slurpy-flatten.t
@@ -1,0 +1,50 @@
+use v6;
+use Test;
+
+# `sprintf($format, *@args)` slurps its arguments, so every list-like argument
+# (Range, List/Seq/Slip, bare Array literal) flattens into one flat positional
+# list before the directives consume them. This mirrors raku exactly and covers
+# both the sub form and the `$format.sprintf(...)` method form.
+
+# --- Range arguments flatten (was: "1 argument was supplied" arg-count error) ---
+is sprintf("%d %d", 1..2), "1 2", "sub form: single Range flattens to 2 args";
+is sprintf("%d %d %d", 1..3), "1 2 3", "sub form: single Range flattens to 3 args";
+is sprintf("%d %d %d", 1, 2..3), "1 2 3", "sub form: scalar + Range flatten together";
+is sprintf("%d %d %d %d", 1..2, 3..4), "1 2 3 4", "sub form: two Ranges flatten";
+
+# --- List / nested list arguments flatten recursively ---
+is sprintf("%d %d %d", (1, 2, 3)), "1 2 3", "sub form: flat list flattens";
+is sprintf("%d %d %d", (1, (2, 3))), "1 2 3", "sub form: nested list flattens recursively";
+
+# --- Seq / Slip arguments flatten ---
+is sprintf("%d %d", (1, 2).Seq), "1 2", "sub form: Seq flattens";
+is sprintf("%d %d %d", |(1, 2, 3)), "1 2 3", "sub form: Slip flattens";
+
+# --- Array arguments flatten (regression guard) ---
+{
+    my @a = 1..3;
+    is sprintf("%d %d %d", @a), "1 2 3", "sub form: named array flattens";
+}
+
+# --- Itemization is respected: a scalar-held array stays one argument ---
+{
+    my $x = [1, 2, 3];
+    is sprintf("%s", $x), "1 2 3", "scalar-held array is a single (unflattened) arg";
+}
+
+# --- Method form: same slurpy flatten ---
+is "%d %d".sprintf(1..2), "1 2", "method form: single Range flattens";
+is "%d %d %d".sprintf(1..3), "1 2 3", "method form: 3-element Range flattens";
+is "%d %d %d".sprintf(1, 2..3), "1 2 3", "method form: scalar + Range flatten";
+is "%s-%s".sprintf([1, 2]), "1-2", "method form: single Array spreads across directives";
+is "%d %d".sprintf((1, 2).Seq), "1 2", "method form: Seq flattens";
+
+# --- Plain scalar args still work (fast-path regression guard) ---
+is sprintf("%d", 42), "42", "sub form: plain scalar";
+is "%d".sprintf(42), "42", "method form: plain scalar";
+is sprintf("%s %s", "a", "b"), "a b", "sub form: two string scalars";
+
+# --- printf writes the same flattened output ---
+lives-ok { printf("%d %d\n", 1..2) }, "printf accepts a Range and flattens it";
+
+done-testing;


### PR DESCRIPTION
## Summary

`sprintf($format, *@args)` slurps its arguments, so every list-like argument flattens into a single flat positional list before the directives consume it. mutsu previously flattened only a lone `Array` argument, so these all failed with a bogus argument-count error instead of formatting:

```raku
sprintf("%d %d", 1..2)          # was: "1 argument was supplied"  -> now "1 2"
sprintf("%d %d %d", 1, 2..3)    # was: "2 arguments were supplied" -> now "1 2 3"
sprintf("%d %d %d", (1, (2, 3)))# nested list                      -> now "1 2 3"
"%d %d".sprintf(1..2)           # method form                      -> now "1 2"
```

## Fix

Replace the ad-hoc single-`Array` flatten in all three sprintf entry points with the shared `flatten_into_slurpy` helper — the single source of truth for `*@args` slurpy flattening (Array/List/Seq/Slip/Range, itemization-aware):

- `native_sprintf` (pure VM fast path)
- `Interpreter::builtin_sprintf` (slow path)
- `$format.sprintf(...)` method-form fast path (now bails to the interpreter for Range/Seq/Slip args, as it already did for a bare Array)

As a correctness side effect, itemization is now respected: a scalar-held array (`my $x = [1,2,3]`) stays one argument, matching raku, whereas a bare `[1,2,3]` literal flattens to its elements.

`flatten_into_slurpy` is promoted from `pub(in crate::runtime)` to `pub(crate)` so the `builtins` fast path can reach it.

## Test

Pin: `t/sprintf-slurpy-flatten.t` (19 subtests, raku green). `make test` PASS (22755 tests), all 10 whitelisted roast `sprintf*.t` PASS (20249 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)