### PR TITLE
feat: read CStruct fields, and implement nativecast

### DIFF
--- a/batteries-whitelist.txt
+++ b/batteries-whitelist.txt
@@ -1,4 +1,5 @@
 IO::Socket::SSL	01-basic.rakutest
+OpenSSL	01-basic.rakutest
 OpenSSL	03-rsa.rakutest
 OpenSSL	05-digest.rakutest
 OpenSSL	06-digest-md5.rakutest

--- a/news/2026-07/nativecall-cstruct-field-reads.md
+++ b/news/2026-07/nativecall-cstruct-field-reads.md
@@ -1,0 +1,43 @@
+# CStruct fields are readable, and `nativecast` exists
+
+mutsu passed an `is repr('CStruct')` value around as an **opaque native
+handle** — an instance carrying the C pointer, enough to hand back to C but not
+to look inside. Real bindings look inside. `OpenSSL::SSL` declares the whole
+`SSL` struct and reads `$ssl.server`; `OpenSSL::CryptTools` casts an
+`EVP_CIPHER*` and reads `$evp.key_len` to validate a key length. Every such
+accessor answered `Nil`, because the class declares the fields as attributes but
+the instance has no Raku storage for them.
+
+`runtime::cstruct_layout` now computes each field's byte offset from the
+declared attributes using the C alignment rules, and the accessor path reads the
+field out of the pointed-to memory. A field declared as another native class
+comes back as a handle of that class, so `$ssl.method.version`-style chains keep
+working; a `Str` field is read through its `char*`. A field type NativeCall
+cannot marshal aborts the whole layout rather than shifting every later field —
+a wrong offset is a silent wild read, not a visible error.
+
+NativeCall's `nativecast($target-type, $source)` is implemented alongside it:
+without it there is no way to reach the fields of a struct a C function returned
+as an opaque pointer.
+
+Two supporting gaps closed on the way:
+
+- `is repr('CPointer')` was not tracked at all. It matters here because a
+  *field* of such a type (OpenSSL's `BIO`) is still one pointer wide inside the
+  enclosing struct — without it, `SSL`'s layout aborted at its third field and
+  no `SSL` field was readable.
+- An empty (or whitespace-only) string numifies to `0` in Raku, so `"" == 0` is
+  True. mutsu's numeric bridge treated it as "not a number at all" and answered
+  False (`+""` was already `0`, so the two disagreed). `"" <=> 0` threw
+  `X::Str::Numeric` instead of returning `Same`. Fixing this also exposed that
+  `!=` did not mirror `==`: it compared operands of different shapes
+  structurally, so `"" != 0` and `"" == 0` were both True/False in the wrong
+  direction. `!=` now uses the same rule as `==`.
+
+`OpenSSL 01-basic` goes 2/7 → **7/7**; the bundled-library baseline is 15/18.
+Pinned by `t/nativecall-cstruct-fields.t` and
+`t/empty-string-numifies-to-zero.t`, both of which also pass unchanged under
+`raku`.
+
+Writing fields, `HAS`-embedded structs/arrays, and allocating a struct from Raku
+(`MyStruct.new`) remain follow-up work.

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -163,6 +163,17 @@ impl Interpreter {
                     ),
                 );
             }
