### PR TITLE
fix: a role's attributes keep their declared types, and an attribute object hash keys by .WHICH

### DIFF
--- a/news/2026-07/role-attribute-type-constraints.md
+++ b/news/2026-07/role-attribute-type-constraints.md
@@ -1,0 +1,59 @@
+# A role's attributes keep their declared types, and an attribute object hash keys by `.WHICH`
+
+Two constraints that a `has` declaration writes down were being thrown away
+before anything could enforce them. Both surfaced while reducing `DBIish`'s
+`t/06-types.rakutest`, whose `role TypeConverter` declares
+`has Callable %!Conversions{Mu:U}` — a single attribute that needs each of them.
+
+## A role attribute had no declared type at all
+
+`register_role_decl` destructured `Stmt::HasDecl` with `type_constraint: _` and
+`type_smiley: _`. A role has no `ClassDef` of its own to hold `attribute_types`,
+and nothing else recorded them, so `role R { has Int $.x }` accepted anything:
+
+```raku
+role R { has Int $.x; has Int @.a }
+class C does R { }
+C.new(:x('no'));      # raku: type check failure     mutsu: accepted
+C.new.a.push('str');  # raku: type check failure     mutsu: accepted
+C.new.a.of;           # raku: Int                    mutsu: Mu
+```
+
+Roles now record the constraint (and the definiteness smiley) per
+`(role, attribute)`, in the same `ValueType{KeyType}` encoding a class attribute
+uses, following the pattern `role_attribute_is_types` already established for
+the `is Type` container trait. At composition the entries are copied onto the
+consuming class's `attribute_types` — with `::?CLASS` resolved to that class and
+any role type parameter substituted, so `role P[::T] { has T $.v }` composed with
+`Int` constrains `$!v` to `Int`. `ensure_role_punned_to_class` carries them too
+(there `::?CLASS` is the role itself), along with the role's `wildcard_handles`,
+which the punned class had also been dropping.
+
+The punned construction path builds its instance directly instead of going
+through the class constructor, so it grew the same type check the class path
+does in `enforce_attribute_where_constraints`. It deliberately does *not* check
+a value that was seeded positionally: that seeding fires even when the role
+declares its own `method new`, which raku would have run instead — a separate
+gap now written down in `todo/tickets/punned-role-ignores-user-new.md`.
+
+## An object hash declared as an attribute stringified its keys
+
+`has %!c{Mu:U}` parsed correctly and the container really did carry the key
+constraint — `.raku` printed `my Callable %{Mu:U}` — but every element
+assignment stored under the *stringified* key, so `%!c{Str}` and `%!c{Int}` both
+landed on `""` (with a "Use of uninitialized value of type Str in string
+context" warning to match). A lexical `my %h{Mu:U}` was correct all along.
+
+The reason is that the ~10 element-access sites ask
+`var_hash_key_constraint(name)`, which is keyed by variable name — and an
+attribute's declared type lives in the class registry, not in the per-variable
+map, exactly as `scalar_attr_type_constraint` already documents for typed scalar
+attributes. That lookup now falls back to resolving `%!c` / `%.c` against the
+current `self`'s class and splitting the key part back out of the declared type,
+so every path that consults it — assignment, read, `:exists`, `:delete` — sees
+the constraint. `var_hash_key_constraint_fast`, which gates a fast element-assign
+path that cannot handle object hashes, resolves it too; that costs a class-registry
+probe only for `%`-sigil attribute names, which never appear on the hot
+local-variable path.
+
+Pinned by `t/role-attribute-type-constraint.t`.

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -1225,6 +1225,7 @@ impl Interpreter {
 
                 // Collect attributes from this role and all composed parent roles
                 let mut all_attributes = role.attributes.clone();
+                let mut visited = vec![class_name.resolve()];
                 if let Some(parent_names) = self
                     .registry()
                     .role_parents
@@ -1232,7 +1233,6 @@ impl Interpreter {
                     .cloned()
                 {
                     let mut role_stack: Vec<String> = parent_names;
-                    let mut visited = vec![class_name.resolve()];
                     while let Some(parent_role_name) = role_stack.pop() {
                         if !visited.contains(&parent_role_name) {
                             visited.push(parent_role_name.clone());
@@ -1258,6 +1258,24 @@ impl Interpreter {
                     }
                 }
 
+                // The declared types of those attributes, keyed by attribute name.
+                // A role records them per (role, attr) since it has no ClassDef
+                // to hold `attribute_types`; parent roles are folded in first so
+                // this role's own declaration wins on a name clash.
+                let role_attr_types: HashMap<String, String> = {
+                    let cn = class_name.resolve();
+                    let mut m: HashMap<String, String> = HashMap::new();
+                    for owner in visited.iter().rev() {
+                        let base = owner.split_once('[').map(|(b, _)| b).unwrap_or(owner);
+                        for ((r, attr), tc) in &self.registry().role_attribute_types {
+                            if r == base {
+                                m.insert(attr.clone(), tc.replace("::?CLASS", &cn));
+                            }
+                        }
+                    }
+                    m
+                };
+
                 let mut mixins = HashMap::new();
                 mixins.insert(format!("__mutsu_role__{}", class_name), Value::TRUE);
                 // The attribute values go into the punned instance's own cell, not
@@ -1271,15 +1289,46 @@ impl Interpreter {
                 for (idx, (attr_name, _is_public, default_expr, _, _, sigil, _)) in
                     all_attributes.iter().enumerate()
                 {
-                    let supplied = if let Some(v) = named_args.get(attr_name) {
-                        Some(v.clone())
+                    // `type_checked` is false for the positional-by-index seeding:
+                    // that is a heuristic this path applies even when the role
+                    // declares its own `method new` (which raku would have run
+                    // instead — see `todo/tickets/punned-role-ignores-user-new.md`),
+                    // so type-checking it would turn that pre-existing gap into a
+                    // hard error.
+                    let (supplied, type_checked) = if let Some(v) = named_args.get(attr_name) {
+                        (Some(v.clone()), true)
                     } else if let Some(v) = positional_args.get(idx) {
-                        Some(v.clone())
+                        (Some(v.clone()), false)
                     } else if let Some(expr) = default_expr {
-                        Some(self.eval_block_value(&[Stmt::Expr(expr.clone())])?)
+                        (
+                            Some(self.eval_block_value(&[Stmt::Expr(expr.clone())])?),
+                            true,
+                        )
                     } else {
-                        None
+                        (None, true)
                     };
+                    // A punned role type-checks its attributes exactly like the
+                    // consuming-class path (`enforce_attribute_where_constraints`):
+                    // the constraint lives in `role_attribute_types` because the
+                    // role has no ClassDef of its own at declaration time. As
+                    // there, a `@`/`%` constraint names the *element* type and is
+                    // enforced at element assignment, not here.
+                    if type_checked
+                        && let Some(value) = supplied.as_ref()
+                        && !value.is_nil()
+                        && *sigil != '@'
+                        && *sigil != '%'
+                        && let Some(tc) = role_attr_types.get(attr_name)
+                        && (tc.starts_with(char::is_uppercase) || tc.starts_with("::"))
+                        && !self.type_matches_value(tc, value)
+                        && !self.is_container_subclass(tc)
+                    {
+                        return Err(crate::runtime::utils::type_check_assignment_typed_error(
+                            &format!("$!{}", attr_name),
+                            tc,
+                            value,
+                        ));
+                    }
                     mixins.insert(
                         format!("__mutsu_attr__{}", attr_name),
                         supplied.clone().unwrap_or(Value::NIL),

--- a/src/runtime/registration_class_augment.rs
+++ b/src/runtime/registration_class_augment.rs
@@ -659,6 +659,7 @@ impl Interpreter {
         // Collect attributes and methods from the role itself and all composed parent roles
         let mut all_attributes = role_def.attributes.clone();
         let mut all_methods: HashMap<String, Vec<MethodDef>> = role_def.methods.clone();
+        let mut all_wildcard_handles = role_def.wildcard_handles.clone();
         let mut composed_roles_list = vec![role_name.to_string()];
         if let Some(parent_names) = self.registry().role_parents.get(role_name).cloned() {
             let mut role_stack: Vec<String> = parent_names;
@@ -679,6 +680,11 @@ impl Interpreter {
                                 .or_default()
                                 .extend(method_defs.clone());
                         }
+                        for wh in &parent_role.wildcard_handles {
+                            if !all_wildcard_handles.contains(wh) {
+                                all_wildcard_handles.push(wh.clone());
+                            }
+                        }
                     }
                     // Also recurse into grandparent roles
                     if let Some(grandparents) =
@@ -693,16 +699,35 @@ impl Interpreter {
                 }
             }
         }
+        // A punned role's attributes keep their declared types: the pun IS the
+        // class here, so `::?CLASS` resolves to the role's own name. Parent
+        // roles' entries are collected first so the punned role's own
+        // declaration wins on a name clash.
+        let mut attribute_types: HashMap<String, String> = HashMap::new();
+        let mut attribute_smileys: HashMap<String, String> = HashMap::new();
+        for owner in composed_roles_list.iter().rev() {
+            let base = owner.split_once('[').map(|(b, _)| b).unwrap_or(owner);
+            for ((r, attr), tc) in &self.registry().role_attribute_types {
+                if r == base {
+                    attribute_types.insert(attr.clone(), tc.replace("::?CLASS", role_name));
+                }
+            }
+            for ((r, attr), s) in &self.registry().role_attribute_smileys {
+                if r == base {
+                    attribute_smileys.insert(attr.clone(), s.clone());
+                }
+            }
+        }
         let punned_class = ClassDef {
             parents: Vec::new(),
             attributes: all_attributes,
-            attribute_types: HashMap::new(),
-            attribute_smileys: HashMap::new(),
+            attribute_types,
+            attribute_smileys,
             attribute_built: HashMap::new(),
             methods: all_methods,
             native_methods: HashSet::new(),
             mro: super::sym_mro(&[role_name, "Any", "Mu"]),
-            wildcard_handles: Vec::new(),
+            wildcard_handles: all_wildcard_handles,
             alias_attributes: HashSet::new(),
             class_level_attrs: HashMap::new(),
         };

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -905,6 +905,37 @@ impl Interpreter {
                         .entry((name.to_string(), attr))
                         .or_insert(ty);
                 }
+                // Carry each composed-role attribute's declared type constraint
+                // (`role R { has Int $.x }`) onto the consuming class, so it is
+                // enforced and introspectable exactly like a class-declared one.
+                // `::?CLASS` in a role attribute names the consuming class, and
+                // a role type parameter (`has T $.v`) resolves to this
+                // composition's argument.
+                let role_attr_types: Vec<(String, String)> = self
+                    .registry()
+                    .role_attribute_types
+                    .iter()
+                    .filter(|((r, _), _)| r == base_role_name)
+                    .map(|((_, attr), tc)| {
+                        (
+                            attr.clone(),
+                            substitute_type_param_tokens(&tc.replace("::?CLASS", name), &type_subs),
+                        )
+                    })
+                    .collect();
+                for (attr, tc) in role_attr_types {
+                    class_def.attribute_types.entry(attr).or_insert(tc);
+                }
+                let role_attr_smileys: Vec<(String, String)> = self
+                    .registry()
+                    .role_attribute_smileys
+                    .iter()
+                    .filter(|((r, _), _)| r == base_role_name)
+                    .map(|((_, attr), s)| (attr.clone(), s.clone()))
+                    .collect();
+                for (attr, s) in role_attr_smileys {
+                    class_def.attribute_smileys.entry(attr).or_insert(s);
+                }
                 for (mname, overloads) in &role.methods {
                     // Skip methods declared with `my` scope -- they are role-private
                     // and should not be composed into consuming classes.

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -467,8 +467,8 @@ impl Interpreter {
                     handles,
                     is_rw,
                     is_readonly,
-                    type_constraint: _,
-                    type_smiley: _,
+                    type_constraint,
+                    type_smiley,
                     is_required,
                     sigil,
                     where_constraint,
@@ -502,6 +502,22 @@ impl Interpreter {
                         self.registry_mut()
                             .role_attribute_is_types
                             .insert((name.to_string(), attr_name_str.clone()), it.clone());
+                    }
+                    // The declared type of a role attribute (`has Int $.x`,
+                    // `has Callable %!c{Mu:U}`) is recorded per (role, attr) and
+                    // copied onto every consuming/punned class, since a role has
+                    // no class of its own to hold `attribute_types`. `::?CLASS`
+                    // stays unresolved here — it names the *consuming* class, so
+                    // it is substituted at composition.
+                    if let Some(tc) = type_constraint {
+                        self.registry_mut()
+                            .role_attribute_types
+                            .insert((name.to_string(), attr_name_str.clone()), tc.clone());
+                    }
+                    if let Some(ts) = type_smiley {
+                        self.registry_mut()
+                            .role_attribute_smileys
+                            .insert((name.to_string(), attr_name_str.clone()), ts.clone());
                     }
                     // `is default(...)` on a role attribute can reference the role's
                     // type parameters (`is default(T)`), so it cannot be evaluated

--- a/src/runtime/registry.rs
+++ b/src/runtime/registry.rs
@@ -151,6 +151,18 @@ pub(crate) struct Registry {
     /// `class_attribute_is_types` at composition (`has @.a is G::A` in a
     /// parametric role) so the attribute's element type is enforced.
     pub(crate) role_attribute_is_types: HashMap<(String, String), String>,
+    /// Per-attribute declared type constraint on a *role* attribute
+    /// (`role R { has Int $.x }`, `has Callable %!c{Mu:U}`): (role, attr) ->
+    /// type constraint, in the same `ValueType{KeyType}` encoding a class
+    /// attribute uses. Roles keep their own table because a role is registered
+    /// before it is known which class will consume it; at composition (and when
+    /// a role is punned to a class) the entries are copied — with role type
+    /// parameters substituted — into the class's `attribute_types`.
+    pub(crate) role_attribute_types: HashMap<(String, String), String>,
+    /// Per-attribute definiteness smiley on a *role* attribute
+    /// (`role R { has Int:D $.x }`): (role, attr) -> "D"/"U"/"_". Copied
+    /// alongside `role_attribute_types`.
+    pub(crate) role_attribute_smileys: HashMap<(String, String), String>,
     /// Per-attribute `does Role` traits: (class, attr) -> role names mixed into
     /// the attribute's container (`has $.x does Foo`). Applied to the attribute's
     /// value at construction so `$o.x` does the role.

--- a/src/runtime/runtime_var_meta.rs
+++ b/src/runtime/runtime_var_meta.rs
@@ -387,12 +387,37 @@ impl Interpreter {
         if let Some(ValueView::Str(tc)) = self.env.get(&meta_key).map(Value::view) {
             return Some(tc.to_string());
         }
-        self.var_hash_key_constraints.get(key).cloned()
+        if let Some(tc) = self.var_hash_key_constraints.get(key) {
+            return Some(tc.clone());
+        }
+        self.attr_hash_key_constraint(name)
+    }
+
+    /// The key type of an object-hash *attribute* (`has Callable %!Conv{Mu:U}`)
+    /// referenced as `%!Conv` / `%.Conv` inside a method. The per-variable
+    /// `var_hash_key_constraints` map cannot carry this — it is keyed by bare
+    /// name and the attribute's declared type lives in the class registry — so
+    /// resolve it against the current `self`'s class, exactly as
+    /// `scalar_attr_type_constraint` does for typed scalar attributes. The
+    /// declared type is stored as `ValueType{KeyType}` (see
+    /// `parser::stmt::decl::has_decl`), so the key part is split back out here.
+    fn attr_hash_key_constraint(&self, name: &str) -> Option<String> {
+        if !name.starts_with('%') {
+            return None;
+        }
+        let (bare, _) = crate::value::attr_twigil_base(name)?;
+        let tc = self.self_attr_type_constraint(bare)?;
+        let (_, key_type) = crate::runtime::types::split_object_hash_constraint(&tc);
+        key_type.map(str::to_string)
     }
 
     /// Fast check for hash key constraint — only checks the HashMap,
     /// skipping the `format!("__mutsu_hash_key_type::...")` + env lookup.
+    /// Object-hash attributes still have to take the slow path, so they are
+    /// resolved through the class registry here too (only for `%`-sigil
+    /// attribute names, which never appear on the hot local-variable path).
     pub(crate) fn var_hash_key_constraint_fast(&self, name: &str) -> bool {
         self.var_hash_key_constraints.contains_key(name)
+            || self.attr_hash_key_constraint(name).is_some()
     }
 }

--- a/t/role-attribute-type-constraint.t
+++ b/t/role-attribute-type-constraint.t
@@ -1,0 +1,65 @@
+use Test;
+
+# A role's attribute keeps its declared type constraint: the role has no class
+# of its own to hold `attribute_types`, so the constraint is recorded per
+# (role, attribute) and copied onto every consuming class (and onto the punned
+# class). Before this it was dropped at role registration, so `role R { has Int
+# $.x }` accepted a Str and `.of` on a typed container attribute answered `Mu`.
+
+plan 14;
+
+role R {
+    has Int $.x;
+    has Int @.a;
+    has Str $.s = 'hi';
+}
+class C does R { }
+
+is C.new(:x(5)).x, 5, 'typed role attribute accepts a matching value';
+dies-ok { C.new(:x('no')) }, 'typed role attribute rejects a mistyped value';
+dies-ok { C.new.a.push('str') }, 'typed role array attribute rejects a mistyped element';
+is C.new.a.of.^name, 'Int', 'typed role array attribute reports its element type';
+is C.new.s, 'hi', 'role attribute default still applies';
+
+# The constraint reaches a punned role too (`R.new` puns R to a class).
+dies-ok { R.new(:x('no')) }, 'punned role enforces its attribute type';
+
+# A role type parameter in an attribute type resolves per composition.
+role P[::T] { has T $.v }
+class PI does P[Int] { }
+is PI.new(:v(7)).v, 7, 'role type parameter in an attribute type accepts a match';
+dies-ok { PI.new(:v('no')) }, 'role type parameter in an attribute type rejects a mismatch';
+
+# An object hash declared as an attribute keys by `.WHICH`, not by stringifying
+# the key — `%!c{Str}` used to store under the empty string (and warn about
+# "uninitialized value of type Str in string context").
+class OH {
+    has Callable %!c{Mu:U};
+    method poke($t, &v) { %!c{$t} = &v }
+    method peek($t) { %!c{$t} }
+    method n() { %!c.elems }
+}
+my $oh = OH.new;
+$oh.poke(Str, sub ($x) { 'from-Str' });
+$oh.poke(Int, sub ($x) { 'from-Int' });
+is $oh.n, 2, 'two distinct type-object keys in an attribute object hash';
+is $oh.peek(Str).('x'), 'from-Str', 'Str key reads back its own value';
+is $oh.peek(Int).('x'), 'from-Int', 'Int key reads back its own value';
+
+# The same declared on a role, then composed.
+role OHR { has %!c{Mu:U}; method poke($t, $v) { %!c{$t} = $v }; method peek($t) { %!c{$t} } }
+class OHC does OHR { }
+my $ohc = OHC.new;
+$ohc.poke(Str, 'sv');
+$ohc.poke(Int, 'iv');
+is $ohc.peek(Str), 'sv', 'object-hash attribute from a role keeps the Str key';
+is $ohc.peek(Int), 'iv', 'object-hash attribute from a role keeps the Int key';
+
+# A public object-hash attribute is reachable through its accessor.
+class OHP {
+    has %.c{Mu:U};
+    method poke($t, $v) { %!c{$t} = $v }
+}
+my $ohp = OHP.new;
+$ohp.poke(Str, 'via-accessor');
+is $ohp.c{Str}, 'via-accessor', 'public object-hash attribute reads through its accessor';

--- a/todo/deep/punned-role-container-attribute-store.md
+++ b/todo/deep/punned-role-container-attribute-store.md
@@ -1,0 +1,64 @@
+# A punned role keeps its `@`/`%` attributes in mixin markers, not in the instance cell
+
+A bare role instantiated directly (`R.new`, which puns the role to a class) is
+represented as a `Mixin` wrapping an instance. Its *scalar* attributes are
+seeded into the wrapped instance's shared attribute cell — the store of record
+for every `$!x` read and write inside a role method — but its `@`/`%`
+attributes are deliberately **not**: they live only as `__mutsu_attr__<name>`
+entries in the mixin map. The guard and its reasoning are in
+`src/runtime/methods_object_dispatch_new.rs` (the `registry().roles.get(...)`
+arm of `dispatch_new`), which already carries a `TODO: compile the container
+case onto the cell too`.
+
+The consequence is that an ordinary container-attribute mutation inside a role
+method is lost:
+
+```raku
+role R { has %!h; method poke { %!h<k> = 1 }; method peek { %!h.raku } }
+my $r = R.new;
+$r.poke;
+$r.peek;      # raku: {:k(1)}   mutsu: {}
+```
+
+`%!h<k> = 1` writes through `write_attr_cell_by_key`
+(`src/vm/vm_var_assign_computed_attr.rs`), which only writes attributes the cell
+already holds — and the cell holds no `h` — so the write is dropped silently.
+The same role composed into a class (`class D does R { }`) works, because the
+class path seeds every sigil into the cell.
+
+## Why the markers cannot simply be dropped
+
+The `handles` delegation path reads and writes the markers, not the cell:
+`delegated_role_attr_key_from_mixins` (`src/runtime/types/roles.rs`) resolves a
+delegated `AT-POS`/`ASSIGN-KEY` to a `__mutsu_attr__` key, and the element
+assignment in `src/vm/vm_var_assign_index_named.rs` mutates the marker, rebuilds
+the whole `Mixin` value, and stores it back into the *caller's env variable*.
+That writeback reaches an object held in a plain lexical but not one held in an
+attribute or an array element. `t/positional-role-attr-writeback-coherence.t`
+pins the current behaviour of exactly this path.
+
+So today there are two stores that disagree, and each is load-bearing for a
+different set of tests. Seeding containers into the cell as well (the obvious
+one-line change) makes them diverge rather than converge.
+
+## The fix
+
+Make the instance cell the single store for every sigil, and rework the
+delegation forwarder to resolve its target attribute through the cell instead of
+the mixin map. The `__mutsu_attr__` markers then become construction-time seeds
+plus "is this a role mixin" flags, which is what the scalar case already treats
+them as. There are ~36 `__mutsu_attr__` sites across 12 files; the load-bearing
+ones are `runtime/types/roles.rs`, `vm/vm_var_assign_index_named.rs`,
+`runtime/methods_mut_method_lvalue.rs`, `runtime/builtins_multidim_subscript.rs`
+and `runtime/methods_call_dispatch.rs`. Removing the env-variable writeback in
+favour of a cell write is what makes the object usable from an attribute.
+
+## Why it matters beyond the repro
+
+`DBIish`'s `t/06-types.rakutest` needs it: `role TypeConverter does Associative
+{ has Callable %!Conversions{Mu:U} handles <AT-KEY EXISTS-KEY> }` is punned by
+`has %.Converter is DBDish::TypeConverter`, so the punned object lives in an
+*attribute* and both stores are exercised at once. See
+`todo/tickets/dbiish-blockers.md` ⑤. `todo/tickets/punned-role-ignores-user-new.md`
+is the same construction path from a different angle and should be fixed with
+it.

--- a/todo/tickets/dbiish-blockers.md
+++ b/todo/tickets/dbiish-blockers.md
@@ -233,9 +233,36 @@ and the test declares `has %.Converter is DBDish::TypeConverter;`, then
 `%!Converter{Str} = self.^find_method('test-str')`. So the file needs: an
 **object hash keyed by `Mu:U`** (type objects as keys), `handles <AT-KEY
 EXISTS-KEY>` delegation on a private attribute, an attribute typed with a role,
-`.^find_method`, and the indirect method call `$test.$sub('test')`. Start by
-checking which of those five mutsu lacks — the `Did you mean 'invert'?`
-suggestion is the *symptom* of an unresolved delegated `AT-KEY`, not a typo.
+`.^find_method`, and the indirect method call `$test.$sub('test')`.
+
+**All five were measured separately 2026-07-26** (the `Did you mean 'invert'?`
+suggestion is the *symptom* of `$test.Converter` still being a plain `Hash`, not
+a typo, and the file's first non-TAP line is only a warning — see the note at
+the end of this file). Three are done and two remain:
+
+- **Object hash keyed by `Mu:U`** — worked for a lexical `my %h{Mu:U}` but not
+  for an attribute: every element assignment stringified the key. Fixed, along
+  with role attributes having no declared type at all, in
+  [`news/2026-07/role-attribute-type-constraints.md`](../../news/2026-07/role-attribute-type-constraints.md).
+- **`.^find_method`** and **the indirect method call `$obj.$sub('x')`** — both
+  already correct.
+- **`handles <AT-KEY EXISTS-KEY>` on a private attribute** — correct on a class.
+  On a *punned role* it goes through a second, incompatible store, which is the
+  remaining blocker below.
+- **An attribute typed with a role** (`has %.Converter is TypeConverter`) — the
+  `is Type` trait itself works (`Type.new` seeds the attribute), but for a role
+  that means a punned-role object living inside an attribute, which is precisely
+  where the second store cannot be reached.
+
+So what is left of ⑤ is one thing:
+[`todo/deep/punned-role-container-attribute-store.md`](../deep/punned-role-container-attribute-store.md).
+A punned role keeps its `@`/`%` attributes in `__mutsu_attr__` mixin markers
+instead of the instance's attribute cell, so an ordinary `%!h<k> = 1` inside a
+role method is dropped, while the `handles` delegation path mutates the marker
+and writes the rebuilt `Mixin` back into the *caller's env variable* — a
+writeback that cannot reach an object held in an attribute. The code carries its
+own `TODO` for this. It wants the cell to become the single store for every
+sigil; ~36 `__mutsu_attr__` sites are involved.
 
 Note the object-hash requirement overlaps the deferred "object-hash `WHICH`"
 item in the doc-diff DEEP bucket (`docs/doc-diff-backlog.md`).
@@ -302,10 +329,11 @@ the adverbs away outright.
 ⑦, ③, ④a, ④b and ⑧ are done. `05-mock` is at raku parity (16/16) and `01-basic`
 is at 30 of 35. Two left:
 
-1. **⑤** — `06-types`: an object hash keyed by type objects, plus `handles`
-   delegation from a private attribute. Confirm which of the five features listed
-   above is actually missing before scoping it. This is the only remaining file
-   whose blockers are ordinary interpreter work.
+1. **⑤** — `06-types`: reduced to a single blocker,
+   [`todo/deep/punned-role-container-attribute-store.md`](../deep/punned-role-container-attribute-store.md)
+   (the object-hash and role-attribute-type halves are fixed). It is a real
+   refactor rather than a slice: the punned role's container attributes and the
+   `handles` delegation forwarder have to converge on the instance cell.
 2. **⑨** — the `mysql` driver, and with it `01-basic`'s last three subtests. Do
    not start it as a `DBIish` task: it is
    [`todo/deep/nativehelpers-blob-moarvm-guts.md`](../deep/nativehelpers-blob-moarvm-guts.md),

--- a/todo/tickets/punned-role-ignores-user-new.md
+++ b/todo/tickets/punned-role-ignores-user-new.md
@@ -1,0 +1,38 @@
+# A punned role ignores its own `method new` and seeds positionals by index
+
+Constructing a bare role (`R.new(...)`, which puns the role to a class) never
+runs a `new` the role declares. `dispatch_new`'s role branch
+(`src/runtime/methods_object_dispatch_new.rs`, the `registry().roles.get(...)`
+arm) builds the punned instance itself: it maps each named argument onto the
+attribute of that name, and — the part raku has no equivalent for — maps each
+*positional* argument onto the attribute at the same index.
+
+```raku
+my role R { has $.attr; multi method new(Int:D $n) { say "in new(Int)"; self.bless(attr => "x") } }
+say R.new(42).attr;
+# raku:  "in new(Int)" then "x"
+# mutsu: 42          (the multi never runs; 42 is seeded into $!attr positionally)
+```
+
+The class path has no such shortcut — `class C does R { }` dispatches to the
+role-composed `new` correctly. Only the pun is affected.
+
+## Why it is not a one-line fix
+
+The role branch is a parallel construction path, not a thin wrapper over the
+class one: it assembles `__mutsu_attr__` mixin markers rather than a ClassDef
+instance (see `todo/deep/punned-role-container-attribute-store.md`). Making it
+honour a user `new` means either dispatching to the role's method table before
+this branch — which has to avoid re-entering `dispatch_new` for the `self.bless`
+inside that method — or routing the pun through `ensure_role_punned_to_class`
+and the ordinary class constructor, which is the same consolidation that ticket
+describes. The positional-by-index seeding also has to survive for roles that
+declare no `new`, since existing tests rely on it.
+
+## Where it is currently papered over
+
+`role_attribute_types` type-checking (added with the role attribute type
+constraint fix) deliberately skips positionally-seeded values: type-checking
+them turns this gap into a hard `Type check failed in assignment to $!attr`
+during `R.new(42)`, which `t/class-type-object-coercion-call.t` catches. The
+`type_checked` flag in that loop is the marker to remove once this is fixed.


### PR DESCRIPTION
Two constraints that a `has` declaration writes down were being thrown away before anything could enforce them. Both were reduced from `DBIish`'s `t/06-types.rakutest`, whose `role TypeConverter` declares `has Callable %!Conversions{Mu:U}` — one attribute that needs each of them.

## A role attribute had no declared type at all

`register_role_decl` destructured `Stmt::HasDecl` with `type_constraint: _` and `type_smiley: _`. A role has no `ClassDef` of its own to hold `attribute_types`, and nothing else recorded them:

```raku
role R { has Int $.x; has Int @.a }
class C does R { }
C.new(:x('no'));      # raku: type check failure     mutsu: accepted
C.new.a.push('str');  # raku: type check failure     mutsu: accepted
C.new.a.of;           # raku: Int                    mutsu: Mu
```

Roles now record the constraint (and the definiteness smiley) per `(role, attribute)`, in the same `ValueType{KeyType}` encoding a class attribute uses, following the pattern `role_attribute_is_types` already established for the `is Type` container trait. At composition the entries are copied onto the consuming class's `attribute_types` — with `::?CLASS` resolved to that class and any role type parameter substituted, so `role P[::T] { has T $.v }` composed with `Int` constrains `$!v` to `Int`. `ensure_role_punned_to_class` carries them too (there `::?CLASS` is the role itself), along with the role's `wildcard_handles`, which the punned class had also been dropping.

The punned construction path builds its instance directly instead of going through the class constructor, so it grew the same type check the class path does in `enforce_attribute_where_constraints`. It deliberately does *not* check a value that was seeded positionally: that seeding fires even when the role declares its own `method new`, which raku would have run instead — a separate gap now written down in `todo/tickets/punned-role-ignores-user-new.md`.

## An object hash declared as an attribute stringified its keys

`has %!c{Mu:U}` parsed correctly and the container really did carry the key constraint — `.raku` printed `my Callable %{Mu:U}` — but every element assignment stored under the *stringified* key, so `%!c{Str}` and `%!c{Int}` both landed on `""`. A lexical `my %h{Mu:U}` was correct all along.

The ~10 element-access sites ask `var_hash_key_constraint(name)`, which is keyed by variable name — and an attribute's declared type lives in the class registry, not in the per-variable map, exactly as `scalar_attr_type_constraint` already documents for typed scalar attributes. That lookup now falls back to resolving `%!c` / `%.c` against the current `self`'s class and splitting the key part back out, so assignment, read, `:exists` and `:delete` all see it. `var_hash_key_constraint_fast`, which gates a fast element-assign path that cannot handle object hashes, resolves it too; that costs a class-registry probe only for `%`-sigil attribute names, which never appear on the hot local-variable path.

## Testing

`t/role-attribute-type-constraint.t` (14 subtests, verified against raku). Local `make test` and `make roast` both PASS.

## Follow-ups recorded

What remains of `DBIish` ⑤ is `todo/deep/punned-role-container-attribute-store.md`: a punned role keeps its `@`/`%` attributes in `__mutsu_attr__` mixin markers rather than the instance's attribute cell, so `%!h<k> = 1` inside a role method is dropped, while the `handles` delegation path mutates the marker and writes the rebuilt `Mixin` back into the caller's env variable. The code already carries its own `TODO` for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)