### PR TITLE
fix(roles): punning a role no longer runs the role's own `new`

### DIFF
--- a/news/2026-07/role-pun-does-not-run-the-roles-own-new.md
+++ b/news/2026-07/role-pun-does-not-run-the-roles-own-new.md
@@ -1,0 +1,44 @@
+# Punning a role no longer runs the role's own `new`
+
+Calling a method on a role type object puns the role into a class and runs the
+method there. mutsu punned by *constructing*: it called `dispatch_new` on the
+role and dispatched to the resulting instance — which means it called the role's
+own `new`, **with no arguments**.
+
+A role whose `new` takes a required parameter therefore lost the arguments of
+every *other* method called on the pun:
+
+```raku
+role C {
+    method new(Int $size) { self.bless }
+    method other(Int $size) { "other:$size" }
+}
+say C.other(3);   # was: Too few positionals passed; expected 1 argument but got 0
+```
+
+`NativeHelpers::CStruct`'s `LinearArray[::T]` is exactly that shape — a
+parameterised role with `method new(::?CLASS:U: Int $size)` and an
+`@!cache handles <AT-POS elems shape>` delegation — so `LinearArray[MYSQL_BIND]`
+could not be measured or indexed at all:
+
+```
+No such method 'elems' for invocant of type 'NativeHelpers::CStruct::LinearArray'
+```
+
+That is where `DBDish::mysql`'s `prepare` sets up its parameter binds.
+
+A role that declares its own `new` now puns to a class and re-dispatches on that
+class's **type object**, which is what raku does in every case. Punning
+registers a class under the same name, so the retry falls through to ordinary
+class dispatch rather than re-entering the role branch; the parameterised branch
+goes through `ensure_parametric_role_pun_class` the same way.
+
+Roles that do *not* declare `new` still pun by constructing. Finishing the job —
+so that reading an instance attribute through a pun errors like raku instead of
+inventing a value — needs two more fixes, both found by
+`roast/S13-overloading/typecasting-long.t` and recorded with their repro in
+[`todo/tickets/role-pun-should-not-construct.md`](../../todo/tickets/role-pun-should-not-construct.md):
+a composed role's methods get copied into the pun twice, and a *type object*
+does not match a `::?ROLE:U:` invocant constraint the way an instance does.
+
+Pinned by `t/role-pun-dispatches-on-type-object.t`.

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -2682,9 +2682,44 @@ impl Interpreter {
                         role.methods.contains_key(method) || is_public_attr_accessor
                     })
                     .unwrap_or(false);
