### PR TITLE
fix: await deeply-nested promises and preserve react sibling-grep emit order

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1374,36 +1374,6 @@ and `[Z]`-reduction-returns-a-Seq landed 2026-07-22 (pin `t/repr-residues-2.t`);
       arguably more useful, and no roast test exercises them. Matching Rakudo here is risky and
       low value; **deferred as an intentional divergence** unless a dist-compat consumer needs it.
 
-### 8.19 Two intermittent concurrency bugs surfaced by the CI flake survey (found 2026-07-24)
-
-Mining the CI history (`scripts/ci-flake-survey.sh`) to build the flaky
-quarantine turned up two tests that fail intermittently on a tree that had just
-passed CI — and that `raku` runs deterministically-correct, so they are real
-mutsu races, not statistical noise. Neither is quarantined (quarantine is for
-by-design non-determinism only); both are recorded here to fix.
-
-- **`roast/S17-promise/nonblocking-await.t` test 28 — `await` in sink context on
-  nested iterables drops a promise.** `await (((p(),(p(),(p(),))),(p(),p(),p())),
-  (p(),p(),p()))` with nine `start { $x⚛++ }` promises should leave `$x == 9`;
-  under load it intermittently reads 8 (repro ~2/20 with `-l 6`, and the isolated
-  nested-iterable shape in `tmp/atomic-vs-await.raku` reproduced 7 once). `raku`
-  is 10/10 correct. The flat `await @nine` form never drops, so the bug is in how
-  `builtin_await` (`src/runtime/builtins_system_async.rs:258`) recurses into a
-  *nested* list argument: it only descends one `ValueView::Array` level
-  (`:331`), so promises nested deeper than one list are pushed as raw values and
-  never `.wait()`ed — the increment they carry may not have landed when `await`
-  returns. Fix: normalize/await recursively through arbitrarily-nested list
-  structure, not just the top array.
-- **`t/supply-live-grep-map-react-order.t` test 5 — sibling `grep` whenevers
-  interleave out of emit order.** Two `whenever $s.grep(...)` in one `react`
-  should deliver in global emit order (`p1,n-1,p2,n-2,p3,n-3`); under load mutsu
-  intermittently batches per-supply (`p1,p2,p3,n-1,n-2,n-3`). `raku` is 10/10
-  correct. Repro ~1/20 with `-l 6`. The react drive loop delivers a derived
-  (`grep`) supply's queued values as a batch rather than merging sibling derived
-  supplies into one emit-ordered stream. This is the same drive-loop ordering
-  area as the fixed `S17-supply/batch.t` period-anchor bug; see
-  `docs/s17-scheduler-supply-drive-model.md`.
-
 ### 8.18 The WebAssembly build traps on `start` / `Channel` instead of degrading (found 2026-07-23 building the tutorial site)
 
 `start { ... }` reaches `spawn_callable_promise` → `spawn_user_thread` → `std::thread::spawn`

--- a/news/2026-07/await-nested-iterable-drops-promise.md
+++ b/news/2026-07/await-nested-iterable-drops-promise.md
@@ -1,0 +1,30 @@
+# `await` on deeply-nested iterables no longer drops a Promise
+
+`await` must suspend for *every* Promise it is handed, no matter how deeply that
+Promise is nested inside list literals. The sink-context form
+
+```raku
+my atomicint $x;
+sub p { start { sleep .3; $x⚛++ } }
+await (((p(), (p(), (p(),))), (p(), p(), p())), (p(), p(), p()));
+is-deeply $x, 9, '&await awaits in sink context, with nested iterables';
+```
+
+(from `roast/S17-promise/nonblocking-await.t` test 28) intermittently read
+`$x < 9` under load: `builtin_await` descended only two list levels, so a
+Promise nested three or more lists deep was pushed through as a raw value and
+never `.wait()`ed — the increment it carried had not necessarily landed when
+`await` returned. `raku` is deterministically correct; the flat `await @nine`
+form never dropped, which localized the bug to the nested-argument walk.
+
+The fix replaces the two hand-unrolled list levels in `builtin_await`
+(`src/runtime/builtins_system_async.rs`) with `await_collect_targets`, a
+recursive descent that flattens arbitrarily-nested list structure into a flat
+list of leaf targets (normalizing each `Supply` to its `.Promise`). A
+Promise/Channel is treated as a leaf and never descended, and non-list scalar
+values pass through unchanged, so the result-list and Slip-flattening semantics
+are preserved.
+
+A deterministic reproduction — a slow Promise nested three list-levels deep
+awaited alongside an instant one — went from `1` to the correct `2`. Pinned by
+`t/await-nested-iterable.t`.

