### PR TITLE
fix: general `<?subrule>` / `<!subrule>` zero-width lookahead assertions

### DIFF
--- a/news/2026-07/regex-subrule-lookahead-assertion.md
+++ b/news/2026-07/regex-subrule-lookahead-assertion.md
@@ -1,0 +1,23 @@
+# `<?subrule>` / `<!subrule>` zero-width lookahead assertions
+
+Raku's `<?name>` / `<!name>` assertion is a zero-width lookahead: it asserts that
+the named subrule matches (or, negated, fails) at the current position without
+consuming any input. mutsu recognised only the *special* forms of this —
+`<?before …>`, `<?[…]>`, `<?alpha>` and the other builtin character classes,
+`<?wb>`, `<?same>`, `<?:Prop>`, `<?@var>` — but a general `<?userToken>` fell
+through to a literal-string match of `?userToken`, so the assertion never fired
+and the surrounding rule simply failed.
+
+Now any `<?name>` / `<!name>` whose `name` is an identifier-led subrule (with an
+optional leading `.` for a non-capturing call, and optional arguments) lowers to
+a `Lookaround` atom wrapping a `Named(subrule)` call — reusing the existing,
+well-tested lookaround matcher. Both the positive and negative forms are covered,
+and known character-class assertions (`<?alpha>` etc.) still resolve to the class
+as before.
+
+This was a blocker for the **YAMLish** battery's block collections: its
+`list-entry` token is `'-' <?break> …`, asserting a break (space/tab/newline)
+follows the dash before the element consumes it. Without the assertion the
+sequence never parsed.
+
+Pin: `t/regex-subrule-lookahead-assertion.t`.

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -126,6 +126,19 @@ fn scan_angle_assertion_body(rest: &[char], honor_quotes: bool) -> AngleBodyScan
     }
 }
 
+/// True when `s` (the text after the `?`/`!` prefix of a `<?…>` / `<!…>`
+/// assertion) names a subrule that a general zero-width lookahead can wrap: an
+/// identifier-led rule name, optionally prefixed with `.` for a non-capturing
+/// call (`<?.foo>`). Excludes the special forms already handled elsewhere —
+/// char classes (`[`), code blocks (`{`), Unicode props (`:`), variables
+/// (`$`/`@`), and empty bodies — so those never fall through to a subrule call.
+fn is_subrule_lookahead_name(s: &str) -> bool {
+    let s = s.strip_prefix('.').unwrap_or(s);
+    s.chars()
+        .next()
+        .is_some_and(|c| c.is_alphabetic() || c == '_')
+}
+
 impl Interpreter {
     /// Build the alternation atom for a `<@var>` array-variable subrule: look up
     /// the array variable named by `env_key` (including its `@` sigil) and
@@ -160,6 +173,45 @@ impl Interpreter {
             try_collapse_alternation_to_charclass(&alt_patterns)
                 .unwrap_or(RegexAtom::Alternation(alt_patterns)),
         )
+    }
+
+    /// Build a zero-width lookahead assertion wrapping a *named subrule* call:
+    /// `<?subrule>` / `<!subrule>`. The `subrule` string is the bare name (with
+    /// any args and an optional leading `.` for a non-capturing call) after the
+    /// `?`/`!` prefix has been stripped. This is the general twin of the special
+    /// `<?before ...>` / `<?[...]>` / `<?alpha>` forms: any other `<?name>` /
+    /// `<!name>` where `name` names a subrule is a zero-width assertion that the
+    /// subrule matches (or, negated, fails) at the current position. YAMLish's
+    /// grammar relies on it (`'-' <?break>` in `list-entry`).
+    fn subrule_lookaround_atom(
+        &self,
+        subrule: &str,
+        negated: bool,
+        ignore_case: bool,
+        ignore_mark: bool,
+    ) -> RegexAtom {
+        let inner_pattern = RegexPattern {
+            tokens: vec![RegexToken {
+                atom: RegexAtom::Named(subrule.to_string()),
+                quant: RegexQuant::One,
+                named_capture: None,
+                hash_capture: None,
+                secondary_named_capture: None,
+                force_list_capture: false,
+                ratchet: false,
+                frugal: false,
+                separator: None,
+            }],
+            anchor_start: false,
+            anchor_end: false,
+            ignore_case,
+            ignore_mark,
+        };
+        RegexAtom::Lookaround {
+            pattern: inner_pattern,
+            negated,
+            is_behind: false,
+        }
     }
 
     /// Owned-`RegexPattern` parse used by the parser's own recursion (sub-pattern
@@ -2105,7 +2157,18 @@ impl Interpreter {
                                                 | "ws"
                                                 | "ident"
                                         );
