### PR TITLE
fix: a subtest no longer makes a module permanently unusable

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -125,63 +125,16 @@ section.
       output match). External dists are either `zef fetch`ed in CI or vendored. Failures are
       report-only (a red run does not stop main). Once the bundle set is fixed, its smoke tests
       become the battery quality gate as-is.
-- [ ] **★ Close the bundled-library test-suite gaps — target: green before the next release**
-      (user policy 2026-07-24). The release-time gate now runs every battery's upstream suite
-      against the shipped library (`scripts/battery-testsuite.sh`, `batteries.lock`,
-      `batteries-whitelist.txt`; see [docs/batteries/testsuite-gate.md](docs/batteries/testsuite-gate.md)),
-      but it is a **baseline** gate, and the measured baseline is **17/18 test files** (it landed at
-      11/18). The goal is to raise that toward all-green so a release ships batteries that genuinely
-      pass their own suites — the gate stops regressions, it does not close these gaps:
-      - **OpenSSL — 7/7** ✅ **DONE (2026-07-25)**. All seven upstream files pass against the
-        bundled library. The gaps were closed by general mutsu fixes, none OpenSSL-specific:
-        NativeCall NULL-`Str` marshalling + `CArray[T].new` list flattening (`10-client-ca-file`'s
-        SIGSEGV), multi-dispatch specificity (a `Str()` coercion candidate outranked an exact
-        `Blob:D`, which made `OpenSSL::Digest` mutually recurse — the `05-digest`/`03-rsa` hangs),
-        `unit module` package scoping (#5369), positional-argument indexing (#5370), and the
-        `where`-constraint caller-lexical wipe (`04-crypt`, PLAN 8.22).
-      - **Zef — 9/10** (was 8/10; `distribution-depends-parsing` is green as of 2026-07-25). Both remaining files fail for **real, general mutsu
-        bugs**, not for a run-context difference, so the "all 10 upstream tests pass" note from
-        2026-07-10 (#4383/#4384) is stale rather than contradicted — these two are reachable only
-        through paths the older mzef/install run did not take. Each has a standalone minimal
-        reproduction; neither is Zef-specific.
-        - **`00-load` (1/2)** — `subtest` **rolls back the type registry but not `loaded_modules`.**
-          `test_fn_subtest` (`src/runtime/test_functions/tap_subtest.rs`) restores `classes`,
-          `roles`, `subsets`, `functions`, `proto_subs`, `token_defs`, … wholesale after the block,
-          so a module first loaded *inside* a subtest has all of its declarations erased on exit —
-          while `loaded_modules` still lists it, which makes every later `use` an early-return
-          no-op. The type is then permanently gone. Repro:
-          ```raku
-          use Test;
-          plan 1;
-          sub probe($t) { say "$t: ", ::('Zef::Fetcher').^name }
-          subtest 'A' => { use Zef; probe('inside'); };   # inside: Zef::Fetcher
-          probe('after');                                  # after: Failure   <-- wrong
-          ```
-          In the real file, `subtest 'Core'` loads `Zef` and `subtest 'Plugins'` then dies with
-          `X::InvalidType: Invalid typename 'Fetcher'` on all three `Zef::Service::Shell::*` files.
-          Deciding the fix needs care about *why* the blanket rollback exists (a `class`/`role`
-          declared directly in a subtest body should stay lexical); making the two stores agree —
-          rather than widening or narrowing the rollback blindly — is the shape of the fix.
-        - **`distribution-depends-parsing`** ✅ **DONE — 35/35**. Three bugs, all general:
-          1. A type constraint whose qualified name ended in `::Any` was equated with the builtin
-             `Any` by the "qualified name matching" short-name bridge in `Interpreter::type_matches`,
-             so it matched every value (every class's MRO ends in `Any`) and its candidate wrongly
-             won. Pin: `t/nested-any-type-constraint.t`.
-          2. That exception aborted the file with **no message at all**: `run()` propagated
-             `finish()`'s error instead of the original, and under `Test` a mainline exception
-             always leaves the plan short, so the "Test failures" plan-mismatch error replaced the
-             real one. **This was the real blocker on triage** — with the exception visible, each
-             remaining failure named itself. Pin: `t/mainline-exception-not-masked-by-plan.t`.
-          3. A block containing a `CATCH` yielded the **topic** instead of its last statement's
-             value: the implicit `try` wrapping such a body had its value `Pop`ped, so the block
-             value fell back to `last_topic_value`. Any block used for its value broke as soon as
-             it grew a `CATCH` — `.map` yielded the topic, `.first`/`.grep` saw a truthy topic and
-             matched the first element. Zef resolves `any(...)` dependency alternatives with
-             `$needed.specs.first({ CATCH {…}; …; @candidates })`, so it always took the first
-             (unsatisfiable) one. Pin: `t/catch-block-keeps-block-value.t`.
-      - **IO::Socket::SSL — 1/1** ✅ already green.
-      Raising a file into the baseline is `scripts/battery-testsuite.sh --update` + committing the
-      whitelist diff.
+- [x] **★ Close the bundled-library test-suite gaps — DONE 2026-07-25, baseline 18/18.**
+      (user policy 2026-07-24.) The release-time gate runs every battery's upstream suite against
+      the shipped library (`scripts/battery-testsuite.sh`, `batteries.lock`,
+      `batteries-whitelist.txt`; see [docs/batteries/testsuite-gate.md](docs/batteries/testsuite-gate.md)).
+      It landed at 11/18 and every remaining gap is now closed — OpenSSL 7/7, Zef 10/10,
+      IO::Socket::SSL 1/1 — entirely through general mutsu fixes, none library-specific. **The gate
+      is now all-green, so a drop below 18/18 is a pure regression to fix, not a baseline to
+      accept.** Adding a new battery is what re-opens work here: whitelist what passes with
+      `scripts/battery-testsuite.sh --update`, then close its gaps the same way. Details in
+      `news/2026-07/`.
 
 ### B2. mzef — an `mzef` package manager bundling the real Zef (north-star; user policy 2026-06-28)
 

--- a/batteries-whitelist.txt
+++ b/batteries-whitelist.txt
@@ -6,6 +6,7 @@ OpenSSL	05-digest.rakutest
 OpenSSL	06-digest-md5.rakutest
 OpenSSL	07-version.rakutest
 OpenSSL	10-client-ca-file.rakutest
+zef	00-load.rakutest
 zef	build.rakutest
 zef	distribution-depends-parsing.rakutest
 zef	extract.rakutest

--- a/news/2026-07/subtest-rolls-back-loaded-modules.md
+++ b/news/2026-07/subtest-rolls-back-loaded-modules.md
@@ -1,0 +1,38 @@
+# A subtest no longer makes a module permanently unusable
+
+A `subtest` body is a block, so everything it declares — `class`, `role`,
+`subset`, `sub`, `token` — is lexical to it and has to disappear when the block
+ends. mutsu implements that by snapshotting the declaration registries before
+running the body and restoring them afterwards.
+
+The set of already-loaded modules was not part of that snapshot, and `use` is
+lexical too. So a module first loaded *inside* a subtest lost every declaration
+it had installed when the subtest ended, yet still counted as loaded. Every
+later `use` of it then short-circuited on the "already loaded" early return in
+`use_module_with_tags_inner()` and installed nothing, so its types stayed gone
+for the rest of the file:
+
+```raku
+subtest 'A' => { use Foo; ok Foo::Thing.new.defined }   # passes
+subtest 'B' => { use Foo; ok Foo::Thing.new.defined }   # X::InvalidType: Invalid typename 'Thing'
+```
+
+`loaded_modules` is now snapshotted and restored with the rest of the
+declaration state, so the second `use` re-loads the module and re-installs its
+declarations. Modules the mainline loaded before the subtest ran are unaffected
+— they are in the snapshot, so they stay loaded.
+
+While collecting the field into the snapshot, the three copies of the
+save/restore sequence (the `subtest` normal path, its `plan skip-all` error
+path, and `group-of`) were replaced by a single `SubtestDeclSnapshot` captured
+by `snapshot_subtest_decls()` and applied by `restore_subtest_decls()`, so a
+future addition cannot be forgotten in one of the three again.
+
+This closes the `00-load` gap in the vendored Zef test suite: its second
+subtest `use`s the `Zef::Service::*` plugins, all of which had already been
+pulled in transitively by the first subtest's `use Zef`, so all twelve of them
+failed with `Invalid typename 'Fetcher'` and friends. The Zef battery is now
+10/10, and with it the release gate reaches its full baseline: **18/18 bundled
+library test files pass**.
+
+Pin: `t/subtest-module-reuse.t`.

--- a/src/runtime/test_functions/tap_subtest.rs
+++ b/src/runtime/test_functions/tap_subtest.rs
@@ -1,6 +1,91 @@
+use std::sync::Arc;
+
+use rustc_hash::{FxHashMap, FxHashSet};
+
 use super::super::*;
+use crate::ast::FunctionDef;
+
+/// Declaration state a subtest body must not leak into its caller.
+///
+/// A subtest body is a block, so anything it declares (`class`, `role`,
+/// `subset`, `sub`, `token`, ...) is lexical to it in Raku and must be rolled
+/// back when the block ends. `use` is lexical too, which is why the set of
+/// loaded modules belongs here: a module first loaded inside a subtest has all
+/// of its declarations rolled back with everything else, so it must also stop
+/// counting as loaded — otherwise a later `use` of it short-circuits as a
+/// no-op and the types stay gone for the rest of the file.
+pub(crate) struct SubtestDeclSnapshot {
+    functions: FxHashMap<Symbol, Arc<FunctionDef>>,
+    proto_functions: FxHashMap<Symbol, Arc<FunctionDef>>,
+    token_defs: FxHashMap<Symbol, Vec<Arc<FunctionDef>>>,
+    proto_subs: FxHashSet<String>,
+    proto_tokens: FxHashSet<String>,
+    classes: FxHashMap<String, ClassDef>,
+    class_trusts: FxHashMap<String, FxHashSet<String>>,
+    roles: FxHashMap<String, RoleDef>,
+    subsets: FxHashMap<String, SubsetDef>,
+    loaded_modules: HashSet<String>,
+    type_metadata: HashMap<String, HashMap<String, Value>>,
+    var_type_constraints: HashMap<String, String>,
+}
 
 impl Interpreter {
+    pub(crate) fn snapshot_subtest_decls(&self) -> SubtestDeclSnapshot {
+        let registry = self.registry();
+        SubtestDeclSnapshot {
+            functions: registry.functions.clone(),
+            proto_functions: registry.proto_functions.clone(),
+            token_defs: registry.token_defs.clone(),
+            proto_subs: registry.proto_subs.clone(),
+            proto_tokens: registry.proto_tokens.clone(),
+            classes: registry.classes.clone(),
+            class_trusts: registry.class_trusts.clone(),
+            roles: registry.roles.clone(),
+            subsets: registry.subsets.clone(),
+            loaded_modules: self.loaded_modules.clone(),
+            type_metadata: self.type_metadata.clone(),
+            var_type_constraints: self.snapshot_var_type_constraints(),
+        }
+    }
+
+    pub(crate) fn restore_subtest_decls(&mut self, snapshot: SubtestDeclSnapshot) {
+        let SubtestDeclSnapshot {
+            functions,
+            proto_functions,
+            token_defs,
+            proto_subs,
+            proto_tokens,
+            classes,
+            class_trusts,
+            roles,
+            subsets,
+            loaded_modules,
+            mut type_metadata,
+            var_type_constraints,
+        } = snapshot;
+        {
+            let mut registry = self.registry_mut();
+            registry.functions = functions;
+            registry.proto_functions = proto_functions;
+            registry.token_defs = token_defs;
+            registry.proto_subs = proto_subs;
+            registry.proto_tokens = proto_tokens;
+            registry.classes = classes;
+            registry.class_trusts = class_trusts;
+            registry.roles = roles;
+            registry.subsets = subsets;
+        }
+        crate::runtime::regex_parse::TOKEN_DEFS_GEN
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.loaded_modules = loaded_modules;
+        // Merge type_metadata: preserve entries added during the subtest
+        for (key, val) in std::mem::take(&mut self.type_metadata) {
+            type_metadata.entry(key).or_insert(val);
+        }
+        self.type_metadata = type_metadata;
+        self.restore_var_type_constraints(var_type_constraints);
+    }
+
     pub(crate) fn test_fn_subtest(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         // subtest 'name' => { ... } (Pair arg) or subtest 'name', { ... } (two args)
         // Pairs are treated as named args by positional_value, so check raw args first
@@ -42,17 +127,7 @@ impl Interpreter {
         // Override the default (true) set by begin_subtest
         self.tap.set_subtest_callable_is_sub_last(callable_is_sub);
         let saved_env = self.env.clone();
-        let saved_functions = self.registry().functions.clone();
-        let saved_proto_functions = self.registry().proto_functions.clone();
-        let saved_token_defs = self.registry().token_defs.clone();
-        let saved_proto_subs = self.registry().proto_subs.clone();
-        let saved_proto_tokens = self.registry().proto_tokens.clone();
-        let saved_classes = self.registry().classes.clone();
-        let saved_class_trusts = self.registry().class_trusts.clone();
-        let saved_roles = self.registry().roles.clone();
-        let saved_subsets = self.registry().subsets.clone();
-        let mut saved_type_metadata = self.type_metadata.clone();
-        let saved_var_type_constraints = self.snapshot_var_type_constraints();
+        let saved_decls = self.snapshot_subtest_decls();
         let run_result = self.call_sub_value(block, vec![], true);
         // If `plan skip-all` was used inside a Block callable, the error is fatal
         // and should propagate out of the subtest entirely (matching Raku behavior).
@@ -65,23 +140,7 @@ impl Interpreter {
             self.halted = ctx.parent_halted;
             self.tap.end_subtest();
             self.env = saved_env;
-            self.registry_mut().functions = saved_functions;
-            self.registry_mut().proto_functions = saved_proto_functions;
-            self.registry_mut().token_defs = saved_token_defs;
-            crate::runtime::regex_parse::TOKEN_DEFS_GEN
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            self.registry_mut().proto_subs = saved_proto_subs;
-            self.registry_mut().proto_tokens = saved_proto_tokens;
-            self.registry_mut().classes = saved_classes;
-            self.registry_mut().class_trusts = saved_class_trusts;
-            self.registry_mut().roles = saved_roles;
-            self.registry_mut().subsets = saved_subsets;
-            // Merge type_metadata: preserve entries added during the subtest
-            for (key, val) in std::mem::take(&mut self.type_metadata) {
-                saved_type_metadata.entry(key).or_insert(val);
-            }
-            self.type_metadata = saved_type_metadata;
-            self.restore_var_type_constraints(saved_var_type_constraints);
+            self.restore_subtest_decls(saved_decls);
             return Err(run_result.unwrap_err());
         }
         let mut merged_env = saved_env.clone();
@@ -95,23 +154,7 @@ impl Interpreter {
             }
         }
         self.env = merged_env;
-        self.registry_mut().functions = saved_functions;
-        self.registry_mut().proto_functions = saved_proto_functions;
-        self.registry_mut().token_defs = saved_token_defs;
-        crate::runtime::regex_parse::TOKEN_DEFS_GEN
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        self.registry_mut().proto_subs = saved_proto_subs;
-        self.registry_mut().proto_tokens = saved_proto_tokens;
-        self.registry_mut().classes = saved_classes;
-        self.registry_mut().class_trusts = saved_class_trusts;
-        self.registry_mut().roles = saved_roles;
-        self.registry_mut().subsets = saved_subsets;
-        // Merge type_metadata: preserve entries added during the subtest
-        for (key, val) in std::mem::take(&mut self.type_metadata) {
-            saved_type_metadata.entry(key).or_insert(val);
-        }
-        self.type_metadata = saved_type_metadata;
-        self.restore_var_type_constraints(saved_var_type_constraints);
+        self.restore_subtest_decls(saved_decls);
         self.finish_subtest(ctx, &label, run_result.map(|_| ()))?;
         Ok(Value::TRUE)
     }
@@ -144,37 +187,11 @@ impl Interpreter {
         let desc = desc_key.to_string_value();
         let ctx = self.begin_subtest();
         let saved_env = self.env.clone();
-        let saved_functions = self.registry().functions.clone();
-        let saved_proto_functions = self.registry().proto_functions.clone();
-        let saved_token_defs = self.registry().token_defs.clone();
-        let saved_proto_subs = self.registry().proto_subs.clone();
-        let saved_proto_tokens = self.registry().proto_tokens.clone();
-        let saved_classes = self.registry().classes.clone();
-        let saved_class_trusts = self.registry().class_trusts.clone();
-        let saved_roles = self.registry().roles.clone();
-        let saved_subsets = self.registry().subsets.clone();
-        let mut saved_type_metadata = self.type_metadata.clone();
-        let saved_var_type_constraints = self.snapshot_var_type_constraints();
+        let saved_decls = self.snapshot_subtest_decls();
         self.test_fn_plan(&[Value::int(plan)])?;
         let run_result = self.call_sub_value(block, vec![], true);
         self.env = saved_env;
-        self.registry_mut().functions = saved_functions;
-        self.registry_mut().proto_functions = saved_proto_functions;
-        self.registry_mut().token_defs = saved_token_defs;
-        crate::runtime::regex_parse::TOKEN_DEFS_GEN
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        self.registry_mut().proto_subs = saved_proto_subs;
-        self.registry_mut().proto_tokens = saved_proto_tokens;
-        self.registry_mut().classes = saved_classes;
-        self.registry_mut().class_trusts = saved_class_trusts;
-        self.registry_mut().roles = saved_roles;
-        self.registry_mut().subsets = saved_subsets;
-        // Merge type_metadata: preserve entries added during the subtest
-        for (key, val) in std::mem::take(&mut self.type_metadata) {
-            saved_type_metadata.entry(key).or_insert(val);
-        }
-        self.type_metadata = saved_type_metadata;
-        self.restore_var_type_constraints(saved_var_type_constraints);
+        self.restore_subtest_decls(saved_decls);
         self.finish_subtest(ctx, &desc, run_result.map(|_| ()))?;
         Ok(Value::TRUE)
     }

--- a/t/lib/SubtestModuleReuse.rakumod
+++ b/t/lib/SubtestModuleReuse.rakumod
@@ -1,0 +1,15 @@
+unit module SubtestModuleReuse;
+
+role SubtestModuleReuse::Marker is export {
+    method marker() { 'marked' }
+}
+
+class SubtestModuleReuse::Thing does SubtestModuleReuse::Marker is export {
+    method greet() { 'hello' }
+}
+
+sub subtest-module-reuse-greeting() is export { 'exported' }
+
+enum SubtestModuleReuseColour is export <SmrRed SmrGreen SmrBlue>;
+
+constant SMR-CONST is export = 42;

--- a/t/subtest-module-reuse.t
+++ b/t/subtest-module-reuse.t
@@ -1,0 +1,47 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+# A subtest body is a block, so everything it declares is rolled back when it
+# ends. `use` is lexical too: a module first loaded inside a subtest has its
+# declarations rolled back with everything else, so it must also stop counting
+# as loaded. Otherwise a later `use` of the same module short-circuits as a
+# no-op and its types stay gone for the rest of the file.
+
+plan 6;
+
+subtest 'first load happens inside a subtest' => {
+    plan 3;
+    use SubtestModuleReuse;
+    is SubtestModuleReuse::Thing.new.greet, 'hello', 'class is visible';
+    ok SubtestModuleReuse::Thing.new ~~ SubtestModuleReuse::Marker, 'role is visible';
+    is subtest-module-reuse-greeting(), 'exported', 'exported sub is visible';
+}
+
+subtest 're-using the module in a later subtest works' => {
+    plan 3;
+    use SubtestModuleReuse;
+    is SubtestModuleReuse::Thing.new.greet, 'hello', 'class is visible again';
+    ok SubtestModuleReuse::Thing.new ~~ SubtestModuleReuse::Marker, 'role is visible again';
+    is subtest-module-reuse-greeting(), 'exported', 'exported sub is visible again';
+}
+
+subtest 'a nested subtest can re-use it too' => {
+    plan 1;
+    subtest 'inner' => {
+        plan 1;
+        use SubtestModuleReuse;
+        is SubtestModuleReuse::Thing.new.greet, 'hello', 'class is visible in nested subtest';
+    }
+}
+
+# The rollback must not resurrect a module the mainline already loaded: `Test`
+# itself was loaded before any subtest ran and must survive.
+ok &ok.defined, 'Test is still loaded after the subtests';
+
+# Re-loading has to stay idempotent for declarations the rollback does not
+# undo (an enum's variants, a constant), so the mainline can `use` a module the
+# subtests already pulled in.
+use SubtestModuleReuse;
+is SmrGreen.value, 1, 'an exported enum survives a mainline re-use';
+is SMR-CONST, 42, 'an exported constant survives a mainline re-use';


### PR DESCRIPTION
A `subtest` body is a block, so everything it declares — `class`, `role`,
`subset`, `sub`, `token` — is lexical to it and has to disappear when the block
ends. mutsu implements that by snapshotting the declaration registries before
running the body and restoring them afterwards.

The set of already-loaded modules was not part of that snapshot, and `use` is
lexical too. So a module first loaded *inside* a subtest lost every declaration
it had installed when the subtest ended, yet still counted as loaded. Every
later `use` of it then short-circuited on the "already loaded" early return in
`use_module_with_tags_inner()` and installed nothing, so its types stayed gone
for the rest of the file:

```raku
subtest 'A' => { use Foo; ok Foo::Thing.new.defined }   # passes
subtest 'B' => { use Foo; ok Foo::Thing.new.defined }   # Invalid typename 'Thing'
```

`loaded_modules` is now snapshotted and restored with the rest of the
declaration state, so the second `use` re-loads the module and re-installs its
declarations. Modules the mainline loaded before the subtest ran are in the
snapshot, so they stay loaded.

While collecting the field into the snapshot, the three copies of the
save/restore sequence (the `subtest` normal path, its `plan skip-all` error
path, and `group-of`) were replaced by a single `SubtestDeclSnapshot` captured
by `snapshot_subtest_decls()` and applied by `restore_subtest_decls()`, so a
future addition cannot be forgotten in one of the three again.

## Why this matters now

This closes the `00-load` gap in the vendored Zef test suite: its second
subtest `use`s the `Zef::Service::*` plugins, all of which had already been
pulled in transitively by the first subtest's `use Zef`, so all twelve of them
failed with `Invalid typename 'Fetcher'` and friends. With #5377 having closed
`distribution-depends-parsing`, the Zef battery is now 10/10 and the release
gate reaches its full baseline:

```
=== summary: 18/18 test files pass ===
GATE PASSED: every whitelisted bundled-library test still passes.
```

`zef 00-load.rakutest` is added to `batteries-whitelist.txt` accordingly.

## Testing

- `make test`: `Files=2417, Tests=23043 ... Result: PASS`
- `MUTSU_BIN=target/release/mutsu scripts/battery-testsuite.sh`: 18/18, gate passed
- New pin `t/subtest-module-reuse.t` (6 tests) — output matches `raku` exactly.
  It also covers re-load idempotence for declarations the rollback does *not*
  undo (an exported enum's variants, an exported constant), so the mainline can
  `use` a module the subtests already pulled in.
- Module-related roast spot-check (`S10-packages/require-and-use.t`,
  `S10-packages/basic.t`, `S10-packages/precompilation.t`,
  `S11-modules/versioning.t`, `S11-repository/*`, `S22-package-format/local.t`,
  `S12-meta/exporthow.t`, `S24-testing/{3-output,11-plan-skip-all-subtests,12-subtest-todo}.t`):
  identical results to `main` — the two non-whitelisted failures
  (`S10-packages/basic.t` 9 subtests, `S12-meta/exporthow.t`) fail the same way
  before and after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)