### PR TITLE
fix: a slurpy hash is not a positional catch-all

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1548,6 +1548,73 @@ entangled with the assignment metaops AND has a hot-path cost:
   (low gain, real risk). The comparison + prefix fixes already captured the
   high-value, zero-hot-path-cost parts of this doc-diff.
 
+### 8.22 A `unit module`'s subs register into GLOBAL, so they leak into every consumer's scope (found 2026-07-24 via Test::Util's `run`)
+
+A `unit module Foo;` body executes with `current_package() == "GLOBAL"`, so every
+routine it declares is registered as `GLOBAL::name` instead of `Foo::name`. The
+result is that mutsu has essentially **no scoping for module-declared routines**:
+every `sub` in a `unit module` is callable unqualified from anywhere that `use`s
+it, regardless of `is export` — and regardless of `my` / `our` / no scope
+declarator. The export machinery (`runtime_module_exports.rs`, `is_export` /
+`export_tags`) is real and works; the `unit_module_exported_subs` side table
+exists precisely to compensate for this GLOBAL registration, which is a good
+marker of where the fix has to reach.
+
+Reproduce (`tmp/lib/OurSub2.rakumod`):
+
+```raku
+unit module OurSub2;
+sub plainhelper(Str $a) { ... }        # not exported
+our sub ourhelper(Str $a) { ... }      # `our`, still not exported
+my sub myhelper(Str $a) { ... }        # explicitly lexical
+```
+
+```raku
+use OurSub2;
+plainhelper('x');            # raku: "Undeclared routine"   mutsu: calls it
+ourhelper('x');              # raku: "Undeclared routine"   mutsu: calls it
+myhelper('x');               # raku: "Undeclared routine"   mutsu: calls it
+GLOBAL::plainhelper('x');    # resolves -- the direct evidence
+```
+
+**Why it matters:** a leaked routine can *shadow a builtin* at a call site that
+never asked for it. `roast/packages/Test-Helpers/lib/Test/Util.rakumod` declares
+`our sub run( Str $code, Str $input = '', *%o)`, which is not exported; in mutsu
+it is a live candidate for every plain `run(...)` in a file that `use`s
+`Test::Util`.
+
+**It is already blocking a correctness fix.** `args_match_param_types` matches
+positional parameters against *raw* argument slots, so a named argument written
+before a positional (`f(:x(1), 7)` — which is what forwarding a capture after
+adding a named, `f(:x(1), |c)`, produces) mis-indexes them and no candidate
+matches:
+
+```
+Cannot resolve caller e(Int:D); none of these signatures matches:
+    (Int $p, $y, $x)
+```
+
+That is `OpenSSL::CryptTools`'s `encrypt` chain
+(`multi encrypt(:$aes256!, |c) { encrypt(:$cipher, |c) }` feeding
+`multi encrypt(Blob $plaintext, :$key, :$iv, :$cipher!)`), so `04-crypt` cannot
+pass without it. The fix is small and known — index positional params through a
+precomputed list of positional argument slots, and give a variadic param every
+positional from its own index on plus every named — **but it cannot land while
+§8.22 stands**: with the indexing corrected, `Test::Util`'s leaked `run` starts
+matching `run(:out, "cmd")` and wins over the builtin, breaking whitelisted
+`roast/S11-repository/cur-current-distribution.t` and `roast/S29-os/system.t`.
+(The `*%o`-is-not-a-positional-slurpy half of that investigation *did* land —
+news `2026-07/named-slurpy-not-positional.md` — because it is independently
+correct and regresses nothing.)
+
+**Why it is large:** running a `unit module` body under its own package changes
+where every routine, constant and package item in every bundled module lands, and
+`unit_module_exported_subs` (plus the `module_owned_exports` hiding logic) exists
+to paper over the current behaviour. Related: the `constant` / `my` bare-name
+collision fixed in #5350, whose root cause was the same registration-side
+flattening. Expect broad fallout in mutsu's own modules and tests that rely on
+the leak — this is a campaign, not a patch.
+
 
 ## Metrics
 

