### PR TITLE
docs(dbiish): re-survey with a working `-I`, and root-cause the 5-file blocker

### DIFF
--- a/todo/tickets/class-in-module-cannot-see-module-subs.md
+++ b/todo/tickets/class-in-module-cannot-see-module-subs.md
@@ -1,0 +1,81 @@
+# A class inside a module cannot see the module's subs
+
+A method of a class declared inside a `module` (either `unit module` or a
+`module { ... }` block) cannot call a sub declared at that module's scope. The
+call dies with `Unknown function: <name>`. raku resolves it.
+
+This is the blocker behind five of the nine `DBIish` test files — see
+[`dbiish-blockers.md`](dbiish-blockers.md) ② — but it has nothing to do with
+`DBIish`, `NativeLibs`, `proto`/`multi` or NativeCall. It is a plain
+lexical-scope bug.
+
+## Repro
+
+```raku
+# lib/NL.rakumod
+unit module NL;
+our sub cannon-name($libname) { "cn:$libname" }
+class Searcher {
+    method try-versions($libname) { cannon-name($libname) }
+}
+```
+
+```
+$ raku  -I lib -e 'use NL; say NL::Searcher.try-versions("sqlite3")'
+cn:sqlite3
+$ mutsu -I lib -e 'use NL; say NL::Searcher.try-versions("sqlite3")'
+Unknown function: cannon-name
+```
+
+## What the boundary is
+
+Measured 2026-07-26 against `main`, one variant per line. raku resolves every
+one of them.
+
+| Variant | mutsu |
+| --- | --- |
+| `class` at **file scope**, sub at file scope | works |
+| `class` inside `unit module`, `our sub` at module scope | **Unknown function** |
+| `class` inside `unit module`, plain (lexical) `sub` at module scope | **Unknown function** |
+| `class` inside `unit module`, `our proto` + `multi` at module scope | **Unknown function** |
+| `class` inside a `module { ... }` **block** | **Unknown function** |
+| Same call from a module-scope **sub** instead of a method | works |
+| Module-scope **`my` variable** read from the method | works |
+| The same call written **fully qualified** (`NL::cannon-name(...)`) | works |
+
+Two of those rows are the whole diagnosis:
+
+- The module-scope **variable** is visible, so the method does run with the
+  enclosing lexical environment available. What fails is specifically **bare-name
+  function lookup**.
+- The **fully qualified** call works, so the sub *is* registered — as
+  `NL::cannon-name`. The method body compiles under package `NL::Searcher`, and
+  bare-name lookup evidently tries that package and then GLOBAL, without walking
+  the enclosing package chain in between.
+
+So the fix is to make bare-name function resolution inside a class body walk
+outward through the enclosing packages (`NL::Searcher` → `NL` → `GLOBAL`) rather
+than jumping straight to GLOBAL. The file-scope row works only because there the
+enclosing package *is* GLOBAL, which is why this never showed up in ordinary
+single-file tests.
+
+Whether the walk belongs in the compiler (resolve the name at compile time,
+where the package nesting is known — cf. `SetCurrentPackage` and
+`current_package()`) or in the runtime fallback needs a look; the compile-time
+route is preferable and matches how the qualified name is already produced.
+
+## Not to be confused with
+
+The earlier reductions recorded under `dbiish-blockers.md` ② — "a plain
+`our proto sub` + multis called from a sibling sub", "the same with a custom
+`sub EXPORT(|)`" — all pass, and correctly so: they call from a *sub*, not from a
+method of a nested class. That is the row that works.
+
+## Aside, found in the same file
+
+`$*VM.config<nativecall_backend>` is missing, so `NativeLibs`'
+`my \dyncall = $*VM.config<nativecall_backend> eq 'dyncall'` warns
+`Use of uninitialized value of type Any in string context` on every run that
+loads it. mutsu's `$*VM.config` has exactly two keys (`be`, `name`); raku
+answers `dyncall`. Harmless — `dyncall` ends up `False`, which is what mutsu
+wants — but it is noise in every DBIish run and a one-line fix.

--- a/todo/tickets/dbiish-blockers.md
+++ b/todo/tickets/dbiish-blockers.md
@@ -30,22 +30,31 @@ mutsu $INC t/45-sqlite-common.rakutest
 `raku $INC …` passes one giant argument and every file "fails" under raku too —
 a bogus baseline that wastes a session.
 
-## Status: mutsu 1/9, raku 9/9
+## Status: mutsu 1/9
 
