### PR TITLE
rakuast: expose model method table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 # Repository Guidelines
 
+## Repository Knowledge
+- Before planning or changing code, read `CLAUDE.md` in full. It is the repository's living
+  development knowledge base and its architecture, testing, debugging, planning, and PR workflow
+  guidance applies to Codex as well as Claude.
+- Re-read the task-relevant sections and linked ADRs or design documents before acting; do not rely
+  only on this shorter file.
+- If `AGENTS.md` and `CLAUDE.md` conflict, follow `AGENTS.md`. Adapt instructions that name
+  Claude-specific tools to the equivalent tools available in the current environment.
+
 ## Project Structure & Module Organization
 `mutsu` is a Rust-based Raku compatibility interpreter.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,9 @@ Existing interpreter fallbacks are technical debt. When you encounter one while 
 - PRs should include: concise problem statement, approach, and test evidence (`make test` / `make roast` results).
 - Link related issues/PRs when applicable (for example, `(#150)`).
 - Ensure CI passes format, clippy, unit tests, TAP tests, and roast checks before merge.
+- After completing and validating an implementation, proactively create and publish its PR without
+  waiting for a separate user request. Treat PR publication as part of finishing the implementation
+  unless the user explicitly asks to keep the changes local.
 - When asked to open a PR, create it as **ready for review (`draft: false`) from the start** and
   enable GitHub auto-merge after opening it unless the user explicitly asks not to. Do not create a
   draft PR and then convert it to ready: GitHub cannot enable auto-merge on draft PRs. Branch

--- a/PLAN.md
+++ b/PLAN.md
@@ -1143,10 +1143,7 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 9: `.^attributes(:local)` exposes model fields as ordinary `Attribute` introspection
         objects on both registered type objects and node values. Tests in
         `t/rakuast-type-attributes.t`.
-  - [x] Slice 10: `.^method_table` exposes the same implemented model API as
-        `.^methods(:local)`, keyed by method name, on registered type objects and node values.
-        Tests in `t/rakuast-type-method-table.t`.
-  - [ ] Slice 11+: remaining type-object metaobject operations.
+  - [ ] Slice 10+: remaining type-object metaobject operations.
 - **Phase 4 (in progress)** — construction (`.new`).
   - [x] Slice 1: literal constructors (`RakuAST::IntLiteral.new(42)`, `StrLiteral`, `RatLiteral`).
         Tests in `t/rakuast-construct.t`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1143,7 +1143,10 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 9: `.^attributes(:local)` exposes model fields as ordinary `Attribute` introspection
         objects on both registered type objects and node values. Tests in
         `t/rakuast-type-attributes.t`.
-  - [ ] Slice 10+: remaining type-object metaobject operations.
+  - [x] Slice 10: `.^method_table` exposes the same implemented model API as
+        `.^methods(:local)`, keyed by method name, on registered type objects and node values.
+        Tests in `t/rakuast-type-method-table.t`.
+  - [ ] Slice 11+: remaining type-object metaobject operations.
 - **Phase 4 (in progress)** — construction (`.new`).
   - [x] Slice 1: literal constructors (`RakuAST::IntLiteral.new(42)`, `StrLiteral`, `RatLiteral`).
         Tests in `t/rakuast-construct.t`.

--- a/news/2026-07/rakuast-method-table.md
+++ b/news/2026-07/rakuast-method-table.md
@@ -1,0 +1,10 @@
+# RakuAST model method table
+
+RakuAST registered type objects and node values now expose `.^method_table`. The table is keyed by
+method name and contains ordinary `Method` introspection objects for the constructors and accessors
+implemented by mutsu's model layer.
+
+The implementation derives the table from the same central metadata as `.^methods(:local)`, keeping
+the two introspection surfaces aligned without copying Rakudo's compiler-private `IMPL-*` API.
+Regression coverage includes literal, multi-field, named-constructor, read-only, empty-surface, and
+node-value cases in `t/rakuast-type-method-table.t`.

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -1109,6 +1109,7 @@ impl Interpreter {
                 let type_name = match args[0].view() {
                     ValueView::Package(name) => name.resolve(),
                     ValueView::Instance { class_name, .. } => class_name.resolve(),
+                    ValueView::RakuAst(node) => node.class.printed_name().to_string(),
                     _ => value_type_name(&args[0]).to_string(),
                 };
                 Ok(Value::hash(self.class_method_table(&type_name)))

--- a/src/runtime/methods_classhow_method_obj.rs
+++ b/src/runtime/methods_classhow_method_obj.rs
@@ -55,6 +55,15 @@ impl Interpreter {
     /// single dispatcher entry.
     pub(super) fn class_method_table(&self, class_name: &str) -> HashMap<String, Value> {
         let mut table = HashMap::new();
+        // RakuAST model classes are native type objects and therefore have no
+        // ClassDef entry. Keep method_table in lockstep with
+        // `.^methods(:local)` by deriving both from the same model metadata.
+        if let Some(names) = crate::rakuast::local_method_names(class_name) {
+            for name in names {
+                table.insert(name.to_string(), self.make_native_method_object(name));
+            }
+            return table;
+        }
         let registry = self.registry();
         let Some(class_def) = registry.classes.get(class_name) else {
             return table;

--- a/t/rakuast-type-method-table.t
+++ b/t/rakuast-type-method-table.t
@@ -1,0 +1,29 @@
+use Test;
+use experimental :rakuast;
+
+plan 10;
+
+my %int-methods = RakuAST::IntLiteral.^method_table;
+is %int-methods.keys.sort.join(','), 'new,value',
+    'literal method table exposes the model API';
+is %int-methods<new>.name, 'new', 'constructor entry is a Method object';
+is %int-methods<value>.name, 'value', 'accessor entry is a Method object';
+is %int-methods.values.map(*.^name).unique.join(','), 'Method',
+    'method table values use ordinary Method introspection objects';
+
+my %apply-methods = RakuAST::ApplyInfix.^method_table;
+is %apply-methods.keys.sort.join(','), 'infix,left,new,right',
+    'multi-field node exposes constructor and accessors';
+
+is RakuAST::Name.^method_table.keys.sort.join(','), 'from-identifier',
+    'named constructor appears in the method table';
+is RakuAST::StatementList.^method_table.keys.sort.join(','), 'statements',
+    'read-only model class exposes its accessor';
+is RakuAST::Assignment.^method_table.elems, 0,
+    'class without an implemented model API has an empty table';
+
+my $node = RakuAST::IntLiteral.new(42);
+is $node.^method_table.keys.sort.join(','), 'new,value',
+    'node values share their type object method table';
+is $node.^method_table<value>.name, 'value',
+    'node value method table contains usable metadata';


### PR DESCRIPTION
## Summary

- expose the implemented RakuAST model API through `.^method_table`
- keep method-table entries aligned with `.^methods(:local)` metadata
- support introspection on both RakuAST type objects and node values
- record the completed slice in the per-accomplishment news ledger
- require agents to proactively publish validated implementations as PRs
- require Codex agents to read the repository knowledge in `CLAUDE.md` before planning or coding

## Why

RakuAST model classes are native type objects rather than ordinary class-registry entries, so the generic ClassHOW method-table path returned an empty hash even though `.^methods(:local)` exposed constructors and accessors.

## Validation

- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- targeted RakuAST introspection tests: 70 tests passed
- `make test`: 2508 files, 23947 tests passed
