### PR TITLE
fix: `Blob ~ Buf` widens to `Buf` instead of keeping the LHS type

### DIFF
--- a/news/2026-07/blob-buf-concat-result-type.md
+++ b/news/2026-07/blob-buf-concat-result-type.md
@@ -1,0 +1,44 @@
+# `Blob ~ Buf` widens to `Buf` instead of keeping the LHS type
+
+`infix:<~>` on two buffer values preserved the *left* operand's type
+unconditionally. Rakudo instead types the result by whether the two operands
+have the **same** type: matching types are preserved, any mismatch widens to the
+plain mutable `Buf`.
+
+```raku
+say (Blob[uint8].new(1) ~ Blob[uint8].new(2)).^name;  # Blob[uint8]  (same)
+say (Buf[uint8].new(1)  ~ Buf[uint8].new(2)).^name;   # Buf[uint8]   (same)
+say ("a".encode ~ "b".encode).^name;                  # utf8         (same)
+say (Blob[uint8].new(1) ~ Buf[uint8].new(2)).^name;   # Buf          (mismatch)
+say (Blob[uint8].new(1) ~ Blob[uint16].new(2)).^name; # Buf          (mismatch)
+```
+
+mutsu reported `Blob[uint8]` for the last two.
+
+## Why the distinction is load-bearing
+
+It is what lets a `Blob`-typed accumulator become bindable to a `Buf` once
+something mutable has been appended to it:
+
+```raku
+my Blob[uint8] $acc = Blob[uint8].new;
+$acc ~= Buf[uint8].new(0x41, 0x42);   # container now holds a Buf
+my Buf $chunk = $acc.clone;           # ... so this type-checks
+```
+
+`HTTP::UserAgent` is built on exactly this shape. `get-response` accumulates the
+socket reads into `my Blob[uint8] $first-chunk` via `~=` — and `recv(:bin)`
+hands back a `Buf` — then slices the body out with `.subbuf` and passes it to
+`get-chunked-content`, whose first statement is `my Buf $chunk = $content.clone`.
+With the LHS type preserved, the value was still a `Blob[uint8]` there and the
+assignment died with *"Type check failed in assignment to $chunk; expected Buf,
+got Blob[uint8]"*, so no chunked response body could be read.
+
+## Fix
+
+In `concat_values` (`src/vm/vm_coerce_concat_ops.rs`), compare the two operands'
+class names: equal names keep that name, anything else produces `Buf`. Byte
+concatenation itself is unchanged.
+
+Pin: `t/blob-buf-concat-result-type.t` — 12 assertions that pass identically
+under `raku` and mutsu.

