### PR TITLE
fix: allow modules/ into the Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,11 @@
 # Keep the Docker build context tiny: ignore everything, then re-include only
 # what the build needs (src + manifests to compile, vendor/ for the bundled
-# zef tree copied into the runtime image). This excludes the 45G target/, the
-# vendored roast/raku-doc trees, tmp/, .git, etc.
+# zef tree, and modules/ for the bundled batteries, both copied into the runtime
+# image). This excludes the 45G target/, the vendored roast/raku-doc trees,
+# tmp/, .git, etc.
 *
 !Cargo.toml
 !Cargo.lock
 !src/
 !vendor/
+!modules/

--- a/news/2026-07/dockerignore-modules-batteries.md
+++ b/news/2026-07/dockerignore-modules-batteries.md
@@ -1,0 +1,22 @@
+# Fix the Docker release build: allow modules/ into the build context
+
+The Docker image build (`docker.yml`, GHCR) had been failing on every tag since
+v0.17.0 with:
+
+```
+ERROR: failed to compute cache key: failed to calculate checksum of ref ...:
+"/src/modules": not found
+```
+
+`.dockerignore` uses an ignore-everything-then-allowlist strategy (`*` followed
+by `!Cargo.toml`, `!src/`, `!vendor/`, …) to keep the build context tiny. When
+the OpenSSL / IO::Socket::SSL battery landed (#5342), it added the `modules/`
+directory and a `COPY --from=builder /src/modules …` line to the `Dockerfile`,
+but did not add `!modules/` to the allowlist. So `modules/` was excluded from the
+build context, `COPY . .` never copied it into the builder, and the runtime-stage
+`COPY /src/modules` failed.
+
+The tarball release (`release.yml`) was unaffected — it copies `modules/`
+straight from the checkout, not through the Docker context — so v0.17.0 and
+v0.17.1 shipped tarballs but no container image. Adding `!modules/` to
+`.dockerignore` restores the Docker publish.


### PR DESCRIPTION
## Summary

The Docker image build (`docker.yml` → GHCR) has failed on **every tag since v0.17.0**:

```
ERROR: failed to compute cache key: failed to calculate checksum of ref ...: "/src/modules": not found
```

Pre-existing bug, surfaced now that we're actively releasing (spotted on the v0.17.1 tag).

## Root cause

`.dockerignore` ignores everything then allowlists what the build needs (`!Cargo.toml`, `!src/`, `!vendor/`, …). The OpenSSL / IO::Socket::SSL battery (#5342) added `modules/` and a `COPY --from=builder /src/modules …` Dockerfile line, but did **not** add `!modules/`. So `modules/` was excluded from the build context, `COPY . .` never copied it, and the runtime-stage `COPY /src/modules` failed.

The tarball release (`release.yml`) copies `modules/` straight from the checkout, not through the Docker context, so it was unaffected — v0.17.0/v0.17.1 shipped tarballs but no container image.

## Fix

Add `!modules/` to `.dockerignore`. Verified by the upcoming re-release (docker.yml runs on the tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)