### PR TITLE
fix: a `Foo::Any` constraint no longer matches everything, and a mainline exception is no longer swallowed

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -162,29 +162,25 @@ section.
           Deciding the fix needs care about *why* the blanket rollback exists (a `class`/`role`
           declared directly in a subtest body should stay lexical); making the two stores agree —
           rather than widening or narrowing the rollback blindly — is the shape of the fix.
-        - **`distribution-depends-parsing` (18/35)** — two bugs, one masking the other.
-          1. ★ **A type constraint whose qualified name ends in `::Any` is resolved as the builtin
-             `Any`**, so it matches every value and its candidate wrongly wins:
-             ```raku
-             class Spec { }
-             class Spec::Any { }
-             class Other {
-                 multi method sm(Spec::Any $s) { "ANY" }
-                 multi method sm($s)           { "GENERIC" }
-             }
-             say Other.new.sm(Spec.new);   # raku: GENERIC   mutsu: ANY   <-- wrong
-             ```
-             Renaming the class to `Spec::Alt` makes it correct, which pins the cause to the
-             trailing-component fallback in type-name resolution rather than to multi-dispatch
-             ranking. In Zef this sends a plain `Zef::Distribution::DependencySpecification` into
-             the `…::DependencySpecification::Any`-constrained `spec-matcher` candidate, which
-             calls `.specs` — a method only the `::Any` sibling has — and dies with
-             `X::Method::NotFound`.
-          2. ★ **That uncaught exception aborts the file with no message at all** — the run just
-             stops after test 18 and only the plan mismatch is reported. Wrapping the call in
-             `try`/`CATCH` is what revealed the error above. A silently swallowed exception makes
-             every failure of this kind look like a plan bug; this is worth fixing on its own, and
-             first, because it is what made this file hard to triage.
+        - **`distribution-depends-parsing` (20/35)** — three bugs so far; the first two are fixed.
+          1. ✅ **DONE** — a type constraint whose qualified name ended in `::Any` was equated with
+             the builtin `Any` by the "qualified name matching" short-name bridge in
+             `Interpreter::type_matches`, so it matched every value (every class's MRO ends in
+             `Any`) and its candidate wrongly won. In Zef that sent a plain
+             `Zef::Distribution::DependencySpecification` into the `…::Any`-constrained
+             `spec-matcher` candidate, which calls `.specs` — a method only the `::Any` sibling
+             has. The bridge now refuses core setting type names, which never live under a user
+             package. Pin: `t/nested-any-type-constraint.t`.
+          2. ✅ **DONE** — that uncaught exception aborted the file with **no message at all**:
+             `run()` propagated `finish()`'s error instead of the original, and under `Test` a
+             mainline exception always leaves the plan short, so the "Test failures" plan-mismatch
+             error replaced the real one. Every such failure read as a plan bug. Pin:
+             `t/mainline-exception-not-masked-by-plan.t`. **This one was the real blocker on
+             triage** — with the exception visible, each remaining failure names itself.
+          3. **Current frontier (test 21)**: `Failed to resolve some missing dependencies` for the
+             `[{:any["Unavailable", "Available"]},]` case — an `any(...)` dependency spec with one
+             satisfiable alternative must resolve, and does not. Reduce from
+             `Zef::Client.!find-prereq-candidates`.
       - **IO::Socket::SSL — 1/1** ✅ already green.
       Raising a file into the baseline is `scripts/battery-testsuite.sh --update` + committing the
       whitelist diff.