-| File | mutsu | Blocker |
-| --- | --- | --- |
-| `02-meta.rakutest` | **PASS** | — |
-| `44-sqlite-memory` | FAIL | ② `Unknown function: cannon-name` |
-| `45-sqlite-common` | FAIL | ② `Unknown function: cannon-name` |
-| `46-sqlite-blob` | FAIL | ② `Unknown function: cannon-name` |
-| `03-lib-util` | FAIL | ② `Unknown function: cannon-name` |
-| `48-sqlite-errors` | FAIL | ② `Unknown function: cannon-name` |
-| `01-basic` | FAIL | ③ `PackageHOW.method_table` |
-| `05-mock` | FAIL | ④ one subtest: `IterationEnd` from a row fetch |
-| `06-types` | FAIL | ⑤ not root-caused |
+Re-measured **2026-07-26** with `tmp/dbiish-survey.sh` (in this repo's `tmp/`,
+recreate it from the recipe above), debug build, both interpreters on the same
+`-I` line. This is the first survey whose `-I` was actually honoured — see the
+section below — so it supersedes everything measured before it.
 
-**Nothing fails inside NativeCall.** The surface `OpenSSL` needed (CStruct,
-opaque pointers, callbacks) is strictly harder than SQLite's, and it is holding.
+| File | raku | mutsu | Blocker |
+| --- | --- | --- | --- |
+| `02-meta` | PASS 1/1 | **PASS 1/1** | — |
+| `03-lib-util` | 1 subtest fails | ran 3/5, dies | ② `Unknown function: cannon-name` |
+| `44-sqlite-memory` | 1 subtest fails* | ran 0/109, dies | ② `Unknown function: cannon-name` |
+| `45-sqlite-common` | 1 subtest fails* | ran 0/109, dies | ② `Unknown function: cannon-name` |
+| `46-sqlite-blob` | PASS 18/18 | ran 0/18, dies | ② `Unknown function: cannon-name` |
+| `48-sqlite-errors` | PASS 17/17 | ran 2/17, dies | ② `Unknown function: cannon-name` |
+| `01-basic` | PASS 35/35 | ran 0/35, dies | ③ `PackageHOW.method_table` |
+| `05-mock` | PASS 16/16 | 1 fail of 13 run | ④ `IterationEnd` from a row fetch, then `Too many positionals passed; expected 0 arguments but got 2` |
+| `06-types` | PASS 12/12 | 2 fail of 3 run | ⑤ `Int is builtin` / `So not defined`; mutsu suggests `Did you mean 'invert'?` |
+
+\* raku is not clean on `03-lib-util`, `44-` and `45-` either: one subtest each.
+Do not chase those — the achievable target is raku parity, not 109/109.
+
+**② is worth five files and is now root-caused** (below). **Nothing fails inside
+NativeCall**: the surface `OpenSSL` needs (CStruct, opaque pointers, callbacks)
+is strictly harder than SQLite's, and it is holding.
 
 ## The first round of these numbers was taken with the wrong `NativeLibs`
 
@@ -56,12 +65,7 @@ That is fixed
 ([`news/2026-07/dash-i-beats-installed-modules.md`](../../news/2026-07/dash-i-beats-installed-modules.md));
 the tell was a stack frame pointing into
 `~/.local/share/mutsu/repo/site/sources/…`, and those frames now name
-`../NativeLibs-0.0.9/lib/NativeLibs.rakumod`.
-
-`45-sqlite-common` was re-measured after the fix: still `Unknown function:
-cannon-name`, so ② is a real blocker and not an artifact of the wrong source —
-but every *reduction* under ② was written against 0.0.8 and needs redoing
-against 0.0.9.
+`../NativeLibs-0.0.9/lib/NativeLibs.rakumod`. The table above is the re-run.
 
 ## ① Parse failure — FIXED, was worth four files
 
@@ -91,20 +95,30 @@ work. That half stays in
 [`todo/deep/nativehelpers-blob-moarvm-guts.md`](../deep/nativehelpers-blob-moarvm-guts.md);
 `DBDish::SQLite` only uses `blob-from-pointer`, which does not go through it.
 
-**Remaining: `cannon-name` itself.** `NativeLibs` declares it as an `our proto
-sub` with two `multi` candidates. Reductions that do **not** reproduce (all
-checked against raku, all behave identically under both):
+**Remaining: `cannon-name` itself — ROOT-CAUSED 2026-07-26.** It has nothing to
+do with `proto`/`multi`, `sub EXPORT`, or NativeCall. `cannon-name` is only ever
+called from *inside* `NativeLibs.rakumod`, at lines 131 and 134, which are in a
+method of `class Searcher` — and **a class declared inside a `module` cannot see
+that module's subs**:
 
-- a plain `our proto sub` + multis in a module, called from a sibling sub;
-- the same with a custom `sub EXPORT(|)` before the `unit module` line;
-- one multi calling the proto recursively (`cannon-name($libname, Version.new($ver))`).
+```raku
+unit module NL;
+our sub cannon-name($libname) { "cn:$libname" }
+class Searcher {
+    method try-versions($libname) { cannon-name($libname) }   # Unknown function
+}
+```
 
