### PR TITLE
fix: word-logicals bind looser than a non-variable-lvalue assignment

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1276,46 +1276,6 @@ their argument the same way and discard the (unreachable) tail. Parsing no-word-
 also fixes the parens ambiguity — `return (1 and 2)` (a complete term = 2) vs
 `return 1 and 2` (`(return 1) and 2`) — which a post-parse tree rewrite could not.
 
-- [ ] **Leftover (NOT niche — found 2026-07-24): a non-simple-variable lvalue still binds too
-      tightly.** The fix above covers a plain `$x`/`@a`/`%h` assignment target. Every *other*
-      lvalue shape still swallows the operator into its RHS, so the wrong value is stored:
-
-      ```raku
-      class C { has $.v is rw }
-      my $o = C.new; $o.v = 1 andthen 0;   say $o.v;   # mutsu 0, raku 1
-      my @a;         @a[0] = 8 andthen 0;  say @a[0];  # mutsu 0, raku 8
-      my %h;         %h<k> = 9 andthen 0;  say %h<k>;  # mutsu 0, raku 9
-      my $x;         $x    = 7 andthen 0;  say $x;     # 7 both — the variable case is fine
-      ```
-
-      It stores the value of `(RHS op tail)`, so `and`/`andthen`/`notandthen` store the *tail*
-      (or `Nil`), while `or`/`orelse` happen to look right by short-circuit accident. The
-      parenthesized `($o.v = 1) andthen 0` is correct, and so is expression position
-      (`my $r = ($o.v = 1 andthen 0)` stores 0 in `$r` but must still leave `$o.v == 1`).
-
-      **Diagnosis so far.** The *expression* precedence chain is already correct
-      (`assign_not_expr_mode` parses its RHS with `parse_assignment_rhs_mode` → `ternary_mode`,
-      which stops before the word-logicals). The defect is that these lvalue shapes are consumed
-      by tighter hand-rolled paths that parse the RHS with the full `expression()`:
-      `stmt/assign/try_assign.rs:151` (and `:109` for `:=`) for the subscripted forms, and an
-      analogous method-lvalue path for `$o.attr`. Patching only
-      `simple_expr_stmt/core.rs`'s `=` branch does **not** help — that branch is not the one
-      reached (verified by AST dump).
-
-      **Shape of the fix.** Parse those RHSs with `expression_no_word_logical` and re-attach the
-      tail. Unlike the variable case there is no need to re-read the lvalue: `$o.attr = v`,
-      `@a[i] = v` and `%h<k> = v` all desugar to assignment *expressions* whose value is the
-      assigned value, so the assignment expression itself can be the tail's left operand
-      (evaluated exactly once, no double evaluation of a subscript). A
-      `wrap_trailing_word_logical_expr` sibling of `wrap_trailing_word_logical` is the natural
-      home. The risk to manage is that `try_parse_assign_expr` has many callers: leaving the
-      tail unconsumed must not turn into a `Confused` error in a caller that does not expect it,
-      so every call site needs auditing. Sized as its own PR.
-
-      Found while driving `HTTP::UserAgent` against a live server: `get-response` ends with
-      `$response.content = $content andthen $response.content = $response.decoded-content(:$bin)`,
-      which stored the wrong thing and surfaced as *"Type check failed for return value; expected
-      Blob:D but got Any"* from `inflate-content`.
 - [ ] **Leftover (niche): `take X and Y`.** `take` is value-producing, so `(take X) and Y`
       must run `Y` with `take`'s *returned* value driving the short-circuit — the re-read-seed
       trick used for assignment does not apply (there is no variable to re-read, and re-evaluating

--- a/news/2026-07/word-logical-precedence-non-variable-lvalue.md
+++ b/news/2026-07/word-logical-precedence-non-variable-lvalue.md
@@ -1,0 +1,56 @@
+# Word-logical operators bind looser than a non-variable-lvalue assignment
+
+The loose word-logicals (`and`, `or`, `xor`, `andthen`, `orelse`, `notandthen`)
+are the loosest infix operators in Raku — looser than item assignment (`=`). A
+plain-variable target already respected this, but every *other* lvalue shape —
+an attribute accessor, an indexed array element, a hash key — swallowed the
+operator into the assignment's right-hand side and stored the wrong value:
+
+```raku
+class C { has $.v is rw }
+my $o = C.new; $o.v = 1 andthen 0;   say $o.v;   # was 0, now 1
+my @a;         @a[0] = 8 andthen 0;  say @a[0];  # was 0, now 8
+my %h;         %h<k> = 9 andthen 0;  say %h<k>;  # was 0, now 9
+```
+
+It stored the value of `(RHS op tail)`, so `and`/`andthen`/`notandthen` stored
+the tail (or `Nil`); `or`/`orelse` only looked right by short-circuit accident.
+The correct parse is `(<assignment>) andthen 0`: the assignment binds first, and
+its assigned value drives the short-circuit, so the attribute/element keeps `1`
+while the statement's value is `0`.
+
+## Root cause
+
+The defect was in the expression precedence chain, not (as first suspected) in a
+statement-level fallback. `assign_not_expr_mode` parses a non-scalar lvalue's `=`
+RHS with `parse_assignment_rhs_mode`, which used `ternary_mode` per comma
+element. `ternary_mode` descends through `or_expr_no_assign_mode` /
+`and_expr_no_assign_mode`, which *include* the loose word-logicals — so the RHS
+absorbed the trailing `andthen 0`. (A bare scalar variable took a separate
+`item_expr` RHS path that already stopped before the word-logicals, which is why
+`$x = 7 andthen 0` was already correct.)
+
+## Fix
+
+`parse_assignment_rhs_mode` now parses each comma element with `list_infix_top`
+instead of `ternary_mode`. That layer sits *just below* the loose word-logicals:
+it still absorbs the list-infix operators (`Z`, `X`, their meta-ops, the sequence
+`...`, `minmax`, feed) so `@a[^3] = 1, 2 ... 10` keeps folding the whole comma
+list into one sequence, but it stops before `and`/`or`/`andthen`. The trailing
+word-logical is left in the stream for the enclosing `and`/`or` chain, which
+re-attaches it with the whole assignment as its left operand — evaluated exactly
+once, no subscript re-evaluation.
+
+The parenthesized / expression-context path for a subscripted lvalue
+(`(@a[0] = 8 andthen 0)`) reaches `try_parse_assign_expr` instead, whose indexed
+`=` branch parsed the RHS with the word-logical-inclusive `expression()`. It now
+parses the RHS with `expression_no_word_logical` and re-attaches the tail via a
+new `wrap_trailing_word_logical_expr` helper (the `IndexAssign` expression is the
+tail's left operand, since it yields the assigned value).
+
+Found while driving `HTTP::UserAgent` against a live server: `get-response` ends
+with `$response.content = $content andthen $response.content = $response.decoded-content(:$bin)`,
+which stored the wrong thing and surfaced as *"Type check failed for return
+value; expected Blob:D but got Any"* from `inflate-content`.
+
+Pin: `t/word-logical-lvalue-precedence.t`.

--- a/src/parser/expr/precedence/assign.rs
+++ b/src/parser/expr/precedence/assign.rs
@@ -361,7 +361,19 @@ pub(crate) fn list_lvalue_assign_expr(items: Vec<Expr>, rhs: Expr) -> Option<Exp
 }
 
 pub(crate) fn parse_assignment_rhs_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
-    let (rest, first) = ternary_mode(input, mode)?;
+    // Parse each comma element at the *list-infix* level (`list_infix_top`):
+    // everything tighter than the comma plus the list-infix operators (`Z`/`X`/
+    // their meta-ops, the sequence `...`, `minmax`, feed), so `@a[^3] = 1, 2 ... 10`
+    // still folds the whole comma list into one sequence. Crucially this stops
+    // BEFORE the loose word-logicals (`and`/`or`/`xor`/`andthen`/`orelse`/
+    // `notandthen`) — the loosest operators in Raku — so an assignment RHS never
+    // absorbs them: `@a[0] = 8 andthen 0` is `(@a[0] = 8) andthen 0`, not
+    // `@a[0] = (8 andthen 0)`. The trailing word-logical is left in the stream for
+    // the enclosing `and`/`or` chain, which re-attaches it with the whole
+    // assignment as its left operand. (`ternary_mode` used to be called here, but
+    // it wrongly folded the word-logical into the RHS, storing the tail value;
+    // see logic.rs `assign_not_expr_mode`.)
+    let (rest, first) = list_infix_top(input, mode)?;
     let (r, _) = ws(rest)?;
     if !r.starts_with(',') || r.starts_with(",,") {
         return Ok((rest, first));
@@ -375,7 +387,7 @@ pub(crate) fn parse_assignment_rhs_mode(input: &str, mode: ExprMode) -> PResult<
         if r2.is_empty() || r2.starts_with(';') || r2.starts_with('}') || r2.starts_with(')') {
             return Ok((r2, finalize_assignment_rhs_list(items)));
         }
-        let (r3, next) = ternary_mode(r2, mode)?;
+        let (r3, next) = list_infix_top(r2, mode)?;
         items.push(next);
         let (r3, _) = ws(r3)?;
         if !r3.starts_with(',') || r3.starts_with(",,") {

--- a/src/parser/stmt/assign/try_assign.rs
+++ b/src/parser/stmt/assign/try_assign.rs
@@ -146,24 +146,30 @@ pub(in crate::parser) fn try_parse_assign_expr(input: &str) -> PResult<'_, Expr>
                 &r_after[1..]
             };
             let (rest, _) = ws(r3)?;
+            // The loose word-logicals bind looser than item assignment, so in an
+            // expression / parenthesized context `(@a[0] = 8 andthen 0)` is
+            // `(@a[0] = 8) andthen 0`. Parse the RHS no-word-logical (a chained
+            // inner assignment via `try_parse_assign_expr` still handles
+            // `@a[0] = @b[0] := 5`) and re-attach the trailing `... and ...`
+            // seeded by the IndexAssign expression itself.
             let (rest, rhs) = match try_parse_assign_expr(rest) {
                 Ok(r) => r,
-                Err(_) => expression(rest)?,
+                Err(_) => expression_no_word_logical(rest)?,
             };
             let target = match sigil {
                 b'@' => Expr::ArrayVar(var.to_string()),
                 b'%' => Expr::HashVar(var.to_string()),
                 _ => Expr::Var(var.to_string()),
             };
-            return Ok((
-                rest,
-                Expr::IndexAssign {
-                    target: Box::new(target),
-                    index: Box::new(index_expr),
-                    value: Box::new(rhs),
-                    is_positional,
-                },
-            ));
+            let assigned = Expr::IndexAssign {
+                target: Box::new(target),
+                index: Box::new(index_expr),
+                value: Box::new(rhs),
+                is_positional,
+            };
+            return crate::parser::stmt::word_logical_split::wrap_trailing_word_logical_expr(
+                rest, assigned,
+            );
         }
         return Err(PError::expected("assignment expression"));
     }

