### PR TITLE
feat(nativecall): `nativesizeof`, a real `Pointer.WHERE`, and `CArray` handle reads

### DIFF
--- a/docs/batteries/database.md
+++ b/docs/batteries/database.md
@@ -104,8 +104,7 @@ bugs, and one of them accounts for a third of the file count on its own.
 | File | mutsu | First observed failure |
 | --- | --- | --- |
 | `02-meta.rakutest` | **PASS** | — |
-| `44-sqlite-memory` / `45-sqlite-common` / `46-sqlite-blob` / `03-lib-util` | FAIL | `NativeLibs` — `Unknown function: cannon-name`, or a failing `CHECK` inside `install-driver` |
-| `48-sqlite-errors` | FAIL | same `NativeLibs` blocker, once its role-attribute failure was fixed |
+| `44-sqlite-memory` / `45-sqlite-common` / `46-sqlite-blob` / `03-lib-util` / `48-sqlite-errors` | FAIL | `Unknown function: cannon-name`, an `our proto sub` in `NativeLibs` |
 | `01-basic` | FAIL | `No such method 'method_table' for invocant of type 'Perl6::Metamodel::PackageHOW'` |
 | `05-mock` | FAIL | 11 of a planned 16 pass, then it aborts; a row fetch yields `IterationEnd` |
 | `06-types` | FAIL | first line is only a *warning*; not yet root-caused |
@@ -123,11 +122,25 @@ A second lever, worth two more files, was role punning: `DBIish` instantiates th
 `$!last-exception`, which a punned role did not carry. Also fixed — see
 [`news/2026-07/role-pun-private-attribute.md`](../../news/2026-07/role-pun-private-attribute.md).
 
-The biggest remaining lever now accounts for five files, and it is deeper than it
-looked: not `NativeLibs` but `NativeHelpers::Blob`, whose `MoarVM::Guts::REPRs`
-needs the unimplemented `nativesizeof` builtin and then walks MoarVM's raw object
-header. `DB::SQLite`'s 0/9 has the same first cause, so it has to be solved
-either way. Filed as `todo/deep/nativehelpers-blob-moarvm-guts.md`.
+Four of those five files used to die one layer earlier, inside a `CHECK`, because
+`NativeHelpers::Blob` could not be loaded at all — its `MoarVM::Guts::REPRs`
+needs `nativesizeof`, a dereferenceable `Pointer.WHERE`, positional
+`Pointer.new`, and reads through a `nativecast`ed `CArray` handle. Those landed
+too ([`news/2026-07/nativecall-sizeof-and-pointer-where.md`](../../news/2026-07/nativecall-sizeof-and-pointer-where.md)),
+so all five now reach the same remaining blocker. `DB::SQLite`'s 0/9 has that
+same first cause, so it has to be solved either way.
+
+The part of `NativeHelpers::Blob` that hands C the address of a container's
+element buffer (`BODY_OF` / `pointer-to()`) is *not* solved and needs a stable
+native allocation behind `Blob`/`array`/`CArray` — a value-representation change
+with its own design work, kept in `todo/deep/nativehelpers-blob-moarvm-guts.md`.
+`DBDish::SQLite` does not go through it.
+
+**A caveat on all the numbers above:** `-I` does not override an installed module
+of the same name in mutsu, and `NativeLibs` is installed at 0.0.8, so these runs
+did not use the 0.0.9 the `-I` line pins. See
+`todo/tickets/dash-i-loses-to-installed-module.md`; re-measure once that is
+fixed.
 
 The remaining blockers are tracked in `todo/tickets/dbiish-blockers.md`.
 

