### PR TITLE
fix(parser): loosen take word-logical binding

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1115,14 +1115,6 @@ do not trust an older survey after fixes have merged. Remaining known findings i
       fails. Corpus = `Type/X*.rakudoc` + `throws-like`-style assertions. Good QA is "fails
       correctly", not only "works".
 
-### 8.9 `take X and Y` still binds the word-logical too tightly
-
-- [ ] `take` is value-producing, so `(take X) and Y`
-      must run `Y` with `take`'s *returned* value driving the short-circuit — the re-read-seed
-      trick used for assignment does not apply (there is no variable to re-read, and re-evaluating
-      `X` would double any side effect). Needs a taken-value capture. Currently `take X and Y`
-      still parses as `take (X and Y)`. Very rare; deferred.
-
 ### Ad-hoc discovered findings now live in `todo/`, not here
 
 Bugs and gaps found in passing (the former 8.15 / 8.18 / 8.20 / 8.21 / 8.22

--- a/news/2026-07/take-word-logical-precedence.md
+++ b/news/2026-07/take-word-logical-precedence.md
@@ -1,0 +1,11 @@
+# `take` now binds tighter than loose word-logical operators
+
+`take X and Y` now parses and executes as `(take X) and Y`, matching Raku's
+operator precedence. The parser captures `X` in a unique internal value before
+taking it, then uses that same value as the left operand of the word-logical
+tail. This preserves short-circuit behavior without evaluating a side-effecting
+`X` twice.
+
+The same lowering covers the loose `andthen`, `notandthen`, `or`, `xor`, and
+`orelse` families. Regression tests pin true, false, and undefined taken values,
+including exact-once evaluation.

--- a/src/parser/stmt/simple/control_stmts.rs
+++ b/src/parser/stmt/simple/control_stmts.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+static TAKE_VALUE_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
 /// Parse `return` statement.
 pub(crate) fn return_stmt(input: &str) -> PResult<'_, Stmt> {
     // If "return" is a declared term symbol (e.g. sigilless variable \return),
@@ -187,9 +189,37 @@ pub(crate) fn take_stmt(input: &str) -> PResult<'_, Stmt> {
     }
     let rest = keyword("take", input).ok_or_else(|| PError::expected("take statement"))?;
     let (rest, _) = ws1(rest)?;
-    let (rest, expr) = parse_comma_or_expr(rest)?;
+    // `take` is value-producing and binds tighter than the loose word-logicals:
+    // `take X and Y` is `(take X) and Y`. Capture X once because it may have
+    // side effects, then use that same taken value to drive the short-circuit.
+    let (rest, expr) = crate::parser::stmt::assign::parse_comma_or_expr_no_word_logical(rest)?;
     let expr = unwrap_single_trailing_comma(expr);
-    parse_statement_modifier(rest, Stmt::Take(expr, false))
+    let (r, _) = ws(rest)?;
+    let stmt = if crate::parser::expr::starts_with_loose_word_logical(r) {
+        let id = TAKE_VALUE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let tmp_name = format!("__mutsu_take_value_{id}");
+        let tmp_var = Expr::Var(tmp_name.clone());
+        let (rest, tail) = crate::parser::expr::word_logical_tail_pub(r, tmp_var.clone())?;
+        let capture = Stmt::VarDecl {
+            name: tmp_name,
+            expr,
+            type_constraint: None,
+            is_state: false,
+            is_our: false,
+            is_dynamic: false,
+            is_export: false,
+            export_tags: Vec::new(),
+            custom_traits: Vec::new(),
+            where_constraint: None,
+        };
+        return parse_statement_modifier(
+            rest,
+            Stmt::SyntheticBlock(vec![capture, Stmt::Take(tmp_var, false), Stmt::Expr(tail)]),
+        );
+    } else {
+        Stmt::Take(expr, false)
+    };
+    parse_statement_modifier(rest, stmt)
 }
 
 /// Parse CATCH/CONTROL blocks.

--- a/t/take-word-logical-precedence.t
+++ b/t/take-word-logical-precedence.t
@@ -1,0 +1,40 @@
+use v6;
+use Test;
+
+plan 8;
+
+{
+    my @log;
+    my @taken = gather {
+        take (do { @log.push('X'); 2 }) and @log.push('Y');
+    };
+    is-deeply @taken, [2], 'take collects only its left operand';
+    is-deeply @log, ['X', 'Y'], 'true taken value runs the and tail';
+}
+
+{
+    my @log;
+    my @taken = gather {
+        take (do { @log.push('X'); 0 }) and @log.push('Y');
+    };
+    is-deeply @taken, [0], 'false left operand is still taken';
+    is-deeply @log, ['X'], 'false taken value short-circuits the and tail';
+}
+
+{
+    my @log;
+    my @taken = gather {
+        take (do { @log.push('X'); Nil }) orelse @log.push('Y');
+    };
+    is-deeply @taken, [Any], 'undefined left operand is still taken';
+    is-deeply @log, ['X', 'Y'], 'undefined taken value runs the orelse tail';
+}
+
+{
+    my @log;
+    my @taken = gather {
+        take (do { @log.push('X'); 3 }) andthen @log.push('Y');
+    };
+    is-deeply @taken, [3], 'andthen preserves the taken left operand';
+    is-deeply @log, ['X', 'Y'], 'taken operand is evaluated exactly once';
+}


### PR DESCRIPTION
## Problem

`take X and Y` parsed as `take (X and Y)`, although `take` binds tighter than loose word-logical operators. This both gathered the wrong value and prevented the taken value from driving short-circuit behavior.

## Approach

Parse the take operand without loose word-logicals, capture it exactly once in a unique internal value, take that captured value, and seed the trailing word-logical chain from the same capture. Remove completed PLAN 8.9 and record the result in news.

## Test evidence

- `cargo clippy -- -D warnings`
- `make test` (590 Rust unit tests; 2,530 TAP files / 24,213 assertions)
- targeted take/word-logical regression tests
- full local `make roast` was started, but its release build did not finish before handoff; CI runs the complete roast gate