--- a/src/parser/stmt/word_logical_split.rs
+++ b/src/parser/stmt/word_logical_split.rs
@@ -23,6 +23,26 @@ use crate::parser::expr::{starts_with_loose_word_logical, word_logical_tail_pub}
 use crate::parser::helpers::ws;
 use crate::parser::parse_result::PResult;
 
+/// Re-attach a trailing loose word-logical to a *non-variable-lvalue* assignment
+/// expression (`@a[i] = v`, `%h<k> = v`, ...) in expression / parenthesized
+/// context.
+///
+/// Unlike the statement-level [`wrap_trailing_word_logical`] — which re-reads the
+/// assigned variable to seed the tail — a subscripted-element assignment is an
+/// *expression* (`IndexAssign`) whose value is precisely the assigned value. So
+/// the assignment expression itself becomes the tail's left operand: it is
+/// evaluated exactly once (no subscript re-evaluation) and the boolean /
+/// definedness short-circuit and the `andthen`/`orelse` value pass-through match
+/// `(<assignment>) <op> ...`. Returns `assigned` unchanged when no loose
+/// word-logical follows.
+pub(crate) fn wrap_trailing_word_logical_expr(rest: &str, assigned: Expr) -> PResult<'_, Expr> {
+    let (r, _) = ws(rest)?;
+    if !starts_with_loose_word_logical(r) {
+        return Ok((rest, assigned));
+    }
+    word_logical_tail_pub(r, assigned)
+}
+
 /// The read expression for an assignment target's variable, used to re-read the
 /// just-assigned value as the left operand of the hoisted word-logical.
 /// `$x` is stored as `Var("x")`, `@a` as `ArrayVar("a")`, `%h` as `HashVar("h")`.

