### PR TITLE
docs(adr): record ADR-0016 P1's bench-CI result and the actions-parse hypothesis

### DIFF
--- a/docs/adr/0016-span-based-captures-and-lazy-match.md
+++ b/docs/adr/0016-span-based-captures-and-lazy-match.md
@@ -190,10 +190,45 @@ positions are absolute**, so P3 depends on it.
 lines, and the four subrule-boundary constructs above now agree with `raku`, pinned by
 `t/regex-subrule-absolute-position.t`.
 
+*Measured (bench CI, `bench-history.tsv` on `bench-data`, `afc3475e2` vs the two
+preceding main commits).* Raw medians are not comparable — runner speed swung ~18%
+between the two pre-P1 runs, and P1's runner was the slow one (`int-arith` +38%,
+`mandelbrot` +41%, neither of which this change can touch). Normalizing each benchmark
+by `int-arith` on its own runner makes the two pre-P1 points agree to within 1–3%, so
+the ratio is usable:
+
+| benchmark (÷ `int-arith`) | `0eb479d9` | `17af2292` | `afc3475e` (P1) |
+|---|---:|---:|---:|
+| `bench-grammar-parse` | 0.370 | 0.369 | **0.301** |
+| `bench-grammar-parse-deep` | 0.311 | 0.320 | **0.250** |
+| `bench-yaml-parse` | 117.4 | 116.9 | **121.5** |
+
+So ≈−20% on both grammar benchmarks and ≈+4% on the YAML one. **Hypothesis for the
+split, to be confirmed at the start of P2:** `REDUCED_SUBRULES` is only armed for a
+`.parse(:actions(...))`. The grammar benchmarks pass no actions, so their subcap `Arc`s
+were unshared and the old rebase's `Arc::make_mut` was already in-place — P1 saves them
+the whole O(subtree) walk. YAMLish's `load-yaml` *does* pass actions, so its nodes stay
+shared with the log; the deep copy P1 removed from the rebase may simply have **moved**
+to `reduce_regex_captures_made_for_rule`, which does `Arc::make_mut(sc)` on every child
+and now takes the copy-on-write path where the (already-copied) node used to be
+unshared. If so the fix is structural, not a tweak: a stored node must be immutable, with
+`ast`/`made` attached without cloning it — which is P2's job.
+
+(`bench-yaml-parse` was checked to be a valid instrument for match time: `use YAMLish`
+alone is 0.04 s of its ~4.07 s, so it is not module-load dominated.)
+
 **P2 — `CapNode` / `RegexCaptures` split.** Extract the immutable stored-node fields into
-`CapNode`; `Arc<CapNode>` replaces `Arc<RegexCaptures>` in both subcap axes. Shrinks the
-per-subcap allocation by roughly an order of magnitude and takes the `Vec<(usize,
-RegexCaptures)>` candidate-list memmove with it.
+`CapNode`; `Arc<CapNode>` replaces `Arc<RegexCaptures>` in both subcap axes. A *leaf* node
+collapses its child collections to a single `None` (`children: Option<Box<CapChildren>>`),
+which is where the order-of-magnitude shrink comes from; it also takes the
+`Vec<(usize, RegexCaptures)>` candidate-list memmove with it.
+**Start by confirming P1's `bench-yaml-parse` hypothesis above**, because it constrains
+the design: every remaining `Arc::make_mut` on a *stored* node
+(`reduce_regex_captures_made_for_rule`, the `action_name` write in
+`build_named_candidates_from_inner`) is a deep copy whenever the reduce log holds the
+node. A `CapNode` that is genuinely immutable — with `ast`/`made` and `action_name`
+attached out-of-band (a side table keyed by node identity, or interior mutability via
+`OnceCell`) rather than written through the `Arc` — removes that class outright.
 
 **P3 — Spans, not text.** Introduce `MatchTarget`; `CapNode` carries `(from, to)` only.
 Delete `chars[a..b].iter().collect()` at capture sites, the `captured.clone()` duplicates,

