### PR TITLE
feat: Promise.in/Promise.at honor a user-defined $*SCHEDULER

### DIFF
--- a/news/2026-07/promise-in-honors-user-scheduler.md
+++ b/news/2026-07/promise-in-honors-user-scheduler.md
@@ -1,0 +1,36 @@
+# `Promise.in` / `Promise.at` honor a user-defined `$*SCHEDULER`
+
+Raku defines `Promise.in($t)` as `$*SCHEDULER.cue({ ... }, :in($t))`. Replacing
+`$*SCHEDULER` is therefore how a test drives *virtual* time — the whole premise of
+the `Test::Scheduler` distribution, where `Promise.in(200)` must not resolve until
+`$*SCHEDULER.advance-by(200)` is called, no matter how much real time passes.
+
+mutsu never consulted `$*SCHEDULER` at all: `Promise.in`/`Promise.at` went
+straight to the shared deadline-heap timer, so swapping the scheduler had zero
+effect and a promise resolved on real time regardless.
+
+Both now route through the dynamic scheduler when it is a **user-defined** class —
+one that is not `ThreadPoolScheduler` / `CurrentThreadScheduler` / `FakeScheduler`
+and that provides a `cue` method. The built-in schedulers keep the direct
+deadline-heap path, which is much cheaper and observationally identical, so
+ordinary `Promise.in` pays nothing. `Promise.at` cues as `:in($at - now)`, matching
+Rakudo (verified against `raku`), not as `:at`.
+
+The callback handed to `.cue` is a synthesized zero-argument block whose body is
+`$promise.keep(True)` — a first-class `Callable` the user scheduler can store and
+invoke whenever its own clock says so.
+
+## A second bug this uncovered
+
+`Scheduler` is a composable built-in role (`class Test::Scheduler does Scheduler
+{...}`), but its class entry claimed a native `cue`. Since `is_native_method` walks
+the MRO, *every* user class composing the role looked native-backed, so its own
+`method cue` was bypassed and dispatch died with
+`No native method 'cue' on 'MyScheduler'`. There is no native implementation keyed
+on bare `Scheduler` — only the three concrete schedulers have one, and each lists
+`cue` itself — so the role no longer claims it.
+
+Found while triaging `TODO_dist` ticket T-037 (Test::Scheduler).
+
+Pin: `t/promise-in-honors-scheduler.t` (9 assertions, passes under both mutsu and
+raku).

--- a/src/runtime/methods_promise_class.rs
+++ b/src/runtime/methods_promise_class.rs
@@ -42,6 +42,81 @@ impl Interpreter {
         );
     }
 
