### PR TITLE
fix: DBIish Pg driver runs end-to-end — NativeCall, grammar-action, and dispatch fixes

### DIFF
--- a/news/2026-07/dbiish-postgresql-end-to-end.md
+++ b/news/2026-07/dbiish-postgresql-end-to-end.md
@@ -1,0 +1,91 @@
+# DBIish runs end-to-end on PostgreSQL — seven general fixes
+
+A day after the MariaDB milestone, the same DBIish 0.6.8 prepared-statement
+lifecycle now runs against a live PostgreSQL 16 (`DBIish.connect('Pg', …)` →
+DDL → `PQprepare` → typed-parameter `PQexecPrepared` → `allrows`/`row` with
+type conversion → `dispose`), byte-identical to Rakudo. An extended check —
+bool/bigint/float8/numeric/text/NULL round-trips, column metadata, `rows`,
+SQL-level transactions, a caught `X::DBDish::DBError::Pg`, `server-version` —
+is also byte-identical. As with MariaDB, every fix is general-purpose; nothing
+special-cases DBIish.
+
+The Pg driver exercises a different surface than mysql, which is why seven new
+bugs surfaced:
+
+1. **A native method's invocant is its first C argument even when the
+   signature leaves it implicit.** `DBDish::Pg::Native` declares
+   `method PQstatus(--> int32)` on a `repr('CPointer')` class — no
+   `::?CLASS:D:` spelled out, unlike the mysql driver. mutsu only synthesized
+   the leading pointer parameter for an explicit invocant, so every libpq call
+   failed with an arity error. The registration now inserts the pointer slot
+   whenever the routine is a method. (`t/nativecall-method-implicit-invocant.t`)
+
+2. **The native `str` type maps to `char*`.** `sub PQconnectdb(str --> PGconn)`
+   silently skipped native registration because lowercase `str` was not in the
+   C-type table.
+
+3. **An undefined element of a `CArray[Str]` is a NULL `char*`.**
+   `PQconnectdbParams` terminates its key/value arrays with `$keys[$i] = Str`;
+   mutsu stringified the type object into a literal `"(Str)"`, which libpq
+   rejected as an invalid connection option.
+
+4. **An undefined `CArray[T]` argument is a genuine NULL pointer.** DBDish::Pg
+   passes `Null` (a type object) for `paramLengths`/`paramFormats`; mutsu
+   handed over a pointer to an empty buffer instead, libpq took the non-NULL
+   `paramFormats` as a real per-parameter array, read garbage, and segfaulted.
+   (Both CArray cases: Rust unit tests in `runtime/nativecall.rs`.)
+
+5. **Action methods fire for subrules inside positional capture groups, and
+   their `.made` is visible through `$0[…]`.** The Pg placeholder tokenizer is
+   `token TOP { ^ ( <normal> | <placeholder> )* $ }` with per-token actions
+   joined in the TOP action — mutsu never dispatched actions into `( )` groups
+   and never stored the updated children back, so `pg-replace-placeholder`
+   returned an empty string and every `prepare` died. The reduce-time isolation
+   copy of the actions object also needed a fresh instance id — sharing the id
+   let the post-dispatch env refresh silently swap the copy back to the real
+   object, tripling attribute mutations (`t/grammar-actions-positional-group.t`,
+   and `t/grammar-reduce-time-dynvar.t` test 5 pinned the leak).
+
+6. **Private method calls resolve lexically.** `StatementHandle`'s BUILD calls
+   `self!get-meta` inside a block passed to `$!parent.protect-connection`; the
+   runtime caller-class check saw the parent's class and refused the call. A
+   closure whose captured `self` is an instance of the owning class is code
+   written inside that class, and is allowed. (`t/private-method-call-in-closure.t`)
+
+7. **A method carrying a LEAVE phaser keeps the value of a tail `if`.**
+   `prepare` ends in `LEAVE { $result.PQclear … }; if $result && $result.is-ok
+   { StatementHandle.new(…) } else { … }` and returned Nil — the
+   phaser-carrying compile path lacked the value-position statement forms
+   (`if`/block/decl) the plain path reifies. (`t/method-leave-tail-if-value.t`)
+
+Three more fell while checking the extended surface:
+
+- **A native handle is tagged with the name its class is registered under.**
+  `PQprepare(--> PGresult)` returned an instance tagged with the short name
+  while the class registered package-qualified (`DBDish::Pg::Native::PGresult`),
+  so the ordinary Raku method `is-ok` on the handle failed to dispatch.
+  (`t/nativecall-cpointer-class-in-module.t`)
+
+- **Per-class BUILDALL: a custom BUILD takes over named-arg auto-assignment
+  only for its own class's attributes.** `X::DBDish::DBError::Pg` computes
+  `$!sqlstate is required` in its BUILD while its parent's required attributes
+  arrive as named args; mutsu suppressed auto-assignment MRO-wide whenever any
+  BUILD existed, mis-raising `X::Attribute::Required`.
+  (`t/new-build-parent-required-attr.t`)
+
+- **A sigilless binding in an `if` condition binds the value itself.**
+  `DBDish::StatementHandle.row` is `if my \r = self._row { … r.Array }`; mutsu
+  itemized `r` into a scalar container so `my @row = $sth.row` got one nested
+  element. Both the `my \r = …` form and the pointy `if EXPR -> \r { }` form
+  are fixed. (`t/if-pointy-sigilless-binding.t`)
+
+One upstream bug found while testing: DBIish 0.6.8's `commit`/`rollback`
+*methods* die under Rakudo too (`$!parent` is the driver, which has no
+`protect-connection`), so SQL-level `BEGIN`/`COMMIT`/`ROLLBACK` is the parity
+surface.
+
+Reproduction: docker `postgres:16` on port 15432, `tmp/dbiish-e2e-pg.raku` and
+`tmp/dbiish-pg-extra.raku` under `tmp/dbslot/DBIish-0.6.8` with the usual `-I`
+lines. With this, DBIish is end-to-end on both of its two most important real
+drivers; what remains for the battery is bundling
+(`todo/tickets/dbiish-blockers.md`).

