### PR TITLE
fix: a package-qualified call no longer silently becomes a builtin

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -339,7 +339,7 @@ sessions).
       blocked the vendored zef install path** (`Zef::Distribution.id`) — now
       implemented (news/2026-07/nqp-sha1.md); `Zef::Distribution.id` matches
       rakudo's digest exactly. Details and the measurements:
-      `todo/tickets/nqp-op-aliasing-and-sha1.md`. The other four
+      `news/2026-07/nqp-op-layer-measured-and-rejected.md`. The other four
       were **mis-classified**, each verified against `raku -I lib`:
       `PDF::Class` and `Qwiratry::Test` merely lack an uninstalled dependency
       (`PDF::COS`, `Qwiratry::Query::Slang` — raku cannot load them here either),

--- a/news/2026-07/nqp-op-layer-measured-and-rejected.md
+++ b/news/2026-07/nqp-op-layer-measured-and-rejected.md
@@ -1,13 +1,15 @@
-# `nqp::` leftovers: a qualified call still aliases a builtin
+# An `nqp::` op layer, measured and rejected — and the three fixes that closed the question
 
-**Status: the `nqp::sha1` half is done** (news/2026-07/nqp-sha1.md). What
-remains open in this file is "Open 2" at the bottom — the package-prefix strip
-outside `nqp::`. The measurements are kept because they are the reason not to
-build an `nqp::` op layer.
+This started as `todo/deep/nqp-op-layer-missing.md`, whose framing ("build an
+`nqp::` op layer, ~53 ops missing, needs an ADR") did not survive measurement.
+What follows is what was actually measured on 2026-07-26, the conclusion it
+forced, and the three changes that closed every item it opened:
 
-Supersedes `todo/deep/nqp-op-layer-missing.md`, whose framing ("build an `nqp::`
-op layer, ~53 ops missing, needs an ADR") did not survive measurement. What
-follows is what was actually measured on 2026-07-26.
+- **`nqp::sha1` implemented** — news/2026-07/nqp-sha1.md
+- **an unimplemented `nqp::` op errors instead of aliasing a builtin** —
+  news/2026-07/nqp-unimplemented-op-errors.md
+- **a package-qualified call no longer becomes a builtin** (the wider shape) —
+  news/2026-07/qualified-call-no-longer-aliases-a-builtin.md
 
 ## Measured: how big is the `nqp::` question, really
 
@@ -94,22 +96,15 @@ Useful context for anyone weighing "bundle vs implement":
   native for unrelated reasons — the data they work on is already an internal
   representation.
 
-## Open 2 — a qualified call still falls back to a builtin (wider than nqp)
+## Done — a qualified call falling back to a builtin (was Open 2)
 
-Same mechanism, outside `nqp::`:
-
-```raku
-say Foo::Bar::index("hello", "l");
-# raku:  Could not find symbol '&index' in 'GLOBAL::Foo::Bar'
-# mutsu: 2
-```
-
-The short-name retry in `call_function_fallback` is load-bearing — it is how a
-call qualified with a package mutsu did not register still finds its routine — so
-narrowing it needs a measurement of what actually depends on it. Note the
-obvious guard does **not** work: `index` is dispatched by a hand-written arm in
-`call_function`, not via `BUILTIN_FUNCTION_NAMES`, so `is_builtin_function` does
-not recognise it. Deferred for that reason, not because it is unimportant.
+The same mechanism, outside `nqp::`: `Foo::Bar::index("hello", "l")` returned 2
+where raku says `Could not find symbol '&index' in 'GLOBAL::Foo::Bar'`. It was
+deferred once because the obvious guard does not work — `index` is dispatched by
+a hand-written arm of `call_function`, not via `BUILTIN_FUNCTION_NAMES`, so
+`is_builtin_function` misses it. The fix inverts the question and asks whether
+anything is *declared* under the short name instead; write-up in
+news/2026-07/qualified-call-no-longer-aliases-a-builtin.md.
 
 ## Files
 

--- a/news/2026-07/nqp-sha1.md
+++ b/news/2026-07/nqp-sha1.md
@@ -4,7 +4,7 @@ mutsu had no SHA-1 anywhere: nothing in tree, and no `sha`/`digest` crate in
 `Cargo.toml`. That made `nqp::sha1` the single unimplemented `nqp::` op with
 real demand inside our own tree — a demand measured, not guessed, while deciding
 whether to build an `nqp::` op layer at all (the answer was no; see
-`todo/tickets/nqp-op-aliasing-and-sha1.md`):
+`news/2026-07/nqp-op-layer-measured-and-rejected.md`):
 
 - **vendored zef** — `Zef::Distribution.id` is `nqp::sha1(self.Str)`, and
   `Zef::CLI`'s `locate` derives installed-source paths from it. That is the mzef

--- a/news/2026-07/nqp-unimplemented-op-errors.md
+++ b/news/2026-07/nqp-unimplemented-op-errors.md
@@ -28,7 +28,7 @@ The guard is deliberately scoped to `nqp::`. The same shape exists more widely â
 is load-bearing there, and the obvious guard does not work: `index` is dispatched
 by a hand-written arm in `call_function`, not via `BUILTIN_FUNCTION_NAMES`, so
 `is_builtin_function` does not even recognise it. That case is recorded in
-`todo/tickets/nqp-op-aliasing-and-sha1.md` rather than changed blind.
+`news/2026-07/nqp-op-layer-measured-and-rejected.md` rather than changed blind.
 
 ## Why this, and not an `nqp::` layer
 

--- a/news/2026-07/qualified-call-no-longer-aliases-a-builtin.md
+++ b/news/2026-07/qualified-call-no-longer-aliases-a-builtin.md
@@ -1,0 +1,66 @@
+# A package-qualified call no longer silently becomes a builtin
+
+`call_function_fallback` ended with a package-prefix strip: an unresolved
+`Foo::bar(…)` retried as `bar(…)`. That retry exists for a real reason — it is
+how a call qualified with a package mutsu never registered still finds its own
+routine — but it was unconditional, so the qualifier was simply discarded and
+the call landed on Raku's same-named builtin:
+
+```
+$ mutsu -e 'say Foo::Bar::index("hello", "l")'
+2                                    # raku: Could not find symbol '&index' in 'GLOBAL::Foo::Bar'
+$ mutsu -e 'use Test; Test::ok(1)'
+ok 1 -                               # really emitted a TAP assertion
+```
+
+This is the wider half of the shape fixed for `nqp::` in #5450: there the
+consequence was a silent wrong answer (`nqp::index` returning Raku's `Nil`
+instead of nqp's `-1`), here it is a call that should not have resolved at all.
+
+## The fix
+
+The strip now runs only when mutsu has something **declared** under the short
+name — a routine (proto, multi, wrap chain, `&name` in env, or a plain
+`resolve_function_with_alias` hit), or a class/role/subset/enum for the
+`Foo::Bar("x")` coercion leg. Otherwise the call fails the way raku fails it.
+
+The guard deliberately asks *"is something declared here"* rather than *"is this
+a builtin"*. The builtin question has no reliable answer: `index` is dispatched
+by a hand-written arm of `call_function` and is not in `BUILTIN_FUNCTION_NAMES`,
+so `is_builtin_function` misses it — which is exactly why the earlier `nqp::`
+fix could not simply be generalised, and why this ticket stayed open.
+
+The error mirrors rakudo's, including the parts that are not obvious:
+
+| program | message |
+| --- | --- |
+| `Foo::Bar::index("hello","l")` | `Could not find symbol '&index' in 'GLOBAL::Foo::Bar'` |
+| `module M { }; M::nope()` | `Could not find symbol '&nope' in 'M'` |
+| `GLOBAL::index("hello","l")` | `Could not find symbol 'index' in 'GLOBAL'` |
+| `module Foo {…}; GLOBAL::Foo::f()` | `Could not find symbol 'f' in 'Foo'` |
+
+A package raku knows is named bare; one it has never seen is reported under
+`GLOBAL::`. An explicitly written `GLOBAL::` qualifier resolves through the
+pseudo-package, and raku then drops the `&` sigil from the symbol — all four
+rows above were read off rakudo, and mutsu now reproduces them exactly.
+
+## What is deliberately unchanged
+
+- **The coercion leg.** `class Bar {…}; Foo::Bar("x")` still coerces, where raku
+  says "Could not find symbol '&Bar' in 'GLOBAL::Foo'". mutsu registers some
+  imported and nested classes under their short name only, so the strip is
+  load-bearing for types in a way it is not for routines.
+- **A builtin still wins over a user routine reached through the strip.**
+  `sub index($a,$b) {99}; M::index("hello","l")` gives 2, not 99: the retry goes
+  through `call_function`, whose builtin arm is hit before the fallback's user
+  resolution. That is the pre-existing builtin-shadow ordering, not this change;
+  raku rejects the whole program anyway (`M` is not a package).
+
+## Verification
+
+`t/qualified-call-does-not-alias-builtin.t` (11 subtests) pins both directions:
+the six error shapes above, and the regression guards that the strip still
+resolves what it exists for — a qualified `our sub`, one two package levels
+deep, a qualified multi, and a qualified call reached through `EVAL`. It
+**passes unchanged under rakudo**, so it is a differential test rather than a
+record of mutsu's own output.

--- a/src/runtime/builtins_operators_fallback.rs
+++ b/src/runtime/builtins_operators_fallback.rs
@@ -932,12 +932,22 @@ impl Interpreter {
             )));
         }
 
