### PR TITLE
fix(precomp): replay the parse effects a cache hit skips, and cover the warm path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,25 @@ jobs:
         env:
           MUTSU_BIN: target/release/mutsu
 
+      - name: Roast tests (warm precomp cache)
+        # The step above deliberately starts from an empty precomp cache, and CI
+        # runners are fresh anyway, so until now the *warm* cache path was never
+        # exercised here at all — a default-on mechanism the project's
+        # comprehensive safety net structurally could not test. A cache hit skips
+        # a module's parse, so any parser state the entry fails to replay becomes
+        # a bug that only shows up on the second run of a program; that is exactly
+        # how the S14-roles/versioning.t language-revision bug reached main.
+        #
+        # The full run above just warmed the cache for every module the suite
+        # loads, so re-running the module-sensitive slice of the whitelist now
+        # covers the hit path. Small subset, seconds of wall clock.
+        run: |
+          set -o pipefail
+          prove -j4 --merge -e 'scripts/run-roast-test.sh' \
+            $(grep -E '/(S10-packages|S11-modules|S14-roles)/' roast-whitelist.txt)
+        env:
+          MUTSU_BIN: target/release/mutsu
+
       - name: Flaky quarantine retries used
         if: always()
         run: scripts/report-flaky-retries.sh

--- a/news/2026-07/precomp-cache-replays-parse-effects.md
+++ b/news/2026-07/precomp-cache-replays-parse-effects.md
@@ -1,0 +1,57 @@
+# The precompilation cache no longer drops what parsing left behind
+
+`src/precomp.rs` caches a module's `Vec<Stmt>` on disk and, on a hit,
+`parse_module_source` returned it and skipped the parse. That is sound only if
+parsing is a pure `source -> AST` function. In mutsu it is not: the parser also
+writes thread-local state that the rest of the runtime reads afterwards, and a
+cache hit performed none of those writes. The result was a class of bug where
+the same program produced different results depending on whether
+`~/.cache/mutsu/precomp` happened to be warm — and, because the effect only
+appears from the *second* run onwards, CI could never see it.
+
+Two effects were measured to matter and are now stored in the cache entry
+(`ParseEffects`) and replayed on a hit:
+
+- **The language revision** the module's `use vX` selected. Without it, code
+  running while the module's mainline executed saw the *importer's* revision.
+  This is how `roast/S14-roles/versioning.t` came to pass on a cold cache and
+  fail on every run after it, with a role group's candidates all collapsing to
+  one revision (see [role-candidate-language-revision](role-candidate-language-revision.md)).
+- **Parse warnings**, which were reported on the first run of a program and then
+  silently vanished on every later one.
+
+A third candidate, inline `module Foo { ... is export }` registrations, was
+measured and behaves identically cold and warm — the importer's own uncached
+export scan already registers them — so it is documented as a deliberate
+non-entry rather than guessed at.
+
+Three smaller defects in the same file went with it:
+
+- **Entries could not name themselves.** The cache file name is a 64-bit hash of
+  the canonical source path, but the path was not stored, so an entry was trusted
+  purely because it sat at the expected name. The canonical path is now part of
+  the metadata and is verified on load.
+- **The cache grew without bound.** `clear_cache()` was dead code and nothing
+  ever evicted an entry whose module stopped being loaded; one real checkout had
+  accumulated 12,355 files. Entries past a 4096 cap are now evicted oldest-first,
+  at most once per process and only from the save path.
+- **There was no way to turn the cache off from outside the CLI.** `--no-precomp`
+  only reaches interpreters built by `main.rs`, so a test harness or CI step
+  could not exercise the no-cache path. `MUTSU_PRECOMP=0` now disables it
+  process-wide.
+
+## The warm path is under test now
+
+`t/precomp-warm-cache-parity.t` runs a probe program twice against a private
+`XDG_CACHE_HOME` and requires byte-identical stdout *and* stderr. The probe
+module is `use v6.e.PREVIEW` and computes `sprintf('%#x', -256)` in its mainline
+(`-0x100` under 6.e, `0x-100` under 6.d) and carries a duplicated `is export`
+trait so its parse warns — i.e. it fails on both counts without the replay,
+which was confirmed by removing the replay and watching the warm run print
+`0x-100` with no warning.
+
+CI additionally re-runs the `S10-packages` / `S11-modules` / `S14-roles` slice of
+the whitelist (46 files, ~12s) *after* `make roast`, when the cache the full run
+just built is warm. Before this, every roast step began with
+`rm -rf ~/.cache/mutsu/precomp` and runners were fresh, so the hit path had no
+coverage at all.

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,9 @@ fn print_help(program: &str) {
     println!("  MUTSULIB       Colon-separated list of module search paths");
     println!("                 (searched after -I paths, so -I takes priority;");
     println!("                 both are searched before installed modules)");
+    println!("  MUTSU_PRECOMP  Set to 0 to disable the module precompilation");
+    println!("                 cache, like --no-precomp but for every mutsu");
+    println!("                 process a script or test harness spawns");
 }
 
 fn print_negation_error(option: &str) -> ! {

--- a/src/precomp.rs
+++ b/src/precomp.rs
@@ -3,6 +3,30 @@
 //! Caches the parsed AST (`Vec<Stmt>`) for loaded modules on disk so that
 //! subsequent runs can skip the parse step when the source has not changed.
 //!
+//! ## Parsing is not a pure function
+//!
+//! Skipping the parse is only sound if parsing is `source -> AST`. It is not:
+//! the parser also writes thread-local state that the rest of the runtime reads
+//! afterwards. A cache hit performs none of those writes, so anything that
+//! depends on them behaved differently depending on whether the cache happened
+//! to be warm — the same program, two different results.
+//!
+//! Two such effects are proven and are therefore captured in the cache entry
+//! (`ParseEffects`) and replayed on a hit:
+//!
+//! - **the language revision** the module's `use vX` selected. Without the
+//!   replay, code running while the module's mainline executes saw the
+//!   *importer's* revision (this made `roast/S14-roles/versioning.t` pass on a
+//!   cold cache and fail on every run after it).
+//! - **parse warnings**, which were emitted on the first run and then silently
+//!   vanished on every subsequent one.
+//!
+//! Anything new the parser starts recording in a thread-local must be added to
+//! `ParseEffects` too, or it becomes the next cache-state-dependent bug. A
+//! deliberate non-entry: inline `module Foo { ... is export }` registrations
+//! (`INLINE_MODULE_EXPORTS`) were measured to behave identically cold and warm,
+//! because the importer's own uncached parse-time export scan registers them.
+//!
 //! ## Cache layout
 //!
 //! Cache files are stored under `$HOME/.cache/mutsu/precomp/` (or a
@@ -13,6 +37,10 @@
 //! ## Cache key
 //!
 //! A cache entry is valid when ALL of the following match:
+//! - The stored canonical source path matches the one being loaded. The file
+//!   name is only a 64-bit hash of that path, so without this an (astronomically
+//!   unlikely) hash collision would serve another module's AST; the entry has to
+//!   be able to name itself.
 //! - The source file modification time matches the stored mtime
 //! - The source content hash matches the stored hash
 //! - The interpreter version matches the stored version stamp. The stamp embeds
@@ -56,8 +84,9 @@ const CACHE_MAGIC: &[u8; 4] = b"MTS2";
 /// `Pointer`. Stamping the exe mtime invalidates the cache on every rebuild,
 /// removing the need to manually `rm` the cache after parser/compiler changes.
 fn interpreter_version() -> String {
-    // Bump CACHE_FORMAT_VERSION when Stmt/Expr/Value enum variants change
-    const CACHE_FORMAT_VERSION: u32 = 7;
+    // Bump CACHE_FORMAT_VERSION when Stmt/Expr/Value enum variants change,
+    // or when `CacheMetadata` / `ParseEffects` gain or lose a field.
+    const CACHE_FORMAT_VERSION: u32 = 8;
     let exe_stamp = std::env::current_exe()
         .and_then(fs::metadata)
         .and_then(|m| m.modified())
@@ -71,6 +100,25 @@ fn interpreter_version() -> String {
         CACHE_FORMAT_VERSION,
         exe_stamp
     )
+}
+
+/// Whether the cache is on unless a caller turns it off.
+///
+/// `MUTSU_PRECOMP=0` disables it process-wide, which `--no-precomp` could not do:
+/// that flag only reaches interpreters built by `main.rs`, so a test harness, a
+/// CI step, or an embedding host had no way to exercise the no-cache path.
+/// Any other value (or an unset variable) leaves the cache enabled.
+pub(crate) fn enabled_by_default() -> bool {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        std::env::var("MUTSU_PRECOMP")
+            .map(|v| v != "0")
+            .unwrap_or(true)
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        true
+    }
 }
 
 /// Compute a deterministic hash of a canonical file path for use as cache filename.
