### PR TITLE
fix: honor user classes shadowing immutable builtins

### DIFF
--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -462,6 +462,15 @@ impl Interpreter {
             } else {
                 base_class_name
             };
+            // A user declaration shadows a same-named builtin. Keep the
+            // original base name for the generic class path below, but bypass
+            // this builtin-constructor match so `class Set is Hash {}` creates
+            // a Set instance rather than an immutable builtin QuantHash.
+            let constructor_dispatch_name = if self.user_declared_classes.contains(&cn_resolved) {
+                "__mutsu_user_class__"
+            } else {
+                base_class_name
+            };
             let is_datetime_subclass = cn_resolved != "DateTime"
                 && self
                     .class_mro(class_key)
@@ -564,7 +573,7 @@ impl Interpreter {
             if is_cathandle_like && !self.has_user_method(class_key, "new") {
                 return Ok(self.build_io_cathandle(*class_name, &args));
             }
-            match base_class_name {
+            match constructor_dispatch_name {
                 "IO::CatHandle" if !self.has_user_method(class_key, "new") => {
                     return Ok(self.build_io_cathandle(*class_name, &args));
                 }

--- a/src/runtime/runtime_class_query.rs
+++ b/src/runtime/runtime_class_query.rs
@@ -170,9 +170,9 @@ impl Interpreter {
 
     pub(crate) fn class_inherits_from_immutable_setty(&self, name: &str) -> bool {
         const IMMUTABLE_SETTY: &[&str] = &["Set", "Bag", "Mix"];
-        if IMMUTABLE_SETTY.contains(&name) {
-            return true;
-        }
+        // A lexical user declaration shadows a builtin with the same name.
+        // Resolve a registered declaration through its parents before treating
+        // an otherwise-unresolved bare name as an immutable builtin QuantHash.
         // Clone out the parents under a single guard, then recurse without holding it.
         let parents = {
             let reg = self.registry();
@@ -188,15 +188,13 @@ impl Interpreter {
         };
         if let Some(parents) = parents {
             for parent in &parents {
-                if IMMUTABLE_SETTY.contains(&parent.as_str()) {
-                    return true;
-                }
                 if self.class_inherits_from_immutable_setty(parent) {
                     return true;
                 }
             }
+            return false;
         }
-        false
+        IMMUTABLE_SETTY.contains(&name)
     }
 
     /// Whether a user-declared class inherits (transitively) from Array or

--- a/src/vm/vm_call_method_compiled_interpret.rs
+++ b/src/vm/vm_call_method_compiled_interpret.rs
@@ -110,6 +110,7 @@ impl Interpreter {
         // interpreter's `dispatch_new` also delegates to.
         if method == "new"
             && let ValueView::Package(class_name) = target.view()
+            && !self.user_declared_classes.contains(&class_name.resolve())
             && let Some(result) = self.try_native_quanthash_construct_for_package(class_name, &args)
         {
             self.method_dispatch_pure = true;
@@ -122,6 +123,7 @@ impl Interpreter {
         // impls the interpreter's `dispatch_new` also delegates to.
         if method == "new"
             && let ValueView::Package(class_name) = target.view()
+            && !self.user_declared_classes.contains(&class_name.resolve())
             && let Some(result) = self.try_native_aggregate_construct_for_package(class_name, &args)
         {
             self.method_dispatch_pure = true;

--- a/src/vm/vm_call_method_compiled_mut.rs
+++ b/src/vm/vm_call_method_compiled_mut.rs
@@ -38,6 +38,7 @@ impl Interpreter {
         // Native QuantHash construction (mut path twin of the above).
         if method == "new"
             && let ValueView::Package(class_name) = target.view()
+            && !self.user_declared_classes.contains(&class_name.resolve())
             && let Some(result) = self.try_native_quanthash_construct_for_package(class_name, &args)
         {
             self.method_dispatch_pure = true;
@@ -46,6 +47,7 @@ impl Interpreter {
         // Native aggregate construction (mut path twin of the above).
         if method == "new"
             && let ValueView::Package(class_name) = target.view()
+            && !self.user_declared_classes.contains(&class_name.resolve())
             && let Some(result) = self.try_native_aggregate_construct_for_package(class_name, &args)
         {
             self.method_dispatch_pure = true;

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -655,7 +655,12 @@ impl Interpreter {
         // dedicated readonly-`%`-constant path further below produces. Defer to
         // that path for a readonly, non-`:=`-bound `%`-constant hash; only a
         // genuine bound Map value (`:=`) uses the container-level message here.
-        if declared_type.as_deref().is_some_and(|t| t == "Map") {
+        let is_shadowing_user_class = matches!(
+            self.env().get(&var_name).map(Value::view),
+            Some(ValueView::Instance { class_name, .. })
+                if self.is_container_subclass(&class_name.resolve())
+        );
+        if declared_type.as_deref().is_some_and(|t| t == "Map") && !is_shadowing_user_class {
             let is_ro_constant_hash = var_name.starts_with('%')
                 && self.is_readonly(&var_name)
                 && !self

--- a/t/user-class-shadows-immutable-builtin.t
+++ b/t/user-class-shadows-immutable-builtin.t
@@ -1,0 +1,38 @@
+use Test;
+
+plan 14;
+
+# A lexical user class shadows an immutable builtin type with the same name.
+# Mutation must follow the resolved class declaration and its Hash parent, not
+# the spelling of the class name.
+class Map is Hash { }
+class Set is Hash { }
+class Bag is Hash { }
+class Mix is Hash { }
+
+my $map = Map.new;
+lives-ok { $map<a> = 1 }, 'user Map permits element assignment';
+is $map<a>, 1, 'user Map stores the assigned element';
+lives-ok { $map<a>:delete }, 'user Map permits element deletion';
+nok $map<a>:exists, 'user Map deletes the element';
+
+my $set = Set.new;
+lives-ok { $set<a> = 2 }, 'user Set permits element assignment';
+is $set<a>, 2, 'user Set stores the assigned element';
+lives-ok { $set<a>:delete }, 'user Set permits element deletion';
+nok $set<a>:exists, 'user Set deletes the element';
+
+my $bag = Bag.new;
+lives-ok { $bag<a> = 3 }, 'user Bag permits element assignment';
+is $bag<a>, 3, 'user Bag stores the assigned element';
+
+my $mix = Mix.new;
+lives-ok { $mix<a> = 4 }, 'user Mix permits element assignment';
+is $mix<a>, 4, 'user Mix stores the assigned element';
+
+# A subclass of the shadowing user Set follows that user declaration's Hash
+# parent and is mutable too.
+class Child is Set { }
+my $child = Child.new;
+lives-ok { $child<a> = 5 }, 'a child of the shadowing user Set is mutable';
+is $child<a>, 5, 'the child stores the assigned element';


### PR DESCRIPTION
## Problem

User classes named `Map`, `Set`, `Bag`, or `Mix` were constructed and checked as their same-named immutable builtins, so Hash-subclass element mutation failed.

## Approach

- Prefer registered user declarations over native aggregate/QuantHash constructors.
- Resolve immutable Setty inheritance through registered class parents before builtin name fallback.
- Exempt resolved user Hash subclasses from the name-based Map assignment guard.
- Add regression coverage for assignment, deletion, all four colliding names, and a child class.

## Test evidence

- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- targeted TAP: 49 tests passed
- `make test`: 2,523 files / 24,122 tests passed
- `make roast`: 1 unrelated failure from a pre-existing `temp-file-RT-126006-test`; after removing that stale test artifact, `roast/S32-io/spurt.t`: 62 tests passed