### PR TITLE
feat: `nqp::sha1`, the one nqp op two shipped components need

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -335,9 +335,10 @@ sessions).
       ops would change nothing observable; and per dist the op set is a threshold
       function (80% of a module's ops still leaves it dead) spanning thunk-taking
       control ops and a null sentinel. Bundling the few nqp-heavy hub modules is
-      much cheaper. The one real `nqp::` demand found is **`nqp::sha1`, which
-      blocks the vendored zef install path** (`Zef::Distribution.id`) — small and
-      on the mzef critical path. Details and the measurements:
+      much cheaper. The one real `nqp::` demand found was **`nqp::sha1`, which
+      blocked the vendored zef install path** (`Zef::Distribution.id`) — now
+      implemented (news/2026-07/nqp-sha1.md); `Zef::Distribution.id` matches
+      rakudo's digest exactly. Details and the measurements:
       `todo/tickets/nqp-op-aliasing-and-sha1.md`. The other four
       were **mis-classified**, each verified against `raku -I lib`:
       `PDF::Class` and `Qwiratry::Test` merely lack an uninstalled dependency

--- a/news/2026-07/nqp-sha1.md
+++ b/news/2026-07/nqp-sha1.md
@@ -1,0 +1,56 @@
+# `nqp::sha1`, the one nqp op two shipped components actually need
+
+mutsu had no SHA-1 anywhere: nothing in tree, and no `sha`/`digest` crate in
+`Cargo.toml`. That made `nqp::sha1` the single unimplemented `nqp::` op with
+real demand inside our own tree — a demand measured, not guessed, while deciding
+whether to build an `nqp::` op layer at all (the answer was no; see
+`todo/tickets/nqp-op-aliasing-and-sha1.md`):
+
+- **vendored zef** — `Zef::Distribution.id` is `nqp::sha1(self.Str)`, and
+  `Zef::CLI`'s `locate` derives installed-source paths from it. That is the mzef
+  critical path.
+- **bundled `modules/OpenSSL`** — `dll-resource()` hashes a resource name to
+  find its unmangled copy under `$*TMPDIR`. `use OpenSSL` worked only because
+  that sub is never called at load time.
+
+Both would have failed with `Unsupported nqp:: op: nqp::sha1` — the error
+introduced the same day, which replaced a worse outcome: before it, an
+unimplemented `nqp::` op fell through the package-prefix strip in
+`call_function_fallback` and quietly reached Raku's same-named builtin.
+
+## What landed
+
+`src/builtins/sha1.rs` implements FIPS 180-4 SHA-1 in ~90 lines with no new
+dependency. A crate would have meant an optional-dependency matrix across the
+`native`/`wasm` feature split for one fixed, tiny algorithm. `sha1_digest`
+returns the 20 raw bytes; `sha1_hex_uppercase` formats the 40 uppercase hex
+digits nqp's op yields.
+
+The op itself is one arm beside `nqp::ordat` / `nqp::gethostname` /
+`nqp::bindattr` in `src/runtime/builtins.rs`, matched under its full `nqp::`
+name — so it is reached before the guard that rejects unimplemented ops.
+
+The digest covers the string's **UTF-8 encoding**, not its codepoints, which is
+what rakudo does: `nqp::sha1("日本語")` is
+`C12140A0FFB4E56481B4FE0A7A25040C2EAFA9CA`, the same as `sha1sum` over those
+bytes.
+
+## Verification
+
+Four Rust unit tests carry the NIST vectors (`""`, `"abc"`, the 448-bit message,
+a million `a`), the padding block boundaries (55 / 56 / 64 bytes — where the
+length field does and does not fit in the first block), and the UTF-8 property.
+
+`t/nqp-sha1.t` (12 subtests) pins the op end to end and **passes unchanged under
+rakudo**, so it is a differential test rather than a record of mutsu's own
+output.
+
+The real consumer was checked directly: building a `Zef::Distribution` and
+asking for its `.id` gives byte-identical results under both implementations.
+
+```
+$ mutsu -I vendor/zef/lib tmp/zef-dist-id.raku
+Foo::Bar:ver<1.2.3>:auth<zef:someone>:api<1>
+8BB1CD1A566589A4514F3C562490D45DB20BDBAB
+$ raku  -I vendor/zef/lib tmp/zef-dist-id.raku      # identical
+```

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod primality;
 pub(crate) mod quanthash_coerce;
 pub(crate) mod rng;
 pub(crate) mod seq_coerce;
+pub(crate) mod sha1;
 pub(crate) mod split;
 pub(crate) mod str_increment;
 pub(crate) mod substr;

--- a/src/builtins/sha1.rs
+++ b/src/builtins/sha1.rs
@@ -1,0 +1,149 @@
+//! SHA-1 (FIPS 180-4).
+//!
+//! Kept in-tree rather than pulled in as a crate: the only consumer is the
+//! `nqp::sha1` op, the algorithm is fixed and tiny, and the wasm build has no
+//! room for an optional-dependency matrix over one hash function.
+
+/// The 20-byte SHA-1 digest of `data`.
+pub(crate) fn sha1_digest(data: &[u8]) -> [u8; 20] {
+    let mut h: [u32; 5] = [
+        0x6745_2301,
+        0xEFCD_AB89,
+        0x98BA_DCFE,
+        0x1032_5476,
+        0xC3D2_E1F0,
+    ];
+    let bit_len = (data.len() as u64).wrapping_mul(8);
+
+    let mut chunks = data.chunks_exact(64);
+    for block in &mut chunks {
+        compress(&mut h, block);
+    }
+
+    // Padding: 0x80, then zeros, then the 64-bit big-endian bit length. It
+    // spills into a second block when the remainder leaves no room for both.
+    let rest = chunks.remainder();
+    let mut tail = [0u8; 128];
+    tail[..rest.len()].copy_from_slice(rest);
+    tail[rest.len()] = 0x80;
+    let tail_len = if rest.len() + 1 + 8 <= 64 { 64 } else { 128 };
+    tail[tail_len - 8..tail_len].copy_from_slice(&bit_len.to_be_bytes());
+    for block in tail[..tail_len].chunks_exact(64) {
+        compress(&mut h, block);
+    }
+
+    let mut out = [0u8; 20];
+    for (slot, word) in out.chunks_exact_mut(4).zip(h.iter()) {
+        slot.copy_from_slice(&word.to_be_bytes());
+    }
+    out
+}
+
+/// The SHA-1 digest of `data` as 40 uppercase hex digits — the shape nqp's
+/// `sha1` op returns.
+pub(crate) fn sha1_hex_uppercase(data: &[u8]) -> String {
+    let mut out = String::with_capacity(40);
+    for byte in sha1_digest(data) {
+        out.push(hex_upper(byte >> 4));
+        out.push(hex_upper(byte & 0x0F));
+    }
+    out
+}
+
+fn hex_upper(nibble: u8) -> char {
+    match nibble {
+        0..=9 => (b'0' + nibble) as char,
+        _ => (b'A' + nibble - 10) as char,
+    }
+}
+
+/// One 64-byte block through the compression function. `block` is always
+/// exactly 64 bytes (both call sites feed it from `chunks_exact(64)`).
+fn compress(h: &mut [u32; 5], block: &[u8]) {
+    let mut w = [0u32; 80];
+    for (word, chunk) in w.iter_mut().zip(block.chunks_exact(4)) {
+        *word = u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+    }
+    for i in 16..80 {
+        w[i] = (w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]).rotate_left(1);
+    }
+
+    let (mut a, mut b, mut c, mut d, mut e) = (h[0], h[1], h[2], h[3], h[4]);
+    for (i, wi) in w.iter().enumerate() {
+        let (f, k) = match i {
+            0..=19 => ((b & c) | (!b & d), 0x5A82_7999u32),
+            20..=39 => (b ^ c ^ d, 0x6ED9_EBA1),
+            40..=59 => ((b & c) | (b & d) | (c & d), 0x8F1B_BCDC),
+            _ => (b ^ c ^ d, 0xCA62_C1D6),
+        };
+        let temp = a
+            .rotate_left(5)
+            .wrapping_add(f)
+            .wrapping_add(e)
+            .wrapping_add(k)
+            .wrapping_add(*wi);
+        e = d;
+        d = c;
+        c = b.rotate_left(30);
+        b = a;
+        a = temp;
+    }
+
+    h[0] = h[0].wrapping_add(a);
+    h[1] = h[1].wrapping_add(b);
+    h[2] = h[2].wrapping_add(c);
+    h[3] = h[3].wrapping_add(d);
+    h[4] = h[4].wrapping_add(e);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sha1_hex_uppercase;
+
+    fn hex(s: &str) -> String {
+        sha1_hex_uppercase(s.as_bytes())
+    }
+
+    #[test]
+    fn nist_vectors() {
+        assert_eq!(hex(""), "DA39A3EE5E6B4B0D3255BFEF95601890AFD80709");
+        assert_eq!(hex("abc"), "A9993E364706816ABA3E25717850C26C9CD0D89D");
+        assert_eq!(
+            hex("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"),
+            "84983E441C3BD26EBAAE4AA1F95129E5E54670F1"
+        );
+    }
+
+    #[test]
+    fn padding_block_boundaries() {
+        // 55 bytes: length still fits in the first block. 56 and 64: it does
+        // not, so padding spills into a second block.
+        assert_eq!(
+            hex(&"a".repeat(55)),
+            "C1C8BBDC22796E28C0E15163D20899B65621D65A"
+        );
+        assert_eq!(
+            hex(&"a".repeat(56)),
+            "C2DB330F6083854C99D4B5BFB6E8F29F201BE699"
+        );
+        assert_eq!(
+            hex(&"a".repeat(64)),
+            "0098BA824B5C16427BD7A1122A5A442A25EC644D"
+        );
+    }
+
+    #[test]
+    fn million_a_vector() {
+        assert_eq!(
+            hex(&"a".repeat(1_000_000)),
+            "34AA973CD4C4DAA4F61EEB2BDBAD27316534016F"
+        );
+    }
+
+    #[test]
+    fn hashes_utf8_bytes_not_codepoints() {
+        // nqp::sha1 digests the string's UTF-8 encoding.
+        assert_eq!(hex("日本語"), "C12140A0FFB4E56481B4FE0A7A25040C2EAFA9CA");
+        assert_eq!(hex("𝄞x"), "116693A63839D657C9461C06193DA339DFFF4EF3");
+    }
+}

