### PR TITLE
feat(rakuast): construct block nodes

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1155,7 +1155,9 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 5: mutable `StatementList.new` + `.add-statement`; aliases share appended children,
         and constructed lists lower through `EVAL`. Tests in
         `t/rakuast-construct-statement-list.t`.
-  - [ ] Slice 6+: block/sub/declaration constructors.
+  - [x] Slice 6: `Blockoid.new(StatementList)` and `Block.new(body => Blockoid)`, including
+        accessors and model introspection. Tests in `t/rakuast-construct-block.t`.
+  - [ ] Slice 7+: sub/declaration constructors.
 - **Phase 5 (in progress)** — EVAL: lower RakuAST → internal AST → existing compiler (no new engine).
   - [x] Slices 1–37 done (PRs #4736–#4804): literals, all common operators + ternary, the full
         control-flow set, sub declarations (typed/default/named/slurpy params) + calls + method calls,

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -189,7 +189,11 @@ earlier ones.
     boundary; the native one-argument method path performs the mutation without a tree-walking
     fallback. Constructed lists render, expose `new`/`add-statement` through introspection, and lower
     through the existing compiler under `EVAL`. Tests in `t/rakuast-construct-statement-list.t`.
-    Next: block/sub/declaration constructors.
+  - **Slice 6 (blocks) — done.** `RakuAST::Blockoid.new($statement-list)` wraps a mutable
+    `StatementList` positionally, and `RakuAST::Block.new(body => $blockoid)` builds the enclosing
+    block node. Both constructors render like Rakudo, expose their children through
+    `.statement-list` / `.body`, and advertise the constructor and accessor through
+    `.^methods(:local)`. Tests in `t/rakuast-construct-block.t`. Next: sub/declaration constructors.
 - **Phase 5 — EVAL / compilation.** `lower(RakuAstNode) -> Vec<Stmt>/Expr`, then the
   **existing** compiler. `EVAL($rakuast)` and any code that yields a RakuAST tree runs
   through this. No new execution engine.

--- a/news/2026-07/rakuast-block-constructors.md
+++ b/news/2026-07/rakuast-block-constructors.md
@@ -1,0 +1,9 @@
+# Construct RakuAST blocks
+
+RakuAST construction now includes `RakuAST::Blockoid.new(StatementList)` and
+`RakuAST::Block.new(body => Blockoid)`. Constructed nodes match Rakudo's rendering, expose their
+children through ordinary model accessors, and report the new API through local method and
+attribute introspection.
+
+The dual-oracle regression test runs under both Rakudo and mutsu and composes the constructors with
+the existing mutable `StatementList` and statement/literal constructors.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -514,6 +514,25 @@ pub fn construct(
             fields: Vec::new(),
         }))));
     }
+    if class_name == "RakuAST::Blockoid" && method == "new" {
+        if args.len() != 1 {
+            return Err(RuntimeError::new(
+                "RakuAST::Blockoid.new expects a single StatementList argument",
+            ));
+        }
+        require_rakuast_class(
+            &args[0],
+            RakuAstClass::StatementList,
+            "RakuAST::Blockoid.new",
+        )?;
+        return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
+            class: RakuAstClass::Blockoid,
+            fields: vec![RakuAstField {
+                name: None,
+                value: RakuAstFieldValue::Node(args[0].clone()),
+            }],
+        }))));
+    }
     // Single-positional-argument constructors: the literals, `Name.from-identifier`,
     // and the bare operator nodes (`Infix.new("+")`).
     if let Some(class) = single_positional_class(class_name, method) {
@@ -553,6 +572,20 @@ pub fn construct(
     Ok(None)
 }
 
+fn require_rakuast_class(
+    value: &Value,
+    expected: RakuAstClass,
+    constructor: &str,
+) -> Result<(), RuntimeError> {
+    match value.view() {
+        ValueView::RakuAst(node) if node.class == expected => Ok(()),
+        _ => Err(RuntimeError::new(format!(
+            "{constructor} expects a {} node",
+            expected.printed_name()
+        ))),
+    }
+}
+
 /// The class for a single-positional-argument constructor, or `None`.
 fn single_positional_class(class_name: &str, method: &str) -> Option<RakuAstClass> {
     Some(match (class_name, method) {
@@ -585,6 +618,7 @@ fn multi_field_schema(
             (RakuAstClass::ApplyPostfix, &["operand", "postfix"][..])
         }
         ("RakuAST::Postfix", "new") => (RakuAstClass::Postfix, &["operator"][..]),
+        ("RakuAST::Block", "new") => (RakuAstClass::Block, &["body"][..]),
         _ => return None,
     })
 }
@@ -625,6 +659,7 @@ pub fn node_accessor(node: &RakuAstNode, method: &str) -> Option<Value> {
             Some("value")
         }
         RakuAstClass::VarLexical => Some("name"),
+        RakuAstClass::Blockoid => Some("statement-list"),
         _ => None,
     };
     if positional_name == Some(method)