--- a/t/word-logical-lvalue-precedence.t
+++ b/t/word-logical-lvalue-precedence.t
@@ -1,0 +1,114 @@
+use Test;
+
+# The loose word-logicals (`and`/`or`/`xor`/`andthen`/`orelse`/`notandthen`) are
+# the LOOSEST infix operators — looser than item assignment (`=`). This is
+# already covered for a plain `$x`/`@a`/`%h` target in
+# t/word-logical-loosest-precedence.t. This file covers every *other* lvalue
+# shape (an attribute accessor, an indexed element, a hash key), which used to
+# swallow the operator into the RHS and store the wrong value:
+#
+#   $o.v = 1 andthen 0   stored 0 (the tail) instead of 1.
+#
+# The assignment binds first and its (assigned) value drives the short-circuit:
+# `($o.v = 1) andthen 0` runs `andthen 0` with the store already done, so the
+# attribute keeps `1` while the statement value is `0`.
+
+plan 19;
+
+class C { has $.v is rw }
+
+# --- method / attribute lvalue ---
+{
+    my $o = C.new;
+    $o.v = 1 andthen 0;
+    is $o.v, 1, '$o.v = 1 andthen 0 -> ($o.v = 1) andthen 0, attribute stays 1';
+}
+{
+    my $o = C.new;
+    $o.v = 5 or die "boom";
+    is $o.v, 5, '$o.v = 5 or die -> die never runs, attribute is 5';
+}
+{
+    my $o = C.new;
+    $o.v = 1 notandthen 99;
+    is $o.v, 1, '$o.v = 1 notandthen 99 -> attribute is 1';
+}
+
+# --- positional (array element) lvalue ---
+{
+    my @a;
+    @a[0] = 8 andthen 0;
+    is @a[0], 8, '@a[0] = 8 andthen 0 -> element stays 8';
+}
+{
+    my @a;
+    @a[0] = 5 orelse 9;
+    is @a[0], 5, '@a[0] = 5 orelse 9 -> element stays 5';
+}
+{
+    my @a;
+    @a[0] = 3 or die "boom";
+    is @a[0], 3, '@a[0] = 3 or die -> die never runs';
+}
+
+# --- associative (hash key) lvalue ---
+{
+    my %h;
+    %h<k> = 9 andthen 0;
+    is %h<k>, 9, '%h<k> = 9 andthen 0 -> key stays 9';
+}
+{
+    my %h;
+    %h{'k'} = 7 andthen 0;
+    is %h{'k'}, 7, '%h{k} = 7 andthen 0 -> key stays 7';
+}
+
+# --- the statement *value* is still the tail (word-logical wraps the whole assignment) ---
+{
+    my $o = C.new;
+    my $r = ($o.v = 5 andthen 0);
+    is $r, 0, 'the parenthesized expression value is the andthen tail (0)';
+    is $o.v, 5, '...but the attribute store still happened (5)';
+}
+{
+    my @a;
+    my $r = (@a[0] = 8 andthen 42);
+    is $r, 42, 'expression value is the andthen tail (42)';
+    is @a[0], 8, '...but the element store still happened (8)';
+}
+
+# --- these were always correct (short-circuit accident); keep them green ---
+{
+    my $o = C.new;
+    $o.v = 0 orelse 9;
+    is $o.v, 0, '$o.v = 0 orelse 9 -> 0 is defined, store is 0';
+}
+
+# --- other RHS forms must keep working under the new no-word-logical RHS parse ---
+{
+    my @a;
+    @a[0] = 1 ?? 8 !! 9;
+    is @a[0], 8, 'ternary RHS still binds inside the assignment';
+}
+{
+    my @a;
+    @a = 1, 2, 3 and 99;
+    is-deeply @a, [1, 2, 3], '@a = 1,2,3 and 99 -> (@a = 1,2,3) and 99';
+}
+{
+    my @a;
+    @a[0,1,2] = 1, 2 ... 10;
+    is-deeply @a, [1, 2, 3], 'sequence RHS still folds the whole comma list';
+}
+{
+    my @a = 10, 20;
+    @a[0] += 5 andthen 0;
+    is @a[0], 15, 'compound-assign element: (@a[0] += 5) andthen 0';
+}
+{
+    my @a;
+    my $u;
+    @a[0] = $u = 42;
+    is @a[0], 42, 'chained assignment through an element still works (element)';
+    is $u, 42, 'chained assignment through an element still works (scalar)';
+}