--- a/news/2026-07/nested-any-constraint-and-masked-mainline-exception.md
+++ b/news/2026-07/nested-any-constraint-and-masked-mainline-exception.md
@@ -1,0 +1,71 @@
+# A `Foo::Any` constraint stops matching everything, and a mainline exception stops being swallowed
+
+Two independent bugs, both found while triaging the bundled Zef battery's
+`t/distribution-depends-parsing.rakutest`. The second is what made the first
+hard to find, so it is worth reading in that order.
+
+## A mainline exception under `Test` was replaced by the plan mismatch
+
+A program that dies in its mainline while using `Test` reported nothing about
+the exception:
+
+```raku
+use Test;
+plan 3;
+ok 1, 'first';
+Any.no-such-method;
+```
+
+```
+# was
+1..3
+ok 1 - first
+Runtime error: Test failures
+# You planned 3 test, but ran 1
+```
+
+`run()` handled a failed mainline with `self.finish()?; return Err(e)` — and
+`finish()` runs the end-of-program TAP checks. Under `Test`, a mainline
+exception always leaves the plan short, so `finish()` returned its own "Test
+failures" plan-mismatch error, the `?` propagated *that*, and the original
+exception was discarded. Every failure of this kind therefore looked like a plan
+bug, with only `# You planned N test, but ran M` to go on.
+
+`finish()`'s side effects — the diagnostics it writes and the exit code it sets —
+are still wanted, so it is now called for effect and its substituted error
+dropped. mutsu prints the exception and then the plan diagnostic, matching raku.
+Pin: `t/mainline-exception-not-masked-by-plan.t`.
+
+## A class nested as `Foo::Any` was equated with the core `Any`
+
+```raku
+class Spec { }
+class Spec::Any { }
+multi f(Spec::Any $s) { 'ANY' }
+multi f($s)           { 'GENERIC' }
+say f(Spec.new);   # raku: GENERIC   was: ANY
+```
+
+`Interpreter::type_matches` carries a "qualified name matching" bridge: when one
+name is qualified and the other is bare, their trailing components are compared,
+so a type declared under a `unit module` (registered as `GH2613::R1`) still
+matches a bare `R1` reference inside that module.
+
+Comparing only the trailing component equated `Spec::Any` with `Any`. That was
+not merely a wrong match, it was catastrophic: every class's MRO ends in `Any`,
+`Mu`, so walking the MRO reached the `constraint == "Any"` universal arm and the
+constraint accepted *every* instance. Renaming the class to `Spec::Alt` made it
+behave correctly, which is what isolated the trailing component rather than
+multi-dispatch ranking as the cause.
+
+The bridge now refuses core setting type names. A core type never lives under a
+user package, so a nested `Foo::Any` is definitionally not `Any`; the
+registration gap the bridge exists to close cannot involve one. Pin:
+`t/nested-any-type-constraint.t`.
+
+In Zef this is what sent a plain `Zef::Distribution::DependencySpecification`
+into the `…::DependencySpecification::Any`-constrained `spec-matcher` candidate,
+which calls `.specs` — a method only the `::Any` sibling has — and died with
+`X::Method::NotFound`. `t/distribution-depends-parsing.rakutest` goes from 18/35
+to 20/35; the next blocker there is an `any(...)` dependency spec with one
+satisfiable alternative failing to resolve, recorded in PLAN.md §1 B1.

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -176,9 +176,16 @@ impl Interpreter {
             queue_result?;
         }
 
-        // If the main body failed (e.g. die), run END phasers before propagating
+        // If the main body failed (e.g. die), run END phasers before propagating.
+        // `finish()`'s own error must not replace `e`: under `Test`, a mainline
+        // exception leaves the plan short, so `finish()` returns the "Test
+        // failures" plan-mismatch error — and propagating that instead swallowed
+        // the exception the user actually needs to see, leaving only
+        // `# You planned N test, but ran M`. Raku prints the exception first and
+        // the plan diagnostic after, so keep `finish()`'s side effects (the
+        // diagnostics it writes and the exit code it sets) and drop its error.
         if let Err(e) = body_result {
-            self.finish()?;
+            let _ = self.finish();
             return Err(e);
         }
 
