### PR TITLE
fix: `.^method_table`, the hash-composer rule, and the bare-adverb listop parse

### DIFF
--- a/news/2026-07/method-table-and-hash-composer-parse.md
+++ b/news/2026-07/method-table-and-hash-composer-parse.md
@@ -1,0 +1,79 @@
+# `.^method_table`, the hash-composer rule, and the bare-adverb listop parse
+
+Fixes taken off the `DBIish` blocker ledger
+(`todo/tickets/dbiish-blockers.md`), all of them general-purpose. Together they
+take `DBIish`'s `t/01-basic.rakutest` from dying before its first test to running
+18 of 35, and `t/05-mock.rakutest` from aborting after 13 of 16 tests to running
+all 16 with one failure left (a separate iterator bug, still on the ledger).
+
+## `.^method_table`
+
+`Metamodel::ClassHOW.method_table` returns the methods declared directly on a
+class, keyed by name. mutsu implemented the sibling `submethod_table` but not
+this one, so `DBIish.^method_table{$_}:exists` died with `No such method
+'method_table'`. It was recorded in the ledger as a `PackageHOW` gap; reducing it
+to a repro showed a plain `ClassHOW` has the same hole.
+
+Rakudo's table holds exactly the class's *own* methods: inherited methods are
+not in it, submethods live in `.^submethod_table`, private methods in
+`.^private_method_table`, while role-composed methods and public attribute
+accessors are included and a `multi` contributes a single dispatcher entry.
+`class_method_table` in `runtime/methods_classhow_method_obj.rs` builds that, and
+the values are real `Method` objects rather than name strings. Pinned by
+`t/method-table.t`, which passes unchanged under rakudo.
+
+## `{ ... }` is a hash composer when its first element *is* a pair
+
+`{ +(SQLT_CHR) => Str, … }` — a constant hash whose keys are expressions — parsed
+as a block, so `DBDish::Oracle::Native` died with `Odd number of elements found
+where hash initializer expected`. mutsu decided hash-versus-block from a
+syntactic prefix table: a bareword, number or quoted string followed by `=>`, a
+`%` variable, or a colonpair. Any other key expression fell through to the block
+reading.
+
+Rakudo's rule is about the *first element of the first statement*: the braces
+compose a hash when that element's outermost operator is a fatarrow. A cheap
+scan now decides whether a top-level `=>` is even in reach — it stops at a
+statement keyword, an assignment (`{ my %h = a => 1 }` assigns a pair, it is not
+one), a listop colon call, a ternary, or a preceding top-level comma or
+semicolon — and when it is, the first element is parsed and the fatarrow has to
+come out as the root of the resulting expression. That last step is what keeps
+`{ group-of 1 => 'x' }` a block: the scan sees the arrow, but the parse says the
+root is a listop call whose argument happens to be a pair.
+
+Widening the detection exposed one bug behind it: the hash-literal body parser
+committed to a bare leading key whenever what followed was not `=>`, so
+`{ 'a' ~ 'b' => 1 }` became the key `a` followed by `~ 'b' => 1` and produced
+`{:a(:b(1))}`. A bare key now stands alone only when the element ends right
+there (`{ a, 1 }`); anything else falls through to the ordinary expression
+parse, which already had the precedence right.
+
+An invocant-less method call also counts as a topic reference now, which is what
+makes `{ .key => 1 }` and `{ a => .key }` blocks in rakudo. mutsu already
+excluded an explicit `$_`; the leading-dot form was missed, and with the widened
+hash detection above it would have turned `map({ +SQLType::{.key} => .value },
+…)` — real code in `DBIish::Common` — into a hash. A `.^name` inside a string
+interpolation still does not count, since it belongs to that interpolation's own
+closure.
+
+## A bare adverb no longer swallows the enclosing argument list
+
+`is-deeply $sth.row :hash, %want, 'desc'` must call `.row(:hash)` and pass the
+remaining two arguments to `is-deeply`. mutsu handed all three to `.row`, so a
+zero-positional signature reported `Too many positionals passed; expected 0
+arguments but got 2`.
+
+The method-call parser distinguishes `.m: a, b` (colon call, takes the comma
+list) from `.m :adv` (space before the colon, an adverb) when it reads the first
+argument, but both then shared the same continuation loop, and that loop kept
+consuming `, next`. The adverb form now continues with further space-separated
+adverbs only — `$h.row :hash :other` binds both, `$h.row :hash, :other` binds
+only the first and leaves `:other` to the enclosing call, matching rakudo.
+
+## `$*VM.config<nativecall_backend>`
+
+`NativeLibs` reads `$*VM.config<nativecall_backend> eq 'dyncall'` unconditionally,
+and mutsu's two-key config warned `Use of uninitialized value of type Any in
+string context` on every load — noise that had twice been mistaken for a
+diagnosis while working through this ledger. mutsu's FFI is libffi, which is
+also what a modern MoarVM reports, so the key now says so.

--- a/src/parser/expr/postfix/loop_.rs
+++ b/src/parser/expr/postfix/loop_.rs
@@ -1042,7 +1042,13 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                             r_inner = r5;
                             continue;
                         }
-                        if !r4.starts_with(',') {
+                        // A space-separated adverb (`$sth.row :hash`) binds only
+                        // adverbs; the comma after it belongs to whatever list
+                        // encloses the call, so `is-deeply $sth.row :hash,
+                        // $want, 'desc'` passes two arguments to `is-deeply`,
+                        // not to `.row`. Only the colon-call form (`.m: a, b`)
+                        // takes the list.
+                        if has_space_before_colon || !r4.starts_with(',') {
                             break;
                         }
                         let r4 = &r4[1..];
