### PR TITLE
fix: sibling grammar inherits core Grammar, not a module-local `grammar Grammar`

### DIFF
--- a/news/2026-07/grammar-sibling-implicit-core-parent.md
+++ b/news/2026-07/grammar-sibling-implicit-core-parent.md
@@ -1,0 +1,33 @@
+# A sibling grammar's implicit parent is the core Grammar, not a module-local `grammar Grammar`
+
+A grammar declared with no explicit `is` clause always inherits the *core*
+`Grammar` Cursor. This holds even inside a `module` that also declares its own
+`grammar Grammar`: a second, sibling grammar in the same module must inherit the
+built-in Grammar, never the user grammar that merely happens to be named
+`Grammar`.
+
+mutsu got this wrong. `qualify_sibling_parent_name` rewrites a bare inheritance
+parent to a package-qualified sibling (`X` -> `M::X`) so that
+`class X::Decode is X` inside `module M` links to `M::X` rather than the built-in
+`X::` exception namespace. But it also rewrote the implicit `Grammar` parent the
+parser auto-adds to every grammar. Inside a module `M` that had already declared
+`grammar Grammar` (registered as `M::Grammar`), a later `grammar Schema` had its
+default `Grammar` parent qualified to `M::Grammar` and so inherited that user
+grammar's tokens, its `Actions` class, and — most damagingly — its `method parse`
+override. Calling `Schema.parse(...)` then re-dispatched through the main
+grammar's `parse` and reduced with the *wrong* Actions, so a scalar result came
+back wrapped/lost instead of the value `Schema`'s own `{ make ... }` produced.
+
+The fix excludes `Grammar` from `qualify_sibling_parent_name`: a bare `Grammar`
+parent stays the core Grammar. Direct references (`Grammar.parse`) still resolve
+to the module-local grammar via bare-word resolution, so the module-local shadow
+(the earlier "`grammar Grammar` in a module is a real grammar" fix) is intact —
+only the implicit inheritance parent is affected.
+
+This was the last blocker on the scalar path of the **YAMLish** battery: with
+the correct parent, `Schema::JSON` / `Schema::Core` stop inheriting the 780-line
+main `Grammar` and reduce their own element tokens, so
+`use YAMLish; load-yaml("42")` now yields `42` (previously `Any`). Block
+collections (sequences, maps) are a separate, still-open parsing frontier.
+
+Pins: `t/grammar-sibling-implicit-core-parent.t` (+ `t/lib/GrammarSiblingCore.rakumod`).

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -443,6 +443,19 @@ impl Interpreter {
         if parent.contains("::") || parent.contains('[') {
             return parent.to_string();
         }
+        // The `Grammar` metatype, when it appears as an inheritance parent, is the
+        // implicit default parent the parser auto-adds to every grammar. In Raku a
+        // grammar with no explicit `is` clause always inherits the *core* `Grammar`
+        // Cursor, even inside a `module M` that declares its own `grammar Grammar`
+        // (which qualifies to `M::Grammar`). Without this guard a sibling grammar
+        // like `grammar Schema::JSON` in the same module would qualify its default
+        // `Grammar` parent to `M::Grammar` and wrongly inherit that user grammar's
+        // tokens/actions/`parse` override (the YAMLish `Schema::*` reduce bug).
+        // Direct references (`Grammar.parse`) still resolve to the module-local
+        // grammar via bare-word resolution, so the module-local shadow is intact.
+        if parent == "Grammar" {
+            return parent.to_string();
+        }
         let pkg = self.current_package();
         if pkg.is_empty() || pkg == "GLOBAL" {
             return parent.to_string();

--- a/t/grammar-sibling-implicit-core-parent.t
+++ b/t/grammar-sibling-implicit-core-parent.t
@@ -1,0 +1,36 @@
+use v6;
+use Test;
+use lib 't/lib';
+use GrammarSiblingCore;
+
+# A grammar declared with no explicit `is` parent always inherits the *core*
+# `Grammar` Cursor, even inside a `unit module` that also declares its own
+# `grammar Grammar`. A sibling grammar in the same module must NOT pick up that
+# user grammar as its implicit parent (which would drag in its tokens, its
+# Actions class, and its `parse` override). This mirrors the YAMLish battery,
+# whose `grammar Schema::JSON {}` sits next to a 780-line `grammar Grammar` and
+# must reduce its own `{ make ... }` blocks, not the main grammar's.
+#
+# Before the fix, `qualify_sibling_parent_name` rewrote the implicit `Grammar`
+# parent of `Schema` to `GrammarSiblingCore::Grammar`, so `Schema.parse("42").ast`
+# came back `("MAIN-GRAMMAR-WRAPPED",)` (routed through the main grammar's
+# list-making `TOP`) instead of the `42` its own action produces.
+
+plan 5;
+
+is schema-parse("42"), 42,
+    'sibling grammar reduces its own action, not the module Grammar';
+
+my @mro = schema-mro();
+ok @mro.grep({ $_ eq 'Grammar' }),
+    'Schema inherits Grammar';
+ok @mro.grep({ $_ eq 'Match' }),
+    'Schema threads through core Grammar -> Match';
+ok @mro.grep({ $_ eq 'Cool' }),
+    'Schema threads through core Grammar -> Cool';
+
+# The module-local `grammar Grammar` is still usable directly (blocker #2 shadow
+# is intact): a reference inside the module resolves to the module grammar, which
+# wraps its result in a 1-list via its own TOP action.
+is-deeply main-parse("42"), ('MAIN-GRAMMAR-WRAPPED',),
+    'the module-local grammar Grammar still runs its own action';

--- a/t/lib/GrammarSiblingCore.rakumod
+++ b/t/lib/GrammarSiblingCore.rakumod
@@ -1,0 +1,33 @@
+unit module GrammarSiblingCore;
+
+# A module that declares its own `grammar Grammar` alongside a sibling grammar
+# with no explicit `is` parent. In Raku the sibling always inherits the *core*
+# `Grammar` Cursor, not this module-local `Grammar`. Mirrors the YAMLish battery
+# (`grammar Schema::JSON {}` next to a 780-line `grammar Grammar`).
+#
+# The main `Grammar` defines its own `method parse` that re-dispatches with an
+# Actions class whose `TOP` wraps the result in a 1-list. If a sibling grammar
+# wrongly inherits *this* grammar, `Sibling.parse` runs this `parse` + Actions
+# and the scalar result is wrapped/lost -- exactly the YAMLish `Schema` bug.
+
+grammar Grammar {
+    token TOP { <element> }
+    token element { \d+ }
+
+    class Actions {
+        method TOP($/) { make ('MAIN-GRAMMAR-WRAPPED',) }
+    }
+
+    method parse($string, *%args) {
+        nextwith($string, :actions(Actions), |%args);
+    }
+}
+
+grammar Schema {
+    token TOP { <element> { make $<element>.ast } }
+    token element { \d+ { make $/.Str.Int } }
+}
+
+our sub schema-parse($s) is export { Schema.parse($s).ast }
+our sub schema-mro() is export { Schema.^mro.map(*.^name).List }
+our sub main-parse($s) is export { Grammar.parse($s).ast }


### PR DESCRIPTION
## Summary

A grammar declared with no explicit `is` clause always inherits the **core** `Grammar` Cursor — even inside a `module` that also declares its own `grammar Grammar`. A second, sibling grammar in the same module must inherit the built-in Grammar, never the user grammar that merely happens to be named `Grammar`.

mutsu got this wrong. `qualify_sibling_parent_name` rewrites a bare inheritance parent to a package-qualified sibling (`X` → `M::X`) so `class X::Decode is X` inside `module M` links to `M::X`. But it also rewrote the implicit `Grammar` parent the parser auto-adds to every grammar. Inside a module that had already declared `grammar Grammar` (registered as `M::Grammar`), a later `grammar Schema` had its default `Grammar` parent qualified to `M::Grammar` and so inherited that user grammar's tokens, its `Actions` class, and its `method parse` override. `Schema.parse(...)` then re-dispatched through the main grammar's `parse` + wrong Actions, mangling the result.

## Fix

Exclude `Grammar` from `qualify_sibling_parent_name`: a bare `Grammar` parent stays the core Grammar. Direct references (`Grammar.parse`) still resolve to the module-local grammar via bare-word resolution, so the module-local shadow (the earlier "`grammar Grammar` in a module is a real grammar" fix, #2) is intact — only the implicit inheritance parent is affected.

## Impact

Last blocker on the scalar path of the **YAMLish** battery: `use YAMLish; load-yaml("42")` now yields `42` (previously `Any`). Block collections (sequences/maps) remain a separate open parsing frontier.

## Tests

- `t/grammar-sibling-implicit-core-parent.t` (+ `t/lib/GrammarSiblingCore.rakumod`) — reproduces via a `use`d `unit module`; fails on `main`, passes here, matches `raku` output exactly.
- Existing `t/grammar-named-grammar-in-module.t` (blocker #2 shadow) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)