### PR TITLE
rakuast: expose model introspection

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1137,7 +1137,13 @@ so it is tracked separately from the roast backlog.
         namespace + semantic hierarchy as `~~`. Tests extended in `t/rakuast-type-objects.t`.
   - [x] Slice 7: `.^mro` / `.^parents` on registered type objects and node values expose the
         namespace + semantic model hierarchy. Tests extended in `t/rakuast-type-objects.t`.
-  - [ ] Slice 8+: remaining type-object metaobject operations.
+  - [x] Slice 8: `.^methods(:local)` on registered type objects and node values exposes the
+        constructors/accessors implemented by mutsu's model layer (without Rakudo's compiler-private
+        `IMPL-*` surface). Tests in `t/rakuast-type-methods.t`.
+  - [x] Slice 9: `.^attributes(:local)` exposes model fields as ordinary `Attribute` introspection
+        objects on both registered type objects and node values. Tests in
+        `t/rakuast-type-attributes.t`.
+  - [ ] Slice 10+: remaining type-object metaobject operations.
 - **Phase 4 (in progress)** — construction (`.new`).
   - [x] Slice 1: literal constructors (`RakuAST::IntLiteral.new(42)`, `StrLiteral`, `RatLiteral`).
         Tests in `t/rakuast-construct.t`.

--- a/news/2026-07/rakuast-type-attributes.md
+++ b/news/2026-07/rakuast-type-attributes.md
@@ -1,0 +1,9 @@
+# RakuAST model fields participate in attribute introspection
+
+RakuAST type objects and node values now expose their implemented model fields
+through `.^attributes(:local)`. Each field is returned as the same `Attribute`
+object used by ordinary classes, including its name, declaring package, and
+unconstrained `Mu` type.
+
+The metadata deliberately describes mutsu's public model fields rather than
+Rakudo's compiler-backend storage slots. This completes RakuAST Phase 3 slice 9.

--- a/news/2026-07/rakuast-type-methods.md
+++ b/news/2026-07/rakuast-type-methods.md
@@ -1,0 +1,8 @@
+# RakuAST type objects expose implemented methods
+
+`.^methods(:local)` on RakuAST type objects and node values now reports the
+constructors and accessors implemented by mutsu's model layer.  The list stays
+model-facing: Rakudo's compiler-private `IMPL-*` methods are not copied.
+
+This completes RakuAST Phase 3 slice 8 and is covered by
+`t/rakuast-type-methods.t`.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -625,6 +625,79 @@ pub fn node_accessor(node: &RakuAstNode, method: &str) -> Option<Value> {
     None
 }
 