### PR DESCRIPTION
## Summary

The loose word-logicals (`and`/`or`/`xor`/`andthen`/`orelse`/`notandthen`) are the loosest infix operators in Raku — looser than item assignment `=`. A plain-variable target already respected this, but every *other* lvalue shape (an attribute accessor, an indexed array element, a hash key) swallowed the operator into the assignment RHS and stored the wrong value:

```raku
class C { has $.v is rw }
my $o = C.new; $o.v = 1 andthen 0;   say $o.v;   # was 0, now 1
my @a;         @a[0] = 8 andthen 0;  say @a[0];  # was 0, now 8
my %h;         %h<k> = 9 andthen 0;  say %h<k>;  # was 0, now 9
```

It stored the value of `(RHS op tail)`, so `and`/`andthen`/`notandthen` stored the tail (or `Nil`); `or`/`orelse` only looked right by short-circuit accident. The correct parse is `(<assignment>) andthen 0`: the assignment binds first and its assigned value drives the short-circuit, so the element keeps `1` while the statement value is `0`.

## Root cause

`assign_not_expr_mode` parses a non-scalar lvalue's `=` RHS with `parse_assignment_rhs_mode`, which used `ternary_mode` per comma element. `ternary_mode` descends through `or_expr_no_assign_mode`/`and_expr_no_assign_mode`, which **include** the loose word-logicals, so the RHS absorbed the trailing tail. (A bare scalar variable took a separate `item_expr` RHS path that already stopped before the word-logicals, which is why `$x = 7 andthen 0` was already correct.)