--- a/news/2026-07/regex-subrule-absolute-positions.md
+++ b/news/2026-07/regex-subrule-absolute-positions.md
@@ -51,6 +51,26 @@ commits to the representation NQP/MoarVM uses (spans into one shared subject, a 
 materialized `Match`) and phases it. This is P1, the phase the rest depends on: a span
 means nothing until positions are absolute.
 
-Measure from `bench-history.tsv` on the `bench-data` branch, not a local A/B — see the
-ADR and `todo/tickets/yaml-parse-throughput.md` for why local numbers on the dev box
-were not trustworthy in the previous rounds.
+## What the bench CI says
+
+Raw medians are not comparable across runs — runner speed swung ~18% between the two
+pre-P1 main commits, and P1's runner was the slow one (`int-arith` +38%, `mandelbrot`
++41%, neither touched by this change). Normalizing each benchmark by `int-arith` on its
+own runner makes the two pre-P1 points agree to within 1–3%:
+
+| benchmark (÷ `int-arith`) | `0eb479d9` | `17af2292` | `afc3475e` (this) |
+|---|---:|---:|---:|
+| `bench-grammar-parse` | 0.370 | 0.369 | **0.301** |
+| `bench-grammar-parse-deep` | 0.311 | 0.320 | **0.250** |
+| `bench-yaml-parse` | 117.4 | 116.9 | **121.5** |
+
+≈−20% on both grammar benchmarks, ≈+4% on the YAML one. The likely reason for the split
+is recorded in ADR-0016's P2 entry and is the first thing that phase must confirm:
+`REDUCED_SUBRULES` is armed only for `.parse(:actions(...))`, which YAMLish uses and the
+grammar benchmarks do not — so for the actions case the deep copy this change removed
+from the rebase may simply have moved to `reduce_regex_captures_made_for_rule`, whose
+`Arc::make_mut(sc)` now takes the copy-on-write path on nodes the log holds.
+
+Numbers come from `bench-history.tsv` on the `bench-data` branch, not a local A/B — see
+`todo/tickets/yaml-parse-throughput.md` for why local numbers on the dev box were not
+trustworthy in the previous rounds.


### PR DESCRIPTION
Follow-up to #5529 — docs only, no code.

The bench CI has run on the P1 commit. The headline medians look like a regression, and they are not: **runner speed swung ~18% between the two pre-P1 main runs, and P1's runner was the slow one** — `int-arith` +38%, `mandelbrot` +41%, neither of which a regex change can touch. Normalizing each benchmark by `int-arith` on its own runner makes the two pre-P1 points agree to within 1–3%, which is what makes the ratio usable:

| benchmark (÷ `int-arith`) | `0eb479d9` | `17af2292` | `afc3475e` (P1) |
|---|---:|---:|---:|
| `bench-grammar-parse` | 0.370 | 0.369 | **0.301** |
| `bench-grammar-parse-deep` | 0.311 | 0.320 | **0.250** |
| `bench-yaml-parse` | 117.4 | 116.9 | **121.5** |

≈−20% on both grammar benchmarks, ≈+4% on the YAML one.

## The hypothesis for the split (P2's first task)

`REDUCED_SUBRULES` is armed **only** for a `.parse(:actions(...))` (`methods_grammar.rs:312`). The grammar benchmarks pass no actions, so their subcap `Arc`s were never shared with the log — the rebase P1 deleted was already an in-place `make_mut`, and P1 saves them the whole O(subtree) walk. YAMLish's `load-yaml` *does* pass actions, so its nodes stay shared, and the deep copy P1 removed from the rebase may simply have **moved** to `reduce_regex_captures_made_for_rule`, which does `Arc::make_mut(sc)` on every child and now takes the copy-on-write path where the freshly-rebased (unshared) node used to be.

That is a mechanism I can point at in the code, not a measured cause — so it is recorded as the thing P2 confirms first, and it constrains P2's design: if it holds, the fix is that a stored node must be genuinely immutable, with `ast`/`made` and `action_name` attached out-of-band rather than written through the `Arc`.

Also records that `bench-yaml-parse` is a valid instrument for match time — `use YAMLish` alone is 0.04 s of its ~4.07 s, so it is not module-load dominated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)