### PR TITLE
feat(rakuast): implement Formatter.AST

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -518,14 +518,14 @@ Raku programs closest to the project goal. The last one, `advent2013-day18.t`, l
 ①(stack overflow) / ②(unparseable) / ③(hang) / ④(error-message) clusters are all cleared —
 history in [news/2026-07.md](news/2026-07.md).
 
-**Re-measured 2026-07-17** — the 33 remaining, by area: `6.c/` 4, `S02-names` (pseudo-package)
-3, `S12-*` 6, `S05-*` 5, `S32-str` 2, `S10-packages` 2, `S06-advanced` 2, `APPENDICES` 2,
+**Re-measured 2026-07-27** — the 32 remaining, by area: `6.c/` 4, `S02-names` (pseudo-package)
+3, `S12-*` 6, `S05-*` 5, `S32-str` 1, `S10-packages` 2, `S06-advanced` 2, `APPENDICES` 2,
 `roast/t/` 2 (roast's own Perl 5 tooling — non-goal by definition), and 5 singletons.
 
 **There is no cluster left to attack.** Per the BLOCKERS.md classification nearly all of
 these are *non-goal* (rakudo itself fails), *no oracle* (local raku SORRYs, so the correct
-answer cannot be confirmed), or *awaiting infrastructure* (RakuAST for `S32-str/format.t`,
-6.e generics for `S02-types/generics.t`). The genuinely ★achievable ones are few and each
+answer cannot be confirmed), or *awaiting infrastructure* (6.e generics for
+`S02-types/generics.t`). The genuinely ★achievable ones are few and each
 needs its own unrelated feature:
 
 - [ ] `S02-types/array-shapes.t` — aborts at 36/43 (full oracle: raku is 43/43 with fudge). T43

--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -53,8 +53,7 @@ fails" is not "no subtest is reachable" — most such files still have many indi
 are correct, spec-defined, and implementable, and mutsu can even be *ahead* of the local raku on a
 file (e.g. `S10-packages/basic.t` = mutsu 59/83 vs raku 6/83). Shelving the whole file throws away
 real, winnable subtest progress. Push subtest-level progress to the limit even when the file can
-never be whitelisted. `S32-str/format.t` (abort-at-26 → 48/49, only the RakuAST test left) is the
-model.
+never be whitelisted.
 
 Concretely:
 
@@ -114,7 +113,6 @@ noted.
 
 | Classification | File | mutsu | raku (v2026.06/6.d) | Blocker (one line) |
 |---|---|---|---|---|
-| Awaiting infrastructure | `S32-str/format.t` | **48/49** (fails only 29) | **49/49 full pass** (SORRY on v2022.12) | Down to **one** blocker: test 29 (`Formatter.AST(...) ~~ RakuAST::Node`) needs a genuine `RakuAST::Node` = **no RakuAST subsystem** (stubbing forbidden). Everything else now passes: `Formatter::Syntax.parse`→Match and `Formatter.CODE`→Callable are implemented (`methods_format.rs`), the full `.fmt(Format, $sep)` matrix works, and `.lazy.List`/`.lazy.Seq` now stay lazy so `.fmt` throws `X::Cannot::Lazy`. `Formatter.AST` returns `Nil` (honest "no AST") so the file runs to the end instead of aborting. Pins: `t/format-formatter.t`, `t/format-class.t` |
 | Track B (element cells) | `S02-types/quanthash.t` | **126/129** | **129/129 full pass** | Parameterized-QuantHash subsystem now implemented: `.^parameterize` on Set/Bag/Mix, coercive types `Int()`/`Date()`, `.keyof`, per-element coercion/validation at `.new` (throws `X::Str::Numeric`/`X::Temporal::InvalidFormat`), key coercion on element access/assignment, and container-variable rebind. The remaining 3 (`97`/`112`/`127` "did all keys get removed") need `%qh.values.map({ $_ = 0 })` **write-through** — an rw `.values` that yields per-element `ContainerRef` cells map can alias. This fails for a plain `Hash` too, so it is general **Track B element-cell** work (ADR-0001, deferred/fused with GC), not QuantHash-specific. Pin: `t/quanthash-parameterized.t` |
 | No oracle | `S11-modules/re-export.t` | 0/3 (aborts) | **SORRY** (`no such tag 'EXPORT'`) | `OuterModule` does `use InnerModule :ALL, :EXPORT` to re-export; **rakudo rejects `:EXPORT` as an undeclared tag**, so this file cannot pass upstream either. mutsu *appeared* to pass it until 2026-07-24 purely because a `unit module`'s routines leaked into `GLOBAL::` — the consumer saw Inner's subs without any re-export happening (news `2026-07/unit-module-routines-stay-in-their-package.md`). Dewhitelisted with that fix. Two independent things would be needed to revisit: real `:EXPORT` re-export semantics, and mutsu raising `X::Import::NoSuchTag` for an unknown tag even when `:ALL` is also requested (today `:ALL` short-circuits tag validation, so `:EXPORT` is silently accepted) |
 | No oracle | `S02-names/pseudo-6d.t` | aborts at 116/159 | SORRY (`::=` NYI) | `::("CALLER")::<$*bar>` CALLER pseudo-package deref unsupported. Even on v2026.06 rakudo SORRYs because `::=` binding is unimplemented |
