### PR TITLE
feat: gate releases on the bundled libraries' upstream test suites

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,8 +103,39 @@ jobs:
           name: mutsu-${{ matrix.archive_name }}
           path: mutsu-${{ github.ref_name }}-${{ matrix.archive_name }}.tar.gz
 
+  # Release-time gate: every bundled library's upstream test suite must still
+  # pass (at its recorded baseline) against the SHIPPED library + this mutsu.
+  # This is the deliberate, thorough check that replaces continuous tagpr churn
+  # (tagpr is now manual-only). A regression here blocks the release publish.
+  # See scripts/battery-testsuite.sh, batteries.lock, batteries-whitelist.txt.
+  batteries:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@1.96.0
+
+      - name: Cache cargo (rust-cache)
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: x86_64-unknown-linux-gnu
+
+      # libpcre2 for building mutsu; libssl for the OpenSSL / IO::Socket::SSL
+      # batteries' NativeCall at runtime.
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libpcre2-dev libssl-dev
+
+      - name: Build release mutsu
+        run: cargo build --release --bin mutsu
+
+      - name: Run bundled-library test suites
+        env:
+          MUTSU_BIN: target/release/mutsu
+        run: scripts/battery-testsuite.sh
+
   release:
-    needs: build
+    needs: [build, batteries]
     runs-on: ubuntu-latest
     # Only publish a GitHub Release for a real tag push. workflow_dispatch runs
     # stop after build (artifacts are available for inspection, no release).

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,20 +1,23 @@
 name: tagpr
 
-# tagpr has no knob to throttle how often it refreshes the release PR: on a
-# `push: main` trigger it rewrites `tagpr-from-v*` after every single merge.
-# This repo lands many small PRs per hour, so that meant a tagpr job (and,
-# before the `tagpr-from-` skip in ci.yml, a full CI run) per merge, all to
-# restate the same pending CHANGELOG. Run it on a schedule instead — the
-# release PR is only ever consumed at release time, so being up to an hour
-# behind costs nothing.
+# tagpr is a MANUAL step: it runs only on `workflow_dispatch`.
 #
-# NOTE: tagpr also creates the tag/GitHub Release when the release PR is
-# merged, and it can only notice that on its next run. After merging a release
-# PR, kick it immediately rather than waiting for the hour:
+# Rationale: cutting a release is now a deliberate, gated act (see release.yml's
+# `batteries` job, which verifies every bundled library's upstream test suite
+# still passes under mutsu before a tag can publish). The release PR is only ever
+# consumed at release time, so there is no value in continuously refreshing it —
+# a `push: main` trigger rewrote `tagpr-from-v*` after every merge (dozens/day),
+# and even the hourly `schedule` was churn for a PR nobody reads between releases.
+# Kick tagpr by hand when you actually intend to release:
 #     gh workflow run tagpr.yml
+#
+# tagpr does two things, both on this same manual run:
+#   1. Before release: (re)opens/updates the release PR with the pending
+#      CHANGELOG and version bump. Run it once to refresh, review, merge.
+#   2. After the release PR merges: creates the tag + GitHub Release (which then
+#      triggers release.yml). tagpr only notices the merge on its NEXT run, so
+#      run `gh workflow run tagpr.yml` again right after merging the release PR.
 on:
-  schedule:
-    - cron: "17 * * * *"
   workflow_dispatch:
 
 permissions:

--- a/BATTERIES.md
+++ b/BATTERIES.md
@@ -109,10 +109,27 @@ imported. The recipe, kept in the library's `docs/batteries/<lib>.md`, states:
    [bundle index](#7-bundle-index).
 4. **Verification** — the smoke test to re-run after the bump (`use` the module +
    a representative call), so a bad bump is caught.
+5. **Re-baseline the test-suite gate** — bump the library's `commit` in
+   `batteries.lock` to the matching upstream commit and re-run
+   `scripts/battery-testsuite.sh --update`, then **review the
+   `batteries-whitelist.txt` diff**. A test file that dropped out of the
+   whitelist is a regression to fix, not a smaller baseline to accept.
 
 Vendored sources are **never hand-edited**; an update is always a clean re-vendor
 of a new upstream release. If mutsu needs a change to run the module, that change
 goes in the interpreter (rung 2), not in the vendored copy.
+
+### Release-time verification: the bundled-library test-suite gate
+
+Upstream test suites are excluded from the vendored copy (above), so "does the
+shipped library actually run under this mutsu?" is verified **at release time**:
+`release.yml`'s `batteries` job fetches every battery's upstream suite at the
+commit pinned in `batteries.lock`, runs it against the *bundled* library and the
+release `mutsu`, and blocks the publish job if any file listed in
+`batteries-whitelist.txt` regressed. It is a per-file baseline (the
+`roast-whitelist.txt` philosophy), not an all-green wall, so suites with known
+gaps still pin their passing files. Full details:
+[docs/batteries/testsuite-gate.md](docs/batteries/testsuite-gate.md).
 
 ## 4. License policy
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -125,6 +125,27 @@ section.
       output match). External dists are either `zef fetch`ed in CI or vendored. Failures are
       report-only (a red run does not stop main). Once the bundle set is fixed, its smoke tests
       become the battery quality gate as-is.
