### PR TITLE
fix(dispatch): de-itemize a positional parameter, and let a user method outrank a builtin

### DIFF
--- a/news/2026-07/positional-param-deitemizes-and-user-method-precedence.md
+++ b/news/2026-07/positional-param-deitemizes-and-user-method-precedence.md
@@ -1,0 +1,69 @@
+# A positional parameter de-itemizes, and a user method outranks a same-named builtin
+
+Two independent dispatch/binding bugs, both surfaced by the same construct: the
+YAMLish battery's block-collection actions. With them fixed, `load-yaml` returns
+what raku returns for every block sequence and mapping.
+
+## An `@`-sigiled parameter de-itemizes its argument
+
+An `@` parameter is a *positional binding*: whatever Positional it is handed
+becomes the array's **elements**. An itemized one (`$(1,2)` — what a
+list-assignment destructure leaves in a scalar) therefore de-itemizes. mutsu did
+that for an ordinary `:@a`, but the attributive form wrote the value straight
+through to the attribute:
+
+```raku
+class S { has @.elems; submethod BUILD(:@!elems) {} }
+my ($cls, $elems) = (S, (1, 2));    # $elems is itemized
+$cls.new(:$elems).elems             # raku: 2 elements.  mutsu: held the list itself
+```
+
+Stored raw, `@!elems` ended up holding the list, so iterating the attribute
+yielded that list instead of its elements — `.map(*.concretize(…))` over
+YAMLish's `Sequence` called `concretize` on the `Array` rather than on each
+`Node`. `bind_param_value` now normalizes an itemized Positional for any
+`@`-sigiled parameter name. A plain attribute assignment (no BUILD) still keeps
+the item, because that is an assignment and not a binding.
+
+Pin: `t/positional-param-deitemizes.t`.
+
+## A user-declared method outranks a same-named builtin
+
+`call_method_with_values` consults three by-name dispatchers
+(`dispatch_method_by_name_1/2/3`) that key on the method *name* alone. They ran
+before user-method resolution, so a class that declared `map`, `elems`, `sort`,
+… could never be reached through that path:
+
+```raku
+grammar G { token TOP { <map> }; token map { … } }
+class Actions { method map($/) { … } }
+G.parse($text, :actions(Actions))
+# X::Cannot::Map: Cannot map a Match to a Actions, it's not callable.
+```
+
+A grammar dispatches the action named after each rule, and YAMLish's
+block-mapping rule is called `map`, so the action was answered by the collection
+builtin — which then rejected the Match as a non-callable block. The by-name
+dispatchers are now skipped when the target's class declares a method of that
+name, checked for the type object as well as an instance (`:actions(Actions)`
+passes the class). Nothing else changes: a class that does not declare the name
+still gets the builtin.
+
+Pin: `t/user-method-shadows-builtin-name.t`.
+
+## Result
+
+Together with the two fixes that landed earlier the same day — regex `{ }`
+side-effect blocks running inline (#5510) and nested type names being qualified
+by their enclosing package (#5511) — YAMLish's block collections now round-trip:
+
+```
+- 1\n- 2    =>  [1, 2]
+a: 1        =>  {a => 1}
+a: 1\nb: 2  =>  {a => 1, b => 2}
+- x\n- y    =>  ["x", True]
+```
+
+identical to raku on all four. The battery's remaining work is packaging
+(vendor into `modules/YAMLish/`, the `batteries.lock` + whitelist gate, the
+Batteries page row), not interpreter fixes.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -3673,18 +3673,47 @@ impl Interpreter {
             }
         }
 
+        // A method the *user declared* on this class outranks the by-name builtin
+        // dispatchers below, which key on the method name alone and would answer
+        // first. `Grammar.parse(:actions(A))` invokes the action named after each
+        // rule, so a grammar with a rule called `map` — YAMLish's block-mapping
+        // rule is exactly that — needs `A.map($/)` to reach the action method and
+        // not the collection builtin, which rejected the Match as "not callable".
+        // Checked for the type object too, since `:actions(A)` passes the class.
+        // `.WHAT` and friends are *macros*, not builtin methods: `$o.WHAT` is the
+        // type object even when the class declares `method WHAT`, and only the
+        // quoted `$o."WHAT"()` reaches it (roast/S12-methods/what.t). They keep
+        // their existing `skip_pseudo_method_native` handling.
+        let shadows_builtin = !is_pseudo_method
+            && match target.view() {
+                ValueView::Instance { class_name, .. } => {
+                    self.class_has_user_method(&class_name.resolve(), method)
+                }
+                ValueView::Package(name) => self.class_has_user_method(&name.resolve(), method),
+                _ => false,
+            };
+
         // Primary method dispatch by name (group 1: string, IO, coercion, misc)
-        if let Some(result) = self.dispatch_method_by_name_1(target.clone(), method, args.clone()) {
+        if !shadows_builtin
+            && let Some(result) =
+                self.dispatch_method_by_name_1(target.clone(), method, args.clone())
+        {
             return result;
         }
 
         // Primary method dispatch by name (group 2: collection/iteration)
-        if let Some(result) = self.dispatch_method_by_name_2(target.clone(), method, args.clone()) {
+        if !shadows_builtin
+            && let Some(result) =
+                self.dispatch_method_by_name_2(target.clone(), method, args.clone())
+        {
             return result;
         }
 
         // Primary method dispatch by name (group 3: Supply, network, temporal, misc)
-        if let Some(result) = self.dispatch_method_by_name_3(target.clone(), method, args.clone()) {
+        if !shadows_builtin
+            && let Some(result) =
+                self.dispatch_method_by_name_3(target.clone(), method, args.clone())
+        {
             return result;
         }
 

--- a/src/runtime/types/mod.rs
+++ b/src/runtime/types/mod.rs
@@ -376,6 +376,19 @@ impl Interpreter {
     }
 
     pub(in crate::runtime) fn bind_param_value(&mut self, name: &str, value: Value) {
+        // An `@`-sigiled parameter is a positional binding: whatever Positional it
+        // is given becomes *the array's elements*. An attributive one
+        // (`submethod BUILD(:@!elems)`) writes straight through to the attribute,
+        // so a List handed to it has to be re-homed into an Array first — stored
+        // raw, `@!elems` ends up holding the List itself and iterating the
+        // attribute yields that List instead of its elements (YAMLish's
+        // `Sequence.new(:$elems)`, where `$elems` came out of a list-assignment
+        // destructure).
+        let value = if name.starts_with('@') {
+            Self::normalize_positional_param_value(value)
+        } else {
+            value
+        };
         self.env.insert(name.to_string(), value.clone());
         // Extract attribute name from twigil params: $!x -> "x", @!types -> "types", %!h -> "h"
         let attr_name = if let Some(a) = name.strip_prefix('!') {
@@ -419,6 +432,30 @@ impl Interpreter {
             self.env.insert(format!("&{}", bare), value);
         } else if let Some(bare) = name.strip_prefix('^') {
             self.env.insert(bare.to_string(), value);
+        }
+    }
+
+    /// The array an `@`-sigiled parameter binds to for a given argument.
+    ///
+    /// An **itemized** Positional (`$(1,2)` / `$[1,2]` — what a list-assignment
+    /// destructure such as `my ($cls, $elems) = @(...)` leaves in `$elems`)
+    /// de-itemizes: binding it to `@a` makes its elements the array's elements,
+    /// not a single element holding the list. Every other value is passed through
+    /// untouched, so an ordinary Array keeps sharing the caller's container and a
+    /// non-Positional is left for the binder's type check to reject.
+    fn normalize_positional_param_value(value: Value) -> Value {
+        match value.view() {
+            // De-itemize in place: `$[…]` becomes an `Array` and `$(…)` a `List`,
+            // so `.raku` still renders the shape the argument had.
+            ValueView::Array(items, kind @ (ArrayKind::ItemList | ArrayKind::ItemArray)) => {
+                let deitemized = if kind == ArrayKind::ItemArray {
+                    ArrayKind::Array
+                } else {
+                    ArrayKind::List
+                };
+                Value::array_with_kind(items.clone(), deitemized)
+            }
+            _ => value,
         }
     }
 

--- a/t/positional-param-deitemizes.t
+++ b/t/positional-param-deitemizes.t
@@ -1,0 +1,52 @@
+use Test;
+
+plan 9;
+
+# An `@`-sigiled parameter is a positional binding: an *itemized* Positional
+# argument (`$(1,2)` — what a list-assignment destructure leaves in a scalar)
+# de-itemizes, so its elements become the array's elements. mutsu stored the
+# itemized value straight through on the attributive form
+# `submethod BUILD(:@!elems)`, leaving the attribute holding the list itself, so
+# iterating it yielded that list instead of its elements.
+
+class Elem { has $.v }
+
+class WithBuild {
+    has Elem @.elems;
+    submethod BUILD(:@!elems) {}
+}
+
+sub names(@seq) { @seq.map(*.^name).join(',') }
+
+my $itemized = (Elem.new(v => 'x'), Elem.new(v => 'y'));
+
+my $from-scalar = WithBuild.new(elems => $itemized);
+is $from-scalar.elems.elems, 2, 'the attribute has both elements';
+is names($from-scalar.elems), 'Elem,Elem', 'iterating the attribute yields the elements';
+
+# The same shape the YAMLish actions use: destructure, then pass on as `:$name`.
+my ($cls, $elems) = (WithBuild, (Elem.new(v => 'x'), Elem.new(v => 'y')));
+my $destructured = $cls.new(:$elems);
+is names($destructured.elems), 'Elem,Elem', 'a destructured scalar binds the same way';
+
+# A plain (non-itemized) list and an array variable were already correct.
+is names(WithBuild.new(elems => (Elem.new(v => 'x'), Elem.new(v => 'y'))).elems),
+    'Elem,Elem', 'a literal list still binds elementwise';
+my @arr = Elem.new(v => 'x'), Elem.new(v => 'y');
+is names(WithBuild.new(elems => @arr).elems), 'Elem,Elem', 'an array variable still binds elementwise';
+
+# A plain `@` parameter (no attribute twigil) is unchanged.
+sub takes(:@a) { names(@a) }
+is takes(a => $itemized), 'Elem,Elem', 'a plain :@a parameter de-itemizes too';
+
+# Assigning an itemized list to a positional attribute WITHOUT a BUILD keeps the
+# item — that is a plain assignment, not a positional binding.
+class NoBuild { has @.e }
+is NoBuild.new(e => $itemized).e.elems, 1, 'plain attribute assignment still keeps the item';
+
+# De-itemizing must preserve the shape: `$[…]` is an Array and `$(…)` a List, so
+# `.raku` still renders what the argument was (roast/S06-currying/positional.t
+# compares `@expect` bound from a `$[…]` against a plain Array with `eqv`).
+sub shape(@a) { @a.raku }
+is shape($['he']), ['he'].raku, 'an itemized Array de-itemizes to an Array';
+is shape($('he',)), ('he',).raku, 'an itemized List de-itemizes to a List';

--- a/t/user-method-shadows-builtin-name.t
+++ b/t/user-method-shadows-builtin-name.t
@@ -1,0 +1,41 @@
+use Test;
+
+plan 6;
+
+# A method the user declared on a class outranks a same-named builtin. The
+# runtime's by-name dispatchers key on the method name alone and used to answer
+# first, so a class method called `map`, `elems`, `sort`, ... was unreachable.
+# The shape that surfaced it: a grammar action class dispatches the action named
+# after each rule, so a grammar with a rule called `map` (YAMLish's block-mapping
+# rule) needs `Actions.map($/)` to reach the action and not the collection
+# builtin, which rejected the Match with "Cannot map a Match ..., it's not
+# callable".
+
+grammar RuleNamedMap {
+    token TOP   { <map> }
+    token map   { <entry>+ % ',' }
+    token entry { $<k>=[\w+] '=' $<v>=[\d+] }
+}
+class MapActions {
+    method TOP($/)   { make $<map>.ast }
+    method map($/)   { make ['MAP', @<entry>».ast] }
+    method entry($/) { make ~$<k> => +$<v> }
+}
+
+my $m = RuleNamedMap.parse('a=1,b=2', :actions(MapActions));
+ok $m.defined, 'a grammar rule named `map` parses with actions';
+is $m.ast.raku, ['MAP', [a => 1, b => 2]].raku, 'its action method ran, not the builtin .map';
+
+# The same shadowing, without grammars, on an instance and on the type object.
+class Shadower {
+    method map($x)  { "user-map($x)" }
+    method elems    { 'user-elems' }
+}
+is Shadower.new.map(7), 'user-map(7)', 'an instance reaches the user `map`';
+is Shadower.map(7),     'user-map(7)', 'the type object reaches the user `map`';
+is Shadower.new.elems,  'user-elems',  'a user `elems` outranks the builtin';
+
+# A class that does NOT declare the name still gets the builtin.
+class Plain { has @.items }
+is Plain.new(items => [1, 2, 3]).items.map(* * 2).join(','), '2,4,6',
+    'the builtin .map is untouched where nothing shadows it';

--- a/todo/deep/yamlish-block-collections-regex-vars.md
+++ b/todo/deep/yamlish-block-collections-regex-vars.md
@@ -1,10 +1,15 @@
-# YAMLish battery: block collections — regex side DONE, three downstream gaps left
+# YAMLish battery: block collections — RESOLVED
 
-**Status 2026-07-28.** The regex half of this ticket is finished: `(a)` and `(b)`
-below are both implemented, plus two gaps they exposed. `YAMLish::Grammar.parse`
-now returns the **byte-identical AST raku produces** for a block sequence
-(`- 1\n- 2`, `- x\n- y`). What is left is no longer regex work — see
-"Remaining after the regex work" at the bottom.
+**Status 2026-07-28: closed.** Everything this ticket tracked is fixed.
+`load-yaml` round-trips block sequences and mappings identically to raku. The
+regex half (`(a)`, `(b)`, plus `(c)` and two gaps they exposed) landed as PR
+#5510; the three downstream gaps are listed at the bottom. What remains for the
+battery is **packaging**, tracked in
+[[project-yaml-battery-campaign]] — see "Remaining after the regex work".
+
+This file should be `git mv`d to `news/2026-07/` once the packaging slice starts,
+per `todo/README.md`; it is kept here only so the next session has the full
+blocker chain in one place.
 
 
 
@@ -119,27 +124,40 @@ whole rule. It now sets the per-token `ratchet` flag on the token just emitted
 (`regex_parse_core.rs`); `::` / `:::` are left alone, and a `:` with no preceding
 atom still errors as raku does. Pin: `t/regex-standalone-backtrack-control.t`.
 
-## Remaining after the regex work
+## Remaining after the regex work — all three CLOSED (2026-07-28)
 
-`YAMLish::Grammar.parse("- 1\n- 2")` now yields the **same AST raku produces**,
-so the grammar is no longer the blocker. `load-yaml` still fails, on three
-independent non-regex gaps:
+`YAMLish::Grammar.parse` produced raku's AST once the regex work landed; three
+non-regex gaps stood between that and `load-yaml`, and all three are fixed:
 
-1. **`.new` on a grammar type object.** `Single.make-value` does
-   `$schema.new.parse($!value)` where `$schema` is `Schema::Core` (a grammar).
-   mutsu: `X::Method::NotFound: Unknown method value dispatch (fallback
-   disabled): new on YAMLish::Schema::Core`. Repro: `tmp/y6.raku`.
-2. **A positional attribute assigned an itemized list stays itemized.**
-   `Actions::root-block` does `my ($class, $elems) = @($<value>.ast); $class.new(:$elems)`
-   into `submethod BUILD(:@!elems)`. mutsu ends up with `@!elems` holding the
-   itemized value: `.elems` reports 2 but `for $seq.elems` iterates **once**,
-   yielding the `Array[Node]` itself, so `.map(*.concretize(…))` calls
-   `concretize` on the Array. Raku de-itemizes into the positional. Repro:
-   `tmp/y6.raku`; `tmp/y7.raku` shows the plain shapes all working, so it is
-   specific to the `:$elems`-from-a-scalar path.
-3. **The block `map` path throws.** `Grammar.parse("a: 1")` →
-   `X::Cannot::Map: Cannot map a Any to a Package` (sequences are fine). Not yet
-   root-caused. Repro: `tmp/y13.raku`.
+1. ✅ **`.new` on a nested type.** Not grammar-specific: `module M { class A::B }`
+   registered the ClassDef under the bare `A::B` while `.^name` said `M::A::B`, so
+   `M::A::B.new` could not find its own definition. PR #5511,
+   `t/nested-type-name-in-package.t`,
+   `news/2026-07/nested-type-name-qualified-by-package.md`.
+2. ✅ **An itemized list bound to a positional attribute.** `submethod
+   BUILD(:@!elems)` stored `$(1,2)` straight through, so `@!elems` held the list
+   itself and iterating it yielded that list.  An `@`-sigiled parameter now
+   de-itemizes. `t/positional-param-deitemizes.t`.
+3. ✅ **A user method losing to a same-named builtin.** The by-name dispatchers
+   (`dispatch_method_by_name_1/2/3`) key on the method name alone and ran before
+   user-method resolution, so YAMLish's action for its rule named `map` was
+   answered by the collection builtin. `t/user-method-shadows-builtin-name.t`.
+
+`load-yaml` now matches raku on every block collection:
+
+```
+- 1\n- 2    =>  [1, 2]
+a: 1        =>  {a => 1}
+a: 1\nb: 2  =>  {a => 1, b => 2}
+- x\n- y    =>  ["x", True]
+```
+
+**What is left for the battery is packaging, not interpreter work**: vendor into
+`modules/YAMLish/`, add the `batteries.lock` + `batteries-whitelist.txt` gate,
+the wasm Batteries page row, flip `docs/batteries/yaml.md` to bundled, and index
+it in BATTERIES.md §7. Worth a broader `load-yaml`/`save-yaml` sweep first (flow
+collections, block scalars, anchors/aliases, multi-document) to find what else
+the module exercises.
 
 ## Repro setup
 


### PR DESCRIPTION
Two independent binding/dispatch bugs, both surfaced by the YAMLish battery's block-collection actions. With them fixed, `load-yaml` returns what raku returns for every block sequence and mapping.

## An `@`-sigiled parameter de-itemizes its argument

An `@` parameter is a *positional binding*: whatever Positional it is handed becomes the array's **elements**, so an itemized one (`$(1,2)` — what a list-assignment destructure leaves in a scalar) de-itemizes. mutsu did that for an ordinary `:@a`, but the attributive form wrote the value straight through to the attribute:

```raku
class S { has @.elems; submethod BUILD(:@!elems) {} }
my ($cls, $elems) = (S, (1, 2));    # $elems is itemized
$cls.new(:$elems).elems             # raku: 2 elements.  mutsu: held the list itself
```

Stored raw, `@!elems` held the list, so iterating the attribute yielded that list instead of its elements — `.map(*.concretize(…))` over YAMLish's `Sequence` called `concretize` on the `Array` rather than on each `Node`.

`bind_param_value` now de-itemizes for any `@`-sigiled parameter name, **preserving the shape** (`$[…]` → Array, `$(…)` → List) so `.raku` still renders what the argument was — `roast/S06-currying/positional.t` compares an `@expect` bound from a `$[…]` against a plain Array with `eqv`. A plain attribute assignment (no BUILD) keeps the item, because that is an assignment and not a binding.

## A user-declared method outranks a same-named builtin

`call_method_with_values` consults three by-name dispatchers (`dispatch_method_by_name_1/2/3`) that key on the method *name* alone, and they ran before user-method resolution:

```raku
grammar G { token TOP { <map> }; token map { … } }
class Actions { method map($/) { … } }
G.parse($text, :actions(Actions))
# X::Cannot::Map: Cannot map a Match to a Actions, it's not callable.
```

A grammar dispatches the action named after each rule, and YAMLish's block-mapping rule is called `map`, so the action was answered by the collection builtin, which then rejected the Match as a non-callable block. Those dispatchers are now skipped when the target's class declares a method of that name — checked for the type object too, since `:actions(Actions)` passes the class.

`.WHAT` / `.WHO` / `.HOW` / … are **excluded**: they are macros, not builtin methods, so `$o.WHAT` stays the type object even when the class declares `method WHAT`, and only the quoted `$o."WHAT"()` reaches it (`roast/S12-methods/what.t`). Nothing else changes — a class that does not declare the name still gets the builtin.

## Result

With these and the two that landed earlier today — regex `{ }` side-effect blocks running inline (#5510) and nested type names qualified by their package (#5511) — YAMLish's block collections round-trip identically to raku:

```
- 1\n- 2    =>  [1, 2]
a: 1        =>  {a => 1}
a: 1\nb: 2  =>  {a => 1, b => 2}
- x\n- y    =>  ["x", True]
```

The battery's remaining work is packaging, not interpreter fixes; the deep ticket is updated accordingly.

## Testing

- New pins `t/positional-param-deitemizes.t` (9) and `t/user-method-shadows-builtin-name.t` (6) — **both also pass under raku**.
- `make test`: PASS (2536 files).
- `make roast`: PASS (1434 files / 218601 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)