--- a/news/2026-07/nativecall-sizeof-and-pointer-where.md
+++ b/news/2026-07/nativecall-sizeof-and-pointer-where.md
@@ -1,0 +1,87 @@
+# `nativesizeof`, a real `Pointer.WHERE`, and reads through a `CArray` handle
+
+`NativeHelpers::Blob` — a hard dependency of the `DBIish` battery — could not be
+loaded at all. mutsu reported it as a nested `An exception occurred while
+evaluating a CHECK`; unwrapped, the first cause was `Unknown function:
+nativesizeof`.
+
+Behind that sat `MoarVM::Guts::REPRs`, which the module uses unconditionally and
+which does something unusual: it derives, at load time, how far into an object
+that object's payload lives, by building a `Pointer` around a known sentinel and
+scanning `.WHERE` for it.
+
+```raku
+constant ptrsize is export = nativesizeof(Pointer);
+
+constant Offset = do {
+    my Pointer \p = Pointer.new(0xdeadbeaf);
+    my CArray[intptr] \ar = nativecast(CArray[intptr], Pointer.new(p.WHERE));
+    my $i = 0;
+    repeat { last if ar[$i] == p; } while ++$i < 10;
+    die "Can't determine actual Offset" if $i == 10;
+    $i * ptrsize;
+};
+```
+
+Measured against mutsu, every step of that failed for a different reason. Each
+turned out to be an ordinary NativeCall compatibility gap worth closing on its
+own:
+
+| what the module needs | mutsu before |
+| --- | --- |
+| `nativesizeof(Pointer)` | `Unknown function: nativesizeof` |
+| `Pointer.new(0xdeadbeaf)` | `Default constructor for 'Pointer' only takes named arguments` |
+| `p.WHERE` | a hash of the object's `WHICH` identity — not dereferenceable |
+| `nativecast(CArray[T], p)[0]` | silently `Nil` |
+| `my CArray[intptr] \ar = …` | type check failed against the resolved `CArray[uint64]` |
+
+## What changed
+
+- **`nativesizeof`** reports the width of a native scalar, one pointer for
+  anything C holds by reference, and the *padded total size* of a
+  `is repr('CStruct')` class (reusing the existing `layout_struct`). Verified
+  field-for-field against raku, including the padding cases —
+  `CStruct { int8, int32, int8 }` is 12, `CStruct { Pointer, int32 }` is 16.
+- **`Pointer.new($address)`** takes the address positionally, as Rakudo does.
+  The named `:address` form Rakudo ignores is kept, because mutsu accepted it
+  before it had the positional one.
+- **`Pointer.WHERE` is a real, readable address.** mutsu's values are unboxed and
+  have no pinnable address, so `.WHERE` is normally derived from object identity
+  — fine until a binding *dereferences* it. A `Pointer` now gets a small,
+  zero-filled, memoised native block whose first word holds the pointer value, so
+  the scan above terminates. The contract this establishes is: **mutsu's
+  `.WHERE` points straight at the payload, with no object header in front of
+  it**, i.e. the offset the probe computes is 0.
+- **Indexing a `CArray[T]` *native handle*** — what `nativecast(CArray[T], $ptr)`
+  returns, a bare C address with no Raku-side storage — reads element `i` out of
+  native memory, the same trust `cstruct_layout::read_field` already extends to
+  struct fields. (Reading past the end is undefined behaviour here exactly as it
+  is in Rakudo, which segfaults on the same input.)
+- **A `CArray[T]` handle satisfies a `CArray[U]` constraint** when the element
+  types agree, and a type argument written as a `constant` type alias
+  (`constant intptr = uint64; my CArray[intptr] $x`) resolves before the
+  comparison — the value already carries the resolved spelling, so only the
+  declared side needed it.
+
+One of these was a trap worth recording. The prelude's `Pointer` class picks up
+the enclosing package when it is prepended inside a module, so it is
+`Probe::Pointer` there, not `Pointer`. A `.WHERE` special case keyed on the exact
+name therefore missed it inside every module — and falling through to the
+identity hash handed a binding a garbage address to dereference, which
+**segfaulted**. The class is now matched on its last `::` component, the same
+"one class, several spellings" problem `cstruct_class_name` already documents.
+
+## Impact
+
+`NativeHelpers::Blob` and `MoarVM::Guts::REPRs` now load. The four `DBIish` files
+that were dying inside a `CHECK` get past it and reach the module's real
+remaining blocker (`Unknown function: cannon-name`).
+
+This is deliberately the *load-time* half of the problem. `BODY_OF` and
+`pointer-to()`, which hand C the address of a container's element buffer, need
+that buffer to be a stable native allocation — mutsu copies into a temporary one
+per call — and that is a value-representation change with its own design work.
+It is written up in `todo/deep/nativehelpers-blob-moarvm-guts.md`.
+
+Pinned by `t/nativecall-sizeof-pointer-where.t`, which passes identically under
+`raku`.

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -534,6 +534,38 @@ pub(super) fn dispatch(
             ))))
         }
         "WHERE" => {
+            // A NativeCall `Pointer` reports a *real, readable* address: bindings
+            // legitimately walk the object's memory through it. `NativeHelpers`'
+            // `MoarVM::Guts::REPRs` does exactly that to derive the offset of an
+            // object's payload from its start, by scanning `.WHERE` for the
+            // pointer value it just stored. See `native_object_where`.
+            // The class is matched on its last `::` component: the prelude's
+            // `Pointer` picks up the enclosing package when it is prepended
+            // inside a module (`Probe::Pointer`), the same "one class, several
+            // spellings" problem `cstruct_class_name` documents. Getting this
+            // wrong is not a cosmetic miss — `.WHERE` would fall through to the
+            // identity hash, and a binding that dereferences the result reads
+            // wild memory.
+            if let ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } = target.view()
+                && class_name
+                    .as_str()
+                    .rsplit("::")
+                    .next()
+                    .is_some_and(|short| short == "Pointer")
+            {
+                let addr = attributes
+                    .as_map()
+                    .get("address")
+                    .map(|v| runtime::to_int(v) as usize)
+                    .unwrap_or(0);
+                return Some(Some(Ok(Value::int(
+                    runtime::nativecall::native_object_where(addr) as i64,
+                ))));
+            }
             // Rakudo: `.WHERE` is the object's memory address as an Int.
             // mutsu's scalar values are unboxed (no stable address to report),
             // so derive a per-identity-stable Int from the WHICH identity

--- a/src/runtime/cstruct_layout.rs
+++ b/src/runtime/cstruct_layout.rs
@@ -272,6 +272,93 @@ impl crate::runtime::Interpreter {
         ))
     }
 
