### PR TITLE
docs: record the supply-block Promise-`whenever` marker leak (PLAN 8.23, T-037)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1541,6 +1541,55 @@ token path-part:sym<matcher> {
   deliberately reaches the enclosing frame — the scope boundary has to
   admit `$_` while excluding ordinary `my` declarations.
 
+### 8.23 `whenever <Promise>` inside a `supply` block emits its own subscription marker (found 2026-07-25, Test::Scheduler)
+
+- **Minimal repro:**
+  ```raku
+  my $s = supply { whenever Promise.in(0.05) { emit 'badger' } }
+  my @r;
+  $s.tap: { @r.push($_) };
+  sleep 0.3;
+  say @r.raku;
+  # raku:  ["badger"]
+  # mutsu: [(Promise.new(…, status => PromiseStatus::Kept), , (), ()),]
+  ```
+  `whenever <Supply>` inside a `supply` block is fine, and
+  `react { whenever Promise.in(…) { … } }` is fine — it is specifically a
+  **Promise source inside a `supply` block**.
+- **Diagnosis:** `run_whenever_with_value`
+  (`src/runtime/subtest.rs:366`) registers a subscription by pushing a
+  4-element marker array `[source, body_cb, [LAST…], [QUIT…]]` onto the
+  active `supply_emit_buffer` frame. Every consumer that later separates
+  markers from genuinely emitted values recognises a marker only when
+  `arr[0]` is a **`Supply`** instance:
+  `supply_promise.rs:53` (`supply_get_values`), `supply_promise.rs:150`
+  (`supply_promise_on_demand`), and `native_supply_mut_methods.rs:291`
+  and `:319` (the `.tap` path). A `Promise`-sourced marker matches none
+  of them, so it falls through as an ordinary emitted value and is handed
+  straight to the tap — which is the raw 4-tuple the repro prints. The
+  react loop is unaffected because it consumes its own frame and already
+  models a promise source (`ReactSubscription.promise`).
+- **Proposed approach:** normalise a Promise source into a one-shot
+  supplier-backed `Supply` at marker-consumption time — Raku's semantics
+  for `whenever $promise` are exactly "emit the result once, then done" —
+  so the whole existing supplier/tap/serialize-group machinery applies
+  unchanged. `SharedPromise::on_resolve` plus `clone_for_thread()` is the
+  mechanism (the same pair `promise_chain_method` uses for `.then`,
+  `src/runtime/methods_promise.rs:89-118`).
+- **The ordering trap:** a supplier keeps no backlog —
+  `register_supplier_tap` does not replay past emissions — so the
+  `on_resolve` waiter must be armed **after** the consumer's
+  tap-registration loop has run, or an already-resolved (or
+  quickly-resolved) promise emits into a tapless supplier and the value
+  is lost. So the conversion cannot be done purely inside
+  `run_on_demand_body`: it has to record the pending arm and let each
+  consumer fire it once its taps are in place.
+- **Impact:** `Test::Scheduler` (`TODO_dist` T-037). With PLAN 8.21 and
+  the `&`-pointy-param fix landed, its `t/not-time-based.rakutest` passes
+  3/3 and `t/synopsis.rakutest` runs all 9 planned tests, but 6 of them
+  fail because `@received` collects these markers instead of the emitted
+  values. This is the last known blocker for that dist.
+
 
 ## Metrics
 

--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -323,7 +323,7 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 - file: DONE — runtime/test_functions/basic.rs (plan *); remaining — a
   Lingua::EN::Numbers cardinal-fraction bug (module logic).
 
-### T-037 — test_die: timeout  [impact: 1 dist]  — TWO ROOT CAUSES FIXED (#5395, #5396); blocked on PLAN §8.21
+### T-037 — test_die: timeout  [impact: 1 dist]  — FOUR ROOT CAUSES FIXED (#5395, #5396, #5402, #5405); blocked on PLAN §8.23
 - dists: Test::Scheduler (raku passes all three files; `t/virtualized-time.rakutest` 83/83)
 - e.g. `Test::Scheduler`: base=3 pass=1 fail=1 die=1 | t/virtualized-time.rakutest: timeout
 - The dist virtualizes time: `my $*SCHEDULER = Test::Scheduler.new` and then
@@ -342,22 +342,36 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   `method !run-due` binds `my (@now, @future) := $!lock.protect: { ... }`; the
   trailing `@future` came back as `(@y,)` instead of `@y`, so the scheduler
   believed work was still pending. Pin: `t/list-bind-trailing-array.t`.
-- **REMAINING — PLAN.md §8.21: `has` defaults are applied BEFORE `submethod
-  BUILD`, not after.** Rakudo runs BUILD first and then applies a `has` default
-  only for attributes BUILD did not set. The dist has
+- **Fixed #3 — `has` defaults were applied BEFORE `submethod BUILD` (#5402).**
+  Rakudo runs BUILD first and then applies a `has` initializer only for
+  attributes BUILD did not set. The dist has
   `has $.virtual-time = now; has $!virtual-target = $!virtual-time;` plus
-  `submethod BUILD(:$!virtual-time = now)`, so under mutsu's order
-  `$!virtual-target` is a couple of milliseconds *behind* `$!virtual-time`;
-  `advance-by($n)` then computes a target earlier than the events it should fire,
-  `!run-due` classifies everything as `future`, and the first `await` hangs.
-  Minimal repro + the full "why this is not a small fix" analysis (three
-  independent construction paths, no runtime "attribute was initialized" state,
-  slots must pre-exist for `$!x = ...` in BUILD to stick) are in PLAN.md §8.21.
-- **Status:** `t/not-time-based.rakutest` 3/3; `t/virtualized-time.rakutest`
-  reaches test 3 then hangs on §8.21; `t/synopsis.rakutest` 1/3.
+  `submethod BUILD(:$!virtual-time = now)`, so under mutsu's old order
+  `$!virtual-target` sat a couple of milliseconds *behind* `$!virtual-time`;
+  `advance-by($n)` computed a target earlier than the events it should fire,
+  `!run-due` classified everything as `future`, and the first `await` hung.
+  Construction is now seed / defer / apply (`runtime/attr_build_defaults.rs`).
+  Pin: `t/build-attr-default-order.t`.
+- **Fixed #4 — a `&`-sigil pointy parameter on `given` died (#5405).**
+  `!run-due` does `given .schedulee -> &to-run { … }`; the `given` desugar
+  emitted a bare `&to-run := $_`, which is "Code items cannot be rebound" and
+  the compiler rejected it as X::Assignment::RO. It now desugars to a
+  declaration. Pin: `t/pointy-code-param.t`.
+- **REMAINING — PLAN.md §8.23: `whenever <Promise>` inside a `supply` block
+  emits its own subscription marker.** The subscription marker
+  `[source, body_cb, [LAST…], [QUIT…]]` is recognised by the marker/value
+  separators only when `arr[0]` is a `Supply`, so a Promise source falls
+  through as an emitted value and reaches the tap as a raw 4-tuple. The dist's
+  `supply { whenever Promise.in($_) { emit 'badger' } }` therefore delivers
+  Promise objects where `'badger'` belongs. Full diagnosis, the proposed
+  normalise-to-one-shot-Supply approach, and the tap-ordering trap are in
+  PLAN.md §8.23.
+- **Status:** `t/not-time-based.rakutest` 3/3; `t/synopsis.rakutest` runs all 9
+  (3 pass, 6 fail on §8.23); `t/virtualized-time.rakutest` reaches test 2.
 - file: DONE — runtime/methods_promise_class.rs, runtime_init.rs (#5395),
-  parser/stmt/decl/destructure.rs (#5396); remaining — PLAN.md §8.21
-  (object construction order; ADR-worthy)
+  parser/stmt/decl/destructure.rs (#5396), runtime/attr_build_defaults.rs
+  (#5402), parser/stmt/control.rs (#5405); remaining — PLAN.md §8.23
+  (supply-block whenever on a Promise source)
 
 ### T-038 — test_fail: .text  [impact: 1 dist]  — FIXED (PR `fix-qqx-closure-interpolation`)
 - dists: PDF::Extract (t/01-san.rakutest 0/1 → 1/1)


### PR DESCRIPTION
Docs-only. Records the last known blocker for `Test::Scheduler` (`TODO_dist`
T-037), found while landing #5402 and #5405.

```raku
my $s = supply { whenever Promise.in(0.05) { emit 'badger' } }
my @r;
$s.tap: { @r.push($_) };
sleep 0.3;
say @r.raku;
# raku:  ["badger"]
# mutsu: [(Promise.new(…, status => PromiseStatus::Kept), , (), ()),]
```

`whenever <Supply>` inside a `supply` block is fine, and
`react { whenever Promise.in(…) { … } }` is fine — it is specifically a
**Promise source inside a `supply` block**.

`run_whenever_with_value` registers a subscription by pushing a 4-element
marker `[source, body_cb, [LAST…], [QUIT…]]` onto the active
`supply_emit_buffer` frame. Every consumer that later separates markers from
genuinely emitted values recognises one only when `arr[0]` is a `Supply`
instance — `supply_promise.rs:53` and `:150`, `native_supply_mut_methods.rs:291`
and `:319` — so a Promise-sourced marker falls through as an ordinary emitted
value and is handed straight to the tap.

The entry records the proposed fix (normalise a Promise source into a one-shot
supplier-backed `Supply`, which is exactly Raku's `whenever $promise` semantics,
using `SharedPromise::on_resolve` + `clone_for_thread()` — the pair
`promise_chain_method` already uses for `.then`) and the ordering trap that
keeps it from being a one-liner: a supplier keeps no backlog, so the waiter has
to be armed *after* the consumer's tap-registration loop or an already-resolved
promise emits into a tapless supplier.

Also updates T-037 with the two root causes that landed today (#5402 BUILD
ordering, #5405 `&`-pointy-param), which took `Test::Scheduler` from a hang to
`t/not-time-based.rakutest` 3/3 and `t/synopsis.rakutest` running all 9 planned
tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)