### PR TITLE
fix: an `Iterator` pulls from its lazy source instead of a frozen prefix

### DIFF
--- a/news/2026-07/iterator-pulls-from-its-lazy-source.md
+++ b/news/2026-07/iterator-pulls-from-its-lazy-source.md
@@ -1,0 +1,33 @@
+# An `Iterator` pulls from its lazy source instead of a frozen prefix
+
+`gather { take 1; take 2 }.iterator.pull-one` answered the string
+`IterationEnd` instead of `1`. The sentinel was leaking out as an ordinary
+value, so a consumer that checks for it saw an empty sequence and one that does
+not saw the literal string — `DBIish`'s `t/05-mock.rakutest` test 12 compared it
+against a row and reported `expected: 'a b 1', got: 'IterationEnd'`.
+
+`.iterator` built its `Iterator` instance by snapshotting
+`value_to_list(target)` into an `items` array plus a zero index, and
+`runtime/iterator_protocol.rs` stepped over that array. For an already
+materialised source that is fine — `(1,2,3).Seq`, an `Array`, even
+`(1..3).map(*+1)` were all correct. For a lazy one the snapshot is only whatever
+prefix has been produced so far, and for a `gather` that has never been forced
+that is nothing at all, so the very first step was already past the end. Forcing
+the source at construction time would have fixed the gather and hung on
+`gather { loop { take 1 } }`.
+
+The instance now keeps the lazy source alongside the prefix, and each protocol
+call tops the prefix up from it before stepping — bounded by what that
+particular call needs. `pull-one` asks for one more element than the cursor,
+`push-exactly(@a, n)` for `n`, `skip-at-least(n)` for `n`; only `push-all` and
+`sink-all`, which consume the source by definition, force it to exhaustion.
+`push-until-lazy` deliberately asks for nothing, since stopping at a lazy
+boundary is its entire purpose. An infinite `gather` therefore still yields
+element after element without materialising, and the mutating dispatch path
+keeps the grown prefix on the instance so repeated pulls do not re-force from
+the start.
+
+Pinned by `t/iterator-pull-from-lazy-source.t`, which passes unchanged under
+rakudo. `DBIish`'s `t/05-mock.rakutest` reaches raku parity at 16/16 with this
+and the bare-adverb parse fix that landed alongside it, taking the database
+battery to 7 of 9 files at parity.

