### PR TITLE
docs: `do for` root cause — the executed body runs a SinkPop that drops the value

### DIFF
--- a/todo/tickets/do-for-loses-imported-sub-return-value.md
+++ b/todo/tickets/do-for-loses-imported-sub-return-value.md
@@ -71,16 +71,40 @@ compiler.
 Ordering is not the variable either: with four calls alternating bare/parens the
 result alternates `Nil, ok, Nil, ok`, and with four bare calls all four fail.
 
+## Measured further: the call is fine, the value is replaced afterwards
+
+Two temporary `eprintln`s — one after `OpCode::CallFunc` in `vm_exec_dispatch.rs`,
+one at the collect point in `vm_for_loop_body.rs` (`if let Some(ref mut coll) =
+collected`) — printing the stack top, over the three-loop file above:
+
+```
+[DBG-callfunc] plainsub -> top=Some("P:x")     [DBG-collect] stack_len=1 base=0 top=Some("P:x")   # parens: OK
+[DBG-callfunc] plainsub -> top=Some("P:x")     [DBG-collect] stack_len=1 base=0 top=Some("")      # bare:   LOST
+[DBG-callfunc] plainsub -> top=Some("P:x")     [DBG-collect] stack_len=1 base=0 top=Some("")      # semi:   LOST
+```
+
+So:
+
+- **`CallFunc` pushes the correct value in every case** — the imported-sub call
+  path is not at fault, and neither is the collector (it faithfully collects
+  whatever is on top).
+- Between the call and the collect point, the stack still has exactly **one**
+  element (`stack_len=1 base=0` in all six iterations) but in the bare case that
+  single element has been **replaced** by `Any`.
+
+Nothing is popped and re-pushed — the count never changes — so whatever runs
+between the two points overwrites the slot in place, or the pushed value is an
+alias (a `ContainerRef`/topic cell) whose target is reset by the loop epilogue.
+`spec.restore_topic` is `true` for this loop, and the epilogue also runs
+`write_back_for_topic_item` / `write_back_to_source_var`; those are the first
+things to check. Why the parenthesized form escapes it is still unexplained and
+is the crux.
+
 ## Where to look
 
-Since the bytecode is identical, look at what the `CallFunc` execution path does
-differently for an imported routine while a `ForLoop` with `collect: true` is
-active — e.g. whether the value is left on the stack versus published through the
-topic/`_` slot that the collector reads. `vm_for_loop_*` (the collect arm) and the
-imported/dynamic-sub return path (`call_function_def` → the env merge) are the two
-sides to instrument. Do this by measuring, not by reading: put a temporary
-`eprintln` at the collect point and at the call's return and compare the two
-forms.
+`vm_for_loop_body.rs`, between the body's last op and the `collected` push: the
+topic restore and the two writeback helpers. Instrument the stack top after each
+of them.
 
 ## Impact
 

--- a/todo/tickets/do-for-loses-imported-sub-return-value.md
+++ b/todo/tickets/do-for-loses-imported-sub-return-value.md
@@ -100,11 +100,45 @@ alias (a `ContainerRef`/topic cell) whose target is reset by the loop epilogue.
 things to check. Why the parenthesized form escapes it is still unexplained and
 is the crux.
 
