### PR TITLE
rakuast: construct sub nodes

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1157,7 +1157,10 @@ so it is tracked separately from the roast backlog.
         `t/rakuast-construct-statement-list.t`.
   - [x] Slice 6: `Blockoid.new(StatementList)` and `Block.new(body => Blockoid)`, including
         accessors and model introspection. Tests in `t/rakuast-construct-block.t`.
-  - [ ] Slice 7+: sub/declaration constructors.
+  - [x] Slice 7: parameter-less `Sub.new`, with an optional name and an empty `Blockoid` default,
+        including accessors, model introspection, and lowering through `EVAL`. Tests in
+        `t/rakuast-construct-sub.t`.
+  - [ ] Slice 8+: signature/parameter and variable-declaration constructors.
 - **Phase 5 (in progress)** — EVAL: lower RakuAST → internal AST → existing compiler (no new engine).
   - [x] Slices 1–37 done (PRs #4736–#4804): literals, all common operators + ternary, the full
         control-flow set, sub declarations (typed/default/named/slurpy params) + calls + method calls,

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -193,7 +193,13 @@ earlier ones.
     `StatementList` positionally, and `RakuAST::Block.new(body => $blockoid)` builds the enclosing
     block node. Both constructors render like Rakudo, expose their children through
     `.statement-list` / `.body`, and advertise the constructor and accessor through
-    `.^methods(:local)`. Tests in `t/rakuast-construct-block.t`. Next: sub/declaration constructors.
+    `.^methods(:local)`. Tests in `t/rakuast-construct-block.t`.
+  - **Slice 7 (`Sub`) — done.** `RakuAST::Sub.new` builds a parameter-less routine with an optional
+    `Name` and `Blockoid` body. Omitting the body creates the same empty `Blockoid` /
+    `StatementList` shape as Rakudo. The constructor validates child node kinds, exposes
+    `.name` / `.signature` / `.body` through model introspection, and the resulting named routine
+    lowers through the existing compiler under `EVAL`. Tests in `t/rakuast-construct-sub.t`.
+    Next: signature/parameter and variable-declaration constructors.
 - **Phase 5 — EVAL / compilation.** `lower(RakuAstNode) -> Vec<Stmt>/Expr`, then the
   **existing** compiler. `EVAL($rakuast)` and any code that yields a RakuAST tree runs
   through this. No new execution engine.

--- a/news/2026-07/rakuast-construct-sub.md
+++ b/news/2026-07/rakuast-construct-sub.md
@@ -1,0 +1,6 @@
+# Construct RakuAST subroutines
+
+`RakuAST::Sub.new` now constructs parameter-less routine nodes with an optional name and body.
+An omitted body receives an empty `Blockoid` and `StatementList`, matching Rakudo's model shape.
+The constructor validates its child node types, exposes the routine fields through model
+introspection, renders in constructor form, and lowers through the existing compiler under `EVAL`.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -533,6 +533,34 @@ pub fn construct(
             }],
         }))));
     }
+    if class_name == "RakuAST::Sub" && method == "new" {
+        let name = named_arg(args, "name");
+        if let Some(value) = &name {
+            require_rakuast_class(value, RakuAstClass::Name, "RakuAST::Sub.new")?;
+        }
+        let body = match named_arg(args, "body") {
+            Some(value) => {
+                require_rakuast_class(&value, RakuAstClass::Blockoid, "RakuAST::Sub.new")?;
+                value
+            }
+            None => empty_blockoid(),
+        };
+        let mut fields = Vec::with_capacity(2);
+        if let Some(name) = name {
+            fields.push(RakuAstField {
+                name: Some("name"),
+                value: RakuAstFieldValue::Node(name),
+            });
+        }
+        fields.push(RakuAstField {
+            name: Some("body"),
+            value: RakuAstFieldValue::Node(body),
+        });
+        return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
+            class: RakuAstClass::Sub,
+            fields,
+        }))));
+    }
     // Single-positional-argument constructors: the literals, `Name.from-identifier`,
     // and the bare operator nodes (`Infix.new("+")`).
     if let Some(class) = single_positional_class(class_name, method) {
@@ -570,6 +598,20 @@ pub fn construct(
         }))));
     }
     Ok(None)
