### PR TITLE
fix: a user `push`/`pop` is no longer hidden by the listop -> method rewrite

### DIFF
--- a/TODO_dist/TICKETS.md
+++ b/TODO_dist/TICKETS.md
@@ -703,33 +703,6 @@ editing this file; keep edits small (one ticket) to avoid conflicts.
   stripped). Fixed in `src/runtime/types/args_matching.rs`. Pin:
   `t/multi-optional-named-definite.t`.
 
-### T-054 — test_fail: builtin push/pop return value [P5push]  [impact: 1 dist]  — RE-MEASURED 2026-07-25: 10/14 (was: shadowed in every call form)
-- dists: P5push
-- `P5push` exports `proto sub push`/`multi sub push(@a,*@v --> Int:D){...}` and
-  `pop`.
-- **The old note ("mutsu's builtin shadows the imported subs in EVERY call form",
-  "same compile-time-import problem as Understitch's `_` operator") is now WRONG
-  and was over-broad.** The builtin-shadow dispatch fix landed for String::Rotate
-  (2026-07-25, `call_function_fallback` prefers a resolved user routine over the
-  native table — see Done) already moved this dist from failing wholesale to
-  **10 of 14 subtests passing**. `pop` works in every form the test uses,
-  including the bare `pop` that reads `@*ARGS`. Re-measure before believing any
-  remaining claim here.
-- **Remaining 4 subtests, two shapes (each needs its own diagnosis):**
-  1. tests 3/5 — `is (push @a, 42), 2` still returns the ARRAY, not the elem
-     count, so the builtin still wins for `push` specifically. `pop` (also a
-     `proto` + `multi`) does not, so this is not simply "protos bypass the
-     shadow"; `push @a, 42` parses as a plain `Call` node, so the divergence is
-     downstream of parsing. Suspect the proto path in `call_function_fallback`
-     runs before the user-routine preference added for the non-proto case.
-  2. tests 11/14 — `pop` on an EMPTY array. The module's
-     `multi sub pop(@array) { @array.elems ?? @array.pop !! Nil }` should yield
-     `Nil`, but mutsu surfaces `Cannot pop from an empty Array` (which is what
-     the BUILTIN `pop` returns as a Failure for an empty array). So either the
-     builtin is reached here, or the guarded branch is evaluated anyway.
-- file: builtin-vs-imported-sub dispatch priority — the *proto* half (the
-  non-proto half is fixed)
-
 ### T-056 — test_fail: Codepoint [P5quotemeta]  [impact: 1 dist]  — ONE ROOT CAUSE FIXED (PR `fix-subst-replacement-double-backslash`); one deferred
 - dists: P5quotemeta (5756 tests: raku 5756/5756)
 - The module is `S:g/ ( <[ …\x[…] ]> ) /\\$0/` — escape each matched char with a
@@ -1268,3 +1241,26 @@ _(move tickets here with `[claim: <branch>]` when you start)_
   lowers a known routine's bare call to `Stmt::Call`, which
   `compile_stmts_value` compiled through the sink path. See
   `news/2026-07/do-for-imported-sub-statement-call-value.md`.
+
+- **T-054 (P5push) — CLOSED at 14/14** (PR `fix-listop-rewrite-imported-shadow`)
+  — one root cause, not the two the open entry predicted. The compiler rewrites
+  the container listops into method calls at compile time (`pop(@a)` ->
+  `@a.pop()`, `push(@a, v)` -> `@a.push(v)`, also `shift`/`unshift`/`append`/
+  `prepend`/`splice`) so array mutation reaches the caller's container. That
+  rewrite was unconditional, so it baked the BUILTIN in before dispatch ever ran
+  — the runtime builtin-vs-user preference landed for String::Rotate could not
+  help, because there was no call left to dispatch. The four rewrite branches in
+  `compiler/expr_call.rs` are now guarded by `listop_shadowed_by_user_routine`.
+  Both halves of that predicate are load-bearing: the importing script sees
+  `push`/`pop` as *imported* (`parser::is_imported_function`), while the module's
+  own body sees them as *declared* (`parser::is_user_declared_sub_pub`, newly
+  exposed to the compiler) — P5push's no-arg `multi sub pop()` calls
+  `pop(@*ARGS)`, i.e. its own other candidate; without that half the final
+  subtest still surfaced the builtin's `Cannot pop from an empty Array`.
+  Pins: `t/listop-shadow-imported.t` + `t/lib/ListopShadow.rakumod`,
+  `t/listop-shadow-declared.t`. See
+  `news/2026-07/listop-rewrite-respects-user-routine-shadow.md`.
+  **Known limitation recorded, not fixed:** the predicate reads the parser's
+  lexical-scope stack, which at compile time only holds scopes that were never
+  popped (in practice the unit scope), so a *block-scoped* shadow is still
+  ignored — `todo/tickets/block-scoped-listop-shadow.md`.

