### PR TITLE
fix: invoking a user class as a coercion (`Foo($x)`) works

### DIFF
--- a/news/2026-07/class-type-object-coercion-call.md
+++ b/news/2026-07/class-type-object-coercion-call.md
@@ -1,0 +1,76 @@
+# Invoking a user class as a coercion (`Foo($x)`) works
+
+Invoking a type object coerces: `Foo($x)` is `Foo.COERCE($x)` when the type
+defines `COERCE`, else `Foo.new($x)`, else `X::Coerce::Impossible`. mutsu already
+took that path for built-in types (`Int("42")`), for roles, and for enums — but a
+**user-declared class** had no branch at all, so
+
+```raku
+class Locale::Dates { multi method new($locale = "EN") { … } }
+my $ld = Locale::Dates("DE");
+```
+
+died with `Unknown function: Dates`: the call fell through every routine lookup,
+and the qualified name collapsed to its last component before being reported.
+
+`call_function_fallback` now handles a class type object with the same protocol
+the role branch implements after punning, in raku's precedence order:
+
+1. `CALL-ME` — a type object carrying one is *invocable*, not coercive;
+2. `COERCE`;
+3. `new`;
+4. otherwise `X::Coerce::Impossible`, with raku's wording
+   (`Impossible coercion from 'Str' into 'B': no acceptable coercion method
+   found`).
+
+A coercion takes **one** value: `B("q", "r")` coerces the `List`, it does not
+splat two arguments. raku shows this by accepting that call for
+`method new($x)` (which receives the List) and rejecting it for
+`method new($x, $y)`. mutsu now wraps multi-argument calls the same way.
+
+A `COERCE` with **no matching candidate falls back to `new`**, which is what raku
+does — a class may declare `multi method COERCE(Str)` alongside
+`multi method new(Int)` and accept both spellings. This mirrors what the role
+branch already did.
+
+## Two traps this fix walked into first
+
+Both were caught by running the suites before committing, and both are pinned:
+
+1. **The class branch must not shadow the role branch.** Coercing a role *puns*
+   it to a class, so after the first `R("x")` the pun makes `has_class("R")` true
+   and a class-first branch takes over every later call — with the pun's `COERCE`
+   found but not its `new`, so `R(42)` died with "No matching candidates for
+   method: COERCE". This broke the whitelisted
+   `roast/S12-coercion/coercion-methods.t` ("Roles" subtest). The class branch is
+   now gated on `!has_role(name)`.
+2. **Arguments are not splatted** (above). The first implementation passed them
+   through, which silently accepted `B("q","r")` for `method new($x, $y)` where
+   raku rejects it.
+
+## Known cosmetic divergence
+
+When the single coerced value matches no `new` candidate, raku reports
+`X::Coerce::Impossible` while mutsu surfaces the arity error from `new`
+(`Too few positionals passed; expected 2 arguments but got 1`). Both reject the
+call; only the message differs. Converting mutsu's error would mean catching a
+failure from inside a user-written `new`, which risks masking genuine errors, so
+it is left as is and pinned only as "dies".
+
+Also still unsupported: the same call form on a **subset** (`subset Sm of Int
+where * < 10; Sm(5)`), which raku accepts. That is a different mechanism (coerce
+to the base type, then check the constraint) and is recorded in
+`todo/tickets/dist-test-suite-failures-batch.md` alongside the other sweep
+findings.
+
+## Found by
+
+The `--run-tests` axis of the real-dist compatibility sweep. `Locale::Dates`
+graded `test_die`: `t/01-basic.rakutest` planned 8 and ran 0. Both of its files
+now match raku exactly (24 subtests, 0 failures).
+
+Pinned by `t/class-type-object-coercion-call.t` (11 subtests: `new`, `COERCE`,
+`COERCE` winning over `new`, `CALL-ME` winning over both, the impossible-coercion
+type and message, a qualified class name, single-List multi-argument semantics
+both ways, and a bare type name still being the type object). All 11 identical
+under raku.

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -692,6 +692,72 @@ impl Interpreter {
             return Err(err);
         }
 
