### PR TITLE
fix: a parenthesised `:ver(...)` declarator adverb is an expression

### DIFF
--- a/news/2026-07/computed-declarator-adverb.md
+++ b/news/2026-07/computed-declarator-adverb.md
@@ -1,0 +1,66 @@
+# A parenthesised `:ver(...)` declarator adverb is an expression
+
+`class C:ver(EXPR)` / `:auth(EXPR)` / `:api(EXPR)` stored **the source text of
+`EXPR`** as the metadata value instead of evaluating it. `class C:ver($v) { }`
+answered `Version.new('$v')`, and the shape that matters in the wild —
+
+```raku
+unit class DBDish::SQLite:ver($?DISTRIBUTION.meta<ver>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
+```
+
+— answered a `Version` built from the literal string
+`$?DISTRIBUTION.meta<ver>`. `unit class` was worse still: it parsed the adverbs
+and threw them away entirely, so `DBDish::SQLite.^ver` was `Mu`.
+
+That is the single remaining failure in `DBIish`'s two big SQLite files.
+`role DBDish::Driver` declares `has $.Version = ::?CLASS.^ver`, and
+`DBIish::CommonTesting` asserts `ok $drh.Version ~~ Version:D` — which cannot
+hold when `.^ver` is `Mu`.
+
+## Fix
+
+`parse_declarator_traits` now returns an `Expr` per adverb rather than a `Value`.
+The parenthesised form is parsed as a full expression (falling back to the old
+literal text if the expression parser cannot consume it whole, so nothing that
+used to parse stops parsing); the angle form `:ver<1.2.3>` stays a literal
+string, as its Raku semantics require. `meta_setter_stmt` passes the expression
+straight through to `__MUTSU_SET_META__`, so it is evaluated where the
+declaration sits.
+
+The `unit class` / `unit role` / `unit grammar` forms now emit those setters too.
+They come back from `unit_module_stmt` as a `Stmt::SyntheticBlock` — a
+*non-lexical* statement sequence, so the declaration keeps its compilation-unit
+scope — with the declaration itself last, which is the element `stmt_list`
+already reaches for when it absorbs the rest of the file into the declaration's
+body. `unit module` / `unit package` are deliberately left alone: several passes
+locate the compilation unit by scanning the top-level statements for
+`Stmt::Package { is_unit: true }`, and wrapping it would hide it from them.
+
+Two supporting corrections fell out of making the expression actually run:
+
+- **`Version.new(Any)` is a part-less `Version`, not `Version.new('(Any)')`.**
+  `version_from_value` stringified anything it did not recognise, so an
+  undefined argument produced a `Version` whose only part was the type object's
+  gist. raku answers a defined but empty `Version`, which is what
+  `:ver($?DISTRIBUTION.meta<ver>)` yields outside a distribution.
+- **A method call on a `Nil` *named* receiver absorbs to `Nil`.** raku's
+  `Nil.FALLBACK` makes `$?DISTRIBUTION.meta<ver>` safe when there is no
+  distribution. mutsu applied that verdict in the scalar `CallMethod` opcode and
+  in the hyper path (both via `nil_absorbs_method`) but not in `CallMethodMut`,
+  the opcode used when the receiver is a named variable — so
+  `$?DISTRIBUTION.meta` died with `No such method 'meta'`. Without this, making
+  the adverb evaluate would have turned a silently-wrong `.^ver` into a hard
+  failure for any module using the idiom from a directory with no `META6.json`.
+  `is_nil` is strictly `Nil`, so an uninitialised `Any` receiver still errors as
+  before.
+
+## Effect on `DBIish`
+
+`44-sqlite-memory` and `45-sqlite-common` go from one failing subtest each to
+**109/109** — a clean sweep, and one better than raku, whose remaining failure
+there is a `# TODO`-marked `rows()` capability check. With
+[the class-in-module fix](class-in-module-sees-module-subs.md) that puts mutsu at
+5 of the 9 `DBIish` files passing, up from 1.
+
+Pinned by `t/computed-declarator-adverb.t` (+ `t/lib/ComputedVerAdverb.rakumod`),
+14 tests, verified identical under raku.

--- a/news/2026-07/computed-declarator-adverb.md
+++ b/news/2026-07/computed-declarator-adverb.md
@@ -46,13 +46,23 @@ Two supporting corrections fell out of making the expression actually run:
 - **A method call on a `Nil` *named* receiver absorbs to `Nil`.** raku's
   `Nil.FALLBACK` makes `$?DISTRIBUTION.meta<ver>` safe when there is no
   distribution. mutsu applied that verdict in the scalar `CallMethod` opcode and
