### PR TITLE
fix: a `unit role` body's `use` now loads before the role composes

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -324,12 +324,25 @@ sessions).
       tight `.=` (news/2026-07/ternary-branch-accepts-dot-assign.md), and a trailing
       comma before a statement modifier failed to parse, which was the whole
       `UpRooted` blocker (news/2026-07/trailing-comma-before-statement-modifier.md;
-      all 24 of its modules load now). **Remaining from that run:** `String::Utils`
-      needs an `nqp::` op layer (deep — `todo/deep/nqp-op-layer-missing.md`),
-      `Qwiratry::Test` is still a `parse_error`, `PDF::Class` reports
-      `Unknown role: PDF::COS::Tie::Hash`, `Raku::Pod::Render` times out, and
-      `RakudoContainerfileBuilder` may be a harness artefact (its CLI prints
-      `Usage:`). This is the
+      all 24 of its modules load now). Also fixed: a `unit role` body's `use` ran
+      *after* the role composed, so `also does` failed with `Unknown role` even for
+      a role that existed — the `PDF::Class` blocker
+      (news/2026-07/unit-role-body-use-hoisted-before-composition.md).
+      **Remaining from that run — only 1 is mutsu's:** `String::Utils` needs an
+      `nqp::` op layer (deep — `todo/deep/nqp-op-layer-missing.md`). The other four
+      were **mis-classified**, each verified against `raku -I lib`:
+      `PDF::Class` and `Qwiratry::Test` merely lack an uninstalled dependency
+      (`PDF::COS`, `Qwiratry::Query::Slang` — raku cannot load them here either),
+      and mutsu reported a downstream symptom instead of "Could not find", which
+      the role fix above corrects for the `PDF::Class` shape;
+      `RakudoContainerfileBuilder` and `Raku::Pod::Render` both **load fine** but
+      export a `MAIN`, which `-e 'use M'` then dispatches — the first prints its
+      usage (raku exits 2 doing the same), the second runs `npm`/`git` and so
+      hangs under the no-net sandbox. **Two follow-ups:** (a) teach
+      `scripts/dist-compat-sweep.py` to bucket an exported-`MAIN` dispatch
+      separately instead of as `runtime_error`/`timeout`, and (b) when reading a
+      sweep, verify any non-`missing_dep` bucket against `raku -I lib` before
+      treating it as a mutsu bug — 4 of 6 here were not. This is the
       execution counterpart of the signal-only
       [`docs/ecosystem-guts-dependency-survey.md`](../docs/ecosystem-guts-dependency-survey.md)
       and the highest-leverage way to widen the batteries base. Workflow per bug:

--- a/news/2026-07/unit-role-body-use-hoisted-before-composition.md
+++ b/news/2026-07/unit-role-body-use-hoisted-before-composition.md
@@ -1,0 +1,76 @@
+# A `unit role` body's `use` now loads before the role composes
+
+```raku
+unit role R;
+
+use Base;
+also does Base;
+```
+
+failed with `Unknown role: Base` — **even when `Base` existed and loaded fine on
+its own**. Every role in the `PDF::Class` distribution is written this way, which
+is what the real-dist compatibility sweep had recorded as
+`PDF::AcroForm: Unknown role: PDF::COS::Tie::Hash`.
+
+## Root cause
+
+`use` is compile-time in Raku, so the module is loaded before the enclosing
+package's traits are applied. In mutsu a unit-role body runs at
+*role-registration* time, and registration walks the body statements — processing
+the `DoesDecl` that `also does Base` lowers to — before any `Stmt::Use` in that
+same body has executed. So composition looked up a role that had not been loaded
+yet.
+
+The `unit class` form already had the fix: `parser/stmt/stmtlist.rs` hoists
+`use`/`need`/`import` out of the captured unit-class body to just before the
+declaration when the body declares parents (added for
+`roast/integration/diamond.t`). The `unit role` arm right below it did not. It
+does now, gated the same way — only when the body actually composes something
+(`DoesDecl` present), so the hoist stays as narrow as the class one. Hoisted
+statements keep the same compilation-unit scope, so imported symbols remain
+visible.
+
+Role registration already knew about this ordering and worked around it
+elsewhere: the parameter type-constraint validation accepts an unresolvable
+qualified type when a body `use` could supply it, with the comment "the body's
+`use` runs after this validation". That workaround stays; composition needed the
+module for real, not a deferral.
+
+## Side effect: honest missing-dependency errors
+
+Because the `use` now runs first, a role body that imports a module which is
+genuinely absent reports the real cause instead of a downstream symptom:
+
+```
+# before: Unknown role: PDF::COS::Tie::Hash
+# after:  Could not find PDF::COS::Tie::Hash in: ...   (matches raku)
+```
+
+That reclassifies `PDF::Class` in the sweep from `runtime_error` (apparent mutsu
+bug) to `missing_dep` (its `PDF::COS` dependency is simply not installed — raku
+cannot load it here either).
+
+Checking the rest of that sweep's failures the same way — against `raku -I lib` —
+found that **4 of the 6 "real mutsu failures" were not mutsu bugs**:
+
+- `Qwiratry::Test` — its `parse_error` is an undeclared custom Unicode operator
+  (`↱`) supplied by the absent `Qwiratry::Query::Slang`; raku fails on the same
+  missing dependency.
+- `RakudoContainerfileBuilder` — loads fine, but exports a `MAIN`, which
+  `-e 'use M'` then dispatches; it prints its usage and exits non-zero. raku does
+  exactly the same (exit 2).
+- `Raku::Pod::Render` — same shape: its `InstallAtomHighlighter` exports a `MAIN`
+  that shells out to `npm`/`git`, which hangs under the sweep's no-net sandbox.
+
+Only `String::Utils` (which needs an `nqp::` op layer,
+`todo/deep/nqp-op-layer-missing.md`) and this role bug were mutsu's. PLAN §B4 now
+records both the corrected counts and two follow-ups: bucket an
+exported-`MAIN` dispatch separately in `scripts/dist-compat-sweep.py`, and always
+confirm a non-`missing_dep` bucket against raku before believing it.
+
+Pinned by `t/unit-role-body-use-before-also-does.t` (6 subtests: a method from the
+composed parent, the composing role's own method, the type hierarchy checked by
+name so the test does not import — and thereby pre-load — the parent, two hoisted
+`use`s composing two parents, and the `unit class` counterpart as a symmetry
+guard). Fixtures: `t/lib/UnitRole{Base,Second,Composer,TwoParents}.rakumod`,
+`t/lib/UnitClassComposer.rakumod`. All 6 identical under raku.