+- [ ] **★ Close the bundled-library test-suite gaps — target: green before the next release**
+      (user policy 2026-07-24). The release-time gate now runs every battery's upstream suite
+      against the shipped library (`scripts/battery-testsuite.sh`, `batteries.lock`,
+      `batteries-whitelist.txt`; see [docs/batteries/testsuite-gate.md](docs/batteries/testsuite-gate.md)),
+      but it is a **baseline** gate, and the measured baseline is only **11/18 test files**. The
+      goal is to raise that toward all-green so a release ships batteries that genuinely pass their
+      own suites — the gate stops regressions, it does not close these gaps:
+      - **OpenSSL — 2/7** (`01-basic`, `03-rsa`, `04-crypt`, `05-digest`, `10-client-ca-file` fail).
+        All five emit their TAP plan and then go silent with **zero** test lines, i.e. something
+        dies right after `plan`; the suites are NativeCall-heavy (RSA / EVP digest / cipher), so the
+        prime suspect is missing NativeCall surface rather than five unrelated bugs. Investigate one
+        (`05-digest`, 0/24) and the cause likely explains the rest.
+      - **Zef — 8/10** (`00-load` 1/2, `distribution-depends-parsing` 18/35). ★ This **contradicts
+        the recorded "all 10 upstream tests pass" (2026-07-10, #4383/#4384)**. Not yet triaged:
+        either a real regression since then, or a run-context difference (the gate runs
+        `mutsu -I vendor/zef/lib <test>` directly, whereas the 2026-07-10 result came from the full
+        mzef/install context). **Determine which before assuming a regression** — if it is context,
+        the gate's invocation may need to match how zef actually runs its own tests.
+      - **IO::Socket::SSL — 1/1** ✅ already green.
+      Raising a file into the baseline is `scripts/battery-testsuite.sh --update` + committing the
+      whitelist diff.
 
 ### B2. mzef — an `mzef` package manager bundling the real Zef (north-star; user policy 2026-06-28)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -132,22 +132,28 @@ section.
       but it is a **baseline** gate, and the measured baseline is only **11/18 test files**. The
       goal is to raise that toward all-green so a release ships batteries that genuinely pass their
       own suites — the gate stops regressions, it does not close these gaps:
-      - **OpenSSL — 2/7** (`01-basic`, `03-rsa`, `04-crypt`, `05-digest`, `10-client-ca-file` fail).
-        All five emit their TAP plan and then produce **zero** test lines, but they split into two
-        distinct shapes (measured from CI run 30075859520 timings, reproduced identically locally):
-        - `05-digest` (0/24) **hangs** — it burns the harness's full 120 s `timeout`. A hang, not a
-          die: investigate as a blocking/looping NativeCall call, not as a thrown exception.
-        - `01-basic` (2/7), `03-rsa` (1/8), `04-crypt` (1/13), `10-client-ca-file` (2/7) **stop
-          immediately** (0.04–0.9 s), i.e. something dies right after the last test they manage.
-        The suites are NativeCall-heavy (RSA / EVP digest / cipher), so missing NativeCall surface
-        is the prime suspect for the fast-failing four, and they likely share one cause. Treat the
-        `05-digest` hang as a separate investigation.
+      - **OpenSSL — 2/7**. Measured shapes (release build, run from the suite's own checkout):
+        `01-basic` 2/7 die (0.1 s) · `03-rsa` 1/8 **hang** · `04-crypt` 1/13 die (0.0 s) ·
+        `05-digest` 0/24 **hang** · `10-client-ca-file` 2/7 **SIGSEGV** (exit 139, 1.2 s).
+        ★ **Root cause of both hangs is found and is ONE general mutsu bug — multi-dispatch picks a
+        coercion candidate over an exact type match.** Minimal repro:
+        ```raku
+        my proto sub f(|) {*}
+        my multi sub f(Str() $s)   { "str"  }
+        my multi sub f(Blob:D $b)  { "blob" }
+        say f("abc".encode);   # raku: blob   mutsu: str   <-- wrong
+        ```
+        `Str()` (a coercion type, which accepts anything coercible) must rank **less specific** than
+        an exact `Blob:D` match. `OpenSSL::Digest` declares exactly this shape, and its `Str()`
+        candidate delegates with `md5 $string.encode` — so in mutsu the Blob re-enters the `Str()`
+        candidate and it is **infinite mutual recursion**, i.e. the hang. Fixing the ranking should
+        close `05-digest` (0/24) and `03-rsa` (1/8, `.sign` → `sha1`) together. Beware blast radius:
+        this is core dispatch ranking (cf. the earlier specificity fix #4967).
+        The `10-client-ca-file` **segfault** is a separate, higher-priority defect (project rule:
+        panics/crashes first), as are the two fast dies.
         ★ Already ruled out: a *harness* artifact. These suites reach for fixtures by relative path
         (`slurp 't/key.pem'`), so the harness now runs each test with its own repo as the working
-        directory. That moved `03-rsa` from 0/8 to 1/8 — real, but it did not flip any file to
-        passing, so the remaining failures are genuine mutsu gaps, not miscounts. A good entry
-        point is `03-rsa`: `OpenSSL::RSAKey.new(private-pem => ...)` now succeeds and the very next
-        call, `.sign($data.encode)`, is where it dies.
+        directory. That moved `03-rsa` from 0/8 to 1/8 — real, but it flipped no file to passing.
       - **Zef — 8/10** (`00-load` 1/2, `distribution-depends-parsing` 18/35). ★ This **contradicts
         the recorded "all 10 upstream tests pass" (2026-07-10, #4383/#4384)**. Not yet triaged:
         either a real regression since then, or a run-context difference (the gate runs

--- a/PLAN.md
+++ b/PLAN.md
@@ -133,10 +133,15 @@ section.
       goal is to raise that toward all-green so a release ships batteries that genuinely pass their
       own suites — the gate stops regressions, it does not close these gaps:
       - **OpenSSL — 2/7** (`01-basic`, `03-rsa`, `04-crypt`, `05-digest`, `10-client-ca-file` fail).
-        All five emit their TAP plan and then go silent with **zero** test lines, i.e. something
-        dies right after `plan`; the suites are NativeCall-heavy (RSA / EVP digest / cipher), so the
-        prime suspect is missing NativeCall surface rather than five unrelated bugs. Investigate one
-        (`05-digest`, 0/24) and the cause likely explains the rest.
+        All five emit their TAP plan and then produce **zero** test lines, but they split into two
+        distinct shapes (measured from CI run 30075859520 timings, reproduced identically locally):
+        - `05-digest` (0/24) **hangs** — it burns the harness's full 120 s `timeout`. A hang, not a
+          die: investigate as a blocking/looping NativeCall call, not as a thrown exception.
+        - `01-basic` (2/7), `03-rsa` (0/8), `04-crypt` (1/13), `10-client-ca-file` (2/7) **stop
+          immediately** (0.04–0.9 s), i.e. something dies right after `plan`.
+        The suites are NativeCall-heavy (RSA / EVP digest / cipher), so missing NativeCall surface
+        is the prime suspect for the fast-failing four, and they likely share one cause. Treat the
+        `05-digest` hang as a separate investigation.
       - **Zef — 8/10** (`00-load` 1/2, `distribution-depends-parsing` 18/35). ★ This **contradicts
         the recorded "all 10 upstream tests pass" (2026-07-10, #4383/#4384)**. Not yet triaged:
         either a real regression since then, or a run-context difference (the gate runs

--- a/PLAN.md
+++ b/PLAN.md
@@ -137,11 +137,17 @@ section.
         distinct shapes (measured from CI run 30075859520 timings, reproduced identically locally):
         - `05-digest` (0/24) **hangs** — it burns the harness's full 120 s `timeout`. A hang, not a
           die: investigate as a blocking/looping NativeCall call, not as a thrown exception.
-        - `01-basic` (2/7), `03-rsa` (0/8), `04-crypt` (1/13), `10-client-ca-file` (2/7) **stop
-          immediately** (0.04–0.9 s), i.e. something dies right after `plan`.
+        - `01-basic` (2/7), `03-rsa` (1/8), `04-crypt` (1/13), `10-client-ca-file` (2/7) **stop
+          immediately** (0.04–0.9 s), i.e. something dies right after the last test they manage.
         The suites are NativeCall-heavy (RSA / EVP digest / cipher), so missing NativeCall surface
         is the prime suspect for the fast-failing four, and they likely share one cause. Treat the
         `05-digest` hang as a separate investigation.
+        ★ Already ruled out: a *harness* artifact. These suites reach for fixtures by relative path
+        (`slurp 't/key.pem'`), so the harness now runs each test with its own repo as the working
+        directory. That moved `03-rsa` from 0/8 to 1/8 — real, but it did not flip any file to
+        passing, so the remaining failures are genuine mutsu gaps, not miscounts. A good entry
+        point is `03-rsa`: `OpenSSL::RSAKey.new(private-pem => ...)` now succeeds and the very next
+        call, `.sign($data.encode)`, is where it dies.
       - **Zef — 8/10** (`00-load` 1/2, `distribution-depends-parsing` 18/35). ★ This **contradicts
         the recorded "all 10 upstream tests pass" (2026-07-10, #4383/#4384)**. Not yet triaged:
         either a real regression since then, or a run-context difference (the gate runs

--- a/batteries-whitelist.txt
+++ b/batteries-whitelist.txt
@@ -1,0 +1,11 @@
+IO::Socket::SSL	01-basic.rakutest
+OpenSSL	06-digest-md5.rakutest
+OpenSSL	07-version.rakutest
+zef	build.rakutest
+zef	extract.rakutest
+zef	fetch.rakutest
+zef	identity.rakutest
+zef	install.rakutest
+zef	repository.rakutest
+zef	test.rakutest
+zef	utils-filesystem.rakutest

--- a/batteries.lock
+++ b/batteries.lock
@@ -1,0 +1,28 @@
+# Bundled runtime libraries ("batteries") — upstream test-suite provenance.
+#
+# mutsu ships these libraries verbatim (see BATTERIES.md and vendor/README.md).
+# Their upstream test suites are NOT vendored (BATTERIES.md §3), so the
+# release-time gate (scripts/battery-testsuite.sh, run by release.yml's
+# `batteries` job) fetches each suite fresh at the pinned commit below and runs
+# it against the BUNDLED library + the release `mutsu`. A release cannot publish
+# unless every file in batteries-whitelist.txt still passes.
+#
+# When you re-vendor a battery to a newer version, bump its `commit` here to the
+# matching upstream commit and re-run `scripts/battery-testsuite.sh --update` to
+# refresh batteries-whitelist.txt (review the diff — a newly failing file is a
+# regression to fix, not to whitelist away).
+#
+# Do NOT edit the data rows' shape by hand carelessly — the harness parses them.
+#
+# Format: tab-separated. Columns:
+#   name            the battery's identity (also the whitelist path prefix)
+#   bundled_lib     the shipped library dir mutsu resolves `use` against
+#   test_url        upstream git repo that carries the test suite
+#   commit          pinned upstream commit to fetch the tests from
+#   test_glob       glob (relative to the clone) selecting the test files
+#   extra_includes  comma-separated extra `-I` dirs; `{clone}` = the fetched
+#                   repo root; `-` means none
+name	bundled_lib	test_url	commit	test_glob	extra_includes
+zef	vendor/zef/lib	https://github.com/ugexe/zef.git	0aa54f53b55662d3a7a3b89981d34b9de97422f1	t/*.rakutest	{clone}/t/lib
+OpenSSL	modules/OpenSSL/lib	https://github.com/raku-community-modules/OpenSSL.git	8dda81950edba943d1acf3f800e01633227d3e04	t/*.rakutest	-
+IO::Socket::SSL	modules/IO-Socket-SSL/lib	https://github.com/raku-community-modules/IO-Socket-SSL.git	353ef4f58da07cb141715d6baa95de5d36d1e26a	t/*.rakutest	modules/OpenSSL/lib

--- a/docs/batteries/testsuite-gate.md
+++ b/docs/batteries/testsuite-gate.md
@@ -47,6 +47,12 @@ vendor/zef/lib`, `-I modules/OpenSSL/lib`, …) — the clone provides only the
 `t/` tests. A test file "passes" when it emits a TAP plan and every planned test
 is `ok` with no `not ok`.
 
+**Each test runs with the fetched repo as its working directory**, which is how
+`prove` / `zef test` run these suites. It matters: they reach for fixtures by
+relative path (OpenSSL's `03-rsa.rakutest` does `slurp 't/key.pem'`). Running
+them from the mutsu repo root instead makes such files die before their first
+test and be miscounted as *library* failures rather than harness artifacts.
+
 ## Baseline, not all-green
 
 The gate is a **per-file baseline** (the same philosophy as

--- a/docs/batteries/testsuite-gate.md
+++ b/docs/batteries/testsuite-gate.md
@@ -1,0 +1,78 @@
+# Release-time bundled-library test-suite gate
+
+mutsu ships several upstream Raku libraries verbatim ("batteries" — see
+[BATTERIES.md](../../BATTERIES.md) and [vendor/README.md](../../vendor/README.md)):
+
+- `vendor/zef/` — the Zef package manager that drives `mzef`
+- `modules/OpenSSL/` — OpenSSL NativeCall bindings
+- `modules/IO-Socket-SSL/` — TLS sockets (the HTTPS foundation)
+
+Their upstream **test suites are not vendored** (BATTERIES.md §3 — we ship only
+`lib/` + attribution). So "does the bundled copy actually work under this mutsu?"
+was previously only ever checked by hand. This gate makes it a **release
+requirement**: a tag cannot publish unless every bundled library's upstream
+tests still pass, at a recorded per-file baseline, against the *shipped* library
+and the release `mutsu`.
+
+## Why at release time (and why tagpr is now manual)
+
+Cutting a release is a deliberate act, so the expensive, network-dependent
+suite run belongs there rather than on every merge. In exchange, `tagpr.yml` is
+now **`workflow_dispatch`-only** — the release PR is no longer continuously
+refreshed; you kick tagpr by hand when you actually intend to release. The
+thoroughness moved from "restate the CHANGELOG constantly" to "verify the
+batteries before we ship."
+
+## Moving parts
+
+| File | Role |
+| --- | --- |
+| `batteries.lock` | Which batteries, where their tests come from, the pinned upstream commit, and the extra `-I` paths each suite needs. |
+| `batteries-whitelist.txt` | The per-file baseline: `name<TAB>testfile` for every test file that currently passes. Sorted. |
+| `scripts/battery-testsuite.sh` | The harness. Fetches each suite at its pinned commit, runs it against the bundled library, and enforces (or, with `--update`, regenerates) the whitelist. |
+| `release.yml` `batteries` job | Runs the harness on every release build; `needs` gates the publish job. |
+
+## Running it
+
+```sh
+cargo build --release
+# Gate mode (what CI runs): enforce the whitelist, non-zero exit on regression.
+MUTSU_BIN=target/release/mutsu scripts/battery-testsuite.sh
+# Update mode: re-measure and rewrite batteries-whitelist.txt.
+MUTSU_BIN=target/release/mutsu scripts/battery-testsuite.sh --update
+```
+
+The harness runs each suite against the **bundled** library (`-I
+vendor/zef/lib`, `-I modules/OpenSSL/lib`, …) — the clone provides only the
+`t/` tests. A test file "passes" when it emits a TAP plan and every planned test
+is `ok` with no `not ok`.
+
+## Baseline, not all-green
+
+The gate is a **per-file baseline** (the same philosophy as
+`roast-whitelist.txt`), not an all-must-pass wall. Some battery suites have known
+gaps under mutsu today (missing NativeCall surface, network/TLS-dependent
+assertions). Whitelisting exactly the files that currently pass means:
+
+- a release is blocked the moment a **previously passing** battery test breaks
+  (a real regression), and
+- suites with known gaps can still ride along — their passing files are pinned,
+  and closing the remaining gaps is ordinary follow-up work, not a release
+  blocker.
+
+A file that starts passing is reported but not required; promote it into the
+baseline by running `--update` and committing the diff.
+
+## Re-vendoring a battery
+
+When you bump a bundled library to a newer version, update its `commit` in
+`batteries.lock` to the matching upstream commit, then:
+
+```sh
+scripts/battery-testsuite.sh --update
+git diff batteries-whitelist.txt   # review!
+```
+
+A file that **dropped** out of the whitelist is a regression the new version (or
+a mutsu change) introduced — fix it rather than accepting the smaller baseline.
+A file that was **added** is progress to lock in.

--- a/news/2026-07/release-battery-testsuite-gate.md
+++ b/news/2026-07/release-battery-testsuite-gate.md
@@ -1,0 +1,43 @@
+# Bundled libraries' upstream test suites now gate the release
+
+mutsu ships several upstream Raku libraries verbatim — Zef (`vendor/zef/`),
+OpenSSL and IO::Socket::SSL (`modules/`). Their upstream test suites are
+deliberately *not* vendored (BATTERIES.md §3 ships only `lib/` plus attribution),
+so until now "does the bundled copy actually work under this mutsu?" was only
+ever checked by hand, and only when someone remembered.
+
+That check is now a **release requirement**. `release.yml` gained a `batteries`
+job that the publish job `needs`: it fetches each battery's upstream test suite
+at the commit pinned in the new `batteries.lock`, runs it against the *shipped*
+library and the release `mutsu`, and fails the release if any test file listed in
+`batteries-whitelist.txt` has regressed.
+
+## Baseline, not all-green
+
+The gate uses a **per-file baseline**, the same philosophy as
+`roast-whitelist.txt`. Some battery suites have known gaps under mutsu today, so
+requiring 100% green would simply block every release. Instead the whitelist pins
+exactly the files that pass today, which means a release is blocked the moment a
+*previously passing* battery test breaks, while the remaining gaps stay ordinary
+follow-up work. The initial measured baseline is **11 of 18 test files**:
+
+| Battery | Passing |
+| --- | --- |
+| Zef | 8 / 10 |
+| OpenSSL | 2 / 7 |
+| IO::Socket::SSL | 1 / 1 |
+
+A file that starts passing is reported but not required; promote it with
+`scripts/battery-testsuite.sh --update` and commit the diff.
+
+## tagpr is manual now
+
+The thoroughness was traded against release-PR churn: `tagpr.yml` no longer runs
+on an hourly schedule and is **`workflow_dispatch`-only**. The release PR is only
+consumed at release time, so continuously restating a pending CHANGELOG bought
+nothing. Kick it by hand when you intend to release (`gh workflow run tagpr.yml`)
+— and again right after merging the release PR, since tagpr creates the tag on
+its next run.
+
+See [docs/batteries/testsuite-gate.md](../../docs/batteries/testsuite-gate.md)
+for the harness, the manifest format, and the re-vendoring workflow.

--- a/scripts/battery-testsuite.sh
+++ b/scripts/battery-testsuite.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# Release-time gate: run every bundled library's upstream test suite against the
+# BUNDLED library + the built `mutsu`, and fail if any whitelisted test file has
+# regressed. See BATTERIES.md and docs/batteries/testsuite-gate.md.
+#
+#   scripts/battery-testsuite.sh            # gate mode: enforce the whitelist
+#   scripts/battery-testsuite.sh --update   # regenerate batteries-whitelist.txt
+#
+# The set of batteries and where their tests come from is batteries.lock; the
+# per-file baseline that must keep passing is batteries-whitelist.txt.
+#
+# Environment:
+#   MUTSU_BIN             mutsu binary to run (default: target/release/mutsu)
+#   BATTERIES_LOCK        manifest path (default: batteries.lock)
+#   BATTERIES_WHITELIST   baseline path (default: batteries-whitelist.txt)
+#
+# The two path overrides exist so the gate itself can be exercised against a
+# scratch manifest/baseline (e.g. to verify that a regression really does fail)
+# without disturbing the committed files.
+#
+# Exit status: 0 if every whitelisted file passes (gate mode) or the whitelist
+# was rewritten (update mode); non-zero if a whitelisted file regressed or setup
+# failed.
+set -u
+
+cd "$(dirname "$0")/.."
+ROOT="$(pwd)"
+MUTSU_BIN="${MUTSU_BIN:-target/release/mutsu}"
+LOCK="${BATTERIES_LOCK:-batteries.lock}"
+WHITELIST="${BATTERIES_WHITELIST:-batteries-whitelist.txt}"
+WORK="tmp/battery-testsuite"
+
+MODE="gate"
+[ "${1:-}" = "--update" ] && MODE="update"
+
+if [ ! -x "$MUTSU_BIN" ]; then
+  echo "error: mutsu binary not found/executable at $MUTSU_BIN" >&2
+  echo "  build it first (cargo build --release) or set MUTSU_BIN" >&2
+  exit 2
+fi
+
+# --- fetch a specific upstream commit into $dir (shallow, no full history) ----
+fetch_commit() {
+  local dir="$1" url="$2" commit="$3"
+  rm -rf "$dir"
+  mkdir -p "$dir"
+  git -C "$dir" init -q
+  git -C "$dir" remote add origin "$url"
+  # GitHub allows fetching an arbitrary reachable sha directly.
+  if ! git -C "$dir" fetch -q --depth 1 origin "$commit" 2>/dev/null; then
+    echo "error: could not fetch $commit from $url" >&2
+    return 1
+  fi
+  git -C "$dir" checkout -q FETCH_HEAD
+}
+
+# --- run one test file; echo PASS or FAIL(detail); return 0 iff it fully passes
+run_one() {
+  local out planned nok okc
+  out="$(timeout 120 "$MUTSU_BIN" "$@" 2>&1)"
+  planned="$(printf '%s\n' "$out" | grep -oE '^1\.\.[0-9]+' | head -1 | cut -d. -f3)"
+  nok="$(printf '%s\n' "$out" | grep -cE '^not ok')"
+  okc="$(printf '%s\n' "$out" | grep -cE '^ok ')"
+  if [ -n "$planned" ] && [ "$nok" -eq 0 ] && [ "$okc" -eq "$planned" ]; then
+    echo "PASS"
+    return 0
+  fi
+  echo "FAIL(ok=$okc/${planned:-?},notok=$nok)"
+  return 1
+}
+
+# Read a tab-separated lock, skipping comments/blank lines and the header row.
+lock_rows() {
+  grep -vE '^[[:space:]]*#|^[[:space:]]*$' "$LOCK" | grep -vE '^name[[:space:]]'
+}
+
+rm -rf "$WORK"
+mkdir -p "$WORK"
+
+# Accumulate the freshly-observed pass set (for --update) and the gate verdict.
+NEW_WHITELIST="$(mktemp)"
+REGRESSED=0
+SETUP_FAILED=0
+TOTAL_PASS=0
+TOTAL_FILES=0
+
+while IFS=$'\t' read -r name bundled_lib test_url commit test_glob extra_includes; do
+  [ -n "$name" ] || continue
+  echo "=== battery: $name (commit ${commit:0:12}) ==="
+
+  clone="$WORK/$(printf '%s' "$name" | tr -c 'A-Za-z0-9._-' '_')"
+  if ! fetch_commit "$clone" "$test_url" "$commit"; then
+    SETUP_FAILED=1
+    continue
+  fi
+
+  # Build the -I list: the bundled library first, then any extra includes
+  # ({clone} expands to the fetched repo root; `-` means none).
+  inc=(-I "$ROOT/$bundled_lib")
+  if [ "$extra_includes" != "-" ]; then
+    IFS=',' read -r -a extras <<< "$extra_includes"
+    for e in "${extras[@]}"; do
+      e="${e//\{clone\}/$clone}"
+      case "$e" in
+        /*) inc+=(-I "$e") ;;
+        *)  inc+=(-I "$ROOT/$e") ;;
+      esac
+    done
+  fi
+
+  shopt -s nullglob
+  files=("$clone"/$test_glob)
+  shopt -u nullglob
+  if [ "${#files[@]}" -eq 0 ]; then
+    echo "  warning: no test files matched '$test_glob'" >&2
+    SETUP_FAILED=1
+    continue
+  fi
+
+  for f in "${files[@]}"; do
+    base="$(basename "$f")"
+    TOTAL_FILES=$((TOTAL_FILES + 1))
+    verdict="$(run_one "${inc[@]}" "$f")"
+    rc=$?
+    printf '  %-40s %s\n' "$base" "$verdict"
+    if [ "$rc" -eq 0 ]; then
+      TOTAL_PASS=$((TOTAL_PASS + 1))
+      printf '%s\t%s\n' "$name" "$base" >> "$NEW_WHITELIST"
+    fi
+    # Gate: a file listed in the whitelist MUST pass.
+    if [ "$MODE" = "gate" ] && [ -f "$WHITELIST" ] \
+       && grep -qxF "$(printf '%s\t%s' "$name" "$base")" "$WHITELIST" \
+       && [ "$rc" -ne 0 ]; then
+      echo "  REGRESSION: whitelisted $name/$base no longer passes" >&2
+      REGRESSED=1
+    fi
+  done
+done < <(lock_rows)
+
+LC_ALL=C sort -o "$NEW_WHITELIST" "$NEW_WHITELIST"
+
+echo
+echo "=== summary: $TOTAL_PASS/$TOTAL_FILES test files pass ==="
+
+if [ "$MODE" = "update" ]; then
+  cp "$NEW_WHITELIST" "$WHITELIST"
+  echo "wrote $WHITELIST ($(wc -l < "$WHITELIST") files)"
+  rm -f "$NEW_WHITELIST"
+  [ "$SETUP_FAILED" -eq 0 ]
+  exit $?
+fi
+
+# Gate mode: also flag any whitelisted file that never ran (e.g. removed
+# upstream while still whitelisted) as a regression.
+if [ -f "$WHITELIST" ]; then
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    if ! grep -qxF "$line" "$NEW_WHITELIST"; then
+      echo "  REGRESSION: whitelisted '$line' did not pass this run" >&2
+      REGRESSED=1
+    fi
+  done < "$WHITELIST"
+fi
+rm -f "$NEW_WHITELIST"
+
+if [ "$SETUP_FAILED" -ne 0 ]; then
+  echo "GATE ERROR: a battery test suite could not be set up (see above)." >&2
+  exit 2
+fi
+if [ "$REGRESSED" -ne 0 ]; then
+  echo "GATE FAILED: a bundled library regressed below its recorded baseline." >&2
+  exit 1
+fi
+echo "GATE PASSED: every whitelisted bundled-library test still passes."

--- a/scripts/battery-testsuite.sh
+++ b/scripts/battery-testsuite.sh
@@ -29,7 +29,7 @@ ROOT="$(pwd)"
 MUTSU_BIN="${MUTSU_BIN:-target/release/mutsu}"
 LOCK="${BATTERIES_LOCK:-batteries.lock}"
 WHITELIST="${BATTERIES_WHITELIST:-batteries-whitelist.txt}"
-WORK="tmp/battery-testsuite"
+WORK="$ROOT/tmp/battery-testsuite"
 
 MODE="gate"
 [ "${1:-}" = "--update" ] && MODE="update"
@@ -39,6 +39,9 @@ if [ ! -x "$MUTSU_BIN" ]; then
   echo "  build it first (cargo build --release) or set MUTSU_BIN" >&2
   exit 2
 fi
+# Tests run with their own repo as the working directory (below), so the binary
+# must be addressable from there.
+case "$MUTSU_BIN" in /*) ;; *) MUTSU_BIN="$ROOT/$MUTSU_BIN" ;; esac
 
 # --- fetch a specific upstream commit into $dir (shallow, no full history) ----
 fetch_commit() {
@@ -56,9 +59,16 @@ fetch_commit() {
 }
 
 # --- run one test file; echo PASS or FAIL(detail); return 0 iff it fully passes
+#
+# $1 is the working directory to run in — the fetched repo root. These suites are
+# written to be run from their own checkout (`prove` / `zef test` do exactly
+# that) and reach for fixtures by RELATIVE path, e.g. OpenSSL's 03-rsa does
+# `slurp 't/key.pem'`. Running from the mutsu repo root instead made such files
+# die before their first test and be miscounted as library failures.
 run_one() {
+  local workdir="$1"; shift
   local out planned nok okc
-  out="$(timeout 120 "$MUTSU_BIN" "$@" 2>&1)"
+  out="$(cd "$workdir" && timeout 120 "$MUTSU_BIN" "$@" 2>&1)"
   planned="$(printf '%s\n' "$out" | grep -oE '^1\.\.[0-9]+' | head -1 | cut -d. -f3)"
   nok="$(printf '%s\n' "$out" | grep -cE '^not ok')"
   okc="$(printf '%s\n' "$out" | grep -cE '^ok ')"
@@ -120,8 +130,10 @@ while IFS=$'\t' read -r name bundled_lib test_url commit test_glob extra_include
 
   for f in "${files[@]}"; do
     base="$(basename "$f")"
+    # Address the test relative to its own repo — run_one runs it from there.
+    rel="${f#"$clone"/}"
     TOTAL_FILES=$((TOTAL_FILES + 1))
-    verdict="$(run_one "${inc[@]}" "$f")"
+    verdict="$(run_one "$clone" "${inc[@]}" "$rel")"
     rc=$?
     printf '  %-40s %s\n' "$base" "$verdict"
     if [ "$rc" -eq 0 ]; then


### PR DESCRIPTION
## Summary

mutsu ships Zef, OpenSSL and IO::Socket::SSL verbatim, but their upstream test
suites are deliberately **not** vendored (BATTERIES.md §3 ships only `lib/` plus
attribution). So *"does the bundled copy actually work under this mutsu?"* was only
ever checked by hand, and only when someone remembered. This makes it a **release
requirement**.

`release.yml` gains a `batteries` job that the publish job `needs`: it fetches each
battery's upstream suite at the commit pinned in the new `batteries.lock`, runs it
against the **shipped** library and the release `mutsu`, and fails the release if any
test file listed in `batteries-whitelist.txt` has regressed.

## Baseline, not all-green

The gate is a **per-file baseline** (the `roast-whitelist.txt` philosophy). Some
battery suites have known gaps today, so requiring 100% green would block every
release. The whitelist pins exactly the files that pass, so a release is blocked the
moment a *previously passing* battery test breaks, while the remaining gaps stay
ordinary follow-up work.

Measured initial baseline — **11 / 18 test files**:

| Battery | Passing |
| --- | --- |
| Zef | 8 / 10 |
| OpenSSL | 2 / 7 |
| IO::Socket::SSL | 1 / 1 |

Closing those gaps is tracked in **PLAN.md B1** with the user's target: *green before
the next release*. Notably the Zef 8/10 contradicts the recorded "all 10 pass"
(2026-07-10) — PLAN.md flags that it must be triaged as regression-vs-run-context
before assuming a regression.

## tagpr is manual now

In exchange for the release-time thoroughness, `tagpr.yml` drops its hourly schedule
and is **`workflow_dispatch`-only** — the release PR is only consumed at release time,
so continuously restating a pending CHANGELOG bought nothing.

## Verification

Both gate directions were exercised against the real batteries with a release build:

- **exits 0** when reality matches the whitelist (no false positives)
- **exits 1**, naming the entry, when a whitelisted file stops passing

`BATTERIES_LOCK` / `BATTERIES_WHITELIST` overrides exist so the gate can be exercised
against a scratch manifest without touching the committed files.

## Files

| File | Role |
| --- | --- |
| `batteries.lock` | batteries, test repo, **pinned commit**, extra `-I` paths |
| `batteries-whitelist.txt` | per-file baseline (sorted) |
| `scripts/battery-testsuite.sh` | the harness (`--update` regenerates the baseline) |
| `docs/batteries/testsuite-gate.md` | full documentation + re-vendoring workflow |

🤖 Generated with [Claude Code](https://claude.com/claude-code)