### PR TITLE
rakuast: expose model hierarchy via MRO

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1135,7 +1135,9 @@ so it is tracked separately from the roast backlog.
         namespace + semantic hierarchy under `.isa`/`~~`. Tests in `t/rakuast-type-objects.t`.
   - [x] Slice 6: `.isa` and `.^isa` on registered type objects and node values use the same
         namespace + semantic hierarchy as `~~`. Tests extended in `t/rakuast-type-objects.t`.
-  - [ ] Slice 7+: remaining type-object metaobject operations.
+  - [x] Slice 7: `.^mro` / `.^parents` on registered type objects and node values expose the
+        namespace + semantic model hierarchy. Tests extended in `t/rakuast-type-objects.t`.
+  - [ ] Slice 8+: remaining type-object metaobject operations.
 - **Phase 4 (in progress)** — construction (`.new`).
   - [x] Slice 1: literal constructors (`RakuAST::IntLiteral.new(42)`, `StrLiteral`, `RatLiteral`).
         Tests in `t/rakuast-construct.t`.

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -157,6 +157,9 @@ earlier ones.
   - **Slice 6 (`.isa` / `.^isa` parity) — done.** Both ordinary and metaobject `isa` dispatch on
     registered type objects and node values use the same namespace and semantic hierarchy as
     smartmatch, including `IntLiteral` → `Term` → `Expression`.
+  - **Slice 7 (`.^mro` / `.^parents`) — done.** Registered type objects and concrete node values
+    expose the model layer's namespace and semantic hierarchy through ClassHOW introspection,
+    including `:local`, `:all`, and parent-tree traversal.
 - **Phase 4 — Construction.** `.new` (and `.from-identifier`, …) on RakuAST type objects
   build `Value::RakuAst`, validating args against the per-class field schema.
   - **Slice 1 (literals) — done.** `RakuAST::IntLiteral.new(42)` / `RatLiteral.new(3.5)` /

--- a/news/2026-07/rakuast-mro-parents.md
+++ b/news/2026-07/rakuast-mro-parents.md
@@ -1,0 +1,15 @@
+# RakuAST type objects expose their model hierarchy
+
+`RakuAST::*` type objects and nodes now report their registered namespace and
+semantic hierarchy through `.^mro` and `.^parents`. Previously those operations
+fell through to the generic runtime class registry, which knew only the concrete
+package name followed by `Any` and `Mu`.
+
+The model layer now supplies one linearized hierarchy used by ClassHOW. For
+example, `RakuAST::IntLiteral.^mro` includes `IntLiteral`, `Term`, `Expression`,
+`Node`, `Any`, and `Mu`; statement types retain their namespace parent before
+`Node`. Parent queries, including `:local`, `:all`, and `:tree`, derive from the
+same hierarchy, and concrete RakuAST node values use their node class rather
+than the generic value representation.
+
+Pinned by the expanded `t/rakuast-type-objects.t`.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -321,6 +321,46 @@ pub fn type_object_isa(actual: &str, expected: &str) -> bool {
     }
 }
 
