### PR TITLE
fix: a handled Failure's .fail METHOD throws its wrapped exception

### DIFF
--- a/news/2026-07/handled-failure-refail-throws.md
+++ b/news/2026-07/handled-failure-refail-throws.md
@@ -1,0 +1,39 @@
+# A handled Failure's `.fail` METHOD throws — DBIish 38-pg-errors 8 → 9/9 (Pg suite 10/11)
+
+2026-07-29. The last failing subtest of DBIish's `t/38-pg-errors.rakutest`
+("Raise Temporary Exception") came down to a Failure-semantics divergence,
+found by shrinking DBDish's execute error path to a DB-free repro:
+
+```raku
+method run() {
+    with self!seterr() { "never" } else { .fail }
+}
+throws-like { my $r = $k.run; CATCH { default { .rethrow } } }, X::My;
+```
+
+The `with` marks the Failure handled (via `.defined`), and in raku the
+**method form `.fail` on a handled Failure throws its wrapped exception
+outright** — while the **sub form `fail $f` re-arms it as a passive Failure**
+even when handled (pinned by roast S04-exceptions/fail.t's
+`foo() orelse fail $_` / `.&fail`, which both route through the sub). mutsu
+treated both forms as re-arm, so `execute` returned a passive Failure that a
+CATCH-carrying `throws-like` block never saw — "code dies" failed. The
+method-dispatch `.fail` arm now throws for a handled Failure invocant;
+`builtin_fail` (the sub form) still re-arms.
+
+Wrong turns worth recording:
+
+- A DBG probe showed `RaiseError` is falsy on the statement handle in raku
+  too — both implementations take the `.fail` branch of
+  `$!RaiseError and .throw or .fail`; only what `.fail` then does differs.
+- An attempted "fix" that made CATCH-carrying blocks yield their tail
+  VarDecl's value (so ThrowIfFailure would see it) was REVERTED after
+  checking raku: `do { my $x = 42; CATCH {} }` is Nil there, and a tail
+  `my $r = flaky()` Failure does NOT reach the block's own CATCH.
+- The first cut put the handled-throw into `builtin_fail` (both forms) and
+  roast's re-arm tests caught it locally — the method/sub distinction IS the
+  spec. Measure each form against raku before generalizing.
+
+Pin: `t/failure-handled-refail-throws.t` (passes under raku too). DBIish's
+upstream Pg suite is now **10/11** files at raku parity; only `36-pg-enum`'s
+closure-capture staleness remains.