--- a/src/builtins/iterator_construct.rs
+++ b/src/builtins/iterator_construct.rs
@@ -61,6 +61,14 @@ pub(crate) fn build_iterator_instance(target: &Value) -> Value {
     attrs.insert("index".to_string(), Value::int(0));
     if lazy {
         attrs.insert("is_lazy".to_string(), Value::TRUE);
+        // `items` above is only whatever prefix the source has produced so far —
+        // for a `gather` that has never been forced, nothing at all. Keep the
+        // source so the protocol methods can pull more on demand instead of
+        // reporting the sentinel as though it were exhausted (see
+        // `Interpreter::iterator_topup_from_lazy_source`).
+        if matches!(target.view(), ValueView::LazyList(_)) {
+            attrs.insert("lazy_source".to_string(), target.clone());
+        }
     }
     if let Some(count) = known_count {
         attrs.insert("known_count".to_string(), count);

--- a/src/runtime/iterator_protocol.rs
+++ b/src/runtime/iterator_protocol.rs
@@ -132,7 +132,60 @@ pub(crate) fn step(
     Some(step)
 }
 
+/// How many elements of `items` a protocol call needs to see before it can
+/// answer, or `None` when the method wants the whole source.
+fn needed_len(method: &str, index: usize, args: &[Value]) -> Option<usize> {
+    let arg_int = |v: Option<&Value>, default: i64| -> usize {
+        v.map(crate::runtime::to_int).unwrap_or(default).max(0) as usize
+    };
+    match method {
+        "pull-one" | "skip-one" => Some(index + 1),
+        "push-exactly" | "push-at-least" => Some(index + arg_int(args.get(1), 1)),
+        "skip-at-least" => Some(index + arg_int(args.first(), 0)),
+        // The value *after* the skipped run, so one more than the skip itself.
+        "skip-at-least-pull-one" => Some(index + arg_int(args.first(), 0) + 1),
+        // `push-until-lazy` exists precisely to stop at a lazy boundary, so it
+        // must not force; the rest consume the source to exhaustion.
+        "push-all" | "sink-all" => None,
+        _ => Some(index),
+    }
+}
+
 impl crate::Interpreter {
+    /// Top up an `Iterator` instance's materialised prefix from the lazy source
+    /// it was built from, so a protocol call sees the elements it needs.
+    ///
+    /// `.iterator` snapshots whatever the source has produced so far. For a
+    /// `gather` that has never been forced that is nothing, so `pull-one`
+    /// stepped straight past the end and handed back the `IterationEnd`
+    /// sentinel as an ordinary value — `S.new.allrows.iterator.pull-one`
+    /// answered `"IterationEnd"` instead of the first row (`DBIish`
+    /// `t/05-mock.rakutest` test 12). The pull is bounded by what the call
+    /// actually needs, so an infinite source stays lazy.
+    ///
+    /// Returns the topped-up items, or `None` when there was nothing to do.
+    pub(crate) fn iterator_topup_from_lazy_source(
+        &mut self,
+        source: Option<&Value>,
+        method: &str,
+        index: usize,
+        args: &[Value],
+        have: usize,
+    ) -> Option<Vec<Value>> {
+        let ValueView::LazyList(list) = source?.view() else {
+            return None;
+        };
+        let pulled = match needed_len(method, index, args) {
+            Some(need) if need <= have => return None,
+            Some(need) => self.force_lazy_list_vm_n(&list, need),
+            None => self.force_lazy_list_bridge(&list),
+        };
+        // A source that cannot be forced (an infinite pipe answers
+        // X::Cannot::Lazy) leaves the prefix as it was; the step then reports
+        // exhaustion exactly as before.
+        pulled.ok().filter(|items| items.len() > have)
+    }
+
     /// Append `vals` to the array passed as the `push-*` family's first
     /// argument, updating every binding that shares the array's identity.
     pub(crate) fn iterator_append_to_array_arg(&mut self, args: &[Value], vals: &[Value]) {

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -1001,7 +1001,7 @@ impl Interpreter {
             // temporary, but the `push-*` family still appends to its array
             // argument. Shares the single stepping implementation with the
             // mutating (variable receiver) path.
-            let items = match attributes.as_map().get("items").map(|v| v.view()) {
+            let mut items = match attributes.as_map().get("items").map(|v| v.view()) {
                 Some(ValueView::Array(values, ..)) => values.to_vec(),
                 _ => Vec::new(),
             };
@@ -1009,6 +1009,19 @@ impl Interpreter {
                 Some(ValueView::Int(i)) if i >= 0 => i as usize,
                 _ => 0,
             };
+            // A lazy source may not have produced the elements this call needs
+            // yet. The cursor is discarded with this temporary receiver, but the
+            // pulled elements still have to reach the step below.
+            let lazy_source = attributes.as_map().get("lazy_source").cloned();
+            if let Some(more) = self.iterator_topup_from_lazy_source(
+                lazy_source.as_ref(),
+                method,
+                index,
+                &args,
+                items.len(),
+            ) {
+                items = more;
+            }
             if let Some(step) = super::iterator_protocol::step(method, &items, index, &args) {
                 if let Some(range) = step.append {
                     let vals = items[range].to_vec();

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -2335,7 +2335,7 @@ impl Interpreter {
                     return Ok(ret);
                 }
 
-                let items = match updated.get("items").map(Value::view) {
+                let mut items = match updated.get("items").map(Value::view) {
                     Some(ValueView::Array(values, ..)) => values.to_vec(),
                     _ => Vec::new(),
                 };
@@ -2343,6 +2343,20 @@ impl Interpreter {
                     Some(ValueView::Int(i)) if i >= 0 => i as usize,
                     _ => 0,
                 };
+                // A lazy source may not have produced the elements this call
+                // needs yet; pull them and keep the grown prefix on the
+                // instance, so the next call starts from it.
+                let lazy_source = updated.get("lazy_source").cloned();
+                if let Some(more) = self.iterator_topup_from_lazy_source(
+                    lazy_source.as_ref(),
+                    method,
+                    index,
+                    &args,
+                    items.len(),
+                ) {
+                    items = more;
+                    updated.insert("items".to_string(), Value::array(items.clone()));
+                }
                 let len = items.len();
                 // A known logical count (set for `LHS xx N` lazy repeats) overrides
                 // the materialized prefix length, so `.count-only` / `.bool-only`

--- a/t/iterator-pull-from-lazy-source.t
+++ b/t/iterator-pull-from-lazy-source.t
@@ -1,0 +1,60 @@
+use Test;
+
+plan 12;
+
+# `.iterator` on a lazy value snapshots whatever prefix the source has produced
+# so far — for a `gather` that has never been forced, nothing. The protocol
+# methods then stepped straight past the end and answered the `IterationEnd`
+# sentinel as an ordinary value (DBIish t/05-mock.rakutest test 12). They pull
+# from the source on demand now, and the pull stays bounded so an infinite
+# source is still safe.
+
+{
+    my $s = gather { take 1; take 2; take 3 };
+    is $s.iterator.pull-one, 1, 'pull-one on an unforced gather yields the first element';
+}
+
+{
+    my $s = gather { take 'a'; take 'b'; take 'c' };
+    my $i = $s.iterator;
+    is $i.pull-one, 'a', 'first pull';
+    is $i.pull-one, 'b', 'second pull';
+    is $i.pull-one, 'c', 'third pull';
+    is $i.pull-one, IterationEnd, 'the sentinel arrives only at the real end';
+}
+
+# Elements can be any value, including a list (the DBIish row shape).
+{
+    class Rows { method allrows() { gather { take ['a', 'b', 1]; take ['d', 'e', 2] } } }
+    my $rows = Rows.new.allrows;
+    is $rows.^name, 'Seq', 'gather in a method still returns a Seq';
+    is-deeply $rows.iterator.pull-one, ['a', 'b', 1], 'the first row comes back whole';
+}
+
+# An infinite source must stay lazy: the pull is bounded by what is needed.
+{
+    my $s = gather { my $n = 0; loop { take $n++ } };
+    my $i = $s.iterator;
+    is $i.pull-one, 0, 'pull-one on an infinite gather does not force it';
+    is $i.pull-one, 1, 'and can be pulled again';
+}
+
+# The rest of the index-advancing family sees the pulled elements too.
+{
+    my $s = gather { take 10; take 20; take 30 };
+    my @out;
+    $s.iterator.push-exactly(@out, 2);
+    is-deeply @out, [10, 20], 'push-exactly pulls what it was asked for';
+}
+{
+    my $s = gather { take 5; take 6 };
+    my @out;
+    $s.iterator.push-all(@out);
+    is-deeply @out, [5, 6], 'push-all drains a finite lazy source';
+}
+{
+    my $s = gather { take 7; take 8; take 9 };
+    my $i = $s.iterator;
+    $i.skip-one;
+    is $i.pull-one, 8, 'skip-one advances through the lazy source';
+}

--- a/todo/tickets/dbiish-blockers.md
+++ b/todo/tickets/dbiish-blockers.md
@@ -30,7 +30,7 @@ mutsu $INC t/45-sqlite-common.rakutest
 `raku $INC …` passes one giant argument and every file "fails" under raku too —
 a bogus baseline that wastes a session.
 
-## Status: mutsu 6/9 (raku parity on 6 of the 9)
+## Status: mutsu 7/9 (raku parity on 7 of the 9)
 
 Re-measured **2026-07-26** with `tmp/dbiish-survey.sh` (in this repo's `tmp/`,
 recreate it from the recipe above), debug build, both interpreters on the same
@@ -45,14 +45,14 @@ recreate it from the recipe above), debug build, both interpreters on the same
 | `45-sqlite-common` | 1 fail of 109* | **PASS 109/109** | — |
 | `03-lib-util` | 1 fail of 5* | 1 fail of 5* | — (same subtest as raku) |
 | `01-basic` | PASS 35/35 | 3 fail of 18 run | ⑧ a second `require ::($m)` of a driver loses `NativeLibs`' exports |
-| `05-mock` | PASS 16/16 | 1 fail of 16 | ④b `IterationEnd` from a row fetch (test 12) |
+| `05-mock` | PASS 16/16 | **PASS 16/16** | — |
 | `06-types` | PASS 12/12 | 2 fail of 3 run | ⑤ `Int is builtin` / `So not defined`; mutsu suggests `Did you mean 'invert'?` |
 
 \* Those raku failures are `# TODO`-marked and environment-dependent, not bugs:
 `03-lib-util` test 5 fails on both because `libpq` is not installed on the survey
 machine, and `44-`/`45-` test 52 is a `rows()` capability check raku itself marks
 `# TODO`. mutsu passes test 52. The achievable target is raku parity, not
-109/109 — six files are now there.
+109/109 — seven files are now there.
 
 **Nothing fails inside NativeCall**: the surface `OpenSSL` needs (CStruct,
 opaque pointers, callbacks) is strictly harder than SQLite's, and it is holding.
@@ -146,7 +146,7 @@ say "7-keys    : ", $*VM.config.keys.sort.join(',');
 | `4a-control` | `HASH\|x\|y` | `HASH\|x\|y` |
 | `4a-bare` | `HASH\|x\|y` | `HASH\|x\|y` (fixed) |
 | `4b-isa` | `Seq` | `Seq` |
-| `4b-pullone` | `["a", "b", 1]` | **`"IterationEnd"`** |
+| `4b-pullone` | `["a", "b", 1]` | `["a", "b", 1]` (fixed) |
 | `3-mtable` | `True` | `True` (fixed) |
 | `7-nc-back` | `"dyncall"` | `"libffi"` (fixed) |
 | `7-keys` | ~200 keys | `be,name,nativecall_backend` |
@@ -160,21 +160,19 @@ space-separated adverb, but both shared one continuation loop that kept
 consuming `, next`. Fixed — see
 [`news/2026-07/method-table-and-hash-composer-parse.md`](../../news/2026-07/method-table-and-hash-composer-parse.md).
 
-### ④b `pull-one` on a hand-obtained iterator yields the `IterationEnd` sentinel
+### ④b `pull-one` on a hand-obtained iterator yielded the `IterationEnd` sentinel — FIXED
 
-Three lines of `gather`/`take` reproduce it: `a.iterator.pull-one` answers the
-string `IterationEnd` instead of the first element. This is `05-mock` test 12.
+It was specific to a **lazy, not-yet-materialised** source.
+`(1,2,3).Seq.iterator.pull-one`, `@a.iterator.pull-one` and
+`(1..3).map(*+1).iterator.pull-one` were all correct; only `gather`/`take`
+failed, and forcing it first (`$s.elems; $s.iterator.pull-one`) made it correct
+too. `build_iterator_instance` snapshotted `value_to_list(target)` into an
+`items` array — for an unforced gather that prefix is empty, so
+`runtime/iterator_protocol.rs` stepped straight past the end.
 
-Reduced further 2026-07-26: it is specific to a **lazy, not-yet-materialised**
-source. `(1,2,3).Seq.iterator.pull-one`, `@a.iterator.pull-one` and
-`(1..3).map(*+1).iterator.pull-one` are all correct; only `gather`/`take` fails,
-and forcing it first (`$s.elems; $s.iterator.pull-one`) makes it correct too. The
-cause is that `builtins::iterator_construct::build_iterator_instance` snapshots
-`value_to_list(target)` into an `items` array — for a lazy gather that prefix is
-empty, so `runtime/iterator_protocol.rs` steps straight past the end. The real
-fix is an `Iterator` that pulls from its source on demand rather than from a
-materialised prefix; eagerly forcing the source instead would hang on an
-infinite lazy list.
+Fixed — the `Iterator` keeps its lazy source and the protocol methods pull from
+it, bounded by what the call needs, so an infinite source stays lazy. See
+[`news/2026-07/iterator-pulls-from-its-lazy-source.md`](../../news/2026-07/iterator-pulls-from-its-lazy-source.md).
 
 ### ③ `.^method_table` — FIXED
 
@@ -275,14 +273,12 @@ the adverbs away outright.
 
 ## Suggested order for the next session
 
-⑦, ③ and ④a are done. What is left, cheapest first; none depends on another:
+⑦, ③, ④a and ④b are done, which takes `05-mock` to raku parity (16/16). Two
+left; neither depends on the other:
 
-1. **④b** — the `IterationEnd` leak, now reduced to "a lazy source hands the
-   `Iterator` an empty materialised prefix". Needs a pull-on-demand `Iterator`,
-   so it is a real slice, not a one-liner.
-2. **⑧** — a repeat `require ::($m)` losing `NativeLibs`' re-exports. Related
+1. **⑧** — a repeat `require ::($m)` losing `NativeLibs`' re-exports. Related
    registry-rewind bugs have been fixed twice before, so there is a model.
-3. **⑤** — the largest: an object hash keyed by type objects, plus `handles`
+2. **⑤** — the largest: an object hash keyed by type objects, plus `handles`
    delegation from a private attribute. Confirm which of the five features listed
    above is actually missing before scoping it.
 


### PR DESCRIPTION
`gather { take 1; take 2 }.iterator.pull-one` answered the string
`IterationEnd` instead of `1`. The sentinel was leaking out as an ordinary
value, so a consumer that checks for it saw an empty sequence and one that does
not saw the literal string — `DBIish`'s `t/05-mock.rakutest` test 12 compared it
against a row and reported `expected: 'a b 1', got: 'IterationEnd'`.

### Cause

`.iterator` built its `Iterator` instance by snapshotting
`value_to_list(target)` into an `items` array plus a zero index, and
`runtime/iterator_protocol.rs` stepped over that array. For an already
materialised source that is fine — `(1,2,3).Seq`, an `Array`, even
`(1..3).map(*+1)` were all correct. For a lazy one the snapshot is only whatever
prefix has been produced so far, and for a `gather` that has never been forced
that is nothing at all, so the very first step was already past the end.
(Forcing it first made it correct: `$s.elems; $s.iterator.pull-one` gave `1`.)

Forcing the source at construction time would have fixed the gather and hung on
`gather { loop { take 1 } }`.

### Fix

The instance keeps its lazy source alongside the prefix, and each protocol call
tops the prefix up from it before stepping — bounded by what that particular
call needs. `pull-one` asks for one more element than the cursor,
`push-exactly(@a, n)` for `n`, `skip-at-least(n)` for `n`; only `push-all` and
`sink-all`, which consume the source by definition, force it to exhaustion, and
`push-until-lazy` deliberately asks for nothing since stopping at a lazy
boundary is its entire purpose. An infinite `gather` therefore still yields
element after element without materialising, and the mutating dispatch path
keeps the grown prefix on the instance so repeated pulls do not re-force from
the start. A source that refuses to force (an infinite pipe answers
`X::Cannot::Lazy`) leaves the prefix as it was, so the step reports exhaustion
exactly as before.

### Effect

Pinned by `t/iterator-pull-from-lazy-source.t`, which passes unchanged under
rakudo. `DBIish`'s `t/05-mock.rakutest` reaches raku parity at 16/16 with this
and the bare-adverb parse fix from #5472, taking the database battery to 7 of 9
files at parity. Local `make test` and `make roast` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)