### PR TITLE
fix: `=>` participates in Whatever-currying

### DIFF
--- a/docs/batteries/yaml.md
+++ b/docs/batteries/yaml.md
@@ -1,0 +1,157 @@
+# Battery: YAML — `YAMLish` (selected; blocked on interpreter work)
+
+**Slot:** YAML parse/emit · **Chosen:** `YAMLish`
+(`auth<zef:leont>`, v0.1.3, Artistic-2.0) · **Kind:** Adopted (community module,
+to be vendored as-is) · **Yardstick:**
+[BATTERIES.md §2](../../BATTERIES.md#2-selection-criteria) — license (hard gate)
+→ dependency weight → proven behaviour on mutsu → API fit → **safe-by-default
+loading** (see [security](#security-safe_load-by-default)).
+
+The procedure that produced the table below is
+[selection-method.md](selection-method.md).
+
+## Status: decided, not yet bundled
+
+`YAMLish` is the choice, but it does **not run on mutsu yet** — it must not be
+advertised as a working battery until the blocking interpreter bugs are fixed
+(per [BATTERIES.md §5](../../BATTERIES.md), only working libraries get a public
+row). Under `raku` all 5 upstream test files pass; under mutsu the module fails
+to `use` at all. This is the normal "fix mutsu first" outcome
+([selection-method.md §5](selection-method.md)): the survey's real output is a
+work list, and the winner is unambiguous.
+
+Target API once it runs:
+
+```raku
+use YAMLish;
+my %data = load-yaml("name: mutsu\ntags: [raku, yaml]\n");   # safe_load-equivalent
+say to-yaml(%data);                                          # emitter
+```
+
+## The field it was chosen from
+
+Enumerated from the local REA + fez indices (`~/.zef/store/{rea,fez}/*.json`,
+the same data `mzef` uses), filtered on name/description/tags for YAML, with the
+Sparrowdo-VSTS generators and `YAMLScript` (a *programming-in-YAML* language, not
+a data parser) excluded as out-of-slot. Reverse-dependency counts are over the
+same indices.
+
+| Candidate | Version | Released | License | Runtime deps | Dependents | raku | mutsu |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| **`YAMLish`** | 0.1.3 | 2026-07-04 | **Artistic-2.0** | `MIME::Base64` (**already bundled**) | **459** | **5/5** | **0/5** (load-blocked) |
+| `YAML` | 0.1 | 2021-01-28 | Artistic-2.0 | `TestML` (test-only) | 2 | not measured | not measured |
+| `YAMLStar` | 0.1.17 | 2026-07-21 | **None** | 0 | 0 | — | — |
+| `LibYAML` | 0.2.1 | 2017-06-12 | Artistic-2.0 | `NativeCall` (binds system `libyaml`) | 0 | — | — |
+| `YAML::Parser::LibYAML` | 0.0.6 | 2021-01-19 | **None** | `LibraryMake` + NativeCall | 0 | — | — |
+| `Config::Parser::yaml` | 1.0.1 | 2017-10-14 | **GPL-3.0** | `Config`, `YAMLish` | (wrapper) | — | — |
+
+`YAMLish`'s 459 dependents is not a rounding artefact — it is the ecosystem's
+de-facto YAML module (it is also a common test/config dependency), so it wins the
+"proven ecosystem standing" axis by three orders of magnitude over anything else
+in the slot.
+
+## Why `YAMLish`, and why each alternative lost
+
+- **`YAMLish`** wins every criterion the policy ranks: Artistic-2.0 (clears the
+  hard license gate), **pure Raku** (no NativeCall, so no system-library or FFI
+  dependency), maintained (v0.1.3, 2026-07-04, by `leont`), and by far the most
+  depended-on YAML dist. Its **only** runtime dependency, `MIME::Base64`, is
+  **already bundled** by mutsu (the HTTP dependency layer), so it adds **zero new
+  vendored deps**. It is both a **parser and an emitter** (`load-yaml` /
+  `load-yamls` / `to-yaml`).
+- **`YAMLStar`** (ingy, the original YAML author; a fresh pure-Raku YAML 1.2
+  loader) is technically appealing but is **out on the license hard gate — no
+  license is declared anywhere** ([BATTERIES.md §4](../../BATTERIES.md#4-license-policy)),
+  and it has 0 dependents. Revisit only if it gains a permissive license.
+- **`YAML::Parser::LibYAML`** and **`Config::Parser::yaml`** are hard-gated out —
+  the former declares no license, the latter is **GPL-3.0** (copyleft, not
+  bundleable). `Config::Parser::yaml` depends on `YAMLish` anyway.
+- **`LibYAML`** is a NativeCall binding to the system `libyaml`. Even setting
+  aside its age (2017) and 0 dependents, binding a native library is a heavier
+  bundling story than a single pure-Raku file, and it would gate on mutsu's
+  NativeCall completeness rather than on ordinary language features.
+- **`YAML`** (raku-community-modules) is Artistic-2.0 but old (v0.1, 2021), has
+  only 2 dependents, and its test suite pulls in `TestML`. It is the fallback if
+  `YAMLish` ever proves unfixable, not the lead.
+
+## Security: `safe_load` by default
+
+The concern with any YAML loader is unsafe deserialization — a document that
+instantiates arbitrary objects or runs code (Python's `yaml.load` vs
+`yaml.safe_load`; Perl's `YAML::XS` object tags). **`YAMLish` has no such mode**,
+which is exactly what a bundled default should be:
+
+- Tag resolution goes through a **fixed callback table** (`%default-tags`), whose
+  handlers produce only plain data — `Str`, `Int`, `Rat`, `Any`, a decoded
+  `Blob` (`binary`), `List`, `Hash`, `Set`. There is **no `EVAL`, no arbitrary
+  class construction, and no attacker-controlled `require`** (the one `require`,
+  for `MIME::Base64` behind the `!!binary` tag, is hardcoded).
+- An **unknown scalar tag** falls back to the raw string value; an unknown
+  mapping/sequence tag has no callback and simply **fails**, rather than
+  constructing anything.
+- The only extension point is the caller-supplied `:%tags` map — **opt-in and
+  under the program's control**, never driven by the document. This is the safe
+  design: `load-yaml` *is* the safe loader; there is no unsafe sibling to reach
+  for by mistake.
+
+So on the axis the user flagged, `YAMLish` is not merely acceptable — being
+safe-by-default with no unsafe-load path is a positive reason to pick it.
+
+## What blocks it on mutsu (the work list)
+
+Measured 2026-07-25 against `target/debug/mutsu` with `-I lib -I
+modules/MIME-Base64/lib`. All 5 files die identically at **module-load time**,
+before any test runs, so the file counts understate how close it is — it is
+currently a two-bug load path, not five independent failures.
+
+1. **`* => *` did not curry into a `WhateverCode`** — the original load blocker,
+   now **FIXED** (`news/2026-07/whatever-curry-through-fatarrow.md`,
+   `t/whatever-curry-fatarrow.t`). `YAMLish`'s `flatten-tags` runs on `use`:
+
+   ```raku
+   %tags.kv.map({ |$^value.kv.map($^namespace ~ * => *) })
+   ```
+
+   In Raku, `=>` participates in Whatever-currying, so `$^namespace ~ * => *` is
+   a 2-arg `WhateverCode`. mutsu used to build a literal `Pair(Whatever,
+   Whatever)`, which `.map` rejected with `X::Cannot::Map: Cannot map a Pair to a
+   Seq`, aborting the `use`. Fixed at the `=>` construction site.
+
+1.5. **A placeholder var inside a nested `WhateverCode` is mis-collected as its
+   parameter** — the *new* load blocker exposed once #1 was fixed. In the same
+   `flatten-tags` line, `$^namespace` is a placeholder of the outer block but the
+   inner `$^namespace ~ * => *` now curries, and mutsu sweeps `$^namespace` into
+   the inner WhateverCode's signature, dying with `Placeholder variable
+   '$^namespace' cannot override existing signature`. Filed:
+   `todo/tickets/placeholder-var-inside-nested-whatevercode.md`. This is a
+   placeholder-scoping bug, independent of `=>`.
+
+2. **`Grammar.parse($input)` fails to dispatch inside the full module** —
+   deeper, not yet root-caused. After the load blocker is patched past locally,
+   `load-yaml` reaches `Grammar.parse($input)` and dies with
+   `X::Method::NotFound: Unknown method value dispatch (fallback disabled):
+   parse`. This is **not** simply "a user grammar named `Grammar` shadowing the
+   core type" — an isolated `grammar Grammar { token TOP {\d+} };
+   Grammar.parse("123")` works fine under mutsu, so the failure is
+   context-dependent (the module defines four grammars — `Grammar`,
+   `Schema::JSON`, `Schema::Core`, `Schema::Extra` — with inheritance and heavy
+   actions) and still needs reduction. Filed:
+   `todo/tickets/yamlish-grammar-parse-dispatch.md`. The YAML grammar
+   (lib/YAMLish.rakumod:150–783) is large and action-heavy, so further
+   grammar-feature gaps may surface once this one is cleared.
+
+## Provenance (for when it is vendored)
+
+| Module | Upstream | Pinned version | Auth |
+| --- | --- | --- | --- |
+| `YAMLish` | <https://github.com/Leont/yamlish> (`zef:leont`) | v0.1.3 (2026-07-04) | `zef:leont` |
+
+To vendor: copy `lib/` plus `META6.json`, `LICENSE`, `README.md`, `Changes`;
+exclude upstream `t/`, `xt/`, precomp artifacts (the release gate fetches the
+tests fresh). `MIME::Base64` is already bundled, so no new dependency tree.
+
+## License
+
+**Artistic-2.0** — declared in `META6.json` and shipped as `LICENSE`. Clears the
+[§4](../../BATTERIES.md#4-license-policy) hard gate. To be vendored verbatim with
+its `LICENSE` / `META6.json` / `README` preserved for attribution.

--- a/news/2026-07/whatever-curry-through-fatarrow.md
+++ b/news/2026-07/whatever-curry-through-fatarrow.md
@@ -1,0 +1,65 @@
+# `=>` now participates in Whatever-currying
+
+Raku's `=>` (fat-arrow) pair constructor participates in Whatever-currying: for a
+**non-bareword** key, a `*` on either side makes the whole pair a `WhateverCode`
+that yields the `Pair` when called. mutsu used to build a literal
+`Pair(Whatever, Whatever)` instead, so these all came out as the wrong type:
+
+```raku
+(* => *).WHAT          # was (Pair)   now (WhateverCode)
+("key" => *).WHAT      # was (Pair)   now (WhateverCode)
+(5 => *).WHAT          # was (Pair)   now (WhateverCode)
+("x" ~ * => *).WHAT    # was (Pair)   now (WhateverCode)
+("k" => (* + 1)).WHAT  # was (Pair)   now (WhateverCode)
+```
+
+The practical fallout was that passing such an expression to `.map` / `.grep`
+failed, because the argument was a `Pair` value rather than a callable:
+
+```raku
+my %h = (str => 1, int => 2);
+%h.kv.map("ns:" ~ * => *);
+# was:  X::Cannot::Map: Cannot map a Pair to a Seq
+# now:  (ns:str => 1, ns:int => 2)
+```
+
+## What was wrong
+
+The six `=>` handlers in `src/parser/expr/mod.rs` (`expression`,
+`expression_no_assign`, `expression_no_word_logical`, `expression_no_sequence`,
+`listop_arg_expr`, `call_arg_expr`) each built the pair node and returned it
+**before** the Whatever-curry-wrapping step that the rest of `expression()` runs.
+So a `*` under a fat-arrow was never inspected for currying and the node was
+emitted as a literal `Pair`.
+
+## The fix
+
+All six sites now route the constructed pair through a shared
+`fat_arrow_result(is_bareword, pair)` helper, which:
+
+- keeps a **bareword** key as a named-argument `Pair` (`a => *` stays a `Pair`,
+  matching raku);
+- otherwise consults a new `fat_arrow_curries(left, right)` predicate and, when
+  it fires, wraps the pair into a `WhateverCode` via the existing
+  `wrap_whatevercode` machinery; else builds the `PositionalPair` as before.
+
+`fat_arrow_curries` reuses `should_wrap_whatevercode` for the compound cases (so
+`xx`, `o`, smartmatch and friends still opt out — `* xx 3 => 1` stays a `Pair`)
+and additionally treats a bare `*` or an already-wrapped `(* … )` operand as a
+curry trigger. The decision is made at the construction site rather than in
+`contains_whatever` because a colonpair (`:as(*)`) and a string-keyed `=>` pair
+(`"as" => *`) share the same inner `Binary{FatArrow, Literal(Str), …}` AST and
+are only distinguishable by their caller; the colonpair exemption in
+`contains_whatever` is left intact, so `:as(*)` and `:foo(* + 1)` stay literal
+`Pair`s exactly as before.
+
+Verified against `raku` across the full currying table (12 forms). Pin:
+`t/whatever-curry-fatarrow.t`.
+
+## Why it mattered
+
+This was the module-load blocker for the `YAMLish` YAML battery candidate
+(`docs/batteries/yaml.md`), whose `flatten-tags` runs `... $^namespace ~ * => *`
+at `use` time. Fixing it is a general correctness improvement — any code that
+currently passes a curried fat-arrow to a higher-order routine now behaves like
+raku.

--- a/src/parser/expr/mod.rs
+++ b/src/parser/expr/mod.rs
@@ -32,6 +32,7 @@ pub(in crate::parser) use postfix::{QuotedMethodName, parse_quoted_method_name};
 use precedence::ternary;
 
 // Re-exports for WhateverCode detection (`whatever.rs`).
+use whatever::fat_arrow_curries;
 pub(in crate::parser) use whatever::should_wrap_whatevercode;
 pub(super) use whatever::{contains_whatever, is_whatever};
 pub(crate) use whatever::{count_whatever, expr_contains_topic, exprs_structurally_eq};
@@ -109,11 +110,7 @@ pub(super) fn expression(input: &str) -> PResult<'_, Expr> {
             };
             // Non-bareword keys (quoted strings, expressions) produce positional pairs,
             // not named arguments. Bareword keys (a => 3) are named arguments.
-            let result = if is_bareword {
-                pair
-            } else {
-                Expr::PositionalPair(Box::new(pair))
-            };
+            let result = fat_arrow_result(is_bareword, pair);
             return Ok((r, result));
         }
         expr = wrap_composition_operands(expr);
@@ -175,11 +172,7 @@ pub(in crate::parser) fn expression_no_assign(input: &str) -> PResult<'_, Expr> 
             op: TokenKind::FatArrow,
             right: Box::new(value),
         };
-        let result = if is_bareword {
-            pair
-        } else {
-            Expr::PositionalPair(Box::new(pair))
-        };
+        let result = fat_arrow_result(is_bareword, pair);
         return Ok((r, result));
     }
     expr = wrap_composition_operands(expr);
@@ -240,11 +233,7 @@ pub(in crate::parser) fn expression_no_word_logical(input: &str) -> PResult<'_, 
             op: TokenKind::FatArrow,
             right: Box::new(value),
         };
-        let result = if is_bareword {
-            pair
-        } else {
-            Expr::PositionalPair(Box::new(pair))
-        };
+        let result = fat_arrow_result(is_bareword, pair);
         return Ok((r, result));
     }
     expr = wrap_composition_operands(expr);
@@ -296,11 +285,7 @@ pub(in crate::parser) fn expression_no_sequence(input: &str) -> PResult<'_, Expr
             op: TokenKind::FatArrow,
             right: Box::new(value),
         };
-        let result = if is_bareword {
-            pair
-        } else {
-            Expr::PositionalPair(Box::new(pair))
-        };
+        let result = fat_arrow_result(is_bareword, pair);
         return Ok((r, result));
     }
     expr = wrap_composition_operands(expr);
@@ -356,11 +341,7 @@ pub(in crate::parser) fn listop_arg_expr(input: &str) -> PResult<'_, Expr> {
             op: TokenKind::FatArrow,
             right: Box::new(value),
         };
-        let result = if is_bareword {
-            pair
-        } else {
-            Expr::PositionalPair(Box::new(pair))
-        };
+        let result = fat_arrow_result(is_bareword, pair);
         return Ok((r, result));
     }
     expr = wrap_composition_operands(expr);
@@ -424,11 +405,7 @@ pub(in crate::parser) fn call_arg_expr(input: &str) -> PResult<'_, Expr> {
             op: TokenKind::FatArrow,
             right: Box::new(value),
         };
-        let result = if is_bareword {
-            pair
-        } else {
-            Expr::PositionalPair(Box::new(pair))
-        };
+        let result = fat_arrow_result(is_bareword, pair);
         return Ok((r, result));
     }
     expr = wrap_composition_operands(expr);
@@ -446,6 +423,24 @@ pub(in crate::parser) fn call_arg_expr(input: &str) -> PResult<'_, Expr> {
         };
     }
     Ok((rest, expr))
+}
+
+/// Turn a freshly-built `=>` pair into its final AST node.
+///
+/// A bareword key (`a => 3`) is a named-argument `Pair`. A non-bareword key is a
+/// positional pair — unless it Whatever-curries (`* => *`, `"k" => *`,
+/// `"x" ~ * => *`), in which case Raku makes the whole pair a `WhateverCode` that
+/// yields the `Pair` when called (see [`fat_arrow_curries`]).
+fn fat_arrow_result(is_bareword: bool, pair: Expr) -> Expr {
+    if is_bareword {
+        return pair;
+    }
+    if let Expr::Binary { left, right, .. } = &pair
+        && fat_arrow_curries(left, right)
+    {
+        return wrap_whatevercode(&pair);
+    }
+    Expr::PositionalPair(Box::new(pair))
 }
 
 pub(in crate::parser) fn parse_fat_arrow_value(input: &str) -> PResult<'_, Expr> {

--- a/src/parser/expr/whatever.rs
+++ b/src/parser/expr/whatever.rs
@@ -61,6 +61,36 @@ pub(crate) fn should_wrap_whatevercode(expr: &Expr) -> bool {
     }
 }
 
+/// Whether a non-bareword `=>` pair with these operands should Whatever-curry
+/// into a `WhateverCode`.
+///
+/// Raku's `=>` participates in Whatever-currying for **non-bareword** keys: when
+/// either operand is (or contains) a currying `*`, the whole pair becomes a
+/// `WhateverCode` that yields the `Pair` when called. So `* => *`, `"k" => *`,
+/// `5 => *`, `* => 5`, `"x" ~ * => *` and `"k" => (* + 1)` are all
+/// `WhateverCode`, while `* xx 3 => 1` (the `xx` operand opts out) and
+/// `"k" => 5` stay plain `Pair`s.
+///
+/// This is decided at the `=>` construction site — not in `contains_whatever` —
+/// because a colonpair (`:as(*)`) and a string-keyed `=>` pair (`"as" => *`)
+/// share the same inner `Binary{FatArrow, Literal(Str), …}` AST and are only
+/// distinguishable by their caller. `contains_whatever` keeps the colonpair
+/// exemption (a bare `Binary{FatArrow}` with a string-literal LHS stays a
+/// literal `Pair`); the currying `=>` form routes through here instead. Bareword
+/// keys (`a => *`, a named-argument `Pair`) never reach this — the caller gates
+/// on `is_bareword` first.
+pub(crate) fn fat_arrow_curries(left: &Expr, right: &Expr) -> bool {
+    fn operand_curries(e: &Expr) -> bool {
+        // A bare `*` or an already-wrapped `(* …)` closure does not wrap when it
+        // stands alone (that is why `should_wrap_whatevercode` excludes them),
+        // but as a `=>` operand it does make the pair curry. Everything else
+        // defers to the shared `should_wrap_whatevercode` opt-out logic (so `xx`,
+        // `o`, smartmatch etc. still suppress currying).
+        is_whatever(e) || is_wrapped_whatevercode(e) || should_wrap_whatevercode(e)
+    }
+    operand_curries(left) || operand_curries(right)
+}
+
 fn contains_xx_with_bare_whatever(expr: &Expr) -> bool {
     match expr {
         Expr::Binary {

--- a/t/whatever-curry-fatarrow.t
+++ b/t/whatever-curry-fatarrow.t
@@ -1,0 +1,54 @@
+use v6;
+use Test;
+
+# `=>` (fat arrow) participates in Whatever-currying for NON-bareword keys.
+# `* => *`, `"k" => *`, `5 => *`, `"x" ~ * => *`, `"k" => (* + 1)` all become a
+# WhateverCode that yields the Pair when called. Bareword keys (`a => *`) stay a
+# named-argument Pair, `xx` operands opt out, and colonpairs (`:as(*)`) stay
+# literal Pairs. Regression pin for the YAMLish battery load blocker.
+
+plan 18;
+
+# --- type of the constructed node ---
+isa-ok (* => *),         WhateverCode, '* => * is a WhateverCode';
+isa-ok ("x" ~ * => *),   WhateverCode, '"x" ~ * => * is a WhateverCode';
+isa-ok ("key" => *),     WhateverCode, '"key" => * is a WhateverCode';
+isa-ok (5 => *),         WhateverCode, '5 => * is a WhateverCode';
+isa-ok (* => 5),         WhateverCode, '* => 5 is a WhateverCode';
+isa-ok ("k" => (* + 1)), WhateverCode, '"k" => (* + 1) is a WhateverCode';
+
+# non-currying forms stay Pairs
+isa-ok (a => *),      Pair, 'bareword key a => * stays a Pair';
+isa-ok (a => 5),      Pair, 'bareword key a => 5 stays a Pair';
+isa-ok ("key" => 5),  Pair, 'non-whatever "key" => 5 stays a Pair';
+isa-ok (* xx 3 => 1), Pair, 'xx operand opts out: * xx 3 => 1 stays a Pair';
+isa-ok (:as(*)),      Pair, 'colonpair :as(*) stays a Pair';
+
+# --- calling the WhateverCode yields the right Pair ---
+{
+    my $c = (* => *);
+    is $c('a', 'b').raku, ('a' => 'b').raku, '(* => *)("a","b") == a => b';
+}
+{
+    my $c = (5 => *);
+    is $c(9).raku, (5 => 9).raku, '(5 => *)(9) == 5 => 9';
+}
+{
+    my $c = ("ns:" ~ * => *);
+    is $c('str', 1).raku, ('ns:str' => 1).raku, 'prefix-concat key curries';
+}
+
+# --- the shape the YAMLish flattener relies on ---
+{
+    my %h = (str => 1, int => 2);
+    my @out = %h.kv.map("ns:" ~ * => *).sort(*.key);
+    is @out.elems, 2, 'kv.map(key ~ * => *) produced two pairs';
+    is @out[0].raku, ('ns:int' => 2).raku, 'first flattened pair';
+    is @out[1].raku, ('ns:str' => 1).raku, 'second flattened pair';
+}
+
+# a Whatever *value* under a bareword key stays an ordinary Pair value
+{
+    my $p = (a => 5);
+    is $p.value, 5, 'bareword pair keeps its plain value';
+}

--- a/todo/tickets/placeholder-var-inside-nested-whatevercode.md
+++ b/todo/tickets/placeholder-var-inside-nested-whatevercode.md
@@ -1,0 +1,61 @@
+# A placeholder var inside a nested WhateverCode is mis-collected as its parameter
+
+When an explicit placeholder block `{ … $^x … }` contains a **nested** currying
+`*` (one scoped to a sub-expression, e.g. a method-call argument), and that same
+sub-expression also references one of the block's `$^` placeholders, mutsu tries
+to make the placeholder a parameter of the *inner* WhateverCode and dies:
+
+```
+Placeholder variable '$^namespace' cannot override existing signature
+```
+
+## Minimal repro
+
+```raku
+my %tags = ( "ns:" => { str => 1, int => 2 } );
+%tags.kv.map({ |$^value.kv.map($^namespace ~ * => *) });
+# raku:  [ns:str => 1 ns:int => 2]
+# mutsu: Placeholder variable '$^namespace' cannot override existing signature
+```
+
+The outer block `{ |$^value.kv.map($^namespace ~ * => *) }` has placeholders
+`$^value` and `$^namespace` — those belong to the outer block. The inner
+`$^namespace ~ * => *` curries into a `WhateverCode` (arity 2, from the two `*`)
+that **closes over** `$^namespace`. mutsu instead sweeps `$^namespace` into the
+inner WhateverCode's placeholder signature, which already has its `*`-derived
+params — hence "cannot override existing signature".
+
+## Why now
+
+This surfaced only after `=>` Whatever-currying was fixed
+(`news/2026-07/whatever-curry-through-fatarrow.md` /
+`t/whatever-curry-fatarrow.t`). Before that fix `$^namespace ~ * => *` was a
+literal `Pair`, so no inner WhateverCode was built and no placeholder collision
+occurred (the failure was the earlier `X::Cannot::Map` instead). The currying is
+now correct; the remaining bug is placeholder **scoping** across a WhateverCode
+boundary.
+
+Note: a bare `*` at the *top level* of a placeholder block (`{ $^x ~ * }`) is a
+**compile error in raku** ("Malformed double closure"), which mutsu does not
+diagnose — that is a separate, lower-priority divergence. This ticket is only
+about a `*` nested inside a sub-expression, which raku accepts.
+
+## Root cause / affected area
+
+The placeholder-collection pass (the code that gathers `$^name` twigil vars into
+a block's implicit signature) must stop at a nested WhateverCode boundary: a
+`$^name` occurring inside an already-wrapped WhateverCode body belongs to the
+nearest **enclosing explicit** placeholder block, not to the WhateverCode. Look
+at where placeholder params are gathered for `{ … }` blocks and where
+`wrap_whatevercode` builds the inner lambda (`src/parser/expr/whatever_wrap.rs`,
+`src/parser/expr/whatever_replace.rs`), and ensure the collection treats the
+wrapped lambda's body as opaque w.r.t. the outer block's placeholders.
+
+## Impact
+
+This is blocker #1.5 for the `YAMLish` battery candidate
+(`docs/batteries/yaml.md`): its module-load `flatten-tags` is exactly this
+shape, so `use YAMLish` still fails here even after the `=>` currying fix (it now
+fails with this error instead of `X::Cannot::Map`). Blocker #2
+(`todo/tickets/yamlish-grammar-parse-dispatch.md`) is further down the same load
+path.

--- a/todo/tickets/yamlish-grammar-parse-dispatch.md
+++ b/todo/tickets/yamlish-grammar-parse-dispatch.md
@@ -1,0 +1,72 @@
+# `Grammar.parse` fails to dispatch inside the full `YAMLish` module
+
+Blocker #2 for the `YAMLish` battery candidate (`docs/batteries/yaml.md`), and
+it is **not yet root-caused**.
+
+After the module-load blocker
+(`todo/tickets/whatever-curry-through-fatarrow.md`) is patched past locally,
+`load-yaml` reaches:
+
+```raku
+our sub load-yaml(Str $input, ...) is export {
+    my $match = Grammar.parse($input);   # lib/YAMLish.rakumod:944
+    ...
+}
+```
+
+and dies with:
+
+```
+Couldn't parse YAML: X::Method::NotFound: Unknown method value dispatch (fallback disabled): parse
+```
+
+## Not the obvious hypothesis
+
+The tempting explanation — "the user declared `grammar Grammar {…}`, which
+shadows the built-in `Grammar` type, and mutsu resolves the name to the core
+type object that has no `.parse`" — is **wrong**, or at least incomplete. An
+isolated repro works:
+
+```raku
+grammar Grammar { token TOP { \d+ } }
+say Grammar.parse("123");   # mutsu: 「123」 — dispatches fine
+```
+
+So the failure is **context-dependent**. `YAMLish` defines four grammars with
+inheritance — `Grammar` (lib/YAMLish.rakumod:150), `Schema::JSON` (784),
+`Schema::Core is Schema::JSON` (839), `Schema::Extra is Schema::Core` (885) —
+plus heavy inline `{ make … }` actions and a large token set. The dispatch
+failure needs reduction against that fuller context before a fix.
+
+Note the error text `Unknown method value dispatch (fallback disabled)` is a
+**recurring mutsu pattern** — the same shape blocks `Template::Classic` in the
+template survey (`docs/batteries/templates.md`) — so root-causing it may pay off
+beyond YAML.
+
+## How to reproduce
+
+The whole module is load-blocked by bug #1, so to see this bug today you must
+first get past the load: take `lib/YAMLish.rakumod`, replace the `flatten-tags`
+body (line 939) with an explicit two-arg-block equivalent:
+
+```raku
+return %tags.kv.map(-> $ns, %v { |%v.kv.map(-> $k, $val { ($ns ~ $k) => $val }) });
+```
+
+then:
+
+```sh
+echo 'use YAMLish; say load-yaml("foo: 1");' \
+  | mutsu -I <patched-lib> -I modules/MIME-Base64/lib -
+# -> Couldn't parse YAML: X::Method::NotFound: … parse
+```
+
+Once bug #1 is fixed in the interpreter, the patch is unnecessary and this
+reproduces directly on the vendored module.
+
+## Next step
+
+Reduce: define `Grammar` alongside a `Schema::JSON`/`Schema::Core` inheritance
+chain and inline actions, and bisect toward the minimal shape that makes
+`Grammar.parse` mis-dispatch. Do **not** assume the name-shadow theory without a
+reducing case that actually fails.


### PR DESCRIPTION
## Summary

Raku's `=>` (fat-arrow) pair constructor participates in Whatever-currying: for a **non-bareword** key, a `*` on either side makes the whole pair a `WhateverCode` that yields the `Pair` when called. mutsu built a literal `Pair(Whatever, Whatever)` instead:

```raku
(* => *).WHAT          # was (Pair)   now (WhateverCode)
("key" => *).WHAT      # was (Pair)   now (WhateverCode)
("x" ~ * => *).WHAT    # was (Pair)   now (WhateverCode)

my %h = (str => 1, int => 2);
%h.kv.map("ns:" ~ * => *);
# was:  X::Cannot::Map: Cannot map a Pair to a Seq
# now:  (ns:str => 1, ns:int => 2)
```

## Fix

The six `=>` handlers in `src/parser/expr/mod.rs` returned the pair node **before** the Whatever-curry-wrapping step that the rest of `expression()` runs. They now route through a shared `fat_arrow_result(is_bareword, pair)`:

- a **bareword** key stays a named-argument `Pair` (`a => *` → `Pair`, matching raku);
- otherwise a new `fat_arrow_curries(left, right)` predicate decides currying. It reuses `should_wrap_whatevercode` so `xx`/`o`/smartmatch still opt out (`* xx 3 => 1` stays a `Pair`), plus a bare-`*` / already-wrapped-`(* …)` operand trigger.

The decision is made at the construction site — not in `contains_whatever` — because a colonpair (`:as(*)`) and a string-keyed `=>` pair (`"as" => *`) share the same inner `Binary{FatArrow, Literal(Str), …}` AST and are only distinguishable by their caller. The colonpair exemption is left intact, so `:as(*)` / `:foo(* + 1)` stay literal `Pair`s.

Verified against `raku` across the full 12-form currying table.

## Why

This was the module-load blocker for the **YAMLish** YAML battery candidate (surveyed in `docs/batteries/yaml.md`). Fixing it is a general correctness improvement — any code passing a curried fat-arrow to a higher-order routine now behaves like raku. The survey record (why YAMLish, safe-by-default loading) and the remaining YAMLish blockers are filed under `docs/batteries/` and `todo/`.

## Tests

- New pin: `t/whatever-curry-fatarrow.t` (18 assertions).
- `make test` green (2459 files / 23468 tests), `cargo clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)