### PR TITLE
feat(rakuast): construct mutable statement lists

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1152,8 +1152,10 @@ so it is tracked separately from the roast backlog.
         `ApplyInfix.new(:left, :infix, :right)`). Tests in `t/rakuast-construct-multi.t`.
   - [x] Slice 4: `Var::Lexical.new`, `ApplyPrefix`/`ApplyPostfix`, `Postfix.new(:operator)`. Tests in
         `t/rakuast-construct-more.t`.
-  - [ ] Slice 5+: `StatementList` (children via `.add-statement` mutator — needs a mutable-node path),
-        block/sub/declaration constructors.
+  - [x] Slice 5: mutable `StatementList.new` + `.add-statement`; aliases share appended children,
+        and constructed lists lower through `EVAL`. Tests in
+        `t/rakuast-construct-statement-list.t`.
+  - [ ] Slice 6+: block/sub/declaration constructors.
 - **Phase 5 (in progress)** — EVAL: lower RakuAST → internal AST → existing compiler (no new engine).
   - [x] Slices 1–37 done (PRs #4736–#4804): literals, all common operators + ternary, the full
         control-flow set, sub declarations (typed/default/named/slurpy params) + calls + method calls,

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -182,9 +182,14 @@ earlier ones.
   - **Slice 4 (more operators) — done.** `Var::Lexical.new("$x")` (positional), `ApplyPrefix.new(
     prefix => …, operand => …)`, `ApplyPostfix.new(operand => …, postfix => …)`, and `Postfix.new(
     operator => …)` (whose `operator` is a *named* string field). Tests in
-    `t/rakuast-construct-more.t`. Next: `StatementList` (its children are added via the `.add-statement`
-    *mutator*, which needs a mutable-node path), block/sub/declaration constructors — then Phase 5
-    (EVAL) can lower a fully-constructed tree.
+    `t/rakuast-construct-more.t`.
+  - **Slice 5 (`StatementList`) — done.** `RakuAST::StatementList.new` builds an empty list and
+    `.add-statement($node)` appends in place, returns the added node, and is visible through every
+    alias of the list. The exceptional shared-node write is centralized behind the NanBox value
+    boundary; the native one-argument method path performs the mutation without a tree-walking
+    fallback. Constructed lists render, expose `new`/`add-statement` through introspection, and lower
+    through the existing compiler under `EVAL`. Tests in `t/rakuast-construct-statement-list.t`.
+    Next: block/sub/declaration constructors.
 - **Phase 5 — EVAL / compilation.** `lower(RakuAstNode) -> Vec<Stmt>/Expr`, then the
   **existing** compiler. `EVAL($rakuast)` and any code that yields a RakuAST tree runs
   through this. No new execution engine.

--- a/news/2026-07/rakuast-statement-list-construction.md
+++ b/news/2026-07/rakuast-statement-list-construction.md
@@ -1,0 +1,9 @@
+# RakuAST StatementList construction
+
+Phase 4 construction now supports an empty `RakuAST::StatementList.new` and the
+`add-statement` mutator. Appends preserve shared node identity, so aliases observe the same children,
+and a fully constructed statement list can be passed to `EVAL` through the existing RakuAST lowering
+and compiler pipeline.
+
+The mutator is part of the native model API and therefore appears in `.^methods(:local)` and
+`.^method_table`; `.^attributes(:local)` continues to report only the `statements` model field.

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -32,6 +32,11 @@ pub(crate) fn native_method_1arg(
 
     // Scalar containers are transparent for method dispatch (no .VAR at this arity).
     let target = target.descalarize();
+    if method == "add-statement"
+        && let Some(result) = target.rakuast_add_statement(arg.clone())
+    {
+        return Some(result);
+    }
     // Instance with __baggy_data__: delegate to the inner Bag/Set for collection methods
     if let ValueView::Instance { attributes, .. } = target.view()
         && let Some(inner) = attributes.as_map().get("__baggy_data__")

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -503,6 +503,17 @@ pub fn construct(
     method: &str,
     args: &[Value],
 ) -> Result<Option<Value>, RuntimeError> {
+    if class_name == "RakuAST::StatementList" && method == "new" {
+        if !args.is_empty() {
+            return Err(RuntimeError::new(
+                "RakuAST::StatementList.new expects no arguments",
+            ));
+        }
+        return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
+            class: RakuAstClass::StatementList,
+            fields: Vec::new(),
+        }))));
+    }
     // Single-positional-argument constructors: the literals, `Name.from-identifier`,
     // and the bare operator nodes (`Infix.new("+")`).
     if let Some(class) = single_positional_class(class_name, method) {
@@ -646,6 +657,9 @@ pub fn local_method_names(class_name: &str) -> Option<Vec<&'static str>> {
     }
 
     names.extend(accessor_names(class));
