### PR TITLE
fix: IO::Pipe.slurp-rest, and a cursor-aware IO::Pipe.slurp

### DIFF
--- a/news/2026-07/io-pipe-slurp-rest.md
+++ b/news/2026-07/io-pipe-slurp-rest.md
@@ -1,0 +1,23 @@
+# `IO::Pipe.slurp-rest`, and a cursor-aware `IO::Pipe.slurp`
+
+`slurp-rest` — the IO::Handle method that reads a handle from its current
+position to the end — was missing on `IO::Pipe`, so `run(:out, ...).out.slurp-rest`
+died with "No native method 'slurp-rest' on IO::Pipe". It is a very common idiom in
+distribution test suites (`.out.slurp-rest(:close)` is how a test reads a
+subprocess's captured output), and every such subtest aborted before running.
+
+Two related fixes:
+
+1. **`slurp-rest` is now dispatched on `IO::Pipe`** — for the stdin pipe, the
+   "live" out/err pipe, and the buffered pipe alike — and is registered in the
+   type's native-method whitelists so introspection agrees.
+2. **`slurp` / `slurp-rest` on a buffered pipe are cursor-aware.** They read from
+   the pipe's current cursor to the end and leave it drained, matching Rakudo:
+   `$proc.out.get` followed by `$proc.out.slurp-rest` yields the *remainder*, not
+   the whole output again, and a second `slurp-rest` returns the empty string.
+   `:bin` returns the remaining bytes as a `Buf`; `:close` closes the pipe.
+
+Found while triaging `TODO_dist` ticket T-046 (RakudoPrereq), whose `xt/01-operation.rakutest`
+runs nine subtests that each read a subprocess with `.slurp-rest(:close)`.
+
+Pin: `t/io-pipe-slurp-rest.t` (passes under both mutsu and raku).

--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -66,6 +66,7 @@ impl Interpreter {
             && matches!(
                 method_name,
                 "slurp"
+                    | "slurp-rest"
                     | "Str"
                     | "gist"
                     | "encoding"

--- a/src/runtime/native_io/io_pipe.rs
+++ b/src/runtime/native_io/io_pipe.rs
@@ -202,7 +202,7 @@ impl Interpreter {
                 }
             };
             match method {
-                "slurp" | "Str" | "gist" => {
+                "slurp" | "slurp-rest" | "Str" | "gist" => {
                     let has_bin = Self::named_bool(args, "bin");
                     let pipe_bin = matches!(
                         attributes.get("bin").map(Value::view),
@@ -314,6 +314,35 @@ impl Interpreter {
                     }
                     return Ok(Value::TRUE);
                 }
+                // `.slurp` / `.slurp-rest` read from the current cursor to the
+                // end (so `$p.out.get; $p.out.slurp-rest` yields the remainder)
+                // and leave the pipe drained, like IO::Handle.
+                "slurp" | "slurp-rest" => {
+                    let close = Self::named_bool(args, "close");
+                    let rest = {
+                        let Ok(mut map) = super::builtins_system::io_pipe_state_map().lock() else {
+                            return Ok(Value::str(String::new()));
+                        };
+                        let Some(state) = map.get_mut(&id) else {
+                            return Ok(Value::str(String::new()));
+                        };
+                        let rest = state.content[state.cursor..].to_string();
+                        state.cursor = state.content.len();
+                        if close {
+                            state.closed = true;
+                        }
+                        rest
+                    };
+                    let has_bin = Self::named_bool(args, "bin");
+                    let pipe_bin = matches!(
+                        attributes.get("bin").map(Value::view),
+                        Some(ValueView::Bool(true))
+                    );
+                    if has_bin || pipe_bin {
+                        return Ok(Self::make_buf(rest.into_bytes()));
+                    }
+                    return Ok(Value::str(rest));
+                }
                 _ => {}
             }
         }
@@ -322,7 +351,7 @@ impl Interpreter {
             .map(|v| v.to_string_value())
             .unwrap_or_default();
         match method {
-            "slurp" | "Str" | "gist" => {
+            "slurp" | "slurp-rest" | "Str" | "gist" => {
                 let has_bin = Self::named_bool(args, "bin");
                 let pipe_bin = matches!(
                     attributes.get("bin").map(Value::view),

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -876,7 +876,7 @@ impl Interpreter {
                 parents: Vec::new(),
                 attributes: Vec::new(),
                 methods: HashMap::new(),
-                native_methods: ["slurp", "Str", "gist", "print", "close"]
+                native_methods: ["slurp", "slurp-rest", "Str", "gist", "print", "close"]
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),

--- a/t/io-pipe-slurp-rest.t
+++ b/t/io-pipe-slurp-rest.t
@@ -1,0 +1,45 @@
+use Test;
+
+plan 9;
+
+# IO::Pipe inherits `slurp-rest` from IO::Handle: it reads from the current
+# cursor to the end of the captured output. `slurp` behaves the same way.
+
+my $exe = $*EXECUTABLE;
+
+{
+    my $proc = run :out, $exe, '-e', 'say 1; say 2';
+    is $proc.out.slurp-rest(:close), "1\n2\n", 'slurp-rest reads the whole output';
+}
+
+{
+    my $proc = run :out, $exe, '-e', 'say 1; say 2';
+    my $pipe = $proc.out;
+    is $pipe.slurp-rest(:close), "1\n2\n", 'slurp-rest (first call) drains the pipe';
+    is $pipe.slurp-rest, '', 'slurp-rest after draining returns the empty string';
+}
+
+{
+    my $proc = run :out, $exe, '-e', 'say 1; say 2; say 3';
+    is $proc.out.get, '1', '.get reads one line';
+    is $proc.out.slurp-rest(:close), "2\n3\n", 'slurp-rest returns only the remainder';
+}
+
+{
+    my $proc = run :out, $exe, '-e', 'say 1; say 2; say 3';
+    is $proc.out.get, '1', '.get reads one line (slurp variant)';
+    is $proc.out.slurp(:close), "2\n3\n", 'slurp is cursor-aware too';
+}
+
+{
+    my $proc = run :out, $exe, '-e', 'say 1';
+    my $buf = $proc.out.slurp-rest(:bin, :close);
+    is $buf.list, (49, 10), 'slurp-rest(:bin) returns the raw bytes';
+}
+
+{
+    my $proc = run :out, :err, $exe, '-e', 'note 9';
+    is $proc.err.slurp-rest(:close), "9\n", 'slurp-rest works on the err pipe';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`slurp-rest` — the `IO::Handle` method that reads a handle from its current
position to the end — was not implemented on `IO::Pipe`, so
`run(:out, ...).out.slurp-rest(:close)` died with
`No native method 'slurp-rest' on IO::Pipe`. That idiom is how distribution test
suites read a subprocess's captured output, so every such subtest aborted before
running a single assertion.

## Changes

1. **`slurp-rest` is dispatched on `IO::Pipe`** — for all three pipe shapes (the
   stdin write pipe, the "live" out/err pipe, the buffered pipe) — and is
   registered in the type's native-method whitelists
   (`class_introspection.rs`, `runtime_init.rs`) so introspection agrees.
2. **`slurp` / `slurp-rest` on a buffered pipe are cursor-aware.** They read from
   the pipe's current cursor to the end and leave it drained, matching Rakudo:

   | expression | before | after / raku |
   |---|---|---|
   | `$p.out.get; $p.out.slurp-rest(:close)` | died | `"2\n3\n"` |
   | `$p.out.get; $p.out.slurp(:close)` | `"1\n2\n3\n"` | `"2\n3\n"` |
   | second `slurp-rest` after draining | died | `""` |

   `:bin` returns the remaining bytes as a `Buf`; `:close` closes the pipe.

Found while triaging `TODO_dist` ticket T-046 (RakudoPrereq), whose
`xt/01-operation.rakutest` runs nine subtests that each read a subprocess with
`.slurp-rest(:close)`; all nine reported "ran 0 tests".

## Test

Pin: `t/io-pipe-slurp-rest.t` — 9 assertions, passes under **both** mutsu and raku.
`make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)