### PR TITLE
fix: a container tie survives a whole-value assign to an attribute, and can be named by a role

### DIFF
--- a/news/2026-07/tied-container-attribute-and-role.md
+++ b/news/2026-07/tied-container-attribute-and-role.md
@@ -1,0 +1,45 @@
+# A container tie survives a whole-value assignment to an attribute, and a tie can be named by a role
+
+`my %h is Foo` ties the variable to a `Foo` instance: `%h = …` dispatches
+`Foo.STORE` instead of replacing the variable with a plain `Hash`. Two gaps kept
+that from working in the shape `DBDish::mysql::Connection` uses,
+
+```raku
+has %.Converter is DBDish::TypeConverter;
+submethod BUILD(…) { %!Converter = method (--> DateTime) { … } }
+```
+
+so `my %Converter := $!parent.Converter; %Converter.convert-function($type)`
+inside `DBDish::StatementHandle`'s `_row` died with *No such method
+'convert-function' for invocant of type 'Hash'* — the tie had been overwritten.
+
+**An attribute's local slot is only seeded by a read.** The tie was detected by
+looking in the local slot and in `env`, and an attribute is in neither until
+something reads it. So `%!Converter = …` in BUILD saw an empty slot, concluded
+there was no tie, and stored a plain `Hash` over the seeded `TypeConverter`. The
+symptom read as intermittent: inserting *any* read of `%!Converter` before the
+assignment — even `note %!Converter.^name` — made the tie reappear, because the
+read seeded the slot the assignment then found. The resolution order now falls
+back to `self`'s attribute cell, which is the store of record, and the bound
+result is written back into the cell as well as the slot and `env`.
+
+**A tie named by a role was skipped entirely.** raku puns a role used as a
+container type, and mutsu represents a punned role as a `Mixin` wrapping an
+instance — but the tie gate and the `STORE` re-assignment path both matched
+`Instance` only, and the method probes behind them (`has_user_method`,
+`class_has_method`) walk the class MRO, which never reaches a bare role's own
+methods. So `my %h is TinyAssoc` left a plain `Hash`, and a role-typed attribute
+lost its role on the first assignment. The tie now unwraps a `Mixin` to find the
+type name, and the `STORE`/`AT-KEY` probes fall back to the role registry
+(`has_user_method_including_role`). Punning itself needed no new code —
+`Value::package(name).new` already takes the path a role-typed *attribute*
+(`has %.C is <Role>`) was using.
+
+An ordinary `%` attribute is untouched: the fallback only fires for a value that
+is instance-like *and* passes the existing tie test (a user `STORE` plus a
+composed `Associative`/`Positional`).
+
+Pinned by `t/tied-container-attribute-and-role.t`, which checks all four shapes
+against raku: a role-tied lexical, a class-typed attribute assigned whole in
+BUILD and again in a method, a role-typed attribute bound to a `%` variable and
+used through a role method, and a plain `%` attribute staying a `Hash`.

--- a/src/runtime/class_introspection.rs
+++ b/src/runtime/class_introspection.rs
@@ -232,6 +232,22 @@ impl Interpreter {
         false
     }
 
