### PR TITLE
fix: a CStruct field write reaches C memory, and .^array_type answers

### DIFF
--- a/news/2026-07/cstruct-field-write-and-array-type.md
+++ b/news/2026-07/cstruct-field-write-and-array-type.md
@@ -1,0 +1,60 @@
+# A CStruct field write reaches C memory, and `.^array_type` answers
+
+Assigning to a field through an `is repr('CStruct')` handle reported success and
+did nothing:
+
+```raku
+my $s = nativecast(Pair2, calloc(1, 16));
+$s.a = 42;
+say $s.a;        # raku: 42    mutsu (before): 0
+```
+
+A CStruct handle keeps no Raku attributes — the C struct its `address` points at
+is the only storage it has — so the assignment fell through to the ordinary
+attribute path and landed in a map nothing reads. `cstruct_layout.rs` had
+`read_field` and no write half, so half of the accessor pair simply did not
+exist. It does now, for every field type the reader handles: the integer and
+float widths, an address (however it is spelled — a `Pointer`, another CStruct
+handle, or a bare `Int`), and `Str`.
+
+A `Str` field stores a `char*`, so the bytes have to outlive the assignment: C
+reads them whenever it likes. Rakudo keeps the Raku `Str` alive through the
+struct's `child_objs`; mutsu has no such back-reference, so the strings are
+interned by content and live for the rest of the process — bounded by the number
+of *distinct* strings a program writes into struct fields rather than by the
+number of writes, the same trade `native_object_where` already makes for `.WHERE`
+blocks.
+
+Alongside it, `.^array_type` — the element type of a native array-ish container —
+which did not exist at all (`No such method 'array_type'`):
+
+| | raku | mutsu now |
+| --- | --- | --- |
+| `Buf.new(1,2,3).^array_type` | `uint8` | `uint8` |
+| `Buf[uint64].new(1,2).^array_type` | `uint64` | `uint64` |
+| `'ab'.encode('utf8').^array_type` | `uint8` | `uint8` |
+| `CArray[int32].new.^array_type` | `int32` | `int32` |
+| `array[uint8].^array_type` | `uint8` | `uint8` |
+| `Str.^array_type` | `Mu` | `Mu` |
+
+It is derived from the name `.^name` reports (`dispatch_caret_name`, which is
+where a `CArray[int32]` gets its parameterised spelling from the container
+metadata), so the two cannot disagree.
+
+Both are [ADR-0015](../../docs/adr/0015-native-backed-container-storage-and-repr-bodies.md)'s
+**P0**: the pieces of the `NativeHelpers::Blob` path that are ordinary NativeCall
+compatibility bugs rather than representation work. `NativeHelpers::Blob` asks
+every container it is handed for `.^array_type` and feeds the answer to
+`nativesizeof` and `nativecast(Pointer[T], …)`; `DBDish::mysql` fills a
+`MYSQL_BIND` by assigning to its fields through exactly such a handle. Neither
+needs anything from P1-P3.
+
+One thing worth recording, because it explains a declaration that looks like a
+mistake: **Rakudo cannot assign through a `Pointer`-typed CStruct accessor** — it
+dies with "Cannot modify an immutable `NativeCall::Types::Pointer` type object".
+That is why `DBIish`'s `MYSQL_BIND` declares `has intptr $.buffer is rw` with the
+`Pointer` version commented out directly above it, and why the test pins the
+integer-field form.
+
+Pinned by `t/nativecall-cstruct-field-write.t`, which passes identically under
+`raku`.

--- a/src/runtime/cstruct_layout.rs
+++ b/src/runtime/cstruct_layout.rs
@@ -12,9 +12,9 @@
 //! attributes using the platform's C alignment rules, and reads a field out of
 //! the pointed-to memory.
 //!
-//! Only *reads* through a pointer that C gave us are supported. Writing fields,
-//! `HAS`-embedded structs/arrays, and allocating a struct from Raku
-//! (`MyStruct.new`) remain follow-up work.
+//! Reads and writes go through a pointer that C gave us. `HAS`-embedded
+//! structs/arrays and allocating a struct from Raku (`MyStruct.new`) remain
+//! follow-up work.
 
 /// The C type of one CStruct field.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -154,6 +154,82 @@ pub(crate) unsafe fn read_field(base: usize, field: &FieldLayout) -> crate::valu
     }
 }
 
