### PR TITLE
fix: `exit` no longer runs MAIN afterwards

### DIFF
--- a/news/2026-07/exit-skips-main-dispatch.md
+++ b/news/2026-07/exit-skips-main-dispatch.md
@@ -1,0 +1,40 @@
+# `exit` no longer runs MAIN afterwards
+
+```raku
+sub MAIN(Str :$r!) { }
+say "mainline";
+exit 0;
+```
+
+raku prints `mainline` and exits 0. mutsu printed `mainline`, then `Usage:`, and
+exited **2** — it dispatched MAIN after the mainline had already called `exit`.
+`exit` terminates the process in Raku, so nothing may run after it.
+
+The mainline's `exit` sets `Interpreter::halted`, but `run()` called
+`dispatch_main` unconditionally (apart from the existing `explicit_run_main`
+guard). It now also skips when `halted` is set. The MAIN behaviour of a program
+that does *not* exit is unchanged: a satisfiable MAIN still runs, and an
+unsatisfiable one still prints usage and exits 2.
+
+## Why it mattered beyond the exit code
+
+This was found while fixing the real-dist compatibility sweep's own probe. The
+sweep asks "does this module load?" by running `mutsu -I <dist>/lib -e 'use M'`,
+and a dist that exports a `MAIN` had it dispatched by that very probe:
+
+- `RakudoContainerfileBuilder::CLI` printed its usage and exited non-zero →
+  bucketed `runtime_error`.
+- `Raku::Pod::Render`'s `InstallAtomHighlighter` exports a `MAIN` that shells out
+  to `npm`/`git`, so under the sweep's no-net sandbox it hung → bucketed
+  `timeout`.
+
+Neither is a mutsu bug; both modules load. The natural fix is to make the probe
+`use M; exit 0`, which is what raku users would expect to suppress MAIN — except
+that did not work in mutsu until this change. `scripts/dist-compat-sweep.py` now
+uses that probe, so those two dists classify honestly.
+
+Pinned by `t/exit-skips-main-dispatch.t` (6 `is_run` subtests covering: exit
+before an unsatisfiable MAIN, exit before a satisfiable MAIN, a non-zero exit
+code, MAIN still dispatching without an exit, usage + exit 2 still reported
+without an exit, and an imported MAIN — fixture `t/lib/ExitMainFixture.rakumod`).
+All 6 identical under raku.

