### PR TITLE
fix: a module `use`d inside EVAL or a block keeps its own routines

### DIFF
--- a/src/runtime/accessors_misc.rs
+++ b/src/runtime/accessors_misc.rs
@@ -98,6 +98,37 @@ impl Interpreter {
         self.end_phaser_sites.insert(site_id)
     }
 
+    /// Put back the routines a module load introduced that `snapshot` predates.
+    ///
+    /// Restoring `registry.functions` to a snapshot taken before a `use` drops
+    /// the used module's own routines, but NOT its entry in `loaded_modules` —
+    /// so the module is left half-loaded: code that still holds one of its subs
+    /// (a `&name` the scope returned, or an export hoisted into the caller) runs
+    /// with the module's file-scoped helpers gone, and re-`use`ing it is a no-op
+    /// that cannot restore them. `'use File::Temp; &tempfile'.EVAL` hits exactly
+    /// this: the returned `&tempfile` then dies with `Unknown function:
+    /// make-temp`.
+    ///
+    /// Only package-qualified keys are tracked (see `module_registered_functions`),
+    /// so the importing scope's bare aliases still go out of scope normally.
+    pub(crate) fn reinstate_module_functions(
+        &self,
+        functions: &mut rustc_hash::FxHashMap<Symbol, std::sync::Arc<FunctionDef>>,
+    ) {
+        if self.module_registered_functions.is_empty() {
+            return;
+        }
+        let registry = self.registry();
+        for key in &self.module_registered_functions {
+            if functions.contains_key(key) {
+                continue;
+            }
+            if let Some(def) = registry.functions.get(key) {
+                functions.insert(*key, def.clone());
+            }
+        }
+    }
+
     pub(crate) fn snapshot_routine_registry(&self) -> RoutineRegistrySnapshot {
         // Single guard for all six reads (avoids stacking read guards).
         let registry = self.registry();
@@ -120,8 +151,9 @@ impl Interpreter {
     }
 
     fn restore_routine_registry_impl(&mut self, snapshot: RoutineRegistrySnapshot, is_eval: bool) {
-        let (functions, proto_functions, token_defs, proto_subs, proto_tokens, our_scoped_keys) =
+        let (mut functions, proto_functions, token_defs, proto_subs, proto_tokens, our_scoped_keys) =
             snapshot;
+        self.reinstate_module_functions(&mut functions);
         // Collect our-scoped functions that were newly added during this block
         // (not present in the snapshot) that need to persist after scope restoration.
         // Preserve functions defined in the current package (original behavior)

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -907,6 +907,16 @@ pub struct Interpreter {
     end_phaser_sites: HashSet<u64>,
     chroot_root: Option<PathBuf>,
     loaded_modules: HashSet<String>,
+    /// Package-qualified routine keys a module load introduced (`M::helper`,
+    /// `M::EXPORT::ALL::foo`) — never the bare `GLOBAL::` import aliases, which
+    /// stay lexical to the importing scope.
+    ///
+    /// `loaded_modules` is never rolled back, so these must not be either: a
+    /// scope that restores the routine registry wholesale (a bare block, an
+    /// `EVAL`) would otherwise leave the module marked as loaded while its own
+    /// routines are gone, and a re-`use` — being a no-op — could not bring them
+    /// back. See `reinstate_module_functions`.
+    module_registered_functions: HashSet<Symbol>,
     need_hidden_classes: HashSet<String>,
     /// CompUnit::Repository::Installation state (`.loaded` units and the symbols
     /// pulled in by `.need` but not yet merged into GLOBAL).

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -172,7 +172,7 @@ impl Interpreter {
             return Ok(Value::NIL);
         }
         let let_mark = self.let_saves_len();
-        let saved_functions = self.registry().functions.clone();
+        let mut saved_functions = self.registry().functions.clone();
         let saved_proto_subs = self.registry().proto_subs.clone();
         let saved_proto_functions = self.registry().proto_functions.clone();
         let saved_operator_assoc = self.operator_assoc.clone();
@@ -252,6 +252,10 @@ impl Interpreter {
             .load(std::sync::atomic::Ordering::Relaxed)
             != registry_gen_before
         {
+            // A `use` inside this block registered the module's own routines;
+            // they outlive the block (`loaded_modules` does), so put them back
+            // before the snapshot lands. See `reinstate_module_functions`.
+            self.reinstate_module_functions(&mut saved_functions);
             {
                 let mut reg = self.registry_mut();
                 reg.functions = saved_functions;

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2081,6 +2081,7 @@ impl Interpreter {
             end_phaser_sites: HashSet::new(),
             chroot_root: None,
             loaded_modules: HashSet::new(),
+            module_registered_functions: HashSet::new(),
             need_hidden_classes: HashSet::new(),
             cur_repo: Box::new(CurRepoState::default()),
             package_stash_hidden: HashSet::new(),

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -511,6 +511,25 @@ impl Interpreter {
             }
 
             self.loaded_modules.insert(module.to_string());
+            // Record the module's own (package-qualified) routines so a later
+            // registry restore cannot drop them while `loaded_modules` still
+            // claims the module is loaded. Collected BEFORE `import_module`, so
+            // the bare `GLOBAL::` aliases it creates are excluded — those are
+            // lexical to the importing scope and must still disappear with it
+            // (roast S11-modules/lexical.t). Mirrors the same distinction
+            // `pop_import_scope` already makes.
+            let module_funcs: Vec<Symbol> = self
+                .registry()
+                .functions
+                .keys()
+                .filter(|k| !func_keys_before.contains(k))
+                .filter(|k| {
+                    let ks = k.resolve();
+                    ks.contains("::") && !ks.starts_with("GLOBAL::")
+                })
+                .copied()
+                .collect();
+            self.module_registered_functions.extend(module_funcs);
             if let Err(err) = self.import_module(module, tags)
                 && !err.message.starts_with("No exports found for module:")
             {

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -227,6 +227,7 @@ impl Interpreter {
             end_phaser_sites: HashSet::new(),
             chroot_root: self.chroot_root.clone(),
             loaded_modules: self.loaded_modules.clone(),
+            module_registered_functions: self.module_registered_functions.clone(),
             need_hidden_classes: self.need_hidden_classes.clone(),
             cur_repo: self.cur_repo.clone(),
             package_stash_hidden: self.package_stash_hidden.clone(),

--- a/t/eval-module-lexical-subs.t
+++ b/t/eval-module-lexical-subs.t
@@ -1,0 +1,31 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+# A module loaded inside a scope that restores the routine registry (a bare
+# block, or `EVAL`) must keep its OWN routines afterwards: `loaded_modules` is
+# never rolled back, so re-`use`ing it is a no-op that could not bring them
+# back. Dropping them left the module half-loaded -- an export the scope handed
+# out still ran, but its calls to the module's file-scoped helpers died with
+# "Unknown function".
+#
+# This is how File::Temp's upstream t/03-tempfile loads the module (it installs
+# its own END phaser before File::Temp's), which failed with
+# "Unknown function: make-temp".
+
+plan 5;
+
+# --- EVAL: the module's file-scoped helper survives the EVAL's registry restore
+my (&doubled, &tripled) := 'use EvalModHelper; &doubled, &tripled'.EVAL;
+is doubled(5), 10, 'an exported sub from an EVAL-loaded module reaches its file-scoped helper';
+is tripled(5), 15, 'an `our` export from an EVAL-loaded module reaches it too';
+is doubled(7), 14, 'and keeps working on a later call';
+
+# --- bare block: same rule, a block is also a registry-restoring scope
+my $from-block;
+{
+    use EvalModHelper;
+    is doubled(3), 6, 'the import is visible inside the importing block';
+    $from-block = &doubled;
+}
+is $from-block(6), 12, 'a sub captured from a block-scoped `use` still reaches its helper';

--- a/t/lib/EvalModHelper.rakumod
+++ b/t/lib/EvalModHelper.rakumod
@@ -1,0 +1,9 @@
+unit module EvalModHelper;
+
+# A file-scoped helper the module's own exports call. It must stay reachable
+# after a registry-restoring scope (`EVAL`, a bare block) that did the `use`
+# has exited -- see t/eval-module-lexical-subs.t.
+my sub helper($x) { $x * 2 }
+
+my sub doubled($x) is export { helper($x) }
+our sub tripled($x) is export { helper($x) + $x }


### PR DESCRIPTION
## The bug

A scope that restores the routine registry wholesale — a bare block, or an `EVAL` (both go through `eval_block_value_inner`) — rolled a `use`d module's own routines back out with it. But `loaded_modules` is **never** rolled back, so the module was left half-loaded: an export the scope handed out still ran, while its calls to the module's file-scoped helpers died with `Unknown function`, and re-`use`ing the module was a no-op that could not restore them.

```raku
# lib/M1.rakumod:  unit module M1;
#                  my sub helper($x) { $x * 2 }
#                  my sub pubfn($x) is export { helper($x) + 1 }
my (&pubfn, &pubfn2) := 'use M1; &pubfn, &pubfn2'.EVAL;
say pubfn(5);   # raku: 11    mutsu: Unknown function: helper
```

Same class of inconsistency as #5379 (a `subtest` rolled back the type registry but not `loaded_modules`).

## The fix

Track the **package-qualified** routine keys each module load introduces (`M::helper`, `M::EXPORT::ALL::foo`) and reinstate them whenever a snapshot that predates the load is restored — in `eval_block_value_inner` and in `restore_routine_registry_impl`.

Deliberately **not** the bare `GLOBAL::` import aliases: those stay lexical to the importing scope and must still disappear with it (roast `S11-modules/lexical.t`: `{ use Foo } EVAL('foo()')` must die). That is exactly the distinction `pop_import_scope` already makes, so the collection happens *before* `import_module` creates the aliases.

## Why now

This was the last blocker on bundling **`File::Temp`** as a battery. Its upstream `t/03-tempfile` loads the module as `'use File::Temp; &tempfile, &tempdir'.EVAL` (so the test can install its own `END` phaser before File::Temp's), which failed with `Unknown function: make-temp`. With this fix File::Temp's upstream suite is **3/3**; the bundling follows in a separate PR on top of #5383.

## Verification

- `t/eval-module-lexical-subs.t` (new, with `t/lib/EvalModHelper.rakumod`) — 5/5 on mutsu, and byte-identical output under real `raku`.
- `roast/S11-modules/lexical.t` — still passes (the alias-scoping canary).
- `File::Temp` upstream suite — 2/3 → **3/3**.
- `make test` — PASS (2418 files, 23048 tests).
- `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)