### PR TITLE
fix: the gobbled-block parse error now names the culprit and the line

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -338,11 +338,20 @@ sessions).
       `RakudoContainerfileBuilder` and `Raku::Pod::Render` both **load fine** but
       export a `MAIN`, which `-e 'use M'` then dispatches — the first prints its
       usage (raku exits 2 doing the same), the second runs `npm`/`git` and so
-      hangs under the no-net sandbox. **Two follow-ups:** (a) teach
-      `scripts/dist-compat-sweep.py` to bucket an exported-`MAIN` dispatch
-      separately instead of as `runtime_error`/`timeout`, and (b) when reading a
-      sweep, verify any non-`missing_dep` bucket against `raku -I lib` before
-      treating it as a mutsu bug — 4 of 6 here were not. This is the
+      hangs under the no-net sandbox. **That probe is fixed:** the sweep now runs
+      `use M; exit 0`, which suppresses MAIN dispatch — and making *that* work was
+      a real mutsu bug of its own (`exit` ran MAIN afterwards, printing usage and
+      exiting 2 where raku exits 0;
+      news/2026-07/exit-skips-main-dispatch.md). Re-running with it,
+      `RakudoContainerfileBuilder` is `load_ok` and `Raku::Pod::Render`'s
+      `InstallAtomHighlighter` is too; the latter then stops on a genuinely absent
+      `URI` dependency, and the bare `X::Comp::Group: Missing block` it used to
+      report now names the culprit and the line
+      (news/2026-07/gobbled-block-error-names-and-locates.md).
+      **Standing rule when reading a sweep: verify any non-`missing_dep` bucket
+      against `raku -I lib` before treating it as a mutsu bug — 4 of 6 here were
+      not, and two "reproductions" reduced from a truncated prefix turned out to
+      be invalid Raku that raku rejects too.** This is the
       execution counterpart of the signal-only
       [`docs/ecosystem-guts-dependency-survey.md`](../docs/ecosystem-guts-dependency-survey.md)
       and the highest-leverage way to widen the batteries base. Workflow per bug:

--- a/news/2026-07/gobbled-block-error-names-and-locates.md
+++ b/news/2026-07/gobbled-block-error-names-and-locates.md
@@ -1,0 +1,53 @@
+# The gobbled-block parse error now names the culprit and points at the line
+
+An undeclared bareword in the reserved `X::`/`CX::` namespaces immediately
+followed by a block gobbles that block, leaving the enclosing `when` without its
+required one. mutsu already detected this and raised the right structured
+exception (`X::Comp::Group` bundling an `X::Syntax::BlockGobbled` sorrow and an
+`X::Syntax::Missing` panic, pinned by `t/comp-group-when-gobbled.t`) — but the
+text a user actually saw was:
+
+```
+Runtime error: X::Comp::Group: Missing block
+```
+
+No offending name. No line. The detailed raku-style wording was built and stored
+inside the exception object, then thrown away for the message, and
+`PError::fatal_with_exception` left `remaining_len` at `None` so the CLI had no
+position to report. Now:
+
+```
+===SORRY!=== Error while compiling tmp/gob.raku
+X::Comp::Group: Function 'X::NotDeclaredAnywhere' needs parens to avoid gobbling block (or perhaps it's a class that's not declared or available in this scope?)
+Missing block (apparently claimed by 'X::NotDeclaredAnywhere')
+at tmp/gob.raku:6
+------>        when X::NotDeclaredAnywhere { say 1 }
+```
+
+which names the same routine and the same line raku does.
+
+## Why it came up
+
+Found while triaging the real-dist compatibility sweep. `Raku::Pod::Render`'s
+`ProcessedPod.rakumod` (1357 lines) failed with the bare
+`X::Comp::Group: Missing block` and nothing else, which pointed nowhere. It turned
+out **not** to be an independent mutsu parse bug: the module's
+`when X::LibCurl { … }` is undeclared because its `LibCurl::Easy` dependency is
+absent, and raku rejects the same file for the same reason — it just says which
+name and which line. So the actionable gap was the diagnostic, not the parser.
+
+Two method notes worth keeping, both learned the hard way here:
+
+- **Naive prefix-truncation bisects are invalid for this file.** Braces appear
+  inside regexes and interpolations (`{$entry}`, `/ '#' /`), so a brace-counting
+  "closed point" heuristic cuts mid-construct; the resulting prefix fails in raku
+  too. Two apparent reproductions evaporated when checked against `raku` — always
+  use raku as the oracle for a candidate repro, not just mutsu's rejection.
+- The same sweep triage showed 4 of its 6 "real mutsu failures" were missing
+  dependencies or harness artefacts. Verify a non-`missing_dep` bucket against
+  `raku -I lib` before believing it.
+
+Pinned by `t/gobbled-block-error-names-and-locates.t` (4 `is_run` subtests on the
+message text and the reported line; the exception *structure* stays pinned by
+`t/comp-group-when-gobbled.t`). All 4 pass identically under raku, so it is a
+parity pin rather than a mutsu-only assertion.