--- a/scripts/dist-compat-sweep.py
+++ b/scripts/dist-compat-sweep.py
@@ -335,7 +335,14 @@ def sweep_dist(name, meta, mutsu, extra_libs, timeout, include_guts, include_nat
         os.makedirs(sbx_home, exist_ok=True)
         rows = []
         for module in sorted(provides):
-            base = [mutsu] + libs + ["-e", f"use {module}"]
+            # `exit 0` after the load: this probe measures whether the module
+            # LOADS, and a dist that exports a `MAIN` would otherwise have it
+            # dispatched by the `-e` program — printing usage and exiting 2
+            # (RakudoContainerfileBuilder) or shelling out to npm/git and hanging
+            # (Raku::Pod::Render's InstallAtomHighlighter), neither of which is a
+            # mutsu bug. `exit` terminates before MAIN dispatch in raku, and now
+            # in mutsu too (news/2026-07/exit-skips-main-dispatch.md).
+            base = [mutsu] + libs + ["-e", f"use {module}; exit 0"]
             cmd = sandbox_wrap(base, root, sbx_home) if sandbox else base
             try:
                 p = subprocess.run(cmd, capture_output=True, text=True,

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -239,8 +239,14 @@ impl Interpreter {
         self.check_unresolved_stubs()?;
 
         // Auto-call MAIN sub if defined, with CLI argument parsing. Skipped when
-        // the program already drove MAIN itself via an explicit `RUN-MAIN`.
-        if !self.explicit_run_main {
+        // the program already drove MAIN itself via an explicit `RUN-MAIN`, and
+        // when the mainline called `exit`: `exit` terminates the process, so a
+        // MAIN (or its usage message and exit code 2) must not run afterwards.
+        // Without the `halted` guard, `sub MAIN(Str :$r!) { }; exit 0` printed
+        // `Usage:` and exited 2 where raku exits 0 silently — which also made
+        // `use <dist>; exit 0` an unusable probe for the dist-compatibility sweep,
+        // since every dist exporting a MAIN dispatched it.
+        if !self.explicit_run_main && !self.halted {
             self.dispatch_main(&compiled_fns)?;
         }
         self.finish()?;

--- a/t/exit-skips-main-dispatch.t
+++ b/t/exit-skips-main-dispatch.t
@@ -1,0 +1,41 @@
+use v6;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use lib 't/lib';
+use Test;
+
+# `exit` terminates the process, so a MAIN must not be dispatched afterwards.
+# mutsu ran the MAIN dispatch unconditionally after the mainline, so
+# `sub MAIN(Str :$r!) { }; exit 0` printed `Usage:` and exited 2 where raku exits
+# 0 silently. The same made `use <dist>; exit 0` useless as a module-load probe:
+# every dist exporting a MAIN dispatched it.
+
+use Test::Util;
+
+plan 6;
+
+# A required-parameter MAIN would print usage and exit 2 if dispatched.
+is_run 'sub MAIN(Str :$r!) { say "MAIN ran" }; say "mainline"; exit 0',
+    { out => "mainline\n", err => '', status => 0 },
+    'exit before an undispatchable MAIN skips its usage and keeps the exit code';
+
+is_run 'sub MAIN() { say "MAIN ran" }; say "mainline"; exit 0',
+    { out => "mainline\n", err => '', status => 0 },
+    'exit skips a MAIN that would otherwise have run';
+
+is_run 'sub MAIN() { say "MAIN ran" }; exit 3',
+    { out => '', err => '', status => 3 },
+    'and the exit code is preserved';
+
+# Without an exit, MAIN dispatch is unchanged.
+is_run 'sub MAIN() { say "MAIN ran" }; say "mainline"',
+    { out => "mainline\nMAIN ran\n", status => 0 },
+    'a normal program still dispatches MAIN';
+
+is_run 'sub MAIN(Str :$r!) { say "MAIN ran" }; say "mainline"',
+    { out => "mainline\n", status => 2 },
+    'and an unsatisfiable MAIN still reports usage with exit 2';
+
+# An imported MAIN behaves the same (this is the shape real distributions use).
+is_run 'use lib "t/lib"; use ExitMainFixture; say "mainline"; exit 0',
+    { out => "mainline\n", err => '', status => 0 },
+    'exit also skips an imported MAIN';

--- a/t/lib/ExitMainFixture.rakumod
+++ b/t/lib/ExitMainFixture.rakumod
@@ -1,0 +1,3 @@
+unit module ExitMainFixture;
+
+sub MAIN(Str :$required!) is export { say "MAIN ran with $required" }


### PR DESCRIPTION
## Problem

```raku
sub MAIN(Str :$r!) { }
say "mainline";
exit 0;
```

raku prints `mainline` and exits **0**. mutsu printed `mainline`, then `Usage:`,
and exited **2** — it dispatched MAIN after the mainline had already called
`exit`. `exit` terminates the process in Raku, so nothing may run after it.

## Fix

The mainline's `exit` sets `Interpreter::halted`, but `run()` called
`dispatch_main` unconditionally apart from the existing `explicit_run_main` guard.
It now also skips when `halted` is set. A program that does *not* exit is
unaffected: a satisfiable MAIN still runs, an unsatisfiable one still prints usage
and exits 2.

## Why this surfaced

Found while fixing the real-dist compatibility sweep's own probe. The sweep asks
"does this module load?" with `mutsu -I <dist>/lib -e 'use M'` — and a dist that
exports a `MAIN` had it dispatched by that very probe:

- `RakudoContainerfileBuilder::CLI` printed its usage and exited non-zero →
  bucketed `runtime_error`.
- `Raku::Pod::Render`'s `InstallAtomHighlighter` exports a `MAIN` that shells out
  to `npm`/`git`, so under the no-net sandbox it hung → bucketed `timeout`.

Neither is a mutsu bug; both modules load. The natural probe fix is
`use M; exit 0` — which is also what a raku user would write to suppress MAIN —
except that did not work in mutsu until this change.
`scripts/dist-compat-sweep.py` now uses that probe. Re-running it:

```
[1/2] RakudoContainerfileBuilder  -> load_ok      (was runtime_error)
[2/2] Raku::Pod::Render           InstallAtomHighlighter -> load_ok  (was timeout)
```

(`Raku::Pod::Render` still stops later, on a genuinely absent `URI` dependency —
raku fails there too.)

## Testing

- `t/exit-skips-main-dispatch.t` (6 `is_run` subtests): exit before an
  unsatisfiable MAIN, exit before a satisfiable MAIN, a non-zero exit code
  preserved, MAIN still dispatching without an exit, usage + exit 2 still reported
  without an exit, and an imported MAIN (fixture `t/lib/ExitMainFixture.rakumod`).
  All 6 identical under `raku`.
- `make test`: 2472 files, 23576 tests, all successful.

PLAN §B4 is deliberately untouched here — PR #5440 edits the same paragraph; the
sweep-probe note goes in once both have landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)