### PR TITLE
fix: match positional parameters against positional argument slots

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1548,35 +1548,42 @@ entangled with the assignment metaops AND has a hot-path cost:
   (low gain, real risk). The comparison + prefix fixes already captured the
   high-value, zero-hot-path-cost parts of this doc-diff.
 
-### 8.22 Positional-parameter indexing ignores named arguments written first (unblocked 2026-07-24)
+### 8.22 A native sub writes back into a `Blob` argument, clobbering the caller's value (found 2026-07-24 via OpenSSL's `04-crypt`)
 
-`args_match_param_types` matches positional parameters against *raw* argument
-slots, so a named argument written before a positional (`f(:x(1), 7)` — which is
-what forwarding a capture after adding a named, `f(:x(1), |c)`, produces)
-mis-indexes them and no candidate matches:
+NativeCall marshals a `Blob`/`Buf` argument as a byte buffer and, after the
+call, copies the (possibly callee-modified) C bytes back into the *same* Raku
+instance (`write_buf_instance_bytes`, `runtime/nativecall.rs`). That is right for
+an out-buffer but wrong for an input: a `Blob` is immutable in Raku, and the
+instance is shared with the caller's variable, so the writeback destroys it.
 
+Reproduce (needs the bundled OpenSSL battery):
+
+```raku
+use OpenSSL::CryptTools;
+my $test = Blob.new(0xf6, 0x9f, 0x24, 0x45, 0xdf, 0x4f, 0x9b, 0x17,
+                    0xad, 0x2b, 0x41, 0x7b, 0xe6, 0x6c, 0x37, 0x10);
+my $ct = encrypt($test, :aes256, :$iv, :$key);
+say $test.raku;    # raku: the original Blob   mutsu: Any (elems == 1)
 ```
-Cannot resolve caller e(Int:D); none of these signatures matches:
-    (Int $p, $y, $x)
+
+`OpenSSL::EVP` declares both the out-buffer and the plaintext as `Blob`:
+
+```raku
+our sub EVP_EncryptUpdate(OpaquePointer, Blob, CArray[int32], Blob, int32
+  --> int32) is native(&gen-lib) { ... }
 ```
 
-That is `OpenSSL::CryptTools`'s `encrypt` chain
-(`multi encrypt(:$aes256!, |c) { encrypt(:$cipher, |c) }` feeding
-`multi encrypt(Blob $plaintext, :$key, :$iv, :$cipher!)`), so the OpenSSL
-battery's `04-crypt` (1/13) cannot pass without it. The fix is small and known:
-index positional params through a precomputed list of positional argument slots,
-and give a variadic param every positional from its own index on plus every
-named.
+so the declared type cannot distinguish them — the *runtime* class can. The
+buffer `$part` is a `buf8` (mutable Buf family); the plaintext is a `Blob`
+(immutable). Restricting the writeback to a mutable Buf-family instance is the
+principled rule and matches Raku semantics, but it needs care: `write_buf_instance_bytes`
+is also reached through `Scalar`/`ContainerRef`/`VarRef` wrappers, and the
+`nativecall_pin` object-lifetime pin (ADR-less, added with the TLS battery)
+feeds it, so both the pinned and unpinned paths have to agree.
 
-**No longer blocked.** This was held back because `Test::Util`'s non-exported
-`our sub run(Str, Str, *%o)` leaked into every consumer's scope, so correcting
-the indexing made it win over the core `run` builtin and broke whitelisted
-`roast/S11-repository/cur-current-distribution.t` and `roast/S29-os/system.t`.
-That leak — a `unit module`'s routines registering into `GLOBAL::` — is fixed
-(news `2026-07/unit-module-routines-stay-in-their-package.md`), so the indexing
-fix can now land on its own merits. Re-verify those two roast files when it
-does.
-
+**Why it matters now**: `t/04-crypt.rakutest` is the OpenSSL battery's last
+failing file (6/13 as of the positional-indexing fix; the remaining failures
+are all this bug), and the battery test-suite gate is a release gate.
 
 ## Metrics
 

