### PR TITLE
fix(nativecall): CStruct fields follow constant type aliases; role parameterisation keeps the caller topic

### DIFF
--- a/news/2026-07/cstruct-fields-follow-constant-type-aliases.md
+++ b/news/2026-07/cstruct-fields-follow-constant-type-aliases.md
@@ -1,0 +1,38 @@
+# A CStruct field's type follows a `constant` alias
+
+A C binding names its platform-dependent types once and then writes the alias
+everywhere. `DBDish::mysql::Native` is typical:
+
+```raku
+constant my_bool = int8;
+constant intptr is export = ptrsize == 8 ?? uint64 !! uint32;
+
+class MYSQL_BIND is repr('CStruct') is export {
+    has intptr  $.length is rw;
+    has intptr  $.is_null is rw;
+    ...
+    has my_bool $.is_unsigned;
+}
+```
+
+Neither `intptr` nor `my_bool` is a NativeCall type name, so `FieldType::from_type_name`
+returned `None` for those fields — and because one unmappable field aborts the
+whole layout (continuing would give every later field a wrong offset, which is a
+silent wild read), `MYSQL_BIND` had **no layout at all**. `nativesizeof(MYSQL_BIND)`
+failed with "expected type with CPointer, CStruct, CArray, P6int or P6num
+representation, but got a P6opaque", even though `MYSQL_BIND.REPR` correctly
+answered `CStruct`.
+
+That disagreement was the tell. It also explains a failure a long way from the
+declaration: `NativeHelpers::CStruct`'s `LinearArray[::T]` computes its stride
+with `my int $sol = nativesizeof(T)` in the role body, so
+`LinearArray[MYSQL_BIND]` died during parameterisation and came back as the bare,
+unparameterised role — whose `.elems`/`AT-POS` then did not exist.
+
+Native *signatures* already followed these aliases (they had the same problem
+with `--> my_bool` return types). `cstruct_layout` now calls the same resolver
+for a field type, and only for a name that is not already marshallable, so a
+field typed with a real C type or with a class held by reference keeps its
+declared spelling.
+
+Pinned by `t/cstruct-field-constant-type-alias.t`.

--- a/news/2026-07/platform-library-name-keeps-its-version.md
+++ b/news/2026-07/platform-library-name-keeps-its-version.md
@@ -1,0 +1,21 @@
+# `$*VM.platform-library-name` honours `:version`
+
+`platform-library-name` mapped a library short name to the OS-specific file name
+(`pq` → `libpq.so`) but dropped the `:version` adverb. A distribution ships the
+ABI-versioned file and only the `-dev` package installs the bare symlink, so on
+a machine with `libpq.so.5` and no `libpq.so`, a binding that probes versions
+found nothing:
+
+```raku
+constant LIB = NativeLibs::Searcher.at-runtime('pq', 'PQstatus', 5);
+```
+
+`NativeLibs`' probe builds each candidate with
+`$*VM.platform-library-name($libname.IO, :$version)`, so every candidate came
+back unversioned, every `dlopen` missed, and `DBDish::Pg` failed to install —
+three subtests of `DBIish`'s `01-basic`.
+
+The version now lands where rakudo puts it: after the extension on Linux
+(`libpq.so.5`), before it on macOS (`libpq.5.dylib`); Windows has no ABI suffix.
+A `Version` type object, which is what an omitted version reaches this code as,
+still yields the unversioned name.

