### PR TITLE
fix: three general bugs behind Template::Mustache's whitelisted-but-failing suite

### DIFF
--- a/news/2026-07/mustache-battery-regressions-fixed.md
+++ b/news/2026-07/mustache-battery-regressions-fixed.md
@@ -1,0 +1,78 @@
+# Template::Mustache was whitelisted but only 6 of its 13 files still passed
+
+`batteries-whitelist.txt` records all 13 upstream `Template::Mustache` test files
+as passing, but on `main` at v0.19.0 only six of them did. The release gate
+(`scripts/battery-testsuite.sh`) is the only thing that runs those suites and it
+only runs at release time, so the drift accumulated unnoticed:
+
+| file | before | after |
+| --- | --- | --- |
+| `01-basic` | 9/10 | 10/10 |
+| `06-logging` | 1/3 | 3/3 |
+| `11-iterable` | 0/6 (died) | 6/6 |
+| `12-inheritence` | 0/1 (died) | 1/1 |
+| `50-readme` | 2/4 | 4/4 |
+| `91-specs` | 3/10 | 10/10 |
+| `92-specs-file` | 3/10 | 10/10 |
+
+Three unrelated interpreter bugs were behind it. None is Mustache-specific.
+
+## 1. `$/.from` in a pair value turned a hash composer into a block
+
+`{ … }` is a hash composer unless its body references the topic, and mutsu
+decides that with a lexical scan. Part of that scan asks whether a `.method` has
+an invocant in front of it by looking at the single byte before the dot: a
+letter, digit, `)`, `]`, `}` or quote means "a term ends here", anything else
+means "no invocant, so this is `$_.method`".
+
+`$/` and `$!` end in punctuation, so `{ :pos($/.from) }` was read as a topic
+reference and became a `Block`. Template::Mustache's grammar action
+`method tag:sym<section>($/) { make { :type<section>, …, :pos($/.from) } }`
+therefore `make`s a Callable instead of a Hash, every `{{#section}}` hunk lost
+its `type` key, and section nesting silently disappeared from every parsed
+template.
+
+The same byte test misreads the `/` that *closes* a term. `q:to/EOF/.trim`,
+`q/x/.uc` and `/rx/.gist` all end in `/`, so a heredoc used as a hash value
+(`b => q:to/EOF/.trim,` — exactly how `12-inheritence` builds its fixture) made
+the surrounding literal a block. `/` before a dot now counts as a term end
+unless it has whitespace on its left, which is how infix division is actually
+spelled (`{ a => 1 / .elems }` stays a block).
+
+Pinned by unit tests in `src/parser/primary/misc/lambda_tests.rs` (the decision
+is a pure parser predicate, so it is asserted on the AST) plus
+`t/hash-composer-term-end.t` for the heredoc spelling, which needs its body on
+the following lines.
+
+## 2. A `my` in a `when` body swallowed the matched value
+
+A body that declares a block-local `my` runs under the `BlockLocalScope` opcode.
+That opcode absorbs a `when`/`default` succeed signal, which is right for a bare
+block or an `if` branch — `given 5 { if c { when Int {…} }; say "after" }` still
+runs the `say`. But the same opcode wraps a `when`/`default`/`given` *body* as
+soon as that body declares a `my`, and there the signal carries the value the
+construct evaluates to. Absorbing it turned
+
+```raku
+when 'section' {
+    my ($datum, $lambda) = get(@context, %val, :section);
+    …
+    elsif $datum -> $_ { when Associative { section_format $_ } }
+}
+```
+
+into `Nil`, which is why rendering a `{{$ page_content }}` override produced an
+empty string. `BlockLocalScope` now carries a `succeed_boundary` flag: true for
+branch bodies (unchanged behaviour), false for `when`/`default`/`given` bodies,
+which let the signal through to the op that knows what to do with it. Pinned by
+`t/when-value-through-block-local.t`.
+
+## 3. `sprintf('%s', $exception)` printed the object, not the message
+
+`%s` dispatches `.Str` on an instance argument, but only when the class had an
+*own* `Str` method. An Exception subclass gets its `Str` from `message` further
+up the MRO, so `sprintf "%s: %s", $level.uc, $e` rendered
+`Template::Mustache::X::FieldNotFound()` where rakudo renders
+`Field not found ❮missing_field1❯` — the whole point of the `06-logging` file.
+`%s` on an instance now goes through the same `stringify_value` that `~$obj`
+uses. Pinned by `t/sprintf-instance-str.t`.

