### PR TITLE
fix(class): qualify a nested type name by its enclosing package

### DIFF
--- a/news/2026-07/nested-type-name-qualified-by-package.md
+++ b/news/2026-07/nested-type-name-qualified-by-package.md
@@ -1,0 +1,66 @@
+# A nested type name declared inside a package is qualified by it
+
+`module M { class A::B { } }` declares **`M::A::B`**. mutsu agreed about the
+*name* — `.^name` reported `M::A::B` — but registered the ClassDef under the bare
+`A::B`, so the type object and the registry disagreed and construction died:
+
+```raku
+module M { class A::B { method f { 42 } } }
+M::A::B.^name     # M::A::B
+M::A::B.new       # X::Method::NotFound: Unknown method value dispatch
+                  # (fallback disabled): new on M::A::B
+```
+
+The same mismatch also leaked the type into `GLOBAL`: plain `A::B` resolved at
+file scope, where raku reports `Could not find symbol '&B' in 'GLOBAL::A'`.
+
+`exec_register_class_op` skipped the package qualification whenever the declared
+name already contained `::`, which is exactly the nested case. It now qualifies
+those like any other declaration; a name that is already the current package, or
+already prefixed with it, is left alone, and `class GLOBAL::Foo` still declares
+into the global namespace.
+
+Two lookups carried the same `contains("::")` guard and had to follow, or the
+qualified declaration became unreachable from inside its own package:
+
+- `resolve_type_in_current_package` — a bareword `X::Decode` inside `module M`
+  now probes `M::X::Decode` up the package chain before falling back, which is
+  also what makes a package-local nested declaration shadow a same-named outer
+  one;
+- `qualify_sibling_parent_name` — an inheritance parent named `X::Decode`
+  resolves to the sibling `M::X::Decode`, which the third link of
+  `class X {}; class X::Decode is X {}; class X::Decode::Length is X::Decode {}`
+  needs.
+
+## Where this stops short of Rakudo
+
+Rakudo does not simply install the class under its qualified name. For
+`unit module M; class X::Imported::Boom is Exception { }` it records
+`M::X::Imported::Boom` as the `.^name` but installs the type into the
+*already-existing* outer `X::` package, so a consumer of `M` reaches it as plain
+`X::Imported::Boom` and **not** as `M::X::Imported::Boom` — the shape Zef uses
+for `X::Zef::UnsatisfiableDependency`. Rather than model that installation rule,
+the written name is registered as an alias for the qualified declaration (never
+over an existing entry), so both spellings resolve. That is a superset of
+Rakudo's visibility, not a match for it.
+
+This is not grammar-specific — a `class`, a `grammar`, or any other package
+declaration with a nested name was affected equally. It came out of the YAMLish
+battery work, where `Single.make-value` does `$schema.new.parse($!value)` with
+`$schema` being `YAMLish::Schema::Core`, a grammar declared as
+`grammar Schema::Core is Schema::JSON` inside `unit module YAMLish`.
+
+## Known gap this does NOT close
+
+Two packages declaring the *same* nested name still collide at declaration time:
+
+```raku
+module A1 { class N::C { } }
+module A2 { class N::C { } }   # Redeclaration of symbol 'C'.
+```
+
+That check runs against a symbol table that is not package-aware for nested
+names, and it fails the same way before this change. Recorded in
+`todo/tickets/nested-type-redeclaration-across-packages.md`.
+
+Pin: `t/nested-type-name-in-package.t` — also passes under raku.

