### PR TITLE
fix: allow LICENSE into the Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,16 @@
 # Keep the Docker build context tiny: ignore everything, then re-include only
-# what the build needs (src + manifests to compile, vendor/ for the bundled
-# zef tree, and modules/ for the bundled batteries, both copied into the runtime
-# image). This excludes the 45G target/, the vendored roast/raku-doc trees,
-# tmp/, .git, etc.
+# what the build needs. This excludes the 45G target/, the vendored
+# roast/raku-doc trees, tmp/, .git, etc.
+#
+# IMPORTANT: every path the Dockerfile pulls from the build context must be
+# allowlisted here, or the build fails with `"/src/<path>": not found`. When you
+# add a `COPY --from=builder /src/<x>` line to the Dockerfile, add `!<x>` below.
+# (This bit us for modules/ and LICENSE — docker.yml only runs on a tag, so PR CI
+# does not catch it.)
 *
 !Cargo.toml
 !Cargo.lock
 !src/
 !vendor/
 !modules/
+!LICENSE


### PR DESCRIPTION
## Summary

Follow-up to #5384. The Docker image build still failed on the v0.17.2 tag, now with:

```
ERROR: failed to compute cache key: failed to calculate checksum of ref ...: "/src/LICENSE": not found
```

Same class of bug as the `modules/` omission: the Artistic-2.0 license PR (#5382) added a `COPY --from=builder /src/LICENSE …` line to the `Dockerfile` but did not add `!LICENSE` to `.dockerignore` (which ignores everything then allowlists). So `LICENSE` was excluded from the build context.

## Fix

- Add `!LICENSE` to `.dockerignore`.
- Add a comment: every Dockerfile `COPY --from=builder /src/<x>` target must be allowlisted, since `docker.yml` only runs on a tag and PR CI does not catch this.

I audited all 5 Dockerfile COPY-from-builder targets against the allowlist; `target/release/*` are built in-stage, `vendor/`+`modules/` are allowlisted, and `LICENSE` was the only remaining gap. Verified end-to-end with a local `docker build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)