### PR TITLE
build: make test runs the TAP suite on the debug binary, not release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,7 +363,7 @@ The `t/` TAP suite is **fatal** in CI (`prove ... t/`, no `|| echo` fallback) �
 Running the entire roast suite locally is wasteful and slow — **let CI run the full `make roast`.** Locally, run only the specific tests relevant to your change:
 
 - Run individual roast tests with `MUTSU_FUDGE=1 prove -e 'target/debug/mutsu' roast/<path>.t` (the `MUTSU_FUDGE=1` is required — see the build/run section above), or the exact files you touched / suspect regressed.
-- CI runs `make test` and `make roast` on a clean machine with the **release build** (`cargo build --release`, `MUTSU_BIN=target/release/mutsu`). Local debug builds are much slower, so a local timeout on a heavy test does not necessarily indicate a real failure — confirm with a release build (`target/release/mutsu`) before assuming a regression, and otherwise trust CI's verdict.
+- CI does not invoke `make test`; its `test` job runs the steps individually and runs the **TAP suite (`prove t/`) on the `debug` binary** (`MUTSU_BIN=target/debug/mutsu`), reserving the **release build** (`cargo build --release`, `MUTSU_BIN=target/release/mutsu`) for **`make roast`**. Local `make test` matches this — it runs `t/` on debug too (see `docs/adr/0014-make-test-runs-tap-on-debug-binary.md`); only roast uses release. Debug builds are much slower at runtime, so a local *roast* timeout on a heavy test does not necessarily indicate a real failure — confirm with a release build (`target/release/mutsu`) before assuming a regression, and otherwise trust CI's verdict.
 - Push the branch and rely on CI for the comprehensive roast result rather than running the whole suite locally.
 
 ### Use the DEBUG build to iterate on `MUTSU_VM_STATS` counters — release is for wall-clock only

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,16 @@ PROVE_JOBS ?= 4
 #
 # `prove -e scripts/run-t-test.sh`: routes t/ through the same per-file timeout
 # + flaky-quarantine wrapper the roast suite uses (docs/flaky-test-policy.md).
+#
+# `MUTSU_BIN=.../debug/mutsu`: run t/ on the DEBUG binary, matching CI's TAP
+# step (ci.yml runs `prove t/` on target/debug/mutsu). The release build is
+# reserved for `make roast`. Building release here too cost ~19 min (a full
+# optimized recompile of the mutsu crate) for only a ~4 min t/ runtime saving
+# vs debug — it dominated `make test` wall-clock for no correctness gain. See
+# docs/adr/0014-make-test-runs-tap-on-debug-binary.md.
 test: check-value-wall check-flaky-list
 	@mkdir -p tmp
-	(cargo build && cargo test -- --test-threads=1 && cargo build --release && MUTSU_BIN='$(MUTSU_BIN)' MUTSU_T_TIMEOUT=60 prove -e 'scripts/run-t-test.sh' t/) 2>&1 | tee tmp/make-test.log
+	(cargo build && cargo test -- --test-threads=1 && MUTSU_BIN='$(CARGO_TARGET_DIR)/debug/mutsu' MUTSU_T_TIMEOUT=60 prove -e 'scripts/run-t-test.sh' t/) 2>&1 | tee tmp/make-test.log
 
 check-value-wall:
 	scripts/check-value-wall.sh