+/// The address of a process-lifetime C string holding `s`, for a `Str`-typed
+/// CStruct field.
+///
+/// A `char*` field stores a pointer, so the bytes have to outlive the
+/// assignment — C reads them whenever it likes, and a `CString` dropped at the
+/// end of the call would leave the struct pointing at freed memory. Rakudo keeps
+/// the Raku `Str` alive through the struct's `child_objs`; mutsu has no such
+/// back-reference, so the strings are interned by content and live for the rest
+/// of the process. That bounds the arena by the number of *distinct* strings a
+/// program writes into struct fields (a handful, in practice) instead of by the
+/// number of writes — the same trade `nativecall::native_object_where` already
+/// makes for `.WHERE` blocks.
+fn interned_c_string(s: &str) -> *const std::ffi::c_char {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+    static STRINGS: OnceLock<Mutex<HashMap<String, usize>>> = OnceLock::new();
+    let mut map = STRINGS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let addr = *map.entry(s.to_string()).or_insert_with(|| {
+        // A NUL in the middle truncates, as it does for every other `Str`
+        // argument NativeCall marshals.
+        let owned = std::ffi::CString::new(s)
+            .unwrap_or_else(|e| {
+                let bytes = e.into_vec();
+                let upto = bytes.iter().position(|b| *b == 0).unwrap_or(bytes.len());
+                std::ffi::CString::new(&bytes[..upto]).unwrap_or_default()
+            })
+            .into_raw();
+        owned as usize
+    });
+    addr as *const std::ffi::c_char
+}
+
+/// Write `value` into the field at `base + offset` in native memory.
+///
+/// # Safety
+/// Same contract as [`read_field`]: `base` must point at a live C struct of the
+/// laid-out type. A wrong declaration corrupts memory here exactly as it does in
+/// Rakudo.
+pub(crate) unsafe fn write_field(base: usize, field: &FieldLayout, value: &crate::value::Value) {
+    let to_int = crate::runtime::to_int;
+    let to_num = |v: &crate::value::Value| crate::runtime::utils::to_float_value(v).unwrap_or(0.0);
+    let ptr = (base + field.offset) as *mut u8;
+    unsafe {
+        match field.ty {
+            FieldType::I8 => ptr.cast::<i8>().write_unaligned(to_int(value) as i8),
+            FieldType::I16 => ptr.cast::<i16>().write_unaligned(to_int(value) as i16),
+            FieldType::I32 => ptr.cast::<i32>().write_unaligned(to_int(value) as i32),
+            FieldType::I64 => ptr.cast::<i64>().write_unaligned(to_int(value)),
+            FieldType::U8 => ptr.write_unaligned(to_int(value) as u8),
+            FieldType::U16 => ptr.cast::<u16>().write_unaligned(to_int(value) as u16),
+            FieldType::U32 => ptr.cast::<u32>().write_unaligned(to_int(value) as u32),
+            FieldType::U64 => ptr.cast::<u64>().write_unaligned(to_int(value) as u64),
+            FieldType::F32 => ptr.cast::<f32>().write_unaligned(to_num(value) as f32),
+            FieldType::F64 => ptr.cast::<f64>().write_unaligned(to_num(value)),
+            FieldType::Str => {
+                // An undefined value is a NULL `char*`, matching the way a `Str`
+                // *argument* is marshalled.
+                let s = if crate::runtime::types::value_is_defined(value) {
+                    interned_c_string(&value.to_string_value())
+                } else {
+                    std::ptr::null()
+                };
+                ptr.cast::<*const std::ffi::c_char>().write_unaligned(s);
+            }
+            // A `Pointer`, another CStruct handle, a `CArray[T]` handle, or a
+            // bare address as an `Int` — all carry their address the same way.
+            FieldType::Pointer => ptr
+                .cast::<usize>()
+                .write_unaligned(crate::runtime::nativecall::value_c_address(value)),
+        }
+    }
+}
+
 impl crate::runtime::Interpreter {
     /// The registered name of the `is repr('CStruct')` class `name` refers to,
     /// or `None` if it is not one.
@@ -270,6 +346,52 @@ impl crate::runtime::Interpreter {
             },
             addr,
         ))
