### PR TITLE
fix: six more general bugs from the HTTP::UserAgent suite

### DIFF
--- a/news/2026-07/http-useragent-suite-general-fixes-2.md
+++ b/news/2026-07/http-useragent-suite-general-fixes-2.md
@@ -1,0 +1,74 @@
+# Six more general fixes from the HTTP::UserAgent suite (19 → 23 files)
+
+The second pass over the upstream HTTP::UserAgent test suite (27 files,
+`raku-community-modules/HTTP-UserAgent` at `1d6a31a`) took it from **19 to 23 fully-passing
+files, with no file left erroring out**. As in the first pass, every fix is a general
+interpreter bug the module merely surfaced first.
+
+## `IO::Socket::INET` kept the `:port` suffix on the host
+
+`IO::Socket::INET.new(:host("localhost:8080"), :port(8080))` resolved
+`localhost:8080:8080`. mutsu split a `host:port` string only when no `:port` was passed;
+rakudo's constructor splits the host unconditionally and merely *defaults* the port from the
+suffix (`%args<port> //= $port`), so an explicit `:port` wins but the host never keeps the
+suffix. HTTP::UserAgent passes both — `$request.host` is `"localhost:8080"` while
+`$request.port` is `8080`. Pin: `t/socket-inet-host-port-split.t`.
+
+## An `is rw` method only exposed an attribute from its *first* statement
+
+An `is rw` routine returns its last expression's container, so a body that does some work
+before naming `$!attr` is still an assignable lvalue. mutsu only recognised the attribute when
+it was the body's first statement, so HTTP::Request's lazily-defaulting
+
+```raku
+multi method scheme(--> Str:D) is rw {
+    without $!scheme { … }
+    $!scheme
+}
+```
+
+threw `X::Assignment::RO: rw method 'scheme' does not expose an assignable attribute`. The
+detection now reads the *last* statement (plus any explicit `return-rw $!attr` anywhere in the
+body), which also makes `method computed is rw { $!v; 1 }` correctly non-assignable. Pin:
+`t/rw-method-trailing-attribute-lvalue.t`.
+
+## A Buf compared numerically as 0
+
+`Buf`/`Blob` is Positional, so it numifies to its element count — `+$buf` and `.Numeric`
+already agreed, but the infix numeric comparisons read an Instance as 0, so
+`Buf.new(1,2,3,4,5) == 5` was False. TestServer gates its whole response on
+`$in-buf.subbuf($header-end + 4) == $length`, so the local server never replied and the
+binary-request tests hung. Pin: `t/buf-numeric-context.t`.
+
+(Known remaining divergence: rakudo makes the *ordering* comparators throw for a Buf
+— `$buf < 6` is `Cannot resolve caller Real(Buf:D:)` — where mutsu now compares element
+counts. That is closer than the previous silent 0, and equality is what code actually uses.)
+
+## `m-meta-ok` parsed as a `m` match with a `-` delimiter
+
+A raku identifier may contain `-` and `'` when an alphabetic follows, and that beats the
+quoting constructs: `m-meta-ok` is a call to the routine `m-meta-ok`, and `q-a-b`,
+`tr-a-b-c`, `s-a-b`, `Q-a-b` likewise. mutsu accepted any non-word character as a delimiter,
+so `m-meta-ok()` became `m-meta-` plus the stray adverb `ok` ("Unsupported use of /ok").
+A `-` NOT followed by an alphabetic still *is* a delimiter, so `m-1-` keeps matching — the new
+`delim_is_identifier_continuation` helper applies exactly raku's identifier rule at every
+quote-op delimiter site (`m`/`rx`/`s`/`S`/`ss`, `tr`/`TR`, `q`/`qq`/`Q`). Pin:
+`t/quote-op-hyphen-identifier.t`.
+
+## A `CATCH` inside a BEGIN phaser did not catch a call
+
+`BEGIN { f(); CATCH { … } }` let an exception thrown *inside* `f` escape as
+`X::Comp::BeginTime` ("An exception occurred while evaluating a CHECK"); only a `die` executed
+at the phaser's own statement level was caught. The phaser body compiles inline into the
+enclosing mainline code, so the handler covered the mainline scope rather than the phaser. A
+body that declares a handler now gets its own block scope — which is also the scope raku gives
+it, since a `my` inside `BEGIN { … }` is block-scoped either way. Handler-less phasers keep
+their inline, scope-less shape. Pin: `t/begin-phaser-catch-handler.t`.
+
+## `require Test::Anything` silently succeeded
+
+`use Test::X` deliberately treats a missing module as a no-op (roast's `Test::Util` pulls in
+helpers that need not exist). `require` inherited that, so `require Test::META <&meta-ok>`
+reported `X::Import::MissingSymbols` instead of the `X::CompUnit::UnsatisfiedDependency` its
+callers catch to skip themselves. The swallow is now scoped to `use`: `require` propagates the
+missing-module failure. Same pin as above.