+            // A field read on an `is repr('CStruct')` handle: the instance
+            // carries the C pointer, so resolve the name against the struct's
+            // declared field layout and read it out of native memory
+            // (`$ssl.server`, `nativecast(evp_cipher_st, $c).key_len`). The
+            // class declares the fields as attributes but has no storage for
+            // them, so accessor resolution reaches here.
+            if args.is_empty()
+                && let Some(field) = self.cstruct_field_value(&inv_value, method_name)
+            {
+                return Ok((field, None));
+            }
             let type_name = receiver_class_name.to_string();
             return Err(
                 super::methods_signature_errors::make_method_not_found_error(

--- a/src/runtime/cstruct_layout.rs
+++ b/src/runtime/cstruct_layout.rs
@@ -1,0 +1,360 @@
+//! C `struct` field layout for `is repr('CStruct')` classes.
+//!
+//! mutsu already passes a CStruct around as an **opaque native handle**: an
+//! `Instance` of the declared class whose `address` attribute carries the C
+//! pointer (see `runtime::nativecall`). That is enough to hand the pointer back
+//! to C, but not to read a field out of it — and real bindings do exactly that.
+//! `OpenSSL::SSL` declares the whole `SSL` struct and reads `$ssl.server`;
+//! `OpenSSL::CryptTools` casts an `EVP_CIPHER*` with `nativecast` and reads
+//! `$evp.key_len` to validate a key length.
+//!
+//! This module computes each field's byte offset from the class's declared
+//! attributes using the platform's C alignment rules, and reads a field out of
+//! the pointed-to memory.
+//!
+//! Only *reads* through a pointer that C gave us are supported. Writing fields,
+//! `HAS`-embedded structs/arrays, and allocating a struct from Raku
+//! (`MyStruct.new`) remain follow-up work.
+
+/// The C type of one CStruct field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FieldType {
+    I8,
+    I16,
+    I32,
+    I64,
+    U8,
+    U16,
+    U32,
+    U64,
+    F32,
+    F64,
+    /// A `Str` field — a `char*` read as a NUL-terminated string.
+    Str,
+    /// Any pointer-shaped field: `Pointer`, `CArray[T]`, or another CStruct
+    /// class (C holds those by reference). Read as an address.
+    Pointer,
+}
+
+impl FieldType {
+    /// Map a declared attribute type name to its C field type. Returns `None`
+    /// for a type NativeCall cannot marshal into a struct field.
+    pub(crate) fn from_type_name(
+        name: &str,
+        is_known_struct: impl Fn(&str) -> bool,
+    ) -> Option<Self> {
+        Some(match name {
+            "int8" => FieldType::I8,
+            "int16" => FieldType::I16,
+            "int32" => FieldType::I32,
+            "int64" | "long" | "longlong" | "int" => FieldType::I64,
+            "uint8" | "byte" => FieldType::U8,
+            "uint16" => FieldType::U16,
+            "uint32" => FieldType::U32,
+            "uint64" | "ulong" | "ulonglong" | "uint" | "size_t" => FieldType::U64,
+            "num32" => FieldType::F32,
+            "num64" | "num" => FieldType::F64,
+            "Str" => FieldType::Str,
+            "Pointer" | "OpaquePointer" => FieldType::Pointer,
+            other => {
+                // `CArray[T]`, and any class C holds by reference (another
+                // CStruct, possibly package-qualified: `OpenSSL::Bio::BIO`).
+                if other.starts_with("CArray[") || is_known_struct(other) {
+                    FieldType::Pointer
+                } else {
+                    return None;
+                }
+            }
+        })
+    }
+
+    /// The field's size in bytes.
+    pub(crate) fn size(self) -> usize {
+        match self {
+            FieldType::I8 | FieldType::U8 => 1,
+            FieldType::I16 | FieldType::U16 => 2,
+            FieldType::I32 | FieldType::U32 | FieldType::F32 => 4,
+            FieldType::I64 | FieldType::U64 | FieldType::F64 => 8,
+            FieldType::Str | FieldType::Pointer => std::mem::size_of::<usize>(),
+        }
+    }
+
+    /// The field's alignment. For every type C supports here this equals its
+    /// size, which is what the SysV/Windows ABIs specify for scalars and
+    /// pointers alike.
+    pub(crate) fn align(self) -> usize {
+        self.size()
+    }
+}
+
+/// One laid-out field: its name (without sigil/twigil), C type and byte offset.
+#[derive(Debug, Clone)]
+pub(crate) struct FieldLayout {
+    pub name: String,
+    pub ty: FieldType,
+    pub offset: usize,
+}
+
+/// Lay out `fields` (in declaration order) as a C struct, returning each
+/// field's offset. A field whose type NativeCall cannot marshal aborts the
+/// layout: continuing past it would give every later field a wrong offset, and
+/// a wrong offset is a silent wild read.
+pub(crate) fn layout_struct(
+    fields: &[(String, String)],
+    is_known_struct: impl Fn(&str) -> bool + Copy,
+) -> Option<Vec<FieldLayout>> {
+    let mut out = Vec::with_capacity(fields.len());
+    let mut offset = 0usize;
+    for (name, type_name) in fields {
+        let ty = FieldType::from_type_name(type_name, is_known_struct)?;
+        let align = ty.align();
+        offset = offset.div_ceil(align) * align;
+        out.push(FieldLayout {
+            name: name.clone(),
+            ty,
+            offset,
+        });
+        offset += ty.size();
+    }
+    Some(out)
+}
+
+/// Read the field at `base + offset` out of native memory.
+///
+/// # Safety
+/// `base` must be a valid pointer to a C struct of the laid-out type, obtained
+/// from C and still alive. This is the same trust the rest of NativeCall
+/// extends to a declared signature: a wrong declaration is undefined behaviour
+/// in Rakudo too.
+pub(crate) unsafe fn read_field(base: usize, field: &FieldLayout) -> crate::value::Value {
+    use crate::value::Value;
+    let ptr = (base + field.offset) as *const u8;
+    unsafe {
+        match field.ty {
+            FieldType::I8 => Value::int(ptr.cast::<i8>().read_unaligned() as i64),
+            FieldType::I16 => Value::int(ptr.cast::<i16>().read_unaligned() as i64),
+            FieldType::I32 => Value::int(ptr.cast::<i32>().read_unaligned() as i64),
+            FieldType::I64 => Value::int(ptr.cast::<i64>().read_unaligned()),
+            FieldType::U8 => Value::int(ptr.read_unaligned() as i64),
+            FieldType::U16 => Value::int(ptr.cast::<u16>().read_unaligned() as i64),
+            FieldType::U32 => Value::int(ptr.cast::<u32>().read_unaligned() as i64),
+            FieldType::U64 => Value::int(ptr.cast::<u64>().read_unaligned() as i64),
+            FieldType::F32 => Value::num(ptr.cast::<f32>().read_unaligned() as f64),
+            FieldType::F64 => Value::num(ptr.cast::<f64>().read_unaligned()),
+            FieldType::Str => {
+                let s = ptr.cast::<*const std::ffi::c_char>().read_unaligned();
+                if s.is_null() {
+                    Value::NIL
+                } else {
+                    Value::str(std::ffi::CStr::from_ptr(s).to_string_lossy().into_owned())
+                }
+            }
+            FieldType::Pointer => Value::int(ptr.cast::<usize>().read_unaligned() as i64),
+        }
+    }
+}
+
+impl crate::runtime::Interpreter {
+    /// The registered name of the `is repr('CStruct')` class `name` refers to,
+    /// or `None` if it is not one.
+    ///
+    /// A CStruct is reached under several spellings: the registry stores the
+    /// declaration's storage name (`OpenSSL::SSL::SSL`), a native return value
+    /// is tagged with the short name (`SSL`), and a field's declared type
+    /// carries the package path it was written with (`OpenSSL::Bio::BIO`). All
+    /// three name the same class, so matching falls back to the last `::`
+    /// component on both sides.
+    pub(crate) fn cstruct_class_name(&self, name: &str) -> Option<String> {
+        let reg = self.registry();
+        if reg.cstruct_classes.contains(name) {
+            return Some(name.to_string());
+        }
+        let short = name.rsplit("::").next().unwrap_or(name);
+        reg.cstruct_classes
+            .iter()
+            .find(|c| c.rsplit("::").next().unwrap_or(c) == short)
+            .cloned()
+    }
+
+    /// Whether `name` is a class declared `is repr('CStruct')`.
+    pub(crate) fn is_cstruct_class(&self, name: &str) -> bool {
+        self.cstruct_class_name(name).is_some()
+    }
+
+    /// Whether a *field* of type `name` occupies one pointer inside an
+    /// enclosing CStruct: any class NativeCall holds by reference, i.e. one
+    /// declared `is repr('CStruct')`, `'CPointer'` or `'CUnion'`.
+    fn is_native_handle_class(&self, name: &str) -> bool {
+        let short = name.rsplit("::").next().unwrap_or(name);
+        let reg = self.registry();
+        [
+            &reg.cstruct_classes,
+            &reg.cpointer_classes,
+            &reg.cunion_classes,
+        ]
+        .iter()
+        .any(|set| {
+            set.contains(name)
+                || set
+                    .iter()
+                    .any(|c| c.rsplit("::").next().unwrap_or(c) == short)
+        })
+    }
+
+    /// The C field layout of a `is repr('CStruct')` class, or `None` if the
+    /// class is not a CStruct or declares a field NativeCall cannot marshal.
+    pub(crate) fn cstruct_layout(&mut self, class_name: &str) -> Option<Vec<FieldLayout>> {
+        let registered = self.cstruct_class_name(class_name)?;
+        let attrs = self.collect_class_attributes(&registered);
+        let fields: Vec<(String, String)> = attrs
+            .iter()
+            .map(|(name, ..)| {
+                let ty = self
+                    .get_attr_type_constraint(&registered, name)
+                    .unwrap_or_default();
+                (name.clone(), ty)
+            })
+            .collect();
+        // `is_known_struct` cannot borrow `self` here (the layout call takes it
+        // by value), so resolve the pointer-shaped field types up front.
+        let handle_fields: std::collections::HashSet<&str> = fields
+            .iter()
+            .map(|(_, ty)| ty.as_str())
+            .filter(|ty| self.is_native_handle_class(ty))
+            .collect();
+        layout_struct(&fields, |n| handle_fields.contains(n))
+    }
+
+    /// Read field `name` out of the C struct `target` points at, if `target` is
+    /// a CStruct handle carrying an address and the class declares that field.
+    ///
+    /// A field whose declared type is another CStruct class comes back wrapped
+    /// as an instance of that class, so `$ssl.method.version`-style chains keep
+    /// working; a plain `Pointer` field comes back as a `Pointer`.
+    pub(crate) fn cstruct_field_value(
+        &mut self,
+        target: &crate::value::Value,
+        name: &str,
+    ) -> Option<crate::value::Value> {
+        use crate::value::ValueView;
+        let (class_name, address) = match target.view() {
+            ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } => {
+                let addr = match attributes.as_map().get("address").map(|v| v.view()) {
+                    Some(ValueView::Int(a)) if a > 0 => a as usize,
+                    _ => return None,
+                };
+                (class_name.resolve().to_string(), addr)
+            }
+            _ => return None,
+        };
+        let registered = self.cstruct_class_name(&class_name)?;
+        let layout = self.cstruct_layout(&registered)?;
+        let field = layout.iter().find(|f| f.name == name)?;
+        // SAFETY: `address` came from C as a pointer to a struct of this
+        // declared type and the instance is alive, so the field is in bounds.
+        let raw = unsafe { read_field(address, field) };
+        if field.ty != FieldType::Pointer {
+            return Some(raw);
+        }
+        let declared = self.get_attr_type_constraint(&registered, name)?;
+        let addr = crate::runtime::to_int(&raw) as usize;
+        Some(crate::runtime::nativecall::make_native_handle(
+            if self.is_cstruct_class(&declared) {
+                declared.rsplit("::").next().unwrap_or(&declared)
+            } else {
+                "Pointer"
+            },
+            addr,
+        ))
+    }
+
+    /// `nativecast($target-type, $source)` — reinterpret the C pointer carried
+    /// by `$source` as `$target-type`. NativeCall's own helper, and the only
+    /// way to reach the fields of a struct a C function handed back as an
+    /// opaque pointer (`nativecast(evp_cipher_st, $cipher).key_len`).
+    pub(crate) fn try_nativecast(
+        &mut self,
+        name: &str,
+        args: &[crate::value::Value],
+    ) -> Option<Result<crate::value::Value, crate::value::RuntimeError>> {
+        use crate::value::{RuntimeError, ValueView};
+        if name != "nativecast" {
+            return None;
+        }
+        let args: Vec<crate::value::Value> = args
+            .iter()
+            .cloned()
+            .map(crate::runtime::types::unwrap_varref_value)
+            .collect();
+        if args.len() != 2 {
+            return Some(Err(RuntimeError::new(format!(
+                "nativecast() expects 2 arguments, got {}",
+                args.len()
+            ))));
+        }
+        let target = match args[0].view() {
+            ValueView::Package(n) => n.resolve().to_string(),
+            ValueView::Instance { class_name, .. } => class_name.resolve().to_string(),
+            _ => {
+                return Some(Err(RuntimeError::new(
+                    "nativecast() expects a type object as its first argument",
+                )));
+            }
+        };
+        let addr = crate::runtime::nativecall::value_c_address(&args[1]);
+        let short = target.rsplit("::").next().unwrap_or(&target);
+        Some(Ok(crate::runtime::nativecall::make_native_handle(
+            short, addr,
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn no_structs(_: &str) -> bool {
+        false
+    }
+
+    #[test]
+    fn scalar_fields_are_padded_to_their_alignment() {
+        let fields = [
+            ("a".to_string(), "int8".to_string()),
+            ("b".to_string(), "int32".to_string()),
+            ("c".to_string(), "int8".to_string()),
+            ("d".to_string(), "num64".to_string()),
+        ];
+        let layout = layout_struct(&fields, no_structs).unwrap();
+        assert_eq!(layout[0].offset, 0);
+        assert_eq!(layout[1].offset, 4, "int32 aligns to 4");
+        assert_eq!(layout[2].offset, 8);
+        assert_eq!(layout[3].offset, 16, "num64 aligns to 8");
+    }
+
+    #[test]
+    fn a_struct_typed_field_is_a_pointer() {
+        let fields = [
+            ("v".to_string(), "int32".to_string()),
+            ("m".to_string(), "OpenSSL::Method::SSL_METHOD".to_string()),
+            ("n".to_string(), "int32".to_string()),
+        ];
+        let layout = layout_struct(&fields, |n| n == "OpenSSL::Method::SSL_METHOD").unwrap();
+        assert_eq!(layout[1].ty, FieldType::Pointer);
+        assert_eq!(layout[1].offset, 8, "the pointer aligns to 8");
+        assert_eq!(layout[2].offset, 16);
+    }
+
+    #[test]
+    fn an_unmarshallable_field_aborts_the_layout() {
+        let fields = [
+            ("a".to_string(), "int32".to_string()),
+            ("b".to_string(), "SomeRakuClass".to_string()),
+        ];
+        assert!(layout_struct(&fields, no_structs).is_none());
+    }
+}

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1220,6 +1220,13 @@ impl Interpreter {
             }
             // Fallback: auto-generated accessor for public attributes.
             if args.is_empty() {
+                // An `is repr('CStruct')` handle stores no Raku attributes: its
+                // fields live in the C struct the instance's `address` points
+                // at, so the accessor reads them out of native memory
+                // (`$ssl.server`, `nativecast(evp_cipher_st, $c).key_len`).
+                if let Some(field) = self.cstruct_field_value(&target, method) {
+                    return Ok(field);
+                }
                 let cn = class_name.resolve();
                 let class_attrs = self.collect_class_attributes(&cn);
                 // For a *user-declared* class the collected public-attribute list is
@@ -2122,6 +2129,15 @@ impl Interpreter {
                     && let Some(node) = crate::rakuast::construct(&type_name, method, &args)?
                 {
                     return Ok(node);
+                }
+                // A field read on an `is repr('CStruct')` handle: the instance
+                // carries the C pointer, so resolve the name against the
+                // struct's declared field layout and read it out of native
+                // memory (`$ssl.server`, `nativecast(evp_cipher_st, $c).key_len`).
+                if args.is_empty()
+                    && let Some(field) = self.cstruct_field_value(&target, method)
+                {
+                    return Ok(field);
                 }
                 Err(make_method_not_found_error(method, &type_name, false))
             }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -171,6 +171,7 @@ mod class;
 mod class_dispatch;
 mod class_introspection;
 pub(crate) use class_introspection::UserMethodOrAccessor;
+pub(crate) mod cstruct_layout;
 mod decl_types;
 pub(crate) use self::decl_types::*;
 pub(crate) mod deprecation;

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -376,20 +376,18 @@ pub fn call_native(spec: &NativeCallSpec, args: &[Value]) -> Result<Value, Runti
 /// method dispatch (`.Int`/`.gist`/…) on the result resolves.
 #[cfg(feature = "libffi")]
 fn make_pointer_value(addr: usize) -> Value {
-    let mut attrs = std::collections::HashMap::new();
-    attrs.insert("address".to_string(), Value::int(addr as i64));
-    Value::make_instance(crate::symbol::Symbol::intern("Pointer"), attrs)
+    make_native_handle("Pointer", addr)
 }
 
-/// Wrap a returned native pointer as an instance of a user-declared
-/// `is repr('CStruct')` class (an opaque native handle, e.g. `SSL_CTX`). The
-/// address is carried in an `address` attribute so it round-trips as a `void*`
-/// when passed back to another native call (`pointer_address` reads it). A NULL
-/// return becomes the class's type object (undefined) so `.defined` / boolean
-/// checks — the OpenSSL binding's `try {...} || try {...}` fallback pattern —
-/// behave like Rakudo, where a null CStruct return is a type object.
-#[cfg(feature = "libffi")]
-fn make_struct_value(class: &str, addr: usize) -> Value {
+/// Wrap a native pointer as an instance of `class` — a user-declared
+/// `is repr('CStruct')` class (an opaque native handle, e.g. `SSL_CTX`) or the
+/// builtin `Pointer`. The address is carried in an `address` attribute so it
+/// round-trips as a `void*` when passed back to another native call
+/// ([`value_c_address`] reads it). A NULL address becomes the class's type
+/// object (undefined) so `.defined` / boolean checks — the OpenSSL binding's
+/// `try {...} || try {...}` fallback pattern — behave like Rakudo, where a null
+/// CStruct return is a type object.
+pub(crate) fn make_native_handle(class: &str, addr: usize) -> Value {
     if addr == 0 {
         return Value::package(crate::symbol::Symbol::intern(class));
     }
@@ -398,12 +396,15 @@ fn make_struct_value(class: &str, addr: usize) -> Value {
     Value::make_instance(crate::symbol::Symbol::intern(class), attrs)
 }
 
-/// Read the C address carried by a NativeCall argument: a `Pointer` object's
-/// `address` attribute, a bare integer, or 0 for Nil / anything else. Unwraps a
-/// `Scalar` / `ContainerRef` container first (a `$`-variable argument arrives
-/// wrapped).
 #[cfg(feature = "libffi")]
-fn pointer_address(v: &Value) -> usize {
+fn make_struct_value(class: &str, addr: usize) -> Value {
+    make_native_handle(class, addr)
+}
+
+/// Read the C address a value carries: a `Pointer`/CStruct handle's `address`
+/// attribute, a bare integer, or 0 for Nil / anything else. Unwraps a `Scalar`
+/// / `ContainerRef` / `VarRef` container first.
+pub(crate) fn value_c_address(v: &Value) -> usize {
     match v.view() {
         ValueView::Int(i) => i as usize,
         ValueView::Instance { attributes, .. } => {
@@ -412,13 +413,19 @@ fn pointer_address(v: &Value) -> usize {
                 _ => 0,
             }
         }
-        ValueView::Scalar(inner) => pointer_address(inner),
-        ValueView::ContainerRef(cell) => cell.lock().ok().map(|g| pointer_address(&g)).unwrap_or(0),
-        // An `is rw` argument arrives as a `VarRef` carrying the bound
-        // variable's current value.
-        ValueView::VarRef { value, .. } => pointer_address(value),
+        ValueView::Scalar(inner) => value_c_address(inner),
+        ValueView::ContainerRef(cell) => cell.lock().ok().map(|g| value_c_address(&g)).unwrap_or(0),
+        ValueView::VarRef { value, .. } => value_c_address(value),
         _ => 0,
     }
+}
+
+/// Read the C address carried by a NativeCall argument. (An `is rw` argument
+/// arrives as a `VarRef` carrying the bound variable's current value, which
+/// [`value_c_address`] unwraps along with `Scalar` / `ContainerRef`.)
+#[cfg(feature = "libffi")]
+fn pointer_address(v: &Value) -> usize {
+    value_c_address(v)
 }
 
 /// Write a resolved C address back into a `Pointer` object's `address`

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -502,6 +502,12 @@ impl Interpreter {
         self.registry_mut().cstruct_classes.insert(name.to_string());
     }
 
+    pub(crate) fn register_cpointer_class(&mut self, name: &str) {
+        self.registry_mut()
+            .cpointer_classes
+            .insert(name.to_string());
+    }
+
     pub(crate) fn construct_cunion_instance(
         &mut self,
         class_name: &str,

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -67,6 +67,12 @@ pub(crate) struct Registry {
     /// passed by pointer, even when the class name is lowercase (e.g.
     /// `evp_cipher_st`) and so would not match the name-shape heuristic.
     pub(crate) cstruct_classes: HashSet<String>,
+    /// Classes declared `is repr('CPointer')` — an opaque native handle with no
+    /// declared field layout of its own (OpenSSL's `BIO`). Tracked separately
+    /// from [`cstruct_classes`] because such a class has no layout to compute,
+    /// but a *field* of that type is still one pointer wide inside an enclosing
+    /// CStruct.
+    pub(crate) cpointer_classes: HashSet<String>,
     /// Classes marked `is hidden` (excluded from `.^mro` etc.).
     pub(crate) hidden_classes: HashSet<String>,
     /// Forward-declared class stubs (`class Foo { ... }` declared later).

--- a/src/runtime/utils/compare.rs
+++ b/src/runtime/utils/compare.rs
@@ -70,7 +70,17 @@ pub(crate) fn to_float_value(val: &Value) -> Option<f64> {
         }
         ValueView::Enum { value, .. } => Some(value.as_i64() as f64),
         ValueView::Bool(b) => Some(if b { 1.0 } else { 0.0 }),
-        ValueView::Str(s) => s.trim().parse::<f64>().ok(),
+        ValueView::Str(s) => {
+            let t = s.trim();
+            // Raku numifies an empty (or whitespace-only) string to 0 — `+""`
+            // is `0` and `"" == 0` is True. Without this the string compared
+            // as "not a number at all" and `==` answered False.
+            if t.is_empty() {
+                Some(0.0)
+            } else {
+                t.parse::<f64>().ok()
+            }
+        }
         ValueView::Nil => Some(0.0),
         ValueView::Set(items, _) => Some(items.len() as f64),
         ValueView::Bag(items, _) => Some(items.len() as f64),

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1284,6 +1284,9 @@ impl Interpreter {
                 } else if let Some(result) = self.try_native_test_function(name, &args) {
                     // Dispatch Test functions straight to their typed handler (lever A).
                     result
+                } else if let Some(result) = self.try_nativecast(name, &args) {
+                    // NativeCall's `nativecast($target-type, $source)` helper.
+                    result
                 } else if let Some(result) = self.try_native_json_function(name, &args) {
                     // Dispatch JSON::Fast / JSON::Tiny `to-json` / `from-json`
                     // to the native implementation (runtime/json.rs).

--- a/src/vm/vm_call_method_ops.rs
+++ b/src/vm/vm_call_method_ops.rs
@@ -208,6 +208,13 @@ impl Interpreter {
             return None;
         }
         let cn = class_name.resolve();
+        // An `is repr('CStruct')` handle stores no Raku attributes: its fields
+        // live in the C struct the instance's `address` points at, so the
+        // accessor must read them out of native memory rather than return the
+        // absent (Nil) slot. Bail to the interpreter path, which does that.
+        if self.is_cstruct_class(&cn) {
+            return None;
+        }
         // The fast accessor read proceeds only when the public attribute
         // accessor wins the per-MRO-level race against user methods of the
         // same name: an explicit method at the same or a more-derived level

--- a/src/vm/vm_comparison_ops.rs
+++ b/src/vm/vm_comparison_ops.rs
@@ -232,7 +232,13 @@ fn value_to_i64(v: &Value) -> Option<i64> {
 
 impl Interpreter {
     fn parse_numeric_string_for_spaceship(s: &str) -> Result<f64, RuntimeError> {
-        s.trim().parse::<f64>().map_err(|_| {
+        let t = s.trim();
+        // Raku numifies an empty (or whitespace-only) string to 0, so `"" <=> 0`
+        // is `Same` rather than an X::Str::Numeric.
+        if t.is_empty() {
+            return Ok(0.0);
+        }
+        t.parse::<f64>().map_err(|_| {
             RuntimeError::new(format!(
                 "X::Str::Numeric: Cannot convert string '{}' to a number",
                 s
@@ -327,7 +333,10 @@ impl Interpreter {
                 && (is_rationalish(&l) || is_rationalish(&r))
             {
                 Ok(Value::truth(runtime::big_rat_parts_equal(a, b)))
-            } else if l.is_nil() || r.is_nil() {
+            } else if !l.same_variant(&r) || l.is_nil() {
+                // Mirror `==` exactly: operands of different shapes (a Str and
+                // an Int, say) compare as floats. Structural equality here made
+                // `"" != 0` answer True while `"" == 0` answered False.
                 Ok(Value::truth(
                     runtime::to_float_value(&l) == runtime::to_float_value(&r),
                 ))
@@ -375,7 +384,10 @@ impl Interpreter {
                 && (is_rationalish(&l) || is_rationalish(&r))
             {
                 Ok(Value::truth(runtime::big_rat_parts_equal(a, b)))
-            } else if l.is_nil() || r.is_nil() {
+            } else if !l.same_variant(&r) || l.is_nil() {
+                // Mirror `==` exactly: operands of different shapes (a Str and
+                // an Int, say) compare as floats. Structural equality here made
+                // `"" != 0` answer True while `"" == 0` answered False.
                 Ok(Value::truth(
                     runtime::to_float_value(&l) == runtime::to_float_value(&r),
                 ))

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -186,6 +186,8 @@ impl Interpreter {
                     self.register_cunion_class(&storage_name);
                 } else if repr_name == "CStruct" {
                     self.register_cstruct_class(&storage_name);
+                } else if repr_name == "CPointer" {
+                    self.register_cpointer_class(&storage_name);
                 }
             }
             // Register the class name in the lexical env so that

--- a/t/empty-string-numifies-to-zero.t
+++ b/t/empty-string-numifies-to-zero.t
@@ -1,0 +1,15 @@
+use Test;
+
+# Raku numifies an empty (or whitespace-only) string to 0, so it compares equal
+# to 0 rather than "not a number at all".
+
+plan 8;
+
+ok "" == 0, 'an empty string equals 0';
+ok "  " == 0, 'a whitespace-only string equals 0';
+ok "\t\n" == 0, 'a string of other whitespace equals 0';
+nok "" != 0, 'and is not unequal to 0';
+ok "" < 1, 'it orders below 1';
+ok "" >= 0, 'it orders at 0';
+is "" <=> 0, Same, 'three-way compares Same';
+is +"", 0, 'prefix + agrees';

--- a/t/nativecall-cstruct-fields.t
+++ b/t/nativecall-cstruct-fields.t
@@ -1,0 +1,57 @@
+use Test;
+use NativeCall;
+
+# A `is repr('CStruct')` handle carries a C pointer; reading one of its declared
+# attributes must read the field out of that struct, at the offset the C ABI
+# gives it. Before this, every such accessor answered Nil.
+
+plan 12;
+
+# POSIX `struct tm` — its first nine members are ints in this order on every
+# platform mutsu targets.
+class Tm is repr('CStruct') {
+    has int32 $.tm_sec;
+    has int32 $.tm_min;
+    has int32 $.tm_hour;
+    has int32 $.tm_mday;
+    has int32 $.tm_mon;
+    has int32 $.tm_year;
+    has int32 $.tm_wday;
+    has int32 $.tm_yday;
+    has int32 $.tm_isdst;
+}
+
+sub gmtime(CArray[int64] --> Pointer) is native { * }
+
+my $epoch = CArray[int64].new;
+$epoch[0] = 0;
+my $p = gmtime($epoch);
+ok $p.defined, 'gmtime returned a pointer';
+
+# The epoch is 1970-01-01T00:00:00Z, a Thursday.
+my $tm = nativecast(Tm, $p);
+is $tm.tm_sec, 0, 'tm_sec at offset 0';
+is $tm.tm_min, 0, 'tm_min at offset 4';
+is $tm.tm_hour, 0, 'tm_hour at offset 8';
+is $tm.tm_mday, 1, 'tm_mday at offset 12';
+is $tm.tm_mon, 0, 'tm_mon at offset 16';
+is $tm.tm_year, 70, 'tm_year at offset 20';
+is $tm.tm_wday, 4, 'tm_wday at offset 24 (the epoch was a Thursday)';
+is $tm.tm_yday, 0, 'tm_yday at offset 28';
+
+# `struct lconv` (C89) begins with `char *decimal_point`, so it exercises a
+# `Str` field (read through the pointer) and a pointer-shaped field.
+class Lconv is repr('CStruct') {
+    has Str $.decimal_point;
+    has Pointer $.thousands_sep;
+}
+
+sub localeconv(--> Pointer) is native { * }
+
+my $lc = nativecast(Lconv, localeconv());
+is $lc.decimal_point, '.', 'a Str field reads through the char*';
+ok $lc.thousands_sep.defined, 'a pointer field comes back as a Pointer';
+
+# Casting the same address twice gives equal field reads: the cast is a
+# reinterpretation, not a copy.
+is nativecast(Tm, $p).tm_year, $tm.tm_year, 'nativecast reinterprets in place';


### PR DESCRIPTION
## Problem

mutsu passed an `is repr('CStruct')` value around as an **opaque native
handle** — an instance carrying the C pointer, enough to hand back to C but not
to look inside. Real bindings look inside: `OpenSSL::SSL` declares the whole
`SSL` struct and reads `$ssl.server`; `OpenSSL::CryptTools` casts an
`EVP_CIPHER*` and reads `$evp.key_len` to validate a key length. Every such
accessor answered `Nil`, because the class declares the fields as attributes but
the instance has no Raku storage for them.

## Fix

`runtime::cstruct_layout` computes each field's byte offset from the declared
attributes using the C alignment rules, and the accessor path reads the field out
of the pointed-to memory.

- A field declared as another native class comes back as a handle of that class,
  so `$ssl.method.version`-style chains keep working; a `Str` field is read
  through its `char*`.
- A field type NativeCall cannot marshal **aborts the whole layout** rather than
  shifting every later field — a wrong offset is a silent wild read, not a
  visible error.
- NativeCall's `nativecast($target-type, $source)` lands with it: without it
  there is no way to reach the fields of a struct a C function returned as an
  opaque pointer.

Two supporting gaps closed on the way:

- **`is repr('CPointer')` was not tracked at all.** It matters here because a
  *field* of such a type (OpenSSL's `BIO`) is still one pointer wide inside the
  enclosing struct — without it, `SSL`'s layout aborted at its third field and
  no `SSL` field was readable.
- **An empty (or whitespace-only) string numifies to `0` in Raku**, so `"" == 0`
  is True. The numeric bridge treated it as "not a number at all" and answered
  False — while `+""` already gave `0`, so the two disagreed — and `"" <=> 0`
  threw `X::Str::Numeric` instead of returning `Same`. Fixing that exposed that
  `!=` did not mirror `==`: it compared operands of different shapes
  structurally. `!=` now uses the same rule as `==`. (This is what `01-basic`'s
  `ok $ssl.read(1) == 0` needed.)

## Result

- `OpenSSL 01-basic`: 2/7 → **7/7**. Battery baseline 14 → **15/18**.
- Pinned by `t/nativecall-cstruct-fields.t` (field offsets across a nine-int
  POSIX `struct tm`, a `Str` field and a pointer field via `struct lconv`, and
  `nativecast` reinterpreting in place) and `t/empty-string-numifies-to-zero.t`.
  Both pass unchanged under `raku`.
- Unit tests cover the layout rules directly (alignment padding, a struct-typed
  field being pointer-shaped, and an unmarshallable field aborting the layout).
- Local `make test` (2408 files) and `make roast` (1433 files / 218512 tests)
  both PASS.

Writing fields, `HAS`-embedded structs/arrays, and allocating a struct from Raku
(`MyStruct.new`) remain follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)