### PR TITLE
perf(regex): match subrules in place instead of re-slicing the subject

### DIFF
--- a/docs/adr/0016-span-based-captures-and-lazy-match.md
+++ b/docs/adr/0016-span-based-captures-and-lazy-match.md
@@ -1,0 +1,252 @@
+# ADR-0016: Span-based regex captures and lazily materialized `Match` objects
+
+- **Status**: Proposed (2026-07-28)
+- **Context**: ADR-0001 Phase A (single-thread speed catch-up, before GC/JIT).
+  Direct follow-on to ADR-0007, which removed the *accumulated-state* clone from the
+  matcher and explicitly deferred the remaining "**per-subrule ceremony**" — captured-text
+  `String`s, `Arc<RegexCaptures>` subcap allocations, `RegexCaptures::default` zeroing,
+  one `snapshot()` per complete inner end. This ADR is the decision about how that
+  ceremony is removed.
+- **Ticket**: `todo/tickets/yaml-parse-throughput.md`. Benchmarks:
+  `benchmarks/bench-yaml-parse.raku`, `benchmarks/bench-grammar-parse{,-deep}.raku`.
+
+## Problem
+
+After three targeted fixes (regex code-block writeback by identity, grammar-action
+dispatch pre-check, `.orig` `Arc` sharing) a clean profile of a grammar parse has **no
+single dominant function left**. It is dominated by libc:
+
+| symbol | share |
+|---|---:|
+| `__memcmp_avx2_movbe` | 11.0% |
+| `_int_free` | 7.5% |
+| `malloc` | 5.4% |
+| `_int_malloc` | 5.3% |
+| `__memmove_avx_unaligned_erms` | 5.2% |
+| `cfree` | 2.9% |
+| `realloc` | 2.7% |
+| `malloc_consolidate` | 1.7% |
+| `unlink_chunk` / `__rdl_alloc` | 2.2% |
+
+(`benchmarks/bench-yaml-parse.raku`, `--profile profiling`, `perf -F 4000`, 20 184
+samples, on an idle box — "idle" is load-bearing here; see the measurement caveat in
+`todo/tickets/yaml-parse-throughput.md` for the session whose local A/B numbers a
+3-day-old CPU spinner invalidated. Shares are *shape* evidence, not an A/B claim;
+magnitudes for any fix must come from `bench-history.tsv` on `bench-data`.)
+
+**≈28% allocator + ≈5% bulk memmove + ≈11% memcmp.** That is not a hot function to fix;
+it is a data model that allocates and copies per match step. This ADR names the five
+structural causes and commits to the target representation.
+
+### Cause 1 — the subject string is re-sliced per subrule, so every capture subtree is deep-copied to rebase it
+
+A subrule call matches its body against `&chars[pos..]` with `start = 0`
+(`regex_match_atom.rs:377`, `regex_match_capture.rs:548`). Every offset the body
+produces is therefore **slice-relative**, and the caller rebases the whole result:
+
+```rust
+Self::shift_capture_descendants(&mut subcap, pos);   // regex_match_atom.rs:764
+```
+
+which recurses with `Arc::make_mut(sub)` over every nested named/positional subcapture.
+Those `Arc`s are **already shared** — `record_reduced_subrule` clones each one into the
+`REDUCED_SUBRULES` thread-local at the moment it is built — so `make_mut` is not the
+cheap unshared path: it **deep-clones the entire descendant subtree, at every level of
+nesting, on every candidate**, including candidates that go on to lose. A depth-`d`
+parse copies its capture tree `d` times.
+
+Two more workarounds exist only because of the slicing: `REGEX_PRECEDING_CHAR` (a
+thread-local + RAII guard whose entire job is to tell a slice what character preceded
+it, so `^^` keeps working) and the slice-relative `capture_start`/`capture_end` rebasing.
+Everything the workaround does *not* cover is simply **wrong** under it: `<<`/`>>`/`<?wb>`
+read `chars[pos - 1]`, which is "nothing" at slice position 0, so a word boundary fires
+mid-word; a look-behind inside a subrule cannot see text before the subrule's start; and
+`<at(N)>` means "position N in the current slice" rather than in the subject. All four
+were verified against `raku` and fixed by P1.
+
+### Cause 2 — captures store text, not spans, so positions are recovered by searching
+
+`RegexCaptures::named` is `HashMap<String, Vec<String>>` — a named capture keeps its
+**matched text** and no offsets. So the Match builder searches for the text in the
+subject to recover them (`value_methods_c.rs`, `make_capture_match`):
+
+```rust
+let needle: Vec<char> = s.chars().collect();
+for start in search_from..=haystack.len().saturating_sub(needle.len()) {
+    if haystack[start..start + needle.len()] == needle[..] { ... }
+}
+```
+
+A fresh `Vec<char>` per leaf, and a linear scan that is O(document) when the text does
+not occur near `search_from` — over a leaf-heavy tree (YAMLish produces one leaf per
+matched character in a run of spaces) that is O(captures × document) `memcmp`. It is
+also **semantically wrong**: it finds the first occurrence at or after a heuristic start,
+not the span that actually matched, so repeated text yields wrong `.from`/`.to`.
+
+The positional axis already records exact spans in `positional_offsets` — **and the Match
+builder ignores them and searches anyway.**
+
+A gated experiment (skip the search, keep everything else) moves `__memcmp_avx2_movbe`
+from 11.0% to 6.9% of samples at equal wall clock, so the search is worth ≈4 points on
+its own. The remaining ≈7% is the *other* string comparison in this model: owned `String`
+capture-name keys compared on every `HashMap` probe and trail record (Cause 4). Neither is
+a single fix — which is the point.
+
+The band-aid this grew: `store_apply_named_capture` synthesizes a whole
+`Arc<RegexCaptures>` per named capture *purely as an offset carrier* ("Record a minimal
+sub-capture carrying the exact (from, to) span"), because `named` has nowhere to put two
+integers.
+
+### Cause 3 — one struct plays two roles, so a stored leaf node costs ~600 bytes
+
+`RegexCaptures` is simultaneously
+
+- the engine's **mutable accumulator** for the current pattern run — `code_blocks`,
+  `regex_vars`, `match_from`, `capture_start`/`capture_end`, and the trail's target; and
+- an immutable **stored capture node** — what an `Arc<RegexCaptures>` subcap is.
+
+A stored node needs `from`, `to`, its children, `ast`, `sym`, `action_name`. It gets all
+14 fields: 5 `HashMap`s + 1 `HashSet` + 7 `Vec`s + a `String` ≈ 600 bytes, zeroed by
+`RegexCaptures::default()`, moved by value inside `Vec<(usize, RegexCaptures)>` candidate
+lists, heap-allocated per subcap, and `clone()`d once per complete match (`snapshot()`).
+That is the `memmove` and a large part of the `malloc`/`free`.
+
+### Cause 4 — six parallel vectors per axis
+
+The positional axis is `positional` ‖ `positional_subcaps` ‖ `positional_quantified` ‖
+`positional_offsets` ‖ `positional_nil` ‖ `positional_slots`; the named axis is `named` ‖
+`named_subcaps` ‖ `named_quantified`. Six allocations, six trail-record families, six
+truncate/extend paths per rewind — and manual alignment invariants of the form "pad with
+`false` up to the current `positional` length before pushing `true`". Every capture name
+is stored as an owned `String`, re-allocated per `entry(key.to_string())` and per trail
+record.
+
+### Cause 5 — the `Match` tree is materialized eagerly, in the heaviest possible shape
+
+Every capture — including a leaf that matched one space — becomes a full
+`Value::Instance("Match")`: a `HashMap<String, Value>` of six entries (`str`, `from`,
+`to`, `list`, `named`, `orig`) built with six `String` key allocations, converted to a
+`Symbol`-keyed `AttrMap`, wrapped in a GC-managed `InstanceAttrs`, plus an empty `list`
+array and an empty `named` hash **per leaf**. Nothing is lazy: the entire tree is built
+whether or not user code ever looks at it.
+
+The consumer side then pays for that shape again. `invoke_grammar_actions` walks the
+finished tree and, per node, does `attributes.as_ref().clone()` (full `AttrMap` copy) and
+`named_hash.as_ref().clone()` (full `HashData` copy) to rebuild the node immutably — an
+O(node) copy per node, i.e. O(n²) over the tree, for a walk that in the common case
+changes nothing (ADR round 2 established that most nodes have no action method at all).
+
+## Decision
+
+Adopt the representation NQP/MoarVM uses and that Raku's own semantics assume: **the
+matcher carries spans into one shared, immutable subject; the Raku-level `Match` object is
+materialized lazily and only where it is observed.**
+
+Concretely, the target state is:
+
+1. **Absolute positions everywhere.** The subject is never re-sliced. A subrule is matched
+   against the full `chars` with an explicit start position. Offsets are absolute from
+   birth; nothing is ever rebased.
+2. **One shared subject.** `MatchTarget { text: Arc<String>, chars: Arc<[char]> }`, created
+   once per top-level match/parse and referenced by every node. `.orig` is a refcount bump;
+   any capture's text is `&target.chars[from..to]`, materialized on demand.
+3. **A capture node distinct from the engine's accumulator.** `CapNode` — the immutable
+   stored node: `{ from: u32, to: u32, children: Option<Box<CapChildren>>, ast, sym,
+   action_name }` — split out of `RegexCaptures`, which keeps only the per-run mutable
+   state (`code_blocks`, `regex_vars`, `capture_start`/`capture_end`, `match_from`) and the
+   in-progress children. A leaf `CapNode` is a handful of words, not ~600 bytes.
+4. **One list per axis, spans not text.** `positional: Vec<PosSlot>` and
+   `named: HashMap<Symbol, Vec<Arc<CapNode>>>` replace the six/three parallel collections.
+   The text axis disappears (it is derivable), which is what makes the collapse possible.
+   Capture names are interned `Symbol`s, not re-allocated `String`s.
+5. **Lazy `Match`.** A dedicated `ValueRepr::Match(Gc<MatchNode>)` holding the target, the
+   span, and the `Arc<CapNode>`; `.list`/`.hash`/`.Str` are derived on first access and
+   memoized. A capture nobody inspects costs nothing. The grammar-action walk runs over
+   `CapNode` and materializes a `Match` only for nodes that actually have an action method.
+
+### Non-goals
+
+- No change to the backtracking algorithm. ADR-0007's trail/`CapStore` stays; this ADR
+  changes *what* the trail records, not *how* backtracking works.
+- No change to observable Raku semantics, except where the current model is provably
+  wrong — search-recovered offsets for repeated text, and the four subrule-boundary
+  constructs above — which become correct.
+- Not a compiled-regex VM. That remains the eventual ceiling (ADR-0007's own framing) and
+  is easier to reach on top of this representation, not instead of it.
+
+## Phasing
+
+Each phase is independently shippable, roast-gated, and measured from `bench-history.tsv`
+on the `bench-data` branch — never from a local A/B.
+
+**P1 — Absolute positions.** Pass `(chars, pos)` instead of `(&chars[pos..], 0)` at the two
+subrule call sites; delete `shift_capture_descendants` / `shift_capture_tree` and the
+`Arc::make_mut` subtree deep-copy they exist to perform, and `REGEX_PRECEDING_CHAR` with
+its guard.
+*Why first:* it is the largest single copy source, it is localized (two call sites plus the
+shared `build_named_candidates_from_inner` wrapper), and **spans are meaningless until
+positions are absolute**, so P3 depends on it.
+**Landed 2026-07-28** (`news/2026-07/regex-subrule-absolute-positions.md`): net −104
+lines, and the four subrule-boundary constructs above now agree with `raku`, pinned by
+`t/regex-subrule-absolute-position.t`.
+
+**P2 — `CapNode` / `RegexCaptures` split.** Extract the immutable stored-node fields into
+`CapNode`; `Arc<CapNode>` replaces `Arc<RegexCaptures>` in both subcap axes. Shrinks the
+per-subcap allocation by roughly an order of magnitude and takes the `Vec<(usize,
+RegexCaptures)>` candidate-list memmove with it.
+
+**P3 — Spans, not text.** Introduce `MatchTarget`; `CapNode` carries `(from, to)` only.
+Delete `chars[a..b].iter().collect()` at capture sites, the `captured.clone()` duplicates,
+and `make_capture_match`'s search entirely — the Match builder reads the recorded span.
+Fixes the repeated-text offset bug.
+
+**P4 — One list per axis + interned names.** Collapse the parallel vectors/maps into
+`Vec<PosSlot>` and `HashMap<Symbol, Vec<Arc<CapNode>>>`, and shrink the trail's undo
+vocabulary accordingly (the alignment invariants become structural rather than asserted in
+comments).
+
+**P5 — Lazy `Match`.** First a pure refactor: funnel the ~34 `class_name == "Match"`
+consumer sites through accessor helpers (`match_str` / `match_span` / `match_list` /
+`match_named`) with no behavior change. Then swap the representation behind them to
+`ValueRepr::Match(Gc<MatchNode>)` with `OnceCell`-memoized derived views, and rewrite
+`invoke_grammar_actions` to walk `CapNode` and materialize only where `has_user_method`
+already says an action exists — which removes the per-node `AttrMap`/`HashData` clone as
+a side effect.
+
+## Consequences
+
+- **Gain** (per CLAUDE.md's definition — moving toward the correct architecture): the
+  per-match-step allocation and copying are removed *structurally*, not shaved. There is no
+  per-capture text copy to regress, no subtree to rebase, no offset to re-derive by
+  searching, and no `Match` object for a node nobody reads. Five real compatibility bugs
+  are fixed on the way (the four subrule-boundary constructs, plus search-recovered
+  offsets for repeated text). The representation is also the one a future compiled-regex VM and JIT
+  want (spans + a shared subject + a lazy user-facing object).
+- **Risk**: high blast radius across `src/runtime/regex/` (~10k lines) and, in P5, across
+  the ~34 `Match`-consuming sites. The semantics surface is wide (capture markers
+  `<( )>`, silent-action channel, aliases, `@<>`/`%<>` sigil captures, `$N=`, LTM / `||` /
+  `&`, ratchet, frugal, separated `%`/`%%`, code blocks, backrefs, left recursion). The
+  mitigation is the standing one: CI's roast S05/S12 suites plus the `t/` grammar/match
+  suite, land per phase on a branch, fix forward. A temporary red CI on a feature branch is
+  not a risk (CLAUDE.md, "Refactor boldly").
+- **Rejected alternatives**:
+  - *Keep the eager `Instance` tree, just build the `AttrMap` directly with pre-interned
+    `Symbol`s.* A real but shallow win (six `String` allocations per leaf) that leaves every
+    structural cause in place and entrenches the eager tree. Fold it into P5 instead of
+    shipping it as the answer.
+  - *Add a parallel `named_offsets` map so the builder can stop searching.* Fixes the
+    symptom by adding a seventh parallel collection — the exact anti-pattern P4 exists to
+    remove.
+  - *Persistent/immutable capture structures (HAMT) instead of the trail.* Already rejected
+    in ADR-0007 and unchanged here: worse constant factor for the small maps involved.
+  - *Jump straight to a compiled-regex VM.* Larger than this ADR and strictly easier on top
+    of it; the representation is the prerequisite, not the competitor.
+
+## References
+
+- ADR-0007 (trail matcher) — the immediate predecessor; its "residual per-subrule ceremony"
+  paragraph is the problem this ADR solves.
+- ADR-0001 — phase order: this is Phase A work, not blocked on GC or Track B.
+- `todo/tickets/yaml-parse-throughput.md` — measurements and the three landed rounds.
+- `news/2026-07/match-object-orig-arc-share.md`, `.../regex-code-block-writeback-by-identity.md`,
+  `.../grammar-actions-skip-dispatch-for-missing-methods.md`.

--- a/news/2026-07/regex-subrule-absolute-positions.md
+++ b/news/2026-07/regex-subrule-absolute-positions.md
@@ -1,0 +1,56 @@
+# Regex subrules match the whole subject in place instead of a re-slice
+
+`docs/adr/0016-span-based-captures-and-lazy-match.md` phase 1.
+
+Until now a subrule call (`<foo>`) matched its body against `&chars[pos..]` with
+`start = 0`. Every offset the body produced was therefore *slice-relative*, and the
+caller rebased the whole result afterwards with `shift_capture_descendants`, which
+recurses through the capture tree calling `Arc::make_mut` on each nested subcapture.
+Those `Arc`s are never unshared — `record_reduced_subrule` clones each one into the
+`REDUCED_SUBRULES` thread-local the moment it is built — so `make_mut` took the
+copy-on-write path every time: **each subrule call deep-copied its entire descendant
+capture subtree, at every level of nesting, for every candidate tried, including the
+ones that went on to lose.** A depth-`d` parse copied its capture tree `d` times.
+
+Subrules now match against the whole `chars` starting at `pos`. Offsets are absolute
+from birth, so nothing is rebased: `shift_capture_tree` / `shift_capture_descendants`
+are gone, and with them the deep copy. `REGEX_PRECEDING_CHAR` — a thread-local plus
+RAII guard whose only job was to tell a slice which character preceded it — is gone
+too, along with the `pos + inner_end` / `pos + capture_start` arithmetic at the two
+subrule call sites. Net −104 lines.
+
+## Four constructs were wrong, and now are not
+
+The re-slice did not just cost copies; it hid the text before the subrule from anything
+that looks backwards. Verified against `raku`, all four previously disagreed with it:
+
+| grammar | raku | mutsu before | mutsu now |
+|---|---|---|---|
+| `token TOP { 'ab' <t> }` / `token t { << \w+ }` on `abcd` | no match | **match** | no match |
+| `token t { <?after 'ab'> \w+ }` on `abcd` | match | **no match** | match |
+| `token t { <!after 'ab'> \w+ }` on `abcd` | no match | **match** | no match |
+| `token t { <at(2)> \w+ }` on `abcd` | match | **no match** | match |
+
+`<<` / `>>` / `<?wb>` read `chars[pos - 1]`, which at slice-position 0 is "nothing", so
+a word boundary fired in the middle of a word; look-behind could not see behind the
+subrule's start at all; `<at(N)>` meant "position N *in the slice*". `^^` was the one
+case that already worked, and only because of the `REGEX_PRECEDING_CHAR` workaround.
+Pinned by `t/regex-subrule-absolute-position.t` (9 subtests, green under `raku` too).
+
+`<{ ... }>` closure interpolation and the cursor-method path (`regex_token_method.rs`)
+now see the full subject as well, which is what `.orig` and a cursor's coordinates are
+supposed to be.
+
+## Why this shape
+
+A clean profile of `benchmarks/bench-yaml-parse.raku` after the previous three rounds
+has no dominant function left: ≈28% allocator (`malloc`/`_int_malloc`/`_int_free`/
+`cfree`/`realloc`/`malloc_consolidate`), 11% `memcmp`, 5% `memmove`. That is a data
+model that allocates and copies per match step, not a hot call site — so ADR-0016
+commits to the representation NQP/MoarVM uses (spans into one shared subject, a lazily
+materialized `Match`) and phases it. This is P1, the phase the rest depends on: a span
+means nothing until positions are absolute.
+
+Measure from `bench-history.tsv` on the `bench-data` branch, not a local A/B — see the
+ADR and `todo/tickets/yaml-parse-throughput.md` for why local numbers on the dev box
+were not trustworthy in the previous rounds.

--- a/src/runtime/regex/regex_helpers.rs
+++ b/src/runtime/regex/regex_helpers.rs
@@ -37,15 +37,6 @@ thread_local! {
     /// probe wants the longest prefix the pattern's declarative skeleton accepts, so
     /// both kinds of code atom simply become no-ops.
     pub(crate) static CODE_ATOMS_INERT: Cell<bool> = const { Cell::new(false) };
-    /// The character immediately preceding the start of the text currently being
-    /// matched. A subrule (`<foo>`) is matched against a *slice* `chars[pos..]`
-    /// in a fresh sub-interpreter, so position 0 of that slice is not necessarily
-    /// the start of a line in the original text. Look-behind anchors (`^^`, `^`)
-    /// consult this to decide whether slice-position 0 is a real line/string
-    /// start: `None` means it truly is the start of the parse text, `Some(c)`
-    /// means `c` was the char just before the slice. Saved/restored around each
-    /// subrule dispatch so nesting threads correctly.
-    pub(crate) static REGEX_PRECEDING_CHAR: Cell<Option<char>> = const { Cell::new(None) };
     /// Parse-scoped overlay of `$*` dynamic-variable values written by grammar
     /// action methods that run at *reduce time* (during matching). The regex
     /// match engine is `&self`, so an action's dyn-var write (e.g.
@@ -402,17 +393,6 @@ impl Drop for RegexDynvarOverlayGuard {
     fn drop(&mut self) {
         REGEX_DYNVAR_OVERLAY.with(|slot| *slot.borrow_mut() = self.prev_overlay.take());
         REGEX_GRAMMAR_DYNVAR_SEEN.with(|c| c.set(self.prev_seen));
-    }
-}
-
-/// Restores `REGEX_PRECEDING_CHAR` to a saved value when dropped, so a subrule
-/// dispatch can publish the slice's preceding char for the duration of the match
-/// and have it restored on every exit path (including early returns).
-pub(crate) struct RegexPrecedingCharGuard(pub(crate) Option<char>);
-
-impl Drop for RegexPrecedingCharGuard {
-    fn drop(&mut self) {
-        REGEX_PRECEDING_CHAR.with(|c| c.set(self.0));
     }
 }
 

--- a/src/runtime/regex/regex_match_atom.rs
+++ b/src/runtime/regex/regex_match_atom.rs
@@ -372,25 +372,16 @@ impl Interpreter {
                 return result;
             }
             if !candidates.is_empty() {
-                // Borrow the remaining text — a `.to_vec()` copy here cost
-                // O(remaining) per subrule reference (O(n^2) over a parse).
-                let tail = &chars[pos..];
-                // The subrule candidates match `tail` (a slice from `pos`) at
-                // position 0, so publish the char before the slice for look-behind
-                // anchors (`^^`). At `pos == 0` inherit the current value (this
-                // slice may itself be a nested subrule's tail). Restored on every
-                // exit path by the guard.
-                let saved_prev = super::regex_helpers::REGEX_PRECEDING_CHAR.with(|c| c.get());
-                let slice_prev = if pos > 0 {
-                    Some(chars[pos - 1])
-                } else {
-                    saved_prev
-                };
-                super::regex_helpers::REGEX_PRECEDING_CHAR.with(|c| c.set(slice_prev));
-                let _restore_prev = super::regex_helpers::RegexPrecedingCharGuard(saved_prev);
+                // The subrule body is matched against the WHOLE subject starting
+                // at `pos` (ADR-0016 P1), not against a `&chars[pos..]` re-slice.
+                // Every offset it produces is therefore already absolute, so
+                // nothing has to be rebased afterwards — the old re-slice forced
+                // a deep copy of the entire descendant capture subtree at every
+                // nesting level — and look-behind/`<<`/`^^`/`<at(N)>` see the real
+                // text before the subrule instead of a slice boundary.
 
                 // Left-recursion detection using (name+args, remaining_chars_count)
-                // as key. remaining = chars.len() - pos = tail.len().
+                // as key. remaining = chars.len() - pos.
                 // When rule r calls <&r> recursively at the same position, both calls
                 // will have the same remaining count, allowing us to detect and break
                 // the left-recursion cycle. The argument values are part of the rule
@@ -407,7 +398,7 @@ impl Interpreter {
                     }
                     n
                 };
-                let lr_key = (lr_name, tail.len());
+                let lr_key = (lr_name, chars.len() - pos);
 
                 // Check if this call is currently active (left recursion detected).
                 let is_active = LR_ACTIVE.with(|a| a.borrow().contains_key(&lr_key));
@@ -416,7 +407,8 @@ impl Interpreter {
                     // its own seed, so the owner must keep growing it.
                     LR_SEED_READ.with(|s| s.borrow_mut().insert(lr_key.clone()));
                     // Return the current seed for this (name, position).
-                    // The seed is stored in HIGHEST FIRST order (raw inner positions relative to tail).
+                    // The seed is stored in HIGHEST FIRST order (raw inner
+                    // matches, absolute positions).
                     let seed =
                         LR_MEMO.with(|m| m.borrow().get(&lr_key).cloned().unwrap_or_default());
                     // Wrap seed into outer captures. build_named_candidates_from_inner
@@ -431,8 +423,8 @@ impl Interpreter {
 
                 // Not currently active: run the growing-seed algorithm.
                 //
-                // Seed storage: raw (un-wrapped) inner matches in HIGHEST FIRST order,
-                // with positions relative to `tail` (0-based from pos).
+                // Seed storage: raw (un-wrapped) inner matches in HIGHEST FIRST
+                // order, with absolute positions.
                 // When is_active branch reads the seed, it passes them to
                 // build_named_candidates_from_inner which adds the outer wrapping.
                 //
@@ -460,7 +452,7 @@ impl Interpreter {
                             has_proto = true;
                         }
                         let all_matches =
-                            self.regex_match_ends_from_caps_in_pkg(parsed, tail, 0, sub_pkg);
+                            self.regex_match_ends_from_caps_in_pkg(parsed, chars, pos, sub_pkg);
                         // all_matches: HIGHEST FIRST.
                         let matches_to_use: Vec<_> = if sym_key.is_some() {
                             all_matches.into_iter().take(1).collect()
@@ -671,59 +663,9 @@ impl Interpreter {
         }
     }
 
-    /// Shift every offset in a capture subtree by `delta`, including this node's
-    /// own `from`/`to`. Used when re-rooting an inner match (matched against a
-    /// `&chars[pos..]` slice, so its offsets are slice-relative) into the parent's
-    /// absolute coordinate system.
-    pub(super) fn shift_capture_tree(caps: &mut RegexCaptures, delta: usize) {
-        if delta == 0 {
-            return;
-        }
-        caps.from += delta;
-        caps.to += delta;
-        Self::shift_capture_descendants(caps, delta);
-    }
-
-    /// Shift the offsets of a capture node's descendants (its own positional
-    /// captures and every nested named/positional subcapture) by `delta`, WITHOUT
-    /// touching this node's own `from`/`to`. `build_named_candidates_from_inner`
-    /// sets the wrapper node's `from`/`to` explicitly (respecting `<( )>` capture
-    /// markers), then calls this so the slice-relative child offsets become
-    /// absolute — matching Rakudo, whose `.from`/`.to` are always absolute to the
-    /// original string even for a subrule matched deep inside a repetition.
-    pub(super) fn shift_capture_descendants(caps: &mut RegexCaptures, delta: usize) {
-        if delta == 0 {
-            return;
-        }
-        for (f, t) in caps.positional_offsets.iter_mut() {
-            *f += delta;
-            *t += delta;
-        }
-        for slot in caps.positional_slots.iter_mut().flatten() {
-            slot.1 += delta;
-            slot.2 += delta;
-        }
-        for entry in caps
-            .positional_quantified
-            .iter_mut()
-            .flatten()
-            .flat_map(|list| list.iter_mut())
-        {
-            entry.1 += delta;
-            entry.2 += delta;
-            if let Some(nested) = entry.3.as_mut() {
-                Self::shift_capture_tree(std::sync::Arc::make_mut(nested), delta);
-            }
-        }
-        for sub in caps.named_subcaps.values_mut().flat_map(|v| v.iter_mut()) {
-            Self::shift_capture_tree(std::sync::Arc::make_mut(sub), delta);
-        }
-        for sub in caps.positional_subcaps.iter_mut().flatten() {
-            Self::shift_capture_tree(std::sync::Arc::make_mut(sub), delta);
-        }
-    }
-
-    /// Build named regex candidates from inner match results (positions relative to tail).
+    /// Build named regex candidates from inner match results. Inner positions are
+    /// already absolute (ADR-0016 P1: the subrule body was matched against the whole
+    /// subject starting at `pos`, not a re-slice), so nothing is rebased here.
     /// Wraps each inner match in the appropriate capture structure for the named regex call.
     /// `pos` is the position of the named atom in `chars`. Each candidate is a
     /// capture DELTA relative to an empty baseline (ADR-0007).
@@ -735,8 +677,7 @@ impl Interpreter {
         sym_key: Option<&String>,
     ) -> Vec<(usize, RegexCaptures)> {
         let mut out = Vec::new();
-        for (inner_end, inner_caps) in inner_matches {
-            let end = pos + inner_end;
+        for (end, inner_caps) in inner_matches {
             let mut new_caps = RegexCaptures::default();
             let capture_name = spec
                 .capture_name
@@ -745,23 +686,15 @@ impl Interpreter {
             if let Some(capture_name) = capture_name {
                 // Apply the subrule's own capture markers (`<(` / `)>`): a token
                 // like `token foo { 12345 <( 67890 }` restricts its `<foo>`
-                // submatch to `67890`. The subrule body is matched against the
-                // tail starting at `pos`, so its `capture_start`/`capture_end` are
-                // tail-relative (0-based); rebase them by `pos`. They are `None`
-                // when the subrule used no markers, so this is a no-op otherwise.
-                let inner_len = end - pos;
-                let cs = (pos + inner_caps.capture_start.unwrap_or(0)).clamp(pos, end);
-                let ce = (pos + inner_caps.capture_end.unwrap_or(inner_len)).clamp(cs, end);
+                // submatch to `67890`. They are already absolute, and `None` when
+                // the subrule used no markers, so this is a no-op otherwise.
+                let cs = inner_caps.capture_start.unwrap_or(pos).clamp(pos, end);
+                let ce = inner_caps.capture_end.unwrap_or(end).clamp(cs, end);
                 let captured: String = chars[cs..ce].iter().collect();
                 let mut subcap = inner_caps;
                 subcap.matched = captured.clone();
                 subcap.from = cs;
                 subcap.to = ce;
-                // The subrule body was matched against `&chars[pos..]`, so every
-                // descendant offset (its own $0/$1 positional captures and any
-                // nested subrule captures) is slice-relative. Rebase them by `pos`
-                // so `.from`/`.to` are absolute like Rakudo's.
-                Self::shift_capture_descendants(&mut subcap, pos);
                 // sym is already set on subcap from raw_out collection loop.
                 // Fall back to sym_key parameter for the is_active (seed) path.
                 if subcap.sym.is_none() && sym_key.is_some() {
@@ -834,16 +767,13 @@ impl Interpreter {
                 // `.hash`; the grammar action walk recurses into them. This replaces
                 // the older "flatten direct children into the parent" hack, which
                 // lost the rule's own action and over-exposed children in `.hash`.
-                let inner_len = end - pos;
-                let cs = (pos + inner_caps.capture_start.unwrap_or(0)).clamp(pos, end);
-                let ce = (pos + inner_caps.capture_end.unwrap_or(inner_len)).clamp(cs, end);
+                let cs = inner_caps.capture_start.unwrap_or(pos).clamp(pos, end);
+                let ce = inner_caps.capture_end.unwrap_or(end).clamp(cs, end);
                 let captured: String = chars[cs..ce].iter().collect();
                 let mut subcap = inner_caps;
                 subcap.matched = captured;
                 subcap.from = cs;
                 subcap.to = ce;
-                // Rebase slice-relative descendant offsets to absolute (see above).
-                Self::shift_capture_descendants(&mut subcap, pos);
                 if subcap.sym.is_none() && sym_key.is_some() {
                     subcap.sym = sym_key.cloned();
                 }

--- a/src/runtime/regex/regex_match_atom_simple.rs
+++ b/src/runtime/regex/regex_match_atom_simple.rs
@@ -256,16 +256,11 @@ impl Interpreter {
                 };
             }
             RegexAtom::StartOfLine => {
-                // The char immediately before `pos`. At slice-position 0 this is
-                // not necessarily the start of the original parse text: a subrule
-                // is matched against `chars[pos..]` in a sub-interpreter, so
-                // consult `REGEX_PRECEDING_CHAR` (the char before this slice). It
-                // is `None` only at the true start of the parse text.
-                let prev = if pos > 0 {
-                    Some(chars[pos - 1])
-                } else {
-                    super::regex_helpers::REGEX_PRECEDING_CHAR.with(|c| c.get())
-                };
+                // The char immediately before `pos`. `chars` is always the whole
+                // subject (ADR-0016 P1 — subrules are matched in place, not
+                // against a re-slice), so `pos == 0` really is the start of the
+                // parse text.
+                let prev = if pos > 0 { Some(chars[pos - 1]) } else { None };
                 let Some(prev) = prev else {
                     // True start of the parse text — a line start.
                     return Some(pos);

--- a/src/runtime/regex/regex_match_capture.rs
+++ b/src/runtime/regex/regex_match_capture.rs
@@ -539,31 +539,19 @@ impl Interpreter {
             };
             // Resolve + parse the candidates once (memoized for the
             // argument-less common case). Patterns are matched in place with
-            // `self` against the `&chars[pos..]` borrow — the previous
-            // implementation built a fresh scratch sub-interpreter (plus a
-            // tail-text `String`) per candidate per call, which dominated
-            // nested-grammar matching.
+            // `self` against the whole `chars` starting at `pos` (ADR-0016 P1) —
+            // an earlier implementation built a fresh scratch sub-interpreter
+            // (plus a tail-text `String`) per candidate per call, and the one
+            // after that re-sliced to `&chars[pos..]`, which made every inner
+            // offset slice-relative and forced a deep rebase of the whole
+            // capture subtree afterwards.
             let (candidates, _raw_empty) = self.parsed_subrule_candidates(&spec, pkg, &arg_values);
             if !candidates.is_empty() {
-                let tail = &chars[pos..];
-                // The subrule matches a slice starting at `pos`, where
-                // slice-position 0 is not the original text start. Publish the
-                // char before the slice so look-behind anchors (`^^`) in the
-                // subrule see the real context. At `pos == 0` inherit the
-                // current value (this slice may itself be a nested subrule).
-                let saved_prev = super::regex_helpers::REGEX_PRECEDING_CHAR.with(|c| c.get());
-                let slice_prev = if pos > 0 {
-                    Some(chars[pos - 1])
-                } else {
-                    saved_prev
-                };
-                super::regex_helpers::REGEX_PRECEDING_CHAR.with(|c| c.set(slice_prev));
-                let _restore_prev = super::regex_helpers::RegexPrecedingCharGuard(saved_prev);
                 let mut best: Option<(usize, RegexCaptures)> = None;
                 let mut best_sym: Option<String> = None;
                 for (parsed, sub_pkg, sym_key) in candidates.iter() {
                     if let Some((inner_end, inner_caps)) =
-                        self.regex_match_end_from_caps_in_pkg(parsed, tail, 0, sub_pkg)
+                        self.regex_match_end_from_caps_in_pkg(parsed, chars, pos, sub_pkg)
                     {
                         let better = best
                             .as_ref()
@@ -571,7 +559,7 @@ impl Interpreter {
                             .unwrap_or(true);
                         if better {
                             let mut inner_caps = inner_caps;
-                            inner_caps.from = 0;
+                            inner_caps.from = pos;
                             inner_caps.to = inner_end;
                             best = Some((inner_end, inner_caps));
                             best_sym = sym_key.clone();

--- a/src/runtime/regex/regex_token_method.rs
+++ b/src/runtime/regex/regex_token_method.rs
@@ -104,18 +104,20 @@ impl Interpreter {
         let Some(parsed) = self.parse_regex(&pattern) else {
             return Ok(Value::NIL);
         };
-        let tail_chars: Vec<char> = tail.chars().collect();
-        let matches = self.regex_match_ends_from_caps_in_pkg(&parsed, &tail_chars, 0, pkg);
+        // Matched against the whole subject from `pos` (ADR-0016 P1), so the
+        // captures this publishes are already in absolute coordinates.
+        let all_chars: Vec<char> = text.chars().collect();
+        let matches = self.regex_match_ends_from_caps_in_pkg(&parsed, &all_chars, pos, pkg);
         // Matches come HIGHEST FIRST: the first entry is the token's best
         // (ratcheted) match, which is what a cursor method call returns.
-        let Some((end_rel, caps)) = matches.into_iter().next() else {
+        let Some((end, caps)) = matches.into_iter().next() else {
             return Ok(Value::NIL);
         };
-        let matched: String = tail_chars[..end_rel].iter().collect();
+        let matched: String = all_chars[pos..end].iter().collect();
         let m = Value::make_match_object_full_q(
             matched,
             pos as i64,
-            (pos + end_rel) as i64,
+            end as i64,
             &caps.positional,
             &caps.named,
             &caps.named_subcaps,
@@ -130,7 +132,7 @@ impl Interpreter {
                 pkg: pkg.to_string(),
                 name: name.to_string(),
                 from: pos,
-                to: pos + end_rel,
+                to: end,
                 caps,
             });
         });
@@ -255,13 +257,14 @@ impl Interpreter {
             }
             _ => RegexCaptures {
                 matched: chars[pos..to_abs].iter().collect(),
-                to: to_abs - pos,
+                from: pos,
+                to: to_abs,
                 ..RegexCaptures::default()
             },
         };
         let sym = inner_caps.sym.clone();
         Some(Self::build_named_candidates_from_inner(
-            vec![(to_abs - pos, inner_caps)],
+            vec![(to_abs, inner_caps)],
             pos,
             chars,
             spec,

--- a/t/regex-subrule-absolute-position.t
+++ b/t/regex-subrule-absolute-position.t
@@ -1,0 +1,69 @@
+use Test;
+
+# A subrule body is matched against the WHOLE subject starting at the subrule's
+# position, not against a `chars[pos..]` re-slice (ADR-0016 P1). Constructs that
+# look at the text *before* the current position must therefore see the real
+# preceding text, not a slice boundary. Before this, a subrule started a fresh
+# coordinate system at its own start, so `<<` wrongly fired mid-word and
+# look-behind wrongly saw "nothing before me".
+
+plan 9;
+
+grammar LeftWb {
+    token TOP { 'ab' <t> }
+    token t { << \w+ }
+}
+nok LeftWb.parse('abcd'), '<< inside a subrule does not fire after a word char';
+
+grammar LeftWbOk {
+    token TOP { 'ab ' <t> }
+    token t { << \w+ }
+}
+ok LeftWbOk.parse('ab cd'), '<< inside a subrule still fires after a space';
+
+grammar After {
+    token TOP { 'ab' <t> }
+    token t { <?after 'ab'> \w+ }
+}
+ok After.parse('abcd'), '<?after> inside a subrule sees text before the subrule';
+
+grammar NotAfter {
+    token TOP { 'ab' <t> }
+    token t { <!after 'ab'> \w+ }
+}
+nok NotAfter.parse('abcd'), '<!after> inside a subrule sees text before the subrule';
+
+grammar RightWb {
+    token TOP { 'ab' <t> 'cd' }
+    token t { >> \w+ }
+}
+nok RightWb.parse('abxxcd'), '>> inside a subrule does not fire mid-word';
+
+# `^^` (start of line) used to work only via a thread-local carrying the char
+# before the slice; keep it pinned now that the workaround is gone.
+grammar Bol {
+    token TOP { \n <ln> }
+    token ln { ^^ \w+ }
+}
+ok Bol.parse("\nabc"), '^^ inside a subrule matches right after a newline';
+
+grammar NotBol {
+    token TOP { 'x' <ln> }
+    token ln { ^^ \w+ }
+}
+nok NotBol.parse('xabc'), '^^ inside a subrule does not match mid-line';
+
+grammar AtPos {
+    token TOP { 'ab' <t> }
+    token t { <at(2)> \w+ }
+}
+ok AtPos.parse('abcd'), '<at(N)> inside a subrule is a position in the whole subject';
+
+# Absolute offsets on the produced Match node (unchanged behaviour, pinned
+# because it is what the removed rebase used to establish by deep-copying).
+grammar Span {
+    token TOP { 'xx' <part> }
+    token part { \w+ }
+}
+is Span.parse('xxyy')<part>.from ~ '..' ~ Span.parse('xxyy')<part>.to, '2..4',
+    'a subrule Match keeps absolute .from/.to';

--- a/todo/tickets/yaml-parse-throughput.md
+++ b/todo/tickets/yaml-parse-throughput.md
@@ -220,6 +220,30 @@ The `MUTSU_VM_STATS` counters are useless here: only ~25k opcodes run for a
    it as its own slice, and validate with `benchmarks/bench-yaml-parse.raku`
    via `bench-data` (not a local run) once a candidate fix exists.
 
+   **Done (2026-07-28): that investigation produced
+   `docs/adr/0016-span-based-captures-and-lazy-match.md`.** It names five
+   structural causes and commits to spans-into-a-shared-subject plus a lazily
+   materialized `Match`, phased P1-P5. Two findings correct the guesses above:
+   - The biggest copy source was not the `Alternation` merge loop (that path
+     already `drain`s rather than clones, post-ADR-0007). It was the **subrule
+     re-slice**: matching a subrule body against `&chars[pos..]` made every inner
+     offset slice-relative, and the rebase (`shift_capture_descendants`) went
+     through `Arc::make_mut` on `Arc`s that `record_reduced_subrule` had already
+     shared — so every subrule call deep-copied its whole descendant subtree, at
+     every nesting level, for every candidate. **P1 removed it** (see
+     `news/2026-07/regex-subrule-absolute-positions.md`), and fixed three
+     look-behind/word-boundary compatibility bugs on the way.
+   - The 11% `__memcmp_avx2_movbe` is two things, not one. A gated experiment
+     (skip the leaf-capture position search, change nothing else) moved it to
+     6.9% at equal wall clock: ≈4 points are the Match builder recovering leaf
+     offsets by **searching the subject for the captured text** (it does this even
+     for positional captures, whose exact spans are already recorded in
+     `positional_offsets` and simply ignored — ADR-0016 P3). The remaining ≈7% is
+     owned `String` capture-name keys compared on every `HashMap` probe and trail
+     record (P4: intern them as `Symbol`).
+
+   Remaining phases are tracked in the ADR, not here.
+
 ## Why it matters
 
 A bundled battery is loaded and *used* on every run of a program that needs it.


### PR DESCRIPTION
Phase 1 of **ADR-0016** (`docs/adr/0016-span-based-captures-and-lazy-match.md`, added here), the follow-on to ADR-0007's explicitly-deferred "per-subrule ceremony".

## The problem this removes

A subrule call (`<foo>`) matched its body against `&chars[pos..]` with `start = 0`, so every offset the body produced was *slice-relative* and the caller rebased the whole result with `shift_capture_descendants`. That recurses with `Arc::make_mut` over every nested subcapture — and those `Arc`s are **never** unshared, because `record_reduced_subrule` clones each one into the `REDUCED_SUBRULES` thread-local the moment it is built. So `make_mut` always took the copy-on-write path: **every subrule call deep-copied its entire descendant capture subtree, at every nesting level, for every candidate tried, losers included.** A depth-`d` parse copied its capture tree `d` times.

Subrules now match the whole `chars` starting at `pos`. Offsets are absolute from birth, nothing is rebased, and `shift_capture_tree` / `shift_capture_descendants` / `REGEX_PRECEDING_CHAR` (a thread-local + RAII guard whose only job was to tell a slice what character preceded it) are all deleted. Net **−104 lines** of engine code.

## Four compatibility bugs fixed

The re-slice also hid the text before a subrule from anything that looks backwards. All four verified against `raku`:

| grammar (`token TOP { 'ab' <t> }`) | raku | before | now |
|---|---|---|---|
| `token t { << \w+ }` on `abcd` | no match | **match** | no match |
| `token t { <?after 'ab'> \w+ }` on `abcd` | match | **no match** | match |
| `token t { <!after 'ab'> \w+ }` on `abcd` | no match | **match** | no match |
| `token t { <at(2)> \w+ }` on `abcd` | match | **no match** | match |

`<<`/`>>`/`<?wb>` read `chars[pos - 1]`, which is "nothing" at slice position 0, so a word boundary fired mid-word; look-behind could not see behind the subrule's start; `<at(N)>` meant "position N *in the slice*". `^^` was the only one that already worked, and only via the `REGEX_PRECEDING_CHAR` workaround this deletes. Pinned by `t/regex-subrule-absolute-position.t` (9 subtests, green under `raku` too).

## Why an ADR

After the previous three rounds, a clean profile of `benchmarks/bench-yaml-parse.raku` has **no dominant function left**: ≈28% allocator, 11% `memcmp`, 5% `memmove`. That is a data model that allocates and copies per match step, not a hot call site. ADR-0016 names the five structural causes and commits to the representation NQP/MoarVM uses — spans into one shared subject, a lazily materialized `Match` — phased P1–P5. P1 is the phase the rest depends on: a span means nothing until positions are absolute.

Speed is deliberately **not** claimed here from a local A/B; `benchmarks/bench-yaml-parse.raku` is already tracked in `bench-history.tsv` on `bench-data`, which is where the number for this should come from.

## Verification

- `make test` — 2553 files / 24412 tests, PASS (plus the new pin file, run separately, 9/9).
- `make roast` **locally** (this is a wide regex change, so it gets the local full run): 1435 files / **218774 tests, Result: PASS**.
- `t/yaml-battery.t` green; `cargo clippy -- -D warnings` and `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)