### PR TITLE
rakuast: register type objects

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1130,7 +1130,10 @@ so it is tracked separately from the roast backlog.
         `t/rakuast-leaf-accessors.t`.
   - [x] Slice 4: semantic Expression/Term hierarchy (`IntLiteral isa RakuAST::Expression`/`Term`,
         `ApplyInfix isa Expression`). Tests in `t/rakuast-semantic-hierarchy.t`.
-  - [ ] Slice 5+: registering `RakuAST::*` as first-class type objects; `.WHAT`.
+  - [x] Slice 5: registered `RakuAST::*` type objects and `.WHAT` — a node's `.WHAT` is the
+        corresponding type object, and concrete/abstract type objects participate in the same
+        namespace + semantic hierarchy under `.isa`/`~~`. Tests in `t/rakuast-type-objects.t`.
+  - [ ] Slice 6+: remaining type-object metaobject operations.
 - **Phase 4 (in progress)** — construction (`.new`).
   - [x] Slice 1: literal constructors (`RakuAST::IntLiteral.new(42)`, `StrLiteral`, `RatLiteral`).
         Tests in `t/rakuast-construct.t`.

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -147,8 +147,13 @@ earlier ones.
     blocks/`Call::Name` are Terms-and-Expressions; `Apply*`/`Ternary` are Expressions-only; `Name`/
     `ArgList`/`Signature`/statements/types are neither) is consulted by `isa_check`. Conservative:
     only verified classes are listed, so an unlisted expression node is a missed match, never a
-    false positive. Tests in `t/rakuast-semantic-hierarchy.t`. Still pending: registering `RakuAST::*`
-    as first-class type objects (they currently resolve as bare type names).
+    false positive. Tests in `t/rakuast-semantic-hierarchy.t`.
+  - **Slice 5 (registered type objects + `.WHAT`) — done.** A node's `.WHAT` returns the
+    corresponding `RakuAST::*` type object, and concrete and abstract RakuAST type objects now
+    participate in the same namespace and semantic hierarchy under `.isa` and `~~`
+    (`IntLiteral isa Term isa Expression isa Node`). The registry rejects unknown `RakuAST::*`
+    package names rather than treating the namespace prefix as sufficient. Tests in
+    `t/rakuast-type-objects.t`.
 - **Phase 4 — Construction.** `.new` (and `.from-identifier`, …) on RakuAST type objects
   build `Value::RakuAst`, validating args against the per-class field schema.
   - **Slice 1 (literals) — done.** `RakuAST::IntLiteral.new(42)` / `RatLiteral.new(3.5)` /

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -294,6 +294,150 @@ impl RakuAstClass {
     }
 }
 