@@ -190,15 +188,6 @@ completed fix history lives in `news/`.
   multi-dimensional EXISTS-POS with Failure from a negative index; 64 needs a `but` mixin with a
   role implementing AT-POS + `substr-rw`. (BIND-POS/DELETE-POS and the shared-cell BIND-POS are
   done — pin: t/bind-pos-shared-cell.t.)
-- **`S32-str/format.t`** — **48/49**, down from the old abort-at-26. The 6.e `Format` class
-  (Format.new, ~~, .arity, .Callable, CALL-ME/sprintf, `.fmt` across containers; pin:
-  t/format-class.t) plus the package-level entry points `Formatter::Syntax.parse` (→ Match) and
-  `Formatter.CODE` (→ Callable) are implemented in `methods_format.rs`; `.lazy.List`/`.lazy.Seq`
-  keep the list lazy (coercion.rs) so a later `.fmt` throws `X::Cannot::Lazy`. The **only**
-  remaining failure is test 29: `Formatter.AST("...") ~~ RakuAST::Node`, which needs a genuine
-  `RakuAST::Node` = **no RakuAST subsystem** (faking it is a forbidden stub). `Formatter.AST`
-  returns `Nil` (an honest "no AST available") so the file runs to completion instead of
-  aborting, leaving exactly one honest failing test. Pin: t/format-formatter.t.
 - **`S32-str/sprintf.t`** — tests 101-104 (`%020.2g`/`%020.2G`) expect mantissa `34.1e+30` from
   a 3.1415e30 input under zero-padding — a raku zero-pad-%g-sci quirk that shifts the decimal
   point; the algorithm is unverifiable (`zprintf` is 6.e-only, absent from the reference raku).

--- a/news/2026-07/formatter-ast-rakuast-node.md
+++ b/news/2026-07/formatter-ast-rakuast-node.md
@@ -1,0 +1,9 @@
+# Formatter.AST returns an executable RakuAST node
+
+`Formatter.AST` now returns a genuine `RakuAST::PointyBlock` instead of `Nil`. The model accepts a
+slurpy argument list and calls `sprintf` with the captured format string, so it is both
+introspectable and executable through `EVAL`.
+
+The new regression test checks the node hierarchy, signature shape, and an evaluated formatting
+round trip. This closes the last failure in `roast/S32-str/format.t`, taking the file from 48/49 to
+49/49 and adding it to the roast whitelist.

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1245,6 +1245,7 @@ roast/S32-str/encode.t
 roast/S32-str/ends-with.t
 roast/S32-str/fc.t
 roast/S32-str/flip.t
+roast/S32-str/format.t
 roast/S32-str/gb18030-encode-decode.t
 roast/S32-str/gb2312-encode-decode.t
 roast/S32-str/indent.t

