### PR TITLE
fix(nativecall): .REPR on a type object reports the declared representation

### DIFF
--- a/news/2026-07/repr-reports-the-declared-representation.md
+++ b/news/2026-07/repr-reports-the-declared-representation.md
@@ -1,0 +1,38 @@
+# `.REPR` reports the declared representation, not just for live handles
+
+`.REPR` answered the representation a class was declared with only for a *live
+native handle* — an instance carrying a C address. A **type object** has no
+address, so it fell through to `P6opaque`:
+
+```raku
+class B is repr('CStruct') { has uint64 $.a }
+say B.REPR;   # was P6opaque, raku says CStruct
+```
+
+A NativeCall binding gates on exactly that. `NativeHelpers::CStruct`'s
+`LinearArray[::T]` opens with
+
+```raku
+role LinearArray[::T] does Positional[T] is export {
+    die "Need a CStruct" unless T.REPR eq 'CStruct';
+```
+
+so the guard fired for every parameterisation and silently killed the role's
+parameterisation: `LinearArray[MYSQL_BIND]` came out as the bare, unparameterised
+`NativeHelpers::CStruct::LinearArray`, with none of the composed
+`handles <AT-POS elems shape>` delegation. That is what
+`DBDish::mysql`'s `prepare` builds its parameter binds on.
+
+`declared_class_repr` now answers from the CStruct / CUnion / CPointer class
+registries for a **type object**, keeping `P6opaque` for an ordinary class and
+for the built-in types. Instances are untouched: a live native handle already
+answered correctly, and a *Raku-constructed* CStruct — one with no C storage yet
+— must keep under-reporting `P6opaque`, or `BODY_OF` would dereference whatever
+`.WHERE` returned (pinned by `t/nativecall-repr-body.t`; giving such an object
+real storage is ADR-0015's P3).
+
+The other half of that guard — a *rejecting* parameterisation should die, and in
+mutsu does not — is a separate gap, recorded in
+[`todo/tickets/role-body-guard-not-run-on-parameterisation.md`](../../todo/tickets/role-body-guard-not-run-on-parameterisation.md).
+
+Pinned by `t/repr-reports-declared-representation.t`.

--- a/src/runtime/cstruct_layout.rs
+++ b/src/runtime/cstruct_layout.rs
@@ -675,6 +675,35 @@ impl crate::runtime::Interpreter {
         })
     }
 
