### PR TITLE
fix: `with $!attr { $_ = ... }` writes back to the attribute cell

### DIFF
--- a/news/2026-07/with-attr-topic-writeback.md
+++ b/news/2026-07/with-attr-topic-writeback.md
@@ -1,0 +1,30 @@
+# `with $!attr { $_ = ... }` writes back to the attribute — DBIish 35-pg-common SEGV fixed
+
+2026-07-29. DBIish's `t/35-pg-common.rakutest` segfaulted after test 76. The
+gdb backtrace showed a double-free inside libpq's `PQclear`, called from
+`DBDish::Pg::StatementHandle.finish`:
+
+```raku
+method finish() {
+    with $!result { .PQclear; $_ = Nil }
+    $!Finished = True;
+}
+```
+
+raku aliases a bare scalar-variable topic read-write, and an attribute
+variable is such a variable — so `$_ = Nil` must clear `$!result`. In mutsu
+the topic write-back (`topic_source_var`) wrote the env mirror of `!result`
+but never reached self's attribute cell, so `$!result` kept the freed
+`PGresult` pointer; the next `finish` (allrows' teardown runs it again)
+PQclear'd the same pointer — double-free, SEGV.
+
+Fix: the `$_`-assignment topic write-back (both the SetGlobal store path and
+the SetLocal path) now also writes an attribute-twigil source through
+`write_self_attr_cell`. With it, `35-pg-common` runs 109/109 (raku parity) —
+the earlier ledger theory ("PQlibVersion stub → version type-check error →
+crash") was wrong; the version error seen mid-file was unrelated to the
+crash, which was pure use-after-free.
+
+The DBIish upstream Pg suite is now 9/11 files at raku parity (remaining:
+36-pg-enum, 38-pg-errors). Pin: `t/with-attr-topic-writeback.t` (passes under
+raku too).

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -1546,6 +1546,16 @@ impl Interpreter {
                     let source_name = source_var.clone();
                     self.set_env_with_main_alias(&source_name, val.clone());
                     self.update_local_if_exists(code, &source_name, &val);
+                    // An attribute topic (`with $!result { .PQclear; $_ = Nil }`
+                    // — DBDish::Pg's StatementHandle.finish) must reach self's
+                    // attribute cell, not just the env mirror: the stale cell
+                    // otherwise keeps the freed C pointer and the next finish
+                    // double-frees it (SEGV).
+                    if Self::attr_twigil_base(&source_name).is_some()
+                        && !Self::is_non_mirrorable_attr_value(&val)
+                    {
+                        self.write_self_attr_cell(&source_name, val.clone());
+                    }
                 }
                 // Reverse alias propagation: find all variables that are
                 // bound TO this variable (i.e. `my $x := $name`) and update

--- a/src/vm/vm_var_assign_set_local.rs
+++ b/src/vm/vm_var_assign_set_local.rs
@@ -1866,6 +1866,13 @@ impl Interpreter {
             let sv = source_var.clone();
             self.set_env_with_main_alias(&sv, val.clone());
             self.update_local_if_exists(code, &sv, &val);
+            // An attribute topic (`with $!result { .PQclear; $_ = Nil }` —
+            // DBDish::Pg's StatementHandle.finish) must reach self's attribute
+            // cell, not just the env mirror: the stale cell otherwise keeps the
+            // freed C pointer and the next finish double-frees it.
+            if Self::attr_twigil_base(&sv).is_some() && !Self::is_non_mirrorable_attr_value(&val) {
+                self.write_self_attr_cell(&sv, val.clone());
+            }
         }
         Ok(())
     }

--- a/t/with-attr-topic-writeback.t
+++ b/t/with-attr-topic-writeback.t
@@ -1,0 +1,54 @@
+use v6;
+use Test;
+
+# `with $!attr { $_ = ... }` writes the topic assignment back to self's
+# attribute (raku aliases a bare scalar-variable topic read-write, and an
+# attribute variable is such a variable). DBDish::Pg's StatementHandle.finish
+# is the load-bearing case:
+#
+#     method finish() {
+#         with $!result { .PQclear; $_ = Nil }
+#         ...
+#     }
+#
+# When the `$_ = Nil` did not reach the attribute cell, $!result kept the
+# freed C pointer and the next finish PQclear'd it again — a double-free
+# SEGV that killed DBIish's t/35-pg-common.rakutest at test 76.
+
+plan 4;
+
+class C {
+    has $.r = 42;
+    method clear() {
+        with $!r { $_ = Nil; }
+    }
+    method set-inner($v) {
+        with $!r { $_ = $v; }
+    }
+}
+
+my $c = C.new;
+$c.set-inner(7);
+is $c.r, 7, 'with $!attr topic assignment reaches the attribute';
+
+$c.clear;
+nok $c.r.defined, 'with $!attr { $_ = Nil } clears the attribute';
+
+# Calling clear twice must be safe (the finish() double-free shape): the
+# second call sees the cleared attribute and its `with` does not fire.
+my $fired = 0;
+class D {
+    has $.h = 1;
+    method fin() {
+        with $!h { $fired++; $_ = Nil; }
+    }
+}
+my $d = D.new;
+$d.fin;
+$d.fin;
+is $fired, 1, 'second finish sees the cleared attribute (with does not fire)';
+
+# A plain lexical topic still writes back too (regression guard).
+my $x = 5;
+with $x { $_ = 6; }
+is $x, 6, 'with $lexical topic assignment still writes back';


### PR DESCRIPTION
raku aliases a bare scalar-variable topic read-write, and an attribute variable is such a variable — `with $!attr { $_ = Nil }` must clear the attribute. mutsu's topic writeback (`topic_source_var`) wrote only the env mirror of `!attr`, never self's attribute cell.

The load-bearing case is `DBDish::Pg::StatementHandle.finish`:

```raku
method finish() {
    with $!result { .PQclear; $_ = Nil }
    $!Finished = True;
}
```

`$!result` kept the freed `PGresult` pointer, so the next `finish` PQclear'd it again — a **double-free SEGV** that killed DBIish's `t/35-pg-common.rakutest` at test 76 (gdb backtrace: `__libc_free ← PQclear ← ffi_call`). With the writeback routed through `write_self_attr_cell` (both the SetGlobal store path and the SetLocal path), **35-pg-common runs 109/109 (raku parity)**; the upstream Pg suite is now **9/11** files matching raku.

Verified locally: `make test` (2587 files) green; DBIish sweep vs live PostgreSQL 16.

Pin: `t/with-attr-topic-writeback.t` (4 asserts, passes under raku too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)