+    if class == RakuAstClass::StatementList {
+        names.push("add-statement");
+    }
     names.sort_unstable();
     names.dedup();
     Some(names)
@@ -669,7 +683,8 @@ fn class_from_name(class_name: &str) -> Option<RakuAstClass> {
 fn constructor_is_supported(class: RakuAstClass) -> bool {
     matches!(
         class,
-        RakuAstClass::IntLiteral
+        RakuAstClass::StatementList
+            | RakuAstClass::IntLiteral
             | RakuAstClass::RatLiteral
             | RakuAstClass::StrLiteral
             | RakuAstClass::Infix

--- a/src/value/nanbox/peek.rs
+++ b/src/value/nanbox/peek.rs
@@ -59,6 +59,29 @@ impl NanBox {
         }
     }
 
+    /// Run `f` on the shared RakuAST node payload in place.
+    ///
+    /// RakuAST model nodes are otherwise immutable, but builder methods such as
+    /// `StatementList.add-statement` deliberately mutate the node shared by all
+    /// holders. Keep that exceptional aliased write behind the NanBox wall so
+    /// the payload kind check and raw-address access live in one place.
+    #[inline]
+    pub(in crate::value) fn with_rakuast_inplace<R>(
+        &self,
+        f: impl FnOnce(&mut crate::rakuast::RakuAstNode) -> R,
+    ) -> Option<R> {
+        let bits = self.0.get();
+        if !matches!(classify(bits), Classified::Kind(Kind::RakuAst)) {
+            return None;
+        }
+        // SAFETY: a RakuAST payload is an Arc<RakuAstNode>. Native model
+        // mutators execute synchronously and do not re-enter the VM while this
+        // borrow is live. The mutation must write through the shared node (COW
+        // would make aliases observe different ASTs).
+        let node = unsafe { &mut *std::ptr::with_exposed_provenance_mut(addr_of_payload(bits)) };
+        Some(f(node))
+    }
+
     /// True iff this is a big-integer-backed rational tagged as a FatRat.
     #[inline]
     pub(in crate::value) fn is_bigfatrat(&self) -> bool {

--- a/src/value/value_methods_a.rs
+++ b/src/value/value_methods_a.rs
@@ -36,6 +36,29 @@ impl Value {
     pub fn rakuast(node: Box<crate::rakuast::RakuAstNode>) -> Self {
         Value::RakuAst(node)
     }
+
+    pub(crate) fn rakuast_add_statement(
+        &self,
+        statement: Value,
+    ) -> Option<Result<Value, RuntimeError>> {
+        self.0.with_rakuast_inplace(|node| {
+            if node.class != crate::rakuast::RakuAstClass::StatementList {
+                return Err(RuntimeError::new(
+                    "add-statement is only available on RakuAST::StatementList",
+                ));
+            }
+            if !matches!(statement.view(), ValueView::RakuAst(_)) {
+                return Err(RuntimeError::new(
+                    "RakuAST::StatementList.add-statement expects a RakuAST node",
+                ));
+            }
+            node.fields.push(crate::rakuast::RakuAstField {
+                name: None,
+                value: crate::rakuast::RakuAstFieldValue::Node(statement.clone()),
+            });
+            Ok(statement)
+        })
+    }
     pub fn mixin(inner: Value, overrides: HashMap<String, Value>) -> Self {
         Value::Mixin(Arc::new(inner), Arc::new(overrides))
     }

--- a/t/rakuast-construct-statement-list.t
+++ b/t/rakuast-construct-statement-list.t
@@ -1,0 +1,36 @@
+use v6;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 4 slice 5 (ADR-0011): mutable StatementList construction.
+# This file passes under both mutsu and raku.
+
+plan 8;
+
+my $list = RakuAST::StatementList.new;
+my $alias = $list;
+is $list.gist, 'RakuAST::StatementList.new()', 'empty StatementList constructor';
+is $list.statements.elems, 0, 'empty StatementList has no children';
+
+my $first = RakuAST::Statement::Expression.new(
+    expression => RakuAST::IntLiteral.new(40),
+);
+is $list.add-statement($first), $first, 'add-statement returns the added node';
+is $list.statements.elems, 1, 'add-statement mutates the shared list';
+is $alias.statements.elems, 1, 'aliases observe the same mutable node';
+
+my $second = RakuAST::Statement::Expression.new(
+    expression => RakuAST::ApplyInfix.new(
+        left  => RakuAST::IntLiteral.new(40),
+        infix => RakuAST::Infix.new("+"),
+        right => RakuAST::IntLiteral.new(2),
+    ),
+);
+$list.add-statement($second);
+is $list.statements[1].expression.right.value, 2,
+    'multiple constructed statements remain queryable';
+is EVAL($list), 42, 'a constructed StatementList lowers through the existing compiler';
+
+my @local-methods = RakuAST::StatementList.^methods(:local)>>.name.sort;
+ok 'new' (elem) @local-methods && 'add-statement' (elem) @local-methods,
+    'type introspection exposes construction and mutation';

--- a/t/rakuast-type-method-table.t
+++ b/t/rakuast-type-method-table.t
@@ -17,8 +17,8 @@ is %apply-methods.keys.sort.join(','), 'infix,left,new,right',
 
 is RakuAST::Name.^method_table.keys.sort.join(','), 'from-identifier',
     'named constructor appears in the method table';
-is RakuAST::StatementList.^method_table.keys.sort.join(','), 'statements',
-    'read-only model class exposes its accessor';
+is RakuAST::StatementList.^method_table.keys.sort.join(','), 'add-statement,new,statements',
+    'mutable model class exposes construction, mutation, and its accessor';
 is RakuAST::Assignment.^method_table.elems, 0,
     'class without an implemented model API has an empty table';
 

--- a/t/rakuast-type-methods.t
+++ b/t/rakuast-type-methods.t
@@ -22,7 +22,8 @@ is RakuAST::Name.^methods(:local).map(*.name).sort.join(','),
     'from-identifier', 'Name exposes its supported named constructor';
 
 is RakuAST::StatementList.^methods(:local).map(*.name).sort.join(','),
-    'statements', 'StatementList exposes its read accessor';
+    'add-statement,new,statements',
+    'StatementList exposes construction, mutation, and its read accessor';
 
 is RakuAST::Statement::Expression.^methods(:local).map(*.name).sort.join(','),
     'expression,new', 'statement wrapper exposes constructor and accessor';


### PR DESCRIPTION
## Summary

- add `RakuAST::StatementList.new` and its native `add-statement` mutator
- preserve shared node identity so aliases observe appended statements
- expose construction and mutation through RakuAST model introspection
- document Phase 4 slice 5 completion in PLAN, ADR-0011, and news

## Why

PLAN Phase 4 requires programmatic RakuAST construction. Statement lists could already be read and
lowered by `EVAL`, but could not be created or populated, preventing callers from assembling a
complete program tree.

## Implementation

The exceptional shared-node write is centralized behind the NanBox value boundary and dispatched
through the native one-argument method path. It does not add a tree-walking interpreter fallback.

## Validation

- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `raku t/rakuast-construct-statement-list.t`
- `prove -e 'target/debug/mutsu' t/rakuast-*.t` (80 files, 421 tests)
- `make test` (2,509 files, 23,955 TAP tests)