--- a/news/2026-07/listop-rewrite-respects-user-routine-shadow.md
+++ b/news/2026-07/listop-rewrite-respects-user-routine-shadow.md
@@ -1,0 +1,48 @@
+# The listop → method rewrite no longer hides a user `push`/`pop`
+
+`TODO_dist` ticket T-054 (`P5push`) is closed at 14/14. The distribution exports
+Perl 5 semantics for `push` and `pop` — `push` returns the new element count, and
+`pop` on an empty array returns `Nil` instead of a Failure — and mutsu returned
+the builtin's answers instead.
+
+## Root cause
+
+The compiler rewrites the container listops into method calls at compile time so
+that array mutation lands in the caller's container: `pop(@a)` → `@a.pop()`,
+`push(@a, v)` → `@a.push(v)`, and the same for `shift`, `unshift`, `append`,
+`prepend`, `splice` (`compiler/expr_call.rs`). That rewrite is unconditional, so
+it baked the builtin in before dispatch ever ran — the runtime's
+builtin-vs-user-routine preference (fixed earlier for `String::Rotate`) could not
+help, because by then there was no call left to dispatch.
+
+The four rewrite branches are now guarded by
+`listop_shadowed_by_user_routine`, which suppresses the rewrite when a user
+routine of that name is visible; the call then falls through to the generic call
+path, which resolves it. Both halves of the predicate are load-bearing:
+
+- the importing script sees `push`/`pop` as **imported**
+  (`parser::is_imported_function`), and
+- the module's own body sees them as **declared**
+  (`parser::is_user_declared_sub_pub`, newly exposed to the compiler) — P5push's
+  no-arg `multi sub pop()` calls `pop(@*ARGS)`, i.e. its own other candidate.
+
+Without the second half, the last subtest (a bare `pop` on an exhausted
+`@*ARGS`) still surfaced the builtin's `Cannot pop from an empty Array`.
+
+The ledger listed the two remaining failure shapes as needing separate
+diagnoses; they turned out to be one root cause.
+
+## Scope / known limitation
+
+The predicate reads the parser's lexical-scope stack, which at compile time only
+still holds scopes that were never popped — in practice the unit scope. So a
+listop shadow declared or imported **inside a block** (`{ my sub push {...}; push
+@x, 1 }`, or a block-scoped `use`) is still not honoured; mutsu calls the builtin
+there. That is pre-existing behaviour, unchanged by this fix, and is recorded in
+`todo/tickets/block-scoped-listop-shadow.md`.
+
+Pins: `t/listop-shadow-imported.t` (fixture `t/lib/ListopShadow.rakumod`) for the
+imported half, `t/listop-shadow-declared.t` for the declared half. Both verified
+identical under `raku`. `roast/S32-array/{pop,push,shift,splice,unshift,perl}.t`
+and `roast/S02-types/array.t` stay green, confirming the unshadowed builtin path
+is untouched.

--- a/src/compiler/expr_call.rs
+++ b/src/compiler/expr_call.rs
@@ -83,6 +83,31 @@ impl Compiler {
                     if matches!(l.view(), crate::value::ValueView::Str(s) if s.as_str() == key)))
     }
 
