### PR TITLE
fix: break equal-length proto-token LTM tie by declaration order

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1428,50 +1428,60 @@ garbage until the page rebuilds the interpreter.
   recorded native output rather than a trap. Removing those flags is the acceptance test
   for this item; `wasm-demo/e2e.test.mjs` sweeps every non-flagged lesson in a real browser.
 
-### 8.20 Proto-token LTM ignores literal-vs-charclass specificity on an equal-length tie (found 2026-07-24, File::Ignore)
+### 8.20 Grammar `:my $*FINAL` per-match dynamic var leaks to earlier candidates' actions (found 2026-07-25, File::Ignore)
 
-When a `proto token` has two `:sym<>` candidates that match the SAME length at a
-position, Rakudo's Longest-Token-Matching breaks the tie by declaration order /
-specificity (a literal `<sym>` candidate outranks a character-class one). mutsu
-picks the wrong candidate, so a globstar `**` in a `.gitignore`-style grammar is
-dispatched to the fall-through `matcher` candidate instead of the dedicated `**`
-candidate.
+*(The original 8.20 — proto-token LTM equal-length tie-break — was FIXED
+2026-07-25: the resolver sorted `:sym<>` candidates alphabetically instead of by
+declaration order, and the quantified-subrule LTM dedup kept the LAST candidate
+on a tie. Fix: stamp `FunctionDef.decl_order` at `insert_token_def`, sort
+sym-variant keys by it (`sort_sym_keys_by_decl_order`), and keep the
+first-declared candidate on an equal-length tie in `regex_match_atom.rs`. Pin:
+`t/proto-token-ltm-tiebreak.t`. That took `File::Ignore` `wildcard.rakutest`
+36/44 → 38/44. The remaining 6 (`a/**/b` mid-path globstar) are THIS separate
+bug.)*
 
-- **Minimal repro** (both candidates match `**`, 2 chars):
+`File::Ignore`'s grammar declares a per-match dynamic variable and sets it inside
+a lookahead, then reads it in the action method to decide whether a path segment
+is the final one:
+
+```raku
+token path-part:sym<matcher> {
+    :my $*FINAL;
+    <matcher>+ {}
+    [<?before '/'? $> { $*FINAL = True }]?   # sets $*FINAL only for the LAST segment
+}
+```
+
+- **Minimal repro:**
   ```raku
   grammar G {
-      token TOP { <pp>+ % '/' }
-      proto token pp {*}
-      token pp:sym<**> { <sym> }        # literal, declared first
-      token pp:sym<m>  { <-[/]>+ }      # char-class fall-through
+      token TOP { <part>+ % '/' }
+      token part {
+          :my $*FINAL;
+          \w+ {}
+          [<?before '/'? $> { $*FINAL = True }]?
+      }
   }
-  class Act {
-      method TOP($/) { make $<pp>.map(*.ast).join('|') }
-      method pp:sym<**>($/) { make 'GLOBSTAR' }
-      method pp:sym<m>($/)  { make "M:$/" }
+  class A {
+      method TOP($/) { make $<part>.map(*.ast).join('|') }
+      method part($/) { make ($*FINAL ?? "FIN" !! "mid") ~ ":$/" }
   }
-  say G.parse('d/**', :actions(Act)).ast;
-  # raku:  M:d|GLOBSTAR      mutsu: M:d|M:**   (dispatched to the wrong sym)
+  say G.parse('a/b/c', :actions(A)).ast;
+  # raku:  mid:a|mid:b|FIN:c      mutsu: FIN:a|FIN:b|FIN:c
   ```