+/// The model-layer MRO for a registered RakuAST type object. This intentionally
+/// reflects mutsu's documented RakuAST hierarchy rather than pretending these
+/// model types are ordinary entries in the runtime class registry.
+pub fn type_object_mro(class_name: &str) -> Option<Vec<String>> {
+    if !is_registered_type_object(class_name) {
+        return None;
+    }
+
+    let mut mro = vec![class_name.to_string()];
+    let mut namespace = class_name;
+    while let Some((parent, _)) = namespace.rsplit_once("::") {
+        if parent == "RakuAST" {
+            break;
+        }
+        if is_registered_type_object(parent) && !mro.iter().any(|name| name == parent) {
+            mro.push(parent.to_string());
+        }
+        namespace = parent;
+    }
+    for ancestor in semantic_type_object_ancestors(class_name) {
+        if !mro.iter().any(|name| name == ancestor) {
+            mro.push((*ancestor).to_string());
+        }
+    }
+    if class_name == "RakuAST::Term" && !mro.iter().any(|name| name == "RakuAST::Expression") {
+        mro.push("RakuAST::Expression".to_string());
+    }
+    if class_name != "RakuAST::Node" {
+        mro.push("RakuAST::Node".to_string());
+    }
+    mro.push("Any".to_string());
+    mro.push("Mu".to_string());
+    Some(mro)
+}
+
+/// The immediate parent in mutsu's linearized RakuAST model hierarchy.
+pub fn type_object_direct_parent(class_name: &str) -> Option<String> {
+    type_object_mro(class_name)?.into_iter().nth(1)
+}
+
 fn semantic_type_object_ancestors(class_name: &str) -> &'static [&'static str] {
     const TERM: &[&str] = &["RakuAST::Term", "RakuAST::Expression"];
     const EXPR: &[&str] = &["RakuAST::Expression"];

--- a/src/runtime/methods_classhow_mro.rs
+++ b/src/runtime/methods_classhow_mro.rs
@@ -5,10 +5,13 @@ impl Interpreter {
     pub(super) fn classhow_mro_names(&mut self, invocant: &Value) -> Vec<String> {
         let class_name = match invocant.view() {
             ValueView::Package(name) => name.resolve(),
+            ValueView::RakuAst(node) => node.class.printed_name().to_string(),
             ValueView::Instance { class_name, .. } => class_name.resolve(),
             _ => value_type_name(invocant).to_string(),
         };
-        let mut mro = if self.registry().classes.contains_key(&class_name) {
+        let mut mro = if let Some(mro) = crate::rakuast::type_object_mro(&class_name) {
+            mro
+        } else if self.registry().classes.contains_key(&class_name) {
             self.class_mro(&class_name)
                 .iter()
                 .map(|s| s.resolve())

--- a/src/runtime/methods_classhow_parents.rs
+++ b/src/runtime/methods_classhow_parents.rs
@@ -16,6 +16,7 @@ impl Interpreter {
         let tree = has_flag("tree");
         let class_name = match args[0].view() {
             ValueView::Package(name) => name.resolve(),
+            ValueView::RakuAst(node) => node.class.printed_name().to_string(),
             ValueView::Instance { class_name, .. } => class_name.resolve(),
             _ => value_type_name(&args[0]).to_string(),
         };
@@ -94,6 +95,9 @@ impl Interpreter {
     /// `Any` inherits `Mu`; `Mu` is the root (no parents). Composed roles are
     /// excluded — only parent classes participate in the tree.
     fn tree_effective_parents(&self, class_name: &str) -> Vec<String> {
+        if let Some(parent) = crate::rakuast::type_object_direct_parent(class_name) {
+            return vec![parent];
+        }
         let registered: Vec<String> = self
             .registry()
             .classes

--- a/t/rakuast-type-objects.t
+++ b/t/rakuast-type-objects.t
@@ -3,7 +3,7 @@ use experimental :rakuast;
 
 # RakuAST Phase 3 slice 5 (ADR-0011): registered type objects and `.WHAT`.
 
-plan 24;
+plan 37;
 
 my $literal = Q[42].AST.statements[0].expression;
 
@@ -42,3 +42,22 @@ is RakuAST::Statement::If.^isa(RakuAST::Expression), 0,
 
 is $literal.^isa(RakuAST::Term), 1, 'node .^isa follows semantic hierarchy';
 is $literal.^isa(RakuAST::Statement), 0, 'node .^isa rejects unrelated node type';
+
+my @literal-mro = RakuAST::IntLiteral.^mro;
+is @literal-mro.elems, 6, 'literal type-object MRO has the model hierarchy and roots';
+is @literal-mro[0].^name, 'RakuAST::IntLiteral', 'literal MRO starts with concrete type';
+is @literal-mro[1].^name, 'RakuAST::Term', 'literal MRO includes semantic Term parent';
+is @literal-mro[2].^name, 'RakuAST::Expression', 'literal MRO includes Expression';
+is @literal-mro[3].^name, 'RakuAST::Node', 'literal MRO includes Node';
+is @literal-mro[4].^name, 'Any', 'literal MRO includes Any';
+is @literal-mro[5].^name, 'Mu', 'literal MRO includes Mu';
+
+my @if-parents = RakuAST::Statement::If.^parents;
+is @if-parents.elems, 2, 'statement parents omit Any and Mu';
+is @if-parents[0].^name, 'RakuAST::Statement', 'statement has namespace parent';
+is @if-parents[1].^name, 'RakuAST::Node', 'statement parents include Node';
+
+is RakuAST::IntLiteral.^parents(:local)[0].^name, 'RakuAST::Term',
+    ':local reports the immediate semantic parent';
+is RakuAST::IntLiteral.^parents(:all)[3].^name, 'Any', ':all retains Any';
+is $literal.^mro[0].^name, 'RakuAST::IntLiteral', 'node .^mro uses its concrete model type';


### PR DESCRIPTION
## What changed

- add a single model-layer MRO for registered `RakuAST::*` types
- route ClassHOW `.^mro` and `.^parents` through that hierarchy for both type objects and concrete nodes
- support `:local`, `:all`, and parent-tree traversal from the same hierarchy
- record Phase 3 Slice 7 in PLAN, ADR, and news

## Why

RakuAST smartmatch and `isa` already understood namespace and semantic parents, but `.^mro` and `.^parents` still fell through to the generic runtime class registry. They therefore reported only the concrete package followed by `Any` and `Mu`, contradicting the other introspection operations.

## Impact

RakuAST hierarchy introspection is now internally consistent. For example, `RakuAST::IntLiteral.^mro` exposes `IntLiteral`, `Term`, `Expression`, `Node`, `Any`, and `Mu`, while statement nodes expose their namespace parent before `Node`.

## Validation

- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `prove -e target/debug/mutsu t/rakuast-type-objects.t` (37 tests)
- `make test` (590 Rust tests; 2501 TAP files / 23875 tests)