### PR TITLE
fix: `.subst` / `s///` replace the `<( … )>` region, not the consumed span

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -1129,9 +1129,18 @@ _(move tickets here with `[claim: <branch>]` when you start)_
   pattern string. Each match of a declaring rule now gets its own binding, carried
   to its action (pin `t/grammar-per-match-dynvar-action.t`; see
   `news/2026-07/grammar-per-match-dynvar-binding.md`).
-  **`t/wildcard.rakutest` is now 44/44 and six of the seven files pass
-  completely; only `t/range.rakutest` still has 1 failure (charclass ranges,
-  un-triaged).** Separate: a `<sym>` auto-capture is not recorded on a
+  The charclass-range failure in `t/range.rakutest` is **also FIXED**
+  (2026-07-25): the module compiles `[a-w]` with
+  `$/.subst(/. <( '-' )> ./, '..', :g)`, and `.subst`'s native fast path replaced
+  the whole consumed span instead of the `<( … )>` region, so `a-w` became `..`
+  rather than `a..w` and every range-bearing rule compiled to a broken pattern
+  (pin `t/subst-capture-markers.t`).
+  **Six of the seven files now pass completely.** The last one,
+  `t/walk.rakutest`, dies with `Unknown function: recurse` — a method's nested
+  `sub` is unresolvable inside `gather` when the class holds a doubly-nested
+  package; standalone repro in
+  `todo/tickets/nested-sub-in-gather-under-doubly-nested-class.md`. Fixing that
+  closes T-050. Separate: a `<sym>` auto-capture is not recorded on a
   multi-candidate proto match (the action doesn't read it, so it doesn't affect
   File::Ignore).
 

--- a/news/2026-07/subst-honours-capture-markers.md
+++ b/news/2026-07/subst-honours-capture-markers.md
@@ -1,0 +1,40 @@
+# `.subst` / `s///` replace the `<( … )>` region, not everything the pattern consumed
+
+```raku
+say 'xaby'.subst(/a <( b )>/, 'Z');            # raku: xaZy   was: xZy
+say 'a-w'.subst(/. <( '-' )> ./, '..', :g);    # raku: a..w   was: ..
+```
+
+`<(` and `)>` narrow a match to the marked region even though the pattern
+consumed more — that is the whole point of them, and it is how you write "match
+`-` but only when it has a character on each side". `.subst` spans its
+replacement with the match, so ignoring the markers overwrote the context the
+pattern had only *looked* at.
+
+## Root cause
+
+Smart-matching was already correct: `'xaby' ~~ /a <( b )>/` reports `.from` 2,
+`.to` 3, and every general match entry point (`regex_match_with_captures_core`,
+`regex_match_all_with_captures`, the `.parse` finder) narrows `caps.from`/`.to`
+to `capture_start`/`capture_end` when the markers are present.
+
+`regex_find_first_from_with_captures` did not. It returned the raw
+`(start, end)` of the consumed span, and it is what `.subst`'s native fast path
+(`vm_native_subst.rs`) walks to place each replacement — so exactly the marked
+case came out wrong, in both the `.subst` method and the `s///` operator, global
+and not. It now narrows the same way its siblings do, in both its plain and its
+`:m`-ignoremark branch.
+
+## Impact
+
+`File::Ignore` (`TODO_dist` T-050) compiles a `[a-w]` character range into a
+Raku character class with `$/.subst(/. <( '-' )> ./, '..', :g)` — turning `a-w`
+into `a..w`. Under the old behaviour that produced `..`, so every range-bearing
+ignore rule compiled to a broken pattern. `t/range.rakutest` now passes, and with
+it six of the dist's seven files are clean (only `t/walk.rakutest` remains — a
+separate nested-`sub`-in-`gather` bug, recorded as
+`todo/tickets/nested-sub-in-gather-under-doubly-nested-class.md`).
+
+Pin: `t/subst-capture-markers.t` (8 assertions, each verified against raku:
+both-sided, leading-only and trailing-only markers, `:g`, the `s///` operator
+form, and a marker-free pattern as the control).

