### PR TITLE
fix: an indirect method-call lvalue writes through the rw accessor

### DIFF
--- a/news/2026-07/indirect-method-call-lvalue.md
+++ b/news/2026-07/indirect-method-call-lvalue.md
@@ -1,0 +1,35 @@
+# Indirect method-call lvalue assignment writes through the accessor
+
+An indirect (quoted or interpolated) method call used as an assignment target —
+`$o."$name"() = value` — now writes back through the object's `is rw` accessor,
+exactly like the literal form `$o.attr = value`. Previously it threw
+`Cannot modify an immutable value (cannot assign through non-callable value)`.
+
+## Root cause
+
+The assignment lowering distinguished a literal method-call lvalue
+(`Expr::MethodCall`, routed to the `__mutsu_assign_method_lvalue` rw-accessor
+writeback) from a callable lvalue (`$code() = v`, routed to
+`__mutsu_assign_callable_lvalue`). An indirect method call parses to a distinct
+`Expr::DynamicMethodCall`, which had no arm in the three assignment-target
+dispatchers (`lvalue_assign_to_expr`, `assign_to_target_expr`, and the
+expression-position handler in `logic.rs`), so it fell through to the
+callable-lvalue path. At runtime the `DynamicMethodCall` was evaluated to the
+accessor's *current value* — not a `Callable` — and the writeback raised
+"cannot assign through non-callable value".
+
+## Fix
+
+A shared `dynamic_method_lvalue_assign_expr` helper lowers a `DynamicMethodCall`
+lvalue to the same `__mutsu_assign_method_lvalue` writeback as the literal form,
+but passes the method-name *expression* (which evaluates eagerly to the name
+string) instead of a literal. A private indirect call (`$o!"$name"() = v`,
+`modifier: Some('!')`) prefixes `!` so it dispatches to the private accessor.
+All three dispatch sites gained a `DynamicMethodCall` arm.
+
+## Surfaced by
+
+HTTP::UserAgent's `HTTP::Cookies` grammar action assigns cookie attributes via a
+computed accessor name: `$h."{$a<name>.lc}"() = ~$a<value>`. This made
+`HTTP::Cookies.set-cookie` abort, and the upstream `t/030-cookies.rakutest`
+suite now passes in full. Pinned by `t/indirect-method-call-lvalue.t`.

--- a/src/parser/expr/precedence/assign.rs
+++ b/src/parser/expr/precedence/assign.rs
@@ -105,6 +105,33 @@ pub(crate) fn assign_to_target_expr(target: Expr, value: Expr) -> Expr {
                 )
             }
         }
+        // An indirect method-call lvalue (`$o."$name"() = v`) in expression
+        // position, e.g. the middle term of a chained assignment. Mirror the
+        // `MethodCall` arm but with a runtime-computed name (see
+        // `dynamic_method_lvalue_assign_expr`).
+        Expr::DynamicMethodCall {
+            target,
+            name_expr,
+            args,
+            modifier,
+        } => {
+            let target_var_name = match target.as_ref() {
+                Expr::Var(v) => Some(v.clone()),
+                Expr::ArrayVar(v) => Some(format!("@{}", v)),
+                Expr::HashVar(v) => Some(format!("%{}", v)),
+                Expr::BareWord(v) => Some(v.clone()),
+                Expr::DoStmt(s) => crate::parser::stmt::simple_expr_stmt::decl_target_var_name(s),
+                _ => None,
+            };
+            crate::parser::stmt::assign::dynamic_method_lvalue_assign_expr(
+                *target,
+                target_var_name,
+                *name_expr,
+                modifier,
+                args,
+                value,
+            )
+        }
         Expr::Call { name, args } => Expr::Call {
             name: Symbol::intern("__mutsu_assign_named_sub_lvalue"),
             args: vec![

--- a/src/parser/expr/precedence/logic.rs
+++ b/src/parser/expr/precedence/logic.rs
@@ -571,6 +571,10 @@ pub(crate) fn assign_not_expr_mode(input: &str, mode: ExprMode) -> PResult<'_, E
                 Ok((r, assign_to_target_expr(mc, rhs)))
             }
         }
+        // An indirect method-call lvalue (`$o."$name"() = v`) in expression
+        // position: route through the shared lowering (which has a
+        // `DynamicMethodCall` arm) instead of leaving `=` unconsumed.
+        dmc @ Expr::DynamicMethodCall { .. } => Ok((r, assign_to_target_expr(dmc, rhs))),
         _ => Ok((rest, expr)),
     }
 }

