### PR TITLE
fix: a NativeCall Blob buffer lives as long as the Raku object

### DIFF
--- a/batteries-whitelist.txt
+++ b/batteries-whitelist.txt
@@ -1,4 +1,5 @@
 IO::Socket::SSL	01-basic.rakutest
+OpenSSL	03-rsa.rakutest
 OpenSSL	05-digest.rakutest
 OpenSSL	06-digest-md5.rakutest
 OpenSSL	07-version.rakutest

--- a/news/2026-07/nativecall-blob-buffer-lifetime.md
+++ b/news/2026-07/nativecall-blob-buffer-lifetime.md
@@ -1,0 +1,43 @@
+# A NativeCall Blob buffer now lives as long as the Raku object
+
+`OpenSSL`'s `03-rsa` test file segfaulted mutsu on its second assertion. The
+root cause was a lifetime, not a crash bug: a `Blob` argument was copied into a
+`Vec<u8>` that only lived for the duration of the call, and
+`BIO_new_mem_buf(buf, len)` builds a read-only memory BIO **over the caller's
+memory** and reads it later. The BIO was left pointing at freed memory, so
+`PEM_read_bio_RSAPrivateKey` returned NULL and `RSA_size(NULL)` took the process
+down. The module even documents the requirement — "`$bio-buf` contains a C
+pointer to `$private-pem-buf`, so `$private-pem-buf` needs to stay alive as long
+as `$bio-buf` does" — which Rakudo satisfies for free, because there a `Blob`'s
+storage *is* the C buffer.
+
+mutsu stores a `Buf`'s bytes as an `Array` of boxed `Int`s, so there is no
+contiguous storage to hand to C directly. The fix pins the C-side copy to the
+Raku object instead of to the call: `runtime::nativecall_pin` keeps the bytes in
+a registry keyed by the object's attribute-cell address, the first call
+allocates and every later call refreshes that same allocation, and the entry is
+released from `Drop for InstanceAttrs`. So the C buffer lives exactly as long as
+the `Buf` that owns it — no leak, and no dangling pointer while the object is
+still reachable. Release short-circuits on a relaxed atomic load, so a program
+that pins nothing pays one read per instance drop. (The real fix remains giving
+`Buf`/`Blob` a native contiguous representation, and a `TODO` in the new module
+says so.)
+
+Two further gaps surfaced on the way to a passing `03-rsa`:
+
+- An **unparameterized `CArray` parameter** was mis-registered. OpenSSL declares
+  `RSA_sign(int32, Blob, int32, Blob, CArray, OpaquePointer)`, whose fifth
+  argument is the `unsigned int*` output length. `CArray` has no mapped C type
+  and starts with a capital letter, so it fell through to the CStruct branch and
+  was passed as an opaque `void*` — i.e. NULL, since a `CArray` carries no
+  address — and `RSA_sign` wrote through it. A bare `CArray` is now marshalled
+  as a C buffer whose element type is read from the argument, which
+  `CArray[T].new` tags with its element type.
+- A **NULL pointer return** produced a defined `Pointer` holding 0 rather than
+  the type object, so the caller's usual `die "..." unless defined($p)` guard
+  never fired. It now returns the type object, as raku does.
+
+`OpenSSL 03-rsa` goes from a segfault at test 2 to 8/8; the bundled-library
+baseline is 14/18. Pinned by `t/nativecall-buf-lifetime.t` and
+`t/nativecall-bare-carray-param.t`, both of which also pass unchanged under
+`raku`.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -283,6 +283,7 @@ mod native_supply_methods;
 mod native_supply_mut_methods;
 pub(crate) mod native_types;
 pub(crate) mod nativecall;
