### PR TITLE
feat(rakuast): construct rich parameters

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1172,7 +1172,12 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 9: plain variable-declaration constructors (`VarDeclaration::Simple.new` and
         `Initializer::Assign.new`), including accessors, introspection, validation, and lowering
         through `EVAL`. Tests in `t/rakuast-construct-vardecl.t`.
-  - [ ] Slice 10+: richer parameter shapes.
+  - [x] Slice 10: common richer parameter shapes — `Type::Simple.new` /
+        `Type::Setting.new`, plus `Parameter.new` with typed, defaulted, optional, named, and
+        flattened/unflattened slurpy fields. Constructed signatures lower through `EVAL`. Tests in
+        `t/rakuast-construct-rich-parameters.t`.
+  - [ ] Slice 11+: advanced parameter shapes (`where`, sub-signatures, type captures, array shapes,
+        and signature constraints).
 - **Phase 5 (in progress)** — EVAL: lower RakuAST → internal AST → existing compiler (no new engine).
   - [x] Slices 1–37 done (PRs #4736–#4804): literals, all common operators + ternary, the full
         control-flow set, sub declarations (typed/default/named/slurpy params) + calls + method calls,

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -209,7 +209,14 @@ earlier ones.
     initializer and declaration model chain. Constructors validate child node kinds, expose their
     fields through model accessors and introspection, render like Rakudo, and lower through the
     existing compiler under `EVAL`. Tests in `t/rakuast-construct-vardecl.t`.
-    Next: richer parameter shapes.
+  - **Slice 10 (common richer parameter shapes) — done.** `RakuAST::Type::Simple.new(Name)` and
+    `Type::Setting.new(Name)` construct type nodes, while `RakuAST::Parameter.new` accepts typed,
+    defaulted, explicitly optional, named, and flattened/unflattened slurpy fields. Constructors
+    validate child shapes, normalize Rakudo's slurpy type-object marker into the model node, expose
+    every field through accessors/introspection, and lower constructed signatures through the
+    existing compiler under `EVAL`. Tests in `t/rakuast-construct-rich-parameters.t`.
+    Next: advanced shapes (`where`, sub-signatures, type captures, array shapes, signature
+    constraints).
 - **Phase 5 — EVAL / compilation.** `lower(RakuAstNode) -> Vec<Stmt>/Expr`, then the
   **existing** compiler. `EVAL($rakuast)` and any code that yields a RakuAST tree runs
   through this. No new execution engine.

--- a/news/2026-07/rakuast-rich-parameter-construction.md
+++ b/news/2026-07/rakuast-rich-parameter-construction.md
@@ -1,0 +1,11 @@
+# Construct Rich RakuAST Parameters
+
+RakuAST's construction API now builds the common parameter shapes used by real routines.
+`RakuAST::Type::Simple.new` and `RakuAST::Type::Setting.new` construct type nodes, and
+`RakuAST::Parameter.new` accepts typed, defaulted, explicitly optional, named, and slurpy
+parameters. The constructor validates its model children and normalizes Rakudo's slurpy
+type-object marker into mutsu's RakuAST node representation.
+
+The resulting signatures expose their fields through the existing metaobject accessors and lower
+through the single RakuAST-to-internal-AST path used by `EVAL`. A dual-oracle TAP test covers every
+new shape under both Rakudo and mutsu.

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -229,11 +229,6 @@ fn signature_positional_params(
         let ValueView::RakuAst(p) = v.view() else {
             return Err(unsupported(node));
         };
-        // An explicitly-optional parameter carries richer shape; defer.
-        // `named`/`slurpy`/`default` are handled below.
-        if p.fields.iter().any(|f| f.name == Some("optional_marker")) {
-            return Err(unsupported(node));
-        }
         let target = named_child(p, "target")?;
         if target.class != RakuAstClass::ParameterTargetVar {
             return Err(unsupported(node));
@@ -246,6 +241,18 @@ fn signature_positional_params(
         if p.fields.iter().any(|f| f.name == Some("names")) {
             def.named = true;
             def.required = false;
+        }
+        // `optional => True` makes a positional parameter optional. For named
+        // parameters, an explicit False marks it required.
+        if let Some(optional) = p.fields.iter().find(|f| f.name == Some("optional")) {
+            let RakuAstFieldValue::Node(value) = &optional.value else {
+                return Err(unsupported(node));
+            };
+            let ValueView::Bool(is_optional) = value.view() else {
+                return Err(unsupported(node));
+            };
+            def.required = !is_optional;
+            def.optional_marker = is_optional;
         }
         // A slurpy parameter `*@a` / `**@a` carries a `slurpy` marker node.
         if let Some(s) = p.fields.iter().find(|f| f.name == Some("slurpy")) {

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -591,6 +591,77 @@ pub fn construct(
             }],
         }))));
     }