+    /// The `$*SCHEDULER` currently in effect, but only when it is a
+    /// *user-defined* scheduler — a class that is not one of the built-ins.
+    ///
+    /// Raku defines `Promise.in($t)` as `$*SCHEDULER.cue({ ... }, :in($t))`, so
+    /// swapping `$*SCHEDULER` (e.g. for `Test::Scheduler`'s virtual time)
+    /// redirects every timed promise. mutsu drives the built-in schedulers
+    /// straight off the shared deadline heap, which is much cheaper and
+    /// observationally identical, so only a user scheduler needs the real
+    /// `.cue` dispatch.
+    fn user_scheduler(&mut self) -> Option<Value> {
+        let sched = self.env().get("*SCHEDULER")?.clone();
+        let ValueView::Instance { class_name, .. } = sched.view() else {
+            return None;
+        };
+        let name = class_name.resolve();
+        if matches!(
+            name.as_str(),
+            "Scheduler" | "ThreadPoolScheduler" | "CurrentThreadScheduler" | "FakeScheduler"
+        ) {
+            return None;
+        }
+        // Only a scheduler that actually provides `cue` can drive the promise.
+        self.class_has_method(&name, "cue").then_some(sched)
+    }
+
+    /// Hand `promise` to a user `$*SCHEDULER` via `.cue(&keeper, :$in)`, where
+    /// `&keeper` is a synthesized zero-arg block whose body is
+    /// `$promise.keep(True)`. Returns the scheduler's cancellation value, which
+    /// the caller discards (`Promise.in` returns the promise itself).
+    fn cue_promise_on_scheduler(
+        &mut self,
+        scheduler: Value,
+        promise: &SharedPromise,
+        delay_key: &str,
+        delay: f64,
+    ) -> Result<Value, RuntimeError> {
+        let keeper = Self::promise_keeper_block(promise);
+        let named = Value::pair(delay_key.to_string(), Value::num(delay));
+        self.call_method_with_values(scheduler, "cue", vec![keeper, named])
+    }
+
+    /// A zero-arg block that keeps `promise` with `True`, as a first-class
+    /// `Callable` a user scheduler can store and invoke later.
+    fn promise_keeper_block(promise: &SharedPromise) -> Value {
+        let body = vec![crate::ast::Stmt::Expr(crate::ast::Expr::MethodCall {
+            target: Box::new(crate::ast::Expr::Literal(Value::promise(promise.clone()))),
+            name: Symbol::intern("keep"),
+            args: vec![crate::ast::Expr::Literal(Value::TRUE)],
+            modifier: None,
+            quoted: false,
+        })];
+        Value::sub_value(crate::gc::Gc::new(crate::value::SubData {
+            package: Symbol::intern("GLOBAL"),
+            name: Symbol::intern(""),
+            params: Vec::new(),
+            param_defs: Vec::new(),
+            body,
+            is_rw: false,
+            is_raw: false,
+            env: Env::new(),
+            assumed_positional: Vec::new(),
+            assumed_named: std::collections::HashMap::new(),
+            id: crate::value::next_instance_id(),
+            empty_sig: false,
+            is_bare_block: true,
+            compiled_code: None,
+            deprecated_message: None,
+            source_line: None,
+            source_file: None,
+            owned_captures: Vec::new(),
+            authoritative_captures: Vec::new(),
+            upvalues: Vec::new(),
+        }))
+    }
+
     /// Promise.in dispatch
     pub(super) fn dispatch_promise_in(
         &mut self,
@@ -52,6 +127,12 @@ impl Interpreter {
             let secs = args.first().map(|v| v.to_f64()).unwrap_or(0.0);
             let promise = SharedPromise::new_with_class(Symbol::intern(&cls));
             let ret = Value::promise(promise.clone());
+            if let Some(scheduler) = self.user_scheduler() {
+                if let Err(e) = self.cue_promise_on_scheduler(scheduler, &promise, "in", secs) {
+                    return Some(Err(e));
+                }
+                return Some(Ok(ret));
+            }
             Self::keep_promise_after(promise, secs);
             return Some(Ok(ret));
         }
@@ -90,6 +171,15 @@ impl Interpreter {
             let delay = at_time - now;
             let promise = SharedPromise::new_with_class(Symbol::intern(&cls));
             let ret = Value::promise(promise.clone());
+            if let Some(scheduler) = self.user_scheduler() {
+                // Rakudo's `Promise.at` cues with `:in($at - now)`, not `:at`,
+                // so a virtual-time scheduler measures the delay from its own
+                // clock. Match that.
+                if let Err(e) = self.cue_promise_on_scheduler(scheduler, &promise, "in", delay) {
+                    return Some(Err(e));
+                }
+                return Some(Ok(ret));
+            }
             Self::keep_promise_after(promise, delay);
             return Some(Ok(ret));
         }

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -462,7 +462,14 @@ impl Interpreter {
                 parents: Vec::new(),
                 attributes: Vec::new(),
                 methods: HashMap::new(),
-                native_methods: ["cue"].iter().map(|s| s.to_string()).collect(),
+                // `Scheduler` is a composable role (`class Test::Scheduler does
+                // Scheduler {...}`) with NO native implementation of its own --
+                // only the concrete schedulers below have one, and each lists
+                // `cue` itself. Claiming a native `cue` here made every user
+                // class that composes the role look native-backed, so its own
+                // `method cue` was bypassed and dispatch died with
+                // "No native method 'cue' on 'MyScheduler'".
+                native_methods: HashSet::new(),
                 mro: sym_mro(&["Scheduler"]),
                 attribute_types: HashMap::new(),
                 attribute_smileys: HashMap::new(),

--- a/t/promise-in-honors-scheduler.t
+++ b/t/promise-in-honors-scheduler.t
@@ -1,0 +1,56 @@
+use Test;
+
+plan 9;
+
+# Raku defines `Promise.in($t)` as `$*SCHEDULER.cue({ ... }, :in($t))`, so
+# replacing `$*SCHEDULER` (e.g. with a virtual-time test scheduler) redirects
+# every timed promise. mutsu drives the built-in schedulers straight off its
+# shared deadline heap; a *user-defined* scheduler must get the real `.cue`.
+
+class QueueScheduler does Scheduler {
+    has @.cues;
+    method cue(&code, :$at, :$in, :$every, :$times = 1, :&stop, :&catch) {
+        @!cues.push({ code => &code, at => $at, in => $in });
+        Nil
+    }
+    method run-all() {
+        my @todo = @!cues;
+        @!cues = ();
+        .<code>() for @todo;
+    }
+    method uncaught_handler() { Nil }
+    method loads() { 0 }
+}
+
+# A class composing the Scheduler role dispatches to its own `cue`.
+{
+    my $s = QueueScheduler.new;
+    $s.cue({ 1 }, :in(5));
+    is $s.cues.elems, 1, 'a user Scheduler class dispatches to its own .cue';
+    is $s.cues[0]<in>, 5, '... with the :in adverb intact';
+}
+
+# Promise.in routes through it.
+{
+    my $*SCHEDULER = QueueScheduler.new;
+    my $p = Promise.in(0.001);
+    is $*SCHEDULER.cues.elems, 1, 'Promise.in cues on the user $*SCHEDULER';
+    is $*SCHEDULER.cues[0]<in>, 0.001, '... passing the delay as :in';
+    sleep 0.05;
+    is $p.status, Planned, 'the promise is NOT kept by real time';
+    $*SCHEDULER.run-all;
+    is $p.status, Kept, 'running the cued code keeps the promise';
+    is await($p), True, 'and the promise is kept with True';
+}
+
+# Promise.at routes through it too. Rakudo cues it as `:in($at - now)`, so the
+# scheduler measures the delay against its own clock.
+{
+    my $*SCHEDULER = QueueScheduler.new;
+    my $p = Promise.at(now + 30);
+    ok 29 < $*SCHEDULER.cues[0]<in> <= 30, 'Promise.at cues with :in($at - now)';
+    sleep 0.05;
+    is $p.status, Planned, 'Promise.at is not kept by real time either';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
Raku defines `Promise.in($t)` as `$*SCHEDULER.cue({ ... }, :in($t))`. Replacing
`$*SCHEDULER` is therefore how a test drives **virtual** time — the whole premise
of the `Test::Scheduler` distribution, where `Promise.in(200)` must not resolve
until `$*SCHEDULER.advance-by(200)` is called, no matter how much real time passes.

mutsu never consulted `$*SCHEDULER` at all: `Promise.in`/`Promise.at` went straight
to the shared deadline-heap timer, so swapping the scheduler had **zero** effect
and a promise resolved on real time regardless.

## Changes

- `Promise.in` / `Promise.at` route through the dynamic scheduler when it is a
  **user-defined** class — one that is not `ThreadPoolScheduler` /
  `CurrentThreadScheduler` / `FakeScheduler` and that provides a `cue` method. The
  built-in schedulers keep the direct deadline-heap path (much cheaper,
  observationally identical), so ordinary `Promise.in` pays nothing.
- `Promise.at` cues as `:in($at - now)`, matching Rakudo (verified against `raku`),
  not as `:at`.
- The callback handed to `.cue` is a synthesized zero-argument block whose body is
  `$promise.keep(True)` — a first-class `Callable` the scheduler can store and
  invoke whenever its own clock says so.

### A second bug this uncovered

`Scheduler` is a composable built-in role (`class Test::Scheduler does Scheduler
{...}`), but its class entry claimed a native `cue`. Since `is_native_method` walks
the MRO, *every* user class composing the role looked native-backed, so its own
`method cue` was bypassed and dispatch died with
`No native method 'cue' on 'MyScheduler'`. There is no native implementation keyed
on bare `Scheduler` — only the three concrete schedulers have one, and each lists
`cue` itself — so the role no longer claims it.

Found while triaging `TODO_dist` ticket T-037 (Test::Scheduler).

## Test

Pin: `t/promise-in-honors-scheduler.t` — 9 assertions, passes under **both** mutsu
and raku. `make test` green; the whitelisted `S17-promise/*` roast files
(`basic.t`, `in.t`, `start.t`, `lock-async*.t`, `nonblocking-await.t`,
`single-assignment.t`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)