### PR TITLE
fix: seven general bugs surfaced by the HTTP::UserAgent test suite

### DIFF
--- a/news/2026-07/http-useragent-suite-general-fixes.md
+++ b/news/2026-07/http-useragent-suite-general-fixes.md
@@ -1,0 +1,78 @@
+# Seven general fixes surfaced by the HTTP::UserAgent test suite
+
+Driving the upstream HTTP::UserAgent suite (27 files, `raku-community-modules/HTTP-UserAgent`
+at `1d6a31a`) against mutsu took it from **17 to 19 fully-passing files**, and most of the
+remaining files went from many failures to one. Every fix below is a general interpreter bug
+that the module merely happened to exercise first; none of them is HTTP-specific.
+
+## A scalar interpolated into a regex could not contain whitespace
+
+`escape_regex_scalar_literal` escaped every whitespace character with a backslash. But `\ ` in
+regex source is the *unspace* form, which raku rejects outright ("No unspace allowed in
+regex"); mutsu's own parser rejects it too. The escaped whitespace was therefore silently
+dropped at the end of a pattern, so `"a\r\nb".split(/$CRLF/)` never split — the single most
+load-bearing line of `HTTP::Message.parse`. Whitespace now becomes a `\x[HH]` codepoint escape
+(same fix in `regex_escape_literal`, used for `:sym<…>` values). Pin:
+`t/regex-interp-whitespace-literal.t`.
+
+## An `is rw` multi candidate was unreachable through a `proto method`
+
+An `is rw` parameter only binds a writable argument, so multi dispatch uses it to narrow
+candidates — mutsu checks the call site's argument sources for that. Running a `proto method
+f(|) {*}` body cleared those sources, and `proto_rw_redispatch_args` only rebuilds them when
+the *proto's own* signature declares an rw parameter (which `(|)` does not). The rw candidate
+then matched nothing. `ProtoMethodCtx` now carries the call site's argument sources across the
+proto body into the `{*}` redispatch. Separately, `is rw` now counts as a narrowing constraint
+in the method-side specificity tie-break (it already did on the sub side), so
+`(Int $b is rw)` beats `(Int $b)` for a variable argument instead of being ambiguous. Pin:
+`t/multi-method-rw-param-dispatch.t`.
+
+## A `:D` smiley on an unsupplied optional vetoed its own candidate
+
+`multi method new(Int:D $code = 200, *%fields)` did not match a bare `.new()`. An unsupplied
+optional binds its default (or, with no default, the bare type object), and mutsu stands in the
+type object for the dispatch-time checks — against which `:D` always fails. Raku checks
+definedness at *bind* time, against the default value; at dispatch time even `Int:D $x?`
+matches. The definedness smiley is now dropped when nothing was passed; the nominal type still
+discriminates candidates. Pin: `t/multi-optional-default-smiley-dispatch.t`.
+
+## A class from a `use`d module was not a valid parameter type
+
+`use URI; sub f(URI $u) { }` died with "Invalid typename 'URI' in parameter declaration". The
+compile-time parameter-type check runs before the mainline — and therefore before `use` has
+loaded anything — so nothing the module declares was visible; only `::`-qualified names escaped
+the check. The pre-pass now harvests type names straight from each `use`d module's source text
+(a keyword scan, not a full parse, so it does not duplicate the load the mainline is about to
+do), honouring `use lib '...'` paths as well as `-I`/`MUTSULIB`/bundled ones. Over-collecting
+is harmless — the set only widens what is accepted, and a genuine typo appears in no module's
+source, so `sub yoink(Junctoin $barf)` is still rejected. Pin:
+`t/param-type-from-used-module.t`.
+
+## `POST($x)` was parsed as the POST phaser
+
+Raku decides between a phaser and a call on the space: `BEGIN (1+2)` is the phaser over a
+parenthesised statement, `BEGIN(1+2)` is a call to a routine named `BEGIN`. mutsu took the
+phaser branch either way, so `HTTP::Request::Common`'s exported `POST`/`PUT` subs — which
+recurse as `POST($uri, …)` — silently returned `Nil` from the swallowed statement. Both the
+statement-level (`phaser_stmt`) and expression-level (`term_literals`) phaser parsers now
+require that the keyword is not immediately followed by `(`. Pin:
+`t/phaser-keyword-call-with-parens.t`.
+
+## `$x ~= "a"` warned on an undefined `$x`
+
+`OP=` on an undefined lvalue seeds the container with `infix:<OP>`'s zero-arg identity — mutsu
+already did this for `*=`/`**=` (identity 1) and `%=` (which has none, so it throws), but not
+for `~=`, whose identity is `''`. Without it every `$.content ~= $chunk` on a fresh message
+emitted a spurious "Use of uninitialized value of type Any in string context". The mutating-
+method compound-assign path (`$o.v ~= …`) also built its `Binary` directly instead of going
+through the shared lowering, and now shares it. A plain `$u ~ "a"` still warns. Pin:
+`t/concat-assign-undefined-identity.t`.
+
+## `utf8.Str` threw instead of decoding
+
+`utf8` is the one Blob flavour whose `.Str` works in rakudo: it decodes as UTF-8, while `Buf`,
+`Blob` and `Blob[uint8]` all throw `X::Buf::AsStr`. mutsu threw for all of them, so
+`"bumble".encode eq "bumble"` was False and `is $req.content.encode, "bumble"` failed. `.Str`/
+`.Stringy`, the string-comparison operand coercion, and `Test`'s `is` now all decode a `utf8`
+(falling back to the byte-wise comparison when the bytes are not valid UTF-8). Pin:
+`t/utf8-str-decodes.t`.

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1228,12 +1228,20 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         }
     }
 
-    // Buf/Blob.Str throws X::Buf::AsStr
+    // Buf/Blob.Str throws X::Buf::AsStr — except `utf8`, whose `.Str`/`.Stringy`
+    // decodes (rakudo: `utf8.new(98,117).Str` is "bu", while `Buf`, `Blob` and
+    // `Blob[uint8]` all die). Only the type object's own name matters; prefix
+    // `~` still dies for utf8 too.
     if (method == "Str" || method == "Stringy")
         && let ValueView::Instance { class_name, .. } = target.view()
         && crate::runtime::Interpreter::is_buf_value(target)
     {
         let cn = class_name.resolve();
+        if cn == "utf8"
+            && let Some(decoded) = crate::builtins::decode_buf_method(target, Some("utf-8"))
+        {
+            return Some(decoded);
+        }
         let mut err = RuntimeError::new(format!(
             "Cannot use a {cn} as a Str. You can use .decode to convert to Str.",
         ));

--- a/src/parser/primary/ident/term_literals.rs
+++ b/src/parser/primary/ident/term_literals.rs
@@ -443,6 +443,11 @@ pub(crate) fn keyword_literal(input: &str) -> PResult<'_, Expr> {
     ] {
         if input.starts_with(kw)
             && !input[kw_len..].starts_with(|c: char| c.is_alphanumeric() || c == '_' || c == '-')
+            // `LEAVE($x)` — the keyword immediately followed by `(` — is a call
+            // to a routine of that name, not the phaser. Raku splits on exactly
+            // that space (`BEGIN (1+2)` is the phaser, `BEGIN(1+2)` a call);
+            // mirrors the statement-level check in `phaser_stmt`.
+            && !input[kw_len..].starts_with('(')
         {
             let r = &input[kw_len..];
             let (r, _) = ws(r)?;

--- a/src/parser/stmt/assign/op.rs
+++ b/src/parser/stmt/assign/op.rs
@@ -173,6 +173,7 @@ fn autoviv_compound_lhs(lhs: Expr, op: CompoundAssignOp) -> Expr {
     let identity = match op {
         CompoundAssignOp::Add | CompoundAssignOp::Sub => MetaAssignIdentity::Zero,
         CompoundAssignOp::Mul | CompoundAssignOp::Power => MetaAssignIdentity::One,
+        CompoundAssignOp::Concat => MetaAssignIdentity::EmptyStr,
         CompoundAssignOp::Div => MetaAssignIdentity::NoZeroArgDiv,
         CompoundAssignOp::Mod => MetaAssignIdentity::NoZeroArgMod,
         _ => return lhs,

--- a/src/parser/stmt/simple/control_stmts.rs
+++ b/src/parser/stmt/simple/control_stmts.rs
@@ -246,6 +246,10 @@ pub(crate) fn phaser_stmt(input: &str) -> PResult<'_, Stmt> {
         // behavior — consume the block and emit nothing — rather than running the
         // block inline (which `BareWord("TEMP")` + a bare `{ ... }` block would
         // do, wrongly executing the body).
+        if r.starts_with('(') {
+            // `TEMP(...)` is a call, not the phaser — see the `(`-check below.
+            return Err(PError::expected("phaser keyword"));
+        }
         let (r, _) = ws(r)?;
         let (r, _body) = if r.starts_with('{') {
             block(r)?
@@ -257,6 +261,15 @@ pub(crate) fn phaser_stmt(input: &str) -> PResult<'_, Stmt> {
     } else {
         return Err(PError::expected("phaser keyword"));
     };
+    // `POST($x)` — the keyword immediately followed by `(`, with no space — is a
+    // call to a routine of that name, not a phaser. Raku decides on the space:
+    // `BEGIN (1+2)` is the phaser over a parenthesised statement, `BEGIN(1+2)`
+    // is an (undeclared) call. HTTP::Request::Common's exported `POST`/`PUT`
+    // subs recurse as `POST($uri, ...)`, which mutsu swallowed as a POST phaser
+    // — the routine silently returned Nil.
+    if rest.starts_with('(') {
+        return Err(PError::expected("phaser keyword"));
+    }
     let (rest, _) = ws(rest)?;
     let (rest, body) = if rest.starts_with('{') {
         block(rest)?

--- a/src/runtime/decl_types.rs
+++ b/src/runtime/decl_types.rs
@@ -130,6 +130,13 @@ pub(crate) struct MethodDef {
 #[derive(Debug, Clone)]
 pub(crate) struct ProtoMethodCtx {
     pub(crate) invocant: Value,
+    /// The caller's `pending_call_arg_sources` as seen at the original call
+    /// site, captured before the proto body runs. `{*}` restores it so the
+    /// multi-candidate selection can still tell that an argument came from a
+    /// writable variable — an `is rw` candidate is otherwise unmatchable
+    /// through a `proto method f(|) {*}` (the proto's own signature declares no
+    /// rw parameter, so `proto_rw_redispatch_args` rebuilds nothing).
+    pub(crate) call_arg_sources: Option<Vec<Option<String>>>,
 }
 
 /// One entry of `multi_dispatch_stack`: (function_name, remaining_candidates,

--- a/src/runtime/dispatch_proto.rs
+++ b/src/runtime/dispatch_proto.rs
@@ -270,11 +270,13 @@ impl Interpreter {
             ValueView::Instance { attributes, .. } => attributes.as_map().clone(),
             _ => crate::value::AttrMap::new(),
         };
+        let call_arg_sources = self.pending_call_arg_sources().cloned();
         self.proto_dispatch_stack.push((
             method_name.to_string(),
             args.clone(),
             Some(ProtoMethodCtx {
                 invocant: invocant.clone(),
+                call_arg_sources,
             }),
         ));
         let result = self.run_resolved_method_compiled_or_treewalk(

--- a/src/runtime/dispatch_proto_call.rs
+++ b/src/runtime/dispatch_proto_call.rs
@@ -45,6 +45,13 @@ impl Interpreter {
             self.proto_method_skip = Some(proto_name.clone());
             if rw_sources.is_some() {
                 self.set_pending_call_arg_sources(rw_sources);
+            } else if ctx.call_arg_sources.is_some() {
+                // The proto declares no rw parameter of its own (`proto method
+                // f(|) {*}` is the common shape), so nothing was rebuilt — but
+                // the ORIGINAL call site's argument sources still decide whether
+                // an `is rw` candidate is eligible. Running the proto body has
+                // long since cleared them, so restore them here.
+                self.set_pending_call_arg_sources(ctx.call_arg_sources.clone());
             }
             return self.call_method_with_values(ctx.invocant, &proto_name, args);
         }

--- a/src/runtime/eval_check.rs
+++ b/src/runtime/eval_check.rs
@@ -10,18 +10,148 @@ fn collect_declared_type_names(
     packages: &mut std::collections::HashSet<String>,
     classes: &mut std::collections::HashSet<String>,
 ) {
+    collect_declared_type_names_with(None, &[], stmts, out, packages, classes)
+}
+
+/// Type names a `use`d module declares, harvested straight from its source text.
+///
+/// The parameter-type pre-pass runs *before* the mainline executes, so a `use`
+/// has not loaded anything yet and a class the module exports is invisible to
+/// the runtime registry — `use URI; sub f(URI $u)` was rejected as an invalid
+/// typename. Fully parsing every used module here would duplicate the load the
+/// mainline is about to do, so this scans the source for declaration keywords
+/// instead. Over-collecting is harmless (the set only ever *widens* what the
+/// check accepts, and a genuine typo still will not appear in any module's
+/// source); under-collecting just restores the old behaviour.
+fn collect_use_declared_type_names(
+    interp: &Interpreter,
+    module: &str,
+    extra_dirs: &[String],
+    out: &mut std::collections::HashSet<String>,
+) {
+    let path = module_source_in_dirs(module, extra_dirs)
+        .or_else(|| interp.resolve_module_path(module).map(|(p, _)| p));
+    let Some(path) = path else {
+        return;
+    };
+    let Ok(source) = std::fs::read_to_string(&path) else {
+        return;
+    };
+    const DECLARATORS: [&str; 5] = ["class", "role", "grammar", "enum", "subset"];
+    let bytes: Vec<char> = source.chars().collect();
+    let is_ident = |c: char| c.is_alphanumeric() || c == '_' || c == '-';
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if i > 0 && is_ident(bytes[i - 1]) {
+            i += 1;
+            continue;
+        }
+        let rest: String = bytes[i..bytes.len().min(i + 8)].iter().collect();
+        let Some(kw) = DECLARATORS.iter().find(|kw| {
+            rest.starts_with(**kw) && !is_ident(*bytes.get(i + kw.len()).unwrap_or(&' '))
+        }) else {
+            i += 1;
+            continue;
+        };
+        let mut j = i + kw.len();
+        while j < bytes.len() && (bytes[j] == ' ' || bytes[j] == '\t') {
+            j += 1;
+        }
+        let start = j;
+        while j < bytes.len() && (is_ident(bytes[j]) || bytes[j] == ':') {
+            j += 1;
+        }
+        if j > start {
+            let name: String = bytes[start..j].iter().collect();
+            if name.starts_with(|c: char| c.is_ascii_uppercase()) {
+                out.insert(name);
+            }
+        }
+        i = (i + kw.len()).max(j);
+    }
+}
+
+/// Locate `module`'s source under one of `dirs` (or its `lib/` subdirectory).
+/// Covers the `use lib '...'` paths, which the runtime has not registered yet
+/// when this compile-time pre-pass runs.
+fn module_source_in_dirs(module: &str, dirs: &[String]) -> Option<std::path::PathBuf> {
+    let base = module.replace("::", "/");
+    for dir in dirs {
+        for ext in [".rakumod", ".pm6", ".pm"] {
+            let name = format!("{}{}", base, ext);
+            let root = std::path::Path::new(dir);
+            for candidate in [root.join(&name), root.join("lib").join(&name)] {
+                if candidate.is_file() {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// The literal paths a `use lib '...'` in this unit adds to the search path.
+fn collect_use_lib_dirs(stmts: &[Stmt], out: &mut Vec<String>) {
+    fn push_literals(expr: &crate::ast::Expr, out: &mut Vec<String>) {
+        use crate::ast::Expr;
+        match expr {
+            Expr::Literal(v) => {
+                if let ValueView::Str(s) = v.view() {
+                    out.push(s.to_string());
+                }
+            }
+            Expr::ArrayLiteral(items) => {
+                for item in items {
+                    push_literals(item, out);
+                }
+            }
+            Expr::Grouped(inner) => push_literals(inner, out),
+            _ => {}
+        }
+    }
     for stmt in stmts {
+        match stmt {
+            Stmt::Use {
+                module,
+                arg: Some(arg),
+                ..
+            } if module == "lib" => push_literals(arg, out),
+            Stmt::Block(body) | Stmt::SyntheticBlock(body) | Stmt::Package { body, .. } => {
+                collect_use_lib_dirs(body, out);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn collect_declared_type_names_with(
+    interp: Option<&Interpreter>,
+    extra_dirs: &[String],
+    stmts: &[Stmt],
+    out: &mut std::collections::HashSet<String>,
+    packages: &mut std::collections::HashSet<String>,
+    classes: &mut std::collections::HashSet<String>,
+) {
+    for stmt in stmts {
+        if let Some(interp) = interp {
+            match stmt {
+                Stmt::Use { module, .. } | Stmt::Need { module } => {
+                    collect_use_declared_type_names(interp, module, extra_dirs, out);
+                }
+                _ => {}
+            }
+        }
         match stmt {
             Stmt::ClassDecl { name, body, .. } => {
                 // A plain `class` is type-like but NOT parametric (parameterizing
                 // it with `[T]`/`of T` is X::NotParametric); roles ARE parametric.
                 out.insert(name.resolve().to_string());
                 classes.insert(name.resolve().to_string());
-                collect_declared_type_names(body, out, packages, classes);
+                collect_declared_type_names_with(interp, extra_dirs, body, out, packages, classes);
             }
             Stmt::RoleDecl { name, body, .. } => {
                 out.insert(name.resolve().to_string());
-                collect_declared_type_names(body, out, packages, classes);
+                collect_declared_type_names_with(interp, extra_dirs, body, out, packages, classes);
             }
             Stmt::EnumDecl { name, variants, .. } => {
                 out.insert(name.resolve().to_string());
@@ -47,10 +177,10 @@ fn collect_declared_type_names(
                 } else {
                     out.insert(name.resolve().to_string());
                 }
-                collect_declared_type_names(body, out, packages, classes);
+                collect_declared_type_names_with(interp, extra_dirs, body, out, packages, classes);
             }
             Stmt::Block(body) | Stmt::SyntheticBlock(body) => {
-                collect_declared_type_names(body, out, packages, classes);
+                collect_declared_type_names_with(interp, extra_dirs, body, out, packages, classes);
             }
             _ => {}
         }
@@ -225,7 +355,16 @@ impl Interpreter {
         let mut declared = std::collections::HashSet::new();
         let mut packages = std::collections::HashSet::new();
         let mut classes = std::collections::HashSet::new();
-        collect_declared_type_names(stmts, &mut declared, &mut packages, &mut classes);
+        let mut lib_dirs = Vec::new();
+        collect_use_lib_dirs(stmts, &mut lib_dirs);
+        collect_declared_type_names_with(
+            Some(self),
+            &lib_dirs,
+            stmts,
+            &mut declared,
+            &mut packages,
+            &mut classes,
+        );
         walk_validate_sub_param_types(self, stmts, &declared, &packages, &classes)
     }
 

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -32,6 +32,10 @@ impl Interpreter {
         for ch in text.chars() {
             if ch.is_ascii_alphanumeric() || ch == '_' {
                 out.push(ch);
+            } else if ch.is_whitespace() {
+                // `\ ` is the unspace form, not an escaped literal — see
+                // `escape_regex_scalar_literal`.
+                out.push_str(&format!("\\x[{:02X}]", ch as u32));
             } else {
                 out.push('\\');
                 out.push(ch);

--- a/src/runtime/regex_parse_modifier.rs
+++ b/src/runtime/regex_parse_modifier.rs
@@ -638,10 +638,17 @@ impl Interpreter {
     fn escape_regex_scalar_literal(input: &str) -> String {
         let mut out = String::new();
         for ch in input.chars() {
-            if ch.is_whitespace()
-                || matches!(
-                    ch,
-                    '\\' | '.'
+            // Whitespace cannot be backslash-escaped in regex source: `\ ` is the
+            // unspace form, which raku rejects ("No unspace allowed in regex").
+            // Emit the codepoint form instead so an interpolated " ", "\t" or
+            // "\r\n" still matches literally.
+            if ch.is_whitespace() {
+                out.push_str(&format!("\\x[{:02X}]", ch as u32));
+                continue;
+            }
+            if matches!(
+                ch,
+                '\\' | '.'
                         | '^'
                         | '$'
                         | '*'
@@ -666,8 +673,7 @@ impl Interpreter {
                         // `\h* % ...` separator. Escape them to force literal match.
                         | '%'
                         | '&'
-                )
-            {
+            ) {
                 out.push('\\');
             }
             out.push(ch);

--- a/src/runtime/resolution_method.rs
+++ b/src/runtime/resolution_method.rs
@@ -247,7 +247,11 @@ impl Interpreter {
             //        Positional/Associative/Callable constraint, so `(@x, @y)` is
             //        narrower than `($a, $b)` for two array args (matching the sub
             //        dispatch's `typed_param_count`, which also counts sigils).
-            let narrowness = |def: &MethodDef| -> (usize, usize) {
+            //   .2 = `is rw`/`is raw` params — the trait demands a writable
+            //        container, so `(Int $b is rw)` is narrower than `(Int $b)`
+            //        for a variable argument (matching `candidate_specificity_rank`,
+            //        which counts the same traits on the sub-dispatch side).
+            let narrowness = |def: &MethodDef| -> (usize, usize, usize) {
                 let where_subset = def
                     .param_defs
                     .iter()
@@ -272,13 +276,18 @@ impl Interpreter {
                                 || p.name.starts_with('&'))
                     })
                     .count();
-                (where_subset, sigil_typed)
+                let rw_typed = def
+                    .param_defs
+                    .iter()
+                    .filter(|p| !p.is_invocant && p.traits.iter().any(|t| t == "rw" || t == "raw"))
+                    .count();
+                (where_subset, sigil_typed, rw_typed)
             };
             let best_where = tied
                 .iter()
                 .map(|&i| narrowness(&all_matches[i].1))
                 .max()
-                .unwrap_or((0, 0));
+                .unwrap_or((0, 0, 0));
             let mut narrowed: Vec<usize> = tied
                 .iter()
                 .copied()

--- a/src/runtime/test_functions/basic.rs
+++ b/src/runtime/test_functions/basic.rs
@@ -124,6 +124,15 @@ impl Interpreter {
             // by that string value rather than its `.gist`.
             ValueView::Instance { class_name, .. } | ValueView::Package(class_name) => {
                 let cn = class_name.resolve().to_string();
+                // `utf8` is the one Blob type whose `.Str` decodes, so
+                // `is "bumble".encode, "bumble"` passes in rakudo.
+                if cn == "utf8"
+                    && matches!(value.view(), ValueView::Instance { .. })
+                    && let Some(Ok(decoded)) =
+                        crate::builtins::decode_buf_method(value, Some("utf-8"))
+                {
+                    return Ok(decoded.to_string_value());
+                }
                 let method = if self.has_user_method(&cn, "Stringy") {
                     Some("Stringy")
                 } else if self.has_user_method(&cn, "Str") {

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -298,7 +298,24 @@ impl Interpreter {
                 if let Some(constraint) = &pd.type_constraint
                     && let Some(arg) = arg_for_checks.as_ref()
                 {
-                    let resolved_constraint = self.resolved_type_capture_name(constraint);
+                    let mut resolved_constraint = self.resolved_type_capture_name(constraint);
+                    // An unsupplied optional binds its default (or, with no
+                    // default, the bare type object), and `arg_for_checks` above
+                    // stands in the type object either way. A `:D` smiley tested
+                    // against that stand-in would reject a candidate raku
+                    // happily selects — `multi method new(Int:D $code = 200)`
+                    // matches `.new()`, and even `Int:D $x?` matches at dispatch
+                    // and only fails later, at bind time. So drop the
+                    // definedness smiley when nothing was passed; the nominal
+                    // type still discriminates candidates.
+                    if !arg_was_supplied {
+                        let (base, smiley) =
+                            crate::runtime::types::strip_type_smiley(&resolved_constraint);
+                        if smiley.is_some() {
+                            resolved_constraint = base.to_string();
+                        }
+                    }
+                    let resolved_constraint = resolved_constraint;
                     if pd.name.starts_with('&') {
                         if !self.type_matches_value("Callable", arg) {
                             return false;

--- a/src/token_kind.rs
+++ b/src/token_kind.rs
@@ -25,6 +25,10 @@ pub(crate) enum MetaAssignIdentity {
     Zero,
     /// `infix:<*>()` / `infix:<**>()` are `1`.
     One,
+    /// `infix:<~>()` is the empty string. Seeding it is also what keeps
+    /// `my $x; $x ~= "a"` from emitting the "uninitialized value in string
+    /// context" warning that the bare `$x ~ "a"` still does.
+    EmptyStr,
     /// `infix:</>` has no zero-argument candidate.
     NoZeroArgDiv,
     /// `infix:<%>` has no zero-argument candidate.
@@ -40,13 +44,17 @@ impl MetaAssignIdentity {
             MetaAssignIdentity::One => 1,
             MetaAssignIdentity::NoZeroArgDiv => 2,
             MetaAssignIdentity::NoZeroArgMod => 3,
+            MetaAssignIdentity::EmptyStr => 4,
         }
     }
 
     /// Whether seeding this identity can never throw (`Zero` / `One`). The JIT
     /// emits a void shim with no status check for these.
     pub(crate) fn is_infallible(self) -> bool {
-        matches!(self, MetaAssignIdentity::Zero | MetaAssignIdentity::One)
+        matches!(
+            self,
+            MetaAssignIdentity::Zero | MetaAssignIdentity::One | MetaAssignIdentity::EmptyStr
+        )
     }
 
     /// Inverse of [`Self::as_u32`]. Only ever called with a value this module
@@ -56,6 +64,7 @@ impl MetaAssignIdentity {
             1 => MetaAssignIdentity::One,
             2 => MetaAssignIdentity::NoZeroArgDiv,
             3 => MetaAssignIdentity::NoZeroArgMod,
+            4 => MetaAssignIdentity::EmptyStr,
             _ => MetaAssignIdentity::Zero,
         }
     }

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -31,6 +31,7 @@ pub(super) fn seed_meta_assign_identity(
     match identity {
         MetaAssignIdentity::Zero => Ok(Value::int(0)),
         MetaAssignIdentity::One => Ok(Value::int(1)),
+        MetaAssignIdentity::EmptyStr => Ok(Value::str(String::new())),
         MetaAssignIdentity::NoZeroArgDiv => Err(RuntimeError::no_zero_arg_meaning("infix:</>")),
         MetaAssignIdentity::NoZeroArgMod => Err(RuntimeError::no_zero_arg_meaning("infix:<%>")),
     }

--- a/src/vm/vm_comparison_order_ops.rs
+++ b/src/vm/vm_comparison_order_ops.rs
@@ -18,10 +18,26 @@ impl Interpreter {
         right: Value,
     ) -> Result<(Value, Value), RuntimeError> {
         let caller_code = self.current_code;
-        let left = self.coerce_stringy_operand(left)?;
-        let right = self.coerce_stringy_operand(right)?;
+        let left = Self::decode_utf8_compare_operand(self.coerce_stringy_operand(left)?);
+        let right = Self::decode_utf8_compare_operand(self.coerce_stringy_operand(right)?);
         self.reconcile_caller_after_internal_dispatch(caller_code);
         Ok((left, right))
+    }
+
+    /// `utf8` is the one Blob type with a working `.Str` (it decodes), so a
+    /// string comparison against one compares the decoded text in rakudo:
+    /// `"bumble".encode eq "bumble"` is True. Undecodable bytes fall through to
+    /// the byte-wise Buf comparison rather than erroring. Only the comparators
+    /// do this — infix `~` concatenates two Blobs into a Blob, so
+    /// `coerce_stringy_operand` itself must leave a utf8 alone.
+    fn decode_utf8_compare_operand(v: Value) -> Value {
+        if let ValueView::Instance { class_name, .. } = v.view()
+            && class_name.resolve() == "utf8"
+            && let Some(Ok(decoded)) = crate::builtins::decode_buf_method(&v, Some("utf-8"))
+        {
+            return decoded;
+        }
+        v
     }
 
     pub(super) fn exec_str_eq_op(&mut self) -> Result<(), RuntimeError> {

--- a/t/concat-assign-undefined-identity.t
+++ b/t/concat-assign-undefined-identity.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+
+plan 8;
+
+# `$x OP= $y` on an undefined `$x` seeds the container with `infix:<OP>`'s
+# zero-arg identity, so `~=` starts from '' and emits no "uninitialized value in
+# string context" warning. (`HTTP::Message.add-content` is `$.content ~= $c`.)
+
+my @warnings;
+my $collect = -> $w { @warnings.push: ~$w };
+
+sub no-warnings(&code, $desc) {
+    my @seen;
+    {
+        code();
+        CONTROL { default { @seen.push: ~$_; $_.resume } }
+    }
+    is @seen.grep(*.contains('uninitialized')).elems, 0, $desc;
+}
+
+no-warnings { my $a; $a ~= "x"; }, 'plain scalar';
+no-warnings { my Str $b; $b ~= "x"; }, 'typed scalar';
+no-warnings { my @arr; @arr[0] ~= "x"; }, 'array element';
+no-warnings { my %h; %h<z> ~= "x"; }, 'hash element';
+no-warnings {
+    my class K { has $.v is rw };
+    my $k = K.new;
+    $k.v ~= "x";
+}, 'rw attribute through its accessor';
+
+# The values are still right.
+my $a; $a ~= "x"; $a ~= "y";
+is $a, "xy", 'the concatenation result is correct';
+
+my $n; $n += 3;
+is $n, 3, 'numeric compound assignment keeps its identity too';
+
+# A plain `~` on an undefined value DOES still warn.
+my @seen;
+{
+    my $u;
+    my $r = $u ~ "a";
+    CONTROL { default { @seen.push: ~$_; $_.resume } }
+}
+ok @seen.grep(*.contains('uninitialized')).elems > 0,
+    'plain infix ~ on an undefined value still warns';

--- a/t/lib/ParamTypeProvider.rakumod
+++ b/t/lib/ParamTypeProvider.rakumod
@@ -1,0 +1,6 @@
+unit class ParamTypeProvider;
+
+has $.label;
+
+our subset ParamTypeSmall is export of Int where * < 10;
+our enum ParamTypeColour is export <ParamRed ParamGreen>;

--- a/t/multi-method-rw-param-dispatch.t
+++ b/t/multi-method-rw-param-dispatch.t
@@ -1,0 +1,46 @@
+use v6;
+use Test;
+
+plan 6;
+
+# An `is rw` parameter only accepts a writable argument, so multi dispatch uses
+# it to narrow candidates. For a `proto method f(|) {*}` the call-site argument
+# sources have to survive the proto body into the `{*}` redispatch, or the rw
+# candidate becomes unmatchable. (HTTP::UserAgent's
+# `multi method get-content(Connection, Blob $content is rw)`.)
+
+class A {
+    proto method f(|) {*}
+    multi method f(Int $b, $len) { "2-arg" }
+    multi method f(Int $b is rw) { "1-arg-rw" }
+}
+
+my $i = 5;
+is A.new.f($i, 3), "2-arg", 'the two-arg candidate still wins with two args';
+is A.new.f($i), "1-arg-rw", 'the rw candidate is reachable through a proto method';
+
+# Same shape with a role-typed invocant argument and a Buf, as in the module
+# that surfaced this.
+role R { }
+class C { }
+
+class B {
+    proto method g(|) {*}
+    multi method g(R $c, Blob $b, $len) { "3-arg" }
+    multi method g(R $c, Blob $b is rw) { "2-arg" }
+}
+
+my $conn = C.new but R;
+my $content = Buf.new(1, 2, 3);
+is B.new.g($conn, $content, 3), "3-arg", 'mixin invocant, three args';
+is B.new.g($conn, $content), "2-arg", 'mixin invocant, rw candidate';
+
+# A literal is not writable, so the rw candidate must not match it.
+class D {
+    proto method h(|) {*}
+    multi method h(Int $b is rw) { "rw" }
+    multi method h(Int $b) { "ro" }
+}
+is D.new.h(5), "ro", 'a literal argument picks the readonly candidate';
+my $w = 5;
+is D.new.h($w), "rw", 'a variable argument picks the rw candidate';

--- a/t/multi-optional-default-smiley-dispatch.t
+++ b/t/multi-optional-default-smiley-dispatch.t
@@ -1,0 +1,30 @@
+use v6;
+use Test;
+
+plan 5;
+
+# An unsupplied optional parameter binds its default (or the bare type object),
+# so a `:D` smiley on it must not veto the candidate during multi dispatch --
+# raku checks definedness at bind time, against the default value.
+# (HTTP::Response's `multi method new(Int:D $code = 200, *%fields)` had to be
+# reachable from a bare `.new`.)
+
+class R {
+    has $.code is rw;
+    submethod BUILD(:$!code) { }
+    proto method new(|) {*}
+    multi method new(Blob:D $chunk) { self.bless(:code(1)) }
+    multi method new(Int:D $code = 200, *%fields) { self.bless(:$code) }
+}
+
+is R.new.code, 200, 'the defaulted Int:D candidate matches a no-argument call';
+is R.new(404).code, 404, 'an explicit argument still binds';
+is R.new(Buf.new(1)).code, 1, 'the Blob:D candidate still wins for a Blob';
+
+# The nominal type keeps discriminating, so an argument of the wrong type does
+# not fall through to a defaulted candidate of another type.
+proto sub p(|) {*}
+multi sub p(Int:D $x = 200) { "int" }
+multi sub p(Str:D $s) { "str" }
+is p(), "int", 'no argument picks the defaulted candidate';
+is p("x"), "str", 'a Str argument picks the Str candidate';

--- a/t/param-type-from-used-module.t
+++ b/t/param-type-from-used-module.t
@@ -1,0 +1,25 @@
+use v6;
+use lib 't/lib';
+use Test;
+use ParamTypeProvider;
+
+plan 4;
+
+# A class a `use`d module declares is a valid parameter type in the using unit.
+# mutsu's compile-time parameter-type check runs before the mainline (and so
+# before `use` has loaded anything), which used to reject `sub f(URI $u)` with
+# "Invalid typename 'URI'" for every unqualified module-defined class.
+
+sub takes-provider(ParamTypeProvider $p) { $p.label }
+is takes-provider(ParamTypeProvider.new(label => 'ok')), 'ok',
+    'an unqualified class from a used module is a valid parameter type';
+
+sub takes-subset(ParamTypeSmall $n) { $n * 2 }
+is takes-subset(4), 8, 'a subset from a used module is a valid parameter type';
+
+sub takes-enum(ParamTypeColour $c) { ~$c }
+is takes-enum(ParamRed), 'ParamRed', 'an enum from a used module is a valid parameter type';
+
+# A genuine typo is still rejected.
+throws-like 'sub yoink(Junctoin $barf) { }', X::Parameter::InvalidType,
+    'a mistyped type name is still caught';

--- a/t/phaser-keyword-call-with-parens.t
+++ b/t/phaser-keyword-call-with-parens.t
@@ -1,0 +1,53 @@
+use v6;
+use Test;
+
+plan 8;
+
+# `PHASER(...)` with no space is a call to a routine of that name; the phaser
+# needs either a block or a space before the statement. Raku decides on exactly
+# that: `BEGIN (1+2)` is the phaser, `BEGIN(1+2)` is a call.
+# HTTP::Request::Common exports subs named POST/PUT that recurse as
+# `POST($uri, ...)`, which mutsu used to swallow as a POST phaser.
+
+sub POST($x) { "POST($x)" }
+sub PRE($x) { "PRE($x)" }
+sub LEAVE($x) { "LEAVE($x)" }
+sub TEMP($x) { "TEMP($x)" }
+
+sub call-them {
+    my @r;
+    @r.push: POST(1);
+    @r.push: PRE(2);
+    @r.push: LEAVE(3);
+    @r.push: TEMP(4);
+    @r
+}
+is-deeply call-them().List, ("POST(1)", "PRE(2)", "LEAVE(3)", "TEMP(4)"),
+    'phaser-named subs are callable with parentheses';
+
+# A routine whose whole body is such a call still returns its value.
+sub tail-call { POST(9) }
+is tail-call(), "POST(9)", 'a tail call to a phaser-named sub returns its value';
+
+# The phasers themselves keep working.
+sub with-post { POST { True }; 42 }
+is with-post(), 42, 'the POST phaser block still parses';
+
+is (BEGIN (1 + 2)), 3, 'BEGIN with a space takes a parenthesised statement';
+
+my $left = 0;
+sub with-leave { LEAVE { $left = 1 }; 7 }
+is with-leave(), 7, 'the LEAVE phaser block still runs';
+is $left, 1, 'and its body fired';
+
+my @order;
+sub with-enter { ENTER { @order.push: 'enter' }; @order.push: 'body'; 1 }
+with-enter();
+is-deeply @order.List, ('enter', 'body'), 'the ENTER phaser block still runs';
+
+sub with-first {
+    my @seen;
+    for 1..3 { FIRST { @seen.push: 'first' }; @seen.push: $_ }
+    @seen
+}
+is-deeply with-first().List, ('first', 1, 2, 3), 'the FIRST phaser block still runs';

--- a/t/regex-interp-whitespace-literal.t
+++ b/t/regex-interp-whitespace-literal.t
@@ -1,0 +1,35 @@
+use v6;
+use Test;
+
+plan 10;
+
+# A scalar interpolated into a regex matches literally. Whitespace inside the
+# value must NOT be escaped as `\ ` (that is the unspace form, which raku
+# rejects outright) -- it has to become a codepoint escape so it still matches.
+
+my $sp = " ";
+ok "a b" ~~ /$sp/, 'an interpolated space matches';
+ok "x y" ~~ /x$sp/, 'a trailing interpolated space matches';
+ok "x y" ~~ /$sp y/, 'a leading interpolated space matches';
+
+my $tab = "\t";
+ok "a\tb" ~~ /$tab/, 'an interpolated tab matches';
+
+my $nl = "\n";
+ok "a\nb" ~~ /$nl/, 'an interpolated newline matches';
+
+my $cr = "\r";
+ok "a\rb" ~~ /$cr/, 'an interpolated carriage return matches';
+
+my $CRLF = "\r\n";
+ok "a\r\nb" ~~ /$CRLF/, 'an interpolated CRLF matches';
+is-deeply "a\r\nb\r\nc".split(/$CRLF/).List, ("a", "b", "c"),
+    'split on an interpolated CRLF';
+
+# Embedded whitespace kept working before; make sure it still does.
+my $ab = "a b";
+ok "xa by" ~~ /$ab/, 'an interpolated value with inner whitespace matches';
+
+# The value is matched literally, not re-parsed as regex source.
+my $dot = ".";
+nok "axb" ~~ /$dot/, 'an interpolated "." is a literal, not the any-char atom';

--- a/t/utf8-str-decodes.t
+++ b/t/utf8-str-decodes.t
@@ -1,0 +1,22 @@
+use v6;
+use Test;
+
+plan 9;
+
+# `utf8` is the one Blob type whose `.Str` works: it decodes. Every other
+# Blob/Buf flavour throws X::Buf::AsStr.
+
+is "bumble".encode.Str, "bumble", 'utf8.Str decodes';
+is utf8.new(98, 117).Stringy, "bu", 'utf8.Stringy decodes';
+is "sn\c[SNOWMAN]w".encode.Str, "sn\c[SNOWMAN]w", 'multi-byte codepoints round-trip';
+
+dies-ok { Buf.new(98, 117).Str }, 'Buf.Str dies';
+dies-ok { Blob.new(98, 117).Str }, 'Blob.Str dies';
+dies-ok { "x".encode('latin-1').Str }, 'Blob[uint8].Str dies';
+
+# `eq` goes through `.Str`, so a utf8 compares as its decoded text.
+ok "bumble".encode eq "bumble", 'utf8 eq Str compares decoded';
+nok "bumble".encode eq "x", 'and is False when they differ';
+
+# `is` uses the same coercion.
+is "bumble".encode, "bumble", 'is() compares a utf8 against a Str';


### PR DESCRIPTION
Driving the upstream [HTTP::UserAgent](https://github.com/raku-community-modules/HTTP-UserAgent) test suite (27 files, pinned at `1d6a31a`) against mutsu, as the next step toward bundling it as a battery. The suite went from **17 to 19 fully-passing files**, and most of the remaining files went from many failures to one.

Every fix here is a general interpreter bug that the module merely happened to exercise first; none is HTTP-specific. Details and repro shapes are in `news/2026-07/http-useragent-suite-general-fixes.md`.

| Fix | Symptom | Pin |
| --- | --- | --- |
| Regex scalar interpolation escaped whitespace as `\ ` (the *unspace* form, which raku rejects), so it silently vanished | `"a\r\nb".split(/$CRLF/)` never split — `HTTP::Message.parse`'s core line | `t/regex-interp-whitespace-literal.t` |
| The call site's argument sources were cleared by a `proto method` body, so an `is rw` candidate could never match; `is rw` also did not count as narrowing in the method specificity tie-break | `multi method get-content(Connection, Blob $content is rw)` was unreachable | `t/multi-method-rw-param-dispatch.t` |
| A `:D` smiley on an **unsupplied** optional vetoed its own candidate (raku checks definedness at bind time, against the default) | `multi method new(Int:D $code = 200)` did not match `.new()` | `t/multi-optional-default-smiley-dispatch.t` |
| The compile-time parameter-type check runs before `use` loads anything, so no module-declared type was visible | `use URI; sub f(URI $u)` → "Invalid typename 'URI'" | `t/param-type-from-used-module.t` |
| A phaser keyword immediately followed by `(` was parsed as the phaser (raku splits on the space: `BEGIN (1+2)` phaser, `BEGIN(1+2)` call) | `HTTP::Request::Common`'s exported `POST`/`PUT` recursed as `POST($uri, …)` and silently returned `Nil` | `t/phaser-keyword-call-with-parens.t` |
| `~=` did not seed `infix:<~>`'s zero-arg identity `''` on an undefined lvalue (`*=`/`**=` already did) | every `$.content ~= $chunk` warned "Use of uninitialized value … in string context" | `t/concat-assign-undefined-identity.t` |
| `utf8.Str` threw instead of decoding (rakudo: `utf8` is the one Blob flavour whose `.Str` works) | `"bumble".encode eq "bumble"` was False | `t/utf8-str-decodes.t` |

Typo detection for parameter types is preserved: the module scan only *widens* the accepted set, and a genuine typo appears in no module's source, so `sub yoink(Junctoin $barf)` still throws `X::Parameter::InvalidType`.

`make test` passes locally (2426 files, 23115 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)