### PR TITLE
refactor(buf): route all Buf/Blob storage access through one accessor layer

### DIFF
--- a/news/2026-07/buf-storage-accessor-chokepoint.md
+++ b/news/2026-07/buf-storage-accessor-chokepoint.md
@@ -1,0 +1,56 @@
+# `Buf`/`Blob` element storage has a single accessor chokepoint
+
+A `Buf` has no dedicated `Value` variant: it is a `Value::Instance` whose one
+attribute, `"bytes"`, holds a `Value::Array` with one boxed `Value::Int` per
+element. Until now every place that touched that storage spelled the attribute
+name itself and open-coded the `ValueView::Array` match — **104 touches across
+~40 files**, with no centralised accessor anywhere. That is what made ADR-0015
+P2 (a native-backed contiguous buffer, so `Buf.REPR` can honestly answer
+`VMArray` and NativeCall can hand C a real `MVMArrayB` body) a forty-file change
+rather than a one-file change.
+
+The new `src/value/value_buf.rs` is that chokepoint. The attribute name is
+`const ELEMS_ATTR`, private to the module, and all 104 touches now go through
+one of its functions. Two levels are offered deliberately:
+
+- the **element** functions (`buf_elems`, `buf_elems_or_empty`, `buf_elems_in`,
+  `with_buf_elems`, `with_buf_elems_mut`, `set_buf_elems`, `store_buf_elems`,
+  `buf_attrs`, `make_buf`, `make_buf_from_u8`, `bytes_to_elems`) decode to and
+  from `Vec<Value>`; under P2 they become the encode/decode boundary;
+- the **storage** functions (`buf_storage`, `set_buf_storage`,
+  `buf_elems_as_array`) move the container across *without* decoding it, for the
+  coercions that only re-tag a buffer (`.Buf`, `.Blob`, `.List`); under P2 they
+  become a node share.
+
+`buf_elems` deliberately returns `Option`, because "no element storage at all"
+(a `Blob` **type object** — `$*DISTRO.signature`) and "an empty buffer" are
+different things at several call sites, including the string-interpolation arm
+that decides whether to raise `X::Buf::AsStr`. `has_buf_elems` is the probe for
+that distinction.
+
+This is a pure refactor: no behaviour changes, and it is smaller than what it
+replaced (45 files, +358/-597). Two nuances were worth preserving rather than
+tidying away:
+
+- The three byte-decoding conventions in the tree (truncating `as u8`,
+  `.clamp(0, 255) as u8`, and `to_f64() as u8`) are **not** unified — that would
+  be a behaviour change, so each caller keeps its own decode over a borrowed
+  element slice from `with_buf_elems`.
+- `.List`/`.list`/`.Array` on a Buf shares the backing array node rather than
+  copying it. `buf_elems_as_array` keeps that share. It is invisible either way,
+  because element writes go through `with_buf_elems_mut`, whose `Gc::make_mut`
+  forks a shared node — but copying would have added an allocation to every
+  such coercion.
+
+The two remaining `"bytes"` literals outside the module are the Raku **method**
+name `.bytes` in dispatch tables, not attribute keys.
+
+This is step 1 of the three-step slicing in
+[`todo/deep/adr0015-p2-buf-storage-survey.md`](../../todo/deep/adr0015-p2-buf-storage-survey.md).
+Steps 2 (the node) and 3 (the `MVMArrayB` body and the honest `.REPR`) are where
+the design judgment lives, and they are now changes to one file plus the GC
+plumbing rather than to forty callers.
+
+Pin: `src/value/value_buf.rs` unit tests (4), covering the round trip, the
+absent-vs-empty distinction, in-place mutation seen through an alias, and the
+storage hand-off.

--- a/src/builtins/buf_write_int.rs
+++ b/src/builtins/buf_write_int.rs
@@ -6,6 +6,7 @@
 //   (similarly for write-int8, write-uint16, ..., write-int128)
 
 use crate::symbol::Symbol;
+use crate::value::value_buf::{bytes_to_elems, set_buf_elems, with_buf_elems};
 use crate::value::{InstanceAttrs, RuntimeError, Value, ValueView};
 
 /// Returns Some((byte_size, is_signed)) if the method is a write-int/uint method.
