### PR TITLE
fix: a module-local type named like a built-in shadows the built-in

### DIFF
--- a/news/2026-07/module-local-type-shadows-builtin.md
+++ b/news/2026-07/module-local-type-shadows-builtin.md
@@ -1,0 +1,67 @@
+# A module-local type named like a built-in now shadows the built-in
+
+Inside a module, a user-declared type whose short name collides with a built-in
+type name (e.g. `grammar Grammar`, colliding with the core `Grammar` type)
+resolved — when referenced by its **unqualified** bareword name from a sub in the
+same module — to the **built-in** type object instead of the module-local
+declaration:
+
+```raku
+unit module GMod;
+grammar Grammar { token TOP { \d+ } }
+our sub do-parse(Str $input) is export { Grammar.parse($input) }
+```
+
+```raku
+use GMod;
+say do-parse("123");
+# was:  X::Method::NotFound: Unknown method value dispatch (fallback disabled): parse
+# now:  ｢123｣
+```
+
+`Grammar` resolved to the core `Grammar` type object (`.^name` → `Grammar`,
+`.HOW` → `ClassHOW`), so `.parse` was routed to the ClassHOW meta-method
+dispatcher, fell through, and raised `X::Method::NotFound`. raku resolves the
+unqualified `Grammar` to the module-local `GMod::Grammar` (whose inherited
+`.parse` runs). The same shape affects any `class Int`/`class Str`/… declared
+inside a module. In the **mainline** the bug did not appear — a top-level
+`grammar Grammar {}` registers under the bare name, so it was already found.
+
+## Root cause
+
+In `exec_get_bare_word_op` (`src/vm/vm_var_get_ops.rs`), the resolution chain
+checked `is_builtin_type(name)` **before** `resolve_type_in_current_package(name)`.
+A user type declared inside a module registers under its fully-qualified name
+(`GMod::Grammar`), so `has_type("Grammar")` is false there; `is_builtin_type`
+then intercepted and returned the core type before the module-qualification walk
+could find `GMod::Grammar`. (In the mainline the type registers under the bare
+name, so `has_type` matched first — which is why only the module case broke.)
+
+## The fix
+
+`resolve_type_in_current_package(name)` is now consulted **before** the
+built-in-type fallback: a module-local declaration of a name shadows a built-in
+of the same name, matching raku. The order is now
+`has_type` → `resolve_type_in_current_package` → built-in → …. This is safe for
+the common path: `resolve_type_in_current_package` returns `None` immediately at
+the mainline (GLOBAL) scope, and returns a qualified name only when the current
+package actually declares one — so a bareword `Int` with no shadowing
+declaration still resolves to the core `Int`.
+
+Verified against `raku`. Pin: `t/module-local-type-shadows-builtin.t` (covers a
+module-local `grammar Grammar` and `class Int`, plus that the core `Int` is
+unaffected where nothing shadows it).
+
+## Why it mattered
+
+This was blocker #2 for the `YAMLish` YAML battery candidate
+(`docs/batteries/yaml.md`): `YAMLish` is `unit module YAMLish` and declares
+`grammar Grammar`, which `load-yaml` calls unqualified as `Grammar.parse($input)`.
+With this fix, `Grammar.parse` dispatches correctly (the next blocker is the
+grammar itself not matching valid YAML —
+`todo/tickets/yamlish-grammar-parse-no-match.md`).
+
+A known remaining nuance: the module-local grammar's `.HOW` still reports
+`ClassHOW` rather than `GrammarHOW`, because `package_kinds` is not consulted
+under the qualified name here. It does not affect `.parse` (which keys off the
+resolved package name) and is tracked separately.

--- a/src/vm/vm_var_get_ops.rs
+++ b/src/vm/vm_var_get_ops.rs
@@ -203,17 +203,22 @@ impl Interpreter {
             } else {
                 self.compile_and_call_function_def(&def, Vec::new(), compiled_fns)?
             }
