### PR TITLE
fix: multi dispatch now honours a named parameter's aliases

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -351,7 +351,16 @@ sessions).
       **Standing rule when reading a sweep: verify any non-`missing_dep` bucket
       against `raku -I lib` before treating it as a mutsu bug — 4 of 6 here were
       not, and two "reproductions" reduced from a truncated prefix turned out to
-      be invalid Raku that raku rejects too.** This is the
+      be invalid Raku that raku rejects too.**
+      **★The `--run-tests` axis is the sharper frontier — work it next.** Running
+      each loading dist's own suite with raku as the baseline (2026-07-25, same
+      sample): of 28 `load_ok` dists only **7 pass their suite, 5 fail, 14 die**
+      (27% of graded). One is already fixed — `Prime::Factor` needed multi dispatch
+      to honour a named parameter's aliases
+      (news/2026-07/multi-dispatch-honours-named-param-aliases.md) and now matches
+      raku across all four of its files. The remaining 18, with three already
+      triaged (`String::Splice` ×2, `Text::Sorensen`, `Locale::Dates`), are in
+      `todo/tickets/dist-test-suite-failures-batch.md`. This is the
       execution counterpart of the signal-only
       [`docs/ecosystem-guts-dependency-survey.md`](../docs/ecosystem-guts-dependency-survey.md)
       and the highest-leverage way to widen the batteries base. Workflow per bug:

--- a/news/2026-07/multi-dispatch-honours-named-param-aliases.md
+++ b/news/2026-07/multi-dispatch-honours-named-param-aliases.md
@@ -1,0 +1,49 @@
+# Multi dispatch now honours a named parameter's aliases
+
+A named parameter may carry aliases: `:s(:$sort)` answers to both `:s(…)` and
+`:sort(…)`. Binding already honoured both spellings, but multi-candidate
+*matching* only looked at the first name, so
+
+```raku
+multi f(Int $n, :s(:$sort) = False) { }
+f(1, :sort(True));   # raku: fine   mutsu: No matching candidates for proto sub: f
+```
+
+failed — while the identical signature on a plain `sub` accepted it. That
+asymmetry is the tell: the alias was known to the binder and invisible to the
+dispatcher.
+
+## Root cause
+
+The parser records aliases as nested *named* entries in the parameter's
+`sub_signature`: `:s(:$sort)` becomes
+`ParamDef { name: "s", named: true, sub_signature: [ParamDef { name: "sort",
+named: true }] }`. `types/signature.rs` walked that nesting when collecting
+consumed named keys; `types/args_matching.rs` did not — both its
+"is this named argument consumed by any parameter?" check and its
+required/`:D`/`where` lookup compared only the outer `pd.name`.
+
+Both now go through a new `ParamDef::named_external_keys()`, which returns every
+external key a named parameter answers to (sigil- and twigil-stripped, plus each
+alias). Candidate selection is unchanged otherwise: an unknown named argument is
+still rejected, and the positional types still pick the candidate.
+
+## Found by
+
+The `--run-tests` axis of the real-dist compatibility sweep (PLAN §B4), which runs
+each loading dist's own suite with raku as the baseline. `Prime::Factor` graded
+`test_die`: its `multi divisors (Str $n, :s(:$sort) = False)` re-dispatches with
+`samewith (+$n).narrow, :sort($sort)`, and that inner call had no matching
+candidate, so its test files aborted at 84 of 87. All four of its files now match
+raku exactly (295 subtests, 0 failures).
+
+That sweep axis is worth repeating: of the 28 dists that load, only 7 pass their
+own suite, 5 fail and 14 die — a much sharper frontier than the load-only view.
+The remaining ones are separate root causes, recorded in
+`todo/tickets/dist-test-suite-failures-batch.md`.
+
+Pinned by `t/multi-aliased-named-param.t` (12 subtests: long and short spellings
+on a multi, the plain-`sub` control, a required aliased named via either name, an
+unknown named still rejected, a type constraint, a `where` constraint, a multi
+method, and candidate selection across two positional types). All 12 identical
+under raku.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -91,6 +91,42 @@ impl ParamDef {
             && self.sigilless
     }
 
