### PR TITLE
fix: a %-sigil attribute coerces an empty (or flat) list init to a Hash

### DIFF
--- a/src/runtime/methods_signature.rs
+++ b/src/runtime/methods_signature.rs
@@ -148,27 +148,25 @@ impl Interpreter {
                     map.insert(Value::hash_key_encode(k), v.clone());
                     Value::hash(map)
                 }
+                // A list coerces to a Hash exactly like `my %h = list`: Pairs
+                // flatten, bare elements pair up `key => value`, and an *empty*
+                // list yields an empty Hash (previously a no-pair / empty list
+                // was kept as an Array, so `%!attr<k>` then died "does not
+                // support associative indexing" — surfaced by HTTP::MediaType's
+                // `has %.parameters` when a media type carried no parameters).
+                // An odd non-pair count raku-throws "Odd number of elements";
+                // `coerce_attr_value_by_sigil` cannot throw, so keep the raw
+                // value on that error and let a later type check report it.
                 ValueView::Array(arr, _) => {
-                    // Convert array of pairs to hash
-                    let mut map = HashMap::new();
-                    let mut has_pairs = false;
-                    for item in arr.iter() {
-                        match item.view() {
-                            ValueView::Pair(k, v) => {
-                                map.insert(k.clone(), v.clone());
-                                has_pairs = true;
-                            }
-                            ValueView::ValuePair(k, v) => {
-                                map.insert(Value::hash_key_encode(k), v.clone());
-                                has_pairs = true;
-                            }
-                            _ => {}
-                        }
+                    match crate::runtime::utils::build_hash_from_items(arr.to_vec()) {
+                        Ok(h) => h,
+                        Err(_) => val.clone(),
                     }
-                    if has_pairs {
-                        Value::hash(map)
-                    } else {
-                        val.clone()
+                }
+                ValueView::Slip(items) => {
+                    match crate::runtime::utils::build_hash_from_items(items.to_vec()) {
+                        Ok(h) => h,
+                        Err(_) => val.clone(),
                     }
                 }
                 _ => val.clone(),

--- a/t/attr-empty-list-hash-coercion.t
+++ b/t/attr-empty-list-hash-coercion.t
@@ -1,0 +1,41 @@
+use v6;
+use Test;
+
+# A `%`-sigil attribute must coerce its init value to a Hash exactly like
+# `my %h = <value>`. Non-empty pair lists already coerced, but an *empty* list
+# (or `Empty`) was kept as a List/Slip, so a later `%!attr<key>` died with
+# "Type Array does not support associative indexing". This surfaced from
+# HTTP::MediaType's `has %.parameters` when a media type carried no parameters
+# (`text/html` with no `; charset=...`).
+
+plan 12;
+
+class C { has %.parameters; }
+
+# --- empty list / Empty / default all yield an (indexable) empty Hash ---
+my $a = C.new(parameters => ());
+ok $a.parameters ~~ Hash, 'empty-list %-attr init is a Hash';
+is $a.parameters.elems, 0, '...and it is empty';
+is ($a.parameters<charset> // 'undef'), 'undef', '...and associative indexing works';
+
+my $b = C.new(parameters => Empty);
+ok $b.parameters ~~ Hash, 'Empty %-attr init is a Hash';
+is ($b.parameters<charset> // 'undef'), 'undef', 'Empty %-attr indexes fine';
+
+my $d = C.new;
+ok $d.parameters ~~ Hash, 'defaulted %-attr is a Hash';
+is ($d.parameters<charset> // 'undef'), 'undef', 'defaulted %-attr indexes fine';
+
+# --- a non-pair even list pairs up key => value, like `my %h = 1,2,3,4` ---
+my $e = C.new(parameters => (1, 2, 3, 4));
+ok $e.parameters ~~ Hash, 'flat even list %-attr is a Hash';
+is $e.parameters<1>, 2, 'alternating list pairs key=>value (1 => 2)';
+is $e.parameters<3>, 4, 'alternating list pairs key=>value (3 => 4)';
+
+# --- a pair list still coerces (unchanged) ---
+my $f = C.new(parameters => (charset => 'utf-8'));
+is $f.parameters<charset>, 'utf-8', 'pair-list %-attr still coerces';
+
+# --- the @-sigil sibling was already correct; keep it green ---
+class D { has @.a; }
+ok D.new(a => ()).a ~~ Array, 'empty-list @-attr is an Array';


### PR DESCRIPTION
## Summary

`coerce_attr_value_by_sigil` turned a `%`-attribute's init value into a `Hash` only when the value was a `Pair` or an array that *contained* at least one `Pair`. An empty list (`parameters => ()`), an `Empty`/`Slip`, or a flat non-pair list was kept verbatim as a `List`/`Slip`/`Array`, so a later `%!attr<key>` died with *"Type Array does not support associative indexing"*.

```raku
class C { has %.parameters }
C.new(parameters => ()).parameters<charset>   # was: dies; now: (Any)
C.new(parameters => ()).parameters.^name      # was: List; now: Hash
```

This surfaced from `HTTP::MediaType`'s `has %.parameters` while driving `HTTP::UserAgent` against a live server: a media type with no parameters (`text/html` with no `; charset=...`) left `%.parameters` an empty `List`, and the `charset` accessor's `%!parameters<charset>` then blew up.

## Fix

Route the `%` case through `build_hash_from_items`, which implements the full `my %h = list` semantics: Pairs flatten, bare elements pair up `key => value`, and an empty list yields an empty `Hash`. `Slip` (`Empty`) is routed the same way. An odd non-pair count raku-throws *"Odd number of elements"*; since `coerce_attr_value_by_sigil` returns a plain `Value` and cannot throw, the raw value is kept on that error so a later type check reports it (no worse than before).

```
()          -> Hash {}
Empty       -> Hash {}
(1,2,3,4)   -> Hash {"1"=>2, "3"=>4}   # matches raku
(charset => 'utf-8') -> Hash {charset => utf-8}   # unchanged
```

The `@`-sigil sibling already coerced an empty list to `Array` correctly and is unchanged.

## Tests

- New pin `t/attr-empty-list-hash-coercion.t` (12 cases).
- Related suites green: `t/bless-hash-attr-coercion.t`, `t/attr-array-hash-whole-assign.t`; roast `S12-attributes/instance`, `S12-construction/new`, `S02-types/hash`. clippy + fmt clean.

Part of the HTTP::UserAgent bring-up (bug-chain surfaced by driving a live request); follows #5357 (bare `'` in regex word list) and #5359 (word-logical vs non-variable lvalue precedence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)