+    /// The number of bytes a value of `type_name` occupies in C: the width of a
+    /// native scalar, one pointer for anything C holds by reference, or the
+    /// padded total size of a `is repr('CStruct')` class. `None` for a type
+    /// NativeCall cannot marshal.
+    pub(crate) fn native_size_of_type(&mut self, type_name: &str) -> Option<usize> {
+        // A CStruct is checked first: as a *field* it is one pointer, but
+        // `nativesizeof` asks for the struct's own size.
+        if self.is_cstruct_class(type_name) {
+            let layout = self.cstruct_layout(type_name)?;
+            let last = layout.last()?;
+            let end = last.offset + last.ty.size();
+            // C rounds a struct up to its strictest member's alignment, so an
+            // array of them keeps every element aligned.
+            let align = layout.iter().map(|f| f.ty.align()).max().unwrap_or(1);
+            return Some(end.div_ceil(align) * align);
+        }
+        let short = type_name.rsplit("::").next().unwrap_or(type_name);
+        FieldType::from_type_name(short, |n| self.is_native_handle_class(n)).map(FieldType::size)
+    }
+
+    /// Read element `index` of a `CArray[elem]` that is a **native handle** —
+    /// what `nativecast(CArray[T], $ptr)` produces, a bare C pointer with no
+    /// Raku-side storage. `None` when the element type is not one NativeCall can
+    /// marshal, so the caller can fall back instead of reading garbage.
+    ///
+    /// A `CArray` carries no length in C, so there is no bound to check: this is
+    /// the same trust `read_field` documents. Reading past the array is
+    /// undefined behaviour here exactly as it is in Rakudo.
+    pub(crate) fn native_carray_element(
+        &mut self,
+        elem: &str,
+        base: usize,
+        index: usize,
+    ) -> Option<crate::value::Value> {
+        if base == 0 {
+            return None;
+        }
+        let ty = FieldType::from_type_name(elem, |n| self.is_native_handle_class(n))?;
+        let field = FieldLayout {
+            name: String::new(),
+            ty,
+            offset: index.checked_mul(ty.size())?,
+        };
+        // SAFETY: `base` came from C (or from `native_object_where`) as the start
+        // of an array of `elem`, and the caller vouches for the index being in
+        // bounds — the contract NativeCall extends to every declared signature.
+        Some(unsafe { read_field(base, &field) })
+    }
+
+    /// `nativesizeof($obj-or-type)` — NativeCall's own helper, reporting how
+    /// many bytes the argument's type takes in C. Both a type object
+    /// (`nativesizeof(uint32)`) and an instance are accepted, matching Rakudo.
+    pub(crate) fn try_nativesizeof(
+        &mut self,
+        name: &str,
+        args: &[crate::value::Value],
+    ) -> Option<Result<crate::value::Value, crate::value::RuntimeError>> {
+        use crate::value::{RuntimeError, ValueView};
+        if name != "nativesizeof" {
+            return None;
+        }
+        if args.len() != 1 {
+            return Some(Err(RuntimeError::new(format!(
+                "nativesizeof() expects 1 argument, got {}",
+                args.len()
+            ))));
+        }
+        let arg = crate::runtime::types::unwrap_varref_value(args[0].clone());
+        let type_name = match arg.view() {
+            ValueView::Package(n) => n.resolve().to_string(),
+            ValueView::Instance { class_name, .. } => class_name.resolve().to_string(),
+            _ => {
+                return Some(Err(RuntimeError::new(
+                    "nativesizeof() expects a native type or a native object",
+                )));
+            }
+        };
+        Some(match self.native_size_of_type(&type_name) {
+            Some(size) => Ok(crate::value::Value::int(size as i64)),
+            // Rakudo's wording, so a binding that greps the message still works.
+            None => Err(RuntimeError::new(format!(
+                "NativeCall op sizeof expected type with CPointer, CStruct, CArray, P6int or P6num representation, but got a P6opaque ({})",
+                type_name
+            ))),
+        })
+    }
+
     /// `nativecast($target-type, $source)` — reinterpret the C pointer carried
     /// by `$source` as `$target-type`. NativeCall's own helper, and the only
     /// way to reach the fields of a struct a C function handed back as an

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -379,6 +379,50 @@ fn make_pointer_value(addr: usize) -> Value {
     make_native_handle("Pointer", addr)
 }
 