+    }
+
+    /// Write `value` into field `name` of the C struct `target` points at.
+    /// Returns `false` — leaving the caller to its ordinary attribute path — if
+    /// `target` is not a CStruct handle carrying an address, or the class does
+    /// not declare that field.
+    ///
+    /// This is the write half of [`Self::cstruct_field_value`]. Without it an
+    /// assignment through a handle (`$bind.buffer = $addr`) reported success and
+    /// went nowhere, because a CStruct handle stores no Raku attributes to
+    /// receive it — the struct in C memory is the only storage there is.
+    pub(crate) fn cstruct_field_assign(
+        &mut self,
+        target: &crate::value::Value,
+        name: &str,
+        value: &crate::value::Value,
+    ) -> bool {
+        use crate::value::ValueView;
+        let (class_name, address) = match target.view() {
+            ValueView::Instance {
+                class_name,
+                attributes,
+                ..
+            } => {
+                let addr = match attributes.as_map().get("address").map(|v| v.view()) {
+                    Some(ValueView::Int(a)) if a > 0 => a as usize,
+                    _ => return false,
+                };
+                (class_name.resolve().to_string(), addr)
+            }
+            _ => return false,
+        };
+        let Some(registered) = self.cstruct_class_name(&class_name) else {
+            return false;
+        };
+        let Some(layout) = self.cstruct_layout(&registered) else {
+            return false;
+        };
+        let Some(field) = layout.iter().find(|f| f.name == name) else {
+            return false;
+        };
+        // SAFETY: `address` came from C as a pointer to a struct of this
+        // declared type and the instance is alive, so the field is in bounds —
+        // the same trust `cstruct_field_value` documents for the read.
+        unsafe { write_field(address, field, value) };
+        true
     }
 
     /// The number of bytes a value of `type_name` occupies in C: the width of a

--- a/src/runtime/methods_classhow_dispatch.rs
+++ b/src/runtime/methods_classhow_dispatch.rs
@@ -25,6 +25,30 @@ fn shorten_type_name(name: &str) -> String {
     out
 }
 
+/// The element type `.^array_type` reports for the type named `type_name`.
+///
+/// A parameterised container names its element type outright
+/// (`Buf[uint64]` -> `uint64`, `array[num32]` -> `num32`,
+/// `CArray[int32]` -> `int32`). An unparameterised byte-buffer type carries its
+/// element width in its own name (`utf16` -> `uint16`), and a bare `Buf`/`Blob`
+/// is `uint8`. Anything else is `Mu`, which is what Rakudo's `ClassHOW` answers
+/// for a type that is not an array (`Str.^array_type` is `Mu`).
+fn array_element_type_name(type_name: &str) -> &str {
+    if let Some(inner) = type_name
+        .split_once('[')
+        .and_then(|(_, rest)| rest.strip_suffix(']'))
+    {
+        return inner;
+    }
+    match type_name {
+        "Buf" | "Blob" | "buf8" | "blob8" | "utf8" | "utf8-c8" => "uint8",
+        "buf16" | "blob16" | "utf16" => "uint16",
+        "buf32" | "blob32" | "utf32" => "uint32",
+        "buf64" | "blob64" => "uint64",
+        _ => "Mu",
+    }
+}
+
 impl Interpreter {
     /// Resolve a nominalizable type name to its nominal base type
     /// (`^nominalize`): strip `:D`/`:U`/`:_` definiteness, unwrap a coercion
@@ -149,6 +173,19 @@ impl Interpreter {
                 }
                 _ => value_type_name(&args[0]).to_string(),
             })),