+    /// Every external key a *named* parameter answers to, sigil- and
+    /// colon-stripped. A named parameter may carry aliases, which the parser
+    /// records as nested named entries in `sub_signature`: `:s(:$sort)` becomes
+    /// `ParamDef { name: "s", named: true, sub_signature: [ParamDef { name:
+    /// "sort", named: true }] }`, and the call may use either `:s(…)` or
+    /// `:sort(…)`.
+    ///
+    /// Callers that match a named argument against a signature must consult all
+    /// of them. Binding already did (`types/signature.rs`); multi-candidate
+    /// matching did not, so `multi f($n, :s(:$sort) = False)` rejected
+    /// `f(1, :sort(True))` with "No matching candidates" while the same
+    /// signature on a plain `sub` accepted it (`Prime::Factor`'s `divisors`
+    /// re-dispatches with `:sort($sort)`).
+    ///
+    /// Returns an empty vector for a non-named parameter.
+    pub(crate) fn named_external_keys(&self) -> Vec<String> {
+        if !self.named {
+            return Vec::new();
+        }
+        let strip = |n: &str| {
+            n.trim_start_matches(|c: char| "$@%&:".contains(c))
+                .trim_start_matches(['!', '.'])
+                .to_string()
+        };
+        let mut keys = vec![strip(&self.name)];
+        if let Some(aliases) = &self.sub_signature {
+            keys.extend(
+                aliases
+                    .iter()
+                    .filter(|a| a.named && !a.slurpy)
+                    .map(|a| strip(&a.name)),
+            );
+        }
+        keys
+    }
+
     /// Mark this param (and every nested sub-signature param) as belonging to
     /// a block, so an unpassed untyped optional seeds Mu instead of Any.
     pub(crate) fn mark_block_param(&mut self) {

--- a/src/runtime/types/args_matching.rs
+++ b/src/runtime/types/args_matching.rs
@@ -561,8 +561,10 @@ impl Interpreter {
                     if let ValueView::Pair(key, _) = arg.view() {
                         let consumed = param_defs.iter().any(|pd| {
                             if pd.named {
-                                let bare = pd.name.trim_start_matches(|c| "$@%&".contains(c));
-                                bare == key
+                                // All of the parameter's external keys, so an
+                                // aliased named param (`:s(:$sort)`) is consumed
+                                // by either spelling.
+                                pd.named_external_keys().iter().any(|k| k == key)
                             } else {
                                 pd.name == format!(":{}", key)
                             }
@@ -586,16 +588,15 @@ impl Interpreter {
                 })
                 .collect();
             for pd in param_defs.iter().filter(|pd| pd.named) {
-                // Strip the sigil AND any twigil: an attribute-binding named param
-                // `:$!size` / `:$.size` has external named key `size`, so its `!`/`.`
-                // twigil must be dropped to match the call's `size => ...` arg.
-                let bare_name = pd
-                    .name
-                    .trim_start_matches(|c: char| "$@%&".contains(c))
-                    .trim_start_matches(['!', '.']);
+                // Every external key this parameter answers to. The sigil and any
+                // twigil are stripped (an attribute-binding named param `:$!size`
+                // / `:$.size` has external key `size`), and an aliased param
+                // (`:s(:$sort)`) matches either spelling — see
+                // `ParamDef::named_external_keys`.
+                let keys = pd.named_external_keys();
                 let arg_val = named_args
                     .iter()
-                    .find(|(k, _)| k == bare_name)
+                    .find(|(k, _)| keys.iter().any(|n| n == k))
                     .map(|(_, v)| v.clone());
 
                 // Check required named params have corresponding args

--- a/t/multi-aliased-named-param.t
+++ b/t/multi-aliased-named-param.t
@@ -1,0 +1,63 @@
+use v6;
+use Test;
+
+# A named parameter may carry aliases: `:s(:$sort)` answers to both `:s(…)` and
+# `:sort(…)`. Binding already honoured both, but multi-candidate *matching* only
+# looked at the first name, so a `multi` with an aliased named parameter rejected
+# the long spelling with "No matching candidates" while the very same signature
+# on a plain `sub` accepted it.
+#
+# Found via Prime::Factor, whose `multi divisors (Str $n, :s(:$sort) = False)`
+# re-dispatches with `samewith (+$n).narrow, :sort($sort)` — that inner call had
+# no matching candidate, so 3 of its 87 subtests never ran.
+
+plan 12;
+
+{
+    multi f(Int $n, :s(:$sort) = False) { "int:$sort" }
+    is f(1, :sort(True)), 'int:True', 'a multi accepts the long alias';
+    is f(1, :s(True)),    'int:True', 'and the short name';
+    is f(1),              'int:False', 'and the default still applies';
+}
+
+# A plain sub always worked — keep it pinned as the control.
+{
+    sub g(:s(:$sort) = False) { "g:$sort" }
+    is g(:sort(True)), 'g:True', 'a plain sub accepts the long alias';
+    is g(:s(True)),    'g:True', 'and the short name';
+}
+
+# Required (no default) must be satisfiable through either spelling.
+{
+    multi r(Int $n, :s(:$sort)!) { "r:$sort" }
+    is r(1, :sort(True)), 'r:True', 'a required aliased named is satisfied by the long name';
+    is r(1, :s(True)),    'r:True', 'and by the short name';
+}
+
+# The alias must not weaken candidate selection: a genuinely unknown named
+# argument is still rejected.
+{
+    multi u(Int $n, :s(:$sort) = False) { 'u' }
+    dies-ok { u(1, :nope(1)) }, 'an unknown named argument is still rejected';
+}
+
+# Type constraints, `where`, and methods take the same path.
+{
+    multi t(Int $n, Bool :s(:$sort) = False) { "t:$sort" }
+    is t(1, :sort(True)), 't:True', 'a typed aliased named matches on the long name';
+
+    multi w($n, :s(:$sort) where { True } = False) { "w:$sort" }
+    is w(1, :sort(True)), 'w:True', 'a `where`-constrained aliased named too';
+
+    my class C { multi method m(Int $n, :s(:$sort) = False) { "m:$sort" } }
+    is C.new.m(1, :sort(True)), 'm:True', 'and a multi method';
+}
+
+# Candidate selection across two positional types still picks correctly with the
+# aliased named present.
+{
+    multi p(Int $n, :s(:$sort) = False) { 'int' }
+    multi p(Str $n, :s(:$sort) = False) { 'str' }
+    is-deeply (p(1, :sort(True)), p('x', :sort(True))), ('int', 'str'),
+        'the positional type still selects the candidate';
+}

--- a/todo/tickets/dist-test-suite-failures-batch.md
+++ b/todo/tickets/dist-test-suite-failures-batch.md
@@ -1,0 +1,82 @@
+# Dists that load but fail their own test suite (sweep `--run-tests`, 2026-07-25)
+
+Found by running `scripts/dist-compat-sweep.py --run-tests` (n=60, seed 20260719)
+on the same sample the load-only sweep uses. That axis runs each loading dist's
+own suite with **raku as the baseline** — only files raku itself passes cleanly
+are graded — and it is a far sharper frontier than "does it load":
+
+```
+=== test-suite axis: 28 load_ok dists ran tests ===
+  test_pass          7  27% of graded
+  test_fail          5  19% of graded
+  test_die          14  54% of graded
+```
+
+Raw data: `tmp/sweep-tests.tsv` / `tmp/sweep-tests.log` (gitignored; regenerate
+with the command above).
+
+One of the 14 `test_die` rows is already fixed: `Prime::Factor` needed multi
+dispatch to honour a named parameter's aliases
+(`news/2026-07/multi-dispatch-honours-named-param-aliases.md`), and now matches
+raku exactly across all four of its files. The rest are separate root causes.
+Three are triaged below; the remainder are un-triaged.
+
+## Triaged
+
+### `String::Splice` — an imported `multi` whose `proto` is not exported is unreachable by name
+
+```raku
+use String::Splice;
+say splice('', 0, 'Raku');   # raku: Raku      mutsu: Unknown function: splice
+say &splice.defined;         # both: True
+```
+
+The dist declares `proto sub splice (Str(Any) $, |c) is pure {*};` **without**
+`is export`, and its four candidates as `multi splice (...) is export`. So the
+name resolves (`&splice` is defined) but the call finds no callable. Note the
+method form is a red herring: `''.splice(0, 'Raku')` fails in **raku** too
+("Routine does not have any candidates. Is only the proto defined?"), so this was
+equally broken before the listop-shadow gate landed
+(`news/2026-07/listop-rewrite-respects-user-routine-shadow.md`) — that gate only
+changed which error appears. Suspect the call path looks for an exported proto
+rather than assembling the exported multi candidates.
+
+### `String::Splice` — spurious octal worry for a bare word inside `<...>`
+
+```raku
+my @ans = <0 10 021 1320 02431>;
+# mutsu: Potential difficulties: Leading 0 does not indicate octal in Raku; use 0o21 ... (found 021)
+# raku:  (no warning)
+```
+
+Inside a word-quote list these are **strings**, not numeric literals, so the
+leading-zero worry must not fire. Independent of the item above; cosmetic but
+noisy (four warnings on one line).
+
+### `Text::Sorensen` — `.value` on Any
+
+Reaches subtest 4 of 21, then dies with
+`No such method 'value' for invocant of type 'Any'` at `t/01-basic.t:15`. Whatever
+the code expects to be a `Pair` there is `Any` in mutsu. Needs reduction.
+
+### `Locale::Dates` — `Unknown function: Dates`
+
+`t/01-basic.rakutest` plans 8 and runs 0, dying with `Unknown function: Dates` at
+line 9 — a name-resolution failure that mangles the package name
+(`Locale::Dates`) into a call to `Dates`. `t/02-create.rakutest` passes 16/16, so
+it is specific to what line 9 does. Needs reduction.
+
+## Un-triaged `test_die` / `test_fail`
+
+`RSV`, `P5seek`, `Date::YearDay`, `PSpec`, `Array::Rounded` (fail);
+`Math::Interval`, `Native::Overflow`, `App::SudokuHelper`, `P5tie`,
+`Mathematica::Serializer::Encoder`, `Hash::Restricted`, `Crypt::RC4`,
+`Random::Choice` (die).
+
+## How to work this list
+
+Per `docs`/PLAN §B4 and the standing rule: **take the raku baseline first**
+(`raku -I <dist>/lib <test>`), reduce to a minimal repro, verify the repro is
+valid Raku by running it under raku, fix generally, pin in `t/`, one PR per root
+cause. Do not trust the bucket label — in the load-only axis 4 of 6 "real mutsu
+failures" turned out to be missing dependencies or harness artefacts.


### PR DESCRIPTION
## Problem

A named parameter may carry aliases: `:s(:$sort)` answers to both `:s(…)` and
`:sort(…)`.

```raku
multi f(Int $n, :s(:$sort) = False) { }
f(1, :sort(True));   # raku: fine   mutsu: No matching candidates for proto sub: f

sub  g(:s(:$sort) = False) { }
g(:sort(True));      # both fine
```

The asymmetry is the tell: the alias was known to the **binder** and invisible to
the **dispatcher**.

## Root cause

The parser records aliases as nested *named* entries in the parameter's
`sub_signature`:

```
:s(:$sort)  ->  ParamDef { name: "s", named: true,
                           sub_signature: [ParamDef { name: "sort", named: true }] }
```

`types/signature.rs` walked that nesting when collecting consumed named keys;
`types/args_matching.rs` did not — both its "is this named argument consumed by
any parameter?" check and its required/`:D`/`where` lookup compared only the outer
`pd.name`. Both now go through a new `ParamDef::named_external_keys()`, returning
every external key a named parameter answers to (sigil- and twigil-stripped, plus
each alias).

Candidate selection is otherwise unchanged: an unknown named argument is still
rejected, and the positional types still pick the candidate (both pinned).

## Found by — and a better frontier

The **`--run-tests` axis** of the real-dist compatibility sweep, which runs each
loading dist's own suite with **raku as the baseline** (only files raku passes
cleanly are graded). `Prime::Factor` graded `test_die`: its
`multi divisors (Str $n, :s(:$sort) = False)` re-dispatches with
`samewith (+$n).narrow, :sort($sort)`, and that inner call had no matching
candidate, so its files aborted at 84 of 87. **All four now match raku exactly
(295 subtests, 0 failures).**

That axis is much sharper than the load-only view:

```
=== test-suite axis: 28 load_ok dists ran tests ===
  test_pass          7  27% of graded
  test_fail          5  19% of graded
  test_die          14  54% of graded
```

PLAN §B4 now points at it, and the remaining root causes — three already triaged
(`String::Splice` ×2, `Text::Sorensen`, `Locale::Dates`) — are recorded in
`todo/tickets/dist-test-suite-failures-batch.md`. That ticket also records a
non-finding worth keeping: `String::Splice`'s `Unknown function: splice` is **not**
a regression from the listop-shadow gate — its method form fails in raku too, so it
was equally broken before; the gate only changed which error appears.

## Testing

- `t/multi-aliased-named-param.t` (12 subtests), all identical under `raku`.
- `roast/S06-multi/` + `roast/S06-signature/`: 46 files, 1200 tests, all pass.
- `make test`: 2475 files, 23597 tests, all successful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)