### PR TITLE
perf(value): share Match-object .orig via Arc instead of re-cloning per leaf capture

### DIFF
--- a/benchmarks/bench-yaml-parse.raku
+++ b/benchmarks/bench-yaml-parse.raku
@@ -1,0 +1,23 @@
+# YAML-parse benchmark: the bundled YAMLish battery over a block mapping whose
+# values are block sequences of single-quoted scalars with embedded runs of
+# spaces — the shape that exposed two real perf bugs (see
+# todo/tickets/yaml-parse-throughput.md): a regex code-block writeback
+# compared by Debug-formatting the whole env, and every match-tree node
+# (including per-character space/bare-string tokens) paying full multi-dispatch
+# resolution just to find the actions class has no method for it. Both are
+# fixed, but this shape is exactly what a config/data file with padded columns
+# looks like in practice, so it stays as the regression benchmark for this
+# class of bug rather than only the flat `k$_: v$_` micro-case in the ticket.
+use YAMLish;
+
+my $ROWS = 3;
+my $row = '      16G         05C        ';
+my $section = ("  - '" ~ $row ~ "'\n") x $ROWS;
+
+my $text = "---\n"
+    ~ (1..2).map({ "section$_:\n" ~ $section }).join
+    ~ "...\n";
+
+my $doc = load-yaml($text);
+die "parse failed" unless $doc<section1>.elems == $ROWS;
+say "yaml-parse: {$doc.elems} sections, {$doc<section1>.elems} rows each";

