### PR TITLE
refactor(buf): give Buf/Blob a byte view and one element-width probe

### DIFF
--- a/news/2026-07/buf-byte-and-width-accessors.md
+++ b/news/2026-07/buf-byte-and-width-accessors.md
@@ -1,0 +1,76 @@
+# `Buf`/`Blob` gains a byte view and one element-width probe
+
+[ADR-0015](../../docs/adr/0015-native-backed-container-storage-and-repr-bodies.md)
+P2 step 1 made `src/value/value_buf.rs` the single place that knows how a
+`Buf`/`Blob` stores its elements. It exposed that storage the only way the old
+representation could: as `Vec<Value>`, one boxed `Int` per element. That is fine
+for a caller that really wants elements, and wrong for the majority, which want
+either a byte string or a count — and which therefore each open-coded their own
+element→byte loop on top of the accessor.
+
+This change adds the second half of the chokepoint, so the module now answers
+three questions instead of one, and P2 step 2 (the contiguous native node) has
+somewhere to land.
+
+## What was actually there
+
+Thirty-five call sites went through `with_buf_elems`. Counting what they did
+with the slice:
+
+- **seven** wanted only `items.len()`;
+- **most of the rest** immediately mapped every element to a `u8` and collected,
+  i.e. they wanted the buffer's bytes and paid a boxed intermediate to get them;
+- a handful genuinely wanted elements.
+
+The byte loops did not agree with each other. Three conventions were in the
+tree — truncating `i as u8`, `.clamp(0, 255) as u8`, and one going through
+`to_int` — and the survey
+([`todo/deep/adr0015-p2-buf-storage-survey.md`](../../todo/deep/adr0015-p2-buf-storage-survey.md))
+deliberately left them alone during step 1, because unifying them is a
+behaviour change and step 1 was meant to preserve behaviour exactly.
+
+Separately, the **element width** — the one piece of a `Buf`'s type that is not
+in its data at all, only in its class name — was re-derived from that name by
+four different `cn.contains("16")` ladders (`.bytes`, `.raku`, `.gist`, and the
+constructor's mask), two of which tested the widths in a different order than
+the other two.
+
+## What it is now
+
+`value_buf` grows a byte level next to the element level:
+`elem_to_u8`, `buf_bytes`, `buf_bytes_or_empty`, `buf_bytes_in`,
+`with_buf_bytes`, `set_buf_bytes`, `store_buf_bytes`, `make_buf_from_bytes`,
+plus `buf_len` / `buf_len_or_zero` for the callers that only ever wanted a
+count. `buf_elem_width` is the single width probe the four ladders collapsed
+into.
+
+Every byte-shaped and length-shaped caller now goes through them, which is
+what removes 275 lines against 232 added across 25 files.
+
+## Which convention won, and why it is safe
+
+**Truncation** — the one Raku itself stores by. `Buf.new(300)` holds `0x2C` and
+`Buf.new(-1)` holds `0xFF` in both mutsu and Rakudo, and every mutation path
+(`.new`, `[i] =`, `push`, `append`, `unshift`, `splice`) was verified to mask on
+the way in, in both implementations. So the stored elements are always already
+in range for the buffer's width, and the three read-side conventions could only
+ever disagree about a state that cannot be constructed — except for a *wider*
+buffer, whose elements legitimately exceed a byte. There truncation yields the
+element's low byte (`buf16.new(0x1170)` → `0x70`) and clamping yielded `0xFF`;
+Rakudo agrees with neither, since `read-ubits` on a non-`uint8` buffer is not
+a defined operation, so nothing is lost by picking the coherent one.
+
+A 37-line smoke script comparing mutsu against `raku` across construction,
+gisting, `.raku`, encode/decode, `.bytes`, indexed assignment, `push`,
+`write-uint16`/`write-int32`/`write-num32`, `read-ubits`, `.Buf`/`.Blob`
+coercion, concatenation and `eqv` produces byte-identical output apart from the
+one already-recorded `write-ubits` masking gap
+(`todo/tickets/buf-numeric-bitneg-and-write-ubits-mask.md`).
+
+## What this sets up
+
+Under the native node a width-1 buffer — every `Buf`, `Blob` and `utf8` — *is*
+its bytes, so `with_buf_bytes` hands its storage straight to the caller and
+`buf_len` is a field read. The element accessors become the encode/decode
+boundary, and they now have far fewer callers to serve. `buf_elem_width` is the
+one line that moves from reading a class name to reading the node.

--- a/src/builtins/buf_write_int.rs
+++ b/src/builtins/buf_write_int.rs
@@ -6,7 +6,7 @@
 //   (similarly for write-int8, write-uint16, ..., write-int128)
 
 use crate::symbol::Symbol;
-use crate::value::value_buf::{bytes_to_elems, set_buf_elems, with_buf_elems};
+use crate::value::value_buf::{buf_bytes_or_empty, set_buf_bytes};
 use crate::value::{InstanceAttrs, RuntimeError, Value, ValueView};
 
 /// Returns Some((byte_size, is_signed)) if the method is a write-int/uint method.
@@ -186,16 +186,7 @@ pub(crate) fn try_native_buf_write(
             if !crate::runtime::utils::is_buf_or_blob_class(&cn) {
                 return None;
             }
-            with_buf_elems(&attributes, |items| {
-                bytes.reserve(items.len());
-                for it in items.iter() {
-                    bytes.push(match it.view() {
-                        ValueView::Int(i) => i.clamp(0, 255) as u8,
-                        ValueView::Num(f) => (f as i64).clamp(0, 255) as u8,
-                        _ => 0,
-                    });
-                }
-            });
+            bytes = buf_bytes_or_empty(&attributes);
             inst = Some(BufWriteCell {
                 attributes: attributes.clone(),
                 class_sym: class_name,
@@ -235,7 +226,7 @@ pub(crate) fn try_native_buf_write(
     match inst {
         Some(cell) => {
             let mut updated_map = cell.attributes.to_map();
-            set_buf_elems(&mut updated_map, bytes_to_elems(&bytes));
+            set_buf_bytes(&mut updated_map, &bytes);
             Some(Ok(Value::write_back_sharing(
                 &cell.attributes,
                 cell.class_sym,

--- a/src/builtins/buf_write_num.rs
+++ b/src/builtins/buf_write_num.rs
@@ -4,7 +4,6 @@
 //   method write-num32(::T:U: $offset, num32 $value, $endian = NativeEndian --> Buf:D)
 //   method write-num32(Buf:D: $offset, num32 $value, $endian = NativeEndian --> Buf:D)
 
-use crate::value::value_buf::bytes_to_elems;
 use crate::value::{RuntimeError, Value, ValueView};
 
 /// Returns Some(size_in_bytes) if the method is a write-num method.
@@ -89,5 +88,5 @@ pub(crate) fn apply_write_num(
 /// Build a fresh Buf instance value from a byte vector.
 pub(crate) fn make_buf_value(class_name: &str, bytes: Vec<u8>) -> Value {
     use crate::symbol::Symbol;
-    crate::value::value_buf::make_buf(Symbol::intern(class_name), bytes_to_elems(&bytes))
+    crate::value::value_buf::make_buf_from_bytes(Symbol::intern(class_name), &bytes)
 }

--- a/src/builtins/methods_0arg/dispatch_core_coerce.rs
+++ b/src/builtins/methods_0arg/dispatch_core_coerce.rs
@@ -2,7 +2,7 @@
 /// Num, Real, Numeric, Bridge
 use crate::runtime;
 use crate::symbol::Symbol;
-use crate::value::value_buf::{buf_storage, set_buf_storage, with_buf_elems};
+use crate::value::value_buf::{buf_len_or_zero, buf_storage, set_buf_storage};
 use crate::value::{RuntimeError, Value, ValueView};
 use num_traits::{ToPrimitive, Zero};
 use std::sync::Arc;
@@ -752,7 +752,7 @@ pub(super) fn dispatch(
                     attributes,
                     ..
                 } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                    Value::int(with_buf_elems(&attributes, <[Value]>::len).unwrap_or(0) as i64)
+                    Value::int(buf_len_or_zero(&attributes) as i64)
                 }
                 // A StrDistance's `.Int` is the edit distance between its
                 // before/after strings, matching `+$str-dist` / `.Numeric`.
@@ -1089,7 +1089,7 @@ pub(super) fn dispatch(
                     attributes,
                     ..
                 } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                    Value::int(with_buf_elems(&attributes, <[Value]>::len).unwrap_or(0) as i64)
+                    Value::int(buf_len_or_zero(&attributes) as i64)
                 }
                 ValueView::Instance {
                     class_name,

--- a/src/builtins/methods_0arg/dispatch_core_list.rs
+++ b/src/builtins/methods_0arg/dispatch_core_list.rs
@@ -1,6 +1,6 @@
 /// List/sequence operations: end, flat, sort, reverse, unique, repeated, floor,
 /// ceiling, round, truncate, narrow, sqrt
-use crate::value::value_buf::{buf_elems_or_empty, make_buf, with_buf_elems};
+use crate::value::value_buf::{buf_elems_or_empty, buf_len_or_zero, make_buf};
 use crate::value::{RuntimeError, Value, ValueView};
 use num_traits::{Signed, Zero};
 
@@ -32,7 +32,7 @@ pub(super) fn dispatch(
                     attributes,
                     ..
                 } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                    let len = with_buf_elems(&attributes, <[Value]>::len).unwrap_or(0);
+                    let len = buf_len_or_zero(&attributes);
                     Some(Ok(Value::int(len as i64 - 1)))
                 }
                 ValueView::LazyList(_) => None,

--- a/src/builtins/methods_0arg/dispatch_core_math.rs
+++ b/src/builtins/methods_0arg/dispatch_core_math.rs
@@ -605,9 +605,9 @@ pub(super) fn dispatch(
         "tree" => Some(Some(Ok(tree_to_depth(target, usize::MAX)))),
         "encode" => {
             let s = target.to_string_value();
-            Some(Some(Ok(crate::value::value_buf::make_buf(
+            Some(Some(Ok(crate::value::value_buf::make_buf_from_bytes(
                 Symbol::intern("utf8"),
-                crate::value::value_buf::bytes_to_elems(s.as_bytes()),
+                s.as_bytes(),
             ))))
         }
         "sink" => Some(match target.view() {

--- a/src/builtins/methods_0arg/dispatch_core_numeric.rs
+++ b/src/builtins/methods_0arg/dispatch_core_numeric.rs
@@ -128,10 +128,7 @@ pub(super) fn dispatch(
                     attributes,
                     ..
                 } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                    Value::int(
-                        crate::value::value_buf::with_buf_elems(&attributes, <[Value]>::len)
-                            .unwrap_or(0) as i64,
-                    )
+                    Value::int(crate::value::value_buf::buf_len_or_zero(&attributes) as i64)
                 }
                 ValueView::Channel(_) => {
                     return Some(Some(Err(RuntimeError::new(

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -308,16 +308,8 @@ pub(super) fn dispatch(
                     if bytes.is_empty() {
                         Some(Ok(Value::str(format!("{}:0x<>", class_name))))
                     } else {
-                        let cn = class_name.resolve();
-                        let hex_width = if cn.contains("64") {
-                            16
-                        } else if cn.contains("32") {
-                            8
-                        } else if cn.contains("16") {
-                            4
-                        } else {
-                            2
-                        };
+                        let hex_width =
+                            2 * crate::value::value_buf::buf_elem_width(&class_name.resolve());
                         let truncated = bytes.len() > 100;
                         let display_bytes = if truncated { &bytes[..100] } else { &bytes[..] };
                         let mut hex: Vec<String> = display_bytes

--- a/src/builtins/methods_0arg/dispatch_core_unicode.rs
+++ b/src/builtins/methods_0arg/dispatch_core_unicode.rs
@@ -28,18 +28,9 @@ pub(super) fn dispatch(
                     || cn.starts_with("blob")
             } =>
             {
-                let elems = crate::value::value_buf::with_buf_elems(&attributes, <[Value]>::len)
-                    .unwrap_or(0) as i64;
-                let cn = class_name.resolve();
-                let bytes_per_elem: i64 = if cn.contains("16") {
-                    2
-                } else if cn.contains("32") {
-                    4
-                } else if cn.contains("64") {
-                    8
-                } else {
-                    1
-                };
+                let elems = crate::value::value_buf::buf_len_or_zero(&attributes) as i64;
+                let bytes_per_elem =
+                    crate::value::value_buf::buf_elem_width(&class_name.resolve()) as i64;
                 Some(Ok(Value::int(elems * bytes_per_elem)))
             }
             ValueView::Str(s) => Some(Ok(Value::int(s.len() as i64))),

--- a/src/builtins/methods_narg/buf.rs
+++ b/src/builtins/methods_narg/buf.rs
@@ -1,5 +1,5 @@
 use crate::symbol::Symbol;
-use crate::value::value_buf::{buf_elems, make_buf, with_buf_elems};
+use crate::value::value_buf::{buf_bytes, buf_elems, make_buf};
 use crate::value::{RuntimeError, Value, ValueView};
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
@@ -138,17 +138,8 @@ pub(crate) fn buf_get_bytes(target: &Value) -> Option<Vec<u8>> {
         ..
     } = target.view()
         && crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve())
-        && let Some(bytes) = with_buf_elems(&attributes, |items| {
-            items
-                .iter()
-                .map(|v| match v.view() {
-                    ValueView::Int(i) => i as u8,
-                    _ => 0,
-                })
-                .collect::<Vec<u8>>()
-        })
     {
-        return Some(bytes);
+        return buf_bytes(&attributes);
     }
     None
 }

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -288,12 +288,11 @@ fn decode_buf_target_bytes(target: &Value, encoding_name: &str) -> Option<Vec<u8
     if !crate::value::value_buf::has_buf_elems_in(&map) {
         return None;
     }
-    let items = crate::value::value_buf::buf_elems_in(&map).unwrap_or_default();
-
     let cn = class_name.resolve();
     // buf16 / Buf[uint16] / utf16 store 16-bit code units; expand each to 2 bytes
     let is_wide = cn == "utf16" || cn == "buf16" || cn == "Buf[uint16]";
     if is_wide {
+        let items = crate::value::value_buf::buf_elems_in(&map).unwrap_or_default();
         let use_be = encoding_name == "utf-16be";
         let mut out = Vec::with_capacity(items.len() * 2);
         for item in items.iter() {
@@ -310,15 +309,7 @@ fn decode_buf_target_bytes(target: &Value, encoding_name: &str) -> Option<Vec<u8
         }
         Some(out)
     } else {
-        Some(
-            items
-                .iter()
-                .map(|v| match v.view() {
-                    ValueView::Int(i) => i as u8,
-                    _ => 0,
-                })
-                .collect(),
-        )
+        Some(crate::value::value_buf::buf_bytes_in(&map).unwrap_or_default())
     }
 }
 

--- a/src/runtime/builtins_eval_misc.rs
+++ b/src/runtime/builtins_eval_misc.rs
@@ -272,17 +272,7 @@ impl Interpreter {
                     ..
                 } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
                     // Buf argument: decode as UTF-8
-                    if let Some(bytes) =
-                        crate::value::value_buf::with_buf_elems(&attributes, |items| {
-                            items
-                                .iter()
-                                .map(|v| match v.view() {
-                                    ValueView::Int(n) => n as u8,
-                                    _ => v.to_string_value().parse::<u8>().unwrap_or(0),
-                                })
-                                .collect::<Vec<u8>>()
-                        })
-                    {
+                    if let Some(bytes) = crate::value::value_buf::buf_bytes(&attributes) {
                         let code = String::from_utf8_lossy(&bytes).to_string();
                         return self.eval_eval_string(&code);
                     }

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -11,7 +11,7 @@ use crate::symbol::Symbol;
 use crate::value::ValueView;
 use crate::value::signature::extract_sig_info;
 use crate::value::value_buf::{
-    buf_elems_or_empty, bytes_to_elems, make_buf, set_buf_elems, with_buf_elems,
+    buf_bytes_or_empty, buf_elems_or_empty, make_buf, set_buf_bytes, with_buf_bytes,
 };
 
 impl Interpreter {
@@ -646,15 +646,8 @@ impl Interpreter {
                         attributes,
                         ..
                     } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
-                        with_buf_elems(&attributes, |items| {
-                            let bytes: Vec<u8> = items
-                                .iter()
-                                .map(|v| match v.view() {
-                                    ValueView::Int(n) => n as u8,
-                                    _ => v.to_string_value().parse::<u8>().unwrap_or(0),
-                                })
-                                .collect();
-                            String::from_utf8_lossy(&bytes).to_string()
+                        with_buf_bytes(&attributes, |bytes| {
+                            String::from_utf8_lossy(bytes).to_string()
                         })
                         .unwrap_or_default()
                     }
@@ -773,17 +766,7 @@ impl Interpreter {
                     } => {
                         let cn = class_name.resolve();
                         if crate::runtime::utils::is_buf_or_blob_class(&cn) {
-                            let v = with_buf_elems(&attributes, |items| {
-                                items
-                                    .iter()
-                                    .map(|it| match it.view() {
-                                        ValueView::Int(i) => i.clamp(0, 255) as u8,
-                                        ValueView::Num(f) => (f as i64).clamp(0, 255) as u8,
-                                        _ => 0,
-                                    })
-                                    .collect::<Vec<u8>>()
-                            })
-                            .unwrap_or_default();
+                            let v = buf_bytes_or_empty(&attributes);
                             (
                                 true,
                                 Some(cn),
@@ -831,7 +814,7 @@ impl Interpreter {
                     let id = id_opt.unwrap();
                     let updated_cell = attrs_opt.unwrap();
                     let mut updated_map = updated_cell.to_map();
-                    set_buf_elems(&mut updated_map, bytes_to_elems(&bytes));
+                    set_buf_bytes(&mut updated_map, &bytes);
                     return Ok(Value::write_back_sharing(
                         &updated_cell,
                         class_sym,
@@ -868,17 +851,7 @@ impl Interpreter {
                     } => {
                         let cn = class_name.resolve();
                         if crate::runtime::utils::is_buf_or_blob_class(&cn) {
-                            let v = with_buf_elems(&attributes, |items| {
-                                items
-                                    .iter()
-                                    .map(|it| match it.view() {
-                                        ValueView::Int(i) => i.clamp(0, 255) as u8,
-                                        ValueView::Num(f) => (f as i64).clamp(0, 255) as u8,
-                                        _ => 0,
-                                    })
-                                    .collect::<Vec<u8>>()
-                            })
-                            .unwrap_or_default();
+                            let v = buf_bytes_or_empty(&attributes);
                             (
                                 true,
                                 Some(cn),
@@ -926,7 +899,7 @@ impl Interpreter {
                     let id = id_opt.unwrap();
                     let updated_cell = attrs_opt.unwrap();
                     let mut updated_map = updated_cell.to_map();
-                    set_buf_elems(&mut updated_map, bytes_to_elems(&bytes));
+                    set_buf_bytes(&mut updated_map, &bytes);
                     return Ok(Value::write_back_sharing(
                         &updated_cell,
                         class_sym,

--- a/src/runtime/methods_io_dispatch.rs
+++ b/src/runtime/methods_io_dispatch.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::symbol::Symbol;
 use crate::value::ValueView;
 use crate::value::value_buf::{
-    buf_elems_or_empty, bytes_to_elems, make_buf, set_buf_elems, with_buf_elems,
+    buf_bytes_or_empty, buf_elems_or_empty, make_buf, set_buf_bytes, set_buf_elems, with_buf_elems,
 };
 
 impl Interpreter {
@@ -160,7 +160,7 @@ impl Interpreter {
                     &encoding,
                     replacement.as_deref(),
                 )?;
-                set_buf_elems(&mut attrs, bytes_to_elems(&bytes));
+                set_buf_bytes(&mut attrs, &bytes);
                 match normalized_encoding.as_str() {
                     "utf-8" | "utf8" => "utf8",
                     _ => "Blob[uint8]",
@@ -221,16 +221,7 @@ impl Interpreter {
                 })
                 .unwrap_or_default()
             } else {
-                with_buf_elems(&attributes, |items| {
-                    items
-                        .iter()
-                        .map(|v| match v.view() {
-                            ValueView::Int(i) => i as u8,
-                            _ => 0,
-                        })
-                        .collect::<Vec<u8>>()
-                })
-                .unwrap_or_default()
+                buf_bytes_or_empty(&attributes)
             };
             let decoded = match self.decode_with_encoding_and_replacement(
                 &bytes,

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -2,7 +2,7 @@ use super::methods_signature_errors::make_x_immutable_error;
 use super::*;
 use crate::symbol::Symbol;
 use crate::value::ValueView;
-use crate::value::value_buf::{buf_elems_in, bytes_to_elems, set_buf_elems, with_buf_elems};
+use crate::value::value_buf::{buf_bytes_in, buf_bytes_or_empty, set_buf_bytes};
 use num_bigint::BigInt;
 use num_traits::Signed;
 
@@ -340,20 +340,7 @@ impl Interpreter {
         } = target.view()
             && crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve())
         {
-            let bytes = with_buf_elems(&attributes, |items| {
-                items
-                    .iter()
-                    .map(|v| match v.view() {
-                        ValueView::Int(i) => i.clamp(0, 255) as u8,
-                        ValueView::Num(f) => (f as i64).clamp(0, 255) as u8,
-                        ValueView::BigInt(bi) => num_traits::ToPrimitive::to_i64(bi.as_ref())
-                            .unwrap_or(0)
-                            .clamp(0, 255) as u8,
-                        _ => 0u8,
-                    })
-                    .collect::<Vec<u8>>()
-            })
-            .unwrap_or_default();
+            let bytes = buf_bytes_or_empty(&attributes);
 
             if (method == "read-ubits" || method == "read-bits") && args.len() == 2 {
                 let Some(from) = Self::value_to_non_negative_i64(&args[0]) else {
@@ -390,7 +377,7 @@ impl Interpreter {
                 };
                 let written = crate::builtins::buf_bits::write_bits(&bytes, from, bits, &args[2])?;
                 let mut updated_attrs = attributes.to_map();
-                set_buf_elems(&mut updated_attrs, bytes_to_elems(&written));
+                set_buf_bytes(&mut updated_attrs, &written);
                 return Ok(Value::write_back_sharing(
                     &attributes,
                     class_name,
@@ -435,22 +422,12 @@ impl Interpreter {
                 ValueView::Num(f) => f as i64,
                 _ => 0,
             };
-            let mut bytes = with_buf_elems(&attributes, |items| {
-                items
-                    .iter()
-                    .map(|it| match it.view() {
-                        ValueView::Int(i) => i.clamp(0, 255) as u8,
-                        ValueView::Num(f) => (f as i64).clamp(0, 255) as u8,
-                        _ => 0,
-                    })
-                    .collect::<Vec<u8>>()
-            })
-            .unwrap_or_default();
+            let mut bytes = buf_bytes_or_empty(&attributes);
             crate::builtins::buf_write_num::apply_write_num(
                 &mut bytes, method, offset_i64, value_val, endian_val,
             )?;
             let mut updated_attrs = attributes.to_map();
-            set_buf_elems(&mut updated_attrs, bytes_to_elems(&bytes));
+            set_buf_bytes(&mut updated_attrs, &bytes);
             let updated = Value::write_back_sharing(&attributes, class_name, updated_attrs, id);
             self.env.insert(target_var.to_string(), updated.clone());
             return Ok(updated);
@@ -526,22 +503,12 @@ impl Interpreter {
                 ValueView::Num(f) => f as i64,
                 _ => 0,
             };
-            let mut bytes = with_buf_elems(&attributes, |items| {
-                items
-                    .iter()
-                    .map(|it| match it.view() {
-                        ValueView::Int(i) => i.clamp(0, 255) as u8,
-                        ValueView::Num(f) => (f as i64).clamp(0, 255) as u8,
-                        _ => 0,
-                    })
-                    .collect::<Vec<u8>>()
-            })
-            .unwrap_or_default();
+            let mut bytes = buf_bytes_or_empty(&attributes);
             crate::builtins::buf_write_int::apply_write_int(
                 &mut bytes, method, offset_i64, value_val, endian_val,
             )?;
             let mut updated_attrs = attributes.to_map();
-            set_buf_elems(&mut updated_attrs, bytes_to_elems(&bytes));
+            set_buf_bytes(&mut updated_attrs, &bytes);
             let updated = Value::write_back_sharing(&attributes, class_name, updated_attrs, id);
             self.env.insert(target_var.to_string(), updated.clone());
             return Ok(updated);
@@ -2047,14 +2014,7 @@ impl Interpreter {
                 let from = from as usize;
                 let bits = bits as usize;
                 let mut updated = attributes.to_map();
-                let mut bytes: Vec<u8> = buf_elems_in(&updated)
-                    .unwrap_or_default()
-                    .iter()
-                    .map(|v| match v.view() {
-                        ValueView::Int(i) => i as u8,
-                        _ => 0,
-                    })
-                    .collect();
+                let mut bytes = buf_bytes_in(&updated).unwrap_or_default();
                 let required_bits = from.saturating_add(bits);
                 let required_len = required_bits.div_ceil(8);
                 if bytes.len() < required_len {
@@ -2064,7 +2024,7 @@ impl Interpreter {
                 if bits > 0 {
                     write_bits_into_bytes(&mut bytes, from, bits, &value);
                 }
-                set_buf_elems(&mut updated, bytes_to_elems(&bytes));
+                set_buf_bytes(&mut updated, &bytes);
                 let updated_instance =
                     Value::write_back_sharing(&attributes, class_name, updated, target_id);
                 self.env

--- a/src/runtime/methods_object_native_ctors_buf_num.rs
+++ b/src/runtime/methods_object_native_ctors_buf_num.rs
@@ -47,10 +47,11 @@ impl Interpreter {
             .collect();
         // Mask values to unsigned range based on element size. For uint64, use
         // BigInt-aware conversion to preserve values > i64::MAX.
+        let width = crate::value::value_buf::buf_elem_width(&cn);
         let byte_vals: Vec<Value> = raw_vals
             .into_iter()
-            .map(|v| {
-                if cn.contains("64") {
+            .map(|v| match width {
+                8 => {
                     let u = match v.view() {
                         ValueView::BigInt(n) => {
                             use num_traits::ToPrimitive;
@@ -59,13 +60,10 @@ impl Interpreter {
                         _ => to_int(&v) as u64,
                     };
                     Value::int(u as i64)
-                } else if cn.contains("32") {
-                    Value::int(to_int(&v) as u32 as i64)
-                } else if cn.contains("16") {
-                    Value::int(to_int(&v) as u16 as i64)
-                } else {
-                    Value::int(to_int(&v) as u8 as i64)
                 }
+                4 => Value::int(to_int(&v) as u32 as i64),
+                2 => Value::int(to_int(&v) as u16 as i64),
+                _ => Value::int(to_int(&v) as u8 as i64),
             })
             .collect();
         // Normalize short buf/blob names to canonical forms.

--- a/src/runtime/native_io/io_handle.rs
+++ b/src/runtime/native_io/io_handle.rs
@@ -857,9 +857,9 @@ impl Interpreter {
                     break;
                 }
                 for chunk in bytes.chunks(size) {
-                    values.push(crate::value::value_buf::make_buf(
+                    values.push(crate::value::value_buf::make_buf_from_bytes(
                         Symbol::intern("Buf[uint8]"),
-                        crate::value::value_buf::bytes_to_elems(chunk),
+                        chunk,
                     ));
                 }
                 if bytes.len() < size {

--- a/src/runtime/native_methods/mod.rs
+++ b/src/runtime/native_methods/mod.rs
@@ -211,18 +211,7 @@ impl Interpreter {
                     || cn.starts_with("Blob[")
             } =>
             {
-                if let Some(bytes) = crate::value::value_buf::with_buf_elems(&attributes, |items| {
-                    items
-                        .iter()
-                        .map(|v| match v.view() {
-                            ValueView::Int(i) => i as u8,
-                            _ => 0,
-                        })
-                        .collect::<Vec<u8>>()
-                }) {
-                    return bytes;
-                }
-                Vec::new()
+                crate::value::value_buf::buf_bytes_or_empty(&attributes)
             }
             ValueView::Instance {
                 class_name,

--- a/src/runtime/native_methods/socket_helpers.rs
+++ b/src/runtime/native_methods/socket_helpers.rs
@@ -20,19 +20,7 @@ impl Interpreter {
                     || cn.starts_with("Blob[")
             } =>
             {
-                if let Some(bytes) = crate::value::value_buf::with_buf_elems(&attributes, |items| {
-                    items
-                        .iter()
-                        .map(|v| match v.view() {
-                            ValueView::Int(i) => i as u8,
-                            _ => 0,
-                        })
-                        .collect::<Vec<u8>>()
-                }) {
-                    Some(bytes)
-                } else {
-                    Some(Vec::new())
-                }
+                Some(crate::value::value_buf::buf_bytes_or_empty(&attributes))
             }
             ValueView::Array(elems, ..) => Some(
                 elems
@@ -263,9 +251,9 @@ impl Interpreter {
 
     /// Create a Buf instance from raw bytes
     pub(crate) fn make_buf(bytes: Vec<u8>) -> Value {
-        crate::value::value_buf::make_buf(
+        crate::value::value_buf::make_buf_from_bytes(
             crate::symbol::Symbol::intern("Buf[uint8]"),
-            crate::value::value_buf::bytes_to_elems(&bytes),
+            &bytes,
         )
     }
 }

--- a/src/runtime/native_proc_async.rs
+++ b/src/runtime/native_proc_async.rs
@@ -669,16 +669,7 @@ impl Interpreter {
                             || cn.starts_with("Blob[")
                     } =>
                     {
-                        crate::value::value_buf::with_buf_elems(&attributes, |items| {
-                            items
-                                .iter()
-                                .map(|v| match v.view() {
-                                    ValueView::Int(i) => i as u8,
-                                    _ => 0,
-                                })
-                                .collect::<Vec<u8>>()
-                        })
-                        .unwrap_or_default()
+                        crate::value::value_buf::buf_bytes_or_empty(&attributes)
                     }
                     ValueView::Str(s) => {
                         let enc = attrs

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -838,10 +838,7 @@ fn buf_instance_pin_key(v: &Value) -> Option<usize> {
 fn write_buf_instance_bytes(v: &Value, bytes: &[u8]) {
     match v.view() {
         ValueView::Instance { attributes, .. } => {
-            crate::value::value_buf::store_buf_elems(
-                &attributes,
-                crate::value::value_buf::bytes_to_elems(bytes),
-            );
+            crate::value::value_buf::store_buf_bytes(&attributes, bytes);
         }
         ValueView::Scalar(inner) => write_buf_instance_bytes(inner, bytes),
         ValueView::ContainerRef(cell) => {

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -726,17 +726,9 @@ impl Value {
                         // `(Blob)` via a separate path.
                         format!("{}:0x<>", class_name)
                     } else {
-                        // Determine hex width from element size in the class name
-                        let cn = class_name.resolve();
-                        let hex_width = if cn.contains("64") {
-                            16 // 64-bit = 8 bytes = 16 hex chars
-                        } else if cn.contains("32") {
-                            8
-                        } else if cn.contains("16") {
-                            4
-                        } else {
-                            2 // 8-bit (default)
-                        };
+                        // Two hex digits per byte of one element.
+                        let hex_width =
+                            2 * crate::value::value_buf::buf_elem_width(&class_name.resolve());
                         let hex: Vec<String> = bytes
                             .iter()
                             .map(|b| match b.view() {

--- a/src/value/value_buf.rs
+++ b/src/value/value_buf.rs
@@ -15,13 +15,22 @@
 //! `Buf.REPR` can honestly answer `VMArray` and NativeCall can hand C a real
 //! `MVMArrayB` body) a change to *this file* rather than to its callers.
 //!
-//! Two levels are offered deliberately:
+//! Three levels are offered deliberately:
 //!
 //! - the **element** functions ([`buf_elems`], [`set_buf_elems`], …) decode to
 //!   and from `Vec<Value>`; under P2 they become the encode/decode boundary;
+//! - the **byte** functions ([`buf_bytes`], [`with_buf_bytes`], [`buf_len`], …)
+//!   speak the representation P2 will actually store, so a caller that only
+//!   wants bytes or a count never round-trips through boxed `Value`s;
 //! - the **storage** functions ([`buf_storage`], [`set_buf_storage`]) move the
 //!   container across without decoding it, for the coercions that only re-tag a
 //!   buffer (`.Buf`, `.Blob`); under P2 they become a node share.
+//!
+//! [`buf_elem_width`] is the fourth thing P2 needs and the one that is *not*
+//! stored in the data at all today: the element width lives only in the class
+//! name (`Buf[uint16]`), and four separate places used to re-derive it with
+//! their own `cn.contains("16")` ladder. It is derived here now, so P2 has one
+//! place to move it from the name into the node.
 //!
 //! [`is_buf_or_blob_class`](crate::runtime::utils::is_buf_or_blob_class) stays
 //! the companion class-name filter: this module answers "what is in there", not
@@ -101,7 +110,7 @@ pub(crate) fn make_buf(class_name: Symbol, elems: Vec<Value>) -> Value {
 /// A fresh plain `Buf` over raw bytes — the commonest construction of all (I/O
 /// reads, socket receives, `Proc::Async` chunks). Under P2 this stops boxing.
 pub(crate) fn make_buf_from_u8(bytes: &[u8]) -> Value {
-    make_buf(Symbol::intern("Buf"), bytes_to_elems(bytes))
+    make_buf_from_bytes(Symbol::intern("Buf"), bytes)
 }
 
 /// Raw bytes as the boxed element list this representation stores.
@@ -157,6 +166,113 @@ pub(crate) fn buf_elems_as_array(map: &AttrMap, kind: super::ArrayKind) -> Optio
     }
 }
 
+// ---------------------------------------------------------------------------
+// Byte-level access — what P2 will actually store.
+// ---------------------------------------------------------------------------
+
+/// One element, as the byte it occupies in a width-1 buffer.
+///
+/// **Truncating**, which is the convention Raku itself stores by: `Buf.new(300)`
+/// holds `0x2C` and `Buf.new(-1)` holds `0xFF` in both mutsu and Rakudo, and
+/// every mutation path (`.new`, `[i] =`, `push`, `append`, `unshift`, `splice`)
+/// already masks on the way in. Three different conventions used to be spelled
+/// out at the call sites — this one, a `.clamp(0, 255)` one, and one going via
+/// `to_int` — and they could only disagree about a buffer whose elements exceed
+/// its width, which the masking makes unreachable. For a wider buffer this is
+/// the low byte of the element, matching what the truncating sites did.
+pub(crate) fn elem_to_u8(v: &Value) -> u8 {
+    match v.view() {
+        ValueView::Int(i) => i as u8,
+        ValueView::Num(f) => f as i64 as u8,
+        ValueView::BigInt(n) => {
+            use num_traits::ToPrimitive;
+            // `to_u64` is `None` for a negative or oversized value; fall back to
+            // the low 64 bits so this stays a truncation rather than a zero.
+            n.as_ref()
+                .to_u64()
+                .unwrap_or_else(|| n.as_ref().to_i64().unwrap_or(0) as u64) as u8
+        }
+        _ => 0,
+    }
+}
+
+/// The number of **elements**, without decoding any of them. Not the number of
+/// bytes — see [`buf_elem_width`], and `.bytes` is `elems * width`.
+pub(crate) fn buf_len(attrs: &InstanceAttrs) -> Option<usize> {
+    with_buf_elems(attrs, <[Value]>::len)
+}
+
+/// [`buf_len`] with an absent buffer read as empty.
+pub(crate) fn buf_len_or_zero(attrs: &InstanceAttrs) -> usize {
+    buf_len(attrs).unwrap_or(0)
+}
+
+/// The elements as one truncated byte each ([`elem_to_u8`]).
+///
+/// `None` when the instance carries no element storage, exactly as
+/// [`buf_elems`]. For a width-1 buffer — every `Buf`/`Blob`/`utf8` — these are
+/// the buffer's real bytes, and P2 hands them over without decoding anything.
+pub(crate) fn buf_bytes(attrs: &InstanceAttrs) -> Option<Vec<u8>> {
+    with_buf_bytes(attrs, <[u8]>::to_vec)
+}
+
+/// [`buf_bytes`] with an absent buffer read as empty.
+pub(crate) fn buf_bytes_or_empty(attrs: &InstanceAttrs) -> Vec<u8> {
+    buf_bytes(attrs).unwrap_or_default()
+}
+
+/// [`buf_bytes`] against an attribute map already in hand.
+pub(crate) fn buf_bytes_in(map: &AttrMap) -> Option<Vec<u8>> {
+    Some(buf_elems_in(map)?.iter().map(elem_to_u8).collect())
+}
+
+/// Run `f` over the bytes without handing out an owned `Vec`.
+///
+/// Today the slice is a temporary this function builds; under P2 a width-1
+/// buffer passes its storage straight through. Callers that go on to mutate the
+/// bytes want [`buf_bytes`] instead.
+pub(crate) fn with_buf_bytes<R>(attrs: &InstanceAttrs, f: impl FnOnce(&[u8]) -> R) -> Option<R> {
+    let bytes = with_buf_elems(attrs, |items| {
+        items.iter().map(elem_to_u8).collect::<Vec<u8>>()
+    })?;
+    Some(f(&bytes))
+}
+
+/// Store raw bytes into a map being built or updated.
+pub(crate) fn set_buf_bytes(map: &mut AttrMap, bytes: &[u8]) {
+    set_buf_elems(map, bytes_to_elems(bytes));
+}
+
+/// Store raw bytes into a **live** instance, through its shared attribute cell.
+pub(crate) fn store_buf_bytes(attrs: &InstanceAttrs, bytes: &[u8]) {
+    store_buf_elems(attrs, bytes_to_elems(bytes));
+}
+
+/// A fresh `Buf`/`Blob`-shaped instance of `class_name` over raw bytes.
+pub(crate) fn make_buf_from_bytes(class_name: Symbol, bytes: &[u8]) -> Value {
+    make_buf(class_name, bytes_to_elems(bytes))
+}
+
+/// How many bytes one element of a `Buf`/`Blob`-shaped class occupies.
+///
+/// The width is **not in the data**: it lives only in the class name, which is
+/// why this is a string probe rather than a field read. `Buf`, `Blob`, `utf8`
+/// and the `uint8`/`int8` parameterisations are 1; `utf16` and anything naming
+/// 16/32/64 widen accordingly. Moving this into the node is P2's job — and the
+/// reason it is a single function now is so that P2 changes it here rather than
+/// in the four places that each had their own `contains` ladder.
+pub(crate) fn buf_elem_width(class_name: &str) -> usize {
+    if class_name.contains("64") {
+        8
+    } else if class_name.contains("32") {
+        4
+    } else if class_name.contains("16") {
+        2
+    } else {
+        1
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -202,6 +318,60 @@ mod tests {
         let alias = attrs_of(&b);
         with_buf_elems_mut(&attrs_of(&b), |items| items.push(Value::int(9)));
         assert_eq!(buf_elems(&alias), Some(vec![Value::int(1), Value::int(9)]));
+    }
+
+    #[test]
+    fn byte_view_matches_the_element_view() {
+        let b = buf_of(bytes_to_elems(&[0, 1, 254, 255]));
+        assert_eq!(buf_bytes(&attrs_of(&b)), Some(vec![0, 1, 254, 255]));
+        assert_eq!(buf_len(&attrs_of(&b)), Some(4));
+        assert_eq!(with_buf_bytes(&attrs_of(&b), <[u8]>::len), Some(4));
+
+        let bare = Value::make_instance(Symbol::intern("Buf"), AttrMap::new());
+        assert_eq!(buf_bytes(&attrs_of(&bare)), None);
+        assert_eq!(buf_bytes_or_empty(&attrs_of(&bare)), Vec::<u8>::new());
+        assert_eq!(buf_len_or_zero(&attrs_of(&bare)), 0);
+    }
+
+    /// The unified convention truncates rather than clamping — the same thing
+    /// Raku does on the way in, so `Buf.new(300)` is `0x2C` and not `0xFF`. It
+    /// only becomes observable for a wider buffer, whose elements legitimately
+    /// exceed a byte; there it is the element's low byte.
+    #[test]
+    fn bytes_truncate_rather_than_clamp() {
+        assert_eq!(elem_to_u8(&Value::int(300)), 0x2C);
+        assert_eq!(elem_to_u8(&Value::int(-1)), 0xFF);
+        assert_eq!(elem_to_u8(&Value::int(0x1170)), 0x70);
+        assert_eq!(elem_to_u8(&Value::num(300.9)), 0x2C);
+        assert_eq!(elem_to_u8(&Value::str("nope".to_string())), 0);
+
+        let wide = make_buf(Symbol::intern("Buf[uint16]"), vec![Value::int(0x1170)]);
+        assert_eq!(buf_bytes(&attrs_of(&wide)), Some(vec![0x70]));
+    }
+
+    #[test]
+    fn element_width_comes_from_the_class_name() {
+        for name in ["Buf", "Blob", "utf8", "Buf[uint8]", "Blob[int8]"] {
+            assert_eq!(buf_elem_width(name), 1, "{name}");
+        }
+        assert_eq!(buf_elem_width("utf16"), 2);
+        assert_eq!(buf_elem_width("Buf[uint16]"), 2);
+        assert_eq!(buf_elem_width("blob32"), 4);
+        assert_eq!(buf_elem_width("Buf[int64]"), 8);
+    }
+
+    #[test]
+    fn bytes_round_trip_through_the_write_side() {
+        let mut map = AttrMap::new();
+        set_buf_bytes(&mut map, &[1, 2, 3]);
+        let b = Value::make_instance(Symbol::intern("Buf"), map);
+        assert_eq!(buf_bytes(&attrs_of(&b)), Some(vec![1, 2, 3]));
+
+        store_buf_bytes(&attrs_of(&b), &[9]);
+        assert_eq!(buf_bytes(&attrs_of(&b)), Some(vec![9]));
+
+        let fresh = make_buf_from_bytes(Symbol::intern("Blob"), &[4, 5]);
+        assert_eq!(buf_bytes(&attrs_of(&fresh)), Some(vec![4, 5]));
     }
 
     #[test]

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -2628,21 +2628,7 @@ impl Interpreter {
         if cn == "Blob" || cn.starts_with("Blob[") || cn.starts_with("blob") {
             return None;
         }
-        // Extract the current bytes (same clamping the interpreter uses).
-        let mut bytes: Vec<u8> = Vec::new();
-        crate::value::value_buf::with_buf_elems(&attributes, |items| {
-            bytes.reserve(items.len());
-            for it in items.iter() {
-                bytes.push(match it.view() {
-                    ValueView::Int(i) => i.clamp(0, 255) as u8,
-                    ValueView::Num(f) => (f as i64).clamp(0, 255) as u8,
-                    ValueView::BigInt(bi) => num_traits::ToPrimitive::to_i64(bi.as_ref())
-                        .unwrap_or(0)
-                        .clamp(0, 255) as u8,
-                    _ => 0,
-                });
-            }
-        });
+        let mut bytes = crate::value::value_buf::buf_bytes_or_empty(&attributes);
         // Compute the new bytes via the shared pure transform.
         let new_bytes: Vec<u8> = if is_write_bits {
             if args.len() != 3 {
@@ -2691,10 +2677,7 @@ impl Interpreter {
         // (so aliases observing the same buf see the mutation), then refresh the
         // receiver binding to match the interpreter's `env.insert(target_var, ...)`.
         let mut updated_attrs = attributes.to_map();
-        crate::value::value_buf::set_buf_elems(
-            &mut updated_attrs,
-            crate::value::value_buf::bytes_to_elems(&new_bytes),
-        );
+        crate::value::value_buf::set_buf_bytes(&mut updated_attrs, &new_bytes);
         let updated = Value::write_back_sharing(&attributes, class_name, updated_attrs, id);
         self.env_mut()
             .insert(target_name.to_string(), updated.clone());

--- a/src/vm/vm_coerce_concat_ops.rs
+++ b/src/vm/vm_coerce_concat_ops.rs
@@ -318,10 +318,7 @@ impl Interpreter {
             };
             let mut bytes = Self::extract_buf_bytes(&left);
             bytes.extend(Self::extract_buf_bytes(&right));
-            return crate::value::value_buf::make_buf(
-                result_class,
-                crate::value::value_buf::bytes_to_elems(&bytes),
-            );
+            return crate::value::value_buf::make_buf_from_bytes(result_class, &bytes);
         }
         // Buf ~ non-Buf or non-Buf ~ Buf: decode the Buf and produce a Str
         if Self::is_buf_value(&left) || Self::is_buf_value(&right) {
@@ -374,18 +371,8 @@ impl Interpreter {
     }
 
     pub fn extract_buf_bytes(val: &Value) -> Vec<u8> {
-        if let ValueView::Instance { attributes, .. } = val.view()
-            && let Some(bytes) = crate::value::value_buf::with_buf_elems(&attributes, |items| {
-                items
-                    .iter()
-                    .map(|v| match v.view() {
-                        ValueView::Int(i) => i as u8,
-                        _ => 0,
-                    })
-                    .collect::<Vec<u8>>()
-            })
-        {
-            return bytes;
+        if let ValueView::Instance { attributes, .. } = val.view() {
+            return crate::value::value_buf::buf_bytes_or_empty(&attributes);
         }
         Vec::new()
     }

--- a/src/vm/vm_var_index_ops.rs
+++ b/src/vm/vm_var_index_ops.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::value::value_buf::{buf_elems, buf_elems_in, with_buf_elems};
+use crate::value::value_buf::{buf_elems, buf_elems_in, buf_len_or_zero};
 
 impl Interpreter {
     /// Wrap a value in item (scalar) context if it's a List/Array,
@@ -1751,7 +1751,7 @@ impl Interpreter {
                 // `list` of positional captures so `$/[*-1]` resolves `*-1` to
                 // the last capture (`m/ (\d) <?{ $/[*-1] < 5 }> /`).
                 let len = if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) {
-                    with_buf_elems(&attributes, <[Value]>::len).unwrap_or(0) as i64
+                    buf_len_or_zero(&attributes) as i64
                 } else if let Some(ValueView::Array(list, ..)) =
                     attributes.as_map().get("list").map(Value::view)
                 {

--- a/todo/deep/adr0015-p2-buf-storage-survey.md
+++ b/todo/deep/adr0015-p2-buf-storage-survey.md
@@ -27,7 +27,8 @@ because a contiguous `Vec<u8>` cannot be interpreted without it.
 `src/value/value_buf.rs` and all 104 touches route through it
 (see [`news/2026-07/buf-storage-accessor-chokepoint.md`](../../news/2026-07/buf-storage-accessor-chokepoint.md)).
 Sections 2 and 5 below are now historical: read them for *why* the campaign was
-needed, not as work still to do. Steps 2 and 3 are open.
+needed, not as work still to do. Step 2 (the byte view and the width probe) is
+done too; steps 3 and 4 are open.
 
 ## 2. The `"bytes"` campaign is 104 sites, not 91 (done — historical)
 
@@ -178,14 +179,26 @@ ADR §4 promises — does not exist yet and is part of P2.
    become a node share). `buf_elems` returns `Option` because "no storage at
    all" (a `Blob` type object) and "empty buffer" are distinguished at several
    call sites, `has_buf_elems` being the probe.
-2. **The node**, behind those accessors: contiguous `Vec<u8>` + element width,
-   with the encode/decode the accessors now hide. Note the three *different*
-   byte-decoding conventions the callers keep (truncating `as u8`,
-   `.clamp(0, 255) as u8`, `to_f64() as u8`) — they were deliberately not
-   unified in step 1, so step 2 must decide which one the native node's byte
-   view implements and migrate the others explicitly, as a behaviour change with
-   its own tests.
-3. **The body and the honest `.REPR`**, in one commit with the `MVMArrayB` test,
+2. **The byte view and the width probe.** **DONE** — see
+   [`news/2026-07/buf-byte-and-width-accessors.md`](../../news/2026-07/buf-byte-and-width-accessors.md).
+   `value_buf` now also answers in bytes (`buf_bytes`, `with_buf_bytes`,
+   `set_buf_bytes`, …) and in counts (`buf_len`), which is what the majority of
+   the element-accessor callers actually wanted; and `buf_elem_width` replaced
+   the four separate `cn.contains("16")` ladders, so the element width — the one
+   part of a `Buf`'s type that is not in its data at all — is derived in one
+   place ready to move into the node.
+
+   The three byte-decoding conventions are resolved to **truncation**: it is
+   what Raku itself stores by (`Buf.new(300)` is `0x2C`, `Buf.new(-1)` is
+   `0xFF`), every mutation path masks on the way in, and for a wider buffer
+   Rakudo agrees with neither convention anyway.
+
+3. **The node**, behind those accessors: contiguous `Vec<u8>` + element width,
+   with the encode/decode the accessors now hide. Signedness has to ride along
+   with the width — mutsu stores every element unsigned today, so
+   `Blob[int8].new(-1)[0]` answers `255` where raku answers `-1`, and the node
+   is where that stops being true.
+4. **The body and the honest `.REPR`**, in one commit with the `MVMArrayB` test,
    plus the deletion of `nativecall_pin.rs` and its three helpers.
 
-Steps 2 and 3 are where the judgment is.
+Steps 3 and 4 are where the judgment is.


### PR DESCRIPTION
[ADR-0015](docs/adr/0015-native-backed-container-storage-and-repr-bodies.md) P2
step 1 (#5521) made `src/value/value_buf.rs` the single place that knows how a
`Buf`/`Blob` stores its elements. It could only expose that storage the way the
current representation holds it: as `Vec<Value>`, one boxed `Int` per element.

Most callers do not want that. Of the 35 sites going through `with_buf_elems`,
**seven** wanted only `items.len()`, and **most of the rest** immediately mapped
every element to a `u8` and collected — paying a boxed intermediate to get at a
byte string.

## What this adds

A byte level next to the element level, so the chokepoint answers three
questions instead of one:

- `elem_to_u8`, `buf_bytes`, `buf_bytes_or_empty`, `buf_bytes_in`,
  `with_buf_bytes`, `set_buf_bytes`, `store_buf_bytes`, `make_buf_from_bytes`
- `buf_len` / `buf_len_or_zero` for the count-only callers
- `buf_elem_width` — the **element width is the one part of a `Buf`'s type that
  is not in its data at all**, only in its class name, and four separate
  `cn.contains("16")` ladders re-derived it (`.bytes`, `.raku`, `.gist`, the
  constructor's mask). Two of them tested the widths in a different order than
  the other two. Now there is one.

## The convention question the survey deferred

[The survey](todo/deep/adr0015-p2-buf-storage-survey.md) recorded three
byte-decoding conventions in the tree and deliberately left them alone in step 1,
because unifying them is a behaviour change: truncating `i as u8`,
`.clamp(0, 255) as u8`, and one going via `to_int`.

They collapse into **truncation**, which is what Raku itself stores by.
`Buf.new(300)` holds `0x2C` and `Buf.new(-1)` holds `0xFF` in both mutsu and
Rakudo, and every mutation path (`.new`, `[i] =`, `push`, `append`, `unshift`,
`splice`) was verified to mask on the way in — so the stored elements are always
already in range and the conventions could only disagree about a state that
cannot be constructed. The exception is a *wider* buffer, whose elements
legitimately exceed a byte: there truncation yields the element's low byte
(`buf16.new(0x1170)` -> `0x70`) and clamping yielded `0xFF`. Rakudo agrees with
neither (`read-ubits` on a non-`uint8` buffer is not a defined operation), so
nothing is lost by picking the coherent one.

## Verification

- 4 new unit tests in `value_buf` covering the byte view, the truncation
  boundary, the width probe and the write-side round trip.
- A 37-line smoke script comparing mutsu against `raku` across construction,
  gisting, `.raku`, encode/decode, `.bytes`, indexed assignment, `push`,
  `write-uint16`/`write-int32`/`write-num32`, `read-ubits`, `.Buf`/`.Blob`
  coercion, concatenation and `eqv` produces **byte-identical output** apart from
  the one already-recorded `write-ubits` masking gap
  (`todo/tickets/buf-numeric-bitneg-and-write-ubits-mask.md`), which this PR
  does not touch.

## Why it matters for P2 step 2

Under the native node a width-1 buffer — every `Buf`, `Blob` and `utf8` — *is*
its bytes, so `with_buf_bytes` hands its storage straight to the caller and
`buf_len` is a field read. The element accessors become the encode/decode
boundary and now have far fewer callers to serve, and `buf_elem_width` is the
one line that moves from reading a class name to reading the node.

Net: **-275 / +232** across 25 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)