### PR TITLE
fix: a grammar `parse` override can `nextwith` to the native parse

### DIFF
--- a/news/2026-07/grammar-parse-override-nextwith-native-fallback.md
+++ b/news/2026-07/grammar-parse-override-nextwith-native-fallback.md
@@ -1,0 +1,46 @@
+# A grammar `parse`/`subparse` override can `nextwith` to the native parse
+
+A grammar that overrides `parse` (or `subparse`/`parsefile`) to wrap the native
+grammar parse — the common pattern for injecting an `:actions` object —
+
+```raku
+grammar G {
+    token TOP { ... }
+    class Actions { ... }
+    method parse($input, *%args) {
+        nextwith($input, :actions(Actions), |%args);
+    }
+}
+```
+
+now works. Previously the `nextwith`/`nextsame` (and `callwith`/`callsame`)
+inside the override had no MRO candidate to defer to: the built-in grammar parse
+is not a `MethodDef`, so it never appears in the dispatch candidate list, and the
+re-dispatch fell through to `Value::NIL` — every `G.parse(...)` returned an
+undefined match. This is the shape YAMLish's `load-yaml` relies on
+(`method parse { nextwith($input, :actions(Actions)) }`).
+
+Two fixes were needed:
+
+1. **Native grammar parse as the final `nextsame`/`nextwith` candidate.**
+   `dispatch_next_candidate` now falls through to `dispatch_package_parse` when
+   an overridden grammar `parse`/`subparse`/`parsefile` exhausts its user MRO —
+   mirroring the existing metamodel-HOW native fallback. A frame is pushed for
+   such an override even with a single user candidate
+   (`push_method_dispatch_frame` / `run_instance_method_celled`) so the deferral
+   has somewhere to land.
+
+2. **A module-local `grammar Grammar` is recognised as a grammar.** The parser
+   used to drop the default `Grammar` superclass for any declaration literally
+   named `Grammar`, to avoid a self-parent. But inside a module a
+   `grammar Grammar` qualifies to `Mod::Grammar` — a distinct type that should
+   still inherit the built-in `Grammar`. Without the parent, `class_is_grammar`
+   returned false for `Mod::Grammar`, so the native-parse fallback above never
+   fired for it (YAMLish declares exactly `grammar Grammar` inside
+   `unit module YAMLish`). The parser now always adds the `Grammar` default
+   parent, and a self-parent (a genuine top-level `grammar Grammar`, or any
+   `class Foo is Foo`) is filtered out at registration in
+   `exec_register_class_op`.
+
+Pins: `t/grammar-parse-override-nextwith.t`,
+`t/grammar-named-grammar-in-module.t`.

--- a/src/parser/stmt/class/grammar_module.rs
+++ b/src/parser/stmt/class/grammar_module.rs
@@ -169,8 +169,12 @@ pub(crate) fn grammar_decl(input: &str) -> PResult<'_, Stmt> {
         let (r2, _) = skip_optional_role_args(r2)?;
         r = r2;
     }
-    // Default parent is Grammar if no `is` clause (unless the grammar itself is named Grammar)
-    if parents.is_empty() && name != "Grammar" {
+    // Default parent is Grammar if no `is` clause. A module-local
+    // `grammar Grammar` (qualified to `Mod::Grammar`) must still inherit the
+    // built-in Grammar; only a genuine top-level `grammar Grammar` that IS the
+    // built-in would self-parent, and that is dropped at registration (see the
+    // self-parent filter in `exec_register_class_op`).
+    if parents.is_empty() {
         parents.push("Grammar".to_string());
     }
     let (rest, body) = {

--- a/src/parser/stmt/class/package_decl.rs
+++ b/src/parser/stmt/class/package_decl.rs
@@ -379,8 +379,12 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
             }
             break;
         }
