### PR TITLE
fix: register a class-body `my $NAME` static even when a same-named binding leaked into env

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -337,26 +337,16 @@ sessions).
       one after another. **Fixed so far (PR #5346):** (1) a named-hash-slurpy multi candidate
       `(Bool :$bin, *%args)` lost dispatch to a bare `()` (so `HTTP::Request.new(GET => $url)` dropped
       the URL); (2) a cross-module `proto method` delegation clobbered the enclosing invocant to `Any`
-      (`HTTP::Message.field` → `HTTP::Header.field`). **Open blocker (bug #3):** a `constant NAME` and
-      a scalar `my $NAME` collide by *bare name* — mutsu strips the `$` sigil from scalar names in the
-      AST (`$CRLF` → `Var("CRLF")`), the same bare key a sigilless `constant CRLF` uses. A module-level
-      scalar `my $CRLF` is not written to its package store (`Pkg::CRLF`), so a method that reads it
-      compiles to `GetGlobal("Pkg::CRLF")` and, when a same-named `constant CRLF` from another module
-      has leaked into the bare-name namespace, falls back to that constant. Triggers only when **both**
-      a parent and child class (in separate modules) declare `my $NAME` and a `constant NAME` exists
-      elsewhere — exactly `HTTP::Message`/`HTTP::Request` (both `my $CRLF = "\r\n"`) plus
-      `HTTP::UserAgent`'s `constant CRLF = Buf.new(13,10)`, which turned the request's line-ending into
-      a `Buf` and threw "Cannot use a Buf as a string". Minimal repro (child method reads the constant,
-      not its own `my`):
-      ```
-      # Base.rakumod   unit class Base; my $CRLF = "\r\n"; method b() {1}
-      # Der.rakumod    use Base; unit class Der is Base; my $CRLF = "\r\n"; method read() { $CRLF.^name }
-      # Ua.rakumod     unit class Ua; use Der; constant CRLF = Buf.new(13,10);
-      # run            use Ua; use Der; say Der.read;   # mutsu: Buf   raku: Str
-      ```
-      Root fix is namespace-scoping (a sigilless `constant NAME` must not leak to a bare global that a
-      scalar `$NAME` read resolves to; module-scope scalar `my` needs a package store its own methods
-      can read). Likely more request/response-parsing bugs behind it — this is a dedicated session.
+      (`HTTP::Message.field` → `HTTP::Header.field`). **(bug #3) FIXED** — a module-level scalar
+      `my $CRLF` in a child class was not registered as a class-body static when the same bare name had
+      already leaked into the persistent mainline env from the parent module's `my $CRLF`, so the child
+      class's methods fell back to the bare-name global (which the third module's `constant CRLF =
+      Buf.new(13,10)` had clobbered). `register_class_decl` now recognizes a name a class body
+      *explicitly* `my`/`state`-declares as a static regardless of any pre-existing leaked binding, so
+      `package_scope_lexical` resolves each class's `$CRLF` to its own value. `HTTP::Request.new(GET =>
+      $url).Str` now renders `\r\n` as `Str`. Pin: `t/constant-scalar-my-bare-name-collision.t`
+      (fixtures `t/lib/Crlf*.rakumod`); see news/2026-07/constant-scalar-my-bare-name-collision.md.
+      Likely more request/response-parsing bugs behind it — continue exercising a real request next.
 - [ ] Stored Regex `<$var>` lexical capture loss (found via Tubu; separate axis).
 - 📌 The off-the-shelf `DBDish::SQLite` depends on `MoarVM::Guts::REPRs` (direct emulation of MoarVM
   internal representations) and cannot work in principle = a de-facto wall. Practical SQLite goes

--- a/news/2026-07/constant-scalar-my-bare-name-collision.md
+++ b/news/2026-07/constant-scalar-my-bare-name-collision.md
@@ -1,0 +1,55 @@
+# A module-level `my $NAME` no longer collides with a same-named `constant`
+
+Fixes PLAN.md §1 B4 bug #3 — the HTTP::UserAgent battery blocker where a request's
+line-ending turned into a `Buf` and threw "Cannot use a Buf as a string".
+
+## The shape
+
+mutsu strips the `$` sigil from scalar names in the AST, so a scalar `my $CRLF`
+and a sigilless `constant CRLF` share the bare key `CRLF`. The bug triggered when
+**both** a parent and a child class (in separate modules) declared `my $CRLF` and
+a same-named `constant CRLF` existed in a third module — exactly
+`HTTP::Message`/`HTTP::Request` (both `my $CRLF = "\r\n"`) plus `HTTP::UserAgent`'s
+`constant CRLF = Buf.new(13, 10)`.
+
+Minimal repro (`t/constant-scalar-my-bare-name-collision.t` with fixtures under
+`t/lib/Crlf*.rakumod`):
+
+```
+# CrlfBase.rakumod     unit class CrlfBase;      my $CRLF = "base-crlf";    method base-crlf() { $CRLF }
+# CrlfDerived.rakumod  use CrlfBase; unit class CrlfDerived is CrlfBase; my $CRLF = "derived-crlf"; method derived-crlf() { $CRLF }
+# CrlfConst.rakumod    unit class CrlfConst; use CrlfDerived; constant CRLF = "const-crlf";
+# run                  use CrlfConst; use CrlfDerived; say CrlfDerived.derived-crlf;   # was: const-crlf   now: derived-crlf
+```
+
+## Root cause
+
+On the class-registration success path a class body's top-level `my` statics are
+intentionally left in the persistent mainline env (so a top-level `class`/`use`
+keeps them reachable), and are *also* mirrored into `package_lexicals[Class]` /
+`class_body_static_names[Class]` so a method can resolve them after the body env
+is gone. A method read of such a static goes through `package_scope_lexical`,
+which is gated on the class having recorded statics.
+
+`register_class_decl` recognized a class-body static by it being **new** in `env`
+(absent from the pre-body `saved_env`). But the parent module's `my $CRLF` had
+already leaked into the persistent mainline env, so by the time the child class
+registered, `saved_env` already carried `CRLF`. The child's own `my $CRLF` was
+therefore *not* recorded as a class-body static, `class_has_package_lexicals`
+returned false for it, and its methods fell back to the bare-name global — which
+the last writer (the `constant CRLF` `Buf`) had clobbered.
+
+## Fix
+
+A name a class body **explicitly declares** with `my`/`state` at top level is a
+class-body static regardless of any pre-existing outer/leaked binding of the same
+name. `register_class_decl` now collects the set of top-level `Stmt::VarDecl`
+names (non-`our`, non-dynamic) from the class body and treats a name as a static
+when it is either new in `env` **or** in that declared set. The leaked outer
+binding no longer suppresses the child's own static, so `package_scope_lexical`
+resolves each class's `$CRLF` to its own value. Names the body merely *reads* from
+an enclosing scope are unaffected (they are not in the declared set), so a class
+that reads an outer lexical still sees the live outer value.
+
+With this, the real `HTTP::Request.new(GET => $url).Str` renders `\r\n`
+line-endings as a `Str` again instead of a `Buf`.

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -2437,14 +2437,36 @@ impl Interpreter {
         // the package-block store in `exec_package_scope_op`. `current_package`
         // is still `name` here, which is exactly when a method of this class
         // reads these names, so the store is correctly scoped.
+        // Names this class body actually `my`/`state`-declared at top level. A
+        // class-body static is normally recognized by being NEW in `env` (absent
+        // from `saved_env`). But a same-named lexical leaked into the persistent
+        // mainline env by an EARLIER module's class body (the success path leaves
+        // body statics in `env`) makes `saved_env` already carry the name, so this
+        // class's own `my $x` would be wrongly skipped and never registered as a
+        // static — its methods then fall back to the leaked bare-name global (e.g.
+        // `HTTP::Message`/`HTTP::Request` both `my $CRLF`). A name explicitly
+        // declared here IS a static regardless of any pre-existing outer/leaked
+        // binding, so recognize it directly from the body.
+        let declared_statics: std::collections::HashSet<&str> = body
+            .iter()
+            .filter_map(|stmt| match stmt {
+                Stmt::VarDecl {
+                    name,
+                    is_our: false,
+                    is_dynamic: false,
+                    ..
+                } => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
         let body_lexicals: Vec<(String, Value)> = self
             .env
             .iter()
             .filter_map(|(k, v)| {
-                if saved_env.contains_key_sym(*k) {
+                let bare = k.resolve();
+                if saved_env.contains_key_sym(*k) && !declared_statics.contains(bare.as_str()) {
                     return None;
                 }
-                let bare = k.resolve();
                 if bare.contains("::")
                     || bare.starts_with("__")
                     || bare.starts_with('?')

--- a/t/constant-scalar-my-bare-name-collision.t
+++ b/t/constant-scalar-my-bare-name-collision.t
@@ -1,0 +1,30 @@
+use Test;
+use lib 't/lib';
+
+# Regression pin: a module-level scalar `my $NAME` and a sigilless `constant NAME`
+# collide by bare name (mutsu strips the `$` sigil from scalar names in the AST,
+# so `$CRLF` and a sigilless `constant CRLF` share the key `CRLF`). When both a
+# parent and a child class (in separate modules) declare `my $NAME`, the parent's
+# leaked into the persistent mainline env; the child's own `my $NAME` was then
+# never registered as a class-body static, so its methods fell back to whatever
+# last wrote the bare-name global — including a same-named `constant` from a third
+# module. This is exactly the HTTP::Message / HTTP::Request (`my $CRLF`) plus
+# HTTP::UserAgent (`constant CRLF`) shape that turned a request's line-ending into
+# the wrong value. See PLAN.md §1 B4 (bug #3).
+
+plan 4;
+
+use CrlfConst;
+use CrlfDerived;
+use CrlfBase;
+
+is CrlfDerived.derived-crlf, "derived-crlf",
+    'child class reads its OWN module-level `my $CRLF`, not a leaked `constant CRLF`';
+is CrlfBase.base-crlf, "base-crlf",
+    'parent class still reads its own module-level `my $CRLF`';
+
+# Instances resolve the same way.
+is CrlfDerived.new.derived-crlf, "derived-crlf",
+    'child instance method reads its own `my $CRLF`';
+is CrlfBase.new.base-crlf, "base-crlf",
+    'parent instance method reads its own `my $CRLF`';

--- a/t/lib/CrlfBase.rakumod
+++ b/t/lib/CrlfBase.rakumod
@@ -1,0 +1,5 @@
+unit class CrlfBase;
+# A module-level scalar `my` whose bare name (mutsu strips the `$`) collides with
+# a same-named `my` in a child module and a `constant` elsewhere.
+my $CRLF = "base-crlf";
+method base-crlf() { $CRLF }

--- a/t/lib/CrlfConst.rakumod
+++ b/t/lib/CrlfConst.rakumod
@@ -1,0 +1,5 @@
+unit class CrlfConst;
+use CrlfDerived;
+# A sigilless `constant` whose bare name is the same `CRLF` key. This is the
+# value that leaked into CrlfDerived's method reads before the fix.
+constant CRLF = "const-crlf";

--- a/t/lib/CrlfDerived.rakumod
+++ b/t/lib/CrlfDerived.rakumod
@@ -1,0 +1,8 @@
+use CrlfBase;
+unit class CrlfDerived is CrlfBase;
+# Same-named module-level scalar as the parent. Before the fix, the parent's
+# `my $CRLF` leaked into the persistent mainline env, so this class's own
+# `my $CRLF` was not registered as a class-body static and the method below fell
+# back to whatever last wrote the bare `CRLF` global.
+my $CRLF = "derived-crlf";
+method derived-crlf() { $CRLF }


### PR DESCRIPTION
## Summary

Fixes **PLAN.md §1 B4 bug #3** — the HTTP::UserAgent battery blocker where a request's line-ending turned into a `Buf` and threw *"Cannot use a Buf as a string"*.

mutsu strips the `$` sigil from scalar names in the AST, so a scalar `my $CRLF` and a sigilless `constant CRLF` share the bare key `CRLF`. The bug triggered when **both** a parent and a child class (in separate modules) declared `my $CRLF` and a same-named `constant CRLF` existed in a third module — exactly `HTTP::Message`/`HTTP::Request` (both `my $CRLF = "\r\n"`) plus `HTTP::UserAgent`'s `constant CRLF = Buf.new(13, 10)`.

## Root cause

On the class-registration success path a class body's top-level `my` statics are intentionally left in the persistent mainline env *and* mirrored into `package_lexicals[Class]` / `class_body_static_names[Class]`, so a method resolves them via `package_scope_lexical` (gated on the class having recorded statics).

`register_class_decl` recognized a class-body static by it being **new** in `env` (absent from the pre-body `saved_env`). But the parent module's `my $CRLF` had already leaked into the persistent mainline env, so when the child class registered, `saved_env` already carried `CRLF`. The child's own `my $CRLF` was therefore **not** recorded as a static, `class_has_package_lexicals` returned false, and its methods fell back to the bare-name global — which the last writer (the `constant CRLF` `Buf`) had clobbered.

## Fix

A name a class body **explicitly** `my`/`state`-declares at top level is a class-body static regardless of any pre-existing outer/leaked binding of the same name. `register_class_decl` now collects the top-level `Stmt::VarDecl` names (non-`our`, non-dynamic) and treats a name as a static when it is new in `env` **or** in that declared set. Names the body merely *reads* from an enclosing scope are unaffected (an outer-lexical read still sees the live outer value).

With this, the real `HTTP::Request.new(GET => \$url).Str` renders `\r\n` line-endings as a `Str` again.

## Tests

- New pin `t/constant-scalar-my-bare-name-collision.t` (fixtures `t/lib/Crlf*.rakumod`) — fails before, passes after.
- `make test` PASS (2388 files, 22726 tests); `cargo clippy -D warnings` + `cargo fmt` clean.
- Verified the real vendored `HTTP::Request` now builds a `Str` CRLF; outer-lexical-read and class-body-shadow cases match `raku`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)