--- a/src/rakuast/formatter.rs
+++ b/src/rakuast/formatter.rs
@@ -1,0 +1,90 @@
+//! RakuAST model emitted by the 6.e `Formatter.AST` API.
+
+use super::{RakuAstClass, RakuAstField, RakuAstFieldValue, RakuAstNode};
+use crate::value::Value;
+
+fn node(class: RakuAstClass, fields: Vec<RakuAstField>) -> Value {
+    Value::rakuast(Box::new(RakuAstNode { class, fields }))
+}
+
+fn positional(value: Value) -> RakuAstField {
+    RakuAstField {
+        name: None,
+        value: RakuAstFieldValue::Node(value),
+    }
+}
+
+fn named(name: &'static str, value: Value) -> RakuAstField {
+    RakuAstField {
+        name: Some(name),
+        value: RakuAstFieldValue::Node(value),
+    }
+}
+
+/// Build the user-facing AST returned by `Formatter.AST`.
+///
+/// Rakudo emits a directive-specialised pointy block. The model layer keeps the
+/// same observable contract with an equivalent general block:
+/// `-> *@args { sprintf($format, @args) }`. It is a genuine, lowerable
+/// RakuAST tree rather than a marker node, so callers can inspect or `EVAL` it.
+pub fn formatter_ast(format: &str) -> Value {
+    let name = |identifier: &str| {
+        node(
+            RakuAstClass::Name,
+            vec![positional(Value::str(identifier.to_string()))],
+        )
+    };
+    let variable = |variable_name: &str| {
+        node(
+            RakuAstClass::VarLexical,
+            vec![positional(Value::str(variable_name.to_string()))],
+        )
+    };
+
+    let target = node(
+        RakuAstClass::ParameterTargetVar,
+        vec![named("name", Value::str("@args".to_string()))],
+    );
+    let slurpy = node(RakuAstClass::ParameterSlurpyFlattened, vec![]);
+    let parameter = node(
+        RakuAstClass::Parameter,
+        vec![named("target", target), named("slurpy", slurpy)],
+    );
+    let signature = node(
+        RakuAstClass::Signature,
+        vec![RakuAstField {
+            name: Some("parameters"),
+            value: RakuAstFieldValue::List(vec![parameter]),
+        }],
+    );
+
+    let call = node(
+        RakuAstClass::CallName,
+        vec![
+            named("name", name("sprintf")),
+            named(
+                "args",
+                node(
+                    RakuAstClass::ArgList,
+                    vec![
+                        positional(node(
+                            RakuAstClass::StrLiteral,
+                            vec![positional(Value::str(format.to_string()))],
+                        )),
+                        positional(variable("@args")),
+                    ],
+                ),
+            ),
+        ],
+    );
+    let statement = node(
+        RakuAstClass::StatementExpression,
+        vec![named("expression", call)],
+    );
+    let statements = node(RakuAstClass::StatementList, vec![positional(statement)]);
+    let body = node(RakuAstClass::Blockoid, vec![positional(statements)]);
+    node(
+        RakuAstClass::PointyBlock,
+        vec![named("signature", signature), named("body", body)],
+    )
+}

--- a/src/rakuast/mod.rs
+++ b/src/rakuast/mod.rs
@@ -11,9 +11,11 @@
 //! phasing (construction, EVAL, macros are later phases).
 
 mod convert;
+mod formatter;
 mod lower;
 mod render;
 
+pub use formatter::formatter_ast;
 pub use lower::lower;
 
 use crate::value::{RuntimeError, Value, ValueView};

--- a/src/runtime/methods_format.rs
+++ b/src/runtime/methods_format.rs
@@ -186,12 +186,8 @@ impl Interpreter {
                     return Some(Ok(self.format_callable(&fmt, count)));
                 }
                 ("Formatter", "AST") => {
-                    // `Formatter.AST` returns a `RakuAST::Node` describing the
-                    // format. mutsu has no RakuAST subsystem, so we cannot build
-                    // a genuine node; return `Nil` (an honest "not available")
-                    // rather than throwing, so the rest of the file can run.
-                    // TODO: return a real RakuAST::Node once RakuAST exists.
-                    return Some(Ok(Value::NIL));
+                    let fmt = args.first().map(Value::to_string_value).unwrap_or_default();
+                    return Some(Ok(crate::rakuast::formatter_ast(&fmt)));
                 }
                 _ => {}
             }

--- a/t/rakuast-formatter.t
+++ b/t/rakuast-formatter.t
@@ -1,0 +1,15 @@
+use v6.e.PREVIEW;
+use Test;
+use experimental :rakuast;
+
+plan 5;
+
+my $ast = Formatter.AST('value=%04d');
+ok $ast ~~ RakuAST::Node, 'Formatter.AST returns a genuine RakuAST node';
+is $ast.^name, 'RakuAST::PointyBlock', 'the formatter AST is a callable pointy block';
+is $ast.signature.parameters.elems, 1, 'the formatter AST has one slurpy parameter';
+is $ast.signature.parameters[0].target.name, '@args',
+    'the formatter AST accepts the format arguments';
+
+my &formatter = EVAL $ast;
+is formatter(23), 'value=0023', 'the formatter AST lowers to an executable callable';


### PR DESCRIPTION
## Summary

- return a genuine executable RakuAST::PointyBlock from Formatter.AST
- cover node introspection, signature shape, and EVAL execution
- whitelist roast/S32-str/format.t after reaching 49/49

## Validation

- cargo fmt --all
- cargo clippy -- -D warnings
- make test (2519 files, 24070 tests)
- MUTSU_FUDGE=1 prove -e target/release/mutsu roast/S32-str/format.t (49/49)