### PR TITLE
perf(regex): detect a code block's writeback by binding identity, not Debug text

### DIFF
--- a/news/2026-07/regex-code-block-writeback-by-identity.md
+++ b/news/2026-07/regex-code-block-writeback-by-identity.md
@@ -1,0 +1,46 @@
+# A regex code block's writeback is detected by binding identity, not by Debug text
+
+Every regex `{ … }` block ran through `eval_regex_code_block_body`, which
+answered "which enclosing lexicals did this block write?" by **formatting the
+entire env with `{:?}` before and after the block and comparing the strings**.
+
+That made `core::fmt` the single largest cost of a grammar parse. A `perf`
+profile of `load-yaml` over a 16-line YAML mapping (the bundled `YAMLish`
+battery) attributed ~20% of the run to formatting machinery alone —
+`String::write_str` 10.2%, `Debug::fmt` 5.0%, plus `DebugStruct::field`,
+`DebugMap::entry`, `pad_integral` and `fmt::write` — before counting the
+`malloc`/`memmove` churn that feeds it. A YAML grammar runs a code block per
+line and per backtrack, and each run formatted a whole module's env twice.
+
+The comparison is now `Value::same_binding()` — an O(1) NaN-box word compare that
+already existed for exactly this purpose. The snapshot holds cloned `Value`s (an
+`Arc` bump), which also keeps the old allocation alive so a freed address cannot
+be recycled into a false "unchanged".
+
+Identity is also the *right* question. What has to be pushed back into the
+caller's local slot is a name that was **rebound**; a container mutated in place
+keeps its allocation, which the caller's local already shares, so it needs no
+writeback. And the old text comparison silently missed the opposite case — a
+rebinding to a different value whose `Debug` output happened to match (`my $x =
+'1'` then `$x = 1`) — which is now reported.
+
+## Effect
+
+Release build, `load-yaml` over a synthetic `k$_: v$_` block mapping:
+
+| lines | before | after | raku |
+| --- | --- | --- | --- |
+| 16 | 1127ms | **568ms** | 196ms |
+| 64 | 10065ms | **2147ms** | 442ms |
+
+4.7x faster at 64 lines, and the growth is now essentially linear (4x the input
+costs ~3.8x the time, where it used to cost 9x). Whole upstream YAMLish files:
+`roundtrip` 10.0s → 5.9s, `test-harness` 24.1s → 18.6s, `anchor-alias` 1.4s →
+0.6s, `p5-tests` 1.7s → 0.5s.
+
+`basic.rakutest` moved only 45.5s → 43.6s, so its documents are dominated by a
+different cost — the next lead, kept in `todo/tickets/yaml-parse-throughput.md`.
+
+Pin: `t/regex-code-block-writeback.t` (assignment, rebinding to a look-alike
+value, in-place container mutation, several blocks in one match) — green under
+`raku` too.

