### PR TITLE
docs(adr-0015): survey P2 against main, and correct what §6 assumes

### DIFF
--- a/todo/deep/adr0015-p2-buf-storage-survey.md
+++ b/todo/deep/adr0015-p2-buf-storage-survey.md
@@ -1,0 +1,178 @@
+# ADR-0015 P2 (native-backed `Buf`/`Blob`) — implementation survey
+
+P2 is the only thing left between mutsu and `DBIish`'s mysql driver: `BODY_OF`
+runs, and stops on `Buf.REPR` answering `P6opaque` where raku answers `VMArray`
+(see the ⑨ row of [`../tickets/dbiish-blockers.md`](../tickets/dbiish-blockers.md)).
+This file is the measured survey of what P2 actually costs, taken 2026-07-28
+against `main`. It **refines** [ADR-0015](../../docs/adr/0015-native-backed-container-storage-and-repr-bodies.md)
+§6; it does not change any decision in it, so the ADR is left as `Accepted`
+rather than superseded. Three of the numbers and one of the mechanisms in §6
+turn out to be wrong, and the third one is the reason this is written down.
+
+## 1. `Buf`/`Blob` today
+
+There is no dedicated `Value` variant. A `Buf` is a plain `Value::Instance`
+(`src/value/mod.rs:1213`) with one attribute, `"bytes"`, holding
+`Value::array(Vec<Value>)` — **one boxed `Value::Int` per element**. Built by
+`build_native_buf_value` (`src/runtime/methods_object_native_ctors_buf_num.rs:77`).
+
+**Element width is not stored anywhere in the data.** It lives only in the class
+name string, and is recovered by matching on it: the construction-time mask is
+`cn.contains("64")` / `("32")` / `("16")` (`methods_object_native_ctors_buf_num.rs:56-74`),
+and `.^array_type` re-derives it in `array_element_type_name`
+(`src/runtime/methods_classhow_dispatch.rs:36-49`). The new node has to carry it,
+because a contiguous `Vec<u8>` cannot be interpreted without it.
+
+## 2. The `"bytes"` campaign is 104 sites, not 91
+
+`grep -rn '"bytes"' src/`: **110 occurrences in 45 files**, of which 6 are not
+attribute touches (method-name literals and comments). The real total is **104
+across ~40 files**:
+
+| kind | count | pattern |
+| --- | --- | --- |
+| reads | 63 | `.get("bytes")` |
+| writes | 38 | `"bytes".to_string()` as an insert key |
+| in-place | 2 | `with_attr_mut("bytes", …)` (`src/vm/vm_var_assign_index_named.rs:845,868`) |
+| probe | 1 | `contains_key("bytes")` (`src/vm/vm_var_assign_typed.rs:611`) |
+
+The ADR's "~91" matches the read count exactly (63) but undercounts writes (28
+vs the actual 38). The heaviest single file is
+`src/runtime/methods_mut_substr_buf.rs` (15). There is **no existing centralised
+accessor** — nothing named `buf_bytes`/`blob_bytes` exists; the nearest thing is
+`socket_helpers::extract_bytes`, scoped to `crate::runtime`.
+
+The touches are highly uniform, which is what makes the migration mechanical:
+reads are `attributes.as_map().get("bytes").map(Value::view)` matched against
+`ValueView::Array(items, ..)`, writes are
+`attrs.insert("bytes".to_string(), Value::array(vals))`. The companion class-name
+filter already exists — `runtime::utils::is_buf_or_blob_class`, 50 call sites.
+
+## 3. `.REPR` already has real machinery (P1 landed)
+
+`.REPR` is no longer a constant. `Interpreter::try_native_handle_repr_where`
+(`src/runtime/cstruct_layout.rs:603-647`) answers **CStruct, CUnion and CArray**
+honestly today, with `Pointer` handled for `.WHERE`. P2 extends that function; it
+does not start from scratch.
+
+Two details to keep in mind when extending it:
+
+- It is reached from **two** call sites which must stay in step —
+  `src/runtime/methods_call_dispatch.rs:68` and `src/vm/vm_native_dispatch.rs:51`
+  (whose comment records that doing it the other way round segfaults).
+- Its current gate keys off an `address` **attribute** being a positive `Int`,
+  i.e. a `nativecast`ed handle. A native-backed `Buf` has no such attribute, so
+  it needs a different discriminator — either the node's presence, or an
+  `address` synthesised from it.
+
+Everything else falls through to `"P6opaque"`
+(`src/runtime/methods_instance_ops.rs:1917`).
+
+## 4. ★ `native_object_where` cannot be extended into `MVMArrayB`
+
+This is the finding that matters, because ADR-0015 §6 describes P1's body block
+as "the shape `native_object_where` already established" and implies P2 extends
+it. It cannot. `native_object_where` (`src/runtime/nativecall.rs:409-424`) is:
+
+- **memoised by payload address** in a process-global map, so two objects at the
+  same address deliberately share one block;
+- **immutable after creation** — `vec![0usize; 16]` with only word 0 set;
+- **`Box::leak`ed permanently**, never freed.
+
+It satisfies P1 only because the CStruct body (`{void* cstruct; void** child_objs}`)
+and the unmanaged CArray body (`{void* storage; void** child; i32 managed; i32
+allocated; i32 elems}`) are both all-zero past word 0 — so one shared zero block
+is byte-identical to both (the reasoning is written out at
+`src/runtime/cstruct_layout.rs:590-599`). There is no `CStructB`/`CArrayB` Rust
+struct anywhere; the layouts exist only as Raku declarations in
+`t/nativecall-repr-body.t:19-30`.
+
+`MVMArrayB` is `{u64 elems; u64 start; u64 ssize; void* any}` — **three live
+non-zero words plus a data pointer**, all of which change when the buffer is
+appended to or reallocated. So P2 needs a **per-object, mutable, owned** block:
+
+- per-object, because sharing by payload address is wrong once the words differ
+  (and buffer addresses are reused after a free);
+- mutable, because ADR-0015 §2 contract 3 promises the body block stays put and
+  its data pointer is rewritten on realloc;
+- owned, because leaking 128 bytes per `Buf` is not acceptable — the block must
+  die with the node.
+
+The upside is that owning it gives a natural home for the teardown that
+`nativecall_pin`'s `release` hook currently performs from
+`impl Drop for InstanceAttrs`.
+
+## 5. Retiring `nativecall_pin.rs`
+
+109 lines, **4 non-test callers**:
+
+- `src/runtime/nativecall.rs:765` — `pin`, in the `CType::Buf` marshalling arm;
+- `src/runtime/nativecall.rs:361` — `read`, in the post-call writeback loop;
+- `src/value/value_instance.rs:342` — `release`, from `impl Drop for InstanceAttrs`.
+
+Three helpers in `nativecall.rs` go with it: `buf_instance_bytes` (`:800`, the
+boxed→`Vec<u8>` copy), `buf_instance_pin_key` (`:826`) and
+`write_buf_instance_bytes` (`:843`). Deleting the `release` call also removes an
+atomic load from every instance drop.
+
+`t/nativecall-buf-lifetime.t` (7 tests) is the behavioural pin — "the same Blob
+keeps the same C address across calls", "a distinct Blob gets a distinct C
+address". Both become *stronger* under P2, so the file should survive unchanged;
+if it needs editing, that is a signal the representation is wrong.
+
+## 6. Where the new GC node goes
+
+Nine `Gc<T>` node types exist today, enumerated in the nanbox refcount dispatch
+(`src/value/nanbox/mod.rs:433-449`) and the collector's scope comment
+(`src/gc/collect.rs:17-20`). A payload-only node holds no `Value`s, so
+`Trace::trace` is an empty body and `drop_gc_edges` / `finalize` keep their
+no-op defaults (trait at `src/gc/gc_ptr.rs:83-116`) — which is exactly what makes
+ADR-0001's type filter keep paying zero for it. `impl Trace for ArrayData`
+(`src/value/value_gc.rs:399`) is the shape to copy.
+
+Files a new kind must touch:
+
+| file | what |
+| --- | --- |
+| `src/value/mod.rs:1155` | new `ValueRepr` variant in the Gc-backed group |
+| `src/value/view.rs:25` | matching `ValueView` variant |
+| `src/value/nanbox/mod.rs:144` | `Kind` discriminant **inside the Gc-backed block**; the page budget assert at `:181` has headroom |
+| `src/value/nanbox/mod.rs:433` | the `gc_op::<T>` refcount arm |
+| `src/value/nanbox/{encode.rs:58,decode.rs:211}` | pack / unpack |
+| `src/value/nanbox/peek.rs:172,246,458` | the three borrowed-view tables |
+| `src/value/value_gc.rs` | `impl Trace` (empty) and the `Value::gc_trace` arm |
+| `src/value/serde_support.rs` | the exhaustive `ValueRepr` match |
+
+Writes into the buffer use ADR-0013's `GcBox` interior mutability so they have
+valid provenance.
+
+## 7. The acceptance test already exists and says what to flip
+
+`t/nativecall-repr-body.t` (15 tests) declares Raku-side `CStructB`/`CArrayB`
+byte-identical to `MoarVM::Guts::REPRs`, and derives the body offset by scanning
+for a sentinel exactly as that module derives `Offset` — it does not assume 0.
+Its last assertion is the one P2 inverts:
+
+```raku
+is Buf.new(1, 2, 3).REPR, 'P6opaque', 'a Buf has no body yet either';
+```
+
+P2 must, **in one commit** (ADR §2.1's ordering rule), add an `MVMArrayB`
+declaration plus its offset probe, flip that assertion to `'VMArray'`, and bump
+`plan 15`. `docs/nativecall-repr-bodies.md` — the compatibility-surface document
+ADR §4 promises — does not exist yet and is part of P2.
+
+## Suggested slicing
+
+1. **Accessors first, no representation change.** Introduce the `buf_elems` /
+   `set_buf_elems` / `make_buf` pair and route all 104 touches through it. Purely
+   mechanical, behaviour-preserving, and a prerequisite under any sequencing —
+   the representation cannot be swapped while 40 files reach into the attribute
+   map directly.
+2. **The node**, behind those accessors: contiguous `Vec<u8>` + element width,
+   with the encode/decode the accessors now hide.
+3. **The body and the honest `.REPR`**, in one commit with the `MVMArrayB` test,
+   plus the deletion of `nativecall_pin.rs` and its three helpers.
+
+Step 1 is large but has no design content left; steps 2 and 3 are where the
+judgment is.

--- a/todo/tickets/dbiish-blockers.md
+++ b/todo/tickets/dbiish-blockers.md
@@ -373,9 +373,14 @@ is at 30 of 35. Two left:
    as of 2026-07-28 so has the last of the small named bugs in front of it (the
    `unit module` prelude capture). **The only thing left is ADR-0015 P2** —
    native-backed `Buf`/`Blob` with an honest `VMArray` `.REPR` and an `MVMArrayB`
-   body. That is the campaign, not a slice: a new payload-only GC node, the two
-   `buf_bytes` accessors over the ~91 direct `"bytes"` touches, and the deletion
-   of `runtime/nativecall_pin.rs`. See ⑨ above for the exact current failure.
+   body. That is the campaign, not a slice. It has been surveyed against `main`:
+   [`todo/deep/adr0015-p2-buf-storage-survey.md`](../deep/adr0015-p2-buf-storage-survey.md)
+   has the measured touch count (104, not the ADR's ~91), the `.REPR` machinery
+   P1 already left in place, and — the load-bearing correction —
+   **`native_object_where` cannot be extended into `MVMArrayB`**: it is memoised
+   by payload address, immutable and leaked, which only works because the
+   CStruct/CArray bodies are all-zero past word 0. Read it before starting. See
+   ⑨ above for the exact current failure.
 
 ## When these are cleared
 


### PR DESCRIPTION
ADR-0015 P2 (native-backed `Buf`/`Blob`) is now the only thing between mutsu and
`DBIish`'s mysql driver — `BODY_OF` runs and stops on `Buf.REPR` answering
`P6opaque`. It is a campaign, so I surveyed it against `main` before starting.
Three of §6's numbers and one of its mechanisms do not hold.

**The `"bytes"` migration is 104 touches across ~40 files, not ~91.** 110 `grep`
hits in 45 files, 6 of which are method-name literals or comments. The ADR's
figure matches the read count exactly (63) but undercounts writes: 38, not 28.

**`.REPR` already has real machinery.** P1 left
`try_native_handle_repr_where` (`src/runtime/cstruct_layout.rs:603`) answering
CStruct, CUnion and CArray honestly, reached from two call sites that must stay
in step (`methods_call_dispatch.rs:68` and `vm_native_dispatch.rs:51`, whose
comment records that the other order segfaults). P2 extends it rather than
starting from a constant — and its gate keys off an `address` *attribute*, which
a native-backed `Buf` will not have.

**★ `native_object_where` cannot be extended into `MVMArrayB`.** §6 describes
P1's body block as the shape P2 builds on. It is memoised by payload address in
a process-global map, immutable after creation, and `Box::leak`ed permanently —
and it satisfies P1 only because the CStruct body and the unmanaged CArray body
are both all-zero past word 0, so one shared zero block is byte-identical to
both. `MVMArrayB` is `{u64 elems; u64 start; u64 ssize; void* any}`: three live
words plus a data pointer, all of which change on append or realloc. P2 needs a
**per-object, mutable, node-owned** block — sharing by payload address is wrong
once the words differ (buffer addresses get reused after a free), and leaking
128 bytes per `Buf` is not acceptable.

Also recorded: element width currently exists **only inside the class-name
string** (`cn.contains("64")`), so the node must carry it; the exact files a new
payload-only GC node must touch (the nanbox tables, an empty `Trace`); the four
callers of `nativecall_pin.rs` and the three helpers that go with it; and that
`t/nativecall-repr-body.t`'s last assertion (`Buf.new(1,2,3).REPR eq
'P6opaque'`) is the one P2 must invert **in the same commit** as the body, per
§2.1's ordering rule.

No decision in ADR-0015 changes, so it stays `Accepted` rather than superseded.
The survey is a `todo/deep/` entry and the DBIish ledger's ⑨ now points at it.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)