--- a/src/compiler/helpers_phasers.rs
+++ b/src/compiler/helpers_phasers.rs
@@ -5,8 +5,24 @@ impl Compiler {
     /// If the body throws, the error is wrapped in X::Comp::BeginTime.
     pub(super) fn compile_check_phaser(&mut self, body: &[Stmt]) {
         let start_idx = self.code.emit(OpCode::CheckPhaserStart { end_ip: 0 });
-        for s in body {
-            self.compile_stmt(s);
+        // A `CATCH` in the phaser body handles that body's exceptions, including
+        // ones thrown from a call inside it. Compiled inline into the enclosing
+        // (mainline) code, the handler covered only a `die` executed at this
+        // statement level — an exception unwinding out of a call escaped it and
+        // surfaced as `X::Comp::BeginTime`. Giving the body its own block scope
+        // installs the handler over the whole phaser, which is also the scope
+        // raku gives it (a `my` inside `BEGIN { … }` is block-scoped either
+        // way). Only done when a handler is present, so the common phaser keeps
+        // its inline, scope-less shape.
+        let has_handler = body
+            .iter()
+            .any(|s| matches!(s, Stmt::Catch(_) | Stmt::Control(_)));
+        if has_handler {
+            self.compile_stmt(&Stmt::Block(body.to_vec()));
+        } else {
+            for s in body {
+                self.compile_stmt(s);
+            }
         }
         self.code.emit(OpCode::CheckPhaserEnd);
         // Patch the end_ip to point to after the CheckPhaserEnd

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -852,3 +852,22 @@ mod tests {
         assert_eq!(words, vec!["a\u{00A0}b"]);
     }
 }
+
+/// Whether `spec` (the text starting at a quoting construct's would-be opening
+/// delimiter) is really the tail of an *identifier*, not a delimiter.
+///
+/// A raku identifier may contain `-` and `'` when the next character is
+/// alphabetic or `_`, and the quoting constructs lose to that rule: `m-meta-ok`
+/// is a call to the routine `m-meta-ok` (raku), never `m` with a `-` delimiter,
+/// while `m-1-` IS a match (a digit cannot continue an identifier). Same for
+/// `q-a-b`, `tr-a-b-c`, `s'x'y'`, ...
+pub(crate) fn delim_is_identifier_continuation(spec: &str) -> bool {
+    let mut chars = spec.chars();
+    let Some(open) = chars.next() else {
+        return false;
+    };
+    if open != '-' && open != '\'' {
+        return false;
+    }
+    chars.next().is_some_and(|c| c.is_alphabetic() || c == '_')
+}

--- a/src/parser/primary/regex/lit.rs
+++ b/src/parser/primary/regex/lit.rs
@@ -10,7 +10,9 @@
 
 use crate::ast::Expr;
 use crate::parser::expr::expression;
-use crate::parser::helpers::{consume_unspace, split_angle_words, ws};
+use crate::parser::helpers::{
+    consume_unspace, delim_is_identifier_continuation, split_angle_words, ws,
+};
 use crate::parser::parse_result::{PError, PResult, parse_char, parse_tag, take_while1};
 use crate::symbol::Symbol;
 use crate::token_kind::TokenKind;
@@ -145,7 +147,8 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
             && open_ch != '_'
             && open_ch != ':'
             && !open_ch.is_whitespace()
-            && (open_ch != '(' || had_ws);
+            && (open_ch != '(' || had_ws)
+            && !delim_is_identifier_continuation(spec);
         // Don't treat `rx.method` as a regex with a `.` delimiter when the `.`
         // is followed by an identifier (a method call on a bare `rx`).
         let looks_like_method = open_ch == '.'
@@ -290,7 +293,8 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
             let is_delim = !open_ch.is_alphanumeric()
                 && open_ch != '_'
                 && !open_ch.is_whitespace()
-                && (open_ch != '(' || had_ws);
+                && (open_ch != '(' || had_ws)
+                && !delim_is_identifier_continuation(spec);
             let looks_like_method = open_ch == '.'
                 && spec.len() > 2
                 && spec[1..].starts_with(|c: char| c.is_alphabetic() || c == '_')
@@ -412,7 +416,8 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
             let is_delim = !open_ch.is_alphanumeric()
                 && open_ch != '_'
                 && !open_ch.is_whitespace()
-                && (open_ch != '(' || had_ws);
+                && (open_ch != '(' || had_ws)
+                && !delim_is_identifier_continuation(spec);
             // Don't treat s.identifier as substitution when the identifier is 2+ chars
             // (likely a method call on bare 's'). Single-char like s.a.b. is still valid regex.
             let looks_like_method = open_ch == '.'
@@ -618,7 +623,8 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
             let is_delim = !open_ch.is_alphanumeric()
                 && open_ch != '_'
                 && !open_ch.is_whitespace()
-                && (open_ch != '(' || had_ws);
+                && (open_ch != '(' || had_ws)
+                && !delim_is_identifier_continuation(spec);
             let looks_like_method = open_ch == '.'
                 && spec.len() > 2
                 && spec[1..].starts_with(|c: char| c.is_alphabetic() || c == '_')
@@ -913,7 +919,8 @@ pub(in crate::parser) fn regex_lit(input: &str) -> PResult<'_, Expr> {
             let is_delim = !open_ch.is_alphanumeric()
                 && open_ch != '_'
                 && !open_ch.is_whitespace()
-                && (open_ch != '(' || had_ws);
+                && (open_ch != '(' || had_ws)
+                && !delim_is_identifier_continuation(spec);
             if is_delim {
                 let (close_ch, is_paired) = match open_ch {
                     '{' => ('}', true),

--- a/src/parser/primary/regex/trans.rs
+++ b/src/parser/primary/regex/trans.rs
@@ -56,7 +56,12 @@ pub(super) fn parse_trans_adverbs(
     let open_ch = rest.chars().next()?;
     // `(` directly after `tr`/`TR` (or its adverbs) is call syntax, never a
     // delimiter — Raku requires whitespace before a paren delimiter.
-    if open_ch.is_alphanumeric() || open_ch == '_' || open_ch.is_whitespace() || open_ch == '(' {
+    if open_ch.is_alphanumeric()
+        || open_ch == '_'
+        || open_ch.is_whitespace()
+        || open_ch == '('
+        || crate::parser::helpers::delim_is_identifier_continuation(rest)
+    {
         return None;
     }
     let (close_ch, is_paired) = match open_ch {

--- a/src/parser/primary/string/q_string.rs
+++ b/src/parser/primary/string/q_string.rs
@@ -38,6 +38,11 @@ pub(crate) fn big_q_string(input: &str) -> PResult<'_, Expr> {
         return Err(PError::expected("Q string"));
     }
 
+    // `Q-a-b` is the routine `Q-a-b` — see the `q` parser below.
+    if crate::parser::helpers::delim_is_identifier_continuation(rest) {
+        return Err(PError::expected("Q string"));
+    }
+
     if let Some((open, close)) = quote_delimiters(rest) {
         flags.quote_open = Some(open);
         flags.quote_close = Some(close);
@@ -231,6 +236,12 @@ pub(crate) fn q_string(input: &str) -> PResult<'_, Expr> {
     // `q => ...` is the pair key `q`, not a `q`-quote with `=` as its delimiter.
     // (rakudo accepts `=` as a delimiter for `q=foo=`, but `=>` is a fat arrow.)
     if trimmed_after_q.starts_with("=>") {
+        return Err(PError::expected("q string"));
+    }
+
+    // `q-a-b` is the routine `q-a-b`, not `q` with a `-` delimiter: `-`/`'`
+    // continue an identifier when an alphabetic follows.
+    if crate::parser::helpers::delim_is_identifier_continuation(after_q) {
         return Err(PError::expected("q string"));
     }
 

--- a/src/runtime/builtins_operators_coerce.rs
+++ b/src/runtime/builtins_operators_coerce.rs
@@ -23,6 +23,13 @@ impl Interpreter {
         if !matches!(value.view(), ValueView::Instance { .. }) {
             return Ok(value);
         }
+        // A Buf/Blob is Positional too, so it numifies to its element count in
+        // exactly the same way: `Buf.new(1,2,3,4,5) == 5` is True (rakudo), and
+        // `+$buf` already agrees. TestServer's
+        // `if $in-buf.subbuf($header-end + 4) == $length` relies on it.
+        if Self::is_buf_value(&value) {
+            return Ok(Value::int(Self::extract_buf_bytes(&value).len() as i64));
+        }
         // Unhandled Failure: throw the stored exception.
         if let Some(err) = self.failure_to_runtime_error_if_unhandled(&value) {
             return Err(err);

--- a/src/runtime/builtins_system_require.rs
+++ b/src/runtime/builtins_system_require.rs
@@ -485,7 +485,10 @@ impl Interpreter {
             {
                 self.loaded_modules.remove(module);
             }
-            self.use_module(module)?;
+            let saved = std::mem::replace(&mut self.require_propagates_missing_module, true);
+            let result = self.use_module(module);
+            self.require_propagates_missing_module = saved;
+            result?;
         } else {
             return Err(RuntimeError::new("require expects a module name"));
         }

--- a/src/runtime/methods_collection_ops/socket_inet_proc.rs
+++ b/src/runtime/methods_collection_ops/socket_inet_proc.rs
@@ -75,18 +75,28 @@ impl Interpreter {
             }
         }
 
-        if !host.is_empty() && port == 0 {
+        // A `host:port` string is ALWAYS split, even when `:port` is also given
+        // — rakudo's `IO::Socket::INET.new` splits the host and only defaults
+        // the port from it (`%args<port> //= $port`), so an explicit `:port`
+        // wins but the host never keeps its `:port` suffix. HTTP::UserAgent
+        // passes both (`$request.host` is "localhost:8080" and `$request.port`
+        // is 8080), which used to be resolved as "localhost:8080:8080".
+        if !host.is_empty() {
             let (parsed_host, parsed_port) = Self::split_host_port_literal(&host);
             if let Some(p) = parsed_port {
                 host = parsed_host;
-                port = p;
+                if port == 0 {
+                    port = p;
+                }
             }
         }
-        if !localhost.is_empty() && localport == 0 {
+        if !localhost.is_empty() {
             let (parsed_host, parsed_port) = Self::split_host_port_literal(&localhost);
             if let Some(p) = parsed_port {
                 localhost = parsed_host;
-                localport = p;
+                if localport == 0 {
+                    localport = p;
+                }
             }
         }
 

--- a/src/runtime/methods_mut_rw_attr.rs
+++ b/src/runtime/methods_mut_rw_attr.rs
@@ -12,8 +12,20 @@ impl Interpreter {
         }
     }
 
+    /// The attribute an `is rw` method exposes as its assignable lvalue: the
+    /// bare `$!attr` (or `return-rw $!attr`) its body evaluates to.
+    ///
+    /// An `is rw` routine returns its *last* expression's container, so the
+    /// last statement is what decides — the earlier ones are ordinary code that
+    /// still has to run (HTTP::Request's
+    /// `multi method scheme(--> Str:D) is rw { without $!scheme { … }; $!scheme }`
+    /// lazily defaults the attribute before exposing it). Every caller invokes
+    /// the method anyway to read its current value, so those side effects
+    /// happen. An explicit `return-rw $!attr` anywhere in the body also counts:
+    /// it decides the return value wherever it sits.
     pub(crate) fn rw_method_attribute_target(body: &[Stmt]) -> Option<String> {
-        let first = body.iter().find(|s| !matches!(s, Stmt::SetLine(_)))?;
+        let significant = || body.iter().filter(|s| !matches!(s, Stmt::SetLine(_)));
+        let last = significant().next_back()?;
         let extract_attr = |expr: &Expr| -> Option<String> {
             match expr {
                 Expr::Var(name) if name.starts_with('!') && name.len() > 1 => {
@@ -31,10 +43,15 @@ impl Interpreter {
                 _ => None,
             }
         };
-        match first {
+        let attr_of = |stmt: &Stmt| match stmt {
             Stmt::Expr(expr) | Stmt::Return(expr) => extract_attr(expr),
             _ => None,
-        }
+        };
+        attr_of(last).or_else(|| {
+            significant()
+                .find(|s| Self::stmt_contains_return_rw_call(s))
+                .and_then(attr_of)
+        })
     }
 
     /// Detect an `is rw` method whose body returns an *indexed* attribute

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -811,6 +811,10 @@ pub struct Interpreter {
     /// `X::Attribute::NoPackage`.
     pub(crate) defining_class: Option<String>,
     pending_call_arg_sources: Option<Vec<Option<String>>>,
+    /// Set while `require` resolves a module: a missing `Test::`-namespace
+    /// module must surface as a catchable X::CompUnit::UnsatisfiedDependency
+    /// instead of the silent no-op `use Test::Util` relies on.
+    pub(crate) require_propagates_missing_module: bool,
     /// Companion to `pending_call_arg_sources` (§1.4/§1.5): the compiler-baked
     /// `arg-source name -> caller local slot` for the current call, decoded from the
     /// `Pair(name, Int(slot))` arg-source entries. Set alongside the names by

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -1827,6 +1827,7 @@ impl Interpreter {
             constructing_class: None,
             defining_class: None,
             pending_call_arg_sources: None,
+            require_propagates_missing_module: false,
             pending_call_arg_source_slots: std::collections::HashMap::new(),
             pending_rw_writeback_slots: std::collections::HashMap::new(),
             test_pending_callsite_line: None,

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -217,10 +217,13 @@ impl Interpreter {
         } else if module == "Test::Tap" {
             // Handle Test::Tap as built-in
             Ok(())
-        } else if module.starts_with("Test::") {
+        } else if module.starts_with("Test::") && !self.require_propagates_missing_module {
             // Load Test:: submodules from source as regular modules.
             // Parse errors should propagate like other `use` failures.
-            // Missing helper modules remain non-fatal for compatibility.
+            // Missing helper modules remain non-fatal for compatibility —
+            // except under `require`, whose whole contract is that a missing
+            // module is a catchable X::CompUnit::UnsatisfiedDependency
+            // (HTTP::UserAgent's `t/001-meta` skips itself that way).
             match self.load_module(module) {
                 Ok(()) => Ok(()),
                 Err(err) if err.is_unsatisfied_dependency() => Ok(()),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -194,6 +194,7 @@ impl Interpreter {
             constructing_class: None,
             defining_class: None,
             pending_call_arg_sources: None,
+            require_propagates_missing_module: false,
             pending_call_arg_source_slots: std::collections::HashMap::new(),
             pending_rw_writeback_slots: std::collections::HashMap::new(),
             test_pending_callsite_line: None,

--- a/t/begin-phaser-catch-handler.t
+++ b/t/begin-phaser-catch-handler.t
@@ -1,0 +1,48 @@
+use v6;
+use Test;
+
+plan 5;
+
+# A `CATCH` inside a BEGIN phaser handles that phaser's exceptions, including
+# ones thrown out of a *call* inside it. Compiled inline into the mainline, the
+# handler only covered a `die` at its own statement level, and anything
+# unwinding from a call escaped as X::Comp::BeginTime.
+# (HTTP::UserAgent's t/001-meta skips itself via exactly this shape.)
+
+my @seen;
+
+BEGIN {
+    sub boom { die "from a call" }
+    boom();
+    CATCH { default { @seen.push: "begin-call:" ~ .message } }
+}
+is @seen[0], 'begin-call:from a call', 'CATCH in BEGIN catches a call that dies';
+
+BEGIN {
+    die "direct";
+    CATCH { default { @seen.push: "begin-direct:" ~ .message } }
+}
+is @seen[1], 'begin-direct:direct', 'CATCH in BEGIN catches a direct die';
+
+# A phaser with no handler still runs, and its declarations still reach the
+# enclosing scope.
+BEGIN { @seen.push: 'plain' }
+is @seen[2], 'plain', 'a handler-less BEGIN is unchanged';
+
+# `require` of a missing module is a catchable X::CompUnit::UnsatisfiedDependency
+# — including in the `Test::` namespace, where a missing module is otherwise a
+# deliberate no-op for `use`.
+my $required-error;
+BEGIN {
+    require Test::DefinitelyNotInstalled;
+    CATCH { default { $required-error = .^name } }
+}
+is $required-error, 'X::CompUnit::UnsatisfiedDependency',
+    'a missing require inside BEGIN is catchable';
+
+my $req2;
+try {
+    require Zork::AlsoNotInstalled;
+    CATCH { default { $req2 = .^name } }
+}
+is $req2, 'X::CompUnit::UnsatisfiedDependency', 'and at runtime too';

--- a/t/buf-numeric-context.t
+++ b/t/buf-numeric-context.t
@@ -1,0 +1,22 @@
+use v6;
+use Test;
+
+plan 6;
+
+# A Buf/Blob is Positional, so it numifies to its element count — `+$buf` and
+# `.Numeric` already agreed; the infix numeric comparisons did not, and read it
+# as 0. (HTTP-UserAgent's TestServer gates its response on
+# `$in-buf.subbuf($header-end + 4) == $length`.)
+
+my $b = Buf.new(1, 2, 3, 4, 5);
+
+is +$b, 5, 'prefix + gives the element count';
+is $b.Numeric, 5, '.Numeric gives the element count';
+ok $b == 5, 'infix == compares the element count';
+nok $b == 4, 'and is False for a different count';
+
+my $blob = Blob.new(9, 9);
+ok $blob == 2, 'a Blob numifies the same way';
+
+my $empty = Buf.new;
+ok $empty == 0, 'an empty Buf numifies to 0';

--- a/t/quote-op-hyphen-identifier.t
+++ b/t/quote-op-hyphen-identifier.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+
+plan 12;
+
+# A raku identifier may contain `-` (and `'`) when an alphabetic follows, and
+# that beats the quoting constructs: `m-meta-ok` is a call to the routine
+# `m-meta-ok`, never `m` with a `-` delimiter. HTTP::UserAgent's `t/001-meta`
+# declares `my &m-meta-ok`.
+
+sub m-meta-ok { "m" }
+sub s-a-b { "s" }
+sub q-a-b { "q" }
+sub qq-a-b { "qq" }
+sub Q-a-b { "Q" }
+sub tr-a-b-c { "tr" }
+sub rx-a-b { "rx" }
+
+is m-meta-ok(), "m", 'm-meta-ok is a routine call';
+is s-a-b(), "s", 's-a-b is a routine call';
+is q-a-b(), "q", 'q-a-b is a routine call';
+is qq-a-b(), "qq", 'qq-a-b is a routine call';
+is Q-a-b(), "Q", 'Q-a-b is a routine call';
+is tr-a-b-c(), "tr", 'tr-a-b-c is a routine call';
+is rx-a-b(), "rx", 'rx-a-b is a routine call';
+
+# A `-` NOT followed by an alphabetic cannot continue an identifier, so it is
+# still a usable delimiter.
+is ~("x1x" ~~ m-1-), "1", 'm-1- is still a match with a - delimiter';
+is q-1-, "1", 'q-1- is still a q-string';
+
+# The ordinary delimiters keep working.
+is ~("xax" ~~ m/a/), "a", 'm// still works';
+is q/hi/, "hi", 'q// still works';
+my $t = "abc";
+$t ~~ tr/a/z/;
+is $t, "zbc", 'tr/// still works';

--- a/t/rw-method-trailing-attribute-lvalue.t
+++ b/t/rw-method-trailing-attribute-lvalue.t
@@ -1,0 +1,45 @@
+use v6;
+use Test;
+
+plan 5;
+
+# An `is rw` routine returns its LAST expression's container, so a body that
+# does some work before exposing `$!attr` is still an assignable lvalue.
+# (HTTP::Request lazily defaults its scheme this way:
+#  `multi method scheme(--> Str:D) is rw { without $!scheme { … }; $!scheme }`)
+
+class Lazy {
+    has Str $!scheme;
+    has Int $.defaulted = 0;
+    method scheme(--> Str:D) is rw {
+        without $!scheme {
+            $!defaulted++;
+            $!scheme = 'http';
+        }
+        $!scheme
+    }
+}
+
+my $l = Lazy.new;
+is $l.scheme, 'http', 'the lazy default is applied on read';
+is $l.defaulted, 1, 'and the leading statements ran';
+
+$l.scheme = 'https';
+is $l.scheme, 'https', 'assigning through the rw method stores into the attribute';
+
+# The single-statement form keeps working.
+class Simple {
+    has $!v;
+    method v is rw { $!v }
+}
+my $s = Simple.new;
+$s.v = 42;
+is $s.v, 42, 'a one-statement rw method is still an lvalue';
+
+# A body that does NOT end in an attribute is still not assignable.
+class NoAttr {
+    has $!v;
+    method computed is rw { $!v; 1 }
+}
+dies-ok { NoAttr.new.computed = 5 },
+    'an rw method whose body ends in a non-attribute is not assignable';

--- a/t/socket-inet-host-port-split.t
+++ b/t/socket-inet-host-port-split.t
@@ -1,0 +1,27 @@
+use v6;
+use Test;
+
+plan 4;
+
+# `IO::Socket::INET.new(:host("h:p"))` always splits the host, even when an
+# explicit `:port` is also given — rakudo's constructor splits first and only
+# *defaults* the port from the suffix (`%args<port> //= $port`). Passing both is
+# what HTTP::UserAgent does (`$request.host` is "localhost:8080" while
+# `$request.port` is 8080), which was resolved as "localhost:8080:8080".
+
+# A listener on port 0 gets an OS-assigned port; ask it what it got.
+my $server = IO::Socket::INET.new(:localhost('127.0.0.1'), :localport(0), :listen);
+my $port = $server.localport;
+ok $port > 0, 'listener got an ephemeral port';
+
+my $accepted = start { $server.accept };
+
+my $client = IO::Socket::INET.new(:host("127.0.0.1:$port"), :port($port));
+is $client.host, '127.0.0.1', 'the host:port suffix is stripped from the host';
+is $client.port, $port, 'the explicit port is kept';
+$client.close;
+
+my $conn = await $accepted;
+ok $conn.defined, 'the connection reached the listener';
+$conn.close;
+$server.close;


### PR DESCRIPTION
Second pass over the upstream [HTTP::UserAgent](https://github.com/raku-community-modules/HTTP-UserAgent) test suite (27 files, pinned at `1d6a31a`), following #5391. The suite goes from **19 to 23 fully-passing files, with no file left erroring out** (17 at the start of the campaign).

Every fix is a general interpreter bug the module merely surfaced first. Details in `news/2026-07/http-useragent-suite-general-fixes-2.md`.

| Fix | Symptom | Pin |
| --- | --- | --- |
| `IO::Socket::INET` kept the `:port` suffix on the host when an explicit `:port` was also given (rakudo always splits the host and only *defaults* the port from it) | `localhost:8080:8080` — every request to a non-default port | `t/socket-inet-host-port-split.t` |
| An `is rw` method only exposed an attribute named by its **first** statement, but an `is rw` routine returns its **last** expression's container | HTTP::Request's lazily-defaulting `method scheme is rw { without $!scheme { … }; $!scheme }` threw `X::Assignment::RO` | `t/rw-method-trailing-attribute-lvalue.t` |
| A Buf compared numerically as 0 instead of its element count (`+$buf` already gave 5) | `Buf.new(1,2,3,4,5) == 5` was False, so the test HTTP server never replied and the binary-request tests hung | `t/buf-numeric-context.t` |
| A `-`/`'` followed by an alphabetic continues a raku identifier and beats every quoting construct; mutsu took any non-word char as a delimiter | `m-meta-ok()` became `m-meta-` + a stray `ok` adverb ("Unsupported use of /ok"); same for `q-a-b`, `tr-a-b-c`, `s-a-b`, `Q-a-b`. `m-1-` is still a match. | `t/quote-op-hyphen-identifier.t` |
| A `CATCH` inside a BEGIN phaser did not catch an exception thrown from a *call* inside it — the inline-compiled handler covered the mainline scope, not the phaser | anything unwinding from a call escaped as `X::Comp::BeginTime` | `t/begin-phaser-catch-handler.t` |
| `require Test::Anything` inherited `use Test::X`'s deliberate missing-module no-op | never raised the catchable `X::CompUnit::UnsatisfiedDependency` that callers use to skip themselves | same |

Known remaining divergence, called out in the news entry: rakudo makes the *ordering* comparators throw for a Buf (`$buf < 6` is `Cannot resolve caller Real(Buf:D:)`) where mutsu now compares element counts. That is closer than the previous silent 0, and equality is what real code uses.

`make test` passes locally (2435 files, 23219 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)