### PR TITLE
fix: `whenever <Promise>` inside a `supply` block runs its body

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1541,55 +1541,6 @@ token path-part:sym<matcher> {
   deliberately reaches the enclosing frame — the scope boundary has to
   admit `$_` while excluding ordinary `my` declarations.
 
-### 8.23 `whenever <Promise>` inside a `supply` block emits its own subscription marker (found 2026-07-25, Test::Scheduler)
-
-- **Minimal repro:**
-  ```raku
-  my $s = supply { whenever Promise.in(0.05) { emit 'badger' } }
-  my @r;
-  $s.tap: { @r.push($_) };
-  sleep 0.3;
-  say @r.raku;
-  # raku:  ["badger"]
-  # mutsu: [(Promise.new(…, status => PromiseStatus::Kept), , (), ()),]
-  ```
-  `whenever <Supply>` inside a `supply` block is fine, and
-  `react { whenever Promise.in(…) { … } }` is fine — it is specifically a
-  **Promise source inside a `supply` block**.
-- **Diagnosis:** `run_whenever_with_value`
-  (`src/runtime/subtest.rs:366`) registers a subscription by pushing a
-  4-element marker array `[source, body_cb, [LAST…], [QUIT…]]` onto the
-  active `supply_emit_buffer` frame. Every consumer that later separates
-  markers from genuinely emitted values recognises a marker only when
-  `arr[0]` is a **`Supply`** instance:
-  `supply_promise.rs:53` (`supply_get_values`), `supply_promise.rs:150`
-  (`supply_promise_on_demand`), and `native_supply_mut_methods.rs:291`
-  and `:319` (the `.tap` path). A `Promise`-sourced marker matches none
-  of them, so it falls through as an ordinary emitted value and is handed
-  straight to the tap — which is the raw 4-tuple the repro prints. The
-  react loop is unaffected because it consumes its own frame and already
-  models a promise source (`ReactSubscription.promise`).
-- **Proposed approach:** normalise a Promise source into a one-shot
-  supplier-backed `Supply` at marker-consumption time — Raku's semantics
-  for `whenever $promise` are exactly "emit the result once, then done" —
-  so the whole existing supplier/tap/serialize-group machinery applies
-  unchanged. `SharedPromise::on_resolve` plus `clone_for_thread()` is the
-  mechanism (the same pair `promise_chain_method` uses for `.then`,
-  `src/runtime/methods_promise.rs:89-118`).
-- **The ordering trap:** a supplier keeps no backlog —
-  `register_supplier_tap` does not replay past emissions — so the
-  `on_resolve` waiter must be armed **after** the consumer's
-  tap-registration loop has run, or an already-resolved (or
-  quickly-resolved) promise emits into a tapless supplier and the value
-  is lost. So the conversion cannot be done purely inside
-  `run_on_demand_body`: it has to record the pending arm and let each
-  consumer fire it once its taps are in place.
-- **Impact:** `Test::Scheduler` (`TODO_dist` T-037). With PLAN 8.21 and
-  the `&`-pointy-param fix landed, its `t/not-time-based.rakutest` passes
-  3/3 and `t/synopsis.rakutest` runs all 9 planned tests, but 6 of them
-  fail because `@received` collects these markers instead of the emitted
-  values. This is the last known blocker for that dist.
-
 
 ## Metrics
 

--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -357,21 +357,27 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   emitted a bare `&to-run := $_`, which is "Code items cannot be rebound" and
   the compiler rejected it as X::Assignment::RO. It now desugars to a
   declaration. Pin: `t/pointy-code-param.t`.
-- **REMAINING — PLAN.md §8.23: `whenever <Promise>` inside a `supply` block
-  emits its own subscription marker.** The subscription marker
-  `[source, body_cb, [LAST…], [QUIT…]]` is recognised by the marker/value
-  separators only when `arr[0]` is a `Supply`, so a Promise source falls
-  through as an emitted value and reaches the tap as a raw 4-tuple. The dist's
-  `supply { whenever Promise.in($_) { emit 'badger' } }` therefore delivers
-  Promise objects where `'badger'` belongs. Full diagnosis, the proposed
-  normalise-to-one-shot-Supply approach, and the tap-ordering trap are in
-  PLAN.md §8.23.
+- **Fixed #5 — `whenever <Promise>` inside a `supply` block leaked its own
+  subscription marker.** The marker `[source, body_cb, [LAST…], [QUIT…]]` was
+  recognised by the marker/value separators only when `arr[0]` was a `Supply`,
+  so a Promise source fell through as an emitted value and reached the tap as a
+  raw 4-tuple. The `.tap` path now rewrites it into a stand-in supplier-backed
+  Supply and the `await` path builds a one-shot channel subscription, matching
+  Raku's "emit once, then done" semantics. Pin:
+  `t/supply-whenever-promise.t`.
+- **REMAINING — the suite hangs at `t/virtualized-time.rakutest` test 29.** Not
+  yet triaged; the dist's `timeout` combinator registers a *nested* `whenever
+  Promise.in(...)` from inside another whenever's body, i.e. after the supply
+  block's initial run, which the rewrite above does not reach (it normalises
+  only the markers the initial body registered). `t/synopsis.rakutest` still
+  fails 6/9 for the same reason.
 - **Status:** `t/not-time-based.rakutest` 3/3; `t/synopsis.rakutest` runs all 9
-  (3 pass, 6 fail on §8.23); `t/virtualized-time.rakutest` reaches test 2.
+  (3 pass); `t/virtualized-time.rakutest` reaches test 28 (was 2).
 - file: DONE — runtime/methods_promise_class.rs, runtime_init.rs (#5395),
   parser/stmt/decl/destructure.rs (#5396), runtime/attr_build_defaults.rs
-  (#5402), parser/stmt/control.rs (#5405); remaining — PLAN.md §8.23
-  (supply-block whenever on a Promise source)
+  (#5402), parser/stmt/control.rs (#5405), runtime/supply_promise.rs +
+  native_supply_mut_methods.rs (this PR); remaining — nested `whenever` on a
+  Promise source registered from inside a whenever body
 
 ### T-038 — test_fail: .text  [impact: 1 dist]  — FIXED (PR `fix-qqx-closure-interpolation`)
 - dists: PDF::Extract (t/01-san.rakutest 0/1 → 1/1)

--- a/news/2026-07/supply-whenever-promise-source.md
+++ b/news/2026-07/supply-whenever-promise-source.md
@@ -1,0 +1,68 @@
+# `whenever <Promise>` inside a `supply` block runs its body instead of leaking a marker
+
+```raku
+my $s = supply { whenever Promise.in(0.05) { emit 'badger' } }
+my @r;
+$s.tap: { @r.push($_) };
+sleep 0.3;
+say @r.raku;
+# raku:  ["badger"]
+# was:   [(Promise.new(…, status => PromiseStatus::Kept), , (), ()),]
+```
+
+`whenever <Supply>` inside a `supply` block was fine, and
+`react { whenever Promise.in(…) { … } }` was fine — it was specifically a
+**Promise source inside a `supply` block**.
+
+## Root cause
+
+`run_whenever_with_value` registers a subscription by pushing a 4-element marker
+`[source, body, [LAST…], [QUIT…]]` onto the active `supply_emit_buffer` frame.
+Every consumer that later separates markers from genuinely emitted values
+recognised one only when its source was a `Supply` instance — the `.tap` path in
+`native_supply_mut_methods.rs` and the `await` / `.Promise` path in
+`supply_promise.rs`. A Promise-sourced marker matched neither, so it fell
+through as an ordinary emitted value and was handed straight to the tap. The
+react loop was never affected: it consumes its own frame and already models a
+promise source (`ReactSubscription.promise`).
+
+## Fix
+
+Raku's `whenever $promise` is exactly a one-shot supply — emit the result once,
+then done — so the two supply-block consumers now each model it that way, using
+the shape that already existed for their kind of source:
+
+- The **`.tap` path** rewrites a Promise-sourced marker into a supplier-backed
+  `Supply`-sourced one (`normalize_promise_whenever_markers`), which lets the
+  whole existing tap / serialize-group / done-group machinery drive it
+  unchanged. When the promise is kept, its result is emitted into that stand-in
+  supplier and the supplier is immediately marked done; a broken promise
+  `quit`s it, so the `whenever`'s QUIT phaser and the tap's `quit` handler both
+  see it. `SharedPromise::on_resolve` plus `clone_for_thread()` drives that —
+  the same pair `promise_chain_method` uses for `.then`.
+- The **`await` / `.Promise` path** builds a one-shot channel subscription
+  directly, the same shape `vm_react_loop.rs` builds for a promise source in a
+  `react` block.
+
+The interesting constraint is ordering. A supplier keeps no backlog —
+`register_supplier_tap` does not replay past emissions — so arming the promise
+at rewrite time would let an already-resolved (or quickly-resolved) promise emit
+into a tapless supplier and lose the value. The rewrite therefore parks each
+`(promise, stand-in supplier)` on `pending_promise_whenever_arms` and the
+consumer fires them with `arm_pending_promise_whenevers()` only after its
+tap-registration loop has run.
+
+Pin: `t/supply-whenever-promise.t`.
+
+## Impact
+
+`Test::Scheduler` (`TODO_dist` T-037), whose `timeout` combinator is
+`supply { whenever $source -> $value { … whenever Promise.in($timeout) { … } } }`.
+Together with the two fixes that landed just before it — BUILD-before-defaults
+and the `&`-sigil pointy parameter — its `t/virtualized-time.rakutest` goes from
+stopping at test 2 to reaching test 28.
+
+Not fixed here, and pre-existing: `await (supply { whenever $live { emit … } })`
+with no explicit `done` in the body resolves to `Nil` rather than the last
+emitted value. That is not specific to promise sources — a live `Supplier`
+source behaves identically — so it is a separate gap.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1201,6 +1201,12 @@ pub struct Interpreter {
     /// `find_local_slot`. `None` for a non-local target (by-name fallback).
     let_saves: Vec<(String, Value, bool, Option<u32>)>,
     pub(super) supply_emit_buffer: Vec<Vec<Value>>,
+    /// `whenever <Promise>` sources inside a `supply` block, rewritten to a
+    /// stand-in supplier and waiting to be armed. A supplier keeps no backlog,
+    /// so the promise must not be armed until the consumer has registered the
+    /// taps for the rewritten subscription — see
+    /// `Interpreter::normalize_promise_whenever_markers`.
+    pub(crate) pending_promise_whenever_arms: Vec<(crate::value::SharedPromise, Value)>,
     pub(super) supply_emit_timed_buffer: Vec<Vec<(Value, crate::runtime::thread_compat::Instant)>>,
     /// Active streaming consumers for on-demand `supply { ... }` bodies driven by
     /// `react`. When a stream consumer is registered for an emitter's

--- a/src/runtime/native_supply_mut_methods.rs
+++ b/src/runtime/native_supply_mut_methods.rs
@@ -277,6 +277,12 @@ impl Interpreter {
                     // Separate whenever subscription registrations from plain
                     // emitted values (same logic as immutable tap path).
 
+                    // A `whenever <Promise>` source becomes a stand-in supplier
+                    // first, so the supplier-backed handling below drives it
+                    // (see `normalize_promise_whenever_markers`). The promises
+                    // are armed only once those taps are registered.
+                    let emitted = self.normalize_promise_whenever_markers(emitted);
+
                     // Pre-count supplier-backed whenever subscriptions
                     let whenever_supplier_count = emitted
                         .iter()
@@ -446,6 +452,10 @@ impl Interpreter {
                             plain_values.push(item.clone());
                         }
                     }
+                    // Every rewritten `whenever <Promise>` source now has its
+                    // body registered as a tap on its stand-in supplier, so the
+                    // promises can be armed without racing the registration.
+                    self.arm_pending_promise_whenevers();
                     // A `done` that terminates the whole supply (an explicit
                     // `done` in the block body, or a `done` inside a whenever
                     // body) fires every whenever source's on-close plus the

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2148,6 +2148,7 @@ impl Interpreter {
             instance_type_metadata: Arc::new(RwLock::new(HashMap::new())),
             let_saves: Vec::new(),
             supply_emit_buffer: Vec::new(),
+            pending_promise_whenever_arms: Vec::new(),
             supply_emit_timed_buffer: Vec::new(),
             supply_stream_consumers: Vec::new(),
             react_active: 0,

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -304,6 +304,7 @@ impl Interpreter {
             )),
             let_saves: Vec::new(),
             supply_emit_buffer: Vec::new(),
+            pending_promise_whenever_arms: Vec::new(),
             supply_emit_timed_buffer: Vec::new(),
             supply_stream_consumers: Vec::new(),
             react_active: 0,

--- a/src/runtime/supply_promise.rs
+++ b/src/runtime/supply_promise.rs
@@ -34,6 +34,94 @@ impl Interpreter {
         (result, emitted, body_ran_done)
     }
 
+    /// Rewrite every `whenever <Promise>` subscription marker the body just
+    /// registered into the supplier-backed `whenever <Supply>` form.
+    ///
+    /// `run_whenever_with_value` records a subscription as a 4-element marker
+    /// `[source, body, [LAST…], [QUIT…]]`, and every consumer downstream of
+    /// here recognises one only by its source being a `Supply` — a `Promise`
+    /// source fell through as an ordinary emitted value and was handed to the
+    /// tap as the raw marker array. Raku's `whenever $promise` is exactly a
+    /// one-shot supply ("emit the result once, then done"), so minting a
+    /// supplier for it here lets the existing tap / serialize-group / done-group
+    /// machinery drive it unchanged.
+    ///
+    /// The promise is NOT armed here: a supplier keeps no backlog
+    /// (`register_supplier_tap` does not replay), so an already-resolved
+    /// promise would emit into a tapless supplier and lose the value. Each arm
+    /// is parked on `pending_promise_whenever_arms` and fired by
+    /// [`Self::arm_pending_promise_whenevers`] once the consumer has registered
+    /// its taps.
+    pub(crate) fn normalize_promise_whenever_markers(&mut self, emitted: Vec<Value>) -> Vec<Value> {
+        if !emitted.iter().any(Self::is_promise_whenever_marker) {
+            return emitted;
+        }
+        emitted
+            .into_iter()
+            .map(|item| {
+                if !Self::is_promise_whenever_marker(&item) {
+                    return item;
+                }
+                let ValueView::Array(arr, ..) = item.view() else {
+                    return item;
+                };
+                let ValueView::Promise(promise) = arr[0].view() else {
+                    return item;
+                };
+                let supplier_id = next_supplier_id();
+                let supplier = Value::make_instance(Symbol::intern("Supplier"), {
+                    let mut a = HashMap::new();
+                    a.insert("emitted".to_string(), Value::array(Vec::new()));
+                    a.insert("done".to_string(), Value::FALSE);
+                    a.insert("supplier_id".to_string(), Value::int(supplier_id as i64));
+                    a
+                });
+                let supply = Value::make_instance(Symbol::intern("Supply"), {
+                    let mut a = HashMap::new();
+                    a.insert("values".to_string(), Value::array(Vec::new()));
+                    a.insert("taps".to_string(), Value::array(Vec::new()));
+                    a.insert("live".to_string(), Value::TRUE);
+                    a.insert("supplier_id".to_string(), Value::int(supplier_id as i64));
+                    a.insert("supplier_done".to_string(), Value::FALSE);
+                    a
+                });
+                self.pending_promise_whenever_arms
+                    .push((promise.clone(), supplier));
+                Value::array(vec![supply, arr[1].clone(), arr[2].clone(), arr[3].clone()])
+            })
+            .collect()
+    }
+
+    /// True for a `whenever` subscription marker whose source is a `Promise`.
+    pub(crate) fn is_promise_whenever_marker(item: &Value) -> bool {
+        matches!(item.view(), ValueView::Array(arr, ..)
+            if arr.len() == 4 && matches!(arr[0].view(), ValueView::Promise(_)))
+    }
+
+    /// Arm every promise parked by [`Self::normalize_promise_whenever_markers`]:
+    /// when the promise resolves, push its result into the supplier that now
+    /// stands in for it and immediately signal `done` (a promise fires once).
+    /// A broken promise `quit`s the stand-in, so the `whenever`'s QUIT phaser
+    /// and the tap's `quit` handler see it.
+    ///
+    /// Callers must run this only after registering the taps for the rewritten
+    /// markers. The waiter runs on whichever thread resolves the promise (or
+    /// synchronously here when it already has), so it drives a thread clone of
+    /// this interpreter — the same pair `promise_chain_method` uses for `.then`.
+    pub(crate) fn arm_pending_promise_whenevers(&mut self) {
+        for (promise, supplier) in std::mem::take(&mut self.pending_promise_whenever_arms) {
+            let mut thread_interp = self.clone_for_thread();
+            promise.on_resolve(Box::new(move |status, result, _output, _stderr| {
+                let method = if status == "Kept" { "emit" } else { "quit" };
+                let _ =
+                    thread_interp.call_method_with_values(supplier.clone(), method, vec![result]);
+                if status == "Kept" {
+                    let _ = thread_interp.call_method_with_values(supplier, "done", vec![]);
+                }
+            }));
+        }
+    }
+
     /// Extract source values from a Supply's attributes.
     pub(super) fn supply_get_values(
         &mut self,
@@ -151,7 +239,10 @@ impl Interpreter {
             } else {
                 false
             };
-            if is_supply_sub {
+            // A `whenever <Promise>` source is a subscription too; the loop
+            // below drives it through a one-shot channel, exactly as the react
+            // loop does for a promise source.
+            if is_supply_sub || Self::is_promise_whenever_marker(&item) {
                 subscriptions.push(item);
             } else {
                 plain_values.push(item);
@@ -188,6 +279,27 @@ impl Interpreter {
                     .get(3)
                     .and_then(Self::value_array_items)
                     .unwrap_or_default();
+                // A promise source fires once: feed its result through a
+                // one-shot channel followed by Done, the same shape the react
+                // loop builds for `react { whenever $promise { … } }`.
+                if let ValueView::Promise(shared) = source.view() {
+                    let (tx, rx) =
+                        crate::runtime::native_methods::supply_channel::supply_event_channel();
+                    let shared_clone = shared.clone();
+                    crate::runtime::builtins_system::spawn_gc_helper_thread(move || {
+                        let (result, _, _) = shared_clone.wait();
+                        let _ = tx.send(crate::runtime::native_methods::SupplyEvent::Emit(result));
+                        let _ = tx.send(crate::runtime::native_methods::SupplyEvent::Done);
+                    });
+                    react_subs.push(crate::runtime::subtest::ReactSubscription {
+                        receiver: Some(rx),
+                        promise: Some(shared.clone()),
+                        last_callbacks: last_cbs,
+                        quit_callbacks: quit_cbs,
+                        ..crate::runtime::subtest::ReactSubscription::new(callback)
+                    });
+                    continue;
+                }
                 if let ValueView::Instance {
                     attributes: inner_attrs,
                     ..

--- a/t/supply-whenever-promise.t
+++ b/t/supply-whenever-promise.t
@@ -1,0 +1,53 @@
+use Test;
+
+plan 6;
+
+# `whenever <Promise>` inside a `supply` block used to hand the tap the raw
+# 4-element subscription marker instead of running the body: the marker/value
+# separators recognised only a Supply source, so a Promise source fell through
+# as an ordinary emitted value.
+
+{
+    my $s = supply { whenever Promise.in(0.05) { emit 'badger' } }
+    my @got;
+    $s.tap: { @got.push($_) };
+    is @got, [], 'nothing before the promise resolves';
+    sleep 0.3;
+    is @got, ['badger'], 'the whenever body ran and its emit reached the tap';
+}
+
+{
+    my $s = supply {
+        whenever Promise.in(0.05) { emit 1 }
+        whenever Promise.in(0.10) { emit 2 }
+    }
+    my @got;
+    my $done = False;
+    $s.tap: { @got.push($_) }, done => { $done = True };
+    sleep 0.4;
+    is @got, [1, 2], 'several promise sources each fire once, in time order';
+    ok $done, 'the supply completes when every promise source is done';
+}
+
+{
+    # The promise's result is the whenever body's topic.
+    my $p = Promise.new;
+    my $s = supply { whenever $p -> $v { emit $v * 2 } }
+    my @got;
+    $s.tap: { @got.push($_) };
+    $p.keep(21);
+    sleep 0.2;
+    is @got, [42], 'the body sees the kept value as its parameter';
+}
+
+{
+    # A broken promise quits the supply.
+    my $p = Promise.new;
+    $p.break('boom');
+    my $s = supply { whenever $p { emit 'never' } }
+    my @got;
+    my $quit;
+    $s.tap: { @got.push($_) }, quit => { $quit = $_ };
+    sleep 0.2;
+    is $quit.Str, 'boom', 'a broken promise source quits the tap';
+}


### PR DESCRIPTION
Closes PLAN §8.23 (recorded in #5407).

```raku
my $s = supply { whenever Promise.in(0.05) { emit 'badger' } }
my @r;
$s.tap: { @r.push($_) };
sleep 0.3;
say @r.raku;
# raku:  ["badger"]
# was:   [(Promise.new(…, status => PromiseStatus::Kept), , (), ()),]
```

`whenever <Supply>` inside a `supply` block was fine, and
`react { whenever Promise.in(…) { … } }` was fine — it was specifically a
**Promise source inside a `supply` block**.

## Root cause

`run_whenever_with_value` registers a subscription by pushing a 4-element marker
`[source, body, [LAST…], [QUIT…]]` onto the active `supply_emit_buffer` frame,
and both supply-block consumers — the `.tap` path in
`native_supply_mut_methods.rs` and the `await` / `.Promise` path in
`supply_promise.rs` — recognised one only when its source was a `Supply`
instance. A Promise-sourced marker matched neither, so it fell through as an
ordinary emitted value and was handed straight to the tap. The react loop was
never affected: it consumes its own frame and already models a promise source
(`ReactSubscription.promise`).

## Fix

Raku's `whenever $promise` is exactly a one-shot supply — emit the result once,
then done — so each consumer now models it with the shape it already has for its
kind of source:

- The **`.tap` path** rewrites a Promise-sourced marker into a supplier-backed
  `Supply`-sourced one (`normalize_promise_whenever_markers`), so the whole
  existing tap / serialize-group / done-group machinery drives it unchanged. A
  kept promise emits its result into that stand-in supplier and immediately
  marks it done; a broken one `quit`s it, so the `whenever`'s QUIT phaser and
  the tap's `quit` handler both see it. `SharedPromise::on_resolve` +
  `clone_for_thread()` drives that — the same pair `promise_chain_method` uses
  for `.then`.
- The **`await` / `.Promise` path** builds a one-shot channel subscription
  directly, the same shape `vm_react_loop.rs` builds for a promise source.

**The ordering constraint:** a supplier keeps no backlog —
`register_supplier_tap` does not replay past emissions — so arming the promise
at rewrite time would let an already-resolved (or quickly-resolved) promise emit
into a tapless supplier and lose the value. The rewrite therefore parks each
`(promise, stand-in supplier)` on `pending_promise_whenever_arms`, and the
consumer fires them with `arm_pending_promise_whenevers()` only after its
tap-registration loop has run.

## Impact

`Test::Scheduler` (`TODO_dist` T-037): `t/virtualized-time.rakutest` goes from
stopping at test 2 to reaching test 28. Its remaining blocker is a *nested*
`whenever Promise.in(…)` registered from inside another whenever's body (i.e.
after the supply block's initial run), which this rewrite does not reach —
recorded on the ticket.

Explicitly **not** fixed and pre-existing: `await (supply { whenever $live { emit … } })`
with no explicit `done` resolves to `Nil` instead of the last emitted value.
That is not specific to promise sources (a live `Supplier` source behaves
identically), so it is a separate gap.

## Verification

- `t/supply-whenever-promise.t` — 6 new assertions, each first verified against
  `raku` (delivery, ordering across two promise sources, `done`, the kept value
  as the body's parameter, and `quit` on a broken promise).
- `make test`: 2444 files / 23293 tests, all pass.
- `make roast` (full whitelist, local): `Result: PASS`, 218509 tests.
- `roast/S17-supply/`, `S17-promise/`, `S17-scheduler/` (76 files) run
  separately: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)