### PR TITLE
fix: an `is rw` sub's Proxy result is FETCHed on the OTF-compiled call branch too

### DIFF
--- a/news/2026-07/rw-sub-proxy-fetch-on-otf-call.md
+++ b/news/2026-07/rw-sub-proxy-fetch-on-otf-call.md
@@ -1,0 +1,40 @@
+# An `is rw` sub's `Proxy` result is FETCHed on the on-the-fly-compiled call branch too
+
+Calling an `is rw` sub whose result is a `Proxy` must FETCH it in value context —
+that is how `cglobal` works, since NativeCall's `cglobal` is a Raku sub returning
+a `Proxy` whose `FETCH` reads the C global. Every branch of
+`dispatch_func_call_inner` did that except the four that run the callee as
+**on-the-fly-compiled bytecode**, which returned the `Proxy` raw.
+
+That branch is not exotic: it is what a file-scope sub takes when it is called
+from a *method* body, because the method's compiled-function table does not carry
+it. So the same call behaved differently depending on where it appeared:
+
+```raku
+sub s()  { my $x = (try cglobal('libnope.so.0', 'sym', Pointer)); $x.^name }
+class C { method m() { my $x = (try cglobal('libnope.so.0', 'sym', Pointer)); $x.^name } }
+s();      # Any  — the FETCH ran inside the try and its failure was caught
+C.m;      # died — the Proxy was stored raw, so the FETCH ran at `.^name`,
+          #        outside the try
+```
+
+The deferral is what makes it user-visible: the `Proxy` sits in the variable
+until the next read, so the FETCH — and any exception it raises — lands past
+whatever `try` was wrapping the call. `NativeLibs::Loader`'s library probe is
+exactly `(try cglobal($lib, $sym, Pointer)) ~~ Pointer`, so a missing library
+threw instead of answering `False`.
+
+The four sites now apply `maybe_fetch_rw_proxy` like their sibling branches,
+gated on `!def.is_raw` — the same precision the compiled-function branch already
+used with `!cf.is_raw`, so an `is raw` routine still hands back its container.
+`maybe_fetch_rw_proxy` keeps its own `in_lvalue_assignment` guard, so an lvalue
+target is untouched.
+
+Pinned by `t/rw-sub-proxy-fetch-otf.t`, which checks a sub, a method, a private
+method, a loop body, and that a throwing FETCH is caught by a surrounding `try`
+in both a sub and a method.
+
+This is one of two bugs on `DBIish`'s real mysql path. The other — a `Proxy`
+`FETCH` body losing its captured lexical to a same-named *caller* lexical — is a
+dual-store problem recorded in
+[`todo/deep/closure-capture-loses-to-same-named-caller-lexical.md`](../../todo/deep/closure-capture-loses-to-same-named-caller-lexical.md).

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -1164,7 +1164,9 @@ impl Interpreter {
                     // `nextsame`/`callsame`/`callwith`/`samewith` from the selected
                     // candidate still work because compile_and_call_function_def pushes
                     // the same multi-dispatch + samewith frames the interpreter would.
-                    self.compile_and_call_function_def(&def, args, compiled_fns)
+                    let is_raw = def.is_raw;
+                    let result = self.compile_and_call_function_def(&def, args, compiled_fns)?;
+                    loan_env!(self, maybe_fetch_rw_proxy(result, !is_raw))
                 } else if self.has_proto(name)
                     && let Some(result) =
                         self.vm_try_run_nontrivial_proto_body(name, args.clone(), compiled_fns)
