### PR TITLE
docs: record the BUILD-vs-attribute-default ordering bug (PLAN §8.21, T-037)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1483,6 +1483,81 @@ token path-part:sym<matcher> {
   the module builds a *wrong* pattern string (`'a'` missing its trailing ` '/'`)
   because the `a` segment's action wrongly sees `$*FINAL = True`.
 
+### 8.21 `has` attribute defaults are applied BEFORE `submethod BUILD`, not after (found 2026-07-25, Test::Scheduler)
+
+Rakudo runs a user `submethod BUILD` **first**, and only then applies a
+`has $.x = <default>` initializer — and only for attributes BUILD did **not**
+set. mutsu does the opposite: it evaluates every default first, then runs BUILD.
+Two things follow, both observable:
+
+1. a default that references a sibling attribute reads the sibling's *pre-BUILD*
+   value instead of the value BUILD gave it;
+2. a default whose initializer has a side effect runs even when BUILD sets the
+   attribute (Rakudo skips it entirely).
+
+- **Minimal repro (ordering):**
+  ```raku
+  class C {
+      has $.a = say("default-a") // 1;
+      has $.b = say("default-b") // 2;
+      submethod BUILD(:$!a = say("build-a") // 9) { say "BUILD body" }
+  }
+  C.new;
+  # raku:  build-a / BUILD body / default-b        (default-a never runs)
+  # mutsu: default-a / default-b / build-a / BUILD body
+  ```
+- **Minimal repro (sibling read — the shape that bites):**
+  ```raku
+  class D {
+      has $.x = now;
+      has $!y = $!x;
+      submethod BUILD(:$!x = now) { }
+      method show { say $!x == $!y }
+  }
+  D.new.show;    # raku: True    mutsu: False (y is ~2ms earlier than x)
+  ```
+- **Impact:** `Test::Scheduler` (`TODO_dist` T-037). Its
+  `has $!virtual-target = $!virtual-time;` ends up a fraction of a second behind
+  `$!virtual-time`, so `advance-by($n)` computes a target *earlier* than the
+  events it should fire; `!run-due` classifies every event as `future` and
+  silently runs nothing. `t/virtualized-time.rakutest` then hangs on the first
+  `await`. Any dist using the very common `has $!b = $!a;` + `submethod BUILD`
+  pattern is affected.
+- **Why this is not a small fix (ADR-worthy):**
+  - There are **three independent construction paths**, each with its own
+    "evaluate all defaults, then run BUILD" loop, that must move in lockstep:
+    the full `.new` default constructor
+    (`runtime/methods_object_dispatch_new.rs:1685-1888`, BUILD at `:1927`), the
+    native fast path (`runtime/methods_object_default_ctor.rs:152-282`, BUILD at
+    `:414`), and `bless` (`runtime/methods_dispatch_new.rs:341-405`, BUILD at
+    `:464`). A fourth, smaller one is the role-pun/mixin default eval
+    (`methods_object_dispatch_new.rs:375-386`, `:1263-1274`).
+  - **There is no runtime "attribute was initialized" state.** `ClassDef.attribute_built`
+    holds the `is built(...)` *trait*, not construction state, and nothing like a
+    `Value::UNINIT` sentinel exists. The post-BUILD `is required` check already
+    approximates "unset" as `Nil`-or-`Any`
+    (`methods_object_dispatch_new.rs:1957-1970`).
+  - **Slots must exist before BUILD runs.** `write_self_attr_cell` →
+    `attr_key_in_map` (`vm/vm_var_assign_computed_attr.rs:123-140`) silently drops
+    a write whose key is absent from the map, so "key missing" cannot be the
+    marker — the slots have to be pre-seeded anyway.
+  - Default initializers legitimately need `self` and earlier siblings
+    (`has $.c = $!a + $!b`, `has $.total = self.a + self.b`,
+    `roast/S12-attributes/defaults.t:84,97`), so the evaluation context has to
+    survive the move; today it is a *snapshot* `temp_self`, and after the move it
+    would be the real instance (an improvement, but an observable identity change).
+  - The `:D`/`:U`, `where`, and required-attribute enforcement points are ordered
+    around the current sequence and must be re-sequenced with it
+    (`methods_object_dispatch_new.rs:1633, 1899-1906, 1930-1980`;
+    `methods_object_default_ctor.rs:369-405, 417-455`).
+- **Proposed approach:** pre-seed every attribute slot with its current
+  type-object/`Any`/native-zero seed (as today) *and remember that seed*, run
+  BUILD, then apply each default only where the slot still holds exactly its
+  seed. `roast/S12-attributes/defaults.t:25-27` (which counts default-closure
+  invocations) is the load-bearing check that the skip is a real skip, not an
+  evaluate-then-discard. Pins to review when reordering:
+  `t/native-build-construct.t:24-30` and `:69-73`.
+
 
 ## Metrics
 

--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -323,11 +323,41 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 - file: DONE — runtime/test_functions/basic.rs (plan *); remaining — a
   Lingua::EN::Numbers cardinal-fraction bug (module logic).
 
-### T-037 — test_die: timeout  [impact: 1 dist]
-- dists: Test::Scheduler
+### T-037 — test_die: timeout  [impact: 1 dist]  — TWO ROOT CAUSES FIXED (#5395, #5396); blocked on PLAN §8.21
+- dists: Test::Scheduler (raku passes all three files; `t/virtualized-time.rakutest` 83/83)
 - e.g. `Test::Scheduler`: base=3 pass=1 fail=1 die=1 | t/virtualized-time.rakutest: timeout
-- repro: _(fill in a minimal repro + raku baseline before fixing)_
-- file: _(suspected parser/runtime file)_
+- The dist virtualizes time: `my $*SCHEDULER = Test::Scheduler.new` and then
+  `Promise.in(200)` must NOT resolve until `$*SCHEDULER.advance-by(200)`.
+- **Fixed #1 — `Promise.in`/`Promise.at` ignored `$*SCHEDULER` (#5395).** Raku
+  defines `Promise.in($t)` as `$*SCHEDULER.cue({...}, :in($t))`; mutsu went
+  straight to the shared deadline-heap timer, so swapping the scheduler had zero
+  effect and every timed promise resolved on real time. Both now route through a
+  *user-defined* scheduler (not ThreadPool/CurrentThread/FakeScheduler, and
+  providing `cue`); built-ins keep the direct heap path. `Promise.at` cues as
+  `:in($at - now)`, matching Rakudo. Also fixed: the composable `Scheduler` role
+  claimed a native `cue`, so every `class X does Scheduler` looked native-backed
+  and its own `method cue` was bypassed ("No native method 'cue' on 'X'").
+  Pin: `t/promise-in-honors-scheduler.t`.
+- **Fixed #2 — a trailing `@x` in a `:=` binding was slurpy (#5396).**
+  `method !run-due` binds `my (@now, @future) := $!lock.protect: { ... }`; the
+  trailing `@future` came back as `(@y,)` instead of `@y`, so the scheduler
+  believed work was still pending. Pin: `t/list-bind-trailing-array.t`.
+- **REMAINING — PLAN.md §8.21: `has` defaults are applied BEFORE `submethod
+  BUILD`, not after.** Rakudo runs BUILD first and then applies a `has` default
+  only for attributes BUILD did not set. The dist has
+  `has $.virtual-time = now; has $!virtual-target = $!virtual-time;` plus
+  `submethod BUILD(:$!virtual-time = now)`, so under mutsu's order
+  `$!virtual-target` is a couple of milliseconds *behind* `$!virtual-time`;
+  `advance-by($n)` then computes a target earlier than the events it should fire,
+  `!run-due` classifies everything as `future`, and the first `await` hangs.
+  Minimal repro + the full "why this is not a small fix" analysis (three
+  independent construction paths, no runtime "attribute was initialized" state,
+  slots must pre-exist for `$!x = ...` in BUILD to stick) are in PLAN.md §8.21.
+- **Status:** `t/not-time-based.rakutest` 3/3; `t/virtualized-time.rakutest`
+  reaches test 3 then hangs on §8.21; `t/synopsis.rakutest` 1/3.
+- file: DONE — runtime/methods_promise_class.rs, runtime_init.rs (#5395),
+  parser/stmt/decl/destructure.rs (#5396); remaining — PLAN.md §8.21
+  (object construction order; ADR-worthy)
 
 ### T-038 — test_fail: .text  [impact: 1 dist]  — FIXED (PR `fix-qqx-closure-interpolation`)
 - dists: PDF::Extract (t/01-san.rakutest 0/1 → 1/1)


### PR DESCRIPTION
Rakudo runs a user `submethod BUILD` **first**, and only then applies a
`has $.x = <default>` initializer — and only for attributes BUILD did **not** set.
mutsu does the opposite: it evaluates every default first, then runs BUILD.

```raku
class C {
    has $.a = say("default-a") // 1;
    has $.b = say("default-b") // 2;
    submethod BUILD(:$!a = say("build-a") // 9) { say "BUILD body" }
}
C.new;
# raku:  build-a / BUILD body / default-b        (default-a never runs)
# mutsu: default-a / default-b / build-a / BUILD body
```

Two observable consequences: a default that references a sibling attribute reads
the sibling's *pre-BUILD* value, and a default with a side effect runs even when
BUILD sets the attribute.

This is what still hangs `Test::Scheduler` (`TODO_dist` T-037): its
`has $!virtual-target = $!virtual-time;` ends up milliseconds *behind*
`$!virtual-time`, so `advance-by($n)` computes a target earlier than the events it
should fire, `!run-due` classifies everything as `future`, and the first `await`
never returns.

## Why this is recorded and not fixed here

- **Three independent construction paths** each carry their own "evaluate all
  defaults, then run BUILD" loop and must move in lockstep (full `.new`, the
  native fast path, and `bless`) — plus the role-pun/mixin default eval.
- **There is no runtime "attribute was initialized" state.** `ClassDef.attribute_built`
  holds the `is built(...)` *trait*, not construction state, and no `UNINIT`
  sentinel exists.
- **Slots must pre-exist for a `$!x = ...` inside BUILD to stick**
  (`attr_key_in_map` silently drops a write for an absent key), so "key missing"
  cannot be the marker either.
- Default initializers legitimately need `self` and earlier siblings, and the
  `:D`/`where`/required enforcement points are sequenced around the current order.

PLAN.md §8.21 carries both minimal repros, the full file:line map of every site
that has to move, and the proposed seed-and-compare approach (plus the roast test
that pins "the skip must be a real skip, not evaluate-then-discard").

T-037 is also updated with the two root causes already fixed along the way —
#5395 (`Promise.in`/`Promise.at` honor a user `$*SCHEDULER`) and #5396 (a trailing
`@x` in a `:=` binding is not slurpy).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)