### PR TITLE
docs: `do for` value loss is runtime state, not a compilation difference

### DIFF
--- a/todo/tickets/do-for-loses-imported-sub-return-value.md
+++ b/todo/tickets/do-for-loses-imported-sub-return-value.md
@@ -35,14 +35,52 @@ routine* as the loop body's last statement. The collected value is `Any`, i.e.
 the body's value is read from somewhere that the imported-sub call path does not
 write.
 
+## Three source-level workarounds, all equivalent
+
+Any of these makes it collect correctly:
+
+```raku
+do for ^2 { (plainsub('x')) }              # wrap the call in parens
+do for ^2 { my $r = plainsub('x'); $r }    # assign to a temp first
+do for ^2 { "{plainsub('x')}" }            # interpolate it
+```
+
+Only the *bare* call as the body's last statement loses the value. A trailing
+semicolon does not help (`{ plainsub('x'); }` still yields `Any`).
+
+## It is NOT a compilation difference — measured 2026-07-25
+
+`--dump-bytecode` on a file containing the parenthesized form and two bare forms
+produces **byte-identical opcode sequences** for all three loop bodies (only the
+local slot indices differ):
+
+```
+     5: ForLoop(...)         20: ForLoop(...)         35: ForLoop(...)
+     6: LoadConst(4)         21: LoadConst(4)         36: LoadConst(4)
+     7: ContainerizePair     22: ContainerizePair     37: ContainerizePair
+     8: CallFunc{name_idx:5, arity:1, arg_sources_idx:None}   (all three)
+```
+
+yet at runtime the first yields `["P:x", "P:x"]` and the other two yield
+`[Any, Any]`. The full ASTs are identical too (`--dump-ast`, ignoring `SetLine`).
+So whatever diverges is **runtime state**, not the emitted code — which rules out
+the "loop-body value capture vs. the compiled-call return path" guess this ticket
+originally recorded, and means the next investigator should NOT start in the
+compiler.
+
+Ordering is not the variable either: with four calls alternating bare/parens the
+result alternates `Nil, ok, Nil, ok`, and with four bare calls all four fail.
+
 ## Where to look
 
-`do for` collects each iteration's value; a local-sub call and a method call both
-land it where the collector reads, while the imported-sub call does not. The
-likely seam is the loop-body value capture (`vm_for_loop_*`, the `do`-prefix
-value collection) versus the return path used for a module/dynamic sub — which
-is the interpreter `call_function_def` route rather than a compiled call, and so
-publishes its result differently.
+Since the bytecode is identical, look at what the `CallFunc` execution path does
+differently for an imported routine while a `ForLoop` with `collect: true` is
+active — e.g. whether the value is left on the stack versus published through the
+topic/`_` slot that the collector reads. `vm_for_loop_*` (the collect arm) and the
+imported/dynamic-sub return path (`call_function_def` → the env merge) are the two
+sides to instrument. Do this by measuring, not by reading: put a temporary
+`eprintln` at the collect point and at the call's return and compare the two
+forms.
 
 ## Impact
 


### PR DESCRIPTION
Docs-only, on `todo/tickets/do-for-loses-imported-sub-return-value.md`.

I started on this ticket and did **not** find the cause, but did rule out the explanation the ticket originally recorded — which is worth writing down so the next attempt does not repeat it.

## What was measured

`--dump-bytecode` on one file containing the working parenthesized form and two failing bare forms produces **byte-identical opcode sequences** for all three loop bodies (only local slot indices differ):

```
     5: ForLoop(...)         20: ForLoop(...)         35: ForLoop(...)
     6: LoadConst(4)         21: LoadConst(4)         36: LoadConst(4)
     7: ContainerizePair     22: ContainerizePair     37: ContainerizePair
     8: CallFunc{name_idx:5, arity:1, arg_sources_idx:None}   (all three)
```

Runtime: the first yields `["P:x", "P:x"]`, the other two yield `[Any, Any]`. Full ASTs match as well (ignoring `SetLine`).

So the divergence is **runtime state, not emitted code**. The ticket's original "the loop-body value capture vs. the compiled-call return path publishes its result differently" was a compile-side guess and is wrong as stated.

## Also recorded

- Three equivalent source-level workarounds — wrap in parens, assign to a temp, or interpolate. Only a *bare* call as the body's last statement loses the value, and a trailing semicolon does **not** help.
- Ordering is not the variable: four alternating bare/parens calls alternate `Nil, ok, Nil, ok`; four bare calls all fail.
- A pointer to instrument the collect point and the call's return with a temporary `eprintln` rather than reading the compiler — the approach that cracked #5425 after a guessed fix had failed.

No behaviour change; the bug is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)