### PR TITLE
fix: `use Module a, b, c` passes every argument to sub EXPORT

### DIFF
--- a/news/2026-07/use-multiple-export-args.md
+++ b/news/2026-07/use-multiple-export-args.md
@@ -1,0 +1,33 @@
+# `use Module a, b, c` passes every argument to `sub EXPORT`
+
+A `use` line may carry a comma-separated argument list, and each element is a
+separate positional argument to the module's `sub EXPORT`:
+
+```raku
+use RakudoPrereq v2021.04, 'Your Raku is way too old, bruh!', 'rakudo-only';
+```
+
+mutsu parsed only the **first** argument. `expression()` stops at a comma (the
+list op lives at statement level), so `use Foo 1, 2, 3` became `use Foo 1`
+followed by two bare constants in sink context — the module's `sub EXPORT` saw
+one argument, and the user got a spurious
+`Useless use of constant integer 2 in sink context` warning.
+
+The `use` parser now collects the whole comma list and hands it on as an
+`ArrayLiteral`, which the compiler already flattens into positional `use`
+arguments (the same path `use Foo <a b c>` takes). A trailing comma ends the
+list.
+
+The same gap broke **`use lib` with more than one path**. `use lib "a", "b"`
+dropped the second path at parse time, and `use lib <a b>` was worse: the whole
+word list reached the `UseLibPath` opcode as one value and was stringified into
+the single bogus repository spec `"a b"`. Both parse-time and run-time handling
+now treat the argument as a list of specs and register each one; a runtime list
+(`use lib @paths`) works for the same reason. An empty spec is still rejected
+with `X::LibEmpty`.
+
+Found while triaging `TODO_dist` ticket T-046 (RakudoPrereq), whose whole API is
+the arguments on the `use` line.
+
+Pin: `t/use-multiple-export-args.t` (+ `t/lib/UseArgsFixture.rakumod`), passing
+under both mutsu and raku.

--- a/src/parser/stmt/decl/use_decl.rs
+++ b/src/parser/stmt/decl/use_decl.rs
@@ -152,16 +152,50 @@ pub(in crate::parser::stmt) fn use_stmt(input: &str) -> PResult<'_, Stmt> {
         let (r, expr) = super::super::super::primary::primary(rest)?;
         (r, Some(expr))
     } else {
-        let (r, expr) = expression(rest)?;
-        (r, Some(expr))
+        // A `use` may carry a comma-separated argument list
+        // (`use RakudoPrereq v2021.04, 'too old', 'rakudo-only'`); each element
+        // is a separate positional argument to the module's `sub EXPORT`.
+        // `expression` stops at the comma (it is a statement-level list op), so
+        // collect the elements here and hand them on as an `ArrayLiteral`, which
+        // the compiler already flattens into positional `use` arguments.
+        let (mut r, first) = expression(rest)?;
+        let mut items = vec![first];
+        loop {
+            let (after_ws, _) = ws(r)?;
+            let Some(after_comma) = after_ws.strip_prefix(',') else {
+                break;
+            };
+            let (next, _) = ws(after_comma)?;
+            // A trailing comma (`use Foo 1, ;`) ends the list.
+            if next.is_empty() || next.starts_with(';') || next.starts_with('}') {
+                r = next;
+                break;
+            }
+            let (after_expr, expr) = expression(next)?;
+            items.push(expr);
+            r = after_expr;
+        }
+        if items.len() == 1 {
+            (r, items.pop())
+        } else {
+            (r, Some(Expr::ArrayLiteral(items)))
+        }
     };
     let (rest, _) = ws(rest)?;
     let (rest, _) = opt_char(rest, ';');
-    // Handle `use lib "path"` or `use lib $*PROGRAM.parent(N).add("path")` at parse time
+    // Handle `use lib "path"` or `use lib $*PROGRAM.parent(N).add("path")` at
+    // parse time. A list (`use lib "a", "b"` / `use lib <a b>`) adds each path.
     if module == "lib"
         && let Some(ref expr) = arg
     {
-        super::super::simple::try_add_parse_time_lib_path(expr);
+        match expr {
+            Expr::ArrayLiteral(items) => {
+                for item in items {
+                    super::super::simple::try_add_parse_time_lib_path(item);
+                }
+            }
+            other => super::super::simple::try_add_parse_time_lib_path(other),
+        }
     }
     // Register exported function names so they are recognized as calls without parens.
     super::super::simple::register_module_exports(&module);