@@ -695,6 +730,8 @@ fn constructor_is_supported(class: RakuAstClass) -> bool {
             | RakuAstClass::ApplyPrefix
             | RakuAstClass::ApplyPostfix
             | RakuAstClass::Postfix
+            | RakuAstClass::Block
+            | RakuAstClass::Blockoid
     )
 }
 
@@ -709,6 +746,8 @@ fn accessor_names(class: RakuAstClass) -> &'static [&'static str] {
         ApplyPrefix => &["prefix", "operand"],
         ApplyPostfix => &["operand", "postfix"],
         Postfix => &["operator"],
+        Block => &["body"],
+        Blockoid => &["statement-list"],
         _ => &[],
     }
 }

--- a/t/rakuast-construct-block.t
+++ b/t/rakuast-construct-block.t
@@ -1,0 +1,51 @@
+use v6;
+use experimental :rakuast;
+use Test;
+
+# RakuAST Phase 4 slice 6 (ADR-0011): Blockoid and Block construction.
+# This file passes under both mutsu and raku.
+
+plan 8;
+
+my $statements = RakuAST::StatementList.new;
+$statements.add-statement(
+    RakuAST::Statement::Expression.new(
+        expression => RakuAST::IntLiteral.new(42),
+    )
+);
+
+my $blockoid = RakuAST::Blockoid.new($statements);
+isa-ok $blockoid, RakuAST::Blockoid, 'Blockoid.new constructs a Blockoid';
+is $blockoid.statement-list, $statements,
+    'Blockoid exposes its StatementList';
+is $blockoid.gist, q:to/END/.chomp, 'Blockoid renders its positional StatementList';
+    RakuAST::Blockoid.new(
+      RakuAST::StatementList.new(
+        RakuAST::Statement::Expression.new(
+          expression => RakuAST::IntLiteral.new(42)
+        )
+      )
+    )
+    END
+
+my $block = RakuAST::Block.new(body => $blockoid);
+isa-ok $block, RakuAST::Block, 'Block.new constructs a Block';
+is $block.body, $blockoid, 'Block exposes its body';
+is $block.gist, q:to/END/.chomp, 'Block renders its named body';
+    RakuAST::Block.new(
+      body => RakuAST::Blockoid.new(
+        RakuAST::StatementList.new(
+          RakuAST::Statement::Expression.new(
+            expression => RakuAST::IntLiteral.new(42)
+          )
+        )
+      )
+    )
+    END
+
+my @block-methods = RakuAST::Block.^methods(:local)>>.name;
+ok 'new' (elem) @block-methods && 'body' (elem) @block-methods,
+    'Block introspection exposes its constructor and accessor';
+my @blockoid-methods = RakuAST::Blockoid.^methods(:local)>>.name;
+ok 'new' (elem) @blockoid-methods && 'statement-list' (elem) @blockoid-methods,
+    'Blockoid introspection exposes its constructor and accessor';


### PR DESCRIPTION
## Problem

Phase 4 construction stopped at mutable `StatementList` nodes, so callers could not assemble the enclosing `Blockoid` and `Block` model nodes.

## Approach

- add `RakuAST::Blockoid.new(StatementList)` and `RakuAST::Block.new(body => Blockoid)`
- expose `.statement-list` and `.body` through the model accessor and introspection tables
- add a dual-oracle TAP regression that passes under both Rakudo and mutsu
- update PLAN, ADR-0011, and the completion log

## Test evidence

- `raku t/rakuast-construct-block.t`
- targeted RakuAST prove set: 9 files, 64 tests, PASS
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `make test`: 590 Rust tests plus 2,511 TAP files / 23,977 tests, PASS