--- a/news/2026-07/role-parameterisation-keeps-the-caller-topic.md
+++ b/news/2026-07/role-parameterisation-keeps-the-caller-topic.md
@@ -1,0 +1,52 @@
+# Parameterising a role no longer retopicalizes the caller
+
+Every compiled body ends with a `SetTopic`: that is how a block publishes its
+value, and `run_compiled_block` reads `$_` back to produce the block's result.
+Two of the bodies run during role parameterisation are not lexically the
+caller's, though — the type-argument expression (`R[Elem]` compiles and runs
+`Elem`) and the role body's deferred statements — and both were leaving their
+value in whatever `$_` happened to be current.
+
+So the *first* `R[T].method` call inside a topic block silently changed the
+topic:
+
+```raku
+role P[::T] { method make() { 'x' } }
+class Elem { }
+class Holder { method tag() { 'TAG' } }
+
+with Holder.new {
+    my $x = P[Elem].make;
+    say .^name;    # raku: Holder    mutsu (before): Elem
+    say .tag;      # raku: TAG       mutsu (before): No such method 'tag' for Str/Elem
+}
+```
+
+It only ever bit the first call, because the second one finds the pun already
+registered and never re-composes — which is exactly the shape that makes it look
+like a heisenbug.
+
+Found in `DBIish`. `DBDish::mysql::StatementHandle`'s `BUILD` is
+
+```raku
+with $!stmt {
+    if $!param-count = .mysql_stmt_param_count -> $pc {
+        $!par-binds = LinearArray[MYSQL_BIND].new($pc);   # <-- retopicalized here
+        ...
+    }
+    if ($!field-count = .mysql_stmt_field_count) && ... { ... }
+}
+```
+
+and the second `if` dispatched `.mysql_stmt_field_count` on the type argument
+instead of the statement handle.
+
+The fix is at the carrier level rather than at the two call sites:
+`eval_block_value` now restores the caller's topic after `run_compiled_block`
+has read the block's value, and the deferred-role-body loop does the same. An
+EVAL'd compilation unit is deliberately exempt — it runs *in* the caller's
+scope, so `EVAL '$_ = 3'` really does set the caller's topic, which is what
+rakudo does. The role body's other lexical effects still persist on purpose: a
+composed method closes over `my int $sol = nativesizeof(T)`.
+
+Pinned by `t/role-parameterisation-keeps-the-topic.t`.

--- a/src/runtime/cstruct_layout.rs
+++ b/src/runtime/cstruct_layout.rs
@@ -313,6 +313,31 @@ impl crate::runtime::Interpreter {
         })
     }
 
+    /// Follow a `constant` type alias a field's declared type is spelled with.
+    ///
+    /// A C binding names its platform-dependent types once and reuses them:
+    /// `DBDish::mysql::Native` declares `constant my_bool = int8` and
+    /// `constant intptr = ptrsize == 8 ?? uint64 !! uint32`, then writes
+    /// `has intptr $.length` / `has my_bool $.is_unsigned` inside `MYSQL_BIND`.
+    /// The alias is not a C type name, so the field was unmappable and — because
+    /// one bad field aborts the whole layout — the struct had *no* layout at all:
+    /// `nativesizeof(MYSQL_BIND)` failed, which in turn killed the
+    /// `LinearArray[MYSQL_BIND]` parameterisation that computes its stride from
+    /// it. Signatures already follow these aliases
+    /// ([`Self::resolve_native_type_alias`]); fields now do too.
+    ///
+    /// Only a name that is *not* already marshallable is followed, so a field
+    /// typed with a real C type or with a class held by reference keeps its
+    /// declared spelling.
+    fn resolve_field_type_alias(&self, ty: &str) -> String {
+        if ty.is_empty()
+            || FieldType::from_type_name(ty, |n| self.is_native_handle_class(n)).is_some()
+        {
+            return ty.to_string();
+        }
+        self.resolve_native_type_alias(ty)
+    }
+
     /// The C field layout of a `is repr('CStruct')` class, or `None` if the
     /// class is not a CStruct or declares a field NativeCall cannot marshal.
     pub(crate) fn cstruct_layout(&mut self, class_name: &str) -> Option<Vec<FieldLayout>> {
@@ -324,7 +349,7 @@ impl crate::runtime::Interpreter {
                 let ty = self
                     .get_attr_type_constraint(&registered, name)
                     .unwrap_or_default();
-                (name.clone(), ty)
+                (name.clone(), self.resolve_field_type_alias(&ty))
             })
             .collect();
         // `is_known_struct` cannot borrow `self` here (the layout call takes it