--- a/news/2026-07/react-sibling-grep-emit-order.md
+++ b/news/2026-07/react-sibling-grep-emit-order.md
@@ -1,0 +1,49 @@
+# Sibling `whenever $s.grep(...)` supplies now replay buffered values in emit order
+
+Two sibling `whenever $s.grep(...)` in one `react` must deliver in global emit
+order:
+
+```raku
+my @out;
+my $inputs = Supplier::Preserving.new;
+my $s = $inputs.Supply;
+react {
+    whenever $s.grep(* > 0) { @out.push: "p$_" }
+    whenever $s.grep(* < 0) { @out.push: "n$_" }
+    whenever start {
+        for 1..3 { $inputs.emit($_); $inputs.emit(-$_) }
+    } { done }
+}
+# expected: p1,n-1,p2,n-2,p3,n-3
+```
+
+Under load mutsu intermittently produced the per-supply-batched
+`p1,p2,p3,n-1,n-2,n-3` instead (`t/supply-live-grep-map-react-order.t` test 5).
+
+## Root cause
+
+Each `$s.grep(...)` builds a distinct live *derived* supplier that buffers its
+filtered values in the process-global supplier registry. The react drive loop
+registers a push sink on each derived supplier and drains one shared,
+emit-ordered waker queue — but the sinks were registered one at a time, and
+`supplier_sink_register` replays *one* supplier's whole buffer before the next
+subscribes. That is only observable when the `whenever start { emit … }`
+producer thread races ahead of the drive loop's sink registration and buffers
+values before the sinks exist: at registration the positive supplier already
+holds `[1, 2, 3]` and the negative `[-1, -2, -3]`, so replaying them
+supplier-by-supplier yields `p1,p2,p3,n-1,n-2,n-3`, losing the interleave. A
+20 ms delay injected before sink registration reproduced it 5/5.
+
+## Fix
+
+Every `supplier_emit`/`supplier_done`/`supplier_quit` now stamps the event with
+a process-global monotonic sequence number (parallel `emitted_seq` vector plus a
+`terminal_seq`). A new `supplier_sinks_register_batch` registers all of a
+react's supplier sinks under a single registry-lock acquisition, collects each
+supplier's buffered events with their sequence stamps, and replays the combined
+set **sorted by sequence** — so sibling derived supplies interleave in true emit
+order. Future live emits (pushed after registration) are naturally later. The
+single-sink callers keep using `supplier_sink_register` unchanged.
+
+With the fix the forced-race reproduction is `p1,n-1,p2,n-2,p3,n-3` 5/5. Pinned
+by `t/supply-live-grep-map-react-order.t` test 5.

--- a/src/runtime/builtins_system_async.rs
+++ b/src/runtime/builtins_system_async.rs
@@ -255,6 +255,33 @@ impl Interpreter {
         Ok(v)
     }
 