+        // Invoking a *class* type object coerces: `Foo($x)` is `Foo.COERCE($x)`
+        // when the class defines COERCE, else `Foo.new($x)`, else
+        // X::Coerce::Impossible — the same protocol the role branch below
+        // implements after punning. Built-in types (`Int("42")`), roles and enums
+        // already went through their own paths; a user-declared class had none, so
+        // `Locale::Dates($locale)` died with "Unknown function: Dates".
+        //
+        // `CALL-ME` wins over both: a type object carrying one is invocable
+        // rather than coercive.
+        // `!has_role`: coercing a role puns it to a class, so after the first
+        // `R1("x")` the pun makes `has_class("R1")` true and this branch would
+        // shadow the role branch below for every later call. The role branch owns
+        // roles (it also handles the `does`-RHS Pair form), so defer to it.
+        if self.has_class(name) && !self.has_role(name) && !args.is_empty() {
+            if self.class_has_method(name, "CALL-ME") {
+                return self.call_method_with_values(
+                    Value::package(Symbol::intern(name)),
+                    "CALL-ME",
+                    args.to_vec(),
+                );
+            }
+            // A coercion takes ONE value: `B("q", "r")` coerces the List, it does
+            // not splat two arguments. raku shows this by rejecting
+            // `class B { method new($x, $y) {…} }; B("q","r")` with "Impossible
+            // coercion from 'List'" while accepting it for `new($x)`.
+            let coercee = if args.len() == 1 {
+                vec![args[0].clone()]
+            } else {
+                vec![Value::array(args.to_vec())]
+            };
+            // COERCE first, then `new` — and fall back from a COERCE that has no
+            // matching candidate to `new`, which is what raku does (a class may
+            // declare `multi method COERCE(Str)` and `multi method new(Int)` and
+            // accept both spellings). Mirrors the role branch below.
+            if self.class_has_method(name, "COERCE") {
+                let coerced = self.call_method_with_values(
+                    Value::package(Symbol::intern(name)),
+                    "COERCE",
+                    coercee.clone(),
+                );
+                if coerced.is_ok() || !self.class_has_method(name, "new") {
+                    return coerced;
+                }
+            }
+            if self.class_has_method(name, "new") {
+                return self.call_method_with_values(
+                    Value::package(Symbol::intern(name)),
+                    "new",
+                    coercee,
+                );
+            }
+            let source_type = crate::runtime::value_type_name(&args[0]).to_string();
+            let msg = format!(
+                "Impossible coercion from '{}' into '{}': no acceptable coercion method found",
+                source_type, name
+            );
+            return Err(RuntimeError::typed(
+                "X::Coerce::Impossible",
+                std::collections::HashMap::from([
+                    ("target-type".to_string(), Value::str(name.to_string())),
+                    ("from-type".to_string(), Value::str(source_type)),
+                    ("message".to_string(), Value::str(msg)),
+                ]),
+            ));
+        }
+
         if self.has_role(name) {
             // If the role has CALL-ME, dispatch to it on the type object
             if self.role_has_method(name, "CALL-ME") {

--- a/t/class-type-object-coercion-call.t
+++ b/t/class-type-object-coercion-call.t
@@ -1,0 +1,94 @@
+use v6;
+use Test;
+
+# Invoking a type object coerces: `Foo($x)` is `Foo.COERCE($x)` when the type
+# defines COERCE, else `Foo.new($x)`, else X::Coerce::Impossible. Built-in types
+# (`Int("42")`), roles and enums already took that path in mutsu; a
+# user-declared *class* had none, so `Locale::Dates($locale)` died with
+# "Unknown function: Dates" — the qualified name collapsed to its last component
+# and was looked up as a routine.
+
+plan 15;
+
+{
+    my class B { method new($x) { self.bless } }
+    isa-ok B("q"), B, 'a class with `new` coerces through it';
+}
+
+{
+    my $seen;
+    my class B { method COERCE($x) { $seen = $x; self.bless } }
+    isa-ok B("q"), B, 'a class with COERCE coerces through it';
+    is $seen, 'q', 'and receives the argument';
+}
+
+{
+    my @order;
+    my class B {
+        method new($x)    { @order.push('new');    self.bless }
+        method COERCE($x) { @order.push('coerce'); self.bless }
+    }
+    B("q");
+    is-deeply @order, ['coerce'], 'COERCE wins over new';
+}
+
+{
+    my class B { method CALL-ME($x) { "called:$x" } }
+    is B("q"), 'called:q', 'CALL-ME wins over both';
+}
+
+{
+    my class B { }
+    throws-like { B("q") }, X::Coerce::Impossible,
+        'a class with none of the three is an impossible coercion';
+    throws-like { B("q") }, X::Coerce::Impossible,
+        message => /'Impossible coercion from' .* "'B'"/,
+        'and says so the way raku does';
+}
+
+# A qualified class name must not collapse to its last component.
+{
+    my class Foo::Bar { multi method new($x = 'd') { self.bless } }
+    is Foo::Bar("q").^name, 'Foo::Bar', 'a qualified class name coerces';
+}
+
+# A coercion takes ONE value: several arguments are coerced as a single List,
+# they are not splatted. So a one-parameter `new` accepts `B("q", "r")` (it
+# receives the List) and a two-parameter one does not.
+{
+    my class B { method new($x) { self.bless } }
+    isa-ok B("q", "r"), B, 'several arguments coerce as a single List';
+
+    my class C { method new($x, $y) { self.bless } }
+    dies-ok { C("q", "r") },
+        'and a two-parameter new does not match that single List';
+}
+
+# The type object itself is unchanged when called with no arguments.
+{
+    my class B { method new($x = 1) { self.bless } }
+    ok B.defined.not, 'a bare type name is still the type object';
+}
+
+# A COERCE with no matching candidate falls back to `new`, as raku does.
+{
+    my class B {
+        multi method COERCE(Str:D $s) { self.bless }
+        multi method new(Int:D $n)    { self.bless }
+    }
+    isa-ok B("x"), B, 'COERCE handles the spelling it declares';
+    isa-ok B(42),  B, 'and a non-matching COERCE falls back to new';
+}
+
+# Roles must keep their own path: coercing a role puns it to a class, so a
+# class-first branch would shadow the role branch on every later call.
+# (roast/S12-coercion/coercion-methods.t "Roles" caught exactly this.)
+{
+    my role R {
+        has Str:D $.attr is required;
+        multi method new(Int:D $n)    { self.new(attr => $n.Str) }
+        multi method COERCE(Str:D $s) { R.new(attr => $s) }
+    }
+    is R("The Answer").attr, 'The Answer', 'a role coerces through COERCE';
+    is R(42).attr, '42', 'and still reaches its `new` on a later call';
+}

--- a/todo/tickets/dist-test-suite-failures-batch.md
+++ b/todo/tickets/dist-test-suite-failures-batch.md
@@ -59,12 +59,17 @@ Reaches subtest 4 of 21, then dies with
 `No such method 'value' for invocant of type 'Any'` at `t/01-basic.t:15`. Whatever
 the code expects to be a `Pair` there is `Any` in mutsu. Needs reduction.
 
-### `Locale::Dates` — `Unknown function: Dates`
+### ~~`Locale::Dates` — `Unknown function: Dates`~~ — FIXED
 
-`t/01-basic.rakutest` plans 8 and runs 0, dying with `Unknown function: Dates` at
-line 9 — a name-resolution failure that mangles the package name
-(`Locale::Dates`) into a call to `Dates`. `t/02-create.rakutest` passes 16/16, so
-it is specific to what line 9 does. Needs reduction.
+Was `Locale::Dates($locale)`, i.e. invoking a user class as a coercion. mutsu had
+that path for built-in types, roles and enums but not for user classes. Fixed in
+`news/2026-07/class-type-object-coercion-call.md`; both of its files now match
+raku (24 subtests).
+
+**Left over from that fix:** the same call form on a **subset** is still
+unsupported — `subset Sm of Int where * < 10; Sm(5)` returns 5 in raku,
+`Unknown function: Sm` in mutsu. Different mechanism (coerce to the base type,
+then check the constraint).
 
 ## Un-triaged `test_die` / `test_fail`
 


### PR DESCRIPTION
## Problem

Invoking a type object coerces: `Foo($x)` is `Foo.COERCE($x)` when the type
defines `COERCE`, else `Foo.new($x)`, else `X::Coerce::Impossible`. mutsu already
took that path for built-in types (`Int("42")`), for roles and for enums — but a
**user-declared class** had no branch at all:

```raku
class Locale::Dates { multi method new($locale = "EN") { … } }
my $ld = Locale::Dates("DE");   # raku: an instance   mutsu: Unknown function: Dates
```

The call fell through every routine lookup, and the qualified name collapsed to
its last component before being reported.

## Fix

`call_function_fallback` now handles a class type object with raku's precedence:
**CALL-ME** (a type object carrying one is *invocable*, not coercive) → **COERCE**
→ **`new`** → `X::Coerce::Impossible` with raku's wording.

Two semantics were **measured against raku rather than assumed**:

- **A coercion takes ONE value.** `B("q", "r")` coerces the `List`; it does not
  splat two arguments. raku accepts that call for `method new($x)` (which receives
  the List) and rejects it for `method new($x, $y)`. The first draft splatted.
- **A `COERCE` with no matching candidate falls back to `new`**, so a class may
  declare `multi method COERCE(Str)` beside `multi method new(Int)` and accept
  both spellings. Mirrors the role branch.

## A regression this caught before landing

The first draft broke the **whitelisted** `roast/S12-coercion/coercion-methods.t`
("Roles"). Coercing a role *puns* it to a class, so after the first `R("x")` the
pun makes `has_class("R")` true and a class-first branch shadows the role branch
on every later call — with the pun's `COERCE` found but not its `new`, so `R(42)`
died with "No matching candidates for method: COERCE". The class branch is now
gated on `!has_role(name)`, and both that shape and the `COERCE`→`new` fallback
are pinned in the test.

## Scope

Still unsupported, recorded rather than attempted: the same call form on a
**subset** (`subset Sm of Int where * < 10; Sm(5)`, which raku accepts). That is a
different mechanism — coerce to the base type, then check the constraint — and is
noted in `todo/tickets/dist-test-suite-failures-batch.md`.

Also unchanged: when the single coerced value matches no `new` candidate, raku
reports `X::Coerce::Impossible` while mutsu surfaces the arity error from `new`.
Both reject the call; converting mutsu's would mean catching a failure from inside
a user-written `new` and risk masking genuine errors, so the pin only asserts
"dies".

## Found by

The `--run-tests` axis of the real-dist compatibility sweep. `Locale::Dates`
graded `test_die` with `t/01-basic.rakutest` planning 8 and running 0. **Both of
its files now match raku exactly (24 subtests).**

## Testing

- `t/class-type-object-coercion-call.t` (15 subtests), all identical under `raku`.
- `roast/S12-coercion/`: 4 files, 45 tests, all pass (including the whitelisted
  `coercion-methods.t` that the first draft broke).
- `make test`: 2477 files, 23621 tests, `Result: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)