@@ -2768,7 +2774,9 @@ fn postfix_expr_loop(mut rest: &str, mut expr: Expr, allow_ws_dot: bool) -> PRes
                             r_inner = r5;
                             continue;
                         }
-                        if !r4.starts_with(',') {
+                        // As for the plain method call above: a space-separated
+                        // adverb takes no positional list after the comma.
+                        if has_space_before_colon || !r4.starts_with(',') {
                             break;
                         }
                         let r4 = &r4[1..];

--- a/src/parser/primary/misc/hash.rs
+++ b/src/parser/primary/misc/hash.rs
@@ -91,9 +91,13 @@ pub(crate) fn parse_hash_literal_body(input: &str) -> PResult<'_, Expr> {
                 continue;
             }
 
-            // If followed by R=> (reverse fat arrow meta-operator), don't treat as
-            // simple key — fall through to expression parsing which handles R=> correctly.
-            if !after_key.starts_with("R=>") {
+            // A bare key only stands alone when the element ends right here
+            // (`{ a, 1 }`). Otherwise it is the start of a larger expression —
+            // `{ 'a' ~ 'b' => 1 }` is one pair with a computed key, not the key
+            // `a` followed by `~ 'b' => 1` — so fall through to the general
+            // expression parse below. `R=>` (the reverse fatarrow metaop) needs
+            // the same treatment.
+            if after_key.starts_with([',', ';', '}']) || after_key.is_empty() {
                 pending_key = Some(key);
                 let (r_key, _) = ws_inner(r_key);
                 if let Some(stripped) = r_key.strip_prefix(',') {

--- a/src/parser/primary/misc/lambda.rs
+++ b/src/parser/primary/misc/lambda.rs
@@ -446,11 +446,48 @@ fn body_references_topic(input: &str) -> bool {
             {
                 return true;
             }
+            // An invocant-less method call (`.key`, `.^name`) is a topic
+            // reference too: rakudo keeps `{ .key => 1 }` and `{ a => .key }`
+            // blocks. Only outside a string — a `.^name` inside an
+            // interpolation belongs to that interpolation's own closure, which
+            // is why `{ "{ .^name }X" => 1 }` stays a hash.
+            b'.' if depth == 1 && is_implicit_topic_call(bytes, i) => return true,
             _ => {}
         }
         i += 1;
     }
     false
+}
+
+/// Whether the `.` at `at` starts a method call with no invocant before it,
+/// i.e. one that takes `$_` as its invocant.
+fn is_implicit_topic_call(bytes: &[u8], at: usize) -> bool {
+    // A name (`.key`, `.^name`, `.?maybe`, `.&f`) or a postcircumfix
+    // (`.[0]`, `.{'k'}`, `.<k>`, `.(1)`). `.5` is a number, `..`/`...` a range
+    // and `.=` an assignment metaop, so none of those qualify.
+    let starts_call = bytes.get(at + 1).is_some_and(|c| {
+        c.is_ascii_alphabetic()
+            || matches!(c, b'_' | b'^' | b'?' | b'&' | b'[' | b'{' | b'<' | b'(')
+    });
+    if !starts_call {
+        return false;
+    }
+    let mut p = at;
+    while p > 0 && bytes[p - 1].is_ascii_whitespace() {
+        p -= 1;
+    }
+    let Some(prev) = p.checked_sub(1).map(|q| bytes[q]) else {
+        return true; // the body starts with the call
+    };
+    match prev {
+        // A term ends here, so the call has a real invocant.
+        b')' | b']' | b'}' | b'\'' | b'"' | b'.' => false,
+        b'>' => {
+            // `a => .key` has no invocant; `%h<a>.key` does.
+            matches!(p.checked_sub(2).map(|q| bytes[q]), Some(b'='))
+        }
+        c => !(c.is_ascii_alphanumeric() || c == b'_'),
+    }
 }
 
 fn body_has_placeholder_vars(input: &str) -> bool {
@@ -590,5 +627,156 @@ fn is_hash_literal_start(input: &str) -> bool {
             return true;
         }
     }
+    // General case: an arbitrary expression can produce the key, as in
+    // `{ +(SQLT_CHR) => Str }` or `{ "a" ~ "b" => 1 }`. Rakudo decides on the
+    // *first element of the first statement*: if its top level is a fatarrow
+    // pair, the braces compose a hash. `{ 1, 2 => 3 }` and `{ (1 => 2) }` are
+    // therefore blocks — the `=>` is not at the first element's top level.
+    first_element_has_toplevel_fatarrow(input)
+}
+
+/// Whether the first comma-element of the first statement in a block body is a
+/// `=>` (or `R=>`) pair, i.e. the fatarrow is the element's outermost operator.
+fn first_element_has_toplevel_fatarrow(input: &str) -> bool {
+    if !body_may_hold_toplevel_fatarrow(input) {
+        return false;
+    }
+    // The scan above only proves a `=>` is in reach; whether it is the element's
+    // *outermost* operator is a question for the expression grammar. `{ group-of
+    // 1 => 'x' }` passes the scan yet is a listop call whose argument happens to
+    // be a pair.
+    let Ok((_, expr)) = crate::parser::expr::expression(input) else {
+        return false;
+    };
+    let first = match &expr {
+        Expr::ArrayLiteral(items) => match items.first() {
+            Some(item) => item,
+            None => return false,
+        },
+        other => other,
+    };
+    let first = match first {
+        Expr::PositionalPair(inner) => inner.as_ref(),
+        other => other,
+    };
+    matches!(
+        first,
+        Expr::Binary {
+            op: crate::token_kind::TokenKind::FatArrow,
+            ..
+        }
+    )
+}
+
+/// A cheap pre-scan for the expensive check above: whether a `=>` can be the
+/// outermost operator of the first element at all. Anything that would sit
+/// above it answers no — a statement keyword, an assignment (`{ my %h = a => 1
+/// }` assigns a pair, it is not one), a listop colon call (`{ $o.m: a => 1 }`),
+/// a ternary, or a preceding top-level comma or semicolon.
+fn body_may_hold_toplevel_fatarrow(input: &str) -> bool {
+    if starts_with_statement_keyword(input) {
+        return false;
+    }
+    let bytes = input.as_bytes();
+    let mut depth = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let c = bytes[i];
+        match c {
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' => depth = depth.saturating_sub(1),
+            b'}' => {
+                if depth == 0 {
+                    return false;
+                }
+                depth -= 1;
+            }
+            b',' | b';' if depth == 0 => return false,
+            // `?? !!` — the pair would be a ternary branch, not the top level.
+            b'?' | b'!' if depth == 0 && bytes.get(i + 1) == Some(&c) => return false,
+            // `$o.m: a => 1` passes the pair to the listop.
+            b':' if depth == 0
+                && bytes.get(i + 1).is_some_and(|c| c.is_ascii_whitespace())
+                && !matches!(i.checked_sub(1).map(|p| bytes[p]), Some(b':')) =>
+            {
+                return false;
+            }
+            b'\'' | b'"' => {
+                let quote = c;
+                i += 1;
+                while i < bytes.len() && bytes[i] != quote {
+                    if bytes[i] == b'\\' {
+                        i += 1;
+                    }
+                    i += 1;
+                }
+            }
+            b'#' => {
+                // A comment runs to the end of the line; its text must not be
+                // mistaken for a fatarrow.
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            b'=' if depth == 0 => {
+                let prev = i.checked_sub(1).map(|p| bytes[p]);
+                if bytes.get(i + 1) == Some(&b'>') {
+                    // `<=>` and `==>` merely end in `=>` and form no pair.
+                    if !matches!(prev, Some(b'<') | Some(b'=')) {
+                        return true;
+                    }
+                    i += 1;
+                } else if bytes.get(i + 1) == Some(&b'=')
+                    || matches!(prev, Some(b'=') | Some(b'!') | Some(b'<') | Some(b'>'))
+                {
+                    // A comparison (`==`, `!=`, `<=`, `>=`), not an assignment.
+                } else {
+                    // Assignment (`=`, `:=`, `+=`, `.=` …) binds looser than or
+                    // equal to `=>`, so any pair to its right is nested.
+                    return false;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
     false
+}
+
+/// Whether a block body opens with a keyword that can only start a statement,
+/// which rules out the hash-composer reading outright.
+fn starts_with_statement_keyword(input: &str) -> bool {
+    let Ok((rest, word)) = crate::parser::stmt::ident_pub(input) else {
+        return false;
+    };
+    if !rest.starts_with(|c: char| c.is_whitespace()) {
+        return false;
+    }
+    matches!(
+        word.as_str(),
+        "my" | "our"
+            | "state"
+            | "has"
+            | "constant"
+            | "sub"
+            | "method"
+            | "return"
+            | "take"
+            | "if"
+            | "unless"
+            | "with"
+            | "without"
+            | "for"
+            | "while"
+            | "until"
+            | "repeat"
+            | "loop"
+            | "given"
+            | "when"
+            | "use"
+            | "need"
+            | "require"
+            | "do"
+    )
 }

--- a/src/runtime/io_sysinfo.rs
+++ b/src/runtime/io_sysinfo.rs
@@ -399,6 +399,12 @@ impl Interpreter {
             "0"
         };
         config.insert("be".to_string(), Value::str_from(be_val));
+        // nativecall_backend names the FFI implementation behind NativeCall.
+        // Modules branch on it to decide whether the dyncall-only extensions are
+        // available (`NativeLibs` does `$*VM.config<nativecall_backend> eq
+        // 'dyncall'`); mutsu's is libffi, which is also what a modern MoarVM
+        // reports, and reading it must not warn about an undefined value.
+        config.insert("nativecall_backend".to_string(), Value::str_from("libffi"));
         attrs.insert("config".to_string(), Value::hash(config));
         Value::make_instance(Symbol::intern("VM"), attrs)
     }

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -1095,6 +1095,14 @@ impl Interpreter {
                 };
                 Ok(Value::str(letter))
             }
+            "method_table" if !args.is_empty() => {
+                let type_name = match args[0].view() {
+                    ValueView::Package(name) => name.resolve(),
+                    ValueView::Instance { class_name, .. } => class_name.resolve(),
+                    _ => value_type_name(&args[0]).to_string(),
+                };
+                Ok(Value::hash(self.class_method_table(&type_name)))
+            }
             "submethod_table" if !args.is_empty() => {
                 let type_name = match args[0].view() {
                     ValueView::Package(name) => name.resolve(),

--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -340,6 +340,7 @@ impl Interpreter {
                 | "curried_role"
                 | "pun"
                 | "language-revision"
+                | "method_table"
                 | "submethod_table"
         ) {
             return Some(Value::str(method_name.to_string()));

--- a/src/runtime/methods_classhow_method_obj.rs
+++ b/src/runtime/methods_classhow_method_obj.rs
@@ -46,6 +46,52 @@ impl Interpreter {
         }
     }
 
+    /// Build the class's own method table (`.^method_table`): the methods
+    /// declared directly on `class_name`, keyed by name.
+    ///
+    /// Rakudo keeps submethods in `.^submethod_table` and private methods in
+    /// `.^private_method_table`, so neither appears here; public attribute
+    /// accessors and role-composed methods do, and a `multi` contributes a
+    /// single dispatcher entry.
+    pub(super) fn class_method_table(&self, class_name: &str) -> HashMap<String, Value> {
+        let mut table = HashMap::new();
+        let registry = self.registry();
+        let Some(class_def) = registry.classes.get(class_name) else {
+            return table;
+        };
+        for (attr_name, is_public, ..) in &class_def.attributes {
+            if *is_public && !class_def.methods.contains_key(attr_name) {
+                table.insert(attr_name.clone(), self.make_native_method_object(attr_name));
+            }
+        }
+        for (method_name, overloads) in &class_def.methods {
+            let Some(first) = overloads.first() else {
+                continue;
+            };
+            if first.is_private || first.is_submethod {
+                continue;
+            }
+            table.insert(
+                method_name.clone(),
+                self.make_method_object_with_owner(
+                    method_name,
+                    first,
+                    overloads.len() > 1,
+                    first.return_type.clone(),
+                    Some(overloads),
+                    Some(class_name),
+                ),
+            );
+        }
+        for native_name in &class_def.native_methods {
+            table.insert(
+                native_name.clone(),
+                self.make_native_method_object(native_name),
+            );
+        }
+        table
+    }
+
     /// Collect methods from a runtime-mixed-in role definition.
     pub(super) fn collect_role_methods(
         &self,

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -52,6 +52,7 @@ impl Interpreter {
                 | "parameterize"
                 | "pun"
                 | "language-revision"
+                | "method_table"
                 | "submethod_table"
         )
     }

--- a/t/bare-adverb-listop-arg.t
+++ b/t/bare-adverb-listop-arg.t
@@ -1,0 +1,42 @@
+use Test;
+
+plan 8;
+
+# A space-separated adverb binds to the method call it follows; the comma after
+# it continues the *enclosing* listop's argument list. Only the colon-call form
+# (`.m: a, b`) takes the comma list itself.
+#
+# `is-deeply $sth.row :hash, %want, 'desc'` used to hand `.row` the two
+# following arguments, so a zero-positional signature reported
+# "Too many positionals passed" (DBIish t/05-mock.rakutest).
+
+class Row {
+    method row(:$hash, :$other) {
+        ($hash ?? 'H' !! '-') ~ ($other ?? 'O' !! '-');
+    }
+    method args(*@a) { @a.join(',') }
+}
+
+my $r = Row.new;
+sub show(*@a, *%n) { '[' ~ @a.join('|') ~ ']' ~ %n.keys.sort.join(',') }
+
+is show($r.row(:hash), 'x', 'y'), '[H-|x|y]',
+    'the parenthesised adverb is the control';
+is show($r.row :hash, 'x', 'y'), '[H-|x|y]',
+    'a bare adverb leaves the following list to the listop';
+is show($r.row :hash :other, 'x'), '[HO|x]',
+    'space-separated adverbs all bind to the method call';
+is show($r.row :hash, :other, 'x'), '[H-|x]other',
+    'an adverb after a comma belongs to the enclosing call';
+is show($r.row :hash), '[H-]',
+    'a bare adverb with nothing after it still binds';
+
+# The colon-call form is unchanged: it still takes the whole comma list.
+my $joined = $r.args: 1, 2, 3;
+is $joined, '1,2,3', 'the colon-call form still takes the whole comma list';
+is show($r.args: 1, 2), '[1,2]', 'a colon call nested in a listop';
+
+# A hyper method call follows the same rule.
+my @rows = Row.new, Row.new;
+is show(@rows>>.row :hash, 'z'), '[H-|H-|z]',
+    'a bare adverb on a hyper method call leaves the list to the listop';

--- a/t/hash-composer-first-element.t
+++ b/t/hash-composer-first-element.t
@@ -1,0 +1,39 @@
+use Test;
+
+plan 16;
+
+# `{ ... }` composes a hash when the *first element of the first statement* is a
+# fatarrow pair, and is a block otherwise. Deciding that from a syntactic prefix
+# table missed every computed key, so `constant %m = { +(A) => Str }` — the shape
+# DBDish::Oracle::Native uses — parsed as a block and died with
+# "Odd number of elements found where hash initializer expected".
+
+constant A = 1;
+constant B = 2;
+
+# Computed keys.
+is-deeply { +(A) => 'x', +(B) => 'y' }, {'1' => 'x', '2' => 'y'},
+    'a prefix-op key composes a hash';
+is-deeply { 'a' ~ 'b' => 1 }, {ab => 1}, 'a concatenation key composes a hash';
+is-deeply { (1) => 'p' }, {'1' => 'p'}, 'a parenthesised key composes a hash';
+constant %m = { +(A) => Str, +(B) => Int };
+is %m.keys.sort.join(','), '1,2', 'a constant hash with computed keys';
+
+# Still hashes.
+isa-ok { a => 1 }, Hash, 'a bareword key is still a hash';
+isa-ok { a => 1; }, Hash, 'a trailing semicolon does not make it a block';
+isa-ok { 1 R=> 2 }, Hash, 'a reverse fatarrow composes a hash';
+isa-ok { }, Hash, 'an empty brace pair is still a hash';
+
+# Blocks: the fatarrow is not the first element's outermost operator.
+isa-ok { 1, 2 => 3 }, Block, 'a non-pair first element makes it a block';
+isa-ok { (1 => 2) }, Block, 'a parenthesised pair is not a top-level pair';
+isa-ok { 1 <=> 2 }, Block, '<=> is not a fatarrow';
+isa-ok { my %h = a => 1; %h }, Block, 'an assignment of a pair is a block';
+isa-ok { $_ => 1 }, Block, 'an explicit topic makes it a block';
+
+# An invocant-less method call is a topic reference too.
+isa-ok { .key => 1 }, Block, 'a leading-dot key makes it a block';
+isa-ok { a => .key }, Block, 'a leading-dot value makes it a block';
+# ... but one inside an interpolation belongs to that interpolation's closure.
+isa-ok { "{ .^name }X" => 1 }, Hash, 'a dot call inside a string does not count';

--- a/t/method-table.t
+++ b/t/method-table.t
@@ -1,0 +1,38 @@
+use Test;
+
+plan 12;
+
+class Base { method inherited() { } }
+role Mixed { method from-role() { } }
+
+class Sample is Base does Mixed {
+    has $.public-attr;
+    has $!private-attr;
+    method connect() { }
+    method !secret() { }
+    submethod BUILD() { }
+    multi method overloaded(Int) { }
+    multi method overloaded(Str) { }
+}
+
+my %table = Sample.^method_table;
+
+isa-ok %table, Hash, '.^method_table returns a Hash';
+is %table.keys.sort.join(','), 'connect,from-role,overloaded,public-attr',
+    'own methods, role-composed methods and public accessors are listed';
+
+ok %table<connect>:exists, 'a declared method is present';
+nok %table<inherited>:exists, 'an inherited method is not in the own table';
+nok %table<BUILD>:exists, 'a submethod is not in the method table';
+nok %table<secret>:exists, 'a private method is not in the method table';
+nok %table<nonesuch>:exists, 'an undeclared name is absent';
+
+isa-ok %table<connect>, Method, 'the value is a Method object';
+is %table<connect>.name, 'connect', 'the Method knows its name';
+ok %table<overloaded>.is_dispatcher, 'a multi contributes one dispatcher entry';
+
+# `.^submethod_table` is the sibling table and holds what `method_table` drops.
+ok Sample.^submethod_table<BUILD>:exists, '.^submethod_table holds the submethod';
+
+# The metamethod works on an instance too, not just on the type object.
+ok Sample.new.^method_table<connect>:exists, '.^method_table works on an instance';

--- a/t/vm-osname.t
+++ b/t/vm-osname.t
@@ -1,9 +1,15 @@
 use v6;
 use Test;
 
-plan 3;
+plan 6;
 
 # `$*VM.osname` exposes the build-time OS name (zef branches on it).
 ok $*VM.osname.defined, '$*VM.osname is defined';
 isa-ok $*VM.osname, Str, '$*VM.osname is a Str';
 ok $*VM.osname.chars > 0, '$*VM.osname is non-empty';
+
+# `$*VM.config<nativecall_backend>` names the FFI implementation. `NativeLibs`
+# reads it unconditionally, so an undefined value there warns on every load.
+ok $*VM.config<nativecall_backend>.defined, '$*VM.config<nativecall_backend> is defined';
+isa-ok $*VM.config<nativecall_backend>, Str, '$*VM.config<nativecall_backend> is a Str';
+ok $*VM.config<be>.defined, '$*VM.config<be> is still defined';

--- a/todo/tickets/dbiish-blockers.md
+++ b/todo/tickets/dbiish-blockers.md
@@ -44,8 +44,8 @@ recreate it from the recipe above), debug build, both interpreters on the same
 | `44-sqlite-memory` | 1 fail of 109* | **PASS 109/109** | — |
 | `45-sqlite-common` | 1 fail of 109* | **PASS 109/109** | — |
 | `03-lib-util` | 1 fail of 5* | 1 fail of 5* | — (same subtest as raku) |
-| `01-basic` | PASS 35/35 | ran 0/35, dies | ③ `PackageHOW.method_table` |
-| `05-mock` | PASS 16/16 | 1 fail of 13 run | ④ `IterationEnd` from a row fetch, then `Too many positionals passed; expected 0 arguments but got 2` |
+| `01-basic` | PASS 35/35 | 3 fail of 18 run | ⑧ a second `require ::($m)` of a driver loses `NativeLibs`' exports |
+| `05-mock` | PASS 16/16 | 1 fail of 16 | ④b `IterationEnd` from a row fetch (test 12) |
 | `06-types` | PASS 12/12 | 2 fail of 3 run | ⑤ `Int is builtin` / `So not defined`; mutsu suggests `Did you mean 'invert'?` |
 
 \* Those raku failures are `# TODO`-marked and environment-dependent, not bugs:
@@ -144,39 +144,55 @@ say "7-keys    : ", $*VM.config.keys.sort.join(',');
 | line | raku | mutsu |
 | --- | --- | --- |
 | `4a-control` | `HASH\|x\|y` | `HASH\|x\|y` |
-| `4a-bare` | `HASH\|x\|y` | **DIED: Too many positionals passed; expected 0 arguments but got 2** |
+| `4a-bare` | `HASH\|x\|y` | `HASH\|x\|y` (fixed) |
 | `4b-isa` | `Seq` | `Seq` |
 | `4b-pullone` | `["a", "b", 1]` | **`"IterationEnd"`** |
-| `3-mtable` | `True` | **DIED: No such method 'method_table'** |
-| `7-nc-back` | `"dyncall"` | **`Any`** |
-| `7-keys` | ~200 keys | `be,name` |
+| `3-mtable` | `True` | `True` (fixed) |
+| `7-nc-back` | `"dyncall"` | `"libffi"` (fixed) |
+| `7-keys` | ~200 keys | `be,name,nativecall_backend` |
 
-### ④a A bare adverb on a listop argument swallows the rest of the argument list
+### ④a A bare adverb on a listop argument — FIXED
 
-`is-deeply $sth.row :hash, hash(...), 'desc'` must parse as
-`is-deeply($sth.row(:hash), hash(...), 'desc')` — the adverb binds to the method
-call, and the comma continues the *listop's* argument list. mutsu instead hands
-`.row` the two following arguments, so a zero-positional signature reports
-`Too many positionals passed; expected 0 arguments but got 2`. Parenthesising the
-adverb (`$h.row(:hash)`) works, which pins this to the bare-adverb parse. This is
-a parser precedence bug with nothing to do with `DBIish`; it aborts `05-mock` at
-line 32 after 13 of 16 tests.
+`is-deeply $sth.row :hash, hash(...), 'desc'` handed `.row` the two following
+arguments instead of leaving them to the listop. The method-call parser already
+told the colon call (`.m: a, b`, which does take the comma list) apart from the
+space-separated adverb, but both shared one continuation loop that kept
+consuming `, next`. Fixed — see
+[`news/2026-07/method-table-and-hash-composer-parse.md`](../../news/2026-07/method-table-and-hash-composer-parse.md).
 
 ### ④b `pull-one` on a hand-obtained iterator yields the `IterationEnd` sentinel
 
 Three lines of `gather`/`take` reproduce it: `a.iterator.pull-one` answers the
-string `IterationEnd` instead of the first element. The sentinel is leaking out
-as an ordinary value rather than terminating iteration — the `Seq`/iterator
-exhaustion family. This is `05-mock` test 12.
+string `IterationEnd` instead of the first element. This is `05-mock` test 12.
 
-### ③ `.^method_table` is not implemented
+Reduced further 2026-07-26: it is specific to a **lazy, not-yet-materialised**
+source. `(1,2,3).Seq.iterator.pull-one`, `@a.iterator.pull-one` and
+`(1..3).map(*+1).iterator.pull-one` are all correct; only `gather`/`take` fails,
+and forcing it first (`$s.elems; $s.iterator.pull-one`) makes it correct too. The
+cause is that `builtins::iterator_construct::build_iterator_instance` snapshots
+`value_to_list(target)` into an `items` array — for a lazy gather that prefix is
+empty, so `runtime/iterator_protocol.rs` steps straight past the end. The real
+fix is an `Iterator` that pulls from its source on demand rather than from a
+materialised prefix; eagerly forcing the source instead would hang on an
+infinite lazy list.
 
-Not a `PackageHOW`-only gap as first recorded: the repro raises it on a plain
-`ClassHOW` too. `src/runtime/methods_classhow_dispatch.rs` implements
-`submethod_table` but not `method_table`; the sibling arm is the model (walk
-`registry().classes[type].methods`, return a `Hash` of name → method). `01-basic`
-uses it as `DBIish.^method_table{$_}:exists`, so name → anything defined is
-enough for that file, but Rakudo returns the method objects.
+### ③ `.^method_table` — FIXED
+
+Not a `PackageHOW`-only gap as first recorded — a plain `ClassHOW` had the same
+hole. Fixed, with `Method` objects as the values, matching rakudo. See
+[`news/2026-07/method-table-and-hash-composer-parse.md`](../../news/2026-07/method-table-and-hash-composer-parse.md).
+
+### ⑧ A repeat `require ::($module)` loses `NativeLibs`' re-exports
+
+New, and what `01-basic` stops on now. Installing the drivers one at a time works
+(`DBIish.install-driver('SQLite')` on its own returns `DBDish::SQLite`), but the
+file's `for <Oracle Pg SQLite TestMock mysql>` loop fails on the third and fifth:
+`Could not find symbol '&is-win' in 'NativeLibs'` for SQLite and `Type 'ulong' is
+not declared` for mysql, both raised from inside `NativeLibs`' `CHECK for
+NativeCall::EXPORT::.keys { UNIT::EXPORT::{$_} := … }`. So a second `require
+::($module)` in the same process re-runs that `CHECK` against a registry that no
+longer holds the first load's exports — the same export/registry-rewind family as
+`news/2026-07/`'s subtest and `EVAL` entries.
 
 ### ⑤ `06-types` — object hash keyed by type objects
 
@@ -200,15 +216,17 @@ suggestion is the *symptom* of an unresolved delegated `AT-KEY`, not a typo.
 Note the object-hash requirement overlaps the deferred "object-hash `WHICH`"
 item in the doc-diff DEEP bucket (`docs/doc-diff-backlog.md`).
 
-### ⑦ `$*VM.config` has two keys
+### ⑦ `$*VM.config` — `nativecall_backend` added, the rest of the surface is not
 
-mutsu's `$*VM.config` answers only `be` and `name`; raku's MoarVM config has
-around 200. `NativeLibs` reads
-`my \dyncall = $*VM.config<nativecall_backend> eq 'dyncall'` and so warns
+`NativeLibs` reads
+`my \dyncall = $*VM.config<nativecall_backend> eq 'dyncall'` and used to warn
 `Use of uninitialized value of type Any in string context` on every run that
-loads it. Harmless — `dyncall` ends up `False`, which is what mutsu wants — but
-it is noise in every `DBIish` run. Adding `nativecall_backend` alone is a
-one-line fix; deciding how much of the config surface to synthesise is not.
+loads it — noise that had twice been mistaken for a diagnosis in this file. That
+key now answers `"libffi"`, which is what mutsu's FFI actually is and what a
+modern MoarVM reports (`dyncall` still ends up `False`, which is what mutsu
+wants). The config still has three keys against raku's ~200; deciding how much
+of that surface to synthesise is a separate question, and nothing in `DBIish`
+needs it.
 
 ## Role attribute not seeded — FIXED
 
@@ -257,16 +275,14 @@ the adverbs away outright.
 
 ## Suggested order for the next session
 
-Cheapest first, and none of them depends on another:
+⑦, ③ and ④a are done. What is left, cheapest first; none depends on another:
 
-1. **⑦** — one line, and it removes the warning that has twice been mistaken for
-   a diagnosis in this file.
-2. **③** — `submethod_table` next door is the model; worth one file (`01-basic`).
-3. **④a** — a parser precedence fix, self-contained, and the thing that aborts
-   `05-mock` two thirds of the way through.
-4. **④b** — the `IterationEnd` leak. Same file as ④a, but a different subsystem
-   (`Seq`/iterator exhaustion); do it as its own change.
-5. **⑤** — the largest: an object hash keyed by type objects, plus `handles`
+1. **④b** — the `IterationEnd` leak, now reduced to "a lazy source hands the
+   `Iterator` an empty materialised prefix". Needs a pull-on-demand `Iterator`,
+   so it is a real slice, not a one-liner.
+2. **⑧** — a repeat `require ::($m)` losing `NativeLibs`' re-exports. Related
+   registry-rewind bugs have been fixed twice before, so there is a model.
+3. **⑤** — the largest: an object hash keyed by type objects, plus `handles`
    delegation from a private attribute. Confirm which of the five features listed
    above is actually missing before scoping it.
 


### PR DESCRIPTION
Four general-purpose fixes taken off the `DBIish` blocker ledger
(`todo/tickets/dbiish-blockers.md`), each reduced to a standalone repro first.

### `.^method_table`

Missing entirely — the ledger recorded it as a `PackageHOW` gap, but a plain
`ClassHOW` had the same hole. It now returns the class's *own* methods as
`Method` objects: inherited methods are not in it, submethods stay in
`.^submethod_table` and private methods in `.^private_method_table`, while
role-composed methods and public attribute accessors are included and a `multi`
contributes a single dispatcher entry. Pinned by `t/method-table.t`, which
passes unchanged under rakudo.

### `{ ... }` composes a hash when its first element *is* a pair

`constant %sqltype-map = { +(SQLT_CHR) => Str, … }` parsed as a block, so
`DBDish::Oracle::Native` died with `Odd number of elements found where hash
initializer expected`. mutsu decided hash-versus-block from a syntactic prefix
table (bareword/number/quoted string followed by `=>`, a `%` variable, a
colonpair); any other key expression fell through to the block reading.

Rakudo's rule is about the first element of the first statement: the braces
compose a hash when that element's outermost operator is a fatarrow. A cheap
scan now decides whether a top-level `=>` is even in reach — it stops at a
statement keyword, an assignment (`{ my %h = a => 1 }` assigns a pair, it is not
one), a listop colon call, a ternary, or a preceding top-level comma or
semicolon — and when it is, the first element is parsed and the fatarrow has to
come out as the root of the resulting expression. That last step is what keeps
`{ group-of 1 => 'x' }` a block: the scan sees the arrow, but the parse says the
root is a listop call whose argument happens to be a pair.

An invocant-less method call counts as a topic reference now, which is what
makes `{ .key => 1 }`, `{ a => .key }` and `{ .[0] => 1 }` blocks in rakudo. A
`.^name` inside a string interpolation still does not count, since it belongs to
that interpolation's own closure.

Widening the detection exposed one bug behind it: the hash-literal body parser
committed to a bare leading key whenever what followed was not `=>`, so
`{ 'a' ~ 'b' => 1 }` became the key `a` followed by `~ 'b' => 1` and produced
`{:a(:b(1))}`. A bare key now stands alone only when the element ends right
there (`{ a, 1 }`).

### A bare adverb no longer swallows the enclosing argument list

`is-deeply $sth.row :hash, %want, 'desc'` must call `.row(:hash)` and pass the
remaining two arguments to `is-deeply`; mutsu handed all three to `.row`, so a
zero-positional signature reported `Too many positionals passed`. The parser
already told `.m: a, b` (colon call, takes the comma list) apart from `.m :adv`
when reading the first argument, but both then shared a continuation loop that
kept consuming `, next`. The adverb form now continues with further
space-separated adverbs only, matching rakudo.

### `$*VM.config<nativecall_backend>`

`NativeLibs` reads it unconditionally, and the two-key config warned `Use of
uninitialized value of type Any in string context` on every load — noise that
had twice been mistaken for a diagnosis while working through this ledger.

### Effect

`DBIish` `t/01-basic.rakutest` goes from dying before its first test to running
18 of 35; `t/05-mock.rakutest` from aborting after 13 of 16 to running all 16
with one failure left (the `IterationEnd` iterator bug, still on the ledger,
now reduced further there). Local `make test` and `make roast` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)