--- a/src/runtime/native_methods/system.rs
+++ b/src/runtime/native_methods/system.rs
@@ -199,15 +199,33 @@ impl Interpreter {
                 // Convert a library short-name to the OS-specific shared library filename.
                 // e.g. "foo" -> "libfoo.so" on Linux, "libfoo.dylib" on macOS, "foo.dll" on Windows.
                 let name = args
-                    .first()
+                    .iter()
+                    .find(|v| !matches!(v.view(), ValueView::Pair(..)))
                     .map(|v| v.to_string_value())
                     .unwrap_or_default();
-                let platform_name = if cfg!(target_os = "macos") {
-                    format!("lib{name}.dylib")
-                } else if cfg!(target_os = "windows") {
-                    format!("{name}.dll")
-                } else {
-                    format!("lib{name}.so")
+                // `:version` names an ABI-versioned library. A distribution ships
+                // the versioned file (`libpq.so.5`) and only the `-dev` package
+                // installs the bare `libpq.so` symlink, so a binding that probes
+                // versions — `NativeLibs::Searcher.at-runtime('pq', 'PQstatus', 5)`,
+                // which DBIish's Pg driver uses — finds nothing at all when the
+                // version is dropped. Rakudo appends it after the extension on
+                // Linux and before it on macOS; Windows has no ABI suffix.
+                let version = args
+                    .iter()
+                    .find_map(|v| match v.view() {
+                        ValueView::Pair(key, value) if key.as_str() == "version" => Some(value),
+                        _ => None,
+                    })
+                    .filter(|v| crate::runtime::types::value_is_defined(v))
+                    .map(|v| v.to_string_value())
+                    // `Version.new(5).Str` is `5`, but a `Version` gists as `v5`.
+                    .map(|s| s.strip_prefix('v').unwrap_or(&s).to_string());
+                let platform_name = match (cfg!(target_os = "macos"), cfg!(windows), version) {
+                    (true, _, Some(v)) => format!("lib{name}.{v}.dylib"),
+                    (true, _, None) => format!("lib{name}.dylib"),
+                    (_, true, _) => format!("{name}.dll"),
+                    (_, _, Some(v)) => format!("lib{name}.so.{v}"),
+                    (_, _, None) => format!("lib{name}.so"),
                 };
                 Ok(self.make_io_path_instance(&platform_name))
             }

--- a/src/runtime/registration_class_decl.rs
+++ b/src/runtime/registration_class_decl.rs
@@ -1033,6 +1033,13 @@ impl Interpreter {
                     // the role package — a lexical `sub`/`my $x` keeps the outer
                     // package so a bare reference from a role method still resolves.
                     let saved_body_pkg = self.current_package().to_string();
+                    // The body's lexical effects are kept on purpose (a composed
+                    // method may close over `my $sol = nativesizeof(T)`), but the
+                    // *topic* is not one of them: each statement publishes its
+                    // value through `$_`, and composition happens wherever the
+                    // role was first parameterised — inside a `with`/`given`
+                    // block, that would retopicalize the caller.
+                    let saved_topic = self.env.get("_").cloned();
                     for stmt in &role.deferred_body_stmts {
                         let is_type_decl =
                             matches!(stmt, Stmt::ClassDecl { .. } | Stmt::RoleDecl { .. });
@@ -1044,6 +1051,14 @@ impl Interpreter {
                             self.set_current_package(saved_body_pkg.clone());
                         }
                         r?;
+                    }
+                    match saved_topic {
+                        Some(topic) => {
+                            self.env.insert("_".to_string(), topic);
+                        }
+                        None => {
+                            self.env.remove("_");
+                        }
                     }
                     // Rename each newly-declared nested class to its
                     // per-composition parameterized name and record an alias so a

--- a/src/runtime/resolution_eval.rs
+++ b/src/runtime/resolution_eval.rs
@@ -218,7 +218,35 @@ impl Interpreter {
             }
         }
         self.block_scope_depth += 1;
+        // A carrier block publishes its value through the topic (the compiler
+        // ends every body with `SetTopic`, which `run_compiled_block` reads back)
+        // — but the *caller's* `$_` must not change, because this entry point
+        // runs a body that is not lexically the caller's: a role type argument,
+        // a `where` clause, a regex code block. Leaking it made
+        // `LinearArray[MYSQL_BIND].new(...)` inside a `with $!stmt { ... }` retopicalize
+        // the block to `MYSQL_BIND`, so the next `.method` call ran on the wrong
+        // invocant. `run_compiled_block` reads the value before this restores, so
+        // the return value is unaffected.
+        //
+        // An EVAL'd compilation unit is the exception: it runs *in* the caller's
+        // scope, so `EVAL '$_ = 3'` really does set the caller's topic (rakudo
+        // agrees), and its own tail value is the topic the caller then sees.
+        let saved_topic = if is_eval_unit {
+            None
+        } else {
+            Some(self.env.get("_").cloned())
+        };
         let result = self.run_compiled_block(&code, &compiled_fns);
+        if let Some(saved) = saved_topic {
+            match saved {
+                Some(topic) => {
+                    self.env.insert("_".to_string(), topic);
+                }
+                None => {
+                    self.env.remove("_");
+                }
+            }
+        }
         let trailing_sub_value = match body.last() {
             Some(Stmt::SubDecl {
                 name,

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -571,7 +571,10 @@ impl Interpreter {
     /// the stub `{ * }` body and the call fails with "No such method".
     ///
     /// Bounded: an alias chain longer than a few links is treated as no alias.
-    fn resolve_native_type_alias(&self, name: &str) -> String {
+    ///
+    /// A CStruct *field* is spelled the same way, so `cstruct_layout` follows
+    /// the alias too — `MYSQL_BIND` declares `has intptr $.length`.
+    pub(crate) fn resolve_native_type_alias(&self, name: &str) -> String {
         use crate::runtime::nativecall::CType;
         let mut current = name.to_string();
         for _ in 0..4 {

--- a/t/cstruct-field-constant-type-alias.t
+++ b/t/cstruct-field-constant-type-alias.t
@@ -1,0 +1,55 @@
+use v6;
+use Test;
+use NativeCall;
+
+# A C binding names its platform-dependent types once and reuses them, so a
+# CStruct field's declared type is routinely a `constant` alias rather than a
+# NativeCall type name. DBIish's `MYSQL_BIND` is the motivating case:
+#
+#   constant my_bool = int8;
+#   constant intptr  = ptrsize == 8 ?? uint64 !! uint32;
+#   class MYSQL_BIND is repr('CStruct') { has intptr $.length is rw; ... }
+#
+# An unresolved field type aborts the whole layout, so the struct had no layout
+# at all and `nativesizeof` failed on it.
+
+plan 6;
+
+constant my_bool = int8;
+constant word = uint64;
+
+class Aliased is repr('CStruct') {
+    has int32   $.a is rw;
+    has my_bool $.b is rw;
+}
+
+class Wide is repr('CStruct') {
+    has word  $.a is rw;
+    has int32 $.b is rw;
+}
+
+class Mixed is repr('CStruct') {
+    has Pointer[my_bool] $.p;
+    has my_bool          $.flag is rw;
+}
+
+is Aliased.REPR, 'CStruct', 'a class with an aliased field type is still a CStruct';
+is nativesizeof(Aliased), 8, 'int32 + int8 field, padded to the 4-byte alignment';
+is nativesizeof(Wide), 16, 'uint64 + int32 field, padded to the 8-byte alignment';
+is nativesizeof(Mixed), 16, 'a typed pointer next to an aliased scalar field';
+
+# The alias resolves to the same C type the spelled-out name would, so the
+# layout is identical.
+class Spelled is repr('CStruct') {
+    has int32 $.a is rw;
+    has int8  $.b is rw;
+}
+is nativesizeof(Aliased), nativesizeof(Spelled), 'an alias lays out like its target type';
+
+# A chain of aliases resolves too.
+constant flag = my_bool;
+class Chained is repr('CStruct') {
+    has int32 $.a is rw;
+    has flag  $.b is rw;
+}
+is nativesizeof(Chained), 8, 'a chained constant alias resolves';

--- a/t/platform-library-name-version.t
+++ b/t/platform-library-name-version.t
@@ -1,0 +1,23 @@
+use v6;
+use Test;
+
+# A distribution ships the ABI-versioned shared library (`libpq.so.5`) and only
+# the `-dev` package installs the bare `libpq.so` symlink, so a binding that
+# probes versions must be able to build the versioned name. `NativeLibs`'
+# `Searcher.at-runtime('pq', 'PQstatus', 5)` — which DBIish's Pg driver uses —
+# goes through `$*VM.platform-library-name($name.IO, :$version)`, which used to
+# drop the adverb and hand back the unversioned name for every candidate.
+
+plan 5;
+
+my $plain = $*VM.platform-library-name('pq'.IO).Str;
+my $v5 = $*VM.platform-library-name('pq'.IO, :version(Version.new(5))).Str;
+my $v516 = $*VM.platform-library-name('pq'.IO, :version(Version.new('5.16'))).Str;
+my $undef = $*VM.platform-library-name('pq'.IO, :version(Version)).Str;
+
+# The extension is platform-specific, so assert the shape rather than a literal.
+like $plain, /^ 'lib' 'pq' \W/, 'the unversioned name still carries the library name';
+isnt $v5, $plain, ':version changes the name it builds';
+ok $v5.contains('5'), 'the version appears in the versioned name';
+ok $v516.contains('5.16'), 'a multi-part version appears in full';
+is $undef, $plain, 'an undefined Version yields the unversioned name';

--- a/t/role-parameterisation-keeps-the-topic.t
+++ b/t/role-parameterisation-keeps-the-topic.t
@@ -1,0 +1,50 @@
+use v6;
+use Test;
+
+# Parameterising a role compiles and runs two bodies that are not lexically the
+# caller's: the type-argument expression (`R[Elem]` evaluates `Elem`) and the
+# role body's deferred statements. Each publishes its value through `$_`, which
+# used to land in whatever scope happened to trigger the composition — so the
+# first `R[T].method` call inside a `with`/`given` block silently retopicalized
+# it to the type argument, and the next `.method` ran on the wrong invocant.
+#
+# Found in DBIish: `LinearArray[MYSQL_BIND].new($pc)` inside
+# `with $!stmt { ... }` left `$_` as `MYSQL_BIND`, so the following
+# `.mysql_stmt_field_count` was dispatched on the wrong object.
+
+plan 7;
+
+class Elem { }
+class Holder { method tag() { 'TAG' } }
+
+role Bare[::T] { method make() { 'bare' } }
+role Bodied[::T] {
+    my $z = 42;
+    method make() { $z }
+}
+
+with Holder.new {
+    my $x = Bare[Elem].make;
+    is .^name, 'Holder', 'a bare parameterised role keeps the caller topic';
+    is .tag, 'TAG', 'and the next method call still dispatches on it';
+}
+
+with Holder.new {
+    my $x = Bodied[Elem].make;
+    is .^name, 'Holder', 'a role with a deferred body keeps the caller topic';
+    is .tag, 'TAG', 'and the next method call still dispatches on it';
+}
+
+given Holder.new {
+    my $x = Bare[Str].make;
+    is .^name, 'Holder', 'given keeps its topic across a parameterisation';
+}
+
+for Holder.new {
+    my $x = Bodied[Str].make;
+    is .^name, 'Holder', 'for keeps its topic across a parameterisation';
+}
+
+# The role body's own lexicals must still survive composition — they are what
+# the composed methods close over.
+is Bodied[Int].make, 42, "the role body's lexical is still visible to its methods";

--- a/todo/tickets/dbiish-blockers.md
+++ b/todo/tickets/dbiish-blockers.md
@@ -46,8 +46,52 @@ even when the block runs inside another object's method, which is what
 `$!parent.protect-connection: { $!stmt… }` does. `DBDish::Pg` shares
 `DBDish::StatementHandle`, so it was going to hit the same line.
 
+**Update 2026-07-29 (later): prepared `INSERT`s run against the server.**
+`$insert.execute('BUBH', 'Hot beef burrito', 1, 4.95)` reaches MariaDB and
+`$insert.rows` comes back. Three more fixes were needed, all of them general:
+
+- [a CStruct field type follows a `constant` alias](../../news/2026-07/cstruct-fields-follow-constant-type-aliases.md).
+  `MYSQL_BIND` declares `has intptr $.length`, `intptr` is not a NativeCall type
+  name, and one unmappable field aborts the whole layout — so `MYSQL_BIND` had
+  no layout, `nativesizeof` on it failed, and `LinearArray[MYSQL_BIND]` (whose
+  role body computes its stride with `nativesizeof(T)`) came back
+  *unparameterised*. The tell: `.REPR` said `CStruct` while `nativesizeof` said
+  `P6opaque`.
+- [parameterising a role no longer retopicalizes the caller](../../news/2026-07/role-parameterisation-keeps-the-caller-topic.md).
+  The type-argument expression and the role's deferred body each published their
+  value through `$_`, so the *first* `LinearArray[MYSQL_BIND].new($pc)` inside
+  `with $!stmt { … }` left the topic as `MYSQL_BIND` and the next
+  `.mysql_stmt_field_count` ran on the wrong invocant.
+- [`$*VM.platform-library-name` honours `:version`](../../news/2026-07/platform-library-name-keeps-its-version.md)
+  — needed by `DBDish::Pg`, see below.
+
+**Next failure on the mysql end-to-end path** (`tmp/mysql-e2e-use.raku`):
+
+```
+No such method 'convert-function' for invocant of type 'Hash'
+  in sub _row ... in sub row ...
+```
+
+i.e. reading rows back. `DBDish::StatementHandle`'s `_row` looks up a per-column
+converter and finds a plain `Hash` where a `TypeConverter` object is expected —
+the same punned-role-in-an-attribute shape as ⑤ below, so check
+[`todo/deep/punned-role-container-attribute-store.md`](../deep/punned-role-container-attribute-store.md)
+first.
+
 Still open before `DBIish.connect(…)` works through its own front door:
 [`require-loaded-module-loses-use-imports.md`](require-loaded-module-loses-use-imports.md).
+
+**`01-basic` regressed to 12 of 35 in this environment, and it is not a mutsu
+regression** — `libpq5` was installed on the survey machine after the 35/35
+measurement, so the file now actually exercises the Pg driver. The first Pg
+blocker (`platform-library-name` dropping `:version`) is fixed above; re-measure
+before reading anything else into that number.
+
+A gap found while pinning the CStruct-alias fix, deliberately left out of scope:
+`nativecast(SomeCStruct, $carray)` on a **Raku-side** `CArray` (as opposed to a
+handle C gave us) produces an instance with no address, so reading a field off
+it fails with "No such method". Every DBIish path casts a pointer that came from
+C, so nothing here needs it.
 
 The three fixes that closed the last file are recorded in
 [`news/2026-07/buf-repr-body-and-native-storage.md`](../../news/2026-07/buf-repr-body-and-native-storage.md),


### PR DESCRIPTION
Three general fixes found on the `DBIish` end-to-end path. With them, mutsu runs
prepared `INSERT`s against a real MariaDB server and gets `$sth.rows` back — the
previous session stopped at `X::Assignment::RO: cannot assign through .length on
non-instance`.

## 1. A CStruct field's type follows a `constant` alias

A C binding names its platform types once and writes the alias everywhere:

```raku
constant my_bool = int8;
constant intptr is export = ptrsize == 8 ?? uint64 !! uint32;
class MYSQL_BIND is repr('CStruct') { has intptr $.length is rw; ... }
```

Neither name is a NativeCall type, so those fields were unmappable — and because
one bad field aborts the whole layout (continuing would give every later field a
wrong offset, i.e. a silent wild read), `MYSQL_BIND` had **no layout at all**.
The tell was the disagreement: `.REPR` said `CStruct` while `nativesizeof` said
`P6opaque`.

That also killed a construct far from the declaration. `NativeHelpers::CStruct`'s
`LinearArray[::T]` computes its stride with `my int $sol = nativesizeof(T)` in the
role body, so `LinearArray[MYSQL_BIND]` died during parameterisation and came back
as the bare, unparameterised role — whose `.elems`/`AT-POS` then did not exist.

Native *signatures* already followed these aliases (#5536). `cstruct_layout` now
uses the same resolver, and only for a name that is not already marshallable.

## 2. Parameterising a role no longer retopicalizes the caller

Every compiled body ends with `SetTopic` — that is how a block publishes its
value, and `run_compiled_block` reads `$_` back to get the result. Two of the
bodies run during role parameterisation are not lexically the caller's (the
type-argument expression, and the role body's deferred statements), and both
were leaving their value in whatever `$_` was current:

```raku
role P[::T] { method make() { 'x' } }
class Elem { }
class Holder { method tag() { 'TAG' } }

with Holder.new {
    my $x = P[Elem].make;
    say .^name;    # raku: Holder    mutsu (before): Elem
    say .tag;      # raku: TAG       mutsu (before): No such method 'tag'
}
```

Only the *first* call is affected — the second finds the pun registered and never
re-composes — which is what made it look like a heisenbug. In DBIish,
`LinearArray[MYSQL_BIND].new($pc)` inside `with $!stmt { ... }` left the topic as
`MYSQL_BIND`, so the next `.mysql_stmt_field_count` ran on the wrong invocant.

Fixed at the carrier level rather than at the two call sites: `eval_block_value`
restores the caller's topic after the value has been read, and the deferred-body
loop does the same. **An EVAL'd compilation unit is deliberately exempt** — it
runs *in* the caller's scope, so `EVAL '$_ = 3'` really does set the caller's
topic (verified against rakudo). The role body's other lexical effects still
persist on purpose: a composed method closes over `my int $sol = nativesizeof(T)`.

## 3. `$*VM.platform-library-name` honours `:version`

A distribution ships `libpq.so.5` and only the `-dev` package installs the bare
`libpq.so` symlink, so dropping the adverb made `NativeLibs`' probe
(`Searcher.at-runtime('pq', 'PQstatus', 5)`) miss every candidate and
`DBDish::Pg` fail to install. The version now lands where rakudo puts it: after
the extension on Linux, before it on macOS; Windows has no ABI suffix. This one
is not a regression from this branch — `libpq5` was installed on the survey
machine after `01-basic` was last measured at 35/35, which is what exposed it.

## Testing

- Pins: `t/cstruct-field-constant-type-alias.t`, `t/role-parameterisation-keeps-the-topic.t`,
  `t/platform-library-name-version.t` — each verified against `raku` first.
- `make test`: 2566 files / 24536 tests, all pass.
- `make roast` run locally (this touches type/name resolution and the topic):
  `Result: PASS`, 1435 files / 218774 tests.

## Follow-up

The next failure on the mysql path is reading rows back —
`No such method 'convert-function' for invocant of type 'Hash'`, i.e. the
`has %.Converter is DBDish::TypeConverter` attribute holding a plain `Hash`.
That is the already-tracked deep item
`todo/deep/punned-role-container-attribute-store.md`; `todo/tickets/dbiish-blockers.md`
is updated to point at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)