--- a/src/runtime/regex/regex_match_find.rs
+++ b/src/runtime/regex/regex_match_find.rs
@@ -385,8 +385,8 @@ impl Interpreter {
                     &pkg,
                 ) {
                     return Some((
-                        map_pos(start, &pos_map, orig_len),
-                        map_pos(end, &pos_map, orig_len),
+                        map_pos(caps.capture_start.unwrap_or(start), &pos_map, orig_len),
+                        map_pos(caps.capture_end.unwrap_or(end), &pos_map, orig_len),
                         caps.positional,
                     ));
                 }
@@ -398,7 +398,17 @@ impl Interpreter {
             if let Some((end, caps)) =
                 self.regex_match_end_from_caps_in_pkg(&parsed, &orig_chars, start, &pkg)
             {
-                return Some((start, end, caps.positional));
+                // `<( … )>` narrows the reported match to the marked region even
+                // though the pattern consumed more, exactly as the other match
+                // entry points do. `.subst`'s native fast path spans a
+                // replacement with what this returns, so ignoring the markers
+                // would overwrite the context the pattern only looked at
+                // (`'xaby'.subst(/a <( b )>/, 'Z')` is `xaZy`, not `xZy`).
+                return Some((
+                    caps.capture_start.unwrap_or(start),
+                    caps.capture_end.unwrap_or(end),
+                    caps.positional,
+                ));
             }
         }
         None

--- a/t/subst-capture-markers.t
+++ b/t/subst-capture-markers.t
@@ -1,0 +1,33 @@
+use Test;
+
+plan 8;
+
+# `<( … )>` narrows a match to the marked region even though the pattern
+# consumed more. `.subst` spans its replacement with the match, so ignoring the
+# markers overwrote the context the pattern had only looked at.
+
+is 'xaby'.subst(/a <( b )>/, 'Z'), 'xaZy',
+    'subst replaces only the marked region, not the consumed one';
+is 'a-w'.subst(/. <( '-' )> ./, 'X'), 'aXw',
+    'markers on both sides keep both context characters';
+is 'a-w'.subst(/. <( '-' )> ./, '..', :g), 'a..w',
+    ':g subst honours the markers too';
+is 'a-z-'.subst(/. <( '-' )> ./, '..', :g), 'a..z-',
+    'a trailing character with no follower is left alone';
+
+# The `s///` operator form goes the same way.
+{
+    my $s = 'a-w';
+    $s ~~ s/. <( '-' )> ./X/;
+    is $s, 'aXw', 's/// honours the markers';
+}
+
+# A marker on one side only.
+is 'foobar'.subst(/foo <( bar )>/, 'X'), 'fooX',
+    'a leading-only marker keeps the prefix';
+is 'foobar'.subst(/<( foo )> bar/, 'X'), 'Xbar',
+    'a trailing-only marker keeps the suffix';
+
+# Without markers nothing changes.
+is 'a-w'.subst(/'-'/, 'X'), 'aXw',
+    'a pattern with no markers still replaces its whole match';