+    /// [`Self::has_user_method`] widened to a bare role name. A punned role
+    /// (`Role.new`) carries the role as its type name, but the role's methods
+    /// live in the role registry, which the class MRO does not reach — so a
+    /// classes-only lookup answers `false` for every method a punned role
+    /// declares.
+    pub(crate) fn has_user_method_including_role(&mut self, name: &str, method_name: &str) -> bool {
+        if self.has_user_method(name, method_name) {
+            return true;
+        }
+        self.registry()
+            .roles
+            .get(name)
+            .and_then(|r| r.methods.get(method_name))
+            .is_some_and(|defs| defs.iter().any(|d| !d.is_private))
+    }
+
     /// Check if a class has a public attribute accessor for the given name.
     pub(crate) fn has_public_accessor(&mut self, class_name: &str, method_name: &str) -> bool {
         let attrs = self.collect_class_attributes(class_name);

--- a/src/vm/vm_var_assign_local.rs
+++ b/src/vm/vm_var_assign_local.rs
@@ -744,11 +744,11 @@ impl Interpreter {
         // `throws-like { %h = ... }` block) the hash is a captured lexical held in
         // `env`, not `self.locals[idx]`. Resolve the instance from either place and
         // remember where it came from so the bound result is written back there.
-        let (instance, from_local) = match self.locals[idx].view() {
-            ValueView::Instance { .. } => (self.locals[idx].clone(), true),
-            _ => match self.get_env_with_main_alias(&name) {
-                Some(v) if matches!(v.view(), ValueView::Instance { .. }) => (v, false),
-                _ => return Ok(None),
+        let (instance, from_local) = match self.locals[idx].clone() {
+            v if Self::is_tie_bindable(&v) => (v, true),
+            _ => match self.tied_candidate_outside_slot(&name) {
+                Some(v) => (v, false),
+                None => return Ok(None),
             },
         };
         if !self.instance_is_tied(&instance) {
@@ -759,8 +759,27 @@ impl Interpreter {
             self.locals[idx] = bound.clone();
         }
         self.set_env_with_main_alias(&name, bound.clone());
+        self.write_self_attr_cell(&name, bound.clone());
         self.stack.push(bound);
         Ok(Some(()))
+    }
+
+    /// A tie candidate for `name` that does not live in the local slot: either
+    /// `env` (a captured lexical / global) or — for an attribute twigil
+    /// (`%!C = ...`) — `self`'s attribute cell, which is the store of record.
+    ///
+    /// The cell fallback is load-bearing: an attribute's local slot is only
+    /// seeded by a *read*, so `%!C = ...` with no prior read of `%!C` sees an
+    /// empty slot and would clobber the tie with a plain Hash. That made the
+    /// bug look intermittent — inserting any read of `%!C` before the
+    /// assignment made it disappear.
+    fn tied_candidate_outside_slot(&mut self, name: &str) -> Option<Value> {
+        if let Some(v) = self.get_env_with_main_alias(name)
+            && Self::is_tie_bindable(&v)
+        {
+            return Some(v);
+        }
+        self.read_self_attr_cell(name).filter(Self::is_tie_bindable)
     }
 
     /// The `env`-named twin of `maybe_tied_store_reassign`: `%h = ...` where the
@@ -774,16 +793,15 @@ impl Interpreter {
         if !(name.starts_with('%') || name.starts_with('@')) {
             return Ok(None);
         }
-        let Some(instance) = self.get_env_with_main_alias(name) else {
+        let Some(instance) = self.tied_candidate_outside_slot(name) else {
             return Ok(None);
         };
-        if !matches!(instance.view(), ValueView::Instance { .. })
-            || !self.instance_is_tied(&instance)
-        {
+        if !self.instance_is_tied(&instance) {
             return Ok(None);
         }
         let bound = self.tied_store_dispatch(instance)?;
         self.set_env_with_main_alias(name, bound.clone());
+        self.write_self_attr_cell(name, bound.clone());
         self.stack.push(bound);
         Ok(Some(()))
     }
@@ -791,12 +809,30 @@ impl Interpreter {
     /// True when `instance` is a tied container: a user `STORE` method plus a
     /// composed `Associative`/`Positional` role.
     pub(super) fn instance_is_tied(&mut self, instance: &Value) -> bool {
-        let ValueView::Instance { class_name, .. } = instance.view() else {
+        let Some(class_name) = Self::tied_instance_type_name(instance) else {
             return false;
         };
         let cn = class_name.as_str();
-        self.has_user_method(cn, "STORE")
+        self.has_user_method_including_role(cn, "STORE")
             && (self.class_does_role(cn, "Associative") || self.class_does_role(cn, "Positional"))
+    }
+
+    /// The type name behind a candidate tied container. A tie declared with a
+    /// *role* (`my %h is TypeConverter`, `has %.C is TypeConverter`) puns the
+    /// role, and a punned role is a `Mixin` wrapping the instance — so matching
+    /// `Instance` alone would silently skip every role-typed tie.
+    pub(super) fn tied_instance_type_name(val: &Value) -> Option<crate::symbol::Symbol> {
+        match val.view() {
+            ValueView::Instance { class_name, .. } => Some(class_name),
+            ValueView::Mixin(inner, _) => Self::tied_instance_type_name(inner),
+            _ => None,
+        }
+    }
+
+    /// Whether `val` is a value a tie can be bound to: an instance, or the
+    /// `Mixin` a punned role is represented as.
+    pub(super) fn is_tie_bindable(val: &Value) -> bool {
+        Self::tied_instance_type_name(val).is_some()
     }
 
     /// Pop the RHS and route it through the tied instance's `STORE`, returning
@@ -810,7 +846,7 @@ impl Interpreter {
         let list_arg = Value::array(store_values);
         let stored =
             self.try_compiled_method_or_interpret(instance.clone(), "STORE", vec![list_arg])?;
-        Ok(if matches!(stored.view(), ValueView::Instance { .. }) {
+        Ok(if Self::is_tie_bindable(&stored) {
             stored
         } else {
             instance

--- a/src/vm/vm_var_trait_ops.rs
+++ b/src/vm/vm_var_trait_ops.rs
@@ -445,11 +445,17 @@ impl Interpreter {
         // defines the associative protocol (STORE / AT-KEY), which covers both
         // the role-composed (`Hash::Agnostic`) and the plain-class (`Hash::str`)
         // styles without grabbing unrelated `is <Type>` container traits.
+        // A *role* names a tie just as well as a class (`my %h is TypeConverter`):
+        // raku puns it, and `Value::package(name).new` already takes the punning
+        // path a role-typed attribute (`has %.C is TypeConverter`) uses. The
+        // method probes must look in the role registry too — the class MRO does
+        // not reach a bare role's own methods.
         if name.starts_with('%')
-            && self.registry().classes.contains_key(&trait_name)
+            && (self.registry().classes.contains_key(&trait_name)
+                || self.registry().roles.contains_key(&trait_name))
             && (self.class_does_role(&trait_name, "Associative")
-                || self.registry_mut().class_has_method(&trait_name, "STORE")
-                || self.registry_mut().class_has_method(&trait_name, "AT-KEY"))
+                || self.has_user_method_including_role(&trait_name, "STORE")
+                || self.has_user_method_including_role(&trait_name, "AT-KEY"))
         {
             if has_arg {
                 self.stack.pop();
@@ -494,7 +500,7 @@ impl Interpreter {
                     "STORE",
                     vec![list_arg, Value::pair("INITIALIZE".to_string(), Value::TRUE)],
                 )?;
-                let bound = if matches!(stored.view(), ValueView::Instance { .. }) {
+                let bound = if Self::is_tie_bindable(&stored) {
                     stored
                 } else {
                     instance

--- a/t/tied-container-attribute-and-role.t
+++ b/t/tied-container-attribute-and-role.t
@@ -1,0 +1,80 @@
+use Test;
+
+plan 14;
+
+# A container tie declared with `is <Type>` must survive a *whole-value*
+# assignment (`%!C = ...`) and must work when the type named is a **role**,
+# which raku puns. Two gaps this pins:
+#
+#   * an attribute's local slot is only seeded by a *read*, so `%!C = ...` with
+#     no prior read of `%!C` used to see an empty slot and clobber the tie with
+#     a plain Hash — inserting any read of `%!C` first made it disappear;
+#   * a punned role is a `Mixin`, and both the tie gate and the `STORE`
+#     re-assignment path matched `Instance` only, so every role-typed tie was
+#     skipped.
+#
+# This is the shape `DBDish::mysql::Connection` uses:
+# `has %.Converter is DBDish::TypeConverter`, populated by a bare `%!Converter =`
+# in BUILD and later read back as `my %C := $conn.Converter; %C.convert-function(...)`.
+
+role TinyAssoc does Associative {
+    has %!store;
+    has $.stores = 0;
+    method AT-KEY($k)         is raw { %!store.AT-KEY($k) }
+    method ASSIGN-KEY($k, \v) is raw { %!store.ASSIGN-KEY($k, v) }
+    method keys()                    { %!store.keys }
+    method tag()                     { 'tiny' }
+    method STORE(*@pairs) {
+        $!stores++;
+        for @pairs -> $p { self.ASSIGN-KEY($p.key, $p.value) }
+        self
+    }
+}
+class TiedHash does TinyAssoc { }
+
+# --- 1. a lexical tied by a bare role (raku puns it) -------------------------
+
+my %r is TinyAssoc;
+is %r.^name, 'TinyAssoc', 'my %h is <Role> puns the role and ties the variable';
+%r = (a => 1, b => 2);
+is %r.^name, 'TinyAssoc', 'assigning to a role-tied lexical keeps the punned role';
+is %r.keys.sort.join(','), 'a,b', 'the assignment went through the role STORE';
+is %r.tag, 'tiny', 'a role method still dispatches after the assignment';
+
+# --- 2. a class-typed attribute assigned whole, with no prior read -----------
+
+class HolderC {
+    has %.C is TiedHash;
+    submethod BUILD() { %!C = (a => 1, b => 2) }
+    method poke()     { %!C = (p => 9) }
+}
+my $hc = HolderC.new;
+is $hc.C.^name, 'TiedHash', 'a whole-value assign in BUILD keeps the tied class';
+is $hc.C.keys.sort.join(','), 'a,b', 'BUILD assignment stored through STORE';
+$hc.poke;
+is $hc.C.^name, 'TiedHash', 'a later whole-value assign in a method keeps the tie';
+is $hc.C<p>, 9, 'the method assignment stored through STORE';
+
+# --- 3. a role-typed attribute (the DBIish shape) ---------------------------
+
+class HolderR {
+    has %.C is TinyAssoc;
+    submethod BUILD() { %!C = (x => 1) }
+}
+my $hr = HolderR.new;
+is $hr.C.^name, 'TinyAssoc', 'a role-typed attribute keeps the punned role across assignment';
+is $hr.C.tag, 'tiny', 'a role method dispatches on the attribute';
+is $hr.C<x>, 1, 'the role STORE populated the attribute';
+
+# Bound to a `%` variable and used through a role method, as DBDish does.
+my %bound := $hr.C;
+is %bound.^name, 'TinyAssoc', 'binding the attribute to a % variable keeps the role';
+is %bound.tag, 'tiny', 'the role method is reachable through the bound variable';
+
+# --- 4. an untied attribute is untouched ------------------------------------
+
+class Plain {
+    has %.h;
+    submethod BUILD() { %!h = (k => 1) }
+}
+is Plain.new.h.^name, 'Hash', 'an ordinary % attribute is still a plain Hash';

--- a/todo/tickets/dbiish-blockers.md
+++ b/todo/tickets/dbiish-blockers.md
@@ -65,18 +65,22 @@ even when the block runs inside another object's method, which is what
 - [`$*VM.platform-library-name` honours `:version`](../../news/2026-07/platform-library-name-keeps-its-version.md)
   — needed by `DBDish::Pg`, see below.
 
-**Next failure on the mysql end-to-end path** (`tmp/mysql-e2e-use.raku`):
+**Reading rows back** used to fail on the mysql end-to-end path
+(`tmp/mysql-e2e-use.raku`) with
 
 ```
 No such method 'convert-function' for invocant of type 'Hash'
   in sub _row ... in sub row ...
 ```
 
-i.e. reading rows back. `DBDish::StatementHandle`'s `_row` looks up a per-column
-converter and finds a plain `Hash` where a `TypeConverter` object is expected —
-the same punned-role-in-an-attribute shape as ⑤ below, so check
-[`todo/deep/punned-role-container-attribute-store.md`](../deep/punned-role-container-attribute-store.md)
-first.
+`DBDish::StatementHandle`'s `_row` binds `my %Converter := $!parent.Converter`
+and found a plain `Hash` where a `TypeConverter` was expected. This was *not* the
+punned-role-in-an-attribute store of ⑤ (that landed 2026-07-26); it was the
+container **tie** in front of it — `has %.Converter is DBDish::TypeConverter`
+populated by a bare `%!Converter = …` in BUILD. Fixed in
+[`news/2026-07/tied-container-attribute-and-role.md`](../../news/2026-07/tied-container-attribute-and-role.md):
+a whole-value assignment to an attribute now routes through `STORE` instead of
+replacing the tie, and a tie named by a *role* is recognised at all.
 
 Still open before `DBIish.connect(…)` works through its own front door:
 [`require-loaded-module-loses-use-imports.md`](require-loaded-module-loses-use-imports.md).
@@ -382,15 +386,13 @@ the end of this file). Three are done and two remain:
   that means a punned-role object living inside an attribute, which is precisely
   where the second store cannot be reached.
 
-So what is left of ⑤ is one thing:
-[`todo/deep/punned-role-container-attribute-store.md`](../deep/punned-role-container-attribute-store.md).
-A punned role keeps its `@`/`%` attributes in `__mutsu_attr__` mixin markers
-instead of the instance's attribute cell, so an ordinary `%!h<k> = 1` inside a
-role method is dropped, while the `handles` delegation path mutates the marker
-and writes the rebuilt `Mixin` back into the *caller's env variable* — a
-writeback that cannot reach an object held in an attribute. The code carries its
-own `TODO` for this. It wants the cell to become the single store for every
-sigil; ~36 `__mutsu_attr__` sites are involved.
+The last of ⑤ was the two-store problem: a punned role kept its `@`/`%`
+attributes in `__mutsu_attr__` mixin markers instead of the instance's attribute
+cell, so an ordinary `%!h<k> = 1` inside a role method was dropped, while the
+`handles` delegation path mutated the marker and wrote the rebuilt `Mixin` back
+into the *caller's env variable* — a writeback that cannot reach an object held
+in an attribute. The cell is the single store for every sigil now:
+[`news/2026-07/punned-role-container-attribute-store.md`](../../news/2026-07/punned-role-container-attribute-store.md).
 
 Note the object-hash requirement overlaps the deferred "object-hash `WHICH`"
 item in the doc-diff DEEP bucket (`docs/doc-diff-backlog.md`).
@@ -466,7 +468,7 @@ is at 30 of 35. Two left:
    `unit module` prelude capture). **The only thing left is ADR-0015 P2** —
    native-backed `Buf`/`Blob` with an honest `VMArray` `.REPR` and an `MVMArrayB`
    body. That is the campaign, not a slice. It has been surveyed against `main`:
-   [`todo/deep/adr0015-p2-buf-storage-survey.md`](../deep/adr0015-p2-buf-storage-survey.md)
+   [`news/2026-07/adr0015-p2-buf-storage-survey.md`](../../news/2026-07/adr0015-p2-buf-storage-survey.md)
    has the measured touch count (104, not the ADR's ~91), the `.REPR` machinery
    P1 already left in place, and — the load-bearing correction —
    **`native_object_where` cannot be extended into `MVMArrayB`**: it is memoised

--- a/todo/tickets/nativecall-surface-gaps.md
+++ b/todo/tickets/nativecall-surface-gaps.md
@@ -62,8 +62,8 @@ done
 
 - ~~**`is native` on methods**~~ — **done 2026-07-29**, see
   [`news/2026-07/nativecall-cglobal-and-native-methods.md`](../../news/2026-07/nativecall-cglobal-and-native-methods.md).
-- **`nativecast` tags handles with the short class name**, so a CStruct declared
-  inside a module loses its hand-written methods:
-  [`nativecast-tags-handles-with-the-short-class-name.md`](nativecast-tags-handles-with-the-short-class-name.md).
+- ~~**`nativecast` tags handles with the short class name**~~ — **done
+  2026-07-29**, see
+  [`news/2026-07/cstruct-handles-carry-their-registered-name.md`](../../news/2026-07/cstruct-handles-carry-their-registered-name.md).
 - **By-value CStructs and callbacks** — recorded in `runtime/nativecall.rs`'s
   module docs as follow-up work; no dist in the batteries needs them yet.


### PR DESCRIPTION
`my %h is Foo` ties the variable to a `Foo` instance, so `%h = ...` dispatches `Foo.STORE` instead of replacing it with a plain `Hash`. Two gaps kept that from working in the shape `DBDish::mysql::Connection` uses:

```raku
has %.Converter is DBDish::TypeConverter;
submethod BUILD(...) { %!Converter = method (--> DateTime) { ... } }
```

so `DBDish::StatementHandle`'s `_row` (`my %Converter := $!parent.Converter; %Converter.convert-function($type)`) died with *No such method 'convert-function' for invocant of type 'Hash'* — the tie had been overwritten.

This is what `todo/tickets/dbiish-blockers.md` pointed at the punned-role-attribute-store deep item for. That item landed in #5484; the remaining failure was the container **tie** in front of it.

### An attribute's local slot is only seeded by a read

The tie was resolved from the local slot and `env`, and an attribute is in neither until something reads it. So `%!Converter = ...` in BUILD saw an empty slot, concluded there was no tie, and stored a plain `Hash` over the seeded `TypeConverter`.

The symptom read as intermittent: inserting *any* read of `%!Converter` before the assignment — even `note %!Converter.^name` — made the tie reappear, because the read seeded the slot the assignment then found. Resolution now falls back to `self`'s attribute cell, which is the store of record, and the bound result is written back into the cell as well as the slot and `env`.

### A tie named by a role was skipped entirely

raku puns a role used as a container type, and mutsu represents a punned role as a `Mixin` — but the tie gate and the `STORE` re-assignment path both matched `Instance` only, and the method probes behind them (`has_user_method`, `class_has_method`) walk the class MRO, which never reaches a bare role's own methods. So `my %h is TinyAssoc` left a plain `Hash`, and a role-typed attribute lost its role on the first assignment.

The tie now unwraps a `Mixin` to find the type name, and the `STORE`/`AT-KEY` probes fall back to the role registry (`has_user_method_including_role`). Punning itself needed no new code — `Value::package(name).new` already takes the path a role-typed *attribute* (`has %.C is <Role>`) was using.

An ordinary `%` attribute is untouched: the fallback only fires for a value that is instance-like *and* passes the existing tie test (a user `STORE` plus a composed `Associative`/`Positional`).

### Verification

- `t/tied-container-attribute-and-role.t` — new pin, 14/14, matching `raku` output exactly. Covers a role-tied lexical, a class-typed attribute assigned whole in BUILD and again in a method, a role-typed attribute bound to a `%` variable and used through a role method, and a plain `%` attribute staying a `Hash`.
- `make test` — 2568 files / 24555 tests, all pass.
- `make roast` (local, release) — 1435 files / 218774 tests, `Result: PASS`.
- DBIish `t/06-types.rakutest` — 12/12.

The live MariaDB end-to-end path was **not** re-run: `libmariadb.so.0` and the MariaDB container are no longer present in this environment.

### Also

Repoints three dangling ledger links at the `news/` entries their targets moved to when that work landed (`punned-role-container-attribute-store`, `adr0015-p2-buf-storage-survey`, `nativecast-tags-handles-with-the-short-class-name`), and replaces the stale "what is left of ⑤" paragraph in `dbiish-blockers.md` with the actual diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)