### PR TITLE
perf(grammar): skip action-method dispatch resolution when no method exists

### DIFF
--- a/news/2026-07/grammar-actions-skip-dispatch-for-missing-methods.md
+++ b/news/2026-07/grammar-actions-skip-dispatch-for-missing-methods.md
@@ -1,0 +1,47 @@
+# Grammar action dispatch no longer pays full multi-dispatch resolution for a method that doesn't exist
+
+`invoke_grammar_actions` walks a grammar's finished match tree bottom-up and,
+for **every** named capture, unconditionally called
+`call_method_with_values(actions, rule_name, ...)` to see whether the actions
+class had a corresponding method — relying on the call failing with
+`MethodNotFound` as the "no action for this rule" signal. Most match-tree
+nodes are low-level helper tokens (YAMLish's `space`, `single-bare`,
+`line-break`, `foldable-whitespace`, `comment`, ...) that an actions class
+never defines a method for, so the overwhelmingly common case paid the full
+cost of multi-dispatch resolution (`has_proto`, `has_multi_candidates`,
+`has_multi_function`, `resolve_function_with_types`, `bare_name_packages`,
+plus the `format!`-built error message) just to be told "not found".
+
+A `perf` profile of `load-yaml` (the bundled YAMLish battery) over a
+block-sequence document with several long, space-heavy quoted scalars showed
+that dispatch-resolution cluster and its downstream allocation
+(`malloc`/`cfree`/`format!`) as a large share of total samples; the total
+sample count for the same input dropped by roughly half after this fix, with
+the dispatch cluster itself almost disappearing from the profile.
+
+The fix adds a cheap pre-check: `has_user_method` is a direct MRO walk + a
+`HashMap`-by-name lookup (no candidate scanning, no error-message
+formatting), so `invoke_grammar_actions` now calls `call_method_with_values`
+only when the actions class (or its `:sym<...>` proto variant) actually
+declares that method. The first attempt at this missed that a stateless
+`:actions(Actions)` grammar action is commonly passed as the **bare type
+object**, not an instance (`ValueView::Package`, not `ValueView::Instance`) —
+without handling that case the class name was never resolved and the
+pre-check silently fell back to "assume it exists, call anyway" for every
+node, which is why the first perf comparison showed no change at all. Once
+`ValueView::Package` was handled the same way `Instance` is, the dispatch
+cluster collapsed as expected.
+
+Pin: `t/grammar-actions-type-object-sparse.t` — a bare type-object actions
+class with methods for only some rules (including a `:sym<>` proto variant),
+verified against `raku` first (including its `Use of Nil in string context`
+warning when a topmost `.made` reads through an un-actioned child).
+
+Verified with `make test` (2552 files, 24408 tests, all green) and the
+grammar/YAMLish-relevant roast whitelist files locally; the actual wall-clock
+win will show up in the next `bench-data` run rather than a local
+measurement, since this session's box was under heavy concurrent-build load
+throughout.
+
+See `todo/tickets/yaml-parse-throughput.md` for what's still open in the
+broader YAML-parse-throughput investigation this came out of.

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -954,22 +954,56 @@ impl Interpreter {
         } else {
             None
         };
