### PR TITLE
fix: a role mixed into a native-backed instance keeps its native methods

### DIFF
--- a/news/2026-07/role-mixin-native-method-delegation.md
+++ b/news/2026-07/role-mixin-native-method-delegation.md
@@ -1,0 +1,56 @@
+# A role mixed into a native-backed instance keeps its native methods
+
+Mixing a role into a native-backed instance (`$path does R`, `$sock does
+Connection`, `"..." .IO but R`) made every *native* method of the base class
+disappear:
+
+```raku
+role R { method g { 1 } }
+my $p = "/foo/bar.txt".IO;
+$p does R;
+say $p.g;         # 1        — the role method was fine
+say $p.basename;  # No such method 'basename' for invocant of type 'IO::Path'
+```
+
+## Root cause
+
+`call_method_with_values` already ends with a Mixin fallback that delegates an
+unhandled method to the inner value, and that fallback is what made mixins work
+for user-defined classes. But three by-name native dispatchers
+(`dispatch_method_by_name_1/2/3` — string, IO, coercion, collection, network)
+run *before* it. Those dispatchers select on the method name and then key on the
+target's runtime shape. Given the `Mixin` wrapper rather than the inner
+`Instance`, they matched the name, failed to find a native receiver, and returned
+a hard `X::Method::NotFound` — so control never reached the delegation at the tail
+of the function.
+
+Role methods were unaffected because `dispatch_mixin_method_call` runs earlier
+still, which is why only the *native* half of a mixed value went missing.
+
+## Fix
+
+Delegate to the inner value just before the by-name dispatchers, but only when
+the inner instance's class declares the method as a native one and does *not*
+declare a user method of that name:
+
+- `is_native_method(cls, method)` selects exactly the methods the by-name
+  dispatchers would otherwise steal.
+- `class_has_user_method(cls, method)` (user-declared `.methods` only — note that
+  `class_has_method` also reports `native_methods`, so it is the wrong predicate
+  here) leaves user-declared and inherited methods to the existing Mixin fallback,
+  which runs them with `self` bound to the wrapper so nested `self.foo` still
+  re-dispatches through the composed roles.
+
+A role method that shadows a native name still wins, because
+`dispatch_mixin_method_call` has already returned by the time this runs.
+
+## Why it matters
+
+This is the first blocker hit when driving the `HTTP::UserAgent` battery against
+a real server. The module mixes a `Connection` role onto the socket
+(`$conn does Connection`) and then calls the native `self.print(...)` /
+`$conn.recv(:bin)` from the role's own `send-request`. Before the fix the request
+could not even be written; with it, mutsu sends a real HTTP request and reads the
+response back off the socket.
+
+Pin: `t/mixin-native-method-delegation.t`.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -3658,6 +3658,27 @@ impl Interpreter {
             }
         }
 
