### PR TITLE
fix(nativecall): native signatures follow constant type aliases

### DIFF
--- a/news/2026-07/native-signatures-follow-constant-type-aliases.md
+++ b/news/2026-07/native-signatures-follow-constant-type-aliases.md
@@ -1,0 +1,40 @@
+# Native signatures follow `constant` type aliases
+
+A C binding routinely spells its platform types as constants.
+`DBDish::mysql::Native` opens with
+
+```raku
+constant my_bool = int8;
+```
+
+and returns `my_bool` from most of the `MYSQL_STMT` surface —
+`mysql_stmt_free_result`, `mysql_stmt_reset`, `mysql_stmt_close`,
+`mysql_stmt_bind_result`.
+
+mutsu mapped a signature's type name straight to a C type, so `my_bool` was
+unmappable. That path is not an error: an unmarshallable type deliberately
+*skips* native registration so the failure surfaces at the call rather than as
+a silently mis-marshalled argument. What actually surfaced was misleading — the
+declaration kept its stub `{ * }` body, so the method was simply not there:
+
+```
+No such method 'mysql_stmt_free_result' for invocant of type 'MYSQL_STMT'
+```
+
+even though `MYSQL_STMT.^can('mysql_stmt_free_result')` said yes, and the
+sibling methods that return `int32` worked. Declared in a single file rather
+than a module the same declaration got far enough to return the `int8` type
+object instead of the C result.
+
+Registration now follows the alias to the type it names (bounded to a short
+chain) before mapping, for parameters, return types and `CArray[T]` element
+types alike. The constant holds the aliased *type object*, so the name is read
+back out of the environment.
+
+This was the blocker immediately after
+[`self` became lexical in blocks](self-is-lexical-in-blocks.md): with both,
+mutsu runs a prepared `INSERT` against MariaDB and reaches result fetching.
+
+Pinned by `t/nativecall-constant-type-alias.t` (libc only, so CI-safe), which
+covers an aliased return type on a native method, an aliased parameter on a
+plain sub, and a two-link alias chain.

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -424,12 +424,16 @@ impl Interpreter {
             let Some(tc) = pd.type_constraint.as_deref() else {
                 return Ok(());
             };
+            // `constant my_bool = int8;` — follow the alias to the type it names.
+            let resolved_tc = self.resolve_native_type_alias(tc);
+            let tc = resolved_tc.as_str();
             let is_rw = pd.traits.iter().any(|t| t == "rw");
             // `CArray[T]` — a contiguous C buffer whose element type T is
             // marshalled per-element. Unrecognized element types skip native
             // registration (so the failure surfaces clearly).
             if let Some(inner) = tc.strip_prefix("CArray[").and_then(|s| s.strip_suffix(']')) {
-                let Some(elem) = CType::from_type_name(inner) else {
+                let inner = self.resolve_native_type_alias(inner);
+                let Some(elem) = CType::from_type_name(&inner) else {
                     return Ok(());
                 };
                 params.push(ParamSpec {
@@ -480,7 +484,7 @@ impl Interpreter {
             // A returned `CArray[T]` has no length to reify into a Raku array,
             // so it is surfaced as the raw `Pointer` it carries.
             Some(rt) if rt.starts_with("CArray[") => CType::Pointer,
-            Some(rt) => match CType::from_type_name(rt) {
+            Some(rt) => match CType::from_type_name(&self.resolve_native_type_alias(rt)) {
                 Some(ct) => ct,
                 // A CStruct return (opaque native handle): wrap the returned
                 // pointer in an instance of the declared class so it round-trips
@@ -554,6 +558,39 @@ impl Interpreter {
     /// `SSL_METHOD`), matching how the class is registered by its short name.
     fn native_struct_class_name(name: &str) -> String {
         name.rsplit("::").next().unwrap_or(name).to_string()
+    }
+
+    /// Follow a `constant` type alias to the type it names.
+    ///
+    /// A C binding routinely spells its platform types as constants:
+    /// `DBDish::mysql::Native` declares `constant my_bool = int8;` and returns
+    /// `my_bool` from most of the `MYSQL_STMT` surface. The constant holds the
+    /// aliased *type object*, so read it back out of the environment and use
+    /// its name. Without this the signature type is unmappable and the whole
+    /// declaration silently skips native registration — the method then stays
+    /// the stub `{ * }` body and the call fails with "No such method".
+    ///
+    /// Bounded: an alias chain longer than a few links is treated as no alias.
+    fn resolve_native_type_alias(&self, name: &str) -> String {
+        use crate::runtime::nativecall::CType;
+        let mut current = name.to_string();
+        for _ in 0..4 {
+            if CType::from_type_name(&current).is_some() {
+                return current;
+            }
+            let Some(value) = self.get_env_with_main_alias(&current) else {
+                break;
+            };
+            let ValueView::Package(target) = value.view() else {
+                break;
+            };
+            let target = target.as_str().to_string();
+            if target == current {
+                break;
+            }
+            current = target;
+        }
+        current
     }
 
     pub(super) fn exec_register_token_op(

--- a/t/lib/NCTypeAliasMod.rakumod
+++ b/t/lib/NCTypeAliasMod.rakumod
@@ -1,0 +1,24 @@
+use NativeCall;
+unit module NCTypeAliasMod;
+
+# A C binding routinely spells its platform types as constants:
+# `DBDish::mysql::Native` declares `constant my_bool = int8;` and returns
+# `my_bool` from most of its `MYSQL_STMT` surface. The alias must be followed to
+# the type it names, or the declaration cannot be marshalled and silently skips
+# native registration — leaving the stub `{ * }` body behind. Uses libc only
+# (CI-safe).
+
+constant my_bool = int8;
+constant my_size = size_t;
+constant my_alias_chain = my_size;
+
+class Mem is export is repr('CPointer') {
+    method malloc_usable_size(::?CLASS:D: --> my_size) is native { * }
+    #| glibc's free() returns void; declared through an aliased integer return
+    #| type purely to exercise the alias, exactly as DBDish does.
+    method free(::?CLASS:D: --> my_bool) is native { * }
+}
+
+sub alloc(my_alias_chain $n --> Mem) is native is symbol('malloc') is export { * }
+
+sub memcmp(Str, Str, my_alias_chain --> int32) is native is export { * }

--- a/t/nativecall-constant-type-alias.t
+++ b/t/nativecall-constant-type-alias.t
@@ -1,0 +1,20 @@
+use Test;
+use lib 't/lib';
+use NCTypeAliasMod;
+
+# `constant my_bool = int8;` must be followed to the type it names when a
+# native signature uses it. Before this, an aliased parameter/return type was
+# unmappable, the whole declaration skipped native registration, and the call
+# hit the stub `{ * }` body: "No such method 'free' for invocant of type 'Mem'".
+
+plan 6;
+
+my $m = alloc(64);
+ok $m.defined, 'a native sub with an aliased (chained) parameter type is callable';
+ok $m.malloc_usable_size >= 64, 'an aliased return type marshals the C result';
+isa-ok $m.malloc_usable_size, Int, 'the aliased return type yields a value, not a type object';
+
+lives-ok { $m.free }, 'a native method with an aliased return type is registered';
+
+is memcmp('abc', 'abc', 3), 0, 'an aliased parameter type on a plain sub marshals';
+ok memcmp('abc', 'abd', 3) != 0, 'and it really passes the length through';


### PR DESCRIPTION
## What

A C binding routinely spells its platform types as constants. `DBDish::mysql::Native` opens with

```raku
constant my_bool = int8;
```

and returns `my_bool` from most of the `MYSQL_STMT` surface — `mysql_stmt_free_result`, `mysql_stmt_reset`, `mysql_stmt_close`, `mysql_stmt_bind_result`.

mutsu mapped a signature's type name straight to a C type, so `my_bool` was unmappable. That path is not an error: an unmarshallable type deliberately *skips* native registration so the failure surfaces at the call rather than as a silently mis-marshalled argument. What surfaced was misleading — the declaration kept its stub `{ * }` body, so the method simply was not there:

```
No such method 'mysql_stmt_free_result' for invocant of type 'MYSQL_STMT'
```

even though `MYSQL_STMT.^can('mysql_stmt_free_result')` said yes, and the sibling methods that return `int32` worked. Declared in a single file rather than a module, the same declaration got far enough to return the `int8` **type object** instead of the C result.

## How

`resolve_native_type_alias` follows the alias to the type it names (bounded to a short chain — the constant holds the aliased *type object*, so the name is read back out of the environment), applied to parameters, return types and `CArray[T]` element types alike.

## Why it matters

This was the blocker immediately after #5535: with both, mutsu runs a prepared `INSERT` against MariaDB and reaches result fetching.

## Tests

`t/nativecall-constant-type-alias.t` + `t/lib/NCTypeAliasMod.rakumod` — libc only, so CI-safe. Covers an aliased return type on a native method, an aliased parameter on a plain sub, and a two-link alias chain. All 6 assertions match `raku`.

Local `make test`: 2560 files, 24483 tests, PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)