-So the earlier note here (a custom `sub EXPORT` before `unit module`) is wrong,
-and the trigger is still unidentified. **These reductions were aimed at the wrong
-source** — see the section above: they were checked while the installed
-`NativeLibs` 0.0.8 was being loaded. Redo them against 0.0.9, whose
-`cannon-name` is `our proto sub cannon-name(|) {*}` with a
-`(Str:D, Version?)` and a `(Str, Cool)` candidate.
+The full variant matrix, the diagnosis (the module-scope *variable* is visible
+and the *qualified* call works, so bare-name function lookup is not walking the
+enclosing package chain) and the suggested fix are in
+[`class-in-module-cannot-see-module-subs.md`](class-in-module-cannot-see-module-subs.md).
+**That ticket is the next thing to do here: it is worth five of the nine files.**
+
+The earlier reductions recorded here were not wrong so much as aimed one row off
+the failing case — they all call from a sibling *sub*, which works. (They were
+also checked while the installed 0.0.8 was being loaded; the matrix in the new
+ticket was measured against 0.0.9 with a working `-I`.)
 
 ## ③ `Perl6::Metamodel::PackageHOW.method_table` (`01-basic`)
 
@@ -116,6 +130,21 @@ No such method 'method_table' for invocant of type 'Perl6::Metamodel::PackageHOW
 Rakudo MOP method that mutsu's `PackageHOW` does not implement. Not investigated
 beyond the message; check what the test actually asks for before implementing the
 whole MOP surface.
+
+## ④ `05-mock` — one subtest, then a hard stop
+
+`A row` expects `'a b 1'` and gets `'IterationEnd'`, and the file then dies at
+line 32 with `Too many positionals passed; expected 0 arguments but got 2`
+(13 of 16 tests run). raku is 16/16. Two separate symptoms, both unexamined —
+the `IterationEnd` leak out of a row fetch is the interesting one and smells
+like the `Seq`/iterator-exhaustion family.
+
+## ⑤ `06-types` — `Int is builtin` / `So not defined`
+
+Two of the three tests that run fail, and mutsu volunteers `Did you mean
+'invert'?`, so a method the test calls is unresolved and being spell-corrected.
+raku is 12/12. Not root-caused; start by reading lines 19-21 of the file and
+finding which call produces that suggestion.
 
 ## ④ Role attribute not seeded — FIXED; `05-mock` has one subtest left
 


### PR DESCRIPTION
Preparation for picking the DBIish battery back up. No interpreter changes — ledger only.

## The numbers are trustworthy now

The previous survey ran with an `-I` that did not override the installed `NativeLibs`, so every measurement was against 0.0.8 instead of the pinned 0.0.9. With #5451 in, all nine generic + SQLite files were re-measured against **both** interpreters on the same `-I` line.

The new table records raku's result per file, which changes the goal: raku is **not** clean on `03-lib-util`, `44-sqlite-memory` or `45-sqlite-common` either (one subtest each). The achievable target is parity, not 109/109.

## Blocker ② is root-caused — five of the nine files

`Unknown function: cannon-name` is not about `proto`/`multi`, `sub EXPORT`, or NativeCall. `cannon-name` is only ever called from *inside* `NativeLibs.rakumod`, at lines 131/134, which sit in a method of `class Searcher`. And:

```raku
unit module NL;
our sub cannon-name($libname) { "cn:$libname" }
class Searcher {
    method try-versions($libname) { cannon-name($libname) }   # Unknown function
}
```

raku resolves it; mutsu does not. Filed as `todo/tickets/class-in-module-cannot-see-module-subs.md` — it is a general lexical-scope bug, not a DBIish one — with the full variant matrix. Two rows of that matrix are the whole diagnosis:

- a module-scope **`my` variable** *is* visible from the method, so the lexical environment is there; what fails is specifically bare-name **function** lookup;
- the **qualified** call `NL::cannon-name(...)` *works*, so the sub is registered under the qualified name.

So bare-name resolution inside a class body is jumping from the class's package straight to GLOBAL instead of walking `NL::Searcher → NL → GLOBAL`. A class at *file* scope works only because there the enclosing package already is GLOBAL — which is why no single-file test ever caught this.

The earlier reductions filed under ② were aimed one row off the failing case: they all call from a sibling *sub*, which works.

## Also recorded

- What `05-mock` and `06-types` actually fail on (both were "not root-caused" placeholders).
- `$*VM.config<nativecall_backend>` is missing (mutsu's `$*VM.config` has two keys; raku answers `dyncall`), which is the `Use of uninitialized value of type Any in string context` warning in every DBIish run. Harmless, one-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)