+## ROOT CAUSE FOUND (2026-07-25): the executed body contains a `SinkPop`
+
+Printing the *executed* op range at the top of the epilogue
+(`run_start..loop_end` plus the opcodes in it) gives:
+
+```
+parens (OK):   range=6..9    ops=["LoadConst(4)", "ContainerizePair", "CallFunc{…}"]
+bare (LOST):   range=21..26  ops=["LoadConst(4)", "ContainerizePair", "CallFunc{…}", "SinkPop(false)", "LoadConst(9)"]
+```
+
+The bare form's loop body runs a **`SinkPop`** after the call — which discards
+the value — while the parenthesized form does not. `compile_stmt`'s
+`Stmt::Expr` arm emits `SinkPop`; `compile_stmts_value`'s `is_last` arm (the
+value-collecting path a `do for` body should use) does not. So the body's last
+statement is being compiled through the **sink-statement** path instead of the
+value path.
+
+### Why the earlier "identical bytecode" measurement was wrong
+
+`--dump-bytecode` on the same file shows op 24 as `SetLocalDecl`, but the
+*executed* op 24 is `SinkPop(false)`. **The dumped and executed bytecode differ**
+— the mainline is recompiled at runtime (after `use` has loaded the module), and
+only the recompiled chunk carries the `SinkPop`. The earlier full-file bytecode
+diff also used an `-e` program with no `use`, where the imported name is unknown
+and no recompile happens; that is why both forms looked identical. **Do not trust
+`--dump-bytecode` for a program that `use`s a module — dump the executed range
+instead.**
+
+That also explains every observation: it is not "imported vs local" per se, it is
+"this statement was recompiled through the sink path". Parens/temp/interpolation
+all change the last statement's shape enough to avoid it.
+
 ## Where to look
 
-`vm_for_loop_body.rs`, between the body's last op and the `collected` push: the
-topic restore and the two writeback helpers. Instrument the stack top after each
-of them.
+The runtime recompile path (`compile_block_raw` / whatever recompiles the
+mainline after a module load) and how it chooses `compile_stmt` vs
+`compile_stmts_value` for a value-collecting `do for` body — the `collect: true`
+context must reach it. `compiler/stmt.rs:489` (`Stmt::Expr` → `SinkPop`) versus
+`compiler/helpers_control_flow.rs:33` (`compile_stmts_value`).
 
 ## Impact
 


### PR DESCRIPTION
Docs-only, on `todo/tickets/do-for-loses-imported-sub-return-value.md`. **Root cause found**, not yet fixed.

## The cause

Printing the *executed* op range at the loop epilogue, over one file holding the working parenthesized form and the failing bare forms:

```
parens (OK):   range=6..9    ops=["LoadConst(4)", "ContainerizePair", "CallFunc{...}"]
bare (LOST):   range=21..26  ops=["LoadConst(4)", "ContainerizePair", "CallFunc{...}", "SinkPop(false)", "LoadConst(9)"]
```

The bare form's loop body runs a **`SinkPop`** after the call, which discards the value. `compile_stmt`'s `Stmt::Expr` arm emits `SinkPop` (`compiler/stmt.rs:489`); `compile_stmts_value`'s `is_last` arm — the value-collecting path a `do for` body should use (`compiler/helpers_control_flow.rs:33`) — does not. So the body's last statement is compiled through the **sink-statement** path instead of the value path.

Earlier measurements had already shown `CallFunc` pushing the correct value and the collector faithfully collecting the top, which is consistent: the value is dropped in between, by an opcode.

## Correcting the previous entry

`--dump-bytecode` on the same file shows op 24 as `SetLocalDecl`, but the **executed** op 24 is `SinkPop(false)`. The dumped and executed bytecode differ — the mainline is recompiled at runtime after the module loads, and only the recompiled chunk carries the `SinkPop`. The earlier full-file bytecode diff also used an `-e` program with no `use`, where the imported name is unknown and no recompile happens, which is why both forms looked identical.

So the previous "identical bytecode, therefore runtime state, do not start in the compiler" conclusion (#5427 and this PR's first commit) was **wrong**, and the ticket now says so explicitly, with a warning not to trust `--dump-bytecode` for a program that `use`s a module.

It also means this is not really "imported vs local" — it is "this statement got recompiled through the sink path". Parens, a temp, or interpolation each change the last statement's shape enough to avoid it.

## Where the fix goes

The runtime recompile path and how it chooses `compile_stmt` vs `compile_stmts_value` for a value-collecting `do for` body — the `collect: true` context has to reach it.

No behaviour change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