--- a/src/vm/vm_coerce_concat_ops.rs
+++ b/src/vm/vm_coerce_concat_ops.rs
@@ -296,12 +296,25 @@ impl Interpreter {
     /// (`apply_reduction_op` delegates here). It uses no Interpreter state, so it is a
     /// plain associated function callable as `crate::runtime::Interpreter::concat_values(...)`.
     pub(crate) fn concat_values(left: Value, right: Value) -> Value {
-        // Buf ~ Buf → Buf (byte concatenation, preserving LHS type)
+        // Buf ~ Buf → byte concatenation. Rakudo types the result by whether the
+        // two operands have the *same* type: `Blob[uint8] ~ Blob[uint8]` stays
+        // `Blob[uint8]` and `utf8 ~ utf8` stays `utf8`, but any mismatch widens to
+        // the plain mutable `Buf` — so `Blob[uint8] ~ Buf[uint8]` is a `Buf`, which
+        // is what lets `my Buf $x = $blob-typed-var` type-check after an append
+        // (HTTP::UserAgent accumulates `Blob[uint8] ~= <recv Buf>` and then binds
+        // the result to a `Buf`). Preserving the LHS type instead kept it a Blob.
         if Self::is_buf_value(&left) && Self::is_buf_value(&right) {
-            let result_class = if let ValueView::Instance { class_name, .. } = left.view() {
-                class_name
-            } else {
-                crate::symbol::Symbol::intern("Buf")
+            let left_class = match left.view() {
+                ValueView::Instance { class_name, .. } => Some(class_name),
+                _ => None,
+            };
+            let right_class = match right.view() {
+                ValueView::Instance { class_name, .. } => Some(class_name),
+                _ => None,
+            };
+            let result_class = match (left_class, right_class) {
+                (Some(l), Some(r)) if l == r => l,
+                _ => crate::symbol::Symbol::intern("Buf"),
             };
             let mut bytes = Self::extract_buf_bytes(&left);
             bytes.extend(Self::extract_buf_bytes(&right));

--- a/t/blob-buf-concat-result-type.t
+++ b/t/blob-buf-concat-result-type.t
@@ -1,0 +1,43 @@
+use v6;
+use Test;
+
+# Rakudo types the result of `Blob ~ Blob` by whether the two operands have the
+# *same* type: matching types are preserved, any mismatch widens to the plain
+# mutable `Buf`. mutsu used to preserve the LHS type unconditionally, so
+# `Blob[uint8] ~= <a Buf>` stayed a Blob and could no longer be bound to a `Buf`.
+
+plan 12;
+
+# Same type on both sides is preserved.
+is (Blob[uint8].new(1) ~ Blob[uint8].new(2)).^name, 'Blob[uint8]',
+    'Blob[uint8] ~ Blob[uint8] stays Blob[uint8]';
+is (Buf[uint8].new(1) ~ Buf[uint8].new(2)).^name, 'Buf[uint8]',
+    'Buf[uint8] ~ Buf[uint8] stays Buf[uint8]';
+is (Blob[uint16].new(1) ~ Blob[uint16].new(2)).^name, 'Blob[uint16]',
+    'Blob[uint16] ~ Blob[uint16] stays Blob[uint16]';
+is ("a".encode ~ "b".encode).^name, 'utf8',
+    'utf8 ~ utf8 stays utf8';
+
+# Mismatched types widen to the plain mutable Buf.
+is (Blob[uint8].new(1) ~ Buf[uint8].new(2)).^name, 'Buf',
+    'Blob[uint8] ~ Buf[uint8] widens to Buf';
+is (Buf[uint8].new(1) ~ Blob[uint8].new(2)).^name, 'Buf',
+    'Buf[uint8] ~ Blob[uint8] widens to Buf';
+is (Blob[uint8].new(1) ~ Blob[uint16].new(2)).^name, 'Buf',
+    'Blob[uint8] ~ Blob[uint16] widens to Buf';
+is ("a".encode ~ Buf[uint8].new(2)).^name, 'Buf',
+    'utf8 ~ Buf[uint8] widens to Buf';
+
+# The bytes themselves still concatenate in order.
+is (Blob[uint8].new(1, 2) ~ Buf[uint8].new(3, 4)).list, (1, 2, 3, 4),
+    'mismatched concat still joins the bytes in order';
+
+# The motivating case: appending a Buf onto a Blob-typed container makes the
+# container hold a Buf, which can then be bound to a `Buf`-typed variable.
+my Blob[uint8] $acc = Blob[uint8].new;
+$acc ~= Buf[uint8].new(0x41, 0x42);
+is $acc.^name, 'Buf', 'Blob[uint8] container holds a Buf after ~= a Buf';
+lives-ok { my Buf $chunk = $acc.clone }, 'the result binds to a Buf-typed variable';
+is $acc.decode('latin-1'), 'AB', 'the accumulated bytes decode correctly';
+
+done-testing;


### PR DESCRIPTION
## Problem

`infix:<~>` on two buffer values preserved the *left* operand's type unconditionally. Rakudo instead types the result by whether the two operands have the **same** type: matching types are preserved, any mismatch widens to the plain mutable `Buf`.

```raku
say (Blob[uint8].new(1) ~ Blob[uint8].new(2)).^name;  # Blob[uint8]  (same)
say (Buf[uint8].new(1)  ~ Buf[uint8].new(2)).^name;   # Buf[uint8]   (same)
say ("a".encode ~ "b".encode).^name;                  # utf8         (same)
say (Blob[uint8].new(1) ~ Buf[uint8].new(2)).^name;   # Buf          (mismatch)
say (Blob[uint8].new(1) ~ Blob[uint16].new(2)).^name; # Buf          (mismatch)
```

mutsu reported `Blob[uint8]` for the last two.

## Why the distinction is load-bearing

It is what lets a `Blob`-typed accumulator become bindable to a `Buf` once something mutable has been appended to it:

```raku
my Blob[uint8] $acc = Blob[uint8].new;
$acc ~= Buf[uint8].new(0x41, 0x42);   # container now holds a Buf
my Buf $chunk = $acc.clone;           # ... so this type-checks
```

`HTTP::UserAgent` is built on exactly this shape. `get-response` accumulates the socket reads into `my Blob[uint8] $first-chunk` via `~=` — and `recv(:bin)` hands back a `Buf` — then slices the body out with `.subbuf` and passes it to `get-chunked-content`, whose first statement is `my Buf $chunk = $content.clone`. With the LHS type preserved, the value was still a `Blob[uint8]` there and the assignment died with *"Type check failed in assignment to \$chunk; expected Buf, got Blob[uint8]"*, so no chunked response body could be read. (example.com is served through Cloudflare with `Transfer-Encoding: chunked`, so this path is unavoidable.)

## Fix

In `concat_values` (`src/vm/vm_coerce_concat_ops.rs`), compare the two operands' class names: equal names keep that name, anything else produces `Buf`. Byte concatenation itself is unchanged.

## Tests

- New pin `t/blob-buf-concat-result-type.t` — 12 assertions covering same-type preservation (`Blob[uint8]`, `Buf[uint8]`, `Blob[uint16]`, `utf8`), the four mismatch shapes, byte ordering, and the `~=`-then-bind-to-`Buf` motivating case. **The file passes identically under `raku` and mutsu** (12/12 both).
- `make test`: **Result: PASS** (Files=2392, Tests=22789).

With this plus #5353, mutsu decodes a real chunked HTTP response body byte-for-byte identically to `raku` (559 bytes from `http://example.com/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)