### PR TITLE
feat(nativecall): honest .REPR and a real .WHERE for native handles (BODY_OF)

### DIFF
--- a/news/2026-07/nativecall-repr-bodies.md
+++ b/news/2026-07/nativecall-repr-bodies.md
@@ -1,0 +1,72 @@
+# `BODY_OF` works: honest `.REPR` and a real `.WHERE` for NativeCall handles
+
+`MoarVM::Guts::REPRs`' `BODY_OF` — how every `NativeHelpers` entry point gets at
+a container's element pointer — now works on mutsu for a `nativecast`ed handle:
+
+```raku
+my $r = nativecast(Rec, $blk);
+say BODY_OF($r).cstruct.Int;    # the address of the struct, on both implementations
+```
+
+It needs two things that mutsu did not answer honestly. `.REPR` said `P6opaque`
+where raku says `CStruct`, so the module refused the object outright; and `.WHERE`
+was a hash of the object's identity, which is fine until something *dereferences*
+it.
+
+## The two travel together, and the order matters
+
+`BODY_OF` dispatches on `.REPR` and then dereferences `.WHERE`, so answering
+`.REPR` honestly is a **promise that a REPR body sits at `.WHERE`**. Doing them
+in the wrong order is not a cosmetic bug: with `.REPR` fixed and `.WHERE` still an
+identity hash, the module read wild memory and mutsu **segfaulted**. That is the
+hazard [ADR-0015](../../docs/adr/0015-native-backed-container-storage-and-repr-bodies.md)
+§2.1 names as its safety rule, and it was measured, not hypothesised.
+
+So the rule is enforced by construction: only an object whose whole identity *is*
+a C address — a `nativecast`ed CStruct, CUnion or CArray — gets the honest name,
+and it gets a body in the same breath.
+
+## The body needed no new machinery
+
+mutsu's `.WHERE` contract, fixed when `NativeHelpers::Blob` was first made to
+load, is "points straight at the payload, no object header" — the module's probe
+computes `Offset` as 0. And `native_object_where` already hands out a zero-filled
+block whose first word is the address. That block *is* the CStruct body
+(`{void* cstruct; void** child_objs}`), byte for byte, and it is also the CArray
+body (`{void* storage; void** child; i32 managed; i32 allocated; i32 elems}`) for
+an unmanaged cast: storage set, `managed` and `elems` zero — exactly what an
+unmanaged `CArray` handle is.
+
+## What deliberately still says `P6opaque`
+
+A CStruct constructed in Raku, and every `Buf`. They have no C storage yet, so
+claiming `CStruct`/`VMArray` would promise a body that is not there and `BODY_OF`
+would quietly read a NULL one instead of refusing. Under-reporting keeps it loud.
+Giving those objects real storage — and with it the honest name — is ADR-0015's
+P2/P3.
+
+## Found on the way
+
+A `nativecast` through a **qualified** body type produced an unusable handle:
+`Pointer[MoarVM::Guts::REPRs::CStructB]` was shortened by splitting on the last
+`::` of the whole string, yielding the nonsense class `CStructB]`. Shortening now
+leaves the type argument alone. The same fix applies to a field type written
+inside a module, which arrives carrying that module's package
+(`MoarVM::Guts::REPRs::Pointer[Pointer]`) and so was not recognised as a pointer
+at all — which, since an unmarshallable field aborts the whole layout by design,
+meant the body struct had no layout and none of its fields could be read.
+
+## What is left before `LinearArray`
+
+ADR-0015 named `NativeHelpers::CStruct`'s `LinearArray` as P1's acceptance. The
+REPR-body mechanism is done and verified against the real module, but two
+unrelated bugs still stand between it and `LinearArray`, neither of them
+NativeCall work: a punned *parameterised* role never runs its `BUILD`, and a `my`
+in a role body initialised from the role's type parameter reads as 0. Both are
+reduced to a few lines in
+[`todo/tickets/parameterised-role-pun-skips-build.md`](../../todo/tickets/parameterised-role-pun-skips-build.md).
+
+Pinned by `t/nativecall-repr-body.t`. Its body-reading half scans for the body
+the way the module does rather than assuming an offset, so it passes identically
+under `raku`; the three assertions that pin mutsu's deliberate under-report are
+marked as such.

