### PR TITLE
fix(nativecall): Pointer[T].deref tags the handle with T's registered name

### DIFF
--- a/news/2026-07/pointer-deref-tags-the-registered-class-name.md
+++ b/news/2026-07/pointer-deref-tags-the-registered-class-name.md
@@ -1,0 +1,40 @@
+# `Pointer[T].deref` tags the handle with T's registered name
+
+`nativecast(T, $addr)` was taught to tag the handle it returns with the class's
+**registered** name — a CStruct declared inside a module registers as `M::BB`,
+and a handle carrying the short `BB` matches neither its own class for method
+resolution nor raku's `.^name`. The sibling path, `Pointer[T].deref`, kept
+shortening.
+
+That is exactly the spelling `NativeHelpers::Blob` uses to reach MoarVM's array
+body:
+
+```raku
+sub BODY_OF(Mu \any) is export {
+    my \type = %known-bodies{any.REPR};
+    nativecast(Pointer[type], OBJECT_BODY(any)).deref;
+}
+```
+
+`%known-bodies<VMArray>` is `MoarVM::Guts::REPRs`' lexical `MVMArrayB`, whose
+hand-written `realstart` was therefore unreachable:
+
+```
+No such method 'realstart' for invocant of type 'MVMArrayB'
+```
+
+while `MVMArrayB.^can('realstart')` said yes and the *generated* accessors
+(`.elems`, `.start`, `.any`) all worked — they have a short-name fallback, which
+is why nothing looked wrong until a hand-written method was called.
+
+`try_pointer_method` now resolves the target through `cstruct_class_name`, the
+same registry lookup `nativecast` uses, falling back to the short name only when
+the class is not registered.
+
+Found while walking `DBIish` towards a real MariaDB query: with this,
+`DBDish::mysql`'s `prepare` gets past its parameter-binding setup.
+
+Pinned by `t/nativecall-deref-registered-name.t` (libc only, so CI-safe), which
+runs the same three assertions over `Pointer[T].deref` with the type taken from
+a hash, `Pointer[T].deref` with a literal type, and `nativecast(T, …)` as the
+control.