-                                        if is_known {
+                                        if !is_known && is_subrule_lookahead_name(negated_name) {
+                                            // <!subrule> — general zero-width *negative*
+                                            // lookahead of a named subrule (the twin of the
+                                            // positive `<?subrule>` below): assert the subrule
+                                            // does NOT match at the current position.
+                                            self.subrule_lookaround_atom(
+                                                negated_name,
+                                                true,
+                                                ignore_case,
+                                                ignore_mark,
+                                            )
+                                        } else if is_known {
                                             let inner_atom = if clean_name == "ident" {
                                                 RegexAtom::Group(RegexPattern {
                                                     tokens: vec![
@@ -2482,6 +2545,19 @@ impl Interpreter {
                                     } else {
                                         RegexAtom::Named(name)
                                     }
+                                } else if let Some(sub) = trimmed
+                                    .strip_prefix('?')
+                                    .filter(|s| is_subrule_lookahead_name(s))
+                                {
+                                    // <?subrule> — general zero-width positive lookahead of a
+                                    // named subrule (the twin of `<?before …>`/`<?alpha>` for
+                                    // any other rule name, e.g. YAMLish's `<?break>`).
+                                    self.subrule_lookaround_atom(
+                                        sub,
+                                        false,
+                                        ignore_case,
+                                        ignore_mark,
+                                    )
                                 } else {
                                     // Strip dot prefix for non-capturing named calls
                                     // <.alpha> is the same as <alpha> but without named capture

--- a/t/regex-subrule-lookahead-assertion.t
+++ b/t/regex-subrule-lookahead-assertion.t
@@ -1,0 +1,41 @@
+use v6;
+use Test;
+
+# `<?subrule>` / `<!subrule>` — a general zero-width lookahead assertion that a
+# named subrule matches (or, negated, does not match) at the current position.
+# This is the general twin of `<?before …>` / `<?[…]>` / `<?alpha>`; before the
+# fix only those special forms were recognised, so `<?break>` (as used by the
+# YAMLish grammar's `list-entry`: `'-' <?break> …`) fell through to a literal
+# string match and never asserted.
+
+plan 8;
+
+grammar P { token TOP { 'a' <?bee> \w }; token bee { 'b' } }
+ok  P.parse("ab").defined, 'positive <?bee> succeeds when bee matches ahead';
+nok P.parse("ax").defined, 'positive <?bee> fails when bee does not match ahead';
+
+grammar N { token TOP { 'a' <!bee> \w }; token bee { 'b' } }
+ok  N.parse("ax").defined, 'negative <!bee> succeeds when bee does not match ahead';
+nok N.parse("ab").defined, 'negative <!bee> fails when bee matches ahead';
+
+# A `<?subrule>` is zero-width: the following atom re-consumes from the same spot.
+grammar Dot { token TOP { 'a' <?.bee> \w }; token bee { 'b' } }
+ok Dot.parse("ab").defined, 'non-capturing <?.bee> works and is zero-width';
+
+# Subrule lookahead with an argument.
+grammar Arg { token TOP { 'a' <?letter('b')> \w }; token letter($c) { $c } }
+ok Arg.parse("ab").defined, 'parameterised subrule lookahead <?letter(...)>';
+
+# The YAMLish list-entry shape: `-` followed by a break (zero-width), then the
+# element consumes the space and the value.
+grammar Seq {
+    token TOP { <entry>+ % "\n" }
+    token entry { '-' <?break> <.sp> <[\d]>+ }
+    token break { " " | "\t" | "\n" }
+    token sp { " "* }
+}
+ok Seq.parse("- 1\n- 2").defined, 'list-entry style `- <?break> value` parses';
+
+# Known character-class assertions still resolve to the class, not a subrule.
+grammar Cls { token TOP { <?alpha> \w } }
+ok Cls.parse("q").defined, '<?alpha> still asserts the builtin class';


### PR DESCRIPTION
## Summary

Raku's `<?name>` / `<!name>` is a **zero-width lookahead** of a named subrule: it asserts the subrule matches (or, negated, fails) at the current position without consuming input. mutsu recognised only the *special* forms — `<?before …>`, `<?[…]>`, `<?alpha>` (and the other builtin classes), `<?wb>`, `<?same>`, `<?:Prop>`, `<?@var>` — but a general `<?userToken>` fell through to a **literal string match** of `?userToken`, so the assertion never fired and the surrounding rule just failed.

## Fix

Any `<?name>` / `<!name>` whose `name` is an identifier-led subrule (optional leading `.` for a non-capturing call, optional args) now lowers to a `Lookaround` atom wrapping a `Named(subrule)` call — reusing the existing, well-tested lookaround matcher. Both positive and negative forms are covered; known character-class assertions (`<?alpha>` etc.) still resolve to the class.

## Impact

Blocker for the **YAMLish** battery's block collections: its `list-entry` token is `'-' <?break> …`, asserting a break (space/tab/newline) follows the dash before the element consumes it. Without the assertion the sequence never parsed.

## Tests

- `t/regex-subrule-lookahead-assertion.t` — positive/negative/dot-prefixed/parameterised subrule lookaheads, a YAMLish-style `list-entry`, and a `<?alpha>` regression guard. Matches `raku` output exactly.
- Full `t/regex-*.t` + `t/grammar-*.t` suite (1006 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)