-  in the hyper path (both via `nil_absorbs_method`) but not in `CallMethodMut`,
-  the opcode used when the receiver is a named variable — so
-  `$?DISTRIBUTION.meta` died with `No such method 'meta'`. Without this, making
-  the adverb evaluate would have turned a silently-wrong `.^ver` into a hard
-  failure for any module using the idiom from a directory with no `META6.json`.
-  `is_nil` is strictly `Nil`, so an uninitialised `Any` receiver still errors as
-  before.
+  in the hyper path but not in `CallMethodMut`, the opcode used when the receiver
+  is a named variable — so `$?DISTRIBUTION.meta` died with
+  `No such method 'meta'`. Without this, making the adverb evaluate would have
+  turned a silently-wrong `.^ver` into a hard failure for any module using the
+  idiom from a directory with no `META6.json`. It is applied *after* normal
+  dispatch fails to find the method, not as a pre-dispatch shortcut: `Nil` really
+  does define control-flow and introspection methods (`&?BLOCK.leave` on a Nil
+  block), and short-circuiting those silently skipped them. Falling back on the
+  not-found error is what `FALLBACK` means. `is_nil` is strictly `Nil`, so an
+  uninitialised `Any` receiver still errors as before.
+- **An unresolved package-qualified `&Pkg::name` is `Any`, not `Nil`.** A package
+  symbol table with no such entry is a different thing from an explicitly absent
+  value, and the difference is observable exactly through the rule above:
+  `Any.assuming` raises `X::Method::NotFound` naming `assuming`, whereas `Nil`
+  absorbs it. `S32-exceptions/misc.t` asserts the former for `&A::b.assuming($a)`
+  — `b` is a *method*, so it is not among `A`'s `&`-symbols. Unqualified `&name`
+  still returns `Nil`; custom `EXPORT` routines probe it that way.
 
 ## Effect on `DBIish`
 

--- a/src/parser/stmt/class/class_decl.rs
+++ b/src/parser/stmt/class/class_decl.rs
@@ -11,7 +11,16 @@ use crate::parser::parse_result::{PError, PResult, opt_char, take_while1};
 use crate::parser::stmt::sub::parse_indirect_decl_name;
 use crate::parser::stmt::{block, keyword, qualified_ident};
 
-pub(crate) fn parse_declarator_traits(input: &str) -> PResult<'_, Vec<(String, Value)>> {
+/// Parse the `:ver<...>` / `:auth(...)` / `:api(...)` adverbs that follow a type
+/// name in its declarator.
+///
+/// The value is an `Expr`, not a `Value`, because the parenthesised form is a
+/// full expression that Raku evaluates at declaration time — `unit class
+/// DBDish::SQLite:ver($?DISTRIBUTION.meta<ver>)` is a real declaration in the
+/// wild. Storing the source text as a `Str` (which is what this used to do)
+/// made `DBDish::SQLite.^ver` answer `Version.new('$?DISTRIBUTION.meta<ver>')`.
+/// The angle form stays a literal string, as its Raku semantics require.
+pub(crate) fn parse_declarator_traits(input: &str) -> PResult<'_, Vec<(String, Expr)>> {
     let mut traits = Vec::new();
     let (mut rest, _) = ws(input)?;
     loop {
@@ -21,18 +30,24 @@ pub(crate) fn parse_declarator_traits(input: &str) -> PResult<'_, Vec<(String, V
         rest = &rest[1..];
         let (r, name) = take_while1(rest, |c: char| c.is_alphanumeric() || c == '_' || c == '-')?;
         rest = r;
-        let mut value = Value::TRUE;
+        let mut value = Expr::Literal(Value::TRUE);
         if let Some(inner) = rest.strip_prefix('<') {
             if let Some(end) = inner.find('>') {
-                value = Value::str(inner[..end].to_string());
+                value = Expr::Literal(Value::str(inner[..end].to_string()));
                 rest = &inner[end + 1..];
             } else {
                 return Err(PError::expected("closing '>' in trait value"));
             }
         } else if rest.starts_with('(') {
             let after = skip_balanced_parens(rest);
-            let body = &rest[1..rest.len() - after.len() - 1];
-            value = Value::str(body.trim().to_string());
+            let body = rest[1..rest.len() - after.len() - 1].trim();
+            // An empty `()` and anything the expression parser cannot consume
+            // whole keep the old literal-text behaviour rather than failing the
+            // whole declaration.
+            value = match expression(body) {
+                Ok((tail, expr)) if tail.trim().is_empty() => expr,
+                _ => Expr::Literal(Value::str(body.to_string())),
+            };
             rest = after;
         }
         traits.push((name.to_string(), value));
@@ -95,13 +110,13 @@ pub(crate) fn export_type_stmt(type_name: &str, tags: &[String]) -> Stmt {
     })
 }
 
