### PR TITLE
docs(batteries): select DBIish for the database slot, and file its blockers

### DIFF
--- a/BATTERIES.md
+++ b/BATTERIES.md
@@ -248,7 +248,14 @@ make a real `https://` request using nothing but the shipped binary.
 | Template engine | `Template::Mustache` (`zef:raku-community-modules`) | Adopted | Artistic-2.0 | **Working** — vendored + zero-config `use`; 11/13 upstream files pass, including the whole official mustache spec suite. Chosen over `Template6` / `Jinja2` / 7 others by a measured survey | [templates.md](docs/batteries/templates.md) |
 | Test helpers | `Test::Util::ServerPort` | Adopted | Artistic-2.0 | **Working** — vendored + zero-config `use`; both upstream test files pass. Lets a bundled-only test suite bind a listener without hardcoding a port, and makes `HTTP::UserAgent`'s local-server tests gateable | [test-helpers.md](docs/batteries/test-helpers.md) |
 | JSON | native `to-json` / `from-json` | Native | — | Working | — |
+| Database (SQLite) | `DBIish` (`zef:raku-community-modules`) | Adopted | BSD-2-Clause | **Selected, not yet bundled** — chosen over `DB::SQLite` by a measured survey (449 dependents vs 0; maintained vs 2021). raku 9/9, mutsu 1/9; blockers tracked in `todo/tickets/dbiish-blockers.md`. Will need system `libsqlite3` at runtime | [database.md](docs/batteries/database.md) |
 
 Other modules with a proven working record (Template::Mustache, HTTP::Parser,
 HTTP::Server::Tiny, NativeCall MVP, the Zef CLI) are tracked in `PLAN.md` §1 and
 are folded into this index as their bundling + documentation is finalized.
+
+A row marked **Selected, not yet bundled** is a decision recorded ahead of the
+vendoring: the candidate has won its survey and the evidence is written down, but
+it does not run on mutsu yet, so shipping it would mean shipping a battery the
+release gate cannot verify. Such a row carries no `modules/` tree and no
+`batteries.lock` entry until its blockers are cleared.

--- a/PLAN.md
+++ b/PLAN.md
@@ -109,6 +109,15 @@ section.
       MIME::Base64 / HTTP::Server::Tiny / Tubu (sync WAF) / DBDishLite (SQLite) / NativeCall.
       Use "a web blog can be written with the bundle alone" as the selection criterion (the HTTP
       client gap needs investigation).