## Fix

- `parse_assignment_rhs_mode` now parses each comma element with `list_infix_top` instead of `ternary_mode`. That layer sits just below the loose word-logicals: it still absorbs the list-infix operators (`Z`/`X`/meta, the sequence `...`, `minmax`, feed) so `@a[^3] = 1, 2 ... 10` keeps folding the whole comma list into one sequence, but it stops before `and`/`or`/`andthen`. The trailing word-logical is left for the enclosing `and`/`or` chain, which re-attaches it with the whole assignment as its left operand.
- The parenthesized / expression-context path for a subscripted lvalue (`(@a[0] = 8 andthen 0)`) reaches `try_parse_assign_expr` instead; its indexed `=` branch now parses the RHS with `expression_no_word_logical` and re-attaches the tail via a new `wrap_trailing_word_logical_expr` helper.

Found while driving `HTTP::UserAgent` against a live server: `get-response` ends with `$response.content = $content andthen $response.content = $response.decoded-content(:$bin)`, which stored the wrong thing and surfaced as *"Type check failed for return value; expected Blob:D but got Any"* from `inflate-content`.

## Tests

- New pin `t/word-logical-lvalue-precedence.t` (19 cases: attribute / element / key targets × `and`/`or`/`andthen`/`orelse`/`notandthen`, plus expression-value, ternary/sequence/compound/chained RHS regressions).
- `make test` green; targeted roast (`S03-operators/{assign,andthen,short-circuit,precedence}`, `S03-sequence/basic`, `S03-metaops/{cross,zip}`, `S09-subscript/slice`, `S32-hash/slice`) green; clippy + fmt clean.

Also removes the now-closed PLAN.md leftover entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)