### PR TITLE
fix: NativeCall rw numeric out-params, smiley-typed C params, and Buf introspection

### DIFF
--- a/docs/batteries/dbiish-upstream-bugs.md
+++ b/docs/batteries/dbiish-upstream-bugs.md
@@ -1,0 +1,52 @@
+# DBIish 0.6.8 — upstream bugs found while validating mutsu
+
+Bugs in DBIish itself (the release we vendor-tested, `DBIish:ver<0.6.8>` from
+REA), discovered while bringing mutsu to parity. Each entry reproduces under
+**Rakudo**, so none of them is a mutsu compatibility target — mutsu should
+match raku's (broken) behavior, and tests must route around them. Recorded
+here per the batteries policy (community-first, adopt as-is; upstream fixes go
+through PRs against the module, not local patches — see
+[BATTERIES.md](../../BATTERIES.md)).
+
+## `Connection.commit` / `Connection.rollback` die: no `protect-connection` on the driver
+
+`DBDish::Connection` (`lib/DBDish/Connection.rakumod`) has:
+
+```raku
+method commit {
+    ...
+    $!parent.protect-connection: {
+        $!pg-conn.PQexec("COMMIT");
+    }
+    ...
+}
+```
+
+(and the same shape in `rollback`, in the Pg subclass
+`lib/DBDish/Pg/Connection.rakumod`). But `$!parent` of a Connection is the
+**driver** (`DBDish::Pg`), and `protect-connection` is a method of
+`DBDish::Connection` itself — so any call dies:
+
+```
+No such method 'protect-connection' for invocant of type 'DBDish::Pg'
+```
+
+Verified 2026-07-29 against Rakudo v2026.06 with a live PostgreSQL 16:
+
+```raku
+my $dbh = DBIish.connect('Pg', |%connect-args);
+$dbh.AutoCommit = False;
+$dbh.execute('BEGIN');
+$dbh.execute('INSERT ...');
+$dbh.rollback;      # ← dies under raku AND mutsu, same message
+```
+
+The upstream test suite never calls `commit`/`rollback` through a live
+connection (`t/35-pg-common.rakutest` uses SQL-level `BEGIN`/`COMMIT`), which
+is why it stays green upstream. **Workaround**: issue `BEGIN` / `COMMIT` /
+`ROLLBACK` as SQL through `.execute`, which is what our e2e scripts
+(`tmp/dbiish-pg-extra.raku`) do. That SQL-level surface is the raku-parity
+target.
+
+Status: not yet reported upstream (candidate for a PR against
+`raku-community-modules/DBIish` once the battery is bundled).

--- a/news/2026-07/dbiish-pg-upstream-suite-fixes.md
+++ b/news/2026-07/dbiish-pg-upstream-suite-fixes.md
@@ -1,0 +1,46 @@
+# DBIish upstream Pg test suite: five more NativeCall/introspection fixes
+
+Running DBIish 0.6.8's own Pg test files (11 files, live PostgreSQL 16)
+after the end-to-end milestone surfaced five more general bugs. Six of the
+eleven files now match raku exactly; the remainder are ledgered in
+`todo/tickets/dbiish-pg-upstream-suite-parity.md` with one deep blocker split
+into its own ticket (`module-loaded-sub-with-tail-var.md`).
+
+1. **`is rw` numeric parameters are out-parameters.** C receives a `T*` and
+   writes the result through it — libpq's
+   `PQescapeByteaConn(..., size_t *to_length)` and
+   `PQunescapeBytea(str, size_t is rw --> Pointer)`. mutsu passed the value
+   itself, so the callee wrote through a garbage pointer (a segfault, when
+   lucky). The slot is seeded, passed as a pointer, decoded after the call,
+   and written back — through the argument's shared container cell when it
+   has one, and by variable name at the VM call site when the argument
+   arrived as a plain `VarRef` (including an inline
+   `my size_t $elems` declared in the argument list).
+
+2. **A definedness smiley is not part of the C type.**
+   `memcpy(Blob:D $dest, ...)` (NativeHelpers::Blob) marshals as `Blob`; with
+   `:D` attached the name missed every scalar mapping, fell through to the
+   opaque-handle branch, and the address-less Buf became a NULL the callee
+   wrote to.
+
+3. **`ret_struct` resolves at call time too.** A native sub declared INSIDE
+   the class body it returns (`sub PQconnectdbParams(... --> PGconn)` inside
+   `class PGconn`) registers before the class exists, so the
+   registration-time resolution left the short name and ordinary Raku
+   methods on the returned handle (`PGconn.escapeBytea`) failed to dispatch.
+   A unique `::Short` suffix match among registered classes recovers it.
+
+4. **Uninitialized C-width-alias native scalars read as 0.**
+   `my size_t $sz;` / `my ulong $u;` answered Nil (and died on first read);
+   the parser's zero-seed lists only knew the sized spellings. Both lists now
+   defer to `NATIVE_INT_TYPES`.
+
+5. **`Buf.of` / `Buf.can` on the builtin surface.** `.of` answers the element
+   type (bracket parameter or the width the short name encodes), and `.can`
+   consults the declared builtin method lists — `blob-from-pointer` branches
+   on `$type.can('allocate')` and took a REPR-poking fallback when it wrongly
+   answered false.
+
+Pins: `t/nativecall-rw-numeric-out-param.t`, `t/buf-of-and-can.t` (both
+verified against raku first). The DBIish-side bugs found in the same sweep are
+recorded in `docs/batteries/dbiish-upstream-bugs.md`.