+        // Cheap existence pre-check: most match-tree nodes are low-level
+        // tokens (e.g. YAMLish's `space`, `single-bare`, `line-break`) that
+        // the actions class never defines a method for. Without this check,
+        // every one of them paid the full multi-dispatch resolution walk
+        // (has_proto/has_multi_function/resolve_function_with_types) just to
+        // get a MethodNotFound — dominating a profile of files with long
+        // quoted-scalar runs (many-char match trees), since
+        // invoke_grammar_actions calls this for EVERY named capture.
+        // `has_user_method` is a direct MRO + HashMap-by-name lookup, so the
+        // common "no action for this rule" case now costs a lookup instead of
+        // a full dispatch resolution + error.
+        let actions_class_name = match actions.view() {
+            ValueView::Instance { class_name, .. } => Some(class_name.as_str()),
+            // A stateless `:actions(Actions)` grammar action is often passed
+            // as the bare type object, not an instance.
+            ValueView::Package(name) => Some(name.as_str()),
+            _ => None,
+        };
         let method_result = if let Some(ref sym_name) = sym_method_name {
-            let result =
-                self.call_method_with_values(actions.clone(), sym_name, vec![match_obj.clone()]);
-            match result {
-                Err(e) if e.is_method_not_found() => {
-                    // Fall back to plain rule name
-                    self.call_method_with_values(
-                        actions.clone(),
-                        rule_name,
-                        vec![match_obj.clone()],
-                    )
+            let sym_exists = actions_class_name.is_none_or(|cn| self.has_user_method(cn, sym_name));
+            if sym_exists {
+                let result = self.call_method_with_values(
+                    actions.clone(),
+                    sym_name,
+                    vec![match_obj.clone()],
+                );
+                match result {
+                    Err(e) if e.is_method_not_found() => {
+                        // Fall back to plain rule name.
+                        if actions_class_name.is_none_or(|cn| self.has_user_method(cn, rule_name)) {
+                            self.call_method_with_values(
+                                actions.clone(),
+                                rule_name,
+                                vec![match_obj.clone()],
+                            )
+                        } else {
+                            Ok(match_obj.clone())
+                        }
+                    }
+                    other => other,
                 }
-                other => other,
+            } else if actions_class_name.is_none_or(|cn| self.has_user_method(cn, rule_name)) {
+                self.call_method_with_values(actions.clone(), rule_name, vec![match_obj.clone()])
+            } else {
+                Ok(match_obj.clone())
             }
-        } else {
+        } else if actions_class_name.is_none_or(|cn| self.has_user_method(cn, rule_name)) {
             self.call_method_with_values(actions.clone(), rule_name, vec![match_obj.clone()])
+        } else {
+            Ok(match_obj.clone())
         };
 
         // After the method call, if actions is an Instance, its attributes

--- a/t/grammar-actions-type-object-sparse.t
+++ b/t/grammar-actions-type-object-sparse.t
@@ -1,0 +1,50 @@
+use Test;
+
+plan 4;
+
+# A stateless `:actions(Actions)` grammar action is commonly passed as the
+# bare type object (not `Actions.new`), e.g. the bundled YAMLish battery does
+# `nextwith($string, :actions(Actions), |%args)`. And most match-tree nodes
+# in a real grammar (low-level tokens like whitespace/char-class helpers) have
+# no corresponding action method at all — the dispatcher must silently skip
+# those without mishandling the type-object case.
+
+grammar SparseGrammar {
+    token TOP { <word> [ <.ws> <word> ]* }
+    token word { <alpha>+ }
+    token ws { <.space>+ }
+}
+
+class SparseActions {
+    method TOP($/) {
+        make $<word>>>.made.join('-');
+    }
+    method word($/) { make ~$/ }
+    # No `alpha` or `ws` method: those rules must be silently skipped.
+}
+
+my $m1 = SparseGrammar.parse('foo bar baz', :actions(SparseActions));
+is $m1.made, 'foo-bar-baz', 'bare type-object actions dispatch works';
+
+my $m2 = SparseGrammar.parse('foo bar baz', :actions(SparseActions.new));
+is $m2.made, 'foo-bar-baz', 'instantiated actions dispatch works the same way';
+
+# A proto/`:sym<>` variant with a type-object actions class: the sym-specific
+# method is tried first, then the plain rule name, then silently skipped.
+grammar SymGrammar {
+    token TOP { <alt> }
+    proto token alt { * }
+    token alt:sym<a> { 'a' }
+    token alt:sym<b> { 'b' }
+}
+
+class SymActions {
+    method TOP($/) { make ~$<alt>.made }
+    method alt:sym<a>($/) { make "A:" ~ ~$/ }
+    # No method for alt:sym<b> or plain "alt": must fall through silently.
+}
+
+is SymGrammar.parse('a', :actions(SymActions)).made, 'A:a',
+   'sym-variant action method resolves on a bare type-object actions class';
+is SymGrammar.parse('b', :actions(SymActions)).made, '',
+   'missing sym-variant action falls through silently on a type-object actions class';

--- a/todo/tickets/yaml-parse-throughput.md
+++ b/todo/tickets/yaml-parse-throughput.md
@@ -5,15 +5,50 @@ is **slow**, and the cost is in *matching*, not module load. This is the
 match-time twin of `grammar-heavy-module-load-slower-than-raku.md`; that ticket
 measures `use`, this one measures the parse itself.
 
-**One round of this has already landed**
-(`news/2026-07/regex-code-block-writeback-by-identity.md`):
+**Two rounds of this have already landed.**
+
+Round 1 (`news/2026-07/regex-code-block-writeback-by-identity.md`):
 `eval_regex_code_block_body` used to snapshot the whole env with
 `format!("{:?}", v)` before and after **every** regex `{ … }` block and compare
 the strings. `core::fmt` was ~20% of a `load-yaml` profile before that; comparing
-by `Value::same_binding()` instead made a block mapping **4.7x faster**. What is
-below is what remains *after* that fix.
+by `Value::same_binding()` instead made a block mapping **4.7x faster**.
 
-## Measurement (2026-07-28, release build)
+Round 2 (`news/2026-07/grammar-actions-skip-dispatch-for-missing-methods.md`):
+`invoke_grammar_actions` called `call_method_with_values` for **every**
+match-tree node regardless of whether the actions class defined a method for
+that rule, relying on `MethodNotFound` as the "no action" signal. Most nodes
+are low-level helper tokens with no action method, so this paid full
+multi-dispatch resolution (`has_proto`/`has_multi_candidates`/
+`has_multi_function`/`resolve_function_with_types`/`bare_name_packages` plus a
+`format!`-built error) just to fail. A cheap `has_user_method` pre-check (a
+direct MRO + HashMap-by-name lookup, no candidate scan) now skips the call
+entirely when neither the `:sym<...>` variant nor the plain rule name is
+declared — this required handling `ValueView::Package` (a stateless
+`:actions(Actions)` grammar action is commonly the bare type object, not an
+instance) alongside `ValueView::Instance`, or the class name never resolves
+and the pre-check is a no-op. A `perf` profile of a space-heavy block-sequence
+document showed the dispatch cluster (and its `malloc`/`format!` downstream)
+shrink to a small residual, with total profiled samples for the same input
+roughly halving.
+
+What is below is what remains *after both* fixes.
+
+## Measurement (2026-07-28, release build, pre-round-2)
+
+The table below predates round 2 (it was taken right after round 1 landed) and
+was re-derived this session as: `basic.rakutest`'s slowest subtest is its
+second document (`message`/`dump:`/`comment:`), and bisecting *that* down
+further showed the cost is proportional to the length of the single **run** of
+consecutive spaces inside a quoted scalar (`'      16G         05C        '`),
+not to item count or overall document size — e.g. a lone `'a' ~ (' ' x
+$n) ~ 'b'` list item cost roughly a flat ~12ms/space in release regardless of
+$n. Round 2's fix removes a large piece of that flat per-position cost (each
+space position walks the quoted-scalar grammar's `space`/`single-bare`/
+`single-quotes`/`foldable-whitespace` alternatives, and *every one* of those
+subrule matches used to pay the full action-dispatch resolution this ticket's
+round 2 removed) — but this table itself was not re-measured locally, since a
+reliable A/B needs an idle box or the `bench-data` CI history, not a
+contended local run (see "Delegate the full roast run to CI" in `CLAUDE.md`).
 
 Synthetic `k$_: v$_` block mapping under `load-yaml`:
 
@@ -63,20 +98,46 @@ The `MUTSU_VM_STATS` counters are useless here: only ~25k opcodes run for a
 
 ## Where to look next
 
-1. **Profile `basic.rakutest` specifically.** The synthetic benchmark is now
-   dominated by something other than what that file is dominated by, so measure
-   the file, not the micro-benchmark.
-2. **Per-call token instantiation.** `resolve_token_patterns_with_args_in_pkg`
-   builds a fresh scratch `Interpreter`, evaluates the token body, and re-runs the
-   whole text-rewrite chain (`bake_bound_params_into_regex_code_blocks` →
-   `interpolate_bound_regex_scalars` → `instantiate_named_regex_arg_calls`) plus a
-   full `parse_regex_uncached` — for **every** `<block($indent, 0)>` call at every
-   position. `REGEX_PARSE_CACHE` does not help: the text differs per `$indent`.
-   A memo keyed on `(rule, pkg, args)` would be sound only for a token whose body
-   names no free variable other than its parameters and its own `:my` lexicals —
-   that static condition is checkable, and YAMLish's indentation rules satisfy it.
+1. **Re-profile `basic.rakutest` after round 2, on an idle box (or via CI).**
+   This session's box had 2-3 concurrent `cargo build --release` jobs from
+   other sessions running throughout (system load 13-15), which makes any
+   local wall-clock number here unreliable — use `perf`'s *relative* sample
+   distribution (not absolute time) for structural comparisons, and the
+   `bench-data` branch history for the number that actually goes in a
+   document, per "Benchmark numbers in documents come from the bench CI" in
+   `CLAUDE.md`.
+2. **Per-call token instantiation turned out to be a dead end — already
+   memoized for the case that matters.** The investigation this session
+   confirmed `resolve_token_patterns_with_args_in_pkg`'s re-parse-per-call cost
+   (described in the original version of this item) is real but *rare*: a
+   debug-build call count on a 30-space synthetic document showed only ~19
+   with-args calls total (`block`/`sequence`/`map`/`map-entry`/`list-entry`/
+   `element`/... once or twice each), independent of the number of spaces.
+   The *argument-less* subrules that actually scale with input size
+   (`space`, `single-bare`, `single-quotes`, `foldable-whitespace` — one
+   alternative-set try per character in a run of spaces) already go through
+   `PARSED_TOKEN_CANDIDATES`, a per-(pkg,name) memo added in #4587 — so their
+   *resolution* was never the per-character cost. What scaled with input size
+   was the *action-dispatch* attempt after each of those matches succeeded,
+   which is round 2's fix. If a future profile still shows
+   `resolve_token_patterns_with_args_in_pkg` (not `resolve_parsed_token_candidates_in_pkg`)
+   as hot, THEN revisit the "(rule, pkg, args)" memo idea above — but verify
+   with a call-count instrumentation first, the way this session did, rather
+   than assuming from the function's doc comment.
 3. **Candidate enumeration.** The `_all_` atom enumerations return every end
    position; with a deeply nested indentation grammar the branching multiplies.
+   Not yet measured directly — still open.
+4. **Residual `malloc`/`_int_free`/`__memcmp_avx2_movbe` cost.** After round 2,
+   these plain allocator/libc symbols are the largest entries in a `perf`
+   self-time sort of the space-heavy synthetic (no single mutsu function
+   dominates). This is consistent with genuine O(n) `Match`/capture object
+   construction — one per matched space character, since each is its own
+   quantified `<str=space>` capture — rather than a single fixable call site.
+   Reducing it would mean cutting per-attempt allocation in the regex engine's
+   capture-construction path itself (e.g. `make_subcap_match`,
+   `RegexCaptures` cloning in the `Alternation` match-merge loop in
+   `regex_match_atom.rs`), which is a different, deeper investigation than
+   either round so far.
 
 ## Why it matters
 


### PR DESCRIPTION
## Summary

- `invoke_grammar_actions` walks a grammar's finished match tree bottom-up and, for every named capture, unconditionally called `call_method_with_values(actions, rule_name, ...)` — relying on `MethodNotFound` as the "no action for this rule" signal. Most match-tree nodes are low-level helper tokens (e.g. YAMLish's `space`, `single-bare`, `line-break`) that an actions class never defines a method for, so the common case paid the full multi-dispatch resolution walk (`has_proto`/`has_multi_candidates`/`has_multi_function`/`resolve_function_with_types`/`bare_name_packages`, plus a `format!`-built error) just to fail.
- Adds a cheap `has_user_method` pre-check (a direct MRO + HashMap-by-name lookup) so the dispatch call only happens when the actions class (or its `:sym<...>` proto variant) actually declares that method.
- This has to handle a bare type-object actions class (`ValueView::Package`) the same way as an instance (`ValueView::Instance`), since a stateless `:actions(Actions)` grammar action — as used by the bundled YAMLish battery — is commonly passed as the type object itself, not `Actions.new`. Missing that case would make the pre-check a permanent no-op.
- Verified with `perf`: profiling a space-heavy YAMLish block-sequence document (from `todo/tickets/yaml-parse-throughput.md`) showed the dispatch-resolution cluster collapse to a small residual, with total profiled samples for the same input roughly halving. Local wall-clock numbers were not used to judge this (the dev box had 2-3 concurrent release builds running throughout from other sessions) — the `bench-data` CI history is the source of truth for the actual wall-clock win.

## Test plan

- [x] `t/grammar-actions-type-object-sparse.t` (new): bare type-object actions class with methods for only some rules including a `:sym<>` proto variant, verified against `raku` first.
- [x] Full local `t/` suite: 2552 files, 24408 tests, all green.
- [x] All 5 upstream YAMLish test files (`basic`, `test-harness`, `roundtrip`, `p5-tests`, `anchor-alias`) pass.
- [x] Grammar/actions-focused roast whitelist files (`S05-grammar/*`, `S12-meta/grammarhow.t`) pass.
- [x] `cargo fmt` / `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)