@@ -185,9 +186,7 @@ pub(crate) fn try_native_buf_write(
             if !crate::runtime::utils::is_buf_or_blob_class(&cn) {
                 return None;
             }
-            if let Some(ValueView::Array(items, ..)) =
-                attributes.as_map().get("bytes").map(Value::view)
-            {
+            with_buf_elems(&attributes, |items| {
                 bytes.reserve(items.len());
                 for it in items.iter() {
                     bytes.push(match it.view() {
@@ -196,7 +195,7 @@ pub(crate) fn try_native_buf_write(
                         _ => 0,
                     });
                 }
-            }
+            });
             inst = Some(BufWriteCell {
                 attributes: attributes.clone(),
                 class_sym: class_name,
@@ -236,10 +235,7 @@ pub(crate) fn try_native_buf_write(
     match inst {
         Some(cell) => {
             let mut updated_map = cell.attributes.to_map();
-            updated_map.insert(
-                "bytes".to_string(),
-                Value::array(bytes.into_iter().map(|b| Value::int(b as i64)).collect()),
-            );
+            set_buf_elems(&mut updated_map, bytes_to_elems(&bytes));
             Some(Ok(Value::write_back_sharing(
                 &cell.attributes,
                 cell.class_sym,

--- a/src/builtins/buf_write_num.rs
+++ b/src/builtins/buf_write_num.rs
@@ -4,6 +4,7 @@
 //   method write-num32(::T:U: $offset, num32 $value, $endian = NativeEndian --> Buf:D)
 //   method write-num32(Buf:D: $offset, num32 $value, $endian = NativeEndian --> Buf:D)
 
+use crate::value::value_buf::bytes_to_elems;
 use crate::value::{RuntimeError, Value, ValueView};
 
 /// Returns Some(size_in_bytes) if the method is a write-num method.
@@ -88,9 +89,5 @@ pub(crate) fn apply_write_num(
 /// Build a fresh Buf instance value from a byte vector.
 pub(crate) fn make_buf_value(class_name: &str, bytes: Vec<u8>) -> Value {
     use crate::symbol::Symbol;
-    use std::collections::HashMap;
-    let items: Vec<Value> = bytes.into_iter().map(|b| Value::int(b as i64)).collect();
-    let mut attrs = HashMap::new();
-    attrs.insert("bytes".to_string(), Value::array(items));
-    Value::make_instance(Symbol::intern(class_name), attrs)
+    crate::value::value_buf::make_buf(Symbol::intern(class_name), bytes_to_elems(&bytes))
 }

--- a/src/builtins/iterator_construct.rs
+++ b/src/builtins/iterator_construct.rs
@@ -29,10 +29,7 @@ fn blob_elements(target: &Value) -> Option<Vec<Value>> {
     if !crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) {
         return None;
     }
-    match attributes.as_map().get("bytes").map(Value::view) {
-        Some(ValueView::Array(items, ..)) => Some(items.to_vec()),
-        _ => Some(Vec::new()),
-    }
+    Some(crate::value::value_buf::buf_elems_or_empty(&attributes))
 }
 
 /// Build the `Iterator` instance for a `.iterator` call on a plain receiver.

--- a/src/builtins/methods_0arg/coercion.rs
+++ b/src/builtins/methods_0arg/coercion.rs
@@ -308,13 +308,11 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                     || cn.starts_with("blob")
             } =>
             {
-                if let Some(ValueView::Array(items, ..)) =
-                    attributes.as_map().get("bytes").map(Value::view)
-                {
-                    Some(Ok(Value::array_with_kind(
-                        items.clone(),
-                        crate::value::ArrayKind::List,
-                    )))
+                if let Some(list) = crate::value::value_buf::buf_elems_as_array(
+                    &attributes.as_map(),
+                    crate::value::ArrayKind::List,
+                ) {
+                    Some(Ok(list))
                 } else {
                     Some(Ok(Value::array_with_kind(
                         crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),
@@ -563,11 +561,9 @@ pub(super) fn dispatch(target: &Value, method: &str) -> Option<Result<Value, Run
                         || cn.starts_with("blob")
                 } =>
                 {
-                    let bytes = match attributes.as_map().get("bytes").map(Value::view) {
-                        Some(ValueView::Array(items, ..)) => items.to_vec(),
-                        _ => Vec::new(),
-                    };
-                    Some(Ok(wrap(bytes)))
+                    Some(Ok(wrap(crate::value::value_buf::buf_elems_or_empty(
+                        &attributes,
+                    ))))
                 }
                 // A shaped array falls through to the slow path (flatten + Nil
                 // → type-default). Non-shaped arrays keep the fast path.
@@ -847,10 +843,7 @@ fn value_to_capture(target: &Value) -> Result<Value, RuntimeError> {
                 || cn.starts_with("blob")
         } =>
         {
-            let positional = match attributes.as_map().get("bytes").map(Value::view) {
-                Some(ValueView::Array(items, ..)) => items.iter().cloned().collect(),
-                _ => vec![],
-            };
+            let positional = crate::value::value_buf::buf_elems_or_empty(&attributes);
             Ok(Value::capture(positional, HashMap::new()))
         }
         // Numeric types follow Mu.Capture: public attributes become nameds.

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -2,6 +2,7 @@
 /// Num, Real, Numeric, Bridge
 use crate::runtime;
 use crate::symbol::Symbol;
+use crate::value::value_buf::{buf_storage, set_buf_storage, with_buf_elems};
 use crate::value::{RuntimeError, Value, ValueView};
 use num_traits::{ToPrimitive, Zero};
 use std::sync::Arc;
@@ -137,13 +138,11 @@ pub(super) fn dispatch(
         } = target.view()
         && crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve())
     {
-        let bytes = attributes
-            .as_map()
-            .get("bytes")
-            .cloned()
-            .unwrap_or_else(|| Value::array(Vec::new()));
-        let mut attrs = std::collections::HashMap::new();
-        attrs.insert("bytes".to_string(), bytes);
+        let mut attrs = crate::value::AttrMap::new();
+        set_buf_storage(
+            &mut attrs,
+            buf_storage(&attributes.as_map()).unwrap_or_else(|| Value::array(Vec::new())),
+        );
         let target_class = if method == "Buf" { "Buf" } else { "Blob" };
         return Some(Some(Ok(Value::make_instance(
             Symbol::intern(target_class),
@@ -753,13 +752,7 @@ pub(super) fn dispatch(
                     attributes,
                     ..
                 } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                    if let Some(ValueView::Array(bytes, ..)) =
-                        attributes.as_map().get("bytes").map(Value::view)
-                    {
-                        Value::int(bytes.len() as i64)
-                    } else {
-                        Value::int(0)
-                    }
+                    Value::int(with_buf_elems(&attributes, <[Value]>::len).unwrap_or(0) as i64)
                 }
                 // A StrDistance's `.Int` is the edit distance between its
                 // before/after strings, matching `+$str-dist` / `.Numeric`.
@@ -1096,13 +1089,7 @@ pub(super) fn dispatch(
                     attributes,
                     ..
                 } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                    if let Some(ValueView::Array(bytes, ..)) =
-                        attributes.as_map().get("bytes").map(Value::view)
-                    {
-                        Value::int(bytes.len() as i64)
-                    } else {
-                        Value::int(0)
-                    }
+                    Value::int(with_buf_elems(&attributes, <[Value]>::len).unwrap_or(0) as i64)
                 }
                 ValueView::Instance {
                     class_name,

--- a/src/builtins/methods_0arg/dispatch_core_list.rs
+++ b/src/builtins/methods_0arg/dispatch_core_list.rs
@@ -1,5 +1,6 @@
 /// List/sequence operations: end, flat, sort, reverse, unique, repeated, floor,
 /// ceiling, round, truncate, narrow, sqrt
+use crate::value::value_buf::{buf_elems_or_empty, make_buf, with_buf_elems};
 use crate::value::{RuntimeError, Value, ValueView};
 use num_traits::{Signed, Zero};
 
@@ -31,13 +32,8 @@ pub(super) fn dispatch(
                     attributes,
                     ..
                 } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                    if let Some(ValueView::Array(bytes, ..)) =
-                        attributes.as_map().get("bytes").map(Value::view)
-                    {
-                        Some(Ok(Value::int(bytes.len() as i64 - 1)))
-                    } else {
-                        Some(Ok(Value::int(-1)))
-                    }
+                    let len = with_buf_elems(&attributes, <[Value]>::len).unwrap_or(0);
+                    Some(Ok(Value::int(len as i64 - 1)))
                 }
                 ValueView::LazyList(_) => None,
                 _ => Some(Ok(Value::int(0))),
@@ -166,17 +162,9 @@ pub(super) fn dispatch(
                 attributes,
                 ..
             } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                let mut bytes = if let Some(ValueView::Array(items, ..)) =
-                    attributes.as_map().get("bytes").map(Value::view)
-                {
-                    items.to_vec()
-                } else {
-                    Vec::new()
-                };
+                let mut bytes = buf_elems_or_empty(&attributes);
                 bytes.reverse();
-                let mut attrs = std::collections::HashMap::new();
-                attrs.insert("bytes".to_string(), Value::array(bytes));
-                Some(Ok(Value::make_instance(class_name, attrs)))
+                Some(Ok(make_buf(class_name, bytes)))
             }
             _ => None,
         }),

--- a/src/builtins/methods_0arg/dispatch_core_math.rs
+++ b/src/builtins/methods_0arg/dispatch_core_math.rs
@@ -605,12 +605,9 @@ pub(super) fn dispatch(
         "tree" => Some(Some(Ok(tree_to_depth(target, usize::MAX)))),
         "encode" => {
             let s = target.to_string_value();
-            let bytes: Vec<Value> = s.as_bytes().iter().map(|&b| Value::int(b as i64)).collect();
-            let mut attrs = std::collections::HashMap::new();
-            attrs.insert("bytes".to_string(), Value::array(bytes));
-            Some(Some(Ok(Value::make_instance(
+            Some(Some(Ok(crate::value::value_buf::make_buf(
                 Symbol::intern("utf8"),
-                attrs,
+                crate::value::value_buf::bytes_to_elems(s.as_bytes()),
             ))))
         }
         "sink" => Some(match target.view() {

--- a/src/builtins/methods_0arg/dispatch_core_numeric.rs
+++ b/src/builtins/methods_0arg/dispatch_core_numeric.rs
@@ -128,13 +128,10 @@ pub(super) fn dispatch(
                     attributes,
                     ..
                 } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                    if let Some(ValueView::Array(bytes, ..)) =
-                        attributes.as_map().get("bytes").map(Value::view)
-                    {
-                        Value::int(bytes.len() as i64)
-                    } else {
-                        Value::int(0)
-                    }
+                    Value::int(
+                        crate::value::value_buf::with_buf_elems(&attributes, <[Value]>::len)
+                            .unwrap_or(0) as i64,
+                    )
                 }
                 ValueView::Channel(_) => {
                     return Some(Some(Err(RuntimeError::new(

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -274,9 +274,7 @@ pub(super) fn dispatch(
             attributes,
             ..
         } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-            if let Some(ValueView::Array(bytes, ..)) =
-                attributes.as_map().get("bytes").map(Value::view)
-            {
+            if let Some(bytes) = crate::value::value_buf::buf_elems(&attributes) {
                 if method == "raku" || method == "perl" {
                     let elems: Vec<String> = bytes
                         .iter()

--- a/src/builtins/methods_0arg/dispatch_core_unicode.rs
+++ b/src/builtins/methods_0arg/dispatch_core_unicode.rs
@@ -28,13 +28,8 @@ pub(super) fn dispatch(
                     || cn.starts_with("blob")
             } =>
             {
-                let elems = if let Some(ValueView::Array(bytes, ..)) =
-                    attributes.as_map().get("bytes").map(Value::view)
-                {
-                    bytes.len() as i64
-                } else {
-                    0
-                };
+                let elems = crate::value::value_buf::with_buf_elems(&attributes, <[Value]>::len)
+                    .unwrap_or(0) as i64;
                 let cn = class_name.resolve();
                 let bytes_per_elem: i64 = if cn.contains("16") {
                     2

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1260,11 +1260,9 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
         && let ValueView::Instance { attributes, .. } = target.view()
         && crate::runtime::Interpreter::is_buf_value(target)
     {
-        if let Some(ValueView::Array(bytes, ..)) = attributes.as_map().get("bytes").map(Value::view)
-        {
-            return Some(Ok(Value::array(bytes.to_vec())));
-        }
-        return Some(Ok(Value::array(Vec::new())));
+        return Some(Ok(Value::array(
+            crate::value::value_buf::buf_elems_or_empty(&attributes),
+        )));
     }
 
     // CX::Warn methods: message, resume

--- a/src/builtins/methods_narg/buf.rs
+++ b/src/builtins/methods_narg/buf.rs
@@ -1,4 +1,5 @@
 use crate::symbol::Symbol;
+use crate::value::value_buf::{buf_elems, make_buf, with_buf_elems};
 use crate::value::{RuntimeError, Value, ValueView};
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
@@ -28,19 +29,15 @@ pub(crate) fn buf_class_name(val: &Value) -> String {
 }
 
 pub(crate) fn buf_get_int_items(target: &Value) -> Option<Vec<Value>> {
-    if let ValueView::Instance { attributes, .. } = target.view()
-        && let Some(ValueView::Array(items, ..)) = attributes.as_map().get("bytes").map(Value::view)
-    {
-        Some(items.to_vec())
+    if let ValueView::Instance { attributes, .. } = target.view() {
+        buf_elems(&attributes)
     } else {
         None
     }
 }
 
 pub(crate) fn make_buf_from_int_items(class_name: &str, items: &[Value]) -> Value {
-    let mut attrs = std::collections::HashMap::new();
-    attrs.insert("bytes".to_string(), Value::array(items.to_vec()));
-    Value::make_instance(Symbol::intern(class_name), attrs)
+    make_buf(Symbol::intern(class_name), items.to_vec())
 }
 
 pub(crate) fn eval_whatever_code(sub_data: &crate::gc::Gc<crate::value::SubData>, arg: i64) -> i64 {
@@ -141,17 +138,17 @@ pub(crate) fn buf_get_bytes(target: &Value) -> Option<Vec<u8>> {
         ..
     } = target.view()
         && crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve())
-        && let Some(ValueView::Array(items, ..)) = attributes.as_map().get("bytes").map(Value::view)
-    {
-        return Some(
+        && let Some(bytes) = with_buf_elems(&attributes, |items| {
             items
                 .iter()
                 .map(|v| match v.view() {
                     ValueView::Int(i) => i as u8,
                     _ => 0,
                 })
-                .collect(),
-        );
+                .collect::<Vec<u8>>()
+        })
+    {
+        return Some(bytes);
     }
     None
 }

--- a/src/builtins/methods_narg/dispatch_1arg.rs
+++ b/src/builtins/methods_narg/dispatch_1arg.rs
@@ -515,10 +515,12 @@ pub(crate) fn native_method_1arg(
                         attributes,
                         ..
                     } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                        if let Some(ValueView::Array(bytes, ..)) =
-                            attributes.as_map().get("bytes").map(Value::view)
+                        if let Some(b) =
+                            crate::value::value_buf::with_buf_elems(&attributes, |items| {
+                                items.get(idx).cloned().unwrap_or(Value::int(0))
+                            })
                         {
-                            return Some(Ok(bytes.get(idx).cloned().unwrap_or(Value::int(0))));
+                            return Some(Ok(b));
                         }
                         Some(Ok(Value::int(0)))
                     }

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -285,9 +285,10 @@ fn decode_buf_target_bytes(target: &Value, encoding_name: &str) -> Option<Vec<u8
     }
 
     let map = attributes.as_map();
-    let ValueView::Array(items, ..) = map.get("bytes")?.view() else {
-        return Some(Vec::new());
-    };
+    if !crate::value::value_buf::has_buf_elems_in(&map) {
+        return None;
+    }
+    let items = crate::value::value_buf::buf_elems_in(&map).unwrap_or_default();
 
     let cn = class_name.resolve();
     // buf16 / Buf[uint16] / utf16 store 16-bit code units; expand each to 2 bytes

--- a/src/runtime/builtins_collection_mapgrep.rs
+++ b/src/runtime/builtins_collection_mapgrep.rs
@@ -305,11 +305,8 @@ impl Interpreter {
                 || cn.starts_with("Blob[")
                 || cn.starts_with("buf")
                 || cn.starts_with("blob");
-            if is_blob
-                && let Some(ValueView::Array(bytes, ..)) =
-                    attributes.as_map().get("bytes").map(Value::view)
-            {
-                return Some(bytes.iter().cloned().collect());
+            if is_blob && let Some(bytes) = crate::value::value_buf::buf_elems(&attributes) {
+                return Some(bytes);
             }
         }
         None

--- a/src/runtime/builtins_eval_misc.rs
+++ b/src/runtime/builtins_eval_misc.rs
@@ -272,16 +272,17 @@ impl Interpreter {
                     ..
                 } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
                     // Buf argument: decode as UTF-8
-                    if let Some(bytes_val) = attributes.as_map().get("bytes")
-                        && let ValueView::Array(items, _) = bytes_val.view()
+                    if let Some(bytes) =
+                        crate::value::value_buf::with_buf_elems(&attributes, |items| {
+                            items
+                                .iter()
+                                .map(|v| match v.view() {
+                                    ValueView::Int(n) => n as u8,
+                                    _ => v.to_string_value().parse::<u8>().unwrap_or(0),
+                                })
+                                .collect::<Vec<u8>>()
+                        })
                     {
-                        let bytes: Vec<u8> = items
-                            .iter()
-                            .map(|v| match v.view() {
-                                ValueView::Int(n) => n as u8,
-                                _ => v.to_string_value().parse::<u8>().unwrap_or(0),
-                            })
-                            .collect();
                         let code = String::from_utf8_lossy(&bytes).to_string();
                         return self.eval_eval_string(&code);
                     }

--- a/src/runtime/builtins_io.rs
+++ b/src/runtime/builtins_io.rs
@@ -215,9 +215,10 @@ impl Interpreter {
                 .into_iter()
                 .map(|b| Value::int(i64::from(b)))
                 .collect();
-            let mut attrs = HashMap::new();
-            attrs.insert("bytes".to_string(), Value::array(byte_vals));
-            return Ok(Value::make_instance(Symbol::intern("Buf[uint8]"), attrs));
+            return Ok(crate::value::value_buf::make_buf(
+                Symbol::intern("Buf[uint8]"),
+                byte_vals,
+            ));
         }
         // If a non-UTF-8 encoding is specified, read raw bytes and decode
         let needs_non_utf8 = enc.as_ref().is_some_and(|e| {

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -10,6 +10,9 @@ use super::*;
 use crate::symbol::Symbol;
 use crate::value::ValueView;
 use crate::value::signature::extract_sig_info;
+use crate::value::value_buf::{
+    buf_elems_or_empty, bytes_to_elems, make_buf, set_buf_elems, with_buf_elems,
+};
 
 impl Interpreter {
     /// A `.raku`-legal identifier derived from a `rakuseen` id, used for the
@@ -643,9 +646,7 @@ impl Interpreter {
                         attributes,
                         ..
                     } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                        if let Some(ValueView::Array(items, _)) =
-                            attributes.as_map().get("bytes").map(|b| b.view())
-                        {
+                        with_buf_elems(&attributes, |items| {
                             let bytes: Vec<u8> = items
                                 .iter()
                                 .map(|v| match v.view() {
@@ -654,9 +655,8 @@ impl Interpreter {
                                 })
                                 .collect();
                             String::from_utf8_lossy(&bytes).to_string()
-                        } else {
-                            String::new()
-                        }
+                        })
+                        .unwrap_or_default()
                     }
                     _ => v.to_string_value(),
                 },
@@ -773,19 +773,17 @@ impl Interpreter {
                     } => {
                         let cn = class_name.resolve();
                         if crate::runtime::utils::is_buf_or_blob_class(&cn) {
-                            let mut v: Vec<u8> = Vec::new();
-                            if let Some(ValueView::Array(items, ..)) =
-                                attributes.as_map().get("bytes").map(|b| b.view())
-                            {
-                                v.reserve(items.len());
-                                for it in items.iter() {
-                                    v.push(match it.view() {
+                            let v = with_buf_elems(&attributes, |items| {
+                                items
+                                    .iter()
+                                    .map(|it| match it.view() {
                                         ValueView::Int(i) => i.clamp(0, 255) as u8,
                                         ValueView::Num(f) => (f as i64).clamp(0, 255) as u8,
                                         _ => 0,
-                                    });
-                                }
-                            }
+                                    })
+                                    .collect::<Vec<u8>>()
+                            })
+                            .unwrap_or_default();
                             (
                                 true,
                                 Some(cn),
@@ -833,10 +831,7 @@ impl Interpreter {
                     let id = id_opt.unwrap();
                     let updated_cell = attrs_opt.unwrap();
                     let mut updated_map = updated_cell.to_map();
-                    updated_map.insert(
-                        "bytes".to_string(),
-                        Value::array(bytes.into_iter().map(|b| Value::int(b as i64)).collect()),
-                    );
+                    set_buf_elems(&mut updated_map, bytes_to_elems(&bytes));
                     return Ok(Value::write_back_sharing(
                         &updated_cell,
                         class_sym,
@@ -873,19 +868,17 @@ impl Interpreter {
                     } => {
                         let cn = class_name.resolve();
                         if crate::runtime::utils::is_buf_or_blob_class(&cn) {
-                            let mut v: Vec<u8> = Vec::new();
-                            if let Some(ValueView::Array(items, ..)) =
-                                attributes.as_map().get("bytes").map(|b| b.view())
-                            {
-                                v.reserve(items.len());
-                                for it in items.iter() {
-                                    v.push(match it.view() {
+                            let v = with_buf_elems(&attributes, |items| {
+                                items
+                                    .iter()
+                                    .map(|it| match it.view() {
                                         ValueView::Int(i) => i.clamp(0, 255) as u8,
                                         ValueView::Num(f) => (f as i64).clamp(0, 255) as u8,
                                         _ => 0,
-                                    });
-                                }
-                            }
+                                    })
+                                    .collect::<Vec<u8>>()
+                            })
+                            .unwrap_or_default();
                             (
                                 true,
                                 Some(cn),
@@ -933,10 +926,7 @@ impl Interpreter {
                     let id = id_opt.unwrap();
                     let updated_cell = attrs_opt.unwrap();
                     let mut updated_map = updated_cell.to_map();
-                    updated_map.insert(
-                        "bytes".to_string(),
-                        Value::array(bytes.into_iter().map(|b| Value::int(b as i64)).collect()),
-                    );
+                    set_buf_elems(&mut updated_map, bytes_to_elems(&bytes));
                     return Ok(Value::write_back_sharing(
                         &updated_cell,
                         class_sym,
@@ -1922,19 +1912,11 @@ impl Interpreter {
                     Some(v) => super::to_int(v) as usize,
                     None => 0,
                 };
-                let mut bytes = if let Some(ValueView::Array(items, ..)) =
-                    attributes.as_map().get("bytes").map(|b| b.view())
-                {
-                    items.to_vec()
-                } else {
-                    Vec::new()
-                };
+                let mut bytes = buf_elems_or_empty(&attributes);
                 // When growing, fill with zeros; when shrinking, truncate
                 // After reallocate(0).reallocate(N), the new bytes should be zeros
                 bytes.resize(new_size, Value::int(0));
-                let mut attrs = std::collections::HashMap::new();
-                attrs.insert("bytes".to_string(), Value::array(bytes));
-                return Ok(Value::make_instance(class_name, attrs));
+                return Ok(make_buf(class_name, bytes));
             }
         }
         // Buf/Blob push/append/unshift/prepend on non-variable (rvalue) targets,
@@ -1976,13 +1958,7 @@ impl Interpreter {
                         return Err(err);
                     }
                 }
-                let mut bytes = if let Some(ValueView::Array(items, ..)) =
-                    attributes.as_map().get("bytes").map(|b| b.view())
-                {
-                    items.to_vec()
-                } else {
-                    Vec::new()
-                };
+                let mut bytes = buf_elems_or_empty(&attributes);
                 let new_items = Self::flatten_buf_args(args);
                 match method {
                     "append" | "push" => bytes.extend(new_items),
@@ -1993,9 +1969,7 @@ impl Interpreter {
                     }
                     _ => unreachable!(),
                 }
-                let mut attrs = std::collections::HashMap::new();
-                attrs.insert("bytes".to_string(), Value::array(bytes));
-                return Ok(Value::make_instance(class_name, attrs));
+                return Ok(make_buf(class_name, bytes));
             }
         }
         // Buf/Blob pop/shift on non-variable targets (e.g. Buf.new.pop throws X::Cannot::Empty)
@@ -2014,13 +1988,7 @@ impl Interpreter {
                         cn, method
                     )));
                 }
-                let bytes = if let Some(ValueView::Array(items, ..)) =
-                    attributes.as_map().get("bytes").map(|b| b.view())
-                {
-                    items.to_vec()
-                } else {
-                    Vec::new()
-                };
+                let bytes = buf_elems_or_empty(&attributes);
                 if bytes.is_empty() {
                     let mut ex_attrs = std::collections::HashMap::new();
                     ex_attrs.insert("action".to_string(), Value::str(method.to_string()));

--- a/src/runtime/methods_call_helpers.rs
+++ b/src/runtime/methods_call_helpers.rs
@@ -409,13 +409,8 @@ impl Interpreter {
                     ..
                 } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
                     // Extract bytes from Buf/Blob instance and cycle them
-                    let pattern: Vec<Value> = if let Some(ValueView::Array(items, ..)) =
-                        attributes.as_map().get("bytes").map(Value::view)
-                    {
-                        items.to_vec()
-                    } else {
-                        Vec::new()
-                    };
+                    let pattern: Vec<Value> =
+                        crate::value::value_buf::buf_elems_or_empty(&attributes);
                     if pattern.is_empty() {
                         vec![Value::int(0); size]
                     } else {
@@ -442,9 +437,7 @@ impl Interpreter {
         } else {
             vec![Value::int(0); size]
         };
-        let mut attrs = std::collections::HashMap::new();
-        attrs.insert("bytes".to_string(), Value::array(byte_vals));
-        Ok(Value::make_instance(class_name, attrs))
+        Ok(crate::value::value_buf::make_buf(class_name, byte_vals))
     }
 
     /// Check if a builtin type inherits from a given ancestor type.

--- a/src/runtime/methods_io_dispatch.rs
+++ b/src/runtime/methods_io_dispatch.rs
@@ -1,6 +1,9 @@
 use super::*;
 use crate::symbol::Symbol;
 use crate::value::ValueView;
+use crate::value::value_buf::{
+    buf_elems_or_empty, bytes_to_elems, make_buf, set_buf_elems, with_buf_elems,
+};
 
 impl Interpreter {
     /// Interpreter-native `.encode` (a `Cool` scalar -> `Buf`) and `.decode`
@@ -141,14 +144,14 @@ impl Interpreter {
             None => raw_input,
         };
         let translated = self.translate_newlines_for_encode(&input);
-        let mut attrs = HashMap::new();
+        let mut attrs = crate::value::AttrMap::new();
         let type_name = match normalized_encoding.as_str() {
             "utf-16" | "utf16" => {
                 let units: Vec<Value> = translated
                     .encode_utf16()
                     .map(|u| Value::int(u as i64))
                     .collect();
-                attrs.insert("bytes".to_string(), Value::array(units));
+                set_buf_elems(&mut attrs, units);
                 "utf16"
             }
             _ => {
@@ -157,9 +160,7 @@ impl Interpreter {
                     &encoding,
                     replacement.as_deref(),
                 )?;
-                let bytes_vals: Vec<Value> =
-                    bytes.into_iter().map(|b| Value::int(b as i64)).collect();
-                attrs.insert("bytes".to_string(), Value::array(bytes_vals));
+                set_buf_elems(&mut attrs, bytes_to_elems(&bytes));
                 match normalized_encoding.as_str() {
                     "utf-8" | "utf8" => "utf8",
                     _ => "Blob[uint8]",
@@ -201,9 +202,7 @@ impl Interpreter {
                 .map(|e| e.name.as_str().to_lowercase())
                 .unwrap_or_else(|| encoding.to_lowercase());
             let bytes = if is_wide {
-                if let Some(ValueView::Array(items, ..)) =
-                    attributes.as_map().get("bytes").map(|v| v.view())
-                {
+                with_buf_elems(&attributes, |items| {
                     let use_be = normalized_encoding == "utf-16be";
                     let mut out = Vec::with_capacity(items.len() * 2);
                     for item in items.iter() {
@@ -219,21 +218,19 @@ impl Interpreter {
                         out.extend_from_slice(&pair);
                     }
                     out
-                } else {
-                    Vec::new()
-                }
-            } else if let Some(ValueView::Array(items, ..)) =
-                attributes.as_map().get("bytes").map(|v| v.view())
-            {
-                items
-                    .iter()
-                    .map(|v| match v.view() {
-                        ValueView::Int(i) => i as u8,
-                        _ => 0,
-                    })
-                    .collect()
+                })
+                .unwrap_or_default()
             } else {
-                Vec::new()
+                with_buf_elems(&attributes, |items| {
+                    items
+                        .iter()
+                        .map(|v| match v.view() {
+                            ValueView::Int(i) => i as u8,
+                            _ => 0,
+                        })
+                        .collect::<Vec<u8>>()
+                })
+                .unwrap_or_default()
             };
             let decoded = match self.decode_with_encoding_and_replacement(
                 &bytes,
@@ -261,13 +258,7 @@ impl Interpreter {
         } = target.view()
             && (class_name == "Buf" || class_name == "Blob")
         {
-            let bytes = if let Some(ValueView::Array(items, ..)) =
-                attributes.as_map().get("bytes").map(|v| v.view())
-            {
-                items.to_vec()
-            } else {
-                Vec::new()
-            };
+            let bytes = buf_elems_or_empty(&attributes);
             let len = bytes.len();
             let start_raw = args
                 .first()
@@ -295,12 +286,7 @@ impl Interpreter {
             } else {
                 len
             };
-            let mut attrs = HashMap::new();
-            attrs.insert(
-                "bytes".to_string(),
-                Value::array(bytes[start..end].to_vec()),
-            );
-            return Some(Ok(Value::make_instance(class_name, attrs)));
+            return Some(Ok(make_buf(class_name, bytes[start..end].to_vec())));
         }
         None
     }

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -2,6 +2,7 @@ use super::methods_signature_errors::make_x_immutable_error;
 use super::*;
 use crate::symbol::Symbol;
 use crate::value::ValueView;
+use crate::value::value_buf::{buf_elems_in, bytes_to_elems, set_buf_elems, with_buf_elems};
 use num_bigint::BigInt;
 use num_traits::Signed;
 
@@ -339,28 +340,20 @@ impl Interpreter {
         } = target.view()
             && crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve())
         {
-            let bytes = attributes
-                .as_map()
-                .get("bytes")
-                .and_then(|v| match v.view() {
-                    ValueView::Array(items, ..) => Some(
-                        items
-                            .iter()
-                            .map(|v| match v.view() {
-                                ValueView::Int(i) => i.clamp(0, 255) as u8,
-                                ValueView::Num(f) => (f as i64).clamp(0, 255) as u8,
-                                ValueView::BigInt(bi) => {
-                                    num_traits::ToPrimitive::to_i64(bi.as_ref())
-                                        .unwrap_or(0)
-                                        .clamp(0, 255) as u8
-                                }
-                                _ => 0u8,
-                            })
-                            .collect::<Vec<u8>>(),
-                    ),
-                    _ => None,
-                })
-                .unwrap_or_default();
+            let bytes = with_buf_elems(&attributes, |items| {
+                items
+                    .iter()
+                    .map(|v| match v.view() {
+                        ValueView::Int(i) => i.clamp(0, 255) as u8,
+                        ValueView::Num(f) => (f as i64).clamp(0, 255) as u8,
+                        ValueView::BigInt(bi) => num_traits::ToPrimitive::to_i64(bi.as_ref())
+                            .unwrap_or(0)
+                            .clamp(0, 255) as u8,
+                        _ => 0u8,
+                    })
+                    .collect::<Vec<u8>>()
+            })
+            .unwrap_or_default();
 
             if (method == "read-ubits" || method == "read-bits") && args.len() == 2 {
                 let Some(from) = Self::value_to_non_negative_i64(&args[0]) else {
@@ -397,15 +390,7 @@ impl Interpreter {
                 };
                 let written = crate::builtins::buf_bits::write_bits(&bytes, from, bits, &args[2])?;
                 let mut updated_attrs = attributes.to_map();
-                updated_attrs.insert(
-                    "bytes".to_string(),
-                    Value::array(
-                        written
-                            .iter()
-                            .map(|b| Value::int(*b as i64))
-                            .collect::<Vec<_>>(),
-                    ),
-                );
+                set_buf_elems(&mut updated_attrs, bytes_to_elems(&written));
                 return Ok(Value::write_back_sharing(
                     &attributes,
                     class_name,
@@ -450,30 +435,22 @@ impl Interpreter {
                 ValueView::Num(f) => f as i64,
                 _ => 0,
             };
-            let mut bytes = {
-                let mut v: Vec<u8> = Vec::new();
-                if let Some(bytes_val) = attributes.as_map().get("bytes")
-                    && let ValueView::Array(items, ..) = bytes_val.view()
-                {
-                    v.reserve(items.len());
-                    for it in items.iter() {
-                        v.push(match it.view() {
-                            ValueView::Int(i) => i.clamp(0, 255) as u8,
-                            ValueView::Num(f) => (f as i64).clamp(0, 255) as u8,
-                            _ => 0,
-                        });
-                    }
-                }
-                v
-            };
+            let mut bytes = with_buf_elems(&attributes, |items| {
+                items
+                    .iter()
+                    .map(|it| match it.view() {
+                        ValueView::Int(i) => i.clamp(0, 255) as u8,
+                        ValueView::Num(f) => (f as i64).clamp(0, 255) as u8,
+                        _ => 0,
+                    })
+                    .collect::<Vec<u8>>()
+            })
+            .unwrap_or_default();
             crate::builtins::buf_write_num::apply_write_num(
                 &mut bytes, method, offset_i64, value_val, endian_val,
             )?;
             let mut updated_attrs = attributes.to_map();
-            updated_attrs.insert(
-                "bytes".to_string(),
-                Value::array(bytes.into_iter().map(|b| Value::int(b as i64)).collect()),
-            );
+            set_buf_elems(&mut updated_attrs, bytes_to_elems(&bytes));
             let updated = Value::write_back_sharing(&attributes, class_name, updated_attrs, id);
             self.env.insert(target_var.to_string(), updated.clone());
             return Ok(updated);
@@ -549,30 +526,22 @@ impl Interpreter {
                 ValueView::Num(f) => f as i64,
                 _ => 0,
             };
-            let mut bytes = {
-                let mut v: Vec<u8> = Vec::new();
-                if let Some(bytes_val) = attributes.as_map().get("bytes")
-                    && let ValueView::Array(items, ..) = bytes_val.view()
-                {
-                    v.reserve(items.len());
-                    for it in items.iter() {
-                        v.push(match it.view() {
-                            ValueView::Int(i) => i.clamp(0, 255) as u8,
-                            ValueView::Num(f) => (f as i64).clamp(0, 255) as u8,
-                            _ => 0,
-                        });
-                    }
-                }
-                v
-            };
+            let mut bytes = with_buf_elems(&attributes, |items| {
+                items
+                    .iter()
+                    .map(|it| match it.view() {
+                        ValueView::Int(i) => i.clamp(0, 255) as u8,
+                        ValueView::Num(f) => (f as i64).clamp(0, 255) as u8,
+                        _ => 0,
+                    })
+                    .collect::<Vec<u8>>()
+            })
+            .unwrap_or_default();
             crate::builtins::buf_write_int::apply_write_int(
                 &mut bytes, method, offset_i64, value_val, endian_val,
             )?;
             let mut updated_attrs = attributes.to_map();
-            updated_attrs.insert(
-                "bytes".to_string(),
-                Value::array(bytes.into_iter().map(|b| Value::int(b as i64)).collect()),
-            );
+            set_buf_elems(&mut updated_attrs, bytes_to_elems(&bytes));
             let updated = Value::write_back_sharing(&attributes, class_name, updated_attrs, id);
             self.env.insert(target_var.to_string(), updated.clone());
             return Ok(updated);
@@ -2078,19 +2047,14 @@ impl Interpreter {
                 let from = from as usize;
                 let bits = bits as usize;
                 let mut updated = attributes.to_map();
-                let mut bytes = if let Some(bytes_val) = updated.get("bytes")
-                    && let ValueView::Array(items, ..) = bytes_val.view()
-                {
-                    items
-                        .iter()
-                        .map(|v| match v.view() {
-                            ValueView::Int(i) => i as u8,
-                            _ => 0,
-                        })
-                        .collect::<Vec<u8>>()
-                } else {
-                    Vec::new()
-                };
+                let mut bytes: Vec<u8> = buf_elems_in(&updated)
+                    .unwrap_or_default()
+                    .iter()
+                    .map(|v| match v.view() {
+                        ValueView::Int(i) => i as u8,
+                        _ => 0,
+                    })
+                    .collect();
                 let required_bits = from.saturating_add(bits);
                 let required_len = required_bits.div_ceil(8);
                 if bytes.len() < required_len {
@@ -2100,10 +2064,7 @@ impl Interpreter {
                 if bits > 0 {
                     write_bits_into_bytes(&mut bytes, from, bits, &value);
                 }
-                updated.insert(
-                    "bytes".to_string(),
-                    Value::array(bytes.into_iter().map(|b| Value::int(b as i64)).collect()),
-                );
+                set_buf_elems(&mut updated, bytes_to_elems(&bytes));
                 let updated_instance =
                     Value::write_back_sharing(&attributes, class_name, updated, target_id);
                 self.env

--- a/src/runtime/methods_mut_substr_buf.rs
+++ b/src/runtime/methods_mut_substr_buf.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::value_buf::{buf_attrs, buf_elems, buf_elems_or_empty, make_buf};
 
 impl Interpreter {
     pub(crate) fn assign_substr_rw(
@@ -109,11 +110,8 @@ impl Interpreter {
         method_args: Vec<Value>,
         value: Value,
     ) -> Result<Value, RuntimeError> {
-        let mut items = if let ValueView::Instance { attributes, .. } = target.view()
-            && let Some(ValueView::Array(items, ..)) =
-                attributes.as_map().get("bytes").map(Value::view)
-        {
-            items.to_vec()
+        let mut items = if let ValueView::Instance { attributes, .. } = target.view() {
+            buf_elems_or_empty(&attributes)
         } else {
             Vec::new()
         };
@@ -133,11 +131,8 @@ impl Interpreter {
             None => items.len() - from,
         };
 
-        let new_bytes = if let ValueView::Instance { attributes, .. } = value.view()
-            && let Some(ValueView::Array(new_items, ..)) =
-                attributes.as_map().get("bytes").map(Value::view)
-        {
-            new_items.to_vec()
+        let new_bytes = if let ValueView::Instance { attributes, .. } = value.view() {
+            buf_elems_or_empty(&attributes)
         } else {
             Vec::new()
         };
@@ -151,9 +146,7 @@ impl Interpreter {
         } else {
             "Buf".to_string()
         };
-        let mut attrs = HashMap::new();
-        attrs.insert("bytes".to_string(), Value::array(items));
-        let new_buf = Value::make_instance(Symbol::intern(&class_name), attrs);
+        let new_buf = make_buf(Symbol::intern(&class_name), items);
 
         if let Some(var) = target_var {
             self.env.insert(var.to_string(), new_buf.clone());
@@ -182,13 +175,7 @@ impl Interpreter {
                     cn
                 )));
             }
-            let items = if let Some(ValueView::Array(items, ..)) =
-                attributes.as_map().get("bytes").map(Value::view)
-            {
-                items.to_vec()
-            } else {
-                Vec::new()
-            };
+            let items = buf_elems_or_empty(&attributes);
             (class_name, items, id, attributes.clone())
         } else {
             return Err(RuntimeError::new("Not a Buf".to_string()));
@@ -202,9 +189,8 @@ impl Interpreter {
         // uncatchable abort; `truncate` then handles the shrink case.
         Self::autoviv_resize(&mut bytes, new_size, Value::int(0))?;
         bytes.truncate(new_size);
-        let mut attrs = HashMap::new();
-        attrs.insert("bytes".to_string(), Value::array(bytes));
-        let updated = Value::write_back_sharing(&attrs_cell, class_name_sym, attrs, orig_id);
+        let updated =
+            Value::write_back_sharing(&attrs_cell, class_name_sym, buf_attrs(bytes), orig_id);
         self.env.insert(target_var.to_string(), updated.clone());
         Ok(updated)
     }
@@ -231,11 +217,7 @@ impl Interpreter {
                     attributes,
                     ..
                 } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                    if let Some(ValueView::Array(items, ..)) =
-                        attributes.as_map().get("bytes").map(Value::view)
-                    {
-                        result.extend(items.to_vec());
-                    }
+                    result.extend(buf_elems_or_empty(&attributes));
                     true
                 }
                 _ => false,
@@ -277,14 +259,12 @@ impl Interpreter {
             ..
         } = target.view()
         {
-            let items = if let Some(ValueView::Array(items, ..)) =
-                attributes.as_map().get("bytes").map(Value::view)
-            {
-                items.to_vec()
-            } else {
-                Vec::new()
-            };
-            (class_name, items, id, attributes.clone())
+            (
+                class_name,
+                buf_elems_or_empty(&attributes),
+                id,
+                attributes.clone(),
+            )
         } else {
             return Err(RuntimeError::new("Not a Buf".to_string()));
         };
@@ -319,9 +299,8 @@ impl Interpreter {
             _ => unreachable!(),
         }
 
-        let mut attrs = HashMap::new();
-        attrs.insert("bytes".to_string(), Value::array(bytes));
-        let updated = Value::write_back_sharing(&attrs_cell, class_name_sym, attrs, orig_id);
+        let updated =
+            Value::write_back_sharing(&attrs_cell, class_name_sym, buf_attrs(bytes), orig_id);
         self.env.insert(target_var.to_string(), updated.clone());
         Ok(updated)
     }
@@ -348,14 +327,12 @@ impl Interpreter {
                     cn, method
                 )));
             }
-            let items = if let Some(ValueView::Array(items, ..)) =
-                attributes.as_map().get("bytes").map(Value::view)
-            {
-                items.to_vec()
-            } else {
-                Vec::new()
-            };
-            (class_name, items, id, attributes.clone())
+            (
+                class_name,
+                buf_elems_or_empty(&attributes),
+                id,
+                attributes.clone(),
+            )
         } else {
             return Err(RuntimeError::new("Not a Buf".to_string()));
         };
@@ -379,10 +356,12 @@ impl Interpreter {
                     return Err(err);
                 }
                 let popped = bytes.pop().unwrap();
-                let mut attrs = HashMap::new();
-                attrs.insert("bytes".to_string(), Value::array(bytes));
-                let updated =
-                    Value::write_back_sharing(&attrs_cell, class_name_sym, attrs, orig_id);
+                let updated = Value::write_back_sharing(
+                    &attrs_cell,
+                    class_name_sym,
+                    buf_attrs(bytes),
+                    orig_id,
+                );
                 self.env.insert(target_var.to_string(), updated);
                 Ok(popped)
             }
@@ -404,10 +383,12 @@ impl Interpreter {
                     return Err(err);
                 }
                 let shifted = bytes.remove(0);
-                let mut attrs = HashMap::new();
-                attrs.insert("bytes".to_string(), Value::array(bytes));
-                let updated =
-                    Value::write_back_sharing(&attrs_cell, class_name_sym, attrs, orig_id);
+                let updated = Value::write_back_sharing(
+                    &attrs_cell,
+                    class_name_sym,
+                    buf_attrs(bytes),
+                    orig_id,
+                );
                 self.env.insert(target_var.to_string(), updated);
                 Ok(shifted)
             }
@@ -453,16 +434,9 @@ impl Interpreter {
                 for arg in args.iter().skip(2) {
                     match arg.view() {
                         ValueView::Instance { attributes, .. }
-                            if matches!(
-                                attributes.as_map().get("bytes").map(Value::view),
-                                Some(ValueView::Array(..))
-                            ) =>
+                            if buf_elems(&attributes).is_some() =>
                         {
-                            if let Some(ValueView::Array(items, ..)) =
-                                attributes.as_map().get("bytes").map(Value::view)
-                            {
-                                replacement.extend(items.iter().cloned());
-                            }
+                            replacement.extend(buf_elems_or_empty(&attributes));
                         }
                         // A plain list/array of replacement values (`<3 2 1>`,
                         // `(3, 2, 1)`): coerce each element to a byte, matching
@@ -474,14 +448,14 @@ impl Interpreter {
                     }
                 }
                 let removed: Vec<Value> = bytes.splice(start..end, replacement).collect();
-                let mut attrs = HashMap::new();
-                attrs.insert("bytes".to_string(), Value::array(bytes));
-                let updated =
-                    Value::write_back_sharing(&attrs_cell, class_name_sym, attrs, orig_id);
+                let updated = Value::write_back_sharing(
+                    &attrs_cell,
+                    class_name_sym,
+                    buf_attrs(bytes),
+                    orig_id,
+                );
                 self.env.insert(target_var.to_string(), updated);
-                let mut result_attrs = HashMap::new();
-                result_attrs.insert("bytes".to_string(), Value::array(removed));
-                Ok(Value::make_instance(class_name_sym, result_attrs))
+                Ok(make_buf(class_name_sym, removed))
             }
             _ => unreachable!(),
         }

--- a/src/runtime/methods_object_native_ctors_buf_num.rs
+++ b/src/runtime/methods_object_native_ctors_buf_num.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::symbol::Symbol;
+use crate::value::value_buf::{buf_elems_or_empty, make_buf};
 
 impl Interpreter {
     pub(crate) fn is_native_buf_constructible(cn: &str) -> bool {
@@ -38,13 +39,7 @@ impl Interpreter {
                     || class_name.resolve().starts_with("buf")
                     || class_name.resolve().starts_with("blob") =>
                 {
-                    if let Some(ValueView::Array(items, ..)) =
-                        attributes.as_map().get("bytes").map(Value::view)
-                    {
-                        items.to_vec()
-                    } else {
-                        Vec::new()
-                    }
+                    buf_elems_or_empty(&attributes)
                 }
                 ValueView::BigInt(_) => vec![a.clone()],
                 _ => vec![Value::int(to_int(a))],
@@ -73,8 +68,6 @@ impl Interpreter {
                 }
             })
             .collect();
-        let mut attrs = HashMap::new();
-        attrs.insert("bytes".to_string(), Value::array(byte_vals));
         // Normalize short buf/blob names to canonical forms.
         let canonical_name = match cn.as_str() {
             "buf8" => Symbol::intern("Buf[uint8]"),
@@ -87,7 +80,7 @@ impl Interpreter {
             "blob64" => Symbol::intern("Blob[uint64]"),
             _ => class_name,
         };
-        Value::make_instance(canonical_name, attrs)
+        make_buf(canonical_name, byte_vals)
     }
 
     /// Build a `utf8`/`utf16` instance from `.new` arguments as pure data:
@@ -110,20 +103,12 @@ impl Interpreter {
                     attributes: ia,
                     ..
                 } if crate::runtime::utils::is_buf_or_blob_class(&cn.resolve()) => {
-                    if let Some(ValueView::Array(items, ..)) =
-                        ia.as_map().get("bytes").map(Value::view)
-                    {
-                        items.to_vec()
-                    } else {
-                        vec![]
-                    }
+                    buf_elems_or_empty(&ia)
                 }
                 _ => vec![],
             })
             .collect();
-        let mut attrs = HashMap::new();
-        attrs.insert("bytes".to_string(), Value::array(elems));
-        Value::make_instance(class_name, attrs)
+        make_buf(class_name, elems)
     }
 
     /// Build a `Uni` value from `.new` arguments as pure data: flatten each

--- a/src/runtime/methods_type_coerce.rs
+++ b/src/runtime/methods_type_coerce.rs
@@ -65,13 +65,7 @@ impl Interpreter {
                     || cn.starts_with("blob")
             } =>
             {
-                if let Some(ValueView::Array(items, ..)) =
-                    attributes.as_map().get("bytes").map(Value::view)
-                {
-                    Value::seq(items.clone().to_vec())
-                } else {
-                    Value::seq(Vec::new())
-                }
+                Value::seq(crate::value::value_buf::buf_elems_or_empty(&attributes))
             }
             _ => Value::seq(vec![target.clone()]),
         })
@@ -120,13 +114,11 @@ impl Interpreter {
                 || cn.starts_with("buf")
                 || cn.starts_with("blob")
             {
-                if let Some(ValueView::Array(items, ..)) =
-                    attributes.as_map().get("bytes").map(Value::view)
-                {
-                    return Ok(Value::array_with_kind(
-                        items.clone(),
-                        crate::value::ArrayKind::List,
-                    ));
+                if let Some(list) = crate::value::value_buf::buf_elems_as_array(
+                    &attributes.as_map(),
+                    crate::value::ArrayKind::List,
+                ) {
+                    return Ok(list);
                 }
                 return Ok(Value::array_with_kind(
                     crate::gc::Gc::new(crate::value::ArrayData::new(Vec::new())),

--- a/src/runtime/native_io/io_handle.rs
+++ b/src/runtime/native_io/io_handle.rs
@@ -857,13 +857,9 @@ impl Interpreter {
                     break;
                 }
                 for chunk in bytes.chunks(size) {
-                    let byte_vals: Vec<Value> =
-                        chunk.iter().map(|b| Value::int(*b as i64)).collect();
-                    let mut buf_attrs = HashMap::new();
-                    buf_attrs.insert("bytes".to_string(), Value::array(byte_vals));
-                    values.push(Value::make_instance(
+                    values.push(crate::value::value_buf::make_buf(
                         Symbol::intern("Buf[uint8]"),
-                        buf_attrs,
+                        crate::value::value_buf::bytes_to_elems(chunk),
                     ));
                 }
                 if bytes.len() < size {

--- a/src/runtime/native_io/io_path_read.rs
+++ b/src/runtime/native_io/io_path_read.rs
@@ -51,9 +51,10 @@ impl Interpreter {
                         .into_iter()
                         .map(|b| Value::int(i64::from(b)))
                         .collect();
-                    let mut attrs = HashMap::new();
-                    attrs.insert("bytes".to_string(), Value::array(byte_vals));
-                    return Ok(Value::make_instance(Symbol::intern("Buf[uint8]"), attrs));
+                    return Ok(crate::value::value_buf::make_buf(
+                        Symbol::intern("Buf[uint8]"),
+                        byte_vals,
+                    ));
                 }
                 // A non-utf-8 encoding reads raw bytes and decodes; utf-8 reads
                 // the string directly (stripping a leading BOM).

--- a/src/runtime/native_io/io_pipe.rs
+++ b/src/runtime/native_io/io_pipe.rs
@@ -91,12 +91,17 @@ impl Interpreter {
                                     &class_name.resolve(),
                                 ) =>
                                 {
-                                    // Try "bytes" first (make_buf), then "data"
+                                    // Buf element storage first, then a `data`
+                                    // attribute (what a user-built stand-in carries).
                                     let map = attributes.as_map();
-                                    let bytes_arr = map.get("bytes").or_else(|| map.get("data"));
-                                    if let Some(ValueView::Array(bytes, _)) =
-                                        bytes_arr.map(Value::view)
-                                    {
+                                    let bytes = crate::value::value_buf::buf_elems_in(&map)
+                                        .or_else(|| match map.get("data").map(Value::view) {
+                                            Some(ValueView::Array(items, ..)) => {
+                                                Some(items.to_vec())
+                                            }
+                                            _ => None,
+                                        });
+                                    if let Some(bytes) = bytes {
                                         let data: Vec<u8> =
                                             bytes.iter().map(|v| v.to_f64() as u8).collect();
                                         let _ = stdin.write_all(&data);

--- a/src/runtime/native_methods/encoding.rs
+++ b/src/runtime/native_methods/encoding.rs
@@ -30,8 +30,10 @@ fn extend_buffer_from_value(out: &mut Vec<u8>, v: &Value) {
             }
         }
         ValueView::Instance { attributes, .. } => {
-            if let Some(bytes_val) = attributes.as_map().get("bytes") {
-                extend_buffer_from_value(out, bytes_val);
+            for item in crate::value::value_buf::buf_elems_or_empty(&attributes) {
+                if let Some(b) = value_to_byte(&item) {
+                    out.push(b);
+                }
             }
         }
         _ => {}
@@ -198,9 +200,10 @@ impl Interpreter {
                     }
                 }
 
-                let mut attrs = HashMap::new();
-                attrs.insert("bytes".to_string(), Value::array(bytes));
-                Ok(Value::make_instance(Symbol::intern("Blob[uint8]"), attrs))
+                Ok(crate::value::value_buf::make_buf(
+                    Symbol::intern("Blob[uint8]"),
+                    bytes,
+                ))
             }
             "WHAT" => Ok(Value::package(Symbol::intern("Encoding::Encoder"))),
             _ => Ok(Value::NIL),

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -211,16 +211,16 @@ impl Interpreter {
                     || cn.starts_with("Blob[")
             } =>
             {
-                if let Some(bytes_v) = attributes.as_map().get("bytes")
-                    && let ValueView::Array(items, ..) = bytes_v.view()
-                {
-                    return items
+                if let Some(bytes) = crate::value::value_buf::with_buf_elems(&attributes, |items| {
+                    items
                         .iter()
                         .map(|v| match v.view() {
                             ValueView::Int(i) => i as u8,
                             _ => 0,
                         })
-                        .collect();
+                        .collect::<Vec<u8>>()
+                }) {
+                    return bytes;
                 }
                 Vec::new()
             }
@@ -229,9 +229,7 @@ impl Interpreter {
                 attributes,
                 ..
             } if class_name == "utf16" => {
-                if let Some(bytes_v) = attributes.as_map().get("bytes")
-                    && let ValueView::Array(items, ..) = bytes_v.view()
-                {
+                if let Some(items) = crate::value::value_buf::buf_elems(&attributes) {
                     let use_be = normalized == "utf-16be";
                     let mut bytes = Vec::with_capacity(items.len() * 2);
                     for item in items.iter() {

--- a/src/runtime/native_methods/socket_helpers.rs
+++ b/src/runtime/native_methods/socket_helpers.rs
@@ -20,18 +20,16 @@ impl Interpreter {
                     || cn.starts_with("Blob[")
             } =>
             {
-                if let Some(ValueView::Array(items, ..)) =
-                    attributes.as_map().get("bytes").map(Value::view)
-                {
-                    Some(
-                        items
-                            .iter()
-                            .map(|v| match v.view() {
-                                ValueView::Int(i) => i as u8,
-                                _ => 0,
-                            })
-                            .collect(),
-                    )
+                if let Some(bytes) = crate::value::value_buf::with_buf_elems(&attributes, |items| {
+                    items
+                        .iter()
+                        .map(|v| match v.view() {
+                            ValueView::Int(i) => i as u8,
+                            _ => 0,
+                        })
+                        .collect::<Vec<u8>>()
+                }) {
+                    Some(bytes)
                 } else {
                     Some(Vec::new())
                 }
@@ -265,9 +263,9 @@ impl Interpreter {
 
     /// Create a Buf instance from raw bytes
     pub(crate) fn make_buf(bytes: Vec<u8>) -> Value {
-        let byte_vals: Vec<Value> = bytes.into_iter().map(|b| Value::int(b as i64)).collect();
-        let mut attrs = HashMap::new();
-        attrs.insert("bytes".to_string(), Value::array(byte_vals));
-        Value::make_instance(crate::symbol::Symbol::intern("Buf[uint8]"), attrs)
+        crate::value::value_buf::make_buf(
+            crate::symbol::Symbol::intern("Buf[uint8]"),
+            crate::value::value_buf::bytes_to_elems(&bytes),
+        )
     }
 }

--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -6,12 +6,7 @@ use std::io::{Read, Write};
 
 /// Create a Buf Value from raw bytes.
 fn make_buf_value(bytes: &[u8]) -> Value {
-    let mut battrs = HashMap::new();
-    battrs.insert(
-        "bytes".to_string(),
-        Value::array(bytes.iter().map(|b| Value::int(*b as i64)).collect()),
-    );
-    Value::make_instance(Symbol::intern("Buf"), battrs)
+    crate::value::value_buf::make_buf_from_u8(bytes)
 }
 
 /// Incrementally UTF-8-decode a Proc::Async output stream. Emits the decoded valid
@@ -674,19 +669,16 @@ impl Interpreter {
                             || cn.starts_with("Blob[")
                     } =>
                     {
-                        if let Some(ValueView::Array(items, ..)) =
-                            attributes.as_map().get("bytes").map(Value::view)
-                        {
+                        crate::value::value_buf::with_buf_elems(&attributes, |items| {
                             items
                                 .iter()
                                 .map(|v| match v.view() {
                                     ValueView::Int(i) => i as u8,
                                     _ => 0,
                                 })
-                                .collect()
-                        } else {
-                            Vec::new()
-                        }
+                                .collect::<Vec<u8>>()
+                        })
+                        .unwrap_or_default()
                     }
                     ValueView::Str(s) => {
                         let enc = attrs

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -800,15 +800,12 @@ fn marshal_arg(ps: &ParamSpec, raw: &Value) -> Result<(libffi::middle::Type, Arg
 fn buf_instance_bytes(v: &Value) -> Option<Vec<u8>> {
     match v.view() {
         ValueView::Instance { attributes, .. } => {
-            match attributes.as_map().get("bytes").map(|b| b.view()) {
-                Some(ValueView::Array(items, ..)) => Some(
-                    items
-                        .iter()
-                        .map(|b| crate::runtime::to_int(b) as u8)
-                        .collect(),
-                ),
-                _ => None,
-            }
+            crate::value::value_buf::with_buf_elems(&attributes, |items| {
+                items
+                    .iter()
+                    .map(|b| crate::runtime::to_int(b) as u8)
+                    .collect::<Vec<u8>>()
+            })
         }
         ValueView::Scalar(inner) => buf_instance_bytes(inner),
         ValueView::ContainerRef(cell) => cell.lock().ok().and_then(|g| buf_instance_bytes(&g)),
@@ -841,8 +838,10 @@ fn buf_instance_pin_key(v: &Value) -> Option<usize> {
 fn write_buf_instance_bytes(v: &Value, bytes: &[u8]) {
     match v.view() {
         ValueView::Instance { attributes, .. } => {
-            let byte_vals: Vec<Value> = bytes.iter().map(|b| Value::int(*b as i64)).collect();
-            attributes.insert("bytes".to_string(), Value::array(byte_vals));
+            crate::value::value_buf::store_buf_elems(
+                &attributes,
+                crate::value::value_buf::bytes_to_elems(bytes),
+            );
         }
         ValueView::Scalar(inner) => write_buf_instance_bytes(inner, bytes),
         ValueView::ContainerRef(cell) => {

--- a/src/runtime/ops_bits.rs
+++ b/src/runtime/ops_bits.rs
@@ -54,15 +54,13 @@ impl Interpreter {
                 out.push(op(a, b) as u8);
             }
             let byte_vals: Vec<Value> = out.into_iter().map(|b| Value::int(b as i64)).collect();
-            let mut attrs = std::collections::HashMap::new();
-            attrs.insert("bytes".to_string(), Value::array(byte_vals));
             let result_type = match (Self::buf_class_name(left), Self::buf_class_name(right)) {
                 (Some(l), Some(r)) if l == r => l,
                 _ => "Buf".to_string(),
             };
-            Ok(Value::make_instance(
+            Ok(crate::value::value_buf::make_buf(
                 crate::symbol::Symbol::intern(&result_type),
-                attrs,
+                byte_vals,
             ))
         } else {
             // For strings, operate on Unicode codepoints (ordinal values)

--- a/src/runtime/types/type_matching.rs
+++ b/src/runtime/types/type_matching.rs
@@ -724,9 +724,7 @@ impl Interpreter {
                         if !class_ok {
                             return false;
                         }
-                        if let Some(ValueView::Array(items, ..)) =
-                            attributes.as_map().get("bytes").map(Value::view)
-                        {
+                        if let Some(items) = crate::value::value_buf::buf_elems(&attributes) {
                             return items.iter().all(|v| self.type_matches_value(inner, v));
                         }
                     }

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -718,9 +718,7 @@ impl Value {
                 attributes,
                 ..
             } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                if let Some(ValueView::Array(bytes, ..)) =
-                    attributes.as_map().get("bytes").map(Value::view)
-                {
+                crate::value::value_buf::with_buf_elems(&attributes, |bytes| {
                     if bytes.is_empty() {
                         // An empty Blob/Buf *instance* gists as `Blob:0x<>` (the
                         // hex body is just empty), not `Blob()` — that spelling
@@ -758,9 +756,8 @@ impl Value {
                             .collect();
                         format!("{}:0x<{}>", class_name, hex.join(" "))
                     }
-                } else {
-                    format!("{}()", class_name)
-                }
+                })
+                .unwrap_or_else(|| format!("{}()", class_name))
             }
             ValueView::Instance {
                 class_name,

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -370,6 +370,8 @@ pub(crate) mod types_eqv;
 pub(crate) mod types_isa;
 pub(crate) mod types_truthy;
 mod value_async;
+/// `Buf`/`Blob` element storage — the accessor chokepoint (ADR-0015 P2).
+pub(crate) mod value_buf;
 mod value_collections;
 mod value_enum;
 mod value_eq;

--- a/src/value/types_truthy.rs
+++ b/src/value/types_truthy.rs
@@ -102,10 +102,10 @@ impl Value {
                     || cn.starts_with("buf")
                     || cn.starts_with("blob")
                 {
-                    return match attributes.as_map().get("bytes").map(Value::view) {
-                        Some(ValueView::Array(items, ..)) => !items.is_empty(),
-                        _ => false,
-                    };
+                    return crate::value::value_buf::with_buf_elems(&attributes, |items| {
+                        !items.is_empty()
+                    })
+                    .unwrap_or(false);
                 }
                 true
             }

--- a/src/value/value_buf.rs
+++ b/src/value/value_buf.rs
@@ -1,0 +1,216 @@
+//! `Buf`/`Blob` element storage — the single accessor layer (ADR-0015 P2 step 1).
+//!
+//! A `Buf`/`Blob` has no dedicated `Value` variant. It is a plain
+//! `Value::Instance` whose one attribute holds a `Value::Array` with **one boxed
+//! `Value::Int` per element**. Until now every one of the ~104 places that
+//! touched that storage spelled the attribute name itself and open-coded the
+//! `ValueView::Array` match, so the representation could not be changed without
+//! editing forty files.
+//!
+//! This module is that chokepoint. The attribute name is private to it, and
+//! every read, write, probe and construction goes through one of the functions
+//! below. Nothing here changes behaviour — it is a pure refactor whose point is
+//! to make [ADR-0015](../../docs/adr/0015-native-backed-container-storage-and-repr-bodies.md)
+//! P2 step 2 (a contiguous native-backed node with an element width, so
+//! `Buf.REPR` can honestly answer `VMArray` and NativeCall can hand C a real
+//! `MVMArrayB` body) a change to *this file* rather than to its callers.
+//!
+//! Two levels are offered deliberately:
+//!
+//! - the **element** functions ([`buf_elems`], [`set_buf_elems`], …) decode to
+//!   and from `Vec<Value>`; under P2 they become the encode/decode boundary;
+//! - the **storage** functions ([`buf_storage`], [`set_buf_storage`]) move the
+//!   container across without decoding it, for the coercions that only re-tag a
+//!   buffer (`.Buf`, `.Blob`); under P2 they become a node share.
+//!
+//! [`is_buf_or_blob_class`](crate::runtime::utils::is_buf_or_blob_class) stays
+//! the companion class-name filter: this module answers "what is in there", not
+//! "is this a Buf".
+
+use super::{AttrMap, InstanceAttrs, Value, ValueView};
+use crate::symbol::Symbol;
+
+/// The attribute a `Buf`/`Blob`-shaped instance keeps its elements under.
+///
+/// Private on purpose: it is the thing P2 deletes. If you find yourself wanting
+/// it outside this module, the accessor you need is missing — add it here.
+const ELEMS_ATTR: &str = "bytes";
+
+/// The elements of a `Buf`/`Blob`-shaped instance, as owned `Value`s.
+///
+/// `None` when the instance carries no element storage — a type object
+/// (`Blob` itself), or an instance that merely happens to be passed in here.
+/// Most callers want [`buf_elems_or_empty`]; use this one when "absent" and
+/// "empty" must be told apart.
+pub(crate) fn buf_elems(attrs: &InstanceAttrs) -> Option<Vec<Value>> {
+    buf_elems_in(&attrs.as_map())
+}
+
+/// [`buf_elems`] with an absent buffer read as empty — the shape of the many
+/// call sites that opened with `if let Some(..) = .. else { Vec::new() }`.
+pub(crate) fn buf_elems_or_empty(attrs: &InstanceAttrs) -> Vec<Value> {
+    buf_elems(attrs).unwrap_or_default()
+}
+
+/// [`buf_elems`] against an attribute map already in hand (a `to_map()` snapshot
+/// or a live read guard), so a caller holding one does not take a second lock.
+pub(crate) fn buf_elems_in(map: &AttrMap) -> Option<Vec<Value>> {
+    match map.get(ELEMS_ATTR)?.view() {
+        ValueView::Array(items, ..) => Some(items.to_vec()),
+        _ => None,
+    }
+}
+
+/// Run `f` over the elements without copying them.
+///
+/// The borrow is held by an attribute read guard for the duration of the call,
+/// so `f` must not re-enter the same instance's attribute cell for writing.
+/// Returns `None` (without calling `f`) when there is no element storage.
+pub(crate) fn with_buf_elems<R>(attrs: &InstanceAttrs, f: impl FnOnce(&[Value]) -> R) -> Option<R> {
+    let map = attrs.as_map();
+    match map.get(ELEMS_ATTR)?.view() {
+        ValueView::Array(items, ..) => Some(f(items.as_slice())),
+        _ => None,
+    }
+}
+
+/// Whether this instance carries element storage at all. Distinguishes a real
+/// (possibly empty) buffer from a `Blob`/`Buf` **type object**, which has none.
+pub(crate) fn has_buf_elems(attrs: &InstanceAttrs) -> bool {
+    attrs.contains_key(ELEMS_ATTR)
+}
+
+/// [`has_buf_elems`] against an attribute map already in hand.
+pub(crate) fn has_buf_elems_in(map: &AttrMap) -> bool {
+    map.contains_key(ELEMS_ATTR)
+}
+
+/// A fresh attribute map holding `elems` — the map to hand
+/// `Value::make_instance` / `Value::write_back_sharing`.
+pub(crate) fn buf_attrs(elems: Vec<Value>) -> AttrMap {
+    let mut map = AttrMap::new();
+    set_buf_elems(&mut map, elems);
+    map
+}
+
+/// A fresh `Buf`/`Blob`-shaped instance of `class_name` holding `elems`.
+pub(crate) fn make_buf(class_name: Symbol, elems: Vec<Value>) -> Value {
+    Value::make_instance(class_name, buf_attrs(elems))
+}
+
+/// A fresh plain `Buf` over raw bytes — the commonest construction of all (I/O
+/// reads, socket receives, `Proc::Async` chunks). Under P2 this stops boxing.
+pub(crate) fn make_buf_from_u8(bytes: &[u8]) -> Value {
+    make_buf(Symbol::intern("Buf"), bytes_to_elems(bytes))
+}
+
+/// Raw bytes as the boxed element list this representation stores.
+pub(crate) fn bytes_to_elems(bytes: &[u8]) -> Vec<Value> {
+    bytes.iter().map(|b| Value::int(*b as i64)).collect()
+}
+
+/// Store `elems` into a map being built or updated, then handed to
+/// `make_instance` / `commit_attrs`.
+pub(crate) fn set_buf_elems(map: &mut AttrMap, elems: Vec<Value>) {
+    map.insert(ELEMS_ATTR, Value::array(elems));
+}
+
+/// Store `elems` into a **live** instance, through its shared attribute cell —
+/// visible to every alias, no rebind of the holding variable needed.
+pub(crate) fn store_buf_elems(attrs: &InstanceAttrs, elems: Vec<Value>) {
+    attrs.insert(ELEMS_ATTR, Value::array(elems));
+}
+
+/// Mutate the elements in place through the shared cell, without decoding the
+/// whole buffer first (`$b[i] = v`). `None` when there is no element storage.
+pub(crate) fn with_buf_elems_mut<R>(
+    attrs: &InstanceAttrs,
+    f: impl FnOnce(&mut Vec<Value>) -> R,
+) -> Option<R> {
+    attrs
+        .with_attr_mut(ELEMS_ATTR, |slot| {
+            slot.with_array_mut(|items, _| f(crate::gc::Gc::make_mut(items)))
+        })
+        .flatten()
+}
+
+/// The element container itself, cloned, for the coercions that re-tag a buffer
+/// without looking inside it (`.Buf`, `.Blob`). Pair with [`set_buf_storage`].
+pub(crate) fn buf_storage(map: &AttrMap) -> Option<Value> {
+    let stored = map.get(ELEMS_ATTR)?;
+    matches!(stored.view(), ValueView::Array(..)).then(|| stored.clone())
+}
+
+/// Store a container obtained from [`buf_storage`] into a map being built.
+pub(crate) fn set_buf_storage(map: &mut AttrMap, storage: Value) {
+    map.insert(ELEMS_ATTR, storage);
+}
+
+/// The elements as an array `Value` of `kind`, **sharing** the backing node
+/// rather than copying it — what the `.List`/`.list`/`.Array` coercions do
+/// today. The share is invisible: element writes go through
+/// [`with_buf_elems_mut`], whose `Gc::make_mut` forks a shared node.
+pub(crate) fn buf_elems_as_array(map: &AttrMap, kind: super::ArrayKind) -> Option<Value> {
+    match map.get(ELEMS_ATTR)?.view() {
+        ValueView::Array(items, ..) => Some(Value::array_with_kind(items.clone(), kind)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn buf_of(elems: Vec<Value>) -> Value {
+        make_buf(Symbol::intern("Buf"), elems)
+    }
+
+    /// The instance's shared attribute cell — a `Gc` clone, so two calls on the
+    /// same `Value` alias one cell (which is what the mutation test relies on).
+    fn attrs_of(v: &Value) -> crate::gc::Gc<InstanceAttrs> {
+        match v.view() {
+            ValueView::Instance { attributes, .. } => (*attributes).clone(),
+            _ => panic!("not an instance"),
+        }
+    }
+
+    #[test]
+    fn round_trips_elements() {
+        let b = buf_of(vec![Value::int(1), Value::int(2)]);
+        assert_eq!(
+            buf_elems(&attrs_of(&b)),
+            Some(vec![Value::int(1), Value::int(2)])
+        );
+        assert_eq!(with_buf_elems(&attrs_of(&b), <[Value]>::len), Some(2));
+    }
+
+    #[test]
+    fn absent_storage_is_distinguishable_from_empty() {
+        let empty = buf_of(Vec::new());
+        assert_eq!(buf_elems(&attrs_of(&empty)), Some(Vec::new()));
+        assert!(has_buf_elems(&attrs_of(&empty)));
+
+        let bare = Value::make_instance(Symbol::intern("Buf"), AttrMap::new());
+        assert_eq!(buf_elems(&attrs_of(&bare)), None);
+        assert_eq!(buf_elems_or_empty(&attrs_of(&bare)), Vec::new());
+        assert!(!has_buf_elems(&attrs_of(&bare)));
+    }
+
+    #[test]
+    fn in_place_mutation_is_visible_through_an_alias() {
+        let b = buf_of(vec![Value::int(1)]);
+        let alias = attrs_of(&b);
+        with_buf_elems_mut(&attrs_of(&b), |items| items.push(Value::int(9)));
+        assert_eq!(buf_elems(&alias), Some(vec![Value::int(1), Value::int(9)]));
+    }
+
+    #[test]
+    fn storage_moves_across_without_decoding() {
+        let b = buf_of(bytes_to_elems(&[7, 8]));
+        let storage = buf_storage(&attrs_of(&b).as_map()).expect("storage");
+        let mut map = AttrMap::new();
+        set_buf_storage(&mut map, storage);
+        let blob = Value::make_instance(Symbol::intern("Blob"), map);
+        assert_eq!(buf_elems(&attrs_of(&blob)), Some(bytes_to_elems(&[7, 8])));
+    }
+}

--- a/src/vm/vm_arith_ops.rs
+++ b/src/vm/vm_arith_ops.rs
@@ -385,16 +385,16 @@ impl Interpreter {
         if Self::is_buf_value(&val) {
             let bytes = Self::extract_buf_bytes(&val);
             let negated: Vec<Value> = bytes.iter().map(|b| Value::int((!b) as i64)).collect();
-            let mut attrs = std::collections::HashMap::new();
-            attrs.insert("bytes".to_string(), Value::array(negated));
             // Determine result type: if input is utf8, result is utf8; otherwise Buf
             let result_type = if let ValueView::Instance { class_name, .. } = val.view() {
                 class_name.resolve().to_string()
             } else {
                 "Buf".to_string()
             };
-            self.stack
-                .push(Value::make_instance(Symbol::intern(&result_type), attrs));
+            self.stack.push(crate::value::value_buf::make_buf(
+                Symbol::intern(&result_type),
+                negated,
+            ));
         } else {
             let s = crate::runtime::utils::coerce_to_str(&val);
             let negated: Vec<u8> = s.as_bytes().iter().map(|b| !b).collect();

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -2630,8 +2630,7 @@ impl Interpreter {
         }
         // Extract the current bytes (same clamping the interpreter uses).
         let mut bytes: Vec<u8> = Vec::new();
-        if let Some(ValueView::Array(items, ..)) = attributes.as_map().get("bytes").map(Value::view)
-        {
+        crate::value::value_buf::with_buf_elems(&attributes, |items| {
             bytes.reserve(items.len());
             for it in items.iter() {
                 bytes.push(match it.view() {
@@ -2643,7 +2642,7 @@ impl Interpreter {
                     _ => 0,
                 });
             }
-        }
+        });
         // Compute the new bytes via the shared pure transform.
         let new_bytes: Vec<u8> = if is_write_bits {
             if args.len() != 3 {
@@ -2692,14 +2691,9 @@ impl Interpreter {
         // (so aliases observing the same buf see the mutation), then refresh the
         // receiver binding to match the interpreter's `env.insert(target_var, ...)`.
         let mut updated_attrs = attributes.to_map();
-        updated_attrs.insert(
-            "bytes".to_string(),
-            Value::array(
-                new_bytes
-                    .into_iter()
-                    .map(|b| Value::int(b as i64))
-                    .collect(),
-            ),
+        crate::value::value_buf::set_buf_elems(
+            &mut updated_attrs,
+            crate::value::value_buf::bytes_to_elems(&new_bytes),
         );
         let updated = Value::write_back_sharing(&attributes, class_name, updated_attrs, id);
         self.env_mut()

--- a/src/vm/vm_coerce_concat_ops.rs
+++ b/src/vm/vm_coerce_concat_ops.rs
@@ -318,10 +318,10 @@ impl Interpreter {
             };
             let mut bytes = Self::extract_buf_bytes(&left);
             bytes.extend(Self::extract_buf_bytes(&right));
-            let byte_vals: Vec<Value> = bytes.into_iter().map(|b| Value::int(b as i64)).collect();
-            let mut attrs = std::collections::HashMap::new();
-            attrs.insert("bytes".to_string(), Value::array(byte_vals));
-            return Value::make_instance(result_class, attrs);
+            return crate::value::value_buf::make_buf(
+                result_class,
+                crate::value::value_buf::bytes_to_elems(&bytes),
+            );
         }
         // Buf ~ non-Buf or non-Buf ~ Buf: decode the Buf and produce a Str
         if Self::is_buf_value(&left) || Self::is_buf_value(&right) {
@@ -375,16 +375,17 @@ impl Interpreter {
 
     pub fn extract_buf_bytes(val: &Value) -> Vec<u8> {
         if let ValueView::Instance { attributes, .. } = val.view()
-            && let Some(ValueView::Array(items, ..)) =
-                attributes.as_map().get("bytes").map(Value::view)
+            && let Some(bytes) = crate::value::value_buf::with_buf_elems(&attributes, |items| {
+                items
+                    .iter()
+                    .map(|v| match v.view() {
+                        ValueView::Int(i) => i as u8,
+                        _ => 0,
+                    })
+                    .collect::<Vec<u8>>()
+            })
         {
-            return items
-                .iter()
-                .map(|v| match v.view() {
-                    ValueView::Int(i) => i as u8,
-                    _ => 0,
-                })
-                .collect();
+            return bytes;
         }
         Vec::new()
     }

--- a/src/vm/vm_hyper_method_ops.rs
+++ b/src/vm/vm_hyper_method_ops.rs
@@ -352,13 +352,7 @@ impl Interpreter {
         } = target.view()
             && crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve())
         {
-            if let Some(ValueView::Array(bytes, ..)) =
-                attributes.as_map().get("bytes").map(Value::view)
-            {
-                bytes.to_vec()
-            } else {
-                Vec::new()
-            }
+            crate::value::value_buf::buf_elems_or_empty(&attributes)
         } else {
             crate::runtime::value_to_list(&target)
         };

--- a/src/vm/vm_var_assign_index_named.rs
+++ b/src/vm/vm_var_assign_index_named.rs
@@ -811,10 +811,10 @@ impl Interpreter {
             }
         }
         // Buf/Blob element and slice assignment (`$b[i] = v` / `$b[i,j] = v,w`):
-        // mutate the underlying "bytes" array in place through the instance's
+        // mutate the element storage in place through the instance's
         // shared attribute cell. Buf identity lives in that cell (not the
         // variable slot it happens to be stored in), so no `env_root_descended_mut`
-        // rebind is needed — a `with_attr_mut` write is visible to every alias.
+        // rebind is needed — a `with_buf_elems_mut` write is visible to every alias.
         // `:=`-binding to a Buf index is not handled here (falls through to the
         // generic path below, unchanged from before this fix).
         if !bind_mode
@@ -842,20 +842,17 @@ impl Interpreter {
                     let max_idx = indices.iter().copied().max().unwrap_or(0);
                     let mut resize_err = None;
                     let mut assigned = Vec::new();
-                    attributes.with_attr_mut("bytes", |bytes_val| {
-                        let _ = bytes_val.with_array_mut(|items, _| {
-                            let arr = crate::gc::Gc::make_mut(items);
-                            if let Err(e) = Self::autoviv_resize(arr, max_idx + 1, Value::int(0)) {
-                                resize_err = Some(e);
-                                return;
-                            }
-                            for (i, &pos) in indices.iter().enumerate() {
-                                let v = vals.get(i).cloned().unwrap_or(Value::NIL);
-                                let byte = crate::runtime::to_int(&v) & 0xff;
-                                arr[pos] = Value::int(byte);
-                                assigned.push(Value::int(byte));
-                            }
-                        });
+                    crate::value::value_buf::with_buf_elems_mut(&attributes, |arr| {
+                        if let Err(e) = Self::autoviv_resize(arr, max_idx + 1, Value::int(0)) {
+                            resize_err = Some(e);
+                            return;
+                        }
+                        for (i, &pos) in indices.iter().enumerate() {
+                            let v = vals.get(i).cloned().unwrap_or(Value::NIL);
+                            let byte = crate::runtime::to_int(&v) & 0xff;
+                            arr[pos] = Value::int(byte);
+                            assigned.push(Value::int(byte));
+                        }
                     });
                     if let Some(e) = resize_err {
                         return Err(e);
@@ -865,15 +862,12 @@ impl Interpreter {
                 } else if let Some(pos) = Self::index_to_usize(&idx) {
                     let byte = crate::runtime::to_int(&val) & 0xff;
                     let mut resize_err = None;
-                    attributes.with_attr_mut("bytes", |bytes_val| {
-                        let _ = bytes_val.with_array_mut(|items, _| {
-                            let arr = crate::gc::Gc::make_mut(items);
-                            if let Err(e) = Self::autoviv_resize(arr, pos + 1, Value::int(0)) {
-                                resize_err = Some(e);
-                                return;
-                            }
-                            arr[pos] = Value::int(byte);
-                        });
+                    crate::value::value_buf::with_buf_elems_mut(&attributes, |arr| {
+                        if let Err(e) = Self::autoviv_resize(arr, pos + 1, Value::int(0)) {
+                            resize_err = Some(e);
+                            return;
+                        }
+                        arr[pos] = Value::int(byte);
                     });
                     if let Some(e) = resize_err {
                         return Err(e);

--- a/src/vm/vm_var_assign_typed.rs
+++ b/src/vm/vm_var_assign_typed.rs
@@ -604,11 +604,12 @@ impl Interpreter {
                 result.push_str(&resumed.to_string_value());
                 continue;
             }
-            // Buf/Blob instances with "bytes" attribute: call .Str which throws X::Buf::AsStr
-            // Blob type objects (no "bytes" attr, e.g. $*DISTRO.signature) stringify to ""
+            // Buf/Blob instances with element storage: call .Str, which throws
+            // X::Buf::AsStr. Blob *type objects* have no storage (e.g.
+            // `$*DISTRO.signature`) and stringify to "".
             if let ValueView::Instance { attributes, .. } = v.view()
                 && Self::is_buf_value(&v)
-                && attributes.contains_key("bytes")
+                && crate::value::value_buf::has_buf_elems(&attributes)
             {
                 let str_result = self.try_compiled_method_or_interpret(v, "Str", Vec::new())?;
                 result.push_str(&str_result.to_string_value());

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::value_buf::{buf_elems, buf_elems_in, with_buf_elems};
 
 impl Interpreter {
     /// Wrap a value in item (scalar) context if it's a List/Array,
@@ -1203,9 +1204,7 @@ impl Interpreter {
                 | ValueView::RangeExclStart(..)
                 | ValueView::RangeExclBoth(..),
             ) if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                if let Some(ValueView::Array(bytes, ..)) =
-                    attributes.as_map().get("bytes").map(Value::view)
-                {
+                if let Some(bytes) = buf_elems(&attributes) {
                     let len = bytes.len() as i64;
                     let (start, end_incl) = match index.view() {
                         ValueView::Range(a, b) => (
@@ -1752,13 +1751,7 @@ impl Interpreter {
                 // `list` of positional captures so `$/[*-1]` resolves `*-1` to
                 // the last capture (`m/ (\d) <?{ $/[*-1] < 5 }> /`).
                 let len = if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) {
-                    if let Some(ValueView::Array(bytes, ..)) =
-                        attributes.as_map().get("bytes").map(Value::view)
-                    {
-                        bytes.len() as i64
-                    } else {
-                        0
-                    }
+                    with_buf_elems(&attributes, <[Value]>::len).unwrap_or(0) as i64
                 } else if let Some(ValueView::Array(list, ..)) =
                     attributes.as_map().get("list").map(Value::view)
                 {
@@ -1789,8 +1782,7 @@ impl Interpreter {
                 match i {
                     Some(i) if i >= 0 => {
                         let map = attributes.as_map();
-                        if let Some(ValueView::Array(bytes, ..)) = map.get("bytes").map(Value::view)
-                        {
+                        if let Some(bytes) = buf_elems_in(&map) {
                             bytes.get(i as usize).cloned().unwrap_or(Value::NIL)
                         } else if let Some(ValueView::Array(list, ..)) =
                             map.get("list").map(Value::view)

--- a/src/vm/vm_var_trait_ops.rs
+++ b/src/vm/vm_var_trait_ops.rs
@@ -158,16 +158,13 @@ impl Interpreter {
                         .collect(),
                     ValueView::Instance { attributes, .. } => {
                         // Extract items from an existing Buf/Blob instance
-                        if let Some(ValueView::Array(items, ..)) =
-                            attributes.as_map().get("bytes").map(Value::view)
-                        {
+                        crate::value::value_buf::with_buf_elems(&attributes, |items| {
                             items
                                 .iter()
                                 .map(|v| Value::int(crate::runtime::to_int(v)))
-                                .collect()
-                        } else {
-                            Vec::new()
-                        }
+                                .collect::<Vec<Value>>()
+                        })
+                        .unwrap_or_default()
                     }
                     _ => Vec::new(),
                 };

--- a/todo/deep/adr0015-p2-buf-storage-survey.md
+++ b/todo/deep/adr0015-p2-buf-storage-survey.md
@@ -23,7 +23,13 @@ and `.^array_type` re-derives it in `array_element_type_name`
 (`src/runtime/methods_classhow_dispatch.rs:36-49`). The new node has to carry it,
 because a contiguous `Vec<u8>` cannot be interpreted without it.
 
-## 2. The `"bytes"` campaign is 104 sites, not 91
+**Status: step 1 of the slicing below is DONE** — the accessor chokepoint is
+`src/value/value_buf.rs` and all 104 touches route through it
+(see [`news/2026-07/buf-storage-accessor-chokepoint.md`](../../news/2026-07/buf-storage-accessor-chokepoint.md)).
+Sections 2 and 5 below are now historical: read them for *why* the campaign was
+needed, not as work still to do. Steps 2 and 3 are open.
+
+## 2. The `"bytes"` campaign is 104 sites, not 91 (done — historical)
 
 `grep -rn '"bytes"' src/`: **110 occurrences in 45 files**, of which 6 are not
 attribute touches (method-name literals and comments). The real total is **104
@@ -164,15 +170,22 @@ ADR §4 promises — does not exist yet and is part of P2.
 
 ## Suggested slicing
 
-1. **Accessors first, no representation change.** Introduce the `buf_elems` /
-   `set_buf_elems` / `make_buf` pair and route all 104 touches through it. Purely
-   mechanical, behaviour-preserving, and a prerequisite under any sequencing —
-   the representation cannot be swapped while 40 files reach into the attribute
-   map directly.
+1. ~~**Accessors first, no representation change.**~~ **DONE.**
+   `src/value/value_buf.rs` owns the attribute name and all 104 touches go
+   through it. Two levels landed, not one: *element* accessors that decode to
+   and from `Vec<Value>` (these become the encode/decode boundary in step 2) and
+   *storage* accessors that move the container across without decoding it (these
+   become a node share). `buf_elems` returns `Option` because "no storage at
+   all" (a `Blob` type object) and "empty buffer" are distinguished at several
+   call sites, `has_buf_elems` being the probe.
 2. **The node**, behind those accessors: contiguous `Vec<u8>` + element width,
-   with the encode/decode the accessors now hide.
+   with the encode/decode the accessors now hide. Note the three *different*
+   byte-decoding conventions the callers keep (truncating `as u8`,
+   `.clamp(0, 255) as u8`, `to_f64() as u8`) — they were deliberately not
+   unified in step 1, so step 2 must decide which one the native node's byte
+   view implements and migrate the others explicitly, as a behaviour change with
+   its own tests.
 3. **The body and the honest `.REPR`**, in one commit with the `MVMArrayB` test,
    plus the deletion of `nativecall_pin.rs` and its three helpers.
 
-Step 1 is large but has no design content left; steps 2 and 3 are where the
-judgment is.
+Steps 2 and 3 are where the judgment is.

--- a/todo/tickets/buf-numeric-bitneg-and-write-ubits-mask.md
+++ b/todo/tickets/buf-numeric-bitneg-and-write-ubits-mask.md
@@ -1,0 +1,66 @@
+# Two pre-existing `Buf` parity gaps: `+^$buf` and `write-ubits` bit masking
+
+Both found 2026-07-28 while smoke-testing the ADR-0015 P2 step 1 refactor
+(`src/value/value_buf.rs`) against `raku`. **Neither is caused by that
+refactor** — it left the arithmetic op dispatch and the bit-masking helpers
+(`crate::builtins::buf_bits::write_bits`, `write_bits_into_bytes`) untouched, and
+both gaps reproduce on the same code paths as before. They are recorded here
+rather than fixed in that PR to keep it a pure refactor.
+
+Both are also *outside* what the whitelisted `roast/S03-buf/read-write-bits.t`
+covers — that file passes, which is why they went unnoticed.
+
+## 1. `+^$buf` does not numify the buffer
+
+`+^` (numeric bitwise negation) should numify its operand, and a `Buf` numifies
+to its element count. mutsu numifies it to 0 instead, so the result is always
+`-1`:
+
+```raku
+my $c = Buf.new(0xff, 0x00);
+say $c.Numeric;   # 2   both
+say +$c;          # 2   both
+say (+^$c);       # raku: -3   mutsu: -1
+```
+
+`.Numeric` and prefix `+` are both already right, so the fix is narrow: the
+numeric-bit-negate op needs to coerce through the same path they do. Note the
+**string** bitwise negate `~^$buf` is correct (`Buf:0x<00 FF>` in both), and is a
+genuinely different operation (`exec_str_bit_neg_op` in
+`src/vm/vm_arith_ops.rs`), so do not "unify" the two.
+
+## 2. `write-ubits` / `write-bits` at bit offset 0 keeps bits it should clear
+
+Writing a bit field that does not fill the byte leaves the untouched low bits
+alone in mutsu, while Rakudo clears them:
+
+```raku
+my $d = Buf.new(0x05, 0xAA);
+$d.write-ubits(0, 4, 3);
+say $d.gist;            # raku: Buf:0x<30 AA>   mutsu: Buf:0x<35 AA>
+say $d.read-ubits(4,4); # raku: 0               mutsu: 5
+```
+
+At bit offset 4 the two agree (`Buf.new(0x05, 0xAA).write-ubits(4, 4, 3)` is
+`Buf:0x<03 AA>` in both) — but only because the high nibble of `0x05` was
+already 0, so that case cannot distinguish the two models. `write-bits` behaves
+identically to `write-ubits` here in both implementations.
+
+**Establish the intended model before changing anything.** It is not obvious
+from the above whether Rakudo is specifying "the write zero-extends over the
+whole byte(s) it touches" or whether this is a Rakudo quirk; check
+`raku-doc/doc/Type/Buf.rakudoc` and, if it is silent, the nqp implementation.
+Then extend `roast`-shaped coverage in `t/native-buf-mut.t` with a case whose
+*untouched* bits are non-zero, which is exactly the coverage hole here.
+
+Note there are **three** write-bits code paths that would all need the same fix,
+which is itself worth collapsing:
+
+- `src/runtime/methods_mut_dispatch.rs` (~line 382), via
+  `crate::builtins::buf_bits::write_bits`;
+- `src/runtime/methods_mut_dispatch.rs` (~line 2040), via a *separate* local
+  `write_bits_into_bytes`;
+- `src/vm/vm_call_method_mut_ops.rs` (~line 2620), the VM fast path.
+
+Two independent implementations of the same masking is the reason a fix in one
+place would look like it worked while another path stayed wrong.


### PR DESCRIPTION
ADR-0015 P2 **step 1** of the three-step slicing in
[`todo/deep/adr0015-p2-buf-storage-survey.md`](../blob/main/todo/deep/adr0015-p2-buf-storage-survey.md).

## Why

A `Buf` has no dedicated `Value` variant: it is a `Value::Instance` whose one
attribute, `"bytes"`, holds a `Value::Array` with **one boxed `Value::Int` per
element**. Every place that touched that storage spelled the attribute name
itself and open-coded the `ValueView::Array` match — **104 touches across ~40
files**, with no centralised accessor anywhere.

That is precisely what makes P2 (a native-backed contiguous buffer, so
`Buf.REPR` can honestly answer `VMArray` and NativeCall can hand C a real
`MVMArrayB` body — the last thing between mutsu and DBIish's mysql driver) a
forty-file change rather than a one-file change. The representation cannot be
swapped while forty files reach into the attribute map directly.

## What

`src/value/value_buf.rs` is now that chokepoint. The attribute name is a private
`const ELEMS_ATTR`, and all 104 touches go through it. Two levels, deliberately:

- **element** accessors (`buf_elems`, `buf_elems_or_empty`, `buf_elems_in`,
  `with_buf_elems`, `with_buf_elems_mut`, `set_buf_elems`, `store_buf_elems`,
  `buf_attrs`, `make_buf`, `make_buf_from_u8`, `bytes_to_elems`) decode to and
  from `Vec<Value>` — under P2 they become the encode/decode boundary;
- **storage** accessors (`buf_storage`, `set_buf_storage`, `buf_elems_as_array`)
  move the container across *without* decoding it, for the coercions that only
  re-tag a buffer (`.Buf`, `.Blob`, `.List`) — under P2 they become a node share.

`buf_elems` returns `Option` on purpose: "no element storage at all" (a `Blob`
**type object**, e.g. `$*DISTRO.signature`) and "an empty buffer" are different
things at several call sites, including the interpolation arm that decides
whether to raise `X::Buf::AsStr`. `has_buf_elems` is the probe for that.

Pure refactor, and **smaller than what it replaced**: 45 files, +358/-597.

## Two nuances preserved rather than tidied away

- The **three** byte-decoding conventions in the tree (truncating `as u8`,
  `.clamp(0, 255) as u8`, `to_f64() as u8`) are *not* unified — that would be a
  behaviour change. Each caller keeps its own decode over a borrowed element
  slice from `with_buf_elems`. The survey doc now records that step 2 must pick
  one for the native node's byte view and migrate the others *explicitly*, with
  their own tests.
- `.List`/`.list`/`.Array` on a Buf keeps **sharing** the backing array node
  instead of copying it (`buf_elems_as_array`). The share is invisible — element
  writes go through `with_buf_elems_mut`, whose `Gc::make_mut` forks a shared
  node — but copying would have added an allocation to every such coercion.

The two remaining `"bytes"` literals outside the module are the Raku **method**
name `.bytes` in dispatch tables, not attribute keys.

## Verification

- `cargo build`, `cargo clippy -- -D warnings`, `cargo fmt` — clean
- `make test` — **PASS**, 2543 files / 24342 tests
- `make roast` (full, local) — **PASS**, 1435 files / 218774 tests
- 4 new unit tests in `src/value/value_buf.rs`: the round trip, the
  absent-vs-empty distinction, in-place mutation seen through an alias, and the
  storage hand-off

## Out of scope, recorded not fixed

Smoke-testing against `raku` surfaced two **pre-existing** parity gaps —
`+^$buf` not numifying the buffer, and `write-ubits` at bit offset 0 keeping low
bits Rakudo clears. Neither is caused by this refactor (op dispatch and the
bit-masking helpers are untouched) and both sit outside the whitelisted
`roast/S03-buf/read-write-bits.t`, which passes. Filed as
`todo/tickets/buf-numeric-bitneg-and-write-ubits-mask.md` to keep this PR a pure
refactor; the ticket also notes the three write-bits paths share only two
masking implementations between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)