### PR TITLE
fix: a module's `our` globals outlive the scope that loaded it

### DIFF
--- a/news/2026-07/module-our-globals-outlive-the-loading-scope.md
+++ b/news/2026-07/module-our-globals-outlive-the-loading-scope.md
@@ -1,0 +1,69 @@
+# A module's `our` globals outlive the scope that loaded it
+
+Three fixes from the `DBIish` ledger, each a general-purpose gap. Together they
+take `DBIish`'s `t/01-basic.rakutest` from 18 of 35 subtests to 30, and make
+`NativeHelpers::CStruct` loadable.
+
+## `our` package variables are not lexical
+
+`DBIish.install-driver('Pg')` followed by `install-driver('SQLite')` died with
+`Could not find symbol '&is-win' in 'NativeLibs'`, raised from inside
+`NativeLibs`' own `CHECK`. Installing either driver on its own worked; only the
+pair failed, and a plain top-level `require ::('DBDish::Pg')` before the second
+one did not reproduce it.
+
+Reduced, it is three lines and does not need a database:
+
+```raku
+sub f() { my \M = (require ::('Base')); }   # Base has `our constant flag = 7`
+f();
+use Base;
+say Base::flag;          # raku: 7    mutsu: could not find symbol
+```
+
+`our` declarations compile to a `SetGlobal` on the qualified name, so they live
+in `env` — and a sub call restores `env` wholesale on return. A module loaded by
+a `require` inside a sub therefore lost its package variables when the sub
+returned, while `loaded_modules` kept the module marked as loaded, so the later
+`use` was a no-op that could not bring them back. That is the same shape as the
+subtest and `EVAL` registry-rewind bugs fixed earlier this month, one carrier
+down: the routine registry already had `module_registered_functions` to survive
+exactly this, but `our` variables are not routines.
+
+Each module load now records the package-qualified globals it introduced, and the
+already-loaded path of `use_module_with_tags_inner` reinstates whatever has gone
+missing since. Only missing keys are put back, so an assignment made after the
+load is never clobbered. In `DBIish` this is what lets the second driver's
+`use NativeLibs` see `NativeLibs::is-win` again.
+
+## The C-width native integer aliases are declarable
+
+`DBDish::mysql::Native` writes `has ulong $.length` and
+`our ulong constant ulong_zero = 0`, and mutsu answered `Type 'ulong' is not
+declared`. The marshalling layer in `runtime/nativecall.rs` already mapped
+`long` / `ulong` / `longlong` / `ulonglong` / `size_t` to `CType::I64` /
+`CType::U64` — only the declaration side was missing, so nothing could *name*
+one. They are in `NATIVE_INT_TYPES` now, with 64-bit bounds, wrapping and
+signedness, and they name a type object as a term so `nativesizeof(ulong)`
+reports 8, matching MoarVM on the platforms mutsu targets.
+
+## A role type parameter can carry a definiteness smiley
+
+`role LinearArray[::T] { … multi method Pointer(::?CLASS:U: T:D $struct) … }` —
+`NativeHelpers::CStruct`'s central role — failed to register with `Invalid
+typename 'T:D' in parameter declaration.`, so the whole module was unloadable.
+Role-method registration compared the *whole* constraint against the role's
+type-parameter list, so a bare `T` matched but `T:D` did not; the base name is
+already computed a few lines further down for exactly this kind of stripping.
+`NativeHelpers::CStruct` loads now.
+
+## What still blocks the mysql driver
+
+`01-basic`'s remaining three failures are all the `mysql` driver, and it is
+gated on the deferred
+[`todo/deep/nativehelpers-blob-moarvm-guts.md`](../../todo/deep/nativehelpers-blob-moarvm-guts.md)
+work rather than on anything new: `DBDish::mysql::StatementHandle` uses
+`BPointer(...)`, which is `NativeHelpers::Blob`'s `pointer-to` and needs
+`BODY_OF` — the address of a container's element buffer, stable across calls.
+The SQLite driver does not go through it, which is why the other eight files are
+unaffected.

--- a/src/runtime/accessors_misc.rs
+++ b/src/runtime/accessors_misc.rs
@@ -129,6 +129,22 @@ impl Interpreter {
         }
     }
 
+    /// Put back any `our` package global of `module` that has gone missing from
+    /// `env` since the module was loaded. See `module_package_globals`.
+    pub(crate) fn reinstate_module_package_globals(&mut self, module: &str) {
+        let Some(globals) = self.module_package_globals.get(module) else {
+            return;
+        };
+        let missing: Vec<(Symbol, Value)> = globals
+            .iter()
+            .filter(|(key, _)| self.env.get_sym(*key).is_none())
+            .cloned()
+            .collect();
+        for (key, value) in missing {
+            self.env.insert_sym(key, value);
+        }
+    }
+
     pub(crate) fn snapshot_routine_registry(&self) -> RoutineRegistrySnapshot {
         // Single guard for all six reads (avoids stacking read guards).
         let registry = self.registry();

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -942,6 +942,17 @@ pub struct Interpreter {
     /// routines are gone, and a re-`use` — being a no-op — could not bring them
     /// back. See `reinstate_module_functions`.
     module_registered_functions: HashSet<Symbol>,
+    /// The package-qualified globals (`Base::flag`, `$NativeLibs::config`) each
+    /// loaded module declared with `our`, keyed by module name.
+    ///
+    /// The routine-registry counterpart above cannot cover these: `our`
+    /// variables live in `env`, and every scope that restores `env` wholesale —
+    /// a sub call, a block, an `EVAL` — drops the ones a module load nested
+    /// inside it created. `loaded_modules` is never rolled back, so a later
+    /// `use` of that module is a no-op and could not bring them back. The
+    /// already-loaded path of `use_module_with_tags_inner` reinstates whatever
+    /// is missing from here instead.
+    module_package_globals: HashMap<String, Vec<(Symbol, Value)>>,
     need_hidden_classes: HashSet<String>,
     /// CompUnit::Repository::Installation state (`.loaded` units and the symbols
     /// pulled in by `.need` but not yet merged into GLOBAL).

--- a/src/runtime/native_types.rs
+++ b/src/runtime/native_types.rs
@@ -18,6 +18,18 @@ pub(crate) const NATIVE_INT_TYPES: &[&str] = &[
     "int",
     "uint",
     "atomicint",
+    // The C-width aliases `NativeCall::Types` exports. The marshalling layer
+    // (`runtime/nativecall.rs`) already maps every one of these to `CType::I64`
+    // / `CType::U64`; declaring them here is what lets a signature or attribute
+    // actually *name* one (`has ulong $.length`, `our ulong constant zero = 0`
+    // in `DBDish::mysql::Native`). All are 64-bit, matching what MoarVM reports
+    // via `nativesizeof` on the platforms mutsu targets (LP64 / LLP64-with-long
+    // is not among them).
+    "long",
+    "ulong",
+    "longlong",
+    "ulonglong",
+    "size_t",
 ];
 
 /// Returns true if `name` is a native integer type.
@@ -48,7 +60,8 @@ pub(crate) fn unbox_bool_to_native_int(val: crate::value::Value) -> crate::value
 /// `uint16` -> `uint`, `num32` -> `num`).
 pub(crate) fn native_family_name(name: &str) -> &'static str {
     match name {
-        "uint" | "uint8" | "uint16" | "uint32" | "uint64" | "byte" => "uint",
+        "uint" | "uint8" | "uint16" | "uint32" | "uint64" | "byte" | "ulong" | "ulonglong"
+        | "size_t" => "uint",
         "num" | "num32" | "num64" => "num",
         "str" => "str",
         _ => "int",
@@ -66,14 +79,14 @@ pub(crate) fn native_int_bounds(type_name: &str) -> Option<(NumBigInt, NumBigInt
             NumBigInt::from(-2147483648i64),
             NumBigInt::from(2147483647i64),
         )),
-        "int64" | "int" | "atomicint" => Some((
+        "int64" | "int" | "atomicint" | "long" | "longlong" => Some((
             NumBigInt::from(-9223372036854775808i64),
             NumBigInt::from(9223372036854775807i64),
         )),
         "uint8" | "byte" => Some((NumBigInt::from(0u64), NumBigInt::from(255u64))),
         "uint16" => Some((NumBigInt::from(0u64), NumBigInt::from(65535u64))),
         "uint32" => Some((NumBigInt::from(0u64), NumBigInt::from(4294967295u64))),
-        "uint64" | "uint" => Some((
+        "uint64" | "uint" | "ulong" | "ulonglong" | "size_t" => Some((
             NumBigInt::from(0u64),
             NumBigInt::from(18446744073709551615u128),
         )),
@@ -87,14 +100,18 @@ fn native_type_bits(type_name: &str) -> Option<u32> {
         "int8" | "uint8" | "byte" => Some(8),
         "int16" | "uint16" => Some(16),
         "int32" | "uint32" => Some(32),
-        "int64" | "uint64" | "int" | "uint" => Some(64),
+        "int64" | "uint64" | "int" | "uint" | "long" | "ulong" | "longlong" | "ulonglong"
+        | "size_t" => Some(64),
         _ => None,
     }
 }
 
 /// Whether the native type is signed.
 fn is_signed_native(type_name: &str) -> bool {
-    matches!(type_name, "int8" | "int16" | "int32" | "int64" | "int")
+    matches!(
+        type_name,
+        "int8" | "int16" | "int32" | "int64" | "int" | "long" | "longlong"
+    )
 }
 
 /// Wrap a BigInt value to fit within the native type's range.

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -876,6 +876,12 @@ impl Interpreter {
                             let self_short = name.rsplit_once("::").map(|(_, s)| s).unwrap_or(name);
                             let resolvable = tc_base == name
                                 || tc_base == self_short
+                                // A role type parameter carrying a definiteness
+                                // smiley (`role R[::T] { method f(T:D $x) }`,
+                                // NativeHelpers::CStruct's `LinearArray`). The
+                                // bare-`T` check above compares the whole
+                                // constraint, so only the base name matches here.
+                                || type_params.iter().any(|tp| tp == tc_base)
                                 // A type declared in this role's own body (`my enum`,
                                 // `my subset`, ...) is not registered until the body
                                 // runs; accept its name here.

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2091,6 +2091,7 @@ impl Interpreter {
             chroot_root: None,
             loaded_modules: HashSet::new(),
             module_registered_functions: HashSet::new(),
+            module_package_globals: HashMap::new(),
             need_hidden_classes: HashSet::new(),
             cur_repo: Box::new(CurRepoState::default()),
             package_stash_hidden: HashSet::new(),

--- a/src/runtime/runtime_module.rs
+++ b/src/runtime/runtime_module.rs
@@ -126,6 +126,12 @@ impl Interpreter {
             } else if module == "fatal" {
                 self.fatal_mode = true;
             }
+            // The module stays loaded, so this `use` is a no-op — but a scope
+            // that restored `env` wholesale since the load (a sub call around a
+            // `require`, a block, an `EVAL`) may have taken its `our` globals
+            // with it. Put them back, or this no-op leaves the caller unable to
+            // reach a symbol the module really does define.
+            self.reinstate_module_package_globals(module);
             // Propagate package declarations from the already-loaded module
             // into the current chain so that chain_has_package_decl checks
             // correctly detect namespace contributions from transitive deps.
@@ -533,6 +539,22 @@ impl Interpreter {
                 .copied()
                 .collect();
             self.module_registered_functions.extend(module_funcs);
+            // Same for the module's `our` package variables, which live in `env`
+            // rather than the routine registry. Collected BEFORE `import_module`
+            // so the bare aliases it installs — lexical to the importing scope —
+            // are excluded, exactly as for the routines above.
+            let package_globals: Vec<(Symbol, Value)> = self
+                .env
+                .keys()
+                .filter(|k| !env_snapshot.contains(k) && k.resolve().contains("::"))
+                .filter_map(|k| self.env.get_sym(*k).map(|v| (*k, v.clone())))
+                .collect();
+            if !package_globals.is_empty() {
+                self.module_package_globals
+                    .entry(module.to_string())
+                    .or_default()
+                    .extend(package_globals);
+            }
             if let Err(err) = self.import_module(module, tags)
                 && !err.message.starts_with("No exports found for module:")
             {

--- a/src/runtime/runtime_thread.rs
+++ b/src/runtime/runtime_thread.rs
@@ -230,6 +230,7 @@ impl Interpreter {
             chroot_root: self.chroot_root.clone(),
             loaded_modules: self.loaded_modules.clone(),
             module_registered_functions: self.module_registered_functions.clone(),
+            module_package_globals: self.module_package_globals.clone(),
             need_hidden_classes: self.need_hidden_classes.clone(),
             cur_repo: self.cur_repo.clone(),
             package_stash_hidden: self.package_stash_hidden.clone(),

--- a/src/runtime/undeclared_routines.rs
+++ b/src/runtime/undeclared_routines.rs
@@ -44,6 +44,10 @@ const NATIVE_TYPE_NAMES: &[&str] = &[
     "complex",
     "size_t",
     "ssize_t",
+    "long",
+    "ulong",
+    "longlong",
+    "ulonglong",
 ];
 
 /// Callables the compiler special-cases into dedicated opcodes, so they never

--- a/src/vm/vm_value_helpers.rs
+++ b/src/vm/vm_value_helpers.rs
@@ -431,6 +431,15 @@ impl Interpreter {
                 | "int"
                 | "uint"
                 | "atomicint"
+                // The C-width aliases from `NativeCall::Types` (see
+                // `runtime::native_types::NATIVE_INT_TYPES`): naming one as a
+                // term has to yield the type object, or `nativesizeof(ulong)`
+                // sees a bare string.
+                | "long"
+                | "ulong"
+                | "longlong"
+                | "ulonglong"
+                | "size_t"
                 | "num"
                 | "num32"
                 | "num64"

--- a/t/lib/OurGlobalsBase.rakumod
+++ b/t/lib/OurGlobalsBase.rakumod
@@ -1,0 +1,8 @@
+unit module OurGlobalsBase;
+
+# `our` declarations live in the package, not in whatever lexical scope happened
+# to trigger the module load.
+our constant answer = 42;
+our $greeting = 'hi';
+our @items = 1, 2, 3;
+our %config = mode => 'fast';

--- a/t/lib/OurGlobalsUser.rakumod
+++ b/t/lib/OurGlobalsUser.rakumod
@@ -1,0 +1,13 @@
+unit module OurGlobalsUser;
+
+# Reads OurGlobalsBase's `our` constant while its own module body runs, exactly
+# like `constant LIB = NativeLibs::is-win ?? … !! …` in DBDish::SQLite::Native.
+# Loading fails outright if the symbol is unreachable, and the check below makes
+# a wrong-but-defined value fail just as loudly.
+use OurGlobalsBase;
+
+constant SEEN = OurGlobalsBase::answer;
+
+die "OurGlobalsBase::answer read back as {SEEN.raku}" unless SEEN == 42;
+
+our sub seen() { SEEN }

--- a/t/module-our-globals-outlive-scope.t
+++ b/t/module-our-globals-outlive-scope.t
@@ -1,0 +1,55 @@
+use Test;
+
+# A module's `our` declarations belong to its package, so they must outlive
+# whatever scope happened to trigger the load. `our` variables live in the
+# global env, and a sub call restores that env wholesale on return, so a module
+# loaded by a `require` inside a sub lost its package variables — while
+# `loaded_modules` still claimed it was loaded, making a later `use` a no-op that
+# could not bring them back.
+#
+# DBIish hit this through `DBIish.install-driver`, which `require`s a driver
+# inside a method: the driver pulls in NativeLibs, and the next driver's
+# `use NativeLibs` then could not see `NativeLibs::is-win`.
+
+plan 7;
+
+use lib 't/lib';
+
+sub load-in-a-sub($name) {
+    my \M = (require ::($name));
+    M;
+}
+
+load-in-a-sub('OurGlobalsBase');
+
+# The `use` is a no-op (the module really is loaded), but it must still leave the
+# package's `our` symbols reachable.
+use OurGlobalsBase;
+
+is OurGlobalsBase::answer, 42, 'an `our constant` survives the loading scope';
+is $OurGlobalsBase::greeting, 'hi', 'an `our` scalar survives';
+is @OurGlobalsBase::items.join(','), '1,2,3', 'an `our` array survives';
+is %OurGlobalsBase::config<mode>, 'fast', 'an `our` hash survives';
+
+# The same shape one level deeper: the second module reads the first one's
+# package symbol while its own body runs.
+sub load-user() {
+    my \M = (require ::('OurGlobalsUser'));
+    M;
+}
+# OurGlobalsUser dies on load if it cannot read the right value, so this covers
+# both reachability and correctness. (`require` does not import into the
+# compile-time scope, so the sub cannot be called by name from here.)
+lives-ok { load-user() },
+    'a module that reads another module\'s `our` symbol loads after that module was loaded in a sub';
+
+# A module loaded at the top level was never affected; check it still is not.
+{
+    my \M = (require ::('OurGlobalsBase'));
+    is OurGlobalsBase::answer, 42, 'a top-level require keeps working';
+}
+
+# Assignments made after the load are not clobbered by the reinstatement.
+$OurGlobalsBase::greeting = 'bye';
+use OurGlobalsBase;
+is $OurGlobalsBase::greeting, 'bye', 'a later assignment is not overwritten by a re-use';

--- a/t/native-c-width-int-types.t
+++ b/t/native-c-width-int-types.t
@@ -1,0 +1,43 @@
+use Test;
+use NativeCall;
+
+# `NativeCall::Types` exports C-width integer aliases. The marshalling layer
+# already mapped every one of these to a 64-bit C integer, but they were not
+# declarable, so `has ulong $.length` / `our ulong constant zero = 0` — the shape
+# DBDish::mysql::Native uses — died with "Type 'ulong' is not declared".
+
+plan 12;
+
+my ulong $u = 42;
+is $u, 42, 'a ulong scalar holds its value';
+my long $l = -42;
+is $l, -42, 'a long scalar is signed';
+my longlong $ll = -9223372036854775807;
+is $ll, -9223372036854775807, 'longlong holds a 64-bit negative';
+my ulonglong $ull = 18446744073709551615;
+is $ull, 18446744073709551615, 'ulonglong holds the full unsigned range';
+my size_t $s = 4096;
+is $s, 4096, 'size_t holds its value';
+
+# Signedness: an unsigned alias wraps rather than going negative.
+my ulong $wrap = -1;
+is $wrap, 18446744073709551615, 'ulong wraps -1 to the unsigned maximum';
+
+# Attributes and signatures can name them.
+class Field {
+    has ulong $.length is rw;
+    has long $.offset is rw;
+    method span(ulong $extra --> ulong) { $!length + $extra }
+}
+my $f = Field.new(:length(10), :offset(-2));
+is $f.length, 10, 'a ulong attribute';
+is $f.offset, -2, 'a long attribute';
+is $f.span(5), 15, 'a ulong parameter and return type';
+
+# `our <native> constant` — the DBDish::mysql::Native declaration.
+our ulong constant ULONG_ZERO = 0;
+is ULONG_ZERO, 0, 'an `our ulong constant`';
+
+# nativesizeof agrees with MoarVM: all of these are 8 bytes.
+is nativesizeof(ulong), 8, 'nativesizeof(ulong) is 8';
+is nativesizeof(size_t), 8, 'nativesizeof(size_t) is 8';

--- a/t/role-type-param-smiley.t
+++ b/t/role-type-param-smiley.t
@@ -1,0 +1,35 @@
+use Test;
+
+# A role's type capture can carry a definiteness smiley in a parameter type:
+# `role R[::T] { method f(T:D $x) }`. Role-method registration validated the
+# whole constraint against the role's type-parameter list, so only a bare `T`
+# matched and `T:D` was rejected as "Invalid typename 'T:D' in parameter
+# declaration." — which stopped `NativeHelpers::CStruct`'s `LinearArray[::T]`
+# from loading at all.
+
+plan 8;
+
+role Holder[::T] {
+    method take(T:D $x) { "def:$x" }
+    method kind(T:U $t) { 'type:' ~ $t.^name }
+    method any(T $x) { "any:{$x // 'undef'}" }
+    multi method pick(T:D $x) { "multi-def:$x" }
+    multi method pick(T:U) { 'multi-type' }
+}
+
+class IntHolder does Holder[Int] { }
+my $h = IntHolder.new;
+
+is $h.take(5), 'def:5', 'a `T:D` parameter accepts a defined value';
+is $h.kind(Int), 'type:Int', 'a `T:U` parameter accepts the type object';
+is $h.any(7), 'any:7', 'a bare `T` parameter still works';
+is $h.any(Int), 'any:undef', 'a bare `T` parameter accepts a type object';
+is $h.pick(9), 'multi-def:9', 'a `T:D` multi candidate';
+is $h.pick(Int), 'multi-type', 'a `T:U` multi candidate';
+
+# The smiley must still constrain: a type object cannot bind to `T:D`.
+dies-ok { $h.take(Int) }, 'a type object does not bind to `T:D`';
+
+# A second instantiation gets its own constraint.
+class StrHolder does Holder[Str] { }
+is StrHolder.new.take('x'), 'def:x', 'the constraint follows the instantiation';

--- a/todo/tickets/dbiish-blockers.md
+++ b/todo/tickets/dbiish-blockers.md
@@ -44,7 +44,7 @@ recreate it from the recipe above), debug build, both interpreters on the same
 | `44-sqlite-memory` | 1 fail of 109* | **PASS 109/109** | — |
 | `45-sqlite-common` | 1 fail of 109* | **PASS 109/109** | — |
 | `03-lib-util` | 1 fail of 5* | 1 fail of 5* | — (same subtest as raku) |
-| `01-basic` | PASS 35/35 | 3 fail of 18 run | ⑧ a second `require ::($m)` of a driver loses `NativeLibs`' exports |
+| `01-basic` | PASS 35/35 | 3 fail of 30 run | ⑨ the `mysql` driver needs `BODY_OF` (deferred deep item) |
 | `05-mock` | PASS 16/16 | **PASS 16/16** | — |
 | `06-types` | PASS 12/12 | 2 fail of 3 run | ⑤ `Int is builtin` / `So not defined`; mutsu suggests `Did you mean 'invert'?` |
 
@@ -180,17 +180,43 @@ Not a `PackageHOW`-only gap as first recorded — a plain `ClassHOW` had the sam
 hole. Fixed, with `Method` objects as the values, matching rakudo. See
 [`news/2026-07/method-table-and-hash-composer-parse.md`](../../news/2026-07/method-table-and-hash-composer-parse.md).
 
-### ⑧ A repeat `require ::($module)` loses `NativeLibs`' re-exports
+### ⑧ `Could not find symbol '&is-win' in 'NativeLibs'` — FIXED
 
-New, and what `01-basic` stops on now. Installing the drivers one at a time works
-(`DBIish.install-driver('SQLite')` on its own returns `DBDish::SQLite`), but the
-file's `for <Oracle Pg SQLite TestMock mysql>` loop fails on the third and fifth:
-`Could not find symbol '&is-win' in 'NativeLibs'` for SQLite and `Type 'ulong' is
-not declared` for mysql, both raised from inside `NativeLibs`' `CHECK for
-NativeCall::EXPORT::.keys { UNIT::EXPORT::{$_} := … }`. So a second `require
-::($module)` in the same process re-runs that `CHECK` against a registry that no
-longer holds the first load's exports — the same export/registry-rewind family as
-`news/2026-07/`'s subtest and `EVAL` entries.
+The first reading here ("a second `require` re-runs `NativeLibs`' `CHECK` against
+a rewound registry") was aimed one level off. It was not about `require` being
+repeated, nor about the `CHECK`: **a module's `our` package variables did not
+survive the scope that loaded it.** `our` compiles to a `SetGlobal`, so those
+live in `env`, and a sub call restores `env` wholesale on return —
+`install-driver` does its `require` inside a method, so `NativeLibs`' `our
+constant is-win` went with it, while `loaded_modules` kept the module marked
+loaded so the next driver's `use NativeLibs` was a no-op. Three lines reproduce
+it with no database:
+
+```raku
+sub f() { my \M = (require ::('Base')); }   # Base has `our constant flag = 7`
+f();
+use Base;
+say Base::flag;          # raku: 7    mutsu (before): could not find symbol
+```
+
+Fixed, along with two gaps it was masking (`ulong` and friends were not
+declarable; a role type parameter could not carry a definiteness smiley, which
+kept `NativeHelpers::CStruct` from loading at all) — see
+[`news/2026-07/module-our-globals-outlive-the-loading-scope.md`](../../news/2026-07/module-our-globals-outlive-the-loading-scope.md).
+`01-basic` went from 18 of 35 to 30.
+
+### ⑨ `01-basic`'s last three failures are the `mysql` driver, gated on `BODY_OF`
+
+Not a new bug so much as a pointer to the deferred deep item.
+`DBDish::mysql::StatementHandle` uses `BPointer(...)`, which is
+`NativeHelpers::Blob`'s `pointer-to` and needs `BODY_OF` — the address of a
+container's element buffer, stable across calls. That is
+[`todo/deep/nativehelpers-blob-moarvm-guts.md`](../deep/nativehelpers-blob-moarvm-guts.md),
+which wants an ADR first. The visible symptom is a parse failure in
+`StatementHandle` (`Unexpected block in infix position`), because the undeclared
+`BPointer` derails the rest of the file — check `use NativeHelpers::Blob; BPointer(Buf.new(1))`
+before chasing the parser. `DBDish::SQLite` does not go through `BODY_OF`, which
+is why the other eight files are unaffected.
 
 ### ⑤ `06-types` — object hash keyed by type objects
 
@@ -273,14 +299,17 @@ the adverbs away outright.
 
 ## Suggested order for the next session
 
-⑦, ③, ④a and ④b are done, which takes `05-mock` to raku parity (16/16). Two
-left; neither depends on the other:
+⑦, ③, ④a, ④b and ⑧ are done. `05-mock` is at raku parity (16/16) and `01-basic`
+is at 30 of 35. Two left:
 
-1. **⑧** — a repeat `require ::($m)` losing `NativeLibs`' re-exports. Related
-   registry-rewind bugs have been fixed twice before, so there is a model.
-2. **⑤** — the largest: an object hash keyed by type objects, plus `handles`
+1. **⑤** — `06-types`: an object hash keyed by type objects, plus `handles`
    delegation from a private attribute. Confirm which of the five features listed
-   above is actually missing before scoping it.
+   above is actually missing before scoping it. This is the only remaining file
+   whose blockers are ordinary interpreter work.
+2. **⑨** — the `mysql` driver, and with it `01-basic`'s last three subtests. Do
+   not start it as a `DBIish` task: it is
+   [`todo/deep/nativehelpers-blob-moarvm-guts.md`](../deep/nativehelpers-blob-moarvm-guts.md),
+   which wants an ADR first.
 
 ## When these are cleared
 


### PR DESCRIPTION
Three general-purpose fixes from the `DBIish` ledger
(`todo/tickets/dbiish-blockers.md`), each reduced to a standalone repro first.

### `our` package variables are not lexical

`DBIish.install-driver('Pg')` followed by `install-driver('SQLite')` died with
`Could not find symbol '&is-win' in 'NativeLibs'`, raised from inside
`NativeLibs`' own `CHECK`. Either driver on its own worked, and a plain top-level
`require ::('DBDish::Pg')` before the second did not reproduce it — which is what
made the ledger's first reading ("a second `require` re-runs the `CHECK` against a
rewound registry") aim one level off.

Reduced, it is three lines and needs no database:

```raku
sub f() { my \M = (require ::('Base')); }   # Base has `our constant flag = 7`
f();
use Base;
say Base::flag;          # raku: 7    mutsu (before): could not find symbol
```

`our` declarations compile to a `SetGlobal` on the qualified name, so they live
in `env` — and a sub call restores `env` wholesale on return. A module loaded by a
`require` inside a sub therefore lost its package variables when the sub
returned, while `loaded_modules` kept the module marked as loaded, so the later
`use` was a no-op that could not bring them back. That is the same shape as the
subtest (#5379) and `EVAL` (#5385) registry-rewind bugs, one carrier down: the
routine registry already has `module_registered_functions` to survive exactly
this, but `our` variables are not routines.

Each module load now records the package-qualified globals it introduced, and the
already-loaded path of `use_module_with_tags_inner` reinstates whatever has gone
missing. Only missing keys are put back, so an assignment made after the load is
never clobbered (pinned).

### The C-width native integer aliases are declarable

`DBDish::mysql::Native` writes `has ulong $.length` and `our ulong constant
ulong_zero = 0`; mutsu answered `Type 'ulong' is not declared`. The marshalling
layer already mapped `long`/`ulong`/`longlong`/`ulonglong`/`size_t` to
`CType::I64`/`CType::U64` — only the declaration side was missing, so nothing
could *name* one. They now carry 64-bit bounds, wrapping and signedness, and name
a type object as a term so `nativesizeof(ulong)` reports 8, matching MoarVM on the
platforms mutsu targets.

### A role type parameter can carry a definiteness smiley

`role LinearArray[::T] { … multi method Pointer(::?CLASS:U: T:D $struct) … }` —
`NativeHelpers::CStruct`'s central role — failed to register with `Invalid
typename 'T:D' in parameter declaration.`, making the whole module unloadable.
Role-method registration compared the *whole* constraint against the role's
type-parameter list, so a bare `T` matched but `T:D` did not; the base name is
already computed a few lines below for exactly this kind of stripping.
`NativeHelpers::CStruct` loads now.

### Effect

`DBIish`'s `t/01-basic.rakutest` goes from 18 of 35 subtests to 30. The remaining
three are the `mysql` driver, and they are gated on the already-deferred
`todo/deep/nativehelpers-blob-moarvm-guts.md` work (`BPointer` → `pointer-to` →
`BODY_OF`), not on anything new — recorded as ⑨ in the ledger so the next session
does not chase the parse error it surfaces as. Seven of the nine files are at raku
parity.

Pinned by `t/module-our-globals-outlive-scope.t`, `t/native-c-width-int-types.t`
and `t/role-type-param-smiley.t`, all three of which pass unchanged under rakudo.
Local `make test` and `make roast` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)