### PR TITLE
fix: a block containing a `CATCH` returns its own value, not the topic

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -129,7 +129,7 @@ section.
       (user policy 2026-07-24). The release-time gate now runs every battery's upstream suite
       against the shipped library (`scripts/battery-testsuite.sh`, `batteries.lock`,
       `batteries-whitelist.txt`; see [docs/batteries/testsuite-gate.md](docs/batteries/testsuite-gate.md)),
-      but it is a **baseline** gate, and the measured baseline is **16/18 test files** (it landed at
+      but it is a **baseline** gate, and the measured baseline is **17/18 test files** (it landed at
       11/18). The goal is to raise that toward all-green so a release ships batteries that genuinely
       pass their own suites — the gate stops regressions, it does not close these gaps:
       - **OpenSSL — 7/7** ✅ **DONE (2026-07-25)**. All seven upstream files pass against the
@@ -139,7 +139,7 @@ section.
         `Blob:D`, which made `OpenSSL::Digest` mutually recurse — the `05-digest`/`03-rsa` hangs),
         `unit module` package scoping (#5369), positional-argument indexing (#5370), and the
         `where`-constraint caller-lexical wipe (`04-crypt`, PLAN 8.22).
-      - **Zef — 8/10**, now triaged (2026-07-25). Both remaining files fail for **real, general mutsu
+      - **Zef — 9/10** (was 8/10; `distribution-depends-parsing` is green as of 2026-07-25). Both remaining files fail for **real, general mutsu
         bugs**, not for a run-context difference, so the "all 10 upstream tests pass" note from
         2026-07-10 (#4383/#4384) is stale rather than contradicted — these two are reachable only
         through paths the older mzef/install run did not take. Each has a standalone minimal
@@ -162,25 +162,23 @@ section.
           Deciding the fix needs care about *why* the blanket rollback exists (a `class`/`role`
           declared directly in a subtest body should stay lexical); making the two stores agree —
           rather than widening or narrowing the rollback blindly — is the shape of the fix.
-        - **`distribution-depends-parsing` (20/35)** — three bugs so far; the first two are fixed.
-          1. ✅ **DONE** — a type constraint whose qualified name ended in `::Any` was equated with
-             the builtin `Any` by the "qualified name matching" short-name bridge in
-             `Interpreter::type_matches`, so it matched every value (every class's MRO ends in
-             `Any`) and its candidate wrongly won. In Zef that sent a plain
-             `Zef::Distribution::DependencySpecification` into the `…::Any`-constrained
-             `spec-matcher` candidate, which calls `.specs` — a method only the `::Any` sibling
-             has. The bridge now refuses core setting type names, which never live under a user
-             package. Pin: `t/nested-any-type-constraint.t`.
-          2. ✅ **DONE** — that uncaught exception aborted the file with **no message at all**:
-             `run()` propagated `finish()`'s error instead of the original, and under `Test` a
-             mainline exception always leaves the plan short, so the "Test failures" plan-mismatch
-             error replaced the real one. Every such failure read as a plan bug. Pin:
-             `t/mainline-exception-not-masked-by-plan.t`. **This one was the real blocker on
-             triage** — with the exception visible, each remaining failure names itself.
-          3. **Current frontier (test 21)**: `Failed to resolve some missing dependencies` for the
-             `[{:any["Unavailable", "Available"]},]` case — an `any(...)` dependency spec with one
-             satisfiable alternative must resolve, and does not. Reduce from
-             `Zef::Client.!find-prereq-candidates`.
+        - **`distribution-depends-parsing`** ✅ **DONE — 35/35**. Three bugs, all general:
+          1. A type constraint whose qualified name ended in `::Any` was equated with the builtin
+             `Any` by the "qualified name matching" short-name bridge in `Interpreter::type_matches`,
+             so it matched every value (every class's MRO ends in `Any`) and its candidate wrongly
+             won. Pin: `t/nested-any-type-constraint.t`.
+          2. That exception aborted the file with **no message at all**: `run()` propagated
+             `finish()`'s error instead of the original, and under `Test` a mainline exception
+             always leaves the plan short, so the "Test failures" plan-mismatch error replaced the
+             real one. **This was the real blocker on triage** — with the exception visible, each
+             remaining failure named itself. Pin: `t/mainline-exception-not-masked-by-plan.t`.
+          3. A block containing a `CATCH` yielded the **topic** instead of its last statement's
+             value: the implicit `try` wrapping such a body had its value `Pop`ped, so the block
+             value fell back to `last_topic_value`. Any block used for its value broke as soon as
+             it grew a `CATCH` — `.map` yielded the topic, `.first`/`.grep` saw a truthy topic and
+             matched the first element. Zef resolves `any(...)` dependency alternatives with
+             `$needed.specs.first({ CATCH {…}; …; @candidates })`, so it always took the first
+             (unsatisfiable) one. Pin: `t/catch-block-keeps-block-value.t`.
       - **IO::Socket::SSL — 1/1** ✅ already green.
       Raising a file into the baseline is `scripts/battery-testsuite.sh --update` + committing the
       whitelist diff.

--- a/batteries-whitelist.txt
+++ b/batteries-whitelist.txt
@@ -7,6 +7,7 @@ OpenSSL	06-digest-md5.rakutest
 OpenSSL	07-version.rakutest
 OpenSSL	10-client-ca-file.rakutest
 zef	build.rakutest
+zef	distribution-depends-parsing.rakutest
 zef	extract.rakutest
 zef	fetch.rakutest
 zef	identity.rakutest

--- a/news/2026-07/catch-block-keeps-its-value.md
+++ b/news/2026-07/catch-block-keeps-its-value.md
@@ -1,0 +1,40 @@
+# A block with a `CATCH` returns its own value again, not the topic
+
+A block whose body contains a `CATCH` (or `CONTROL`) phaser yielded `$_` instead
+of its last statement's value. Any block used for its value broke the moment it
+grew a `CATCH`:
+
+```raku
+say (<a b>).map({ CATCH { default { } }; $_ eq 'b' });
+# raku: (False True)   was: (a b)
+say (<a b>).first({ CATCH { default { } }; $_ eq 'b' });
+# raku: b              was: a
+```
+
+A body containing such a phaser compiles to an implicit `try` wrapping every
+statement, so the phaser can observe exceptions from the surrounding code. The
+compiler then emitted `Pop`, discarding that `try`'s value — and with nothing
+left on the stack, the block's value fell back to `last_topic_value`, i.e. the
+topic. `.map` therefore produced the topic rather than the computed value, and
+`.first`/`.grep` saw a truthy topic and matched the very first element.
+
+The fix is one instruction: emit `SetTopic` rather than `Pop`, which is exactly
+what the non-`CATCH` path already does for a body's tail statement.
+
+This was the last blocker in the bundled Zef battery's
+`t/distribution-depends-parsing.rakutest`. `Zef::Client!find-prereq-candidates`
+resolves an `any(...)` dependency's alternatives with
+
+```raku
+$needed.specs.first({ CATCH { … }; @candidates = self!find-candidates(…); @candidates })
+```
+
+so the search always accepted the first alternative, unsatisfiable or not, and
+the file died with `Failed to resolve some missing dependencies`. It now passes
+**35/35**, which takes the Zef battery to 9/10 and the release-time battery gate
+baseline (`batteries-whitelist.txt`) to **17/18**.
+
+The one remaining battery gap is Zef's `00-load`, recorded in PLAN.md §1 B1:
+`subtest` rolls back the class/role/subset registries but not `loaded_modules`,
+so a module first loaded inside a subtest loses every declaration on exit while
+still counting as loaded.

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1604,7 +1604,7 @@ impl Compiler {
             .any(|s| matches!(s, Stmt::Catch(_) | Stmt::Control(_)));
         if has_catch {
             self.compile_try(stmts, &None);
-            self.code.emit(OpCode::Pop);
+            self.code.emit(OpCode::SetTopic);
         } else if self.is_routine && Self::has_block_enter_leave_phasers(stmts) {
             self.compile_phaser_block_scope(stmts, false);
         } else {

--- a/t/catch-block-keeps-block-value.t
+++ b/t/catch-block-keeps-block-value.t
@@ -1,0 +1,45 @@
+use Test;
+
+# Regression pin: a block containing a `CATCH` yielded the *topic* instead of
+# its last statement's value.
+#
+# A body with a `CATCH`/`CONTROL` phaser compiles to an implicit `try` wrapping
+# every statement; the compiler then emitted `Pop`, discarding that try's value.
+# With nothing left on the stack the block's value fell back to
+# `last_topic_value` — i.e. `$_`. Any block used for its value broke as soon as
+# it grew a `CATCH`: `.map` yielded the topic rather than the computed value,
+# and `.first`/`.grep` saw a truthy topic and matched the first element.
+#
+# Zef's `Zef::Client!find-prereq-candidates` resolves `any(...)` dependency
+# alternatives with `$needed.specs.first({ CATCH {...}; ...; @candidates })`,
+# so it always picked the first (unsatisfiable) alternative.
+
+plan 8;
+
+is (<a b>).first({ CATCH { default { } }; $_ eq 'b' }), 'b',
+    '.first uses the block value, not the topic, when the block has a CATCH';
+is-deeply (<a b>).grep({ CATCH { default { } }; $_ eq 'b' }).List, ('b',),
+    '.grep uses the block value when the block has a CATCH';
+is-deeply (<a b>).map({ CATCH { default { } }; $_ eq 'b' }).List, (False, True),
+    '.map uses the block value when the block has a CATCH';
+
+# An empty list is a falsy block value, which is what the `any(...)` resolution
+# above relies on to move past an unsatisfiable alternative.
+my @seen;
+my $hit = (<a b>).first({
+    CATCH { default { } }
+    @seen = $_ eq 'b' ?? ('C',) !! ();
+    @seen
+});
+is $hit, 'b', 'an empty-list block value is falsy and the search continues';
+is-deeply @seen, ['C'], 'the matching iteration left its state behind';
+
+# The control cases must be unchanged.
+is (<a b>).first({ $_ eq 'b' }), 'b', '.first without a CATCH still works';
+is ({ CATCH { default { } }; 42 })(), 42,
+    'a plain block with a CATCH still returns its last value';
+
+# A CATCH that actually fires still swallows the exception.
+my $caught = 0;
+my $r = ({ CATCH { default { $caught = 1 } }; die 'boom'; 7 })();
+is $caught, 1, 'a firing CATCH still handles the exception';


### PR DESCRIPTION
A block whose body contains a `CATCH` (or `CONTROL`) phaser yielded `$_` instead of its last statement's value:

```raku
say (<a b>).map({ CATCH { default { } }; $_ eq 'b' });
# raku: (False True)   was: (a b)
say (<a b>).first({ CATCH { default { } }; $_ eq 'b' });
# raku: b              was: a
```

Such a body compiles to an implicit `try` wrapping every statement, so the phaser can observe exceptions from the surrounding code. The compiler then emitted `Pop`, discarding that try's value — and with nothing left on the stack, the block's value fell back to `last_topic_value`, i.e. the topic. `.map` therefore produced the topic rather than the computed value, and `.first`/`.grep` saw a truthy topic and matched the very first element.

The fix is one instruction: emit `SetTopic` rather than `Pop`, which is exactly what the non-`CATCH` path already does for a body's tail statement.

## Effect

This was the last blocker in the bundled Zef battery's `t/distribution-depends-parsing.rakutest`. `Zef::Client!find-prereq-candidates` resolves an `any(...)` dependency's alternatives with

```raku
$needed.specs.first({ CATCH { ... }; @candidates = self!find-candidates(...); @candidates })
```

so the search always accepted the first alternative, unsatisfiable or not, and the file died with `Failed to resolve some missing dependencies`.

- `t/distribution-depends-parsing.rakutest`: 20/35 → **35/35** (whitelisted here)
- Zef battery: 8/10 → **9/10**
- Release-time battery gate baseline: 16/18 → **17/18**

The one remaining battery gap is Zef's `00-load`, recorded in PLAN.md §1 B1 (`subtest` rolls back the class/role/subset registries but not `loaded_modules`).

## Testing

- New pin `t/catch-block-keeps-block-value.t` (8 tests), including a control that a firing `CATCH` still swallows its exception; verified 5 of the 8 fail on the parent commit and all pass here.
- `make test`: 2415 files / 23029 tests, all pass.
- Targeted roast: every whitelisted `S02-types`, `S04` (blocks/statements/exceptions/phasers/exception-handlers) and `S32-exceptions` file — 142 files / 10165 tests — all pass. Full roast left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)