### PR TITLE
fix: a trailing comma before a statement modifier parses again

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -317,12 +317,19 @@ sessions).
       Live ledger: [`docs/dist-compat-sweep.md`](../docs/dist-compat-sweep.md)
       (regenerate: `scripts/dist-compat-sweep.py`; **sandboxed via `bwrap` — no net,
       read-only FS, throwaway HOME**, since dist code runs arbitrary load-time code).
-      First run (n=60, 2026-07-19): of the pure-Raku, dep-satisfiable dists, **~half
-      load, ~half hit a real mutsu bug on `use` alone**. The top recurring blocker
-      (`Assignment operators inside ?? !! are too loose`, 2 dists) is **fixed**
-      — the guard was firing on a valid tight `.=` in a ternary branch
-      (news/2026-07/ternary-branch-accepts-dot-assign.md); re-run the sweep to pick
-      the next one. This is the
+      **Re-run 2026-07-25 (same n=60 / seed 20260719): 19 load_ok, 20 missing_dep,
+      and only 6 real mutsu failures (2 parse_error, 3 runtime_error, 1 timeout)** —
+      the original "~half hit a real mutsu bug on `use` alone" figure is stale.
+      Cleared since: the `?? !!` "assignment too loose" guard was firing on a valid
+      tight `.=` (news/2026-07/ternary-branch-accepts-dot-assign.md), and a trailing
+      comma before a statement modifier failed to parse, which was the whole
+      `UpRooted` blocker (news/2026-07/trailing-comma-before-statement-modifier.md;
+      all 24 of its modules load now). **Remaining from that run:** `String::Utils`
+      needs an `nqp::` op layer (deep — `todo/deep/nqp-op-layer-missing.md`),
+      `Qwiratry::Test` is still a `parse_error`, `PDF::Class` reports
+      `Unknown role: PDF::COS::Tie::Hash`, `Raku::Pod::Render` times out, and
+      `RakudoContainerfileBuilder` may be a harness artefact (its CLI prints
+      `Usage:`). This is the
       execution counterpart of the signal-only
       [`docs/ecosystem-guts-dependency-survey.md`](../docs/ecosystem-guts-dependency-survey.md)
       and the highest-leverage way to widen the batteries base. Workflow per bug:

--- a/news/2026-07/trailing-comma-before-statement-modifier.md
+++ b/news/2026-07/trailing-comma-before-statement-modifier.md
@@ -1,0 +1,55 @@
+# A trailing comma before a statement modifier parses again
+
+`die "x", if @c;` is legal Raku — the trailing comma is an empty list slot, not a
+syntax error — but mutsu rejected it with `expected statement: expected '.' or
+digits or generic radix literal or ...`. The same applied to `return 1, if 0;`
+and to a paren-less listop argument list (`die sprintf '...', $a, $b, if ...;`).
+
+Found by re-running the real-dist compatibility sweep (PLAN §B4): it is what
+blocked the whole `UpRooted` distribution, which writes exactly that shape in
+`UpRooted::Table`:
+
+```raku
+die sprintf 'UpRooted::Column %s has order conflict in UpRooted::Table %s.', $column.name, $.name,
+    if %!columns.values.grep: *.order == $column.order;
+```
+
+## Root cause
+
+Four different argument-list parsers each decide when a comma was a *trailing*
+comma. All of them treated only `;`, `}`, `)` and end-of-input as terminators, so
+after consuming the comma they tried to parse the modifier keyword as a term and
+failed. `listop.rs` (the general user-sub listop path) already had the
+statement-modifier check; the other three did not:
+
+- `stmt/modifier.rs::parse_statement_modifier` — for statements that parse a
+  single argument expression (`die`/`fail`, via `expression_no_word_logical`,
+  which does not consume commas at all, so the comma was still pending).
+- `stmt/assign/comma.rs` — the comma-list parser used by `return` and the
+  assignment/declaration RHS. Both trailing-comma checks now go through one
+  `comma_list_ends_here` helper.
+- `primary/ident/identifier_call.rs` — twice: the builtin-listop argument loop
+  and the general no-paren-call loop. This is why `sprintf`/`join` heads failed
+  while a user sub of the same shape already worked.
+
+The new predicate `is_stmt_modifier_after_trailing_comma` deliberately rejects a
+same-named **pair key**: `keyword()` only checks a word boundary, so a bare
+`is_stmt_modifier_keyword` would have matched the `with` in `my @a = 1, with =>
+2` and silently truncated the list at its last element. The predicate therefore
+requires that the keyword is not followed by `=>`.
+
+## Result
+
+All 24 `UpRooted` modules now load (the two remaining failures are its missing
+`DBIish` dependency, not a mutsu bug); before this it was one of the two
+`parse_error` rows in the sweep.
+
+The same sweep re-run also confirmed the earlier "~half of dep-satisfiable dists
+hit a real mutsu bug on `use` alone" figure is out of date: of 60 sampled dists
+(seed 20260719) 19 load, 20 are `missing_dep`, and only 6 are real mutsu
+failures (2 `parse_error`, 3 `runtime_error`, 1 `timeout`).
+
+Pinned by `t/trailing-comma-before-statement-modifier.t` (12 subtests covering
+`die`/`fail`, `return` with true and false modifiers, a multi-element `return`,
+both builtin and general listop heads, the pair-key guard, and an ordinary
+trailing comma). All 12 identical under raku.