--- a/docs/adr/0014-make-test-runs-tap-on-debug-binary.md
+++ b/docs/adr/0014-make-test-runs-tap-on-debug-binary.md
@@ -1,0 +1,121 @@
+# ADR-0014: `make test` runs the TAP (`t/`) suite on the debug binary, not release
+
+- **Status**: Accepted
+- **Date**: 2026-07-26
+- **Deciders**: tokuhirom, Claude
+- **Related**: `Makefile` (the `test` target), `.github/workflows/ci.yml` (the `test` job),
+  `scripts/run-t-test.sh`, CLAUDE.md "Checking `make test` / `make roast` results" /
+  "Delegate the full roast run to CI".
+
+## 1. Context
+
+Before this ADR the `make test` target built **both** a debug and a release binary:
+
+```make
+test:
+	cargo build \
+	 && cargo test -- --test-threads=1 \
+	 && cargo build --release \
+	 && MUTSU_BIN=target/release/mutsu MUTSU_T_TIMEOUT=60 prove -e scripts/run-t-test.sh t/
+```
+
+- `cargo build` + `cargo test` — the Rust `#[test]` unit tests, on the debug build.
+- `cargo build --release` + `prove t/` — the ~2469-file Raku TAP suite, run against the **release**
+  binary.
+
+The release build exists in this target *only* so `prove t/` runs on an optimized binary. That build
+is the single dominant cost of `make test`.
+
+### Measurement (2026-07-26, 12-core dev box; only the `mutsu` crate recompiles — deps cached)
+
+| Phase | Time |
+|---|---|
+| `cargo build` (debug, full recompile of `mutsu`) | 31.8 s |
+| `cargo test -- --test-threads=1` (recompile under test cfg + run) | 5 m 02 s |
+| **`cargo build --release` (full recompile of `mutsu`)** | **19 m 17 s** |
+| `prove t/` (2469 files, **release** binary) | 2 m 52 s |
+| `prove t/` (2469 files, **debug** binary) | 6 m 43 s |
+
+The release compile is ~36× the debug compile (the crate is large and its optimized codegen is
+extremely heavy) and accounts for roughly 70 % of the whole-target wall-clock. Yet running the TAP
+suite on debug instead of release costs only ~4 more minutes of *runtime*. Trading a 19-minute build
+for a 4-minute runtime delta is a clear net win: ~28 min → ~12 min.
+
+### The release binary was never actually required here — CI already proves it
+
+CI does **not** invoke `make test`. The `test` job in `.github/workflows/ci.yml` runs the steps
+individually, and its TAP step already runs on the **debug** binary:
+
+```yaml
+- name: Build (debug, for TAP tests)
+  run: cargo build
+- name: TAP tests (prove t/)
+  run: prove -e 'scripts/run-t-test.sh' t/
+  env:
+    MUTSU_BIN: target/debug/mutsu
+    MUTSU_T_TIMEOUT: "30"
+```
+
+The gc-stress and jit-stress jobs likewise run `prove t/` on `target/debug/mutsu`. CI's `cargo build
+--release` is used **only** for `make roast`. So the authoritative gate has always exercised the TAP
+suite on debug; the local `make test` running it on release was the *outlier*, not the standard. It
+was also strictly *more lenient* in one axis (release runtime + a 60 s per-file timeout vs CI's debug
+runtime + a 30 s timeout), which cannot catch a debug-only timeout that CI would.
+
+## 2. Options considered
+
+### Option A — replace `make test` to run `t/` on the debug binary — CHOSEN
+
+Drop `cargo build --release` from the `test` target; point `prove t/` at `target/debug/mutsu`.
+
+- **+** Removes the 19-minute release build; `make test` drops from ~28 min to ~12 min.
+- **+** **Aligns local `make test` with CI**, which already runs the TAP suite on debug. A pass/fail
+  locally now means the same thing it means in CI.
+- **+** No correctness loss: the TAP tests assert on program *output*, which is identical between
+  debug and release; only wall-clock differs.
+- **−** A per-file timeout is closer on debug (debug runtime ≈ 2.3× release). Mitigated by keeping
+  `MUTSU_T_TIMEOUT=60` locally (CI uses 30 and passes), leaving generous headroom.
+- **−** `make test` no longer produces a release binary as a side effect. Anyone needing one for
+  roast/bench runs `make roast` or `cargo build --release` explicitly — which is already how those
+  paths work.
+
+### Option B — add a separate `make test-fast`, keep `make test` on release
+
+Keep the release-based `make test` and add a debug-based fast variant.
+
+- **+** Preserves the existing target verbatim.
+- **−** The release-based `make test` has no unique value over CI (CI *is* the release-adjacent gate
+  for roast, and runs t/ on debug), so keeping it as the default just preserves the 19-minute build
+  as the thing everyone types by habit. Two targets that differ only in an axis CI does not even use
+  is needless surface. The default should be the fast, CI-aligned one.
+
+### Option C — status quo (build both)
+
+Rejected: pays a 19-minute release build on every `make test` for a ~4-minute runtime benefit that
+CI does not even rely on.
+
+## 3. Decision
+
+- **Adopt Option A.** `make test` runs `cargo build` + `cargo test -- --test-threads=1`, then
+  `prove t/` against `target/debug/mutsu` with `MUTSU_T_TIMEOUT=60`. The `cargo build --release`
+  step is removed from the `test` target.
+- **`make roast` is unchanged** — it still builds and runs on the release binary
+  (`MUTSU_BIN ?= target/release/mutsu`), because the roast suite is timing-sensitive (S17
+  concurrency) and long enough that release runtime genuinely matters. The default `MUTSU_BIN` at the
+  top of the Makefile stays release for that reason; only the `test` target overrides it to debug.
+- **CI is unchanged** — it already ran the TAP suite on debug; this ADR just makes local `make test`
+  match it.
+
+## 4. Consequences
+
+- `make test` wall-clock drops from ~28 min to ~12 min on a warm dependency cache, and local
+  pass/fail semantics now match CI's TAP step exactly.
+- Documentation that described `make test` as building/using the release binary for `t/` is now
+  inaccurate and is corrected (CLAUDE.md "Delegate the full roast run to CI": CI runs the TAP suite on
+  debug and reserves release for roast).
+- If a `t/` test starts timing out under `make test` on debug, that is a real signal (the test got
+  slow, or the box is loaded) — investigate per the flaky-test triage protocol rather than reaching
+  back for the release binary. Confirm against a release build (`target/release/mutsu`) only to
+  distinguish "genuinely too slow" from "debug-only slow".
+- To get a release binary, run `make roast` or `cargo build --release` explicitly; `make test` no
+  longer produces one as a side effect.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,3 +32,4 @@ The role of an ADR is to preserve the *context of the judgment* — something th
 | [0011](0011-rakuast-model-layer-and-phasing.md) | RakuAST — a reflection/model layer over the internal AST, and its phasing | Accepted |
 | [0012](0012-libffi-macos-arm64-vendored-bump.md) | libffi on macOS arm64 — bump the vendored build, do not switch to system libffi | Accepted |
 | [0013](0013-container-interior-mutability-cellvalue.md) | Container interior mutability — kill the `gc_contents_mut` provenance UB with a `GcCell` newtype | Proposed |
+| [0014](0014-make-test-runs-tap-on-debug-binary.md) | `make test` runs the TAP (`t/`) suite on the debug binary, not release | Accepted |

--- a/news/2026-07/make-test-drops-release-build.md
+++ b/news/2026-07/make-test-drops-release-build.md
@@ -1,0 +1,29 @@
+# `make test` no longer builds a release binary (~28 min → ~12 min)
+
+`make test` used to build **both** a debug and a release binary: debug for the Rust
+`#[test]` unit tests, release solely so the ~2469-file `t/` TAP suite ran on an optimized
+binary. Measuring the phases on a 12-core box (only the `mutsu` crate recompiling, deps
+cached) showed the release build was the entire problem:
+
+| Phase | Time |
+|---|---|
+| `cargo build` (debug, full) | 31.8 s |
+| `cargo test -- --test-threads=1` | 5 m 02 s |
+| `cargo build --release` (full) | **19 m 17 s** |
+| `prove t/` on release | 2 m 52 s |
+| `prove t/` on debug | 6 m 43 s |
+
+The release compile is ~36× the debug compile and ~70 % of the whole target's wall-clock,
+while running the TAP suite on debug instead of release costs only ~4 more minutes of
+runtime. Worse, the release binary was never actually required here: CI does not invoke
+`make test`, and its `test` job already runs `prove t/` on `target/debug/mutsu` (the
+gc-stress and jit-stress jobs too), reserving the release build for `make roast`. So local
+`make test` running `t/` on release was the outlier, and a *more lenient* one (release
+runtime + a 60 s timeout vs CI's debug + 30 s).
+
+`make test` now drops `cargo build --release` and runs `prove t/` on `target/debug/mutsu`
+with `MUTSU_T_TIMEOUT=60`, cutting wall-clock from ~28 min to ~12 min and making local
+pass/fail match CI's TAP step exactly. `make roast` is unchanged — it still builds and runs
+on release, because the roast suite is timing-sensitive and long enough that release runtime
+matters. The decision and measurements are recorded in
+`docs/adr/0014-make-test-runs-tap-on-debug-binary.md`.


### PR DESCRIPTION
## Summary

`make test` built **both** a debug and a release binary; the release build existed *only* so the ~2469-file `t/` TAP suite ran on an optimized binary. That release compile is the single dominant cost of the target.

### Measured (12-core box, only the `mutsu` crate recompiling, deps cached)

| Phase | Time |
|---|---|
| `cargo build` (debug, full) | 31.8 s |
| `cargo test -- --test-threads=1` | 5 m 02 s |
| **`cargo build --release` (full)** | **19 m 17 s** |
| `prove t/` on release | 2 m 52 s |
| `prove t/` on debug | 6 m 43 s |

The release compile is ~36× the debug compile (~70 % of the whole target's wall-clock), while running `t/` on debug instead costs only ~4 more minutes of *runtime*.

### Why the release binary was never needed here

CI does **not** invoke `make test`. Its `test` job already runs `prove t/` on `target/debug/mutsu` (gc-stress and jit-stress jobs too), reserving the release build for `make roast`. So local `make test` running `t/` on release was the outlier — and a *more lenient* one (release runtime + 60 s per-file timeout vs CI's debug + 30 s), which cannot catch a debug-only timeout CI would.

## Change

- Drop `cargo build --release` from the `test` target; point `prove t/` at `target/debug/mutsu` (`MUTSU_T_TIMEOUT=60`). Wall-clock ~28 min → ~12 min; local pass/fail now matches CI's TAP step.
- `make roast` unchanged — still release, for its timing-sensitive S17 concurrency tests.
- Decision + measurements recorded in `docs/adr/0014-make-test-runs-tap-on-debug-binary.md`; CLAUDE.md corrected; news entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)