--- a/src/compiler/helpers_block_inline.rs
+++ b/src/compiler/helpers_block_inline.rs
@@ -114,6 +114,19 @@ impl Compiler {
         self.hoist_sub_decls(stmts, true);
         // Hoist `my TYPE $var;` type constraints (see `hoist_typed_var_decls`).
         self.hoist_typed_var_decls(stmts);
+        // Register sigilless names BEFORE compiling their VarDecl (mirroring
+        // the `Stmt::SyntheticBlock` arm of `compile_stmt`): the marker
+        // statement comes AFTER the decl, but the decl must already know the
+        // name is sigilless so its store binds the value itself instead of
+        // itemizing it into a scalar container. This value-position path is
+        // how `if my \r = @rows { r.Array }` compiles its condition
+        // (`DoStmt(SyntheticBlock([VarDecl, MarkSigillessReadonly]))`) —
+        // without the pre-pass, `r` became `$[...]` and `r.Array` nested.
+        for s in stmts {
+            if let Stmt::MarkSigillessReadonly(name) | Stmt::MarkSigilless(name) = s {
+                self.sigilless_locals.insert(name.clone());
+            }
+        }
         for (i, stmt) in stmts.iter().enumerate() {
             let is_last = i == stmts.len() - 1;
             if is_last {

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -119,6 +119,38 @@ impl Compiler {
         self.pop_dynamic_scope_lexical(saved);
     }
 
+    /// Compile the `if EXPR -> v { }` binding declaration and return the
+    /// expression that reads the bound name back (for the truth test and the
+    /// branch body). A `\`-prefixed binding names a sigilless pointy
+    /// (`if EXPR -> \r { }`): it is registered as a sigilless local BEFORE the
+    /// decl compiles, so the store binds the condition value itself instead of
+    /// itemizing it into a scalar container (DBIish's `if self._row -> \r
+    /// { r.Array }` must not nest the row array), and it reads back as a bare
+    /// word rather than a `$`-variable.
+    pub(super) fn compile_if_binding_decl(&mut self, var_name: &str, cond: &Expr) -> Expr {
+        let (bare_name, read_expr) = if let Some(bare) = var_name.strip_prefix('\\') {
+            self.sigilless_locals.insert(bare.to_string());
+            (bare.to_string(), Expr::BareWord(bare.to_string()))
+        } else {
+            let bare = var_name.trim_start_matches('$').to_string();
+            (bare.clone(), Expr::Var(bare))
+        };
+        let var_decl = Stmt::VarDecl {
+            name: bare_name,
+            expr: cond.clone(),
+            type_constraint: None,
+            is_state: false,
+            is_our: false,
+            is_dynamic: false,
+            is_export: false,
+            export_tags: vec![],
+            custom_traits: Vec::new(),
+            where_constraint: None,
+        };
+        self.compile_stmt(&var_decl);
+        read_expr
+    }
+
     pub(super) fn compile_if_value(
         &mut self,
         cond: &Expr,
@@ -170,21 +202,8 @@ impl Compiler {
             self.code.emit(OpCode::EnterPointyTopic);
         }
         if let Some(var_name) = binding_var {
-            let bare_name = var_name.trim_start_matches('$').to_string();
-            let var_decl = Stmt::VarDecl {
-                name: bare_name.clone(),
-                expr: cond.clone(),
-                type_constraint: None,
-                is_state: false,
-                is_our: false,
-                is_dynamic: false,
-                is_export: false,
-                export_tags: vec![],
-                custom_traits: Vec::new(),
-                where_constraint: None,
-            };
-            self.compile_stmt(&var_decl);
-            self.compile_expr(&Expr::Var(bare_name));
+            let read_expr = self.compile_if_binding_decl(var_name, cond);
+            self.compile_expr(&read_expr);
         } else {
             self.compile_expr(cond);
         }

--- a/src/compiler/helpers_do_expr.rs
+++ b/src/compiler/helpers_do_expr.rs
@@ -130,21 +130,8 @@ impl Compiler {
         };
         let needs_cond_value = needs_at_underscore || cond_placeholder.is_some();
         if let Some(var_name) = binding_var {
-            let bare_name = var_name.trim_start_matches('$').to_string();
-            let var_decl = Stmt::VarDecl {
-                name: bare_name.clone(),
-                expr: cond.clone(),
-                type_constraint: None,
-                is_state: false,
-                is_our: false,
-                is_dynamic: false,
-                is_export: false,
-                export_tags: vec![],
-                custom_traits: Vec::new(),
-                where_constraint: None,
-            };
-            self.compile_stmt(&var_decl);
-            self.compile_expr(&Expr::Var(bare_name));
+            let read_expr = self.compile_if_binding_decl(var_name, cond);
+            self.compile_expr(&read_expr);
         } else {
             self.compile_expr(cond);
         }

--- a/src/compiler/helpers_sub_body.rs
+++ b/src/compiler/helpers_sub_body.rs
@@ -869,6 +869,46 @@ impl Compiler {
                     sub_compiler.compile_expr(&Expr::Literal(Value::TRUE));
                     continue;
                 }
+                // The same value-position statement forms `compile_routine_body_stmts`
+                // reifies for named subs: without these a phaser-carrying method whose
+                // tail is an `if`/block/decl compiled as a plain statement and returned
+                // Nil (DBDish::Pg's `prepare` ends in `LEAVE {...}; if ... { .new(...) }`).
+                if is_value
+                    && let Stmt::If {
+                        cond,
+                        then_branch,
+                        else_branch,
+                        binding_var,
+                    } = stmt
+                {
+                    sub_compiler.compile_if_value(cond, then_branch, else_branch, binding_var);
+                    continue;
+                }
+                if is_value && let Stmt::Block(stmts) | Stmt::SyntheticBlock(stmts) = stmt {
+                    sub_compiler.compile_block_inline(stmts);
+                    continue;
+                }
+                if is_value && let Stmt::VarDecl { name, .. } = stmt {
+                    sub_compiler.compile_stmt(stmt);
+                    if let Some(&slot) = sub_compiler.local_map.get(name) {
+                        sub_compiler.code.emit(OpCode::GetLocal(slot));
+                    } else {
+                        sub_compiler.emit_nil_value();
+                    }
+                    continue;
+                }
+                if is_value && let Stmt::Assign { name, .. } = stmt {
+                    sub_compiler.compile_stmt(stmt);
+                    if let Some(&slot) = sub_compiler.local_map.get(name) {
+                        sub_compiler.code.emit(OpCode::GetLocal(slot));
+                    } else {
+                        let idx = sub_compiler
+                            .code
+                            .add_constant(Value::str(sub_compiler.qualify_variable_name(name)));
+                        sub_compiler.code.emit(OpCode::GetGlobal(idx));
+                    }
+                    continue;
+                }
                 sub_compiler.compile_stmt(stmt);
             }
             if last_is_enter {

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -1709,21 +1709,7 @@ impl Compiler {
                 if let Some(var_name) = binding_var {
                     // Desugar: if EXPR -> $var { BODY } else { ELSE }
                     // into: { my $var = EXPR; if $var { BODY } else { ELSE } }
-                    let bare_name = var_name.trim_start_matches('$').to_string();
-                    let desugared_cond = Expr::Var(bare_name.clone());
-                    let var_decl = Stmt::VarDecl {
-                        name: bare_name,
-                        expr: cond.clone(),
-                        type_constraint: None,
-                        is_state: false,
-                        is_our: false,
-                        is_dynamic: false,
-                        is_export: false,
-                        export_tags: vec![],
-                        custom_traits: Vec::new(),
-                        where_constraint: None,
-                    };
-                    self.compile_stmt(&var_decl);
+                    let desugared_cond = self.compile_if_binding_decl(var_name, cond);
                     self.compile_condition_expr(&desugared_cond);
                 } else {
                     self.compile_condition_expr(cond);

--- a/src/parser/stmt/control/conditionals.rs
+++ b/src/parser/stmt/control/conditionals.rs
@@ -113,7 +113,17 @@ fn lower_if_clause_binding(
         return (None, then_branch);
     }
     if param_defs.len() == 1 && is_simple_if_binding(&param_defs[0]) {
-        return (Some(param_defs[0].name.clone()), then_branch);
+        // A sigilless pointy (`if EXPR -> \r { }`) is marked with a leading
+        // `\` so the compiler binds the value itself (no scalar itemization)
+        // and resolves the name as a bare word — see
+        // `Compiler::compile_if_binding_decl`.
+        let p = &param_defs[0];
+        let name = if p.sigilless {
+            format!("\\{}", p.name)
+        } else {
+            p.name.clone()
+        };
+        return (Some(name), then_branch);
     }
 
     let source_binding = next_if_bind_tmp_name();

--- a/src/runtime/methods_grammar.rs
+++ b/src/runtime/methods_grammar.rs
@@ -755,13 +755,14 @@ impl Interpreter {
         None
     }
 
-    /// Dispatch the silent-action captures reachable from a match's attribute
-    /// map: this level's own `silent_caps` (hidden `<.foo>` subrule matches that
-    /// carry nested captures), then — descending through positional `( )` groups
-    /// — each group's `silent_caps`. Only `silent_caps` are fired, never a group's
-    /// named children: those are already dispatched by the named-children walk in
-    /// `invoke_grammar_actions`, so re-firing them would double-dispatch (see
-    /// t/grammar-reduce-time-dynvar.t). Captures are dispatched in source order.
+    /// Dispatch this level's own silent-action captures: hidden `<.foo>`
+    /// subrule matches that carry nested captures. Only `silent_caps` are
+    /// fired, never named children or positional groups: named children are
+    /// dispatched by the named-children walk in `invoke_grammar_actions`, and
+    /// positional `( )` groups are recursed into by its positional walk (which
+    /// fires each group's own `silent_caps` exactly once) — descending here too
+    /// would double-dispatch (see t/grammar-reduce-time-dynvar.t). Captures are
+    /// dispatched in source order.
     fn dispatch_silent_action_caps(
         &mut self,
         attrs: &crate::value::AttrReadGuard<'_>,
@@ -782,15 +783,6 @@ impl Interpreter {
             for item in items {
                 let dispatch_name = Self::get_action_name(&item).unwrap_or_default();
                 self.invoke_grammar_actions(item, actions, &dispatch_name)?;
-            }
-        }
-        let positionals: Vec<Value> = match attrs.get("list").map(Value::view) {
-            Some(ValueView::Array(pos_arr, _)) => pos_arr.iter().cloned().collect(),
-            _ => Vec::new(),
-        };
-        for p in &positionals {
-            if let ValueView::Instance { attributes, .. } = p.view() {
-                self.dispatch_silent_action_caps(&attributes.as_map(), actions)?;
             }
         }
         Ok(())
@@ -858,6 +850,54 @@ impl Interpreter {
                 }
             }
             updated_attrs.insert("named".to_string(), Value::hash(updated_named));
+        }
+
+        // Recurse into positional `( )` group captures the same way. A group
+        // itself has no action method (dispatch name "" unless the capture
+        // carries an aliased `action_name`), but the named subrules matched
+        // INSIDE it do — DBDish::Pg's tokenizer is `( <normal> | <placeholder>
+        // )*` with per-token actions — and their `.made` must be attached to
+        // the Match objects reachable via `$0[…]`, so the updated children are
+        // stored back into `list`.
+        if let Some(ValueView::Array(pos_arr, meta)) =
+            attributes.as_map().get("list").map(Value::view)
+        {
+            let mut updated_list = Vec::with_capacity(pos_arr.len());
+            let mut changed = false;
+            for item in pos_arr.as_ref() {
+                let updated_item = match item.view() {
+                    // A quantified group `(...)*`: an Array of per-iteration Matches.
+                    ValueView::Array(items, imeta) => {
+                        let mut updated_items = Vec::with_capacity(items.len());
+                        for it in items.as_ref() {
+                            let dispatch_name = Self::get_action_name(it).unwrap_or_default();
+                            let updated =
+                                self.invoke_grammar_actions(it.clone(), actions, &dispatch_name)?;
+                            updated_items.push(updated);
+                        }
+                        Value::array_with_kind(
+                            crate::gc::Gc::new(crate::value::ArrayData::new(updated_items)),
+                            imeta,
+                        )
+                    }
+                    ValueView::Instance { .. } => {
+                        let dispatch_name = Self::get_action_name(item).unwrap_or_default();
+                        self.invoke_grammar_actions(item.clone(), actions, &dispatch_name)?
+                    }
+                    _ => item.clone(),
+                };
+                changed = true;
+                updated_list.push(updated_item);
+            }
+            if changed {
+                updated_attrs.insert(
+                    "list".to_string(),
+                    Value::array_with_kind(
+                        crate::gc::Gc::new(crate::value::ArrayData::new(updated_list)),
+                        meta,
+                    ),
+                );
+            }
         }
 
         // Dispatch actions for silent-action captures: hidden `<.foo>` subrule

--- a/src/runtime/methods_instance_ops.rs
+++ b/src/runtime/methods_instance_ops.rs
@@ -7,6 +7,33 @@ use crate::value::AttrMap;
 use crate::value::ValueView;
 
 impl Interpreter {
+    /// Whether an unqualified private call is permitted *lexically*: the
+    /// executing code's `self` is an instance of the owning class.
+    ///
+    /// `method_class_stack` reflects the *runtime* caller, which is wrong for a
+    /// private call written in a closure: in `$.b.run: { self!secret }` the
+    /// stack top is B (whose method invoked the closure) though the call is
+    /// lexically inside A. Raku resolves private calls lexically, and the
+    /// closure runs with its captured `self` — so an env `self` whose class is
+    /// (or inherits from) the owner marks code that was written inside that
+    /// class. DBDish's Pg StatementHandle BUILD calls `self!get-meta` inside a
+    /// block passed to `$!parent.protect-connection` this way.
+    fn lexical_self_allows_private(&mut self, resolved_owner: &str) -> bool {
+        let Some(ValueView::Instance {
+            class_name: self_cls,
+            ..
+        }) = self.env.get("self").map(Value::view)
+        else {
+            return false;
+        };
+        let self_cls = self_cls.resolve().to_string();
+        self_cls == resolved_owner
+            || self
+                .class_mro(&self_cls)
+                .iter()
+                .any(|s| s.resolve() == resolved_owner)
+    }
+
     /// Dispatch method calls for Instance values and handle all fallback paths.
     ///
     /// This is called from `call_method_with_values` after the main method name
@@ -132,7 +159,8 @@ impl Interpreter {
                                 caller_class
                                     .as_ref()
                                     .is_some_and(|caller| trusted.contains(caller))
-                            });
+                            })
+                        || self.lexical_self_allows_private(&resolved_owner);
                     if !caller_allowed {
                         if was_qualified {
                             return Err(make_private_permission_error(
@@ -1590,7 +1618,8 @@ impl Interpreter {
                                 caller_class
                                     .as_ref()
                                     .is_some_and(|caller| trusted.contains(caller))
-                            });
+                            })
+                        || self.lexical_self_allows_private(&resolved_owner);
                     if !caller_allowed {
                         return Err(make_private_permission_error(
                             pm_name,

--- a/src/runtime/methods_object.rs
+++ b/src/runtime/methods_object.rs
@@ -381,6 +381,45 @@ impl Interpreter {
         plan
     }
 
+    /// Attribute names declared by an MRO layer that has its OWN `BUILD`
+    /// (class submethod or role-composed). Raku's BUILDALL runs one build step
+    /// per class: a custom BUILD replaces the default named-arg → attribute
+    /// auto-assignment only for the attributes of the layer that declares it —
+    /// a parent class without its own BUILD still auto-assigns
+    /// (X::DBDish::DBError::Pg computes `$!sqlstate` in its BUILD while its
+    /// parent's `$.native-message is required` arrives as an ordinary named
+    /// arg; gating on "any BUILD in the MRO" mis-raised X::Attribute::Required
+    /// for it).
+    pub(crate) fn build_owning_attr_names(
+        &mut self,
+        classes: &[String],
+    ) -> std::collections::HashSet<String> {
+        let mut owned = std::collections::HashSet::new();
+        for cls in classes {
+            if cls == "Any" || cls == "Mu" {
+                continue;
+            }
+            let has_own_build = self
+                .registry()
+                .classes
+                .get(cls)
+                .is_some_and(|cd| cd.methods.contains_key("BUILD"))
+                || !self
+                    .ordered_role_submethods_for_class(cls, "BUILD")
+                    .is_empty();
+            if !has_own_build {
+                continue;
+            }
+            let registry = self.registry();
+            if let Some(cd) = registry.classes.get(cls) {
+                for a in cd.attributes.iter() {
+                    owned.insert(a.0.clone());
+                }
+            }
+        }
+        owned
+    }
+
     /// Default-construct `class_name` natively when it is eligible (see
     /// `is_native_default_constructible`). Returns `None` for ineligible
     /// classes so callers fall through to the full constructor dispatch.

--- a/src/runtime/methods_object_default_ctor.rs
+++ b/src/runtime/methods_object_default_ctor.rs
@@ -32,21 +32,27 @@ impl Interpreter {
         let sigil_of =
             |name: &str| -> char { attr_idx_of(name).map(|i| class_attrs[i].5).unwrap_or('$') };
 
-        // A custom BUILD replaces the default named-argument → attribute binding:
-        // with a BUILD present, a provided `:attr(value)` is NOT auto-assigned to
-        // `$!attr` — only BUILD decides what gets set (via its signature's
-        // `:$!attr` params or explicit assignment in its body). So
+        // A custom BUILD replaces the default named-argument → attribute binding
+        // for the attributes of the MRO layer that declares it: a provided
+        // `:attr(value)` for such an attribute is NOT auto-assigned — only that
+        // BUILD decides what gets set (via its signature's `:$!attr` params or
+        // explicit assignment in its body). So
         // `class P { has $.x = 42; submethod BUILD() {} }; P.new(:666x).x` is 42.
-        // Skip the auto-assignment loop when the class has a BUILD; defaults are
-        // still filled below and BUILD runs afterward.
+        // Attributes of layers WITHOUT their own BUILD still auto-assign
+        // (per-class BUILDALL semantics — see `build_owning_attr_names`).
+        // Defaults are still filled below and BUILD runs afterward.
         let has_build = plan.has_build;
+        let build_owned_attrs = if has_build {
+            let mro = self.mro_readonly(cn_resolved);
+            self.build_owning_attr_names(&mro)
+        } else {
+            Default::default()
+        };
 
         let mut attrs = AttrMap::new();
         for arg in args {
-            if has_build {
-                break;
-            }
             if let ValueView::Pair(key, val) = arg.view()
+                && !build_owned_attrs.contains(key.as_str())
                 && self.is_attribute_buildable(cn_resolved, key)
             {
                 let key_sym = attr_idx_of(key).map(|i| plan.attr_syms[i]);

--- a/src/runtime/methods_object_dispatch_new.rs
+++ b/src/runtime/methods_object_dispatch_new.rs
@@ -1655,12 +1655,24 @@ impl Interpreter {
                             .is_empty()
                 });
                 let has_build_phase = any_build || any_role_build;
+                // A custom BUILD takes over named-arg → attribute mapping only
+                // for the attributes of the MRO layer declaring it; other
+                // layers still auto-assign (see `build_owning_attr_names`).
+                let build_owned_attrs = if has_build_phase {
+                    let mro_names: Vec<String> =
+                        class_mro.iter().map(|s| s.as_str().to_string()).collect();
+                    self.build_owning_attr_names(&mro_names)
+                } else {
+                    Default::default()
+                };
                 let mut deferred_defaults: Vec<super::attr_build_defaults::DeferredAttrDefault> =
                     Vec::new();
                 for val in &args {
                     match val.view() {
                         ValueView::Pair(k, v) => {
-                            if !any_build && self.is_attribute_buildable(class_key, k) {
+                            if !build_owned_attrs.contains(k.as_str())
+                                && self.is_attribute_buildable(class_key, k)
+                            {
                                 let sigil = sigil_map.get(k).copied().unwrap_or('$');
                                 let mut value = v.clone();
                                 // A coercion-typed attribute (`has Int() $.x`)

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -66,7 +66,9 @@ impl CType {
             "uint64" | "ulong" | "ulonglong" | "uint" | "size_t" => CType::U64,
             "num32" => CType::F32,
             "num64" | "num" | "Num" => CType::F64,
-            "Str" => CType::Str,
+            // `str` is the native string type — still a NUL-terminated `char*`
+            // at the C boundary (DBDish::Pg declares `PQconnectdb(str ...)`).
+            "Str" | "str" => CType::Str,
             "Pointer" | "OpaquePointer" => CType::Pointer,
             // A byte buffer passed as a `void*` to its raw bytes. `blob8`/`buf8`
             // are the `uint8` parametric spellings; the bracketed forms
@@ -858,6 +860,18 @@ fn marshal_carray_arg(
     raw: &Value,
 ) -> Result<(libffi::middle::Type, ArgOwner), String> {
     use libffi::middle::Type;
+    // An UNDEFINED argument (a type object / Nil) for a `CArray[T]` parameter
+    // is a genuine NULL, as in Rakudo. Handing over a pointer to an empty
+    // buffer instead is fatal for callees that branch on NULL-ness: libpq's
+    // `PQexecPrepared(..., paramLengths, paramFormats, ...)` treats a non-NULL
+    // `paramFormats` as "per-parameter format array" and reads nParams entries
+    // from it — DBDish::Pg passes `Null` (a Pointer type object) for both.
+    {
+        let resolved = resolve_arg(raw);
+        if !crate::runtime::types::value_is_defined(&resolved) {
+            return Ok((Type::pointer(), ArgOwner::Ptr(std::ptr::null())));
+        }
+    }
     // An unparameterized `CArray` parameter carries no element type in the
     // signature, so take it from the argument itself (`CArray[int32].new` tags
     // the array with its element type).
@@ -877,7 +891,17 @@ fn marshal_carray_arg(
         let mut strings = Vec::with_capacity(list.len());
         let mut ptrs: Vec<*const std::ffi::c_char> = Vec::with_capacity(list.len() + 1);
         for item in &list {
-            let s = item.to_string_value();
+            // An undefined element (a `Str` type object / Nil) is a NULL
+            // `char*`, same as an undefined `Str` argument. Libpq's
+            // `PQconnectdbParams` key/value arrays are terminated exactly this
+            // way (`$keys[$i] = Str`); stringifying instead sent "(Str)" as a
+            // connection option.
+            let resolved = resolve_arg(item);
+            if !crate::runtime::types::value_is_defined(&resolved) {
+                ptrs.push(std::ptr::null());
+                continue;
+            }
+            let s = resolved.to_string_value();
             let cstr = std::ffi::CString::new(s)
                 .map_err(|_| "CArray[Str] element contains an embedded NUL byte".to_string())?;
             ptrs.push(cstr.as_ptr());
@@ -938,4 +962,52 @@ pub fn call_native(spec: &NativeCallSpec, _args: &[Value]) -> Result<Value, Runt
         "NativeCall is not available in this build (cannot call '{}')",
         spec.symbol
     )))
+}
+
+#[cfg(all(test, feature = "libffi"))]
+mod tests {
+    use super::*;
+
+    fn carray_spec(elem: CType) -> ParamSpec {
+        ParamSpec {
+            ct: CType::CArray,
+            is_rw: false,
+            elem: Some(elem),
+        }
+    }
+
+    /// An undefined `CArray[T]` argument (a type object) must marshal as a
+    /// genuine NULL — libpq branches on the NULL-ness of `paramFormats`.
+    #[test]
+    fn undefined_carray_argument_is_null() {
+        let ty = Value::package(crate::symbol::Symbol::intern("Pointer"));
+        let (_, owner) = marshal_carray_arg(&carray_spec(CType::I32), &ty).unwrap();
+        match owner {
+            ArgOwner::Ptr(p) => assert!(p.is_null(), "expected a NULL pointer"),
+            other => panic!(
+                "expected ArgOwner::Ptr, got {:?}",
+                std::mem::discriminant(&other)
+            ),
+        }
+    }
+
+    /// An undefined element of a `CArray[Str]` (`$a[$i] = Str`) is a NULL
+    /// `char*` — libpq's `PQconnectdbParams` key array is terminated this way.
+    #[test]
+    fn undefined_carray_str_element_is_null() {
+        let arr = Value::array(vec![
+            Value::str("host".to_string()),
+            Value::package(crate::symbol::Symbol::intern("Str")),
+        ]);
+        let (_, owner) = marshal_carray_arg(&carray_spec(CType::Str), &arr).unwrap();
+        match owner {
+            ArgOwner::CArrayStr { ptrs, .. } => {
+                assert_eq!(ptrs.len(), 3, "two elements + terminator");
+                assert!(!ptrs[0].is_null(), "defined element is a real char*");
+                assert!(ptrs[1].is_null(), "type-object element is NULL");
+                assert!(ptrs[2].is_null(), "the array stays NULL-terminated");
+            }
+            _ => panic!("expected ArgOwner::CArrayStr"),
+        }
+    }
 }

--- a/src/runtime/regex/regex_eval.rs
+++ b/src/runtime/regex/regex_eval.rs
@@ -447,12 +447,32 @@ impl Interpreter {
         // ONLY to extract `$*` dynamic-var writes (which flow through the scratch
         // env into the overlay, not through actions state). `InstanceAttrs::clone`
         // is a deep, fresh-cell copy.
+        //
+        // The copy gets a FRESH instance id: `invoke_grammar_actions` re-reads
+        // the actions object from the env after each dispatch by (class, id)
+        // match, and the scratch env holds the caller's ORIGINAL instance — a
+        // copy sharing the id would be silently swapped back to the original
+        // mid-walk, leaking every subsequent attribute mutation (pinned by
+        // t/grammar-reduce-time-dynvar.t test 5).
         let mut actions = match actions.view() {
             ValueView::Instance {
                 class_name,
                 attributes,
-                id,
-            } => Value::instance_parts(class_name, crate::gc::Gc::new((**attributes).clone()), id),
+                ..
+            } => {
+                // Deep-clone first (detaching shared containers), then rebuild
+                // under the fresh id — `InstanceAttrs` carries its id internally
+                // and `instance_parts` asserts the two agree.
+                let detached = (**attributes).clone().to_map();
+                let fresh_id = crate::value::next_instance_id();
+                Value::instance_parts(
+                    class_name,
+                    crate::gc::Gc::new(crate::value::InstanceAttrs::new(
+                        class_name, detached, fresh_id, false,
+                    )),
+                    fresh_id,
+                )
+            }
             _ => actions.clone(),
         };
         let match_obj = Value::make_match_object_full_q(

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -405,7 +405,20 @@ impl Interpreter {
         // Map each parameter's type constraint to a C type. An unmapped /
         // missing type means we cannot marshal it — skip native registration so
         // the failure surfaces clearly rather than mis-calling.
-        let mut params = Vec::with_capacity(param_defs.len());
+        let mut params = Vec::with_capacity(param_defs.len() + 1);
+        // A native method receives its invocant as the first C argument whether
+        // or not the signature spells it: `method PQstatus(--> int32)` on a
+        // CPointer class is `PQstatus(PGconn*)` (DBDish::Pg declares its whole
+        // surface this way). An explicit invocant (`MYSQL:D:`) arrives as a
+        // leading `is_invocant` parameter; synthesize the pointer slot when the
+        // signature leaves it implicit.
+        if invocant_class.is_some() && !param_defs.first().is_some_and(|pd| pd.is_invocant) {
+            params.push(ParamSpec {
+                ct: CType::Pointer,
+                is_rw: false,
+                elem: None,
+            });
+        }
         for pd in param_defs {
             // A method's invocant is its first C argument, passed by pointer —
             // a handle's address for `:D:`, NULL for `:U:` (`MYSQL.mysql_init`
@@ -490,7 +503,7 @@ impl Interpreter {
                 // pointer in an instance of the declared class so it round-trips
                 // as that handle type (`ret_struct` carries the class name).
                 None if self.is_native_struct_type(rt) => {
-                    ret_struct = Some(Self::native_struct_class_name(rt));
+                    ret_struct = Some(self.registered_native_class_name(rt));
                     CType::Pointer
                 }
                 None => return Ok(()),
@@ -558,6 +571,24 @@ impl Interpreter {
     /// `SSL_METHOD`), matching how the class is registered by its short name.
     fn native_struct_class_name(name: &str) -> String {
         name.rsplit("::").next().unwrap_or(name).to_string()
+    }
+
+    /// The class name a returned native handle should be tagged with so that
+    /// ordinary method dispatch on it works: the name the class is actually
+    /// *registered* under. A class declared inside a `unit module` is
+    /// registered package-qualified (`DBDish::Pg::Native::PGresult`) while the
+    /// return type is spelled short (`--> PGresult`); resolving through the
+    /// env — the same lookup `.^name` performs — recovers the registered name.
+    /// Falls back to the short name for a class not visible here (declared in
+    /// another compilation unit), preserving the previous behavior.
+    fn registered_native_class_name(&mut self, name: &str) -> String {
+        if let Some(ValueView::Package(sym)) = self.env().get(name).map(Value::view) {
+            let resolved = sym.resolve().to_string();
+            if self.registry().classes.contains_key(&resolved) {
+                return resolved;
+            }
+        }
+        Self::native_struct_class_name(name)
     }
 
     /// Follow a `constant` type alias to the type it names.

--- a/t/grammar-actions-positional-group.t
+++ b/t/grammar-actions-positional-group.t
@@ -1,0 +1,58 @@
+use v6;
+use Test;
+
+# Action methods must fire for subrules matched INSIDE a positional capture
+# group, and their `.made` must be readable through `$0[…]`. DBDish::Pg's
+# placeholder tokenizer is exactly this shape:
+#   token TOP { ^ ( <normal> | <placeholder> )* $ }
+# with per-token action methods joined in the TOP action.
+plan 4;
+
+my grammar Tok {
+    token normal      { <-[?]>+ }
+    token placeholder { '?' }
+    token TOP { ^ ( | <normal> | <placeholder> )* $ }
+}
+
+my class Actions {
+    has $.counter = 0;
+    method normal($/)      { make $/.Str }
+    method placeholder($/) { make '$' ~ ++$!counter }
+    method TOP($/) {
+        make $0.flatmap({ .values[0].ast }).join;
+    }
+}
+
+is Tok.parse('ab?cd?e', :actions(Actions.new)).ast, 'ab$1cd$2e',
+    'subrule actions fire inside a quantified positional group';
+
+is Tok.parse('no placeholders', :actions(Actions.new)).ast, 'no placeholders',
+    'single-alternative group round-trips';
+
+# Non-quantified single group: the same walk must recurse into it.
+my grammar One {
+    token word { \w+ }
+    token TOP { ^ (<word>) '!' $ }
+}
+my class OneActions {
+    method word($/) { make $/.Str.uc }
+    method TOP($/)  { make $0<word>.ast }
+}
+is One.parse('hey!', :actions(OneActions.new)).ast, 'HEY',
+    'action fires for a subrule inside a plain group';
+
+# A named subrule OUTSIDE a group must keep firing exactly once (no
+# double-dispatch through the positional walk).
+my grammar Count {
+    token item { \w+ }
+    token TOP { ^ <item>+ % ',' $ }
+}
+my class CountActions {
+    has $.fired = 0;
+    method item($/) { $!fired++ }
+    method TOP($/)  { make $!fired }
+}
+is Count.parse('a,b,c', :actions(CountActions.new)).ast, 3,
+    'named subrule actions fire exactly once each';
+
+done-testing;

--- a/t/if-pointy-sigilless-binding.t
+++ b/t/if-pointy-sigilless-binding.t
@@ -1,0 +1,45 @@
+use v6;
+use Test;
+
+# A sigilless binding in an `if` condition — `if my \r = EXPR {}` or the
+# pointy `if EXPR -> \r {}` — binds the value ITSELF (no scalar container),
+# so an `@`-array condition must not itemize: `r.Array` yields the same
+# elements, not a single nested item. DBDish::StatementHandle's `row` is
+# `if my \r = self._row { ... r.Array }`, whose result feeds `my @row = ...`.
+plan 8;
+
+class C {
+    method _row { my @l; @l.push(1); @l.push(2); @l }
+    method decl    { if my \r = self._row { r.Array } }
+    method pointy  { if self._row -> \r { r.Array } }
+    method with-p  { with self._row -> \r { r.Array } }
+}
+
+my @a = C.new.decl;
+is @a.elems, 2, 'if my \r = @rows: r.Array keeps its elements';
+is @a[0], 1, '... first element intact';
+
+my @b = C.new.pointy;
+is @b.elems, 2, 'if EXPR -> \r: r.Array keeps its elements';
+
+my @c = C.new.with-p;
+is @c.elems, 2, 'with EXPR -> \r: r.Array keeps its elements';
+
+if 42 -> \v {
+    is v, 42, 'pointy sigilless binds the condition value';
+}
+
+my $else-taken = False;
+if 0 -> \w { } else { $else-taken = True }
+ok $else-taken, 'falsy condition still takes the else branch';
+
+# Scalar pointy binding stays a container.
+if 5 -> $v { is $v, 5, 'scalar pointy binding still works' }
+
+# Re-binding in a loop condition works per iteration.
+my $i = 0;
+my @seen;
+while my \x = ($i < 3 ?? ++$i !! Nil) { @seen.push(x) }
+is @seen.join(','), '1,2,3', 'sigilless while-condition binding re-binds each iteration';
+
+done-testing;

--- a/t/lib/PgLikeNative.rakumod
+++ b/t/lib/PgLikeNative.rakumod
@@ -1,0 +1,13 @@
+unit module PgLikeNative;
+use NativeCall;
+
+# Mirrors DBDish::Pg::Native's shape: a CPointer class declared inside a
+# `unit module` (so it registers package-qualified), whose native methods
+# leave the invocant implicit and which also carries ordinary Raku methods.
+class StrHandle is export is repr('CPointer') {
+    method strlen(--> size_t) is native { * }
+    method is-ok { self.strlen > 0 }
+}
+
+sub make-handle(str $s --> StrHandle) is export is native is symbol('strdup') { * }
+sub free-handle(StrHandle $h) is export is native is symbol('free') { * }

--- a/t/method-leave-tail-if-value.t
+++ b/t/method-leave-tail-if-value.t
@@ -1,0 +1,42 @@
+use v6;
+use Test;
+
+# A method carrying a LEAVE (or other block phaser) must still produce the
+# value of a tail `if` / block / declaration — DBDish::Pg's `prepare` ends in
+# `LEAVE { … }; if $result && $result.is-ok { StatementHandle.new(…) } else …`
+# and mutsu returned Nil from it (the phaser-carrying compile path lacked the
+# value-position statement forms the plain path reifies).
+plan 6;
+
+my $left = 0;
+class C {
+    method tail-if {
+        LEAVE { $left++ }
+        if 1 { 42 } else { 'no' }
+    }
+    method tail-if-else {
+        LEAVE { $left++ }
+        if 0 { 'no' } else { 'e' }
+    }
+    method tail-block {
+        LEAVE { $left++ }
+        do { 'blk' }
+    }
+    method tail-decl {
+        LEAVE { $left++ }
+        my $x = 7;
+        $x
+    }
+}
+
+is C.new.tail-if, 42, 'LEAVE + tail if (then branch) returns its value';
+is C.new.tail-if-else, 'e', 'LEAVE + tail if (else branch) returns its value';
+is C.new.tail-block, 'blk', 'LEAVE + tail do-block returns its value';
+is C.new.tail-decl, 7, 'LEAVE + tail variable read returns its value';
+is $left, 4, 'every LEAVE phaser ran';
+
+# sub form stays correct too (guards the shared compile helper).
+sub s-tail-if { LEAVE { $left++ }; if 1 { 'sub-ok' } }
+is s-tail-if(), 'sub-ok', 'sub LEAVE + tail if keeps its value';
+
+done-testing;

--- a/t/nativecall-cpointer-class-in-module.t
+++ b/t/nativecall-cpointer-class-in-module.t
@@ -1,0 +1,18 @@
+use v6;
+use lib 't/lib';
+use Test;
+use PgLikeNative;
+
+# A native call returning a CPointer class that was declared inside a
+# `unit module` must tag the instance with the name the class is *registered*
+# under (package-qualified), so ordinary method dispatch on the handle works.
+# DBDish::Pg's `PQprepare(--> PGresult)` + `$result.is-ok` is this exact shape.
+plan 3;
+
+my $h = make-handle("hello");
+ok $h.defined, 'native sub returned a handle instance';
+is $h.strlen, 5, 'native method on the module-scoped CPointer class works';
+ok $h.is-ok, 'ordinary Raku method on the returned handle dispatches';
+free-handle($h);
+
+done-testing;

--- a/t/nativecall-method-implicit-invocant.t
+++ b/t/nativecall-method-implicit-invocant.t
@@ -1,0 +1,33 @@
+use v6;
+use Test;
+use NativeCall;
+
+# A native method's invocant is its first C argument even when the signature
+# does not spell it: `method strlen(--> size_t)` on a CPointer class is
+# `strlen(char*)`. DBDish::Pg declares its whole libpq surface this way
+# (`method PQstatus(--> int32)`), unlike DBDish::mysql which writes the
+# invocant out (`::?CLASS:D:`).
+plan 4;
+
+class CStrHandle is repr('CPointer') {
+    method strlen(--> size_t) is native { * }
+    # A regular (non-native) method on a CPointer class must dispatch too.
+    method double-len { self.strlen * 2 }
+}
+
+# `str` (the native string type) must marshal like `Str` — a NUL-terminated
+# char*. DBDish::Pg declares `sub PQconnectdb(str --> PGconn)`.
+sub strdup(str --> CStrHandle) is native { * }
+sub free(CStrHandle) is native { * }
+
+my $h = strdup("hello");
+ok $h.defined, 'native sub returned a CPointer instance';
+is $h.strlen, 5, 'implicit invocant passed as the first C argument';
+is $h.double-len, 10, 'regular method on a CPointer class dispatches';
+
+my $empty = strdup("");
+is $empty.strlen, 0, 'empty native str round-trips';
+
+free($_) for $h, $empty;
+
+done-testing;

--- a/t/new-build-parent-required-attr.t
+++ b/t/new-build-parent-required-attr.t
@@ -1,0 +1,36 @@
+use v6;
+use Test;
+
+# Raku's BUILDALL runs one build step per MRO class: a custom BUILD replaces
+# the default named-arg → attribute auto-assignment only for the attributes of
+# the class that declares it. A parent class without its own BUILD still
+# auto-assigns — and its `is required` attributes are satisfied by named args.
+# X::DBDish::DBError::Pg (`has $.sqlstate is required` computed in BUILD, with
+# required parent attrs passed as named args) is this exact shape.
+plan 5;
+
+class Base { has $.msg is required; has $.extra = 'dflt'; }
+class Kid is Base {
+    has $.state is required;
+    submethod BUILD(:$x) { $!state = $x * 2 }
+}
+
+my $k = Kid.new(msg => 'm', x => 21);
+is $k.state, 42, "the child's BUILD computed its own attribute";
+is $k.msg, 'm', "the parent's attribute auto-assigned from the named arg";
+is $k.extra, 'dflt', "the parent's defaulted attribute kept its default";
+
+# The child's required attribute must still be enforced post-BUILD.
+class Kid2 is Base {
+    has $.state is required;
+    submethod BUILD() { }
+}
+dies-ok { Kid2.new(msg => 'm') },
+    "a required attribute the BUILD leaves unset still dies";
+
+# A custom BUILD still takes over ITS OWN class's named-arg mapping.
+class P { has $.x = 42; submethod BUILD() { } }
+is P.new(:666x).x, 42,
+    "a named arg for a BUILD-owning class's attribute is not auto-assigned";
+
+done-testing;

--- a/t/private-method-call-in-closure.t
+++ b/t/private-method-call-in-closure.t
@@ -1,0 +1,32 @@
+use v6;
+use Test;
+
+# A private method call is resolved lexically: `self!secret` written inside
+# class A stays legal when the block containing it is invoked by ANOTHER
+# object's method. DBDish::Pg's StatementHandle BUILD calls `self!get-meta`
+# inside a block passed to `$!parent.protect-connection`.
+plan 3;
+
+class Runner {
+    method run(&code) { code() }
+}
+
+class Owner {
+    has $.runner;
+    has $.log = '';
+    method !secret($x) { $!log ~= "secret($x)"; $x * 2 }
+    method go {
+        $.runner.run: { self!secret(21) };
+    }
+}
+
+my $o = Owner.new(runner => Runner.new);
+is $o.go, 42, 'private call inside a closure run by another class works';
+is $o.log, 'secret(21)', 'the private method body ran';
+
+# Calling a private method from genuinely-foreign code must still die
+# (compile-time in Rakudo, runtime in mutsu — EVAL covers both).
+dies-ok { EVAL q[class Outsider { method poke($victim) { $victim!secret(1) } }; Outsider.new.poke(Owner.new(runner => Runner.new))] },
+    'a foreign class still cannot call the private method';
+
+done-testing;

--- a/todo/tickets/dbiish-blockers.md
+++ b/todo/tickets/dbiish-blockers.md
@@ -6,6 +6,18 @@ This file is the ledger of what stops `DBIish` from running on mutsu. Measured
 2026-07-25, `DBIish` 0.6.8, debug build of `main`, and re-measured the same day
 after the parse blocker was fixed.
 
+**Update 2026-07-29 (Pg): the same lifecycle runs end-to-end against a live
+PostgreSQL 16 too** (`DBIish.connect('Pg', …)` → `PQprepare`/`PQexecPrepared`
+with `$1`-placeholders → typed `allrows`/`row` → `dispose`), byte-identical to
+Rakudo, including the extended surface (bool/bigint/float8/numeric/text/NULL
+round-trips, column metadata, `rows`, SQL-level transactions, an
+`X::DBDish::DBError::Pg` raised and caught, `server-version`). Seven more
+general fixes — see
+[`news/2026-07/dbiish-postgresql-end-to-end.md`](../../news/2026-07/dbiish-postgresql-end-to-end.md).
+The upstream 0.6.8 `commit`/`rollback` *methods* are broken in DBIish itself
+(`$!parent` is the driver, which has no `protect-connection`) — raku dies the
+same way, so SQL-level `BEGIN`/`COMMIT`/`ROLLBACK` is the parity surface.
+
 **Update 2026-07-29 (final): the full prepared-statement lifecycle runs
 end-to-end against a live MariaDB through the front door**
 (`DBIish.connect('mysql', …)` → `prepare` → typed-parameter `execute` →


### PR DESCRIPTION
## Summary

DBIish 0.6.8's prepared-statement lifecycle now runs against a live PostgreSQL 16 **byte-identically to Rakudo**: `DBIish.connect('Pg', …)` → DDL → `PQprepare` (`$1` placeholders) → typed-parameter `PQexecPrepared` → `allrows`/`row` with type conversion → `dispose`. An extended check (bool/bigint/float8/numeric/text/NULL round-trips, column metadata, `rows`, SQL-level transactions, a caught `X::DBDish::DBError::Pg`, `server-version`) is also byte-identical. Combined with the MariaDB milestone (#5546), DBIish is end-to-end on both of its most important real drivers.

Every fix is general-purpose — nothing special-cases DBIish:

- **NativeCall**: implicit method invocants (`method PQstatus(--> int32)` on a CPointer class passes `self` as the first C argument), the native `str` type, and genuine NULLs for undefined `CArray` arguments and undefined `CArray[Str]` elements (the latter two fixed a libpq segfault and an invalid connection option).
- **Grammar actions** fire for subrules inside positional `( )` capture groups with `.made` visible through `$0[…]`; the reduce-time actions copy gets a fresh instance id so the post-dispatch env refresh can't leak mutations to the real object (pinned by `t/grammar-reduce-time-dynvar.t` test 5).
- **Private method calls resolve lexically**: a closure whose captured `self` is an instance of the owning class may call its private methods even when another object's method runs the block.
- **A method with a LEAVE phaser keeps its tail `if`/block/decl value.**
- **Native handles carry their registered class name** (package-qualified inside a `unit module`), so ordinary methods on them dispatch.
- **Per-class BUILDALL**: a custom BUILD takes over named-arg auto-assignment only for its own class's attributes; a parent's `is required` attribute satisfied by a named arg no longer mis-raises `X::Attribute::Required`.
- **Sigilless `if`/`with` condition bindings** (`if my \r = …`, `if EXPR -> \r`) bind the value itself instead of itemizing it.

## Testing

- 8 new `t/` pin files (all verified against raku first) + 2 Rust unit tests for the CArray NULL marshalling.
- Local `make test` (2,582 files) and `make roast` (1,435 files / 218,774 tests): **full PASS**.
- Both DB e2e scripts re-verified after every change; MariaDB e2e still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)