--- a/src/parser/stmt/control/given_when.rs
+++ b/src/parser/stmt/control/given_when.rs
@@ -47,7 +47,7 @@ pub(crate) fn when_stmt(input: &str) -> PResult<'_, Stmt> {
         && !crate::runtime::utils::is_known_compound_type(name)
         && !crate::parser::stmt::simple::is_user_declared_type(name)
     {
-        return Err(gobbled_block_error(name));
+        return Err(gobbled_block_error(name, rest.len()));
     }
     let (rest, body) = block(rest)?;
     Ok((rest, Stmt::When { cond, body }))
@@ -55,7 +55,15 @@ pub(crate) fn when_stmt(input: &str) -> PResult<'_, Stmt> {
 
 /// Build the `X::Comp::Group` raised when an undeclared bareword gobbles the
 /// block that a surrounding construct (e.g. `when`) required.
-fn gobbled_block_error(name: &str) -> PError {
+///
+/// `remaining_len` is the length of the still-unparsed input at the offending
+/// `when`, so the CLI can report a line/column. Both matter for diagnosability:
+/// the message used to be the bare `X::Comp::Group: Missing block` with no name
+/// and no location, which in a 1300-line module (`Raku::Pod::Render`'s
+/// `ProcessedPod`, whose `when X::LibCurl { … }` is undeclared because its
+/// `LibCurl::Easy` dependency is absent) said nothing about where to look. raku
+/// names the routine and the line; now so does mutsu.
+fn gobbled_block_error(name: &str, remaining_len: usize) -> PError {
     let sorrow = Value::make_exception(
         "X::Syntax::BlockGobbled",
         &[
@@ -89,7 +97,16 @@ fn gobbled_block_error(name: &str) -> PError {
         vec![sorrow],
         vec![],
     );
-    PError::fatal_with_exception("X::Comp::Group: Missing block".to_string(), Box::new(group))
+    let mut err = PError::fatal_with_exception(
+        format!(
+            "X::Comp::Group: Function '{name}' needs parens to avoid gobbling block \
+             (or perhaps it's a class that's not declared or available in this scope?)\n\
+             Missing block (apparently claimed by '{name}')"
+        ),
+        Box::new(group),
+    );
+    err.remaining_len = Some(remaining_len);
+    err
 }
 
 pub(crate) fn default_stmt(input: &str) -> PResult<'_, Stmt> {

--- a/t/gobbled-block-error-names-and-locates.t
+++ b/t/gobbled-block-error-names-and-locates.t
@@ -1,0 +1,43 @@
+use v6;
+use lib $*PROGRAM.parent(2).add("roast/packages/Test-Helpers/lib");
+use Test;
+use Test::Util;
+
+# The X::Comp::Group raised when an undeclared bareword gobbles a required block
+# (`when X::Undeclared { ... }`) used to reach the user as the bare text
+# "X::Comp::Group: Missing block" — no offending name, no line. It builds the
+# detailed raku-style wording internally, so surface that, and carry a position
+# so the CLI can report the line. This is what makes the failure findable in a
+# large file: Raku::Pod::Render's 1300-line ProcessedPod.rakumod fails this way
+# (its `when X::LibCurl { … }` is undeclared because the LibCurl::Easy dependency
+# is absent) and mutsu pointed nowhere.
+#
+# The exception *structure* is pinned by t/comp-group-when-gobbled.t; this file
+# pins the human-facing text and location only.
+
+plan 4;
+
+my $prog = qq:to/END/;
+say "line 1";
+say "line 2";
+try \{
+    die "x";
+    CATCH \{
+        when X::NotDeclaredAnywhere \{ say 1 }
+        default \{ say "d" }
+    }
+}
+END
+
+is_run $prog, { status => { $_ != 0 }, err => /'X::NotDeclaredAnywhere'/ },
+    'the error names the offending bareword';
+
+is_run $prog, { status => { $_ != 0 }, err => /'needs parens to avoid gobbling block'/ },
+    'and uses the raku wording';
+
+is_run $prog, { status => { $_ != 0 }, err => /'Missing block (apparently claimed by'/ },
+    'and still reports the missing block';
+
+# Line 6 is the `when` line; raku reports the same line for this program.
+is_run $prog, { status => { $_ != 0 }, err => /':6'/ },
+    'and points at the offending line';


### PR DESCRIPTION
## Problem

An undeclared bareword in the reserved `X::`/`CX::` namespaces immediately
followed by a block gobbles that block, leaving the enclosing `when` without its
required one. mutsu already detected this and raised the right *structured*
exception (`X::Comp::Group` bundling an `X::Syntax::BlockGobbled` sorrow and an
`X::Syntax::Missing` panic — pinned by `t/comp-group-when-gobbled.t`). But the
text a user saw was:

```
Runtime error: X::Comp::Group: Missing block
```

No offending name. No line. The detailed raku-style wording was built and stored
*inside* the exception object, then thrown away for the message, and
`PError::fatal_with_exception` left `remaining_len` at `None`, so the CLI had no
position to report.

## After

```
===SORRY!=== Error while compiling tmp/gob.raku
X::Comp::Group: Function 'X::NotDeclaredAnywhere' needs parens to avoid gobbling block (or perhaps it's a class that's not declared or available in this scope?)
Missing block (apparently claimed by 'X::NotDeclaredAnywhere')
at tmp/gob.raku:6
------>        when X::NotDeclaredAnywhere { say 1 }
```

Same routine name, same line raku reports.

## Why it came up — and what it was *not*

Triaging the real-dist compatibility sweep: `Raku::Pod::Render`'s 1357-line
`ProcessedPod.rakumod` failed with the bare message and pointed nowhere. It turned
out **not** to be an independent mutsu parse bug — the module's
`when X::LibCurl { … }` is undeclared because its `LibCurl::Easy` dependency is
absent, and **raku rejects the same file for the same reason**, just legibly. So
the actionable gap was the diagnostic, not the parser.

Two method notes are recorded in the news entry and PLAN, both learned the hard
way here:

- **Naive prefix-truncation bisects are invalid for that file.** Braces appear
  inside regexes and interpolations (`{$entry}`, `/ '#' /`), so a brace-counting
  "closed point" heuristic cuts mid-construct — and the resulting prefix fails in
  raku too. Two apparent reproductions evaporated when checked against `raku`.
  Use raku as the oracle for a candidate repro, not just mutsu's rejection.
- A non-`missing_dep` sweep bucket must be verified against `raku -I lib` before
  being believed — 4 of 6 in this run were not mutsu bugs.

PLAN §B4 is also updated: the sweep-probe follow-up it listed as pending is done
(landed in #5441), with the corrected classification.

## Testing

- `t/gobbled-block-error-names-and-locates.t` (4 `is_run` subtests on the message
  text and the reported line). All 4 pass identically under `raku`, so this is a
  parity pin rather than a mutsu-only assertion. The exception *structure* stays
  pinned by `t/comp-group-when-gobbled.t`.
- The nine existing tests exercising this error path (`t/comp-group-*.t`,
  `t/undeclared-when-type.t`, `t/imported-exception-when.t`,
  `t/package-nested-type-name.t`, `t/keyword-as-function.t`,
  `t/operator-adverbs.t`, `t/vcs-conflict-marker.t`) stay green.
- `make test`: 2472 files, 23574 tests, all successful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)