### PR TITLE
feat(rakuast): expose model methods through can

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1149,7 +1149,10 @@ so it is tracked separately from the roast backlog.
   - [x] Slice 9: `.^attributes(:local)` exposes model fields as ordinary `Attribute` introspection
         objects on both registered type objects and node values. Tests in
         `t/rakuast-type-attributes.t`.
-  - [ ] Slice 10+: remaining type-object metaobject operations.
+  - [x] Slice 10: `.^can` discovers supported constructors, accessors, and mutators from the same
+        model metadata as `.^methods(:local)` and `.^method_table`, on both registered type objects
+        and node values. Tests in `t/rakuast-type-can.t`.
+  - [ ] Slice 11+: remaining type-object metaobject operations.
 - **Phase 4 (in progress)** — construction (`.new`).
   - [x] Slice 1: literal constructors (`RakuAST::IntLiteral.new(42)`, `StrLiteral`, `RatLiteral`).
         Tests in `t/rakuast-construct.t`.

--- a/docs/adr/0011-rakuast-model-layer-and-phasing.md
+++ b/docs/adr/0011-rakuast-model-layer-and-phasing.md
@@ -160,6 +160,10 @@ earlier ones.
   - **Slice 7 (`.^mro` / `.^parents`) — done.** Registered type objects and concrete node values
     expose the model layer's namespace and semantic hierarchy through ClassHOW introspection,
     including `:local`, `:all`, and parent-tree traversal.
+  - **Slice 10 (`.^can`) — done.** Registered type objects and concrete node values discover the
+    constructors, accessors, and mutators implemented by mutsu's model layer. The lookup shares
+    `local_method_names` with `.^methods(:local)` and `.^method_table`, so the three introspection
+    surfaces cannot drift independently.
 - **Phase 4 — Construction.** `.new` (and `.from-identifier`, …) on RakuAST type objects
   build `Value::RakuAst`, validating args against the per-class field schema.
   - **Slice 1 (literals) — done.** `RakuAST::IntLiteral.new(42)` / `RatLiteral.new(3.5)` /

--- a/news/2026-07/rakuast-type-can.md
+++ b/news/2026-07/rakuast-type-can.md
@@ -1,0 +1,6 @@
+# RakuAST type objects expose `.^can`
+
+RakuAST type objects and node values now answer `.^can` for the constructors, accessors, and
+mutators implemented by mutsu's model layer. The lookup uses the same metadata as
+`.^methods(:local)` and `.^method_table`, closing an inconsistency where a field such as
+`RakuAST::IntLiteral.value` was listed by introspection but could not be discovered with `.^can`.

--- a/src/runtime/methods_classhow_method_obj.rs
+++ b/src/runtime/methods_classhow_method_obj.rs
@@ -288,9 +288,24 @@ impl Interpreter {
         let class_name = match target.view() {
             ValueView::Instance { class_name, .. } => class_name.resolve(),
             ValueView::Package(name) => name.resolve(),
+            ValueView::RakuAst(node) => node.class.printed_name().to_string(),
             ValueView::Enum { enum_type, .. } => enum_type.resolve(),
             _ => utils::value_type_name(target).to_string(),
         };
+        // RakuAST model classes are native type objects rather than ordinary
+        // ClassDef entries. Keep `.^can` in lockstep with `.^methods(:local)`
+        // and `.^method_table` by consulting their shared model metadata.
+        if let Some(names) = crate::rakuast::local_method_names(&class_name) {
+            return if names.contains(&method_name) {
+                vec![Value::routine_parts(
+                    Symbol::intern(&class_name),
+                    Symbol::intern(method_name),
+                    false,
+                )]
+            } else {
+                Vec::new()
+            };
+        }
         let mro = self.classhow_mro_unhidden_names(target);
         let mut results = Vec::new();
         for cn in &mro {

--- a/t/rakuast-type-can.t
+++ b/t/rakuast-type-can.t
@@ -1,0 +1,28 @@
+use Test;
+use experimental :rakuast;
+
+plan 10;
+
+is RakuAST::IntLiteral.^can('new').elems, 1,
+    'type object can find its supported constructor';
+is RakuAST::IntLiteral.^can('value').elems, 1,
+    'type object can find its positional accessor';
+is RakuAST::ApplyInfix.^can('left').elems, 1,
+    'type object can find a named-field accessor';
+is RakuAST::StatementList.^can('add-statement').elems, 1,
+    'type object can find its model mutator';
+is RakuAST::Name.^can('from-identifier').elems, 1,
+    'type object can find its named constructor';
+
+is RakuAST::Assignment.^can('new').elems, 0,
+    'can omits an unsupported model constructor';
+is RakuAST::IntLiteral.^can('missing').elems, 0,
+    'can rejects an unknown model method';
+
+my $literal = RakuAST::IntLiteral.new(42);
+is $literal.^can('value').elems, 1,
+    'node value can find its accessor';
+is $literal.^can('new').elems, 1,
+    'node value shares its type object constructor metadata';
+is $literal.^can('missing').elems, 0,
+    'node value rejects an unknown model method';


### PR DESCRIPTION
## Summary

- make RakuAST type objects and node values discover model methods through `.^can`
- reuse the metadata shared by `.^methods(:local)` and `.^method_table`
- document Phase 3 slice 10 and add regression coverage

## Tests

- `cargo clippy -- -D warnings`
- `make test` (590 Rust tests; 2,520 TAP files / 24,080 tests)