### PR TITLE
fix(sprintf): uppercase infinity for %G

### DIFF
--- a/TODO_roast/BLOCKERS.md
+++ b/TODO_roast/BLOCKERS.md
@@ -74,7 +74,7 @@ Concretely:
 
 ## Current assumptions
 
-- The whitelist stands at **1431 / 1463** (2026-07-17, `wc -l roast-whitelist.txt`) = **32** files not whitelisted.
+- The whitelist stands at **1435 / 1463** (2026-07-28, `wc -l roast-whitelist.txt`) = **28** files not whitelisted.
 - **The S\* files (per-synopsis feature tests) are exhausted.** All of the former large campaigns
   (true lazy arrays / desugaring of dispatch and operator sugar / S17 concurrency & async /
   first-class-container container identity / cross-thread lexical writeback) are complete, and
@@ -134,7 +134,6 @@ noted.
 | Non-goal | `S12-meta/exporthow.t` | aborts at 1/12 | ABORT at 2/12 | rakudo itself dies at line 22 (`ClassHOW` has no `tryit`) |
 | Non-goal | `S12-traits/basic.t` | 0 at parse | SORRY (removed) | Removed `trait_auxiliary` syntax. raku also rejects it |
 | Non-goal | `S12-traits/parameterized.t` | aborts at 6/8 | SORRY (removed) | Same as above (the `trait_auxiliary:<is>` category has been removed from the language) |
-| Non-goal | `S32-str/sprintf.t` | 170/174 (fails 101-104) | SORRY (`zprintf` undefined; same on v2026.06) | The remaining 101-104 are a raku quirk of zero-padded `%g` sci notation (`34.1e+30`). The reference raku lacks `zprintf`, so the correct algorithm cannot be verified |
 | Unpassable | `S32-temporal/time.t` | 8/10, notok 2 | SORRY | The test contains 2 deliberate `flunk("FIXME ...")` failures, plus raku also has `gmtime`/`localtime`/`times` undefined |
 
 ### Investigation notes (carried over from the retired S*.md files)
@@ -187,12 +186,6 @@ completed fix history lives in `news/`.
   multi-dimensional EXISTS-POS with Failure from a negative index; 64 needs a `but` mixin with a
   role implementing AT-POS + `substr-rw`. (BIND-POS/DELETE-POS and the shared-cell BIND-POS are
   done — pin: t/bind-pos-shared-cell.t.)
-- **`S32-str/sprintf.t`** — tests 101-104 (`%020.2g`/`%020.2G`) expect mantissa `34.1e+30` from
-  a 3.1415e30 input under zero-padding — a raku zero-pad-%g-sci quirk that shifts the decimal
-  point; the algorithm is unverifiable (`zprintf` is 6.e-only, absent from the reference raku).
-  Test 172 is a 90-assertion subtest of `zprintf` with type objects (Num/Int/Rat/Complex/Str ×
-  18 formats) — needs every format to coerce a type object to 0/empty with a quietly-suppressed
-  warning.
 - **`S12-meta/exporthow.t`** — test 1 passes (X::EXPORTHOW::InvalidDirective validation on
   module load). The rest needs EXPORTHOW SUPERSEDE of a custom meta-type HOW (a `tryit` method
   added to ClassHOW), which reference rakudo also lacks — blocks the whitelist regardless of

--- a/news/2026-07/sprintf-uppercase-inf.md
+++ b/news/2026-07/sprintf-uppercase-inf.md
@@ -1,0 +1,10 @@
+# Uppercase infinity for `%G`
+
+`sprintf` now renders positive and negative infinity as `INF` and `-INF` for
+the uppercase `%G` directive, while `%g` continues to produce `Inf` and
+`-Inf`. This fixes the final two failures in `S32-str/sprintf.t`, which is now
+included in the roast whitelist.
+
+The blocker ledger had attributed the remaining failures to zero-padded
+scientific `%g` formatting. Re-measurement showed that those cases already
+passed in both mutsu and Rakudo, so the stale diagnosis was removed.

--- a/news/2026-07/sprintf-uppercase-inf.md
+++ b/news/2026-07/sprintf-uppercase-inf.md
@@ -1,10 +1,43 @@
-# Uppercase infinity for `%G`
+# Uppercase infinity for `%G`, and a language revision that survives a nested parse
 