+                // Punning by *constructing* runs the role's own `new` with no
+                // arguments. A role whose `new` takes a required parameter
+                // therefore lost the arguments of every *other* method called
+                // on the pun — `LinearArray[T].elems` died with "Too few
+                // positionals passed" (NativeHelpers::CStruct):
+                //
+                //     role C {
+                //         method new(Int $size) { self.bless }
+                //         method other(Int $size) { "other:$size" }
+                //     }
+                //     C.other(3);
+                //
+                // raku puns onto the class's *type object* and never constructs
+                // at all. Do that here for a role that declares its own `new`,
+                // where constructing cannot work. (Switching the no-`new` case
+                // over too is the correct end state but not yet sound: the
+                // punned class ends up with a consumed role's multi candidates
+                // twice — see todo/tickets/role-pun-should-not-construct.md.)
+                //
+                // Punning registers a class under the same name, so the retry
+                // falls through to ordinary class dispatch rather than
+                // re-entering here.
+                let role_declares_new = self
+                    .registry()
+                    .roles
+                    .get(&role_name.resolve())
+                    .is_some_and(|role| role.methods.contains_key("new"));
                 if should_dispatch {
-                    let instance = self.dispatch_new(target.clone(), Vec::new())?;
-                    return self.call_method_with_values(instance, method, args);
+                    if !role_declares_new {
+                        let instance = self.dispatch_new(target.clone(), Vec::new())?;
+                        return self.call_method_with_values(instance, method, args);
+                    }
+                    // Already punned: fall through to ordinary class dispatch,
+                    // which is what makes the retry below terminate.
+                    if !self.registry().classes.contains_key(&role_name.resolve()) {
+                        self.ensure_role_punned_to_class(&role_name.resolve());
+                        return self.call_method_with_values(target.clone(), method, args);
+                    }
                 }
             } else if let ValueView::ParametricRole {
                 base_name,
@@ -2699,6 +2734,20 @@ impl Interpreter {
                         .iter()
                         .any(|(attr_name, is_public, ..)| *is_public && attr_name == method);
                 if role.methods.contains_key(method) || is_public_attr_accessor {
+                    // Same as the unparameterised branch above: a role that
+                    // declares its own `new` cannot be punned by constructing,
+                    // so run the method on the punned class's type object.
+                    let base = base_name.resolve();
+                    if role.methods.contains_key("new")
+                        && let Some(punned) =
+                            self.ensure_parametric_role_pun_class(&base, type_args)
+                    {
+                        return self.call_method_with_values(
+                            Value::package(Symbol::intern(&punned)),
+                            method,
+                            args,
+                        );
+                    }
                     let instance = self.dispatch_new(target.clone(), Vec::new())?;
                     return self.call_method_with_values(instance, method, args);
                 }

--- a/t/role-pun-dispatches-on-type-object.t
+++ b/t/role-pun-dispatches-on-type-object.t
@@ -1,0 +1,44 @@
+use Test;
+
+plan 8;
+
+# Punning a role by *constructing* an instance runs the role's own `new` with
+# no arguments. A role whose `new` takes a required parameter therefore lost
+# the arguments of every *other* method called on the pun. raku puns onto the
+# class's type object and never constructs at all.
+
+role Plain {
+    method new(Int $size) { self.bless }
+    method other(Int $size) { "other:$size" }
+    method no-args() { 'no-args' }
+}
+
+is Plain.other(3), 'other:3',
+    'a role with a required-argument `new` still passes arguments to its other methods';
+is Plain.no-args, 'no-args', 'and to its no-argument methods';
+is Plain.other(4), 'other:4', 'and again once the role has been punned';
+
+role Param[::T] {
+    method new(Int $size) { self.bless }
+    method other(Int $size) { "other:{$size}:{T.^name}" }
+}
+
+is Param[Int].other(3), 'other:3:Int',
+    'the same holds for a parameterised role pun';
+
+# A role that does not declare its own `new` keeps working.
+role NoNew {
+    method other(Int $size) { "plain:$size" }
+}
+is NoNew.other(3), 'plain:3', 'a role without a custom `new` still dispatches';
+
+# `.new` on a role still builds an instance through the role's own constructor.
+role WithNew {
+    has Int $.size;
+    method new(Int $size) { self.bless(:$size) }
+    method describe() { 'described' }
+}
+my $built = WithNew.new(7);
+ok $built.defined, '.new on a role still constructs';
+is $built.size, 7, 'and it runs the role-provided constructor';
+is $built.describe, 'described', 'the instance dispatches role methods too';

--- a/todo/tickets/role-pun-should-not-construct.md
+++ b/todo/tickets/role-pun-should-not-construct.md
@@ -1,0 +1,61 @@
+# A role pun should never construct an instance
+
+Calling a method on a role type object puns the role into a class and runs the
+method on that class's **type object**. mutsu puns by *constructing*: it calls
+`dispatch_new` on the role and dispatches to the resulting instance
+(`methods_call_dispatch.rs`, the "Role type-object method punning" block).
+
+The observable divergence:
+
+```raku
+role C { has $.x = 5; method get { $!x } }
+say C.get;
+# raku:  Cannot look up attributes in a C type object. Did you forget a '.new'?
+# mutsu: 5
+```
+
+The half of this that broke real code — a role that declares its own `new` lost
+the arguments of every *other* method called on the pun, because punning called
+that `new` with none — is fixed
+([news](../../news/2026-07/role-pun-does-not-run-the-roles-own-new.md)). Only
+roles that declare `new` take the type-object path; everything else still puns
+by constructing.
+
+## What blocks finishing it
+
+Switching the no-`new` case over as well fails
+`roast/S13-overloading/typecasting-long.t` (the `rakudo#4094` block at the end),
+in two successive ways:
+
+1. **Duplicated candidates.** `my role R04 does R01 { }` — composition already
+   copies R01's methods into R04's own table, and
+   `ensure_role_punned_to_class` (`registration_class_augment.rs`) then extends
+   them again from `role_parents`. `R04.()` reports four matching `CALL-ME`
+   signatures for R01's two multis. Making that extend an
+   `or_insert_with` fixes the duplication.
+
+2. **Type-object matching ignores composed roles.** With the duplication gone,
+   `R04.()` becomes "No such method 'CALL-ME' for invocant of type 'R04'":
+   R01's candidates are `multi method CALL-ME(::?ROLE:U:)`, i.e. their invocant
+   is constrained to `R01:U`, and an `R04` *type object* does not match it. An
+   `R04` *instance* does, which is why the constructing pun worked. So the
+   remaining work is in the acceptance check for a `Package` value against a
+   role constraint — `class_composed_roles` is consulted for the distance
+   ranking (`dispatch_candidates.rs`) but not, apparently, for the match itself.
+
+Both are worth fixing on their own; together they should let the pun always
+dispatch on the type object, at which point the `role_declares_new` special case
+in `methods_call_dispatch.rs` can go away and reading an instance attribute
+through a pun can start erroring like raku.
+
+## Repro
+
+```raku
+my role R01 {
+    multi method CALL-ME(::?ROLE:U:) { 'no-arg' }
+    multi method CALL-ME(::?ROLE:U: \v) { 'arg:' ~ v }
+}
+my role R04 does R01 { }
+say R04.();     # both spellings must work
+say R04.(3);
+```


### PR DESCRIPTION
## What

Calling a method on a role type object puns the role into a class and runs the method there. mutsu punned by *constructing*: it called `dispatch_new` on the role and dispatched to the resulting instance — which means it called the role's own `new`, **with no arguments**.

A role whose `new` takes a required parameter therefore lost the arguments of every *other* method called on the pun:

```raku
role C {
    method new(Int $size) { self.bless }
    method other(Int $size) { "other:$size" }
}
say C.other(3);   # was: Too few positionals passed; expected 1 argument but got 0
```

## Why it matters

`NativeHelpers::CStruct`'s `LinearArray[::T]` is exactly that shape — a parameterised role with `method new(::?CLASS:U: Int $size)` and an `@!cache handles <AT-POS elems shape>` delegation. So `LinearArray[MYSQL_BIND]` could not be measured or indexed at all:

```
No such method 'elems' for invocant of type 'NativeHelpers::CStruct::LinearArray'
```

which is where `DBDish::mysql`'s `prepare` sets up its parameter binds. Next blocker after #5535 / #5536 / #5537 on the way to a real MariaDB query.

## How

A role that declares its own `new` puns to a class and re-dispatches on that class's **type object**, which is what raku does in every case. Punning registers a class under the same name, so the retry falls through to ordinary class dispatch rather than re-entering the role branch; the parameterised branch goes through `ensure_parametric_role_pun_class` the same way.

## What is deliberately left

Roles that do *not* declare `new` still pun by constructing, so reading an instance attribute through such a pun still invents a value instead of erroring like raku. Switching them over too is the correct end state; it needs two more fixes that `roast/S13-overloading/typecasting-long.t` pins down and that I confirmed by trying:

1. a composed role's methods land in the pun twice (`R04 does R01` → four matching `CALL-ME` signatures for R01's two multis), and
2. a *type object* does not match a `::?ROLE:U:` invocant constraint the way an instance does.

Both are recorded with their repro in `todo/tickets/role-pun-should-not-construct.md`.

## Tests

`t/role-pun-dispatches-on-type-object.t` — 8 assertions, all matching `raku`: argument passing through a pun for a role with a required-argument `new` (bare, parameterised, and on the second call once punned), a role *without* a custom `new`, and that `.new` on a role still runs the role's own constructor.

Local `make test` (2563 files, 24516 tests) and `make roast` (1435 files, 218774 tests) both PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