--- a/news/2026-07/match-object-orig-arc-share.md
+++ b/news/2026-07/match-object-orig-arc-share.md
@@ -1,0 +1,43 @@
+# Match-object construction shares `.orig` via `Arc` instead of re-cloning the whole document per leaf capture
+
+`Value::make_match_object_full_q` (the Match-object builder behind grammar
+`.parse()`, `~~`, substitution, and `split`) builds one `Match` `Instance` per
+node in a match tree — including a fresh one for every element of a
+quantified capture like `<str=space>*`, so a document with a long run of
+individually-matched characters (e.g. a quoted YAML scalar's embedded spaces)
+can have thousands of leaf `Match` objects for one `.parse()`.
+
+Two of its internal helpers, `make_capture_match` and `make_subcap_match`,
+took `orig: Option<&str>` and, **per leaf capture**, both re-collected the
+entire original string into a fresh `Vec<char>` (to search for the capture's
+position) and re-cloned it into a fresh `String` (for the `.orig` attribute).
+For a leaf-heavy match tree this made one `.parse()` cost O(captures ×
+document length) in redundant allocation and copying, independent of the
+document's actual content.
+
+Both helpers now take a small `OrigCtx` pair — `&Arc<String>` (for `.orig`,
+via `Value::str_arc`, an O(1) refcount bump instead of a fresh allocation) and
+`&[char]` (a borrowed slice of a `Vec<char>` built once) — computed a single
+time per `.parse()`/match at the top of `make_match_object_full_q`, rather
+than re-derived at every leaf.
+
+## A methodology note, since this landed without a clean local measurement
+
+While investigating this fix's actual wall-clock effect, this session found
+eight `sh` processes on the dev box running a busy-loop
+(`while :; do :; done`) continuously since 2026-07-25 — a `sleep 12; kill`
+script whose backgrounded loops never actually died, silently consuming ~6
+cores for 3 days. On this box's hybrid P-core/E-core chip, that contention
+made every local A/B in this session (including round 2's, in the PR just
+before this one) unreliable: a "before" and "after" binary measured
+identically once the spinners were killed and the comparison re-run pinned to
+one core. See `todo/tickets/yaml-parse-throughput.md` for the full account
+and the lesson (`ps --sort=-pcpu` before trusting any local perf number here).
+
+This fix is still landed on its own merits — it is a correct, verified
+reduction in real, measurable-in-principle redundant work (confirmed by
+reading the code, not by a wall-clock delta), and the full `t/` suite (2553
+files, 24412 tests) plus `Match.orig`/position-tracking-specific tests all
+stay green. Its actual size of effect, if any, on real documents will show up
+in `bench-history.tsv` on `bench-data` via the newly-added
+`benchmarks/bench-yaml-parse.raku`, not in this write-up.

--- a/src/value/value_methods_c.rs
+++ b/src/value/value_methods_c.rs
@@ -45,13 +45,22 @@ impl Value {
         orig: Option<&str>,
         named_quantified: &HashSet<String>,
     ) -> Self {
-        fn make_capture_match(s: &str, orig: Option<&str>, search_from: usize) -> Value {
+        // `orig`'s original string (for the `.orig` attribute, shared via Arc
+        // rather than cloned) and its char vector (for the position search
+        // below) are threaded through as a pair rather than re-derived from
+        // `Option<&str>` at every leaf capture — a match tree can have one
+        // such leaf per matched character (e.g. a quoted scalar's run of
+        // space captures), and re-collecting the WHOLE original string into
+        // a fresh `Vec<char>` (and cloning it into a fresh `String`) at each
+        // one made a single `.parse()` cost O(captures × document length).
+        type OrigCtx<'o> = (&'o std::sync::Arc<String>, &'o [char]);
+
+        fn make_capture_match(s: &str, orig_ctx: Option<OrigCtx>, search_from: usize) -> Value {
             let mut attrs = HashMap::new();
             attrs.insert("str".to_string(), Value::str(s.to_string()));
             // Try to find the captured text's position within the original string
-            let (cap_from, cap_to) = if let Some(o) = orig {
+            let (cap_from, cap_to) = if let Some((_, haystack)) = orig_ctx {
                 // Search for the captured substring starting from search_from
-                let haystack: Vec<char> = o.chars().collect();
                 let needle: Vec<char> = s.chars().collect();
                 let mut found_from = 0i64;
                 let mut found = false;
@@ -74,14 +83,17 @@ impl Value {
             attrs.insert("to".to_string(), Value::Int(cap_to));
             attrs.insert("list".to_string(), Value::array(Vec::new()));
             attrs.insert("named".to_string(), Value::hash(HashMap::new()));
-            if let Some(o) = orig {
-                attrs.insert("orig".to_string(), Value::str(o.to_string()));
+            if let Some((o, _)) = orig_ctx {
+                attrs.insert("orig".to_string(), Value::str_arc(std::sync::Arc::clone(o)));
             }
             Value::make_instance(Symbol::intern("Match"), attrs)
         }
 
         /// Build a Match object from a RegexCaptures, recursively handling subcaptures.
-        fn make_subcap_match(caps: &crate::runtime::RegexCaptures, orig: Option<&str>) -> Value {
+        fn make_subcap_match(
+            caps: &crate::runtime::RegexCaptures,
+            orig_ctx: Option<OrigCtx>,
+        ) -> Value {
             let search_start = caps.from;
             let pos_vals: Vec<Value> = caps
                 .positional
@@ -98,7 +110,7 @@ impl Value {
                             .iter()
                             .map(|(text, from, to, subcap)| {
                                 if let Some(sc) = subcap {
-                                    return make_subcap_match(sc, orig);
+                                    return make_subcap_match(sc, orig_ctx);
                                 }
                                 let mut a = HashMap::new();
                                 a.insert("str".to_string(), Value::str(text.clone()));
@@ -106,8 +118,11 @@ impl Value {
                                 a.insert("to".to_string(), Value::Int(*to as i64));
                                 a.insert("list".to_string(), Value::array(Vec::new()));
                                 a.insert("named".to_string(), Value::hash(HashMap::new()));
-                                if let Some(o) = orig {
-                                    a.insert("orig".to_string(), Value::str(o.to_string()));
+                                if let Some((o, _)) = orig_ctx {
+                                    a.insert(
+                                        "orig".to_string(),
+                                        Value::str_arc(std::sync::Arc::clone(o)),
+                                    );
                                 }
                                 Value::make_instance(Symbol::intern("Match"), a)
                             })
@@ -116,9 +131,9 @@ impl Value {
                     }
                     // Recursively build nested Match objects for positional subcaptures
                     if let Some(Some(subcap)) = caps.positional_subcaps.get(i) {
-                        return make_subcap_match(subcap, orig);
+                        return make_subcap_match(subcap, orig_ctx);
                     }
-                    make_capture_match(s, orig, search_start)
+                    make_capture_match(s, orig_ctx, search_start)
                 })
                 .collect();
             let mut sub_named: HashMap<String, Value> = HashMap::new();
@@ -131,9 +146,9 @@ impl Value {
                         if let Some(scs) = subcaps_for_key
                             && let Some(sc) = scs.get(i)
                         {
-                            return make_subcap_match(sc, orig);
+                            return make_subcap_match(sc, orig_ctx);
                         }
-                        make_capture_match(s, orig, search_start)
+                        make_capture_match(s, orig_ctx, search_start)
                     })
                     .collect();
                 if vals.len() == 1 && !caps.named_quantified.contains(key) {
@@ -157,7 +172,7 @@ impl Value {
             for (key, scs) in &caps.named_subcaps {
                 if key.starts_with(crate::runtime::SILENT_ACTION_MARKER_PREFIX) {
                     for sc in scs {
-                        silent_caps_vals.push(make_subcap_match(sc, orig));
+                        silent_caps_vals.push(make_subcap_match(sc, orig_ctx));
                     }
                 }
             }
@@ -173,8 +188,8 @@ impl Value {
                     Value::real_array(silent_caps_vals),
                 );
             }
-            if let Some(o) = orig {
-                attrs.insert("orig".to_string(), Value::str(o.to_string()));
+            if let Some((o, _)) = orig_ctx {
+                attrs.insert("orig".to_string(), Value::str_arc(std::sync::Arc::clone(o)));
             }
             // Store :sym<> variant name so action dispatch can find it
             if let Some(ref sym_val) = caps.sym {
@@ -210,12 +225,20 @@ impl Value {
             Value::make_instance(Symbol::intern("Match"), attrs)
         }
 
+        // Built once per `.parse()` (not per leaf capture, see `OrigCtx` above).
+        let orig_arc = orig.map(|o| std::sync::Arc::new(o.to_string()));
+        let orig_chars_vec: Option<Vec<char>> = orig.map(|o| o.chars().collect());
+        let orig_ctx: Option<OrigCtx> = match (&orig_arc, &orig_chars_vec) {
+            (Some(a), Some(c)) => Some((a, c.as_slice())),
+            _ => None,
+        };
+
         let mut attrs = HashMap::new();
         attrs.insert("str".to_string(), Value::str(matched));
         attrs.insert("from".to_string(), Value::Int(from));
         attrs.insert("to".to_string(), Value::Int(to));
-        if let Some(o) = orig {
-            attrs.insert("orig".to_string(), Value::str(o.to_string()));
+        if let Some((o, _)) = orig_ctx {
+            attrs.insert("orig".to_string(), Value::str_arc(std::sync::Arc::clone(o)));
         }
         let search_start = from as usize;
         let caps: Vec<Value> = positional
@@ -232,7 +255,7 @@ impl Value {
                         .iter()
                         .map(|(text, qfrom, qto, subcap)| {
                             if let Some(sc) = subcap {
-                                return make_subcap_match(sc, orig);
+                                return make_subcap_match(sc, orig_ctx);
                             }
                             let mut a = HashMap::new();
                             a.insert("str".to_string(), Value::str(text.clone()));
@@ -240,8 +263,11 @@ impl Value {
                             a.insert("to".to_string(), Value::Int(*qto as i64));
                             a.insert("list".to_string(), Value::array(Vec::new()));
                             a.insert("named".to_string(), Value::hash(HashMap::new()));
-                            if let Some(o) = orig {
-                                a.insert("orig".to_string(), Value::str(o.to_string()));
+                            if let Some((o, _)) = orig_ctx {
+                                a.insert(
+                                    "orig".to_string(),
+                                    Value::str_arc(std::sync::Arc::clone(o)),
+                                );
                             }
                             Value::make_instance(Symbol::intern("Match"), a)
                         })
@@ -251,9 +277,9 @@ impl Value {
                 // If there are nested subcaptures for this positional capture,
                 // build a full Match object with subcaptures
                 if let Some(Some(subcap)) = positional_subcaps.get(i) {
-                    return make_subcap_match(subcap, orig);
+                    return make_subcap_match(subcap, orig_ctx);
                 }
-                make_capture_match(s, orig, search_start)
+                make_capture_match(s, orig_ctx, search_start)
             })
             .collect();
         attrs.insert("list".to_string(), Value::array(caps));
@@ -267,9 +293,9 @@ impl Value {
                     if let Some(scs) = subcaps_for_key
                         && let Some(sc) = scs.get(i)
                     {
-                        return make_subcap_match(sc, orig);
+                        return make_subcap_match(sc, orig_ctx);
                     }
-                    make_capture_match(s, orig, search_start)
+                    make_capture_match(s, orig_ctx, search_start)
                 })
                 .collect();
             if vals.len() == 1 && !named_quantified.contains(key) {
@@ -293,7 +319,7 @@ impl Value {
         for (key, scs) in named_subcaps {
             if key.starts_with(crate::runtime::SILENT_ACTION_MARKER_PREFIX) {
                 for sc in scs {
-                    silent_caps_vals.push(make_subcap_match(sc, orig));
+                    silent_caps_vals.push(make_subcap_match(sc, orig_ctx));
                 }
             }
         }

--- a/todo/tickets/yaml-parse-throughput.md
+++ b/todo/tickets/yaml-parse-throughput.md
@@ -5,7 +5,9 @@ is **slow**, and the cost is in *matching*, not module load. This is the
 match-time twin of `grammar-heavy-module-load-slower-than-raku.md`; that ticket
 measures `use`, this one measures the parse itself.
 
-**Two rounds of this have already landed.**
+**Three rounds of this have already landed** (see the important measurement
+caveat right after them — most of this session's local A/B numbers turned out
+to be unreliable).
 
 Round 1 (`news/2026-07/regex-code-block-writeback-by-identity.md`):
 `eval_regex_code_block_body` used to snapshot the whole env with
@@ -31,7 +33,71 @@ document showed the dispatch cluster (and its `malloc`/`format!` downstream)
 shrink to a small residual, with total profiled samples for the same input
 roughly halving.
 
-What is below is what remains *after both* fixes.
+Round 3 (`news/2026-07/match-object-orig-arc-share.md`): `make_match_object_full_q`
+(the Match-object builder used by grammar parsing, `~~`, substitution, and
+`split`) re-derived the `.orig` string and the position-search haystack from
+scratch — `orig.chars().collect()` and `orig.to_string()` — inside its
+per-leaf-capture helpers, so a leaf-heavy match tree (again, one leaf per
+matched character in a quoted scalar's space run) re-collected/re-cloned the
+*entire original document* once per leaf. Both are now computed once per
+`.parse()`/match and shared via `Arc` (`Value::str_arc`) and a borrowed
+`&[char]` slice instead. This is a correct, tested, real reduction in
+allocation — but see the measurement caveat below for why its wall-clock
+contribution could not actually be confirmed this session.
+
+## Measurement caveat: a 3-day-old CPU-spinner corrupted this session's local A/B
+
+Partway through round 3, `ps -eo pid,pcpu,comm --sort=-pcpu` turned up eight
+`sh -c 'for i in $(seq 1 8); do (while :; do :; done) & done; sleep 12; kill
+...'` processes (PIDs 694193-694201), each pinned near 73% CPU, running
+continuously since 2026-07-25 — over 2 days. The `sleep 12; kill` clearly
+intended to self-terminate but the backgrounded `while :; do :; done` loops
+outlived it (job-control artifact of a non-interactive shell), leaving ~6
+cores' worth of pure busy-loop competing with everything else on a 12-thread,
+hybrid P-core/E-core (13th Gen i7-1355U) laptop chip for 3 days straight.
+
+This made every local wall-clock and even `perf record` sample-count
+comparison in this session **unreliable**, not just noisy: on a hybrid CPU,
+which core type (fast P-core vs slow E-core) the scheduler assigns a run to
+under contention swings effective speed by 2-4x on its own, independent of
+any code change. Concretely: the "round 2 roughly halves total samples"
+finding cited above (and in its own news entry) was measured under this
+contention and looked like a ~2x win; after killing the spinners and
+re-measuring the SAME two binaries (pre-round-2 vs round-2+3) pinned to one
+core (`taskset -c 0`), both took the same ~17.5s task-clock for
+`basic.rakutest`'s worst subtest, and a plain (unpinned, but now
+spinner-free) comparison on `dump_n9.raku` (the `todo/tickets/...`
+reproduce-script case at n=9) also showed no measurable difference
+(~6.0-6.5s both ways over 3 runs each). Rounds 2 and 3 are still correct,
+safe, tested fixes for real inefficiencies (verified by reading the code and
+by the `perf` self-time cluster disappearing/never reappearing in a **clean**
+profile — see below) — they are just smaller in absolute wall-clock terms
+than this session initially believed, and **not** the dominant cost for this
+document shape.
+
+A clean (spinner-free, `-F 4000` for better sample resolution) `perf record`
+self-time sort of `dump_n9.raku` under the round-2+3 binary shows **no single
+dominant function** — `malloc` leads at under 9%, with `__memcmp_avx2_movbe`/
+`_int_free`/`cfree`/`_int_malloc`/`__memmove_avx_unaligned_erms` close behind
+and a long tail of small (`~1%` or less) mutsu functions. This is "death by a
+thousand small allocations" rather than one fixable call site — consistent
+with, but now actually *confirmed* rather than assumed, item 4 below.
+
+**Lesson for future sessions on this box**: before trusting ANY local A/B
+timing (wall-clock OR `perf` sample counts) here, run `ps -eo
+pid,pcpu,comm --sort=-pcpu | head` and look for anything pinned near a fixed
+high `%CPU` for an implausibly long `TIME`/elapsed — a busy-loop artifact
+looks exactly like that, is easy to miss among normal `cargo`/`rustc` churn,
+and (as demonstrated here) can silently invalidate an entire session's
+"confirmed" perf findings. `taskset -c <core>` reduces (not eliminates)
+remaining variance from thermal/frequency scaling once the machine is
+actually idle.
+
+**A `benchmarks/bench-yaml-parse.raku` file now exists** (this exact
+space-heavy block-sequence shape, sized for CI's `BENCH_TIMEOUT`), so future
+rounds on this ticket get tracked automatically in `bench-history.tsv` on the
+`bench-data` branch — use that history, not a local run, to judge whether a
+future change actually helped.
 
 ## Measurement (2026-07-28, release build, pre-round-2)
 
@@ -127,17 +193,32 @@ The `MUTSU_VM_STATS` counters are useless here: only ~25k opcodes run for a
 3. **Candidate enumeration.** The `_all_` atom enumerations return every end
    position; with a deeply nested indentation grammar the branching multiplies.
    Not yet measured directly — still open.
-4. **Residual `malloc`/`_int_free`/`__memcmp_avx2_movbe` cost.** After round 2,
-   these plain allocator/libc symbols are the largest entries in a `perf`
-   self-time sort of the space-heavy synthetic (no single mutsu function
-   dominates). This is consistent with genuine O(n) `Match`/capture object
-   construction — one per matched space character, since each is its own
-   quantified `<str=space>` capture — rather than a single fixable call site.
-   Reducing it would mean cutting per-attempt allocation in the regex engine's
-   capture-construction path itself (e.g. `make_subcap_match`,
-   `RegexCaptures` cloning in the `Alternation` match-merge loop in
-   `regex_match_atom.rs`), which is a different, deeper investigation than
-   either round so far.
+4. **Residual `malloc`/`_int_free`/`__memcmp_avx2_movbe` cost — confirmed, not
+   just hypothesized, on a clean machine (see the measurement caveat above).**
+   After rounds 2+3, these plain allocator/libc symbols are still the largest
+   entries in a `perf` self-time sort of the space-heavy synthetic, and no
+   single mutsu function stands out (each is ~1% or less). This is genuine
+   O(n) `Match`/capture object construction — one per matched space
+   character, since each is its own quantified `<str=space>` capture, and
+   each such capture builds a fresh `HashMap` (str/from/to/list/named/orig)
+   plus a GC-managed `Instance` via `Value::make_instance`. Reducing this
+   is NOT a single call-site fix like rounds 2/3 — candidates worth
+   investigating, roughly in order of invasiveness:
+   - Avoid building a full `Match` **object** for a quantified list element
+     that is never actually accessed as a `Match` (only `.Str`-ified) — hard
+     to prove safely in general since Raku lets any element be inspected.
+   - Reduce the *shape* of the per-element `HashMap`/`Instance` (e.g. a
+     smaller specialized repr for "leaf capture, no subcaps" instead of the
+     same general Match shape as a top-level richly-nested one).
+   - Look at `RegexCaptures` cloning in the `Alternation` match-merge loop in
+     `regex_match_atom.rs` (`regex_match_ends_from_caps_in_pkg`) — every
+     `<str=single-bare> | <str=single-quotes> | ...` alternative attempt
+     clones `RegexCaptures` (named/positional maps) on each candidate tried,
+     which is itself allocation-heavy per position even before a `Match`
+     object is ever built.
+   This is a different, deeper investigation than any of rounds 1-3 — treat
+   it as its own slice, and validate with `benchmarks/bench-yaml-parse.raku`
+   via `bench-data` (not a local run) once a candidate fix exists.
 
 ## Why it matters
 


### PR DESCRIPTION
## Summary

- `Value::make_match_object_full_q` (Match-object builder for grammar `.parse()`, `~~`, substitution, `split`) re-derived its `.orig` string and position-search haystack from scratch inside per-leaf-capture helpers (`make_capture_match`, `make_subcap_match`): `orig.chars().collect()` and `orig.to_string()`, called once per leaf. A leaf-heavy match tree (one leaf per matched character — e.g. a quoted YAML scalar's run of spaces) made this O(captures × document length) in redundant allocation.
- Both are now computed once per `.parse()`/match and threaded through as a small `OrigCtx` pair — `&Arc<String>` (via `Value::str_arc`, an O(1) refcount bump) and a borrowed `&[char]` slice — instead of re-derived at every leaf.
- Adds `benchmarks/bench-yaml-parse.raku`: a space-heavy YAMLish block-sequence document (the exact shape that exposed this fix and the two prior ones in `todo/tickets/yaml-parse-throughput.md`), so future rounds on that ticket get tracked automatically in `bench-history.tsv` on `bench-data` rather than relying on local measurements.

## A methodology note

While investigating this fix's wall-clock effect, this session found 8 `sh` processes on the dev box running an unbounded busy-loop continuously since 2026-07-25 (a `sleep 12; kill` script whose backgrounded loops never actually died) — ~6 cores of pure contention for 3 days. On this box's hybrid P-core/E-core chip that made every local A/B this session (including the just-merged #5526's) unreliable: a clean re-measurement after killing the spinners showed no difference between the pre-#5526 and post-#5526 binaries. Full account in `todo/tickets/yaml-parse-throughput.md`. This fix still lands on its own merits — a correct, verified reduction in real redundant work — but its actual effect size will show up in `bench-history.tsv`, not in local numbers.

## Test plan

- [x] Full local `t/` suite: 2553 files, 24412 tests, all green (on the now-clean box).
- [x] `Match.orig`/position-tracking-specific tests (`t/match-global-orig.t`, `t/regex-nested-subrule-absolute-offsets.t`).
- [x] `t/yaml-battery.t` and all 5 upstream YAMLish test files.
- [x] `benchmarks/bench-yaml-parse.raku` produces identical output under both `raku` and `mutsu`.
- [x] `cargo fmt` / `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)