### PR TITLE
fix: quantified-group capture semantics — DBIish 36-pg-array 0 to 46/46

### DIFF
--- a/news/2026-07/match-quantified-group-capture-semantics.md
+++ b/news/2026-07/match-quantified-group-capture-semantics.md
@@ -1,0 +1,36 @@
+# Quantified-group capture semantics: DBIish 36-pg-array goes 0 → 46/46
+
+2026-07-29. DBDish::Pg's `PgArrayGrammar`/`_to-array` (the PostgreSQL array
+column reader) died on its first row with "Type Array does not support
+associative indexing". Unwinding it exposed three general capture-semantics
+divergences from raku, all around quantified capture groups
+(`( <element> ','?)*`):
+
+1. **A capturing group is a capture boundary.** A named capture inside
+   `( $<e>=(\w) )*` belongs to each iteration's own group Match (reached via
+   `$0[n]<e>`); raku leaves `$/<e>` entirely absent. mutsu's
+   `collect_named_captures_in_atom` descended into `CaptureGroup` atoms when
+   collecting quantified names, so the parent Match's hash grew a spurious
+   empty-Array entry for every inner name. (A NON-capturing group `[ ... ]*`
+   correctly exposes inner names to the parent as lists — that path is
+   unchanged and now pinned.)
+2. **`Match.values` / `Match.kv` flatten a quantified positional capture.**
+   Match is a Capture: `.values` is positional-then-named, and a quantified
+   `$0` (an Array of per-iteration Matches) flattens into it — raku's
+   `$m.values` over `(\w)*` on "ab" is the two Matches, not a one-element
+   list holding an Array. (`.keys` and `.pairs` do not flatten; verified
+   against raku and matched.)
+3. **The `for <element>.values` writeback desugar mangled non-Array
+   elements.** `for %h<k>.values { $_ *= 2 }` compiles to a temp-array copy +
+   loop + element write-back (#3156). For a Match element
+   (`for $m.<array>.values`) the bare-element copy wrapped the Match into a
+   one-element array (iterating the wrong thing) and the unconditional
+   write-back then REPLACED the Match with that Array as a silent side
+   effect. The copy now goes through `.values` (identical for Positional
+   elements) and the write-back is guarded by `~~ Array` — note `~~
+   Positional` is not a usable guard, Match does Positional.
+
+Pinned by `t/match-quantified-group-capture-semantics.t` (12 asserts, passes
+under raku too). The DBIish upstream Pg suite is now 8/11 files at raku
+parity (remaining: 35-pg-common SEGV, 36-pg-enum, 38-pg-errors — see
+`todo/tickets/dbiish-pg-upstream-suite-parity.md`).

--- a/src/builtins/methods_0arg/mod.rs
+++ b/src/builtins/methods_0arg/mod.rs
@@ -1848,7 +1848,17 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 if let Some(ValueView::Array(list, _)) =
                     attributes.as_map().get("list").map(Value::view)
                 {
-                    vals.extend(list.iter().cloned());
+                    // A quantified positional capture (`( ... )*` — $0 is an
+                    // Array of per-iteration Matches) flattens into the value
+                    // list, matching raku's Seq flattening: `$m.values` over
+                    // `( <element> ','?)*` yields the group Matches themselves.
+                    for v in list.iter() {
+                        if let ValueView::Array(inner, _) = v.view() {
+                            vals.extend(inner.iter().cloned());
+                        } else {
+                            vals.push(v.clone());
+                        }
+                    }
                 }
                 if let Some(ValueView::Hash(named)) =
                     attributes.as_map().get("named").map(Value::view)
@@ -1888,7 +1898,13 @@ fn dispatch_core(target: &Value, method: &str) -> Option<Result<Value, RuntimeEr
                 {
                     for (i, v) in list.iter().enumerate() {
                         kv.push(Value::int(i as i64));
-                        kv.push(v.clone());
+                        // A quantified capture's Array flattens after its key
+                        // (raku: `$m.kv` over `(\w)*` is `(0, m1, m2)`).
+                        if let ValueView::Array(inner, _) = v.view() {
+                            kv.extend(inner.iter().cloned());
+                        } else {
+                            kv.push(v.clone());
+                        }
                     }
                 }
                 if let Some(ValueView::Hash(named)) =

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -427,9 +427,21 @@ impl Compiler {
         let tmp = format!("__for_elem_src_{}", self.code.constants.len());
         let element = target.as_ref().clone();
 
+        // Copy the element's `.values` (not the element itself): for a
+        // Positional element the two are the same list, but for a value whose
+        // `.values` has its own semantics — a Match's Capture view
+        // (`$m.<array>.values` over a quantified group) — assigning the bare
+        // element to `@tmp` would wrap it as a one-element array and iterate
+        // the wrong thing.
         let decl = Stmt::VarDecl {
             name: format!("@{}", tmp),
-            expr: element,
+            expr: Expr::MethodCall {
+                target: Box::new(element.clone()),
+                name: crate::symbol::Symbol::intern("values"),
+                args: Vec::new(),
+                modifier: None,
+                quoted: false,
+            },
             type_constraint: None,
             is_state: false,
             is_our: false,
@@ -457,12 +469,27 @@ impl Compiler {
             };
         }
 
-        let writeback = Stmt::Expr(Expr::IndexAssign {
-            target: container.clone(),
-            index: index.clone(),
-            value: Box::new(Expr::ArrayVar(tmp)),
-            is_positional: *is_positional,
-        });
+        // Write the temp back only when the element actually is an Array —
+        // the one case where `@tmp = <ELEM>.values` copies and mutations
+        // would otherwise be lost. An unconditional write turned a
+        // non-container element (`$match.<array>`, a Match — note Match does
+        // Positional, so that role is not a usable guard) into a one-element
+        // Array as a silent side effect of merely looping over its values.
+        let writeback = Stmt::If {
+            cond: Expr::Binary {
+                op: crate::token_kind::TokenKind::SmartMatch,
+                left: Box::new(element),
+                right: Box::new(Expr::BareWord("Array".to_string())),
+            },
+            then_branch: vec![Stmt::Expr(Expr::IndexAssign {
+                target: container.clone(),
+                index: index.clone(),
+                value: Box::new(Expr::ArrayVar(tmp)),
+                is_positional: *is_positional,
+            })],
+            else_branch: Vec::new(),
+            binding_var: None,
+        };
 
         Some(vec![decl, for_stmt, writeback])
     }

--- a/src/runtime/regex/regex_match_core.rs
+++ b/src/runtime/regex/regex_match_core.rs
@@ -56,7 +56,13 @@ impl Interpreter {
                     }
                 }
             }
