### PR TITLE
fix: a Map-defaulted hash attribute accepts element assignments

### DIFF
--- a/news/2026-07/map-defaulted-hash-attr-element-assign.md
+++ b/news/2026-07/map-defaulted-hash-attr-element-assign.md
@@ -1,0 +1,25 @@
+# A Map-defaulted hash attribute accepts element assignments — DBIish 36-pg-enum 13 → 25/26
+
+2026-07-29. `DBDish::Pg::Connection` declares
+`has %.dynamic-types = %oid-to-type;` where `%oid-to-type` is a `Map`
+constant, and `t/36-pg-enum.rakutest` later does
+`$dbh.dynamic-types{$oid} = YesNo` — which died with the telltale
+"Type check failed for an element of %; expected  but got Package"
+(note the EMPTY expected type), stopping the file at 13 of 26.
+
+Root cause: a `Map` carries embedded container metadata (`declared_type:
+"Map"`, no value type). When the attribute-subscript assignment path
+(`builtin_index_assign_method_lvalue`) consulted that metadata,
+`hashdata_type_info` rendered the absent value type as an empty string, and
+the element type check ran against `""` — rejecting every value. The check
+now treats an empty `value_type` as "no element constraint", alongside the
+existing `Mu`/`Any` exemptions.
+
+With the fix the file runs 25/26. The remaining fail ("Value OK (No eq
+Yes)") is an unrelated closure-capture staleness: a converter sub stored via
+`$dbh.Converter{YesNo} = $yesno` reads `$expected` as captured at store
+time, missing the mainline's later `$expected = 'No'` write (the minimal
+`$k.c{Str} = sub ...` shape also trips an "Impossible coercion from 'Str'
+into 'Any'" on the type-object hash key — both remain in the parity ledger).
+
+Pin: `t/hash-attr-map-default-element-assign.t` (passes under raku too).