+    if class_name == "RakuAST::Parameter" && method == "new" {
+        let target = named_arg(args, "target").ok_or_else(|| {
+            RuntimeError::new("RakuAST::Parameter.new requires a `target` argument")
+        })?;
+        require_rakuast_class(
+            &target,
+            RakuAstClass::ParameterTargetVar,
+            "RakuAST::Parameter.new",
+        )?;
+        let mut fields = Vec::with_capacity(5);
+        if let Some(type_node) = named_arg(args, "type") {
+            require_rakuast_type(&type_node, "RakuAST::Parameter.new")?;
+            fields.push(RakuAstField {
+                name: Some("type"),
+                value: RakuAstFieldValue::Node(type_node),
+            });
+        }
+        if let Some(names) = named_arg(args, "names") {
+            let names = names
+                .as_list_items()
+                .map(<[Value]>::to_vec)
+                .ok_or_else(|| {
+                    RuntimeError::new("RakuAST::Parameter.new expects `names` to be a list")
+                })?;
+            if names
+                .iter()
+                .any(|name| !matches!(name.view(), ValueView::Str(_)))
+            {
+                return Err(RuntimeError::new(
+                    "RakuAST::Parameter.new expects `names` to contain strings",
+                ));
+            }
+            fields.push(RakuAstField {
+                name: Some("names"),
+                value: RakuAstFieldValue::List(names),
+            });
+        }
+        fields.push(RakuAstField {
+            name: Some("target"),
+            value: RakuAstFieldValue::Node(target),
+        });
+        if let Some(optional) = named_arg(args, "optional") {
+            if !matches!(optional.view(), ValueView::Bool(_)) {
+                return Err(RuntimeError::new(
+                    "RakuAST::Parameter.new expects `optional` to be Bool",
+                ));
+            }
+            fields.push(RakuAstField {
+                name: Some("optional"),
+                value: RakuAstFieldValue::Node(optional),
+            });
+        }
+        if let Some(default) = named_arg(args, "default") {
+            require_any_rakuast(&default, "RakuAST::Parameter.new", "default")?;
+            fields.push(RakuAstField {
+                name: Some("default"),
+                value: RakuAstFieldValue::Node(default),
+            });
+        }
+        if let Some(slurpy) = named_arg(args, "slurpy") {
+            let slurpy = normalize_slurpy_marker(slurpy)?;
+            fields.push(RakuAstField {
+                name: Some("slurpy"),
+                value: RakuAstFieldValue::Node(slurpy),
+            });
+        }
+        return Ok(Some(Value::rakuast(Box::new(RakuAstNode {
+            class: RakuAstClass::Parameter,
+            fields,
+        }))));
+    }
     if class_name == "RakuAST::VarDeclaration::Simple" && method == "new" {
         let sigil = named_arg(args, "sigil").ok_or_else(|| {
             RuntimeError::new("RakuAST::VarDeclaration::Simple.new requires a `sigil` argument")
@@ -698,6 +769,71 @@ fn require_rakuast_class(
     }
 }
 
+fn require_any_rakuast(
+    value: &Value,
+    constructor: &str,
+    argument: &str,
+) -> Result<(), RuntimeError> {
+    if matches!(value.view(), ValueView::RakuAst(_)) {
+        Ok(())
+    } else {
+        Err(RuntimeError::new(format!(
+            "{constructor} expects `{argument}` to be a RakuAST node"
+        )))
+    }
+}
+
+fn require_rakuast_type(value: &Value, constructor: &str) -> Result<(), RuntimeError> {
+    match value.view() {
+        ValueView::RakuAst(node)
+            if matches!(
+                node.class,
+                RakuAstClass::TypeSimple
+                    | RakuAstClass::TypeSetting
+                    | RakuAstClass::TypeDefinedness
+                    | RakuAstClass::TypeParameterized
+                    | RakuAstClass::TypeCoercion
+            ) =>
+        {
+            Ok(())
+        }
+        _ => Err(RuntimeError::new(format!(
+            "{constructor} expects `type` to be a RakuAST type node"
+        ))),
+    }
+}
+
+fn normalize_slurpy_marker(value: Value) -> Result<Value, RuntimeError> {
+    let class = match value.view() {
+        ValueView::RakuAst(node)
+            if matches!(
+                node.class,
+                RakuAstClass::ParameterSlurpyFlattened | RakuAstClass::ParameterSlurpyUnflattened
+            ) =>
+        {
+            return Ok(value);
+        }
+        ValueView::Package(name) => match name.resolve().as_str() {
+            "RakuAST::Parameter::Slurpy::Flattened" => RakuAstClass::ParameterSlurpyFlattened,
+            "RakuAST::Parameter::Slurpy::Unflattened" => RakuAstClass::ParameterSlurpyUnflattened,
+            _ => {
+                return Err(RuntimeError::new(
+                    "RakuAST::Parameter.new expects a RakuAST slurpy marker",
+                ));
+            }
+        },
+        _ => {
+            return Err(RuntimeError::new(
+                "RakuAST::Parameter.new expects a RakuAST slurpy marker",
+            ));
+        }
+    };
+    Ok(Value::rakuast(Box::new(RakuAstNode {
+        class,
+        fields: Vec::new(),
+    })))
+}
+
 /// The class for a single-positional-argument constructor, or `None`.
 fn single_positional_class(class_name: &str, method: &str) -> Option<RakuAstClass> {
     Some(match (class_name, method) {
@@ -710,6 +846,8 @@ fn single_positional_class(class_name: &str, method: &str) -> Option<RakuAstClas
         ("RakuAST::Prefix", "new") => RakuAstClass::Prefix,
         ("RakuAST::Var::Lexical", "new") => RakuAstClass::VarLexical,
         ("RakuAST::Initializer::Assign", "new") => RakuAstClass::InitializerAssign,
+        ("RakuAST::Type::Simple", "new") => RakuAstClass::TypeSimple,
+        ("RakuAST::Type::Setting", "new") => RakuAstClass::TypeSetting,
         _ => return None,
     })
 }
@@ -735,7 +873,6 @@ fn multi_field_schema(
         ("RakuAST::ParameterTarget::Var", "new") => {
             (RakuAstClass::ParameterTargetVar, &["name"][..])
         }
-        ("RakuAST::Parameter", "new") => (RakuAstClass::Parameter, &["target"][..]),
         _ => return None,
     })
 }