--- a/news/2026-07/named-slurpy-not-positional.md
+++ b/news/2026-07/named-slurpy-not-positional.md
@@ -1,0 +1,21 @@
+# A slurpy hash is not a positional catch-all
+
+`sub f(Str $a, Str $b = '', *%o)` accepts at most two positional arguments — the
+`*%o` collects *named* ones. mutsu's dispatch type-check treated it as a
+positional slurpy, which set `has_variadic_positional` and switched off the
+"too many positionals" rejection entirely, so such a candidate matched a call
+with any number of positionals. Binding then failed with the
+`Calling f(Str, Str, Str, Str) will never work with declared signature` error
+that resolution should have avoided by not picking the candidate at all.
+
+A slurpy `%`-sigil parameter is now excluded from the positional parameter set
+in `args_match_param_types`.
+
+This surfaced while chasing `OpenSSL::CryptTools`, whose `encrypt` chain relies
+on a named argument written before a positional. That larger fix is blocked on
+PLAN.md §8.22 — a `unit module`'s routines register under `GLOBAL`, so
+`Test::Util`'s non-exported `our sub run(Str $code, Str $input = '', *%o)` is a
+live candidate for the builtin `run` in every file that `use`s `Test::Util`.
+This half landed on its own because it is independently correct.
+
+Pinned by `t/named-slurpy-not-positional.t`, which passes unchanged under `raku`.

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -85,8 +85,17 @@ impl Interpreter {
                 || pd.code_signature.is_some()
         });
         let result = (|| {
-            let positional_params: Vec<&ParamDef> =
-                param_defs.iter().filter(|p| !p.named).collect();
+            // A slurpy hash (`*%o`) collects *named* arguments, so it is neither
+            // a positional parameter nor a positional variadic: `sub f(Str $a,
+            // Str $b = '', *%o)` still accepts at most two positionals. Counting
+            // it as a positional slurpy let such a candidate match any argument
+            // count at all -- which is how Test::Util's
+            // `our sub run(Str $code, Str $input = '', *%o)` became a live
+            // candidate for the builtin `run`.
+            let positional_params: Vec<&ParamDef> = param_defs
+                .iter()
+                .filter(|p| !(p.named || p.slurpy && p.name.starts_with('%')))
+                .collect();
             // A `Pair` (interned String key) is a *named* argument (`a => 1`,
             // `:a(1)`); a `ValuePair` (general key) is a *positional* argument
             // produced by the parser's `PositionalPair` (a computed/quoted-key

--- a/t/named-slurpy-not-positional.t
+++ b/t/named-slurpy-not-positional.t
@@ -1,0 +1,27 @@
+use Test;
+
+# A slurpy hash (`*%o`) collects *named* arguments. It is neither a positional
+# parameter nor a positional variadic, so it must not make its candidate accept
+# an unbounded number of positionals.
+
+plan 6;
+
+{
+    sub s(Str $a, Str $b = '', *%o) { "a=$a b=$b o={%o.keys.sort.join(',')}" }
+
+    is s('x'), 'a=x b= o=', 'the optional positional stays optional';
+    is s('x', 'y'), 'a=x b=y o=', 'both positionals bind';
+    is s('x', 'y', :k(1), :j(2)), 'a=x b=y o=j,k', 'the slurpy collects the nameds';
+    dies-ok { s('x', 'y', 'z') }, 'a third positional does not fit';
+}
+
+{
+    # Dispatch must reject the named-slurpy candidate on positional arity, not
+    # treat it as a catch-all.
+    proto sub p(|) {*}
+    multi sub p(Str $a, *%o) { 'one' }
+    multi sub p(Str $a, Str $b, Str $c) { 'three' }
+
+    is p('x'), 'one', 'the named-slurpy candidate takes its own arity';
+    is p('x', 'y', 'z'), 'three', 'it does not swallow a wider call';
+}


### PR DESCRIPTION
## Problem

`sub f(Str $a, Str $b = '', *%o)` accepts at most **two** positional arguments —
the `*%o` collects *named* ones. mutsu's dispatch type-check treated it as a
positional slurpy, which set `has_variadic_positional` and switched off the "too
many positionals" rejection entirely, so the candidate matched a call with any
number of positionals. Binding then failed with the

```
Calling f(Str, Str, Str, Str) will never work with declared signature (Str $a, Str $b, %o)
```

error that resolution should have avoided by never picking the candidate.

## Fix

A slurpy `%`-sigil parameter is excluded from the positional parameter set in
`args_match_param_types`. Pinned by `t/named-slurpy-not-positional.t`, which
passes unchanged under `raku`.

## Context — the other half, and why it is not here

This came out of chasing OpenSSL's `04-crypt`, whose `OpenSSL::CryptTools`
`encrypt` chain is `multi encrypt(:$aes256!, |c) { encrypt(:$cipher, |c) }`
feeding `multi encrypt(Blob $plaintext, :$key, :$iv, :$cipher!)`. Forwarding a
capture after adding a named produces `f(:x(1), 7)`, and
`args_match_param_types` matches positional parameters against **raw** argument
slots, so the leading `Pair` is handed to the first positional and nothing
matches:

```
Cannot resolve caller e(Int:D); none of these signatures matches:
    (Int $p, $y, $x)
```

That fix is small and I have it working — but it **cannot land yet**, and the
reason is worth stating: a `unit module` body executes with
`current_package() == "GLOBAL"`, so every routine it declares registers as
`GLOBAL::name`. `Test::Util` declares a non-exported
`our sub run(Str $code, Str $input = '', *%o)`, which is therefore a live
candidate for the builtin `run` in every file that `use`s it. With the
positional indexing corrected, that candidate starts matching
`run(:out, "cmd")` and wins, breaking whitelisted
`roast/S11-repository/cur-current-distribution.t` and `roast/S29-os/system.t`.
Both regressions were caught by a local `make roast` and are the reason the
indexing change is held back rather than shipped.

Recorded as **PLAN.md §8.22** with the reproduction, the direct evidence
(`GLOBAL::plainhelper('x')` resolves for a non-exported `unit module` sub), and
the ready-to-apply indexing patch, since running module bodies under their own
package is a campaign rather than a patch.

## Verification

Local `make test` (2405 files) and `make roast` (1433 files / 218512 tests) both
PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)