+/// Words in the block [`native_object_where`] hands out. The payload sits in
+/// word 0; the rest are zero so a binding that probes a few words past it reads
+/// its own memory rather than faulting.
+const WHERE_BLOCK_WORDS: usize = 16;
+
+/// The address of a small, readable block whose first word holds `payload` —
+/// what `.WHERE` returns for a NativeCall `Pointer`.
+///
+/// mutsu's values are unboxed and have no pinnable address, so `.WHERE` is
+/// normally derived from the object's identity (see
+/// `builtins::methods_0arg::dispatch_core_coerce`). That is fine until a binding
+/// *dereferences* it: `MoarVM::Guts::REPRs` builds a `Pointer` holding a known
+/// sentinel, reads `.WHERE` as an array of machine words, and scans for the
+/// sentinel to learn how far into an object its payload lives. Handing it a hash
+/// would make it read wild memory.
+///
+/// So mutsu materialises the payload for real, and the answer the probe gets is
+/// **0**: mutsu's `.WHERE` points straight at the payload, with no object header
+/// in front of it. That is the contract, and it is the one a future
+/// representation change should keep.
+///
+/// Blocks are memoised by payload, so repeated `.WHERE` on equal pointers is
+/// allocation-free and the arena stays bounded by the number of distinct pointer
+/// values a program probes. Because the block's content *is* its key, two
+/// `Pointer` objects with the same address share one block — an identity
+/// distinction Rakudo would make and mutsu does not. Nothing reads `.WHERE` for
+/// object identity (that is `.WHICH`), and the alternative is an unbounded leak.
+pub(crate) fn native_object_where(payload: usize) -> usize {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+    static BLOCKS: OnceLock<Mutex<HashMap<usize, usize>>> = OnceLock::new();
+    let mut blocks = BLOCKS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    *blocks.entry(payload).or_insert_with(|| {
+        let mut block = vec![0usize; WHERE_BLOCK_WORDS];
+        block[0] = payload;
+        // Leaked on purpose: the address must stay valid for the rest of the
+        // process, since C code may hold it. The memo bounds how many there are.
+        Box::leak(block.into_boxed_slice()).as_ptr() as usize
+    })
+}
+
 /// Wrap a native pointer as an instance of `class` — a user-declared
 /// `is repr('CStruct')` class (an opaque native handle, e.g. `SSL_CTX`) or the
 /// builtin `Pointer`. The address is carried in an `address` attribute so it

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -28,6 +28,12 @@ role Rational[::NuT = Int, ::DeT = Int] does Real {
 pub(super) const NATIVECALL_POINTER_PRELUDE: &str = r#"
 class Pointer {
     has $.address = 0;
+    multi method new(--> Pointer) { self.bless(:address(0)) }
+    multi method new(Int() $address --> Pointer) { self.bless(:$address) }
+    # Rakudo's Pointer.new takes only a positional and silently ignores a
+    # `:address` named. mutsu accepted the named form before it had the
+    # positional one, so it is kept to avoid breaking code that used it.
+    multi method new(Int() :$address! --> Pointer) { self.bless(:$address) }
     method Int(--> Int) { $!address }
     method Numeric(--> Int) { $!address }
     method Bool(--> Bool) { $!address != 0 }

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -25,6 +25,31 @@ impl Interpreter {
         value
     }
 
+    /// The type a `constant` type alias names, if `name` is one.
+    ///
+    /// `constant intptr = uint64;` makes `intptr` usable wherever a type is
+    /// expected, so a declared constraint written `CArray[intptr]` has to be
+    /// compared against `CArray[uint64]` — the spelling the *value* already
+    /// carries, because evaluating `CArray[intptr]` resolves the alias.
+    /// (`NativeHelpers`' `MoarVM::Guts::REPRs` picks its word type this way.)
+    ///
+    /// Only a name currently bound to a plain type object counts, and never one
+    /// that is already a type name in its own right, so an ordinary
+    /// parameterization such as `CArray[uint64]` is left untouched.
+    fn type_alias_target(&self, name: &str) -> Option<String> {
+        if name.is_empty()
+            || crate::runtime::utils::is_known_type_constraint(name)
+            || self.registry().classes.contains_key(name)
+            || self.registry().roles.contains_key(name)
+        {
+            return None;
+        }
+        match self.env.get(name)?.view() {
+            ValueView::Package(target) => Some(target.resolve()),
+            _ => None,
+        }
+    }
+
     pub(crate) fn resolved_type_capture_name(&self, constraint: &str) -> String {
         if self.has_type_capture_binding(constraint)
             && let Some(value) = self.env.get(constraint)
@@ -81,7 +106,8 @@ impl Interpreter {
                     if resolved != arg {
                         resolved
                     } else {
-                        arg.to_string()
+                        self.type_alias_target(arg)
+                            .unwrap_or_else(|| arg.to_string())
                     }
                 })
                 .collect();
@@ -482,6 +508,20 @@ impl Interpreter {
                             inner,
                             &Value::package(Symbol::intern(&metadata.value_type)),
                         );
+                    }
+                    // A `nativecast(CArray[T], $ptr)` handle is an Instance
+                    // carrying a bare C address, not a backed Array — its element
+                    // type lives in its class name. Compare the two element
+                    // types, resolving a `constant` type alias on the declared
+                    // side (`CArray[intptr]` vs the handle's `CArray[uint64]`).
+                    if let ValueView::Instance { class_name, .. } = value.view()
+                        && let Some((value_base, value_inner)) =
+                            Self::parse_generic_constraint(&class_name.resolve())
+                        && value_base == "CArray"
+                    {
+                        let want = self.resolved_type_capture_name(inner);
+                        let want = self.type_alias_target(&want).unwrap_or(want);
+                        return want == value_inner || Self::type_matches(&want, value_inner);
                     }
                     return false;
                 }
