### PR TITLE
feat(rakuast): construct plain signatures

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1160,7 +1160,10 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 7: parameter-less `Sub.new`, with an optional name and an empty `Blockoid` default,
         including accessors, model introspection, and lowering through `EVAL`. Tests in
         `t/rakuast-construct-sub.t`.
-  - [ ] Slice 8+: signature/parameter and variable-declaration constructors.
+  - [x] Slice 8: plain positional signature constructors (`ParameterTarget::Var.new`,
+        `Parameter.new`, `Signature.new`) and `Sub.new(:signature)`. Tests in
+        `t/rakuast-construct-signature.t`.
+  - [ ] Slice 9+: variable-declaration constructors and richer parameter shapes.
 - **Phase 5 (in progress)** — EVAL: lower RakuAST → internal AST → existing compiler (no new engine).
   - [x] Slices 1–37 done (PRs #4736–#4804): literals, all common operators + ternary, the full
         control-flow set, sub declarations (typed/default/named/slurpy params) + calls + method calls,

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -199,7 +199,12 @@ earlier ones.
     `StatementList` shape as Rakudo. The constructor validates child node kinds, exposes
     `.name` / `.signature` / `.body` through model introspection, and the resulting named routine
     lowers through the existing compiler under `EVAL`. Tests in `t/rakuast-construct-sub.t`.
-    Next: signature/parameter and variable-declaration constructors.
+  - **Slice 8 (plain positional signatures) — done.** `RakuAST::ParameterTarget::Var.new`,
+    `RakuAST::Parameter.new`, and `RakuAST::Signature.new` construct the target → parameter →
+    signature model chain. `Sub.new(:signature)` validates and retains that signature, and the
+    constructed routine lowers through the existing compiler under `EVAL`. Empty signatures default
+    to an empty parameter list. Tests in `t/rakuast-construct-signature.t`.
+    Next: variable-declaration constructors and richer parameter shapes.
 - **Phase 5 — EVAL / compilation.** `lower(RakuAstNode) -> Vec<Stmt>/Expr`, then the
   **existing** compiler. `EVAL($rakuast)` and any code that yields a RakuAST tree runs
   through this. No new execution engine.

--- a/news/2026-07/rakuast-signature-constructors.md
+++ b/news/2026-07/rakuast-signature-constructors.md
@@ -1,0 +1,10 @@
+# Construct plain RakuAST signatures
+
+RakuAST construction now covers the plain positional signature model:
+`ParameterTarget::Var.new`, `Parameter.new`, and `Signature.new`. Constructed signatures are
+walkable through their normal accessors, render in Rakudo's constructor form, and can be attached to
+`Sub.new(:signature)` and lowered through the existing compiler by `EVAL`.
+
+The implementation validates each child node at the model boundary, defaults an omitted parameter
+list to an empty list, and exposes the new constructors and fields through `.^methods(:local)` and
+`.^attributes(:local)`. The regression test runs unchanged under both mutsu and Rakudo.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -538,6 +538,10 @@ pub fn construct(
         if let Some(value) = &name {
             require_rakuast_class(value, RakuAstClass::Name, "RakuAST::Sub.new")?;
         }
+        let signature = named_arg(args, "signature");
+        if let Some(value) = &signature {
+            require_rakuast_class(value, RakuAstClass::Signature, "RakuAST::Sub.new")?;
+        }
         let body = match named_arg(args, "body") {
             Some(value) => {
                 require_rakuast_class(&value, RakuAstClass::Blockoid, "RakuAST::Sub.new")?;
@@ -545,11 +549,17 @@ pub fn construct(
             }
             None => empty_blockoid(),
         };
-        let mut fields = Vec::with_capacity(2);
+        let mut fields = Vec::with_capacity(3);
         if let Some(name) = name {
             fields.push(RakuAstField {
                 name: Some("name"),
                 value: RakuAstFieldValue::Node(name),
+            });
+        }
+        if let Some(signature) = signature {
+            fields.push(RakuAstField {
+                name: Some("signature"),
+                value: RakuAstFieldValue::Node(signature),
             });
         }
         fields.push(RakuAstField {
@@ -559,6 +569,26 @@ pub fn construct(
         return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
             class: RakuAstClass::Sub,
             fields,
+        }))));
+    }
+    if class_name == "RakuAST::Signature" && method == "new" {
+        let parameters = named_arg(args, "parameters")
+            .map(|value| {
+                value.as_list_items().map(<[Value]>::to_vec).ok_or_else(|| {
+                    RuntimeError::new("RakuAST::Signature.new expects `parameters` to be a list")
+                })
+            })
+            .transpose()?
+            .unwrap_or_default();
+        for parameter in &parameters {
+            require_rakuast_class(parameter, RakuAstClass::Parameter, "RakuAST::Signature.new")?;
+        }
+        return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
+            class: RakuAstClass::Signature,
+            fields: vec![RakuAstField {
+                name: Some("parameters"),
+                value: RakuAstFieldValue::List(parameters),
+            }],
         }))));
     }
     // Single-positional-argument constructors: the literals, `Name.from-identifier`,