+    /// Recursively descend through arbitrarily-nested list structure, collecting
+    /// each leaf as a normalized await target. `await` must wait on *every*
+    /// Promise no matter how deeply it is nested inside list literals — the old
+    /// code only descended two list levels, so promises nested deeper (e.g.
+    /// `await (((p(), (p(), (p(),))), ...), ...)`) were pushed as raw values and
+    /// never `.wait()`ed, intermittently returning before their side effects
+    /// landed (S17-promise/nonblocking-await.t test 28). A Promise/Channel is a
+    /// leaf even if some list helper could peek inside it, so it is never
+    /// descended.
+    fn await_collect_targets(
+        &mut self,
+        v: Value,
+        out: &mut Vec<Value>,
+    ) -> Result<(), RuntimeError> {
+        if !matches!(v.view(), ValueView::Promise(_) | ValueView::Channel(_))
+            && let Some(items) = v.as_list_items()
+        {
+            let items: Vec<Value> = items.to_vec();
+            for it in items {
+                self.await_collect_targets(it, out)?;
+            }
+            return Ok(());
+        }
+        out.push(self.await_normalize(v)?);
+        Ok(())
+    }
+
     pub(super) fn builtin_await(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         if args.is_empty() {
             return Err(RuntimeError::new(
@@ -263,15 +290,7 @@ impl Interpreter {
         }
         let mut await_targets: Vec<Value> = Vec::new();
         for arg in args {
-            if let Some(items) = arg.as_list_items() {
-                let items: Vec<Value> = items.to_vec();
-                for it in items {
-                    await_targets.push(self.await_normalize(it)?);
-                }
-            } else {
-                let normalized = self.await_normalize(arg.clone())?;
-                await_targets.push(normalized);
-            }
+            self.await_collect_targets(arg.clone(), &mut await_targets)?;
         }
         let mut results = Vec::new();
         for arg in &await_targets {

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -41,7 +41,7 @@ pub(in crate::runtime) use state::{
 // Supplier registry accessors driven by the VM-side react/supply loop.
 pub(crate) use state::{
     next_supplier_id, supplier_register_promise, supplier_sink_register, supplier_sink_unregister,
-    supplier_snapshot, take_promise_combinator_sources,
+    supplier_sinks_register_batch, supplier_snapshot, take_promise_combinator_sources,
 };
 pub(in crate::runtime) use state_lock::next_lock_id;
 pub(in crate::runtime) use state_lock::next_semaphore_id;

--- a/src/runtime/native_methods/state.rs
+++ b/src/runtime/native_methods/state.rs
@@ -155,11 +155,34 @@ pub(in crate::runtime) fn supply_channel_map_pub() -> &'static SupplyChannelMap 
     supply_channel_map()
 }
 
+/// Global monotonic emit sequence, stamped on every `supplier_emit` /
+/// `supplier_done` / `supplier_quit`. Buffered values across *different*
+/// suppliers (e.g. two `whenever $s.grep(...)` derived supplies) carry
+/// comparable sequence numbers, so a batch sink registration can replay them
+/// merged in true emit order rather than one whole supplier's buffer at a time
+/// (see `supplier_sinks_register_batch`).
+fn next_emit_seq() -> u64 {
+    static EMIT_SEQ: AtomicU64 = AtomicU64::new(1);
+    EMIT_SEQ.fetch_add(1, Ordering::Relaxed)
+}
+
+fn next_sink_id() -> u64 {
+    static SINK_IDS: AtomicU64 = AtomicU64::new(1);
+    SINK_IDS.fetch_add(1, Ordering::Relaxed)
+}
+
 #[derive(Debug, Default)]
 struct SupplierRuntimeState {
     emitted: Vec<Value>,
+    /// Global emit sequence for each entry in `emitted` (parallel vector), used
+    /// to merge buffered values across suppliers in true emit order at sink
+    /// registration.
+    emitted_seq: Vec<u64>,
     done: bool,
     quit_reason: Option<Value>,
+    /// Global emit sequence of the terminal (done/quit) event, so a replay can
+    /// order it relative to buffered emits of sibling suppliers.
+    terminal_seq: Option<u64>,
     pending_promises: Vec<SharedPromise>,
     /// Push sinks registered by consuming drive loops (react / `await
     /// $supply` / control waits). Every emit/done/quit is pushed to each
@@ -202,8 +225,7 @@ pub(crate) fn supplier_sink_register(
     key: usize,
     waker: &crate::value::waker::ReactWaker,
 ) -> u64 {
-    static SINK_IDS: AtomicU64 = AtomicU64::new(1);
-    let sink_id = SINK_IDS.fetch_add(1, Ordering::Relaxed);
+    let sink_id = next_sink_id();
     if let Ok(mut map) = supplier_state_map().lock() {
         let state = map.entry(supplier_id).or_default();
         for v in &state.emitted {
@@ -221,6 +243,67 @@ pub(crate) fn supplier_sink_register(
         });
     }
     sink_id
+}
+
+/// Register push sinks on several suppliers at once, replaying their buffered
+/// events **merged in global emit order** rather than one supplier's whole
+/// buffer at a time.
+///
+/// A single [`supplier_sink_register`] replays exactly one supplier's buffer,
+/// so registering N sibling derived supplies (e.g. two `whenever $s.grep(...)`)
+/// one after another emits `p1,p2,p3` then `n1,n2,n3` — losing the interleaved
+/// order the values were actually emitted in. That is only observable when a
+/// producer (a `whenever start { emit … }` thread) races ahead of the react
+/// drive loop's sink registration and buffers values before the sinks exist
+/// (PLAN.md 8.19). By holding the registry lock across every subscribe, reading
+/// each buffer with its per-value [`next_emit_seq`] stamp, then replaying the
+/// combined set sorted by that stamp, sibling supplies interleave in true emit
+/// order. Future live emits (pushed after this returns) are naturally later.
+///
+/// `regs` is `(supplier_id, consumer key)`; returns `(supplier_id, sink_id)`
+/// pairs for [`supplier_sink_unregister`].
+pub(crate) fn supplier_sinks_register_batch(
+    regs: &[(u64, usize)],
+    waker: &crate::value::waker::ReactWaker,
+) -> Vec<(u64, u64)> {
+    let mut sink_ids = Vec::with_capacity(regs.len());
+    let mut replay: Vec<(u64, usize, crate::value::waker::SinkEvent)> = Vec::new();
+    if let Ok(mut map) = supplier_state_map().lock() {
+        for &(supplier_id, key) in regs {
+            let sink_id = next_sink_id();
+            let state = map.entry(supplier_id).or_default();
+            for (i, v) in state.emitted.iter().enumerate() {
+                let seq = state.emitted_seq.get(i).copied().unwrap_or(0);
+                replay.push((seq, key, crate::value::waker::SinkEvent::Emit(v.clone())));
+            }
+            // A terminal event follows all of this supplier's own emits; give it
+            // the recorded terminal sequence (or, defensively, one past the last
+            // buffered emit) so it sorts after them but relative to siblings.
+            if state.quit_reason.is_some() || state.done {
+                let seq = state
+                    .terminal_seq
+                    .unwrap_or_else(|| state.emitted_seq.last().map(|s| s + 1).unwrap_or(0));
+                let event = if let Some(reason) = &state.quit_reason {
+                    crate::value::waker::SinkEvent::Quit(reason.clone())
+                } else {
+                    crate::value::waker::SinkEvent::Done
+                };
+                replay.push((seq, key, event));
+            }
+            state.sinks.push(SupplierSink {
+                sink_id,
+                key,
+                waker: waker.clone(),
+            });
+            sink_ids.push((supplier_id, sink_id));
+        }
+        // Stable sort keeps same-sequence ties in registration order.
+        replay.sort_by_key(|(seq, _, _)| *seq);
+        for (_, key, event) in replay {
+            waker.push(key, event);
+        }
+    }
+    sink_ids
 }
 
 pub(crate) fn supplier_sink_unregister(supplier_id: u64, sink_id: u64) {
@@ -393,6 +476,7 @@ pub(in crate::runtime) fn supplier_emit(supplier_id: u64, value: Value) {
                 .push(s.key, crate::value::waker::SinkEvent::Emit(value.clone()));
         }
         state.emitted.push(value);
+        state.emitted_seq.push(next_emit_seq());
     }
 }
 
@@ -403,6 +487,7 @@ pub(in crate::runtime) fn supplier_done(supplier_id: u64) {
             return;
         }
         state.done = true;
+        state.terminal_seq = Some(next_emit_seq());
         for s in &state.sinks {
             s.waker.push(s.key, crate::value::waker::SinkEvent::Done);
         }
@@ -426,6 +511,7 @@ pub(in crate::runtime) fn supplier_done_deferred(
             return Vec::new();
         }
         state.done = true;
+        state.terminal_seq = Some(next_emit_seq());
         for s in &state.sinks {
             s.waker.push(s.key, crate::value::waker::SinkEvent::Done);
         }
@@ -444,6 +530,7 @@ pub(in crate::runtime) fn supplier_quit(supplier_id: u64, reason: Value) {
             return;
         }
         state.quit_reason = Some(reason.clone());
+        state.terminal_seq = Some(next_emit_seq());
         for s in &state.sinks {
             s.waker
                 .push(s.key, crate::value::waker::SinkEvent::Quit(reason.clone()));
@@ -462,7 +549,9 @@ pub(in crate::runtime) fn supplier_reset(supplier_id: u64) {
     {
         state.done = false;
         state.quit_reason = None;
+        state.terminal_seq = None;
         state.emitted.clear();
+        state.emitted_seq.clear();
     }
 }
 

--- a/src/vm/vm_react_subscriptions.rs
+++ b/src/vm/vm_react_subscriptions.rs
@@ -12,7 +12,8 @@
 //! `$s.done` raced the poll).
 use super::*;
 use crate::runtime::native_methods::{
-    SupplyEvent, supplier_sink_register, supplier_sink_unregister, take_promise_combinator_sources,
+    SupplyEvent, supplier_sink_unregister, supplier_sinks_register_batch,
+    take_promise_combinator_sources,
 };
 use crate::runtime::subtest::{ReactSubscription, SupplyDrivePolicy};
 use crate::value::waker::{ReactWaker, SinkEvent};
@@ -208,14 +209,18 @@ impl Interpreter {
         }
 
         let waker = ReactWaker::new();
-        // Supplier-backed subscriptions: register push sinks (this also
-        // replays any already-buffered values into the queue).
-        let mut sink_regs: Vec<(u64, u64)> = Vec::new();
-        for (i, sub) in react_subs.iter().enumerate() {
-            if let Some(sid) = sub.supplier_id {
-                sink_regs.push((sid, supplier_sink_register(sid, i, &waker)));
-            }
-        }
+        // Supplier-backed subscriptions: register push sinks in one batch so
+        // any already-buffered values across sibling derived supplies (e.g. two
+        // `whenever $s.grep(...)`) replay merged in true emit order, not one
+        // supplier's whole buffer at a time (PLAN.md 8.19). Registering them
+        // one at a time would interleave-lose the order when a producer thread
+        // races ahead of this registration and buffers values first.
+        let regs: Vec<(u64, usize)> = react_subs
+            .iter()
+            .enumerate()
+            .filter_map(|(i, sub)| sub.supplier_id.map(|sid| (sid, i)))
+            .collect();
+        let sink_regs: Vec<(u64, u64)> = supplier_sinks_register_batch(&regs, &waker);
         // Promise / channel / mpsc-receiver sources still deliver their
         // payloads through the existing receiver / poll paths, but wake the
         // loop instantly instead of waiting out the idle cap.

--- a/t/await-nested-iterable.t
+++ b/t/await-nested-iterable.t
@@ -1,0 +1,41 @@
+use Test;
+
+# `await` must suspend for EVERY Promise it is given, no matter how deeply that
+# Promise is nested inside list literals. The old implementation only descended
+# two list levels, so a Promise nested deeper was pushed through as a raw value
+# and never `.wait()`ed — `await` returned before its side effect landed
+# (S17-promise/nonblocking-await.t test 28, PLAN.md 8.19). These tests force a
+# deeply-nested slow Promise: if `await` skipped it, the atomic counter would be
+# short by one when read immediately after `await` returns.
+
+plan 4;
+
+{
+    # slow Promise at depth 3 (two inner lists deep); fast one at depth 1.
+    my atomicint $x;
+    sub slow1 { start { sleep 1; $x⚛++ } }
+    sub fast1 { start { $x⚛++ } }
+    await ( ( (slow1(),), ), fast1() );
+    is $x, 2, 'await waits for a Promise nested three list-levels deep';
+}
+
+{
+    # The exact shape from the roast test: nine Promises across several nesting
+    # depths, awaited in sink context.
+    my atomicint $x;
+    sub p { start { sleep .1; $x⚛++ } }
+    await (((p(), (p(), (p(),))), (p(), p(), p())), (p(), p(), p()));
+    is $x, 9, 'await in sink context waits for all deeply-nested Promises';
+}
+
+{
+    # Mixed depths; result list collects every leaf result in order.
+    my @r = await ( (start { 1 },), (start { 2 }, (start { 3 },)) );
+    is @r.sort, [1, 2, 3], 'nested await collects every result';
+}
+
+{
+    # A flat list of Promises still works (regression guard).
+    my @r = await (start { 10 }, start { 20 });
+    is-deeply @r, [10, 20], 'flat list of promises still awaited';
+}


### PR DESCRIPTION
Fixes the two intermittent concurrency bugs recorded in PLAN.md §8.19 — both real
mutsu races that `raku` runs deterministically-correct.

## 1. `await` on nested iterables dropped a Promise

`roast/S17-promise/nonblocking-await.t` test 28: `await` in sink context on
nested iterables should wait for every Promise, but `builtin_await` unrolled only
**two** list levels, so a Promise nested three or more lists deep was pushed
through as a raw value and never `.wait()`ed — the side effect it carried had not
necessarily landed when `await` returned.

Fix: replace the hand-unrolled levels with `await_collect_targets`, a recursive
descent that flattens arbitrarily-nested list structure into leaf targets
(normalizing each `Supply` to its `.Promise`). Promises/Channels are leaves,
scalars pass through, so result-list and Slip-flatten semantics are unchanged.

A deterministic repro — a slow Promise nested three list-levels deep awaited
alongside an instant one — went from `1` to the correct `2`. Pin:
`t/await-nested-iterable.t`.

## 2. Sibling `whenever \$s.grep(...)` interleaved out of emit order

`t/supply-live-grep-map-react-order.t` test 5: two `whenever \$s.grep(...)` in one
`react` should deliver in global emit order (`p1,n-1,p2,n-2,p3,n-3`) but under
load mutsu batched per-supply (`p1,p2,p3,n-1,n-2,n-3`).

Root cause: each derived grep supplier buffers its filtered values; the react
loop registered push sinks one at a time, and `supplier_sink_register` replays
one supplier's *whole* buffer before the next subscribes. When the
`whenever start { emit … }` producer races ahead of registration and buffers
values first, replaying supplier-by-supplier loses the interleave.

Fix: stamp every `supplier_emit`/`supplier_done`/`supplier_quit` with a global
monotonic sequence, and add `supplier_sinks_register_batch`, which registers all
of a react's supplier sinks under one registry-lock acquisition and replays their
combined buffers **sorted by sequence** — so siblings interleave in true emit
order. Single-sink callers keep `supplier_sink_register` unchanged.

A 20 ms delay injected before sink registration reproduced the bug 5/5 and
confirms the fix 5/5.

## Verification

- Both pins pass; all 63 `t/` supply/react/await tests and the touched
  `roast/S17-{supply,promise}` files pass.
- `cargo fmt` + `cargo clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)