+        // A role-mixed native-backed value (`$sock does Connection`,
+        // `$path does R`): a native method of the inner class must delegate to the
+        // inner value BEFORE the by-name native dispatchers below. Those key on the
+        // target's runtime shape and hard-error on the Mixin wrapper (e.g.
+        // `.basename` on `IO::Path+{R}`, `.print` on `IO::Socket::INET+{Connection}`)
+        // instead of falling through to the Mixin-inner delegation at the tail of
+        // this function. Role methods and `__mutsu_attr__` markers were already
+        // handled by `dispatch_mixin_method_call` above; a user-declared (possibly
+        // inherited) method is left for the Mixin fallback so it runs with `self`
+        // bound to the wrapper.
+        if let ValueView::Mixin(inner, _) = target.view() {
+            let inner_owned = inner.as_ref().clone();
+            if let ValueView::Instance { class_name, .. } = inner_owned.view() {
+                let cls = class_name.resolve().to_string();
+                if !self.class_has_user_method(&cls, method) && self.is_native_method(&cls, method)
+                {
+                    return self.call_method_with_values(inner_owned, method, args);
+                }
+            }
+        }
+
         // Primary method dispatch by name (group 1: string, IO, coercion, misc)
         if let Some(result) = self.dispatch_method_by_name_1(target.clone(), method, args.clone()) {
             return result;

--- a/t/mixin-native-method-delegation.t
+++ b/t/mixin-native-method-delegation.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+# A role mixed into a native-backed instance (via `does`/`but`) must still
+# dispatch the instance's *native* methods to the inner value. Before the fix,
+# the by-name native dispatchers (string/IO/etc.) intercepted the method on the
+# `Base+{Role}` Mixin wrapper and hard-errored with "No such method" instead of
+# delegating to the inner value. This is what HTTP::UserAgent needs: it mixes a
+# `Connection` role onto an `IO::Socket::INET` and calls native `.print`/`.recv`.
+
+plan 8;
+
+role Marker { method marker { "marked" } }
+
+# IO::Path is a native-backed instance. Mix a role in and call native methods.
+my $path = "/foo/bar/baz.txt".IO;
+$path does Marker;
+
+is $path.marker,   "marked",  "role method works on mixed IO::Path";
+is $path.basename, "baz.txt", "native basename delegates to inner IO::Path";
+is $path.extension, "txt",    "native extension delegates to inner IO::Path";
+is $path.parent.basename, "bar", "native parent chain works through the mixin";
+
+# `but` form (single value mixin) on IO::Path.
+my $p2 = "/a/b.md".IO but Marker;
+is $p2.marker, "marked", "role method works via `but` on IO::Path";
+is $p2.basename, "b.md", "native basename works via `but` on IO::Path";
+
+# A user-declared method that shadows a native one still runs (with self bound to
+# the wrapper) — the delegation must NOT swallow user overrides.
+role Renamer { method basename { "OVERRIDDEN" } }
+my $p3 = "/x/y.txt".IO but Renamer;
+is $p3.basename, "OVERRIDDEN", "role method shadowing a native name wins";
+
+# Allomorph-style value mixin still coerces natively (regression guard).
+my $n = 5 but Marker;
+is $n + 3, 8, "numeric mixin still does arithmetic natively";
+
+done-testing;


### PR DESCRIPTION
## Problem

Mixing a role into a native-backed instance (`$path does R`, `$sock does Connection`) made every *native* method of the base class disappear:

```raku
role R { method g { 1 } }
my $p = "/foo/bar.txt".IO;
$p does R;
say $p.g;         # 1        — the role method was fine
say $p.basename;  # No such method 'basename' for invocant of type 'IO::Path'
```

## Root cause

`call_method_with_values` already ends with a Mixin fallback that delegates an unhandled method to the inner value, and that fallback is what made mixins work for user-defined classes. But the three by-name native dispatchers (`dispatch_method_by_name_1/2/3` — string, IO, coercion, collection, network) run *before* it. Those select on the method name and then key on the target's runtime shape. Given the `Mixin` wrapper rather than the inner `Instance`, they matched the name, failed to find a native receiver, and returned a hard `X::Method::NotFound` — so control never reached the delegation at the tail of the function.

Role methods were unaffected because `dispatch_mixin_method_call` runs earlier still, which is why only the *native* half of a mixed value went missing.

## Fix

Delegate to the inner value just before the by-name dispatchers, but only when the inner instance's class declares the method as a native one and does *not* declare a user method of that name:

- `is_native_method(cls, method)` selects exactly the methods the by-name dispatchers would otherwise steal.
- `class_has_user_method(cls, method)` is the right predicate — note that `class_has_method` also reports `native_methods`, so it would never fire. User-declared and inherited methods are left to the existing Mixin fallback, which runs them with `self` bound to the wrapper so nested `self.foo` still re-dispatches through the composed roles.

A role method that shadows a native name still wins, because `dispatch_mixin_method_call` has already returned by the time this runs (covered by test 7).

## Why it matters

This is the first blocker hit when driving the `HTTP::UserAgent` battery against a real server. The module mixes a `Connection` role onto the socket (`$conn does Connection`) and then calls the native `self.print(...)` / `$conn.recv(:bin)` from the role's own `send-request`. Before the fix the request could not even be written; with it, mutsu sends a real HTTP request and reads the response back off the socket.

## Tests

- New pin `t/mixin-native-method-delegation.t` (8 tests: role method, native delegation via `does` and `but`, chained native calls, user-override shadowing, numeric-mixin regression guard).
- `make test`: **Result: PASS** (Files=2391, Tests=22767).
- Role/mixin canaries re-run green: `roast/S12-construction/roles-6e.t`, `roast/S14-roles/basic.t`, `roast/S14-roles/instantiation.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)