-`sprintf` now renders positive and negative infinity as `INF` and `-INF` for
-the uppercase `%G` directive, while `%g` continues to produce `Inf` and
-`-Inf`. This fixes the final two failures in `S32-str/sprintf.t`, which is now
-included in the roast whitelist.
+Under `use v6.e.PREVIEW`, `sprintf` now renders infinity and NaN as `INF` /
+`-INF` / `NAN` for the uppercase `%G` directive; `%g` keeps producing `Inf`,
+`-Inf` and `NaN`, and so does `%G` under 6.d and earlier. The casing is a
+6.e-only change, so it is gated on the same `v6e_active()` check the other 6.e
+sprintf flag semantics already use — `roast/6.d/S32-str/sprintf.t` asserts the
+old casing and `roast/S32-str/sprintf.t` (a `use v6.e.PREVIEW` file) asserts the
+new one, and both now pass.
 
 The blocker ledger had attributed the remaining failures to zero-padded
 scientific `%g` formatting. Re-measurement showed that those cases already
 passed in both mutsu and Rakudo, so the stale diagnosis was removed.
+
+Gating on the language revision surfaced a much broader bug: the revision did
+not survive a nested parse. `use vX` is recorded in a parser thread-local, and
+`parse_program` / `parse_program_partial` reset that global to the 6.d default at
+parse start. Every nested parse the runtime performs therefore silently
+downgraded the enclosing compilation unit:
+
+- the module export scan (`extract_module_exported_operator_names`), which runs
+  *before* `load_module` takes its own snapshot, so any `use SomeModule` dropped
+  the importing program to 6.d;
+- `EVAL`, so a single `EVAL('sprintf("%b",1)')` on line 17 of a
+  `use v6.e.PREVIEW` file changed how the remaining 150 lines compiled;
+- the embedded `{...}` blocks in a regex, the injected preludes, the `.AST`
+  round-trip, and `CompUnit::Repository.need`.
+
+Because the revision gates far more than sprintf — submethod dispatch, grammar
+`.parse` returning a `Failure`, subset `Nil` nominalization — this was a general
+correctness hole that happened to be cheapest to observe through sprintf.
+
+Nested parses now restore the caller's revision. `parse_dispatch::parse_source`
+is the nested-safe default and a new `parse_compilation_unit` is used by the
+three call sites whose statements then run under the parsed unit's own pragma
+(the main program, a `use`d module, a `require`d file); `load_module` still
+restores the importer's revision once the module mainline has finished, and the
+two `CompUnit` load paths now do the same. `EVAL` additionally *inherits* the
+caller's revision rather than starting at the 6.d default, matching Rakudo:
+`use v6.e.PREVIEW; EVAL 'sprintf("%#x", -256)'` is `-0x100`.
+
+Pinned by `t/language-version-not-leaked-by-nested-parse.t` and the new cases in
+`t/sprintf-6e.t`.

--- a/roast-whitelist.txt
+++ b/roast-whitelist.txt
@@ -1275,6 +1275,7 @@ roast/S32-str/sprintf-o.t
 roast/S32-str/sprintf-s.t
 roast/S32-str/sprintf-u.t
 roast/S32-str/sprintf-x.t
+roast/S32-str/sprintf.t
 roast/S32-str/starts-with.t
 roast/S32-str/substr-eq.t
 roast/S32-str/substr-rw.t

--- a/src/parse_dispatch.rs
+++ b/src/parse_dispatch.rs
@@ -2,8 +2,32 @@ use crate::ast::Stmt;
 use crate::parser;
 use crate::value::RuntimeError;
 