--- a/src/vm/vm_module_ops.rs
+++ b/src/vm/vm_module_ops.rs
@@ -155,7 +155,22 @@ impl Interpreter {
         _code: &CompiledCode,
     ) -> Result<(), RuntimeError> {
         let value = self.stack.pop().unwrap_or(Value::NIL);
-        let path = value.to_string_value();
+        // `use lib` takes a *list* of repository specs (`use lib <a b>`,
+        // `use lib "a", "b"`, `use lib @paths`); each element is its own spec,
+        // so never stringify the list as a whole.
+        let specs: Vec<Value> = match value.view() {
+            ValueView::Array(items, ..) => items.iter().cloned().collect(),
+            ValueView::Seq(items) | ValueView::Slip(items) => items.iter().cloned().collect(),
+            _ => vec![value.clone()],
+        };
+        for spec in specs {
+            self.add_one_lib_path(spec.to_string_value())?;
+        }
+        Ok(())
+    }
+
+    /// Register a single `use lib` repository spec.
+    fn add_one_lib_path(&mut self, path: String) -> Result<(), RuntimeError> {
         if path.is_empty() {
             return Err(RuntimeError::new(
                 "X::LibEmpty: Repository specification can not be an empty string",

--- a/t/lib/UseArgsFixture.rakumod
+++ b/t/lib/UseArgsFixture.rakumod
@@ -1,0 +1,6 @@
+#| Records the positional arguments a `use` line passes to `sub EXPORT`, and
+#| exports them as `&use-args` so a test can inspect them.
+sub EXPORT(*@args) {
+    my @seen = @args;
+    Map.new: '&use-args' => sub { @seen }
+}

--- a/t/use-multiple-export-args.t
+++ b/t/use-multiple-export-args.t
@@ -1,0 +1,44 @@
+use Test;
+use lib 't/lib';
+
+plan 8;
+
+# A `use` line may carry a comma-separated argument list; each element is a
+# separate positional argument to the module's `sub EXPORT`.
+# (e.g. `use RakudoPrereq v2021.04, 'too old', 'rakudo-only'`)
+
+use UseArgsFixture 1, 'two', 3.5;
+is-deeply use-args().List, (1, 'two', 3.5), 'three `use` arguments reach sub EXPORT';
+
+# The other argument shapes run in a subprocess: a module's `sub EXPORT` runs
+# once per process, so re-`use`ing the same fixture in this file would not
+# re-record.
+sub args-for($use-line) {
+    my $proc = run :out, :err, $*EXECUTABLE, '-I', 't/lib',
+        '-e', "$use-line say use-args().raku";
+    my $out = $proc.out.slurp-rest(:close).chomp;
+    $proc.err.slurp-rest(:close);
+    $out;
+}
+
+is args-for('use UseArgsFixture "a", "b";'), '["a", "b"]',
+    'a comma list of two arguments';
+is args-for('use UseArgsFixture "only";'), '["only"]',
+    'a single argument still works';
+is args-for('use UseArgsFixture;'), '[]',
+    'no arguments still works';
+is args-for('use UseArgsFixture <a b c>;'), '["a", "b", "c"]',
+    'a word list still flattens into positionals';
+is args-for('use UseArgsFixture 1, 2, 3, 4, 5;'), '[1, 2, 3, 4, 5]',
+    'five arguments all arrive';
+
+# `use lib` takes a *list* of repository specs, not one stringified blob.
+{
+    my $dir = 't/lib';
+    lives-ok { EVAL "use lib 'no/such/dir', '$dir'; use UseArgsFixture 'x'" },
+        '`use lib` with a comma list registers every path';
+    lives-ok { EVAL "use lib <no/such/dir $dir>; use UseArgsFixture 'y'" },
+        '`use lib` with a word list registers every path';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
A `use` line may carry a comma-separated argument list, and each element is a
separate positional argument to the module's `sub EXPORT`:

```raku
use RakudoPrereq v2021.04, 'Your Raku is way too old, bruh!', 'rakudo-only';
```

mutsu parsed only the **first** argument. `expression()` stops at a comma (the
list op lives at statement level), so `use Foo 1, 2, 3` became `use Foo 1`
followed by two bare constants in sink context — `sub EXPORT` saw one argument,
and the user got a spurious `Useless use of constant integer 2 in sink context`
warning.

The `use` parser now collects the whole comma list and hands it on as an
`ArrayLiteral`, which the compiler already flattens into positional `use`
arguments (the same path `use Foo <a b c>` takes). A trailing comma ends the list.

## `use lib` with more than one path

The same gap broke `use lib`:

| expression | before | after / raku |
|---|---|---|
| `use lib "a", "b"` | `"b"` silently dropped | both registered |
| `use lib <a b>` | one bogus spec `"a b"` | both registered |

The word-list form was worse than a drop: the whole list reached the
`UseLibPath` opcode as one value and got stringified. Both the parse-time and the
run-time handler now treat the argument as a list of specs and register each one,
so a runtime list (`use lib @paths`) works for the same reason. An empty spec is
still rejected with `X::LibEmpty`.

Found while triaging `TODO_dist` ticket T-046 (RakudoPrereq), whose entire API is
the arguments on the `use` line.

## Test

Pin: `t/use-multiple-export-args.t` (+ `t/lib/UseArgsFixture.rakumod`) — 8
assertions, passes under **both** mutsu and raku. `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)