--- a/src/runtime/cstruct_layout.rs
+++ b/src/runtime/cstruct_layout.rs
@@ -733,9 +733,20 @@ impl crate::runtime::Interpreter {
             )));
         };
         if self.is_cstruct_class(&of) || self.is_native_handle_class(&of) {
-            let short = of.rsplit("::").next().unwrap_or(&of);
+            // Tag with the class's **registered** name, exactly as `nativecast`
+            // does (see `try_nativecast`): a CStruct declared inside a module is
+            // registered as `M::BB`, and a handle carrying the short `BB`
+            // resolves neither its own class's hand-written methods nor raku's
+            // `.^name`. `NativeHelpers::Blob` reaches its `MVMArrayB` through
+            // `nativecast(Pointer[type], …).deref`, so `.realstart` was
+            // unreachable on this path even after the `nativecast` path was
+            // fixed — only the *generated* accessors worked, via their
+            // short-name fallback.
+            let tag = self
+                .cstruct_class_name(&of)
+                .unwrap_or_else(|| of.rsplit("::").next().unwrap_or(&of).to_string());
             return Some(Ok(crate::runtime::nativecall::make_native_handle(
-                short, addr,
+                &tag, addr,
             )));
         }
         Some(match self.native_carray_element(&of, addr, 0) {

--- a/t/lib/NCDerefTagMod.rakumod
+++ b/t/lib/NCDerefTagMod.rakumod
@@ -1,0 +1,35 @@
+use NativeCall;
+unit module NCDerefTagMod;
+
+# `NativeHelpers::Blob` reaches MoarVM's array body through
+# `nativecast(Pointer[type], OBJECT_BODY(any)).deref`, where the target class is
+# a lexical CStruct inside a module and comes out of a hash at runtime. The
+# handle that comes back must carry the class's *registered* name, or its
+# hand-written methods are unreachable (only the generated accessors resolve,
+# via their short-name fallback). Uses libc only (CI-safe).
+
+my class LexBody is repr('CStruct') {
+    has uint64 $.a;
+    has uint64 $.b;
+    method sum(::?CLASS:D:) { $!a + $!b }
+}
+
+my %known = (body => LexBody);
+
+sub calloc(size_t, size_t --> Pointer) is native { * }
+
+#| The NativeHelpers::Blob shape: target class from a hash, cast via Pointer[T].
+sub deref-body(--> Mu) is export {
+    my \type = %known<body>;
+    nativecast(Pointer[type], calloc(1, 32)).deref;
+}
+
+#| Same, with the type written literally.
+sub deref-body-literal(--> Mu) is export {
+    nativecast(Pointer[LexBody], calloc(1, 32)).deref;
+}
+
+#| The already-working `nativecast(T, …)` spelling, kept as the control.
+sub cast-body(--> Mu) is export {
+    nativecast(LexBody, calloc(1, 32));
+}

--- a/t/nativecall-deref-registered-name.t
+++ b/t/nativecall-deref-registered-name.t
@@ -1,0 +1,17 @@
+use Test;
+use lib 't/lib';
+use NCDerefTagMod;
+
+# A handle produced by `Pointer[T].deref` must carry T's registered name, the
+# same as one produced by `nativecast(T, …)`. Tagged with the short name it
+# resolved neither its own class's hand-written methods nor raku's `.^name`.
+
+plan 9;
+
+for (deref-body(), 'Pointer[T].deref (type from a hash)'),
+    (deref-body-literal(), 'Pointer[T].deref (literal type)'),
+    (cast-body(), 'nativecast(T, ...)') -> ($handle, $label) {
+    is $handle.^name, 'NCDerefTagMod::LexBody', "$label: .^name is the registered name";
+    is $handle.a, 0, "$label: a generated accessor reads the struct";
+    is $handle.sum, 0, "$label: a hand-written method resolves";
+}


### PR DESCRIPTION
## What

`nativecast(T, $addr)` already tags the handle it returns with the class's **registered** name — a CStruct declared inside a module registers as `M::BB`, and a handle carrying the short `BB` matches neither its own class for method resolution nor raku's `.^name`. The sibling path, `Pointer[T].deref`, kept shortening.

That is exactly the spelling `NativeHelpers::Blob` uses to reach MoarVM's array body:

```raku
sub BODY_OF(Mu \any) is export {
    my \type = %known-bodies{any.REPR};
    nativecast(Pointer[type], OBJECT_BODY(any)).deref;
}
```

`%known-bodies<VMArray>` is `MoarVM::Guts::REPRs`' lexical `MVMArrayB`, whose hand-written `realstart` was therefore unreachable:

```
No such method 'realstart' for invocant of type 'MVMArrayB'
```

while `MVMArrayB.^can('realstart')` said yes and the *generated* accessors (`.elems`, `.start`, `.any`) all worked — they have a short-name fallback, which is why nothing looked wrong until a hand-written method was called.

## How

`try_pointer_method` resolves the target through `cstruct_class_name`, the same registry lookup `nativecast` uses, falling back to the short name only when the class is not registered.

## Why it matters

Found while walking `DBIish` towards a real MariaDB query (after #5535 and #5536): with this, `DBDish::mysql`'s `prepare` gets past its parameter-binding setup.

## Tests

`t/nativecall-deref-registered-name.t` + `t/lib/NCDerefTagMod.rakumod` — libc only, so CI-safe. Runs the same three assertions (registered `.^name`, a generated accessor, a hand-written method) over `Pointer[T].deref` with the type taken from a hash, `Pointer[T].deref` with a literal type, and `nativecast(T, …)` as the control. All 9 match `raku`.

Local `make test`: 2561 files, 24502 tests, PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)