### PR TITLE
fix: a sigilless param no longer re-reads the callee's freshly-reset `$_`

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -741,7 +741,9 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   ~~File::Ignore~~ (FIXED — all 7 files 103/103; see Done),
   ~~IO::Path::AutoDecompress~~ (FIXED — see Done), ~~Math::Angle~~ (FIXED — see Done),
   ~~Math::PascalTriangle~~ (FIXED — see Done),
-  ~~Statistics::LinearRegression~~ (FIXED — see Done), String::Rotate,
+  ~~Statistics::LinearRegression~~ (FIXED — see Done),
+  String::Rotate (PARTIAL — the `method rotate` half passes via the
+  sigilless-param topic fix; see Done),
   Text::CodeProcessing (PARTIAL — extraction 05/07 pass via `&Named` + frugal-`:g`
   fixes; code-eval 02/03/04/06 deferred; see Done),
   Trait::IO, WriteOnceHash, `are`, ~~`sortuk`~~ (FIXED — see Done),
@@ -750,9 +752,15 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 - These `test_die` on the current binary but were not individually reproduced.
   Split off a dedicated ticket when you pick one up.
 - Triaged 2026-07-23 (deferred, each deep — own root cause):
-  - **String::Rotate**: an imported `sub rotate` must override the builtin `rotate`
-    listop (mutsu's builtin shadows it in all call forms) — same class as T-054
-    (P5push) builtin-vs-imported-sub dispatch. DEFER.
+  - **String::Rotate**: PARTIALLY FIXED 2026-07-25 — see Done. The 2026-07-23
+    triage note ("an imported `sub rotate` must override the builtin in all call
+    forms") was only half right: the `method rotate` half failed for an unrelated
+    reason (a sigilless param re-read the callee's reset `$_`), now fixed. The
+    `sub rotate` half is the builtin-shadow issue, and its condition is narrower
+    than "all call forms" — the user sub loses only when it has a **default
+    parameter** and the argument count matches a native builtin arity. Root cause
+    and repro: `todo/tickets/builtin-shadow-with-default-param-loses.md`. Same
+    class as T-054 (P5push).
   - **WriteOnceHash**: `self.BIND-KEY`/`self.ASSIGN-KEY`/`self.DELETE-KEY` don't
     dispatch on a fresh `class ... is Hash` instance (Array-subclass `self.push`
     is the same no-op) — deep container-subclass-instance self-mutation gap. DEFER
@@ -1191,3 +1199,21 @@ _(move tickets here with `[claim: <branch>]` when you start)_
   **Residual (FIXED above):** Tree::Binary defines
   `class Iterator does Iterator` inside `package Tree::Binary`, where the second
   `Iterator` is the **core Raku `Iterator` role**.
+
+- **T-057 (String::Rotate)** (PR `fix-sigilless-param-magic-source`) — test_die
+  (0 of 136 ran) → 68/136, the whole `method rotate` half. One general bug: a
+  sigilless parameter (`\ch`) is bound by re-reading its argument from the
+  CALLEE's env under the argument's source name (so a later `ch := …` writes
+  through), and that reread did not exclude the per-routine magic names. By
+  binding time the frame has already reset `$_` to Any and `$!` to Nil and
+  rebound `@_`/`%_`, so `$str.rotate($_)` bound the blanked topic — a type error
+  for `Int \ch`, a silent `Any` for an untyped `\ch`. The `?`-prefixed
+  compile-time pseudo-variables were already excluded for exactly this reason;
+  `_`/`!`/`@_`/`%_` joined them (`runtime/types/binding_signature.rs`).
+  The apparent dependence on the invocant smiley (`Str:D:` failed, `Str:` worked)
+  was the source-name list lining up with the positional index only in some
+  signature shapes. Pin: `t/sigilless-param-magic-source.t`.
+  **Residual (own root cause, deferred):** the `sub rotate` half — a user sub that
+  shadows a builtin loses the call when it has a default parameter and the
+  argument count matches a native builtin arity
+  (`todo/tickets/builtin-shadow-with-default-param-loses.md`).

--- a/news/2026-07/sigilless-param-rereads-reset-topic.md
+++ b/news/2026-07/sigilless-param-rereads-reset-topic.md
@@ -1,0 +1,58 @@
+# A sigilless parameter no longer re-reads the callee's freshly-reset `$_`
+
+Passing the topic to a routine with a sigilless parameter bound the *type object*
+instead of the value:
+
+```raku
+class K { method m (K:D: Int \ch = 1) { "ch={ch}" } }
+$_ = 7;
+K.new.m($_);
+# raku:  ch=7
+# mutsu: X::TypeCheck::Binding::Parameter: Type check failed for ch: expected Int, got Package
+```
+
+An untyped `\ch` was worse — it bound `Any` silently, so the body just saw an
+uninitialized value. A sigiled `Int $ch` was already correct, which is what made
+the bug look arbitrary.
+
+Found in `String::Rotate` (`TODO_dist` T-057), whose test does
+`for ^$str.chars { $str.rotate($_) }` against
+`multi method rotate (Str:D: Int \ch = 1)` — the whole file died at the first
+call.
+
+## Root cause
+
+A sigilless parameter is bound by re-reading its argument from the **callee's**
+env under the argument's source name, so a later `x := …` can write through to
+the caller's variable. `binding_signature.rs` already excluded the compile-time
+pseudo-variables from that reread, for exactly the right reason:
+
+> Compile-time pseudo-variables (?CLASS, ?ROLE, ?PACKAGE, etc.) should NOT be
+> re-resolved from the callee's env because the env may have already overwritten
+> them.
+
+The per-routine magic names are the same hazard and were missing. By the time
+binding runs, the frame has already reset `$_` to `Any` and `$!` to `Nil`, and
+rebound `@_`/`%_` to its own arguments. So `f($_)` re-read the freshly-blanked
+`_` and bound `Any`.
+
+The reason it looked like it depended on the invocant smiley (`K:D:` failed,
+`K:` worked) is that the source-name list only lines up with the positional index
+in some signature shapes; where it did not line up, the reread was skipped and
+the passed value survived by accident.
+
+## Fix
+
+The reread now skips `_`, `!`, `@_` and `%_` alongside the `?`-prefixed
+pseudo-variables, using the argument value as passed. Ordinary lexicals are
+untouched, so `sub writes (\x) { x = 99 }` still aliases and writes through.
+
+`String::Rotate`'s method half now passes. Its `sub rotate` half is a separate,
+broader root cause — a user sub that shadows a builtin loses the call when it has
+a default parameter — recorded in
+`todo/tickets/builtin-shadow-with-default-param-loses.md`.
+
+Pin: `t/sigilless-param-magic-source.t` (12 tests, identical output under `raku`)
+— the topic through every invocant shape, from a `for` loop and a `given`, `$!`
+as an argument, the write-through alias that must keep working, and the
+`augment` + role shape from the dist.

--- a/src/runtime/types/binding_signature.rs
+++ b/src/runtime/types/binding_signature.rs
@@ -1388,10 +1388,20 @@ impl Interpreter {
                             // should NOT be re-resolved from the callee's env because the
                             // env may have already overwritten them (e.g., ?CLASS is set to
                             // the method's owner class). Use the argument value as-is.
+                            //
+                            // The per-routine magic names are the same hazard and were
+                            // missing: this frame has ALREADY reset `$_` to Any and `$!`
+                            // to Nil, and rebound `@_`/`%_` to its own arguments, before
+                            // binding runs. So `f($_)` into a sigilless `\x` re-read the
+                            // callee's freshly-blanked `_` and bound the Any type object
+                            // — a plain `$x` param, which does not re-read, got the real
+                            // value (`method m (K:D: Int \ch)` called as `$k.m($_)`).
                             let is_compile_time_pseudo = source_name.starts_with('?');
+                            let is_routine_reset_magic =
+                                matches!(source_name.as_str(), "_" | "!" | "@_" | "%_");
                             let resolved_source =
                                 self.resolve_sigilless_alias_source_name(&source_name);
-                            if is_compile_time_pseudo {
+                            if is_compile_time_pseudo || is_routine_reset_magic {
                                 self.env.remove(&alias_key);
                                 self.env.insert(readonly_key, Value::TRUE);
                             } else if let Some(source_val) = self.env.get(&resolved_source).cloned()

--- a/t/sigilless-param-magic-source.t
+++ b/t/sigilless-param-magic-source.t
@@ -1,0 +1,58 @@
+use Test;
+
+plan 12;
+
+# A sigilless parameter (`\x`) re-reads its argument from the callee's env by the
+# argument's SOURCE name, so that a later `x := …` can write through. That reread
+# must not apply to the per-routine magic names: this frame has already reset `$_`
+# to Any and `$!` to Nil, and rebound `@_`/`%_` to its own arguments, before
+# binding runs — so `f($_)` bound the freshly-blanked topic instead of the value.
+
+class K {
+    method smiley    (K:D: Int \ch = 1) { "smiley={ch}" }
+    method smiley-nd (K:D: Int \ch)     { "smiley-nd={ch}" }
+    method plain     (K:   Int \ch)     { "plain={ch}" }
+    method noinv     (Int \ch)          { "noinv={ch}" }
+    method sigiled   (K:D: Int $ch)     { "sigiled=$ch" }
+    method untyped   (K:D: \ch)         { "untyped={ch}" }
+}
+
+my $k = K.new;
+$_ = 7;
+
+is $k.smiley($_),    'smiley=7',    'a sigilless param takes the topic through a :D invocant';
+is $k.smiley-nd($_), 'smiley-nd=7', 'and with no default';
+is $k.plain($_),     'plain=7',     'and through a plain invocant';
+is $k.noinv($_),     'noinv=7',     'and with no explicit invocant';
+is $k.sigiled($_),   'sigiled=7',   'a sigiled param was already right';
+is $k.untyped($_),   'untyped=7',   'an untyped sigilless param takes the topic, not Any';
+
+# The topic from a `for` loop and from `given`, which is how it shows up in real
+# code (String::Rotate's `for ^$str.chars { $str.rotate($_) }`).
+for 7..7   { is $k.smiley($_), 'smiley=7', 'a for-loop topic binds'; }
+given 7    { is $k.smiley($_), 'smiley=7', 'a given topic binds'; }
+
+# `$!` is reset to Nil on entry, so it was the same hazard.
+class E { method take (E:D: \ex) { ex.defined ?? ex.message !! 'Nil' } }
+try { die "boom" };
+is E.new.take($!), 'boom', 'a sigilless param takes $! by value, not the callee-reset Nil';
+
+# A sigilless param must still alias a normal lexical (the reread's actual job).
+sub writes (\x) { x = 99 }
+my $target = 1;
+writes($target);
+is $target, 99, 'a sigilless param still aliases an ordinary lexical for write-through';
+
+# The whole shape from String::Rotate: a role method with a :D invocant and a
+# sigilless param, composed into an augmented builtin class.
+role Rotate {
+    multi method rotate-str (Str:D: Int \ch = 1 --> Str) {
+        my \shft = abs(ch % self.chars);
+        self.substr(shft) ~ self.substr(0, shft)
+    }
+}
+use MONKEY-TYPING;
+augment class Str does Rotate { }
+
+is 'Rakudo'.rotate-str(3), 'udoRak', 'the augment+role shape works with a literal';
+for 3..3 { is 'Rakudo'.rotate-str($_), 'udoRak', 'and with the loop topic'; }

--- a/todo/tickets/builtin-shadow-with-default-param-loses.md
+++ b/todo/tickets/builtin-shadow-with-default-param-loses.md
@@ -1,0 +1,77 @@
+# A user sub that shadows a builtin loses the call when it has a default parameter
+
+Found 2026-07-25 while fixing the sigilless-parameter topic-rebinding bug for
+`String::Rotate` (`TODO_dist` T-057). That fix made the dist's *method* half pass;
+this is the remaining half, and it is a different, broader root cause.
+
+## Repro
+
+`tmp/mlib/MyRot.rakumod`:
+
+```raku
+unit module MyRot;
+sub rotate (Str $s, Int $n = 1 --> Str) is export { "R:$s/$n" }
+sub abs    (Str $s, Int $n = 1 --> Str) is export { "A:$s/$n" }
+```
+
+```raku
+use MyRot;
+say rotate('x', 3);   # raku: R:x/3   mutsu: Nil
+say abs('x', 3);      # raku: A:x/3   mutsu: A:x/3    <- user sub wins
+say abs('x');         # raku: A:x/1   mutsu: dies in the BUILTIN abs
+```
+
+The pattern is sharp: the user's sub loses **exactly when the call's argument
+count matches a native builtin of the same name**. `abs('x', 3)` wins because
+there is no 2-arg builtin `abs`; `abs('x')` and `rotate('x', 3)` lose because
+1-arg `abs` and 2-arg `rotate` exist natively.
+
+A locally-declared `sub rotate` in the same file wins, so this is not simply
+"builtins beat user subs" — it is specific to the shape below.
+
+## Root cause
+
+`vm_call_func_ops.rs` (~line 1247) resolves a single non-proto candidate and, when
+the name is a builtin, applies a deliberately **strict** gate before running it:
+
+```rust
+let gate_ok = if is_builtin {
+    // Genuine builtin shadow: strict gate (no default —
+    // name-cache pollution hazard, PR #3546).
+    Self::def_is_otf_compilable(&def)
+} else {
+    Self::def_is_otf_compilable_module_single(&def)
+};
+```
+
+`def_is_otf_compilable` rejects a signature with a **default parameter**. When it
+rejects, control falls through to `vm_call_function_fallback`, which dispatches
+the native builtin — silently running the wrong routine rather than reporting
+anything. `Int $n = 1` is an extremely ordinary signature, so any module that
+exports a builtin-named sub with a default is affected.
+
+## Why it is not a one-liner
+
+The strict gate exists on purpose: PR #3546 found that OTF-compiling a
+builtin-shadowing def with defaults pollutes the name-keyed call caches. The fix
+is therefore not "relax the gate" but "when the gate rejects, still call the USER
+def (through the interpreter path) instead of falling through to the builtin" —
+i.e. the fallback needs to know a user shadow exists and prefer it. That touches
+the hot named-call path and the caches #3546 was protecting, so it wants its own
+PR with a full roast run.
+
+## Affected files
+
+- `src/vm/vm_call_func_ops.rs` — the `gate_ok` branch (~1247-1285) and the
+  `vm_call_function_fallback` call that follows it
+- `src/runtime/builtins.rs` — `BUILTIN_FUNCTION_NAMES` / `is_builtin_function`,
+  which decides that a name is a builtin at all
+
+## Impact
+
+`String::Rotate`'s `t/01-basic.rakutest`: 68 of 136 subtests (every `sub rotate`
+assertion; the `method rotate` half passes now). Any dist exporting a
+builtin-named sub with a defaulted parameter hits it.
+
+Related, smaller: `&rotate.signature.gist` renders the default as
+`Int \ch = ...` where raku renders `Int \ch = 1`.


### PR DESCRIPTION
## Problem

Passing the topic to a routine with a sigilless parameter bound the *type object* instead of the value:

```raku
class K { method m (K:D: Int \ch = 1) { "ch={ch}" } }
$_ = 7;
K.new.m($_);
# raku:  ch=7
# mutsu: X::TypeCheck::Binding::Parameter: Type check failed for ch: expected Int, got Package
```

An untyped `\ch` was worse — it bound `Any` silently, so the body just saw an uninitialized value. A sigiled `Int $ch` was already correct, which is what made the bug look arbitrary.

Found in `String::Rotate` (`TODO_dist` T-057), whose test does `for ^$str.chars { $str.rotate($_) }` against `multi method rotate (Str:D: Int \ch = 1)` — the whole file died at the first call.

## Root cause

A sigilless parameter is bound by re-reading its argument from the **callee's** env under the argument's source name, so a later `x := …` can write through to the caller's variable. `binding_signature.rs` already excluded the compile-time pseudo-variables from that reread, for exactly the right reason:

> Compile-time pseudo-variables (?CLASS, ?ROLE, ?PACKAGE, etc.) should NOT be re-resolved from the callee's env because the env may have already overwritten them.

The per-routine magic names are the same hazard and were missing. By the time binding runs, the frame has already reset `$_` to `Any` and `$!` to `Nil`, and rebound `@_`/`%_` to its own arguments — so `f($_)` re-read the freshly-blanked `_`.

The reason it *looked* like it depended on the invocant smiley (`K:D:` failed, `K:` worked) is that the source-name list only lines up with the positional index in some signature shapes; where it did not line up, the reread was skipped and the passed value survived by accident.

## Fix

The reread skips `_`, `!`, `@_` and `%_` alongside the `?`-prefixed pseudo-variables, using the argument value as passed. Ordinary lexicals are untouched, so `sub writes (\x) { x = 99 }` still aliases and writes through.

## Result

`String::Rotate` `t/01-basic.rakutest`: **0 of 136 subtests ran → 68/136**, the entire `method rotate` half.

## Tests

- Pin: `t/sigilless-param-magic-source.t` (12 tests) — the topic through every invocant shape, from a `for` loop and a `given`, `$!` as an argument, the write-through alias that must keep working, and the `augment` + role shape from the dist. Identical output under `raku`.
- `make test`: 2455 files, 23408 tests, PASS.
- Roast subset (S02-names-vars / S04 / S06 / S12 / S14 — 316 files, 7773 tests): PASS.

## Left open

The dist's `sub rotate` half is a separate, broader root cause: a user sub that shadows a builtin loses the call when it has a **default parameter** and the argument count matches a native builtin arity (`rotate('x', 3)` → the builtin; `abs('x', 3)` → the user sub, since there is no 2-arg builtin `abs`). The strict `def_is_otf_compilable` gate rejects defaults by design (PR #3546, name-cache pollution), and control then falls through to the builtin instead of to the user def. Filed as `todo/tickets/builtin-shadow-with-default-param-loses.md`; same class as T-054 (P5push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)