### PR TITLE
fix: a sigilless param named after a native type shadows the type

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -742,8 +742,7 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   ~~IO::Path::AutoDecompress~~ (FIXED — see Done), ~~Math::Angle~~ (FIXED — see Done),
   ~~Math::PascalTriangle~~ (FIXED — see Done),
   ~~Statistics::LinearRegression~~ (FIXED — see Done),
-  String::Rotate (PARTIAL — the `method rotate` half passes via the
-  sigilless-param topic fix; see Done),
+  ~~String::Rotate~~ (FIXED — 136/136; three root causes, see Done),
   Text::CodeProcessing (PARTIAL — extraction 05/07 pass via `&Named` + frugal-`:g`
   fixes; code-eval 02/03/04/06 deferred; see Done),
   Trait::IO, WriteOnceHash, `are`, ~~`sortuk`~~ (FIXED — see Done),
@@ -752,15 +751,15 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
 - These `test_die` on the current binary but were not individually reproduced.
   Split off a dedicated ticket when you pick one up.
 - Triaged 2026-07-23 (deferred, each deep — own root cause):
-  - **String::Rotate**: PARTIALLY FIXED 2026-07-25 — see Done. The 2026-07-23
-    triage note ("an imported `sub rotate` must override the builtin in all call
-    forms") was only half right: the `method rotate` half failed for an unrelated
-    reason (a sigilless param re-read the callee's reset `$_`), now fixed. The
-    `sub rotate` half is the builtin-shadow issue, and its condition is narrower
-    than "all call forms" — the user sub loses only when it has a **default
-    parameter** and the argument count matches a native builtin arity. Root cause
-    and repro: `todo/tickets/builtin-shadow-with-default-param-loses.md`. Same
-    class as T-054 (P5push).
+  - **String::Rotate**: FIXED 2026-07-25, 136/136 — see Done. Worth reading as a
+    cautionary tale: the 2026-07-23 triage note ("an imported `sub rotate` must
+    override the builtin in all call forms") named ONE cause, and there were
+    **three**, each independent. (1) the `method rotate` half failed because a
+    sigilless param re-read the callee's reset `$_`; (2) the `sub rotate` half
+    did hit the builtin shadow, but the condition was narrower than "all call
+    forms" — only with a **default parameter** and an argument count matching a
+    native builtin arity; (3) even once called, its `Str(Any) \str` parameter
+    read the `str` TYPE OBJECT. Do not trust a single-cause triage label.
   - **WriteOnceHash**: `self.BIND-KEY`/`self.ASSIGN-KEY`/`self.DELETE-KEY` don't
     dispatch on a fresh `class ... is Hash` instance (Array-subclass `self.push`
     is the same no-op) — deep container-subclass-instance self-mutation gap. DEFER
@@ -1230,8 +1229,23 @@ _(move tickets here with `[claim: <branch>]` when you start)_
   user routine (gated on the name being a builtin, so every other name is
   unchanged). Pin: `t/builtin-shadow-default-param.t`. Same class as T-054
   (P5push), which should be re-checked against this.
-  **Residual (third root cause, deferred):** the dist's signature is
-  `sub rotate (Str(Any) \str, …)`, and a sigilless parameter named after a native
-  type reads the `str` TYPE OBJECT inside a module routine —
-  `todo/tickets/sigilless-param-named-like-a-native-type.md`. String::Rotate
-  stays at 68/136 until that lands.
+  **Residual (third root cause) — FIXED, see the next entry.**
+
+- **T-057 (String::Rotate, part 3 — CLOSES the dist at 136/136)** (PR
+  `fix-sigilless-param-native-type-name`) — the third and last root cause. One
+  general bug: a sigilless parameter named after a native type (`\str`, `\int`)
+  read the TYPE OBJECT instead of its argument, in a routine compiled as a
+  separate compilation unit. The bare-word compiler resolves a sigilless binding
+  from an ENCLOSING scope by name — which is how a module body sees its own
+  signature — but carried an `&& !is_builtin_type(name)` guard, and
+  `is_builtin_type` includes the lowercase natives (`str`, `int`, `num`, `array`,
+  `int8`…`uint64`, `blob8`…`buf64`). So `\str` fell through to `GetBareWord`,
+  which consults the type registry. The same-frame branch already had this right
+  and documents why ("in Raku the lexical binding shadows the native type within
+  its scope"); the guard is now gone from the enclosing branch too
+  (`compiler/expr.rs`). Pin: `t/sigilless-param-named-like-native-type.t` +
+  `t/lib/NativeNameSigilless.rakumod`.
+  **Found while pinning (unrelated, deferred):** `do for` loses the return value
+  of an imported module sub (`do for ^2 { plainsub('x') }` collects `(Any)`,
+  while a local sub, a method, `.map` and `do given` all work) —
+  `todo/tickets/do-for-loses-imported-sub-return-value.md`.

--- a/news/2026-07/sigilless-param-shadows-native-type-name.md
+++ b/news/2026-07/sigilless-param-shadows-native-type-name.md
@@ -1,0 +1,64 @@
+# A sigilless parameter named after a native type now shadows the type
+
+A sigilless parameter whose name coincides with a native type read the **type
+object** instead of its argument — but only for a routine in a `use`d module:
+
+```raku
+# lib/M.rakumod
+unit module M;
+sub probe (Str \str) is export { "name={str.^name} defined={str.defined}" }
+sub other (Str \zzz) is export { "name={zzz.^name}" }
+```
+
+```
+mutsu was:  name=str defined=False   |  name=Str
+raku:       name=Str defined=True    |  name=Str
+```
+
+`\int` behaved the same way (binding the `int` type object), while `\zzz` and a
+sigiled `$str` were always fine. Declaring the same sub in the main script — or
+in an in-file `module M { … }` / `package P { … }` — also worked, which is what
+made it look arbitrary.
+
+## Root cause
+
+A bare word that names a sigilless binding must compile to a read of that
+binding. The compiler handles two cases: a **same-frame** sigilless local, and a
+sigilless binding from an **enclosing** scope (which a separately-compiled module
+body sees, since the signature reaches that compilation through
+`enclosing_sigilless`). The same-frame branch already got this right, and says so:
+
+> Sigilless bindings and in-scope constants: the bare word IS the variable, so
+> read directly from the local slot — even when the name coincides with a native
+> lowercase type (`my \str`, an `Int \ch` param): in Raku the lexical binding
+> shadows the native type within its scope.
+
+The enclosing-scope branch carried an extra `&& !is_builtin_type(name)` guard —
+and `is_builtin_type` includes the lowercase natives `str`, `int`, `num`,
+`array`, `byte`, `int8`…`uint64`, `blob8`…`buf64`. So `\str` fell past it to
+`GetBareWord`, which consults the type registry and returns the type object.
+
+## Fix
+
+The guard is gone: an enclosing sigilless binding shadows a same-named type,
+exactly as a same-frame one does.
+
+`String::Rotate` (`TODO_dist` T-057) now passes **136/136** — its signature is
+`sub rotate (Str(Any) \str, Int \ch = 1 --> Str)`, and this was the last of the
+dist's three root causes (after the sigilless-`$_` reread and the builtin-shadow
+dispatch fixes earlier the same day).
+
+Pin: `t/sigilless-param-named-like-native-type.t` with `t/lib/NativeNameSigilless.rakumod`
+(10 tests, identical output under `raku`) — `\str`/`\int`/`\num` parameters, a
+non-type-named control, the dist's coercion + defaulted-sigilless shape, the
+loop-topic form, the same-frame case, and an unshadowed `str` that must still
+name the type.
+
+## Found while pinning
+
+`do for` loses the return value of an imported module sub — `do for ^2 {
+plainsub('x') }` collects `(Any) (Any)` where a local sub, a method, `.map` and
+`do given` all collect correctly. Unrelated to this fix (it reproduces with an
+ordinary sigiled signature) and filed as
+`todo/tickets/do-for-loses-imported-sub-return-value.md`; the pin's loop
+assertion uses an explicit `for` + `.push` to avoid it.

--- a/src/compiler/expr.rs
+++ b/src/compiler/expr.rs
@@ -190,9 +190,7 @@ impl Compiler {
                         let name_idx = self.code.add_constant(Value::str(name.clone()));
                         self.code.emit(OpCode::GetBareWord(name_idx));
                     }
-                } else if self.enclosing_sigilless.contains(name.as_str())
-                    && !crate::runtime::Interpreter::is_builtin_type(name)
-                {
+                } else if self.enclosing_sigilless.contains(name.as_str()) {
                     // A sigilless binding (`\thing`, `my \x`) from an ENCLOSING
                     // scope, read here from a nested — possibly escaping — closure.
                     // It IS the variable, so emit a by-name global read: GetGlobal
@@ -201,6 +199,15 @@ impl Compiler {
                     // frame's slot value. A plain GetBareWord would not be captured
                     // and would degrade to the literal string once the creating
                     // frame returns (escaping closure / `.^add_method` method body).
+                    //
+                    // This holds even when the name coincides with a builtin type
+                    // (`\str`, `\int`) — a lexical sigilless binding shadows the
+                    // type within its scope, exactly as the `sigilless_locals`
+                    // branch above already documents for the same-frame case. The
+                    // old `!is_builtin_type(name)` guard here sent `\str` to
+                    // GetBareWord, which consults the TYPE registry, so a module
+                    // sub's `Str \str` parameter read the `str` TYPE OBJECT
+                    // instead of its argument (String::Rotate's `sub rotate`).
                     let name_idx = self.code.add_constant(Value::str(name.clone()));
                     self.code.emit(OpCode::GetGlobal(name_idx));
                 } else {

--- a/t/lib/NativeNameSigilless.rakumod
+++ b/t/lib/NativeNameSigilless.rakumod
@@ -1,0 +1,23 @@
+unit module NativeNameSigilless;
+
+# A sigilless parameter whose name coincides with a native type (`str`, `int`,
+# `num`) must shadow that type inside the routine, exactly as a same-frame
+# sigilless binding does. These live in a module because the bug only appeared
+# for a routine compiled in a separate compilation unit, where the body is
+# compiled with the signature supplied through `enclosing_sigilless` rather than
+# as same-frame `sigilless_locals`.
+
+sub takes-str (Str \str) is export { "str=[{str}] name={str.^name}" }
+sub takes-int (Int \int) is export { "int=[{int}] name={int.^name}" }
+sub takes-num (Num \num) is export { "num=[{num}] name={num.^name}" }
+sub takes-other (Str \zzz) is export { "zzz=[{zzz}] name={zzz.^name}" }
+
+# The String::Rotate shape: a coercion type, a defaulted second sigilless param,
+# and a return constraint.
+sub rot (Str(Any) \str, Int \ch = 1 --> Str) is export {
+    my \shft = abs(ch % str.chars);
+    str.substr(shft) ~ str.substr(0, shft)
+}
+
+# The type name must still resolve where no binding shadows it.
+sub type-still-visible is export { str.^name }

--- a/t/sigilless-param-named-like-native-type.t
+++ b/t/sigilless-param-named-like-native-type.t
@@ -1,0 +1,37 @@
+use Test;
+use lib 't/lib';
+use NativeNameSigilless;
+
+plan 10;
+
+# A sigilless parameter named after a native type (`\str`, `\int`) read that
+# TYPE OBJECT instead of its argument, but only for a routine compiled in a
+# separate compilation unit: the BareWord compiler resolved an enclosing-scope
+# sigilless binding by name EXCEPT when the name was a builtin type, and `str`
+# and `int` are builtin type names. In raku a lexical sigilless binding shadows
+# the type within its scope — which the same-frame branch already did.
+
+is takes-str('Rakudo'),  'str=[Rakudo] name=Str', 'a \str parameter binds the argument, not the str type';
+is takes-int(42),        'int=[42] name=Int',     'a \int parameter binds the argument';
+is takes-num(1.5e0),     'num=[1.5] name=Num',    'a \num parameter binds the argument';
+is takes-other('x'),     'zzz=[x] name=Str',      'a non-type-named parameter was already right';
+
+# The String::Rotate shape end to end.
+is rot('Rakudo', 3), 'udoRak', 'the coercion + defaulted-sigilless shape works';
+is rot('Rakudo'),    'akudoR', 'and takes its default';
+is rot('Rakudo', -1), 'oRakud', 'and a negative rotation';
+
+# The loop-topic form the dist actually uses. (Collected by hand rather than with
+# `do for`, which loses an imported sub's return value — a separate bug, see
+# todo/tickets/do-for-loses-imported-sub-return-value.md.)
+my $str = 'Rakudo';
+my @got;
+for ^3 { @got.push: rot($str, $_) }
+is @got, ('Rakudo', 'akudoR', 'kudoRa'), 'called with the loop topic across a range';
+
+# Nothing shadowing: the bare type name still names the type.
+is type-still-visible(), 'str', 'an unshadowed native type name still resolves to the type';
+
+# And in the main script, where the same-frame branch handles it.
+sub local-str (Str \str) { str.^name }
+is local-str('x'), 'Str', 'the same-frame case keeps working';

--- a/todo/tickets/do-for-loses-imported-sub-return-value.md
+++ b/todo/tickets/do-for-loses-imported-sub-return-value.md
@@ -1,0 +1,52 @@
+# `do for` loses the return value of an imported module sub
+
+Found 2026-07-25 while pinning the sigilless-parameter/native-type-name fix
+(`news/2026-07/sigilless-param-shadows-native-type-name.md`). Independent of that
+fix — it reproduces with an ordinary sigiled signature.
+
+## Repro
+
+`tmp/mlib/MyPlain.rakumod`:
+
+```raku
+unit module MyPlain;
+sub plainsub (Str $s) is export { "P:$s" }
+```
+
+```raku
+use MyPlain;
+say do for ^2 { plainsub('x') };        # raku: (P:x P:x)   mutsu: ((Any) (Any))
+say do for ^2 -> $i { plainsub('x') };  # raku: (P:x P:x)   mutsu: ((Any) (Any))
+say do given 1 { plainsub('x') };       # both: (P:x)
+say plainsub('x');                      # both: P:x
+```
+
+Only `do for` is affected. `do given` collects correctly, a plain `for` loop with
+an explicit `.push` collects correctly, `.map` collects correctly, and a
+**locally declared** sub of the same shape collects correctly under `do for`:
+
+```raku
+sub localsub($s) { "L:$s" }
+say do for ^2 { localsub('x') };        # both: (L:x L:x)
+```
+
+So the failing combination is precisely *`do for`* + *a call to an imported
+routine* as the loop body's last statement. The collected value is `Any`, i.e.
+the body's value is read from somewhere that the imported-sub call path does not
+write.
+
+## Where to look
+
+`do for` collects each iteration's value; a local-sub call and a method call both
+land it where the collector reads, while the imported-sub call does not. The
+likely seam is the loop-body value capture (`vm_for_loop_*`, the `do`-prefix
+value collection) versus the return path used for a module/dynamic sub — which
+is the interpreter `call_function_def` route rather than a compiled call, and so
+publishes its result differently.
+
+## Impact
+
+Silent wrong data, not an error — a `do for` over imported routines yields a list
+of `Any`. Any script that builds a list this way from a module's exported subs is
+affected. Found while writing `t/sigilless-param-named-like-native-type.t`, whose
+loop assertion had to be rewritten as an explicit `for` + `.push` to avoid it.


### PR DESCRIPTION
Closes **String::Rotate** (`TODO_dist` T-057) at **136/136** — the third and last of that dist's three independent root causes, after #5423 and #5424.

## Problem

A sigilless parameter whose name coincides with a native type read the **type object** instead of its argument — but only for a routine in a `use`d module:

```raku
# lib/M.rakumod
unit module M;
sub probe (Str \str) is export { "name={str.^name} defined={str.defined}" }
sub other (Str \zzz) is export { "name={zzz.^name}" }
```

```
mutsu was:  name=str defined=False   |  name=Str
raku:       name=Str defined=True    |  name=Str
```

`\int` behaved the same way (binding the `int` type object). `\zzz` and a sigiled `$str` were always fine, and declaring the same sub in the main script — or in an in-file `module M { … }` / `package P { … }` — also worked, which is what made it look arbitrary.

## Root cause

A bare word that names a sigilless binding must compile to a read of that binding. The compiler handles two cases: a **same-frame** sigilless local, and a sigilless binding from an **enclosing** scope (which is how a separately-compiled module body sees its own signature). The same-frame branch already got this right, and says so:

> Sigilless bindings and in-scope constants: the bare word IS the variable, so read directly from the local slot — even when the name coincides with a native lowercase type (`my \str`, an `Int \ch` param): in Raku the lexical binding shadows the native type within its scope.

The enclosing-scope branch carried an extra `&& !is_builtin_type(name)` guard — and `is_builtin_type` includes the lowercase natives `str`, `int`, `num`, `array`, `byte`, `int8`…`uint64`, `blob8`…`buf64`. So `\str` fell past it to `GetBareWord`, which consults the type registry and returns the type object.

## Fix

The guard is removed: an enclosing sigilless binding shadows a same-named type, exactly as a same-frame one does.

## Tests

- Pin: `t/sigilless-param-named-like-native-type.t` + `t/lib/NativeNameSigilless.rakumod` (10 tests) — `\str`/`\int`/`\num` parameters, a non-type-named control, the dist's `Str(Any) \str, Int \ch = 1 --> Str` shape, the loop-topic form, the same-frame case, and an unshadowed bare `str` that must still name the type. Identical output under `raku`.
- `make test`: 2458 files, 23439 tests, PASS.
- **Full `make roast` locally (release): 1432 files, 218509 tests, PASS.** Run in full rather than a subset because this changes bare-word compilation.

## Found while pinning (filed, not fixed here)

`do for` loses the return value of an imported module sub — `do for ^2 { plainsub('x') }` collects `(Any) (Any)` where a **local** sub, a method, `.map` and `do given` all collect correctly. It reproduces with an ordinary sigiled signature, so it is unrelated to this fix. Filed as `todo/tickets/do-for-loses-imported-sub-return-value.md`; the pin's loop assertion uses an explicit `for` + `.push` to avoid it.

## Ledger note

The 2026-07-23 triage of String::Rotate named **one** cause ("an imported `sub rotate` must override the builtin in all call forms") and there were **three**, each independent — and that one was itself narrower than stated. The ticket entry now records that as a cautionary note against trusting a single-cause triage label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)