### PR TITLE
fix: accept a tight `.=` in a ternary branch instead of calling it too loose

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -309,8 +309,11 @@ sessions).
       (regenerate: `scripts/dist-compat-sweep.py`; **sandboxed via `bwrap` — no net,
       read-only FS, throwaway HOME**, since dist code runs arbitrary load-time code).
       First run (n=60, 2026-07-19): of the pure-Raku, dep-satisfiable dists, **~half
-      load, ~half hit a real mutsu bug on `use` alone**. Top recurring blocker:
-      `Assignment operators inside ?? !! are too loose` (2 dists). This is the
+      load, ~half hit a real mutsu bug on `use` alone**. The top recurring blocker
+      (`Assignment operators inside ?? !! are too loose`, 2 dists) is **fixed**
+      — the guard was firing on a valid tight `.=` in a ternary branch
+      (news/2026-07/ternary-branch-accepts-dot-assign.md); re-run the sweep to pick
+      the next one. This is the
       execution counterpart of the signal-only
       [`docs/ecosystem-guts-dependency-survey.md`](../docs/ecosystem-guts-dependency-survey.md)
       and the highest-leverage way to widen the batteries base. Workflow per bug:

--- a/news/2026-07/ternary-branch-accepts-dot-assign.md
+++ b/news/2026-07/ternary-branch-accepts-dot-assign.md
@@ -1,0 +1,51 @@
+# `.=` in a ternary branch is no longer rejected as "too loose"
+
+`1 ?? $v.=uc !! 9` failed with
+`X::Syntax::ConditionalOperator::PrecedenceTooLoose` ("Assignment operators
+inside ?? !! are too loose; parenthesize them"). raku accepts it: `.=` is a
+*mutating method call* at method-postfix / dotty-infix precedence
+(`raku-doc/doc/Language/operators.rakudoc`, the "Method call" and "Dotty infix"
+rows), which is far **tighter** than the conditional `?? !!` — unlike `=` and the
+compound assignments, which really are looser and do need parentheses.
+
+This was PLAN §B4's top recurring blocker from the dist-compatibility sweep
+("Assignment operators inside ?? !! are too loose", 2 dists): the guard was
+firing on valid code.
+
+## Root cause
+
+The parser lowers `$v .= uc` to exactly the same node `$v = $v.uc` produces —
+`Expr::AssignExpr { name: "v", expr: MethodCall { target: Var("v"), … } }`
+(`postfix::dot_assign::wrap_dot_assign`). The two ternary guards
+(`precedence/ternary.rs` and `precedence/list_infix_top.rs`) tested only that AST
+shape, so they could not tell the tight operator from the loose one and rejected
+both.
+
+Both guards now consult `assign_operator_is_tight`, which looks at the branch's
+source text: it skips the leading sigil variable and checks whether the operator
+that follows is `.=`. Anything else is still reported as too loose, so `=`, `+=`,
+`~=`, `//=` and friends keep raising the same exception.
+
+Reading the source is a workaround for the AST ambiguity, not the end state — the
+helper carries a `TODO` to record the operator in the AST instead. That was not
+done here because `Expr::AssignExpr` has ~170 construction sites and Rust struct
+literals must name every field, so adding a discriminant is a large mechanical
+change best done on its own.
+
+Measured, not assumed: a temporary probe showed which of the two guards fires for
+each shape — `ternary.rs` for the plain expression form and `list_infix_top.rs`
+for the list-assignment form (`my @z = 1 ?? $v.=uc !! 9`), so both needed the
+same treatment.
+
+Pinned by `t/ternary-dot-assign-branch.t` (10 subtests: then-branch, spaced
+dotty-infix, else-branch, list-assignment context, chained `.=`, hash and array
+element targets, plus `=` and `+=` still throwing
+`X::Syntax::ConditionalOperator::PrecedenceTooLoose`). All 10 identical under
+raku.
+
+## Known remaining divergence
+
+`1 ?? $v .= 3 !! 9` (a `.=` with a non-method RHS) is a compile-time error in
+raku; mutsu rejects it at runtime with `No such method '3'`. Both reject it, so
+this is the general compile-time-vs-runtime detection gap, not specific to the
+ternary.

--- a/src/parser/expr/precedence/list_infix_top.rs
+++ b/src/parser/expr/precedence/list_infix_top.rs
@@ -1,5 +1,5 @@
 use super::list_infix::{attach_trailing_adverbs, wrap_left_exclusive_sequence};
-use super::ternary::is_assignment_expr;
+use super::ternary::{assign_operator_is_tight, is_assignment_expr};
 use super::*;
 
 /// The "item" level: Z/X's operand precedence.
@@ -59,7 +59,12 @@ pub(crate) fn item_expr(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
     let (rest, else_expr) = item_expr(after_bang, mode).map_err(|err| {
         enrich_expected_error(err, "expected else-expression after '!!'", after_bang.len())
     })?;
-    if is_assignment_expr(&then_expr) || is_assignment_expr(&else_expr) {
+    // Only a LOOSE assignment is an error here; the mutating method call `.=` is
+    // at method-postfix precedence and is legal inside `?? !!` (see
+    // `assign_operator_is_tight`).
+    if (is_assignment_expr(&then_expr) && !assign_operator_is_tight(after_q))
+        || (is_assignment_expr(&else_expr) && !assign_operator_is_tight(after_bang))
+    {
         return Err(conditional_precedence_too_loose_error());
     }
     Ok((

--- a/src/parser/expr/precedence/ternary.rs
+++ b/src/parser/expr/precedence/ternary.rs
@@ -7,6 +7,42 @@ pub(crate) fn is_assignment_expr(expr: &Expr) -> bool {
     )
 }
 
+/// Whether the assignment at the start of `src` used a *tight* operator, i.e.
+/// the mutating method call `.=` (`$v .= uc`, `$v.=uc`). `.=` sits at method
+/// postfix / dotty-infix precedence, which is much tighter than the conditional
+/// `?? !!`, so it is legal inside a ternary branch — unlike `=` and the compound
+/// assignments, which are looser and must be parenthesized.
+///
+/// This has to read the source because the parser lowers `$v .= uc` to exactly
+/// the same `Expr::AssignExpr { name: "v", expr: MethodCall { target: Var("v"),
+/// … } }` that `$v = $v.uc` produces (`postfix::dot_assign::wrap_dot_assign`),
+/// so the AST alone cannot tell the tight operator from the loose one.
+/// TODO: record the operator in the AST (an `AssignExpr` discriminant) and drop
+/// this text scan; that is a ~170-construction-site change, so it is deferred.
+///
+/// `src` is the branch's source text, starting at its first token: a sigil
+/// variable, whose name is skipped before looking for the operator. Anything
+/// else is reported as loose, preserving the previous behaviour.
+pub(crate) fn assign_operator_is_tight(src: &str) -> bool {
+    let src = src.trim_start();
+    let mut chars = src.char_indices();
+    let Some((_, sigil)) = chars.next() else {
+        return false;
+    };
+    if !matches!(sigil, '$' | '@' | '%' | '&') {
+        return false;
+    }
+    let mut end = sigil.len_utf8();
+    for (idx, ch) in chars {
+        if ch.is_alphanumeric() || ch == '_' || ch == '-' || ch == '\'' || ch == ':' {
+            end = idx + ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+    src[end..].trim_start().starts_with(".=")
+}
+
 pub(crate) fn comparison_nonassoc_key(op: &TokenKind) -> Option<&'static str> {
     match op {
         TokenKind::LtEqGt => Some("<=>"),
@@ -171,6 +207,10 @@ pub(crate) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
     let (rest_ws, _) = ws(rest)?;
     if let Ok((input, _)) = parse_tag(rest_ws, "??") {
         let (input, _) = ws(input)?;
+        // Source text of the then-branch, kept so the too-loose guard below can
+        // tell which assignment operator produced an `Expr::AssignExpr` (see
+        // `assign_operator_is_tight`).
+        let then_src = input;
         // Parse then-expr at ternary precedence (stops before `!!`)
         let (input, then_expr) = if mode == ExprMode::Full {
             ternary_mode(input, mode).map_err(|err| {
@@ -217,6 +257,7 @@ pub(crate) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
         // parses as `(cond ?? t !! lhs) = rhs` (an lvalue-ternary assignment),
         // not as an assignment nested inside the else-branch. Parsing the
         // else-branch no-assign leaves `= rhs` for the trailing handler below.
+        let else_src = input;
         let (input, else_expr) = if mode == ExprMode::Full {
             ternary_no_assign(input).map_err(|err| {
                 enrich_expected_error(err, "expected else-expression after '!!'", input.len())
@@ -227,7 +268,13 @@ pub(crate) fn ternary_mode(input: &str, mode: ExprMode) -> PResult<'_, Expr> {
         // A then-branch assignment is a genuine error (the `=` would sit between
         // `??` and `!!`); raku rejects it too. In non-Full modes the else-branch
         // may still have greedily taken an assignment, which is likewise too loose.
-        if is_assignment_expr(&then_expr) || is_assignment_expr(&else_expr) {
+        // Only the LOOSE assignment operators count: `.=` is a mutating method
+        // call at method-postfix precedence (operators.rakudoc "Method call" /
+        // "Dotty infix"), far tighter than `?? !!`, so `1 ?? $v .= uc !! 9` is
+        // legal and must not be rejected.
+        if (is_assignment_expr(&then_expr) && !assign_operator_is_tight(then_src))
+            || (is_assignment_expr(&else_expr) && !assign_operator_is_tight(else_src))
+        {
             return Err(conditional_precedence_too_loose_error());
         }
         let ternary_expr = if let Expr::Binary { left, op, right } = cond {

--- a/t/ternary-dot-assign-branch.t
+++ b/t/ternary-dot-assign-branch.t
@@ -1,0 +1,56 @@
+use v6;
+use Test;
+
+# `.=` is a mutating method call at method-postfix / dotty-infix precedence
+# (operators.rakudoc), far TIGHTER than the conditional `?? !!`, so it is legal
+# unparenthesized inside a ternary branch. mutsu used to reject it with
+# `X::Syntax::ConditionalOperator::PrecedenceTooLoose`, because the parser lowers
+# `$v .= uc` to the same `AssignExpr` shape as the genuinely-too-loose `$v = ...`.
+#
+# The loose assignment operators must keep being rejected.
+
+plan 10;
+
+{
+    my $v = 'a';
+    is (1 ?? $v.=uc !! 9), 'A', 'a tight `.=` in the then-branch is accepted';
+    is $v, 'A', 'and it mutated the variable';
+}
+
+{
+    my $v = 'a';
+    is (1 ?? $v .= uc !! 9), 'A', 'the spaced dotty-infix form works too';
+}
+
+{
+    my $v = 'a';
+    is (0 ?? 9 !! $v.=uc), 'A', 'and in the else-branch';
+}
+
+{
+    # A list-assignment context reaches the guard through a different parse path.
+    my $v = 'a';
+    my @z = 1 ?? $v.=uc !! 9;
+    is-deeply @z, ['A'], 'a `.=` branch inside a list assignment is accepted';
+}
+
+{
+    my $v = 'ab';
+    is (1 ?? $v.=uc.=lc !! 9), 'ab', 'a chained `.=` in a branch works';
+}
+
+{
+    my %h = k => 'a';
+    is (1 ?? %h<k>.=uc !! 9), 'A', 'a `.=` on a hash element works';
+    my @a = 'x',;
+    is (1 ?? @a[0].=uc !! 9), 'X', 'a `.=` on an array element works';
+}
+
+# The loose operators are still rejected.
+throws-like 'my $a = 0; 1 ?? $a = 5 !! 6',
+    X::Syntax::ConditionalOperator::PrecedenceTooLoose,
+    'a bare `=` in a ternary branch is still rejected';
+
+throws-like 'my $a = 0; 1 ?? $a += 5 !! 6',
+    X::Syntax::ConditionalOperator::PrecedenceTooLoose,
+    'a compound assignment in a ternary branch is still rejected';


### PR DESCRIPTION
## Problem

```raku
my $v = 'a';
say 1 ?? $v.=uc !! 9;   # raku: A     mutsu: X::Syntax::ConditionalOperator::PrecedenceTooLoose
```

raku accepts this. `.=` is a *mutating method call* at method-postfix /
dotty-infix precedence (`operators.rakudoc`, the "Method call" and "Dotty infix"
rows), far **tighter** than the conditional `?? !!` — unlike `=` and the compound
assignments, which really are looser and do need parentheses.

This was PLAN §B4's top recurring blocker from the dist-compatibility sweep
("Assignment operators inside ?? !! are too loose", 2 dists). The guard was
firing on **valid** code, not flagging a real problem.

## Root cause

The parser lowers `$v .= uc` to exactly the same node `$v = $v.uc` produces —
`Expr::AssignExpr { name: "v", expr: MethodCall { target: Var("v"), … } }`
(`postfix::dot_assign::wrap_dot_assign`). Both ternary guards
(`precedence/ternary.rs`, `precedence/list_infix_top.rs`) tested only that AST
shape, so they could not tell the tight operator from the loose one.

They now consult `assign_operator_is_tight`, which reads the branch's source text:
skip the leading sigil variable, then check whether the operator that follows is
`.=`. Anything else is still reported as too loose.

Both guards needed it, measured rather than assumed: a temporary probe showed
`ternary.rs` fires for the plain expression form and `list_infix_top.rs` for the
list-assignment form (`my @z = 1 ?? $v.=uc !! 9`).

**On reading the source:** this is a workaround for the AST ambiguity, and the
helper carries a `TODO` to record the operator in the AST instead. That is
deferred deliberately — `Expr::AssignExpr` has ~170 construction sites and Rust
struct literals must name every field, so adding a discriminant is a large
mechanical change better done as its own PR than smuggled into a bug fix.

## Testing

- `t/ternary-dot-assign-branch.t` (10 subtests): then-branch, spaced dotty-infix
  form, else-branch, list-assignment context, chained `.=`, hash- and
  array-element targets, plus `=` and `+=` still throwing
  `X::Syntax::ConditionalOperator::PrecedenceTooLoose`. All 10 identical under
  `raku`.
- `roast/S03-operators/{ternary,assign,scalar-assign,assign-is-not-binding}.t`:
  343 tests, all pass.
- `make test`: 2463 files, 23484 tests, all successful.

## Known remaining divergence (unchanged, noted in the news entry)

`1 ?? $v .= 3 !! 9` (a `.=` with a non-method RHS) is a compile-time error in
raku; mutsu rejects it at runtime with `No such method '3'`. Both reject it — this
is the general compile-time-vs-runtime detection gap, not ternary-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)