### PR TITLE
fix: method-form sprintf validates its directive count against the arg count

### DIFF
--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -1052,6 +1052,15 @@ pub(crate) fn native_method_1arg(
                 return None;
             }
             let fmt = target.to_string_value();
+            // The single scalar arg feeds exactly one directive. Any other
+            // directive count is an arg-count mismatch (`"%s and %s".sprintf("a")`
+            // wants two args), which `format_sprintf` would silently paper over by
+            // rendering the missing directives as empty/0. Defer to the slow-path
+            // arm so `builtin_sprintf` raises the same `X::Str::Sprintf::Directives::Count`
+            // the sub form does.
+            if runtime::sprintf_directive_count(&fmt) != 1 {
+                return None;
+            }
             let rendered = runtime::format_sprintf(&fmt, Some(arg));
             Some(Ok(Value::str(rendered)))
         }

--- a/src/runtime/methods_io_dispatch.rs
+++ b/src/runtime/methods_io_dispatch.rs
@@ -65,8 +65,19 @@ impl Interpreter {
     }
 
     pub(super) fn dispatch_sprintf(&mut self, target: &Value) -> Result<Value, RuntimeError> {
+        // No-arg method form: `$format.sprintf`. The stringified invocant is the
+        // format, consumed against zero arguments — so a format with any directive
+        // (`"%s".sprintf`) is an arg-count mismatch, exactly as `sprintf("%s")` is,
+        // while a directive-free string (`"no dir".sprintf`, `42.sprintf`) renders
+        // as itself.
         let content = self.render_str_value(target);
-        Ok(Value::str(content))
+        crate::runtime::sprintf::validate_sprintf_directives(&content, 0)?;
+        // Still run the formatter so an escaped `%%` collapses to a literal `%`
+        // (`"100%%".sprintf` is `100%`), matching `sprintf("100%%")`.
+        Ok(Value::str(crate::runtime::format_sprintf_args(
+            &content,
+            &[],
+        )))
     }
 
     pub(super) fn dispatch_put(&mut self, target: &Value) -> Result<Value, RuntimeError> {

--- a/src/runtime/utils.rs
+++ b/src/runtime/utils.rs
@@ -449,3 +449,4 @@ pub(crate) use type_misc::*;
 pub(crate) use super::sprintf::format_sprintf;
 pub(crate) use super::sprintf::format_sprintf_args;
 pub(crate) use super::sprintf::format_zprintf;
+pub(crate) use super::sprintf::sprintf_directive_count;

--- a/t/sprintf-method-form-arg-count.t
+++ b/t/sprintf-method-form-arg-count.t
@@ -1,0 +1,46 @@
+use v6;
+use Test;
+
+# The `$format.sprintf(...)` method form must validate the directive count
+# against the number of arguments, exactly as the `sprintf($format, ...)` sub
+# form does. Previously mutsu's method-form fast path silently rendered missing
+# directives as empty/0 (`"%s and %s".sprintf("a")` gave "a and " instead of
+# throwing X::Str::Sprintf::Directives::Count).
+
+# --- Too few args: single-arg method form errors like the sub form ---
+throws-like { "%s and %s".sprintf("a") }, X::Str::Sprintf::Directives::Count,
+    "method form: 2 directives, 1 arg throws Count";
+throws-like { "%d-%d-%d".sprintf(1) }, X::Str::Sprintf::Directives::Count,
+    "method form: 3 directives, 1 arg throws Count";
+throws-like { "%d %d".sprintf(5) }, X::Str::Sprintf::Directives::Count,
+    "method form: 2 directives, 1 arg throws Count";
+
+# --- Too few args: no-arg method form errors too ---
+throws-like { "%s".sprintf }, X::Str::Sprintf::Directives::Count,
+    "no-arg method form: 1 directive, 0 args throws Count";
+throws-like { "%d %d".sprintf() }, X::Str::Sprintf::Directives::Count,
+    "no-arg method form: 2 directives, 0 args throws Count";
+
+# --- The sub form throws the same exception (baseline) ---
+throws-like { sprintf("%s and %s", "a") }, X::Str::Sprintf::Directives::Count,
+    "sub form: 2 directives, 1 arg throws Count";
+
+# --- Correct arg counts still render (fast-path regression guard) ---
+is "%s".sprintf("x"), "x", "method form: 1 directive, 1 arg";
+is "%d".sprintf(42), "42", "method form: numeric directive";
+is "%05.2f".sprintf(3.14), "03.14", "method form: width/precision";
+is "%x".sprintf(255), "ff", "method form: hex";
+is "%d %d".sprintf(1, 2), "1 2", "method form: 2 directives, 2 args";
+is "%2\$s %1\$s".sprintf("a", "b"), "b a", "method form: positional args";
+is "%*d".sprintf(5, 42), "   42", "method form: '*' width consumes an arg";
+
+# --- Directive-free formats render as themselves with no args ---
+is "no directives".sprintf, "no directives", "no-arg method form: literal string";
+is 42.sprintf, "42", "no-arg method form: numeric invocant stringifies";
+is 3.14.sprintf, "3.14", "no-arg method form: rational invocant";
+
+# --- An escaped %% collapses to a literal % even with no args ---
+is "100%%".sprintf, "100%", "no-arg method form: %% collapses to %";
+is "50%% off".sprintf, "50% off", "no-arg method form: %% mid-string";
+
+done-testing;


### PR DESCRIPTION
## Summary

`$format.sprintf(...)` and the no-arg `$format.sprintf` silently papered over an argument-count mismatch, where the `sprintf($format, ...)` sub form correctly throws `X::Str::Sprintf::Directives::Count`:

```raku
"%s and %s".sprintf("a")   # was "a and "  -> now throws Count (like the sub form)
"%s".sprintf               # was "%s"       -> now throws Count
"%d %d".sprintf()          # was "%d %d"    -> now throws Count
```

The method-form fast paths handed the format straight to `format_sprintf`, which fills missing directives with empty/0 instead of validating the directive count.

## Fix

- **Single-arg fast path** (`native_method_1arg`): a lone scalar feeds exactly one directive, so bail to the slow-path `sprintf` arm (which routes through `builtin_sprintf` and validates) whenever the format's directive count is not 1.
- **No-arg method form** (`dispatch_sprintf`): validate the stringified invocant against zero arguments, then still run the formatter so an escaped `%%` collapses to a literal `%` (`"100%%".sprintf` is `100%`), while a directive-free string (`"no dir".sprintf`, `42.sprintf`) renders as itself.

`sprintf_directive_count` is re-exported through `runtime::utils` (next to `format_sprintf`) so the builtins fast path can reach it.

## Test

Pin: `t/sprintf-method-form-arg-count.t` (18 subtests, raku green). `make test` PASS (22773 tests), whitelisted roast `sprintf*.t` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)