+    /// True when a *user* routine named after a container listop (`push`, `pop`,
+    /// ...) is visible — either imported by a `use` or declared in a live
+    /// lexical scope. The compile-time listop -> method rewrites below
+    /// (`pop(@a)` -> `@a.pop()`, `push(@a, v)` -> `@a.push(v)`) must not fire
+    /// then: they bake the builtin in at compile time, so the user routine can
+    /// never be dispatched to, no matter what the runtime's builtin-vs-user
+    /// preference does. Suppressing them lets the call fall through to the
+    /// generic call path, which resolves the user routine.
+    ///
+    /// `P5push` exports `push`/`pop` with Perl 5 return values; without this
+    /// guard `push @a, 42` returned the array instead of the module's element
+    /// count, and `pop @a` on an empty array surfaced the builtin's
+    /// `Cannot pop from an empty Array` Failure instead of the module's `Nil`.
+    /// Both halves are needed: the importing script sees `pop` as *imported*,
+    /// while the module's own body — which calls `pop(@*ARGS)` from one of its
+    /// `multi`s — sees it as *declared*.
+    fn listop_shadowed_by_user_routine(name: &Symbol) -> bool {
+        let n = name.resolve();
+        matches!(
+            n.as_str(),
+            "push" | "pop" | "shift" | "unshift" | "append" | "prepend" | "splice"
+        ) && (crate::parser::is_imported_function(&n)
+            || crate::parser::is_user_declared_sub_pub(&n))
+    }
+
     pub(super) fn compile_expr_call(&mut self, name: &Symbol, args: &[Expr]) {
         // `callframe`/`caller` inside N enclosing `for` blocks must report the
         // frames those blocks introduce. The block nesting is a compile-time
@@ -812,6 +837,7 @@ impl Compiler {
         else if matches!(name.resolve().as_str(), "shift" | "pop")
             && args.len() == 1
             && matches!(args[0], Expr::ArrayVar(_) | Expr::Var(_))
+            && !Self::listop_shadowed_by_user_routine(name)
         {
             let method_call = Expr::MethodCall {
                 target: Box::new(args[0].clone()),
@@ -831,6 +857,7 @@ impl Compiler {
                 "push" | "unshift" | "append" | "prepend"
             )
             && matches!(&args[0], Expr::MethodCall { args: mc_args, .. } if mc_args.is_empty())
+            && !Self::listop_shadowed_by_user_routine(name)
         {
             if let Expr::MethodCall {
                 target: mc_target,
@@ -866,6 +893,7 @@ impl Compiler {
             )
             && matches!(&args[0], Expr::DoStmt(s)
                 if matches!(s.as_ref(), Stmt::VarDecl { name: vn, .. } if vn.starts_with('@')))
+            && !Self::listop_shadowed_by_user_routine(name)
         {
             if let Expr::DoStmt(stmt) = &args[0]
                 && let Stmt::VarDecl { name: vn, .. } = stmt.as_ref()
@@ -896,6 +924,7 @@ impl Compiler {
                 "push" | "unshift" | "append" | "prepend"
             ) && args.len() >= 2
                 || name.resolve().as_str() == "splice")
+            && !Self::listop_shadowed_by_user_routine(name)
         {
             // Autovivification: when the first arg is an `Expr::Index` referring
             // to a missing slot (e.g. `push @array[2], ...` / `push %h<key>, ...`),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -13,6 +13,13 @@ pub(crate) fn is_imported_function(name: &str) -> bool {
     stmt::simple::is_imported_function(name)
 }
 
+/// Whether a `sub`/`multi`/`proto` with this name was declared in a still-live
+/// lexical scope. Exposed to the compiler so a user routine that shadows a
+/// builtin listop suppresses the compile-time `pop(@a)` -> `@a.pop()` rewrite.
+pub(crate) fn is_user_declared_sub_pub(name: &str) -> bool {
+    stmt::simple::is_user_declared_sub(name)
+}
+
 /// Parse a heredoc body string as an interpolated (qq-style) string expression.
 /// Used by the compiler to defer heredoc interpolation to compile time.
 pub(crate) fn interpolate_heredoc_content(content: &str) -> crate::ast::Expr {

--- a/t/lib/ListopShadow.rakumod
+++ b/t/lib/ListopShadow.rakumod
@@ -1,0 +1,14 @@
+unit module ListopShadow;
+
+# Perl 5 style push/pop, the shape the P5push distribution exports: `push`
+# returns the new element count, and `pop` on an empty array returns Nil rather
+# than the builtin's `Cannot pop from an empty Array` Failure.
+proto sub push(|) is export {*}
+multi sub push(@array, *@values --> Int:D) {
+    @array.append(@values).elems
+}
+
+proto sub pop(|) is export {*}
+multi sub pop(@array) {
+    @array.elems ?? @array.pop !! Nil
+}

--- a/t/listop-shadow-declared.t
+++ b/t/listop-shadow-declared.t
@@ -1,0 +1,21 @@
+use v6;
+use Test;
+
+# The declared-in-this-unit half of the listop shadow (see
+# t/listop-shadow-imported.t for the imported half): a `sub push` declared at
+# unit scope wins over the builtin, and the builtin must not mutate the array
+# behind its back. This is the shape P5push's own module body relies on — one of
+# its `multi sub pop` candidates calls its *declared* `pop`, not the builtin.
+
+plan 4;
+
+sub push(@a, *@v) { "mine:" ~ @v.join(',') }
+sub pop(@a) { @a.elems ?? @a.pop !! 'empty' }
+
+my @x = 1;
+is push(@x, 2), 'mine:2', 'a declared `push` wins over the builtin';
+is-deeply @x, [1], 'and the builtin did not mutate the array behind its back';
+
+my @y = 7;
+is pop(@y), 7, 'a declared `pop` delegating to the method still returns the element';
+is pop(@y), 'empty', 'and its own empty-array branch wins over the builtin Failure';

--- a/t/listop-shadow-imported.t
+++ b/t/listop-shadow-imported.t
@@ -1,0 +1,25 @@
+use v6;
+use lib 't/lib';
+use Test;
+use ListopShadow;
+
+# The compiler rewrites the container listops (`pop(@a)` -> `@a.pop()`,
+# `push(@a, v)` -> `@a.push(v)`) to get array mutation right. That rewrite bakes
+# the builtin in at compile time, so it must be suppressed when a user routine of
+# the same name is visible — otherwise the imported routine can never be reached
+# no matter what the runtime's builtin-vs-user preference does. `ListopShadow`
+# exports Perl 5 style `push`/`pop` (P5push's shape).
+
+plan 6;
+
+my @a = 1;
+is push(@a, 42), 2, 'an imported push returns the module value, not the array';
+is-deeply @a, [1, 42], 'and the array was still mutated by the module body';
+is push(@a, 666, 667), 4, 'the slurpy form returns the new element count too';
+
+my @b = 1, 2;
+is pop(@b), 2, 'an imported pop returns the element';
+is pop(@b), 1, 'and the next one';
+# The builtin would surface a `Cannot pop from an empty Array` Failure here; the
+# module's `@array.elems ?? @array.pop !! Nil` must win.
+is pop(@b), Nil, 'popping empty yields the module Nil, not the builtin Failure';

--- a/todo/tickets/block-scoped-listop-shadow.md
+++ b/todo/tickets/block-scoped-listop-shadow.md
@@ -1,0 +1,78 @@
+# A block-scoped `push`/`pop` shadow does not suppress the listop rewrite
+
+Found 2026-07-25 while closing `TODO_dist` T-054 (`P5push`) — see
+`news/2026-07/listop-rewrite-respects-user-routine-shadow.md`. Pre-existing
+behaviour, not a regression from that fix.
+
+## Repro
+
+```raku
+{
+    my sub push(@a, *@v) { "mine" }
+    my @x = 1;
+    say push(@x, 2);   # raku: mine     mutsu: [1 2]  (and @x was mutated)
+}
+```
+
+The same applies to a block-scoped import:
+
+```raku
+{
+    use ListopShadow;   # exports a Perl 5 style `push`
+    my @a = 1;
+    say push(@a, 42);   # raku: 2       mutsu: [1 42]
+}
+```
+
+At unit scope both forms work (that is what T-054 needed and what
+`t/listop-shadow-imported.t` / `t/listop-shadow-declared.t` pin).
+
+## Why
+
+`compiler/expr_call.rs` rewrites the container listops into method calls at
+compile time (`pop(@a)` → `@a.pop()`, …) so array mutation reaches the caller's
+container. `listop_shadowed_by_user_routine` suppresses that rewrite when a user
+routine of the same name is visible, using the parser's thread-local lexical
+scope stack (`parser::is_imported_function` /
+`parser::is_user_declared_sub_pub`).
+
+That stack is a *parse-time* structure. The compiler runs after the parse has
+finished, so every scope that was pushed and popped during parsing is gone; only
+scopes still live at the end — in practice the unit scope — can be queried. A
+`my sub push` (or a `use`) inside a block was registered into a scope that no
+longer exists, so the predicate returns false and the rewrite fires.
+
+## Why it is not a small fix
+
+The right fix is to stop asking the parser and instead decide at the point where
+lexical scoping is actually modelled:
+
+- **Option A — record it in the AST at parse time.** While the name *is* in
+  scope, the parser knows whether a user routine shadows the builtin; it could
+  mark the call node (e.g. a flag on `Expr::Call` / `Stmt::Call`, or emit a
+  distinct node). This is the semantically correct place, but it widens the AST
+  and every construction/match site for those variants.
+- **Option B — track shadowed listop names in the compiler's own scope stack.**
+  The compiler already pushes/pops scopes for locals, so it could carry a
+  `shadowed_listops: Vec<HashSet<String>>` alongside, populated from `SubDecl` /
+  `ProtoDecl`. The complication is `hoist_sub_decls`: a sub declaration is
+  visible before its textual position, so the set has to be seeded when a block
+  is entered, not when the declaration is reached.
+
+A conservative unit-wide AST scan ("any `sub push` anywhere in the file → never
+rewrite") is *not* an acceptable shortcut: it would disable the rewrite in scopes
+where the builtin is the correct target, and the generic call path does not
+guarantee the in-place array mutation the rewrite exists to provide.
+
+## Affected files
+
+- `src/compiler/expr_call.rs` — `listop_shadowed_by_user_routine` and the four
+  rewrite branches it guards
+- `src/parser/mod.rs` — `is_imported_function`, `is_user_declared_sub_pub`
+- `src/parser/stmt/simple/{compile_consts,pragma_preseed}.rs` — the scope stack
+
+## Impact
+
+Low in practice: real distributions export these names at unit scope (P5push
+does), which now works. A block-scoped shadow silently calls the builtin — wrong
+value, and it mutates the array the user routine meant to leave alone.


### PR DESCRIPTION
Closes `TODO_dist` **T-054 (P5push)** at 14/14.

## Problem

`P5push` exports Perl 5 semantics for `push`/`pop` — `push` returns the new
element count, `pop` on an empty array returns `Nil` rather than a Failure — and
mutsu answered with the builtin's values instead (10/14 before this PR).

## Root cause — one, not the two the ledger predicted

The compiler rewrites the container listops into method calls at compile time so
array mutation lands in the caller's container: `pop(@a)` → `@a.pop()`,
`push(@a, v)` → `@a.push(v)`, likewise `shift`, `unshift`, `append`, `prepend`,
`splice` (`compiler/expr_call.rs`). That rewrite was unconditional, so it baked
the **builtin** in before dispatch ever ran — the runtime's builtin-vs-user
preference (added earlier for `String::Rotate`) could not help, because by then
there was no call left to dispatch.

The four rewrite branches are now guarded by `listop_shadowed_by_user_routine`,
which suppresses the rewrite when a user routine of that name is visible; the
call then falls through to the generic call path, which resolves it.

**Both halves of the predicate are load-bearing:**

- the importing script sees `push`/`pop` as **imported**
  (`parser::is_imported_function`), and
- the module's own body sees them as **declared**
  (`parser::is_user_declared_sub_pub`, newly exposed to the compiler) — P5push's
  no-arg `multi sub pop()` calls `pop(@*ARGS)`, i.e. its own other candidate.

Without the second half, the last subtest (a bare `pop` on an exhausted
`@*ARGS`) still surfaced the builtin's `Cannot pop from an empty Array`. Measured
with a temporary probe: the two module-body call sites report
`imported=false declared=true`, the five script-side ones `imported=true`.

## Known limitation (recorded, not fixed)

The predicate reads the parser's lexical-scope stack, which at compile time only
holds scopes that were never popped — in practice the unit scope. So a shadow
declared or imported **inside a block** is still ignored. That is pre-existing
behaviour, unchanged here; `todo/tickets/block-scoped-listop-shadow.md` lays out
the two viable fixes (mark it in the AST at parse time, or track it in the
compiler's own scope stack) and why a conservative unit-wide AST scan is *not*
acceptable — it would disable the rewrite where the builtin is the correct target
and the generic path does not guarantee in-place mutation.

## Testing

- `t/listop-shadow-imported.t` (6 subtests, fixture `t/lib/ListopShadow.rakumod`)
  and `t/listop-shadow-declared.t` (4 subtests) — both identical under `raku`.
- P5push's own `t/01-basic.rakutest`: 14/14, matching raku.
- `roast/S32-array/{pop,push,shift,splice,unshift,perl}.t` +
  `roast/S02-types/array.t`: 714 tests, all pass — the unshadowed builtin path is
  untouched.
- `make test`: 2461 files, 23465 tests, all successful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)