@@ -97,21 +145,46 @@ fn cache_dir() -> Option<PathBuf> {
     Some(dir)
 }
 
+/// The thread-local parser state a module's parse leaves behind, which a cache
+/// hit would otherwise skip. See the module docs for why this exists and what
+/// belongs in it.
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct ParseEffects {
+    /// The language revision the parser was left in — the module's own `use vX`,
+    /// or the 6.d default. Replayed so the module's mainline runs under its own
+    /// revision, exactly as it does on a cache miss.
+    pub(crate) language_version: String,
+    /// Warnings the parse emitted, so a warm run reports them like a cold one.
+    pub(crate) warnings: Vec<String>,
+}
+
+/// A cached compilation unit: the AST plus the parse effects to replay.
+pub(crate) struct CachedUnit {
+    pub(crate) stmts: Vec<Stmt>,
+    pub(crate) effects: ParseEffects,
+}
+
 /// Metadata stored alongside the cached AST.
 #[derive(serde::Serialize, serde::Deserialize)]
 struct CacheMetadata {
+    /// Canonical path of the source this entry was built from. The cache file
+    /// name is only a hash of it, so storing it lets the entry be verified
+    /// rather than merely assumed to belong to the file being loaded.
+    source_path: String,
     /// Source file modification time as nanoseconds since UNIX epoch.
     mtime_nanos: u128,
     /// Hash of source content at cache write time.
     source_hash: Option<u64>,
     /// Interpreter version at the time of caching.
     version: String,
+    /// Parser side effects to replay on a hit.
+    effects: ParseEffects,
 }
 
