### PR TITLE
feat(rakuast): construct where-constrained parameters

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1176,8 +1176,10 @@ so it is tracked separately from the roast backlog.
         `Type::Setting.new`, plus `Parameter.new` with typed, defaulted, optional, named, and
         flattened/unflattened slurpy fields. Constructed signatures lower through `EVAL`. Tests in
         `t/rakuast-construct-rich-parameters.t`.
-  - [ ] Slice 11+: advanced parameter shapes (`where`, sub-signatures, type captures, array shapes,
-        and signature constraints).
+  - [x] Slice 11: `Parameter.new(:where)` constructs, exposes, renders, and lowers parameter
+        constraints through `EVAL`. Tests in `t/rakuast-construct-where.t`.
+  - [ ] Slice 12+: advanced parameter shapes (sub-signatures, type captures, array shapes, and
+        signature constraints).
 - **Phase 5 (in progress)** — EVAL: lower RakuAST → internal AST → existing compiler (no new engine).
   - [x] Slices 1–37 done (PRs #4736–#4804): literals, all common operators + ternary, the full
         control-flow set, sub declarations (typed/default/named/slurpy params) + calls + method calls,

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -215,8 +215,11 @@ earlier ones.
     validate child shapes, normalize Rakudo's slurpy type-object marker into the model node, expose
     every field through accessors/introspection, and lower constructed signatures through the
     existing compiler under `EVAL`. Tests in `t/rakuast-construct-rich-parameters.t`.
-    Next: advanced shapes (`where`, sub-signatures, type captures, array shapes, signature
-    constraints).
+  - **Slice 11 (`where` constraints) — done.** `RakuAST::Parameter.new(:where)` validates and
+    retains a constraint node, exposes it through `.where` and model introspection, renders the
+    constructor form like Rakudo, and lowers it to the existing `ParamDef.where_constraint` path
+    through `EVAL`. Tests in `t/rakuast-construct-where.t`. Next: sub-signatures, type captures,
+    array shapes, and signature constraints.
 - **Phase 5 — EVAL / compilation.** `lower(RakuAstNode) -> Vec<Stmt>/Expr`, then the
   **existing** compiler. `EVAL($rakuast)` and any code that yields a RakuAST tree runs
   through this. No new execution engine.

--- a/news/2026-07/rakuast-construct-where.md
+++ b/news/2026-07/rakuast-construct-where.md
@@ -1,0 +1,9 @@
+# Construct RakuAST where-constrained parameters
+
+`RakuAST::Parameter.new` now accepts a `where` constraint node. Constructed parameters retain the
+node for `.where`, advertise the accessor through model introspection, and render the same
+constructor shape as Rakudo.
+
+When a constructed signature is evaluated, the model node lowers to the existing internal
+`ParamDef.where_constraint` representation and continues through the normal compiler and VM.
+The dual-oracle regression test passes under both Rakudo and mutsu.

--- a/src/rakuast/lower.rs
+++ b/src/rakuast/lower.rs
@@ -304,6 +304,16 @@ fn signature_positional_params(
             def.default = Some(lower_expr(default_node)?);
             def.required = false;
         }
+        if let Some(w) = p.fields.iter().find(|f| f.name == Some("where")) {
+            let where_node = match &w.value {
+                RakuAstFieldValue::Node(val) => match val.view() {
+                    ValueView::RakuAst(child) => child,
+                    _ => return Err(unsupported(node)),
+                },
+                _ => return Err(unsupported(node)),
+            };
+            def.where_constraint = Some(Box::new(lower_expr(where_node)?));
+        }
         names.push(name);
         defs.push(def);
     }

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -650,6 +650,13 @@ pub fn construct(
                 value: RakuAstFieldValue::Node(default),
             });
         }
+        if let Some(where_constraint) = named_arg(args, "where") {
+            require_any_rakuast(&where_constraint, "RakuAST::Parameter.new", "where")?;
+            fields.push(RakuAstField {
+                name: Some("where"),
+                value: RakuAstFieldValue::Node(where_constraint),
+            });
+        }
         if let Some(slurpy) = named_arg(args, "slurpy") {
             let slurpy = normalize_slurpy_marker(slurpy)?;
             fields.push(RakuAstField {
@@ -1014,7 +1021,9 @@ fn accessor_names(class: RakuAstClass) -> &'static [&'static str] {
         Blockoid => &["statement-list"],
         Sub => &["name", "signature", "body"],
         Signature => &["parameters"],
-        Parameter => &["type", "names", "target", "optional", "default", "slurpy"],
+        Parameter => &[
+            "type", "names", "target", "optional", "default", "where", "slurpy",
+        ],
         ParameterTargetVar => &["name"],
         VarDeclarationSimple => &["sigil", "desigilname", "initializer"],
         InitializerAssign => &["expression"],

--- a/t/rakuast-construct-where.t
+++ b/t/rakuast-construct-where.t
@@ -1,0 +1,50 @@
+use v6;
+use experimental :rakuast;
+use MONKEY-SEE-NO-EVAL;
+use Test;
+
+# RakuAST Phase 4 slice 11: programmatic construction of where-constrained
+# parameters.
+
+plan 6;
+
+sub target($name) {
+    RakuAST::ParameterTarget::Var.new(name => $name)
+}
+
+sub body-for($name) {
+    my $statements = RakuAST::StatementList.new;
+    $statements.add-statement(
+        RakuAST::Statement::Expression.new(
+            expression => RakuAST::Var::Lexical.new($name),
+        )
+    );
+    RakuAST::Blockoid.new($statements)
+}
+
+sub install($name, $parameter) {
+    EVAL(
+        RakuAST::Sub.new(
+            name => RakuAST::Name.from-identifier($name),
+            signature => RakuAST::Signature.new(parameters => [$parameter]),
+            body => body-for('$x'),
+        )
+    )
+}
+
+my $constraint = RakuAST::IntLiteral.new(1);
+my $parameter = RakuAST::Parameter.new(
+    target => target('$x'),
+    where => $constraint,
+);
+
+isa-ok $parameter, RakuAST::Parameter,
+    'Parameter.new constructs a where-constrained parameter';
+is $parameter.where, $constraint, 'the where accessor exposes the constraint';
+is $parameter.where.value, 1, 'the exposed constraint remains walkable';
+ok $parameter.gist.contains('where  => RakuAST::IntLiteral.new(1)'),
+    'a where-constrained parameter renders like Rakudo';
+ok RakuAST::Parameter.^methods(:local).grep(*.name eq 'where'),
+    'Parameter model introspection advertises the where accessor';
+lives-ok { install('constructed-where', $parameter) },
+    'a where-constrained parameter lowers through EVAL';


### PR DESCRIPTION
## Problem

RakuAST parameter construction covered common types, defaults, named and slurpy parameters, but could not represent or lower `where` constraints.

## Approach

- accept and validate `where` nodes in `RakuAST::Parameter.new`
- expose `.where` through accessors and model introspection
- lower the node into the existing `ParamDef.where_constraint` compiler path
- record Phase 4 slice 11 completion in PLAN.md and ADR-0011

## Tests

- `prove -e raku t/rakuast-construct-where.t`
- `prove -e target/debug/mutsu t/rakuast-construct-where.t`
- `cargo clippy -- -D warnings`
- `make test` (590 Rust tests; 2,518 TAP files / 24,065 tests)
- `make roast` (1,432 files / 218,509 tests; one stale temp-file abort only; targeted `roast/S32-io/spurt.t` then passed 62/62)