-pub(crate) fn meta_setter_stmt(type_name: &str, key: &str, value: Value) -> Stmt {
+pub(crate) fn meta_setter_stmt(type_name: &str, key: &str, value: Expr) -> Stmt {
     Stmt::Expr(Expr::Call {
         name: Symbol::intern("__MUTSU_SET_META__"),
         args: vec![
             Expr::Literal(Value::str(type_name.to_string())),
             Expr::Literal(Value::str(key.to_string())),
-            Expr::Literal(value),
+            value,
         ],
     })
 }
@@ -452,16 +467,12 @@ pub(crate) fn class_decl_body(input: &str, is_lexical: bool) -> PResult<'_, Stmt
     });
     // Extract repr from `is repr(...)` or from declarator traits
     let repr = is_repr.or_else(|| {
-        traits.iter().find_map(|(k, v)| {
-            if k == "repr" {
-                if let ValueView::Str(s) = v.view() {
-                    Some(s.to_string())
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
+        traits.iter().find_map(|(k, v)| match v {
+            Expr::Literal(lit) if k == "repr" => match lit.view() {
+                ValueView::Str(s) => Some(s.to_string()),
+                _ => None,
+            },
+            _ => None,
         })
     });
     // Register the class name so the parser can disambiguate identifiers

--- a/src/parser/stmt/class/package_decl.rs
+++ b/src/parser/stmt/class/package_decl.rs
@@ -141,6 +141,32 @@ pub(crate) fn check_pseudo_package_in_decl(name: &str) -> Result<(), PError> {
     Ok(())
 }
 
+/// The `__MUTSU_SET_META__` calls for a declarator's `:ver`/`:auth`/`:api`
+/// adverbs. Other adverbs are not metadata and are dropped here, as they are in
+/// the block forms.
+fn decl_adverb_meta_stmts(name: &str, adverbs: Vec<(String, crate::ast::Expr)>) -> Vec<Stmt> {
+    adverbs
+        .into_iter()
+        .filter(|(k, _)| matches!(k.as_str(), "ver" | "auth" | "api"))
+        .map(|(k, v)| super::class_decl::meta_setter_stmt(name, &k, v))
+        .collect()
+}
+
+/// Pair a `unit class`/`unit role`/`unit grammar` declaration with the metadata
+/// setters its declarator adverbs produced. A `SyntheticBlock` is a non-lexical
+/// statement sequence, so the declaration keeps its compilation-unit scope; the
+/// declaration is always its *last* element, which is what `stmt_list` relies on
+/// when it absorbs the rest of the file into the declaration's body. Returns the
+/// bare declaration when there are no adverbs, so the overwhelmingly common
+/// shape is untouched.
+fn with_meta_stmts(mut meta_stmts: Vec<Stmt>, decl: Stmt) -> Stmt {
+    if meta_stmts.is_empty() {
+        return decl;
+    }
+    meta_stmts.push(decl);
+    Stmt::SyntheticBlock(meta_stmts)
+}
+
 /// Parse `unit module` or `unit class` statement.
 pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
     let rest = keyword("unit", input).ok_or_else(|| PError::expected("unit statement"))?;
@@ -151,9 +177,10 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
         let (r, _) = ws1(r)?;
         let (r, name) = qualified_ident(r)?;
         check_pseudo_package_in_decl(&name)?;
-        // Skip optional type adverbs (:ver<...>, :auth<...>, :api<...>)
-        let (r, _traits) = parse_declarator_traits(r)?;
+        // Optional type adverbs (:ver<...>, :auth<...>, :api<...>)
+        let (r, traits) = parse_declarator_traits(r)?;
         let (r, _) = ws(r)?;
+        let meta_stmts = decl_adverb_meta_stmts(&name, traits);
         // Parse `is Parent` and `does Role` clauses before the semicolon
         let mut parents = Vec::new();
         let mut does_parents = Vec::new();
@@ -223,22 +250,25 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
         let (r, _) = opt_char(r, ';');
         return Ok((
             r,
-            Stmt::ClassDecl {
-                name: Symbol::intern(&name),
-                name_expr: None,
-                parents,
-                class_is_rw,
-                is_hidden,
-                is_lexical: false,
-                hidden_parents,
-                does_parents,
-                repr: None,
-                body: Vec::new(),
-                language_version: super::super::simple::current_language_version(),
-                custom_traits: Vec::new(),
-                is_unit: true,
-                decl_id: crate::ast::next_class_decl_id(),
-            },
+            with_meta_stmts(
+                meta_stmts,
+                Stmt::ClassDecl {
+                    name: Symbol::intern(&name),
+                    name_expr: None,
+                    parents,
+                    class_is_rw,
+                    is_hidden,
+                    is_lexical: false,
+                    hidden_parents,
+                    does_parents,
+                    repr: None,
+                    body: Vec::new(),
+                    language_version: super::super::simple::current_language_version(),
+                    custom_traits: Vec::new(),
+                    is_unit: true,
+                    decl_id: crate::ast::next_class_decl_id(),
+                },
+            ),
         ));
     }
     // unit role Name;  — declare a role at the file scope.
@@ -250,8 +280,9 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
         let (mut r, (mut type_params, mut type_param_defs)) =
             super::role_decl::parse_optional_role_type_params(r)?;
         // Optional type adverbs (:ver<...>, :auth<...>, :api<...>).
-        let (r2, _adverbs) = parse_declarator_traits(r)?;
+        let (r2, adverbs) = parse_declarator_traits(r)?;
         let (r2, _) = ws(r2)?;
+        let meta_stmts = decl_adverb_meta_stmts(&name, adverbs);
         r = r2;
         // The signature may also FOLLOW the adverbs — the order Raku itself uses:
         // `unit role Algorithm::Treap:ver<0.10.3>:auth<zef:titsuki>[::KeyT];`.
@@ -326,17 +357,20 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
         }
         return Ok((
             r,
-            Stmt::RoleDecl {
-                name: Symbol::intern(&name),
-                type_params,
-                type_param_defs,
-                is_export,
-                export_tags,
-                body,
-                is_rw: role_is_rw,
-                language_version: super::super::simple::current_language_version(),
-                custom_traits,
-            },
+            with_meta_stmts(
+                meta_stmts,
+                Stmt::RoleDecl {
+                    name: Symbol::intern(&name),
+                    type_params,
+                    type_param_defs,
+                    is_export,
+                    export_tags,
+                    body,
+                    is_rw: role_is_rw,
+                    language_version: super::super::simple::current_language_version(),
+                    custom_traits,
+                },
+            ),
         ));
     }
     // unit grammar Name;  — declare a grammar at the file scope.
@@ -349,8 +383,9 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
         // on the grammar name before the `is`/`does` parent clauses, e.g.
         // `unit grammar Foo:ver<0.3.8> is Bar;`. Without this, the adverb blocks
         // the `is Bar` parent from being parsed (parent silently dropped).
-        let (r, _traits) = parse_declarator_traits(r)?;
+        let (r, traits) = parse_declarator_traits(r)?;
         let (r, _) = ws(r)?;
+        let meta_stmts = decl_adverb_meta_stmts(&name, traits);
         let mut r = r;
         let mut parents = Vec::new();
         let mut does_parents = Vec::new();
@@ -391,22 +426,25 @@ pub(crate) fn unit_module_stmt(input: &str) -> PResult<'_, Stmt> {
         super::super::simple::register_user_type(&name);
         return Ok((
             r,
-            Stmt::ClassDecl {
-                name: Symbol::intern(&name),
-                name_expr: None,
-                parents,
-                class_is_rw: false,
-                is_hidden: false,
-                is_lexical: false,
-                hidden_parents: vec![],
-                does_parents,
-                repr: None,
-                body: Vec::new(),
-                language_version: super::super::simple::current_language_version(),
-                custom_traits: Vec::new(),
-                is_unit: true,
-                decl_id: crate::ast::next_class_decl_id(),
-            },
+            with_meta_stmts(
+                meta_stmts,
+                Stmt::ClassDecl {
+                    name: Symbol::intern(&name),
+                    name_expr: None,
+                    parents,
+                    class_is_rw: false,
+                    is_hidden: false,
+                    is_lexical: false,
+                    hidden_parents: vec![],
+                    does_parents,
+                    repr: None,
+                    body: Vec::new(),
+                    language_version: super::super::simple::current_language_version(),
+                    custom_traits: Vec::new(),
+                    is_unit: true,
+                    decl_id: crate::ast::next_class_decl_id(),
+                },
+            ),
         ));
     }
     // Accept both `unit module Foo;` and `unit package Foo;`