+pub(crate) mod nativecall_pin;
 pub(crate) mod once_store;
 mod ops_bits;
 mod ops_compare;

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -298,9 +298,18 @@ pub fn call_native(spec: &NativeCallSpec, args: &[Value]) -> Result<Value, Runti
             // declared class so it round-trips as that native handle type.
             CType::Pointer | CType::CArray | CType::Buf => {
                 let addr = cif.call::<usize>(code, &ffi_args);
-                match &spec.ret_struct {
-                    Some(class) => make_struct_value(class, addr),
-                    None => make_pointer_value(addr),
+                let class = spec.ret_struct.as_deref().unwrap_or("Pointer");
+                if addr == 0 {
+                    // A NULL return is the *type object*, not a defined pointer
+                    // holding 0 — that is what lets the caller's usual
+                    // `die "..." unless defined($p)` guard fire (OpenSSL's
+                    // `PEM_read_bio_RSAPrivateKey` reports failure this way).
+                    Value::package(crate::symbol::Symbol::intern(class))
+                } else {
+                    match &spec.ret_struct {
+                        Some(class) => make_struct_value(class, addr),
+                        None => make_pointer_value(addr),
+                    }
                 }
             }
             CType::Str => {
@@ -346,8 +355,15 @@ pub fn call_native(spec: &NativeCallSpec, args: &[Value]) -> Result<Value, Runti
     // Copy each `Buf`/`Blob` out-buffer's (possibly callee-modified) C bytes
     // back into the caller's Buf instance.
     for idx in buf_writebacks {
-        if let ArgOwner::BufBytes { buf, .. } = &owners[idx] {
-            write_buf_instance_bytes(&args[idx], buf);
+        if let ArgOwner::BufBytes { pin_key, buf, .. } = &owners[idx] {
+            match pin_key {
+                Some(key) => {
+                    if let Some(bytes) = crate::runtime::nativecall_pin::read(*key) {
+                        write_buf_instance_bytes(&args[idx], &bytes);
+                    }
+                }
+                None => write_buf_instance_bytes(&args[idx], buf),
+            }
         }
     }
 
@@ -463,11 +479,18 @@ enum ArgOwner {
         data_ptr: *const std::ffi::c_void,
         elem: CType,
     },
-    /// A `Blob` / `Buf` byte buffer (`void*`): `buf` is the contiguous bytes
-    /// (heap, stable address), `data_ptr` is the pointer handed to libffi. The
-    /// callee may write into `buf` (an out-buffer), so it is copied back into
-    /// the caller's `Buf` instance after the call.
+    /// A `Blob` / `Buf` byte buffer (`void*`): `data_ptr` is the pointer handed
+    /// to libffi. The callee may write into it (an out-buffer), so the bytes
+    /// are copied back into the caller's `Buf` instance after the call.
+    ///
+    /// `pin_key` is `Some` in the normal case, where the bytes live in the
+    /// object-lifetime pin registry (see [`crate::runtime::nativecall_pin`]) so
+    /// that a C function which *retains* the pointer keeps seeing live memory.
+    /// It is `None` only when the argument is not a pinnable instance (a type
+    /// object, say), and then the fallback `buf` backs the pointer for the
+    /// duration of the call.
     BufBytes {
+        pin_key: Option<usize>,
         buf: Vec<u8>,
         data_ptr: *const std::ffi::c_void,
     },
@@ -544,6 +567,19 @@ fn resolve_array_value(v: &Value) -> Option<Value> {
         ValueView::VarRef { value, .. } => resolve_array_value(value),
         _ => None,
     }
+}
+
+/// The C element type recorded on a `CArray` *value* (`CArray[int32].new` tags
+/// the array's container metadata with `int32`). Used for an unparameterized
+/// `CArray` parameter, whose signature does not say what the elements are.
+#[cfg(feature = "libffi")]
+fn carray_value_elem_type(v: &Value) -> Option<CType> {
+    let arr = resolve_array_value(v)?;
+    let name = match arr.view() {
+        ValueView::Array(items, ..) => items.value_type.clone()?,
+        _ => return None,
+    };
+    CType::from_type_name(&name)
 }
 
 /// The size in bytes of one `CArray[T]` element for a scalar C element type.
@@ -653,11 +689,35 @@ fn marshal_arg(ps: &ParamSpec, raw: &Value) -> Result<(libffi::middle::Type, Arg
         }
         CType::Buf => {
             // A `Blob`/`Buf` is passed as a `void*` to a contiguous copy of its
-            // bytes (kept alive by the owner for the call). A NULL/absent buffer
-            // becomes a null pointer.
-            let buf = buf_instance_bytes(v).unwrap_or_default();
-            let data_ptr = buf.as_ptr() as *const std::ffi::c_void;
-            (Type::pointer(), ArgOwner::BufBytes { buf, data_ptr })
+            // bytes. The copy is pinned to the Raku object rather than to the
+            // call, so a C function that retains the pointer (OpenSSL's
+            // `BIO_new_mem_buf` builds a memory BIO *over* the caller's bytes)
+            // still sees live memory afterwards.
+            let bytes = buf_instance_bytes(v).unwrap_or_default();
+            match buf_instance_pin_key(v).and_then(|key| {
+                crate::runtime::nativecall_pin::pin(key, &bytes).map(|ptr| (key, ptr))
+            }) {
+                Some((key, ptr)) => (
+                    Type::pointer(),
+                    ArgOwner::BufBytes {
+                        pin_key: Some(key),
+                        buf: Vec::new(),
+                        data_ptr: ptr as *const std::ffi::c_void,
+                    },
+                ),
+                // Not a pinnable instance: fall back to a per-call temporary.
+                None => {
+                    let data_ptr = bytes.as_ptr() as *const std::ffi::c_void;
+                    (
+                        Type::pointer(),
+                        ArgOwner::BufBytes {
+                            pin_key: None,
+                            buf: bytes,
+                            data_ptr,
+                        },
+                    )
+                }
+            }
         }
         CType::Void => return Err("a parameter cannot have type void".to_string()),
         // Routed to `marshal_carray_arg` above; unreachable here.
@@ -686,6 +746,21 @@ fn buf_instance_bytes(v: &Value) -> Option<Vec<u8>> {
         ValueView::Scalar(inner) => buf_instance_bytes(inner),
         ValueView::ContainerRef(cell) => cell.lock().ok().and_then(|g| buf_instance_bytes(&g)),
         ValueView::VarRef { value, .. } => buf_instance_bytes(value),
+        _ => None,
+    }
+}
+
+/// The pin-registry key for a `Blob`/`Buf` native-call argument: the address of
+/// its shared attribute cell, which is unique per object and stays valid until
+/// the object dies. `None` for anything that is not an instance (a type object
+/// passed where a buffer was declared), which then gets a per-call temporary.
+#[cfg(feature = "libffi")]
+fn buf_instance_pin_key(v: &Value) -> Option<usize> {
+    match v.view() {
+        ValueView::Instance { attributes, .. } => Some(attributes.cell_key()),
+        ValueView::Scalar(inner) => buf_instance_pin_key(inner),
+        ValueView::ContainerRef(cell) => cell.lock().ok().and_then(|g| buf_instance_pin_key(&g)),
+        ValueView::VarRef { value, .. } => buf_instance_pin_key(value),
         _ => None,
     }
 }
@@ -722,8 +797,12 @@ fn marshal_carray_arg(
     raw: &Value,
 ) -> Result<(libffi::middle::Type, ArgOwner), String> {
     use libffi::middle::Type;
+    // An unparameterized `CArray` parameter carries no element type in the
+    // signature, so take it from the argument itself (`CArray[int32].new` tags
+    // the array with its element type).
     let elem = ps
         .elem
+        .or_else(|| carray_value_elem_type(raw))
         .ok_or_else(|| "CArray parameter is missing its element type".to_string())?;
     let list = match resolve_array_value(raw) {
         Some(arr) => arr

--- a/src/runtime/nativecall_pin.rs
+++ b/src/runtime/nativecall_pin.rs
@@ -1,0 +1,109 @@
+//! Object-lifetime pinning for NativeCall `Blob`/`Buf` arguments.
+//!
+//! A `Blob` argument is passed to C as a `void*` to its bytes. mutsu stores a
+//! `Buf`'s bytes as an `Array` of boxed `Int` values, not as contiguous C
+//! memory, so the address handed to C has to come from a separate byte buffer.
+//! Copying into a buffer that only lives for the duration of the call is wrong
+//! for any C function that *retains* the pointer — OpenSSL's
+//! `BIO_new_mem_buf(buf, len)` is exactly that: it builds a read-only memory
+//! BIO **over the caller's memory** and reads it later, so a per-call temporary
+//! left the BIO pointing at freed memory (the PEM parse then returned NULL and
+//! `RSA_size(NULL)` segfaulted). The library that does this documents the
+//! requirement — OpenSSL.rakumod comments that "`$bio-buf` contains a C pointer
+//! to `$private-pem-buf`, so `$private-pem-buf` needs to stay alive as long as
+//! `$bio-buf` does" — and in Rakudo it is satisfied for free, because a Blob's
+//! storage *is* the C buffer.
+//!
+//! So mutsu pins the buffer to the Raku object instead: the first native call
+//! that passes a given `Buf` allocates its C-side bytes here, keyed by the
+//! object's attribute-cell address, and every later call reuses (and refreshes)
+//! that same allocation. The entry is released from `Drop for InstanceAttrs`,
+//! so the C buffer lives exactly as long as the Raku `Buf` that owns it — no
+//! leak, and no dangling pointer while the object is still reachable.
+//!
+//! TODO: the real fix is to give `Buf`/`Blob` a native contiguous byte
+//! representation, so its storage can be handed to C directly the way Rakudo
+//! does, and this mirror can go away.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Live pin count. `release` is called from every `InstanceAttrs` drop — a very
+/// hot path — so it checks this first and skips the lock entirely for the
+/// overwhelmingly common case of a program that pins nothing.
+static PINNED_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+fn registry() -> &'static Mutex<HashMap<usize, Box<[u8]>>> {
+    static REGISTRY: std::sync::OnceLock<Mutex<HashMap<usize, Box<[u8]>>>> =
+        std::sync::OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Pin `bytes` for the object identified by `key` and return the stable address
+/// of the pinned copy. Reuses the existing allocation when the length is
+/// unchanged (the usual case: the same `Buf` handed to C again), so a pointer C
+/// already retained keeps pointing at the live bytes.
+///
+/// Returns `None` only if the registry mutex is poisoned, in which case the
+/// caller falls back to a per-call temporary.
+pub(crate) fn pin(key: usize, bytes: &[u8]) -> Option<*mut u8> {
+    let mut map = registry().lock().ok()?;
+    let slot = match map.get_mut(&key) {
+        Some(existing) if existing.len() == bytes.len() => existing,
+        _ => {
+            if map.insert(key, bytes.to_vec().into_boxed_slice()).is_none() {
+                PINNED_COUNT.fetch_add(1, Ordering::Relaxed);
+            }
+            map.get_mut(&key)?
+        }
+    };
+    slot.copy_from_slice(bytes);
+    Some(slot.as_mut_ptr())
+}
+
+/// Read back the pinned bytes for `key` — the C side may have written into
+/// them (an out-buffer such as `SSL_read` / `BIO_read`).
+pub(crate) fn read(key: usize) -> Option<Vec<u8>> {
+    registry().lock().ok()?.get(&key).map(|b| b.to_vec())
+}
+
+/// Free the pinned buffer owned by `key`. Called from `Drop for InstanceAttrs`
+/// while the attribute cell is still alive, so the key cannot yet have been
+/// recycled by a later allocation.
+pub(crate) fn release(key: usize) {
+    if PINNED_COUNT.load(Ordering::Relaxed) == 0 {
+        return;
+    }
+    if let Ok(mut map) = registry().lock()
+        && map.remove(&key).is_some()
+    {
+        PINNED_COUNT.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pinned_address_is_stable_across_repins_of_the_same_length() {
+        let key = 0x1000;
+        let first = pin(key, b"hello").unwrap();
+        let second = pin(key, b"world").unwrap();
+        assert_eq!(
+            first, second,
+            "same-length re-pin must reuse the allocation"
+        );
+        assert_eq!(read(key).unwrap(), b"world".to_vec());
+        release(key);
+        assert!(read(key).is_none());
+    }
+
+    #[test]
+    fn release_is_cheap_and_idempotent_for_unpinned_keys() {
+        release(0x2000);
+        release(0x2000);
+        assert!(read(0x2000).is_none());
+    }
+}

--- a/src/value/value_instance.rs
+++ b/src/value/value_instance.rs
@@ -139,6 +139,19 @@ impl InstanceAttrs {
         self.id
     }
 
+    /// The address of this instance's shared attribute cell.
+    ///
+    /// Unlike [`instance_id`], which an [`InstanceAttrs::clone`] deliberately
+    /// carries over to the copy, this is unique per *allocation*: every alias
+    /// of one object shares the cell, and a deep clone gets a fresh one. That
+    /// makes it the right key for a side table whose entry must be released
+    /// exactly once, when this object dies — see the NativeCall pinned-buffer
+    /// registry, which frees its entry from `Drop for InstanceAttrs` (while the
+    /// cell is still alive, so the address cannot yet have been recycled).
+    pub(crate) fn cell_key(&self) -> usize {
+        Arc::as_ptr(&self.attributes) as usize
+    }
+
     pub(crate) fn contains_key<K: AttrKey>(&self, key: K) -> bool {
         self.as_map().contains_key(key)
     }
@@ -321,6 +334,12 @@ impl InstanceAttrs {
 
 impl Drop for InstanceAttrs {
     fn drop(&mut self) {
+        // Free any C buffer pinned to this object for NativeCall (see
+        // `runtime::nativecall_pin`). Done here, while the attribute cell is
+        // still alive, so the key cannot have been recycled — and it short-
+        // circuits on an atomic load, so a program that pins nothing pays a
+        // single relaxed read per instance drop.
+        crate::runtime::nativecall_pin::release(self.cell_key());
         self.finalize_destroy();
     }
 }

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -367,6 +367,22 @@ impl Interpreter {
                 });
                 continue;
             }
+            // An unparameterized `CArray` parameter — OpenSSL declares
+            // `RSA_sign(int32, Blob, int32, Blob, CArray, OpaquePointer)`, whose
+            // fifth argument is the `unsigned int*` signature-length slot. The
+            // element type is not in the signature, so it is read from the
+            // argument's container metadata at call time. Without this the name
+            // fell through to the CStruct branch and was passed as an opaque
+            // `void*` — i.e. NULL, since a `CArray` carries no address — and the
+            // callee wrote through it.
+            if tc == "CArray" {
+                params.push(ParamSpec {
+                    ct: CType::CArray,
+                    is_rw,
+                    elem: None,
+                });
+                continue;
+            }
             let ct = match CType::from_type_name(tc) {
                 Some(ct) => ct,
                 // A user-declared `is repr('CStruct')` class (an opaque native

--- a/t/nativecall-bare-carray-param.t
+++ b/t/nativecall-bare-carray-param.t
@@ -1,0 +1,22 @@
+use Test;
+use NativeCall;
+
+plan 4;
+
+# An unparameterized `CArray` parameter -- OpenSSL declares
+# `RSA_sign(int32, Blob, int32, Blob, CArray, OpaquePointer)`, whose fifth
+# argument is the `unsigned int*` output length. The element type is not in the
+# signature, so it has to come from the argument, which `CArray[T].new` tags
+# with its element type.
+sub frexp(num64, CArray --> num64) is native { * }
+
+my $exp = CArray[int32].new;
+$exp[0] = 0;
+my $mantissa = frexp(8e0, $exp);
+
+is $mantissa, 0.5, 'frexp returned the mantissa';
+is $exp[0], 4, 'the bare CArray out-parameter was written through';
+
+$exp[0] = 0;
+is frexp(0.75e0, $exp), 0.75, 'frexp returned the mantissa (second call)';
+is $exp[0], 0, 'the bare CArray out-parameter was written through (second call)';

--- a/t/nativecall-buf-lifetime.t
+++ b/t/nativecall-buf-lifetime.t
@@ -1,0 +1,46 @@
+use Test;
+use NativeCall;
+
+plan 7;
+
+# A Blob passed to C must be backed by memory that lives as long as the Raku
+# object, not just as long as the call: `open_memstream`-style APIs and
+# OpenSSL's `BIO_new_mem_buf` retain the pointer they were handed.
+#
+# `memmem(haystack, hlen, needle, nlen)` returns an interior pointer into the
+# haystack, so subtracting the haystack's own address gives the match offset --
+# and it can only be checked against the haystack *after* the call, which is
+# exactly what a per-call temporary buffer would make meaningless.
+sub memmem(Blob, size_t, Blob, size_t --> Pointer) is native { * }
+sub strlen(Pointer --> size_t) is native { * }
+sub getenv(Str --> Pointer) is native { * }
+
+my $hay = "hello wonderful world\0".encode;
+my $needle = "wonderful".encode;
+
+my $hit = memmem($hay, $hay.bytes, $needle, $needle.bytes);
+ok $hit.defined, 'memmem found the needle';
+# The returned interior pointer must still address live bytes.
+is strlen($hit), "wonderful world".chars, 'the returned interior pointer is still valid';
+
+# Passing the same Blob again must keep giving the same base address, so a C
+# structure that captured the earlier pointer stays consistent.
+my $again = memmem($hay, $hay.bytes, $needle, $needle.bytes);
+is $again.Int, $hit.Int, 'the same Blob keeps the same C address across calls';
+
+# A different Blob gets its own buffer.
+my $other = "hello wonderful world\0".encode;
+isnt memmem($other, $other.bytes, $needle, $needle.bytes).Int, $hit.Int,
+    'a distinct Blob gets a distinct C address';
+
+# A C function that returns NULL yields the type object, not a defined pointer
+# holding 0 -- that is what makes the usual `unless defined(...)` guard work.
+nok getenv('MUTSU_NO_SUCH_ENV_VAR_XYZZY').defined,
+    'a NULL pointer return is undefined';
+ok getenv('PATH').defined, 'a non-NULL pointer return is defined';
+
+# An out-buffer still round-trips: the callee's writes land back in the Buf.
+sub memcpy(Blob, Blob, size_t --> Pointer) is native { * }
+my $dest = Buf.allocate(5, 0);
+memcpy($dest, "abcde".encode, 5);
+is $dest.decode, 'abcde', 'a callee-written out-buffer is copied back';


### PR DESCRIPTION
## Problem

`OpenSSL`'s `03-rsa` **segfaulted** mutsu on its second assertion. The root
cause is a lifetime, not a crash bug: a `Blob` argument was copied into a
`Vec<u8>` that only lived for the duration of the call, and
`BIO_new_mem_buf(buf, len)` builds a read-only memory BIO **over the caller's
memory** and reads it later. The BIO was left pointing at freed memory, so
`PEM_read_bio_RSAPrivateKey` returned NULL and `RSA_size(NULL)` took the process
down.

The tell, reduced: after `BIO_new_mem_buf`, a `BIO_read` came back with the
first 32 bytes replaced by what looked like four pointers, where raku reads
`-----BEGIN RSA PRIVATE KEY-----`.

The module even documents the requirement — "`$bio-buf` contains a C pointer to
`$private-pem-buf`, so `$private-pem-buf` needs to stay alive as long as
`$bio-buf` does" — which Rakudo satisfies for free, because there a `Blob`'s
storage *is* the C buffer.

## Fix

mutsu stores a `Buf`'s bytes as an `Array` of boxed `Int`s, so there is no
contiguous storage to hand to C directly. `runtime::nativecall_pin` pins the
C-side copy to the Raku object instead of to the call:

- keyed by the object's **attribute-cell address** — unique per allocation
  (unlike the instance id, which a deep clone deliberately carries over), so
  every alias of one object shares an entry and a clone gets its own;
- allocated on the first call, **refreshed in place** on later ones, so a
  pointer C already retained keeps addressing live bytes;
- released from `Drop for InstanceAttrs`, while the cell is still alive so the
  key cannot have been recycled.

The C buffer therefore lives exactly as long as the `Buf` that owns it — no
leak, and no dangling pointer while the object is reachable. Release
short-circuits on a relaxed atomic load, so a program that pins nothing pays one
read per instance drop. A `TODO` records that the real fix is giving
`Buf`/`Blob` a native contiguous representation.

Two further gaps surfaced on the way to a passing `03-rsa`:

- An **unparameterized `CArray` parameter** was mis-registered. OpenSSL declares
  `RSA_sign(int32, Blob, int32, Blob, CArray, OpaquePointer)`, whose fifth
  argument is the `unsigned int*` output length. `CArray` has no mapped C type
  and starts with a capital letter, so it fell through to the CStruct branch and
  was passed as an opaque `void*` — i.e. NULL, since a `CArray` carries no
  address — and `RSA_sign` wrote through it. A bare `CArray` is now marshalled
  as a C buffer whose element type is read from the argument, which
  `CArray[T].new` tags with its element type.
- A **NULL pointer return** produced a defined `Pointer` holding 0 rather than
  the type object, so the caller's usual `die "..." unless defined($p)` guard
  never fired. It now returns the type object, as raku does.

## Result

- `OpenSSL 03-rsa`: segfault at test 2 → **8/8**. Battery baseline 13 → **14/18**.
- Pinned by `t/nativecall-buf-lifetime.t` (interior-pointer validity after the
  call, address stability across calls, distinct Blobs get distinct addresses,
  NULL-return definedness, out-buffer round-trip) and
  `t/nativecall-bare-carray-param.t`. Both pass unchanged under `raku`.
- Local `make test` (2406 files) and `make roast` (1433 files / 218512 tests)
  both PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)