--- a/src/parser/primary/ident/identifier_call.rs
+++ b/src/parser/primary/ident/identifier_call.rs
@@ -1520,10 +1520,19 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                 }
                 let r3 = &r3[1..];
                 let (r3, _) = ws(r3)?;
+                // Trailing comma: the comma just consumed had no argument after
+                // it, so the argument list ends here. A statement modifier counts
+                // as a terminator — `die sprintf "%s", 1, if @c;` is legal Raku
+                // (the trailing comma is an empty list slot), and `parse_arg`
+                // would otherwise try to read `if` as a term. The generic
+                // user-sub listop loop in `listop.rs` already does this; the
+                // builtin-listop loop here did not, so only builtin heads
+                // (`sprintf`, `join`, ...) rejected the shape.
                 if r3.starts_with(';')
                     || r3.starts_with('}')
                     || r3.starts_with(')')
                     || r3.is_empty()
+                    || is_stmt_modifier_ahead(r3)
                 {
                     break;
                 }
@@ -1713,10 +1722,15 @@ pub(crate) fn identifier_or_call(input: &str) -> PResult<'_, Expr> {
                 }
                 let r3 = &r3[1..];
                 let (r3, _) = ws(r3)?;
+                // Trailing comma ends the argument list; a statement modifier is
+                // one of its terminators (`die sprintf "%s", 1, if @c;` — the
+                // comma is an empty list slot). See the same guard in the
+                // builtin-listop loop above and in `listop.rs`.
                 if r3.starts_with(';')
                     || r3.starts_with('}')
                     || r3.starts_with(')')
                     || r3.is_empty()
+                    || is_stmt_modifier_ahead(r3)
                 {
                     break;
                 }

--- a/src/parser/stmt/assign/comma.rs
+++ b/src/parser/stmt/assign/comma.rs
@@ -1,4 +1,19 @@
 use super::*;
+use crate::parser::stmt::modifier::is_stmt_modifier_after_trailing_comma;
+
+/// Whether a comma list ends here — i.e. the comma just consumed was a TRAILING
+/// comma (an empty list slot). Besides the obvious terminators, a statement
+/// modifier ends it: `return 1, if 0;` and `take 1, for @a;` are legal Raku, and
+/// without this the element parser would try to read `if`/`for` as a term and
+/// fail with a bogus "expected expression" (`UpRooted::Table` writes
+/// `die sprintf(...), $a, $b,\n\tif ...;`).
+fn comma_list_ends_here(r: &str) -> bool {
+    r.starts_with(';')
+        || r.is_empty()
+        || r.starts_with('}')
+        || r.starts_with(')')
+        || is_stmt_modifier_after_trailing_comma(r)
+}
 
 /// Parse a comma expression (may produce a list).
 pub(in crate::parser) fn parse_comma_or_expr(input: &str) -> PResult<'_, Expr> {
