### PR TITLE
fix: Version keeps the source spelling of its parts

### DIFF
--- a/news/2026-07/version-source-spelling.md
+++ b/news/2026-07/version-source-spelling.md
@@ -1,0 +1,33 @@
+# `Version` keeps the source spelling of its parts
+
+`v1.02.3` stringified as `1.02.3` in Rakudo but as `1.2.3` in mutsu: a `Version`
+was stored purely as its parsed parts (`(1, 2, 3)`), and every stringification
+(`.Str`, `~`, `.gist`, `.raku`, hash-key coercion) rebuilt the text from those
+parts, throwing away the zero padding.
+
+Rakudo keeps the original text of each part while `.parts` still reports the
+parsed `Int`s, so `Version.new("1.02.3").Str` is `"1.02.3"` and
+`Version.new("1.02.3").parts` is `(1, 2, 3)`. Only the *separators* are
+normalized (`Version.new("1.2-beta").Str` is `"1.2.beta"` in both).
+
+`ValueRepr::Version` now carries an optional `text` field with the source
+spelling of the parts joined by `.`. It is populated only when it differs from
+what the parts alone render to, so the overwhelmingly common `v1.2.3` case stays
+allocation-free and byte-identical to before. All three string-derived
+constructors (the `v…` literal in the parser, `Version.new(Str)`, and the
+`.Version` coercion) route through a new `Value::version_from_str`.
+
+Two follow-on parity fixes fell out of it, both of which were wrong before and
+only became *observable* once versions could differ by spelling:
+
+- **`.WHICH`** had no `Version` arm and fell through to the global-counter
+  fallback, yielding a meaningless `Version|1`. It is now
+  `Version|<canonical string>` (a `ValueObjAt`, as in Rakudo).
+- **`===`** fell back to `eqv`, so `v1.02.3 === v1.2.3` was `True`. Identity is
+  the `.WHICH` string, so it is `False` now — while `==`, `cmp` and `eqv` all
+  still see the two as equal, exactly as Rakudo does.
+
+Found while triaging `TODO_dist` ticket T-046 (RakudoPrereq), whose test asserts
+the error message contains the compiler version `v2017.03.290`.
+
+Pin: `t/version-source-spelling.t` (22 assertions, passes under both mutsu and raku).

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -360,6 +360,7 @@ pub(super) fn dispatch(
                     | ValueView::RangeExclStart(..)
                     | ValueView::RangeExclBoth(..)
                     | ValueView::GenericRange { .. }
+                    | ValueView::Version { .. }
             );
             let which_str = match target.view() {
                 ValueView::Package(name) => format!(
@@ -399,6 +400,10 @@ pub(super) fn dispatch(
                     enum_type, index, ..
                 } => format!("{}|{}", enum_type.resolve(), index),
                 ValueView::Nil => format!("Nil|U{}", Symbol::intern("Nil").id()),
+                // A Version's identity is its canonical string (raku:
+                // `v1.02.3.WHICH` is `Version|1.02.3`), so two versions
+                // spelled differently are NOT `===` even when they `==`.
+                ValueView::Version { .. } => format!("Version|{}", target.to_string_value()),
                 ValueView::Set(set, _) => {
                     let mut keys: Vec<&String> = set.iter().collect();
                     keys.sort();
@@ -832,8 +837,7 @@ pub(super) fn dispatch(
                 if s.is_empty() {
                     Some(Some(Ok(Value::version(Vec::new(), false, false))))
                 } else {
-                    let (parts, plus, minus) = Value::parse_version_string(&s);
-                    Some(Some(Ok(Value::version(parts, plus, minus))))
+                    Some(Some(Ok(Value::version_from_str(&s))))
                 }
             }
             _ => None,

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -449,8 +449,15 @@ pub(super) fn dispatch(
             }
         }
         ValueView::Instance { .. } | ValueView::Enum { .. } => None,
-        ValueView::Version { parts, plus, minus } => {
-            let s = Value::version_parts_to_string(parts);
+        ValueView::Version {
+            parts,
+            plus,
+            minus,
+            text,
+        } => {
+            let s = text
+                .map(str::to_string)
+                .unwrap_or_else(|| Value::version_parts_to_string(parts));
             let suffix = if plus {
                 "+"
             } else if minus {

--- a/src/parser/primary/regex/lit.rs
+++ b/src/parser/primary/regex/lit.rs
@@ -1019,8 +1019,7 @@ pub(in crate::parser::primary) fn version_lit(input: &str) -> PResult<'_, Expr> 
     } else {
         (version, rest)
     };
-    let (parts, plus, minus) = Value::parse_version_string(version);
-    Ok((rest, Expr::Literal(Value::version(parts, plus, minus))))
+    Ok((rest, Expr::Literal(Value::version_from_str(version))))
 }
 
 /// Parse a topicalized method call: .say, .uc, .defined, etc.

--- a/src/runtime/ops_compare.rs
+++ b/src/runtime/ops_compare.rs
@@ -108,11 +108,13 @@ impl Interpreter {
                 parts: ap,
                 plus: apl,
                 minus: ami,
+                ..
             },
             ValueView::Version {
                 parts: bp,
                 plus: bpl,
                 minus: bmi,
+                ..
             },
         ) = (left.view(), right.view())
         {

--- a/src/runtime/ops_reduction.rs
+++ b/src/runtime/ops_reduction.rs
@@ -577,11 +577,13 @@ impl Interpreter {
                             parts: ap,
                             plus: apl,
                             minus: ami,
+                            ..
                         },
                         ValueView::Version {
                             parts: bp,
                             plus: bpl,
                             minus: bmi,
+                            ..
                         },
                     ) => super::version_cmp(ap, apl, ami, bp, bpl, bmi),
                     _ => left.to_string_value().cmp(&right.to_string_value()),

--- a/src/runtime/seq_helpers/smart_match.rs
+++ b/src/runtime/seq_helpers/smart_match.rs
@@ -106,9 +106,12 @@ impl Interpreter {
                     crate::builtins::methods_0arg::temporal::date_attrs(&(right_attrs).as_map());
                 y == ry && m == rm && d == rd
             }
-            (ValueView::Version { .. }, ValueView::Version { parts, plus, minus }) => {
-                Self::version_smart_match(left, parts, plus, minus)
-            }
+            (
+                ValueView::Version { .. },
+                ValueView::Version {
+                    parts, plus, minus, ..
+                },
+            ) => Self::version_smart_match(left, parts, plus, minus),
             // When RHS is a callable (Sub), invoke it with LHS as argument and
             // return truthiness of the result.  If the sub accepts no parameters,
             // call it with no arguments (simple closure truth).

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -184,8 +184,7 @@ impl Interpreter {
                 if s.is_empty() {
                     return Value::version(Vec::new(), false, false);
                 }
-                let (parts, plus, minus) = Value::parse_version_string(&s);
-                Value::version(parts, plus, minus)
+                Value::version_from_str(&s)
             }
             // Version.new(*) - Whatever argument (bare * evaluates to Num(Inf))
             ValueView::Num(f) if f.is_infinite() && f.is_sign_positive() => {

--- a/src/runtime/utils/compare.rs
+++ b/src/runtime/utils/compare.rs
@@ -179,11 +179,13 @@ pub(crate) fn compare_values(a: &Value, b: &Value) -> i32 {
                 parts: ap,
                 plus: apl,
                 minus: ami,
+                ..
             },
             ValueView::Version {
                 parts: bp,
                 plus: bpl,
                 minus: bmi,
+                ..
             },
         ) => crate::runtime::version_cmp(ap, apl, ami, bp, bpl, bmi) as i32,
         (ValueView::Int(a), ValueView::Int(b)) => a.cmp(&b) as i32,

--- a/src/runtime/utils/shaped.rs
+++ b/src/runtime/utils/shaped.rs
@@ -280,6 +280,13 @@ pub(crate) fn values_identical(left: &Value, right: &Value) -> bool {
                 a_id == b_id
             }
         }
+        // A Version's identity is its canonical string (`.WHICH` is
+        // `Version|1.02.3`), so two versions that compare equal but are spelled
+        // differently are NOT `===`: `v1.02.3 == v1.2.3` and they are `eqv`,
+        // but `v1.02.3 === v1.2.3` is False.
+        (ValueView::Version { .. }, ValueView::Version { .. }) => {
+            left.to_string_value() == right.to_string_value()
+        }
         // Junction identity: each junction object is unique
         (
             ValueView::Junction { values: a_vals, .. },

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -948,8 +948,15 @@ impl Value {
                 }
                 format!("m{prefix}/{pattern}/")
             }
-            ValueView::Version { parts, plus, minus } => {
-                let s = Self::version_parts_to_string(parts);
+            ValueView::Version {
+                parts,
+                plus,
+                minus,
+                text,
+            } => {
+                let s = text
+                    .map(str::to_string)
+                    .unwrap_or_else(|| Self::version_parts_to_string(parts));
                 if plus {
                     format!("{}+", s)
                 } else if minus {
@@ -1057,6 +1064,29 @@ impl Value {
     /// - Transitions between digits and non-digit/non-separator chars create implicit splits
     /// - Leading zeros stripped from numeric parts
     pub(crate) fn parse_version_string(s: &str) -> (Vec<VersionPart>, bool, bool) {
+        let (parts, _, plus, minus) = Self::parse_version_string_spelled(s);
+        (parts, plus, minus)
+    }
+
+    /// Build a `Version` from its string form, preserving the *source spelling*
+    /// of every part for stringification.
+    ///
+    /// Rakudo keeps the original text of each part: `Version.new("1.02.3").Str`
+    /// is `"1.02.3"` (not `"1.2.3"`) while `.parts` still reports `(1, 2, 3)`.
+    /// Only the separators are normalized to `.`.
+    pub(crate) fn version_from_str(s: &str) -> Value {
+        let (parts, spellings, plus, minus) = Self::parse_version_string_spelled(s);
+        let spelled = spellings.join(".");
+        // Only carry the text when it differs from what the parts alone render
+        // to, so the overwhelmingly common `v1.2.3` case stays allocation-free.
+        let text =
+            (spelled != Self::version_parts_to_string(&parts)).then(|| spelled.into_boxed_str());
+        Value::version_with_text(parts, plus, minus, text)
+    }
+
+    /// `parse_version_string` plus the source spelling of each produced part
+    /// (parallel to `parts`, so `spellings[i]` is the text `parts[i]` came from).
+    fn parse_version_string_spelled(s: &str) -> (Vec<VersionPart>, Vec<String>, bool, bool) {
         let mut plus = false;
         let mut minus = false;
         let mut raw = s;
@@ -1069,32 +1099,38 @@ impl Value {
         }
 
         let mut parts = Vec::new();
+        let mut spellings: Vec<String> = Vec::new();
         let mut current = String::new();
         let mut is_digit_run = false;
+        let flush = |parts: &mut Vec<VersionPart>,
+                     spellings: &mut Vec<String>,
+                     current: &mut String,
+                     is_digit: bool| {
+            parts.push(Self::make_version_part(current, is_digit));
+            spellings.push(std::mem::take(current));
+        };
 
         for ch in raw.chars() {
             match ch {
                 '.' | '-' | '+' | '/' => {
                     if !current.is_empty() {
-                        parts.push(Self::make_version_part(&current, is_digit_run));
-                        current.clear();
+                        flush(&mut parts, &mut spellings, &mut current, is_digit_run);
                     }
                     is_digit_run = false;
                 }
                 '_' => {
                     if !current.is_empty() {
-                        parts.push(Self::make_version_part(&current, is_digit_run));
-                        current.clear();
+                        flush(&mut parts, &mut spellings, &mut current, is_digit_run);
                     }
                     // _ by itself is a "whatever" separator part
                     parts.push(VersionPart::Str("_".to_string()));
+                    spellings.push("_".to_string());
                     is_digit_run = false;
                 }
                 c if c.is_ascii_digit() => {
                     if !current.is_empty() && !is_digit_run {
                         // Transition from alpha to digit
-                        parts.push(Self::make_version_part(&current, false));
-                        current.clear();
+                        flush(&mut parts, &mut spellings, &mut current, false);
                     }
                     current.push(c);
                     is_digit_run = true;
@@ -1102,8 +1138,7 @@ impl Value {
                 c => {
                     if !current.is_empty() && is_digit_run {
                         // Transition from digit to alpha
-                        parts.push(Self::make_version_part(&current, true));
-                        current.clear();
+                        flush(&mut parts, &mut spellings, &mut current, true);
                     }
                     current.push(c);
                     is_digit_run = false;
@@ -1111,14 +1146,15 @@ impl Value {
             }
         }
         if !current.is_empty() {
-            parts.push(Self::make_version_part(&current, is_digit_run));
+            flush(&mut parts, &mut spellings, &mut current, is_digit_run);
         }
 
         if parts.is_empty() {
             parts.push(VersionPart::Num(0));
+            spellings.push("0".to_string());
         }
 
-        (parts, plus, minus)
+        (parts, spellings, plus, minus)
     }
 
     fn make_version_part(s: &str, is_digit: bool) -> VersionPart {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1231,6 +1231,12 @@ pub(in crate::value) enum ValueRepr {
         parts: Vec<VersionPart>,
         plus: bool,
         minus: bool,
+        /// The source spelling of the parts, joined by `.`, when it differs
+        /// from what `parts` alone render to — Rakudo keeps `v1.02.3` as
+        /// `"1.02.3"` while `.parts` still reports `(1, 2, 3)`. `None` for the
+        /// common case where the parts round-trip exactly. Excludes the
+        /// `+`/`-` suffix, which `plus`/`minus` carry.
+        text: Option<Box<str>>,
     },
     Promise(SharedPromise),
     Channel(SharedChannel),

--- a/src/value/nanbox/boxes.rs
+++ b/src/value/nanbox/boxes.rs
@@ -56,6 +56,7 @@ pub(in crate::value) struct VersionBox {
     pub(in crate::value) parts: Vec<VersionPart>,
     pub(in crate::value) plus: bool,
     pub(in crate::value) minus: bool,
+    pub(in crate::value) text: Option<Box<str>>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/value/nanbox/decode.rs
+++ b/src/value/nanbox/decode.rs
@@ -131,6 +131,7 @@ unsafe fn decode_kind(kind: Kind, bits: u64) -> ValueRepr {
                 parts: v.parts,
                 plus: v.plus,
                 minus: v.minus,
+                text: v.text,
             }
         }
         Kind::Capture => {

--- a/src/value/nanbox/encode.rs
+++ b/src/value/nanbox/encode.rs
@@ -146,9 +146,20 @@ impl NanBox {
             ValueRepr::RaceSeq(items) => pack_arc(Kind::RaceSeq, items),
             ValueRepr::Slip(items) => pack_arc(Kind::Slip, items),
             ValueRepr::LazyList(l) => pack_gc(Kind::LazyList, l),
-            ValueRepr::Version { parts, plus, minus } => {
-                pack_arc(Kind::Version, Arc::new(VersionBox { parts, plus, minus }))
-            }
+            ValueRepr::Version {
+                parts,
+                plus,
+                minus,
+                text,
+            } => pack_arc(
+                Kind::Version,
+                Arc::new(VersionBox {
+                    parts,
+                    plus,
+                    minus,
+                    text,
+                }),
+            ),
             ValueRepr::Promise(p) => pack_gc(Kind::Promise, p.inner),
             ValueRepr::Channel(c) => pack_gc(Kind::Channel, c.inner),
             ValueRepr::Mixin(inner, overrides) => {

--- a/src/value/nanbox/peek.rs
+++ b/src/value/nanbox/peek.rs
@@ -353,6 +353,7 @@ unsafe fn view_kind<'a>(kind: Kind, bits: u64) -> ValueView<'a> {
                     parts: &v.parts,
                     plus: v.plus,
                     minus: v.minus,
+                    text: v.text.as_deref(),
                 }
             }
             Kind::Capture => {

--- a/src/value/nanbox/tests.rs
+++ b/src/value/nanbox/tests.rs
@@ -460,6 +460,7 @@ fn every_variant_roundtrips_losslessly() {
             ],
             plus: true,
             minus: false,
+            text: Some("01.beta.*".into()),
         },
         ValueRepr::Nil,
         ValueRepr::Whatever,

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -88,6 +88,8 @@ enum SerValue {
         parts: Vec<VersionPart>,
         plus: bool,
         minus: bool,
+        #[serde(default)]
+        text: Option<Box<str>>,
     },
     Instance {
         class_name: Symbol,
@@ -258,10 +260,16 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
             let ser_items: Result<Vec<_>, _> = items.iter().map(value_to_ser).collect();
             Ok(SerValue::Slip(ser_items?))
         }
-        ValueView::Version { parts, plus, minus } => Ok(SerValue::Version {
+        ValueView::Version {
+            parts,
+            plus,
+            minus,
+            text,
+        } => Ok(SerValue::Version {
             parts: parts.clone(),
             plus,
             minus,
+            text: text.map(Box::from),
         }),
         ValueView::Instance {
             class_name,
@@ -459,9 +467,17 @@ fn ser_to_value(sv: SerValue) -> Value {
         SerValue::Slip(items) => {
             Value::Slip(Arc::new(items.into_iter().map(ser_to_value).collect()))
         }
-        SerValue::Version { parts, plus, minus } => {
-            Value::from_repr(ValueRepr::Version { parts, plus, minus })
-        }
+        SerValue::Version {
+            parts,
+            plus,
+            minus,
+            text,
+        } => Value::from_repr(ValueRepr::Version {
+            parts,
+            plus,
+            minus,
+            text,
+        }),
         SerValue::Instance {
             class_name,
             attributes,

--- a/src/value/value_eq.rs
+++ b/src/value/value_eq.rs
@@ -246,11 +246,13 @@ impl PartialEq for Value {
                     parts: ap,
                     plus: aplus,
                     minus: aminus,
+                    ..
                 },
                 ValueView::Version {
                     parts: bp,
                     plus: bplus,
                     minus: bminus,
+                    ..
                 },
             ) => {
                 if aplus != bplus || aminus != bminus {

--- a/src/value/view.rs
+++ b/src/value/view.rs
@@ -86,6 +86,8 @@ pub enum ValueView<'a> {
         parts: &'a Vec<VersionPart>,
         plus: bool,
         minus: bool,
+        /// Source spelling of the parts (see `ValueRepr::Version::text`).
+        text: Option<&'a str>,
     },
     Promise(RefGuard<'a, SharedPromise>),
     Channel(RefGuard<'a, SharedChannel>),
@@ -271,7 +273,29 @@ impl Value {
     /// Construct a `Version` value from its parts.
     #[inline]
     pub(crate) fn version(parts: Vec<VersionPart>, plus: bool, minus: bool) -> Self {
-        Value::from_repr(ValueRepr::Version { parts, plus, minus })
+        Value::from_repr(ValueRepr::Version {
+            parts,
+            plus,
+            minus,
+            text: None,
+        })
+    }
+
+    /// Construct a `Version` value from its parts, keeping the source spelling
+    /// used for stringification (see `ValueRepr::Version::text`).
+    #[inline]
+    pub(crate) fn version_with_text(
+        parts: Vec<VersionPart>,
+        plus: bool,
+        minus: bool,
+        text: Option<Box<str>>,
+    ) -> Self {
+        Value::from_repr(ValueRepr::Version {
+            parts,
+            plus,
+            minus,
+            text,
+        })
     }
 
     /// Construct a `CompUnitDepSpec` from its short name.

--- a/src/vm/vm_comparison_order_ops.rs
+++ b/src/vm/vm_comparison_order_ops.rs
@@ -302,11 +302,13 @@ impl Interpreter {
                     parts: ap,
                     plus: apl,
                     minus: ami,
+                    ..
                 },
                 ValueView::Version {
                     parts: bp,
                     plus: bpl,
                     minus: bmi,
+                    ..
                 },
             ) => runtime::version_cmp(ap, apl, ami, bp, bpl, bmi),
             // Enum values: compare by their integer value

--- a/src/vm/vm_smart_match.rs
+++ b/src/vm/vm_smart_match.rs
@@ -124,9 +124,12 @@ pub(crate) fn pure_smart_match(left: &Value, right: &Value) -> Option<bool> {
         }
 
         // Version ~~ Version
-        (ValueView::Version { .. }, ValueView::Version { parts, plus, minus }) => {
-            Some(Interpreter::version_smart_match(left, parts, plus, minus))
-        }
+        (
+            ValueView::Version { .. },
+            ValueView::Version {
+                parts, plus, minus, ..
+            },
+        ) => Some(Interpreter::version_smart_match(left, parts, plus, minus)),
 
         // When RHS is NaN, check if LHS is also NaN
         (_, ValueView::Num(b)) if b.is_nan() && !needs_interpreter_lhs(left) => {

--- a/t/version-source-spelling.t
+++ b/t/version-source-spelling.t
@@ -1,0 +1,44 @@
+use Test;
+
+plan 22;
+
+# A Version keeps the *source spelling* of its parts for stringification, the
+# way Rakudo does: `v1.02.3` stringifies as "1.02.3" while `.parts` still
+# reports the parsed Ints `(1, 2, 3)`. Only the separators are normalized to
+# `.`, and a leading/trailing `+`/`-` marker stays a flag.
+
+is (v1.02.3).Str, '1.02.3', 'Str keeps a zero-padded part';
+is ~(v1.02.3), '1.02.3', 'string context keeps a zero-padded part';
+is (v1.02.3).gist, 'v1.02.3', 'gist keeps a zero-padded part';
+is (v1.02.3).raku, 'v1.02.3', 'raku keeps a zero-padded part';
+is (v01.2).Str, '01.2', 'a zero-padded leading part is kept';
+is Version.new('1.02.3').Str, '1.02.3', 'Version.new keeps the spelling';
+is Version.new('1.02.3').raku, 'v1.02.3', 'Version.new .raku keeps the spelling';
+is '1.02.3'.Version.Str, '1.02.3', '.Version coercion keeps the spelling';
+is Version.new(v1.02.3).Str, '1.02.3', 'Version.new(Version) keeps the spelling';
+
+# ... but the parts themselves are still parsed numbers.
+is-deeply (v1.02.3).parts.List, (1, 2, 3), 'parts are the parsed Ints';
+
+# Ordinary versions are untouched.
+is (v1.2.3).Str, '1.2.3', 'a plain version is unchanged';
+is (v6.d.PREVIEW).Str, '6.d.PREVIEW', 'alphabetic parts are unchanged';
+is (v6.0.0+).Str, '6.0.0+', 'the `+` marker still stringifies';
+my $minus = Version.new('1.2.3-');
+is $minus.Str, '1.2.3-', 'the `-` marker still stringifies';
+
+# Separators are normalized to `.`, matching Rakudo.
+is Version.new('1.2-beta').Str, '1.2.beta', 'a `-` separator normalizes to `.`';
+is Version.new('1.2/3').Str, '1.2.3', 'a `/` separator normalizes to `.`';
+
+# Comparison ignores the spelling: a zero-padded part is numerically equal.
+ok v1.02.3 == v1.2.3, 'a zero-padded version is == its plain spelling';
+is (v1.02.3 cmp v1.2.3), Same, 'cmp sees them as the same';
+ok (v1.02.3 eqv v1.2.3), 'eqv sees them as the same';
+
+# ... but identity (WHICH) is the canonical string, so they are not `===`.
+is (v1.02.3).WHICH.Str, 'Version|1.02.3', 'WHICH is Version|<canonical string>';
+nok (v1.02.3 === v1.2.3), 'differently spelled versions are not ===';
+ok (v1.2 === v1.2), 'identically spelled versions are ===';
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
`v1.02.3` stringified as `1.2.3` in mutsu but as `1.02.3` in Rakudo: a `Version`
was stored purely as its parsed parts (`(1, 2, 3)`), and every stringification
(`.Str`, `~`, `.gist`, `.raku`, hash-key coercion) rebuilt the text from those
parts, throwing away the zero padding.

Rakudo keeps the original text of each part while `.parts` still reports the
parsed `Int`s. Only the *separators* are normalized — `Version.new("1.2-beta").Str`
is `"1.2.beta"` in both.

| expression | before | after / raku |
|---|---|---|
| `(v1.02.3).Str` | `1.2.3` | `1.02.3` |
| `(v1.02.3).gist` / `.raku` | `v1.2.3` | `v1.02.3` |
| `Version.new('1.02.3').Str` | `1.2.3` | `1.02.3` |
| `(v1.02.3).parts` | `(1, 2, 3)` | `(1, 2, 3)` (unchanged) |
| `(v1.02.3).WHICH.Str` | `Version\|1` | `Version\|1.02.3` |
| `v1.02.3 === v1.2.3` | `True` | `False` |

## Implementation

`ValueRepr::Version` carries an optional `text` field holding the source spelling
of the parts joined by `.`. It is populated **only when it differs** from what the
parts alone render to, so the overwhelmingly common `v1.2.3` case stays
allocation-free and byte-identical to before. The three string-derived
constructors (the `v…` literal in the parser, `Version.new(Str)`, and the
`.Version` coercion) route through a new `Value::version_from_str`; every
comparison site ignores `text` (patterns just gained `..`).

Two follow-on parity fixes fell out, both wrong before and only *observable* once
versions can differ by spelling:

- **`.WHICH`** had no `Version` arm and fell through to the global-counter
  fallback, yielding a meaningless `Version|1`. It is now `Version|<canonical
  string>` (a `ValueObjAt`, as in Rakudo).
- **`===`** fell back to `eqv`, so `v1.02.3 === v1.2.3` was `True`. Identity is
  the `.WHICH` string, so it is `False` now — while `==`, `cmp` and `eqv` all
  still see the two as equal, exactly as Rakudo does.

Found while triaging `TODO_dist` ticket T-046 (RakudoPrereq), whose test asserts
the error message contains the compiler version `v2017.03.290`.

## Test

Pin: `t/version-source-spelling.t` — 22 assertions, passes under **both** mutsu
and raku. `make test` green; the six whitelisted version roast files
(`6.d/S02-literals/version.t`, `S02-literals/version.t`, `S02-types/version.t`,
`S02-types/version-stress.t`, `S11-modules/versioning.t`, `S14-roles/versioning.t`
— 2161 assertions) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)