--- a/src/parser/stmt/stmtlist.rs
+++ b/src/parser/stmt/stmtlist.rs
@@ -254,7 +254,18 @@ pub(crate) fn stmt_list_with_mode(
         // X::Attribute::NoPackage. (`unit module`/`unit package` are excluded:
         // the compiler keeps their package context for the rest of the scope.)
         if allow_mainline_capture && starts_unit_class_role_grammar(r) {
-            let (after_decl, mut decl) = class::unit_module_stmt(r)?;
+            let (after_decl, decl0) = class::unit_module_stmt(r)?;
+            // `unit class Foo:ver(...)` comes back as a non-lexical
+            // `SyntheticBlock` of `:ver`/`:auth`/`:api` metadata setters with the
+            // declaration itself last. Work on the declaration and re-emit the
+            // setters ahead of it.
+            let (mut meta_stmts, mut decl) = match decl0 {
+                Stmt::SyntheticBlock(mut inner) => {
+                    let decl = inner.pop().expect("declaration is the last element");
+                    (inner, decl)
+                }
+                other => (Vec::new(), other),
+            };
             let (tail_rest, mut tail_stmts) = stmt_list_with_mode(after_decl, false, emit_setline)?;
             match &mut decl {
                 Stmt::ClassDecl {
@@ -343,6 +354,7 @@ pub(crate) fn stmt_list_with_mode(
                 }
                 _ => {}
             }
+            stmts.append(&mut meta_stmts);
             stmts.push(decl);
             return Ok((tail_rest, stmts));
         }

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -190,6 +190,18 @@ impl Interpreter {
             ValueView::Num(f) if f.is_infinite() && f.is_sign_positive() => {
                 Value::version(vec![VersionPart::Whatever], false, false)
             }
+            // An undefined argument gives a part-less `Version.new`, like raku's
+            // `Version.new(Any)`. Stringifying the type object instead produced
+            // the nonsense `Version.new('(Any)')` -- reachable from a computed
+            // declarator adverb such as
+            // `unit class C:ver($?DISTRIBUTION.meta<ver>)` when there is no
+            // distribution.
+            ValueView::Nil => Value::version(Vec::new(), false, false),
+            ValueView::Package(name)
+                if matches!(name.resolve().as_str(), "Any" | "Mu" | "Nil" | "Version") =>
+            {
+                Value::version(Vec::new(), false, false)
+            }
             _ => {
                 let s = arg.to_string_value();
                 Self::version_from_value(Value::str(s))

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -1778,6 +1778,17 @@ impl Interpreter {
         } else {
             target
         };
+        // Nil absorbs a method it does not define (raku's `Nil.FALLBACK`), the
+        // same verdict the scalar `CallMethod` opcode and the hyper path reach
+        // via `nil_absorbs_method`. This opcode — a method call on a *named*
+        // receiver — never applied it, so `$?DISTRIBUTION.meta<ver>` outside a
+        // distribution died with "No such method 'meta'" where raku answers Nil.
+        // (`is_nil` is strictly `Nil`, so an uninitialised `Any` receiver still
+        // errors as before.)
+        if target.is_nil() && crate::vm::vm_call_method_ops::nil_absorbs_method(&method) {
+            self.stack.push(Value::NIL);
+            return Ok(());
+        }
         // For .* and .+ modifiers, skip the single-dispatch call and go
         // directly to the all-methods-in-MRO path to avoid double execution.
         match modifier {

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -372,6 +372,15 @@ impl Interpreter {
         quoted: bool,
         arg_sources_idx: Option<u32>,
     ) -> Result<(), RuntimeError> {
+        // Whether the receiver is `Nil`, read before the impl consumes the
+        // operands (the stack is `[.., target, args...]` here, so the target is
+        // `arity` slots below the top). Used for the Nil-absorb fallback below.
+        let receiver_is_nil = self
+            .stack
+            .len()
+            .checked_sub(arity as usize + 1)
+            .and_then(|i| self.stack.get(i))
+            .is_some_and(Value::is_nil);
         let result = self.exec_call_method_mut_op_impl(
             code,
             name_idx,
@@ -381,6 +390,26 @@ impl Interpreter {
             quoted,
             arg_sources_idx,
         );
+        // Nil absorbs a method it does not define (raku's `Nil.FALLBACK`), the
+        // same verdict the scalar `CallMethod` opcode and the hyper path reach.
+        // This opcode -- a method call on a *named* receiver -- never applied
+        // it, so `$?DISTRIBUTION.meta<ver>` outside a distribution died with
+        // "No such method 'meta'" where raku answers Nil.
+        //
+        // Applied only *after* normal dispatch fails to find the method, not as
+        // a pre-dispatch shortcut: `Nil` really does define control-flow and
+        // introspection methods (`&?BLOCK.leave` on a Nil block, the exception
+        // accessors), and short-circuiting those to Nil silently skipped them
+        // (S04-statements/leave.t, S32-exceptions/misc.t). Falling back on the
+        // not-found error is what `FALLBACK` means. `is_nil` is strictly `Nil`,
+        // so an uninitialised `Any` receiver still errors as before.
+        let result = match result {
+            Err(e) if receiver_is_nil && Self::is_method_not_found_error(&e) => {
+                self.stack.push(Value::NIL);
+                Ok(())
+            }
+            other => other,
+        };
         // The pending arg-source names/slots are scoped to THIS dispatch: a
         // callee signature bind consumes them, but a native/builtin dispatch
         // never binds and would leave them behind. A later bind with no
@@ -1778,17 +1807,6 @@ impl Interpreter {
         } else {
             target
         };
-        // Nil absorbs a method it does not define (raku's `Nil.FALLBACK`), the
-        // same verdict the scalar `CallMethod` opcode and the hyper path reach
-        // via `nil_absorbs_method`. This opcode — a method call on a *named*
-        // receiver — never applied it, so `$?DISTRIBUTION.meta<ver>` outside a
-        // distribution died with "No such method 'meta'" where raku answers Nil.
-        // (`is_nil` is strictly `Nil`, so an uninitialised `Any` receiver still
-        // errors as before.)
-        if target.is_nil() && crate::vm::vm_call_method_ops::nil_absorbs_method(&method) {
-            self.stack.push(Value::NIL);
-            return Ok(());
-        }
         // For .* and .+ modifiers, skip the single-dispatch call and go
         // directly to the all-methods-in-MRO path to avoid double execution.
         match modifier {

--- a/src/vm/vm_misc_codevar.rs
+++ b/src/vm/vm_misc_codevar.rs
@@ -88,6 +88,18 @@ impl Interpreter {
                 ));
             }
         }
+        // A package-qualified `&Pkg::name` that resolves to nothing is the `Any`
+        // type object in raku, not `Nil` — a package's symbol table simply has
+        // no such entry, which is a different thing from "explicitly absent".
+        // The distinction is observable through method dispatch: `Any.assuming`
+        // raises X::Method::NotFound naming `assuming`, whereas `Nil` absorbs
+        // any method it does not define (S32-exceptions/misc.t asserts the
+        // former for `&A::b.assuming($a)`, where `b` is a *method* and so is not
+        // in `A`'s `&`-symbols). Unqualified `&name` keeps returning Nil — custom
+        // `EXPORT` routines probe it that way.
+        if val.is_nil() && name.contains("::") {
+            val = Value::package(crate::symbol::Symbol::intern("Any"));
+        }
         self.stack.push(val);
         Ok(())
     }

--- a/t/computed-declarator-adverb.t
+++ b/t/computed-declarator-adverb.t
@@ -1,0 +1,48 @@
+use Test;
+
+# A parenthesised declarator adverb (`:ver(...)`, `:auth(...)`, `:api(...)`) is
+# an expression, not a literal. mutsu used to store its *source text*, so
+# `class C:ver($v) { }` answered `Version.new('$v')` and
+# `unit class DBDish::SQLite:ver($?DISTRIBUTION.meta<ver>)` answered
+# `Version.new('$?DISTRIBUTION.meta<ver>')` -- which is why `DBIish`'s
+# `ok $drh.Version ~~ Version:D` failed. The angle form stays a literal.
+
+plan 14;
+
+# The angle form is unchanged: a literal string, never an expression.
+class Angle:ver<1.2.3>:auth<zef:me>:api<7> { }
+is Angle.^ver, v1.2.3, ':ver<...> stays a literal version';
+is Angle.^auth, 'zef:me', ':auth<...> stays a literal string';
+is Angle.^api, '7', ':api<...> stays a literal string';
+
+# The paren form evaluates. (Only expressions that are already computable where
+# the declarator sits: raku evaluates the adverb at BEGIN time, so a runtime
+# `my $v` assigned later would be undefined there.)
+constant VER = '4.5.6';
+class Computed:ver(VER):auth('zef:' ~ 'you'):api(3 + 4) { }
+is Computed.^ver, v4.5.6, ':ver(EXPR) evaluates the expression';
+is Computed.^auth, 'zef:you', ':auth(EXPR) evaluates the expression';
+is Computed.^api, 7, ':api(EXPR) evaluates the expression';
+
+# An undefined result is a defined but part-less Version -- `Version.new(Any)`
+# in raku -- not a Version built from the type object's gist.
+class Undef:ver(Nil) { }
+ok Undef.^ver ~~ Version:D, ':ver(Nil) is still a defined Version';
+is Undef.^ver.parts.elems, 0, ':ver(Nil) has no parts';
+is Version.new(Any).raku, 'Version.new', 'Version.new(Any) is part-less';
+
+# A role takes the same adverbs.
+role RComputed:ver('2.0') { }
+is RComputed.^ver, v2.0, 'a role declarator adverb evaluates too';
+
+# The `unit class` form, which used to drop its adverbs entirely.
+use lib 't/lib';
+use ComputedVerAdverb;
+ok ComputedVerAdverb.^ver ~~ Version:D,
+    'unit class with a computed :ver has a defined Version';
+is ComputedVerAdverb.^api, 3, 'unit class :api(EXPR) evaluates';
+
+# The idiom the above rests on: with no distribution, `$?DISTRIBUTION` is Nil,
+# and Nil absorbs a method it does not define instead of throwing.
+is $?DISTRIBUTION.meta<ver>.raku, 'Nil', 'a method call on a Nil $?DISTRIBUTION absorbs to Nil';
+is ComputedVerAdverb.marker, 'ok', 'the unit class body still works';

--- a/t/lib/ComputedVerAdverb.rakumod
+++ b/t/lib/ComputedVerAdverb.rakumod
@@ -1,0 +1,9 @@
+unit class ComputedVerAdverb:ver($?DISTRIBUTION.meta<ver>):auth(join ':', 'zef', 'me'):api(1 + 2);
+
+# The `unit class` form of the computed declarator adverb, shaped after
+# `unit class DBDish::SQLite:ver($?DISTRIBUTION.meta<ver>):api(...):auth(...)`.
+# With no distribution behind `-I`, the `:ver` expression is undefined, which
+# must still yield a defined (part-less) Version rather than a Version built
+# from the source text.
+
+method marker() { 'ok' }

--- a/todo/tickets/dbiish-blockers.md
+++ b/todo/tickets/dbiish-blockers.md
@@ -30,28 +30,29 @@ mutsu $INC t/45-sqlite-common.rakutest
 `raku $INC …` passes one giant argument and every file "fails" under raku too —
 a bogus baseline that wastes a session.
 
-## Status: mutsu 3/9
+## Status: mutsu 6/9 (raku parity on 6 of the 9)
 
 Re-measured **2026-07-26** with `tmp/dbiish-survey.sh` (in this repo's `tmp/`,
 recreate it from the recipe above), debug build, both interpreters on the same
-`-I` line, **after ② was fixed**.
+`-I` line, **after ② and ⑥ were fixed**.
 
 | File | raku | mutsu | Blocker |
 | --- | --- | --- | --- |
 | `02-meta` | PASS 1/1 | **PASS 1/1** | — |
 | `46-sqlite-blob` | PASS 18/18 | **PASS 18/18** | — |
 | `48-sqlite-errors` | PASS 17/17 | **PASS 17/17** | — |
-| `03-lib-util` | 1 subtest fails | 1 fail of 5 | ⑥ same count as raku; confirm it is the *same* subtest |
-| `44-sqlite-memory` | 1 subtest fails* | 1 fail of 109 | ⑥ `.^ver` of a class declared `:ver(<expr>)` |
-| `45-sqlite-common` | 1 subtest fails* | 1 fail of 109 | ⑥ `.^ver` of a class declared `:ver(<expr>)` |
+| `44-sqlite-memory` | 1 fail of 109* | **PASS 109/109** | — |
+| `45-sqlite-common` | 1 fail of 109* | **PASS 109/109** | — |
+| `03-lib-util` | 1 fail of 5* | 1 fail of 5* | — (same subtest as raku) |
 | `01-basic` | PASS 35/35 | ran 0/35, dies | ③ `PackageHOW.method_table` |
 | `05-mock` | PASS 16/16 | 1 fail of 13 run | ④ `IterationEnd` from a row fetch, then `Too many positionals passed; expected 0 arguments but got 2` |
 | `06-types` | PASS 12/12 | 2 fail of 3 run | ⑤ `Int is builtin` / `So not defined`; mutsu suggests `Did you mean 'invert'?` |
 
-\* raku is not clean on `03-lib-util`, `44-` and `45-` either: one subtest each —
-but **not the same subtest as mutsu's**. raku's is test 52, a `# TODO`-marked
-`rows()` capability check; mutsu's is test 2, ⑥ below. Do not chase raku's — the
-achievable target is raku parity, not 109/109.
+\* Those raku failures are `# TODO`-marked and environment-dependent, not bugs:
+`03-lib-util` test 5 fails on both because `libpq` is not installed on the survey
+machine, and `44-`/`45-` test 52 is a `rows()` capability check raku itself marks
+`# TODO`. mutsu passes test 52. The achievable target is raku parity, not
+109/109 — six files are now there.
 
 **Nothing fails inside NativeCall**: the surface `OpenSSL` needs (CStruct,
 opaque pointers, callbacks) is strictly harder than SQLite's, and it is holding.
@@ -172,10 +173,12 @@ both implementations and is *not* the diagnosis. This exact trap already cost a
 session on `Template::Mustache`; get the real failing assertion before forming a
 theory.
 
-## ⑥ `.^ver` of a class declared with a computed `:ver(<expr>)` (`44-`, `45-`)
+## ⑥ `.^ver` of a class declared with a computed `:ver(<expr>)` — FIXED
 
-The one subtest each that mutsu still fails on `44-sqlite-memory` and
-`45-sqlite-common` is test 2 of `DBIish::CommonTesting`:
+Was the one subtest each that mutsu failed on `44-sqlite-memory` and
+`45-sqlite-common`; both now pass 109/109. Fixed — see
+[`news/2026-07/computed-declarator-adverb.md`](../../news/2026-07/computed-declarator-adverb.md).
+The failing assertion was test 2 of `DBIish::CommonTesting`:
 
 ```raku
 my $aversion = $drh.Version;
@@ -194,15 +197,13 @@ Note the plain `class A {}` case: raku's `A.^ver` really is `Mu`, so the fix is
 specifically "an explicit `:ver(<expr>)` always yields a `Version`", not "default
 `.^ver` to something defined".
 
-The actual defect is one level down: **mutsu does not evaluate the `:ver(...)`
-expression at all, it stores its source text.** `class C:ver($v) {}` gives
-`Version.new('$v')` and `class B:ver(Nil) {}` gives `Version.new('Nil')`, where
-raku evaluates both at declaration time (and yields `Version.new` for an
-undefined result). The storage site is `type_metadata[name]["ver"]`, read by
-`dispatch_classhow_method`'s `"ver"` arm in
-`src/runtime/methods_classhow_dispatch.rs`.
+The defect was one level down: **mutsu did not evaluate the `:ver(...)`
+expression at all, it stored its source text** — and the `unit class` form threw
+the adverbs away outright.
 
-Aside, seen in the same runs: `$*VM.config<nativecall_backend>` is missing, so
+## ⑦ `$*VM.config<nativecall_backend>` is missing
+
+Seen in every `DBIish` run: `$*VM.config<nativecall_backend>` is missing, so
 `NativeLibs`' `my \dyncall = $*VM.config<nativecall_backend> eq 'dyncall'` warns
 `Use of uninitialized value of type Any in string context` on every run that
 loads it. mutsu's `$*VM.config` has exactly two keys (`be`, `name`); raku answers


### PR DESCRIPTION
`class C:ver(EXPR)` / `:auth(EXPR)` / `:api(EXPR)` stored **the source text of
`EXPR`** as the metadata value instead of evaluating it. `class C:ver($v) { }`
answered `Version.new('$v')`, and the shape that matters in the wild —

```raku
unit class DBDish::SQLite:ver($?DISTRIBUTION.meta<ver>):api($?DISTRIBUTION.meta<api>):auth($?DISTRIBUTION.meta<auth>);
```

— answered a `Version` built from the literal string `$?DISTRIBUTION.meta<ver>`.
`unit class` was worse still: it parsed the adverbs and threw them away
entirely, so `DBDish::SQLite.^ver` was `Mu`.

That is the single remaining failure in `DBIish`'s two big SQLite files.
`role DBDish::Driver` declares `has $.Version = ::?CLASS.^ver`, and
`DBIish::CommonTesting` asserts `ok $drh.Version ~~ Version:D` — which cannot
hold when `.^ver` is `Mu`.

## Fix

`parse_declarator_traits` returns an `Expr` per adverb rather than a `Value`.
The parenthesised form is parsed as a full expression (falling back to the old
literal text if the expression parser cannot consume it whole, so nothing that
used to parse stops parsing); the angle form `:ver<1.2.3>` stays a literal
string, as its Raku semantics require. `meta_setter_stmt` passes the expression
straight through to `__MUTSU_SET_META__`, so it is evaluated where the
declaration sits.

The `unit class` / `unit role` / `unit grammar` forms now emit those setters too.
They come back from `unit_module_stmt` as a `Stmt::SyntheticBlock` — a
*non-lexical* statement sequence, so the declaration keeps its compilation-unit
scope — with the declaration itself last, which is the element `stmt_list`
already reaches for when it absorbs the rest of the file into the declaration's
body. **`unit module` / `unit package` are deliberately left alone**: several
passes locate the compilation unit by scanning the top-level statements for
`Stmt::Package { is_unit: true }`, and wrapping it would hide it from them.

Two supporting corrections fell out of making the expression actually run:

- **`Version.new(Any)` is a part-less `Version`, not `Version.new('(Any)')`.**
  `version_from_value` stringified anything it did not recognise, so an
  undefined argument produced a `Version` whose only part was the type object's
  gist. raku answers a defined but empty `Version`, which is what
  `:ver($?DISTRIBUTION.meta<ver>)` yields outside a distribution.
- **A method call on a `Nil` *named* receiver absorbs to `Nil`.** raku's
  `Nil.FALLBACK` makes `$?DISTRIBUTION.meta<ver>` safe when there is no
  distribution. mutsu applied that verdict in the scalar `CallMethod` opcode and
  in the hyper path (both via `nil_absorbs_method`) but not in `CallMethodMut`,
  the opcode used when the receiver is a named variable — so
  `$?DISTRIBUTION.meta` died with `No such method 'meta'`. Without this, making
  the adverb evaluate would have turned a silently-wrong `.^ver` into a hard
  failure for any module using the idiom from a directory with no `META6.json`.
  `is_nil` is strictly `Nil`, so an uninitialised `Any` receiver still errors as
  before.

## Effect on `DBIish`

`44-sqlite-memory` and `45-sqlite-common` go from one failing subtest each to
**109/109** — a clean sweep, and one better than raku, whose remaining failure
there is a `# TODO`-marked `rows()` capability check. With #5457 that puts
**6 of the 9 `DBIish` files at raku parity, up from 1**:

| File | raku | mutsu |
| --- | --- | --- |
| `02-meta` | PASS 1/1 | PASS 1/1 |
| `46-sqlite-blob` | PASS 18/18 | PASS 18/18 |
| `48-sqlite-errors` | PASS 17/17 | PASS 17/17 |
| `44-sqlite-memory` | 1 fail of 109 (`# TODO`) | **PASS 109/109** |
| `45-sqlite-common` | 1 fail of 109 (`# TODO`) | **PASS 109/109** |
| `03-lib-util` | 1 fail of 5 (`# TODO`, no libpq) | same subtest |

## Tests

- New pin `t/computed-declarator-adverb.t` (+ `t/lib/ComputedVerAdverb.rakumod`),
  14 tests, verified identical under raku: the angle form staying literal, the
  paren form evaluating for all three adverbs, `:ver(Nil)` yielding a defined
  part-less `Version`, a role declarator, the `unit class` form, and the
  `Nil`-absorbing `$?DISTRIBUTION.meta<ver>` the last one rests on.
- `make test`: `Files=2489, Tests=23725 … Result: PASS`.

Docs: `news/2026-07/computed-declarator-adverb.md`, and
`todo/tickets/dbiish-blockers.md` re-surveyed (⑥ retired, ⑦ split out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)