### PR TITLE
feat(buf): store Buf/Blob as native bytes instead of a boxed Int per element

### DIFF
--- a/news/2026-07/buf-native-byte-node.md
+++ b/news/2026-07/buf-native-byte-node.md
@@ -1,0 +1,84 @@
+# `Buf`/`Blob` stops being a boxed `Int` per byte
+
+A `Buf` was a `Value::Instance` whose one attribute held a `Value::Array` with
+**one boxed `Value::Int` per element**. A megabyte buffer therefore cost a
+million boxed `Value`s and a million GC edges to trace, the element type existed
+only as a substring of the class name, and there was no contiguous memory
+anywhere for a C function to be handed a pointer into.
+
+It is a [`BufData`] node now: contiguous little-endian bytes, plus the element
+width and signedness as data. This is
+[ADR-0015](../../docs/adr/0015-native-backed-container-storage-and-repr-bodies.md)
+P2's representation change — the step the survey called "where the judgment is".
+
+## What made it a contained change
+
+The two preceding slices. [Step 1](buf-storage-accessor-chokepoint.md) routed all
+~104 attribute touches through `src/value/value_buf.rs`; [step
+2](buf-byte-and-width-accessors.md) added the byte and count accessors most of
+those callers actually wanted, and collapsed four `cn.contains("16")` ladders
+into one width probe. With both in place, swapping the representation is a
+change to *that file* — the ~170 call sites across forty files are untouched.
+
+What did change shape is the write side: **reads need no class name, but
+construction does.** The node carries the element type, so every read — and
+`with_buf_elems_mut`, which re-encodes at whatever width the buffer already
+has — works from the node alone. The functions that *create* storage
+(`buf_attrs`, `set_buf_elems`, `set_buf_bytes`, `store_buf_*`) now take the
+class `Symbol`, because the name is where Raku keeps the element type and there
+is nowhere else to read it from. That is 20-odd call sites, every one of which
+had the class name in scope already.
+
+## Three parity gaps closed on the way
+
+None of these were the goal; all three are the same bug — the element type was
+not data — seen from different sides.
+
+| | raku | mutsu before | mutsu now |
+| --- | --- | --- | --- |
+| `Blob[int8].new(-1)[0]` | `-1` | `255` | `-1` |
+| `Blob[int8].new(200)[0]` | `-56` | `200` | `-56` |
+| `Buf[int16].new(-2)[0]` | `-2` | `65534` | `-2` |
+| `buf64.new(0xFFFF_FFFF_FFFF_FFFF)[0]` | `18446744073709551615` | `-1` | `18446744073709551615` |
+
+Signed elements are sign-extended from their own width on the way out; a
+`uint64` element above `i64::MAX` decodes to a `BigInt` rather than wrapping
+negative. Two display paths had to follow: `.gist` and `.raku` both matched
+`ValueView::Int` and fell back to zeros, so `buf64`'s largest value gisted as
+`0x<0000000000000000>` and `.raku`'d as `.new(0)`. The hex formatting — which
+was duplicated in two files — is now one `elem_hex` in `value_buf`, formatting
+from the element's unsigned bit pattern so a signed or oversized element prints
+the bytes it actually occupies.
+
+## Cost and shape
+
+`BufData` is a **payload-only** GC node: it holds no `Value`s, so `Trace` is an
+empty body, `drop_gc_edges` is a no-op, it can never take part in a cycle, and
+ADR-0001's container type filter keeps paying nothing for it beyond the refcount
+every `Gc` has. Both `Trace` methods are written out rather than defaulted, so
+adding a `Value` field later shows up as an obvious omission.
+
+Adding the variant turned out to reach exactly **six** exhaustive matches
+(`.^name`, `value_type_name`, `isa`, `truthy`, `to_string_value`, serde), plus
+`==` and `eqv`. It stays out of `Buf`'s Raku-visible surface entirely —
+`Buf.new(1,2).^attributes` is empty, so nothing at the language level ever names
+the storage attribute.
+
+## Verification
+
+The raku comparison script from step 2 — construction, gisting, `.raku`,
+encode/decode, `.bytes`, indexed assignment, `push`, the `write-*int` and
+`write-num` methods, `read-ubits`, `.Buf`/`.Blob` coercion, concatenation,
+`eqv` — is byte-identical to `raku` apart from the already-recorded `write-ubits`
+masking gap (`todo/tickets/buf-numeric-bitneg-and-write-ubits-mask.md`), which
+this change does not touch. Six new unit tests pin the node's byte layout, the
+signedness round trip, the `BigInt` decode, and that in-place mutation preserves
+the element width.
+
+## What is left of P2
+
+The body. `Buf.REPR` still answers `P6opaque`; making it answer `VMArray`
+requires the synthesised `MVMArrayB` block behind it in the same commit
+(ADR-0015 §2.1's ordering rule), and that is what `NativeHelpers::Blob`'s
+`BODY_OF` — and through it `DBIish`'s mysql driver — is waiting for. The node is
+the storage that block will point at.

--- a/src/builtins/buf_write_int.rs
+++ b/src/builtins/buf_write_int.rs
@@ -226,7 +226,7 @@ pub(crate) fn try_native_buf_write(
     match inst {
         Some(cell) => {
             let mut updated_map = cell.attributes.to_map();
-            set_buf_bytes(&mut updated_map, &bytes);
+            set_buf_bytes(&mut updated_map, cell.class_sym, &bytes);
             Some(Ok(Value::write_back_sharing(
                 &cell.attributes,
                 cell.class_sym,

--- a/src/builtins/methods_0arg/dispatch_core_repr.rs
+++ b/src/builtins/methods_0arg/dispatch_core_repr.rs
@@ -276,13 +276,10 @@ pub(super) fn dispatch(
         } if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) => {
             if let Some(bytes) = crate::value::value_buf::buf_elems(&attributes) {
                 if method == "raku" || method == "perl" {
-                    let elems: Vec<String> = bytes
-                        .iter()
-                        .map(|b| match b.view() {
-                            ValueView::Int(i) => i.to_string(),
-                            _ => "0".to_string(),
-                        })
-                        .collect();
+                    // `to_string_value`, not an `Int`-only match: a `uint64`
+                    // element above `i64::MAX` decodes to a `BigInt`, and the
+                    // old fallback printed it as `0`.
+                    let elems: Vec<String> = bytes.iter().map(Value::to_string_value).collect();
                     // Normalize short names to canonical forms for .raku
                     let cn = class_name.resolve();
                     let canonical = match cn.as_str() {
@@ -308,21 +305,12 @@ pub(super) fn dispatch(
                     if bytes.is_empty() {
                         Some(Ok(Value::str(format!("{}:0x<>", class_name))))
                     } else {
-                        let hex_width =
-                            2 * crate::value::value_buf::buf_elem_width(&class_name.resolve());
+                        let width = crate::value::value_buf::buf_elem_width(&class_name.resolve());
                         let truncated = bytes.len() > 100;
                         let display_bytes = if truncated { &bytes[..100] } else { &bytes[..] };
                         let mut hex: Vec<String> = display_bytes
                             .iter()
-                            .map(|b| match b.view() {
-                                ValueView::Int(i) => match hex_width {
-                                    16 => format!("{:016X}", i as u64),
-                                    8 => format!("{:08X}", i as u32),
-                                    4 => format!("{:04X}", i as u16),
-                                    _ => format!("{:02X}", i as u8),
-                                },
-                                _ => "0".repeat(hex_width),
-                            })
+                            .map(|b| crate::value::value_buf::elem_hex(b, width))
                             .collect();
                         if truncated {
                             hex.push("...".to_string());

--- a/src/precomp.rs
+++ b/src/precomp.rs
@@ -86,7 +86,9 @@ const CACHE_MAGIC: &[u8; 4] = b"MTS2";
 fn interpreter_version() -> String {
     // Bump CACHE_FORMAT_VERSION when Stmt/Expr/Value enum variants change,
     // or when `CacheMetadata` / `ParseEffects` gain or lose a field.
-    const CACHE_FORMAT_VERSION: u32 = 8;
+    // 9: `Value` gained `BufStorage` (ADR-0015 P2), which also shifted the
+    // serialized `SerValue` discriminants after `Array`.
+    const CACHE_FORMAT_VERSION: u32 = 9;
     let exe_stamp = std::env::current_exe()
         .and_then(fs::metadata)
         .and_then(|m| m.modified())

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -814,7 +814,7 @@ impl Interpreter {
                     let id = id_opt.unwrap();
                     let updated_cell = attrs_opt.unwrap();
                     let mut updated_map = updated_cell.to_map();
-                    set_buf_bytes(&mut updated_map, &bytes);
+                    set_buf_bytes(&mut updated_map, class_sym, &bytes);
                     return Ok(Value::write_back_sharing(
                         &updated_cell,
                         class_sym,
@@ -899,7 +899,7 @@ impl Interpreter {
                     let id = id_opt.unwrap();
                     let updated_cell = attrs_opt.unwrap();
                     let mut updated_map = updated_cell.to_map();
-                    set_buf_bytes(&mut updated_map, &bytes);
+                    set_buf_bytes(&mut updated_map, class_sym, &bytes);
                     return Ok(Value::write_back_sharing(
                         &updated_cell,
                         class_sym,

--- a/src/runtime/methods_introspect.rs
+++ b/src/runtime/methods_introspect.rs
@@ -46,6 +46,10 @@ impl Interpreter {
         }
         let type_name: &str = match target.view() {
             ValueView::VarRef { .. } => unreachable!("unwrapped above"),
+            // `Buf`/`Blob` element storage never surfaces as a Raku-level value:
+            // it lives in the buffer instance's attribute cell and only
+            // `value::value_buf` reads it. Answer as the buffer it backs.
+            ValueView::BufStorage(_) => "Buf",
             ValueView::RakuAst(node) => node.class.printed_name(),
             ValueView::Int(_) => "Int",
             ValueView::BigInt(_) => "Int",

--- a/src/runtime/methods_io_dispatch.rs
+++ b/src/runtime/methods_io_dispatch.rs
@@ -144,30 +144,35 @@ impl Interpreter {
             None => raw_input,
         };
         let translated = self.translate_newlines_for_encode(&input);
-        let mut attrs = crate::value::AttrMap::new();
-        let type_name = match normalized_encoding.as_str() {
-            "utf-16" | "utf16" => {
-                let units: Vec<Value> = translated
-                    .encode_utf16()
-                    .map(|u| Value::int(u as i64))
-                    .collect();
-                set_buf_elems(&mut attrs, units);
-                "utf16"
-            }
-            _ => {
-                let bytes = self.encode_with_encoding_and_replacement(
-                    &translated,
-                    &encoding,
-                    replacement.as_deref(),
-                )?;
-                set_buf_bytes(&mut attrs, &bytes);
-                match normalized_encoding.as_str() {
-                    "utf-8" | "utf8" => "utf8",
-                    _ => "Blob[uint8]",
-                }
-            }
+        // The class has to be settled before the storage is: it is what says
+        // how wide an element is (`utf16` holds 16-bit code units, the rest
+        // bytes), and the storage now carries that width rather than
+        // re-deriving it from the name on every read.
+        let is_utf16 = matches!(normalized_encoding.as_str(), "utf-16" | "utf16");
+        let type_name = if is_utf16 {
+            "utf16"
+        } else if matches!(normalized_encoding.as_str(), "utf-8" | "utf8") {
+            "utf8"
+        } else {
+            "Blob[uint8]"
         };
-        Ok(Value::make_instance(Symbol::intern(type_name), attrs))
+        let class_sym = Symbol::intern(type_name);
+        let mut attrs = crate::value::AttrMap::new();
+        if is_utf16 {
+            let units: Vec<Value> = translated
+                .encode_utf16()
+                .map(|u| Value::int(u as i64))
+                .collect();
+            set_buf_elems(&mut attrs, class_sym, units);
+        } else {
+            let bytes = self.encode_with_encoding_and_replacement(
+                &translated,
+                &encoding,
+                replacement.as_deref(),
+            )?;
+            set_buf_bytes(&mut attrs, class_sym, &bytes);
+        }
+        Ok(Value::make_instance(class_sym, attrs))
     }
 
     pub(super) fn dispatch_decode(

--- a/src/runtime/methods_mut_dispatch.rs
+++ b/src/runtime/methods_mut_dispatch.rs
@@ -377,7 +377,7 @@ impl Interpreter {
                 };
                 let written = crate::builtins::buf_bits::write_bits(&bytes, from, bits, &args[2])?;
                 let mut updated_attrs = attributes.to_map();
-                set_buf_bytes(&mut updated_attrs, &written);
+                set_buf_bytes(&mut updated_attrs, class_name, &written);
                 return Ok(Value::write_back_sharing(
                     &attributes,
                     class_name,
@@ -427,7 +427,7 @@ impl Interpreter {
                 &mut bytes, method, offset_i64, value_val, endian_val,
             )?;
             let mut updated_attrs = attributes.to_map();
-            set_buf_bytes(&mut updated_attrs, &bytes);
+            set_buf_bytes(&mut updated_attrs, class_name, &bytes);
             let updated = Value::write_back_sharing(&attributes, class_name, updated_attrs, id);
             self.env.insert(target_var.to_string(), updated.clone());
             return Ok(updated);
@@ -508,7 +508,7 @@ impl Interpreter {
                 &mut bytes, method, offset_i64, value_val, endian_val,
             )?;
             let mut updated_attrs = attributes.to_map();
-            set_buf_bytes(&mut updated_attrs, &bytes);
+            set_buf_bytes(&mut updated_attrs, class_name, &bytes);
             let updated = Value::write_back_sharing(&attributes, class_name, updated_attrs, id);
             self.env.insert(target_var.to_string(), updated.clone());
             return Ok(updated);
@@ -2024,7 +2024,7 @@ impl Interpreter {
                 if bits > 0 {
                     write_bits_into_bytes(&mut bytes, from, bits, &value);
                 }
-                set_buf_bytes(&mut updated, &bytes);
+                set_buf_bytes(&mut updated, class_name, &bytes);
                 let updated_instance =
                     Value::write_back_sharing(&attributes, class_name, updated, target_id);
                 self.env

--- a/src/runtime/methods_mut_substr_buf.rs
+++ b/src/runtime/methods_mut_substr_buf.rs
@@ -189,8 +189,12 @@ impl Interpreter {
         // uncatchable abort; `truncate` then handles the shrink case.
         Self::autoviv_resize(&mut bytes, new_size, Value::int(0))?;
         bytes.truncate(new_size);
-        let updated =
-            Value::write_back_sharing(&attrs_cell, class_name_sym, buf_attrs(bytes), orig_id);
+        let updated = Value::write_back_sharing(
+            &attrs_cell,
+            class_name_sym,
+            buf_attrs(class_name_sym, bytes),
+            orig_id,
+        );
         self.env.insert(target_var.to_string(), updated.clone());
         Ok(updated)
     }
@@ -299,8 +303,12 @@ impl Interpreter {
             _ => unreachable!(),
         }
 
-        let updated =
-            Value::write_back_sharing(&attrs_cell, class_name_sym, buf_attrs(bytes), orig_id);
+        let updated = Value::write_back_sharing(
+            &attrs_cell,
+            class_name_sym,
+            buf_attrs(class_name_sym, bytes),
+            orig_id,
+        );
         self.env.insert(target_var.to_string(), updated.clone());
         Ok(updated)
     }
@@ -359,7 +367,7 @@ impl Interpreter {
                 let updated = Value::write_back_sharing(
                     &attrs_cell,
                     class_name_sym,
-                    buf_attrs(bytes),
+                    buf_attrs(class_name_sym, bytes),
                     orig_id,
                 );
                 self.env.insert(target_var.to_string(), updated);
@@ -386,7 +394,7 @@ impl Interpreter {
                 let updated = Value::write_back_sharing(
                     &attrs_cell,
                     class_name_sym,
-                    buf_attrs(bytes),
+                    buf_attrs(class_name_sym, bytes),
                     orig_id,
                 );
                 self.env.insert(target_var.to_string(), updated);
@@ -451,7 +459,7 @@ impl Interpreter {
                 let updated = Value::write_back_sharing(
                     &attrs_cell,
                     class_name_sym,
-                    buf_attrs(bytes),
+                    buf_attrs(class_name_sym, bytes),
                     orig_id,
                 );
                 self.env.insert(target_var.to_string(), updated);

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -837,8 +837,12 @@ fn buf_instance_pin_key(v: &Value) -> Option<usize> {
 #[cfg(feature = "libffi")]
 fn write_buf_instance_bytes(v: &Value, bytes: &[u8]) {
     match v.view() {
-        ValueView::Instance { attributes, .. } => {
-            crate::value::value_buf::store_buf_bytes(&attributes, bytes);
+        ValueView::Instance {
+            class_name,
+            attributes,
+            ..
+        } => {
+            crate::value::value_buf::store_buf_bytes(&attributes, class_name, bytes);
         }
         ValueView::Scalar(inner) => write_buf_instance_bytes(inner, bytes),
         ValueView::ContainerRef(cell) => {

--- a/src/runtime/utils/type_misc.rs
+++ b/src/runtime/utils/type_misc.rs
@@ -5,6 +5,10 @@ pub(crate) fn value_type_name(value: &Value) -> &'static str {
         // A `VarRef` is a transient binder wrapper, not a type: report the type
         // of the variable's value.
         ValueView::VarRef { value, .. } => value_type_name(value),
+        // `Buf`/`Blob` element storage never surfaces as a Raku-level value:
+        // it lives in the buffer instance's attribute cell and only
+        // `value::value_buf` reads it. Answer as the buffer it backs.
+        ValueView::BufStorage(_) => "Buf",
         ValueView::RakuAst(node) => node.class.printed_name(),
         ValueView::Int(_) => "Int",
         ValueView::BigInt(_) => "Int",

--- a/src/value/display.rs
+++ b/src/value/display.rs
@@ -302,6 +302,11 @@ impl Value {
             // A `VarRef` is a transient binder wrapper: it stringifies as the
             // variable's value.
             ValueView::VarRef { value, .. } => value.to_string_value(),
+            // `Buf`/`Blob` element storage never surfaces as a Raku-level
+            // value; a buffer stringifies through the `X::Buf::AsStr` path on
+            // the instance holding this. Latin-1 keeps the bytes recoverable
+            // if one ever leaks into a diagnostic.
+            ValueView::BufStorage(b) => b.bytes.iter().map(|&c| c as char).collect(),
             ValueView::RakuAst(node) => crate::rakuast::node_gist(node),
             ValueView::Int(i) => i.to_string(),
             ValueView::BigInt(n) => n.to_string(),
@@ -726,25 +731,10 @@ impl Value {
                         // `(Blob)` via a separate path.
                         format!("{}:0x<>", class_name)
                     } else {
-                        // Two hex digits per byte of one element.
-                        let hex_width =
-                            2 * crate::value::value_buf::buf_elem_width(&class_name.resolve());
+                        let width = crate::value::value_buf::buf_elem_width(&class_name.resolve());
                         let hex: Vec<String> = bytes
                             .iter()
-                            .map(|b| match b.view() {
-                                ValueView::Int(i) => {
-                                    if hex_width == 16 {
-                                        format!("{:016X}", i as u64)
-                                    } else if hex_width == 8 {
-                                        format!("{:08X}", i as u32)
-                                    } else if hex_width == 4 {
-                                        format!("{:04X}", i as u16)
-                                    } else {
-                                        format!("{:02X}", i as u8)
-                                    }
-                                }
-                                _ => "0".repeat(hex_width),
-                            })
+                            .map(|b| crate::value::value_buf::elem_hex(b, width))
                             .collect();
                         format!("{}:0x<{}>", class_name, hex.join(" "))
                     }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -292,6 +292,35 @@ pub(crate) fn seq_sink(arc_ptr: &Arc<Vec<Value>>) {
 /// Shared mutable attribute storage for Proxy subclasses.
 pub(crate) type ProxySubclassAttrs = Arc<Mutex<HashMap<String, Value>>>;
 
+/// The element storage of a `Buf`/`Blob`, as contiguous native bytes
+/// (ADR-0015 P2).
+///
+/// This is a **payload-only** GC node: it holds no `Value`s, so it cannot take
+/// part in a cycle, `Trace` is an empty body, and ADR-0001's container type
+/// filter keeps paying nothing for it. It replaces the `Array` of one boxed
+/// `Value::Int` per element that a `Buf` used to carry — a megabyte buffer cost
+/// a million boxed `Value`s and a million GC edges to trace; it now costs a
+/// megabyte and no edges.
+///
+/// The element **type** used to live only in the class-name string
+/// (`Buf[uint16]`), which is why mutsu could not tell `Blob[int8]` from
+/// `Blob[uint8]` on the way back out. It is data now: `width` bytes per
+/// element, `signed` deciding how those bytes read back.
+///
+/// Bytes are stored little-endian, matching every `.read-*`/`.write-*` default
+/// and what `.decode` on a `buf16` already produced.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct BufData {
+    /// `elems * width` bytes. The buffer C is handed a pointer into under P2's
+    /// remaining phase, hence contiguous and never a `Vec<Value>` again.
+    pub bytes: Vec<u8>,
+    /// Bytes per element: 1, 2, 4 or 8.
+    pub width: u8,
+    /// Whether an element reads back as signed (`Blob[int8]`) or unsigned
+    /// (`Blob[uint8]`, and every plain `Buf`/`Blob`/`utf8`/`utf16`).
+    pub signed: bool,
+}
+
 /// Bag data: wraps HashMap<String, NumBigInt> with optional original-typed keys.
 /// Implements Deref to HashMap<String, NumBigInt> so existing code works unchanged.
 /// Weights are arbitrary-precision so a BagHash weight can exceed i64::MAX.
@@ -1160,6 +1189,10 @@ pub(in crate::value) enum ValueRepr {
     /// GC-migrated (§11 step 5c first wave): backed by a cycle-collectable
     /// `Gc<ArrayData>` rather than a plain `crate::gc::Gc<ArrayData>`.
     Array(crate::gc::Gc<ArrayData>, ArrayKind),
+    /// The element storage of a `Buf`/`Blob` (ADR-0015 P2). Never a Raku-level
+    /// value on its own: it lives in the buffer instance's attribute cell and
+    /// only [`crate::value::value_buf`] constructs or reads it.
+    BufStorage(crate::gc::Gc<BufData>),
     /// The `bool` is the per-holder itemization flag (`true` when this hash sits
     /// in a `$` scalar container: `$(%h)` / `.item` / `my $h = %x`). It mirrors
     /// `ArrayKind::ItemArray` for arrays — a Value-level marker that shares the

--- a/src/value/nanbox/decode.rs
+++ b/src/value/nanbox/decode.rs
@@ -224,6 +224,7 @@ unsafe fn decode_kind(kind: Kind, bits: u64) -> ValueRepr {
                 _ => ArrayKind::Lazy,
             },
         ),
+        Kind::BufStorage => ValueRepr::BufStorage(unsafe { take_gc::<BufData>(bits) }),
         Kind::HashPlain => ValueRepr::Hash(unsafe { take_gc::<HashData>(bits) }, false),
         Kind::HashItemized => ValueRepr::Hash(unsafe { take_gc::<HashData>(bits) }, true),
         Kind::SetImm => ValueRepr::Set(unsafe { take_gc::<SetData>(bits) }, false),

--- a/src/value/nanbox/encode.rs
+++ b/src/value/nanbox/encode.rs
@@ -66,6 +66,7 @@ impl NanBox {
                 },
                 data,
             ),
+            ValueRepr::BufStorage(data) => pack_gc(Kind::BufStorage, data),
             ValueRepr::Hash(data, itemized) => pack_gc(
                 if itemized {
                     Kind::HashItemized

--- a/src/value/nanbox/mod.rs
+++ b/src/value/nanbox/mod.rs
@@ -158,6 +158,8 @@ pub(in crate::value) enum Kind {
     ArrayItemArray,
     ArrayShaped,
     ArrayLazy,
+    /// `Buf`/`Blob` element storage (ADR-0015 P2) — a payload-only node.
+    BufStorage,
     HashPlain,
     HashItemized,
     SetImm,
@@ -443,6 +445,7 @@ unsafe fn payload_op(kind: Kind, bits: u64, op: PayloadOp) {
             | Kind::ArrayItemArray
             | Kind::ArrayShaped
             | Kind::ArrayLazy => gc_op::<ArrayData>(bits, op),
+            Kind::BufStorage => gc_op::<BufData>(bits, op),
             Kind::HashPlain | Kind::HashItemized => gc_op::<HashData>(bits, op),
             Kind::SetImm | Kind::SetMut => gc_op::<SetData>(bits, op),
             Kind::BagImm | Kind::BagMut => gc_op::<BagData>(bits, op),

--- a/src/value/nanbox/peek.rs
+++ b/src/value/nanbox/peek.rs
@@ -461,6 +461,7 @@ unsafe fn view_kind<'a>(kind: Kind, bits: u64) -> ValueView<'a> {
             Kind::ArrayItemArray => ValueView::Array(gc_guard(bits), ArrayKind::ItemArray),
             Kind::ArrayShaped => ValueView::Array(gc_guard(bits), ArrayKind::Shaped),
             Kind::ArrayLazy => ValueView::Array(gc_guard(bits), ArrayKind::Lazy),
+            Kind::BufStorage => ValueView::BufStorage(gc_guard(bits)),
             Kind::HashPlain | Kind::HashItemized => ValueView::Hash(gc_guard(bits)),
             Kind::SetImm => ValueView::Set(gc_guard(bits), false),
             Kind::SetMut => ValueView::Set(gc_guard(bits), true),

--- a/src/value/serde_support.rs
+++ b/src/value/serde_support.rs
@@ -31,6 +31,9 @@ enum SerValue {
         excl_end: bool,
     },
     Array(Vec<SerValue>, ArrayKind),
+    /// `Buf`/`Blob` element storage: the bytes plus the element type, so a
+    /// precompiled `constant $CRLF = Buf.new(13, 10)` round-trips.
+    BufStorage(Vec<u8>, u8, bool),
     Hash(HashMap<String, SerValue>),
     Rat(i64, i64),
     FatRat(i64, i64),
@@ -147,6 +150,7 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
         // does, serialize the variable's value.
         ValueView::VarRef { value, .. } => value_to_ser(value),
         ValueView::RakuAst(_) => Err("cannot serialize a RakuAST node".to_string()),
+        ValueView::BufStorage(b) => Ok(SerValue::BufStorage(b.bytes.clone(), b.width, b.signed)),
         ValueView::Int(n) => Ok(SerValue::Int(n)),
         ValueView::BigInt(n) => Ok(SerValue::BigInt((**n).clone())),
         ValueView::Num(n) => Ok(SerValue::Num(n)),
@@ -348,6 +352,13 @@ fn value_to_ser(v: &Value) -> Result<SerValue, String> {
 fn ser_to_value(sv: SerValue) -> Value {
     match sv {
         SerValue::Int(n) => Value::Int(n),
+        SerValue::BufStorage(bytes, width, signed) => Value::from_repr(ValueRepr::BufStorage(
+            crate::gc::Gc::new(crate::value::BufData {
+                bytes,
+                width,
+                signed,
+            }),
+        )),
         SerValue::BigInt(n) => Value::BigInt(Arc::new(n)),
         SerValue::Num(n) => Value::Num(n),
         SerValue::Str(s) => Value::Str(Arc::new(s)),

--- a/src/value/types_eqv.rs
+++ b/src/value/types_eqv.rs
@@ -55,6 +55,8 @@ impl Value {
                     && a.len() == b.len()
                     && a.iter().zip(b.iter()).all(|(x, y)| x.eqv(y))
             }
+            // Buffer storage: bytes and element type, same rule as `==`.
+            (ValueView::BufStorage(a), ValueView::BufStorage(b)) => *a == *b,
             // Hashes: recursively use eqv for values
             (ValueView::Hash(a), ValueView::Hash(b)) => {
                 a.len() == b.len() && a.iter().all(|(k, v)| b.get(k).is_some_and(|bv| v.eqv(bv)))

--- a/src/value/types_isa.rs
+++ b/src/value/types_isa.rs
@@ -17,6 +17,10 @@ impl Value {
         }
         let my_type = match self.view() {
             ValueView::VarRef { .. } => unreachable!("unwrapped above"),
+            // `Buf`/`Blob` element storage never surfaces as a Raku-level value:
+            // it lives in the buffer instance's attribute cell and only
+            // `value::value_buf` reads it. Answer as the buffer it backs.
+            ValueView::BufStorage(_) => "Buf",
             ValueView::RakuAst(node) => node.class.printed_name(),
             ValueView::Int(_) | ValueView::BigInt(_) => "Int",
             ValueView::Num(_) => "Num",

--- a/src/value/types_truthy.rs
+++ b/src/value/types_truthy.rs
@@ -39,6 +39,10 @@ impl Value {
             // A `VarRef` is a transient binder wrapper: it is as true as the
             // variable's value.
             ValueView::VarRef { value, .. } => value.truthy(),
+            // A buffer is true when it has elements — the same rule the
+            // instance-level `Buf` arm applies, so a stray storage value
+            // cannot answer differently from the buffer holding it.
+            ValueView::BufStorage(b) => !b.bytes.is_empty(),
             ValueView::RakuAst(_) => true,
             ValueView::Bool(b) => b,
             ValueView::Int(i) => i != 0,

--- a/src/value/value_buf.rs
+++ b/src/value/value_buf.rs
@@ -80,14 +80,24 @@ fn elem_type(class_name: &str) -> (u8, bool) {
 fn elem_to_u64(v: &Value) -> u64 {
     match v.view() {
         ValueView::Int(i) => i as u64,
-        ValueView::Num(f) => f as i64 as u64,
+        // `to_int` saturates a `BigInt` at `i64::MAX`, which would turn a
+        // legitimate `uint64` element into `0x7FFF_FFFF_FFFF_FFFF`; take the
+        // full-range conversion here and let it fall through only for a value
+        // that does not fit either way.
         ValueView::BigInt(n) => {
             use num_traits::ToPrimitive;
             n.as_ref()
                 .to_u64()
                 .unwrap_or_else(|| n.as_ref().to_i64().unwrap_or(0) as u64)
         }
-        _ => 0,
+        // Everything else goes through the general numeric coercion: elements
+        // do not always arrive as bare `Int`s. `Blob.allocate(10, <1 2 3>)` and
+        // `$buf.append(array[int].new: <7 1 3>)` hand over `IntStr` allomorphs,
+        // and a `:=`-bound element arrives as a `ContainerRef`. The boxed
+        // representation stored those as-is and converted lazily on read, so
+        // encoding at write time has to do the same conversion or they silently
+        // become zeros (`roast/S32-container/buf.t` 3/14/16).
+        _ => crate::runtime::to_int(v) as u64,
     }
 }
 
@@ -547,6 +557,15 @@ mod tests {
         let elems = buf_elems(&attrs_of(&b)).expect("elems");
         assert_eq!(elems[0].to_string_value(), "18446744073709551615");
         assert_eq!(elem_hex(&elems[0], 8), "FFFFFFFFFFFFFFFF");
+    }
+
+    /// Elements do not always arrive as bare `Int`s — `Blob.allocate(10, <1 2 3>)`
+    /// hands over `IntStr` allomorphs. The boxed representation stored them
+    /// as-is and converted on read; encoding at write time has to convert too.
+    #[test]
+    fn non_int_elements_are_coerced_not_zeroed() {
+        let b = buf_of(vec![Value::str("7".to_string()), Value::num(13.9)]);
+        assert_eq!(buf_bytes(&attrs_of(&b)), Some(vec![7, 13]));
     }
 
     #[test]

--- a/src/value/value_buf.rs
+++ b/src/value/value_buf.rs
@@ -1,49 +1,148 @@
-//! `Buf`/`Blob` element storage — the single accessor layer (ADR-0015 P2 step 1).
+//! `Buf`/`Blob` element storage — the single accessor layer (ADR-0015 P2).
 //!
-//! A `Buf`/`Blob` has no dedicated `Value` variant. It is a plain
-//! `Value::Instance` whose one attribute holds a `Value::Array` with **one boxed
-//! `Value::Int` per element**. Until now every one of the ~104 places that
-//! touched that storage spelled the attribute name itself and open-coded the
-//! `ValueView::Array` match, so the representation could not be changed without
-//! editing forty files.
+//! A `Buf`/`Blob` is a plain `Value::Instance` whose one attribute holds its
+//! elements. That storage used to be a `Value::Array` with **one boxed
+//! `Value::Int` per element**: a megabyte buffer cost a million boxed `Value`s
+//! and a million GC edges, the element width was recoverable only by matching on
+//! the class-name string, and there was no contiguous memory to hand a C
+//! function a pointer into.
 //!
-//! This module is that chokepoint. The attribute name is private to it, and
-//! every read, write, probe and construction goes through one of the functions
-//! below. Nothing here changes behaviour — it is a pure refactor whose point is
-//! to make [ADR-0015](../../docs/adr/0015-native-backed-container-storage-and-repr-bodies.md)
-//! P2 step 2 (a contiguous native-backed node with an element width, so
-//! `Buf.REPR` can honestly answer `VMArray` and NativeCall can hand C a real
-//! `MVMArrayB` body) a change to *this file* rather than to its callers.
+//! It is now a [`BufData`] node — contiguous little-endian bytes plus the
+//! element type. That node is payload-only (it holds no `Value`s), so it can
+//! never form a cycle and ADR-0001's container type filter pays nothing for it.
+//!
+//! This module is the chokepoint that made the swap possible and is what keeps
+//! it contained: the attribute name is private to it, and every read, write,
+//! probe and construction goes through one of the functions below, so the ~170
+//! call sites across forty files did not have to know the representation
+//! changed. What remains of
+//! [ADR-0015](../../docs/adr/0015-native-backed-container-storage-and-repr-bodies.md)
+//! P2 — the synthesised `MVMArrayB` body and an honest `Buf.REPR` of `VMArray`,
+//! which is what `NativeHelpers::Blob`'s `BODY_OF` needs — builds on this node.
 //!
 //! Three levels are offered deliberately:
 //!
-//! - the **element** functions ([`buf_elems`], [`set_buf_elems`], …) decode to
-//!   and from `Vec<Value>`; under P2 they become the encode/decode boundary;
+//! - the **element** functions ([`buf_elems`], [`set_buf_elems`], …) are the
+//!   encode/decode boundary: they hand out and take back `Vec<Value>`;
 //! - the **byte** functions ([`buf_bytes`], [`with_buf_bytes`], [`buf_len`], …)
-//!   speak the representation P2 will actually store, so a caller that only
-//!   wants bytes or a count never round-trips through boxed `Value`s;
+//!   speak what the node stores, so a caller that only wants bytes or a count
+//!   never round-trips through boxed `Value`s;
 //! - the **storage** functions ([`buf_storage`], [`set_buf_storage`]) move the
-//!   container across without decoding it, for the coercions that only re-tag a
-//!   buffer (`.Buf`, `.Blob`); under P2 they become a node share.
+//!   node across without decoding it, for the coercions that only re-tag a
+//!   buffer (`.Buf`, `.Blob`).
 //!
-//! [`buf_elem_width`] is the fourth thing P2 needs and the one that is *not*
-//! stored in the data at all today: the element width lives only in the class
-//! name (`Buf[uint16]`), and four separate places used to re-derive it with
-//! their own `cn.contains("16")` ladder. It is derived here now, so P2 has one
-//! place to move it from the name into the node.
+//! **Reads need no class name; construction does.** The node carries the
+//! element type, so everything that reads a buffer — including
+//! [`with_buf_elems_mut`], which re-encodes at the width the buffer already
+//! has — works from the node alone. Only the functions that *create* storage
+//! take a `class_name`, because the name is where Raku keeps the element type
+//! (`Blob[int8]`) and there is nowhere else to read it from.
 //!
 //! [`is_buf_or_blob_class`](crate::runtime::utils::is_buf_or_blob_class) stays
 //! the companion class-name filter: this module answers "what is in there", not
 //! "is this a Buf".
 
-use super::{AttrMap, InstanceAttrs, Value, ValueView};
+use super::{AttrMap, BufData, InstanceAttrs, Value, ValueRepr, ValueView};
+use crate::gc::Gc;
 use crate::symbol::Symbol;
 
-/// The attribute a `Buf`/`Blob`-shaped instance keeps its elements under.
+/// The attribute a `Buf`/`Blob`-shaped instance keeps its storage under.
 ///
-/// Private on purpose: it is the thing P2 deletes. If you find yourself wanting
-/// it outside this module, the accessor you need is missing — add it here.
+/// Private on purpose. If you find yourself wanting it outside this module, the
+/// accessor you need is missing — add it here.
 const ELEMS_ATTR: &str = "bytes";
+
+// ---------------------------------------------------------------------------
+// The node, and the encode/decode across it.
+// ---------------------------------------------------------------------------
+
+/// The element type of a `Buf`/`Blob`-shaped class: bytes per element, and
+/// whether an element reads back signed.
+///
+/// Recovered from the class name, which is where Raku puts it (`Blob[int8]`).
+/// This is the *only* place that reading stops — from here on the type travels
+/// in the node, which is what lets `Blob[int8].new(-1)[0]` answer `-1`.
+fn elem_type(class_name: &str) -> (u8, bool) {
+    // `uint` contains `int`, so the unsigned test has to come first.
+    let signed = !class_name.contains("uint") && class_name.contains("int");
+    (buf_elem_width(class_name) as u8, signed)
+}
+
+/// One element as the unsigned integer its bytes spell.
+///
+/// **Truncating**, which is the convention Raku itself stores by: `Buf.new(300)`
+/// holds `0x2C` and `Buf.new(-1)` holds `0xFF` in both mutsu and Rakudo, and
+/// every mutation path (`.new`, `[i] =`, `push`, `append`, `unshift`, `splice`)
+/// masks on the way in. Three different conventions used to be spelled out at
+/// the call sites — this one, a `.clamp(0, 255)` one, and one going via
+/// `to_int` — and they could only disagree about a buffer whose elements exceed
+/// its width, which the masking makes unreachable.
+fn elem_to_u64(v: &Value) -> u64 {
+    match v.view() {
+        ValueView::Int(i) => i as u64,
+        ValueView::Num(f) => f as i64 as u64,
+        ValueView::BigInt(n) => {
+            use num_traits::ToPrimitive;
+            n.as_ref()
+                .to_u64()
+                .unwrap_or_else(|| n.as_ref().to_i64().unwrap_or(0) as u64)
+        }
+        _ => 0,
+    }
+}
+
+/// Elements to the contiguous little-endian bytes the node stores.
+fn encode_elems(elems: &[Value], width: u8) -> Vec<u8> {
+    let w = width as usize;
+    let mut bytes = Vec::with_capacity(elems.len() * w);
+    for v in elems {
+        bytes.extend_from_slice(&elem_to_u64(v).to_le_bytes()[..w]);
+    }
+    bytes
+}
+
+/// The node's bytes back to elements.
+///
+/// A `uint64` element above `i64::MAX` becomes a `BigInt` rather than wrapping
+/// negative — `buf64.new(0xFFFF_FFFF_FFFF_FFFF)[0]` is `18446744073709551615`,
+/// as in Rakudo. A signed element is sign-extended from its width.
+fn decode_elems(data: &BufData) -> Vec<Value> {
+    let w = data.width as usize;
+    data.bytes
+        .chunks_exact(w)
+        .map(|chunk| {
+            let mut raw = [0u8; 8];
+            raw[..w].copy_from_slice(chunk);
+            let u = u64::from_le_bytes(raw);
+            if data.signed {
+                // Sign-extend from the element's own width.
+                let shift = 64 - w * 8;
+                Value::int(((u << shift) as i64) >> shift)
+            } else if w == 8 && u > i64::MAX as u64 {
+                Value::bigint(num_bigint::BigInt::from(u))
+            } else {
+                Value::int(u as i64)
+            }
+        })
+        .collect()
+}
+
+/// The storage `Value` a buffer instance keeps under [`ELEMS_ATTR`].
+fn storage_value(bytes: Vec<u8>, width: u8, signed: bool) -> Value {
+    Value::from_repr(ValueRepr::BufStorage(Gc::new(BufData {
+        bytes,
+        width,
+        signed,
+    })))
+}
+
+/// The node behind a buffer instance's storage attribute, if it has one.
+fn node_in(map: &AttrMap) -> Option<super::GcRef<'_, BufData>> {
+    match map.get(ELEMS_ATTR)?.view() {
+        ValueView::BufStorage(data) => Some(data),
+        _ => None,
+    }
+}
 
 /// The elements of a `Buf`/`Blob`-shaped instance, as owned `Value`s.
 ///
@@ -64,10 +163,8 @@ pub(crate) fn buf_elems_or_empty(attrs: &InstanceAttrs) -> Vec<Value> {
 /// [`buf_elems`] against an attribute map already in hand (a `to_map()` snapshot
 /// or a live read guard), so a caller holding one does not take a second lock.
 pub(crate) fn buf_elems_in(map: &AttrMap) -> Option<Vec<Value>> {
-    match map.get(ELEMS_ATTR)?.view() {
-        ValueView::Array(items, ..) => Some(items.to_vec()),
-        _ => None,
-    }
+    let node = node_in(map)?;
+    Some(decode_elems(&node))
 }
 
 /// Run `f` over the elements without copying them.
@@ -76,11 +173,8 @@ pub(crate) fn buf_elems_in(map: &AttrMap) -> Option<Vec<Value>> {
 /// so `f` must not re-enter the same instance's attribute cell for writing.
 /// Returns `None` (without calling `f`) when there is no element storage.
 pub(crate) fn with_buf_elems<R>(attrs: &InstanceAttrs, f: impl FnOnce(&[Value]) -> R) -> Option<R> {
-    let map = attrs.as_map();
-    match map.get(ELEMS_ATTR)?.view() {
-        ValueView::Array(items, ..) => Some(f(items.as_slice())),
-        _ => None,
-    }
+    let elems = buf_elems(attrs)?;
+    Some(f(&elems))
 }
 
 /// Whether this instance carries element storage at all. Distinguishes a real
@@ -96,15 +190,15 @@ pub(crate) fn has_buf_elems_in(map: &AttrMap) -> bool {
 
 /// A fresh attribute map holding `elems` — the map to hand
 /// `Value::make_instance` / `Value::write_back_sharing`.
-pub(crate) fn buf_attrs(elems: Vec<Value>) -> AttrMap {
+pub(crate) fn buf_attrs(class_name: Symbol, elems: Vec<Value>) -> AttrMap {
     let mut map = AttrMap::new();
-    set_buf_elems(&mut map, elems);
+    set_buf_elems(&mut map, class_name, elems);
     map
 }
 
 /// A fresh `Buf`/`Blob`-shaped instance of `class_name` holding `elems`.
 pub(crate) fn make_buf(class_name: Symbol, elems: Vec<Value>) -> Value {
-    Value::make_instance(class_name, buf_attrs(elems))
+    Value::make_instance(class_name, buf_attrs(class_name, elems))
 }
 
 /// A fresh plain `Buf` over raw bytes — the commonest construction of all (I/O
@@ -120,14 +214,22 @@ pub(crate) fn bytes_to_elems(bytes: &[u8]) -> Vec<Value> {
 
 /// Store `elems` into a map being built or updated, then handed to
 /// `make_instance` / `commit_attrs`.
-pub(crate) fn set_buf_elems(map: &mut AttrMap, elems: Vec<Value>) {
-    map.insert(ELEMS_ATTR, Value::array(elems));
+pub(crate) fn set_buf_elems(map: &mut AttrMap, class_name: Symbol, elems: Vec<Value>) {
+    let (width, signed) = elem_type(&class_name.resolve());
+    map.insert(
+        ELEMS_ATTR,
+        storage_value(encode_elems(&elems, width), width, signed),
+    );
 }
 
 /// Store `elems` into a **live** instance, through its shared attribute cell —
 /// visible to every alias, no rebind of the holding variable needed.
-pub(crate) fn store_buf_elems(attrs: &InstanceAttrs, elems: Vec<Value>) {
-    attrs.insert(ELEMS_ATTR, Value::array(elems));
+pub(crate) fn store_buf_elems(attrs: &InstanceAttrs, class_name: Symbol, elems: Vec<Value>) {
+    let (width, signed) = elem_type(&class_name.resolve());
+    attrs.insert(
+        ELEMS_ATTR,
+        storage_value(encode_elems(&elems, width), width, signed),
+    );
 }
 
 /// Mutate the elements in place through the shared cell, without decoding the
@@ -136,18 +238,28 @@ pub(crate) fn with_buf_elems_mut<R>(
     attrs: &InstanceAttrs,
     f: impl FnOnce(&mut Vec<Value>) -> R,
 ) -> Option<R> {
-    attrs
-        .with_attr_mut(ELEMS_ATTR, |slot| {
-            slot.with_array_mut(|items, _| f(crate::gc::Gc::make_mut(items)))
-        })
-        .flatten()
+    // The node knows its own element type, so unlike the construction helpers
+    // this one needs no class name: decode, hand `f` the elements, re-encode at
+    // the width the buffer already has.
+    let map = attrs.as_map();
+    let (mut elems, width, signed) = {
+        let node = node_in(&map)?;
+        (decode_elems(&node), node.width, node.signed)
+    };
+    drop(map);
+    let out = f(&mut elems);
+    attrs.insert(
+        ELEMS_ATTR,
+        storage_value(encode_elems(&elems, width), width, signed),
+    );
+    Some(out)
 }
 
 /// The element container itself, cloned, for the coercions that re-tag a buffer
 /// without looking inside it (`.Buf`, `.Blob`). Pair with [`set_buf_storage`].
 pub(crate) fn buf_storage(map: &AttrMap) -> Option<Value> {
     let stored = map.get(ELEMS_ATTR)?;
-    matches!(stored.view(), ValueView::Array(..)).then(|| stored.clone())
+    matches!(stored.view(), ValueView::BufStorage(..)).then(|| stored.clone())
 }
 
 /// Store a container obtained from [`buf_storage`] into a map being built.
@@ -160,46 +272,44 @@ pub(crate) fn set_buf_storage(map: &mut AttrMap, storage: Value) {
 /// today. The share is invisible: element writes go through
 /// [`with_buf_elems_mut`], whose `Gc::make_mut` forks a shared node.
 pub(crate) fn buf_elems_as_array(map: &AttrMap, kind: super::ArrayKind) -> Option<Value> {
-    match map.get(ELEMS_ATTR)?.view() {
-        ValueView::Array(items, ..) => Some(Value::array_with_kind(items.clone(), kind)),
-        _ => None,
-    }
+    Some(Value::array_with_kind(
+        crate::gc::Gc::new(super::ArrayData::new(buf_elems_in(map)?)),
+        kind,
+    ))
 }
 
 // ---------------------------------------------------------------------------
 // Byte-level access — what P2 will actually store.
 // ---------------------------------------------------------------------------
 
-/// One element, as the byte it occupies in a width-1 buffer.
+/// One element as the fixed-width hex digits a `Buf` gists with
+/// (`Buf[uint16]:0x<1170>`), big-endian within the element as Rakudo prints it.
 ///
-/// **Truncating**, which is the convention Raku itself stores by: `Buf.new(300)`
-/// holds `0x2C` and `Buf.new(-1)` holds `0xFF` in both mutsu and Rakudo, and
-/// every mutation path (`.new`, `[i] =`, `push`, `append`, `unshift`, `splice`)
-/// already masks on the way in. Three different conventions used to be spelled
-/// out at the call sites — this one, a `.clamp(0, 255)` one, and one going via
-/// `to_int` — and they could only disagree about a buffer whose elements exceed
-/// its width, which the masking makes unreachable. For a wider buffer this is
-/// the low byte of the element, matching what the truncating sites did.
-pub(crate) fn elem_to_u8(v: &Value) -> u8 {
-    match v.view() {
-        ValueView::Int(i) => i as u8,
-        ValueView::Num(f) => f as i64 as u8,
-        ValueView::BigInt(n) => {
-            use num_traits::ToPrimitive;
-            // `to_u64` is `None` for a negative or oversized value; fall back to
-            // the low 64 bits so this stays a truncation rather than a zero.
-            n.as_ref()
-                .to_u64()
-                .unwrap_or_else(|| n.as_ref().to_i64().unwrap_or(0) as u64) as u8
-        }
-        _ => 0,
+/// Formatting from the element's *unsigned* bit pattern is what makes a signed
+/// or oversized element print the bytes it actually occupies: `Blob[int8]`
+/// holding `-1` is `FF`, and a `uint64` element above `i64::MAX` — a `BigInt`
+/// once decoded — is its own sixteen digits rather than zeros.
+pub(crate) fn elem_hex(v: &Value, width: usize) -> String {
+    let u = elem_to_u64(v);
+    match width {
+        8 => format!("{u:016X}"),
+        4 => format!("{:08X}", u as u32),
+        2 => format!("{:04X}", u as u16),
+        _ => format!("{:02X}", u as u8),
     }
 }
 
 /// The number of **elements**, without decoding any of them. Not the number of
-/// bytes — see [`buf_elem_width`], and `.bytes` is `elems * width`.
+/// bytes — see [`buf_elem_width`]; `.bytes` is `elems * width`.
 pub(crate) fn buf_len(attrs: &InstanceAttrs) -> Option<usize> {
-    with_buf_elems(attrs, <[Value]>::len)
+    buf_len_in(&attrs.as_map())
+}
+
+/// [`buf_len`] against an attribute map already in hand. A division, not a
+/// decode: the node's byte count divided by its element width.
+pub(crate) fn buf_len_in(map: &AttrMap) -> Option<usize> {
+    let node = node_in(map)?;
+    Some(node.bytes.len() / node.width as usize)
 }
 
 /// [`buf_len`] with an absent buffer read as empty.
@@ -207,13 +317,14 @@ pub(crate) fn buf_len_or_zero(attrs: &InstanceAttrs) -> usize {
     buf_len(attrs).unwrap_or(0)
 }
 
-/// The elements as one truncated byte each ([`elem_to_u8`]).
+/// The elements as one byte each — the buffer's real bytes for a width-1
+/// buffer (every `Buf`/`Blob`/`utf8`), read straight off the node.
 ///
 /// `None` when the instance carries no element storage, exactly as
-/// [`buf_elems`]. For a width-1 buffer — every `Buf`/`Blob`/`utf8` — these are
-/// the buffer's real bytes, and P2 hands them over without decoding anything.
+/// [`buf_elems`]. For a wider buffer this is the low byte of each element,
+/// which is what the byte-shaped callers have always taken.
 pub(crate) fn buf_bytes(attrs: &InstanceAttrs) -> Option<Vec<u8>> {
-    with_buf_bytes(attrs, <[u8]>::to_vec)
+    buf_bytes_in(&attrs.as_map())
 }
 
 /// [`buf_bytes`] with an absent buffer read as empty.
@@ -223,29 +334,44 @@ pub(crate) fn buf_bytes_or_empty(attrs: &InstanceAttrs) -> Vec<u8> {
 
 /// [`buf_bytes`] against an attribute map already in hand.
 pub(crate) fn buf_bytes_in(map: &AttrMap) -> Option<Vec<u8>> {
-    Some(buf_elems_in(map)?.iter().map(elem_to_u8).collect())
+    let node = node_in(map)?;
+    Some(node_bytes(&node).into_owned())
+}
+
+/// The byte view of a node: its storage as-is for a width-1 buffer (every
+/// `Buf`/`Blob`/`utf8`, so the common case borrows and copies nothing extra),
+/// and the low byte of each element for a wider one.
+fn node_bytes<'a>(node: &'a BufData) -> std::borrow::Cow<'a, [u8]> {
+    if node.width == 1 {
+        std::borrow::Cow::Borrowed(&node.bytes)
+    } else {
+        std::borrow::Cow::Owned(
+            node.bytes
+                .chunks_exact(node.width as usize)
+                .map(|c| c[0])
+                .collect(),
+        )
+    }
 }
 
 /// Run `f` over the bytes without handing out an owned `Vec`.
 ///
-/// Today the slice is a temporary this function builds; under P2 a width-1
-/// buffer passes its storage straight through. Callers that go on to mutate the
-/// bytes want [`buf_bytes`] instead.
+/// For a width-1 buffer this is the node's storage, borrowed — no decode and no
+/// allocation. Callers that go on to mutate the bytes want [`buf_bytes`].
 pub(crate) fn with_buf_bytes<R>(attrs: &InstanceAttrs, f: impl FnOnce(&[u8]) -> R) -> Option<R> {
-    let bytes = with_buf_elems(attrs, |items| {
-        items.iter().map(elem_to_u8).collect::<Vec<u8>>()
-    })?;
-    Some(f(&bytes))
+    let map = attrs.as_map();
+    let node = node_in(&map)?;
+    Some(f(&node_bytes(&node)))
 }
 
-/// Store raw bytes into a map being built or updated.
-pub(crate) fn set_buf_bytes(map: &mut AttrMap, bytes: &[u8]) {
-    set_buf_elems(map, bytes_to_elems(bytes));
+/// Store raw bytes into a map being built or updated, one byte per element.
+pub(crate) fn set_buf_bytes(map: &mut AttrMap, class_name: Symbol, bytes: &[u8]) {
+    set_buf_elems(map, class_name, bytes_to_elems(bytes));
 }
 
 /// Store raw bytes into a **live** instance, through its shared attribute cell.
-pub(crate) fn store_buf_bytes(attrs: &InstanceAttrs, bytes: &[u8]) {
-    store_buf_elems(attrs, bytes_to_elems(bytes));
+pub(crate) fn store_buf_bytes(attrs: &InstanceAttrs, class_name: Symbol, bytes: &[u8]) {
+    store_buf_elems(attrs, class_name, bytes_to_elems(bytes));
 }
 
 /// A fresh `Buf`/`Blob`-shaped instance of `class_name` over raw bytes.
@@ -339,11 +465,11 @@ mod tests {
     /// exceed a byte; there it is the element's low byte.
     #[test]
     fn bytes_truncate_rather_than_clamp() {
-        assert_eq!(elem_to_u8(&Value::int(300)), 0x2C);
-        assert_eq!(elem_to_u8(&Value::int(-1)), 0xFF);
-        assert_eq!(elem_to_u8(&Value::int(0x1170)), 0x70);
-        assert_eq!(elem_to_u8(&Value::num(300.9)), 0x2C);
-        assert_eq!(elem_to_u8(&Value::str("nope".to_string())), 0);
+        assert_eq!(elem_to_u64(&Value::int(300)) as u8, 0x2C);
+        assert_eq!(elem_to_u64(&Value::int(-1)) as u8, 0xFF);
+        assert_eq!(elem_to_u64(&Value::int(0x1170)) as u8, 0x70);
+        assert_eq!(elem_to_u64(&Value::num(300.9)) as u8, 0x2C);
+        assert_eq!(elem_to_u64(&Value::str("nope".to_string())), 0);
 
         let wide = make_buf(Symbol::intern("Buf[uint16]"), vec![Value::int(0x1170)]);
         assert_eq!(buf_bytes(&attrs_of(&wide)), Some(vec![0x70]));
@@ -362,12 +488,13 @@ mod tests {
 
     #[test]
     fn bytes_round_trip_through_the_write_side() {
+        let buf = Symbol::intern("Buf");
         let mut map = AttrMap::new();
-        set_buf_bytes(&mut map, &[1, 2, 3]);
-        let b = Value::make_instance(Symbol::intern("Buf"), map);
+        set_buf_bytes(&mut map, buf, &[1, 2, 3]);
+        let b = Value::make_instance(buf, map);
         assert_eq!(buf_bytes(&attrs_of(&b)), Some(vec![1, 2, 3]));
 
-        store_buf_bytes(&attrs_of(&b), &[9]);
+        store_buf_bytes(&attrs_of(&b), buf, &[9]);
         assert_eq!(buf_bytes(&attrs_of(&b)), Some(vec![9]));
 
         let fresh = make_buf_from_bytes(Symbol::intern("Blob"), &[4, 5]);
@@ -382,5 +509,68 @@ mod tests {
         set_buf_storage(&mut map, storage);
         let blob = Value::make_instance(Symbol::intern("Blob"), map);
         assert_eq!(buf_elems(&attrs_of(&blob)), Some(bytes_to_elems(&[7, 8])));
+    }
+
+    /// The node stores contiguous bytes at the class's element width, so a
+    /// wide buffer's storage is `elems * width` bytes — not one byte per
+    /// element, which is all the old boxed representation could express.
+    #[test]
+    fn the_node_stores_contiguous_bytes_at_the_element_width() {
+        let wide = make_buf(Symbol::intern("Buf[uint16]"), vec![Value::int(0x1170)]);
+        let attrs = attrs_of(&wide);
+        let map = attrs.as_map();
+        let node = node_in(&map).expect("node");
+        assert_eq!(node.bytes, vec![0x70, 0x11]); // little-endian
+        assert_eq!(node.width, 2);
+        assert!(!node.signed);
+    }
+
+    /// The element type used to live only in the class-name string, so every
+    /// element read back unsigned. It is data now.
+    #[test]
+    fn signed_elements_read_back_signed() {
+        let signed = make_buf(Symbol::intern("Blob[int8]"), vec![Value::int(-1)]);
+        assert_eq!(buf_elems(&attrs_of(&signed)), Some(vec![Value::int(-1)]));
+        // Same bytes, unsigned type: a different value.
+        let unsigned = make_buf(Symbol::intern("Blob[uint8]"), vec![Value::int(-1)]);
+        assert_eq!(buf_elems(&attrs_of(&unsigned)), Some(vec![Value::int(255)]));
+
+        let wide = make_buf(Symbol::intern("Buf[int16]"), vec![Value::int(-2)]);
+        assert_eq!(buf_elems(&attrs_of(&wide)), Some(vec![Value::int(-2)]));
+    }
+
+    /// `uint64` is the one width whose range does not fit `i64`; the old
+    /// representation wrapped it negative on the way out.
+    #[test]
+    fn oversized_unsigned_elements_decode_to_bigint() {
+        let b = make_buf(Symbol::intern("Buf[uint64]"), vec![Value::int(-1)]);
+        let elems = buf_elems(&attrs_of(&b)).expect("elems");
+        assert_eq!(elems[0].to_string_value(), "18446744073709551615");
+        assert_eq!(elem_hex(&elems[0], 8), "FFFFFFFFFFFFFFFF");
+    }
+
+    #[test]
+    fn element_type_reads_signedness_off_the_name() {
+        for name in ["Buf", "Blob", "utf8", "utf16", "Buf[uint8]", "Blob[uint64]"] {
+            assert!(!elem_type(name).1, "{name} should be unsigned");
+        }
+        for name in ["Blob[int8]", "Buf[int16]", "Buf[int64]"] {
+            assert!(elem_type(name).1, "{name} should be signed");
+        }
+    }
+
+    /// An in-place element mutation re-encodes at the buffer's own width — it
+    /// takes no class name, because the node already knows.
+    #[test]
+    fn in_place_mutation_keeps_the_element_width() {
+        let wide = make_buf(Symbol::intern("Buf[uint16]"), vec![Value::int(1)]);
+        let attrs = attrs_of(&wide);
+        with_buf_elems_mut(&attrs, |items| items.push(Value::int(0x1234)));
+        assert_eq!(
+            buf_elems(&attrs),
+            Some(vec![Value::int(1), Value::int(0x1234)])
+        );
+        let map = attrs.as_map();
+        assert_eq!(node_in(&map).expect("node").bytes, vec![1, 0, 0x34, 0x12]);
     }
 }

--- a/src/value/value_eq.rs
+++ b/src/value/value_eq.rs
@@ -46,6 +46,10 @@ impl PartialEq for Value {
                 },
             ) => es1 == es2 && ee1 == ee2 && s1 == s2 && e1 == e2,
             (ValueView::Array(a, ..), ValueView::Array(b, ..)) => *a == *b,
+            // Two buffers are equal when their bytes and their element type
+            // are: a `Blob[int8]` and a `Blob[uint8]` over the same bytes read
+            // back as different elements, so they are not the same value.
+            (ValueView::BufStorage(a), ValueView::BufStorage(b)) => *a == *b,
             (ValueView::Seq(a), ValueView::Seq(b)) => *a == *b,
             (ValueView::Slip(a), ValueView::Slip(b)) => *a == *b,
             (ValueView::Array(a, ..), ValueView::Seq(b))

--- a/src/value/value_gc.rs
+++ b/src/value/value_gc.rs
@@ -24,8 +24,8 @@ use std::sync::{Arc, Condvar, Mutex};
 use crate::gc::{ErasedGc, RootVisitor, Trace, visit_map_values};
 
 use super::{
-    ArrayData, BagData, ChannelState, EnumValue, HashData, InstanceAttrs, LazyList, MixData,
-    PromiseState, SetData, SharedChannel, SharedPromise, SubData, Value,
+    ArrayData, BagData, BufData, ChannelState, EnumValue, HashData, InstanceAttrs, LazyList,
+    MixData, PromiseState, SetData, SharedChannel, SharedPromise, SubData, Value,
 };
 
 /// Whether an `Arc`-shared wrapper is *uniquely owned* — its only holder is the
@@ -412,6 +412,17 @@ impl Trace for ArrayData {
         self.items.clear();
         self.default = None;
     }
+}
+
+/// A `Buf`/`Blob`'s bytes hold no `Value`s, so this node has no outgoing edges
+/// at all: it can never be part of a cycle, and ADR-0001's container type filter
+/// therefore pays nothing for it beyond the refcount every `Gc` has. Both
+/// methods are deliberately empty rather than absent, so that adding a `Value`
+/// field to `BufData` later would show up here as an obvious omission.
+impl Trace for BufData {
+    fn trace(&self, _visit: &mut dyn FnMut(&ErasedGc)) {}
+
+    fn drop_gc_edges(&mut self) {}
 }
 
 impl Trace for HashData {

--- a/src/value/view.rs
+++ b/src/value/view.rs
@@ -39,6 +39,7 @@ pub enum ValueView<'a> {
         excl_end: bool,
     },
     Array(GcRef<'a, ArrayData>, ArrayKind),
+    BufStorage(GcRef<'a, BufData>),
     Hash(GcRef<'a, HashData>),
     Rat(i64, i64),
     FatRat(i64, i64),

--- a/src/vm/vm_call_method_mut_ops.rs
+++ b/src/vm/vm_call_method_mut_ops.rs
@@ -2677,7 +2677,7 @@ impl Interpreter {
         // (so aliases observing the same buf see the mutation), then refresh the
         // receiver binding to match the interpreter's `env.insert(target_var, ...)`.
         let mut updated_attrs = attributes.to_map();
-        crate::value::value_buf::set_buf_bytes(&mut updated_attrs, &new_bytes);
+        crate::value::value_buf::set_buf_bytes(&mut updated_attrs, class_name, &new_bytes);
         let updated = Value::write_back_sharing(&attributes, class_name, updated_attrs, id);
         self.env_mut()
             .insert(target_name.to_string(), updated.clone());

--- a/todo/deep/adr0015-p2-buf-storage-survey.md
+++ b/todo/deep/adr0015-p2-buf-storage-survey.md
@@ -28,7 +28,8 @@ because a contiguous `Vec<u8>` cannot be interpreted without it.
 (see [`news/2026-07/buf-storage-accessor-chokepoint.md`](../../news/2026-07/buf-storage-accessor-chokepoint.md)).
 Sections 2 and 5 below are now historical: read them for *why* the campaign was
 needed, not as work still to do. Step 2 (the byte view and the width probe) is
-done too; steps 3 and 4 are open.
+done too, as is step 3 (the node). Only step 4 — the body and the honest
+`.REPR` — is open.
 
 ## 2. The `"bytes"` campaign is 104 sites, not 91 (done — historical)
 
@@ -193,12 +194,15 @@ ADR §4 promises — does not exist yet and is part of P2.
    `0xFF`), every mutation path masks on the way in, and for a wider buffer
    Rakudo agrees with neither convention anyway.
 
-3. **The node**, behind those accessors: contiguous `Vec<u8>` + element width,
-   with the encode/decode the accessors now hide. Signedness has to ride along
-   with the width — mutsu stores every element unsigned today, so
-   `Blob[int8].new(-1)[0]` answers `255` where raku answers `-1`, and the node
-   is where that stops being true.
+3. **The node.** **DONE** — see
+   [`news/2026-07/buf-native-byte-node.md`](../../news/2026-07/buf-native-byte-node.md).
+   `ValueRepr::BufStorage(Gc<BufData>)`: contiguous little-endian bytes plus the
+   element width and signedness, behind the accessors from steps 1 and 2. Adding
+   the variant reached exactly six exhaustive matches plus `==` and `eqv`.
+   Reads take no class name (the node carries the type); the ~20 *construction*
+   sites do, since the name is the only place Raku keeps it. Closed the
+   signedness and `uint64` readback gaps as a side effect.
 4. **The body and the honest `.REPR`**, in one commit with the `MVMArrayB` test,
    plus the deletion of `nativecall_pin.rs` and its three helpers.
 
-Steps 3 and 4 are where the judgment is.
+Step 4 is what `DBIish`'s mysql driver is actually waiting for.


### PR DESCRIPTION
A `Buf` was a `Value::Instance` whose one attribute held a `Value::Array` with
**one boxed `Value::Int` per element**. A megabyte buffer therefore cost a
million boxed `Value`s and a million GC edges to trace, the element type existed
only as a substring of the class name, and there was no contiguous memory
anywhere for a C function to be handed a pointer into.

It is a `BufData` node now: contiguous little-endian bytes plus the element
width and signedness, as data. This is
[ADR-0015](docs/adr/0015-native-backed-container-storage-and-repr-bodies.md)
P2's representation change — the step
[the survey](todo/deep/adr0015-p2-buf-storage-survey.md) called "where the
judgment is".

## What keeps it contained

The two preceding slices. Step 1 (#5521) routed all ~104 attribute touches
through `src/value/value_buf.rs`; step 2 (#5523) added the byte and count
accessors most of those callers actually wanted. With both in place, swapping
the representation is a change to *that file* — the ~170 call sites across forty
files are untouched.

What did change shape is the write side: **reads need no class name,
construction does.** The node carries the element type, so every read — and
`with_buf_elems_mut`, which re-encodes at whatever width the buffer already
has — works from the node alone. The functions that *create* storage
(`buf_attrs`, `set_buf_elems`, `set_buf_bytes`, `store_buf_*`) take the class
`Symbol`, because the name is where Raku keeps the element type and there is
nowhere else to read it from. Every one of those ~20 sites had it in scope
already.

## Three parity gaps close as a side effect

None were the goal; all three are the same bug — the element type was not
data — seen from different sides.

| | raku | before | now |
| --- | --- | --- | --- |
| `Blob[int8].new(-1)[0]` | `-1` | `255` | `-1` |
| `Blob[int8].new(200)[0]` | `-56` | `200` | `-56` |
| `Buf[int16].new(-2)[0]` | `-2` | `65534` | `-2` |
| `buf64.new(0xFFFF_FFFF_FFFF_FFFF)[0]` | `18446744073709551615` | `-1` | `18446744073709551615` |

Signed elements are sign-extended from their own width; a `uint64` element above
`i64::MAX` decodes to a `BigInt` rather than wrapping negative. Two display
paths had to follow — `.gist` and `.raku` both matched `ValueView::Int` and fell
back to zeros, so `buf64`'s largest value gisted as `0x<0000000000000000>` and
`.raku`'d as `.new(0)`. The hex formatting, which was duplicated across two
files, is now one `elem_hex` formatting from the element's unsigned bit pattern.

## Cost and shape

`BufData` is a **payload-only** GC node: no `Value`s, so `Trace` is an empty
body, it can never take part in a cycle, and ADR-0001's container type filter
keeps paying nothing for it beyond the refcount every `Gc` has. Both `Trace`
methods are written out rather than defaulted, so adding a `Value` field later
shows up as an obvious omission.

Adding the variant reached exactly **six** exhaustive matches (`.^name`,
`value_type_name`, `isa`, `truthy`, `to_string_value`, serde) plus `==` and
`eqv`. It stays out of `Buf`'s Raku-visible surface entirely —
`Buf.new(1,2).^attributes` is empty, so nothing at the language level ever names
the storage attribute.

`CACHE_FORMAT_VERSION` goes to 9: the new `SerValue` variant shifts the
serialized discriminants after `Array`. (The exe-mtime stamp already invalidates
on every rebuild, but the bump is the documented convention.)

## Verification

- The raku comparison script from #5523 — construction, gisting, `.raku`,
  encode/decode, `.bytes`, indexed assignment, `push`, the `write-*int` and
  `write-num` methods, `read-ubits`, `.Buf`/`.Blob` coercion, concatenation,
  `eqv` — is **byte-identical to `raku`** apart from the already-recorded
  `write-ubits` masking gap
  (`todo/tickets/buf-numeric-bitneg-and-write-ubits-mask.md`), untouched here.
- Six new unit tests pin the node's byte layout, the signedness round trip, the
  `BigInt` decode, and that in-place mutation preserves the element width.
- Local `make test`: 2551 files / 24401 tests, all pass.

## What is left of P2

The body. `Buf.REPR` still answers `P6opaque`; making it answer `VMArray`
requires the synthesised `MVMArrayB` block behind it **in the same commit**
(ADR-0015 §2.1's ordering rule), and that is what `NativeHelpers::Blob`'s
`BODY_OF` — and through it `DBIish`'s mysql driver — is waiting for. This node
is the storage that block will point at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)