--- a/src/runtime/builtins_control_flow.rs
+++ b/src/runtime/builtins_control_flow.rs
@@ -129,7 +129,10 @@ impl Interpreter {
     pub(super) fn builtin_fail(&mut self, args: &[Value]) -> Result<Value, RuntimeError> {
         if let Some(v) = args.first().cloned() {
             // When fail() receives a Failure:D, extract the inner exception
-            // and re-arm it (Raku behavior: fail(Failure:D) re-arms)
+            // and re-arm it (Raku behavior: fail(Failure:D) re-arms, even a
+            // handled one — roast S04-exceptions/fail.t pins
+            // `foo() orelse fail $_`. The METHOD form `.fail` on a handled
+            // Failure throws instead; that lives in the method dispatch.)
             if let ValueView::Instance {
                 class_name,
                 attributes,

--- a/src/runtime/methods_call_dispatch.rs
+++ b/src/runtime/methods_call_dispatch.rs
@@ -552,6 +552,23 @@ impl Interpreter {
                 // exception (which throws only when sunk/used unhandled), not an
                 // immediate throw like `.throw`.
                 if method == "fail" {
+                    // EXCEPT on a HANDLED Failure, where the METHOD form
+                    // throws the wrapped exception outright (verified against
+                    // raku; the sub form `fail $f` re-arms instead — roast
+                    // S04-exceptions/fail.t). DBDish's execute error path is
+                    // `with self!handle-errors { ... } else { .fail }`: the
+                    // `with` marks the Failure handled via `.defined`, and
+                    // the `.fail` must surface the exception.
+                    if cn == "Failure"
+                        && target.is_failure_handled()
+                        && let ValueView::Instance { attributes, .. } = target.view()
+                        && let Some(exc) = attributes.as_map().get("exception").cloned()
+                    {
+                        let msg = self.exception_message_or_died_with(&exc);
+                        let mut err = crate::value::RuntimeError::new(&msg);
+                        err.exception = Some(Box::new(exc));
+                        return Err(err);
+                    }
                     return self.builtin_fail(std::slice::from_ref(&target));
                 }
                 // throw / rethrow: build a RuntimeError carrying this exception.

--- a/t/failure-handled-refail-throws.t
+++ b/t/failure-handled-refail-throws.t
@@ -1,0 +1,42 @@
+use v6;
+use Test;
+
+# Re-failing a HANDLED Failure throws its wrapped exception outright
+# (verified against raku); only an unhandled Failure re-arms as a passive
+# Failure. DBDish::ErrorHandling's execute error path is the load-bearing
+# case:
+#
+#     with self!handle-errors { ... } else { .fail }
+#
+# `with` marks the Failure handled (via .defined), so the `.fail` in the
+# else branch must surface the exception — DBIish's t/38-pg-errors.rakutest
+# "Raise Temporary Exception" hung on a passive Failure instead.
+
+plan 4;
+
+class X::My is Exception { has $.m; method message { $.m } }
+
+class K {
+    method !dispatch($ex) { $ex.fail; }
+    method !seterr() { self!dispatch(X::My.new(m => "b")); }
+    method run() {
+        with self!seterr() { "never" } else { .fail }
+    }
+}
+
+my $k = K.new;
+
+throws-like {
+    my $r = $k.run;
+    CATCH { default { .rethrow } }
+}, X::My, 'handled-Failure .fail throws through a CATCH-rethrow block';
+
+throws-like {
+    my $r = $k.run;
+}, X::My, 'handled-Failure .fail throws without a CATCH too';
+
+# Direct form: a Failure handled by .defined, then re-failed, throws.
+sub s() { X::My.new(m => "direct").fail }
+my $f = s();
+ok $f.handled === False || $f.defined === False, 'Failure starts unhandled / undefined';
+throws-like { $f.fail }, X::My, 're-failing the now-handled Failure throws';

--- a/todo/tickets/dbiish-pg-upstream-suite-parity.md
+++ b/todo/tickets/dbiish-pg-upstream-suite-parity.md
@@ -34,14 +34,14 @@ PGDATABASE=dbdishtest DBIISH_WRITE_TEST=YES`; create `dbdishtest` first).
 applies: a scalar `$INCS` string under zsh silently breaks the module path and
 produced a bogus first survey in this very session.
 
-Of the 11 upstream Pg files, 9 match raku exactly (30-pg, 34-pg-types,
+Of the 11 upstream Pg files, 10 match raku exactly (30-pg, 34-pg-types,
 35-pg-common, 36-pg-array, 36-pg-blob, 36-pg-native, 37-pg-datetime,
-38-pg-connection-lock, 38-pg-threads). The basic + extended e2e scripts
-(`tmp/dbiish-e2e-pg.raku`, `tmp/dbiish-pg-extra.raku`) are byte-identical to
-raku. Remaining:
+38-pg-connection-lock, 38-pg-errors, 38-pg-threads). The basic + extended
+e2e scripts (`tmp/dbiish-e2e-pg.raku`, `tmp/dbiish-pg-extra.raku`) are
+byte-identical to raku. Remaining:
 
-Re-measured 2026-07-29 (fifth pass; sweep helper `tmp/pg-sweep.sh`; raku
-totals 26/9):
+Re-measured 2026-07-29 (sixth pass; sweep helper `tmp/pg-sweep.sh`; raku
+totals 26):
 
 - `36-pg-blob` — **RESOLVED** (17/17, raku parity) by the six-fix chain in
   `news/2026-07/module-loaded-sub-with-tail-var.md`.
@@ -66,6 +66,7 @@ totals 26/9):
   `class K { has %.c; }; my $k = K.new; my $e = "Yes";
   $k.c{Str} = sub ($v) { "$v-$e" }; $e = "No"; say $k.c{Str}("x")`
   — raku warns and prints `x-No`; mutsu dies on the coercion.
-- **`38-pg-errors` (7 ok, 1 fail)** — one subtest assertion inside "Incorrect
-  column" (the first three subtest checks pass; dig out which of the 15
-  fails).
+- `38-pg-errors` — **RESOLVED** (9/9, raku parity): a handled Failure's
+  `.fail` METHOD throws its wrapped exception (the sub form `fail $f`
+  re-arms) — `news/2026-07/handled-failure-refail-throws.md`, pinned by
+  `t/failure-handled-refail-throws.t`.


### PR DESCRIPTION
The method form and the sub form of `fail` diverge on a **handled** Failure (verified against raku):

- `$handled-failure.fail` (method) **throws** the wrapped exception outright.
- `fail $handled-failure` / `.&fail` (sub) **re-arms** it as a passive Failure — pinned by roast `S04-exceptions/fail.t` (`foo() orelse fail $_`), which stays green.

mutsu treated both as re-arm. The load-bearing case is `DBDish::ErrorHandling`'s execute error path:

```raku
with self!handle-errors { ... } else { .fail }
```

The `with` marks the Failure handled (via `.defined`), so the `.fail` must surface the exception — instead `execute` returned a passive Failure that a CATCH-carrying `throws-like` block never saw, failing DBIish `t/38-pg-errors.rakutest`'s "Raise Temporary Exception". The file now runs **9/9 (raku parity)**, putting the upstream Pg suite at **10/11** files (only `36-pg-enum`'s closure-capture staleness remains; ledger updated).

Verified locally: `make test` (2590 files) green; S04 exception/fail roast files green; DBIish sweep vs live PostgreSQL 16. A DB-free minimal repro is in the pin test.

Pin: `t/failure-handled-refail-throws.t` (4 asserts, passes under raku too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)