### PR TITLE
docs(dbiish): record that BODY_OF is unblocked and name what remains

### DIFF
--- a/todo/tickets/dbiish-blockers.md
+++ b/todo/tickets/dbiish-blockers.md
@@ -221,11 +221,22 @@ container's element buffer, stable across calls. That is
 whose ADR is now written and accepted:
 [ADR-0015](../../docs/adr/0015-native-backed-container-storage-and-repr-bodies.md)
 (P0 = two small NativeCall fixes, P1 = bodies over handles, P2/P3 = native-backed
-container storage). The visible symptom is a parse failure in
-`StatementHandle` (`Unexpected block in infix position`), because the undeclared
-`BPointer` derails the rest of the file — check `use NativeHelpers::Blob; BPointer(Buf.new(1))`
-before chasing the parser. `DBDish::SQLite` does not go through `BODY_OF`, which
-is why the other eight files are unaffected.
+container storage). `DBDish::SQLite` does not go through `BODY_OF`, which is why
+the other eight files are unaffected.
+
+**Update: ADR-0015 P0/P1 are landed and `BODY_OF` works.** The recorded symptom
+above — a parse failure in `StatementHandle` (`Unexpected block in infix
+position`) caused by an undeclared `BPointer` — is stale. `BPointer` now
+resolves and runs all the way into `BODY_OF`, and
+`NativeHelpers::CStruct`'s `LinearArray` matches raku's output exactly
+(allocates, computes its stride, indexes, nativecasts, assigns element fields,
+disposes). What it hits now is one concrete, unrelated bug with a six-line
+repro: a `unit module` qualifies an *imported* type so `Pointer[t]` inside
+`NativeHelpers::Blob` resolves to `NativeHelpers::Blob::Pointer` and cannot be
+parameterized — see
+[`unit-module-qualifies-imported-type-parameterization.md`](unit-module-qualifies-imported-type-parameterization.md).
+Check `use NativeHelpers::Blob; BPointer(Buf.new(1,2,3))` to see where it stands
+before chasing anything else.
 
 ### ⑤ `06-types` — object hash keyed by type objects
 
@@ -341,10 +352,11 @@ is at 30 of 35. Two left:
 1. ~~**⑤** — `06-types`~~ **DONE 2026-07-26.** The punned role's container
    attributes and the `handles` delegation path converged on the instance cell;
    see [`news/2026-07/punned-role-container-attribute-store.md`](../../news/2026-07/punned-role-container-attribute-store.md).
-2. **⑨** — the `mysql` driver, and with it `01-basic`'s last three subtests. Do
-   not start it as a `DBIish` task: it is
-   [`todo/deep/nativehelpers-blob-moarvm-guts.md`](../deep/nativehelpers-blob-moarvm-guts.md),
-   which wants an ADR first.
+2. **⑨** — the `mysql` driver, and with it `01-basic`'s last three subtests.
+   The ADR it wanted is written and accepted (ADR-0015), and its P0/P1 have
+   landed, so `BODY_OF` and `LinearArray` now work. What remains is a single
+   named bug with a six-line repro:
+   [`unit-module-qualifies-imported-type-parameterization.md`](unit-module-qualifies-imported-type-parameterization.md).
 
 ## When these are cleared
 

--- a/todo/tickets/unit-module-qualifies-imported-type-parameterization.md
+++ b/todo/tickets/unit-module-qualifies-imported-type-parameterization.md
@@ -1,0 +1,62 @@
+# A `unit module` qualifies an *imported* type, breaking its parameterization
+
+Inside a `unit module`, a type that came from `use` is looked up under the
+module's own package before the import, so parameterizing it fails:
+
+```raku
+# tmp/qlib/QMod.rakumod
+unit module QMod;
+use NativeCall;
+sub make-ptr() is export {
+    my \t = uint8;
+    Pointer[t];
+}
+```
+
+```
+$ mutsu -I tmp/qlib -e 'use QMod; say make-ptr().^name;'
+QMod::Pointer cannot be parameterized
+  in sub make-ptr at tmp/qlib/QMod.rakumod line 1
+
+$ raku -I tmp/qlib -e 'use QMod; say make-ptr().^name;'
+NativeCall::Types::Pointer[uint8]
+```
+
+The bare (unparameterized) `Pointer` resolves fine — only the `[...]`
+parameterization takes the qualified path. The **block** form of the same
+module (`module QMod { ... }`) is unaffected, so this is specific to how
+`unit module` sets the current package for the statements that follow it.
+
+Reversing the order (`use NativeCall;` before `unit module QMod;`) is not a
+workaround — `unit module` must be the first statement.
+
+## Why it matters
+
+It is what now stops `NativeHelpers::Blob`'s `pointer-to` / `BPointer`, and with
+it `DBIish`'s mysql driver — the ⑨ row of
+[`dbiish-blockers.md`](dbiish-blockers.md). Both `NativeHelpers::Blob` and
+`MoarVM::Guts::REPRs` are `unit module`s that `use NativeCall` and write
+`Pointer[t]`:
+
+```
+$ mutsu -I <NativeHelpers-Blob>/lib -e 'use NativeHelpers::Blob; BPointer(Buf.new(1,2,3))'
+NativeHelpers::Blob::Pointer cannot be parameterized
+  in sub BODY_OF ...
+  in sub pointer-to ...
+  in sub BPointer ...
+```
+
+This is *progress*, not a regression: the ledger's recorded symptom for ⑨ was a
+parse failure in `DBDish::mysql::StatementHandle` caused by an undeclared
+`BPointer`. With [ADR-0015](../../docs/adr/0015-native-backed-container-storage-and-repr-bodies.md)
+P0/P1 landed, `BPointer` now resolves and runs all the way into `BODY_OF`; this
+name-qualification bug is what it hits there.
+
+## Where to look
+
+`SetCurrentPackage` and the unit-module package scoping added in #5369/#5370/
+#5373 — the type-parameterization path presumably resolves the base name
+through the current package without first consulting the lexical import, while
+the plain type-object lookup consults the import. Making the two agree (import
+first, then package) is the likely fix; check it against
+`t/lib-path-precedence.t` and the `unit module` pins from those PRs.


### PR DESCRIPTION
[ADR-0015](docs/adr/0015-native-backed-container-storage-and-repr-bodies.md) P0/P1 have landed (#5487, #5493, #5509), and the parameterised-role pun work (#5512) plus the subscript write-back fix (#5516) cleared `LinearArray`. The DBIish ledger's ⑨ row still described the *old* symptom — a parse failure in `DBDish::mysql::StatementHandle` caused by an undeclared `BPointer` — which no longer happens.

Current state, measured against the real `NativeHelpers::Blob` (not a stand-in):

- `BPointer` resolves and runs all the way into `BODY_OF`.
- `NativeHelpers::CStruct`'s `LinearArray` matches raku's output exactly: it allocates, computes its element stride from the role-body `my int $sol = nativesizeof(T)`, indexes, nativecasts, assigns element fields and disposes.
- What it hits now is one concrete, unrelated bug, filed with a six-line repro: a `unit module` qualifies an *imported* type, so `Pointer[t]` inside `NativeHelpers::Blob` resolves to `NativeHelpers::Blob::Pointer` and cannot be parameterized.

```
$ mutsu -I tmp/qlib -e 'use QMod; say make-ptr().^name;'
QMod::Pointer cannot be parameterized

$ raku -I tmp/qlib -e 'use QMod; say make-ptr().^name;'
NativeCall::Types::Pointer[uint8]
```

The block form (`module QMod { ... }`) is unaffected, so this is specific to how `unit module` sets the current package.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)