-        // Try stripping the package prefix (e.g. "Main::foo" -> "foo"). This is
-        // how a call qualified with a package mutsu did not register still finds
-        // its routine.
+        // A qualified call retries under its short name (`Main::foo` -> `foo`) —
+        // that is how a call qualified with a package mutsu did not register
+        // still finds its routine.
+        //
+        // The retry only makes sense when mutsu has *something declared* under
+        // the short name. Retrying unconditionally meant a qualified call landed
+        // on Raku's same-named builtin: `Foo::Bar::index("hello", "l")` returned
+        // 2, and `Test::ok(1)` ran the TAP routine, where raku says "Could not
+        // find symbol '&index' in 'GLOBAL::Foo::Bar'". A package qualifier is
+        // not a decoration to be discarded.
         if let Some(pos) = name.rfind("::") {
             let short_name = &name[pos + 2..];
-            return self.call_function(short_name, args.to_vec());
+            if self.qualified_retry_resolves(short_name, args) {
+                return self.call_function(short_name, args.to_vec());
+            }
+            return Err(self.no_such_qualified_symbol(&name[..pos], short_name));
         }
 
         // NativeCall's `explicitly-manage($str)` marks a value's C-side buffer
@@ -961,6 +971,70 @@ impl Interpreter {
             name,
             format!("Unknown function: {}", name),
             suggestions,
+        ))
+    }
+
+    /// Does mutsu have anything *declared* under a qualified call's short name?
+    /// This gates the package-prefix strip: the strip exists so that a call
+    /// qualified with a package mutsu never registered still finds its own
+    /// routine, not so that any qualifier can be dropped to reach a builtin.
+    ///
+    /// Deliberately asks "is something declared here" rather than "is this a
+    /// builtin": the builtin question has no reliable answer, because names like
+    /// `index` are dispatched by a hand-written arm of `call_function` and are
+    /// not in `BUILTIN_FUNCTION_NAMES`, so `is_builtin_function` misses them.
+    fn qualified_retry_resolves(&mut self, short_name: &str, args: &[Value]) -> bool {
+        if self.resolve_proto_function_with_alias(short_name).is_some()
+            || self.has_multi_candidates(short_name)
+            || self.wrap_sub_id_for_name(short_name).is_some()
+            || self.env.get(&format!("&{short_name}")).is_some()
+        {
+            return true;
+        }
+        if self.resolve_function_with_alias(short_name, args).is_some() {
+            return true;
+        }
+        // A routine that exists but whose candidates did not match left a
+        // pending dispatch error. Let the retry run so that error is what the
+        // caller sees, rather than "no such symbol".
+        if self.pending_dispatch_error.is_some() {
+            return true;
+        }
+        // The strip also carries type coercion (`Foo::Bar("x")`) when mutsu
+        // registered the class only under its short name.
+        self.has_class(short_name)
+            || self.has_role(short_name)
+            || self.registry().subsets.contains_key(short_name)
+            || self.registry().enum_types.contains_key(short_name)
+    }
+
+    /// raku's error for a qualified call whose short name resolves to nothing:
+    /// `Could not find symbol '&index' in 'GLOBAL::Foo::Bar'` (an `X::AdHoc`).
+    /// A package raku knows about is named bare — `class C {}; C::foo()` says
+    /// `in 'C'` — while one it has never seen is reported under `GLOBAL::`.
+    fn no_such_qualified_symbol(&self, package: &str, short_name: &str) -> RuntimeError {
+        // An explicitly written `GLOBAL::` qualifier resolves through the
+        // pseudo-package, and raku then names the symbol without its `&` sigil:
+        // `GLOBAL::index(…)` is "Could not find symbol 'index' in 'GLOBAL'",
+        // while `Foo::Bar::index(…)` is "'&index' in 'GLOBAL::Foo::Bar'".
+        let (package, sigil) = match package.strip_prefix("GLOBAL::") {
+            Some(rest) => (rest, ""),
+            None if package == "GLOBAL" => ("", ""),
+            None => (package, "&"),
+        };
+        let known = self.has_class(package)
+            || self.has_role(package)
+            || self.registry().package_kinds.contains_key(package)
+            || self.registry().package_stubs.contains(package);
+        let qualified = if package.is_empty() {
+            "GLOBAL".to_string()
+        } else if known {
+            package.to_string()
+        } else {
+            format!("GLOBAL::{package}")
+        };
+        RuntimeError::new(format!(
+            "Could not find symbol '{sigil}{short_name}' in '{qualified}'"
         ))
     }
 }