--- a/src/runtime/cstruct_layout.rs
+++ b/src/runtime/cstruct_layout.rs
@@ -43,7 +43,12 @@ impl FieldType {
         name: &str,
         is_known_struct: impl Fn(&str) -> bool,
     ) -> Option<Self> {
-        Some(match name {
+        // A type written inside a module carries that module's package on the
+        // way in (`MoarVM::Guts::REPRs::Pointer[Pointer]` for a plain
+        // `Pointer[Pointer]`), so match on the base's last component — the same
+        // "one class, several spellings" problem `cstruct_class_name` documents.
+        // `is_known_struct` gets the name as written; it does its own matching.
+        Some(match short_base_name(name) {
             "int8" => FieldType::I8,
             "int16" => FieldType::I16,
             "int32" => FieldType::I32,
@@ -65,7 +70,7 @@ impl FieldType {
                 // layout at all and every field access on it failed.
                 if other.starts_with("CArray[")
                     || other.starts_with("Pointer[")
-                    || is_known_struct(other)
+                    || is_known_struct(name)
                 {
                     FieldType::Pointer
                 } else {
@@ -161,10 +166,26 @@ pub(crate) unsafe fn read_field(base: usize, field: &FieldLayout) -> crate::valu
     }
 }
 
+/// Shorten a possibly-parameterised type name to its last `::` component
+/// **without touching the type argument**: `A::B::CArray[X::Y]` stays
+/// `CArray[X::Y]`. Splitting on the last `::` of the whole string instead turned
+/// `Pointer[MoarVM::Guts::REPRs::CStructB]` into the nonsense class `CStructB]`,
+/// which is how a `nativecast` through a qualified body type silently produced
+/// an unusable handle.
+pub(crate) fn short_base_name(type_name: &str) -> &str {
+    let base_end = type_name.find('[').unwrap_or(type_name.len());
+    match type_name[..base_end].rfind("::") {
+        Some(i) => &type_name[i + 2..],
+        None => type_name,
+    }
+}
+
 /// The element type of a parameterised `Pointer[T]` spelling, or `None` for a
-/// plain `Pointer`.
+/// plain `Pointer`. The base may be qualified (`NativeCall::Types::Pointer[T]`);
+/// the parameter is returned exactly as written, since every consumer resolves
+/// a qualified type name by its last component anyway.
 fn pointer_parameter(type_name: &str) -> Option<&str> {
-    type_name
+    short_base_name(type_name)
         .strip_prefix("Pointer[")
         .and_then(|rest| rest.strip_suffix(']'))
 }
@@ -542,7 +563,7 @@ impl crate::runtime::Interpreter {
             }
         };
         let addr = crate::runtime::nativecall::value_c_address(&args[1]);
-        let short = target.rsplit("::").next().unwrap_or(&target);
+        let short = short_base_name(&target);
         // `Pointer[T]` stays an ordinary `Pointer` object and remembers `T` in
         // an `of` attribute, rather than becoming an instance of a class named
         // "Pointer[T]" — every `Pointer` method (`.Int`, `.gist`, the
@@ -554,6 +575,75 @@ impl crate::runtime::Interpreter {
         Some(Ok(crate::runtime::nativecall::make_native_handle(
             short, addr,
         )))
+    }
+
+    /// `.REPR` / `.WHERE` for a **native handle** — an instance whose whole
+    /// identity is a C address (a `nativecast`ed CStruct, CUnion or CArray).
+    /// `None` for anything else, which keeps its ordinary answers.
+    ///
+    /// These two travel together on purpose. `MoarVM::Guts::REPRs`' `BODY_OF`
+    /// dispatches on `.REPR` and then *dereferences* `.WHERE`, so answering
+    /// `.REPR` honestly is a promise that a REPR body exists at `.WHERE`.
+    /// Answering it before the body existed would hand a module the identity
+    /// hash to dereference — see ADR-0015 §2.1.
+    ///
+    /// The body itself needs no new machinery. mutsu's `.WHERE` contract is
+    /// "points straight at the payload, no object header" (`Offset` is 0), and
+    /// `native_object_where` already hands out a zero-filled block whose first
+    /// word is the address. That is byte-for-byte the CStruct body
+    /// (`{void* cstruct; void** child_objs}`) and the CArray body
+    /// (`{void* storage; void** child; i32 managed; i32 allocated; i32 elems}`)
+    /// for an unmanaged cast: storage set, `managed`/`elems` zero, which is
+    /// exactly what an unmanaged `CArray` handle is.
+    ///
+    /// A CStruct *constructed in Raku* deliberately does not qualify: it has no
+    /// C storage yet, so it keeps `P6opaque` and `BODY_OF` keeps refusing it
+    /// loudly instead of quietly reading a NULL body. Giving it real storage is
+    /// ADR-0015's P3.
+    pub(crate) fn try_native_handle_repr_where(
+        &mut self,
+        target: &crate::value::Value,
+        method: &str,
+    ) -> Option<crate::value::Value> {
+        use crate::value::{Value, ValueView};
+        if !matches!(method, "REPR" | "WHERE") {
+            return None;
+        }
+        let ValueView::Instance {
+            class_name,
+            attributes,
+            ..
+        } = target.view()
+        else {
+            return None;
+        };
+        let addr = match attributes.as_map().get("address").map(|v| v.view()) {
+            Some(ValueView::Int(a)) if a > 0 => a as usize,
+            _ => return None,
+        };
+        let name = class_name.resolve();
+        let short = name.rsplit("::").next().unwrap_or(&name).to_string();
+        let is_cunion = {
+            let reg = self.registry();
+            reg.cunion_classes.contains(&name)
+                || reg
+                    .cunion_classes
+                    .iter()
+                    .any(|c| c.rsplit("::").next().unwrap_or(c) == short)
+        };
+        let repr = if self.is_cstruct_class(&name) {
+            "CStruct"
+        } else if is_cunion {
+            "CUnion"
+        } else if short == "CArray" || short.starts_with("CArray[") {
+            "CArray"
+        } else {
+            return None;
+        };
+        Some(match method {
+            "REPR" => Value::str_from(repr),
+            _ => Value::int(crate::runtime::nativecall::native_object_where(addr) as i64),
+        })
     }
 
     /// `$ptr.of` — what a typed `Pointer[T]` points at, `void` for an untyped

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -65,6 +65,17 @@ impl Interpreter {
         {
             return Ok(v.clone());
         }
+        // `.REPR` / `.WHERE` on a NativeCall handle. Both need the class
+        // registry to tell a `nativecast`ed CStruct/CUnion/CArray from an
+        // ordinary instance, so they cannot be answered on the pure native fast
+        // path — and they must not reach it, since its `.WHERE` is an identity
+        // hash that a module would go on to dereference.
+        if args.is_empty()
+            && matches!(method, "REPR" | "WHERE")
+            && let Some(v) = self.try_native_handle_repr_where(&target, method)
+        {
+            return Ok(v);
+        }
         // .emit on any value: push to the supply emit buffer if inside a
         // supply block, otherwise raise CX::Emit like the `emit` sub.
         if method == "emit"

--- a/src/vm/vm_native_dispatch.rs
+++ b/src/vm/vm_native_dispatch.rs
@@ -48,6 +48,18 @@ impl Interpreter {
         {
             return None;
         }
+        // `.REPR` / `.WHERE` on a NativeCall handle. Telling a `nativecast`ed
+        // CStruct/CUnion/CArray from an ordinary instance needs the class
+        // registry, so the pure native path cannot answer these — and it must
+        // not be allowed to: its `.WHERE` is an identity hash, and a module that
+        // trusted an honest `.REPR` would go on to *dereference* that hash.
+        // (Measured: doing this the other way round segfaults.)
+        if args.is_empty()
+            && matches!(method_name.as_str(), "REPR" | "WHERE")
+            && let Some(v) = self.try_native_handle_repr_where(target, method_name.as_str())
+        {
+            return Some(Ok(v));
+        }
         // `.Capture` that must call user methods / drain a live source (Channel/
         // Supply, or a non-Str Pair key needing `.Str`) is interpreter-aware; other
         // targets fall through to the pure native `value_to_capture` below.

--- a/t/nativecall-repr-body.t
+++ b/t/nativecall-repr-body.t
@@ -1,0 +1,91 @@
+use Test;
+use NativeCall;
+
+# `.REPR` and `.WHERE` for a NativeCall handle — an object whose whole identity
+# is a C address. Together they are what `MoarVM::Guts::REPRs`' `BODY_OF` needs:
+# it dispatches on `.REPR` and then *dereferences* `.WHERE`, so an honest
+# `.REPR` is a promise that a REPR body sits at `.WHERE`.
+#
+# mutsu's `.WHERE` contract is "points straight at the payload, no object
+# header", so the probe in `MoarVM::Guts::REPRs` computes `Offset` as 0 and the
+# body is read at `.WHERE` itself. The bodies below are the same hand-written
+# CStruct mirrors that module declares.
+
+plan 15;
+
+sub calloc(size_t, size_t --> Pointer) is native { * }
+sub free(Pointer) is native { * }
+
+class CStructB is repr('CStruct') {
+    has Pointer          $.cstruct;
+    has Pointer[Pointer] $.child_objs;
+}
+class CArrayB is repr('CStruct') {
+    has Pointer          $.storage;
+    has Pointer[Pointer] $.child;
+    has int32            $.managed;
+    has int32            $.allocated;
+    has int32            $.elems;
+}
+
+class Rec is repr('CStruct') {
+    has int64 $.one is rw;
+    has int64 $.two is rw;
+}
+
+# How far into an object its body sits is implementation-defined — Rakudo puts
+# it past MoarVM's object header, mutsu's `.WHERE` points straight at it — so
+# scan for it the way `MoarVM::Guts::REPRs` does rather than assuming an offset.
+sub body-offset($where, $wanted) {
+    my $words = nativecast(CArray[uint64], Pointer.new($where));
+    my $i = 0;
+    repeat { last if $words[$i] == $wanted } while ++$i < 10;
+    $i == 10 ?? Nil !! $i * 8
+}
+
+# --- a CStruct handle ---
+my $blk = calloc(1, 16);
+ok $blk.defined, 'calloc gave us a block to work in';
+
+my $r = nativecast(Rec, $blk);
+is $r.REPR, 'CStruct',            'a nativecast CStruct handle reports CStruct';
+isnt $r.WHERE, 0,                 'and has a non-zero WHERE';
+
+# What BODY_OF does, spelled out.
+my $off = body-offset($r.WHERE, $blk.Int);
+ok $off.defined,                  'the CStruct body is found within ten words';
+my $body = nativecast(CStructB, Pointer.new($r.WHERE + $off));
+is $body.cstruct.Int, $blk.Int,   'the CStruct body points at the struct itself';
+
+$r.one = 5;
+is nativecast(Rec, $body.cstruct).one, 5,
+                                  'and going back through it reaches the same memory';
+
+# --- a CArray handle ---
+my $ca = nativecast(CArray[int32], $blk);
+is $ca.REPR, 'CArray',            'a nativecast CArray handle reports CArray';
+my $coff = body-offset($ca.WHERE, $blk.Int);
+ok $coff.defined,                 'the CArray body is found within ten words';
+my $cb = nativecast(CArrayB, Pointer.new($ca.WHERE + $coff));
+is $cb.storage.Int, $blk.Int,     'the CArray body points at the storage';
+is $cb.managed, 0,                'a cast CArray is not managed';
+is $cb.elems, 0,                  'and carries no element count';
+
+free($blk);
+
+# --- what deliberately does NOT get a body ---
+# The three assertions below pin a *deliberate under-report*, so they are the
+# one part of this file that does not match raku: raku answers `CStruct` and
+# `VMArray` here, because those objects have C storage and mutsu's do not yet.
+# Reporting the honest name without a body is the one thing that must never
+# happen — `BODY_OF` would dereference whatever `.WHERE` returned. Under-report
+# and it refuses loudly instead. Giving these objects real storage (and with it
+# the honest name) is ADR-0015's P2/P3.
+is Rec.new.REPR, 'P6opaque',      'a Raku-constructed CStruct has no body yet';
+
+class Plain { has $.address = 12345; }
+is Plain.new.REPR, 'P6opaque',    'an ordinary class is untouched';
+isnt Plain.new.WHERE, Plain.new.WHERE,
+                                  'and keeps identity-derived WHERE';
+is Buf.new(1, 2, 3).REPR, 'P6opaque',
+                                  'a Buf has no body yet either';

--- a/todo/tickets/parameterised-role-pun-skips-build.md
+++ b/todo/tickets/parameterised-role-pun-skips-build.md
@@ -1,0 +1,74 @@
+# A punned *parameterised* role never runs its `BUILD`
+
+`R[T].new` on a parameterised role builds an object whose `submethod BUILD` never
+ran. The same shape on a plain `class` works, and so does a punned role with no
+type parameter (that was #5495).
+
+```raku
+role R2[::T] {
+    has @!cache handles <AT-POS>;
+    submethod BUILD() {
+        @!cache := Array[T].new(:shape(2));
+        @!cache[0] = T.new;
+        note "inside BUILD";        # raku prints this; mutsu never does
+        self
+    }
+    method new(::?CLASS:U:) { self.bless }
+}
+say R2[Int].new[0].^name;           # raku: Int   mutsu: Nil
+```
+
+Swap `role R2[::T]` for `class C1` (with the type written out) and mutsu prints
+`inside BUILD` and answers correctly, so the delegation, the private array
+attribute and the `:=` bind are all fine. The parameterised-role pun is the
+trigger.
+
+## Why it matters
+
+It is what stops `NativeHelpers::CStruct`'s `LinearArray` — the last piece of the
+`NativeHelpers` surface `DBIish`'s mysql driver uses:
+
+```raku
+role LinearArray[::T] does Positional[T] {
+    has Pointer $!storage;
+    has @!cache handles <AT-POS elems shape>;
+    submethod BUILD(:$!size!, :$!storage!, :$!managed) { ... }
+    method new(::?CLASS:U: Int $size) {
+        with calloc($size, $sol) -> $storage { self.bless(:$size, :$storage, :managed) }
+    }
+}
+```
+
+`LinearArray[MYSQL_BIND].new($n)` returns an object with an empty cache, so
+`$arr[$i]` is `Nil` and every field assignment on it dies with
+`X::Assignment::RO: cannot assign through .buffer on non-instance`.
+
+## A second, separate bug in the same file
+
+A `my` in a **role body** initialised from the role's type parameter reads as 0:
+
+```raku
+role R[::T] {
+    my int $sol = nativesizeof(T);
+    method sizeof() { $sol }
+}
+say R[int64].new.sizeof;    # raku: 8   mutsu: 0
+```
+
+`LinearArray` computes its element stride that way (`my int $sol =
+nativesizeof(T)`), so even with `BUILD` fixed the stride would be 0 and every
+element would alias element 0. Either `T` is not yet bound when the role body's
+`my` runs, or the role-body `my` the method closes over is not the one the body
+initialised.
+
+Reduction for both:
+[`tmp/linear-reduce.raku`](../../tmp) shape is reproduced above; neither needs a
+database, `NativeLibs`, or a native library beyond `calloc`.
+
+## Context
+
+Found while landing [ADR-0015](../../docs/adr/0015-native-backed-container-storage-and-repr-bodies.md)'s
+P1 (`BODY_OF` over a native handle), whose stated acceptance was "`LinearArray`
+allocates, indexes and disposes". The REPR-body mechanism itself is done and
+verified against the real `MoarVM::Guts::REPRs`; these two are what remain
+between it and `LinearArray`, and neither is NativeCall work.


### PR DESCRIPTION
[ADR-0015](https://github.com/tokuhirom/mutsu/blob/main/docs/adr/0015-native-backed-container-storage-and-repr-bodies.md)'s
**P1b**. `MoarVM::Guts::REPRs`' `BODY_OF` — how every `NativeHelpers` entry point
gets at a container's element pointer — now works on mutsu for a `nativecast`ed
handle:

```raku
my $r = nativecast(Rec, $blk);
say BODY_OF($r).cstruct.Int;    # the struct's address, on both implementations
```

Verified against the **real** `MoarVM::Guts::REPRs` from the zef store, not a
local imitation.

### The two halves must land together

`BODY_OF` dispatches on `.REPR` and then *dereferences* `.WHERE`, so answering
`.REPR` honestly is a promise that a REPR body sits at `.WHERE`. Doing only the
first half is not a cosmetic bug — the module read wild memory and mutsu
**segfaulted**. That is the safety rule ADR-0015 §2.1 states, now measured rather
than hypothesised, and it is enforced by construction here: only an object whose
whole identity *is* a C address gets the honest name, and it gets a body in the
same breath.

### The body needed no new machinery

mutsu's `.WHERE` contract (set when `NativeHelpers::Blob` was first made to load)
is "points straight at the payload, no object header" — the module's probe
computes `Offset` as 0. And `native_object_where` already hands out a zero-filled
block whose first word is the address. That block **is** the CStruct body
(`{void* cstruct; void** child_objs}`) byte for byte, and it is also the CArray
body (`{void* storage; void** child; i32 managed; i32 allocated; i32 elems}`) for
an unmanaged cast: storage set, `managed`/`elems` zero — exactly what an unmanaged
`CArray` handle is.

### What deliberately still says `P6opaque`

A CStruct constructed in Raku, and every `Buf`. They have no C storage yet, so the
honest name would promise a body that is not there and `BODY_OF` would quietly
read a NULL one instead of refusing. Under-reporting keeps it loud. Giving them
real storage is P2/P3.

### Two bugs found on the way

Both from shortening a qualified type name by splitting on the last `::` of the
**whole string**:

- `Pointer[MoarVM::Guts::REPRs::CStructB]` became the nonsense class `CStructB]`,
  so a `nativecast` through a qualified body type produced an unusable handle.
- A field type written inside a module arrives carrying that module's package
  (`MoarVM::Guts::REPRs::Pointer[Pointer]`) and was not recognised as a pointer at
  all — and an unmarshallable field aborts the whole layout by design, so the body
  struct had *no layout* and none of its fields could be read.

Shortening now leaves the type argument alone.

### Testing

- `t/nativecall-repr-body.t` — new, 15 tests. Its body-reading half **scans for
  the body the way the module does** rather than assuming an offset, so those 11
  pass identically under `raku`; the 3 that pin mutsu's deliberate under-report are
  marked as such (raku answers `CStruct`/`VMArray` there).
- `make test` — 2531 files / 24228 tests, all pass.
- 499 whitelisted `S02`/`S12`/`S32` roast files: pass. (`S32-io/spurt.t` needed the
  documented `rm -f temp-file-RT-126006-test` first; the encode-decode files need
  `scripts/run-roast-test.sh` rather than a bare `prove -e`.)

### Recorded, not fixed

ADR-0015 named `LinearArray` as P1's acceptance. The mechanism is done, but two
**non-NativeCall** bugs still stand between it and `LinearArray`: a punned
*parameterised* role never runs its `BUILD`, and a `my` in a role body initialised
from the role's type parameter reads as 0. Both reduced to a few lines in
`todo/tickets/parameterised-role-pun-skips-build.md`.

Note: an earlier revision of this branch also fixed CStruct fields being shadowed
by builtin methods; #5502 landed a better version of that fix meanwhile (it routes
through accessor resolution), so the duplicate was dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)