### PR TITLE
fix: a trailing `@x` in a `:=` binding is not slurpy

### DIFF
--- a/news/2026-07/list-bind-trailing-array.md
+++ b/news/2026-07/list-bind-trailing-array.md
@@ -1,0 +1,35 @@
+# A trailing `@x` in a `:=` binding is not slurpy
+
+In a signature **binding** (`my (...) := ...`) a plain `@x` binds one positional
+argument; only an explicit `*@rest` is slurpy. mutsu treated a *trailing* array
+target as implicitly slurpy, so the last one came back wrapped in an extra layer:
+
+```raku
+my @x = 1, 2;
+my @y = 5;
+my (@a, @b) := (@x, @y);
+say @b.raku;    # was [[5],]  --  raku: [5]
+```
+
+Every array target except the last bound correctly, which made this easy to miss.
+The comment above the code already spelled out the right rule and called the
+slurpy branch a "historical heuristic"; the heuristic is now gone in binding mode.
+List **assignment** (`=`) keeps its own, different greedy semantics — there the
+*first* `@`/`%` target slurps and every later target gets an empty container —
+which is unchanged.
+
+Found while triaging `TODO_dist` ticket T-037 (Test::Scheduler), whose
+`method !run-due` opens with
+
+```raku
+my (@now, @future) := $!lock.protect: {
+    my (:@now, :@future) := @!future.classify: { ... }
+    ...
+};
+```
+
+The doubly-wrapped `@future` made the scheduler believe work was still pending, so
+`advance-by` silently ran nothing.
+
+Pin: `t/list-bind-trailing-array.t` (11 assertions, passes under both mutsu and
+raku).