+- [ ] **Bundle the database battery — `DBIish` (SQLite).** The slot is **selected** and its survey is
+      recorded in [docs/batteries/database.md](docs/batteries/database.md) (`DBIish` over `DB::SQLite`:
+      449 dependents vs 0, maintained vs 2021, fewer deps, one API for several engines). It is **not
+      yet bundled** because it does not run: raku 9/9, mutsu 1/9. Clear the blockers in
+      `todo/tickets/dbiish-blockers.md` — the parser one
+      (`package`-nested classes are not type names) is worth 3 of the 9 files on its own — then
+      vendor `DBIish` + `NativeLibs` + `NativeHelpers::Blob` and baseline the release gate.
+      This is the next step toward "a web blog can be written with the bundle alone": the bundle can
+      already fetch, render and parse JSON, but it cannot store.
 - [ ] **Vendoring mechanism**: vendor the bundled modules into the source tree (e.g. `modules/`) so
       an installed mutsu resolves them with no extra configuration (make `MUTSULIB` have a built-in
       default, or register a standard lib path in `Interpreter::new()` — same pattern as

--- a/docs/batteries/database.md
+++ b/docs/batteries/database.md
@@ -1,0 +1,161 @@
+# Battery: database layer — `DBIish` (SQLite)
+
+**Slot:** Database / persistence · **Chosen:** `DBIish`
+(`auth<zef:raku-community-modules>`, v0.6.8, BSD-2-Clause) · **Kind:** Adopted
+(community module, to be vendored as-is) · **Yardstick:**
+[BATTERIES.md §2](../../BATTERIES.md#2-selection-criteria) — license (hard gate)
+→ dependency weight → proven behaviour on mutsu → API fit → "a small web blog can
+be written with the bundle alone"
+
+Surveyed with the procedure in [selection-method.md](selection-method.md).
+
+## Status: selected, NOT yet bundled
+
+This is a **selection record ahead of the vendoring**, which is deliberate: the
+winner is decided and its evidence is written down, but `DBIish` does not run on
+mutsu yet, so bundling it would ship a battery that cannot be gated. The blockers
+are enumerated below and tracked in `todo/tickets/`; bundling follows once they
+are cleared.
+
+The slot matters because the bundle can currently *fetch* (HTTP client + TLS),
+*render* (`Template::Mustache`) and *parse* (native JSON) — but it cannot
+**store**. A blog needs persistence, and SQLite is the shape that needs no server.
+
+## The field
+
+Numbers are whole upstream test files fully passing (a TAP plan, every planned
+test `ok`, no `not ok`), run against a plain checkout of the dist with `-I lib`
+plus its dependencies. Measured 2026-07-25 against `raku` (Rakudo v2026.06) and a
+debug build of mutsu `main`.
+
+Only SQLite is in scope: `libsqlite3` is present on the survey machine while
+`libpq` and `libmysqlclient` are not, so the Pg/MySQL/Oracle/SQLCipher files of
+both candidates are out of scope for the comparison (they are skipped, not
+failed). `DBIISH_WRITE_TEST=YES` was set so the write tests actually run.
+
+| Candidate | Version | Released | License | Runtime deps | Dependents¹ | raku | **mutsu** |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| **`DBIish`** | 0.6.8 | 2026-04-12 | BSD-2-Clause | 2 | **449** | **9/9** | **1/9** |
+| `DB::SQLite` (+ `DB`) | 0.7 | 2021-04-29 | BSD-2-Clause | 4 | 0 (`DB`: 232) | **9/9** | **0/9** |
+| `Red` | 0.2.4 | 2025-11-13 | Artistic-2.0 | 4 | 44 | *not a competitor* | — |
+| `Duckie` | 0.0.9 | 2026-01-13 | MIT | 1 | 66 | *wrong engine* | — |
+| `Badger` | 1.2.0 | 2024-11-07 | Artistic-2.0 | **0** | 11 | *not a driver* | — |
+
+¹ Distributions in the ecosystem index that declare a dependency on it — computed
+over the 2506 distinct dist names in the local REA + fez indices
+(`~/.zef/store/{rea,fez}/*.json`), the same data `mzef` uses.
+
+### Why the bottom three are not really in the running
+
+- **`Red` is a consumer, not a competitor.** It is an ORM whose own `depends`
+  lists `DBIish` and `DB::Pg`. Bundling it would mean bundling a driver anyway,
+  and an ORM is a layer above what this slot is for. It is a good argument
+  *for* `DBIish` — the ecosystem's ORM builds on it.
+- **`Duckie` is the wrong engine.** DuckDB is a columnar analytics database; the
+  blog yardstick wants an embedded transactional store.
+- **`Badger` is not a driver.** It exposes SQL files as Raku subs and still needs
+  a database layer underneath.
+
+That leaves a straight two-way comparison: **`DBIish` vs `DB::SQLite`**.
+
+## Why `DBIish`
+
+Both are BSD-2-Clause and both are 9/9 under raku, so the license gate and the
+upstream-health check do not separate them. The rest does:
+
+- **Ecosystem standing is not close: 449 dependents vs 0.** `DB::SQLite` itself
+  has no dependents at all; its `DB` base-roles dist has 232, but that counts the
+  whole `DB::*` family. `DBIish` is what the ecosystem actually builds on,
+  including `Red`, the ORM most likely to sit on top of this slot later.
+- **Maintenance: 2026-04-12 vs 2021-04-29.** `DB::SQLite` has not been released
+  in over four years, and its `DB` base is from 2020. `DBIish` is current.
+- **Fewer dependencies, and better ones.** `DBIish` needs `NativeHelpers::Blob`
+  and `NativeLibs`. `DB::SQLite` needs `BitEnum`, `DB`, `NativeLibs` **and**
+  `Concurrent::Stack`, i.e. it drags in a concurrency primitive as well.
+- **One driver interface for several engines.** `DBIish` covers SQLite, Pg, MySQL
+  and Oracle behind one API, so bundling it now does not foreclose a Postgres
+  story later; `DB::SQLite` would need a sibling dist per engine.
+- **mutsu is closer to it.** 1/9 vs 0/9 is a small margin, but the *shape* is
+  very different — see below.
+
+## Licenses (the hard gate)
+
+All three trees that would be vendored are clear:
+
+| Dist | Declared where | License |
+| --- | --- | --- |
+| `DBIish` 0.6.8 | `META6.json` + `LICENSE` | BSD-2-Clause |
+| `NativeLibs` 0.0.9 | `META6.json` + `LICENSE` | Artistic-2.0 |
+| `NativeHelpers::Blob` 0.1.9 | **`LICENSE` only** — `META6.json` has no `license` key | Artistic-2.0 |
+
+`NativeHelpers::Blob` ships the full Artistic-2.0 text with a copyright line
+("Copyright (c) 2016 by Salvador Ortiz"), so it is declared *somewhere* and
+passes [§4](../../BATTERIES.md#4-license-policy). This is **not** a second
+`Encode` situation: `Encode` ships no license statement anywhere, which is why it
+is carried provisionally. No new provisional exception is needed here.
+
+## What blocks mutsu today
+
+The good news first: **nothing fails in NativeCall.** The foundation laid for
+`OpenSSL` (CStruct, opaque pointers, callbacks — a much harder surface than
+SQLite's) is carrying the SQLite bindings. The failures are ordinary interpreter
+bugs, and one of them accounts for a third of the file count on its own.
+
+| File | mutsu | First observed failure |
+| --- | --- | --- |
+| `02-meta.rakutest` | **PASS** | — |
+| `44-sqlite-memory` / `45-sqlite-common` / `46-sqlite-blob` | FAIL | `Failed to parse module 'DBIish::CommonTesting': X::Comp::Group: Missing block` |
+| `01-basic` | FAIL | `No such method 'method_table' for invocant of type 'Perl6::Metamodel::PackageHOW'` |
+| `05-mock` | FAIL | `P6opaque: no such attribute '$!parent' on type DBDish::ErrorHandling` |
+| `03-lib-util`, `06-types`, `48-sqlite-errors` | FAIL | first line is only a *warning*; not yet root-caused |
+
+**The single biggest lever is the parse error**, which kills three SQLite files at
+once and is root-caused down to a five-line repro: a class declared inside a
+`package` block is not visible to the parser as a *type name*, so `when
+<that name>` fails to parse. `DBIish` declares every one of its exception types
+that way (`package GLOBAL::X::DBIish { class LibraryMissing … }`), and
+`CommonTesting` dispatches on them in a `CATCH`. Replacing the two `when`
+matchers with built-in types makes the module load. Filed as
+`todo/tickets/package-nested-class-not-a-parser-type-name.md`.
+
+The remaining blockers are tracked in `todo/tickets/dbiish-blockers.md`.
+
+`DB::SQLite`'s 0/9 has a different first cause — `Unknown function: cannon-name`,
+an `our proto sub` in `NativeLibs`, which both candidates depend on. It is filed
+separately (`todo/tickets/nativelibs-our-proto-sub-unknown-function.md`) because
+`NativeLibs` is on `DBIish`'s dependency list too, so it has to be fixed either
+way.
+
+## How the field was surveyed
+
+The ecosystem was enumerated from the **local REA + fez indices** rather than by
+guesswork: 2506 dists, filtered on name/description/tags for database keywords,
+then each candidate's tarball fetched straight from the REA archive at its pinned
+version and its own suite run under both `raku` and `target/debug/mutsu`.
+Reverse-dependency counts come from the same indices.
+
+Note for whoever reruns this: `raku`'s baseline must be taken **with the
+dependency `-I` paths supplied as a shell array**. A `$VAR` holding
+`-I a -I b` is passed to the process as a single argument by zsh (no word
+splitting), which produces a bogus "everything fails under raku" result.
+
+## Ruled out before measuring
+
+- **`DBIish::Pg` / `MongoDB` / `MySQL`-only dists** — a server-backed database
+  contradicts the "install one binary" premise of the bundle. SQLite is the only
+  engine that needs nothing else running.
+- **`Red`** — see above; an ORM belongs on top of this slot, not in it. Worth
+  revisiting as a *later* battery once `DBIish` works, since it is the
+  ecosystem's ORM and already targets `DBIish`.
+
+## Next steps before this can be bundled
+
+1. Clear the blockers in `todo/tickets/` (parser first — it is worth 3 files).
+2. Re-measure; the gate needs a per-file baseline worth pinning.
+3. Vendor `DBIish` + `NativeLibs` + `NativeHelpers::Blob` per
+   [BATTERIES.md §3](../../BATTERIES.md#3-vendoring-and-resolution), write the
+   re-vendoring recipe into this record, and add the dists to `batteries.lock`.
+4. `scripts/battery-testsuite.sh --update`, then close the remaining gaps the
+   same way the other batteries were closed.
+5. Note the runtime requirement: like `OpenSSL`, this battery needs a **system
+   `libsqlite3`** at runtime. That belongs in the bundle index row.

--- a/todo/tickets/dbiish-blockers.md
+++ b/todo/tickets/dbiish-blockers.md
@@ -1,0 +1,94 @@
+# `DBIish` battery — remaining blockers
+
+The database battery is selected but not yet bundled; the reasoning and the
+candidate comparison are in [docs/batteries/database.md](../../docs/batteries/database.md).
+This file is the ledger of what stops `DBIish` from running on mutsu. Measured
+2026-07-25, `DBIish` 0.6.8, debug build of `main`.
+
+Only the generic and SQLite files are in scope — `libpq` / `libmysqlclient` are
+not installed on the survey machine, so the Pg/MySQL/Oracle/SQLCipher files are
+neither passing nor failing.
+
+## Reproducing
+
+```sh
+mkdir -p tmp/dbslot && cd tmp/dbslot
+for u in \
+ 'https://raw.githubusercontent.com/raku/REA/main/archive/D/DBIish/DBIish%3Aver%3C0.6.8%3E%3Aauth%3Czef%3Araku-community-modules%3E%3Aapi%3C1%3E.tar.gz' \
+ 'https://raw.githubusercontent.com/raku/REA/main/archive/N/NativeHelpers%3A%3ABlob/NativeHelpers%3A%3ABlob%3Aver%3C0.1.9%3E%3Aauth%3Cgithub%3Asalortiz%3E.tar.gz' \
+ 'https://raw.githubusercontent.com/raku/REA/main/archive/N/NativeLibs/NativeLibs%3Aver%3C0.0.9%3E%3Aauth%3Czef%3Araku-community-modules%3E.tar.gz' ; do
+ curl -sSL "$u" | tar xz; done
+cd DBIish-0.6.8
+INC=(-I lib -I ../NativeLibs-0.0.9/lib -I ../NativeHelpers-Blob-*/lib)
+export DBIISH_WRITE_TEST=YES        # required, or the write tests all skip
+raku $INC t/45-sqlite-common.rakutest      # baseline: 9/9 files pass
+mutsu $INC t/45-sqlite-common.rakutest
+```
+
+**`$INC` must be a shell array.** zsh does not word-split a plain scalar, so
+`raku $INC …` passes one giant argument and every file "fails" under raku too —
+a bogus baseline that wastes a session.
+
+## Status: mutsu 1/9, raku 9/9
+
+| File | mutsu | Blocker |
+| --- | --- | --- |
+| `02-meta.rakutest` | **PASS** | — |
+| `44-sqlite-memory` | FAIL | ① parse |
+| `45-sqlite-common` | FAIL | ① parse |
+| `46-sqlite-blob` | FAIL | ① parse |
+| `01-basic` | FAIL | ② `PackageHOW.method_table` |
+| `05-mock` | FAIL | ③ role attribute `$!parent` |
+| `03-lib-util` | FAIL | ④ not root-caused |
+| `06-types` | FAIL | ④ not root-caused |
+| `48-sqlite-errors` | FAIL | ④ not root-caused |
+
+**Nothing fails inside NativeCall.** The surface `OpenSSL` needed (CStruct,
+opaque pointers, callbacks) is strictly harder than SQLite's, and it is holding.
+
+## ① Parse failure — worth three files
+
+`Failed to parse module 'DBIish::CommonTesting': X::Comp::Group: Missing block`.
+
+Root-caused and filed separately:
+**`todo/tickets/package-nested-class-not-a-parser-type-name.md`** — a class
+declared inside a `package` block is not a type name to the parser, so the
+`when X::DBIish::LibraryMissing { … }` in `CommonTesting`'s `CATCH` cannot parse.
+Fix that first; it is the highest-yield item here.
+
+## ② `Perl6::Metamodel::PackageHOW.method_table` (`01-basic`)
+
+```
+No such method 'method_table' for invocant of type 'Perl6::Metamodel::PackageHOW'
+```
+
+`01-basic` walks the metamodel to check the driver interface. `method_table` is a
+Rakudo MOP method that mutsu's `PackageHOW` does not implement. Not investigated
+beyond the message; check what the test actually asks for before implementing the
+whole MOP surface.
+
+## ③ Role attribute not seeded (`05-mock`)
+
+```
+P6opaque: no such attribute '$!parent' on type DBDish::ErrorHandling in a DBDish::ErrorHandling
+```
+
+`DBDish::ErrorHandling` is a role with a `$!parent` attribute; the attribute is
+not present on the composed instance. Related in shape to the attribute-cell work
+in `news/2026-07/scalar-attribute-subscript-assignment.md`, but it is a
+*composition-time seeding* problem rather than a write-path one.
+
+## ④ Not root-caused (`03-lib-util`, `06-types`, `48-sqlite-errors`)
+
+Their first non-TAP line is only a **warning** —
+`Use of uninitialized value of type Any in string context` / `Use of Nil in
+string context` — which is emitted by both implementations and is *not* the
+diagnosis. This exact trap already cost a session on `Template::Mustache`; get
+the real failing assertion before forming a theory.
+
+## When these are cleared
+
+Follow the "Next steps before this can be bundled" list at the end of
+`docs/batteries/database.md`: re-measure, vendor the three trees, add them to
+`batteries.lock`, and baseline the release gate with
+`scripts/battery-testsuite.sh --update`.

--- a/todo/tickets/nativelibs-our-proto-sub-unknown-function.md
+++ b/todo/tickets/nativelibs-our-proto-sub-unknown-function.md
@@ -1,0 +1,81 @@
+# `NativeLibs`: `Unknown function: cannon-name` (an `our proto sub`)
+
+Loading anything that goes through `NativeLibs`' library-name resolution dies
+with
+
+```
+Unknown function: cannon-name
+```
+
+`cannon-name` is not a typo in the caller — it is the real (mis-spelled upstream)
+name of an `our proto sub` declared in `NativeLibs.rakumod`:
+
+```raku
+our proto sub cannon-name(|) {*}
+multi sub cannon-name(Str:D $libname, Version $version?) { … }
+multi sub cannon-name(Str $libname, Cool $ver) { … }
+```
+
+## Impact
+
+`NativeLibs` (0.0.9, `zef:raku-community-modules`, Artistic-2.0, **96
+dependents**) is a runtime dependency of *both* database candidates:
+
+- `DB::SQLite` — this is its **first** failure; all 9 of its upstream test files
+  die here (raku: 9/9 pass).
+- `DBIish` — the chosen battery (`docs/batteries/database.md`) also lists
+  `NativeLibs` in `depends`, so this has to be fixed for the database slot
+  regardless of which candidate is bundled.
+
+## Repro
+
+```sh
+mkdir -p tmp/dbslot && cd tmp/dbslot
+curl -sSL 'https://raw.githubusercontent.com/raku/REA/main/archive/N/NativeLibs/NativeLibs%3Aver%3C0.0.9%3E%3Aauth%3Czef%3Araku-community-modules%3E.tar.gz' | tar xz
+# then load DB::SQLite (or any dist whose driver calls NativeLibs::Loader)
+```
+
+## What it is NOT
+
+A plain `our proto sub` in a module works. This parses, loads and dispatches
+correctly under both implementations:
+
+```raku
+# lib/ProtoMod.rakumod
+unit module ProtoMod;
+our proto sub cannon-name(|) {*}
+multi sub cannon-name(Str:D $n) { "one:$n" }
+multi sub cannon-name(Str:D $n, Int $i) { "two:$n:$i" }
+our sub use-it($n) { cannon-name($n) }
+```
+
+So the trigger is narrower than "`our proto sub` is broken". The distinguishing
+feature of `NativeLibs.rakumod` is its **file shape**: it opens with a custom
+`sub EXPORT(|)` that builds a `Map` by introspecting `&trait_mod:<is>.candidates`,
+and only *then* declares `unit module NativeLibs`:
+
+```raku
+use NativeCall;
+
+sub EXPORT(|) {
+    my $exp = &trait_mod:<is>.candidates.first: { .signature ~~ :(Routine, :$native!) };
+    Map.new('NativeCall' => NativeCall, '&trait_mod:<is>' => $exp.dispatcher);
+}
+
+unit module NativeLibs:ver<0.0.9>;
+
+our proto sub cannon-name(|) {*}
+```
+
+Start by reducing that: a custom `sub EXPORT` **before** a `unit module`
+declaration, with an `our proto sub` after it. The likely story is that the
+declarations following `unit module` are not being registered into the module's
+package when a custom `EXPORT` is present, so the intra-module call cannot
+resolve.
+
+## Note on the diagnostic
+
+The first line mutsu prints for these files is
+`Use of uninitialized value of type Any in string context`, which is a **warning
+in both implementations** and not the failure. The real error is several lines
+down. Do not root-cause from the first line.

--- a/todo/tickets/package-nested-class-not-a-parser-type-name.md
+++ b/todo/tickets/package-nested-class-not-a-parser-type-name.md
@@ -1,0 +1,76 @@
+# A class declared inside a `package` block is not a type name to the parser
+
+`when <Qualified::Name>` fails to **parse** when `Qualified::Name` was declared as
+a class nested inside a `package` block rather than with a fully-qualified `class`
+declaration. The error is `X::Comp::Group: Missing block`, i.e. the parser did not
+recognise the name as a type and so never found the `when` block.
+
+## Repro
+
+```raku
+package GLOBAL::X::Foo {
+    class Missing is Exception { method message { "missing" } }
+}
+try {
+    die X::Foo::Missing.new;
+    CATCH {
+        when X::Foo::Missing { say "matched" }
+        default { .rethrow }
+    }
+}
+```
+
+```
+raku:  matched
+mutsu: Runtime error: X::Comp::Group: Missing block
+```
+
+## What it is NOT
+
+Each of these was checked in isolation against raku, and none is the trigger:
+
+- **The `use` boundary.** It fails identically when the `package` block and the
+  `CATCH` are in the same file, and when the classes come from a `use`d module.
+- **A union matcher.** `when A | B { }` is not needed — a single `when` fails.
+- **Two `when` clauses.** One is enough.
+- **`CATCH` specifically.** A plain `given`/`when` on the same name fails the
+  same way.
+- **The qualified name itself.** Declaring the very same name directly —
+  `class X::Foo::Missing is Exception { }` — parses and matches fine. So does
+  `package X::Bar { … }` without the `GLOBAL::` prefix; both spellings of the
+  nesting fail.
+
+And note that **referencing the type works**: `say X::Foo::Missing.^name` prints
+`X::Foo::Missing`. The class *is* registered at runtime under its composed name —
+it is only the parser's notion of "is this token a type name?" that misses it.
+
+## Where to look
+
+Whatever table the parser consults to decide that a `::`-qualified identifier in
+term position is a type (rather than, say, a function call, which is what would
+make it swallow the following block and then report a missing one). A direct
+`class A::B { }` declaration populates it; composing the name from an enclosing
+`package`/`module` block declaration does not. The fix is to register the
+composed name at declaration time, from the package-scope stack, rather than only
+from the literal text of the `class` declarator.
+
+## Impact
+
+This is the single biggest blocker for the `DBIish` battery
+(`docs/batteries/database.md`): `DBIish` declares all of its exception types this
+way —
+
+```raku
+package GLOBAL::X::DBIish {
+    class LibraryMissing is Exception { … }
+}
+```
+
+— and `DBIish::CommonTesting` dispatches on them in a `CATCH`, so the module
+fails to parse and takes **three** SQLite test files with it. Replacing the two
+`when` matchers with built-in types makes the module load, which confirms the
+diagnosis.
+
+The construct is ordinary Raku and `package X:: { class … }` is the idiomatic way
+to declare a family of exception types, so the blast radius is much wider than
+that one dist.

--- a/todo/tickets/package-nested-class-not-a-parser-type-name.md
+++ b/todo/tickets/package-nested-class-not-a-parser-type-name.md
@@ -44,15 +44,56 @@ And note that **referencing the type works**: `say X::Foo::Missing.^name` prints
 `X::Foo::Missing`. The class *is* registered at runtime under its composed name —
 it is only the parser's notion of "is this token a type name?" that misses it.
 
-## Where to look
+## Where it is — exact code sites
 
-Whatever table the parser consults to decide that a `::`-qualified identifier in
-term position is a type (rather than, say, a function call, which is what would
-make it swallow the following block and then report a missing one). A direct
-`class A::B { }` declaration populates it; composing the name from an enclosing
-`package`/`module` block declaration does not. The fix is to register the
-composed name at declaration time, from the package-scope stack, rather than only
-from the literal text of the `class` declarator.
+The guard that produces the error is
+[`src/parser/stmt/control/given_when.rs:43`](../../src/parser/stmt/control/given_when.rs):
+
+```rust
+if rest.starts_with('{')
+    && let Expr::BareWord(name) = &cond
+    && (name.starts_with("X::") || name.starts_with("CX::"))
+    && !crate::runtime::utils::is_known_type_constraint(name)
+    && !crate::runtime::utils::is_known_compound_type(name)
+    && !crate::parser::stmt::simple::is_user_declared_type(name)
+{
+    return Err(gobbled_block_error(name));
+}
+```
+
+The guard itself is correct and deliberate — an undeclared bareword before a
+block really does gobble it in raku, and this reproduces Rakudo's
+`X::Syntax::BlockGobbled` + `X::Syntax::Missing` pair. Note it only fires for the
+`X::` / `CX::` namespaces, which is why the bug shows up on exception types and
+nowhere else.
+
+The defect is in the third check. `is_user_declared_type` /
+`register_user_type` live in
+[`src/parser/stmt/simple/pragma_preseed.rs:50-70`](../../src/parser/stmt/simple/pragma_preseed.rs)
+and are backed by a scope-stack of name sets. Every declarator registers the
+**literal name as written**:
+
+- `src/parser/stmt/class/class_decl.rs:466` — `register_user_type(&name)`
+- `src/parser/stmt/class/package_decl.rs:387`, `role_decl.rs:451`,
+  `grammar_module.rs:177`, `decl/constant_subset.rs:229,333`,
+  `decl/my_decl_dispatch.rs:96` — same shape
+
+So `package GLOBAL::X::Foo { class Missing { } }` registers only `Missing`, and
+`is_user_declared_type("X::Foo::Missing")` is false.
+
+## Suggested fix
+
+Register the **composed** name in addition to the literal one. The parser has no
+package-path stack today (grepping for `current_package` / `package_stack` in
+`src/parser/` finds nothing), so the fix needs one: push the declared package
+name in `package_decl` (and the `module`/`class`/`role` block declarators) while
+their body is parsed, and have `register_user_type` also insert
+`<enclosing path>::<name>` — stripping a leading `GLOBAL::`, which is a
+pseudo-package and not part of the composed name.
+
+Prefer that over relaxing the guard: the guard is what gives the correct Rakudo
+error for genuinely undeclared names, and weakening it would trade a wrong
+rejection for a wrong acceptance.
 
 ## Impact
 


### PR DESCRIPTION
Records the survey for the **database / persistence** battery ahead of the
vendoring. Docs and tickets only — no source changes.

The bundle can already *fetch* (HTTP client + TLS), *render*
(`Template::Mustache`) and *parse* JSON, but it cannot **store**. That is the
next thing standing between the bundle and "a small web blog can be written with
the bundle alone", and SQLite is the shape that needs no server running.

## The decision

`DBIish` 0.6.8 (BSD-2-Clause) over `DB::SQLite`, the only other real candidate:

| | `DBIish` | `DB::SQLite` (+ `DB`) |
| --- | --- | --- |
| Dependents | **449** | 0 (`DB` base: 232) |
| Released | 2026-04-12 | 2021-04-29 (`DB` base: 2020) |
| Runtime deps | 2 | 4 (incl. `Concurrent::Stack`) |
| Engines | SQLite / Pg / MySQL / Oracle behind one API | one dist per engine |
| raku | **9/9** | **9/9** |
| mutsu | **1/9** | **0/9** |

`Red` is an ORM whose own `depends` lists `DBIish` — a consumer, not a
competitor, and an argument *for* `DBIish`. `Duckie` is DuckDB (columnar
analytics, wrong engine). `Badger` exposes SQL files as subs and still needs a
driver underneath.

Measured rather than assumed, per `docs/batteries/selection-method.md`. Only
SQLite is in scope: `libsqlite3` is present on the survey machine, `libpq` and
`libmysqlclient` are not, so the Pg/MySQL/Oracle/SQLCipher files of both
candidates are skipped rather than failed. `DBIISH_WRITE_TEST=YES` was set so the
write tests actually ran.

## Marked "Selected, not yet bundled"

The bundle index gets a row in that new state, and the PR explains what it means:
the candidate has won its survey and the evidence is written down, but it does
not run on mutsu yet, so bundling would ship a battery the release gate cannot
verify. No `modules/` tree and no `batteries.lock` entry until the blockers
clear.

## Licenses — all clear

`DBIish` BSD-2-Clause, `NativeLibs` Artistic-2.0, and `NativeHelpers::Blob` ships
the full Artistic-2.0 text with a copyright line even though its `META6.json`
omits the `license` key. Declared *somewhere* passes §4, so this is **not** a
second `Encode` situation and no new provisional exception is needed.

## Blockers filed

**Nothing fails inside NativeCall** — the surface `OpenSSL` needed (CStruct,
opaque pointers, callbacks) is strictly harder than SQLite's and it is holding.
The failures are ordinary interpreter bugs:

- **`package-nested-class-not-a-parser-type-name.md`** — the biggest lever, worth
  **3 of the 9 files** on its own. A class declared inside a `package` block is
  not a type name to the parser, so `when X::Foo::Missing { … }` fails to parse
  with `X::Comp::Group: Missing block`. Reduced to a five-line repro; the `use`
  boundary, union matchers, multiple `when` clauses and `CATCH`-vs-`given` were
  each ruled out against raku. Referencing the type works — only the parser's
  "is this a type name?" table misses it. `DBIish` declares every exception type
  this way, and replacing the two `when` matchers with built-in types makes the
  module load, which confirms the diagnosis.
- **`nativelibs-our-proto-sub-unknown-function.md`** — `Unknown function:
  cannon-name` on an `our proto sub` in `NativeLibs` (96 dependents), a runtime
  dependency of *both* candidates, so it has to be fixed either way. A plain
  `our proto sub` module works, so the trigger is narrower — most likely the
  custom `sub EXPORT(|)` that precedes the `unit module` declaration.
- **`dbiish-blockers.md`** — the per-file ledger with the reproduction recipe.
  Two entries are deliberately left un-root-caused and say so, because their
  first output line is only a *warning* (`Use of uninitialized value …`), the
  trap that already cost a session on `Template::Mustache`.

The reproduction recipe also warns that the dependency `-I` paths must be passed
as a **shell array** — zsh does not word-split a scalar, which silently produces
a bogus "raku fails everything" baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
