### PR TITLE
fix(regex): run side-effect code blocks inline and let :my lexicals reach later atoms

### DIFF
--- a/news/2026-07/regex-inline-code-blocks-and-my-lexicals.md
+++ b/news/2026-07/regex-inline-code-blocks-and-my-lexicals.md
@@ -1,0 +1,91 @@
+# Regex `{ … }` side-effect blocks run inline, and in-regex `:my` lexicals reach the atoms after them
+
+A plain `{ code }` block inside a regex used to be **deferred**: it was recorded
+in `RegexCaptures::code_blocks` during the match and executed afterwards, on the
+reduce-time walk that also commits `make`. Raku instead runs it immediately,
+left-to-right, while matching — which matters because the whole point of such a
+block is usually to compute something the *following* atoms depend on:
+
+```raku
+grammar L { token TOP { :my $x = 'n'; { $x = 'y' } <?{ $x eq 'y' }> 'z' } }
+L.parse('z')      # raku: matches.  mutsu, before: no match.
+```
+
+## What changed
+
+A plain block that needs nothing from the reduce-time walk is a pure side-effect
+block and now runs inline on the real interpreter, by the same route ADR-0009
+part B established for `<?{ … }>` code assertions. It is not also recorded for
+the reduce-time replay, so it still runs exactly once.
+
+Two constructs keep the block on the reduce path, because both depend on an
+ordering that only exists after the match:
+
+- **`make`** — a node's AST is built from its *already reduced* children, which
+  is what makes `make $<child>.made` work;
+- **a dynamic variable** (`$*x`) — a rule's `:my $*x` is one binding per match,
+  installed and read back around each node's reduce step, so the node's action
+  method sees its own match's value rather than a sibling's.
+
+`code_block_defers_to_reduce` (`regex_helpers.rs`) draws the line, conservatively:
+anything that might be either keeps the established behaviour.
+
+Writes the block makes to in-regex `:my` / `:let` lexicals are harvested out of
+the env and threaded back through `RegexCaptures::regex_vars`, which the match
+trail already knows how to undo on backtracking, so a write on a path that is
+later abandoned does not survive it. Writes to an *outer* lexical still reach the
+caller's compiled local slots — `'123' ~~ / (\d) { $seen = $/.Str } \d+ /` leaves
+`$seen` set — via the same env-diff bookkeeping the reduce-time replay used;
+assertions keep ADR-0009's cheaper "leave it in `env`" behaviour so the hot
+`<?{ … }>` path does not take on an env snapshot per cursor position.
+
+Three gaps around the same lexicals came out of the work and are fixed with it:
+
+- **Code atoms could not read a `:my` lexical at all.** Neither an assertion nor
+  a block ever had `caps.regex_vars` installed in the env it evaluates in, so
+  `:my $x = 'y'; <?{ $x eq 'y' }>` was reading an outer `$x` — or nothing.
+- **Inline sub-patterns lost them.** A lookaround, a group and an alternative are
+  each matched with a *fresh* capture store, so they neither inherited the
+  enclosing regex's lexicals nor propagated writes back out. A take-scoped
+  `INLINE_REGEX_VARS_SEED` now seeds exactly those, and their arms merge
+  `regex_vars` outward. A *subrule* is a different regex and deliberately does
+  not inherit them.
+- **Subrule arguments were frozen too early.** `instantiate_named_regex_arg_calls`
+  renders argument expressions into the pattern text before the match runs. For
+  an argument naming a `:my` lexical that is a value that does not exist yet, so
+  it baked a permanent `Nil` into the pattern. Such an argument is now left
+  verbatim and re-evaluated at match time, where `make_regex_eval_env` supplies
+  the lexicals.
+
+## Standalone `:` backtrack control
+
+Separately, a solitary `:` — "commit to the atom just matched, never backtrack
+into it" — was rejected outright as `Unrecognized regex metacharacter :`, which
+killed the entire rule containing it. It now sets the per-token `ratchet` flag on
+the token just emitted, which is precisely what the construct means. `::` and
+`:::` are different controls and are untouched, and a `:` with no preceding atom
+still errors, as raku does.
+
+## Why
+
+This is the regex half of the YAMLish battery blocker
+(`todo/deep/yamlish-block-collections-regex-vars.md`). YAMLish measures the
+indentation of every block collection with
+
+```
+token root-block {
+    :my $new-indent;
+    <?before $<sp>=[' ' ** { 0..* } ] { $new-indent = ~$<sp> }>
+    $new-indent
+    [ <value=sequence($new-indent)> | <value=map($new-indent)> ]
+}
+```
+
+which needs every one of the above at once: the block runs inside a lookahead,
+writes a `:my` lexical, and that lexical is then both interpolated as an atom and
+passed as a subrule argument. `YAMLish::Grammar.parse("- 1\n- 2")` now produces
+the byte-identical AST raku produces. `load-yaml` still has three non-regex gaps
+left, recorded in the ticket.
+
+Pins: `t/regex-inline-code-block.t`, `t/regex-standalone-backtrack-control.t` —
+both also pass under raku.

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -219,16 +219,19 @@ impl Interpreter {
         // `<?{ … $/.lc … }>` assertion inside a `token` relies on this (the card
         // grammar's dup check does `%*PLAYED{$/.lc}++`). `$/[n]` still indexes the
         // positional captures on the Match object.
-        env.push((
-            "/".to_string(),
-            Value::make_match_object_with_captures(
-                matched_so_far.to_string(),
-                caps.match_from as i64,
-                (caps.match_from + matched_so_far.chars().count()) as i64,
-                &caps.positional,
-                &caps.named,
-            ),
-        ));
+        let cursor = Value::make_match_object_with_captures(
+            matched_so_far.to_string(),
+            caps.match_from as i64,
+            (caps.match_from + matched_so_far.chars().count()) as i64,
+            &caps.positional,
+            &caps.named,
+        );
+        // `$¢` is the current match state at this point in the pattern — the same
+        // object as `$/` here (`/ .{ $c = $¢ } /` must leave `$c` with a usable
+        // `.pos`, roast/S05-capture/match-object.t). The reduce-time replay always
+        // installed both; running inline has to as well.
+        env.push(("\u{00A2}".to_string(), cursor.clone()));
+        env.push(("/".to_string(), cursor));
         // When the assertion references `.made` AND we are inside a
         // `Grammar.parse(:actions(...))`, run the relevant action method on each
         // just-matched named capture so `$<x>.made` is available *during* the

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -88,12 +88,9 @@ impl Interpreter {
         target: &str,
     ) -> Option<String> {
         let mut env = self.make_regex_eval_env(caps);
-        // Set $_ to the match target string
+        // Set $_ to the match target string. After `make_regex_eval_env`, which
+        // installs the `:my`/`:let` lexicals — the topic must win over them.
         env.insert("_".to_string(), Value::str(target.to_string()));
-        // Add variables declared via :my inside the regex
-        for (k, v) in &caps.regex_vars {
-            env.insert(k.clone(), v.clone());
-        }
         let (stmts, _) = crate::parse_dispatch::parse_source(code).ok()?;
         let mut interp = Interpreter {
             env,
@@ -165,31 +162,54 @@ impl Interpreter {
         }
     }
 
-    /// Evaluate a code assertion inside a regex, **on this interpreter**.
+    /// Run one inline regex code atom — a `<?{ … }>` / `<!{ … }>` assertion or a
+    /// plain `{ … }` side-effect block — **on this interpreter**.
     ///
-    /// Raku semantics: the assertion runs inline, once, where the cursor reaches
-    /// it, and its side effects are real — visible to later assertions in the same
-    /// match, and surviving a match that ultimately fails. `advent2013-day18` needs
-    /// all three (`%*PLAYED{$card}++` must be visible to the next card's assertion;
+    /// Raku semantics: the code runs inline, once, where the cursor reaches it,
+    /// and its side effects are real — visible to later atoms in the same match,
+    /// and surviving a match that ultimately fails. `advent2013-day18` needs all
+    /// three (`%*PLAYED{$card}++` must be visible to the next card's assertion;
     /// `@dups.push` must survive the failing parses). A scratch interpreter cannot
     /// provide any of them, so this runs in `self` (ADR-0009 part B).
     ///
-    /// Only the *regex-internal* bindings this sets up (`$/`, `$0`…, `$<name>`) and
-    /// the assertion's own `my` declarations are scoped: they are saved and
-    /// restored around the body. Every other write is a genuine side effect and is
-    /// left in place — that is the whole point.
-    pub(super) fn eval_regex_code_assertion(
+    /// Only the *regex-internal* bindings this sets up (`$/`, `$0`…, `$<name>`,
+    /// the in-regex `:my`/`:let` lexicals) and the body's own `my` declarations are
+    /// scoped: they are saved and restored around the body. Every other write is a
+    /// genuine side effect and is left in place — that is the whole point.
+    ///
+    /// Returns the body's value (`None` if the code failed to parse or threw) and
+    /// the writes it made to the in-regex lexicals. Those are regex-scoped, so they
+    /// must not stay in `self.env`; the caller threads them back through
+    /// `RegexCaptures::regex_vars`, where the match trail can undo them on
+    /// backtracking.
+    ///
+    /// `writes_back_to_caller` selects how a write to an *outer* lexical is
+    /// propagated. A plain `{ … }` block must reach the caller's compiled local
+    /// slots (`'123' ~~ / (\d) { $seen = $/.Str } \d+ /` has to leave `$seen`
+    /// set), which is the env-diff → `pending_local_updates` bookkeeping the
+    /// reduce-time replay does; an assertion keeps ADR-0009's cheaper behaviour of
+    /// simply leaving the write in `env`, so the hot `<?{ … }>` path does not take
+    /// on a full env snapshot per cursor position.
+    pub(super) fn eval_regex_inline_code(
         &mut self,
         code: &str,
         caps: &RegexCaptures,
         matched_so_far: &str,
-    ) -> bool {
+        writes_back_to_caller: bool,
+    ) -> (Option<Value>, HashMap<String, Value>) {
         let (stmts, _) = match crate::parse_dispatch::parse_source(code) {
             Ok(result) => result,
-            Err(_) => return false,
+            Err(_) => return (None, HashMap::new()),
         };
         // The bindings to install for the body, and to restore afterwards.
         let mut env: Vec<(String, Value)> = Vec::new();
+        // In-regex `:my`/`:let` lexicals (and anything a preceding inline `{ }`
+        // block wrote to them). They are lexical to the regex, so they are
+        // installed here and restored with the rest of the regex bindings —
+        // `:my $x = 'y'; <?{ $x eq 'y' }>` must see 'y', not an outer `$x`.
+        for (k, v) in &caps.regex_vars {
+            env.push((k.clone(), v.clone()));
+        }
         // Set positional capture variables ($0, $1, etc.)
         for (i, val) in caps.positional.iter().enumerate() {
             env.push((i.to_string(), Value::str(val.clone())));
@@ -259,17 +279,53 @@ impl Interpreter {
         for (k, v) in env {
             self.env.insert(k, v);
         }
-        let result = self.eval_block_value(&stmts);
+        // Marks the body as embedded regex code so a bare free variable's
+        // auto-package-qualified write (`$x` inside `grammar G { … }` compiles to
+        // `SetGlobal("G::x")`) is redirected back onto the lexical in `env` —
+        // otherwise the write strands itself in a `G::x` package slot and the
+        // harvest below sees nothing. Same flag the reduce-time replay uses.
+        let result = if writes_back_to_caller {
+            let before = self.pending_local_updates.len();
+            self.eval_regex_code_block_body(&stmts);
+            // The regex's own `:my`/`:let` lexicals are not caller lexicals — they
+            // are harvested into `regex_vars` below and must not be written into
+            // the caller's slots as well.
+            if !caps.regex_vars.is_empty() {
+                let kept: Vec<(String, Value)> = self
+                    .pending_local_updates
+                    .split_off(before)
+                    .into_iter()
+                    .filter(|(name, _)| !caps.regex_vars.contains_key(name))
+                    .collect();
+                self.pending_local_updates.extend(kept);
+            }
+            Ok(Value::NIL)
+        } else {
+            let saved_in_block = self.in_regex_code_block;
+            self.in_regex_code_block = true;
+            let r = self.eval_block_value(&stmts);
+            self.in_regex_code_block = saved_in_block;
+            r
+        };
+        // Harvest writes to the in-regex lexicals *before* restoring them: the
+        // value has to survive as a `regex_vars` delta so a later `$name`
+        // interpolation or `<?{ … }>` assertion in the same match reads it, while
+        // `self.env` goes back to what the enclosing scope had.
+        let mut writes: HashMap<String, Value> = HashMap::new();
+        for k in caps.regex_vars.keys() {
+            if let Some(now) = self.env.get(k)
+                && caps.regex_vars.get(k) != Some(now)
+            {
+                writes.insert(k.clone(), now.clone());
+            }
+        }
         for (k, orig) in saved {
             match orig {
                 Some(v) => self.env.insert(k, v),
                 None => self.env.remove(&k),
             };
         }
-        match result {
-            Ok(val) => val.truthy(),
-            Err(_) => false,
-        }
+        (result.ok(), writes)
     }
 
     /// Build a Match object for each named capture in `caps` and run its grammar

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -72,6 +72,73 @@ thread_local! {
     /// subrules had matched. This log lets the failure path replay them. `Some`
     /// only while an action-driven parse is live.
     pub(crate) static REDUCED_SUBRULES: RefCell<Option<ReducedSubruleLog>> = const { RefCell::new(None) };
+    /// In-regex `:my`/`:let` lexicals to seed the *next* capture store with.
+    ///
+    /// A sub-pattern that is lexically part of the same regex — a lookaround, a
+    /// group, an alternative — is matched with a fresh `CapStore`, which would
+    /// otherwise lose the `:my` lexicals declared before it (YAMLish computes its
+    /// block indent in a `{ … }` inside a `<?before …>` and reads it back after).
+    /// A *subrule* is a different regex and must NOT inherit them, so every other
+    /// atom arms this *empty* for the duration of its match.
+    pub(crate) static INLINE_REGEX_VARS_SEED: RefCell<Option<HashMap<String, Value>>> = const { RefCell::new(None) };
+    /// Whether [`INLINE_REGEX_VARS_SEED`] currently holds anything. Read once per
+    /// atom match to skip the `RefCell` entirely on the overwhelmingly common path
+    /// where no regex in flight declares a `:my`/`:let` lexical.
+    pub(crate) static INLINE_REGEX_VARS_ACTIVE: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Arms the [`INLINE_REGEX_VARS_SEED`] for the duration of one atom match,
+/// restoring the enclosing atom's seed on drop. An atom that is an inline
+/// sub-pattern arms it with the lexicals in scope; every other atom — a subrule
+/// reference above all — arms it *empty*, which is what stops a `:my` lexical
+/// from leaking into a different regex.
+pub(crate) struct InlineVarsSeed {
+    prev: Option<HashMap<String, Value>>,
+    armed: bool,
+}
+
+impl InlineVarsSeed {
+    pub(crate) fn arm(vars: &HashMap<String, Value>) -> Self {
+        let active = INLINE_REGEX_VARS_ACTIVE.with(Cell::get);
+        if vars.is_empty() && !active {
+            // Nothing to publish and nothing published: the atom cannot change
+            // what any nested store would see, so leave the slot untouched.
+            return InlineVarsSeed {
+                prev: None,
+                armed: false,
+            };
+        }
+        let next = if vars.is_empty() {
+            None
+        } else {
+            Some(vars.clone())
+        };
+        INLINE_REGEX_VARS_ACTIVE.with(|f| f.set(next.is_some()));
+        let prev = INLINE_REGEX_VARS_SEED.with(|s| std::mem::replace(&mut *s.borrow_mut(), next));
+        InlineVarsSeed { prev, armed: true }
+    }
+}
+
+impl Drop for InlineVarsSeed {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let prev = self.prev.take();
+        INLINE_REGEX_VARS_ACTIVE.with(|f| f.set(prev.is_some()));
+        INLINE_REGEX_VARS_SEED.with(|s| *s.borrow_mut() = prev);
+    }
+}
+
+/// The in-regex lexicals a freshly built capture store should start from (see
+/// [`INLINE_REGEX_VARS_SEED`]).
+pub(crate) fn take_inline_regex_vars_seed() -> HashMap<String, Value> {
+    if !INLINE_REGEX_VARS_ACTIVE.with(Cell::get) {
+        return HashMap::new();
+    }
+    INLINE_REGEX_VARS_SEED
+        .with(|s| s.borrow().clone())
+        .unwrap_or_default()
 }
 
 /// Hard cap on `ReducedSubruleLog` entries. The log only feeds the *failure*
@@ -151,6 +218,70 @@ impl Drop for ReducedSubruleGuard {
 /// Look up a `$*` dynamic var in the reduce-time overlay (see
 /// `REGEX_DYNVAR_OVERLAY`). `name` is the env form without sigil (e.g. `*LEFT`).
 /// Returns `None` when the overlay is inactive or has no entry for the name.
+/// Must this regex `{ … }` block stay on the **reduce-time** path rather than
+/// running inline during the match?
+///
+/// Two constructs need the post-match bottom-up walk
+/// (`reduce_regex_captures_made`) and cannot be answered while matching:
+///
+/// - `make`, because a node's AST is built from its already-reduced children —
+///   that ordering is what lets `make $<child>.made` work;
+/// - a **dynamic** variable (`$*x`), because a rule's `:my $*x` is one binding
+///   per match, installed and read back around each node's reduce step
+///   (`install_fresh_rule_dynvars` / `record_rule_dynvars`) so the node's action
+///   method sees its own match's value.
+///
+/// Everything else is a pure side-effect block and runs inline, as raku does, so
+/// its writes are visible to the atoms that follow it in the same match.
+///
+/// The scan is deliberately conservative — anything that *might* be one of the
+/// two keeps the established deferred behaviour. `make` matches the bare
+/// identifier (which also covers the `$/.make(…)` method form via the trailing
+/// `.`) but not a longer identifier containing it (`maker`, `remake`) nor a
+/// variable named `$make`.
+pub(crate) fn code_block_defers_to_reduce(code: &str) -> bool {
+    if code_block_uses_dynamic_var(code) {
+        return true;
+    }
+    let bytes = code.as_bytes();
+    let mut idx = 0;
+    while let Some(rel) = code[idx..].find("make") {
+        let start = idx + rel;
+        let end = start + 4;
+        let prev_ok = match start.checked_sub(1).map(|i| bytes[i]) {
+            None => true,
+            Some(c) => {
+                !(c.is_ascii_alphanumeric()
+                    || c == b'_'
+                    || c == b'$'
+                    || c == b'@'
+                    || c == b'%'
+                    || c == b'&'
+                    || c == b'-')
+            }
+        };
+        let next_ok = match bytes.get(end).copied() {
+            None => true,
+            Some(c) => !(c.is_ascii_alphanumeric() || c == b'_' || c == b'-'),
+        };
+        if prev_ok && next_ok {
+            return true;
+        }
+        idx = end;
+    }
+    false
+}
+
+/// Does the block mention a dynamic variable (`$*x`, `@*x`, `%*x`)?
+fn code_block_uses_dynamic_var(code: &str) -> bool {
+    let bytes = code.as_bytes();
+    bytes.windows(3).any(|w| {
+        matches!(w[0], b'$' | b'@' | b'%')
+            && w[1] == b'*'
+            && (w[2].is_ascii_alphabetic() || w[2] == b'_')
+    })
+}
+
 pub(crate) fn dynvar_overlay_get(name: &str) -> Option<Value> {
     REGEX_DYNVAR_OVERLAY.with(|slot| slot.borrow().as_ref().and_then(|m| m.get(name).cloned()))
 }

--- a/src/runtime/regex/regex_interpolate.rs
+++ b/src/runtime/regex/regex_interpolate.rs
@@ -384,6 +384,18 @@ impl Interpreter {
         out
     }
 
+    /// Does this argument expression mention a `:my`/`:let` lexical of the regex
+    /// it appears in? Such an expression has to stay unrendered (see
+    /// [`Self::instantiate_named_regex_arg_calls`]).
+    fn regex_arg_names_local(arg: &str, locals: &std::collections::HashSet<String>) -> bool {
+        if locals.is_empty() {
+            return false;
+        }
+        crate::runtime::regex_parse_core::scalar_names_in_decl(arg)
+            .iter()
+            .any(|n| locals.contains(n))
+    }
+
     pub(in crate::runtime) fn instantiate_named_regex_arg_calls(
         &mut self,
         pattern: &str,
@@ -391,6 +403,12 @@ impl Interpreter {
         let chars: Vec<char> = pattern.chars().collect();
         let mut out = String::new();
         let default_caps = RegexCaptures::default();
+        // An argument naming an in-regex `:my`/`:let` lexical must NOT be rendered
+        // here: this pass runs before the match, when that lexical has no value
+        // yet, and baking the resulting `Nil` into the pattern text is permanent.
+        // Left verbatim, it is re-evaluated at match time against the live
+        // captures (`eval_regex_arg_list`), which is where the value exists.
+        let regex_local_vars = crate::runtime::regex_parse_core::declared_regex_var_names(pattern);
         let mut i = 0usize;
         while i < chars.len() {
             if chars[i] != '<' {
@@ -504,7 +522,9 @@ impl Interpreter {
                 // For complex / non-round-trippable values (Pair, Slip, Array, Hash, ...),
                 // keep the original argument expression so the match-time evaluator can
                 // re-evaluate and route them as named arguments or flatten Slips.
-                if Self::regex_arg_is_complex(arg) {
+                if Self::regex_arg_is_complex(arg)
+                    || Self::regex_arg_names_local(arg, &regex_local_vars)
+                {
                     rendered_args.push(arg.clone());
                     continue;
                 }

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -67,6 +67,7 @@ impl Interpreter {
         // store and rewinds it on backtrack. `current_caps` is the engine's
         // accumulated store, passed for READS only (backrefs, code assertions,
         // subrule argument evaluation) — it must never be cloned into results.
+        let _vars_seed = Self::arm_inline_vars_seed(atom, current_caps);
 
         if let RegexAtom::Alternation(alternatives) = atom {
             // | (LTM): try all alternatives, longest match wins.

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -3,6 +3,36 @@ use super::super::*;
 use super::regex_helpers::{is_word_char, matches_named_builtin, merge_regex_captures};
 
 impl Interpreter {
+    /// Is this atom an inline sub-pattern — part of the *same* regex, just matched
+    /// with its own capture store? Those inherit the enclosing regex's `:my`/`:let`
+    /// lexicals; a subrule reference (a different regex) must not.
+    fn atom_is_inline_subpattern(atom: &RegexAtom) -> bool {
+        matches!(
+            atom,
+            RegexAtom::Group(_)
+                | RegexAtom::CaptureGroup(_)
+                | RegexAtom::Alternation(_)
+                | RegexAtom::SequentialAlternation(_)
+                | RegexAtom::Conjunction(_)
+                | RegexAtom::Lookaround { .. }
+                | RegexAtom::GoalMatch { .. }
+        )
+    }
+
+    /// Publish (or deliberately withhold) the in-regex lexicals for the sub-pattern
+    /// matches this atom is about to run. See
+    /// [`super::regex_helpers::INLINE_REGEX_VARS_SEED`].
+    pub(super) fn arm_inline_vars_seed(
+        atom: &RegexAtom,
+        current_caps: &RegexCaptures,
+    ) -> super::regex_helpers::InlineVarsSeed {
+        if Self::atom_is_inline_subpattern(atom) {
+            super::regex_helpers::InlineVarsSeed::arm(&current_caps.regex_vars)
+        } else {
+            super::regex_helpers::InlineVarsSeed::arm(&HashMap::new())
+        }
+    }
+
     /// Single-candidate atom matcher: the atom's highest-priority match only.
     /// The returned captures are a DELTA relative to an EMPTY baseline
     /// (ADR-0007); `current_caps` is the engine's accumulated store, passed
@@ -16,6 +46,7 @@ impl Interpreter {
         pkg: &str,
         ignore_case: bool,
     ) -> Option<(usize, RegexCaptures)> {
+        let _vars_seed = Self::arm_inline_vars_seed(atom, current_caps);
         // Handle zero-width and group atoms before the length check
         match atom {
             RegexAtom::Group(pattern) => {
@@ -50,6 +81,10 @@ impl Interpreter {
                         if inner_caps.capture_end.is_some() {
                             new_caps.capture_end = inner_caps.capture_end;
                         }
+                        // Writes an inline `{ … }` made to the regex's `:my`
+                        // lexicals are part of the same lexical scope as the
+                        // enclosing pattern, so they leave the group with it.
+                        new_caps.regex_vars.extend(inner_caps.regex_vars);
                         (next, new_caps)
                     });
             }
@@ -102,6 +137,7 @@ impl Interpreter {
                             .positional_quantified
                             .append(&mut inner_caps.positional_quantified);
                         new_caps.code_blocks.append(&mut inner_caps.code_blocks);
+                        new_caps.regex_vars.extend(inner_caps.regex_vars);
                         let replace = best
                             .as_ref()
                             .map(|(best_next, _)| next > *best_next)
@@ -148,6 +184,7 @@ impl Interpreter {
                             .positional_quantified
                             .append(&mut inner_caps.positional_quantified);
                         new_caps.code_blocks.append(&mut inner_caps.code_blocks);
+                        new_caps.regex_vars.extend(inner_caps.regex_vars);
                         return Some((next, new_caps));
                     }
                 }
@@ -172,25 +209,39 @@ impl Interpreter {
                 negated,
                 is_behind,
             } => {
+                let mut inner_vars: HashMap<String, Value> = HashMap::new();
                 let matched = if *is_behind {
                     let mut found = false;
                     for start in 0..=pos {
-                        if self
-                            .regex_match_end_from_caps_in_pkg(pattern, chars, start, pkg)
-                            .is_some_and(|(end, _)| end == pos)
+                        if let Some((end, inner)) =
+                            self.regex_match_end_from_caps_in_pkg(pattern, chars, start, pkg)
+                            && end == pos
                         {
+                            inner_vars = inner.regex_vars;
                             found = true;
                             break;
                         }
                     }
                     found
                 } else {
-                    self.regex_match_end_from_caps_in_pkg(pattern, chars, pos, pkg)
-                        .is_some()
+                    match self.regex_match_end_from_caps_in_pkg(pattern, chars, pos, pkg) {
+                        Some((_, inner)) => {
+                            inner_vars = inner.regex_vars;
+                            true
+                        }
+                        None => false,
+                    }
                 };
                 let pass = if *negated { !matched } else { matched };
                 return if pass {
-                    Some((pos, RegexCaptures::default()))
+                    // A lookaround consumes nothing and publishes no captures, but a
+                    // `{ … }` inside it did run: its writes to the enclosing regex's
+                    // `:my` lexicals are real and must survive (YAMLish's `root-block`
+                    // measures the indent in a `<?before … { … } >` and matches it
+                    // afterwards).
+                    let mut new_caps = RegexCaptures::default();
+                    new_caps.regex_vars.extend(inner_vars);
+                    Some((pos, new_caps))
                 } else {
                     None
                 };
@@ -261,18 +312,36 @@ impl Interpreter {
                     // (ADR-0009 part B). It is therefore NOT recorded as a code block
                     // for `execute_regex_code_blocks` to replay on the winning path —
                     // that replay would run it a second time.
-                    let result =
-                        self.eval_regex_code_assertion(code, current_caps, &matched_so_far);
+                    let (value, writes) =
+                        self.eval_regex_inline_code(code, current_caps, &matched_so_far, false);
+                    let result = value.map(|v| v.truthy()).unwrap_or(false);
                     let pass = if *negated { !result } else { result };
                     if pass {
-                        return Some((pos, RegexCaptures::default()));
+                        let mut new_caps = RegexCaptures::default();
+                        new_caps.regex_vars.extend(writes);
+                        return Some((pos, new_caps));
                     } else {
                         return None;
                     }
                 }
-                // Plain { code } block — always succeeds, record for side effects
-                let mut new_caps = RegexCaptures::default();
                 let matched_so_far: String = chars[current_caps.match_from..pos].iter().collect();
+                // A plain `{ … }` block that needs nothing from the reduce-time
+                // walk is a pure side-effect block: raku runs it inline,
+                // left-to-right, during matching, so a write to an in-regex `:my`
+                // lexical is visible to the atoms that follow it (YAMLish's
+                // `root-block` computes its indent this way). Run it here instead
+                // of recording it for the reduce-time replay — recording it as
+                // well would execute it twice.
+                if !super::regex_helpers::code_block_defers_to_reduce(code) {
+                    let (_value, writes) =
+                        self.eval_regex_inline_code(code, current_caps, &matched_so_far, true);
+                    let mut new_caps = RegexCaptures::default();
+                    new_caps.regex_vars.extend(writes);
+                    return Some((pos, new_caps));
+                }
+                // A `make`- or dynamic-variable-bearing block needs the ordering
+                // the bottom-up reduce walk provides, so it stays on that path.
+                let mut new_caps = RegexCaptures::default();
                 let ctx = CodeBlockContext {
                     code: code.clone(),
                     named: current_caps.named.clone(),
@@ -424,6 +493,14 @@ impl Interpreter {
                     let _ = interp.eval_block_value(&stmts);
                     let mut new_caps = RegexCaptures::default();
                     for (k, v) in &interp.env {
+                        // The topic is not a `:my` declaration — the scratch run
+                        // leaves `$_` holding the declaration's value, and
+                        // recording it would let a later code block / assertion
+                        // (which installs `regex_vars` into its env) see that stale
+                        // value as `$_` instead of the real topic.
+                        if k.resolve() == "_" {
+                            continue;
+                        }
                         if !self.env.contains_key_sym(*k) || self.env.get_sym(*k) != Some(v) {
                             new_caps.regex_vars.insert(k.resolve(), v.clone());
                         }

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -153,6 +153,11 @@ impl Interpreter {
         }
         let mut store = CapStore::new(RegexCaptures {
             match_from: start,
+            // Inline sub-patterns (lookaround/group/alternative) inherit the
+            // enclosing regex's `:my`/`:let` lexicals; a subrule does not. The
+            // seed is take-once, so only the store the arming site is about to
+            // build gets it.
+            regex_vars: super::regex_helpers::take_inline_regex_vars_seed(),
             ..Default::default()
         });
         let mut matches = Vec::new();

--- a/src/runtime/regex/regex_resolve.rs
+++ b/src/runtime/regex/regex_resolve.rs
@@ -499,6 +499,13 @@ impl Interpreter {
             };
             env.insert(format!("<{}>", k), value);
         }
+        // In-regex `:my`/`:let` lexicals, so an expression evaluated mid-match —
+        // a subrule argument `<sequence($new-indent)>`, a `<{ … }>` interpolation,
+        // a dynamic quantifier — reads the value the regex computed rather than an
+        // outer variable of the same name (or nothing at all).
+        for (k, v) in &caps.regex_vars {
+            env.insert(k.clone(), v.clone());
+        }
         env
     }
 

--- a/src/runtime/regex_parse_core.rs
+++ b/src/runtime/regex_parse_core.rs
@@ -143,6 +143,32 @@ fn is_subrule_lookahead_name(s: &str) -> bool {
 /// as `my $x = ''`, `my $new-indent`, or `my ($a, $b)`. Returns the bare names
 /// without the `$` sigil (`x`, `new-indent`, `a`, `b`). Only `$`-sigil names are
 /// collected — `@`/`%` interpolations are not handled as literal backreferences.
+/// The scalar names a pattern introduces with an in-regex `:my` / `:let`
+/// declaration. Their values only exist *while matching* (a `{ … }` block
+/// commonly computes them), so any pre-pass that would bake a value into the
+/// pattern text has to leave references to them alone.
+pub(crate) fn declared_regex_var_names(pattern: &str) -> std::collections::HashSet<String> {
+    let mut names = std::collections::HashSet::new();
+    let bytes: Vec<char> = pattern.chars().collect();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i] == ':' {
+            let rest: String = bytes[i + 1..].iter().collect();
+            if rest.starts_with("my ") || rest.starts_with("let ") {
+                let start = i;
+                while i < bytes.len() && bytes[i] != ';' {
+                    i += 1;
+                }
+                let decl: String = bytes[start..i.min(bytes.len())].iter().collect();
+                names.extend(scalar_names_in_decl(&decl));
+                continue;
+            }
+        }
+        i += 1;
+    }
+    names
+}
+
 pub(super) fn scalar_names_in_decl(code: &str) -> Vec<String> {
     let chars: Vec<char> = code.chars().collect();
     let mut names = Vec::new();
@@ -1188,6 +1214,24 @@ impl Interpreter {
                     let consumed = remaining.len() - modifier_rest.len();
                     for _ in 0..consumed {
                         chars.next();
+                    }
+                    continue;
+                }
+                // Standalone backtrack control `:` — "commit to the atom just
+                // matched, never backtrack into it" (`token key { <.plainfirst> :
+                // <-[\:\#]>* }`). It is not a modifier and not a `:my` decl: it
+                // ratchets the token already emitted, which is exactly what the
+                // per-token `ratchet` flag means. `::` / `:::` are *different*
+                // controls and are left alone here. With no preceding atom the
+                // construct is an error, which the validator below reports.
+                if !tokens.is_empty()
+                    && chars.peek() != Some(&':')
+                    && chars
+                        .peek()
+                        .is_none_or(|ch| !ch.is_alphanumeric() && !matches!(ch, '_' | '!' | '('))
+                {
+                    if let Some(last) = tokens.last_mut() {
+                        last.ratchet = true;
                     }
                     continue;
                 }

--- a/t/regex-inline-code-block.t
+++ b/t/regex-inline-code-block.t
@@ -1,0 +1,97 @@
+use Test;
+
+plan 13;
+
+# A plain `{ … }` block inside a regex runs INLINE, left-to-right, during the
+# match (raku semantics) — not deferred until the match has finished. Its writes
+# to in-regex `:my`/`:let` lexicals are therefore visible to the atoms that come
+# after it in the same match.
+
+# 1. A `<?{ … }>` assertion sees a `:my`-declared lexical.
+grammar AssertSeesMy {
+    token TOP { :my $x = 'y'; <?{ $x eq 'y' }> 'z' }
+}
+ok AssertSeesMy.parse('z').defined, 'code assertion reads an in-regex :my lexical';
+
+# 2. An inline block writes the lexical; a later assertion sees the new value.
+grammar BlockThenAssert {
+    token TOP { :my $x = 'n'; { $x = 'y' } <?{ $x eq 'y' }> 'z' }
+}
+ok BlockThenAssert.parse('z').defined, 'inline block write is visible to a later assertion';
+
+# 3. An inline block writes the lexical; a later interpolation matches its value.
+grammar BlockThenInterp {
+    token TOP { :my $x = 'n'; { $x = 'ab' } $x 'c' }
+}
+ok BlockThenInterp.parse('abc').defined, 'inline block write is visible to a later interpolation';
+nok BlockThenInterp.parse('nc').defined, 'the pre-block value no longer matches';
+
+# 4. The block may sit inside a lookahead — the lookaround consumes nothing, but
+#    the write it performed is real. This is how YAMLish measures block indent.
+grammar IndentProbe {
+    token TOP {
+        :my $indent;
+        <?before $<sp>=[ ' '* ] { $indent = ~$<sp> }>
+        $indent 'x'
+    }
+}
+ok IndentProbe.parse('x').defined,     'lookahead-computed indent, empty';
+ok IndentProbe.parse('   x').defined,  'lookahead-computed indent, three spaces';
+
+# 5. The lexical also reaches a subrule ARGUMENT expression.
+grammar ArgFromMy {
+    token TOP {
+        :my $indent;
+        <?before $<sp>=[ ' '* ] { $indent = ~$<sp> }>
+        $indent <tail($indent)>
+    }
+    token tail(Str $ind) { 'a' [ "\n" $ind 'a' ]* }
+}
+ok ArgFromMy.parse("  a\n  a").defined, ':my lexical passed as a subrule argument';
+
+# 6. A `:my` lexical belongs to ITS regex. A subrule is a different regex, so it
+#    resolves the same name against its own enclosing scope, not the caller's.
+{
+    my $shared = 'q';
+    grammar NoLeakIntoSubrule {
+        token TOP { :my $shared = 'zz'; <inner> }
+        token inner { $shared }
+    }
+    # Pre-existing gap (also fails before this change): the caller's `:my` keeps
+    # the subrule's own pre-substitution from resolving the outer lexical, so the
+    # subrule interpolates nothing at all. The important half — that the caller's
+    # VALUE does not leak in — holds either way.
+    todo 'caller :my suppresses the subrule\'s own outer-lexical substitution';
+    ok NoLeakIntoSubrule.parse('q').defined,     'a subrule sees the outer lexical, not the caller regex\'s :my';
+    nok NoLeakIntoSubrule.parse('zz').defined,   'the caller regex\'s :my value does not leak into the subrule';
+}
+
+# 7. Running blocks inline must not disturb the two things that already worked:
+#    a plain block's side effect on an outer variable, and `make`.
+my @log;
+grammar SideEffect {
+    token TOP { 'q' { @log.push('hit') } }
+}
+SideEffect.parse('q');
+is @log.join(','), 'hit', 'a plain block still has its outer side effect, exactly once';
+
+grammar Made {
+    token TOP { <n> { make $<n>.made * 2 } }
+    token n { (\d+) { make +$0 } }
+}
+is Made.parse('21').made, 42, 'make still reduces bottom-up over the match tree';
+
+# 8. The deferral split is on what a block NEEDS from the reduce walk. A `:my $*x`
+#    dynamic variable is one binding per match, installed and read back around
+#    each node's reduce step, so a block that writes one must stay deferred.
+grammar PerMatchDynvar {
+    token TOP { <part>+ % ',' }
+    token part { :my $*V = 'decl'; \w+ [ <?before ','> { $*V = 'set' } ]? { make $*V } }
+}
+is PerMatchDynvar.parse('a,b')<part>.map(*.ast).join('|'), 'set|decl',
+    'a block writing a per-match dynamic variable still reduces per match';
+
+# 9. ...while a block writing a plain OUTER lexical still reaches the caller's slots.
+my $seen;
+'123' ~~ / (\d) { $seen = $/.Str } \d+ /;
+is $seen, '1', 'an inline block still writes back to a caller lexical';

--- a/t/regex-inline-code-block.t
+++ b/t/regex-inline-code-block.t
@@ -1,6 +1,6 @@
 use Test;
 
-plan 13;
+plan 14;
 
 # A plain `{ … }` block inside a regex runs INLINE, left-to-right, during the
 # match (raku semantics) — not deferred until the match has finished. Its writes
@@ -95,3 +95,9 @@ is PerMatchDynvar.parse('a,b')<part>.map(*.ast).join('|'), 'set|decl',
 my $seen;
 '123' ~~ / (\d) { $seen = $/.Str } \d+ /;
 is $seen, '1', 'an inline block still writes back to a caller lexical';
+
+# 10. `$¢`, the match state at this point in the pattern, is bound too — the
+#     reduce-time replay always installed it, so running inline must as well.
+my $cursor;
+'abc' ~~ / . { $cursor = $¢ } /;
+ok defined($cursor) && defined($cursor.pos), 'an inline block sees $¢ with a usable .pos';

--- a/t/regex-standalone-backtrack-control.t
+++ b/t/regex-standalone-backtrack-control.t
@@ -1,0 +1,31 @@
+use Test;
+
+plan 7;
+
+# `:` on its own is the backtrack control "commit to the atom just matched" — a
+# ratchet on the PRECEDING atom, not a modifier and not a `:my` declaration. It
+# was rejected outright ("Unrecognized regex metacharacter :"), which killed the
+# whole rule it appeared in (YAMLish writes its key token this way).
+# Note raku only accepts it after a plain, unquantified atom.
+
+grammar Ratchets {
+    token space { <[\ \t]> }
+    token pf    { <-[\-\?\:\,\#\ \t]> }
+
+    token pair     { 'a' : 'b' }
+    token triple   { 'a' : 'b' : 'c' }
+    token classes  { <[a..z]> : <[a..z]> }
+    token subrule  { <.pf> : <-[\:\#]>* }
+    token captured { $<v>=[ <.pf> : <-[\:\#]>* ] }
+    token trailing { <.pf> <-[\:\#]>* <!after <.space>> : }
+}
+
+ok Ratchets.parse('ab',  :rule<pair>).defined,    'a solitary `:` between two literals';
+ok Ratchets.parse('abc', :rule<triple>).defined,  'two solitary `:` controls in one rule';
+ok Ratchets.parse('ab',  :rule<classes>).defined, '`:` after a character class';
+ok Ratchets.parse('ab',  :rule<subrule>).defined, '`:` after a non-capturing subrule call';
+ok Ratchets.parse('ab',  :rule<trailing>).defined, '`:` after a zero-width assertion';
+
+my $c = Ratchets.parse('ab', :rule<captured>);
+ok $c.defined, '`:` inside a named capture group';
+is ~$c<v>, 'ab', 'the capture still spans the whole group';

--- a/todo/deep/yamlish-block-collections-regex-vars.md
+++ b/todo/deep/yamlish-block-collections-regex-vars.md
@@ -1,4 +1,12 @@
-# YAMLish battery: block collections need match-time regex `:my` vars + inline code blocks
+# YAMLish battery: block collections — regex side DONE, three downstream gaps left
+
+**Status 2026-07-28.** The regex half of this ticket is finished: `(a)` and `(b)`
+below are both implemented, plus two gaps they exposed. `YAMLish::Grammar.parse`
+now returns the **byte-identical AST raku produces** for a block sequence
+(`- 1\n- 2`, `- x\n- y`). What is left is no longer regex work — see
+"Remaining after the regex work" at the bottom.
+
+
 
 Blocker chain for the **YAMLish** battery (`zef:leont`, safe-by-default YAML, 459
 dependents — `docs/batteries/yaml.md`). The **scalar path now works**:
@@ -24,7 +32,7 @@ missing regex-engine features.
    any `<?name>`/`<!name>` naming a subrule to a `Lookaround` wrapping
    `Named(subrule)`. PR #5459, pin `t/regex-subrule-lookahead-assertion.t`.
 
-## Remaining blocker: the indentation machinery (two deep regex features)
+## The indentation machinery (was the blocker; now resolved)
 
 Every block collection goes through `root-block` / `block`:
 
@@ -37,12 +45,9 @@ token root-block {
 }
 ```
 
-Proof this is the *only* remaining gate: replacing the `:my $new-indent` +
-interpolation with a param-passed empty indent (`<sequence('')>`) makes
-`- 1\n- 2` parse in mutsu today (`tmp/noindent.raku` → MATCH). Dynamic
-quantifiers (`' ' ** { 0..* }`), `$<sp>=[...]` captures, and separated
-quantifiers (`+ % [ <.newline> $indent ]`) all already work. What does *not*
-work:
+Dynamic quantifiers (`' ' ** { 0..* }`), `$<sp>=[...]` captures and separated
+quantifiers (`+ % [ <.newline> $indent ]`) already worked; what did not is
+below.
 
 ### (a) Match-time interpolation of a `:my`-declared regex var — DONE
 
@@ -65,37 +70,81 @@ not needed for YAMLish.
 This does **not** unblock YAMLish by itself: `root-block` uses `:my $new-indent;`
 with **no initializer** and computes the value in a code block (needs (b)).
 
-### (b) Inline execution of `{ code }` side-effect blocks during matching
+### (b) Inline execution of `{ code }` side-effect blocks during matching — DONE
 
 ```raku
 grammar L { token TOP { :my $x = 'n'; { $x = 'y' } <?{ $x eq 'y' }> 'z' } }
-L.parse("z")     # raku: MATCH ; mutsu: NO ("Use of Nil in string context")
+L.parse("z")     # now MATCHes
 ```
 
-mutsu **defers** plain `{ code }` blocks (stored in `caps.code_blocks`, run after
-match for `make`/side effects). Raku runs them **immediately, left-to-right,
-during matching**, so a `{ $x = ~$<sp> }` write is visible to the following
-`$new-indent` interpolation and `<?{…}>` assertions. This is the harder half:
-side-effect blocks must execute inline and write to `caps.regex_vars`, while the
-writes must be **undone on backtracking** (the `regex_trail` already snapshots
-`regex_vars` — see `src/runtime/regex/regex_trail.rs:325`). `{ make … }` must
-still behave as today (its result is carried at reduce time and must not change
-the match). Distinguishing "side-effect block" from "make block" and threading
-the writes through backtracking is the design work — likely ADR-worthy, high
-blast radius (touches every regex with a `{ }` block).
+mutsu used to **defer** every plain `{ code }` block (stored in
+`caps.code_blocks`, run after the match for `make`/side effects), so a
+`{ $x = ~$<sp> }` write was invisible to the atoms after it. Implemented: a plain
+block that needs nothing from the reduce walk is a pure side-effect block and now
+runs inline, left-to-right, on the real interpreter — the same route ADR-0009
+part B established for `<?{ … }>` — and is *not* recorded for the reduce-time
+replay, so it still runs exactly once. Two constructs keep a block deferred,
+because both need post-match ordering: **`make`** (a node's AST is built from its
+already-reduced children) and a **dynamic variable** `$*x` (a rule's `:my $*x` is
+one binding per match, installed/read back around each node's reduce step).
+`code_block_defers_to_reduce` in `regex_helpers.rs` splits the two. Writes to the
+in-regex `:my`/`:let` lexicals are harvested out of `env` and threaded back
+through `RegexCaptures::regex_vars`, which `regex_trail` already undoes on
+backtracking; writes to an *outer* lexical still reach the caller's compiled
+slots via the reduce path's env-diff bookkeeping.
 
-## Order / recommendation
+Three gaps fell out of it and were fixed in the same slice:
 
-1. ✅ (a) DONE — `t/regex-my-var-interpolation.t`.
-2. Then design (b): inline side-effect code blocks with backtrack-safe
-   `regex_vars` writes, keeping `make` deferral intact. With (a)+(b),
-   `Grammar.parse` of `- 1\n- 2` / `a: 1` should reduce, and `load-yaml` should
-   round-trip block collections.
+- `<?{ … }>` / `{ … }` never had `caps.regex_vars` installed in their env, so an
+  assertion could not read a `:my` lexical at all.
+- A lookaround / group / alternative is matched with a **fresh** capture store, so
+  it neither saw the enclosing regex's `:my` lexicals nor propagated writes back
+  out — which is exactly the shape `root-block` uses. A take-scoped
+  `INLINE_REGEX_VARS_SEED` now seeds inline sub-patterns (and deliberately *not*
+  subrules, which are a different regex), and those arms merge `regex_vars` out.
+- `instantiate_named_regex_arg_calls` pre-rendered subrule **arguments** before
+  the match, baking the not-yet-computed `Nil` into the pattern text permanently
+  (`<value=sequence($new-indent)>`). An argument naming a `:my`/`:let` lexical is
+  now left verbatim and re-evaluated at match time, and `make_regex_eval_env`
+  installs the lexicals so it resolves.
+
+Pin: `t/regex-inline-code-block.t` (11 tests, all also pass under raku).
+
+### (c) Standalone `:` backtrack control — DONE
+
+Unrelated to the code blocks, but the other half of what blocked YAMLish's map
+path. `token key { <.plainfirst> : <-[\:\#]>* }` — a solitary `:` commits the
+preceding atom — was rejected as "Unrecognized regex metacharacter :", killing the
+whole rule. It now sets the per-token `ratchet` flag on the token just emitted
+(`regex_parse_core.rs`); `::` / `:::` are left alone, and a `:` with no preceding
+atom still errors as raku does. Pin: `t/regex-standalone-backtrack-control.t`.
+
+## Remaining after the regex work
+
+`YAMLish::Grammar.parse("- 1\n- 2")` now yields the **same AST raku produces**,
+so the grammar is no longer the blocker. `load-yaml` still fails, on three
+independent non-regex gaps:
+
+1. **`.new` on a grammar type object.** `Single.make-value` does
+   `$schema.new.parse($!value)` where `$schema` is `Schema::Core` (a grammar).
+   mutsu: `X::Method::NotFound: Unknown method value dispatch (fallback
+   disabled): new on YAMLish::Schema::Core`. Repro: `tmp/y6.raku`.
+2. **A positional attribute assigned an itemized list stays itemized.**
+   `Actions::root-block` does `my ($class, $elems) = @($<value>.ast); $class.new(:$elems)`
+   into `submethod BUILD(:@!elems)`. mutsu ends up with `@!elems` holding the
+   itemized value: `.elems` reports 2 but `for $seq.elems` iterates **once**,
+   yielding the `Array[Node]` itself, so `.map(*.concretize(…))` calls
+   `concretize` on the Array. Raku de-itemizes into the positional. Repro:
+   `tmp/y6.raku`; `tmp/y7.raku` shows the plain shapes all working, so it is
+   specific to the `:$elems`-from-a-scalar path.
+3. **The block `map` path throws.** `Grammar.parse("a: 1")` →
+   `X::Cannot::Map: Cannot map a Any to a Package` (sequences are fine). Not yet
+   root-caused. Repro: `tmp/y13.raku`.
 
 ## Repro setup
 
-`mutsu -I tmp/ybis -I modules/MIME-Base64/lib tmp/yseq.raku` (all four block
-inputs → Failure today). Module tarball
-`~/.cache/mutsu-yaml-survey/yamlish/YAMLish-0.1.3`. Minimal repros:
-`tmp/rb3.raku` (a), `tmp/cb_inline.raku` (b), `tmp/noindent.raku` (proof the
-rest works). Emitter is `save-yaml` / `save-yamls`.
+`mutsu -I tmp/ybis -I modules/MIME-Base64/lib tmp/yseq.raku` (four block inputs).
+Module tarball `~/.cache/mutsu-yaml-survey/yamlish/YAMLish-0.1.3`. Minimal repros:
+`tmp/rb4.raku` (root-block shape), `tmp/cb_inline.raku` (inline blocks),
+`tmp/y12.raku` (standalone `:`), `tmp/y13.raku` (TOP over all inputs),
+`tmp/y6.raku` (the two concretize gaps). Emitter is `save-yaml` / `save-yamls`.


### PR DESCRIPTION
A plain `{ code }` block inside a regex was **deferred**: recorded during the match and executed afterwards on the reduce-time walk that commits `make`. Raku runs it immediately, left-to-right, *while matching* — which is the point of such a block, since it usually computes something the atoms after it depend on:

```raku
grammar L { token TOP { :my $x = 'n'; { $x = 'y' } <?{ $x eq 'y' }> 'z' } }
L.parse('z')      # raku: matches.  mutsu, before: no match.
```

## What changed

A plain block that needs nothing from the reduce walk now runs **inline on the real interpreter**, by the route ADR-0009 part B established for `<?{ … }>`, and is not also recorded for the replay, so it still runs exactly once.

Two constructs keep a block deferred, because both need post-match ordering:

- **`make`** — a node's AST is built from its *already reduced* children, which is what makes `make $<child>.made` work;
- **a dynamic variable `$*x`** — a rule's `:my $*x` is one binding per match, installed and read back around each node's reduce step, so the node's action sees its own match's value.

`code_block_defers_to_reduce` draws the line conservatively. Writes to an *outer* lexical still reach the caller's compiled slots (`'123' ~~ / (\d) { $seen = $/.Str } \d+ /` leaves `$seen` set) via the reduce path's env-diff bookkeeping; writes to the regex's own `:my`/`:let` lexicals are threaded through `RegexCaptures::regex_vars`, which the match trail already undoes on backtracking.

Three gaps around those lexicals are fixed with it:

- **Code atoms never had `caps.regex_vars` in their eval env**, so an assertion could not read a `:my` lexical at all.
- **A lookaround / group / alternative is matched with a fresh capture store**, so it neither inherited the enclosing regex's lexicals nor propagated writes out. A scoped `INLINE_REGEX_VARS_SEED` seeds exactly those inline sub-patterns; a *subrule* is a different regex and deliberately does not inherit them.
- **`instantiate_named_regex_arg_calls` pre-rendered subrule arguments** before the match, baking a permanent `Nil` into the pattern for an argument naming a `:my` lexical. Such an argument is now left verbatim and re-evaluated at match time.

## Standalone `:` backtrack control

Separately, a solitary `:` — "commit to the atom just matched" — was rejected as `Unrecognized regex metacharacter :`, killing the whole rule it appeared in (`token key { <.plainfirst> : <-[\:\#]>* }`). It now sets the per-token ratchet flag on the token just emitted. `::` / `:::` are untouched, and a `:` with no preceding atom still errors as raku does.

## Why

This is the regex half of the YAMLish battery blocker (`todo/deep/yamlish-block-collections-regex-vars.md`). YAMLish measures every block collection's indentation with

```
token root-block {
    :my $new-indent;
    <?before $<sp>=[' ' ** { 0..* } ] { $new-indent = ~$<sp> }>
    $new-indent
    [ <value=sequence($new-indent)> | <value=map($new-indent)> ]
}
```

which needs all of the above at once. `YAMLish::Grammar.parse("- 1\n- 2")` now produces the **byte-identical AST raku produces**. Three remaining non-regex gaps (`.new` on a grammar type object, an itemized list assigned to a positional attribute, and the block `map` path) are recorded in the ticket with repros.

## Testing

- New pins `t/regex-inline-code-block.t` (13) and `t/regex-standalone-backtrack-control.t` (7) — **both also pass under raku**. One test is `todo`-marked for a pre-existing gap that also fails before this change.
- `make test`: PASS, 2532 files / 24233 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)