+            "array_type" if !args.is_empty() => {
+                // The element type of a native array-ish container. Derived from
+                // the same name `.^name` reports — `dispatch_caret_name`, which
+                // is where a `CArray[int32]` / `array[uint8]` gets its
+                // parameterised spelling from the container metadata — so the
+                // two can never disagree. `NativeHelpers::Blob` asks every
+                // container it is handed for this and feeds the answer to
+                // `nativesizeof` and `nativecast(Pointer[T], …)`.
+                let name = self.dispatch_caret_name(&args[0])?.to_string_value();
+                Ok(Value::package(crate::symbol::Symbol::intern(
+                    array_element_type_name(&name),
+                )))
+            }
             "shortname" if !args.is_empty() => {
                 let full = self
                     .dispatch_classhow_method("name", vec![args[0].clone()])?

--- a/src/runtime/methods_classhow_lookup.rs
+++ b/src/runtime/methods_classhow_lookup.rs
@@ -316,6 +316,7 @@ impl Interpreter {
             method_name,
             "name"
                 | "shortname"
+                | "array_type"
                 | "ver"
                 | "auth"
                 | "api"

--- a/src/runtime/methods_mut_method_lvalue.rs
+++ b/src/runtime/methods_mut_method_lvalue.rs
@@ -126,6 +126,16 @@ impl Interpreter {
             let repr = cur.to_string_value();
             return Err(RuntimeError::assignment_ro_typename(&typename, &repr));
         }
+        // An `is repr('CStruct')` handle keeps no Raku attributes: its fields
+        // live in the C struct its `address` points at, so an assignment has to
+        // write native memory (`$bind.buffer = $addr`). Without this the write
+        // fell through to the ordinary attribute path, which stored it in a map
+        // nothing reads — the assignment reported success and the struct never
+        // changed. The guard is tight: only an instance carrying a non-null
+        // `address` whose class is a registered CStruct declaring that field.
+        if method_args.is_empty() && self.cstruct_field_assign(&target, method, &value) {
+            return Ok(value);
+        }
         // Handle AT-POS lvalue assignment: @arr.AT-POS(idx...) = v  =>  ASSIGN-POS(idx..., v)
         if method == "AT-POS"
             && !method_args.is_empty()

--- a/src/runtime/methods_native_bypass.rs
+++ b/src/runtime/methods_native_bypass.rs
@@ -34,6 +34,7 @@ impl Interpreter {
                 | "nominalize"
                 | "name"
                 | "shortname"
+                | "array_type"
                 | "set_name"
                 | "ver"
                 | "auth"

--- a/t/nativecall-cstruct-field-write.t
+++ b/t/nativecall-cstruct-field-write.t
@@ -1,0 +1,81 @@
+use Test;
+use NativeCall;
+
+# The write half of `is repr('CStruct')` field access. A CStruct handle keeps no
+# Raku attributes — the C struct its `address` points at is the only storage it
+# has — so an assignment through it must write native memory. Before this the
+# write fell through to the ordinary attribute path, reported success, and went
+# nowhere: `$s.a = 42` read back as 0.
+#
+# `.^array_type` is here too: `NativeHelpers::Blob` asks every container it is
+# handed for its element type and feeds the answer to `nativesizeof` and
+# `nativecast(Pointer[T], ...)`.
+
+plan 17;
+
+sub calloc(size_t, size_t --> Pointer) is native { * }
+sub free(Pointer) is native { * }
+
+class Rec is repr('CStruct') {
+    has int32  $.i32 is rw;
+    has int64  $.i64 is rw;
+    has num64  $.n64 is rw;
+    has uint8  $.u8  is rw;
+    # An address-holding field is declared as an integer, not as `Pointer`:
+    # Rakudo refuses to assign through a `Pointer`-typed accessor ("Cannot
+    # modify an immutable Pointer type object"), which is why DBIish's
+    # `MYSQL_BIND` declares `has intptr $.buffer is rw` with the `Pointer`
+    # version commented out.
+    has uint64 $.ptr is rw;
+}
+
+my $block = calloc(1, 64);
+ok $block.defined, 'calloc gave us a block to work in';
+my $r = nativecast(Rec, $block);
+
+# --- scalar fields ---
+is $r.i32, 0,                   'calloc zeroed the block, so i32 starts at 0';
+$r.i32 = 42;
+is $r.i32, 42,                  'an int32 field write reaches C memory';
+$r.i32 = -7;
+is $r.i32, -7,                  'an int32 field holds a negative value';
+
+$r.i64 = 4294967296;            # 2**32, so a 32-bit write would lose it
+is $r.i64, 4294967296,          'an int64 field write keeps the high word';
+
+$r.n64 = 1.5e0;
+is $r.n64, 1.5e0,               'a num64 field write round-trips as a float';
+
+$r.u8 = 200;
+is $r.u8, 200,                  'a uint8 field write round-trips';
+is $r.i32, -7,                  'writing one field leaves its neighbour alone';
+
+# --- an address stored in an integer field, the way real bindings do it ---
+my $other = calloc(1, 8);
+$r.ptr = $other.Int;
+is $r.ptr, $other.Int,          'an address written into an integer field round-trips';
+$r.ptr = Pointer.new(0xdead000).Int;
+is $r.ptr, 0xdead000,           'a freshly built Pointer address round-trips';
+
+# A second handle onto the same block sees the writes: there is one struct, not
+# a per-handle copy.
+my $alias = nativecast(Rec, $block);
+is $alias.i64, 4294967296,      'a second handle onto the same address sees the write';
+
+free($other);
+free($block);
+
+# --- .^array_type ---
+is Buf.new(1, 2, 3).^array_type.^name, 'uint8',
+                                'a Buf is an array of uint8';
+is Buf[uint64].new(1, 2).^array_type.^name, 'uint64',
+                                'a parameterised Buf reports its element type';
+is 'ab'.encode('utf8').^array_type.^name, 'uint8',
+                                'utf8 is an array of uint8';
+is CArray[int32].new.^array_type.^name, 'int32',
+                                'a CArray reports its element type';
+my array[uint8] $a .= new(1, 2, 3);
+is $a.^array_type.^name, 'uint8',
+                                'a native array reports its element type';
+is nativesizeof(CArray[int32].new.^array_type), 4,
+                                'the reported element type feeds nativesizeof';


### PR DESCRIPTION
[ADR-0015](https://github.com/tokuhirom/mutsu/blob/main/docs/adr/0015-native-backed-container-storage-and-repr-bodies.md)'s
**P0** — the two pieces of the `NativeHelpers::Blob` path that turn out to be
ordinary NativeCall compatibility bugs rather than representation work. Neither
depends on P1-P3.

### A CStruct field write went nowhere

```raku
my $s = nativecast(Pair2, calloc(1, 16));
$s.a = 42;
say $s.a;        # raku: 42    mutsu (before): 0
```

A CStruct handle keeps no Raku attributes — the C struct its `address` points at
is the only storage it has — so the assignment fell through to the ordinary
attribute path and landed in a map nothing reads. `cstruct_layout.rs` had
`read_field` and no write half.

Adds `write_field` for every field type the reader handles, plus a tight guard in
the method-lvalue path: an instance carrying a non-null `address` whose class is
a registered CStruct declaring that field.

A `Str` field stores a `char*`, so the bytes must outlive the assignment. Rakudo
keeps the Raku `Str` alive through the struct's `child_objs`; mutsu has no such
back-reference, so the strings are interned by content for the process lifetime —
bounded by *distinct* strings written into struct fields rather than by writes,
the same trade `native_object_where` already makes for `.WHERE` blocks.

`DBDish::mysql` fills a `MYSQL_BIND` by assigning to its fields through exactly
such a handle.

### `.^array_type` did not exist

`No such method 'array_type'`, where raku answers the container's element type.
`NativeHelpers::Blob` asks every container it is handed for this and feeds the
answer to `nativesizeof` and `nativecast(Pointer[T], …)`.

| | raku | mutsu now |
| --- | --- | --- |
| `Buf.new(1,2,3).^array_type` | `uint8` | `uint8` |
| `Buf[uint64].new(1,2).^array_type` | `uint64` | `uint64` |
| `'ab'.encode('utf8').^array_type` | `uint8` | `uint8` |
| `CArray[int32].new.^array_type` | `int32` | `int32` |
| `array[uint8].^array_type` | `uint8` | `uint8` |
| `Str.^array_type` | `Mu` | `Mu` |

Derived from the name `.^name` reports (`dispatch_caret_name`, where a
`CArray[int32]` gets its parameterised spelling from the container metadata), so
the two cannot disagree.

### Worth recording

**Rakudo cannot assign through a `Pointer`-typed CStruct accessor** — it dies with
"Cannot modify an immutable `NativeCall::Types::Pointer` type object". That is
why `DBIish`'s `MYSQL_BIND` declares `has intptr $.buffer is rw` with the
`Pointer` version commented out directly above it, and why the test pins the
integer-field form.

### Testing

- `t/nativecall-cstruct-field-write.t` — new, 17/17 **identical under `raku`**.
- `make test` — 2515 files / 24032 tests, all pass.
- Whitelisted `S12-introspection` + `S12-meta` + 40 `S12-attributes/class/methods/construction`
  files: pass (`S12-meta/exporthow.t` is not whitelisted and fails on `EXPORTHOW`
  as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)