--- a/src/runtime/builtins.rs
+++ b/src/runtime/builtins.rs
@@ -657,6 +657,19 @@ impl Interpreter {
                     .unwrap_or(-1);
                 Ok(Value::int(cp))
             }
+            // nqp::sha1($str): the SHA-1 digest of the string's UTF-8 encoding,
+            // as 40 uppercase hex digits. Needed by two components mutsu ships:
+            // the vendored zef (`Zef::Distribution.id` and the source-path
+            // computation) and bundled OpenSSL's `dll-resource()`.
+            "nqp::sha1" => {
+                let s = args
+                    .first()
+                    .map(|v| v.to_string_value())
+                    .unwrap_or_default();
+                Ok(Value::str(crate::builtins::sha1::sha1_hex_uppercase(
+                    s.as_bytes(),
+                )))
+            }
             // nqp::gethostname(): the system hostname as a native str. Used by
             // Sys::Hostname's `hostname` sub (`nqp::gethostname.subst(...)`).
             "nqp::gethostname" => Ok(Value::str(Self::hostname())),

--- a/t/nqp-sha1.t
+++ b/t/nqp-sha1.t
@@ -1,0 +1,47 @@
+use v6;
+use Test;
+use nqp;
+
+# nqp::sha1($str) returns the SHA-1 digest of the string's UTF-8 encoding as
+# 40 uppercase hex digits. Two components mutsu ships need it: the vendored
+# zef (`Zef::Distribution.id`, plus the source-path computation in
+# `Zef::CLI`'s `locate`) and bundled OpenSSL's `dll-resource()`.
+#
+# All expected digests below are the values rakudo's nqp::sha1 produces.
+
+plan 12;
+
+is nqp::sha1(""), 'DA39A3EE5E6B4B0D3255BFEF95601890AFD80709',
+    'the empty string';
+is nqp::sha1("abc"), 'A9993E364706816ABA3E25717850C26C9CD0D89D',
+    'the NIST "abc" vector';
+is nqp::sha1("hello"), 'AAF4C61DDCC5E8A2DABEDE0F3B482CD9AEA9434D',
+    'a short string';
+is nqp::sha1("The quick brown fox jumps over the lazy dog"),
+    '2FD4E1C67A2D28FCED849EE1BB76E7391B93EB12',
+    'a sentence';
+is nqp::sha1("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"),
+    '84983E441C3BD26EBAAE4AA1F95129E5E54670F1',
+    'the NIST 448-bit vector';
+
+# Padding edge cases: at 55 bytes the length still fits in the first block; at
+# 56 and 64 it does not, so the padding spills into a second block.
+is nqp::sha1("a" x 55), 'C1C8BBDC22796E28C0E15163D20899B65621D65A',
+    '55 bytes (padding fits in one block)';
+is nqp::sha1("a" x 56), 'C2DB330F6083854C99D4B5BFB6E8F29F201BE699',
+    '56 bytes (padding spills into a second block)';
+is nqp::sha1("a" x 64), '0098BA824B5C16427BD7A1122A5A442A25EC644D',
+    'exactly one block';
+is nqp::sha1("a" x 1000), '291E9A6C66994949B57BA5E650361E98FC36B1BA',
+    'a multi-block message';
+
+# Non-ASCII hashes the UTF-8 bytes, not the codepoints.
+is nqp::sha1("日本語"), 'C12140A0FFB4E56481B4FE0A7A25040C2EAFA9CA',
+    'a non-ASCII string hashes its UTF-8 encoding';
+is nqp::sha1("\x[1D11E]x"), '116693A63839D657C9461C06193DA339DFFF4EF3',
+    'including astral codepoints';
+
+# The result is a plain Str, which is what callers concatenate and use as a
+# path component (`$curi.prefix.child('sources').child($lib-sha1)`).
+ok nqp::sha1("hello") ~~ Str && nqp::sha1("hello").chars == 40,
+    'the digest is a 40-character Str';