@@ -1216,7 +1218,10 @@ impl Interpreter {
                         && Self::def_is_otf_compilable_multi_candidate(&def)
                         && !self.multi_candidate_state_forces_interpreter(name, &def)
                     {
-                        self.compile_and_call_function_def(&def, args, compiled_fns)
+                        let is_raw = def.is_raw;
+                        let result =
+                            self.compile_and_call_function_def(&def, args, compiled_fns)?;
+                        loan_env!(self, maybe_fetch_rw_proxy(result, !is_raw))
                     } else {
                         crate::vm::vm_stats::record_function_fallback(name);
                         self.set_pending_call_arg_sources(arg_sources);
@@ -1275,7 +1280,10 @@ impl Interpreter {
                             Self::def_is_otf_compilable_module_single(&def)
                         };
                         if gate_ok {
-                            return self.compile_and_call_function_def(&def, args, compiled_fns);
+                            let is_raw = def.is_raw;
+                            let result =
+                                self.compile_and_call_function_def(&def, args, compiled_fns)?;
+                            return loan_env!(self, maybe_fetch_rw_proxy(result, !is_raw));
                         }
                     }
                     crate::vm::vm_stats::record_function_fallback(name);
@@ -1295,7 +1303,9 @@ impl Interpreter {
                 // code params (&foo), no where constraints, no closures.
                 && Self::def_is_otf_compilable(&def)
                 {
-                    self.compile_and_call_function_def(&def, args, compiled_fns)
+                    let is_raw = def.is_raw;
+                    let result = self.compile_and_call_function_def(&def, args, compiled_fns)?;
+                    loan_env!(self, maybe_fetch_rw_proxy(result, !is_raw))
                 } else if let Some(result) = self.try_native_test_function(name, &args) {
                     // Dispatch Test functions straight to their typed handler (lever A).
                     result

--- a/t/rw-sub-proxy-fetch-otf.t
+++ b/t/rw-sub-proxy-fetch-otf.t
@@ -1,0 +1,48 @@
+use Test;
+
+plan 8;
+
+# Calling an `is rw` sub whose result is a `Proxy` must FETCH it in value
+# context. Every branch of `dispatch_func_call_inner` did that except the four
+# that run the callee as on-the-fly-compiled bytecode, which is the branch a
+# file-scope sub takes when it is called from a *method* body (the method's
+# compiled-function table does not carry it). The Proxy was then stored raw, so
+# the FETCH happened later — at the next read — and escaped any `try` around the
+# call.
+#
+# This is what made `NativeLibs::Loader`'s
+# `(try cglobal($lib, $sym, Pointer)) ~~ Pointer` probe throw instead of
+# answering False for a library that is not installed.
+
+my $fetches = 0;
+sub mk($ok) is rw {
+    Proxy.new(FETCH => -> $ { $fetches++; $ok ?? 42 !! die "boom" }, STORE => -> $, $ { })
+}
+
+sub from-sub()    { my $x = mk(True); $x }
+class C {
+    method from-method()      { my $x = mk(True); $x }
+    method !from-private()    { my $x = mk(True); $x }
+    method via-private()      { self!from-private }
+    method in-loop()          { my @r; for 1, 2 { @r.push: (my $x = mk(True)) }; @r }
+}
+
+$fetches = 0;
+is from-sub(), 42, 'an is-rw sub call in a sub FETCHes the Proxy';
+is $fetches, 1, 'exactly one FETCH from the sub call';
+
+$fetches = 0;
+is C.from-method, 42, 'the same call from a method body FETCHes it too';
+is $fetches, 1, 'exactly one FETCH from the method call';
+
+$fetches = 0;
+is C.via-private, 42, 'and from a private method';
+is C.in-loop.join(','), '42,42', 'and once per iteration inside a loop';
+
+# A throwing FETCH must be caught by a `try` around the call, in a method just
+# as in a sub — it used to escape because the FETCH was deferred past the `try`.
+sub caught-in-sub()    { (try mk(False)).defined }
+class D { method caught-in-method() { (try mk(False)).defined } }
+
+nok caught-in-sub(),        'a throwing FETCH is caught by try in a sub';
+nok D.caught-in-method,     'a throwing FETCH is caught by try in a method';

--- a/todo/deep/closure-capture-loses-to-same-named-caller-lexical.md
+++ b/todo/deep/closure-capture-loses-to-same-named-caller-lexical.md
@@ -1,0 +1,108 @@
+# A deferred closure's captured lexical loses to a same-named caller lexical
+
+A closure invoked through the **caller-priority env merge** (`call_sub_value(…,
+merge_all = true)`) does not see its own captured value for any lexical the
+*caller* happens to have declared under the same name. The caller's variable —
+an entirely unrelated binding — shadows the capture.
+
+```raku
+our sub mkproxy($libname) is rw {
+    Proxy.new(FETCH => -> $ { "saw:$libname" }, STORE => -> $, $ { })
+}
+sub caller-with() {
+    my $libname = 'OUTER';          # same name, unrelated variable
+    mkproxy('INNER')
+}
+say caller-with();    # raku: saw:INNER   mutsu: Use of uninitialized value
+```
+
+Note the mutsu result is *uninitialized*, not `'OUTER'`: the caller's `$libname`
+lives in a local slot whose env twin is still unset, so the merge injects an
+empty entry. When the caller's variable is a **parameter** (which does live in
+env) the closure sees the caller's value instead — that is the shape that broke
+`DBIish` (below).
+
+Ordinary closure calls are correct — `-> { }` returned from a sub and invoked
+normally sees `INNER`. Only the caller-priority path is affected, which in
+practice means **`Proxy` `FETCH`/`STORE` bodies**: `maybe_fetch_rw_proxy` and
+`auto_fetch_proxy` both call `call_sub_value(…, true)`.
+
+## Why the caller-priority merge exists
+
+`src/runtime/resolution_call_sub.rs` (~line 315) builds the callee env from the
+caller env and then folds in the captured env:
+
+- a captured `ContainerRef` **overwrites** — it is a shared cell, the single
+  source of truth for that lexical;
+- with `merge_all` the captured value is `entry_or_insert`ed — **the caller
+  wins**;
+- otherwise the captured value overwrites.
+
+The `merge_all` arm is deliberate: `auto_fetch_proxy` documents that a `FETCH`
+body must see the *current* value of a lexical its `STORE` twin mutates
+(`substr-rw`'s `$str`). Freshness, not identity, is what it is buying.
+
+## Why the obvious fix does not work
+
+Preferring the capture for names in the compiler's `free_var_syms` (the
+authoritative set of lexicals a body references from an enclosing scope) fixes
+the repro above and the `DBIish` case, but breaks freshness where the merge was
+load-bearing. Measured 2026-07-29: `NativeLibs`'s
+
+```raku
+multi sub cannon-name(Str:D $libname, Version $version?) {
+    with $libname.IO { … $*VM.platform-library-name($_, :$version).Str }
+}
+```
+
+froze `$version` at the first call's value for every later call — the `with`
+block's captured env is persisted (`closure_env_overrides`) and stale, and only
+caller-priority was keeping it fresh. So `try-versions` went from picking the
+wrong library to picking none.
+
+Name-based priority cannot separate the two cases, in either direction: "same
+name" is not "same variable". The sound fix is identity — the shared case must
+be a shared **cell** (the `ContainerRef` branch already does the right thing for
+those), so `substr-rw`-style sharing stops depending on a name collision and the
+`merge_all` caller-priority arm can be retired. That is the dual-store /
+cell-ification work (ADR-0001 layer 3a, Track B), not a slice.
+
+## Affected files
+
+- `src/runtime/resolution_call_sub.rs` — the merge (~line 315-341); the
+  `merge_all` arm is the defect site.
+- `src/runtime/builtins_lvalue.rs` — `maybe_fetch_rw_proxy` /
+  `auto_fetch_proxy`, the two callers that pass `merge_all = true` for a
+  `Proxy` body.
+
+## Minimal repro
+
+`tmp/closurecap2.raku` in the working tree, or:
+
+```raku
+our sub mk($libname) { -> { "saw:" ~ ($libname // 'UNDEF') } }
+our sub mkp($libname) is rw { Proxy.new(FETCH => -> $ { "saw:" ~ ($libname // 'UNDEF') }, STORE => -> $, $ {}) }
+sub c1() { my $libname = 'OUTER'; mk('INNER')() }     # correct in mutsu
+sub c2() { my $libname = 'OUTER'; mkp('INNER') }      # wrong in mutsu
+say c1(); say c2();
+```
+
+## Impact
+
+This is the **last blocker for `DBIish`'s real end-to-end mysql path**.
+`NativeLibs::Searcher.try-versions('mariadb', 'mysql_init', 0..4)` probes each
+candidate with `(try cglobal($cn, $wks, Pointer)) ~~ Pointer`. `cglobal`'s
+`FETCH` closure captures `$libname`, and its caller `try-versions` has its own
+`Str $libname` = `'mariadb'` — so every probe dlopens `mariadb` (which
+`resolve_library_candidates` expands to the *existing* `libmariadb.so`) instead
+of `libmariadb.so.<n>`. All five versions "succeed", `try-versions` returns
+`libmariadb.so.0`, and the driver then fails to load it for real:
+
+```
+Cannot load native library 'libmariadb.so.0'
+```
+
+raku picks `libmariadb.so.3` and the whole script runs (verified against a live
+MariaDB on 2026-07-29). A separate, now-fixed bug in the same path — an `is rw`
+sub's `Proxy` result not being FETCHed on the OTF-compiled call branch — is
+recorded in `news/2026-07/rw-sub-proxy-fetch-on-otf-call.md`.


### PR DESCRIPTION
Calling an `is rw` sub whose result is a `Proxy` must FETCH it in value context — that is how NativeCall's `cglobal` works, since it is a Raku sub returning a `Proxy` whose `FETCH` reads the C global. Every branch of `dispatch_func_call_inner` did that except the four that run the callee as **on-the-fly-compiled bytecode**, which returned the `Proxy` raw.

That branch is not exotic: it is what a file-scope sub takes when it is called from a *method* body, because the method's compiled-function table does not carry it. So the same call behaved differently depending on where it appeared:

```raku
sub s()  { my $x = (try cglobal('libnope.so.0', 'sym', Pointer)); $x.^name }
class C { method m() { my $x = (try cglobal('libnope.so.0', 'sym', Pointer)); $x.^name } }
s();      # Any  — the FETCH ran inside the try and its failure was caught
C.m;      # died — the Proxy was stored raw, so the FETCH ran at `.^name`,
          #        outside the try
```

The deferral is what makes it user-visible: the `Proxy` sits in the variable until the next read, so the FETCH — and any exception it raises — lands past whatever `try` was wrapping the call. `NativeLibs::Loader`'s library probe is exactly `(try cglobal($lib, $sym, Pointer)) ~~ Pointer`, so a missing library threw instead of answering `False`.

The four sites now apply `maybe_fetch_rw_proxy` like their sibling branches, gated on `!def.is_raw` — the same precision the compiled-function branch already used with `!cf.is_raw`, so an `is raw` routine still hands back its container. `maybe_fetch_rw_proxy` keeps its own `in_lvalue_assignment` guard, so an lvalue target is untouched.

### How it was found

Reducing `DBIish`'s real end-to-end mysql path against a live MariaDB. `NativeLibs::Searcher.try-versions('mariadb', 'mysql_init', 0..4)` picked `libmariadb.so.0` where raku picks `libmariadb.so.3`, and the driver then died with `Cannot load native library 'libmariadb.so.0'`. `cglobal` and `$*VM.platform-library-name` both matched raku exactly; the divergence was in the probe's `try`.

### Verification

- `t/rw-sub-proxy-fetch-otf.t` — new pin, 8/8, identical to `raku`'s output. Covers a sub, a method, a private method, a loop body, and a throwing FETCH caught by a surrounding `try` in both a sub and a method.
- `make test` — 2568 files / 24555 tests, all pass.
- `make roast` (local, release) — 1435 files / 218774 tests, `Result: PASS`.

### Not fixed here

`DBIish` still does not connect. The second bug on the same path is a **`Proxy` FETCH body losing its captured lexical to a same-named *caller* lexical** — `cglobal`'s FETCH captures `$libname`, and its caller `try-versions` has its own `Str $libname` = `'mariadb'`, which wins the caller-priority env merge. Recorded with the full diagnosis, including a measured account of why the obvious `free_var_syms`-based fix breaks freshness elsewhere, in `todo/deep/closure-capture-loses-to-same-named-caller-lexical.md`. The sound fix is cell identity rather than name matching, i.e. ADR-0001 layer 3a territory, not a slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)