+/// Native methods currently exposed directly by a RakuAST model class.
+///
+/// This intentionally describes mutsu's implemented model API rather than
+/// copying Rakudo's compiler-internal `IMPL-*` methods.  The result feeds
+/// `.^methods(:local)`, so callers can discover constructors and accessors
+/// without the RakuAST classes having ordinary registry entries.
+pub fn local_method_names(class_name: &str) -> Option<Vec<&'static str>> {
+    let class = class_from_name(class_name)?;
+    let mut names = Vec::new();
+
+    match class.constructor() {
+        Constructor::FromIdentifier
+            if matches!(class, RakuAstClass::Name | RakuAstClass::TermEnum) =>
+        {
+            names.push("from-identifier");
+        }
+        Constructor::New if constructor_is_supported(class) => names.push("new"),
+        _ => {}
+    }
+
+    names.extend(accessor_names(class));
+    names.sort_unstable();
+    names.dedup();
+    Some(names)
+}
+
+/// Model fields declared directly by a RakuAST class, for `.^attributes(:local)`.
+///
+/// As with [`local_method_names`], these are mutsu's public model fields rather
+/// than Rakudo's backend storage slots.
+pub fn local_attribute_names(class_name: &str) -> Option<&'static [&'static str]> {
+    class_from_name(class_name).map(accessor_names)
+}
+
+fn class_from_name(class_name: &str) -> Option<RakuAstClass> {
+    RAKUAST_CLASSES
+        .iter()
+        .copied()
+        .find(|class| class.printed_name() == class_name)
+}
+
+fn constructor_is_supported(class: RakuAstClass) -> bool {
+    matches!(
+        class,
+        RakuAstClass::IntLiteral
+            | RakuAstClass::RatLiteral
+            | RakuAstClass::StrLiteral
+            | RakuAstClass::Infix
+            | RakuAstClass::Prefix
+            | RakuAstClass::VarLexical
+            | RakuAstClass::StatementExpression
+            | RakuAstClass::ApplyInfix
+            | RakuAstClass::ApplyPrefix
+            | RakuAstClass::ApplyPostfix
+            | RakuAstClass::Postfix
+    )
+}
+
+fn accessor_names(class: RakuAstClass) -> &'static [&'static str] {
+    use RakuAstClass::*;
+    match class {
+        StatementList => &["statements"],
+        StatementExpression => &["expression"],
+        IntLiteral | RatLiteral | StrLiteral => &["value"],
+        VarLexical => &["name"],
+        ApplyInfix => &["left", "infix", "right"],
+        ApplyPrefix => &["prefix", "operand"],
+        ApplyPostfix => &["operand", "postfix"],
+        Postfix => &["operator"],
+        _ => &[],
+    }
+}
+
 fn field_to_value(fv: &RakuAstFieldValue) -> Value {
     match fv {
         RakuAstFieldValue::Node(v) => v.clone(),

--- a/src/runtime/methods_classhow_attribute.rs
+++ b/src/runtime/methods_classhow_attribute.rs
@@ -7,6 +7,15 @@ impl Interpreter {
         class_name: &str,
         local_only: bool,
     ) -> Vec<Value> {
+        // RakuAST classes live in the native model registry, not the ordinary
+        // class registry. Their fields still participate in Attribute
+        // introspection so callers can walk the model uniformly.
+        if let Some(names) = crate::rakuast::local_attribute_names(class_name) {
+            return names
+                .iter()
+                .map(|name| Self::make_builtin_attribute_object(name, "Mu", class_name))
+                .collect();
+        }
         // For Attribute itself, return BOOTSTRAPATTR instances for its well-known attributes
         if class_name == "Attribute" && !self.registry().classes.contains_key("Attribute") {
             return Self::make_bootstrapattr_list();

--- a/src/runtime/methods_classhow_builtin_methods.rs
+++ b/src/runtime/methods_classhow_builtin_methods.rs
@@ -36,6 +36,15 @@ impl Interpreter {
 
         let mut result = Vec::new();
 
+        // RakuAST model classes are native type objects rather than entries in
+        // the user-class registry.  Expose the constructors/accessors that the
+        // model layer really implements so `.^methods(:local)` is useful (and
+        // does not fall through to an empty built-in method list).
+        if local && let Some(names) = crate::rakuast::local_method_names(&class_name) {
+            self.push_native_method_objects(&names, &mut result);
+            return Ok(Value::array(result));
+        }
+
         // Extract mixin role names from the invocant for runtime role method collection
         let mixin_role_names: Vec<String> = if let ValueView::Mixin(_, mixins) = invocant.view() {
             mixins

--- a/t/rakuast-type-attributes.t
+++ b/t/rakuast-type-attributes.t
@@ -1,0 +1,33 @@
+use Test;
+use experimental :rakuast;
+
+plan 11;
+
+my @attrs = RakuAST::ApplyInfix.^attributes(:local);
+is @attrs.map(*.name).sort.join(','), '$!infix,$!left,$!right',
+    'ApplyInfix exposes its three model fields';
+is @attrs.map(*.^name).unique.join(','), 'Attribute',
+    'RakuAST fields use ordinary Attribute introspection objects';
+is @attrs[0].package.^name, 'RakuAST::ApplyInfix',
+    'attribute package identifies the declaring RakuAST class';
+is @attrs[0].type.^name, 'Mu', 'model fields have an unconstrained type';
+ok !@attrs[0].has_accessor, 'model storage remains private';
+
+my $node = RakuAST::ApplyInfix.new(
+    left  => RakuAST::IntLiteral.new(1),
+    infix => RakuAST::Infix.new('+'),
+    right => RakuAST::IntLiteral.new(2),
+);
+is $node.^attributes(:local).map(*.name).sort.join(','), '$!infix,$!left,$!right',
+    'node values share their type object attribute metadata';
+
+is RakuAST::IntLiteral.^attributes(:local).map(*.name).join(','),
+    '$!value', 'literal value is discoverable as a model field';
+is RakuAST::Var::Lexical.^attributes(:local).map(*.name).join(','),
+    '$!name', 'lexical variable name is discoverable as a model field';
+is RakuAST::StatementList.^attributes(:local).map(*.name).join(','),
+    '$!statements', 'statement children are discoverable as a model field';
+is RakuAST::Statement::Expression.^attributes(:local).map(*.name).join(','),
+    '$!expression', 'statement expression is discoverable as a model field';
+is RakuAST::Assignment.^attributes(:local).elems, 0,
+    'a class without modeled fields reports no local attributes';

--- a/t/rakuast-type-methods.t
+++ b/t/rakuast-type-methods.t
@@ -1,0 +1,31 @@
+use Test;
+use experimental :rakuast;
+
+plan 12;
+
+my @int-methods = RakuAST::IntLiteral.^methods(:local).map(*.name);
+ok @int-methods.grep(* eq 'new'), 'literal type object exposes its constructor';
+ok @int-methods.grep(* eq 'value'), 'literal type object exposes its value accessor';
+is @int-methods.sort.join(','), 'new,value', 'literal local method list is model-only';
+
+my $int = RakuAST::IntLiteral.new(42);
+is $int.^methods(:local).map(*.name).sort.join(','), 'new,value',
+    'node value uses the same local method metadata';
+
+my @infix-methods = RakuAST::ApplyInfix.^methods(:local).map(*.name);
+ok @infix-methods.grep(* eq 'new'), 'multi-field node exposes new';
+ok @infix-methods.grep(* eq 'left'), 'multi-field node exposes left';
+ok @infix-methods.grep(* eq 'infix'), 'multi-field node exposes infix';
+ok @infix-methods.grep(* eq 'right'), 'multi-field node exposes right';
+
+is RakuAST::Name.^methods(:local).map(*.name).sort.join(','),
+    'from-identifier', 'Name exposes its supported named constructor';
+
+is RakuAST::StatementList.^methods(:local).map(*.name).sort.join(','),
+    'statements', 'StatementList exposes its read accessor';
+
+is RakuAST::Statement::Expression.^methods(:local).map(*.name).sort.join(','),
+    'expression,new', 'statement wrapper exposes constructor and accessor';
+
+is RakuAST::Postfix.^methods(:local).map(*.name).sort.join(','),
+    'new,operator', 'Postfix exposes its named field as an accessor';


### PR DESCRIPTION
## What changed

- expose implemented RakuAST constructors and accessors through `.^methods(:local)`
- expose RakuAST model fields as ordinary `Attribute` objects through `.^attributes(:local)`
- support both registered RakuAST type objects and concrete node values
- update PLAN.md and add release notes for Phase 3 slices 8 and 9

## Why

RakuAST nodes already supported accessors and construction, but the native model classes are not ordinary registry classes. Their metaobject method and attribute queries therefore returned empty lists, making the supported model API undiscoverable.

The reported surface deliberately describes mutsu's public RakuAST model and omits Rakudo compiler-private `IMPL-*` methods and backend storage slots.

## Validation

- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `prove -e target/debug/mutsu t/rakuast-type-attributes.t t/rakuast-type-methods.t t/rakuast-type-objects.t`
- additional RakuAST constructor regression tests (60 assertions in the Slice 8 run)