@@ -11,7 +26,7 @@ fn parse_comma_or_expr_impl(input: &str, item_context: bool) -> PResult<'_, Expr
     if r.starts_with(',') && !r.starts_with(",,") {
         let (r, _) = parse_char(r, ',')?;
         let (r, _) = ws(r)?;
-        if r.starts_with(';') || r.is_empty() || r.starts_with('}') || r.starts_with(')') {
+        if comma_list_ends_here(r) {
             // Single element with a trailing comma. In list context this is a
             // 1-element list (`@a = 1..5,` keeps the Range unflattened); in item
             // context it collapses to the element (`return 5,` -> `5`).
@@ -31,7 +46,7 @@ fn parse_comma_or_expr_impl(input: &str, item_context: bool) -> PResult<'_, Expr
             }
             let (r2, _) = parse_char(r2, ',')?;
             let (r2, _) = ws(r2)?;
-            if r2.starts_with(';') || r2.is_empty() || r2.starts_with('}') || r2.starts_with(')') {
+            if comma_list_ends_here(r2) {
                 let items = normalize_comma_list_items(items);
                 return Ok((r2, finalize_list(items)));
             }
@@ -68,7 +83,7 @@ fn parse_comma_or_expr_no_wl_impl(input: &str, item_context: bool) -> PResult<'_
     if r.starts_with(',') && !r.starts_with(",,") {
         let (r, _) = parse_char(r, ',')?;
         let (r, _) = ws(r)?;
-        if r.starts_with(';') || r.is_empty() || r.starts_with('}') || r.starts_with(')') {
+        if comma_list_ends_here(r) {
             if item_context {
                 return Ok((r, first));
             }
@@ -85,7 +100,7 @@ fn parse_comma_or_expr_no_wl_impl(input: &str, item_context: bool) -> PResult<'_
             }
             let (r2, _) = parse_char(r2, ',')?;
             let (r2, _) = ws(r2)?;
-            if r2.starts_with(';') || r2.is_empty() || r2.starts_with('}') || r2.starts_with(')') {
+            if comma_list_ends_here(r2) {
                 let items = normalize_comma_list_items(items);
                 return Ok((r2, finalize_list(items)));
             }

--- a/src/parser/stmt/modifier.rs
+++ b/src/parser/stmt/modifier.rs
@@ -160,6 +160,17 @@ pub(super) fn is_stmt_modifier_keyword(input: &str) -> bool {
     leading_modifier_keyword(input).is_some()
 }
 
+/// A statement-modifier keyword sitting right after a *trailing comma*
+/// (`die "x", if @c;` / `return 1, if 0;` — legal Raku, the trailing comma is an
+/// empty list slot). Rejects a same-named **pair key** (`1, with => 2`) so a
+/// legal comma list is never truncated at its last element.
+pub(in crate::parser) fn is_stmt_modifier_after_trailing_comma(input: &str) -> bool {
+    let Some(kw) = leading_modifier_keyword(input) else {
+        return false;
+    };
+    !input[kw.len()..].trim_start().starts_with("=>")
+}
+
 /// The statement-modifier keyword at the start of `input`, if any.
 fn leading_modifier_keyword(input: &str) -> Option<&'static str> {
     [
@@ -234,6 +245,24 @@ fn block_follows_modifier_condition(r: &str) -> bool {
 /// Supports chaining: `expr if cond for list` parses as `for list { expr if cond }`.
 pub(crate) fn parse_statement_modifier(input: &str, stmt: Stmt) -> PResult<'_, Stmt> {
     let (rest, _) = ws(input)?;
+    // A trailing comma in the statement's argument list is an empty list slot, not
+    // a syntax error: `die "x", if @c;` is legal Raku. Statements that parse a
+    // single argument expression (`die`/`fail`, via `expression_no_word_logical`,
+    // which does not consume commas) leave that comma here, so skip it when a
+    // statement modifier follows. A comma before anything else is left alone so
+    // real errors still surface. (The comma-list statements — `return` and
+    // friends, via `parse_comma_or_expr*` — never reach here with the comma
+    // pending: that parser ends the list itself, see `comma.rs`.)
+    let rest = if let Some(after_comma) = rest.strip_prefix(',') {
+        let (after_ws, _) = ws(after_comma)?;
+        if is_stmt_modifier_after_trailing_comma(after_ws) {
+            after_ws
+        } else {
+            rest
+        }
+    } else {
+        rest
+    };
     // Blocks: never attach a statement modifier across a newline.
     if matches!(stmt, Stmt::Block(_)) {
         let consumed_len = input.len().saturating_sub(rest.len());

--- a/t/trailing-comma-before-statement-modifier.t
+++ b/t/trailing-comma-before-statement-modifier.t
@@ -1,0 +1,54 @@
+use v6;
+use Test;
+
+# A trailing comma in a statement's argument list is an empty list slot, not a
+# syntax error: `die "x", if @c;` is legal Raku. mutsu used to fail to parse it —
+# the argument-list parsers only treated `;`, `}`, `)` and end-of-input as
+# terminators after a comma, so they tried to read the modifier keyword as a term.
+#
+# Found in `UpRooted::Table`, which writes
+#     die sprintf '...', $a, $b,
+#         if %!columns.values.grep: *.order == $column.order;
+
+plan 12;
+
+# `die` / `fail` — a single argument expression (no comma parser involved).
+lives-ok { EVAL 'die "x", if 0' }, 'die with a trailing comma before `if`';
+lives-ok { EVAL 'die "x", unless 1' }, 'die with a trailing comma before `unless`';
+lives-ok { EVAL 'die "x", for ()' }, 'die with a trailing comma before `for`';
+
+# `return` — goes through the comma-list parser.
+{
+    sub skips { return 1, if 0; 2 }
+    is skips(), 2, 'return with a trailing comma before a false `if` falls through';
+    sub takes { return 5, if 1; 2 }
+    is takes(), 5, 'and returns its value when the modifier is true';
+    sub listy { return 1, 2, if 1 }
+    is-deeply listy(), (1, 2), 'a multi-element return keeps its list';
+}
+
+# Paren-less listop argument lists, both the builtin head and the general one.
+{
+    my @c;
+    lives-ok { EVAL 'my @c; die sprintf "a %s", 1, if @c' },
+        'a builtin listop head (sprintf) with a trailing comma before `if`';
+    lives-ok { EVAL 'my @c; say join ",", 1, if @c' },
+        'another builtin listop head (join)';
+    is (EVAL 'my $x = sprintf "%s", 1, if 0; $x // "unset"'), 'unset',
+        'the modifier still governs the whole statement';
+}
+
+# A same-named PAIR KEY must not be mistaken for a statement modifier, or the
+# comma list would be truncated at its last element.
+{
+    my @a = 1, with => 2;
+    is-deeply @a, [1, (with => 2)], 'a `with =>` pair key still parses as a pair';
+    my @b = 1, if => 2;
+    is-deeply @b, [1, (if => 2)], 'an `if =>` pair key too';
+}
+
+# Plain trailing commas keep working.
+{
+    my @a = 1, 2,;
+    is @a.elems, 2, 'an ordinary trailing comma still yields a 2-element list';
+}

--- a/todo/deep/nqp-op-layer-missing.md
+++ b/todo/deep/nqp-op-layer-missing.md
@@ -1,0 +1,85 @@
+# mutsu has almost no `nqp::` ops, which blocks the lizmat-style dists
+
+Found 2026-07-25 while re-running the real-dist compatibility sweep (PLAN §B4).
+`String::Utils` — a widely depended-on distribution — fails to load with:
+
+```
+Runtime error: An exception occurred while evaluating a CHECK
+  Unknown function: unipropcode
+```
+
+The trigger is a module-scope constant, so it fires at load time:
+
+```raku
+my constant $gcprop = nqp::unipropcode("General_Category");
+```
+
+## What is actually missing (measured, not estimated)
+
+mutsu maps `nqp::foo` to a plain function named `foo` (a handful of ops are
+special-cased by full name in `src/runtime/builtins.rs`: `nqp::atkey`,
+`nqp::atpos`, `nqp::ordat`, `nqp::gethostname`, `nqp::bindattr`). Everything else
+resolves as an ordinary builtin, which is why some ops happen to work — `chars`,
+`concat`, `index`, `substr`, `join`, `split`, `flip`, `elems` collide with real
+Raku builtins of the same name.
+
+`String::Utils` alone uses 59 distinct `nqp::` ops. Probing each one
+(`mutsu -e 'use nqp; nqp::<op>()'` and looking for `Unknown function`) says **53
+of the 59 are missing**:
+
+```
+add_i atpos_i atpos_s bindattr_i bindattr_s bindkey bindpos_s bitand_i
+bitshiftr_i box_s chars clone concat const create deletekey eqaddr eqat existskey
+findcclass findnotcclass flip getattr getattr_i getuniprop_int hllbool if iseq_i
+isgt_i isle_i islt_i isne_i isnull isnull_s istype list_s mod_i not_i null null_s
+push_i push_s setelems sha1 stmts strfromcodes strtocodes sub_i substr
+unipropcode until while x
+```
+
+(The probe reports a name as present when the failure is about arguments rather
+than resolution, so the list is a lower bound on what needs real semantics —
+`chars`/`substr`/`concat` "exist" only as their Raku namesakes, whose signatures
+and coercion rules are not the nqp ones.)
+
+## Why it is a deep problem, not a ticket
+
+- **It is a whole compatibility layer, not a bug.** These ops are a typed,
+  low-level ISA: `_i`/`_s`/`_n` suffixes mean native int/str/num operands with no
+  boxing, `nqp::if`/`nqp::while`/`nqp::until`/`nqp::stmts` are *control
+  structures* taking thunks (they cannot be ordinary functions at all),
+  `nqp::null` / `nqp::isnull` expose a null sentinel that mutsu's `Value` has no
+  representation for, and `nqp::const::*` is a constant namespace, not a call.
+- **Several ops need representation work.** `nqp::create`/`getattr`/`bindattr`
+  operate on uninitialised P6opaque storage; `nqp::box_s`/`nqp::decont` straddle
+  the native/boxed boundary; `array[uint32]` buffers (`nqp::strtocodes`,
+  `nqp::strfromcodes`, `nqp::push_i`) want native-typed arrays.
+- **The ISA is large and open-ended.** Fixing one dist's 53 ops does not settle
+  the next dist's set, so the design question is "which subset, with what
+  semantics, dispatched how" — a decision worth an ADR rather than a pile of
+  ad-hoc builtins. In particular, folding nqp ops into the ordinary builtin
+  namespace (today's implicit design) is what makes `nqp::chars` silently mean
+  Raku's `chars`; a separate `nqp::` dispatch table would be the honest shape.
+
+## Deliberate note on scope
+
+This is *not* the same axis as the "compiler guts" skip in the sweep
+(`QAST`/`NQPHLL`/`EXPORTHOW`/`Metamodel::Primitives`), which is genuinely
+out of reach. `nqp::` ops are ordinary low-level operations with well-defined
+semantics; implementing a chosen subset is tractable and would unlock a
+meaningful slice of the ecosystem, since lizmat's modules reach for them freely
+for speed.
+
+## Affected files
+
+- `src/runtime/builtins.rs` — the five full-name `nqp::` special cases
+- `src/compiler/stmt.rs`, `src/runtime/runtime_module.rs` — `use nqp` is accepted
+  as a no-op pragma
+- `src/vm/vm_var_get_ops.rs` — `nqp::gethostname` as a term
+
+## Repro
+
+```
+$ mutsu -I <String-Utils>/lib -e 'use String::Utils'
+Runtime error: An exception occurred while evaluating a CHECK
+  Unknown function: unipropcode
+```


### PR DESCRIPTION
## Problem

```raku
die "x", if @c;      # raku: fine    mutsu: ===SORRY!=== expected statement: expected '.' or digits or ...
return 1, if 0;      # same
die sprintf '%s', $a, $b,
    if @c;           # same
```

The trailing comma is an empty list slot in Raku, not a syntax error.

Found by re-running the real-dist compatibility sweep (PLAN §B4): this was the
entire blocker for the **`UpRooted`** distribution, whose `UpRooted::Table` writes

```raku
die sprintf 'UpRooted::Column %s has order conflict in UpRooted::Table %s.', $column.name, $.name,
    if %!columns.values.grep: *.order == $column.order;
```

All 24 of its modules load now (the two remaining failures are its missing
`DBIish` dependency, not a mutsu bug).

## Root cause

Four separate argument-list parsers each decide when a comma was a *trailing*
comma, and all of them treated only `;`, `}`, `)` and end-of-input as terminators
— so after consuming the comma they tried to parse the modifier keyword as a
term. `listop.rs` (the general user-sub listop path) already had the
statement-modifier check; the other three did not:

| parser | reached by |
|---|---|
| `stmt/modifier.rs::parse_statement_modifier` | `die`/`fail` — single argument expression via `expression_no_word_logical`, which never consumes commas, so the comma was still pending |
| `stmt/assign/comma.rs` | `return` and the assignment/declaration RHS — both trailing-comma checks now share one `comma_list_ends_here` helper |
| `primary/ident/identifier_call.rs` (×2) | the builtin-listop argument loop and the general no-paren-call loop |

That last asymmetry is why `sprintf`/`join` heads failed while a **user sub** of
the same shape already worked — the bisection went `die` → `return` → `join` →
`sprintf`, each exposing one more parser.

**Pair-key guard:** the new `is_stmt_modifier_after_trailing_comma` rejects a
same-named pair key. `keyword()` only checks a word boundary, so a bare
`is_stmt_modifier_keyword` would have matched the `with` in `my @a = 1, with => 2`
and silently truncated the list at its last element. Pinned in the test.

## Sweep numbers, corrected

The PLAN figure ("~half of the dep-satisfiable dists hit a real mutsu bug on `use`
alone", first run 2026-07-19) is stale. Re-running with the same n=60 / seed
20260719: **19 load_ok, 20 missing_dep, 6 real mutsu failures** (2 parse_error,
3 runtime_error, 1 timeout). PLAN now lists the remaining six by name.

One of them, `String::Utils`, needs an `nqp::` op layer — measured: **53 of the 59
ops it uses are missing**, and several (`nqp::if`/`while`/`stmts` take thunks,
`nqp::null` needs a sentinel `Value` has no room for, `nqp::create`/`getattr` need
uninitialised-storage semantics) cannot be ordinary builtins. That is a
compatibility layer and a design decision, not a bug, so it is filed as
`todo/deep/nqp-op-layer-missing.md` instead of being attempted here.

## Testing

- `t/trailing-comma-before-statement-modifier.t` (12 subtests): `die`/`fail`
  before `if`/`unless`/`for`, `return` with true and false modifiers, a
  multi-element `return`, both builtin and general listop heads, the pair-key
  guard, and an ordinary trailing comma. All 12 identical under `raku`.
- `make test`: 2465 files, 23514 tests, all successful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)