### PR TITLE
fix: a lone `'` in a `< ... >` word list is a word, not a quote delimiter

### DIFF
--- a/news/2026-07/regex-angle-word-list-bare-quote.md
+++ b/news/2026-07/regex-angle-word-list-bare-quote.md
@@ -1,0 +1,55 @@
+# A lone `'` in a `< ... >` word list is a word, not a quote delimiter
+
+A `< a b c >` alternation inside a regex lists literal words, and a lone `'` (or
+`"`) there is an ordinary one-character word. Three scanners toggled quote state
+on it and then treated the whole rest of the pattern as quoted:
+
+```raku
+say ("!#" ~~ / ^ < ! ' # >+ /).pos;   # was 1, raku says 2
+grammar B { token TOP { < ! ' # > || <[A..Za..z]> } }
+say B.parse("t").defined;             # was False, raku says True
+```
+
+Two distinct symptoms, one cause:
+
+1. **The quantifier vanished.** The `<...>` assertion-body scanner in
+   `regex_parse_core.rs` opened a quote on the `'`, never found a closing one, and
+   so ran past the assertion's own `>` to the end of the pattern. The body came
+   out as `` ! ' # >+ `` — the closing `>` and the `+` were absorbed into the word
+   list — so the alternation carried no quantifier and matched exactly once, for
+   *any* input.
+2. **`|` / `||` stopped splitting.** `split_top_level_alternation` and
+   `split_top_level_conjunction` in `regex_parse_ltm.rs` toggled the same way, so
+   every branch operator after the word list looked like it was inside a string
+   and the pattern was never split.
+
+Both were invisible unless the quote count in the pattern was odd — `< ! ' ' # >`
+happened to re-balance and worked.
+
+## Fix
+
+- **Assertion body:** scan honouring quotes first; if the scan reaches the end of
+  the input with a quote still open, that `'`/`"` was never a quote opener, so
+  re-scan with quote tracking off. A properly closed quote keeps the previous
+  behaviour exactly. The scan loop moved into a reusable
+  `scan_angle_assertion_body` helper to make the two passes possible.
+- **Alternation/conjunction splitters:** pause quote tracking while inside an
+  angle assertion (`depth_angle > 0`). This is safe because the `|` and `&` split
+  arms already require `depth_angle == 0`, so an assertion's contents can never
+  produce a spurious split and need no quote tracking at all.
+
+## Why it matters
+
+This is the HTTP `tchar` production, which `HTTP::MediaType` uses verbatim:
+
+```raku
+token tchar { || < ! # $ % & ' * + - . ^ _ ` | ~ > || <.DIGIT> || <.ALPHA> }
+```
+
+Every media type failed to parse, so `HTTP::Response.is-text` threw
+`X::MediaTypeParser::IllegalMediaType` on a plain `text/html` response — the
+third blocker found while driving `HTTP::UserAgent` against a live server. It now
+returns `True`, matching `raku`.
+
+Pin: `t/regex-angle-word-list-bare-quote.t` — 14 assertions that pass identically
+under `raku` and mutsu.

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -1,6 +1,131 @@
 use super::regex_parse::*;
 use super::*;
 
+/// Result of scanning the body of a `< ... >` regex assertion (the opening `<`
+/// is already consumed).
+struct AngleBodyScan {
+    /// The text between the angle brackets, exclusive of the closing `>`.
+    name: String,
+    /// How many characters of the input the scan consumed, *including* the
+    /// closing `>` when one was found.
+    consumed: usize,
+    /// Whether the body terminated properly: the matching `>` was reached with
+    /// no quote left open.
+    closed: bool,
+}
+
+/// Scan the body of a `< ... >` assertion, balancing nested angles, parens,
+/// brackets and braces so that an inner `>` (`<.foo(a => 1)>`) does not
+/// terminate it.
+///
+/// `honor_quotes` controls whether `'`/`"` open a quoted span. Callers scan once
+/// with it on and, if the result is not `closed` (a quote ran off the end of the
+/// input), scan again with it off — an unterminated quote means the character
+/// was a literal word of a `< a b ' c >` alternation rather than a quote opener.
+fn scan_angle_assertion_body(rest: &[char], honor_quotes: bool) -> AngleBodyScan {
+    let mut name = String::new();
+    let mut angle_depth = 1usize;
+    let mut paren_depth: usize = 0;
+    let mut bracket_depth: usize = 0;
+    let mut brace_depth: usize = 0;
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+    let mut idx = 0usize;
+    while idx < rest.len() {
+        let ch = rest[idx];
+        idx += 1;
+        if let Some(q) = quote {
+            name.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == q {
+                quote = None;
+            }
+            continue;
+        }
+        // Handle backslash escapes: \< and \> should not affect angle_depth,
+        // \[ and \] should not affect bracket_depth, etc.
+        if escaped {
+            escaped = false;
+            name.push(ch);
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            name.push(ch);
+            continue;
+        }
+        // An apostrophe that sits between two identifier characters is part of a
+        // Raku long identifier (e.g. `with'hyphen`), not the start of a quoted
+        // literal. Only treat `'` as a quote opener when it is not flanked by
+        // word characters.
+        let apostrophe_in_ident = ch == '\''
+            && name
+                .chars()
+                .last()
+                .is_some_and(|p| p.is_alphanumeric() || p == '_')
+            && rest
+                .get(idx)
+                .is_some_and(|n| n.is_alphanumeric() || *n == '_');
+        match ch {
+            '\'' if apostrophe_in_ident => {
+                name.push(ch);
+            }
+            '\'' | '"' if honor_quotes && bracket_depth == 0 => {
+                quote = Some(ch);
+                name.push(ch);
+            }
+            '(' => {
+                paren_depth += 1;
+                name.push(ch);
+            }
+            ')' => {
+                paren_depth = paren_depth.saturating_sub(1);
+                name.push(ch);
+            }
+            '[' => {
+                bracket_depth += 1;
+                name.push(ch);
+            }
+            ']' => {
+                bracket_depth = bracket_depth.saturating_sub(1);
+                name.push(ch);
+            }
+            '{' => {
+                brace_depth += 1;
+                name.push(ch);
+            }
+            '}' => {
+                brace_depth = brace_depth.saturating_sub(1);
+                name.push(ch);
+            }
+            '<' if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 => {
+                angle_depth += 1;
+                name.push(ch);
+            }
+            '>' if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 => {
+                angle_depth -= 1;
+                if angle_depth == 0 {
+                    return AngleBodyScan {
+                        name,
+                        consumed: idx,
+                        closed: true,
+                    };
+                }
+                name.push(ch);
+            }
+            _ => name.push(ch),
+        }
+    }
+    AngleBodyScan {
+        name,
+        consumed: idx,
+        closed: false,
+    }
+}
+
 impl Interpreter {
     /// Build the alternation atom for a `<@var>` array-variable subrule: look up
     /// the array variable named by `env_key` (including its `@` sigil) and
@@ -1696,103 +1821,25 @@ impl Interpreter {
                             // strings so `<.foo(a => 1)>` and `<.foo(|[3,4,5])>`
                             // are not terminated by the inner `>` or by close
                             // brackets that match opens inside the args list.
-                            let mut name = String::new();
-                            let mut angle_depth = 1usize;
-                            let mut paren_depth: usize = 0;
-                            let mut bracket_depth: usize = 0;
-                            let mut brace_depth: usize = 0;
-                            let mut quote: Option<char> = None;
-                            let mut escaped = false;
-                            while let Some(ch) = chars.next() {
-                                if let Some(q) = quote {
-                                    name.push(ch);
-                                    if escaped {
-                                        escaped = false;
-                                    } else if ch == '\\' {
-                                        escaped = true;
-                                    } else if ch == q {
-                                        quote = None;
-                                    }
-                                    continue;
-                                }
-                                // Handle backslash escapes: \< and \> should not
-                                // affect angle_depth, \[ and \] should not affect
-                                // bracket_depth, etc.
-                                if escaped {
-                                    escaped = false;
-                                    name.push(ch);
-                                    continue;
-                                }
-                                if ch == '\\' {
-                                    escaped = true;
-                                    name.push(ch);
-                                    continue;
-                                }
-                                // An apostrophe that sits between two identifier
-                                // characters is part of a Raku long identifier
-                                // (e.g. `with'hyphen`), not the start of a quoted
-                                // literal. Only treat `'` as a quote opener when it
-                                // is not flanked by word characters.
-                                let apostrophe_in_ident = ch == '\''
-                                    && name
-                                        .chars()
-                                        .last()
-                                        .is_some_and(|p| p.is_alphanumeric() || p == '_')
-                                    && chars
-                                        .peek()
-                                        .is_some_and(|n| n.is_alphanumeric() || *n == '_');
-                                match ch {
-                                    '\'' if apostrophe_in_ident => {
-                                        name.push(ch);
-                                    }
-                                    '\'' | '"' if bracket_depth == 0 => {
-                                        quote = Some(ch);
-                                        name.push(ch);
-                                    }
-                                    '(' => {
-                                        paren_depth += 1;
-                                        name.push(ch);
-                                    }
-                                    ')' => {
-                                        paren_depth = paren_depth.saturating_sub(1);
-                                        name.push(ch);
-                                    }
-                                    '[' => {
-                                        bracket_depth += 1;
-                                        name.push(ch);
-                                    }
-                                    ']' => {
-                                        bracket_depth = bracket_depth.saturating_sub(1);
-                                        name.push(ch);
-                                    }
-                                    '{' => {
-                                        brace_depth += 1;
-                                        name.push(ch);
-                                    }
-                                    '}' => {
-                                        brace_depth = brace_depth.saturating_sub(1);
-                                        name.push(ch);
-                                    }
-                                    '<' if paren_depth == 0
-                                        && bracket_depth == 0
-                                        && brace_depth == 0 =>
-                                    {
-                                        angle_depth += 1;
-                                        name.push(ch);
-                                    }
-                                    '>' if paren_depth == 0
-                                        && bracket_depth == 0
-                                        && brace_depth == 0 =>
-                                    {
-                                        angle_depth -= 1;
-                                        if angle_depth == 0 {
-                                            break;
-                                        }
-                                        name.push(ch);
-                                    }
-                                    _ => name.push(ch),
-                                }
+                            // Scan honouring quotes first. A quote that never closes
+                            // means the `'`/`"` was not a quote opener at all but a
+                            // literal word of a `< ... >` alternation (Raku takes a
+                            // lone `'` there as the one-character word `'`, e.g. the
+                            // HTTP tchar set `< ! # $ % & ' * + - . ^ _ \` | ~ >`).
+                            // Honouring it swallowed the closing `>` and everything
+                            // after it, silently dropping the assertion's quantifier
+                            // — `< ! ' # >+` matched exactly once. Re-scan with quote
+                            // tracking off in that case; a properly closed quote keeps
+                            // the original behaviour.
+                            let rest: Vec<char> = chars.clone().collect();
+                            let scanned = match scan_angle_assertion_body(&rest, true) {
+                                scan @ AngleBodyScan { closed: true, .. } => scan,
+                                _ => scan_angle_assertion_body(&rest, false),
+                            };
+                            for _ in 0..scanned.consumed {
+                                chars.next();
                             }
+                            let mut name = scanned.name;
                             // Check for word alternation: < word1 word2 ... >
                             // In Raku, when the first character after `<` is
                             // whitespace (space or tab), the contents are treated

--- a/src/runtime/regex_parse_ltm.rs
+++ b/src/runtime/regex_parse_ltm.rs
@@ -60,12 +60,19 @@ impl Interpreter {
                 escaped = true;
                 continue;
             }
-            if ch == '\'' && !in_double_quote {
+            // Inside a `<...>` assertion, `'` and `"` are ordinary characters, not
+            // quote delimiters: a `< a b ' c >` alternation may list a lone quote
+            // as a one-character word (the HTTP `tchar` set does). Toggling on it
+            // left the scanner "inside a string" for the rest of the pattern, so a
+            // following `||` never split. The split operators below all require
+            // `depth_angle == 0` anyway, so an assertion's contents cannot produce
+            // a spurious split and need no quote tracking at all.
+            if ch == '\'' && !in_double_quote && depth_angle == 0 {
                 in_single_quote = !in_single_quote;
                 current.push(ch);
                 continue;
             }
-            if ch == '"' && !in_single_quote {
+            if ch == '"' && !in_single_quote && depth_angle == 0 {
                 in_double_quote = !in_double_quote;
                 current.push(ch);
                 continue;
@@ -168,12 +175,15 @@ impl Interpreter {
                 escaped = true;
                 continue;
             }
-            if ch == '\'' && !in_double_quote {
+            // See `split_top_level_alternation`: `'`/`"` inside a `<...>` assertion
+            // are literal word characters, and the `&`/`&&` split below requires
+            // `depth_angle == 0`, so quote tracking must pause inside an assertion.
+            if ch == '\'' && !in_double_quote && depth_angle == 0 {
                 in_single_quote = !in_single_quote;
                 current.push(ch);
                 continue;
             }
-            if ch == '"' && !in_single_quote {
+            if ch == '"' && !in_single_quote && depth_angle == 0 {
                 in_double_quote = !in_double_quote;
                 current.push(ch);
                 continue;

--- a/t/regex-angle-word-list-bare-quote.t
+++ b/t/regex-angle-word-list-bare-quote.t
@@ -1,0 +1,39 @@
+use v6;
+use Test;
+
+# A `< a b c >` alternation inside a regex lists literal words, and a lone `'`
+# (or `"`) there is an ordinary one-character word — not a quote delimiter. Two
+# scanners used to toggle quote state on it and then treat the rest of the
+# pattern as quoted, which silently ate the assertion's closing `>` (dropping its
+# quantifier) and suppressed top-level `|` / `||` splitting.
+#
+# This is the shape of the HTTP `tchar` production, used by HTTP::MediaType:
+#     token tchar { || < ! # $ % & ' * + - . ^ _ ` | ~ > || <.DIGIT> || <.ALPHA> }
+
+plan 14;
+
+# The lone quote is itself matchable as a word.
+ok "'" ~~ / ^ < ! ' # > $ /, "a lone ' in the word list matches as a word";
+ok '"' ~~ / ^ < ! " # > $ /, 'a lone " in the word list matches as a word';
+ok "!" ~~ / ^ < ! ' # > $ /, "the other words still match";
+
+# The quantifier after `>` is not swallowed.
+is ("!#" ~~ / ^ < ! ' # >+ /).pos, 2, "a `+` after a quote-containing word list repeats";
+is ("!!" ~~ / ^ < ! ' # >+ /).pos, 2, "... independently of which word matched";
+is ("''" ~~ / ^ < ! ' # >+ /).pos, 2, "... including repeats of the quote word";
+is ("!#" ~~ / ^ < ! ' # >* /).pos, 2, "a `*` after a quote-containing word list repeats";
+is ("!#" ~~ / ^ < ! # >+ /).pos, 2, "a list without a quote is unaffected";
+
+# A following alternation branch still splits.
+ok "t" ~~ / ^ [ < ! ' # > || <[A..Za..z]> ] $ /, "`||` after the word list still splits";
+ok "t" ~~ / ^ [ < ! ' # > | <[A..Za..z]> ] $ /, "`|` after the word list still splits";
+ok "!" ~~ / ^ [ < ! ' # > || < a b > ] $ /, "two word lists in an alternation";
+
+# Genuine quoted literals elsewhere in the pattern keep working.
+ok "!x" ~~ / ^ < ! ' # > 'x' $ /, "a real quoted literal after the list still parses";
+ok "ab" ~~ / ^ 'a' || 'b' $ /, "top-level `||` between quoted literals still splits";
+
+# An apostrophe inside an identifier-like word is still part of that word.
+is ("don't" ~~ / ^ < don't yes >+ /).pos, 5, "an apostrophe inside a word stays in the word";
+
+done-testing;


### PR DESCRIPTION
## Problem

A `< a b c >` alternation inside a regex lists literal words, and a lone `'` (or `"`) there is an ordinary one-character word. Three scanners toggled quote state on it and then treated the whole rest of the pattern as quoted:

```raku
say ("!#" ~~ / ^ < ! ' # >+ /).pos;   # was 1, raku says 2
grammar B { token TOP { < ! ' # > || <[A..Za..z]> } }
say B.parse("t").defined;             # was False, raku says True
```

Two distinct symptoms, one cause:

1. **The quantifier vanished.** The `<...>` assertion-body scanner in `regex_parse_core.rs` opened a quote on the `'`, never found a closing one, and so ran past the assertion's own `>` to the end of the pattern. The body came out as `` ! ' # >+ `` — the closing `>` and the `+` were absorbed into the word list — so the alternation carried no quantifier and matched exactly once, for *any* input (even `"!!"`).
2. **`|` / `||` stopped splitting.** `split_top_level_alternation` and `split_top_level_conjunction` in `regex_parse_ltm.rs` toggled the same way, so every branch operator after the word list looked like it was inside a string and the pattern was never split.

Both were invisible unless the quote count in the pattern was odd — `< ! ' ' # >` happened to re-balance and worked, which is what made this hard to spot.

## Fix

- **Assertion body:** scan honouring quotes first; if the scan reaches the end of the input with a quote still open, that `'`/`"` was never a quote opener, so re-scan with quote tracking off. A properly closed quote keeps the previous behaviour exactly. The scan loop moved into a reusable `scan_angle_assertion_body` helper to make the two passes possible.
- **Alternation/conjunction splitters:** pause quote tracking while inside an angle assertion (`depth_angle > 0`). This is safe because the `|` and `&` split arms already require `depth_angle == 0`, so an assertion's contents can never produce a spurious split and need no quote tracking at all.

## Why it matters

This is the HTTP `tchar` production, which `HTTP::MediaType` uses verbatim:

```raku
token tchar { || < ! # $ % & ' * + - . ^ _ ` | ~ > || <.DIGIT> || <.ALPHA> }
```

Every media type failed to parse, so `HTTP::Response.is-text` threw `X::MediaTypeParser::IllegalMediaType` on a plain `text/html` response — the third blocker found while driving `HTTP::UserAgent` against a live server (after #5353 and #5355). It now returns `True`, matching `raku`.

## Tests

- New pin `t/regex-angle-word-list-bare-quote.t` — 14 assertions covering the lone `'`/`"` as a word, quantifier repetition (`+`/`*`), `|` and `||` splitting after the list, genuine quoted literals elsewhere in the pattern still parsing, and an apostrophe inside an identifier-like word. **The file passes identically under `raku` and mutsu** (14/14 both).
- `make test`: **Result: PASS** (Files=2393, Tests=22799).
- Regex/grammar roast canaries re-run green: `S05-metasyntax/regex.t`, `charset.t`, `litvar.t`, `S05-grammar/protoregex.t`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)