--- a/todo/tickets/nested-sub-in-gather-under-doubly-nested-class.md
+++ b/todo/tickets/nested-sub-in-gather-under-doubly-nested-class.md
@@ -1,0 +1,61 @@
+# A method's nested `sub` is unresolvable inside `gather` when the class holds a doubly-nested package
+
+Found 2026-07-25 in File::Ignore (`TODO_dist` T-050), the last failing file of
+that dist once the `<( … )>` and per-match-`:my` fixes landed.
+
+## Repro
+
+```raku
+class O {
+    class I { class C { } }                 # <-- two levels of nesting
+    method w() {
+        sub r() { take 7 }
+        gather r()
+    }
+}
+say O.new.w.List;
+# raku:  (7)
+# mutsu: ()      (and "Unknown function: recurse" in the real dist)
+```
+
+Three things each make it go away, which brackets the cause tightly:
+
+- **one** level of nesting works: `class O { class I { }; method w() { … } }` → `(7)`;
+- calling the nested sub **outside** `gather` works:
+  `method w() { sub r() { 7 }; r() }` → `7`, even with `class I { class C { } }`;
+- a **top-level** sub called inside `gather` works, even with a doubly-nested
+  class in scope.
+
+So it is the combination: a `sub` declared in a method body, called from inside
+`gather`, in a class that contains a package declaration nested two deep.
+
+## Impact
+
+`File::Ignore` `t/walk.rakutest` — its `method walk` is exactly this shape:
+
+```raku
+method walk(Str() $path) {
+    sub recurse($path, $prefix) { for dir($path) { … recurse($_, "$target/") … } }
+    gather recurse($path, '');
+}
+```
+
+and `File::Ignore` nests `class Rule { grammar Parser {…} class RuleCompiler {…} }`.
+It dies with `Unknown function: recurse`. With this fixed the dist's remaining
+file passes and **T-050 closes** — the other six files are already clean.
+
+Reproducing it standalone needs no module and no `dir()`; the snippet above is
+enough.
+
+## Where to look
+
+The nested sub is registered under the enclosing package, and `gather` runs its
+body in a context whose `current_package` differs — a second level of package
+nesting appears to leave the wrong package current when the gather body
+resolves a by-name call. Likely files: `runtime/registry.rs` /
+`registration_class_decl.rs` (how a method-body `sub` is keyed),
+`vm/vm_call_func_ops.rs` (by-name resolution and its package scoping), and the
+gather/take implementation's package handling.
+
+Note the failure is silent in the reduced form (an empty gather) and only
+surfaces as `Unknown function` in the dist, so fix and pin **both** shapes.


### PR DESCRIPTION
```raku
say 'xaby'.subst(/a <( b )>/, 'Z');            # raku: xaZy   was: xZy
say 'a-w'.subst(/. <( '-' )> ./, '..', :g);    # raku: a..w   was: ..
```

`<(` and `)>` narrow a match to the marked region even though the pattern
consumed more — that is the point of them, and it is how you write "match `-`,
but only when it has a character on each side". `.subst` spans its replacement
with the match, so ignoring the markers overwrote the context the pattern had
only *looked* at.

## Root cause

Smart-matching was already correct: `'xaby' ~~ /a <( b )>/` reports `.from` 2,
`.to` 3, and every general match entry point (`regex_match_with_captures_core`,
`regex_match_all_with_captures`, the `.parse` finder) narrows `caps.from`/`.to`
to `capture_start`/`capture_end` when the markers are present.

`regex_find_first_from_with_captures` did not — it returned the raw
`(start, end)` of the consumed span. That is the finder `.subst`'s native fast
path (`vm_native_subst.rs`) walks to place each replacement, so exactly the
marked case came out wrong, in both the `.subst` method and the `s///` operator,
global and not. It now narrows the same way its siblings do, in both its plain
and its `:m` ignoremark branch.

## Impact

`File::Ignore` (`TODO_dist` T-050) compiles a `[a-w]` character range into a Raku
character class with `$/.subst(/. <( '-' )> ./, '..', :g)` — turning `a-w` into
`a..w`. Under the old behaviour that produced `..`, so **every range-bearing
ignore rule compiled to a broken pattern**. `t/range.rakutest` now passes and
**six of the dist's seven files are clean**.

## Also in this PR: the last File::Ignore blocker, recorded

`t/walk.rakutest` dies with `Unknown function: recurse`. Reduced to a standalone
repro with no module and no `dir()`:

```raku
class O {
    class I { class C { } }          # two levels of nesting
    method w() { sub r() { take 7 }; gather r() }
}
say O.new.w.List;    # raku: (7)   mutsu: ()
```

Three things each make it go away, which brackets it tightly: one level of
nesting works; calling the nested sub outside `gather` works; a top-level sub
inside `gather` works. Recorded as
`todo/tickets/nested-sub-in-gather-under-doubly-nested-class.md` — fixing it
closes T-050.

## Verification

- `t/subst-capture-markers.t` — 8 new assertions, each first verified against
  `raku`: both-sided, leading-only and trailing-only markers, `:g`, the `s///`
  operator form, and a marker-free pattern as the control.
- `make test`: 2450 files / 23349 tests, all pass.
- `make roast` (full whitelist, local): `Result: PASS`, 218509 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)