### PR TITLE
fix(roles): take a role candidate's language revision from its declaration, not the ambient one

### DIFF
--- a/news/2026-07/role-candidate-language-revision.md
+++ b/news/2026-07/role-candidate-language-revision.md
@@ -1,0 +1,31 @@
+# A role candidate's language revision comes from its declaration
+
+A role candidate recorded `crate::parser::current_language_version()` at
+*registration* time — the revision ambient when the declaration executed — rather
+than the one snapshotted on `Stmt::RoleDecl` when it was parsed, which is how a
+class has always done it. For a role declared inside a `use`d module that is the
+importer's revision, not the module's.
+
+This only ever produced the right answer by accident: the module export scan used
+to leak the module's own `use vX` into the parser global and leave it there, so
+the ambient revision happened to equal the declaring module's. Once that leak was
+closed (see [sprintf-uppercase-inf](sprintf-uppercase-inf.md)), every candidate of
+a role group spread across modules collapsed to a single revision —
+`roast/S14-roles/versioning.t` subtest 2 saw `("e", "e", "e")` where the three
+candidates come from a 6.c, a 6.d and a 6.e module.
+
+The same reasoning applies independently of that leak, because the ambient
+revision is also wrong whenever the module comes out of the **precompilation
+cache**: `parse_module_source` returns the cached AST without parsing, so nothing
+ever sets the module's revision on the parser global. That made the failure
+cache-state dependent — on `main` today the first run after
+`rm -rf ~/.cache/mutsu/precomp` passes and every run after it fails, which is why
+CI never saw it: its runners always start cold. The parse-time snapshot is
+serialized with the AST, so it survives precompilation; the parser global does
+not.
+
+`register_role_decl` now takes the parse-time revision as a parameter and stores
+it on the `RoleCandidateDef`, mirroring `register_class_decl`. Pinned by
+`t/role-candidate-language-revision-from-decl.t`, which loads a 6.c and a 6.e
+module declaring candidates of the same role and checks both the candidate list
+and the revision each pun reports.

--- a/src/runtime/registration_role.rs
+++ b/src/runtime/registration_role.rs
@@ -261,6 +261,7 @@ impl Interpreter {
         type_param_defs: &[ParamDef],
         body: &[Stmt],
         role_is_rw: bool,
+        language_version: &str,
     ) -> Result<(), RuntimeError> {
         self.clear_private_zeroarg_method_cache();
 
@@ -1117,7 +1118,12 @@ impl Interpreter {
                 type_param_defs: type_param_defs.to_vec(),
                 role_def: role_def.clone(),
                 parents: candidate_parents,
-                language_version: crate::parser::current_language_version(),
+                // The revision the role was *declared* under, snapshotted at parse
+                // time (`Stmt::RoleDecl.language_version`) exactly like a class's.
+                // Reading the parser global here instead would report whatever
+                // revision happens to be active when the declaration executes,
+                // which for a role in a `use`d module is the importer's.
+                language_version: language_version.to_string(),
             });
         if self
             .registry()

--- a/src/vm/vm_typedecl_ops.rs
+++ b/src/vm/vm_typedecl_ops.rs
@@ -453,7 +453,14 @@ impl Interpreter {
             self.unsuppress_name(&name_str);
             loan_env!(
                 self,
-                register_role_decl(&qualified_name, type_params, type_param_defs, body, *is_rw,)
+                register_role_decl(
+                    &qualified_name,
+                    type_params,
+                    type_param_defs,
+                    body,
+                    *is_rw,
+                    language_version,
+                )
             )?;
             // Link `is Parent` references on this role to the lexical class visible
             // in this scope (which may be stored under a mangled name), matching

--- a/t/lib/RoleRev6c.rakumod
+++ b/t/lib/RoleRev6c.rakumod
@@ -1,0 +1,5 @@
+use v6.c;
+
+role RevRole is export { }
+
+# vim: expandtab shiftwidth=4

--- a/t/lib/RoleRev6e.rakumod
+++ b/t/lib/RoleRev6e.rakumod
@@ -1,0 +1,6 @@
+use v6.e.PREVIEW;
+use RoleRev6c;
+
+role RevRole[::T] is export { }
+
+# vim: expandtab shiftwidth=4

--- a/t/role-candidate-language-revision-from-decl.t
+++ b/t/role-candidate-language-revision-from-decl.t
@@ -1,0 +1,19 @@
+use Test;
+
+# A role candidate's language revision is the one its *declaration* was compiled
+# under, snapshotted at parse time — exactly like a class's. Reading the parser's
+# ambient revision when the declaration executes instead reports whichever
+# revision happens to be active then, which for a role in a `use`d module is the
+# importer's, so every candidate of a multi-module role group collapsed to the
+# same revision.
+
+plan 3;
+
+use lib $?FILE.IO.parent.add('lib').Str;
+use RoleRev6c;
+use RoleRev6e;
+
+is-deeply RevRole.^candidates.map( ~ *.^language-revision ), <c e>,
+    'each candidate keeps the revision of the module that declared it';
+is RevRole.new.^language-revision, 'c', 'pun of the 6.c candidate stays 6.c';
+is RevRole[Str].new.^language-revision, 'e', 'pun of the 6.e candidate stays 6.e';


### PR DESCRIPTION
## Problem

`roast/S14-roles/versioning.t` subtest 2 fails on `main` whenever the module
**precompilation cache is warm**:

```
# expected: ("c", "d", "e")
#      got: ("e", "e", "e").Seq
```

A role candidate recorded `crate::parser::current_language_version()` at
*registration* time — the revision ambient when the declaration executed —
instead of the one snapshotted on `Stmt::RoleDecl` at parse time, which is how a
class has always done it. For a role declared inside a `use`d module, the ambient
revision is the **importer's**, not the module's.

Two things had been masking it:

- the module export scan used to leak the module's own `use vX` into the parser
  global and leave it there, so the ambient revision happened to equal the
  declaring module's. #5508 closed that leak.
- when the module comes out of the precompilation cache, `parse_module_source`
  returns the cached AST *without parsing*, so nothing ever sets the module's
  revision on the parser global at all.

The second point makes the failure cache-state dependent, which is why CI never
caught it — its runners always start cold:

```
$ rm -rf ~/.cache/mutsu/precomp
$ target/debug/mutsu roast/S14-roles/versioning.t   # run 1: ok 2
$ target/debug/mutsu roast/S14-roles/versioning.t   # run 2: not ok 2
$ target/debug/mutsu roast/S14-roles/versioning.t   # run 3: not ok 2
```

## Approach

Thread the parse-time revision through `register_role_decl` and store it on the
`RoleCandidateDef`, mirroring `register_class_decl`. The snapshot is serialized
with the AST, so unlike the parser global it survives precompilation.

## Tests

- New pin `t/role-candidate-language-revision-from-decl.t` (a 6.c and a 6.e
  module declaring candidates of the same role; checks the candidate list and the
  revision each pun reports).
- `roast/S14-roles/versioning.t` now passes on 4 consecutive runs with both a
  cold and a warm precomp cache (it fails on runs 2+ without this change).
- `roast/S14-roles/{submethods-6e,mixin-6e,attributes-6e}.t`,
  `roast/6.c/S14-roles/submethods.t`: pass.
- `prove -j4 t/`: 2534 files / 24272 tests pass.
- Full whitelisted roast locally (debug): no subtest failures.
- `cargo fmt --all`, `cargo clippy -- -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)