--- a/src/runtime/registration_class.rs
+++ b/src/runtime/registration_class.rs
@@ -432,15 +432,20 @@ impl Interpreter {
     /// MRO links `X::Decode` to the built-in namespace (an unknown parent, so it
     /// falls back to `Any`) instead of the module-local `M::X`.
     ///
-    /// Only rewrites a bare name (no `::`, no type args) when
-    /// `{current_package}::{name}` names a registered class/role. A module-local
-    /// class lexically shadows any same-named outer or built-in type, so the
-    /// package-qualified sibling is preferred even when a bare built-in of that
-    /// name also exists (e.g. `X`, which is registered as the built-in `X::`
-    /// exception namespace class); genuine built-in and cross-package parents,
-    /// which have no current-package-qualified sibling, are left untouched.
+    /// Only rewrites a name (no type args) when `{current_package}::{name}` names
+    /// a registered class/role. A module-local class lexically shadows any
+    /// same-named outer or built-in type, so the package-qualified sibling is
+    /// preferred even when a bare built-in of that name also exists (e.g. `X`,
+    /// which is registered as the built-in `X::` exception namespace class);
+    /// genuine built-in and cross-package parents, which have no
+    /// current-package-qualified sibling, are left untouched.
+    ///
+    /// A *nested* parent name is qualified the same way — the third link of
+    /// `class X {}; class X::Decode is X {}; class X::Decode::Length is X::Decode {}`
+    /// inside a module has to reach `M::X::Decode`, not a bare `X::Decode` that
+    /// nothing declared.
     pub(crate) fn qualify_sibling_parent_name(&self, parent: &str) -> String {
-        if parent.contains("::") || parent.contains('[') {
+        if parent.contains('[') {
             return parent.to_string();
         }
         // The `Grammar` metatype, when it appears as an inheritance parent, is the

--- a/src/runtime/types/type_registry.rs
+++ b/src/runtime/types/type_registry.rs
@@ -315,15 +315,21 @@ impl Interpreter {
             })
     }
 
-    /// Resolve a short type name against the current package chain: inside
+    /// Resolve a type name against the current package chain: inside
     /// `module Foo { class Params {…}; sub mk { Params.new } }` the sub's
     /// bareword `Params` names `Foo::Params` (registered fully qualified),
     /// even when `mk` is called from another package (JSON::Marshal's
     /// `MarshalParams`, reached through META6's `to-json`). Walks enclosing
     /// packages outward (`A::B::name`, then `A::name`); GLOBAL is the normal
     /// bare namespace, so it ends the walk.
+    ///
+    /// A *nested* name resolves the same way — `module M { class X::Decode { } }`
+    /// declares `M::X::Decode`, and a bareword `X::Decode` inside `M` has to find
+    /// it. The qualified probe running first is also what makes a package-local
+    /// declaration shadow a same-named outer one; an already-fully-qualified name
+    /// simply fails every probe and falls back to itself.
     pub(crate) fn resolve_type_in_current_package(&self, name: &str) -> Option<String> {
-        if name.contains("::") || name.is_empty() {
+        if name.is_empty() {
             return None;
         }
         let pkg_owned = self.current_package().to_string();

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -86,12 +86,18 @@ impl Interpreter {
             let qualified_name = if let Some(stripped) = resolved_name.strip_prefix("GLOBAL::") {
                 // `class GLOBAL::Foo` declares Foo in the global namespace
                 stripped.to_string()
-            } else if resolved_name.contains("::")
-                || current_package == "GLOBAL"
+            } else if current_package == "GLOBAL"
                 || resolved_name == current_package
+                || resolved_name.starts_with(&format!("{current_package}::"))
             {
                 resolved_name.clone()
             } else {
+                // A *nested* declared name is qualified by the enclosing package
+                // like any other: `module M { class A::B { } }` declares
+                // `M::A::B`, and `A::B` is not visible on its own. Registering it
+                // under the bare `A::B` both leaked it into GLOBAL and left
+                // `M::A::B.new` unable to find its own ClassDef (`.^name` already
+                // reported the qualified name).
                 format!("{current_package}::{resolved_name}")
             };
             // A lexical (`my`) class is stored in the registry under a *storage
@@ -216,6 +222,20 @@ impl Interpreter {
                 qualified_name.clone(),
                 Value::package(Symbol::intern(&storage_name)),
             );
+            // A *nested* declared name stays reachable under the name as written,
+            // too. Rakudo installs `class X::Imported::Boom` inside
+            // `unit module M` into the already-existing outer `X::` package while
+            // recording `M::X::Imported::Boom` as its `.^name`, so a consumer of
+            // `M` refers to it as plain `X::Imported::Boom`
+            // (`t/imported-exception-when.t`, the shape Zef uses). Register the
+            // written name as an alias for the qualified declaration rather than
+            // modelling that installation rule, and never over an existing entry.
+            if resolved_name != qualified_name && resolved_name.contains("::") {
+                let storage = storage_name.clone();
+                env.entry_or_insert_with(resolved_name.clone(), || {
+                    Value::package(Symbol::intern(&storage))
+                });
+            }
             // When a nested class is registered inside another class (e.g. class B inside class A
             // becomes A::B), suppress the short name (B) so it cannot be used outside.
             // Only suppress when the parent package is itself a class, not a module.

--- a/t/nested-type-name-in-package.t
+++ b/t/nested-type-name-in-package.t
@@ -1,0 +1,24 @@
+use Test;
+
+plan 6;
+
+# A type whose declared name is itself nested (`class A::B`) is qualified by the
+# enclosing package like any other declaration: inside `module M` it declares
+# `M::A::B`. mutsu registered it under the bare `A::B`, so `M::A::B.new` could
+# not find its own definition — `.^name` already said `M::A::B`, which meant the
+# type object and the registry disagreed and construction died with
+# "Unknown method value dispatch ... new on M::A::B".
+
+module Outer {
+    class Deep::Klass  { method who { 'klass' } }
+    grammar Deep::Gram { token TOP { \d+ } }
+    class Shallow      { method who { 'shallow' } }
+}
+
+is Outer::Deep::Klass.^name, 'Outer::Deep::Klass', 'a nested class name is package-qualified';
+is Outer::Deep::Gram.^name, 'Outer::Deep::Gram', 'a nested grammar name is package-qualified';
+is Outer::Shallow.^name,    'Outer::Shallow',    'a plain name is package-qualified as before';
+
+is Outer::Deep::Klass.new.who, 'klass',   'a nested class can be instantiated';
+is Outer::Shallow.new.who,     'shallow', 'a plain name can still be instantiated';
+ok Outer::Deep::Gram.new.parse('42').defined, 'a nested grammar can be instantiated and parses';

--- a/todo/tickets/nested-type-redeclaration-across-packages.md
+++ b/todo/tickets/nested-type-redeclaration-across-packages.md
@@ -1,0 +1,48 @@
+# Two packages cannot declare the same nested type name
+
+```raku
+module A1 { class N::C { method tag { 'a1' } } }
+module A2 { class N::C { method tag { 'a2' } } }
+say A1::N::C.new.tag;
+```
+
+raku prints `a1`; mutsu dies at declaration time with
+
+```
+Redeclaration of symbol 'C'.
+```
+
+The two are distinct types — `A1::N::C` and `A2::N::C` — so there is nothing to
+redeclare. The check that rejects it looks up the *last component* of the
+declared name (`C`) in a symbol table that is not package-aware for nested names,
+so any second `X::C` anywhere in the compilation unit collides with the first.
+
+## Not the same bug as the registration one
+
+The registry-key half of this — `module M { class A::B { } }` registering under
+the bare `A::B`, which left `M::A::B.new` unable to find its own ClassDef and
+leaked `A::B` into `GLOBAL` — is fixed
+(`news/2026-07/nested-type-name-qualified-by-package.md`,
+`t/nested-type-name-in-package.t`). This one reproduces both before and after
+that change, because it fires in the declaration-time symbol check rather than in
+`exec_register_class_op`.
+
+## Why it is worth fixing
+
+It is a hard error, not a wrong answer, so any distribution that declares a
+common nested name in more than one of its modules fails to load outright.
+`Foo::Cache`, `Foo::Error` and friends are ordinary names for a library to reuse
+across sibling packages.
+
+## Where to look
+
+The registration path is `exec_register_class_op` (`src/vm/vm_typedecl_ops.rs`),
+which now computes a package-qualified `qualified_name`. The redeclaration
+diagnostic is raised earlier, from the declaration-time symbol bookkeeping —
+grep for `Redeclaration of symbol` — and needs to key on the same qualified name
+rather than the bare final component.
+
+## Repro
+
+The one-liner above, or `tmp/gnlib/GN.rakumod` + `tmp/gn3.raku` for the
+module-file shape.


### PR DESCRIPTION
`module M { class A::B { } }` declares **`M::A::B`**. mutsu agreed about the *name* — `.^name` reported `M::A::B` — but registered the ClassDef under the bare `A::B`, so the type object and the registry disagreed and construction died:

```raku
module M { class A::B { method f { 42 } } }
M::A::B.^name     # M::A::B
M::A::B.new       # X::Method::NotFound: Unknown method value dispatch
                  # (fallback disabled): new on M::A::B
```

The same mismatch also leaked the type into `GLOBAL`: plain `A::B` resolved at file scope, where raku reports `Could not find symbol '&B' in 'GLOBAL::A'`.

## What changed

`exec_register_class_op` skipped the package qualification whenever the declared name already contained `::` — exactly the nested case. Two lookups carried the same guard and had to follow, or the qualified declaration became unreachable from inside its own package:

- **`resolve_type_in_current_package`** — a bareword `X::Decode` inside `module M` now probes `M::X::Decode` up the package chain before falling back, which is also what makes a package-local nested declaration shadow a same-named outer one;
- **`qualify_sibling_parent_name`** — an inheritance parent named `X::Decode` resolves to the sibling `M::X::Decode`, which the third link of `class X {}; class X::Decode is X {}; class X::Decode::Length is X::Decode {}` needs.

## Where this stops short of Rakudo

Rakudo does not simply install the class under its qualified name. For `unit module M; class X::Imported::Boom is Exception { }` it records `M::X::Imported::Boom` as the `.^name` but installs the type into the **already-existing** outer `X::` package, so a consumer of `M` reaches it as plain `X::Imported::Boom` and *not* as `M::X::Imported::Boom` — the shape Zef uses for `X::Zef::UnsatisfiableDependency` (pinned by `t/imported-exception-when.t`). Rather than model that installation rule, the written name is registered as an alias for the qualified declaration, never over an existing entry, so both spellings resolve. That is a superset of Rakudo's visibility, not a match for it.

## Why

This is not grammar-specific — a `class`, a `grammar`, or any other package declaration with a nested name was affected equally. It came out of the YAMLish battery work, where `Single.make-value` does `$schema.new.parse($!value)` with `$schema` being `YAMLish::Schema::Core`, a grammar declared as `grammar Schema::Core is Schema::JSON` inside `unit module YAMLish`. `YAMLish::Schema::Core.new.parse('42')` now returns `42`, as under raku.

A related gap is left open and recorded in `todo/tickets/nested-type-redeclaration-across-packages.md`: two packages declaring the *same* nested name still collide (`Redeclaration of symbol 'C'`), which reproduces both before and after this change because it fires in the declaration-time symbol check rather than in registration.

## Testing

- New pin `t/nested-type-name-in-package.t` (6) — also passes under raku.
- `make test`: PASS.
- `make roast`: PASS apart from `S32-io/spurt.t`'s documented stale-`temp-file-RT-126006-test` abort, which passes on its own re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)