### PR TITLE
fix: Nil.abs / .floor / .ceiling / .round / .truncate / .sign numify to 0

### DIFF
--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -78,6 +78,13 @@ pub(crate) fn nil_absorbs_method(method: &str) -> bool {
             | "ords"
             | "chrs"
     )
+    // NOTE: the numify-to-0 Real methods (abs/floor/ceiling/round/truncate/sign)
+    // are deliberately NOT listed above. Their warn+resume handling lives only in
+    // the scalar `MethodCall` opcode path, not in `try_native_method`, so the
+    // hyper leaf (`».abs`) would raise "No such method" if it declined to absorb
+    // them. Absorbing to Nil in the hyper path keeps the pre-existing behavior
+    // (the same gap the Int/Rat/Num coercions above have for `(Nil,)».Int`);
+    // making the hyper path warn+resume is a separate follow-up.
 }
 
 impl Interpreter {
@@ -1504,6 +1511,22 @@ impl Interpreter {
                             };
                             let msg = "Use of Nil in numeric context".to_string();
                             return Err(RuntimeError::warn_signal_with_resume(msg, zero));
+                        }
+                        // Real methods that numify their invocant (`abs`, `floor`,
+                        // `ceiling`, `round`, `truncate`, `sign`) treat Nil as the
+                        // numeric zero: they warn "Use of Nil in numeric context"
+                        // and resume with the method applied to 0 — which is 0 (an
+                        // Int) for every one of these — instead of absorbing to Nil.
+                        // (`sqrt`/`exp`/`log` are `Cool:D`-only and error on Nil:U;
+                        // they stay in the Nil-absorbing catch-all — matching raku's
+                        // X::Multi::NoMatch is a separate follow-up.)
+                        "abs" | "floor" | "ceiling" | "round" | "truncate" | "sign"
+                            if args.is_empty() =>
+                        {
+                            return Err(RuntimeError::warn_signal_with_resume(
+                                "Use of Nil in numeric context".to_string(),
+                                Value::int(0),
+                            ));
                         }
                         // `Nil.ords` warns ("Use of Nil in string context") and
                         // resumes to an empty Seq; `Nil.chrs` warns and resumes

--- a/t/nil-numeric-method-zero.t
+++ b/t/nil-numeric-method-zero.t
@@ -1,0 +1,40 @@
+use v6;
+use Test;
+
+# The Real methods that numify their invocant (`abs`, `floor`, `ceiling`,
+# `round`, `truncate`, `sign`) treat Nil as the numeric zero: they warn "Use of
+# Nil in numeric context" and resume with the method applied to 0 — which is the
+# Int 0 for all of them — instead of absorbing to Nil. (This extends the same
+# treatment `Nil.Int` / `Nil.Num` / `Nil.Rat` already get.)
+
+is (quietly Nil.abs),      0, "Nil.abs is 0";
+is (quietly Nil.floor),    0, "Nil.floor is 0";
+is (quietly Nil.ceiling),  0, "Nil.ceiling is 0";
+is (quietly Nil.round),    0, "Nil.round is 0";
+is (quietly Nil.truncate), 0, "Nil.truncate is 0";
+is (quietly Nil.sign),     0, "Nil.sign is 0";
+
+# The zero is a defined Int, not a type object.
+is (quietly Nil.abs).^name,   "Int", "Nil.abs is an Int";
+ok (quietly Nil.abs).defined,        "Nil.abs is defined";
+
+# The coercion is a warning, not a hard failure — it resumes.
+{
+    my @warnings;
+    my $result = do {
+        CONTROL { when CX::Warn { @warnings.push(.message); .resume } }
+        Nil.abs;
+    };
+    is $result, 0, "Nil.abs resumes with 0";
+    ok @warnings.grep(*.contains("Nil")).elems >= 1, "Nil.abs warns about Nil in numeric context";
+}
+
+# Regression: a genuinely Nil-absorbing (unknown) method still returns Nil.
+is Nil.foo.gist, "Nil", "unknown method on Nil is still absorbed to Nil";
+
+# Regression: the numify methods still work on real numbers.
+is (-5).abs, 5, "abs on a real Int is unchanged";
+is 3.7.floor, 3, "floor on a real Rat is unchanged";
+is (-2).sign, -1, "sign on a real Int is unchanged";
+
+done-testing;


### PR DESCRIPTION
## Summary

The Real methods that numify their invocant — `abs`, `floor`, `ceiling`, `round`, `truncate`, `sign` — treat Nil as the numeric zero in raku: they warn "Use of Nil in numeric context" and resume with the method applied to 0 (the Int `0` for all six), instead of being absorbed to Nil.

```raku
Nil.abs      # was Nil -> now 0 (with "Use of Nil in numeric context" warning)
Nil.floor    # was Nil -> now 0
Nil.sign     # was Nil -> now 0
```

This extends the same treatment `Nil.Int` / `Nil.Num` / `Nil.Rat` already get.

## Fix

Add the six methods to the Nil-invocant warn+resume arm in the `MethodCall` opcode handler.

- `sqrt`/`exp`/`log` are `Cool:D`-only and error on `Nil:U` in raku (`X::Multi::NoMatch`); they stay Nil-absorbing here — a separate follow-up.
- The hyper leaf (`(Nil,)».abs`) keeps absorbing to Nil rather than warn+resume, because that path dispatches through `try_native_method`, which does not carry the Nil numeric handling — the same pre-existing gap `(Nil,)».Int` has. Left as a documented follow-up on `nil_absorbs_method`.

## Test

Pin: `t/nil-numeric-method-zero.t` (14 subtests, raku green). `make test` PASS, roast `S02-types/nil.t` + `S32-num/abs.t` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)