-        // Default parent is Grammar if no `is` clause
-        if parents.is_empty() && name != "Grammar" {
+        // Default parent is Grammar if no `is` clause. A module-local
+        // `grammar Grammar` (qualified to `Mod::Grammar`) must still inherit the
+        // built-in Grammar; only a genuine top-level `grammar Grammar` that IS
+        // the built-in would self-parent, and that is dropped at registration
+        // (see the self-parent filter in `exec_register_class_op`).
+        if parents.is_empty() {
             parents.push("Grammar".to_string());
         }
         let (r, _) = opt_char(r, ';');

--- a/src/runtime/accessors_state.rs
+++ b/src/runtime/accessors_state.rs
@@ -695,13 +695,23 @@ impl Interpreter {
             args,
             Some(invocant.clone()),
         );
+        // A user-overridden grammar `parse`/`subparse`/`parsefile` needs an MRO frame
+        // even with a single user candidate, so a `nextsame`/`nextwith` inside it can
+        // defer to the NATIVE grammar parse — the base candidate that is not a
+        // `MethodDef` and so never appears in the dispatch candidates (YAMLish's
+        // `method parse` does `nextwith($input, :actions(Actions))`).
+        let grammar_parse_override = matches!(method_name, "parse" | "subparse" | "parsefile")
+            && self.class_is_grammar(receiver_class)
+            && self.has_user_method(receiver_class, method_name);
         // Fast path: a name with at most one *structural* dispatch candidate across
         // the MRO can never produce a deferral frame (arg-matching only reduces the
         // candidate count), so skip the per-call `resolve_all_methods_with_owner`
         // MRO walk + MethodDef clones. The structural shape depends only on
         // (class, method), so it is memoized in `dispatch_multi_candidate` and
         // invalidated with the other method caches on any registry change.
-        if !self.has_multiple_dispatch_candidates(receiver_class, method_name) {
+        if !grammar_parse_override
+            && !self.has_multiple_dispatch_candidates(receiver_class, method_name)
+        {
             return false;
         }
         let all_candidates = self.resolve_all_methods_with_owner(receiver_class, method_name, args);
@@ -711,7 +721,9 @@ impl Interpreter {
         // per-call `function_body_fingerprint` work below — which Debug-traverses the
         // whole method body AST to derive a candidate identity — for the overwhelmingly
         // common single-method case. Mirrors `push_multi_dispatch_frame`'s `<= 1` guard.
-        if all_candidates.len() <= 1 {
+        // A grammar parse override still pushes a frame (empty `remaining`) so its
+        // `nextsame`/`nextwith` reaches the native fallback.
+        if !grammar_parse_override && all_candidates.len() <= 1 {
             return false;
         }
         // Identify the chosen candidate and skip exactly that one
@@ -732,7 +744,7 @@ impl Interpreter {
             }
             remaining.push((owner.resolve(), def));
         }
-        let pushed = !remaining.is_empty();
+        let pushed = !remaining.is_empty() || grammar_parse_override;
         if pushed {
             let rw_params = chosen
                 .as_ref()

--- a/src/runtime/builtins_dispatch_next.rs
+++ b/src/runtime/builtins_dispatch_next.rs
@@ -149,6 +149,30 @@ impl Interpreter {
         }
     }
 
+    /// When a user-overridden grammar `parse`/`subparse`/`parsefile` calls
+    /// `nextsame`/`nextwith` (or `callsame`/`callwith`) and the user MRO is
+    /// exhausted, the NATIVE grammar parse is the final base candidate. It is not
+    /// a `MethodDef`, so the regular MRO chain never reaches it (mirrors
+    /// `native_metamodel_next_candidate`). YAMLish relies on this: its
+    /// `method parse` wraps the native parse to inject `:actions(Actions)`.
+    fn native_grammar_parse_next_candidate(
+        &mut self,
+        override_args: Option<&[Value]>,
+    ) -> Option<Result<Value, RuntimeError>> {
+        let method_name = self.samewith_context_stack.last().map(|(n, _)| n.clone())?;
+        if !matches!(method_name.as_str(), "parse" | "subparse" | "parsefile") {
+            return None;
+        }
+        let frame = self.method_dispatch_stack.last()?;
+        let receiver_class = frame.receiver_class.clone();
+        let orig_args = frame.args.clone();
+        if !self.class_is_grammar(&receiver_class) {
+            return None;
+        }
+        let args: Vec<Value> = override_args.map(<[Value]>::to_vec).unwrap_or(orig_args);
+        Some(self.dispatch_package_parse(&receiver_class, &method_name, &args))
+    }
+
     /// Shared implementation for callsame/nextsame/callwith/nextwith.
     /// `override_args`: if Some, use these args instead of the original.
     /// `tail_call`: if true, raise a return-control exception with the result.
@@ -295,14 +319,19 @@ impl Interpreter {
             let (receiver_class, invocant, mut call_args, owner_class, mut method_def, rw_params) = {
                 let frame = &mut self.method_dispatch_stack[frame_idx];
                 let Some((owner_class, method_def)) = frame.remaining.first().cloned() else {
-                    // User MRO exhausted: a metamodel-HOW dispatch falls through
-                    // to the native metamodel implementation as the last
-                    // candidate before giving up.
-                    let result =
+                    // User MRO exhausted: a grammar `parse`/`subparse` override or a
+                    // metamodel-HOW dispatch falls through to the native
+                    // implementation as the last candidate before giving up.
+                    let result = if let Some(res) =
+                        self.native_grammar_parse_next_candidate(override_args.as_deref())
+                    {
+                        res?
+                    } else {
                         match self.native_metamodel_next_candidate(override_args.as_deref()) {
                             Some(res) => res?,
                             None => Value::NIL,
-                        };
+                        }
+                    };
                     if tail_call {
                         return Err(RuntimeError {
                             return_value: Some(result),

--- a/src/runtime/class_dispatch.rs
+++ b/src/runtime/class_dispatch.rs
@@ -323,7 +323,15 @@ impl Interpreter {
         }
         let invocant_for_dispatch = make_invocant_for_dispatch(&invocant, attributes);
         let remaining = build_remaining(self, &method_def);
-        let pushed_dispatch = !remaining.is_empty();
+        // A user-overridden grammar `parse`/`subparse`/`parsefile` still needs an MRO
+        // frame even with no further USER candidate, so a `nextsame`/`nextwith` inside
+        // it can defer to the NATIVE grammar parse — the base candidate that is not a
+        // `MethodDef` and so never appears in `remaining` (YAMLish's `method parse`
+        // does `nextwith($input, :actions(Actions))`).
+        let grammar_parse_fallback = remaining.is_empty()
+            && matches!(method_name, "parse" | "subparse" | "parsefile")
+            && self.class_is_grammar(receiver_class_name);
+        let pushed_dispatch = !remaining.is_empty() || grammar_parse_fallback;
         self.push_method_samewith_context(
             receiver_class_name,
             method_name,

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -147,6 +147,15 @@ impl Interpreter {
                 // is the enclosing module — the child class name reaches
                 // `register_class_decl` without its module prefix.
                 .map(|p| self.qualify_sibling_parent_name(&p))
+                // Drop the auto-added `Grammar` default parent from a genuine
+                // top-level `grammar Grammar` (qualified name exactly `Grammar`,
+                // which would otherwise list itself as its own parent and loop the
+                // MRO walk). A module-local `grammar Grammar` qualifies to
+                // `Mod::Grammar`, so its `Grammar` parent (the built-in) is NOT
+                // itself and is kept — that is how the parser can unconditionally
+                // add the `Grammar` default parent. An EXPLICIT `class Foo is Foo`
+                // is left intact so it still raises the self-inheritance error.
+                .filter(|p| !(p == "Grammar" && qualified_name == "Grammar"))
                 .collect();
             let mapped_hidden_parents: Vec<String> = hidden_parents
                 .iter()

--- a/t/grammar-named-grammar-in-module.t
+++ b/t/grammar-named-grammar-in-module.t
@@ -1,0 +1,26 @@
+use v6;
+use Test;
+
+# A grammar declared with the same name as the built-in `Grammar`, but inside a
+# module, must still be recognised as a grammar: it qualifies to `Mod::Grammar`,
+# which is a distinct type that inherits the built-in Grammar. Before the fix the
+# parser dropped the default `Grammar` parent for any decl literally named
+# `Grammar`, so `Mod::Grammar` had no Grammar ancestor and `.parse` dispatch /
+# `class_is_grammar` failed for it.
+
+plan 3;
+
+# The named-Grammar-in-module case is exercised through EVAL of a unit module so
+# the qualification (`GM::Grammar`) actually happens.
+my $mod = q:to/MOD/;
+    unit module GM;
+    grammar Grammar {
+        token TOP { \d+ }
+    }
+    our sub parse-it($s) is export { Grammar.parse($s) }
+    MOD
+
+my &parse-it = EVAL $mod ~ "\n&parse-it";
+ok parse-it("123").defined, 'module-local `grammar Grammar` parses';
+is ~parse-it("123"), '123', 'the whole input matched';
+nok parse-it("abc").defined, 'a non-match still fails cleanly';

--- a/t/grammar-parse-override-nextwith.t
+++ b/t/grammar-parse-override-nextwith.t
@@ -1,0 +1,43 @@
+use v6;
+use Test;
+
+# A grammar that overrides `parse` and re-dispatches to the native grammar
+# parse via `nextwith`, injecting an actions object — the pattern used by
+# YAMLish's `method parse { nextwith($input, :actions(Actions)) }`. Before the
+# fix, `nextwith` from an overridden grammar `parse`/`subparse` had no MRO
+# candidate to defer to (the native parse is not a MethodDef), so it returned an
+# undefined match and every parse failed.
+
+plan 6;
+
+grammar Simple {
+    token TOP { <digits> }
+    token digits { \d+ }
+
+    class Actions {
+        method TOP($/) { make $<digits>.Str.Int }
+        method digits($/) { make $/.Str.Int }
+    }
+    method parse($input, *%args) {
+        nextwith($input, :actions(Actions), |%args);
+    }
+    method subparse($input, *%args) {
+        nextwith($input, :actions(Actions), |%args);
+    }
+}
+
+my $m = Simple.parse("42");
+ok $m.defined, 'overridden parse + nextwith matches';
+is ~$m, '42', 'match stringifies to the whole input';
+is $m.ast, 42, 'the injected actions ran (ast is made value)';
+
+my $s = Simple.subparse("99abc");
+ok $s.defined, 'overridden subparse + nextwith matches a prefix';
+is ~$s, '99', 'subparse consumed the leading digits';
+
+# An explicit :actions passed by the caller still flows through |%args.
+grammar Plain {
+    token TOP { \w+ }
+    method parse($input, *%args) { nextwith($input, |%args) }
+}
+ok Plain.parse("hello").defined, 'nextwith without an actions object still parses';


### PR DESCRIPTION
## Problem

A grammar that overrides `parse` (or `subparse`/`parsefile`) to wrap the native grammar parse — the common pattern for injecting an `:actions` object — silently failed under mutsu, returning an undefined match for every input:

```raku
grammar G {
    token TOP { \d+ }
    class Actions { method TOP($/) { make +$/ } }
    method parse($input, *%args) {
        nextwith($input, :actions(Actions), |%args);
    }
}
G.parse("42");   # was: undefined match;  now: matches, .ast == 42
```

The `nextwith`/`nextsame` (and `callwith`/`callsame`) inside the override had no MRO candidate to defer to: the built-in grammar parse is not a `MethodDef`, so it never appears in the dispatch candidate list, and the re-dispatch fell through to `Nil`. This is exactly the shape `YAMLish`'s `load-yaml` relies on (`method parse { nextwith($input, :actions(Actions)) }`), so `use YAMLish; load-yaml(...)` could not parse anything.

## Fix

1. **Native grammar parse as the final `nextsame`/`nextwith` candidate.** `dispatch_next_candidate` now falls through to `dispatch_package_parse` when an overridden grammar `parse`/`subparse`/`parsefile` exhausts its user MRO — mirroring the existing metamodel-HOW native fallback. A dispatch frame is pushed for such an override even with a single user candidate (`push_method_dispatch_frame` / `run_instance_method_celled`) so the deferral has somewhere to land.

2. **A module-local `grammar Grammar` is recognised as a grammar.** The parser used to drop the default `Grammar` superclass for any declaration literally named `Grammar` (to avoid a self-parent). But inside a module a `grammar Grammar` qualifies to `Mod::Grammar` — a distinct type that should still inherit the built-in `Grammar`. Without the parent, `class_is_grammar` returned false for `Mod::Grammar` and the fallback above never fired (YAMLish declares exactly `grammar Grammar` inside `unit module YAMLish`). The parser now always adds the `Grammar` default parent; a genuine top-level `grammar Grammar` self-parent is filtered at registration (`exec_register_class_op`), while an explicit `class Foo is Foo` is left intact so it still raises the self-inheritance error.

## Tests

- `t/grammar-parse-override-nextwith.t` — override + `nextwith`/`subparse`, with and without an actions object.
- `t/grammar-named-grammar-in-module.t` — a module-local `grammar Grammar` parses.
- Verified `t/class-does-self-named-role.t` (self-inheritance error) and the existing grammar suite still pass.

Part of the YAMLish battery campaign (blocker #3); YAMLish's document grammar now matches — the remaining schema-`concretize` step is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)