### PR TITLE
feat(rakuast): construct variable declarations

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1163,7 +1163,10 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 8: plain positional signature constructors (`ParameterTarget::Var.new`,
         `Parameter.new`, `Signature.new`) and `Sub.new(:signature)`. Tests in
         `t/rakuast-construct-signature.t`.
-  - [ ] Slice 9+: variable-declaration constructors and richer parameter shapes.
+  - [x] Slice 9: plain variable-declaration constructors (`VarDeclaration::Simple.new` and
+        `Initializer::Assign.new`), including accessors, introspection, validation, and lowering
+        through `EVAL`. Tests in `t/rakuast-construct-vardecl.t`.
+  - [ ] Slice 10+: richer parameter shapes.
 - **Phase 5 (in progress)** — EVAL: lower RakuAST → internal AST → existing compiler (no new engine).
   - [x] Slices 1–37 done (PRs #4736–#4804): literals, all common operators + ternary, the full
         control-flow set, sub declarations (typed/default/named/slurpy params) + calls + method calls,

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -204,7 +204,12 @@ earlier ones.
     signature model chain. `Sub.new(:signature)` validates and retains that signature, and the
     constructed routine lowers through the existing compiler under `EVAL`. Empty signatures default
     to an empty parameter list. Tests in `t/rakuast-construct-signature.t`.
-    Next: variable-declaration constructors and richer parameter shapes.
+  - **Slice 9 (plain variable declarations) — done.** `RakuAST::Initializer::Assign.new($expr)`
+    and `RakuAST::VarDeclaration::Simple.new(:sigil, :desigilname, :initializer)` construct the
+    initializer and declaration model chain. Constructors validate child node kinds, expose their
+    fields through model accessors and introspection, render like Rakudo, and lower through the
+    existing compiler under `EVAL`. Tests in `t/rakuast-construct-vardecl.t`.
+    Next: richer parameter shapes.
 - **Phase 5 — EVAL / compilation.** `lower(RakuAstNode) -> Vec<Stmt>/Expr`, then the
   **existing** compiler. `EVAL($rakuast)` and any code that yields a RakuAST tree runs
   through this. No new execution engine.

--- a/news/2026-07/rakuast-variable-declaration-constructors.md
+++ b/news/2026-07/rakuast-variable-declaration-constructors.md
@@ -1,0 +1,12 @@
+# Construct plain RakuAST variable declarations
+
+RakuAST Phase 4 now constructs plain variable declarations through
+`RakuAST::VarDeclaration::Simple.new` and their assignment initializers through
+`RakuAST::Initializer::Assign.new`. The model validates child node kinds, exposes the declaration
+and initializer fields through accessors and introspection, and renders the same constructor form
+as Rakudo.
+
+Constructed declarations lower back to mutsu's internal AST through the existing RakuAST lowering
+path, so a statement list assembled entirely from model nodes can declare, initialize, and read a
+lexical variable under `EVAL`. The regression test is also run against Rakudo as the behavioral
+oracle.

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -591,6 +591,46 @@ pub fn construct(
             }],
         }))));
     }
+    if class_name == "RakuAST::VarDeclaration::Simple" && method == "new" {
+        let sigil = named_arg(args, "sigil").ok_or_else(|| {
+            RuntimeError::new("RakuAST::VarDeclaration::Simple.new requires a `sigil` argument")
+        })?;
+        let desigilname = named_arg(args, "desigilname").ok_or_else(|| {
+            RuntimeError::new(
+                "RakuAST::VarDeclaration::Simple.new requires a `desigilname` argument",
+            )
+        })?;
+        require_rakuast_class(
+            &desigilname,
+            RakuAstClass::Name,
+            "RakuAST::VarDeclaration::Simple.new",
+        )?;
+        let mut fields = vec![
+            RakuAstField {
+                name: Some("sigil"),
+                value: RakuAstFieldValue::Node(sigil),
+            },
+            RakuAstField {
+                name: Some("desigilname"),
+                value: RakuAstFieldValue::Node(desigilname),
+            },
+        ];
+        if let Some(initializer) = named_arg(args, "initializer") {
+            require_rakuast_class(
+                &initializer,
+                RakuAstClass::InitializerAssign,
+                "RakuAST::VarDeclaration::Simple.new",
+            )?;
+            fields.push(RakuAstField {
+                name: Some("initializer"),
+                value: RakuAstFieldValue::Node(initializer),
+            });
+        }
+        return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
+            class: RakuAstClass::VarDeclarationSimple,
+            fields,
+        }))));
+    }
     // Single-positional-argument constructors: the literals, `Name.from-identifier`,
     // and the bare operator nodes (`Infix.new("+")`).
     if let Some(class) = single_positional_class(class_name, method) {
@@ -669,6 +709,7 @@ fn single_positional_class(class_name: &str, method: &str) -> Option<RakuAstClas
         ("RakuAST::Infix", "new") => RakuAstClass::Infix,
         ("RakuAST::Prefix", "new") => RakuAstClass::Prefix,
         ("RakuAST::Var::Lexical", "new") => RakuAstClass::VarLexical,
+        ("RakuAST::Initializer::Assign", "new") => RakuAstClass::InitializerAssign,
         _ => return None,
     })
 }