@@ -778,6 +915,7 @@ pub fn node_accessor(node: &RakuAstNode, method: &str) -> Option<Value> {
         RakuAstClass::VarLexical => Some("name"),
         RakuAstClass::Blockoid => Some("statement-list"),
         RakuAstClass::InitializerAssign => Some("expression"),
+        RakuAstClass::TypeSimple | RakuAstClass::TypeSetting => Some("name"),
         _ => None,
     };
     if positional_name == Some(method)
@@ -856,6 +994,8 @@ fn constructor_is_supported(class: RakuAstClass) -> bool {
             | RakuAstClass::ParameterTargetVar
             | RakuAstClass::VarDeclarationSimple
             | RakuAstClass::InitializerAssign
+            | RakuAstClass::TypeSimple
+            | RakuAstClass::TypeSetting
     )
 }
 
@@ -874,10 +1014,11 @@ fn accessor_names(class: RakuAstClass) -> &'static [&'static str] {
         Blockoid => &["statement-list"],
         Sub => &["name", "signature", "body"],
         Signature => &["parameters"],
-        Parameter => &["target"],
+        Parameter => &["type", "names", "target", "optional", "default", "slurpy"],
         ParameterTargetVar => &["name"],
         VarDeclarationSimple => &["sigil", "desigilname", "initializer"],
         InitializerAssign => &["expression"],
+        TypeSimple | TypeSetting => &["name"],
         _ => &[],
     }
 }