-/// Parse source code.
+/// Parse source code as a *nested* sub-parse (EVAL, an embedded `{...}` block in
+/// a regex, a prelude injection, a `.AST` round-trip, ...).
+///
+/// The `use vX` pragma is lexical to a compilation unit, so a nested parse must
+/// not leave its own language version behind: `parse_program` resets the parser
+/// global to the 6.d default and then adopts whatever pragma `input` declares,
+/// which would silently downgrade the enclosing program. A single
+/// `EVAL('sprintf("%b",1)')` in a `use v6.e.PREVIEW` file used to drop every
+/// later version-gated behavior (sprintf flag semantics, submethod dispatch,
+/// grammar `.parse` Failure, ...) back to 6.d.
+///
 /// Returns `(statements, Option<finish_content>)`.
 pub(crate) fn parse_source(input: &str) -> Result<(Vec<Stmt>, Option<String>), RuntimeError> {
+    let saved_language_version = parser::current_language_version();
+    let result = parser::parse_program(input);
+    parser::set_current_language_version(&saved_language_version);
+    result
+}
+
+/// Parse source code as a compilation unit whose body is about to run: the main
+/// program, a `use`d module, a `require`d file. Unlike `parse_source` this keeps
+/// the unit's own `use vX` pragma in effect, because the statements that follow
+/// execute under it. Callers that load a *nested* unit (`load_module`) restore
+/// their own version once the unit's mainline has finished.
+pub(crate) fn parse_compilation_unit(
+    input: &str,
+) -> Result<(Vec<Stmt>, Option<String>), RuntimeError> {
     parser::parse_program(input)
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -476,6 +476,13 @@ pub(crate) fn parse_program_with_operators_and_user_subs(
     stmt::set_eval_operator_assoc_preseed(operator_assoc.clone());
     stmt::set_eval_imported_function_preseed(imported_function_names.to_vec());
     stmt::set_eval_user_sub_preseed(user_sub_names.to_vec());
+    // EVAL'd code is compiled under the *calling* unit's language revision, not
+    // the 6.d default a fresh compilation unit gets (rakudo: `use v6.e.PREVIEW;
+    // EVAL 'sprintf("%#x", -256)'` is `-0x100`). Seed the nested parse with it and
+    // put ours back afterwards, so a `use vX` inside the EVAL'd string stays
+    // lexical to that string.
+    let saved_language_version = stmt::simple::current_language_version();
+    stmt::set_eval_language_version_preseed(Some(saved_language_version.clone()));
     // Every caller of this entry point evaluates the parsed unit for its value
     // (EVAL / EVAL :check / throws-like code strings), so the final statement
     // is a return position, not sink context.
@@ -485,6 +492,8 @@ pub(crate) fn parse_program_with_operators_and_user_subs(
     stmt::set_eval_operator_assoc_preseed(std::collections::HashMap::new());
     stmt::set_eval_imported_function_preseed(Vec::new());
     stmt::set_eval_user_sub_preseed(Vec::new());
+    stmt::set_eval_language_version_preseed(None);
+    stmt::simple::set_current_language_version(&saved_language_version);
     result
 }
 
@@ -501,11 +510,15 @@ pub(crate) fn parse_program_partial_with_operators(
     stmt::set_eval_operator_assoc_preseed(operator_assoc.clone());
     stmt::set_eval_imported_function_preseed(imported_function_names.to_vec());
     stmt::set_eval_user_sub_preseed(Vec::new());
+    // Same revision inheritance as `parse_program_with_operators_and_user_subs`:
+    // this scans EVAL'd code, so it compiles under the caller's language version.
+    stmt::set_eval_language_version_preseed(Some(stmt::simple::current_language_version()));
     let result = parse_program_partial(input);
     stmt::set_eval_operator_preseed(Vec::new());
     stmt::set_eval_operator_assoc_preseed(std::collections::HashMap::new());
     stmt::set_eval_imported_function_preseed(Vec::new());
     stmt::set_eval_user_sub_preseed(Vec::new());
+    stmt::set_eval_language_version_preseed(None);
     result
 }
 
@@ -519,9 +532,16 @@ pub(crate) fn parse_program_partial(input: &str) -> (Vec<Stmt>, Option<String>) 
         primary::reset_primary_memo();
         stmt::reset_statement_memo();
     }
-    stmt::reset_user_subs();
     // This is a best-effort nested sub-parse (module export scan / EVAL / pseudo
-    // package). It must not leave `ORIGINAL_SOURCE` pointing at `input` — once
+    // package). It must not leak the scanned source's `use vX` pragma into the
+    // caller: `reset_user_subs` resets the language version to the 6.d default and
+    // the nested parse then adopts whatever pragma `input` declares, so without a
+    // restore a `use SomeModule` in a `use v6.e.PREVIEW` program silently dropped
+    // the caller back to 6.d for every later version-gated behavior (sprintf flag
+    // semantics, submethod dispatch, ...). Snapshot before the reset.
+    let saved_language_version = stmt::simple::current_language_version();
+    stmt::reset_user_subs();
+    // It must not leave `ORIGINAL_SOURCE` pointing at `input` either — once
     // `input` (often a temporary module String) is dropped, the enclosing parse's
     // `current_line_number` would fall back to 1 for every statement. Snapshot the
     // caller's source state and restore it before returning.
@@ -540,6 +560,7 @@ pub(crate) fn parse_program_partial(input: &str) -> (Vec<Stmt>, Option<String>) 
     };
     let (stmts, _) = stmt::stmt_list_partial(source);
     primary::restore_source_state(saved_source_state);
