### PR TITLE
docs(wasm-demo): rename the "Batteries" nav to "Bundled Libraries" (both languages)

### DIFF
--- a/wasm-demo/assets/i18n.js
+++ b/wasm-demo/assets/i18n.js
@@ -14,7 +14,7 @@ const STRINGS = {
     'nav.tutorial': 'Tutorial',
     'nav.playground': 'Playground',
     'nav.repl': 'REPL',
-    'nav.batteries': 'Batteries',
+    'nav.batteries': 'Bundled Libraries',
     'nav.bench': 'Benchmarks',
     'nav.github': 'GitHub',
 
@@ -78,7 +78,7 @@ const STRINGS = {
     'repl.try': 'Try',
     'repl.pg-cta': 'Writing something longer than a line? Open the playground →',
 
-    'bat.title': 'Batteries',
+    'bat.title': 'Bundled Libraries',
     'bat.intro': 'mutsu ships a standard library in the box. These modules are ' +
       'bundled with mutsu — installed next to the binary, not compiled into it — so ' +
       'a plain <code>use</code> works the moment you install mutsu, with no ' +
@@ -170,7 +170,7 @@ const STRINGS = {
     'repl.try': '例',
     'repl.pg-cta': '1 行に収まらないものを書くならプレイグラウンドへ →',
 
-    'bat.title': '同梱ライブラリ（バッテリー）',
+    'bat.title': '同梱ライブラリ',
     'bat.intro': 'mutsu は標準ライブラリを最初から同梱しています。これらのモジュールは' +
       'バイナリに埋め込まれるのではなくバイナリの隣に配置される形で mutsu に同梱され、' +
       'mutsu をインストールした瞬間から素の <code>use</code> で使えます' +

--- a/wasm-demo/assets/i18n.js
+++ b/wasm-demo/assets/i18n.js
@@ -108,7 +108,7 @@ const STRINGS = {
     'nav.tutorial': 'チュートリアル',
     'nav.playground': 'プレイグラウンド',
     'nav.repl': 'REPL',
-    'nav.batteries': 'バッテリー',
+    'nav.batteries': '同梱ライブラリ',
     'nav.bench': 'ベンチマーク',
     'nav.github': 'GitHub',
 
@@ -170,7 +170,7 @@ const STRINGS = {
     'repl.try': '例',
     'repl.pg-cta': '1 行に収まらないものを書くならプレイグラウンドへ →',
 
-    'bat.title': 'バッテリー（同梱ライブラリ）',
+    'bat.title': '同梱ライブラリ（バッテリー）',
     'bat.intro': 'mutsu は標準ライブラリを最初から同梱しています。これらのモジュールは' +
       'バイナリに埋め込まれるのではなくバイナリの隣に配置される形で mutsu に同梱され、' +
       'mutsu をインストールした瞬間から素の <code>use</code> で使えます' +

--- a/wasm-demo/content/landing.en.js
+++ b/wasm-demo/content/landing.en.js
@@ -124,7 +124,7 @@ export default {
           'binary, ready for a plain <code>use</code> with no <code>zef install</code>. ' +
           'Browse the bundled libraries and their docs.',
         href: 'batteries.html',
-        cta: 'Browse the batteries →',
+        cta: 'Browse the bundled libraries →',
       },
       {
         title: 'Read the real docs',

--- a/wasm-demo/content/landing.ja.js
+++ b/wasm-demo/content/landing.ja.js
@@ -120,7 +120,7 @@ export default {
           '<code>zef install</code> なしで素の <code>use</code> がすぐ動きます。' +
           '同梱ライブラリとそのドキュメントを一覧できます。',
         href: 'batteries.html',
-        cta: 'バッテリーを見る →',
+        cta: '同梱ライブラリを見る →',
       },
       {
         title: '本家のドキュメントを読む',

--- a/wasm-demo/e2e.test.mjs
+++ b/wasm-demo/e2e.test.mjs
@@ -207,7 +207,7 @@ try {
 
   assert(await page.locator('.site-nav .nav-links a').count() >= 5,
          'the nav now includes the batteries page');
-  assert(await page.textContent('.site-nav a[aria-current="page"]') === 'Batteries',
+  assert(await page.textContent('.site-nav a[aria-current="page"]') === 'Bundled Libraries',
          'with itself marked as the current page');
   assert(await page.locator('.bat-card').count() === battManifest.libraries.length,
          `every bundled library has a card (${battManifest.libraries.length})`);


### PR DESCRIPTION
## Problem

The wasm-demo site labelled the bundled-standard-library section as **Batteries** / **バッテリー**. This relies on the Python *batteries-included* idiom:

- in Japanese, バッテリー is just the loanword for a physical battery — the idiom does not carry over at all;
- in English, a beginner who has not met "batteries-included" cannot tell what the section is either.

## Change

Use a self-explanatory label in both languages (the term the page already uses in its prose):

| | before | after |
|---|---|---|
| en nav / heading | `Batteries` | `Bundled Libraries` |
| ja nav | `バッテリー` | `同梱ライブラリ` |
| ja heading | `バッテリー（同梱ライブラリ）` | `同梱ライブラリ` |
| en landing CTA | `Browse the batteries →` | `Browse the bundled libraries →` |
| ja landing CTA | `バッテリーを見る →` | `同梱ライブラリを見る →` |

The *batteries-included* idiom survives only in the landing-page prose, where it is explained inline. The e2e nav assertion is updated to the new English label; the ja e2e check only asserts the heading changes on language switch, which still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)