-/// Try to load a cached AST for the given source file.
+/// Try to load a cached compilation unit for the given source file.
 ///
-/// Returns `Some(stmts)` if a valid cache entry exists, `None` otherwise.
-pub(crate) fn load_cached_ast(source_path: &Path) -> Option<Vec<Stmt>> {
+/// Returns `Some(unit)` if a valid cache entry exists, `None` otherwise.
+pub(crate) fn load_cached_unit(source_path: &Path) -> Option<CachedUnit> {
     let canonical = source_path.canonicalize().ok()?;
     let dir = cache_dir()?;
     let hash = path_hash(&canonical);
@@ -146,6 +219,13 @@ pub(crate) fn load_cached_ast(source_path: &Path) -> Option<Vec<Stmt>> {
         bincode::serde::decode_from_slice(&rest[..meta_len], bincode::config::standard()).ok()?;
     let ast_data = &rest[meta_len..];
 
+    // Validate that the entry actually describes this file. The cache file name
+    // is a 64-bit hash of the path, so a collision would otherwise hand back
+    // another module's AST.
+    if meta.source_path != canonical.to_string_lossy() {
+        return None;
+    }
+
     // Validate version
     if meta.version != interpreter_version() {
         // Version mismatch — remove stale cache
@@ -172,20 +252,19 @@ pub(crate) fn load_cached_ast(source_path: &Path) -> Option<Vec<Stmt>> {
         return None;
     }
 
-    // Check format version (stored right after magic)
-    // Actually, let me restructure: magic(4) + format_version(4) + meta_len(4) + meta + ast
-    // But we already wrote the format above without format_version. Let me just embed
-    // format_version in the metadata for simplicity.
-
     bincode::serde::decode_from_slice(ast_data, bincode::config::standard())
         .ok()
-        .map(|(stmts, _)| stmts)
+        .map(|(stmts, _)| CachedUnit {
+            stmts,
+            effects: meta.effects,
+        })
 }
 
-/// Save a parsed AST to the cache for the given source file.
+/// Save a parsed compilation unit — the AST *and* the parse effects to replay —
+/// to the cache for the given source file.
 ///
 /// Errors are silently ignored (cache is best-effort).
-pub(crate) fn save_cached_ast(source_path: &Path, stmts: &[Stmt]) {
+pub(crate) fn save_cached_unit(source_path: &Path, stmts: &[Stmt], effects: &ParseEffects) {
     let Some(canonical) = source_path.canonicalize().ok() else {
         return;
     };
@@ -195,14 +274,17 @@ pub(crate) fn save_cached_ast(source_path: &Path, stmts: &[Stmt]) {
     let Some(source_mtime) = source_mtime_nanos(source_path) else {
         return;
     };
+    prune_cache_once(&dir);
 
     let hash = path_hash(&canonical);
     let cache_file = dir.join(format!("{}.bin", hash));
 
     let meta = CacheMetadata {
+        source_path: canonical.to_string_lossy().into_owned(),
         mtime_nanos: source_mtime,
         source_hash: source_content_hash(source_path),
         version: interpreter_version(),
+        effects: effects.clone(),
     };
 
     let Ok(meta_bytes) = bincode::serde::encode_to_vec(&meta, bincode::config::standard()) else {
@@ -231,6 +313,48 @@ pub(crate) fn save_cached_ast(source_path: &Path, stmts: &[Stmt]) {
 pub(crate) fn clear_cache() {
     if let Some(dir) = cache_dir() {
         let _ = fs::remove_dir_all(&dir);
+    }
+}
+
+/// Upper bound on cache entries before the oldest are evicted.
+const MAX_CACHE_ENTRIES: usize = 4096;
+
+/// Evict the oldest entries when the cache grows past `MAX_CACHE_ENTRIES`.
+///
+/// Nothing ever removed an entry whose source path stopped being loaded, so the
+/// directory grew without bound — one real checkout had accumulated 12,355 files
+/// across renamed/deleted modules and abandoned worktrees. Entries are cheap to
+/// rebuild (that is the whole point of a cache), so evicting by file mtime —
+/// which a regenerated entry refreshes, making this an approximate LRU — is
+/// enough.
+///
+/// Runs at most once per process, and only from the save path, so a warm run
+/// that never writes never pays for the scan.
+fn prune_cache_once(dir: &Path) {
+    static PRUNED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    if PRUNED.set(()).is_err() {
+        return;
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    let mut files: Vec<(SystemTime, PathBuf)> = entries
+        .flatten()
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "bin"))
+        .filter_map(|e| {
+            let modified = e.metadata().ok()?.modified().ok()?;
+            Some((modified, e.path()))
+        })
+        .collect();
+    if files.len() <= MAX_CACHE_ENTRIES {
+        return;
+    }
+    // Oldest first, then drop everything past half the cap so the next prune is
+    // not immediately due again.
+    files.sort_by_key(|(modified, _)| *modified);
+    let keep = MAX_CACHE_ENTRIES / 2;
+    for (_, path) in files.iter().take(files.len() - keep) {
+        let _ = fs::remove_file(path);
     }
 }
 
@@ -273,10 +397,10 @@ mod tests {
         }
 
         // Save and load
-        save_cached_ast(&source, &stmts);
-        let loaded = load_cached_ast(&source);
+        save_cached_unit(&source, &stmts, &ParseEffects::default());
+        let loaded = load_cached_unit(&source);
         assert!(loaded.is_some(), "cache should return Some");
-        let loaded = loaded.unwrap();
+        let loaded = loaded.unwrap().stmts;
         assert_eq!(loaded.len(), 2);
 
         // Verify round-trip preserves structure
@@ -301,8 +425,8 @@ mod tests {
             writeln!(f, "say 1;").unwrap();
         }
 
-        save_cached_ast(&source, &stmts);
-        assert!(load_cached_ast(&source).is_some());
+        save_cached_unit(&source, &stmts, &ParseEffects::default());
+        assert!(load_cached_unit(&source).is_some());
 
         // Touch the file (update mtime)
         std::thread::sleep(std::time::Duration::from_secs(2));
@@ -312,7 +436,7 @@ mod tests {
         }
 
         // Cache should now be invalid
-        assert!(load_cached_ast(&source).is_none());
+        assert!(load_cached_unit(&source).is_none());
 
         let _ = fs::remove_dir_all(&dir);
     }
@@ -355,9 +479,11 @@ mod tests {
         let cdir = cache_dir().unwrap();
         let cache_file = cdir.join(format!("{}.bin", path_hash(&canonical)));
         let meta = CacheMetadata {
+            source_path: canonical.to_string_lossy().into_owned(),
             mtime_nanos: source_mtime_nanos(&source).unwrap(),
             source_hash: source_content_hash(&source),
             version: "0.0.0+cf0+exe0".to_string(),
+            effects: ParseEffects::default(),
         };
         let meta_bytes = bincode::serde::encode_to_vec(&meta, bincode::config::standard()).unwrap();
         let ast_bytes = bincode::serde::encode_to_vec(&stmts, bincode::config::standard()).unwrap();
@@ -369,8 +495,78 @@ mod tests {
         fs::write(&cache_file, &data).unwrap();
 
         // Stale version → cache must be rejected (and removed).
-        assert!(load_cached_ast(&source).is_none());
+        assert!(load_cached_unit(&source).is_none());
         assert!(!cache_file.exists(), "stale cache file should be removed");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn parse_effects_survive_the_round_trip() {
+        // The whole point of the entry: a hit must be able to replay what the
+        // skipped parse would have left in the parser's thread-locals.
+        let stmts = vec![Stmt::Say(vec![Expr::Literal(Value::int(1))])];
+        let effects = ParseEffects {
+            language_version: "6.e".to_string(),
+            warnings: vec!["Potential difficulties:\n    Duplicate 'is export' trait".to_string()],
+        };
+
+        let dir = tempdir("effects");
+        let source = dir.join("effects.rakumod");
+        {
+            let mut f = fs::File::create(&source).unwrap();
+            writeln!(f, "use v6.e.PREVIEW; say 1;").unwrap();
+        }
+
+        save_cached_unit(&source, &stmts, &effects);
+        let loaded = load_cached_unit(&source).expect("cache should return Some");
+        assert_eq!(loaded.effects, effects);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn entry_rejected_when_it_names_a_different_source() {
+        // The cache file name is only a 64-bit hash of the path, so an entry has
+        // to be able to prove it belongs to the file being loaded rather than
+        // being trusted because it sits at the expected name.
+        let stmts = vec![Stmt::Say(vec![Expr::Literal(Value::int(3))])];
+
+        let dir = tempdir("identity");
+        let source = dir.join("identity.rakumod");
+        {
+            let mut f = fs::File::create(&source).unwrap();
+            writeln!(f, "say 3;").unwrap();
+        }
+
+        save_cached_unit(&source, &stmts, &ParseEffects::default());
+        assert!(load_cached_unit(&source).is_some());
+
+        // Rewrite the entry claiming a different source path, as a path-hash
+        // collision would produce.
+        let canonical = source.canonicalize().unwrap();
+        let cdir = cache_dir().unwrap();
+        let cache_file = cdir.join(format!("{}.bin", path_hash(&canonical)));
+        let meta = CacheMetadata {
+            source_path: "/somewhere/else/Other.rakumod".to_string(),
+            mtime_nanos: source_mtime_nanos(&source).unwrap(),
+            source_hash: source_content_hash(&source),
+            version: interpreter_version(),
+            effects: ParseEffects::default(),
+        };
+        let meta_bytes = bincode::serde::encode_to_vec(&meta, bincode::config::standard()).unwrap();
+        let ast_bytes = bincode::serde::encode_to_vec(&stmts, bincode::config::standard()).unwrap();
+        let mut data = Vec::new();
+        data.extend_from_slice(CACHE_MAGIC);
+        data.extend_from_slice(&(meta_bytes.len() as u32).to_le_bytes());
+        data.extend_from_slice(&meta_bytes);
+        data.extend_from_slice(&ast_bytes);
+        fs::write(&cache_file, &data).unwrap();
+
+        assert!(
+            load_cached_unit(&source).is_none(),
+            "an entry naming another source must not be served"
+        );
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src/runtime/builtins_system_require.rs
+++ b/src/runtime/builtins_system_require.rs
@@ -71,12 +71,14 @@ impl Interpreter {
         None
     }
 
-    /// Parse a source file for require, returning the merged AST.
+    /// Parse a source file for require, returning the merged AST together with
+    /// the parser state the parse left behind (see `precomp::ParseEffects`), so
+    /// the cache can replay it on a later hit.
     fn parse_require_source(
         &mut self,
         file: &str,
         path: &std::path::Path,
-    ) -> Result<Vec<crate::ast::Stmt>, RuntimeError> {
+    ) -> Result<(Vec<crate::ast::Stmt>, crate::precomp::ParseEffects), RuntimeError> {
         let code = std::fs::read_to_string(path)
             .map_err(|e| RuntimeError::new(format!("Failed to read module {}: {}", file, e)))?;
         let preprocessed = Self::maybe_preprocess_roast_directives(&code);
@@ -84,8 +86,12 @@ impl Interpreter {
         crate::parser::set_parser_program_path(self.program_path.clone());
         let result = parse_dispatch::parse_compilation_unit(&preprocessed);
         crate::parser::clear_parser_lib_paths();
-        for warning in crate::parser::take_parse_warnings() {
-            self.write_warn_to_stderr(&warning);
+        let effects = crate::precomp::ParseEffects {
+            language_version: crate::parser::current_language_version(),
+            warnings: crate::parser::take_parse_warnings(),
+        };
+        for warning in &effects.warnings {
+            self.write_warn_to_stderr(warning);
         }
         let stmts = result.map(|(stmts, _)| stmts).map_err(|mut err| {
             err.message = format!("Failed to parse module '{}': {}", file, err.message);
@@ -94,7 +100,7 @@ impl Interpreter {
         // `unit class`/`unit role`/`unit grammar` bodies are already merged at
         // parse time (see `parser::stmt::stmtlist` unit-capture), so the parsed
         // statements need no post-parse surgery.
-        Ok(stmts)
+        Ok((stmts, effects))
     }
 
     fn require_load_from_file(
@@ -106,17 +112,22 @@ impl Interpreter {
             .resolve_require_file_path(file)
             .ok_or_else(|| RuntimeError::unsatisfied_dependency(file))?;
 
-        // Try loading from precompilation cache
+        // Try loading from precompilation cache. A hit skips the parse, so replay
+        // the parser state it would have produced (see `precomp::ParseEffects`).
         let stmts = if self.precomp_enabled {
-            if let Some(cached) = crate::precomp::load_cached_ast(&path) {
-                cached
+            if let Some(unit) = crate::precomp::load_cached_unit(&path) {
+                crate::parser::set_current_language_version(&unit.effects.language_version);
+                for warning in &unit.effects.warnings {
+                    self.write_warn_to_stderr(warning);
+                }
+                unit.stmts
             } else {
-                let parsed = self.parse_require_source(file, &path)?;
-                crate::precomp::save_cached_ast(&path, &parsed);
+                let (parsed, effects) = self.parse_require_source(file, &path)?;
+                crate::precomp::save_cached_unit(&path, &parsed, &effects);
                 parsed
             }
         } else {
-            self.parse_require_source(file, &path)?
+            self.parse_require_source(file, &path)?.0
         };
         let saved_package = self.current_package();
         let before_function_keys: std::collections::HashSet<Symbol> =

--- a/src/runtime/run_modules.rs
+++ b/src/runtime/run_modules.rs
@@ -423,9 +423,17 @@ impl Interpreter {
         let precomp_eligible =
             self.precomp_enabled && !has_no_precompilation && !dependency_disables_precomp;
 
-        // Try loading from precompilation cache when eligible.
-        if precomp_eligible && let Some(stmts) = crate::precomp::load_cached_ast(source_path) {
-            return Ok((stmts, true));
+        // Try loading from precompilation cache when eligible. A hit skips the
+        // parse, so the parser state the parse would have left behind must be
+        // replayed from the entry — otherwise the module's mainline runs under
+        // the *importer's* language revision and the module's warnings never
+        // appear. See `precomp::ParseEffects`.
+        if precomp_eligible && let Some(unit) = crate::precomp::load_cached_unit(source_path) {
+            crate::parser::set_current_language_version(&unit.effects.language_version);
+            for warning in &unit.effects.warnings {
+                self.write_warn_to_stderr(warning);
+            }
+            return Ok((unit.stmts, true));
         }
 
         let preprocessed = Self::maybe_preprocess_roast_directives(&code);
@@ -433,8 +441,14 @@ impl Interpreter {
         crate::parser::set_parser_program_path(self.program_path.clone());
         let result = parse_dispatch::parse_compilation_unit(&preprocessed);
         crate::parser::clear_parser_lib_paths();
-        for warning in crate::parser::take_parse_warnings() {
-            self.write_warn_to_stderr(&warning);
+        // Capture exactly what a later cache hit will have to replay, before
+        // anything downstream can disturb it.
+        let effects = crate::precomp::ParseEffects {
+            language_version: crate::parser::current_language_version(),
+            warnings: crate::parser::take_parse_warnings(),
+        };
+        for warning in &effects.warnings {
+            self.write_warn_to_stderr(warning);
         }
         // `unit class`/`unit role`/`unit grammar` bodies are already merged at
         // parse time by the statement-list unit-capture (see
@@ -452,7 +466,7 @@ impl Interpreter {
 
         // Save to precompilation cache when the module is eligible.
         if precomp_eligible {
-            crate::precomp::save_cached_ast(source_path, &stmts);
+            crate::precomp::save_cached_unit(source_path, &stmts, &effects);
         }
 
         Ok((stmts, precomp_eligible))

--- a/src/runtime/runtime_init.rs
+++ b/src/runtime/runtime_init.rs
@@ -2202,7 +2202,7 @@ impl Interpreter {
             action_made: None,
             current_grammar_actions: None,
             pending_regex_error: None,
-            precomp_enabled: true,
+            precomp_enabled: crate::precomp::enabled_by_default(),
             monkey_typing: false,
             json_import_defaults: crate::runtime::json::JsonImportDefaults::default(),
 

--- a/t/lib/PrecompRevisionProbe.rakumod
+++ b/t/lib/PrecompRevisionProbe.rakumod
@@ -1,0 +1,13 @@
+use v6.e.PREVIEW;
+unit module PrecompRevisionProbe;
+
+# Evaluated while this module's mainline runs, so it reports the revision the
+# module was compiled under -- 6.e puts the sign before the radix prefix
+# (`-0x100`), 6.d renders `0x-100`. A precomp cache hit skips this module's
+# parse, so unless the cached entry replays the revision the parse selected,
+# this reads the *importer's* revision instead.
+our $revision-probe is export = sprintf('%#x', -256);
+
+# A duplicated trait makes the parse emit a warning, which a cache hit must
+# replay too.
+sub precomp-probe-hello() is export is export { 'hello' }

--- a/t/precomp-warm-cache-parity.t
+++ b/t/precomp-warm-cache-parity.t
@@ -1,0 +1,70 @@
+use Test;
+
+# A precompilation cache hit skips the module's parse entirely. That is only
+# sound if parsing is a pure `source -> AST` function, and it is not: the parser
+# also leaves state behind that the runtime reads afterwards. Whatever a cache
+# hit fails to reproduce turns into a bug that only shows up on the *second* run
+# of a program -- invisible to CI, whose runners always start cold.
+#
+# So the contract this pins is simply: running the same program twice, the
+# second time with a warm cache, must produce byte-identical output.
+#
+# The probe module (t/lib/PrecompRevisionProbe.rakumod) exercises the two
+# effects measured to matter:
+#   - it is `use v6.e.PREVIEW`, and computes `sprintf('%#x', -256)` in its
+#     mainline. 6.e puts the sign before the radix prefix (`-0x100`); 6.d gives
+#     `0x-100`. Without the replay the warm run compiled it under the importer's
+#     revision and printed `0x-100`.
+#   - it declares a duplicated `is export` trait, so its parse emits a warning.
+#     Without the replay the warning appeared on the cold run and vanished after.
+
+plan 5;
+
+my $lib = $?FILE.IO.parent.add('lib').Str;
+my $cache = $*TMPDIR.add("mutsu-precomp-parity-{$*PID}");
+my $script = $cache.add('probe.raku');
+
+$cache.mkdir;
+$script.spurt: qq:to/PROBE/;
+    use lib '$lib';
+    use PrecompRevisionProbe;
+    say \$revision-probe;
+    say precomp-probe-hello();
+    PROBE
+
+# Point the cache at an empty directory of our own so the run really is cold,
+# whatever the developer's ~/.cache happens to hold.
+%*ENV<XDG_CACHE_HOME> = $cache.Str;
+
+sub run-probe() {
+    my $proc = run($*EXECUTABLE, $script.Str, :out, :err);
+    my $out = $proc.out.slurp;
+    my $err = $proc.err.slurp;
+    return %( :$out, :$err );
+}
+
+my %cold = run-probe();
+my %warm = run-probe();
+
+ok %cold<out>.contains('-0x100'),
+    'cold run compiles the module under its own 6.e revision';
+is %warm<out>, %cold<out>,
+    'stdout is identical with a warm cache';
+ok %warm<out>.contains('-0x100'),
+    'the warm run still reports the 6.e revision (replayed from the cache)';
+ok %cold<err>.contains('Duplicate'),
+    'cold run reports the parse warning';
+is %warm<err>, %cold<err>,
+    'stderr is identical with a warm cache';
+
+END {
+    # `run` may still hold the directory; ignore a failed cleanup.
+    try $cache.&rmtree if $cache.e;
+}
+
+sub rmtree(IO::Path $d) {
+    for $d.dir -> $e {
+        $e.d ?? rmtree($e) !! $e.unlink;
+    }
+    $d.rmdir;
+}

--- a/todo/tickets/module-parse-warning-reported-twice.md
+++ b/todo/tickets/module-parse-warning-reported-twice.md
@@ -1,0 +1,65 @@
+# A module's parse warning is reported twice
+
+A warning raised while parsing a `use`d module is printed twice. Rakudo prints
+it once.
+
+```
+# tmp/pclib/PrecompWarn.rakumod
+unit module PrecompWarn;
+sub pw-hello() is export is export { "hi" }
+
+# tmp/pcwarn.raku
+use PrecompWarn;
+say pw-hello();
+```
+
+```
+$ mutsu -I tmp/pclib tmp/pcwarn.raku
+Potential difficulties:
+    Duplicate 'is export' trait
+  in block <unit> at tmp/pcwarn.raku line 1
+Potential difficulties:
+    Duplicate 'is export' trait
+  in block <unit> at tmp/pcwarn.raku line 1
+hi
+
+$ raku -I tmp/pclib tmp/pcwarn.raku
+Potential difficulties:
+    Duplicate 'is export' trait
+    at .../PrecompWarn.rakumod (PrecompWarn):3
+    ------> sub pw-hello() is export <HERE>is export { "hi" }
+hi
+```
+
+## Cause
+
+The module's source is parsed twice, and both parses drain `PARSE_WARNINGS` into
+stderr:
+
+1. at the importer's *parse* time, by the export scan
+   (`parser::stmt::simple::module_exports::extract_exported_names`, which calls
+   `parse_program_partial`), and
+2. at *run* time, by `Interpreter::parse_module_source`
+   (`src/runtime/run_modules.rs`).
+
+Whoever drains second sees a fresh set from its own parse, so both print.
+
+Found while making the precompilation cache replay parse effects
+(`news/2026-07/precomp-cache-replays-parse-effects.md`). That change made the
+count *consistent* between a cold and a warm cache — it is two either way now,
+where it used to be two cold and one warm — but did not address the duplication
+itself.
+
+Note the second difference visible above: mutsu attributes the warning to the
+*importer's* line (`at tmp/pcwarn.raku line 1`) rather than to the module file
+and offending source line. Both are worth fixing together, since they come from
+the same place — the warning carries no origin, so it is stamped with whatever
+location is current when it is drained.
+
+## Why this is not a one-liner
+
+Simply suppressing the export-scan drain would lose warnings from a module that
+is only ever scanned and never loaded at run time. The warnings need an origin
+(source path + line) recorded when they are raised, and de-duplication on that
+origin — which also fixes the misattributed location. That means touching
+`add_parse_warning`'s signature and every one of its ~10 call sites.


### PR DESCRIPTION
## Problem

The precompilation cache stores a module's `Vec<Stmt>` and, on a hit,
`parse_module_source` returns it and **skips the parse entirely**. That is sound
only if parsing is a pure `source -> AST` function. In mutsu it is not — the
parser also writes thread-local state the runtime reads afterwards, and a hit
performs none of those writes.

The result is a class of bug where the *same program produces different results*
depending on whether `~/.cache/mutsu/precomp` happens to be warm. Because the
divergence starts on the second run, CI structurally cannot see it: every roast
step begins with `rm -rf ~/.cache/mutsu/precomp` and runners are fresh anyway.

Two effects were measured to matter:

**Language revision** — the module's mainline ran under the *importer's*
revision. This is how #5513's bug reached `main`:

```
$ rm -rf ~/.cache/mutsu/precomp
$ mutsu roast/S14-roles/versioning.t   # run 1: ok 2
$ mutsu roast/S14-roles/versioning.t   # run 2: not ok 2
```

**Parse warnings** — reported on the first run, silently gone on every later one:

```
# module with a duplicated `is export` trait
cold: warning printed
warm: nothing
```

A third candidate (inline `module Foo { ... is export }` registrations) was
measured and behaves identically cold and warm, so it is documented as a
deliberate non-entry rather than guessed at.

## Approach

Store the effects in the cache entry (`ParseEffects`) and replay them on a hit.
The module docs state the rule for future parser state, since anything new the
parser records in a thread-local becomes the next cache-state-dependent bug.

Three smaller defects in the same file, found while reading it:

- **Entries could not name themselves.** The file name is a 64-bit hash of the
  canonical path, but the path was not stored, so an entry was trusted purely
  for sitting at the expected name. Now stored and verified.
- **The cache grew without bound.** `clear_cache()` was dead code and nothing
  evicted an entry whose module stopped being loaded; one real checkout had
  accumulated **12,355 files**. Entries past a 4096 cap are now evicted
  oldest-first, at most once per process, only from the save path.
- **No way to disable it outside the CLI.** `--no-precomp` only reaches
  interpreters built by `main.rs`, so a test harness could not exercise the
  no-cache path. `MUTSU_PRECOMP=0` now disables it process-wide.

## Tests

- **`t/precomp-warm-cache-parity.t`** (new) — runs a probe twice against a
  private `XDG_CACHE_HOME`, demanding byte-identical stdout *and* stderr. The
  probe is `use v6.e.PREVIEW` and computes `sprintf('%#x', -256)` in its mainline
  (`-0x100` under 6.e, `0x-100` under 6.d) and carries a duplicated `is export`
  trait. Confirmed load-bearing by deleting the replay and watching the warm run
  print `0x-100` with no warning.
- **CI** re-runs the `S10-packages`/`S11-modules`/`S14-roles` slice (46 files,
  ~12s locally) after `make roast`, against the cache that run just warmed.
- 4 `precomp.rs` unit tests, 2 new (effects round-trip, entry naming a different
  source is rejected).
- `prove -j4 t/`: 2537 files / 24286 tests pass.
- Full whitelisted roast run **cold, then again warm** — see the comment below
  for the result.
- `cargo fmt --all`, `cargo clippy -- -D warnings`.

## Follow-up filed

`todo/tickets/module-parse-warning-reported-twice.md` — a module's parse warning
prints twice (rakudo prints once) because the source is parsed twice and both
drains print. This change made the count *consistent* cold vs warm; fixing the
duplication needs origins on warnings, which also fixes their misattributed
location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)