### PR TITLE
fix: `%?RESOURCES` in a `require`d module resolves against its own distribution

### DIFF
--- a/news/2026-07/resources-in-a-required-module.md
+++ b/news/2026-07/resources-in-a-required-module.md
@@ -1,0 +1,56 @@
+# `%?RESOURCES` in a module loaded by `require` resolved against the wrong distribution
+
+`HTTP::UserAgent` could not fetch an `https://` URL. It reported
+
+```
+Runtime error: An exception occurred while evaluating a CHECK
+Exception details:
+  Please install IO::Socket::SSL in order to fetch https sites
+```
+
+even though `IO::Socket::SSL` is bundled and working — adding a bare
+`use IO::Socket::SSL;` to the script made the very same request return 200.
+
+## What was actually wrong
+
+`HTTP::UserAgent.get-connection` loads the TLS socket lazily:
+
+```raku
+try require ::("IO::Socket::SSL");
+die "Please install IO::Socket::SSL …" if ::('IO::Socket::SSL') ~~ Failure;
+```
+
+The `try` swallowed the real error. Unwrapped, it was
+`No such method 'slurp' for invocant of type 'Any'`, thrown from
+`OpenSSL::NativeLib`:
+
+```raku
+BEGIN my %libraries = Rakudo::Internals::JSON.from-json: %?RESOURCES<libraries.json>.slurp(:close);
+```
+
+`%?RESOURCES` is lexically tied to the compilation unit that contains the token,
+so this must resolve against the *OpenSSL* distribution. mutsu instead preferred
+the distribution of the innermost routine on the call stack — a rule added so
+that a module's method reading `%?RESOURCES` while *another* module is still
+loading gets its own distribution (the MIME::Types case). But a module's own
+mainline and `BEGIN` blocks run with **no frame of their own**, so the innermost
+frame is then whoever triggered the load: `HTTP::UserAgent.get-connection`. Its
+distribution has no `libraries.json`, so the lookup was `Any` and `.slurp` blew
+up. Because the failure happened at `BEGIN` time it surfaced wrapped as
+"An exception occurred while evaluating a CHECK", hiding the cause.
+
+`use IO::Socket::SSL` worked because the whole chain then loads at the script's
+compile time, with no routine frame in the way.
+
+## The fix
+
+A module load now records the `routine_stack` height at which it established
+`current_distribution` (`current_distribution_frame_floor`). The
+routine-stack rule only considers frames at or above that floor — those were
+pushed by code the loading module itself called, which is exactly the
+MIME::Types shape it was written for. Frames below belong to the caller that
+triggered the load, and no longer shadow the module being loaded.
+
+`$ua.get("https://example.com/").code` now returns 200 with no extra `use`.
+Pinned by `t/resources-in-required-module.t`, whose fixture distributions live
+under `t/lib/ResCaller`, `t/lib/ResDist` and `t/lib/ResInner`.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -998,6 +998,13 @@ pub struct Interpreter {
     module_load_stack: Vec<String>,
     /// The current distribution context ($?DISTRIBUTION).
     pub(crate) current_distribution: Option<Value>,
+    /// `routine_stack` height when the in-progress module load established
+    /// `current_distribution`. Frames at or above it were pushed by code the
+    /// loading module called, so they are the ones whose own distribution owns a
+    /// `%?RESOURCES` they read; frames below belong to whoever triggered the
+    /// load and must not shadow the module being loaded. See
+    /// `build_resources_for_package`.
+    pub(crate) current_distribution_frame_floor: usize,
     /// Maps package names to their distribution context.
     /// Populated during module loading so OTF compilation can resolve $?DISTRIBUTION.
     pub(crate) package_distributions: HashMap<String, Value>,

--- a/src/runtime/run_dist.rs
+++ b/src/runtime/run_dist.rs
@@ -18,7 +18,17 @@ impl Interpreter {
         // would otherwise (incorrectly) point at the outer module's dist.
         //
         // Priority 1: the executing routine's defining package (innermost first).
-        for frame in self.routine_stack.iter().rev() {
+        // Only frames pushed since the in-progress module load began count: a
+        // module's own mainline / `BEGIN` runs with NO frame of its own, so the
+        // innermost frame is then the caller that triggered the load (e.g. the
+        // routine running `require`), whose distribution is the wrong answer.
+        // `OpenSSL::NativeLib`'s `BEGIN … %?RESOURCES<libraries.json>.slurp` is
+        // exactly that shape, and it is what stopped HTTP::UserAgent from
+        // loading IO::Socket::SSL for an https request.
+        let floor = self
+            .current_distribution_frame_floor
+            .min(self.routine_stack.len());
+        for frame in self.routine_stack[floor..].iter().rev() {
             if let Some(dist) = self.package_distributions.get(&frame.package) {
                 return self.build_resources_from_dist(&dist.clone());
             }

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -558,6 +558,7 @@ impl Interpreter {
         // For installed modules (inst# paths), use the dist JSON directly.
         // Otherwise fall back to META6.json detection.
         let saved_distribution = self.current_distribution.clone();
+        let saved_distribution_floor = self.current_distribution_frame_floor;
         // Prefer the dist JSON of the distribution resolve_module_path actually
         // selected (selectors / highest-version pick): a by-name rescan could
         // land on a DIFFERENT dist that also provides this short name. The
@@ -590,6 +591,10 @@ impl Interpreter {
         };
         if let Some(dist) = &module_dist {
             self.current_distribution = Some(dist.clone());
+            // Everything this module's own mainline runs from here on sits at or
+            // above this frame height; frames below belong to whoever triggered
+            // the load (see `build_resources_for_package`).
+            self.current_distribution_frame_floor = self.routine_stack_len();
             // Record the distribution for the module's package name
             // so OTF compilation can resolve $?DISTRIBUTION later.
             self.package_distributions
@@ -695,6 +700,7 @@ impl Interpreter {
         }
         crate::parser::set_current_language_version(&saved_language_version);
         self.current_distribution = saved_distribution;
+        self.current_distribution_frame_floor = saved_distribution_floor;
         Ok(())
     }
 

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2105,6 +2105,7 @@ impl Interpreter {
             private_zeroarg_method_cache: HashMap::new(),
             module_load_stack: Vec::new(),
             current_distribution: None,
+            current_distribution_frame_floor: 0,
             package_distributions: HashMap::new(),
             exported_subs: HashMap::new(),
             exported_sub_values: HashMap::new(),

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -244,6 +244,7 @@ impl Interpreter {
             private_zeroarg_method_cache: HashMap::new(),
             module_load_stack: Vec::new(),
             current_distribution: self.current_distribution.clone(),
+            current_distribution_frame_floor: 0,
             package_distributions: self.package_distributions.clone(),
             exported_subs: self.exported_subs.clone(),
             exported_vars: self.exported_vars.clone(),

--- a/t/lib/ResCaller/META6.json
+++ b/t/lib/ResCaller/META6.json
@@ -1,0 +1,13 @@
+{
+  "name": "ResCaller",
+  "description": "Fixture distribution that `require`s another distribution from inside a method",
+  "version": "0.0.1",
+  "auth": "zef:mutsu",
+  "perl": "6.d",
+  "provides": {
+    "ResRequirer": "lib/ResRequirer.rakumod"
+  },
+  "resources": [],
+  "depends": [],
+  "license": "Artistic-2.0"
+}

--- a/t/lib/ResCaller/lib/ResRequirer.rakumod
+++ b/t/lib/ResCaller/lib/ResRequirer.rakumod
@@ -1,0 +1,8 @@
+unit class ResRequirer;
+
+# Loads ResDist lazily from inside a routine, the way HTTP::UserAgent loads
+# IO::Socket::SSL when a request turns out to be https.
+method load-greeting() {
+    try require ::("ResDist");
+    ::('ResDist').greeting;
+}

--- a/t/lib/ResDist/META6.json
+++ b/t/lib/ResDist/META6.json
@@ -1,0 +1,15 @@
+{
+  "name": "ResDist",
+  "description": "Fixture distribution whose module reads %?RESOURCES at BEGIN time",
+  "version": "0.0.1",
+  "auth": "zef:mutsu",
+  "perl": "6.d",
+  "provides": {
+    "ResDist": "lib/ResDist.rakumod"
+  },
+  "resources": [],
+  "depends": [
+    "ResInner"
+  ],
+  "license": "Artistic-2.0"
+}

--- a/t/lib/ResDist/lib/ResDist.rakumod
+++ b/t/lib/ResDist/lib/ResDist.rakumod
@@ -1,0 +1,7 @@
+unit class ResDist;
+
+# Pulls in a module from ANOTHER distribution, the way IO::Socket::SSL pulls in
+# OpenSSL (whose OpenSSL::NativeLib reads `%?RESOURCES` at BEGIN time).
+use ResInner;
+
+method greeting() { ResInner.greeting }

--- a/t/lib/ResInner/META6.json
+++ b/t/lib/ResInner/META6.json
@@ -1,0 +1,15 @@
+{
+  "name": "ResInner",
+  "description": "Fixture distribution whose module reads %?RESOURCES at BEGIN time",
+  "version": "0.0.1",
+  "auth": "zef:mutsu",
+  "perl": "6.d",
+  "provides": {
+    "ResInner": "lib/ResInner.rakumod"
+  },
+  "resources": [
+    "greeting.txt"
+  ],
+  "depends": [],
+  "license": "Artistic-2.0"
+}

--- a/t/lib/ResInner/lib/ResInner.rakumod
+++ b/t/lib/ResInner/lib/ResInner.rakumod
@@ -1,0 +1,9 @@
+unit class ResInner;
+
+# Read at BEGIN time, from the module's own mainline — the shape
+# OpenSSL::NativeLib uses. `%?RESOURCES` here must resolve against THIS
+# distribution, not against whichever distribution the routine that triggered
+# the load happens to belong to.
+my $greeting = BEGIN %?RESOURCES<greeting.txt>.slurp(:close).trim;
+
+method greeting() { $greeting }

--- a/t/lib/ResInner/resources/greeting.txt
+++ b/t/lib/ResInner/resources/greeting.txt
@@ -1,0 +1,1 @@
+hello from the ResInner resources

--- a/t/resources-in-required-module.t
+++ b/t/resources-in-required-module.t
@@ -1,0 +1,28 @@
+use v6;
+use lib 't/lib/ResCaller/lib', 't/lib/ResDist/lib', 't/lib/ResInner/lib';
+use Test;
+
+plan 3;
+
+# `%?RESOURCES` is lexically tied to the compilation unit that contains the
+# token, so a module's own mainline/`BEGIN` must see ITS distribution's
+# resources — including when the module is pulled in by `require` from inside
+# another module's routine, where the innermost call frame belongs to the
+# caller. mutsu resolved `%?RESOURCES` against that caller's distribution, so
+# `%?RESOURCES<greeting.txt>` was `Any` and the `BEGIN … .slurp` blew up with
+# "No such method 'slurp' for invocant of type 'Any'" — wrapped, unhelpfully,
+# as "An exception occurred while evaluating a CHECK". That is exactly what
+# stopped HTTP::UserAgent from loading IO::Socket::SSL (via OpenSSL::NativeLib)
+# for an https request.
+
+use ResRequirer;
+
+my $greeting;
+lives-ok { $greeting = ResRequirer.load-greeting },
+    'a module `require`d from inside another module\'s method loads';
+is $greeting, 'hello from the ResInner resources',
+    'its BEGIN-time %?RESOURCES resolved against its own distribution';
+
+# The plain `use` path must keep working too.
+lives-ok { EVAL 'use ResDist; ResDist.greeting' },
+    '%?RESOURCES still resolves on the `use` path';


### PR DESCRIPTION
`HTTP::UserAgent` could not fetch an `https://` URL:

```
Runtime error: An exception occurred while evaluating a CHECK
Exception details:
  Please install IO::Socket::SSL in order to fetch https sites
```

…even though `IO::Socket::SSL` is bundled and working — adding a bare `use IO::Socket::SSL;` to the script made the very same request return 200.

## What was actually wrong

`HTTP::UserAgent.get-connection` loads the TLS socket lazily, and the `try` swallowed the real error:

```raku
try require ::("IO::Socket::SSL");
die "Please install IO::Socket::SSL …" if ::('IO::Socket::SSL') ~~ Failure;
```

Unwrapped it was `No such method 'slurp' for invocant of type 'Any'`, thrown from `OpenSSL::NativeLib`:

```raku
BEGIN my %libraries = Rakudo::Internals::JSON.from-json: %?RESOURCES<libraries.json>.slurp(:close);
```

`%?RESOURCES` is lexically tied to the compilation unit that contains the token, so this must resolve against the **OpenSSL** distribution. mutsu instead preferred the distribution of the innermost routine on the call stack — a rule added so a module's method reading `%?RESOURCES` while *another* module is still loading gets its own distribution (the MIME::Types case). But a module's own mainline and `BEGIN` blocks run with **no frame of their own**, so the innermost frame is then whoever triggered the load — `HTTP::UserAgent.get-connection`, whose distribution has no `libraries.json`. The lookup was `Any`, `.slurp` blew up, and because it happened at BEGIN time it surfaced wrapped as "An exception occurred while evaluating a CHECK", hiding the cause.

`use IO::Socket::SSL` worked because the whole chain then loads at the script's compile time, with no routine frame in the way.

## The fix

A module load records the `routine_stack` height at which it established `current_distribution` (`current_distribution_frame_floor`). The routine-stack rule now only considers frames at or above that floor — those are exactly the frames the loading module itself pushed, which is the MIME::Types shape the rule was written for. Frames below belong to the caller that triggered the load and no longer shadow the module being loaded.

## Result

```
$ua.get("https://example.com/").code   # 200, with no extra `use`
```

Pin: `t/resources-in-required-module.t`, with fixture distributions under `t/lib/ResCaller`, `t/lib/ResDist` and `t/lib/ResInner`. Verified against `raku`, and verified to FAIL on the previous behaviour.

`make test` PASS (2442 files / 23277 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)