--- a/src/compiler/helpers_control_flow.rs
+++ b/src/compiler/helpers_control_flow.rs
@@ -363,7 +363,10 @@ impl Compiler {
     /// clobber without the full env restore of `BlockScope` (which would revert a
     /// `:=` binding the branch makes to an outer variable).
     pub(super) fn compile_block_local_branch(&mut self, stmts: &[Stmt]) {
-        let idx = self.code.emit(OpCode::BlockLocalScope { body_end: 0 });
+        let idx = self.code.emit(OpCode::BlockLocalScope {
+            body_end: 0,
+            succeed_boundary: true,
+        });
         self.compile_body_with_implicit_try(stmts);
         self.code.patch_block_local_body_end(idx);
     }

--- a/src/compiler/stmt.rs
+++ b/src/compiler/stmt.rs
@@ -2482,7 +2482,12 @@ impl Compiler {
                 });
                 let block_local_idx = (!*is_statement_modifier
                     && Self::branch_declares_block_local(body))
-                .then(|| self.code.emit(OpCode::BlockLocalScope { body_end: 0 }));
+                .then(|| {
+                    self.code.emit(OpCode::BlockLocalScope {
+                        body_end: 0,
+                        succeed_boundary: false,
+                    })
+                });
                 let saved_scope =
                     (!*is_statement_modifier).then(|| self.push_dynamic_scope_lexical());
                 if Self::has_catch_or_control(body) {
@@ -2511,8 +2516,12 @@ impl Compiler {
             Stmt::When { cond, body } => {
                 self.compile_expr(cond);
                 let when_idx = self.code.emit(OpCode::When { body_end: 0 });
-                let block_local_idx = Self::branch_declares_block_local(body)
-                    .then(|| self.code.emit(OpCode::BlockLocalScope { body_end: 0 }));
+                let block_local_idx = Self::branch_declares_block_local(body).then(|| {
+                    self.code.emit(OpCode::BlockLocalScope {
+                        body_end: 0,
+                        succeed_boundary: false,
+                    })
+                });
                 let saved_scope = self.push_dynamic_scope_lexical();
                 for (i, s) in body.iter().enumerate() {
                     let is_last = i == body.len() - 1;
@@ -2532,8 +2541,12 @@ impl Compiler {
             }
             Stmt::Default(body) => {
                 let default_idx = self.code.emit(OpCode::Default { body_end: 0 });
-                let block_local_idx = Self::branch_declares_block_local(body)
-                    .then(|| self.code.emit(OpCode::BlockLocalScope { body_end: 0 }));
+                let block_local_idx = Self::branch_declares_block_local(body).then(|| {
+                    self.code.emit(OpCode::BlockLocalScope {
+                        body_end: 0,
+                        succeed_boundary: false,
+                    })
+                });
                 let saved_scope = self.push_dynamic_scope_lexical();
                 if Self::has_catch_or_control(body) {
                     self.compile_try(body, &None);

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -771,8 +771,15 @@ pub(crate) enum OpCode {
     /// exit. Names bound with `:=` to an outer var (not `my`-declared in the
     /// branch) are never recorded, so they survive. Runs the body in
     /// `ip+1 .. body_end`.
+    /// `succeed_boundary` says whether *this* block is where a `when`/`default`
+    /// succeed signal stops. A bare block or an `if`/`unless`/`else` branch is
+    /// such a boundary (`given 5 { if c { when Int {...} }; say "after" }` still
+    /// runs the `say`), so the signal is absorbed. A `when`/`default`/`given`
+    /// body is NOT: the signal has to reach the enclosing `When`/`Default`/
+    /// `Given` op, which turns it into that construct's value.
     BlockLocalScope {
         body_end: u32,
+        succeed_boundary: bool,
     },
     /// Check the top-of-stack value; if falsy, throw X::Phaser::PrePost.
     /// `is_pre` distinguishes PRE (true) from POST (false). `condition_idx` is
@@ -3917,7 +3924,7 @@ impl CompiledCode {
     pub(crate) fn patch_block_local_body_end(&mut self, idx: usize) {
         let target = self.ops.len() as u32;
         match &mut self.ops[idx] {
-            OpCode::BlockLocalScope { body_end } => *body_end = target,
+            OpCode::BlockLocalScope { body_end, .. } => *body_end = target,
             _ => panic!("patch_block_local_body_end on non-BlockLocalScope opcode"),
         }
     }

--- a/src/parser/primary/misc.rs
+++ b/src/parser/primary/misc.rs
@@ -9,6 +9,8 @@ mod anon_decl;
 mod colonpair;
 mod hash;
 mod lambda;
+#[cfg(test)]
+mod lambda_tests;
 mod reduction;
 
 pub(super) use anon_decl::{

--- a/src/parser/primary/misc/lambda.rs
+++ b/src/parser/primary/misc/lambda.rs
@@ -486,6 +486,20 @@ fn is_implicit_topic_call(bytes: &[u8], at: usize) -> bool {
             // `a => .key` has no invocant; `%h<a>.key` does.
             matches!(p.checked_sub(2).map(|q| bytes[q]), Some(b'='))
         }
+        // `$!.message` is a term even though it ends in punctuation; a bare `!`
+        // is prefix negation (`{ a => !.defined }` is a block).
+        b'!' => !matches!(p.checked_sub(2).map(|q| bytes[q]), Some(b'$')),
+        // A `/` right before the dot closes a term far more often than it
+        // divides by one: it ends `$/`, a quoting construct (`q:to/EOF/.trim`,
+        // `q/x/.uc`) or a regex literal (`/rx/.gist`). Infix division, on the
+        // other hand, is spelled with a space on its left (`1 / .elems`), and
+        // that spelling stays a topic reference.
+        b'/' => matches!(
+            p.checked_sub(2).map(|q| bytes[q]),
+            None | Some(b' ') | Some(b'\t') | Some(b'\n') | Some(b'\r')
+        ),
+        // `$¢.foo` — the last byte of the UTF-8 `¢` is 0xA2.
+        0xA2 if bytes[..p].ends_with("$\u{a2}".as_bytes()) => false,
         c => !(c.is_ascii_alphanumeric() || c == b'_'),
     }
 }

--- a/src/parser/primary/misc/lambda_tests.rs
+++ b/src/parser/primary/misc/lambda_tests.rs
@@ -1,0 +1,81 @@
+//! Unit tests for the `{ … }` hash-composer-vs-block decision in `lambda.rs`.
+//!
+//! The decision is a lexical heuristic, so it is tested here on the parsed AST
+//! rather than through the interpreter: a wrong answer silently turns a hash
+//! literal into a closure (or vice versa), which is far easier to read off
+//! `Expr::Hash` / `Expr::AnonSub` than off a program's output.
+
+use crate::ast::Expr;
+use crate::parser::primary::misc::block_or_hash_expr;
+
+/// `true` if the source parses as a hash literal, `false` if as a block.
+/// Panics if it does not parse at all.
+fn is_hash(src: &str) -> bool {
+    let (rest, expr) = block_or_hash_expr(src).unwrap_or_else(|e| panic!("{src:?}: {e:?}"));
+    assert_eq!(rest, "", "{src:?} left unparsed input");
+    match expr {
+        Expr::Hash(_) => true,
+        // A body that mixes pairs with a spread compiles to a `hash(...)` call
+        // rather than an `Expr::Hash`; still the hash-composer reading.
+        Expr::Call { ref name, .. } => name.resolve() == "hash",
+        _ => false,
+    }
+}
+
+#[test]
+fn plain_pair_bodies_are_hashes() {
+    assert!(is_hash("{ a => 1 }"));
+    assert!(is_hash("{ :type<var>, :val('v') }"));
+    assert!(is_hash("{}"));
+}
+
+#[test]
+fn topic_references_force_a_block() {
+    // An explicit topic variable, in the key or the value.
+    assert!(!is_hash("{ a => $_ }"));
+    assert!(!is_hash(r#"{ "$_" => 1 }"#));
+    // An invocant-less method call is a topic reference too.
+    assert!(!is_hash("{ a => .key }"));
+    assert!(!is_hash("{ .key => 1 }"));
+    // Infix division by a topic method call — the one `/`-before-`.` spelling
+    // that is NOT a term end (see `is_implicit_topic_call`).
+    assert!(!is_hash("{ a => 1 / .elems }"));
+    // ...and prefix negation of one.
+    assert!(!is_hash("{ a => !.defined }"));
+}
+
+#[test]
+fn punctuation_variables_are_terms_not_topic_calls() {
+    // `$/` and `$!` end in punctuation, but `.from` / `.message` still has a
+    // real invocant. Regression: `make { :pos($/.from) }` in a grammar action
+    // parsed as a block, so the action produced a Callable instead of a Hash.
+    assert!(is_hash("{ :pos($/.from) }"));
+    assert!(is_hash("{ a => $/.from, b => 1 }"));
+    assert!(is_hash("{ a => $!.message }"));
+    assert!(is_hash("{ a => $¢.pos }"));
+}
+
+#[test]
+fn a_closing_quote_delimiter_is_a_term_end() {
+    // The `/` that closes a quoting construct or a regex literal ends a term,
+    // so the following `.method` has an invocant. The heredoc spelling that
+    // triggered this (`b => q:to/EOF/.trim,`) needs its body on the following
+    // lines, so it is pinned end-to-end in `t/hash-composer-term-end.t`.
+    assert!(is_hash("{ a => q/x/.uc }"));
+    assert!(is_hash("{ a => /rx/.gist }"));
+}
+
+#[test]
+fn method_calls_with_ordinary_invocants_stay_hashes() {
+    assert!(is_hash("{ a => $x.key }"));
+    assert!(is_hash("{ a => %h<k>.key }"));
+    assert!(is_hash("{ a => (1, 2).elems }"));
+    // A `.^name` inside a string interpolation belongs to the interpolation's
+    // own closure, so the outer literal is still a hash.
+    assert!(is_hash(r#"{ "{ .^name }X" => 1 }"#));
+}
+
+#[test]
+fn placeholder_variables_force_a_block() {
+    assert!(!is_hash("{ a => $^x }"));
+}

--- a/src/runtime/builtins_string.rs
+++ b/src/runtime/builtins_string.rs
@@ -57,6 +57,17 @@ impl Interpreter {
                 'e' | 'f' | 'g' => "Numeric",
                 _ => continue,
             };
+            // `%s` on an instance is plain string context: dispatch `.Str` the
+            // same way `~$obj` does, whether or not the class spells the method
+            // out itself. Gating this on an *own* `Str` method rendered every
+            // inherited one as the raw object — an Exception subclass, whose
+            // `Str` comes from `message` up the MRO, printed
+            // `My::X::Thing()` instead of its message.
+            if method == "Str" && !is_type_object {
+                let arg_clone = actual_args[idx].clone();
+                actual_args[idx] = Value::str(self.stringify_value(arg_clone)?);
+                continue;
+            }
             if !self.has_user_method(&cn, method) {
                 // A bare type object stringifies (`%s`) to "" with rakudo's
                 // "uninitialized value of type X in string context" warning

--- a/src/vm/vm_control_ops.rs
+++ b/src/vm/vm_control_ops.rs
@@ -199,6 +199,7 @@ impl Interpreter {
         &mut self,
         code: &CompiledCode,
         body_end: u32,
+        succeed_boundary: bool,
         ip: &mut usize,
         compiled_fns: &CompiledFns,
     ) -> Result<(), RuntimeError> {
@@ -234,8 +235,15 @@ impl Interpreter {
         // directly in a `given` (`given 5 { { when Int {...} }; say "after" }`
         // prints "after" in raku). Statement position: absorb without leaving a
         // value on the stack.
+        //
+        // Only when this scope is itself the boundary, though. Wrapping a
+        // `when`/`default`/`given` *body* (which happens as soon as the body
+        // declares a `my`) must let the signal through: it carries the value the
+        // enclosing `When`/`Default`/`Given` op yields, and swallowing it here
+        // silently turned `when 'x' { my $d = ...; ...; when Int { 'A' } }` into
+        // Nil.
         let res = match res {
-            Err(e) if e.is_succeed() => {
+            Err(e) if succeed_boundary && e.is_succeed() => {
                 self.stack.truncate(stack_base);
                 // Reset the match flag too: an enclosing `given` breaks its body
                 // on it after every op (see `exec_do_block_expr_op`'s twin).

--- a/src/vm/vm_exec_dispatch.rs
+++ b/src/vm/vm_exec_dispatch.rs
@@ -4232,9 +4232,18 @@ impl Interpreter {
                     compiled_fns,
                 )?;
             }
-            OpCode::BlockLocalScope { body_end } => {
+            OpCode::BlockLocalScope {
+                body_end,
+                succeed_boundary,
+            } => {
                 self.sync_source_line(code, *ip);
-                self.exec_block_local_scope_op(code, *body_end, ip, compiled_fns)?;
+                self.exec_block_local_scope_op(
+                    code,
+                    *body_end,
+                    *succeed_boundary,
+                    ip,
+                    compiled_fns,
+                )?;
             }
             OpCode::CheckPhaser {
                 is_pre,

--- a/t/hash-composer-term-end.t
+++ b/t/hash-composer-term-end.t
@@ -1,0 +1,34 @@
+use Test;
+
+# A `{ ... }` body that opens with a pair is a hash composer unless it
+# references the topic. Deciding that lexically means knowing where a term
+# ends: `$/`, `$!` and a closing quote/regex delimiter all end one, so a
+# `.method` after them has a real invocant and does NOT make the body a block.
+# The unit tests in src/parser/primary/misc/lambda_tests.rs cover the decision
+# directly; this file pins the end-to-end spellings, including the heredoc one
+# (which needs its body on the following lines, so it cannot be a unit test).
+
+plan 8;
+
+'abc' ~~ /(\w+)/;
+
+is { :pos($/.from) }.^name, 'Hash', '$/.from in a pair value keeps a hash composer';
+is { :m($!.^name) }.^name, 'Hash', '$!.method in a pair value keeps a hash composer';
+is { :a(q/x/.uc) }.^name, 'Hash', 'a closing q// delimiter ends a term';
+
+my $h = { t => 'T', b => q:to/EOF/.trim, };
+    line one
+    line two
+    EOF
+is $h.^name, 'Hash', 'a heredoc with a trailing method call keeps a hash composer';
+is $h<b>, "line one\nline two", 'the heredoc value survives';
+
+my %outer = (x => { t => 'T', b => q:to/EOF/.trim, });
+    nested one
+    EOF
+is %outer<x><b>, 'nested one', 'the same nested inside another literal';
+
+# The one `/`-before-`.` spelling that really is a topic reference: infix
+# division, which is written with a space on its left.
+is { a => 1 / .elems }.^name, 'Block', 'infix division by a topic call is a block';
+is { a => .key }.^name, 'Block', 'a bare invocant-less call is still a block';

--- a/t/sprintf-instance-str.t
+++ b/t/sprintf-instance-str.t
@@ -1,0 +1,41 @@
+use Test;
+
+# `%s` puts its argument in string context, so it dispatches `.Str` exactly like
+# `~$obj` does. That includes a `.Str` the class only inherits — an Exception
+# subclass gets its `Str` from `message` up the MRO, and gating the dispatch on
+# an *own* `Str` method printed the raw object instead.
+
+plan 6;
+
+class Plain {
+    has $.v;
+    method Str { "plain<$!v>" }
+}
+
+role X[Str:D $err] is Exception {
+    has $.str;
+    method message { "$err <<$!str>>" }
+}
+class X::NotFound does X['not found'] { }
+
+class Wrapper {
+    class Inner is Exception {
+        has $.what;
+        method message { "inner: $!what" }
+    }
+}
+
+is sprintf('%s', Plain.new(:v<1>)), 'plain<1>', 'an own .Str is used';
+is sprintf('%s', X::NotFound.new(:str<abc>)), 'not found <<abc>>',
+    'an inherited Exception .Str is used';
+is sprintf('%s', Wrapper::Inner.new(:what<x>)), 'inner: x',
+    'the same through a package-qualified name';
+is sprintf('%s: %s', 'WARN', X::NotFound.new(:str<abc>)), 'WARN: not found <<abc>>',
+    'and alongside other directives';
+is sprintf('%s', X::NotFound.new(:str<abc>)), ~X::NotFound.new(:str<abc>),
+    'sprintf %s agrees with the ~ prefix operator';
+
+class Numish {
+    method Int { 42 }
+}
+is sprintf('%d', Numish.new), '42', 'numeric directives still dispatch .Int';

--- a/t/when-value-through-block-local.t
+++ b/t/when-value-through-block-local.t
@@ -1,0 +1,68 @@
+use Test;
+
+# A `when` that matches leaves its topicalizer with the block's value. When the
+# enclosing `when`/`default`/`given` body happens to declare a `my`, that body
+# runs under the block-local scope opcode — which used to swallow the succeed
+# signal, so the whole construct evaluated to Nil instead of the matched value.
+
+plan 8;
+
+sub in-when($d) {
+    given 'section' {
+        when 'section' {
+            my $extra = 1;
+            if $d -> $_ {
+                when Associative { 'ASSOC' }
+                when Iterable | Positional { 'ITER' }
+                default { 'DEF' }
+            }
+            else {
+                'EMPTY'
+            }
+        }
+    }
+}
+
+is in-when({ a => 1 }), 'ASSOC', 'when body with a `my`: Associative arm';
+is in-when([1, 2]), 'ITER', 'when body with a `my`: Iterable arm';
+is in-when('s'), 'DEF', 'when body with a `my`: default arm';
+is in-when(0), 'EMPTY', 'when body with a `my`: else branch still wins';
+
+sub in-given() {
+    given 'x' {
+        my $extra = 1;
+        when 'x' { 'GIVEN' }
+    }
+}
+is in-given(), 'GIVEN', 'given body with a `my` keeps the when value';
+
+sub in-default() {
+    given 'x' {
+        default {
+            my $extra = 1;
+            if 5 -> $_ {
+                when Int { 'DEFAULT' }
+            }
+        }
+    }
+}
+is in-default(), 'DEFAULT', 'default body with a `my` keeps the when value';
+
+sub direct() {
+    given 'x' {
+        when 'x' {
+            my $extra = 1;
+            'DIRECT'
+        }
+    }
+}
+is direct(), 'DIRECT', 'a when body with a `my` still yields its last value';
+
+# The block-local scope must still restore a shadowed outer lexical.
+my $shadowed = 'outer';
+given 'x' {
+    when 'x' {
+        my $shadowed = 'inner';
+    }
+}
+is $shadowed, 'outer', 'a when-body `my` does not leak out';

--- a/todo/tickets/batteries-gate-only-runs-at-release.md
+++ b/todo/tickets/batteries-gate-only-runs-at-release.md
@@ -1,0 +1,28 @@
+# The bundled-library gate only runs at release, so its whitelist silently rots
+
+`scripts/battery-testsuite.sh` is wired into exactly one place: the `batteries`
+job in `.github/workflows/release.yml`, which runs on a `v*` tag push or a
+manual `workflow_dispatch`. Nothing runs it on a pull request or on a push to
+`main`.
+
+That means `batteries-whitelist.txt` can claim a file passes for weeks while it
+does not. It happened: between #5434 (2026-07-25, the slice that took
+`Template::Mustache` to 13/13) and v0.19.0, three unrelated interpreter changes
+took it down to 6/13 and no CI run said a word. The regressions are fixed in
+`news/2026-07/mustache-battery-regressions-fixed.md`, but the detection gap is
+still open, and it applies to every battery, not just Mustache.
+
+Why this is not a one-line change: the job builds a release binary, clones ~10
+upstream repositories at pinned commits and runs their suites, with a 30-minute
+timeout. Putting that on every PR roughly doubles CI cost and adds a network
+dependency to the merge path. Options, cheapest first:
+
+1. **Run it on pushes to `main` only.** Drift is then caught within one merge
+   instead of one release, at one extra run per merge. Does not block a bad PR,
+   but names the culprit commit immediately.
+2. **Run it on PRs that touch the interpreter**, via a `paths:` filter on `src/`.
+   Blocks the regression, but that filter matches most PRs anyway.
+3. **Split the gate**: run a fast subset (the batteries whose suites are quick,
+   which is most of them) on PRs and the full set at release.
+
+Whichever is chosen, the release-time gate should stay as the authoritative one.


### PR DESCRIPTION
All 13 upstream `Template::Mustache` test files are on `batteries-whitelist.txt`,
but only six of them still passed on `main` at v0.19.0. `scripts/battery-testsuite.sh`
is the only thing that runs those suites and it only runs at release time, so the
drift accumulated unnoticed.

| file | before | after |
| --- | --- | --- |
| `01-basic` | 9/10 | 10/10 |
| `06-logging` | 1/3 | 3/3 |
| `11-iterable` | 0/6 (died) | 6/6 |
| `12-inheritence` | 0/1 (died) | 1/1 |
| `50-readme` | 2/4 | 4/4 |
| `91-specs` | 3/10 | 10/10 |
| `92-specs-file` | 3/10 | 10/10 |

Three unrelated interpreter bugs were behind it. None is Mustache-specific.

### 1. `$/.from` / `q:to/EOF/.trim` in a pair value turned a hash composer into a block

`{ … }` is a hash composer unless its body references the topic, and mutsu decides
that lexically: whether a `.method` has an invocant is answered by the single byte
before the dot. `$/` and `$!` end in punctuation, so `{ :pos($/.from) }` was read as
`$_.from` and the literal became a `Block`. Template::Mustache's action

```raku
method tag:sym<section>($/) { make { :type<section>, …, :pos($/.from) } }
```

therefore `make`s a Callable instead of a Hash — every `{{#section}}` hunk lost its
`type` key and section nesting silently disappeared from every parsed template.

The same test misreads the `/` that *closes* a term: `q:to/EOF/.trim`, `q/x/.uc` and
`/rx/.gist` all end in `/`, so a heredoc used as a hash value (exactly how
`12-inheritence` builds its fixture) made the surrounding literal a block. A `/`
before a dot now ends a term unless it has whitespace on its left, which is how
infix division is actually spelled — `{ a => 1 / .elems }` stays a block.

### 2. A `my` in a `when` body swallowed the matched value

A body that declares a block-local `my` runs under `BlockLocalScope`, which absorbs a
`when`/`default` succeed signal. That is right for a bare block or an `if` branch —
`given 5 { if c { when Int {…} }; say "after" }` still runs the `say`. But the same
opcode wraps a `when`/`default`/`given` *body* as soon as that body declares a `my`,
and there the signal carries the value the construct evaluates to. `BlockLocalScope`
now carries a `succeed_boundary` flag: true for branch bodies (unchanged), false for
`when`/`default`/`given` bodies, which lets the signal reach the op that knows what to
do with it.

### 3. `sprintf('%s', $exception)` printed the object, not the message

`%s` dispatched `.Str` on an instance only when the class had an *own* `Str` method.
An Exception subclass gets its `Str` from `message` further up the MRO, so
`sprintf "%s: %s", $level.uc, $e` rendered `Template::Mustache::X::FieldNotFound()`
where rakudo renders `Field not found ❮missing_field1❯` — the whole point of
`06-logging`. `%s` on an instance now goes through the same `stringify_value` that
`~$obj` uses.

## Tests

The hash-composer decision is a pure parser predicate, so it is pinned by unit tests
asserting on the AST (`src/parser/primary/misc/lambda_tests.rs`) rather than through
the interpreter; the heredoc spelling needs its body on the following lines, so it is
pinned end-to-end in `t/hash-composer-term-end.t`. The other two fixes are pinned by
`t/when-value-through-block-local.t` and `t/sprintf-instance-str.t`.

Verified locally: Template::Mustache 13/13, `make test` 2602 files PASS,
`make roast` 1435 files PASS.

## Not fixed here

The reason the whitelist could lie for days is that the batteries gate only runs at
release. Putting it on every PR roughly doubles CI cost and adds a network dependency
to the merge path, so the options are written up in
`todo/tickets/batteries-gate-only-runs-at-release.md` rather than decided in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)