+    /// The representation a class was *declared* with (`is repr('CStruct')`).
+    /// `None` for an ordinary class, whose representation is `P6opaque`.
+    ///
+    /// [`Self::try_native_handle_repr_where`] answers `.REPR` for a live handle
+    /// — an instance that carries a C address. A **type object** has no address,
+    /// so it fell through to `P6opaque`, and a binding that gates on the
+    /// representation of its type parameter got the wrong answer:
+    /// `NativeHelpers::CStruct`'s `LinearArray[::T]` opens with
+    /// `die "Need a CStruct" unless T.REPR eq 'CStruct'`.
+    pub(crate) fn declared_class_repr(&self, name: &str) -> Option<&'static str> {
+        let short = name.rsplit("::").next().unwrap_or(name);
+        let reg = self.registry();
+        let holds = |set: &rustc_hash::FxHashSet<String>| {
+            set.contains(name)
+                || set
+                    .iter()
+                    .any(|c| c.rsplit("::").next().unwrap_or(c) == short)
+        };
+        if holds(&reg.cstruct_classes) {
+            Some("CStruct")
+        } else if holds(&reg.cunion_classes) {
+            Some("CUnion")
+        } else if holds(&reg.cpointer_classes) {
+            Some("CPointer")
+        } else {
+            None
+        }
+    }
+
     /// `$ptr.of` — what a typed `Pointer[T]` points at, `void` for an untyped
     /// one, as in Rakudo. `NativeHelpers::Blob`'s `blob-from-pointer` branches
     /// on exactly this (`ptr.of ~~ void ?? $type.of !! ptr.of`).

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -1915,12 +1915,28 @@ impl Interpreter {
                 ))
             }
             "REPR" if args.is_empty() => {
-                // CustomType/CustomTypeInstance report their stored REPR; every
+                // CustomType/CustomTypeInstance report their stored REPR; a
+                // class declared `is repr('CStruct')` (or CUnion/CPointer)
+                // reports that even as a *type object*, which is where a
+                // NativeCall binding gates on it
+                // (`die "Need a CStruct" unless T.REPR eq 'CStruct'`); every
                 // other type is P6opaque.
                 if let Some(repr) = target.custom_repr() {
-                    Ok(Value::str_from(repr))
-                } else {
-                    Ok(Value::str_from("P6opaque"))
+                    return Ok(Value::str_from(repr));
+                }
+                // Type objects only. An *instance* reaches here when it has no C
+                // storage (a Raku-constructed CStruct), and `t/nativecall-repr-body.t`
+                // pins that it must keep under-reporting `P6opaque`: answering
+                // the honest name without a body would make `BODY_OF`
+                // dereference whatever `.WHERE` returned. A live handle already
+                // answers `CStruct` through `try_native_handle_repr_where`.
+                let class = match target.view() {
+                    ValueView::Package(name) => Some(name.resolve()),
+                    _ => None,
+                };
+                match class.as_deref().and_then(|c| self.declared_class_repr(c)) {
+                    Some(repr) => Ok(Value::str_from(repr)),
+                    None => Ok(Value::str_from("P6opaque")),
                 }
             }
             "Str" | "Stringy" if args.is_empty() => match target.view() {

--- a/t/repr-reports-declared-representation.t
+++ b/t/repr-reports-declared-representation.t
@@ -1,0 +1,42 @@
+use Test;
+use NativeCall;
+
+plan 7;
+
+# `.REPR` must report the representation a class was *declared* with, on the
+# type object as well as on a live handle. A NativeCall binding gates on
+# exactly that: `NativeHelpers::CStruct`'s `LinearArray[::T]` opens with
+# `die "Need a CStruct" unless T.REPR eq 'CStruct'`, so a type object
+# answering `P6opaque` killed the role's parameterisation outright.
+
+class AStruct is repr('CStruct') {
+    has uint64 $.a;
+    has uint64 $.b;
+}
+class APointer is repr('CPointer') { }
+class AUnion is repr('CUnion') {
+    has uint64 $.a;
+    has uint32 $.b;
+}
+class Ordinary { has $.x }
+
+is AStruct.REPR, 'CStruct', 'a CStruct type object reports CStruct';
+is APointer.REPR, 'CPointer', 'a CPointer type object reports CPointer';
+is AUnion.REPR, 'CUnion', 'a CUnion type object reports CUnion';
+is Ordinary.REPR, 'P6opaque', 'an ordinary class is still P6opaque';
+is Int.REPR, 'P6opaque', 'and so is a built-in type';
+
+sub calloc(size_t, size_t --> Pointer) is native { * }
+my $handle = nativecast(AStruct, calloc(1, 32));
+is $handle.REPR, 'CStruct', 'a live CStruct handle reports CStruct too';
+
+# The shape that motivated this: a role gating on its type parameter's REPR.
+role Guarded[::T] {
+    die "Need a CStruct" unless T.REPR eq 'CStruct';
+    method describe() { "guarded:{T.^name}" }
+}
+is Guarded[AStruct].describe, 'guarded:AStruct',
+    'a role can gate on its type parameter being a CStruct';
+# NOTE: `Guarded[Ordinary].describe` should die (raku does). mutsu does not run
+# the role body's guard on the rejecting parameterisation — a separate gap,
+# recorded in todo/tickets/role-body-guard-not-run-on-parameterisation.md.

--- a/todo/tickets/role-body-guard-not-run-on-parameterisation.md
+++ b/todo/tickets/role-body-guard-not-run-on-parameterisation.md
@@ -1,0 +1,31 @@
+# A role body's guard does not run on the rejecting parameterisation
+
+A role body statement that rejects a type argument is not executed, so a bad
+parameterisation is accepted:
+
+```raku
+class Ordinary { has $.x }
+role Guarded[::T] {
+    die "Need a CStruct" unless T.REPR eq 'CStruct';
+    method describe() { "guarded:{T.^name}" }
+}
+say Guarded[Ordinary].describe;
+# raku:  dies with "Need a CStruct"
+# mutsu: guarded:Ordinary
+```
+
+The *accepting* case works — `Guarded[SomeCStruct].describe` runs the body and
+returns normally — so the body is evaluated at least once; what does not happen
+is that the `die` propagates out of the parameterisation that should be
+rejected. (Rakudo runs the body per concrete parameterisation, at composition
+time.)
+
+Found while fixing `.REPR` on a type object
+([news](../../news/2026-07/repr-reports-the-declared-representation.md)):
+`NativeHelpers::CStruct`'s `LinearArray[::T]` opens with exactly this guard, and
+until `.REPR` was fixed the guard fired for *every* parameterisation and silently
+killed the role's parameterisation. Now the guard passes for a real CStruct,
+which is what the module needs; the rejecting path is the remaining half.
+
+Pin candidate: extend `t/repr-reports-declared-representation.t`, which has the
+assertion written out in a comment.


### PR DESCRIPTION
## What

`.REPR` answered the representation a class was declared with only for a *live native handle* — an instance carrying a C address. A **type object** has no address, so it fell through to `P6opaque`:

```raku
class B is repr('CStruct') { has uint64 $.a }
say B.REPR;   # was P6opaque, raku says CStruct
```

## Why it matters

A NativeCall binding gates on exactly that. `NativeHelpers::CStruct`'s `LinearArray[::T]` opens with

```raku
role LinearArray[::T] does Positional[T] is export {
    die "Need a CStruct" unless T.REPR eq 'CStruct';
```

so the guard fired for **every** parameterisation and silently killed the role's parameterisation: `LinearArray[MYSQL_BIND]` came out as the bare, unparameterised `NativeHelpers::CStruct::LinearArray`, with none of the composed `handles <AT-POS elems shape>` delegation. That is what `DBDish::mysql`'s `prepare` builds its parameter binds on. Next blocker after #5535 / #5536 / #5537 / #5538 on the way to a real MariaDB query.

## How

`declared_class_repr` answers from the CStruct / CUnion / CPointer class registries for a **type object**, keeping `P6opaque` for an ordinary class and for the built-in types.

Instances are deliberately untouched: a live handle already answered correctly through `try_native_handle_repr_where`, and a *Raku-constructed* CStruct — one with no C storage yet — must keep under-reporting `P6opaque`, or `BODY_OF` would dereference whatever `.WHERE` returned. `t/nativecall-repr-body.t` pins that, and caught the first version of this change.

## What is deliberately left

The other half of that guard — a *rejecting* parameterisation should die, and in mutsu does not (`Guarded[Ordinary].describe` returns normally where raku throws) — is a separate gap, recorded with its repro in `todo/tickets/role-body-guard-not-run-on-parameterisation.md`. The assertion is written out as a comment in the new test.

## Tests

`t/repr-reports-declared-representation.t` — 7 assertions, all matching `raku`: CStruct/CPointer/CUnion type objects, an ordinary class and a built-in still `P6opaque`, a live handle, and a role gating on its type parameter's REPR.

Local `make test`: 2563 files, 24515 tests, PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)