### PR TITLE
fix: run grammar actions when the parse fails

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1486,20 +1486,31 @@ token path-part:sym<matcher> {
   hypotheses: mutsu builds the whole match tree first and only then walks it
   bottom-up (`invoke_grammar_actions`, called from `methods_grammar.rs` after
   the match returns), whereas raku runs an action method the moment its subrule
-  reduces. The same defect has a second, sharper symptom: **when the overall
-  parse FAILS, mutsu runs no actions at all**, while raku has already run every
-  action whose subrule matched — including ones later undone by backtracking.
-  HTTP::Header::parse depends on exactly that:
-  ```raku
-  grammar G { token TOP { [ <message-header> \r?\n ]* } ... }
-  # `$h.parse('ETag: W/"1201-…"')` has no trailing newline, so TOP matches ""
-  # and .parse fails — but raku has already fired the message-header action,
-  # which is what populates the header object. mutsu fires nothing.
-  ```
-  Blocks HTTP::UserAgent's `t/010-headers` (3 subtests) and `t/050-response`
-  (1 subtest). Fixing it means invoking actions at subrule-reduce time inside
-  the matcher instead of in a post-pass — a real regex-engine change, and the
-  single remaining lever for both this and the `$*FINAL` symptom above.
+  reduces.
+- **Failed-parse half: FIXED 2026-07-25.** The sharper symptom — *when the
+  overall parse FAILS, mutsu ran no actions at all* — is done. The matcher now
+  logs every named-subrule reduce (`REDUCED_SUBRULES` in
+  `regex/regex_helpers.rs`), `.parse` keeps the longest partial match instead of
+  discarding it, and the failure path dispatches that partial tree plus the
+  reduces that fell outside it. That took HTTP::UserAgent's upstream suite
+  23/27 → 25/27 (`t/010-headers`, `t/050-response`). Pin:
+  `t/grammar-actions-on-failed-parse.t`.
+- **What is left is only the ORDERING half (the `$*FINAL` repro above).** New
+  diagnosis: it does **not** need actions moved into the matcher. On a
+  *successful* parse mutsu makes two separate bottom-up passes over the finished
+  tree — `reduce_regex_captures_made` runs every node's inline `{ … }` code
+  blocks, and only then does `invoke_grammar_actions` run every node's action.
+  So by the time `part`'s action for segment `a` runs, segment `c`'s
+  `{ $*FINAL = True }` has already executed. Interleaving the two into a single
+  bottom-up walk (per node: code blocks, then that node's action) reproduces
+  raku's order — `mid:a|mid:b|FIN:c` — without touching the regex engine. The
+  work is that `reduce_regex_captures_made` walks `RegexCaptures` while
+  `invoke_grammar_actions` walks the built Match `Value`, so the merged walk has
+  to build each node's Match object as it descends and mark nodes whose action
+  already ran so the outer pass cannot double-dispatch (the hazard
+  `dispatch_silent_action_caps` already documents).
+- **Impact of the remainder:** the 6 `File::Ignore` `wildcard.rakutest`
+  `a/**/b` failures.
 
 ### 8.21 `$!attr = v` inside a method skips the attribute's declared type check (found 2026-07-25, HTTP::Request)
 

--- a/news/2026-07/grammar-actions-on-a-failed-parse.md
+++ b/news/2026-07/grammar-actions-on-a-failed-parse.md
@@ -1,0 +1,60 @@
+# Grammar actions now run when the parse fails
+
+Rakudo dispatches a grammar action method the moment its rule reduces — the
+instant the rule matches — and never un-dispatches it when the surrounding
+pattern later backtracks past it. So a `Grammar.parse` that fails *overall*
+still leaves behind the effects of every subrule that did match.
+
+mutsu instead walked the finished match tree in a post-pass, which on a failed
+parse is either absent or covers only a prefix. The result: a failed `.parse`
+ran **no actions at all**.
+
+`HTTP::Header.parse` depends on exactly the behaviour mutsu lacked. Its start
+rule is
+
+```raku
+token TOP { [ <message-header> \r?\n ]* }
+```
+
+so a header string without a trailing newline makes the `*` commit zero
+iterations: `TOP` matches `""`, `.parse` fails — and yet raku has already run
+the `message-header` action, which is what populates the header object.
+`$h.parse('ETag: W/"1201-51b0ce7ad3900"')` worked in raku and silently did
+nothing in mutsu.
+
+## What changed
+
+Three pieces, none of which moves action dispatch into the regex engine:
+
+- **The matcher logs each reduce.** `REDUCED_SUBRULES`
+  (`src/runtime/regex/regex_helpers.rs`) records every named subrule that
+  matched during an action-driven parse, keyed by `(rule, from, to)` so the
+  candidate enumeration cannot log the same reduce twice. It is inert unless
+  `:actions` is in play, and never records while the matcher is only measuring
+  a declarative prefix or probing the failure position (ADR-0009).
+- **A failed `.parse` keeps its partial match.**
+  `regex_match_with_captures_full_from_start_tracking_partial` hands back the
+  longest match even when it does not cover the whole text, so the failure path
+  can dispatch that tree — start rule's own action included, as raku does.
+- **The failure path dispatches, then replays.** Whatever reduced *outside* the
+  surviving tree (the trailing attempt that made the parse stop short) is
+  replayed from the log, keeping only maximal spans so a nested rule is reached
+  through its parent's walk and still gets bottom-up order and `.made`
+  propagation.
+
+One related hole closed with it: when a lone (non-proto) start rule failed the
+declarative-prefix measurement, mutsu skipped the real match entirely as an
+optimisation. During an action-driven parse that match has observable side
+effects, so the candidate is now handed back and the real match runs and fails.
+
+## Result
+
+The upstream HTTP::UserAgent test suite goes from 23/27 to 25/27 files passing —
+`t/010-headers.rakutest` (3 subtests) and `t/050-response.rakutest` (1 subtest)
+are now clean. Pinned by `t/grammar-actions-on-failed-parse.t`.
+
+The other half of PLAN.md §8.20 — a per-match `:my $*FINAL` leaking to earlier
+segments' actions on a *successful* parse — remains, and the entry now records a
+sharper diagnosis: it is an ordering problem between mutsu's two bottom-up
+post-passes (code blocks first, then actions), not something that needs
+reduce-time dispatch inside the matcher.

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -159,6 +159,7 @@ impl Interpreter {
         // match — which executes nothing — so the "does this candidate match at
         // all?" filter is unchanged for those.
         let mut candidates: Vec<(usize, String)> = Vec::new(); // (prefix_match_len, pattern)
+        let mut rejected: Vec<String> = Vec::new();
         for def in defs {
             if let Some(pattern) = self.eval_token_def(&def, arg_values)? {
                 if let Some(ref text) = subject {
@@ -169,7 +170,7 @@ impl Interpreter {
                         // last) and let the real match decide.
                         (None, true) => candidates.push((0, pattern)),
                         // A fully declarative candidate that does not match at all.
-                        (None, false) => {}
+                        (None, false) => rejected.push(pattern),
                     }
                 } else {
                     candidates.push((0, pattern));
@@ -181,6 +182,19 @@ impl Interpreter {
         candidates.sort_by_key(|c| std::cmp::Reverse(c.0));
         if let Some((_, pattern)) = candidates.into_iter().next() {
             return Ok(Some(pattern));
+        }
+        // Nothing matched declaratively. Normally that is a cheap "this rule
+        // cannot match" verdict and the real match is skipped — but during a
+        // `Grammar.parse(:actions(...))` the real match has OBSERVABLE side
+        // effects: Rakudo dispatches an action the moment a subrule reduces, so
+        // even a doomed match leaves the actions of its matched subrules behind.
+        // With a single (non-proto) candidate there is nothing to select between,
+        // so hand it back and let the real match run and fail.
+        if rejected.len() == 1
+            && self.current_grammar_actions.is_some()
+            && !self.has_proto_token(name)
+        {
+            return Ok(rejected.pop());
         }
         if self.has_proto_token(name) {
             return Err(RuntimeError::new(format!(

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -283,6 +283,13 @@ impl Interpreter {
         let _dynvar_overlay_guard = actions_obj
             .is_some()
             .then(super::regex::regex_helpers::RegexDynvarOverlayGuard::activate);
+        // Log every subrule reduce so that a parse which fails overall can still
+        // dispatch the actions of the subrules that DID match — Rakudo dispatches
+        // at reduce time and does not undo it on backtracking, whereas mutsu's
+        // post-pass walks the (nonexistent) final tree. See `REDUCED_SUBRULES`.
+        let _reduced_subrule_guard = actions_obj
+            .is_some()
+            .then(super::regex::regex_helpers::ReducedSubruleGuard::activate);
         // Establish any `:my $*/%*/@*… = …;` dynamic variables the grammar's rules
         // declare, so action methods run during the match share them (`%*PLAYED`).
         let saved_grammar_dynvars = self.establish_grammar_dynamic_vars(package_name);
@@ -341,8 +348,16 @@ impl Interpreter {
             if want_eager {
                 self.enable_eager_code_blocks();
             }
+            // When `.parse` fails because the start rule matched only a PREFIX,
+            // that prefix's match tree is still what Rakudo dispatched actions
+            // over at reduce time, so keep it instead of throwing it away.
+            let mut partial_match: Option<RegexCaptures> = None;
             let captures = if method == "parse" || method == "parsefile" {
-                self.regex_match_with_captures_full_from_start(&pattern, &text)
+                self.regex_match_with_captures_full_from_start_tracking_partial(
+                    &pattern,
+                    &text,
+                    &mut partial_match,
+                )
             } else if let Some(pos) = start_pos {
                 // `:pos(N)` — subparse anchored to begin exactly at N.
                 self.regex_match_with_captures_at(&pattern, &text, pos)
@@ -368,6 +383,24 @@ impl Interpreter {
             let Some(mut captures) = captures else {
                 if !eager_blocks.is_empty() {
                     self.execute_regex_code_blocks(&eager_blocks);
+                }
+                // The parse failed, but subrules reduced along the way — raku
+                // already ran their actions. Dispatch the longest partial tree
+                // (which includes the start rule's own action) when there is one,
+                // then replay whatever reduced outside it.
+                if let Some(ref mut actions) = actions_obj {
+                    match partial_match.take() {
+                        Some(mut caps) => {
+                            self.reduce_regex_captures_made(&mut caps, Some(&text));
+                            self.dispatch_partial_parse_actions(
+                                &caps,
+                                actions,
+                                &start_rule,
+                                &text,
+                            )?;
+                        }
+                        None => self.replay_backtracked_reduce_actions(actions, None, &text)?,
+                    }
                 }
                 let goal = Self::take_pending_goal_failure().or_else(|| {
                     self.parse_regex(&pattern)
@@ -408,6 +441,9 @@ impl Interpreter {
             if let Some(want) = required_from
                 && captures.from != want
             {
+                if let Some(ref mut actions) = actions_obj {
+                    self.replay_backtracked_reduce_actions(actions, None, &text)?;
+                }
                 self.env.insert("/".to_string(), Value::NIL);
                 if is_full_parse {
                     return Ok(self.parse_failure_for_pattern(&text, Some(&pattern)));
@@ -415,6 +451,14 @@ impl Interpreter {
                 return Ok(self.make_failed_match_value(&text, start_pos.unwrap_or(0)));
             }
             if (method == "parse" || method == "parsefile") && captures.to != text.chars().count() {
+                // The start rule matched a PREFIX of the text, so `.parse` fails —
+                // but raku ran every action along the way, including the start
+                // rule's own. Dispatch the partial tree, then replay the reduces
+                // that fell outside it (the trailing attempt that made the parse
+                // stop short is exactly one of those).
+                if let Some(ref mut actions) = actions_obj {
+                    self.dispatch_partial_parse_actions(&captures, actions, &start_rule, &text)?;
+                }
                 self.env.insert("/".to_string(), Value::NIL);
                 return Ok(self.make_parse_failure_value(&text, captures.to));
             }
@@ -556,6 +600,124 @@ impl Interpreter {
             && class_name == "Failure"
         {
             return Ok(Value::NIL);
+        }
+        result
+    }
+
+    /// Build the Match object a capture node describes, with `orig` set to the
+    /// whole parse text so `.orig`/`.prematch` work on it.
+    fn match_object_from_captures(caps: &RegexCaptures, text: &str) -> Value {
+        Value::make_match_object_full_q(
+            caps.matched.clone(),
+            caps.from as i64,
+            caps.to as i64,
+            &caps.positional,
+            &caps.named,
+            &caps.named_subcaps,
+            &caps.positional_subcaps,
+            &caps.positional_quantified,
+            &caps.positional_nil,
+            Some(text),
+            &caps.named_quantified,
+        )
+    }
+
+    /// Run the actions over the match tree of a parse that FAILED because the
+    /// start rule covered only part of the input: Rakudo dispatched every one of
+    /// them at reduce time, including the start rule's own. Anything that reduced
+    /// outside that tree (the trailing attempt that made the parse stop short) is
+    /// replayed afterwards.
+    fn dispatch_partial_parse_actions(
+        &mut self,
+        caps: &RegexCaptures,
+        actions: &mut Value,
+        start_rule: &str,
+        text: &str,
+    ) -> Result<(), RuntimeError> {
+        let covered = (caps.from, caps.to);
+        let partial = Self::match_object_from_captures(caps, text);
+        let saved_self = self.env.get("self").cloned();
+        let dispatched = self.invoke_grammar_actions(partial, actions, start_rule);
+        match saved_self {
+            Some(s) => {
+                self.env.insert("self".to_string(), s);
+            }
+            None => {
+                self.env.remove("self");
+            }
+        }
+        dispatched?;
+        self.replay_backtracked_reduce_actions(actions, Some(covered), text)
+    }
+
+    /// Dispatch the action methods of subrules that reduced during a parse whose
+    /// OVERALL verdict is failure.
+    ///
+    /// Rakudo calls an action the moment its rule matches and never un-calls it
+    /// when the enclosing pattern backtracks past it, so a failed `.parse` still
+    /// leaves every matched subrule's action effects behind. mutsu instead walks
+    /// the finished match tree, which on a failed parse is either absent or covers
+    /// only a prefix — so those actions were never run at all. `REDUCED_SUBRULES`
+    /// logs each reduce during matching and this replays the ones the surviving
+    /// tree does not already account for.
+    ///
+    /// `covered` is the span of the surviving (partial) match: its own action walk
+    /// handles everything inside, so entries there are skipped. Of the rest only
+    /// the *maximal* spans are dispatched — a nested subrule is reached by its
+    /// parent's `invoke_grammar_actions` walk, which also gives it the bottom-up
+    /// order and `.made` propagation Rakudo has.
+    pub(crate) fn replay_backtracked_reduce_actions(
+        &mut self,
+        actions: &mut Value,
+        covered: Option<(usize, usize)>,
+        text: &str,
+    ) -> Result<(), RuntimeError> {
+        let entries = super::regex::regex_helpers::ReducedSubruleGuard::take_entries();
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let outside: Vec<(String, std::sync::Arc<RegexCaptures>)> = entries
+            .into_iter()
+            .filter(|(_, caps)| {
+                !covered.is_some_and(|(from, to)| caps.from >= from && caps.to <= to)
+            })
+            .collect();
+        // Keep only spans not contained in another survivor. Equal spans (e.g.
+        // `token a { <b> }` where both cover the same text) keep the LAST logged
+        // one, which is the outer rule: the matcher recurses, so children are
+        // logged before their parent.
+        let maximal: Vec<&(String, std::sync::Arc<RegexCaptures>)> = outside
+            .iter()
+            .enumerate()
+            .filter(|(i, (_, e))| {
+                !outside.iter().enumerate().any(|(j, (_, f))| {
+                    j != *i
+                        && f.from <= e.from
+                        && e.to <= f.to
+                        && ((f.from, f.to) != (e.from, e.to) || j > *i)
+                })
+            })
+            .map(|(_, entry)| entry)
+            .collect();
+        let saved_self = self.env.get("self").cloned();
+        let mut result = Ok(());
+        for (rule, caps) in maximal {
+            let mut caps = (**caps).clone();
+            self.reduce_regex_captures_made(&mut caps, Some(text));
+            let match_obj = Self::match_object_from_captures(&caps, text);
+            let dispatch = Self::get_action_name(&match_obj).unwrap_or_else(|| rule.clone());
+            if let Err(e) = self.invoke_grammar_actions(match_obj, actions, &dispatch) {
+                result = Err(e);
+                break;
+            }
+        }
+        match saved_self {
+            Some(s) => {
+                self.env.insert("self".to_string(), s);
+            }
+            None => {
+                self.env.remove("self");
+            }
         }
         result
     }

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -63,6 +63,89 @@ thread_local! {
     /// actually depends on a dynamic variable. The reduce-time action hook only
     /// fires when this is true, so ordinary (non-dyn-var) grammars pay nothing.
     pub(crate) static REGEX_GRAMMAR_DYNVAR_SEEN: Cell<bool> = const { Cell::new(false) };
+    /// Log of every named subrule that *reduced* (matched successfully) during the
+    /// live `Grammar.parse(:actions(...))`, in reduce order (children before their
+    /// parent, since the matcher recurses). Rakudo dispatches an action method the
+    /// moment its rule matches and never un-dispatches it when the surrounding
+    /// pattern later backtracks; mutsu instead walks the finished match tree, so a
+    /// parse that FAILS overall used to run no actions at all even though several
+    /// subrules had matched. This log lets the failure path replay them. `Some`
+    /// only while an action-driven parse is live.
+    pub(crate) static REDUCED_SUBRULES: RefCell<Option<ReducedSubruleLog>> = const { RefCell::new(None) };
+}
+
+/// Hard cap on `ReducedSubruleLog` entries. The log only feeds the *failure*
+/// replay, so dropping the tail of a pathologically large parse costs nothing
+/// but keeps a long action-driven parse from accumulating unbounded memory.
+const REDUCED_SUBRULE_LOG_CAP: usize = 20_000;
+
+/// Reduce-order log of named-subrule matches — see `REDUCED_SUBRULES`.
+#[derive(Default)]
+pub(crate) struct ReducedSubruleLog {
+    /// `(rule name to dispatch the action under, that rule's captures)`.
+    entries: Vec<(String, std::sync::Arc<RegexCaptures>)>,
+    /// De-dups `(rule, from, to)`: mutsu's matcher enumerates every candidate end
+    /// position of a subrule, so the same reduce is often produced repeatedly.
+    seen: std::collections::HashSet<(String, usize, usize)>,
+}
+
+impl ReducedSubruleLog {
+    pub(crate) fn into_entries(self) -> Vec<(String, std::sync::Arc<RegexCaptures>)> {
+        self.entries
+    }
+}
+
+/// Record a named subrule's successful match for the failure-path action replay.
+/// No-op unless an action-driven parse is live, and never while the matcher is
+/// only *measuring* a declarative prefix or probing the failure position
+/// (ADR-0009: those passes must have no observable side effects).
+pub(crate) fn record_reduced_subrule(rule: &str, caps: &std::sync::Arc<RegexCaptures>) {
+    if LTM_DECLARATIVE_MODE.with(Cell::get) || CODE_ATOMS_INERT.with(Cell::get) {
+        return;
+    }
+    REDUCED_SUBRULES.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        let Some(log) = slot.as_mut() else {
+            return;
+        };
+        if log.entries.len() >= REDUCED_SUBRULE_LOG_CAP {
+            return;
+        }
+        if log.seen.insert((rule.to_string(), caps.from, caps.to)) {
+            log.entries.push((rule.to_string(), caps.clone()));
+        }
+    });
+}
+
+/// Activates the reduce log for one `Grammar.parse(:actions(...))`, restoring any
+/// enclosing parse's log on drop.
+pub(crate) struct ReducedSubruleGuard {
+    prev: Option<ReducedSubruleLog>,
+}
+
+impl ReducedSubruleGuard {
+    pub(crate) fn activate() -> Self {
+        let prev =
+            REDUCED_SUBRULES.with(|slot| slot.borrow_mut().replace(ReducedSubruleLog::default()));
+        ReducedSubruleGuard { prev }
+    }
+
+    /// Take the entries logged so far, leaving a fresh empty log in place.
+    pub(crate) fn take_entries() -> Vec<(String, std::sync::Arc<RegexCaptures>)> {
+        REDUCED_SUBRULES.with(|slot| {
+            let mut slot = slot.borrow_mut();
+            match slot.as_mut() {
+                Some(log) => std::mem::take(log).into_entries(),
+                None => Vec::new(),
+            }
+        })
+    }
+}
+
+impl Drop for ReducedSubruleGuard {
+    fn drop(&mut self) {
+        REDUCED_SUBRULES.with(|slot| *slot.borrow_mut() = self.prev.take());
+    }
 }
 
 /// Look up a `$*` dynamic var in the reduce-time overlay (see

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -776,11 +776,16 @@ impl Interpreter {
                     && !spec.alias_replaces_original
                     && capture_name != spec.lookup_name;
                 let original_subcap = also_under_original.then(|| subcap.clone());
+                let subcap = std::sync::Arc::new(subcap);
+                // This subrule has just REDUCED. Log it so a parse that fails
+                // overall can still run its action, the way Rakudo (which
+                // dispatches at reduce time) does — see `REDUCED_SUBRULES`.
+                super::regex_helpers::record_reduced_subrule(&spec.lookup_name, &subcap);
                 new_caps
                     .named_subcaps
                     .entry(capture_name.to_string())
                     .or_default()
-                    .push(std::sync::Arc::new(subcap));
+                    .push(subcap);
                 new_caps
                     .named
                     .entry(capture_name.to_string())
@@ -842,11 +847,13 @@ impl Interpreter {
                     crate::runtime::SILENT_ACTION_MARKER_PREFIX,
                     spec.lookup_name
                 );
+                let subcap = std::sync::Arc::new(subcap);
+                super::regex_helpers::record_reduced_subrule(&spec.lookup_name, &subcap);
                 new_caps
                     .named_subcaps
                     .entry(marker)
                     .or_default()
-                    .push(std::sync::Arc::new(subcap));
+                    .push(subcap);
             } else {
                 // Childless silent subrule (`<.ws>`, `<.CRLF>`, `<.sym>`, ...): no
                 // nested captures and (in practice) no action of interest, so keep

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -673,7 +673,12 @@ impl Interpreter {
                     subcap.matched = captured.clone();
                     subcap.from = current;
                     subcap.to = end;
-                    store.push_named_subcap(&capture_name, std::sync::Arc::new(subcap));
+                    let subcap = std::sync::Arc::new(subcap);
+                    // This subrule iteration has REDUCED — log it for the
+                    // failed-parse action replay, exactly as the general
+                    // `build_named_candidates_from_inner` path does.
+                    super::regex_helpers::record_reduced_subrule(&capture_name, &subcap);
+                    store.push_named_subcap(&capture_name, subcap);
                     store.push_named(&capture_name, captured);
                 }
                 current = end;

--- a/src/runtime/regex/regex_match_find.rs
+++ b/src/runtime/regex/regex_match_find.rs
@@ -16,10 +16,17 @@ impl Interpreter {
         )
     }
 
-    pub(in crate::runtime) fn regex_match_with_captures_full_from_start(
+    /// Match `pattern` anchored at the start of `text` and require it to cover the
+    /// whole text (what `Grammar.parse` needs). When it only matches a PREFIX —
+    /// so the parse fails — the best-ranked partial match is written to `partial`.
+    /// `Grammar.parse(:actions(...))` needs that: Rakudo dispatches the start
+    /// rule's action whenever the start rule matched, even though the parse as a
+    /// whole then fails on the leftover text.
+    pub(in crate::runtime) fn regex_match_with_captures_full_from_start_tracking_partial(
         &mut self,
         pattern: &str,
         text: &str,
+        partial: &mut Option<RegexCaptures>,
     ) -> Option<RegexCaptures> {
         let parsed = self.parse_regex(pattern)?;
         let pkg = self.current_package();
@@ -60,9 +67,20 @@ impl Interpreter {
         // then take the first full match, so equal-key `||`/`|` ties keep the
         // highest-priority alternative instead of inverting it via `.rev()`.
         matches.sort_by(|a, b| Self::full_match_rank(b).cmp(&Self::full_match_rank(a)));
-        let (end, mut caps) = matches
-            .into_iter()
-            .find(|(end, _)| *end == orig_chars.len())?;
+        let Some(full_idx) = matches.iter().position(|(end, _)| *end == orig_chars.len()) else {
+            // No full match, so `.parse` fails — but hand the longest partial
+            // match back so an action-driven parse can still dispatch what the
+            // start rule DID match, the way Rakudo's reduce-time dispatch does.
+            if !matches.is_empty() {
+                let (end, mut caps) = matches.swap_remove(0);
+                caps.from = caps.capture_start.unwrap_or(0);
+                caps.to = caps.capture_end.unwrap_or(end);
+                caps.matched = orig_chars[caps.from..caps.to].iter().collect();
+                *partial = Some(caps);
+            }
+            return None;
+        };
+        let (end, mut caps) = matches.swap_remove(full_idx);
         caps.from = caps.capture_start.unwrap_or(0);
         caps.to = caps.capture_end.unwrap_or(end);
         caps.matched = orig_chars[caps.from..caps.to].iter().collect();

--- a/t/grammar-actions-on-failed-parse.t
+++ b/t/grammar-actions-on-failed-parse.t
@@ -1,0 +1,63 @@
+use Test;
+
+plan 8;
+
+# Rakudo dispatches a grammar action the moment its rule matches (at reduce
+# time) and never un-dispatches it when the enclosing pattern backtracks past
+# it. So a `.parse` that FAILS overall still leaves behind the effects of every
+# subrule that did match. mutsu walks the finished match tree instead, so this
+# used to run no actions at all on a failed parse — which broke
+# HTTP::Header.parse (its TOP is `[ <message-header> \r?\n ]*`, so a header
+# block without a trailing newline makes TOP match "" and the parse fail, yet
+# raku has already populated the header object).
+
+grammar Headers {
+    token TOP { [ <message-header> \r?\n ]* }
+    token message-header { $<field-name>=[ <-[:]>+ ] ':' \h* $<field-value>=[ \N* ] }
+}
+
+my @fired;
+class HeaderActions {
+    method message-header($/) { @fired.push: ~$<field-name> ~ '=' ~ ~$<field-value> }
+}
+
+# The whole input matches TOP, so the parse succeeds.
+@fired = ();
+ok Headers.parse("ETag: abc\n", :actions(HeaderActions)).defined, 'parse with trailing newline succeeds';
+is-deeply @fired, ['ETag=abc'], 'action ran once on the successful parse';
+
+# No trailing newline: the `*` commits zero iterations, TOP matches "" and the
+# parse fails — but `message-header` DID match, so its action must have run.
+@fired = ();
+nok Headers.parse("ETag: abc", :actions(HeaderActions)).defined, 'parse without trailing newline fails';
+is-deeply @fired, ['ETag=abc'], 'action still ran for the subrule that matched';
+
+# The start rule's own action fires too when it matched but the parse stops
+# short of the end of the input.
+grammar Words {
+    token TOP { <word>+ }
+    token word { \w }
+}
+my @seen;
+class WordActions {
+    method word($/) { @seen.push: "w:$/" }
+    method TOP($/)  { @seen.push: "TOP:$/" }
+}
+@seen = ();
+nok Words.parse("xy!", :actions(WordActions)).defined, 'parse stopping short of the end fails';
+is-deeply @seen, ['w:x', 'w:y', 'TOP:xy'], 'the partial tree dispatched bottom-up, start rule included';
+
+# The start rule fails outright: it still reduced `<body>` on the way, so that
+# action ran, but the start rule's own did not.
+grammar Tail {
+    token TOP { <body> 'ZZZ' }
+    token body { \w+ }
+}
+my @ran;
+class TailActions {
+    method body($/) { @ran.push: "body:$/" }
+    method TOP($/)  { @ran.push: "TOP:$/" }
+}
+@ran = ();
+nok Tail.parse("qq", :actions(TailActions)).defined, 'start rule that cannot match fails';
+is-deeply @ran, ['body:qq'], 'the subrule that reduced ran its action, the start rule did not';


### PR DESCRIPTION
Rakudo dispatches a grammar action the moment its rule reduces, and never un-dispatches it when the surrounding pattern backtracks past it — so a `Grammar.parse` that fails *overall* still leaves behind the effects of every subrule that matched. mutsu walked the finished match tree in a post-pass instead, so **a failed parse ran no actions at all**.

`HTTP::Header.parse` depends on exactly that behaviour:

```raku
token TOP { [ <message-header> \r?\n ]* }
```

A header string without a trailing newline makes the `*` commit zero iterations: `TOP` matches `""`, `.parse` fails — and yet raku has already run the `message-header` action, which is what populates the header object. `$h.parse('ETag: W/"1201-51b0ce7ad3900"')` worked in raku and silently did nothing in mutsu.

## What changed

None of this moves action dispatch into the regex engine.

- **The matcher logs each reduce.** `REDUCED_SUBRULES` (`src/runtime/regex/regex_helpers.rs`) records every named subrule that matched during an action-driven parse, keyed by `(rule, from, to)` so the candidate enumeration cannot log the same reduce twice. Inert unless `:actions` is in play, capped at 20k entries, and never recorded while the matcher is only measuring a declarative prefix or probing the failure position (ADR-0009).
- **A failed `.parse` keeps its partial match.** `regex_match_with_captures_full_from_start_tracking_partial` hands back the longest match even when it does not cover the whole text, so the failure path can dispatch that tree — start rule's own action included, as raku does.
- **The failure path dispatches, then replays.** Whatever reduced *outside* the surviving tree (the trailing attempt that made the parse stop short) is replayed from the log, keeping only maximal spans so a nested rule is reached through its parent's walk and still gets bottom-up order and `.made` propagation.
- **One related hole closed:** when a lone (non-proto) start rule failed the declarative-prefix measurement, mutsu skipped the real match entirely as an optimisation. During an action-driven parse that match has observable side effects, so the candidate is now handed back and the real match runs and fails.

## Result

Upstream HTTP::UserAgent suite: **23/27 → 25/27** files passing (`t/010-headers.rakutest` 3 subtests, `t/050-response.rakutest` 1 subtest). Pin: `t/grammar-actions-on-failed-parse.t`, verified against `raku` case by case.

`make test` PASS (2439 files / 23255 tests); all 97 whitelisted `S05-*` / grammar roast files PASS locally.

PLAN.md §8.20 keeps the remaining half — a per-match `:my $*FINAL` leaking to earlier segments' actions on a *successful* parse — with a sharper diagnosis: it is an ordering problem between mutsu's two bottom-up post-passes (code blocks first, then actions), fixable by interleaving them, not something that needs reduce-time dispatch inside the matcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)