### PR TITLE
feat: match-time interpolation of an in-regex `:my` variable

### DIFF
--- a/news/2026-07/regex-my-var-interpolation.md
+++ b/news/2026-07/regex-my-var-interpolation.md
@@ -1,0 +1,34 @@
+# Match-time interpolation of an in-regex `:my` variable
+
+A bare `$name` in a regex, where `$name` was declared by an in-regex
+`:my $name …` declaration, is a Raku interpolation of that lexical's string value
+as a literal — evaluated **at match time**. mutsu handled `$name` only via
+`interpolate_bound_regex_scalars` / `interpolate_regex_scalars`, which substitute
+the value from the outer `env` *before* matching. A regex-local `:my` var isn't
+in `env` (its value is produced while matching, e.g. by a `VarDecl` atom or a
+code block), so the substitution found nothing and lowered `$name` to an
+always-fail (`<!>`) — the interpolation never matched.
+
+Now a bare `$name` naming an in-regex `:my`/`:let` var lowers to a new
+`RegexAtom::VarInterp(name)` atom that, when matched, reads the value from the
+running capture store's `regex_vars` (falling back to `env`) and matches its
+string form literally — like a `NamedBackref` reads a capture. An undefined value
+interpolates as the empty string (a zero-width match). The two interpolation
+pre-passes now leave a `:my`-declared name verbatim for this lowering instead of
+substituting it.
+
+```raku
+grammar G { token TOP { :my $v = 'ab'; $v 'c' } }
+G.parse("abc")   # now matches (was: never)
+```
+
+This is a prerequisite for the YAMLish battery's block collections, whose
+indentation-tracking `root-block` captures an indent string into a `:my` var and
+re-matches it on continuation lines. (The remaining half — running a `{ … }`
+side-effect block *inline* during matching so it can compute that var — is
+tracked separately in `todo/deep/yamlish-block-collections-regex-vars.md`.)
+
+Known limitation: when an outer lexical shares the exact name of the regex-local
+`:my` var, mutsu can still pre-substitute the outer value on a secondary parse
+path; the common (non-shadowing) case — which is what real grammars use — is
+correct. Pin: `t/regex-my-var-interpolation.t`.

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -333,7 +333,7 @@ impl Interpreter {
             RegexAtom::CaptureStartMarker | RegexAtom::CaptureEndMarker => {
                 return Some(pos);
             }
-            RegexAtom::Backref(_) | RegexAtom::NamedBackref(_) => {
+            RegexAtom::Backref(_) | RegexAtom::NamedBackref(_) | RegexAtom::VarInterp(_) => {
                 return None;
             }
             RegexAtom::Lookaround {
@@ -690,6 +690,7 @@ impl Interpreter {
             | RegexAtom::CaptureEndMarker
             | RegexAtom::Backref(_)
             | RegexAtom::NamedBackref(_)
+            | RegexAtom::VarInterp(_)
             | RegexAtom::VarDecl { .. }
             | RegexAtom::ClosureInterpolation { .. }
             | RegexAtom::LeftWordBoundary

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -381,6 +381,37 @@ impl Interpreter {
                 }
                 return None;
             }
+            RegexAtom::VarInterp(name) => {
+                // Read the in-regex `:my $name …` lexical from the running
+                // `regex_vars` (set by an earlier `VarDecl` / code block), falling
+                // back to the outer env, and match its string value literally. An
+                // undefined value matches nothing (zero-width, like an empty
+                // literal) rather than failing.
+                let val = current_caps
+                    .regex_vars
+                    .get(name.as_str())
+                    .or_else(|| current_caps.regex_vars.get(&format!("${name}")))
+                    .cloned()
+                    .or_else(|| self.env.get(name).cloned())
+                    .or_else(|| self.env.get(&format!("${name}")).cloned());
+                // An undefined value (Nil or a bare type object) interpolates as
+                // the empty string — a zero-width match — rather than its
+                // `.gist`; a defined value matches its string form literally.
+                let ref_text = match val {
+                    Some(v) => match v.view() {
+                        ValueView::Nil | ValueView::Package(_) => String::new(),
+                        _ => v.to_string_value(),
+                    },
+                    None => String::new(),
+                };
+                let ref_chars: Vec<char> = ref_text.chars().collect();
+                if pos + ref_chars.len() <= chars.len()
+                    && chars[pos..pos + ref_chars.len()] == ref_chars[..]
+                {
+                    return Some((pos + ref_chars.len(), RegexCaptures::default()));
+                }
+                return None;
+            }
             RegexAtom::VarDecl { code } => {
                 let source = format!("{};", code);
                 if let Ok((stmts, _)) = crate::parse_dispatch::parse_source(&source) {

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -139,6 +139,41 @@ fn is_subrule_lookahead_name(s: &str) -> bool {
         .is_some_and(|c| c.is_alphabetic() || c == '_')
 }
 
+/// Extract the scalar variable names introduced by an in-regex declaration such
+/// as `my $x = ''`, `my $new-indent`, or `my ($a, $b)`. Returns the bare names
+/// without the `$` sigil (`x`, `new-indent`, `a`, `b`). Only `$`-sigil names are
+/// collected — `@`/`%` interpolations are not handled as literal backreferences.
+pub(super) fn scalar_names_in_decl(code: &str) -> Vec<String> {
+    let chars: Vec<char> = code.chars().collect();
+    let mut names = Vec::new();
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] == '$' {
+            let mut j = i + 1;
+            let start = j;
+            while j < chars.len() {
+                let ch = chars[j];
+                let kebab = ch == '-'
+                    && chars
+                        .get(j + 1)
+                        .is_some_and(|n| n.is_alphabetic() || *n == '_');
+                if ch.is_alphanumeric() || ch == '_' || kebab {
+                    j += 1;
+                } else {
+                    break;
+                }
+            }
+            if j > start {
+                names.push(chars[start..j].iter().collect());
+            }
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+    names
+}
+
 impl Interpreter {
     /// Build the alternation atom for a `<@var>` array-variable subrule: look up
     /// the array variable named by `env_key` (including its `@` sigil) and
@@ -625,6 +660,13 @@ impl Interpreter {
         let mut pending_named_capture_is_array = false;
         let mut pending_builtin_named_capture: Option<String> = None;
         let mut pending_hash_capture: Option<String> = None;
+        // Scalar names declared by an in-regex `:my $v …` / `:let $v …`. A bare
+        // `$v` later in the same pattern is then a *match-time* interpolation of
+        // that lexical (read from `caps.regex_vars`), NOT a pre-substituted
+        // outer variable — the `:my` value is only known while matching. Tracked
+        // left-to-right; a `:my` always precedes its uses (Raku scoping).
+        let mut declared_regex_vars: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
         while let Some(c) = chars.next() {
             // In Raku, unescaped whitespace in regex is insignificant
             if c.is_whitespace() {
@@ -827,6 +869,51 @@ impl Interpreter {
                     separator: None,
                 });
                 continue;
+            }
+            // Bare `$name` interpolating an in-regex `:my $name …` lexical: a
+            // match-time interpolation of that variable's string value as a
+            // literal (Raku semantics). Pre-substitution from `env`
+            // (`interpolate_bound_regex_scalars`) can't do this — the value is
+            // only set while matching (often by a code block), so it is read from
+            // `caps.regex_vars` at match time via the `VarInterp` atom. Only fires
+            // for names this pattern declared with `:my`/`:let` (tracked above);
+            // outer-scope `$var` still goes through pre-substitution.
+            if mode == RegexParseMode::Match
+                && c == '$'
+                && chars
+                    .peek()
+                    .is_some_and(|ch| ch.is_alphabetic() || *ch == '_')
+            {
+                let mut probe = chars.clone();
+                let mut var_name = String::new();
+                while let Some(&ch) = probe.peek() {
+                    let kebab = ch == '-' && {
+                        let mut after = probe.clone();
+                        after.next();
+                        after.peek().is_some_and(|n| n.is_alphabetic() || *n == '_')
+                    };
+                    if ch.is_alphanumeric() || ch == '_' || kebab {
+                        var_name.push(ch);
+                        probe.next();
+                    } else {
+                        break;
+                    }
+                }
+                if declared_regex_vars.contains(&var_name) {
+                    chars = probe;
+                    tokens.push(RegexToken {
+                        atom: RegexAtom::VarInterp(var_name),
+                        quant: RegexQuant::One,
+                        named_capture: pending_named_capture.take(),
+                        hash_capture: None,
+                        secondary_named_capture: None,
+                        force_list_capture: false,
+                        ratchet,
+                        frugal: false,
+                        separator: None,
+                    });
+                    continue;
+                }
             }
             // `@<name>=(...)` — array capture alias. Behaves like the scalar
             // `$<name>=` alias (routes the following atom's capture to `name`),
@@ -1067,6 +1154,12 @@ impl Interpreter {
                             break;
                         }
                         decl_code.push(ch);
+                    }
+                    // Record each scalar name this declaration introduces so a
+                    // later bare `$name` becomes a match-time interpolation of the
+                    // regex-local lexical rather than an outer-scope substitution.
+                    for name in scalar_names_in_decl(&decl_code) {
+                        declared_regex_vars.insert(name);
                     }
                     tokens.push(RegexToken {
                         atom: RegexAtom::VarDecl { code: decl_code },

--- a/src/runtime/regex_parse_modifier.rs
+++ b/src/runtime/regex_parse_modifier.rs
@@ -129,6 +129,14 @@ impl Interpreter {
         let chars: Vec<char> = pattern.chars().collect();
         let mut out = String::new();
         let mut i = 0usize;
+        // Scalar names introduced by an in-pattern `:my $v …` / `:let $v …`. A
+        // later bare `$v` must NOT be pre-substituted from the outer `env` here —
+        // its value is a *match-time* lexical (often set by a code block), so it
+        // is left verbatim for the structural parser to lower to a `VarInterp`
+        // atom (read from `caps.regex_vars` while matching). Tracked
+        // left-to-right; a `:my` always precedes its uses.
+        let mut declared_my_vars: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
         while i < chars.len() {
             let ch = chars[i];
             // # starts a comment — skip without interpolation.
@@ -194,12 +202,23 @@ impl Interpreter {
                     || rest.starts_with("let ")
                     || rest.starts_with("temp ")
                 {
+                    let decl_start = i;
                     while i < chars.len() {
                         let c = chars[i];
                         out.push(c);
                         i += 1;
                         if c == ';' {
                             break;
+                        }
+                    }
+                    // Record the scalar names this declaration introduces so a
+                    // later bare `$name` is preserved for match-time interpolation
+                    // (only `:my`/`:let` introduce a fresh regex-local lexical;
+                    // `:our`/`:constant`/`:temp` refer to existing storage).
+                    if rest.starts_with("my ") || rest.starts_with("let ") {
+                        let decl: String = chars[decl_start..i].iter().collect();
+                        for name in super::regex_parse_core::scalar_names_in_decl(&decl) {
+                            declared_my_vars.insert(name);
                         }
                     }
                     continue;
@@ -321,6 +340,13 @@ impl Interpreter {
                             continue;
                         }
                         let name: String = chars[name_start..j].iter().collect();
+                        // A `:my`-declared regex-local var: leave `${name}`
+                        // verbatim for the parser's match-time `VarInterp` lowering.
+                        if declared_my_vars.contains(&name) {
+                            out.extend(chars[i..=j].iter());
+                            i = j + 1;
+                            continue;
+                        }
                         let value = self
                             .env
                             .get(&name)
@@ -370,6 +396,14 @@ impl Interpreter {
                         continue;
                     }
                     let name: String = chars[name_start..j].iter().collect();
+                    // A `:my`-declared regex-local var: leave `$name` verbatim so
+                    // the structural parser lowers it to a match-time `VarInterp`
+                    // atom instead of pre-substituting an outer-scope value here.
+                    if declared_my_vars.contains(&name) {
+                        out.extend(chars[i..j].iter());
+                        i = j;
+                        continue;
+                    }
                     // Reduce-time dyn-var overlay: a `$*` var written by a grammar
                     // action mid-parse takes precedence over `self.env` so the next
                     // subrule matches with the updated value (see REGEX_DYNVAR_OVERLAY).

--- a/src/runtime/regex_types.rs
+++ b/src/runtime/regex_types.rs
@@ -215,6 +215,13 @@ pub(crate) enum RegexAtom {
     Backref(usize),
     /// `$<name>` — backreference to named capture group
     NamedBackref(String),
+    /// Bare `$name` interpolating an in-regex `:my $name …` lexical: a match-time
+    /// interpolation of the variable's string value as a literal. The value is
+    /// read from `caps.regex_vars` (falling back to `env`) when the atom is
+    /// matched, so it reflects assignments made earlier in the same match (e.g.
+    /// a captured indentation string). Distinct from `NamedBackref` (which reads
+    /// a capture) and from pre-substituted outer-scope `$var` interpolation.
+    VarInterp(String),
     /// `<?same>` / `<!same>` — zero-width assertion: adjacent chars are same/different
     SameAssertion {
         negated: bool,

--- a/t/regex-my-var-interpolation.t
+++ b/t/regex-my-var-interpolation.t
@@ -1,0 +1,28 @@
+use v6;
+use Test;
+
+# A bare `$name` in a regex, where `$name` is declared by an in-regex
+# `:my $name …` declaration, interpolates that lexical's string value as a
+# literal *at match time* (Raku semantics). mutsu previously pre-substituted
+# `$name` from the outer `env` before matching, so a regex-local `:my` var — whose
+# value is only known while matching — was invisible and the interpolation became
+# a never-match. Now it lowers to a match-time `VarInterp` atom reading the value
+# from the running capture store.
+
+plan 5;
+
+# Plain regex.
+ok ("xxy" ~~ / :my $p = 'xx'; $p 'y' /).defined,
+    'plain regex: :my $p = "xx"; $p matches the literal "xx"';
+nok ("zzy" ~~ / :my $q = 'xx'; $q 'y' /).defined,
+    'plain regex: the interpolation is the :my value, not a wildcard';
+
+# Grammar token.
+grammar G { token TOP { :my $v = 'ab'; $v 'c' } }
+ok G.parse("abc").defined, 'grammar token: :my $v interpolates in a token';
+nok G.parse("xyc").defined, 'grammar token: only the :my value matches';
+
+# An empty :my value interpolates as the empty string (zero-width), so the
+# following atom matches from the same position.
+grammar E { token TOP { :my $w = ''; $w <[\d]>+ } }
+ok E.parse("5").defined, 'grammar token: empty :my value is a zero-width match';

--- a/todo/deep/yamlish-block-collections-regex-vars.md
+++ b/todo/deep/yamlish-block-collections-regex-vars.md
@@ -44,30 +44,26 @@ quantifiers (`' ' ** { 0..* }`), `$<sp>=[...]` captures, and separated
 quantifiers (`+ % [ <.newline> $indent ]`) all already work. What does *not*
 work:
 
-### (a) Match-time interpolation of a `:my`-declared regex var as a literal
+### (a) Match-time interpolation of a `:my`-declared regex var — DONE
 
 ```raku
 grammar G { token TOP { :my $v = 'ab'; $v 'c' } }
-G.parse("abc")   # raku: MATCH ; mutsu: NO
+G.parse("abc")   # now MATCHes
 ```
 
-`interpolate_bound_regex_scalars` (`src/runtime/regex/regex_interpolate.rs:247`)
-substitutes `$var` from `self.env` at **pre-match** time. A regex-local `:my`
-var isn't in `env` (it's set at match time by the `VarDecl` atom into
-`caps.regex_vars`), so `$v` is left literal and then mis-parsed as the literal
-text `$v` (or errors "Null regex"/"Use of Nil"). Bare `$var` interpolation must
-become a **deferred** atom that at match time reads `current_caps.regex_vars`
-(then `env`) and matches the string value literally, like `NamedBackref`
-(`src/runtime/regex/regex_match_capture.rs:368`) does for `$<name>`.
+Implemented: a bare `$name` naming an in-regex `:my`/`:let` var lowers to
+`RegexAtom::VarInterp(name)`, which at match time reads `caps.regex_vars` (then
+`env`) and matches the string value literally (undefined → empty/zero-width),
+mirroring `NamedBackref` (`src/runtime/regex/regex_match_capture.rs`). The parser
+tracks `declared_regex_vars` (`regex_parse_core.rs`) and both interpolation
+pre-passes (`interpolate_regex_scalars` in `regex_parse_modifier.rs`) leave a
+declared name verbatim for this lowering. Pin: `t/regex-my-var-interpolation.t`.
+Known gap: an outer lexical sharing the `:my` var's name can still be
+pre-substituted on a secondary parse path (raku uses the `:my` shadow) — obscure,
+not needed for YAMLish.
 
-Sketch: add `RegexAtom::VarInterp(String)`; in the parser track a
-`declared_regex_vars: HashSet<String>` (populate from each `:my`/`:let`
-`VarDecl`'s code — the name is the first `$ident` after `my `), and in Match mode
-emit `VarInterp(name)` for a bare `$name` when `name` is in that set instead of
-falling through to literal handling (`regex_parse_core.rs:875`). This alone is a
-clean, general Raku feature worth landing even before (b) — but it does **not**
-unblock YAMLish by itself, because `root-block` uses `:my $new-indent;` with **no
-initializer** and computes the value in a code block (needs (b)).
+This does **not** unblock YAMLish by itself: `root-block` uses `:my $new-indent;`
+with **no initializer** and computes the value in a code block (needs (b)).
 
 ### (b) Inline execution of `{ code }` side-effect blocks during matching
 
@@ -90,8 +86,7 @@ blast radius (touches every regex with a `{ }` block).
 
 ## Order / recommendation
 
-1. Land (a) standalone first — general, self-contained, low risk. Pin:
-   `:my $v = 'ab'; $v` matches, and `:my $v = ''; $v` matches empty.
+1. ✅ (a) DONE — `t/regex-my-var-interpolation.t`.
 2. Then design (b): inline side-effect code blocks with backtrack-safe
    `regex_vars` writes, keeping `make` deferral intact. With (a)+(b),
    `Grammar.parse` of `- 1\n- 2` / `a: 1` should reduce, and `load-yaml` should


### PR DESCRIPTION
## Summary

A bare `$name` in a regex, where `$name` is declared by an in-regex `:my $name …`, is a Raku interpolation of that lexical's string value as a literal — evaluated **at match time**. mutsu only pre-substituted `$name` from the outer `env` before matching, so a regex-local `:my` var (whose value is produced while matching) was invisible and the interpolation lowered to an always-fail (`<!>`).

```raku
grammar G { token TOP { :my $v = 'ab'; $v 'c' } }
G.parse("abc")   # now matches (was: never)
```

## Fix

- New `RegexAtom::VarInterp(name)`: at match time reads the value from the running capture store's `regex_vars` (falling back to `env`) and matches its string form literally, mirroring how `NamedBackref` reads a capture. Undefined → empty string (zero-width).
- The parser tracks in-pattern `:my`/`:let` scalar names (`declared_regex_vars`) and emits `VarInterp` for a later bare `$name`.
- Both interpolation pre-passes leave a `:my`-declared name verbatim for this lowering instead of substituting an outer value.

## Impact

Prerequisite for the YAMLish battery's block collections, whose indentation-tracking `root-block` captures an indent string into a `:my` var and re-matches it. The remaining half — running a `{ … }` side-effect block *inline* during matching so it can compute that var — is tracked in `todo/deep/yamlish-block-collections-regex-vars.md` (item (b)).

Known limitation: when an outer lexical shares the exact name of the regex-local `:my` var, mutsu can still pre-substitute the outer value on a secondary parse path; the common (non-shadowing) case — what real grammars use — is correct.

## Tests

- `t/regex-my-var-interpolation.t` (plain regex + grammar token, non-empty/empty/negative), matches `raku` exactly.
- Full `make test`: **2491 files / 23729 tests PASS**; `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)