-- **Confirmed:** a SOLE `pp:sym<**>` candidate matches `**` fine (so `<sym>`
-  literal escaping is correct); the bug is purely the multi-candidate tie-break.
-  raku's tie-break is declaration order — swapping the two `token` lines makes
-  raku pick `m` too; mutsu picks `m` regardless of order.
-- **Code paths ruled out during triage:** the tie-break is NOT in
-  `regex_match_public.rs` `parse_anchored_single_subrule` LTM loop (never entered
-  for a `<pp>` inside `<pp>+ % '/'`) nor the `regex_match_capture.rs:453`
-  "keep-longest inner_end / first-on-tie" subrule loop (a `MUTSU_DBG_LTM` probe in
-  both produced zero output for this grammar). The live path is a third
-  proto-token dispatch — likely via `regex_match_ends_from_caps_in_pkg` /
-  `regex_token_method.rs` (or wherever `parsed_subrule_candidates` for a proto is
-  actually consumed). Find that path first; the fix is to break an equal-length
-  tie by candidate declaration order (and/or literal-over-charclass specificity),
-  matching Rakudo. Validate against the whole `S05-grammar/` roast set — this is
-  load-bearing for every proto-token grammar.
-- **Impact:** unblocks the `File::Ignore` distribution's `**` globstar patterns
-  (T-057): `wildcard.rakutest` 36/44 → (expected) full, plus `negated`/`range`
-  partials that also stem from globstar. `path`/`charclass`/`literal` already pass.
-  Also a general grammar-correctness fix.
+- **Diagnosis:** each `part` match should get its OWN `$*FINAL` binding
+  (`:my $*FINAL` inside the token), True only for the segment whose
+  `<?before '/'? $>` lookahead succeeds (the last). In mutsu every segment's
+  action reads `FIN` — the value set during the LAST segment's match leaks back
+  to the earlier segments' action methods. Either action methods are run
+  *after* the whole parse (so `$*FINAL` reads its final value) rather than at
+  reduce time, or `:my $*FINAL` is not creating a fresh per-match binding. This
+  is a grammar dynamic-variable / action-timing bug, unrelated to LTM.
+- **Impact:** the 6 remaining `File::Ignore` `wildcard.rakutest` `a/**/b`
+  failures. The mid-path globstar's compiled regex is correct (a direct
+  `/^ 'a' '/' [ <-[/]>+ [ '/' | $ ] ]* 'b' <?before "/" | $> /` matches in mutsu);
+  the module builds a *wrong* pattern string (`'a'` missing its trailing ` '/'`)
+  because the `a` segment's action wrongly sees `$*FINAL = True`.
 
 
 ## Metrics