--- a/src/runtime/builtins_multidim_assign.rs
+++ b/src/runtime/builtins_multidim_assign.rs
@@ -186,7 +186,14 @@ impl Interpreter {
                 && let Some(info) = self.container_type_metadata(&current)
             {
                 let constraint = &info.value_type.clone();
-                if constraint != "Mu"
+                // An empty value_type means "no element constraint": a Map
+                // carries embedded metadata (declared_type) with no value
+                // type, and `hashdata_type_info` renders that as "" — checking
+                // against it would reject EVERY assignment (`has %.h =
+                // Map.new(...)`; `$obj.h{k} = v` — DBDish::Pg's
+                // dynamic-types).
+                if !constraint.is_empty()
+                    && constraint != "Mu"
                     && constraint != "Any"
                     && !self.type_matches_value(constraint, &effective_value)
                 {

--- a/t/hash-attr-map-default-element-assign.t
+++ b/t/hash-attr-map-default-element-assign.t
@@ -1,0 +1,26 @@
+use v6;
+use Test;
+
+# A hash attribute initialized from a Map must accept element assignments.
+# The Map's embedded container metadata (declared_type, no value type)
+# rendered as an EMPTY element constraint, which rejected every assignment
+# with "Type check failed for an element of %; expected  but got ...".
+# DBDish::Pg::Connection does exactly this:
+#
+#     has %.dynamic-types = %oid-to-type;    # a Map constant
+#     ...
+#     $dbh.dynamic-types{$oid} = SomeType;   # t/36-pg-enum.rakutest
+#
+# which died at that assignment (13 of 26 tests ran).
+
+plan 4;
+
+class C {
+    has %.h = Map.new(1 => Int, 2 => Str);
+}
+
+my $c = C.new;
+lives-ok { $c.h{3} = Str }, 'type-object element assignment into Map-defaulted hash attr';
+lives-ok { $c.h{4} = 42 }, 'plain value element assignment into Map-defaulted hash attr';
+is $c.h.elems, 4, 'both elements landed';
+is $c.h{4}, 42, 'assigned value reads back';

--- a/todo/tickets/dbiish-pg-upstream-suite-parity.md
+++ b/todo/tickets/dbiish-pg-upstream-suite-parity.md
@@ -34,14 +34,14 @@ PGDATABASE=dbdishtest DBIISH_WRITE_TEST=YES`; create `dbdishtest` first).
 applies: a scalar `$INCS` string under zsh silently breaks the module path and
 produced a bogus first survey in this very session.
 
-Of the 11 upstream Pg files, 8 match raku exactly (30-pg, 34-pg-types,
-36-pg-array, 36-pg-blob, 36-pg-native, 37-pg-datetime,
+Of the 11 upstream Pg files, 9 match raku exactly (30-pg, 34-pg-types,
+35-pg-common, 36-pg-array, 36-pg-blob, 36-pg-native, 37-pg-datetime,
 38-pg-connection-lock, 38-pg-threads). The basic + extended e2e scripts
 (`tmp/dbiish-e2e-pg.raku`, `tmp/dbiish-pg-extra.raku`) are byte-identical to
 raku. Remaining:
 
-Re-measured 2026-07-29 (fourth pass; sweep helper `tmp/pg-sweep.sh`; raku
-totals 109/26/9):
+Re-measured 2026-07-29 (fifth pass; sweep helper `tmp/pg-sweep.sh`; raku
+totals 26/9):
 
 - `36-pg-blob` — **RESOLVED** (17/17, raku parity) by the six-fix chain in
   `news/2026-07/module-loaded-sub-with-tail-var.md`.
@@ -51,17 +51,21 @@ totals 109/26/9):
   `for <element>.values` writeback desugar no longer converts a non-Array
   element to an Array), pinned by
   `t/match-quantified-group-capture-semantics.t`.
-- **`36-pg-enum` (13 of 26)** — dies at test 14 with "Type check failed for
-  an element of %; expected  but got Package" (note the EMPTY expected type):
-  a typed hash element check against an enum/type-object value.
+- `35-pg-common` — **RESOLVED** (109/109, raku parity): the SEGV was a
+  `PQclear` double-free — `finish()`'s `with $!result { .PQclear; $_ = Nil }`
+  never wrote the Nil back to the attribute cell, so the freed pointer was
+  cleared again (`news/2026-07/with-attr-topic-writeback.md`). The old
+  "PQlibVersion stub → version type-check" theory was unrelated to the crash.
+- **`36-pg-enum` (25 of 26)** — was 13/26 until the Map-metadata empty
+  element constraint fix (`news/2026-07/map-defaulted-hash-attr-element-assign.md`).
+  The last fail ("Value OK (No eq Yes)") is a closure-capture staleness: a
+  converter sub stored via `$dbh.Converter{YesNo} = $yesno` reads the
+  captured `$expected` as of store time, missing the mainline's later
+  `$expected = 'No'` write. Minimal shape (also trips an "Impossible
+  coercion from 'Str' into 'Any'" on the type-object hash key):
+  `class K { has %.c; }; my $k = K.new; my $e = "Yes";
+  $k.c{Str} = sub ($v) { "$v-$e" }; $e = "No"; say $k.c{Str}("x")`
+  — raku warns and prints `x-No`; mutsu dies on the coercion.
 - **`38-pg-errors` (7 ok, 1 fail)** — one subtest assertion inside "Incorrect
   column" (the first three subtest checks pass; dig out which of the 15
   fails).
-- **`35-pg-common` (76 ok, then dumps core)** — after the mid-file `version`
-  type-check error was reached it now segfaults outright; get a fresh gdb
-  backtrace before theorizing. The earlier note about `PQlibVersion` falling
-  through to its `{ * }` stub ("expected uint32 but got Whatever") still
-  stands as the first visible symptom.
-
-Once `module-loaded-sub-with-tail-var` is fixed, re-run the full 11-file sweep
-before reading anything into individual numbers.


### PR DESCRIPTION
A `Map` carries embedded container metadata (`declared_type: "Map"`, no value type). When the attribute-subscript assignment path (`builtin_index_assign_method_lvalue`) consulted that metadata, `hashdata_type_info` rendered the absent value type as an empty string, and the element type check ran against `""` — rejecting **every** assignment with `Type check failed for an element of %; expected  but got ...` (note the empty expected type).

`DBDish::Pg::Connection` declares `has %.dynamic-types = %oid-to-type;` (a Map constant), and DBIish's `t/36-pg-enum.rakutest` assigns `$dbh.dynamic-types{$oid} = YesNo` — which died there, stopping the file at 13 of 26. With an empty `value_type` treated as "no element constraint" (alongside the existing `Mu`/`Any` exemptions), the file runs **25/26**. The last fail is an unrelated closure-capture staleness, recorded in `todo/tickets/dbiish-pg-upstream-suite-parity.md` (updated here: the Pg suite is at **9/11** files matching raku after #5550/#5551/#5552).

Verified locally: `make test` (2588 files) green.

Pin: `t/hash-attr-map-default-element-assign.t` (passes under raku too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)