--- a/src/parser/stmt/stmtlist.rs
+++ b/src/parser/stmt/stmtlist.rs
@@ -302,6 +302,37 @@ pub(crate) fn stmt_list_with_mode(
                     *body = tail_stmts;
                 }
                 Stmt::RoleDecl { body, .. } => {
+                    // Same as the `unit class` case above: `use` is compile-time
+                    // in Raku, so `unit role R; use Base; also does Base;` must
+                    // load Base before R's composition resolves. A unit-role body
+                    // runs at role-registration time, which is *after* the body's
+                    // `DoesDecl` statements are processed, so a body `use` would
+                    // load too late and composition failed with
+                    // "Unknown role: Base" — even when Base exists (PDF::Class's
+                    // roles are all written this way). Hoist the `use`/`need`/
+                    // `import` statements out to before the declaration; they stay
+                    // in the same compilation-unit scope, so imported symbols
+                    // remain visible. Only when the body actually composes
+                    // something, mirroring the class gate on `parents`.
+                    let composes = tail_stmts
+                        .iter()
+                        .any(|s| matches!(s, Stmt::DoesDecl { .. }))
+                        || body.iter().any(|s| matches!(s, Stmt::DoesDecl { .. }));
+                    if composes {
+                        let mut hoisted: Vec<Stmt> = Vec::new();
+                        tail_stmts.retain(|stmt| {
+                            if matches!(
+                                stmt,
+                                Stmt::Use { .. } | Stmt::Need { .. } | Stmt::Import { .. }
+                            ) {
+                                hoisted.push(stmt.clone());
+                                false
+                            } else {
+                                true
+                            }
+                        });
+                        stmts.extend(hoisted);
+                    }
                     // The declarator may have already recorded `does Role`
                     // composition as leading `DoesDecl` statements in `body`
                     // (e.g. `unit role R does Base;`). Keep those and append the

--- a/t/lib/UnitClassComposer.rakumod
+++ b/t/lib/UnitClassComposer.rakumod
@@ -1,0 +1,6 @@
+unit class UnitClassComposer;
+
+use UnitRoleBase;
+also does UnitRoleBase;
+
+method own() { 'own' }

--- a/t/lib/UnitRoleBase.rakumod
+++ b/t/lib/UnitRoleBase.rakumod
@@ -1,0 +1,3 @@
+unit role UnitRoleBase;
+
+method base-hello() { 'base-hello' }

--- a/t/lib/UnitRoleComposer.rakumod
+++ b/t/lib/UnitRoleComposer.rakumod
@@ -1,0 +1,7 @@
+unit role UnitRoleComposer;
+
+# `use` is compile-time, so this must load before the `also does` below resolves.
+use UnitRoleBase;
+also does UnitRoleBase;
+
+method own() { 'own' }

--- a/t/lib/UnitRoleSecond.rakumod
+++ b/t/lib/UnitRoleSecond.rakumod
@@ -1,0 +1,3 @@
+unit role UnitRoleSecond;
+
+method second() { 'second' }

--- a/t/lib/UnitRoleTwoParents.rakumod
+++ b/t/lib/UnitRoleTwoParents.rakumod
@@ -1,0 +1,6 @@
+unit role UnitRoleTwoParents;
+
+use UnitRoleBase;
+use UnitRoleSecond;
+also does UnitRoleBase;
+also does UnitRoleSecond;

--- a/t/unit-role-body-use-before-also-does.t
+++ b/t/unit-role-body-use-before-also-does.t
@@ -1,0 +1,48 @@
+use v6;
+use lib 't/lib';
+use Test;
+
+# `use` is compile-time in Raku, so
+#
+#     unit role R;
+#     use Base;
+#     also does Base;
+#
+# must load `Base` before R's composition resolves. mutsu runs a unit-role body at
+# role-registration time, which happens *after* the body's `DoesDecl` statements
+# are processed, so the body `use` loaded too late and composition died with
+# "Unknown role: Base" — even when Base existed. The `unit class` form already
+# hoisted its body `use` statements; the `unit role` form did not.
+#
+# Every role in the PDF::Class distribution is written this way.
+
+plan 6;
+
+use UnitRoleComposer;
+use UnitRoleTwoParents;
+use UnitClassComposer;
+
+{
+    my class C does UnitRoleComposer { }
+    is C.new.base-hello, 'base-hello',
+        'a method from the role composed via a body `use` + `also does` is present';
+    is C.new.own, 'own', 'and the composing role keeps its own methods';
+    # By name, so the test does not have to import the parent role itself
+    # (importing it here would load it early and mask the bug).
+    is-deeply C.^roles.map(*.^name).sort.List,
+        ('UnitRoleBase', 'UnitRoleComposer'),
+        'the composed parent role is in the type hierarchy';
+}
+
+{
+    my class D does UnitRoleTwoParents { }
+    is D.new.base-hello, 'base-hello', 'two hoisted `use`s: first parent composed';
+    is D.new.second, 'second', 'two hoisted `use`s: second parent composed';
+}
+
+# The `unit class` counterpart already worked — keep it pinned so the shared
+# hoisting stays symmetric.
+{
+    is UnitClassComposer.new.base-hello, 'base-hello',
+        'a `unit class` composing a role through a body `use` still works';
+}


### PR DESCRIPTION
## Problem

```raku
unit role R;

use Base;
also does Base;
```

failed with `Unknown role: Base` — **even when `Base` existed and loaded fine on
its own**. Every role in the `PDF::Class` distribution is written this way, which
is what the real-dist compatibility sweep (PLAN §B4) had recorded as
`PDF::AcroForm: Unknown role: PDF::COS::Tie::Hash`.

## Root cause

`use` is compile-time in Raku, so the module loads before the enclosing package's
traits are applied. In mutsu a unit-role body runs at *role-registration* time,
and registration walks the body statements — processing the `DoesDecl` that
`also does Base` lowers to — before any `Stmt::Use` in that same body has
executed. Composition therefore looked up a role that had not been loaded yet.

The `unit class` form already had the fix: `parser/stmt/stmtlist.rs` hoists
`use`/`need`/`import` out of the captured unit-class body to just before the
declaration when the body declares parents (added for
`roast/integration/diamond.t`). **The `unit role` arm directly below it did not.**
It does now, gated the same way — only when the body actually composes something
(`DoesDecl` present) — so the hoist stays as narrow as the class one. Hoisted
statements keep the same compilation-unit scope, so imported symbols stay visible.

Role registration already knew about this ordering and worked around it elsewhere
(parameter type-constraint validation accepts an unresolvable qualified type when
a body `use` could supply it, commented "the body's `use` runs after this
validation"). That workaround stays; composition needed the module for real.

## Side effect: honest missing-dependency errors

```
# before: Unknown role: PDF::COS::Tie::Hash
# after:  Could not find PDF::COS::Tie::Hash in: ...     (matches raku)
```

## Sweep triage correction

Checking the rest of that sweep's failures against `raku -I lib` found **4 of the
6 "real mutsu failures" were not mutsu bugs**:

| dist | actual cause |
|---|---|
| `PDF::Class` | uninstalled `PDF::COS` — raku can't load it here either |
| `Qwiratry::Test` | its `parse_error` is an undeclared custom operator `↱` from the absent `Qwiratry::Query::Slang` |
| `RakudoContainerfileBuilder` | loads fine; exports a `MAIN` that `-e 'use M'` dispatches → usage + non-zero exit (raku exits 2 identically) |
| `Raku::Pod::Render` | same shape: its `InstallAtomHighlighter` `MAIN` shells out to npm/git and hangs under the no-net sandbox |

That leaves `String::Utils` (needs an `nqp::` op layer,
`todo/deep/nqp-op-layer-missing.md`) as the only genuine remaining one. PLAN §B4
records the corrected counts plus a follow-up: teach
`scripts/dist-compat-sweep.py` to bucket an exported-`MAIN` dispatch separately
instead of as `runtime_error`/`timeout`.

## Testing

- `t/unit-role-body-use-before-also-does.t` (6 subtests, 5 fixtures): parent
  method present, composing role's own method, type hierarchy checked **by name**
  so the test does not import — and thereby pre-load — the parent, two hoisted
  `use`s composing two parents, and the `unit class` counterpart as a symmetry
  guard. All 6 identical under `raku`.
- `roast/S14-roles/*.t` + `S12-construction/roles-6e.t` +
  `integration/diamond.t`: 23 files, 389 tests, all pass.
- `make test`: 2470 files, 23563 tests, all successful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)