--- a/src/parser/stmt/assign.rs
+++ b/src/parser/stmt/assign.rs
@@ -87,8 +87,8 @@ pub(crate) use compound_expr::{
     build_compound_assign_expr, build_custom_compound_assign_expr, build_meta_assign_expr,
 };
 pub(crate) use lvalue::{
-    callable_lvalue_assign_expr, list_lvalue_assign_expr, method_lvalue_assign_expr,
-    named_sub_lvalue_assign_expr, subscript_adverb_lvalue_assign_expr,
+    callable_lvalue_assign_expr, dynamic_method_lvalue_assign_expr, list_lvalue_assign_expr,
+    method_lvalue_assign_expr, named_sub_lvalue_assign_expr, subscript_adverb_lvalue_assign_expr,
 };
 pub(crate) use op::{
     compound_assign_op_from_name, compound_assigned_value_expr, parse_compound_assign_op,

--- a/src/parser/stmt/assign/lvalue.rs
+++ b/src/parser/stmt/assign/lvalue.rs
@@ -31,6 +31,46 @@ pub(crate) fn method_lvalue_assign_expr(
     }
 }
 
+/// Lower an assignment whose lvalue is an indirect method call
+/// (`$o."$name"() = value`) to the same rw-accessor writeback as a literal
+/// method-call lvalue, but with the method name computed at runtime. The name
+/// expression is passed as `__mutsu_assign_method_lvalue`'s method-name argument
+/// (evaluated eagerly to a string), so `$o."x"() = v` writes through the `x`
+/// accessor exactly like `$o.x = v`. A private indirect call (`$o!"$name"()`,
+/// `modifier: Some('!')`) prefixes `!` so it dispatches to the private accessor.
+pub(crate) fn dynamic_method_lvalue_assign_expr(
+    target: Expr,
+    target_var_name: Option<String>,
+    name_expr: Expr,
+    modifier: Option<char>,
+    method_args: Vec<Expr>,
+    value: Expr,
+) -> Expr {
+    let name_expr = if modifier == Some('!') {
+        Expr::Binary {
+            left: Box::new(Expr::Literal(Value::str_from("!"))),
+            op: crate::token_kind::TokenKind::Tilde,
+            right: Box::new(name_expr),
+        }
+    } else {
+        name_expr
+    };
+    let args = vec![
+        target,
+        name_expr,
+        Expr::ArrayLiteral(method_args),
+        value,
+        match target_var_name {
+            Some(name) => Expr::Literal(Value::str(name)),
+            None => Expr::Literal(Value::NIL),
+        },
+    ];
+    Expr::Call {
+        name: Symbol::intern("__mutsu_assign_method_lvalue"),
+        args,
+    }
+}
+
 pub(crate) fn named_sub_lvalue_assign_expr(
     name: String,
     call_args: Vec<Expr>,

--- a/src/parser/stmt/simple_expr_stmt/core.rs
+++ b/src/parser/stmt/simple_expr_stmt/core.rs
@@ -67,6 +67,33 @@ fn lvalue_assign_to_expr(lvalue: Expr, rhs: Expr) -> Expr {
                 method_lvalue_assign_expr(*target, target_var_name, method_name, args, rhs)
             }
         }
+        // An indirect method-call lvalue (`$o."$name"() = v` — an rw accessor
+        // whose name is computed at runtime). Mirror the `MethodCall` arm above but
+        // pass the name expression through instead of a literal, so it writes back
+        // through the accessor rather than being mis-lowered to a callable lvalue
+        // (which threw "cannot assign through non-callable value").
+        Expr::DynamicMethodCall {
+            target,
+            name_expr,
+            args,
+            modifier,
+        } => {
+            let target_var_name = match target.as_ref() {
+                Expr::Var(v) => Some(v.clone()),
+                Expr::ArrayVar(v) => Some(format!("@{}", v)),
+                Expr::HashVar(v) => Some(format!("%{}", v)),
+                Expr::DoStmt(s) => decl_target_var_name(s),
+                _ => None,
+            };
+            crate::parser::stmt::assign::dynamic_method_lvalue_assign_expr(
+                *target,
+                target_var_name,
+                *name_expr,
+                modifier,
+                args,
+                rhs,
+            )
+        }
         Expr::Call { name, args } => named_sub_lvalue_assign_expr(name.resolve(), args, rhs),
         Expr::CallOn { target, args } => callable_lvalue_assign_expr(*target, args, rhs),
         other => callable_lvalue_assign_expr(other, Vec::new(), rhs),

