### PR TITLE
fix: pass an undefined Str to C as NULL, and flatten CArray.new list args

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -129,12 +129,20 @@ section.
       (user policy 2026-07-24). The release-time gate now runs every battery's upstream suite
       against the shipped library (`scripts/battery-testsuite.sh`, `batteries.lock`,
       `batteries-whitelist.txt`; see [docs/batteries/testsuite-gate.md](docs/batteries/testsuite-gate.md)),
-      but it is a **baseline** gate, and the measured baseline is only **11/18 test files**. The
-      goal is to raise that toward all-green so a release ships batteries that genuinely pass their
-      own suites — the gate stops regressions, it does not close these gaps:
-      - **OpenSSL — 2/7**. Measured shapes (release build, run from the suite's own checkout):
+      but it is a **baseline** gate, and the measured baseline is only **12/18 test files** (it
+      landed at 11/18; `10-client-ca-file` was fixed since). The goal is to raise that toward
+      all-green so a release ships batteries that genuinely pass their own suites — the gate stops
+      regressions, it does not close these gaps:
+      - **OpenSSL — 3/7**. Measured shapes (release build, run from the suite's own checkout):
         `01-basic` 2/7 die (0.1 s) · `03-rsa` 1/8 **hang** · `04-crypt` 1/13 die (0.0 s) ·
-        `05-digest` 0/24 **hang** · `10-client-ca-file` 2/7 **SIGSEGV** (exit 139, 1.2 s).
+        `05-digest` 0/24 **hang**.
+        ✅ `10-client-ca-file` **DONE** — was a SIGSEGV (exit 139), now 7/7. Two general NativeCall
+        bugs, neither OpenSSL-specific: an undefined `Str` argument was stringified instead of
+        marshalled as a NULL `char*` (so `ERR_error_string($e, Nil)`, where NULL means "use your own
+        static buffer", wrote up to 256 bytes into a 1-byte buffer and corrupted the heap), and
+        `CArray[T].new` did not flatten an Array/List argument (so the `CArray[uint8].new(
+        $path.encode.list, 0)` C-string idiom built a 2-element buffer and the callee saw a garbage
+        filename). Pins: `t/nativecall-null-str-arg.t`, `t/carray-new-flattens-list.t`.
         ★ **Root cause of both hangs is found and is ONE general mutsu bug — multi-dispatch picks a
         coercion candidate over an exact type match.** Minimal repro:
         ```raku

--- a/batteries-whitelist.txt
+++ b/batteries-whitelist.txt
@@ -1,6 +1,7 @@
 IO::Socket::SSL	01-basic.rakutest
 OpenSSL	06-digest-md5.rakutest
 OpenSSL	07-version.rakutest
+OpenSSL	10-client-ca-file.rakutest
 zef	build.rakutest
 zef	extract.rakutest
 zef	fetch.rakutest

--- a/news/2026-07/nativecall-null-str-and-carray-flatten.md
+++ b/news/2026-07/nativecall-null-str-and-carray-flatten.md
@@ -1,0 +1,43 @@
+# Two NativeCall fixes: NULL `Str` arguments, and `CArray.new` list flattening
+
+The release-time battery gate reported OpenSSL's `10-client-ca-file.rakutest`
+exiting 139 — a **SIGSEGV**. Two independent NativeCall bugs were behind it; both
+are general marshalling defects, not OpenSSL-specific.
+
+## 1. An undefined `Str` argument must be a NULL `char*`
+
+`marshal_arg`'s `CType::Str` arm stringified the value unconditionally, so `Nil`
+(or a type object) became a pointer to a 1-byte buffer instead of NULL. A callee
+that treats the parameter as a caller-supplied **output** buffer then writes past
+it. That is exactly OpenSSL's
+
+```raku
+ERR_error_string($e, Nil)   # NULL means "use your own static buffer"
+```
+
+which writes up to 256 bytes — aborting mutsu with `realloc(): invalid next
+size`. Undefined values now marshal to a null pointer, matching Rakudo.
+
+Pinned by `t/nativecall-null-str-arg.t`, which uses `getcwd(buf, size)` because
+its NULL path is both safe and observable: `getcwd(NULL, 0)` allocates and
+returns the cwd, while a non-NULL buffer with size 0 fails with `EINVAL`. That
+distinguishes NULL from the empty string the old code sent (`Nil.Str` is `""`).
+
+## 2. `CArray[T].new` flattens an Array/List argument
+
+`CArray[uint8].new($path.encode.list, 0)` — the idiomatic way to build a
+NUL-terminated C string — produced a **2**-element buffer (the whole list as
+element 0, then 0) instead of the 13 elements Rakudo gives. The callee therefore
+saw a garbage filename, and OpenSSL's `use-client-ca-file` reported "No such file
+or directory" for a file that was right there.
+
+The aggregate constructor flattened `Slip` / `Range` / `Seq` / `LazyList`
+arguments but not `Array`/`List`. Checked against rakudo, **only `CArray`**
+flattens those: `Array.new(@a, 3)` and `List.new(@a, 3)` keep `@a` as a single
+element, so the fix is scoped to `CArray` alone. Pinned by
+`t/carray-new-flattens-list.t`.
+
+## Result
+
+`10-client-ca-file.rakutest` goes from SIGSEGV to **7/7 passing**, lifting the
+OpenSSL battery baseline from 2/7 to 3/7 in `batteries-whitelist.txt`.

--- a/src/runtime/methods_aggregate_ctor.rs
+++ b/src/runtime/methods_aggregate_ctor.rs
@@ -205,6 +205,17 @@ impl Interpreter {
                 | ValueView::LazyList(_) => {
                     items.extend(crate::runtime::utils::value_to_list(arg));
                 }
+                // `CArray` — and ONLY `CArray` — also flattens an Array/List
+                // argument into its elements: `CArray[uint8].new(@a, 3)` is 3
+                // elements, whereas `Array.new(@a, 3)` / `List.new(@a, 3)` keep
+                // `@a` as a single element (verified against rakudo). The
+                // idiomatic way to build a NUL-terminated C string depends on
+                // it — `CArray[uint8].new($path.encode.list, 0)` (OpenSSL's
+                // `use-client-ca-file`) otherwise produced a 2-element buffer
+                // and the callee saw a garbage filename.
+                ValueView::Array(..) if base_class_name == "CArray" => {
+                    items.extend(crate::runtime::utils::value_to_list(arg));
+                }
                 _ => items.push(arg.clone()),
             }
         }

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -634,11 +634,22 @@ fn marshal_arg(ps: &ParamSpec, raw: &Value) -> Result<(libffi::middle::Type, Arg
             (Type::pointer(), ArgOwner::Ptr(addr))
         }
         CType::Str => {
-            let s = v.to_string_value();
-            let cstr = std::ffi::CString::new(s)
-                .map_err(|_| "Str argument contains an embedded NUL byte".to_string())?;
-            let ptr = cstr.as_ptr();
-            (Type::pointer(), ArgOwner::CStr(cstr, ptr))
+            // An UNDEFINED `Str` argument (`Nil`, `Str`, any type object) is a
+            // NULL `char*`, as in Rakudo. Stringifying it instead handed C a
+            // pointer to a 1-byte buffer, and a callee that treats the argument
+            // as a caller-provided output buffer then wrote past it and
+            // corrupted the heap: OpenSSL's `ERR_error_string($e, Nil)` — where
+            // NULL means "use your own static buffer" — writes up to 256 bytes
+            // and aborted mutsu with "realloc(): invalid next size".
+            if !crate::runtime::types::value_is_defined(v) {
+                (Type::pointer(), ArgOwner::Ptr(std::ptr::null()))
+            } else {
+                let s = v.to_string_value();
+                let cstr = std::ffi::CString::new(s)
+                    .map_err(|_| "Str argument contains an embedded NUL byte".to_string())?;
+                let ptr = cstr.as_ptr();
+                (Type::pointer(), ArgOwner::CStr(cstr, ptr))
+            }
         }
         CType::Buf => {
             // A `Blob`/`Buf` is passed as a `void*` to a contiguous copy of its

--- a/t/carray-new-flattens-list.t
+++ b/t/carray-new-flattens-list.t
@@ -1,0 +1,36 @@
+use Test;
+use NativeCall;
+
+# `CArray[T].new` — and ONLY CArray — flattens an Array/List argument into its
+# elements. `Array.new(@a, 3)` / `List.new(@a, 3)` keep `@a` as ONE element.
+# (Verified against rakudo.)
+#
+# The idiomatic way to build a NUL-terminated C string depends on the flatten:
+#   CArray[uint8].new($path.encode.list, 0)
+# Without it that produced a 2-element buffer (the whole list as element 0,
+# then 0), so the callee saw a garbage filename — OpenSSL's
+# `use-client-ca-file` reported "No such file or directory" for a file that
+# was right there.
+
+plan 8;
+
+my @a = 1, 2;
+
+# CArray flattens.
+is CArray[uint8].new(@a, 3).elems, 3, 'CArray[uint8].new flattens an Array arg';
+is CArray[int32].new(@a, 3).elems, 3, 'CArray[int32].new flattens an Array arg';
+is CArray[uint8].new(@a.list, 3).elems, 3, 'CArray.new flattens a List arg';
+
+# Array / List do NOT flatten — the arg stays a single element.
+is Array.new(@a, 3).elems, 2, 'Array.new does NOT flatten an Array arg';
+is List.new(@a, 3).elems, 2, 'List.new does NOT flatten an Array arg';
+
+# The C-string idiom yields the bytes plus the NUL terminator, in order.
+my $c = CArray[uint8].new("t/x".encode.list, 0);
+is $c.elems, 4, 'encoded bytes plus the NUL terminator';
+is (^$c.elems).map({ $c[$_] }).join(','), '116,47,120,0', 'bytes are in order and NUL-terminated';
+
+# Flattening composes with the already-flattened kinds (Range/Seq).
+is CArray[uint8].new(1..3, 4).elems, 4, 'a Range arg still flattens alongside';
+
+# vim: expandtab shiftwidth=4 ft=perl6

--- a/t/nativecall-null-str-arg.t
+++ b/t/nativecall-null-str-arg.t
@@ -1,0 +1,34 @@
+use Test;
+use NativeCall;
+
+# An UNDEFINED `Str` argument to a native sub must be passed as a NULL `char*`,
+# as in Rakudo. Stringifying it instead handed C a pointer to a 1-byte buffer;
+# a callee that treats the parameter as a caller-supplied OUTPUT buffer then
+# wrote past it and corrupted the heap. The real-world case is OpenSSL's
+# `ERR_error_string($e, Nil)`, where NULL means "use your own static buffer":
+# it writes up to 256 bytes and aborted mutsu with
+# "realloc(): invalid next size".
+#
+# `getcwd(char *buf, size_t size)` pins it precisely, and safely:
+#   getcwd(NULL, 0)      -> allocates and RETURNS the cwd  (defined)
+#   getcwd(<non-NULL>,0) -> fails with EINVAL, returns NULL (undefined)
+# So a NULL is observably different from the empty string the old code sent
+# (`Nil.Str` is ""), and size 0 means nothing is ever written into the buffer.
+
+plan 5;
+
+sub getcwd(Str, size_t --> Str) is native { * }
+sub strlen(Str --> size_t) is native { * }
+
+# A DEFINED Str still marshals as a normal NUL-terminated C string.
+is strlen('hello'), 5, 'a defined Str arg is passed NUL-terminated';
+is strlen(''), 0, 'an empty (but defined) Str arg is still a valid C string';
+
+# An UNDEFINED Str must be NULL.
+ok getcwd(Nil, 0).defined, 'Nil Str arg is passed as NULL (callee takes its NULL path)';
+ok getcwd(Str, 0).defined, 'Str type-object arg is passed as NULL too';
+
+# ...and is genuinely distinct from the empty string the old code would send.
+nok getcwd('', 0).defined, 'an empty Str is NOT NULL (callee takes its non-NULL path)';
+
+# vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
## Summary

The new release-time battery gate reported OpenSSL's `10-client-ca-file.rakutest`
exiting **139 (SIGSEGV)**. Two independent NativeCall marshalling bugs were behind it;
neither is OpenSSL-specific.

## 1. An undefined `Str` argument must be a NULL `char*`

`marshal_arg`'s `CType::Str` arm stringified the value unconditionally, so `Nil` (or a
type object) became a pointer to a **1-byte buffer** instead of NULL. A callee that
treats the parameter as a caller-supplied **output** buffer then writes past it:

```raku
ERR_error_string($e, Nil)   # NULL means "use your own static buffer"
```

OpenSSL writes up to 256 bytes there — aborting mutsu with `realloc(): invalid next
size`. Undefined values now marshal to a null pointer, matching Rakudo.

## 2. `CArray[T].new` must flatten an Array/List argument

```raku
CArray[uint8].new($path.encode.list, 0)   # the NUL-terminated C-string idiom
# rakudo: 13 elements   mutsu (before): 2
```

The callee therefore saw a garbage filename, and `use-client-ca-file` reported *"No
such file or directory"* for a file that was right there. The aggregate constructor
flattened `Slip`/`Range`/`Seq`/`LazyList` but not `Array`/`List`.

Checked against rakudo, **only `CArray`** flattens those — `Array.new(@a, 3)` and
`List.new(@a, 3)` keep `@a` as a single element — so the fix is scoped to `CArray`
alone.

## Result

`10-client-ca-file.rakutest`: **SIGSEGV → 7/7 passing**. The OpenSSL battery goes
2/7 → **3/7** and the gate baseline 11/18 → **12/18** (`batteries-whitelist.txt`
gains one line and drops none).

## Tests

- `t/nativecall-null-str-arg.t` (5) — uses `getcwd(buf, size)` because its NULL path is
  both safe and *observable*: `getcwd(NULL, 0)` allocates and returns the cwd, while a
  non-NULL buffer with size 0 fails with `EINVAL`. That distinguishes NULL from the
  empty string the old code sent (`Nil.Str` is `""`), so the test genuinely
  discriminates. (`getenv(NULL)` was tried first and is unusable — glibc dereferences
  it, so the test itself dumped core.)
- `t/carray-new-flattens-list.t` (8) — CArray flattens; `Array`/`List` do not; the
  C-string idiom yields the bytes plus NUL in order.
- `make test` green (2403 files, 22934 tests), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)