--- a/t/rakuast-construct-rich-parameters.t
+++ b/t/rakuast-construct-rich-parameters.t
@@ -1,0 +1,84 @@
+use v6;
+use experimental :rakuast;
+use MONKEY-SEE-NO-EVAL;
+use Test;
+
+# RakuAST Phase 4 slice 10: programmatic construction of typed, defaulted,
+# optional, named, and slurpy parameters.
+
+plan 14;
+
+sub target($name) {
+    RakuAST::ParameterTarget::Var.new(name => $name)
+}
+
+sub body-for($name) {
+    my $statements = RakuAST::StatementList.new;
+    $statements.add-statement(
+        RakuAST::Statement::Expression.new(
+            expression => RakuAST::Var::Lexical.new($name),
+        )
+    );
+    RakuAST::Blockoid.new($statements)
+}
+
+sub install($name, $parameter, $body-name) {
+    EVAL(
+        RakuAST::Sub.new(
+            name => RakuAST::Name.from-identifier($name),
+            signature => RakuAST::Signature.new(parameters => [$parameter]),
+            body => body-for($body-name),
+        )
+    )
+}
+
+my $int-type = RakuAST::Type::Simple.new(
+    RakuAST::Name.from-identifier('Int')
+);
+isa-ok $int-type, RakuAST::Type::Simple, 'Type::Simple.new constructs a type';
+is $int-type.name.gist, RakuAST::Name.from-identifier('Int').gist,
+    'a constructed simple type exposes its name';
+
+my $typed = RakuAST::Parameter.new(
+    type => $int-type,
+    target => target('$x'),
+);
+is $typed.type, $int-type, 'a typed parameter exposes its type';
+is $typed.target.name, '$x', 'a typed parameter exposes its target';
+ok $typed.gist.contains('type   => RakuAST::Type::Simple.new('),
+    'a typed parameter renders like Rakudo';
+lives-ok { install('constructed-typed', $typed, '$x') },
+    'a typed parameter lowers through EVAL';
+
+my $defaulted = RakuAST::Parameter.new(
+    target => target('$x'),
+    default => RakuAST::IntLiteral.new(7),
+);
+is $defaulted.default.value, 7, 'a defaulted parameter exposes its default';
+lives-ok { install('constructed-default', $defaulted, '$x') },
+    'a defaulted parameter lowers through EVAL';
+
+my $optional = RakuAST::Parameter.new(
+    target => target('$x'),
+    optional => True,
+);
+is $optional.optional, True, 'an optional parameter exposes its marker';
+lives-ok { install('constructed-optional', $optional, '$x') },
+    'an optional parameter lowers through EVAL';
+
+my $named = RakuAST::Parameter.new(
+    names => ['value'],
+    target => target('$value'),
+);
+is $named.names[0], 'value', 'a named parameter exposes its accepted name';
+lives-ok { install('constructed-named', $named, '$value') },
+    'a named parameter lowers through EVAL';
+
+my $slurpy = RakuAST::Parameter.new(
+    target => target('@values'),
+    slurpy => RakuAST::Parameter::Slurpy::Flattened,
+);
+is $slurpy.slurpy.^name, 'RakuAST::Parameter::Slurpy::Flattened',
+    'a slurpy parameter exposes its marker';
+lives-ok { install('constructed-slurpy', $slurpy, '@values') },
+    'a slurpy parameter lowers through EVAL';


### PR DESCRIPTION
## Summary

- construct `RakuAST::Type::Simple` and `RakuAST::Type::Setting` nodes
- accept typed, defaulted, optional, named, and slurpy fields in `RakuAST::Parameter.new`
- validate and expose the new model fields, including normalizing Rakudo's slurpy type-object markers
- lower constructed rich signatures through the existing RakuAST-to-internal-AST compiler path
- update the RakuAST plan, ADR, and accomplishment log

## Impact

Programs can now build the common real-world routine parameter shapes through the public RakuAST
construction API instead of only obtaining them from `Q[…].AST`.

## Validation

- `raku t/rakuast-construct-rich-parameters.t`
- targeted RakuAST suite: 48 tests passed
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `make test` — 2,516 files / 24,042 tests passed
- `make roast` — 1,432 files / 218,509 tests passed