@@ -195,7 +202,8 @@ impl Interpreter {
             && let Some(v) = last_value.as_ref()
             && let Some(err) = self.failure_to_runtime_error_if_unhandled(v)
         {
-            self.finish()?;
+            // Keep this error over `finish()`'s (see the mainline-failure arm above).
+            let _ = self.finish();
             return Err(err);
         }
         // Raku also DRAINS the sunk tail when it is a side-effecting lazy Seq:
@@ -218,7 +226,8 @@ impl Interpreter {
             if let Some(ll) = drain
                 && let Err(e) = self.force_lazy_list_vm(&ll)
             {
-                self.finish()?;
+                // Keep this error over `finish()`'s (see the mainline-failure arm above).
+                let _ = self.finish();
                 return Err(e);
             }
         }

--- a/src/runtime/types/type_matching_static.rs
+++ b/src/runtime/types/type_matching_static.rs
@@ -1,6 +1,22 @@
 use super::*;
 
 impl Interpreter {
+    /// Whether `qualified`'s trailing component may stand in for the bare name
+    /// `short` (see the "qualified name matching" bridge in [`Self::type_matches`]).
+    ///
+    /// A *core setting* type never lives under a user package, so a nested
+    /// `Foo::Any` is a genuinely different type from `Any` and the bridge must
+    /// not equate them. Doing so was catastrophic rather than merely wrong: a
+    /// `Foo::Any` constraint reached the `constraint == "Any"` universal arm via
+    /// every class's MRO (which ends in `Any`, `Mu`), so it accepted *every*
+    /// instance — e.g. Zef's `multi method spec-matcher(…::DependencySpecification::Any $spec)`
+    /// swallowed a plain `…::DependencySpecification` and then died calling the
+    /// `.specs` method only the `::Any` sibling has.
+    fn short_name_bridges(qualified: &str, short: &str) -> bool {
+        qualified.rsplit("::").next() == Some(short)
+            && !crate::runtime::Interpreter::is_builtin_type(short)
+    }
+
     pub(crate) fn type_matches(constraint: &str, value_type: &str) -> bool {
         if constraint == "Mu" {
             return true;
@@ -15,21 +31,17 @@ impl Interpreter {
         // Qualified name matching: GH2613::R1 should match R1 and vice versa.
         // When one name is qualified (contains ::) and the other is a short name,
         // check if the short name matches the last component of the qualified name.
+        // This bridges a registration gap: a type declared under a `unit module`
+        // is registered qualified but referred to bare inside that module.
         if constraint.contains("::")
             && !value_type.contains("::")
-            && constraint
-                .rsplit("::")
-                .next()
-                .is_some_and(|short| short == value_type)
+            && Self::short_name_bridges(constraint, value_type)
         {
             return true;
         }
         if value_type.contains("::")
             && !constraint.contains("::")
-            && value_type
-                .rsplit("::")
-                .next()
-                .is_some_and(|short| short == constraint)
+            && Self::short_name_bridges(value_type, constraint)
         {
             return true;
         }

--- a/t/mainline-exception-not-masked-by-plan.t
+++ b/t/mainline-exception-not-masked-by-plan.t
@@ -1,0 +1,30 @@
+use Test;
+
+# Regression pin: an exception that escapes the mainline of a program using
+# `Test` must still be reported. `run()` propagated `finish()`'s error instead
+# of the original one, and under `Test` a mainline exception always leaves the
+# plan short — so `finish()` returned the "Test failures" plan-mismatch error and
+# the real exception was silently discarded. Every such failure looked like a
+# plan bug, with only `# You planned N test, but ran M` to go on. Raku prints the
+# exception first and the plan diagnostic after.
+
+plan 2;
+
+my $script = $*TMPDIR.child("mutsu-mainline-exc-{$*PID}.raku");
+$script.spurt(q:to/CODE/);
+    use Test;
+    plan 3;
+    ok 1, 'first';
+    Any.no-such-method-here;
+    ok 1, 'never reached';
+    CODE
+
+my $proc = run($*EXECUTABLE, ~$script, :out, :err);
+my $err = $proc.err.slurp(:close);
+$proc.out.slurp(:close);
+$script.unlink;
+
+like $err, /'no-such-method-here'/,
+    'the escaping exception is reported, not swallowed by the plan mismatch';
+like $err, /'You planned 3 test'/,
+    'the plan diagnostic is still emitted alongside it';

--- a/t/nested-any-type-constraint.t
+++ b/t/nested-any-type-constraint.t
@@ -1,0 +1,41 @@
+use Test;
+
+# Regression pin: a class nested as `Foo::Any` is a different type from the core
+# `Any`, so a `Foo::Any` constraint must not accept everything.
+#
+# The "qualified name matching" bridge in `Interpreter::type_matches` — which
+# lets a type declared under a `unit module` be referred to bare inside it —
+# compared only the trailing component. Every class's MRO ends in `Any`, `Mu`,
+# so a `Foo::Any` constraint matched that `Any` entry and then took the
+# `constraint == "Any"` universal arm: it accepted every instance. Zef hit this
+# as `multi method spec-matcher(…::DependencySpecification::Any $spec)`
+# swallowing a plain `…::DependencySpecification` and dying on `.specs`, a
+# method only the `::Any` sibling has.
+
+plan 9;
+
+class Spec { }
+class Spec::Any { has @.specs; }
+class Spec::Alt { }
+
+my $plain = Spec.new;
+my $any = Spec::Any.new(:specs[1, 2]);
+
+nok $plain ~~ Spec::Any, 'a Spec instance does not smartmatch the nested Spec::Any';
+ok $any ~~ Spec::Any, 'a Spec::Any instance does smartmatch Spec::Any';
+nok $plain.isa(Spec::Any), 'a Spec instance does not .isa(Spec::Any)';
+
+multi f(Spec::Any $s) { 'ANY' }
+multi f($s) { 'GENERIC' }
+
+is f($plain), 'GENERIC', 'multi dispatch prefers the generic candidate for a plain Spec';
+is f($any), 'ANY', 'multi dispatch still picks the Spec::Any candidate for a Spec::Any';
+is f(42), 'GENERIC', 'a Spec::Any constraint does not swallow an Int';
+is f('x'), 'GENERIC', 'a Spec::Any constraint does not swallow a Str';
+
+# The bridge itself must keep working for a genuinely bare-vs-qualified pair,
+# and a non-core trailing component is unaffected.
+multi g(Spec::Alt $s) { 'ALT' }
+multi g($s) { 'GENERIC' }
+is g($plain), 'GENERIC', 'a Spec::Alt constraint does not accept a plain Spec';
+is g(Spec::Alt.new), 'ALT', 'a Spec::Alt constraint accepts a Spec::Alt';


### PR DESCRIPTION
Two independent bugs, both found triaging the bundled Zef battery's `t/distribution-depends-parsing.rakutest` (recorded in #5374). The second is what made the first hard to find, so read in that order.

## A mainline exception under `Test` was replaced by the plan mismatch

```raku
use Test;
plan 3;
ok 1, 'first';
Any.no-such-method;
```
```
# was
1..3
ok 1 - first
Runtime error: Test failures
# You planned 3 test, but ran 1
```

`run()` handled a failed mainline with `self.finish()?; return Err(e)`. Under `Test`, a mainline exception always leaves the plan short, so `finish()` returned its own "Test failures" plan-mismatch error, the `?` propagated **that**, and the original exception was discarded. Every failure of this kind looked like a plan bug.

`finish()`'s side effects — the diagnostics it writes, the exit code it sets — are still wanted, so it is now called for effect and its substituted error dropped. mutsu prints the exception and then the plan diagnostic, matching raku.

## A class nested as `Foo::Any` was equated with the core `Any`

```raku
class Spec { }
class Spec::Any { }
multi f(Spec::Any $s) { 'ANY' }
multi f($s)           { 'GENERIC' }
say f(Spec.new);   # raku: GENERIC   was: ANY
```

`Interpreter::type_matches` carries a "qualified name matching" bridge: when one name is qualified and the other bare, their trailing components are compared, so a type declared under a `unit module` (registered `GH2613::R1`) still matches a bare `R1` inside that module.

Comparing only the trailing component equated `Spec::Any` with `Any` — **catastrophically**, not merely wrongly: every class's MRO ends in `Any`, `Mu`, so walking the MRO reached the `constraint == "Any"` universal arm and the constraint accepted *every* instance. Renaming the class to `Spec::Alt` behaved correctly, which is what isolated the trailing component (rather than multi-dispatch ranking) as the cause.

The bridge now refuses core setting type names: a core type never lives under a user package, so a nested `Foo::Any` is definitionally not `Any` and the registration gap the bridge closes cannot involve one.

In Zef this sent a plain `Zef::Distribution::DependencySpecification` into the `…::DependencySpecification::Any`-constrained `spec-matcher` candidate, which calls `.specs` — a method only the `::Any` sibling has — and died with `X::Method::NotFound`. `t/distribution-depends-parsing.rakutest` goes **18/35 → 20/35**; the next blocker there is recorded in PLAN.md §1 B1 (an `any(...)` dependency spec with one satisfiable alternative failing to resolve).

## Testing

- New pins `t/nested-any-type-constraint.t` (9 tests) and `t/mainline-exception-not-masked-by-plan.t` (2 tests); verified both fail on the parent commit (`nested-any` fails tests 1 and 4; `mainline-exception` fails test 1) and pass here.
- `make test`: 2415 files / 23029 tests, all pass.
- Targeted roast subset — every whitelisted `S02-types`, `S04`, `S06`, `S12`, `S14` file (353 files / 14490 tests), covering the type-matching and exception-reporting blast radius: all pass. Full roast left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)