-            RegexAtom::Group(pat) | RegexAtom::CaptureGroup(pat) => {
+            // A CAPTURING group is a capture boundary: a named capture inside
+            // `( <element> ',' )*` belongs to each group's own Match (reached
+            // via `$0[n]<element>`), NOT to the enclosing Match — raku leaves
+            // `$/<element>` entirely absent there. Only a non-capturing group
+            // (`[ <e> ]*`) exposes its inner names to the quantified parent
+            // (as lists). So do not descend into CaptureGroup.
+            RegexAtom::Group(pat) => {
                 for tok in &pat.tokens {
                     if let Some(name) = tok.named_capture.as_ref() {
                         out.insert(name.clone());

--- a/t/match-quantified-group-capture-semantics.t
+++ b/t/match-quantified-group-capture-semantics.t
@@ -1,0 +1,53 @@
+use v6;
+use Test;
+
+# Capture semantics of quantified groups, pinned by DBDish::Pg's
+# PgArrayGrammar / `_to-array` (t/36-pg-array.rakutest went from dying at
+# test 1 to 46/46 on these).
+
+plan 12;
+
+# --- 1. A CAPTURING group is a capture boundary: named captures inside
+# `( ... )*` belong to each group's own Match, NOT the enclosing Match.
+{
+    my $m = "a,b," ~~ /( $<e>=(\w) \, )*/;
+    nok $m.hash<e>:exists, 'capturing group: inner named capture absent from outer hash';
+    is $m[0].elems, 2, 'quantified capture group collected per-iteration Matches';
+    is ~$m[0][0]<e>, 'a', 'first group Match carries its own named capture';
+    is ~$m[0][1]<e>, 'b', 'second group Match carries its own named capture';
+}
+
+# --- 2. A NON-capturing group still exposes inner names to the parent as lists.
+{
+    my $m = "a,b," ~~ /[ $<e>=(\w) \, ]*/;
+    ok $m.hash<e>:exists, 'non-capturing group: named capture collected on parent';
+    is $m<e>.elems, 2, 'non-capturing group: one entry per iteration';
+}
+
+# --- 3. Match.values flattens a quantified positional capture (Capture view).
+{
+    my $m = "ab" ~~ /(\w)*/;
+    is $m.values.elems, 2, '.values flattens the quantified $0 array';
+    is $m.keys.elems, 1, '.keys still has the single positional key';
+    is-deeply $m.kv.map(~*).list, ('0', 'a', 'b'), '.kv flattens the value after its key';
+}
+
+# --- 4. The PgArrayGrammar shape end-to-end.
+my grammar G {
+    rule TOP     { ^ <array> $ }
+    rule array   { '{' ( <element> ','?)* '}' }
+    rule element { <array> | <unquoted-string> }
+    rule unquoted-string { <-["{},]>+ }
+};
+{
+    my $m = G.parse('{1,2,3}');
+    my @texts;
+    for $m.<array>.values -> $element {
+        @texts.push: ~$element.values[0]<unquoted-string>;
+    }
+    is-deeply @texts, ['1', '2', '3'],
+        'iterating a quantified-group Match .values yields the group Matches';
+    is $m.<array>.^name.substr(0, 1), 'G' | 'M',
+        'array capture is still a Match-like after the loop';
+    ok $m.<array> !~~ Array, 'for <elem>.values does not turn a Match element into an Array';
+}

--- a/todo/tickets/dbiish-pg-upstream-suite-parity.md
+++ b/todo/tickets/dbiish-pg-upstream-suite-parity.md
@@ -34,21 +34,23 @@ PGDATABASE=dbdishtest DBIISH_WRITE_TEST=YES`; create `dbdishtest` first).
 applies: a scalar `$INCS` string under zsh silently breaks the module path and
 produced a bogus first survey in this very session.
 
-Of the 11 upstream Pg files, 7 match raku exactly (30-pg, 34-pg-types,
-36-pg-blob, 36-pg-native, 37-pg-datetime, 38-pg-connection-lock,
-38-pg-threads). The basic + extended e2e scripts (`tmp/dbiish-e2e-pg.raku`,
-`tmp/dbiish-pg-extra.raku`) are byte-identical to raku. Remaining:
+Of the 11 upstream Pg files, 8 match raku exactly (30-pg, 34-pg-types,
+36-pg-array, 36-pg-blob, 36-pg-native, 37-pg-datetime,
+38-pg-connection-lock, 38-pg-threads). The basic + extended e2e scripts
+(`tmp/dbiish-e2e-pg.raku`, `tmp/dbiish-pg-extra.raku`) are byte-identical to
+raku. Remaining:
 
-Re-measured 2026-07-29 (third pass, full sweep via `tmp/pg-sweep.sh`, after
-the with-tail-value chain + nativecast(Str) + method rw-out-param fixes; raku
-totals 109/46/26/9):
+Re-measured 2026-07-29 (fourth pass; sweep helper `tmp/pg-sweep.sh`; raku
+totals 109/26/9):
 
 - `36-pg-blob` — **RESOLVED** (17/17, raku parity) by the six-fix chain in
   `news/2026-07/module-loaded-sub-with-tail-var.md`.
-- **`36-pg-array` (0 run)** — dies in `_to-array` with "Type Array does not
-  support associative indexing": `$element.values[0]<array>` — a hash
-  subscript on a `Match`'s positional child comes back as a plain `Array`
-  somewhere in the `PgArrayGrammar` match tree.
+- `36-pg-array` — **RESOLVED** (46/46, raku parity): three quantified-group
+  capture-semantics fixes (capturing groups are a capture boundary for inner
+  named captures; `Match.values`/`.kv` flatten a quantified `$0`; the
+  `for <element>.values` writeback desugar no longer converts a non-Array
+  element to an Array), pinned by
+  `t/match-quantified-group-capture-semantics.t`.
 - **`36-pg-enum` (13 of 26)** — dies at test 14 with "Type check failed for
   an element of %; expected  but got Package" (note the EMPTY expected type):
   a typed hash element check against an enum/type-object value.


### PR DESCRIPTION
Three general capture-semantics fixes around quantified capture groups (`( <element> ','?)*`), surfaced by DBDish::Pg's `PgArrayGrammar`/`_to-array` dying with "Type Array does not support associative indexing" — `t/36-pg-array.rakutest` goes **0 run → 46/46 (raku parity)**, and the upstream Pg suite is now **8/11** files matching raku.

1. **A capturing group is a capture boundary.** `collect_named_captures_in_atom` no longer descends into `CaptureGroup` atoms when collecting quantified names: a named capture inside `( $<e>=(\w) )*` belongs to each iteration's group Match (`$0[n]<e>`), and raku leaves `$/<e>` entirely absent. mutsu grew a spurious empty-Array hash entry for every inner name. Non-capturing `[ ... ]*` keeps the parent-list behavior.
2. **`Match.values` / `Match.kv` flatten a quantified `$0`** (an Array of per-iteration Matches), matching raku's Capture-view Seq flattening; `.keys`/`.pairs` do not flatten (verified against raku).
3. **The `for <element>.values` writeback desugar** (#3156) copies via `.values` and guards the write-back with `~~ Array`. It used to wrap a Match element into a one-element array (iterating the wrong thing) and then **replace the Match with that Array** as a silent side effect of merely looping. (`~~ Positional` is not a usable guard — Match does Positional.)

Verified locally: `make test` (2587 files) green; all 93 whitelisted S05 roast files (5524 tests) green; `t/for-element-source-writeback.t` (the desugar's original pin) green; DBIish sweep vs live PostgreSQL 16.

Pin: `t/match-quantified-group-capture-semantics.t` (12 asserts, passes under raku too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)