--- a/src/runtime/regex/regex_eval_repeat.rs
+++ b/src/runtime/regex/regex_eval_repeat.rs
@@ -331,21 +331,29 @@ impl Interpreter {
     /// update for the outer VM. Assumes the block's `$/`, `$<name>`, `$0…` etc.
     /// have already been installed in `self.env` by the caller.
     pub(in crate::runtime) fn eval_regex_code_block_body(&mut self, stmts: &[crate::ast::Stmt]) {
-        // Snapshot env keys and values before execution
-        let snapshot: HashMap<Symbol, String> = self
-            .env
-            .iter()
-            .map(|(k, v)| (*k, format!("{:?}", v)))
-            .collect();
+        // Snapshot the env by *binding identity* — the cloned `Value` is an Arc
+        // bump, and holding it also keeps the old allocation alive so a freed
+        // address cannot be recycled into a false "unchanged".
+        //
+        // This used to snapshot `format!("{:?}", v)` for every name and compare
+        // the strings, which made `Debug` formatting of the whole env the single
+        // largest cost of a grammar parse (~20% of a `load-yaml` profile — a YAML
+        // grammar runs a `{ … }` block per line, per backtrack). Identity is also
+        // the *right* question: what has to be written back to the caller's local
+        // is a name that was **rebound**. A container mutated in place keeps its
+        // allocation, which the caller's local already shares, so it needs no
+        // writeback — while a rebinding to an equal-looking value (which the
+        // string comparison missed) now is reported.
+        let snapshot: HashMap<Symbol, Value> =
+            self.env.iter().map(|(k, v)| (*k, v.clone())).collect();
         let saved_in_block = self.in_regex_code_block;
         self.in_regex_code_block = true;
         let _ = self.eval_block_value(stmts);
         self.in_regex_code_block = saved_in_block;
         // Record changed env variables as pending local updates for the outer VM
         for (k, v) in &self.env {
-            let old_repr = snapshot.get(k).map(|s| s.as_str()).unwrap_or("");
-            let new_repr = format!("{:?}", v);
-            if old_repr != new_repr {
+            let rebound = snapshot.get(k).is_none_or(|old| !old.same_binding(v));
+            if rebound {
                 let name = k.resolve();
                 // Slice C' (docs/vm-single-store.md, open-question #2): an
                 // embedded regex `{ ... }` / `:my`/`:let` block writes a caller

--- a/t/regex-code-block-writeback.t
+++ b/t/regex-code-block-writeback.t
@@ -1,0 +1,28 @@
+use Test;
+
+plan 7;
+
+# A regex `{ … }` block writes to the enclosing scope's lexicals, and those
+# writes must be visible after the match. mutsu detects them by comparing the
+# block's env before and after by *binding identity*, so each of these shapes has
+# to survive: a fresh value, a value that looks the same as the old one, and a
+# container mutated in place (which keeps its binding).
+
+my $n = 0;
+ok 'abc' ~~ / a { $n = 42 } bc /, 'a match whose code block assigns';
+is $n, 42, 'the assignment is visible afterwards';
+
+# Rebinding to a value that stringifies the same as the old one still counts.
+my $same = '1';
+ok 'abc' ~~ / a { $same = 1 } bc /, 'a match that rebinds to a look-alike value';
+is $same.WHAT.^name, 'Int', 'the new binding replaced the old one';
+
+# A container mutated in place keeps its binding, and the mutation is shared.
+my @acc;
+ok 'abc' ~~ / a { @acc.push('seen') } bc /, 'a match whose code block mutates an array';
+is-deeply @acc, ['seen'], 'the in-place mutation is visible afterwards';
+
+# Several blocks in one match all land.
+my @order;
+'abc' ~~ / a { @order.push(1) } b { @order.push(2) } c /;
+is-deeply @order, [1, 2], 'every block in the match ran and wrote back';

--- a/todo/tickets/yaml-parse-throughput.md
+++ b/todo/tickets/yaml-parse-throughput.md
@@ -1,72 +1,84 @@
-# Parsing YAML with the bundled `YAMLish` is ~20–40× slower than raku
+# Parsing YAML with the bundled `YAMLish` is still ~5-35x slower than raku
 
 The YAML battery is correct — all 5 upstream files (81/81 subtests) pass — but it
 is **slow**, and the cost is in *matching*, not module load. This is the
 match-time twin of `grammar-heavy-module-load-slower-than-raku.md`; that ticket
 measures `use`, this one measures the parse itself.
 
+**One round of this has already landed**
+(`news/2026-07/regex-code-block-writeback-by-identity.md`):
+`eval_regex_code_block_body` used to snapshot the whole env with
+`format!("{:?}", v)` before and after **every** regex `{ … }` block and compare
+the strings. `core::fmt` was ~20% of a `load-yaml` profile before that; comparing
+by `Value::same_binding()` instead made a block mapping **4.7x faster**. What is
+below is what remains *after* that fix.
+
 ## Measurement (2026-07-28, release build)
 
-Whole upstream files, `target/release/mutsu` vs `raku`, bundled library:
+Synthetic `k$_: v$_` block mapping under `load-yaml`:
 
-| File | raku | mutsu (release) | ratio |
+| lines | mutsu (before) | mutsu (now) | raku |
 | --- | --- | --- | --- |
-| `anchor-alias.rakutest` | — | 1.4s | |
-| `p5-tests.rakutest` | — | 1.7s | |
-| `roundtrip.rakutest` | 1.4s | 10.0s | ~7× |
-| `test-harness.rakutest` | 1.9s | 24.1s | ~13× |
-| `basic.rakutest` | 1.2s | 45.5s | **~40×** |
+| 16 | 1127ms | **568ms** | 196ms |
+| 64 | 10065ms | **2147ms** | 442ms |
 
-`basic.rakutest`'s documents are the largest, which is the shape of the problem:
-the cost grows faster than the input. A synthetic `k$_: v$_` block mapping under
-`load-yaml` (debug build, so read the *shape*, not the absolute numbers):
+The super-linearity is largely gone (4x the input is now ~3.8x the time), and the
+ratio to raku fell from 23x to ~5x.
 
-| lines | mutsu | raku |
-| --- | --- | --- |
-| 1 | 0.9s | 0.04s |
-| 2 | 1.0s | 0.07s |
-| 3 | 1.6s | 0.07s |
-| 4 | 3.2s | 0.05s |
-| 5 | 3.9s | 0.07s |
+Whole upstream test files, however, did **not** all move:
 
-raku is flat; mutsu is super-linear. A ~5-line mapping should not cost seconds.
+| File | before | now | raku |
+| --- | --- | --- | --- |
+| `anchor-alias.rakutest` | 1.4s | 0.6s | — |
+| `p5-tests.rakutest` | 1.7s | 0.5s | — |
+| `roundtrip.rakutest` | 10.0s | 5.9s | 1.4s |
+| `test-harness.rakutest` | 24.1s | 18.6s | 1.9s |
+| `basic.rakutest` | 45.5s | **43.6s** | 1.2s |
+
+`basic.rakutest` barely improved, so **its documents hit a different dominant
+cost** — that is the next thing to find. Its inputs are the largest and the most
+feature-dense (nested block sequences inside mappings, explicit `? key` /
+`: value` pairs, flow collections, folded scalars, `%TAG` directives).
 
 ## Reproduce
 
 ```sh
 cargo build --release
-cat > /tmp/y.raku <<'EOF'
+cat > tmp/y.raku <<'EOF'
 use YAMLish;
-my $n = (@*ARGS[0] // 5).Int;
+my $n = (@*ARGS[0] // 16).Int;
 my $text = "---\n" ~ (1..$n).map({ "k$_: v$_\n" }).join;
 my $t0 = now;
 load-yaml($text);
 say "n=$n elapsed=", ((now - $t0) * 1000).round, "ms";
 EOF
-for n in 1 2 4 8; do ./target/release/mutsu /tmp/y.raku $n; done
+for n in 16 64; do ./target/release/mutsu tmp/y.raku $n; done
+# and the file that did not improve (fetch the suite at the pinned commit first):
+time ./target/release/mutsu <yamlish-checkout>/t/basic.rakutest
 ```
 
-## Where to look
+Profile with a `--profile profiling` build (release + debuginfo) under `perf`.
+The `MUTSU_VM_STATS` counters are useless here: only ~25k opcodes run for a
+16-line document, so essentially all of the time is native regex-engine code.
 
-YAMLish's grammar is indentation-driven: `block`, `root-block`, `sequence` and
-`map` all take an `$indent` parameter and are re-resolved per call. Two suspects,
-both measurable before changing anything:
+## Where to look next
 
-1. **Per-call token instantiation.** `resolve_token_patterns_with_args_in_pkg`
-   builds a fresh scratch `Interpreter`, evaluates the token body, and then
-   re-runs the whole text-rewrite chain (`bake_bound_params_into_regex_code_blocks`
-   → `interpolate_bound_regex_scalars` → `instantiate_named_regex_arg_calls`) and
-   a full `parse_regex_uncached` — for **every** `<block($indent, 0)>` call at
-   every position. `REGEX_PARSE_CACHE` does not help: the pattern text differs
-   per `$indent`, and the parse is not the only cost.
-2. **Candidate enumeration.** The `_all_` atom enumerations return every end
+1. **Profile `basic.rakutest` specifically.** The synthetic benchmark is now
+   dominated by something other than what that file is dominated by, so measure
+   the file, not the micro-benchmark.
+2. **Per-call token instantiation.** `resolve_token_patterns_with_args_in_pkg`
+   builds a fresh scratch `Interpreter`, evaluates the token body, and re-runs the
+   whole text-rewrite chain (`bake_bound_params_into_regex_code_blocks` →
+   `interpolate_bound_regex_scalars` → `instantiate_named_regex_arg_calls`) plus a
+   full `parse_regex_uncached` — for **every** `<block($indent, 0)>` call at every
+   position. `REGEX_PARSE_CACHE` does not help: the text differs per `$indent`.
+   A memo keyed on `(rule, pkg, args)` would be sound only for a token whose body
+   names no free variable other than its parameters and its own `:my` lexicals —
+   that static condition is checkable, and YAMLish's indentation rules satisfy it.
+3. **Candidate enumeration.** The `_all_` atom enumerations return every end
    position; with a deeply nested indentation grammar the branching multiplies.
-   `MUTSU_VM_STATS` plus a `--profile profiling` build with `perf` will say which
-   of the two dominates.
 
 ## Why it matters
 
 A bundled battery is loaded and *used* on every run of a program that needs it.
-Reading a 100-line config file must not take seconds. The correctness work is
-done, so this is purely a throughput problem — and a good candidate for the first
-real profile of the grammar engine.
+Reading a 100-line config file must not take seconds.


### PR DESCRIPTION
Every regex `{ … }` block runs through `eval_regex_code_block_body`, which answered *"which enclosing lexicals did this block write?"* by **formatting the entire env with `{:?}` before and after the block and comparing the strings**.

That made `core::fmt` the single largest cost of a grammar parse. A `perf` profile of `load-yaml` over a 16-line YAML mapping (the bundled `YAMLish` battery) attributed **~20% of the run to formatting machinery alone**:

| % | symbol |
| --- | --- |
| 10.2% | `String as fmt::Write::write_str` |
| 5.0% | `core::fmt::Debug::fmt` |
| 1.5% / 1.5% / 1.3% / 0.9% | `write_char` / `DebugStruct::field` / `pad_integral` / `DebugMap::entry` |

…before counting the `malloc` / `memmove` churn feeding it (another ~18% across `_int_malloc`, `malloc`, `_int_free`, `memmove`). A YAML grammar runs a code block per line and per backtrack, and each run formatted a whole module's env **twice**.

## The fix

The comparison is now `Value::same_binding()` — the O(1) NaN-box word compare that already existed for exactly this purpose (its doc comment even says "usable on hot paths that only need to know whether a name was **rebound**"). The snapshot holds cloned `Value`s (an `Arc` bump), which also keeps the old allocation alive so a freed address cannot be recycled into a false "unchanged".

Identity is also the *right* question:

- **Rebinding** (`$x = 5`) changes the word → reported, as before.
- **In-place mutation** (`@a.push(1)`) keeps the allocation, which the caller's local already shares → no writeback needed.
- A **rebinding to a look-alike value** (`my $x = '1'` then `$x = 1`) has identical `Debug` output, so the old text comparison *missed* it. It is now reported.

## Effect

Release build, `load-yaml` over a synthetic `k$_: v$_` block mapping:

| lines | before | after | raku |
| --- | --- | --- | --- |
| 16 | 1127ms | **568ms** | 196ms |
| 64 | 10065ms | **2147ms** | 442ms |

**4.7× faster** at 64 lines, and growth is now essentially linear — 4× the input costs ~3.8× the time, where it used to cost 9×. The ratio to raku fell from 23× to ~5×.

Whole upstream YAMLish files: `roundtrip` 10.0s → 5.9s, `test-harness` 24.1s → 18.6s, `anchor-alias` 1.4s → 0.6s, `p5-tests` 1.7s → 0.5s.

`basic.rakutest` moved only 45.5s → 43.6s, so **its** documents are dominated by something else. That is the next lead, recorded in `todo/tickets/yaml-parse-throughput.md` along with the reproduction and the two remaining suspects.

## Verification

- Pin: `t/regex-code-block-writeback.t` — assignment, rebinding to a look-alike value, in-place container mutation, several blocks in one match. Green under `raku` too.
- Local `make test` **PASS** (2552 files, 24408 tests) and `make roast` **PASS** (1435 files, 218774 tests). This touches the writeback path of every regex code block, so both were run locally before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)