--- a/t/indirect-method-call-lvalue.t
+++ b/t/indirect-method-call-lvalue.t
@@ -1,0 +1,53 @@
+use Test;
+
+# An indirect (quoted / interpolated) method call used as an assignment lvalue
+# must write back through the rw accessor, exactly like a literal method-call
+# lvalue (`$o.attr = v`). Previously `$o."$name"() = v` was mis-lowered to a
+# callable lvalue and threw "cannot assign through non-callable value".
+# Surfaced by HTTP::UserAgent's HTTP::Cookies grammar action
+# (`$h."{$a<name>.lc}"() = ~$a<value>`).
+
+plan 9;
+
+class Attr {
+    has $.x is rw;
+    has $.y is rw;
+    has $.path is rw;
+    has $.domain is rw;
+}
+
+# Interpolated variable name.
+my $o = Attr.new;
+my $m = "x";
+$o."$m"() = 2;
+is $o.x, 2, 'interpolated $var method name writes through accessor';
+
+# Quoted static name.
+$o."y"() = 7;
+is $o.y, 7, 'quoted static method name writes through accessor';
+
+# Block interpolation in the method name.
+$o."{ "x" }"() = 42;
+is $o.x, 42, 'block-interpolated method name writes through accessor';
+
+# The exact HTTP::Cookies shape: computed name inside a loop.
+my $c = Attr.new;
+for <path domain> -> $n {
+    $c."{$n}"() = "val-$n";
+}
+is $c.path, 'val-path', 'loop with computed name (1/2)';
+is $c.domain, 'val-domain', 'loop with computed name (2/2)';
+
+# Chained assignment whose middle term is an indirect method-call lvalue.
+my $r = ($c."path"() = "chained");
+is $r, 'chained', 'chained assignment returns the assigned value';
+is $c.path, 'chained', 'chained assignment writes through accessor';
+
+# A read of the indirect accessor still works (rvalue position unaffected).
+is $o."$m"(), 42, 'indirect method call as rvalue reads the accessor';
+
+# The literal form keeps working alongside the dynamic form.
+$o.x = 99;
+is $o.x, 99, 'literal method-call lvalue still works';
+
+# vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
## Summary

`$o."$name"() = value` (a quoted or interpolated method call used as an
assignment target) now writes back through the object's `is rw` accessor,
exactly like the literal `$o.attr = value`. Previously it threw
`Cannot modify an immutable value (cannot assign through non-callable value)`.

## Root cause

The assignment lowering routed a literal method-call lvalue (`Expr::MethodCall`)
to the `__mutsu_assign_method_lvalue` rw-accessor writeback, but an indirect call
parses to `Expr::DynamicMethodCall`, which had **no arm** in the three
assignment-target dispatchers (`lvalue_assign_to_expr`, `assign_to_target_expr`,
and the expression-position handler in `logic.rs`), so it fell through to the
callable-lvalue path (`$code() = v`). At runtime the `DynamicMethodCall` was
evaluated to the accessor's *current value* — not a `Callable` — and the
writeback raised the RO error.

## Fix

A shared `dynamic_method_lvalue_assign_expr` helper lowers a `DynamicMethodCall`
lvalue to the same `__mutsu_assign_method_lvalue` writeback as the literal form,
passing the method-name *expression* (evaluated eagerly to the name string)
instead of a literal. A private indirect call (`$o!"$name"()`) prefixes `!`.
All three dispatch sites gained a `DynamicMethodCall` arm.

## Surfaced by

HTTP::UserAgent's `HTTP::Cookies` grammar action assigns cookie attributes via a
computed accessor name: `$h."{$a<name>.lc}"() = ~$a<value>`. This made
`HTTP::Cookies.set-cookie` abort; the upstream `t/030-cookies.rakutest` suite now
passes in full.

## Test

- `t/indirect-method-call-lvalue.t` (interpolated/quoted/block-interp names, loop
  with computed name, chained assignment, rvalue read, literal form still works)
- `make test` green, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)