### PR TITLE
feat(nativecall): Pointer[T], .of and .deref, and Pointer[T]-typed fields

### DIFF
--- a/news/2026-07/nativecall-typed-pointer.md
+++ b/news/2026-07/nativecall-typed-pointer.md
@@ -1,0 +1,64 @@
+# `Pointer[T]` — a pointer that knows what it points at
+
+`Pointer[T]` did not exist. Parameterising it raised `Pointer cannot be
+parameterized`, and neither `.of` nor `.deref` was implemented, so the two things
+NativeCall bindings do with a typed pointer were both unreachable:
+
+```raku
+my \t = ptr.of ~~ void ?? $type.of !! ptr.of;         # NativeHelpers::Blob
+nativecast(Pointer[type], OBJECT_BODY(any)).deref     # MoarVM::Guts::REPRs
+```
+
+## What landed
+
+- **`Pointer[T]` parameterises.** The resulting object stays an ordinary
+  `Pointer` and remembers `T` in an `of` attribute, rather than becoming an
+  instance of a class named `Pointer[T]` — every existing `Pointer` method
+  (`.Int`, `.gist`, and the marshalling layer's `address` read) keeps working
+  unchanged.
+- **`.of`** reports that type, or `void` for an untyped pointer. `void` is a new
+  prelude type: it exists only to be compared against, which is all Rakudo's
+  `NativeCall::Types::void` is used for here.
+- **`.deref`** reads through the pointer. A pointer to a struct yields a handle
+  onto that same address — C holds structs by reference, so
+  `nativecast(Pointer[SomeStruct], $p).deref.field` reads (and now writes) the
+  struct in place; a pointer to a native scalar reads the value there, which is
+  element 0 of the equivalent `CArray[T]`. An untyped pointer refuses, as Rakudo
+  does.
+
+## The bug behind the bug
+
+A **`Pointer[T]`-typed field** was not recognised as a pointer, and a field type
+NativeCall cannot marshal *aborts the whole struct layout* — deliberately, since
+continuing past it would give every later field a wrong offset. So a struct
+carrying a single `has Pointer[my_bool] $.error;` had no layout at all, and every
+field access on it failed along with `nativesizeof`. `DBIish`'s `MYSQL_BIND` is
+exactly that shape:
+
+```raku
+class MYSQL_BIND is repr('CStruct') is export {
+    has intptr           $.length is rw;
+    ...
+    has Pointer[my_bool] $.error;
+    has Pointer[uint8]   $.row_ptr;
+```
+
+`nativesizeof(WithTyped)` answered `16` in raku and died in mutsu. It answers 16
+now.
+
+While fixing it: a **NULL `Pointer`-typed field now reads as a defined `Pointer`
+with address 0**, not as a type object. The type-object rule is right for a
+CStruct handle (Rakudo returns a type object for a null struct, so `.defined`
+works), but `Pointer.new(0)` is a defined value in Rakudo too, and the old
+behaviour made `$s.field.Int` come back empty instead of `0`.
+
+This is [ADR-0015](../../docs/adr/0015-native-backed-container-storage-and-repr-bodies.md)'s
+**P1a** — the half of P1 that needs no `.REPR`/`.WHERE` work and so carries none
+of the ordering hazard. Pinned by `t/nativecall-typed-pointer.t`, 14/14 identical
+under `raku`.
+
+One finding recorded rather than fixed: a CStruct field whose name collides with
+a builtin method (`first`, `elems`, …) is unreachable, because a handle's fields
+are reached from the accessor *fallback*, after builtin dispatch. Not currently
+blocking any binding —
+[`todo/tickets/cstruct-field-shadowed-by-builtin-method.md`](../../todo/tickets/cstruct-field-shadowed-by-builtin-method.md).

--- a/src/runtime/cstruct_layout.rs
+++ b/src/runtime/cstruct_layout.rs
@@ -57,9 +57,16 @@ impl FieldType {
             "Str" => FieldType::Str,
             "Pointer" | "OpaquePointer" => FieldType::Pointer,
             other => {
-                // `CArray[T]`, and any class C holds by reference (another
-                // CStruct, possibly package-qualified: `OpenSSL::Bio::BIO`).
-                if other.starts_with("CArray[") || is_known_struct(other) {
+                // `CArray[T]`, a typed `Pointer[T]`, and any class C holds by
+                // reference (another CStruct, possibly package-qualified:
+                // `OpenSSL::Bio::BIO`). A typed pointer is still one pointer —
+                // missing it aborted the whole layout, so a struct with a single
+                // `has Pointer[my_bool] $.error;` (DBIish's `MYSQL_BIND`) had no
+                // layout at all and every field access on it failed.
+                if other.starts_with("CArray[")
+                    || other.starts_with("Pointer[")
+                    || is_known_struct(other)
+                {
                     FieldType::Pointer
                 } else {
                     return None;
@@ -152,6 +159,14 @@ pub(crate) unsafe fn read_field(base: usize, field: &FieldLayout) -> crate::valu
             FieldType::Pointer => Value::int(ptr.cast::<usize>().read_unaligned() as i64),
         }
     }
+}
+
+/// The element type of a parameterised `Pointer[T]` spelling, or `None` for a
+/// plain `Pointer`.
+fn pointer_parameter(type_name: &str) -> Option<&str> {
+    type_name
+        .strip_prefix("Pointer[")
+        .and_then(|rest| rest.strip_suffix(']'))
 }
 
 /// The address of a process-lifetime C string holding `s`, for a `Str`-typed
@@ -338,6 +353,18 @@ impl crate::runtime::Interpreter {
         }
         let declared = self.get_attr_type_constraint(&registered, name)?;
         let addr = crate::runtime::to_int(&raw) as usize;
+        // A `Pointer`-typed field is a `Pointer` object even when it is NULL:
+        // unlike a CStruct handle (where a null return is a type object, so
+        // `.defined` behaves like Rakudo's), `Pointer.new(0)` is a defined value
+        // in Rakudo too, and reading a null field as a type object made
+        // `$s.field.Int` empty instead of 0. A parameterised field keeps its
+        // parameter, so `.of` / `.deref` work on the value that comes out.
+        if declared == "Pointer" || declared.starts_with("Pointer[") {
+            return Some(crate::runtime::nativecall::make_typed_pointer(
+                addr,
+                pointer_parameter(&declared).unwrap_or("void"),
+            ));
+        }
         Some(crate::runtime::nativecall::make_native_handle(
             if self.is_cstruct_class(&declared) {
                 declared.rsplit("::").next().unwrap_or(&declared)
@@ -516,9 +543,89 @@ impl crate::runtime::Interpreter {
         };
         let addr = crate::runtime::nativecall::value_c_address(&args[1]);
         let short = target.rsplit("::").next().unwrap_or(&target);
+        // `Pointer[T]` stays an ordinary `Pointer` object and remembers `T` in
+        // an `of` attribute, rather than becoming an instance of a class named
+        // "Pointer[T]" — every `Pointer` method (`.Int`, `.gist`, the
+        // marshalling layer's `address` read) keeps working unchanged, and `.of`
+        // / `.deref` read the parameter from there.
+        if let Some(of) = pointer_parameter(short) {
+            return Some(Ok(crate::runtime::nativecall::make_typed_pointer(addr, of)));
+        }
         Some(Ok(crate::runtime::nativecall::make_native_handle(
             short, addr,
         )))
+    }
+
+    /// `$ptr.of` — what a typed `Pointer[T]` points at, `void` for an untyped
+    /// one, as in Rakudo. `NativeHelpers::Blob`'s `blob-from-pointer` branches
+    /// on exactly this (`ptr.of ~~ void ?? $type.of !! ptr.of`).
+    ///
+    /// `$ptr.deref` — the thing at the address. A pointer to a struct yields a
+    /// handle onto that same address (C holds structs by reference, so
+    /// `nativecast(Pointer[SomeStruct], $p).deref.field` reads the struct in
+    /// place); a pointer to a native scalar reads the value there, which is
+    /// element 0 of the equivalent `CArray[T]`.
+    pub(crate) fn try_pointer_method(
+        &mut self,
+        target: &crate::value::Value,
+        method: &str,
+    ) -> Option<Result<crate::value::Value, crate::value::RuntimeError>> {
+        use crate::value::{RuntimeError, Value, ValueView};
+        if !matches!(method, "of" | "deref") {
+            return None;
+        }
+        let ValueView::Instance {
+            class_name,
+            attributes,
+            ..
+        } = target.view()
+        else {
+            return None;
+        };
+        // The prelude's `Pointer` picks up the enclosing package when it is
+        // prepended inside a module (`Foo::Pointer`), so match on the last `::`
+        // component — the same "one class, several spellings" problem
+        // `cstruct_class_name` documents.
+        if class_name.as_str().rsplit("::").next() != Some("Pointer") {
+            return None;
+        }
+        let of: Option<String> = attributes
+            .as_map()
+            .get("of")
+            .map(|v| match v.view() {
+                ValueView::Package(n) => n.resolve(),
+                _ => v.to_string_value(),
+            })
+            .filter(|n| !n.is_empty() && n != "void");
+        if method == "of" {
+            return Some(Ok(Value::package(crate::symbol::Symbol::intern(
+                of.as_deref().unwrap_or("void"),
+            ))));
+        }
+        let addr = attributes
+            .as_map()
+            .get("address")
+            .map(|v| crate::runtime::to_int(v) as usize)
+            .unwrap_or(0);
+        let Some(of) = of else {
+            // Rakudo: "Internal error: unhandled target type".
+            return Some(Err(RuntimeError::new(
+                "Cannot dereference an untyped Pointer (no `of` type to read)",
+            )));
+        };
+        if self.is_cstruct_class(&of) || self.is_native_handle_class(&of) {
+            let short = of.rsplit("::").next().unwrap_or(&of);
+            return Some(Ok(crate::runtime::nativecall::make_native_handle(
+                short, addr,
+            )));
+        }
+        Some(match self.native_carray_element(&of, addr, 0) {
+            Some(v) => Ok(v),
+            None => Err(RuntimeError::new(format!(
+                "Cannot dereference a Pointer[{}]: not a type NativeCall can read",
+                of
+            ))),
+        })
     }
 }
 

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1273,6 +1273,11 @@ impl Interpreter {
                 if let Some(field) = self.cstruct_field_value(&target, method) {
                     return Ok(field);
                 }
+                // `$ptr.of` / `$ptr.deref` on a NativeCall `Pointer`. The prelude
+                // class declares neither, so they arrive here.
+                if let Some(result) = self.try_pointer_method(&target, method) {
+                    return result;
+                }
                 let cn = class_name.resolve();
                 let class_attrs = self.collect_class_attributes(&cn);
                 // For a *user-declared* class the collected public-attribute list is

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -431,6 +431,22 @@ pub(crate) fn native_object_where(payload: usize) -> usize {
 /// object (undefined) so `.defined` / boolean checks — the OpenSSL binding's
 /// `try {...} || try {...}` fallback pattern — behave like Rakudo, where a null
 /// CStruct return is a type object.
+/// A `Pointer[T]` — an ordinary `Pointer` object that also remembers what it
+/// points at, so `.of` can report `T` and `.deref` can read through it. Kept as
+/// class `Pointer` rather than a class named "Pointer[T]" so every existing
+/// `Pointer` method and the marshalling layer's `address` read keep working.
+/// A NULL address is still a defined object here: unlike an opaque CStruct
+/// handle, `Pointer.new(0)` is a legitimate value in Rakudo too.
+pub(crate) fn make_typed_pointer(addr: usize, of: &str) -> Value {
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert("address".to_string(), Value::int(addr as i64));
+    attrs.insert(
+        "of".to_string(),
+        Value::package(crate::symbol::Symbol::intern(of)),
+    );
+    Value::make_instance(crate::symbol::Symbol::intern("Pointer"), attrs)
+}
+
 pub(crate) fn make_native_handle(class: &str, addr: usize) -> Value {
     if addr == 0 {
         return Value::package(crate::symbol::Symbol::intern(class));

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -44,6 +44,10 @@ class Pointer {
     }
     method Str(--> Str) { self.gist }
 }
+# NativeCall's `void`: what an untyped `Pointer.of` reports. Only ever used as a
+# type object to compare against (`ptr.of ~~ void` in NativeHelpers::Blob's
+# `blob-from-pointer`), so an empty class is the whole of it.
+class void { }
 "#;
 
 /// Builtin `IO::Socket` role. Raku's socket classes (`IO::Socket::INET`,

--- a/src/runtime/runtime_class_query.rs
+++ b/src/runtime/runtime_class_query.rs
@@ -65,6 +65,9 @@ impl Interpreter {
                 | "Positional"
                 | "Associative"
                 | "Iterable"
+                // NativeCall's `Pointer[T]` — a pointer that remembers what it
+                // points at, so `.of` can report it and `.deref` can read it.
+                | "Pointer"
         );
         !parametric_builtin
             && !self.is_role(name)

--- a/t/nativecall-typed-pointer.t
+++ b/t/nativecall-typed-pointer.t
@@ -1,0 +1,68 @@
+use Test;
+use NativeCall;
+
+# A `Pointer[T]` is a pointer that remembers what it points at: `.of` reports
+# `T` (`void` when untyped) and `.deref` reads through it. `NativeHelpers::Blob`
+# branches on `ptr.of ~~ void`, and `MoarVM::Guts::REPRs` reads a struct with
+# `nativecast(Pointer[SomeBody], $addr).deref`.
+#
+# A `Pointer[T]`-typed *field* is also here: it is one pointer like any other,
+# but not recognising the spelling aborted the whole enclosing struct's layout,
+# so a struct with a single such field had no layout at all and every field
+# access on it failed. DBIish's `MYSQL_BIND` is exactly that shape.
+
+plan 14;
+
+sub calloc(size_t, size_t --> Pointer) is native { * }
+sub free(Pointer) is native { * }
+
+class Body is repr('CStruct') {
+    has int64 $.alpha  is rw;
+    has int64 $.beta   is rw;
+}
+
+my $blk = calloc(1, 16);
+ok $blk.defined, 'calloc gave us a block to work in';
+nativecast(Body, $blk).alpha = 7;
+
+# --- .of ---
+# raku spells it `NativeCall::Types::void`; mutsu leaves the NativeCall types
+# unqualified throughout (`CArray[uint8]` vs `NativeCall::Types::CArray[uint8]`),
+# so match the tail rather than pinning one implementation's namespace.
+ok Pointer.new(1).of.^name.ends-with('void'),
+                                      'an untyped Pointer points at void';
+ok Pointer.new(1).of ~~ void,         'and that is the `void` type itself';
+is nativecast(Pointer[Body], $blk).of.^name, 'Body',
+                                      'a typed Pointer reports its type';
+is nativecast(Pointer[int32], $blk).of.^name, 'int32',
+                                      'a typed Pointer over a native scalar';
+
+# --- .deref ---
+my $bp = nativecast(Pointer[Body], $blk);
+is $bp.Int, $blk.Int,                 'a typed Pointer keeps the address';
+is $bp.deref.^name, 'Body',           '.deref on a struct pointer yields the struct';
+is $bp.deref.alpha, 7,                'and reads the struct in place';
+$bp.deref.beta = 9;
+is nativecast(Body, $blk).beta, 9,  'a write through .deref reaches the same memory';
+
+is nativecast(Pointer[int64], $blk).deref, 7,
+                                      '.deref on a scalar pointer reads the value';
+
+dies-ok { Pointer.new($blk.Int).deref },
+                                      'an untyped Pointer cannot be dereferenced';
+
+free($blk);
+
+# --- a Pointer[T] field is one pointer, and does not break the layout ---
+class WithTyped is repr('CStruct') {
+    has Pointer[int8] $.err;
+    has int32         $.n is rw;
+}
+is nativesizeof(WithTyped), 16,       'a Pointer[T] field is one pointer, padded';
+
+my $blk2 = calloc(1, 32);
+my $w = nativecast(WithTyped, $blk2);
+$w.n = 5;
+is $w.n, 5,                           'the struct still has a working layout';
+is $w.err.Int, 0,                     'and the Pointer[T] field reads as NULL';
+free($blk2);

--- a/todo/tickets/cstruct-field-shadowed-by-builtin-method.md
+++ b/todo/tickets/cstruct-field-shadowed-by-builtin-method.md
@@ -1,0 +1,42 @@
+# A CStruct field named like a builtin method is unreachable
+
+A field of an `is repr('CStruct')` class whose name collides with a builtin
+method cannot be read or written through the accessor — the builtin answers
+first:
+
+```raku
+use NativeCall;
+class Body is repr('CStruct') { has int64 $.first is rw; }
+sub calloc(size_t, size_t --> Pointer) is native { * }
+my $b = nativecast(Body, calloc(1, 16));
+$b.first = 7;
+say $b.first;      # raku: 7    mutsu: Body.new
+```
+
+`Body.new` is the invocant coming back out of the *list* `.first`, which treats
+a non-list as a one-element list.
+
+## Why
+
+A CStruct handle keeps no Raku attributes: its fields live in the C struct its
+`address` points at, so `cstruct_field_value` / `cstruct_field_assign` are
+reached from the **accessor fallback** in `runtime/methods_instance_ops.rs`,
+which runs *after* builtin method dispatch. A plain Raku class is unaffected —
+its declared attribute is found on the earlier declared-method path
+(`class C { has $.first }` works in both implementations).
+
+## Why it is not a one-liner
+
+The fix is an ordering change on a hot path: the field lookup has to happen
+before builtin method dispatch for instances of a registered CStruct class. That
+means either a cheap "is this class a CStruct?" gate early in the dispatch chain,
+or hoisting the whole native-handle branch. Both touch method dispatch for every
+instance method call, so it wants a measurement, not a quick patch.
+
+## How much it matters
+
+Not currently blocking. The field names in the bindings mutsu runs (`DBIish`'s
+`MYSQL_BIND`: `length`, `is_null`, `buffer`, `buffer_type`, `error`, …;
+OpenSSL's structs) do not collide with builtins — `length` is not a mutsu builtin
+method. Found while writing `t/nativecall-typed-pointer.t`, whose first draft
+used `$.first`/`$.second` and had to rename them.


### PR DESCRIPTION
[ADR-0015](https://github.com/tokuhirom/mutsu/blob/main/docs/adr/0015-native-backed-container-storage-and-repr-bodies.md)'s
**P1a** — the half of P1 that needs no `.REPR`/`.WHERE` work, and so carries none
of that phase's ordering hazard.

`Pointer[T]` raised `Pointer cannot be parameterized`, and neither `.of` nor
`.deref` existed, so both things NativeCall bindings do with a typed pointer were
unreachable:

```raku
my \t = ptr.of ~~ void ?? $type.of !! ptr.of;         # NativeHelpers::Blob
nativecast(Pointer[type], OBJECT_BODY(any)).deref     # MoarVM::Guts::REPRs
```

### What landed

- **`Pointer[T]` parameterises.** The object stays an ordinary `Pointer` carrying
  the target type in an `of` attribute, rather than becoming an instance of a
  class named `Pointer[T]` — so every existing `Pointer` method (`.Int`, `.gist`,
  the marshalling layer's `address` read) keeps working unchanged.
- **`.of`** reports that type, `void` when untyped. `void` joins the NativeCall
  prelude; it exists only to be compared against, which is all Rakudo uses it for
  here.
- **`.deref`** reads through the pointer: a handle onto the same address for a
  struct (C holds those by reference, so `…deref.field` reads *and writes* the
  struct in place), the value for a native scalar — element 0 of the equivalent
  `CArray[T]`. Untyped refuses, as Rakudo does.

### The bug behind the bug

A **`Pointer[T]`-typed field** was not recognised as a pointer, and a field type
NativeCall cannot marshal *aborts the whole struct layout* — deliberately, since
continuing would give every later field a wrong offset. So a struct carrying one
`has Pointer[my_bool] $.error;` had **no layout at all**: every field access on it
failed, along with `nativesizeof`. `DBIish`'s `MYSQL_BIND` is exactly that shape.
`nativesizeof` on such a struct answered 16 under raku and died under mutsu; it
answers 16 now.

Also: a **NULL `Pointer`-typed field now reads as a defined `Pointer` with address
0**, not a type object. The type-object rule is right for a CStruct handle (Rakudo
returns a type object for a null struct), but `Pointer.new(0)` is defined in
Rakudo too, and the old behaviour made `$s.field.Int` come back empty instead of 0.

### Testing

- `t/nativecall-typed-pointer.t` — new, 14/14 **identical under `raku`**.
- `make test` — 2517 files / 24059 tests, all pass.
- Parameterisation-sensitive roast (`S32-exceptions/misc.t`, `S02-types/WHICH.t`,
  the whitelisted `S02-types` native/num files): pass.

### Recorded, not fixed

`todo/tickets/cstruct-field-shadowed-by-builtin-method.md` — a CStruct field named
like a builtin method (`first`, `elems`, …) is unreachable, because a handle's
fields are reached from the accessor *fallback*, after builtin dispatch. Fixing it
is an ordering change on a hot path, and no binding mutsu runs collides. Found
because this test's first draft used `$.first`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)