--- a/t/nqp-unimplemented-op-errors.t
+++ b/t/nqp-unimplemented-op-errors.t
@@ -39,10 +39,14 @@ throws-like 'use nqp; nqp::substr("hello", 1, 3)', X::AdHoc,
     is M::f(), 42, 'a qualified user sub still resolves';
 }
 
-{
-    my $out = EVAL 'Foo::Bar::index("hello", "l")';
-    is $out, 2, 'a non-nqp qualified call still falls back to the short name';
-}
+# A non-`nqp` qualified call whose short name resolves to nothing fails too now
+# — it used to reach Raku's `index` and return 2
+# (news/2026-07/qualified-call-no-longer-aliases-a-builtin.md) — but it reports
+# raku's own error, not this file's nqp-specific one, so the guard above stays
+# scoped to `nqp::`.
+throws-like 'Foo::Bar::index("hello", "l")', X::AdHoc,
+    message => /"Could not find symbol '&index' in 'GLOBAL::Foo::Bar'"/,
+    'a non-nqp qualified call reports raku\'s error, not the nqp one';
 
 # `use nqp` itself stays a no-op pragma.
 {

--- a/t/qualified-call-does-not-alias-builtin.t
+++ b/t/qualified-call-does-not-alias-builtin.t
@@ -1,0 +1,78 @@
+use v6;
+use Test;
+
+# `call_function_fallback` ends with a package-prefix strip: an unresolved
+# `Foo::bar(…)` retries as `bar(…)`, which is how a call qualified with a
+# package mutsu never registered still finds its routine. Retrying
+# unconditionally meant the qualifier was simply discarded and the call landed
+# on Raku's same-named builtin — `Foo::Bar::index("hello", "l")` returned 2,
+# and `Test::ok(1)` really ran a TAP assertion — where raku says
+#
+#     Could not find symbol '&index' in 'GLOBAL::Foo::Bar'
+#
+# The strip now runs only when mutsu has something *declared* under the short
+# name. Every message below is the one rakudo produces for the same program.
+
+plan 11;
+
+throws-like 'Foo::Bar::index("hello", "l")', X::AdHoc,
+    message => /"Could not find symbol '&index' in 'GLOBAL::Foo::Bar'"/,
+    'a qualified call does not fall through to the same-named builtin';
+
+throws-like 'Foo::Bar::say("x")', X::AdHoc,
+    message => /"Could not find symbol '&say' in 'GLOBAL::Foo::Bar'"/,
+    'including builtins that would otherwise have produced output';
+
+# `Test` is loaded in this very file, and its routines are exported lexically —
+# so a package-qualified call must not reach them either.
+throws-like 'Test::ok(1)', X::AdHoc,
+    message => /"Could not find symbol '&ok' in '" .* "Test'"/,
+    'an exported routine is not reachable under its package name';
+
+# A package mutsu *does* know is named bare in the error, as raku names it.
+{
+    module M { }
+    throws-like 'M::nope()', X::AdHoc,
+        message => /"Could not find symbol '&nope' in 'M'"/,
+        'a known package is named without the GLOBAL:: prefix';
+}
+
+{
+    class C { }
+    throws-like 'C::foo()', X::AdHoc,
+        message => /"Could not find symbol '&foo' in 'C'"/,
+        'and so is a class';
+}
+
+# An explicitly written `GLOBAL::` qualifier resolves through the pseudo-package,
+# and raku then names the symbol without its `&` sigil.
+throws-like 'GLOBAL::index("hello", "l")', X::AdHoc,
+    message => /"Could not find symbol 'index' in 'GLOBAL'"/,
+    'GLOBAL::<builtin> is not the builtin either';
+
+throws-like 'GLOBAL::Foo::bar()', X::AdHoc,
+    message => /"Could not find symbol 'bar' in 'GLOBAL::Foo'"/,
+    'a GLOBAL::-qualified unknown package keeps the rest of the qualifier';
+
+# Regression guards: the strip is load-bearing and must keep resolving what it
+# was there for.
+{
+    module M2 { our sub f() { 42 } }
+    is M2::f(), 42, 'a qualified user sub still resolves';
+}
+
+{
+    module Outer { module Inner { our sub g($x) { $x * 2 } } }
+    is Outer::Inner::g(21), 42, 'through more than one package level';
+}
+
+{
+    module M3 { our proto p(|) {*}; our multi p(Int $x) { "int" }; our multi p(Str $x) { "str" } }
+    is M3::p("x"), 'str', 'a qualified multi still dispatches';
+}
+
+{
+    module M4 { our sub h() { 7 } }
+    my $name = 'M4::h';
+    is EVAL($name ~ '()'), 7, 'and still resolves when reached through EVAL';
+}

--- a/todo/tickets/bundle-json-tiny-instead-of-emulating.md
+++ b/todo/tickets/bundle-json-tiny-instead-of-emulating.md
@@ -80,7 +80,7 @@ functions at all. And per dist this is a **threshold function** — implementing
 Weigh that against what it buys: `JSON::Fast` carries 1439 reverse-deps (12.6% of
 all ecosystem dependency weight), but mutsu **already answers `use JSON::Fast`
 natively**, so implementing the 42 ops would change nothing a user can observe.
-See `todo/tickets/nqp-op-aliasing-and-sha1.md` for the full measurement and the
+See `news/2026-07/nqp-op-layer-measured-and-rejected.md` for the full measurement and the
 conclusion that bundling/emulating the few nqp-heavy hubs is the cheaper
 strategy.
 

--- a/todo/tickets/package-named-after-a-quote-language.md
+++ b/todo/tickets/package-named-after-a-quote-language.md
@@ -1,0 +1,50 @@
+# A package named `Q` / `q` / `qq` / `m` is parsed as a quoting construct
+
+Found 2026-07-26 while probing qualified calls (`Foo::bar()`); unrelated to that
+work, and it predates it.
+
+Raku lets a package be named after a quote language — `Q`, `q`, `qq`, `m` are
+ordinary identifiers in name position. mutsu's parser takes them as the start of
+a quoting construct instead, so the declaration and/or the qualified call blows
+up:
+
+```
+$ mutsu -e 'module Q { our sub f() { 1 } }; say Q::f()'
+Two terms in a row              # raku: 1
+
+$ mutsu -e 'module q  { our sub f() { 1 } }; say q::f()'
+Two terms in a row              # raku: 1
+
+$ mutsu -e 'module qq { our sub f() { 1 } }; say qq::f()'
+Two terms in a row              # raku: 1
+
+$ mutsu -e 'module m  { our sub f() { 1 } }; say m::f()'
+Runtime error: Unsupported use of /f. In Raku please use: a Raku adverb.
+                                # raku: 1
+```
+
+`s`, `tr`, `rx`, `x`, `Z`, `X` are all fine, so this is specifically the
+`Q`/`q`/`qq` bracketing-quote family plus `m` (which fails at the *call* site,
+where `m::f()` is read as `m/…/`).
+
+Two distinct fixes, both about where the quote slang may start:
+
+1. **Name position after a declarator.** After `module` / `class` / `package` /
+   `role` / `grammar`, the next identifier is a package name; the quote slang
+   must not be entered there. That is what breaks `module Q { … }` — `Q {` is
+   read as a `Q`-quote with `{}` delimiters, which also explains the error
+   surfacing as "Two terms in a row" rather than a parse error at the keyword.
+2. **Identifier followed by `::`.** `m::f()` / `Q::f()` is a package-qualified
+   name; an identifier immediately followed by `::` is never a quote opener.
+
+Fix (2) is the smaller and more general of the two, and would also cover
+`my Q::Bar $x` and other name positions the declarator rule does not reach.
+
+Worth doing because the failure mode is silent-ish and confusing (the reported
+error names neither the package nor the real problem), and because `Q` is not an
+exotic name — `Q::…` appears in the wild as a short namespace.
+
+## Files
+
+- `src/parser/` — quote-construct entry (the `Q`/`q`/`qq`/`m` openers) and the
+  package-name parse after a declarator.


### PR DESCRIPTION
`call_function_fallback` ended with a package-prefix strip: an unresolved `Foo::bar(…)` retried as `bar(…)`. That retry exists for a real reason — it is how a call qualified with a package mutsu never registered still finds its own routine — but it was unconditional, so the qualifier was simply discarded and the call landed on Raku's same-named builtin:

```raku
say Foo::Bar::index("hello", "l");
# raku:  Could not find symbol '&index' in 'GLOBAL::Foo::Bar'
# mutsu: 2

use Test; Test::ok(1);      # really emitted a TAP assertion
```

This is the wider half of the shape fixed for `nqp::` in #5450, and the half that ticket **deferred**: the obvious guard does not work, because `index` is dispatched by a hand-written arm of `call_function` and is not in `BUILTIN_FUNCTION_NAMES`, so `is_builtin_function` misses it.

## The fix

Invert the question. The strip now runs only when mutsu has something **declared** under the short name — a routine (proto, multi, wrap chain, `&name` in env, or a plain `resolve_function_with_alias` hit), or a class/role/subset/enum for the `Foo::Bar("x")` coercion leg — and otherwise fails the way raku fails it. Asking *"is something declared here"* needs no reliable catalogue of builtins, which is exactly what made the earlier attempt impossible.

The error mirrors rakudo's, including the parts that are not obvious:

| program | message |
| --- | --- |
| `Foo::Bar::index("hello","l")` | `Could not find symbol '&index' in 'GLOBAL::Foo::Bar'` |
| `module M { }; M::nope()` | `Could not find symbol '&nope' in 'M'` |
| `GLOBAL::index("hello","l")` | `Could not find symbol 'index' in 'GLOBAL'` |
| `module Foo {…}; GLOBAL::Foo::f()` | `Could not find symbol 'f' in 'Foo'` |

A package raku knows is named bare; one it has never seen is reported under `GLOBAL::`; an explicitly written `GLOBAL::` qualifier resolves through the pseudo-package, and raku then drops the `&` sigil. All four rows were read off rakudo and are reproduced exactly.

## Deliberately unchanged

- **The coercion leg** — `class Bar {…}; Foo::Bar("x")` still coerces. mutsu registers some imported and nested classes under their short name only, so the strip is load-bearing for types in a way it is not for routines.
- **A builtin still wins over a user routine reached through the strip** (`sub index {…}; M::index(…)` → 2). Pre-existing ordering in the fallback; raku rejects that whole program anyway.

## Verification

`t/qualified-call-does-not-alias-builtin.t` (11 subtests) pins both directions — the six error shapes, plus regression guards that the strip still resolves a qualified `our sub`, one two package levels deep, a qualified multi, and a qualified call reached through `EVAL`. It **passes unchanged under rakudo**, so it is a differential test.

`t/nqp-unimplemented-op-errors.t` had pinned the *old* behaviour (a non-nqp qualified call returning 2, to prove the nqp guard stayed scoped); that subtest now asserts raku's error, keeping the same intent.

`make test`: 2484 files, 23684 tests, Result: PASS.

## Docs

With both halves done, `todo/tickets/nqp-op-aliasing-and-sha1.md` is closed and moves to `news/2026-07/nqp-op-layer-measured-and-rejected.md`, keeping the measurement that says not to build an `nqp::` op layer. New write-up: `news/2026-07/qualified-call-no-longer-aliases-a-builtin.md`.

Also files `todo/tickets/package-named-after-a-quote-language.md` — found while probing this and **confirmed to predate it**: `module Q { }` / `q` / `qq` / `m` are parsed as quoting constructs, so a package cannot be named after a quote language; raku accepts all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)