--- a/src/builtins/builtin_type_methods.rs
+++ b/src/builtins/builtin_type_methods.rs
@@ -437,7 +437,42 @@ const MU_METHODS: &[&str] = &[
 /// The method names a built-in `type_name` responds to, in `.^methods` order.
 /// Returns an empty `Vec` for types not modelled here (e.g. user classes, which
 /// are handled separately via `registry().classes`).
+/// `Buf`/`Blob` methods the native probe can't reach (slow-path or type-object
+/// constructors). `allocate` matters beyond introspection:
+/// `NativeHelpers::Blob`'s `blob-from-pointer` branches on
+/// `$type.can('allocate')` and takes a REPR-poking fallback when it answers
+/// false.
+const BUF_METHODS: &[&str] = &[
+    "allocate",
+    "new",
+    "push",
+    "pop",
+    "shift",
+    "unshift",
+    "append",
+    "prepend",
+    "splice",
+    "reallocate",
+    "subbuf",
+    "subbuf-rw",
+    "decode",
+    "elems",
+    "bytes",
+    "of",
+    "reverse",
+    "list",
+    "Blob",
+    "Buf",
+    "Bool",
+    "Str",
+    "gist",
+    "raku",
+];
+
 pub(crate) fn builtin_type_method_names(type_name: &str) -> Vec<&'static str> {
+    if crate::runtime::utils::is_buf_or_blob_class(type_name) {
+        return BUF_METHODS.to_vec();
+    }
     match type_name {
         "Str" => [STR_OWN, NUMERIC_COERCIONS, &["elems", "fmt"]].concat(),
         "Int" | "Num" | "Rat" | "Complex" => [NUMERIC_OWN, NUMERIC_COERCIONS].concat(),
@@ -466,6 +501,12 @@ pub(crate) fn builtin_type_method_names(type_name: &str) -> Vec<&'static str> {
 /// `samemark` but not `abs`, while `2` responds to `abs` but not `chars`, so the
 /// same `METHOD_UNIVERSE` yields each type's correct subset automatically.
 pub(crate) fn builtin_sample_value(type_name: &str) -> Option<Value> {
+    if crate::runtime::utils::is_buf_or_blob_class(type_name) {
+        return Some(crate::value::value_buf::make_buf(
+            Symbol::intern(type_name),
+            vec![Value::int(1)],
+        ));
+    }
     Some(match type_name {
         "Str" => Value::str_from("abc"),
         "Int" => Value::int(2),

--- a/src/builtins/methods_0arg/dispatch_core_range.rs
+++ b/src/builtins/methods_0arg/dispatch_core_range.rs
@@ -547,6 +547,17 @@ pub(super) fn dispatch(
             ValueView::Package(name) if name.resolve() == "Hash" || name.resolve() == "Array" => {
                 Some(Ok(Value::package(Symbol::intern("Mu"))))
             }
+            // A `Buf`/`Blob`-shaped instance answers its element type
+            // (`Buf.new(1).of` is `(uint8)`, `buf16.new(1).of` is `(uint16)`)
+            // — DBDish::Pg's `escapeBytea` sizes its buffer with
+            // `nativesizeof($buf.of)`.
+            ValueView::Instance { class_name, .. }
+                if crate::runtime::utils::is_buf_or_blob_class(&class_name.resolve()) =>
+            {
+                Some(Ok(Value::package(Symbol::intern(
+                    &crate::value::value_buf::buf_elem_type_name(&class_name.resolve()),
+                ))))
+            }
             ValueView::Package(_) | ValueView::CustomType(_) => {
                 let name = match target.view() {
                     ValueView::Package(name) => name,
@@ -569,6 +580,11 @@ pub(super) fn dispatch(
                     || n.starts_with("MixHash[")
                 {
                     Some(Ok(Value::package(Symbol::intern("Real"))))
+                } else if crate::runtime::utils::is_buf_or_blob_class(&n) {
+                    // The type object answers `.of` too (`Buf.of` is `(uint8)`).
+                    Some(Ok(Value::package(Symbol::intern(
+                        &crate::value::value_buf::buf_elem_type_name(&n),
+                    ))))
                 } else {
                     None
                 }

--- a/src/parser/stmt/decl/destructure.rs
+++ b/src/parser/stmt/decl/destructure.rs
@@ -611,10 +611,9 @@ fn parse_destructuring_with_rhs(
 /// Return the default expression for a native type, or Nil for non-native types.
 fn native_type_default(tc: &Option<String>) -> Expr {
     match tc.as_deref() {
-        Some(
-            "int" | "int8" | "int16" | "int32" | "int64" | "uint" | "uint8" | "uint16" | "uint32"
-            | "uint64",
-        ) => Expr::Literal(Value::int(0)),
+        Some(t) if crate::runtime::native_types::is_native_int_type(t) => {
+            Expr::Literal(Value::int(0))
+        }
         Some("num" | "num32" | "num64") => Expr::Literal(Value::num(0.0)),
         Some("str") => Expr::Literal(Value::str(String::new())),
         _ => Expr::Literal(Value::NIL),

--- a/src/parser/stmt/decl/mod.rs
+++ b/src/parser/stmt/decl/mod.rs
@@ -129,19 +129,10 @@ fn typed_default_expr(type_name: &str) -> Expr {
     let base = strip_type_smiley_suffix(type_name);
     if base == "Mu" {
         Expr::BareWord("Mu".to_string())
-    } else if base == "int"
-        || base == "int8"
-        || base == "int16"
-        || base == "int32"
-        || base == "int64"
-        || base == "uint"
-        || base == "uint8"
-        || base == "uint16"
-        || base == "uint32"
-        || base == "uint64"
-        || base == "atomicint"
-        || base == "byte"
-    {
+    } else if crate::runtime::native_types::is_native_int_type(base) {
+        // Includes the C-width aliases (`ulong`, `size_t`, …): an
+        // uninitialized `my size_t $sz;` reads as 0, not Nil (DBDish::Pg's
+        // `escapeBytea` declares its out-length slot exactly this way).
         Expr::Literal(Value::int(0))
     } else if base == "num" || base == "num32" || base == "num64" {
         Expr::Literal(Value::num(0.0))

--- a/src/runtime/methods_classhow_method_obj.rs
+++ b/src/runtime/methods_classhow_method_obj.rs
@@ -388,6 +388,13 @@ impl Interpreter {
                     &Value::NIL,
                 )
                 .is_some()
+                // Slow-path builtin methods (block-taking / `&mut self`, e.g.
+                // `Buf.allocate`) are invisible to the pure native probe; the
+                // declared per-type lists cover them. NativeHelpers::Blob's
+                // `blob-from-pointer` branches on `$type.can('allocate')` and
+                // takes a REPR-poking fallback when it wrongly answers false.
+                || crate::builtins::builtin_type_methods::builtin_type_method_names(&class_name)
+                    .contains(&method_name)
                 // Check user-defined classes and their native_methods set
                 || {
                     let pkg = Value::package(Symbol::intern(&class_name));

--- a/src/runtime/nativecall.rs
+++ b/src/runtime/nativecall.rs
@@ -234,6 +234,19 @@ pub(crate) fn load_library_cached(
 
 #[cfg(feature = "libffi")]
 pub fn call_native(spec: &NativeCallSpec, args: &[Value]) -> Result<Value, RuntimeError> {
+    call_native_with_out_args(spec, args).map(|(v, _)| v)
+}
+
+/// [`call_native`], additionally returning the decoded values of `is rw`
+/// numeric out-parameters as `(arg index, value)` pairs. A caller's variable
+/// that arrives as a shared cell is already written in place; the returned
+/// pairs let an interpreter-side call path also write back a plain `VarRef`
+/// argument (a local variable passed by name), which this layer cannot reach.
+#[cfg(feature = "libffi")]
+pub fn call_native_with_out_args(
+    spec: &NativeCallSpec,
+    args: &[Value],
+) -> Result<(Value, Vec<(usize, Value)>), RuntimeError> {
     use libffi::middle::{Arg, Cif, CodePtr, Type};
 
     if args.len() != spec.params.len() {
@@ -271,12 +284,37 @@ pub fn call_native(spec: &NativeCallSpec, args: &[Value]) -> Result<Value, Runti
     // into the caller's Raku array after the call (an out-array fill).
     let mut carray_writebacks: Vec<usize> = Vec::new();
 
+    // Arg indices holding an `is rw` numeric out-slot whose value must be
+    // decoded and written back into the caller's variable after the call.
+    let mut num_writebacks: Vec<usize> = Vec::new();
+
     for (i, (ps, v)) in spec.params.iter().zip(args.iter()).enumerate() {
         let (ty, owner) = if ps.is_rw && ps.ct == CType::Pointer {
             // `Pointer is rw`: pass `void**` — a pointer to a slot holding the
             // current address; C writes the new pointer into the slot.
             let slot = Box::new(pointer_address(v));
             writebacks.push(i);
+            (Type::pointer(), ArgOwner::new_out_ptr(slot))
+        } else if ps.is_rw && numeric_out_width(ps.ct).is_some() {
+            // An `is rw` numeric parameter is an out-parameter: C receives a
+            // `T*` and writes the result through it (libpq's
+            // `PQescapeByteaConn(..., size_t *to_length)` — declared
+            // `size_t $to_length is rw`). Passing the value directly hands C a
+            // garbage pointer and it writes into the weeds (a segfault, when
+            // lucky). The slot is seeded with the current value; the result is
+            // decoded and written back into the caller's variable below.
+            let resolved = resolve_arg(v);
+            let seed = match ps.ct {
+                CType::F32 => (crate::runtime::utils::to_float_value(&resolved).unwrap_or(0.0)
+                    as f32)
+                    .to_bits() as u64,
+                CType::F64 => crate::runtime::utils::to_float_value(&resolved)
+                    .unwrap_or(0.0)
+                    .to_bits(),
+                _ => crate::runtime::to_int(&resolved) as u64,
+            };
+            let slot = Box::new(seed as usize);
+            num_writebacks.push(i);
             (Type::pointer(), ArgOwner::new_out_ptr(slot))
         } else {
             let (ty, owner) = marshal_arg(ps, v).map_err(|msg| {
@@ -364,6 +402,22 @@ pub fn call_native(spec: &NativeCallSpec, args: &[Value]) -> Result<Value, Runti
         }
     }
 
+    // Decode each `is rw` numeric out-slot (C wrote through the `T*`) and
+    // write the value back into the caller's variable through its shared
+    // container cell; also collect the values so an interpreter-side caller
+    // can write back a plain `VarRef` argument this layer cannot reach.
+    let mut out_args: Vec<(usize, Value)> = Vec::with_capacity(num_writebacks.len());
+    for idx in num_writebacks {
+        if let ArgOwner::OutPtr { slot, .. } = &owners[idx] {
+            let raw = **slot as u64;
+            let width = numeric_out_width(spec.params[idx].ct).unwrap_or(8);
+            let bytes = raw.to_ne_bytes();
+            let val = decode_carray_elem(spec.params[idx].ct, &bytes[..width]);
+            write_scalar_back(&args[idx], val.clone());
+            out_args.push((idx, val));
+        }
+    }
+
     // Copy each numeric CArray's (possibly callee-modified) C buffer back into
     // the caller's Raku array, element by element, through the shared backing
     // node so the mutation is visible at the call site.
@@ -387,7 +441,7 @@ pub fn call_native(spec: &NativeCallSpec, args: &[Value]) -> Result<Value, Runti
     // own storage (ADR-0015 P2). This is the sync point that used to be needed
     // and the one that could not exist for a pointer C merely retained.
 
-    Ok(result)
+    Ok((result, out_args))
 }
 
 /// Build a `Pointer` object holding the given C address. Used to marshal a
@@ -514,6 +568,37 @@ pub(crate) fn value_c_address(v: &Value) -> usize {
 #[cfg(feature = "libffi")]
 fn pointer_address(v: &Value) -> usize {
     value_c_address(v)
+}
+
+/// The byte width C writes through an `is rw` numeric out-parameter of the
+/// given type, or `None` for a non-numeric type (which is not an out-slot).
+#[cfg(feature = "libffi")]
+fn numeric_out_width(ct: CType) -> Option<usize> {
+    match ct {
+        CType::I8 | CType::U8 => Some(1),
+        CType::I16 | CType::U16 => Some(2),
+        CType::I32 | CType::U32 | CType::F32 => Some(4),
+        CType::I64 | CType::U64 | CType::F64 => Some(8),
+        CType::Void | CType::Str | CType::Pointer | CType::CArray | CType::Buf => None,
+    }
+}
+
+/// Write an `is rw` numeric out-parameter's result back into the caller's
+/// variable, through its shared `ContainerRef` cell (a `$`-variable argument
+/// arrives wrapped in one). A non-container argument (a literal) has nowhere
+/// to write back to and is silently skipped, like Rakudo.
+#[cfg(feature = "libffi")]
+fn write_scalar_back(v: &Value, new_val: Value) {
+    match v.view() {
+        ValueView::ContainerRef(cell) => {
+            if let Ok(mut g) = cell.lock() {
+                *g = new_val;
+            }
+        }
+        ValueView::Scalar(inner) => write_scalar_back(inner, new_val),
+        ValueView::VarRef { value, .. } => write_scalar_back(value, new_val),
+        _ => {}
+    }
 }
 
 /// Write a resolved C address back into a `Pointer` object's `address`
@@ -962,6 +1047,15 @@ pub fn call_native(spec: &NativeCallSpec, _args: &[Value]) -> Result<Value, Runt
         "NativeCall is not available in this build (cannot call '{}')",
         spec.symbol
     )))
+}
+
+/// Stub used when the `libffi` feature is disabled (e.g. wasm builds).
+#[cfg(not(feature = "libffi"))]
+pub fn call_native_with_out_args(
+    spec: &NativeCallSpec,
+    args: &[Value],
+) -> Result<(Value, Vec<(usize, Value)>), RuntimeError> {
+    call_native(spec, args).map(|v| (v, Vec::new()))
 }
 
 #[cfg(all(test, feature = "libffi"))]

--- a/src/runtime/nativecall_global.rs
+++ b/src/runtime/nativecall_global.rs
@@ -151,6 +151,53 @@ impl Interpreter {
 }
 
 impl Interpreter {
+    /// Resolve a NativeCallSpec's `ret_struct` to the name its class is
+    /// actually registered under, at CALL time. Registration-time resolution
+    /// (`registered_native_class_name`) covers most declarations, but a native
+    /// sub declared INSIDE the class body it returns —
+    /// `sub PQconnectdbParams(... --> PGconn)` inside `class PGconn` — runs
+    /// its registration before the class exists, leaving the short name; by
+    /// call time the class is registered package-qualified, and an instance
+    /// tagged with the short name cannot dispatch the class's ordinary Raku
+    /// methods (`PGconn.escapeBytea`). Falls back to a UNIQUE `::Short`
+    /// suffix match among registered classes; an ambiguous short name is left
+    /// alone.
+    pub(crate) fn resolve_native_ret_struct(
+        &mut self,
+        spec: &mut crate::runtime::nativecall::NativeCallSpec,
+    ) {
+        let Some(name) = spec.ret_struct.clone() else {
+            return;
+        };
+        if self.registry().classes.contains_key(&name) {
+            return;
+        }
+        if let Some(ValueView::Package(sym)) = self.env.get(&name).map(Value::view) {
+            let resolved = sym.resolve().to_string();
+            if resolved != name && self.registry().classes.contains_key(&resolved) {
+                spec.ret_struct = Some(resolved);
+                return;
+            }
+        }
+        let suffix = format!("::{name}");
+        let found = {
+            let registry = self.registry();
+            let mut found: Option<String> = None;
+            for k in registry.classes.keys() {
+                if k.ends_with(suffix.as_str()) {
+                    if found.is_some() {
+                        return;
+                    }
+                    found = Some(k.clone());
+                }
+            }
+            found
+        };
+        if let Some(f) = found {
+            spec.ret_struct = Some(f);
+        }
+    }
+
     /// Route a resolved `is native(...)` **method** to NativeCall, with the
     /// invocant marshalled as the first C argument.
     ///
@@ -176,6 +223,8 @@ impl Interpreter {
                     .get(&Self::native_method_key(short, method))
             })?
             .clone();
+        let mut spec = spec;
+        self.resolve_native_ret_struct(&mut spec);
         let mut call_args = Vec::with_capacity(args.len() + 1);
         call_args.push(invocant.clone());
         call_args.extend(args.iter().cloned());

--- a/src/value/value_buf.rs
+++ b/src/value/value_buf.rs
@@ -461,6 +461,26 @@ pub(crate) fn buf_elem_width(class_name: &str) -> usize {
     }
 }
 
+/// The element type name a `Buf`/`Blob`-shaped class answers from `.of`:
+/// the bracket parameter when spelled (`Blob[int8]` → `int8`), else the
+/// width/signedness the short name encodes (`buf16` → `uint16`), defaulting
+/// to `uint8` — matching Rakudo (`Buf.of` is `(uint8)`).
+pub(crate) fn buf_elem_type_name(class_name: &str) -> String {
+    if let Some(inner) = class_name
+        .split_once('[')
+        .and_then(|(_, rest)| rest.strip_suffix(']'))
+    {
+        return inner.to_string();
+    }
+    let (width, signed) = elem_type(class_name);
+    let bits = width as usize * 8;
+    if signed {
+        format!("int{bits}")
+    } else {
+        format!("uint{bits}")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/vm/vm_call_func_ops.rs
+++ b/src/vm/vm_call_func_ops.rs
@@ -229,7 +229,8 @@ impl Interpreter {
                     .rsplit_once("::")
                     .and_then(|(_, short)| self.native_call_specs.get(short).cloned())
             });
-            if let Some(spec) = spec {
+            if let Some(mut spec) = spec {
+                self.resolve_native_ret_struct(&mut spec);
                 let arity_usize = arity as usize;
                 if self.stack.len() < arity_usize {
                     return Err(RuntimeError::new(format!(
@@ -241,7 +242,27 @@ impl Interpreter {
                 let mut args: Vec<Value> = self.stack.drain(start..).collect();
                 // Drop the synthetic callsite-line marker the compiler may append.
                 args.retain(|a| !Self::is_callsite_line_marker(a));
-                let result = crate::runtime::nativecall::call_native(&spec, &args)?;
+                let (result, out_args) =
+                    crate::runtime::nativecall::call_native_with_out_args(&spec, &args)?;
+                // An `is rw` numeric out-parameter whose argument is a plain
+                // variable arrives as a `VarRef`; the marshalling layer cannot
+                // reach the caller's slot, so write it back here by name —
+                // `PQunescapeBytea($v, my size_t $elems)` must leave the
+                // written length in `$elems`.
+                if !out_args.is_empty() {
+                    let mut wrote = false;
+                    for (idx, val) in out_args {
+                        if let crate::value::ValueView::VarRef { name, .. } = args[idx].view() {
+                            let n = name.resolve().to_string();
+                            self.env_mut().insert(n.clone(), val);
+                            self.pending_rw_writeback_sources.push(n);
+                            wrote = true;
+                        }
+                    }
+                    if wrote {
+                        self.apply_pending_rw_writeback(code);
+                    }
+                }
                 self.stack.push(result);
                 return Ok(());
             }

--- a/src/vm/vm_register_sub_ops.rs
+++ b/src/vm/vm_register_sub_ops.rs
@@ -437,6 +437,16 @@ impl Interpreter {
             let Some(tc) = pd.type_constraint.as_deref() else {
                 return Ok(());
             };
+            // A definedness smiley is not part of the C type: `Blob:D $dest`
+            // marshals as `Blob`. Left attached, the name missed every scalar
+            // mapping and fell through to the opaque-CStruct branch — the Buf
+            // was passed as an address-less handle, i.e. NULL, and the callee
+            // (NativeHelpers::Blob's `memcpy(Blob:D $dest, ...)`) wrote to it.
+            let tc = tc
+                .strip_suffix(":D")
+                .or_else(|| tc.strip_suffix(":U"))
+                .or_else(|| tc.strip_suffix(":_"))
+                .unwrap_or(tc);
             // `constant my_bool = int8;` — follow the alias to the type it names.
             let resolved_tc = self.resolve_native_type_alias(tc);
             let tc = resolved_tc.as_str();

--- a/t/buf-of-and-can.t
+++ b/t/buf-of-and-can.t
@@ -1,0 +1,19 @@
+use v6;
+use Test;
+
+# Buf/Blob element-type introspection and `.can` on the builtin surface.
+# NativeHelpers::Blob branches on `$type.can('allocate')` (a false answer
+# sends it down a REPR-poking fallback) and sizes buffers with
+# `nativesizeof($buf.of)`.
+plan 7;
+
+is Buf.of.^name, 'uint8', 'Buf.of is uint8';
+is Buf.new(1, 2).of.^name, 'uint8', 'a Buf instance answers .of too';
+is buf16.new(1).of.^name, 'uint16', 'buf16.of is uint16';
+is Blob.of.^name, 'uint8', 'Blob.of is uint8';
+
+ok Buf.can('allocate'), 'Buf.can("allocate")';
+ok Buf.new(1).can('push'), 'a Buf instance can("push")';
+nok Buf.can('no-such-method-xyz'), 'unknown method still answers false';
+
+done-testing;

--- a/t/nativecall-rw-numeric-out-param.t
+++ b/t/nativecall-rw-numeric-out-param.t
@@ -1,0 +1,49 @@
+use v6;
+use Test;
+use NativeCall;
+
+# `is rw` NUMERIC parameters are out-parameters: C receives a `T*` and writes
+# the result through it. libpq's `PQescapeByteaConn(..., size_t *to_length)`
+# and `PQunescapeBytea(str, size_t is rw --> Pointer)` are declared this way;
+# passing the value directly handed C a garbage pointer (a segfault, when
+# lucky).
+plan 6;
+
+# frexp(3): x = mantissa * 2**exp, exp written through the int*.
+# (No library named: frexp lives in the C runtime — naming 'm' would dlopen
+# the libm.so linker script and fail under Rakudo on glibc systems.)
+sub frexp(num64, int32 is rw --> num64) is native { * }
+my int32 $exp;
+my $mant = frexp(8e0, $exp);
+is $exp, 4, 'C wrote the exponent through the int32* out-param';
+is-approx $mant, 0.5e0, 'the return value is unaffected';
+
+# The out-param also works for an inline declaration in the argument list —
+# NativeHelpers::Blob writes `PQunescapeBytea($value, my size_t $elems)`.
+my $m2 = frexp(4e0, my int32 $e2);
+is $e2, 3, 'inline `my` declaration receives the written value';
+
+# A definedness smiley on a parameter type is not part of the C type:
+# `Blob:D $dest` marshals as `Blob` (the buffer's own storage pointer).
+# Left attached it fell through to the opaque-handle branch and C wrote to
+# NULL (NativeHelpers::Blob's `memcpy(Blob:D $dest, ...)`).
+sub malloc(size_t --> Pointer) is native { * }
+sub free(Pointer) is native { * }
+sub memset(Pointer, int32, size_t --> Pointer) is native { * }
+sub memcpy(Blob:D $dest, Pointer $src, size_t $size --> Pointer) is native { * }
+
+my \p = malloc(4);
+memset(p, 65, 3);
+my $buf = Buf.allocate(3);
+memcpy($buf, p, 3);
+is $buf, Buf.new(65, 65, 65), 'Blob:D destination received the bytes';
+free(p);
+
+# An uninitialized C-width-alias native scalar reads as 0, not Nil —
+# `my size_t $sz;` is how DBDish::Pg declares its out-length slots.
+my size_t $sz;
+is $sz, 0, 'uninitialized size_t defaults to 0';
+my ulong $ul;
+is $ul, 0, 'uninitialized ulong defaults to 0';
+
+done-testing;

--- a/todo/tickets/dbiish-pg-upstream-suite-parity.md
+++ b/todo/tickets/dbiish-pg-upstream-suite-parity.md
@@ -1,0 +1,38 @@
+# DBIish upstream Pg test suite — remaining parity gaps
+
+Measured 2026-07-29 against a live PostgreSQL 16 (docker `mutsu-postgres`,
+port 15432, `PGHOST=127.0.0.1 PGPORT=15432 PGUSER=postgres PGPASSWORD=mutsu
+PGDATABASE=dbdishtest DBIISH_WRITE_TEST=YES`; create `dbdishtest` first).
+**Set the `-I` include list as a shell array** — the ticket's old warning
+applies: a scalar `$INCS` string under zsh silently breaks the module path and
+produced a bogus first survey in this very session.
+
+Of the 11 upstream Pg files, 6 match raku exactly (30-pg, 34-pg-types,
+36-pg-native, 37-pg-datetime, 38-pg-connection-lock, 38-pg-threads). The
+basic + extended e2e scripts (`tmp/dbiish-e2e-pg.raku`,
+`tmp/dbiish-pg-extra.raku`) are byte-identical to raku. Remaining:
+
+Re-measured 2026-07-29 (late, with the correct include array, after the
+rw-out-param/smiley/ret_struct/Buf-of fixes; raku totals 109/46/17/26/9):
+
+- **`36-pg-blob` (12 ok, 5 fail)** — blocked on
+  [`module-loaded-sub-with-tail-var.md`](module-loaded-sub-with-tail-var.md):
+  `blob-from-pointer` returns its `memcpy`'s `Pointer` instead of the `Buf`.
+- **`36-pg-array` (0 run)** — dies in `_to-array` with "Type Array does not
+  support associative indexing": `$element.values[0]<array>` — a hash
+  subscript on a `Match`'s positional child comes back as a plain `Array`
+  somewhere in the `PgArrayGrammar` match tree.
+- **`36-pg-enum` (13 of 26)** — dies at test 14 with "Type check failed for
+  an element of %; expected  but got Package" (note the EMPTY expected type):
+  a typed hash element check against an enum/type-object value.
+- **`38-pg-errors` (7 ok, 1 fail)** — one subtest assertion inside "Incorrect
+  column" (the first three subtest checks pass; dig out which of the 15
+  fails).
+- **`35-pg-common` (76 ok, then dumps core)** — after the mid-file `version`
+  type-check error was reached it now segfaults outright; get a fresh gdb
+  backtrace before theorizing. The earlier note about `PQlibVersion` falling
+  through to its `{ * }` stub ("expected uint32 but got Whatever") still
+  stands as the first visible symptom.
+
+Once `module-loaded-sub-with-tail-var` is fixed, re-run the full 11-file sweep
+before reading anything into individual numbers.

--- a/todo/tickets/module-loaded-sub-with-tail-var.md
+++ b/todo/tickets/module-loaded-sub-with-tail-var.md
@@ -1,0 +1,45 @@
+# A `use`-loaded sub returns its `with`-block value instead of the tail variable
+
+In a sub loaded from a module via `use`, a statement-position `with` block's
+value replaces the value of the bare-variable tail that follows it:
+
+```raku
+# TAIL5.rakumod
+unit module TAIL5;
+sub y2(\ptr) is export {
+    my $b = 42;
+    with ptr { 2.so; }
+    $b;
+}
+```
+
+```raku
+use TAIL5;
+say y2(5);      # raku: 42    mutsu: True
+```
+
+Three properties make it precise:
+
+- **Only via `use`.** The same file executed as a mainline script (module decl
+  and all) answers 42. `--dump-ast` of the module is correct (`body = [VarDecl,
+  If{then: [Given …]}, Expr(Var "b")]`), and gdb shows the call executing
+  through the VM (`exec_given_op`), not the tree-walk — so the divergence is in
+  how the module-load / import path compiles or re-registers the sub, not in
+  parsing or in the Given op per se.
+- **Only `with`** (which lowers to `If { cond: .defined, then: [Given …] }`).
+  A plain `if 1 { 2.so; }` or a bare `given 5 { 2.so; }` before the tail
+  variable is fine.
+- A sigilless parameter is involved in the original hit but `with $sigiled`
+  reproduces too (unverified — re-check when picking this up).
+
+Real-world impact: `NativeHelpers::Blob`'s `blob-from-pointer` has exactly this
+shape (`with ptr { …; memcpy($b, ptr, n); } $b;`), so it returns the `memcpy`
+result (a `Pointer`) instead of the filled `Buf` — which is what keeps
+DBIish's `t/36-pg-blob.rakutest` from reading bytea values back (5 of its 17
+subtests). Fixing this unblocks that file and likely `36-pg-array` /
+`38-pg-errors` retesting.
+
+Found 2026-07-29 while bringing the DBIish upstream Pg test suite to parity
+(see `docs/batteries/dbiish-upstream-bugs.md` for the DBIish-side bugs found in
+the same sweep, and `todo/tickets/dbiish-pg-upstream-suite-parity.md` for the
+remaining suite gaps).


### PR DESCRIPTION
## Summary

Follow-up to #5547: running DBIish 0.6.8's **own Pg test suite** (11 files) against a live PostgreSQL 16 surfaced five more general bugs. Six of the eleven files now match raku exactly, and the basic + extended e2e scripts remain byte-identical.

- **`is rw` numeric parameters are out-parameters**: C receives a `T*` and writes through it (libpq's `PQescapeByteaConn(..., size_t *to_length)` / `PQunescapeBytea`). mutsu passed the value itself — a segfault when lucky. The slot is seeded, passed by pointer, decoded after the call, and written back (shared container cell, or by variable name at the VM call site for a plain `VarRef` argument, including inline `my size_t $elems` declarations).
- **A definedness smiley is not part of the C type**: `memcpy(Blob:D $dest, …)` marshals as `Blob`; with `:D` attached the Buf fell through to the opaque-handle branch and C wrote to NULL.
- **`ret_struct` resolves at call time too**: a native sub declared inside the class body it returns (`sub PQconnectdbParams(... --> PGconn)` inside `class PGconn`) registers before the class exists, so ordinary Raku methods on the returned handle (`PGconn.escapeBytea`) failed to dispatch.
- **Uninitialized C-width-alias native scalars read as 0** (`my size_t $sz;` answered Nil and died on first read).
- **`Buf.of` / `Buf.can`** on the builtin surface (`blob-from-pointer` branches on `$type.can('allocate')`).

Also records the DBIish-side upstream bugs found in the same sweep (`docs/batteries/dbiish-upstream-bugs.md` — `commit`/`rollback` die under Rakudo too) and ledgers the remaining suite gaps with fresh failure modes (`todo/tickets/dbiish-pg-upstream-suite-parity.md`, deep blocker split into `todo/tickets/module-loaded-sub-with-tail-var.md` with a minimal repro).

## Testing

- New pins: `t/nativecall-rw-numeric-out-param.t`, `t/buf-of-and-can.t` (both verified against raku first).
- Local `make test` and `make roast`: **full PASS** on this branch.
- Both DB e2e scripts (MariaDB + PostgreSQL) re-verified on the final build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)