--- a/news/2026-07/positional-params-index-positional-slots.md
+++ b/news/2026-07/positional-params-index-positional-slots.md
@@ -1,0 +1,44 @@
+# Positional parameters are matched against positional argument slots
+
+Multi-dispatch's type check walked positional parameters against the *raw*
+argument list, so a named argument written before a positional shifted every
+positional parameter onto the wrong slot and no candidate matched:
+
+```
+Cannot resolve caller e(Int:D); none of these signatures matches:
+    (Int $p, $y, $x)
+```
+
+Writing a named argument first is not an exotic style — it is exactly what
+forwarding a capture after adding a named produces. `f(:x(1), |c)` puts `:x`
+in slot 0 and the capture's positionals after it, which is the idiom
+`OpenSSL::CryptTools` uses throughout:
+
+```raku
+multi encrypt(:$aes256! where .so, |c) { encrypt(:$cipher, |c) }
+multi encrypt(Blob $plaintext, :$key, :$iv, :$cipher! where .so) { ... }
+```
+
+`args_match_param_types` now precomputes the indices of the positional
+arguments and walks *those*: a plain positional parameter reads the slot its
+own positional index names, and a variadic one (`*@a`, `|c`, a capture
+subsignature) is handed the positionals from its index onward plus every named
+argument. The `is rw` writability check and the argument-source lookup used for
+typed-container matching follow the same index, so they no longer inspect a
+neighbouring argument either.
+
+The fix had been known for a while but could not land: with the indexing
+corrected, `Test::Util`'s non-exported `our sub run(Str, Str, *%o)` — which
+leaked into every consumer's scope — started matching `run(:out, "cmd")` and
+beat the core builtin. That leak is gone (news
+`2026-07/unit-module-routines-stay-in-their-package.md`), so this lands on its
+own merits.
+
+The bundled OpenSSL battery's `t/04-crypt.rakutest` goes from 1/13 to 6/13 —
+every `encrypt`/`decrypt` call in it goes through that forwarding chain. The
+remaining failures are a separate NativeCall bug (a `Blob` argument passed to a
+native sub is written back into, so the caller's immutable Blob is clobbered),
+recorded in `PLAN.md`.
+
+Pinned by `t/multi-dispatch-named-before-positional.t`, which passes
+identically under `raku`.

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -102,15 +102,48 @@ impl Interpreter {
             // pair or a space-parenthesized `f (a => 1)`), so it counts toward the
             // positional arity here. Without this, `multi q($x)` fails to match
             // `q("a" => 1)` / `q (a => 1)` (0 positional args counted).
-            let positional_arg_count = args
+            //
+            // Positional parameters are matched against the *positional* argument
+            // slots, not the raw ones: a named argument written before a
+            // positional (`f(:x(1), 7)` — which is what forwarding a capture after
+            // adding a named, `f(:x(1), |c)`, produces) would otherwise shift every
+            // positional param onto the wrong slot and no candidate would match.
+            let positional_indices: Vec<usize> = args
                 .iter()
-                .filter(|arg| {
+                .enumerate()
+                .filter(|(_, arg)| {
                     !matches!(
                         unwrap_varref_value((*arg).clone()).view(),
                         ValueView::Pair(..)
                     )
                 })
-                .count();
+                .map(|(idx, _)| idx)
+                .collect();
+            let positional_arg_count = positional_indices.len();
+            // Every named argument, in call order. A variadic positional (`*@a`,
+            // `|c`, a capture subsignature) is handed the positionals from its own
+            // index onward *plus* these, mirroring how a capture carries both
+            // parts.
+            let named_args: Vec<Value> = args
+                .iter()
+                .filter(|arg| {
+                    matches!(
+                        unwrap_varref_value((*arg).clone()).view(),
+                        ValueView::Pair(..)
+                    )
+                })
+                .cloned()
+                .collect();
+            let remaining_args = |from_positional: usize| -> Vec<Value> {
+                let mut out: Vec<Value> = positional_indices
+                    .get(from_positional..)
+                    .unwrap_or(&[])
+                    .iter()
+                    .map(|&idx| args[idx].clone())
+                    .collect();
+                out.extend(named_args.iter().cloned());
+                out
+            };
             let mut required_positional_count = 0usize;
             let mut positional_max_count = 0usize;
             let mut has_variadic_positional = false;
@@ -136,8 +169,12 @@ impl Interpreter {
             if !has_variadic_positional && positional_arg_count > positional_max_count {
                 return false;
             }
-            let mut i = 0usize;
+            // `p` walks the *positional* argument slots; `arg_idx` is the raw
+            // `args` index of the slot `p` names (they differ as soon as a named
+            // argument is written before a positional).
+            let mut p = 0usize;
             for pd in positional_params {
+                let arg_idx = positional_indices.get(p).copied();
                 let is_capture_param = pd.name == "_capture" || (pd.slurpy && pd.sigilless);
                 let is_subsig_capture = pd.is_capture_subsignature();
                 let mut arg_for_checks: Option<Value> = if pd.slurpy || is_capture_param {
@@ -145,8 +182,8 @@ impl Interpreter {
                         // |c capture params preserve both positional and named parts.
                         let mut positional = Vec::new();
                         let mut named = std::collections::HashMap::new();
-                        let remaining = args.get(i..).unwrap_or(&[]);
-                        for arg in remaining {
+                        let remaining = remaining_args(p);
+                        for arg in &remaining {
                             let arg = unwrap_varref_value(arg.clone());
                             if let ValueView::Pair(key, val) = arg.view() {
                                 named.insert(key.clone(), val.clone());
@@ -159,8 +196,8 @@ impl Interpreter {
                         // For single-star slurpy (*@), flatten list arguments but preserve
                         // itemized Arrays ($[...] / .item) as single positional values.
                         let mut items = Vec::new();
-                        let remaining = args.get(i..).unwrap_or(&[]);
-                        for arg in remaining {
+                        let remaining = remaining_args(p);
+                        for arg in &remaining {
                             let arg = unwrap_varref_value(arg.clone());
                             if !pd.double_slurpy {
                                 if let ValueView::Array(arr, kind) = arg.view()
@@ -188,18 +225,17 @@ impl Interpreter {
                         Some(Value::real_array(items))
                     }
                 } else if pd.name.starts_with('@') || pd.name.starts_with('%') {
-                    args.get(i).cloned().map(unwrap_varref_value)
+                    arg_idx.and_then(|idx| args.get(idx).cloned().map(unwrap_varref_value))
                 } else if is_subsig_capture {
-                    let remaining = args.get(i..).unwrap_or(&[]);
+                    let remaining = remaining_args(p);
                     Some(sub_signature_target_from_remaining_args(
                         &remaining
-                            .iter()
-                            .cloned()
+                            .into_iter()
                             .map(unwrap_varref_value)
                             .collect::<Vec<_>>(),
                     ))
                 } else {
-                    args.get(i).cloned().map(unwrap_varref_value)
+                    arg_idx.and_then(|idx| args.get(idx).cloned().map(unwrap_varref_value))
                 };
                 // Whether an actual argument was passed for this param (vs. an
                 // unsupplied optional filled with its type object below). An
@@ -226,16 +262,17 @@ impl Interpreter {
                 // Check VarRef wrapping (function calls) and pending arg sources
                 // (which may be set for method calls via arg_sources_idx).
                 if pd.traits.iter().any(|t| t == "rw") {
-                    let raw_arg = args.get(i);
+                    let raw_arg = arg_idx.and_then(|idx| args.get(idx));
                     let is_varref = raw_arg
                         .map(|a| varref_from_value(a).is_some())
                         .unwrap_or(false);
-                    let has_arg_source = self
-                        .pending_call_arg_sources
-                        .as_ref()
-                        .and_then(|sources| sources.get(i))
-                        .and_then(|name| name.as_ref())
-                        .is_some();
+                    let has_arg_source = arg_idx.is_some_and(|idx| {
+                        self.pending_call_arg_sources
+                            .as_ref()
+                            .and_then(|sources| sources.get(idx))
+                            .and_then(|name| name.as_ref())
+                            .is_some()
+                    });
                     if !is_varref && !has_arg_source {
                         return false;
                     }
@@ -279,16 +316,18 @@ impl Interpreter {
                     let dispatch_arg = self
                         .coercion_dispatch_value(&resolved_constraint, arg)
                         .unwrap_or_else(|| arg.clone());
-                    let source_name = args
-                        .get(i)
+                    let source_name = arg_idx
+                        .and_then(|idx| args.get(idx))
                         .and_then(varref_from_value)
                         .map(|(source_name, _)| source_name)
                         .or_else(|| {
-                            self.pending_call_arg_sources
-                                .as_ref()
-                                .and_then(|sources| sources.get(i))
-                                .and_then(|name| name.as_ref())
-                                .cloned()
+                            arg_idx.and_then(|idx| {
+                                self.pending_call_arg_sources
+                                    .as_ref()
+                                    .and_then(|sources| sources.get(idx))
+                                    .and_then(|name| name.as_ref())
+                                    .cloned()
+                            })
                         });
                     let source_constraint = source_name.as_deref().and_then(|source_name| {
                         self.var_type_constraint(source_name).or_else(|| {
@@ -402,8 +441,9 @@ impl Interpreter {
                     // a literal/constant argument.  Map each positional subsignature
                     // param to the corresponding raw positional arg (the subsignature
                     // consumes the capture's positional args in order, starting at
-                    // index `i`).
-                    if !self.sub_signature_rw_args_writable(sub_params, args, i) {
+                    // this param's own positional slot).
+                    let raw_start = positional_indices.get(p).copied().unwrap_or(args.len());
+                    if !self.sub_signature_rw_args_writable(sub_params, args, raw_start) {
                         return false;
                     }
                 }
@@ -484,9 +524,9 @@ impl Interpreter {
                     self.bind_param_value(&pd.name, arg.clone());
                 }
                 if is_subsig_capture {
-                    i = args.len();
+                    p = positional_indices.len();
                 } else if !pd.slurpy {
-                    i += 1;
+                    p += 1;
                 }
             }
             // A capture parameter carrying a subsignature (e.g. `|(*@all, :$really!)`

--- a/t/multi-dispatch-named-before-positional.t
+++ b/t/multi-dispatch-named-before-positional.t
@@ -1,0 +1,42 @@
+use Test;
+
+plan 8;
+
+# Multi-dispatch matches positional parameters against the *positional*
+# argument slots. A named argument written before a positional — which is what
+# forwarding a capture after adding a named (`f(:x(1), |c)`) produces — used to
+# shift every positional param onto the wrong slot, so no candidate matched.
+
+proto sub enc(|) { * }
+multi sub enc(:$aes256! where .so, |c) { enc(:cipher('c256'), |c) }
+multi sub enc(Blob $plain, :$key, :$iv, :$cipher! where .so) {
+    "enc({$plain.elems}):$cipher:{$key.elems}:{$iv.elems}"
+}
+
+my $plain = Blob.new(1, 2, 3, 4);
+my $key = Blob.new(9, 9);
+my $iv = Blob.new(7, 7, 7);
+is enc($plain, :aes256, :$iv, :$key), 'enc(4):c256:2:3',
+    'a capture forwarded after adding a named still binds the positional';
+is-deeply $plain, Blob.new(1, 2, 3, 4), 'the forwarded argument is untouched';
+
+# The same, written directly rather than through a forwarder.
+multi sub two(Int $a, Str $b, :$flag) { "two:$a:$b:$flag" }
+sub fwd(|c) { two(:flag, |c) }
+is fwd(5, 'z'), 'two:5:z:True', 'a named written first does not shift two positionals';
+
+# Type-based selection must still see the right argument in each slot.
+multi sub pick(Int $n, :$tag) { "int:$n:$tag" }
+multi sub pick(Str $s, :$tag) { "str:$s:$tag" }
+is pick(:tag<t>, 3), 'int:3:t', 'the Int candidate wins with a leading named';
+is pick(:tag<t>, 'a'), 'str:a:t', 'the Str candidate wins with a leading named';
+
+# A slurpy takes the positionals from its own slot on, not from the raw one.
+multi sub rest(Int $first, *@more, :$sep = '-') { ($first, |@more).join($sep) }
+is rest(:sep<+>, 1, 2, 3), '1+2+3', 'a slurpy after a leading named collects the right tail';
+
+# An arity that only matches once the named args are discounted.
+multi sub arity(Int $a, :$x) { "one:$a" }
+multi sub arity(Int $a, Int $b, :$x) { "two:$a,$b" }
+is arity(:x, 1), 'one:1', 'a named argument does not count toward positional arity';
+is arity(:x, 1, 2), 'two:1,2', 'the two-positional candidate still wins on two positionals';


### PR DESCRIPTION
## Problem

Multi-dispatch's type check walked positional parameters against the **raw** argument list, so a named argument written before a positional shifted every positional parameter onto the wrong slot and no candidate matched:

```
Cannot resolve caller e(Int:D); none of these signatures matches:
    (Int $p, $y, $x)
```

Writing a named argument first is not an exotic style — it is exactly what forwarding a capture after adding a named produces. `f(:x(1), |c)` puts `:x` in slot 0 and the capture's positionals after it, which is the idiom `OpenSSL::CryptTools` uses throughout:

```raku
multi encrypt(:$aes256! where .so, |c) { encrypt(:$cipher, |c) }
multi encrypt(Blob $plaintext, :$key, :$iv, :$cipher! where .so) { ... }
```

## Fix

`args_match_param_types` precomputes the indices of the positional arguments and walks *those*:

- a plain positional parameter reads the slot its own positional index names;
- a variadic one (`*@a`, `|c`, a capture subsignature) is handed the positionals from its index onward plus every named argument, mirroring how a capture carries both parts;
- the `is rw` writability check and the argument-source lookup used for typed-container matching follow the same index, so they no longer inspect a neighbouring argument either.

## Why now

The fix has been known for a while but could not land: with the indexing corrected, `Test::Util`'s non-exported `our sub run(Str, Str, *%o)` — which leaked into every consumer's scope — started matching `run(:out, "cmd")` and beat the core builtin, breaking whitelisted `roast/S11-repository/cur-current-distribution.t` and `roast/S29-os/system.t`. That leak is gone as of #5369, so this lands on its own merits. Both files verified green here.

## Result

The bundled OpenSSL battery's `t/04-crypt.rakutest` goes from **1/13 to 6/13** — every `encrypt`/`decrypt` call in it goes through that forwarding chain. The remaining failures are a separate NativeCall bug (a `Blob` argument passed to a native sub is written back into, clobbering the caller's immutable Blob), recorded as **PLAN.md 8.22** with a reproduction and the shape of the fix.

## Tests

- `t/multi-dispatch-named-before-positional.t` — forwarding, direct calls, type-based selection, slurpy tails, and arity counting with a leading named. Passes identically under `raku`.
- `make test`: PASS (2411 files). `make roast`: PASS (1432 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)