+/// Whether a registered RakuAST type object is a subtype of another RakuAST
+/// type object. This mirrors [`Value::isa_check`] for node instances while also
+/// covering abstract registry entries such as `RakuAST::Node` and
+/// `RakuAST::Expression`.
+pub fn type_object_isa(actual: &str, expected: &str) -> bool {
+    if !is_registered_type_object(actual) || !is_registered_type_object(expected) {
+        return false;
+    }
+    if actual == expected || expected == "RakuAST::Node" {
+        return true;
+    }
+    if let Some(rest) = actual.strip_prefix(expected)
+        && rest.starts_with("::")
+    {
+        return true;
+    }
+    match expected {
+        "RakuAST::Expression" => {
+            actual == "RakuAST::Term" || semantic_type_object_ancestors(actual).contains(&expected)
+        }
+        "RakuAST::Term" => semantic_type_object_ancestors(actual).contains(&expected),
+        _ => false,
+    }
+}
+
+fn semantic_type_object_ancestors(class_name: &str) -> &'static [&'static str] {
+    const TERM: &[&str] = &["RakuAST::Term", "RakuAST::Expression"];
+    const EXPR: &[&str] = &["RakuAST::Expression"];
+    match class_name {
+        "RakuAST::IntLiteral"
+        | "RakuAST::RatLiteral"
+        | "RakuAST::StrLiteral"
+        | "RakuAST::QuotedString"
+        | "RakuAST::Var::Lexical"
+        | "RakuAST::Term::Reduce"
+        | "RakuAST::Sub"
+        | "RakuAST::Block"
+        | "RakuAST::PointyBlock"
+        | "RakuAST::Call::Name"
+        | "RakuAST::Call::Name::WithoutParentheses" => TERM,
+        "RakuAST::ApplyInfix"
+        | "RakuAST::ApplyPrefix"
+        | "RakuAST::ApplyPostfix"
+        | "RakuAST::ApplyListInfix"
+        | "RakuAST::Ternary" => EXPR,
+        _ => &[],
+    }
+}
+
+fn is_registered_type_object(class_name: &str) -> bool {
+    if matches!(
+        class_name,
+        "RakuAST::Node"
+            | "RakuAST::Expression"
+            | "RakuAST::Term"
+            | "RakuAST::Statement"
+            | "RakuAST::Call"
+            | "RakuAST::Var"
+            | "RakuAST::VarDeclaration"
+            | "RakuAST::Initializer"
+            | "RakuAST::Type"
+            | "RakuAST::Trait"
+            | "RakuAST::ParameterTarget"
+            | "RakuAST::Postcircumfix"
+            | "RakuAST::Circumfix"
+            | "RakuAST::StatementPrefix"
+            | "RakuAST::MetaPostfix"
+    ) {
+        return true;
+    }
+    RAKUAST_CLASSES
+        .iter()
+        .any(|class| class.printed_name() == class_name)
+}
+
+const RAKUAST_CLASSES: &[RakuAstClass] = &[
+    RakuAstClass::StatementList,
+    RakuAstClass::StatementExpression,
+    RakuAstClass::IntLiteral,
+    RakuAstClass::RatLiteral,
+    RakuAstClass::StrLiteral,
+    RakuAstClass::QuotedString,
+    RakuAstClass::CallName,
+    RakuAstClass::CallNameWithoutParentheses,
+    RakuAstClass::Name,
+    RakuAstClass::ArgList,
+    RakuAstClass::VarLexical,
+    RakuAstClass::VarDeclarationSimple,
+    RakuAstClass::InitializerAssign,
+    RakuAstClass::ApplyInfix,
+    RakuAstClass::Infix,
+    RakuAstClass::ApplyPrefix,
+    RakuAstClass::Prefix,
+    RakuAstClass::ApplyPostfix,
+    RakuAstClass::Postfix,
+    RakuAstClass::Assignment,
+    RakuAstClass::CallMethod,
+    RakuAstClass::CallQuotedMethod,
+    RakuAstClass::MetaPostfixHyper,
+    RakuAstClass::Block,
+    RakuAstClass::Blockoid,
+    RakuAstClass::PointyBlock,
+    RakuAstClass::Signature,
+    RakuAstClass::Parameter,
+    RakuAstClass::ParameterTargetVar,
+    RakuAstClass::StatementIf,
+    RakuAstClass::StatementLoopWhile,
+    RakuAstClass::StatementLoop,
+    RakuAstClass::StatementElsif,
+    RakuAstClass::StatementFor,
+    RakuAstClass::Sub,
+    RakuAstClass::TypeSetting,
+    RakuAstClass::StatementLoopRepeatWhile,
+    RakuAstClass::ApplyListInfix,
+    RakuAstClass::TypeSimple,
+    RakuAstClass::TypeDefinedness,
+    RakuAstClass::TraitWillBuild,
+    RakuAstClass::TypeParameterized,
+    RakuAstClass::TypeCoercion,
+    RakuAstClass::Class,
+    RakuAstClass::Method,
+    RakuAstClass::Role,
+    RakuAstClass::RoleBody,
+    RakuAstClass::Label,
+    RakuAstClass::StatementGiven,
+    RakuAstClass::StatementWhen,
+    RakuAstClass::StatementDefault,
+    RakuAstClass::Ternary,
+    RakuAstClass::SemiList,
+    RakuAstClass::PostcircumfixArrayIndex,
+    RakuAstClass::TermReduce,
+    RakuAstClass::TermEnum,
+    RakuAstClass::CircumfixParentheses,
+    RakuAstClass::ParameterSlurpyFlattened,
+    RakuAstClass::ParameterSlurpyUnflattened,
+    RakuAstClass::CircumfixArrayComposer,
+    RakuAstClass::TermWhatever,
+    RakuAstClass::FatArrow,
+    RakuAstClass::StatementPrefixDo,
+    RakuAstClass::StatementPrefixTry,
+    RakuAstClass::StatementPrefixGather,
+    RakuAstClass::CallTerm,
+];
+
 /// Entry point for `Str.AST`: parse the source, convert, wrap in `Value::RakuAst`.
 pub fn str_dot_ast(source: &str) -> Result<Value, RuntimeError> {
     let (stmts, _finish) = crate::parse_dispatch::parse_source(source)?;

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -312,7 +312,9 @@ pub fn type_object_isa(actual: &str, expected: &str) -> bool {
     }
     match expected {
         "RakuAST::Expression" => {
-            actual == "RakuAST::Term" || semantic_type_object_ancestors(actual).contains(&expected)
+            actual == "RakuAST::Term"
+                || actual.starts_with("RakuAST::Term::")
+                || semantic_type_object_ancestors(actual).contains(&expected)
         }
         "RakuAST::Term" => semantic_type_object_ancestors(actual).contains(&expected),
         _ => false,
@@ -357,6 +359,7 @@ fn is_registered_type_object(class_name: &str) -> bool {
             | "RakuAST::Type"
             | "RakuAST::Trait"
             | "RakuAST::ParameterTarget"
+            | "RakuAST::Parameter::Slurpy"
             | "RakuAST::Postcircumfix"
             | "RakuAST::Circumfix"
             | "RakuAST::StatementPrefix"

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -1251,11 +1251,17 @@ impl Interpreter {
                 return self.type_matches_value(&resolved, value);
             }
         }
-        // For Package (type object) values, use the package name as the type
-        // so that e.g. Junction (which is Mu, not Any) is correctly rejected
-        // when the constraint is Any.
+        // Registered RakuAST type objects have their own hierarchy, including
+        // semantic ancestors (`IntLiteral` isa `Term` isa `Expression`) that
+        // cannot be derived from namespace spelling alone.
         if let ValueView::Package(package_name) = value.view() {
             let resolved = package_name.resolve();
+            if resolved.starts_with("RakuAST::") && constraint.starts_with("RakuAST::") {
+                return value.isa_check(constraint);
+            }
+            // For other Package (type object) values, use the package name as
+            // the type so that e.g. Junction (which is Mu, not Any) is correctly
+            // rejected when the constraint is Any.
             return Self::type_matches(constraint, &resolved);
         }
         let value_type = crate::runtime::value_type_name(value);

--- a/src/value/types_isa.rs
+++ b/src/value/types_isa.rs
@@ -152,6 +152,12 @@ impl Value {
         if my_type == type_name {
             return true;
         }
+        if let ValueView::Package(name) = self.view() {
+            let actual = name.resolve();
+            if actual.starts_with("RakuAST::") && type_name.starts_with("RakuAST::") {
+                return crate::rakuast::type_object_isa(&actual, type_name);
+            }
+        }
         // RakuAST node hierarchy (Phase 3): every node isa `RakuAST::Node`, a node
         // isa any `::`-namespace ancestor of its printed class name (e.g.
         // `Statement::If` isa `RakuAST::Statement`; the `::` boundary avoids a

--- a/t/rakuast-type-objects.t
+++ b/t/rakuast-type-objects.t
@@ -1,0 +1,24 @@
+use Test;
+use experimental :rakuast;
+
+# RakuAST Phase 3 slice 5 (ADR-0011): registered type objects and `.WHAT`.
+
+plan 12;
+
+my $literal = Q[42].AST.statements[0].expression;
+
+is $literal.WHAT.^name, 'RakuAST::IntLiteral', 'node .WHAT has the concrete RakuAST type';
+ok $literal.WHAT === RakuAST::IntLiteral, 'node .WHAT is the registered type object';
+
+ok RakuAST::IntLiteral ~~ RakuAST::Node, 'literal type object isa Node';
+ok RakuAST::IntLiteral ~~ RakuAST::Expression, 'literal type object isa Expression';
+ok RakuAST::IntLiteral ~~ RakuAST::Term, 'literal type object isa Term';
+
+ok RakuAST::Term ~~ RakuAST::Expression, 'Term type object isa Expression';
+ok RakuAST::Term ~~ RakuAST::Node, 'Term type object isa Node';
+ok RakuAST::Expression ~~ RakuAST::Node, 'Expression type object isa Node';
+
+ok RakuAST::Statement::If ~~ RakuAST::Statement, 'nested type object isa namespace ancestor';
+ok RakuAST::Statement::If ~~ RakuAST::Node, 'statement type object isa Node';
+nok RakuAST::Statement::If ~~ RakuAST::Expression, 'statement type object is not an Expression';
+nok RakuAST::Name ~~ RakuAST::Expression, 'non-expression node type stays outside Expression';

--- a/t/rakuast-type-objects.t
+++ b/t/rakuast-type-objects.t
@@ -3,7 +3,7 @@ use experimental :rakuast;
 
 # RakuAST Phase 3 slice 5 (ADR-0011): registered type objects and `.WHAT`.
 
-plan 12;
+plan 16;
 
 my $literal = Q[42].AST.statements[0].expression;
 
@@ -17,8 +17,15 @@ ok RakuAST::IntLiteral ~~ RakuAST::Term, 'literal type object isa Term';
 ok RakuAST::Term ~~ RakuAST::Expression, 'Term type object isa Expression';
 ok RakuAST::Term ~~ RakuAST::Node, 'Term type object isa Node';
 ok RakuAST::Expression ~~ RakuAST::Node, 'Expression type object isa Node';
+ok RakuAST::Term::Enum ~~ RakuAST::Expression, 'Term::Enum transitively isa Expression';
+ok RakuAST::Term::Whatever ~~ RakuAST::Expression, 'Term::Whatever transitively isa Expression';
 
 ok RakuAST::Statement::If ~~ RakuAST::Statement, 'nested type object isa namespace ancestor';
 ok RakuAST::Statement::If ~~ RakuAST::Node, 'statement type object isa Node';
 nok RakuAST::Statement::If ~~ RakuAST::Expression, 'statement type object is not an Expression';
 nok RakuAST::Name ~~ RakuAST::Expression, 'non-expression node type stays outside Expression';
+
+ok RakuAST::Parameter::Slurpy::Flattened ~~ RakuAST::Parameter::Slurpy,
+    'Flattened slurpy type isa its namespace parent';
+ok RakuAST::Parameter::Slurpy::Unflattened ~~ RakuAST::Parameter::Slurpy,
+    'Unflattened slurpy type isa its namespace parent';


### PR DESCRIPTION
## Summary

- register concrete and abstract `RakuAST::*` type objects in the model-layer hierarchy
- make `.isa` and `~~` honor namespace and semantic ancestry such as `IntLiteral isa Term isa Expression isa Node`
- keep unknown `RakuAST::*` package names outside the registered hierarchy
- record Phase 3 slice 5 in `PLAN.md` and ADR-0011

## Why

RakuAST node values already returned the correct object from `.WHAT`, but those returned type objects did not participate in the RakuAST hierarchy. As a result, type-object checks such as `RakuAST::IntLiteral ~~ RakuAST::Node` disagreed with Rakudo even though instance checks worked.

## Validation

- `prove -e raku t/rakuast-type-objects.t` — 12/12
- `prove -e target/debug/mutsu t/rakuast-type-objects.t t/rakuast-smartmatch.t t/rakuast-semantic-hierarchy.t t/rakuast-construct.t` — 32/32
- `HOME=/tmp/mutsu-rakuast-home cargo test --quiet` — pass
- `cargo clippy --quiet -- -D warnings` — pass
- `git diff --check` — pass
