### PR TITLE
fix: a `&`-sigil pointy parameter on `given`/`with` declares, not rebinds

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1513,6 +1513,34 @@ token path-part:sym<matcher> {
   method"); more broadly, every typed attribute in every class is unenforced
   from inside its own methods.
 
+### 8.22 A `given` / `with` block is not a lexical scope for `my` (found 2026-07-25)
+
+- **Minimal repro:**
+  ```raku
+  my $z = 1;
+  given 1 { my $z = 5; say $z }   # 5 in both
+  say $z;                          # raku: 1     mutsu: 5
+
+  my $x = 1;
+  given 5 -> $x { }
+  say $x;                          # raku: 1     mutsu: 5
+  ```
+- **Diagnosis:** a `my` declaration inside a `given` / `with` body writes
+  through to the enclosing scope instead of shadowing there, so both an
+  explicit `my` and the pointy-parameter head statement
+  (`pointy_topic_bind`, `src/parser/stmt/control.rs`) leak. Sigil-blind —
+  `$`, `@`, `%` and `&` all leak the same way. A bare `{ … }` block scopes
+  correctly, so it is the `given`/`with` body specifically that is not
+  compiled as its own scope.
+- **Impact:** silent clobbering of a same-named outer lexical, which is
+  hard to spot precisely because the block's own behaviour is correct.
+  Not currently known to break a dist, but it is a real divergence and
+  the shape (`my $x` inside `given`) is common.
+- **Why it needs care:** `given` bodies are shared with `when`/`default`
+  and with the statement-modifier forms, and the topic (`$_`) binding
+  deliberately reaches the enclosing frame — the scope boundary has to
+  admit `$_` while excluding ordinary `my` declarations.
+
 
 ## Metrics
 

--- a/news/2026-07/pointy-code-sigil-param.md
+++ b/news/2026-07/pointy-code-sigil-param.md
@@ -1,0 +1,44 @@
+# `given $code -> &f { … }` no longer dies with X::Assignment::RO
+
+A pointy block's `&`-sigil parameter on `given` / `with` died before running a
+single statement:
+
+```raku
+my $c = { say "ran" };
+given $c -> &to-run { to-run() }   # Cannot modify an immutable value
+```
+
+`for ($c,) -> &g { g() }` and `sub s(&f) { f() }` were fine — only the
+`given`/`with` forms failed.
+
+## Root cause
+
+`given`/`with` implement their pointy parameter by prepending a head statement
+to the body that binds the parameter name to the topic (`pointy_topic_bind`, in
+`src/parser/stmt/control.rs`). For an aliasing parameter that head statement is
+`&f := $_`, which is exactly the form Raku rejects — "Cannot bind to '&f'
+because Code items cannot be rebound" — and mutsu's compiler rejects it too, at
+`src/compiler/stmt.rs`, by emitting `OpCode::AssignReadOnly` for any `&name`
+assignment whose name is not already a known local. So the desugar produced a
+statement the language forbids and the compiler correctly refused it.
+
+`for` was unaffected because it carries the parameter as a real `ParamDef` on
+the loop node and binds it through the signature machinery instead.
+
+## Fix
+
+A `&`-sigil pointy parameter now desugars to a *declaration* of that lexical
+code alias rather than a rebind. A code alias has no writeback semantics to
+lose — the `:=` form exists so that `given @a -> @p { @p.push(1) }` aliases the
+source container — so a declaration is the exact shape for it. `$`, `@` and `%`
+parameters keep the `:=` head statement unchanged.
+
+Pin: `t/pointy-code-param.t`.
+
+## Found on the way
+
+The pin deliberately does not assert that the alias stops shadowing at the
+closing brace: a `given` / `with` body is not a lexical scope for `my` at all in
+mutsu, so `given 1 { my $z = 5 }` clobbers an outer `$z` and `given 5 -> $x { }`
+leaks `$x` just the same. That is a separate, pre-existing, sigil-blind gap,
+now recorded as PLAN 8.22.

--- a/src/parser/stmt/control.rs
+++ b/src/parser/stmt/control.rs
@@ -147,6 +147,24 @@ fn pointy_topic_bind(pd: &ParamDef) -> Stmt {
             op: AssignOp::Assign,
             expr,
         }
+    } else if pd.name.starts_with('&') {
+        // A `&`-sigil parameter (`given $code -> &to-run { … }`) declares a
+        // fresh lexical code alias. It must NOT go out as a bare `&f := $_`:
+        // that is `Code items cannot be rebound` in Raku, and mutsu's compiler
+        // rejects it as such (`OpCode::AssignReadOnly`). A code alias has no
+        // writeback semantics to lose, so a declaration is the exact form.
+        Stmt::VarDecl {
+            name: pd.name.clone(),
+            expr: topic,
+            type_constraint: None,
+            is_state: false,
+            is_our: false,
+            is_dynamic: false,
+            is_export: false,
+            export_tags: Vec::new(),
+            custom_traits: Vec::new(),
+            where_constraint: None,
+        }
     } else {
         // Aliasing parameter: `:=` so the compiler/VM writes the parameter's
         // final value back to the topic source.

--- a/t/pointy-code-param.t
+++ b/t/pointy-code-param.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 8;
+
+# A `&`-sigil pointy-block parameter declares a fresh lexical code alias.
+# `given $code -> &f { … }` used to desugar to a bare `&f := $_`, which Raku
+# rejects as "Code items cannot be rebound" — so the block died with
+# X::Assignment::RO before running its first statement.
+
+my $code = { 'called' };
+
+given $code -> &f {
+    is f(), 'called', 'given -> &f can be called by bare name';
+    is &f(), 'called', 'given -> &f can be called through the & sigil';
+    ok &f ~~ Callable, 'the alias is the Callable itself';
+}
+
+with $code -> &g {
+    is g(), 'called', 'with -> &g binds the same way';
+}
+
+for ($code,) -> &h {
+    is h(), 'called', 'for -> &h still works';
+}
+
+sub takes(&i) { i() }
+is takes($code), 'called', 'a sub signature &param still works';
+
+# Inside the block the alias shadows an outer routine of that name. (That it
+# should also stop shadowing at the closing brace is a separate, pre-existing
+# gap: mutsu's `given` block does not open a lexical scope for `my` at all, so
+# `given 1 { my $z = 5 }` leaks `$z` too — see PLAN 8.22.)
+sub named() { 'outer' }
+given { 'inner' } -> &named {
+    is named(), 'inner', 'the block alias shadows an outer sub of that name';
+}
+
+# Arguments pass through the alias.
+given -> $x, $y { $x ~ $y } -> &joiner {
+    is joiner('a', 'b'), 'ab', 'arguments reach the aliased code';
+}


### PR DESCRIPTION
`given $code -> &to-run { to-run() }` died with `X::Assignment::RO` before
running a single statement, while `for ($c,) -> &g { g() }` and a plain
`sub s(&f) { f() }` signature were fine:

```raku
my $c = { say "ran" };
given $c -> &to-run { to-run() }   # Cannot modify an immutable value
```

## Root cause

`given`/`with` implement their pointy parameter by prepending a head statement
to the body that binds the parameter name to the topic (`pointy_topic_bind`,
`src/parser/stmt/control.rs`). For an aliasing parameter that head statement is
`&f := $_` — exactly the form Raku rejects ("Cannot bind to '&f' because Code
items cannot be rebound"), and the form mutsu's compiler also rejects, by
emitting `OpCode::AssignReadOnly` for any `&name` assignment whose name is not
already a known local (`src/compiler/stmt.rs`). So the desugar emitted a
statement the language forbids, and the compiler correctly refused it.

`for` was unaffected because it carries the parameter as a real `ParamDef` on
the loop node and binds it through the signature machinery instead.

## Fix

A `&`-sigil pointy parameter now desugars to a **declaration** of that lexical
code alias rather than a rebind. A code alias has no writeback semantics to
lose — the `:=` form exists so that `given @a -> @p { @p.push(1) }` aliases the
source container — so a declaration is the exact shape for it. `$`, `@` and `%`
parameters keep the `:=` head statement unchanged.

## Found on the way (recorded, not fixed here)

A `given` / `with` body is not a lexical scope for `my` at all in mutsu, so
`given 1 { my $z = 5 }` clobbers an outer `$z` and `given 5 -> $x { }` leaks
`$x`. Pre-existing and sigil-blind (a bare `{ … }` block scopes correctly), so
it is a separate root cause — now **PLAN 8.22**. The pin therefore asserts that
the alias shadows an outer sub *inside* the block, but does not assert the
closing-brace boundary.

## Verification

- `t/pointy-code-param.t` — 8 new assertions, each first verified against `raku`.
- `make test`: 2442 files / 23272 tests, all pass.
- `make roast` (full whitelist, local): `Result: PASS`, 218509 tests.
- Downstream: `Test::Scheduler` (`TODO_dist` T-037) no longer dies here —
  `t/not-time-based.rakutest` is 3/3 and `t/synopsis.rakutest` now runs all 9
  planned tests instead of aborting at test 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)