--- a/src/parser/stmt/decl/destructure.rs
+++ b/src/parser/stmt/decl/destructure.rs
@@ -496,9 +496,10 @@ fn parse_destructuring_with_rhs(
     //  - binding: a plain `@`/`%` binds ONE positional argument; only an
     //    explicit `*@rest` is slurpy (`my ($x, @y, *@r) := (42,[13,17],5,6,7)`
     //    → `@y` = `[13,17]`, `@r` = `[5,6,7]`).
-    // So the greedy behaviour applies only in assignment mode; binding keeps the
-    // historical "trailing array with nothing non-slurpy after it" heuristic.
-    let has_explicit_slurpy = vars.iter().any(|v| v.is_slurpy);
+    // So the greedy behaviour applies only in assignment mode. In binding mode a
+    // trailing `@x` is NOT slurpy: `my (@a, @b) := (@x, @y)` binds `@b` to `@y`,
+    // not to `(@y,)`. (Rakudo type-checks each element as Positional, so the
+    // shapes where the distinction is invisible are the ones it rejects outright.)
     let mut seen_slurpy = false;
     for (i, dvar) in vars.iter().enumerate() {
         if let Some(lit) = &dvar.literal_value {
@@ -529,11 +530,7 @@ fn parse_destructuring_with_rhs(
 
         let is_array = dvar.name.starts_with('@');
         let is_hash = dvar.name.starts_with('%');
-        let is_implicit_slurpy = if is_binding {
-            !has_explicit_slurpy && is_array && !vars[i + 1..].iter().any(|v| !v.is_slurpy)
-        } else {
-            !seen_slurpy && (is_array || is_hash)
-        };
+        let is_implicit_slurpy = !is_binding && !seen_slurpy && (is_array || is_hash);
 
         let effective_tc = dvar
             .per_var_type_constraint

--- a/t/list-bind-trailing-array.t
+++ b/t/list-bind-trailing-array.t
@@ -1,0 +1,62 @@
+use Test;
+
+plan 11;
+
+# In a signature BINDING (`:=`) a plain `@x` binds ONE positional argument; only
+# an explicit `*@rest` is slurpy. mutsu treated a *trailing* `@x` as implicitly
+# slurpy, so the last array target came back wrapped in an extra layer:
+# `my (@a, @b) := (@x, @y)` bound `@b` to `(@y,)` instead of `@y`.
+
+{
+    my @x = 1, 2;
+    my @y = 5;
+    my (@a, @b) := (@x, @y);
+    is-deeply @a.List, (1, 2), 'first array target binds its element';
+    is-deeply @b.List, (5,), 'trailing array target binds its element, not a wrapper';
+}
+
+{
+    my @x = 1, 2;
+    my @y;
+    my (@a, @b) := (@x, @y);
+    is-deeply @b.List, (), 'an empty trailing array binds as empty';
+}
+
+{
+    my @x = 1, 2;
+    my @y = 5;
+    my @z = 7, 8;
+    my (@a, @b, @c) := (@x, @y, @z);
+    is-deeply @c.List, (7, 8), 'the last of three array targets binds its element';
+}
+
+{
+    my @y = 5;
+    my (@b) := (@y,);
+    is-deeply @b.List, (5,), 'a lone array target binds its element';
+}
+
+# An explicit `*@rest` is still slurpy.
+{
+    my ($x, @y, *@r) := (42, [13, 17], 5, 6, 7);
+    is $x, 42, 'scalar target binds first element';
+    is-deeply @y.List, (13, 17), 'plain array target binds one element';
+    is-deeply @r.List, (5, 6, 7), 'an explicit *@rest is slurpy';
+}
+
+# The shape this was found through: `.classify` returns only the keys that
+# matched, and the named-binding form must leave the other target empty.
+{
+    my (:@now, :@future) := (1, 2, 3).classify({ 'now' });
+    is-deeply @now.List, (1, 2, 3), 'classify: the matched key binds its list';
+    is-deeply @future.List, (), 'classify: the absent key binds empty';
+}
+
+# List ASSIGNMENT (`=`) keeps its greedy semantics: the FIRST @ slurps.
+{
+    my ($a, @b, $c) = 1, 2, 3, 4;
+    is-deeply ($a, @b.List, $c), (1, (2, 3, 4), Any),
+        'list assignment is still greedy at the first @ target';
+}
+
+# vim: expandtab shiftwidth=4


### PR DESCRIPTION
In a signature **binding** (`my (...) := ...`) a plain `@x` binds one positional
argument; only an explicit `*@rest` is slurpy. mutsu treated a *trailing* array
target as implicitly slurpy, so the last one came back wrapped in an extra layer:

```raku
my @x = 1, 2;
my @y = 5;
my (@a, @b) := (@x, @y);
say @b.raku;    # was [[5],]  —  raku: [5]
```

Every array target *except the last* bound correctly, which made this easy to miss.

| expression | before | after / raku |
|---|---|---|
| `my (@a, @b) := (@x, @y)` → `@b` | `[[5],]` | `[5]` |
| `my (@a, @b, @c) := (@x, @y, @z)` → `@c` | `[[7, 8],]` | `[7, 8]` |
| `my (@b) := (@y,)` → `@b` | `[[5],]` | `[5]` |
| `my ($x, @y, *@r) := (42, [13, 17], 5, 6, 7)` | correct | unchanged |

The comment above the code already spelled out the correct rule and called the
slurpy branch a "historical heuristic"; the heuristic is now gone in binding mode.
List **assignment** (`=`) keeps its own, different greedy semantics — the *first*
`@`/`%` target slurps and later targets get an empty container — unchanged, and
pinned in the test.

Found while triaging `TODO_dist` ticket T-037 (Test::Scheduler), whose
`method !run-due` opens with

```raku
my (@now, @future) := $!lock.protect: {
    my (:@now, :@future) := @!future.classify: { ... }
    ...
};
```

The doubly-wrapped `@future` made the scheduler believe work was still pending, so
`advance-by` silently ran nothing.

## Test

Pin: `t/list-bind-trailing-array.t` — 11 assertions, passes under **both** mutsu
and raku. `make test` green; 212 whitelisted roast files across S03/S06/S02-lists
(24k assertions) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)