@@ -736,6 +777,7 @@ pub fn node_accessor(node: &RakuAstNode, method: &str) -> Option<Value> {
         }
         RakuAstClass::VarLexical => Some("name"),
         RakuAstClass::Blockoid => Some("statement-list"),
+        RakuAstClass::InitializerAssign => Some("expression"),
         _ => None,
     };
     if positional_name == Some(method)
@@ -812,6 +854,8 @@ fn constructor_is_supported(class: RakuAstClass) -> bool {
             | RakuAstClass::Signature
             | RakuAstClass::Parameter
             | RakuAstClass::ParameterTargetVar
+            | RakuAstClass::VarDeclarationSimple
+            | RakuAstClass::InitializerAssign
     )
 }
 
@@ -832,6 +876,8 @@ fn accessor_names(class: RakuAstClass) -> &'static [&'static str] {
         Signature => &["parameters"],
         Parameter => &["target"],
         ParameterTargetVar => &["name"],
+        VarDeclarationSimple => &["sigil", "desigilname", "initializer"],
+        InitializerAssign => &["expression"],
         _ => &[],
     }
 }

--- a/t/rakuast-construct-vardecl.t
+++ b/t/rakuast-construct-vardecl.t
@@ -1,0 +1,81 @@
+use v6;
+use experimental :rakuast;
+use MONKEY-SEE-NO-EVAL;
+use Test;
+
+# RakuAST Phase 4 slice 9: construction of plain variable declarations.
+
+plan 13;
+
+my $name = RakuAST::Name.from-identifier('answer');
+my $declaration = RakuAST::VarDeclaration::Simple.new(
+    sigil => '$',
+    desigilname => $name,
+);
+isa-ok $declaration, RakuAST::VarDeclaration::Simple,
+    'VarDeclaration::Simple.new constructs a declaration';
+is $declaration.sigil, '$', 'the declaration exposes its sigil';
+is $declaration.desigilname, $name, 'the declaration exposes its name';
+is $declaration.gist, q:to/END/.chomp, 'an uninitialized declaration renders like Rakudo';
+    RakuAST::VarDeclaration::Simple.new(
+      sigil       => "\$",
+      desigilname => RakuAST::Name.from-identifier("answer")
+    )
+    END
+
+my $initializer = RakuAST::Initializer::Assign.new(
+    RakuAST::IntLiteral.new(42),
+);
+isa-ok $initializer, RakuAST::Initializer::Assign,
+    'Initializer::Assign.new constructs an initializer';
+is $initializer.expression.value, 42, 'the initializer exposes its expression';
+
+my $initialized = RakuAST::VarDeclaration::Simple.new(
+    sigil => '$',
+    desigilname => $name,
+    initializer => $initializer,
+);
+is $initialized.initializer, $initializer,
+    'the declaration exposes its initializer';
+is $initialized.gist, q:to/END/.chomp, 'an initialized declaration renders like Rakudo';
+    RakuAST::VarDeclaration::Simple.new(
+      sigil       => "\$",
+      desigilname => RakuAST::Name.from-identifier("answer"),
+      initializer => RakuAST::Initializer::Assign.new(
+        RakuAST::IntLiteral.new(42)
+      )
+    )
+    END
+
+my @declaration-methods = RakuAST::VarDeclaration::Simple.^methods(:local)>>.name;
+ok 'new' (elem) @declaration-methods
+        && 'sigil' (elem) @declaration-methods
+        && 'desigilname' (elem) @declaration-methods
+        && 'initializer' (elem) @declaration-methods,
+    'declaration introspection exposes its constructor and accessors';
+my $statements = RakuAST::StatementList.new;
+$statements.add-statement(
+    RakuAST::Statement::Expression.new(expression => $initialized),
+);
+$statements.add-statement(
+    RakuAST::Statement::Expression.new(
+        expression => RakuAST::Var::Lexical.new('$answer'),
+    ),
+);
+is EVAL($statements), 42, 'the constructed declaration lowers through EVAL';
+
+lives-ok {
+    RakuAST::VarDeclaration::Simple.new(
+        sigil => '@',
+        desigilname => RakuAST::Name.from-identifier('items'),
+    )
+}, 'non-scalar sigils are accepted';
+dies-ok {
+    RakuAST::VarDeclaration::Simple.new(sigil => '$')
+}, 'a desigilname is required';
+dies-ok {
+    RakuAST::VarDeclaration::Simple.new(
+        sigil => '$',
+        desigilname => RakuAST::IntLiteral.new(1),
+    )
+}, 'desigilname must be a Name node';


### PR DESCRIPTION
## Problem

RakuAST Phase 4 could construct signatures and routines, but not the variable-declaration nodes already supported by the read and lowering paths.

## Approach

Add constructors for `RakuAST::Initializer::Assign` and plain `RakuAST::VarDeclaration::Simple` nodes, validate their child node types, and expose their model accessors and introspection metadata. Constructed declarations lower through the existing RakuAST-to-internal-AST EVAL path.

## Tests

- `raku t/rakuast-construct-vardecl.t`
- `make test` (2,514 files, 24,014 TAP tests)
- `cargo clippy -- -D warnings`
- `cargo fmt --all --check`