### PR TITLE
fix: a `where` constraint no longer wipes the caller's earlier lexicals

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -129,39 +129,16 @@ section.
       (user policy 2026-07-24). The release-time gate now runs every battery's upstream suite
       against the shipped library (`scripts/battery-testsuite.sh`, `batteries.lock`,
       `batteries-whitelist.txt`; see [docs/batteries/testsuite-gate.md](docs/batteries/testsuite-gate.md)),
-      but it is a **baseline** gate, and the measured baseline is only **12/18 test files** (it
-      landed at 11/18; `10-client-ca-file` was fixed since). The goal is to raise that toward
-      all-green so a release ships batteries that genuinely pass their own suites — the gate stops
-      regressions, it does not close these gaps:
-      - **OpenSSL — 3/7**. Measured shapes (release build, run from the suite's own checkout):
-        `01-basic` 2/7 die (0.1 s) · `03-rsa` 1/8 **hang** · `04-crypt` 1/13 die (0.0 s) ·
-        `05-digest` 0/24 **hang**.
-        ✅ `10-client-ca-file` **DONE** — was a SIGSEGV (exit 139), now 7/7. Two general NativeCall
-        bugs, neither OpenSSL-specific: an undefined `Str` argument was stringified instead of
-        marshalled as a NULL `char*` (so `ERR_error_string($e, Nil)`, where NULL means "use your own
-        static buffer", wrote up to 256 bytes into a 1-byte buffer and corrupted the heap), and
-        `CArray[T].new` did not flatten an Array/List argument (so the `CArray[uint8].new(
-        $path.encode.list, 0)` C-string idiom built a 2-element buffer and the callee saw a garbage
-        filename). Pins: `t/nativecall-null-str-arg.t`, `t/carray-new-flattens-list.t`.
-        ★ **Root cause of both hangs is found and is ONE general mutsu bug — multi-dispatch picks a
-        coercion candidate over an exact type match.** Minimal repro:
-        ```raku
-        my proto sub f(|) {*}
-        my multi sub f(Str() $s)   { "str"  }
-        my multi sub f(Blob:D $b)  { "blob" }
-        say f("abc".encode);   # raku: blob   mutsu: str   <-- wrong
-        ```
-        `Str()` (a coercion type, which accepts anything coercible) must rank **less specific** than
-        an exact `Blob:D` match. `OpenSSL::Digest` declares exactly this shape, and its `Str()`
-        candidate delegates with `md5 $string.encode` — so in mutsu the Blob re-enters the `Str()`
-        candidate and it is **infinite mutual recursion**, i.e. the hang. Fixing the ranking should
-        close `05-digest` (0/24) and `03-rsa` (1/8, `.sign` → `sha1`) together. Beware blast radius:
-        this is core dispatch ranking (cf. the earlier specificity fix #4967).
-        The `10-client-ca-file` **segfault** is a separate, higher-priority defect (project rule:
-        panics/crashes first), as are the two fast dies.
-        ★ Already ruled out: a *harness* artifact. These suites reach for fixtures by relative path
-        (`slurp 't/key.pem'`), so the harness now runs each test with its own repo as the working
-        directory. That moved `03-rsa` from 0/8 to 1/8 — real, but it flipped no file to passing.
+      but it is a **baseline** gate, and the measured baseline is **16/18 test files** (it landed at
+      11/18). The goal is to raise that toward all-green so a release ships batteries that genuinely
+      pass their own suites — the gate stops regressions, it does not close these gaps:
+      - **OpenSSL — 7/7** ✅ **DONE (2026-07-25)**. All seven upstream files pass against the
+        bundled library. The gaps were closed by general mutsu fixes, none OpenSSL-specific:
+        NativeCall NULL-`Str` marshalling + `CArray[T].new` list flattening (`10-client-ca-file`'s
+        SIGSEGV), multi-dispatch specificity (a `Str()` coercion candidate outranked an exact
+        `Blob:D`, which made `OpenSSL::Digest` mutually recurse — the `05-digest`/`03-rsa` hangs),
+        `unit module` package scoping (#5369), positional-argument indexing (#5370), and the
+        `where`-constraint caller-lexical wipe (`04-crypt`, PLAN 8.22).
       - **Zef — 8/10** (`00-load` 1/2, `distribution-depends-parsing` 18/35). ★ This **contradicts
         the recorded "all 10 upstream tests pass" (2026-07-10, #4383/#4384)**. Not yet triaged:
         either a real regression since then, or a run-context difference (the gate runs
@@ -1547,95 +1524,6 @@ entangled with the assignment metaops AND has a hot-path cost:
   see). Measure the loop-bench delta first; if it regresses, this stays deferred
   (low gain, real risk). The comparison + prefix fixes already captured the
   high-value, zero-hot-path-cost parts of this doc-diff.
-
-### 8.22 Calling a `where`-constrained module sub wipes every earlier caller lexical (found 2026-07-24 via OpenSSL's `04-crypt`)
-
-**Decided 2026-07-24 (user): fix this with the correct architecture — make the
-call-return coherence precise, do NOT paper over it by flushing every `my`
-declaration into `env`.** The precise route is the one the codebase is already
-converging on (carrier writes are logged by name; cell boxing is the permanent
-mechanism); the env-flush route would put an `env` write on the hottest
-declaration path *and* keep `env` as a shadow source of truth, which is the
-thing being retired.
-
-#### Symptom
-
-Every caller lexical declared *before* the call is reset to `Any`. Minimal
-reproduction — no NativeCall, no multi-dispatch, no forwarding:
-
-```raku
-# lib/WhereMod.rakumod
-unit module WhereMod;
-sub w(Int $n, :$c! where .so) is export { $n }
-```
-
-```raku
-use WhereMod;
-my $a = Blob.new(1);
-my $b = 99;
-my $r = w(1, :c<x>);
-say "a={$a.gist} b={$b.gist} r={$r.gist}";
-# raku:  a=Blob:0x<01> b=99 r=1
-# mutsu: a=(Any)       b=(Any) r=1
-```
-
-Note `$r` — the local receiving the call's result — is **correct**; only the
-earlier ones are wiped. Their type is irrelevant (`Blob`, `Int`, `Str` all go to
-`Any`).
-
-All three of these are required; drop any one and it is clean:
-
-1. the sub is declared in a **module** (the same sub in the main script is fine);
-2. it carries a **`where` constraint** — that is what keeps the routine on the
-   interpreter carrier instead of the OTF compile;
-3. the call's **result is assigned to a variable** — both `my $r = w(...)` and
-   a separate `my $r; $r = w(...)` reproduce; discarding it (`w(1, :c<x>);` as a
-   bare statement) is clean.
-
-Two things hide it, both diagnostic: reading the variable once before the call,
-and putting any unrelated statement (`say "sep";`) between the declaration and
-the call. Both make `env` carry the value, which says the slot's value had never
-reached `env` and something is rebuilding the slots from `env`.
-
-Not JIT- or GC-related (`MUTSU_JIT=off` / `MUTSU_GC=off` reproduce identically).
-
-#### What has been ruled out (2026-07-24, by instrumentation — do not re-walk)
-
-- **`sync_locals_from_env` no longer exists.** The blanket env→locals reconcile
-  is retired (`drain_and_reconcile_after_cached_call` now only calls
-  `apply_pending_rw_writeback`; `box_carrier_free_var_writes` documents cell
-  boxing as the permanent mechanism). An earlier version of this entry blamed
-  it — that citation was stale.
-- **None of the carrier writebacks fire for this case**: `apply_pending_rw_writeback`,
-  `writeback_carrier_writes`, and both branches of
-  `carrier_writeback_changed_aggregates` were instrumented and produce no output
-  on the reproduction.
-- **The frame-entry seeding loop in `run_inner`** (`vm/vm_run_loop.rs`, which
-  fills every slot from `env` by name and NILs the misses) is **not** re-running
-  for the caller frame — also instrumented, no output.
-- **NativeCall's `Blob` writeback (`write_buf_instance_bytes`) is not involved** —
-  the reproduction contains no native call at all. (That writeback *is*
-  separately wrong for an immutable `Blob`; restricting it to the mutable `Buf`
-  family is correct but fixes nothing here, so it needs its own evidence.)
-
-#### Where to start next
-
-The remaining candidate is the save/restore of the per-execution registers
-around the nested run: `with_nested_registers` (`vm/vm_run_loop.rs`) takes
-`self.locals` and restores it afterwards, and `exec_call` reaches it via
-`run_block` → `run_block_raw` → `run_nested`. Instrument the restore itself
-(and `push_call_frame`/`pop_call_frame`'s `saved_locals`) to find which snapshot
-the stale `Any`s come from; the asymmetry to explain is why the result-receiving
-slot survives while every earlier one does not.
-
-**Verified pre-existing**: reproduces unchanged at `3fc5a5a5b`, before the
-unit-module package-scoping (#5369) and positional-indexing (#5370) work.
-
-**Why it matters now**: it is what holds the bundled OpenSSL battery's
-`t/04-crypt.rakutest` at 6/13 — `OpenSSL::CryptTools`'s `encrypt`/`decrypt`
-candidates are all `where`-constrained module subs, so every call wipes the
-caller's plaintext Blob and the round-trip assertions compare against `Any`. The
-battery test-suite gate is a release gate.
 
 ## Metrics
 

--- a/batteries-whitelist.txt
+++ b/batteries-whitelist.txt
@@ -1,6 +1,7 @@
 IO::Socket::SSL	01-basic.rakutest
 OpenSSL	01-basic.rakutest
 OpenSSL	03-rsa.rakutest
+OpenSSL	04-crypt.rakutest
 OpenSSL	05-digest.rakutest
 OpenSSL	06-digest-md5.rakutest
 OpenSSL	07-version.rakutest

--- a/news/2026-07/where-constraint-caller-lexical-wipe.md
+++ b/news/2026-07/where-constraint-caller-lexical-wipe.md
@@ -1,0 +1,67 @@
+# A `where`-constrained module sub no longer wipes every earlier caller lexical
+
+Calling a module sub whose signature carries a `where` constraint reset every
+caller lexical declared *before* the call to `Any`:
+
+```raku
+# lib/WhereMod.rakumod
+unit module WhereMod;
+sub w(Int $n, :$c! where .so) is export { $n }
+```
+
+```raku
+use WhereMod;
+my $a = Blob.new(1);
+my $b = 99;
+my $r = w(1, :c<x>);
+say "a={$a.gist} b={$b.gist} r={$r.gist}";
+# raku:  a=Blob:0x<01> b=99 r=1
+# was:   a=(Any)       b=(Any) r=1
+```
+
+Only the earlier lexicals were affected — `$r`, which receives the call's
+result, was assigned after the damage and so read correctly. That asymmetry, and
+the fact that reading a variable (or running any statement at all) between the
+declarations and the call made the problem vanish, was the shape of the bug:
+something was rebuilding the caller's local slots from `env`, and `env` only
+carried the right value once an unrelated read or write had pushed it there.
+
+## The cause
+
+A `where` clause can legitimately mutate a caller lexical by name
+(`where { $t ~= 'a' }`). Such a write lands in `env`, so the owning caller
+*slot* has to be refreshed for the caller to observe it. The names to refresh
+were determined by snapshotting `env` before the clause and diffing it after.
+
+That diff is not sound. `Env` is a chain of scoped tiers and `Env::iter` walks
+only the innermost tier's overlay, while `Env::get` searches the whole chain. A
+nested call inside the clause can flatten the parent chain into the current tier
+(`Env::scoped_child` does this once the chain passes `MAX_OVERLAY_DEPTH`), and
+after that flattening every *inherited* caller lexical appears in `iter` for the
+first time — indistinguishable, to the diff, from a name the clause just wrote.
+Each was then written back into the caller's slot from its `env` value, which is
+the declaration seed `Any`: with the slot authoritative, a plain `my $a = 41`
+never pushes `41` to `env`. Hence the wipe, and hence why any statement that did
+push a value to `env` hid it.
+
+The precise record already exists: the compiler tracks each block's
+`free_var_writes`. The `where` clause now runs through a new
+`eval_block_value_recording_writes`, which registers exactly those names for the
+caller-slot writeback, and the `env` diff is gone. A clause that mutates a
+caller lexical still propagates; a clause that mutates nothing now records
+nothing.
+
+## Effect
+
+This was the last gap in the bundled OpenSSL battery.
+`OpenSSL::CryptTools`'s `encrypt`/`decrypt` candidates are all
+`where`-constrained module subs, so every call wiped the caller's plaintext
+`Blob` and the round-trip assertions compared against `Any`.
+`t/04-crypt.rakutest` goes from 6/13 to **13/13**, which brings the OpenSSL
+suite to **7/7** and the release-time battery gate baseline
+(`batteries-whitelist.txt`) to 16/18.
+
+Pin: `t/where-constraint-caller-lexicals.t` (with `t/lib/WhereConstraintMod.rakumod`).
+Reproducing needs the module declaration, the `where` constraint, an assigned
+result, and a mainline caller frame — the pin documents all four so it is not
+accidentally rewritten into a shape that stops testing anything.

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -134,12 +134,39 @@ impl Interpreter {
         self.eval_block_value_opts(body, false)
     }
 
+    /// `eval_block_value`, additionally recording the block's compile-time
+    /// `free_var_writes` for the caller-slot writeback (retain-on-miss list).
+    ///
+    /// A carrier that runs user code by name — a `where` clause, notably — can
+    /// mutate a caller lexical (`where { $t ~= 'a' }`). The write reaches `env`,
+    /// but the owning caller *slot* is only refreshed if the name is recorded.
+    /// The compiler already knows exactly which free variables the block writes,
+    /// so record those and nothing else. (Diffing `env` before/after is not a
+    /// usable substitute: `Env::iter` walks only this tier's overlay, and a
+    /// nested call can flatten the parent chain into it mid-block, which makes
+    /// every inherited lexical look brand-new — see PLAN 8.22.)
+    pub(crate) fn eval_block_value_recording_writes(
+        &mut self,
+        body: &[Stmt],
+    ) -> Result<Value, RuntimeError> {
+        self.eval_block_value_inner(body, false, true)
+    }
+
     /// `eval_block_value`, with `is_eval_unit` marking `body` as an EVAL'd
     /// compilation unit's mainline (see `Compiler::mark_as_eval_unit`).
     pub(crate) fn eval_block_value_opts(
         &mut self,
         body: &[Stmt],
         is_eval_unit: bool,
+    ) -> Result<Value, RuntimeError> {
+        self.eval_block_value_inner(body, is_eval_unit, false)
+    }
+
+    fn eval_block_value_inner(
+        &mut self,
+        body: &[Stmt],
+        is_eval_unit: bool,
+        record_free_var_writes: bool,
     ) -> Result<Value, RuntimeError> {
         if body.is_empty() {
             return Ok(Value::NIL);
@@ -182,6 +209,14 @@ impl Interpreter {
         // frames, so the by-name write survives the owner frame's env restore.
         // No-op in the default build (gated on cell_boxing_active).
         self.box_carrier_free_var_writes(&code);
+        if record_free_var_writes {
+            for sym in &code.free_var_writes {
+                let name = sym.resolve();
+                if name != "_" && name != "$_" && name != "@_" && name != "%_" {
+                    self.record_caller_var_writeback(&name);
+                }
+            }
+        }
         self.block_scope_depth += 1;
         let result = self.run_compiled_block(&code, &compiled_fns);
         let trailing_sub_value = match body.last() {

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -73,20 +73,22 @@ impl Interpreter {
         // a `where { $t ~= 'a' }` clause can mutate a captured-outer caller
         // lexical by name. The write reaches env, but the owning caller slot is
         // refreshed only by the call site's blanket pull — a no-op once
-        // env_dirty is removed. Snapshot the env scalars before the clause runs
-        // and record the names it changes into the retain-on-miss caller-var
-        // writeback, drained at the call site.
-        let pre_env: std::collections::HashMap<crate::symbol::Symbol, Value> = self
-            .env
-            .iter()
-            .filter(|(_, v)| Self::is_writeback_safe_scalar(v))
-            .map(|(k, v)| (*k, v.clone()))
-            .collect();
+        // env_dirty is removed. `eval_block_value_recording_writes` records the
+        // clause's compile-time `free_var_writes` into the retain-on-miss
+        // caller-var writeback, drained at the call site.
+        //
+        // This used to diff `env` around the clause instead, which was unsound:
+        // `Env::iter` walks only the innermost tier's overlay, so a nested call
+        // that flattens the parent chain into it (`Env::scoped_child` past
+        // `MAX_OVERLAY_DEPTH`) makes every inherited caller lexical look
+        // brand-new. Each was then "written back" from its stale `env` value —
+        // the declaration seed `Any`, because the slot is authoritative — wiping
+        // every caller lexical declared before the call (PLAN 8.22).
         let ok = match where_expr.as_ref() {
             Expr::AnonSub { body, .. } => {
                 let ph_keys = self.bind_where_placeholders(body, &bound_val);
                 let r = self
-                    .eval_block_value(body)
+                    .eval_block_value_recording_writes(body)
                     .map(|v| v.truthy())
                     .unwrap_or(false);
                 for k in ph_keys {
@@ -96,28 +98,15 @@ impl Interpreter {
                 r
             }
             Expr::MethodCall { target, .. } if matches!(target.as_ref(), Expr::Var(name) if name == "_") => {
-                self.eval_block_value(&[Stmt::Expr(where_expr.as_ref().clone())])
+                self.eval_block_value_recording_writes(&[Stmt::Expr(where_expr.as_ref().clone())])
                     .map(|v| v.truthy())
                     .unwrap_or(false)
             }
             expr => self
-                .eval_block_value(&[Stmt::Expr(expr.clone())])
+                .eval_block_value_recording_writes(&[Stmt::Expr(expr.clone())])
                 .map(|v| self.smart_match(&bound_val, &v))
                 .unwrap_or(false),
         };
-        let changed: Vec<String> = self
-            .env
-            .iter()
-            .filter(|(k, v)| {
-                k.resolve() != "_"
-                    && Self::is_writeback_safe_scalar(v)
-                    && pre_env.get(*k).map(|p| p != *v).unwrap_or(true)
-            })
-            .map(|(k, _)| k.resolve())
-            .collect();
-        for name in changed {
-            self.record_caller_var_writeback(&name);
-        }
         if let Some(previous) = saved_topic {
             self.env.insert("_".to_string(), previous);
         } else {

--- a/t/lib/WhereConstraintMod.rakumod
+++ b/t/lib/WhereConstraintMod.rakumod
@@ -1,0 +1,9 @@
+unit module WhereConstraintMod;
+
+# A `where`-constrained named parameter keeps the routine on the interpreter
+# carrier (it is not eligible for the on-the-fly compile), so calling it runs
+# the constraint through `check_named_param_where_constraint`.
+sub constrained(Int $n, :$c! where .so) is export { $n }
+
+# Same signature shape without the constraint, as the control.
+sub unconstrained(Int $n, :$c) is export { $n }

--- a/t/where-constraint-caller-lexicals.t
+++ b/t/where-constraint-caller-lexicals.t
@@ -1,0 +1,36 @@
+use Test;
+use lib 't/lib';
+use WhereConstraintMod;
+
+# Regression pin (PLAN 8.22): calling a `where`-constrained module sub wiped
+# every caller lexical declared before the call.
+#
+# The `where` clause check recorded the names to write back into the caller's
+# local slots by diffing `env` around the clause. `Env::iter` walks only the
+# innermost tier's overlay, and a nested call can flatten the parent chain into
+# it mid-clause — after which every inherited caller lexical looks brand-new and
+# was "written back" from its stale `env` value (the declaration seed `Any`,
+# since the slot is authoritative). The compile-time `free_var_writes` of the
+# clause body is the precise record and is used instead.
+#
+# Reproducing needs all of: the sub lives in a module, it carries a `where`
+# constraint, the call's result is assigned, and the caller frame is the
+# mainline (the same code inside a `{ }` block does not reproduce). Reading a
+# lexical — or running any statement at all — between the declarations and the
+# call also hides it, so nothing may be inserted between them below.
+
+plan 6;
+
+my $blob = Blob.new(1);
+my $int = 99;
+my $str = 'kept';
+my $result = constrained(1, :c<x>);
+is $result, 1, 'the constrained call returns its value';
+is $int, 99, 'an Int lexical declared before the call survives';
+is $str, 'kept', 'a Str lexical declared before the call survives';
+is $blob.elems, 1, 'a Blob lexical declared before the call survives';
+
+my $plain-int = 42;
+my $plain-result = unconstrained(1, :c<x>);
+is $plain-int, 42, 'the unconstrained control keeps its caller lexical too';
+is $plain-result, 1, 'the unconstrained call returns its value';


### PR DESCRIPTION
Calling a module sub with a `where`-constrained parameter reset **every caller lexical declared before the call** to `Any`:

```raku
# lib/WhereMod.rakumod
unit module WhereMod;
sub w(Int $n, :$c! where .so) is export { $n }
```
```raku
use WhereMod;
my $a = Blob.new(1);
my $b = 99;
my $r = w(1, :c<x>);
say "a={$a.gist} b={$b.gist} r={$r.gist}";
# raku:  a=Blob:0x<01> b=99 r=1
# was:   a=(Any)       b=(Any) r=1
```

Only the earlier lexicals were hit — `$r` is assigned after the damage — and inserting any statement between the declarations and the call hid it.

## Cause

A `where` clause may legitimately mutate a caller lexical by name (`where { $t ~= 'a' }`); that write lands in `env`, so the owning caller *slot* must be refreshed. The names to refresh were found by snapshotting `env` before the clause and diffing after.

That diff is unsound. `Env` is a chain of scoped tiers: `Env::iter` walks only the innermost tier's overlay while `Env::get` searches the chain. A nested call inside the clause can flatten the parent chain into the current tier (`Env::scoped_child` past `MAX_OVERLAY_DEPTH`), after which every *inherited* caller lexical appears in `iter` for the first time — indistinguishable from a name the clause just wrote. Each was then written back into the caller's slot from its `env` value: the declaration seed `Any`, because the slot is authoritative and a plain `my $a = 41` never pushes `41` to `env`. That is also why any statement that did push to `env` hid the bug.

## Fix

Use the precise record that already exists — the compiler's per-block `free_var_writes` — via a new `eval_block_value_recording_writes`, and delete the `env` diff. A clause that mutates a caller lexical still propagates; a clause that mutates nothing now records nothing.

## Effect

Last gap in the bundled OpenSSL battery: `OpenSSL::CryptTools`'s `encrypt`/`decrypt` candidates are all `where`-constrained module subs, so every call wiped the caller's plaintext `Blob` and the round-trip assertions compared against `Any`.

- `t/04-crypt.rakutest`: 6/13 → **13/13**
- OpenSSL battery: **7/7** (all seven upstream files)
- Release-time battery gate baseline (`batteries-whitelist.txt`): 12/18 → **16/18**

Closes PLAN 8.22 (section removed; recorded in `news/2026-07/`).

## Testing

- Pin `t/where-constraint-caller-lexicals.t` (+ `t/lib/WhereConstraintMod.rakumod`); verified it fails on the parent commit and passes here. Reproducing needs the module declaration, the `where` constraint, an assigned result, and a mainline caller frame — the pin documents all four.
- `make test`: 2413 files / 23018 tests, all pass.
- The `where`-using whitelisted roast files (`S06-signature/{named-parameters,slurpy-and-interpolation,introspection,type-capture,types}.t`, `S12-subset/{multi-dispatch,subtypes,type-subset}.t`): all pass.
- Behavior for a `where` clause that *does* mutate a caller lexical is unchanged (checked before/after against the parent commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)