@@ -661,6 +691,10 @@ fn multi_field_schema(
         }
         ("RakuAST::Postfix", "new") => (RakuAstClass::Postfix, &["operator"][..]),
         ("RakuAST::Block", "new") => (RakuAstClass::Block, &["body"][..]),
+        ("RakuAST::ParameterTarget::Var", "new") => {
+            (RakuAstClass::ParameterTargetVar, &["name"][..])
+        }
+        ("RakuAST::Parameter", "new") => (RakuAstClass::Parameter, &["target"][..]),
         _ => return None,
     })
 }
@@ -775,6 +809,9 @@ fn constructor_is_supported(class: RakuAstClass) -> bool {
             | RakuAstClass::Block
             | RakuAstClass::Blockoid
             | RakuAstClass::Sub
+            | RakuAstClass::Signature
+            | RakuAstClass::Parameter
+            | RakuAstClass::ParameterTargetVar
     )
 }
 
@@ -792,6 +829,9 @@ fn accessor_names(class: RakuAstClass) -> &'static [&'static str] {
         Block => &["body"],
         Blockoid => &["statement-list"],
         Sub => &["name", "signature", "body"],
+        Signature => &["parameters"],
+        Parameter => &["target"],
+        ParameterTargetVar => &["name"],
         _ => &[],
     }
 }

--- a/t/rakuast-construct-signature.t
+++ b/t/rakuast-construct-signature.t
@@ -1,0 +1,67 @@
+use v6;
+use experimental :rakuast;
+use MONKEY-SEE-NO-EVAL;
+use Test;
+
+# RakuAST Phase 4 slice 8: construction of a plain positional signature.
+
+plan 15;
+
+my $target = RakuAST::ParameterTarget::Var.new(name => '$x');
+isa-ok $target, RakuAST::ParameterTarget::Var,
+    'ParameterTarget::Var.new constructs a variable target';
+is $target.name, '$x', 'the target exposes its name';
+
+my $parameter = RakuAST::Parameter.new(target => $target);
+isa-ok $parameter, RakuAST::Parameter, 'Parameter.new constructs a parameter';
+is $parameter.target, $target, 'the parameter exposes its target';
+
+my $signature = RakuAST::Signature.new(parameters => [$parameter]);
+isa-ok $signature, RakuAST::Signature, 'Signature.new constructs a signature';
+is $signature.parameters.elems, 1, 'the signature contains one parameter';
+is $signature.parameters[0], $parameter,
+    'the signature exposes the constructed parameter';
+is $signature.gist, q:to/END/.chomp, 'the signature renders like Rakudo';
+    RakuAST::Signature.new(
+      parameters => (
+        RakuAST::Parameter.new(
+          target => RakuAST::ParameterTarget::Var.new(
+            name => "\$x"
+          )
+        ),
+      )
+    )
+    END
+
+my @signature-methods = RakuAST::Signature.^methods(:local)>>.name;
+ok 'new' (elem) @signature-methods && 'parameters' (elem) @signature-methods,
+    'Signature introspection exposes its constructor and accessor';
+my @parameter-methods = RakuAST::Parameter.^methods(:local)>>.name;
+ok 'new' (elem) @parameter-methods && 'target' (elem) @parameter-methods,
+    'Parameter introspection exposes its constructor and accessor';
+my @target-methods = RakuAST::ParameterTarget::Var.^methods(:local)>>.name;
+ok 'new' (elem) @target-methods && 'name' (elem) @target-methods,
+    'ParameterTarget::Var introspection exposes its constructor and accessor';
+
+my $statements = RakuAST::StatementList.new;
+$statements.add-statement(
+    RakuAST::Statement::Expression.new(
+        expression => RakuAST::IntLiteral.new(42),
+    )
+);
+my $routine = RakuAST::Sub.new(
+    name => RakuAST::Name.from-identifier('answer'),
+    signature => $signature,
+    body => RakuAST::Blockoid.new($statements),
+);
+is $routine.signature, $signature, 'Sub.new accepts and exposes a signature';
+lives-ok { EVAL($routine) }, 'a constructed Sub with a signature lowers through EVAL';
+
+my $empty = RakuAST::Signature.new;
+is $empty.parameters.elems, 0, 'Signature.new defaults to no parameters';
+lives-ok {
+    RakuAST::Sub.new(
+        name => RakuAST::Name.from-identifier('empty-signature'),
+        signature => $empty,
+    )
+}, 'an empty constructed signature can be attached to a Sub';


### PR DESCRIPTION
## Problem

RakuAST construction stopped at parameter-less `Sub.new`, so callers could not build the target → parameter → signature chain or attach a constructed signature to a routine.

## Approach

- add validated constructors for `ParameterTarget::Var`, `Parameter`, and `Signature`
- retain and validate `Sub.new(:signature)`
- expose the constructors and accessors through model introspection
- record Phase 4 slice 8 in PLAN/ADR/news

## Tests

- `timeout 30 raku t/rakuast-construct-signature.t`
- `timeout 30 target/debug/mutsu t/rakuast-construct-signature.t`
- `prove -e target/debug/mutsu t/rakuast-construct*.t`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo fmt --all`
- `make test` (2,513 files, 24,001 tests)