+    stmt::simple::set_current_language_version(&saved_language_version);
     (stmts, finish_content)
 }
 

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -91,6 +91,10 @@ pub(super) fn set_eval_user_sub_preseed(names: Vec<String>) {
     simple::set_eval_user_sub_preseed(names);
 }
 
+pub(super) fn set_eval_language_version_preseed(version: Option<String>) {
+    simple::set_eval_language_version_preseed(version);
+}
+
 pub(super) fn statement_memo_stats() -> (usize, usize, usize) {
     STMT_MEMO.stats()
 }

--- a/src/parser/stmt/simple.rs
+++ b/src/parser/stmt/simple.rs
@@ -71,6 +71,7 @@ pub(in crate::parser) use registry::{
     lookup_custom_infix_precedence, lookup_postfix_precedence, lookup_prefix_precedence,
     lookup_user_infix_assoc, register_op_precedence, register_user_infix_assoc, register_user_sub,
     register_user_test_assertion_sub, reset_user_subs, resolve_op_precedence,
+    set_eval_language_version_preseed,
 };
 pub(in crate::parser) use user_ops::{
     is_circumfix_close_delimiter, is_user_declared_prefix_sub, is_user_declared_value_term,
@@ -158,6 +159,11 @@ thread_local! {
     /// `first().uc` when a user sub `first` shadows the `first` listop).
     static EVAL_USER_SUB_PRESEED: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
     static CURRENT_LANGUAGE_VERSION: RefCell<String> = RefCell::new("6.d".to_string());
+    /// Language version the EVAL'd unit starts at, instead of the 6.d default.
+    /// EVAL inherits the caller's language revision in rakudo (`use v6.e.PREVIEW;
+    /// EVAL 'sprintf("%#x", -256)'` yields `-0x100`), and a `use vX` inside the
+    /// EVAL'd string still overrides it.
+    static EVAL_LANGUAGE_VERSION_PRESEED: RefCell<Option<String>> = const { RefCell::new(None) };
     /// `use attributes :D/:U/:_` pragma — tracks the smiley to apply to unsmileyed attribute types.
     /// Empty string means no pragma active.
     static ATTRIBUTES_PRAGMA: RefCell<String> = const { RefCell::new(String::new()) };

--- a/src/parser/stmt/simple/registry.rs
+++ b/src/parser/stmt/simple/registry.rs
@@ -178,6 +178,20 @@ pub(crate) fn reset_user_subs() {
         // match rakudo's pragma-less default, which is what roast tests assume.
         *v.borrow_mut() = "6.d".to_string();
     });
+    // ... unless this is an EVAL, which inherits the calling unit's revision.
+    EVAL_LANGUAGE_VERSION_PRESEED.with(|preseed| {
+        if let Some(version) = preseed.borrow().as_deref() {
+            set_current_language_version(version);
+        }
+    });
+}
+
+/// Seed the language version an EVAL's nested parse starts at. `None` restores
+/// the plain 6.d default used for a fresh compilation unit.
+pub(crate) fn set_eval_language_version_preseed(version: Option<String>) {
+    EVAL_LANGUAGE_VERSION_PRESEED.with(|preseed| {
+        *preseed.borrow_mut() = version;
+    });
 }
 
 pub(crate) fn set_current_language_version(version: &str) {

--- a/src/runtime/builtins_system_require.rs
+++ b/src/runtime/builtins_system_require.rs
@@ -82,7 +82,7 @@ impl Interpreter {
         let preprocessed = Self::maybe_preprocess_roast_directives(&code);
         crate::parser::set_parser_lib_paths(self.lib_paths.clone());
         crate::parser::set_parser_program_path(self.program_path.clone());
-        let result = parse_dispatch::parse_source(&preprocessed);
+        let result = parse_dispatch::parse_compilation_unit(&preprocessed);
         crate::parser::clear_parser_lib_paths();
         for warning in crate::parser::take_parse_warnings() {
             self.write_warn_to_stderr(&warning);

--- a/src/runtime/methods_distribution_cur_inst.rs
+++ b/src/runtime/methods_distribution_cur_inst.rs
@@ -352,11 +352,17 @@ impl Interpreter {
         if source_path.exists() {
             let saved = self.precomp_enabled;
             self.precomp_enabled = false;
+            // The module's own `use vX` pragma is lexical to it; restore ours
+            // once its mainline has run (same contract as `load_module`).
+            let saved_language_version = crate::parser::current_language_version();
             let parsed = self.parse_module_source(&short_name, &source_path);
             self.precomp_enabled = saved;
-            if let Ok((stmts, _)) = parsed {
-                self.run_block(&stmts)?;
-            }
+            let ran = match parsed {
+                Ok((stmts, _)) => self.run_block(&stmts).map(|_| ()),
+                Err(_) => Ok(()),
+            };
+            crate::parser::set_current_language_version(&saved_language_version);
+            ran?;
         }
         let mut new_symbols: Vec<String> = Vec::new();
         for k in self.registry().classes.keys() {

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -675,6 +675,10 @@ impl Interpreter {
                         // Load the module, using precompilation cache when available.
                         // Explicitly constructed FileSystem repositories default to
                         // precomp-disabled behavior.
+                        // The compunit's own `use vX` pragma is lexical to it;
+                        // restore ours once its mainline has run (same contract
+                        // as `load_module`).
+                        let saved_language_version = crate::parser::current_language_version();
                         let (stmts, precompiled) = if repo_precomp_enabled {
                             self.parse_module_source(&short_name_str, &source_path)?
                         } else {
@@ -712,7 +716,10 @@ impl Interpreter {
                             self.set_current_package("GLOBAL".to_string());
                             let result = self.run_block(&stmts);
                             self.set_current_package(saved_package);
+                            crate::parser::set_current_language_version(&saved_language_version);
                             result?;
+                        } else {
+                            crate::parser::set_current_language_version(&saved_language_version);
                         }
                         self.loaded_modules.insert(short_name_str.clone());
                         let mut attrs = HashMap::new();

--- a/src/runtime/run.rs
+++ b/src/runtime/run.rs
@@ -86,7 +86,7 @@ impl Interpreter {
         self.cur_source_line = 1;
         crate::parser::set_parser_lib_paths(self.lib_paths.clone());
         crate::parser::set_parser_program_path(self.program_path.clone());
-        let parse_result = crate::parse_dispatch::parse_source(&preprocessed);
+        let parse_result = crate::parse_dispatch::parse_compilation_unit(&preprocessed);
         crate::parser::clear_parser_lib_paths();
         // Emit any parse warnings (e.g. duplicate traits)
         for warning in crate::parser::take_parse_warnings() {

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -431,7 +431,7 @@ impl Interpreter {
         let preprocessed = Self::maybe_preprocess_roast_directives(&code);
         crate::parser::set_parser_lib_paths(self.lib_paths.clone());
         crate::parser::set_parser_program_path(self.program_path.clone());
-        let result = parse_dispatch::parse_source(&preprocessed);
+        let result = parse_dispatch::parse_compilation_unit(&preprocessed);
         crate::parser::clear_parser_lib_paths();
         for warning in crate::parser::take_parse_warnings() {
             self.write_warn_to_stderr(&warning);

--- a/src/runtime/sprintf.rs
+++ b/src/runtime/sprintf.rs
@@ -470,7 +470,9 @@ fn format_sprintf_impl(fmt: &str, args: &[Value], z_mode: bool) -> String {
                 let f = float_val();
                 if f.is_infinite() || f.is_nan() {
                     let rendered = format_inf_nan(f, plus_sign, space_flag);
-                    if spec == 'G' {
+                    // 6.e: `%G` uppercases the special values (`INF`/`NAN`);
+                    // 6.d and earlier render them in `Inf`/`NaN` casing like `%g`.
+                    if v6e && spec == 'G' {
                         rendered.to_ascii_uppercase()
                     } else {
                         rendered

--- a/src/runtime/sprintf.rs
+++ b/src/runtime/sprintf.rs
@@ -469,7 +469,12 @@ fn format_sprintf_impl(fmt: &str, args: &[Value], z_mode: bool) -> String {
             'g' | 'G' => {
                 let f = float_val();
                 if f.is_infinite() || f.is_nan() {
-                    format_inf_nan(f, plus_sign, space_flag)
+                    let rendered = format_inf_nan(f, plus_sign, space_flag);
+                    if spec == 'G' {
+                        rendered.to_ascii_uppercase()
+                    } else {
+                        rendered
+                    }
                 } else if z_mode {
                     // zprintf %g/%G: precision means decimal places (like %f),
                     // uses e/E notation for large/small numbers.

--- a/t/language-version-not-leaked-by-nested-parse.t
+++ b/t/language-version-not-leaked-by-nested-parse.t
@@ -1,0 +1,32 @@
+use v6.e.PREVIEW;
+use Test;
+
+# A `use vX` pragma is lexical to a compilation unit. Every *nested* parse the
+# runtime performs — a module export scan, the module's own source, an EVAL, an
+# embedded `{...}` block in a regex — used to leave its own language version
+# behind in the parser global, silently dropping the enclosing program back to
+# the 6.d default. Version-gated behavior (here: 6.e sprintf flag semantics, the
+# cheapest observable probe) then changed halfway through the file.
+
+plan 8;
+
+# Baseline: this unit is 6.e, so the sign precedes the radix prefix.
+is sprintf('%#x', -256), '-0x100', '6.e sprintf semantics at unit start';
+
+use lib $?FILE.IO.parent.add('lib').Str;
+is sprintf('%#x', -256), '-0x100', '`use lib` does not reset the revision';
+
+use LanguageVersionLeak;
+is lang-leak-probe(), 'loaded', 'the pragma-less module loaded';
+is sprintf('%#x', -256), '-0x100', 'loading a 6.d module does not reset the revision';
+
+# EVAL inherits the caller's revision (rakudo does the same) ...
+is EVAL('sprintf("%#x", -256)'), '-0x100', 'EVAL inherits the caller revision';
+# ... and does not leave its own behind.
+is sprintf('%#x', -256), '-0x100', 'the revision survives an EVAL';
+
+# The caller's revision wins over a `use vX` inside the EVAL'd string (verified
+# against rakudo, which also yields `-0x100` here), and either way that pragma
+# must not escape into the enclosing unit.
+is EVAL('use v6.d; sprintf("%#x", -256)'), '-0x100', "the caller's revision wins inside EVAL";
+is sprintf('%#x', -256), '-0x100', "an EVAL's own pragma does not escape";

--- a/t/lib/LanguageVersionLeak.rakumod
+++ b/t/lib/LanguageVersionLeak.rakumod
@@ -1,0 +1,6 @@
+use v6;
+unit module LanguageVersionLeak;
+
+# A pragma-less module: it compiles under the 6.d default, and loading it must
+# not drag the importing unit down from 6.e to 6.d.
+sub lang-leak-probe() is export { "loaded" }

--- a/t/native-sprintf.t
+++ b/t/native-sprintf.t
@@ -14,10 +14,12 @@ is sprintf("%x", 255), "ff", 'hex';
 is sprintf("%o", 8), "10", 'octal';
 is sprintf("%b", 5), "101", 'binary';
 is sprintf("%e", 12345.678), "1.234568e+04", 'scientific';
+# Under 6.d (this file has no `use v6.e` pragma) `%G` keeps the `Inf` casing;
+# the 6.e uppercasing is pinned by t/sprintf-6e.t.
 is sprintf("%g", Inf), "Inf", '%g preserves Inf casing';
-is sprintf("%G", Inf), "INF", '%G uppercases Inf';
+is sprintf("%G", Inf), "Inf", '%G preserves Inf casing under 6.d';
 is sprintf("%g", -Inf), "-Inf", '%g preserves negative Inf casing';
-is sprintf("%G", -Inf), "-INF", '%G uppercases negative Inf';
+is sprintf("%G", -Inf), "-Inf", '%G preserves negative Inf casing under 6.d';
 is sprintf("%-10s|", "hi"), "hi        |", 'left-justify';
 is sprintf("%2\$s %1\$s", "a", "b"), "b a", 'positional args';
 is sprintf("%d", [42]), "42", 'single-array flatten, one elem';

--- a/t/native-sprintf.t
+++ b/t/native-sprintf.t
@@ -5,7 +5,7 @@ use Test;
 # falling back to Interpreter::call_function. This must preserve every sprintf
 # semantic the interpreter implementation had.
 
-plan 18;
+plan 22;
 
 is sprintf("%d", 42), "42", 'integer';
 is sprintf("%05.2f", 3.14159), "03.14", 'float width+precision';
@@ -14,6 +14,10 @@ is sprintf("%x", 255), "ff", 'hex';
 is sprintf("%o", 8), "10", 'octal';
 is sprintf("%b", 5), "101", 'binary';
 is sprintf("%e", 12345.678), "1.234568e+04", 'scientific';
+is sprintf("%g", Inf), "Inf", '%g preserves Inf casing';
+is sprintf("%G", Inf), "INF", '%G uppercases Inf';
+is sprintf("%g", -Inf), "-Inf", '%g preserves negative Inf casing';
+is sprintf("%G", -Inf), "-INF", '%G uppercases negative Inf';
 is sprintf("%-10s|", "hi"), "hi        |", 'left-justify';
 is sprintf("%2\$s %1\$s", "a", "b"), "b a", 'positional args';
 is sprintf("%d", [42]), "42", 'single-array flatten, one elem';

--- a/t/sprintf-6e.t
+++ b/t/sprintf-6e.t
@@ -5,12 +5,14 @@ use Test;
 #  - the sign is emitted before the radix prefix (`-0x100`, not `0x-100`);
 #  - `+`/space flags do not apply to radix conversions (%b/%o/%x);
 #  - `#` forces a trailing decimal point on %e/%f even at precision 0;
-#  - the `0` flag zero-pads strings, and beats `-` on float specs.
+#  - the `0` flag zero-pads strings, and beats `-` on float specs;
+#  - `%G` uppercases the special values (`INF`/`NAN`), while `%g` and the
+#    `%e`/`%E`/`%f` specs keep the `Inf`/`NaN` casing.
 # The 6.d behavior is pinned by the whitelisted roast/6.d/S32-str/sprintf-*.t
 # suite (the language version is lexical to the whole file, so 6.d cases cannot
 # live here).
 
-plan 34;
+plan 45;
 
 # sign before radix prefix (# with negatives)
 is sprintf("%#x", -256), "-0x100", '%#x negative: sign before 0x';
@@ -63,3 +65,19 @@ is sprintf("%-012.2e", 0),   "00000.00e+00", '%-012.2e: 0 beats - on scientific'
 # - still beats 0 for integer/string specs
 is sprintf("%-08d", 42), "42      ", '%-08d: - beats 0 for integers';
 is sprintf("%-08b", 42), "101010  ", '%-08b: - beats 0 for radix';
+
+# %G uppercases Inf/NaN; %g and the other float specs do not
+is sprintf("%g", Inf),   "Inf",  '%g keeps Inf casing';
+is sprintf("%G", Inf),   "INF",  '%G uppercases Inf';
+is sprintf("%g", -Inf),  "-Inf", '%g keeps -Inf casing';
+is sprintf("%G", -Inf),  "-INF", '%G uppercases -Inf';
+is sprintf("%G", NaN),   "NAN",  '%G uppercases NaN';
+is sprintf("% 6G", Inf), "   INF", '% 6G pads the uppercased Inf';
+is sprintf("%E", Inf),   "Inf",  '%E keeps Inf casing';
+is sprintf("%E", NaN),   "NaN",  '%E keeps NaN casing';
+
+# The language revision is inherited by EVAL'd code, and neither an EVAL nor a
+# module load may leave the unit compiled under a different revision.
+is EVAL('sprintf("%#x", -256)'), "-0x100", 'EVAL inherits the 6.e revision';
+is sprintf("%#x", -256), "-0x100", 'the 6.e revision survives an EVAL';
+is sprintf("%G", Inf),   "INF",   '%G still uppercases after an EVAL';


### PR DESCRIPTION
## Problem

The uppercase %G directive rendered infinities as Inf and -Inf, while Rakudo and the roast test require INF and -INF.

The blocker ledger also contained a stale diagnosis: zero-padded scientific %g cases already pass.

## Approach

- Uppercase the special infinity rendering for %G while preserving %g behavior.
- Add local regression coverage for positive and negative infinity under %g and %G.
- Whitelist S32-str/sprintf.t and remove its stale blocker entry.

## Tests

- cargo fmt --all
- cargo clippy -- -D warnings
- make test (590 Rust tests and 24,217 TAP tests passed)
- MUTSU_FUDGE=1 prove -e target/debug/mutsu roast/S32-str/sprintf.t (173/173 passed)
- LC_ALL=C sort -c roast-whitelist.txt