-        } else if self.has_type(name)
-            || Self::is_builtin_type(name)
-            || Self::is_type_with_smiley(name, self)
-        {
+        } else if self.has_type(name) {
             Value::package(Symbol::intern(Self::resolve_type_alias(name)))
         } else if let Some(qualified) = self.resolve_type_in_current_package(name) {
-            // A short type name declared in the (dynamically) current package —
-            // `module Foo { class Params {…}; sub mk { Params.new } }` where the
-            // class registered as `Foo::Params` and `mk` runs from another
-            // package's call site.
+            // A short type name declared in the (dynamically) current package.
+            // Checked BEFORE the built-in-type fallback so a module-local
+            // declaration shadows a built-in of the same name: `grammar Grammar`
+            // (or `class Int`) inside `module Foo` resolves to `Foo::Grammar`,
+            // matching raku where a package-local type shadows the core name —
+            // otherwise `Grammar.parse(...)` mis-dispatched on the core `Grammar`
+            // type object (ClassHOW, no `.parse`). Also the original
+            // non-collision case: `module Foo { class Params {…};
+            // sub mk { Params.new } }` reached from another package's call site,
+            // where the bareword `Params` is `Foo::Params`.
             Value::package(Symbol::intern(&qualified))
+        } else if Self::is_builtin_type(name) || Self::is_type_with_smiley(name, self) {
+            Value::package(Symbol::intern(Self::resolve_type_alias(name)))
         } else if let Some(enum_val) = self.resolve_enum_member_in_current_package(name) {
             // A bare enum member read from inside the package that declared the
             // enum (`unit class URI::Query; our enum HashFormat <… Lists>;

--- a/t/lib/ModuleLocalShadow.rakumod
+++ b/t/lib/ModuleLocalShadow.rakumod
@@ -1,0 +1,24 @@
+unit module ModuleLocalShadow;
+
+# A grammar whose short name collides with the built-in `Grammar` type.
+grammar Grammar {
+    token TOP { <num> '-' <num> }
+    token num { \d+ }
+}
+
+# A class whose short name collides with the built-in `Int` type.
+class Int {
+    has $.tag = "module-local-Int";
+}
+
+our sub parse-it(Str $input) is export {
+    # Unqualified `Grammar` must resolve to ModuleLocalShadow::Grammar, not core.
+    return Grammar.parse($input);
+}
+
+our sub grammar-name() is export { Grammar.^name }
+
+our sub make-int() is export {
+    # Unqualified `Int` must resolve to ModuleLocalShadow::Int here.
+    return Int.new;
+}

--- a/t/module-local-type-shadows-builtin.t
+++ b/t/module-local-type-shadows-builtin.t
@@ -1,0 +1,29 @@
+use v6;
+use lib $?FILE.IO.parent.add('lib').Str;
+use Test;
+
+# Inside a module, a user-declared type whose short name collides with a
+# built-in (e.g. `grammar Grammar`, `class Int`) must resolve, when referenced
+# by its unqualified bareword name from a sub in that module, to the
+# module-local declaration — not the built-in. Regression pin for the YAMLish
+# battery: `unit module YAMLish` declares `grammar Grammar` and calls
+# `Grammar.parse($input)` unqualified.
+
+plan 5;
+
+use ModuleLocalShadow;
+
+# grammar Grammar (shadows core Grammar) must dispatch .parse
+my $m = parse-it("12-34");
+ok $m.defined, 'module-local grammar Grammar.parse dispatched (not core Grammar)';
+is ~$m, "12-34", 'module-local grammar matched the input';
+
+# its name resolves module-qualified, and .parse working proves GrammarHOW-ish behavior
+is grammar-name(), 'ModuleLocalShadow::Grammar', 'bareword Grammar names the module-local grammar';
+
+# class Int (shadows core Int) must resolve to the module-local class
+my $i = make-int();
+is $i.tag, 'module-local-Int', 'module-local class Int resolves over the built-in Int';
+
+# sanity: the core Int is unaffected at the mainline (no shadowing declaration here)
+is (40 + 2).WHAT.^name, 'Int', 'core Int still works where nothing shadows it';

--- a/todo/tickets/yamlish-grammar-parse-no-match.md
+++ b/todo/tickets/yamlish-grammar-parse-no-match.md
@@ -1,0 +1,70 @@
+# YAMLish's grammar matches no input under mutsu
+
+Blocker #3 for the `YAMLish` battery candidate (`docs/batteries/yaml.md`),
+reached after #1 (`=>` currying, #5432), #1.5 (placeholder-in-WhateverCode) and
+#2 (module-local type shadowing) are all applied.
+
+With those three fixes, `use YAMLish` loads and `Grammar.parse($input)`
+**dispatches** — but the grammar then matches nothing, so every `load-yaml`
+returns a `Failure`:
+
+```raku
+use YAMLish;
+say load-yaml("42").raku;        # raku: 42            mutsu: Failure "Couldn't parse YAML"
+say load-yaml("foo: 1").raku;    # raku: ${:foo(1)}    mutsu: Failure
+say load-yaml("- a\n- b").raku;  # raku: $["a", "b"]   mutsu: Failure
+```
+
+Even the trivial single-scalar input fails, so this is not input-specific — the
+grammar's `TOP` fundamentally does not match under mutsu.
+
+## Where to look
+
+The YAML grammar is `grammar Grammar` at lib/YAMLish.rakumod:150–783 — large and
+action-heavy, with a four-grammar schema hierarchy used for scalar resolution
+(`grammar Schema::JSON`, `grammar Schema::Core is Schema::JSON`,
+`grammar Schema::Extra is Schema::Core`). `TOP` (line 163) uses:
+
+- named captures with an explicit alias and a subrule
+  (`<document=directive-document>`, `<document=simple-document>`);
+- non-capturing subrule calls (`<.document-prefix>`, `<.document-suffix>`);
+- quantified alternations across document forms.
+
+`load-yaml` also does scalar resolution via `$schema.new.parse($!value)`
+(line 80) against the `Schema::*` grammars, and `Grammar.parse($input)` for the
+document (line 944).
+
+Concrete candidate features to check first (the `Schema::*` grammars lean on all
+of these, and the document `Grammar` on the capture/boundary ones):
+
+- **`proto token element { * }` + `token element:<null>` / `:<int>` / …** — proto
+  tokens with `:<sym>`-based multi dispatch, **extended across grammar
+  inheritance** (`Schema::Core is Schema::JSON` adds more `element:<sym>`
+  candidates to the inherited proto). This is the highest-risk feature.
+- **`<|w>`** word-boundary assertion.
+- **`$<sign=[+-]>?` / `$<value>=[ … ]`** — named captures bound to a character
+  class / bracketed pattern.
+- **`<name=subrule>`** aliased subrule captures and non-capturing `<.subrule>`.
+- **`:16(~$<value>)`** radix conversion in an action (only reached once parsing
+  works).
+
+Since even `load-yaml("42")` fails, start with the **document `Grammar`**
+(line 150) `simple-document`/scalar path, which is what `Grammar.parse("42")`
+exercises — before chasing the `Schema::*` proto-token machinery.
+
+## Next step (needs the #1/#1.5/#2 stack applied)
+
+Reduce which construct fails: build a minimal grammar exercising
+`<name=subrule>` aliased captures, non-capturing `<.subrule>`, and a
+`Schema::Core is Schema::JSON` inheritance chain with inline `{ make … }`
+actions, and bisect toward the smallest `TOP` that matches under raku but not
+mutsu. It may be one grammar-feature gap or several; the module now loads, so the
+grammar can be exercised directly:
+
+```sh
+mutsu -I <yamlish-lib> -I modules/MIME-Base64/lib \
+  -e 'use YAMLish; say load-yaml("42").raku'
+```
+
+(Requires a build carrying #5432 + the placeholder-in-WhateverCode fix + the
+module-local-shadow fix; on a plain checkout the module does not yet load.)


### PR DESCRIPTION
## Summary

Inside a module, a user-declared type whose short name collides with a built-in (e.g. `grammar Grammar`, `class Int`) resolved, when referenced by its **unqualified** bareword name from a sub in that module, to the **built-in** type object instead of the module-local declaration:

```raku
unit module GMod;
grammar Grammar { token TOP { \d+ } }
our sub do-parse(Str $in) is export { Grammar.parse($in) }
```
```raku
use GMod;
say do-parse("123");
# was:  X::Method::NotFound: Unknown method value dispatch (fallback disabled): parse
# now:  ｢123｣
```

`Grammar` resolved to the core `Grammar` type (`.^name` → `Grammar`, `.HOW` → `ClassHOW`), so `.parse` was routed to the ClassHOW meta-method dispatcher and fell through. raku resolves the unqualified `Grammar` to `GMod::Grammar`. The mainline was unaffected (a top-level `grammar Grammar {}` registers under the bare name).

## Root cause

In `exec_get_bare_word_op` (`src/vm/vm_var_get_ops.rs`) the resolution chain checked `is_builtin_type(name)` **before** `resolve_type_in_current_package(name)`. A type declared inside a module registers under its fully-qualified name (`GMod::Grammar`), so `has_type("Grammar")` is false there; the built-in then intercepted before the module-qualification walk could find `GMod::Grammar`.

## Fix

`resolve_type_in_current_package(name)` is now consulted **before** the built-in-type fallback, so a module-local declaration shadows a built-in of the same name (matching raku). Safe for the common path: it returns `None` immediately at GLOBAL (mainline) scope and a qualified name only when the current package actually declares one — a bareword `Int` with no shadowing declaration still resolves to the core `Int` (`t/core-type-not-shadowed-in-typematch.t` still passes).

## Why

This is blocker #2 for the **YAMLish** YAML battery (`docs/batteries/yaml.md`): `YAMLish` is `unit module YAMLish` and declares `grammar Grammar`, called unqualified as `Grammar.parse($input)`. With this fix `Grammar.parse` dispatches. (Next blocker: the grammar not matching valid YAML — `todo/tickets/yamlish-grammar-parse-no-match.md`.)

## Tests

- New pin: `t/module-local-type-shadows-builtin.t` (module-local `grammar Grammar` + `class Int`, plus the core `Int` unaffected where nothing shadows it).
- `make test` green (2463 files / 23492 tests), `cargo clippy -D warnings` clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)