### PR TITLE
fix: Nil.say / .note / .put / .print print instead of being Nil-absorbed

### DIFF
--- a/src/runtime/methods_io_dispatch.rs
+++ b/src/runtime/methods_io_dispatch.rs
@@ -88,7 +88,8 @@ impl Interpreter {
     pub(super) fn dispatch_note(&mut self, target: &Value) -> Result<Value, RuntimeError> {
         let content = format!("{}\n", self.render_gist_value(target)?);
         self.write_to_named_handle("$*ERR", &content, false)?;
-        Ok(Value::NIL)
+        // `note` returns True (like the `note LIST` sub form), not Nil.
+        Ok(Value::TRUE)
     }
 
     /// Apply a Unicode normalization form before encoding. Accepts the short

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -1476,6 +1476,17 @@ impl Interpreter {
                         | "Slip" | "flat" | "Seq" | "cache" | "head" | "tail" | "elems" => {
                             // Fall through to normal dispatch
                         }
+                        // I/O routines print rather than absorb: `Nil.say` /
+                        // `Nil.note` emit the gist "Nil" (and return True), while
+                        // `Nil.put` / `Nil.print` coerce via `.Str`, warning "Use of
+                        // Nil in string context" and printing the empty string.
+                        // Route them to the normal dispatch (dispatch_say/note/
+                        // put/print), the same as the `say Nil` sub form. (A
+                        // positional arg — `Nil.say("x")` — is a separate
+                        // X::Multi::NoMatch case handled by the catch-all below.)
+                        "say" | "note" | "put" | "print" if args.is_empty() => {
+                            // Fall through to normal dispatch
+                        }
                         // Numeric coercion on Nil (an undefined value) warns and
                         // resumes with the corresponding numeric *zero* — raku's
                         // `Nil.Int` is `0` (defined), `Nil.Num` is `0e0`,

--- a/t/nil-io-method-not-absorbed.t
+++ b/t/nil-io-method-not-absorbed.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+# The I/O routines `say` / `note` / `put` / `print` print rather than being
+# Nil-absorbed: `Nil.say` emits the gist "Nil" (like the `say Nil` sub form)
+# instead of silently returning Nil. Previously mutsu's Nil-method fast path
+# swallowed these, so `sub a { }; a().say` printed nothing.
+
+# --- Nil.say / Nil.note emit the gist and return True ---
+{
+    my $out = $*OUT;
+    is (Nil.say).raku, "Bool::True", "Nil.say returns True";
+    is (Nil.note).raku, "Bool::True", "Nil.note returns True";
+}
+
+# `.note` (on any invocant) returns True, matching the sub form.
+is ("hello".note).raku, "Bool::True", ".note returns True (general)";
+
+# --- The Type/Nil doc examples: empty subs / blocks return Nil, and .say
+#     prints "Nil" ---
+{
+    sub a { };
+    is a().gist, "Nil", "empty sub returns Nil";
+    sub b { return };
+    is b().gist, "Nil", "return with no value yields Nil";
+    is ({ ; }()).gist, "Nil", "empty block returns Nil";
+    sub c( --> Int:D ) { return Nil };
+    is c().gist, "Nil", "return Nil ignores the :D return constraint";
+}
+
+# --- Regression: a genuinely Nil-absorbing (unknown) method still returns Nil ---
+is Nil.foo.gist, "Nil", "unknown method on Nil is absorbed to Nil";
+
+# --- Regression: the sub forms are unchanged ---
+is (say Nil).raku, "Bool::True", "say Nil sub form returns True";
+
+done-testing;


### PR DESCRIPTION
## Summary

`Nil.say` (and `.note`/`.put`/`.print`) silently returned Nil and printed nothing, so an empty sub — which returns Nil — printed an empty line where raku prints "Nil":

```raku
sub a { }; a().say;          # was ""      -> now "Nil"
sub b { return }; b().say;   # was ""      -> now "Nil"
{ ; }().say;                 # was ""      -> now "Nil"
Nil.say;                     # was ""      -> now "Nil"
```

The Nil-invocant fast path in `exec_call_method_op_impl` treated these I/O routines as Nil-absorbing (returning Nil, no output).

## Fix

Route the four 0-arg I/O methods to normal dispatch: `Nil.say` / `Nil.note` emit the gist "Nil" (and return True), while `Nil.put` / `Nil.print` coerce via `.Str`, warning "Use of Nil in string context" and printing the empty string — the same as the `say Nil` sub form. (A positional argument like `Nil.say("x")` remains the `X::Multi::NoMatch` case handled by the catch-all.)

Also fix `dispatch_note` to return `True` rather than `Nil`, matching the `note LIST` sub form — `"x".note` (any invocant) now returns True.

This resolves the `Type/Nil` doc examples (empty subs / blocks / `return Nil` returning Nil, with `.say` printing "Nil").

## Test

Pin: `t/nil-io-method-not-absorbed.t` (9 subtests, raku green). `make test` PASS, roast `S02-types/nil.t` + `S04-statements/return.t` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)