--- a/todo/tickets/nqp-op-aliasing-and-sha1.md
+++ b/todo/tickets/nqp-op-aliasing-and-sha1.md
@@ -1,4 +1,9 @@
-# `nqp::` leftovers: `nqp::sha1` blocks vendored zef, and qualified calls still alias builtins
+# `nqp::` leftovers: a qualified call still aliases a builtin
+
+**Status: the `nqp::sha1` half is done** (news/2026-07/nqp-sha1.md). What
+remains open in this file is "Open 2" at the bottom — the package-prefix strip
+outside `nqp::`. The measurements are kept because they are the reason not to
+build an `nqp::` op layer.
 
 Supersedes `todo/deep/nqp-op-layer-missing.md`, whose framing ("build an `nqp::`
 op layer, ~53 ops missing, needs an ADR") did not survive measurement. What
@@ -49,9 +54,12 @@ yields **-1** — a silent wrong answer, and nqp code branches on exactly that
 `Unsupported nqp:: op: nqp::<name>`. Pinned by
 `t/nqp-unimplemented-op-errors.t`.
 
-## Open 1 — `nqp::sha1` is needed by TWO things we already ship
+## Done — `nqp::sha1` (was Open 1)
 
-This is the one *real* demand found, and it is entirely in our own tree:
+Implemented 2026-07-26: `src/builtins/sha1.rs` (in-tree SHA-1, no new crate)
+wired as the `nqp::sha1` builtin arm beside `nqp::ordat`. Pinned by
+`t/nqp-sha1.t`, which passes unchanged under rakudo too. Write-up:
+news/2026-07/nqp-sha1.md. The demand it served, for the record:
 
 ```
 vendor/zef/lib/Zef/Distribution.rakumod:230       return nqp::sha1(self.Str);
@@ -65,15 +73,9 @@ modules/OpenSSL/lib/OpenSSL/NativeLib.rakumod:33  my $content-id = nqp::sha1($re
   unmangled copy under `$*TMPDIR`. `use OpenSSL` succeeds today only because that
   sub is not called at load time.
 
-mutsu has no SHA-1 at all — nothing in tree and no `sha`/`digest` crate in
-`Cargo.toml` — so this needs either ~60 lines of SHA-1 or a dependency, then
-wiring `nqp::sha1` as a full-name builtin beside `nqp::ordat` /
-`nqp::gethostname` / `nqp::bindattr`.
-
-Small, self-contained, and unblocks a north-star path in code we already ship.
-**Best next `nqp::` work by far** — and note the contrast: the "obvious" target
-(`JSON::Fast`, 42 ops) would unlock nothing, while this one op unblocks two
-shipped components.
+Note the contrast that made this the right pick: the "obvious" target
+(`JSON::Fast`, 42 ops) would have unlocked nothing, while this one op serves two
+components we already ship.
 
 ## Which bundled modules exist, and why (measured 2026-07-26)
 


### PR DESCRIPTION
mutsu had no SHA-1 anywhere — nothing in tree and no `sha`/`digest` crate in `Cargo.toml`. That made `nqp::sha1` the single unimplemented `nqp::` op with real demand **inside our own tree**, measured while deciding whether to build an `nqp::` op layer at all (the answer was no — `todo/tickets/nqp-op-aliasing-and-sha1.md`):

- **vendored zef** — `Zef::Distribution.id` is `nqp::sha1(self.Str)`, and `Zef::CLI`'s `locate` derives installed-source paths from it. That is the mzef critical path.
- **bundled `modules/OpenSSL`** — `dll-resource()` hashes a resource name to find its unmangled copy under `$*TMPDIR`. `use OpenSSL` worked only because that sub is never called at load time.

Both would have hit `Unsupported nqp:: op: nqp::sha1` — the error added in #5450, which replaced the worse outcome of silently aliasing a Raku builtin.

## What landed

`src/builtins/sha1.rs` implements FIPS 180-4 SHA-1 with **no new dependency**: a crate would have meant an optional-dependency matrix across the `native`/`wasm` feature split for one fixed, tiny algorithm. `sha1_digest` returns the 20 raw bytes; `sha1_hex_uppercase` formats the 40 uppercase hex digits nqp's op yields.

The op itself is one arm beside `nqp::ordat` / `nqp::gethostname` / `nqp::bindattr`, matched under its full `nqp::` name so it is reached before the unimplemented-op guard. It digests the string's **UTF-8 encoding**, not its codepoints, as rakudo does.

## Verification

Checked against the real consumer, not just vectors — building a `Zef::Distribution` and asking for `.id` gives byte-identical results:

```
$ mutsu -I vendor/zef/lib tmp/zef-dist-id.raku
Foo::Bar:ver<1.2.3>:auth<zef:someone>:api<1>
8BB1CD1A566589A4514F3C562490D45DB20BDBAB
$ raku  -I vendor/zef/lib tmp/zef-dist-id.raku      # identical
```

Four Rust unit tests carry the NIST vectors (`""`, `"abc"`, the 448-bit message, a million `a`), the padding block boundaries (55 / 56 / 64 bytes — where the length field does and does not fit in the first block), and the UTF-8 property. `t/nqp-sha1.t` (12 subtests) pins the op end to end and **passes unchanged under rakudo**, so it is a differential test rather than a record of mutsu's own output.

`make test`: 2482 files, 23664 tests, Result: PASS.

## Docs

`news/2026-07/nqp-sha1.md` added; the ticket's Open 1 is marked Done (its Open 2 — a qualified call outside `nqp::` still falling back to a builtin — stays open), and PLAN.md's dist-sweep entry updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)