+}
+
+fn empty_blockoid() -> Value {
+    let statements = Value::rakuast(Box::new(RakuAstNode {
+        class: RakuAstClass::StatementList,
+        fields: Vec::new(),
+    }));
+    Value::rakuast(Box::new(RakuAstNode {
+        class: RakuAstClass::Blockoid,
+        fields: vec![RakuAstField {
+            name: None,
+            value: RakuAstFieldValue::Node(statements),
+        }],
+    }))
 }
 
 fn require_rakuast_class(
@@ -732,6 +774,7 @@ fn constructor_is_supported(class: RakuAstClass) -> bool {
             | RakuAstClass::Postfix
             | RakuAstClass::Block
             | RakuAstClass::Blockoid
+            | RakuAstClass::Sub
     )
 }
 
@@ -748,6 +791,7 @@ fn accessor_names(class: RakuAstClass) -> &'static [&'static str] {
         Postfix => &["operator"],
         Block => &["body"],
         Blockoid => &["statement-list"],
+        Sub => &["name", "signature", "body"],
         _ => &[],
     }
 }

--- a/t/rakuast-construct-sub.t
+++ b/t/rakuast-construct-sub.t
@@ -1,0 +1,61 @@
+use v6;
+use experimental :rakuast;
+use MONKEY-SEE-NO-EVAL;
+use Test;
+
+# RakuAST Phase 4 slice 7 (ADR-0011): parameter-less Sub construction.
+
+plan 9;
+
+my $statements = RakuAST::StatementList.new;
+$statements.add-statement(
+    RakuAST::Statement::Expression.new(
+        expression => RakuAST::IntLiteral.new(42),
+    )
+);
+my $body = RakuAST::Blockoid.new($statements);
+
+my $anonymous = RakuAST::Sub.new(body => $body);
+isa-ok $anonymous, RakuAST::Sub, 'Sub.new constructs an anonymous Sub';
+is $anonymous.body, $body, 'anonymous Sub exposes its body';
+is $anonymous.gist, q:to/END/.chomp, 'anonymous Sub renders its body';
+    RakuAST::Sub.new(
+      body => RakuAST::Blockoid.new(
+        RakuAST::StatementList.new(
+          RakuAST::Statement::Expression.new(
+            expression => RakuAST::IntLiteral.new(42)
+          )
+        )
+      )
+    )
+    END
+
+my $empty = RakuAST::Sub.new;
+isa-ok $empty.body, RakuAST::Blockoid, 'omitted body defaults to a Blockoid';
+is $empty.body.statement-list.statements.elems, 0,
+    'omitted body defaults to an empty StatementList';
+
+my $named = RakuAST::Sub.new(
+    name => RakuAST::Name.from-identifier('answer'),
+    body => $body,
+);
+is $named.name.gist, RakuAST::Name.from-identifier('answer').gist,
+    'named Sub exposes its name';
+is $named.gist, q:to/END/.chomp, 'named Sub renders its name before its body';
+    RakuAST::Sub.new(
+      name => RakuAST::Name.from-identifier("answer"),
+      body => RakuAST::Blockoid.new(
+        RakuAST::StatementList.new(
+          RakuAST::Statement::Expression.new(
+            expression => RakuAST::IntLiteral.new(42)
+          )
+        )
+      )
+    )
+    END
+
+my @methods = RakuAST::Sub.^methods(:local)>>.name;
+ok 'new' (elem) @methods && 'name' (elem) @methods && 'body' (elem) @methods,
+    'Sub introspection exposes its constructor and accessors';
+
+lives-ok { EVAL($named) }, 'constructed named Sub lowers through EVAL';


### PR DESCRIPTION
## Problem

Phase 4 RakuAST construction could build blocks, but not compose them into routine declarations.

## Approach

- add `RakuAST::Sub.new` with optional `Name` and `Blockoid` children
- match Rakudo by defaulting an omitted body to an empty `Blockoid` / `StatementList`
- expose constructor and routine fields through model introspection
- cover rendering and lowering through the existing compiler under `EVAL`
- update PLAN, ADR-0011, and the accomplishment log

## Test evidence

- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `make test` — 2,512 files / 23,986 tests, PASS
- `make roast` — 1,432 files / 218,509 tests, PASS