### PR TITLE
ci: use client-id for the release app token (app-id is deprecated)

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.TAGPR_APP_ID }}
+          client-id: ${{ vars.TAGPR_APP_CLIENT_ID }}
           private-key: ${{ secrets.TAGPR_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Summary

The v0.17.1 release (first cut with the new `tag-release.yml`) succeeded, but `actions/create-github-app-token` printed a deprecation notice: `Input 'app-id' has been deprecated with message: Use 'client-id' instead.`

Switch the token step from the legacy `app-id` to `client-id`, sourced from a new `TAGPR_APP_CLIENT_ID` repo variable holding the App's (non-secret) Client ID.

## Verified

- `TAGPR_APP_CLIENT_ID` repo variable added.
- Will re-release (v0.17.2) after merge to confirm the warning is gone and the App-token push to main + tag still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)