@@ -1198,6 +1238,18 @@ impl Interpreter {
         // static `type_matches` name table (Phase 3).
         if matches!(value.view(), ValueView::RakuAst(_)) && constraint.starts_with("RakuAST::") {
             return value.isa_check(constraint);
+        }
+        // Last resort: a parameterization whose type argument is a `constant`
+        // type alias (`constant intptr = uint64; my CArray[intptr] $x`). The
+        // *value* already carries the resolved spelling, because evaluating
+        // `CArray[intptr]` resolves the alias, so the two only differ in the
+        // declared constraint. Resolving here rather than on entry keeps the hot
+        // path free of the env lookup — nothing that already matched reaches it.
+        if constraint.contains('[') {
+            let resolved = self.resolved_type_capture_name(constraint);
+            if resolved != constraint {
+                return self.type_matches_value(&resolved, value);
+            }
         }
         // For Package (type object) values, use the package name as the type
         // so that e.g. Junction (which is Mu, not Any) is correctly rejected

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1302,6 +1302,9 @@ impl Interpreter {
                 } else if let Some(result) = self.try_nativecast(name, &args) {
                     // NativeCall's `nativecast($target-type, $source)` helper.
                     result
+                } else if let Some(result) = self.try_nativesizeof(name, &args) {
+                    // NativeCall's `nativesizeof($obj-or-type)` helper.
+                    result
                 } else if let Some(result) = self.try_native_json_function(name, &args) {
                     // Dispatch JSON::Fast / JSON::Tiny `to-json` / `from-json`
                     // to the native implementation (runtime/json.rs).

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1114,6 +1114,38 @@ impl Interpreter {
                     result
                 }
             }
+            // A `CArray[T]` *native handle* — what `nativecast(CArray[T], $ptr)`
+            // returns — is a C pointer, not a Raku array: read element `i` out of
+            // native memory. This is the same trust NativeCall already extends to
+            // a declared signature (`cstruct_layout::read_field`): a wrong
+            // declaration is undefined behaviour in Rakudo too.
+            (
+                ValueView::Instance {
+                    class_name,
+                    attributes,
+                    ..
+                },
+                ValueView::Int(i),
+            ) if i >= 0
+                && attributes.contains_key("address")
+                && class_name.resolve().starts_with("CArray[") =>
+            {
+                let cn = class_name.resolve();
+                let elem = cn
+                    .strip_prefix("CArray[")
+                    .and_then(|s| s.strip_suffix(']'))
+                    .unwrap_or_default()
+                    .to_string();
+                let base = attributes
+                    .as_map()
+                    .get("address")
+                    .map(|v| crate::runtime::to_int(v) as usize)
+                    .unwrap_or(0);
+                match self.native_carray_element(&elem, base, i as usize) {
+                    Some(v) => v,
+                    None => Value::NIL,
+                }
+            }
             (ValueView::Instance { .. }, ValueView::Int(i)) => {
                 let fallback = target.clone();
                 let result = self

--- a/t/nativecall-sizeof-pointer-where.t
+++ b/t/nativecall-sizeof-pointer-where.t
@@ -1,0 +1,54 @@
+use v6;
+use Test;
+use NativeCall;
+
+plan 15;
+
+# `nativesizeof` reports how many bytes a type occupies in C.
+is nativesizeof(int8),   1, 'nativesizeof(int8)';
+is nativesizeof(uint8),  1, 'nativesizeof(uint8)';
+is nativesizeof(uint32), 4, 'nativesizeof(uint32)';
+is nativesizeof(num32),  4, 'nativesizeof(num32)';
+is nativesizeof(uint64), 8, 'nativesizeof(uint64)';
+is nativesizeof(num64),  8, 'nativesizeof(num64)';
+is nativesizeof(Pointer), 8, 'nativesizeof(Pointer) is one pointer';
+
+# A CStruct reports its own padded size, not one pointer.
+class Padded is repr('CStruct') {
+    has int8  $.a;
+    has int32 $.b;
+    has int8  $.c;
+}
+is nativesizeof(Padded), 12, 'a CStruct is padded to its strictest member';
+
+class Ptrish is repr('CStruct') {
+    has Pointer $.p;
+    has int32   $.n;
+}
+is nativesizeof(Ptrish), 16, 'a CStruct with a pointer member rounds up to 8';
+
+# `Pointer.new` takes the address positionally, as Rakudo does.
+is Pointer.new(0xdeadbeaf).Int, 0xdeadbeaf, 'Pointer.new($address)';
+is Pointer.new.Int, 0, 'Pointer.new defaults to the null address';
+ok Pointer.new.defined, 'a null Pointer built from Raku is still defined';
+
+# `.WHERE` on a Pointer is a real address whose first machine word holds the
+# pointer value. `NativeHelpers`' MoarVM::Guts::REPRs derives the offset of an
+# object's payload this way, so handing it an identity hash would make it read
+# wild memory.
+my Pointer \p = Pointer.new(0xdeadbeaf);
+ok p.WHERE != 0, '.WHERE on a Pointer is a non-zero address';
+
+# The declared constraint is written with a `constant` type alias, exactly as
+# MoarVM::Guts::REPRs writes it; it has to match the resolved spelling the value
+# carries.
+constant intptr = uint64;
+my CArray[intptr] \ar = nativecast(CArray[intptr], Pointer.new(p.WHERE));
+
+# How far into the object the payload sits is implementation-defined (Rakudo
+# puts it past MoarVM's object header; mutsu's `.WHERE` points straight at it),
+# so scan for it the way the module does rather than assuming an offset.
+my $i = 0;
+repeat { last if ar[$i] == p.Int; } while ++$i < 10;
+ok $i < 10, 'the payload is found within the first ten words';
+is ar[$i], 0xdeadbeaf, 'the word found by the scan is the pointer value';

--- a/todo/deep/nativehelpers-blob-moarvm-guts.md
+++ b/todo/deep/nativehelpers-blob-moarvm-guts.md
@@ -156,7 +156,16 @@ Measured against mutsu (2026-07-25, debug build):
 deliberately identity-derived, because mutsu's scalar values are unboxed and have
 no pinnable address.
 
-### Tier 1 — make it *load* (tractable, and enough for the battery)
+### Tier 1 — make it *load* — **DONE 2026-07-26**
+
+Implemented; `NativeHelpers::Blob` and `MoarVM::Guts::REPRs` now load. See
+[`news/2026-07/nativecall-sizeof-and-pointer-where.md`](../../news/2026-07/nativecall-sizeof-and-pointer-where.md)
+for what landed and the segfault trap it uncovered (the prelude's `Pointer` is
+`Foo::Pointer` inside a module, so a name-exact guard silently fell through to
+the identity-hash `.WHERE` and a binding dereferenced garbage). The rest of this
+section is the plan as written before the work; tier 2 below is still open.
+
+The original plan was:
 
 Give the four load-time contracts honest implementations, scoped to NativeCall
 types only:

--- a/todo/tickets/dash-i-loses-to-installed-module.md
+++ b/todo/tickets/dash-i-loses-to-installed-module.md
@@ -35,19 +35,45 @@ that had an installed copy present is suspect and needs re-measuring.
 The same trap applies to every battery survey and to any bug report reduced with
 `-I` on a machine that has run `mzef install`.
 
-## Where to look
+## Where it is
 
-Module resolution for `use` at run time, and the parse-time scan in
-`src/parser/stmt/simple/module_exports.rs` (`find_module_file`, which searches
-`LIB_PATHS` — those two must agree on precedence, or the parser and the runtime
-can disagree about which file a module is).
+`Interpreter::find_module_path` in `src/runtime/run_modules.rs`. The ordering
+data is already right — `add_default_site_repo` *appends* the site repository to
+`lib_paths` as an `inst#` entry, so `-I` paths come first in the vector. The
+resolver then throws that ordering away:
+
+```rust
+// Check inst# paths (CompUnit::Repository::Installation) first.
+let mut inst_candidates: Vec<(std::path::PathBuf, String)> = Vec::new();
+for base in &self.lib_paths {
+    if let Some(prefix) = base.strip_prefix("inst#") { … }
+}
+```
+
+It makes a full pass over `lib_paths` collecting every `inst#` candidate and
+resolves those before ever looking at the plain directories — the exact
+inversion of Raku's precedence. The fix is to walk `lib_paths` **once, in
+order**, treating each entry as either an installed repository or a plain
+directory, rather than hoisting all the `inst#` ones.
 
 Raku's precedence is: `-I` paths (in order) → `RAKULIB`/`MUTSULIB` → installed
 repositories (`site`, `vendor`, `core`). mutsu already documents the `-I` over
 `MUTSULIB` half in CLAUDE.md; the installed-repo half is what is missing.
 
-## Check while fixing
+Also check the parse-time scan, `find_module_file` in
+`src/parser/stmt/simple/module_exports.rs`, which searches `LIB_PATHS`: the
+parser and the runtime must agree on which file a module is, or the parser can
+extract exports from one file while the runtime loads another.
 
-A precompiled/installed distribution may also be selected by version/auth
-criteria (`use NativeLibs:ver<0.0.9>`), which is a separate question from path
-precedence — but a plain `use` must still prefer `-I`.
+## Keep these while fixing
+
+- **Candidate selection within one installed repo.** Several installed dists can
+  provide the same short name, and the `use` statement's `:ver`/`:auth`/`:api`
+  selectors plus the highest-version tie-break apply *within* an `inst#` entry.
+  That is a separate concern from path precedence and should not change.
+- **`bundled_lib_paths` stays lowest.** It is deliberately last so that an
+  `mzef`-installed version shadows a bundled battery (`run_modules.rs` says so).
+  The battery test-suite gate (`scripts/battery-testsuite.sh`) is the check that
+  this still holds.
+- A plain `use` must prefer `-I` even when the installed copy has a *higher*
+  version — the flag is not a version hint.

--- a/todo/tickets/dash-i-loses-to-installed-module.md
+++ b/todo/tickets/dash-i-loses-to-installed-module.md
@@ -1,0 +1,53 @@
+# `-I` does not override an installed module of the same name
+
+A module reachable through `-I` is ignored when a module of the same name is
+installed in mutsu's site repository — the installed one wins. In raku, `-I`
+takes priority over the installed repositories, which is the whole point of the
+flag.
+
+## Repro
+
+```sh
+mkdir -p tmp/shadow
+cat > tmp/shadow/NativeLibs.rakumod <<'EOF'
+unit module NativeLibs;
+our sub which-one() is export { "from-dash-I" }
+EOF
+raku  -I tmp/shadow -e 'use NativeLibs; say which-one()'   # from-dash-I
+mutsu -I tmp/shadow -e 'use NativeLibs; say which-one()'   # loads the INSTALLED one
+```
+
+With `NativeLibs` installed (it is, as a `DBIish`/`DB::SQLite` dependency),
+mutsu loads `~/.local/share/mutsu/repo/site/sources/<id>` and never sees
+`tmp/shadow/NativeLibs.rakumod`. The error it eventually reports comes from the
+installed source, and the stack frames point into
+`~/.local/share/mutsu/repo/site/sources/...`, which is the tell.
+
+## Why this matters beyond the flag
+
+It **silently invalidates measurements**. The `DBIish` survey
+(`todo/tickets/dbiish-blockers.md`, `docs/batteries/database.md`) passes
+`-I ../NativeLibs-0.0.9/lib` to pin a version, but an installed `NativeLibs`
+0.0.8 was being loaded instead — a different file with a differently-shaped
+`cannon-name`. Anything concluded about "NativeLibs 0.0.9 on mutsu" from a run
+that had an installed copy present is suspect and needs re-measuring.
+
+The same trap applies to every battery survey and to any bug report reduced with
+`-I` on a machine that has run `mzef install`.
+
+## Where to look
+
+Module resolution for `use` at run time, and the parse-time scan in
+`src/parser/stmt/simple/module_exports.rs` (`find_module_file`, which searches
+`LIB_PATHS` — those two must agree on precedence, or the parser and the runtime
+can disagree about which file a module is).
+
+Raku's precedence is: `-I` paths (in order) → `RAKULIB`/`MUTSULIB` → installed
+repositories (`site`, `vendor`, `core`). mutsu already documents the `-I` over
+`MUTSULIB` half in CLAUDE.md; the installed-repo half is what is missing.
+
+## Check while fixing
+
+A precompiled/installed distribution may also be selected by version/auth
+criteria (`use NativeLibs:ver<0.0.9>`), which is a separate question from path
+precedence — but a plain `use` must still prefer `-I`.

--- a/todo/tickets/dbiish-blockers.md
+++ b/todo/tickets/dbiish-blockers.md
@@ -35,17 +35,29 @@ a bogus baseline that wastes a session.
 | File | mutsu | Blocker |
 | --- | --- | --- |
 | `02-meta.rakutest` | **PASS** | — |
-| `44-sqlite-memory` | FAIL | ② NativeLibs `install-driver` |
-| `45-sqlite-common` | FAIL | ② NativeLibs `install-driver` |
-| `46-sqlite-blob` | FAIL | ② NativeLibs `install-driver` |
-| `03-lib-util` | FAIL | ② NativeLibs `cannon-name` |
+| `44-sqlite-memory` | FAIL | ② `Unknown function: cannon-name` |
+| `45-sqlite-common` | FAIL | ② `Unknown function: cannon-name` |
+| `46-sqlite-blob` | FAIL | ② `Unknown function: cannon-name` |
+| `03-lib-util` | FAIL | ② `Unknown function: cannon-name` |
+| `48-sqlite-errors` | FAIL | ② `Unknown function: cannon-name` |
 | `01-basic` | FAIL | ③ `PackageHOW.method_table` |
-| `48-sqlite-errors` | FAIL | ② NativeLibs (was ④, now cleared) |
 | `05-mock` | FAIL | ④ one subtest: `IterationEnd` from a row fetch |
 | `06-types` | FAIL | ⑤ not root-caused |
 
 **Nothing fails inside NativeCall.** The surface `OpenSSL` needed (CStruct,
 opaque pointers, callbacks) is strictly harder than SQLite's, and it is holding.
+
+## ⚠ These numbers were taken with the wrong `NativeLibs`
+
+`-I` does **not** override an installed module of the same name in mutsu (it does
+in raku) — see
+[`todo/tickets/dash-i-loses-to-installed-module.md`](dash-i-loses-to-installed-module.md).
+`NativeLibs` is installed in the site repo at **0.0.8**, so every run above
+loaded that instead of the 0.0.9 the `-I` line pins, and 0.0.8's `cannon-name`
+has a different signature. The tell is a stack frame pointing into
+`~/.local/share/mutsu/repo/site/sources/…`.
+
+Re-measure after that is fixed before trusting ② in particular.
 
 ## ① Parse failure — FIXED, was worth four files
 
@@ -58,21 +70,36 @@ parse. Fixed — see
 All four affected files now parse and reach their TAP plan; they fail later, on
 ② below.
 
-## ② `NativeHelpers::Blob` (`03-lib-util`, `48-sqlite-errors`, the three SQLite files)
+## ② `Unknown function: cannon-name` — worth **five** files
 
-`03-lib-util` fails with `Unknown function: cannon-name`; the others fail one
-layer up, inside `NativeLibs::install-driver`, with `An exception occurred while
-evaluating a CHECK`. It is one item, and now the highest-yield blocker here —
-worth **five** files.
+All five now fail with the same message. Getting them here took two steps.
 
-Root-caused 2026-07-25 and moved to
-[`todo/deep/nativehelpers-blob-moarvm-guts.md`](../deep/nativehelpers-blob-moarvm-guts.md):
-the failure is not in `NativeLibs` (which loads fine on its own) but in
-`NativeHelpers::Blob`, whose `MoarVM::Guts::REPRs` needs the unimplemented
-`nativesizeof` builtin and then walks MoarVM's raw object header. **Do not start
-this as a slice** — implementing `nativesizeof` alone does not clear it, and the
-rest needs a design decision. The suspicion recorded here earlier (a custom `sub
-EXPORT` before `unit module`) was tested and is wrong.
+**Cleared: the `NativeHelpers::Blob` load.** Four of them used to die earlier,
+inside a `CHECK`, because `NativeHelpers::Blob` could not be loaded at all: its
+`MoarVM::Guts::REPRs` needs `nativesizeof`, a dereferenceable `Pointer.WHERE`,
+positional `Pointer.new` and reads through a `nativecast`ed `CArray` handle —
+none of which mutsu had. Those are in now; see
+[`news/2026-07/nativecall-sizeof-and-pointer-where.md`](../../news/2026-07/nativecall-sizeof-and-pointer-where.md).
+The *rest* of that module — `BODY_OF` / `pointer-to()`, which hand C the address
+of a container's element buffer — needs a stable native allocation behind
+`Blob`/`array`/`CArray`, i.e. a value-representation change with its own design
+work. That half stays in
+[`todo/deep/nativehelpers-blob-moarvm-guts.md`](../deep/nativehelpers-blob-moarvm-guts.md);
+`DBDish::SQLite` only uses `blob-from-pointer`, which does not go through it.
+
+**Remaining: `cannon-name` itself.** `NativeLibs` declares it as an `our proto
+sub` with two `multi` candidates. Reductions that do **not** reproduce (all
+checked against raku, all behave identically under both):
+
+- a plain `our proto sub` + multis in a module, called from a sibling sub;
+- the same with a custom `sub EXPORT(|)` before the `unit module` line;
+- one multi calling the proto recursively (`cannon-name($libname, Version.new($ver))`).
+
+So the earlier note here (a custom `sub EXPORT` before `unit module`) is wrong,
+and the trigger is still unidentified. **Read the ⚠ above first** — these runs
+loaded the installed `NativeLibs` 0.0.8, whose `cannon-name` is shaped
+differently from the 0.0.9 the reductions were written against, so the reduction
+may simply have been aimed at the wrong source.
 
 ## ③ `Perl6::Metamodel::PackageHOW.method_table` (`01-basic`)
 


### PR DESCRIPTION
`NativeHelpers::Blob` — a hard dependency of the `DBIish` battery — could not be
loaded at all. mutsu reported it as a nested `An exception occurred while
evaluating a CHECK`; unwrapped, the first cause was `Unknown function:
nativesizeof`.

Behind that sat `MoarVM::Guts::REPRs`, which the module uses unconditionally and
which derives, at load time, how far into an object that object's payload lives —
by building a `Pointer` around a known sentinel and scanning `.WHERE` for it:

```raku
constant ptrsize is export = nativesizeof(Pointer);

constant Offset = do {
    my Pointer \p = Pointer.new(0xdeadbeaf);
    my CArray[intptr] \ar = nativecast(CArray[intptr], Pointer.new(p.WHERE));
    my $i = 0;
    repeat { last if ar[$i] == p; } while ++$i < 10;
    die "Can't determine actual Offset" if $i == 10;
    $i * ptrsize;
};
```

Every step failed for a different reason, and each turned out to be an ordinary
NativeCall compatibility gap worth closing on its own:

| what the module needs | mutsu before |
| --- | --- |
| `nativesizeof(Pointer)` | `Unknown function: nativesizeof` |
| `Pointer.new(0xdeadbeaf)` | `Default constructor for 'Pointer' only takes named arguments` |
| `p.WHERE` | a hash of the object's `WHICH` identity — not dereferenceable |
| `nativecast(CArray[T], p)[0]` | silently `Nil` |
| `my CArray[intptr] \ar = …` | type check failed against the resolved `CArray[uint64]` |

## What changed

- **`nativesizeof`** reports the width of a native scalar, one pointer for
  anything C holds by reference, and the *padded total size* of a
  `is repr('CStruct')` class (reusing the existing `layout_struct`). Verified
  against raku including the padding cases — `CStruct { int8, int32, int8 }` is
  12, `CStruct { Pointer, int32 }` is 16.
- **`Pointer.new($address)`** takes the address positionally, as Rakudo does. The
  named `:address` form (which Rakudo ignores) is kept, because mutsu accepted it
  before it had the positional one.
- **`Pointer.WHERE` is a real, readable address.** mutsu's values are unboxed and
  have no pinnable address, so `.WHERE` is normally derived from object identity
  — fine until a binding *dereferences* it. A `Pointer` now gets a small,
  zero-filled, memoised native block whose first word holds the pointer value.
  The contract this establishes: **mutsu's `.WHERE` points straight at the
  payload, with no object header in front of it** (so the offset the probe
  computes is 0). Blocks are memoised by payload, so the arena stays bounded.
- **Indexing a `CArray[T]` native handle** — what `nativecast(CArray[T], $ptr)`
  returns, a bare C address with no Raku-side storage — reads element `i` out of
  native memory, the same trust `cstruct_layout::read_field` already extends to
  struct fields. Reading past the end is undefined behaviour here exactly as in
  Rakudo, which segfaults on the same input (checked).
- **A `CArray[T]` handle satisfies a `CArray[U]` constraint** when the element
  types agree, and a type argument written as a `constant` type alias
  (`constant intptr = uint64; my CArray[intptr] $x`) is resolved first — the
  value already carries the resolved spelling, so only the declared side needed
  it. The resolution sits at the end of `type_matches_value`, so nothing that
  already matched pays for it.

### The trap worth remembering

The prelude's `Pointer` class picks up the enclosing package when it is prepended
inside a module, so it is `Probe::Pointer` there, not `Pointer`. A `.WHERE`
special case keyed on the exact name therefore missed it inside **every** module
— and falling through to the identity hash handed a binding a garbage address to
dereference, which **segfaulted**. It now matches on the last `::` component, the
same "one class, several spellings" problem `cstruct_class_name` documents.

## Impact

`NativeHelpers::Blob` and `MoarVM::Guts::REPRs` now load. Four `DBIish` files
that were dying inside a `CHECK` get past it and reach the module's real
remaining blocker (`Unknown function: cannon-name`), so all five of that group
now fail at the same place.

This is deliberately the *load-time* half. `BODY_OF` / `pointer-to()`, which hand
C the address of a container's element buffer, need that buffer to be a stable
native allocation — mutsu copies into a temporary one per call — and that is a
value-representation change with its own design work, kept in
`todo/deep/nativehelpers-blob-moarvm-guts.md`. `DBDish::SQLite` does not go
through it.

## Also: a measurement bug worth knowing about

While measuring I found that **`-I` does not override an installed module of the
same name** in mutsu (it does in raku):

```sh
mutsu -I tmp/shadow -e 'use NativeLibs; say which-one()'   # loads the INSTALLED one
```

`NativeLibs` is installed in the site repo at 0.0.8, so the whole `DBIish` survey
has been measuring that rather than the 0.0.9 its `-I` line pins — and 0.0.8's
`cannon-name` is shaped differently. Filed as
`todo/tickets/dash-i-loses-to-installed-module.md`, and both ledgers now carry
the caveat.

## Testing

- New pin `t/nativecall-sizeof-pointer-where.t` (15 tests) — passes identically
  under `raku`. The payload *offset* is implementation-defined, so the test scans
  for it the way the module does rather than asserting a constant.
- `make test`: 2470 files / 23574 subtests pass.
- `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