--- a/news/2026-07/proto-token-ltm-declaration-order-tiebreak.md
+++ b/news/2026-07/proto-token-ltm-declaration-order-tiebreak.md
@@ -1,0 +1,49 @@
+# Proto-token LTM breaks an equal-length tie by declaration order
+
+Rakudo's Longest-Token-Matching, when two `proto token` `:sym<>` candidates
+match the *same* number of characters at a position, breaks the tie by
+declaration order: the first-declared candidate wins. mutsu picked the wrong
+candidate, so a globstar `**` in a `.gitignore`-style grammar
+
+```raku
+grammar G {
+    token TOP { <pp>+ % '/' }
+    proto token pp {*}
+    token pp:sym<**> { <sym> }        # literal, declared first
+    token pp:sym<m>  { <-[/]>+ }      # char-class fall-through
+}
+```
+
+was dispatched to the `m` fall-through candidate instead of the dedicated `**`
+candidate (`G.parse('d/**')` produced `M:d|M:**` instead of `M:d|GLOBSTAR`).
+
+Two bugs combined to produce this:
+
+1. The subrule resolver collected `:sym<>` variant candidates by walking a
+   `HashMap` and then sorting the keys **alphabetically** (`sym_keys.sort()`) for
+   determinism — so `pp:sym<**>` always sorted before `pp:sym<m>` regardless of
+   source order, losing declaration order entirely.
+2. The quantified-subrule LTM dedup in `regex_match_atom.rs` kept the **last**
+   candidate on an equal-length tie (it popped the previous match and pushed the
+   new one), rather than the first.
+
+The fix records declaration order and honours it:
+
+- `FunctionDef` gains a monotonic `decl_order`, stamped at `insert_token_def`
+  time (grammar bodies register their tokens top-to-bottom, so registration
+  order is declaration order). It rides along with the `Arc<FunctionDef>` stored
+  in `token_defs`, so it survives every registry clone/snapshot.
+- All five sym-key resolution sites sort by `sort_sym_keys_by_decl_order`
+  (declaration order, alphabetical as a stable fallback) instead of
+  alphabetically.
+- The `regex_match_atom.rs` LTM dedup keeps the first-declared candidate on an
+  equal-length tie.
+
+Longest-token-still-wins on a genuine length difference, and the fall-through
+candidate still wins only when the specific candidates fail to match.
+
+Pinned by `t/proto-token-ltm-tiebreak.t` and the existing
+`roast/S05-metasyntax/proto-token-ltm.t`. This takes the `File::Ignore`
+distribution's `wildcard.rakutest` from 36/44 to 38/44 (the remaining `a/**/b`
+mid-path globstar cases are a separate grammar dynamic-variable bug, recorded in
+PLAN.md 8.20).

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -138,6 +138,13 @@ pub(crate) struct FunctionDef {
     /// can report the module file (integration/error-reporting.t test 15).
     #[serde(default)]
     pub(crate) source_file: Option<String>,
+    /// Monotonic declaration/registration order, stamped when a `token`/`rule`
+    /// is registered (`insert_token_def`). Used to break an equal-length
+    /// Longest-Token-Match tie between proto candidates by declaration order,
+    /// matching Rakudo (`token pp:sym<**>` declared before `token pp:sym<m>`
+    /// wins the tie). 0 for defs that are not proto-token candidates.
+    #[serde(default)]
+    pub(crate) decl_order: u64,
 }
 
 /// A `fmt::Write` sink that streams formatted bytes straight into a `Hasher`,

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -471,12 +471,19 @@ impl Interpreter {
 
                     // Sort/dedup into HIGHEST FIRST order.
                     let deduped_raw: Vec<(usize, RegexCaptures)> = if has_proto {
-                        // LTM: sort by end ascending, dedup, then reverse → HIGHEST (longest) FIRST.
+                        // LTM: stable-sort by end ascending, dedup, then reverse
+                        // → HIGHEST (longest) FIRST. On an equal-length tie,
+                        // Rakudo's LTM breaks the tie by candidate declaration
+                        // order — the FIRST-declared candidate wins. `raw_out`
+                        // preserves declaration order (candidates.iter()) and
+                        // the sort is stable, so on a tie the first-declared
+                        // candidate appears first among equal ends; keep it and
+                        // skip the rest (do NOT pop/replace with the later one).
                         raw_out.sort_by_key(|(e, _)| *e);
                         let mut tmp: Vec<(usize, RegexCaptures)> = Vec::new();
                         for item in raw_out {
                             if tmp.last().is_some_and(|(e, _)| *e == item.0) {
-                                tmp.pop();
+                                continue;
                             }
                             tmp.push(item);
                         }

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -206,7 +206,7 @@ impl Interpreter {
             .map(|key| key.resolve())
             .filter(|key| key.starts_with(&sym_prefix_angle) || key.starts_with(&sym_prefix_french))
             .collect();
-        sym_keys.sort();
+        self.sort_sym_keys_by_decl_order(&mut sym_keys);
         for key in &sym_keys {
             let sym_val = Self::extract_sym_adverb(key);
             if let Some(defs) = self.registry().token_defs.get(&Symbol::intern(key)) {

--- a/src/runtime/regex/regex_token_resolve.rs
+++ b/src/runtime/regex/regex_token_resolve.rs
@@ -241,7 +241,7 @@ impl Interpreter {
                     key.starts_with(&sym_prefix_angle) || key.starts_with(&sym_prefix_french)
                 })
                 .collect();
-            sym_keys.sort();
+            self.sort_sym_keys_by_decl_order(&mut sym_keys);
             for key in &sym_keys {
                 if let Some(defs) = self.registry().token_defs.get(&Symbol::intern(key)) {
                     out.extend(defs.clone());

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -135,6 +135,7 @@ impl Interpreter {
             is_default: false,
             deprecated_message: None,
             source_file: self.current_source_file(),
+            decl_order: 0,
         };
         // Register as a typed multi candidate under the class package, mirroring
         // the `multi sub` registration keys so `import` copies it and operator
@@ -2048,6 +2049,7 @@ impl Interpreter {
                             is_default: *is_default_candidate,
                             deprecated_message: None,
                             source_file: self.current_source_file(),
+                            decl_order: 0,
                         };
                         self.registry_mut().functions.insert(
                             Symbol::intern(&qualified_name),
@@ -2125,6 +2127,7 @@ impl Interpreter {
                             is_default: *is_default_candidate,
                             deprecated_message: None,
                             source_file: self.current_source_file(),
+                            decl_order: 0,
                         };
                         // Register under the short name (lexical scope)
                         self.registry_mut().functions.insert(
@@ -2311,6 +2314,7 @@ impl Interpreter {
                         is_default: false,
                         deprecated_message: None,
                         source_file: self.current_source_file(),
+                        decl_order: 0,
                     };
                     self.registry_mut()
                         .proto_methods

--- a/src/runtime/registration_sub.rs
+++ b/src/runtime/registration_sub.rs
@@ -688,6 +688,7 @@ impl Interpreter {
             is_default: custom_traits.iter().any(|(t, _)| t == "default"),
             deprecated_message,
             source_file: self.current_source_file(),
+            decl_order: 0,
         };
         let single_key = format!("{}::{}", self.current_package(), name);
         let multi_prefix = format!("{}::{}/", self.current_package(), name);
@@ -1079,6 +1080,7 @@ impl Interpreter {
             is_default: false,
             deprecated_message: None,
             source_file: self.current_source_file(),
+            decl_order: 0,
         };
         self.insert_token_def(name, def, multi);
     }
@@ -1136,6 +1138,7 @@ impl Interpreter {
                 is_default: false,
                 deprecated_message: None,
                 source_file: self.current_source_file(),
+                decl_order: 0,
             }),
         );
         Ok(())
@@ -1241,6 +1244,7 @@ impl Interpreter {
             is_default: false,
             deprecated_message: None,
             source_file: self.current_source_file(),
+            decl_order: 0,
         };
         let single_key = format!("GLOBAL::{}", name);
         let single_key_sym = Symbol::intern(&single_key);
@@ -1384,6 +1388,7 @@ impl Interpreter {
                 is_default: false,
                 deprecated_message: None,
                 source_file: self.current_source_file(),
+                decl_order: 0,
             }),
         );
         Ok(())

--- a/src/runtime/resolution.rs
+++ b/src/runtime/resolution.rs
@@ -1,6 +1,13 @@
 use super::*;
 use crate::symbol::Symbol;
 
+/// Monotonic counter stamped onto each `token`/`rule` `FunctionDef` at
+/// registration time (`insert_token_def`) to record declaration order. Rakudo
+/// breaks an equal-length Longest-Token-Match tie between proto candidates by
+/// declaration order, so the resolver sorts sym-variant candidates by this
+/// value instead of alphabetically.
+static NEXT_TOKEN_DECL_ORDER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
 impl Interpreter {
     pub(crate) const LAZY_GATHER_TAKE_LIMIT_SIGNAL: &str =
         "__mutsu_lazy_gather_take_limit_reached__";
@@ -128,8 +135,13 @@ impl Interpreter {
         }
     }
 
-    pub(super) fn insert_token_def(&mut self, name: &str, def: FunctionDef, multi: bool) {
+    pub(super) fn insert_token_def(&mut self, name: &str, mut def: FunctionDef, multi: bool) {
         let key = Symbol::intern(&format!("{}::{}", self.current_package(), name));
+        // Stamp declaration order: grammar bodies register their `token`s
+        // top-to-bottom, so a monotonic counter captures declaration order,
+        // which is Rakudo's tie-break for an equal-length LTM tie between
+        // proto candidates (`token pp:sym<**>` before `token pp:sym<m>`).
+        def.decl_order = NEXT_TOKEN_DECL_ORDER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let def = std::sync::Arc::new(def);
         if multi {
             self.registry_mut()
@@ -150,6 +162,29 @@ impl Interpreter {
     /// Candidate identity of a token def: the def's own name when it is a
     /// proto candidate of `token_name` (`statement:sym<expr>`), else the bare
     /// `token_name`.
+    /// Declaration order of a token key's candidates (the earliest-declared
+    /// one), for sorting proto sym-variant candidates by Rakudo's LTM
+    /// declaration-order tie-break. Unknown keys sort last (`u64::MAX`), then
+    /// alphabetically as a stable fallback.
+    pub(crate) fn token_key_decl_order(&self, key: &str) -> u64 {
+        self.registry()
+            .token_defs
+            .get(&Symbol::intern(key))
+            .and_then(|defs| defs.iter().map(|d| d.decl_order).min())
+            .unwrap_or(u64::MAX)
+    }
+
+    /// Sort resolved `:sym<>` variant keys by declaration order (Rakudo's LTM
+    /// tie-break), falling back to alphabetical order for keys that share a
+    /// declaration order or are unregistered — keeping the result deterministic.
+    pub(crate) fn sort_sym_keys_by_decl_order(&self, sym_keys: &mut [String]) {
+        sym_keys.sort_by(|a, b| {
+            self.token_key_decl_order(a)
+                .cmp(&self.token_key_decl_order(b))
+                .then_with(|| a.cmp(b))
+        });
+    }
+
     pub(crate) fn token_def_identity(def_name: &str, token_name: &str) -> String {
         if def_name
             .strip_prefix(token_name)
@@ -192,7 +227,7 @@ impl Interpreter {
             .map(|key| key.resolve())
             .filter(|key| key.starts_with(&sym_prefix_angle) || key.starts_with(&sym_prefix_french))
             .collect();
-        sym_keys.sort();
+        self.sort_sym_keys_by_decl_order(&mut sym_keys);
         for key in &sym_keys {
             let identity = &key[scope_prefix_len..];
             if seen.contains(identity) {
@@ -224,7 +259,7 @@ impl Interpreter {
             .map(|key| key.resolve())
             .filter(|key| key.starts_with(&sym_prefix_angle) || key.starts_with(&sym_prefix_french))
             .collect();
-        sym_keys.sort();
+        self.sort_sym_keys_by_decl_order(&mut sym_keys);
         for key in &sym_keys {
             if let Some(sym_defs) = self.registry().token_defs.get(&Symbol::intern(key)) {
                 defs.extend(sym_defs.clone());
@@ -298,7 +333,7 @@ impl Interpreter {
                     key.starts_with(&sym_prefix_angle) || key.starts_with(&sym_prefix_french)
                 })
                 .collect();
-            sym_keys.sort();
+            self.sort_sym_keys_by_decl_order(&mut sym_keys);
             for key in &sym_keys {
                 if let Some(sym_defs) = self.registry().token_defs.get(&Symbol::intern(key)) {
                     defs.extend(sym_defs.clone());

--- a/t/proto-token-ltm-tiebreak.t
+++ b/t/proto-token-ltm-tiebreak.t
@@ -1,0 +1,76 @@
+use v6;
+use Test;
+
+# Rakudo's Longest-Token-Matching breaks an equal-length tie between two proto
+# `:sym<>` candidates by declaration order: the FIRST-declared candidate wins
+# (PLAN.md 8.20). A globstar `**` (a literal `<sym>` candidate) declared before
+# a char-class fall-through must win the 2-char tie against it.
+
+plan 4;
+
+{
+    grammar G {
+        token TOP { <pp>+ % '/' }
+        proto token pp {*}
+        token pp:sym<**> { <sym> }        # literal, declared first
+        token pp:sym<m>  { <-[/]>+ }      # char-class fall-through
+    }
+    class Act {
+        method TOP($/) { make $<pp>.map(*.ast).join('|') }
+        method pp:sym<**>($/) { make 'GLOBSTAR' }
+        method pp:sym<m>($/)  { make "M:$/" }
+    }
+    is G.parse('d/**', :actions(Act)).ast, 'M:d|GLOBSTAR',
+        'tie broken toward first-declared literal <sym> candidate';
+}
+
+{
+    # Swapping the declaration order flips the tie-break winner (Rakudo semantics).
+    grammar G2 {
+        token TOP { <pp>+ % '/' }
+        proto token pp {*}
+        token pp:sym<m>  { <-[/]>+ }      # char-class, declared first now
+        token pp:sym<**> { <sym> }        # literal, declared second
+    }
+    class Act2 {
+        method TOP($/) { make $<pp>.map(*.ast).join('|') }
+        method pp:sym<**>($/) { make 'GLOBSTAR' }
+        method pp:sym<m>($/)  { make "M:$/" }
+    }
+    is G2.parse('d/**', :actions(Act2)).ast, 'M:d|M:**',
+        'swapping declaration order flips the tie-break winner';
+}
+
+{
+    # A strictly longer candidate still wins on length (not a tie).
+    grammar G3 {
+        token TOP { <x> }
+        proto token x {*}
+        token x:sym<any> { \w+ }          # matches the whole thing (longer)
+        token x:sym<a>   { <sym> }        # shorter
+    }
+    class Act3 {
+        method TOP($/) { make $<x>.ast }
+        method x:sym<any>($/) { make 'ANY' }
+        method x:sym<a>($/)   { make 'A' }
+    }
+    is G3.parse('abc', :actions(Act3)).ast, 'ANY',
+        'longest-token wins regardless of declaration order';
+}
+
+{
+    # Fall-through only wins when the specific candidates do not match.
+    grammar G4 {
+        token TOP { <x> }
+        proto token x {*}
+        token x:sym<foo> { <sym> }
+        token x:sym<any> { \w+ }
+    }
+    class Act4 {
+        method TOP($/) { make $<x>.ast }
+        method x:sym<foo>($/) { make 'FOO' }
+        method x:sym<any>($/) { make 'ANY' }
+    }
+    is G4.parse('bar', :actions(Act4)).ast, 'ANY',
+        'fall-through candidate wins when the specific one does not match';
+}


### PR DESCRIPTION
## Summary

Rakudo's Longest-Token-Matching breaks an **equal-length** tie between two `proto token` `:sym<>` candidates by **declaration order** — the first-declared candidate wins. mutsu picked the wrong one, so a globstar `**` in a `.gitignore`-style grammar was dispatched to the char-class fall-through candidate instead of the dedicated `**` candidate.

```raku
grammar G {
    token TOP { <pp>+ % '/' }
    proto token pp {*}
    token pp:sym<**> { <sym> }        # literal, declared first
    token pp:sym<m>  { <-[/]>+ }      # char-class fall-through
}
say G.parse('d/**', :actions(Act)).ast;
# raku:  M:d|GLOBSTAR      mutsu (before): M:d|M:**
```

## Root cause

Two bugs combined:

1. The subrule resolver collected `:sym<>` variant candidates from a `HashMap` and sorted the keys **alphabetically** (`sym_keys.sort()`) for determinism — discarding declaration order, so `pp:sym<**>` always preceded `pp:sym<m>` regardless of source order.
2. The quantified-subrule LTM dedup in `regex_match_atom.rs` kept the **last** candidate on an equal-length tie (popped the previous match, pushed the new one) rather than the first.

## Fix

- `FunctionDef` gains a monotonic `decl_order`, stamped at `insert_token_def` time (grammar bodies register tokens top-to-bottom, so registration order = declaration order). It rides with the `Arc<FunctionDef>` stored in `token_defs`, surviving every registry clone/snapshot.
- All five sym-key resolution sites now sort by `sort_sym_keys_by_decl_order` (declaration order, alphabetical fallback).
- The `regex_match_atom.rs` LTM dedup keeps the first-declared candidate on an equal-length tie.

Longest-token still wins on a genuine length difference; the fall-through candidate still wins only when the specific ones fail to match.

## Tests

- New pin `t/proto-token-ltm-tiebreak.t` (4 cases: tie toward first-declared, swapped order flips winner, longest-still-wins, fall-through).
- `roast/S05-metasyntax/proto-token-ltm.t` and the `S05-grammar/` proto suite (`protoregex.t`, `protos.t`, `action-stubs.t`, `inheritance.t`, `polymorphism.t`), plus `S06-multi/proto.t` and `S12-meta/grammarhow.t`, all stay green.
- Takes `File::Ignore`'s `wildcard.rakutest` from 36/44 to 38/44. The remaining 6 (`a/**/b` mid-path globstar) are a **separate** grammar dynamic-variable bug (`:my $*FINAL` per-match binding leaking to earlier candidates' actions), now recorded in PLAN.md 8.20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)